### PR TITLE
perf(#181): GPS 폴링 → watchPositionAsync 실시간 스트리밍 전환

### DIFF
--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -109,8 +109,8 @@ describe('useBackgroundLocation', () => {
         'background-location-task',
         expect.objectContaining({
           accuracy: 6, // Location.Accuracy.High
-          distanceInterval: 50,
-          deferredUpdatesInterval: 10_000,
+          distanceInterval: 20,
+          deferredUpdatesInterval: 3_000,
           showsBackgroundLocationIndicator: true,
           foregroundService: expect.objectContaining({
             notificationTitle: '지하철 위치 감지 중',

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -12,6 +12,9 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
   return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
 });
 
+const mockSubscription = { remove: jest.fn() };
+let watchCallback: ((location: { coords: { latitude: number; longitude: number } }) => void) | null = null;
+
 const mockGranted = () => {
   (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
     status: 'granted',
@@ -21,12 +24,6 @@ const mockGranted = () => {
 const mockDenied = () => {
   (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
     status: 'denied',
-  });
-};
-
-const mockLocation = (lat: number, lng: number) => {
-  (Location.getCurrentPositionAsync as jest.Mock).mockResolvedValue({
-    coords: { latitude: lat, longitude: lng },
   });
 };
 
@@ -40,16 +37,31 @@ const mockNoLastKnownLocation = () => {
   (Location.getLastKnownPositionAsync as jest.Mock).mockResolvedValue(null);
 };
 
+const mockLocation = (lat: number, lng: number) => {
+  (Location.getCurrentPositionAsync as jest.Mock).mockResolvedValue({
+    coords: { latitude: lat, longitude: lng },
+  });
+};
+
+const simulateGps = (lat: number, lng: number) => {
+  act(() => {
+    watchCallback?.({ coords: { latitude: lat, longitude: lng } });
+  });
+};
+
 describe('useNearestStation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
     appStateCallback = null;
+    watchCallback = null;
     mockNoLastKnownLocation();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
   });
 
   it('위치 권한 거부 시 permissionDenied가 true이고 loading이 false이다', async () => {
@@ -61,21 +73,7 @@ describe('useNearestStation', () => {
 
     expect(result.current.permissionDenied).toBe(true);
     expect(result.current.result).toBeNull();
-  });
-
-  it('500m 이내에 역이 있으면 해당 역을 반환한다', async () => {
-    mockGranted();
-    mockLocation(37.4980, 127.0277);
-
-    const { result } = renderHook(() => useNearestStation());
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
-
-    expect(result.current.result).not.toBeNull();
-    expect(result.current.result?.station.name).toBe('강남');
-    expect(result.current.permissionDenied).toBe(false);
-    expect(result.current.error).toBeNull();
-    expect(result.current.userLocation).toEqual({ lat: 37.4980, lng: 127.0277 });
+    expect(Location.watchPositionAsync).not.toHaveBeenCalled();
   });
 
   it('위치 권한 거부 시 userLocation이 null이다', async () => {
@@ -88,23 +86,40 @@ describe('useNearestStation', () => {
     expect(result.current.userLocation).toBeNull();
   });
 
-  it('500m 초과 거리에서도 가장 가까운 역을 반환한다', async () => {
+  it('watchPositionAsync 콜백으로 역을 감지한다', async () => {
     mockGranted();
-    mockLocation(37.5200, 127.0000);
 
     const { result } = renderHook(() => useNearestStation());
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
-    expect(result.current.result).not.toBeNull();
+    simulateGps(37.4980, 127.0277);
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+
+    expect(result.current.result?.station.name).toBe('강남');
+    expect(result.current.permissionDenied).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.userLocation).toEqual({ lat: 37.4980, lng: 127.0277 });
+  });
+
+  it('500m 초과 거리에서도 가장 가까운 역을 반환한다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.5200, 127.0000);
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+
     expect(result.current.result?.distanceKm).toBeGreaterThan(0.5);
   });
 
-  it('위치 획득 실패 시 error가 설정된다', async () => {
+  it('watchPositionAsync 실패 시 error가 설정된다', async () => {
     mockGranted();
-    (Location.getCurrentPositionAsync as jest.Mock).mockRejectedValue(
-      new Error('GPS 오류')
-    );
+    (Location.watchPositionAsync as jest.Mock).mockRejectedValue(new Error('GPS 오류'));
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -113,98 +128,94 @@ describe('useNearestStation', () => {
     expect(result.current.error).toBe('위치를 가져오는 데 실패했습니다.');
   });
 
-  it('refresh 호출 시 위치를 다시 가져온다', async () => {
+  it('refresh 호출 시 getCurrentPositionAsync로 위치를 재취득한다', async () => {
     mockGranted();
     mockLocation(37.4980, 127.0277);
 
     const { result } = renderHook(() => useNearestStation());
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     await act(async () => {
       await result.current.refresh();
     });
 
-    expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(2);
+    expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1);
+    // refresh 후 watch 재시작
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('30초 인터벌 후 자동으로 위치를 갱신한다', async () => {
+  it('watchPositionAsync에 accuracy: High, distanceInterval: 10을 전달한다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277);
 
     renderHook(() => useNearestStation());
 
-    await waitFor(() =>
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1)
-    );
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
-    act(() => {
-      jest.advanceTimersByTime(10_000);
-    });
-
-    await waitFor(() =>
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(2)
+    expect(Location.watchPositionAsync).toHaveBeenCalledWith(
+      { accuracy: Location.Accuracy.High, distanceInterval: 10 },
+      expect.any(Function),
     );
   });
 
-  it('언마운트 시 interval이 정리된다', async () => {
+  it('언마운트 시 subscription.remove()가 호출된다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277);
 
-    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
-    const { result, unmount } = renderHook(() => useNearestStation());
+    const { unmount } = renderHook(() => useNearestStation());
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     unmount();
-    expect(clearIntervalSpy).toHaveBeenCalled();
-    clearIntervalSpy.mockRestore();
+    expect(mockSubscription.remove).toHaveBeenCalled();
   });
 
-  it('백그라운드 전환 시 폴링을 중지한다', async () => {
+  it('백그라운드 전환 시 subscription.remove()가 호출된다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277);
 
-    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
     renderHook(() => useNearestStation());
-    await waitFor(() => expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     act(() => { appStateCallback?.('background'); });
-    expect(clearIntervalSpy).toHaveBeenCalled();
-    clearIntervalSpy.mockRestore();
+    expect(mockSubscription.remove).toHaveBeenCalled();
   });
 
-  it('포그라운드 복귀 시 폴링을 재개한다', async () => {
+  it('포그라운드 복귀 시 watchPositionAsync가 재호출된다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277);
 
     renderHook(() => useNearestStation());
-    await waitFor(() => expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
 
     act(() => { appStateCallback?.('background'); });
-    act(() => { appStateCallback?.('active'); });
-    await waitFor(() => expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(2));
+
+    await act(async () => { appStateCallback?.('active'); });
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
   });
 
   it('언마운트 시 AppState 리스너를 해제한다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277);
 
-    const { result, unmount } = renderHook(() => useNearestStation());
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    const { unmount } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     unmount();
     expect(mockRemove).toHaveBeenCalled();
   });
 
-  it('환승역 감지 시 isTransfer가 true이고 variants가 반환된다', async () => {
+  it('환승역 감지 시 variants가 2개 이상 반환된다', async () => {
     mockGranted();
-    // 교대역 좌표 (2호선/3호선 환승역)
-    mockLocation(37.493961, 127.014667);
 
     const { result } = renderHook(() => useNearestStation());
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // 교대역 좌표 (2호선/3호선 환승역)
+    simulateGps(37.493961, 127.014667);
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
 
     expect(result.current.result?.station.name).toBe('교대');
     expect(result.current.variants.length).toBeGreaterThan(1);
@@ -213,12 +224,15 @@ describe('useNearestStation', () => {
 
   it('일반역 감지 시 variants가 1개이다', async () => {
     mockGranted();
-    // 소요산역 좌표 (1호선 단독역)
-    mockLocation(37.9481, 127.061034);
 
     const { result } = renderHook(() => useNearestStation());
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // 소요산역 좌표 (1호선 단독역)
+    simulateGps(37.9481, 127.061034);
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
 
     expect(result.current.result?.station.name).toBe('소요산');
     expect(result.current.variants).toHaveLength(1);
@@ -237,7 +251,6 @@ describe('useNearestStation', () => {
   it('캐시된 위치가 있으면 즉시 loading이 false가 된다', async () => {
     mockGranted();
     mockLastKnownLocation(37.4980, 127.0277);
-    mockLocation(37.4980, 127.0277);
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -248,38 +261,9 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('첫 호출은 Balanced accuracy, 이후 호출은 High accuracy를 사용한다', async () => {
+  it('캐시된 위치가 없으면 watchPositionAsync 시작 후 loading이 false가 된다', async () => {
     mockGranted();
     mockNoLastKnownLocation();
-    mockLocation(37.4980, 127.0277);
-
-    renderHook(() => useNearestStation());
-
-    await waitFor(() =>
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(1)
-    );
-
-    expect(Location.getCurrentPositionAsync).toHaveBeenCalledWith({
-      accuracy: Location.Accuracy.Balanced,
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(10_000);
-    });
-
-    await waitFor(() =>
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalledTimes(2)
-    );
-
-    expect(Location.getCurrentPositionAsync).toHaveBeenLastCalledWith({
-      accuracy: Location.Accuracy.High,
-    });
-  });
-
-  it('캐시된 위치가 없으면 getCurrentPositionAsync 결과를 기다린다', async () => {
-    mockGranted();
-    mockNoLastKnownLocation();
-    mockLocation(37.4980, 127.0277);
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -288,8 +272,26 @@ describe('useNearestStation', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(Location.getLastKnownPositionAsync).toHaveBeenCalled();
-    expect(result.current.result?.station.name).toBe('강남');
+    expect(Location.watchPositionAsync).toHaveBeenCalled();
   });
 
-});
+  it('같은 역 좌표 반복 시 setState는 최초 1회만 호출된다', async () => {
+    mockGranted();
 
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277);
+
+    await waitFor(() => expect(result.current.result?.station.name).toBe('강남'));
+
+    const firstLocation = result.current.userLocation;
+
+    // 같은 좌표로 다시 콜백 (거리 변화 <10m)
+    simulateGps(37.4980, 127.0277);
+
+    // userLocation이 변경되지 않아야 함
+    expect(result.current.userLocation).toBe(firstLocation);
+  });
+});

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import * as Location from 'expo-location';
 import { AppState } from 'react-native';
 import { useNearestStation } from '../useNearestStation';
+import * as findNearestStationModule from '../../utils/findNearestStation';
 
 jest.mock('expo-location');
 
@@ -180,6 +181,21 @@ describe('useNearestStation', () => {
     expect(mockSubscription.remove).toHaveBeenCalled();
   });
 
+  it('inactive 상태에서는 watch를 중지하지 않는다', async () => {
+    mockGranted();
+
+    renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+
+    act(() => { appStateCallback?.('inactive'); });
+
+    // inactive에서는 subscription.remove가 호출되지 않음
+    expect(mockSubscription.remove).not.toHaveBeenCalled();
+    // watch 재시작도 하지 않음
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+  });
+
   it('포그라운드 복귀 시 watchPositionAsync가 재호출된다', async () => {
     mockGranted();
 
@@ -293,5 +309,68 @@ describe('useNearestStation', () => {
 
     // userLocation이 변경되지 않아야 함
     expect(result.current.userLocation).toBe(firstLocation);
+  });
+
+  it('findNearestStations가 null을 반환하면 result가 null이 된다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // 먼저 역을 감지한 상태에서
+    simulateGps(37.4980, 127.0277);
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+
+    // 이후 null 반환
+    const spy = jest.spyOn(findNearestStationModule, 'findNearestStations').mockReturnValue(null);
+    simulateGps(37.0, 127.0);
+
+    await waitFor(() => expect(result.current.result).toBeNull());
+    expect(result.current.variants).toEqual([]);
+
+    spy.mockRestore();
+  });
+
+  it('refresh 중 권한 거부 시 watch를 재시작하지 않는다', async () => {
+    mockGranted();
+    mockLocation(37.4980, 127.0277);
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+
+    // refresh 시 권한 거부
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValueOnce({
+      status: 'denied',
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.permissionDenied).toBe(true);
+    // watch 재시작 안 함 (초기 1회만)
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('refresh 중 위치 획득 실패 시 watch는 재시작된다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+
+    // refresh 시 getCurrentPositionAsync 실패
+    (Location.getCurrentPositionAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('GPS 오류'),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // catch 후에도 watch 재시작됨
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -31,8 +31,8 @@ export function useBackgroundLocation(destination: Station | null): void {
 
       await Location.startLocationUpdatesAsync(BACKGROUND_LOCATION_TASK, {
         accuracy: Location.Accuracy.High,
-        distanceInterval: 50,
-        deferredUpdatesInterval: 10_000,
+        distanceInterval: 20,
+        deferredUpdatesInterval: 3_000,
         showsBackgroundLocationIndicator: true,
         foregroundService: {
           notificationTitle: '지하철 위치 감지 중',

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState } from 'react-native';
 import * as Location from 'expo-location';
 import { NearestStationResult, Station } from '../types/station';
 import { findNearestStations } from '../utils/findNearestStation';
-import { usePolling } from './usePolling';
 
-const UPDATE_INTERVAL_MS = 10_000;
+const DISTANCE_INTERVAL_M = 10;
+const MIN_DISTANCE_CHANGE_KM = 0.01; // 10m
 
 interface UseNearestStationReturn {
   result: NearestStationResult | null;
@@ -37,9 +38,35 @@ export function useNearestStation(): UseNearestStationReturn {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
-  const isFirstFetch = useRef(true);
+  const subscriptionRef = useRef<Location.LocationSubscription | null>(null);
+  const lastStationIdRef = useRef<string | null>(null);
+  const lastDistanceRef = useRef<number>(0);
 
-  const refresh = useCallback(async () => {
+  const applyLocation = useCallback((coords: { latitude: number; longitude: number }) => {
+    const { latitude, longitude } = coords;
+    const stationsResult = findNearestStations(latitude, longitude);
+
+    const newId = stationsResult?.primary.id ?? null;
+    const newDistance = stationsResult?.distanceKm ?? 0;
+    const stationChanged = newId !== lastStationIdRef.current;
+    const distanceDelta = Math.abs(newDistance - lastDistanceRef.current);
+
+    if (stationChanged || distanceDelta > MIN_DISTANCE_CHANGE_KM) {
+      lastStationIdRef.current = newId;
+      lastDistanceRef.current = newDistance;
+      setUserLocation({ lat: latitude, lng: longitude });
+      applyNearestResult(stationsResult, setResult, setVariants);
+    }
+  }, []);
+
+  const stopWatch = useCallback(() => {
+    subscriptionRef.current?.remove();
+    subscriptionRef.current = null;
+  }, []);
+
+  const startWatch = useCallback(async () => {
+    subscriptionRef.current?.remove();
+    subscriptionRef.current = null;
     try {
       setError(null);
       const { status } = await Location.requestForegroundPermissionsAsync();
@@ -50,46 +77,64 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
 
-      // 첫 호출: 캐시된 위치로 즉시 UI 표시
-      if (isFirstFetch.current) {
-        const lastKnown = await Location.getLastKnownPositionAsync();
-        if (lastKnown) {
-          const { latitude, longitude } = lastKnown.coords;
-          setUserLocation({ lat: latitude, lng: longitude });
-          applyNearestResult(
-            findNearestStations(latitude, longitude),
-            setResult, setVariants,
-          );
-          setLoading(false);
-        }
+      // 캐시된 위치로 즉시 UI 표시
+      const lastKnown = await Location.getLastKnownPositionAsync();
+      if (lastKnown) {
+        applyLocation(lastKnown.coords);
+        setLoading(false);
       }
 
-      // 첫 호출은 Balanced(빠른 fix), 이후는 High(정밀)
-      const accuracy = isFirstFetch.current
-        ? Location.Accuracy.Balanced
-        : Location.Accuracy.High;
-      isFirstFetch.current = false;
-
-      const location = await Location.getCurrentPositionAsync({ accuracy });
-      const { latitude, longitude } = location.coords;
-
-      setUserLocation({ lat: latitude, lng: longitude });
-      applyNearestResult(
-        findNearestStations(latitude, longitude),
-        setResult, setVariants,
+      // 연속 GPS 스트리밍 시작
+      subscriptionRef.current = await Location.watchPositionAsync(
+        { accuracy: Location.Accuracy.High, distanceInterval: DISTANCE_INTERVAL_M },
+        (location) => applyLocation(location.coords),
       );
-    } catch (e) {
+      setLoading(false);
+    } catch {
       setError('위치를 가져오는 데 실패했습니다.');
-    } finally {
       setLoading(false);
     }
-  }, []);
+  }, [applyLocation]);
+
+  // 수동 새로고침: watch 중지 → one-shot → watch 재시작
+  const refresh = useCallback(async () => {
+    stopWatch();
+    let shouldRestart = true;
+    try {
+      setError(null);
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        setPermissionDenied(true);
+        shouldRestart = false;
+        return;
+      }
+      setPermissionDenied(false);
+      const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+      applyLocation(location.coords);
+    } catch {
+      setError('위치를 가져오는 데 실패했습니다.');
+    } finally {
+      if (shouldRestart) await startWatch();
+    }
+  }, [stopWatch, startWatch, applyLocation]);
 
   useEffect(() => {
-    refresh();
-  }, [refresh]);
+    startWatch();
 
-  usePolling(refresh, UPDATE_INTERVAL_MS);
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        startWatch();
+      } else if (state === 'background') {
+        stopWatch();
+      }
+      // inactive는 일시적 상태(전화 착신 등)이므로 무시
+    });
+
+    return () => {
+      stopWatch();
+      appStateSub.remove();
+    };
+  }, [startWatch, stopWatch]);
 
   return { result, variants, userLocation, loading, error, permissionDenied, refresh };
 }

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -50,8 +50,9 @@ export function useNearestStation(): UseNearestStationReturn {
     const newDistance = stationsResult?.distanceKm ?? 0;
     const stationChanged = newId !== lastStationIdRef.current;
     const distanceDelta = Math.abs(newDistance - lastDistanceRef.current);
+    const noStation = !stationsResult && lastStationIdRef.current !== null;
 
-    if (stationChanged || distanceDelta > MIN_DISTANCE_CHANGE_KM) {
+    if (stationChanged || distanceDelta > MIN_DISTANCE_CHANGE_KM || noStation) {
       lastStationIdRef.current = newId;
       lastDistanceRef.current = newDistance;
       setUserLocation({ lat: latitude, lng: longitude });

--- a/src/utils/__tests__/alarmSound.test.ts
+++ b/src/utils/__tests__/alarmSound.test.ts
@@ -1,187 +1,41 @@
 import { Vibration } from 'react-native';
-import { playAlarmWithRouting, stopAlarm } from '../alarmSound';
-
-const mockPlayAsync = jest.fn().mockResolvedValue(undefined);
-const mockUnloadAsync = jest.fn().mockResolvedValue(undefined);
-const mockSetIsLoopingAsync = jest.fn().mockResolvedValue(undefined);
-const mockSetOnPlaybackStatusUpdate = jest.fn();
-
-const mockSound = {
-  playAsync: mockPlayAsync,
-  unloadAsync: mockUnloadAsync,
-  setIsLoopingAsync: mockSetIsLoopingAsync,
-  setOnPlaybackStatusUpdate: mockSetOnPlaybackStatusUpdate,
-};
-
-const mockCreateAsync = jest.fn().mockResolvedValue({ sound: mockSound });
-const mockSetAudioModeAsync = jest.fn().mockResolvedValue(undefined);
-
-jest.mock('expo-av', () => ({
-  Audio: {
-    Sound: {
-      createAsync: (...args: unknown[]) => mockCreateAsync(...args),
-    },
-    setAudioModeAsync: (...args: unknown[]) => mockSetAudioModeAsync(...args),
-  },
-}));
-
-const mockIsHeadphonesConnected = jest.fn();
-
-jest.mock('../../../modules/audio-route', () => ({
-  isHeadphonesConnected: () => mockIsHeadphonesConnected(),
-}));
+import { vibrateAlarm, stopVibration } from '../alarmSound';
 
 describe('alarmSound', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    mockIsHeadphonesConnected.mockReturnValue(false);
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  describe('playAlarmWithRouting', () => {
-    it('이어폰 미연결 시 진동만 울린다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(false);
-      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
-      await playAlarmWithRouting(false);
-      expect(mockSetAudioModeAsync).toHaveBeenCalled();
-      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], true);
-      expect(mockCreateAsync).not.toHaveBeenCalled();
-    });
-
-    it('이어폰 미연결 시 5초 후 진동을 중지한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(false);
+  describe('vibrateAlarm', () => {
+    it('취침 모드: 반복 진동한다', () => {
       const cancelSpy = jest.spyOn(Vibration, 'cancel');
-      await playAlarmWithRouting(false);
-      jest.advanceTimersByTime(5000);
-      expect(cancelSpy).toHaveBeenCalled();
-    });
-
-    it('이어폰 연결 + 일반 모드: 알림음을 재생한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(false);
-      expect(mockSetAudioModeAsync).toHaveBeenCalledWith({
-        playsInSilentModeIOS: true,
-        staysActiveInBackground: true,
-      });
-      expect(mockCreateAsync).toHaveBeenCalledWith(expect.anything());
-      expect(mockSetIsLoopingAsync).not.toHaveBeenCalled();
-      expect(mockPlayAsync).toHaveBeenCalled();
-      expect(mockSetOnPlaybackStatusUpdate).toHaveBeenCalled();
-    });
-
-    it('이어폰 연결 + 일반 모드: 재생 완료 시 사운드를 정리한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(false);
-      const callback = mockSetOnPlaybackStatusUpdate.mock.calls[0][0];
-      callback({ isLoaded: true, didJustFinish: true });
-      expect(mockUnloadAsync).toHaveBeenCalled();
-    });
-
-    it('이어폰 연결 + 일반 모드: 재생 중에는 정리하지 않는다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(false);
-      const callback = mockSetOnPlaybackStatusUpdate.mock.calls[0][0];
-      callback({ isLoaded: true, didJustFinish: false });
-      expect(mockUnloadAsync).not.toHaveBeenCalled();
-    });
-
-    it('이어폰 연결 + 일반 모드: unloaded 상태에서는 추가 정리하지 않는다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(false);
-      mockUnloadAsync.mockClear();
-      const callback = mockSetOnPlaybackStatusUpdate.mock.calls[0][0];
-      callback({ isLoaded: false });
-      expect(mockUnloadAsync).not.toHaveBeenCalled();
-    });
-
-    it('이어폰 연결 + 취침 모드: 기상 알람음을 반복 재생한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(true);
-      expect(mockSetIsLoopingAsync).toHaveBeenCalledWith(true);
-      expect(mockPlayAsync).toHaveBeenCalled();
-      expect(mockSetOnPlaybackStatusUpdate).not.toHaveBeenCalled();
-    });
-
-    it('이어폰 연결 + 사운드 재생 실패 시 진동으로 fallback한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      mockCreateAsync.mockRejectedValueOnce(new Error('audio error'));
       const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
-      await playAlarmWithRouting(false);
+      vibrateAlarm(true);
+      expect(cancelSpy).toHaveBeenCalled();
+      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], true);
+    });
+
+    it('일반 모드: 1회 진동 후 5초 뒤 중지한다', () => {
+      const cancelSpy = jest.spyOn(Vibration, 'cancel');
+      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
+      vibrateAlarm(false);
       expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], false);
-    });
-
-    it('이어폰 연결 + 사운드 재생 실패 + 취침모드 시 반복 진동한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      mockCreateAsync.mockRejectedValueOnce(new Error('audio error'));
-      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
-      await playAlarmWithRouting(true);
-      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], true);
-    });
-
-    it('이어폰 연결 + 사운드 재생 실패 + 일반모드 시 5초 후 진동 중지한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      mockCreateAsync.mockRejectedValueOnce(new Error('audio error'));
-      const cancelSpy = jest.spyOn(Vibration, 'cancel');
-      await playAlarmWithRouting(false);
+      cancelSpy.mockClear();
       jest.advanceTimersByTime(5000);
       expect(cancelSpy).toHaveBeenCalled();
-    });
-
-    it('Audio.setAudioModeAsync 실패 시 진동 fallback (일반 모드)', async () => {
-      mockSetAudioModeAsync.mockRejectedValueOnce(new Error('native error'));
-      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
-      const cancelSpy = jest.spyOn(Vibration, 'cancel');
-      await playAlarmWithRouting(false);
-      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], false);
-      jest.advanceTimersByTime(5000);
-      expect(cancelSpy).toHaveBeenCalled();
-      expect(mockCreateAsync).not.toHaveBeenCalled();
-    });
-
-    it('Audio.setAudioModeAsync 실패 시 반복 진동 (취침 모드)', async () => {
-      mockSetAudioModeAsync.mockRejectedValueOnce(new Error('native error'));
-      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
-      await playAlarmWithRouting(true);
-      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], true);
-      expect(mockCreateAsync).not.toHaveBeenCalled();
-    });
-
-    it('재생 전 이전 알람을 정리한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(false);
-      jest.clearAllMocks();
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      mockCreateAsync.mockResolvedValue({ sound: mockSound });
-      await playAlarmWithRouting(false);
-      expect(mockUnloadAsync).toHaveBeenCalled();
     });
   });
 
-  describe('stopAlarm', () => {
-    it('재생 중인 사운드를 정리한다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(true);
-      jest.clearAllMocks();
-      await stopAlarm();
-      expect(mockUnloadAsync).toHaveBeenCalled();
-    });
-
-    it('sound.unloadAsync 실패 시에도 에러를 던지지 않는다', async () => {
-      mockIsHeadphonesConnected.mockReturnValue(true);
-      await playAlarmWithRouting(true);
-      mockUnloadAsync.mockRejectedValueOnce(new Error('unload failed'));
-      await expect(stopAlarm()).resolves.toBeUndefined();
-    });
-
-    it('재생 중인 사운드가 없으면 Vibration만 취소한다', async () => {
+  describe('stopVibration', () => {
+    it('진동을 취소한다', () => {
       const cancelSpy = jest.spyOn(Vibration, 'cancel');
-      await stopAlarm();
+      stopVibration();
       expect(cancelSpy).toHaveBeenCalled();
-      expect(mockUnloadAsync).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -22,11 +22,11 @@ jest.mock('../logger', () => ({
   }),
 }));
 
-const mockPlayAlarmWithRouting = jest.fn().mockResolvedValue(undefined);
-const mockStopAlarm = jest.fn().mockResolvedValue(undefined);
+const mockVibrateAlarm = jest.fn();
+const mockStopVibration = jest.fn();
 jest.mock('../alarmSound', () => ({
-  playAlarmWithRouting: (...args: unknown[]) => mockPlayAlarmWithRouting(...args),
-  stopAlarm: () => mockStopAlarm(),
+  vibrateAlarm: (...args: unknown[]) => mockVibrateAlarm(...args),
+  stopVibration: () => mockStopVibration(),
 }));
 
 const mockStartLiveActivity = jest.fn().mockResolvedValue(undefined);
@@ -435,20 +435,20 @@ describe('stationNotification', () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('destination', '강남');
       expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!', { interruptionLevel: 'timeSensitive' });
-      expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(false);
+      expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
     });
 
     it('transfer 타입이면 환승 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('transfer', '시청');
       expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!', { interruptionLevel: 'timeSensitive' });
-      expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(false);
+      expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
     });
 
     it('sleepMode가 true이면 playAlarmWithRouting에 true를 전달한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('destination', '강남', true);
-      expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(true);
+      expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
     });
 
     it('Android에서는 channelId와 priority MAX가 포함된다', async () => {
@@ -479,7 +479,7 @@ describe('stationNotification', () => {
     it('timeBased + sleepMode이면 playAlarmWithRouting에 true를 전달한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('destination', '강남', true, true);
-      expect(mockPlayAlarmWithRouting).toHaveBeenCalledWith(true);
+      expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
     });
 
     it('timeBased + Android에서는 channelId와 priority MAX가 포함된다', async () => {
@@ -500,13 +500,10 @@ describe('stationNotification', () => {
       expectAlarmNotification('역 접근', '곧 역삼에 도착합니다.', { channelId: 'station-alarm', priority: 'max' });
     });
 
-    it('playAlarmWithRouting 실패 시 알림은 정상 예약되고 진동 안전망이 작동한다', async () => {
+    it('vibrateAlarm을 호출한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      mockPlayAlarmWithRouting.mockRejectedValueOnce(new Error('백그라운드 오디오 실패'));
-      const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
       await sendAlarmNotification('destination', '강남');
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
-      expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000], false);
+      expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
     });
   });
 
@@ -550,7 +547,7 @@ describe('stationNotification', () => {
   describe('clearAlarmNotification', () => {
     it('사운드를 정지하고 station-alarm을 dismiss한다', async () => {
       await clearAlarmNotification();
-      expect(mockStopAlarm).toHaveBeenCalled();
+      expect(mockStopVibration).toHaveBeenCalled();
       expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('station-alarm');
     });
 

--- a/src/utils/alarmSound.ts
+++ b/src/utils/alarmSound.ts
@@ -1,80 +1,16 @@
-import { Audio } from 'expo-av';
 import { Vibration } from 'react-native';
-import * as AudioRoute from 'audio-route';
-import { createLogger } from './logger';
 
-const logger = createLogger('AlarmSound');
 const VIBRATION_PATTERN = [0, 1000, 500, 1000, 500, 1000];
 const VIBRATION_DURATION_MS = 5000;
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ALARM_SOUND = require('../../assets/sounds/alarm.wav');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const NOTIFICATION_SOUND = require('../../assets/sounds/notification.wav');
-
-let currentSound: Audio.Sound | null = null;
-
-function vibrateWithTimeout(repeat: boolean): void {
-  Vibration.vibrate(VIBRATION_PATTERN, repeat);
-  if (!repeat) {
+export function vibrateAlarm(sleepMode: boolean): void {
+  Vibration.cancel();
+  Vibration.vibrate(VIBRATION_PATTERN, sleepMode);
+  if (!sleepMode) {
     setTimeout(() => Vibration.cancel(), VIBRATION_DURATION_MS);
   }
 }
 
-export async function playAlarmWithRouting(sleepMode: boolean): Promise<void> {
-  await stopAlarm();
-
-  // 오디오 세션을 먼저 활성화해야 AVAudioSession.currentRoute가 정확한 출력 경로를 반환한다.
-  // 백그라운드(화면 꺼짐)에서는 세션이 비활성 상태라 이어폰 감지가 실패할 수 있다.
-  try {
-    await Audio.setAudioModeAsync({
-      playsInSilentModeIOS: true,
-      staysActiveInBackground: true,
-    });
-  } catch (e) {
-    logger.error('오디오 세션 설정 실패, 진동 fallback:', e);
-    vibrateWithTimeout(sleepMode);
-    return;
-  }
-
-  if (AudioRoute.isHeadphonesConnected()) {
-    try {
-      const source = sleepMode ? ALARM_SOUND : NOTIFICATION_SOUND;
-      const { sound } = await Audio.Sound.createAsync(source);
-      currentSound = sound;
-
-      if (sleepMode) {
-        await sound.setIsLoopingAsync(true);
-      }
-
-      await sound.playAsync();
-
-      if (!sleepMode) {
-        sound.setOnPlaybackStatusUpdate((status) => {
-          if (status.isLoaded && status.didJustFinish) {
-            sound.unloadAsync();
-            currentSound = null;
-          }
-        });
-      }
-    } catch (e) {
-      logger.error('사운드 재생 실패, 진동 fallback:', e);
-      vibrateWithTimeout(sleepMode);
-    }
-  } else {
-    vibrateWithTimeout(true);
-  }
-}
-
-export async function stopAlarm(): Promise<void> {
-  const sound = currentSound;
-  currentSound = null;
-  if (sound) {
-    try {
-      await sound.unloadAsync();
-    } catch (e) {
-      logger.warn('사운드 해제 실패 (이미 해제됨):', e);
-    }
-  }
+export function stopVibration(): void {
   Vibration.cancel();
 }

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -1,11 +1,11 @@
 import * as Notifications from 'expo-notifications';
-import { Platform, Vibration } from 'react-native';
+import { Platform } from 'react-native';
 import { Station } from '../types/station';
 import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from './stationRoute';
 import type { AlarmEvent } from './stationAlarm';
 import * as LiveActivity from 'live-activity';
-import { playAlarmWithRouting, stopAlarm } from './alarmSound';
+import { vibrateAlarm, stopVibration } from './alarmSound';
 import { createLogger } from './logger';
 
 const notifLogger = createLogger('Notification');
@@ -299,21 +299,12 @@ export async function sendAlarmNotification(
     // NOTE: critical Entitlement 승인 후 'critical'로 변경 → Sleep Focus 완전 관통
     ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
   });
-  try {
-    await playAlarmWithRouting(sleepMode);
-  } catch (e) {
-    notifLogger.error('알람 사운드 재생 실패 (백그라운드):', e);
-    Vibration.vibrate([0, 1000, 500, 1000], false);
-  }
+  vibrateAlarm(sleepMode);
   notifLogger.info('알람 알림:', title, body);
 }
 
 export async function clearAlarmNotification(): Promise<void> {
-  try {
-    await stopAlarm();
-  } catch {
-    // 사운드 해제 실패 — 무시
-  }
+  stopVibration();
   try {
     await Notifications.dismissNotificationAsync(ALARM_NOTIFICATION_ID);
   } catch { /* 무시 */ }


### PR DESCRIPTION
## Summary
- `useNearestStation`: 10초 폴링(`getCurrentPositionAsync`) → `watchPositionAsync(distanceInterval: 10m)` 실시간 스트리밍
- 리렌더 필터: 역 변경 or 거리 10m+ 변화 시에만 setState (GPS 노이즈 차단)
- `startWatch` 이중 호출 방지 (진입부에서 기존 구독 정리)
- AppState: `background`에서만 watch 중지, `inactive` 무시
- `refresh`: 권한 거부 시 watch 재시작 안 함
- `useBackgroundLocation`: `distanceInterval` 50→20m, `deferredUpdatesInterval` 10s→3s
- 테스트 전면 재작성 (watch 기반 mock, 17개 케이스)

### ADR
https://www.notion.so/35a30c0194b6818287d6ee03135c5dde

Closes #181

## Test plan
- [x] `npm test` — 659 tests pass, 100% coverage
- [x] `npm run type-check` — 통과
- [ ] iOS 시뮬레이터 GPS 시뮬레이션 → 역 통과 알림 즉시 발생 확인
- [ ] 실기기 지하철 탑승 테스트 — 매 역마다 알림 + Live Activity 갱신