### PR TITLE
feat(#232): i18n Phase 7 — 열차 방면 표현(trainLineNm) 영문화

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -141,7 +141,6 @@
     "minutesAndTransfers_one": "{{min}}m · {{count}} transfer",
     "minutesAndTransfers_other": "{{min}}m · {{count}} transfers",
     "directOnly": "{{min}}m · Direct",
-    "directionToward": "Toward {{name}}",
     "currentStation": "{{name}}",
     "atCurrentStation": "Currently at {{name}}",
     "approximateDistance": "~{{m}}m",
@@ -186,5 +185,10 @@
     "summaryWithTransfer_other": "→ {{destination}} · Transfer at {{name}} in {{count}} stops{{etaSuffix}}",
     "summaryDestinationOnly": "→ {{destination}}{{etaSuffix}}",
     "etaSuffix": " · ~{{min}} min"
+  },
+  "direction": {
+    "boundFor": "Bound for {{name}}",
+    "innerLoop": "Inner Loop",
+    "outerLoop": "Outer Loop"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -141,7 +141,6 @@
     "minutesAndTransfers_one": "{{min}}분 · {{count}}환승",
     "minutesAndTransfers_other": "{{min}}분 · {{count}}환승",
     "directOnly": "{{min}}분 · 직통",
-    "directionToward": "{{name}} 방면",
     "currentStation": "{{name}}역",
     "atCurrentStation": "현재 {{name}}역",
     "approximateDistance": "약 {{m}}m",
@@ -182,5 +181,10 @@
     "summaryWithTransfer_other": "→ {{destination}} · {{count}}역 후 {{name}} 환승{{etaSuffix}}",
     "summaryDestinationOnly": "→ {{destination}}{{etaSuffix}}",
     "etaSuffix": " · 약 {{min}}분"
+  },
+  "direction": {
+    "boundFor": "{{name}}행",
+    "innerLoop": "내선순환",
+    "outerLoop": "외선순환"
   }
 }

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -62,10 +62,10 @@ describe('arrivalInfoToArrivalTrain', () => {
   afterEach(() => { jest.restoreAllMocks(); });
 
   it('should convert arrival info with destination', () => {
-    const items = [makeArrivalInfo({ destination: '봉화산', arrivalSeconds: 134 })];
+    const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toEqual([
-      { direction: '봉화산 방면', line: '6', arrivalAtMs: 1000000 + 134 * 1000, subtext: undefined },
+      { direction: '봉화산행', line: '6', arrivalAtMs: 1000000 + 134 * 1000, subtext: undefined },
     ]);
   });
 
@@ -76,15 +76,15 @@ describe('arrivalInfoToArrivalTrain', () => {
   });
 
   it('should include statusMessage as subtext when present', () => {
-    const items = [makeArrivalInfo({ destination: '응암', arrivalSeconds: 271, statusMessage: '전역 출발' })];
+    const items = [makeArrivalInfo({ destination: '응암행', arrivalSeconds: 271, statusMessage: '전역 출발' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result[0].subtext).toBe('전역 출발');
   });
 
   it('should handle multiple items', () => {
     const items = [
-      makeArrivalInfo({ destination: '봉화산', arrivalSeconds: 134 }),
-      makeArrivalInfo({ destination: '응암', arrivalSeconds: 271, statusMessage: '진입 중', trainCode: 'T002' }),
+      makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 }),
+      makeArrivalInfo({ destination: '응암행', arrivalSeconds: 271, statusMessage: '진입 중', trainCode: 'T002' }),
     ];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toHaveLength(2);
@@ -93,7 +93,7 @@ describe('arrivalInfoToArrivalTrain', () => {
   });
 
   it('should handle special line number', () => {
-    const items = [makeArrivalInfo({ destination: '인천공항', arrivalSeconds: 600, trainCode: 'A001' })];
+    const items = [makeArrivalInfo({ destination: '인천공항행', arrivalSeconds: 600, trainCode: 'A001' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', 'airport');
     expect(result[0].line).toBe('airport');
   });

--- a/src/utils/__tests__/trainLineDirection.test.ts
+++ b/src/utils/__tests__/trainLineDirection.test.ts
@@ -13,60 +13,21 @@ describe('parseTrainLineDirection', () => {
     await i18next.changeLanguage('ko');
   });
 
-  describe('내선/외선순환', () => {
-    it('한글 모드: 내선순환은 그대로', () => {
-      expect(parseTrainLineDirection('내선순환', stations)).toBe('내선순환');
-    });
-
-    it('영문 모드: 내선순환 → Inner Loop', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('내선순환', stations)).toBe('Inner Loop');
-    });
-
-    it('한글 모드: 외선순환은 그대로', () => {
-      expect(parseTrainLineDirection('외선순환', stations)).toBe('외선순환');
-    });
-
-    it('영문 모드: 외선순환 → Outer Loop', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('외선순환', stations)).toBe('Outer Loop');
-    });
-  });
-
-  describe('X행 패턴', () => {
-    it('한글 모드: 소요산행은 그대로 표시', () => {
-      expect(parseTrainLineDirection('소요산행', stations)).toBe('소요산행');
-    });
-
-    it('영문 모드: 소요산행 → Bound for Soyosan', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('소요산행', stations)).toBe('Bound for Soyosan');
-    });
-
-    it('영문 모드: 매칭 안 되는 역명 → 한글 그대로 boundFor', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('알수없는행', stations)).toBe('Bound for 알수없는');
-    });
-
-    it('nameEn 누락된 역의 X행 → 한글 fallback', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('없는역행', stations)).toBe('Bound for 없는역');
-    });
-  });
-
-  describe('알 수 없는 패턴', () => {
-    it('한글 모드: 패턴 외 입력은 원본 그대로', () => {
-      expect(parseTrainLineDirection('급행임시', stations)).toBe('급행임시');
-    });
-
-    it('영문 모드: 빈 문자열 → 그대로', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('', stations)).toBe('');
-    });
-
-    it('영문 모드: "행" 단독 → 원본 그대로 (빈 역명 가드)', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('행', stations)).toBe('행');
-    });
+  it.each([
+    // [lang, input, expected, 설명]
+    ['ko', '내선순환', '내선순환'],
+    ['en', '내선순환', 'Inner Loop'],
+    ['ko', '외선순환', '외선순환'],
+    ['en', '외선순환', 'Outer Loop'],
+    ['ko', '소요산행', '소요산행'],
+    ['en', '소요산행', 'Bound for Soyosan'],
+    ['en', '알수없는행', 'Bound for 알수없는'],
+    ['en', '없는역행', 'Bound for 없는역'],
+    ['ko', '급행임시', '급행임시'],
+    ['en', '', ''],
+    ['en', '행', '행'],
+  ])('lang=%s, input=%s → %s', async (lang, input, expected) => {
+    await i18next.changeLanguage(lang);
+    expect(parseTrainLineDirection(input, stations)).toBe(expected);
   });
 });

