### PR TITLE
fix(#154): 백그라운드 알람이 UI 경로와 동일한 저장된 경로를 사용하도록 개선

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -14,6 +14,8 @@ import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/j
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ROUTE_KEY } from '../../src/constants/storageKeys';
 import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
 import { useTheme, typography, spacing, radius } from '../../src/theme';
@@ -61,6 +63,7 @@ export default function HomeScreen() {
     if (!effectiveOrigin || !destination) {
       setCandidates([]);
       setSelectedIdx(0);
+      AsyncStorage.removeItem(ROUTE_KEY).catch(() => {});
       return;
     }
     const interactionStart = performance.now();
@@ -71,6 +74,11 @@ export default function HomeScreen() {
       setCandidates(results);
       const picked = pickRouteByPreference(results, routePreference);
       setSelectedIdx(picked ? results.indexOf(picked) : 0);
+      if (picked) {
+        AsyncStorage.setItem(ROUTE_KEY, JSON.stringify(picked.route)).catch(() => {});
+      } else {
+        AsyncStorage.removeItem(ROUTE_KEY).catch(() => {});
+      }
     });
     return () => interaction.cancel();
   }, [effectiveOrigin?.id, destination?.id, routePreference]);
@@ -326,7 +334,10 @@ export default function HomeScreen() {
                             key={i}
                             testID={`route-tab-${i}`}
                             style={[styles.routePill, active && { backgroundColor: colors.accent }]}
-                            onPress={() => setSelectedIdx(i)}
+                            onPress={() => {
+                              setSelectedIdx(i);
+                              AsyncStorage.setItem(ROUTE_KEY, JSON.stringify(c.route)).catch(() => {});
+                            }}
                           >
                             <Text style={[styles.routePillText, { color: active ? colors.onAccent : colors.muted }]}>
                               {label}

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -6,3 +6,4 @@ export const ALARM_EVENT_KEY = 'subway-now:alarm-event';
 export const CUSTOM_ORIGIN_KEY = 'subway-now:custom-origin';
 export const THEME_MODE_KEY = 'subway-now:theme-mode';
 export const ROUTE_PREFERENCE_KEY = 'subway-now:route-preference';
+export const ROUTE_KEY = 'subway-now:route';

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -160,6 +160,7 @@ describe('useAppStore', () => {
     setDestination(null);
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:destination');
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-alarms');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:route');
   });
 
   it('setDestination: AsyncStorage 실패 시에도 에러를 던지지 않는다', async () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Station } from '../types/station';
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY } from '../constants/storageKeys';
 import type { RoutePreference } from '../utils/stationRoute';
 
 export type ThemeMode = 'auto' | 'light' | 'dark';
@@ -81,6 +81,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     } else {
       AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
       AsyncStorage.removeItem(FIRED_ALARMS_KEY).catch(noop);
+      AsyncStorage.removeItem(ROUTE_KEY).catch(noop);
     }
   },
 

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -196,7 +196,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     (AsyncStorage.getItem as jest.Mock)
       .mockResolvedValueOnce(JSON.stringify(mockDestination)) // DESTINATION_KEY
       .mockResolvedValueOnce(null)                            // SLEEP_MODE_KEY
-      .mockResolvedValueOnce(null);                           // FIRED_ALARMS_KEY
+      .mockResolvedValueOnce(null)                            // FIRED_ALARMS_KEY
+      .mockResolvedValueOnce(null);                           // ROUTE_KEY
 
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent: null,
@@ -214,6 +215,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       false,
+      null,
     );
     expect(AsyncStorage.setItem).not.toHaveBeenCalled();
   });
@@ -224,6 +226,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     (AsyncStorage.getItem as jest.Mock)
       .mockResolvedValueOnce(JSON.stringify(mockDestination))
       .mockResolvedValueOnce('true')
+      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
@@ -239,6 +242,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       true,
+      null,
     );
   });
 
@@ -246,6 +250,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     (AsyncStorage.getItem as jest.Mock)
       .mockResolvedValueOnce(JSON.stringify(mockDestination))
       .mockResolvedValueOnce('false')
+      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
@@ -261,6 +266,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       false,
+      null,
     );
   });
 
