### PR TITLE
feat(#67): Live Activity UI 개선 및 하차/환승 알람

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,7 +8,8 @@ import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRoute, buildJourneyDisplay, calculateETA, calculateStaticETA } from '../../src/utils/stationRoute';
 import { JourneyTimeline } from '../../src/components/JourneyTimeline';
-import { initStationNotification, updateStationNotification, clearStationNotification } from '../../src/utils/stationNotification';
+import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
+import { useStationAlarm } from '../../src/hooks/useStationAlarm';
 import { createLogger } from '../../src/utils/logger';
 
 const logger = createLogger('HomeScreen');
@@ -33,7 +34,10 @@ export default function HomeScreen() {
     ? calculateETA(nextTrainMinutes, route)
     : null;
   const staticEtaMinutes = route ? calculateStaticETA(route) : null;
-  const displayEta = (etaMinutes !== null && !arrivalIsMock) ? etaMinutes : staticEtaMinutes;
+  const isRealtimeEta = etaMinutes !== null && !arrivalIsMock && arrival !== null;
+  const displayEta = isRealtimeEta ? etaMinutes : staticEtaMinutes;
+
+  useStationAlarm(route, destination?.name ?? null);
 
   useEffect(() => {
     loadFavorites();
@@ -49,7 +53,7 @@ export default function HomeScreen() {
       }
       return;
     }
-    const key = `${result.station.id}__${destination?.id ?? ''}`;
+    const key = `${result.station.id}__${destination?.id ?? ''}__${displayEta ?? ''}__${arrivalIsMock}`;
     if (key === prevNotifKeyRef.current) return;
     prevNotifKeyRef.current = key;
     logger.info('알림 업데이트:', result.station.name, destination ? `→ ${destination.name}` : '');
@@ -58,12 +62,15 @@ export default function HomeScreen() {
       Math.round(result.distanceKm * 1000),
       destination,
       route ?? null,
+      displayEta,
+      arrivalIsMock,
     ).catch((e) => logger.error('알림 업데이트 실패:', e));
-  }, [result?.station.id, destination?.id, route]);
+  }, [result?.station.id, destination?.id, route, displayEta, arrivalIsMock]);
 
   useEffect(() => {
     if (arrivedBanner) {
       clearStationNotification().catch(console.error);
+      clearAlarmNotification().catch(console.error);
       prevNotifKeyRef.current = undefined;
     }
   }, [arrivedBanner]);
