### PR TITLE
refactor(#133): 정적 colors import → useTheme() 전환 (홈 + 컴포넌트 7개)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,24 @@ coverage/
 # generated native folders
 /ios
 /android
+
+# IDE
+.idea/
+
+# Claude Code
+.claude/
+
+# Generated coverage temp
+coverage-temp/
+
+# Build artifacts
+*.zip
+
+# Project docs & data (별도 이슈로 관리)
+docs/
+handoff/
+img/
+subway/
+Live\ Activity.md
+oauth-implementation.md
+subway-now_icon.png

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -16,12 +16,13 @@ import { useStationAlarm } from '../../src/hooks/useStationAlarm';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
-import { colors, typography, spacing, radius } from '../../src/theme';
+import { useTheme, typography, spacing, radius } from '../../src/theme';
 import { LineBadge } from '../../src/components/LineBadge';
 
 const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
+  const { colors } = useTheme();
   const { result, userLocation, loading, error, permissionDenied, refresh } = useNearestStation();
   const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(result?.station.name ?? null);
   const arrival = useArrivalCountdown(rawArrival);
@@ -169,15 +170,15 @@ export default function HomeScreen() {
 
   if (permissionDenied) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
           <Text style={styles.icon}>📍</Text>
-          <Text style={styles.title}>위치 권한 필요</Text>
-          <Text style={styles.subtitle}>
+          <Text style={[styles.title, { color: colors.ink }]}>위치 권한 필요</Text>
+          <Text style={[styles.subtitle, { color: colors.muted }]}>
             설정에서 위치 권한을 허용해 주세요.{'\n'}현재 탑승 중인 역을 감지하려면{'\n'}위치 권한이 필요합니다.
           </Text>
-          <TouchableOpacity style={styles.button} onPress={refresh}>
-            <Text style={styles.buttonText}>다시 시도</Text>
+          <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>다시 시도</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -186,9 +187,9 @@ export default function HomeScreen() {
 
   if (loading) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={styles.loadingText}>위치 확인 중...</Text>
+          <Text style={[styles.loadingText, { color: colors.muted }]}>위치 확인 중...</Text>
         </View>
       </SafeAreaView>
     );
@@ -196,11 +197,11 @@ export default function HomeScreen() {
 
   if (error) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={styles.errorText}>{error}</Text>
-          <TouchableOpacity style={styles.button} onPress={refresh}>
-            <Text style={styles.buttonText}>새로고침</Text>
+          <Text style={[styles.errorText, { color: colors.accent }]}>{error}</Text>
+          <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>새로고침</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -210,7 +211,7 @@ export default function HomeScreen() {
   const nearest = result ? nearestResultToNearest(result) : null;
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
       {arrivedBanner && (
         <View style={styles.arrivedBanner} testID="arrived-banner">
           <Text style={styles.arrivedBannerText}>도착!</Text>
@@ -300,7 +301,7 @@ export default function HomeScreen() {
                       목적지 변경 →
                     </Text>
                   </Pressable>
-                  <View style={styles.vHair} />
+                  <View style={[styles.vHair, { backgroundColor: colors.hair }]} />
                   <Pressable onPress={() => setDestination(null)} testID="destination-clear-button">
                     <Text style={[typography.bodySm, { color: colors.muted }]}>초기화</Text>
                   </Pressable>
@@ -336,13 +337,13 @@ export default function HomeScreen() {
               <View style={{ paddingHorizontal: spacing.xxl, paddingVertical: spacing.xxl }}>
                 {recentDestination && (
                   <TouchableOpacity
-                    style={styles.recentDestinationButton}
+                    style={[styles.recentDestinationButton, { borderColor: colors.accent }]}
                     onPress={() => setDestination(recentDestination)}
                     testID="recent-destination-button"
                   >
-                    <Text style={styles.recentDestinationLabel}>이전 목적지</Text>
+                    <Text style={[styles.recentDestinationLabel, { color: colors.accent }]}>이전 목적지</Text>
                     <View style={styles.recentDestinationRow}>
-                      <Text style={styles.recentDestinationName}>{recentDestination.name}</Text>
+                      <Text style={[styles.recentDestinationName, { color: colors.ink }]}>{recentDestination.name}</Text>
                       <View style={[styles.recentLineBadge, { backgroundColor: recentDestination.lineColor }]}>
                         <Text style={styles.recentLineText}>{LINE_NAMES[recentDestination.line]}</Text>
                       </View>
@@ -350,23 +351,23 @@ export default function HomeScreen() {
                   </TouchableOpacity>
                 )}
                 <TouchableOpacity
-                  style={styles.destinationButton}
+                  style={[styles.destinationButton, { backgroundColor: colors.accent }]}
                   onPress={() => setPickerVisible(true)}
                   testID="destination-button"
                 >
-                  <Text style={styles.destinationButtonText}>목적지 설정</Text>
+                  <Text style={[styles.destinationButtonText, { color: colors.onAccent }]}>목적지 설정</Text>
                 </TouchableOpacity>
               </View>
             )}
 
             {/* Arrivals — 기존 상행/하행 포맷 유지 */}
-            <View style={styles.arrivalSection}>
-              <Text style={styles.sectionTitle}>열차 도착 정보</Text>
+            <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
+              <Text style={[styles.sectionTitle, { color: colors.muted }]}>열차 도착 정보</Text>
               {arrivalLoading && !arrival && (
-                <Text style={styles.arrivalItem}>불러오는 중...</Text>
+                <Text style={[styles.arrivalItem, { color: colors.ink }]}>불러오는 중...</Text>
               )}
               {arrivalIsMock && (
-                <Text style={styles.mockNotice}>실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다</Text>
+                <Text style={[styles.mockNotice, { color: colors.warn }]}>실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다</Text>
               )}
               {arrival && (
                 <>
@@ -379,10 +380,10 @@ export default function HomeScreen() {
         ) : (
           <View style={styles.center}>
             <Text style={styles.icon}>🚶</Text>
-            <Text style={styles.title}>지하철역 근처가 아닙니다</Text>
-            <Text style={styles.subtitle}>지하철역 500m 이내에 있을 때{'\n'}현재 역이 표시됩니다.</Text>
-            <TouchableOpacity style={styles.button} onPress={refresh}>
-              <Text style={styles.buttonText}>새로고침</Text>
+            <Text style={[styles.title, { color: colors.ink }]}>지하철역 근처가 아닙니다</Text>
+            <Text style={[styles.subtitle, { color: colors.muted }]}>지하철역 500m 이내에 있을 때{'\n'}현재 역이 표시됩니다.</Text>
+            <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+              <Text style={[styles.buttonText, { color: colors.onAccent }]}>새로고침</Text>
             </TouchableOpacity>
           </View>
         )}
@@ -415,21 +416,22 @@ function ArrivalRow({
   label: string;
   items: { destination: string; arrivalSeconds: number; statusMessage: string }[];
 }) {
+  const { colors } = useTheme();
   return (
-    <View style={styles.arrivalRow}>
-      <Text style={styles.arrivalLabel}>{label}</Text>
+    <View style={[styles.arrivalRow, { borderTopColor: colors.hair }]}>
+      <Text style={[styles.arrivalLabel, { color: colors.muted }]}>{label}</Text>
       <View>
         {items.length === 0 ? (
-          <Text style={styles.arrivalItem}>도착 정보 없음</Text>
+          <Text style={[styles.arrivalItem, { color: colors.ink }]}>도착 정보 없음</Text>
         ) : (
           items.map((item, idx) => (
             <View key={idx} style={styles.arrivalItemContainer}>
-              <Text style={styles.arrivalItem}>
+              <Text style={[styles.arrivalItem, { color: colors.ink }]}>
                 {item.destination ? `${item.destination} · ` : ''}
                 {formatArrivalTime(item.arrivalSeconds)}
               </Text>
               {item.statusMessage !== '' && (
-                <Text style={styles.statusMessage}>{item.statusMessage}</Text>
+                <Text style={[styles.statusMessage, { color: colors.accent }]}>{item.statusMessage}</Text>
               )}
             </View>
           ))
@@ -439,13 +441,18 @@ function ArrivalRow({
   );
 }
 
-const Dot = () => <Text style={{ color: colors.subtle }}>·</Text>;
-const Hr  = () => <View style={{ height: 1, backgroundColor: colors.hair, marginHorizontal: spacing.xxl }} />;
+function Dot() {
+  const { colors } = useTheme();
+  return <Text style={{ color: colors.subtle }}>·</Text>;
+}
+function Hr() {
+  const { colors } = useTheme();
+  return <View style={{ height: 1, backgroundColor: colors.hair, marginHorizontal: spacing.xxl }} />;
+}
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bg,
   },
   arrivedBanner: {
     backgroundColor: '#22c55e',
@@ -488,7 +495,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.xxl,
     paddingTop: spacing.sm,
   },
-  vHair: { width: 1, height: 12, backgroundColor: colors.hair },
+  vHair: { width: 1, height: 12 },
   sleepRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -498,14 +505,12 @@ const styles = StyleSheet.create({
   },
   recentDestinationButton: {
     borderWidth: 1,
-    borderColor: colors.accent,
     borderRadius: radius.md,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
     marginBottom: spacing.sm,
   },
   recentDestinationLabel: {
-    color: colors.accent,
     fontSize: 11,
     fontWeight: '600',
     letterSpacing: 0.5,
@@ -517,7 +522,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   recentDestinationName: {
-    color: colors.ink,
     fontSize: 16,
     fontWeight: '700',
   },
@@ -532,13 +536,11 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   destinationButton: {
-    backgroundColor: colors.accent,
     borderRadius: radius.md,
     paddingVertical: 10,
     alignItems: 'center',
   },
   destinationButtonText: {
-    color: colors.onAccent,
     fontSize: 15,
     fontWeight: '700',
   },
@@ -547,12 +549,10 @@ const styles = StyleSheet.create({
     marginTop: spacing.xl,
     paddingVertical: spacing.xl,
     paddingHorizontal: spacing.xl,
-    backgroundColor: colors.card,
     borderRadius: radius.lg,
   },
   sectionTitle: {
     fontSize: 14,
-    color: colors.muted,
     marginBottom: spacing.lg,
     letterSpacing: 1,
     textTransform: 'uppercase',
@@ -563,11 +563,9 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     paddingVertical: 10,
     borderTopWidth: 1,
-    borderTopColor: colors.hair,
   },
   arrivalLabel: {
     fontSize: 15,
-    color: colors.muted,
     fontWeight: '600',
   },
   arrivalItemContainer: {
@@ -575,18 +573,15 @@ const styles = StyleSheet.create({
   },
   arrivalItem: {
     fontSize: 15,
-    color: colors.ink,
     textAlign: 'right',
   },
   statusMessage: {
     fontSize: 12,
-    color: colors.accent,
     textAlign: 'right',
     marginTop: 2,
   },
   mockNotice: {
     fontSize: 12,
-    color: colors.warn,
     marginBottom: 8,
   },
   icon: {
@@ -596,34 +591,28 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 22,
     fontWeight: '700',
-    color: colors.ink,
     marginBottom: 12,
     textAlign: 'center',
   },
   subtitle: {
     fontSize: 15,
-    color: colors.muted,
     textAlign: 'center',
     lineHeight: 22,
     marginBottom: 24,
   },
   loadingText: {
     fontSize: 16,
-    color: colors.muted,
   },
   errorText: {
     fontSize: 16,
-    color: colors.accent,
     marginBottom: 16,
   },
   button: {
-    backgroundColor: colors.accent,
     paddingHorizontal: 28,
     paddingVertical: 14,
     borderRadius: radius.lg,
   },
   buttonText: {
-    color: colors.onAccent,
     fontSize: 15,
     fontWeight: '700',
   },

--- a/src/components/AlarmOverlay.tsx
+++ b/src/components/AlarmOverlay.tsx
@@ -1,7 +1,7 @@
 import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { AlarmEvent } from '../store/useAppStore';
 import { clearAlarmNotification } from '../utils/stationNotification';
-import { colors, typography, spacing, radius } from '../theme';
+import { useTheme, typography, spacing, radius } from '../theme';
 
 interface AlarmOverlayProps {
   event: AlarmEvent;
@@ -14,6 +14,7 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
   const message = isTransfer
     ? `${event.stationName}에서\n환승하세요`
     : `${event.stationName}에서\n내리세요`;
+  const { colors } = useTheme();
 
   const handleDismiss = async () => {
     await clearAlarmNotification();
@@ -22,16 +23,16 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
 
   return (
     <Modal visible animationType="fade" testID="alarm-overlay" onRequestClose={handleDismiss}>
-      <View style={styles.container}>
-        <Text style={styles.title}>{title}</Text>
-        <Text style={styles.station}>{message}</Text>
+      <View style={[styles.container, { backgroundColor: colors.bg }]}>
+        <Text style={[styles.title, { color: colors.accent }]}>{title}</Text>
+        <Text style={[styles.station, { color: colors.ink }]}>{message}</Text>
         <TouchableOpacity
-          style={styles.button}
+          style={[styles.button, { backgroundColor: colors.accent }]}
           onPress={handleDismiss}
           testID="alarm-dismiss-button"
           activeOpacity={0.7}
         >
-          <Text style={styles.buttonText}>알람 끄기</Text>
+          <Text style={[styles.buttonText, { color: colors.onAccent }]}>알람 끄기</Text>
         </TouchableOpacity>
       </View>
     </Modal>
@@ -41,7 +42,6 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bg,
     alignItems: 'center',
     justifyContent: 'center',
     padding: spacing.xxxl,
@@ -49,26 +49,22 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: '700',
-    color: colors.accent,
     marginBottom: spacing.xxl,
     letterSpacing: 2,
   },
   station: {
     fontSize: 48,
     fontWeight: '900',
-    color: colors.ink,
     textAlign: 'center',
     lineHeight: 64,
     marginBottom: 64,
   },
   button: {
-    backgroundColor: colors.accent,
     paddingHorizontal: 64,
     paddingVertical: spacing.xxl,
     borderRadius: radius.pill,
   },
   buttonText: {
-    color: colors.onAccent,
     fontSize: 28,
     fontWeight: '800',
   },

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -12,7 +12,7 @@ import type { Station } from '../types/station';
 import { LINE_NAMES } from '../constants/lineColors';
 import { StationMap } from './StationMap';
 import { createLogger } from '../utils/logger';
-import { colors, spacing, radius } from '../theme';
+import { useTheme, spacing, radius } from '../theme';
 
 const logger = createLogger('DestinationPicker');
 
@@ -39,6 +39,7 @@ export function DestinationPicker({
   const [query, setQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const openTimeRef = useRef<number | null>(null);
+  const { colors } = useTheme();
 
   useEffect(() => {
     if (visible) {
@@ -80,7 +81,7 @@ export function DestinationPicker({
 
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={handleClose}>
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor: colors.bg }]}>
         {mapAvailable && userLat && userLng ? (
           <StationMap
             userLat={userLat}
@@ -91,21 +92,21 @@ export function DestinationPicker({
           />
         ) : (
           <View style={styles.mapFallback} testID="map-fallback">
-            <Text style={styles.mapFallbackText}>
+            <Text style={[styles.mapFallbackText, { color: colors.muted }]}>
               위치 정보가 없습니다.
             </Text>
           </View>
         )}
 
         <View style={styles.overlay} pointerEvents="box-none">
-          <View style={styles.header}>
-            <Text style={styles.title}>목적지 설정</Text>
+          <View style={[styles.header, { backgroundColor: colors.overlay }]}>
+            <Text style={[styles.title, { color: colors.ink }]}>목적지 설정</Text>
             <TouchableOpacity onPress={handleClose} testID="close-button">
-              <Text style={styles.closeText}>닫기</Text>
+              <Text style={[styles.closeText, { color: colors.accent }]}>닫기</Text>
             </TouchableOpacity>
           </View>
           <TextInput
-            style={styles.input}
+            style={[styles.input, { backgroundColor: colors.card, color: colors.ink, borderColor: colors.hair }]}
             placeholder="역 이름 검색"
             placeholderTextColor={colors.subtle}
             value={query}
@@ -117,15 +118,15 @@ export function DestinationPicker({
             testID="search-input"
           />
           {showDropdown && suggestions.length > 0 && (
-            <View style={styles.dropdown} testID="suggestions-list">
+            <View style={[styles.dropdown, { backgroundColor: colors.card, borderColor: colors.hair }]} testID="suggestions-list">
               {suggestions.map((s) => (
                 <TouchableOpacity
                   key={s.id}
-                  style={styles.suggestionItem}
+                  style={[styles.suggestionItem, { borderBottomColor: colors.hair }]}
                   onPress={() => handleSelect(s)}
                   testID={`suggestion-item-${s.id}`}
                 >
-                  <Text style={styles.suggestionName}>{s.name}</Text>
+                  <Text style={[styles.suggestionName, { color: colors.ink }]}>{s.name}</Text>
                   <View style={[styles.lineBadge, { backgroundColor: s.lineColor }]}>
                     <Text style={styles.lineText}>{LINE_NAMES[s.line]}</Text>
                   </View>
@@ -142,7 +143,6 @@ export function DestinationPicker({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bg,
   },
   mapFallback: {
     flex: 1,
@@ -151,7 +151,6 @@ const styles = StyleSheet.create({
     padding: spacing.xxl,
   },
   mapFallbackText: {
-    color: colors.muted,
     fontSize: 14,
     textAlign: 'center',
   },
@@ -168,36 +167,28 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.xl,
     paddingTop: 50,
     paddingBottom: spacing.md,
-    backgroundColor: 'rgba(245, 242, 236, 0.92)',
   },
   title: {
-    color: colors.ink,
     fontSize: 20,
     fontWeight: 'bold',
   },
   closeText: {
-    color: colors.accent,
     fontSize: 16,
   },
   input: {
-    backgroundColor: colors.card,
-    color: colors.ink,
     marginHorizontal: spacing.xl,
     borderRadius: radius.sm,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
     fontSize: 16,
     borderWidth: 1,
-    borderColor: colors.hair,
   },
   dropdown: {
-    backgroundColor: colors.card,
     marginHorizontal: spacing.xl,
     marginTop: 4,
     borderRadius: radius.sm,
     overflow: 'hidden',
     borderWidth: 1,
-    borderColor: colors.hair,
   },
   suggestionItem: {
     flexDirection: 'row',
@@ -206,10 +197,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
     borderBottomWidth: 1,
-    borderBottomColor: colors.hair,
   },
   suggestionName: {
-    color: colors.ink,
     fontSize: 15,
   },
   lineBadge: {
@@ -218,7 +207,7 @@ const styles = StyleSheet.create({
     paddingVertical: 2,
   },
   lineText: {
-    color: colors.onAccent, // 노선색 배경 위 텍스트
+    color: '#ffffff', // 노선색 배경 위 텍스트 — 항상 흰색 유지
     fontSize: 12,
     fontWeight: 'bold',
   },

--- a/src/components/EditorialArrivalRow.tsx
+++ b/src/components/EditorialArrivalRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { colors, typography, spacing } from '../theme';
+import { useTheme, typography, spacing } from '../theme';
 import { useCountdown } from '../hooks/useCountdown';
 import type { ArrivalTrain } from '../utils/journeyAdapter';
 import { LineBadge, getLineColor } from './LineBadge';
@@ -12,9 +12,10 @@ interface Props {
 export function EditorialArrivalRow({ train }: Props) {
   const { mm, ss } = useCountdown(train.arrivalAtMs);
   const lineC = getLineColor(train.line);
+  const { colors } = useTheme();
 
   return (
-    <View style={styles.arrivalRow} testID="editorial-arrival-row">
+    <View style={[styles.arrivalRow, { borderBottomColor: colors.hair }]} testID="editorial-arrival-row">
       <View style={{ minWidth: 90 }}>
         <Text>
           <Text style={[typography.countMM, { color: colors.ink }]}>{mm}</Text>
@@ -44,6 +45,5 @@ const styles = StyleSheet.create({
     gap: spacing.lg,
     paddingVertical: 14,
     borderBottomWidth: 1,
-    borderBottomColor: colors.hair,
   },
 });

--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { colors, typography, spacing } from '../theme';
+import { useTheme, typography, spacing } from '../theme';
 import type { Stop } from '../utils/journeyAdapter';
 import { LineBadge, getLineColor } from './LineBadge';
 
@@ -9,6 +9,7 @@ interface Props {
 }
 
 export function EditorialTimeline({ stops }: Props) {
+  const { colors } = useTheme();
   return (
     <View>
       {stops.map((s, i) => {
@@ -34,7 +35,7 @@ export function EditorialTimeline({ stops }: Props) {
                 <View style={[styles.dot, { backgroundColor: lineC }]} testID="filled-dot" />
               )}
               {s.mark === 'transfer' && (
-                <View style={[styles.dotRing, { borderColor: lineC }]} testID="transfer-dot" />
+                <View style={[styles.dotRing, { borderColor: lineC, backgroundColor: colors.bg }]} testID="transfer-dot" />
               )}
               {s.mark === 'dest' && (
                 <View style={[styles.dotDest, { backgroundColor: lineC }]} testID="dest-dot" />
@@ -99,6 +100,6 @@ const styles = StyleSheet.create({
     width: 1,
   },
   dot:     { width: 10, height: 10, borderRadius: 5 },
-  dotRing: { width: 12, height: 12, borderRadius: 6, borderWidth: 2, backgroundColor: colors.bg },
+  dotRing: { width: 12, height: 12, borderRadius: 6, borderWidth: 2 },
   dotDest: { width: 12, height: 12, borderRadius: 6 },
 });

--- a/src/components/JourneyTimeline.tsx
+++ b/src/components/JourneyTimeline.tsx
@@ -2,7 +2,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { LINE_NAMES } from '../constants/lineColors';
 import type { JourneyDisplay } from '../utils/stationRoute';
 import type { LineNumber } from '../types/station';
-import { colors, typography, spacing, radius } from '../theme';
+import { useTheme, typography, spacing, radius } from '../theme';
 
 interface JourneyTimelineProps {
   journey: JourneyDisplay;
@@ -10,6 +10,7 @@ interface JourneyTimelineProps {
 
 export function JourneyTimeline({ journey }: JourneyTimelineProps) {
   const { segments } = journey;
+  const { colors } = useTheme();
 
   return (
     <View style={styles.container}>
@@ -23,7 +24,7 @@ export function JourneyTimeline({ journey }: JourneyTimelineProps) {
             {isFirst && (
               <View style={styles.stationRow}>
                 <View style={[styles.dot, { backgroundColor: segment.lineColor }]} testID="start-dot" />
-                <Text style={styles.stationName}>{segment.fromName}</Text>
+                <Text style={[styles.stationName, { color: colors.ink }]}>{segment.fromName}</Text>
               </View>
             )}
 
@@ -33,21 +34,21 @@ export function JourneyTimeline({ journey }: JourneyTimelineProps) {
                 <View style={[styles.lineBadge, { backgroundColor: segment.lineColor }]}>
                   <Text style={styles.lineBadgeText}>{lineName}</Text>
                 </View>
-                <Text style={styles.stopsText}>{segment.stops}정거장</Text>
+                <Text style={[styles.stopsText, { color: colors.muted }]}>{segment.stops}정거장</Text>
               </View>
             </View>
 
             {!isLast && (
               <View style={styles.stationRow}>
-                <Text style={styles.transferIcon}>⇄</Text>
-                <Text style={styles.transferName}>{segment.toName}</Text>
+                <Text style={[styles.transferIcon, { color: colors.accent }]}>⇄</Text>
+                <Text style={[styles.transferName, { color: colors.accent }]}>{segment.toName}</Text>
               </View>
             )}
 
             {isLast && (
               <View style={styles.stationRow}>
                 <View style={[styles.dot, { backgroundColor: segment.lineColor }]} testID="end-dot" />
-                <Text style={styles.stationName}>{segment.toName}</Text>
+                <Text style={[styles.stationName, { color: colors.ink }]}>{segment.toName}</Text>
               </View>
             )}
           </View>
@@ -76,11 +77,9 @@ const styles = StyleSheet.create({
   stationName: {
     fontSize: 16,
     fontWeight: '700',
-    color: colors.ink,
   },
   transferIcon: {
     fontSize: 16,
-    color: colors.accent,
     width: 12,
     textAlign: 'center',
     marginRight: 10,
@@ -88,7 +87,6 @@ const styles = StyleSheet.create({
   transferName: {
     fontSize: 15,
     fontWeight: '600',
-    color: colors.accent,
   },
   segmentRow: {
     flexDirection: 'row',
@@ -113,12 +111,11 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
   },
   lineBadgeText: {
-    color: colors.onAccent, // 노선색 배경 위 텍스트
+    color: '#ffffff', // 노선색 배경 위 텍스트 — 항상 흰색 유지
     fontSize: 12,
     fontWeight: '700',
   },
   stopsText: {
     fontSize: 13,
-    color: colors.muted,
   },
 });

--- a/src/components/LineBadge.tsx
+++ b/src/components/LineBadge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
-import { colors, typography } from '../theme';
+import { lightColors, typography } from '../theme';
 import { LINE_NAMES } from '../constants/lineColors';
 import type { LineNumber } from '../types/station';
 
@@ -10,7 +10,7 @@ interface LineBadgeProps {
 }
 
 export function getLineColor(line: string): string {
-  return colors.line[line as LineNumber] ?? colors.accent;
+  return lightColors.line[line as LineNumber] ?? lightColors.accent;
 }
 
 export function getLineLabel(line: string): string {


### PR DESCRIPTION
## Summary
프로덕션 코드에서 정적 `import { colors }` 0개 달성. 모든 화면/컴포넌트가 `useTheme()`으로 동적 색상 참조.

- `app/(tabs)/index.tsx` — ~20개 색상 참조 + Dot/Hr/ArrivalRow 포함 전환
- `src/components/AlarmOverlay.tsx` — 5개 색상 → 인라인
- `src/components/DestinationPicker.tsx` — 11개 색상 → 인라인
- `src/components/JourneyTimeline.tsx` — 4개 색상 → 인라인
- `src/components/EditorialTimeline.tsx` — 3개 색상 → 인라인
- `src/components/EditorialArrivalRow.tsx` — 5개 색상 → 인라인
- `src/components/LineBadge.tsx` — `lightColors` 직접 참조 (line/accent는 테마 불변)

## 의도적으로 남긴 하드코딩
- `#22c55e` 도착 배너, `#FEE500`/`#191919` 카카오, `#ff6b6b` 삭제, `#ffffff` 노선 배지

## Test plan
- [x] `npm test` — 43 suites, 550 tests 통과
- [x] 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 실기기에서 다크모드 전환 확인 필요

Closes #133