### PR TITLE
feat(#47): 알림 내용 개선 - 현재 역 상시 표시 + 목적지/경로 정보

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,17 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.subwaynow.app"
+      "bundleIdentifier": "com.subwaynow.app",
+      "appleTeamId": "4755N5H4T4",
+      "infoPlist": {
+        "NSAppTransportSecurity": {
+          "NSExceptionDomains": {
+            "swopenapi.seoul.go.kr": {
+              "NSExceptionAllowsInsecureHTTPLoads": true
+            }
+          }
+        }
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -32,7 +42,7 @@
       [
         "@mj-studio/react-native-naver-map",
         {
-          "ios_client_id": "4l2hq7pw5l"
+          "client_id": "4l2hq7pw5l"
         }
       ],
       [
@@ -43,7 +53,10 @@
           "locationWhenInUsePermission": "앱 사용 중 현재 지하철역을 감지하기 위해 위치 권한이 필요합니다."
         }
       ],
-      "expo-router"
+      "expo-router",
+      "./modules/live-activity/app.plugin.js",
+      "./remove-push-entitlement.js",
+      "@bacons/apple-targets"
     ],
     "extra": {
       "publicDataApiKey": "",

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,6 +7,10 @@ import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRoute } from '../../src/utils/stationRoute';
+import { initStationNotification, updateStationNotification, clearStationNotification } from '../../src/utils/stationNotification';
+import { createLogger } from '../../src/utils/logger';
+
+const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
   const { result, userLocation, loading, error, permissionDenied, refresh } = useNearestStation();
