### PR TITLE
feat(#183): 스피커 출력 설정 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -45,6 +45,7 @@ export default function HomeScreen() {
   const sleepMode = useAppStore((s) => s.sleepMode);
   const setSleepMode = useAppStore((s) => s.setSleepMode);
   const loadSleepMode = useAppStore((s) => s.loadSleepMode);
+  const loadAllowSpeaker = useAppStore((s) => s.loadAllowSpeaker);
   const alarmEvent = useAppStore((s) => s.alarmEvent);
   const clearAlarmEvent = useAppStore((s) => s.clearAlarmEvent);
   const loadAlarmEvent = useAppStore((s) => s.loadAlarmEvent);
@@ -131,6 +132,7 @@ export default function HomeScreen() {
   useEffect(() => {
     loadFavorites();
     loadSleepMode();
+    loadAllowSpeaker();
     loadCustomOrigin();
     loadRoutePreference();
     loadAlarmEvent();

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Pressable, StyleSheet, Switch, Text, View } from 'react-native';
+import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppStore, type ThemeMode } from '../../src/store/useAppStore';
 import type { RoutePreference } from '../../src/utils/stationRoute';
@@ -15,6 +15,9 @@ export default function SettingsScreen() {
   const sleepMode = useAppStore((s) => s.sleepMode);
   const setSleepMode = useAppStore((s) => s.setSleepMode);
   const loadSleepMode = useAppStore((s) => s.loadSleepMode);
+  const allowSpeaker = useAppStore((s) => s.allowSpeaker);
+  const setAllowSpeaker = useAppStore((s) => s.setAllowSpeaker);
+  const loadAllowSpeaker = useAppStore((s) => s.loadAllowSpeaker);
   const themeMode = useAppStore((s) => s.themeMode);
   const setThemeMode = useAppStore((s) => s.setThemeMode);
   const loadThemeMode = useAppStore((s) => s.loadThemeMode);
@@ -25,6 +28,7 @@ export default function SettingsScreen() {
 
   useEffect(() => {
     loadSleepMode();
+    loadAllowSpeaker();
     loadThemeMode();
     loadRoutePreference();
   }, []);
@@ -114,6 +118,35 @@ export default function SettingsScreen() {
             trackColor={{ false: colors.hair, true: colors.accent }}
             thumbColor={sleepMode ? colors.onAccent : colors.subtle}
             testID="sleep-mode-switch"
+          />
+        </View>
+
+        <View style={[styles.settingRow, { borderTopWidth: 1, borderTopColor: colors.hair }]}>
+          <View style={styles.settingInfo}>
+            <Text style={[styles.settingLabel, { color: colors.ink }]}>스피커 출력 허용</Text>
+            <Text style={[styles.settingDesc, { color: colors.muted }]}>
+              이어폰 미연결 시에도 알람음을 스피커로 재생합니다
+            </Text>
+          </View>
+          <Switch
+            value={allowSpeaker}
+            onValueChange={(value) => {
+              if (!value) {
+                Alert.alert(
+                  '스피커 출력 끄기',
+                  '스피커 출력을 끄면 이어폰이 연결되지 않은 상태에서 진동만 울립니다. 계속하시겠습니까?',
+                  [
+                    { text: '취소', style: 'cancel' },
+                    { text: '끄기', style: 'destructive', onPress: () => setAllowSpeaker(false) },
+                  ],
+                );
+              } else {
+                setAllowSpeaker(true);
+              }
+            }}
+            trackColor={{ false: colors.hair, true: colors.accent }}
+            thumbColor={allowSpeaker ? colors.onAccent : colors.subtle}
+            testID="allow-speaker-switch"
           />
         </View>
       </View>

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -8,3 +8,4 @@ export const THEME_MODE_KEY = 'subway-now:theme-mode';
 export const ROUTE_PREFERENCE_KEY = 'subway-now:route-preference';
 export const ROUTE_KEY = 'subway-now:route';
 export const LAST_NOTIFIED_STATION_KEY = 'subway-now:last-notified-station';
+export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -45,7 +45,7 @@ const makeStation = (id: string, name: string): Station => ({
 describe('useStationAlarm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useAppStore.setState({ sleepMode: false, alarmEvent: null });
+    useAppStore.setState({ sleepMode: false, allowSpeaker: true, alarmEvent: null });
     mockEvaluateAllAlarms.mockReturnValue(null);
     mockResolveNextTarget.mockReturnValue(null);
   });
@@ -75,7 +75,7 @@ describe('useStationAlarm', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
     renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false, true);
   });
 
   it('should send transfer alarm for transfer route', () => {
@@ -89,7 +89,7 @@ describe('useStationAlarm', () => {
     };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청' });
     renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false, true);
   });
 
   it('should send destination alarm for transfer route stopsFromTransfer', () => {
@@ -103,7 +103,7 @@ describe('useStationAlarm', () => {
     };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
     renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false, true);
   });
 
   it('should send transfer alarm for multi-transfer route', () => {
@@ -117,7 +117,7 @@ describe('useStationAlarm', () => {
     };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청' });
     renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false, true);
   });
 
   it('should not fire same alarm twice', () => {
@@ -142,7 +142,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '잠실' });
     rerender({ dest: '잠실' });
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
-    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith('destination', '잠실', false, false);
+    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith('destination', '잠실', false, false, true);
   });
 
   it('should pass sleepMode to sendAlarmNotification', () => {
@@ -150,7 +150,7 @@ describe('useStationAlarm', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
     renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', true, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', true, false, true);
   });
 
   it('취침 모드일 때 alarmEvent를 설정한다', () => {
@@ -167,6 +167,14 @@ describe('useStationAlarm', () => {
     mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
     renderHook(() => useStationAlarm(route, '강남', null));
     expect(useAppStore.getState().alarmEvent).toBeNull();
+  });
+
+  it('should pass allowSpeaker=false to sendAlarmNotification when store has allowSpeaker=false', () => {
+    useAppStore.setState({ allowSpeaker: false });
+    const route: DirectRoute = { type: 'direct', stops: 1 };
+    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
+    renderHook(() => useStationAlarm(route, '강남', null));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false, false);
   });
 
   it('should not re-fire alarm when sleepMode changes', () => {
@@ -192,7 +200,7 @@ describe('useStationAlarm', () => {
       const route: DirectRoute = { type: 'direct', stops: 5 };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'approaching', stationName: '역삼', timeBased: true });
       renderHook(() => useStationAlarm(route, '강남', null));
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith('approaching', '역삼', false, true);
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith('approaching', '역삼', false, true, true);
     });
 
     it('should send time-based transfer alarm', () => {
@@ -206,7 +214,7 @@ describe('useStationAlarm', () => {
       };
       mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청', timeBased: true });
       renderHook(() => useStationAlarm(route, '강남', null));
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, true);
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, true, true);
     });
 
     it('should set alarmEvent in sleep mode for destination time-based alarm', () => {

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -18,12 +18,18 @@ export function useStationAlarm(
   const prevDestRef = useRef<string | null>(null);
   const lastNotifiedStationIdRef = useRef<string | null>(null);
   const sleepMode = useAppStore((s) => s.sleepMode);
+  const allowSpeaker = useAppStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
   const sleepModeRef = useRef(sleepMode);
+  const allowSpeakerRef = useRef(allowSpeaker);
 
   useEffect(() => {
     sleepModeRef.current = sleepMode;
   }, [sleepMode]);
+
+  useEffect(() => {
+    allowSpeakerRef.current = allowSpeaker;
+  }, [allowSpeaker]);
 
   useEffect(() => {
     if (destinationName !== prevDestRef.current) {
@@ -39,7 +45,7 @@ export function useStationAlarm(
       if (sleepModeRef.current && event.type !== 'approaching') {
         setAlarmEvent({ type: event.type, stationName: event.stationName });
       }
-      sendAlarmNotification(event.type, event.stationName, sleepModeRef.current, event.timeBased ?? false).catch((e) =>
+      sendAlarmNotification(event.type, event.stationName, sleepModeRef.current, event.timeBased ?? false, allowSpeakerRef.current).catch((e) =>
         logger.error('알람 알림 실패:', e),
       );
     }

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -26,7 +26,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', alarmEvent: null });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', alarmEvent: null });
     jest.clearAllMocks();
   });
 
@@ -432,6 +432,69 @@ describe('useAppStore', () => {
     (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
     await useAppStore.getState().loadRoutePreference();
     expect(useAppStore.getState().routePreference).toBe('optimal');
+  });
+
+  it('초기 allowSpeaker는 true이다', () => {
+    const { allowSpeaker } = useAppStore.getState();
+    expect(allowSpeaker).toBe(true);
+  });
+
+  it('setAllowSpeaker: false를 설정하면 상태가 업데이트된다', async () => {
+    const { setAllowSpeaker } = useAppStore.getState();
+    await setAllowSpeaker(false);
+
+    const { allowSpeaker } = useAppStore.getState();
+    expect(allowSpeaker).toBe(false);
+  });
+
+  it('setAllowSpeaker: AsyncStorage에 저장한다', async () => {
+    const { setAllowSpeaker } = useAppStore.getState();
+    await setAllowSpeaker(false);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:allow-speaker',
+      JSON.stringify(false),
+    );
+  });
+
+  it('loadAllowSpeaker: AsyncStorage에서 false를 복원한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(false));
+
+    const { loadAllowSpeaker } = useAppStore.getState();
+    await loadAllowSpeaker();
+
+    const { allowSpeaker } = useAppStore.getState();
+    expect(allowSpeaker).toBe(false);
+  });
+
+  it('loadAllowSpeaker: AsyncStorage에서 true를 복원한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(true));
+
+    const { loadAllowSpeaker } = useAppStore.getState();
+    await loadAllowSpeaker();
+
+    const { allowSpeaker } = useAppStore.getState();
+    expect(allowSpeaker).toBe(true);
+  });
+
+  it('loadAllowSpeaker: AsyncStorage가 비어있으면 true를 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { loadAllowSpeaker } = useAppStore.getState();
+    await loadAllowSpeaker();
+
+    const { allowSpeaker } = useAppStore.getState();
+    expect(allowSpeaker).toBe(true);
+  });
+
+  it('loadAllowSpeaker: AsyncStorage 오류 시 true를 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+
+    const { loadAllowSpeaker } = useAppStore.getState();
+    await loadAllowSpeaker();
+
+    const { allowSpeaker } = useAppStore.getState();
+    expect(allowSpeaker).toBe(true);
   });
 
   it('초기 alarmEvent는 null이다', () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Station } from '../types/station';
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import type { RoutePreference } from '../utils/stationRoute';
 
 export type ThemeMode = 'auto' | 'light' | 'dark';
@@ -17,6 +17,7 @@ interface AppState {
   destination: Station | null;
   recentDestination: Station | null;
   sleepMode: boolean;
+  allowSpeaker: boolean;
   customOrigin: Station | null;
   themeMode: ThemeMode;
   routePreference: RoutePreference;
@@ -34,6 +35,8 @@ interface AppState {
   loadRoutePreference: () => Promise<void>;
   setSleepMode: (enabled: boolean) => Promise<void>;
   loadSleepMode: () => Promise<void>;
+  setAllowSpeaker: (enabled: boolean) => Promise<void>;
+  loadAllowSpeaker: () => Promise<void>;
   setAlarmEvent: (event: AlarmEvent) => void;
   clearAlarmEvent: () => void;
   loadAlarmEvent: () => Promise<void>;
@@ -44,6 +47,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   destination: null,
   recentDestination: null,
   sleepMode: false,
+  allowSpeaker: true,
   customOrigin: null,
   themeMode: 'auto' as ThemeMode,
   routePreference: 'optimal' as RoutePreference,
@@ -150,6 +154,22 @@ export const useAppStore = create<AppState>((set, get) => ({
   setSleepMode: async (enabled: boolean) => {
     set({ sleepMode: enabled });
     await AsyncStorage.setItem(SLEEP_MODE_KEY, JSON.stringify(enabled));
+  },
+
+  setAllowSpeaker: async (enabled: boolean) => {
+    set({ allowSpeaker: enabled });
+    await AsyncStorage.setItem(ALLOW_SPEAKER_KEY, JSON.stringify(enabled));
+  },
+
+  loadAllowSpeaker: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(ALLOW_SPEAKER_KEY);
+      if (raw) {
+        set({ allowSpeaker: JSON.parse(raw) === true });
+      }
+    } catch {
+      // 저장된 데이터 없음 — true 유지
+    }
   },
 
   setAlarmEvent: (event: AlarmEvent) => {

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -103,20 +103,22 @@ function getTaskCallback(): TaskCallback {
   return (global as any).__bgTaskCallback as TaskCallback;
 }
 
-/** AsyncStorage.getItem 5개를 순서대로 모킹한다 (dest, sleep, fired, route, lastNotified) */
+/** AsyncStorage.getItem 6개를 순서대로 모킹한다 (dest, sleep, fired, route, lastNotified, allowSpeaker) */
 function mockStorageValues(
   dest: string | null,
   sleep: string | null = null,
   fired: string | null = null,
   route: string | null = null,
   lastNotified: string | null = null,
+  allowSpeaker: string | null = null,
 ): void {
   (AsyncStorage.getItem as jest.Mock)
     .mockResolvedValueOnce(dest)
     .mockResolvedValueOnce(sleep)
     .mockResolvedValueOnce(fired)
     .mockResolvedValueOnce(route)
-    .mockResolvedValueOnce(lastNotified);
+    .mockResolvedValueOnce(lastNotified)
+    .mockResolvedValueOnce(allowSpeaker);
 }
 
 describe('BACKGROUND_LOCATION_TASK 상수', () => {
@@ -228,6 +230,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       false,
+      true,
       null,
       null,
     );
@@ -252,6 +255,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       true,
+      true,
       null,
       null,
     );
@@ -273,6 +277,53 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       false,
+      true,
+      null,
+      null,
+    );
+  });
+
+  // ── allowSpeaker 파싱 ──
+
+  it("allowSpeakerJson이 'false'이면 allowSpeaker=false로 processLocationUpdate를 호출한다", async () => {
+    mockStorageValues(JSON.stringify(mockDestination), null, null, null, null, 'false');
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(),
+      false,
+      false,
+      null,
+      null,
+    );
+  });
+
+  it("allowSpeakerJson이 'true'이면 allowSpeaker=true로 processLocationUpdate를 호출한다", async () => {
+    mockStorageValues(JSON.stringify(mockDestination), null, null, null, null, 'true');
+
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      mockDestination,
+      new Set(),
+      false,
+      true,
       null,
       null,
     );
@@ -297,6 +348,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(fired),
       false,
+      true,
       null,
       null,
     );
@@ -334,6 +386,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       false,
+      true,
       storedRoute,
       null,
     );
