### PR TITLE
feat(#124): 공통 컴포넌트 추출 (ScreenContainer, Card, SectionHeader)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,24 @@ coverage/
 # generated native folders
 /ios
 /android
+
+# IDE
+.idea/
+
+# Claude Code
+.claude/
+
+# Generated coverage temp
+coverage-temp/
+
+# Build artifacts
+*.zip
+
+# Project docs & data (별도 이슈로 관리)
+docs/
+handoff/
+img/
+subway/
+Live\ Activity.md
+oauth-implementation.md
+subway-now_icon.png

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+import { StyleSheet, View, type ViewStyle } from 'react-native';
+import { useTheme, radius, spacing } from '../theme';
+
+interface Props {
+  children: ReactNode;
+  style?: ViewStyle;
+  testID?: string;
+}
+
+export function Card({ children, style, testID }: Props) {
+  const { colors } = useTheme();
+  return (
+    <View style={[styles.card, { backgroundColor: colors.card }, style]} testID={testID}>
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: radius.lg,
+    padding: spacing.xl,
+  },
+});

--- a/src/components/ScreenContainer.tsx
+++ b/src/components/ScreenContainer.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { StyleSheet, type ViewStyle } from 'react-native';
+import { SafeAreaView, type Edge } from 'react-native-safe-area-context';
+import { useTheme } from '../theme';
+
+interface Props {
+  children: ReactNode;
+  edges?: Edge[];
+  style?: ViewStyle;
+  testID?: string;
+}
+
+export function ScreenContainer({ children, edges, style, testID }: Props) {
+  const { colors } = useTheme();
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bg }, style]}
+      edges={edges}
+      testID={testID}
+    >
+      {children}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,26 @@
+import { StyleSheet, Text, type TextStyle } from 'react-native';
+import { useTheme, typography, spacing } from '../theme';
+
+interface Props {
+  label: string;
+  style?: TextStyle;
+  testID?: string;
+}
+
+export function SectionHeader({ label, style, testID }: Props) {
+  const { colors } = useTheme();
+  return (
+    <Text
+      style={[typography.label, styles.header, { color: colors.muted }, style]}
+      testID={testID}
+    >
+      {label}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    marginBottom: spacing.lg,
+  },
+});

--- a/src/components/__tests__/Card.test.tsx
+++ b/src/components/__tests__/Card.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import { Card } from '../Card';
+import { ThemeProvider, lightColors, darkColors } from '../../theme';
+import * as RN from 'react-native';
+
+const mockUseColorScheme = jest.spyOn(RN, 'useColorScheme');
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe('Card', () => {
+  beforeEach(() => {
+    mockUseColorScheme.mockReturnValue('light');
+  });
+
+  afterEach(() => {
+    mockUseColorScheme.mockReset();
+  });
+
+  it('children을 렌더링한다', () => {
+    renderWithTheme(
+      <Card>
+        <Text>카드 내용</Text>
+      </Card>,
+    );
+    expect(screen.getByText('카드 내용')).toBeTruthy();
+  });
+
+  it('라이트 모드에서 배경색이 lightColors.card이다', () => {
+    renderWithTheme(
+      <Card testID="card">
+        <Text>내용</Text>
+      </Card>,
+    );
+    const flat = StyleSheet.flatten(screen.getByTestId('card').props.style);
+    expect(flat.backgroundColor).toBe(lightColors.card);
+  });
+
+  it('다크 모드에서 배경색이 darkColors.card이다', () => {
+    mockUseColorScheme.mockReturnValue('dark');
+    renderWithTheme(
+      <Card testID="card">
+        <Text>내용</Text>
+      </Card>,
+    );
+    const flat = StyleSheet.flatten(screen.getByTestId('card').props.style);
+    expect(flat.backgroundColor).toBe(darkColors.card);
+  });
+
+  it('커스텀 style을 병합한다', () => {
+    renderWithTheme(
+      <Card testID="card" style={{ marginTop: 20 }}>
+        <Text>내용</Text>
+      </Card>,
+    );
+    const flat = StyleSheet.flatten(screen.getByTestId('card').props.style);
+    expect(flat.marginTop).toBe(20);
+  });
+});