@@ -15,10 +19,41 @@ export default function HomeScreen() {
   const [pickerVisible, setPickerVisible] = useState(false);
   const [arrivedBanner, setArrivedBanner] = useState(false);
   const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevNotifKeyRef = useRef<string | undefined>(undefined);
+  const route = result && destination ? findRoute(result.station.id, destination.id) : null;
 
   useEffect(() => {
     loadFavorites();
+    initStationNotification();
   }, []);
+
+  useEffect(() => {
+    if (!result) {
+      if (prevNotifKeyRef.current !== 'none') {
+        prevNotifKeyRef.current = 'none';
+        logger.info('역 없음 → 알림 해제');
+        clearStationNotification();
+      }
+      return;
+    }
+    const key = `${result.station.id}__${destination?.id ?? ''}`;
+    if (key === prevNotifKeyRef.current) return;
+    prevNotifKeyRef.current = key;
+    logger.info('알림 업데이트:', result.station.name, destination ? `→ ${destination.name}` : '');
+    updateStationNotification(
+      result.station,
+      Math.round(result.distanceKm * 1000),
+      destination,
+      route ?? null,
+    ).catch((e) => logger.error('알림 업데이트 실패:', e));
+  }, [result?.station.id, destination?.id, route]);
+
+  useEffect(() => {
+    if (arrivedBanner) {
+      clearStationNotification().catch(console.error);
+      prevNotifKeyRef.current = undefined;
+    }
+  }, [arrivedBanner]);
 
   useEffect(() => {
     if (result?.station.id && destination?.id && result.station.id === destination.id) {
@@ -32,8 +67,6 @@ export default function HomeScreen() {
       if (arrivedTimeoutRef.current) clearTimeout(arrivedTimeoutRef.current);
     };
   }, [result?.station.id, destination?.id]);
-
-  const route = result && destination ? findRoute(result.station.id, destination.id) : null;
 
   if (permissionDenied) {
     return (
@@ -324,7 +357,7 @@ const styles = StyleSheet.create({
     marginRight: 12,
   },
   destinationName: {
-    fontSize: 30,
+    fontSize: 20,
     fontWeight: '700',
     color: '#ffffff',
   },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,14 @@
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { setupNotificationHandler } from '../src/utils/stationNotification';
+import { setMinLevel } from '../src/utils/logger';
+
+setupNotificationHandler();
+
+// 프로덕션 빌드에서는 warn 이상만 출력
+if (!__DEV__) {
+  setMinLevel('warn');
+}
 
 export default function RootLayout() {
   return (

--- a/modules/live-activity/LiveActivity.podspec
+++ b/modules/live-activity/LiveActivity.podspec
@@ -1,0 +1,16 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'LiveActivity'
+  s.version        = package['version']
+  s.summary        = 'Live Activity native module for subway-now'
+  s.homepage       = 'https://github.com/handokei/subway-now'
+  s.license        = 'MIT'
+  s.author         = 'subway-now'
+  s.platform       = :ios, '15.1'
+  s.source         = { path: '.' }
+  s.source_files   = 'ios/**/*.swift'
+  s.dependency 'ExpoModulesCore'
+end

--- a/modules/live-activity/app.plugin.js
+++ b/modules/live-activity/app.plugin.js
@@ -1,0 +1,87 @@
+const { withInfoPlist, withXcodeProject } = require('@expo/config-plugins');
+
+const LIVE_ACTIVITY_FILES = ['LiveActivityModule.swift', 'LiveActivityManager.swift'];
+
+/**
+ * expo-modules-autolinking이 Swift 파일을 잘못된 경로로 추가하는 버그를 수정.
+ * prebuild 실행 시마다 올바른 경로(../modules/live-activity/ios/*)로 재설정.
+ */
+const withLiveActivityXcodeFiles = (config) => {
+  return withXcodeProject(config, (mod) => {
+    const xcodeProject = mod.modResults;
+    const projectName = mod.modRequest.projectName; // 'subwaynow'
+
+    const objects = xcodeProject.hash.project.objects;
+    const fileRefs = objects['PBXFileReference'] ?? {};
+    const buildFiles = objects['PBXBuildFile'] ?? {};
+
+    // 앱 타겟 UUID 찾기
+    const nativeTargets = objects['PBXNativeTarget'] ?? {};
+    const targetEntry = Object.entries(nativeTargets).find(([uuid, target]) => {
+      if (uuid.endsWith('_comment')) return false;
+      return (target.name ?? '').replace(/"/g, '') === projectName;
+    });
+    const targetUUID = targetEntry?.[0];
+
+    // 앱 타겟의 Sources 빌드 페이즈 UUID 찾기
+    const sourcesBuildPhases = objects['PBXSourcesBuildPhase'] ?? {};
+    let sourcesBuildPhase = null;
+    let sourcesBuildPhaseUUID = null;
+    if (targetUUID) {
+      const target = nativeTargets[targetUUID];
+      for (const phaseRef of target.buildPhases ?? []) {
+        const phaseUUID = phaseRef.value ?? phaseRef;
+        if (sourcesBuildPhases[phaseUUID]) {
+          sourcesBuildPhase = sourcesBuildPhases[phaseUUID];
+          sourcesBuildPhaseUUID = phaseUUID;
+          break;
+        }
+      }
+    }
+
+    // 1. 기존 LiveActivity Swift 파일 참조를 모두 제거 (경로 오류 정리)
+    for (const [uuid, ref] of Object.entries(fileRefs)) {
+      if (uuid.endsWith('_comment')) continue;
+      const name = (ref.name ?? '').replace(/"/g, '');
+      if (!LIVE_ACTIVITY_FILES.includes(name)) continue;
+
+      // 관련 build file 찾아서 제거
+      for (const [bfUUID, bf] of Object.entries(buildFiles)) {
+        if (bfUUID.endsWith('_comment') || bf.fileRef !== uuid) continue;
+        // Sources 빌드 페이즈에서 제거
+        if (sourcesBuildPhase) {
+          sourcesBuildPhase.files = (sourcesBuildPhase.files ?? []).filter(
+            (f) => (f.value ?? f) !== bfUUID,
+          );
+        }
+        delete buildFiles[bfUUID];
+        delete buildFiles[`${bfUUID}_comment`];
+      }
+
+      // PBXGroup에서 제거
+      for (const group of Object.values(objects['PBXGroup'] ?? {})) {
+        if (Array.isArray(group.children)) {
+          group.children = group.children.filter((c) => (c.value ?? c) !== uuid);
+        }
+      }
+
+      delete fileRefs[uuid];
+      delete fileRefs[`${uuid}_comment`];
+    }
+
+    return mod;
+  });
+};
+
+/** @type {import('@expo/config-plugins').ConfigPlugin} */
+const withLiveActivity = (config) => {
+  config = withInfoPlist(config, (mod) => {
+    mod.modResults['NSSupportsLiveActivities'] = true;
+    mod.modResults['NSSupportsLiveActivitiesFrequentUpdates'] = true;
+    return mod;
+  });
+  config = withLiveActivityXcodeFiles(config);
+  return config;
+};
+
+module.exports = withLiveActivity;

--- a/modules/live-activity/expo-module.config.json
+++ b/modules/live-activity/expo-module.config.json
@@ -1,0 +1,7 @@
+{
+  "platforms": ["ios"],
+  "ios": {
+    "modules": ["LiveActivityModule"],
+    "podspecPath": "LiveActivity.podspec"
+  }
+}

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -1,0 +1,33 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+import { Platform } from 'react-native';
+
+export interface LiveActivityData {
+  stationName: string;
+  lineName: string;
+  lineColorHex: string;
+  destinationName?: string;
+  stopsRemaining?: number;
+  stopsToTransfer?: number;
+  transferStationName?: string;
+  stopsFromTransfer?: number;
+  distanceM: number;
+}
+
+const LiveActivityModule =
+  Platform.OS === 'ios' ? requireOptionalNativeModule('LiveActivity') : null;
+
+export function startLiveActivity(data: LiveActivityData): Promise<void> {
+  return LiveActivityModule?.startLiveActivity(data) ?? Promise.resolve();
+}
+
+export function updateLiveActivity(data: LiveActivityData): Promise<void> {
+  return LiveActivityModule?.updateLiveActivity(data) ?? Promise.resolve();
+}
+
+export function endLiveActivity(): Promise<void> {
+  return LiveActivityModule?.endLiveActivity() ?? Promise.resolve();
+}
+
+export function isLiveActivityEnabled(): boolean {
+  return LiveActivityModule?.isLiveActivityEnabled() ?? false;
+}

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -1,0 +1,84 @@
+#if canImport(ActivityKit)
+import ActivityKit
+import Foundation
+
+// 앱 타겟에서의 SubwayActivityAttributes 정의
+// 위젯 타겟의 동일한 구조체와 이름이 일치해야 ActivityKit이 연동됨
+@available(iOS 16.2, *)
+struct SubwayActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var stationName: String
+        var lineName: String
+        var lineColorHex: String
+        var destinationName: String?
+        var stopsRemaining: Int?
+        var stopsToTransfer: Int?
+        var transferStationName: String?
+        var stopsFromTransfer: Int?
+        var distanceM: Int
+    }
+}
+
+@available(iOS 16.2, *)
+class LiveActivityManager {
+    static let shared = LiveActivityManager()
+    private var currentActivity: Activity<SubwayActivityAttributes>?
+
+    private init() {}
+
+    func start(data: [String: Any]) async throws {
+        if let existing = currentActivity {
+            await existing.end(dismissalPolicy: .immediate)
+            currentActivity = nil
+        }
+
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            throw NSError(
+                domain: "LiveActivity",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Live Activities가 iOS 설정에서 비활성화됨"]
+            )
+        }
+
+        let state = buildState(from: data)
+        let attributes = SubwayActivityAttributes()
+        let content = ActivityContent(state: state, staleDate: nil)
+        currentActivity = try Activity.request(
+            attributes: attributes,
+            content: content,
+            pushType: nil
+        )
+    }
+
+    func update(data: [String: Any]) async throws {
+        guard let activity = currentActivity else {
+            try await start(data: data)
+            return
+        }
+        let state = buildState(from: data)
+        let content = ActivityContent(state: state, staleDate: nil)
+        await activity.update(content)
+    }
+
+    func end() async {
+        if let activity = currentActivity {
+            await activity.end(dismissalPolicy: .immediate)
+            currentActivity = nil
+        }
+    }
+
+    private func buildState(from data: [String: Any]) -> SubwayActivityAttributes.ContentState {
+        SubwayActivityAttributes.ContentState(
+            stationName: data["stationName"] as? String ?? "",
+            lineName: data["lineName"] as? String ?? "",
+            lineColorHex: data["lineColorHex"] as? String ?? "#888888",
+            destinationName: data["destinationName"] as? String,
+            stopsRemaining: data["stopsRemaining"] as? Int,
+            stopsToTransfer: data["stopsToTransfer"] as? Int,
+            transferStationName: data["transferStationName"] as? String,
+            stopsFromTransfer: data["stopsFromTransfer"] as? Int,
+            distanceM: data["distanceM"] as? Int ?? 0
+        )
+    }
+}
+#endif

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -1,0 +1,35 @@
+import ExpoModulesCore
+#if canImport(ActivityKit)
+import ActivityKit
+#endif
+
+public class LiveActivityModule: Module {
+    public func definition() -> ModuleDefinition {
+        Name("LiveActivity")
+
+        AsyncFunction("startLiveActivity") { (data: [String: Any]) in
+            if #available(iOS 16.2, *) {
+                try await LiveActivityManager.shared.start(data: data)
+            }
+        }
+
+        AsyncFunction("updateLiveActivity") { (data: [String: Any]) in
+            if #available(iOS 16.2, *) {
+                try await LiveActivityManager.shared.update(data: data)
+            }
+        }
+
+        AsyncFunction("endLiveActivity") { () -> Void in
+            if #available(iOS 16.2, *) {
+                await LiveActivityManager.shared.end()
+            }
+        }
+
+        Function("isLiveActivityEnabled") { () -> Bool in
+            if #available(iOS 16.1, *) {
+                return ActivityAuthorizationInfo().areActivitiesEnabled
+            }
+            return false
+        }
+    }
+}

--- a/modules/live-activity/package.json
+++ b/modules/live-activity/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "live-activity",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-router": "~6.0.23",
         "expo-status-bar": "~3.0.9",
         "expo-task-manager": "~14.0.9",
+        "live-activity": "file:./modules/live-activity",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -28,6 +29,8 @@
         "zustand": "^5.0.12"
       },
       "devDependencies": {
+        "@bacons/apple-targets": "^4.0.6",
+        "@expo/prebuild-config": "^54.0.8",
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.14",
         "@types/react": "~19.1.0",
@@ -36,6 +39,9 @@
         "react-test-renderer": "^19.1.0",
         "typescript": "~5.9.2"
       }
+    },
+    "modules/live-activity": {
+      "version": "1.0.0"
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.2.0",
@@ -1538,6 +1544,130 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bacons/apple-targets": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@bacons/apple-targets/-/apple-targets-4.0.6.tgz",
+      "integrity": "sha512-aDSXI6HPgsroPMOAlNvVyvM2TvU25hgGu/UUWD6XWfWIX4nhGchCSaoEGx7cB3xO+ClQYdzlIAIlZScX6lHBwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bacons/xcode": "1.0.0-alpha.32",
+        "@react-native/normalize-colors": "^0.79.2",
+        "debug": "^4.3.4",
+        "glob": "^10.4.2"
+      },
+      "peerDependencies": {
+        "expo": ">=52"
+      }
+    },
+    "node_modules/@bacons/apple-targets/node_modules/@react-native/normalize-colors": {
+      "version": "0.79.7",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.7.tgz",
+      "integrity": "sha512-RrvewhdanEWhlyrHNWGXGZCc6MY0JGpNgRzA8y6OomDz0JmlnlIsbBHbNpPnIrt9Jh2KaV10KTscD1Ry8xU9gQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bacons/apple-targets/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@bacons/apple-targets/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@bacons/apple-targets/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@bacons/xcode": {
+      "version": "1.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@bacons/xcode/-/xcode-1.0.0-alpha.32.tgz",
+      "integrity": "sha512-OGpH7+yMbWC2cgYZon5B+VVadH9HsB2V/abtEiplA65XnSuV4GAYAVixOCDc5k182WkfoakfdM0zW6U9cbcsbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/plist": "^0.0.18",
+        "debug": "^4.3.4",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/@expo/plist": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
+      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.0",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version has critical issues, please update to the latest version",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/xmlbuilder": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -2196,6 +2326,27 @@
         "xmlbuilder": "^15.1.1"
       }
     },