@@ -355,6 +408,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       false,
+      true,
       null,
       null,
     );
@@ -480,6 +534,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       mockDestination,
       new Set(),
       false,
+      true,
       null,
       'station-1',
     );

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -6,7 +6,7 @@ import { alarmKey } from '../utils/stationAlarm';
 import { updateStationNotification } from '../utils/stationNotification';
 import { findNearestStation } from '../utils/findNearestStation';
 import { createLogger } from '../utils/logger';
-import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import type { Route } from '../utils/stationRoute';
 
 const logger = createLogger('BackgroundLocation');
@@ -27,12 +27,13 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const { latitude, longitude } = latest.coords;
 
   try {
-    const [destJson, sleepJson, firedJson, routeJson, lastNotifiedJson] = await Promise.all([
+    const [destJson, sleepJson, firedJson, routeJson, lastNotifiedJson, allowSpeakerJson] = await Promise.all([
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(SLEEP_MODE_KEY),
       AsyncStorage.getItem(FIRED_ALARMS_KEY),
       AsyncStorage.getItem(ROUTE_KEY),
       AsyncStorage.getItem(LAST_NOTIFIED_STATION_KEY),
+      AsyncStorage.getItem(ALLOW_SPEAKER_KEY),
     ]);
 
     // 목적지 미설정 시 현재 역 알림만 업데이트
@@ -55,6 +56,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       return;
     }
     const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
+    const allowSpeaker = allowSpeakerJson ? JSON.parse(allowSpeakerJson) === true : true;
     const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
     const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
 
@@ -64,6 +66,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       destination,
       firedAlarms,
       sleepMode,
+      allowSpeaker,
       storedRoute,
       lastNotifiedJson,
     );

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -110,14 +110,17 @@ describe('stationNotification', () => {
       );
     });
 