--- a/src/components/__tests__/ScreenContainer.test.tsx
+++ b/src/components/__tests__/ScreenContainer.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import { ScreenContainer } from '../ScreenContainer';
+import { ThemeProvider, lightColors, darkColors } from '../../theme';
+import * as RN from 'react-native';
+
+jest.mock('react-native-safe-area-context', () => {
+  const { View } = require('react-native');
+  return { SafeAreaView: View };
+});
+
+const mockUseColorScheme = jest.spyOn(RN, 'useColorScheme');
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe('ScreenContainer', () => {
+  beforeEach(() => {
+    mockUseColorScheme.mockReturnValue('light');
+  });
+
+  afterEach(() => {
+    mockUseColorScheme.mockReset();
+  });
+
+  it('children을 렌더링한다', () => {
+    renderWithTheme(
+      <ScreenContainer>
+        <Text>테스트</Text>
+      </ScreenContainer>,
+    );
+    expect(screen.getByText('테스트')).toBeTruthy();
+  });
+
+  it('라이트 모드에서 배경색이 lightColors.bg이다', () => {
+    renderWithTheme(
+      <ScreenContainer testID="screen">
+        <Text>내용</Text>
+      </ScreenContainer>,
+    );
+    const flat = StyleSheet.flatten(screen.getByTestId('screen').props.style);
+    expect(flat.backgroundColor).toBe(lightColors.bg);
+  });
+
+  it('다크 모드에서 배경색이 darkColors.bg이다', () => {
+    mockUseColorScheme.mockReturnValue('dark');
+    renderWithTheme(
+      <ScreenContainer testID="screen">
+        <Text>내용</Text>
+      </ScreenContainer>,
+    );
+    const flat = StyleSheet.flatten(screen.getByTestId('screen').props.style);
+    expect(flat.backgroundColor).toBe(darkColors.bg);
+  });
+
+  it('커스텀 style을 병합한다', () => {
+    renderWithTheme(
+      <ScreenContainer testID="screen" style={{ paddingTop: 10 }}>
+        <Text>내용</Text>
+      </ScreenContainer>,
+    );
+    const flat = StyleSheet.flatten(screen.getByTestId('screen').props.style);
+    expect(flat.paddingTop).toBe(10);
+  });
+});

--- a/src/components/__tests__/SectionHeader.test.tsx
+++ b/src/components/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import { SectionHeader } from '../SectionHeader';
+import { ThemeProvider, lightColors, darkColors } from '../../theme';
+import * as RN from 'react-native';
+
+const mockUseColorScheme = jest.spyOn(RN, 'useColorScheme');
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe('SectionHeader', () => {
+  beforeEach(() => {
+    mockUseColorScheme.mockReturnValue('light');
+  });
+
+  afterEach(() => {
+    mockUseColorScheme.mockReset();
+  });
+
+  it('라벨 텍스트를 렌더링한다', () => {
+    renderWithTheme(<SectionHeader label="열차 도착 정보" />);
+    expect(screen.getByText('열차 도착 정보')).toBeTruthy();
+  });
+
+  it('라이트 모드에서 색상이 lightColors.muted이다', () => {
+    renderWithTheme(<SectionHeader label="섹션" />);
+    const flat = StyleSheet.flatten(screen.getByText('섹션').props.style);
+    expect(flat.color).toBe(lightColors.muted);
+  });
+
+  it('다크 모드에서 색상이 darkColors.muted이다', () => {
+    mockUseColorScheme.mockReturnValue('dark');
+    renderWithTheme(<SectionHeader label="섹션" />);
+    const flat = StyleSheet.flatten(screen.getByText('섹션').props.style);
+    expect(flat.color).toBe(darkColors.muted);
+  });
+
+  it('uppercase 스타일이 적용된다', () => {
+    renderWithTheme(<SectionHeader label="섹션" />);
+    const flat = StyleSheet.flatten(screen.getByText('섹션').props.style);
+    expect(flat.textTransform).toBe('uppercase');
+  });
+
+  it('커스텀 style을 병합한다', () => {
+    renderWithTheme(<SectionHeader label="섹션" style={{ fontSize: 18 }} />);
+    const flat = StyleSheet.flatten(screen.getByText('섹션').props.style);
+    expect(flat.fontSize).toBe(18);
+  });
+});


### PR DESCRIPTION
## Summary
- `ScreenContainer` — SafeAreaView + flex:1 + 테마 배경색 래퍼 (6곳 반복 패턴 추출)
- `Card` — borderRadius + padding + 테마 카드 배경색 래퍼 (4곳 반복 패턴 추출)
- `SectionHeader` — uppercase 라벨 + muted 색상 (4곳 반복 패턴 추출)
- 모든 컴포넌트 `useTheme()`으로 동적 색상 참조 → 라이트/다크 자동 전환

## 후속 작업
컴포넌트 정의만 포함. 기존 탭 화면에서 사용 교체는 #126, #127에서 진행.

## Test plan
- [x] `npm test` — 43 suites, 550 tests 통과
- [x] 커버리지 100%
- [x] `npm run type-check` 통과

Closes #124