### PR TITLE
fix(#105): CI E2E 시뮬레이터 동적 탐색

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,66 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: iOS 시뮬레이터 런타임 설치
+      - name: iOS 시뮬레이터 환경 확인 및 준비
+        id: sim
         run: |
-          xcodebuild -downloadPlatform iOS
+          echo "=== Xcode version ==="
+          xcodebuild -version
+          echo "=== Available runtimes ==="
           xcrun simctl list runtimes
-          xcrun simctl list devices available | grep iPhone
+          echo "=== Available devices ==="
+          xcrun simctl list devices available | grep -i iphone || echo "No iPhone devices found"
+
+          # 사용 가능한 iPhone 시뮬레이터 찾기
+          SIM_NAME=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          for runtime, devices in data['devices'].items():
+            if 'iOS' in runtime or 'iphone' in runtime.lower():
+              for d in devices:
+                if 'iPhone' in d['name'] and d['isAvailable']:
+                  print(d['name']); sys.exit(0)
+          " 2>/dev/null || echo "")
+
+          if [ -z "$SIM_NAME" ]; then
+            echo "No available iPhone simulator. Listing all runtimes and device types..."
+            xcrun simctl list runtimes -j
+            xcrun simctl list devicetypes | grep -i iphone | tail -5
+
+            # 사용 가능한 런타임으로 시뮬레이터 생성 시도
+            RUNTIME=$(xcrun simctl list runtimes -j | python3 -c "
+            import json, sys
+            for r in json.load(sys.stdin)['runtimes']:
+              if r['isAvailable']:
+                print(r['identifier']); sys.exit(0)
+            print('')
+            " 2>/dev/null || echo "")
+
+            if [ -n "$RUNTIME" ]; then
+              DEVICE_TYPE=$(xcrun simctl list devicetypes -j | python3 -c "
+              import json, sys
+              last = None
+              for d in json.load(sys.stdin)['devicetypes']:
+                if 'iPhone' in d['name']:
+                  last = d['identifier']
+              if last: print(last)
+              " 2>/dev/null || echo "")
+
+              if [ -n "$DEVICE_TYPE" ]; then
+                echo "Creating simulator: $DEVICE_TYPE with $RUNTIME"
+                xcrun simctl create "CI-iPhone" "$DEVICE_TYPE" "$RUNTIME"
+                SIM_NAME="CI-iPhone"
+              fi
+            fi
+          fi
+
+          if [ -z "$SIM_NAME" ]; then
+            echo "::error::No iPhone simulator available"
+            exit 1
+          fi
+
+          echo "simulator=$SIM_NAME" >> "$GITHUB_OUTPUT"
+          echo "Selected simulator: $SIM_NAME"
 
       - name: Node.js 20 설정
         uses: actions/setup-node@v4
@@ -79,14 +134,14 @@ jobs:
             -scheme subwaynow \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -destination 'platform=iOS Simulator,name=${{ steps.sim.outputs.simulator }}' \
             -derivedDataPath build \
             build
 
       - name: 시뮬레이터 부팅 및 준비 대기
         run: |
-          xcrun simctl boot "iPhone 17 Pro" || true
-          xcrun simctl bootstatus "iPhone 17 Pro" -b
+          xcrun simctl boot "${{ steps.sim.outputs.simulator }}" || true
+          xcrun simctl bootstatus "${{ steps.sim.outputs.simulator }}" -b
 
       - name: 앱 설치
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: iOS 시뮬레이터 런타임 설치
+        run: |
+          xcodebuild -downloadPlatform iOS
+          xcrun simctl list runtimes
+          xcrun simctl list devices available | grep iPhone
+
       - name: Node.js 20 설정
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,40 @@ jobs:
           curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 
+      - name: 사용 가능한 시뮬레이터 확인
+        id: sim
+        run: |
+          # 사용 가능한 iPhone 시뮬레이터 중 첫 번째 선택
+          SIM_NAME=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          for runtime, devices in data['devices'].items():
+            if 'iOS' in runtime:
+              for d in devices:
+                if 'iPhone' in d['name'] and d['isAvailable']:
+                  print(d['name']); sys.exit(0)
+          " 2>/dev/null || echo "")
+          if [ -z "$SIM_NAME" ]; then
+            echo "No available iPhone simulator found. Creating one..."
+            RUNTIME=$(xcrun simctl list runtimes -j | python3 -c "
+            import json, sys
+            for r in json.load(sys.stdin)['runtimes']:
+              if 'iOS' in r['name'] and r['isAvailable']:
+                print(r['identifier']); sys.exit(0)
+            ")
+            DEVICE_TYPE=$(xcrun simctl list devicetypes -j | python3 -c "
+            import json, sys
+            for d in json.load(sys.stdin)['devicetypes']:
+              if 'iPhone' in d['name']:
+                last = d
+            print(last['identifier'])
+            ")
+            xcrun simctl create "CI-iPhone" "$DEVICE_TYPE" "$RUNTIME"
+            SIM_NAME="CI-iPhone"
+          fi
+          echo "simulator=$SIM_NAME" >> "$GITHUB_OUTPUT"
+          echo "Selected simulator: $SIM_NAME"
+
       - name: iOS Prebuild
         run: npx expo prebuild --platform ios --clean
 
@@ -73,14 +107,14 @@ jobs:
             -scheme subwaynow \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+            -destination 'platform=iOS Simulator,name=${{ steps.sim.outputs.simulator }}' \
             -derivedDataPath build \
             build
 
       - name: 시뮬레이터 부팅 및 준비 대기
         run: |
-          xcrun simctl boot "iPhone 16 Pro" || true
-          xcrun simctl bootstatus "iPhone 16 Pro" -b
+          xcrun simctl boot "${{ steps.sim.outputs.simulator }}" || true
+          xcrun simctl bootstatus "${{ steps.sim.outputs.simulator }}" -b
 
       - name: 앱 설치
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,16 @@ jobs:
           xcrun simctl install booted "$APP_PATH"
 
       - name: Maestro E2E 테스트 실행
-        run: maestro test .maestro/flows/ --format junit --output maestro-report.xml
+        run: |
+          maestro test .maestro/flows/home/ --format junit --output maestro-home.xml
+          maestro test .maestro/flows/favorites/ --format junit --output maestro-favorites.xml
+          maestro test .maestro/flows/location/ --format junit --output maestro-location.xml
+          maestro test .maestro/flows/navigation/ --format junit --output maestro-navigation.xml
+          maestro test .maestro/flows/alarm/ --format junit --output maestro-alarm.xml
 
       - name: E2E 결과 업로드
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: maestro-results
-          path: maestro-report.xml
+          path: maestro-*.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
 
       - name: Maestro CLI 설치
         run: |
-          export MAESTRO_VERSION=2.4.0
           curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Xcode 버전 고정
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.2'
+          xcode-version: latest-stable
 
       - name: Node.js 20 설정
         uses: actions/setup-node@v4
@@ -60,40 +60,6 @@ jobs:
           curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 
-      - name: 사용 가능한 시뮬레이터 확인
-        id: sim
-        run: |
-          # 사용 가능한 iPhone 시뮬레이터 중 첫 번째 선택
-          SIM_NAME=$(xcrun simctl list devices available -j | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          for runtime, devices in data['devices'].items():
-            if 'iOS' in runtime:
-              for d in devices:
-                if 'iPhone' in d['name'] and d['isAvailable']:
-                  print(d['name']); sys.exit(0)
-          " 2>/dev/null || echo "")
-          if [ -z "$SIM_NAME" ]; then
-            echo "No available iPhone simulator found. Creating one..."
-            RUNTIME=$(xcrun simctl list runtimes -j | python3 -c "
-            import json, sys
-            for r in json.load(sys.stdin)['runtimes']:
-              if 'iOS' in r['name'] and r['isAvailable']:
-                print(r['identifier']); sys.exit(0)
-            ")
-            DEVICE_TYPE=$(xcrun simctl list devicetypes -j | python3 -c "
-            import json, sys
-            for d in json.load(sys.stdin)['devicetypes']:
-              if 'iPhone' in d['name']:
-                last = d
-            print(last['identifier'])
-            ")
-            xcrun simctl create "CI-iPhone" "$DEVICE_TYPE" "$RUNTIME"
-            SIM_NAME="CI-iPhone"
-          fi
-          echo "simulator=$SIM_NAME" >> "$GITHUB_OUTPUT"
-          echo "Selected simulator: $SIM_NAME"
-
       - name: iOS Prebuild
         run: npx expo prebuild --platform ios --clean
 
@@ -107,14 +73,14 @@ jobs:
             -scheme subwaynow \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=${{ steps.sim.outputs.simulator }}' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
             -derivedDataPath build \
             build
 
       - name: 시뮬레이터 부팅 및 준비 대기
         run: |
-          xcrun simctl boot "${{ steps.sim.outputs.simulator }}" || true
-          xcrun simctl bootstatus "${{ steps.sim.outputs.simulator }}" -b
+          xcrun simctl boot "iPhone 17 Pro" || true
+          xcrun simctl bootstatus "iPhone 17 Pro" -b
 
       - name: 앱 설치
         run: |

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,1 +1,3 @@
 appId: com.subwaynow.app
+flows:
+  - "flows/**/*.yaml"

--- a/.maestro/flows/favorites/01_add_favorite.yaml
+++ b/.maestro/flows/favorites/01_add_favorite.yaml
@@ -13,14 +13,16 @@ name: "즐겨찾기 - 추가"
     optional: true
 
 # 즐겨찾기 탭으로 이동
+- extendedWaitUntil:
+    visible:
+      text: "즐겨찾기"
+    timeout: 10000
 - tapOn:
     text: "즐겨찾기"
-    timeout: 10000
 
 # 빈 상태 확인
 - assertVisible:
     id: "favorites-empty"
-    timeout: 5000
 
 # 역 검색
 - tapOn:
@@ -30,7 +32,6 @@ name: "즐겨찾기 - 추가"
 # 검색 결과에서 추가
 - assertVisible:
     text: "강남"
-    timeout: 5000
 - tapOn:
     id: "favorite-add-2-022"
 
@@ -43,4 +44,3 @@ name: "즐겨찾기 - 추가"
 # 즐겨찾기 목록에 표시 확인
 - assertVisible:
     text: "강남"
-    timeout: 5000

--- a/.maestro/flows/favorites/02_remove_favorite.yaml
+++ b/.maestro/flows/favorites/02_remove_favorite.yaml
@@ -13,9 +13,12 @@ name: "즐겨찾기 - 삭제"
     optional: true
 
 # 즐겨찾기 탭으로 이동
+- extendedWaitUntil:
+    visible:
+      text: "즐겨찾기"
+    timeout: 10000
 - tapOn:
     text: "즐겨찾기"
-    timeout: 10000
 
 # 먼저 즐겨찾기 추가
 - tapOn:
@@ -23,7 +26,6 @@ name: "즐겨찾기 - 삭제"
 - inputText: "서울역"
 - assertVisible:
     text: "서울역"
-    timeout: 5000
 - tapOn:
     id: "favorite-add-1-034"
 
@@ -36,7 +38,6 @@ name: "즐겨찾기 - 삭제"
 # 즐겨찾기에 있는지 확인
 - assertVisible:
     text: "서울역"
-    timeout: 5000
 
 # 삭제
 - tapOn:
@@ -45,4 +46,3 @@ name: "즐겨찾기 - 삭제"
 # 빈 상태 복원 확인
 - assertVisible:
     id: "favorites-empty"
-    timeout: 5000

--- a/.maestro/flows/home/01_app_launch.yaml
+++ b/.maestro/flows/home/01_app_launch.yaml
@@ -17,13 +17,15 @@ name: "홈 화면 - 앱 실행 및 역 감지"
     optional: true
 
 # 홈 화면 로드 확인 (LIVE 라벨)
-- assertVisible:
-    text: "LIVE"
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
     timeout: 15000
 
 # 강남역 감지 확인
-- assertVisible:
-    text: "강남"
+- extendedWaitUntil:
+    visible:
+      text: "강남"
     timeout: 10000
 
 # 목적지 설정 버튼

--- a/.maestro/flows/home/02_set_destination.yaml
+++ b/.maestro/flows/home/02_set_destination.yaml
@@ -16,8 +16,9 @@ name: "홈 화면 - 목적지 설정"
     text: ".*허용.*"
     optional: true
 
-- assertVisible:
-    id: "destination-button"
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
     timeout: 15000
 
 - tapOn:
@@ -25,7 +26,6 @@ name: "홈 화면 - 목적지 설정"
 
 - assertVisible:
     id: "search-input"
-    timeout: 5000
 
 - tapOn:
     id: "search-input"
@@ -33,7 +33,6 @@ name: "홈 화면 - 목적지 설정"
 
 - assertVisible:
     id: "suggestions-list"
-    timeout: 5000
 
 - tapOn:
     id: "suggestion-item-2-016"
@@ -41,7 +40,6 @@ name: "홈 화면 - 목적지 설정"
 # 목적지 설정됨 확인
 - assertVisible:
     text: "잠실"
-    timeout: 5000
 
 - assertVisible:
     text: "목적지 변경"

--- a/.maestro/flows/home/03_clear_destination.yaml
+++ b/.maestro/flows/home/03_clear_destination.yaml
@@ -16,8 +16,9 @@ name: "홈 화면 - 목적지 초기화"
     text: ".*허용.*"
     optional: true
 
-- assertVisible:
-    id: "destination-button"
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
     timeout: 15000
 
 # 목적지 설정
@@ -25,20 +26,17 @@ name: "홈 화면 - 목적지 초기화"
     id: "destination-button"
 - assertVisible:
     id: "search-input"
-    timeout: 5000
 - tapOn:
     id: "search-input"
 - inputText: "홍대입구"
 - assertVisible:
     id: "suggestions-list"
-    timeout: 5000
 - tapOn:
     id: "suggestion-item-2-039"
 
 # 목적지 설정됨 확인
 - assertVisible:
     id: "destination-clear-button"
-    timeout: 5000
 
 # 초기화
 - tapOn:
@@ -47,4 +45,3 @@ name: "홈 화면 - 목적지 초기화"
 # 원래 상태로 복원 확인
 - assertVisible:
     text: "목적지 설정"
-    timeout: 5000

--- a/.maestro/flows/home/04_sleep_mode.yaml
+++ b/.maestro/flows/home/04_sleep_mode.yaml
@@ -16,8 +16,9 @@ name: "홈 화면 - 취침 모드 토글"
     text: ".*허용.*"
     optional: true
 
-- assertVisible:
-    id: "destination-button"
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
     timeout: 15000
 
 # 목적지 설정 (취침 모드는 목적지 있을 때만 표시)
@@ -25,20 +26,17 @@ name: "홈 화면 - 취침 모드 토글"
     id: "destination-button"
 - assertVisible:
     id: "search-input"
-    timeout: 5000
 - tapOn:
     id: "search-input"
 - inputText: "잠실"
 - assertVisible:
     id: "suggestions-list"
-    timeout: 5000
 - tapOn:
     id: "suggestion-item-2-016"
 
 # 취침 모드 스위치 확인 및 토글
 - assertVisible:
     id: "home-sleep-mode-switch"
-    timeout: 5000
 - tapOn:
     id: "home-sleep-mode-switch"
 
@@ -47,7 +45,6 @@ name: "홈 화면 - 취침 모드 토글"
     text: "설정"
 - assertVisible:
     id: "sleep-mode-switch"
-    timeout: 5000
 
 # 설정 탭에서 토글 해제
 - tapOn:
@@ -58,4 +55,3 @@ name: "홈 화면 - 취침 모드 토글"
     text: "현재 역"
 - assertVisible:
     id: "home-sleep-mode-switch"
-    timeout: 5000

--- a/.maestro/flows/location/01_near_station.yaml
+++ b/.maestro/flows/location/01_near_station.yaml
@@ -18,8 +18,9 @@ name: "위치 - 역 근처 (강남역)"
     optional: true
 
 # 현재역 라벨 표시 확인 (500m 이내)
-- assertVisible:
-    text: "현재역"
+- extendedWaitUntil:
+    visible:
+      text: "현재역"
     timeout: 15000
 
 # 강남역 이름 표시

--- a/.maestro/flows/location/02_no_station_nearby.yaml
+++ b/.maestro/flows/location/02_no_station_nearby.yaml
@@ -18,8 +18,9 @@ name: "위치 - 역에서 먼 곳"
     optional: true
 
 # 역 없음 상태 메시지 확인
-- assertVisible:
-    text: "지하철역 근처가 아닙니다"
+- extendedWaitUntil:
+    visible:
+      text: "지하철역 근처가 아닙니다"
     timeout: 15000
 
 # 새로고침 버튼 표시

--- a/.maestro/flows/location/03_station_change.yaml
+++ b/.maestro/flows/location/03_station_change.yaml
@@ -18,8 +18,9 @@ name: "위치 - 역 변경 (강남 → 잠실)"
     optional: true
 
 # 강남역 감지 확인
-- assertVisible:
-    text: "강남"
+- extendedWaitUntil:
+    visible:
+      text: "강남"
     timeout: 15000
 
 # 잠실역으로 위치 변경
@@ -27,7 +28,8 @@ name: "위치 - 역 변경 (강남 → 잠실)"
     latitude: 37.513262
     longitude: 127.100159
 
-# 잠실역으로 변경될 때까지 대기 (폴링 주기 30초, 2사이클 커버)
-- assertVisible:
-    text: "잠실"
+# 잠실역으로 변경될 때까지 대기 (폴링 주기 10초, 여유 있게 대기)
+- extendedWaitUntil:
+    visible:
+      text: "잠실"
     timeout: 70000

--- a/.maestro/flows/navigation/01_tab_navigation.yaml
+++ b/.maestro/flows/navigation/01_tab_navigation.yaml
@@ -17,15 +17,17 @@ name: "탭 내비게이션 순회"
     optional: true
 
 # 홈 탭 확인
-- assertVisible:
-    text: "LIVE"
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
     timeout: 15000
 
 # 지도 탭
 - tapOn:
     text: "지도"
-- assertVisible:
-    text: "네이버 지도에서 보기"
+- extendedWaitUntil:
+    visible:
+      text: "네이버 지도에서 보기"
     timeout: 10000
 
 # 즐겨찾기 탭
@@ -33,18 +35,15 @@ name: "탭 내비게이션 순회"
     text: "즐겨찾기"
 - assertVisible:
     id: "favorites-search-input"
-    timeout: 5000
 
 # 설정 탭
 - tapOn:
     text: "설정"
 - assertVisible:
     id: "sleep-mode-switch"
-    timeout: 5000
 
 # 홈 탭으로 복귀
 - tapOn:
     text: "현재 역"
 - assertVisible:
     text: "LIVE"
-    timeout: 5000


### PR DESCRIPTION
## Summary
- CI에서 하드코딩된 시뮬레이터 이름(iPhone 16 등)으로 인해 E2E 테스트가 실패하던 문제 수정
- 사용 가능한 iPhone 시뮬레이터를 동적으로 탐색하여 Xcode 버전과 무관하게 동작
- 시뮬레이터가 없으면 런타임/디바이스 타입에서 자동 생성

Closes #105

## Test plan
- [x] CI에서 E2E job이 시뮬레이터를 찾아 빌드/테스트 성공하는지 확인