### PR TITLE
feat(#105): Maestro E2E 테스트 환경 셋업

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,71 @@ jobs:
 
       - name: 단위 테스트 실행 (커버리지 100% 검증)
         run: npm test -- --ci --forceExit
+
+  e2e:
+    name: E2E Tests (Maestro)
+    runs-on: macos-latest
+    needs: test
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Xcode 버전 고정
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 의존성 설치
+        run: npm ci --legacy-peer-deps
+
+      - name: Maestro CLI 설치
+        run: |
+          export MAESTRO_VERSION=2.4.0
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: iOS Prebuild
+        run: npx expo prebuild --platform ios --clean
+
+      - name: CocoaPods 설치
+        run: cd ios && pod install
+
+      - name: iOS 빌드 (Debug)
+        run: |
+          cd ios
+          xcodebuild -workspace subwaynow.xcworkspace \
+            -scheme subwaynow \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -derivedDataPath build \
+            build
+
+      - name: 시뮬레이터 부팅 및 준비 대기
+        run: |
+          xcrun simctl boot "iPhone 16" || true
+          xcrun simctl bootstatus "iPhone 16" -b
+
+      - name: 앱 설치
+        run: |
+          APP_PATH=$(find ios/build -name "*.app" -type d | head -1)
+          if [ -z "$APP_PATH" ]; then echo "ERROR: .app not found"; exit 1; fi
+          xcrun simctl install booted "$APP_PATH"
+
+      - name: Maestro E2E 테스트 실행
+        run: maestro test .maestro/flows/ --format junit --output maestro-report.xml
+
+      - name: E2E 결과 업로드
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-results
+          path: maestro-report.xml

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,0 +1,1 @@
+appId: com.subwaynow.app

--- a/.maestro/flows/favorites/01_add_favorite.yaml
+++ b/.maestro/flows/favorites/01_add_favorite.yaml
@@ -1,0 +1,46 @@
+appId: com.subwaynow.app
+name: "즐겨찾기 - 추가"
+---
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 즐겨찾기 탭으로 이동
+- tapOn:
+    text: "즐겨찾기"
+    timeout: 10000
+
+# 빈 상태 확인
+- assertVisible:
+    id: "favorites-empty"
+    timeout: 5000
+
+# 역 검색
+- tapOn:
+    id: "favorites-search-input"
+- inputText: "강남"
+
+# 검색 결과에서 추가
+- assertVisible:
+    text: "강남"
+    timeout: 5000
+- tapOn:
+    id: "favorite-add-2-022"
+
+# 검색어 지우기
+- tapOn:
+    id: "favorites-search-input"
+- clearText
+- hideKeyboard
+
+# 즐겨찾기 목록에 표시 확인
+- assertVisible:
+    text: "강남"
+    timeout: 5000

--- a/.maestro/flows/favorites/02_remove_favorite.yaml
+++ b/.maestro/flows/favorites/02_remove_favorite.yaml
@@ -1,0 +1,48 @@
+appId: com.subwaynow.app
+name: "즐겨찾기 - 삭제"
+---
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 즐겨찾기 탭으로 이동
+- tapOn:
+    text: "즐겨찾기"
+    timeout: 10000
+
+# 먼저 즐겨찾기 추가
+- tapOn:
+    id: "favorites-search-input"
+- inputText: "서울역"
+- assertVisible:
+    text: "서울역"
+    timeout: 5000
+- tapOn:
+    id: "favorite-add-1-034"
+
+# 검색어 지우기
+- tapOn:
+    id: "favorites-search-input"
+- clearText
+- hideKeyboard
+
+# 즐겨찾기에 있는지 확인
+- assertVisible:
+    text: "서울역"
+    timeout: 5000
+
+# 삭제
+- tapOn:
+    id: "favorite-remove-1-034"
+
+# 빈 상태 복원 확인
+- assertVisible:
+    id: "favorites-empty"
+    timeout: 5000

--- a/.maestro/flows/home/01_app_launch.yaml
+++ b/.maestro/flows/home/01_app_launch.yaml
@@ -1,0 +1,38 @@
+appId: com.subwaynow.app
+name: "홈 화면 - 앱 실행 및 역 감지"
+---
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 홈 화면 로드 확인 (LIVE 라벨)
+- assertVisible:
+    text: "LIVE"
+    timeout: 15000
+
+# 강남역 감지 확인
+- assertVisible:
+    text: "강남"
+    timeout: 10000
+
+# 목적지 설정 버튼
+- assertVisible:
+    id: "destination-button"
+
+- assertVisible:
+    text: "목적지 설정"
+
+# 도착 정보 섹션
+- assertVisible:
+    text: "Next trains"

--- a/.maestro/flows/home/02_set_destination.yaml
+++ b/.maestro/flows/home/02_set_destination.yaml
@@ -1,0 +1,53 @@
+appId: com.subwaynow.app
+name: "홈 화면 - 목적지 설정"
+---
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+- assertVisible:
+    id: "destination-button"
+    timeout: 15000
+
+- tapOn:
+    id: "destination-button"
+
+- assertVisible:
+    id: "search-input"
+    timeout: 5000
+
+- tapOn:
+    id: "search-input"
+- inputText: "잠실"
+
+- assertVisible:
+    id: "suggestions-list"
+    timeout: 5000
+
+- tapOn:
+    id: "suggestion-item-2-016"
+
+# 목적지 설정됨 확인
+- assertVisible:
+    text: "잠실"
+    timeout: 5000
+
+- assertVisible:
+    text: "목적지 변경"
+
+- assertVisible:
+    id: "destination-clear-button"
+
+- assertVisible:
+    id: "sleep-mode-row"

--- a/.maestro/flows/home/03_clear_destination.yaml
+++ b/.maestro/flows/home/03_clear_destination.yaml
@@ -1,0 +1,50 @@
+appId: com.subwaynow.app
+name: "홈 화면 - 목적지 초기화"
+---
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+- assertVisible:
+    id: "destination-button"
+    timeout: 15000
+
+# 목적지 설정
+- tapOn:
+    id: "destination-button"
+- assertVisible:
+    id: "search-input"
+    timeout: 5000
+- tapOn:
+    id: "search-input"
+- inputText: "홍대입구"
+- assertVisible:
+    id: "suggestions-list"
+    timeout: 5000
+- tapOn:
+    id: "suggestion-item-2-039"
+
+# 목적지 설정됨 확인
+- assertVisible:
+    id: "destination-clear-button"
+    timeout: 5000
+
+# 초기화
+- tapOn:
+    id: "destination-clear-button"
+
+# 원래 상태로 복원 확인
+- assertVisible:
+    text: "목적지 설정"
+    timeout: 5000

--- a/.maestro/flows/home/04_sleep_mode.yaml
+++ b/.maestro/flows/home/04_sleep_mode.yaml
@@ -1,0 +1,61 @@
+appId: com.subwaynow.app
+name: "홈 화면 - 취침 모드 토글"
+---
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+- assertVisible:
+    id: "destination-button"
+    timeout: 15000
+
+# 목적지 설정 (취침 모드는 목적지 있을 때만 표시)
+- tapOn:
+    id: "destination-button"
+- assertVisible:
+    id: "search-input"
+    timeout: 5000
+- tapOn:
+    id: "search-input"
+- inputText: "잠실"
+- assertVisible:
+    id: "suggestions-list"
+    timeout: 5000
+- tapOn:
+    id: "suggestion-item-2-016"
+
+# 취침 모드 스위치 확인 및 토글
+- assertVisible:
+    id: "home-sleep-mode-switch"
+    timeout: 5000
+- tapOn:
+    id: "home-sleep-mode-switch"
+
+# 설정 탭에서 동기화 확인
+- tapOn:
+    text: "설정"
+- assertVisible:
+    id: "sleep-mode-switch"
+    timeout: 5000
+
+# 설정 탭에서 토글 해제
+- tapOn:
+    id: "sleep-mode-switch"
+
+# 홈으로 돌아가서 확인
+- tapOn:
+    text: "현재 역"
+- assertVisible:
+    id: "home-sleep-mode-switch"
+    timeout: 5000

--- a/.maestro/flows/location/01_near_station.yaml
+++ b/.maestro/flows/location/01_near_station.yaml
@@ -1,0 +1,37 @@
+appId: com.subwaynow.app
+name: "위치 - 역 근처 (강남역)"
+---
+# 강남역 바로 앞 (50m 이내)
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 현재역 라벨 표시 확인 (500m 이내)
+- assertVisible:
+    text: "현재역"
+    timeout: 15000
+
+# 강남역 이름 표시
+- assertVisible:
+    text: "강남"
+
+# 도착 정보 섹션 표시
+- assertVisible:
+    text: "Next trains"
+
+# 상행/하행 표시
+- assertVisible:
+    text: "상행"
+- assertVisible:
+    text: "하행"

--- a/.maestro/flows/location/02_no_station_nearby.yaml
+++ b/.maestro/flows/location/02_no_station_nearby.yaml
@@ -1,0 +1,27 @@
+appId: com.subwaynow.app
+name: "위치 - 역에서 먼 곳"
+---
+# 서울 외곽 (역에서 500m 이상 떨어진 곳)
+- setLocation:
+    latitude: 37.40
+    longitude: 127.10
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 역 없음 상태 메시지 확인
+- assertVisible:
+    text: "지하철역 근처가 아닙니다"
+    timeout: 15000
+
+# 새로고침 버튼 표시
+- assertVisible:
+    text: "새로고침"

--- a/.maestro/flows/location/03_station_change.yaml
+++ b/.maestro/flows/location/03_station_change.yaml
@@ -1,0 +1,33 @@
+appId: com.subwaynow.app
+name: "위치 - 역 변경 (강남 → 잠실)"
+---
+# 강남역에서 시작
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 강남역 감지 확인
+- assertVisible:
+    text: "강남"
+    timeout: 15000
+
+# 잠실역으로 위치 변경
+- setLocation:
+    latitude: 37.513262
+    longitude: 127.100159
+
+# 잠실역으로 변경될 때까지 대기 (폴링 주기 30초, 2사이클 커버)
+- assertVisible:
+    text: "잠실"
+    timeout: 70000

--- a/.maestro/flows/navigation/01_tab_navigation.yaml
+++ b/.maestro/flows/navigation/01_tab_navigation.yaml
@@ -1,0 +1,50 @@
+appId: com.subwaynow.app
+name: "탭 내비게이션 순회"
+---
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: allow
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 홈 탭 확인
+- assertVisible:
+    text: "LIVE"
+    timeout: 15000
+
+# 지도 탭
+- tapOn:
+    text: "지도"
+- assertVisible:
+    text: "네이버 지도에서 보기"
+    timeout: 10000
+
+# 즐겨찾기 탭
+- tapOn:
+    text: "즐겨찾기"
+- assertVisible:
+    id: "favorites-search-input"
+    timeout: 5000
+
+# 설정 탭
+- tapOn:
+    text: "설정"
+- assertVisible:
+    id: "sleep-mode-switch"
+    timeout: 5000
+
+# 홈 탭으로 복귀
+- tapOn:
+    text: "현재 역"
+- assertVisible:
+    text: "LIVE"
+    timeout: 5000

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -60,6 +60,7 @@ export default function FavoritesScreen() {
           placeholderTextColor="#8888aa"
           value={query}
           onChangeText={setQuery}
+          testID="favorites-search-input"
         />
 
         {isSearching ? (
@@ -78,7 +79,7 @@ export default function FavoritesScreen() {
             ))
           )
         ) : favorites.length === 0 ? (
-          <View style={styles.empty}>
+          <View style={styles.empty} testID="favorites-empty">
             <Text style={styles.emptyIcon}>⭐</Text>
             <Text style={styles.emptyTitle}>즐겨찾기가 없습니다</Text>
             <Text style={styles.emptySubtitle}>
@@ -126,6 +127,7 @@ function SearchResultCard({
         style={[styles.addButton, already && styles.addButtonDisabled]}
         onPress={onAdd}
         disabled={already}
+        testID={`favorite-add-${station.id}`}
       >
         <Text style={styles.addButtonText}>{already ? '✓' : '+'}</Text>
       </TouchableOpacity>
@@ -157,7 +159,7 @@ function FavoriteCard({
         </View>
         <View style={styles.cardActions}>
           <Text style={styles.expandIcon}>{isExpanded ? '▲' : '▼'}</Text>
-          <TouchableOpacity style={styles.removeButton} onPress={onRemove}>
+          <TouchableOpacity style={styles.removeButton} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
             <Text style={styles.removeText}>삭제</Text>
           </TouchableOpacity>
         </View>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
     "web": "expo start --web",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "e2e": "maestro test .maestro/flows/",
+    "e2e:home": "maestro test .maestro/flows/home/",
+    "e2e:favorites": "maestro test .maestro/flows/favorites/",
+    "e2e:navigation": "maestro test .maestro/flows/navigation/",
+    "e2e:location": "maestro test .maestro/flows/location/",
+    "e2e:flow": "maestro test",
+    "verify": "npm test && npm run e2e"
   },
   "jest": {
     "preset": "jest-expo",


### PR DESCRIPTION
## Summary
- Maestro E2E 테스트 인프라 셋업 (CLI + 디렉토리 구조 + config)
- 10개 E2E flow 작성 (home 4, favorites 2, navigation 1, location 3)
- favorites.tsx에 testID 4개 추가 (기존 단위 테스트 영향 없음)
- npm 스크립트 7개 추가 (`e2e`, `e2e:home`, `e2e:favorites`, `e2e:navigation`, `e2e:location`, `e2e:flow`, `verify`)
- GitHub Actions CI에 macOS runner 기반 E2E job 추가 (PR에서만 실행)

## 개발 워크플로우 변경
**기존**: 코드 수정 → `npm test` → 수동 시뮬레이터 확인
**개선**: 코드 수정 → `npm run verify` (단위 + E2E 한방에)

기능별 빠른 확인:
- `npm run e2e:home` — 홈 화면 관련
- `npm run e2e:favorites` — 즐겨찾기 관련
- `npm run e2e:location` — 위치 시나리오

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 커버리지 100% 유지 (384 tests)
- [ ] iOS 시뮬레이터에서 `npm run e2e` 전체 flow 통과
- [ ] CI에서 PR 생성 시 e2e job 동작 확인

Closes #105