### PR TITLE
perf(#75): 경로 탐색 인덱스 캐싱 및 InteractionManager 적용

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { InteractionManager, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
-import { findRoute, buildJourneyDisplay, calculateETA, calculateStaticETA } from '../../src/utils/stationRoute';
+import { findRoute, buildJourneyDisplay, calculateETA, calculateStaticETA, type Route } from '../../src/utils/stationRoute';
 import { JourneyTimeline } from '../../src/components/JourneyTimeline';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
@@ -36,10 +36,19 @@ export default function HomeScreen() {
   const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
   const prevDestIdRef = useRef<string | null>(null);
-  const route = useMemo(
-    () => (result && destination ? findRoute(result.station.id, destination.id) : null),
-    [result?.station.id, destination?.id],
-  );
+  const [route, setRoute] = useState<Route>(null);
+
+  useEffect(() => {
+    if (!result || !destination) {
+      setRoute(null);
+      return;
+    }
+    const interaction = InteractionManager.runAfterInteractions(() => {
+      setRoute(findRoute(result.station.id, destination.id));
+    });
+    return () => interaction.cancel();
+  }, [result?.station.id, destination?.id]);
+
   const journey = useMemo(
     () => (route && result && destination ? buildJourneyDisplay(route, result.station, destination) : null),
     [route, result?.station.id, destination?.id],
@@ -105,7 +114,7 @@ export default function HomeScreen() {
       );
     };
     update().catch((e) => logger.error('알림 업데이트 실패:', e));
-  }, [result?.station.id, destination?.id, displayEta, arrivalIsMock]);
+  }, [result?.station.id, destination?.id, displayEta, arrivalIsMock, route]);
 
   useEffect(() => {
     if (arrivedBanner) {

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -18,6 +18,18 @@ function getLineStationsCached(line: string): Station[] {
   return cached;
 }
 
+// 노선별 name→index 캐시 (성능 최적화: buildNameIndex 중복 호출 제거)
+const lineNameIndexCache = new Map<string, Map<string, number>>();
+
+function getLineNameIndexCached(line: string): Map<string, number> {
+  let cached = lineNameIndexCache.get(line);
+  if (!cached) {
+    cached = buildNameIndex(getLineStationsCached(line));
+    lineNameIndexCache.set(line, cached);
+  }
+  return cached;
+}
+
 export interface DirectRoute {
   type: 'direct';
   stops: number;
@@ -144,7 +156,7 @@ export function findRoute(currentId: string, destinationId: string): Route {
   const destIdx = destLineStations.findIndex((s) => s.id === destinationId);
 
   // 목적지 노선의 이름 → 인덱스 Map (O(1) 룩업)
-  const destNameIndex = buildNameIndex(destLineStations);
+  const destNameIndex = getLineNameIndexCached(destination.line);
 
   let bestRoute: TransferRoute | null = null;
   let bestTotal = Infinity;
@@ -194,8 +206,8 @@ function findMultiTransferRoute(
   let best: MultiTransferRoute | null = null;
   let bestTotal = Infinity;
 
-  const currentNameIndex = buildNameIndex(currentLineStations);
-  const destNameIndex = buildNameIndex(destLineStations);
+  const currentNameIndex = getLineNameIndexCached(current.line);
+  const destNameIndex = getLineNameIndexCached(destination.line);
 
   // 현재 노선에서 갈 수 있는 중간 노선들
   for (const [midLine, transfer1Names] of fromEdges) {
@@ -208,8 +220,7 @@ function findMultiTransferRoute(
     /* istanbul ignore next */
     if (!transfer2Names) continue;
 
-    const midLineStations = getLineStationsCached(midLine);
-    const midNameIndex = buildNameIndex(midLineStations);
+    const midNameIndex = getLineNameIndexCached(midLine);
 
     // 첫 번째 환승: 현재노선 → 중간노선
     for (const t1Name of transfer1Names) {


### PR DESCRIPTION
## Summary
- `buildNameIndex()` 중복 호출을 `lineNameIndexCache`로 캐싱하여 멀티환승 경로 탐색 성능 대폭 개선 (~434회 → 노선당 1회)
- `findRoute()`를 `InteractionManager.runAfterInteractions()`로 지연 실행하여 모달 닫기 애니메이션 중 UI 블로킹 해소
- 알림 useEffect에 `route` 의존성 추가하여 stale 데이터 방지

## Changes
### `src/utils/stationRoute.ts`
- `lineNameIndexCache` 모듈 레벨 캐시 추가
- `getLineNameIndexCached()` 함수로 노선별 name→index Map 재사용
- `findRoute()`, `findMultiTransferRoute()` 내 `buildNameIndex()` 호출 4곳을 캐시 버전으로 교체

### `app/(tabs)/index.tsx`
- `route` 계산을 `useMemo` → `useState` + `useEffect` + `InteractionManager.runAfterInteractions()`로 변경
- `journey`는 가벼운 연산이므로 `useMemo`로 파생 유지
- 알림 useEffect 의존성에 `route` 추가

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 커버리지 100% (lines/functions/branches/statements)
- [x] 기존 테스트 300개 전체 통과

Closes #75