### PR TITLE
fix(#108): 잠금화면 취침모드 알람 사운드 미재생 수정

### DIFF
--- a/.maestro/flows/alarm/01_alarm_notification_sound.yaml
+++ b/.maestro/flows/alarm/01_alarm_notification_sound.yaml
@@ -1,0 +1,83 @@
+appId: com.subwaynow.app
+name: "알람 - 포그라운드 취침모드 알람 트리거"
+---
+# 강남역에서 시작
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+
+# Expo Dev Client: localhost 서버 선택
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+
+# 번들 로드 대기
+- waitForAnimationToEnd
+
+# iOS 알림 권한 허용
+- tapOn:
+    text: "허용"
+    optional: true
+
+# Expo 개발자 메뉴 Continue 탭
+- tapOn:
+    text: "Continue"
+    optional: true
+
+# 앱 UI 안정화 대기
+- waitForAnimationToEnd
+
+- assertVisible:
+    id: "destination-button"
+
+# 목적지: 잠실 설정
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(1000)
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(500)
+- setClipboard: "잠실"
+- evalScript: maestro.wait(500)
+- pasteText
+- evalScript: maestro.wait(2000)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-2-016"
+- waitForAnimationToEnd
+
+# 취침 모드 ON
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+- evalScript: maestro.wait(500)
+- tapOn:
+    id: "home-sleep-mode-switch"
+- evalScript: maestro.wait(1000)
+
+# 위치를 잠실새내(잠실 1정거장 전)로 변경
+- setLocation:
+    latitude: 37.511687
+    longitude: 127.086162
+
+# 위치 변경 감지 + 알람 발생 대기 (폴링 30초 x 최대 4사이클)
+- repeat:
+    times: 120
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# 포그라운드 AlarmOverlay 확인
+- assertVisible:
+    text: "하차 알림"
+
+- assertVisible:
+    text: "알람 끄기"

--- a/.maestro/flows/alarm/02_alarm_overlay_on_resume.yaml
+++ b/.maestro/flows/alarm/02_alarm_overlay_on_resume.yaml
@@ -1,0 +1,92 @@
+appId: com.subwaynow.app
+name: "알람 - 포그라운드 AlarmOverlay 표시 및 해제"
+---
+# 강남역에서 시작
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+
+# Expo Dev Client: localhost 서버 선택
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+
+# 번들 로드 대기
+- waitForAnimationToEnd
+
+# iOS 알림 권한 허용
+- tapOn:
+    text: "허용"
+    optional: true
+
+# Expo 개발자 메뉴 Continue 탭
+- tapOn:
+    text: "Continue"
+    optional: true
+
+# 앱 UI 안정화 대기
+- waitForAnimationToEnd
+
+- assertVisible:
+    id: "destination-button"
+
+# 목적지: 잠실 설정
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(1000)
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(500)
+- setClipboard: "잠실"
+- evalScript: maestro.wait(500)
+- pasteText
+- evalScript: maestro.wait(2000)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-2-016"
+- waitForAnimationToEnd
+
+# 취침 모드 ON
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+- evalScript: maestro.wait(500)
+- tapOn:
+    id: "home-sleep-mode-switch"
+- evalScript: maestro.wait(1000)
+
+# 위치를 잠실새내(잠실 1정거장 전)로 변경
+- setLocation:
+    latitude: 37.511687
+    longitude: 127.086162
+
+# 위치 변경 감지 + 알람 발생 대기
+- repeat:
+    times: 120
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# AlarmOverlay 표시 확인
+- assertVisible:
+    text: "하차 알림"
+
+- assertVisible:
+    text: ".*내리세요"
+
+# 알람 끄기 버튼 탭
+- tapOn:
+    text: "알람 끄기"
+
+# AlarmOverlay 사라짐 확인
+- evalScript: maestro.wait(1000)
+- assertVisible:
+    id: "destination-button"

--- a/app.json
+++ b/app.json
@@ -55,6 +55,12 @@
           "locationWhenInUsePermission": "앱 사용 중 현재 지하철역을 감지하기 위해 위치 권한이 필요합니다."
         }
       ],
