### PR TITLE
fix(#219): 경로 진행 중일 때만 Live Activity(실시간 현황) 표시

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -157,31 +157,28 @@ export default function HomeScreen() {
     const currDestId = destination?.id ?? null;
     prevDestIdRef.current = currDestId;
 
-    if (!effectiveOrigin) {
+    // 실시간 현황(Live Activity/알림)은 경로 진행 중일 때만 노출한다.
+    if (!effectiveOrigin || !destination) {
       if (prevNotifKeyRef.current !== 'none') {
         prevNotifKeyRef.current = 'none';
-        logger.info('역 없음 → 알림 해제');
-        clearStationNotification();
+        logger.info('경로 없음 → 알림 해제');
+        clearAlarmNotification().catch((e) => logger.error('알림 해제 실패:', e));
+        clearStationNotification().catch((e) => logger.error('알림 해제 실패:', e));
       }
       return;
     }
-    const key = `${effectiveOrigin.id}__${destination?.id ?? ''}__${displayEta ?? ''}__${arrivalIsMock}__${alarmEvent?.type ?? ''}`;
+    const key = `${effectiveOrigin.id}__${destination.id}__${displayEta ?? ''}__${arrivalIsMock}__${alarmEvent?.type ?? ''}`;
     if (key === prevNotifKeyRef.current) return;
     prevNotifKeyRef.current = key;
 
-    const destinationCleared = prevDestId != null && currDestId == null;
-    const destinationChanged = prevDestId != null && currDestId != null && prevDestId !== currDestId;
+    const destinationChanged = prevDestId != null && prevDestId !== currDestId;
     const update = async () => {
-      if (destinationCleared || destinationChanged) {
-        if (destinationCleared) {
-          logger.info('목적지 해제 → Live Activity 종료 후 재시작');
-        } else {
-          logger.info('목적지 변경 → 이전 알림 교체');
-        }
+      if (destinationChanged) {
+        logger.info('목적지 변경 → 이전 알림 교체');
         await clearAlarmNotification();
         await clearStationNotification();
       }
-      logger.info('알림 업데이트:', effectiveOrigin.name, destination ? `→ ${destination.name}` : '');
+      logger.info('알림 업데이트:', effectiveOrigin.name, `→ ${destination.name}`);
       await updateStationNotification(
         effectiveOrigin,
         isCustomOrigin ? 0 : Math.round((result?.distanceKm ?? 0) * 1000),

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -32,18 +32,6 @@ jest.mock('../../utils/stationAlarm', () => ({
   alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
 }));
 
-// ── stationNotification 모킹 ──
-const mockUpdateStationNotification = jest.fn();
-jest.mock('../../utils/stationNotification', () => ({
-  updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
-}));
-
-// ── findNearestStation 모킹 ──
-const mockFindNearestStation = jest.fn();
-jest.mock('../../utils/findNearestStation', () => ({
-  findNearestStation: (...args: unknown[]) => mockFindNearestStation(...args),
-}));
-
 // ── logger 모킹 ──
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
@@ -56,7 +44,6 @@ jest.mock('../../utils/logger', () => ({
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AlarmEvent } from '../../utils/stationAlarm';
-import type { NearestStationResult } from '../../types/station';
 // 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
 import '../../tasks/backgroundLocationTask';
 import { BACKGROUND_LOCATION_TASK } from '../../tasks/backgroundLocationTask';
@@ -143,8 +130,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
-    mockUpdateStationNotification.mockResolvedValue(undefined);
-    mockFindNearestStation.mockReturnValue(null);
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -177,38 +162,16 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     expect(AsyncStorage.getItem).not.toHaveBeenCalled();
   });
 
-  // ── 목적지 미설정 + nearest 없음 ──
+  // ── 목적지 미설정: 실시간 현황을 띄우지 않는다 ──
 
-  it('destJson이 없고 findNearestStation이 null을 반환하면 updateStationNotification을 호출하지 않는다', async () => {
+  it('destJson이 없으면 processLocationUpdate를 호출하지 않고 즉시 return한다', async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-    mockFindNearestStation.mockReturnValue(null);
-
-    await taskCallback({
-      data: { locations: [makeLocation(37.5, 127.0)] },
-      error: null,
-    });
-
-    expect(mockUpdateStationNotification).not.toHaveBeenCalled();
-    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
-  });
-
-  // ── 목적지 미설정 + nearest 있음 ──
-
-  it('destJson이 없고 nearest가 있으면 updateStationNotification만 호출한다', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-    const nearestResult: NearestStationResult = {
-      station: mockStation,
-      distanceKm: 0.2,
-    };
-    mockFindNearestStation.mockReturnValue(nearestResult);
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
       error: null,
     });
 
-    // Math.round(0.2 * 1000) = 200
-    expect(mockUpdateStationNotification).toHaveBeenCalledWith(mockStation, 200);
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
   });
 
@@ -441,8 +404,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── 마지막 location 선택 ──
 
   it('locations 배열의 마지막 요소를 사용한다', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-    mockFindNearestStation.mockReturnValue(null);
+    mockStorageValues(JSON.stringify(mockDestination));
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
 
     const loc1 = makeLocation(37.1, 127.1);
     const loc2 = makeLocation(37.9, 127.9); // 마지막
@@ -452,7 +415,10 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(mockFindNearestStation).toHaveBeenCalledWith(37.9, 127.9, 1.0);
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      lat: 37.9,
+      lng: 127.9,
+    }));
   });
 
   // ── stale 위치 / 저정확도 게이트 ──
