### PR TITLE
feat(#99): 취침모드에서 Live Activity 긴급 상태 표시

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,7 @@
             }
           }
         },
-        "UIBackgroundModes": ["audio"]
+        "UIBackgroundModes": ["audio", "location"]
       }
     },
     "android": {
@@ -32,6 +32,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
+      "permissions": ["ACCESS_FINE_LOCATION", "ACCESS_BACKGROUND_LOCATION"],
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "package": "com.subwaynow.app"

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,6 +10,7 @@ import { findRoute, buildJourneyDisplay, calculateETA, calculateStaticETA, type 
 import { JourneyTimeline } from '../../src/components/JourneyTimeline';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
+import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
 
@@ -72,6 +73,7 @@ export default function HomeScreen() {
   const displayEta = isRealtimeEta ? etaMinutes : staticEtaMinutes;
 
   useStationAlarm(route, destination?.name ?? null);
+  useBackgroundLocation(destination);
 
   useEffect(() => {
     loadFavorites();

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -94,7 +94,7 @@ export default function HomeScreen() {
       }
       return;
     }
-    const key = `${result.station.id}__${destination?.id ?? ''}__${displayEta ?? ''}__${arrivalIsMock}`;
+    const key = `${result.station.id}__${destination?.id ?? ''}__${displayEta ?? ''}__${arrivalIsMock}__${alarmEvent?.type ?? ''}`;
     if (key === prevNotifKeyRef.current) return;
     prevNotifKeyRef.current = key;
 
@@ -118,10 +118,11 @@ export default function HomeScreen() {
         route ?? null,
         displayEta,
         arrivalIsMock,
+        alarmEvent,
       );
     };
     update().catch((e) => logger.error('알림 업데이트 실패:', e));
-  }, [result?.station.id, destination?.id, displayEta, arrivalIsMock, route]);
+  }, [result?.station.id, destination?.id, displayEta, arrivalIsMock, route, alarmEvent]);
 
   useEffect(() => {
     if (arrivedBanner) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { setupNotificationHandler } from '../src/utils/stationNotification';
 import { setMinLevel } from '../src/utils/logger';
+import '../src/tasks/backgroundLocationTask';
 
 setupNotificationHandler();
 

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -16,6 +16,8 @@ export interface LiveActivityData {
   distanceM: number;
   etaMinutes?: number;
   isMock?: boolean;
+  alarmType?: 'destination' | 'transfer';
+  alarmStationName?: string;
 }
 
 const LiveActivityModule =

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -21,6 +21,8 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var distanceM: Int
         var etaMinutes: Int?
         var isMock: Bool?
+        var alarmType: String?
+        var alarmStationName: String?
     }
 }
 