@@ -166,7 +173,7 @@ export default function HomeScreen() {
                     <Text style={styles.destinationArrow}>→</Text>
                     <Text style={styles.destinationName}>{destination.name}</Text>
                     {displayEta != null && (
-                      <Text style={styles.etaInline}>약 {displayEta}분 소요{arrivalIsMock ? ' (예상)' : ''}</Text>
+                      <Text style={styles.etaInline}>약 {displayEta}분 소요{!isRealtimeEta ? ' (예상)' : ''}</Text>
                     )}
                   </View>
                   {journey && (

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -14,6 +14,8 @@ export interface LiveActivityData {
   secondTransferStationName?: string;
   stopsAfterLastTransfer?: number;
   distanceM: number;
+  etaMinutes?: number;
+  isMock?: boolean;
 }
 
 const LiveActivityModule =

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -19,6 +19,8 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var secondTransferStationName: String?
         var stopsAfterLastTransfer: Int?
         var distanceM: Int
+        var etaMinutes: Int?
+        var isMock: Bool?
     }
 }
 
@@ -83,7 +85,9 @@ class LiveActivityManager {
             stopsToSecondTransfer: data["stopsToSecondTransfer"] as? Int,
             secondTransferStationName: data["secondTransferStationName"] as? String,
             stopsAfterLastTransfer: data["stopsAfterLastTransfer"] as? Int,
-            distanceM: data["distanceM"] as? Int ?? 0
+            distanceM: data["distanceM"] as? Int ?? 0,
+            etaMinutes: data["etaMinutes"] as? Int,
+            isMock: data["isMock"] as? Bool
         )
     }
 }

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -157,6 +157,50 @@ describe('fetchArrivalInfo', () => {
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
 
+  it('fetch가 5초 초과하면 Mock 데이터를 반환한다', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    jest.useFakeTimers();
+
+    global.fetch = jest.fn().mockImplementation((_url: string, options?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+
+    const promise = fetchArrivalInfo('강남');
+    jest.advanceTimersByTime(5000);
+    const result = await promise;
+
+    expect(result.isMock).toBe(true);
+
+    jest.useRealTimers();
+    delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
+  it('fetch에 AbortController signal을 전달한다', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        realtimeArrivalList: [
+          { trainLineNm: '소요산행', barvlDt: 120, btrainNo: 'T001', updnLine: '상행' },
+        ],
+      }),
+    } as Response);
+
+    await fetchArrivalInfo('강남');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+
+    delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
   it('trainLineNm, barvlDt, btrainNo가 undefined이면 기본값을 사용한다', async () => {
     process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
 

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -22,7 +22,16 @@ export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   isMock: true,
 });
 
-export async function fetchArrivalInfo(stationName: string): Promise<StationArrival> {
+export interface FetchArrivalOptions {
+  timeoutMs?: number;
+  maxPerDirection?: number;
+}
+
+export async function fetchArrivalInfo(
+  stationName: string,
+  options?: FetchArrivalOptions,
+): Promise<StationArrival> {
+  const { timeoutMs = 5000, maxPerDirection = 2 } = options ?? {};
   const apiKey = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
 
   if (!apiKey) {
@@ -30,10 +39,12 @@ export async function fetchArrivalInfo(stationName: string): Promise<StationArri
     return MOCK_ARRIVALS;
   }
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const url = `https://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/10/${encodeURIComponent(stationName)}`;
 
-    const response = await fetch(url);
+    const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
       return MOCK_ARRIVALS;
     }
@@ -57,12 +68,14 @@ export async function fetchArrivalInfo(stationName: string): Promise<StationArri
       }
     }
 
-    const sliced = { up: up.slice(0, 2), down: down.slice(0, 2) };
+    const sliced = { up: up.slice(0, maxPerDirection), down: down.slice(0, maxPerDirection) };
     if (sliced.up.length === 0 && sliced.down.length === 0) {
       return MOCK_ARRIVALS;
     }
     return sliced;
   } catch {
     return MOCK_ARRIVALS;
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -126,6 +126,74 @@ describe('useArrivalInfo', () => {
     expect(result.current.loading).toBe(true);
   });
 
+  it('같은 역 재진입 시 캐시 데이터를 즉시 표시한다', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string | null }) => useArrivalInfo(name),
+      { initialProps: { name: '강남' as string | null } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.arrival).toEqual(mockArrival);
+
+    // 다른 역으로 전환
+    rerender({ name: '역삼' });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 다시 강남으로 복귀 — 캐시 즉시 표시
+    rerender({ name: '강남' });
+    expect(result.current.arrival).toEqual(mockArrival);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('캐시가 없는 새 역은 loading이 true로 시작한다', async () => {
+    let resolveFirst!: (value: typeof mockArrival) => void;
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockImplementation(
+      () => new Promise((r) => { resolveFirst = r; })
+    );
+
+    const { result } = renderHook(() => useArrivalInfo('신규역'));
+
+    expect(result.current.arrival).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => { resolveFirst(mockArrival); });
+
+    expect(result.current.arrival).toEqual(mockArrival);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
+    const updatedArrival = {
+      up: [{ destination: '소요산행', arrivalMinutes: 5, trainCode: 'T001' }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, trainCode: 'T002' }],
+    };
+
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string | null }) => useArrivalInfo(name),
+      { initialProps: { name: '강남' as string | null } }
+    );
+
+    await waitFor(() => expect(result.current.arrival).toEqual(mockArrival));
+
+    // 다른 역으로 갔다가 복귀
+    rerender({ name: '역삼' });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 복귀 시 새로운 데이터로 갱신
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(updatedArrival);
+    rerender({ name: '강남' });
+
+    // 캐시 즉시 표시
+    expect(result.current.arrival).toEqual(mockArrival);
+
+    // 백그라운드 fetch 완료 후 갱신
+    await waitFor(() => expect(result.current.arrival).toEqual(updatedArrival));
+  });
+
   it('stationName이 유효한 값에서 null로 바뀌면 loading이 false가 된다', async () => {
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react-native';
+import { useStationAlarm } from '../useStationAlarm';
+import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../../utils/stationRoute';
+
+const mockSendAlarmNotification = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../utils/stationNotification', () => ({
+  sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe('useStationAlarm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not send alarm when route is null', () => {
+    renderHook(() => useStationAlarm(null, '강남'));
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('should not send alarm when destinationName is null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1 };
+    renderHook(() => useStationAlarm(route, null));
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('should not send alarm when stops is not 1', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3 };
+    renderHook(() => useStationAlarm(route, '강남'));
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('should send destination alarm for direct route with stops === 1', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1 };
+    renderHook(() => useStationAlarm(route, '강남'));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남');
+  });
+
+  it('should send transfer alarm for transfer route with stopsToTransfer === 1', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '시청',
+      fromLine: '1',
+      toLine: '2',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    };
+    renderHook(() => useStationAlarm(route, '강남'));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청');
+  });
+
+  it('should send destination alarm for transfer route with stopsFromTransfer === 1', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '시청',
+      fromLine: '1',
+      toLine: '2',
+      stopsToTransfer: 5,
+      stopsFromTransfer: 1,
+    };
+    renderHook(() => useStationAlarm(route, '강남'));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남');
+  });
+
+  it('should send transfer alarm for multi-transfer route', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '시청', fromLine: '1', toLine: '3', stopsToTransfer: 1 },
+        { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 3,
+    };
+    renderHook(() => useStationAlarm(route, '강남'));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청');
+  });
+
+  it('should not fire same alarm twice', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const { rerender } = renderHook(() => useStationAlarm(route, '강남'));
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+
+    rerender({});
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reset fired alarms when destination changes', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const { rerender } = renderHook(
+      ({ dest }: { dest: string }) => useStationAlarm(route, dest),
+      { initialProps: { dest: '강남' } },
+    );
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+
+    rerender({ dest: '잠실' });
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
+    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith('destination', '잠실');
+  });
+
+  it('should handle sendAlarmNotification failure gracefully', () => {
+    mockSendAlarmNotification.mockRejectedValueOnce(new Error('알림 실패'));
+    const route: DirectRoute = { type: 'direct', stops: 1 };
+    expect(() => renderHook(() => useStationAlarm(route, '강남'))).not.toThrow();
+  });
+});

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -13,21 +13,38 @@ export function useArrivalInfo(stationName: string | null): UseArrivalInfoReturn
   const [arrival, setArrival] = useState<StationArrival | null>(null);
   const [loading, setLoading] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined as unknown as ReturnType<typeof setInterval>);
