### PR TITLE
feat(#107): Editorial Light (B) 디자인 시스템 적용 - 홈 화면 UI 리디자인

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { InteractionManager, Pressable, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
@@ -9,12 +9,15 @@ import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRoute, buildJourneyDisplay, calculateETA, calculateStaticETA, type Route } from '../../src/utils/stationRoute';
-import { JourneyTimeline } from '../../src/components/JourneyTimeline';
+import { EditorialTimeline } from '../../src/components/EditorialTimeline';
+import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/journeyAdapter';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
+import { colors, typography, spacing, radius } from '../../src/theme';
+import type { LineNumber } from '../../src/types/station';
 
 const logger = createLogger('HomeScreen');
 
@@ -190,6 +193,8 @@ export default function HomeScreen() {
     );
   }
 
+  const nearest = result ? nearestResultToNearest(result) : null;
+
   return (
     <SafeAreaView style={styles.container}>
       {arrivedBanner && (
@@ -197,16 +202,26 @@ export default function HomeScreen() {
           <Text style={styles.arrivedBannerText}>도착!</Text>
         </View>
       )}
-      <ScrollView contentContainerStyle={styles.scroll}>
-        <Text style={styles.header}>지금 여기</Text>
-
-        {result ? (
+      <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
+        {result && nearest ? (
           <>
-            <View style={[styles.stationCard, { borderLeftColor: result.station.lineColor }]}>
-              <View style={styles.stationCardHeader}>
-                <View style={[styles.lineBadge, { backgroundColor: result.station.lineColor }]}>
-                  <Text style={styles.lineBadgeText}>{LINE_NAMES[result.station.line]}</Text>
-                </View>
+            {/* Top meta */}
+            <View style={styles.topMeta}>
+              <Text style={[typography.mono, { color: colors.subtle }]}>
+                {new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+              </Text>
+              <Text style={[typography.label, { color: colors.subtle }]}>LIVE</Text>
+            </View>
+
+            {/* Hero: nearest station */}
+            <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxxl - 4 }}>
+              <Text style={[typography.label, { color: colors.muted, marginBottom: 10 }]}>
+                {result.distanceKm <= 0.5 ? '현재역' : '가장 가까운 역'}
+              </Text>
+              <View style={styles.heroRow}>
+                <Text style={[typography.hero, { color: colors.ink, flex: 1 }]}>
+                  {nearest.name}
+                </Text>
                 <TouchableOpacity
                   onPress={() =>
                     isFav
@@ -219,76 +234,118 @@ export default function HomeScreen() {
                   </Text>
                 </TouchableOpacity>
               </View>
-              <Text style={styles.currentStationLabel}>
-                {result.distanceKm <= 0.5 ? '현재역' : '가장 가까운 역'}
-              </Text>
-              <Text style={styles.stationName}>{result.station.name}</Text>
-              <Text style={styles.distanceText}>
-                현재 위치에서 약 {Math.round(result.distanceKm * 1000)}m
-              </Text>
+              <View style={styles.metaRow}>
+                <LineDot line={result.station.line} />
+                <Dot />
+                <Text style={[typography.bodySm, { color: colors.muted }]}>
+                  {nearest.distanceM} m
+                </Text>
+                <Dot />
+                <Text style={[typography.bodySm, { color: colors.muted }]}>
+                  {nearest.walkMin} min walk
+                </Text>
+              </View>
             </View>
 
-            <View style={styles.destinationCard}>
-              {destination ? (
-                <View>
-                  <View style={styles.destinationInfo}>
-                    <Text style={styles.destinationArrow}>→</Text>
-                    <Text style={styles.destinationName}>{destination.name}</Text>
-                    {displayEta != null && (
-                      <Text style={styles.etaInline}>약 {displayEta}분 소요{!isRealtimeEta ? ' (예상)' : ''}</Text>
-                    )}
-                  </View>
-                  {journey && (
-                    <JourneyTimeline journey={journey} />
-                  )}
-                </View>
-              ) : null}
-              {!destination && recentDestination && (
-                <TouchableOpacity
-                  style={styles.recentDestinationButton}
-                  onPress={() => setDestination(recentDestination)}
-                  testID="recent-destination-button"
-                >
-                  <Text style={styles.recentDestinationLabel}>이전 목적지</Text>
-                  <View style={styles.recentDestinationRow}>
-                    <Text style={styles.recentDestinationName}>{recentDestination.name}</Text>
-                    <View style={[styles.recentLineBadge, { backgroundColor: recentDestination.lineColor }]}>
-                      <Text style={styles.recentLineText}>{LINE_NAMES[recentDestination.line]}</Text>
+            <Hr />
+
+            {/* Route */}
+            {destination && (
+              <>
+                <View style={{ paddingHorizontal: spacing.xxl, paddingVertical: spacing.xxl }}>
+                  <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: spacing.xl }}>
+                    <View>
+                      <Text style={[typography.label, { color: colors.muted, marginBottom: 4 }]}>
+                        Route to
+                      </Text>
+                      <Text style={[typography.title, { color: colors.ink }]}>{destination.name}</Text>
+                    </View>
+                    <View style={{ alignItems: 'flex-end' }}>
+                      {displayEta != null && (
+                        <>
+                          <Text style={[typography.countMM, { color: colors.ink }]}>
+                            {displayEta}
+                            <Text style={{ fontSize: 13, color: colors.muted }}> min</Text>
+                          </Text>
+                          <Text style={[typography.label, { color: colors.subtle, marginTop: 4 }]}>
+                            {isRealtimeEta ? 'EST' : '예상'} · {journey?.totalStops ?? 0} STOPS
+                          </Text>
+                        </>
+                      )}
                     </View>
                   </View>
-                </TouchableOpacity>
-              )}
-              <TouchableOpacity
-                style={styles.destinationButton}
-                onPress={() => setPickerVisible(true)}
-                testID="destination-button"
-              >
-                <Text style={styles.destinationButtonText}>
-                  {destination ? '목적지 변경' : '목적지 설정'}
-                </Text>
-              </TouchableOpacity>
-              {destination ? (
-                <>
-                  <View style={styles.sleepModeRow} testID="sleep-mode-row">
-                    <Text style={styles.sleepModeLabel}>취침 모드</Text>
-                    <Switch
-                      value={sleepMode}
-                      onValueChange={setSleepMode}
-                      trackColor={{ false: '#2a2a4a', true: '#a78bfa' }}
-                      thumbColor={sleepMode ? '#ffffff' : '#666688'}
-                      testID="home-sleep-mode-switch"
-                    />
-                  </View>
-                  <TouchableOpacity
-                    onPress={() => setDestination(null)}
-                    testID="destination-clear-button"
-                  >
-                    <Text style={styles.clearText}>초기화</Text>
-                  </TouchableOpacity>
-                </>
-              ) : null}
-            </View>
+                  {journey && (
+                    <EditorialTimeline stops={journeyDisplayToStops(journey)} />
+                  )}
+                </View>
 
+                {/* Actions */}
+                <View style={styles.actionsRow}>
+                  <Pressable onPress={() => setPickerVisible(true)}>
+                    <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}>
+                      목적지 변경 →
+                    </Text>
+                  </Pressable>
+                  <View style={styles.vHair} />
+                  <Pressable onPress={() => setDestination(null)} testID="destination-clear-button">
+                    <Text style={[typography.bodySm, { color: colors.muted }]}>초기화</Text>
+                  </Pressable>
+                </View>
+
+                <Hr />
+
+                {/* Sleep mode */}
+                <View style={styles.sleepRow} testID="sleep-mode-row">
+                  <View>
+                    <Text style={[typography.bodySm, { color: colors.ink, fontWeight: '600' }]}>
+                      취침 모드
+                    </Text>
+                    <Text style={[typography.mono, { color: colors.muted, marginTop: 2 }]}>
+                      환승·도착 1정거장 전 진동 · 알림
+                    </Text>
+                  </View>
+                  <Switch
+                    value={sleepMode}
+                    onValueChange={setSleepMode}
+                    trackColor={{ false: colors.hair, true: colors.accent }}
+                    thumbColor={colors.bg}
+                    testID="home-sleep-mode-switch"
+                  />
+                </View>
+
+                <Hr />
+              </>
+            )}
+
+            {/* No destination: picker + recent */}
+            {!destination && (
+              <View style={{ paddingHorizontal: spacing.xxl, paddingVertical: spacing.xxl }}>
+                {recentDestination && (
+                  <TouchableOpacity
+                    style={styles.recentDestinationButton}
+                    onPress={() => setDestination(recentDestination)}
+                    testID="recent-destination-button"
+                  >
+                    <Text style={styles.recentDestinationLabel}>이전 목적지</Text>
+                    <View style={styles.recentDestinationRow}>
+                      <Text style={styles.recentDestinationName}>{recentDestination.name}</Text>
+                      <View style={[styles.recentLineBadge, { backgroundColor: recentDestination.lineColor }]}>
+                        <Text style={styles.recentLineText}>{LINE_NAMES[recentDestination.line]}</Text>
+                      </View>
+                    </View>
+                  </TouchableOpacity>
+                )}
+                <TouchableOpacity
+                  style={styles.destinationButton}
+                  onPress={() => setPickerVisible(true)}
+                  testID="destination-button"
+                >
+                  <Text style={styles.destinationButtonText}>목적지 설정</Text>
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {/* Arrivals — 기존 상행/하행 포맷 유지 */}
             <View style={styles.arrivalSection}>
               <Text style={styles.sectionTitle}>열차 도착 정보</Text>
               {arrivalLoading && !arrival && (
@@ -368,10 +425,24 @@ function ArrivalRow({
   );
 }
 
+function LineDot({ line }: { line: LineNumber }) {
+  const c = colors.line[line] ?? colors.accent;
+  const label = LINE_NAMES[line] ?? line;
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+      <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: c }} />
+      <Text style={[typography.mono, { color: c, fontWeight: '600' }]}>{label}</Text>
+    </View>
+  );
+}
+
+const Dot = () => <Text style={{ color: colors.subtle }}>·</Text>;
+const Hr  = () => <View style={{ height: 1, backgroundColor: colors.hair, marginHorizontal: spacing.xxl }} />;
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a2e',
+    backgroundColor: colors.bg,
   },
   arrivedBanner: {
     backgroundColor: '#22c55e',
@@ -383,106 +454,55 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '700',
   },
-  scroll: {
-    padding: 24,
-    flexGrow: 1,
-  },
   center: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 24,
+    padding: spacing.xxl,
+    minHeight: 400,
   },
-  header: {
-    fontSize: 14,
-    color: '#8888aa',
-    marginBottom: 16,
-    letterSpacing: 2,
-    textTransform: 'uppercase',
-  },
-  stationCard: {
-    backgroundColor: '#16213e',
-    borderRadius: 16,
-    padding: 24,
-    borderLeftWidth: 6,
-    marginBottom: 16,
-  },
-  stationCardHeader: {
+  topMeta: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xxl,
+    paddingTop: spacing.lg,
+  },
+  heroRow: {
+    flexDirection: 'row',
     alignItems: 'center',
     marginBottom: 12,
   },
   favoriteIcon: {
     fontSize: 26,
+    marginLeft: spacing.md,
   },
-  lineBadge: {
-    alignSelf: 'flex-start',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 20,
-  },
-  lineBadgeText: {
-    color: '#ffffff',
-    fontSize: 13,
-    fontWeight: '700',
-  },
-  stationName: {
-    fontSize: 32,
-    fontWeight: '800',
-    color: '#ffffff',
-    marginBottom: 8,
-  },
-  currentStationLabel: {
-    fontSize: 12,
-    color: '#8888aa',
-    fontWeight: '600',
-    letterSpacing: 1,
-    marginBottom: 4,
-  },
-  distanceText: {
-    fontSize: 14,
-    color: '#8888aa',
-  },
-  destinationCard: {
-    backgroundColor: '#16213e',
-    borderRadius: 16,
-    padding: 20,
-    marginBottom: 16,
-  },
-  destinationInfo: {
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 14 },
+  actionsRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 12,
+    gap: spacing.xxl,
+    paddingHorizontal: spacing.xxl,
+    paddingTop: spacing.sm,
   },
-  destinationArrow: {
-    fontSize: 24,
-    color: '#a78bfa',
-    marginRight: 12,
-  },
-  destinationName: {
-    fontSize: 26,
-    fontWeight: '800',
-    color: '#ffffff',
-    flexShrink: 1,
-  },
-  etaInline: {
-    fontSize: 14,
-    color: '#a78bfa',
-    fontWeight: '600',
-    marginLeft: 10,
+  vHair: { width: 1, height: 12, backgroundColor: colors.hair },
+  sleepRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xxl,
+    paddingVertical: spacing.xl,
   },
   recentDestinationButton: {
-    backgroundColor: '#0f0f2a',
     borderWidth: 1,
-    borderColor: '#a78bfa',
-    borderRadius: 10,
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    marginBottom: 8,
+    borderColor: colors.accent,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    marginBottom: spacing.sm,
   },
   recentDestinationLabel: {
-    color: '#a78bfa',
+    color: colors.accent,
     fontSize: 11,
     fontWeight: '600',
     letterSpacing: 0.5,
@@ -494,7 +514,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   recentDestinationName: {
-    color: '#ffffff',
+    color: colors.ink,
     fontSize: 16,
     fontWeight: '700',
   },
@@ -509,8 +529,8 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   destinationButton: {
-    backgroundColor: '#a78bfa',
-    borderRadius: 10,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
     paddingVertical: 10,
     alignItems: 'center',
   },
@@ -519,40 +539,18 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '700',
   },
-  sleepModeRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginTop: 12,
-    paddingTop: 12,
-    borderTopWidth: 1,
-    borderTopColor: '#2a2a4a',
-  },
-  sleepModeLabel: {
-    fontSize: 14,
-    color: '#aaaacc',
-    fontWeight: '600',
-  },
-  clearText: {
-    color: '#8888aa',
-    fontSize: 13,
-    textAlign: 'center',
-    marginTop: 8,
-  },
   arrivalSection: {
-    backgroundColor: '#16213e',
-    borderRadius: 16,
-    padding: 20,
-  },
-  mockNotice: {
-    fontSize: 12,
-    color: '#ff9f43',
-    marginBottom: 8,
+    marginHorizontal: spacing.xxl,
+    marginTop: spacing.xl,
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.xl,
+    backgroundColor: '#ffffff',
+    borderRadius: radius.lg,
   },
   sectionTitle: {
     fontSize: 14,
-    color: '#8888aa',
-    marginBottom: 16,
+    color: colors.muted,
+    marginBottom: spacing.lg,
     letterSpacing: 1,
     textTransform: 'uppercase',
   },
@@ -562,11 +560,11 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     paddingVertical: 10,
     borderTopWidth: 1,
-    borderTopColor: '#2a2a4a',
+    borderTopColor: colors.hair,
   },
   arrivalLabel: {
     fontSize: 15,
-    color: '#aaaacc',
+    color: colors.muted,
     fontWeight: '600',
   },
   arrivalItemContainer: {
@@ -574,14 +572,19 @@ const styles = StyleSheet.create({
   },
   arrivalItem: {
     fontSize: 15,
-    color: '#ffffff',
+    color: colors.ink,
     textAlign: 'right',
   },
   statusMessage: {
     fontSize: 12,
-    color: '#a78bfa',
+    color: colors.accent,
     textAlign: 'right',
     marginTop: 2,
+  },
+  mockNotice: {
+    fontSize: 12,
+    color: colors.warn,
+    marginBottom: 8,
   },
   icon: {
     fontSize: 48,
@@ -590,31 +593,31 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 22,
     fontWeight: '700',
-    color: '#ffffff',
+    color: colors.ink,
     marginBottom: 12,
     textAlign: 'center',
   },
   subtitle: {
     fontSize: 15,
-    color: '#8888aa',
+    color: colors.muted,
     textAlign: 'center',
     lineHeight: 22,
     marginBottom: 24,
   },
   loadingText: {
     fontSize: 16,
-    color: '#8888aa',
+    color: colors.muted,
   },
   errorText: {
     fontSize: 16,
-    color: '#ff6b6b',
+    color: colors.accent,
     marginBottom: 16,
   },
   button: {
-    backgroundColor: '#0052A4',
+    backgroundColor: colors.accent,
     paddingHorizontal: 28,
     paddingVertical: 14,
-    borderRadius: 12,
+    borderRadius: radius.lg,
   },
   buttonText: {
     color: '#ffffff',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,7 +17,7 @@ import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
 import { colors, typography, spacing, radius } from '../../src/theme';
-import type { LineNumber } from '../../src/types/station';
+import { LineBadge } from '../../src/components/LineBadge';
 
 const logger = createLogger('HomeScreen');
 
@@ -235,7 +235,7 @@ export default function HomeScreen() {
                 </TouchableOpacity>
               </View>
               <View style={styles.metaRow}>
-                <LineDot line={result.station.line} />
+                <LineBadge line={result.station.line} />
                 <Dot />
                 <Text style={[typography.bodySm, { color: colors.muted }]}>
                   {nearest.distanceM} m
@@ -421,17 +421,6 @@ function ArrivalRow({
           ))
         )}
       </View>
-    </View>
-  );
-}
-
-function LineDot({ line }: { line: LineNumber }) {
-  const c = colors.line[line] ?? colors.accent;
-  const label = LINE_NAMES[line] ?? line;
-  return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
-      <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: c }} />
-      <Text style={[typography.mono, { color: c, fontWeight: '600' }]}>{label}</Text>
     </View>
   );
 }

