### PR TITLE
fix(#192): GPS 신뢰성 게이트로 false 통과 알림 차단

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -1,0 +1,3 @@
+export const MAX_LOCATION_AGE_MS = 30_000;
+export const MAX_ACCURACY_M = 150;
+export const MAX_STATION_DISTANCE_KM = 1.0;

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -14,7 +14,11 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockSubscription = { remove: jest.fn() };
-let watchCallback: ((location: { coords: { latitude: number; longitude: number } }) => void) | null = null;
+type WatchLocation = {
+  coords: { latitude: number; longitude: number; accuracy?: number | null };
+  timestamp?: number;
+};
+let watchCallback: ((location: WatchLocation) => void) | null = null;
 
 const mockGranted = () => {
   (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
@@ -28,9 +32,14 @@ const mockDenied = () => {
   });
 };
 
-const mockLastKnownLocation = (lat: number, lng: number) => {
+const mockLastKnownLocation = (
+  lat: number,
+  lng: number,
+  opts: { ageMs?: number; accuracy?: number | null } = {},
+) => {
   (Location.getLastKnownPositionAsync as jest.Mock).mockResolvedValue({
-    coords: { latitude: lat, longitude: lng },
+    coords: { latitude: lat, longitude: lng, accuracy: opts.accuracy ?? null },
+    timestamp: Date.now() - (opts.ageMs ?? 0),
   });
 };
 
@@ -38,15 +47,19 @@ const mockNoLastKnownLocation = () => {
   (Location.getLastKnownPositionAsync as jest.Mock).mockResolvedValue(null);
 };
 
-const mockLocation = (lat: number, lng: number) => {
+const mockLocation = (lat: number, lng: number, opts: { accuracy?: number | null } = {}) => {
   (Location.getCurrentPositionAsync as jest.Mock).mockResolvedValue({
-    coords: { latitude: lat, longitude: lng },
+    coords: { latitude: lat, longitude: lng, accuracy: opts.accuracy ?? null },
+    timestamp: Date.now(),
   });
 };
 
-const simulateGps = (lat: number, lng: number) => {
+const simulateGps = (lat: number, lng: number, accuracy: number | null = null) => {
   act(() => {
-    watchCallback?.({ coords: { latitude: lat, longitude: lng } });
+    watchCallback?.({
+      coords: { latitude: lat, longitude: lng, accuracy },
+      timestamp: Date.now(),
+    });
   });
 };
 
@@ -104,18 +117,19 @@ describe('useNearestStation', () => {
     expect(result.current.userLocation).toEqual({ lat: 37.4980, lng: 127.0277 });
   });
 
-  it('500m 초과 거리에서도 가장 가까운 역을 반환한다', async () => {
+  it('1km 이내 거리는 정상 반환된다 (거리 상한 내 통과)', async () => {
     mockGranted();
 
     const { result } = renderHook(() => useNearestStation());
 
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
-    simulateGps(37.5200, 127.0000);
+    simulateGps(37.5035, 127.0277);
 
     await waitFor(() => expect(result.current.result).not.toBeNull());
 
-    expect(result.current.result?.distanceKm).toBeGreaterThan(0.5);
+    expect(result.current.result?.distanceKm).toBeGreaterThan(0);
+    expect(result.current.result?.distanceKm).toBeLessThanOrEqual(1.0);
   });
 
   it('watchPositionAsync 실패 시 error가 설정된다', async () => {
@@ -372,5 +386,110 @@ describe('useNearestStation', () => {
 
     // catch 후에도 watch 재시작됨
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('stale 캐시 위치(30초 초과)는 무시하고 watch만 시작한다', async () => {
+    mockGranted();
+    mockLastKnownLocation(37.4980, 127.0277, { ageMs: 60_000 });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // stale 캐시는 무시 → result는 null 유지 (watch 콜백 전까지)
+    expect(result.current.result).toBeNull();
+  });
+
+  it('저정확도 캐시 위치(150m 초과)는 무시한다', async () => {
+    mockGranted();
+    mockLastKnownLocation(37.4980, 127.0277, { accuracy: 200 });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    expect(result.current.result).toBeNull();
+  });
+
+  it('신선하고 정확한 캐시 위치는 사용한다', async () => {
+    mockGranted();
+    mockLastKnownLocation(37.4980, 127.0277, { ageMs: 5_000, accuracy: 30 });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.result?.station.name).toBe('강남');
+  });
+
+  it('watch 콜백 저정확도(150m 초과) 좌표는 setState하지 않는다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, 200);
+
+    // 저정확도라 result 갱신 안 됨
+    expect(result.current.result).toBeNull();
+    expect(result.current.userLocation).toBeNull();
+  });
+
+  it('watch 콜백 accuracy가 null이면 통과한다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, null);
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.result?.station.name).toBe('강남');
+  });
+
+  it('refresh 시 저정확도 좌표는 setState하지 않는다', async () => {
+    mockGranted();
+    mockLocation(37.4980, 127.0277, { accuracy: 200 });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
+    // 저정확도라 result 갱신 안 됨
+    expect(result.current.result).toBeNull();
+  });
+
+  it('timestamp가 없는 캐시 위치는 무시한다', async () => {
+    mockGranted();
+    (Location.getLastKnownPositionAsync as jest.Mock).mockResolvedValue({
+      coords: { latitude: 37.4980, longitude: 127.0277, accuracy: null },
+      // timestamp 누락
+    });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    expect(result.current.result).toBeNull();
+  });
+
+  it('1km 초과 거리의 위치는 findNearestStations가 null을 반환한다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // 강원도 등 지하철 역과 멀리 떨어진 좌표
+    simulateGps(38.5, 128.5, 30);
+
+    // MAX_STATION_DISTANCE_KM(1.0) 초과 → null
+    expect(result.current.result).toBeNull();
   });
 });

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -330,5 +330,59 @@ describe('useStationAlarm', () => {
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
       expect(() => renderHook(() => useStationAlarm(route, '강남', station))).not.toThrow();
     });
+
+    it('transfer route에서 경로 외 노선의 역은 알림을 발송하지 않는다', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 5,
+      };
+      // 4호선 역 (경로상 노선 1, 2가 아님)
+      const offRouteStation: Station = {
+        id: 'OFF-1',
+        name: '동대문',
+        line: '4',
+        lineColor: '#00A4E3',
+        lat: 37.5,
+        lng: 127.0,
+      };
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '시청', stopsToNextStation: 3 });
+      renderHook(() => useStationAlarm(route, '강남', offRouteStation));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('경로 외 역 다음에 경로상 역이 오면 알림을 발송한다 (ref 미갱신 검증)', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 5,
+      };
+      const offRouteStation: Station = {
+        id: 'OFF-1',
+        name: '동대문',
+        line: '4',
+        lineColor: '#00A4E3',
+        lat: 37.5,
+        lng: 127.0,
+      };
+      const onRouteStation = makeStation('S1', '서울'); // line '2' (toLine)
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '시청', stopsToNextStation: 2 });
+
+      const { rerender } = renderHook(
+        ({ s }: { s: Station }) => useStationAlarm(route, '강남', s),
+        { initialProps: { s: offRouteStation } },
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+
+      rerender({ s: onRouteStation });
+      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('서울', '강남', 2);
+    });
   });
 });

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -3,6 +3,8 @@ import { AppState } from 'react-native';
 import * as Location from 'expo-location';
 import { NearestStationResult, Station } from '../types/station';
 import { findNearestStations } from '../utils/findNearestStation';
