### PR TITLE
fix(#161): 2번 환승 경로에서 두 번째 환승 알람 미발생 버그 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,3 +173,9 @@ EXPO_PUBLIC_KAKAO_MAP_KEY=         # 카카오맵 JavaScript API
 - 상수: `UPPER_SNAKE_CASE`
 - 파일명: 컴포넌트는 `PascalCase.tsx`, 유틸/훅은 `camelCase.ts`
 - 색상: `useTheme()`으로 동적 참조. 정적 `import { colors }` 사용 금지 (테스트 제외)
+
+### 확장성/재사용성 (글로벌 규칙 3번 적용)
+- 노선/역 관련 분기: `if-else`/`switch` 대신 `stations.json`, `lineColors.ts` 등 데이터로 구동
+- 상수 위치: `src/constants/`에 `UPPER_SNAKE_CASE`로 분리
+- API Provider: 새 제공자 추가 시 `src/providers/` 인터페이스 구현체만 추가
+- 알람/경로 로직: 환승 횟수에 의존하지 않고 `transfers` 배열 순회로 처리

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -1,4 +1,4 @@
-import { checkAlarm, checkTimeBasedAlarm, alarmKey, estimateRemainingSeconds, resolveCurrentTarget, AlarmEvent } from '../stationAlarm';
+import { checkAlarm, checkTimeBasedAlarm, alarmKey, estimateRemainingSeconds, resolveAllTargets, AlarmEvent } from '../stationAlarm';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, Route } from '../stationRoute';
 
 // ── 테스트 헬퍼 ──
@@ -71,65 +71,54 @@ describe('estimateRemainingSeconds', () => {
   });
 });
 
