### PR TITLE
feat(#67): 도착 정보 API fallback 및 정적 ETA 계산

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
-import { findRoute, buildJourneyDisplay, calculateETA } from '../../src/utils/stationRoute';
+import { findRoute, buildJourneyDisplay, calculateETA, calculateStaticETA } from '../../src/utils/stationRoute';
 import { JourneyTimeline } from '../../src/components/JourneyTimeline';
 import { initStationNotification, updateStationNotification, clearStationNotification } from '../../src/utils/stationNotification';
 import { createLogger } from '../../src/utils/logger';
@@ -15,7 +15,7 @@ const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
   const { result, userLocation, loading, error, permissionDenied, refresh } = useNearestStation();
-  const { arrival } = useArrivalInfo(result?.station.name ?? null);
+  const { arrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(result?.station.name ?? null);
   const { addFavorite, removeFavorite, isFavorite, loadFavorites, destination, setDestination, recentDestination, setRecentDestination } = useAppStore();
   const [pickerVisible, setPickerVisible] = useState(false);
   const [arrivedBanner, setArrivedBanner] = useState(false);
@@ -32,6 +32,8 @@ export default function HomeScreen() {
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
     ? calculateETA(nextTrainMinutes, route)
     : null;
+  const staticEtaMinutes = route ? calculateStaticETA(route) : null;
+  const displayEta = (etaMinutes !== null && !arrivalIsMock) ? etaMinutes : staticEtaMinutes;
 
   useEffect(() => {
     loadFavorites();
@@ -163,8 +165,8 @@ export default function HomeScreen() {
                   <View style={styles.destinationInfo}>
                     <Text style={styles.destinationArrow}>→</Text>
                     <Text style={styles.destinationName}>{destination.name}</Text>
-                    {etaMinutes != null && (
-                      <Text style={styles.etaInline}>약 {etaMinutes}분 소요</Text>
+                    {displayEta != null && (
+                      <Text style={styles.etaInline}>약 {displayEta}분 소요{arrivalIsMock ? ' (예상)' : ''}</Text>
                     )}
                   </View>
                   {journey && (
@@ -206,13 +208,21 @@ export default function HomeScreen() {
               ) : null}
             </View>
 
-            {arrival && (
-              <View style={styles.arrivalSection}>
-                <Text style={styles.sectionTitle}>열차 도착 정보</Text>
-                <ArrivalRow label="상행" items={arrival.up} />
-                <ArrivalRow label="하행" items={arrival.down} />
-              </View>
-            )}
+            <View style={styles.arrivalSection}>
+              <Text style={styles.sectionTitle}>열차 도착 정보</Text>
+              {arrivalLoading && !arrival && (
+                <Text style={styles.arrivalItem}>불러오는 중...</Text>
+              )}
+              {arrivalIsMock && (
+                <Text style={styles.mockNotice}>실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다</Text>
+              )}
+              {arrival && (
+                <>
+                  <ArrivalRow label="상행" items={arrival.up} />
+                  <ArrivalRow label="하행" items={arrival.down} />
+                </>
+              )}
+            </View>
           </>
         ) : (
           <View style={styles.center}>
@@ -249,17 +259,20 @@ function ArrivalRow({
   label: string;
   items: { destination: string; arrivalMinutes: number }[];
 }) {
-  if (items.length === 0) return null;
   return (
     <View style={styles.arrivalRow}>
       <Text style={styles.arrivalLabel}>{label}</Text>
       <View>
-        {items.map((item, idx) => (
-          <Text key={idx} style={styles.arrivalItem}>
-            {item.destination ? `${item.destination} · ` : ''}
-            {item.arrivalMinutes === 0 ? '곧 도착' : `${item.arrivalMinutes}분 후`}
-          </Text>
-        ))}
+        {items.length === 0 ? (
+          <Text style={styles.arrivalItem}>도착 정보 없음</Text>
+        ) : (
+          items.map((item, idx) => (
+            <Text key={idx} style={styles.arrivalItem}>
+              {item.destination ? `${item.destination} · ` : ''}
+              {item.arrivalMinutes === 0 ? '곧 도착' : `${item.arrivalMinutes}분 후`}
+            </Text>
+          ))
+        )}
       </View>
     </View>
   );
@@ -426,6 +439,11 @@ const styles = StyleSheet.create({
     backgroundColor: '#16213e',
     borderRadius: 16,
     padding: 20,
+  },
+  mockNotice: {
+    fontSize: 12,
+    color: '#ff9f43',
+    marginBottom: 8,
   },
   sectionTitle: {
     fontSize: 14,

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -1,4 +1,4 @@
-import { fetchArrivalInfo } from '../arrivalApi';
+import { fetchArrivalInfo, MOCK_ARRIVALS } from '../arrivalApi';
 
 describe('fetchArrivalInfo', () => {
   beforeEach(() => {
@@ -15,6 +15,7 @@ describe('fetchArrivalInfo', () => {
     expect(result.up[0]).toHaveProperty('destination');
     expect(result.up[0]).toHaveProperty('arrivalMinutes');
     expect(result.up[0]).toHaveProperty('trainCode');
+    expect(result.isMock).toBe(true);
   });
 
   it('API 키가 있으면 fetch를 호출한다', async () => {
@@ -40,11 +41,12 @@ describe('fetchArrivalInfo', () => {
     expect(result.up).toHaveLength(2);
     expect(result.down).toHaveLength(2);
     expect(result.up[0].arrivalMinutes).toBe(2); // 120초 → 2분
+    expect(result.isMock).toBeUndefined();
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
 
-  it('API 응답이 실패하면 에러를 던진다', async () => {
+  it('API 응답이 실패하면 Mock 데이터를 반환한다', async () => {
     process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
 
     global.fetch = jest.fn().mockResolvedValue({
@@ -52,12 +54,30 @@ describe('fetchArrivalInfo', () => {
       status: 500,
     } as Response);
 
-    await expect(fetchArrivalInfo('강남')).rejects.toThrow('도착 정보 API 오류: 500');
+    const result = await fetchArrivalInfo('강남');
+
+    expect(result.up.length).toBeGreaterThan(0);
+    expect(result.down.length).toBeGreaterThan(0);
+    expect(result.isMock).toBe(true);
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
 
-  it('realtimeArrivalList가 없으면 빈 배열을 반환한다', async () => {
+  it('fetch가 네트워크 오류를 발생시키면 Mock 데이터를 반환한다', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    const result = await fetchArrivalInfo('강남');
+
+    expect(result.up.length).toBeGreaterThan(0);
+    expect(result.down.length).toBeGreaterThan(0);
+    expect(result.isMock).toBe(true);
+
+    delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
+  it('realtimeArrivalList가 없으면 Mock 데이터를 반환한다', async () => {
     process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
 
     global.fetch = jest.fn().mockResolvedValue({
@@ -67,10 +87,17 @@ describe('fetchArrivalInfo', () => {
 
     const result = await fetchArrivalInfo('강남');
 
-    expect(result.up).toHaveLength(0);
-    expect(result.down).toHaveLength(0);
+    expect(result.up.length).toBeGreaterThan(0);
+    expect(result.down.length).toBeGreaterThan(0);
+    expect(result.isMock).toBe(true);
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
+  it('MOCK_ARRIVALS가 export 된다', () => {
+    expect(MOCK_ARRIVALS).toBeDefined();
+    expect(MOCK_ARRIVALS.up.length).toBeGreaterThan(0);
+    expect(MOCK_ARRIVALS.down.length).toBeGreaterThan(0);
   });
 
   it('arrivalMinutes가 0초이면 0분을 반환한다', async () => {

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -7,9 +7,10 @@ export interface ArrivalInfo {
 export interface StationArrival {
   up: ArrivalInfo[];
   down: ArrivalInfo[];
+  isMock?: boolean;
 }
 
-const MOCK_ARRIVALS: StationArrival = {
+export const MOCK_ARRIVALS: StationArrival = {
   up: [
     { destination: '상행 종착역', arrivalMinutes: 2, trainCode: 'UP-001' },
     { destination: '상행 종착역', arrivalMinutes: 8, trainCode: 'UP-002' },
@@ -25,34 +26,42 @@ export async function fetchArrivalInfo(stationName: string): Promise<StationArri
 
   if (!apiKey) {
     // API 키 없을 때 Mock 데이터 반환
-    return MOCK_ARRIVALS;
+    return { ...MOCK_ARRIVALS, isMock: true };
   }
 
-  const url = `http://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/10/${encodeURIComponent(stationName)}`;
+  try {
+    const url = `https://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/10/${encodeURIComponent(stationName)}`;
 
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`도착 정보 API 오류: ${response.status}`);
-  }
-
-  const data = await response.json();
-  const items: any[] = data.realtimeArrivalList ?? [];
-
-  const up: ArrivalInfo[] = [];
-  const down: ArrivalInfo[] = [];
-
-  for (const item of items) {
-    const info: ArrivalInfo = {
-      destination: item.trainLineNm ?? '',
-      arrivalMinutes: Math.max(0, Math.floor((item.barvlDt ?? 0) / 60)),
-      trainCode: item.btrainNo ?? '',
-    };
-    if (item.updnLine === '상행' || item.updnLine === '내선') {
-      up.push(info);
-    } else {
-      down.push(info);
+    const response = await fetch(url);
+    if (!response.ok) {
+      return { ...MOCK_ARRIVALS, isMock: true };
     }
-  }
 
-  return { up: up.slice(0, 2), down: down.slice(0, 2) };
+    const data = await response.json();
+    const items: any[] = data.realtimeArrivalList ?? [];
+
+    const up: ArrivalInfo[] = [];
+    const down: ArrivalInfo[] = [];
+
+    for (const item of items) {
+      const info: ArrivalInfo = {
+        destination: item.trainLineNm ?? '',
+        arrivalMinutes: Math.max(0, Math.floor((item.barvlDt ?? 0) / 60)),
+        trainCode: item.btrainNo ?? '',
+      };
+      if (item.updnLine === '상행' || item.updnLine === '내선') {
+        up.push(info);
+      } else {
+        down.push(info);
+      }
+    }
+
+    const sliced = { up: up.slice(0, 2), down: down.slice(0, 2) };
+    if (sliced.up.length === 0 && sliced.down.length === 0) {
+      return { ...MOCK_ARRIVALS, isMock: true };
+    }
+    return sliced;
+  } catch {
+    return { ...MOCK_ARRIVALS, isMock: true };
+  }
 }

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -9,6 +9,11 @@ const mockArrival = {
   down: [{ destination: '인천행', arrivalMinutes: 5, trainCode: 'T002' }],
 };
 
+const mockArrivalWithMock = {
+  ...mockArrival,
+  isMock: true,
+};
+
 describe('useArrivalInfo', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -25,6 +30,7 @@ describe('useArrivalInfo', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.arrival).toBeNull();
+    expect(result.current.isMock).toBe(false);
     expect(arrivalApiModule.fetchArrivalInfo).not.toHaveBeenCalled();
   });
 
@@ -36,20 +42,18 @@ describe('useArrivalInfo', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.arrival).toEqual(mockArrival);
-    expect(result.current.error).toBeNull();
+    expect(result.current.isMock).toBe(false);
   });
 
-  it('API 오류 시 error가 설정된다', async () => {
-    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockRejectedValue(
-      new Error('Network error')
-    );
+  it('isMock이 true인 데이터를 받으면 isMock이 true이다', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrivalWithMock);
 
     const { result } = renderHook(() => useArrivalInfo('강남'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.error).toBe('도착 정보를 불러오지 못했습니다.');
-    expect(result.current.arrival).toBeNull();
+    expect(result.current.arrival).toEqual(mockArrivalWithMock);
+    expect(result.current.isMock).toBe(true);
   });
 
   it('30초 인터벌 후 자동으로 도착 정보를 갱신한다', async () => {

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -6,39 +6,35 @@ const POLL_INTERVAL_MS = 30_000;
 interface UseArrivalInfoReturn {
   arrival: StationArrival | null;
   loading: boolean;
-  error: string | null;
+  isMock: boolean;
 }
 
 export function useArrivalInfo(stationName: string | null): UseArrivalInfoReturn {
   const [arrival, setArrival] = useState<StationArrival | null>(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined as unknown as ReturnType<typeof setInterval>);
+  const isMountedRef = useRef(true);
 
   const fetch = useCallback(async () => {
     if (!stationName) {
       setArrival(null);
       return;
     }
-    try {
-      setError(null);
-      setLoading(true);
-      const data = await fetchArrivalInfo(stationName);
-      setArrival(data);
-    } catch {
-      setError('도착 정보를 불러오지 못했습니다.');
-    } finally {
-      setLoading(false);
-    }
+    setLoading(true);
+    const data = await fetchArrivalInfo(stationName);
+    if (!isMountedRef.current) return;
+    setArrival(data);
+    setLoading(false);
   }, [stationName]);
 
   useEffect(() => {
     fetch();
     intervalRef.current = setInterval(fetch, POLL_INTERVAL_MS);
     return () => {
+      isMountedRef.current = false;
       clearInterval(intervalRef.current);
     };
   }, [fetch]);
 
-  return { arrival, loading, error };
+  return { arrival, loading, isMock: arrival?.isMock ?? false };
 }

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, findRoute, buildJourneyDisplay, calculateETA } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, findRoute, buildJourneyDisplay, calculateETA, calculateStaticETA } from '../stationRoute';
 import type { Station } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 
@@ -333,6 +333,44 @@ describe('calculateETA', () => {
 
   it('route가 null이면 대기시간만 반환한다', () => {
     expect(calculateETA(5, null)).toBe(5);
+  });
+});
+
+describe('calculateStaticETA', () => {
+  it('DirectRoute일 때 기본대기3분 + 정거장*2분을 반환한다', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5 };
+    // 3분 대기 + 5*2분 = 13분
+    expect(calculateStaticETA(route)).toBe(13);
+  });
+
+  it('TransferRoute일 때 기본대기3분 + 정거장*2분 + 환승3분을 반환한다', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    };
+    // 3분 대기 + 6*2분 + 3분 환승 = 18분
+    expect(calculateStaticETA(route)).toBe(18);
+  });
+
+  it('MultiTransferRoute일 때 기본대기3분 + 정거장*2분 + 환승3분*2를 반환한다', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    // 3분 대기 + 12*2분 + 3분*2 환승 = 33분
+    expect(calculateStaticETA(route)).toBe(33);
+  });
+
+  it('route가 null이면 null을 반환한다', () => {
+    expect(calculateStaticETA(null)).toBeNull();
   });
 });
 

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -303,6 +303,26 @@ export function buildJourneyDisplay(
   };
 }
 
+const DEFAULT_WAIT_MINUTES = 3;
+
+export function calculateStaticETA(route: Route): number | null {
+  if (!route) return null;
+
+  if (route.type === 'direct') {
+    return DEFAULT_WAIT_MINUTES + route.stops * MINUTES_PER_STOP;
+  }
+
+  if (route.type === 'transfer') {
+    const totalStops = route.stopsToTransfer + route.stopsFromTransfer;
+    return DEFAULT_WAIT_MINUTES + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES;
+  }
+
+  // multi-transfer
+  const transferStops = route.transfers.reduce((sum, t) => sum + t.stopsToTransfer, 0);
+  const totalStops = transferStops + route.stopsAfterLastTransfer;
+  return DEFAULT_WAIT_MINUTES + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES * route.transfers.length;
+}
+
 export function calculateETA(nextTrainMinutes: number, route: Route): number {
   if (!route) return nextTrainMinutes;
 
@@ -315,7 +335,8 @@ export function calculateETA(nextTrainMinutes: number, route: Route): number {
     return nextTrainMinutes + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES;
   }
 
-  // multi-transfer: 2회 환승
-  const totalStops = route.transfers[0].stopsToTransfer + route.transfers[1].stopsToTransfer + route.stopsAfterLastTransfer;
-  return nextTrainMinutes + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES * 2;
+  // multi-transfer
+  const transferStops = route.transfers.reduce((sum, t) => sum + t.stopsToTransfer, 0);
+  const totalStops = transferStops + route.stopsAfterLastTransfer;
+  return nextTrainMinutes + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES * route.transfers.length;
 }


### PR DESCRIPTION
## Summary
- API 실패/네트워크 오류/빈 응답 시 에러 throw 대신 Mock 데이터 graceful fallback
- `isMock` 플래그로 실시간/예상 데이터 구분, UI에 안내 문구 표시
- `calculateStaticETA()` 추가: 실시간 데이터 없이도 목적지 예상 소요시간 표시
- 도착 정보 UI 개선: 로딩 상태, "도착 정보 없음" 처리
- `useArrivalInfo` dead code 제거 및 unmount guard 추가
- API URL HTTP → HTTPS 변경
- multi-transfer ETA 계산 하드코딩 → 동적 reduce 처리

## Test plan
- [x] `npm test` 커버리지 100% 통과 (171 tests)
- [x] `npm run type-check` 통과
- [x] CI 체크 통과 확인

Closes #67