### PR TITLE
fix(#213): 앱 시작 시 저장된 다크모드가 즉시 적용되지 않는 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ coverage/
 # Claude Code
 .claude/
 
+# Maestro E2E 산출물
+.maestro/screenshots/
+
 # Generated coverage temp
 coverage-temp/
 

--- a/.maestro/flows/settings/01_dark_mode_persists.yaml
+++ b/.maestro/flows/settings/01_dark_mode_persists.yaml
@@ -1,0 +1,88 @@
+appId: com.subwaynow.app
+name: "설정 - 다크모드 재시작 후 즉시 적용"
+---
+# Step 1: 초기 실행 (clearState로 AsyncStorage 초기화)
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# dev-client URL 선택 화면 (개발 빌드에서만)
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# Dev Menu가 있으면 swipe down으로 dismiss
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 홈 로드 대기
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
+    timeout: 30000
+
+- takeScreenshot: .maestro/screenshots/01_initial_home_light
+
+# 설정 탭 이동
+- tapOn:
+    point: "87%,95%"
+
+# 다크 선택
+- tapOn:
+    id: "theme-dark"
+
+- takeScreenshot: .maestro/screenshots/02_settings_dark_selected
+
+# Step 2: 앱 종료 후 cold restart (AsyncStorage 유지)
+- stopApp:
+    appId: com.subwaynow.app
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: false
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 핵심 검증: 재시작 직후 홈 탭이 즉시 다크 테마로 보여야 함
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
+    timeout: 30000
+
+- takeScreenshot: .maestro/screenshots/03_home_after_restart_should_be_dark
+
+# 설정 탭 진입 — 다크 segment가 active 상태로 유지되었는지
+- tapOn:
+    point: "87%,95%"
+
+- extendedWaitUntil:
+    visible:
+      id: "theme-dark"
+    timeout: 10000
+
+- takeScreenshot: .maestro/screenshots/04_settings_dark_still_active

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -22,7 +22,6 @@ export default function SettingsScreen() {
   const loadAllowSpeaker = useAppStore((s) => s.loadAllowSpeaker);
   const themeMode = useAppStore((s) => s.themeMode);
   const setThemeMode = useAppStore((s) => s.setThemeMode);
-  const loadThemeMode = useAppStore((s) => s.loadThemeMode);
   const routePreference = useAppStore((s) => s.routePreference);
   const setRoutePreference = useAppStore((s) => s.setRoutePreference);
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
@@ -33,7 +32,6 @@ export default function SettingsScreen() {
   useEffect(() => {
     loadSleepMode();
     loadAllowSpeaker();
-    loadThemeMode();
     loadRoutePreference();
   }, []);
 

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, type ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
 import { lightColors, darkColors, type ThemeColors } from './theme';
 import { useAppStore } from '../store/useAppStore';
@@ -16,6 +16,11 @@ const ThemeContext = createContext<ThemeContextValue>({
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const scheme = useColorScheme();
   const themeMode = useAppStore((s) => s.themeMode);
+
+  useEffect(() => {
+    useAppStore.getState().loadThemeMode();
+  }, []);
+
   const isDark = themeMode === 'auto' ? scheme === 'dark' : themeMode === 'dark';
   const colors = isDark ? darkColors : lightColors;
 

--- a/src/theme/__tests__/ThemeContext.test.tsx
+++ b/src/theme/__tests__/ThemeContext.test.tsx
@@ -8,9 +8,12 @@ import { useAppStore } from '../../store/useAppStore';
 const mockUseColorScheme = jest.spyOn(RN, 'useColorScheme');
 
 describe('ThemeContext', () => {
+  let loadThemeMode: jest.Mock;
+
   beforeEach(() => {
     mockUseColorScheme.mockReturnValue('light');
-    useAppStore.setState({ themeMode: 'auto' });
+    loadThemeMode = jest.fn();
+    useAppStore.setState({ themeMode: 'auto', loadThemeMode });
   });
 
   afterEach(() => {
@@ -79,6 +82,12 @@ describe('ThemeContext', () => {
 
       expect(result.current.colors).toBe(darkColors);
       expect(result.current.isDark).toBe(true);
+    });
+
+    it('마운트 시 저장된 테마 모드를 로드한다', () => {
+      renderHook(() => useTheme(), { wrapper });
+
+      expect(loadThemeMode).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `ThemeProvider` 마운트 시 `loadThemeMode()`를 호출하여 AsyncStorage에 저장된 테마 모드를 즉시 store에 반영
- 기존에는 설정 화면 진입 `useEffect`에서만 로드되어, 앱 재시작 후 설정 탭에 들어가야만 다크모드가 적용되는 문제 발생
- 설정 화면의 중복 `loadThemeMode` 호출 제거 (이제 `ThemeProvider`가 단일 책임)
- `ThemeContext` 테스트에 마운트 시 `loadThemeMode` 호출 검증 케이스 추가

## 근본 원인
- `src/store/useAppStore.ts:52` Zustand 초기값 `themeMode: 'auto'`
- `loadThemeMode()`는 `app/(tabs)/settings.tsx`에서만 호출됨 → 앱 시작 시점에 store가 저장값을 알지 못함
- OS가 라이트 모드이면 `'auto' + light scheme` 조합으로 라이트 테마 렌더링되다가, 설정 탭 진입 후에야 다크로 전환됨

## Test plan
- [x] `npm test` — 692개 테스트 통과, 커버리지 100% 유지
- [x] `npm run type-check` — 타입 오류 없음
- [x] code-reviewer 에이전트 리뷰 — P1 없음
- [ ] 수동 확인: 다크 선택 → 앱 강제 종료 → OS 라이트 상태에서 재시작 → 홈 탭이 즉시 다크 테마로 표시되는지 확인
- [ ] 수동 확인: `auto` 모드에서 OS 다크모드 토글 시 즉시 반영되는 기존 동작 유지
- [ ] 수동 확인: 라이트 선택 후 재시작 시 라이트 테마로 시작되는지

Closes #213