--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -1,0 +1,246 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import type { Station } from '../../types/station';
+
+// ── expo-location 모킹 ──
+const mockRequestBackgroundPermissionsAsync = jest.fn();
+const mockStartLocationUpdatesAsync = jest.fn();
+const mockStopLocationUpdatesAsync = jest.fn();
+
+jest.mock('expo-location', () => ({
+  requestBackgroundPermissionsAsync: (...args: unknown[]) =>
+    mockRequestBackgroundPermissionsAsync(...args),
+  startLocationUpdatesAsync: (...args: unknown[]) =>
+    mockStartLocationUpdatesAsync(...args),
+  stopLocationUpdatesAsync: (...args: unknown[]) =>
+    mockStopLocationUpdatesAsync(...args),
+  Accuracy: { High: 6 },
+}));
+
+// ── expo-task-manager 모킹 ──
+const mockIsTaskRegisteredAsync = jest.fn();
+
+jest.mock('expo-task-manager', () => ({
+  isTaskRegisteredAsync: (...args: unknown[]) => mockIsTaskRegisteredAsync(...args),
+  // defineTask는 backgroundLocationTask 모듈이 호출하지만,
+  // 여기서는 그 모듈을 직접 import하지 않으므로 stub만 필요하다
+  defineTask: jest.fn(),
+}));
+
+// ── backgroundLocationTask 모킹: BACKGROUND_LOCATION_TASK 상수만 필요 ──
+jest.mock('../../tasks/backgroundLocationTask', () => ({
+  BACKGROUND_LOCATION_TASK: 'background-location-task',
+}));
+
+// ── logger 모킹 ──
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { useBackgroundLocation } from '../useBackgroundLocation';
+
+// ── 픽스처 ──
+
+const mockDestination: Station = {
+  id: 'station-2',
+  name: '시청',
+  line: '1',
+  lineColor: '#0052A4',
+  lat: 37.565,
+  lng: 126.977,
+};
+
+const mockDestination2: Station = {
+  id: 'station-3',
+  name: '강남',
+  line: '2',
+  lineColor: '#009246',
+  lat: 37.498,
+  lng: 127.028,
+};
+
+describe('useBackgroundLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStopLocationUpdatesAsync.mockResolvedValue(undefined);
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
+    mockIsTaskRegisteredAsync.mockResolvedValue(false);
+    mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
+  });
+
+  // ── destination이 null인 경우 ──
+
+  it('destination이 null이면 stopLocationUpdatesAsync를 호출한다', async () => {
+    const { unmount } = renderHook(() => useBackgroundLocation(null));
+
+    await waitFor(() => {
+      expect(mockStopLocationUpdatesAsync).toHaveBeenCalledWith('background-location-task');
+    });
+
+    expect(mockRequestBackgroundPermissionsAsync).not.toHaveBeenCalled();
+    expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('destination이 null이면 stopLocationUpdatesAsync 실패해도 에러를 던지지 않는다', async () => {
+    mockStopLocationUpdatesAsync.mockRejectedValueOnce(new Error('이미 정지됨'));
+
+    const { unmount } = renderHook(() => useBackgroundLocation(null));
+
+    await waitFor(() => {
+      expect(mockStopLocationUpdatesAsync).toHaveBeenCalled();
+    });
+
+    // .catch(() => {}) 로 감싸져 있으므로 에러 없음
+    unmount();
+  });
+
+  // ── 권한 허용 + 태스크 미등록: 정상 시작 ──
+
+  it('권한이 granted이고 태스크 미등록이면 startLocationUpdatesAsync를 호출한다', async () => {
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
+        'background-location-task',
+        expect.objectContaining({
+          accuracy: 6, // Location.Accuracy.High
+          distanceInterval: 100,
+          deferredUpdatesInterval: 30_000,
+          showsBackgroundLocationIndicator: true,
+          foregroundService: expect.objectContaining({
+            notificationTitle: '지하철 위치 감지 중',
+            notificationBody: '백그라운드에서 현재 역을 추적하고 있습니다',
+          }),
+        }),
+      );
+    });
+  });
+
+  // ── 권한 거부 ──
+
+  it('권한이 denied이면 startLocationUpdatesAsync를 호출하지 않는다', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' });
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
+    });
+
+    expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+  });
+
+  // ── 태스크가 이미 등록된 경우 ──
+
+  it('태스크가 이미 등록되어 있으면 startLocationUpdatesAsync를 호출하지 않는다', async () => {
+    mockIsTaskRegisteredAsync.mockResolvedValueOnce(true);
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockIsTaskRegisteredAsync).toHaveBeenCalledWith('background-location-task');
+    });
+
+    expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+  });
+
+  // ── cleanup: cancelled 플래그로 경쟁 조건 방지 ──
+
+  it('useEffect 클린업이 실행되면 cancelled=true로 startLocationUpdatesAsync를 호출하지 않는다', async () => {
+    // 권한 요청이 느리게 resolve되는 동안 컴포넌트가 unmount된 경우를 시뮬레이션
+    let resolvePermission!: (value: { status: string }) => void;
+    mockRequestBackgroundPermissionsAsync.mockReturnValueOnce(
+      new Promise<{ status: string }>((resolve) => {
+        resolvePermission = resolve;
+      }),
+    );
+
+    const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
+
+    // unmount로 cleanup(cancelled=true) 실행 후 권한 응답
+    unmount();
+    resolvePermission({ status: 'granted' });
+
+    // 마이크로태스크가 처리될 시간을 준다
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+  });
+
+  it('isTaskRegisteredAsync 응답 전 unmount되면 startLocationUpdatesAsync를 호출하지 않는다', async () => {
+    // 권한은 즉시 허용되지만 isTaskRegistered가 느린 경우
+    mockRequestBackgroundPermissionsAsync.mockResolvedValueOnce({ status: 'granted' });
+    let resolveRegistered!: (value: boolean) => void;
+    mockIsTaskRegisteredAsync.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveRegistered = resolve;
+      }),
+    );
+
+    const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
+
+    // 권한 응답까지 기다린 후 unmount
+    await waitFor(() => {
+      expect(mockIsTaskRegisteredAsync).toHaveBeenCalled();
+    });
+    unmount();
+    resolveRegistered(false); // 등록 안 됨으로 응답 — 하지만 이미 cancelled
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+  });
+
+  // ── destination.id 변경 시 effect 재실행 ──
+
+  it('destination.id가 변경되면 effect가 재실행되어 새로 startLocationUpdatesAsync를 호출한다', async () => {
+    const { rerender } = renderHook(
+      ({ dest }: { dest: Station | null }) => useBackgroundLocation(dest),
+      { initialProps: { dest: mockDestination } },
+    );
+
+    await waitFor(() => {
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledTimes(1);
+    });
+
+    jest.clearAllMocks();
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
+    mockIsTaskRegisteredAsync.mockResolvedValue(false);
+    mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
+
+    rerender({ dest: mockDestination2 });
+
+    await waitFor(() => {
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('destination이 null에서 non-null로 변경되면 startLocationUpdatesAsync를 호출한다', async () => {
+    const { rerender } = renderHook(
+      ({ dest }: { dest: Station | null }) => useBackgroundLocation(dest),
+      { initialProps: { dest: null } },
+    );
+
+    await waitFor(() => {
+      expect(mockStopLocationUpdatesAsync).toHaveBeenCalled();
+    });
+
+    jest.clearAllMocks();
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
+    mockIsTaskRegisteredAsync.mockResolvedValue(false);
+    mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
+
+    rerender({ dest: mockDestination });
+
+    await waitFor(() => {
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+import type { Station } from '../types/station';
+import { BACKGROUND_LOCATION_TASK } from '../tasks/backgroundLocationTask';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('BackgroundLocation');
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+export function useBackgroundLocation(destination: Station | null): void {
+  useEffect(() => {
+    if (!destination) {
+      Location.stopLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(noop);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      const { status } = await Location.requestBackgroundPermissionsAsync();
+      if (status !== 'granted' || cancelled) {
+        logger.info('백그라운드 위치 권한 거부 또는 취소됨');
+        return;
+      }
+
+      const isRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_LOCATION_TASK);
+      if (isRegistered || cancelled) return;
+
+      await Location.startLocationUpdatesAsync(BACKGROUND_LOCATION_TASK, {
+        accuracy: Location.Accuracy.High,
+        distanceInterval: 100,
+        deferredUpdatesInterval: 30_000,
+        showsBackgroundLocationIndicator: true,
+        foregroundService: {
+          notificationTitle: '지하철 위치 감지 중',
+          notificationBody: '백그라운드에서 현재 역을 추적하고 있습니다',
+        },
+      });
+      logger.info('백그라운드 위치 추적 시작');
+    })();
+
+    return () => {
+      cancelled = true;
+      Location.stopLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(noop);
+    };
+  }, [destination?.id]);
+}

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -1,11 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import * as Location from 'expo-location';
-import stationsData from '../data/stations.json';
-import { haversine } from '../utils/haversine';
-import { NearestStationResult, Station } from '../types/station';
+import { NearestStationResult } from '../types/station';
+import { findNearestStation } from '../utils/findNearestStation';
 import { usePolling } from './usePolling';
 
-const stations = stationsData as Station[];
 const UPDATE_INTERVAL_MS = 30_000;
 
 interface UseNearestStationReturn {
@@ -24,27 +22,6 @@ export function useNearestStation(): UseNearestStationReturn {
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
 
-  const findNearest = useCallback(
-    (lat: number, lng: number): NearestStationResult | null => {
-      let nearest: Station | null = null;
-      let minDistance = Infinity;
-
-      for (const station of stations) {
-        const dist = haversine(lat, lng, station.lat, station.lng);
-        if (dist < minDistance) {
-          minDistance = dist;
-          nearest = station;
-        }
-      }
-
-      if (nearest) {
-        return { station: nearest, distanceKm: minDistance };
-      }
-      return null;
-    },
-    []
-  );
-
   const refresh = useCallback(async () => {
     try {
       setError(null);
@@ -61,14 +38,14 @@ export function useNearestStation(): UseNearestStationReturn {
       });
 
       setUserLocation({ lat: location.coords.latitude, lng: location.coords.longitude });
-      const nearest = findNearest(location.coords.latitude, location.coords.longitude);
+      const nearest = findNearestStation(location.coords.latitude, location.coords.longitude);
       setResult(nearest);
     } catch (e) {
       setError('위치를 가져오는 데 실패했습니다.');
     } finally {
       setLoading(false);
     }
-  }, [findNearest]);
+  }, []);
 
   useEffect(() => {
     refresh();

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -148,16 +148,33 @@ describe('useAppStore', () => {
     expect(destination).toBeNull();
   });
 
-  it('setDestination: AsyncStorage를 호출하지 않는다', () => {
+  it('setDestination: 역 설정 시 AsyncStorage에 저장하고 null 시 삭제한다', () => {
     const { setDestination } = useAppStore.getState();
     setDestination(mockStation);
-    setDestination(null);
-
-    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
-      expect.stringContaining('destination'),
-      expect.anything()
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:destination',
+      JSON.stringify(mockStation),
     );
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+    setDestination(null);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:destination');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-alarms');
+  });
+
+  it('setDestination: AsyncStorage 실패 시에도 에러를 던지지 않는다', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('저장 실패'));
+    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
+    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
+
+    const { setDestination } = useAppStore.getState();
+    setDestination(mockStation);
+    // catch(noop)로 에러가 무시되므로 에러가 던져지지 않아야 한다
+    await new Promise((r) => setTimeout(r, 0));
+
+    setDestination(null);
+    await new Promise((r) => setTimeout(r, 0));
+    // 에러 없이 완료
   });
 
   it('초기 recentDestination은 null이다', () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -4,6 +4,11 @@ import { Station } from '../types/station';
 
 const FAVORITES_KEY = 'subway-now:favorites';
 const SLEEP_MODE_KEY = 'subway-now:sleep-mode';
+const DESTINATION_KEY = 'subway-now:destination';
+const FIRED_ALARMS_KEY = 'subway-now:fired-alarms';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 export interface AlarmEvent {
   type: 'destination' | 'transfer';
@@ -61,6 +66,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setDestination: (station: Station | null) => {
     set({ destination: station });
+    if (station) {
+      AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station)).catch(noop);
+    } else {
+      AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
+      AsyncStorage.removeItem(FIRED_ALARMS_KEY).catch(noop);
+    }
   },
 
   setRecentDestination: (station: Station | null) => {

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -1,0 +1,394 @@
+// ── TaskManager: defineTask 콜백을 캡처하기 위해 global 객체를 사용 ──
+// jest.mock 팩토리는 변수 호이스팅보다 먼저 실행되므로,
+// 팩토리 외부 변수를 참조하면 undefined가 된다.
+// global 객체는 항상 접근 가능하므로 여기에 콜백을 저장한다.
+jest.mock('expo-task-manager', () => ({
+  defineTask: (name: string, callback: Function) => {
+    (global as any).__bgTaskCallback = callback;
+    (global as any).__bgTaskName = name;
+  },
+}));
+
+// ── expo-location 모킹 ──
+jest.mock('expo-location', () => ({
+  LocationObject: {},
+}));
+
+// ── AsyncStorage 모킹 ──
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+// ── stationPipeline 모킹 ──
+const mockProcessLocationUpdate = jest.fn();
+jest.mock('../../utils/stationPipeline', () => ({
+  processLocationUpdate: (...args: unknown[]) => mockProcessLocationUpdate(...args),
+}));
+
+// ── stationAlarm 모킹 ──
+const mockAlarmKey = jest.fn();
+jest.mock('../../utils/stationAlarm', () => ({
+  alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
+}));
+
+// ── stationNotification 모킹 ──
+const mockUpdateStationNotification = jest.fn();
+jest.mock('../../utils/stationNotification', () => ({
+  updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
+}));
+
+// ── findNearestStation 모킹 ──
+const mockFindNearestStation = jest.fn();
+jest.mock('../../utils/findNearestStation', () => ({
+  findNearestStation: (...args: unknown[]) => mockFindNearestStation(...args),
+}));
+
+// ── logger 모킹 ──
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { AlarmEvent } from '../../utils/stationAlarm';
+import type { NearestStationResult } from '../../types/station';
+// 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
+import '../../tasks/backgroundLocationTask';
+import { BACKGROUND_LOCATION_TASK } from '../../tasks/backgroundLocationTask';
+
+// ── 픽스처 ──
+
+const mockStation = {
+  id: 'station-1',
+  name: '강남',
+  line: '2' as const,
+  lineColor: '#009246',
+  lat: 37.498,
+  lng: 127.028,
+};
+
+const mockDestination = {
+  id: 'station-2',
+  name: '시청',
+  line: '1' as const,
+  lineColor: '#0052A4',
+  lat: 37.565,
+  lng: 126.977,
+};
+
+function makeLocation(lat: number, lng: number) {
+  return {
+    coords: {
+      latitude: lat,
+      longitude: lng,
+      altitude: null,
+      accuracy: null,
+      altitudeAccuracy: null,
+      heading: null,
+      speed: null,
+    },
+    timestamp: Date.now(),
+  };
+}
+
+type TaskCtx = { data: unknown; error: { message: string } | null };
+type TaskCallback = (ctx: TaskCtx) => Promise<void>;
+
+function getTaskCallback(): TaskCallback {
+  return (global as any).__bgTaskCallback as TaskCallback;
+}
+
+describe('BACKGROUND_LOCATION_TASK 상수', () => {
+  it('올바른 태스크 이름 문자열을 갖는다', () => {
+    expect(BACKGROUND_LOCATION_TASK).toBe('background-location-task');
+  });
+});
+
+describe('backgroundLocationTask defineTask 콜백', () => {
+  let taskCallback: TaskCallback;
+
+  beforeAll(() => {
+    taskCallback = getTaskCallback();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockUpdateStationNotification.mockResolvedValue(undefined);
+    mockFindNearestStation.mockReturnValue(null);
+  });
+
+  it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
+    expect((global as any).__bgTaskName).toBe('background-location-task');
+    expect(typeof taskCallback).toBe('function');
+  });
+
+  // ── error 분기 ──
+
+  it('error가 있으면 즉시 return하고 다른 함수를 호출하지 않는다', async () => {
+    await taskCallback({ data: null, error: { message: '위치 오류' } });
+
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── data 없음 분기 ──
+
+  it('data가 null이면 즉시 return한다', async () => {
+    await taskCallback({ data: null, error: null });
+
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  // ── locations 빈 배열 분기 ──
+
+  it('locations가 빈 배열이면 즉시 return한다', async () => {
+    await taskCallback({ data: { locations: [] }, error: null });
+
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  // ── 목적지 미설정 + nearest 없음 ──
+
+  it('destJson이 없고 findNearestStation이 null을 반환하면 updateStationNotification을 호출하지 않는다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    mockFindNearestStation.mockReturnValue(null);
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.5, 127.0)] },
+      error: null,
+    });
+
+    expect(mockUpdateStationNotification).not.toHaveBeenCalled();
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── 목적지 미설정 + nearest 있음 ──
+
+  it('destJson이 없고 nearest가 있으면 updateStationNotification만 호출한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const nearestResult: NearestStationResult = {
+      station: mockStation,
+      distanceKm: 0.2,
+    };
+    mockFindNearestStation.mockReturnValue(nearestResult);
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    // Math.round(0.2 * 1000) = 200
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(mockStation, 200);
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── 목적지 설정 + alarmEvent 없음 ──
+
+  it('destJson이 있고 alarmEvent가 null이면 AsyncStorage.setItem을 호출하지 않는다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination)) // DESTINATION_KEY
+      .mockResolvedValueOnce(null)                            // SLEEP_MODE_KEY
+      .mockResolvedValueOnce(null);                           // FIRED_ALARMS_KEY
+
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent: null,
+      nearest: { station: mockStation, distanceKm: 0.1 },
+    });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      37.498,
+      127.028,
+      mockDestination,
+      new Set(),
+      false,
+    );
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  // ── sleepMode 파싱 ──
+
+  it("sleepJson이 'true'이면 sleepMode=true로 processLocationUpdate를 호출한다", async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce('true')
+      .mockResolvedValueOnce(null);
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(),
+      true,
+    );
+  });
+
+  it("sleepJson이 'false'이면 sleepMode=false로 processLocationUpdate를 호출한다", async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce('false')
+      .mockResolvedValueOnce(null);
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(),
+      false,
+    );
+  });
+
+  // ── firedAlarms 파싱 ──
+
+  it('firedJson이 있으면 파싱한 Set을 processLocationUpdate에 전달한다', async () => {
+    const fired = ['destination:강남', 'transfer:시청'];
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JSON.stringify(fired));
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(fired),
+      false,
+    );
+  });
+
+  // ── alarmEvent 있음: firedAlarms 저장 ──
+
+  it('alarmEvent가 있으면 alarmKey를 추가하고 AsyncStorage.setItem을 호출한다', async () => {
+    const alarmEvent: AlarmEvent = { type: 'destination', stationName: '시청' };
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent,
+      nearest: { station: mockStation, distanceKm: 0.1 },
+    });
+    mockAlarmKey.mockReturnValue('destination:시청');
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockAlarmKey).toHaveBeenCalledWith(alarmEvent);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:fired-alarms',
+      JSON.stringify(['destination:시청']),
+    );
+  });
+
+  it('기존 firedAlarms에 alarmEvent 키를 추가하여 저장한다', async () => {
+    const alarmEvent: AlarmEvent = { type: 'transfer', stationName: '강남' };
+    const existingFired = ['destination:시청'];
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JSON.stringify(existingFired));
+
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent,
+      nearest: { station: mockStation, distanceKm: 0.1 },
+    });
+    mockAlarmKey.mockReturnValue('transfer:강남');
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:fired-alarms',
+      JSON.stringify(['destination:시청', 'transfer:강남']),
+    );
+  });
+
+  // ── destJson 파싱 실패 분기 ──
+
+  it('destJson이 손상된 JSON이면 즉시 return한다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce('invalid-json{{{')  // DESTINATION_KEY — 파싱 실패
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── 마지막 location 선택 ──
+
+  it('locations 배열의 마지막 요소를 사용한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    mockFindNearestStation.mockReturnValue(null);
+
+    const loc1 = makeLocation(37.1, 127.1);
+    const loc2 = makeLocation(37.9, 127.9); // 마지막
+
+    await taskCallback({
+      data: { locations: [loc1, loc2] },
+      error: null,
+    });
+
+    expect(mockFindNearestStation).toHaveBeenCalledWith(37.9, 127.9);
+  });
+
+  // ── 전체 try-catch 에러 핸들링 ──
+
+  it('processLocationUpdate가 실패해도 태스크가 크래시하지 않는다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    mockProcessLocationUpdate.mockRejectedValueOnce(new Error('파이프라인 오류'));
+
+    await expect(
+      taskCallback({
+        data: { locations: [makeLocation(37.498, 127.028)] },
+        error: null,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -1,0 +1,77 @@
+import * as TaskManager from 'expo-task-manager';
+import * as Location from 'expo-location';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { processLocationUpdate } from '../utils/stationPipeline';
+import { alarmKey } from '../utils/stationAlarm';
+import { updateStationNotification } from '../utils/stationNotification';
+import { findNearestStation } from '../utils/findNearestStation';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('BackgroundLocation');
+
+export const BACKGROUND_LOCATION_TASK = 'background-location-task';
+
+const DESTINATION_KEY = 'subway-now:destination';
+const SLEEP_MODE_KEY = 'subway-now:sleep-mode';
+const FIRED_ALARMS_KEY = 'subway-now:fired-alarms';
+
+TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
+  if (error) {
+    logger.error('백그라운드 위치 오류:', error.message);
+    return;
+  }
+  if (!data) return;
+
+  const { locations } = data as { locations: Location.LocationObject[] };
+  const latest = locations[locations.length - 1];
+  if (!latest) return;
+
+  const { latitude, longitude } = latest.coords;
+
+  try {
+    const [destJson, sleepJson, firedJson] = await Promise.all([
+      AsyncStorage.getItem(DESTINATION_KEY),
+      AsyncStorage.getItem(SLEEP_MODE_KEY),
+      AsyncStorage.getItem(FIRED_ALARMS_KEY),
+    ]);
+
+    // 목적지 미설정 시 현재 역 알림만 업데이트
+    if (!destJson) {
+      const nearest = findNearestStation(latitude, longitude);
+      if (nearest) {
+        await updateStationNotification(
+          nearest.station,
+          Math.round(nearest.distanceKm * 1000),
+        );
+      }
+      return;
+    }
+
+    let destination;
+    try {
+      destination = JSON.parse(destJson);
+    } catch {
+      logger.error('목적지 JSON 파싱 실패');
+      return;
+    }
+    const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
+    const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
+
+    const { alarmEvent } = await processLocationUpdate(
+      latitude,
+      longitude,
+      destination,
+      firedAlarms,
+      sleepMode,
+    );
+
+    if (alarmEvent) {
+      firedAlarms.add(alarmKey(alarmEvent));
+      await AsyncStorage.setItem(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms]));
+    }
+
+    logger.info('백그라운드 위치 업데이트 완료:', latitude.toFixed(4), longitude.toFixed(4));
+  } catch (e) {
+    logger.error('백그라운드 태스크 실패:', e);
+  }
+});

--- a/src/utils/__tests__/findNearestStation.test.ts
+++ b/src/utils/__tests__/findNearestStation.test.ts
@@ -1,0 +1,115 @@
+import { findNearestStation } from '../findNearestStation';
+
+// haversine을 모킹하여 어떤 역이 가장 가깝게 계산되는지 완전히 제어한다.
+// stations.json 데이터가 크므로 haversine 결과를 고정하여 루프 분기를 독립적으로 검증한다.
+const mockHaversine = jest.fn();
+jest.mock('../haversine', () => ({
+  haversine: (...args: unknown[]) => mockHaversine(...args),
+}));
+
+describe('findNearestStation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the station with minimum haversine distance', () => {
+    // 모든 역에 대해 큰 값을 반환하다가 특정 호출에서만 작은 값을 반환
+    // stations.json 에는 528개 역이 있으므로 첫 번째 역만 0.1 km로 설정
+    mockHaversine.mockReturnValue(5); // 기본값: 모든 역 5km
+    // 첫 번째 호출만 0.1km — 소요산(1-001)
+    mockHaversine.mockReturnValueOnce(0.1);
+
+    const result = findNearestStation(37.9481, 127.061034);
+
+    expect(result).not.toBeNull();
+    expect(result!.station.id).toBe('1-001'); // 소요산
+    expect(result!.distanceKm).toBe(0.1);
+  });
+
+  it('should return null when stations array is empty (mocked via module reset)', () => {
+    // stations.json을 빈 배열로 모킹하려면 모듈을 재설정해야 한다.
+    // jest.resetModules를 활용한 격리 테스트
+    jest.resetModules();
+
+    jest.doMock('../haversine', () => ({ haversine: jest.fn() }));
+    jest.doMock('../../data/stations.json', () => []);
+
+    const { findNearestStation: fn } = require('../findNearestStation');
+    const result = fn(37.5, 127.0);
+    expect(result).toBeNull();
+
+    jest.resetModules();
+  });
+
+  it('should update nearest when a later station has smaller distance', () => {
+    // 두 번째 역이 더 가까운 경우를 시뮬레이션
+    // 첫 호출: 3km, 두 번째 호출: 1km, 이후 모두 5km
+    mockHaversine
+      .mockReturnValueOnce(3) // 첫 번째 역 3km
+      .mockReturnValueOnce(1) // 두 번째 역 1km (동두천 1-002)
+      .mockReturnValue(5);    // 나머지 모두 5km
+
+    const result = findNearestStation(37.927878, 127.05479);
+
+    expect(result).not.toBeNull();
+    expect(result!.station.id).toBe('1-002'); // 동두천
+    expect(result!.distanceKm).toBe(1);
+  });
+
+  it('should return the last station if it is the closest', () => {
+    // 마지막 역에 가장 작은 거리를 배정
+    // 528개 역 중 마지막 역(sinbundang-016: 광교)이 가장 가깝도록 설정
+    mockHaversine.mockReturnValue(10); // 기본값: 10km
+    // 마지막 호출(528번째)만 0.05km
+    let callCount = 0;
+    mockHaversine.mockImplementation(() => {
+      callCount++;
+      return callCount === 528 ? 0.05 : 10;
+    });
+
+    const result = findNearestStation(37.28, 127.04);
+    expect(result).not.toBeNull();
+    expect(result!.distanceKm).toBe(0.05);
+  });
+
+  it('should return nearest result with correct distanceKm value', () => {
+    const distanceKm = 0.3;
+    mockHaversine.mockReturnValueOnce(distanceKm).mockReturnValue(5);
+
+    const result = findNearestStation(37.9481, 127.061034);
+
+    expect(result).not.toBeNull();
+    expect(result!.distanceKm).toBe(distanceKm);
+    expect(result!.station).toBeDefined();
+    expect(result!.station.id).toBeDefined();
+    expect(result!.station.name).toBeDefined();
+    expect(result!.station.line).toBeDefined();
+    expect(result!.station.lat).toBeDefined();
+    expect(result!.station.lng).toBeDefined();
+  });
+
+  it('should call haversine with correct lat/lng arguments', () => {
+    mockHaversine.mockReturnValue(1);
+    const lat = 37.5;
+    const lng = 127.0;
+
+    findNearestStation(lat, lng);
+
+    // 첫 호출에 lat/lng가 정확히 전달됐는지 확인
+    expect(mockHaversine).toHaveBeenCalledWith(lat, lng, expect.any(Number), expect.any(Number));
+    // 528개 역 전체 순회
+    expect(mockHaversine).toHaveBeenCalledTimes(528);
+  });
+
+  it('should not update nearest when later station distance equals current minimum (strict less-than)', () => {
+    // 두 역이 같은 거리일 때 먼저 설정된 역(첫 번째)이 유지된다
+    mockHaversine.mockReturnValue(2); // 모든 역이 2km 동일
+
+    const result = findNearestStation(37.5, 127.0);
+
+    expect(result).not.toBeNull();
+    // 첫 번째 역(소요산)이 반환되어야 한다 (거리가 같으면 갱신 안 됨)
+    expect(result!.station.id).toBe('1-001');
+    expect(result!.distanceKm).toBe(2);
+  });
+});

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -284,6 +284,33 @@ describe('stationNotification', () => {
       await updateStationNotification(mockStation, 154);
       expectNotificationContent('시청역', '1호선 · 약 154m');
     });
+
+    it('alarmEvent가 있으면 alarmType과 alarmStationName이 포함된다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, transferRoute, 12, false, { type: 'transfer', stationName: '동대문' });
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          alarmType: 'transfer',
+          alarmStationName: '동대문',
+        })
+      );
+    });
+
+    it('alarmEvent가 destination 타입이면 alarmType이 destination이다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12, false, { type: 'destination', stationName: '강남' });
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          alarmType: 'destination',
+          alarmStationName: '강남',
+        })
+      );
+    });
+
+    it('alarmEvent가 없으면 alarmType이 포함되지 않는다', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute);
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
+        expect.not.objectContaining({ alarmType: expect.anything() })
+      );
+    });
   });
 
   describe('updateStationNotification (Android - expo-notifications)', () => {

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -85,7 +85,7 @@ function expectNotificationContent(title: string, body: string) {
 function expectAlarmNotification(title: string, body: string, extra?: Record<string, unknown>) {
   expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
     identifier: 'station-alarm',
-    content: { title, body, sound: false, ...extra },
+    content: { title, body, sound: true, ...extra },
     trigger: null,
   });
 }
@@ -109,14 +109,14 @@ describe('stationNotification', () => {
       );
     });
 
