### PR TITLE
fix(#190): 도착 알람 시점 재설계 — 1정거장 전 + 도착 5~10초 전 다단계 phase

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -27,7 +27,7 @@ const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
   const { colors } = useTheme();
-  const { result, variants, userLocation, loading, error, permissionDenied, refresh } = useNearestStation();
+  const { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh } = useNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
@@ -121,8 +121,13 @@ export default function HomeScreen() {
     [effectiveOrigin?.id, destination?.id, route],
   );
 
-  // nextStationName이 확정됐으면 stops=0으로 즉시 시간 기반 임계 통과 (firedAlarms로 중복 방지)
-  useStationAlarm(route, destination?.name ?? null, result?.station ?? null);
+  useStationAlarm({
+    route,
+    destination,
+    nearestStation: result?.station ?? null,
+    userLocation,
+    speedMps,
+  });
   useBackgroundLocation(destination);
 
   useEffect(() => {

--- a/src/components/__tests__/AlarmOverlay.test.tsx
+++ b/src/components/__tests__/AlarmOverlay.test.tsx
@@ -17,21 +17,21 @@ describe('AlarmOverlay', () => {
   });
 
   it('하차 알림을 표시한다', () => {
-    const event: AlarmEvent = { type: 'destination', stationName: '강남' };
+    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
     const { getByText } = render(<AlarmOverlay event={event} onDismiss={mockDismiss} />);
     expect(getByText('하차 알림')).toBeTruthy();
     expect(getByText('강남에서\n내리세요')).toBeTruthy();
   });
 
   it('환승 알림을 표시한다', () => {
-    const event: AlarmEvent = { type: 'transfer', stationName: '시청' };
+    const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
     const { getByText } = render(<AlarmOverlay event={event} onDismiss={mockDismiss} />);
     expect(getByText('환승 알림')).toBeTruthy();
     expect(getByText('시청에서\n환승하세요')).toBeTruthy();
   });
 
   it('알람 끄기 버튼을 누르면 사운드를 정지하고 dismiss한다', async () => {
-    const event: AlarmEvent = { type: 'destination', stationName: '강남' };
+    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
     const { getByTestId } = render(<AlarmOverlay event={event} onDismiss={mockDismiss} />);
 
     fireEvent.press(getByTestId('alarm-dismiss-button'));
@@ -43,7 +43,7 @@ describe('AlarmOverlay', () => {
   });
 
   it('알람 끄기 버튼 텍스트를 표시한다', () => {
-    const event: AlarmEvent = { type: 'destination', stationName: '강남' };
+    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
     const { getByText } = render(<AlarmOverlay event={event} onDismiss={mockDismiss} />);
     expect(getByText('알람 끄기')).toBeTruthy();
   });

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -14,7 +14,7 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockSubscription = { remove: jest.fn() };
-let watchCallback: ((location: { coords: { latitude: number; longitude: number } }) => void) | null = null;
+let watchCallback: ((location: { coords: { latitude: number; longitude: number; speed?: number | null } }) => void) | null = null;
 
 const mockGranted = () => {
   (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
@@ -44,9 +44,9 @@ const mockLocation = (lat: number, lng: number) => {
   });
 };
 
-const simulateGps = (lat: number, lng: number) => {
+const simulateGps = (lat: number, lng: number, speed: number | null = null) => {
   act(() => {
-    watchCallback?.({ coords: { latitude: lat, longitude: lng } });
+    watchCallback?.({ coords: { latitude: lat, longitude: lng, speed } });
   });
 };
 
@@ -102,6 +102,37 @@ describe('useNearestStation', () => {
     expect(result.current.permissionDenied).toBe(false);
     expect(result.current.error).toBeNull();
     expect(result.current.userLocation).toEqual({ lat: 37.4980, lng: 127.0277 });
+  });
+
+  it('GPS speed가 양수이면 speedMps로 노출한다', async () => {
+    mockGranted();
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, 15.5);
+
+    await waitFor(() => expect(result.current.speedMps).toBe(15.5));
+  });
+
+  it('GPS speed가 음수면 speedMps를 null로 정규화한다', async () => {
+    mockGranted();
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, -1);
+
+    await waitFor(() => expect(result.current.speedMps).toBeNull());
+  });
+
+  it('GPS speed가 null이면 speedMps도 null이다', async () => {
+    mockGranted();
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, null);
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.speedMps).toBeNull();
   });
 
   it('500m 초과 거리에서도 가장 가까운 역을 반환한다', async () => {

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1,8 +1,9 @@
 import { renderHook } from '@testing-library/react-native';
-import { useStationAlarm } from '../useStationAlarm';
+import { useStationAlarm, type UseStationAlarmInputs } from '../useStationAlarm';
 import { useAppStore } from '../../store/useAppStore';
 import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../../utils/stationRoute';
 import type { Station } from '../../types/station';
+import type { AlarmEvent } from '../../utils/stationAlarm';
 
 const mockSendAlarmNotification = jest.fn().mockResolvedValue(undefined);
 const mockSendStationPassedNotification = jest.fn().mockResolvedValue(undefined);
@@ -12,11 +13,17 @@ jest.mock('../../utils/stationNotification', () => ({
   sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
 }));
 
-const mockEvaluateAllAlarms = jest.fn();
-const mockResolveNextTarget = jest.fn();
+const mockEvaluateAlarmPhase = jest.fn();
+jest.mock('../../utils/stationAlarm', () => {
+  const actual = jest.requireActual('../../utils/stationAlarm');
+  return {
+    ...actual,
+    evaluateAlarmPhase: (...args: unknown[]) => mockEvaluateAlarmPhase(...args),
+  };
+});
 
+const mockResolveNextTarget = jest.fn();
 jest.mock('../../utils/stationPipeline', () => ({
-  evaluateAllAlarms: (...args: unknown[]) => mockEvaluateAllAlarms(...args),
   resolveNextTarget: (...args: unknown[]) => mockResolveNextTarget(...args),
 }));
 
@@ -30,55 +37,107 @@ jest.mock('../../utils/logger', () => ({
 }));
 
 jest.mock('@react-native-async-storage/async-storage', () =>
-  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
 
-const makeStation = (id: string, name: string): Station => ({
+const makeStation = (id: string, name: string, lat = 37.5, lng = 127.0): Station => ({
   id,
   name,
   line: '2',
   lineColor: '#33A23D',
-  lat: 37.5,
-  lng: 127.0,
+  lat,
+  lng,
 });
+
+const destination = makeStation('D1', '강남', 37.498, 127.028);
+const altDestination = makeStation('D2', '잠실', 37.513, 127.100);
+
+const earlyDest: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+const earlyTransfer: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
+const imminentDest: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: '강남' };
+
+function defaultInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStationAlarmInputs {
+  return {
+    route: null,
+    destination: null,
+    nearestStation: null,
+    userLocation: null,
+    speedMps: null,
+    ...overrides,
+  };
+}
 
 describe('useStationAlarm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useAppStore.setState({ sleepMode: false, allowSpeaker: true, alarmEvent: null });
-    mockEvaluateAllAlarms.mockReturnValue(null);
+    mockEvaluateAlarmPhase.mockReturnValue(null);
     mockResolveNextTarget.mockReturnValue(null);
   });
 
-  it('should not send alarm when route is null', () => {
-    renderHook(() => useStationAlarm(null, '강남', null));
-    expect(mockEvaluateAllAlarms).not.toHaveBeenCalled();
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+  it('does not evaluate when route is null', () => {
+    renderHook(() => useStationAlarm(defaultInputs({ destination })));
+    expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
   });
 
-  it('should not send alarm when destinationName is null', () => {
+  it('does not evaluate when destination is null', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    renderHook(() => useStationAlarm(route, null, null));
-    expect(mockEvaluateAllAlarms).not.toHaveBeenCalled();
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    renderHook(() => useStationAlarm(defaultInputs({ route })));
+    expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
   });
 
-  it('should not send alarm when evaluateAllAlarms returns null', () => {
+  it('builds AlarmSource and calls evaluator', () => {
     const route: DirectRoute = { type: 'direct', stops: 3 };
-    mockEvaluateAllAlarms.mockReturnValue(null);
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockEvaluateAllAlarms).toHaveBeenCalledWith(route, '강남', expect.any(Set));
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({
+          route,
+          destination,
+          userLocation: { lat: 37.4, lng: 127.0 },
+          speedMps: 10,
+        }),
+      ),
+    );
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route,
+        destinationName: '강남',
+        etaSeconds: expect.any(Number),
+      }),
+      expect.any(Set),
+    );
   });
 
-  it('should send destination alarm for direct route', () => {
+  it('passes null etaSeconds when speed is null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3 };
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127.0 }, speedMps: null }),
+      ),
+    );
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+      expect.objectContaining({ etaSeconds: null }),
+      expect.any(Set),
+    );
+  });
+
+  it('passes null etaSeconds when userLocation is null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3 };
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination, speedMps: 10 })));
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+      expect.objectContaining({ etaSeconds: null }),
+      expect.any(Set),
+    );
+  });
+
+  it('sends alarm notification with the full event', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false, true);
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true);
   });
 
-  it('should send transfer alarm for transfer route', () => {
+  it('sends transfer alarm for transfer route', () => {
     const route: TransferRoute = {
       type: 'transfer',
       transferName: '시청',
@@ -87,26 +146,12 @@ describe('useStationAlarm', () => {
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
     };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청' });
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false, true);
+    mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true);
   });
 
-  it('should send destination alarm for transfer route stopsFromTransfer', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
-      transferName: '시청',
-      fromLine: '1',
-      toLine: '2',
-      stopsToTransfer: 5,
-      stopsFromTransfer: 1,
-    };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false, true);
-  });
-
-  it('should send transfer alarm for multi-transfer route', () => {
+  it('sends transfer alarm for multi-transfer route', () => {
     const route: MultiTransferRoute = {
       type: 'multi-transfer',
       transfers: [
@@ -115,72 +160,93 @@ describe('useStationAlarm', () => {
       ],
       stopsAfterLastTransfer: 3,
     };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청' });
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, false, true);
+    mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true);
   });
 
-  it('should not fire same alarm twice', () => {
+  it('does not fire the same alarm twice', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    const { rerender } = renderHook(() => useStationAlarm(route, '강남', null));
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
-
     rerender({});
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('should reset fired alarms when destination changes', () => {
+  it('fires imminent after early for the same waypoint', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
+    mockEvaluateAlarmPhase.mockReturnValueOnce(earlyDest);
     const { rerender } = renderHook(
-      ({ dest }: { dest: string }) => useStationAlarm(route, dest, null),
-      { initialProps: { dest: '강남' } },
+      ({ inputs }: { inputs: UseStationAlarmInputs }) => useStationAlarm(inputs),
+      {
+        initialProps: {
+          inputs: defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127.0 }, speedMps: 5 }),
+        },
+      },
+    );
+    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(earlyDest, false, true);
+
+    mockEvaluateAlarmPhase.mockReturnValueOnce(imminentDest);
+    rerender({
+      inputs: defaultInputs({ route, destination, userLocation: { lat: 37.49, lng: 127.025 }, speedMps: 20 }),
+    });
+    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(imminentDest, false, true);
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('resets fired alarms when destination changes', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1 };
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    const { rerender } = renderHook(
+      ({ dest }: { dest: Station }) => useStationAlarm(defaultInputs({ route, destination: dest })),
+      { initialProps: { dest: destination } },
     );
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
 
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '잠실' });
-    rerender({ dest: '잠실' });
+    const altEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '잠실' };
+    mockEvaluateAlarmPhase.mockReturnValue(altEvent);
+    rerender({ dest: altDestination });
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
-    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith('destination', '잠실', false, false, true);
+    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(altEvent, false, true);
   });
 
