### PR TITLE
chore(#11,#13): GitHub Actions CI + CLAUDE.md 테스트 규칙 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 의존성 설치
+        run: npm ci --legacy-peer-deps
+
+      - name: TypeScript 타입 체크
+        run: npm run type-check
+
+      - name: 단위 테스트 실행 (커버리지 100% 검증)
+        run: npm test -- --ci --forceExit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,13 @@ GPS 기반으로 현재 탑승 중인 지하철역을 실시간으로 감지하�
 ## GitHub 워크플로우 (필수 준수)
 
 ### 작업 순서
-1. **GitHub Issue 먼저 생성** — 모든 작업은 이슈에서 시작
+1. **GitHub Issue 먼저 생성** — 코드 한 줄도 없이 이슈부터
 2. **이슈 번호로 브랜치 생성** — `feat/#이슈번호-기능명` 형식
 3. **작은 단위로 커밋** — 기능 단위로 세세하게 남김
-4. **PR 생성 시 이슈 연결** — 본문에 `Closes #이슈번호` 포함
-5. **리뷰 후 머지**
+4. **`npm test` 통과 확인** — 커버리지 100% 달성 후 PR 생성
+5. **`npm run type-check` 통과 확인** — 타입 오류 없음 확인 후 PR 생성
+6. **PR 생성 시 이슈 연결** — 본문에 `Closes #이슈번호` 포함
+7. **CI 통과 후 머지** — GitHub Actions `CI / Type Check & Test` 체크 통과 필수
 
 ### 브랜치 네이밍
 ```
@@ -80,6 +82,37 @@ subway-now/
 ├── .env.example            # 환경변수 템플릿 (git 포함)
 └── CLAUDE.md               # 이 파일
 ```
+
+---
+
+## 테스트 규칙 (필수 준수)
+
+- **모든 새 파일에 테스트 필수** — 테스트 없는 코드는 커밋 불가
+- **커버리지 100%** — lines / functions / branches / statements 모두 100%
+  - `package.json`의 `coverageThreshold`로 자동 강제됨 (미달 시 `npm test` 실패)
+- **테스트 파일 위치**: `src/<모듈>/__tests__/<파일명>.test.ts`
+- **Mock 원칙**: 외부 의존성(`expo-location`, `fetch`, `AsyncStorage`)은 jest.mock()으로 격리
+
+### 테스트 명령
+```bash
+npm test          # 전체 테스트 + 커버리지 리포트
+npm run test:watch  # 파일 변경 감지 테스트
+npm run type-check  # TypeScript 타입 오류 확인
+```
+
+---
+
+## PR 머지 조건 (GitHub Actions Branch Protection)
+
+PR은 아래 조건이 **모두** 충족될 때만 머지 가능:
+
+| 조건 | 자동화 |
+|------|--------|
+| `npm run type-check` 통과 | ✅ CI 자동 실행 |
+| `npm test` 커버리지 100% 통과 | ✅ CI 자동 실행 |
+| GitHub Actions `CI / Type Check & Test` 체크 green | ✅ Branch Protection |
+
+> CI가 실패한 PR은 절대 머지하지 않는다.
 
 ---
 


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml`: push/PR → main 시 type-check + test 자동 실행
- CI 실패(테스트 미통과 / 커버리지 100% 미달) 시 PR 머지 차단
- `CLAUDE.md`: 테스트 규칙, PR 머지 조건 섹션 추가
- GitHub 워크플로우 강화: 이슈 먼저 → 테스트 통과 → CI green → 머지

## Next Steps
- GitHub Settings > Branches > Add branch protection rule:
  - `main` 브랜치에 `CI / Type Check & Test` 상태 체크 필수 설정 권장

Closes #11
Closes #13