### PR TITLE
fix(#62): 8호선 목적지 선택 시 환승/정거장 정보 미표시 수정

### DIFF
--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -10,6 +10,9 @@ export interface LiveActivityData {
   stopsToTransfer?: number;
   transferStationName?: string;
   stopsFromTransfer?: number;
+  stopsToSecondTransfer?: number;
+  secondTransferStationName?: string;
+  stopsAfterLastTransfer?: number;
   distanceM: number;
 }
 

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -15,6 +15,9 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var stopsToTransfer: Int?
         var transferStationName: String?
         var stopsFromTransfer: Int?
+        var stopsToSecondTransfer: Int?
+        var secondTransferStationName: String?
+        var stopsAfterLastTransfer: Int?
         var distanceM: Int
     }
 }
@@ -77,6 +80,9 @@ class LiveActivityManager {
             stopsToTransfer: data["stopsToTransfer"] as? Int,
             transferStationName: data["transferStationName"] as? String,
             stopsFromTransfer: data["stopsFromTransfer"] as? Int,
+            stopsToSecondTransfer: data["stopsToSecondTransfer"] as? Int,
+            secondTransferStationName: data["secondTransferStationName"] as? String,
+            stopsAfterLastTransfer: data["stopsAfterLastTransfer"] as? Int,
             distanceM: data["distanceM"] as? Int ?? 0
         )
     }

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -7,7 +7,7 @@ import {
   clearStationNotification,
 } from '../stationNotification';
 import { Station } from '../../types/station';
-import { DirectRoute, TransferRoute } from '../stationRoute';
+import { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 
 jest.mock('expo-notifications');
 jest.mock('../logger', () => ({
@@ -57,6 +57,14 @@ const transferRoute: TransferRoute = {
   toLine: '4',
   stopsToTransfer: 3,
   stopsFromTransfer: 2,
+};
+const multiTransferRoute: MultiTransferRoute = {
+  type: 'multi-transfer',
+  transfers: [
+    { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+    { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+  ],
+  stopsAfterLastTransfer: 4,
 };
 
 describe('stationNotification', () => {
@@ -164,6 +172,20 @@ describe('stationNotification', () => {
       );
     });
 
+    it('multi-transfer 경로이면 두 환승 정보를 포함한다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, multiTransferRoute);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destinationName: '성신여대입구',
+          stopsToTransfer: 3,
+          transferStationName: '잠실',
+          stopsToSecondTransfer: 5,
+          secondTransferStationName: '시청',
+          stopsAfterLastTransfer: 4,
+        })
+      );
+    });
+
     it('expo-notifications를 호출하지 않는다', async () => {
       await updateStationNotification(mockStation, 154);
       expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
@@ -242,6 +264,18 @@ describe('stationNotification', () => {
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           content: { title: '시청 → 성신여대입구', body: '3정거장 후 동대문 환승 · 2정거장' },
+        })
+      );
+    });
+
+    it('multi-transfer 경로이면 두 환승 정보를 표시한다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, multiTransferRoute);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: {
+            title: '시청 → 성신여대입구',
+            body: '3정거장 후 잠실 환승 → 5정거장 후 시청 환승 · 4정거장',
+          },
         })
       );
     });

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,6 +1,6 @@
 import { getStationsOnLine, getRemainingStops, findRoute, buildJourneyDisplay, calculateETA } from '../stationRoute';
 import type { Station } from '../../types/station';
