### PR TITLE
chore(#227): bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- `package.json` 1.0.3 → 1.1.0 (minor)
- `app.config.js`의 `ios.buildNumber: "38"` 그대로 (production 미배포 번호 → 첫 1.1.0 빌드가 38이 됨)

## main release용
이 PR 머지 후 dev → main release PR로 묶어서 main 반영. 첫 production 빌드는 **version 1.1.0 / build 38**.

### 포함 변경 (main 첫 반영)
- #213 다크모드 영구화
- #216 i18n Phase 5 — 앱 내 수동 언어 전환 + 자동 감지
- #219 경로 진행 중일 때만 Live Activity
- #221 i18n Phase 4 — 528개 역 영문명 + 표시 헬퍼
- #224 EAS 버전 SoT 로컬 통합

## Test plan
- [x] `npm run type-check`
- [x] `npx expo config --type public` → `version: '1.1.0'`, `buildNumber: '38'`, `versionCode: 1` 확인
- [ ] PR 머지 후 dev → main release PR 생성
- [ ] main에서 `eas build --profile production --platform ios`
- [ ] `eas submit --platform ios --latest`

Closes #227