@@ -271,7 +277,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     (AsyncStorage.getItem as jest.Mock)
       .mockResolvedValueOnce(JSON.stringify(mockDestination))
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(JSON.stringify(fired));
+      .mockResolvedValueOnce(JSON.stringify(fired))
+      .mockResolvedValueOnce(null);
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
@@ -286,6 +293,75 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(fired),
       false,
+      null,
+    );
+  });
+
+  // ── ROUTE_KEY 관련 테스트 ──
+
+  it('ROUTE_KEY를 AsyncStorage에서 읽는다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('subway-now:route');
+  });
+
+  it('routeJson이 있으면 파싱한 route를 processLocationUpdate에 전달한다', async () => {
+    const storedRoute = { type: 'direct', stops: 3 };
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JSON.stringify(storedRoute));
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(),
+      false,
+      storedRoute,
+    );
+  });
+
+  it('routeJson이 null이면 null storedRoute를 processLocationUpdate에 전달한다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(),
+      false,
+      null,
     );
   });
 

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -6,7 +6,8 @@ import { alarmKey } from '../utils/stationAlarm';
 import { updateStationNotification } from '../utils/stationNotification';
 import { findNearestStation } from '../utils/findNearestStation';
 import { createLogger } from '../utils/logger';
-import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY } from '../constants/storageKeys';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY } from '../constants/storageKeys';
+import type { Route } from '../utils/stationRoute';
 
 const logger = createLogger('BackgroundLocation');
 
@@ -26,10 +27,11 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const { latitude, longitude } = latest.coords;
 
   try {
-    const [destJson, sleepJson, firedJson] = await Promise.all([
+    const [destJson, sleepJson, firedJson, routeJson] = await Promise.all([
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(SLEEP_MODE_KEY),
       AsyncStorage.getItem(FIRED_ALARMS_KEY),
+      AsyncStorage.getItem(ROUTE_KEY),
     ]);
 
     // 목적지 미설정 시 현재 역 알림만 업데이트
@@ -53,6 +55,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     }
     const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
     const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
+    const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
 
     const { alarmEvent } = await processLocationUpdate(
       latitude,
@@ -60,6 +63,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       destination,
       firedAlarms,
       sleepMode,
+      storedRoute,
     );
 
     if (alarmEvent) {

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -11,9 +11,11 @@ jest.mock('../findNearestStation', () => ({
 
 const mockFindRoute = jest.fn();
 const mockCalculateStaticETA = jest.fn();
+const mockUpdateRouteFromPosition = jest.fn();
 jest.mock('../stationRoute', () => ({
   findRoute: (...args: unknown[]) => mockFindRoute(...args),
   calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
+  updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
 }));
 
 const mockCheckAlarm = jest.fn();
@@ -421,6 +423,43 @@ describe('processLocationUpdate', () => {
     await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
 
     expect(mockCheckTimeBasedAlarm).not.toHaveBeenCalled();
+  });
+
+  it('should use updateRouteFromPosition result when storedRoute is provided and succeeds', async () => {
+    const storedRoute: DirectRoute = { type: 'direct', stops: 5 };
+    const updatedRoute: DirectRoute = { type: 'direct', stops: 3 };
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockUpdateRouteFromPosition.mockReturnValue(updatedRoute);
+    mockCalculateStaticETA.mockReturnValue(6);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, storedRoute);
+
+    expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
+    expect(mockFindRoute).not.toHaveBeenCalled();
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(updatedRoute);
+  });
+
+  it('should fall back to findRoute when storedRoute is provided but updateRouteFromPosition returns null', async () => {
+    const storedRoute: DirectRoute = { type: 'direct', stops: 5 };
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockUpdateRouteFromPosition.mockReturnValue(null);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockCalculateStaticETA.mockReturnValue(6);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, storedRoute);
+
+    expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
+    expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
+  });
+
+  it('should call findRoute when no storedRoute is provided (default null)', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+
+    expect(mockUpdateRouteFromPosition).not.toHaveBeenCalled();
+    expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
   });
 });
 

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition } from '../stationRoute';
 import type { Station } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate } from '../stationRoute';
 
