### PR TITLE
refactor(#171): 컴포넌트 하드코딩 색상을 테마 토큰으로 교체

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -168,7 +168,7 @@ function FavoriteCard({
         <View style={styles.cardActions}>
           <Text style={[styles.expandIcon, { color: colors.muted }]}>{isExpanded ? '▲' : '▼'}</Text>
           <TouchableOpacity style={[styles.removeButton, { backgroundColor: colors.card }]} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
-            <Text style={styles.removeText}>삭제</Text>
+            <Text style={[styles.removeText, { color: colors.danger }]}>삭제</Text>
           </TouchableOpacity>
         </View>
       </TouchableOpacity>
@@ -312,7 +312,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   removeText: {
-    color: '#ff6b6b',
     fontSize: 13,
     fontWeight: '600',
   },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -251,7 +251,7 @@ export default function HomeScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
       {arrivedBanner && (
-        <View style={styles.arrivedBanner} testID="arrived-banner">
+        <View style={[styles.arrivedBanner, { backgroundColor: colors.success }]} testID="arrived-banner">
           <Text style={styles.arrivedBannerText}>도착!</Text>
         </View>
       )}
@@ -532,12 +532,11 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   arrivedBanner: {
-    backgroundColor: '#22c55e',
     paddingVertical: 12,
     alignItems: 'center',
   },
   arrivedBannerText: {
-    color: '#ffffff', // #22c55e 배너 위 텍스트 — 항상 흰색 유지
+    color: '#ffffff', // success 배경 위 텍스트 — 항상 흰색 유지
     fontSize: 18,
     fontWeight: '700',
   },

--- a/src/components/LineBadge.tsx
+++ b/src/components/LineBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text } from 'react-native';
-import { lightColors, typography } from '../theme';
-import { LINE_NAMES } from '../constants/lineColors';
+import { typography } from '../theme';
+import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
 import type { LineNumber } from '../types/station';
 
 interface LineBadgeProps {
@@ -10,7 +10,7 @@ interface LineBadgeProps {
 }
 
 export function getLineColor(line: string): string {
-  return lightColors.line[line as LineNumber] ?? lightColors.accent;
+  return LINE_COLORS[line as LineNumber] ?? '#888888';
 }
 
 export function getLineLabel(line: string): string {

--- a/src/components/__tests__/LineBadge.test.tsx
+++ b/src/components/__tests__/LineBadge.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import { LineBadge, getLineColor, getLineLabel } from '../LineBadge';
-import { colors } from '../../theme';
 
 describe('LineBadge', () => {
   it('should render line label for known numeric lines', () => {
@@ -31,8 +30,8 @@ describe('getLineColor', () => {
     expect(getLineColor('6')).toBe('#CD7C2F');
   });
 
-  it('should return accent color for unknown lines', () => {
-    expect(getLineColor('unknown')).toBe(colors.accent);
+  it('should return fallback color for unknown lines', () => {
+    expect(getLineColor('unknown')).toBe('#888888');
   });
 });
 

--- a/src/theme/__tests__/theme.test.ts
+++ b/src/theme/__tests__/theme.test.ts
@@ -50,6 +50,8 @@ describe('theme', () => {
       expect(colors.card).toBe('#ffffff');
       expect(colors.onAccent).toBe('#ffffff');
       expect(colors.overlay).toBe('rgba(0,0,0,0.4)');
+      expect(colors.success).toBe('#22c55e');
+      expect(colors.danger).toBe('#ff6b6b');
     });
   });
 

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -23,6 +23,8 @@ export const lightColors = {
   bgTranslucent: 'rgba(245,242,236,0.92)', // 반투명 bg (헤더 등)
   accent:        '#C8553D',             // CTA (어스 레드)
   onAccent:      '#ffffff',             // accent 위 텍스트
+  success:       '#22c55e',             // 성공/완료 (도착 배너 등)
+  danger:        '#ff6b6b',             // 위험/삭제 (삭제 버튼 등)
 };
 
 // C · Focus — 다크모드
@@ -38,6 +40,8 @@ export const darkColors = {
   bgTranslucent: 'rgba(10,10,10,0.92)', // 반투명 bg (헤더 등)
   accent:        '#C8E600',             // CTA (라임그린)
   onAccent: '#000000',                 // accent 위 텍스트
+  success:       '#22c55e',             // 성공/완료
+  danger:        '#ff6b6b',             // 위험/삭제
 };
 
 export type ThemeColors = typeof lightColors;


### PR DESCRIPTION
## Summary
- `theme.ts`에 `success`(#22c55e), `danger`(#ff6b6b) 시맨틱 토큰 추가
- `index.tsx`: `#22c55e` → `colors.success` (도착 배너)
- `favorites.tsx`: `#ff6b6b` → `colors.danger` (삭제 버튼)
- `LineBadge.tsx`: `lightColors` 정적 import 제거 → `LINE_COLORS` 직접 조회

Closes #171

## Test plan
- [x] `npm test` — 672 tests pass, 100% coverage
- [x] `npm run type-check` — 통과