### PR TITLE
feat(#201): 앱 표시 이름 한국어 현지화 — 지금 어디

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,10 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": false,
+    "locales": {
+      "ko": "./locales/ko.json",
+      "en": "./locales/en.json"
+    },
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,9 @@
+{
+  "ios": {
+    "CFBundleDisplayName": "subway-now",
+    "CFBundleName": "subway-now"
+  },
+  "android": {
+    "app_name": "subway-now"
+  }
+}

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -1,0 +1,9 @@
+{
+  "ios": {
+    "CFBundleDisplayName": "지금 어디",
+    "CFBundleName": "지금 어디"
+  },
+  "android": {
+    "app_name": "지금 어디"
+  }
+}


### PR DESCRIPTION
## Summary

출시된 앱의 표시 이름이 영문 `subway-now` 단일값이라 한국어 사용자에게 친숙하지 않다. 한국어 기기에는 "지금 어디", 영문 기기에는 기존 "subway-now"를 노출하도록 현지화.

## 변경

- `app.json` 에 `expo.locales` 키 추가 (`ko`, `en`)
- `locales/ko.json`, `locales/en.json` 신규 (플랫폼 분기 구조)
- iOS는 `CFBundleDisplayName`/`CFBundleName`, Android는 `app_name` 만 각자 출력 — dead key 없음

## 설계 근거

- `ios/`, `android/` 는 git ignore이고 EAS Build 가 매번 prebuild 로 재생성하므로 `app.json` 레벨 처리가 영구 반영을 보장
- `@expo/config-plugins` 의 `LocaleJson` 타입(`utils/locales.d.ts`)이 `ios?` / `android?` 분기를 1급 시민으로 정의 → 평탄 키 방식 대신 분기 구조 채택 (코드 리뷰 P1-1 반영)

## 검증

- [x] `npx expo prebuild --clean --platform ios` → `ios/subwaynow/Supporting/ko.lproj/InfoPlist.strings` 정상 생성 (`CFBundleDisplayName`, `CFBundleName` 만)
- [x] `npx expo prebuild --clean --platform android` → `android/app/src/main/res/values-b+ko/strings.xml` 정상 생성 (`app_name` 만)
- [x] `npm test` — 48 suites / 680 tests, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] `code-review` 에이전트 리뷰 P1-1 반영 (플랫폼 분기 구조로 dead key 제거)
- [ ] **실기기 검증 필요** — TestFlight 빌드 후 iOS 한국어/영어 기기에서 홈 화면 라벨 확인

## App Store / Google Play 콘솔 작업 (코드 외)

새 EAS 빌드 제출 시 사용자가 직접 수행:
- App Store Connect → 앱 정보 → 한국어 로컬라이제이션 → 이름 "지금 어디"
- Google Play Console → 스토어 등록정보 → 한국어 → 앱 이름 "지금 어디"

## 후속 작업 (별도 이슈 권장)

- 위젯 `configurationDisplayName("지하철 현재 역")` 등 `targets/subway-widget/SubwayWidget.swift:124-125` 의 한국어 하드코딩을 다국어화
- 스플래시 placeholder 이미지 교체 (별도 이슈 진행 예정)

Closes #201