### PR TITLE
refactor(#136): 테마 색상 확정 — B(라이트) + C·Focus(다크)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,24 @@ coverage/
 # generated native folders
 /ios
 /android
+
+# IDE
+.idea/
+
+# Claude Code
+.claude/
+
+# Generated coverage temp
+coverage-temp/
+
+# Build artifacts
+*.zip
+
+# Project docs & data (별도 이슈로 관리)
+docs/
+handoff/
+img/
+subway/
+Live\ Activity.md
+oauth-implementation.md
+subway-now_icon.png

--- a/src/theme/__tests__/theme.test.ts
+++ b/src/theme/__tests__/theme.test.ts
@@ -10,12 +10,12 @@ const ALL_LINES: LineNumber[] = [
 describe('theme', () => {
   describe('colors', () => {
     it('should have all base color tokens', () => {
-      expect(colors.bg).toBe('#1a1a2e');
-      expect(colors.ink).toBe('#ffffff');
-      expect(colors.muted).toBe('#8888aa');
-      expect(colors.subtle).toBe('#aaaacc');
-      expect(colors.hair).toBe('#2a2a4a');
-      expect(colors.accent).toBe('#00D4FF');
+      expect(colors.bg).toBe('#F5F2EC');
+      expect(colors.ink).toBe('#1A1814');
+      expect(colors.muted).toBe('#6B6459');
+      expect(colors.subtle).toBe('#A8A197');
+      expect(colors.hair).toBe('rgba(26,24,20,0.08)');
+      expect(colors.accent).toBe('#C8553D');
       expect(colors.warn).toBe('#ff9f43');
     });
 
@@ -47,9 +47,9 @@ describe('theme', () => {
     });
 
     it('should have new theme tokens (card, onAccent, overlay)', () => {
-      expect(colors.card).toBe('#16213e');
-      expect(colors.onAccent).toBe('#000000');
-      expect(colors.overlay).toBe('rgba(0,0,0,0.6)');
+      expect(colors.card).toBe('#ffffff');
+      expect(colors.onAccent).toBe('#ffffff');
+      expect(colors.overlay).toBe('rgba(0,0,0,0.4)');
     });
   });
 
@@ -64,20 +64,20 @@ describe('theme', () => {
       expect(lightKeys).toEqual(darkKeys);
     });
 
-    it('darkColors는 AMOLED 다크 테마 값을 가진다', () => {
-      expect(darkColors.bg).toBe('#000000');
-      expect(darkColors.card).toBe('#111111');
+    it('darkColors는 C·Focus 다크 테마 값을 가진다', () => {
+      expect(darkColors.bg).toBe('#0A0A0A');
+      expect(darkColors.card).toBe('#1A1A1A');
       expect(darkColors.ink).toBe('#ffffff');
       expect(darkColors.muted).toBe('#888888');
       expect(darkColors.subtle).toBe('#666666');
-      expect(darkColors.hair).toBe('#222222');
+      expect(darkColors.hair).toBe('#2A2A2A');
       expect(darkColors.overlay).toBe('rgba(0,0,0,0.8)');
+      expect(darkColors.accent).toBe('#C8E600');
+      expect(darkColors.onAccent).toBe('#000000');
     });
 
     it('테마 불변 토큰은 양쪽 동일하다', () => {
-      expect(lightColors.accent).toBe(darkColors.accent);
       expect(lightColors.warn).toBe(darkColors.warn);
-      expect(lightColors.onAccent).toBe(darkColors.onAccent);
       expect(lightColors.line).toEqual(darkColors.line);
     });
 

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -6,32 +6,36 @@ import { LINE_COLORS } from '../constants/lineColors';
 
 // 테마 불변 토큰
 const sharedColors = {
-  accent:   '#00D4FF',                 // CTA, 강조 (시안)
-  warn:     '#ff9f43',                 // 경고 (mock 데이터 등)
-  onAccent: '#000000',                 // accent 배경 위 텍스트
+  warn:   '#ff9f43',                   // 경고 (mock 데이터 등)
   line: { ...LINE_COLORS } as Record<LineNumber, string>,
 };
 
+// Editorial Light (B) — 핸드오프 원본
 export const lightColors = {
   ...sharedColors,
-  bg:      '#1a1a2e',                  // 딥 네이비 배경
-  card:    '#16213e',                  // 네이비 카드
-  ink:     '#ffffff',                  // 순백 텍스트
-  muted:   '#8888aa',                  // 보조 텍스트
-  subtle:  '#aaaacc',                  // 메타 정보
-  hair:    '#2a2a4a',                  // divider
-  overlay: 'rgba(0,0,0,0.6)',          // 모달 배경
+  bg:       '#F5F2EC',                 // 따뜻한 페이퍼 배경
+  card:     '#ffffff',                 // 카드, 입력창
+  ink:      '#1A1814',                 // 본문 (near-black warm)
+  muted:    '#6B6459',                 // 보조 텍스트
+  subtle:   '#A8A197',                 // 메타 정보
+  hair:     'rgba(26,24,20,0.08)',     // divider
+  overlay:  'rgba(0,0,0,0.4)',         // 모달 배경
+  accent:   '#C8553D',                 // CTA (어스 레드)
+  onAccent: '#ffffff',                 // accent 위 텍스트
 };
 
+// C · Focus — 다크모드
 export const darkColors = {
   ...sharedColors,
-  bg:      '#000000',                  // AMOLED 퓨어 블랙
-  card:    '#111111',                  // 약간 밝은 카드
-  ink:     '#ffffff',                  // 순백 텍스트
-  muted:   '#888888',                  // 보조 텍스트
-  subtle:  '#666666',                  // 메타 정보
-  hair:    '#222222',                  // divider
-  overlay: 'rgba(0,0,0,0.8)',          // 모달 배경
+  bg:       '#0A0A0A',                 // 거의 퓨어블랙
+  card:     '#1A1A1A',                 // 다크 카드
+  ink:      '#ffffff',                 // 순백 텍스트
+  muted:    '#888888',                 // 보조 텍스트
+  subtle:   '#666666',                 // 메타 정보
+  hair:     '#2A2A2A',                 // divider
+  overlay:  'rgba(0,0,0,0.8)',         // 모달 배경
+  accent:   '#C8E600',                 // CTA (라임그린)
+  onAccent: '#000000',                 // accent 위 텍스트
 };
 
 export type ThemeColors = typeof lightColors;


### PR DESCRIPTION
## Summary
- **라이트**: Editorial Light (B) 복원 — 크림톤(#F5F2EC) + 어스레드(#C8553D)
- **다크**: C · Focus — 퓨어블랙(#0A0A0A) + 라임그린(#C8E600)
- accent/onAccent를 sharedColors에서 분리 → 테마별 개별 정의

## Test plan
- [x] `npm test` — 43 suites, 550 tests
- [x] 커버리지 100%
- [x] `npm run type-check` 통과

Closes #136