### PR TITLE
feat(#101): 실시간 도착 정보 개선 (5초 폴링 + 카운트다운 + 상태 메시지)

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -12,6 +12,8 @@ import { useAppStore } from '../../src/store/useAppStore';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { Station } from '../../src/types/station';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
+import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
+import { formatArrivalTime } from '../../src/utils/formatTime';
 import stationsData from '../../src/data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -32,7 +34,8 @@ export default function FavoritesScreen() {
     () => favorites.find((f) => f.id === selectedId) ?? null,
     [favorites, selectedId],
   );
-  const { arrival } = useArrivalInfo(selectedStation?.name ?? null);
+  const { arrival: rawArrival } = useArrivalInfo(selectedStation?.name ?? null);
+  const arrival = useArrivalCountdown(rawArrival);
 
   const searchResults = useMemo(() => {
     const trimmed = query.trim();
@@ -139,7 +142,7 @@ function FavoriteCard({
 }: {
   station: Station;
   isExpanded: boolean;
-  arrival: { up: { destination: string; arrivalMinutes: number }[]; down: { destination: string; arrivalMinutes: number }[] } | null;
+  arrival: { up: { destination: string; arrivalSeconds: number; statusMessage: string }[]; down: { destination: string; arrivalSeconds: number; statusMessage: string }[] } | null;
   onToggle: () => void;
   onRemove: () => void;
 }) {
@@ -188,17 +191,22 @@ function ArrivalRow({
   items,
 }: {
   label: string;
-  items: { destination: string; arrivalMinutes: number }[];
+  items: { destination: string; arrivalSeconds: number; statusMessage: string }[];
 }) {
   return (
     <View style={styles.arrivalRow}>
       <Text style={styles.arrivalLabel}>{label}</Text>
       <View>
         {items.map((item, idx) => (
-          <Text key={idx} style={styles.arrivalItem}>
-            {item.destination ? `${item.destination} · ` : ''}
-            {item.arrivalMinutes === 0 ? '곧 도착' : `${item.arrivalMinutes}분 후`}
-          </Text>
+          <View key={idx}>
+            <Text style={styles.arrivalItem}>
+              {item.destination ? `${item.destination} · ` : ''}
+              {formatArrivalTime(item.arrivalSeconds)}
+            </Text>
+            {item.statusMessage !== '' && (
+              <Text style={styles.statusMessage}>{item.statusMessage}</Text>
+            )}
+          </View>
         ))}
       </View>
     </View>
@@ -344,6 +352,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#ffffff',
     textAlign: 'right',
+  },
+  statusMessage: {
+    fontSize: 11,
+    color: '#a78bfa',
+    textAlign: 'right',
+    marginTop: 1,
     marginBottom: 2,
   },
   noArrival: {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,6 +3,8 @@ import { InteractionManager, ScrollView, StyleSheet, Switch, Text, TouchableOpac
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
+import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
+import { formatArrivalTime } from '../../src/utils/formatTime';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
@@ -17,7 +19,8 @@ const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
   const { result, userLocation, loading, error, permissionDenied, refresh } = useNearestStation();
-  const { arrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(result?.station.name ?? null);
+  const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(result?.station.name ?? null);
+  const arrival = useArrivalCountdown(rawArrival);
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
   const favorites = useAppStore((s) => s.favorites);
@@ -60,8 +63,8 @@ export default function HomeScreen() {
   );
   const nextTrainMinutes = arrival
     ? Math.min(
-        arrival.up[0]?.arrivalMinutes ?? Infinity,
-        arrival.down[0]?.arrivalMinutes ?? Infinity,
+        arrival.up[0]?.arrivalSeconds != null ? Math.floor(arrival.up[0].arrivalSeconds / 60) : Infinity,
+        arrival.down[0]?.arrivalSeconds != null ? Math.floor(arrival.down[0].arrivalSeconds / 60) : Infinity,
       )
     : null;
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
@@ -336,7 +339,7 @@ function ArrivalRow({
   items,
 }: {
   label: string;
-  items: { destination: string; arrivalMinutes: number }[];
+  items: { destination: string; arrivalSeconds: number; statusMessage: string }[];
 }) {
   return (
     <View style={styles.arrivalRow}>
@@ -346,10 +349,15 @@ function ArrivalRow({
           <Text style={styles.arrivalItem}>도착 정보 없음</Text>
         ) : (
           items.map((item, idx) => (
-            <Text key={idx} style={styles.arrivalItem}>
-              {item.destination ? `${item.destination} · ` : ''}
-              {item.arrivalMinutes === 0 ? '곧 도착' : `${item.arrivalMinutes}분 후`}
-            </Text>
+            <View key={idx} style={styles.arrivalItemContainer}>
+              <Text style={styles.arrivalItem}>
+                {item.destination ? `${item.destination} · ` : ''}
+                {formatArrivalTime(item.arrivalSeconds)}
+              </Text>
+              {item.statusMessage !== '' && (
+                <Text style={styles.statusMessage}>{item.statusMessage}</Text>
+              )}
+            </View>
           ))
         )}
       </View>
@@ -558,11 +566,19 @@ const styles = StyleSheet.create({
     color: '#aaaacc',
     fontWeight: '600',
   },
+  arrivalItemContainer: {
+    marginBottom: 4,
+  },
   arrivalItem: {
     fontSize: 15,
     color: '#ffffff',
     textAlign: 'right',
-    marginBottom: 4,
+  },
+  statusMessage: {
+    fontSize: 12,
+    color: '#a78bfa',
+    textAlign: 'right',
+    marginTop: 2,
   },
   icon: {
     fontSize: 48,

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -20,6 +20,8 @@ describe('fetchArrivalInfo', () => {
     expect(result.down.length).toBeGreaterThan(0);
     expect(result.up[0]).toHaveProperty('destination');
     expect(result.up[0]).toHaveProperty('arrivalMinutes');
+    expect(result.up[0]).toHaveProperty('arrivalSeconds');
+    expect(result.up[0]).toHaveProperty('statusMessage');
     expect(result.up[0]).toHaveProperty('trainCode');
     expect(result.isMock).toBe(true);
   });
@@ -47,6 +49,8 @@ describe('fetchArrivalInfo', () => {
     expect(result.up).toHaveLength(2);
     expect(result.down).toHaveLength(2);
     expect(result.up[0].arrivalMinutes).toBe(2); // 120초 → 2분
+    expect(result.up[0].arrivalSeconds).toBe(120);
+    expect(result.up[0].statusMessage).toBe('');
     expect(result.isMock).toBeUndefined();
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
@@ -120,6 +124,7 @@ describe('fetchArrivalInfo', () => {
 
     const result = await fetchArrivalInfo('강남');
     expect(result.up[0].arrivalMinutes).toBe(0);
+    expect(result.up[0].arrivalSeconds).toBe(0);
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
@@ -207,6 +212,26 @@ describe('fetchArrivalInfo', () => {
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
 
+  it('arvlMsg2를 statusMessage로 파싱한다', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        realtimeArrivalList: [
+          { trainLineNm: '소요산행', barvlDt: 90, btrainNo: 'T001', updnLine: '상행', arvlMsg2: '전역 출발' },
+        ],
+      }),
+    } as Response);
+
+    const result = await fetchArrivalInfo('강남');
+    expect(result.up[0].statusMessage).toBe('전역 출발');
+    expect(result.up[0].arrivalSeconds).toBe(90);
+    expect(result.up[0].arrivalMinutes).toBe(1);
+
+    delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
   it('trainLineNm, barvlDt, btrainNo가 undefined이면 기본값을 사용한다', async () => {
     process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
 
@@ -222,6 +247,8 @@ describe('fetchArrivalInfo', () => {
     const result = await fetchArrivalInfo('강남');
     expect(result.up[0].destination).toBe('');
     expect(result.up[0].arrivalMinutes).toBe(0);
+    expect(result.up[0].arrivalSeconds).toBe(0);
+    expect(result.up[0].statusMessage).toBe('');
     expect(result.up[0].trainCode).toBe('');
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -5,6 +5,8 @@ const log = createLogger('arrivalApi');
 export interface ArrivalInfo {
   destination: string;
   arrivalMinutes: number;
+  arrivalSeconds: number;
+  statusMessage: string;
   trainCode: string;
 }
 
@@ -16,12 +18,12 @@ export interface StationArrival {
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
-    { destination: '상행 종착역', arrivalMinutes: 2, trainCode: 'UP-001' },
-    { destination: '상행 종착역', arrivalMinutes: 8, trainCode: 'UP-002' },
+    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001' },
+    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002' },
   ],
   down: [
-    { destination: '하행 종착역', arrivalMinutes: 4, trainCode: 'DN-001' },
-    { destination: '하행 종착역', arrivalMinutes: 11, trainCode: 'DN-002' },
+    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001' },
+    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002' },
   ],
   isMock: true,
 });
@@ -61,9 +63,12 @@ export async function fetchArrivalInfo(
     const down: ArrivalInfo[] = [];
 
     for (const item of items) {
+      const seconds = Math.max(0, item.barvlDt ?? 0);
       const info: ArrivalInfo = {
         destination: item.trainLineNm ?? '',
-        arrivalMinutes: Math.max(0, Math.floor((item.barvlDt ?? 0) / 60)),
+        arrivalMinutes: Math.floor(seconds / 60),
+        arrivalSeconds: seconds,
+        statusMessage: item.arvlMsg2 ?? '',
         trainCode: item.btrainNo ?? '',
       };
       if (item.updnLine === '상행' || item.updnLine === '내선') {

--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -1,0 +1,142 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useArrivalCountdown } from '../useArrivalCountdown';
+import type { StationArrival } from '../../api/arrivalApi';
+
+const mockArrival: StationArrival = {
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001' }],
+  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002' }],
+};
+
+const mockArrivalMock: StationArrival = {
+  ...mockArrival,
+  isMock: true,
+};
+
+describe('useArrivalCountdown', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('arrival이 null이면 null을 반환한다', () => {
+    const { result } = renderHook(() => useArrivalCountdown(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('초기값으로 arrival을 그대로 반환한다', () => {
+    const { result } = renderHook(() => useArrivalCountdown(mockArrival));
+    expect(result.current).toEqual(mockArrival);
+  });
+
+  it('1초마다 arrivalSeconds가 1씩 감소한다', () => {
+    const { result } = renderHook(() => useArrivalCountdown(mockArrival));
+
+    act(() => { jest.advanceTimersByTime(1_000); });
+
+    expect(result.current!.up[0].arrivalSeconds).toBe(119);
+    expect(result.current!.down[0].arrivalSeconds).toBe(89);
+  });
+
+  it('3초 후 arrivalSeconds가 3 감소하고 arrivalMinutes가 업데이트된다', () => {
+    const { result } = renderHook(() => useArrivalCountdown(mockArrival));
+
+    act(() => { jest.advanceTimersByTime(3_000); });
+
+    expect(result.current!.up[0].arrivalSeconds).toBe(117);
+    expect(result.current!.up[0].arrivalMinutes).toBe(1); // 117/60 = 1
+    expect(result.current!.down[0].arrivalSeconds).toBe(87);
+    expect(result.current!.down[0].arrivalMinutes).toBe(1); // 87/60 = 1
+  });
+
+  it('arrivalSeconds가 0 이하로 내려가지 않는다', () => {
+    const nearArrival: StationArrival = {
+      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001' }],
+      down: [],
+    };
+
+    const { result } = renderHook(() => useArrivalCountdown(nearArrival));
+
+    act(() => { jest.advanceTimersByTime(5_000); });
+
+    expect(result.current!.up[0].arrivalSeconds).toBe(0);
+    expect(result.current!.up[0].arrivalMinutes).toBe(0);
+  });
+
+  it('isMock인 데이터는 카운트다운하지 않는다', () => {
+    const { result } = renderHook(() => useArrivalCountdown(mockArrivalMock));
+
+    act(() => { jest.advanceTimersByTime(3_000); });
+
+    expect(result.current).toEqual(mockArrivalMock);
+  });
+
+  it('새 arrival 데이터가 들어오면 값이 리셋된다', () => {
+    const { result, rerender } = renderHook(
+      ({ arrival }: { arrival: StationArrival | null }) => useArrivalCountdown(arrival),
+      { initialProps: { arrival: mockArrival as StationArrival | null } },
+    );
+
+    act(() => { jest.advanceTimersByTime(3_000); });
+    expect(result.current!.up[0].arrivalSeconds).toBe(117);
+
+    // 새 API 데이터 도착
+    const newArrival: StationArrival = {
+      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001' }],
+      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002' }],
+    };
+
+    rerender({ arrival: newArrival });
+    expect(result.current!.up[0].arrivalSeconds).toBe(200);
+  });
+
+  it('arrival이 null에서 값으로 변경되면 카운트다운을 시작한다', () => {
+    const { result, rerender } = renderHook(
+      ({ arrival }: { arrival: StationArrival | null }) => useArrivalCountdown(arrival),
+      { initialProps: { arrival: null as StationArrival | null } },
+    );
+
+    expect(result.current).toBeNull();
+
+    rerender({ arrival: mockArrival });
+    expect(result.current).toEqual(mockArrival);
+
+    act(() => { jest.advanceTimersByTime(2_000); });
+    expect(result.current!.up[0].arrivalSeconds).toBe(118);
+  });
+
+  it('arrival이 값에서 null로 변경되면 카운트다운을 중지한다', () => {
+    const { result, rerender } = renderHook(
+      ({ arrival }: { arrival: StationArrival | null }) => useArrivalCountdown(arrival),
+      { initialProps: { arrival: mockArrival as StationArrival | null } },
+    );
+
+    act(() => { jest.advanceTimersByTime(1_000); });
+    expect(result.current!.up[0].arrivalSeconds).toBe(119);
+
+    rerender({ arrival: null });
+    expect(result.current).toBeNull();
+  });
+
+  it('언마운트 시 카운트다운 인터벌이 정리된다', () => {
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    const { unmount } = renderHook(() => useArrivalCountdown(mockArrival));
+
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('destination과 statusMessage 등 다른 필드는 유지된다', () => {
+    const { result } = renderHook(() => useArrivalCountdown(mockArrival));
+
+    act(() => { jest.advanceTimersByTime(1_000); });
+
+    expect(result.current!.up[0].destination).toBe('소요산행');
+    expect(result.current!.up[0].statusMessage).toBe('전역 출발');
+    expect(result.current!.up[0].trainCode).toBe('T001');
+  });
+});

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -13,8 +13,8 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, trainCode: 'T001' }],
-  down: [{ destination: '인천행', arrivalMinutes: 5, trainCode: 'T002' }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001' }],
+  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002' }],
 };
 
 const mockArrivalWithMock = {
@@ -65,7 +65,7 @@ describe('useArrivalInfo', () => {
     expect(result.current.isMock).toBe(true);
   });
 
-  it('30초 인터벌 후 자동으로 도착 정보를 갱신한다', async () => {
+  it('5초 인터벌 후 자동으로 도착 정보를 갱신한다', async () => {
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 
     renderHook(() => useArrivalInfo('강남'));
@@ -75,7 +75,7 @@ describe('useArrivalInfo', () => {
     );
 
     act(() => {
-      jest.advanceTimersByTime(30_000);
+      jest.advanceTimersByTime(5_000);
     });
 
     await waitFor(() =>
@@ -175,8 +175,8 @@ describe('useArrivalInfo', () => {
 
   it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
     const updatedArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 5, trainCode: 'T001' }],
-      down: [{ destination: '인천행', arrivalMinutes: 8, trainCode: 'T002' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001' }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002' }],
     };
 
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
@@ -286,7 +286,7 @@ describe('useArrivalInfo', () => {
   it('stationName이 null일 때 폴링 콜백은 fetch하지 않는다', async () => {
     renderHook(() => useArrivalInfo(null));
 
-    jest.advanceTimersByTime(30_000);
+    jest.advanceTimersByTime(5_000);
     await Promise.resolve();
 
     expect(arrivalApiModule.fetchArrivalInfo).not.toHaveBeenCalled();
@@ -294,11 +294,11 @@ describe('useArrivalInfo', () => {
 
   it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
     const staleArrival = {
-      up: [{ destination: '이전역', arrivalMinutes: 99, trainCode: 'OLD' }],
+      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD' }],
       down: [],
     };
     const freshArrival = {
-      up: [{ destination: '새역', arrivalMinutes: 1, trainCode: 'NEW' }],
+      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW' }],
       down: [],
     };
 
@@ -323,7 +323,7 @@ describe('useArrivalInfo', () => {
     );
 
     // 폴링 트리거 → '강남'에 대한 느린 fetch 시작
-    act(() => { jest.advanceTimersByTime(30_000); });
+    act(() => { jest.advanceTimersByTime(5_000); });
 
     // 역 변경 → stationNameRef.current가 '역삼'으로 바뀜
     rerender({ name: '역삼' });
@@ -349,7 +349,7 @@ describe('useArrivalInfo', () => {
     // 폴링에서 mock 데이터 반환 → 캐시에 저장 안 됨
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrivalWithMock);
 
-    act(() => { jest.advanceTimersByTime(30_000); });
+    act(() => { jest.advanceTimersByTime(5_000); });
     await waitFor(() => expect(result.current.isMock).toBe(true));
     // mock 데이터가 arrival에 반영되었지만 캐시에는 이전 실제 데이터만 있음
     expect(result.current.arrival).toEqual(mockArrivalWithMock);
@@ -366,7 +366,7 @@ describe('useArrivalInfo', () => {
     // 폴링에서 에러 발생
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockRejectedValue(new Error('network'));
 
-    act(() => { jest.advanceTimersByTime(30_000); });
+    act(() => { jest.advanceTimersByTime(5_000); });
     await Promise.resolve();
 
     // 에러 무시 — 기존 데이터 유지
@@ -375,8 +375,8 @@ describe('useArrivalInfo', () => {
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
     const freshArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 1, trainCode: 'T003' }],
-      down: [{ destination: '인천행', arrivalMinutes: 3, trainCode: 'T004' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003' }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004' }],
     };
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/hooks/useArrivalCountdown.ts
+++ b/src/hooks/useArrivalCountdown.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
+
+const COUNTDOWN_INTERVAL_MS = 1_000;
+
+function tickItems(items: ArrivalInfo[]): ArrivalInfo[] {
+  return items.map((item) => {
+    const seconds = Math.max(0, item.arrivalSeconds - 1);
+    return {
+      ...item,
+      arrivalSeconds: seconds,
+      arrivalMinutes: Math.floor(seconds / 60),
+    };
+  });
+}
+
+export function useArrivalCountdown(arrival: StationArrival | null): StationArrival | null {
+  const [display, setDisplay] = useState<StationArrival | null>(arrival);
+  const arrivalRef = useRef(arrival);
+
+  // Sync when new API data arrives
+  useEffect(() => {
+    arrivalRef.current = arrival;
+    setDisplay(arrival);
+  }, [arrival]);
+
+  // Countdown every second for non-mock data
+  const isMock = arrival?.isMock === true;
+  const hasArrival = arrival != null;
+  useEffect(() => {
+    if (!hasArrival || isMock) return;
+
+    const id = setInterval(() => {
+      const current = arrivalRef.current!;
+      const ticked: StationArrival = {
+        ...current,
+        up: tickItems(current.up),
+        down: tickItems(current.down),
+      };
+      arrivalRef.current = ticked;
+      setDisplay(ticked);
+    }, COUNTDOWN_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [hasArrival, isMock]);
+
+  return display;
+}

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -5,7 +5,8 @@ import { createArrivalProvider } from '../providers/factory';
 import { TtlCache } from '../utils/ttlCache';
 import { usePolling } from './usePolling';
 
-const POLL_INTERVAL_MS = 30_000;
+const POLL_INTERVAL_MS = 5_000;
+const CACHE_TTL_MS = 30_000;
 
 function arrivalEqual(a: StationArrival | null, b: StationArrival): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
@@ -23,7 +24,7 @@ export function useArrivalInfo(
 ): UseArrivalInfoReturn {
   const [arrival, setArrival] = useState<StationArrival | null>(null);
   const [loading, setLoading] = useState(false);
-  const cacheRef = useRef(new TtlCache<string, StationArrival>(POLL_INTERVAL_MS));
+  const cacheRef = useRef(new TtlCache<string, StationArrival>(CACHE_TTL_MS));
   const providerRef = useRef<ArrivalProvider>(provider ?? createArrivalProvider());
   const arrivalRef = useRef<StationArrival | null>(null);
   const stationNameRef = useRef(stationName);

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -8,8 +8,8 @@ describe('BffArrivalProvider', () => {
   let provider: BffArrivalProvider;
 
   const VALID_DATA: StationArrival = {
-    up: [{ destination: '서울역', arrivalMinutes: 3, trainCode: 'UP-001' }],
-    down: [{ destination: '인천역', arrivalMinutes: 5, trainCode: 'DN-001' }],
+    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001' }],
+    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001' }],
   };
 
   function mockFetchOk(data: StationArrival) {

--- a/src/utils/__tests__/formatTime.test.ts
+++ b/src/utils/__tests__/formatTime.test.ts
@@ -1,0 +1,21 @@
+import { formatArrivalTime } from '../formatTime';
+
+describe('formatArrivalTime', () => {
+  it('0초 이하이면 "곧 도착"을 반환한다', () => {
+    expect(formatArrivalTime(0)).toBe('곧 도착');
+    expect(formatArrivalTime(-1)).toBe('곧 도착');
+  });
+
+  it('60초 미만이면 초만 표시한다', () => {
+    expect(formatArrivalTime(30)).toBe('30초');
+    expect(formatArrivalTime(1)).toBe('1초');
+    expect(formatArrivalTime(59)).toBe('59초');
+  });
+
+  it('60초 이상이면 분과 초를 표시한다', () => {
+    expect(formatArrivalTime(60)).toBe('1분 0초');
+    expect(formatArrivalTime(90)).toBe('1분 30초');
+    expect(formatArrivalTime(150)).toBe('2분 30초');
+    expect(formatArrivalTime(300)).toBe('5분 0초');
+  });
+});

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,7 @@
+export function formatArrivalTime(seconds: number): string {
+  if (seconds <= 0) return '곧 도착';
+  const min = Math.floor(seconds / 60);
+  const sec = seconds % 60;
+  if (min === 0) return `${sec}초`;
+  return `${min}분 ${sec}초`;
+}


### PR DESCRIPTION
## Summary
- API 폴링 간격 30초 → 5초로 변경하여 도착 정보 오차 ±30초 → ±5초로 개선
- `useArrivalCountdown` 훅 추가: API 호출 사이 1초 카운트다운으로 UI가 매초 갱신
- `barvlDt` 초 단위 보존 + `arvlMsg2` 상태 메시지("전역 출발", "곧 도착" 등) 파싱 및 표시
- `formatArrivalTime` 유틸 추출로 index.tsx/favorites.tsx 중복 제거

## 변경 파일
- `src/api/arrivalApi.ts` — ArrivalInfo에 arrivalSeconds, statusMessage 추가
- `src/hooks/useArrivalInfo.ts` — 폴링 5초, TTL 캐시 30초 분리
- `src/hooks/useArrivalCountdown.ts` — 1초 카운트다운 훅 (신규)
- `src/utils/formatTime.ts` — 도착 시간 포맷 유틸 (신규)
- `app/(tabs)/index.tsx` — 초 단위 + 상태 메시지 UI
- `app/(tabs)/favorites.tsx` — 동일하게 초 단위 UI 적용

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (324 tests, 100% coverage)
- [x] 카운트다운 훅 테스트 11개 추가
- [x] formatArrivalTime 유틸 테스트 추가
- [x] iOS 시뮬레이터에서 실시간 카운트다운 동작 확인
- [x] 백그라운드 → 포그라운드 전환 시 데이터 갱신 확인

Closes #101