### PR TITLE
chore(#198): 버전 단일 진실원천화 + 1.0.1 릴리스

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,7 @@
+const appJson = require('./app.json');
+const pkg = require('./package.json');
+
+module.exports = {
+  ...appJson.expo,
+  version: pkg.version,
+};

--- a/app.json
+++ b/app.json
@@ -2,7 +2,6 @@
   "expo": {
     "name": "subway-now",
     "slug": "subway-now",
-    "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -66,6 +65,7 @@
         }
       ],
       "expo-router",
+      "expo-localization",
       "./modules/live-activity/app.plugin.js",
       "@bacons/apple-targets"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## 배경

App Store 업로드 시 ITMS-90062/90186 오류(`CFBundleShortVersionString 1.0.0`이 이미 승인됨, TestFlight `1.0.0` 트레인 닫힘)로 인해 새 마케팅 버전이 필요합니다.

기존에는 버전 문자열이 `package.json` / `app.json` / `Info.plist` / `pbxproj` 4곳에 분산되어 매 릴리스마다 손으로 맞춰야 했습니다.

## 변경 사항

1. **`app.config.js` 신규** — `app.json`의 expo 객체를 spread하고 `version`은 `package.json.version`으로 override
2. **`app.json`의 `version: "1.0.0"` 키 제거** — `app.config.js`가 진실원천이므로 중복 제거
3. **`package.json` 1.0.0 → 1.0.1** (`npm version patch` 사용)

### 향후 릴리스 절차

```bash
npm version patch -m "chore(#N): bump version to %s"
eas build --profile production --platform ios
eas submit --platform ios --latest
```

- `ios/`는 `.gitignore`되어 EAS가 빌드 시 자동 prebuild → native 동기화 자동
- buildNumber는 `eas.json`의 `appVersionSource: "remote"` + `autoIncrement: true`로 EAS가 관리

## 검증

- `node -e "console.log(require('./app.config.js').version)"` → `1.0.1` ✅
- `npm run type-check` 통과 ✅
- `npm test` 680 tests, 커버리지 100% 통과 ✅

Closes #198