@@ -645,5 +645,247 @@ describe('pickRouteByPreference', () => {
 
   it('빈 배열이면 null을 반환한다', () => {
     expect(pickRouteByPreference([], 'optimal')).toBeNull();
+  });
+});
+
+describe('findStationByNameAndLine', () => {
+  it('이름과 노선이 일치하는 역을 반환한다', () => {
+    const station = findStationByNameAndLine('교대', '2');
+    expect(station).toBeDefined();
+    expect(station?.name).toBe('교대');
+    expect(station?.line).toBe('2');
+    expect(station?.id).toBe('2-023');
+  });
+
+  it('다른 노선에 있는 같은 이름의 역을 반환한다', () => {
+    const station = findStationByNameAndLine('교대', '3');
+    expect(station).toBeDefined();
+    expect(station?.name).toBe('교대');
+    expect(station?.line).toBe('3');
+    expect(station?.id).toBe('3-032');
+  });
+
+  it('존재하지 않는 역 이름이면 undefined를 반환한다', () => {
+    expect(findStationByNameAndLine('존재하지않는역', '2')).toBeUndefined();
+  });
+
+  it('해당 노선에 없는 역이면 undefined를 반환한다 (다른 노선에는 있어도)', () => {
+    // 교대역은 1호선에 없음
+    expect(findStationByNameAndLine('교대', '1')).toBeUndefined();
+  });
+});
+
+describe('updateRouteFromPosition', () => {
+  // ── DirectRoute ──
+  describe('DirectRoute', () => {
+    it('현재 역에서 목적지까지 남은 정거장 수로 업데이트한다', () => {
+      // 1호선: 소요산(1-001) → 보산(1-003): 2 stops
+      // 현재 동두천(1-002)에 있으면 보산까지 1 stop
+      const storedRoute: DirectRoute = { type: 'direct', stops: 2 };
+      const nearestStation = getStationsOnLine('1').find((s) => s.id === '1-002')!;
+      const result = updateRouteFromPosition(storedRoute, nearestStation, '1-003');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('direct');
+      if (result?.type === 'direct') {
+        expect(result.stops).toBe(1);
+      }
+    });
+
+    it('현재 역과 목적지가 다른 노선이면 null을 반환한다', () => {
+      const storedRoute: DirectRoute = { type: 'direct', stops: 3 };
+      // 2호선 강남, 목적지는 1호선 시청
+      const gangnam2 = getStationsOnLine('2').find((s) => s.name === '강남')!;
+      const result = updateRouteFromPosition(storedRoute, gangnam2, '1-033');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── TransferRoute ──
+  describe('TransferRoute', () => {
+    // fromLine: '2', toLine: '3', transferName: '교대'
+    // 교대(2호선): 2-023, 교대(3호선): 3-032
+    // 목적지: 3호선 양재 3-034
+    const storedTransferRoute: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 2,
+    };
+
+    it('fromLine에 있으면 환승역까지 남은 정거장으로 stopsToTransfer를 업데이트한다', () => {
+      // 강남(2-022)에서 교대(2-023)까지 1 stop
+      const gangnam2 = getStationsOnLine('2').find((s) => s.name === '강남')!;
+      const result = updateRouteFromPosition(storedTransferRoute, gangnam2, '3-034');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('transfer');
+      if (result?.type === 'transfer') {
+        expect(result.stopsToTransfer).toBe(1);
+        expect(result.fromLine).toBe('2');
+        expect(result.toLine).toBe('3');
+      }
+    });
+
+    it('fromLine에 있지만 transferName이 해당 노선에 존재하지 않으면 null을 반환한다', () => {
+      const invalidRoute: TransferRoute = {
+        type: 'transfer',
+        transferName: '존재하지않는환승역',
+        fromLine: '2',
+        toLine: '3',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 2,
+      };
+      const gangnam2 = getStationsOnLine('2').find((s) => s.name === '강남')!;
+      const result = updateRouteFromPosition(invalidRoute, gangnam2, '3-034');
+      expect(result).toBeNull();
+    });
+
+    it('fromLine에 있고 transferName은 있지만 nearestStation ID가 유효하지 않으면 null을 반환한다', () => {
+      // nearestStation의 id가 유효하지 않으면 getRemainingStops가 null을 반환
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '교대',
+        fromLine: '2',
+        toLine: '3',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 2,
+      };
+      const fakeStation = { id: 'invalid-id', name: '가짜역', line: '2' as const, lineColor: '#009D3E', lat: 0, lng: 0 };
+      const result = updateRouteFromPosition(route, fakeStation, '3-034');
+      expect(result).toBeNull();
+    });
+
+    it('toLine에 있으면 stopsToTransfer=0, 목적지까지 stopsFromTransfer를 업데이트한다', () => {
+      // 교대(3-032)에서 양재(3-034)까지 2 stops
+      const gyodae3 = getStationsOnLine('3').find((s) => s.name === '교대')!;
+      const result = updateRouteFromPosition(storedTransferRoute, gyodae3, '3-034');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('transfer');
+      if (result?.type === 'transfer') {
+        expect(result.stopsToTransfer).toBe(0);
+        expect(result.stopsFromTransfer).toBe(2);
+      }
+    });
+
+    it('toLine에 있지만 destinationId가 다른 노선이면 null을 반환한다', () => {
+      // 교대(3호선)에 있지만 목적지가 1호선 역
+      const gyodae3 = getStationsOnLine('3').find((s) => s.name === '교대')!;
+      const result = updateRouteFromPosition(storedTransferRoute, gyodae3, '1-001');
+      expect(result).toBeNull();
+    });
+
+    it('fromLine도 toLine도 아닌 노선이면 null을 반환한다', () => {
+      // 7호선 장암 역
+      const jangam7 = getStationsOnLine('7').find((s) => s.id === '7-001')!;
+      const result = updateRouteFromPosition(storedTransferRoute, jangam7, '3-034');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── MultiTransferRoute ──
+  describe('MultiTransferRoute', () => {
+    // 8호선 → 2호선(잠실) → 1호선
+    // t1: 8호선 → 2호선, transferName: '잠실'
+    // t2: 2호선 → 1호선, transferName: '시청'
+    const storedMultiRoute: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 4 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 10 },
+      ],
+      stopsAfterLastTransfer: 5,
+    };
+
+    it('t1.fromLine(8호선)에 있으면 t1.stopsToTransfer를 업데이트한다', () => {
+      // 8호선 암사(8-001)에서 잠실(8호선 8-005)까지 4 stops
+      const amsa8 = getStationsOnLine('8').find((s) => s.id === '8-001')!;
+      const result = updateRouteFromPosition(storedMultiRoute, amsa8, '1-001');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('multi-transfer');
+      if (result?.type === 'multi-transfer') {
+        expect(result.transfers[0].stopsToTransfer).toBe(4);
+        expect(result.transfers[1].stopsToTransfer).toBe(10);
+      }
+    });
+
+    it('t1.fromLine에 있지만 t1.transferName이 해당 노선에 없으면 null을 반환한다', () => {
+      const invalidMultiRoute: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '존재하지않는역', fromLine: '8', toLine: '2', stopsToTransfer: 4 },
+          { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 10 },
+        ],
+        stopsAfterLastTransfer: 5,
+      };
+      const amsa8 = getStationsOnLine('8').find((s) => s.id === '8-001')!;
+      const result = updateRouteFromPosition(invalidMultiRoute, amsa8, '1-001');
+      expect(result).toBeNull();
+    });
+
+    it('t1.fromLine에 있고 transferName은 있지만 nearestStation ID가 유효하지 않으면 null을 반환한다', () => {
+      const fakeStation = { id: 'invalid-id', name: '가짜역', line: '8' as const, lineColor: '#E6186C', lat: 0, lng: 0 };
+      const result = updateRouteFromPosition(storedMultiRoute, fakeStation, '1-001');
+      expect(result).toBeNull();
+    });
+
+    it('t1.toLine(2호선, 즉 t2.fromLine)에 있으면 t1=0, t2.stopsToTransfer를 업데이트한다', () => {
+      // 2호선 잠실(2-016)에서 시청(2-001)까지의 stops
+      const jamsil2 = getStationsOnLine('2').find((s) => s.name === '잠실')!;
+      const result = updateRouteFromPosition(storedMultiRoute, jamsil2, '1-001');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('multi-transfer');
+      if (result?.type === 'multi-transfer') {
+        expect(result.transfers[0].stopsToTransfer).toBe(0);
+        expect(result.transfers[1].stopsToTransfer).toBeGreaterThan(0);
+      }
+    });
+
+    it('t1.toLine에 있지만 t2.transferName이 해당 노선에 없으면 null을 반환한다', () => {
+      const invalidMultiRoute: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 4 },
+          { transferName: '존재하지않는역', fromLine: '2', toLine: '1', stopsToTransfer: 10 },
+        ],
+        stopsAfterLastTransfer: 5,
+      };
+      const jamsil2 = getStationsOnLine('2').find((s) => s.name === '잠실')!;
+      const result = updateRouteFromPosition(invalidMultiRoute, jamsil2, '1-001');
+      expect(result).toBeNull();
+    });
+
+    it('t1.toLine에 있고 t2.transferName은 있지만 nearestStation ID가 유효하지 않으면 null을 반환한다', () => {
+      const fakeStation = { id: 'invalid-id', name: '가짜역', line: '2' as const, lineColor: '#009D3E', lat: 0, lng: 0 };
+      const result = updateRouteFromPosition(storedMultiRoute, fakeStation, '1-001');
+      expect(result).toBeNull();
+    });
+
+    it('t2.toLine(1호선)에 있으면 both transfers=0, stopsAfterLastTransfer를 업데이트한다', () => {
+      // 1호선 시청(1-033)에서 소요산(1-001)까지의 stops
+      const city1 = getStationsOnLine('1').find((s) => s.name === '시청')!;
+      const result = updateRouteFromPosition(storedMultiRoute, city1, '1-001');
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('multi-transfer');
+      if (result?.type === 'multi-transfer') {
+        expect(result.transfers[0].stopsToTransfer).toBe(0);
+        expect(result.transfers[1].stopsToTransfer).toBe(0);
+        expect(result.stopsAfterLastTransfer).toBeGreaterThan(0);
+      }
+    });
+
+    it('t2.toLine에 있지만 destinationId가 다른 노선이면 null을 반환한다', () => {
+      // 1호선 시청에 있지만 목적지가 2호선 역
+      const city1 = getStationsOnLine('1').find((s) => s.name === '시청')!;
+      const result = updateRouteFromPosition(storedMultiRoute, city1, '2-001');
+      expect(result).toBeNull();
+    });
+
+    it('관련 없는 노선에 있으면 null을 반환한다', () => {
+      // 7호선 장암 역
+      const jangam7 = getStationsOnLine('7').find((s) => s.id === '7-001')!;
+      const result = updateRouteFromPosition(storedMultiRoute, jangam7, '1-001');
+      expect(result).toBeNull();
+    });
   });
 });

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -1,5 +1,5 @@
 import { findNearestStation } from './findNearestStation';
