### PR TITLE
feat(#4,#5,#6): 메인 화면, API 레이어, 즐겨찾기 구현

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,33 @@
+import { Tabs } from 'expo-router';
+import { Text } from 'react-native';
+
+export default function TabsLayout() {
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: {
+          backgroundColor: '#1a1a2e',
+          borderTopColor: '#2a2a4a',
+        },
+        tabBarActiveTintColor: '#ffffff',
+        tabBarInactiveTintColor: '#666688',
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: '현재 역',
+          tabBarIcon: ({ color }) => <Text style={{ fontSize: 20, color }}>🚇</Text>,
+        }}
+      />
+      <Tabs.Screen
+        name="favorites"
+        options={{
+          title: '즐겨찾기',
+          tabBarIcon: ({ color }) => <Text style={{ fontSize: 20, color }}>⭐</Text>,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -1,0 +1,137 @@
+import { useEffect } from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useAppStore } from '../../src/store/useAppStore';
+import { LINE_NAMES } from '../../src/constants/lineColors';
+import { Station } from '../../src/types/station';
+
+export default function FavoritesScreen() {
+  const { favorites, removeFavorite, loadFavorites } = useAppStore();
+
+  useEffect(() => {
+    loadFavorites();
+  }, []);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <Text style={styles.header}>즐겨찾기</Text>
+        {favorites.length === 0 ? (
+          <View style={styles.empty}>
+            <Text style={styles.emptyIcon}>⭐</Text>
+            <Text style={styles.emptyTitle}>즐겨찾기가 없습니다</Text>
+            <Text style={styles.emptySubtitle}>
+              현재 역 화면에서 역을 즐겨찾기에{'\n'}추가할 수 있습니다.
+            </Text>
+          </View>
+        ) : (
+          favorites.map((station: Station) => (
+            <FavoriteCard key={station.id} station={station} onRemove={() => removeFavorite(station.id)} />
+          ))
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function FavoriteCard({
+  station,
+  onRemove,
+}: {
+  station: Station;
+  onRemove: () => void;
+}) {
+  return (
+    <View style={[styles.card, { borderLeftColor: station.lineColor }]}>
+      <View style={styles.cardInfo}>
+        <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
+          <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
+        </View>
+        <Text style={styles.stationName}>{station.name}</Text>
+      </View>
+      <TouchableOpacity style={styles.removeButton} onPress={onRemove}>
+        <Text style={styles.removeText}>삭제</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  scroll: {
+    padding: 24,
+    flexGrow: 1,
+  },
+  header: {
+    fontSize: 14,
+    color: '#8888aa',
+    marginBottom: 20,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 80,
+  },
+  emptyIcon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#ffffff',
+    marginBottom: 8,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#8888aa',
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  card: {
+    backgroundColor: '#16213e',
+    borderRadius: 12,
+    padding: 16,
+    borderLeftWidth: 5,
+    marginBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  cardInfo: {
+    flex: 1,
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 20,
+    marginBottom: 8,
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  stationName: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+  removeButton: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#2a2a4a',
+  },
+  removeText: {
+    color: '#ff6b6b',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,11 +1,18 @@
+import { useEffect } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { LINE_NAMES } from '../../src/constants/lineColors';
+import { useAppStore } from '../../src/store/useAppStore';
 
 export default function HomeScreen() {
   const { result, loading, error, permissionDenied, refresh } = useNearestStation();
   const { arrival } = useArrivalInfo(result?.station.name ?? null);
+  const { addFavorite, removeFavorite, isFavorite, loadFavorites } = useAppStore();
+
+  useEffect(() => {
+    loadFavorites();
+  }, []);
 
   if (permissionDenied) {
     return (
@@ -55,8 +62,21 @@ export default function HomeScreen() {
         {result ? (
           <>
             <View style={[styles.stationCard, { borderLeftColor: result.station.lineColor }]}>
-              <View style={[styles.lineBadge, { backgroundColor: result.station.lineColor }]}>
-                <Text style={styles.lineBadgeText}>{LINE_NAMES[result.station.line]}</Text>
+              <View style={styles.stationCardHeader}>
+                <View style={[styles.lineBadge, { backgroundColor: result.station.lineColor }]}>
+                  <Text style={styles.lineBadgeText}>{LINE_NAMES[result.station.line]}</Text>
+                </View>
+                <TouchableOpacity
+                  onPress={() =>
+                    isFavorite(result.station.id)
+                      ? removeFavorite(result.station.id)
+                      : addFavorite(result.station)
+                  }
+                >
+                  <Text style={styles.favoriteIcon}>
+                    {isFavorite(result.station.id) ? '⭐' : '☆'}
+                  </Text>
+                </TouchableOpacity>
               </View>
               <Text style={styles.stationName}>{result.station.name}</Text>
               <Text style={styles.distanceText}>
@@ -138,12 +158,20 @@ const styles = StyleSheet.create({
     borderLeftWidth: 6,
     marginBottom: 24,
   },
+  stationCardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  favoriteIcon: {
+    fontSize: 26,
+  },
   lineBadge: {
     alignSelf: 'flex-start',
     paddingHorizontal: 10,
     paddingVertical: 4,
     borderRadius: 20,
-    marginBottom: 12,
   },
   lineBadgeText: {
     color: '#ffffff',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,0 +1,232 @@
+import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useNearestStation } from '../../src/hooks/useNearestStation';
+import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
+import { LINE_NAMES } from '../../src/constants/lineColors';
+
+export default function HomeScreen() {
+  const { result, loading, error, permissionDenied, refresh } = useNearestStation();
+  const { arrival } = useArrivalInfo(result?.station.name ?? null);
+
+  if (permissionDenied) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.center}>
+          <Text style={styles.icon}>📍</Text>
+          <Text style={styles.title}>위치 권한 필요</Text>
+          <Text style={styles.subtitle}>
+            설정에서 위치 권한을 허용해 주세요.{'\n'}현재 탑승 중인 역을 감지하려면{'\n'}위치 권한이 필요합니다.
+          </Text>
+          <TouchableOpacity style={styles.button} onPress={refresh}>
+            <Text style={styles.buttonText}>다시 시도</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.center}>
+          <Text style={styles.loadingText}>위치 확인 중...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.center}>
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.button} onPress={refresh}>
+            <Text style={styles.buttonText}>새로고침</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <Text style={styles.header}>지금 여기</Text>
+
+        {result ? (
+          <>
+            <View style={[styles.stationCard, { borderLeftColor: result.station.lineColor }]}>
+              <View style={[styles.lineBadge, { backgroundColor: result.station.lineColor }]}>
+                <Text style={styles.lineBadgeText}>{LINE_NAMES[result.station.line]}</Text>
+              </View>
+              <Text style={styles.stationName}>{result.station.name}</Text>
+              <Text style={styles.distanceText}>
+                현재 위치에서 약 {Math.round(result.distanceKm * 1000)}m
+              </Text>
+            </View>
+
+            {arrival && (
+              <View style={styles.arrivalSection}>
+                <Text style={styles.sectionTitle}>열차 도착 정보</Text>
+                <ArrivalRow label="상행" items={arrival.up} />
+                <ArrivalRow label="하행" items={arrival.down} />
+              </View>
+            )}
+          </>
+        ) : (
+          <View style={styles.center}>
+            <Text style={styles.icon}>🚶</Text>
+            <Text style={styles.title}>지하철역 근처가 아닙니다</Text>
+            <Text style={styles.subtitle}>지하철역 500m 이내에 있을 때{'\n'}현재 역이 표시됩니다.</Text>
+            <TouchableOpacity style={styles.button} onPress={refresh}>
+              <Text style={styles.buttonText}>새로고침</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function ArrivalRow({
+  label,
+  items,
+}: {
+  label: string;
+  items: { destination: string; arrivalMinutes: number }[];
+}) {
+  if (items.length === 0) return null;
+  return (
+    <View style={styles.arrivalRow}>
+      <Text style={styles.arrivalLabel}>{label}</Text>
+      <View>
+        {items.map((item, idx) => (
+          <Text key={idx} style={styles.arrivalItem}>
+            {item.arrivalMinutes === 0 ? '곧 도착' : `${item.arrivalMinutes}분 후`}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  scroll: {
+    padding: 24,
+    flexGrow: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  header: {
+    fontSize: 14,
+    color: '#8888aa',
+    marginBottom: 16,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  stationCard: {
+    backgroundColor: '#16213e',
+    borderRadius: 16,
+    padding: 24,
+    borderLeftWidth: 6,
+    marginBottom: 24,
+  },
+  lineBadge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 20,
+    marginBottom: 12,
+  },
+  lineBadgeText: {
+    color: '#ffffff',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  stationName: {
+    fontSize: 42,
+    fontWeight: '800',
+    color: '#ffffff',
+    marginBottom: 8,
+  },
+  distanceText: {
+    fontSize: 14,
+    color: '#8888aa',
+  },
+  arrivalSection: {
+    backgroundColor: '#16213e',
+    borderRadius: 16,
+    padding: 20,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    color: '#8888aa',
+    marginBottom: 16,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  arrivalRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderTopColor: '#2a2a4a',
+  },
+  arrivalLabel: {
+    fontSize: 15,
+    color: '#aaaacc',
+    fontWeight: '600',
+  },
+  arrivalItem: {
+    fontSize: 15,
+    color: '#ffffff',
+    textAlign: 'right',
+    marginBottom: 4,
+  },
+  icon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#ffffff',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 15,
+    color: '#8888aa',
+    textAlign: 'center',
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  loadingText: {
+    fontSize: 16,
+    color: '#8888aa',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#ff6b6b',
+    marginBottom: 16,
+  },
+  button: {
+    backgroundColor: '#0052A4',
+    paddingHorizontal: 28,
+    paddingVertical: 14,
+    borderRadius: 12,
+  },
+  buttonText: {
+    color: '#ffffff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+
+export default function RootLayout() {
+  return (
+    <>
+      <StatusBar style="light" />
+      <Stack screenOptions={{ headerShown: false }} />
+    </>
+  );
+}

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -1,0 +1,58 @@
+export interface ArrivalInfo {
+  destination: string;
+  arrivalMinutes: number;
+  trainCode: string;
+}
+
+export interface StationArrival {
+  up: ArrivalInfo[];
+  down: ArrivalInfo[];
+}
+
+const MOCK_ARRIVALS: StationArrival = {
+  up: [
+    { destination: '상행 종착역', arrivalMinutes: 2, trainCode: 'UP-001' },
+    { destination: '상행 종착역', arrivalMinutes: 8, trainCode: 'UP-002' },
+  ],
+  down: [
+    { destination: '하행 종착역', arrivalMinutes: 4, trainCode: 'DN-001' },
+    { destination: '하행 종착역', arrivalMinutes: 11, trainCode: 'DN-002' },
+  ],
+};
+
+export async function fetchArrivalInfo(stationName: string): Promise<StationArrival> {
+  const apiKey = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+
+  if (!apiKey) {
+    // API 키 없을 때 Mock 데이터 반환
+    return MOCK_ARRIVALS;
+  }
+
+  const url = `http://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/10/${encodeURIComponent(stationName)}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`도착 정보 API 오류: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const items: any[] = data.realtimeArrivalList ?? [];
+
+  const up: ArrivalInfo[] = [];
+  const down: ArrivalInfo[] = [];
+
+  for (const item of items) {
+    const info: ArrivalInfo = {
+      destination: item.trainLineNm ?? '',
+      arrivalMinutes: Math.max(0, Math.floor((item.barvlDt ?? 0) / 60)),
+      trainCode: item.btrainNo ?? '',
+    };
+    if (item.updnLine === '상행' || item.updnLine === '내선') {
+      up.push(info);
+    } else {
+      down.push(info);
+    }
+  }
+
+  return { up: up.slice(0, 2), down: down.slice(0, 2) };
+}

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchArrivalInfo, StationArrival } from '../api/arrivalApi';
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface UseArrivalInfoReturn {
+  arrival: StationArrival | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useArrivalInfo(stationName: string | null): UseArrivalInfoReturn {
+  const [arrival, setArrival] = useState<StationArrival | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!stationName) {
+      setArrival(null);
+      return;
+    }
+    try {
+      setError(null);
+      setLoading(true);
+      const data = await fetchArrivalInfo(stationName);
+      setArrival(data);
+    } catch {
+      setError('도착 정보를 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }, [stationName]);
+
+  useEffect(() => {
+    fetch();
+    intervalRef.current = setInterval(fetch, POLL_INTERVAL_MS);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [fetch]);
+
+  return { arrival, loading, error };
+}

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Station } from '../types/station';
+
+const STORAGE_KEY = 'subway-now:favorites';
+
+interface AppState {
+  favorites: Station[];
+  addFavorite: (station: Station) => Promise<void>;
+  removeFavorite: (stationId: string) => Promise<void>;
+  isFavorite: (stationId: string) => boolean;
+  loadFavorites: () => Promise<void>;
+}
+
+export const useAppStore = create<AppState>((set, get) => ({
+  favorites: [],
+
+  loadFavorites: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        set({ favorites: JSON.parse(raw) });
+      }
+    } catch {
+      // 저장된 데이터 없음 — 빈 배열 유지
+    }
+  },
+
+  addFavorite: async (station: Station) => {
+    const current = get().favorites;
+    if (current.some((s) => s.id === station.id)) return;
+    const updated = [...current, station];
+    set({ favorites: updated });
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  },
+
+  removeFavorite: async (stationId: string) => {
+    const updated = get().favorites.filter((s) => s.id !== stationId);
+    set({ favorites: updated });
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  },
+
+  isFavorite: (stationId: string) => {
+    return get().favorites.some((s) => s.id === stationId);
+  },
+}));


### PR DESCRIPTION
## Summary
- 실시간 도착 정보 API 레이어 구현 (API 키 없으면 Mock 데이터 반환)
- 현재 역 메인 화면: 역명, 호선 배지, 거리, 도착 정보 표시
- Zustand 스토어: 즐겨찾기 상태 관리 + AsyncStorage 영속화
- 즐겨찾기 화면: 저장된 역 목록 및 삭제 기능

## Test plan
- [ ] `npx expo start`로 앱 실행
- [ ] 위치 권한 허용 후 현재 역 감지 확인
- [ ] ⭐ 버튼으로 즐겨찾기 추가/해제
- [ ] 즐겨찾기 탭에서 저장된 역 확인 및 삭제

Closes #4
Closes #5
Closes #6