+import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
+import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 
 const DISTANCE_INTERVAL_M = 10;
 const MIN_DISTANCE_CHANGE_KM = 0.01; // 10m
@@ -44,7 +46,7 @@ export function useNearestStation(): UseNearestStationReturn {
 
   const applyLocation = useCallback((coords: { latitude: number; longitude: number }) => {
     const { latitude, longitude } = coords;
-    const stationsResult = findNearestStations(latitude, longitude);
+    const stationsResult = findNearestStations(latitude, longitude, MAX_STATION_DISTANCE_KM);
 
     const newId = stationsResult?.primary.id ?? null;
     const newDistance = stationsResult?.distanceKm ?? 0;
@@ -78,17 +80,20 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
 
-      // 캐시된 위치로 즉시 UI 표시
+      // 캐시된 위치는 신선하고 정확한 경우만 즉시 표시 (stale/저정확도로 인한 false alarm 방지)
       const lastKnown = await Location.getLastKnownPositionAsync();
-      if (lastKnown) {
+      if (lastKnown && isLocationFresh(lastKnown.timestamp) && isAccuracyAcceptable(lastKnown.coords.accuracy)) {
         applyLocation(lastKnown.coords);
         setLoading(false);
       }
 
-      // 연속 GPS 스트리밍 시작
+      // 연속 GPS 스트리밍 시작 — 저정확도 좌표는 무시
       subscriptionRef.current = await Location.watchPositionAsync(
         { accuracy: Location.Accuracy.High, distanceInterval: DISTANCE_INTERVAL_M },
-        (location) => applyLocation(location.coords),
+        (location) => {
+          if (!isAccuracyAcceptable(location.coords.accuracy)) return;
+          applyLocation(location.coords);
+        },
       );
       setLoading(false);
     } catch {
@@ -111,7 +116,9 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
       const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
-      applyLocation(location.coords);
+      if (isAccuracyAcceptable(location.coords.accuracy)) {
+        applyLocation(location.coords);
+      }
     } catch {
       setError('위치를 가져오는 데 실패했습니다.');
     } finally {

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { isStationOnRoute } from '../utils/stationRoute';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
 import { alarmKey } from '../utils/stationAlarm';
@@ -50,8 +51,14 @@ export function useStationAlarm(
       );
     }
 
-    // 역 변경 감지 → per-station 알림 (route + destination이 모두 있을 때만)
-    if (nearestStation && route && destinationName && nearestStation.id !== lastNotifiedStationIdRef.current) {
+    // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
+    if (
+      nearestStation &&
+      route &&
+      destinationName &&
+      isStationOnRoute(nearestStation, route) &&
+      nearestStation.id !== lastNotifiedStationIdRef.current
+    ) {
       lastNotifiedStationIdRef.current = nearestStation.id;
       const target = resolveNextTarget(route, destinationName);
       const stopsRemaining = target?.stopsToNextStation ?? null;

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -506,15 +506,18 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   // ── stale 위치 / 저정확도 게이트 ──
 
-  it('stale 위치(timestamp 30초 초과)는 무시한다', async () => {
-    await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028, { ageMs: 60_000 })] },
-      error: null,
-    });
+  const runWithLocation = (location: unknown) =>
+    taskCallback({ data: { locations: [location] }, error: null });
 
+  const expectGateBlocked = () => {
     expect(AsyncStorage.getItem).not.toHaveBeenCalled();
     expect(mockFindNearestStation).not.toHaveBeenCalled();
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  };
+
+  it('stale 위치(timestamp 30초 초과)는 무시한다', async () => {
+    await runWithLocation(makeLocation(37.498, 127.028, { ageMs: 60_000 }));
+    expectGateBlocked();
   });
 
   it('timestamp가 없는 위치는 무시한다', async () => {
@@ -530,24 +533,13 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       },
       // timestamp 누락
     };
-
-    await taskCallback({
-      data: { locations: [noTsLocation] },
-      error: null,
-    });
-
-    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    await runWithLocation(noTsLocation);
+    expectGateBlocked();
   });
 
   it('저정확도 위치(accuracy 150m 초과)는 무시한다', async () => {
-    await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028, { accuracy: 200 })] },
-      error: null,
-    });
-
-    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
-    expect(mockFindNearestStation).not.toHaveBeenCalled();
-    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    await runWithLocation(makeLocation(37.498, 127.028, { accuracy: 200 }));
+    expectGateBlocked();
   });
 
   it('accuracy가 임계값(150m) 이내면 통과한다', async () => {

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -81,18 +81,22 @@ const mockDestination = {
   lng: 126.977,
 };
 
-function makeLocation(lat: number, lng: number) {
+function makeLocation(
+  lat: number,
+  lng: number,
+  opts: { ageMs?: number; accuracy?: number | null } = {},
+) {
   return {
     coords: {
       latitude: lat,
       longitude: lng,
       altitude: null,
-      accuracy: null,
+      accuracy: opts.accuracy ?? null,
       altitudeAccuracy: null,
       heading: null,
       speed: null,
     },
-    timestamp: Date.now(),
+    timestamp: Date.now() - (opts.ageMs ?? 0),
   };
 }
 
@@ -497,7 +501,65 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockFindNearestStation).toHaveBeenCalledWith(37.9, 127.9);
+    expect(mockFindNearestStation).toHaveBeenCalledWith(37.9, 127.9, 1.0);
+  });
+
+  // ── stale 위치 / 저정확도 게이트 ──
+
+  it('stale 위치(timestamp 30초 초과)는 무시한다', async () => {
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028, { ageMs: 60_000 })] },
+      error: null,
+    });
+
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    expect(mockFindNearestStation).not.toHaveBeenCalled();
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  it('timestamp가 없는 위치는 무시한다', async () => {
+    const noTsLocation = {
+      coords: {
+        latitude: 37.498,
+        longitude: 127.028,
+        altitude: null,
+        accuracy: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+      },
+      // timestamp 누락
+    };
+
+    await taskCallback({
+      data: { locations: [noTsLocation] },
+      error: null,
+    });
+
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  it('저정확도 위치(accuracy 150m 초과)는 무시한다', async () => {
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028, { accuracy: 200 })] },
+      error: null,
+    });
+
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    expect(mockFindNearestStation).not.toHaveBeenCalled();
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  it('accuracy가 임계값(150m) 이내면 통과한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    mockFindNearestStation.mockReturnValue(null);
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028, { accuracy: 100 })] },
+      error: null,
+    });
+
+    expect(AsyncStorage.getItem).toHaveBeenCalled();
   });
 
   // ── 전체 try-catch 에러 핸들링 ──

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -7,6 +7,8 @@ import { updateStationNotification } from '../utils/stationNotification';
 import { findNearestStation } from '../utils/findNearestStation';
 import { createLogger } from '../utils/logger';
 import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
