### PR TITLE
feat(#216): i18n Phase 5 — 앱 내 수동 언어 전환 + 자동 감지

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import { useAppStore, type ThemeMode } from '../../src/store/useAppStore';
+import { useAppStore, type ThemeMode, type LocalePreference } from '../../src/store/useAppStore';
 import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
@@ -12,6 +12,12 @@ const THEME_OPTIONS = [
   { value: 'light', labelKey: 'settings.themeLight' },
   { value: 'dark', labelKey: 'settings.themeDark' },
 ] as const satisfies readonly { value: ThemeMode; labelKey: string }[];
+
+const LOCALE_OPTIONS = [
+  { value: 'auto', labelKey: 'settings.languageAuto' },
+  { value: 'ko', labelKey: 'settings.languageKorean' },
+  { value: 'en', labelKey: 'settings.languageEnglish' },
+] as const satisfies readonly { value: LocalePreference; labelKey: string }[];
 
 export default function SettingsScreen() {
   const sleepMode = useAppStore((s) => s.sleepMode);
@@ -26,6 +32,8 @@ export default function SettingsScreen() {
   const routePreference = useAppStore((s) => s.routePreference);
   const setRoutePreference = useAppStore((s) => s.setRoutePreference);
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
+  const localePreference = useAppStore((s) => s.localePreference);
+  const setLocalePreference = useAppStore((s) => s.setLocalePreference);
   const { colors } = useTheme();
   const { t } = useTranslation();
   const showSleepModeGuide = useSleepModeGuide();
@@ -40,6 +48,38 @@ export default function SettingsScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
       <Text style={[styles.header, { color: colors.muted }]}>{t('settings.title')}</Text>
+
+      {/* 언어 */}
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.languageSection')}</Text>
+
+        <View style={styles.settingRow}>
+          <View style={styles.settingInfo}>
+            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.languageLabel')}</Text>
+            <Text style={[styles.settingDesc, { color: colors.muted }]}>
+              {t('settings.languageDescription')}
+            </Text>
+          </View>
+        </View>
+
+        <View style={[styles.segmentGroup, { backgroundColor: colors.hair }]} testID="locale-segment">
+          {LOCALE_OPTIONS.map(({ value, labelKey }) => {
+            const active = localePreference === value;
+            return (
+              <Pressable
+                key={value}
+                style={[styles.segment, active && { backgroundColor: colors.accent }]}
+                onPress={() => setLocalePreference(value)}
+                testID={`locale-${value}`}
+              >
+                <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
+                  {t(labelKey)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
 
       {/* 테마 */}
       <View style={[styles.card, { backgroundColor: colors.card }]}>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -49,101 +49,35 @@ export default function SettingsScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
       <Text style={[styles.header, { color: colors.muted }]}>{t('settings.title')}</Text>
 
-      {/* 언어 */}
-      <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.languageSection')}</Text>
+      <SegmentSetting
+        sectionTitle={t('settings.languageSection')}
+        label={t('settings.languageLabel')}
+        description={t('settings.languageDescription')}
+        testIDPrefix="locale"
+        value={localePreference}
+        onChange={setLocalePreference}
+        options={LOCALE_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
+      />
 
-        <View style={styles.settingRow}>
-          <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.languageLabel')}</Text>
-            <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              {t('settings.languageDescription')}
-            </Text>
-          </View>
-        </View>
+      <SegmentSetting
+        sectionTitle={t('settings.themeSection')}
+        label={t('settings.themeLabel')}
+        description={t('settings.themeDescription')}
+        testIDPrefix="theme"
+        value={themeMode}
+        onChange={setThemeMode}
+        options={THEME_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
+      />
 
-        <View style={[styles.segmentGroup, { backgroundColor: colors.hair }]} testID="locale-segment">
-          {LOCALE_OPTIONS.map(({ value, labelKey }) => {
-            const active = localePreference === value;
-            return (
-              <Pressable
-                key={value}
-                style={[styles.segment, active && { backgroundColor: colors.accent }]}
-                onPress={() => setLocalePreference(value)}
-                testID={`locale-${value}`}
-              >
-                <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
-                  {t(labelKey)}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-      </View>
-
-      {/* 테마 */}
-      <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.themeSection')}</Text>
-
-        <View style={styles.settingRow}>
-          <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.themeLabel')}</Text>
-            <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              {t('settings.themeDescription')}
-            </Text>
-          </View>
-        </View>
-
-        <View style={[styles.segmentGroup, { backgroundColor: colors.hair }]} testID="theme-segment">
-          {THEME_OPTIONS.map(({ value, labelKey }) => {
-            const active = themeMode === value;
-            return (
-              <Pressable
-                key={value}
-                style={[styles.segment, active && { backgroundColor: colors.accent }]}
-                onPress={() => setThemeMode(value)}
-                testID={`theme-${value}`}
-              >
-                <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
-                  {t(labelKey)}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-      </View>
-
-      {/* 경로 */}
-      <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.routeSection')}</Text>
-
-        <View style={styles.settingRow}>
-          <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.routePreferenceLabel')}</Text>
-            <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              {t('settings.routePreferenceDescription')}
-            </Text>
-          </View>
-        </View>
-
-        <View style={[styles.segmentGroup, { backgroundColor: colors.hair }]} testID="route-segment">
-          {ROUTE_CATEGORIES.map((category) => {
-            const active = routePreference === category.key;
-            return (
-              <Pressable
-                key={category.key}
-                style={[styles.segment, active && { backgroundColor: colors.accent }]}
-                onPress={() => setRoutePreference(category.key)}
-                testID={`route-${category.key}`}
-              >
-                <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
-                  {t(`routes.${category.key}`)}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-      </View>
+      <SegmentSetting
+        sectionTitle={t('settings.routeSection')}
+        label={t('settings.routePreferenceLabel')}
+        description={t('settings.routePreferenceDescription')}
+        testIDPrefix="route"
+        value={routePreference}
+        onChange={setRoutePreference}
+        options={ROUTE_CATEGORIES.map((c) => ({ value: c.key, label: t(`routes.${c.key}`) }))}
+      />
 
       {/* 알람 */}
       <View style={[styles.card, { backgroundColor: colors.card }]}>
@@ -201,6 +135,58 @@ export default function SettingsScreen() {
         </View>
       </View>
     </SafeAreaView>
+  );
+}
+
+interface SegmentSettingProps<T extends string> {
+  readonly sectionTitle: string;
+  readonly label: string;
+  readonly description: string;
+  readonly testIDPrefix: string;
+  readonly value: T;
+  readonly onChange: (next: T) => void;
+  readonly options: readonly { value: T; label: string }[];
+}
+
+function SegmentSetting<T extends string>({
+  sectionTitle,
+  label,
+  description,
+  testIDPrefix,
+  value,
+  onChange,
+  options,
+}: SegmentSettingProps<T>) {
+  const { colors } = useTheme();
+  return (
+    <View style={[styles.card, { backgroundColor: colors.card }]}>
+      <Text style={[styles.sectionTitle, { color: colors.muted }]}>{sectionTitle}</Text>
+
+      <View style={styles.settingRow}>
+        <View style={styles.settingInfo}>
+          <Text style={[styles.settingLabel, { color: colors.ink }]}>{label}</Text>
+          <Text style={[styles.settingDesc, { color: colors.muted }]}>{description}</Text>
+        </View>
+      </View>
+
+      <View style={[styles.segmentGroup, { backgroundColor: colors.hair }]} testID={`${testIDPrefix}-segment`}>
+        {options.map(({ value: optionValue, label: optionLabel }) => {
+          const active = value === optionValue;
+          return (
+            <Pressable
+              key={optionValue}
+              style={[styles.segment, active && { backgroundColor: colors.accent }]}
+              onPress={() => onChange(optionValue)}
+              testID={`${testIDPrefix}-${optionValue}`}
+            >
+              <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
+                {optionLabel}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
   );
 }
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,17 @@
+import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
-import { I18nextProvider } from 'react-i18next';
+import { I18nextProvider, useTranslation } from 'react-i18next';
 import { ThemeProvider, useTheme } from '../src/theme';
-import { setupNotificationHandler } from '../src/utils/stationNotification';
-import { setMinLevel } from '../src/utils/logger';
+import { setupNotificationHandler, refreshNotificationChannels } from '../src/utils/stationNotification';
+import { setMinLevel, createLogger } from '../src/utils/logger';
 import { i18n } from '../src/i18n';
+import { useApplyLocale } from '../src/hooks/useApplyLocale';
+import { useAppStore } from '../src/store/useAppStore';
 import '../src/tasks/backgroundLocationTask';
+
+const layoutLogger = createLogger('RootLayout');
 
 SplashScreen.preventAutoHideAsync();
 setupNotificationHandler();
@@ -18,6 +23,20 @@ if (!__DEV__) {
 
 function RootContent() {
   const { isDark } = useTheme();
+  const loadLocalePreference = useAppStore((s) => s.loadLocalePreference);
+  const { i18n: i18nInstance } = useTranslation();
+
+  useEffect(() => {
+    loadLocalePreference();
+  }, []);
+
+  useApplyLocale();
+
+  // 언어 전환 시 Android 알림 채널 이름을 새 언어로 갱신 (권한 다이얼로그 트리거 없이 채널만)
+  useEffect(() => {
+    refreshNotificationChannels().catch((e) => layoutLogger.error('알림 채널 갱신 실패:', e));
+  }, [i18nInstance.language]);
+
   return (
     <>
       <StatusBar style={isDark ? 'light' : 'dark'} />

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -10,3 +10,4 @@ export const ROUTE_KEY = 'subway-now:route';
 export const LAST_NOTIFIED_STATION_KEY = 'subway-now:last-notified-station';
 export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';
 export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
+export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';

--- a/src/hooks/__tests__/useApplyLocale.test.ts
+++ b/src/hooks/__tests__/useApplyLocale.test.ts
@@ -3,6 +3,7 @@ import * as Localization from 'expo-localization';
 import i18next from 'i18next';
 import { resolveLanguage, useApplyLocale } from '../useApplyLocale';
 import { useAppStore } from '../../store/useAppStore';
+import type { LocalePreference } from '../../store/useAppStore';
 
 jest.mock('expo-localization', () => ({
   getLocales: jest.fn(() => [{ languageCode: 'ko' }]),
@@ -10,28 +11,15 @@ jest.mock('expo-localization', () => ({
 }));
 
 describe('resolveLanguage', () => {
-  it('preference=ko면 ko 반환', () => {
-    expect(resolveLanguage('ko', 'en')).toBe('ko');
-  });
-
-  it('preference=en이면 en 반환', () => {
-    expect(resolveLanguage('en', 'ko')).toBe('en');
-  });
-
-  it('auto + OS가 ko면 ko 반환', () => {
-    expect(resolveLanguage('auto', 'ko')).toBe('ko');
-  });
-
-  it('auto + OS가 en이면 en 반환', () => {
-    expect(resolveLanguage('auto', 'en')).toBe('en');
-  });
-
-  it('auto + OS가 미지원 언어면 fallback(en) 반환', () => {
-    expect(resolveLanguage('auto', 'ja')).toBe('en');
-  });
-
-  it('auto + OS가 null이면 fallback(en) 반환', () => {
-    expect(resolveLanguage('auto', null)).toBe('en');
+  it.each([
+    ['ko', 'en', 'ko'],
+    ['en', 'ko', 'en'],
+    ['auto', 'ko', 'ko'],
+    ['auto', 'en', 'en'],
+    ['auto', 'ja', 'en'],
+    ['auto', null, 'en'],
+  ] as const)('resolveLanguage(%s, %s) === %s', (preference, os, expected) => {
+    expect(resolveLanguage(preference as LocalePreference, os)).toBe(expected);
   });
 });
 
@@ -54,44 +42,35 @@ describe('useApplyLocale', () => {
     }
   });
 
-  function setI18nLanguage(lang: string) {
-    Object.defineProperty(i18next, 'language', { value: lang, configurable: true });
+  function arrange(opts: { current: string; preference: LocalePreference; os?: string }) {
+    Object.defineProperty(i18next, 'language', { value: opts.current, configurable: true });
+    useLocalesMock.mockReturnValue([{ languageCode: opts.os ?? 'ko' }]);
+    useAppStore.setState({ localePreference: opts.preference });
+    renderHook(() => useApplyLocale());
   }
 
   it('localePreference=ko이고 현재 언어가 en이면 changeLanguage(ko) 호출', () => {
-    setI18nLanguage('en');
-    useAppStore.setState({ localePreference: 'ko' });
-    renderHook(() => useApplyLocale());
+    arrange({ current: 'en', preference: 'ko' });
     expect(changeLanguageSpy).toHaveBeenCalledWith('ko');
   });
 
   it('현재 i18next.language와 동일한 언어면 changeLanguage 호출 안 함', () => {
-    setI18nLanguage('ko');
-    useAppStore.setState({ localePreference: 'ko' });
-    renderHook(() => useApplyLocale());
+    arrange({ current: 'ko', preference: 'ko' });
     expect(changeLanguageSpy).not.toHaveBeenCalled();
   });
 
   it('auto + OS가 en이면 changeLanguage(en) 호출', () => {
-    setI18nLanguage('ko');
-    useLocalesMock.mockReturnValue([{ languageCode: 'en' }]);
-    useAppStore.setState({ localePreference: 'auto' });
-    renderHook(() => useApplyLocale());
+    arrange({ current: 'ko', preference: 'auto', os: 'en' });
     expect(changeLanguageSpy).toHaveBeenCalledWith('en');
   });
 
   it('auto + OS 미지원이면 fallback(en) 적용', () => {
-    setI18nLanguage('ko');
-    useLocalesMock.mockReturnValue([{ languageCode: 'fr' }]);
-    useAppStore.setState({ localePreference: 'auto' });
-    renderHook(() => useApplyLocale());
+    arrange({ current: 'ko', preference: 'auto', os: 'fr' });
     expect(changeLanguageSpy).toHaveBeenCalledWith('en');
   });
 
   it('changeLanguage가 reject돼도 throw하지 않는다', () => {
-    setI18nLanguage('ko');
     changeLanguageSpy.mockRejectedValue(new Error('boom'));
-    useAppStore.setState({ localePreference: 'en' });
-    expect(() => renderHook(() => useApplyLocale())).not.toThrow();
+    expect(() => arrange({ current: 'ko', preference: 'en' })).not.toThrow();
   });
 });

--- a/src/hooks/__tests__/useApplyLocale.test.ts
+++ b/src/hooks/__tests__/useApplyLocale.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react-native';
+import * as Localization from 'expo-localization';
+import i18next from 'i18next';
+import { resolveLanguage, useApplyLocale } from '../useApplyLocale';
+import { useAppStore } from '../../store/useAppStore';
+
+jest.mock('expo-localization', () => ({
+  getLocales: jest.fn(() => [{ languageCode: 'ko' }]),
+  useLocales: jest.fn(() => [{ languageCode: 'ko' }]),
+}));
+
+describe('resolveLanguage', () => {
+  it('preference=ko면 ko 반환', () => {
+    expect(resolveLanguage('ko', 'en')).toBe('ko');
+  });
+
+  it('preference=en이면 en 반환', () => {
+    expect(resolveLanguage('en', 'ko')).toBe('en');
+  });
+
+  it('auto + OS가 ko면 ko 반환', () => {
+    expect(resolveLanguage('auto', 'ko')).toBe('ko');
+  });
+
+  it('auto + OS가 en이면 en 반환', () => {
+    expect(resolveLanguage('auto', 'en')).toBe('en');
+  });
+
+  it('auto + OS가 미지원 언어면 fallback(en) 반환', () => {
+    expect(resolveLanguage('auto', 'ja')).toBe('en');
+  });
+
+  it('auto + OS가 null이면 fallback(en) 반환', () => {
+    expect(resolveLanguage('auto', null)).toBe('en');
+  });
+});
+
+describe('useApplyLocale', () => {
+  const useLocalesMock = Localization.useLocales as jest.Mock;
+  let changeLanguageSpy: jest.SpyInstance;
+  let originalLanguageDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    useAppStore.setState({ localePreference: 'auto' });
+    useLocalesMock.mockReturnValue([{ languageCode: 'ko' }]);
+    changeLanguageSpy = jest.spyOn(i18next, 'changeLanguage').mockResolvedValue(undefined as never);
+    originalLanguageDescriptor = Object.getOwnPropertyDescriptor(i18next, 'language');
+  });
+
+  afterEach(() => {
+    changeLanguageSpy.mockRestore();
+    if (originalLanguageDescriptor) {
+      Object.defineProperty(i18next, 'language', originalLanguageDescriptor);
+    }
+  });
+
+  function setI18nLanguage(lang: string) {
+    Object.defineProperty(i18next, 'language', { value: lang, configurable: true });
+  }
+
+  it('localePreference=ko이고 현재 언어가 en이면 changeLanguage(ko) 호출', () => {
+    setI18nLanguage('en');
+    useAppStore.setState({ localePreference: 'ko' });
+    renderHook(() => useApplyLocale());
+    expect(changeLanguageSpy).toHaveBeenCalledWith('ko');
+  });
+
+  it('현재 i18next.language와 동일한 언어면 changeLanguage 호출 안 함', () => {
+    setI18nLanguage('ko');
+    useAppStore.setState({ localePreference: 'ko' });
+    renderHook(() => useApplyLocale());
+    expect(changeLanguageSpy).not.toHaveBeenCalled();
+  });
+
+  it('auto + OS가 en이면 changeLanguage(en) 호출', () => {
+    setI18nLanguage('ko');
+    useLocalesMock.mockReturnValue([{ languageCode: 'en' }]);
+    useAppStore.setState({ localePreference: 'auto' });
+    renderHook(() => useApplyLocale());
+    expect(changeLanguageSpy).toHaveBeenCalledWith('en');
+  });
+
+  it('auto + OS 미지원이면 fallback(en) 적용', () => {
+    setI18nLanguage('ko');
+    useLocalesMock.mockReturnValue([{ languageCode: 'fr' }]);
+    useAppStore.setState({ localePreference: 'auto' });
+    renderHook(() => useApplyLocale());
+    expect(changeLanguageSpy).toHaveBeenCalledWith('en');
+  });
+
+  it('changeLanguage가 reject돼도 throw하지 않는다', () => {
+    setI18nLanguage('ko');
+    changeLanguageSpy.mockRejectedValue(new Error('boom'));
+    useAppStore.setState({ localePreference: 'en' });
+    expect(() => renderHook(() => useApplyLocale())).not.toThrow();
+  });
+});

--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -140,7 +140,7 @@ describe('useBackgroundLocation', () => {
     expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
   });
 
-  // ── 태스크가 이미 등록된 경우 ──
+  // ── 태스크가 이미 등록된 경우: GPS 추적 공백 방지를 위해 재시작하지 않음 ──
 
   it('태스크가 이미 등록되어 있으면 startLocationUpdatesAsync를 호출하지 않는다', async () => {
     mockIsTaskRegisteredAsync.mockResolvedValueOnce(true);

--- a/src/hooks/useApplyLocale.ts
+++ b/src/hooks/useApplyLocale.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import * as Localization from 'expo-localization';
+import i18next from 'i18next';
+import { useAppStore } from '../store/useAppStore';
+import { FALLBACK_LANGUAGE, SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
+
+export function resolveLanguage(
+  preference: 'auto' | 'ko' | 'en',
+  osLanguageCode: string | null | undefined,
+): SupportedLanguage {
+  if (preference === 'auto') {
+    return SUPPORTED_LANGUAGES.find((lang) => lang === osLanguageCode) ?? FALLBACK_LANGUAGE;
+  }
+  return preference;
+}
+
+// 사용자 명시 선택(localePreference) + auto 모드의 OS 언어 변화에 반응해
+// i18next 인스턴스의 활성 언어를 동기화한다.
+export function useApplyLocale(): void {
+  const localePreference = useAppStore((s) => s.localePreference);
+  const locales = Localization.useLocales();
+  const osLanguageCode = locales[0]?.languageCode;
+
+  useEffect(() => {
+    const next = resolveLanguage(localePreference, osLanguageCode);
+    if (i18next.language !== next) {
+      i18next.changeLanguage(next).catch(() => {});
+    }
+  }, [localePreference, osLanguageCode]);
+}

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
-import i18next from 'i18next';
+import { useTranslation } from 'react-i18next';
 import type { Station } from '../types/station';
 import { BACKGROUND_LOCATION_TASK } from '../tasks/backgroundLocationTask';
 import { createLogger } from '../utils/logger';
@@ -12,6 +12,8 @@ const logger = createLogger('BackgroundLocation');
 const noop = () => {};
 
 export function useBackgroundLocation(destination: Station | null): void {
+  const { t } = useTranslation();
+
   useEffect(() => {
     if (!destination) {
       Location.stopLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(noop);
@@ -38,11 +40,12 @@ export function useBackgroundLocation(destination: Station | null): void {
         pausesUpdatesAutomatically: false,
         distanceInterval: 20,
         showsBackgroundLocationIndicator: true,
-        // foregroundService 텍스트는 서비스 시작 시점에 OS에 고정됨.
-        // 런타임 언어 변경 반영은 Phase 5(알림 채널/포그라운드 서비스 마이그레이션)에서 처리.
+        // foregroundService 알림 텍스트는 task 시작 시점 언어로 고정. 사용자가 추적 중 언어를
+        // 바꿔도 GPS 추적 공백을 만들지 않기 위해 i18n.language를 deps에 두지 않는다.
+        // 다음 destination 변경 시점에 자연스럽게 새 언어로 반영된다.
         foregroundService: {
-          notificationTitle: i18next.t('background.title'),
-          notificationBody: i18next.t('background.body'),
+          notificationTitle: t('background.title'),
+          notificationBody: t('background.body'),
         },
       });
       logger.info('백그라운드 위치 추적 시작');
@@ -52,5 +55,6 @@ export function useBackgroundLocation(destination: Station | null): void {
       cancelled = true;
       Location.stopLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(noop);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [destination?.id]);
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -60,7 +60,13 @@
     "speakerOutputDescription": "Plays the alarm through the speaker even without earphones",
     "speakerOffTitle": "Turn off speaker output",
     "speakerOffMessage": "Disabling speaker output will play only vibration when earphones are not connected. Continue?",
-    "speakerOffConfirm": "Turn off"
+    "speakerOffConfirm": "Turn off",
+    "languageSection": "Language",
+    "languageLabel": "App language",
+    "languageDescription": "Auto follows your device setting",
+    "languageAuto": "Auto",
+    "languageKorean": "Korean",
+    "languageEnglish": "English"
   },
   "map": {
     "originBadge": "Origin",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -60,7 +60,13 @@
     "speakerOutputDescription": "이어폰 미연결 시에도 알람음을 스피커로 재생합니다",
     "speakerOffTitle": "스피커 출력 끄기",
     "speakerOffMessage": "스피커 출력을 끄면 이어폰이 연결되지 않은 상태에서 진동만 울립니다. 계속하시겠습니까?",
-    "speakerOffConfirm": "끄기"
+    "speakerOffConfirm": "끄기",
+    "languageSection": "언어",
+    "languageLabel": "앱 언어",
+    "languageDescription": "자동은 기기 설정을 따릅니다",
+    "languageAuto": "자동",
+    "languageKorean": "한국어",
+    "languageEnglish": "English"
   },
   "map": {
     "originBadge": "출발",

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -559,9 +559,7 @@ describe('useAppStore', () => {
   });
 
   it('setLocalePreference: 상태를 업데이트하고 AsyncStorage에 저장한다', async () => {
-    const { setLocalePreference } = useAppStore.getState();
-    await setLocalePreference('en');
-
+    await useAppStore.getState().setLocalePreference('en');
     expect(useAppStore.getState().localePreference).toBe('en');
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:locale-preference',
@@ -575,22 +573,16 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().localePreference).toBe('ko');
   });
 
-  it('loadLocalePreference: 유효하지 않은 값이면 auto 유지', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify('jp'));
-    useAppStore.setState({ localePreference: 'auto' });
-    await useAppStore.getState().loadLocalePreference();
-    expect(useAppStore.getState().localePreference).toBe('auto');
-  });
-
-  it('loadLocalePreference: 비어있으면 auto 유지', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
-    useAppStore.setState({ localePreference: 'auto' });
-    await useAppStore.getState().loadLocalePreference();
-    expect(useAppStore.getState().localePreference).toBe('auto');
-  });
-
-  it('loadLocalePreference: AsyncStorage 오류 시 auto 유지', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+  it.each([
+    ['invalid value', JSON.stringify('jp')],
+    ['null', null],
+    ['storage error', new Error('storage error')],
+  ])('loadLocalePreference: %s이면 auto 유지', async (_label, raw) => {
+    if (raw instanceof Error) {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(raw);
+    } else {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(raw);
+    }
     useAppStore.setState({ localePreference: 'auto' });
     await useAppStore.getState().loadLocalePreference();
     expect(useAppStore.getState().localePreference).toBe('auto');

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -26,7 +26,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', alarmEvent: null });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null });
     jest.clearAllMocks();
   });
 
@@ -550,5 +550,49 @@ describe('useAppStore', () => {
 
     const { alarmEvent } = useAppStore.getState();
     expect(alarmEvent).toBeNull();
+  });
+
+  // ── localePreference ──
+
+  it('초기 localePreference는 auto이다', () => {
+    expect(useAppStore.getState().localePreference).toBe('auto');
+  });
+
+  it('setLocalePreference: 상태를 업데이트하고 AsyncStorage에 저장한다', async () => {
+    const { setLocalePreference } = useAppStore.getState();
+    await setLocalePreference('en');
+
+    expect(useAppStore.getState().localePreference).toBe('en');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:locale-preference',
+      JSON.stringify('en'),
+    );
+  });
+
+  it('loadLocalePreference: AsyncStorage에서 ko를 복원한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify('ko'));
+    await useAppStore.getState().loadLocalePreference();
+    expect(useAppStore.getState().localePreference).toBe('ko');
+  });
+
+  it('loadLocalePreference: 유효하지 않은 값이면 auto 유지', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify('jp'));
+    useAppStore.setState({ localePreference: 'auto' });
+    await useAppStore.getState().loadLocalePreference();
+    expect(useAppStore.getState().localePreference).toBe('auto');
+  });
+
+  it('loadLocalePreference: 비어있으면 auto 유지', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+    useAppStore.setState({ localePreference: 'auto' });
+    await useAppStore.getState().loadLocalePreference();
+    expect(useAppStore.getState().localePreference).toBe('auto');
+  });
+
+  it('loadLocalePreference: AsyncStorage 오류 시 auto 유지', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+    useAppStore.setState({ localePreference: 'auto' });
+    await useAppStore.getState().loadLocalePreference();
+    expect(useAppStore.getState().localePreference).toBe('auto');
   });
 });

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -2,10 +2,13 @@ import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Station } from '../types/station';
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY } from '../constants/storageKeys';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 
 export type ThemeMode = 'auto' | 'light' | 'dark';
+export type LocalePreference = 'auto' | 'ko' | 'en';
+
+const LOCALE_PREFERENCES: readonly LocalePreference[] = ['auto', 'ko', 'en'];
 
 export type { AlarmEvent };
 
@@ -21,6 +24,7 @@ interface AppState {
   customOrigin: Station | null;
   themeMode: ThemeMode;
   routePreference: RoutePreference;
+  localePreference: LocalePreference;
   alarmEvent: AlarmEvent | null;
   addFavorite: (station: Station) => Promise<void>;
   removeFavorite: (stationId: string) => Promise<void>;
@@ -33,6 +37,8 @@ interface AppState {
   loadThemeMode: () => Promise<void>;
   setRoutePreference: (pref: RoutePreference) => Promise<void>;
   loadRoutePreference: () => Promise<void>;
+  setLocalePreference: (pref: LocalePreference) => Promise<void>;
+  loadLocalePreference: () => Promise<void>;
   setSleepMode: (enabled: boolean) => Promise<void>;
   loadSleepMode: () => Promise<void>;
   setAllowSpeaker: (enabled: boolean) => Promise<void>;
@@ -51,6 +57,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   customOrigin: null,
   themeMode: 'auto' as ThemeMode,
   routePreference: 'optimal' as RoutePreference,
+  localePreference: 'auto' as LocalePreference,
   alarmEvent: null,
 
   loadFavorites: async () => {
@@ -148,6 +155,25 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     } catch {
       // 저장된 데이터 없음 — 'optimal' 유지
+    }
+  },
+
+  setLocalePreference: async (pref: LocalePreference) => {
+    set({ localePreference: pref });
+    await AsyncStorage.setItem(LOCALE_PREFERENCE_KEY, JSON.stringify(pref));
+  },
+
+  loadLocalePreference: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(LOCALE_PREFERENCE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (LOCALE_PREFERENCES.includes(parsed)) {
+          set({ localePreference: parsed });
+        }
+      }
+    } catch {
+      // 저장된 데이터 없음 — 'auto' 유지
     }
   },
 

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -52,39 +52,48 @@ export function setupNotificationHandler(): void {
   });
 }
 
+const STATION_CHANNEL_ID = 'station';
+
+// Android 알림 채널을 현재 언어 기준으로 재생성. 권한 다이얼로그를 트리거하지 않으므로
+// 언어 전환마다 호출해도 안전.
+export async function refreshNotificationChannels(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  await Notifications.deleteNotificationChannelAsync(STATION_CHANNEL_ID).catch(() => {});
+  await Notifications.setNotificationChannelAsync(STATION_CHANNEL_ID, {
+    name: i18next.t('notifications.channelStation'),
+    importance: Notifications.AndroidImportance.HIGH,
+    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+  });
+  await Notifications.deleteNotificationChannelAsync(ALARM_CHANNEL_ID).catch(() => {});
+  await Notifications.setNotificationChannelAsync(ALARM_CHANNEL_ID, {
+    name: i18next.t('notifications.channelTransferAlarm'),
+    importance: Notifications.AndroidImportance.MAX,
+    sound: 'alarm.wav',
+    enableVibrate: true,
+    vibrationPattern: [0, 1000, 500, 1000],
+    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+    bypassDnd: true,
+  });
+  await Notifications.deleteNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID).catch(() => {});
+  await Notifications.setNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID, {
+    name: i18next.t('notifications.channelTransferAlarmSilent'),
+    importance: Notifications.AndroidImportance.MAX,
+    sound: null,
+    enableVibrate: true,
+    vibrationPattern: [0, 1000, 500, 1000],
+    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+    bypassDnd: true,
+  });
+  await Notifications.deleteNotificationChannelAsync(STATION_PASSED_CHANNEL_ID).catch(() => {});
+  await Notifications.setNotificationChannelAsync(STATION_PASSED_CHANNEL_ID, {
+    name: i18next.t('notifications.channelStationPass'),
+    importance: Notifications.AndroidImportance.DEFAULT,
+    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+  });
+}
+
 export async function initStationNotification(): Promise<void> {
-  if (Platform.OS === 'android') {
-    await Notifications.setNotificationChannelAsync('station', {
-      name: i18next.t('notifications.channelStation'),
-      importance: Notifications.AndroidImportance.HIGH,
-      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-    });
-    await Notifications.deleteNotificationChannelAsync(ALARM_CHANNEL_ID).catch(() => {});
-    await Notifications.setNotificationChannelAsync(ALARM_CHANNEL_ID, {
-      name: i18next.t('notifications.channelTransferAlarm'),
-      importance: Notifications.AndroidImportance.MAX,
-      sound: 'alarm.wav',
-      enableVibrate: true,
-      vibrationPattern: [0, 1000, 500, 1000],
-      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-      bypassDnd: true,
-    });
-    await Notifications.deleteNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID).catch(() => {});
-    await Notifications.setNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID, {
-      name: i18next.t('notifications.channelTransferAlarmSilent'),
-      importance: Notifications.AndroidImportance.MAX,
-      sound: null,
-      enableVibrate: true,
-      vibrationPattern: [0, 1000, 500, 1000],
-      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-      bypassDnd: true,
-    });
-    await Notifications.setNotificationChannelAsync(STATION_PASSED_CHANNEL_ID, {
-      name: i18next.t('notifications.channelStationPass'),
-      importance: Notifications.AndroidImportance.DEFAULT,
-      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-    });
-  }
+  await refreshNotificationChannels();
   const { status } = await Notifications.requestPermissionsAsync({
     ios: {
       allowAlert: true,


### PR DESCRIPTION
## Summary

설정 화면에서 사용자가 **자동 / 한국어 / 영어** 중 직접 선택할 수 있도록 하고, 자동 모드는 OS 언어 변경을 실시간으로 따라간다. Android 알림 채널 이름도 언어 전환 시 즉시 갱신.

## 변경 사항

### 상태 관리
- `localePreference: 'auto' | 'ko' | 'en'` Zustand store에 추가, AsyncStorage 영속화
- `LOCALE_PREFERENCE_KEY` 상수 추가

### 새 훅 `useApplyLocale`
- `resolveLanguage(preference, osLanguageCode)` 순수 함수로 우선순위 결정
  - 사용자 명시 선택 (`ko`/`en`) > 자동 모드 → OS 언어 > fallback (`en`)
- `Localization.useLocales()` 구독으로 OS 언어 변경 실시간 반영
- store/OS 변화 시 `i18next.changeLanguage()` 호출

### 설정 화면
- 새 "언어 / Language" 섹션 + 3-segment control
- 키: `settings.languageSection`, `languageLabel`, `languageDescription`, `languageAuto`, `languageKorean`, `languageEnglish`

### Android 알림 채널 갱신
- `refreshNotificationChannels()` 함수로 채널 재생성 로직 분리 — 권한 다이얼로그 없이 호출 가능
- `initStationNotification()`은 첫 실행 시 + 권한 요청에만 사용
- `app/_layout.tsx`에서 `i18n.language` 변경 시 `refreshNotificationChannels()` 자동 호출

## 핵심 결정

| 결정 | 값 |
|---|---|
| 첫 진입 기본값 | `auto` |
| OS 언어 감지 | `Localization.useLocales()` 훅 |
| Android 채널 마이그레이션 | 기존 ID 유지 + delete-recreate로 이름 갱신 |
| 포그라운드 서비스 텍스트 갱신 | **하지 않음** — 추적 중 GPS 공백 방지 위해 `i18n.language`를 deps에서 제외. 다음 destination 변경 시점에 자연 반영 |

## 비범위 (후속)

- Phase 4: 역명 영문 데이터 (Seoul Metro 공식 로마자)
- util→view i18n 결합 분리 리팩토링

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — **50 suites / 708 tests** / 커버리지 100%
- [x] code-reviewer 통과 (P1 두 건 + P2 두 건 반영)
- [ ] CI `Type Check & Test` 통과 후 머지

Closes #216