-    it('일반 알림은 shouldPlaySound false, 알람 알림은 true를 반환한다', async () => {
+    it('일반 알림은 shouldPlaySound false, 알람 알림(sound 있음)은 true를 반환한다', async () => {
       setupNotificationHandler();
       const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
-      const normalResult = await handleNotification({ request: { identifier: 'current-station' } });
+      const normalResult = await handleNotification({ request: { identifier: 'current-station', content: { sound: null } } });
       expect(normalResult).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: false, shouldSetBadge: false });
 
-      const alarmResult = await handleNotification({ request: { identifier: 'station-alarm' } });
+      const alarmResult = await handleNotification({ request: { identifier: 'station-alarm', content: { sound: 'alarm.wav' } } });
       expect(alarmResult).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: true, shouldSetBadge: false });
+
+      const silentAlarmResult = await handleNotification({ request: { identifier: 'station-alarm', content: { sound: null } } });
+      expect(silentAlarmResult).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: false, shouldSetBadge: false });
     });
   });
 
@@ -149,6 +152,16 @@ describe('stationNotification', () => {
         name: '하차/환승 알림',
         importance: Notifications.AndroidImportance.MAX,
         sound: 'alarm.wav',
+        enableVibrate: true,
+        vibrationPattern: [0, 1000, 500, 1000],
+        lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+        bypassDnd: true,
+      });
+      expect(Notifications.deleteNotificationChannelAsync).toHaveBeenCalledWith('station-alarm-silent');
+      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-alarm-silent', {
+        name: '하차/환승 알림 (무음)',
+        importance: Notifications.AndroidImportance.MAX,
+        sound: null,
         enableVibrate: true,
         vibrationPattern: [0, 1000, 500, 1000],
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
@@ -504,6 +517,26 @@ describe('stationNotification', () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification('destination', '강남');
       expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
+    });
+
+    it('allowSpeaker=false이면 iOS에서 sound를 false로 설정한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification('destination', '강남', false, false, false);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-alarm',
+        content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: false, interruptionLevel: 'timeSensitive' },
+        trigger: null,
+      });
+    });
+
+    it('allowSpeaker=false이면 Android에서 무음 채널을 사용한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await sendAlarmNotification('destination', '강남', false, false, false);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-alarm',
+        content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: false, channelId: 'station-alarm-silent', priority: 'max' },
+        trigger: null,
+      });
     });
   });
 

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -227,7 +227,7 @@ describe('processLocationUpdate', () => {
 
     await processLocationUpdate(37.498, 127.028, mockDestination, firedAlarms, false);
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, false, true);
     expect(firedAlarms.size).toBe(0);
   });
 