-describe('resolveCurrentTarget', () => {
+describe('resolveAllTargets', () => {
   describe('DirectRoute', () => {
-    it('should target destination', () => {
+    it('should return single destination target', () => {
       const route: DirectRoute = { type: 'direct', stops: 5 };
-      expect(resolveCurrentTarget(route, '강남')).toEqual({
-        name: '강남', stops: 5, alarmType: 'destination',
-      });
+      expect(resolveAllTargets(route, '강남')).toEqual([
+        { name: '강남', stops: 5, alarmType: 'destination' },
+      ]);
     });
   });
 
   describe('TransferRoute', () => {
-    it('should target transfer when stopsToTransfer > 0', () => {
-      expect(resolveCurrentTarget(makeTransferRoute(3, 5), '강남')).toEqual({
-        name: '시청', stops: 3, alarmType: 'transfer',
-      });
+    it('should return transfer target followed by destination target', () => {
+      expect(resolveAllTargets(makeTransferRoute(3, 5), '강남')).toEqual([
+        { name: '시청', stops: 3, alarmType: 'transfer' },
+        { name: '강남', stops: 5, alarmType: 'destination' },
+      ]);
     });
 
-    it('should target transfer when stopsToTransfer = 0 (user at transfer)', () => {
-      expect(resolveCurrentTarget(makeTransferRoute(0, 5), '강남')).toEqual({
-        name: '시청', stops: 0, alarmType: 'transfer',
-      });
-    });
-
-    it('should target destination when transferName = destinationName', () => {
-      expect(resolveCurrentTarget(makeTransferRoute(3, 0, '옥수', 'gyeongui', '3'), '옥수')).toEqual({
-        name: '옥수', stops: 3, alarmType: 'destination',
-      });
+    it('should return single destination when transferName equals destinationName', () => {
+      expect(resolveAllTargets(makeTransferRoute(3, 0, '옥수', 'gyeongui', '3'), '옥수')).toEqual([
+        { name: '옥수', stops: 3, alarmType: 'destination' },
+      ]);
     });
   });
 
   describe('MultiTransferRoute', () => {
-    it('should target first transfer (current segment)', () => {
-      expect(resolveCurrentTarget(makeMultiRoute(5, 1, 3), '강남')).toEqual({
-        name: '시청', stops: 5, alarmType: 'transfer',
-      });
+    it('should return all waypoints in order: [transfer1, transfer2, destination]', () => {
+      expect(resolveAllTargets(makeMultiRoute(5, 3, 2), '강남')).toEqual([
+        { name: '시청', stops: 5, alarmType: 'transfer' },
+        { name: '충무로', stops: 3, alarmType: 'transfer' },
+        { name: '강남', stops: 2, alarmType: 'destination' },
+      ]);
     });
 
-    it('should target first transfer even when later segments are closer', () => {
-      expect(resolveCurrentTarget(makeMultiRoute(7, 2, 1, '강남구청', '선릉'), '역삼')).toEqual({
-        name: '강남구청', stops: 7, alarmType: 'transfer',
-      });
+    it('should mark transfer as destination when transferName equals destinationName', () => {
+      expect(resolveAllTargets(makeMultiRoute(1, 5, 3, '옥수'), '옥수')).toEqual([
+        { name: '옥수', stops: 1, alarmType: 'destination' },
+        { name: '충무로', stops: 5, alarmType: 'transfer' },
+        { name: '옥수', stops: 3, alarmType: 'destination' },
+      ]);
     });
 
-    it('should target destination when first transferName = destinationName', () => {
-      expect(resolveCurrentTarget(makeMultiRoute(1, 5, 3, '옥수'), '옥수')).toEqual({
-        name: '옥수', stops: 1, alarmType: 'destination',
-      });
-    });
-
-    it('should target first transfer when stopsToTransfer = 0', () => {
-      expect(resolveCurrentTarget(makeMultiRoute(0, 5, 3), '강남')).toEqual({
-        name: '시청', stops: 0, alarmType: 'transfer',
-      });
-    });
-
-    it('should target destination when first transferName = destinationName and stopsToTransfer = 0', () => {
-      expect(resolveCurrentTarget(makeMultiRoute(0, 5, 3, '옥수'), '옥수')).toEqual({
-        name: '옥수', stops: 0, alarmType: 'destination',
-      });
+    it('should reflect updated stops after first transfer passed', () => {
+      expect(resolveAllTargets(makeMultiRoute(0, 1, 3), '강남')).toEqual([
+        { name: '시청', stops: 0, alarmType: 'transfer' },
+        { name: '충무로', stops: 1, alarmType: 'transfer' },
+        { name: '강남', stops: 3, alarmType: 'destination' },
+      ]);
     });
   });
 });
@@ -207,6 +196,17 @@ describe('checkAlarm', () => {
       expect(checkAlarm(makeTransferRoute(1, 1), destinationName, new Set()))
         .toEqual({ type: 'transfer', stationName: '시청' });
     });
+
+    it('should return destination alarm after transfer is fired and destination is close', () => {
+      const fired = new Set(['transfer:시청']);
+      expect(checkAlarm(makeTransferRoute(0, 1), destinationName, fired))
+        .toEqual({ type: 'destination', stationName: '강남' });
+    });
+
+    it('should return null after transfer is fired but destination is far', () => {
+      const fired = new Set(['transfer:시청']);
+      expect(checkAlarm(makeTransferRoute(0, 5), destinationName, fired)).toBeNull();
+    });
   });
 
   // MultiTransferRoute
@@ -272,6 +272,44 @@ describe('checkAlarm', () => {
 
     it('should return null when first transferName equals destinationName but is far', () => {
       expect(checkAlarm(makeMultiRoute(5, 1, 3, '옥수'), '옥수', new Set())).toBeNull();
+    });
+
+    it('should return second transfer alarm after first is fired', () => {
+      const route = makeMultiRoute(0, 1, 3);
+      const fired = new Set(['transfer:시청']);
+      expect(checkAlarm(route, destinationName, fired))
+        .toEqual({ type: 'transfer', stationName: '충무로' });
+    });
+
+    it('should return destination alarm after both transfers are fired', () => {
+      const route = makeMultiRoute(0, 0, 1);
+      const fired = new Set(['transfer:시청', 'transfer:충무로']);
+      expect(checkAlarm(route, destinationName, fired))
+        .toEqual({ type: 'destination', stationName: '강남' });
+    });
+
+    it('should return null when first is fired but second is still far', () => {
+      const route = makeMultiRoute(0, 5, 3);
+      const fired = new Set(['transfer:시청']);
+      expect(checkAlarm(route, destinationName, fired)).toBeNull();
+    });
+
+    it('should fire alarms sequentially through full journey', () => {
+      const fired = new Set<string>();
+
+      // 1) 첫 환승 접근
+      const step1 = checkAlarm(makeMultiRoute(1, 5, 3), destinationName, fired);
+      expect(step1).toEqual({ type: 'transfer', stationName: '시청' });
+      fired.add('transfer:시청');
+
+      // 2) 첫 환승 통과, 두 번째 접근
+      const step2 = checkAlarm(makeMultiRoute(0, 1, 3), destinationName, fired);
+      expect(step2).toEqual({ type: 'transfer', stationName: '충무로' });
+      fired.add('transfer:충무로');
+
+      // 3) 둘 다 통과, 도착역 접근
+      const step3 = checkAlarm(makeMultiRoute(0, 0, 1), destinationName, fired);
+      expect(step3).toEqual({ type: 'destination', stationName: '강남' });
     });
   });
 

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -28,36 +28,37 @@ export interface CurrentTarget {
 }
 
 /**
- * 현재 경로에서 알람 대상(환승역 또는 도착역)과 남은 정거장 수를 반환한다.
- * 경로는 GPS 기반으로 매번 재계산되므로, 첫 번째 구간만이 사용자의 실제 거리를 반영한다.
- * 따라서 항상 현재 구간의 다음 웨이포인트(환승역 또는 도착역)만 반환한다.
- *
- * resolveNextTarget과의 차이: resolveNextTarget은 stopsToTransfer=0을 "환승 완료"로 간주하지만,
- * 여기서는 "사용자가 환승역에 있다"로 간주하여 환승 알람을 발생시킨다.
+ * 경로의 모든 웨이포인트(환승역 + 도착역)를 경로 순서대로 반환한다.
+ * checkAlarm이 이 목록을 순회하며, 이미 발생한 알람은 건너뛰고 다음 타겟을 평가한다.
+ * 환승 횟수에 의존하지 않고 transfers 배열을 순회하므로 N번 환승까지 확장 가능하다.
  */
-export function resolveCurrentTarget(
+export function resolveAllTargets(
   route: NonNullable<Route>,
   destinationName: string,
-): CurrentTarget {
+): CurrentTarget[] {
   if (route.type === 'direct') {
-    return { name: destinationName, stops: route.stops, alarmType: 'destination' };
+    return [{ name: destinationName, stops: route.stops, alarmType: 'destination' }];
   }
 
   if (route.type === 'transfer') {
     if (route.transferName === destinationName) {
-      return { name: destinationName, stops: route.stopsToTransfer, alarmType: 'destination' };
+      return [{ name: destinationName, stops: route.stopsToTransfer, alarmType: 'destination' }];
     }
-    return { name: route.transferName, stops: route.stopsToTransfer, alarmType: 'transfer' };
+    return [
+      { name: route.transferName, stops: route.stopsToTransfer, alarmType: 'transfer' },
+      { name: destinationName, stops: route.stopsFromTransfer, alarmType: 'destination' },
+    ];
   }
 
-  // multi-transfer: 첫 번째 환승이 항상 현재 구간
-  // (GPS 재계산으로 이전 환승은 경로에서 사라짐)
-  const firstTransfer = route.transfers[0];
-  if (firstTransfer.transferName === destinationName) {
-    return { name: destinationName, stops: firstTransfer.stopsToTransfer, alarmType: 'destination' };
-  }
-  return { name: firstTransfer.transferName, stops: firstTransfer.stopsToTransfer, alarmType: 'transfer' };
+  // multi-transfer: 모든 웨이포인트를 순서대로 반환
+  const targets: CurrentTarget[] = route.transfers.map((t) => {
+    const alarmType = t.transferName === destinationName ? 'destination' as const : 'transfer' as const;
+    return { name: t.transferName === destinationName ? destinationName : t.transferName, stops: t.stopsToTransfer, alarmType };
+  });
+  targets.push({ name: destinationName, stops: route.stopsAfterLastTransfer, alarmType: 'destination' });
+  return targets;
 }
+
 
 export function checkAlarm(
   route: Route,
@@ -67,14 +68,15 @@ export function checkAlarm(
 ): AlarmEvent | null {
   if (!route) return null;
 
-  const target = resolveCurrentTarget(route, destinationName);
-  if (target.stops > threshold) return null;
-
-  const event: AlarmEvent = { type: target.alarmType, stationName: target.name };
-  const key = alarmKey(event);
-  if (firedAlarms.has(key)) return null;
-
-  return event;
+  const targets = resolveAllTargets(route, destinationName);
+  for (const target of targets) {
+    const event: AlarmEvent = { type: target.alarmType, stationName: target.name };
+    const key = alarmKey(event);
+    if (firedAlarms.has(key)) continue;
+    if (target.stops > threshold) return null;
+    return event;
+  }
+  return null;
 }
 
 function resolveStationType(

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -47,12 +47,16 @@ export interface TransferRoute {
   stopsFromTransfer: number;
 }
 
+export interface TransferSegment {
+  transferName: string;
+  fromLine: string;
+  toLine: string;
+  stopsToTransfer: number;
+}
+
 export interface MultiTransferRoute {
   type: 'multi-transfer';
-  transfers: [
-    { transferName: string; fromLine: string; toLine: string; stopsToTransfer: number },
-    { transferName: string; fromLine: string; toLine: string; stopsToTransfer: number },
-  ];
+  transfers: TransferSegment[];
   stopsAfterLastTransfer: number;
 }
 
@@ -155,32 +159,30 @@ export function updateRouteFromPosition(
     return null;
   }
 
-  // multi-transfer
-  const [t1, t2] = storedRoute.transfers;
+  // multi-transfer: transfers 배열을 순회하여 현재 구간 탐색
+  const { transfers } = storedRoute;
 
-  if (nearestStation.line === t1.fromLine) {
-    const station = findStationByNameAndLine(t1.transferName, t1.fromLine);
-    if (!station) return null;
-    const stops = getRemainingStops(nearestStation.id, station.id);
-    return stops !== null
-      ? { ...storedRoute, transfers: [{ ...t1, stopsToTransfer: stops }, t2] as MultiTransferRoute['transfers'] }
-      : null;
+  for (let i = 0; i < transfers.length; i++) {
+    const segment = transfers[i];
+    if (nearestStation.line === segment.fromLine) {
+      const station = findStationByNameAndLine(segment.transferName, segment.fromLine);
+      if (!station) return null;
+      const stops = getRemainingStops(nearestStation.id, station.id);
+      if (stops === null) return null;
+      const updatedTransfers = transfers.map((t, j) =>
+        j < i ? { ...t, stopsToTransfer: 0 } : j === i ? { ...t, stopsToTransfer: stops } : t,
+      );
+      return { ...storedRoute, transfers: updatedTransfers };
+    }
   }
 
-  if (nearestStation.line === t1.toLine) {
-    const station = findStationByNameAndLine(t2.transferName, t1.toLine);
-    if (!station) return null;
-    const stops = getRemainingStops(nearestStation.id, station.id);
-    return stops !== null
-      ? { ...storedRoute, transfers: [{ ...t1, stopsToTransfer: 0 }, { ...t2, stopsToTransfer: stops }] as MultiTransferRoute['transfers'] }
-      : null;
-  }
-
-  if (nearestStation.line === t2.toLine) {
+  // 마지막 환승 이후 구간 (목적지 방향)
+  const lastTransfer = transfers[transfers.length - 1];
+  if (lastTransfer && nearestStation.line === lastTransfer.toLine) {
     const stops = getRemainingStops(nearestStation.id, destinationId);
-    return stops !== null
-      ? { ...storedRoute, transfers: [{ ...t1, stopsToTransfer: 0 }, { ...t2, stopsToTransfer: 0 }] as MultiTransferRoute['transfers'], stopsAfterLastTransfer: stops }
-      : null;
+    if (stops === null) return null;
+    const updatedTransfers = transfers.map((t) => ({ ...t, stopsToTransfer: 0 }));
+    return { ...storedRoute, transfers: updatedTransfers, stopsAfterLastTransfer: stops };
   }
 
   return null;
@@ -446,35 +448,29 @@ export function buildJourneyDisplay(
     };
   }
 
-  // multi-transfer
-  const [t1, t2] = route.transfers;
-  const totalStops = t1.stopsToTransfer + t2.stopsToTransfer + route.stopsAfterLastTransfer;
-  return {
-    segments: [
-      {
-        line: t1.fromLine,
-        lineColor: LINE_COLORS[t1.fromLine as LineNumber] ?? current.lineColor,
-        fromName: current.name,
-        toName: t1.transferName,
-        stops: t1.stopsToTransfer,
-      },
-      {
-        line: t1.toLine,
-        lineColor: LINE_COLORS[t1.toLine as LineNumber] ?? '#888888',
-        fromName: t1.transferName,
-        toName: t2.transferName,
-        stops: t2.stopsToTransfer,
-      },
-      {
-        line: t2.toLine,
-        lineColor: LINE_COLORS[t2.toLine as LineNumber] ?? destination.lineColor,
-        fromName: t2.transferName,
-        toName: destination.name,
-        stops: route.stopsAfterLastTransfer,
-      },
-    ],
-    totalStops,
-  };
+  // multi-transfer: transfers 배열을 순회하여 세그먼트 생성
+  const { transfers } = route;
+  const segments: JourneyDisplay['segments'] = transfers.map((t, i) => {
+    const prevName = i === 0 ? current.name : transfers[i - 1].transferName;
+    const fallbackColor = i === 0 ? current.lineColor : '#888888';
+    return {
+      line: t.fromLine,
+      lineColor: LINE_COLORS[t.fromLine as LineNumber] ?? fallbackColor,
+      fromName: prevName,
+      toName: t.transferName,
+      stops: t.stopsToTransfer,
+    };
+  });
+  const lastTransfer = transfers[transfers.length - 1];
+  segments.push({
+    line: lastTransfer.toLine,
+    lineColor: LINE_COLORS[lastTransfer.toLine as LineNumber] ?? destination.lineColor,
+    fromName: lastTransfer.transferName,
+    toName: destination.name,
+    stops: route.stopsAfterLastTransfer,
+  });
+  const totalStops = transfers.reduce((sum, t) => sum + t.stopsToTransfer, 0) + route.stopsAfterLastTransfer;
+  return { segments, totalStops };
 }
 
 const DEFAULT_WAIT_MINUTES = 3;
@@ -546,12 +542,15 @@ export function getNextStationName(
   }
 
   // multi-transfer
-  const [t1, t2] = route.transfers;
-  if (t1.stopsToTransfer > 0) {
-    return getNextStationOnLine(t1.fromLine, current.name, t1.transferName);
+  // multi-transfer: 첫 번째 미완료 구간의 다음 역 반환
+  const { transfers } = route;
+  for (let i = 0; i < transfers.length; i++) {
+    const segment = transfers[i];
+    if (segment.stopsToTransfer > 0) {
+      const line = i === 0 ? segment.fromLine : transfers[i - 1].toLine;
+      return getNextStationOnLine(line, current.name, segment.transferName);
+    }
   }
-  if (t2.stopsToTransfer > 0) {
-    return getNextStationOnLine(t1.toLine, current.name, t2.transferName);
-  }
-  return getNextStationOnLine(t2.toLine, current.name, destination.name);
+  const lastTransfer = transfers[transfers.length - 1];
+  return getNextStationOnLine(lastTransfer.toLine, current.name, destination.name);
 }


### PR DESCRIPTION
## Summary

- 2번 환승(multi-transfer) 경로에서 첫 환승 알람 발생 후 두 번째 환승 알람이 절대 발생하지 않는 버그 수정
- `resolveCurrentTarget`이 항상 `transfers[0]`만 반환하는 하드코딩 → `resolveAllTargets`로 모든 웨이포인트 순회
- `MultiTransferRoute.transfers` 타입을 튜플 → `TransferSegment[]` 배열로 변경
- `updateRouteFromPosition`, `buildJourneyDisplay`, `getNextStationName`의 `const [t1, t2]` 하드코딩을 모두 배열 순회로 변경

## Test plan

- [x] `npm test` — 648 테스트 통과, 커버리지 100%
- [x] `npm run type-check` — 타입체크 통과
- [x] 2번 환승 전체 여정 시뮬레이션 테스트 (첫 환승 → 두 번째 환승 → 도착 순차 알람 발생 확인)
- [x] TransferRoute 환승 fired 후 도착 알람 발생 테스트
- [ ] 시뮬레이터에서 2번 환승 경로 실제 알람 동작 확인

Closes #161