+import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
 import type { Route } from '../utils/stationRoute';
 
 const logger = createLogger('BackgroundLocation');
@@ -24,6 +26,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const latest = locations[locations.length - 1];
   if (!latest) return;
 
+  // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단
+  if (!isLocationFresh(latest.timestamp)) return;
+  if (!isAccuracyAcceptable(latest.coords.accuracy)) return;
+
   const { latitude, longitude } = latest.coords;
 
   try {
@@ -38,7 +44,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
 
     // 목적지 미설정 시 현재 역 알림만 업데이트
     if (!destJson) {
-      const nearest = findNearestStation(latitude, longitude);
+      const nearest = findNearestStation(latitude, longitude, MAX_STATION_DISTANCE_KM);
       if (nearest) {
         await updateStationNotification(
           nearest.station,

--- a/src/utils/__tests__/findNearestStation.test.ts
+++ b/src/utils/__tests__/findNearestStation.test.ts
@@ -112,6 +112,32 @@ describe('findNearestStation', () => {
     expect(result!.station.id).toBe('1-001');
     expect(result!.distanceKm).toBe(2);
   });
+
+  it('maxDistanceKm을 초과하면 null을 반환한다', () => {
+    mockHaversine.mockReturnValue(5); // 모든 역 5km
+
+    const result = findNearestStation(37.5, 127.0, 1.0);
+
+    expect(result).toBeNull();
+  });
+
+  it('maxDistanceKm 이내일 때 정상적으로 역을 반환한다', () => {
+    mockHaversine.mockReturnValueOnce(0.5).mockReturnValue(5);
+
+    const result = findNearestStation(37.5, 127.0, 1.0);
+
+    expect(result).not.toBeNull();
+    expect(result!.distanceKm).toBe(0.5);
+  });
+
+  it('maxDistanceKm 미지정 시 기존 동작 유지 (거리 무관 반환)', () => {
+    mockHaversine.mockReturnValue(100); // 100km (매우 멀음)
+
+    const result = findNearestStation(37.5, 127.0);
+
+    expect(result).not.toBeNull();
+    expect(result!.distanceKm).toBe(100);
+  });
 });
 
 describe('findNearestStations', () => {
@@ -140,5 +166,23 @@ describe('findNearestStations', () => {
     expect(fn(37.5, 127.0)).toBeNull();
 
     jest.resetModules();
+  });
+
+  it('maxDistanceKm을 초과하면 null을 반환한다', () => {
+    mockHaversine.mockReturnValue(5);
+
+    const result = findNearestStations(37.5, 127.0, 1.0);
+
+    expect(result).toBeNull();
+  });
+
+  it('maxDistanceKm 이내일 때 variants와 함께 반환한다', () => {
+    mockHaversine.mockReturnValueOnce(0.2).mockReturnValue(5);
+
+    const result = findNearestStations(37.5, 127.0, 1.0);
+
+    expect(result).not.toBeNull();
+    expect(result!.distanceKm).toBe(0.2);
+    expect(result!.variants.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -12,10 +12,12 @@ jest.mock('../findNearestStation', () => ({
 const mockFindRoute = jest.fn();
 const mockCalculateStaticETA = jest.fn();
 const mockUpdateRouteFromPosition = jest.fn();
+const mockIsStationOnRoute = jest.fn();
 jest.mock('../stationRoute', () => ({
   findRoute: (...args: unknown[]) => mockFindRoute(...args),
   calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
   updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
+  isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
 }));
 
 const mockCheckAlarm = jest.fn();
@@ -191,6 +193,7 @@ describe('processLocationUpdate', () => {
     mockCalculateStaticETA.mockReturnValue(10);
     mockCheckAlarm.mockReturnValue(null);
     mockCheckTimeBasedAlarm.mockReturnValue(null);
+    mockIsStationOnRoute.mockReturnValue(true);
   });
 
   it('should return null nearest and null alarmEvent when findNearestStation returns null', async () => {
@@ -499,6 +502,54 @@ describe('processLocationUpdate', () => {
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
     expect(result.lastNotifiedStationId).toBe('station-1');
+  });
+
+  it('경로 외 노선의 역이면 station-passed 알림을 보내지 않고 lastNotifiedStationId를 갱신하지 않는다', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockIsStationOnRoute.mockReturnValue(false);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false, true, null, 'previous-station',
+    );
+
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(result.lastNotifiedStationId).toBe('previous-station');
+  });
+
+  it('route가 null이면 station-passed 알림을 보내지 않는다', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(null);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false, true, null, null,
+    );
+
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(result.lastNotifiedStationId).toBeNull();
+  });
+
+  it('findNearestStation을 MAX_STATION_DISTANCE_KM(1.0)와 함께 호출한다', async () => {
+    mockFindNearestStation.mockReturnValue(null);
+
+    await processLocationUpdate(37.5, 127.0, mockDestination, new Set(), false);
+
+    expect(mockFindNearestStation).toHaveBeenCalledWith(37.5, 127.0, 1.0);
+  });
+
+  it('route 타입이 unknown(타입 오염)으로 resolveNextTarget이 null이면 알림 미발송 + ref 미갱신', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    // AsyncStorage 등에서 손상된 route가 들어온 케이스
+    const corruptedRoute = { type: 'unknown', stops: 0 } as unknown as DirectRoute;
+    mockFindRoute.mockReturnValue(corruptedRoute);
+    mockIsStationOnRoute.mockReturnValue(true);
+
+    const result = await processLocationUpdate(
+      37.498, 127.028, mockDestination, new Set(), false, true, null, 'prev-station',
+    );
+
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(result.lastNotifiedStationId).toBe('prev-station');
   });
 });
 

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute } from '../stationRoute';
 import type { Station } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate } from '../stationRoute';
 
@@ -894,5 +894,83 @@ describe('updateRouteFromPosition', () => {
       const result = updateRouteFromPosition(storedMultiRoute, jangam7, '1-001');
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('isStationOnRoute', () => {
+  const makeStation = (id: string, line: Station['line']): Station => ({
+    id,
+    name: 'X',
+    line,
+    lineColor: '#fff',
+    lat: 0,
+    lng: 0,
+  });
+
+  it('direct route는 항상 true (fromLine 정보 없어 검증 불가)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3 };
+    expect(isStationOnRoute(makeStation('A', '4'), route)).toBe(true);
+  });
+
+  it('transfer route — fromLine 일치 시 true', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '동대문',
+      fromLine: '1',
+      toLine: '4',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 2,
+    };
+    expect(isStationOnRoute(makeStation('A', '1'), route)).toBe(true);
+  });
+
+  it('transfer route — toLine 일치 시 true', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '동대문',
+      fromLine: '1',
+      toLine: '4',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 2,
+    };
+    expect(isStationOnRoute(makeStation('A', '4'), route)).toBe(true);
+  });
+
+  it('transfer route — 둘 다 아니면 false', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '동대문',
+      fromLine: '1',
+      toLine: '4',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 2,
+    };
+    expect(isStationOnRoute(makeStation('A', '7'), route)).toBe(false);
+  });
+
+  it('multi-transfer route — 환승 구간 어느 노선이든 일치 시 true', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
+        { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 5,
+    };
+    expect(isStationOnRoute(makeStation('A', '1'), route)).toBe(true);
+    expect(isStationOnRoute(makeStation('A', '4'), route)).toBe(true);
+    expect(isStationOnRoute(makeStation('A', '3'), route)).toBe(true);
+  });
+
+  it('multi-transfer route — 어느 환승 구간에도 없으면 false', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
+        { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 5,
+    };
+    expect(isStationOnRoute(makeStation('A', '7'), route)).toBe(false);
   });
 });

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -898,8 +898,8 @@ describe('updateRouteFromPosition', () => {
 });
 
 describe('isStationOnRoute', () => {
-  const makeStation = (id: string, line: Station['line']): Station => ({
-    id,
+  const makeStation = (line: Station['line']): Station => ({
+    id: 'X',
     name: 'X',
     line,
     lineColor: '#fff',
@@ -907,70 +907,48 @@ describe('isStationOnRoute', () => {
     lng: 0,
   });
 
+  const transferRoute: TransferRoute = {
+    type: 'transfer',
+    transferName: '동대문',
+    fromLine: '1',
+    toLine: '4',
+    stopsToTransfer: 3,
+    stopsFromTransfer: 2,
+  };
+
+  const multiTransferRoute: MultiTransferRoute = {
+    type: 'multi-transfer',
+    transfers: [
+      { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
+      { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
+    ],
+    stopsAfterLastTransfer: 5,
+  };
+
   it('direct route는 항상 true (fromLine 정보 없어 검증 불가)', () => {
     const route: DirectRoute = { type: 'direct', stops: 3 };
-    expect(isStationOnRoute(makeStation('A', '4'), route)).toBe(true);
+    expect(isStationOnRoute(makeStation('4'), route)).toBe(true);
   });
 
   it('transfer route — fromLine 일치 시 true', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
-      transferName: '동대문',
-      fromLine: '1',
-      toLine: '4',
-      stopsToTransfer: 3,
-      stopsFromTransfer: 2,
-    };
-    expect(isStationOnRoute(makeStation('A', '1'), route)).toBe(true);
+    expect(isStationOnRoute(makeStation('1'), transferRoute)).toBe(true);
   });
 
   it('transfer route — toLine 일치 시 true', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
-      transferName: '동대문',
-      fromLine: '1',
-      toLine: '4',
-      stopsToTransfer: 3,
-      stopsFromTransfer: 2,
-    };
-    expect(isStationOnRoute(makeStation('A', '4'), route)).toBe(true);
+    expect(isStationOnRoute(makeStation('4'), transferRoute)).toBe(true);
   });
 
   it('transfer route — 둘 다 아니면 false', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
-      transferName: '동대문',
-      fromLine: '1',
-      toLine: '4',
-      stopsToTransfer: 3,
-      stopsFromTransfer: 2,
-    };
-    expect(isStationOnRoute(makeStation('A', '7'), route)).toBe(false);
+    expect(isStationOnRoute(makeStation('7'), transferRoute)).toBe(false);
   });
 
   it('multi-transfer route — 환승 구간 어느 노선이든 일치 시 true', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
-      transfers: [
-        { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
-        { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
-      ],
-      stopsAfterLastTransfer: 5,
-    };
-    expect(isStationOnRoute(makeStation('A', '1'), route)).toBe(true);
-    expect(isStationOnRoute(makeStation('A', '4'), route)).toBe(true);
-    expect(isStationOnRoute(makeStation('A', '3'), route)).toBe(true);
+    expect(isStationOnRoute(makeStation('1'), multiTransferRoute)).toBe(true);
+    expect(isStationOnRoute(makeStation('4'), multiTransferRoute)).toBe(true);
+    expect(isStationOnRoute(makeStation('3'), multiTransferRoute)).toBe(true);
   });
 
   it('multi-transfer route — 어느 환승 구간에도 없으면 false', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
-      transfers: [
-        { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
-        { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
-      ],
-      stopsAfterLastTransfer: 5,
-    };
-    expect(isStationOnRoute(makeStation('A', '7'), route)).toBe(false);
+    expect(isStationOnRoute(makeStation('7'), multiTransferRoute)).toBe(false);
   });
 });

