### PR TITLE
feat(#35): 수동 목적지 설정 및 남은 정거장 표시

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,18 +1,28 @@
-import { useEffect } from 'react';
-import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
+import { DestinationPicker } from '../../src/components/DestinationPicker';
+import { getRemainingStops } from '../../src/utils/stationRoute';
 
 export default function HomeScreen() {
   const { result, loading, error, permissionDenied, refresh } = useNearestStation();
   const { arrival } = useArrivalInfo(result?.station.name ?? null);
-  const { addFavorite, removeFavorite, isFavorite, loadFavorites } = useAppStore();
+  const { addFavorite, removeFavorite, isFavorite, loadFavorites, destination, setDestination, loadDestination } = useAppStore();
+  const [pickerVisible, setPickerVisible] = useState(false);
 
   useEffect(() => {
     loadFavorites();
+    loadDestination();
   }, []);
+
+  const remainingStops =
+    result && destination
+      ? getRemainingStops(result.station.id, destination.id)
+      : null;
 
   if (permissionDenied) {
     return (
@@ -84,6 +94,39 @@ export default function HomeScreen() {
               </Text>
             </View>
 
+            <View style={styles.destinationCard}>
+              {destination ? (
+                <View style={styles.destinationInfo}>
+                  <Text style={styles.destinationArrow}>→</Text>
+                  <View>
+                    <Text style={styles.destinationName}>{destination.name}</Text>
+                    {remainingStops !== null ? (
+                      <Text style={styles.remainingText}>{remainingStops} 정거장 남음</Text>
+                    ) : (
+                      <Text style={styles.remainingText}>다른 노선</Text>
+                    )}
+                  </View>
+                </View>
+              ) : null}
+              <TouchableOpacity
+                style={styles.destinationButton}
+                onPress={() => setPickerVisible(true)}
+                testID="destination-button"
+              >
+                <Text style={styles.destinationButtonText}>
+                  {destination ? '목적지 변경' : '목적지 설정'}
+                </Text>
+              </TouchableOpacity>
+              {destination ? (
+                <TouchableOpacity
+                  onPress={() => setDestination(null)}
+                  testID="destination-clear-button"
+                >
+                  <Text style={styles.clearText}>초기화</Text>
+                </TouchableOpacity>
+              ) : null}
+            </View>
+
             {arrival && (
               <View style={styles.arrivalSection}>
                 <Text style={styles.sectionTitle}>열차 도착 정보</Text>
@@ -103,6 +146,15 @@ export default function HomeScreen() {
           </View>
         )}
       </ScrollView>
+
+      <DestinationPicker
+        visible={pickerVisible}
+        onSelect={(station) => {
+          setDestination(station);
+          setPickerVisible(false);
+        }}
+        onClose={() => setPickerVisible(false)}
+      />
     </SafeAreaView>
   );
 }
@@ -157,7 +209,7 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     padding: 24,
     borderLeftWidth: 6,
-    marginBottom: 24,
+    marginBottom: 16,
   },
   stationCardHeader: {
     flexDirection: 'row',
@@ -188,6 +240,49 @@ const styles = StyleSheet.create({
   distanceText: {
     fontSize: 14,
     color: '#8888aa',
+  },
+  destinationCard: {
+    backgroundColor: '#16213e',
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+  },
+  destinationInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  destinationArrow: {
+    fontSize: 24,
+    color: '#a78bfa',
+    marginRight: 12,
+  },
+  destinationName: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+  remainingText: {
+    fontSize: 13,
+    color: '#8888aa',
+    marginTop: 2,
+  },
+  destinationButton: {
+    backgroundColor: '#a78bfa',
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  destinationButtonText: {
+    color: '#ffffff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  clearText: {
+    color: '#8888aa',
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 8,
   },
   arrivalSection: {
     backgroundColor: '#16213e',

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -1,0 +1,134 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import stations from '../data/stations.json';
+import type { Station } from '../types/station';
+
+const allStations = stations as Station[];
+
+interface Props {
+  visible: boolean;
+  onSelect: (station: Station) => void;
+  onClose: () => void;
+}
+
+export function DestinationPicker({ visible, onSelect, onClose }: Props) {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.trim();
+    if (!q) return allStations.slice(0, 50);
+    return allStations.filter((s) => s.name.includes(q));
+  }, [query]);
+
+  function handleSelect(station: Station) {
+    setQuery('');
+    onSelect(station);
+  }
+
+  function handleClose() {
+    setQuery('');
+    onClose();
+  }
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={handleClose}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>목적지 설정</Text>
+          <TouchableOpacity onPress={handleClose} testID="close-button">
+            <Text style={styles.closeText}>닫기</Text>
+          </TouchableOpacity>
+        </View>
+        <TextInput
+          style={styles.input}
+          placeholder="역 이름 검색"
+          placeholderTextColor="#888"
+          value={query}
+          onChangeText={setQuery}
+          testID="search-input"
+        />
+        <FlatList
+          data={filtered}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              style={styles.item}
+              onPress={() => handleSelect(item)}
+              testID={`station-item-${item.id}`}
+            >
+              <Text style={styles.stationName}>{item.name}</Text>
+              <View style={[styles.lineBadge, { backgroundColor: item.lineColor }]}>
+                <Text style={styles.lineText}>{item.line}호선</Text>
+              </View>
+            </TouchableOpacity>
+          )}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+    paddingTop: 50,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingBottom: 16,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  closeText: {
+    color: '#a78bfa',
+    fontSize: 16,
+  },
+  input: {
+    backgroundColor: '#16213e',
+    color: '#fff',
+    marginHorizontal: 20,
+    marginBottom: 12,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#16213e',
+  },
+  stationName: {
+    color: '#fff',
+    fontSize: 16,
+  },
+  lineBadge: {
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  lineText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { DestinationPicker } from '../DestinationPicker';
+import type { Station } from '../../types/station';
+
+const mockStation: Station = {
+  id: '2-022',
+  name: '강남',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+const defaultProps = {
+  visible: true,
+  onSelect: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe('DestinationPicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('visible=true 일 때 제목과 검색창을 렌더링한다', () => {
+    const { getByText, getByTestId } = render(<DestinationPicker {...defaultProps} />);
+    expect(getByText('목적지 설정')).toBeTruthy();
+    expect(getByTestId('search-input')).toBeTruthy();
+    expect(getByTestId('close-button')).toBeTruthy();
+  });
+
+  it('닫기 버튼 클릭 시 onClose를 호출한다', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <DestinationPicker {...defaultProps} onClose={onClose} />
+    );
+    fireEvent.press(getByTestId('close-button'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('역 이름으로 검색하면 필터링된 결과를 보여준다', () => {
+    const { getByTestId, queryByTestId } = render(
+      <DestinationPicker {...defaultProps} />
+    );
+    fireEvent.changeText(getByTestId('search-input'), '강남');
+    expect(getByTestId(`station-item-${mockStation.id}`)).toBeTruthy();
+    // 강남이 포함되지 않는 역은 표시되지 않아야 함
+    expect(queryByTestId('station-item-1-001')).toBeNull();
+  });
+
+  it('역 항목 선택 시 onSelect를 호출한다', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <DestinationPicker {...defaultProps} onSelect={onSelect} />
+    );
+    fireEvent.changeText(getByTestId('search-input'), '강남');
+    fireEvent.press(getByTestId(`station-item-${mockStation.id}`));
+    expect(onSelect).toHaveBeenCalledWith(mockStation);
+  });
+
+  it('역 선택 후 검색어가 초기화된다', () => {
+    const { getByTestId } = render(<DestinationPicker {...defaultProps} />);
+    fireEvent.changeText(getByTestId('search-input'), '강남');
+    fireEvent.press(getByTestId(`station-item-${mockStation.id}`));
+    expect(getByTestId('search-input').props.value).toBe('');
+  });
+
+  it('닫기 후 검색어가 초기화된다', () => {
+    const { getByTestId } = render(<DestinationPicker {...defaultProps} />);
+    fireEvent.changeText(getByTestId('search-input'), '강남');
+    fireEvent.press(getByTestId('close-button'));
+    expect(getByTestId('search-input').props.value).toBe('');
+  });
+
+  it('검색어가 비어있으면 기본 목록이 표시된다', () => {
+    const { getAllByTestId } = render(<DestinationPicker {...defaultProps} />);
+    const items = getAllByTestId(/^station-item-/);
+    expect(items.length).toBeGreaterThan(0);
+  });
+});

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -26,7 +26,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [] });
+    useAppStore.setState({ favorites: [], destination: null });
     jest.clearAllMocks();
   });
 
@@ -136,5 +136,76 @@ describe('useAppStore', () => {
 
     const { favorites } = useAppStore.getState();
     expect(favorites).toHaveLength(0);
+  });
+
+  it('초기 목적지는 null이다', () => {
+    const { destination } = useAppStore.getState();
+    expect(destination).toBeNull();
+  });
+
+  it('setDestination: 목적지를 설정하면 상태가 업데이트된다', async () => {
+    const { setDestination } = useAppStore.getState();
+    await setDestination(mockStation);
+
+    const { destination } = useAppStore.getState();
+    expect(destination?.id).toBe('2-022');
+  });
+
+  it('setDestination: null을 설정하면 목적지가 초기화된다', async () => {
+    const { setDestination } = useAppStore.getState();
+    await setDestination(mockStation);
+    await setDestination(null);
+
+    const { destination } = useAppStore.getState();
+    expect(destination).toBeNull();
+  });
+
+  it('setDestination: 역 설정 시 AsyncStorage에 저장한다', async () => {
+    const { setDestination } = useAppStore.getState();
+    await setDestination(mockStation);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:destination',
+      JSON.stringify(mockStation)
+    );
+  });
+
+  it('setDestination: null 설정 시 AsyncStorage에서 삭제한다', async () => {
+    const { setDestination } = useAppStore.getState();
+    await setDestination(null);
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:destination');
+  });
+
+  it('loadDestination: AsyncStorage에서 목적지를 복원한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify(mockStation)
+    );
+
+    const { loadDestination } = useAppStore.getState();
+    await loadDestination();
+
+    const { destination } = useAppStore.getState();
+    expect(destination?.id).toBe('2-022');
+  });
+
+  it('loadDestination: AsyncStorage가 비어있으면 null을 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { loadDestination } = useAppStore.getState();
+    await loadDestination();
+
+    const { destination } = useAppStore.getState();
+    expect(destination).toBeNull();
+  });
+
+  it('loadDestination: AsyncStorage 오류 시 null을 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+
+    const { loadDestination } = useAppStore.getState();
+    await loadDestination();
+
+    const { destination } = useAppStore.getState();
+    expect(destination).toBeNull();
   });
 });

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -2,22 +2,27 @@ import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Station } from '../types/station';
 