-    it('모든 알림은 shouldPlaySound false를 반환한다', async () => {
+    it('일반 알림은 shouldPlaySound false, 알람 알림은 true를 반환한다', async () => {
       setupNotificationHandler();
       const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
       const normalResult = await handleNotification({ request: { identifier: 'current-station' } });
       expect(normalResult).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: false, shouldSetBadge: false });
 
       const alarmResult = await handleNotification({ request: { identifier: 'station-alarm' } });
-      expect(alarmResult).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: false, shouldSetBadge: false });
+      expect(alarmResult).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: true, shouldSetBadge: false });
     });
   });
 
@@ -141,8 +141,9 @@ describe('stationNotification', () => {
       expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-alarm', {
         name: '하차/환승 알림',
         importance: Notifications.AndroidImportance.HIGH,
-        sound: null,
-        enableVibrate: false,
+        sound: 'alarm.wav',
+        enableVibrate: true,
+        vibrationPattern: [0, 1000, 500, 1000],
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
       });
       expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
@@ -383,14 +384,14 @@ describe('stationNotification', () => {
     it('destination 타입이면 하차 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('destination', '강남');
-      expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!');
+      expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!', { interruptionLevel: 'timeSensitive' });
       expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(false);
     });
 
     it('transfer 타입이면 환승 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('transfer', '시청');
-      expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!');
+      expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!', { interruptionLevel: 'timeSensitive' });
       expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(false);
     });
 
