### PR TITLE
fix(#108): 잠금화면/취침모드에서 알림 미표시 수정

### DIFF
--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -121,10 +121,16 @@ describe('stationNotification', () => {
   });
 
   describe('initStationNotification', () => {
-    it('iOS에서는 권한 요청만 한다', async () => {
+    it('iOS에서는 critical alerts 포함 권한 요청만 한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await initStationNotification();
-      expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(Notifications.requestPermissionsAsync).toHaveBeenCalledWith({
+        ios: {
+          allowAlert: true,
+          allowSound: true,
+          allowCriticalAlerts: true,
+        },
+      });
       expect(Notifications.setNotificationChannelAsync).not.toHaveBeenCalled();
     });
 
@@ -140,11 +146,12 @@ describe('stationNotification', () => {
       expect(Notifications.deleteNotificationChannelAsync).toHaveBeenCalledWith('station-alarm');
       expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-alarm', {
         name: '하차/환승 알림',
-        importance: Notifications.AndroidImportance.HIGH,
+        importance: Notifications.AndroidImportance.MAX,
         sound: 'alarm.wav',
         enableVibrate: true,
         vibrationPattern: [0, 1000, 500, 1000],
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+        bypassDnd: true,
       });
       expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
     });
@@ -428,10 +435,10 @@ describe('stationNotification', () => {
       expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(true);
     });
 
-    it('Android에서는 channelId가 포함된다', async () => {
+    it('Android에서는 channelId와 priority MAX가 포함된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
       await sendAlarmNotification('destination', '강남');
-      expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!', { channelId: 'station-alarm' });
+      expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!', { channelId: 'station-alarm', priority: 'max' });
     });
 
     it('dismiss 실패해도 schedule은 호출된다', async () => {
@@ -459,10 +466,10 @@ describe('stationNotification', () => {
       expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(true);
     });
 
-    it('timeBased + Android에서는 channelId가 포함된다', async () => {
+    it('timeBased + Android에서는 channelId와 priority MAX가 포함된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
       await sendAlarmNotification('destination', '강남', false, true);
-      expectAlarmNotification('도착 임박', '곧 강남에 도착합니다. 하차 준비하세요!', { channelId: 'station-alarm' });
+      expectAlarmNotification('도착 임박', '곧 강남에 도착합니다. 하차 준비하세요!', { channelId: 'station-alarm', priority: 'max' });
     });
 
     it('timeBased approaching이면 역 접근 알림을 보낸다', async () => {
@@ -471,10 +478,10 @@ describe('stationNotification', () => {
       expectAlarmNotification('역 접근', '곧 역삼에 도착합니다.', { interruptionLevel: 'timeSensitive' });
     });
 
-    it('timeBased approaching + Android에서는 channelId가 포함된다', async () => {
+    it('timeBased approaching + Android에서는 channelId와 priority MAX가 포함된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
       await sendAlarmNotification('approaching', '역삼', false, true);
-      expectAlarmNotification('역 접근', '곧 역삼에 도착합니다.', { channelId: 'station-alarm' });
+      expectAlarmNotification('역 접근', '곧 역삼에 도착합니다.', { channelId: 'station-alarm', priority: 'max' });
     });
 
     it('playAlarmWithRouting 실패해도 알림은 정상 예약된다', async () => {

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -1,5 +1,5 @@
 import type { Station, NearestStationResult } from '../../types/station';
-import type { Route, DirectRoute } from '../stationRoute';
+import type { Route, DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 import type { AlarmEvent } from '../stationAlarm';
 
 // ── 모든 외부 의존성 모킹 ──
@@ -17,9 +17,11 @@ jest.mock('../stationRoute', () => ({
 }));
 
 const mockCheckAlarm = jest.fn();
+const mockCheckTimeBasedAlarm = jest.fn();
 const mockAlarmKey = jest.fn();
 jest.mock('../stationAlarm', () => ({
   checkAlarm: (...args: unknown[]) => mockCheckAlarm(...args),
+  checkTimeBasedAlarm: (...args: unknown[]) => mockCheckTimeBasedAlarm(...args),
   alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
 }));
 
@@ -30,7 +32,7 @@ jest.mock('../stationNotification', () => ({
   updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
 }));
 
-import { evaluateAlarm, processLocationUpdate } from '../stationPipeline';
+import { evaluateAlarm, processLocationUpdate, resolveNextTarget } from '../stationPipeline';
 
 // ── 테스트 픽스처 ──
 
@@ -145,6 +147,7 @@ describe('processLocationUpdate', () => {
     mockSendAlarmNotification.mockResolvedValue(undefined);
     mockUpdateStationNotification.mockResolvedValue(undefined);
     mockCalculateStaticETA.mockReturnValue(10);
+    mockCheckTimeBasedAlarm.mockReturnValue(null);
   });
 
   it('should return null nearest and null alarmEvent when findNearestStation returns null', async () => {
@@ -182,7 +185,7 @@ describe('processLocationUpdate', () => {
 
     await processLocationUpdate(37.498, 127.028, mockDestination, firedAlarms, false);
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, false);
     expect(firedAlarms.size).toBe(0);
   });
 
@@ -194,7 +197,7 @@ describe('processLocationUpdate', () => {
 
     await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', true);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', true, false);
   });
 
   it('should not call sendAlarmNotification when alarmEvent is null', async () => {
@@ -336,5 +339,145 @@ describe('processLocationUpdate', () => {
       undefined, null,
     );
     expect(result.nearest).toBe(mockNearestResult);
+  });
+
+  it('should check time-based alarm when stop-count alarm is null', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+    const timeEvent: AlarmEvent = { type: 'destination', stationName: '시청', timeBased: true };
+    mockCheckTimeBasedAlarm.mockReturnValue(timeEvent);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false,
+    );
+
+    expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
+      '시청', 3, '시청', mockRoute, expect.any(Set),
+    );
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, true);
+    expect(result.alarmEvent).toBe(timeEvent);
+  });
+
+  it('should skip time-based alarm when stop-count alarm already exists', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    expect(mockCheckTimeBasedAlarm).not.toHaveBeenCalled();
+  });
+
+  it('should pass timeBased flag to sendAlarmNotification for time-based alarm with sleepMode', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCheckAlarm.mockReturnValue(null);
+    const timeEvent: AlarmEvent = { type: 'transfer', stationName: '동대문', timeBased: true };
+    mockCheckTimeBasedAlarm.mockReturnValue(timeEvent);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
+
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '동대문', true, true);
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+      mockStation, 150, mockDestination, mockRoute, 10, undefined, timeEvent,
+    );
+  });
+
+  it('should not check time-based alarm when route is null', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(null);
+    mockCheckAlarm.mockReturnValue(null);
+    mockCalculateStaticETA.mockReturnValue(null);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    expect(mockCheckTimeBasedAlarm).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveNextTarget', () => {
+  it('should return null for null route', () => {
+    expect(resolveNextTarget(null, '강남')).toBeNull();
+  });
+
+  it('should return destination and stops for direct route', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5 };
+    expect(resolveNextTarget(route, '강남')).toEqual({
+      nextStationName: '강남',
+      stopsToNextStation: 5,
+    });
+  });
+
+  it('should return transfer station for transfer route with stopsToTransfer > 0', () => {
+    const route: TransferRoute = {
+      type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
+      stopsToTransfer: 3, stopsFromTransfer: 2,
+    };
+    expect(resolveNextTarget(route, '강남')).toEqual({
+      nextStationName: '동대문',
+      stopsToNextStation: 3,
+    });
+  });
+
+  it('should return destination for transfer route with stopsToTransfer = 0', () => {
+    const route: TransferRoute = {
+      type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
+      stopsToTransfer: 0, stopsFromTransfer: 2,
+    };
+    expect(resolveNextTarget(route, '강남')).toEqual({
+      nextStationName: '강남',
+      stopsToNextStation: 2,
+    });
+  });
+
+  it('should return first transfer for multi-transfer route with stopsToTransfer > 0', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    expect(resolveNextTarget(route, '강남')).toEqual({
+      nextStationName: '잠실',
+      stopsToNextStation: 3,
+    });
+  });
+
+  it('should return second transfer when first has stopsToTransfer = 0', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 0 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    expect(resolveNextTarget(route, '강남')).toEqual({
+      nextStationName: '시청',
+      stopsToNextStation: 5,
+    });
+  });
+
+  it('should return null for unknown route type', () => {
+    const route = { type: 'unknown' } as unknown as Route;
+    expect(resolveNextTarget(route, '강남')).toBeNull();
+  });
+
+  it('should return destination when all transfers have stopsToTransfer = 0', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 0 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 0 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    expect(resolveNextTarget(route, '강남')).toEqual({
+      nextStationName: '강남',
+      stopsToNextStation: 4,
+    });
   });
 });

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -18,7 +18,7 @@ const ALARM_CHANNEL_ID = 'station-alarm';
 
 async function scheduleNotification(
   id: string,
-  content: { title: string; body: string; sound?: boolean; channelId?: string; interruptionLevel?: 'timeSensitive' },
+  content: { title: string; body: string; sound?: boolean; channelId?: string; interruptionLevel?: 'timeSensitive' | 'critical'; priority?: Notifications.AndroidNotificationPriority },
 ): Promise<void> {
   try {
     await Notifications.dismissNotificationAsync(id);
@@ -57,14 +57,21 @@ export async function initStationNotification(): Promise<void> {
     await Notifications.deleteNotificationChannelAsync(ALARM_CHANNEL_ID).catch(() => {});
     await Notifications.setNotificationChannelAsync(ALARM_CHANNEL_ID, {
       name: '하차/환승 알림',
-      importance: Notifications.AndroidImportance.HIGH,
+      importance: Notifications.AndroidImportance.MAX,
       sound: 'alarm.wav',
       enableVibrate: true,
       vibrationPattern: [0, 1000, 500, 1000],
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+      bypassDnd: true,
     });
   }
-  const { status } = await Notifications.requestPermissionsAsync();
+  const { status } = await Notifications.requestPermissionsAsync({
+    ios: {
+      allowAlert: true,
+      allowSound: true,
+      allowCriticalAlerts: true,
+    },
+  });
   notifLogger.info('권한 상태:', status);
 }
 
@@ -250,7 +257,11 @@ export async function sendAlarmNotification(
     title,
     body,
     sound: true,
-    ...(Platform.OS === 'android' && { channelId: ALARM_CHANNEL_ID }),
+    ...(Platform.OS === 'android' && {
+      channelId: ALARM_CHANNEL_ID,
+      priority: Notifications.AndroidNotificationPriority.MAX,
+    }),
+    // NOTE: critical Entitlement 승인 후 'critical'로 변경 → Sleep Focus 완전 관통
     ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
   });
   try {

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -1,6 +1,6 @@
 import { findNearestStation } from './findNearestStation';
 import { findRoute, calculateStaticETA } from './stationRoute';
-import { checkAlarm } from './stationAlarm';
+import { checkAlarm, checkTimeBasedAlarm } from './stationAlarm';
 import { sendAlarmNotification, updateStationNotification } from './stationNotification';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
@@ -24,6 +24,37 @@ export function evaluateAlarm(input: AlarmCheckInput): AlarmCheckResult {
   const route = findRoute(input.nearestStationId, input.destinationId);
   const alarmEvent = checkAlarm(route, input.destinationName, input.firedAlarms);
   return { route, alarmEvent };
+}
+
+export interface NextTarget {
+  nextStationName: string;
+  stopsToNextStation: number;
+}
+
+export function resolveNextTarget(route: Route, destinationName: string): NextTarget | null {
+  if (!route) return null;
+
+  if (route.type === 'direct') {
+    return { nextStationName: destinationName, stopsToNextStation: route.stops };
+  }
+
+  if (route.type === 'transfer') {
+    if (route.stopsToTransfer > 0) {
+      return { nextStationName: route.transferName, stopsToNextStation: route.stopsToTransfer };
+    }
+    return { nextStationName: destinationName, stopsToNextStation: route.stopsFromTransfer };
+  }
+
+  if (route.type === 'multi-transfer') {
+    for (const t of route.transfers) {
+      if (t.stopsToTransfer > 0) {
+        return { nextStationName: t.transferName, stopsToNextStation: t.stopsToTransfer };
+      }
+    }
+    return { nextStationName: destinationName, stopsToNextStation: route.stopsAfterLastTransfer };
+  }
+
+  return null;
 }
 
 // ── 비동기 파이프라인: 백그라운드 태스크 전용 (부수효과 포함) ──
@@ -50,8 +81,31 @@ export async function processLocationUpdate(
     firedAlarms,
   });
 
