### PR TITLE
chore(#210): 1.0.3 릴리스

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## 변경 사항

- `package.json` 1.0.1 → 1.0.3 (npm version patch 2회)
- `app.config.js`가 자동으로 `package.json.version` 반영

## 포함되는 기능 (1.0.1 이후 머지된 PR)

- #202 — i18n 인프라 셋업 (한국어/영어 지원)
- #203 — 앱 표시 이름 한국어 현지화 (지금 어디)
- #206 — UI 정적 텍스트 i18n 적용
- #208 — 스플래시 placeholder 이미지를 실제 디자인으로 교체

Closes #210