@@ -462,7 +428,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   const expectGateBlocked = () => {
     expect(AsyncStorage.getItem).not.toHaveBeenCalled();
-    expect(mockFindNearestStation).not.toHaveBeenCalled();
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
   };
 
@@ -495,7 +460,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('accuracy가 임계값(150m) 이내면 통과한다', async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-    mockFindNearestStation.mockReturnValue(null);
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028, { accuracy: 100 })] },

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -3,11 +3,8 @@ import * as Location from 'expo-location';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from '../utils/stationPipeline';
 import { alarmKey } from '../utils/stationAlarm';
-import { updateStationNotification } from '../utils/stationNotification';
-import { findNearestStation } from '../utils/findNearestStation';
 import { createLogger } from '../utils/logger';
 import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
-import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
 import type { Route } from '../utils/stationRoute';
 
@@ -43,17 +40,8 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       AsyncStorage.getItem(ALLOW_SPEAKER_KEY),
     ]);
 
-    // 목적지 미설정 시 현재 역 알림만 업데이트
-    if (!destJson) {
-      const nearest = findNearestStation(latitude, longitude, MAX_STATION_DISTANCE_KM);
-      if (nearest) {
-        await updateStationNotification(
-          nearest.station,
-          Math.round(nearest.distanceKm * 1000),
-        );
-      }
-      return;
-    }
+    // 경로(목적지) 없으면 백그라운드에서도 실시간 현황 알림을 띄우지 않는다.
+    if (!destJson) return;
 
     let destination;
     try {


### PR DESCRIPTION
## Summary
- 목적지가 없을 때 Live Activity / 실시간 현황 알림이 계속 떠 있던 문제 수정
- HomeScreen 알림 `useEffect`에서 `!destination`이면 알림 클리어 후 early return — Live Activity를 "현재 역" 모드로 (재)시작하지 않는다
- `backgroundLocationTask`의 destination 없을 때 fallback 알림 경로 제거 (관련 import 정리)

## Why
GPS로 근처 역만 잡혀도 Live Activity가 켜졌다. 사용자는 경로 진행 중일 때만 실시간 현황이 보이길 원함.

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 49 suites / 692 tests / 커버리지 100% 통과
- [ ] iOS 실기기: 앱 실행 시 Live Activity 안 뜸 → 목적지 설정 시 뜸 → 목적지 해제 시 즉시 사라짐
- [ ] Android: 목적지 없을 때 station notification 없음 확인

Closes #219