### PR TITLE
feat(#58): 전체 여정 타임라인 표시 + 도착 예상 시간

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,7 +6,8 @@ import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
-import { findRoute } from '../../src/utils/stationRoute';
+import { findRoute, buildJourneyDisplay, calculateETA } from '../../src/utils/stationRoute';
+import { JourneyTimeline } from '../../src/components/JourneyTimeline';
 import { initStationNotification, updateStationNotification, clearStationNotification } from '../../src/utils/stationNotification';
 import { createLogger } from '../../src/utils/logger';
 
@@ -21,6 +22,16 @@ export default function HomeScreen() {
   const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
   const route = result && destination ? findRoute(result.station.id, destination.id) : null;
+  const journey = route && result && destination ? buildJourneyDisplay(route, result.station, destination) : null;
+  const nextTrainMinutes = arrival
+    ? Math.min(
+        arrival.up[0]?.arrivalMinutes ?? Infinity,
+        arrival.down[0]?.arrivalMinutes ?? Infinity,
+      )
+    : null;
+  const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
+    ? calculateETA(nextTrainMinutes, route)
+    : null;
 
   useEffect(() => {
     loadFavorites();
@@ -148,29 +159,14 @@ export default function HomeScreen() {
 
             <View style={styles.destinationCard}>
               {destination ? (
-                <View style={styles.destinationInfo}>
-                  <Text style={styles.destinationArrow}>→</Text>
-                  <View>
+                <View>
+                  <View style={styles.destinationInfo}>
+                    <Text style={styles.destinationArrow}>→</Text>
                     <Text style={styles.destinationName}>{destination.name}</Text>
-                    {route?.type === 'direct' ? (
-                      <View style={styles.routeDirectBox}>
-                        <Text style={styles.routeDirectStops}>{route.stops}</Text>
-                        <Text style={styles.routeDirectLabel}>정거장 남음</Text>
-                      </View>
-                    ) : route?.type === 'transfer' ? (
-                      <View style={styles.transferBox}>
-                        <View style={styles.transferBeforeRow}>
-                          <Text style={styles.transferBeforeStops}>{route.stopsToTransfer}</Text>
-                          <Text style={styles.transferBeforeLabel}>정거장 후 환승</Text>
-                        </View>
-                        <View style={styles.transferStationRow}>
-                          <Text style={styles.transferIcon}>⇄</Text>
-                          <Text style={styles.transferStationName}>{route.transferName}</Text>
-                        </View>
-                        <Text style={styles.transferAfterText}>환승 후 {route.stopsFromTransfer}정거장</Text>
-                      </View>
-                    ) : null}
                   </View>
+                  {journey && (
+                    <JourneyTimeline journey={journey} etaMinutes={etaMinutes} />
+                  )}
                 </View>
               ) : null}
               {!destination && recentDestination && (
@@ -362,65 +358,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: '700',
     color: '#ffffff',
-  },
-  remainingText: {
-    fontSize: 13,
-    color: '#8888aa',
-    marginTop: 2,
-  },
-  routeDirectBox: {
-    marginTop: 8,
-    alignItems: 'flex-start',
-  },
-  routeDirectStops: {
-    fontSize: 32,
-    fontWeight: '800',
-    color: '#ffffff',
-    lineHeight: 36,
-  },
-  routeDirectLabel: {
-    fontSize: 13,
-    color: '#8888aa',
-    marginTop: 2,
-  },
-  transferBox: {
-    marginTop: 12,
-    paddingTop: 12,
-    borderTopWidth: 1,
-    borderTopColor: '#2a2a4a',
-    gap: 6,
-  },
-  transferBeforeRow: {
-    flexDirection: 'row',
-    alignItems: 'baseline',
-    gap: 4,
-  },
-  transferBeforeStops: {
-    fontSize: 28,
-    fontWeight: '800',
-    color: '#ffffff',
-  },
-  transferBeforeLabel: {
-    fontSize: 13,
-    color: '#8888aa',
-  },
-  transferStationRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  transferIcon: {
-    fontSize: 20,
-    color: '#a78bfa',
-  },
-  transferStationName: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: '#ffffff',
-  },
-  transferAfterText: {
-    fontSize: 13,
-    color: '#8888aa',
   },
   recentDestinationButton: {
     backgroundColor: '#0f0f2a',

--- a/src/components/JourneyTimeline.tsx
+++ b/src/components/JourneyTimeline.tsx
@@ -1,0 +1,146 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { LINE_NAMES } from '../constants/lineColors';
+import type { JourneyDisplay } from '../utils/stationRoute';
+import type { LineNumber } from '../types/station';
+
+interface JourneyTimelineProps {
+  journey: JourneyDisplay;
+  etaMinutes?: number | null;
+}
+
+export function JourneyTimeline({ journey, etaMinutes }: JourneyTimelineProps) {
+  const { segments } = journey;
+
+  return (
+    <View style={styles.container}>
+      {segments.map((segment, idx) => {
+        const isFirst = idx === 0;
+        const isLast = idx === segments.length - 1;
+        const lineName = LINE_NAMES[segment.line as LineNumber] ?? segment.line;
+
+        return (
+          <View key={idx}>
+            {isFirst && (
+              <View style={styles.stationRow}>
+                <View style={[styles.dot, styles.startDot]} />
+                <Text style={styles.stationName}>{segment.fromName}</Text>
+              </View>
+            )}
+
+            <View style={styles.segmentRow}>
+              <View style={[styles.segmentLine, { backgroundColor: segment.lineColor }]} />
+              <View style={styles.segmentInfo}>
+                <View style={[styles.lineBadge, { backgroundColor: segment.lineColor }]}>
+                  <Text style={styles.lineBadgeText}>{lineName}</Text>
+                </View>
+                <Text style={styles.stopsText}>{segment.stops}정거장</Text>
+              </View>
+            </View>
+
+            {!isLast && (
+              <View style={styles.stationRow}>
+                <Text style={styles.transferIcon}>⇄</Text>
+                <Text style={styles.transferName}>{segment.toName}</Text>
+              </View>
+            )}
+
+            {isLast && (
+              <View style={styles.stationRow}>
+                <View style={[styles.dot, styles.endDot]} />
+                <Text style={styles.stationName}>{segment.toName}</Text>
+              </View>
+            )}
+          </View>
+        );
+      })}
+
+      {etaMinutes != null && (
+        <View style={styles.etaRow}>
+          <Text style={styles.etaText}>약 {etaMinutes}분 소요</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 12,
+  },
+  stationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+  },
+  dot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    marginRight: 10,
+  },
+  startDot: {
+    backgroundColor: '#a78bfa',
+  },
+  endDot: {
+    backgroundColor: '#22c55e',
+  },
+  stationName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+  transferIcon: {
+    fontSize: 16,
+    color: '#a78bfa',
+    width: 12,
+    textAlign: 'center',
+    marginRight: 10,
+  },
+  transferName: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#a78bfa',
+  },
+  segmentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 4,
+    paddingVertical: 4,
+  },
+  segmentLine: {
+    width: 4,
+    height: 36,
+    borderRadius: 2,
+    marginRight: 14,
+  },
+  segmentInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  lineBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+  },
+  lineBadgeText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  stopsText: {
+    fontSize: 13,
+    color: '#8888aa',
+  },
+  etaRow: {
+    marginTop: 12,
+    paddingTop: 10,
+    borderTopWidth: 1,
+    borderTopColor: '#2a2a4a',
+  },
+  etaText: {
+    fontSize: 14,
+    color: '#a78bfa',
+    fontWeight: '600',
+  },
+});

--- a/src/components/__tests__/JourneyTimeline.test.tsx
+++ b/src/components/__tests__/JourneyTimeline.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { JourneyTimeline } from '../JourneyTimeline';
+import type { JourneyDisplay } from '../../utils/stationRoute';
+
+const directJourney: JourneyDisplay = {
+  segments: [
+    {
+      line: '2',
+      lineColor: '#009D3E',
+      fromName: '강남',
+      toName: '삼성',
+      stops: 2,
+    },
+  ],
+  totalStops: 2,
+};
+
+const transferJourney: JourneyDisplay = {
+  segments: [
+    {
+      line: '2',
+      lineColor: '#009D3E',
+      fromName: '강남',
+      toName: '교대',
+      stops: 1,
+    },
+    {
+      line: '3',
+      lineColor: '#EF7C1C',
+      fromName: '교대',
+      toName: '경복궁',
+      stops: 5,
+    },
+  ],
+  totalStops: 6,
+};
+
+describe('JourneyTimeline', () => {
+  it('직통 여정을 렌더링한다', () => {
+    const { getByText } = render(<JourneyTimeline journey={directJourney} />);
+    expect(getByText('강남')).toBeTruthy();
+    expect(getByText('삼성')).toBeTruthy();
+    expect(getByText('2호선')).toBeTruthy();
+    expect(getByText('2정거장')).toBeTruthy();
+  });
+
+  it('환승 여정을 렌더링한다', () => {
+    const { getByText, getAllByText } = render(
+      <JourneyTimeline journey={transferJourney} />,
+    );
+    expect(getByText('강남')).toBeTruthy();
+    expect(getByText('교대')).toBeTruthy();
+    expect(getByText('경복궁')).toBeTruthy();
+    expect(getByText('2호선')).toBeTruthy();
+    expect(getByText('3호선')).toBeTruthy();
+    expect(getByText('1정거장')).toBeTruthy();
+    expect(getByText('5정거장')).toBeTruthy();
+  });
+
+  it('ETA를 표시한다', () => {
+    const { getByText } = render(
+      <JourneyTimeline journey={directJourney} etaMinutes={15} />,
+    );
+    expect(getByText('약 15분 소요')).toBeTruthy();
+  });
+
+  it('etaMinutes가 null이면 ETA를 표시하지 않는다', () => {
+    const { queryByText } = render(
+      <JourneyTimeline journey={directJourney} etaMinutes={null} />,
+    );
+    expect(queryByText(/소요/)).toBeNull();
+  });
+
+  it('etaMinutes가 undefined이면 ETA를 표시하지 않는다', () => {
+    const { queryByText } = render(
+      <JourneyTimeline journey={directJourney} />,
+    );
+    expect(queryByText(/소요/)).toBeNull();
+  });
+
+  it('알 수 없는 노선이면 line 값을 그대로 표시한다', () => {
+    const unknownLineJourney: JourneyDisplay = {
+      segments: [
+        {
+          line: 'unknown',
+          lineColor: '#999999',
+          fromName: '역A',
+          toName: '역B',
+          stops: 1,
+        },
+      ],
+      totalStops: 1,
+    };
+    const { getByText } = render(
+      <JourneyTimeline journey={unknownLineJourney} />,
+    );
+    expect(getByText('unknown')).toBeTruthy();
+  });
+});

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,6 @@
-import { getStationsOnLine, getRemainingStops, findRoute } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, findRoute, buildJourneyDisplay, calculateETA } from '../stationRoute';
+import type { Station } from '../../types/station';
+import type { DirectRoute, TransferRoute } from '../stationRoute';
 
 describe('getStationsOnLine', () => {
   it('returns only stations on the given line, sorted by id', () => {
@@ -125,5 +127,110 @@ describe('findRoute', () => {
       const route = findRoute(line1[0].id, line9[0].id);
       expect(route?.type).toBe('transfer');
     }
+  });
+});
+
+const mockStation = (overrides: Partial<Station> = {}): Station => ({
+  id: '2-022',
+  name: '강남',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.4979,
+  lng: 127.0276,
+  ...overrides,
+});
+
+describe('buildJourneyDisplay', () => {
+  it('route가 null이면 null을 반환한다', () => {
+    expect(buildJourneyDisplay(null, mockStation(), mockStation())).toBeNull();
+  });
+
+  it('DirectRoute이면 세그먼트 1개를 반환한다', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3 };
+    const current = mockStation({ id: '2-022', name: '강남' });
+    const dest = mockStation({ id: '2-025', name: '잠실' });
+
+    const result = buildJourneyDisplay(route, current, dest);
+    expect(result).not.toBeNull();
+    expect(result!.segments).toHaveLength(1);
+    expect(result!.segments[0].fromName).toBe('강남');
+    expect(result!.segments[0].toName).toBe('잠실');
+    expect(result!.segments[0].line).toBe('2');
+    expect(result!.segments[0].lineColor).toBe('#009D3E');
+    expect(result!.segments[0].stops).toBe(3);
+    expect(result!.totalStops).toBe(3);
+  });
+
+  it('TransferRoute이면 세그먼트 2개를 반환한다', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    };
+    const current = mockStation({ name: '강남', line: '2', lineColor: '#009D3E' });
+    const dest = mockStation({ name: '경복궁', line: '3', lineColor: '#EF7C1C' });
+
+    const result = buildJourneyDisplay(route, current, dest);
+    expect(result).not.toBeNull();
+    expect(result!.segments).toHaveLength(2);
+
+    expect(result!.segments[0].fromName).toBe('강남');
+    expect(result!.segments[0].toName).toBe('교대');
+    expect(result!.segments[0].line).toBe('2');
+    expect(result!.segments[0].stops).toBe(1);
+
+    expect(result!.segments[1].fromName).toBe('교대');
+    expect(result!.segments[1].toName).toBe('경복궁');
+    expect(result!.segments[1].line).toBe('3');
+    expect(result!.segments[1].stops).toBe(5);
+
+    expect(result!.totalStops).toBe(6);
+  });
+});
+
+describe('calculateETA', () => {
+  it('DirectRoute일 때 대기시간 + 정거장*2분을 반환한다', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5 };
+    // 3분 대기 + 5*2분 = 13분
+    expect(calculateETA(3, route)).toBe(13);
+  });
+
+  it('TransferRoute일 때 대기시간 + 정거장*2분 + 환승3분을 반환한다', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    };
+    // 2분 대기 + 6*2분 + 3분 환승 = 17분
+    expect(calculateETA(2, route)).toBe(17);
+  });
+
+  it('route가 null이면 대기시간만 반환한다', () => {
+    expect(calculateETA(5, null)).toBe(5);
+  });
+});
+
+describe('buildJourneyDisplay — LINE_COLORS fallback', () => {
+  it('알 수 없는 노선이면 station의 lineColor를 사용한다', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '환승역',
+      fromLine: 'unknown1' as string,
+      toLine: 'unknown2' as string,
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    };
+    const current = mockStation({ lineColor: '#AAA' });
+    const dest = mockStation({ lineColor: '#BBB' });
+
+    const result = buildJourneyDisplay(route, current, dest);
+    expect(result!.segments[0].lineColor).toBe('#AAA');
+    expect(result!.segments[1].lineColor).toBe('#BBB');
   });
 });

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -1,5 +1,7 @@
 import stations from '../data/stations.json';
 import type { Station } from '../types/station';
