### PR TITLE
refactor(#126): 탭 화면 다크 하드코딩 제거 → useTheme() 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,24 @@ coverage/
 # generated native folders
 /ios
 /android
+
+# IDE
+.idea/
+
+# Claude Code
+.claude/
+
+# Generated coverage temp
+coverage-temp/
+
+# Build artifacts
+*.zip
+
+# Project docs & data (별도 이슈로 관리)
+docs/
+handoff/
+img/
+subway/
+Live\ Activity.md
+oauth-implementation.md
+subway-now_icon.png

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,8 +1,9 @@
 import { Tabs } from 'expo-router';
 import { Text } from 'react-native';
-import { colors } from '../../src/theme';
+import { useTheme } from '../../src/theme';
 
 export default function TabsLayout() {
+  const { colors } = useTheme();
   return (
     <Tabs
       screenOptions={{

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
-  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -8,12 +7,14 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppStore } from '../../src/store/useAppStore';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { Station } from '../../src/types/station';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../../src/utils/formatTime';
+import { useTheme, type ThemeColors } from '../../src/theme';
 import stationsData from '../../src/data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -25,6 +26,7 @@ export default function FavoritesScreen() {
   const loadFavorites = useAppStore((s) => s.loadFavorites);
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const { colors } = useTheme();
 
   useEffect(() => {
     loadFavorites();
@@ -50,14 +52,14 @@ export default function FavoritesScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
       <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
-        <Text style={styles.header}>즐겨찾기</Text>
+        <Text style={[styles.header, { color: colors.muted }]}>즐겨찾기</Text>
 
         <TextInput
-          style={styles.searchInput}
+          style={[styles.searchInput, { backgroundColor: colors.card, color: colors.ink, borderColor: colors.hair }]}
           placeholder="역 이름 검색..."
-          placeholderTextColor="#8888aa"
+          placeholderTextColor={colors.muted}
           value={query}
           onChangeText={setQuery}
           testID="favorites-search-input"
@@ -66,7 +68,7 @@ export default function FavoritesScreen() {
         {isSearching ? (
           searchResults.length === 0 ? (
             <View style={styles.empty}>
-              <Text style={styles.emptyTitle}>검색 결과가 없습니다</Text>
+              <Text style={[styles.emptyTitle, { color: colors.ink }]}>검색 결과가 없습니다</Text>
             </View>
           ) : (
             searchResults.map((station) => (
@@ -75,14 +77,15 @@ export default function FavoritesScreen() {
                 station={station}
                 already={favorites.some((f) => f.id === station.id)}
                 onAdd={() => addFavorite(station)}
+                colors={colors}
               />
             ))
           )
         ) : favorites.length === 0 ? (
           <View style={styles.empty} testID="favorites-empty">
             <Text style={styles.emptyIcon}>⭐</Text>
-            <Text style={styles.emptyTitle}>즐겨찾기가 없습니다</Text>
-            <Text style={styles.emptySubtitle}>
+            <Text style={[styles.emptyTitle, { color: colors.ink }]}>즐겨찾기가 없습니다</Text>
+            <Text style={[styles.emptySubtitle, { color: colors.muted }]}>
               위 검색창에서 역을 검색해 즐겨찾기에{'\n'}추가할 수 있습니다.
             </Text>
           </View>
@@ -98,6 +101,7 @@ export default function FavoritesScreen() {
                 if (selectedId === station.id) setSelectedId(null);
                 removeFavorite(station.id);
               }}
+              colors={colors}
             />
           ))
         )}
@@ -110,26 +114,28 @@ function SearchResultCard({
   station,
   already,
   onAdd,
+  colors,
 }: {
   station: Station;
   already: boolean;
   onAdd: () => void;
+  colors: ThemeColors;
 }) {
   return (
-    <View style={[styles.card, { borderLeftColor: station.lineColor }]}>
+    <View style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}>
       <View style={styles.cardInfo}>
         <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
           <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
         </View>
-        <Text style={styles.stationName}>{station.name}</Text>
+        <Text style={[styles.stationName, { color: colors.ink }]}>{station.name}</Text>
       </View>
       <TouchableOpacity
-        style={[styles.addButton, already && styles.addButtonDisabled]}
+        style={[styles.addButton, { backgroundColor: colors.accent }, already && { backgroundColor: colors.hair }]}
         onPress={onAdd}
         disabled={already}
         testID={`favorite-add-${station.id}`}
       >
-        <Text style={styles.addButtonText}>{already ? '✓' : '+'}</Text>
+        <Text style={[styles.addButtonText, { color: already ? colors.muted : colors.onAccent }]}>{already ? '✓' : '+'}</Text>
       </TouchableOpacity>
     </View>
   );
@@ -141,46 +147,48 @@ function FavoriteCard({
   arrival,
   onToggle,
   onRemove,
+  colors,
 }: {
   station: Station;
   isExpanded: boolean;
   arrival: { up: { destination: string; arrivalSeconds: number; statusMessage: string }[]; down: { destination: string; arrivalSeconds: number; statusMessage: string }[] } | null;
   onToggle: () => void;
   onRemove: () => void;
+  colors: ThemeColors;
 }) {
   return (
-    <View style={[styles.card, { borderLeftColor: station.lineColor }]}>
+    <View style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}>
       <TouchableOpacity style={styles.cardMain} onPress={onToggle} activeOpacity={0.7}>
         <View style={styles.cardInfo}>
           <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
             <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
           </View>
-          <Text style={styles.stationName}>{station.name}</Text>
+          <Text style={[styles.stationName, { color: colors.ink }]}>{station.name}</Text>
         </View>
         <View style={styles.cardActions}>
-          <Text style={styles.expandIcon}>{isExpanded ? '▲' : '▼'}</Text>
-          <TouchableOpacity style={styles.removeButton} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
+          <Text style={[styles.expandIcon, { color: colors.muted }]}>{isExpanded ? '▲' : '▼'}</Text>
+          <TouchableOpacity style={[styles.removeButton, { backgroundColor: colors.card }]} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
             <Text style={styles.removeText}>삭제</Text>
           </TouchableOpacity>
         </View>
       </TouchableOpacity>
 
       {isExpanded && (
-        <View style={styles.arrivalSection}>
+        <View style={[styles.arrivalSection, { borderTopColor: colors.hair }]}>
           {arrival ? (
             <>
               {arrival.up.length > 0 && (
-                <ArrivalRow label="상행" items={arrival.up} />
+                <ArrivalRow label="상행" items={arrival.up} colors={colors} />
               )}
               {arrival.down.length > 0 && (
-                <ArrivalRow label="하행" items={arrival.down} />
+                <ArrivalRow label="하행" items={arrival.down} colors={colors} />
               )}
               {arrival.up.length === 0 && arrival.down.length === 0 && (
-                <Text style={styles.noArrival}>도착 정보 없음</Text>
+                <Text style={[styles.noArrival, { color: colors.muted }]}>도착 정보 없음</Text>
               )}
             </>
           ) : (
-            <Text style={styles.noArrival}>불러오는 중...</Text>
+            <Text style={[styles.noArrival, { color: colors.muted }]}>불러오는 중...</Text>
           )}
         </View>
       )}
@@ -191,22 +199,24 @@ function FavoriteCard({
 function ArrivalRow({
   label,
   items,
+  colors,
 }: {
   label: string;
   items: { destination: string; arrivalSeconds: number; statusMessage: string }[];
+  colors: ThemeColors;
 }) {
   return (
     <View style={styles.arrivalRow}>
-      <Text style={styles.arrivalLabel}>{label}</Text>
+      <Text style={[styles.arrivalLabel, { color: colors.subtle }]}>{label}</Text>
       <View>
         {items.map((item, idx) => (
           <View key={idx}>
-            <Text style={styles.arrivalItem}>
+            <Text style={[styles.arrivalItem, { color: colors.ink }]}>
               {item.destination ? `${item.destination} · ` : ''}
               {formatArrivalTime(item.arrivalSeconds)}
             </Text>
             {item.statusMessage !== '' && (
-              <Text style={styles.statusMessage}>{item.statusMessage}</Text>
+              <Text style={[styles.statusMessage, { color: colors.accent }]}>{item.statusMessage}</Text>
             )}
           </View>
         ))}
@@ -218,7 +228,6 @@ function ArrivalRow({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a2e',
   },
   scroll: {
     padding: 24,
@@ -226,21 +235,17 @@ const styles = StyleSheet.create({
   },
   header: {
     fontSize: 14,
-    color: '#8888aa',
     marginBottom: 16,
     letterSpacing: 2,
     textTransform: 'uppercase',
   },
   searchInput: {
-    backgroundColor: '#16213e',
     borderRadius: 10,
     paddingHorizontal: 16,
     paddingVertical: 12,
-    color: '#ffffff',
     fontSize: 15,
     marginBottom: 16,
     borderWidth: 1,
-    borderColor: '#2a2a4a',
   },
   empty: {
     flex: 1,
@@ -255,17 +260,14 @@ const styles = StyleSheet.create({
   emptyTitle: {
     fontSize: 18,
     fontWeight: '700',
-    color: '#ffffff',
     marginBottom: 8,
   },
   emptySubtitle: {
     fontSize: 14,
-    color: '#8888aa',
     textAlign: 'center',
     lineHeight: 22,
   },
   card: {
-    backgroundColor: '#16213e',
     borderRadius: 12,
     borderLeftWidth: 5,
     marginBottom: 12,
@@ -286,7 +288,6 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   expandIcon: {
-    color: '#8888aa',
     fontSize: 12,
   },
   badge: {
@@ -297,20 +298,18 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   badgeText: {
-    color: '#ffffff',
+    color: '#ffffff', // 노선색(lineColor) 배경은 항상 진한색 — 흰 텍스트 유지
     fontSize: 12,
     fontWeight: '700',
   },
   stationName: {
     fontSize: 20,
     fontWeight: '700',
-    color: '#ffffff',
   },
   removeButton: {
     paddingHorizontal: 14,
     paddingVertical: 8,
     borderRadius: 8,
-    backgroundColor: '#2a2a4a',
   },
   removeText: {
     color: '#ff6b6b',
@@ -321,22 +320,16 @@ const styles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: '#0052A4',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  addButtonDisabled: {
-    backgroundColor: '#2a2a4a',
-  },
   addButtonText: {
-    color: '#ffffff',
     fontSize: 18,
     fontWeight: '700',
     lineHeight: 20,
   },
   arrivalSection: {
     borderTopWidth: 1,
-    borderTopColor: '#2a2a4a',
     padding: 16,
   },
   arrivalRow: {
@@ -347,24 +340,20 @@ const styles = StyleSheet.create({
   },
   arrivalLabel: {
     fontSize: 14,
-    color: '#aaaacc',
     fontWeight: '600',
   },
   arrivalItem: {
     fontSize: 14,
-    color: '#ffffff',
     textAlign: 'right',
   },
   statusMessage: {
     fontSize: 11,
-    color: '#a78bfa',
     textAlign: 'right',
     marginTop: 1,
     marginBottom: 2,
   },
   noArrival: {
     fontSize: 13,
-    color: '#8888aa',
     textAlign: 'center',
     paddingVertical: 4,
   },

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -5,6 +5,7 @@ import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useMapData } from '../../src/hooks/useMapData';
 import { StationMap } from '../../src/components/StationMap';
 import { buildKakaoMapAppUrl, buildKakaoMapWebUrl } from '../../src/utils/kakaoMapLink';
+import { useTheme } from '../../src/theme';
 
 export default function MapScreen() {
   const { userLocation, result, loading, error, permissionDenied, refresh } =
@@ -13,6 +14,7 @@ export default function MapScreen() {
     userLocation?.lat ?? null,
     userLocation?.lng ?? null
   );
+  const { colors } = useTheme();
 
   const openInKakaoMap = async () => {
     if (!userLocation) return;
@@ -27,11 +29,11 @@ export default function MapScreen() {
 
   if (permissionDenied) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={styles.message}>위치 권한이 필요합니다.</Text>
-          <TouchableOpacity style={styles.button} onPress={refresh}>
-            <Text style={styles.buttonText}>권한 요청</Text>
+          <Text style={[styles.message, { color: colors.muted }]}>위치 권한이 필요합니다.</Text>
+          <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>권한 요청</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -40,9 +42,9 @@ export default function MapScreen() {
 
   if (loading || !userLocation) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={styles.message}>위치 확인 중...</Text>
+          <Text style={[styles.message, { color: colors.muted }]}>위치 확인 중...</Text>
         </View>
       </SafeAreaView>
     );
@@ -50,11 +52,11 @@ export default function MapScreen() {
 
   if (error) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={styles.message}>{error}</Text>
-          <TouchableOpacity style={styles.button} onPress={refresh}>
-            <Text style={styles.buttonText}>다시 시도</Text>
+          <Text style={[styles.message, { color: colors.muted }]}>{error}</Text>
+          <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>다시 시도</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -62,7 +64,7 @@ export default function MapScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['top']}>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top']}>
       <StationMap
         userLat={userLocation.lat}
         userLng={userLocation.lng}
@@ -79,7 +81,6 @@ export default function MapScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a2e',
   },
   center: {
     flex: 1,
@@ -88,19 +89,16 @@ const styles = StyleSheet.create({
     padding: 24,
   },
   message: {
-    color: '#8888aa',
     fontSize: 16,
     marginBottom: 16,
     textAlign: 'center',
   },
   button: {
-    backgroundColor: '#4a4a8a',
     paddingHorizontal: 24,
     paddingVertical: 12,
     borderRadius: 8,
   },
   buttonText: {
-    color: '#ffffff',
     fontSize: 16,
   },
   kakaoButton: {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -2,35 +2,37 @@ import { useEffect } from 'react';
 import { StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppStore } from '../../src/store/useAppStore';
+import { useTheme } from '../../src/theme';
 
 export default function SettingsScreen() {
   const sleepMode = useAppStore((s) => s.sleepMode);
   const setSleepMode = useAppStore((s) => s.setSleepMode);
   const loadSleepMode = useAppStore((s) => s.loadSleepMode);
+  const { colors } = useTheme();
 
   useEffect(() => {
     loadSleepMode();
   }, []);
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Text style={styles.header}>설정</Text>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <Text style={[styles.header, { color: colors.muted }]}>설정</Text>
 
-      <View style={styles.card}>
-        <Text style={styles.sectionTitle}>알람</Text>
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.sectionTitle, { color: colors.muted }]}>알람</Text>
 
         <View style={styles.settingRow}>
           <View style={styles.settingInfo}>
-            <Text style={styles.settingLabel}>취침 모드</Text>
-            <Text style={styles.settingDesc}>
+            <Text style={[styles.settingLabel, { color: colors.ink }]}>취침 모드</Text>
+            <Text style={[styles.settingDesc, { color: colors.muted }]}>
               이어폰 연결 시 기상 알람음으로 울립니다
             </Text>
           </View>
           <Switch
             value={sleepMode}
             onValueChange={setSleepMode}
-            trackColor={{ false: '#2a2a4a', true: '#a78bfa' }}
-            thumbColor={sleepMode ? '#ffffff' : '#666688'}
+            trackColor={{ false: colors.hair, true: colors.accent }}
+            thumbColor={sleepMode ? colors.onAccent : colors.subtle}
             testID="sleep-mode-switch"
           />
         </View>
@@ -42,25 +44,21 @@ export default function SettingsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a2e',
   },
   header: {
     fontSize: 14,
-    color: '#8888aa',
     letterSpacing: 2,
     textTransform: 'uppercase',
     padding: 24,
     paddingBottom: 16,
   },
   card: {
-    backgroundColor: '#16213e',
     borderRadius: 16,
     padding: 20,
     marginHorizontal: 24,
   },
   sectionTitle: {
     fontSize: 14,
-    color: '#8888aa',
     letterSpacing: 1,
     textTransform: 'uppercase',
     marginBottom: 16,
@@ -76,13 +74,11 @@ const styles = StyleSheet.create({
   },
   settingLabel: {
     fontSize: 16,
-    color: '#ffffff',
     fontWeight: '600',
     marginBottom: 4,
   },
   settingDesc: {
     fontSize: 13,
-    color: '#8888aa',
     lineHeight: 18,
   },
 });


### PR DESCRIPTION
## Summary
- `_layout.tsx` — 정적 `colors` import → `useTheme()` 동적 참조
- `settings.tsx` — 6개 하드코딩(#1a1a2e, #16213e, #8888aa, #2a2a4a, #a78bfa, #666688) → 테마 토큰
- `map.tsx` — 6개 하드코딩 → 테마 토큰 (카카오 브랜드색 #FEE500, #191919 유지)
- `favorites.tsx` — 15+ 하드코딩 → 테마 토큰, SafeAreaView import 소스 교정

## 의도적으로 남긴 하드코딩
- `#FEE500`, `#191919` — 카카오 브랜드색
- `#ff6b6b` — 삭제 버튼 danger 색상 (양쪽 테마 동일)
- `#ffffff` — 노선 배지 텍스트 (lineColor 배경 위, 항상 흰색)
- `index.tsx` 하드코딩 → #127에서 처리

## Test plan
- [x] `npm test` — 43 suites, 550 tests 통과
- [x] 커버리지 100%
- [x] `npm run type-check` 통과

Closes #126