-  if (alarmEvent) {
-    await sendAlarmNotification(alarmEvent.type, alarmEvent.stationName, sleepMode);
+  // 시간 기반 알람: 정거장 수 기반 알람이 없을 때만 체크 (중복 방지)
+  let effectiveAlarmEvent = alarmEvent;
+  if (!alarmEvent) {
+    const target = resolveNextTarget(route, destination.name);
+    if (target && target.stopsToNextStation > 0) {
+      const timeEvent = checkTimeBasedAlarm(
+        target.nextStationName,
+        target.stopsToNextStation,
+        destination.name,
+        route,
+        firedAlarms,
+      );
+      if (timeEvent) {
+        effectiveAlarmEvent = timeEvent;
+      }
+    }
+  }
+
+  if (effectiveAlarmEvent) {
+    await sendAlarmNotification(
+      effectiveAlarmEvent.type,
+      effectiveAlarmEvent.stationName,
+      sleepMode,
+      effectiveAlarmEvent.timeBased ?? false,
+    );
   }
 
   const eta = calculateStaticETA(route);
@@ -62,8 +116,8 @@ export async function processLocationUpdate(
     route,
     eta,
     undefined,
-    sleepMode ? alarmEvent : null,
+    sleepMode ? effectiveAlarmEvent : null,
   );
 
-  return { alarmEvent, nearest };
+  return { alarmEvent: effectiveAlarmEvent, nearest };
 }


### PR DESCRIPTION
## Summary
- Android 알람 채널에 `bypassDnd: true`, `importance: MAX`, 알림 `priority: MAX` 추가하여 DND 모드 관통
- iOS `requestPermissionsAsync`에 `allowCriticalAlerts` 옵션 추가
- 백그라운드 파이프라인(`processLocationUpdate`)에 시간 기반 알람(`checkTimeBasedAlarm`) 통합
- `resolveNextTarget` 헬퍼 추가로 경로 타입별 다음 목표역/정거장 수 추출

## Test plan
- [x] `npm test` — 431개 통과, 커버리지 100%
- [x] `npm run type-check` — 통과
- [x] `reviewer` 에이전트 리뷰 — P1 없음, 머지 가능
- [x] Maestro E2E (`npm run e2e:home`) — 취침모드 플로우 수동 확인 필요

Closes #108