+      [
+        "expo-notifications",
+        {
+          "sounds": ["./assets/sounds/alarm.wav"]
+        }
+      ],
       "expo-router",
       "./modules/live-activity/app.plugin.js",
       "./remove-push-entitlement.js",

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { AppState, InteractionManager, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
@@ -35,6 +35,7 @@ export default function HomeScreen() {
   const loadSleepMode = useAppStore((s) => s.loadSleepMode);
   const alarmEvent = useAppStore((s) => s.alarmEvent);
   const clearAlarmEvent = useAppStore((s) => s.clearAlarmEvent);
+  const loadAlarmEvent = useAppStore((s) => s.loadAlarmEvent);
   const [pickerVisible, setPickerVisible] = useState(false);
   const [arrivedBanner, setArrivedBanner] = useState(false);
   const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -81,7 +82,14 @@ export default function HomeScreen() {
   useEffect(() => {
     loadFavorites();
     loadSleepMode();
+    loadAlarmEvent();
     initStationNotification();
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        loadAlarmEvent();
+      }
+    });
+    return () => subscription.remove();
   }, []);
 
   useEffect(() => {

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,0 +1,5 @@
+export const FAVORITES_KEY = 'subway-now:favorites';
+export const SLEEP_MODE_KEY = 'subway-now:sleep-mode';
+export const DESTINATION_KEY = 'subway-now:destination';
+export const FIRED_ALARMS_KEY = 'subway-now:fired-alarms';
+export const ALARM_EVENT_KEY = 'subway-now:alarm-event';

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -265,10 +265,43 @@ describe('useAppStore', () => {
     expect(alarmEvent).toEqual({ type: 'destination', stationName: '강남' });
   });
 
-  it('clearAlarmEvent: 알람 이벤트를 초기화한다', () => {
+  it('clearAlarmEvent: 알람 이벤트를 초기화하고 AsyncStorage도 정리한다', () => {
     const { setAlarmEvent, clearAlarmEvent } = useAppStore.getState();
     setAlarmEvent({ type: 'transfer', stationName: '역삼' });
     clearAlarmEvent();
+
+    const { alarmEvent } = useAppStore.getState();
+    expect(alarmEvent).toBeNull();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
+  });
+
+  it('loadAlarmEvent: AsyncStorage에서 알람 이벤트를 복원하고 제거한다', async () => {
+    const event = { type: 'destination' as const, stationName: '강남' };
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(event));
+
+    const { loadAlarmEvent } = useAppStore.getState();
+    await loadAlarmEvent();
+
+    const { alarmEvent } = useAppStore.getState();
+    expect(alarmEvent).toEqual(event);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
+  });
+
+  it('loadAlarmEvent: AsyncStorage가 비어있으면 null을 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { loadAlarmEvent } = useAppStore.getState();
+    await loadAlarmEvent();
+
+    const { alarmEvent } = useAppStore.getState();
+    expect(alarmEvent).toBeNull();
+  });
+
+  it('loadAlarmEvent: AsyncStorage 오류 시 null을 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+
+    const { loadAlarmEvent } = useAppStore.getState();
+    await loadAlarmEvent();
 
     const { alarmEvent } = useAppStore.getState();
     expect(alarmEvent).toBeNull();

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,19 +1,13 @@
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Station } from '../types/station';
+import type { AlarmEvent } from '../utils/stationAlarm';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY } from '../constants/storageKeys';
 
-const FAVORITES_KEY = 'subway-now:favorites';
-const SLEEP_MODE_KEY = 'subway-now:sleep-mode';
-const DESTINATION_KEY = 'subway-now:destination';
-const FIRED_ALARMS_KEY = 'subway-now:fired-alarms';
+export type { AlarmEvent };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
-
-export interface AlarmEvent {
-  type: 'destination' | 'transfer';
-  stationName: string;
-}
 
 interface AppState {
   favorites: Station[];
@@ -30,6 +24,7 @@ interface AppState {
   loadSleepMode: () => Promise<void>;
   setAlarmEvent: (event: AlarmEvent) => void;
   clearAlarmEvent: () => void;
+  loadAlarmEvent: () => Promise<void>;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -89,6 +84,19 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   clearAlarmEvent: () => {
     set({ alarmEvent: null });
+    AsyncStorage.removeItem(ALARM_EVENT_KEY).catch(noop);
+  },
+
+  loadAlarmEvent: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(ALARM_EVENT_KEY);
+      if (raw) {
+        set({ alarmEvent: JSON.parse(raw) });
+        await AsyncStorage.removeItem(ALARM_EVENT_KEY);
+      }
+    } catch {
+      // 저장된 데이터 없음 — 무시
+    }
   },
 
   loadSleepMode: async () => {

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -314,6 +314,10 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       'subway-now:fired-alarms',
       JSON.stringify(['destination:시청']),
     );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:alarm-event',
+      JSON.stringify(alarmEvent),
+    );
   });
 
   it('기존 firedAlarms에 alarmEvent 키를 추가하여 저장한다', async () => {
@@ -338,6 +342,10 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:fired-alarms',
       JSON.stringify(['destination:시청', 'transfer:강남']),
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:alarm-event',
+      JSON.stringify(alarmEvent),
     );
   });
 

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -6,14 +6,11 @@ import { alarmKey } from '../utils/stationAlarm';
 import { updateStationNotification } from '../utils/stationNotification';
 import { findNearestStation } from '../utils/findNearestStation';
 import { createLogger } from '../utils/logger';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY } from '../constants/storageKeys';
 
 const logger = createLogger('BackgroundLocation');
 
 export const BACKGROUND_LOCATION_TASK = 'background-location-task';
