### PR TITLE
fix(#236): 경로 선택 시에만 실시간 도착 현황 노출

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -36,8 +36,6 @@ export default function HomeScreen() {
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
   const isCustomOrigin = customOrigin !== null;
   const effectiveOrigin = customOrigin ?? result?.station ?? null;
-  const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(effectiveOrigin?.name ?? null);
-  const arrival = useArrivalCountdown(rawArrival);
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
   const favorites = useAppStore((s) => s.favorites);
@@ -65,6 +63,10 @@ export default function HomeScreen() {
   const [selectedKey, setSelectedKey] = useState<RoutePreference>(routePreference);
   const route: Route =
     categorized.find((r) => r.category.key === selectedKey)?.candidate.route ?? null;
+  const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(
+    route ? (effectiveOrigin?.name ?? null) : null,
+  );
+  const arrival = useArrivalCountdown(rawArrival);
   const isFav = effectiveOrigin ? favorites.some((f) => f.id === effectiveOrigin.id) : false;
 
   // 환승역이면 모든 호선 변형에서 경로 계산 → 출발역 환승 없는 최적 경로 자동 선택
@@ -458,22 +460,24 @@ export default function HomeScreen() {
               </View>
             )}
 
-            {/* Arrivals — 기존 상행/하행 포맷 유지 */}
-            <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
-              <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('home.arrivalInfoTitle')}</Text>
-              {arrivalLoading && !arrival && (
-                <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.loading')}</Text>
-              )}
-              {arrivalIsMock && (
-                <Text style={[styles.mockNotice, { color: colors.warn }]}>{t('home.mockNotice')}</Text>
-              )}
-              {arrival && (
-                <>
-                  <ArrivalRow label={t('arrival.upbound')} items={arrival.up} />
-                  <ArrivalRow label={t('arrival.downbound')} items={arrival.down} />
-                </>
-              )}
-            </View>
+            {/* Arrivals — 경로 선택된 경우에만 노출 */}
+            {route && (
+              <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
+                <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('home.arrivalInfoTitle')}</Text>
+                {arrivalLoading && !arrival && (
+                  <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.loading')}</Text>
+                )}
+                {arrivalIsMock && (
+                  <Text style={[styles.mockNotice, { color: colors.warn }]}>{t('home.mockNotice')}</Text>
+                )}
+                {arrival && (
+                  <>
+                    <ArrivalRow label={t('arrival.upbound')} items={arrival.up} />
+                    <ArrivalRow label={t('arrival.downbound')} items={arrival.down} />
+                  </>
+                )}
+              </View>
+            )}
           </>
         ) : (
           <View style={styles.center}>


### PR DESCRIPTION
## Summary
- GPS로 자동 감지된 출발역만 있으면 도착 정보가 항상 노출되던 동작을 **경로(`route`)가 선택된 경우에만 노출**로 변경.
- `useArrivalInfo` 호출 위치를 `route` 선언 이후로 이동하고 `route ? (effectiveOrigin?.name ?? null) : null`로 게이트 → 경로 없을 땐 API 호출/30초 폴링 자체 차단.
- arrival 섹션 JSX를 `{route && (...)}`로 래핑.
- 게이트 변수로 `destination` 대신 `route`를 택한 이유: 목적지 설정 후 경로 빌드 실패 케이스에도 일관되게 숨김.

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 737/737, 커버리지 100% 유지
- [x] code-review approved (P0/P1 없음)
- [x] iOS 시뮬레이터:
  - 앱 진입 직후(목적지 미설정) → 도착 정보 섹션 미노출
  - 목적지 설정 → 경로 빌드 후 도착 정보 섹션 노출
  - 목적지 해제 → 다시 미노출

Closes #236