--- a/src/utils/findNearestStation.ts
+++ b/src/utils/findNearestStation.ts
@@ -4,7 +4,11 @@ import type { NearestStationResult, NearestStationsResult, Station } from '../ty
 
 const stations = stationsData as Station[];
 
-export function findNearestStation(lat: number, lng: number): NearestStationResult | null {
+export function findNearestStation(
+  lat: number,
+  lng: number,
+  maxDistanceKm?: number,
+): NearestStationResult | null {
   let nearest: Station | null = null;
   let minDistance = Infinity;
 
@@ -16,11 +20,17 @@ export function findNearestStation(lat: number, lng: number): NearestStationResu
     }
   }
 
-  return nearest ? { station: nearest, distanceKm: minDistance } : null;
+  if (!nearest) return null;
+  if (maxDistanceKm != null && minDistance > maxDistanceKm) return null;
+  return { station: nearest, distanceKm: minDistance };
 }
 
-export function findNearestStations(lat: number, lng: number): NearestStationsResult | null {
-  const result = findNearestStation(lat, lng);
+export function findNearestStations(
+  lat: number,
+  lng: number,
+  maxDistanceKm?: number,
+): NearestStationsResult | null {
+  const result = findNearestStation(lat, lng, maxDistanceKm);
   if (!result) return null;
 
   const variants = stations.filter((s) => s.name === result.station.name);

--- a/src/utils/locationGates.ts
+++ b/src/utils/locationGates.ts
@@ -1,0 +1,12 @@
+import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../constants/location';
+
+export function isLocationFresh(timestamp: number | undefined): boolean {
+  // expo-location 타입상 timestamp는 non-nullable이지만, 네이티브 deferred batch에서
+  // 누락된 사례가 보고된 적이 있어 방어적으로 null 체크를 유지한다.
+  if (timestamp == null) return false;
+  return Date.now() - timestamp <= MAX_LOCATION_AGE_MS;
+}
+
+export function isAccuracyAcceptable(accuracy: number | null | undefined): boolean {
+  return accuracy == null || accuracy <= MAX_ACCURACY_M;
+}

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -1,7 +1,8 @@
 import { findNearestStation } from './findNearestStation';
-import { findRoute, calculateStaticETA, updateRouteFromPosition } from './stationRoute';
+import { findRoute, calculateStaticETA, isStationOnRoute, updateRouteFromPosition } from './stationRoute';
 import { checkAlarm, checkTimeBasedAlarm } from './stationAlarm';
 import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
+import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
 import type { AlarmEvent } from './stationAlarm';
@@ -88,7 +89,7 @@ export async function processLocationUpdate(
   storedRoute: Route = null,
   lastNotifiedStationId: string | null = null,
 ): Promise<PipelineResult> {
-  const nearest = findNearestStation(lat, lng);
+  const nearest = findNearestStation(lat, lng, MAX_STATION_DISTANCE_KM);
   if (!nearest) return { alarmEvent: null, nearest: null, lastNotifiedStationId };
 
   let route: Route = null;
@@ -110,16 +111,18 @@ export async function processLocationUpdate(
     );
   }
 
-  // 역 변경 감지 → per-station 알림
+  // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
   let newLastNotifiedStationId = lastNotifiedStationId;
-  if (nearest.station.id !== lastNotifiedStationId) {
-    newLastNotifiedStationId = nearest.station.id;
+  if (route && isStationOnRoute(nearest.station, route) && nearest.station.id !== lastNotifiedStationId) {
     const target = resolveNextTarget(route, destination.name);
-    await sendStationPassedNotification(
-      nearest.station.name,
-      destination.name,
-      target?.stopsToNextStation ?? null,
-    );
+    if (target) {
+      newLastNotifiedStationId = nearest.station.id;
+      await sendStationPassedNotification(
+        nearest.station.name,
+        destination.name,
+        target.stopsToNextStation,
+      );
+    }
   }
 
   const eta = calculateStaticETA(route);

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -188,6 +188,21 @@ export function updateRouteFromPosition(
   return null;
 }
 
+export function isStationOnRoute(station: Station, route: NonNullable<Route>): boolean {
+  if (route.type === 'direct') {
+    // direct는 fromLine 정보가 없어서 노선 검증이 불가능 — 통과
+    return true;
+  }
+  if (route.type === 'transfer') {
+    return station.line === route.fromLine || station.line === route.toLine;
+  }
+  // multi-transfer
+  for (const t of route.transfers) {
+    if (station.line === t.fromLine || station.line === t.toLine) return true;
+  }
+  return false;
+}
+
 export function getRemainingStops(
   currentId: string,
   destinationId: string,


### PR DESCRIPTION
Closes #192

## 문제
앱을 실행했을 때 실제로 타지 않은 역(예: 건대입구)에 \"역 통과\" 푸시 알림이 발송됨.

## 원인 (4개 결함 결합)
1. **stale 캐시 위치**: \`getLastKnownPositionAsync\` 결과의 timestamp 검증 없이 사용 → 어제 좌표로 오늘 역 판정.
2. **GPS 정확도 미필터링**: \`coords.accuracy\` 무시 → 워밍업 단계의 ±수백m 좌표가 그대로 사용.
3. **거리 상한 없음**: \`findNearestStation\`이 어떤 위치든 최소거리 역을 반환.
4. **첫 감지 즉시 알림**: \`lastNotifiedStationIdRef\` 초기값 null → 첫 콜백 무조건 알림. 경로상 역인지 검증 없음.

## 해결 (실시간성 우선 — grace period 없음)
\"오래 기다리기\"보다 \"나쁜 좌표 자체를 거부\". valid 좌표는 즉시 알림 발송.

| 게이트 | 값 | 근거 |
|---|---|---|
| MAX_LOCATION_AGE_MS | 30_000 | 한 정거장 이동(~2분)보다 짧음 |
| MAX_ACCURACY_M | 150 | 지하/터널 진입(±100~150m) 통과 가능 |
| MAX_STATION_DISTANCE_KM | 1.0 | 한국 지하철 평균 역간 거리 |

## 변경
- \`src/constants/location.ts\` (신규) — 임계값 상수
- \`src/utils/locationGates.ts\` (신규) — \`isLocationFresh\` / \`isAccuracyAcceptable\` 공유 헬퍼
- \`src/utils/findNearestStation.ts\` — \`maxDistanceKm\` 옵션
- \`src/utils/stationRoute.ts\` — \`isStationOnRoute(station, route)\` helper (transfer/multi-transfer는 노선 검증, direct는 정보 부족으로 항상 통과 → 후속 #195)
- \`src/hooks/useNearestStation.ts\` — getLastKnown/watch/refresh 모두 게이트 적용
- \`src/tasks/backgroundLocationTask.ts\` — iOS deferred batch stale/저정확도 차단
- \`src/utils/stationPipeline.ts\` + \`src/hooks/useStationAlarm.ts\` — per-station 알림에 경로 검증 추가

## 검증
- \`npm test\` — 711 tests passed, coverage 100%
- \`npm run type-check\` — 통과
- 코드 리뷰 완료 (P1 없음, P2 3건 반영, direct route 검증 미흡은 후속 #195로 분리)

## Test plan
- [ ] 시뮬레이터에서 위치를 건대입구로 설정 → 앱 종료 → 30분 경과 → 강남에서 앱 실행 → 건대입구 알림 안 옴 확인
- [ ] 실제 지하철 탑승 시 역마다 통과 알림 정상 발송 확인
- [ ] 환승역/도착 알람 기존 동작 유지 확인
- [ ] 경로 외 역 근처 위치 시뮬레이션 → 알림 미발송 확인