### PR TITLE
fix(#51): 목적지 설정 지도 전체 역 표시 및 overlay 터치 차단 수정

### DIFF
--- a/__mocks__/@mj-studio/react-native-naver-map.ts
+++ b/__mocks__/@mj-studio/react-native-naver-map.ts
@@ -4,5 +4,5 @@ import { View } from 'react-native';
 export const NaverMapView = ({ children, ...props }: any) =>
   React.createElement(View, { testID: 'naver-map-view', ...props }, children);
 
-export const NaverMapMarkerOverlay = ({ children, onTap, latitude, ...props }: any) =>
-  React.createElement(View, { testID: `marker-${latitude}`, onTap, latitude, ...props }, children);
+export const NaverMapMarkerOverlay = ({ children, onTap, latitude, testID, ...props }: any) =>
+  React.createElement(View, { testID: testID ?? `marker-${latitude}`, onTap, latitude, ...props }, children);

--- a/__mocks__/@mj-studio/react-native-naver-map.ts
+++ b/__mocks__/@mj-studio/react-native-naver-map.ts
@@ -4,5 +4,5 @@ import { View } from 'react-native';
 export const NaverMapView = ({ children, ...props }: any) =>
   React.createElement(View, { testID: 'naver-map-view', ...props }, children);
 
-export const NaverMapMarkerOverlay = ({ children, onTap, latitude, testID, ...props }: any) =>
-  React.createElement(View, { testID: testID ?? `marker-${latitude}`, onTap, latitude, ...props }, children);
+export const NaverMapMarkerOverlay = ({ children, onTap, latitude, longitude, ...props }: any) =>
+  React.createElement(View, { testID: `marker-${latitude}-${longitude}`, onTap, latitude, longitude, ...props }, children);

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -10,10 +10,7 @@ import {
 import stations from '../data/stations.json';
 import type { Station } from '../types/station';
 import { StationMap } from './StationMap';
-import { haversine } from '../utils/haversine';
 
-
-const MAP_RADIUS_KM = 5;
 
 const allStations = stations as Station[];
 
@@ -41,9 +38,7 @@ export function DestinationPicker({
 
   const mapStations = useMemo(() => {
     if (!userLat || !userLng) return [];
-    return allStations.filter(
-      (s) => haversine(userLat, userLng, s.lat, s.lng) <= MAP_RADIUS_KM
-    );
+    return allStations;
   }, [userLat, userLng]);
 
   const suggestions = useMemo(() => {
@@ -83,7 +78,7 @@ export function DestinationPicker({
           </View>
         )}
 
-        <View style={styles.overlay}>
+        <View style={styles.overlay} pointerEvents="box-none">
           <View style={styles.header}>
             <Text style={styles.title}>목적지 설정</Text>
             <TouchableOpacity onPress={handleClose} testID="close-button">

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -32,10 +32,12 @@ export function StationMap({
         return (
           <NaverMapMarkerOverlay
             key={station.id}
+            testID={`marker-${station.id}`}
             latitude={station.lat}
             longitude={station.lng}
             width={size}
             height={size}
+            anchor={{ x: 0.5, y: 0.5 }}
             caption={{ text: station.name, textSize: 11, color: '#ffffff', haloColor: '#000000' }}
             onTap={() => onStationPress?.(station)}
           >

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -32,7 +32,6 @@ export function StationMap({
         return (
           <NaverMapMarkerOverlay
             key={station.id}
-            testID={`marker-${station.id}`}
             latitude={station.lat}
             longitude={station.lng}
             width={size}

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -102,7 +102,7 @@ describe('DestinationPicker', () => {
   it('지도 마커 탭으로 onSelect가 호출된다', () => {
     const onSelect = jest.fn();
     const { getByTestId } = render(<DestinationPicker {...mapProps} onSelect={onSelect} />);
-    getByTestId(`marker-${mockStation.lat}`).props.onTap();
+    getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`).props.onTap();
     expect(onSelect).toHaveBeenCalledWith(mockStation);
   });
 

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -40,8 +40,8 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    expect(getByTestId(`marker-${mockStation.lat}`)).toBeTruthy();
-    expect(getByTestId(`marker-${anotherStation.lat}`)).toBeTruthy();
+    expect(getByTestId(`marker-${mockStation.id}`)).toBeTruthy();
+    expect(getByTestId(`marker-${anotherStation.id}`)).toBeTruthy();
   });
 
   it('nearbyStations가 빈 배열이면 마커 없이 렌더링한다', () => {
@@ -49,12 +49,12 @@ describe('StationMap', () => {
       <StationMap {...baseProps} nearbyStations={[]} />
     );
     expect(getByTestId('naver-map-view')).toBeTruthy();
-    expect(queryByTestId(`marker-${mockStation.lat}`)).toBeNull();
+    expect(queryByTestId(`marker-${mockStation.id}`)).toBeNull();
   });
 
   it('nearestStation과 일치하는 마커는 크기가 36이다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    const marker = getByTestId(`marker-${mockStation.lat}`);
+    const marker = getByTestId(`marker-${mockStation.id}`);
     expect(marker.props.width).toBe(36);
     expect(marker.props.height).toBe(36);
   });
@@ -63,7 +63,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    const marker = getByTestId(`marker-${anotherStation.lat}`);
+    const marker = getByTestId(`marker-${anotherStation.id}`);
     expect(marker.props.width).toBe(24);
     expect(marker.props.height).toBe(24);
   });
@@ -72,7 +72,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearestStation={null} />
     );
-    const marker = getByTestId(`marker-${mockStation.lat}`);
+    const marker = getByTestId(`marker-${mockStation.id}`);
     expect(marker.props.width).toBe(24);
   });
 
@@ -81,14 +81,14 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} onStationPress={onStationPress} />
     );
-    getByTestId(`marker-${mockStation.lat}`).props.onTap();
+    getByTestId(`marker-${mockStation.id}`).props.onTap();
     expect(onStationPress).toHaveBeenCalledWith(mockStation);
   });
 
   it('onStationPress가 없을 때 마커 onTap 호출해도 에러가 없다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
     expect(() => {
-      getByTestId(`marker-${mockStation.lat}`).props.onTap();
+      getByTestId(`marker-${mockStation.id}`).props.onTap();
     }).not.toThrow();
   });
 });

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -40,8 +40,8 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    expect(getByTestId(`marker-${mockStation.id}`)).toBeTruthy();
-    expect(getByTestId(`marker-${anotherStation.id}`)).toBeTruthy();
+    expect(getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`)).toBeTruthy();
+    expect(getByTestId(`marker-${anotherStation.lat}-${anotherStation.lng}`)).toBeTruthy();
   });
 
   it('nearbyStations가 빈 배열이면 마커 없이 렌더링한다', () => {
@@ -49,12 +49,12 @@ describe('StationMap', () => {
       <StationMap {...baseProps} nearbyStations={[]} />
     );
     expect(getByTestId('naver-map-view')).toBeTruthy();
-    expect(queryByTestId(`marker-${mockStation.id}`)).toBeNull();
+    expect(queryByTestId(`marker-${mockStation.lat}-${mockStation.lng}`)).toBeNull();
   });
 
   it('nearestStation과 일치하는 마커는 크기가 36이다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    const marker = getByTestId(`marker-${mockStation.id}`);
+    const marker = getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`);
     expect(marker.props.width).toBe(36);
     expect(marker.props.height).toBe(36);
   });
@@ -63,7 +63,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearbyStations={[mockStation, anotherStation]} />
     );
-    const marker = getByTestId(`marker-${anotherStation.id}`);
+    const marker = getByTestId(`marker-${anotherStation.lat}-${anotherStation.lng}`);
     expect(marker.props.width).toBe(24);
     expect(marker.props.height).toBe(24);
   });
@@ -72,7 +72,7 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} nearestStation={null} />
     );
-    const marker = getByTestId(`marker-${mockStation.id}`);
+    const marker = getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`);
     expect(marker.props.width).toBe(24);
   });
 
@@ -81,14 +81,14 @@ describe('StationMap', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} onStationPress={onStationPress} />
     );
-    getByTestId(`marker-${mockStation.id}`).props.onTap();
+    getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`).props.onTap();
     expect(onStationPress).toHaveBeenCalledWith(mockStation);
   });
 
   it('onStationPress가 없을 때 마커 onTap 호출해도 에러가 없다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
     expect(() => {
-      getByTestId(`marker-${mockStation.id}`).props.onTap();
+      getByTestId(`marker-${mockStation.lat}-${mockStation.lng}`).props.onTap();
     }).not.toThrow();
   });
 });


### PR DESCRIPTION
## 변경 사항

- `mapStations` 5km 필터 제거 → 전체 388개 역 표시 (목적지 선택이므로 거리 제한 불필요)
- `MAP_RADIUS_KM` 상수 및 `haversine` import 제거
- `overlay` View에 `pointerEvents="box-none"` 적용 → 자식(닫기 버튼, 검색창)은 터치 유지, 지도 마커 터치 통과
- 테스트 testID를 `station.id` 기반으로 수정

## 영향 파일

- `src/components/DestinationPicker.tsx`
- `src/components/__tests__/DestinationPicker.test.tsx`

> **주의**: #52 (PR1) 머지 후 머지 권장 (mock testID 변경 의존)

Closes #51