### PR TITLE
chore(#222): bump version to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- `package.json` / `package-lock.json` 버전을 1.0.2 → 1.0.3 으로 bump
- 다음 TestFlight 빌드(#38) 배포용

## 포함 변경
- #213 다크모드 영구화 픽스
- #219 경로 진행 중일 때만 Live Activity(실시간 현황) 표시

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (커버리지 100%) — 버전 외 코드 무변경
- [ ] dev → main 머지 후 `eas build --profile production --platform ios`
- [ ] `eas submit --platform ios --latest`

Closes #222