### PR TITLE
test(#91): 경로 탐색 및 DestinationPicker 성능 측정 로그 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -44,8 +44,12 @@ export default function HomeScreen() {
       setRoute(null);
       return;
     }
+    const interactionStart = performance.now();
     const interaction = InteractionManager.runAfterInteractions(() => {
-      setRoute(findRoute(result.station.id, destination.id));
+      const route = findRoute(result.station.id, destination.id);
+      const total = performance.now() - interactionStart;
+      logger.debug(`경로 계산 전체 (InteractionManager 포함): ${total.toFixed(2)}ms`);
+      setRoute(route);
     });
     return () => interaction.cancel();
   }, [result?.station.id, destination?.id]);

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import {
   Modal,
   View,
@@ -11,6 +11,9 @@ import stations from '../data/stations.json';
 import type { Station } from '../types/station';
 import { LINE_NAMES } from '../constants/lineColors';
 import { StationMap } from './StationMap';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('DestinationPicker');
 
 
 const allStations = stations as Station[];
@@ -34,6 +37,17 @@ export function DestinationPicker({
 }: Props) {
   const [query, setQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
+  const openTimeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      openTimeRef.current = performance.now();
+    } else if (openTimeRef.current !== null) {
+      const duration = performance.now() - openTimeRef.current;
+      logger.debug(`모달 세션 유지 시간: ${duration.toFixed(2)}ms`);
+      openTimeRef.current = null;
+    }
+  }, [visible]);
 
   const mapAvailable = !!(userLat && userLng);
 