--- a/src/components/AlarmOverlay.tsx
+++ b/src/components/AlarmOverlay.tsx
@@ -1,6 +1,7 @@
 import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { AlarmEvent } from '../store/useAppStore';
 import { clearAlarmNotification } from '../utils/stationNotification';
+import { colors, typography, spacing, radius } from '../theme';
 
 interface AlarmOverlayProps {
   event: AlarmEvent;
@@ -40,31 +41,31 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a2e',
+    backgroundColor: colors.bg,
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 32,
+    padding: spacing.xxxl,
   },
   title: {
     fontSize: 24,
     fontWeight: '700',
-    color: '#ff6b6b',
-    marginBottom: 24,
+    color: colors.accent,
+    marginBottom: spacing.xxl,
     letterSpacing: 2,
   },
   station: {
     fontSize: 48,
     fontWeight: '900',
-    color: '#ffffff',
+    color: colors.ink,
     textAlign: 'center',
     lineHeight: 64,
     marginBottom: 64,
   },
   button: {
-    backgroundColor: '#ff6b6b',
+    backgroundColor: colors.accent,
     paddingHorizontal: 64,
-    paddingVertical: 24,
-    borderRadius: 32,
+    paddingVertical: spacing.xxl,
+    borderRadius: radius.pill,
   },
   buttonText: {
     color: '#ffffff',

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -12,6 +12,7 @@ import type { Station } from '../types/station';
 import { LINE_NAMES } from '../constants/lineColors';
 import { StationMap } from './StationMap';
 import { createLogger } from '../utils/logger';
+import { colors, spacing, radius } from '../theme';
 
 const logger = createLogger('DestinationPicker');
 
@@ -106,7 +107,7 @@ export function DestinationPicker({
           <TextInput
             style={styles.input}
             placeholder="역 이름 검색"
-            placeholderTextColor="#888"
+            placeholderTextColor={colors.subtle}
             value={query}
             onChangeText={(t) => {
               setQuery(t);
@@ -141,16 +142,16 @@ export function DestinationPicker({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a2e',
+    backgroundColor: colors.bg,
   },
   mapFallback: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 24,
+    padding: spacing.xxl,
   },
   mapFallbackText: {
-    color: '#8888aa',
+    color: colors.muted,
     fontSize: 14,
     textAlign: 'center',
   },
@@ -164,52 +165,56 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingHorizontal: 20,
+    paddingHorizontal: spacing.xl,
     paddingTop: 50,
-    paddingBottom: 12,
-    backgroundColor: 'rgba(26, 26, 46, 0.92)',
+    paddingBottom: spacing.md,
+    backgroundColor: 'rgba(245, 242, 236, 0.92)',
   },
   title: {
-    color: '#fff',
+    color: colors.ink,
     fontSize: 20,
     fontWeight: 'bold',
   },
   closeText: {
-    color: '#a78bfa',
+    color: colors.accent,
     fontSize: 16,
   },
   input: {
-    backgroundColor: '#16213e',
-    color: '#fff',
-    marginHorizontal: 20,
-    borderRadius: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 10,
+    backgroundColor: '#ffffff',
+    color: colors.ink,
+    marginHorizontal: spacing.xl,
+    borderRadius: radius.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
     fontSize: 16,
+    borderWidth: 1,
+    borderColor: colors.hair,
   },
   dropdown: {
-    backgroundColor: '#16213e',
-    marginHorizontal: 20,
+    backgroundColor: '#ffffff',
+    marginHorizontal: spacing.xl,
     marginTop: 4,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.hair,
   },
   suggestionItem: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
     borderBottomWidth: 1,
-    borderBottomColor: '#2a2a4a',
+    borderBottomColor: colors.hair,
   },
   suggestionName: {
-    color: '#fff',
+    color: colors.ink,
     fontSize: 15,
   },
   lineBadge: {
     borderRadius: 4,
-    paddingHorizontal: 8,
+    paddingHorizontal: spacing.sm,
     paddingVertical: 2,
   },
   lineText: {

--- a/src/components/EditorialArrivalRow.tsx
+++ b/src/components/EditorialArrivalRow.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors, typography, spacing } from '../theme';
+import { LINE_NAMES } from '../constants/lineColors';
+import type { LineNumber } from '../types/station';
+import { useCountdown } from '../hooks/useCountdown';
+import type { ArrivalTrain } from '../utils/journeyAdapter';
+
+interface Props {
+  train: ArrivalTrain;
+}
+
+export function EditorialArrivalRow({ train }: Props) {
+  const { mm, ss } = useCountdown(train.arrivalAtMs);
+  const lineC = colors.line[train.line as LineNumber] ?? colors.accent;
+  const lineLabel = LINE_NAMES[train.line as LineNumber] ?? `LINE ${train.line}`;
+
+  return (
+    <View style={styles.arrivalRow} testID="editorial-arrival-row">
+      <View style={{ minWidth: 90 }}>
+        <Text>
+          <Text style={{ ...typography.countMM, color: colors.ink }}>{mm}</Text>
+          <Text style={{ fontSize: 20, color: colors.subtle }}> : </Text>
+          <Text style={{ ...typography.countSS, color: colors.muted }}>{ss}</Text>
+        </Text>
+      </View>
+      <View style={{ flex: 1 }}>
+        <Text style={[typography.bodySm, { color: colors.ink, fontWeight: '600' }]}>
+          {train.direction}
+        </Text>
+        {train.subtext != null && (
+          <Text style={[typography.mono, { color: colors.subtle, marginTop: 2 }]}>
+            {train.subtext}
+          </Text>
+        )}
+      </View>
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+        <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: lineC }} />
+        <Text style={[typography.mono, { color: lineC, fontWeight: '600' }]}>{lineLabel}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  arrivalRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.lg,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.hair,
+  },
+});