-
-const DESTINATION_KEY = 'subway-now:destination';
-const SLEEP_MODE_KEY = 'subway-now:sleep-mode';
-const FIRED_ALARMS_KEY = 'subway-now:fired-alarms';
 
 TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   if (error) {
@@ -67,7 +64,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
 
     if (alarmEvent) {
       firedAlarms.add(alarmKey(alarmEvent));
-      await AsyncStorage.setItem(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms]));
+      await Promise.all([
+        AsyncStorage.setItem(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms])),
+        AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
+      ]);
     }
 
     logger.info('백그라운드 위치 업데이트 완료:', latitude.toFixed(4), longitude.toFixed(4));

--- a/src/utils/__tests__/alarmSound.test.ts
+++ b/src/utils/__tests__/alarmSound.test.ts
@@ -106,6 +106,31 @@ describe('alarmSound', () => {
       expect(mockSetOnPlaybackStatusUpdate).not.toHaveBeenCalled();
     });
 
+    it('이어폰 연결 + 사운드 재생 실패 시 진동으로 fallback한다', async () => {
+      mockIsHeadphonesConnected.mockReturnValue(true);
+      mockCreateAsync.mockRejectedValueOnce(new Error('audio error'));
+      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
+      await playAlarmWithRouting(false);
+      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], false);
+    });
+
+    it('이어폰 연결 + 사운드 재생 실패 + 취침모드 시 반복 진동한다', async () => {
+      mockIsHeadphonesConnected.mockReturnValue(true);
+      mockCreateAsync.mockRejectedValueOnce(new Error('audio error'));
+      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
+      await playAlarmWithRouting(true);
+      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], true);
+    });
+
+    it('이어폰 연결 + 사운드 재생 실패 + 일반모드 시 5초 후 진동 중지한다', async () => {
+      mockIsHeadphonesConnected.mockReturnValue(true);
+      mockCreateAsync.mockRejectedValueOnce(new Error('audio error'));
+      const cancelSpy = jest.spyOn(Vibration, 'cancel');
+      await playAlarmWithRouting(false);
+      jest.advanceTimersByTime(5000);
+      expect(cancelSpy).toHaveBeenCalled();
+    });
+
     it('재생 전 이전 알람을 정리한다', async () => {
       mockIsHeadphonesConnected.mockReturnValue(true);
       await playAlarmWithRouting(false);

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -1,5 +1,5 @@
 import * as Notifications from 'expo-notifications';
-import { Platform } from 'react-native';
+import { Platform, Vibration } from 'react-native';
 import {
   setupNotificationHandler,
   initStationNotification,
@@ -85,7 +85,7 @@ function expectNotificationContent(title: string, body: string) {
 function expectAlarmNotification(title: string, body: string, extra?: Record<string, unknown>) {
   expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
     identifier: 'station-alarm',
-    content: { title, body, sound: true, ...extra },
+    content: { title, body, sound: 'alarm.wav', ...extra },
     trigger: null,
   });
 }
@@ -484,11 +484,13 @@ describe('stationNotification', () => {
       expectAlarmNotification('역 접근', '곧 역삼에 도착합니다.', { channelId: 'station-alarm', priority: 'max' });
     });
 
-    it('playAlarmWithRouting 실패해도 알림은 정상 예약된다', async () => {
+    it('playAlarmWithRouting 실패 시 알림은 정상 예약되고 진동 안전망이 작동한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       mockPlayAlarmWithRouting.mockRejectedValueOnce(new Error('백그라운드 오디오 실패'));
+      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
       await sendAlarmNotification('destination', '강남');
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000], false);
     });
   });
 

