### PR TITLE
fix(#189): 백그라운드 위치 업데이트 batching 제거

### DIFF
--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -14,6 +14,7 @@ jest.mock('expo-location', () => ({
   stopLocationUpdatesAsync: (...args: unknown[]) =>
     mockStopLocationUpdatesAsync(...args),
   Accuracy: { High: 6 },
+  LocationActivityType: { AutomotiveNavigation: 2 },
 }));
 
 // ── expo-task-manager 모킹 ──
@@ -109,8 +110,9 @@ describe('useBackgroundLocation', () => {
         'background-location-task',
         expect.objectContaining({
           accuracy: 6, // Location.Accuracy.High
+          activityType: 2, // Location.LocationActivityType.AutomotiveNavigation
+          pausesUpdatesAutomatically: false,
           distanceInterval: 20,
-          deferredUpdatesInterval: 3_000,
           showsBackgroundLocationIndicator: true,
           foregroundService: expect.objectContaining({
             notificationTitle: '지하철 위치 감지 중',
@@ -119,6 +121,9 @@ describe('useBackgroundLocation', () => {
         }),
       );
     });
+
+    const callArgs = mockStartLocationUpdatesAsync.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(callArgs).not.toHaveProperty('deferredUpdatesInterval');
   });
 
   // ── 권한 거부 ──

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -31,8 +31,11 @@ export function useBackgroundLocation(destination: Station | null): void {
 
       await Location.startLocationUpdatesAsync(BACKGROUND_LOCATION_TASK, {
         accuracy: Location.Accuracy.High,
+        // 매 역 통과 시점 알림을 위해 iOS가 GPS 업데이트를 가장 공격적으로 유지하도록 차량 내비 프로필을 사용한다.
+        activityType: Location.LocationActivityType.AutomotiveNavigation,
+        // 지하 정차/터널에서 GPS가 약해질 때 iOS가 stationary로 오판해 업데이트를 멈추면 알림이 누락되므로 명시적으로 끈다.
+        pausesUpdatesAutomatically: false,
         distanceInterval: 20,
-        deferredUpdatesInterval: 3_000,
         showsBackgroundLocationIndicator: true,
         foregroundService: {
           notificationTitle: '지하철 위치 감지 중',


### PR DESCRIPTION
## Summary

백그라운드 상태에서 역을 통과할 때 알림이 즉시 도착하지 않고 앱을 다시 열 때 누적 알림이 한꺼번에 표시되던 문제를 수정한다.

`src/hooks/useBackgroundLocation.ts` 의 `Location.startLocationUpdatesAsync` 옵션 보정:

- `pausesUpdatesAutomatically: false` 추가
- `activityType: AutomotiveNavigation` 추가
- `deferredUpdatesInterval: 3_000` 제거

## 근거

`node_modules/expo-location/ios/TaskConsumers/EXLocationTaskConsumer.m` 의 네이티브 기본값/배치 동작을 확인:

- `:73` — `pausesUpdatesAutomatically` 네이티브 기본값은 `true` (TypeScript 문서의 `@default false` 는 잘못된 문서). 시스템이 stationary로 판단하면 업데이트 자동 중단.
- `:72`, `EXLocation.m:45-54` — `activityType` 미설정 시 `CLActivityTypeOther`. Navigation 용도로 인식되지 않아 iOS가 power saving 우선.
- `:158-161` — `deferredUpdatesInterval` 이 백그라운드에서만 활성화되어 위치 업데이트를 시간 + 거리 조건으로 batch 처리. 앱이 다시 활성화될 때 batch가 한꺼번에 dispatch 되어 알림이 몰려 도착하는 직접 원인.

## Test plan

- [x] `npm test` — 46 suites / 682 tests 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] `useBackgroundLocation.test.ts` — `pausesUpdatesAutomatically: false`, `activityType` 포함 + `deferredUpdatesInterval` 미포함 회귀 가드 추가
- [ ] **실기기 검증 필요** — TestFlight 빌드 후 백그라운드 상태에서 지하철 1~2 정거장 이동, 매 역 알림이 즉시 도착하는지 확인

## 후속 작업 (별도 이슈 권장)

- `useBackgroundLocation` / `useNearestStation` 의 GPS 옵션을 `src/constants/` 로 통합 추출 (현재 `distanceInterval` 매직 넘버)
- 도착 후 N분간 위치 정체 시 자동 추적 종료 로직 검토

Closes #189