### PR TITLE
feat(#67): 도착 정보 API fallback, Live Activity 개선 및 버그 수정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
@@ -22,8 +22,14 @@ export default function HomeScreen() {
   const [arrivedBanner, setArrivedBanner] = useState(false);
   const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
-  const route = result && destination ? findRoute(result.station.id, destination.id) : null;
-  const journey = route && result && destination ? buildJourneyDisplay(route, result.station, destination) : null;
+  const route = useMemo(
+    () => (result && destination ? findRoute(result.station.id, destination.id) : null),
+    [result?.station.id, destination?.id],
+  );
+  const journey = useMemo(
+    () => (route && result && destination ? buildJourneyDisplay(route, result.station, destination) : null),
+    [route, result?.station.id, destination?.id],
+  );
   const nextTrainMinutes = arrival
     ? Math.min(
         arrival.up[0]?.arrivalMinutes ?? Infinity,
@@ -65,7 +71,7 @@ export default function HomeScreen() {
       displayEta,
       arrivalIsMock,
     ).catch((e) => logger.error('알림 업데이트 실패:', e));
-  }, [result?.station.id, destination?.id, route, displayEta, arrivalIsMock]);
+  }, [result?.station.id, destination?.id, displayEta, arrivalIsMock]);
 
   useEffect(() => {
     if (arrivedBanner) {

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -45,7 +45,7 @@ class LiveActivityManager {
             )
         }
 
-        let state = buildState(from: data)
+        let state = try decodeState(from: data)
         let attributes = SubwayActivityAttributes()
         let content = ActivityContent(state: state, staleDate: nil)
         currentActivity = try Activity.request(
@@ -53,16 +53,30 @@ class LiveActivityManager {
             content: content,
             pushType: nil
         )
+        #if DEBUG
+        print("[LiveActivity] started, destination=\(state.destinationName ?? "nil")")
+        #endif
     }
 
     func update(data: [String: Any]) async throws {
-        guard let activity = currentActivity else {
-            try await start(data: data)
-            return
+        // Activity 상태 검증: ended/dismissed면 재시작
+        if let activity = currentActivity {
+            if activity.activityState == .active {
+                let state = try decodeState(from: data)
+                let content = ActivityContent(state: state, staleDate: nil)
+                await activity.update(content)
+                #if DEBUG
+                print("[LiveActivity] updated, destination=\(state.destinationName ?? "nil")")
+                #endif
+                return
+            } else {
+                #if DEBUG
+                print("[LiveActivity] activity state=\(activity.activityState), restarting")
+                #endif
+                currentActivity = nil
+            }
         }
-        let state = buildState(from: data)
-        let content = ActivityContent(state: state, staleDate: nil)
-        await activity.update(content)
+        try await start(data: data)
     }
 
     func end() async {
@@ -72,23 +86,10 @@ class LiveActivityManager {
         }
     }
 
-    private func buildState(from data: [String: Any]) -> SubwayActivityAttributes.ContentState {
-        SubwayActivityAttributes.ContentState(
-            stationName: data["stationName"] as? String ?? "",
-            lineName: data["lineName"] as? String ?? "",
-            lineColorHex: data["lineColorHex"] as? String ?? "#888888",
-            destinationName: data["destinationName"] as? String,
-            stopsRemaining: data["stopsRemaining"] as? Int,
-            stopsToTransfer: data["stopsToTransfer"] as? Int,
-            transferStationName: data["transferStationName"] as? String,
-            stopsFromTransfer: data["stopsFromTransfer"] as? Int,
-            stopsToSecondTransfer: data["stopsToSecondTransfer"] as? Int,
-            secondTransferStationName: data["secondTransferStationName"] as? String,
-            stopsAfterLastTransfer: data["stopsAfterLastTransfer"] as? Int,
-            distanceM: data["distanceM"] as? Int ?? 0,
-            etaMinutes: data["etaMinutes"] as? Int,
-            isMock: data["isMock"] as? Bool
-        )
+    // JSON → Codable 디코딩: 타입 안전성 보장, 필드 추가 시 struct만 수정하면 됨
+    private func decodeState(from data: [String: Any]) throws -> SubwayActivityAttributes.ContentState {
+        let jsonData = try JSONSerialization.data(withJSONObject: data)
+        return try JSONDecoder().decode(SubwayActivityAttributes.ContentState.self, from: jsonData)
     }
 }
 #endif

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -244,6 +244,19 @@ describe('stationNotification', () => {
       );
     });
 
+    it('목적지만 있고 경로가 없으면 destinationName만 포함한다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, null);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ destinationName: '성신여대입구' })
+      );
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.not.objectContaining({ stopsRemaining: expect.anything() })
+      );
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+        expect.not.objectContaining({ stopsToTransfer: expect.anything() })
+      );
+    });
+
     it('expo-notifications를 호출하지 않는다', async () => {
       await updateStationNotification(mockStation, 154);
       expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
@@ -333,6 +346,11 @@ describe('stationNotification', () => {
       (Notifications.scheduleNotificationAsync as jest.Mock).mockImplementation(async () => { callOrder.push('schedule'); return 'id'; });
       await updateStationNotification(mockStation, 154);
       expect(callOrder).toEqual(['dismiss', 'schedule']);
+    });
+
+    it('목적지만 있고 경로가 없으면 제목에 목적지가 표시된다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, null);
+      expectNotificationContent('시청 → 성신여대입구', '1호선 · 약 154m');
     });
 
     it('Live Activity를 호출하지 않는다', async () => {

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -75,24 +75,26 @@ function buildContent(
   isMock?: boolean,
 ): { title: string; body: string } {
   const etaSuffix = etaMinutes != null ? ` · 약 ${etaMinutes}분${isMock ? ' (예상)' : ''}` : '';
+
+  // destination layer: 목적지 있으면 title에 반영
+  const title = destination
+    ? `${currentStation.name} → ${destination.name}`
+    : `${currentStation.name}역`;
+
+  // route layer: 경로 정보가 있으면 body에 반영
   if (destination && route) {
-    const title = `${currentStation.name} → ${destination.name}`;
     if (route.type === 'direct') {
-      const body = `${LINE_NAMES[currentStation.line]} · ${route.stops}정거장 남음${etaSuffix}`;
-      return { title, body };
+      return { title, body: `${LINE_NAMES[currentStation.line]} · ${route.stops}정거장 남음${etaSuffix}` };
     }
     if (route.type === 'transfer') {
-      const body = `${route.stopsToTransfer}역 후 ${route.transferName} 환승${etaSuffix}`;
-      return { title, body };
+      return { title, body: `${route.stopsToTransfer}역 후 ${route.transferName} 환승${etaSuffix}` };
     }
     const [t1] = route.transfers;
-    const body = `${t1.stopsToTransfer}역 후 ${t1.transferName} 환승${etaSuffix}`;
-    return { title, body };
+    return { title, body: `${t1.stopsToTransfer}역 후 ${t1.transferName} 환승${etaSuffix}` };
   }
-  return {
-    title: `${currentStation.name}역`,
-    body: `${LINE_NAMES[currentStation.line]} · 약 ${distanceM}m`,
-  };
+
+  // base: 경로 없이 목적지만 있거나 목적지도 없는 경우
+  return { title, body: `${LINE_NAMES[currentStation.line]} · 약 ${distanceM}m${etaSuffix}` };
 }
 
 function buildLiveActivityData(
@@ -103,38 +105,45 @@ function buildLiveActivityData(
   etaMinutes?: number | null,
   isMock?: boolean,
 ): LiveActivity.LiveActivityData {
-  const base: LiveActivity.LiveActivityData = {
+  // station layer: 항상 포함
+  const data: LiveActivity.LiveActivityData = {
     stationName: currentStation.name,
     lineName: LINE_NAMES[currentStation.line],
     lineColorHex: LINE_COLORS[currentStation.line],
     distanceM,
   };
 
-  if (etaMinutes != null) {
-    base.etaMinutes = etaMinutes;
-  }
-  if (isMock) {
-    base.isMock = true;
+  // destination layer: 목적지 있으면 독립적으로 포함
+  if (destination) {
+    data.destinationName = destination.name;
   }
 
+  // route layer: 경로 정보가 있을 때만
   if (destination && route) {
-    base.destinationName = destination.name;
     if (route.type === 'direct') {
-      base.stopsRemaining = route.stops;
+      data.stopsRemaining = route.stops;
     } else if (route.type === 'transfer') {
-      base.stopsToTransfer = route.stopsToTransfer;
-      base.transferStationName = route.transferName;
-      base.stopsFromTransfer = route.stopsFromTransfer;
+      data.stopsToTransfer = route.stopsToTransfer;
+      data.transferStationName = route.transferName;
+      data.stopsFromTransfer = route.stopsFromTransfer;
     } else {
-      base.stopsToTransfer = route.transfers[0].stopsToTransfer;
-      base.transferStationName = route.transfers[0].transferName;
-      base.stopsToSecondTransfer = route.transfers[1].stopsToTransfer;
-      base.secondTransferStationName = route.transfers[1].transferName;
-      base.stopsAfterLastTransfer = route.stopsAfterLastTransfer;
+      data.stopsToTransfer = route.transfers[0].stopsToTransfer;
+      data.transferStationName = route.transfers[0].transferName;
+      data.stopsToSecondTransfer = route.transfers[1].stopsToTransfer;
+      data.secondTransferStationName = route.transfers[1].transferName;
+      data.stopsAfterLastTransfer = route.stopsAfterLastTransfer;
     }
   }
 
-  return base;
+  // eta layer: ETA가 있을 때만
+  if (etaMinutes != null) {
+    data.etaMinutes = etaMinutes;
+  }
+  if (isMock) {
+    data.isMock = true;
+  }
+
+  return data;
 }
 
 export async function updateStationNotification(


### PR DESCRIPTION
## Summary

- 도착 정보 API fallback 및 정적 ETA 계산 구현
- useArrivalInfo 로딩 고착 버그 수정
- Live Activity UI 개선: ETA 표시, 하차/환승 알람 추가
- Live Activity 목적지 정보 미표시 버그 수정 (destinationName을 route와 독립 분리)
- Swift 브릿지 Codable 디코딩 전환으로 타입 안전성 확보
- Activity 상태 검증 + 자동 복구 로직 추가
- route/journey useMemo 안정화
- 알림 코드 중복 패턴 헬퍼 함수 추출

## Test plan

- [x] `npm test` 커버리지 100% 통과 (226 tests)
- [x] `npm run type-check` 통과
- [x] iOS 디바이스에서 목적지 설정 → Live Activity에 목적지 정보 표시 확인
- [x] 목적지 도착 시 하차 알림 확인
- [x] 환승역 접근 시 환승 알림 확인
- [x] API 장애 시 mock 데이터 fallback 확인

Closes #67