@@ -45,7 +59,10 @@ export function DestinationPicker({
   const suggestions = useMemo(() => {
     const q = query.trim();
     if (!q) return [];
-    return allStations.filter((s) => s.name.includes(q)).slice(0, 8);
+    const start = performance.now();
+    const result = allStations.filter((s) => s.name.includes(q)).slice(0, 8);
+    logger.debug(`검색 필터링 "${q}": ${(performance.now() - start).toFixed(2)}ms (${result.length}건)`);
+    return result;
   }, [query]);
 
   function handleSelect(station: Station) {

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -112,6 +112,27 @@ describe('DestinationPicker', () => {
     expect(getAllByText('공항철도').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('visible false로 전환 시 모달 세션 로그를 출력한다', () => {
+    const debugSpy = jest.spyOn(console, 'log');
+    const { rerender } = render(<DestinationPicker {...defaultProps} visible={true} />);
+    rerender(<DestinationPicker {...defaultProps} visible={false} />);
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[DestinationPicker]'),
+      expect.stringContaining('모달 세션 유지 시간'),
+    );
+    debugSpy.mockRestore();
+  });
+
+  it('처음부터 visible false이면 세션 로그를 출력하지 않는다', () => {
+    const debugSpy = jest.spyOn(console, 'log');
+    render(<DestinationPicker {...defaultProps} visible={false} />);
+    const sessionLogs = debugSpy.mock.calls.filter(
+      (args) => typeof args[1] === 'string' && args[1].includes('모달 세션 유지 시간'),
+    );
+    expect(sessionLogs).toHaveLength(0);
+    debugSpy.mockRestore();
+  });
+
   it('검색창 포커스 시 드롭다운 표시 상태가 활성화된다', () => {
     const { getByTestId, queryByTestId } = render(<DestinationPicker {...defaultProps} />);
     // 검색어 입력 후 선택으로 드롭다운을 닫은 뒤 다시 포커스

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -2,6 +2,9 @@ import stations from '../data/stations.json';
 import type { Station } from '../types/station';
 import { LINE_COLORS } from '../constants/lineColors';
 import type { LineNumber } from '../types/station';
+import { createLogger } from './logger';
+
+const logger = createLogger('StationRoute');
 
 const allStations = stations as Station[];
 
@@ -136,57 +139,66 @@ function buildNameIndex(stations: Station[]): Map<string, number> {
 }
 
 export function findRoute(currentId: string, destinationId: string): Route {
+  const start = performance.now();
   const current = stationById.get(currentId);
   const destination = stationById.get(destinationId);
 
   if (!current || !destination) return null;
+
+  let result: Route;
 
   // 같은 노선: 직통
   if (current.line === destination.line) {
     const lineStations = getLineStationsCached(current.line);
     const cIdx = lineStations.findIndex((s) => s.id === currentId);
     const dIdx = lineStations.findIndex((s) => s.id === destinationId);
-    return { type: 'direct', stops: Math.abs(dIdx - cIdx) };
-  }
+    result = { type: 'direct', stops: Math.abs(dIdx - cIdx) };
+  } else {
+    // 다른 노선: 환승역 탐색
+    const currentLineStations = getLineStationsCached(current.line);
+    const destLineStations = getLineStationsCached(destination.line);
+    const currentIdx = currentLineStations.findIndex((s) => s.id === currentId);
+    const destIdx = destLineStations.findIndex((s) => s.id === destinationId);
 
-  // 다른 노선: 환승역 탐색
-  const currentLineStations = getLineStationsCached(current.line);
-  const destLineStations = getLineStationsCached(destination.line);
-  const currentIdx = currentLineStations.findIndex((s) => s.id === currentId);
-  const destIdx = destLineStations.findIndex((s) => s.id === destinationId);
+    // 목적지 노선의 이름 → 인덱스 Map (O(1) 룩업)
+    const destNameIndex = getLineNameIndexCached(destination.line);
 
-  // 목적지 노선의 이름 → 인덱스 Map (O(1) 룩업)
-  const destNameIndex = getLineNameIndexCached(destination.line);
+    let bestRoute: TransferRoute | null = null;
+    let bestTotal = Infinity;
 
-  let bestRoute: TransferRoute | null = null;
-  let bestTotal = Infinity;
+    for (let i = 0; i < currentLineStations.length; i++) {
+      const candidate = currentLineStations[i];
+      const transferDestIdx = destNameIndex.get(candidate.name);
+      if (transferDestIdx === undefined) continue;
 
-  for (let i = 0; i < currentLineStations.length; i++) {
-    const candidate = currentLineStations[i];
-    const transferDestIdx = destNameIndex.get(candidate.name);
-    if (transferDestIdx === undefined) continue;
+      const stopsToTransfer = Math.abs(i - currentIdx);
+      const stopsFromTransfer = Math.abs(transferDestIdx - destIdx);
+      const total = stopsToTransfer + stopsFromTransfer;
 
-    const stopsToTransfer = Math.abs(i - currentIdx);
-    const stopsFromTransfer = Math.abs(transferDestIdx - destIdx);
-    const total = stopsToTransfer + stopsFromTransfer;
+      if (total < bestTotal) {
+        bestTotal = total;
+        bestRoute = {
+          type: 'transfer',
+          transferName: candidate.name,
+          fromLine: current.line,
+          toLine: destination.line,
+          stopsToTransfer,
+          stopsFromTransfer,
+        };
+      }
+    }
 
-    if (total < bestTotal) {
-      bestTotal = total;
-      bestRoute = {
-        type: 'transfer',
-        transferName: candidate.name,
-        fromLine: current.line,
-        toLine: destination.line,
-        stopsToTransfer,
-        stopsFromTransfer,
-      };
+    if (bestRoute) {
+      result = bestRoute;
+    } else {
+      // 2회 환승 BFS: 현재노선 → 중간노선 → 목적지노선
+      result = findMultiTransferRoute(current, destination, currentLineStations, destLineStations, currentIdx, destIdx);
     }
   }
 
-  if (bestRoute) return bestRoute;
-
-  // 2회 환승 BFS: 현재노선 → 중간노선 → 목적지노선
-  return findMultiTransferRoute(current, destination, currentLineStations, destLineStations, currentIdx, destIdx);
+  const duration = performance.now() - start;
+  logger.debug(`findRoute(${currentId} → ${destinationId}): ${duration.toFixed(2)}ms`);
+  return result;
 }
 
 function findMultiTransferRoute(


### PR DESCRIPTION
## Summary
- `findRoute()` 실행 시간을 `performance.now()` + `logger.debug`로 측정
- `DestinationPicker` 모달 세션 시간 + 검색 필터링 시간 로그 추가
- `InteractionManager` 대기 포함 전체 경로 계산 시간 로그 추가
- 프로덕션에서는 `logger` minLevel 설정으로 비활성화 가능

Closes #91

## Test plan
- [x] `npm test` 통과 (커버리지 100%)
- [x] `npm run type-check` 통과
- [x] 시뮬레이터에서 앱 실행 후 콘솔 로그 수치 확인 (추후 코멘트로 첨부)