### PR TITLE
perf(#163): 매 역마다 Live Activity 갱신 + 푸시 알림

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -116,7 +116,7 @@ export default function HomeScreen() {
   );
 
   // nextStationName이 확정됐으면 stops=0으로 즉시 시간 기반 임계 통과 (firedAlarms로 중복 방지)
-  useStationAlarm(route, destination?.name ?? null);
+  useStationAlarm(route, destination?.name ?? null, result?.station ?? null);
   useBackgroundLocation(destination);
 
   useEffect(() => {

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -7,3 +7,4 @@ export const CUSTOM_ORIGIN_KEY = 'subway-now:custom-origin';
 export const THEME_MODE_KEY = 'subway-now:theme-mode';
 export const ROUTE_PREFERENCE_KEY = 'subway-now:route-preference';
 export const ROUTE_KEY = 'subway-now:route';
+export const LAST_NOTIFIED_STATION_KEY = 'subway-now:last-notified-station';

--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -109,8 +109,8 @@ describe('useBackgroundLocation', () => {
         'background-location-task',
         expect.objectContaining({
           accuracy: 6, // Location.Accuracy.High
-          distanceInterval: 100,
-          deferredUpdatesInterval: 30_000,
+          distanceInterval: 50,
+          deferredUpdatesInterval: 10_000,
           showsBackgroundLocationIndicator: true,
           foregroundService: expect.objectContaining({
             notificationTitle: '지하철 위치 감지 중',

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -139,7 +139,7 @@ describe('useNearestStation', () => {
     );
 
     act(() => {
-      jest.advanceTimersByTime(30_000);
+      jest.advanceTimersByTime(10_000);
     });
 
     await waitFor(() =>
@@ -264,7 +264,7 @@ describe('useNearestStation', () => {
     });
 
     act(() => {
-      jest.advanceTimersByTime(30_000);
+      jest.advanceTimersByTime(10_000);
     });
 
     await waitFor(() =>

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -2,17 +2,22 @@ import { renderHook } from '@testing-library/react-native';
 import { useStationAlarm } from '../useStationAlarm';
 import { useAppStore } from '../../store/useAppStore';
 import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../../utils/stationRoute';
+import type { Station } from '../../types/station';
 
 const mockSendAlarmNotification = jest.fn().mockResolvedValue(undefined);
+const mockSendStationPassedNotification = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../../utils/stationNotification', () => ({
   sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
+  sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
 }));
 
 const mockEvaluateAllAlarms = jest.fn();
+const mockResolveNextTarget = jest.fn();
 
 jest.mock('../../utils/stationPipeline', () => ({
   evaluateAllAlarms: (...args: unknown[]) => mockEvaluateAllAlarms(...args),
+  resolveNextTarget: (...args: unknown[]) => mockResolveNextTarget(...args),
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -28,22 +33,32 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );
 
+const makeStation = (id: string, name: string): Station => ({
+  id,
+  name,
+  line: '2',
+  lineColor: '#33A23D',
+  lat: 37.5,
+  lng: 127.0,
+});
+
 describe('useStationAlarm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useAppStore.setState({ sleepMode: false, alarmEvent: null });
     mockEvaluateAllAlarms.mockReturnValue(null);
+    mockResolveNextTarget.mockReturnValue(null);
   });
 
   it('should not send alarm when route is null', () => {
-    renderHook(() => useStationAlarm(null, '강남'));
+    renderHook(() => useStationAlarm(null, '강남', null));
     expect(mockEvaluateAllAlarms).not.toHaveBeenCalled();
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
 
   it('should not send alarm when destinationName is null', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    renderHook(() => useStationAlarm(route, null));
+    renderHook(() => useStationAlarm(route, null, null));
     expect(mockEvaluateAllAlarms).not.toHaveBeenCalled();
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
@@ -51,7 +66,7 @@ describe('useStationAlarm', () => {
   it('should not send alarm when evaluateAllAlarms returns null', () => {
     const route: DirectRoute = { type: 'direct', stops: 3 };
     mockEvaluateAllAlarms.mockReturnValue(null);
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockEvaluateAllAlarms).toHaveBeenCalledWith(route, '강남', expect.any(Set));
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
@@ -59,7 +74,7 @@ describe('useStationAlarm', () => {
   it('should send destination alarm for direct route', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false);
   });
 
@@ -73,7 +88,7 @@ describe('useStationAlarm', () => {
       stopsFromTransfer: 5,
     };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청' });
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false);
   });
 
@@ -87,7 +102,7 @@ describe('useStationAlarm', () => {
       stopsFromTransfer: 1,
     };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false);
   });
 
@@ -101,14 +116,14 @@ describe('useStationAlarm', () => {
       stopsAfterLastTransfer: 3,
     };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청' });
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false);
   });
 
   it('should not fire same alarm twice', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    const { rerender } = renderHook(() => useStationAlarm(route, '강남'));
+    const { rerender } = renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
 
     rerender({});
@@ -119,7 +134,7 @@ describe('useStationAlarm', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
     const { rerender } = renderHook(
-      ({ dest }: { dest: string }) => useStationAlarm(route, dest),
+      ({ dest }: { dest: string }) => useStationAlarm(route, dest, null),
       { initialProps: { dest: '강남' } },
     );
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
@@ -134,7 +149,7 @@ describe('useStationAlarm', () => {
     useAppStore.setState({ sleepMode: true });
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', true, false);
   });
 
@@ -142,7 +157,7 @@ describe('useStationAlarm', () => {
     useAppStore.setState({ sleepMode: true });
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(useAppStore.getState().alarmEvent).toEqual({ type: 'destination', stationName: '강남' });
   });
 
@@ -150,14 +165,14 @@ describe('useStationAlarm', () => {
     useAppStore.setState({ sleepMode: false });
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남'));
+    renderHook(() => useStationAlarm(route, '강남', null));
     expect(useAppStore.getState().alarmEvent).toBeNull();
   });
 
   it('should not re-fire alarm when sleepMode changes', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    const { rerender } = renderHook(() => useStationAlarm(route, '강남'));
+    const { rerender } = renderHook(() => useStationAlarm(route, '강남', null));
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
 
     useAppStore.setState({ sleepMode: true });
@@ -169,14 +184,14 @@ describe('useStationAlarm', () => {
     mockSendAlarmNotification.mockRejectedValueOnce(new Error('알림 실패'));
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    expect(() => renderHook(() => useStationAlarm(route, '강남'))).not.toThrow();
+    expect(() => renderHook(() => useStationAlarm(route, '강남', null))).not.toThrow();
   });
 
   describe('time-based alarm', () => {
     it('should send time-based alarm with timeBased flag', () => {
       const route: DirectRoute = { type: 'direct', stops: 5 };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'approaching', stationName: '역삼', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남'));
+      renderHook(() => useStationAlarm(route, '강남', null));
       expect(mockSendAlarmNotification).toHaveBeenCalledWith('approaching', '역삼', false, true);
     });
 
@@ -190,7 +205,7 @@ describe('useStationAlarm', () => {
         stopsFromTransfer: 5,
       };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남'));
+      renderHook(() => useStationAlarm(route, '강남', null));
       expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, true);
     });
 
@@ -198,7 +213,7 @@ describe('useStationAlarm', () => {
       useAppStore.setState({ sleepMode: true });
       const route: DirectRoute = { type: 'direct', stops: 1 };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남'));
+      renderHook(() => useStationAlarm(route, '강남', null));
       expect(useAppStore.getState().alarmEvent).toEqual({ type: 'destination', stationName: '강남' });
     });
 
@@ -206,7 +221,7 @@ describe('useStationAlarm', () => {
       useAppStore.setState({ sleepMode: true });
       const route: DirectRoute = { type: 'direct', stops: 5 };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'approaching', stationName: '역삼', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남'));
+      renderHook(() => useStationAlarm(route, '강남', null));
       expect(useAppStore.getState().alarmEvent).toBeNull();
     });
 
@@ -214,7 +229,7 @@ describe('useStationAlarm', () => {
       mockSendAlarmNotification.mockRejectedValueOnce(new Error('시간 기반 알림 실패'));
       const route: DirectRoute = { type: 'direct', stops: 5 };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'approaching', stationName: '역삼', timeBased: true });
-      expect(() => renderHook(() => useStationAlarm(route, '강남'))).not.toThrow();
+      expect(() => renderHook(() => useStationAlarm(route, '강남', null))).not.toThrow();
     });
 
     it('should set alarmEvent in sleep mode for transfer time-based alarm', () => {
@@ -228,8 +243,84 @@ describe('useStationAlarm', () => {
         stopsFromTransfer: 5,
       };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남'));
+      renderHook(() => useStationAlarm(route, '강남', null));
       expect(useAppStore.getState().alarmEvent).toEqual({ type: 'transfer', stationName: '시청' });
+    });
+  });
+
+  describe('station-passed notification', () => {
+    it('역이 변경되면 per-station 알림을 발송한다', () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      renderHook(() => useStationAlarm(route, '강남', station));
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', 3);
+    });
+
+    it('같은 역이면 per-station 알림을 발송하지 않는다', () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      const { rerender } = renderHook(
+        ({ s }: { s: Station }) => useStationAlarm(route, '강남', s),
+        { initialProps: { s: station } },
+      );
+      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+
+      rerender({ s: station });
+      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('역이 다른 역으로 변경되면 다시 발송한다', () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station1 = makeStation('S1', '역삼');
+      const station2 = makeStation('S2', '선릉');
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      const { rerender } = renderHook(
+        ({ s }: { s: Station }) => useStationAlarm(route, '강남', s),
+        { initialProps: { s: station1 } },
+      );
+      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2 });
+      rerender({ s: station2 });
+      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
+      expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', 2);
+    });
+
+    it('nearestStation이 null이면 per-station 알림을 발송하지 않는다', () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      renderHook(() => useStationAlarm(route, '강남', null));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('route가 없으면 per-station 알림을 발송하지 않는다', () => {
+      const station = makeStation('S1', '역삼');
+      renderHook(() => useStationAlarm(null, '강남', station));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('destinationName이 없으면 per-station 알림을 발송하지 않는다', () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      renderHook(() => useStationAlarm(route, null, station));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('resolveNextTarget이 null을 반환하면 stopsRemaining을 null로 전달한다', () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue(null);
+      renderHook(() => useStationAlarm(route, '강남', station));
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', null);
+    });
+
+    it('sendStationPassedNotification 실패 시 에러를 던지지 않는다', () => {
+      mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 실패'));
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      expect(() => renderHook(() => useStationAlarm(route, '강남', station))).not.toThrow();
     });
   });
 });

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -31,8 +31,8 @@ export function useBackgroundLocation(destination: Station | null): void {
 
       await Location.startLocationUpdatesAsync(BACKGROUND_LOCATION_TASK, {
         accuracy: Location.Accuracy.High,
-        distanceInterval: 100,
-        deferredUpdatesInterval: 30_000,
+        distanceInterval: 50,
+        deferredUpdatesInterval: 10_000,
         showsBackgroundLocationIndicator: true,
         foregroundService: {
           notificationTitle: '지하철 위치 감지 중',

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -4,7 +4,7 @@ import { NearestStationResult, Station } from '../types/station';
 import { findNearestStations } from '../utils/findNearestStation';
 import { usePolling } from './usePolling';
 
-const UPDATE_INTERVAL_MS = 30_000;
+const UPDATE_INTERVAL_MS = 10_000;
 
 interface UseNearestStationReturn {
   result: NearestStationResult | null;

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -1,8 +1,9 @@
 import { useEffect, useRef } from 'react';
 import type { Route } from '../utils/stationRoute';
+import type { Station } from '../types/station';
 import { alarmKey } from '../utils/stationAlarm';
-import { evaluateAllAlarms } from '../utils/stationPipeline';
-import { sendAlarmNotification } from '../utils/stationNotification';
+import { evaluateAllAlarms, resolveNextTarget } from '../utils/stationPipeline';
+import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 
@@ -11,9 +12,11 @@ const logger = createLogger('StationAlarm');
 export function useStationAlarm(
   route: Route,
   destinationName: string | null,
+  nearestStation: Station | null,
 ): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
+  const lastNotifiedStationIdRef = useRef<string | null>(null);
   const sleepMode = useAppStore((s) => s.sleepMode);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
   const sleepModeRef = useRef(sleepMode);
@@ -31,14 +34,23 @@ export function useStationAlarm(
     if (!route || !destinationName) return;
 
     const event = evaluateAllAlarms(route, destinationName, firedAlarmsRef.current);
-    if (!event) return;
-
-    firedAlarmsRef.current.add(alarmKey(event));
-    if (sleepModeRef.current && event.type !== 'approaching') {
-      setAlarmEvent({ type: event.type, stationName: event.stationName });
+    if (event) {
+      firedAlarmsRef.current.add(alarmKey(event));
+      if (sleepModeRef.current && event.type !== 'approaching') {
+        setAlarmEvent({ type: event.type, stationName: event.stationName });
+      }
+      sendAlarmNotification(event.type, event.stationName, sleepModeRef.current, event.timeBased ?? false).catch((e) =>
+        logger.error('알람 알림 실패:', e),
+      );
     }
-    sendAlarmNotification(event.type, event.stationName, sleepModeRef.current, event.timeBased ?? false).catch((e) =>
-      logger.error('알람 알림 실패:', e),
-    );
-  }, [route, destinationName]);
+
+    // 역 변경 감지 → per-station 알림 (route + destination이 모두 있을 때만)
+    if (nearestStation && route && destinationName && nearestStation.id !== lastNotifiedStationIdRef.current) {
+      lastNotifiedStationIdRef.current = nearestStation.id;
+      const target = resolveNextTarget(route, destinationName);
+      const stopsRemaining = target?.stopsToNextStation ?? null;
+      sendStationPassedNotification(nearestStation.name, destinationName, stopsRemaining)
+        .catch((e) => logger.error('역 통과 알림 실패:', e));
+    }
+  }, [route, destinationName, nearestStation?.id]);
 }

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -103,6 +103,22 @@ function getTaskCallback(): TaskCallback {
   return (global as any).__bgTaskCallback as TaskCallback;
 }
 
+/** AsyncStorage.getItem 5개를 순서대로 모킹한다 (dest, sleep, fired, route, lastNotified) */
+function mockStorageValues(
+  dest: string | null,
+  sleep: string | null = null,
+  fired: string | null = null,
+  route: string | null = null,
+  lastNotified: string | null = null,
+): void {
+  (AsyncStorage.getItem as jest.Mock)
+    .mockResolvedValueOnce(dest)
+    .mockResolvedValueOnce(sleep)
+    .mockResolvedValueOnce(fired)
+    .mockResolvedValueOnce(route)
+    .mockResolvedValueOnce(lastNotified);
+}
+
 describe('BACKGROUND_LOCATION_TASK 상수', () => {
   it('올바른 태스크 이름 문자열을 갖는다', () => {
     expect(BACKGROUND_LOCATION_TASK).toBe('background-location-task');
@@ -120,7 +136,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     jest.clearAllMocks();
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
     mockUpdateStationNotification.mockResolvedValue(undefined);
     mockFindNearestStation.mockReturnValue(null);
   });
@@ -193,15 +209,12 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── 목적지 설정 + alarmEvent 없음 ──
 
   it('destJson이 있고 alarmEvent가 null이면 AsyncStorage.setItem을 호출하지 않는다', async () => {
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination)) // DESTINATION_KEY
-      .mockResolvedValueOnce(null)                            // SLEEP_MODE_KEY
-      .mockResolvedValueOnce(null)                            // FIRED_ALARMS_KEY
-      .mockResolvedValueOnce(null);                           // ROUTE_KEY
+    mockStorageValues(JSON.stringify(mockDestination));
 
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent: null,
       nearest: { station: mockStation, distanceKm: 0.1 },
+      lastNotifiedStationId: null,
     });
 
     await taskCallback({
@@ -216,6 +229,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       new Set(),
       false,
       null,
+      null,
     );
     expect(AsyncStorage.setItem).not.toHaveBeenCalled();
   });
@@ -223,13 +237,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── sleepMode 파싱 ──
 
   it("sleepJson이 'true'이면 sleepMode=true로 processLocationUpdate를 호출한다", async () => {
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce('true')
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+    mockStorageValues(JSON.stringify(mockDestination), 'true');
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -243,17 +253,14 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       new Set(),
       true,
       null,
+      null,
     );
   });
 
   it("sleepJson이 'false'이면 sleepMode=false로 processLocationUpdate를 호출한다", async () => {
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce('false')
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+    mockStorageValues(JSON.stringify(mockDestination), 'false');
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -267,6 +274,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       new Set(),
       false,
       null,
+      null,
     );
   });
 
@@ -274,13 +282,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('firedJson이 있으면 파싱한 Set을 processLocationUpdate에 전달한다', async () => {
     const fired = ['destination:강남', 'transfer:시청'];
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(JSON.stringify(fired))
-      .mockResolvedValueOnce(null);
+    mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(fired));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -294,19 +298,16 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       new Set(fired),
       false,
       null,
+      null,
     );
   });
 
   // ── ROUTE_KEY 관련 테스트 ──
 
   it('ROUTE_KEY를 AsyncStorage에서 읽는다', async () => {
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+    mockStorageValues(JSON.stringify(mockDestination));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -318,13 +319,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('routeJson이 있으면 파싱한 route를 processLocationUpdate에 전달한다', async () => {
     const storedRoute = { type: 'direct', stops: 3 };
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(JSON.stringify(storedRoute));
+    mockStorageValues(JSON.stringify(mockDestination), null, null, JSON.stringify(storedRoute));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -338,17 +335,14 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       new Set(),
       false,
       storedRoute,
+      null,
     );
   });
 
   it('routeJson이 null이면 null storedRoute를 processLocationUpdate에 전달한다', async () => {
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+    mockStorageValues(JSON.stringify(mockDestination));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -362,6 +356,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       new Set(),
       false,
       null,
+      null,
     );
   });
 
@@ -369,14 +364,12 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('alarmEvent가 있으면 alarmKey를 추가하고 AsyncStorage.setItem을 호출한다', async () => {
     const alarmEvent: AlarmEvent = { type: 'destination', stationName: '시청' };
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+    mockStorageValues(JSON.stringify(mockDestination));
 
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent,
       nearest: { station: mockStation, distanceKm: 0.1 },
+      lastNotifiedStationId: null,
     });
     mockAlarmKey.mockReturnValue('destination:시청');
 
@@ -399,14 +392,12 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it('기존 firedAlarms에 alarmEvent 키를 추가하여 저장한다', async () => {
     const alarmEvent: AlarmEvent = { type: 'transfer', stationName: '강남' };
     const existingFired = ['destination:시청'];
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(JSON.stringify(existingFired));
+    mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(existingFired));
 
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent,
       nearest: { station: mockStation, distanceKm: 0.1 },
+      lastNotifiedStationId: null,
     });
     mockAlarmKey.mockReturnValue('transfer:강남');
 
@@ -428,10 +419,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── destJson 파싱 실패 분기 ──
 
   it('destJson이 손상된 JSON이면 즉시 return한다', async () => {
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce('invalid-json{{{')  // DESTINATION_KEY — 파싱 실패
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+    mockStorageValues('invalid-json{{{');
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -461,10 +449,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── 전체 try-catch 에러 핸들링 ──
 
   it('processLocationUpdate가 실패해도 태스크가 크래시하지 않는다', async () => {
-    (AsyncStorage.getItem as jest.Mock)
-      .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+    mockStorageValues(JSON.stringify(mockDestination));
 
     mockProcessLocationUpdate.mockRejectedValueOnce(new Error('파이프라인 오류'));
 
@@ -474,5 +459,83 @@ describe('backgroundLocationTask defineTask 콜백', () => {
         error: null,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  // ── LAST_NOTIFIED_STATION_KEY 관련 테스트 ──
+
+  it('LAST_NOTIFIED_STATION_KEY를 AsyncStorage에서 읽어 processLocationUpdate에 전달한다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'station-1');
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: 'station-1' });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('subway-now:last-notified-station');
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(),
+      false,
+      null,
+      'station-1',
+    );
+  });
+
+  it('lastNotifiedStationId가 변경되면 AsyncStorage에 저장한다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'station-1');
+
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent: null,
+      nearest: null,
+      lastNotifiedStationId: 'station-2',
+    });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:last-notified-station',
+      'station-2',
+    );
+  });
+
+  it('lastNotifiedStationId가 변경되지 않으면 저장하지 않는다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'station-1');
+
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent: null,
+      nearest: null,
+      lastNotifiedStationId: 'station-1',
+    });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('lastNotifiedStationId가 null이면 저장하지 않는다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination));
+
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent: null,
+      nearest: null,
+      lastNotifiedStationId: null,
+    });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
   });
 });

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -6,7 +6,7 @@ import { alarmKey } from '../utils/stationAlarm';
 import { updateStationNotification } from '../utils/stationNotification';
 import { findNearestStation } from '../utils/findNearestStation';
 import { createLogger } from '../utils/logger';