--- a/src/utils/alarmSound.ts
+++ b/src/utils/alarmSound.ts
@@ -23,23 +23,30 @@ export async function playAlarmWithRouting(sleepMode: boolean): Promise<void> {
   });
 
   if (AudioRoute.isHeadphonesConnected()) {
-    const source = sleepMode ? ALARM_SOUND : NOTIFICATION_SOUND;
-    const { sound } = await Audio.Sound.createAsync(source);
-    currentSound = sound;
+    try {
+      const source = sleepMode ? ALARM_SOUND : NOTIFICATION_SOUND;
+      const { sound } = await Audio.Sound.createAsync(source);
+      currentSound = sound;
 
-    if (sleepMode) {
-      await sound.setIsLoopingAsync(true);
-    }
+      if (sleepMode) {
+        await sound.setIsLoopingAsync(true);
+      }
 
-    await sound.playAsync();
+      await sound.playAsync();
 
-    if (!sleepMode) {
-      sound.setOnPlaybackStatusUpdate((status) => {
-        if (status.isLoaded && status.didJustFinish) {
-          sound.unloadAsync();
-          currentSound = null;
-        }
-      });
+      if (!sleepMode) {
+        sound.setOnPlaybackStatusUpdate((status) => {
+          if (status.isLoaded && status.didJustFinish) {
+            sound.unloadAsync();
+            currentSound = null;
+          }
+        });
+      }
+    } catch {
+      Vibration.vibrate(VIBRATION_PATTERN, sleepMode);
+      if (!sleepMode) {
+        setTimeout(() => Vibration.cancel(), VIBRATION_DURATION_MS);
+      }
     }
   } else {
     Vibration.vibrate(VIBRATION_PATTERN, true);

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -1,5 +1,5 @@
 import * as Notifications from 'expo-notifications';
-import { Platform } from 'react-native';
+import { Platform, Vibration } from 'react-native';
 import { Station } from '../types/station';
 import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from './stationRoute';
@@ -18,7 +18,7 @@ const ALARM_CHANNEL_ID = 'station-alarm';
 
 async function scheduleNotification(
   id: string,
-  content: { title: string; body: string; sound?: boolean; channelId?: string; interruptionLevel?: 'timeSensitive' | 'critical'; priority?: Notifications.AndroidNotificationPriority },
+  content: { title: string; body: string; sound?: boolean | string; channelId?: string; interruptionLevel?: 'timeSensitive' | 'critical'; priority?: Notifications.AndroidNotificationPriority },
 ): Promise<void> {
   try {
     await Notifications.dismissNotificationAsync(id);
@@ -256,7 +256,7 @@ export async function sendAlarmNotification(
   await scheduleNotification(ALARM_NOTIFICATION_ID, {
     title,
     body,
-    sound: true,
+    sound: 'alarm.wav',
     ...(Platform.OS === 'android' && {
       channelId: ALARM_CHANNEL_ID,
       priority: Notifications.AndroidNotificationPriority.MAX,
@@ -268,6 +268,7 @@ export async function sendAlarmNotification(
     await playAlarmWithRouting(sleepMode);
   } catch (e) {
     notifLogger.error('알람 사운드 재생 실패 (백그라운드):', e);
+    Vibration.vibrate([0, 1000, 500, 1000], false);
   }
   notifLogger.info('알람 알림:', title, body);
 }


### PR DESCRIPTION
## Summary
- 잠금화면(백그라운드) 상태에서 취침모드 알람 사운드가 재생되지 않는 문제 수정
- 기존: `expo-av`(앱 내부 오디오)에 의존 → 백그라운드에서 작동 불가
- 수정: 시스템 알림이 직접 `alarm.wav` 커스텀 사운드를 재생하도록 변경

## Changes
- `expo-notifications` 플러그인으로 `alarm.wav`를 iOS 번들에 포함
- 시스템 알림 사운드: `sound: true`(기본 딩) → `sound: 'alarm.wav'`(커스텀 알람음)
- 백그라운드 알람 이벤트를 AsyncStorage에 영속화 → 포그라운드 복귀 시 AlarmOverlay 표시
- 이어폰 연결 + 사운드 재생 실패 시 진동 fallback 추가
- AsyncStorage 키 상수 통합 (`storageKeys.ts`), AlarmEvent 타입 단일 소스 통합

## Test plan
- [x] `npm test` — 437개 통과, 커버리지 100%
- [x] `npm run type-check` — 통과
- [x] `expo prebuild` 후 실기기에서 잠금화면 알람 사운드 재생 확인

Closes #108