### PR TITLE
fix(#214): 환승 전 역 통과 알림에 최종 목적지까지 총 정거장 수 표시

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -262,18 +262,25 @@ describe('useStationAlarm', () => {
   });
 
   describe('station-passed notification', () => {
+    const directTarget = {
+      nextStationName: '강남',
+      stopsToNextStation: 3,
+      isTransfer: false,
+      stopsToDestination: 3,
+    };
+
     it('fires when nearest station changes', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
-      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      mockResolveNextTarget.mockReturnValue(directTarget);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', 3);
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', directTarget);
     });
 
     it('does not fire when nearest station is unchanged', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
-      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      mockResolveNextTarget.mockReturnValue(directTarget);
       const { rerender } = renderHook(
         ({ s }: { s: Station }) =>
           useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
@@ -289,7 +296,7 @@ describe('useStationAlarm', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station1 = makeStation('S1', '역삼');
       const station2 = makeStation('S2', '선릉');
-      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      mockResolveNextTarget.mockReturnValue(directTarget);
       const { rerender } = renderHook(
         ({ s }: { s: Station }) =>
           useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
@@ -297,10 +304,16 @@ describe('useStationAlarm', () => {
       );
       expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
 
-      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2 });
+      const nextTarget = {
+        nextStationName: '강남',
+        stopsToNextStation: 2,
+        isTransfer: false,
+        stopsToDestination: 2,
+      };
+      mockResolveNextTarget.mockReturnValue(nextTarget);
       rerender({ s: station2 });
       expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
-      expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', 2);
+      expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', nextTarget);
     });
 
     it('does not fire when nearestStation is null', () => {
@@ -322,7 +335,7 @@ describe('useStationAlarm', () => {
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('passes null stopsRemaining when resolveNextTarget returns null', () => {
+    it('passes null target when resolveNextTarget returns null', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(null);
@@ -334,7 +347,7 @@ describe('useStationAlarm', () => {
       mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 실패'));
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
-      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 3 });
+      mockResolveNextTarget.mockReturnValue(directTarget);
       expect(() =>
         renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station }))),
       ).not.toThrow();
@@ -358,7 +371,12 @@ describe('useStationAlarm', () => {
         lat: 37.5,
         lng: 127.0,
       };
-      mockResolveNextTarget.mockReturnValue({ nextStationName: '시청', stopsToNextStation: 3 });
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '시청',
+        stopsToNextStation: 3,
+        isTransfer: true,
+        stopsToDestination: 8,
+      });
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: offRouteStation })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
@@ -381,7 +399,13 @@ describe('useStationAlarm', () => {
         lng: 127.0,
       };
       const onRouteStation = makeStation('S1', '서울'); // line '2' (toLine)
-      mockResolveNextTarget.mockReturnValue({ nextStationName: '시청', stopsToNextStation: 2 });
+      const transferTarget = {
+        nextStationName: '시청',
+        stopsToNextStation: 2,
+        isTransfer: true,
+        stopsToDestination: 7,
+      };
+      mockResolveNextTarget.mockReturnValue(transferTarget);
 
       const { rerender } = renderHook(
         ({ s }: { s: Station }) =>
@@ -392,7 +416,7 @@ describe('useStationAlarm', () => {
 
       rerender({ s: onRouteStation });
       expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('서울', '강남', 2);
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('서울', '강남', transferTarget);
     });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -86,8 +86,7 @@ export function useStationAlarm({
     ) {
       lastNotifiedStationIdRef.current = nearestStation.id;
       const target = resolveNextTarget(route, destination.name);
-      const stopsRemaining = target?.stopsToNextStation ?? null;
-      sendStationPassedNotification(nearestStation.name, destination.name, stopsRemaining)
+      sendStationPassedNotification(nearestStation.name, destination.name, target)
         .catch((e) => logger.error('역 통과 알림 실패:', e));
     }
   }, [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -141,7 +141,8 @@
     "approximateDistance": "~{{m}}m",
     "stationPassed": "Passed {{name}}",
     "stopsRemainingToDestination_one": "{{count}} stop to {{destination}}",
-    "stopsRemainingToDestination_other": "{{count}} stops to {{destination}}"
+    "stopsRemainingToDestination_other": "{{count}} stops to {{destination}}",
+    "stopsRemainingViaTransfer": "{{transferStops}} stops to {{transfer}} transfer · {{totalStops}} stops to {{destination}}"
   },
   "lines": {
     "1": "Line 1",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -141,7 +141,8 @@
     "approximateDistance": "약 {{m}}m",
     "stationPassed": "{{name}}역 통과",
     "stopsRemainingToDestination_one": "{{destination}}까지 {{count}}정거장 남음",
-    "stopsRemainingToDestination_other": "{{destination}}까지 {{count}}정거장 남음"
+    "stopsRemainingToDestination_other": "{{destination}}까지 {{count}}정거장 남음",
+    "stopsRemainingViaTransfer": "{{transfer}} 환승까지 {{transferStops}}정거장 · {{destination}}까지 {{totalStops}}정거장"
   },
   "lines": {
     "1": "1호선",

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -527,9 +527,14 @@ describe('stationNotification', () => {
   });
 
   describe('sendStationPassedNotification', () => {
-    it('stopsRemaining이 있으면 남은 정거장 수를 body에 표시한다', async () => {
+    it('마지막 구간(isTransfer=false)이면 목적지까지 남은 정거장 수를 body에 표시한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendStationPassedNotification('역삼', '강남', 3);
+      await sendStationPassedNotification('역삼', '강남', {
+        nextStationName: '강남',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-passed',
         content: { title: '역삼역 통과', body: '강남까지 3정거장 남음' },
@@ -537,7 +542,25 @@ describe('stationNotification', () => {
       });
     });
 
-    it('stopsRemaining이 null이면 현재 역만 표시한다', async () => {
+    it('환승 전 구간(isTransfer=true)이면 환승역과 최종 목적지를 모두 표시한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendStationPassedNotification('용마산', '이대', {
+        nextStationName: '군자',
+        stopsToNextStation: 2,
+        isTransfer: true,
+        stopsToDestination: 11,
+      });
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-passed',
+        content: {
+          title: '용마산역 통과',
+          body: '군자 환승까지 2정거장 · 이대까지 11정거장',
+        },
+        trigger: null,
+      });
+    });
+
+    it('target이 null이면 현재 역만 표시한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendStationPassedNotification('역삼', '강남', null);
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
@@ -549,7 +572,12 @@ describe('stationNotification', () => {
 
     it('Android에서는 channelId와 priority DEFAULT가 포함된다', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
-      await sendStationPassedNotification('역삼', '강남', 3);
+      await sendStationPassedNotification('역삼', '강남', {
+        nextStationName: '강남',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-passed',
         content: {

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -266,7 +266,12 @@ describe('processLocationUpdate', () => {
 
     const result = await call({ lastNotifiedStationId: 'other-station' });
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
+    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', {
+      nextStationName: '시청',
+      stopsToNextStation: 3,
+      isTransfer: false,
+      stopsToDestination: 3,
+    });
     expect(result.lastNotifiedStationId).toBe('station-1');
   });
 
@@ -286,7 +291,12 @@ describe('processLocationUpdate', () => {
 
     const result = await call({ lastNotifiedStationId: null });
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', 3);
+    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', {
+      nextStationName: '시청',
+      stopsToNextStation: 3,
+      isTransfer: false,
+      stopsToDestination: 3,
+    });
     expect(result.lastNotifiedStationId).toBe('station-1');
   });
 
@@ -368,6 +378,8 @@ describe('resolveNextTarget', () => {
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
       stopsToNextStation: 5,
+      isTransfer: false,
+      stopsToDestination: 5,
     });
   });
 
@@ -379,6 +391,8 @@ describe('resolveNextTarget', () => {
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '동대문',
       stopsToNextStation: 3,
+      isTransfer: true,
+      stopsToDestination: 5,
     });
   });
 
@@ -390,6 +404,8 @@ describe('resolveNextTarget', () => {
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
       stopsToNextStation: 2,
+      isTransfer: false,
+      stopsToDestination: 2,
     });
   });
 
@@ -405,6 +421,8 @@ describe('resolveNextTarget', () => {
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '잠실',
       stopsToNextStation: 3,
+      isTransfer: true,
+      stopsToDestination: 12,
     });
   });
 
@@ -420,6 +438,8 @@ describe('resolveNextTarget', () => {
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '시청',
       stopsToNextStation: 5,
+      isTransfer: true,
+      stopsToDestination: 9,
     });
   });
 
@@ -440,6 +460,22 @@ describe('resolveNextTarget', () => {
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
       stopsToNextStation: 4,
+      isTransfer: false,
+      stopsToDestination: 4,
+    });
+  });
+
+  it('회귀(#214): 환승 전 구간에서 stopsToDestination은 환승 후 구간을 포함한 총합이다', () => {
+    // 용마산 → 군자(환승) → 이대 시나리오: 환승까지 2정거장, 환승 후 9정거장 → 총 11
+    const route: TransferRoute = {
+      type: 'transfer', transferName: '군자', fromLine: '7', toLine: '5',
+      stopsToTransfer: 2, stopsFromTransfer: 9,
+    };
+    expect(resolveNextTarget(route, '이대')).toEqual({
+      nextStationName: '군자',
+      stopsToNextStation: 2,
+      isTransfer: true,
+      stopsToDestination: 11,
     });
   });
 });

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -5,6 +5,7 @@ import { Station } from '../types/station';
 import { LINE_COLORS, LINE_NAMES } from '../constants/lineColors';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from './stationRoute';
 import type { AlarmEvent } from './stationAlarm';
