### PR TITLE
refactor(#75): 폴링/캐시 재사용 유틸 추출 및 stale 데이터 해결

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -83,9 +83,15 @@ export default function HomeScreen() {
     prevNotifKeyRef.current = key;
 
     const destinationCleared = prevDestId != null && currDestId == null;
+    const destinationChanged = prevDestId != null && currDestId != null && prevDestId !== currDestId;
     const update = async () => {
-      if (destinationCleared) {
-        logger.info('목적지 해제 → Live Activity 종료 후 재시작');
+      if (destinationCleared || destinationChanged) {
+        if (destinationCleared) {
+          logger.info('목적지 해제 → Live Activity 종료 후 재시작');
+        } else {
+          logger.info('목적지 변경 → 이전 알림 교체');
+        }
+        await clearAlarmNotification();
         await clearStationNotification();
       }
       logger.info('알림 업데이트:', result.station.name, destination ? `→ ${destination.name}` : '');

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -254,4 +254,140 @@ describe('useArrivalInfo', () => {
     unmount();
     expect(mockRemove).toHaveBeenCalled();
   });
+
+  it('TTL 만료 시 캐시를 사용하지 않고 loading 상태로 전환한다', async () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string | null }) => useArrivalInfo(name),
+      { initialProps: { name: '강남' as string | null } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 다른 역으로 전환
+    rerender({ name: '역삼' });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // TTL 초과 후 강남 복귀
+    jest.spyOn(Date, 'now').mockReturnValue(now + 31_000);
+    rerender({ name: '강남' });
+
+    // TTL 만료 → 캐시 미사용 → loading 상태
+    expect(result.current.arrival).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    jest.restoreAllMocks();
+  });
+
+  it('stationName이 null일 때 폴링 콜백은 fetch하지 않는다', async () => {
+    renderHook(() => useArrivalInfo(null));
+
+    jest.advanceTimersByTime(30_000);
+    await Promise.resolve();
+
+    expect(arrivalApiModule.fetchArrivalInfo).not.toHaveBeenCalled();
+  });
+
+  it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
+    const staleArrival = {
+      up: [{ destination: '이전역', arrivalMinutes: 99, trainCode: 'OLD' }],
+      down: [],
+    };
+    const freshArrival = {
+      up: [{ destination: '새역', arrivalMinutes: 1, trainCode: 'NEW' }],
+      down: [],
+    };
+
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(freshArrival);
+
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string | null }) => useArrivalInfo(name),
+      { initialProps: { name: '강남' as string | null } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 폴링 콜백에서 느린 fetch가 시작되도록 설정
+    let resolvePollingFetch!: (value: typeof staleArrival) => void;
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockImplementation(
+      (name: string) => {
+        if (name === '강남') {
+          return new Promise((r) => { resolvePollingFetch = r; });
+        }
+        return Promise.resolve(freshArrival);
+      }
+    );
+
+    // 폴링 트리거 → '강남'에 대한 느린 fetch 시작
+    act(() => { jest.advanceTimersByTime(30_000); });
+
+    // 역 변경 → stationNameRef.current가 '역삼'으로 바뀜
+    rerender({ name: '역삼' });
+    await waitFor(() => expect(result.current.arrival).toEqual(freshArrival));
+
+    // 이전 폴링의 '강남' 응답 도착 → name !== stationNameRef.current → 무시
+    await act(async () => { resolvePollingFetch(staleArrival); });
+
+    expect(result.current.arrival).toEqual(freshArrival);
+  });
+
+  it('폴링 콜백에서 mock 데이터를 받으면 캐시에 저장하지 않는다', async () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const { result } = renderHook(() => useArrivalInfo('강남'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.arrival).toEqual(mockArrival);
+
+    // 폴링에서 mock 데이터 반환 → 캐시에 저장 안 됨
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrivalWithMock);
+
+    act(() => { jest.advanceTimersByTime(30_000); });
+    await waitFor(() => expect(result.current.isMock).toBe(true));
+    // mock 데이터가 arrival에 반영되었지만 캐시에는 이전 실제 데이터만 있음
+    expect(result.current.arrival).toEqual(mockArrivalWithMock);
+
+    jest.restoreAllMocks();
+  });
+
+  it('폴링 콜백에서 fetch 실패 시 에러를 무시한다', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const { result } = renderHook(() => useArrivalInfo('강남'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 폴링에서 에러 발생
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockRejectedValue(new Error('network'));
+
+    act(() => { jest.advanceTimersByTime(30_000); });
+    await Promise.resolve();
+
+    // 에러 무시 — 기존 데이터 유지
+    expect(result.current.arrival).toEqual(mockArrival);
+  });
+
+  it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
+    const freshArrival = {
+      up: [{ destination: '소요산행', arrivalMinutes: 1, trainCode: 'T003' }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, trainCode: 'T004' }],
+    };
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    const { result } = renderHook(() => useArrivalInfo('강남'));
+    await waitFor(() => expect(result.current.arrival).toEqual(mockArrival));
+
+    // 백그라운드 → 포그라운드 복귀 시 새 데이터
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(freshArrival);
+    act(() => { appStateCallback?.('background'); });
+    act(() => { appStateCallback?.('active'); });
+
+    await waitFor(() => expect(result.current.arrival).toEqual(freshArrival));
+  });
 });