@@ -239,7 +239,7 @@ describe('processLocationUpdate', () => {
 
     await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', true, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', true, false, true);
   });
 
   it('should not call sendAlarmNotification when no alarm', async () => {
@@ -390,7 +390,7 @@ describe('processLocationUpdate', () => {
     expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
       '시청', 3, '시청', mockRoute, expect.any(Set),
     );
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, true);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, true, true);
     expect(result.alarmEvent).toBe(timeEvent);
   });
 
@@ -412,7 +412,7 @@ describe('processLocationUpdate', () => {
 
     await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '동대문', true, true);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '동대문', true, true, true);
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
       mockStation, 150, mockDestination, mockRoute, 10, undefined, timeEvent,
     );
@@ -435,7 +435,7 @@ describe('processLocationUpdate', () => {
     mockUpdateRouteFromPosition.mockReturnValue(updatedRoute);
     mockCalculateStaticETA.mockReturnValue(6);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, storedRoute);
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, true, storedRoute);
 
     expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
     expect(mockFindRoute).not.toHaveBeenCalled();
@@ -449,7 +449,7 @@ describe('processLocationUpdate', () => {
     mockFindRoute.mockReturnValue(mockRoute);
     mockCalculateStaticETA.mockReturnValue(6);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, storedRoute);
+    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, true, storedRoute);
 
     expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
     expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
