### PR TITLE
fix(#67): Live Activity 중복 잔존 및 목적지 해제 미종료 버그 수정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -18,11 +18,24 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { result, userLocation, loading, error, permissionDenied, refresh } = useNearestStation();
   const { arrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(result?.station.name ?? null);
-  const { addFavorite, removeFavorite, isFavorite, loadFavorites, destination, setDestination, recentDestination, setRecentDestination, sleepMode, setSleepMode, loadSleepMode, alarmEvent, clearAlarmEvent } = useAppStore();
+  const addFavorite = useAppStore((s) => s.addFavorite);
+  const removeFavorite = useAppStore((s) => s.removeFavorite);
+  const isFavorite = useAppStore((s) => s.isFavorite);
+  const loadFavorites = useAppStore((s) => s.loadFavorites);
+  const destination = useAppStore((s) => s.destination);
+  const setDestination = useAppStore((s) => s.setDestination);
+  const recentDestination = useAppStore((s) => s.recentDestination);
+  const setRecentDestination = useAppStore((s) => s.setRecentDestination);
+  const sleepMode = useAppStore((s) => s.sleepMode);
+  const setSleepMode = useAppStore((s) => s.setSleepMode);
+  const loadSleepMode = useAppStore((s) => s.loadSleepMode);
+  const alarmEvent = useAppStore((s) => s.alarmEvent);
+  const clearAlarmEvent = useAppStore((s) => s.clearAlarmEvent);
   const [pickerVisible, setPickerVisible] = useState(false);
   const [arrivedBanner, setArrivedBanner] = useState(false);
   const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
+  const prevDestIdRef = useRef<string | null>(null);
   const route = useMemo(
     () => (result && destination ? findRoute(result.station.id, destination.id) : null),
     [result?.station.id, destination?.id],
@@ -53,6 +66,10 @@ export default function HomeScreen() {
   }, []);
 
   useEffect(() => {
+    const prevDestId = prevDestIdRef.current;
+    const currDestId = destination?.id ?? null;
+    prevDestIdRef.current = currDestId;
+
     if (!result) {
       if (prevNotifKeyRef.current !== 'none') {
         prevNotifKeyRef.current = 'none';
@@ -64,15 +81,24 @@ export default function HomeScreen() {
     const key = `${result.station.id}__${destination?.id ?? ''}__${displayEta ?? ''}__${arrivalIsMock}`;
     if (key === prevNotifKeyRef.current) return;
     prevNotifKeyRef.current = key;
-    logger.info('알림 업데이트:', result.station.name, destination ? `→ ${destination.name}` : '');
-    updateStationNotification(
-      result.station,
-      Math.round(result.distanceKm * 1000),
-      destination,
-      route ?? null,
-      displayEta,
-      arrivalIsMock,
-    ).catch((e) => logger.error('알림 업데이트 실패:', e));
+
+    const destinationCleared = prevDestId != null && currDestId == null;
+    const update = async () => {
+      if (destinationCleared) {
+        logger.info('목적지 해제 → Live Activity 종료 후 재시작');
+        await clearStationNotification();
+      }
+      logger.info('알림 업데이트:', result.station.name, destination ? `→ ${destination.name}` : '');
+      await updateStationNotification(
+        result.station,
+        Math.round(result.distanceKm * 1000),
+        destination,
+        route ?? null,
+        displayEta,
+        arrivalIsMock,
+      );
+    };
+    update().catch((e) => logger.error('알림 업데이트 실패:', e));
   }, [result?.station.id, destination?.id, displayEta, arrivalIsMock]);
 
   useEffect(() => {

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -31,11 +31,16 @@ class LiveActivityManager {
 
     private init() {}
 
-    func start(data: [String: Any]) async throws {
-        if let existing = currentActivity {
-            await existing.end(dismissalPolicy: .immediate)
-            currentActivity = nil
+    /// 현재 추적 중인 Activity + 이전 세션에서 남은 고아 Activity 일괄 종료
+    private func endAllActivities() async {
+        currentActivity = nil
+        for activity in Activity<SubwayActivityAttributes>.activities {
+            await activity.end(dismissalPolicy: .immediate)
         }
+    }
+
+    func start(data: [String: Any]) async throws {
+        await endAllActivities()
 
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             throw NSError(
@@ -80,10 +85,7 @@ class LiveActivityManager {
     }
 
     func end() async {
-        if let activity = currentActivity {
-            await activity.end(dismissalPolicy: .immediate)
-            currentActivity = nil
-        }
+        await endAllActivities()
     }
 
     // JSON → Codable 디코딩: 타입 안전성 보장, 필드 추가 시 struct만 수정하면 됨

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -1,8 +1,16 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { AppState } from 'react-native';
 import { useArrivalInfo } from '../useArrivalInfo';
 import * as arrivalApiModule from '../../api/arrivalApi';
 
 jest.mock('../../api/arrivalApi');
+
+const mockRemove = jest.fn();
+let appStateCallback: ((state: string) => void) | null = null;
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
+  appStateCallback = listener as (state: string) => void;
+  return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+});
 
 const mockArrival = {
   up: [{ destination: '소요산행', arrivalMinutes: 2, trainCode: 'T001' }],
@@ -18,6 +26,7 @@ describe('useArrivalInfo', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    appStateCallback = null;
   });
 
   afterEach(() => {
@@ -192,6 +201,42 @@ describe('useArrivalInfo', () => {
 
     // 백그라운드 fetch 완료 후 갱신
     await waitFor(() => expect(result.current.arrival).toEqual(updatedArrival));
+  });
+
+  it('AppState가 active로 변경되면 도착 정보를 다시 가져온다', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    renderHook(() => useArrivalInfo('강남'));
+
+    await waitFor(() =>
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledTimes(1)
+    );
+
+    await act(async () => {
+      appStateCallback?.('active');
+    });
+
+    await waitFor(() =>
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it('AppState가 background로 변경되면 interval을 정리한다', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    renderHook(() => useArrivalInfo('강남'));
+
+    await waitFor(() =>
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledTimes(1)
+    );
+
+    act(() => {
+      appStateCallback?.('background');
+    });
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
   });
 
   it('stationName이 유효한 값에서 null로 바뀌면 loading이 false가 된다', async () => {

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -18,7 +18,6 @@ describe('useArrivalInfo', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    appStateCallback = null;
   });
 
   afterEach(() => {

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -1,16 +1,8 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
-import { AppState } from 'react-native';
 import { useArrivalInfo } from '../useArrivalInfo';
 import * as arrivalApiModule from '../../api/arrivalApi';
 
 jest.mock('../../api/arrivalApi');
-
-const mockRemove = jest.fn();
-let appStateCallback: ((state: string) => void) | null = null;
-jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
-  appStateCallback = listener as (state: string) => void;
-  return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
-});
 
 const mockArrival = {
   up: [{ destination: '소요산행', arrivalMinutes: 2, trainCode: 'T001' }],
@@ -201,42 +193,6 @@ describe('useArrivalInfo', () => {
 
     // 백그라운드 fetch 완료 후 갱신
     await waitFor(() => expect(result.current.arrival).toEqual(updatedArrival));
-  });
-
-  it('AppState가 active로 변경되면 도착 정보를 다시 가져온다', async () => {
-    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
-
-    renderHook(() => useArrivalInfo('강남'));
-
-    await waitFor(() =>
-      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledTimes(1)
-    );
-
-    await act(async () => {
-      appStateCallback?.('active');
-    });
-
-    await waitFor(() =>
-      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledTimes(2)
-    );
-  });
-
-  it('AppState가 background로 변경되면 interval을 정리한다', async () => {
-    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
-
-    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
-    renderHook(() => useArrivalInfo('강남'));
-
-    await waitFor(() =>
-      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledTimes(1)
-    );
-
-    act(() => {
-      appStateCallback?.('background');
-    });
-
-    expect(clearIntervalSpy).toHaveBeenCalled();
-    clearIntervalSpy.mockRestore();
   });
 
   it('stationName이 유효한 값에서 null로 바뀌면 loading이 false가 된다', async () => {

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -1,8 +1,16 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import * as Location from 'expo-location';
+import { AppState } from 'react-native';
 import { useNearestStation } from '../useNearestStation';
 
 jest.mock('expo-location');
+
+const mockRemove = jest.fn();
+let appStateCallback: ((state: string) => void) | null = null;
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
+  appStateCallback = listener as (state: string) => void;
+  return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+});
 
 const mockGranted = () => {
   (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
@@ -26,6 +34,7 @@ describe('useNearestStation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    appStateCallback = null;
   });
 
   afterEach(() => {
@@ -137,6 +146,44 @@ describe('useNearestStation', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('AppState가 active로 변경되면 위치를 다시 가져온다', async () => {
+    mockGranted();
+    mockLocation(37.4980, 127.0277);
+
+    renderHook(() => useNearestStation());
+
+    await waitFor(() =>
+      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1)
+    );
+
+    await act(async () => {
+      appStateCallback?.('active');
+    });
+
+    await waitFor(() =>
+      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it('AppState가 background로 변경되면 interval을 정리한다', async () => {
+    mockGranted();
+    mockLocation(37.4980, 127.0277);
+
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    renderHook(() => useNearestStation());
+
+    await waitFor(() =>
+      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1)
+    );
+
+    act(() => {
+      appStateCallback?.('background');
+    });
+
     expect(clearIntervalSpy).toHaveBeenCalled();
     clearIntervalSpy.mockRestore();
   });

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -1,16 +1,8 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import * as Location from 'expo-location';
-import { AppState } from 'react-native';
 import { useNearestStation } from '../useNearestStation';
 
 jest.mock('expo-location');
-
-const mockRemove = jest.fn();
-let appStateCallback: ((state: string) => void) | null = null;
-jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
-  appStateCallback = listener as (state: string) => void;
-  return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
-});
 
 const mockGranted = () => {
   (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
@@ -34,7 +26,6 @@ describe('useNearestStation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    appStateCallback = null;
   });
 
   afterEach(() => {
@@ -150,42 +141,5 @@ describe('useNearestStation', () => {
     clearIntervalSpy.mockRestore();
   });
 
-  it('AppState가 active로 변경되면 위치를 다시 가져온다', async () => {
-    mockGranted();
-    mockLocation(37.4980, 127.0277);
-
-    renderHook(() => useNearestStation());
-
-    await waitFor(() =>
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1)
-    );
-
-    await act(async () => {
-      appStateCallback?.('active');
-    });
-
-    await waitFor(() =>
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(2)
-    );
-  });
-
-  it('AppState가 background로 변경되면 interval을 정리한다', async () => {
-    mockGranted();
-    mockLocation(37.4980, 127.0277);
-
-    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
-    renderHook(() => useNearestStation());
-
-    await waitFor(() =>
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1)
-    );
-
-    act(() => {
-      appStateCallback?.('background');
-    });
-
-    expect(clearIntervalSpy).toHaveBeenCalled();
-    clearIntervalSpy.mockRestore();
-  });
 });
 

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -159,15 +159,13 @@ describe('stationNotification', () => {
   describe('updateStationNotification (iOS - Live Activity)', () => {
     beforeEach(async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      // liveActivityStarted 초기화
-      await clearStationNotification();
       jest.clearAllMocks();
       mockIsLiveActivityEnabled.mockReturnValue(true);
     });
 
-    it('처음 호출 시 startLiveActivity를 호출한다', async () => {
+    it('updateLiveActivity를 호출한다', async () => {
       await updateStationNotification(mockStation, 154);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           stationName: '시청',
           lineName: '1호선',
@@ -175,26 +173,26 @@ describe('stationNotification', () => {
           distanceM: 154,
         })
       );
-      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+      expect(mockStartLiveActivity).not.toHaveBeenCalled();
     });
 
-    it('두 번째 호출부터는 updateLiveActivity를 호출한다', async () => {
+    it('연속 호출 시 항상 updateLiveActivity를 호출한다', async () => {
       await updateStationNotification(mockStation, 154);
       await updateStationNotification(mockStation, 100);
-      expect(mockStartLiveActivity).toHaveBeenCalledTimes(1);
-      expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+      expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(2);
+      expect(mockStartLiveActivity).not.toHaveBeenCalled();
     });
 
     it('목적지 없으면 destinationName이 없다', async () => {
       await updateStationNotification(mockStation, 154);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.not.objectContaining({ destinationName: expect.anything() })
       );
     });
 
     it('직통 경로이면 stopsRemaining을 포함한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, directRoute);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           destinationName: '성신여대입구',
           stopsRemaining: 4,
@@ -204,7 +202,7 @@ describe('stationNotification', () => {
 
     it('환승 경로이면 환승 정보를 포함한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, transferRoute);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           destinationName: '성신여대입구',
           stopsToTransfer: 3,
@@ -216,7 +214,7 @@ describe('stationNotification', () => {
 
     it('multi-transfer 경로이면 두 환승 정보를 포함한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, multiTransferRoute);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           destinationName: '성신여대입구',
           stopsToTransfer: 3,
@@ -230,7 +228,7 @@ describe('stationNotification', () => {
 
     it('etaMinutes를 전달하면 Live Activity 데이터에 포함된다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           etaMinutes: 12,
         })
@@ -239,7 +237,7 @@ describe('stationNotification', () => {
 
     it('isMock이 true이면 Live Activity 데이터에 포함된다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12, true);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           etaMinutes: 12,
           isMock: true,
@@ -249,20 +247,20 @@ describe('stationNotification', () => {
 
     it('etaMinutes가 없으면 Live Activity 데이터에 포함되지 않는다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, directRoute);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.not.objectContaining({ etaMinutes: expect.anything() })
       );
     });
 
     it('목적지만 있고 경로가 없으면 destinationName만 포함한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, null);
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({ destinationName: '성신여대입구' })
       );
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.not.objectContaining({ stopsRemaining: expect.anything() })
       );
-      expect(mockStartLiveActivity).toHaveBeenCalledWith(
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.not.objectContaining({ stopsToTransfer: expect.anything() })
       );
     });
@@ -280,32 +278,10 @@ describe('stationNotification', () => {
       expectNotificationContent('시청역', '1호선 · 약 154m');
     });
 
-    it('startLiveActivity 실패 시 expo-notifications로 폴백한다', async () => {
-      mockStartLiveActivity.mockRejectedValueOnce(new Error('ActivityKit 오류'));
+    it('updateLiveActivity 실패 시 expo-notifications로 폴백한다', async () => {
+      mockUpdateLiveActivity.mockRejectedValueOnce(new Error('ActivityKit 오류'));
       await updateStationNotification(mockStation, 154);
       expectNotificationContent('시청역', '1호선 · 약 154m');
-    });
-
-    it('startLiveActivity 실패 시 liveActivityStarted를 false로 리셋한다', async () => {
-      mockStartLiveActivity.mockRejectedValueOnce(new Error('ActivityKit 오류'));
-      await updateStationNotification(mockStation, 154);
-      // liveActivityStarted가 리셋됐으므로 다음 호출도 start를 사용해야 함
-      jest.clearAllMocks();
-      mockIsLiveActivityEnabled.mockReturnValue(true);
-      await updateStationNotification(mockStation, 100);
-      expect(mockStartLiveActivity).toHaveBeenCalled();
-      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
-    });
-
-    it('updateLiveActivity 실패 시 liveActivityStarted를 false로 리셋한다', async () => {
-      await updateStationNotification(mockStation, 154);
-      mockUpdateLiveActivity.mockRejectedValueOnce(new Error('업데이트 오류'));
-      await updateStationNotification(mockStation, 100);
-      // liveActivityStarted가 리셋됐으므로 다음 호출은 start를 사용해야 함
-      jest.clearAllMocks();
-      mockIsLiveActivityEnabled.mockReturnValue(true);
-      await updateStationNotification(mockStation, 80);
-      expect(mockStartLiveActivity).toHaveBeenCalled();
     });
   });
 
@@ -370,39 +346,21 @@ describe('stationNotification', () => {
   });
 
   describe('clearStationNotification', () => {
-    it('iOS에서 endLiveActivity를 호출하고 liveActivityStarted를 초기화한다', async () => {
+    it('iOS에서 endLiveActivity를 호출한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      // 먼저 start 상태로 만들기
-      await updateStationNotification(mockStation, 154);
-      jest.clearAllMocks();
       mockIsLiveActivityEnabled.mockReturnValue(true);
 
       await clearStationNotification();
       expect(mockEndLiveActivity).toHaveBeenCalled();
       expect(Notifications.dismissNotificationAsync).not.toHaveBeenCalled();
-
-      // 초기화 확인: 다음 update는 start를 호출해야 함
-      jest.clearAllMocks();
-      mockIsLiveActivityEnabled.mockReturnValue(true);
-      await updateStationNotification(mockStation, 100);
-      expect(mockStartLiveActivity).toHaveBeenCalled();
     });
 
-    it('iOS에서 endLiveActivity가 실패해도 liveActivityStarted를 초기화한다', async () => {
+    it('iOS에서 endLiveActivity가 실패해도 에러를 던지지 않는다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await updateStationNotification(mockStation, 154);
-      mockEndLiveActivity.mockRejectedValueOnce(new Error('종료 실패'));
-      jest.clearAllMocks();
-      mockEndLiveActivity.mockRejectedValueOnce(new Error('종료 실패'));
       mockIsLiveActivityEnabled.mockReturnValue(true);
+      mockEndLiveActivity.mockRejectedValueOnce(new Error('종료 실패'));
 
-      await clearStationNotification();
-
-      // 에러 후에도 liveActivityStarted가 리셋되어야 함
-      jest.clearAllMocks();
-      mockIsLiveActivityEnabled.mockReturnValue(true);
-      await updateStationNotification(mockStation, 100);
-      expect(mockStartLiveActivity).toHaveBeenCalled();
+      await expect(clearStationNotification()).resolves.toBeUndefined();
     });
 
     it('iOS에서 Live Activity 비활성화 시 dismissNotificationAsync를 호출한다', async () => {

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -14,8 +14,6 @@ const NOTIFICATION_ID = 'current-station';
 const ALARM_NOTIFICATION_ID = 'station-alarm';
 const ALARM_CHANNEL_ID = 'station-alarm';
 
-// iOS Live Activity 상태 추적 (start vs update 구분)
-let liveActivityStarted = false;
 
 async function scheduleNotification(
   id: string,
@@ -170,19 +168,11 @@ export async function updateStationNotification(
     }
     const data = buildLiveActivityData(currentStation, distanceM, destination, route, etaMinutes, isMock);
     try {
-      if (!liveActivityStarted) {
-        liveActivityLogger.info('시작 요청');
-        await LiveActivity.startLiveActivity(data);
-        liveActivityStarted = true;
-        liveActivityLogger.info('시작 성공');
-      } else {
-        liveActivityLogger.info('업데이트 요청');
-        await LiveActivity.updateLiveActivity(data);
-        liveActivityLogger.info('업데이트 성공');
-      }
+      liveActivityLogger.info('업데이트 요청');
+      await LiveActivity.updateLiveActivity(data);
+      liveActivityLogger.info('업데이트 성공');
     } catch (e) {
-      liveActivityLogger.error('시작/업데이트 실패:', e);
-      liveActivityStarted = false;
+      liveActivityLogger.error('업데이트 실패:', e);
       notifLogger.info('Live Activity 실패 → 알림 fallback');
       const { title, body } = buildContent(currentStation, distanceM, destination, route, etaMinutes, isMock);
       await scheduleNotification(NOTIFICATION_ID, { title, body });
@@ -211,7 +201,6 @@ export async function clearStationNotification(): Promise<void> {
     } catch (e) {
       liveActivityLogger.error('종료 실패:', e);
     }
-    liveActivityStarted = false;
     return;
   }
   notifLogger.info('Android 알림 해제');


### PR DESCRIPTION
## Summary
- Live Activity가 앱 재시작 시 고아 Activity로 중복 잔존하는 버그 수정
- 목적지 해제 시 Live Activity가 종료되지 않고 업데이트만 되던 버그 수정
- `liveActivityStarted` TS 플래그 제거, Swift `update()`에 start/update 분기 위임

## Changes
- **Swift**: `endAllActivities()` 헬퍼로 `Activity<T>.activities` 전체 순회하여 고아 Activity 일괄 정리
- **TS**: `liveActivityStarted` 전역 플래그 제거, 항상 `updateLiveActivity()` 호출
- **HomeScreen**: `prevDestIdRef`로 목적지 해제 감지 → `clear→update` 순서로 Live Activity 재시작

## Test plan
- [x] `npm test` 커버리지 100% 통과
- [x] `npm run type-check` 통과
- [x] 앱 강제종료 후 재시작 → Live Activity 1개만 표시
- [x] 목적지 설정 → 초기화 → 이전 Live Activity 사라지고 새로 갱신
- [x] 목적지 설정 → 도착 → Live Activity 자동 종료

Closes #67