--- a/src/hooks/__tests__/usePolling.test.ts
+++ b/src/hooks/__tests__/usePolling.test.ts
@@ -1,0 +1,119 @@
+import { renderHook } from '@testing-library/react-native';
+import { AppState } from 'react-native';
+import { usePolling } from '../usePolling';
+
+const mockRemove = jest.fn();
+let appStateCallback: ((state: string) => void) | null = null;
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
+  appStateCallback = listener as (state: string) => void;
+  return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+});
+
+describe('usePolling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    appStateCallback = null;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('intervalMs 간격으로 callback을 반복 호출한다', () => {
+    const cb = jest.fn();
+    renderHook(() => usePolling(cb, 30_000));
+
+    expect(cb).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30_000);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(30_000);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('백그라운드 전환 시 인터벌을 중지한다', () => {
+    const cb = jest.fn();
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    renderHook(() => usePolling(cb, 30_000));
+
+    appStateCallback?.('background');
+    expect(clearIntervalSpy).toHaveBeenCalled();
+
+    // 백그라운드에서는 호출되지 않음
+    jest.advanceTimersByTime(60_000);
+    expect(cb).not.toHaveBeenCalled();
+
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('포그라운드 복귀 시 즉시 호출 + 인터벌 재시작', () => {
+    const cb = jest.fn();
+    renderHook(() => usePolling(cb, 30_000));
+
+    appStateCallback?.('background');
+    appStateCallback?.('active');
+
+    // 즉시 호출
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // 인터벌 재시작
+    jest.advanceTimersByTime(30_000);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('포그라운드 복귀 시 onResume을 callback 전에 호출한다', () => {
+    const order: string[] = [];
+    const cb = jest.fn(() => order.push('callback'));
+    const onResume = jest.fn(() => order.push('onResume'));
+
+    renderHook(() => usePolling(cb, 30_000, { onResume }));
+
+    appStateCallback?.('background');
+    appStateCallback?.('active');
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['onResume', 'callback']);
+  });
+
+  it('onResume 없이도 정상 동작한다', () => {
+    const cb = jest.fn();
+    renderHook(() => usePolling(cb, 30_000));
+
+    appStateCallback?.('background');
+    appStateCallback?.('active');
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('언마운트 시 인터벌과 AppState 리스너를 정리한다', () => {
+    const cb = jest.fn();
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    const { unmount } = renderHook(() => usePolling(cb, 30_000));
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(mockRemove).toHaveBeenCalled();
+
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('callback이 변경되면 최신 callback을 호출한다', () => {
+    const cb1 = jest.fn();
+    const cb2 = jest.fn();
+
+    const { rerender } = renderHook(
+      (props: { cb: () => void }) => usePolling(props.cb, 30_000),
+      { initialProps: { cb: cb1 } },
+    );
+
+    rerender({ cb: cb2 });
+
+    jest.advanceTimersByTime(30_000);
+    expect(cb1).not.toHaveBeenCalled();
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import { AppState } from 'react-native';
 import type { StationArrival } from '../api/arrivalApi';
 import type { ArrivalProvider } from '../providers/types';
 import { createArrivalProvider } from '../providers/factory';
+import { TtlCache } from '../utils/ttlCache';
+import { usePolling } from './usePolling';
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -18,9 +19,10 @@ export function useArrivalInfo(
 ): UseArrivalInfoReturn {
   const [arrival, setArrival] = useState<StationArrival | null>(null);
   const [loading, setLoading] = useState(false);
-  const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined as unknown as ReturnType<typeof setInterval>);
-  const cacheRef = useRef<Map<string, StationArrival>>(new Map());
+  const cacheRef = useRef(new TtlCache<string, StationArrival>(POLL_INTERVAL_MS));
   const providerRef = useRef<ArrivalProvider>(provider ?? createArrivalProvider());
+  const stationNameRef = useRef(stationName);
+  stationNameRef.current = stationName;
 
   useEffect(() => {
     if (!stationName) {
@@ -29,7 +31,6 @@ export function useArrivalInfo(
       return;
     }
 
-    let cancelled = false;
     const cached = cacheRef.current.get(stationName);
     if (cached) {
       setArrival(cached);
@@ -38,6 +39,12 @@ export function useArrivalInfo(
       setArrival(null);
       setLoading(true);
     }
+  }, [stationName]);
+
+  useEffect(() => {
+    if (!stationName) return;
+
+    let cancelled = false;
 
     const poll = async () => {
       try {
@@ -55,22 +62,28 @@ export function useArrivalInfo(
     };
 
     poll();
-    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
-
-    const subscription = AppState.addEventListener('change', (state) => {
-      clearInterval(intervalRef.current);
-      if (state === 'active') {
-        poll();
-        intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
-      }
-    });
 
     return () => {
       cancelled = true;
-      clearInterval(intervalRef.current);
-      subscription.remove();
     };
   }, [stationName]);
+
+  usePolling(
+    () => {
+      const name = stationNameRef.current;
+      if (!name) return;
+      providerRef.current.getArrival(name).then((data) => {
+        if (name !== stationNameRef.current) return;
+        if (!data.isMock) {
+          cacheRef.current.set(name, data);
+        }
+        setArrival(data);
+        setLoading(false);
+      }).catch(() => {});
+    },
+    POLL_INTERVAL_MS,
+    { onResume: () => cacheRef.current.clear() },
+  );
 
   return { arrival, loading, isMock: arrival?.isMock ?? false };
 }

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AppState } from 'react-native';
 import * as Location from 'expo-location';
 import stationsData from '../data/stations.json';
 import { haversine } from '../utils/haversine';
 import { NearestStationResult, Station } from '../types/station';
+import { usePolling } from './usePolling';
 
 const stations = stationsData as Station[];
 const UPDATE_INTERVAL_MS = 30_000;
@@ -23,7 +23,6 @@ export function useNearestStation(): UseNearestStationReturn {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
-  const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined as unknown as ReturnType<typeof setInterval>);
 
   const findNearest = useCallback(
     (lat: number, lng: number): NearestStationResult | null => {
@@ -73,21 +72,9 @@ export function useNearestStation(): UseNearestStationReturn {
 
   useEffect(() => {
     refresh();
-    intervalRef.current = setInterval(refresh, UPDATE_INTERVAL_MS);
-
-    const subscription = AppState.addEventListener('change', (state) => {
-      clearInterval(intervalRef.current);
-      if (state === 'active') {
-        refresh();
-        intervalRef.current = setInterval(refresh, UPDATE_INTERVAL_MS);
-      }
-    });
-
-    return () => {
-      clearInterval(intervalRef.current);
-      subscription.remove();
-    };
   }, [refresh]);
+
+  usePolling(refresh, UPDATE_INTERVAL_MS);
 
   return { result, userLocation, loading, error, permissionDenied, refresh };
 }

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
+
+export function usePolling(
+  callback: () => void,
+  intervalMs: number,
+  options?: { onResume?: () => void },
+): void {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const onResumeRef = useRef(options?.onResume);
+  onResumeRef.current = options?.onResume;
+
+  useEffect(() => {
+    const intervalRef = { current: setInterval(() => callbackRef.current(), intervalMs) };
+
+    const subscription = AppState.addEventListener('change', (state) => {
+      clearInterval(intervalRef.current);
+      if (state === 'active') {
+        onResumeRef.current?.();
+        callbackRef.current();
+        intervalRef.current = setInterval(() => callbackRef.current(), intervalMs);
+      }
+    });
+
+    return () => {
+      clearInterval(intervalRef.current);
+      subscription.remove();
+    };
+  }, [intervalMs]);
+}

--- a/src/utils/__tests__/ttlCache.test.ts
+++ b/src/utils/__tests__/ttlCache.test.ts
@@ -1,0 +1,73 @@
+import { TtlCache } from '../ttlCache';
+
+describe('TtlCache', () => {
+  let now: number;
+
+  beforeEach(() => {
+    now = 1000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('TTL 이내 get → 값 반환', () => {
+    const cache = new TtlCache<string, number>(100);
+    cache.set('a', 42);
+
+    now = 1050; // 50ms 경과 (TTL 100ms 이내)
+    expect(cache.get('a')).toBe(42);
+  });
+
+  it('TTL 초과 get → undefined 반환 및 엔트리 삭제', () => {
+    const cache = new TtlCache<string, number>(100);
+    cache.set('a', 42);
+
+    now = 1100; // 100ms 경과 (TTL 도달)
+    expect(cache.get('a')).toBeUndefined();
+
+    // 삭제 확인: TTL 되돌려도 없음
+    now = 1000;
+    expect(cache.get('a')).toBeUndefined();
+  });
+
+  it('존재하지 않는 키 get → undefined', () => {
+    const cache = new TtlCache<string, number>(100);
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('같은 키 set → 타임스탬프 갱신', () => {
+    const cache = new TtlCache<string, number>(100);
+    cache.set('a', 1);
+
+    now = 1080; // 80ms 경과
+    cache.set('a', 2); // 타임스탬프 갱신
+
+    now = 1160; // 첫 set 기준 160ms, 두번째 set 기준 80ms
+    expect(cache.get('a')).toBe(2);
+  });
+
+  it('clear → 전체 삭제', () => {
+    const cache = new TtlCache<string, number>(100);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    cache.clear();
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBeUndefined();
+  });
+
+  it('서로 다른 키는 독립적으로 만료', () => {
+    const cache = new TtlCache<string, number>(100);
+    cache.set('a', 1);
+
+    now = 1050;
+    cache.set('b', 2);
+
+    now = 1100; // a는 100ms 경과(만료), b는 50ms 경과(유효)
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+  });
+});

--- a/src/utils/ttlCache.ts
+++ b/src/utils/ttlCache.ts
@@ -1,0 +1,23 @@
+export class TtlCache<K, V> {
+  private map = new Map<K, { data: V; timestamp: number }>();
+
+  constructor(private ttlMs: number) {}
+
+  get(key: K): V | undefined {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (Date.now() - entry.timestamp >= this.ttlMs) {
+      this.map.delete(key);
+      return undefined;
+    }
+    return entry.data;
+  }
+
+  set(key: K, value: V): void {
+    this.map.set(key, { data: value, timestamp: Date.now() });
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}


### PR DESCRIPTION
## Summary

- **TtlCache 유틸리티 생성**: 제네릭 TTL 기반 캐시 클래스 (`src/utils/ttlCache.ts`) — 재사용 가능
- **usePolling 훅 생성**: 폴링 + AppState 중복 로직 추출 (`src/hooks/usePolling.ts`) — `useArrivalInfo`, `useNearestStation` 두 훅에서 공통 사용
- **useArrivalInfo 리팩토링**: `Map` → `TtlCache` (30초 TTL) 교체, 포그라운드 복귀 시 캐시 클리어로 stale 데이터 근본 해결
- **useNearestStation 리팩토링**: 폴링 로직을 `usePolling`으로 대체하여 중복 제거
- **알림 즉시 교체**: 목적지 변경 시 이전 알람 알림 제거 + Live Activity 종료 후 재시작 (항상 1개만 유지)

Closes #75

## Test plan

- [x] `npm test` — 300개 전체 통과
- [x] 커버리지 100% (statements / branches / functions / lines)
- [x] `npm run type-check` — 타입 오류 없음
- [x] 신규 유틸 테스트는 본 코드에 의존하지 않고 독립 실행 가능
- [x] 기존 테스트 전부 통과 (외부 동작 변경 없음)