### PR TITLE
fix(#182): UIBackgroundModes에서 audio 제거

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,6 @@
           }
         },
         "UIBackgroundModes": [
-          "audio",
           "location"
         ],
         "ITSAppUsesNonExemptEncryption": false


### PR DESCRIPTION
## Summary
- App Store Guideline 2.5.4 대응: `UIBackgroundModes`에서 `audio` 제거
- expo-av 직접 재생 → notification custom sound 전환은 perf/#181에서 선행 완료
- 이 PR은 `app.json` 설정만 변경

## 변경 이유
Apple App Store 리뷰에서 `audio` background mode 제거를 요구. 
알람 소리는 notification sound로 재생되므로 audio background mode 불필요.

Closes #182

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 663 tests 전체 통과, 커버리지 100%
- [ ] EAS 빌드 후 TestFlight 제출 → App Store 재심사