### PR TITLE
feat(#67): 도착 정보 API fallback 및 정적 ETA 계산

### DIFF
--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -137,6 +137,26 @@ describe('fetchArrivalInfo', () => {
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
 
+  it('상행만 있고 하행이 없으면 실데이터로 반환한다', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        realtimeArrivalList: [
+          { trainLineNm: '소요산행', barvlDt: 120, btrainNo: 'T001', updnLine: '상행' },
+        ],
+      }),
+    } as Response);
+
+    const result = await fetchArrivalInfo('소요산');
+    expect(result.up).toHaveLength(1);
+    expect(result.down).toHaveLength(0);
+    expect(result.isMock).toBeUndefined();
+
+    delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
   it('trainLineNm, barvlDt, btrainNo가 undefined이면 기본값을 사용한다', async () => {
     process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
 

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -10,7 +10,7 @@ export interface StationArrival {
   isMock?: boolean;
 }
 
-export const MOCK_ARRIVALS: StationArrival = {
+export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
     { destination: '상행 종착역', arrivalMinutes: 2, trainCode: 'UP-001' },
     { destination: '상행 종착역', arrivalMinutes: 8, trainCode: 'UP-002' },
@@ -19,14 +19,15 @@ export const MOCK_ARRIVALS: StationArrival = {
     { destination: '하행 종착역', arrivalMinutes: 4, trainCode: 'DN-001' },
     { destination: '하행 종착역', arrivalMinutes: 11, trainCode: 'DN-002' },
   ],
-};
+  isMock: true,
+});
 
 export async function fetchArrivalInfo(stationName: string): Promise<StationArrival> {
   const apiKey = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
 
   if (!apiKey) {
     // API 키 없을 때 Mock 데이터 반환
-    return { ...MOCK_ARRIVALS, isMock: true };
+    return MOCK_ARRIVALS;
   }
 
   try {
@@ -34,7 +35,7 @@ export async function fetchArrivalInfo(stationName: string): Promise<StationArri
 
     const response = await fetch(url);
     if (!response.ok) {
-      return { ...MOCK_ARRIVALS, isMock: true };
+      return MOCK_ARRIVALS;
     }
 
     const data = await response.json();
@@ -58,10 +59,10 @@ export async function fetchArrivalInfo(stationName: string): Promise<StationArri
 
     const sliced = { up: up.slice(0, 2), down: down.slice(0, 2) };
     if (sliced.up.length === 0 && sliced.down.length === 0) {
-      return { ...MOCK_ARRIVALS, isMock: true };
+      return MOCK_ARRIVALS;
     }
     return sliced;
   } catch {
-    return { ...MOCK_ARRIVALS, isMock: true };
+    return MOCK_ARRIVALS;
   }
 }

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -77,7 +77,7 @@ describe('useArrivalInfo', () => {
   it('stationName이 변경되면 새로운 역의 데이터를 가져온다', async () => {
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 
-    const { result, rerender } = renderHook(
+    const { rerender } = renderHook(
       ({ name }: { name: string | null }) => useArrivalInfo(name),
       { initialProps: { name: '강남' as string | null } }
     );
@@ -106,5 +106,42 @@ describe('useArrivalInfo', () => {
     unmount();
     expect(clearIntervalSpy).toHaveBeenCalled();
     clearIntervalSpy.mockRestore();
+  });
+
+  it('언마운트 후 fetch 응답이 도착하면 상태를 갱신하지 않는다', async () => {
+    let resolve!: (value: typeof mockArrival) => void;
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockImplementation(
+      () => new Promise((r) => { resolve = r; })
+    );
+
+    const { result, unmount } = renderHook(() => useArrivalInfo('강남'));
+
+    expect(result.current.loading).toBe(true);
+
+    unmount();
+    resolve(mockArrival);
+    await Promise.resolve();
+
+    expect(result.current.arrival).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('stationName이 유효한 값에서 null로 바뀌면 loading이 false가 된다', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string | null }) => useArrivalInfo(name),
+      { initialProps: { name: '강남' as string | null } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.arrival).toEqual(mockArrival);
+
+    rerender({ name: null });
+
+    await waitFor(() => {
+      expect(result.current.arrival).toBeNull();
+      expect(result.current.loading).toBe(false);
+    });
   });
 });

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { fetchArrivalInfo, StationArrival } from '../api/arrivalApi';
 
 const POLL_INTERVAL_MS = 30_000;
@@ -13,28 +13,30 @@ export function useArrivalInfo(stationName: string | null): UseArrivalInfoReturn
   const [arrival, setArrival] = useState<StationArrival | null>(null);
   const [loading, setLoading] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined as unknown as ReturnType<typeof setInterval>);
-  const isMountedRef = useRef(true);
-
-  const fetch = useCallback(async () => {
-    if (!stationName) {
-      setArrival(null);
-      return;
-    }
-    setLoading(true);
-    const data = await fetchArrivalInfo(stationName);
-    if (!isMountedRef.current) return;
-    setArrival(data);
-    setLoading(false);
-  }, [stationName]);
 
   useEffect(() => {
-    fetch();
-    intervalRef.current = setInterval(fetch, POLL_INTERVAL_MS);
+    let cancelled = false;
+
+    const poll = async () => {
+      if (!stationName) {
+        setArrival(null);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      const data = await fetchArrivalInfo(stationName);
+      if (cancelled) return;
+      setArrival(data);
+      setLoading(false);
+    };
+
+    poll();
+    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
     return () => {
-      isMountedRef.current = false;
+      cancelled = true;
       clearInterval(intervalRef.current);
     };
-  }, [fetch]);
+  }, [stationName]);
 
   return { arrival, loading, isMock: arrival?.isMock ?? false };
 }

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -305,38 +305,27 @@ export function buildJourneyDisplay(
 
 const DEFAULT_WAIT_MINUTES = 3;
 
-export function calculateStaticETA(route: Route): number | null {
-  if (!route) return null;
-
+function getTravelMinutes(route: NonNullable<Route>): number {
   if (route.type === 'direct') {
-    return DEFAULT_WAIT_MINUTES + route.stops * MINUTES_PER_STOP;
+    return route.stops * MINUTES_PER_STOP;
   }
 
   if (route.type === 'transfer') {
     const totalStops = route.stopsToTransfer + route.stopsFromTransfer;
-    return DEFAULT_WAIT_MINUTES + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES;
+    return totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES;
   }
 
-  // multi-transfer
   const transferStops = route.transfers.reduce((sum, t) => sum + t.stopsToTransfer, 0);
   const totalStops = transferStops + route.stopsAfterLastTransfer;
-  return DEFAULT_WAIT_MINUTES + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES * route.transfers.length;
+  return totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES * route.transfers.length;
+}
+
+export function calculateStaticETA(route: Route): number | null {
+  if (!route) return null;
+  return DEFAULT_WAIT_MINUTES + getTravelMinutes(route);
 }
 
 export function calculateETA(nextTrainMinutes: number, route: Route): number {
   if (!route) return nextTrainMinutes;
-
-  if (route.type === 'direct') {
-    return nextTrainMinutes + route.stops * MINUTES_PER_STOP;
-  }
-
-  if (route.type === 'transfer') {
-    const totalStops = route.stopsToTransfer + route.stopsFromTransfer;
-    return nextTrainMinutes + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES;
-  }
-
-  // multi-transfer
-  const transferStops = route.transfers.reduce((sum, t) => sum + t.stopsToTransfer, 0);
-  const totalStops = transferStops + route.stopsAfterLastTransfer;
-  return nextTrainMinutes + totalStops * MINUTES_PER_STOP + TRANSFER_MINUTES * route.transfers.length;
+  return nextTrainMinutes + getTravelMinutes(route);
 }


### PR DESCRIPTION
## Summary
- 실시간 도착 정보 API 실패/빈 응답 시 Mock 데이터 fallback 구현
- 정적 ETA 계산 (`calculateStaticETA`) 추가 — API 없이도 예상 소요 시간 표시
- `useArrivalInfo` 로딩 고착 버그 수정 (`isMountedRef` → 로컬 `cancelled` 클로저)
- `stationName` null 전환 시 `setLoading(false)` 누락 수정
- `MOCK_ARRIVALS`에 `Object.freeze` 적용으로 변이 방어
- `calculateStaticETA`/`calculateETA` 중복 로직을 `getTravelMinutes` 헬퍼로 추출

## Test plan
- [x] `npm test` 커버리지 100% 통과 (174 tests)
- [x] `npm run type-check` 통과
- [x] 언마운트 후 응답 무시 테스트 추가
- [x] stationName null 전환 시 loading 해제 테스트 추가
- [x] 한쪽 방향만 운행하는 역 테스트 추가

Closes #67