@@ -470,7 +470,7 @@ describe('processLocationUpdate', () => {
     mockFindRoute.mockReturnValue(mockRoute);
 
     const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false, null, 'other-station',
+      37.498, 127.028, mockDestination, new Set(), false, true, null, 'other-station',
     );
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
@@ -482,7 +482,7 @@ describe('processLocationUpdate', () => {
     mockFindRoute.mockReturnValue(mockRoute);
 
     const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false, null, 'station-1',
+      37.498, 127.028, mockDestination, new Set(), false, true, null, 'station-1',
     );
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
@@ -494,7 +494,7 @@ describe('processLocationUpdate', () => {
     mockFindRoute.mockReturnValue(mockRoute);
 
     const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false, null, null,
+      37.498, 127.028, mockDestination, new Set(), false, true, null, null,
     );
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -14,6 +14,7 @@ const liveActivityLogger = createLogger('LiveActivity');
 export const NOTIFICATION_ID = 'current-station';
 export const ALARM_NOTIFICATION_ID = 'station-alarm';
 const ALARM_CHANNEL_ID = 'station-alarm';
+const ALARM_SILENT_CHANNEL_ID = 'station-alarm-silent';
 export const STATION_PASSED_NOTIFICATION_ID = 'station-passed';
 const STATION_PASSED_CHANNEL_ID = 'station-passed';
 
@@ -38,11 +39,12 @@ export function setupNotificationHandler(): void {
   Notifications.setNotificationHandler({
     handleNotification: async (notification) => {
       const isAlarm = notification.request.identifier === ALARM_NOTIFICATION_ID;
+      const hasSound = notification.request.content.sound != null;
       return {
         shouldShowAlert: true,
         shouldShowBanner: true,
         shouldShowList: true,
-        shouldPlaySound: isAlarm,
+        shouldPlaySound: isAlarm && hasSound,
         shouldSetBadge: false,
       };
     },
@@ -61,6 +63,16 @@ export async function initStationNotification(): Promise<void> {
       name: '하차/환승 알림',
       importance: Notifications.AndroidImportance.MAX,
       sound: 'alarm.wav',
+      enableVibrate: true,
+      vibrationPattern: [0, 1000, 500, 1000],
+      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+      bypassDnd: true,
+    });
+    await Notifications.deleteNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID).catch(() => {});
+    await Notifications.setNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID, {
+      name: '하차/환승 알림 (무음)',
+      importance: Notifications.AndroidImportance.MAX,
+      sound: null,
       enableVibrate: true,
       vibrationPattern: [0, 1000, 500, 1000],
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
@@ -265,6 +277,7 @@ export async function sendAlarmNotification(
   stationName: string,
   sleepMode: boolean = false,
   timeBased: boolean = false,
+  allowSpeaker: boolean = true,
 ): Promise<void> {
   let title: string;
   let body: string;
@@ -291,9 +304,9 @@ export async function sendAlarmNotification(
   await scheduleNotification(ALARM_NOTIFICATION_ID, {
     title,
     body,
-    sound: 'alarm.wav',
+    sound: allowSpeaker ? 'alarm.wav' : false,
     ...(Platform.OS === 'android' && {
-      channelId: ALARM_CHANNEL_ID,
+      channelId: allowSpeaker ? ALARM_CHANNEL_ID : ALARM_SILENT_CHANNEL_ID,
       priority: Notifications.AndroidNotificationPriority.MAX,
     }),
     // NOTE: critical Entitlement 승인 후 'critical'로 변경 → Sleep Focus 완전 관통

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -84,6 +84,7 @@ export async function processLocationUpdate(
   destination: Station,
   firedAlarms: Set<string>,
   sleepMode: boolean,
+  allowSpeaker: boolean = true,
   storedRoute: Route = null,
   lastNotifiedStationId: string | null = null,
 ): Promise<PipelineResult> {
@@ -105,6 +106,7 @@ export async function processLocationUpdate(
       alarmEvent.stationName,
       sleepMode,
       alarmEvent.timeBased ?? false,
+      allowSpeaker,
     );
   }
 


### PR DESCRIPTION
## Summary
- 이어폰 미연결 시 알람음 스피커 출력 여부를 사용자가 선택하는 토글 설정 추가
- `allowSpeaker=true` → notification sound 재생 (iOS 자동 라우팅)
- `allowSpeaker=false` → sound 제거 + 진동만
- Android: 무음 채널(`station-alarm-silent`) 추가로 채널 레벨 사운드 제어
- 포그라운드 핸들러에서 sound 필드 확인하여 `shouldPlaySound` 정확히 반영

## 변경 파일 (13개)
store, constants, notification, pipeline, background task, hooks, settings UI, home screen + 각 테스트

Closes #183

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 675 tests 전체 통과, 커버리지 100%
- [ ] 설정 > 알람 > 스피커 출력 토글 동작 확인
- [ ] 토글 OFF 시 Alert 확인 팝업 표시
- [ ] allowSpeaker=false 시 알람 진동만 발생 확인