--- a/src/utils/__tests__/trainLineDirection.test.ts
+++ b/src/utils/__tests__/trainLineDirection.test.ts
@@ -1,0 +1,72 @@
+import i18next from 'i18next';
+import { parseTrainLineDirection } from '../trainLineDirection';
+import type { Station } from '../../types/station';
+
+const stations: Station[] = [
+  { id: '1-001', name: '소요산', nameEn: 'Soyosan', line: '1', lineColor: '#0052A4', lat: 37, lng: 127 },
+  { id: '1-141', name: '구로', nameEn: 'Guro', line: '1', lineColor: '#0052A4', lat: 37, lng: 127 },
+  { id: '5-555', name: '없는역', line: '5', lineColor: '#996CAC', lat: 37, lng: 127 },
+];
+
+describe('parseTrainLineDirection', () => {
+  afterEach(async () => {
+    await i18next.changeLanguage('ko');
+  });
+
+  describe('내선/외선순환', () => {
+    it('한글 모드: 내선순환은 그대로', () => {
+      expect(parseTrainLineDirection('내선순환', stations)).toBe('내선순환');
+    });
+
+    it('영문 모드: 내선순환 → Inner Loop', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('내선순환', stations)).toBe('Inner Loop');
+    });
+
+    it('한글 모드: 외선순환은 그대로', () => {
+      expect(parseTrainLineDirection('외선순환', stations)).toBe('외선순환');
+    });
+
+    it('영문 모드: 외선순환 → Outer Loop', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('외선순환', stations)).toBe('Outer Loop');
+    });
+  });
+
+  describe('X행 패턴', () => {
+    it('한글 모드: 소요산행은 그대로 표시', () => {
+      expect(parseTrainLineDirection('소요산행', stations)).toBe('소요산행');
+    });
+
+    it('영문 모드: 소요산행 → Bound for Soyosan', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('소요산행', stations)).toBe('Bound for Soyosan');
+    });
+
+    it('영문 모드: 매칭 안 되는 역명 → 한글 그대로 boundFor', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('알수없는행', stations)).toBe('Bound for 알수없는');
+    });
+
+    it('nameEn 누락된 역의 X행 → 한글 fallback', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('없는역행', stations)).toBe('Bound for 없는역');
+    });
+  });
+
+  describe('알 수 없는 패턴', () => {
+    it('한글 모드: 패턴 외 입력은 원본 그대로', () => {
+      expect(parseTrainLineDirection('급행임시', stations)).toBe('급행임시');
+    });
+
+    it('영문 모드: 빈 문자열 → 그대로', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('', stations)).toBe('');
+    });
+
+    it('영문 모드: "행" 단독 → 원본 그대로 (빈 역명 가드)', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('행', stations)).toBe('행');
+    });
+  });
+});

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -3,6 +3,7 @@ import type { JourneyDisplay } from './stationRoute';
 import type { ArrivalInfo } from '../api/arrivalApi';
 import type { NearestStationResult, LineNumber, Station } from '../types/station';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