--- a/src/components/EditorialArrivalRow.tsx
+++ b/src/components/EditorialArrivalRow.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { colors, typography, spacing } from '../theme';
-import { LINE_NAMES } from '../constants/lineColors';
-import type { LineNumber } from '../types/station';
 import { useCountdown } from '../hooks/useCountdown';
 import type { ArrivalTrain } from '../utils/journeyAdapter';
+import { LineBadge, getLineColor } from './LineBadge';
 
 interface Props {
   train: ArrivalTrain;
@@ -12,16 +11,15 @@ interface Props {
 
 export function EditorialArrivalRow({ train }: Props) {
   const { mm, ss } = useCountdown(train.arrivalAtMs);
-  const lineC = colors.line[train.line as LineNumber] ?? colors.accent;
-  const lineLabel = LINE_NAMES[train.line as LineNumber] ?? `LINE ${train.line}`;
+  const lineC = getLineColor(train.line);
 
   return (
     <View style={styles.arrivalRow} testID="editorial-arrival-row">
       <View style={{ minWidth: 90 }}>
         <Text>
-          <Text style={{ ...typography.countMM, color: colors.ink }}>{mm}</Text>
+          <Text style={[typography.countMM, { color: colors.ink }]}>{mm}</Text>
           <Text style={{ fontSize: 20, color: colors.subtle }}> : </Text>
-          <Text style={{ ...typography.countSS, color: colors.muted }}>{ss}</Text>
+          <Text style={[typography.countSS, { color: colors.muted }]}>{ss}</Text>
         </Text>
       </View>
       <View style={{ flex: 1 }}>
@@ -34,10 +32,7 @@ export function EditorialArrivalRow({ train }: Props) {
           </Text>
         )}
       </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
-        <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: lineC }} />
-        <Text style={[typography.mono, { color: lineC, fontWeight: '600' }]}>{lineLabel}</Text>
-      </View>
+      <LineBadge line={train.line} color={lineC} />
     </View>
   );
 }

--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { colors, typography, spacing } from '../theme';
-import { LINE_NAMES } from '../constants/lineColors';
-import type { LineNumber } from '../types/station';
 import type { Stop } from '../utils/journeyAdapter';
