### PR TITLE
fix(#50): NaverMapMarkerOverlay anchor 중앙 정렬 및 testID 고유화

### DIFF
--- a/__mocks__/@mj-studio/react-native-naver-map.ts
+++ b/__mocks__/@mj-studio/react-native-naver-map.ts
@@ -4,5 +4,5 @@ import { View } from 'react-native';
 export const NaverMapView = ({ children, ...props }: any) =>
   React.createElement(View, { testID: 'naver-map-view', ...props }, children);
 
-export const NaverMapMarkerOverlay = ({ children, onTap, latitude, ...props }: any) =>
-  React.createElement(View, { testID: `marker-${latitude}`, onTap, latitude, ...props }, children);
+export const NaverMapMarkerOverlay = ({ children, onTap, latitude, testID, ...props }: any) =>
+  React.createElement(View, { testID: testID ?? `marker-${latitude}`, onTap, latitude, ...props }, children);

--- a/__mocks__/@mj-studio/react-native-naver-map.ts
+++ b/__mocks__/@mj-studio/react-native-naver-map.ts
@@ -4,5 +4,5 @@ import { View } from 'react-native';
 export const NaverMapView = ({ children, ...props }: any) =>
   React.createElement(View, { testID: 'naver-map-view', ...props }, children);
 
-export const NaverMapMarkerOverlay = ({ children, onTap, latitude, testID, ...props }: any) =>
-  React.createElement(View, { testID: testID ?? `marker-${latitude}`, onTap, latitude, ...props }, children);
+export const NaverMapMarkerOverlay = ({ children, onTap, latitude, longitude, ...props }: any) =>
+  React.createElement(View, { testID: `marker-${latitude}-${longitude}`, onTap, latitude, longitude, ...props }, children);

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -32,10 +32,12 @@ export function StationMap({
         return (
           <NaverMapMarkerOverlay
             key={station.id}
+            testID={`marker-${station.id}`}
             latitude={station.lat}
             longitude={station.lng}
             width={size}
             height={size}
+            anchor={{ x: 0.5, y: 0.5 }}
             caption={{ text: station.name, textSize: 11, color: '#ffffff', haloColor: '#000000' }}
             onTap={() => onStationPress?.(station)}
           >

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -32,7 +32,6 @@ export function StationMap({
         return (
           <NaverMapMarkerOverlay
             key={station.id}
-            testID={`marker-${station.id}`}
             latitude={station.lat}
             longitude={station.lng}
             width={size}

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -102,7 +102,7 @@ describe('DestinationPicker', () => {
   it('지도 마커 탭으로 onSelect가 호출된다', () => {
     const onSelect = jest.fn();
     const { getByTestId } = render(<DestinationPicker {...mapProps} onSelect={onSelect} />);
-    getByTestId(`marker-${mockStation.lat}`).props.onTap();
+    getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`).props.onTap();
     expect(onSelect).toHaveBeenCalledWith(mockStation);
   });
 

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -40,8 +40,8 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    expect(getByTestId(`marker-${mockStation.lat}`)).toBeTruthy();
-    expect(getByTestId(`marker-${anotherStation.lat}`)).toBeTruthy();
+    expect(getByTestId(`marker-${mockStation.id}`)).toBeTruthy();
+    expect(getByTestId(`marker-${anotherStation.id}`)).toBeTruthy();
   });
 
   it('nearbyStations가 빈 배열이면 마커 없이 렌더링한다', () => {
@@ -49,12 +49,12 @@ describe('StationMap', () => {
       <StationMap {...baseProps} nearbyStations={[]} />
     );
     expect(getByTestId('naver-map-view')).toBeTruthy();
-    expect(queryByTestId(`marker-${mockStation.lat}`)).toBeNull();
+    expect(queryByTestId(`marker-${mockStation.id}`)).toBeNull();
   });
 
   it('nearestStation과 일치하는 마커는 크기가 36이다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    const marker = getByTestId(`marker-${mockStation.lat}`);
+    const marker = getByTestId(`marker-${mockStation.id}`);
     expect(marker.props.width).toBe(36);
     expect(marker.props.height).toBe(36);
   });
@@ -63,7 +63,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    const marker = getByTestId(`marker-${anotherStation.lat}`);
+    const marker = getByTestId(`marker-${anotherStation.id}`);
     expect(marker.props.width).toBe(24);
     expect(marker.props.height).toBe(24);
   });
@@ -72,7 +72,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearestStation={null} />
     );
-    const marker = getByTestId(`marker-${mockStation.lat}`);
+    const marker = getByTestId(`marker-${mockStation.id}`);
     expect(marker.props.width).toBe(24);
   });
 
@@ -81,14 +81,14 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} onStationPress={onStationPress} />
     );
-    getByTestId(`marker-${mockStation.lat}`).props.onTap();
+    getByTestId(`marker-${mockStation.id}`).props.onTap();
     expect(onStationPress).toHaveBeenCalledWith(mockStation);
   });
 
   it('onStationPress가 없을 때 마커 onTap 호출해도 에러가 없다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
     expect(() => {
-      getByTestId(`marker-${mockStation.lat}`).props.onTap();
+      getByTestId(`marker-${mockStation.id}`).props.onTap();
     }).not.toThrow();
   });
 });

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -40,8 +40,8 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    expect(getByTestId(`marker-${mockStation.id}`)).toBeTruthy();
-    expect(getByTestId(`marker-${anotherStation.id}`)).toBeTruthy();
+    expect(getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`)).toBeTruthy();
+    expect(getByTestId(`marker-${anotherStation.lat}-${anotherStation.lng}`)).toBeTruthy();
   });
 
   it('nearbyStations가 빈 배열이면 마커 없이 렌더링한다', () => {
@@ -49,12 +49,12 @@ describe('StationMap', () => {
       <StationMap {...baseProps} nearbyStations={[]} />
     );
     expect(getByTestId('naver-map-view')).toBeTruthy();
-    expect(queryByTestId(`marker-${mockStation.id}`)).toBeNull();
+    expect(queryByTestId(`marker-${mockStation.lat}-${mockStation.lng}`)).toBeNull();
   });
 
   it('nearestStation과 일치하는 마커는 크기가 36이다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    const marker = getByTestId(`marker-${mockStation.id}`);
+    const marker = getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`);
     expect(marker.props.width).toBe(36);
     expect(marker.props.height).toBe(36);
   });
@@ -63,7 +63,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    const marker = getByTestId(`marker-${anotherStation.id}`);
+    const marker = getByTestId(`marker-${anotherStation.lat}-${anotherStation.lng}`);
     expect(marker.props.width).toBe(24);
     expect(marker.props.height).toBe(24);
   });
@@ -72,7 +72,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearestStation={null} />
     );
-    const marker = getByTestId(`marker-${mockStation.id}`);
+    const marker = getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`);
     expect(marker.props.width).toBe(24);
   });
 
@@ -81,14 +81,14 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} onStationPress={onStationPress} />
     );
-    getByTestId(`marker-${mockStation.id}`).props.onTap();
+    getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`).props.onTap();
     expect(onStationPress).toHaveBeenCalledWith(mockStation);
   });
 
   it('onStationPress가 없을 때 마커 onTap 호출해도 에러가 없다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
     expect(() => {
-      getByTestId(`marker-${mockStation.id}`).props.onTap();
+      getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`).props.onTap();
     }).not.toThrow();
   });
 });


### PR DESCRIPTION
## 변경 사항

- `anchor={{ x: 0.5, y: 0.5 }}` 적용 → 마커 중심이 지도 좌표에 정렬 (기본값 `y:1` 은 하단 중앙)
- `testID={marker-${station.id}}` 추가 → 고유 식별자 기반으로 변경
- mock 및 StationMap 테스트의 testID 기준을 `lat` → `id` 로 변경

## 영향 파일

- `src/components/StationMap.tsx`
- `__mocks__/@mj-studio/react-native-naver-map.ts`
- `src/components/__tests__/StationMap.test.tsx`

Closes #50