+  const cacheRef = useRef<Map<string, StationArrival>>(new Map());
 
   useEffect(() => {
+    if (!stationName) {
+      setArrival(null);
+      setLoading(false);
+      return;
+    }
+
     let cancelled = false;
+    const cached = cacheRef.current.get(stationName);
+    if (cached) {
+      setArrival(cached);
+      setLoading(false);
+    } else {
+      setArrival(null);
+      setLoading(true);
+    }
 
     const poll = async () => {
-      if (!stationName) {
-        setArrival(null);
-        setLoading(false);
-        return;
+      try {
+        const data = await fetchArrivalInfo(stationName);
+        if (cancelled) return;
+        if (!data.isMock) {
+          cacheRef.current.set(stationName, data);
+        }
+        setArrival(data);
+      } catch {
+        // fetchArrivalInfo는 내부에서 처리하지만, 미래 변경 대비
+      } finally {
+        if (!cancelled) setLoading(false);
       }
-      setLoading(true);
-      const data = await fetchArrivalInfo(stationName);
-      if (cancelled) return;
-      setArrival(data);
-      setLoading(false);
     };
 
     poll();

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import type { Route } from '../utils/stationRoute';
+import { checkAlarm, alarmKey } from '../utils/stationAlarm';
+import { sendAlarmNotification } from '../utils/stationNotification';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('StationAlarm');
+
+export function useStationAlarm(route: Route, destinationName: string | null): void {
+  const firedAlarmsRef = useRef<Set<string>>(new Set());
+  const prevDestRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (destinationName !== prevDestRef.current) {
+      firedAlarmsRef.current = new Set();
+      prevDestRef.current = destinationName;
+    }
+
+    if (!route || !destinationName) return;
+
+    const event = checkAlarm(route, destinationName, firedAlarmsRef.current);
+    if (!event) return;
+
+    firedAlarmsRef.current.add(alarmKey(event));
+    sendAlarmNotification(event.type, event.stationName).catch((e) =>
+      logger.error('알람 알림 실패:', e),
+    );
+  }, [route, destinationName]);
+}

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -1,0 +1,213 @@
+import { checkAlarm, alarmKey, AlarmEvent } from '../stationAlarm';
+import type { DirectRoute, TransferRoute, MultiTransferRoute, Route } from '../stationRoute';
+
+describe('alarmKey', () => {
+  it('should return type:stationName format', () => {
+    const event: AlarmEvent = { type: 'destination', stationName: '강남' };
+    expect(alarmKey(event)).toBe('destination:강남');
+  });
+
+  it('should return transfer key', () => {
+    const event: AlarmEvent = { type: 'transfer', stationName: '시청' };
+    expect(alarmKey(event)).toBe('transfer:시청');
+  });
+});
+
+describe('checkAlarm', () => {
+  const destinationName = '강남';
+
+  it('should return null for null route', () => {
+    expect(checkAlarm(null, destinationName, new Set())).toBeNull();
+  });
+
+  // DirectRoute
+  describe('DirectRoute', () => {
+    it('should return destination alarm when stops === 1', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'destination', stationName: '강남' });
+    });
+
+    it('should return destination alarm when stops === 0', () => {
+      const route: DirectRoute = { type: 'direct', stops: 0 };
+      expect(checkAlarm(route, destinationName, new Set())).toEqual({
+        type: 'destination',
+        stationName: '강남',
+      });
+    });
+
+    it('should return null when stops === 2', () => {
+      const route: DirectRoute = { type: 'direct', stops: 2 };
+      expect(checkAlarm(route, destinationName, new Set())).toBeNull();
+    });
+
+    it('should return null when already fired', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const fired = new Set(['destination:강남']);
+      expect(checkAlarm(route, destinationName, fired)).toBeNull();
+    });
+  });
+
+  // TransferRoute
+  describe('TransferRoute', () => {
+    it('should return transfer alarm when stopsToTransfer === 1', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 5,
+      };
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'transfer', stationName: '시청' });
+    });
+
+    it('should return destination alarm when stopsFromTransfer === 1', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 5,
+        stopsFromTransfer: 1,
+      };
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'destination', stationName: '강남' });
+    });
+
+    it('should return null when neither is 1', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 5,
+      };
+      expect(checkAlarm(route, destinationName, new Set())).toBeNull();
+    });
+
+    it('should return null when transfer alarm already fired', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 5,
+      };
+      const fired = new Set(['transfer:시청']);
+      expect(checkAlarm(route, destinationName, fired)).toBeNull();
+    });
+
+    it('should prioritize transfer over destination when both are 1', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 1,
+      };
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'transfer', stationName: '시청' });
+    });
+  });
+
+  // MultiTransferRoute
+  describe('MultiTransferRoute', () => {
+    const makeMultiRoute = (
+      stops1: number,
+      stops2: number,
+      stopsAfter: number,
+    ): MultiTransferRoute => ({
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '시청', fromLine: '1', toLine: '3', stopsToTransfer: stops1 },
+        { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: stops2 },
+      ],
+      stopsAfterLastTransfer: stopsAfter,
+    });
+
+    it('should return transfer alarm for first transfer when stopsToTransfer === 1', () => {
+      const route = makeMultiRoute(1, 5, 3);
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'transfer', stationName: '시청' });
+    });
+
+    it('should return transfer alarm for second transfer when stopsToTransfer === 1', () => {
+      const route = makeMultiRoute(5, 1, 3);
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'transfer', stationName: '충무로' });
+    });
+
+    it('should return destination alarm when stopsAfterLastTransfer === 1', () => {
+      const route = makeMultiRoute(5, 3, 1);
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'destination', stationName: '강남' });
+    });
+
+    it('should return null when no stops are 1', () => {
+      const route = makeMultiRoute(3, 4, 5);
+      expect(checkAlarm(route, destinationName, new Set())).toBeNull();
+    });
+
+    it('should return null when already fired', () => {
+      const route = makeMultiRoute(1, 5, 3);
+      const fired = new Set(['transfer:시청']);
+      expect(checkAlarm(route, destinationName, fired)).toBeNull();
+    });
+
+    it('should prioritize first transfer over second when both are 1', () => {
+      const route = makeMultiRoute(1, 1, 3);
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'transfer', stationName: '시청' });
+    });
+
+    it('should prioritize second transfer over destination when both are 1', () => {
+      const route = makeMultiRoute(5, 1, 1);
+      const result = checkAlarm(route, destinationName, new Set());
+      expect(result).toEqual({ type: 'transfer', stationName: '충무로' });
+    });
+  });
+
+  describe('custom threshold', () => {
+    it('should return alarm when stops <= threshold (threshold=2)', () => {
+      const route: DirectRoute = { type: 'direct', stops: 2 };
+      const result = checkAlarm(route, destinationName, new Set(), 2);
+      expect(result).toEqual({ type: 'destination', stationName: '강남' });
+    });
+
+    it('should return null when stops > threshold (threshold=2)', () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      expect(checkAlarm(route, destinationName, new Set(), 2)).toBeNull();
+    });
+
+    it('should apply threshold to transfer route stopsToTransfer', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 5,
+      };
+      const result = checkAlarm(route, destinationName, new Set(), 2);
+      expect(result).toEqual({ type: 'transfer', stationName: '시청' });
+    });
+
+    it('should apply threshold to multi-transfer route', () => {
+      const route: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '시청', fromLine: '1', toLine: '3', stopsToTransfer: 5 },
+          { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 5 },
+        ],
+        stopsAfterLastTransfer: 3,
+      };
+      const result = checkAlarm(route, destinationName, new Set(), 3);
+      expect(result).toEqual({ type: 'destination', stationName: '강남' });
+    });
+  });
+});

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -5,6 +5,8 @@ import {
   initStationNotification,
   updateStationNotification,
   clearStationNotification,
+  sendAlarmNotification,
+  clearAlarmNotification,
 } from '../stationNotification';
 import { Station } from '../../types/station';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
