### PR TITLE
fix(#85): 특수 노선 호선명 영어 표시 버그 수정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -241,7 +241,7 @@ export default function HomeScreen() {
                   <View style={styles.recentDestinationRow}>
                     <Text style={styles.recentDestinationName}>{recentDestination.name}</Text>
                     <View style={[styles.recentLineBadge, { backgroundColor: recentDestination.lineColor }]}>
-                      <Text style={styles.recentLineText}>{recentDestination.line}호선</Text>
+                      <Text style={styles.recentLineText}>{LINE_NAMES[recentDestination.line]}</Text>
                     </View>
                   </View>
                 </TouchableOpacity>

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import stations from '../data/stations.json';
 import type { Station } from '../types/station';
+import { LINE_NAMES } from '../constants/lineColors';
 import { StationMap } from './StationMap';
 
 
@@ -108,7 +109,7 @@ export function DestinationPicker({
                 >
                   <Text style={styles.suggestionName}>{s.name}</Text>
                   <View style={[styles.lineBadge, { backgroundColor: s.lineColor }]}>
-                    <Text style={styles.lineText}>{s.line}호선</Text>
+                    <Text style={styles.lineText}>{LINE_NAMES[s.line]}</Text>
                   </View>
                 </TouchableOpacity>
               ))}

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -106,6 +106,12 @@ describe('DestinationPicker', () => {
     expect(onSelect).toHaveBeenCalledWith(mockStation);
   });
 
+  it('특수 노선 검색 시 한글 호선명이 표시된다', () => {
+    const { getByTestId, getAllByText } = render(<DestinationPicker {...defaultProps} />);
+    fireEvent.changeText(getByTestId('search-input'), '김포공항');
+    expect(getAllByText('공항철도').length).toBeGreaterThanOrEqual(1);
+  });
+
   it('검색창 포커스 시 드롭다운 표시 상태가 활성화된다', () => {
     const { getByTestId, queryByTestId } = render(<DestinationPicker {...defaultProps} />);
     // 검색어 입력 후 선택으로 드롭다운을 닫은 뒤 다시 포커스


### PR DESCRIPTION
## Summary
- `DestinationPicker.tsx`, `index.tsx`에서 `{line}호선` → `LINE_NAMES[line]` 교체
- 공항철도/경의중앙선/분당선/신분당선 한글 호선명 정상 표시
- 특수 노선 배지 회귀 방지 테스트 추가

## Test plan
- [x] `npm test` 커버리지 100% 통과 (301 tests)
- [x] `npm run type-check` 통과

Closes #85