### PR TITLE
fix(#234): 설정 화면 ScrollView 래핑

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
+import { Alert, Pressable, ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useAppStore, type ThemeMode, type LocalePreference } from '../../src/store/useAppStore';
@@ -45,93 +45,95 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
-      <Text style={[styles.header, { color: colors.muted }]}>{t('settings.title')}</Text>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <Text style={[styles.header, { color: colors.muted }]}>{t('settings.title')}</Text>
 
-      <SegmentSetting
-        sectionTitle={t('settings.languageSection')}
-        label={t('settings.languageLabel')}
-        description={t('settings.languageDescription')}
-        testIDPrefix="locale"
-        value={localePreference}
-        onChange={setLocalePreference}
-        options={LOCALE_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
-      />
+        <SegmentSetting
+          sectionTitle={t('settings.languageSection')}
+          label={t('settings.languageLabel')}
+          description={t('settings.languageDescription')}
+          testIDPrefix="locale"
+          value={localePreference}
+          onChange={setLocalePreference}
+          options={LOCALE_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
+        />
 
-      <SegmentSetting
-        sectionTitle={t('settings.themeSection')}
-        label={t('settings.themeLabel')}
-        description={t('settings.themeDescription')}
-        testIDPrefix="theme"
-        value={themeMode}
-        onChange={setThemeMode}
-        options={THEME_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
-      />
+        <SegmentSetting
+          sectionTitle={t('settings.themeSection')}
+          label={t('settings.themeLabel')}
+          description={t('settings.themeDescription')}
+          testIDPrefix="theme"
+          value={themeMode}
+          onChange={setThemeMode}
+          options={THEME_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
+        />
 
-      <SegmentSetting
-        sectionTitle={t('settings.routeSection')}
-        label={t('settings.routePreferenceLabel')}
-        description={t('settings.routePreferenceDescription')}
-        testIDPrefix="route"
-        value={routePreference}
-        onChange={setRoutePreference}
-        options={ROUTE_CATEGORIES.map((c) => ({ value: c.key, label: t(`routes.${c.key}`) }))}
-      />
+        <SegmentSetting
+          sectionTitle={t('settings.routeSection')}
+          label={t('settings.routePreferenceLabel')}
+          description={t('settings.routePreferenceDescription')}
+          testIDPrefix="route"
+          value={routePreference}
+          onChange={setRoutePreference}
+          options={ROUTE_CATEGORIES.map((c) => ({ value: c.key, label: t(`routes.${c.key}`) }))}
+        />
 
-      {/* 알람 */}
-      <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.alarmSection')}</Text>
+        {/* 알람 */}
+        <View style={[styles.card, { backgroundColor: colors.card }]}>
+          <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('settings.alarmSection')}</Text>
 
-        <View style={styles.settingRow}>
-          <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.sleepModeLabel')}</Text>
-            <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              {t('settings.sleepModeDescription')}
-            </Text>
+          <View style={styles.settingRow}>
+            <View style={styles.settingInfo}>
+              <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.sleepModeLabel')}</Text>
+              <Text style={[styles.settingDesc, { color: colors.muted }]}>
+                {t('settings.sleepModeDescription')}
+              </Text>
+            </View>
+            <Switch
+              value={sleepMode}
+              onValueChange={(value) => {
+                if (value) {
+                  showSleepModeGuide(() => setSleepMode(true));
+                } else {
+                  setSleepMode(false);
+                }
+              }}
+              trackColor={{ false: colors.hair, true: colors.accent }}
+              thumbColor={sleepMode ? colors.onAccent : colors.subtle}
+              testID="sleep-mode-switch"
+            />
           </View>
-          <Switch
-            value={sleepMode}
-            onValueChange={(value) => {
-              if (value) {
-                showSleepModeGuide(() => setSleepMode(true));
-              } else {
-                setSleepMode(false);
-              }
-            }}
-            trackColor={{ false: colors.hair, true: colors.accent }}
-            thumbColor={sleepMode ? colors.onAccent : colors.subtle}
-            testID="sleep-mode-switch"
-          />
-        </View>
 
-        <View style={[styles.settingRow, { borderTopWidth: 1, borderTopColor: colors.hair }]}>
-          <View style={styles.settingInfo}>
-            <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.speakerOutputLabel')}</Text>
-            <Text style={[styles.settingDesc, { color: colors.muted }]}>
-              {t('settings.speakerOutputDescription')}
-            </Text>
+          <View style={[styles.settingRow, { borderTopWidth: 1, borderTopColor: colors.hair }]}>
+            <View style={styles.settingInfo}>
+              <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.speakerOutputLabel')}</Text>
+              <Text style={[styles.settingDesc, { color: colors.muted }]}>
+                {t('settings.speakerOutputDescription')}
+              </Text>
+            </View>
+            <Switch
+              value={allowSpeaker}
+              onValueChange={(value) => {
+                if (!value) {
+                  Alert.alert(
+                    t('settings.speakerOffTitle'),
+                    t('settings.speakerOffMessage'),
+                    [
+                      { text: t('common.cancel'), style: 'cancel' },
+                      { text: t('settings.speakerOffConfirm'), style: 'destructive', onPress: () => setAllowSpeaker(false) },
+                    ],
+                  );
+                } else {
+                  setAllowSpeaker(true);
+                }
+              }}
+              trackColor={{ false: colors.hair, true: colors.accent }}
+              thumbColor={allowSpeaker ? colors.onAccent : colors.subtle}
+              testID="allow-speaker-switch"
+            />
           </View>
-          <Switch
-            value={allowSpeaker}
-            onValueChange={(value) => {
-              if (!value) {
-                Alert.alert(
-                  t('settings.speakerOffTitle'),
-                  t('settings.speakerOffMessage'),
-                  [
-                    { text: t('common.cancel'), style: 'cancel' },
-                    { text: t('settings.speakerOffConfirm'), style: 'destructive', onPress: () => setAllowSpeaker(false) },
-                  ],
-                );
-              } else {
-                setAllowSpeaker(true);
-              }
-            }}
-            trackColor={{ false: colors.hair, true: colors.accent }}
-            thumbColor={allowSpeaker ? colors.onAccent : colors.subtle}
-            testID="allow-speaker-switch"
-          />
         </View>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -191,6 +193,9 @@ function SegmentSetting<T extends string>({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  scroll: {
+    paddingBottom: 80,
   },
   header: {
     fontSize: 14,


### PR DESCRIPTION
## Summary
- `app/(tabs)/settings.tsx`의 최상위가 `SafeAreaView`이고 그 안에 `ScrollView`로 래핑되지 않아, 컨텐츠가 화면을 넘으면 하단 알람 섹션(Sleep Mode / Speaker Output)이 잘려 접근 불가하던 문제를 수정.
- `index.tsx` / `favorites.tsx`와 동일한 `<SafeAreaView><ScrollView contentContainerStyle={{paddingBottom: 80}}>` 패턴 적용.
- 로직 변경 없음 — JSX 래핑 + `ScrollView` import + `styles.scroll` 한 줄 추가.

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 737/737 통과, 커버리지 100% 유지
- [x] code-review 에이전트 approved (P0/P1 없음)
- [x] iOS 시뮬레이터에서 설정 탭 진입 → 아래로 스크롤되어 Speaker Output까지 보이는지 확인
- [x] 마지막 카드 하단이 탭바에 가리지 않는지 확인 (`paddingBottom: 80`)
- [x] 다크/라이트 테마 둘 다 확인

Closes #234