-import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY } from '../constants/storageKeys';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
 import type { Route } from '../utils/stationRoute';
 
 const logger = createLogger('BackgroundLocation');
@@ -27,11 +27,12 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const { latitude, longitude } = latest.coords;
 
   try {
-    const [destJson, sleepJson, firedJson, routeJson] = await Promise.all([
+    const [destJson, sleepJson, firedJson, routeJson, lastNotifiedJson] = await Promise.all([
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(SLEEP_MODE_KEY),
       AsyncStorage.getItem(FIRED_ALARMS_KEY),
       AsyncStorage.getItem(ROUTE_KEY),
+      AsyncStorage.getItem(LAST_NOTIFIED_STATION_KEY),
     ]);
 
     // 목적지 미설정 시 현재 역 알림만 업데이트
@@ -57,21 +58,29 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
     const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
 
-    const { alarmEvent } = await processLocationUpdate(
+    const { alarmEvent, lastNotifiedStationId: newLastId } = await processLocationUpdate(
       latitude,
       longitude,
       destination,
       firedAlarms,
       sleepMode,
       storedRoute,
+      lastNotifiedJson,
     );
 
+    const writes: Promise<void>[] = [];
     if (alarmEvent) {
       firedAlarms.add(alarmKey(alarmEvent));
-      await Promise.all([
+      writes.push(
         AsyncStorage.setItem(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms])),
         AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
-      ]);
+      );
+    }
+    if (newLastId && newLastId !== lastNotifiedJson) {
+      writes.push(AsyncStorage.setItem(LAST_NOTIFIED_STATION_KEY, newLastId));
+    }
+    if (writes.length > 0) {
+      await Promise.all(writes);
     }
 
     logger.info('백그라운드 위치 업데이트 완료:', latitude.toFixed(4), longitude.toFixed(4));

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -7,6 +7,7 @@ import {
   clearStationNotification,
   sendAlarmNotification,
   clearAlarmNotification,
+  sendStationPassedNotification,
 } from '../stationNotification';
 import { Station } from '../../types/station';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
@@ -152,6 +153,11 @@ describe('stationNotification', () => {
         vibrationPattern: [0, 1000, 500, 1000],
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
         bypassDnd: true,
+      });
+      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-passed', {
+        name: '역 통과 알림',
+        importance: Notifications.AndroidImportance.DEFAULT,
+        lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
       });
       expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
     });
