### PR TITLE
fix(#116): New Architecture 비활성화로 앱 실행 크래시 수정

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Summary
- App Store 심사 리젝(Guideline 2.1a, 5.1.2i) 대응
- `@mj-studio/react-native-naver-map` 제거 → Kakao Maps WebView로 전환
- `newArchEnabled: false`로 TurboModule 브릿지 크래시 해소
- 크래시 원인: `ObjCTurboModule::performVoidMethodInvocation`에서 ObjC 예외 미처리 → SIGABRT
- `alarmSound.ts` catch 블록 에러 로깅 추가

### 변경 파일
- `src/utils/buildMapHtml.ts` (신규) — Kakao Maps HTML 생성
- `src/components/StationMap.tsx` — NaverMapView → WebView + Kakao Maps
- `app/(tabs)/map.tsx` — 외부 링크 네이버→카카오맵 전환
- `app.json` / `package.json` — naver-map 플러그인/의존성 제거, newArchEnabled: false

Closes #116

## Test plan
- [x] `npm test` — 526 tests passed, 커버리지 100%
- [x] `npm run type-check` — 타입 에러 없음
- [x] `npx expo prebuild --clean --platform ios` — 성공
- [ ] EAS 빌드 후 TestFlight 실기기 테스트
- [ ] App Store Connect 프라이버시 설정 수정 (Precise Location → App Functionality)
- [ ] 심사 재제출