### PR TITLE
chore: .gitignore 보완 — IDE/도구/임시 파일 제외 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,24 @@ coverage/
 # generated native folders
 /ios
 /android
+
+# IDE
+.idea/
+
+# Claude Code
+.claude/
+
+# Generated coverage temp
+coverage-temp/
+
+# Build artifacts
+*.zip
+
+# Project docs & data (별도 이슈로 관리)
+docs/
+handoff/
+img/
+subway/
+Live\ Activity.md
+oauth-implementation.md
+subway-now_icon.png


### PR DESCRIPTION
## Summary
- `.idea/`, `.claude/`, `coverage-temp/` gitignore 추가
- `*.zip` 빌드 아카이브 제외
- 프로젝트 문서/데이터 (docs/, img/, subway/) 별도 이슈로 관리 예정

## Test plan
- [x] `git status`에서 untracked 파일이 표시되지 않는지 확인