@@ -409,6 +410,13 @@ describe('stationNotification', () => {
     it('dismiss 실패해도 schedule은 호출된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
+      await sendAlarmNotification('destination', '강남');
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    });
+
+    it('playAlarmWithRouting 실패해도 알림은 정상 예약된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      mockPlayAlarmWithRouting.mockRejectedValueOnce(new Error('백그라운드 오디오 실패'));
       await sendAlarmNotification('destination', '강남');
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
     });

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -222,6 +222,36 @@ describe('processLocationUpdate', () => {
       mockDestination,
       mockRoute,
       12,
+      undefined,
+      null,
+    );
+  });
+
+  it('should pass alarmEvent to updateStationNotification only when sleepMode is true', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+    mockCalculateStaticETA.mockReturnValue(10);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
+
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+      mockStation, 150, mockDestination, mockRoute, 10,
+      undefined, mockAlarmEvent,
+    );
+  });
+
+  it('should not pass alarmEvent to updateStationNotification when sleepMode is false', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+    mockCalculateStaticETA.mockReturnValue(10);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+      mockStation, 150, mockDestination, mockRoute, 10,
+      undefined, null,
     );
   });
 
@@ -277,6 +307,7 @@ describe('processLocationUpdate', () => {
     // Math.round(0.4567 * 1000) = 457
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
       mockStation, 457, mockDestination, mockRoute, 5,
+      undefined, null,
     );
   });
 
