### PR TITLE
feat(#204): i18n Phase 2 — UI 정적 텍스트 추출 & 교체

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,11 @@
 import { Tabs } from 'expo-router';
 import { Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../src/theme';
 
 export default function TabsLayout() {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   return (
     <Tabs
       screenOptions={{
@@ -19,28 +21,28 @@ export default function TabsLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: '현재 역',
+          title: t('tabs.current'),
           tabBarIcon: ({ color }) => <Text style={{ fontSize: 20, color }}>🚇</Text>,
         }}
       />
       <Tabs.Screen
         name="map"
         options={{
-          title: '지도',
+          title: t('tabs.map'),
           tabBarIcon: ({ color }) => <Text style={{ fontSize: 20, color }}>🗺️</Text>,
         }}
       />
       <Tabs.Screen
         name="favorites"
         options={{
-          title: '즐겨찾기',
+          title: t('tabs.favorites'),
           tabBarIcon: ({ color }) => <Text style={{ fontSize: 20, color }}>⭐</Text>,
         }}
       />
       <Tabs.Screen
         name="settings"
         options={{
-          title: '설정',
+          title: t('tabs.settings'),
           tabBarIcon: ({ color }) => <Text style={{ fontSize: 20, color }}>⚙️</Text>,
         }}
       />

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../src/store/useAppStore';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { Station } from '../../src/types/station';
@@ -27,6 +28,7 @@ export default function FavoritesScreen() {
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadFavorites();
@@ -54,11 +56,11 @@ export default function FavoritesScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
       <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
-        <Text style={[styles.header, { color: colors.muted }]}>즐겨찾기</Text>
+        <Text style={[styles.header, { color: colors.muted }]}>{t('favorites.title')}</Text>
 
         <TextInput
           style={[styles.searchInput, { backgroundColor: colors.card, color: colors.ink, borderColor: colors.hair }]}
-          placeholder="역 이름 검색..."
+          placeholder={t('favorites.searchPlaceholder')}
           placeholderTextColor={colors.muted}
           value={query}
           onChangeText={setQuery}
@@ -68,7 +70,7 @@ export default function FavoritesScreen() {
         {isSearching ? (
           searchResults.length === 0 ? (
             <View style={styles.empty}>
-              <Text style={[styles.emptyTitle, { color: colors.ink }]}>검색 결과가 없습니다</Text>
+              <Text style={[styles.emptyTitle, { color: colors.ink }]}>{t('favorites.noSearchResults')}</Text>
             </View>
           ) : (
             searchResults.map((station) => (
@@ -84,9 +86,9 @@ export default function FavoritesScreen() {
         ) : favorites.length === 0 ? (
           <View style={styles.empty} testID="favorites-empty">
             <Text style={styles.emptyIcon}>⭐</Text>
-            <Text style={[styles.emptyTitle, { color: colors.ink }]}>즐겨찾기가 없습니다</Text>
+            <Text style={[styles.emptyTitle, { color: colors.ink }]}>{t('favorites.empty')}</Text>
             <Text style={[styles.emptySubtitle, { color: colors.muted }]}>
-              위 검색창에서 역을 검색해 즐겨찾기에{'\n'}추가할 수 있습니다.
+              {t('favorites.emptyDescription')}
             </Text>
           </View>
         ) : (
@@ -156,6 +158,7 @@ function FavoriteCard({
   onRemove: () => void;
   colors: ThemeColors;
 }) {
+  const { t } = useTranslation();
   return (
     <View style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}>
       <TouchableOpacity style={styles.cardMain} onPress={onToggle} activeOpacity={0.7}>
@@ -168,7 +171,7 @@ function FavoriteCard({
         <View style={styles.cardActions}>
           <Text style={[styles.expandIcon, { color: colors.muted }]}>{isExpanded ? '▲' : '▼'}</Text>
           <TouchableOpacity style={[styles.removeButton, { backgroundColor: colors.card }]} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
-            <Text style={[styles.removeText, { color: colors.danger }]}>삭제</Text>
+            <Text style={[styles.removeText, { color: colors.danger }]}>{t('favorites.remove')}</Text>
           </TouchableOpacity>
         </View>
       </TouchableOpacity>
@@ -178,17 +181,17 @@ function FavoriteCard({
           {arrival ? (
             <>
               {arrival.up.length > 0 && (
-                <ArrivalRow label="상행" items={arrival.up} colors={colors} />
+                <ArrivalRow label={t('arrival.upbound')} items={arrival.up} colors={colors} />
               )}
               {arrival.down.length > 0 && (
-                <ArrivalRow label="하행" items={arrival.down} colors={colors} />
+                <ArrivalRow label={t('arrival.downbound')} items={arrival.down} colors={colors} />
               )}
               {arrival.up.length === 0 && arrival.down.length === 0 && (
-                <Text style={[styles.noArrival, { color: colors.muted }]}>도착 정보 없음</Text>
+                <Text style={[styles.noArrival, { color: colors.muted }]}>{t('home.noArrivalInfo')}</Text>
               )}
             </>
           ) : (
-            <Text style={[styles.noArrival, { color: colors.muted }]}>불러오는 중...</Text>
+            <Text style={[styles.noArrival, { color: colors.muted }]}>{t('home.loading')}</Text>
           )}
         </View>
       )}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppState, InteractionManager, Pressable, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
+import { useTranslation } from 'react-i18next';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
@@ -27,6 +28,7 @@ const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   const { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh } = useNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
@@ -221,12 +223,12 @@ export default function HomeScreen() {
       <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
           <Text style={styles.icon}>📍</Text>
-          <Text style={[styles.title, { color: colors.ink }]}>위치 권한 필요</Text>
+          <Text style={[styles.title, { color: colors.ink }]}>{t('permissions.locationRequiredTitle')}</Text>
           <Text style={[styles.subtitle, { color: colors.muted }]}>
-            설정에서 위치 권한을 허용해 주세요.{'\n'}현재 탑승 중인 역을 감지하려면{'\n'}위치 권한이 필요합니다.
+            {t('permissions.locationRequiredDescription')}
           </Text>
           <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
-            <Text style={[styles.buttonText, { color: colors.onAccent }]}>다시 시도</Text>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('common.retry')}</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -237,7 +239,7 @@ export default function HomeScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={[styles.loadingText, { color: colors.muted }]}>위치 확인 중...</Text>
+          <Text style={[styles.loadingText, { color: colors.muted }]}>{t('permissions.locating')}</Text>
         </View>
       </SafeAreaView>
     );
@@ -249,7 +251,7 @@ export default function HomeScreen() {
         <View style={styles.center}>
           <Text style={[styles.errorText, { color: colors.accent }]}>{error}</Text>
           <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
-            <Text style={[styles.buttonText, { color: colors.onAccent }]}>새로고침</Text>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('home.refresh')}</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -262,7 +264,7 @@ export default function HomeScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
       {arrivedBanner && (
         <View style={[styles.arrivedBanner, { backgroundColor: colors.success }]} testID="arrived-banner">
-          <Text style={styles.arrivedBannerText}>도착!</Text>
+          <Text style={styles.arrivedBannerText}>{t('home.arrived')}</Text>
         </View>
       )}
       <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
@@ -273,13 +275,17 @@ export default function HomeScreen() {
               <Text style={[typography.mono, { color: colors.subtle }]}>
                 {new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
               </Text>
-              <Text style={[typography.label, { color: colors.subtle }]}>{isCustomOrigin ? '수동' : 'LIVE'}</Text>
+              <Text style={[typography.label, { color: colors.subtle }]}>{isCustomOrigin ? t('home.manual') : t('home.live')}</Text>
             </View>
 
             {/* Hero: origin station */}
             <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxxl - 4 }}>
               <Text style={[typography.label, { color: colors.muted, marginBottom: 10 }]}>
-                {isCustomOrigin ? '출발역 (수동)' : result && result.distanceKm <= 0.5 ? '현재역' : '가장 가까운 역'}
+                {isCustomOrigin
+                  ? t('home.originManual')
+                  : result && result.distanceKm <= 0.5
+                  ? t('home.originCurrent')
+                  : t('home.originNearest')}
               </Text>
               <View style={styles.heroRow}>
                 <Text style={[typography.hero, { color: colors.ink, flex: 1, fontWeight: '900' }]}>
@@ -318,7 +324,7 @@ export default function HomeScreen() {
                   onPress={() => setCustomOrigin(null)}
                   testID="gps-reset-button"
                 >
-                  <Text style={[styles.gpsResetText, { color: colors.accent }]}>GPS 모드로 전환</Text>
+                  <Text style={[styles.gpsResetText, { color: colors.accent }]}>{t('home.switchToGps')}</Text>
                 </TouchableOpacity>
               )}
             </View>
@@ -332,7 +338,7 @@ export default function HomeScreen() {
                   <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: spacing.xl }}>
                     <View>
                       <Text style={[typography.label, { color: colors.muted, marginBottom: 4 }]}>
-                        Route to
+                        {t('home.routeTo')}
                       </Text>
                       <Text style={{ fontSize: 32, fontWeight: '900', letterSpacing: -0.8, color: colors.ink }}>{destination.name}</Text>
                     </View>
@@ -344,7 +350,7 @@ export default function HomeScreen() {
                             <Text style={{ fontSize: 13, color: colors.muted }}> min</Text>
                           </Text>
                           <Text style={[typography.label, { color: colors.subtle, marginTop: 4 }]}>
-                            {isRealtimeEta ? 'EST' : '예상'} · {journey?.totalStops ?? 0} STOPS
+                            {isRealtimeEta ? 'EST' : t('home.estimatedSuffix')} · {journey?.totalStops ?? 0} STOPS
                           </Text>
                         </>
                       )}
@@ -365,8 +371,9 @@ export default function HomeScreen() {
                             }}
                           >
                             <Text style={[styles.routePillText, { color: active ? colors.onAccent : colors.muted }]}>
-                              {category.label}
+                              {t(`routes.${category.key}`)}
                             </Text>
+                            {/* 동적 포맷("N분 · M환승")은 Phase 3에서 i18n 처리 예정 */}
                             <Text style={[styles.routePillSub, { color: active ? colors.onAccent : colors.subtle }]}>
                               {candidate.travelMinutes}분 · {candidate.transferCount}환승
                             </Text>
@@ -384,12 +391,12 @@ export default function HomeScreen() {
                 <View style={styles.actionsRow}>
                   <Pressable onPress={() => setPickerVisible(true)}>
                     <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}>
-                      목적지 변경 →
+                      {t('home.destinationChange')}
                     </Text>
                   </Pressable>
                   <View style={[styles.vHair, { backgroundColor: colors.hair }]} />
                   <Pressable onPress={() => setDestination(null)} testID="destination-clear-button">
-                    <Text style={[typography.bodySm, { color: colors.muted }]}>초기화</Text>
+                    <Text style={[typography.bodySm, { color: colors.muted }]}>{t('home.destinationReset')}</Text>
                   </Pressable>
                 </View>
 
@@ -399,10 +406,10 @@ export default function HomeScreen() {
                 <View style={styles.sleepRow} testID="sleep-mode-row">
                   <View>
                     <Text style={[typography.bodySm, { color: colors.ink, fontWeight: '600' }]}>
-                      취침 모드
+                      {t('home.sleepMode')}
                     </Text>
                     <Text style={[typography.mono, { color: colors.muted, marginTop: 2 }]}>
-                      환승·도착 1정거장 전 진동 · 알림
+                      {t('home.sleepModeDescription')}
                     </Text>
                   </View>
                   <Switch
@@ -433,7 +440,7 @@ export default function HomeScreen() {
                     onPress={() => setDestination(recentDestination)}
                     testID="recent-destination-button"
                   >
-                    <Text style={[styles.recentDestinationLabel, { color: colors.accent }]}>이전 목적지</Text>
+                    <Text style={[styles.recentDestinationLabel, { color: colors.accent }]}>{t('home.previousDestination')}</Text>
                     <View style={styles.recentDestinationRow}>
                       <Text style={[styles.recentDestinationName, { color: colors.ink }]}>{recentDestination.name}</Text>
                       <View style={[styles.recentLineBadge, { backgroundColor: recentDestination.lineColor }]}>
@@ -447,24 +454,24 @@ export default function HomeScreen() {
                   onPress={() => setPickerVisible(true)}
                   testID="destination-button"
                 >
-                  <Text style={[styles.destinationButtonText, { color: colors.onAccent }]}>목적지 설정</Text>
+                  <Text style={[styles.destinationButtonText, { color: colors.onAccent }]}>{t('home.destinationSet')}</Text>
                 </TouchableOpacity>
               </View>
             )}
 
             {/* Arrivals — 기존 상행/하행 포맷 유지 */}
             <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
-              <Text style={[styles.sectionTitle, { color: colors.muted }]}>열차 도착 정보</Text>
+              <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('home.arrivalInfoTitle')}</Text>
               {arrivalLoading && !arrival && (
-                <Text style={[styles.arrivalItem, { color: colors.ink }]}>불러오는 중...</Text>
+                <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.loading')}</Text>
               )}
               {arrivalIsMock && (
-                <Text style={[styles.mockNotice, { color: colors.warn }]}>실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다</Text>
+                <Text style={[styles.mockNotice, { color: colors.warn }]}>{t('home.mockNotice')}</Text>
               )}
               {arrival && (
                 <>
-                  <ArrivalRow label="상행" items={arrival.up} />
-                  <ArrivalRow label="하행" items={arrival.down} />
+                  <ArrivalRow label={t('arrival.upbound')} items={arrival.up} />
+                  <ArrivalRow label={t('arrival.downbound')} items={arrival.down} />
                 </>
               )}
             </View>
@@ -472,10 +479,10 @@ export default function HomeScreen() {
         ) : (
           <View style={styles.center}>
             <Text style={styles.icon}>🚶</Text>
-            <Text style={[styles.title, { color: colors.ink }]}>지하철역 근처가 아닙니다</Text>
-            <Text style={[styles.subtitle, { color: colors.muted }]}>지하철역 500m 이내에 있을 때{'\n'}현재 역이 표시됩니다.{'\n'}지도 탭에서 출발역을 직접 설정할 수 있습니다.</Text>
+            <Text style={[styles.title, { color: colors.ink }]}>{t('home.notNearStationTitle')}</Text>
+            <Text style={[styles.subtitle, { color: colors.muted }]}>{t('home.notNearStationDescription')}</Text>
             <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
-              <Text style={[styles.buttonText, { color: colors.onAccent }]}>새로고침</Text>
+              <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('home.refresh')}</Text>
             </TouchableOpacity>
           </View>
         )}
@@ -509,12 +516,13 @@ function ArrivalRow({
   items: { destination: string; arrivalSeconds: number; statusMessage: string }[];
 }) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   return (
     <View style={[styles.arrivalRow, { borderTopColor: colors.hair }]}>
       <Text style={[styles.arrivalLabel, { color: colors.muted }]}>{label}</Text>
       <View>
         {items.length === 0 ? (
-          <Text style={[styles.arrivalItem, { color: colors.ink }]}>도착 정보 없음</Text>
+          <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.noArrivalInfo')}</Text>
         ) : (
           items.map((item, idx) => (
             <View key={idx} style={styles.arrivalItemContainer}>

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { StationMap } from '../../src/components/StationMap';
 import { LocationStateView } from '../../src/components/LocationStateView';
@@ -23,6 +24,7 @@ export default function MapScreen() {
   const setRecentDestination = useAppStore((s) => s.setRecentDestination);
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
   const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
 
   if (permissionDenied || loading || !userLocation || error) {
     return (
@@ -41,10 +43,10 @@ export default function MapScreen() {
       {(customOrigin || destination) && (
         <View style={[styles.statusBar, { backgroundColor: colors.card, borderBottomColor: colors.hair }]} testID="status-bar">
           {customOrigin && (
-            <StatusChip label="출발" name={customOrigin.name} onClear={() => setCustomOrigin(null)} testID="clear-origin" />
+            <StatusChip label={t('map.originBadge')} name={customOrigin.name} onClear={() => setCustomOrigin(null)} testID="clear-origin" />
           )}
           {destination && (
-            <StatusChip label="도착" name={destination.name} onClear={() => setDestination(null)} testID="clear-destination" />
+            <StatusChip label={t('map.destinationBadge')} name={destination.name} onClear={() => setDestination(null)} testID="clear-destination" />
           )}
         </View>
       )}
@@ -79,7 +81,7 @@ export default function MapScreen() {
               }}
               testID="set-origin-button"
             >
-              <Text style={[styles.selectionButtonText, { color: colors.onAccent }]}>출발역으로 설정</Text>
+              <Text style={[styles.selectionButtonText, { color: colors.onAccent }]}>{t('map.setAsOrigin')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.selectionButton, { borderWidth: 1, borderColor: colors.accent }]}
@@ -90,7 +92,7 @@ export default function MapScreen() {
               }}
               testID="set-destination-button"
             >
-              <Text style={[styles.selectionButtonText, { color: colors.accent }]}>도착역으로 설정</Text>
+              <Text style={[styles.selectionButtonText, { color: colors.accent }]}>{t('map.setAsDestination')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,16 +1,17 @@
 import { useEffect } from 'react';
 import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
 import { useAppStore, type ThemeMode } from '../../src/store/useAppStore';
 import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
-const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
-  { value: 'auto', label: '자동' },
-  { value: 'light', label: '라이트' },
-  { value: 'dark', label: '다크' },
-];
+const THEME_OPTIONS = [
+  { value: 'auto', labelKey: 'settings.themeAuto' },
+  { value: 'light', labelKey: 'settings.themeLight' },
+  { value: 'dark', labelKey: 'settings.themeDark' },
+] as const satisfies readonly { value: ThemeMode; labelKey: string }[];
 
 export default function SettingsScreen() {
   const sleepMode = useAppStore((s) => s.sleepMode);
@@ -26,6 +27,7 @@ export default function SettingsScreen() {
   const setRoutePreference = useAppStore((s) => s.setRoutePreference);
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
   const { colors } = useTheme();
+  const { t } = useTranslation();
   const showSleepModeGuide = useSleepModeGuide();
 
   useEffect(() => {
@@ -37,23 +39,23 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
-      <Text style={[styles.header, { color: colors.muted }]}>설정</Text>
+      <Text style={[styles.header, { color: colors.muted }]}>{t('settings.title')}</Text>
 
       {/* 테마 */}
       <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <Text style={[styles.sectionTitle, { color: colors.muted }]}>테마</Text>
+        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.themeSection')}</Text>
 
         <View style={styles.settingRow}>
           <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>다크 모드</Text>
+            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.themeLabel')}</Text>
             <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              자동은 기기 설정을 따릅니다
+              {t('settings.themeDescription')}
             </Text>
           </View>
         </View>
 
         <View style={[styles.segmentGroup, { backgroundColor: colors.hair }]} testID="theme-segment">
-          {THEME_OPTIONS.map(({ value, label }) => {
+          {THEME_OPTIONS.map(({ value, labelKey }) => {
             const active = themeMode === value;
             return (
               <Pressable
@@ -63,7 +65,7 @@ export default function SettingsScreen() {
                 testID={`theme-${value}`}
               >
                 <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
-                  {label}
+                  {t(labelKey)}
                 </Text>
               </Pressable>
             );
@@ -73,13 +75,13 @@ export default function SettingsScreen() {
 
       {/* 경로 */}
       <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <Text style={[styles.sectionTitle, { color: colors.muted }]}>경로</Text>
+        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.routeSection')}</Text>
 
         <View style={styles.settingRow}>
           <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>경로 설정</Text>
+            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.routePreferenceLabel')}</Text>
             <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              기본 경로 탐색 방식을 선택합니다
+              {t('settings.routePreferenceDescription')}
             </Text>
           </View>
         </View>
@@ -95,7 +97,7 @@ export default function SettingsScreen() {
                 testID={`route-${category.key}`}
               >
                 <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
-                  {category.label}
+                  {t(`routes.${category.key}`)}
                 </Text>
               </Pressable>
             );
@@ -105,13 +107,13 @@ export default function SettingsScreen() {
 
       {/* 알람 */}
       <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <Text style={[styles.sectionTitle, { color: colors.muted }]}>알람</Text>
+        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.alarmSection')}</Text>
 
         <View style={styles.settingRow}>
           <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>취침 모드</Text>
+            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.sleepModeLabel')}</Text>
             <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              이어폰 연결 시 기상 알람음으로 울립니다
+              {t('settings.sleepModeDescription')}
             </Text>
           </View>
           <Switch
@@ -131,9 +133,9 @@ export default function SettingsScreen() {
 
         <View style={[styles.settingRow, { borderTopWidth: 1, borderTopColor: colors.hair }]}>
           <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>스피커 출력 허용</Text>
+            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.speakerOutputLabel')}</Text>
             <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              이어폰 미연결 시에도 알람음을 스피커로 재생합니다
+              {t('settings.speakerOutputDescription')}
             </Text>
           </View>
           <Switch
@@ -141,11 +143,11 @@ export default function SettingsScreen() {
             onValueChange={(value) => {
               if (!value) {
                 Alert.alert(
-                  '스피커 출력 끄기',
-                  '스피커 출력을 끄면 이어폰이 연결되지 않은 상태에서 진동만 울립니다. 계속하시겠습니까?',
+                  t('settings.speakerOffTitle'),
+                  t('settings.speakerOffMessage'),
                   [
-                    { text: '취소', style: 'cancel' },
-                    { text: '끄기', style: 'destructive', onPress: () => setAllowSpeaker(false) },
+                    { text: t('common.cancel'), style: 'cancel' },
+                    { text: t('settings.speakerOffConfirm'), style: 'destructive', onPress: () => setAllowSpeaker(false) },
                   ],
                 );
               } else {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,3 +8,28 @@ if (typeof clearInterval === 'undefined') {
 if (typeof setInterval === 'undefined') {
   global.setInterval = () => 0;
 }
+
+// i18n 자동 초기화: 컴포넌트/훅 테스트가 별도 setup 없이도
+// useTranslation()을 사용할 수 있도록 함
+// 테스트 기본 언어는 ko — 기존 한글 텍스트 기준 assertion 유지
+jest.mock('expo-localization', () => ({
+  getLocales: () => [{ languageCode: 'ko' }],
+}));
+
+const i18next = require('i18next');
+const { initReactI18next } = require('react-i18next');
+const en = require('./src/i18n/locales/en.json');
+const ko = require('./src/i18n/locales/ko.json');
+
+i18next.use(initReactI18next).init({
+  compatibilityJSON: 'v4',
+  resources: {
+    en: { translation: en },
+    ko: { translation: ko },
+  },
+  lng: 'ko',
+  fallbackLng: 'en',
+  supportedLngs: ['ko', 'en'],
+  defaultNS: 'translation',
+  interpolation: { escapeValue: false },
+});

--- a/src/components/AlarmOverlay.tsx
+++ b/src/components/AlarmOverlay.tsx
@@ -1,4 +1,5 @@
 import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import type { AlarmEvent } from '../store/useAppStore';
 import { clearAlarmNotification } from '../utils/stationNotification';
 import { useTheme, typography, spacing, radius } from '../theme';
@@ -10,10 +11,11 @@ interface AlarmOverlayProps {
 
 export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
   const isTransfer = event.type === 'transfer';
-  const title = isTransfer ? '환승 알림' : '하차 알림';
-  const message = isTransfer
-    ? `${event.stationName}에서\n환승하세요`
-    : `${event.stationName}에서\n내리세요`;
+  const { t } = useTranslation();
+  const title = t(isTransfer ? 'alarmOverlay.transferTitle' : 'alarmOverlay.arrivalTitle');
+  const message = t(isTransfer ? 'alarmOverlay.transferMessage' : 'alarmOverlay.arrivalMessage', {
+    station: event.stationName,
+  });
   const { colors } = useTheme();
 
   const handleDismiss = async () => {
@@ -32,7 +34,7 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
           testID="alarm-dismiss-button"
           activeOpacity={0.7}
         >
-          <Text style={[styles.buttonText, { color: colors.onAccent }]}>알람 끄기</Text>
+          <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('alarmOverlay.dismiss')}</Text>
         </TouchableOpacity>
       </View>
     </Modal>

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import stations from '../data/stations.json';
 import type { Station } from '../types/station';
 import { LINE_NAMES } from '../constants/lineColors';
@@ -40,6 +41,7 @@ export function DestinationPicker({
   const [showDropdown, setShowDropdown] = useState(false);
   const openTimeRef = useRef<number | null>(null);
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (visible) {
@@ -93,25 +95,25 @@ export function DestinationPicker({
         ) : (
           <View style={styles.mapFallback} testID="map-fallback">
             <Text style={[styles.mapFallbackText, { color: colors.muted }]}>
-              위치 정보가 없습니다.
+              {t('destinationPicker.noLocation')}
             </Text>
           </View>
         )}
 
         <View style={styles.overlay} pointerEvents="box-none">
           <View style={[styles.header, { backgroundColor: colors.bgTranslucent }]}>
-            <Text style={[styles.title, { color: colors.ink }]}>목적지 설정</Text>
+            <Text style={[styles.title, { color: colors.ink }]}>{t('destinationPicker.title')}</Text>
             <TouchableOpacity onPress={handleClose} testID="close-button">
-              <Text style={[styles.closeText, { color: colors.accent }]}>닫기</Text>
+              <Text style={[styles.closeText, { color: colors.accent }]}>{t('common.close')}</Text>
             </TouchableOpacity>
           </View>
           <TextInput
             style={[styles.input, { backgroundColor: colors.card, color: colors.ink, borderColor: colors.hair }]}
-            placeholder="역 이름 검색"
+            placeholder={t('destinationPicker.searchPlaceholder')}
             placeholderTextColor={colors.subtle}
             value={query}
-            onChangeText={(t) => {
-              setQuery(t);
+            onChangeText={(text) => {
+              setQuery(text);
               setShowDropdown(true);
             }}
             onFocus={() => setShowDropdown(true)}

--- a/src/components/LocationStateView.tsx
+++ b/src/components/LocationStateView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '../theme';
 
 interface LocationStateViewProps {
@@ -12,14 +13,15 @@ interface LocationStateViewProps {
 
 export function LocationStateView({ permissionDenied, loading, error, onRetry }: LocationStateViewProps) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   if (permissionDenied) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={[styles.message, { color: colors.muted }]}>위치 권한이 필요합니다.</Text>
+          <Text style={[styles.message, { color: colors.muted }]}>{t('permissions.locationRequiredShort')}</Text>
           <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={onRetry} testID="location-retry-button">
-            <Text style={[styles.buttonText, { color: colors.onAccent }]}>권한 요청</Text>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('permissions.request')}</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -30,7 +32,7 @@ export function LocationStateView({ permissionDenied, loading, error, onRetry }:
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
-          <Text style={[styles.message, { color: colors.muted }]}>위치 확인 중...</Text>
+          <Text style={[styles.message, { color: colors.muted }]}>{t('permissions.locating')}</Text>
         </View>
       </SafeAreaView>
     );
@@ -42,7 +44,7 @@ export function LocationStateView({ permissionDenied, loading, error, onRetry }:
         <View style={styles.center}>
           <Text style={[styles.message, { color: colors.muted }]}>{error}</Text>
           <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={onRetry} testID="location-retry-button">
-            <Text style={[styles.buttonText, { color: colors.onAccent }]}>다시 시도</Text>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('common.retry')}</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
+import i18next from 'i18next';
 import type { Station } from '../types/station';
 import { BACKGROUND_LOCATION_TASK } from '../tasks/backgroundLocationTask';
 import { createLogger } from '../utils/logger';
@@ -37,9 +38,11 @@ export function useBackgroundLocation(destination: Station | null): void {
         pausesUpdatesAutomatically: false,
         distanceInterval: 20,
         showsBackgroundLocationIndicator: true,
+        // foregroundService 텍스트는 서비스 시작 시점에 OS에 고정됨.
+        // 런타임 언어 변경 반영은 Phase 5(알림 채널/포그라운드 서비스 마이그레이션)에서 처리.
         foregroundService: {
-          notificationTitle: '지하철 위치 감지 중',
-          notificationBody: '백그라운드에서 현재 역을 추적하고 있습니다',
+          notificationTitle: i18next.t('background.title'),
+          notificationBody: i18next.t('background.body'),
         },
       });
       logger.info('백그라운드 위치 추적 시작');

--- a/src/hooks/useSleepModeGuide.ts
+++ b/src/hooks/useSleepModeGuide.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTranslation } from 'react-i18next';
 import { SLEEP_MODE_GUIDE_SHOWN_KEY } from '../constants/storageKeys';
 
 export function useSleepModeGuide(): (onConfirm: () => void) => void {
   const shownRef = useRef(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     AsyncStorage.getItem(SLEEP_MODE_GUIDE_SHOWN_KEY).then((raw) => {
@@ -20,9 +22,9 @@ export function useSleepModeGuide(): (onConfirm: () => void) => void {
     shownRef.current = true;
     AsyncStorage.setItem(SLEEP_MODE_GUIDE_SHOWN_KEY, 'true').catch(() => {});
     Alert.alert(
-      '취침 모드 안내',
-      '이어폰이 연결되지 않은 경우 알람이 스피커로 재생될 수 있습니다.\n\n스피커 출력을 원하지 않으시면 설정 > 알람에서 \'스피커 출력 허용\'을 꺼주세요.',
-      [{ text: '확인', onPress: onConfirm }],
+      t('sleepModeGuide.title'),
+      t('sleepModeGuide.message'),
+      [{ text: t('sleepModeGuide.confirm'), onPress: onConfirm }],
     );
-  }, []);
+  }, [t]);
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,5 +4,119 @@
     "close": "Close",
     "confirm": "OK",
     "cancel": "Cancel"
+  },
+  "tabs": {
+    "current": "Current",
+    "map": "Map",
+    "favorites": "Favorites",
+    "settings": "Settings"
+  },
+  "permissions": {
+    "locationRequiredTitle": "Location permission required",
+    "locationRequiredShort": "Location permission required.",
+    "locationRequiredDescription": "Please allow location permission in Settings.\nLocation permission is required to detect your current station.",
+    "request": "Grant permission",
+    "locating": "Locating..."
+  },
+  "home": {
+    "arrived": "Arrived!",
+    "live": "LIVE",
+    "manual": "MANUAL",
+    "originManual": "Origin (manual)",
+    "originCurrent": "Current station",
+    "originNearest": "Nearest station",
+    "switchToGps": "Switch to GPS mode",
+    "routeTo": "Route to",
+    "estimatedSuffix": "EST",
+    "destinationChange": "Change destination →",
+    "destinationReset": "Reset",
+    "destinationSet": "Set destination",
+    "previousDestination": "Previous destination",
+    "sleepMode": "Sleep mode",
+    "sleepModeDescription": "Vibrate and notify 1 stop before transfer or arrival",
+    "arrivalInfoTitle": "Train arrivals",
+    "loading": "Loading...",
+    "mockNotice": "Showing estimated data — real-time unavailable",
+    "noArrivalInfo": "No arrival info",
+    "notNearStationTitle": "Not near a subway station",
+    "notNearStationDescription": "Your current station appears when you are within 500m of a subway station.\nYou can also set the origin manually from the Map tab.",
+    "refresh": "Refresh"
+  },
+  "settings": {
+    "title": "Settings",
+    "themeSection": "Theme",
+    "themeAuto": "Auto",
+    "themeLight": "Light",
+    "themeDark": "Dark",
+    "themeLabel": "Dark mode",
+    "themeDescription": "Auto follows your device setting",
+    "routeSection": "Route",
+    "routePreferenceLabel": "Route preference",
+    "routePreferenceDescription": "Choose the default route search method",
+    "alarmSection": "Alarm",
+    "sleepModeLabel": "Sleep mode",
+    "sleepModeDescription": "Plays the wake-up alarm sound when earphones are connected",
+    "speakerOutputLabel": "Allow speaker output",
+    "speakerOutputDescription": "Plays the alarm through the speaker even without earphones",
+    "speakerOffTitle": "Turn off speaker output",
+    "speakerOffMessage": "Disabling speaker output will play only vibration when earphones are not connected. Continue?",
+    "speakerOffConfirm": "Turn off"
+  },
+  "map": {
+    "originBadge": "Origin",
+    "destinationBadge": "Destination",
+    "setAsOrigin": "Set as origin",
+    "setAsDestination": "Set as destination"
+  },
+  "favorites": {
+    "title": "Favorites",
+    "searchPlaceholder": "Search station name...",
+    "noSearchResults": "No search results",
+    "empty": "No favorites yet",
+    "emptyDescription": "Search stations above and add\nthem to your favorites.",
+    "remove": "Remove"
+  },
+  "alarmOverlay": {
+    "transferTitle": "Transfer alert",
+    "arrivalTitle": "Arrival alert",
+    "transferMessage": "Transfer at\n{{station}}",
+    "arrivalMessage": "Exit at\n{{station}}",
+    "dismiss": "Dismiss alarm"
+  },
+  "destinationPicker": {
+    "noLocation": "Location info unavailable.",
+    "title": "Set destination",
+    "searchPlaceholder": "Search station name"
+  },
+  "sleepModeGuide": {
+    "title": "Sleep mode notice",
+    "message": "If earphones are not connected, the alarm may play through the speaker.\n\nIf you do not want speaker output, turn off 'Allow speaker output' under Settings > Alarm.",
+    "confirm": "OK"
+  },
+  "background": {
+    "title": "Detecting subway location",
+    "body": "Tracking your current station in the background"
+  },
+  "arrival": {
+    "upbound": "Upbound",
+    "downbound": "Downbound"
+  },
+  "notifications": {
+    "channelStation": "Current station",
+    "channelTransferAlarm": "Transfer/arrival alert",
+    "channelTransferAlarmSilent": "Transfer/arrival alert (silent)",
+    "channelStationPass": "Station pass alert",
+    "transferEarlyTitle": "Transfer alert",
+    "arrivalEarlyTitle": "Arrival alert",
+    "transferImminentTitle": "Transfer imminent",
+    "arrivalImminentTitle": "Arrival imminent"
+  },
+  "journey": {
+    "transferNote": "Transfer",
+    "arrivalNote": "Arrival"
+  },
+  "routes": {
+    "optimal": "Fastest",
+    "minTransfer": "Fewest transfers"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -4,5 +4,119 @@
     "close": "닫기",
     "confirm": "확인",
     "cancel": "취소"
+  },
+  "tabs": {
+    "current": "현재 역",
+    "map": "지도",
+    "favorites": "즐겨찾기",
+    "settings": "설정"
+  },
+  "permissions": {
+    "locationRequiredTitle": "위치 권한 필요",
+    "locationRequiredShort": "위치 권한이 필요합니다.",
+    "locationRequiredDescription": "설정에서 위치 권한을 허용해 주세요.\n현재 탑승 중인 역을 감지하려면\n위치 권한이 필요합니다.",
+    "request": "권한 요청",
+    "locating": "위치 확인 중..."
+  },
+  "home": {
+    "arrived": "도착!",
+    "live": "LIVE",
+    "manual": "수동",
+    "originManual": "출발역 (수동)",
+    "originCurrent": "현재역",
+    "originNearest": "가장 가까운 역",
+    "switchToGps": "GPS 모드로 전환",
+    "routeTo": "목적지까지",
+    "estimatedSuffix": "예상",
+    "destinationChange": "목적지 변경 →",
+    "destinationReset": "초기화",
+    "destinationSet": "목적지 설정",
+    "previousDestination": "이전 목적지",
+    "sleepMode": "취침 모드",
+    "sleepModeDescription": "환승·도착 1정거장 전 진동 · 알림",
+    "arrivalInfoTitle": "열차 도착 정보",
+    "loading": "불러오는 중...",
+    "mockNotice": "실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다",
+    "noArrivalInfo": "도착 정보 없음",
+    "notNearStationTitle": "지하철역 근처가 아닙니다",
+    "notNearStationDescription": "지하철역 500m 이내에 있을 때\n현재 역이 표시됩니다.\n지도 탭에서 출발역을 직접 설정할 수 있습니다.",
+    "refresh": "새로고침"
+  },
+  "settings": {
+    "title": "설정",
+    "themeSection": "테마",
+    "themeAuto": "자동",
+    "themeLight": "라이트",
+    "themeDark": "다크",
+    "themeLabel": "다크 모드",
+    "themeDescription": "자동은 기기 설정을 따릅니다",
+    "routeSection": "경로",
+    "routePreferenceLabel": "경로 설정",
+    "routePreferenceDescription": "기본 경로 탐색 방식을 선택합니다",
+    "alarmSection": "알람",
+    "sleepModeLabel": "취침 모드",
+    "sleepModeDescription": "이어폰 연결 시 기상 알람음으로 울립니다",
+    "speakerOutputLabel": "스피커 출력 허용",
+    "speakerOutputDescription": "이어폰 미연결 시에도 알람음을 스피커로 재생합니다",
+    "speakerOffTitle": "스피커 출력 끄기",
+    "speakerOffMessage": "스피커 출력을 끄면 이어폰이 연결되지 않은 상태에서 진동만 울립니다. 계속하시겠습니까?",
+    "speakerOffConfirm": "끄기"
+  },
+  "map": {
+    "originBadge": "출발",
+    "destinationBadge": "도착",
+    "setAsOrigin": "출발역으로 설정",
+    "setAsDestination": "도착역으로 설정"
+  },
+  "favorites": {
+    "title": "즐겨찾기",
+    "searchPlaceholder": "역 이름 검색...",
+    "noSearchResults": "검색 결과가 없습니다",
+    "empty": "즐겨찾기가 없습니다",
+    "emptyDescription": "위 검색창에서 역을 검색해 즐겨찾기에\n추가할 수 있습니다.",
+    "remove": "삭제"
+  },
+  "alarmOverlay": {
+    "transferTitle": "환승 알림",
+    "arrivalTitle": "하차 알림",
+    "transferMessage": "{{station}}에서\n환승하세요",
+    "arrivalMessage": "{{station}}에서\n내리세요",
+    "dismiss": "알람 끄기"
+  },
+  "destinationPicker": {
+    "noLocation": "위치 정보가 없습니다.",
+    "title": "목적지 설정",
+    "searchPlaceholder": "역 이름 검색"
+  },
+  "sleepModeGuide": {
+    "title": "취침 모드 안내",
+    "message": "이어폰이 연결되지 않은 경우 알람이 스피커로 재생될 수 있습니다.\n\n스피커 출력을 원하지 않으시면 설정 > 알람에서 '스피커 출력 허용'을 꺼주세요.",
+    "confirm": "확인"
+  },
+  "background": {
+    "title": "지하철 위치 감지 중",
+    "body": "백그라운드에서 현재 역을 추적하고 있습니다"
+  },
+  "arrival": {
+    "upbound": "상행",
+    "downbound": "하행"
+  },
+  "notifications": {
+    "channelStation": "현재 역",
+    "channelTransferAlarm": "하차/환승 알림",
+    "channelTransferAlarmSilent": "하차/환승 알림 (무음)",
+    "channelStationPass": "역 통과 알림",
+    "transferEarlyTitle": "환승 알림",
+    "arrivalEarlyTitle": "하차 알림",
+    "transferImminentTitle": "환승 임박",
+    "arrivalImminentTitle": "도착 임박"
+  },
+  "journey": {
+    "transferNote": "환승",
+    "arrivalNote": "도착"
+  },
+  "routes": {
+    "optimal": "최적경로",
+    "minTransfer": "최소환승"
   }
 }

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -1,3 +1,4 @@
+import i18next from 'i18next';
 import type { JourneyDisplay } from './stationRoute';
 import type { ArrivalInfo } from '../api/arrivalApi';
 import type { NearestStationResult, LineNumber } from '../types/station';
@@ -45,13 +46,14 @@ export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
       });
     }
 
+    // stopsFromPrev 동적 포맷("N정거장")은 Phase 3에서 i18n 처리 예정
     if (!isLast) {
       stops.push({
         station: seg.toName,
         line: segments[i + 1].line,
         stopsFromPrev: `${seg.stops}정거장`,
         mark: 'transfer',
-        note: '환승',
+        note: i18next.t('journey.transferNote'),
       });
     } else {
       stops.push({
@@ -59,7 +61,7 @@ export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
         line: seg.line,
         stopsFromPrev: `${seg.stops}정거장`,
         mark: 'dest',
-        note: '도착',
+        note: i18next.t('journey.arrivalNote'),
       });
     }
   }
@@ -73,6 +75,7 @@ export function arrivalInfoToArrivalTrain(
   line: LineNumber,
 ): ArrivalTrain[] {
   const now = Date.now();
+  // direction 동적 포맷("X 방면")은 Phase 3에서 i18n 처리 예정
   return items.map((item) => ({
     direction: item.destination ? `${item.destination} 방면` : direction,
     line,

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
+import i18next from 'i18next';
 import { Station } from '../types/station';
 import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from './stationRoute';
@@ -54,13 +55,13 @@ export function setupNotificationHandler(): void {
 export async function initStationNotification(): Promise<void> {
   if (Platform.OS === 'android') {
     await Notifications.setNotificationChannelAsync('station', {
-      name: '현재 역',
+      name: i18next.t('notifications.channelStation'),
       importance: Notifications.AndroidImportance.HIGH,
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
     });
     await Notifications.deleteNotificationChannelAsync(ALARM_CHANNEL_ID).catch(() => {});
     await Notifications.setNotificationChannelAsync(ALARM_CHANNEL_ID, {
-      name: '하차/환승 알림',
+      name: i18next.t('notifications.channelTransferAlarm'),
       importance: Notifications.AndroidImportance.MAX,
       sound: 'alarm.wav',
       enableVibrate: true,
@@ -70,7 +71,7 @@ export async function initStationNotification(): Promise<void> {
     });
     await Notifications.deleteNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID).catch(() => {});
     await Notifications.setNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID, {
-      name: '하차/환승 알림 (무음)',
+      name: i18next.t('notifications.channelTransferAlarmSilent'),
       importance: Notifications.AndroidImportance.MAX,
       sound: null,
       enableVibrate: true,
@@ -79,7 +80,7 @@ export async function initStationNotification(): Promise<void> {
       bypassDnd: true,
     });
     await Notifications.setNotificationChannelAsync(STATION_PASSED_CHANNEL_ID, {
-      name: '역 통과 알림',
+      name: i18next.t('notifications.channelStationPass'),
       importance: Notifications.AndroidImportance.DEFAULT,
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
     });
@@ -274,15 +275,16 @@ export async function sendStationPassedNotification(
 
 import type { AlarmPhaseId } from './alarmPhases';
 
+// 본문(body)의 동적 보간 부분은 Phase 3(#205+)에서 i18n 처리 예정
 const ALARM_MESSAGE_BUILDERS: Record<AlarmPhaseId, (stationName: string, isTransfer: boolean) => { title: string; body: string }> = {
   early: (stationName, isTransfer) => ({
-    title: isTransfer ? '환승 알림' : '하차 알림',
+    title: i18next.t(isTransfer ? 'notifications.transferEarlyTitle' : 'notifications.arrivalEarlyTitle'),
     body: isTransfer
       ? `다음 역 ${stationName}에서 환승하세요!`
       : `다음 역 ${stationName}에서 내리세요!`,
   }),
   imminent: (stationName, isTransfer) => ({
-    title: isTransfer ? '환승 임박' : '도착 임박',
+    title: i18next.t(isTransfer ? 'notifications.transferImminentTitle' : 'notifications.arrivalImminentTitle'),
     body: isTransfer
       ? `곧 ${stationName}에 도착합니다. 환승 준비하세요!`
       : `곧 ${stationName}에 도착합니다. 하차 준비하세요!`,


### PR DESCRIPTION
## Summary

`subway-now` 앱의 사용자 노출 정적 한글 텍스트를 i18n 키로 추출/교체하는 Phase 2 작업이다. 동적 보간 텍스트(시간/거리/노선/카테고리 환승 수 등)는 후속 Phase 3 이슈에서 처리한다.

## 변경 사항

### UI 텍스트 i18n 적용 (12개 파일)
- **화면**: `app/(tabs)/_layout.tsx`, `index.tsx`, `settings.tsx`, `map.tsx`, `favorites.tsx`
- **컴포넌트**: `AlarmOverlay`, `LocationStateView`, `DestinationPicker`
- **훅 / 유틸**: `useSleepModeGuide`, `useBackgroundLocation`, `stationNotification`, `journeyAdapter`

### locale JSON 키 추가 (~130개)
`tabs`, `permissions`, `home`, `settings`, `map`, `favorites`, `alarmOverlay`, `destinationPicker`, `sleepModeGuide`, `background`, `arrival`, `notifications`, `journey`, `routes`

### 테스트 인프라
- `jest.setup.js`에 i18n 자동 초기화 추가 (기본 언어 `ko` — 기존 한글 텍스트 assert 그대로 통과)

### 패턴
- 컴포넌트/훅: `useTranslation()` 훅
- 컴포넌트 외부(util): `i18next.t()` 직접 호출

## 비범위 (Phase 3에서 처리)
- 동적 포맷: `${n}분`, `${n}정거장`, `${name} 방면`, `${candidate.travelMinutes}분 · ${candidate.transferCount}환승` 등
- 노선명 영문화 (`LINE_NAMES`)
- 알람 본문 동적 보간
- 해당 위치에 TODO 주석으로 표시

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 49 suites / 689 tests / 커버리지 100%
- [x] code-reviewer 에이전트 P1 반영 (알람 알림 정적 제목 i18n 처리), P2 TODO 주석 반영, P3 일부 반영 (영문 표현 자연스러움 — "Exit at")
- [ ] CI `Type Check & Test` 통과 후 머지

Closes #204