@@ -381,13 +387,13 @@ describe('stationNotification', () => {
   });
 
   describe('clearStationNotification', () => {
-    it('iOS에서 endLiveActivity를 호출한다', async () => {
+    it('iOS에서 endLiveActivity를 호출하고 station-passed 알림도 해제한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       mockIsLiveActivityEnabled.mockReturnValue(true);
 
       await clearStationNotification();
       expect(mockEndLiveActivity).toHaveBeenCalled();
-      expect(Notifications.dismissNotificationAsync).not.toHaveBeenCalled();
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('station-passed');
     });
 
     it('iOS에서 endLiveActivity가 실패해도 에러를 던지지 않는다', async () => {
@@ -398,11 +404,20 @@ describe('stationNotification', () => {
       await expect(clearStationNotification()).resolves.toBeUndefined();
     });
 
+    it('station-passed dismiss 실패해도 에러를 던지지 않는다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+      (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValue(new Error('dismiss 실패'));
+
+      await expect(clearStationNotification()).resolves.toBeUndefined();
+    });
+
     it('iOS에서 Live Activity 비활성화 시 dismissNotificationAsync를 호출한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       mockIsLiveActivityEnabled.mockReturnValue(false);
       await clearStationNotification();
       expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('current-station');
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('station-passed');
       expect(mockEndLiveActivity).not.toHaveBeenCalled();
     });
 
@@ -410,6 +425,7 @@ describe('stationNotification', () => {
       jest.replaceProperty(Platform, 'OS', 'android');
       await clearStationNotification();
       expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('current-station');
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('station-passed');
       expect(mockEndLiveActivity).not.toHaveBeenCalled();
     });
   });
@@ -491,6 +507,43 @@ describe('stationNotification', () => {
       await sendAlarmNotification('destination', '강남');
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
       expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000], false);
+    });
+  });
+
+  describe('sendStationPassedNotification', () => {
+    it('stopsRemaining이 있으면 남은 정거장 수를 body에 표시한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendStationPassedNotification('역삼', '강남', 3);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-passed',
+        content: { title: '역삼역 통과', body: '강남까지 3정거장 남음' },
+        trigger: null,
+      });
+    });
+
+    it('stopsRemaining이 null이면 현재 역만 표시한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendStationPassedNotification('역삼', '강남', null);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-passed',
+        content: { title: '역삼역 통과', body: '현재 역삼역' },
+        trigger: null,
+      });
+    });
+
+    it('Android에서는 channelId와 priority DEFAULT가 포함된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await sendStationPassedNotification('역삼', '강남', 3);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-passed',
+        content: {
+          title: '역삼역 통과',
+          body: '강남까지 3정거장 남음',
+          channelId: 'station-passed',
+          priority: 'default',
+        },
+        trigger: null,
+      });
     });
   });
 

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -29,9 +29,11 @@ jest.mock('../stationAlarm', () => ({
 
 const mockSendAlarmNotification = jest.fn();
 const mockUpdateStationNotification = jest.fn();
+const mockSendStationPassedNotification = jest.fn();
 jest.mock('../stationNotification', () => ({
   sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
   updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
+  sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
 }));
 
 import { evaluateAllAlarms, processLocationUpdate, resolveNextTarget } from '../stationPipeline';
@@ -185,6 +187,7 @@ describe('processLocationUpdate', () => {
     jest.clearAllMocks();
     mockSendAlarmNotification.mockResolvedValue(undefined);
     mockUpdateStationNotification.mockResolvedValue(undefined);
+    mockSendStationPassedNotification.mockResolvedValue(undefined);
     mockCalculateStaticETA.mockReturnValue(10);
     mockCheckAlarm.mockReturnValue(null);
     mockCheckTimeBasedAlarm.mockReturnValue(null);
@@ -197,7 +200,7 @@ describe('processLocationUpdate', () => {
       37.5, 127.0, mockDestination, new Set(), false,
     );
 
-    expect(result).toEqual({ alarmEvent: null, nearest: null });
+    expect(result).toEqual({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
     expect(mockFindRoute).not.toHaveBeenCalled();
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
     expect(mockUpdateStationNotification).not.toHaveBeenCalled();
@@ -460,6 +463,42 @@ describe('processLocationUpdate', () => {
 
     expect(mockUpdateRouteFromPosition).not.toHaveBeenCalled();
     expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
+  });
+
+  it('should send station-passed notification when station changes', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false, null, 'other-station',
+    );
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
+    expect(result.lastNotifiedStationId).toBe('station-1');
+  });
+
+  it('should not send station-passed notification when station is the same', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false, null, 'station-1',
+    );
+
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(result.lastNotifiedStationId).toBe('station-1');
+  });
+
+  it('should send station-passed notification when lastNotifiedStationId is null', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false, null, null,
+    );
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
+    expect(result.lastNotifiedStationId).toBe('station-1');
   });
 });
 

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -14,6 +14,8 @@ const liveActivityLogger = createLogger('LiveActivity');
 export const NOTIFICATION_ID = 'current-station';
 export const ALARM_NOTIFICATION_ID = 'station-alarm';
 const ALARM_CHANNEL_ID = 'station-alarm';
