### PR TITLE
refactor(#178): arrivalApi 방향 판별 문자열 상수 분리

### DIFF
--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -28,6 +28,9 @@ export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   isMock: true,
 });
 
+/** 서울 열린데이터 API updnLine 응답값 — 상행/내선이면 up 방향 */
+const UP_DIRECTION_VALUES = ['상행', '내선'] as const;
+
 export interface FetchArrivalOptions {
   timeoutMs?: number;
   maxPerDirection?: number;
@@ -71,7 +74,7 @@ export async function fetchArrivalInfo(
         statusMessage: item.arvlMsg2 ?? '',
         trainCode: item.btrainNo ?? '',
       };
-      if (item.updnLine === '상행' || item.updnLine === '내선') {
+      if (UP_DIRECTION_VALUES.includes(item.updnLine)) {
         up.push(info);
       } else {
         down.push(info);


### PR DESCRIPTION
## Summary
- `'상행'`, `'내선'` 인라인 문자열을 `UP_DIRECTION_VALUES` 상수 배열로 추출
- API 응답 스펙 변경 시 한 곳만 수정하면 됨

Closes #178

## Test plan
- [x] `npm test` — 672 tests pass, 100% coverage
- [x] `npm run type-check` — 통과