-const STORAGE_KEY = 'subway-now:favorites';
+const FAVORITES_KEY = 'subway-now:favorites';
+const DESTINATION_KEY = 'subway-now:destination';
 
 interface AppState {
   favorites: Station[];
+  destination: Station | null;
   addFavorite: (station: Station) => Promise<void>;
   removeFavorite: (stationId: string) => Promise<void>;
   isFavorite: (stationId: string) => boolean;
   loadFavorites: () => Promise<void>;
+  setDestination: (station: Station | null) => Promise<void>;
+  loadDestination: () => Promise<void>;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
   favorites: [],
+  destination: null,
 
   loadFavorites: async () => {
     try {
-      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      const raw = await AsyncStorage.getItem(FAVORITES_KEY);
       if (raw) {
         set({ favorites: JSON.parse(raw) });
       }
@@ -31,16 +36,36 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (current.some((s) => s.id === station.id)) return;
     const updated = [...current, station];
     set({ favorites: updated });
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
   },
 
   removeFavorite: async (stationId: string) => {
     const updated = get().favorites.filter((s) => s.id !== stationId);
     set({ favorites: updated });
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
   },
 
   isFavorite: (stationId: string) => {
     return get().favorites.some((s) => s.id === stationId);
+  },
+
+  setDestination: async (station: Station | null) => {
+    set({ destination: station });
+    if (station) {
+      await AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station));
+    } else {
+      await AsyncStorage.removeItem(DESTINATION_KEY);
+    }
+  },
+
+  loadDestination: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(DESTINATION_KEY);
+      if (raw) {
+        set({ destination: JSON.parse(raw) });
+      }
+    } catch {
+      // 저장된 데이터 없음 — null 유지
+    }
   },
 }));

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,0 +1,43 @@
+import { getStationsOnLine, getRemainingStops } from '../stationRoute';
+
+describe('getStationsOnLine', () => {
+  it('returns only stations on the given line, sorted by id', () => {
+    const line1 = getStationsOnLine('1');
+    expect(line1.length).toBeGreaterThan(0);
+    line1.forEach((s) => expect(s.line).toBe('1'));
+    for (let i = 1; i < line1.length; i++) {
+      expect(line1[i - 1].id.localeCompare(line1[i].id)).toBeLessThan(0);
+    }
+  });
+
+  it('returns empty array for unknown line', () => {
+    expect(getStationsOnLine('999')).toEqual([]);
+  });
+});
+
+describe('getRemainingStops', () => {
+  it('returns 0 when current and destination are the same station', () => {
+    expect(getRemainingStops('1-001', '1-001')).toBe(0);
+  });
+
+  it('returns correct count in forward direction', () => {
+    // 1-001(소요산) → 1-003(보산): 2 stops
+    expect(getRemainingStops('1-001', '1-003')).toBe(2);
+  });
+
+  it('returns correct count in reverse direction', () => {
+    // 1-003(보산) → 1-001(소요산): 2 stops
+    expect(getRemainingStops('1-003', '1-001')).toBe(2);
+  });
+
+  it('returns null when stations are on different lines', () => {
+    const line1 = getStationsOnLine('1')[0];
+    const line2 = getStationsOnLine('2')[0];
+    expect(getRemainingStops(line1.id, line2.id)).toBeNull();
+  });
+
+  it('returns null for unknown station id', () => {
+    expect(getRemainingStops('1-001', 'unknown-id')).toBeNull();
+    expect(getRemainingStops('unknown-id', '1-001')).toBeNull();
+  });
+});

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -1,0 +1,27 @@
+import stations from '../data/stations.json';
+import type { Station } from '../types/station';
+
+const allStations = stations as Station[];
+
+export function getStationsOnLine(line: string): Station[] {
+  return allStations
+    .filter((s) => s.line === line)
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function getRemainingStops(
+  currentId: string,
+  destinationId: string,
+): number | null {
+  const current = allStations.find((s) => s.id === currentId);
+  const destination = allStations.find((s) => s.id === destinationId);
+
+  if (!current || !destination) return null;
+  if (current.line !== destination.line) return null;
+
+  const lineStations = getStationsOnLine(current.line);
+  const currentIdx = lineStations.findIndex((s) => s.id === currentId);
+  const destIdx = lineStations.findIndex((s) => s.id === destinationId);
+
+  return Math.abs(destIdx - currentIdx);
+}


### PR DESCRIPTION
## Summary

- 사용자가 목적지 역을 직접 검색·선택할 수 있는 `DestinationPicker` 모달 컴포넌트 추가
- 현재 역과 목적지가 같은 노선일 때 남은 정거장 수 계산 (`stationRoute.ts`)
- 홈 화면에 목적지 설정 버튼 및 `→ 목적지역 (N 정거장 남음)` UI 추가
- 목적지는 AsyncStorage에 영속화되어 앱 재시작 후에도 유지

## Test plan

- [x] `npm test` — 전체 테스트 90개, 커버리지 100% 확인
- [x] `npm run type-check` — 타입 오류 없음 확인
- [x] 홈 화면에서 "목적지 설정" 버튼 탭 → 역 검색 모달 열림 확인
- [x] 역 선택 후 `→ 목적지역 (N 정거장 남음)` 표시 확인
- [x] 다른 노선 목적지 선택 시 "다른 노선" 문구 표시 확인
- [x] 앱 재시작 후 목적지 유지 확인
- [x] "초기화" 탭 시 목적지 해제 확인

Closes #35