### PR TITLE
fix(#95): 실시간 도착 정보 API 프로토콜을 HTTP로 변경

### DIFF
--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -3,6 +3,12 @@ import { fetchArrivalInfo, MOCK_ARRIVALS } from '../arrivalApi';
 describe('fetchArrivalInfo', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('API 키가 없으면 Mock 데이터를 반환한다', async () => {

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('arrivalApi');
+
 export interface ArrivalInfo {
   destination: string;
   arrivalMinutes: number;
@@ -35,17 +39,18 @@ export async function fetchArrivalInfo(
   const apiKey = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
 
   if (!apiKey) {
-    // API 키 없을 때 Mock 데이터 반환
+    log.warn('API key not set (EXPO_PUBLIC_SEOUL_DATA_API_KEY)');
     return MOCK_ARRIVALS;
   }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const url = `https://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/10/${encodeURIComponent(stationName)}`;
+    const url = `http://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/10/${encodeURIComponent(stationName)}`;
 
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
+      log.warn(`HTTP ${response.status} for station "${stationName}"`);
       return MOCK_ARRIVALS;
     }
 
@@ -70,10 +75,12 @@ export async function fetchArrivalInfo(
 
     const sliced = { up: up.slice(0, maxPerDirection), down: down.slice(0, maxPerDirection) };
     if (sliced.up.length === 0 && sliced.down.length === 0) {
+      log.warn(`No arrivals for station "${stationName}"`);
       return MOCK_ARRIVALS;
     }
     return sliced;
-  } catch {
+  } catch (e) {
+    log.error(`Fetch failed for station "${stationName}":`, e);
     return MOCK_ARRIVALS;
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- `swopenapi.seoul.go.kr`이 HTTPS(443)를 지원하지 않아 연결 타임아웃 발생 → mock 데이터만 표시되던 문제 수정
- API URL을 `https://` → `http://`로 변경하여 실시간 도착 정보 정상 수신
- 각 fallback 지점에 디버그 로깅 추가로 향후 장애 진단 용이

## Test plan
- [x] `npm test` 통과 (커버리지 100%)
- [x] `npm run type-check` 통과
- [x] curl로 HTTP 엔드포인트 정상 응답 확인
- [x] 실기기에서 실시간 도착 정보 표시 확인

Closes #95