+    "node_modules/@expo/prebuild-config": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
+      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/image-utils": "^0.8.8",
+        "@expo/json-file": "^10.0.8",
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/@expo/schema-utils": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.8.tgz",
@@ -2353,6 +2504,109 @@
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
       "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
       "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
@@ -3265,6 +3519,17 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -5822,6 +6087,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6781,27 +7053,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
-      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
-        "@react-native/normalize-colors": "0.81.5",
-        "debug": "^4.3.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
     "node_modules/expo/node_modules/@expo/metro-config": {
       "version": "54.0.14",
       "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.14.tgz",
@@ -7224,6 +7475,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -8117,6 +8398,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -10705,6 +11002,10 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/live-activity": {
+      "resolved": "modules/live-activity",
+      "link": true
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -11699,6 +12000,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -13277,10 +13585,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14373,6 +14711,61 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
@@ -53,6 +53,7 @@
     "expo-router": "~6.0.23",
     "expo-status-bar": "~3.0.9",
     "expo-task-manager": "~14.0.9",
+    "live-activity": "file:./modules/live-activity",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
@@ -63,6 +64,8 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@bacons/apple-targets": "^4.0.6",
+    "@expo/prebuild-config": "^54.0.8",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.1.0",

--- a/remove-push-entitlement.js
+++ b/remove-push-entitlement.js
@@ -1,0 +1,7 @@
+const { withEntitlementsPlist } = require('@expo/config-plugins');
+
+module.exports = (config) =>
+  withEntitlementsPlist(config, (mod) => {
+    delete mod.modResults['aps-environment'];
+    return mod;
+  });

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -45,7 +45,6 @@ describe('useNearestStation', () => {
 
   it('500m 이내에 역이 있으면 해당 역을 반환한다', async () => {
     mockGranted();
-    // 강남역 좌표 (37.4979, 127.0276) 근처
     mockLocation(37.4980, 127.0277);
 
     const { result } = renderHook(() => useNearestStation());
@@ -71,15 +70,12 @@ describe('useNearestStation', () => {
 
   it('500m 초과 거리에 있으면 null을 반환한다', async () => {
     mockGranted();
-    // 아무 역도 없는 한강 한가운데 좌표
     mockLocation(37.5200, 127.0000);
 
     const { result } = renderHook(() => useNearestStation());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // 가장 가까운 역이 500m 밖이면 null
-    // (이 좌표 주변 검사 — 결과가 null 이거나 근처 역일 수 있으므로 distanceKm 체크)
     if (result.current.result !== null) {
       expect(result.current.result.distanceKm).toBeLessThanOrEqual(0.5);
     }

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,76 @@
+import { createLogger, setMinLevel } from '../logger';
+
+describe('createLogger', () => {
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('debug 레벨은 console.log를 호출한다', () => {
+    const logger = createLogger('TEST');
+    logger.debug('메시지');
+    expect(logSpy).toHaveBeenCalledWith('[TEST]', '메시지');
+  });
+
+  it('info 레벨은 console.log를 호출한다', () => {
+    const logger = createLogger('TEST');
+    logger.info('메시지');
+    expect(logSpy).toHaveBeenCalledWith('[TEST]', '메시지');
+  });
+
+  it('warn 레벨은 console.warn을 호출한다', () => {
+    const logger = createLogger('TEST');
+    logger.warn('경고');
+    expect(warnSpy).toHaveBeenCalledWith('[TEST]', '경고');
+  });
+
+  it('error 레벨은 console.error를 호출한다', () => {
+    const logger = createLogger('TEST');
+    logger.error('오류');
+    expect(errorSpy).toHaveBeenCalledWith('[TEST]', '오류');
+  });
+
+  it('태그가 메시지에 포함된다', () => {
+    const logger = createLogger('LiveActivity');
+    logger.info('시작');
+    expect(logSpy).toHaveBeenCalledWith('[LiveActivity]', '시작');
+  });
+
+  it('여러 인수를 전달할 수 있다', () => {
+    const logger = createLogger('TEST');
+    logger.info('상태:', 'granted', 42);
+    expect(logSpy).toHaveBeenCalledWith('[TEST]', '상태:', 'granted', 42);
+  });
+
+  describe('setMinLevel', () => {
+    afterEach(() => {
+      setMinLevel('debug'); // 테스트 후 복원
+    });
+
+    it('minLevel 이하 로그는 출력하지 않는다', () => {
+      setMinLevel('warn');
+      const logger = createLogger('TEST');
+      logger.debug('무시됨');
+      logger.info('무시됨');
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('minLevel 이상 로그는 출력한다', () => {
+      setMinLevel('warn');
+      const logger = createLogger('TEST');
+      logger.warn('경고');
+      logger.error('오류');
+      expect(warnSpy).toHaveBeenCalledWith('[TEST]', '경고');
+      expect(errorSpy).toHaveBeenCalledWith('[TEST]', '오류');
+    });
+  });
+});

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -1,0 +1,320 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import {
+  setupNotificationHandler,
+  initStationNotification,
+  updateStationNotification,
+  clearStationNotification,
+} from '../stationNotification';
+import { Station } from '../../types/station';
+import { DirectRoute, TransferRoute } from '../stationRoute';
+
+jest.mock('expo-notifications');
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const mockStartLiveActivity = jest.fn().mockResolvedValue(undefined);
+const mockUpdateLiveActivity = jest.fn().mockResolvedValue(undefined);
+const mockEndLiveActivity = jest.fn().mockResolvedValue(undefined);
+const mockIsLiveActivityEnabled = jest.fn().mockReturnValue(true);
+
+jest.mock('../../../modules/live-activity', () => ({
+  startLiveActivity: (...args: unknown[]) => mockStartLiveActivity(...args),
+  updateLiveActivity: (...args: unknown[]) => mockUpdateLiveActivity(...args),
+  endLiveActivity: () => mockEndLiveActivity(),
+  isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
+}));
+
+const mockStation: Station = {
+  id: 'si-cheong-1',
+  name: '시청',
+  line: '1',
+  lineColor: '#0052A4',
+  lat: 37.5651,
+  lng: 126.9774,
+};
+
+const mockDestination: Station = {
+  id: 'seong-sin-4',
+  name: '성신여대입구',
+  line: '4',
+  lineColor: '#00A2D1',
+  lat: 37.5926,
+  lng: 127.0163,
+};
+
+const directRoute: DirectRoute = { type: 'direct', stops: 4 };
+const transferRoute: TransferRoute = {
+  type: 'transfer',
+  transferName: '동대문',
+  fromLine: '1',
+  toLine: '4',
+  stopsToTransfer: 3,
+  stopsFromTransfer: 2,
+};
+
+describe('stationNotification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Notifications.setNotificationHandler as jest.Mock).mockReturnValue(undefined);
+    (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+    (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('current-station');
+    (Notifications.setNotificationChannelAsync as jest.Mock).mockResolvedValue(undefined);
+    mockIsLiveActivityEnabled.mockReturnValue(true);
+  });
+
+  describe('setupNotificationHandler', () => {
+    it('setNotificationHandler를 호출한다', () => {
+      setupNotificationHandler();
+      expect(Notifications.setNotificationHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ handleNotification: expect.any(Function) })
+      );
+    });
+
+    it('handleNotification은 shouldShowAlert true를 반환한다', async () => {
+      setupNotificationHandler();
+      const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+      const result = await handleNotification();
+      expect(result).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: false, shouldSetBadge: false });
+    });
+  });
+
+  describe('initStationNotification', () => {
+    it('iOS에서는 권한 요청만 한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await initStationNotification();
+      expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(Notifications.setNotificationChannelAsync).not.toHaveBeenCalled();
+    });
+
+    it('Android에서는 채널 생성 후 권한 요청한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await initStationNotification();
+      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station', {
+        name: '현재 역',
+        importance: Notifications.AndroidImportance.HIGH,
+        lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+      });
+      expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('updateStationNotification (iOS - Live Activity)', () => {
+    beforeEach(async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      // liveActivityStarted 초기화
+      await clearStationNotification();
+      jest.clearAllMocks();
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+    });
+
+    it('처음 호출 시 startLiveActivity를 호출한다', async () => {
+      await updateStationNotification(mockStation, 154);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stationName: '시청',
+          lineName: '1호선',
+          lineColorHex: '#0052A4',
+          distanceM: 154,
+        })
+      );
+      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    });
+
+    it('두 번째 호출부터는 updateLiveActivity를 호출한다', async () => {
+      await updateStationNotification(mockStation, 154);
+      await updateStationNotification(mockStation, 100);
+      expect(mockStartLiveActivity).toHaveBeenCalledTimes(1);
+      expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+    });
+
+    it('목적지 없으면 destinationName이 없다', async () => {
+      await updateStationNotification(mockStation, 154);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.not.objectContaining({ destinationName: expect.anything() })
+      );
+    });
+
+    it('직통 경로이면 stopsRemaining을 포함한다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destinationName: '성신여대입구',
+          stopsRemaining: 4,
+        })
+      );
+    });
+
+    it('환승 경로이면 환승 정보를 포함한다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, transferRoute);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destinationName: '성신여대입구',
+          stopsToTransfer: 3,
+          transferStationName: '동대문',
+          stopsFromTransfer: 2,
+        })
+      );
+    });
+
+    it('expo-notifications를 호출하지 않는다', async () => {
+      await updateStationNotification(mockStation, 154);
+      expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('isLiveActivityEnabled가 false이면 expo-notifications로 fallback한다', async () => {
+      mockIsLiveActivityEnabled.mockReturnValue(false);
+      await updateStationNotification(mockStation, 154);
+      expect(mockStartLiveActivity).not.toHaveBeenCalled();
+      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { title: '시청역', body: '1호선 · 약 154m' },
+        })
+      );
+    });
+
+    it('startLiveActivity 실패 시 expo-notifications로 폴백한다', async () => {
+      mockStartLiveActivity.mockRejectedValueOnce(new Error('ActivityKit 오류'));
+      await updateStationNotification(mockStation, 154);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { title: '시청역', body: '1호선 · 약 154m' },
+        })
+      );
+    });
+
+    it('startLiveActivity 실패 시 liveActivityStarted를 false로 리셋한다', async () => {
+      mockStartLiveActivity.mockRejectedValueOnce(new Error('ActivityKit 오류'));
+      await updateStationNotification(mockStation, 154);
+      // liveActivityStarted가 리셋됐으므로 다음 호출도 start를 사용해야 함
+      jest.clearAllMocks();
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+      await updateStationNotification(mockStation, 100);
+      expect(mockStartLiveActivity).toHaveBeenCalled();
+      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    });
+
+    it('updateLiveActivity 실패 시 liveActivityStarted를 false로 리셋한다', async () => {
+      await updateStationNotification(mockStation, 154);
+      mockUpdateLiveActivity.mockRejectedValueOnce(new Error('업데이트 오류'));
+      await updateStationNotification(mockStation, 100);
+      // liveActivityStarted가 리셋됐으므로 다음 호출은 start를 사용해야 함
+      jest.clearAllMocks();
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+      await updateStationNotification(mockStation, 80);
+      expect(mockStartLiveActivity).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateStationNotification (Android - expo-notifications)', () => {
+    beforeEach(() => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+    });
+
+    it('목적지 없으면 역 이름과 거리를 표시한다', async () => {
+      await updateStationNotification(mockStation, 154);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { title: '시청역', body: '1호선 · 약 154m' },
+        })
+      );
+    });
+
+    it('직통 경로이면 목적지와 정거장 수를 표시한다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { title: '시청 → 성신여대입구', body: '1호선 · 4정거장 남음' },
+        })
+      );
+    });
+
+    it('환승 경로이면 환승 정보를 표시한다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, transferRoute);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { title: '시청 → 성신여대입구', body: '3정거장 후 동대문 환승 · 2정거장' },
+        })
+      );
+    });
+
+    it('dismiss가 실패해도 schedule은 호출된다', async () => {
+      (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValue(new Error('없음'));
+      await updateStationNotification(mockStation, 154);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    });
+
+    it('dismiss가 schedule보다 먼저 호출된다', async () => {
+      const callOrder: string[] = [];
+      (Notifications.dismissNotificationAsync as jest.Mock).mockImplementation(async () => { callOrder.push('dismiss'); });
+      (Notifications.scheduleNotificationAsync as jest.Mock).mockImplementation(async () => { callOrder.push('schedule'); return 'id'; });
+      await updateStationNotification(mockStation, 154);
+      expect(callOrder).toEqual(['dismiss', 'schedule']);
+    });
+
+    it('Live Activity를 호출하지 않는다', async () => {
+      await updateStationNotification(mockStation, 154);
+      expect(mockStartLiveActivity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearStationNotification', () => {
+    it('iOS에서 endLiveActivity를 호출하고 liveActivityStarted를 초기화한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      // 먼저 start 상태로 만들기
+      await updateStationNotification(mockStation, 154);
+      jest.clearAllMocks();
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+
+      await clearStationNotification();
+      expect(mockEndLiveActivity).toHaveBeenCalled();
+      expect(Notifications.dismissNotificationAsync).not.toHaveBeenCalled();
+
+      // 초기화 확인: 다음 update는 start를 호출해야 함
+      jest.clearAllMocks();
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+      await updateStationNotification(mockStation, 100);
+      expect(mockStartLiveActivity).toHaveBeenCalled();
+    });
+
+    it('iOS에서 endLiveActivity가 실패해도 liveActivityStarted를 초기화한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await updateStationNotification(mockStation, 154);
+      mockEndLiveActivity.mockRejectedValueOnce(new Error('종료 실패'));
+      jest.clearAllMocks();
+      mockEndLiveActivity.mockRejectedValueOnce(new Error('종료 실패'));
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+
+      await clearStationNotification();
+
+      // 에러 후에도 liveActivityStarted가 리셋되어야 함
+      jest.clearAllMocks();
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+      await updateStationNotification(mockStation, 100);
+      expect(mockStartLiveActivity).toHaveBeenCalled();
+    });
+
+    it('iOS에서 Live Activity 비활성화 시 dismissNotificationAsync를 호출한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      mockIsLiveActivityEnabled.mockReturnValue(false);
+      await clearStationNotification();
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('current-station');
+      expect(mockEndLiveActivity).not.toHaveBeenCalled();
+    });
+
+    it('Android에서 dismissNotificationAsync를 호출한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await clearStationNotification();
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('current-station');
+      expect(mockEndLiveActivity).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,42 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVELS: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+// 기본값은 debug. 프로덕션 빌드에서는 앱 초기화 시 setMinLevel('warn') 호출
+let minLevel: LogLevel = 'debug';
+
+export function setMinLevel(level: LogLevel): void {
+  minLevel = level;
+}
+
+function log(level: LogLevel, tag: string, ...args: unknown[]): void {
+  if (LEVELS[level] < LEVELS[minLevel]) return;
+
+  const message = `[${tag}]`;
+  switch (level) {
+    case 'debug':
+    case 'info':
+      console.log(message, ...args);
+      break;
+    case 'warn':
+      console.warn(message, ...args);
+      break;
+    case 'error':
+      console.error(message, ...args);
+      break;
+  }
+}
+
+export function createLogger(tag: string) {
+  return {
+    debug: (...args: unknown[]) => log('debug', tag, ...args),
+    info: (...args: unknown[]) => log('info', tag, ...args),
+    warn: (...args: unknown[]) => log('warn', tag, ...args),
+    error: (...args: unknown[]) => log('error', tag, ...args),
+  };
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -1,0 +1,183 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { Station } from '../types/station';
+import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
+import { DirectRoute, TransferRoute } from './stationRoute';
+import * as LiveActivity from 'live-activity';
+import { createLogger } from './logger';
+
+const notifLogger = createLogger('Notification');
+const liveActivityLogger = createLogger('LiveActivity');
+
+const NOTIFICATION_ID = 'current-station';
+
+// iOS Live Activity 상태 추적 (start vs update 구분)
+let liveActivityStarted = false;
+
+export function setupNotificationHandler(): void {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowAlert: true,
+      shouldShowBanner: true,
+      shouldShowList: true,
+      shouldPlaySound: false,
+      shouldSetBadge: false,
+    }),
+  });
+}
+
+export async function initStationNotification(): Promise<void> {
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('station', {
+      name: '현재 역',
+      importance: Notifications.AndroidImportance.HIGH,
+      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+    });
+  }
+  const { status } = await Notifications.requestPermissionsAsync();
+  notifLogger.info('권한 상태:', status);
+}
+
+function buildContent(
+  currentStation: Station,
+  distanceM: number,
+  destination?: Station | null,
+  route?: DirectRoute | TransferRoute | null,
+): { title: string; body: string } {
+  if (destination && route) {
+    const title = `${currentStation.name} → ${destination.name}`;
+    if (route.type === 'direct') {
+      const body = `${LINE_NAMES[currentStation.line]} · ${route.stops}정거장 남음`;
+      return { title, body };
+    }
+    const body = `${route.stopsToTransfer}정거장 후 ${route.transferName} 환승 · ${route.stopsFromTransfer}정거장`;
+    return { title, body };
+  }
+  return {
+    title: `${currentStation.name}역`,
+    body: `${LINE_NAMES[currentStation.line]} · 약 ${distanceM}m`,
+  };
+}
+
+function buildLiveActivityData(
+  currentStation: Station,
+  distanceM: number,
+  destination?: Station | null,
+  route?: DirectRoute | TransferRoute | null,
+): LiveActivity.LiveActivityData {
+  const base: LiveActivity.LiveActivityData = {
+    stationName: currentStation.name,
+    lineName: LINE_NAMES[currentStation.line],
+    lineColorHex: LINE_COLORS[currentStation.line],
+    distanceM,
+  };
+
+  if (destination && route) {
+    base.destinationName = destination.name;
+    if (route.type === 'direct') {
+      base.stopsRemaining = route.stops;
+    } else {
+      base.stopsToTransfer = route.stopsToTransfer;
+      base.transferStationName = route.transferName;
+      base.stopsFromTransfer = route.stopsFromTransfer;
+    }
+  }
+
+  return base;
+}
+
+export async function updateStationNotification(
+  currentStation: Station,
+  distanceM: number,
+  destination?: Station | null,
+  route?: DirectRoute | TransferRoute | null,
+): Promise<void> {
+  notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
+
+  if (Platform.OS === 'ios') {
+    const liveActivityEnabled = LiveActivity.isLiveActivityEnabled();
+    liveActivityLogger.info('isLiveActivityEnabled:', liveActivityEnabled);
+
+    if (!liveActivityEnabled) {
+      notifLogger.info('Live Activity 비활성 → 알림 fallback');
+      const { title, body } = buildContent(currentStation, distanceM, destination, route);
+      try {
+        await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+      } catch {
+        // 기존 알림 없어도 무시하고 계속 진행
+      }
+      await Notifications.scheduleNotificationAsync({
+        identifier: NOTIFICATION_ID,
+        content: { title, body },
+        trigger: null,
+      });
+      notifLogger.info('알림 예약 완료:', title, body);
+      return;
+    }
+    const data = buildLiveActivityData(currentStation, distanceM, destination, route);
+    try {
+      if (!liveActivityStarted) {
+        liveActivityLogger.info('시작 요청');
+        await LiveActivity.startLiveActivity(data);
+        liveActivityStarted = true;
+        liveActivityLogger.info('시작 성공');
+      } else {
+        liveActivityLogger.info('업데이트 요청');
+        await LiveActivity.updateLiveActivity(data);
+        liveActivityLogger.info('업데이트 성공');
+      }
+    } catch (e) {
+      liveActivityLogger.error('시작/업데이트 실패:', e);
+      liveActivityStarted = false;
+      notifLogger.info('Live Activity 실패 → 알림 fallback');
+      const { title, body } = buildContent(currentStation, distanceM, destination, route);
+      try {
+        await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+      } catch {
+        // 기존 알림 없어도 무시하고 계속 진행
+      }
+      await Notifications.scheduleNotificationAsync({
+        identifier: NOTIFICATION_ID,
+        content: { title, body },
+        trigger: null,
+      });
+    }
+    return;
+  }
+
+  // Android: 기존 expo-notifications 유지
+  const { title, body } = buildContent(currentStation, distanceM, destination, route);
+  notifLogger.info('Android 알림:', title, body);
+  try {
+    await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+  } catch {
+    // 기존 알림 없어도 무시하고 계속 진행
+  }
+  await Notifications.scheduleNotificationAsync({
+    identifier: NOTIFICATION_ID,
+    content: { title, body },
+    trigger: null,
+  });
+  notifLogger.info('알림 예약 완료');
+}
+
+export async function clearStationNotification(): Promise<void> {
+  if (Platform.OS === 'ios') {
+    if (!LiveActivity.isLiveActivityEnabled()) {
+      notifLogger.info('알림 해제 (Live Activity 비활성)');
+      await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+      return;
+    }
+    try {
+      liveActivityLogger.info('종료 요청');
+      await LiveActivity.endLiveActivity();
+      liveActivityLogger.info('종료 성공');
+    } catch (e) {
+      liveActivityLogger.error('종료 실패:', e);
+    }
+    liveActivityStarted = false;
+    return;
+  }
+  notifLogger.info('Android 알림 해제');
+  await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+}

