### PR TITLE
fix(#116): iPad 크래시 수정 및 E2E 퍼미션 수정

### DIFF
--- a/.maestro/flows/favorites/01_add_favorite.yaml
+++ b/.maestro/flows/favorites/01_add_favorite.yaml
@@ -5,7 +5,7 @@ name: "즐겨찾기 - 추가"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/favorites/02_remove_favorite.yaml
+++ b/.maestro/flows/favorites/02_remove_favorite.yaml
@@ -5,7 +5,7 @@ name: "즐겨찾기 - 삭제"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/home/01_app_launch.yaml
+++ b/.maestro/flows/home/01_app_launch.yaml
@@ -9,7 +9,7 @@ name: "홈 화면 - 앱 실행 및 역 감지"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/home/02_set_destination.yaml
+++ b/.maestro/flows/home/02_set_destination.yaml
@@ -9,7 +9,7 @@ name: "홈 화면 - 목적지 설정"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/home/03_clear_destination.yaml
+++ b/.maestro/flows/home/03_clear_destination.yaml
@@ -9,7 +9,7 @@ name: "홈 화면 - 목적지 초기화"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/home/04_sleep_mode.yaml
+++ b/.maestro/flows/home/04_sleep_mode.yaml
@@ -9,7 +9,7 @@ name: "홈 화면 - 취침 모드 토글"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/location/01_near_station.yaml
+++ b/.maestro/flows/location/01_near_station.yaml
@@ -10,7 +10,7 @@ name: "위치 - 역 근처 (강남역)"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/location/02_no_station_nearby.yaml
+++ b/.maestro/flows/location/02_no_station_nearby.yaml
@@ -10,7 +10,7 @@ name: "위치 - 역에서 먼 곳"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/location/03_station_change.yaml
+++ b/.maestro/flows/location/03_station_change.yaml
@@ -10,7 +10,7 @@ name: "위치 - 역 변경 (강남 → 잠실)"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/.maestro/flows/navigation/01_tab_navigation.yaml
+++ b/.maestro/flows/navigation/01_tab_navigation.yaml
@@ -9,7 +9,7 @@ name: "탭 내비게이션 순회"
     appId: com.subwaynow.app
     clearState: true
     permissions:
-      location: allow
+      location: always
       notifications: allow
 
 - tapOn:

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -1,6 +1,7 @@
 #if canImport(ActivityKit)
 import ActivityKit
 import Foundation
+import UIKit
 
 // 앱 타겟에서의 SubwayActivityAttributes 정의
 // 위젯 타겟의 동일한 구조체와 이름이 일치해야 ActivityKit이 연동됨
@@ -43,6 +44,14 @@ class LiveActivityManager {
 
     func start(data: [String: Any]) async throws {
         await endAllActivities()
+
+        guard UIDevice.current.userInterfaceIdiom != .pad else {
+            throw NSError(
+                domain: "LiveActivity",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "iPad에서는 Live Activity를 지원하지 않습니다"]
+            )
+        }
 
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             throw NSError(

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import UIKit
 #if canImport(ActivityKit)
 import ActivityKit
 #endif
@@ -27,6 +28,9 @@ public class LiveActivityModule: Module {
 
         Function("isLiveActivityEnabled") { () -> Bool in
             if #available(iOS 16.1, *) {
+                guard UIDevice.current.userInterfaceIdiom != .pad else {
+                    return false
+                }
                 return ActivityAuthorizationInfo().areActivitiesEnabled
             }
             return false


### PR DESCRIPTION
## Summary
- iPad에서 `ActivityAuthorizationInfo()` 호출 시 ObjC 예외로 인한 크래시 수정
- `isLiveActivityEnabled()`: iPad일 때 `false` 반환 (iPad은 Lock Screen Live Activities 미지원)
- `start()`: iPad일 때 에러 throw로 안전 차단
- Maestro E2E `location: allow` → `location: always` 수정 (iOS 시뮬레이터 호환)

Closes #116

## Test plan
- [x] `npm test` — 526 tests passed, 커버리지 100%
- [x] `npm run type-check` — 타입 에러 없음
- [x] CI E2E 통과 확인
- [x] EAS 빌드 후 iPad 시뮬레이터 크래시 없이 기동 확인