### PR TITLE
fix(#41): 이전 목적지 홈 화면 빠른 선택 버튼 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -126,6 +126,21 @@ export default function HomeScreen() {
                   </View>
                 </View>
               ) : null}
+              {!destination && recentDestination && (
+                <TouchableOpacity
+                  style={styles.recentDestinationButton}
+                  onPress={() => setDestination(recentDestination)}
+                  testID="recent-destination-button"
+                >
+                  <Text style={styles.recentDestinationLabel}>이전 목적지</Text>
+                  <View style={styles.recentDestinationRow}>
+                    <Text style={styles.recentDestinationName}>{recentDestination.name}</Text>
+                    <View style={[styles.recentLineBadge, { backgroundColor: recentDestination.lineColor }]}>
+                      <Text style={styles.recentLineText}>{recentDestination.line}호선</Text>
+                    </View>
+                  </View>
+                </TouchableOpacity>
+              )}
               <TouchableOpacity
                 style={styles.destinationButton}
                 onPress={() => setPickerVisible(true)}
@@ -296,6 +311,42 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: '#8888aa',
     marginTop: 2,
+  },
+  recentDestinationButton: {
+    backgroundColor: '#0f0f2a',
+    borderWidth: 1,
+    borderColor: '#a78bfa',
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    marginBottom: 8,
+  },
+  recentDestinationLabel: {
+    color: '#a78bfa',
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  recentDestinationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  recentDestinationName: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  recentLineBadge: {
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  recentLineText: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: 'bold',
   },
   destinationButton: {
     backgroundColor: '#a78bfa',


### PR DESCRIPTION
## Summary

- 목적지 미설정 상태에서 `recentDestination`이 있으면 목적지 설정 버튼 위에 빠른 선택 버튼 표시
- 탭 시 피커를 열지 않고 즉시 해당 역으로 목적지 설정
- 목적지가 이미 설정된 경우 또는 `recentDestination`이 없는 경우 미표시

## Test plan

- [x] 목적지 설정 후 "초기화" 탭 → 홈 화면에 이전 목적지 빠른 선택 버튼 표시 확인
- [x] 빠른 선택 버튼 탭 → 피커 없이 즉시 목적지 설정 확인
- [x] 앱 최초 실행 시 버튼 미표시 확인

Closes #41