### PR TITLE
feat(#39): 환승 경로 계산 및 표시

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,23 +6,19 @@ import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
-import { getRemainingStops } from '../../src/utils/stationRoute';
+import { findRoute } from '../../src/utils/stationRoute';
 
 export default function HomeScreen() {
   const { result, loading, error, permissionDenied, refresh } = useNearestStation();
   const { arrival } = useArrivalInfo(result?.station.name ?? null);
-  const { addFavorite, removeFavorite, isFavorite, loadFavorites, destination, setDestination, loadDestination } = useAppStore();
+  const { addFavorite, removeFavorite, isFavorite, loadFavorites, destination, setDestination } = useAppStore();
   const [pickerVisible, setPickerVisible] = useState(false);
 
   useEffect(() => {
     loadFavorites();
-    loadDestination();
   }, []);
 
-  const remainingStops =
-    result && destination
-      ? getRemainingStops(result.station.id, destination.id)
-      : null;
+  const route = result && destination ? findRoute(result.station.id, destination.id) : null;
 
   if (permissionDenied) {
     return (
@@ -100,11 +96,13 @@ export default function HomeScreen() {
                   <Text style={styles.destinationArrow}>→</Text>
                   <View>
                     <Text style={styles.destinationName}>{destination.name}</Text>
-                    {remainingStops !== null ? (
-                      <Text style={styles.remainingText}>{remainingStops} 정거장 남음</Text>
-                    ) : (
-                      <Text style={styles.remainingText}>다른 노선</Text>
-                    )}
+                    {route?.type === 'direct' ? (
+                      <Text style={styles.remainingText}>{route.stops} 정거장 남음</Text>
+                    ) : route?.type === 'transfer' ? (
+                      <Text style={styles.remainingText}>
+                        {route.transferName}에서 환승 · 총 {route.stopsToTransfer + route.stopsFromTransfer} 정거장
+                      </Text>
+                    ) : null}
                   </View>
                 </View>
               ) : null}

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, findRoute } from '../stationRoute';
 
 describe('getStationsOnLine', () => {
   it('returns only stations on the given line, sorted by id', () => {
@@ -39,5 +39,91 @@ describe('getRemainingStops', () => {
   it('returns null for unknown station id', () => {
     expect(getRemainingStops('1-001', 'unknown-id')).toBeNull();
     expect(getRemainingStops('unknown-id', '1-001')).toBeNull();
+  });
+});
+
+describe('findRoute', () => {
+  it('returns null for unknown station id', () => {
+    expect(findRoute('1-001', 'unknown-id')).toBeNull();
+    expect(findRoute('unknown-id', '1-001')).toBeNull();
+  });
+
+  it('같은 노선이면 DirectRoute를 반환한다', () => {
+    // 1-001(소요산) → 1-003(보산)
+    const route = findRoute('1-001', '1-003');
+    expect(route).not.toBeNull();
+    expect(route?.type).toBe('direct');
+    if (route?.type === 'direct') {
+      expect(route.stops).toBe(2);
+    }
+  });
+
+  it('같은 역이면 DirectRoute stops=0을 반환한다', () => {
+    const route = findRoute('1-001', '1-001');
+    expect(route?.type).toBe('direct');
+    if (route?.type === 'direct') {
+      expect(route.stops).toBe(0);
+    }
+  });
+
+  it('환승 가능한 다른 노선이면 TransferRoute를 반환한다', () => {
+    // 2호선 강남(2-022) → 3호선 방배 근처: 교대(2-023/3-032)가 환승역
+    // 2호선 → 3호선 환승 가능 여부 확인
+    const line2 = getStationsOnLine('2');
+    const line3 = getStationsOnLine('3');
+    // 교대역: line2에 있고 line3에도 있음
+    const gyodae2 = line2.find((s) => s.name === '교대');
+    const gyodae3 = line3.find((s) => s.name === '교대');
+
+    if (gyodae2 && gyodae3) {
+      // 강남(2호선) → 교대 바로 다음 3호선 역으로 라우팅
+      const destStation = line3[line3.indexOf(gyodae3) + 1]; // 교대 다음 3호선 역
+      if (destStation) {
+        const route = findRoute(gyodae2.id, destStation.id);
+        expect(route?.type).toBe('transfer');
+        if (route?.type === 'transfer') {
+          expect(route.transferName).toBe('교대');
+          expect(route.fromLine).toBe('2');
+          expect(route.toLine).toBe('3');
+          expect(route.stopsToTransfer).toBe(0); // 이미 환승역에 있음
+          expect(route.stopsFromTransfer).toBe(1);
+        }
+      }
+    }
+  });
+
+  it('환승역이 여러 개일 때 최적 경로를 선택한다', () => {
+    // 2호선↔5호선: 을지로4가, 동대문역사문화공원, 왕십리, 영등포구청, 충정로 (5개 환승역)
+    // 여러 후보 중 total이 가장 작은 경로를 선택해야 함
+    const line2 = getStationsOnLine('2');
+    const line5 = getStationsOnLine('5');
+    // 2호선과 5호선 각각 첫 역에서 라우팅 → 여러 후보 순회
+    const route = findRoute(line2[0].id, line5[0].id);
+    // 환승역이 존재하므로 TransferRoute여야 함
+    expect(route?.type).toBe('transfer');
+    if (route?.type === 'transfer') {
+      expect(route.fromLine).toBe('2');
+      expect(route.toLine).toBe('5');
+      // 5개 후보 중 가장 좋은 것을 선택했으므로 valid한 환승역 이름이어야 함
+      const validTransfers = ['을지로4가', '동대문역사문화공원', '왕십리', '영등포구청', '충정로'];
+      expect(validTransfers).toContain(route.transferName);
+    }
+  });
+
+  it('환승역이 없으면 null을 반환한다', () => {
+    // 1호선과 9호선은 환승역이 없음
+    const line1 = getStationsOnLine('1');
+    const line9 = getStationsOnLine('9');
+    const line1Names = new Set(line1.map((s) => s.name));
+    const hasTransfer = line9.some((s) => line1Names.has(s.name));
+
+    if (!hasTransfer) {
+      const route = findRoute(line1[0].id, line9[0].id);
+      expect(route).toBeNull();
+    } else {
+      // 환승역이 있으면 TransferRoute를 반환해야 함
+      const route = findRoute(line1[0].id, line9[0].id);
+      expect(route?.type).toBe('transfer');
+    }
   });
 });

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -3,6 +3,22 @@ import type { Station } from '../types/station';
 
 const allStations = stations as Station[];
 
+export interface DirectRoute {
+  type: 'direct';
+  stops: number;
+}
+
+export interface TransferRoute {
+  type: 'transfer';
+  transferName: string;
+  fromLine: string;
+  toLine: string;
+  stopsToTransfer: number;
+  stopsFromTransfer: number;
+}
+
+export type Route = DirectRoute | TransferRoute | null;
+
 export function getStationsOnLine(line: string): Station[] {
   return allStations
     .filter((s) => s.line === line)
@@ -24,4 +40,54 @@ export function getRemainingStops(
   const destIdx = lineStations.findIndex((s) => s.id === destinationId);
 
   return Math.abs(destIdx - currentIdx);
+}
+
+export function findRoute(currentId: string, destinationId: string): Route {
+  const current = allStations.find((s) => s.id === currentId);
+  const destination = allStations.find((s) => s.id === destinationId);
+
+  if (!current || !destination) return null;
+
+  // 같은 노선: 직통
+  if (current.line === destination.line) {
+    const lineStations = getStationsOnLine(current.line);
+    const cIdx = lineStations.findIndex((s) => s.id === currentId);
+    const dIdx = lineStations.findIndex((s) => s.id === destinationId);
+    return { type: 'direct', stops: Math.abs(dIdx - cIdx) };
+  }
+
+  // 다른 노선: 환승역 탐색
+  const currentLineStations = getStationsOnLine(current.line);
+  const destLineStations = getStationsOnLine(destination.line);
+  const currentIdx = currentLineStations.findIndex((s) => s.id === currentId);
+  const destIdx = destLineStations.findIndex((s) => s.id === destinationId);
+
+  // 목적지 노선에 같은 이름이 있는 현재 노선의 역 = 환승 후보
+  let bestRoute: TransferRoute | null = null;
+  let bestTotal = Infinity;
+
+  for (let i = 0; i < currentLineStations.length; i++) {
+    const candidate = currentLineStations[i];
+    const transferTarget = destLineStations.find((s) => s.name === candidate.name);
+    if (!transferTarget) continue;
+
+    const transferDestIdx = destLineStations.findIndex((s) => s.id === transferTarget.id);
+    const stopsToTransfer = Math.abs(i - currentIdx);
+    const stopsFromTransfer = Math.abs(transferDestIdx - destIdx);
+    const total = stopsToTransfer + stopsFromTransfer;
+
+    if (total < bestTotal) {
+      bestTotal = total;
+      bestRoute = {
+        type: 'transfer',
+        transferName: candidate.name,
+        fromLine: current.line,
+        toLine: destination.line,
+        stopsToTransfer,
+        stopsFromTransfer,
+      };
+    }
+  }
+
+  return bestRoute;
 }


### PR DESCRIPTION
## Summary

- `findRoute()` 추가: 같은 노선은 직통, 다른 노선은 최적 환승역 자동 계산
- 환승역 판별: stations.json에서 같은 이름, 다른 line인 역 (예: 교대 2↔3호선)
- 여러 환승 후보가 있을 때 총 정거장 수가 가장 적은 경로 선택
- 홈 화면 UI: 직통 → `N 정거장 남음` / 환승 → `교대에서 환승 · 총 N 정거장`

## Test plan

- [x] `npm test` — 96개 테스트, 커버리지 100% 확인
- [x] `npm run type-check` — 타입 오류 없음 확인
- [x] 같은 노선 목적지 선택 → `N 정거장 남음` 표시 확인
- [x] 다른 노선 목적지 선택 → `OO에서 환승 · 총 N 정거장` 표시 확인
- [x] 환승역 없는 노선 간 선택 → 아무것도 표시 안 됨 확인

Closes #39