-import { findRoute, calculateStaticETA } from './stationRoute';
+import { findRoute, calculateStaticETA, updateRouteFromPosition } from './stationRoute';
 import { checkAlarm, checkTimeBasedAlarm } from './stationAlarm';
 import { sendAlarmNotification, updateStationNotification } from './stationNotification';
 import type { NearestStationResult, Station } from '../types/station';
@@ -83,11 +83,18 @@ export async function processLocationUpdate(
   destination: Station,
   firedAlarms: Set<string>,
   sleepMode: boolean,
+  storedRoute: Route = null,
 ): Promise<PipelineResult> {
   const nearest = findNearestStation(lat, lng);
   if (!nearest) return { alarmEvent: null, nearest: null };
 
-  const route = findRoute(nearest.station.id, destination.id);
+  let route: Route = null;
+  if (storedRoute) {
+    route = updateRouteFromPosition(storedRoute, nearest.station, destination.id);
+  }
+  if (!route) {
+    route = findRoute(nearest.station.id, destination.id);
+  }
   const alarmEvent = evaluateAllAlarms(route, destination.name, firedAlarms);
 
   if (alarmEvent) {

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -122,6 +122,70 @@ export function getStationsOnLine(line: string): Station[] {
   return getLineStationsCached(line);
 }
 
+export function findStationByNameAndLine(name: string, line: string): Station | undefined {
+  return getLineStationsCached(line).find((s) => s.name === name);
+}
+
+export function updateRouteFromPosition(
+  storedRoute: NonNullable<Route>,
+  nearestStation: Station,
+  destinationId: string,
+): Route | null {
+  if (storedRoute.type === 'direct') {
+    // getRemainingStops는 다른 노선이면 null을 반환하므로 노선 이탈 시 자동 fallback
+    const dest = stationById.get(destinationId);
+    if (!dest || nearestStation.line !== dest.line) return null;
+    const remaining = getRemainingStops(nearestStation.id, destinationId);
+    return remaining !== null ? { type: 'direct', stops: remaining } : null;
+  }
+
+  if (storedRoute.type === 'transfer') {
+    if (nearestStation.line === storedRoute.fromLine) {
+      const transfer = findStationByNameAndLine(storedRoute.transferName, storedRoute.fromLine);
+      if (!transfer) return null;
+      const stopsToTransfer = getRemainingStops(nearestStation.id, transfer.id);
+      return stopsToTransfer !== null ? { ...storedRoute, stopsToTransfer } : null;
+    }
+    if (nearestStation.line === storedRoute.toLine) {
+      const stopsFromTransfer = getRemainingStops(nearestStation.id, destinationId);
+      return stopsFromTransfer !== null
+        ? { ...storedRoute, stopsToTransfer: 0, stopsFromTransfer }
+        : null;
+    }
+    return null;
+  }
+
+  // multi-transfer
+  const [t1, t2] = storedRoute.transfers;
+
+  if (nearestStation.line === t1.fromLine) {
+    const station = findStationByNameAndLine(t1.transferName, t1.fromLine);
+    if (!station) return null;
+    const stops = getRemainingStops(nearestStation.id, station.id);
+    return stops !== null
+      ? { ...storedRoute, transfers: [{ ...t1, stopsToTransfer: stops }, t2] as MultiTransferRoute['transfers'] }
+      : null;
+  }
+
+  if (nearestStation.line === t1.toLine) {
+    const station = findStationByNameAndLine(t2.transferName, t1.toLine);
+    if (!station) return null;
+    const stops = getRemainingStops(nearestStation.id, station.id);
+    return stops !== null
+      ? { ...storedRoute, transfers: [{ ...t1, stopsToTransfer: 0 }, { ...t2, stopsToTransfer: stops }] as MultiTransferRoute['transfers'] }
+      : null;
+  }
+
+  if (nearestStation.line === t2.toLine) {
+    const stops = getRemainingStops(nearestStation.id, destinationId);
+    return stops !== null
+      ? { ...storedRoute, transfers: [{ ...t1, stopsToTransfer: 0 }, { ...t2, stopsToTransfer: 0 }] as MultiTransferRoute['transfers'], stopsAfterLastTransfer: stops }
+      : null;
+  }
+
+  return null;
+}
+
 export function getRemainingStops(
   currentId: string,
   destinationId: string,


### PR DESCRIPTION
## Summary

- 백그라운드 알람이 매번 `findRoute`로 경로를 재계산하여 UI와 다른 경로로 알람이 발생하는 문제 수정
- 포그라운드에서 선택된 경로를 AsyncStorage에 저장하고, 백그라운드에서는 저장된 경로의 구조(환승역, 노선)를 유지한 채 GPS 위치 기반으로 남은 정거장만 갱신
- 저장된 경로에서 현재 위치를 찾지 못하면 `findRoute`로 fallback

## 변경 내용

- `ROUTE_KEY` 추가 (storageKeys)
- `updateRouteFromPosition` 함수: 저장된 경로 + nearest station → 갱신된 Route 반환
- `processLocationUpdate`: storedRoute 파라미터 추가, updateRouteFromPosition 우선 → findRoute fallback
- `backgroundLocationTask`: ROUTE_KEY 읽기 + processLocationUpdate에 전달
- `index.tsx`: 경로 계산 시 + 탭 수동 선택 시 ROUTE_KEY 저장
- `useAppStore`: setDestination(null) 시 ROUTE_KEY 제거

## Test plan

- [x] 639 테스트 전부 통과
- [x] 커버리지 100%
- [x] TypeScript 타입체크 통과
- [x] `updateRouteFromPosition` 단위 테스트 (Direct/Transfer/MultiTransfer, 각 세그먼트별 + null 케이스)
- [x] `processLocationUpdate` storedRoute 전달/fallback 테스트
- [x] backgroundLocationTask ROUTE_KEY 읽기 + 전달 테스트

Closes #154