### PR TITLE
fix(#89): 홈 화면 즐겨찾기 아이콘 즉시 갱신되지 않는 버그 수정

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -20,7 +20,6 @@ export default function FavoritesScreen() {
   const favorites = useAppStore((s) => s.favorites);
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
-  const isFavorite = useAppStore((s) => s.isFavorite);
   const loadFavorites = useAppStore((s) => s.loadFavorites);
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -70,7 +69,7 @@ export default function FavoritesScreen() {
               <SearchResultCard
                 key={station.id}
                 station={station}
-                already={isFavorite(station.id)}
+                already={favorites.some((f) => f.id === station.id)}
                 onAdd={() => addFavorite(station)}
               />
             ))

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -20,7 +20,7 @@ export default function HomeScreen() {
   const { arrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(result?.station.name ?? null);
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
-  const isFavorite = useAppStore((s) => s.isFavorite);
+  const favorites = useAppStore((s) => s.favorites);
   const loadFavorites = useAppStore((s) => s.loadFavorites);
   const destination = useAppStore((s) => s.destination);
   const setDestination = useAppStore((s) => s.setDestination);
@@ -37,6 +37,7 @@ export default function HomeScreen() {
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
   const prevDestIdRef = useRef<string | null>(null);
   const [route, setRoute] = useState<Route>(null);
+  const isFav = result ? favorites.some((f) => f.id === result.station.id) : false;
 
   useEffect(() => {
     if (!result || !destination) {
@@ -198,13 +199,13 @@ export default function HomeScreen() {
                 </View>
                 <TouchableOpacity
                   onPress={() =>
-                    isFavorite(result.station.id)
+                    isFav
                       ? removeFavorite(result.station.id)
                       : addFavorite(result.station)
                   }
                 >
                   <Text style={styles.favoriteIcon}>
-                    {isFavorite(result.station.id) ? '⭐' : '☆'}
+                    {isFav ? '⭐' : '☆'}
                   </Text>
                 </TouchableOpacity>
               </View>

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -71,18 +71,6 @@ describe('useAppStore', () => {
     expect(favorites).toHaveLength(1);
   });
 
-  it('isFavorite: 즐겨찾기 역은 true를 반환한다', async () => {
-    const { addFavorite, isFavorite } = useAppStore.getState();
-    await addFavorite(mockStation);
-
-    expect(isFavorite(mockStation.id)).toBe(true);
-  });
-
-  it('isFavorite: 즐겨찾기 아닌 역은 false를 반환한다', () => {
-    const { isFavorite } = useAppStore.getState();
-    expect(isFavorite('non-existent')).toBe(false);
-  });
-
   it('addFavorite 호출 시 AsyncStorage에 저장한다', async () => {
     const { addFavorite } = useAppStore.getState();
     await addFavorite(mockStation);

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -18,7 +18,6 @@ interface AppState {
   alarmEvent: AlarmEvent | null;
   addFavorite: (station: Station) => Promise<void>;
   removeFavorite: (stationId: string) => Promise<void>;
-  isFavorite: (stationId: string) => boolean;
   loadFavorites: () => Promise<void>;
   setDestination: (station: Station | null) => void;
   setRecentDestination: (station: Station | null) => void;
@@ -58,10 +57,6 @@ export const useAppStore = create<AppState>((set, get) => ({
     const updated = get().favorites.filter((s) => s.id !== stationId);
     set({ favorites: updated });
     await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
-  },
-
-  isFavorite: (stationId: string) => {
-    return get().favorites.some((s) => s.id === stationId);
   },
 
   setDestination: (station: Station | null) => {


### PR DESCRIPTION
## Summary
- `index.tsx`: `isFavorite` 함수 selector → `favorites` 배열 구독 + `favorites.some()` 비교로 교체
- `favorites.tsx`: 동일 패턴 수정
- `useAppStore`: `isFavorite` dead code 제거 (인터페이스 + 구현 + 테스트)

## Test plan
- [x] `npm test` 커버리지 100% 통과 (307 tests)
- [x] `npm run type-check` 통과

Closes #89