### PR TITLE
feat(#55): 500m 제한 제거 - 항상 가장 가까운 역 표시

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -56,7 +56,7 @@ export default function HomeScreen() {
   }, [arrivedBanner]);
 
   useEffect(() => {
-    if (result?.station.id && destination?.id && result.station.id === destination.id) {
+    if (result?.station.id && destination?.id && result.station.id === destination.id && result.distanceKm <= 0.5) {
       setArrivedBanner(true);
       arrivedTimeoutRef.current = setTimeout(() => {
         setDestination(null);
@@ -137,7 +137,9 @@ export default function HomeScreen() {
                   </Text>
                 </TouchableOpacity>
               </View>
-              <Text style={styles.currentStationLabel}>현재역</Text>
+              <Text style={styles.currentStationLabel}>
+                {result.distanceKm <= 0.5 ? '현재역' : '가장 가까운 역'}
+              </Text>
               <Text style={styles.stationName}>{result.station.name}</Text>
               <Text style={styles.distanceText}>
                 현재 위치에서 약 {Math.round(result.distanceKm * 1000)}m

--- a/src/hooks/__tests__/useNearestStation.emptyData.test.ts
+++ b/src/hooks/__tests__/useNearestStation.emptyData.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import * as Location from 'expo-location';
+
+jest.mock('expo-location');
+jest.mock('../../../src/data/stations.json', () => []);
+
+import { useNearestStation } from '../useNearestStation';
+
+describe('useNearestStation - 역 데이터 없는 경우', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: 'granted',
+    });
+    (Location.getCurrentPositionAsync as jest.Mock).mockResolvedValue({
+      coords: { latitude: 37.4980, longitude: 127.0277 },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('역 데이터가 없으면 null을 반환한다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -68,7 +68,7 @@ describe('useNearestStation', () => {
     expect(result.current.userLocation).toBeNull();
   });
 
-  it('500m 초과 거리에 있으면 null을 반환한다', async () => {
+  it('500m 초과 거리에서도 가장 가까운 역을 반환한다', async () => {
     mockGranted();
     mockLocation(37.5200, 127.0000);
 
@@ -76,9 +76,8 @@ describe('useNearestStation', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    if (result.current.result !== null) {
-      expect(result.current.result.distanceKm).toBeLessThanOrEqual(0.5);
-    }
+    expect(result.current.result).not.toBeNull();
+    expect(result.current.result?.distanceKm).toBeGreaterThan(0.5);
   });
 
   it('위치 획득 실패 시 error가 설정된다', async () => {
@@ -142,3 +141,4 @@ describe('useNearestStation', () => {
     clearIntervalSpy.mockRestore();
   });
 });
+

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -5,7 +5,6 @@ import { haversine } from '../utils/haversine';
 import { NearestStationResult, Station } from '../types/station';
 
 const stations = stationsData as Station[];
-const NEARBY_THRESHOLD_KM = 0.5;
 const UPDATE_INTERVAL_MS = 30_000;
 
 interface UseNearestStationReturn {
@@ -38,7 +37,7 @@ export function useNearestStation(): UseNearestStationReturn {
         }
       }
 
-      if (nearest && minDistance <= NEARBY_THRESHOLD_KM) {
+      if (nearest) {
         return { station: nearest, distanceKm: minDistance };
       }
       return null;


### PR DESCRIPTION
## Summary

- `useNearestStation`: `NEARBY_THRESHOLD_KM` 조건 제거 → 거리에 관계없이 항상 최근접 역 반환
- `index.tsx`: `distanceKm <= 0.5` 기준으로 "현재역" / "가장 가까운 역" 레이블 분기
- `index.tsx`: 도착 감지 조건에 `distanceKm <= 0.5` 추가 (500m 밖에서 false positive 방지)
- 테스트: 500m 초과 시에도 역 반환 검증, 빈 역 데이터 null 반환 케이스 별도 파일로 추가

## Test plan

- [x] `npm test` 커버리지 100% 통과
- [x] `npm run type-check` 타입 오류 없음
- [x] 실기기에서 역과 멀 때 "가장 가까운 역" 레이블 표시 확인
- [x] 역 500m 이내 진입 시 "현재역" 레이블로 전환 확인

Closes #55