@@ -86,11 +88,20 @@ describe('stationNotification', () => {
       );
     });
 
-    it('handleNotification은 shouldShowAlert true를 반환한다', async () => {
+    it('일반 알림은 shouldPlaySound false를 반환한다', async () => {
       setupNotificationHandler();
       const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
-      const result = await handleNotification();
+      const mockNotification = { request: { identifier: 'current-station' } };
+      const result = await handleNotification(mockNotification);
       expect(result).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: false, shouldSetBadge: false });
+    });
+
+    it('알람 알림은 shouldPlaySound true를 반환한다', async () => {
+      setupNotificationHandler();
+      const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+      const mockNotification = { request: { identifier: 'station-alarm' } };
+      const result = await handleNotification(mockNotification);
+      expect(result).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: true, shouldSetBadge: false });
     });
   });
 
@@ -108,6 +119,13 @@ describe('stationNotification', () => {
       expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station', {
         name: '현재 역',
         importance: Notifications.AndroidImportance.HIGH,
+        lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+      });
+      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-alarm', {
+        name: '하차/환승 알림',
+        importance: Notifications.AndroidImportance.HIGH,
+        sound: 'default',
+        vibrationPattern: [0, 250, 250, 250],
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
       });
       expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
@@ -183,6 +201,32 @@ describe('stationNotification', () => {
           secondTransferStationName: '시청',
           stopsAfterLastTransfer: 4,
         })
+      );
+    });
+
+    it('etaMinutes를 전달하면 Live Activity 데이터에 포함된다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          etaMinutes: 12,
+        })
+      );
+    });
+
+    it('isMock이 true이면 Live Activity 데이터에 포함된다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12, true);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          etaMinutes: 12,
+          isMock: true,
+        })
+      );
+    });
+
+    it('etaMinutes가 없으면 Live Activity 데이터에 포함되지 않는다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.not.objectContaining({ etaMinutes: expect.anything() })
       );
     });
 
@@ -263,7 +307,7 @@ describe('stationNotification', () => {
       await updateStationNotification(mockStation, 154, mockDestination, transferRoute);
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: { title: '시청 → 성신여대입구', body: '3정거장 후 동대문 환승 · 2정거장' },
+          content: { title: '시청 → 성신여대입구', body: '3역 후 동대문 환승' },
         })
       );
     });
@@ -274,8 +318,26 @@ describe('stationNotification', () => {
         expect.objectContaining({
           content: {
             title: '시청 → 성신여대입구',
-            body: '3정거장 후 잠실 환승 → 5정거장 후 시청 환승 · 4정거장',
+            body: '3역 후 잠실 환승',
           },
+        })
+      );
+    });
+
+    it('etaMinutes가 있으면 알림 body에 소요 시간이 포함된다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { title: '시청 → 성신여대입구', body: '1호선 · 4정거장 남음 · 약 12분' },
+        })
+      );
+    });
+
+    it('isMock이면 알림 body에 (예상) 표시가 포함된다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12, true);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { title: '시청 → 성신여대입구', body: '1호선 · 4정거장 남음 · 약 12분 (예상)' },
         })
       );
     });
@@ -349,6 +411,57 @@ describe('stationNotification', () => {
       await clearStationNotification();
       expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('current-station');
       expect(mockEndLiveActivity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendAlarmNotification', () => {
+    it('destination 타입이면 하차 알림을 보낸다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification('destination', '강남');
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-alarm',
+        content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: true },
+        trigger: null,
+      });
+    });
+
+    it('transfer 타입이면 환승 알림을 보낸다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification('transfer', '시청');
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-alarm',
+        content: { title: '환승 알림', body: '다음 역 시청에서 환승하세요!', sound: true },
+        trigger: null,
+      });
+    });
+
+    it('Android에서는 channelId가 포함된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await sendAlarmNotification('destination', '강남');
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-alarm',
+        content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: true, channelId: 'station-alarm' },
+        trigger: null,
+      });
+    });
+
+    it('dismiss 실패해도 schedule은 호출된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
+      await sendAlarmNotification('destination', '강남');
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('clearAlarmNotification', () => {
+    it('station-alarm을 dismiss한다', async () => {
+      await clearAlarmNotification();
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('station-alarm');
+    });
+
+    it('dismiss 실패해도 에러를 던지지 않는다', async () => {
+      (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
+      await expect(clearAlarmNotification()).resolves.toBeUndefined();
     });
   });
 });

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -69,6 +69,20 @@ const multiTransferRoute: MultiTransferRoute = {
   stopsAfterLastTransfer: 4,
 };
 
