### PR TITLE
fix(#86): 환승역 목적지 알람 미발생 + 도착 감지 로직 개선

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -126,7 +126,8 @@ export default function HomeScreen() {
   }, [arrivedBanner]);
 
   useEffect(() => {
-    if (result?.station.id && destination?.id && result.station.id === destination.id && result.distanceKm <= 0.5) {
+    if (arrivedBanner) return;
+    if (result?.station.name && destination?.name && result.station.name === destination.name && result.distanceKm <= 0.5) {
       setArrivedBanner(true);
       arrivedTimeoutRef.current = setTimeout(() => {
         setDestination(null);
@@ -136,7 +137,7 @@ export default function HomeScreen() {
     return () => {
       if (arrivedTimeoutRef.current) clearTimeout(arrivedTimeoutRef.current);
     };
-  }, [result?.station.id, destination?.id]);
+  }, [result?.station.name, destination?.name, result?.distanceKm]);
 
   if (permissionDenied) {
     return (

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -143,6 +143,19 @@ describe('useStationAlarm', () => {
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
   });
 
+  it('should send destination alarm (not transfer) when transferName equals destinationName', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '옥수',
+      fromLine: 'gyeongui',
+      toLine: '3',
+      stopsToTransfer: 0,
+      stopsFromTransfer: 0,
+    };
+    renderHook(() => useStationAlarm(route, '옥수'));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '옥수', false);
+  });
+
   it('should handle sendAlarmNotification failure gracefully', () => {
     mockSendAlarmNotification.mockRejectedValueOnce(new Error('알림 실패'));
     const route: DirectRoute = { type: 'direct', stops: 1 };

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -101,6 +101,44 @@ describe('checkAlarm', () => {
       expect(checkAlarm(route, destinationName, fired)).toBeNull();
     });
 
+    it('should return destination alarm when transferName equals destinationName and stopsToTransfer <= 1', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '옥수',
+        fromLine: 'gyeongui',
+        toLine: '3',
+        stopsToTransfer: 0,
+        stopsFromTransfer: 0,
+      };
+      const result = checkAlarm(route, '옥수', new Set());
+      expect(result).toEqual({ type: 'destination', stationName: '옥수' });
+    });
+
+    it('should return null when transferName equals destinationName but stopsToTransfer > 1', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '옥수',
+        fromLine: 'gyeongui',
+        toLine: '3',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 0,
+      };
+      expect(checkAlarm(route, '옥수', new Set())).toBeNull();
+    });
+
+    it('should return destination alarm when transferName equals destinationName and both stops <= 1', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '공덕',
+        fromLine: '5',
+        toLine: '6',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 0,
+      };
+      const result = checkAlarm(route, '공덕', new Set());
+      expect(result).toEqual({ type: 'destination', stationName: '공덕' });
+    });
+
     it('should prioritize transfer over destination when both are 1', () => {
       const route: TransferRoute = {
         type: 'transfer',
@@ -169,6 +207,56 @@ describe('checkAlarm', () => {
       const route = makeMultiRoute(5, 1, 1);
       const result = checkAlarm(route, destinationName, new Set());
       expect(result).toEqual({ type: 'transfer', stationName: '충무로' });
+    });
+
+    it('should return destination alarm when first transferName equals destinationName', () => {
+      const route: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '옥수', fromLine: 'gyeongui', toLine: '3', stopsToTransfer: 1 },
+          { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 5 },
+        ],
+        stopsAfterLastTransfer: 3,
+      };
+      const result = checkAlarm(route, '옥수', new Set());
+      expect(result).toEqual({ type: 'destination', stationName: '옥수' });
+    });
+
+    it('should return destination alarm when second transferName equals destinationName', () => {
+      const route: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '시청', fromLine: '1', toLine: '3', stopsToTransfer: 5 },
+          { transferName: '옥수', fromLine: '3', toLine: 'bundang', stopsToTransfer: 1 },
+        ],
+        stopsAfterLastTransfer: 0,
+      };
+      const result = checkAlarm(route, '옥수', new Set());
+      expect(result).toEqual({ type: 'destination', stationName: '옥수' });
+    });
+
+    it('should return null when transferName equals destinationName but stopsToTransfer > threshold', () => {
+      const route: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '옥수', fromLine: 'gyeongui', toLine: '3', stopsToTransfer: 3 },
+          { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 5 },
+        ],
+        stopsAfterLastTransfer: 2,
+      };
+      expect(checkAlarm(route, '옥수', new Set())).toBeNull();
+    });
+
+    it('should return null when first transferName equals destinationName but is far', () => {
+      const route: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '옥수', fromLine: 'gyeongui', toLine: '3', stopsToTransfer: 5 },
+          { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 1 },
+        ],
+        stopsAfterLastTransfer: 3,
+      };
+      expect(checkAlarm(route, '옥수', new Set())).toBeNull();
     });
   });
 

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -30,6 +30,12 @@ const checkers: Record<string, AlarmChecker> = {
 
   transfer(route, destinationName, threshold) {
     const r = route as TransferRoute;
+    if (r.transferName === destinationName) {
+      if (r.stopsToTransfer <= threshold) {
+        return { type: 'destination', stationName: destinationName };
+      }
+      return null;
+    }
     if (r.stopsToTransfer <= threshold) {
       return { type: 'transfer', stationName: r.transferName };
     }
@@ -41,12 +47,16 @@ const checkers: Record<string, AlarmChecker> = {
 
   'multi-transfer'(route, destinationName, threshold) {
     const r = route as MultiTransferRoute;
-    const [t1, t2] = r.transfers;
-    if (t1.stopsToTransfer <= threshold) {
-      return { type: 'transfer', stationName: t1.transferName };
-    }
-    if (t2.stopsToTransfer <= threshold) {
-      return { type: 'transfer', stationName: t2.transferName };
+    for (const t of r.transfers) {
+      if (t.transferName === destinationName) {
+        if (t.stopsToTransfer <= threshold) {
+          return { type: 'destination', stationName: destinationName };
+        }
+        return null;
+      }
+      if (t.stopsToTransfer <= threshold) {
+        return { type: 'transfer', stationName: t.transferName };
+      }
     }
     if (r.stopsAfterLastTransfer <= threshold) {
       return { type: 'destination', stationName: destinationName };


### PR DESCRIPTION
## Summary
- `stationAlarm.ts`: transfer/multi-transfer 체커에 환승역==목적지 분기 추가
- `stationAlarm.ts`: multi-transfer에서 목적지 환승역이 먼 경우 즉시 null 반환 (continue → return null)
- `index.tsx`: 도착 감지 비교를 id → name으로 변경 (동명이역 환승 대응)
- `index.tsx`: arrivedBanner 가드 추가로 불필요한 useEffect 재실행 방지
- 관련 테스트 케이스 8개 추가

## Test plan
- [x] `npm test` 커버리지 100% 통과 (308 tests)
- [x] `npm run type-check` 통과

Closes #86