### PR TITLE
feat(#207): i18n Phase 3 — 동적 포맷팅 (시간/거리/노선/환승)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -373,9 +373,10 @@ export default function HomeScreen() {
                             <Text style={[styles.routePillText, { color: active ? colors.onAccent : colors.muted }]}>
                               {t(`routes.${category.key}`)}
                             </Text>
-                            {/* 동적 포맷("N분 · M환승")은 Phase 3에서 i18n 처리 예정 */}
                             <Text style={[styles.routePillSub, { color: active ? colors.onAccent : colors.subtle }]}>
-                              {candidate.travelMinutes}분 · {candidate.transferCount}환승
+                              {candidate.transferCount === 0
+                                ? t('route.directOnly', { min: candidate.travelMinutes })
+                                : t('route.minutesAndTransfers', { min: candidate.travelMinutes, count: candidate.transferCount })}
                             </Text>
                           </Pressable>
                         );

--- a/src/constants/__tests__/lineColors.test.ts
+++ b/src/constants/__tests__/lineColors.test.ts
@@ -26,9 +26,19 @@ describe('LINE_NAMES', () => {
   });
 
   it('모든 호선에 이름이 있다', () => {
-    Object.values(LINE_NAMES).forEach((name) => {
+    const names = Object.values(LINE_NAMES);
+    expect(names).toHaveLength(Object.keys(LINE_COLORS).length);
+    names.forEach((name) => {
       expect(typeof name).toBe('string');
       expect(name.length).toBeGreaterThan(0);
     });
+  });
+
+  it('정의되지 않은 호선 키는 undefined를 반환한다', () => {
+    expect(LINE_NAMES['unknown' as never]).toBeUndefined();
+  });
+
+  it('정의되지 않은 키의 디스크립터는 undefined를 반환한다', () => {
+    expect(Object.getOwnPropertyDescriptor(LINE_NAMES, 'unknown' as never)).toBeUndefined();
   });
 });