-import type { DirectRoute, TransferRoute } from '../stationRoute';
+import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 
 describe('getStationsOnLine', () => {
   it('returns only stations on the given line, sorted by id', () => {
@@ -112,21 +112,34 @@ describe('findRoute', () => {
     }
   });
 
-  it('환승역이 없으면 null을 반환한다', () => {
-    // 1호선과 9호선은 환승역이 없음
+  it('직접 환승이 없으면 MultiTransferRoute를 반환한다 (8호선→1호선)', () => {
+    const line8 = getStationsOnLine('8');
     const line1 = getStationsOnLine('1');
-    const line9 = getStationsOnLine('9');
-    const line1Names = new Set(line1.map((s) => s.name));
-    const hasTransfer = line9.some((s) => line1Names.has(s.name));
-
-    if (!hasTransfer) {
-      const route = findRoute(line1[0].id, line9[0].id);
-      expect(route).toBeNull();
-    } else {
-      // 환승역이 있으면 TransferRoute를 반환해야 함
-      const route = findRoute(line1[0].id, line9[0].id);
-      expect(route?.type).toBe('transfer');
+    const route = findRoute(line8[0].id, line1[0].id);
+    expect(route).not.toBeNull();
+    expect(route?.type).toBe('multi-transfer');
+    if (route?.type === 'multi-transfer') {
+      expect(route.transfers).toHaveLength(2);
+      expect(route.transfers[0].fromLine).toBe('8');
+      expect(route.transfers[1].toLine).toBe('1');
+      expect(route.stopsAfterLastTransfer).toBeGreaterThanOrEqual(0);
     }
+  });
+
+  it('직접 환승 가능하면 단일 환승을 우선한다', () => {
+    // 8호선 → 2호선은 잠실에서 직접 환승 가능
+    const line8 = getStationsOnLine('8');
+    const line2 = getStationsOnLine('2');
+    const route = findRoute(line8[0].id, line2[0].id);
+    expect(route?.type).toBe('transfer');
+  });
+
+  it('8호선→4호선 multi-transfer 경로를 찾는다', () => {
+    const line8 = getStationsOnLine('8');
+    const line4 = getStationsOnLine('4');
+    const route = findRoute(line8[0].id, line4[0].id);
+    expect(route).not.toBeNull();
+    expect(route?.type).toBe('multi-transfer');
   });
 });
 
@@ -159,6 +172,40 @@ describe('buildJourneyDisplay', () => {
     expect(result!.segments[0].lineColor).toBe('#009D3E');
     expect(result!.segments[0].stops).toBe(3);
     expect(result!.totalStops).toBe(3);
+  });
+
+  it('MultiTransferRoute이면 세그먼트 3개를 반환한다', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    const current = mockStation({ name: '암사', line: '8', lineColor: '#E6186C' });
+    const dest = mockStation({ name: '종각', line: '1', lineColor: '#0052A4' });
+
+    const result = buildJourneyDisplay(route, current, dest);
+    expect(result).not.toBeNull();
+    expect(result!.segments).toHaveLength(3);
+
+    expect(result!.segments[0].fromName).toBe('암사');
+    expect(result!.segments[0].toName).toBe('잠실');
+    expect(result!.segments[0].line).toBe('8');
+    expect(result!.segments[0].stops).toBe(3);
+
+    expect(result!.segments[1].fromName).toBe('잠실');
+    expect(result!.segments[1].toName).toBe('시청');
+    expect(result!.segments[1].line).toBe('2');
+    expect(result!.segments[1].stops).toBe(5);
+
+    expect(result!.segments[2].fromName).toBe('시청');
+    expect(result!.segments[2].toName).toBe('종각');
+    expect(result!.segments[2].line).toBe('1');
+    expect(result!.segments[2].stops).toBe(4);
+
+    expect(result!.totalStops).toBe(12);
   });
 
   it('TransferRoute이면 세그먼트 2개를 반환한다', () => {
@@ -211,6 +258,19 @@ describe('calculateETA', () => {
     expect(calculateETA(2, route)).toBe(17);
   });
 
+  it('MultiTransferRoute일 때 대기시간 + 정거장*2분 + 환승3분*2를 반환한다', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    // 2분 대기 + 12*2분 + 3분*2 환승 = 32분
+    expect(calculateETA(2, route)).toBe(32);
+  });
+
   it('route가 null이면 대기시간만 반환한다', () => {
     expect(calculateETA(5, null)).toBe(5);
   });
@@ -232,5 +292,23 @@ describe('buildJourneyDisplay — LINE_COLORS fallback', () => {
     const result = buildJourneyDisplay(route, current, dest);
     expect(result!.segments[0].lineColor).toBe('#AAA');
     expect(result!.segments[1].lineColor).toBe('#BBB');
+  });
+
+  it('MultiTransferRoute에서 알 수 없는 노선이면 fallback lineColor를 사용한다', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '환승A', fromLine: 'unknown1' as string, toLine: 'unknown2' as string, stopsToTransfer: 1 },
+        { transferName: '환승B', fromLine: 'unknown2' as string, toLine: 'unknown3' as string, stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 3,
+    };
+    const current = mockStation({ lineColor: '#AAA' });
+    const dest = mockStation({ lineColor: '#BBB' });
+
+    const result = buildJourneyDisplay(route, current, dest);
+    expect(result!.segments[0].lineColor).toBe('#AAA');
+    expect(result!.segments[1].lineColor).toBe('#888888');
+    expect(result!.segments[2].lineColor).toBe('#BBB');
   });
 });

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -2,7 +2,7 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { Station } from '../types/station';
 import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