+import type { NextTarget } from './stationPipeline';
 import * as LiveActivity from 'live-activity';
 import { vibrateAlarm, stopVibration } from './alarmSound';
 import { createLogger } from './logger';
@@ -272,15 +273,24 @@ export async function clearStationNotification(): Promise<void> {
 export async function sendStationPassedNotification(
   stationName: string,
   destinationName: string,
-  stopsRemaining: number | null,
+  target: NextTarget | null,
 ): Promise<void> {
-  const body =
-    stopsRemaining != null
-      ? i18next.t('route.stopsRemainingToDestination', {
-          destination: destinationName,
-          count: stopsRemaining,
-        })
-      : i18next.t('route.atCurrentStation', { name: stationName });
+  let body: string;
+  if (target == null) {
+    body = i18next.t('route.atCurrentStation', { name: stationName });
+  } else if (target.isTransfer) {
+    body = i18next.t('route.stopsRemainingViaTransfer', {
+      transfer: target.nextStationName,
+      transferStops: target.stopsToNextStation,
+      destination: destinationName,
+      totalStops: target.stopsToDestination,
+    });
+  } else {
+    body = i18next.t('route.stopsRemainingToDestination', {
+      destination: destinationName,
+      count: target.stopsToDestination,
+    });
+  }
 
   await scheduleNotification(STATION_PASSED_NOTIFICATION_ID, {
     title: i18next.t('route.stationPassed', { name: stationName }),

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -11,29 +11,63 @@ import type { AlarmEvent } from './stationAlarm';
 export interface NextTarget {
   nextStationName: string;
   stopsToNextStation: number;
+  isTransfer: boolean;
+  stopsToDestination: number;
 }
 
 export function resolveNextTarget(route: Route, destinationName: string): NextTarget | null {
   if (!route) return null;
 
   if (route.type === 'direct') {
-    return { nextStationName: destinationName, stopsToNextStation: route.stops };
+    return {
+      nextStationName: destinationName,
+      stopsToNextStation: route.stops,
+      isTransfer: false,
+      stopsToDestination: route.stops,
+    };
   }
 
   if (route.type === 'transfer') {
+    const stopsToDestination = route.stopsToTransfer + route.stopsFromTransfer;
     if (route.stopsToTransfer > 0) {
-      return { nextStationName: route.transferName, stopsToNextStation: route.stopsToTransfer };
+      return {
+        nextStationName: route.transferName,
+        stopsToNextStation: route.stopsToTransfer,
+        isTransfer: true,
+        stopsToDestination,
+      };
     }
-    return { nextStationName: destinationName, stopsToNextStation: route.stopsFromTransfer };
+    return {
+      nextStationName: destinationName,
+      stopsToNextStation: route.stopsFromTransfer,
+      isTransfer: false,
+      stopsToDestination: route.stopsFromTransfer,
+    };
   }
 
   if (route.type === 'multi-transfer') {
-    for (const t of route.transfers) {
+    const { transfers } = route;
+    for (let i = 0; i < transfers.length; i++) {
+      const t = transfers[i];
       if (t.stopsToTransfer > 0) {
-        return { nextStationName: t.transferName, stopsToNextStation: t.stopsToTransfer };
+        let remaining = route.stopsAfterLastTransfer;
+        for (let j = i; j < transfers.length; j++) {
+          remaining += transfers[j].stopsToTransfer;
+        }
+        return {
+          nextStationName: t.transferName,
+          stopsToNextStation: t.stopsToTransfer,
+          isTransfer: true,
+          stopsToDestination: remaining,
+        };
       }
     }
-    return { nextStationName: destinationName, stopsToNextStation: route.stopsAfterLastTransfer };
+    return {
+      nextStationName: destinationName,
+      stopsToNextStation: route.stopsAfterLastTransfer,
+      isTransfer: false,
+      stopsToDestination: route.stopsAfterLastTransfer,
+    };
   }
 
   return null;
@@ -102,7 +136,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       await sendStationPassedNotification(
         nearest.station.name,
         destination.name,
-        target.stopsToNextStation,
+        target,
       );
     }
   }


### PR DESCRIPTION
## Summary

용마산(7호선) → 군자(환승) → 이대(5호선) 경로에서 용마산 통과 시 알림이 `이대까지 2정거장 남음`으로 잘못 표시되던 버그를 수정한다.

- `resolveNextTarget`이 반환하는 "다음 중간 목표(군자)까지의 정거장 수"가 본문에서 최종 목적지 이름(이대)과 함께 포맷되며 사용자가 곧 도착한다고 오해하던 문제.
- `NextTarget`에 `isTransfer`(다음 목표가 환승역인지)와 `stopsToDestination`(현재 위치→최종 목적지 총 정거장 수)을 추가하고, 알림 본문 빌더가 두 케이스를 명확히 분기하도록 변경.

## 변경 동작

| 상황 | Before | After |
|---|---|---|
| 환승 전 구간 (용마산) | `이대까지 2정거장 남음` ❌ | `군자 환승까지 2정거장 · 이대까지 11정거장` ✅ |
| 마지막 구간 (청구) | `이대까지 9정거장 남음` ✅ | `이대까지 9정거장 남음` ✅ (변경 없음) |
| 직통 경로 (역삼) | `강남까지 1정거장 남음` ✅ | `강남까지 1정거장 남음` ✅ (변경 없음) |

## 영향 파일

- `src/utils/stationPipeline.ts` — `NextTarget` 확장 + multi-transfer까지 `stopsToDestination` 계산
- `src/utils/stationNotification.ts` — `sendStationPassedNotification` 시그니처/본문 분기
- `src/hooks/useStationAlarm.ts` — target 객체 그대로 전달
- `src/i18n/locales/{ko,en}.json` — 새 키 `route.stopsRemainingViaTransfer`

## Test plan

- [x] `npm test` — 693/693 통과 · 커버리지 100% 유지
- [x] `npm run type-check` — 통과
- [x] 회귀 테스트 추가: `resolveNextTarget` — 용마산→이대 시나리오 (`stopsToDestination=11`, `nextStationName='군자'`, `isTransfer=true`) 검증
- [x] `sendStationPassedNotification` — isTransfer=true/false 두 본문 포맷 검증
- [x] code-reviewer 에이전트 리뷰 통과 (P1 없음)
- [ ] CI `Type Check & Test` 통과 확인 후 머지

Closes #214