+import { parseTrainLineDirection } from './trainLineDirection';
 import stationsData from '../data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -78,12 +79,11 @@ export function arrivalInfoToArrivalTrain(
   line: LineNumber,
 ): ArrivalTrain[] {
   const now = Date.now();
-  // item.destination은 서울 열린데이터 API의 trainLineNm 기반으로 "소요산행", "내선순환" 같은
-  // 방면 표현이 포함되어 순수 역명 lookup이 실패할 수 있다. 매칭 실패 시 한글 원본 그대로 fallback.
-  // 영문 모드에서 방면 표현 자체 번역은 별도 이슈(서울 API 응답 후처리 i18n)로 추적.
+  // item.destination은 서울 열린데이터 API의 trainLineNm 기반("소요산행", "내선순환" 등 방면 표현).
+  // parseTrainLineDirection이 패턴(역명+행, 내선/외선순환)을 인식해 현재 언어로 표시한다.
   return items.map((item) => ({
     direction: item.destination
-      ? i18next.t('route.directionToward', { name: getStationDisplayNameByName(item.destination, allStations) })
+      ? parseTrainLineDirection(item.destination, allStations)
       : direction,
     line,
     arrivalAtMs: now + item.arrivalSeconds * 1000,

--- a/src/utils/trainLineDirection.ts
+++ b/src/utils/trainLineDirection.ts
@@ -1,0 +1,26 @@
+import i18next from 'i18next';
+import type { Station } from '../types/station';
+import { getStationDisplayNameByName } from './stationDisplay';
+
+// 서울 열린데이터 API의 trainLineNm 필드는 순수 역명이 아닌 방면 표현을 담는다:
+//   - "<역명>행" 일반 노선 (소요산행, 성수행, 광운대행 등)
+//   - "내선순환" / "외선순환" 2호선 순환선 특수
+// 이 함수는 패턴을 인식해 현재 언어로 자연스러운 방면 표시를 반환한다.
+// 매칭 안 되는 입력은 원본을 그대로 반환 (fallback).
+export function parseTrainLineDirection(
+  trainLineNm: string,
+  stations: readonly Station[],
+): string {
+  if (trainLineNm === '내선순환') return i18next.t('direction.innerLoop');
+  if (trainLineNm === '외선순환') return i18next.t('direction.outerLoop');
+
+  if (trainLineNm.endsWith('행')) {
+    const stationName = trainLineNm.slice(0, -1);
+    // 빈 역명 가드 — "행" 단독이거나 비정상 입력은 원본 그대로
+    if (stationName.length === 0) return trainLineNm;
+    const displayName = getStationDisplayNameByName(stationName, stations);
+    return i18next.t('direction.boundFor', { name: displayName });
+  }
+
+  return trainLineNm;
+}


### PR DESCRIPTION
## Summary

서울 열린데이터 API의 `realtimeArrivalList[].trainLineNm` 필드(예: `소요산행`, `내선순환`)가 영문 모드에서 한글 그대로 노출되던 문제 해결. 패턴 인식 헬퍼로 `Bound for Soyosan`, `Inner Loop` 등 자연스러운 영문 표시 제공.

## 변경 사항

### 신규
- `src/utils/trainLineDirection.ts` — `parseTrainLineDirection` 헬퍼
  - **내선순환** / **외선순환** 정확 매칭 → `direction.innerLoop` / `outerLoop`
  - **`<역명>행`** 패턴 → stations에서 역명 lookup 후 `direction.boundFor`
  - **빈 역명 / 패턴 외** → 원본 그대로 fallback
- `src/utils/__tests__/trainLineDirection.test.ts` — 11 케이스 (한/영 모드 × 4 패턴 + 가드)

### 수정
- `src/i18n/locales/{ko,en}.json` — `direction.{boundFor, innerLoop, outerLoop}` 키 추가
- `src/utils/journeyAdapter.ts` — `arrivalInfoToArrivalTrain`에서 직접 lookup 대신 `parseTrainLineDirection` 사용
- `src/utils/__tests__/journeyAdapter.test.ts` — fixture를 실제 API 형태(`<역명>행`)로 정정

### 리뷰 P1 반영
- journeyAdapter fixture 불일치 정정 (`'봉화산'` → `'봉화산행'` 등 3곳)
- `route.directionToward` dead key 제거 (이번 PR로 사용처 사라짐)
- `endsWith('행')` 휴리스틱에 빈 역명 가드 추가 (`행` 단독 입력 대비)

## 동작 예시 (영문 모드)

| 입력 | 출력 |
|---|---|
| `소요산행` | `Bound for Soyosan` |
| `내선순환` | `Inner Loop` |
| `외선순환` | `Outer Loop` |
| `없는역행` (stations 누락) | `Bound for 없는역` (한글 fallback) |
| `급행임시` (패턴 외) | `급행임시` (원본) |

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — **52 suites / 737 tests** / 커버리지 100%
- [x] code-reviewer P1 모두 반영
- [ ] CI `Type Check & Test` + `SonarCloud Code Analysis` 통과 후 머지

Closes #232