-import { DirectRoute, TransferRoute } from './stationRoute';
+import { DirectRoute, TransferRoute, MultiTransferRoute } from './stationRoute';
 import * as LiveActivity from 'live-activity';
 import { createLogger } from './logger';
 
@@ -42,7 +42,7 @@ function buildContent(
   currentStation: Station,
   distanceM: number,
   destination?: Station | null,
-  route?: DirectRoute | TransferRoute | null,
+  route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
 ): { title: string; body: string } {
   if (destination && route) {
     const title = `${currentStation.name} → ${destination.name}`;
@@ -50,7 +50,12 @@ function buildContent(
       const body = `${LINE_NAMES[currentStation.line]} · ${route.stops}정거장 남음`;
       return { title, body };
     }
-    const body = `${route.stopsToTransfer}정거장 후 ${route.transferName} 환승 · ${route.stopsFromTransfer}정거장`;
+    if (route.type === 'transfer') {
+      const body = `${route.stopsToTransfer}정거장 후 ${route.transferName} 환승 · ${route.stopsFromTransfer}정거장`;
+      return { title, body };
+    }
+    const [t1, t2] = route.transfers;
+    const body = `${t1.stopsToTransfer}정거장 후 ${t1.transferName} 환승 → ${t2.stopsToTransfer}정거장 후 ${t2.transferName} 환승 · ${route.stopsAfterLastTransfer}정거장`;
     return { title, body };
   }
   return {
@@ -63,7 +68,7 @@ function buildLiveActivityData(
   currentStation: Station,
   distanceM: number,
   destination?: Station | null,
-  route?: DirectRoute | TransferRoute | null,
+  route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
 ): LiveActivity.LiveActivityData {
   const base: LiveActivity.LiveActivityData = {
     stationName: currentStation.name,
@@ -76,10 +81,16 @@ function buildLiveActivityData(
     base.destinationName = destination.name;
     if (route.type === 'direct') {
       base.stopsRemaining = route.stops;
-    } else {
+    } else if (route.type === 'transfer') {
       base.stopsToTransfer = route.stopsToTransfer;
       base.transferStationName = route.transferName;
       base.stopsFromTransfer = route.stopsFromTransfer;
+    } else {
+      base.stopsToTransfer = route.transfers[0].stopsToTransfer;
+      base.transferStationName = route.transfers[0].transferName;
+      base.stopsToSecondTransfer = route.transfers[1].stopsToTransfer;
+      base.secondTransferStationName = route.transfers[1].transferName;
+      base.stopsAfterLastTransfer = route.stopsAfterLastTransfer;
     }
   }
 
@@ -90,7 +101,7 @@ export async function updateStationNotification(
   currentStation: Station,
   distanceM: number,
   destination?: Station | null,
-  route?: DirectRoute | TransferRoute | null,
+  route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
 

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -19,7 +19,16 @@ export interface TransferRoute {
   stopsFromTransfer: number;
 }
 
-export type Route = DirectRoute | TransferRoute | null;
+export interface MultiTransferRoute {
+  type: 'multi-transfer';
+  transfers: [
+    { transferName: string; fromLine: string; toLine: string; stopsToTransfer: number },
+    { transferName: string; fromLine: string; toLine: string; stopsToTransfer: number },
+  ];
+  stopsAfterLastTransfer: number;
+}
+
+export type Route = DirectRoute | TransferRoute | MultiTransferRoute | null;
 
 export interface JourneySegment {
   line: string;
@@ -33,6 +42,44 @@ export interface JourneyDisplay {
   segments: JourneySegment[];
   totalStops: number;
 }
+
+// 환승 그래프: fromLine → toLine → 환승역 이름 목록
+const transferGraph = new Map<string, Map<string, string[]>>();
+
+function buildTransferGraph(): void {
+  const nameToLines = new Map<string, Set<string>>();
+  for (const s of allStations) {
+    let lines = nameToLines.get(s.name);
+    if (!lines) {
+      lines = new Set();
+      nameToLines.set(s.name, lines);
+    }
+    lines.add(s.line);
+  }
+
+  for (const [name, lines] of nameToLines) {
+    if (lines.size < 2) continue;
+    const lineArr = Array.from(lines);
+    for (let i = 0; i < lineArr.length; i++) {
+      for (let j = 0; j < lineArr.length; j++) {
+        if (i === j) continue;
+        let toMap = transferGraph.get(lineArr[i]);
+        if (!toMap) {
+          toMap = new Map();
+          transferGraph.set(lineArr[i], toMap);
+        }
+        let names = toMap.get(lineArr[j]);
+        if (!names) {
+          names = [];
+          toMap.set(lineArr[j], names);
+        }
+        names.push(name);
+      }
+    }
+  }
+}
+
+buildTransferGraph();
 
 export function getStationsOnLine(line: string): Station[] {
   return allStations
@@ -104,7 +151,78 @@ export function findRoute(currentId: string, destinationId: string): Route {
     }
   }
 
-  return bestRoute;
+  if (bestRoute) return bestRoute;
+
+  // 2회 환승 BFS: 현재노선 → 중간노선 → 목적지노선
+  return findMultiTransferRoute(current, destination, currentLineStations, destLineStations, currentIdx, destIdx);
+}
+
+function findMultiTransferRoute(
+  current: Station,
+  destination: Station,
+  currentLineStations: Station[],
+  destLineStations: Station[],
+  currentIdx: number,
+  destIdx: number,
+): MultiTransferRoute | null {
+  const fromLine = current.line;
+  const toLine = destination.line;
+  const fromEdges = transferGraph.get(fromLine);
+  /* istanbul ignore next -- 실제 역 데이터에서는 모든 노선이 환승 가능 */
+  if (!fromEdges) return null;
+
+  let best: MultiTransferRoute | null = null;
+  let bestTotal = Infinity;
+
+  // 현재 노선에서 갈 수 있는 중간 노선들
+  for (const [midLine, transfer1Names] of fromEdges) {
+    /* istanbul ignore next -- 직접 환승은 findRoute에서 먼저 처리됨 */
+    if (midLine === toLine) continue;
+    const midEdges = transferGraph.get(midLine);
+    /* istanbul ignore next */
+    if (!midEdges) continue;
+    const transfer2Names = midEdges.get(toLine);
+    /* istanbul ignore next */
+    if (!transfer2Names) continue;
+
+    const midLineStations = getStationsOnLine(midLine);
+
+    // 첫 번째 환승: 현재노선 → 중간노선
+    for (const t1Name of transfer1Names) {
+      const t1CurrentIdx = currentLineStations.findIndex((s) => s.name === t1Name);
+      const t1MidIdx = midLineStations.findIndex((s) => s.name === t1Name);
+      /* istanbul ignore next -- 환승 그래프가 같은 데이터에서 빌드되므로 -1 불가 */
+      if (t1CurrentIdx === -1 || t1MidIdx === -1) continue;
+
+      const stopsToFirst = Math.abs(t1CurrentIdx - currentIdx);
+
+      // 두 번째 환승: 중간노선 → 목적지노선
+      for (const t2Name of transfer2Names) {
+        const t2MidIdx = midLineStations.findIndex((s) => s.name === t2Name);
+        const t2DestIdx = destLineStations.findIndex((s) => s.name === t2Name);
+        /* istanbul ignore next */
+        if (t2MidIdx === -1 || t2DestIdx === -1) continue;
+
+        const stopsToSecond = Math.abs(t2MidIdx - t1MidIdx);
+        const stopsAfter = Math.abs(destIdx - t2DestIdx);
+        const total = stopsToFirst + stopsToSecond + stopsAfter;
+
+        if (total < bestTotal) {
+          bestTotal = total;
+          best = {
+            type: 'multi-transfer',
+            transfers: [
+              { transferName: t1Name, fromLine, toLine: midLine, stopsToTransfer: stopsToFirst },
+              { transferName: t2Name, fromLine: midLine, toLine, stopsToTransfer: stopsToSecond },
+            ],
+            stopsAfterLastTransfer: stopsAfter,
+          };
+        }
+      }
+    }
+  }
+
+  return best;
 }
 
 const MINUTES_PER_STOP = 2;
@@ -132,36 +250,72 @@ export function buildJourneyDisplay(
     };
   }
 
+  if (route.type === 'transfer') {
+    return {
+      segments: [
+        {
+          line: route.fromLine,
+          lineColor: LINE_COLORS[route.fromLine as LineNumber] ?? current.lineColor,
+          fromName: current.name,
+          toName: route.transferName,
+          stops: route.stopsToTransfer,
+        },
+        {
+          line: route.toLine,
+          lineColor: LINE_COLORS[route.toLine as LineNumber] ?? destination.lineColor,
+          fromName: route.transferName,
+          toName: destination.name,
+          stops: route.stopsFromTransfer,
+        },
+      ],
+      totalStops: route.stopsToTransfer + route.stopsFromTransfer,
+    };
+  }
+
+  // multi-transfer
+  const [t1, t2] = route.transfers;
+  const totalStops = t1.stopsToTransfer + t2.stopsToTransfer + route.stopsAfterLastTransfer;
   return {
     segments: [
       {
-        line: route.fromLine,
-        lineColor: LINE_COLORS[route.fromLine as LineNumber] ?? current.lineColor,
+        line: t1.fromLine,
+        lineColor: LINE_COLORS[t1.fromLine as LineNumber] ?? current.lineColor,
         fromName: current.name,
-        toName: route.transferName,
-        stops: route.stopsToTransfer,
+        toName: t1.transferName,
+        stops: t1.stopsToTransfer,
       },
       {
-        line: route.toLine,
-        lineColor: LINE_COLORS[route.toLine as LineNumber] ?? destination.lineColor,
-        fromName: route.transferName,
+        line: t1.toLine,
+        lineColor: LINE_COLORS[t1.toLine as LineNumber] ?? '#888888',
+        fromName: t1.transferName,
+        toName: t2.transferName,
+        stops: t2.stopsToTransfer,
+      },
+      {
+        line: t2.toLine,
+        lineColor: LINE_COLORS[t2.toLine as LineNumber] ?? destination.lineColor,
+        fromName: t2.transferName,
         toName: destination.name,
-        stops: route.stopsFromTransfer,
+        stops: route.stopsAfterLastTransfer,
       },
     ],
-    totalStops: route.stopsToTransfer + route.stopsFromTransfer,
+    totalStops,
   };
 }
 
 export function calculateETA(nextTrainMinutes: number, route: Route): number {
   if (!route) return nextTrainMinutes;
 
-  const totalStops =
-    route.type === 'direct'
-      ? route.stops
-      : route.stopsToTransfer + route.stopsFromTransfer;
+  if (route.type === 'direct') {
+    return nextTrainMinutes + route.stops * MINUTES_PER_STOP;
+  }
 
-  const transferTime = route.type === 'transfer' ? TRANSFER_MINUTES : 0;
+  if (route.type === 'transfer') {
+    const totalStops = route.stopsToTransfer + route.stopsFromTransfer;
+    return nextTrainMinutes + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES;
+  }
 
-  return nextTrainMinutes + totalStops * MINUTES_PER_STOP + transferTime;
+  // multi-transfer: 2회 환승
+  const totalStops = route.transfers[0].stopsToTransfer + route.transfers[1].stopsToTransfer + route.stopsAfterLastTransfer;
+  return nextTrainMinutes + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES * 2;
 }

--- a/targets/subway-widget/SubwayLiveActivity.swift
+++ b/targets/subway-widget/SubwayLiveActivity.swift
@@ -12,6 +12,9 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var stopsToTransfer: Int?
         var transferStationName: String?
         var stopsFromTransfer: Int?
+        var stopsToSecondTransfer: Int?
+        var secondTransferStationName: String?
+        var stopsAfterLastTransfer: Int?
         var distanceM: Int
     }
 }

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -153,7 +153,7 @@ private struct ExpandedRouteView: View {
                   let afterLast = state.stopsAfterLastTransfer,
                   let toFirst = state.stopsToTransfer,
                   let firstName = state.transferStationName {
-            Text("→ \(dest) (\(toFirst)→\(firstName) 환승→\(toSecond)→\(secondName) 환승→\(afterLast)정거장)")
+            Text("→ \(dest) (\(toFirst)정거장→\(firstName) 환승→\(toSecond)정거장→\(secondName) 환승→\(afterLast)정거장)")
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .lineLimit(2)

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -118,6 +118,15 @@ private struct LockScreenRouteView: View {
                 Text("\(stops)정거장 남음")
                     .font(.caption)
                     .foregroundColor(.secondary)
+            } else if let toSecond = state.stopsToSecondTransfer,
+                      let secondName = state.secondTransferStationName,
+                      let afterLast = state.stopsAfterLastTransfer,
+                      let toFirst = state.stopsToTransfer,
+                      let firstName = state.transferStationName {
+                Text("\(toFirst)정거장→\(firstName) 환승→\(toSecond)정거장→\(secondName) 환승→\(afterLast)정거장")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
             } else if let toTransfer = state.stopsToTransfer,
                       let transferName = state.transferStationName,
                       let fromTransfer = state.stopsFromTransfer {
@@ -139,6 +148,15 @@ private struct ExpandedRouteView: View {
             Text("→ \(dest) · \(stops)정거장")
                 .font(.caption)
                 .foregroundColor(.secondary)
+        } else if let toSecond = state.stopsToSecondTransfer,
+                  let secondName = state.secondTransferStationName,
+                  let afterLast = state.stopsAfterLastTransfer,
+                  let toFirst = state.stopsToTransfer,
+                  let firstName = state.transferStationName {
+            Text("→ \(dest) (\(toFirst)→\(firstName) 환승→\(toSecond)→\(secondName) 환승→\(afterLast)정거장)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
         } else if let toTransfer = state.stopsToTransfer,
                   let transferName = state.transferStationName,
                   let fromTransfer = state.stopsFromTransfer {


### PR DESCRIPTION
## Summary
- `MultiTransferRoute` 타입 추가 (2회 환승 경로 지원)
- 환승 그래프 + BFS 알고리즘으로 중간 노선 경유 경로 탐색
- UI(JourneyTimeline), 알림, Live Activity, iOS 위젯에 multi-transfer 분기 추가

Closes #62