### PR TITLE
feat(#26): 홈 화면 열차 도착 정보에 종착역 방면 표시

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -121,6 +121,7 @@ function ArrivalRow({
       <View>
         {items.map((item, idx) => (
           <Text key={idx} style={styles.arrivalItem}>
+            {item.destination ? `${item.destination} · ` : ''}
             {item.arrivalMinutes === 0 ? '곧 도착' : `${item.arrivalMinutes}분 후`}
           </Text>
         ))}


### PR DESCRIPTION
## 변경 내용

홈 화면 열차 도착 정보에 종착역(방면) 정보를 추가 표시합니다.

**변경 전**
- `"3분 후"` / `"곧 도착"`

**변경 후**
- `"강남 방면 · 3분 후"` / `"강남 방면 · 곧 도착"`
- `destination`이 빈 문자열이면 방면 정보 생략

## 변경 파일
- `app/(tabs)/index.tsx` — `ArrivalRow` 컴포넌트 1줄 수정

Closes #26