### PR TITLE
refactor(#173): useNearestStation deep chaining 구조 분해

### DIFF
--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -54,9 +54,10 @@ export function useNearestStation(): UseNearestStationReturn {
       if (isFirstFetch.current) {
         const lastKnown = await Location.getLastKnownPositionAsync();
         if (lastKnown) {
-          setUserLocation({ lat: lastKnown.coords.latitude, lng: lastKnown.coords.longitude });
+          const { latitude, longitude } = lastKnown.coords;
+          setUserLocation({ lat: latitude, lng: longitude });
           applyNearestResult(
-            findNearestStations(lastKnown.coords.latitude, lastKnown.coords.longitude),
+            findNearestStations(latitude, longitude),
             setResult, setVariants,
           );
           setLoading(false);
@@ -70,10 +71,11 @@ export function useNearestStation(): UseNearestStationReturn {
       isFirstFetch.current = false;
 
       const location = await Location.getCurrentPositionAsync({ accuracy });
+      const { latitude, longitude } = location.coords;
 
-      setUserLocation({ lat: location.coords.latitude, lng: location.coords.longitude });
+      setUserLocation({ lat: latitude, lng: longitude });
       applyNearestResult(
-        findNearestStations(location.coords.latitude, location.coords.longitude),
+        findNearestStations(latitude, longitude),
         setResult, setVariants,
       );
     } catch (e) {


### PR DESCRIPTION
## Summary
- `lastKnown.coords.latitude/longitude` 3단 체이닝을 구조 분해로 개선
- `location.coords.latitude/longitude` 동일하게 적용

Closes #173

## Test plan
- [x] `npm test` — 672 tests pass, 100% coverage
- [x] `npm run type-check` — 통과