### PR TITLE
fix(#62): 2회 환승 경로 지원 및 JourneyTimeline UI 개선

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -163,9 +163,12 @@ export default function HomeScreen() {
                   <View style={styles.destinationInfo}>
                     <Text style={styles.destinationArrow}>→</Text>
                     <Text style={styles.destinationName}>{destination.name}</Text>
+                    {etaMinutes != null && (
+                      <Text style={styles.etaInline}>약 {etaMinutes}분 소요</Text>
+                    )}
                   </View>
                   {journey && (
-                    <JourneyTimeline journey={journey} etaMinutes={etaMinutes} />
+                    <JourneyTimeline journey={journey} />
                   )}
                 </View>
               ) : null}
@@ -355,9 +358,16 @@ const styles = StyleSheet.create({
     marginRight: 12,
   },
   destinationName: {
-    fontSize: 20,
-    fontWeight: '700',
+    fontSize: 26,
+    fontWeight: '800',
     color: '#ffffff',
+    flexShrink: 1,
+  },
+  etaInline: {
+    fontSize: 14,
+    color: '#a78bfa',
+    fontWeight: '600',
+    marginLeft: 10,
   },
   recentDestinationButton: {
     backgroundColor: '#0f0f2a',

--- a/src/components/JourneyTimeline.tsx
+++ b/src/components/JourneyTimeline.tsx
@@ -5,10 +5,9 @@ import type { LineNumber } from '../types/station';
 
 interface JourneyTimelineProps {
   journey: JourneyDisplay;
-  etaMinutes?: number | null;
 }
 
-export function JourneyTimeline({ journey, etaMinutes }: JourneyTimelineProps) {
+export function JourneyTimeline({ journey }: JourneyTimelineProps) {
   const { segments } = journey;
 
   return (
@@ -22,7 +21,7 @@ export function JourneyTimeline({ journey, etaMinutes }: JourneyTimelineProps) {
           <View key={idx}>
             {isFirst && (
               <View style={styles.stationRow}>
-                <View style={[styles.dot, styles.startDot]} />
+                <View style={[styles.dot, { backgroundColor: segment.lineColor }]} testID="start-dot" />
                 <Text style={styles.stationName}>{segment.fromName}</Text>
               </View>
             )}
@@ -46,7 +45,7 @@ export function JourneyTimeline({ journey, etaMinutes }: JourneyTimelineProps) {
 
             {isLast && (
               <View style={styles.stationRow}>
-                <View style={[styles.dot, styles.endDot]} />
+                <View style={[styles.dot, { backgroundColor: segment.lineColor }]} testID="end-dot" />
                 <Text style={styles.stationName}>{segment.toName}</Text>
               </View>
             )}
@@ -54,11 +53,6 @@ export function JourneyTimeline({ journey, etaMinutes }: JourneyTimelineProps) {
         );
       })}
 
-      {etaMinutes != null && (
-        <View style={styles.etaRow}>
-          <Text style={styles.etaText}>약 {etaMinutes}분 소요</Text>
-        </View>
-      )}
     </View>
   );
 }
@@ -77,12 +71,6 @@ const styles = StyleSheet.create({
     height: 12,
     borderRadius: 6,
     marginRight: 10,
-  },
-  startDot: {
-    backgroundColor: '#a78bfa',
-  },
-  endDot: {
-    backgroundColor: '#22c55e',
   },
   stationName: {
     fontSize: 16,
@@ -131,16 +119,5 @@ const styles = StyleSheet.create({
   stopsText: {
     fontSize: 13,
     color: '#8888aa',
-  },
-  etaRow: {
-    marginTop: 12,
-    paddingTop: 10,
-    borderTopWidth: 1,
-    borderTopColor: '#2a2a4a',
-  },
-  etaText: {
-    fontSize: 14,
-    color: '#a78bfa',
-    fontWeight: '600',
   },
 });

--- a/src/components/__tests__/JourneyTimeline.test.tsx
+++ b/src/components/__tests__/JourneyTimeline.test.tsx
@@ -58,25 +58,28 @@ describe('JourneyTimeline', () => {
     expect(getByText('5정거장')).toBeTruthy();
   });
 
-  it('ETA를 표시한다', () => {
-    const { getByText } = render(
-      <JourneyTimeline journey={directJourney} etaMinutes={15} />,
+  it('출발역 dot에 노선 색상을 적용한다', () => {
+    const { getByTestId } = render(<JourneyTimeline journey={directJourney} />);
+    const startDot = getByTestId('start-dot');
+    expect(startDot.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#009D3E' })]),
     );
-    expect(getByText('약 15분 소요')).toBeTruthy();
   });
 
-  it('etaMinutes가 null이면 ETA를 표시하지 않는다', () => {
-    const { queryByText } = render(
-      <JourneyTimeline journey={directJourney} etaMinutes={null} />,
+  it('도착역 dot에 노선 색상을 적용한다', () => {
+    const { getByTestId } = render(<JourneyTimeline journey={directJourney} />);
+    const endDot = getByTestId('end-dot');
+    expect(endDot.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#009D3E' })]),
     );
-    expect(queryByText(/소요/)).toBeNull();
   });
 
-  it('etaMinutes가 undefined이면 ETA를 표시하지 않는다', () => {
-    const { queryByText } = render(
-      <JourneyTimeline journey={directJourney} />,
+  it('환승 시 도착역 dot에 마지막 세그먼트 노선 색상을 적용한다', () => {
+    const { getByTestId } = render(<JourneyTimeline journey={transferJourney} />);
+    const endDot = getByTestId('end-dot');
+    expect(endDot.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#EF7C1C' })]),
     );
-    expect(queryByText(/소요/)).toBeNull();
   });
 
   it('알 수 없는 노선이면 line 값을 그대로 표시한다', () => {


### PR DESCRIPTION
## Summary
- 2회 환승 경로 탐색 지원 (`MultiTransferRoute`) — `stationRoute.ts`에 `findMultiTransferRoute` 추가
- `ExpandedRouteView` multi-transfer 텍스트에 '정거장' 단위 추가
- JourneyTimeline 출발/도착역 dot을 해당 노선 색상으로 표시
- 목적지 이름 폰트 확대 + ETA를 목적지 옆에 인라인 표시

## Test plan
- [x] `npm test` 커버리지 100% 통과
- [x] `npm run type-check` 통과
- [x] 코드 리뷰 완료 (크리티컬 이슈 없음)

Closes #62