+export const STATION_PASSED_NOTIFICATION_ID = 'station-passed';
+const STATION_PASSED_CHANNEL_ID = 'station-passed';
 
 
 async function scheduleNotification(
@@ -63,6 +65,11 @@ export async function initStationNotification(): Promise<void> {
       vibrationPattern: [0, 1000, 500, 1000],
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
       bypassDnd: true,
+    });
+    await Notifications.setNotificationChannelAsync(STATION_PASSED_CHANNEL_ID, {
+      name: '역 통과 알림',
+      importance: Notifications.AndroidImportance.DEFAULT,
+      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
     });
   }
   const { status } = await Notifications.requestPermissionsAsync({
@@ -205,11 +212,16 @@ export async function updateStationNotification(
   notifLogger.info('알림 예약 완료');
 }
 
+async function dismissStationPassedNotification(): Promise<void> {
+  await Notifications.dismissNotificationAsync(STATION_PASSED_NOTIFICATION_ID).catch(() => {});
+}
+
 export async function clearStationNotification(): Promise<void> {
   if (Platform.OS === 'ios') {
     if (!LiveActivity.isLiveActivityEnabled()) {
       notifLogger.info('알림 해제 (Live Activity 비활성)');
       await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+      await dismissStationPassedNotification();
       return;
     }
     try {
@@ -219,10 +231,32 @@ export async function clearStationNotification(): Promise<void> {
     } catch (e) {
       liveActivityLogger.error('종료 실패:', e);
     }
+    await dismissStationPassedNotification();
     return;
   }
   notifLogger.info('Android 알림 해제');
   await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
+  await dismissStationPassedNotification();
+}
+
+export async function sendStationPassedNotification(
+  stationName: string,
+  destinationName: string,
+  stopsRemaining: number | null,
+): Promise<void> {
+  const body = stopsRemaining != null
+    ? `${destinationName}까지 ${stopsRemaining}정거장 남음`
+    : `현재 ${stationName}역`;
+
+  await scheduleNotification(STATION_PASSED_NOTIFICATION_ID, {
+    title: `${stationName}역 통과`,
+    body,
+    ...(Platform.OS === 'android' && {
+      channelId: STATION_PASSED_CHANNEL_ID,
+      priority: Notifications.AndroidNotificationPriority.DEFAULT,
+    }),
+  });
+  notifLogger.info('역 통과 알림:', stationName, body);
 }
 
 export async function sendAlarmNotification(

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -1,7 +1,7 @@
 import { findNearestStation } from './findNearestStation';
 import { findRoute, calculateStaticETA, updateRouteFromPosition } from './stationRoute';
 import { checkAlarm, checkTimeBasedAlarm } from './stationAlarm';
-import { sendAlarmNotification, updateStationNotification } from './stationNotification';
+import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
 import type { AlarmEvent } from './stationAlarm';
@@ -75,6 +75,7 @@ export function evaluateAllAlarms(
 export interface PipelineResult {
   alarmEvent: AlarmEvent | null;
   nearest: NearestStationResult | null;
+  lastNotifiedStationId: string | null;
 }
 
 export async function processLocationUpdate(
@@ -84,9 +85,10 @@ export async function processLocationUpdate(
   firedAlarms: Set<string>,
   sleepMode: boolean,
   storedRoute: Route = null,
+  lastNotifiedStationId: string | null = null,
 ): Promise<PipelineResult> {
   const nearest = findNearestStation(lat, lng);
-  if (!nearest) return { alarmEvent: null, nearest: null };
+  if (!nearest) return { alarmEvent: null, nearest: null, lastNotifiedStationId };
 
   let route: Route = null;
   if (storedRoute) {
@@ -106,6 +108,18 @@ export async function processLocationUpdate(
     );
   }
 
+  // 역 변경 감지 → per-station 알림
+  let newLastNotifiedStationId = lastNotifiedStationId;
+  if (nearest.station.id !== lastNotifiedStationId) {
+    newLastNotifiedStationId = nearest.station.id;
+    const target = resolveNextTarget(route, destination.name);
+    await sendStationPassedNotification(
+      nearest.station.name,
+      destination.name,
+      target?.stopsToNextStation ?? null,
+    );
+  }
+
   const eta = calculateStaticETA(route);
   await updateStationNotification(
     nearest.station,
@@ -117,5 +131,5 @@ export async function processLocationUpdate(
     sleepMode ? alarmEvent : null,
   );
 
-  return { alarmEvent, nearest };
+  return { alarmEvent, nearest, lastNotifiedStationId: newLastNotifiedStationId };
 }


### PR DESCRIPTION
## Summary
- GPS 폴링 주기 단축: 포그라운드 30s→10s, 백그라운드 100m/30s→50m/10s
- 역 변경 감지(`lastNotifiedStationId`) 추가로 매 역마다 푸시 알림 발송
- `sendStationPassedNotification` 함수 추가 (소리/진동 없이 역 통과 알림)
- Live Activity는 폴링 단축으로 자연스럽게 매 역마다 갱신

## Changes
| 파일 | 변경 |
|------|------|
| `useNearestStation.ts` | 폴링 30s → 10s |
| `useBackgroundLocation.ts` | distanceInterval 100→50, deferred 30s→10s |
| `storageKeys.ts` | `LAST_NOTIFIED_STATION_KEY` 추가 |
| `stationNotification.ts` | `sendStationPassedNotification` + Android 채널 |
| `stationPipeline.ts` | 백그라운드 역 변경 감지 + per-station 알림 |
| `useStationAlarm.ts` | 포그라운드 역 변경 감지 (nearestStation 파라미터 추가) |
| `backgroundLocationTask.ts` | lastNotifiedStationId AsyncStorage 관리 |
| `index.tsx` | useStationAlarm 호출부 수정 |

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 커버리지 100% 통과 (670 tests)
- [ ] 실기기 지하철 탑승 테스트: 매 역마다 Live Activity 갱신 + 푸시 알림 확인

Closes #163