-  it('should pass sleepMode to sendAlarmNotification', () => {
+  it('passes sleepMode to sendAlarmNotification', () => {
     useAppStore.setState({ sleepMode: true });
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', true, false, true);
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, true, true);
   });
 
-  it('취침 모드일 때 alarmEvent를 설정한다', () => {
+  it('sets alarmEvent in store when sleepMode is on', () => {
     useAppStore.setState({ sleepMode: true });
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(useAppStore.getState().alarmEvent).toEqual({ type: 'destination', stationName: '강남' });
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+    expect(useAppStore.getState().alarmEvent).toEqual(earlyDest);
   });
 
-  it('취침 모드가 아닐 때 alarmEvent를 설정하지 않는다', () => {
+  it('does not set alarmEvent when sleepMode is off', () => {
     useAppStore.setState({ sleepMode: false });
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남', null));
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(useAppStore.getState().alarmEvent).toBeNull();
   });
 
-  it('should pass allowSpeaker=false to sendAlarmNotification when store has allowSpeaker=false', () => {
+  it('passes allowSpeaker=false from store', () => {
     useAppStore.setState({ allowSpeaker: false });
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    renderHook(() => useStationAlarm(route, '강남', null));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '강남', false, false, false);
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, false);
   });
 
-  it('should not re-fire alarm when sleepMode changes', () => {
+  it('does not re-fire when sleepMode toggles after first fire', () => {
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    const { rerender } = renderHook(() => useStationAlarm(route, '강남', null));
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
 
     useAppStore.setState({ sleepMode: true });
@@ -188,89 +254,29 @@ describe('useStationAlarm', () => {
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle sendAlarmNotification failure gracefully', () => {
+  it('handles sendAlarmNotification rejection gracefully', () => {
     mockSendAlarmNotification.mockRejectedValueOnce(new Error('알림 실패'));
     const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남' });
-    expect(() => renderHook(() => useStationAlarm(route, '강남', null))).not.toThrow();
-  });
-
-  describe('time-based alarm', () => {
-    it('should send time-based alarm with timeBased flag', () => {
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      mockEvaluateAllAlarms.mockReturnValue({ type: 'approaching', stationName: '역삼', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남', null));
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith('approaching', '역삼', false, true, true);
-    });
-
-    it('should send time-based transfer alarm', () => {
-      const route: TransferRoute = {
-        type: 'transfer',
-        transferName: '시청',
-        fromLine: '1',
-        toLine: '2',
-        stopsToTransfer: 1,
-        stopsFromTransfer: 5,
-      };
-      mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남', null));
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '시청', false, true, true);
-    });
-
-    it('should set alarmEvent in sleep mode for destination time-based alarm', () => {
-      useAppStore.setState({ sleepMode: true });
-      const route: DirectRoute = { type: 'direct', stops: 1 };
-      mockEvaluateAllAlarms.mockReturnValue({ type: 'destination', stationName: '강남', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남', null));
-      expect(useAppStore.getState().alarmEvent).toEqual({ type: 'destination', stationName: '강남' });
-    });
-
-    it('should not set alarmEvent in sleep mode for approaching time-based alarm', () => {
-      useAppStore.setState({ sleepMode: true });
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      mockEvaluateAllAlarms.mockReturnValue({ type: 'approaching', stationName: '역삼', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남', null));
-      expect(useAppStore.getState().alarmEvent).toBeNull();
-    });
-
-    it('should handle time-based alarm notification failure gracefully', () => {
-      mockSendAlarmNotification.mockRejectedValueOnce(new Error('시간 기반 알림 실패'));
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      mockEvaluateAllAlarms.mockReturnValue({ type: 'approaching', stationName: '역삼', timeBased: true });
-      expect(() => renderHook(() => useStationAlarm(route, '강남', null))).not.toThrow();
-    });
-
-    it('should set alarmEvent in sleep mode for transfer time-based alarm', () => {
-      useAppStore.setState({ sleepMode: true });
-      const route: TransferRoute = {
-        type: 'transfer',
-        transferName: '시청',
-        fromLine: '1',
-        toLine: '2',
-        stopsToTransfer: 1,
-        stopsFromTransfer: 5,
-      };
-      mockEvaluateAllAlarms.mockReturnValue({ type: 'transfer', stationName: '시청', timeBased: true });
-      renderHook(() => useStationAlarm(route, '강남', null));
-      expect(useAppStore.getState().alarmEvent).toEqual({ type: 'transfer', stationName: '시청' });
-    });
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    expect(() => renderHook(() => useStationAlarm(defaultInputs({ route, destination })))).not.toThrow();
   });
 
   describe('station-passed notification', () => {
-    it('역이 변경되면 per-station 알림을 발송한다', () => {
+    it('fires when nearest station changes', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
-      renderHook(() => useStationAlarm(route, '강남', station));
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
       expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', 3);
     });
 
-    it('같은 역이면 per-station 알림을 발송하지 않는다', () => {
+    it('does not fire when nearest station is unchanged', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
       const { rerender } = renderHook(
-        ({ s }: { s: Station }) => useStationAlarm(route, '강남', s),
+        ({ s }: { s: Station }) =>
+          useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
         { initialProps: { s: station } },
       );
       expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
@@ -279,13 +285,14 @@ describe('useStationAlarm', () => {
       expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
     });
 
-    it('역이 다른 역으로 변경되면 다시 발송한다', () => {
+    it('fires again when nearest station changes to a different one', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station1 = makeStation('S1', '역삼');
       const station2 = makeStation('S2', '선릉');
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
       const { rerender } = renderHook(
-        ({ s }: { s: Station }) => useStationAlarm(route, '강남', s),
+        ({ s }: { s: Station }) =>
+          useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
         { initialProps: { s: station1 } },
       );
       expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
@@ -296,39 +303,41 @@ describe('useStationAlarm', () => {
       expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', 2);
     });
 
-    it('nearestStation이 null이면 per-station 알림을 발송하지 않는다', () => {
+    it('does not fire when nearestStation is null', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
-      renderHook(() => useStationAlarm(route, '강남', null));
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('route가 없으면 per-station 알림을 발송하지 않는다', () => {
+    it('does not fire when route is null', () => {
       const station = makeStation('S1', '역삼');
-      renderHook(() => useStationAlarm(null, '강남', station));
+      renderHook(() => useStationAlarm(defaultInputs({ destination, nearestStation: station })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('destinationName이 없으면 per-station 알림을 발송하지 않는다', () => {
+    it('does not fire when destination is null', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
-      renderHook(() => useStationAlarm(route, null, station));
+      renderHook(() => useStationAlarm(defaultInputs({ route, nearestStation: station })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('resolveNextTarget이 null을 반환하면 stopsRemaining을 null로 전달한다', () => {
+    it('passes null stopsRemaining when resolveNextTarget returns null', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(null);
-      renderHook(() => useStationAlarm(route, '강남', station));
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
       expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', null);
     });
 
-    it('sendStationPassedNotification 실패 시 에러를 던지지 않는다', () => {
+    it('handles sendStationPassedNotification rejection gracefully', () => {
       mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 실패'));
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
-      expect(() => renderHook(() => useStationAlarm(route, '강남', station))).not.toThrow();
+      expect(() =>
+        renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station }))),
+      ).not.toThrow();
     });
   });
 });

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -11,6 +11,7 @@ interface UseNearestStationReturn {
   result: NearestStationResult | null;
   variants: Station[];
   userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
   loading: boolean;
   error: string | null;
   permissionDenied: boolean;
@@ -35,6 +36,7 @@ export function useNearestStation(): UseNearestStationReturn {
   const [result, setResult] = useState<NearestStationResult | null>(null);
   const [variants, setVariants] = useState<Station[]>([]);
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
+  const [speedMps, setSpeedMps] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
@@ -42,8 +44,8 @@ export function useNearestStation(): UseNearestStationReturn {
   const lastStationIdRef = useRef<string | null>(null);
   const lastDistanceRef = useRef<number>(0);
 
-  const applyLocation = useCallback((coords: { latitude: number; longitude: number }) => {
-    const { latitude, longitude } = coords;
+  const applyLocation = useCallback((coords: Location.LocationObjectCoords) => {
+    const { latitude, longitude, speed } = coords;
     const stationsResult = findNearestStations(latitude, longitude);
 
     const newId = stationsResult?.primary.id ?? null;
@@ -51,6 +53,8 @@ export function useNearestStation(): UseNearestStationReturn {
     const stationChanged = newId !== lastStationIdRef.current;
     const distanceDelta = Math.abs(newDistance - lastDistanceRef.current);
     const noStation = !stationsResult && lastStationIdRef.current !== null;
+
+    setSpeedMps(speed != null && speed >= 0 ? speed : null);
 
     if (stationChanged || distanceDelta > MIN_DISTANCE_CHANGE_KM || noStation) {
       lastStationIdRef.current = newId;
@@ -137,5 +141,5 @@ export function useNearestStation(): UseNearestStationReturn {
     };
   }, [startWatch, stopWatch]);
 
-  return { result, variants, userLocation, loading, error, permissionDenied, refresh };
+  return { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh };
 }

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -1,19 +1,30 @@
 import { useEffect, useRef } from 'react';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
-import { alarmKey } from '../utils/stationAlarm';
-import { evaluateAllAlarms, resolveNextTarget } from '../utils/stationPipeline';
+import { alarmKey, evaluateAlarmPhase } from '../utils/stationAlarm';
+import { distanceMetersBetween, estimateEtaSeconds } from '../utils/stationEta';
+import { resolveNextTarget } from '../utils/stationPipeline';
 import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('StationAlarm');
 
-export function useStationAlarm(
-  route: Route,
-  destinationName: string | null,
-  nearestStation: Station | null,
-): void {
+export interface UseStationAlarmInputs {
+  route: Route;
+  destination: Station | null;
+  nearestStation: Station | null;
+  userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
+}
+
+export function useStationAlarm({
+  route,
+  destination,
+  nearestStation,
+  userLocation,
+  speedMps,
+}: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
   const lastNotifiedStationIdRef = useRef<string | null>(null);
@@ -32,31 +43,55 @@ export function useStationAlarm(
   }, [allowSpeaker]);
 
   useEffect(() => {
+    const destinationName = destination?.name ?? null;
     if (destinationName !== prevDestRef.current) {
       firedAlarmsRef.current = new Set();
       prevDestRef.current = destinationName;
     }
 
-    if (!route || !destinationName) return;
+    if (!route || !destination) return;
 
-    const event = evaluateAllAlarms(route, destinationName, firedAlarmsRef.current);
+    let etaSeconds: number | null = null;
+    if (userLocation) {
+      const distM = distanceMetersBetween(
+        userLocation.lat,
+        userLocation.lng,
+        destination.lat,
+        destination.lng,
+      );
+      etaSeconds = estimateEtaSeconds(distM, speedMps);
+    }
+
+    const event = evaluateAlarmPhase(
+      { route, destinationName: destination.name, etaSeconds },
+      firedAlarmsRef.current,
+    );
     if (event) {
       firedAlarmsRef.current.add(alarmKey(event));
-      if (sleepModeRef.current && event.type !== 'approaching') {
-        setAlarmEvent({ type: event.type, stationName: event.stationName });
+      if (sleepModeRef.current) {
+        setAlarmEvent(event);
       }
-      sendAlarmNotification(event.type, event.stationName, sleepModeRef.current, event.timeBased ?? false, allowSpeakerRef.current).catch((e) =>
+      sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
         logger.error('알람 알림 실패:', e),
       );
     }
 
-    // 역 변경 감지 → per-station 알림 (route + destination이 모두 있을 때만)
-    if (nearestStation && route && destinationName && nearestStation.id !== lastNotifiedStationIdRef.current) {
+    if (nearestStation && nearestStation.id !== lastNotifiedStationIdRef.current) {
       lastNotifiedStationIdRef.current = nearestStation.id;
-      const target = resolveNextTarget(route, destinationName);
+      const target = resolveNextTarget(route, destination.name);
       const stopsRemaining = target?.stopsToNextStation ?? null;
-      sendStationPassedNotification(nearestStation.name, destinationName, stopsRemaining)
+      sendStationPassedNotification(nearestStation.name, destination.name, stopsRemaining)
         .catch((e) => logger.error('역 통과 알림 실패:', e));
     }
-  }, [route, destinationName, nearestStation?.id]);
+  }, [
+    route,
+    destination?.id,
+    destination?.name,
+    destination?.lat,
+    destination?.lng,
+    nearestStation?.id,
+    userLocation?.lat,
+    userLocation?.lng,
+    speedMps,
+  ]);
 }

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -504,15 +504,15 @@ describe('useAppStore', () => {
 
   it('setAlarmEvent: 알람 이벤트를 설정한다', () => {
     const { setAlarmEvent } = useAppStore.getState();
-    setAlarmEvent({ type: 'destination', stationName: '강남' });
+    setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '강남' });
 
     const { alarmEvent } = useAppStore.getState();
-    expect(alarmEvent).toEqual({ type: 'destination', stationName: '강남' });
+    expect(alarmEvent).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
   });
 
   it('clearAlarmEvent: 알람 이벤트를 초기화하고 AsyncStorage도 정리한다', () => {
     const { setAlarmEvent, clearAlarmEvent } = useAppStore.getState();
-    setAlarmEvent({ type: 'transfer', stationName: '역삼' });
+    setAlarmEvent({ phaseId: 'early', type: 'transfer', stationName: '역삼' });
     clearAlarmEvent();
 
     const { alarmEvent } = useAppStore.getState();
@@ -521,7 +521,7 @@ describe('useAppStore', () => {
   });
 
   it('loadAlarmEvent: AsyncStorage에서 알람 이벤트를 복원하고 제거한다', async () => {
-    const event = { type: 'destination' as const, stationName: '강남' };
+    const event = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(event));
 
     const { loadAlarmEvent } = useAppStore.getState();

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -81,7 +81,7 @@ const mockDestination = {
   lng: 126.977,
 };
 
-function makeLocation(lat: number, lng: number) {
+function makeLocation(lat: number, lng: number, speed: number | null = null) {
   return {
     coords: {
       latitude: lat,
@@ -90,7 +90,7 @@ function makeLocation(lat: number, lng: number) {
       accuracy: null,
       altitudeAccuracy: null,
       heading: null,
-      speed: null,
+      speed,
     },
     timestamp: Date.now(),
   };
@@ -224,16 +224,16 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      37.498,
-      127.028,
-      mockDestination,
-      new Set(),
-      false,
-      true,
-      null,
-      null,
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      lat: 37.498,
+      lng: 127.028,
+      destination: mockDestination,
+      firedAlarms: new Set(),
+      sleepMode: false,
+      allowSpeaker: true,
+      storedRoute: null,
+      lastNotifiedStationId: null,
+    }));
     expect(AsyncStorage.setItem).not.toHaveBeenCalled();
   });
 
@@ -249,16 +249,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(),
-      true,
-      true,
-      null,
-      null,
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      sleepMode: true,
+    }));
   });
 
   it("sleepJson이 'false'이면 sleepMode=false로 processLocationUpdate를 호출한다", async () => {
@@ -271,16 +264,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(),
-      false,
-      true,
-      null,
-      null,
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      sleepMode: false,
+    }));
   });
 
   // ── allowSpeaker 파싱 ──
@@ -295,16 +281,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(),
-      false,
-      false,
-      null,
-      null,
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      allowSpeaker: false,
+    }));
   });
 
   it("allowSpeakerJson이 'true'이면 allowSpeaker=true로 processLocationUpdate를 호출한다", async () => {
@@ -317,16 +296,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(),
-      false,
-      true,
-      null,
-      null,
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      allowSpeaker: true,
+    }));
   });
 
   // ── firedAlarms 파싱 ──
@@ -342,16 +314,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(fired),
-      false,
-      true,
-      null,
-      null,
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      firedAlarms: new Set(fired),
+    }));
   });
 
   // ── ROUTE_KEY 관련 테스트 ──
@@ -380,16 +345,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(),
-      false,
-      true,
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
       storedRoute,
-      null,
-    );
+    }));
   });
 
   it('routeJson이 null이면 null storedRoute를 processLocationUpdate에 전달한다', async () => {
@@ -402,22 +360,15 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(),
-      false,
-      true,
-      null,
-      null,
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      storedRoute: null,
+    }));
   });
 
   // ── alarmEvent 있음: firedAlarms 저장 ──
 
   it('alarmEvent가 있으면 alarmKey를 추가하고 AsyncStorage.setItem을 호출한다', async () => {
-    const alarmEvent: AlarmEvent = { type: 'destination', stationName: '시청' };
+    const alarmEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '시청' };
     mockStorageValues(JSON.stringify(mockDestination));
 
     mockProcessLocationUpdate.mockResolvedValue({
@@ -444,7 +395,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   });
 
   it('기존 firedAlarms에 alarmEvent 키를 추가하여 저장한다', async () => {
-    const alarmEvent: AlarmEvent = { type: 'transfer', stationName: '강남' };
+    const alarmEvent: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '강남' };
     const existingFired = ['destination:시청'];
     mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(existingFired));
 
@@ -528,16 +479,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     });
 
     expect(AsyncStorage.getItem).toHaveBeenCalledWith('subway-now:last-notified-station');
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      mockDestination,
-      new Set(),
-      false,
-      true,
-      null,
-      'station-1',
-    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      lastNotifiedStationId: 'station-1',
+    }));
   });
 
   it('lastNotifiedStationId가 변경되면 AsyncStorage에 저장한다', async () => {
@@ -575,6 +519,30 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     });
 
     expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('GPS speed가 양수이면 speedMps로 processLocationUpdate에 전달한다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination));
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028, 12.5)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({ speedMps: 12.5 }));
+  });
+
+  it('GPS speed가 음수이면 speedMps를 null로 정규화한다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination));
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028, -1)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({ speedMps: null }));
   });
 
   it('lastNotifiedStationId가 null이면 저장하지 않는다', async () => {

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -24,7 +24,8 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const latest = locations[locations.length - 1];
   if (!latest) return;
 
-  const { latitude, longitude } = latest.coords;
+  const { latitude, longitude, speed } = latest.coords;
+  const speedMps = speed != null && speed >= 0 ? speed : null;
 
   try {
     const [destJson, sleepJson, firedJson, routeJson, lastNotifiedJson, allowSpeakerJson] = await Promise.all([
@@ -60,16 +61,17 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
     const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
 
-    const { alarmEvent, lastNotifiedStationId: newLastId } = await processLocationUpdate(
-      latitude,
-      longitude,
+    const { alarmEvent, lastNotifiedStationId: newLastId } = await processLocationUpdate({
+      lat: latitude,
+      lng: longitude,
       destination,
       firedAlarms,
       sleepMode,
       allowSpeaker,
       storedRoute,
-      lastNotifiedJson,
-    );
+      lastNotifiedStationId: lastNotifiedJson,
+      speedMps,
+    });
 
     const writes: Promise<void>[] = [];
     if (alarmEvent) {

--- a/src/utils/__tests__/alarmPhases.test.ts
+++ b/src/utils/__tests__/alarmPhases.test.ts
@@ -1,0 +1,51 @@
+import { ALARM_PHASES, type AlarmContext } from '../alarmPhases';
+
+function ctx(partial: Partial<AlarmContext>): AlarmContext {
+  return {
+    remainingStops: partial.remainingStops ?? 99,
+    etaSeconds: partial.etaSeconds ?? null,
+  };
+}
+
+const earlyPhase = ALARM_PHASES.find((p) => p.id === 'early')!;
+const imminentPhase = ALARM_PHASES.find((p) => p.id === 'imminent')!;
+
+describe('ALARM_PHASES', () => {
+  it('exposes early and imminent in order', () => {
+    expect(ALARM_PHASES.map((p) => p.id)).toEqual(['early', 'imminent']);
+  });
+
+  describe('early phase', () => {
+    it('fires when remainingStops <= 1', () => {
+      expect(earlyPhase.evaluate(ctx({ remainingStops: 1 }))).toBe(true);
+      expect(earlyPhase.evaluate(ctx({ remainingStops: 0 }))).toBe(true);
+    });
+
+    it('does not fire when remainingStops > 1', () => {
+      expect(earlyPhase.evaluate(ctx({ remainingStops: 2 }))).toBe(false);
+      expect(earlyPhase.evaluate(ctx({ remainingStops: 5 }))).toBe(false);
+    });
+  });
+
+  describe('imminent phase', () => {
+    it('does not fire when remainingStops > 1, regardless of eta', () => {
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 2, etaSeconds: 5 }))).toBe(false);
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 3, etaSeconds: 1 }))).toBe(false);
+    });
+
+    it('fires when etaSeconds <= 10 within approach', () => {
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 1, etaSeconds: 10 }))).toBe(true);
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 1, etaSeconds: 5 }))).toBe(true);
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 0, etaSeconds: 1 }))).toBe(true);
+    });
+
+    it('does not fire when etaSeconds > 10', () => {
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 1, etaSeconds: 11 }))).toBe(false);
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 1, etaSeconds: 60 }))).toBe(false);
+    });
+
+    it('does not fire when eta is null', () => {
+      expect(imminentPhase.evaluate(ctx({ remainingStops: 1, etaSeconds: null }))).toBe(false);
+    });
+  });
+});

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -1,7 +1,5 @@
-import { checkAlarm, checkTimeBasedAlarm, alarmKey, estimateRemainingSeconds, resolveAllTargets, AlarmEvent } from '../stationAlarm';
-import type { DirectRoute, TransferRoute, MultiTransferRoute, Route } from '../stationRoute';
-
-// ── 테스트 헬퍼 ──
+import { alarmKey, evaluateAlarmPhase, resolveAllTargets, type AlarmEvent, type AlarmSource } from '../stationAlarm';
+import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 
 function makeTransferRoute(
   stopsToTransfer: number,
@@ -30,418 +28,254 @@ function makeMultiRoute(
   };
 }
 