@@ -302,6 +333,7 @@ describe('processLocationUpdate', () => {
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
       mockStation, 150, mockDestination, null, null,
+      undefined, null,
     );
     expect(result.nearest).toBe(mockNearestResult);
   });

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -1,0 +1,308 @@
+import type { Station, NearestStationResult } from '../../types/station';
+import type { Route, DirectRoute } from '../stationRoute';
+import type { AlarmEvent } from '../stationAlarm';
+
+// ── 모든 외부 의존성 모킹 ──
+
+const mockFindNearestStation = jest.fn();
+jest.mock('../findNearestStation', () => ({
+  findNearestStation: (...args: unknown[]) => mockFindNearestStation(...args),
+}));
+
+const mockFindRoute = jest.fn();
+const mockCalculateStaticETA = jest.fn();
+jest.mock('../stationRoute', () => ({
+  findRoute: (...args: unknown[]) => mockFindRoute(...args),
+  calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
+}));
+
+const mockCheckAlarm = jest.fn();
+const mockAlarmKey = jest.fn();
+jest.mock('../stationAlarm', () => ({
+  checkAlarm: (...args: unknown[]) => mockCheckAlarm(...args),
+  alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
+}));
+
+const mockSendAlarmNotification = jest.fn();
+const mockUpdateStationNotification = jest.fn();
+jest.mock('../stationNotification', () => ({
+  sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
+  updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
+}));
+
+import { evaluateAlarm, processLocationUpdate } from '../stationPipeline';
+
+// ── 테스트 픽스처 ──
+
+const mockStation: Station = {
+  id: 'station-1',
+  name: '강남',
+  line: '2',
+  lineColor: '#009246',
+  lat: 37.498,
+  lng: 127.028,
+};
+
+const mockDestination: Station = {
+  id: 'station-2',
+  name: '시청',
+  line: '1',
+  lineColor: '#0052A4',
+  lat: 37.565,
+  lng: 126.977,
+};
+
+const mockNearestResult: NearestStationResult = {
+  station: mockStation,
+  distanceKm: 0.15,
+};
+
+const mockRoute: DirectRoute = { type: 'direct', stops: 3 };
+
+const mockAlarmEvent: AlarmEvent = { type: 'destination', stationName: '시청' };
+
+describe('evaluateAlarm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call findRoute with nearestStationId and destinationId', () => {
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+
+    evaluateAlarm({
+      nearestStationId: 'station-1',
+      destinationId: 'station-2',
+      destinationName: '시청',
+      firedAlarms: new Set(),
+    });
+
+    expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
+  });
+
+  it('should call checkAlarm with route, destinationName and firedAlarms', () => {
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+    const firedAlarms = new Set(['destination:강남']);
+
+    evaluateAlarm({
+      nearestStationId: 'station-1',
+      destinationId: 'station-2',
+      destinationName: '시청',
+      firedAlarms,
+    });
+
+    expect(mockCheckAlarm).toHaveBeenCalledWith(mockRoute, '시청', firedAlarms);
+  });
+
+  it('should return route and alarmEvent from checkAlarm', () => {
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+
+    const result = evaluateAlarm({
+      nearestStationId: 'station-1',
+      destinationId: 'station-2',
+      destinationName: '시청',
+      firedAlarms: new Set(),
+    });
+
+    expect(result).toEqual({ route: mockRoute, alarmEvent: mockAlarmEvent });
+  });
+
+  it('should return null alarmEvent when checkAlarm returns null', () => {
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+
+    const result = evaluateAlarm({
+      nearestStationId: 'station-1',
+      destinationId: 'station-2',
+      destinationName: '시청',
+      firedAlarms: new Set(),
+    });
+
+    expect(result.alarmEvent).toBeNull();
+    expect(result.route).toBe(mockRoute);
+  });
+
+  it('should handle null route from findRoute', () => {
+    mockFindRoute.mockReturnValue(null);
+    mockCheckAlarm.mockReturnValue(null);
+
+    const result = evaluateAlarm({
+      nearestStationId: 'unknown',
+      destinationId: 'unknown2',
+      destinationName: '없음',
+      firedAlarms: new Set(),
+    });
+
+    expect(result).toEqual({ route: null, alarmEvent: null });
+  });
+});
+
+describe('processLocationUpdate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendAlarmNotification.mockResolvedValue(undefined);
+    mockUpdateStationNotification.mockResolvedValue(undefined);
+    mockCalculateStaticETA.mockReturnValue(10);
+  });
+
+  it('should return null nearest and null alarmEvent when findNearestStation returns null', async () => {
+    mockFindNearestStation.mockReturnValue(null);
+
+    const result = await processLocationUpdate(
+      37.5, 127.0, mockDestination, new Set(), false,
+    );
+
+    expect(result).toEqual({ alarmEvent: null, nearest: null });
+    expect(mockFindRoute).not.toHaveBeenCalled();
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockUpdateStationNotification).not.toHaveBeenCalled();
+  });
+
+  it('should call evaluateAlarm with correct arguments when nearest is found', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+
+    await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false,
+    );
+
+    expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
+    expect(mockCheckAlarm).toHaveBeenCalledWith(mockRoute, '시청', expect.any(Set));
+  });
+
+  it('should send alarm notification when alarmEvent is not null (without mutating firedAlarms)', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+
+    const firedAlarms = new Set<string>();
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, firedAlarms, false);
+
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false);
+    expect(firedAlarms.size).toBe(0);
+  });
+
+  it('should pass sleepMode to sendAlarmNotification', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+    mockAlarmKey.mockReturnValue('destination:시청');
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
+
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', true);
+  });
+
+  it('should not call sendAlarmNotification when alarmEvent is null', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('should call updateStationNotification with correct arguments', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+    mockCalculateStaticETA.mockReturnValue(12);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    // distanceKm 0.15 → Math.round(0.15 * 1000) = 150
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+      mockStation,
+      150,
+      mockDestination,
+      mockRoute,
+      12,
+    );
+  });
+
+  it('should call calculateStaticETA with route', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(mockRoute);
+  });
+
+  it('should return alarmEvent and nearest in result', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+    mockAlarmKey.mockReturnValue('destination:시청');
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false,
+    );
+
+    expect(result.alarmEvent).toBe(mockAlarmEvent);
+    expect(result.nearest).toBe(mockNearestResult);
+  });
+
+  it('should return null alarmEvent and nearest result when no alarm', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false,
+    );
+
+    expect(result.alarmEvent).toBeNull();
+    expect(result.nearest).toBe(mockNearestResult);
+  });
+
+  it('should round distanceKm to meters correctly', async () => {
+    const nearestWithFraction: NearestStationResult = {
+      station: mockStation,
+      distanceKm: 0.4567,
+    };
+    mockFindNearestStation.mockReturnValue(nearestWithFraction);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+    mockCalculateStaticETA.mockReturnValue(5);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    // Math.round(0.4567 * 1000) = 457
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+      mockStation, 457, mockDestination, mockRoute, 5,
+    );
+  });
+
+  it('should not call alarmKey in processLocationUpdate (responsibility moved to caller)', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    expect(mockAlarmKey).not.toHaveBeenCalled();
+  });
+
+  it('should use null route correctly when findRoute returns null', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(null);
+    mockCheckAlarm.mockReturnValue(null);
+    mockCalculateStaticETA.mockReturnValue(null);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false,
+    );
+
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+      mockStation, 150, mockDestination, null, null,
+    );
+    expect(result.nearest).toBe(mockNearestResult);
+  });
+});