--- a/targets/subway-widget/Info.plist
+++ b/targets/subway-widget/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSExtension</key>
+    <dict>
+      <key>NSExtensionPointIdentifier</key>
+      <string>com.apple.widgetkit-extension</string>
+    </dict>
+    <key>NSSupportsLiveActivities</key>
+    <true/>
+  </dict>
+</plist>

--- a/targets/subway-widget/SubwayLiveActivity.swift
+++ b/targets/subway-widget/SubwayLiveActivity.swift
@@ -1,0 +1,18 @@
+#if os(iOS)
+import ActivityKit
+
+@available(iOS 16.1, *)
+struct SubwayActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var stationName: String
+        var lineName: String
+        var lineColorHex: String
+        var destinationName: String?
+        var stopsRemaining: Int?
+        var stopsToTransfer: Int?
+        var transferStationName: String?
+        var stopsFromTransfer: Int?
+        var distanceM: Int
+    }
+}
+#endif

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -1,0 +1,156 @@
+#if os(iOS)
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+@available(iOS 16.1, *)
+struct SubwayLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: SubwayActivityAttributes.self) { context in
+            // 잠금화면 / 배너 뷰
+            LockScreenView(state: context.state)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded
+                DynamicIslandExpandedRegion(.leading) {
+                    Circle()
+                        .fill(Color(hex: context.state.lineColorHex) ?? .gray)
+                        .frame(width: 12, height: 12)
+                        .padding(.leading, 4)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(context.state.stationName)
+                            .font(.headline)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                        if let dest = context.state.destinationName {
+                            ExpandedRouteView(dest: dest, state: context.state)
+                        } else {
+                            Text("\(context.state.lineName) · \(context.state.distanceM)m")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            } compactLeading: {
+                Circle()
+                    .fill(Color(hex: context.state.lineColorHex) ?? .gray)
+                    .frame(width: 10, height: 10)
+                    .padding(.leading, 2)
+            } compactTrailing: {
+                Text(context.state.stationName)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+            } minimal: {
+                Circle()
+                    .fill(Color(hex: context.state.lineColorHex) ?? .gray)
+                    .frame(width: 10, height: 10)
+            }
+        }
+    }
+}
+
+@available(iOS 16.1, *)
+private struct LockScreenView: View {
+    let state: SubwayActivityAttributes.ContentState
+
+    var lineColor: Color {
+        Color(hex: state.lineColorHex) ?? .gray
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            // 노선 색상 바
+            RoundedRectangle(cornerRadius: 4)
+                .fill(lineColor)
+                .frame(width: 6)
+
+            VStack(alignment: .leading, spacing: 4) {
+                // 노선 배지
+                Text(state.lineName)
+                    .font(.caption2)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(lineColor)
+                    .cornerRadius(10)
+
+                // 역 이름
+                Text(state.stationName)
+                    .font(.title2)
+                    .fontWeight(.black)
+                    .foregroundColor(.white)
+
+                // 목적지 / 거리
+                if let dest = state.destinationName {
+                    LockScreenRouteView(dest: dest, state: state)
+                } else {
+                    Text("약 \(state.distanceM)m")
+                        .font(.subheadline)
+                        .foregroundColor(lineColor)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(16)
+        .background(.black.opacity(0.85))
+    }
+}
+
+@available(iOS 16.1, *)
+private struct LockScreenRouteView: View {
+    let dest: String
+    let state: SubwayActivityAttributes.ContentState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("→ \(dest)")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(.white)
+
+            if let stops = state.stopsRemaining {
+                Text("\(stops)정거장 남음")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else if let toTransfer = state.stopsToTransfer,
+                      let transferName = state.transferStationName,
+                      let fromTransfer = state.stopsFromTransfer {
+                Text("\(toTransfer)정거장 후 \(transferName) 환승 · \(fromTransfer)정거장")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+@available(iOS 16.1, *)
+private struct ExpandedRouteView: View {
+    let dest: String
+    let state: SubwayActivityAttributes.ContentState
+
+    var body: some View {
+        if let stops = state.stopsRemaining {
+            Text("→ \(dest) · \(stops)정거장")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        } else if let toTransfer = state.stopsToTransfer,
+                  let transferName = state.transferStationName,
+                  let fromTransfer = state.stopsFromTransfer {
+            Text("→ \(dest) (\(toTransfer)정거장 후 \(transferName) 환승 · \(fromTransfer)정거장)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+        } else {
+            Text("→ \(dest)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+#endif

--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -1,0 +1,129 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - Data Model
+
+struct SubwayEntry: TimelineEntry {
+    let date: Date
+    let stationName: String
+    let lineColor: String
+    let distanceM: Int
+    let isAvailable: Bool
+}
+
+// MARK: - Timeline Provider
+
+struct SubwayProvider: TimelineProvider {
+    private let appGroup = "group.com.subwaynow.app"
+
+    func placeholder(in context: Context) -> SubwayEntry {
+        SubwayEntry(
+            date: Date(),
+            stationName: "강남",
+            lineColor: "#009933",
+            distanceM: 120,
+            isAvailable: true
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SubwayEntry) -> Void) {
+        completion(makeEntry())
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<SubwayEntry>) -> Void) {
+        let entry = makeEntry()
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+
+    private func makeEntry() -> SubwayEntry {
+        let defaults = UserDefaults(suiteName: appGroup)
+        let name = defaults?.string(forKey: "stationName") ?? ""
+        let color = defaults?.string(forKey: "lineColor") ?? "#888888"
+        let distanceStr = defaults?.string(forKey: "distanceM") ?? "0"
+        let distance = Int(distanceStr) ?? 0
+        let isAvailable = !name.isEmpty
+
+        return SubwayEntry(
+            date: Date(),
+            stationName: isAvailable ? name : "감지 중",
+            lineColor: color,
+            distanceM: distance,
+            isAvailable: isAvailable
+        )
+    }
+}
+
+// MARK: - Color Extension
+
+extension Color {
+    init?(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        guard Scanner(string: hex).scanHexInt64(&int), hex.count == 6 else { return nil }
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+// MARK: - Widget View
+
+struct SubwayWidgetView: View {
+    var entry: SubwayEntry
+
+    var lineColor: Color {
+        Color(hex: entry.lineColor) ?? .gray
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(lineColor)
+                    .frame(width: 10, height: 10)
+                Text("지하철")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Text(entry.stationName)
+                .font(.headline)
+                .fontWeight(.bold)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+
+            if entry.isAvailable {
+                Text("\(entry.distanceM)m")
+                    .font(.subheadline)
+                    .foregroundColor(lineColor)
+            }
+
+            Spacer()
+
+            Text(entry.date, style: .time)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+    }
+}
+
+// MARK: - Widget Configuration
+
+struct SubwayWidget: Widget {
+    let kind = "SubwayWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: SubwayProvider()) { entry in
+            SubwayWidgetView(entry: entry)
+        }
+        .configurationDisplayName("지하철 현재 역")
+        .description("가장 가까운 지하철역을 홈 화면에서 확인하세요.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+

--- a/targets/subway-widget/SubwayWidgetBundle.swift
+++ b/targets/subway-widget/SubwayWidgetBundle.swift
@@ -1,0 +1,13 @@
+import WidgetKit
+import SwiftUI
+
+@main
+struct SubwayWidgetBundle: WidgetBundle {
+    @WidgetBundleBuilder
+    var body: some Widget {
+        SubwayWidget()
+        if #available(iOS 16.1, *) {
+            SubwayLiveActivityWidget()
+        }
+    }
+}

--- a/targets/subway-widget/expo-target.config.json
+++ b/targets/subway-widget/expo-target.config.json
@@ -1,0 +1,4 @@
+{
+  "type": "widget",
+  "deploymentTarget": "16.0"
+}

--- a/targets/subway-widget/expo-target.json
+++ b/targets/subway-widget/expo-target.json
@@ -1,0 +1,7 @@
+{
+  "type": "widget",
+  "deploymentTarget": "16.0",
+  "entitlements": {
+    "com.apple.security.application-groups": ["group.com.subwaynow.app"]
+  }
+}


### PR DESCRIPTION
## Summary

- `stationNotification.ts`: destination + route 파라미터 기반 알림 content 생성 (직통/환승 경로 포맷)
- `logger.ts`: 레벨별 로거 유틸리티 추가, 프로덕션에서 warn 이상만 출력
- `index.tsx`: station/destination/route 변화 감지 → 알림 갱신, 도착 시 알림 자동 제거
- `live-activity` 네이티브 모듈: iOS Live Activity 연동 (ActivityKit)
- `targets/subway-widget`: Live Activity 위젯 타겟 (Dynamic Island + 잠금화면)
- `remove-push-entitlement.js`: aps-environment 엔타이틀먼트 제거 플러그인

## 알림 포맷

| 상황 | title | body |
|---|---|---|
| 역 근처, 목적지 없음 | `시청역` | `1호선 · 약 154m` |
| 역 근처, 직통 경로 | `시청 → 성신여대입구` | `1호선 · 4정거장 남음` |
| 역 근처, 환승 경로 | `시청 → 성신여대입구` | `4정거장 후 동대문 환승 · 3정거장` |
| 역 범위 밖 / 도착 | 알림 제거 | - |

## Test plan

- [x] `npm test` 커버리지 100% 통과
- [x] `npm run type-check` 타입 오류 없음
- [x] 실기기에서 역 근처 진입 시 알림 발송 확인
- [x] 목적지 설정 후 경로 정보 알림 표시 확인
- [x] 도착 시 알림 자동 해제 확인
- [x] iOS Live Activity (Dynamic Island) 동작 확인

Closes #47