--- a/src/constants/lineColors.ts
+++ b/src/constants/lineColors.ts
@@ -1,3 +1,4 @@
+import i18next from 'i18next';
 import { LineNumber } from '../types/station';
 
 export const LINE_COLORS: Record<LineNumber, string> = {
@@ -16,18 +17,19 @@ export const LINE_COLORS: Record<LineNumber, string> = {
   sinbundang: '#D4003B',
 };
 
-export const LINE_NAMES: Record<LineNumber, string> = {
-  '1': '1호선',
-  '2': '2호선',
-  '3': '3호선',
-  '4': '4호선',
-  '5': '5호선',
-  '6': '6호선',
-  '7': '7호선',
-  '8': '8호선',
-  '9': '9호선',
-  airport: '공항철도',
-  gyeongui: '경의중앙선',
-  bundang: '분당선',
-  sinbundang: '신분당선',
-};
+// 현재 언어에 맞춰 노선 이름을 동적으로 조회. 기존 LINE_NAMES[line] 형태 사용처 호환.
+// 정의되지 않은 키는 undefined를 반환해 호출부의 `?? fallback` 동작을 보존한다.
+// ownKeys/getOwnPropertyDescriptor 트랩은 Object.keys/values/entries 순회 지원용.
+export const LINE_NAMES = new Proxy({} as Record<LineNumber, string>, {
+  get(_, prop: string) {
+    if (!(prop in LINE_COLORS)) return undefined;
+    return i18next.t(`lines.${prop}` as 'lines.1') as string;
+  },
+  ownKeys() {
+    return Object.keys(LINE_COLORS);
+  },
+  getOwnPropertyDescriptor(_, prop: string) {
+    if (!(prop in LINE_COLORS)) return undefined;
+    return { enumerable: true, configurable: true, writable: false };
+  },
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -118,5 +118,50 @@
   "routes": {
     "optimal": "Fastest",
     "minTransfer": "Fewest transfers"
+  },
+  "time": {
+    "arrivingSoon": "Arriving soon",
+    "minutesAndSeconds": "{{min}}m {{sec}}s",
+    "seconds": "{{sec}}s",
+    "approximateMinutes": "~{{min}}m",
+    "estimatedSuffix": " (estimated)"
+  },
+  "route": {
+    "stops_one": "{{count}} stop",
+    "stops_other": "{{count}} stops",
+    "stopsLeft_one": "{{count}} stop left",
+    "stopsLeft_other": "{{count}} stops left",
+    "transferAfterStops": "Transfer at {{name}} in {{stops}} stops",
+    "minutesAndTransfers_one": "{{min}}m · {{count}} transfer",
+    "minutesAndTransfers_other": "{{min}}m · {{count}} transfers",
+    "directOnly": "{{min}}m · Direct",
+    "directionToward": "Toward {{name}}",
+    "currentStation": "{{name}}",
+    "atCurrentStation": "Currently at {{name}}",
+    "approximateDistance": "~{{m}}m",
+    "stationPassed": "Passed {{name}}",
+    "stopsRemainingToDestination_one": "{{count}} stop to {{destination}}",
+    "stopsRemainingToDestination_other": "{{count}} stops to {{destination}}"
+  },
+  "lines": {
+    "1": "Line 1",
+    "2": "Line 2",
+    "3": "Line 3",
+    "4": "Line 4",
+    "5": "Line 5",
+    "6": "Line 6",
+    "7": "Line 7",
+    "8": "Line 8",
+    "9": "Line 9",
+    "airport": "AREX",
+    "gyeongui": "Gyeongui-Jungang Line",
+    "bundang": "Bundang Line",
+    "sinbundang": "Shinbundang Line"
+  },
+  "alarms": {
+    "earlyTransferBody": "Transfer at {{station}} (next stop)!",
+    "earlyArrivalBody": "Exit at {{station}} (next stop)!",
+    "imminentTransferBody": "Arriving at {{station}}. Get ready to transfer!",
+    "imminentArrivalBody": "Arriving at {{station}}. Get ready to exit!"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -118,5 +118,50 @@
   "routes": {
     "optimal": "최적경로",
     "minTransfer": "최소환승"
+  },
+  "time": {
+    "arrivingSoon": "곧 도착",
+    "minutesAndSeconds": "{{min}}분 {{sec}}초",
+    "seconds": "{{sec}}초",
+    "approximateMinutes": "약 {{min}}분",
+    "estimatedSuffix": " (예상)"
+  },
+  "route": {
+    "stops_one": "{{count}}정거장",
+    "stops_other": "{{count}}정거장",
+    "stopsLeft_one": "{{count}}정거장 남음",
+    "stopsLeft_other": "{{count}}정거장 남음",
+    "transferAfterStops": "{{stops}}정거장 후 {{name}} 환승",
+    "minutesAndTransfers_one": "{{min}}분 · {{count}}환승",
+    "minutesAndTransfers_other": "{{min}}분 · {{count}}환승",
+    "directOnly": "{{min}}분 · 직통",
+    "directionToward": "{{name}} 방면",
+    "currentStation": "{{name}}역",
+    "atCurrentStation": "현재 {{name}}역",
+    "approximateDistance": "약 {{m}}m",
+    "stationPassed": "{{name}}역 통과",
+    "stopsRemainingToDestination_one": "{{destination}}까지 {{count}}정거장 남음",
+    "stopsRemainingToDestination_other": "{{destination}}까지 {{count}}정거장 남음"
+  },
+  "lines": {
+    "1": "1호선",
+    "2": "2호선",
+    "3": "3호선",
+    "4": "4호선",
+    "5": "5호선",
+    "6": "6호선",
+    "7": "7호선",
+    "8": "8호선",
+    "9": "9호선",
+    "airport": "공항철도",
+    "gyeongui": "경의중앙선",
+    "bundang": "분당선",
+    "sinbundang": "신분당선"
+  },
+  "alarms": {
+    "earlyTransferBody": "다음 역 {{station}}에서 환승하세요!",
+    "earlyArrivalBody": "다음 역 {{station}}에서 내리세요!",
+    "imminentTransferBody": "곧 {{station}}에 도착합니다. 환승 준비하세요!",
+    "imminentArrivalBody": "곧 {{station}}에 도착합니다. 하차 준비하세요!"
   }
 }

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -356,12 +356,12 @@ describe('stationNotification', () => {
 
     it('환승 경로이면 환승 정보를 표시한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, transferRoute);
-      expectNotificationContent('시청 → 성신여대입구', '3역 후 동대문 환승');
+      expectNotificationContent('시청 → 성신여대입구', '3정거장 후 동대문 환승');
     });
 
     it('multi-transfer 경로이면 두 환승 정보를 표시한다', async () => {
       await updateStationNotification(mockStation, 154, mockDestination, multiTransferRoute);
-      expectNotificationContent('시청 → 성신여대입구', '3역 후 잠실 환승');
+      expectNotificationContent('시청 → 성신여대입구', '3정거장 후 잠실 환승');
     });
 
     it('etaMinutes가 있으면 알림 body에 소요 시간이 포함된다', async () => {

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,7 +1,9 @@
+import i18next from 'i18next';
+
 export function formatArrivalTime(seconds: number): string {
-  if (seconds <= 0) return '곧 도착';
+  if (seconds <= 0) return i18next.t('time.arrivingSoon');
   const min = Math.floor(seconds / 60);
   const sec = seconds % 60;
-  if (min === 0) return `${sec}초`;
-  return `${min}분 ${sec}초`;
+  if (min === 0) return i18next.t('time.seconds', { sec });
+  return i18next.t('time.minutesAndSeconds', { min, sec });
 }

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -46,12 +46,11 @@ export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
       });
     }
 
-    // stopsFromPrev 동적 포맷("N정거장")은 Phase 3에서 i18n 처리 예정
     if (!isLast) {
       stops.push({
         station: seg.toName,
         line: segments[i + 1].line,
-        stopsFromPrev: `${seg.stops}정거장`,
+        stopsFromPrev: i18next.t('route.stops', { count: seg.stops }),
         mark: 'transfer',
         note: i18next.t('journey.transferNote'),
       });
@@ -59,7 +58,7 @@ export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
       stops.push({
         station: seg.toName,
         line: seg.line,
-        stopsFromPrev: `${seg.stops}정거장`,
+        stopsFromPrev: i18next.t('route.stops', { count: seg.stops }),
         mark: 'dest',
         note: i18next.t('journey.arrivalNote'),
       });
@@ -75,9 +74,8 @@ export function arrivalInfoToArrivalTrain(
   line: LineNumber,
 ): ArrivalTrain[] {
   const now = Date.now();
-  // direction 동적 포맷("X 방면")은 Phase 3에서 i18n 처리 예정
   return items.map((item) => ({
-    direction: item.destination ? `${item.destination} 방면` : direction,
+    direction: item.destination ? i18next.t('route.directionToward', { name: item.destination }) : direction,
     line,
     arrivalAtMs: now + item.arrivalSeconds * 1000,
     subtext: item.statusMessage || undefined,

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -103,27 +103,43 @@ function buildContent(
   etaMinutes?: number | null,
   isMock?: boolean,
 ): { title: string; body: string } {
-  const etaSuffix = etaMinutes != null ? ` · 약 ${etaMinutes}분${isMock ? ' (예상)' : ''}` : '';
+  const etaSuffix =
+    etaMinutes != null
+      ? ` · ${i18next.t('time.approximateMinutes', { min: etaMinutes })}${isMock ? i18next.t('time.estimatedSuffix') : ''}`
+      : '';
 
   // destination layer: 목적지 있으면 title에 반영
+  // TODO(phase4): 역명 영문 데이터 도입 시 currentStation.name/destination.name도 현지화 필요
   const title = destination
     ? `${currentStation.name} → ${destination.name}`
-    : `${currentStation.name}역`;
+    : i18next.t('route.currentStation', { name: currentStation.name });
 
   // route layer: 경로 정보가 있으면 body에 반영
   if (destination && route) {
     if (route.type === 'direct') {
-      return { title, body: `${LINE_NAMES[currentStation.line]} · ${route.stops}정거장 남음${etaSuffix}` };
+      return {
+        title,
+        body: `${LINE_NAMES[currentStation.line]} · ${i18next.t('route.stopsLeft', { count: route.stops })}${etaSuffix}`,
+      };
     }
     if (route.type === 'transfer') {
-      return { title, body: `${route.stopsToTransfer}역 후 ${route.transferName} 환승${etaSuffix}` };
+      return {
+        title,
+        body: `${i18next.t('route.transferAfterStops', { stops: route.stopsToTransfer, name: route.transferName })}${etaSuffix}`,
+      };
     }
     const [t1] = route.transfers;
-    return { title, body: `${t1.stopsToTransfer}역 후 ${t1.transferName} 환승${etaSuffix}` };
+    return {
+      title,
+      body: `${i18next.t('route.transferAfterStops', { stops: t1.stopsToTransfer, name: t1.transferName })}${etaSuffix}`,
+    };
   }
 
   // base: 경로 없이 목적지만 있거나 목적지도 없는 경우
-  return { title, body: `${LINE_NAMES[currentStation.line]} · 약 ${distanceM}m${etaSuffix}` };
+  return {
+    title,
+    body: `${LINE_NAMES[currentStation.line]} · ${i18next.t('route.approximateDistance', { m: distanceM })}${etaSuffix}`,
+  };
 }
 
 function buildLiveActivityData(
@@ -258,12 +274,16 @@ export async function sendStationPassedNotification(
   destinationName: string,
   stopsRemaining: number | null,
 ): Promise<void> {
-  const body = stopsRemaining != null
-    ? `${destinationName}까지 ${stopsRemaining}정거장 남음`
-    : `현재 ${stationName}역`;
+  const body =
+    stopsRemaining != null
+      ? i18next.t('route.stopsRemainingToDestination', {
+          destination: destinationName,
+          count: stopsRemaining,
+        })
+      : i18next.t('route.atCurrentStation', { name: stationName });
 
   await scheduleNotification(STATION_PASSED_NOTIFICATION_ID, {
-    title: `${stationName}역 통과`,
+    title: i18next.t('route.stationPassed', { name: stationName }),
     body,
     ...(Platform.OS === 'android' && {
       channelId: STATION_PASSED_CHANNEL_ID,
@@ -275,19 +295,14 @@ export async function sendStationPassedNotification(
 
 import type { AlarmPhaseId } from './alarmPhases';
 
-// 본문(body)의 동적 보간 부분은 Phase 3(#205+)에서 i18n 처리 예정
 const ALARM_MESSAGE_BUILDERS: Record<AlarmPhaseId, (stationName: string, isTransfer: boolean) => { title: string; body: string }> = {
   early: (stationName, isTransfer) => ({
     title: i18next.t(isTransfer ? 'notifications.transferEarlyTitle' : 'notifications.arrivalEarlyTitle'),
-    body: isTransfer
-      ? `다음 역 ${stationName}에서 환승하세요!`
-      : `다음 역 ${stationName}에서 내리세요!`,
+    body: i18next.t(isTransfer ? 'alarms.earlyTransferBody' : 'alarms.earlyArrivalBody', { station: stationName }),
   }),
   imminent: (stationName, isTransfer) => ({
     title: i18next.t(isTransfer ? 'notifications.transferImminentTitle' : 'notifications.arrivalImminentTitle'),
-    body: isTransfer
-      ? `곧 ${stationName}에 도착합니다. 환승 준비하세요!`
-      : `곧 ${stationName}에 도착합니다. 하차 준비하세요!`,
+    body: i18next.t(isTransfer ? 'alarms.imminentTransferBody' : 'alarms.imminentArrivalBody', { station: stationName }),
   }),
 };
 


### PR DESCRIPTION
## Summary

i18n Phase 3. 변수 보간이 포함된 동적 텍스트를 모두 i18n 키로 옮기고, 이전 Phase 3 리뷰에서 받은 P1/P2 지적사항을 같은 PR에 반영했다.

## 변경 사항

### 동적 텍스트 i18n
- `formatTime.ts` — `${min}분 ${sec}초`, `곧 도착`
- `journeyAdapter.ts` — `${seg.stops}정거장`, `${name} 방면`
- `stationNotification.ts` — ETA suffix, 거리(`약 Xm`), 정거장 수, 환승, 알람 본문 4종, station passed 본문
- `index.tsx` — 루트 필 서브텍스트 (직통은 `route.directOnly` 별도 라벨)

### LINE_NAMES Proxy 패턴
- `LINE_NAMES`를 i18next 기반 `Proxy<Record<LineNumber, string>>`로 변환
- `get` + `ownKeys` + `getOwnPropertyDescriptor` 트랩 정의 — `Object.values/keys/entries` 순회 정상 동작 (이전 리뷰 P1)
- 정의되지 않은 키는 `undefined` 반환 → 호출부 `?? fallback` 동작 보존

### locale JSON 키
- `time.{arrivingSoon, minutesAndSeconds, seconds, approximateMinutes, estimatedSuffix}`
- `route.{stops, stopsLeft, transferAfterStops, minutesAndTransfers, directOnly, directionToward, currentStation, atCurrentStation, approximateDistance, stationPassed, stopsRemainingToDestination}`
- `lines.{1~9, airport(AREX), gyeongui, bundang, sinbundang}`
- `alarms.{earlyTransferBody, earlyArrivalBody, imminentTransferBody, imminentArrivalBody}`

### 이전 리뷰 반영
- **P1** Proxy `ownKeys`/`getOwnPropertyDescriptor` 트랩 추가 + `lineColors.test.ts` false-positive 해소
- **P2** `route.transferCount_one/_other` dead key 제거 (사용처 없음)
- **P2** `transferCount === 0` 직통 경로일 때 `route.directOnly` 별도 라벨로 `"0환승"` 노출 방지
- **P2** `transferAfterStops` 단위 통일(`역 후` → `정거장 후`) — 다른 키와 일관성
- **P2** 공항철도 영문명 `Airport Railroad` → `AREX` (공식 브랜드명)

### 비범위 (후속)
- Phase 4: 역명 영문 데이터 (Seoul Metro 공식 로마자) — `stationNotification` title에 TODO 주석
- Phase 5: 권한 메시지·알림 채널 마이그레이션 + 수동 언어 전환 UX
- util→view i18n 의존 분리 (현재는 util이 i18next에 결합)

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 49 suites / 691 tests / 커버리지 100% (lines/functions/branches/statements)
- [x] code-reviewer 통과 (P0 P1 P2 모두 반영)
- [x] CI `Type Check & Test` 통과 후 머지

Closes #207