+function source(overrides: Partial<AlarmSource> & Pick<AlarmSource, 'route' | 'destinationName'>): AlarmSource {
+  return {
+    etaSeconds: null,
+    ...overrides,
+  };
+}
+
 describe('alarmKey', () => {
-  it('should return type:stationName format', () => {
-    const event: AlarmEvent = { type: 'destination', stationName: '강남' };
-    expect(alarmKey(event)).toBe('destination:강남');
+  it('returns phaseId:stationName format', () => {
+    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+    expect(alarmKey(event)).toBe('early:강남');
   });
 
-  it('should return transfer key', () => {
-    const event: AlarmEvent = { type: 'transfer', stationName: '시청' };
-    expect(alarmKey(event)).toBe('transfer:시청');
-  });
-
-  it('should return time-based destination key', () => {
-    const event: AlarmEvent = { type: 'destination', stationName: '강남', timeBased: true };
-    expect(alarmKey(event)).toBe('time-destination:강남');
-  });
-
-  it('should return time-based transfer key', () => {
-    const event: AlarmEvent = { type: 'transfer', stationName: '시청', timeBased: true };
-    expect(alarmKey(event)).toBe('time-transfer:시청');
-  });
-
-  it('should return approaching key', () => {
-    const event: AlarmEvent = { type: 'approaching', stationName: '역삼', timeBased: true };
-    expect(alarmKey(event)).toBe('time-approaching:역삼');
-  });
-});
-
-describe('estimateRemainingSeconds', () => {
-  it('should return 0 for 0 stops', () => {
-    expect(estimateRemainingSeconds(0)).toBe(0);
-  });
-
-  it('should return 120 for 1 stop', () => {
-    expect(estimateRemainingSeconds(1)).toBe(120);
-  });
-
-  it('should return 360 for 3 stops', () => {
-    expect(estimateRemainingSeconds(3)).toBe(360);
+  it('differentiates phases for the same station', () => {
+    expect(alarmKey({ phaseId: 'imminent', stationName: '강남' })).toBe('imminent:강남');
   });
 });
 
 describe('resolveAllTargets', () => {
-  describe('DirectRoute', () => {
-    it('should return single destination target', () => {
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      expect(resolveAllTargets(route, '강남')).toEqual([
-        { name: '강남', stops: 5, alarmType: 'destination' },
-      ]);
-    });
+  it('returns single destination for DirectRoute', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5 };
+    expect(resolveAllTargets(route, '강남')).toEqual([
+      { name: '강남', stops: 5, alarmType: 'destination' },
+    ]);
   });
 
-  describe('TransferRoute', () => {
-    it('should return transfer target followed by destination target', () => {
-      expect(resolveAllTargets(makeTransferRoute(3, 5), '강남')).toEqual([
-        { name: '시청', stops: 3, alarmType: 'transfer' },
-        { name: '강남', stops: 5, alarmType: 'destination' },
-      ]);
-    });
-
-    it('should return single destination when transferName equals destinationName', () => {
-      expect(resolveAllTargets(makeTransferRoute(3, 0, '옥수', 'gyeongui', '3'), '옥수')).toEqual([
-        { name: '옥수', stops: 3, alarmType: 'destination' },
-      ]);
-    });
+  it('returns transfer + destination for TransferRoute', () => {
+    expect(resolveAllTargets(makeTransferRoute(3, 5), '강남')).toEqual([
+      { name: '시청', stops: 3, alarmType: 'transfer' },
+      { name: '강남', stops: 5, alarmType: 'destination' },
+    ]);
   });
 
-  describe('MultiTransferRoute', () => {
-    it('should return all waypoints in order: [transfer1, transfer2, destination]', () => {
-      expect(resolveAllTargets(makeMultiRoute(5, 3, 2), '강남')).toEqual([
-        { name: '시청', stops: 5, alarmType: 'transfer' },
-        { name: '충무로', stops: 3, alarmType: 'transfer' },
-        { name: '강남', stops: 2, alarmType: 'destination' },
-      ]);
-    });
+  it('collapses transfer when transferName equals destination', () => {
+    expect(resolveAllTargets(makeTransferRoute(3, 0, '옥수', 'gyeongui', '3'), '옥수')).toEqual([
+      { name: '옥수', stops: 3, alarmType: 'destination' },
+    ]);
+  });
 
-    it('should mark transfer as destination when transferName equals destinationName', () => {
-      expect(resolveAllTargets(makeMultiRoute(1, 5, 3, '옥수'), '옥수')).toEqual([
-        { name: '옥수', stops: 1, alarmType: 'destination' },
-        { name: '충무로', stops: 5, alarmType: 'transfer' },
-        { name: '옥수', stops: 3, alarmType: 'destination' },
-      ]);
-    });
+  it('returns all waypoints in order for MultiTransferRoute', () => {
+    expect(resolveAllTargets(makeMultiRoute(5, 3, 2), '강남')).toEqual([
+      { name: '시청', stops: 5, alarmType: 'transfer' },
+      { name: '충무로', stops: 3, alarmType: 'transfer' },
+      { name: '강남', stops: 2, alarmType: 'destination' },
+    ]);
+  });
 
-    it('should reflect updated stops after first transfer passed', () => {
-      expect(resolveAllTargets(makeMultiRoute(0, 1, 3), '강남')).toEqual([
-        { name: '시청', stops: 0, alarmType: 'transfer' },
-        { name: '충무로', stops: 1, alarmType: 'transfer' },
-        { name: '강남', stops: 3, alarmType: 'destination' },
-      ]);
-    });
+  it('marks first transfer as destination when name matches', () => {
+    expect(resolveAllTargets(makeMultiRoute(1, 5, 3, '옥수'), '옥수')).toEqual([
+      { name: '옥수', stops: 1, alarmType: 'destination' },
+      { name: '충무로', stops: 5, alarmType: 'transfer' },
+      { name: '옥수', stops: 3, alarmType: 'destination' },
+    ]);
+  });
+
+  it('does not duplicate destination when last transfer name equals destination', () => {
+    expect(resolveAllTargets(makeMultiRoute(5, 3, 0, '시청', '강남'), '강남')).toEqual([
+      { name: '시청', stops: 5, alarmType: 'transfer' },
+      { name: '강남', stops: 3, alarmType: 'destination' },
+    ]);
   });
 });
 
-describe('checkAlarm', () => {
+describe('evaluateAlarmPhase', () => {
   const destinationName = '강남';
 
-  it('should return null for null route', () => {
-    expect(checkAlarm(null, destinationName, new Set())).toBeNull();
+  it('returns null for null route', () => {
+    expect(evaluateAlarmPhase(source({ route: null, destinationName }), new Set())).toBeNull();
   });
 
-  // DirectRoute
-  describe('DirectRoute', () => {
-    it('should return destination alarm when stops === 1', () => {
+  describe('DirectRoute — early phase', () => {
+    it('fires early at stops === 1', () => {
       const route: DirectRoute = { type: 'direct', stops: 1 };
-      const result = checkAlarm(route, destinationName, new Set());
-      expect(result).toEqual({ type: 'destination', stationName: '강남' });
-    });
-
-    it('should return destination alarm when stops === 0', () => {
-      const route: DirectRoute = { type: 'direct', stops: 0 };
-      expect(checkAlarm(route, destinationName, new Set())).toEqual({
+      expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toEqual({
+        phaseId: 'early',
         type: 'destination',
         stationName: '강남',
       });
     });
 
-    it('should return null when stops === 2', () => {
+    it('does not fire when stops > 1', () => {
       const route: DirectRoute = { type: 'direct', stops: 2 };
-      expect(checkAlarm(route, destinationName, new Set())).toBeNull();
+      expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toBeNull();
     });
 
-    it('should return null when already fired', () => {
+    it('skips early when already fired', () => {
       const route: DirectRoute = { type: 'direct', stops: 1 };
-      const fired = new Set(['destination:강남']);
-      expect(checkAlarm(route, destinationName, fired)).toBeNull();
+      const fired = new Set(['early:강남']);
+      expect(evaluateAlarmPhase(source({ route, destinationName }), fired)).toBeNull();
     });
   });
 
-  // TransferRoute
+  describe('DirectRoute — imminent phase', () => {
+    it('fires imminent after early when eta within 10s', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const fired = new Set(['early:강남']);
+      expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 8 }), fired)).toEqual({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: '강남',
+      });
+    });
+
+    it('does not fire imminent when eta exceeds 10s', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const fired = new Set(['early:강남']);
+      expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 30 }), fired)).toBeNull();
+    });
+
+    it('prefers early over imminent when both qualify and neither fired', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1 };
+      expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 5 }), new Set())).toEqual({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: '강남',
+      });
+    });
+
+    it('skips imminent when already fired', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const fired = new Set(['early:강남', 'imminent:강남']);
+      expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 5 }), fired)).toBeNull();
+    });
+
+    it('does not fire imminent at stops 0 if remainingStops gate fails — gate allows 0 so it does fire', () => {
+      const route: DirectRoute = { type: 'direct', stops: 0 };
+      expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toEqual({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: '강남',
+      });
+    });
+  });
+
   describe('TransferRoute', () => {
-    it('should return transfer alarm when stopsToTransfer === 1', () => {
-      expect(checkAlarm(makeTransferRoute(1, 5), destinationName, new Set()))
-        .toEqual({ type: 'transfer', stationName: '시청' });
+    it('fires early for transfer when stopsToTransfer === 1', () => {
+      expect(
+        evaluateAlarmPhase(source({ route: makeTransferRoute(1, 5), destinationName }), new Set()),
+      ).toEqual({ phaseId: 'early', type: 'transfer', stationName: '시청' });
     });
 
-    it('should return null when stopsToTransfer > threshold even if stopsFromTransfer <= threshold', () => {
-      expect(checkAlarm(makeTransferRoute(5, 1), destinationName, new Set())).toBeNull();
-    });
-
-    it('should return null when neither is 1', () => {
-      expect(checkAlarm(makeTransferRoute(3, 5), destinationName, new Set())).toBeNull();
-    });
-
-    it('should return null when transfer alarm already fired', () => {
-      const fired = new Set(['transfer:시청']);
-      expect(checkAlarm(makeTransferRoute(1, 5), destinationName, fired)).toBeNull();
-    });
-
-    it('should return destination alarm when transferName equals destinationName and stopsToTransfer <= 1', () => {
-      expect(checkAlarm(makeTransferRoute(0, 0, '옥수', 'gyeongui', '3'), '옥수', new Set()))
-        .toEqual({ type: 'destination', stationName: '옥수' });
-    });
-
-    it('should return null when transferName equals destinationName but stopsToTransfer > 1', () => {
-      expect(checkAlarm(makeTransferRoute(3, 0, '옥수', 'gyeongui', '3'), '옥수', new Set())).toBeNull();
-    });
-
-    it('should return destination alarm when transferName equals destinationName and both stops <= 1', () => {
-      expect(checkAlarm(makeTransferRoute(1, 0, '공덕', '5', '6'), '공덕', new Set()))
-        .toEqual({ type: 'destination', stationName: '공덕' });
-    });
-
-    it('should prioritize transfer over destination when both are 1', () => {
-      expect(checkAlarm(makeTransferRoute(1, 1), destinationName, new Set()))
-        .toEqual({ type: 'transfer', stationName: '시청' });
-    });
-
-    it('should return destination alarm after transfer is fired and destination is close', () => {
-      const fired = new Set(['transfer:시청']);
-      expect(checkAlarm(makeTransferRoute(0, 1), destinationName, fired))
-        .toEqual({ type: 'destination', stationName: '강남' });
-    });
-
-    it('should return null after transfer is fired but destination is far', () => {
-      const fired = new Set(['transfer:시청']);
-      expect(checkAlarm(makeTransferRoute(0, 5), destinationName, fired)).toBeNull();
-    });
-  });
-
-  // MultiTransferRoute
-  describe('MultiTransferRoute', () => {
-    it('should return transfer alarm for first transfer when stopsToTransfer === 1', () => {
-      const route = makeMultiRoute(1, 5, 3);
-      const result = checkAlarm(route, destinationName, new Set());
-      expect(result).toEqual({ type: 'transfer', stationName: '시청' });
-    });
-
-    it('should return null when first stopsToTransfer > threshold even if second <= threshold', () => {
-      const route = makeMultiRoute(5, 1, 3);
-      const result = checkAlarm(route, destinationName, new Set());
-      expect(result).toBeNull();
-    });
-
-    it('should return null when first stopsToTransfer > threshold even if stopsAfterLastTransfer <= threshold', () => {
-      const route = makeMultiRoute(5, 3, 1);
-      const result = checkAlarm(route, destinationName, new Set());
-      expect(result).toBeNull();
-    });
-
-    it('should return null when no stops are 1', () => {
-      const route = makeMultiRoute(3, 4, 5);
-      expect(checkAlarm(route, destinationName, new Set())).toBeNull();
-    });
-
-    it('should return null when already fired', () => {
-      const route = makeMultiRoute(1, 5, 3);
-      const fired = new Set(['transfer:시청']);
-      expect(checkAlarm(route, destinationName, fired)).toBeNull();
-    });
-
-    it('should prioritize first transfer over second when both are 1', () => {
-      const route = makeMultiRoute(1, 1, 3);
-      const result = checkAlarm(route, destinationName, new Set());
-      expect(result).toEqual({ type: 'transfer', stationName: '시청' });
-    });
-
-    it('should return null when first stopsToTransfer > threshold even if second and stopsAfter <= threshold', () => {
-      const route = makeMultiRoute(5, 1, 1);
-      const result = checkAlarm(route, destinationName, new Set());
-      expect(result).toBeNull();
-    });
-
-    it('should return destination alarm when first transferName equals destinationName', () => {
-      expect(checkAlarm(makeMultiRoute(1, 5, 3, '옥수'), '옥수', new Set()))
-        .toEqual({ type: 'destination', stationName: '옥수' });
-    });
-
-    it('should return null when second transferName equals destinationName but first stopsToTransfer > threshold', () => {
-      expect(checkAlarm(makeMultiRoute(5, 1, 0, '시청', '옥수'), '옥수', new Set())).toBeNull();
-    });
-
-    it('should return null when transferName equals destinationName but stopsToTransfer > threshold', () => {
-      expect(checkAlarm(makeMultiRoute(3, 5, 2, '옥수'), '옥수', new Set())).toBeNull();
-    });
-
-    it('should not fire alarm at start of multi-segment route (regression: #152)', () => {
-      // 용마산 → 강남구청(7정거장) → 선릉(2정거장) → 역삼(1정거장)
-      expect(checkAlarm(makeMultiRoute(7, 2, 1, '강남구청', '선릉'), '역삼', new Set())).toBeNull();
-    });
-
-    it('should return null when first transferName equals destinationName but is far', () => {
-      expect(checkAlarm(makeMultiRoute(5, 1, 3, '옥수'), '옥수', new Set())).toBeNull();
-    });
-
-    it('should return second transfer alarm after first is fired', () => {
-      const route = makeMultiRoute(0, 1, 3);
-      const fired = new Set(['transfer:시청']);
-      expect(checkAlarm(route, destinationName, fired))
-        .toEqual({ type: 'transfer', stationName: '충무로' });
-    });
-
-    it('should return destination alarm after both transfers are fired', () => {
-      const route = makeMultiRoute(0, 0, 1);
-      const fired = new Set(['transfer:시청', 'transfer:충무로']);
-      expect(checkAlarm(route, destinationName, fired))
-        .toEqual({ type: 'destination', stationName: '강남' });
-    });
-
-    it('should return null when first is fired but second is still far', () => {
-      const route = makeMultiRoute(0, 5, 3);
-      const fired = new Set(['transfer:시청']);
-      expect(checkAlarm(route, destinationName, fired)).toBeNull();
-    });
-
-    it('should fire alarms sequentially through full journey', () => {
+    it('does not fire when transfer is far even if destination eta is close', () => {
       const fired = new Set<string>();
+      // 환승까지 5정거장 → 환승역 early 미발사, 도착역 stops=2도 미해당
+      expect(
+        evaluateAlarmPhase(
+          source({ route: makeTransferRoute(5, 2), destinationName, etaSeconds: 5 }),
+          fired,
+        ),
+      ).toBeNull();
+    });
 
-      // 1) 첫 환승 접근
-      const step1 = checkAlarm(makeMultiRoute(1, 5, 3), destinationName, fired);
-      expect(step1).toEqual({ type: 'transfer', stationName: '시청' });
-      fired.add('transfer:시청');
+    it('fires transfer early without consuming destination eta (eta routed to final waypoint only)', () => {
+      // 환승 1정거장 전, 도착 5정거장 후. eta는 도착역 한정 신호이므로 환승 imminent에는 적용되지 않는다.
+      expect(
+        evaluateAlarmPhase(
+          source({ route: makeTransferRoute(1, 5), destinationName, etaSeconds: 5 }),
+          new Set(),
+        ),
+      ).toEqual({ phaseId: 'early', type: 'transfer', stationName: '시청' });
+    });
 
-      // 2) 첫 환승 통과, 두 번째 접근
-      const step2 = checkAlarm(makeMultiRoute(0, 1, 3), destinationName, fired);
-      expect(step2).toEqual({ type: 'transfer', stationName: '충무로' });
-      fired.add('transfer:충무로');
+    it('routes external eta to destination once transfer is passed (stops=0)', () => {
+      // 환승 통과(stops=0), 도착 1정거장 전, eta 5초 → 도착역 imminent 발사 가능
+      const fired = new Set(['early:시청', 'imminent:시청', 'early:강남']);
+      expect(
+        evaluateAlarmPhase(
+          source({ route: makeTransferRoute(0, 1), destinationName, etaSeconds: 5 }),
+          fired,
+        ),
+      ).toEqual({ phaseId: 'imminent', type: 'destination', stationName: '강남' });
+    });
 
-      // 3) 둘 다 통과, 도착역 접근
-      const step3 = checkAlarm(makeMultiRoute(0, 0, 1), destinationName, fired);
-      expect(step3).toEqual({ type: 'destination', stationName: '강남' });
+    it('fires destination alarm when transferName equals destination and approaches', () => {
+      expect(
+        evaluateAlarmPhase(
+          source({ route: makeTransferRoute(1, 0, '옥수', '5', '6'), destinationName: '옥수' }),
+          new Set(),
+        ),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '옥수' });
+    });
+
+    it('returns destination alarm after transfer early is fired and destination is close', () => {
+      const fired = new Set(['early:시청']);
+      expect(
+        evaluateAlarmPhase(source({ route: makeTransferRoute(0, 1), destinationName }), fired),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
     });
   });
 
-  describe('custom threshold', () => {
-    it('should return alarm when stops <= threshold (threshold=2)', () => {
-      const route: DirectRoute = { type: 'direct', stops: 2 };
-      const result = checkAlarm(route, destinationName, new Set(), 2);
-      expect(result).toEqual({ type: 'destination', stationName: '강남' });
+  describe('MultiTransferRoute', () => {
+    it('fires first transfer at stopsToTransfer === 1', () => {
+      expect(
+        evaluateAlarmPhase(source({ route: makeMultiRoute(1, 5, 3), destinationName }), new Set()),
+      ).toEqual({ phaseId: 'early', type: 'transfer', stationName: '시청' });
     });
 
-    it('should return null when stops > threshold (threshold=2)', () => {
+    it('proceeds to second transfer after first is fired', () => {
+      const fired = new Set(['early:시청']);
+      expect(
+        evaluateAlarmPhase(source({ route: makeMultiRoute(0, 1, 3), destinationName }), fired),
+      ).toEqual({ phaseId: 'early', type: 'transfer', stationName: '충무로' });
+    });
+
+    it('proceeds to destination after both transfers fired', () => {
+      const fired = new Set(['early:시청', 'early:충무로']);
+      expect(
+        evaluateAlarmPhase(source({ route: makeMultiRoute(0, 0, 1), destinationName }), fired),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
+    });
+
+    it('does not fire at the start of multi-segment route (regression: #152)', () => {
+      // 용마산 → 강남구청(7) → 선릉(2) → 역삼(1)
+      expect(
+        evaluateAlarmPhase(
+          source({ route: makeMultiRoute(7, 2, 1, '강남구청', '선릉'), destinationName: '역삼' }),
+          new Set(),
+        ),
+      ).toBeNull();
+    });
+
+    it('fires alarms sequentially through full journey', () => {
+      const fired = new Set<string>();
+      const step1 = evaluateAlarmPhase(source({ route: makeMultiRoute(1, 5, 3), destinationName }), fired);
+      expect(step1).toEqual({ phaseId: 'early', type: 'transfer', stationName: '시청' });
+      fired.add(alarmKey(step1!));
+
+      const step2 = evaluateAlarmPhase(source({ route: makeMultiRoute(0, 1, 3), destinationName }), fired);
+      expect(step2).toEqual({ phaseId: 'early', type: 'transfer', stationName: '충무로' });
+      fired.add(alarmKey(step2!));
+
+      const step3 = evaluateAlarmPhase(source({ route: makeMultiRoute(0, 0, 1), destinationName }), fired);
+      expect(step3).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
+    });
+  });
+
+  describe('custom phases', () => {
+    it('accepts a custom phase array', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
-      expect(checkAlarm(route, destinationName, new Set(), 2)).toBeNull();
-    });
-
-    it('should apply threshold to transfer route stopsToTransfer', () => {
-      expect(checkAlarm(makeTransferRoute(2, 5), destinationName, new Set(), 2))
-        .toEqual({ type: 'transfer', stationName: '시청' });
-    });
-
-    it('should return null when all stopsToTransfer > threshold even if stopsAfterLastTransfer <= threshold', () => {
-      expect(checkAlarm(makeMultiRoute(5, 5, 3), destinationName, new Set(), 3)).toBeNull();
-    });
-  });
-});
-
-describe('checkTimeBasedAlarm', () => {
-  const destinationName = '강남';
-
-  it('should return null when nextStationName is null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5 };
-    expect(checkTimeBasedAlarm(null, 1, destinationName, route, new Set())).toBeNull();
-  });
-
-  it('should return null when route is null', () => {
-    expect(checkTimeBasedAlarm('역삼', 1, destinationName, null, new Set())).toBeNull();
-  });
-
-  it('should return null when estimated time exceeds threshold', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5 };
-    expect(checkTimeBasedAlarm('역삼', 2, destinationName, route, new Set())).toBeNull();
-  });
-
-  describe('approaching regular station', () => {
-    it('should return approaching alarm for regular station (0 stops to next)', () => {
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      const result = checkTimeBasedAlarm('역삼', 0, destinationName, route, new Set());
-      expect(result).toEqual({ type: 'approaching', stationName: '역삼', timeBased: true });
-    });
-
-    it('should return null when already fired for that station', () => {
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      const fired = new Set(['time-approaching:역삼']);
-      expect(checkTimeBasedAlarm('역삼', 0, destinationName, route, fired)).toBeNull();
-    });
-
-    it('should fire for different stations independently', () => {
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      const fired = new Set(['time-approaching:역삼']);
-      const result = checkTimeBasedAlarm('선릉', 0, destinationName, route, fired);
-      expect(result).toEqual({ type: 'approaching', stationName: '선릉', timeBased: true });
-    });
-  });
-
-  describe('approaching destination station', () => {
-    it('should return destination alarm when next station is destination', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
-      const result = checkTimeBasedAlarm('강남', 0, '강남', route, new Set());
-      expect(result).toEqual({ type: 'destination', stationName: '강남', timeBased: true });
-    });
-
-    it('should return null when already fired for destination', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
-      const fired = new Set(['time-destination:강남']);
-      expect(checkTimeBasedAlarm('강남', 0, '강남', route, fired)).toBeNull();
-    });
-  });
-
-  describe('approaching transfer station', () => {
-    it('should return transfer alarm for transfer station (TransferRoute)', () => {
-      const result = checkTimeBasedAlarm('시청', 0, destinationName, makeTransferRoute(1, 5), new Set());
-      expect(result).toEqual({ type: 'transfer', stationName: '시청', timeBased: true });
-    });
-
-    it('should return transfer alarm for first transfer (MultiTransferRoute)', () => {
-      const result = checkTimeBasedAlarm('시청', 0, destinationName, makeMultiRoute(1, 5, 3), new Set());
-      expect(result).toEqual({ type: 'transfer', stationName: '시청', timeBased: true });
-    });
-
-    it('should return transfer alarm for second transfer (MultiTransferRoute)', () => {
-      const result = checkTimeBasedAlarm('충무로', 0, destinationName, makeMultiRoute(5, 1, 3), new Set());
-      expect(result).toEqual({ type: 'transfer', stationName: '충무로', timeBased: true });
-    });
-
-    it('should return null when already fired for transfer station', () => {
-      const fired = new Set(['time-transfer:시청']);
-      expect(checkTimeBasedAlarm('시청', 0, destinationName, makeTransferRoute(1, 5), fired)).toBeNull();
-    });
-  });
-
-  describe('direct route: approaching regular station is not destination', () => {
-    it('should return approaching for non-destination station on direct route', () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
-      const result = checkTimeBasedAlarm('역삼', 0, '강남', route, new Set());
-      expect(result).toEqual({ type: 'approaching', stationName: '역삼', timeBased: true });
-    });
-  });
-
-  describe('approaching regular station on transfer/multi-transfer route', () => {
-    it('should return approaching for non-transfer station on TransferRoute', () => {
-      const result = checkTimeBasedAlarm('종각', 0, destinationName, makeTransferRoute(3, 5), new Set());
-      expect(result).toEqual({ type: 'approaching', stationName: '종각', timeBased: true });
-    });
-
-    it('should return approaching for non-transfer station on MultiTransferRoute', () => {
-      const result = checkTimeBasedAlarm('종각', 0, destinationName, makeMultiRoute(3, 5, 3), new Set());
-      expect(result).toEqual({ type: 'approaching', stationName: '종각', timeBased: true });
-    });
-  });
-
-  describe('custom threshold', () => {
-    it('should trigger when estimated time equals threshold', () => {
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      // 1 stop * 120s = 120s, threshold = 120
-      const result = checkTimeBasedAlarm('역삼', 1, destinationName, route, new Set(), 120);
-      expect(result).toEqual({ type: 'approaching', stationName: '역삼', timeBased: true });
-    });
-
-    it('should not trigger when estimated time exceeds threshold', () => {
-      const route: DirectRoute = { type: 'direct', stops: 5 };
-      // 1 stop * 120s = 120s, threshold = 60
-      expect(checkTimeBasedAlarm('역삼', 1, destinationName, route, new Set(), 60)).toBeNull();
+      const customPhases = [
+        {
+          id: 'early' as const,
+          evaluate: (ctx: { remainingStops: number }) => ctx.remainingStops <= 3,
+        },
+      ];
+      expect(
+        evaluateAlarmPhase(source({ route, destinationName }), new Set(), customPhases),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
     });
   });
 });

--- a/src/utils/__tests__/stationEta.test.ts
+++ b/src/utils/__tests__/stationEta.test.ts
@@ -1,0 +1,38 @@
+import { estimateEtaSeconds, distanceMetersBetween } from '../stationEta';
+
+describe('estimateEtaSeconds', () => {
+  it('returns null when speed is null', () => {
+    expect(estimateEtaSeconds(100, null)).toBeNull();
+  });
+
+  it('returns null when speed is below minimum (< 0.5 m/s)', () => {
+    expect(estimateEtaSeconds(100, 0)).toBeNull();
+    expect(estimateEtaSeconds(100, 0.4)).toBeNull();
+    expect(estimateEtaSeconds(100, -1)).toBeNull();
+  });
+
+  it('computes eta when speed >= 0.5 m/s (역 진입 감속 구간 포함)', () => {
+    expect(estimateEtaSeconds(100, 10)).toBe(10);
+    expect(estimateEtaSeconds(50, 5)).toBe(10);
+    expect(estimateEtaSeconds(0, 5)).toBe(0);
+    expect(estimateEtaSeconds(5, 0.5)).toBe(10);
+  });
+
+  it('matches typical subway speed', () => {
+    // 200m at 20 m/s (72 km/h) → 10s
+    expect(estimateEtaSeconds(200, 20)).toBe(10);
+  });
+});
+
+describe('distanceMetersBetween', () => {
+  it('returns 0 for identical coords', () => {
+    expect(distanceMetersBetween(37.5, 127.0, 37.5, 127.0)).toBe(0);
+  });
+
+  it('returns positive distance for different coords', () => {
+    // 강남(37.4980, 127.0278) <-> 역삼(37.5006, 127.0364) — 약 800m
+    const d = distanceMetersBetween(37.4980, 127.0278, 37.5006, 127.0364);
+    expect(d).toBeGreaterThan(500);
+    expect(d).toBeLessThan(1200);
+  });
+});

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -312,7 +312,7 @@ describe('stationNotification', () => {
     });
 
     it('alarmEvent가 있으면 alarmType과 alarmStationName이 포함된다', async () => {
-      await updateStationNotification(mockStation, 154, mockDestination, transferRoute, 12, false, { type: 'transfer', stationName: '동대문' });
+      await updateStationNotification(mockStation, 154, mockDestination, transferRoute, 12, false, { phaseId: 'early', type: 'transfer', stationName: '동대문' });
       expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           alarmType: 'transfer',
@@ -322,7 +322,7 @@ describe('stationNotification', () => {
     });
 
     it('alarmEvent가 destination 타입이면 alarmType이 destination이다', async () => {
-      await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12, false, { type: 'destination', stationName: '강남' });
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute, 12, false, { phaseId: 'early', type: 'destination', stationName: '강남' });
       expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           alarmType: 'destination',
@@ -444,84 +444,70 @@ describe('stationNotification', () => {
   });
 
   describe('sendAlarmNotification', () => {
-    it('destination 타입이면 하차 알림을 보낸다', async () => {
+    const earlyDest = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
+    const earlyTransfer = { phaseId: 'early' as const, type: 'transfer' as const, stationName: '시청' };
+    const imminentDest = { phaseId: 'imminent' as const, type: 'destination' as const, stationName: '강남' };
+    const imminentTransfer = { phaseId: 'imminent' as const, type: 'transfer' as const, stationName: '시청' };
+
+    it('early destination이면 하차 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('destination', '강남');
+      await sendAlarmNotification(earlyDest);
       expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!', { interruptionLevel: 'timeSensitive' });
       expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
     });
 
-    it('transfer 타입이면 환승 알림을 보낸다', async () => {
+    it('early transfer이면 환승 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('transfer', '시청');
+      await sendAlarmNotification(earlyTransfer);
       expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!', { interruptionLevel: 'timeSensitive' });
-      expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
     });
 
-    it('sleepMode가 true이면 playAlarmWithRouting에 true를 전달한다', async () => {
+    it('sleepMode가 true이면 vibrateAlarm에 true를 전달한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('destination', '강남', true);
+      await sendAlarmNotification(earlyDest, true);
       expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
     });
 
     it('Android에서는 channelId와 priority MAX가 포함된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
-      await sendAlarmNotification('destination', '강남');
+      await sendAlarmNotification(earlyDest);
       expectAlarmNotification('하차 알림', '다음 역 강남에서 내리세요!', { channelId: 'station-alarm', priority: 'max' });
     });
 
     it('dismiss 실패해도 schedule은 호출된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
-      await sendAlarmNotification('destination', '강남');
+      await sendAlarmNotification(earlyDest);
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
     });
 
-    it('timeBased destination이면 도착 임박 알림을 보낸다', async () => {
+    it('imminent destination이면 도착 임박 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('destination', '강남', false, true);
+      await sendAlarmNotification(imminentDest);
       expectAlarmNotification('도착 임박', '곧 강남에 도착합니다. 하차 준비하세요!', { interruptionLevel: 'timeSensitive' });
     });
 
-    it('timeBased transfer이면 환승 임박 알림을 보낸다', async () => {
+    it('imminent transfer이면 환승 임박 알림을 보낸다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('transfer', '시청', false, true);
+      await sendAlarmNotification(imminentTransfer);
       expectAlarmNotification('환승 임박', '곧 시청에 도착합니다. 환승 준비하세요!', { interruptionLevel: 'timeSensitive' });
     });
 
-    it('timeBased + sleepMode이면 playAlarmWithRouting에 true를 전달한다', async () => {
+    it('imminent + sleepMode이면 vibrateAlarm에 true를 전달한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('destination', '강남', true, true);
+      await sendAlarmNotification(imminentDest, true);
       expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
     });
 
-    it('timeBased + Android에서는 channelId와 priority MAX가 포함된다', async () => {
+    it('imminent + Android에서는 channelId와 priority MAX가 포함된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
-      await sendAlarmNotification('destination', '강남', false, true);
+      await sendAlarmNotification(imminentDest);
       expectAlarmNotification('도착 임박', '곧 강남에 도착합니다. 하차 준비하세요!', { channelId: 'station-alarm', priority: 'max' });
-    });
-
-    it('timeBased approaching이면 역 접근 알림을 보낸다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('approaching', '역삼', false, true);
-      expectAlarmNotification('역 접근', '곧 역삼에 도착합니다.', { interruptionLevel: 'timeSensitive' });
-    });
-
-    it('timeBased approaching + Android에서는 channelId와 priority MAX가 포함된다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'android');
-      await sendAlarmNotification('approaching', '역삼', false, true);
-      expectAlarmNotification('역 접근', '곧 역삼에 도착합니다.', { channelId: 'station-alarm', priority: 'max' });
-    });
-
-    it('vibrateAlarm을 호출한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('destination', '강남');
-      expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
     });
 
     it('allowSpeaker=false이면 iOS에서 sound를 false로 설정한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification('destination', '강남', false, false, false);
+      await sendAlarmNotification(earlyDest, false, false);
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-alarm',
         content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: false, interruptionLevel: 'timeSensitive' },
@@ -531,7 +517,7 @@ describe('stationNotification', () => {
 
     it('allowSpeaker=false이면 Android에서 무음 채널을 사용한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
-      await sendAlarmNotification('destination', '강남', false, false, false);
+      await sendAlarmNotification(earlyDest, false, false);
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-alarm',
         content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: false, channelId: 'station-alarm-silent', priority: 'max' },

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -2,8 +2,6 @@ import type { Station, NearestStationResult } from '../../types/station';
 import type { Route, DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 import type { AlarmEvent } from '../stationAlarm';
 
-// ── 모든 외부 의존성 모킹 ──
-
 const mockFindNearestStation = jest.fn();
 jest.mock('../findNearestStation', () => ({
   findNearestStation: (...args: unknown[]) => mockFindNearestStation(...args),
@@ -18,12 +16,10 @@ jest.mock('../stationRoute', () => ({
   updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
 }));
 
-const mockCheckAlarm = jest.fn();
-const mockCheckTimeBasedAlarm = jest.fn();
+const mockEvaluateAlarmPhase = jest.fn();
 const mockAlarmKey = jest.fn();
 jest.mock('../stationAlarm', () => ({
-  checkAlarm: (...args: unknown[]) => mockCheckAlarm(...args),
-  checkTimeBasedAlarm: (...args: unknown[]) => mockCheckTimeBasedAlarm(...args),
+  evaluateAlarmPhase: (...args: unknown[]) => mockEvaluateAlarmPhase(...args),
   alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
 }));
 
@@ -36,9 +32,7 @@ jest.mock('../stationNotification', () => ({
   sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
 }));
 
-import { evaluateAllAlarms, processLocationUpdate, resolveNextTarget } from '../stationPipeline';
-
-// ── 테스트 픽스처 ──
+import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
 
 const mockStation: Station = {
   id: 'station-1',
@@ -64,123 +58,18 @@ const mockNearestResult: NearestStationResult = {
 };
 
 const mockRoute: DirectRoute = { type: 'direct', stops: 3 };
+const mockAlarmEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '시청' };
 
-const mockAlarmEvent: AlarmEvent = { type: 'destination', stationName: '시청' };
-
-describe('evaluateAllAlarms', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockCheckTimeBasedAlarm.mockReturnValue(null);
+function call(overrides: Partial<Parameters<typeof processLocationUpdate>[0]> = {}) {
+  return processLocationUpdate({
+    lat: 37.498,
+    lng: 127.028,
+    destination: mockDestination,
+    firedAlarms: new Set(),
+    sleepMode: false,
+    ...overrides,
   });
-
-  it('should return null for null route', () => {
-    expect(evaluateAllAlarms(null, '강남', new Set())).toBeNull();
-    expect(mockCheckAlarm).not.toHaveBeenCalled();
-  });
-
-  it('should return stop-based alarm when checkAlarm fires', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1 };
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
-
-    const result = evaluateAllAlarms(route, '시청', new Set());
-
-    expect(result).toBe(mockAlarmEvent);
-    expect(mockCheckTimeBasedAlarm).not.toHaveBeenCalled();
-  });
-
-  it('should check time-based alarm when stop-based alarm is null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
-    mockCheckAlarm.mockReturnValue(null);
-    const timeEvent: AlarmEvent = { type: 'destination', stationName: '시청', timeBased: true };
-    mockCheckTimeBasedAlarm.mockReturnValue(timeEvent);
-
-    const result = evaluateAllAlarms(route, '시청', new Set());
-
-    expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
-      '시청', 3, '시청', route, expect.any(Set),
-    );
-    expect(result).toBe(timeEvent);
-  });
-
-  it('should use resolveNextTarget for transfer route', () => {
-    const route: TransferRoute = {
-      type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
-      stopsToTransfer: 5, stopsFromTransfer: 2,
-    };
-    mockCheckAlarm.mockReturnValue(null);
-    mockCheckTimeBasedAlarm.mockReturnValue(null);
-
-    evaluateAllAlarms(route, '강남', new Set());
-
-    expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
-      '동대문', 5, '강남', route, expect.any(Set),
-    );
-  });
-
-  it('should use resolveNextTarget for multi-transfer route', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
-      transfers: [
-        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
-        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
-      ],
-      stopsAfterLastTransfer: 4,
-    };
-    mockCheckAlarm.mockReturnValue(null);
-    mockCheckTimeBasedAlarm.mockReturnValue(null);
-
-    evaluateAllAlarms(route, '강남', new Set());
-
-    expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
-      '잠실', 3, '강남', route, expect.any(Set),
-    );
-  });
-
-  it('should return null when both alarms return null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
-    mockCheckAlarm.mockReturnValue(null);
-    mockCheckTimeBasedAlarm.mockReturnValue(null);
-
-    expect(evaluateAllAlarms(route, '시청', new Set())).toBeNull();
-  });
-
-  it('should pass firedAlarms to both alarm checks', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
-    const firedAlarms = new Set(['destination:시청']);
-    mockCheckAlarm.mockReturnValue(null);
-
-    evaluateAllAlarms(route, '시청', firedAlarms);
-
-    expect(mockCheckAlarm).toHaveBeenCalledWith(route, '시청', firedAlarms);
-    expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
-      '시청', 3, '시청', route, firedAlarms,
-    );
-  });
-
-  it('should return null when stopsToNextStation is 0 (already at target)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 0 };
-    mockCheckAlarm.mockReturnValue(null);
-
-    expect(evaluateAllAlarms(route, '강남', new Set())).toBeNull();
-    expect(mockCheckTimeBasedAlarm).not.toHaveBeenCalled();
-  });
-
-  it('should skip time-based alarm for transfer route with stopsToTransfer = 0 and stopsFromTransfer > 0', () => {
-    const route: TransferRoute = {
-      type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
-      stopsToTransfer: 0, stopsFromTransfer: 5,
-    };
-    mockCheckAlarm.mockReturnValue(null);
-    mockCheckTimeBasedAlarm.mockReturnValue(null);
-
-    evaluateAllAlarms(route, '강남', new Set());
-
-    // resolveNextTarget returns destination with stopsFromTransfer=5
-    expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
-      '강남', 5, '강남', route, expect.any(Set),
-    );
-  });
-});
+}
 
 describe('processLocationUpdate', () => {
   beforeEach(() => {
@@ -189,76 +78,80 @@ describe('processLocationUpdate', () => {
     mockUpdateStationNotification.mockResolvedValue(undefined);
     mockSendStationPassedNotification.mockResolvedValue(undefined);
     mockCalculateStaticETA.mockReturnValue(10);
-    mockCheckAlarm.mockReturnValue(null);
-    mockCheckTimeBasedAlarm.mockReturnValue(null);
+    mockEvaluateAlarmPhase.mockReturnValue(null);
   });
 
-  it('should return null nearest and null alarmEvent when findNearestStation returns null', async () => {
+  it('returns null nearest and null alarm when findNearestStation returns null', async () => {
     mockFindNearestStation.mockReturnValue(null);
-
-    const result = await processLocationUpdate(
-      37.5, 127.0, mockDestination, new Set(), false,
-    );
-
+    const result = await call();
     expect(result).toEqual({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
     expect(mockFindRoute).not.toHaveBeenCalled();
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
-    expect(mockUpdateStationNotification).not.toHaveBeenCalled();
   });
 
-  it('should call findRoute and evaluateAllAlarms with correct arguments', async () => {
+  it('calls findRoute and evaluator with full source', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
-    await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false,
-    );
+    await call({ speedMps: 10 });
 
     expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
-    expect(mockCheckAlarm).toHaveBeenCalledWith(mockRoute, '시청', expect.any(Set));
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: mockRoute,
+        destinationName: '시청',
+        etaSeconds: expect.any(Number),
+      }),
+      expect.any(Set),
+    );
   });
 
-  it('should send alarm notification when alarm fires (without mutating firedAlarms)', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
-
-    const firedAlarms = new Set<string>();
-
-    await processLocationUpdate(37.498, 127.028, mockDestination, firedAlarms, false);
-
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, false, true);
-    expect(firedAlarms.size).toBe(0);
-  });
-
-  it('should pass sleepMode to sendAlarmNotification', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
-    mockAlarmKey.mockReturnValue('destination:시청');
-
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
-
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', true, false, true);
-  });
-
-  it('should not call sendAlarmNotification when no alarm', async () => {
+  it('passes null etaSeconds when speedMps is not provided', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+    await call();
 
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+      expect.objectContaining({ etaSeconds: null }),
+      expect.any(Set),
+    );
+  });
+
+  it('sends alarm notification with the full event when alarm fires', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+    await call();
+
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, false, true);
+  });
+
+  it('passes sleepMode and allowSpeaker to sendAlarmNotification', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+    await call({ sleepMode: true, allowSpeaker: false });
+
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, true, false);
+  });
+
+  it('does not call sendAlarmNotification when no alarm', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    await call();
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
 
-  it('should call updateStationNotification with correct arguments', async () => {
+  it('calls updateStationNotification with computed args', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
     mockCalculateStaticETA.mockReturnValue(12);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+    await call();
 
-    // distanceKm 0.15 → Math.round(0.15 * 1000) = 150
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
       mockStation,
       150,
@@ -270,244 +163,162 @@ describe('processLocationUpdate', () => {
     );
   });
 
-  it('should pass alarmEvent to updateStationNotification only when sleepMode is true', async () => {
+  it('passes alarmEvent to updateStationNotification only when sleepMode is true', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
+    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
     mockCalculateStaticETA.mockReturnValue(10);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
+    await call({ sleepMode: true });
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 150, mockDestination, mockRoute, 10,
-      undefined, mockAlarmEvent,
+      mockStation, 150, mockDestination, mockRoute, 10, undefined, mockAlarmEvent,
     );
   });
 
-  it('should not pass alarmEvent to updateStationNotification when sleepMode is false', async () => {
+  it('does not pass alarmEvent to updateStationNotification when sleepMode is false', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
-    mockCalculateStaticETA.mockReturnValue(10);
+    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+    await call();
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 150, mockDestination, mockRoute, 10,
-      undefined, null,
+      mockStation, 150, mockDestination, mockRoute, 10, undefined, null,
     );
   });
 
-  it('should call calculateStaticETA with route', async () => {
+  it('returns alarmEvent and nearest in result', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
+    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
-
-    expect(mockCalculateStaticETA).toHaveBeenCalledWith(mockRoute);
-  });
-
-  it('should return alarmEvent and nearest in result', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
-    mockAlarmKey.mockReturnValue('destination:시청');
-
-    const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false,
-    );
+    const result = await call();
 
     expect(result.alarmEvent).toBe(mockAlarmEvent);
     expect(result.nearest).toBe(mockNearestResult);
   });
 
-  it('should return null alarmEvent and nearest result when no alarm', async () => {
+  it('returns null alarm when evaluator returns null', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
-    const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false,
-    );
+    const result = await call();
 
     expect(result.alarmEvent).toBeNull();
     expect(result.nearest).toBe(mockNearestResult);
   });
 
-  it('should round distanceKm to meters correctly', async () => {
-    const nearestWithFraction: NearestStationResult = {
-      station: mockStation,
-      distanceKm: 0.4567,
-    };
-    mockFindNearestStation.mockReturnValue(nearestWithFraction);
+  it('rounds distanceKm to meters correctly', async () => {
+    mockFindNearestStation.mockReturnValue({ station: mockStation, distanceKm: 0.4567 });
     mockFindRoute.mockReturnValue(mockRoute);
     mockCalculateStaticETA.mockReturnValue(5);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
-
-    // Math.round(0.4567 * 1000) = 457
-    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 457, mockDestination, mockRoute, 5,
-      undefined, null,
-    );
-  });
-
-  it('should not call alarmKey in processLocationUpdate (responsibility moved to caller)', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
-
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
-
-    expect(mockAlarmKey).not.toHaveBeenCalled();
-  });
-
-  it('should use null route correctly when findRoute returns null', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(null);
-    mockCalculateStaticETA.mockReturnValue(null);
-
-    const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false,
-    );
+    await call();
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 150, mockDestination, null, null,
-      undefined, null,
+      mockStation, 457, mockDestination, mockRoute, 5, undefined, null,
     );
-    expect(result.nearest).toBe(mockNearestResult);
   });
 
-  it('should check time-based alarm when stop-count alarm is null', async () => {
+  it('falls back to findRoute when storedRoute exists but updateRouteFromPosition returns null', async () => {
+    const storedRoute: DirectRoute = { type: 'direct', stops: 5 };
     mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockUpdateRouteFromPosition.mockReturnValue(null);
     mockFindRoute.mockReturnValue(mockRoute);
-    const timeEvent: AlarmEvent = { type: 'destination', stationName: '시청', timeBased: true };
-    mockCheckTimeBasedAlarm.mockReturnValue(timeEvent);
 
-    const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false,
-    );
+    await call({ storedRoute });
 
-    expect(mockCheckTimeBasedAlarm).toHaveBeenCalledWith(
-      '시청', 3, '시청', mockRoute, expect.any(Set),
-    );
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('destination', '시청', false, true, true);
-    expect(result.alarmEvent).toBe(timeEvent);
+    expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
+    expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
   });
 
-  it('should skip time-based alarm when stop-count alarm already exists', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockCheckAlarm.mockReturnValue(mockAlarmEvent);
-
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
-
-    expect(mockCheckTimeBasedAlarm).not.toHaveBeenCalled();
-  });
-
-  it('should pass timeBased flag to sendAlarmNotification for time-based alarm with sleepMode', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    const timeEvent: AlarmEvent = { type: 'transfer', stationName: '동대문', timeBased: true };
-    mockCheckTimeBasedAlarm.mockReturnValue(timeEvent);
-
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), true);
-
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith('transfer', '동대문', true, true, true);
-    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 150, mockDestination, mockRoute, 10, undefined, timeEvent,
-    );
-  });
-
-  it('should not check time-based alarm when route is null', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(null);
-    mockCalculateStaticETA.mockReturnValue(null);
-
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
-
-    expect(mockCheckTimeBasedAlarm).not.toHaveBeenCalled();
-  });
-
-  it('should use updateRouteFromPosition result when storedRoute is provided and succeeds', async () => {
+  it('uses updateRouteFromPosition result when storedRoute is provided and succeeds', async () => {
     const storedRoute: DirectRoute = { type: 'direct', stops: 5 };
     const updatedRoute: DirectRoute = { type: 'direct', stops: 3 };
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockUpdateRouteFromPosition.mockReturnValue(updatedRoute);
     mockCalculateStaticETA.mockReturnValue(6);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, true, storedRoute);
+    await call({ storedRoute });
 
     expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
     expect(mockFindRoute).not.toHaveBeenCalled();
     expect(mockCalculateStaticETA).toHaveBeenCalledWith(updatedRoute);
   });
 
-  it('should fall back to findRoute when storedRoute is provided but updateRouteFromPosition returns null', async () => {
-    const storedRoute: DirectRoute = { type: 'direct', stops: 5 };
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockUpdateRouteFromPosition.mockReturnValue(null);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockCalculateStaticETA.mockReturnValue(6);
-
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false, true, storedRoute);
-
-    expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
-    expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
-  });
-
-  it('should call findRoute when no storedRoute is provided (default null)', async () => {
+  it('calls findRoute when no storedRoute is provided', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
-    await processLocationUpdate(37.498, 127.028, mockDestination, new Set(), false);
+    await call();
 
     expect(mockUpdateRouteFromPosition).not.toHaveBeenCalled();
     expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
   });
 
-  it('should send station-passed notification when station changes', async () => {
+  it('sends station-passed notification when station changes', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
-    const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false, true, null, 'other-station',
-    );
+    const result = await call({ lastNotifiedStationId: 'other-station' });
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
     expect(result.lastNotifiedStationId).toBe('station-1');
   });
 
-  it('should not send station-passed notification when station is the same', async () => {
+  it('does not send station-passed notification when station is the same', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
-    const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false, true, null, 'station-1',
-    );
+    const result = await call({ lastNotifiedStationId: 'station-1' });
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     expect(result.lastNotifiedStationId).toBe('station-1');
   });
 
-  it('should send station-passed notification when lastNotifiedStationId is null', async () => {
+  it('sends station-passed notification when lastNotifiedStationId is null', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
-    const result = await processLocationUpdate(
-      37.498, 127.028, mockDestination, new Set(), false, true, null, null,
-    );
+    const result = await call({ lastNotifiedStationId: null });
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
     expect(result.lastNotifiedStationId).toBe('station-1');
   });
+
+  it('does not mutate firedAlarms (responsibility moved to caller)', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+    const firedAlarms = new Set<string>();
+    await call({ firedAlarms });
+
+    expect(firedAlarms.size).toBe(0);
+    expect(mockAlarmKey).not.toHaveBeenCalled();
+  });
+
+  it('handles null route gracefully', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(null);
+    mockCalculateStaticETA.mockReturnValue(null);
+
+    const result = await call();
+
+    expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+      mockStation, 150, mockDestination, null, null, undefined, null,
+    );
+    expect(result.nearest).toBe(mockNearestResult);
+  });
 });
 
 describe('resolveNextTarget', () => {
-  it('should return null for null route', () => {
+  it('returns null for null route', () => {
     expect(resolveNextTarget(null, '강남')).toBeNull();
   });
 
-  it('should return destination and stops for direct route', () => {
+  it('returns destination and stops for direct route', () => {
     const route: DirectRoute = { type: 'direct', stops: 5 };
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
@@ -515,7 +326,7 @@ describe('resolveNextTarget', () => {
     });
   });
 
-  it('should return transfer station for transfer route with stopsToTransfer > 0', () => {
+  it('returns transfer station for transfer route with stopsToTransfer > 0', () => {
     const route: TransferRoute = {
       type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
       stopsToTransfer: 3, stopsFromTransfer: 2,
@@ -526,7 +337,7 @@ describe('resolveNextTarget', () => {
     });
   });
 
-  it('should return destination for transfer route with stopsToTransfer = 0', () => {
+  it('returns destination for transfer route with stopsToTransfer = 0', () => {
     const route: TransferRoute = {
       type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
       stopsToTransfer: 0, stopsFromTransfer: 2,
@@ -537,7 +348,7 @@ describe('resolveNextTarget', () => {
     });
   });
 
-  it('should return first transfer for multi-transfer route with stopsToTransfer > 0', () => {
+  it('returns first transfer for multi-transfer route with stopsToTransfer > 0', () => {
     const route: MultiTransferRoute = {
       type: 'multi-transfer',
       transfers: [
@@ -552,7 +363,7 @@ describe('resolveNextTarget', () => {
     });
   });
 
-  it('should return second transfer when first has stopsToTransfer = 0', () => {
+  it('returns second transfer when first has stopsToTransfer = 0', () => {
     const route: MultiTransferRoute = {
       type: 'multi-transfer',
       transfers: [
@@ -567,12 +378,12 @@ describe('resolveNextTarget', () => {
     });
   });
 
-  it('should return null for unknown route type', () => {
+  it('returns null for unknown route type', () => {
     const route = { type: 'unknown' } as unknown as Route;
     expect(resolveNextTarget(route, '강남')).toBeNull();
   });
 
-  it('should return destination when all transfers have stopsToTransfer = 0', () => {
+  it('returns destination when all transfers have stopsToTransfer = 0', () => {
     const route: MultiTransferRoute = {
       type: 'multi-transfer',
       transfers: [

--- a/src/utils/alarmPhases.ts
+++ b/src/utils/alarmPhases.ts
@@ -1,0 +1,28 @@
+export type AlarmPhaseId = 'early' | 'imminent';
+
+export interface AlarmContext {
+  remainingStops: number;
+  etaSeconds: number | null;
+}
+
+export interface AlarmPhase {
+  readonly id: AlarmPhaseId;
+  readonly evaluate: (ctx: AlarmContext) => boolean;
+}
+
+const APPROACH_STOPS = 1;
+const IMMINENT_ETA_SECONDS = 10;
+
+export const ALARM_PHASES: AlarmPhase[] = [
+  {
+    id: 'early',
+    evaluate: (ctx) => ctx.remainingStops <= APPROACH_STOPS,
+  },
+  {
+    id: 'imminent',
+    evaluate: (ctx) =>
+      ctx.remainingStops <= APPROACH_STOPS &&
+      ctx.etaSeconds !== null &&
+      ctx.etaSeconds <= IMMINENT_ETA_SECONDS,
+  },
+];

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -1,36 +1,27 @@
 import type { Route } from './stationRoute';
+import { ALARM_PHASES, type AlarmContext, type AlarmPhase, type AlarmPhaseId } from './alarmPhases';
 
-export type AlarmType = 'destination' | 'transfer' | 'approaching';
+export type AlarmType = 'destination' | 'transfer';
 
 export interface AlarmEvent {
+  phaseId: AlarmPhaseId;
   type: AlarmType;
   stationName: string;
-  timeBased?: boolean;
 }
 
-const DEFAULT_THRESHOLD = 1;
-const SECONDS_PER_STOP = 120;
-const TIME_BASED_THRESHOLD_SECONDS = 30;
-
-export function alarmKey(event: AlarmEvent): string {
-  const prefix = event.timeBased ? 'time-' : '';
-  return `${prefix}${event.type}:${event.stationName}`;
-}
-
-export function estimateRemainingSeconds(stops: number): number {
-  return stops * SECONDS_PER_STOP;
+export function alarmKey(event: Pick<AlarmEvent, 'phaseId' | 'stationName'>): string {
+  return `${event.phaseId}:${event.stationName}`;
 }
 
 export interface CurrentTarget {
   name: string;
   stops: number;
-  alarmType: 'transfer' | 'destination';
+  alarmType: AlarmType;
 }
 
 /**
  * 경로의 모든 웨이포인트(환승역 + 도착역)를 경로 순서대로 반환한다.
- * checkAlarm이 이 목록을 순회하며, 이미 발생한 알람은 건너뛰고 다음 타겟을 평가한다.
- * 환승 횟수에 의존하지 않고 transfers 배열을 순회하므로 N번 환승까지 확장 가능하다.
+ * transfers 배열을 순회하므로 N번 환승까지 확장 가능하다.
  */
 export function resolveAllTargets(
   route: NonNullable<Route>,
@@ -50,72 +41,64 @@ export function resolveAllTargets(
     ];
   }
 
-  // multi-transfer: 모든 웨이포인트를 순서대로 반환
   const targets: CurrentTarget[] = route.transfers.map((t) => {
-    const alarmType = t.transferName === destinationName ? 'destination' as const : 'transfer' as const;
-    return { name: t.transferName === destinationName ? destinationName : t.transferName, stops: t.stopsToTransfer, alarmType };
+    const isDestination = t.transferName === destinationName;
+    return {
+      name: isDestination ? destinationName : t.transferName,
+      stops: t.stopsToTransfer,
+      alarmType: isDestination ? 'destination' : 'transfer',
+    };
   });
-  targets.push({ name: destinationName, stops: route.stopsAfterLastTransfer, alarmType: 'destination' });
+  const lastTransferIsDestination = targets[targets.length - 1]?.name === destinationName;
+  if (!lastTransferIsDestination) {
+    targets.push({ name: destinationName, stops: route.stopsAfterLastTransfer, alarmType: 'destination' });
+  }
   return targets;
 }
 
-
-export function checkAlarm(
-  route: Route,
-  destinationName: string,
-  firedAlarms: Set<string>,
-  threshold: number = DEFAULT_THRESHOLD,
-): AlarmEvent | null {
-  if (!route) return null;
-
-  const targets = resolveAllTargets(route, destinationName);
-  for (const target of targets) {
-    const event: AlarmEvent = { type: target.alarmType, stationName: target.name };
-    const key = alarmKey(event);
-    if (firedAlarms.has(key)) continue;
-    if (target.stops > threshold) return null;
-    return event;
-  }
-  return null;
+export interface AlarmSource {
+  route: Route;
+  destinationName: string;
+  etaSeconds: number | null;
 }
 
-function resolveStationType(
-  nextStationName: string,
-  destinationName: string,
-  route: NonNullable<Route>,
-): AlarmType {
-  if (nextStationName === destinationName) return 'destination';
+/**
+ * 경로상 웨이포인트를 순회하며 phase 조건을 평가한다.
+ *
+ * - etaSeconds는 최종 목적지 웨이포인트에만 적용된다 (GPS 거리 산출이 도착역 기준이므로).
+ *   환승역은 정거장 수 기반(early) 으로만 평가된다.
+ * - 어느 phase도 발사되지 않은 fresh 웨이포인트에서 트리거가 없으면 null을 반환한다.
+ *   이미 한 번이라도 발사된 웨이포인트는 통과한 것으로 간주하고 다음으로 진행한다.
+ *   환승 전 도착역 알람이 먼저 울리는 것을 막는다 (#152 회귀 방지).
+ */
+export function evaluateAlarmPhase(
+  source: AlarmSource,
+  firedAlarms: Set<string>,
+  phases: AlarmPhase[] = ALARM_PHASES,
+): AlarmEvent | null {
+  if (!source.route) return null;
 
-  if (route.type === 'transfer') {
-    if (nextStationName === route.transferName) return 'transfer';
-  }
+  const targets = resolveAllTargets(source.route, source.destinationName);
 
-  if (route.type === 'multi-transfer') {
-    for (const t of route.transfers) {
-      if (nextStationName === t.transferName) return 'transfer';
+  for (let i = 0; i < targets.length; i++) {
+    const target = targets[i];
+    const isFinal = i === targets.length - 1;
+
+    const context: AlarmContext = {
+      remainingStops: target.stops,
+      etaSeconds: isFinal ? source.etaSeconds : null,
+    };
+
+    for (const phase of phases) {
+      const key = `${phase.id}:${target.name}`;
+      if (firedAlarms.has(key)) continue;
+      if (!phase.evaluate(context)) continue;
+      return { phaseId: phase.id, type: target.alarmType, stationName: target.name };
     }
+
+    const anyFired = phases.some((p) => firedAlarms.has(`${p.id}:${target.name}`));
+    if (!anyFired) return null;
   }
 
-  return 'approaching';
-}
-
-export function checkTimeBasedAlarm(
-  nextStationName: string | null,
-  stopsToNextStation: number,
-  destinationName: string,
-  route: Route,
-  firedAlarms: Set<string>,
-  thresholdSeconds: number = TIME_BASED_THRESHOLD_SECONDS,
-): AlarmEvent | null {
-  if (!nextStationName || !route) return null;
-
-  if (estimateRemainingSeconds(stopsToNextStation) > thresholdSeconds) return null;
-
-  const type = resolveStationType(nextStationName, destinationName, route);
-  const event: AlarmEvent = { type, stationName: nextStationName, timeBased: true };
-
-  const key = alarmKey(event);
-  if (firedAlarms.has(key)) return null;
-
-  return event;
+  return null;
 }

--- a/src/utils/stationEta.ts
+++ b/src/utils/stationEta.ts
@@ -1,0 +1,21 @@
+import { haversine } from './haversine';
+
+// 0.5m/s 미만은 GPS 정지 노이즈로 간주. 역 진입 시 감속(1~5m/s)은 통과시켜 imminent phase가 동작하도록 한다.
+const MIN_VALID_SPEED_MPS = 0.5;
+
+export function estimateEtaSeconds(
+  distanceMeters: number,
+  speedMps: number | null,
+): number | null {
+  if (speedMps === null || speedMps < MIN_VALID_SPEED_MPS) return null;
+  return distanceMeters / speedMps;
+}
+
+export function distanceMetersBetween(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+): number {
+  return haversine(fromLat, fromLng, toLat, toLng) * 1000;
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -272,34 +272,33 @@ export async function sendStationPassedNotification(
   notifLogger.info('역 통과 알림:', stationName, body);
 }
 
+import type { AlarmPhaseId } from './alarmPhases';
+
+const ALARM_MESSAGE_BUILDERS: Record<AlarmPhaseId, (stationName: string, isTransfer: boolean) => { title: string; body: string }> = {
+  early: (stationName, isTransfer) => ({
+    title: isTransfer ? '환승 알림' : '하차 알림',
+    body: isTransfer
+      ? `다음 역 ${stationName}에서 환승하세요!`
+      : `다음 역 ${stationName}에서 내리세요!`,
+  }),
+  imminent: (stationName, isTransfer) => ({
+    title: isTransfer ? '환승 임박' : '도착 임박',
+    body: isTransfer
+      ? `곧 ${stationName}에 도착합니다. 환승 준비하세요!`
+      : `곧 ${stationName}에 도착합니다. 하차 준비하세요!`,
+  }),
+};
+
+function buildAlarmContent(event: AlarmEvent): { title: string; body: string } {
+  return ALARM_MESSAGE_BUILDERS[event.phaseId](event.stationName, event.type === 'transfer');
+}
+
 export async function sendAlarmNotification(
-  type: 'destination' | 'transfer' | 'approaching',
-  stationName: string,
+  event: AlarmEvent,
   sleepMode: boolean = false,
-  timeBased: boolean = false,
   allowSpeaker: boolean = true,
 ): Promise<void> {
-  let title: string;
-  let body: string;
-
-  if (timeBased) {
-    if (type === 'transfer') {
-      title = '환승 임박';
-      body = `곧 ${stationName}에 도착합니다. 환승 준비하세요!`;
-    } else if (type === 'destination') {
-      title = '도착 임박';
-      body = `곧 ${stationName}에 도착합니다. 하차 준비하세요!`;
-    } else {
-      title = '역 접근';
-      body = `곧 ${stationName}에 도착합니다.`;
-    }
-  } else {
-    const isTransfer = type === 'transfer';
-    title = isTransfer ? '환승 알림' : '하차 알림';
-    body = isTransfer
-      ? `다음 역 ${stationName}에서 환승하세요!`
-      : `다음 역 ${stationName}에서 내리세요!`;
-  }
+  const { title, body } = buildAlarmContent(event);
 
   await scheduleNotification(ALARM_NOTIFICATION_ID, {
     title,

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -1,12 +1,11 @@
 import { findNearestStation } from './findNearestStation';
 import { findRoute, calculateStaticETA, updateRouteFromPosition } from './stationRoute';
-import { checkAlarm, checkTimeBasedAlarm } from './stationAlarm';
+import { evaluateAlarmPhase } from './stationAlarm';
 import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
+import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
 import type { AlarmEvent } from './stationAlarm';
-
-// ── 순수 함수: 포그라운드/백그라운드 공용 ──
 
 export interface NextTarget {
   nextStationName: string;
@@ -39,55 +38,37 @@ export function resolveNextTarget(route: Route, destinationName: string): NextTa
   return null;
 }
 
-/**
- * 통합 알람 평가: 정거장 수 기반(우선) + 시간 기반(보조).
- * 포그라운드(useStationAlarm)와 백그라운드(processLocationUpdate) 모두 이 함수를 사용한다.
- * 주의: firedAlarms를 변경하지 않는다. 알람 발생 후 키 추가는 호출자 책임이다.
- */
-export function evaluateAllAlarms(
-  route: Route,
-  destinationName: string,
-  firedAlarms: Set<string>,
-): AlarmEvent | null {
-  if (!route) return null;
-
-  // 1) 정거장 수 기반 알람 (우선)
-  const stopAlarm = checkAlarm(route, destinationName, firedAlarms);
-  if (stopAlarm) return stopAlarm;
-
-  // 2) 시간 기반 알람 (보조)
-  const target = resolveNextTarget(route, destinationName);
-  if (target && target.stopsToNextStation > 0) {
-    return checkTimeBasedAlarm(
-      target.nextStationName,
-      target.stopsToNextStation,
-      destinationName,
-      route,
-      firedAlarms,
-    );
-  }
-
-  return null;
-}
-
-// ── 비동기 파이프라인: 백그라운드 태스크 전용 (부수효과 포함) ──
-
 export interface PipelineResult {
   alarmEvent: AlarmEvent | null;
   nearest: NearestStationResult | null;
   lastNotifiedStationId: string | null;
 }
 
-export async function processLocationUpdate(
-  lat: number,
-  lng: number,
-  destination: Station,
-  firedAlarms: Set<string>,
-  sleepMode: boolean,
-  allowSpeaker: boolean = true,
-  storedRoute: Route = null,
-  lastNotifiedStationId: string | null = null,
-): Promise<PipelineResult> {
+export interface ProcessLocationInputs {
+  lat: number;
+  lng: number;
+  destination: Station;
+  firedAlarms: Set<string>;
+  sleepMode: boolean;
+  allowSpeaker?: boolean;
+  storedRoute?: Route;
+  lastNotifiedStationId?: string | null;
+  speedMps?: number | null;
+}
+
+export async function processLocationUpdate(inputs: ProcessLocationInputs): Promise<PipelineResult> {
+  const {
+    lat,
+    lng,
+    destination,
+    firedAlarms,
+    sleepMode,
+    allowSpeaker = true,
+    storedRoute = null,
+    lastNotifiedStationId = null,
+    speedMps = null,
+  } = inputs;
+
   const nearest = findNearestStation(lat, lng);
   if (!nearest) return { alarmEvent: null, nearest: null, lastNotifiedStationId };
 
@@ -98,19 +79,19 @@ export async function processLocationUpdate(
   if (!route) {
     route = findRoute(nearest.station.id, destination.id);
   }
-  const alarmEvent = evaluateAllAlarms(route, destination.name, firedAlarms);
+
+  const distanceToDestM = distanceMetersBetween(lat, lng, destination.lat, destination.lng);
+  const etaSeconds = estimateEtaSeconds(distanceToDestM, speedMps);
+
+  const alarmEvent = evaluateAlarmPhase(
+    { route, destinationName: destination.name, etaSeconds },
+    firedAlarms,
+  );
 
   if (alarmEvent) {
-    await sendAlarmNotification(
-      alarmEvent.type,
-      alarmEvent.stationName,
-      sleepMode,
-      alarmEvent.timeBased ?? false,
-      allowSpeaker,
-    );
+    await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker);
   }
 
-  // 역 변경 감지 → per-station 알림
   let newLastNotifiedStationId = lastNotifiedStationId;
   if (nearest.station.id !== lastNotifiedStationId) {
     newLastNotifiedStationId = nearest.station.id;


### PR DESCRIPTION
## Summary

도착/환승 알람이 역에 진입한 직후에야 발사되던 문제를 phase 데이터 주도로 재설계.

- **early phase**: 환승/도착역 **1정거장 전** 사전 안내 (정거장 수 기반)
- **imminent phase**: 해당 역 **도착 5~10초 전** 임박 알림 (GPS 거리 + 속도 기반 ETA)
- 새 phase 추가는 `ALARM_PHASES` 배열에 객체 push만으로 가능 — 데이터 주도

## Root cause

1. `stationAlarm.ts`의 `DEFAULT_THRESHOLD=1` 단일 임계값으로만 평가
2. stops / seconds가 `checkAlarm` / `checkTimeBasedAlarm` 별도 함수로 분리
3. `SECONDS_PER_STOP=120` 추정만 사용, 실제 GPS 속도/거리 미활용

## 설계

### AlarmPhase 데이터 주도 (\`src/utils/alarmPhases.ts\`)
\`\`\`ts
export const ALARM_PHASES: AlarmPhase[] = [
  { id: 'early',    evaluate: (ctx) => ctx.remainingStops <= 1 },
  { id: 'imminent', evaluate: (ctx) =>
      ctx.remainingStops <= 1 && ctx.etaSeconds !== null && ctx.etaSeconds <= 10 },
];
\`\`\`

### ETA 추정 (\`src/utils/stationEta.ts\`)
- GPS 거리(\`haversine\`) × 속도(\`Location.coords.speed\`)
- 0.5 m/s 미만은 정지 노이즈로 간주, 역 진입 감속(1~5 m/s) 구간은 통과

### Evaluator 통합 (\`src/utils/stationAlarm.ts\`)
- \`checkAlarm\` / \`checkTimeBasedAlarm\` / \`evaluateAllAlarms\` 3-함수 분리 → \`evaluateAlarmPhase\` 단일 함수
- 외부 신호(etaSeconds)는 최종 목적지 웨이포인트에만 적용 (GPS 거리는 도착역 기준)
- #152 회귀 방지: fresh 웨이포인트에서 어떤 phase도 발사 안 되면 이후 웨이포인트로 진행하지 않음

### 메시지 분기를 데이터 주도로 (\`stationNotification.ts\`)
\`Record<AlarmPhaseId, builder>\` 패턴으로 새 phase 추가 시 컴파일 타임에 누락 강제.

## 변경 파일
- 신규: \`alarmPhases.ts\`, \`stationEta.ts\` + 테스트
- 수정: \`stationAlarm.ts\`, \`stationPipeline.ts\`, \`stationNotification.ts\`, \`useStationAlarm.ts\`, \`useNearestStation.ts\`, \`backgroundLocationTask.ts\`, \`app/(tabs)/index.tsx\`
- 호출부 시그니처: positional → 객체 인자

## 코드 리뷰 반영
- 🔴 \`arrivalSignal\` 데드코드 제거 (후속 이슈에서 도착정보 API 연결)
- 🟡 multi-transfer 마지막 transfer == destination 중복 가드
- 🟡 ETA 속도 임계값 1 → 0.5 m/s (감속 진입 살리기)
- 🟢 \`Record<AlarmPhaseId, ...>\` exhaustive 강제

## 관련 이슈
- #189 (백그라운드 위치 batching 제거) — dev 머지 완료, 본 PR에 통합됨

## Test plan
- [x] 단위 테스트 643개 통과
- [x] 커버리지 100% 유지 (lines/functions/branches/statements)
- [x] \`npm run type-check\` 통과
- [x] 자동 코드 리뷰 2차 통과 (P0/P1 없음)
- [ ] 실기기: 지하철 1정거장 전 알람 1회 + 도착 5~10초 전 알람 1회 발사 확인 (백그라운드/포그라운드)
- [ ] 환승 + 도착 시나리오, 환승 2회 시나리오

Closes #190