### PR TITLE
perf(#81): Zustand selector 개별 분리로 불필요한 리렌더 제거

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -17,7 +17,11 @@ import stationsData from '../../src/data/stations.json';
 const allStations = stationsData as Station[];
 
 export default function FavoritesScreen() {
-  const { favorites, addFavorite, removeFavorite, isFavorite, loadFavorites } = useAppStore();
+  const favorites = useAppStore((s) => s.favorites);
+  const addFavorite = useAppStore((s) => s.addFavorite);
+  const removeFavorite = useAppStore((s) => s.removeFavorite);
+  const isFavorite = useAppStore((s) => s.isFavorite);
+  const loadFavorites = useAppStore((s) => s.loadFavorites);
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -4,7 +4,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppStore } from '../../src/store/useAppStore';
 
 export default function SettingsScreen() {
-  const { sleepMode, setSleepMode, loadSleepMode } = useAppStore();
+  const sleepMode = useAppStore((s) => s.sleepMode);
+  const setSleepMode = useAppStore((s) => s.setSleepMode);
+  const loadSleepMode = useAppStore((s) => s.loadSleepMode);
 
   useEffect(() => {
     loadSleepMode();


### PR DESCRIPTION
## Summary
- `favorites.tsx`: `useAppStore()` 전체 구독 → 개별 selector로 분리
- `settings.tsx`: `useAppStore()` 전체 구독 → 개별 selector로 분리
- 스토어의 무관한 상태 변경 시 불필요한 리렌더 방지

## Test plan
- [x] `npm test` 커버리지 100% 통과
- [x] `npm run type-check` 통과

Closes #81