+import { LINE_COLORS } from '../constants/lineColors';
+import type { LineNumber } from '../types/station';
 
 const allStations = stations as Station[];
 
@@ -18,6 +20,19 @@ export interface TransferRoute {
 }
 
 export type Route = DirectRoute | TransferRoute | null;
+
+export interface JourneySegment {
+  line: string;
+  lineColor: string;
+  fromName: string;
+  toName: string;
+  stops: number;
+}
+
+export interface JourneyDisplay {
+  segments: JourneySegment[];
+  totalStops: number;
+}
 
 export function getStationsOnLine(line: string): Station[] {
   return allStations
@@ -90,4 +105,63 @@ export function findRoute(currentId: string, destinationId: string): Route {
   }
 
   return bestRoute;
+}
+
+const MINUTES_PER_STOP = 2;
+const TRANSFER_MINUTES = 3;
+
+export function buildJourneyDisplay(
+  route: Route,
+  current: Station,
+  destination: Station,
+): JourneyDisplay | null {
+  if (!route) return null;
+
+  if (route.type === 'direct') {
+    return {
+      segments: [
+        {
+          line: current.line,
+          lineColor: current.lineColor,
+          fromName: current.name,
+          toName: destination.name,
+          stops: route.stops,
+        },
+      ],
+      totalStops: route.stops,
+    };
+  }
+
+  return {
+    segments: [
+      {
+        line: route.fromLine,
+        lineColor: LINE_COLORS[route.fromLine as LineNumber] ?? current.lineColor,
+        fromName: current.name,
+        toName: route.transferName,
+        stops: route.stopsToTransfer,
+      },
+      {
+        line: route.toLine,
+        lineColor: LINE_COLORS[route.toLine as LineNumber] ?? destination.lineColor,
+        fromName: route.transferName,
+        toName: destination.name,
+        stops: route.stopsFromTransfer,
+      },
+    ],
+    totalStops: route.stopsToTransfer + route.stopsFromTransfer,
+  };
+}
+
+export function calculateETA(nextTrainMinutes: number, route: Route): number {
+  if (!route) return nextTrainMinutes;
+
+  const totalStops =
+    route.type === 'direct'
+      ? route.stops
+      : route.stopsToTransfer + route.stopsFromTransfer;
+
+  const transferTime = route.type === 'transfer' ? TRANSFER_MINUTES : 0;
+
+  return nextTrainMinutes + totalStops * MINUTES_PER_STOP + transferTime;
 }


### PR DESCRIPTION
## Summary
- 목적지 설정 시 세로 타임라인으로 전체 여정 표시 (출발역 → 호선배지 + 정거장 수 → 환승역 → 목적지)
- 도착 예상 시간 계산 및 표시 (다음 열차 대기 + 정거장당 2분 + 환승 3분)
- 기존 인라인 route 표시를 `JourneyTimeline` 컴포넌트로 교체

## 변경 파일
- `src/utils/stationRoute.ts` — `buildJourneyDisplay`, `calculateETA` 함수 추가
- `src/components/JourneyTimeline.tsx` — 세로 타임라인 컴포넌트
- `app/(tabs)/index.tsx` — JourneyTimeline 적용 + ETA 계산
- 테스트 추가 (커버리지 100%)

Closes #58