### PR TITLE
feat(#184): 취침 모드 첫 활성화 시 스피커 안내 팝업

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -21,6 +21,7 @@ import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
 import { useTheme, typography, spacing, radius } from '../../src/theme';
 import { LineBadge } from '../../src/components/LineBadge';
+import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
 const logger = createLogger('HomeScreen');
 
@@ -46,6 +47,7 @@ export default function HomeScreen() {
   const setSleepMode = useAppStore((s) => s.setSleepMode);
   const loadSleepMode = useAppStore((s) => s.loadSleepMode);
   const loadAllowSpeaker = useAppStore((s) => s.loadAllowSpeaker);
+  const showSleepModeGuide = useSleepModeGuide();
   const alarmEvent = useAppStore((s) => s.alarmEvent);
   const clearAlarmEvent = useAppStore((s) => s.clearAlarmEvent);
   const loadAlarmEvent = useAppStore((s) => s.loadAlarmEvent);
@@ -403,7 +405,13 @@ export default function HomeScreen() {
                   </View>
                   <Switch
                     value={sleepMode}
-                    onValueChange={setSleepMode}
+                    onValueChange={(value) => {
+                      if (value) {
+                        showSleepModeGuide(() => setSleepMode(true));
+                      } else {
+                        setSleepMode(false);
+                      }
+                    }}
                     trackColor={{ false: colors.hair, true: colors.accent }}
                     thumbColor={colors.bg}
                     testID="home-sleep-mode-switch"

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppStore, type ThemeMode } from '../../src/store/useAppStore';
 import type { RoutePreference } from '../../src/utils/stationRoute';
 import { useTheme, spacing, radius } from '../../src/theme';
+import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
 const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: 'auto', label: '자동' },
@@ -25,6 +26,7 @@ export default function SettingsScreen() {
   const setRoutePreference = useAppStore((s) => s.setRoutePreference);
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
   const { colors } = useTheme();
+  const showSleepModeGuide = useSleepModeGuide();
 
   useEffect(() => {
     loadSleepMode();
@@ -114,7 +116,13 @@ export default function SettingsScreen() {
           </View>
           <Switch
             value={sleepMode}
-            onValueChange={setSleepMode}
+            onValueChange={(value) => {
+              if (value) {
+                showSleepModeGuide(() => setSleepMode(true));
+              } else {
+                setSleepMode(false);
+              }
+            }}
             trackColor={{ false: colors.hair, true: colors.accent }}
             thumbColor={sleepMode ? colors.onAccent : colors.subtle}
             testID="sleep-mode-switch"

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -9,3 +9,4 @@ export const ROUTE_PREFERENCE_KEY = 'subway-now:route-preference';
 export const ROUTE_KEY = 'subway-now:route';
 export const LAST_NOTIFIED_STATION_KEY = 'subway-now:last-notified-station';
 export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';
+export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';

--- a/src/hooks/__tests__/useSleepModeGuide.test.ts
+++ b/src/hooks/__tests__/useSleepModeGuide.test.ts
@@ -1,0 +1,151 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSleepModeGuide } from '../useSleepModeGuide';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+describe('useSleepModeGuide', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('should show Alert on first call when AsyncStorage has no stored value', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const { result } = renderHook(() => useSleepModeGuide());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalled();
+    });
+
+    const onConfirm = jest.fn();
+    act(() => {
+      result.current(onConfirm);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      '취침 모드 안내',
+      expect.any(String),
+      [{ text: '확인', onPress: onConfirm }],
+    );
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('should save true to AsyncStorage on first call', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const { result } = renderHook(() => useSleepModeGuide());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalled();
+    });
+
+    const onConfirm = jest.fn();
+    act(() => {
+      result.current(onConfirm);
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:sleep-mode-guide-shown',
+      'true',
+    );
+  });
+
+  it('should call onConfirm via Alert button press on first call', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (Alert.alert as jest.Mock).mockImplementationOnce((_title, _msg, buttons) => {
+      buttons[0].onPress();
+    });
+
+    const { result } = renderHook(() => useSleepModeGuide());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalled();
+    });
+
+    const onConfirm = jest.fn();
+    act(() => {
+      result.current(onConfirm);
+    });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip Alert on second call and call onConfirm directly', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const { result } = renderHook(() => useSleepModeGuide());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalled();
+    });
+
+    const firstConfirm = jest.fn();
+    act(() => {
+      result.current(firstConfirm);
+    });
+
+    const secondConfirm = jest.fn();
+    act(() => {
+      result.current(secondConfirm);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    expect(secondConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip Alert and call onConfirm directly when AsyncStorage has stored true', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHook(() => useSleepModeGuide());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalled();
+    });
+
+    const onConfirm = jest.fn();
+    act(() => {
+      result.current(onConfirm);
+    });
+
+    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still show Alert when AsyncStorage.getItem rejects', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('storage error'));
+    const { result } = renderHook(() => useSleepModeGuide());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalled();
+    });
+
+    const onConfirm = jest.fn();
+    act(() => {
+      result.current(onConfirm);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when AsyncStorage.setItem rejects', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('setItem error'));
+    const { result } = renderHook(() => useSleepModeGuide());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalled();
+    });
+
+    const onConfirm = jest.fn();
+    expect(() => {
+      act(() => {
+        result.current(onConfirm);
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/useSleepModeGuide.ts
+++ b/src/hooks/useSleepModeGuide.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Alert } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SLEEP_MODE_GUIDE_SHOWN_KEY } from '../constants/storageKeys';
+
+export function useSleepModeGuide(): (onConfirm: () => void) => void {
+  const shownRef = useRef(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem(SLEEP_MODE_GUIDE_SHOWN_KEY).then((raw) => {
+      shownRef.current = raw === 'true';
+    }).catch(() => {});
+  }, []);
+
+  return useCallback((onConfirm: () => void) => {
+    if (shownRef.current) {
+      onConfirm();
+      return;
+    }
+    shownRef.current = true;
+    AsyncStorage.setItem(SLEEP_MODE_GUIDE_SHOWN_KEY, 'true').catch(() => {});
+    Alert.alert(
+      '취침 모드 안내',
+      '이어폰이 연결되지 않은 경우 알람이 스피커로 재생될 수 있습니다.\n\n스피커 출력을 원하지 않으시면 설정 > 알람에서 \'스피커 출력 허용\'을 꺼주세요.',
+      [{ text: '확인', onPress: onConfirm }],
+    );
+  }, []);
+}


### PR DESCRIPTION
## Summary
- 취침 모드 첫 활성화 시 스피커 출력 관련 안내 Alert 팝업 표시 (1회만)
- `useSleepModeGuide` 훅으로 로직 공유 (설정 화면 + 홈 화면)
- AsyncStorage에 표시 여부 영속화

## 안내 내용
> 이어폰이 연결되지 않은 경우 알람이 스피커로 재생될 수 있습니다.
> 스피커 출력을 원하지 않으시면 설정 > 알람에서 '스피커 출력 허용'을 꺼주세요.

Closes #184

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 682 tests 전체 통과, 커버리지 100%
- [x] 취침 모드 첫 활성화 시 안내 팝업 표시 확인
- [x] 2회차 활성화 시 팝업 미표시 확인