--- a/src/utils/findNearestStation.ts
+++ b/src/utils/findNearestStation.ts
@@ -1,0 +1,20 @@
+import stationsData from '../data/stations.json';
+import { haversine } from './haversine';
+import type { NearestStationResult, Station } from '../types/station';
+
+const stations = stationsData as Station[];
+
+export function findNearestStation(lat: number, lng: number): NearestStationResult | null {
+  let nearest: Station | null = null;
+  let minDistance = Infinity;
+
+  for (const station of stations) {
+    const dist = haversine(lat, lng, station.lat, station.lng);
+    if (dist < minDistance) {
+      minDistance = dist;
+      nearest = station;
+    }
+  }
+
+  return nearest ? { station: nearest, distanceKm: minDistance } : null;
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import { Station } from '../types/station';
 import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from './stationRoute';
+import type { AlarmEvent } from './stationAlarm';
 import * as LiveActivity from 'live-activity';
 import { playAlarmWithRouting, stopAlarm } from './alarmSound';
 import { createLogger } from './logger';
@@ -105,6 +106,7 @@ function buildLiveActivityData(
   route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
   etaMinutes?: number | null,
   isMock?: boolean,
+  alarmEvent?: AlarmEvent | null,
 ): LiveActivity.LiveActivityData {
   // station layer: 항상 포함
   const data: LiveActivity.LiveActivityData = {
@@ -144,6 +146,12 @@ function buildLiveActivityData(
     data.isMock = true;
   }
 
+  // alarm layer: 알람 이벤트가 있을 때만
+  if (alarmEvent) {
+    data.alarmType = alarmEvent.type;
+    data.alarmStationName = alarmEvent.stationName;
+  }
+
   return data;
 }
 
@@ -154,6 +162,7 @@ export async function updateStationNotification(
   route?: DirectRoute | TransferRoute | MultiTransferRoute | null,
   etaMinutes?: number | null,
   isMock?: boolean,
+  alarmEvent?: AlarmEvent | null,
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
 
@@ -168,7 +177,7 @@ export async function updateStationNotification(
       notifLogger.info('알림 예약 완료:', title, body);
       return;
     }
-    const data = buildLiveActivityData(currentStation, distanceM, destination, route, etaMinutes, isMock);
+    const data = buildLiveActivityData(currentStation, distanceM, destination, route, etaMinutes, isMock, alarmEvent);
     try {
       liveActivityLogger.info('업데이트 요청');
       await LiveActivity.updateLiveActivity(data);

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -10,14 +10,14 @@ import { createLogger } from './logger';
 const notifLogger = createLogger('Notification');
 const liveActivityLogger = createLogger('LiveActivity');
 
-const NOTIFICATION_ID = 'current-station';
-const ALARM_NOTIFICATION_ID = 'station-alarm';
+export const NOTIFICATION_ID = 'current-station';
+export const ALARM_NOTIFICATION_ID = 'station-alarm';
 const ALARM_CHANNEL_ID = 'station-alarm';
 
 
 async function scheduleNotification(
   id: string,
-  content: { title: string; body: string; sound?: boolean; channelId?: string },
+  content: { title: string; body: string; sound?: boolean; channelId?: string; interruptionLevel?: 'timeSensitive' },
 ): Promise<void> {
   try {
     await Notifications.dismissNotificationAsync(id);
@@ -33,12 +33,13 @@ async function scheduleNotification(
 
 export function setupNotificationHandler(): void {
   Notifications.setNotificationHandler({
-    handleNotification: async () => {
+    handleNotification: async (notification) => {
+      const isAlarm = notification.request.identifier === ALARM_NOTIFICATION_ID;
       return {
         shouldShowAlert: true,
         shouldShowBanner: true,
         shouldShowList: true,
-        shouldPlaySound: false,
+        shouldPlaySound: isAlarm,
         shouldSetBadge: false,
       };
     },
@@ -56,8 +57,9 @@ export async function initStationNotification(): Promise<void> {
     await Notifications.setNotificationChannelAsync(ALARM_CHANNEL_ID, {
       name: '하차/환승 알림',
       importance: Notifications.AndroidImportance.HIGH,
-      sound: null,
-      enableVibrate: false,
+      sound: 'alarm.wav',
+      enableVibrate: true,
+      vibrationPattern: [0, 1000, 500, 1000],
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
     });
   }
@@ -221,10 +223,15 @@ export async function sendAlarmNotification(
   await scheduleNotification(ALARM_NOTIFICATION_ID, {
     title,
     body,
-    sound: false,
+    sound: true,
     ...(Platform.OS === 'android' && { channelId: ALARM_CHANNEL_ID }),
+    ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
   });
-  await playAlarmWithRouting(sleepMode);
+  try {
+    await playAlarmWithRouting(sleepMode);
+  } catch (e) {
+    notifLogger.error('알람 사운드 재생 실패 (백그라운드):', e);
+  }
   notifLogger.info('알람 알림:', title, body);
 }
 

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -1,0 +1,67 @@
+import { findNearestStation } from './findNearestStation';
+import { findRoute, calculateStaticETA } from './stationRoute';
+import { checkAlarm } from './stationAlarm';
+import { sendAlarmNotification, updateStationNotification } from './stationNotification';
+import type { NearestStationResult, Station } from '../types/station';
+import type { Route } from './stationRoute';
+import type { AlarmEvent } from './stationAlarm';
+
+// ── 순수 함수: 포그라운드/백그라운드 공용 ──
+
+export interface AlarmCheckInput {
+  nearestStationId: string;
+  destinationId: string;
+  destinationName: string;
+  firedAlarms: Set<string>;
+}
+
+export interface AlarmCheckResult {
+  route: Route;
+  alarmEvent: AlarmEvent | null;
+}
+
+export function evaluateAlarm(input: AlarmCheckInput): AlarmCheckResult {
+  const route = findRoute(input.nearestStationId, input.destinationId);
+  const alarmEvent = checkAlarm(route, input.destinationName, input.firedAlarms);
+  return { route, alarmEvent };
+}
+
+// ── 비동기 파이프라인: 백그라운드 태스크 전용 (부수효과 포함) ──
+
+export interface PipelineResult {
+  alarmEvent: AlarmEvent | null;
+  nearest: NearestStationResult | null;
+}
+
+export async function processLocationUpdate(
+  lat: number,
+  lng: number,
+  destination: Station,
+  firedAlarms: Set<string>,
+  sleepMode: boolean,
+): Promise<PipelineResult> {
+  const nearest = findNearestStation(lat, lng);
+  if (!nearest) return { alarmEvent: null, nearest: null };
+
+  const { route, alarmEvent } = evaluateAlarm({
+    nearestStationId: nearest.station.id,
+    destinationId: destination.id,
+    destinationName: destination.name,
+    firedAlarms,
+  });
+
+  if (alarmEvent) {
+    await sendAlarmNotification(alarmEvent.type, alarmEvent.stationName, sleepMode);
+  }
+
+  const eta = calculateStaticETA(route);
+  await updateStationNotification(
+    nearest.station,
+    Math.round(nearest.distanceKm * 1000),
+    destination,
+    route,
+    eta,
+  );
+
+  return { alarmEvent, nearest };
+}

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -61,6 +61,8 @@ export async function processLocationUpdate(
     destination,
     route,
     eta,
+    undefined,
+    sleepMode ? alarmEvent : null,
   );
 
   return { alarmEvent, nearest };

--- a/targets/subway-widget/SubwayLiveActivity.swift
+++ b/targets/subway-widget/SubwayLiveActivity.swift
@@ -18,6 +18,8 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var distanceM: Int
         var etaMinutes: Int?
         var isMock: Bool?
+        var alarmType: String?
+        var alarmStationName: String?
     }
 }
 #endif

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -14,7 +14,9 @@ struct SubwayLiveActivityWidget: Widget {
                 // Expanded
                 DynamicIslandExpandedRegion(.leading) {
                     Circle()
-                        .fill(Color(hex: context.state.lineColorHex) ?? .gray)
+                        .fill(context.state.alarmType != nil
+                              ? (context.state.alarmType == "destination" ? Color.red : Color.orange)
+                              : (Color(hex: context.state.lineColorHex) ?? .gray))
                         .frame(width: 12, height: 12)
                         .padding(.leading, 4)
                 }
@@ -24,7 +26,15 @@ struct SubwayLiveActivityWidget: Widget {
                             .font(.headline)
                             .fontWeight(.bold)
                             .foregroundColor(.white)
-                        if let dest = context.state.destinationName {
+                        if let alarmType = context.state.alarmType,
+                           let alarmName = context.state.alarmStationName {
+                            Text(alarmType == "transfer"
+                                 ? "다음 역 \(alarmName)에서 환승하세요!"
+                                 : "다음 역 \(alarmName)에서 내리세요!")
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundColor(alarmType == "destination" ? .red : .orange)
+                        } else if let dest = context.state.destinationName {
                             ExpandedRouteView(dest: dest, state: context.state)
                         } else {
                             Text("\(context.state.lineName) · \(context.state.distanceM)m")
@@ -35,7 +45,9 @@ struct SubwayLiveActivityWidget: Widget {
                 }
             } compactLeading: {
                 Circle()
-                    .fill(Color(hex: context.state.lineColorHex) ?? .gray)
+                    .fill(context.state.alarmType != nil
+                          ? (context.state.alarmType == "destination" ? Color.red : Color.orange)
+                          : (Color(hex: context.state.lineColorHex) ?? .gray))
                     .frame(width: 10, height: 10)
                     .padding(.leading, 2)
             } compactTrailing: {
@@ -46,7 +58,9 @@ struct SubwayLiveActivityWidget: Widget {
                     .lineLimit(1)
             } minimal: {
                 Circle()
-                    .fill(Color(hex: context.state.lineColorHex) ?? .gray)
+                    .fill(context.state.alarmType != nil
+                          ? (context.state.alarmType == "destination" ? Color.red : Color.orange)
+                          : (Color(hex: context.state.lineColorHex) ?? .gray))
                     .frame(width: 10, height: 10)
             }
         }
@@ -61,57 +75,116 @@ private struct LockScreenView: View {
         Color(hex: state.lineColorHex) ?? .gray
     }
 
+    var isUrgent: Bool {
+        state.alarmType != nil
+    }
+
+    var urgentColor: Color {
+        state.alarmType == "destination" ? .red : .orange
+    }
+
+    var urgentText: String {
+        guard let name = state.alarmStationName, let type = state.alarmType else { return "" }
+        return type == "transfer"
+            ? "다음 역 \(name)에서 환승하세요!"
+            : "다음 역 \(name)에서 내리세요!"
+    }
+
     var body: some View {
-        HStack(spacing: 16) {
-            // 노선 색상 바
-            RoundedRectangle(cornerRadius: 4)
-                .fill(lineColor)
-                .frame(width: 6)
+        if isUrgent {
+            // 긴급 모드
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.white.opacity(0.3))
+                    .frame(width: 6)
 
-            VStack(alignment: .leading, spacing: 4) {
-                // 노선 배지
-                Text(state.lineName)
-                    .font(.caption2)
-                    .fontWeight(.bold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 2)
-                    .background(lineColor)
-                    .cornerRadius(10)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(state.lineName)
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white.opacity(0.9))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(.white.opacity(0.2))
+                        .cornerRadius(10)
 
-                // 역 이름
-                Text(state.stationName)
-                    .font(.title2)
-                    .fontWeight(.black)
-                    .foregroundColor(.white)
+                    Text(state.stationName)
+                        .font(.title2)
+                        .fontWeight(.black)
+                        .foregroundColor(.white)
 
-                // 목적지 / 거리
-                if let dest = state.destinationName {
-                    LockScreenRouteView(dest: dest, state: state)
-                } else {
-                    Text("약 \(state.distanceM)m")
+                    Text(urgentText)
                         .font(.subheadline)
-                        .foregroundColor(lineColor)
-                }
-            }
-
-            Spacer()
-
-            if let eta = state.etaMinutes {
-                VStack(spacing: 2) {
-                    Text("약 \(eta)분")
-                        .font(.title3)
                         .fontWeight(.bold)
                         .foregroundColor(.white)
-                    Text(state.isMock == true ? "예상" : "소요")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
                 }
-                .padding(.trailing, 4)
+
+                Spacer()
+
+                Text(state.alarmType == "transfer" ? "환승" : "하차")
+                    .font(.title3)
+                    .fontWeight(.black)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.white.opacity(0.2))
+                    .cornerRadius(8)
             }
+            .padding(16)
+            .background(urgentColor)
+        } else {
+            // 일반 모드
+            HStack(spacing: 16) {
+                // 노선 색상 바
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(lineColor)
+                    .frame(width: 6)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    // 노선 배지
+                    Text(state.lineName)
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(lineColor)
+                        .cornerRadius(10)
+
+                    // 역 이름
+                    Text(state.stationName)
+                        .font(.title2)
+                        .fontWeight(.black)
+                        .foregroundColor(.white)
+
+                    // 목적지 / 거리
+                    if let dest = state.destinationName {
+                        LockScreenRouteView(dest: dest, state: state)
+                    } else {
+                        Text("약 \(state.distanceM)m")
+                            .font(.subheadline)
+                            .foregroundColor(lineColor)
+                    }
+                }
+
+                Spacer()
+
+                if let eta = state.etaMinutes {
+                    VStack(spacing: 2) {
+                        Text("약 \(eta)분")
+                            .font(.title3)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                        Text(state.isMock == true ? "예상" : "소요")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.trailing, 4)
+                }
+            }
+            .padding(16)
+            .background(.black.opacity(0.85))
         }
-        .padding(16)
-        .background(.black.opacity(0.85))
     }
 }
 


### PR DESCRIPTION
## Summary
- 취침모드에서 환승/하차 1역 전일 때 잠금화면 Live Activity를 긴급 모드로 전환
- 잠금화면: 빨간색(하차)/주황색(환승) 배경 + 경고 텍스트 + 환승/하차 배지
- Dynamic Island: circle 색상 변경 + 경고 텍스트 표시
- 일반 모드에서는 기존 알림 유지, Live Activity 변경 없음

Closes #99

## Changes
- `modules/live-activity/index.ts` — `alarmType`, `alarmStationName` 필드 추가
- `SubwayLiveActivity.swift`, `LiveActivityManager.swift` — Swift ContentState에 필드 추가
- `SubwayLiveActivityWidget.swift` — 긴급 상태 UI (색상·텍스트 전환)
- `stationNotification.ts` — `buildLiveActivityData`에 알람 정보 전달
- `index.tsx` — 포그라운드에서 `alarmEvent` 전달 (store 경유, 취침모드에서만 설정됨)
- `stationPipeline.ts` — 백그라운드에서 `sleepMode`일 때만 `alarmEvent` 전달

## Test plan
- [x] `npm test` — 365 테스트 통과, 100% 커버리지
- [x] `npm run type-check` — 타입 오류 없음
- [ ] iOS 실기기에서 취침모드 ON → 1역 전 도달 시 Live Activity 긴급 UI 확인
- [ ] 일반 모드에서는 Live Activity가 변경되지 않는지 확인