+import { LineBadge, getLineColor } from './LineBadge';
 
 interface Props {
   stops: Stop[];
@@ -54,7 +53,7 @@ export function EditorialTimeline({ stops }: Props) {
             </View>
 
             <View style={{ alignItems: 'flex-end' }}>
-              {s.line != null && <LineTag line={s.line} color={lineC} />}
+              {s.line != null && <LineBadge line={s.line} color={lineC} />}
               {s.stopsFromPrev != null && (
                 <Text style={[typography.mono, { color: colors.subtle, marginTop: 2 }]}>
                   {s.stopsFromPrev}
@@ -66,20 +65,6 @@ export function EditorialTimeline({ stops }: Props) {
       })}
     </View>
   );
-}
-
-function LineTag({ line, color }: { line: string; color: string }) {
-  const label = LINE_NAMES[line as LineNumber] ?? `LINE ${line}`;
-  return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
-      <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: color }} />
-      <Text style={[typography.mono, { color, fontWeight: '600' }]}>{label}</Text>
-    </View>
-  );
-}
-
-function getLineColor(line: string): string {
-  return colors.line[line as LineNumber] ?? colors.accent;
 }
 
 export function mix(a: string, b: string, w: number): string {

--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors, typography, spacing } from '../theme';
+import { LINE_NAMES } from '../constants/lineColors';
+import type { LineNumber } from '../types/station';
+import type { Stop } from '../utils/journeyAdapter';
+
+interface Props {
+  stops: Stop[];
+}
+
+export function EditorialTimeline({ stops }: Props) {
+  return (
+    <View>
+      {stops.map((s, i) => {
+        const isLast = i === stops.length - 1;
+        const lineC = s.line != null ? getLineColor(s.line) : colors.accent;
+        const nextLineC = !isLast
+          ? (stops[i + 1].line != null ? getLineColor(stops[i + 1].line!) : colors.accent)
+          : lineC;
+
+        return (
+          <View key={i} style={[styles.row, isLast && { minHeight: 36 }]} testID={`timeline-stop-${i}`}>
+            {!isLast && (
+              <View
+                style={[
+                  styles.connector,
+                  { backgroundColor: mix(lineC, nextLineC, 0.5), opacity: 0.35 },
+                ]}
+              />
+            )}
+
+            <View style={styles.markerCol}>
+              {s.mark === 'filled' && (
+                <View style={[styles.dot, { backgroundColor: lineC }]} testID="filled-dot" />
+              )}
+              {s.mark === 'transfer' && (
+                <View style={[styles.dotRing, { borderColor: lineC }]} testID="transfer-dot" />
+              )}
+              {s.mark === 'dest' && (
+                <View style={[styles.dotDest, { backgroundColor: lineC }]} testID="dest-dot" />
+              )}
+            </View>
+
+            <View style={{ flex: 1 }}>
+              <Text style={[typography.body, { fontWeight: '600', color: colors.ink }]}>
+                {s.station}
+              </Text>
+              {s.note != null && (
+                <Text style={[typography.label, { color: colors.subtle, marginTop: 2 }]}>
+                  {s.note}
+                </Text>
+              )}
+            </View>
+
+            <View style={{ alignItems: 'flex-end' }}>
+              {s.line != null && <LineTag line={s.line} color={lineC} />}
+              {s.stopsFromPrev != null && (
+                <Text style={[typography.mono, { color: colors.subtle, marginTop: 2 }]}>
+                  {s.stopsFromPrev}
+                </Text>
+              )}
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function LineTag({ line, color }: { line: string; color: string }) {
+  const label = LINE_NAMES[line as LineNumber] ?? `LINE ${line}`;
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+      <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: color }} />
+      <Text style={[typography.mono, { color, fontWeight: '600' }]}>{label}</Text>
+    </View>
+  );
+}
+
+function getLineColor(line: string): string {
+  return colors.line[line as LineNumber] ?? colors.accent;
+}
+
+export function mix(a: string, b: string, w: number): string {
+  const pa = hex(a), pb = hex(b);
+  const r = Math.round(pa[0] * (1 - w) + pb[0] * w);
+  const g = Math.round(pa[1] * (1 - w) + pb[1] * w);
+  const bl = Math.round(pa[2] * (1 - w) + pb[2] * w);
+  return `rgb(${r},${g},${bl})`;
+}
+
+/** #RRGGBB 형식 전용. 비 hex 입력 시 [0,0,0] fallback */
+export function hex(h: string): [number, number, number] {
+  if (!h.startsWith('#') || h.length < 7) return [0, 0, 0];
+  const x = h.replace('#', '');
+  return [parseInt(x.slice(0, 2), 16), parseInt(x.slice(2, 4), 16), parseInt(x.slice(4, 6), 16)];
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 56,
+    position: 'relative',
+    gap: spacing.md,
+  },
+  markerCol: { width: 28, alignItems: 'flex-start', paddingLeft: 7 },
+  connector: {
+    position: 'absolute',
+    left: 13,
+    top: 18,
+    bottom: -6,
+    width: 1,
+  },
+  dot:     { width: 10, height: 10, borderRadius: 5 },
+  dotRing: { width: 12, height: 12, borderRadius: 6, borderWidth: 2, backgroundColor: colors.bg },
+  dotDest: { width: 12, height: 12, borderRadius: 6 },
+});

--- a/src/components/JourneyTimeline.tsx
+++ b/src/components/JourneyTimeline.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { LINE_NAMES } from '../constants/lineColors';
 import type { JourneyDisplay } from '../utils/stationRoute';
 import type { LineNumber } from '../types/station';
+import { colors, typography, spacing, radius } from '../theme';
 
 interface JourneyTimelineProps {
   journey: JourneyDisplay;
@@ -59,7 +60,7 @@ export function JourneyTimeline({ journey }: JourneyTimelineProps) {
 
 const styles = StyleSheet.create({
   container: {
-    marginTop: 12,
+    marginTop: spacing.md,
   },
   stationRow: {
     flexDirection: 'row',
@@ -75,11 +76,11 @@ const styles = StyleSheet.create({
   stationName: {
     fontSize: 16,
     fontWeight: '700',
-    color: '#ffffff',
+    color: colors.ink,
   },
   transferIcon: {
     fontSize: 16,
-    color: '#a78bfa',
+    color: colors.accent,
     width: 12,
     textAlign: 'center',
     marginRight: 10,
@@ -87,7 +88,7 @@ const styles = StyleSheet.create({
   transferName: {
     fontSize: 15,
     fontWeight: '600',
-    color: '#a78bfa',
+    color: colors.accent,
   },
   segmentRow: {
     flexDirection: 'row',
@@ -104,12 +105,12 @@ const styles = StyleSheet.create({
   segmentInfo: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: spacing.sm,
   },
   lineBadge: {
-    paddingHorizontal: 8,
+    paddingHorizontal: spacing.sm,
     paddingVertical: 3,
-    borderRadius: 12,
+    borderRadius: radius.lg,
   },
   lineBadgeText: {
     color: '#ffffff',
@@ -118,6 +119,6 @@ const styles = StyleSheet.create({
   },
   stopsText: {
     fontSize: 13,
-    color: '#8888aa',
+    color: colors.muted,
   },
 });

--- a/src/components/LineBadge.tsx
+++ b/src/components/LineBadge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { colors, typography } from '../theme';
+import { LINE_NAMES } from '../constants/lineColors';
+import type { LineNumber } from '../types/station';
+
+interface LineBadgeProps {
+  line: string;
+  color?: string;
+}
+
+export function getLineColor(line: string): string {
+  return colors.line[line as LineNumber] ?? colors.accent;
+}
+
+export function getLineLabel(line: string): string {
+  return LINE_NAMES[line as LineNumber] ?? `LINE ${line}`;
+}
+
+export function LineBadge({ line, color }: LineBadgeProps) {
+  const c = color ?? getLineColor(line);
+  const label = getLineLabel(line);
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+      <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: c }} />
+      <Text style={[typography.mono, { color: c, fontWeight: '600' }]}>{label}</Text>
+    </View>
+  );
+}

--- a/src/components/__tests__/EditorialArrivalRow.test.tsx
+++ b/src/components/__tests__/EditorialArrivalRow.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import { EditorialArrivalRow } from '../EditorialArrivalRow';
-import type { ArrivalTrain } from '../../utils/journeyAdapter';
+import { makeArrivalTrain } from '../../testUtils/fixtures';
 
 describe('EditorialArrivalRow', () => {
   beforeEach(() => {
@@ -14,93 +14,46 @@ describe('EditorialArrivalRow', () => {
     jest.restoreAllMocks();
   });
 
-  it('should render countdown mm:ss', () => {
-    const train: ArrivalTrain = {
-      direction: '봉화산 방면',
-      line: '6',
-      arrivalAtMs: 1_000_000 + 134 * 1000, // 02:14
-    };
+  const baseTrain = { direction: '봉화산 방면', line: '6', arrivalAtMs: 1_000_000 + 134 * 1000 };
 
-    render(<EditorialArrivalRow train={train} />);
+  it('should render countdown mm:ss', () => {
+    render(<EditorialArrivalRow train={makeArrivalTrain(baseTrain)} />);
     expect(screen.getByText('02')).toBeTruthy();
     expect(screen.getByText('14')).toBeTruthy();
   });
 
   it('should render direction text', () => {
-    const train: ArrivalTrain = {
-      direction: '봉화산 방면',
-      line: '6',
-      arrivalAtMs: 1_000_000 + 60 * 1000,
-    };
-
-    render(<EditorialArrivalRow train={train} />);
+    render(<EditorialArrivalRow train={makeArrivalTrain({ ...baseTrain, arrivalAtMs: 1_000_000 + 60000 })} />);
     expect(screen.getByText('봉화산 방면')).toBeTruthy();
   });
 
   it('should render subtext when provided', () => {
-    const train: ArrivalTrain = {
-      direction: '응암 방면',
-      line: '6',
-      arrivalAtMs: 1_000_000 + 271 * 1000,
-      subtext: '전역 출발',
-    };
-
-    render(<EditorialArrivalRow train={train} />);
+    render(<EditorialArrivalRow train={makeArrivalTrain({ direction: '응암 방면', line: '6', arrivalAtMs: 1_000_000 + 271000, subtext: '전역 출발' })} />);
     expect(screen.getByText('전역 출발')).toBeTruthy();
   });
 
   it('should not render subtext when not provided', () => {
-    const train: ArrivalTrain = {
-      direction: '봉화산 방면',
-      line: '6',
-      arrivalAtMs: 1_000_000 + 60 * 1000,
-    };
-
-    render(<EditorialArrivalRow train={train} />);
+    render(<EditorialArrivalRow train={makeArrivalTrain({ ...baseTrain, arrivalAtMs: 1_000_000 + 60000 })} />);
     expect(screen.queryByText('전역 출발')).toBeNull();
   });
 
   it('should render line label for numeric lines', () => {
-    const train: ArrivalTrain = {
-      direction: '봉화산 방면',
-      line: '6',
-      arrivalAtMs: 1_000_000 + 60 * 1000,
-    };
-
-    render(<EditorialArrivalRow train={train} />);
+    render(<EditorialArrivalRow train={makeArrivalTrain({ ...baseTrain, arrivalAtMs: 1_000_000 + 60000 })} />);
     expect(screen.getByText('6호선')).toBeTruthy();
   });
 
   it('should render line label for special lines', () => {
-    const train: ArrivalTrain = {
-      direction: '인천공항 방면',
-      line: 'airport',
-      arrivalAtMs: 1_000_000 + 600 * 1000,
-    };
-
-    render(<EditorialArrivalRow train={train} />);
+    render(<EditorialArrivalRow train={makeArrivalTrain({ direction: '인천공항 방면', line: 'airport', arrivalAtMs: 1_000_000 + 600000 })} />);
     expect(screen.getByText('공항철도')).toBeTruthy();
   });
 
   it('should fallback to LINE label for unknown lines', () => {
-    const train: ArrivalTrain = {
-      direction: '방면',
-      line: 'unknown',
-      arrivalAtMs: 1_000_000 + 60 * 1000,
-    };
-
-    render(<EditorialArrivalRow train={train} />);
+    render(<EditorialArrivalRow train={makeArrivalTrain({ direction: '방면', line: 'unknown', arrivalAtMs: 1_000_000 + 60000 })} />);
     expect(screen.getByText('LINE unknown')).toBeTruthy();
   });
 
   it('should have testID', () => {
-    const train: ArrivalTrain = {
-      direction: '봉화산 방면',
-      line: '6',
-      arrivalAtMs: 1_000_000 + 60 * 1000,
-    };
-
-    render(<EditorialArrivalRow train={train} />);
+    render(<EditorialArrivalRow train={makeArrivalTrain({ ...baseTrain, arrivalAtMs: 1_000_000 + 60000 })} />);
     expect(screen.getByTestId('editorial-arrival-row')).toBeTruthy();
   });
 });

--- a/src/components/__tests__/EditorialArrivalRow.test.tsx
+++ b/src/components/__tests__/EditorialArrivalRow.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { EditorialArrivalRow } from '../EditorialArrivalRow';
+import type { ArrivalTrain } from '../../utils/journeyAdapter';
+
+describe('EditorialArrivalRow', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('should render countdown mm:ss', () => {
+    const train: ArrivalTrain = {
+      direction: '봉화산 방면',
+      line: '6',
+      arrivalAtMs: 1_000_000 + 134 * 1000, // 02:14
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.getByText('02')).toBeTruthy();
+    expect(screen.getByText('14')).toBeTruthy();
+  });
+
+  it('should render direction text', () => {
+    const train: ArrivalTrain = {
+      direction: '봉화산 방면',
+      line: '6',
+      arrivalAtMs: 1_000_000 + 60 * 1000,
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.getByText('봉화산 방면')).toBeTruthy();
+  });
+
+  it('should render subtext when provided', () => {
+    const train: ArrivalTrain = {
+      direction: '응암 방면',
+      line: '6',
+      arrivalAtMs: 1_000_000 + 271 * 1000,
+      subtext: '전역 출발',
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.getByText('전역 출발')).toBeTruthy();
+  });
+
+  it('should not render subtext when not provided', () => {
+    const train: ArrivalTrain = {
+      direction: '봉화산 방면',
+      line: '6',
+      arrivalAtMs: 1_000_000 + 60 * 1000,
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.queryByText('전역 출발')).toBeNull();
+  });
+
+  it('should render line label for numeric lines', () => {
+    const train: ArrivalTrain = {
+      direction: '봉화산 방면',
+      line: '6',
+      arrivalAtMs: 1_000_000 + 60 * 1000,
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.getByText('6호선')).toBeTruthy();
+  });
+
+  it('should render line label for special lines', () => {
+    const train: ArrivalTrain = {
+      direction: '인천공항 방면',
+      line: 'airport',
+      arrivalAtMs: 1_000_000 + 600 * 1000,
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.getByText('공항철도')).toBeTruthy();
+  });
+
+  it('should fallback to LINE label for unknown lines', () => {
+    const train: ArrivalTrain = {
+      direction: '방면',
+      line: 'unknown',
+      arrivalAtMs: 1_000_000 + 60 * 1000,
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.getByText('LINE unknown')).toBeTruthy();
+  });
+
+  it('should have testID', () => {
+    const train: ArrivalTrain = {
+      direction: '봉화산 방면',
+      line: '6',
+      arrivalAtMs: 1_000_000 + 60 * 1000,
+    };
+
+    render(<EditorialArrivalRow train={train} />);
+    expect(screen.getByTestId('editorial-arrival-row')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -1,30 +1,19 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import { EditorialTimeline, mix, hex } from '../EditorialTimeline';
+import { MOCK_STOPS } from '../../testUtils/fixtures';
 import type { Stop } from '../../utils/journeyAdapter';
 
 describe('EditorialTimeline', () => {
   it('should render all stops', () => {
-    const stops: Stop[] = [
-      { station: '효창공원앞', line: '6', mark: 'filled' },
-      { station: '공덕', line: '5', stopsFromPrev: '2정거장', mark: 'transfer', note: '환승' },
-      { station: '여의나루', line: '5', stopsFromPrev: '3정거장', mark: 'dest', note: '도착' },
-    ];
-
-    render(<EditorialTimeline stops={stops} />);
-
+    render(<EditorialTimeline stops={MOCK_STOPS.threeStops} />);
     expect(screen.getByText('효창공원앞')).toBeTruthy();
     expect(screen.getByText('공덕')).toBeTruthy();
     expect(screen.getByText('여의나루')).toBeTruthy();
   });
 
   it('should render filled dot for first stop', () => {
-    const stops: Stop[] = [
-      { station: '강남', line: '2', mark: 'filled' },
-      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
-    ];
-
-    render(<EditorialTimeline stops={stops} />);
+    render(<EditorialTimeline stops={MOCK_STOPS.twoStops} />);
     expect(screen.getByTestId('filled-dot')).toBeTruthy();
   });
 
@@ -34,48 +23,27 @@ describe('EditorialTimeline', () => {
       { station: '시청', line: '2', stopsFromPrev: '1정거장', mark: 'transfer', note: '환승' },
       { station: '을지로입구', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
     ];
-
     render(<EditorialTimeline stops={stops} />);
     expect(screen.getByTestId('transfer-dot')).toBeTruthy();
   });
 
   it('should render dest dot for destination stop', () => {
-    const stops: Stop[] = [
-      { station: '강남', line: '2', mark: 'filled' },
-      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
-    ];
-
-    render(<EditorialTimeline stops={stops} />);
+    render(<EditorialTimeline stops={MOCK_STOPS.twoStops} />);
     expect(screen.getByTestId('dest-dot')).toBeTruthy();
   });
 
   it('should render note text', () => {
-    const stops: Stop[] = [
-      { station: '강남', line: '2', mark: 'filled' },
-      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
-    ];
-
-    render(<EditorialTimeline stops={stops} />);
+    render(<EditorialTimeline stops={MOCK_STOPS.twoStops} />);
     expect(screen.getByText('도착')).toBeTruthy();
   });
 
   it('should render stopsFromPrev text', () => {
-    const stops: Stop[] = [
-      { station: '강남', line: '2', mark: 'filled' },
-      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
-    ];
-
-    render(<EditorialTimeline stops={stops} />);
+    render(<EditorialTimeline stops={MOCK_STOPS.twoStops} />);
     expect(screen.getByText('1정거장')).toBeTruthy();
   });
 
   it('should render line name for known lines', () => {
-    const stops: Stop[] = [
-      { station: '강남', line: '2', mark: 'filled' },
-      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
-    ];
-
-    render(<EditorialTimeline stops={stops} />);
+    render(<EditorialTimeline stops={MOCK_STOPS.twoStops} />);
     expect(screen.getAllByText('2호선').length).toBeGreaterThan(0);
   });
 
@@ -84,7 +52,6 @@ describe('EditorialTimeline', () => {
       { station: '출발역', line: null, mark: 'filled' },
       { station: '종착역', line: null, stopsFromPrev: '5정거장', mark: 'dest', note: '도착' },
     ];
-
     render(<EditorialTimeline stops={stops} />);
     expect(screen.getByText('출발역')).toBeTruthy();
     expect(screen.getByText('종착역')).toBeTruthy();
@@ -95,7 +62,6 @@ describe('EditorialTimeline', () => {
       { station: '서울역', line: 'airport', mark: 'filled' },
       { station: '인천공항', line: 'airport', stopsFromPrev: '5정거장', mark: 'dest', note: '도착' },
     ];
-
     render(<EditorialTimeline stops={stops} />);
     expect(screen.getAllByText('공항철도').length).toBeGreaterThan(0);
   });
@@ -105,7 +71,6 @@ describe('EditorialTimeline', () => {
       { station: '출발역', line: 'unknown', mark: 'filled' },
       { station: '종착역', line: 'unknown', stopsFromPrev: '3정거장', mark: 'dest', note: '도착' },
     ];
-
     render(<EditorialTimeline stops={stops} />);
     expect(screen.getAllByText('LINE unknown').length).toBeGreaterThan(0);
   });
@@ -118,18 +83,15 @@ describe('EditorialTimeline', () => {
 
 describe('mix', () => {
   it('should blend two colors at 50%', () => {
-    const result = mix('#FF0000', '#0000FF', 0.5);
-    expect(result).toBe('rgb(128,0,128)');
+    expect(mix('#FF0000', '#0000FF', 0.5)).toBe('rgb(128,0,128)');
   });
 
   it('should return first color at weight 0', () => {
-    const result = mix('#FF0000', '#0000FF', 0);
-    expect(result).toBe('rgb(255,0,0)');
+    expect(mix('#FF0000', '#0000FF', 0)).toBe('rgb(255,0,0)');
   });
 
   it('should return second color at weight 1', () => {
-    const result = mix('#FF0000', '#0000FF', 1);
-    expect(result).toBe('rgb(0,0,255)');
+    expect(mix('#FF0000', '#0000FF', 1)).toBe('rgb(0,0,255)');
   });
 });
 

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { EditorialTimeline, mix, hex } from '../EditorialTimeline';
+import type { Stop } from '../../utils/journeyAdapter';
+
+describe('EditorialTimeline', () => {
+  it('should render all stops', () => {
+    const stops: Stop[] = [
+      { station: '효창공원앞', line: '6', mark: 'filled' },
+      { station: '공덕', line: '5', stopsFromPrev: '2정거장', mark: 'transfer', note: '환승' },
+      { station: '여의나루', line: '5', stopsFromPrev: '3정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+
+    expect(screen.getByText('효창공원앞')).toBeTruthy();
+    expect(screen.getByText('공덕')).toBeTruthy();
+    expect(screen.getByText('여의나루')).toBeTruthy();
+  });
+
+  it('should render filled dot for first stop', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByTestId('filled-dot')).toBeTruthy();
+  });
+
+  it('should render transfer dot for transfer stop', () => {
+    const stops: Stop[] = [
+      { station: '서울역', line: '1', mark: 'filled' },
+      { station: '시청', line: '2', stopsFromPrev: '1정거장', mark: 'transfer', note: '환승' },
+      { station: '을지로입구', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByTestId('transfer-dot')).toBeTruthy();
+  });
+
+  it('should render dest dot for destination stop', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByTestId('dest-dot')).toBeTruthy();
+  });
+
+  it('should render note text', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByText('도착')).toBeTruthy();
+  });
+
+  it('should render stopsFromPrev text', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByText('1정거장')).toBeTruthy();
+  });
+
+  it('should render line name for known lines', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getAllByText('2호선').length).toBeGreaterThan(0);
+  });
+
+  it('should handle null line gracefully', () => {
+    const stops: Stop[] = [
+      { station: '출발역', line: null, mark: 'filled' },
+      { station: '종착역', line: null, stopsFromPrev: '5정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByText('출발역')).toBeTruthy();
+    expect(screen.getByText('종착역')).toBeTruthy();
+  });
+
+  it('should handle special line names (airport)', () => {
+    const stops: Stop[] = [
+      { station: '서울역', line: 'airport', mark: 'filled' },
+      { station: '인천공항', line: 'airport', stopsFromPrev: '5정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getAllByText('공항철도').length).toBeGreaterThan(0);
+  });
+
+  it('should fallback to LINE label and accent color for unknown line', () => {
+    const stops: Stop[] = [
+      { station: '출발역', line: 'unknown', mark: 'filled' },
+      { station: '종착역', line: 'unknown', stopsFromPrev: '3정거장', mark: 'dest', note: '도착' },
+    ];
+
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getAllByText('LINE unknown').length).toBeGreaterThan(0);
+  });
+
+  it('should render empty for no stops', () => {
+    const { toJSON } = render(<EditorialTimeline stops={[]} />);
+    expect(toJSON()).toBeTruthy();
+  });
+});
+
+describe('mix', () => {
+  it('should blend two colors at 50%', () => {
+    const result = mix('#FF0000', '#0000FF', 0.5);
+    expect(result).toBe('rgb(128,0,128)');
+  });
+
+  it('should return first color at weight 0', () => {
+    const result = mix('#FF0000', '#0000FF', 0);
+    expect(result).toBe('rgb(255,0,0)');
+  });
+
+  it('should return second color at weight 1', () => {
+    const result = mix('#FF0000', '#0000FF', 1);
+    expect(result).toBe('rgb(0,0,255)');
+  });
+});
+
+describe('hex', () => {
+  it('should parse hex color to RGB tuple', () => {
+    expect(hex('#FF0000')).toEqual([255, 0, 0]);
+    expect(hex('#00FF00')).toEqual([0, 255, 0]);
+    expect(hex('#0000FF')).toEqual([0, 0, 255]);
+  });
+
+  it('should fallback to [0,0,0] for non-hex formats', () => {
+    expect(hex('rgba(26,24,20,0.08)')).toEqual([0, 0, 0]);
+    expect(hex('rgb(255,0,0)')).toEqual([0, 0, 0]);
+    expect(hex('FF8800')).toEqual([0, 0, 0]);
+    expect(hex('#FFF')).toEqual([0, 0, 0]);
+  });
+});

--- a/src/components/__tests__/LineBadge.test.tsx
+++ b/src/components/__tests__/LineBadge.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { LineBadge, getLineColor, getLineLabel } from '../LineBadge';
+import { colors } from '../../theme';
+
+describe('LineBadge', () => {
+  it('should render line label for known numeric lines', () => {
+    render(<LineBadge line="2" />);
+    expect(screen.getByText('2호선')).toBeTruthy();
+  });
+
+  it('should render line label for special lines', () => {
+    render(<LineBadge line="airport" />);
+    expect(screen.getByText('공항철도')).toBeTruthy();
+  });
+
+  it('should fallback to LINE label for unknown lines', () => {
+    render(<LineBadge line="unknown" />);
+    expect(screen.getByText('LINE unknown')).toBeTruthy();
+  });
+
+  it('should use provided color override', () => {
+    render(<LineBadge line="1" color="#FF0000" />);
+    expect(screen.getByText('1호선')).toBeTruthy();
+  });
+});
+
+describe('getLineColor', () => {
+  it('should return correct color for known lines', () => {
+    expect(getLineColor('1')).toBe('#0052A4');
+    expect(getLineColor('6')).toBe('#CD7C2F');
+  });
+
+  it('should return accent color for unknown lines', () => {
+    expect(getLineColor('unknown')).toBe(colors.accent);
+  });
+});
+
+describe('getLineLabel', () => {
+  it('should return Korean name for known lines', () => {
+    expect(getLineLabel('1')).toBe('1호선');
+    expect(getLineLabel('airport')).toBe('공항철도');
+  });
+
+  it('should return LINE fallback for unknown lines', () => {
+    expect(getLineLabel('unknown')).toBe('LINE unknown');
+  });
+});

--- a/src/hooks/__tests__/useCountdown.test.ts
+++ b/src/hooks/__tests__/useCountdown.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useCountdown } from '../useCountdown';
+
+describe('useCountdown', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('should return formatted mm:ss for a future timestamp', () => {
+    const arrivalAtMs = 1_000_000 + 134 * 1000; // 134 seconds = 02:14
+    const { result } = renderHook(() => useCountdown(arrivalAtMs));
+
+    expect(result.current.mm).toBe('02');
+    expect(result.current.ss).toBe('14');
+    expect(result.current.totalSec).toBe(134);
+    expect(result.current.done).toBe(false);
+  });
+
+  it('should count down every second', () => {
+    const arrivalAtMs = 1_000_000 + 10 * 1000; // 10 seconds
+    const { result } = renderHook(() => useCountdown(arrivalAtMs));
+
+    expect(result.current.totalSec).toBe(10);
+
+    // Advance 1 second
+    (Date.now as jest.Mock).mockReturnValue(1_001_000);
+    act(() => { jest.advanceTimersByTime(1000); });
+
+    expect(result.current.totalSec).toBe(9);
+    expect(result.current.ss).toBe('09');
+  });
+
+  it('should stop at 0 and set done to true', () => {
+    const arrivalAtMs = 1_000_000 + 2 * 1000; // 2 seconds
+    const { result } = renderHook(() => useCountdown(arrivalAtMs));
+
+    expect(result.current.done).toBe(false);
+
+    // Advance past the arrival time
+    (Date.now as jest.Mock).mockReturnValue(1_000_000 + 3000);
+    act(() => { jest.advanceTimersByTime(1000); });
+
+    expect(result.current.totalSec).toBe(0);
+    expect(result.current.mm).toBe('00');
+    expect(result.current.ss).toBe('00');
+    expect(result.current.done).toBe(true);
+  });
+
+  it('should handle already past timestamps', () => {
+    const arrivalAtMs = 1_000_000 - 5000; // 5 seconds ago
+    const { result } = renderHook(() => useCountdown(arrivalAtMs));
+
+    expect(result.current.totalSec).toBe(0);
+    expect(result.current.done).toBe(true);
+    expect(result.current.mm).toBe('00');
+    expect(result.current.ss).toBe('00');
+  });
+
+  it('should pad single digits with leading zeros', () => {
+    const arrivalAtMs = 1_000_000 + 65 * 1000; // 1:05
+    const { result } = renderHook(() => useCountdown(arrivalAtMs));
+
+    expect(result.current.mm).toBe('01');
+    expect(result.current.ss).toBe('05');
+  });
+
+  it('should reset timer when arrivalAtMs changes', () => {
+    const arrivalAtMs1 = 1_000_000 + 60 * 1000;
+    const { result, rerender } = renderHook(
+      ({ ms }: { ms: number }) => useCountdown(ms),
+      { initialProps: { ms: arrivalAtMs1 } },
+    );
+
+    expect(result.current.totalSec).toBe(60);
+
+    // Change to a different arrival time
+    const arrivalAtMs2 = 1_000_000 + 120 * 1000;
+    rerender({ ms: arrivalAtMs2 });
+
+    expect(result.current.totalSec).toBe(120);
+    expect(result.current.mm).toBe('02');
+    expect(result.current.ss).toBe('00');
+  });
+
+  it('should clean up interval on unmount', () => {
+    const arrivalAtMs = 1_000_000 + 60 * 1000;
+    const { unmount } = renderHook(() => useCountdown(arrivalAtMs));
+
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('should handle large durations', () => {
+    const arrivalAtMs = 1_000_000 + 3661 * 1000; // 61 minutes 1 second
+    const { result } = renderHook(() => useCountdown(arrivalAtMs));
+
+    expect(result.current.mm).toBe('61');
+    expect(result.current.ss).toBe('01');
+    expect(result.current.totalSec).toBe(3661);
+  });
+});

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+export type Countdown = { mm: string; ss: string; totalSec: number; done: boolean };
+
+function calc(arrivalAtMs: number): Countdown {
+  const diff = Math.max(0, Math.floor((arrivalAtMs - Date.now()) / 1000));
+  const mm = String(Math.floor(diff / 60)).padStart(2, '0');
+  const ss = String(diff % 60).padStart(2, '0');
+  return { mm, ss, totalSec: diff, done: diff <= 0 };
+}
+
+export function useCountdown(arrivalAtMs: number): Countdown {
+  const [state, setState] = useState<Countdown>(() => calc(arrivalAtMs));
+
+  useEffect(() => {
+    setState(calc(arrivalAtMs));
+    const id = setInterval(() => setState(calc(arrivalAtMs)), 1000);
+    return () => clearInterval(id);
+  }, [arrivalAtMs]);
+
+  return state;
+}

--- a/src/testUtils/fixtures.ts
+++ b/src/testUtils/fixtures.ts
@@ -1,0 +1,57 @@
+import type { NearestStationResult } from '../types/station';
+import type { ArrivalInfo } from '../api/arrivalApi';
+import type { JourneyDisplay } from '../utils/stationRoute';
+import type { Stop, ArrivalTrain } from '../utils/journeyAdapter';
+
+export const MOCK_STATIONS = {
+  hyochang: { id: '0601', name: '효창공원앞', line: '6' as const, lineColor: '#CD7C2F', lat: 37.5, lng: 126.9 },
+  gangnam: { id: '0201', name: '강남', line: '2' as const, lineColor: '#009D3E', lat: 37.5, lng: 127.0 },
+  chungmuro: { id: '0301', name: '충무로', line: '3' as const, lineColor: '#EF7C1C', lat: 37.5, lng: 127.0 },
+  yeouinaru: { id: '0501', name: '여의나루', line: '5' as const, lineColor: '#996CAC', lat: 37.5, lng: 126.9 },
+  seoulStation: { id: 'AP01', name: '서울역', line: 'airport' as const, lineColor: '#4B81BF', lat: 37.5, lng: 126.9 },
+};
+
+export function makeNearestResult(stationKey: keyof typeof MOCK_STATIONS, distanceKm: number): NearestStationResult {
+  return { station: MOCK_STATIONS[stationKey], distanceKm };
+}
+
+export function makeArrivalInfo(overrides: Partial<ArrivalInfo> & { destination: string; arrivalSeconds: number }): ArrivalInfo {
+  return {
+    arrivalMinutes: Math.floor(overrides.arrivalSeconds / 60),
+    statusMessage: '',
+    trainCode: 'T001',
+    ...overrides,
+  };
+}
+
+export const MOCK_JOURNEYS = {
+  direct: {
+    segments: [
+      { line: '2', lineColor: '#009D3E', fromName: '강남', toName: '역삼', stops: 1 },
+    ],
+    totalStops: 1,
+  } satisfies JourneyDisplay,
+  transfer: {
+    segments: [
+      { line: '6', lineColor: '#CD7C2F', fromName: '효창공원앞', toName: '공덕', stops: 2 },
+      { line: '5', lineColor: '#996CAC', fromName: '공덕', toName: '여의나루', stops: 3 },
+    ],
+    totalStops: 5,
+  } satisfies JourneyDisplay,
+};
+
+export const MOCK_STOPS = {
+  twoStops: [
+    { station: '강남', line: '2', mark: 'filled' },
+    { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+  ] satisfies Stop[],
+  threeStops: [
+    { station: '효창공원앞', line: '6', mark: 'filled' },
+    { station: '공덕', line: '5', stopsFromPrev: '2정거장', mark: 'transfer', note: '환승' },
+    { station: '여의나루', line: '5', stopsFromPrev: '3정거장', mark: 'dest', note: '도착' },
+  ] satisfies Stop[],
+};
+
+export function makeArrivalTrain(overrides: Partial<ArrivalTrain> & { direction: string; line: string; arrivalAtMs: number }): ArrivalTrain {
+  return { subtext: undefined, ...overrides };
+}

--- a/src/theme/__tests__/theme.test.ts
+++ b/src/theme/__tests__/theme.test.ts
@@ -1,0 +1,105 @@
+import { colors, font, typography, spacing, radius } from '../theme';
+import type { LineNumber } from '../../types/station';
+
+const ALL_LINES: LineNumber[] = [
+  '1', '2', '3', '4', '5', '6', '7', '8', '9',
+  'airport', 'gyeongui', 'bundang', 'sinbundang',
+];
+
+describe('theme', () => {
+  describe('colors', () => {
+    it('should have all base color tokens', () => {
+      expect(colors.bg).toBe('#F5F2EC');
+      expect(colors.ink).toBe('#1A1814');
+      expect(colors.muted).toBe('#6B6459');
+      expect(colors.subtle).toBe('#A8A197');
+      expect(colors.hair).toBe('rgba(26,24,20,0.08)');
+      expect(colors.accent).toBe('#C8553D');
+      expect(colors.warn).toBe('#ff9f43');
+    });
+
+    it('should have line colors for all LineNumber values', () => {
+      for (const line of ALL_LINES) {
+        expect(colors.line[line]).toBeDefined();
+        expect(typeof colors.line[line]).toBe('string');
+        expect(colors.line[line].length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should have correct Seoul Metro official colors for lines 1-9', () => {
+      expect(colors.line['1']).toBe('#0052A4');
+      expect(colors.line['2']).toBe('#009D3E');
+      expect(colors.line['3']).toBe('#EF7C1C');
+      expect(colors.line['4']).toBe('#00A2D1');
+      expect(colors.line['5']).toBe('#996CAC');
+      expect(colors.line['6']).toBe('#CD7C2F');
+      expect(colors.line['7']).toBe('#747F00');
+      expect(colors.line['8']).toBe('#E6186C');
+      expect(colors.line['9']).toBe('#BDB092');
+    });
+
+    it('should have colors for special lines', () => {
+      expect(colors.line.airport).toBe('#4B81BF');
+      expect(colors.line.gyeongui).toBe('#77C4A3');
+      expect(colors.line.bundang).toBe('#F5A200');
+      expect(colors.line.sinbundang).toBe('#D4003B');
+    });
+  });
+
+  describe('font', () => {
+    it('should use system fallback (undefined) for text fonts before Pretendard', () => {
+      expect(font.regular).toBeUndefined();
+      expect(font.medium).toBeUndefined();
+      expect(font.semibold).toBeUndefined();
+      expect(font.bold).toBeUndefined();
+    });
+
+    it('should use Menlo for monospace', () => {
+      expect(font.mono).toBe('Menlo');
+    });
+  });
+
+  describe('typography', () => {
+    it('should define all type scales', () => {
+      const scales = ['hero', 'title', 'countMM', 'countSS', 'body', 'bodySm', 'label', 'mono'] as const;
+      for (const scale of scales) {
+        expect(typography[scale]).toBeDefined();
+        expect(typeof typography[scale].fontSize).toBe('number');
+      }
+    });
+
+    it('should have correct hero style', () => {
+      expect(typography.hero.fontSize).toBe(44);
+      expect(typography.hero.letterSpacing).toBe(-1.4);
+    });
+
+    it('should have uppercase label', () => {
+      expect(typography.label.textTransform).toBe('uppercase');
+    });
+
+    it('should use mono font for mono style', () => {
+      expect(typography.mono.fontFamily).toBe('Menlo');
+    });
+  });
+
+  describe('spacing', () => {
+    it('should define all spacing values in ascending order', () => {
+      expect(spacing.xs).toBe(4);
+      expect(spacing.sm).toBe(8);
+      expect(spacing.md).toBe(12);
+      expect(spacing.lg).toBe(16);
+      expect(spacing.xl).toBe(20);
+      expect(spacing.xxl).toBe(24);
+      expect(spacing.xxxl).toBe(32);
+    });
+  });
+
+  describe('radius', () => {
+    it('should define all radius values', () => {
+      expect(radius.sm).toBe(6);
+      expect(radius.md).toBe(10);
+      expect(radius.lg).toBe(14);
+      expect(radius.pill).toBe(999);
+    });
+  });
+});

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,1 @@
+export { colors, font, typography, spacing, radius } from './theme';

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,56 @@
+// theme.ts — Editorial Light (B) 디자인 토큰
+// 앱 전체에서 import하여 사용. 색/폰트/간격을 한 곳에서 관리.
+
+import type { LineNumber } from '../types/station';
+import { LINE_COLORS } from '../constants/lineColors';
+
+export const colors = {
+  bg:     '#F5F2EC',                   // 따뜻한 페이퍼 배경
+  ink:    '#1A1814',                   // 본문 (near-black warm)
+  muted:  '#6B6459',                   // 보조 텍스트
+  subtle: '#A8A197',                   // 더 연한 메타 정보
+  hair:   'rgba(26,24,20,0.08)',       // divider
+
+  accent: '#C8553D',                   // CTA, 강조 (earth red)
+  warn:   '#ff9f43',                   // 경고 (mock 데이터 등)
+
+  // 노선 색 — LineNumber 키 사용, LINE_COLORS에서 가져옴
+  line: { ...LINE_COLORS } as Record<LineNumber, string>,
+};
+
+export const font = {
+  // Pretendard 폰트 적용 전까지 시스템 기본 폰트 사용
+  regular:  undefined as string | undefined,
+  medium:   undefined as string | undefined,
+  semibold: undefined as string | undefined,
+  bold:     undefined as string | undefined,
+  mono:     'Menlo' as string | undefined,
+};
+
+export const typography = {
+  hero:    { fontFamily: font.bold,     fontSize: 44, letterSpacing: -1.4, lineHeight: 44 * 0.95 },
+  title:   { fontFamily: font.bold,     fontSize: 26, letterSpacing: -0.7, lineHeight: 26 },
+  countMM: { fontFamily: font.bold,     fontSize: 32, letterSpacing: -0.8 },
+  countSS: { fontFamily: font.semibold, fontSize: 24, letterSpacing: -0.8 },
+  body:    { fontFamily: font.medium,   fontSize: 17, letterSpacing: -0.3 },
+  bodySm:  { fontFamily: font.medium,   fontSize: 14 },
+  label:   { fontFamily: font.medium,   fontSize: 11, letterSpacing: 1.2, textTransform: 'uppercase' as const },
+  mono:    { fontFamily: font.mono,     fontSize: 11, letterSpacing: 0.6 },
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  xxl: 24,
+  xxxl: 32,
+};
+
+export const radius = {
+  sm: 6,
+  md: 10,
+  lg: 14,
+  pill: 999,
+};

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -1,0 +1,204 @@
+import {
+  journeyDisplayToStops,
+  arrivalInfoToArrivalTrain,
+  nearestResultToNearest,
+} from '../journeyAdapter';
+import type { JourneyDisplay } from '../stationRoute';
+import type { ArrivalInfo } from '../../api/arrivalApi';
+import type { NearestStationResult } from '../../types/station';
+
+describe('journeyDisplayToStops', () => {
+  it('should convert a direct route (single segment)', () => {
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '2', lineColor: '#009D3E', fromName: '강남', toName: '역삼', stops: 1 },
+      ],
+      totalStops: 1,
+    };
+
+    const stops = journeyDisplayToStops(journey);
+    expect(stops).toEqual([
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
+    ]);
+  });
+
+  it('should convert a transfer route (two segments)', () => {
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '6', lineColor: '#CD7C2F', fromName: '효창공원앞', toName: '공덕', stops: 2 },
+        { line: '5', lineColor: '#996CAC', fromName: '공덕', toName: '여의나루', stops: 3 },
+      ],
+      totalStops: 5,
+    };
+
+    const stops = journeyDisplayToStops(journey);
+    expect(stops).toEqual([
+      { station: '효창공원앞', line: '6', mark: 'filled' },
+      { station: '공덕', line: '5', stopsFromPrev: '2정거장', mark: 'transfer', note: '환승' },
+      { station: '여의나루', line: '5', stopsFromPrev: '3정거장', mark: 'dest', note: '도착' },
+    ]);
+  });
+
+  it('should convert a multi-transfer route (three segments)', () => {
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '1', lineColor: '#0052A4', fromName: '서울역', toName: '시청', stops: 1 },
+        { line: '2', lineColor: '#009D3E', fromName: '시청', toName: '을지로3가', stops: 2 },
+        { line: '3', lineColor: '#EF7C1C', fromName: '을지로3가', toName: '경복궁', stops: 4 },
+      ],
+      totalStops: 7,
+    };
+
+    const stops = journeyDisplayToStops(journey);
+    expect(stops).toHaveLength(4);
+    expect(stops[0]).toEqual({ station: '서울역', line: '1', mark: 'filled' });
+    expect(stops[1]).toEqual({ station: '시청', line: '2', stopsFromPrev: '1정거장', mark: 'transfer', note: '환승' });
+    expect(stops[2]).toEqual({ station: '을지로3가', line: '3', stopsFromPrev: '2정거장', mark: 'transfer', note: '환승' });
+    expect(stops[3]).toEqual({ station: '경복궁', line: '3', stopsFromPrev: '4정거장', mark: 'dest', note: '도착' });
+  });
+
+  it('should handle special line numbers', () => {
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: 'airport', lineColor: '#4B81BF', fromName: '서울역', toName: '인천공항', stops: 5 },
+      ],
+      totalStops: 5,
+    };
+
+    const stops = journeyDisplayToStops(journey);
+    expect(stops[0].line).toBe('airport');
+    expect(stops[1].line).toBe('airport');
+  });
+
+  it('should return empty array for empty segments', () => {
+    const journey: JourneyDisplay = { segments: [], totalStops: 0 };
+    expect(journeyDisplayToStops(journey)).toEqual([]);
+  });
+});
+
+describe('arrivalInfoToArrivalTrain', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should convert arrival info with destination', () => {
+    const items: ArrivalInfo[] = [
+      { destination: '봉화산', arrivalSeconds: 134, arrivalMinutes: 2, statusMessage: '', trainCode: 'T001' },
+    ];
+
+    const result = arrivalInfoToArrivalTrain(items, '상행', '6');
+    expect(result).toEqual([
+      {
+        direction: '봉화산 방면',
+        line: '6',
+        arrivalAtMs: 1000000 + 134 * 1000,
+        subtext: undefined,
+      },
+    ]);
+  });
+
+  it('should use direction fallback when destination is empty', () => {
+    const items: ArrivalInfo[] = [
+      { destination: '', arrivalSeconds: 60, arrivalMinutes: 1, statusMessage: '', trainCode: 'T002' },
+    ];
+
+    const result = arrivalInfoToArrivalTrain(items, '하행', '2');
+    expect(result[0].direction).toBe('하행');
+  });
+
+  it('should include statusMessage as subtext when present', () => {
+    const items: ArrivalInfo[] = [
+      { destination: '응암', arrivalSeconds: 271, arrivalMinutes: 4, statusMessage: '전역 출발', trainCode: 'T003' },
+    ];
+
+    const result = arrivalInfoToArrivalTrain(items, '상행', '6');
+    expect(result[0].subtext).toBe('전역 출발');
+  });
+
+  it('should handle multiple items', () => {
+    const items: ArrivalInfo[] = [
+      { destination: '봉화산', arrivalSeconds: 134, arrivalMinutes: 2, statusMessage: '', trainCode: 'T001' },
+      { destination: '응암', arrivalSeconds: 271, arrivalMinutes: 4, statusMessage: '진입 중', trainCode: 'T002' },
+    ];
+
+    const result = arrivalInfoToArrivalTrain(items, '상행', '6');
+    expect(result).toHaveLength(2);
+    expect(result[1].arrivalAtMs).toBe(1000000 + 271 * 1000);
+    expect(result[1].subtext).toBe('진입 중');
+  });
+
+  it('should handle special line number', () => {
+    const items: ArrivalInfo[] = [
+      { destination: '인천공항', arrivalSeconds: 600, arrivalMinutes: 10, statusMessage: '', trainCode: 'A001' },
+    ];
+
+    const result = arrivalInfoToArrivalTrain(items, '상행', 'airport');
+    expect(result[0].line).toBe('airport');
+  });
+
+  it('should return empty array for empty items', () => {
+    expect(arrivalInfoToArrivalTrain([], '상행', '1')).toEqual([]);
+  });
+});
+
+describe('nearestResultToNearest', () => {
+  it('should convert distance from km to meters', () => {
+    const result: NearestStationResult = {
+      station: { id: '0601', name: '효창공원앞', line: '6', lineColor: '#CD7C2F', lat: 37.5, lng: 126.9 },
+      distanceKm: 0.541,
+    };
+
+    const nearest = nearestResultToNearest(result);
+    expect(nearest.name).toBe('효창공원앞');
+    expect(nearest.line).toBe('6');
+    expect(nearest.distanceM).toBe(541);
+  });
+
+  it('should calculate walk time at 80m/min', () => {
+    const result: NearestStationResult = {
+      station: { id: '0201', name: '강남', line: '2', lineColor: '#009D3E', lat: 37.5, lng: 127.0 },
+      distanceKm: 0.4,
+    };
+
+    const nearest = nearestResultToNearest(result);
+    expect(nearest.distanceM).toBe(400);
+    expect(nearest.walkMin).toBe(5); // 400 / 80 = 5
+  });
+
+  it('should have minimum 1 minute walk time', () => {
+    const result: NearestStationResult = {
+      station: { id: '0301', name: '충무로', line: '3', lineColor: '#EF7C1C', lat: 37.5, lng: 127.0 },
+      distanceKm: 0.01,
+    };
+
+    const nearest = nearestResultToNearest(result);
+    expect(nearest.distanceM).toBe(10);
+    expect(nearest.walkMin).toBe(1);
+  });
+
+  it('should round distance to nearest meter', () => {
+    const result: NearestStationResult = {
+      station: { id: '0501', name: '여의나루', line: '5', lineColor: '#996CAC', lat: 37.5, lng: 126.9 },
+      distanceKm: 0.1234,
+    };
+
+    const nearest = nearestResultToNearest(result);
+    expect(nearest.distanceM).toBe(123);
+  });
+
+  it('should handle special line (airport)', () => {
+    const result: NearestStationResult = {
+      station: { id: 'AP01', name: '서울역', line: 'airport', lineColor: '#4B81BF', lat: 37.5, lng: 126.9 },
+      distanceKm: 0.25,
+    };
+
+    const nearest = nearestResultToNearest(result);
+    expect(nearest.line).toBe('airport');
+    expect(nearest.walkMin).toBe(4); // ceil(250 / 80) = 4
+  });
+});

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -3,20 +3,11 @@ import {
   arrivalInfoToArrivalTrain,
   nearestResultToNearest,
 } from '../journeyAdapter';
-import type { JourneyDisplay } from '../stationRoute';
-import type { ArrivalInfo } from '../../api/arrivalApi';
-import type { NearestStationResult } from '../../types/station';
+import { MOCK_JOURNEYS, makeNearestResult, makeArrivalInfo } from '../../testUtils/fixtures';
 
 describe('journeyDisplayToStops', () => {
   it('should convert a direct route (single segment)', () => {
-    const journey: JourneyDisplay = {
-      segments: [
-        { line: '2', lineColor: '#009D3E', fromName: '강남', toName: '역삼', stops: 1 },
-      ],
-      totalStops: 1,
-    };
-
-    const stops = journeyDisplayToStops(journey);
+    const stops = journeyDisplayToStops(MOCK_JOURNEYS.direct);
     expect(stops).toEqual([
       { station: '강남', line: '2', mark: 'filled' },
       { station: '역삼', line: '2', stopsFromPrev: '1정거장', mark: 'dest', note: '도착' },
@@ -24,15 +15,7 @@ describe('journeyDisplayToStops', () => {
   });
 
   it('should convert a transfer route (two segments)', () => {
-    const journey: JourneyDisplay = {
-      segments: [
-        { line: '6', lineColor: '#CD7C2F', fromName: '효창공원앞', toName: '공덕', stops: 2 },
-        { line: '5', lineColor: '#996CAC', fromName: '공덕', toName: '여의나루', stops: 3 },
-      ],
-      totalStops: 5,
-    };
-
-    const stops = journeyDisplayToStops(journey);
+    const stops = journeyDisplayToStops(MOCK_JOURNEYS.transfer);
     expect(stops).toEqual([
       { station: '효창공원앞', line: '6', mark: 'filled' },
       { station: '공덕', line: '5', stopsFromPrev: '2정거장', mark: 'transfer', note: '환승' },
@@ -41,7 +24,7 @@ describe('journeyDisplayToStops', () => {
   });
 
   it('should convert a multi-transfer route (three segments)', () => {
-    const journey: JourneyDisplay = {
+    const journey = {
       segments: [
         { line: '1', lineColor: '#0052A4', fromName: '서울역', toName: '시청', stops: 1 },
         { line: '2', lineColor: '#009D3E', fromName: '시청', toName: '을지로3가', stops: 2 },
@@ -49,7 +32,6 @@ describe('journeyDisplayToStops', () => {
       ],
       totalStops: 7,
     };
-
     const stops = journeyDisplayToStops(journey);
     expect(stops).toHaveLength(4);
     expect(stops[0]).toEqual({ station: '서울역', line: '1', mark: 'filled' });
@@ -59,73 +41,51 @@ describe('journeyDisplayToStops', () => {
   });
 
   it('should handle special line numbers', () => {
-    const journey: JourneyDisplay = {
+    const journey = {
       segments: [
         { line: 'airport', lineColor: '#4B81BF', fromName: '서울역', toName: '인천공항', stops: 5 },
       ],
       totalStops: 5,
     };
-
     const stops = journeyDisplayToStops(journey);
     expect(stops[0].line).toBe('airport');
     expect(stops[1].line).toBe('airport');
   });
 
   it('should return empty array for empty segments', () => {
-    const journey: JourneyDisplay = { segments: [], totalStops: 0 };
-    expect(journeyDisplayToStops(journey)).toEqual([]);
+    expect(journeyDisplayToStops({ segments: [], totalStops: 0 })).toEqual([]);
   });
 });
 
 describe('arrivalInfoToArrivalTrain', () => {
-  beforeEach(() => {
-    jest.spyOn(Date, 'now').mockReturnValue(1000000);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+  beforeEach(() => { jest.spyOn(Date, 'now').mockReturnValue(1000000); });
+  afterEach(() => { jest.restoreAllMocks(); });
 
   it('should convert arrival info with destination', () => {
-    const items: ArrivalInfo[] = [
-      { destination: '봉화산', arrivalSeconds: 134, arrivalMinutes: 2, statusMessage: '', trainCode: 'T001' },
-    ];
-
+    const items = [makeArrivalInfo({ destination: '봉화산', arrivalSeconds: 134 })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toEqual([
-      {
-        direction: '봉화산 방면',
-        line: '6',
-        arrivalAtMs: 1000000 + 134 * 1000,
-        subtext: undefined,
-      },
+      { direction: '봉화산 방면', line: '6', arrivalAtMs: 1000000 + 134 * 1000, subtext: undefined },
     ]);
   });
 
   it('should use direction fallback when destination is empty', () => {
-    const items: ArrivalInfo[] = [
-      { destination: '', arrivalSeconds: 60, arrivalMinutes: 1, statusMessage: '', trainCode: 'T002' },
-    ];
-
+    const items = [makeArrivalInfo({ destination: '', arrivalSeconds: 60 })];
     const result = arrivalInfoToArrivalTrain(items, '하행', '2');
     expect(result[0].direction).toBe('하행');
   });
 
   it('should include statusMessage as subtext when present', () => {
-    const items: ArrivalInfo[] = [
-      { destination: '응암', arrivalSeconds: 271, arrivalMinutes: 4, statusMessage: '전역 출발', trainCode: 'T003' },
-    ];
-
+    const items = [makeArrivalInfo({ destination: '응암', arrivalSeconds: 271, statusMessage: '전역 출발' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result[0].subtext).toBe('전역 출발');
   });
 
   it('should handle multiple items', () => {
-    const items: ArrivalInfo[] = [
-      { destination: '봉화산', arrivalSeconds: 134, arrivalMinutes: 2, statusMessage: '', trainCode: 'T001' },
-      { destination: '응암', arrivalSeconds: 271, arrivalMinutes: 4, statusMessage: '진입 중', trainCode: 'T002' },
+    const items = [
+      makeArrivalInfo({ destination: '봉화산', arrivalSeconds: 134 }),
+      makeArrivalInfo({ destination: '응암', arrivalSeconds: 271, statusMessage: '진입 중', trainCode: 'T002' }),
     ];
-
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toHaveLength(2);
     expect(result[1].arrivalAtMs).toBe(1000000 + 271 * 1000);
@@ -133,10 +93,7 @@ describe('arrivalInfoToArrivalTrain', () => {
   });
 
   it('should handle special line number', () => {
-    const items: ArrivalInfo[] = [
-      { destination: '인천공항', arrivalSeconds: 600, arrivalMinutes: 10, statusMessage: '', trainCode: 'A001' },
-    ];
-
+    const items = [makeArrivalInfo({ destination: '인천공항', arrivalSeconds: 600, trainCode: 'A001' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', 'airport');
     expect(result[0].line).toBe('airport');
   });
@@ -148,57 +105,32 @@ describe('arrivalInfoToArrivalTrain', () => {
 
 describe('nearestResultToNearest', () => {
   it('should convert distance from km to meters', () => {
-    const result: NearestStationResult = {
-      station: { id: '0601', name: '효창공원앞', line: '6', lineColor: '#CD7C2F', lat: 37.5, lng: 126.9 },
-      distanceKm: 0.541,
-    };
-
-    const nearest = nearestResultToNearest(result);
+    const nearest = nearestResultToNearest(makeNearestResult('hyochang', 0.541));
     expect(nearest.name).toBe('효창공원앞');
     expect(nearest.line).toBe('6');
     expect(nearest.distanceM).toBe(541);
   });
 
   it('should calculate walk time at 80m/min', () => {
-    const result: NearestStationResult = {
-      station: { id: '0201', name: '강남', line: '2', lineColor: '#009D3E', lat: 37.5, lng: 127.0 },
-      distanceKm: 0.4,
-    };
-
-    const nearest = nearestResultToNearest(result);
+    const nearest = nearestResultToNearest(makeNearestResult('gangnam', 0.4));
     expect(nearest.distanceM).toBe(400);
-    expect(nearest.walkMin).toBe(5); // 400 / 80 = 5
+    expect(nearest.walkMin).toBe(5);
   });
 
   it('should have minimum 1 minute walk time', () => {
-    const result: NearestStationResult = {
-      station: { id: '0301', name: '충무로', line: '3', lineColor: '#EF7C1C', lat: 37.5, lng: 127.0 },
-      distanceKm: 0.01,
-    };
-
-    const nearest = nearestResultToNearest(result);
+    const nearest = nearestResultToNearest(makeNearestResult('chungmuro', 0.01));
     expect(nearest.distanceM).toBe(10);
     expect(nearest.walkMin).toBe(1);
   });
 
   it('should round distance to nearest meter', () => {
-    const result: NearestStationResult = {
-      station: { id: '0501', name: '여의나루', line: '5', lineColor: '#996CAC', lat: 37.5, lng: 126.9 },
-      distanceKm: 0.1234,
-    };
-
-    const nearest = nearestResultToNearest(result);
+    const nearest = nearestResultToNearest(makeNearestResult('yeouinaru', 0.1234));
     expect(nearest.distanceM).toBe(123);
   });
 
   it('should handle special line (airport)', () => {
-    const result: NearestStationResult = {
-      station: { id: 'AP01', name: '서울역', line: 'airport', lineColor: '#4B81BF', lat: 37.5, lng: 126.9 },
-      distanceKm: 0.25,
-    };
-
-    const nearest = nearestResultToNearest(result);
+    const nearest = nearestResultToNearest(makeNearestResult('seoulStation', 0.25));
     expect(nearest.line).toBe('airport');
-    expect(nearest.walkMin).toBe(4); // ceil(250 / 80) = 4
+    expect(nearest.walkMin).toBe(4);
   });
 });

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -1,0 +1,92 @@
+import type { JourneyDisplay } from './stationRoute';
+import type { ArrivalInfo } from '../api/arrivalApi';
+import type { NearestStationResult, LineNumber } from '../types/station';
+
+export interface Stop {
+  station: string;
+  line: string | null;
+  stopsFromPrev?: string;
+  mark: 'filled' | 'transfer' | 'dest';
+  note?: string;
+}
+
+export interface ArrivalTrain {
+  direction: string;
+  line: string;
+  arrivalAtMs: number;
+  subtext?: string;
+}
+
+export interface HandoffNearest {
+  name: string;
+  line: string;
+  distanceM: number;
+  walkMin: number;
+}
+
+const WALK_SPEED_M_PER_MIN = 80;
+
+export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
+  const { segments } = journey;
+  if (segments.length === 0) return [];
+
+  const stops: Stop[] = [];
+
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const isFirst = i === 0;
+    const isLast = i === segments.length - 1;
+
+    if (isFirst) {
+      stops.push({
+        station: seg.fromName,
+        line: seg.line,
+        mark: 'filled',
+      });
+    }
+
+    if (!isLast) {
+      stops.push({
+        station: seg.toName,
+        line: segments[i + 1].line,
+        stopsFromPrev: `${seg.stops}정거장`,
+        mark: 'transfer',
+        note: '환승',
+      });
+    } else {
+      stops.push({
+        station: seg.toName,
+        line: seg.line,
+        stopsFromPrev: `${seg.stops}정거장`,
+        mark: 'dest',
+        note: '도착',
+      });
+    }
+  }
+
+  return stops;
+}
+
+export function arrivalInfoToArrivalTrain(
+  items: ArrivalInfo[],
+  direction: string,
+  line: LineNumber,
+): ArrivalTrain[] {
+  const now = Date.now();
+  return items.map((item) => ({
+    direction: item.destination ? `${item.destination} 방면` : direction,
+    line,
+    arrivalAtMs: now + item.arrivalSeconds * 1000,
+    subtext: item.statusMessage || undefined,
+  }));
+}
+
+export function nearestResultToNearest(result: NearestStationResult): HandoffNearest {
+  const distanceM = Math.round(result.distanceKm * 1000);
+  return {
+    name: result.station.name,
+    line: result.station.line,
+    distanceM,
+    walkMin: Math.max(1, Math.ceil(distanceM / WALK_SPEED_M_PER_MIN)),
+  };
+}


### PR DESCRIPTION
## Summary
- 중앙 디자인 토큰 시스템 도입 (`src/theme/theme.ts` — colors, typography, spacing, radius)
- 데이터 어댑터 패턴으로 기존 데이터 ↔ 핸드오프 컴포넌트 연결 (`journeyAdapter.ts`)
- EditorialTimeline, EditorialArrivalRow, useCountdown 컴���넌트/훅 포팅
- 홈 화면 다크 테마 → Editorial Light 라이�� 테마(warm paper #F5F2EC) 전환
- AlarmOverlay, DestinationPicker, JourneyTimeline 테마 토큰 적용
- 도착 정보는 기존 상행/하행 포맷 유지, 색상만 테마 토큰 적용
- hex() 함수 비 #RRGGBB 입력 방어 처리 추가

Closes #107

## Test plan
- [x] `npm test` — 479개 테스트 전체 통과, 커버리�� 100%
- [x] `npm run type-check` — 타입 오류 없음
- [x] iOS 시뮬레이터에서 라이트 테마 시각적 확인
- [x] 기존 기능 동작 확인 (알람, 알림, 즐겨찾기, 취침 모드)