### PR TITLE
feat(#27): 웹 플랫폼 StationMap 주변 역 목록 표시

### DIFF
--- a/src/components/StationMap.web.tsx
+++ b/src/components/StationMap.web.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Station } from '../types/station';
+import { haversine } from '../utils/haversine';
+import { LINE_NAMES } from '../constants/lineColors';
 
 interface StationMapProps {
   userLat: number;
@@ -10,15 +12,51 @@ interface StationMapProps {
   kakaoKey: string;
 }
 
-export function StationMap(_props: StationMapProps) {
+export function StationMap({ userLat, userLng, nearestStation, nearbyStations }: StationMapProps) {
+  if (nearbyStations.length === 0) {
+    return (
+      <View style={styles.fallback}>
+        <Text style={styles.emptyText}>주변 1km 내 지하철역이 없습니다.</Text>
+      </View>
+    );
+  }
+
+  const sorted = [...nearbyStations]
+    .map((s) => ({
+      station: s,
+      distanceM: Math.round(haversine(userLat, userLng, s.lat, s.lng) * 1000),
+    }))
+    .sort((a, b) => a.distanceM - b.distanceM);
+
   return (
-    <View style={styles.fallback}>
-      <Text style={styles.text}>지도는 모바일 앱(Expo Go)에서 이용하세요.</Text>
-    </View>
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.header}>주변 지하철역 (1km 이내)</Text>
+      {sorted.map(({ station, distanceM }) => (
+        <View
+          key={station.id}
+          style={[styles.row, nearestStation?.id === station.id && styles.nearestRow]}
+        >
+          <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
+            <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
+          </View>
+          <Text style={[styles.name, nearestStation?.id === station.id && styles.nearestName]}>
+            {station.name}
+          </Text>
+          <Text style={styles.distance}>{distanceM}m</Text>
+        </View>
+      ))}
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  content: {
+    padding: 20,
+  },
   fallback: {
     flex: 1,
     alignItems: 'center',
@@ -26,9 +64,52 @@ const styles = StyleSheet.create({
     backgroundColor: '#1a1a2e',
     padding: 24,
   },
-  text: {
+  emptyText: {
     color: '#8888aa',
     fontSize: 14,
     textAlign: 'center',
+  },
+  header: {
+    fontSize: 12,
+    color: '#8888aa',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#16213e',
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 8,
+    gap: 10,
+  },
+  nearestRow: {
+    borderWidth: 1,
+    borderColor: '#0052A4',
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  name: {
+    flex: 1,
+    fontSize: 16,
+    color: '#ffffff',
+    fontWeight: '600',
+  },
+  nearestName: {
+    color: '#6699ff',
+  },
+  distance: {
+    fontSize: 13,
+    color: '#8888aa',
   },
 });

--- a/src/components/__tests__/StationMap.web.test.tsx
+++ b/src/components/__tests__/StationMap.web.test.tsx
@@ -1,6 +1,25 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { StationMap } from '../StationMap.web';
+import { Station } from '../../types/station';
+
+const gangnam: Station = {
+  id: '2-222',
+  name: '강남',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+const sinnonhyeon: Station = {
+  id: '9-007',
+  name: '신논현',
+  line: '9',
+  lineColor: '#BDB092',
+  lat: 37.5044,
+  lng: 127.0245,
+};
 
 const defaultProps = {
   userLat: 37.4979,
@@ -11,13 +30,46 @@ const defaultProps = {
 };
 
 describe('StationMap.web', () => {
-  it('모바일 앱 안내 문구를 렌더링한다', () => {
+  it('nearbyStations이 없으면 안내 문구를 렌더링한다', () => {
     const { getByText } = render(<StationMap {...defaultProps} />);
-    expect(getByText('지도는 모바일 앱(Expo Go)에서 이용하세요.')).toBeTruthy();
+    expect(getByText('주변 1km 내 지하철역이 없습니다.')).toBeTruthy();
   });
 
-  it('kakaoKey가 없어도 동일한 안내 문구를 렌더링한다', () => {
-    const { getByText } = render(<StationMap {...defaultProps} kakaoKey="" />);
-    expect(getByText('지도는 모바일 앱(Expo Go)에서 이용하세요.')).toBeTruthy();
+  it('nearbyStations이 있으면 역 목록과 헤더를 렌더링한다', () => {
+    const { getByText } = render(
+      <StationMap {...defaultProps} nearbyStations={[gangnam, sinnonhyeon]} />,
+    );
+    expect(getByText('주변 지하철역 (1km 이내)')).toBeTruthy();
+    expect(getByText('강남')).toBeTruthy();
+    expect(getByText('신논현')).toBeTruthy();
+  });
+
+  it('nearestStation과 일치하는 역이 있으면 nearestRow 스타일이 적용된다', () => {
+    const { getByText } = render(
+      <StationMap
+        {...defaultProps}
+        nearbyStations={[gangnam, sinnonhyeon]}
+        nearestStation={gangnam}
+      />,
+    );
+    expect(getByText('강남')).toBeTruthy();
+  });
+
+  it('nearestStation이 목록에 없으면 nearestRow 스타일 없이 렌더링한다', () => {
+    const { getByText } = render(
+      <StationMap
+        {...defaultProps}
+        nearbyStations={[sinnonhyeon]}
+        nearestStation={gangnam}
+      />,
+    );
+    expect(getByText('신논현')).toBeTruthy();
+  });
+
+  it('kakaoKey가 없어도 정상 동작한다', () => {
+    const { getByText } = render(
+      <StationMap {...defaultProps} nearbyStations={[gangnam]} kakaoKey="" />,
+    );
+    expect(getByText('강남')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## 변경 내용

웹 플랫폼에서 단순 안내 문구만 표시하던 `StationMap`을 주변 역 목록으로 개선합니다.

**변경 전**
- "지도는 모바일 앱(Expo Go)에서 이용하세요." 고정 텍스트

**변경 후**
- 상위 컴포넌트에서 전달된 `nearbyStations` + `haversine`으로 거리 계산
- 가까운 순 정렬 후 노선 뱃지 + 역 이름 + 거리(m) 목록 표시
- `nearestStation`은 파란 테두리 + 파란 텍스트로 강조
- 주변 역이 없을 시 "주변 1km 내 지하철역이 없습니다." 표시

## 변경 파일
- `src/components/StationMap.web.tsx` — 컴포넌트 재작성
- `src/components/__tests__/StationMap.web.test.tsx` — 5개 테스트 케이스로 확장

Closes #27