+function expectNotificationContent(title: string, body: string) {
+  expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+    expect.objectContaining({ content: { title, body } }),
+  );
+}
+
+function expectAlarmNotification(title: string, body: string, extra?: Record<string, unknown>) {
+  expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+    identifier: 'station-alarm',
+    content: { title, body, sound: true, ...extra },
+    trigger: null,
+  });
+}
+
 describe('stationNotification', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -240,21 +254,13 @@ describe('stationNotification', () => {
       await updateStationNotification(mockStation, 154);
       expect(mockStartLiveActivity).not.toHaveBeenCalled();
       expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: { title: '시청역', body: '1호선 · 약 154m' },
-        })
-      );
+      expectNotificationContent('시청역', '1호선 · 약 154m');
     });
 
     it('startLiveActivity 실패 시 expo-notifications로 폴백한다', async () => {
       mockStartLiveActivity.mockRejectedValueOnce(new Error('ActivityKit 오류'));
       await updateStationNotification(mockStation, 154);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: { title: '시청역', body: '1호선 · 약 154m' },
-        })
-      );
+      expectNotificationContent('시청역', '1호선 · 약 154m');
     });
 
     it('startLiveActivity 실패 시 liveActivityStarted를 false로 리셋한다', async () => {
@@ -287,59 +293,32 @@ describe('stationNotification', () => {
 
     it('목적지 없으면 역 이름과 거리를 표시한다', async () => {
       await updateStationNotification(mockStation, 154);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: { title: '시청역', body: '1호선 · 약 154m' },
-        })
-      );
+      expectNotificationContent('시청역', '1호선 · 약 154m');
     });
 
     it('직통 경로이면 목적지와 정거장 수를 표시한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, directRoute);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: { title: '시청 → 성신여대입구', body: '1호선 · 4정거장 남음' },
-        })
-      );
+      expectNotificationContent('시청 → 성신여대입구', '1호선 · 4정거장 남음');
     });
 
     it('환승 경로이면 환승 정보를 표시한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, transferRoute);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: { title: '시청 → 성신여대입구', body: '3역 후 동대문 환승' },
-        })
-      );
+      expectNotificationContent('시청 → 성신여대입구', '3역 후 동대문 환승');
     });
 
     it('multi-transfer 경로이면 두 환승 정보를 표시한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, multiTransferRoute);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: {
-            title: '시청 → 성신여대입구',
-            body: '3역 후 잠실 환승',
-          },
-        })
-      );
+      expectNotificationContent('시청 → 성신여대입구', '3역 후 잠실 환승');
     });
 
     it('etaMinutes가 있으면 알림 body에 소요 시간이 포함된다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: { title: '시청 → 성신여대입구', body: '1호선 · 4정거장 남음 · 약 12분' },
-        })
-      );
+      expectNotificationContent('시청 → 성신여대입구', '1호선 · 4정거장 남음 · 약 12분');
     });
 
     it('isMock이면 알림 body에 (예상) 표시가 포함된다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12, true);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: { title: '시청 → 성신여대입구', body: '1호선 · 4정거장 남음 · 약 12분 (예상)' },
-        })
-      );
+      expectNotificationContent('시청 → 성신여대입구', '1호선 · 4정거장 남음 · 약 12분 (예상)');
     });
 
     it('dismiss가 실패해도 schedule은 호출된다', async () => {
@@ -418,31 +397,19 @@ describe('stationNotification', () => {
     it('destination 타입이면 하차 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('destination', '강남');
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-alarm',
-        content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: true },
-        trigger: null,
-      });
+      expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!');
     });
 
     it('transfer 타입이면 환승 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('transfer', '시청');
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-alarm',
-        content: { title: '환승 알림', body: '다음 역 시청에서 환승하세요!', sound: true },
-        trigger: null,
-      });
+      expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!');
     });
 
     it('Android에서는 channelId가 포함된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
       await sendAlarmNotification('destination', '강남');
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-alarm',
-        content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: true, channelId: 'station-alarm' },
-        trigger: null,
-      });
+      expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!', { channelId: 'station-alarm' });
     });
 
     it('dismiss 실패해도 schedule은 호출된다', async () => {

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -1,0 +1,75 @@
+import type { Route, DirectRoute, TransferRoute, MultiTransferRoute } from './stationRoute';
+
+export type AlarmType = 'destination' | 'transfer';
+
+export interface AlarmEvent {
+  type: AlarmType;
+  stationName: string;
+}
+
+const DEFAULT_THRESHOLD = 1;
+
+export function alarmKey(event: AlarmEvent): string {
+  return `${event.type}:${event.stationName}`;
+}
+
+type AlarmChecker = (
+  route: NonNullable<Route>,
+  destinationName: string,
+  threshold: number,
+) => AlarmEvent | null;
+
+const checkers: Record<string, AlarmChecker> = {
+  direct(route, destinationName, threshold) {
+    const r = route as DirectRoute;
+    if (r.stops <= threshold) {
+      return { type: 'destination', stationName: destinationName };
+    }
+    return null;
+  },
+
+  transfer(route, destinationName, threshold) {
+    const r = route as TransferRoute;
+    if (r.stopsToTransfer <= threshold) {
+      return { type: 'transfer', stationName: r.transferName };
+    }
+    if (r.stopsFromTransfer <= threshold) {
+      return { type: 'destination', stationName: destinationName };
+    }
+    return null;
+  },
+
+  'multi-transfer'(route, destinationName, threshold) {
+    const r = route as MultiTransferRoute;
+    const [t1, t2] = r.transfers;
+    if (t1.stopsToTransfer <= threshold) {
+      return { type: 'transfer', stationName: t1.transferName };
+    }
+    if (t2.stopsToTransfer <= threshold) {
+      return { type: 'transfer', stationName: t2.transferName };
+    }
+    if (r.stopsAfterLastTransfer <= threshold) {
+      return { type: 'destination', stationName: destinationName };
+    }
+    return null;
+  },
+};
+
+export function checkAlarm(
+  route: Route,
+  destinationName: string,
+  firedAlarms: Set<string>,
+  threshold: number = DEFAULT_THRESHOLD,
+): AlarmEvent | null {
+  if (!route) return null;
+
+  const checker = checkers[route.type];
+  const event = checker(route, destinationName, threshold);
+
+  if (!event) return null;
+
+  const key = alarmKey(event);
+  if (firedAlarms.has(key)) return null;
+
+  return event;
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -10,19 +10,24 @@ const notifLogger = createLogger('Notification');
 const liveActivityLogger = createLogger('LiveActivity');
 
 const NOTIFICATION_ID = 'current-station';
+const ALARM_NOTIFICATION_ID = 'station-alarm';
+const ALARM_CHANNEL_ID = 'station-alarm';
 
 // iOS Live Activity 상태 추적 (start vs update 구분)
 let liveActivityStarted = false;
 
 export function setupNotificationHandler(): void {
   Notifications.setNotificationHandler({
-    handleNotification: async () => ({
-      shouldShowAlert: true,
-      shouldShowBanner: true,
-      shouldShowList: true,
-      shouldPlaySound: false,
-      shouldSetBadge: false,
-    }),
+    handleNotification: async (notification) => {
+      const isAlarm = notification.request.identifier === ALARM_NOTIFICATION_ID;
+      return {
+        shouldShowAlert: true,
+        shouldShowBanner: true,
+        shouldShowList: true,
+        shouldPlaySound: isAlarm,
+        shouldSetBadge: false,
+      };
+    },
   });
 }
 
@@ -31,6 +36,13 @@ export async function initStationNotification(): Promise<void> {
     await Notifications.setNotificationChannelAsync('station', {
       name: '현재 역',
       importance: Notifications.AndroidImportance.HIGH,
+      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+    });
+    await Notifications.setNotificationChannelAsync(ALARM_CHANNEL_ID, {
+      name: '하차/환승 알림',
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: 'default',
+      vibrationPattern: [0, 250, 250, 250],
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
     });
   }
@@ -43,19 +55,22 @@ function buildContent(
   distanceM: number,
   destination?: Station | null,
   route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
+  etaMinutes?: number | null,
+  isMock?: boolean,
 ): { title: string; body: string } {
+  const etaSuffix = etaMinutes != null ? ` · 약 ${etaMinutes}분${isMock ? ' (예상)' : ''}` : '';
   if (destination && route) {
     const title = `${currentStation.name} → ${destination.name}`;
     if (route.type === 'direct') {
-      const body = `${LINE_NAMES[currentStation.line]} · ${route.stops}정거장 남음`;
+      const body = `${LINE_NAMES[currentStation.line]} · ${route.stops}정거장 남음${etaSuffix}`;
       return { title, body };
     }
     if (route.type === 'transfer') {
-      const body = `${route.stopsToTransfer}정거장 후 ${route.transferName} 환승 · ${route.stopsFromTransfer}정거장`;
+      const body = `${route.stopsToTransfer}역 후 ${route.transferName} 환승${etaSuffix}`;
       return { title, body };
     }
-    const [t1, t2] = route.transfers;
-    const body = `${t1.stopsToTransfer}정거장 후 ${t1.transferName} 환승 → ${t2.stopsToTransfer}정거장 후 ${t2.transferName} 환승 · ${route.stopsAfterLastTransfer}정거장`;
+    const [t1] = route.transfers;
+    const body = `${t1.stopsToTransfer}역 후 ${t1.transferName} 환승${etaSuffix}`;
     return { title, body };
   }
   return {
@@ -69,6 +84,8 @@ function buildLiveActivityData(
   distanceM: number,
   destination?: Station | null,
   route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
+  etaMinutes?: number | null,
+  isMock?: boolean,
 ): LiveActivity.LiveActivityData {
   const base: LiveActivity.LiveActivityData = {
     stationName: currentStation.name,
@@ -76,6 +93,13 @@ function buildLiveActivityData(
     lineColorHex: LINE_COLORS[currentStation.line],
     distanceM,
   };
+
+  if (etaMinutes != null) {
+    base.etaMinutes = etaMinutes;
+  }
+  if (isMock) {
+    base.isMock = true;
+  }
 
   if (destination && route) {
     base.destinationName = destination.name;
@@ -102,6 +126,8 @@ export async function updateStationNotification(
   distanceM: number,
   destination?: Station | null,
   route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
+  etaMinutes?: number | null,
+  isMock?: boolean,
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
 
@@ -111,7 +137,7 @@ export async function updateStationNotification(
 
     if (!liveActivityEnabled) {
       notifLogger.info('Live Activity 비활성 → 알림 fallback');
-      const { title, body } = buildContent(currentStation, distanceM, destination, route);
+      const { title, body } = buildContent(currentStation, distanceM, destination, route, etaMinutes, isMock);
       try {
         await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
       } catch {
@@ -125,7 +151,7 @@ export async function updateStationNotification(
       notifLogger.info('알림 예약 완료:', title, body);
       return;
     }
-    const data = buildLiveActivityData(currentStation, distanceM, destination, route);
+    const data = buildLiveActivityData(currentStation, distanceM, destination, route, etaMinutes, isMock);
     try {
       if (!liveActivityStarted) {
         liveActivityLogger.info('시작 요청');
@@ -141,7 +167,7 @@ export async function updateStationNotification(
       liveActivityLogger.error('시작/업데이트 실패:', e);
       liveActivityStarted = false;
       notifLogger.info('Live Activity 실패 → 알림 fallback');
-      const { title, body } = buildContent(currentStation, distanceM, destination, route);
+      const { title, body } = buildContent(currentStation, distanceM, destination, route, etaMinutes, isMock);
       try {
         await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
       } catch {
@@ -157,7 +183,7 @@ export async function updateStationNotification(
   }
 
   // Android: 기존 expo-notifications 유지
-  const { title, body } = buildContent(currentStation, distanceM, destination, route);
+  const { title, body } = buildContent(currentStation, distanceM, destination, route, etaMinutes, isMock);
   notifLogger.info('Android 알림:', title, body);
   try {
     await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
@@ -191,4 +217,41 @@ export async function clearStationNotification(): Promise<void> {
   }
   notifLogger.info('Android 알림 해제');
   await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+}
+
+export async function sendAlarmNotification(
+  type: 'destination' | 'transfer',
+  stationName: string,
+): Promise<void> {
+  const isTransfer = type === 'transfer';
+  const title = isTransfer ? '환승 알림' : '하차 알림';
+  const body = isTransfer
+    ? `다음 역 ${stationName}에서 환승하세요!`
+    : `다음 역 ${stationName}에서 내리세요!`;
+
+  try {
+    await Notifications.dismissNotificationAsync(ALARM_NOTIFICATION_ID);
+  } catch {
+    // 기존 알람 없어도 무시
+  }
+
+  await Notifications.scheduleNotificationAsync({
+    identifier: ALARM_NOTIFICATION_ID,
+    content: {
+      title,
+      body,
+      sound: true,
+      ...(Platform.OS === 'android' && { channelId: ALARM_CHANNEL_ID }),
+    },
+    trigger: null,
+  });
+  notifLogger.info('알람 알림:', title, body);
+}
+
+export async function clearAlarmNotification(): Promise<void> {
+  try {
+    await Notifications.dismissNotificationAsync(ALARM_NOTIFICATION_ID);
+  } catch {
+    // 기존 알람 없어도 무시
+  }
 }

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -16,6 +16,22 @@ const ALARM_CHANNEL_ID = 'station-alarm';
 // iOS Live Activity 상태 추적 (start vs update 구분)
 let liveActivityStarted = false;
 
+async function scheduleNotification(
+  id: string,
+  content: { title: string; body: string; sound?: boolean; channelId?: string },
+): Promise<void> {
+  try {
+    await Notifications.dismissNotificationAsync(id);
+  } catch {
+    // 기존 알림 없어도 무시
+  }
+  await Notifications.scheduleNotificationAsync({
+    identifier: id,
+    content,
+    trigger: null,
+  });
+}
+
 export function setupNotificationHandler(): void {
   Notifications.setNotificationHandler({
     handleNotification: async (notification) => {
@@ -138,16 +154,7 @@ export async function updateStationNotification(
     if (!liveActivityEnabled) {
       notifLogger.info('Live Activity 비활성 → 알림 fallback');
       const { title, body } = buildContent(currentStation, distanceM, destination, route, etaMinutes, isMock);
-      try {
-        await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
-      } catch {
-        // 기존 알림 없어도 무시하고 계속 진행
-      }
-      await Notifications.scheduleNotificationAsync({
-        identifier: NOTIFICATION_ID,
-        content: { title, body },
-        trigger: null,
-      });
+      await scheduleNotification(NOTIFICATION_ID, { title, body });
       notifLogger.info('알림 예약 완료:', title, body);
       return;
     }
@@ -168,16 +175,7 @@ export async function updateStationNotification(
       liveActivityStarted = false;
       notifLogger.info('Live Activity 실패 → 알림 fallback');
       const { title, body } = buildContent(currentStation, distanceM, destination, route, etaMinutes, isMock);
-      try {
-        await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
-      } catch {
-        // 기존 알림 없어도 무시하고 계속 진행
-      }
-      await Notifications.scheduleNotificationAsync({
-        identifier: NOTIFICATION_ID,
-        content: { title, body },
-        trigger: null,
-      });
+      await scheduleNotification(NOTIFICATION_ID, { title, body });
     }
     return;
   }
@@ -185,16 +183,7 @@ export async function updateStationNotification(
   // Android: 기존 expo-notifications 유지
   const { title, body } = buildContent(currentStation, distanceM, destination, route, etaMinutes, isMock);
   notifLogger.info('Android 알림:', title, body);
-  try {
-    await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
-  } catch {
-    // 기존 알림 없어도 무시하고 계속 진행
-  }
-  await Notifications.scheduleNotificationAsync({
-    identifier: NOTIFICATION_ID,
-    content: { title, body },
-    trigger: null,
-  });
+  await scheduleNotification(NOTIFICATION_ID, { title, body });
   notifLogger.info('알림 예약 완료');
 }
 
@@ -229,21 +218,11 @@ export async function sendAlarmNotification(
     ? `다음 역 ${stationName}에서 환승하세요!`
     : `다음 역 ${stationName}에서 내리세요!`;
 
-  try {
-    await Notifications.dismissNotificationAsync(ALARM_NOTIFICATION_ID);
-  } catch {
-    // 기존 알람 없어도 무시
-  }
-
-  await Notifications.scheduleNotificationAsync({
-    identifier: ALARM_NOTIFICATION_ID,
-    content: {
-      title,
-      body,
-      sound: true,
-      ...(Platform.OS === 'android' && { channelId: ALARM_CHANNEL_ID }),
-    },
-    trigger: null,
+  await scheduleNotification(ALARM_NOTIFICATION_ID, {
+    title,
+    body,
+    sound: true,
+    ...(Platform.OS === 'android' && { channelId: ALARM_CHANNEL_ID }),
   });
   notifLogger.info('알람 알림:', title, body);
 }
@@ -251,7 +230,5 @@ export async function sendAlarmNotification(
 export async function clearAlarmNotification(): Promise<void> {
   try {
     await Notifications.dismissNotificationAsync(ALARM_NOTIFICATION_ID);
-  } catch {
-    // 기존 알람 없어도 무시
-  }
+  } catch { /* 무시 */ }
 }

--- a/targets/subway-widget/SubwayLiveActivity.swift
+++ b/targets/subway-widget/SubwayLiveActivity.swift
@@ -16,6 +16,8 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var secondTransferStationName: String?
         var stopsAfterLastTransfer: Int?
         var distanceM: Int
+        var etaMinutes: Int?
+        var isMock: Bool?
     }
 }
 #endif

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -96,6 +96,19 @@ private struct LockScreenView: View {
             }
 
             Spacer()
+
+            if let eta = state.etaMinutes {
+                VStack(spacing: 2) {
+                    Text("약 \(eta)분")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                    Text(state.isMock == true ? "예상" : "소요")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.trailing, 4)
+            }
         }
         .padding(16)
         .background(.black.opacity(0.85))
@@ -115,25 +128,16 @@ private struct LockScreenRouteView: View {
                 .foregroundColor(.white)
 
             if let stops = state.stopsRemaining {
-                Text("\(stops)정거장 남음")
+                Text("\(stops)역 후 \(dest) 도착")
                     .font(.caption)
                     .foregroundColor(.secondary)
-            } else if let toSecond = state.stopsToSecondTransfer,
-                      let secondName = state.secondTransferStationName,
-                      let afterLast = state.stopsAfterLastTransfer,
-                      let toFirst = state.stopsToTransfer,
+            } else if let toFirst = state.stopsToTransfer,
                       let firstName = state.transferStationName {
-                Text("\(toFirst)정거장→\(firstName) 환승→\(toSecond)정거장→\(secondName) 환승→\(afterLast)정거장")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .lineLimit(2)
-            } else if let toTransfer = state.stopsToTransfer,
-                      let transferName = state.transferStationName,
-                      let fromTransfer = state.stopsFromTransfer {
-                Text("\(toTransfer)정거장 후 \(transferName) 환승 · \(fromTransfer)정거장")
+                Text("\(toFirst)역 후 \(firstName) 환승")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
+
         }
     }
 }
@@ -143,29 +147,23 @@ private struct ExpandedRouteView: View {
     let dest: String
     let state: SubwayActivityAttributes.ContentState
 
+    private var etaSuffix: String {
+        guard let eta = state.etaMinutes else { return "" }
+        return " · 약 \(eta)분"
+    }
+
     var body: some View {
         if let stops = state.stopsRemaining {
-            Text("→ \(dest) · \(stops)정거장")
+            Text("→ \(dest) · \(stops)역 후 도착\(etaSuffix)")
                 .font(.caption)
                 .foregroundColor(.secondary)
-        } else if let toSecond = state.stopsToSecondTransfer,
-                  let secondName = state.secondTransferStationName,
-                  let afterLast = state.stopsAfterLastTransfer,
-                  let toFirst = state.stopsToTransfer,
+        } else if let toFirst = state.stopsToTransfer,
                   let firstName = state.transferStationName {
-            Text("→ \(dest) (\(toFirst)정거장→\(firstName) 환승→\(toSecond)정거장→\(secondName) 환승→\(afterLast)정거장)")
+            Text("→ \(dest) · \(toFirst)역 후 \(firstName) 환승\(etaSuffix)")
                 .font(.caption)
                 .foregroundColor(.secondary)
-                .lineLimit(2)
-        } else if let toTransfer = state.stopsToTransfer,
-                  let transferName = state.transferStationName,
-                  let fromTransfer = state.stopsFromTransfer {
-            Text("→ \(dest) (\(toTransfer)정거장 후 \(transferName) 환승 · \(fromTransfer)정거장)")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .lineLimit(2)
         } else {
-            Text("→ \(dest)")
+            Text("→ \(dest)\(etaSuffix)")
                 .font(.caption)
                 .foregroundColor(.secondary)
         }


### PR DESCRIPTION
## Summary
- Live Activity 경로 표시를 "다음 이벤트"만 보여주도록 단순화
- ETA 소요 시간을 Lock Screen 우측에 배치, Dynamic Island에 인라인 표시
- fetch 5초 타임아웃(AbortController) + stale-while-revalidate 캐시 적용
- useArrivalInfo 로딩 고착 버그 근본 수정 (try/catch/finally)
- 하차/환승 1정거장 전 알람 알림 기능 추가
- fetchArrivalInfo, checkAlarm 파라미터화로 확장성 확보

Closes #67

## Test plan
- [x] `npm test` — 224개 테스트 통과, 커버리지 100%
- [x] `npm run type-check` — 타입 오류 없음
- [x] iOS 빌드 후 Live Activity ETA 우측 표시 확인
- [x] 하차/환승 1정거장 전 알람 알림 동작 확인
- [x] API 타임아웃 5초 초과 시 Mock fallback 확인
- [x] 같은 역 재진입 시 캐시 즉시 표시 확인