### PR TITLE
fix(#193): 경로 카테고리 기반 탭 UI 표시로 변경

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,7 +9,7 @@ import { formatArrivalTime } from '../../src/utils/formatTime';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
-import { findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, type Route, type RouteCandidate } from '../../src/utils/stationRoute';
+import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
 import { EditorialTimeline } from '../../src/components/EditorialTimeline';
 import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/journeyAdapter';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
@@ -58,9 +58,10 @@ export default function HomeScreen() {
   const prevDestIdRef = useRef<string | null>(null);
   const routePreference = useAppStore((s) => s.routePreference);
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
-  const [candidates, setCandidates] = useState<RouteCandidate[]>([]);
-  const [selectedIdx, setSelectedIdx] = useState(0);
-  const route: Route = candidates[selectedIdx]?.route ?? null;
+  const [categorized, setCategorized] = useState<CategorizedRoute[]>([]);
+  const [selectedKey, setSelectedKey] = useState<RoutePreference>(routePreference);
+  const route: Route =
+    categorized.find((r) => r.category.key === selectedKey)?.candidate.route ?? null;
   const isFav = effectiveOrigin ? favorites.some((f) => f.id === effectiveOrigin.id) : false;
 
   // 환승역이면 모든 호선 변형에서 경로 계산 → 출발역 환승 없는 최적 경로 자동 선택
@@ -69,26 +70,23 @@ export default function HomeScreen() {
 
   useEffect(() => {
     if (!effectiveOrigin || !destination) {
-      setCandidates([]);
-      setSelectedIdx(0);
+      setCategorized([]);
       AsyncStorage.removeItem(ROUTE_KEY).catch(() => {});
       return;
     }
     const interactionStart = performance.now();
     const interaction = InteractionManager.runAfterInteractions(() => {
-      let allResults: RouteCandidate[] = [];
-      for (const origin of originVariants) {
-        const routes = findRoutes(origin.id, destination.id);
-        allResults.push(...routes);
-      }
-      allResults.sort((a, b) => a.travelMinutes - b.travelMinutes || a.transferCount - b.transferCount);
+      const result = findRouteCandidatesByCategory(
+        originVariants.map((o) => o.id),
+        destination.id,
+      );
       const total = performance.now() - interactionStart;
       logger.debug(`경로 계산 전체 (InteractionManager 포함): ${total.toFixed(2)}ms`);
-      setCandidates(allResults);
-      const picked = pickRouteByPreference(allResults, routePreference);
-      setSelectedIdx(picked ? allResults.indexOf(picked) : 0);
-      if (picked) {
-        AsyncStorage.setItem(ROUTE_KEY, JSON.stringify(picked.route)).catch(() => {});
+      setCategorized(result);
+      const preferred = result.find((r) => r.category.key === routePreference) ?? result[0];
+      if (preferred) {
+        setSelectedKey(preferred.category.key);
+        AsyncStorage.setItem(ROUTE_KEY, JSON.stringify(preferred.candidate.route)).catch(() => {});
       } else {
         AsyncStorage.removeItem(ROUTE_KEY).catch(() => {});
       }
@@ -347,26 +345,25 @@ export default function HomeScreen() {
                       )}
                     </View>
                   </View>
-                  {candidates.length > 1 && (
+                  {categorized.length > 0 && (
                     <View style={[styles.routePillGroup, { backgroundColor: colors.hair }]} testID="route-segment-control">
-                      {candidates.map((c, i) => {
-                        const active = i === selectedIdx;
-                        const label = c.transferCount <= 1 ? '최적경로' : '최소환승';
+                      {categorized.map(({ category, candidate }) => {
+                        const active = category.key === selectedKey;
                         return (
                           <Pressable
-                            key={i}
-                            testID={`route-tab-${i}`}
+                            key={category.key}
+                            testID={`route-tab-${category.key}`}
                             style={[styles.routePill, active && { backgroundColor: colors.accent }]}
                             onPress={() => {
-                              setSelectedIdx(i);
-                              AsyncStorage.setItem(ROUTE_KEY, JSON.stringify(c.route)).catch(() => {});
+                              setSelectedKey(category.key);
+                              AsyncStorage.setItem(ROUTE_KEY, JSON.stringify(candidate.route)).catch(() => {});
                             }}
                           >
                             <Text style={[styles.routePillText, { color: active ? colors.onAccent : colors.muted }]}>
-                              {label}
+                              {category.label}
                             </Text>
                             <Text style={[styles.routePillSub, { color: active ? colors.onAccent : colors.subtle }]}>
-                              {c.travelMinutes}분 · {c.transferCount}환승
+                              {candidate.travelMinutes}분 · {candidate.transferCount}환승
                             </Text>
                           </Pressable>
                         );

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppStore, type ThemeMode } from '../../src/store/useAppStore';
-import type { RoutePreference } from '../../src/utils/stationRoute';
+import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
@@ -85,17 +85,17 @@ export default function SettingsScreen() {
         </View>
 
         <View style={[styles.segmentGroup, { backgroundColor: colors.hair }]} testID="route-segment">
-          {([['optimal', '최적경로'], ['minTransfer', '최소환승']] as [RoutePreference, string][]).map(([value, label]) => {
-            const active = routePreference === value;
+          {ROUTE_CATEGORIES.map((category) => {
+            const active = routePreference === category.key;
             return (
               <Pressable
-                key={value}
+                key={category.key}
                 style={[styles.segment, active && { backgroundColor: colors.accent }]}
-                onPress={() => setRoutePreference(value)}
-                testID={`route-${value}`}
+                onPress={() => setRoutePreference(category.key)}
+                testID={`route-${category.key}`}
               >
                 <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
-                  {label}
+                  {category.label}
                 </Text>
               </Pressable>
             );

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -3,7 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Station } from '../types/station';
 import type { AlarmEvent } from '../utils/stationAlarm';
 import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
-import type { RoutePreference } from '../utils/stationRoute';
+import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 
 export type ThemeMode = 'auto' | 'light' | 'dark';
 
@@ -142,7 +142,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const raw = await AsyncStorage.getItem(ROUTE_PREFERENCE_KEY);
       if (raw) {
         const parsed = JSON.parse(raw);
-        if (parsed === 'optimal' || parsed === 'minTransfer') {
+        if (ROUTE_CATEGORIES.some((c) => c.key === parsed)) {
           set({ routePreference: parsed });
         }
       }

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,6 +1,6 @@
-import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, findRouteCandidatesByCategory, ROUTE_CATEGORIES } from '../stationRoute';
 import type { Station } from '../../types/station';
-import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate } from '../stationRoute';
+import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 
 describe('getStationsOnLine', () => {
   it('returns only stations on the given line, sorted by id', () => {
@@ -645,6 +645,84 @@ describe('pickRouteByPreference', () => {
 
   it('빈 배열이면 null을 반환한다', () => {
     expect(pickRouteByPreference([], 'optimal')).toBeNull();
+  });
+});
+
+describe('findRouteCandidatesByCategory', () => {
+  it('직통 경로일 때 모든 카테고리가 후보를 반환한다 (같은 경로를 가리킴)', () => {
+    const result = findRouteCandidatesByCategory(['1-001'], '1-003');
+    expect(result).toHaveLength(ROUTE_CATEGORIES.length);
+    result.forEach((entry) => {
+      expect(entry.candidate.route.type).toBe('direct');
+    });
+    expect(result[0].candidate).toBe(result[1].candidate);
+  });
+
+  it('환승 경로가 있어도 항상 모든 카테고리에 대해 결과를 반환한다', () => {
+    const result = findRouteCandidatesByCategory(['2-022'], '3-012');
+    expect(result.length).toBe(ROUTE_CATEGORIES.length);
+    const keys = result.map((r) => r.category.key);
+    expect(keys).toEqual(ROUTE_CATEGORIES.map((c) => c.key));
+  });
+
+  it('originIds가 비어있으면 빈 배열을 반환한다', () => {
+    expect(findRouteCandidatesByCategory([], '1-001')).toEqual([]);
+  });
+
+  it('유효하지 않은 origin이면 빈 배열을 반환한다', () => {
+    expect(findRouteCandidatesByCategory(['invalid-id'], '1-001')).toEqual([]);
+  });
+
+  it('여러 originIds를 모두 탐색하여 카테고리별 최적을 선택한다', () => {
+    // 3-032(교대 3호선) → 3-034 직통, 2-022(강남 2호선) → 3-034는 환승 필요
+    // optimal 카테고리는 더 짧은 직통 후보(transferCount=0)를 선택해야 한다.
+    const result = findRouteCandidatesByCategory(['2-022', '3-032'], '3-034');
+    expect(result.length).toBe(ROUTE_CATEGORIES.length);
+    const optimal = result.find((r) => r.category.key === 'optimal')!;
+    expect(optimal.candidate.transferCount).toBe(0);
+    expect(optimal.candidate.route.type).toBe('direct');
+  });
+
+  it('커스텀 categories 인자를 받아 해당 정렬 기준으로 동작한다', () => {
+    const onlyOptimal: RouteCategory[] = [
+      { key: 'optimal', label: '빠른길', comparator: (a, b) => a.travelMinutes - b.travelMinutes },
+    ];
+    const result = findRouteCandidatesByCategory(['1-001'], '1-003', onlyOptimal);
+    expect(result).toHaveLength(1);
+    expect(result[0].category.label).toBe('빠른길');
+  });
+});
+
+describe('ROUTE_CATEGORIES comparators', () => {
+  const makeCandidate = (transferCount: number, travelMinutes: number): RouteCandidate => ({
+    route: { type: 'direct', stops: Math.max(0, Math.floor(travelMinutes / 2)) },
+    totalStops: Math.max(0, Math.floor(travelMinutes / 2)),
+    transferCount,
+    travelMinutes,
+  });
+
+  it('optimal: travelMinutes 차이가 우선, 동률이면 transferCount로 정렬한다', () => {
+    const optimal = ROUTE_CATEGORIES.find((c) => c.key === 'optimal')!;
+    const fast = makeCandidate(2, 10);
+    const slow = makeCandidate(0, 20);
+    expect(optimal.comparator(fast, slow)).toBeLessThan(0);
+    expect(optimal.comparator(slow, fast)).toBeGreaterThan(0);
+
+    const sameTimeMoreTransfer = makeCandidate(2, 10);
+    const sameTimeFewerTransfer = makeCandidate(0, 10);
+    expect(optimal.comparator(sameTimeMoreTransfer, sameTimeFewerTransfer)).toBeGreaterThan(0);
+  });
+
+  it('minTransfer: transferCount 차이가 우선, 동률이면 travelMinutes로 정렬한다', () => {
+    const minTransfer = ROUTE_CATEGORIES.find((c) => c.key === 'minTransfer')!;
+    const fewer = makeCandidate(0, 30);
+    const more = makeCandidate(2, 10);
+    expect(minTransfer.comparator(fewer, more)).toBeLessThan(0);
+    expect(minTransfer.comparator(more, fewer)).toBeGreaterThan(0);
+
+    const sameTransferSlower = makeCandidate(1, 20);
+    const sameTransferFaster = makeCandidate(1, 10);
+    expect(minTransfer.comparator(sameTransferSlower, sameTransferFaster)).toBeGreaterThan(0);
   });
 });
 

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -71,6 +71,32 @@ export interface RouteCandidate {
   travelMinutes: number;
 }
 
+export interface RouteCategory {
+  key: RoutePreference;
+  label: string;
+  comparator: (a: RouteCandidate, b: RouteCandidate) => number;
+}
+
+export interface CategorizedRoute {
+  category: RouteCategory;
+  candidate: RouteCandidate;
+}
+
+export const ROUTE_CATEGORIES: readonly RouteCategory[] = [
+  {
+    key: 'optimal',
+    label: '최적경로',
+    comparator: (a, b) =>
+      a.travelMinutes - b.travelMinutes || a.transferCount - b.transferCount,
+  },
+  {
+    key: 'minTransfer',
+    label: '최소환승',
+    comparator: (a, b) =>
+      a.transferCount - b.transferCount || a.travelMinutes - b.travelMinutes,
+  },
+];
+
 export interface JourneySegment {
   line: string;
   lineColor: string;
@@ -283,7 +309,8 @@ export function findRoutes(currentId: string, destinationId: string): RouteCandi
     current, destination, currentLineStations, destLineStations, currentIdx, destIdx,
   );
 
-  // 후보 수집 + 정렬 + 열등 후보 제거
+  // 후보 수집 + 정렬 — 도미네이션 필터는 적용하지 않음.
+  // 카테고리별 선택은 findRouteCandidatesByCategory에서 책임진다.
   const candidates: RouteCandidate[] = [];
   if (bestSingle) candidates.push(toCandidate(bestSingle));
   /* istanbul ignore next -- 실제 서울 지하철 데이터에서 2회 환승 불가 노선 조합은 없음 */
@@ -291,23 +318,22 @@ export function findRoutes(currentId: string, destinationId: string): RouteCandi
 
   candidates.sort((a, b) => a.travelMinutes - b.travelMinutes);
 
-  // strict domination 필터
-  const filtered = candidates.filter((c, i) => {
-    for (let j = 0; j < candidates.length; j++) {
-      if (i === j) continue;
-      const other = candidates[j];
-      /* istanbul ignore next -- 현재 후보는 항상 transferCount가 다름 (1 vs 2) */
-      if (other.travelMinutes <= c.travelMinutes && other.transferCount <= c.transferCount
-          && (other.travelMinutes < c.travelMinutes || other.transferCount < c.transferCount)) {
-        return false;
-      }
-    }
-    return true;
-  });
-
   const duration = performance.now() - start;
   logger.debug(`findRoutes(${currentId} → ${destinationId}): ${duration.toFixed(2)}ms`);
-  return filtered;
+  return candidates;
+}
+
+export function findRouteCandidatesByCategory(
+  originIds: readonly string[],
+  destinationId: string,
+  categories: readonly RouteCategory[] = ROUTE_CATEGORIES,
+): CategorizedRoute[] {
+  const all = originIds.flatMap((id) => findRoutes(id, destinationId));
+  if (all.length === 0) return [];
+  return categories.map((category) => ({
+    category,
+    candidate: [...all].sort(category.comparator)[0],
+  }));
 }
 
 export function findRoute(currentId: string, destinationId: string): Route {
@@ -322,12 +348,10 @@ export function pickRouteByPreference(
   preference: RoutePreference,
 ): RouteCandidate | null {
   if (candidates.length === 0) return null;
-  if (preference === 'minTransfer') {
-    return [...candidates].sort(
-      (a, b) => a.transferCount - b.transferCount || a.travelMinutes - b.travelMinutes,
-    )[0];
-  }
-  return candidates[0];
+  const category = ROUTE_CATEGORIES.find((c) => c.key === preference);
+  /* istanbul ignore next -- RoutePreference 유니온이 ROUTE_CATEGORIES 키와 동기화되므로 undefined 불가 */
+  if (!category) return candidates[0];
+  return [...candidates].sort(category.comparator)[0];
 }
 
 function findMultiTransferRoute(


### PR DESCRIPTION
## Summary
- 홈 화면의 "최적경로 / 최소환승" 탭 UI가 후보가 1개 이하일 때 표시되지 않던 문제 해결
- 데이터 주도 `ROUTE_CATEGORIES` 도입 → 경로가 하나라도 있으면 두 탭이 항상 표시되며, 카테고리 추가 시 단일 진실 소스 한 곳만 수정하면 됨

## Changes
- `src/utils/stationRoute.ts`
  - `RouteCategory` / `CategorizedRoute` 타입과 `ROUTE_CATEGORIES` 상수 추가 (key/label/comparator)
  - `findRoutes`의 strict domination 필터 제거 → 모든 후보 반환
  - 신규 `findRouteCandidatesByCategory(originIds, destinationId, categories?)` — 카테고리별 best 1개 반환
  - `pickRouteByPreference`를 `ROUTE_CATEGORIES.comparator`로 통일
- `app/(tabs)/index.tsx`
  - `candidates`+`selectedIdx`(인덱스) → `categorized`+`selectedKey`(카테고리 키)
  - 렌더 조건 `> 1` → `> 0`, 라벨 하드코딩 제거 (`category.label` 사용)
  - testID도 키 기반(`route-tab-optimal`)으로 변경
- `app/(tabs)/settings.tsx`: 하드코딩 카테고리 배열 → `ROUTE_CATEGORIES.map(...)`
- `src/store/useAppStore.ts`: `loadRoutePreference` 검증을 `ROUTE_CATEGORIES`에서 파생
- 테스트: `findRouteCandidatesByCategory` + `ROUTE_CATEGORIES` comparator 케이스 추가

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 46 suites · 690 tests 통과, 커버리지 100% (lines/functions/branches/statements)
- [x] `code-reviewer` 에이전트 리뷰 — P1 2건 + P2 2건 반영
- [ ] 시뮬레이터 수동 검증: 직통 경로(예: 1호선 종로3가 → 시청) 두 탭 표시
- [ ] 시뮬레이터 수동 검증: 환승 경로(예: 강남 → 홍대입구) 두 탭 표시 + 카테고리별 시간/환승 수 다름 확인
- [ ] 설정 화면에서 기본 경로 "최소환승"으로 변경 시 홈 진입 시 해당 탭이 기본 선택되는지 확인
- [ ] GitHub Actions `CI / Type Check & Test` 통과 확인

Closes #193