### PR TITLE
refactor(#237): 다국어 인프라 정돈 (언어 레지스트리 + 설정 UI 리스트화)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -29,7 +29,7 @@ const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
   const { colors } = useTheme();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh } = useNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
@@ -273,7 +273,7 @@ export default function HomeScreen() {
             {/* Top meta */}
             <View style={styles.topMeta}>
               <Text style={[typography.mono, { color: colors.subtle }]}>
-                {new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+                {new Date().toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })}
               </Text>
               <Text style={[typography.label, { color: colors.subtle }]}>{isCustomOrigin ? t('home.manual') : t('home.live')}</Text>
             </View>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useAppStore, type ThemeMode, type LocalePreference } from '../../src/store/useAppStore';
 import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
+import { LANGUAGE_REGISTRY } from '../../src/i18n/types';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
@@ -12,12 +13,6 @@ const THEME_OPTIONS = [
   { value: 'light', labelKey: 'settings.themeLight' },
   { value: 'dark', labelKey: 'settings.themeDark' },
 ] as const satisfies readonly { value: ThemeMode; labelKey: string }[];
-
-const LOCALE_OPTIONS = [
-  { value: 'auto', labelKey: 'settings.languageAuto' },
-  { value: 'ko', labelKey: 'settings.languageKorean' },
-  { value: 'en', labelKey: 'settings.languageEnglish' },
-] as const satisfies readonly { value: LocalePreference; labelKey: string }[];
 
 export default function SettingsScreen() {
   const sleepMode = useAppStore((s) => s.sleepMode);
@@ -48,14 +43,13 @@ export default function SettingsScreen() {
       <ScrollView contentContainerStyle={styles.scroll}>
         <Text style={[styles.header, { color: colors.muted }]}>{t('settings.title')}</Text>
 
-        <SegmentSetting
+        <LocaleListSetting
           sectionTitle={t('settings.languageSection')}
           label={t('settings.languageLabel')}
           description={t('settings.languageDescription')}
-          testIDPrefix="locale"
+          autoLabel={t('settings.languageAuto')}
           value={localePreference}
           onChange={setLocalePreference}
-          options={LOCALE_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
         />
 
         <SegmentSetting
@@ -135,6 +129,78 @@ export default function SettingsScreen() {
         </View>
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+interface LocaleListSettingProps {
+  readonly sectionTitle: string;
+  readonly label: string;
+  readonly description: string;
+  readonly autoLabel: string;
+  readonly value: LocalePreference;
+  readonly onChange: (next: LocalePreference) => void;
+}
+
+function LocaleListSetting({
+  sectionTitle,
+  label,
+  description,
+  autoLabel,
+  value,
+  onChange,
+}: LocaleListSettingProps) {
+  const { colors } = useTheme();
+  const rows: readonly { value: LocalePreference; label: string }[] = [
+    { value: 'auto', label: autoLabel },
+    ...LANGUAGE_REGISTRY.map((lang) => ({ value: lang.code, label: lang.nativeName })),
+  ];
+  return (
+    <View style={[styles.card, { backgroundColor: colors.card }]}>
+      <Text style={[styles.sectionTitle, { color: colors.muted }]}>{sectionTitle}</Text>
+
+      <View style={styles.settingRow}>
+        <View style={styles.settingInfo}>
+          <Text style={[styles.settingLabel, { color: colors.ink }]}>{label}</Text>
+          <Text style={[styles.settingDesc, { color: colors.muted }]}>{description}</Text>
+        </View>
+      </View>
+
+      <View
+        style={[styles.localeList, { borderTopColor: colors.hair }]}
+        testID="locale-list"
+        accessibilityRole="radiogroup"
+      >
+        {rows.map(({ value: rowValue, label: rowLabel }, index) => {
+          const active = value === rowValue;
+          return (
+            <Pressable
+              key={rowValue}
+              style={[
+                styles.localeRow,
+                index > 0 && { borderTopWidth: 1, borderTopColor: colors.hair },
+              ]}
+              onPress={() => onChange(rowValue)}
+              testID={`locale-row-${rowValue}`}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: active }}
+            >
+              <Text style={[styles.localeRowLabel, { color: active ? colors.ink : colors.muted }]}>
+                {rowLabel}
+              </Text>
+              <View
+                style={[
+                  styles.localeRadio,
+                  { borderColor: active ? colors.accent : colors.hair },
+                  active && { backgroundColor: colors.accent },
+                ]}
+              >
+                {active && <View style={[styles.localeRadioDot, { backgroundColor: colors.onAccent }]} />}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
   );
 }
 
@@ -249,5 +315,33 @@ const styles = StyleSheet.create({
   segmentText: {
     fontSize: 13,
     fontWeight: '600',
+  },
+  localeList: {
+    marginTop: spacing.md,
+    borderTopWidth: 1,
+  },
+  localeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 44,
+    paddingVertical: spacing.sm,
+  },
+  localeRowLabel: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  localeRadio: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  localeRadioDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
   },
 });

--- a/src/hooks/useApplyLocale.ts
+++ b/src/hooks/useApplyLocale.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 import * as Localization from 'expo-localization';
 import i18next from 'i18next';
-import { useAppStore } from '../store/useAppStore';
+import { useAppStore, type LocalePreference } from '../store/useAppStore';
 import { FALLBACK_LANGUAGE, SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
 
 export function resolveLanguage(
-  preference: 'auto' | 'ko' | 'en',
+  preference: LocalePreference,
   osLanguageCode: string | null | undefined,
 ): SupportedLanguage {
   if (preference === 'auto') {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,20 +3,22 @@ import { initReactI18next } from 'react-i18next';
 import * as Localization from 'expo-localization';
 
 import { createLogger } from '../utils/logger';
-import en from './locales/en.json';
-import ko from './locales/ko.json';
 import {
   FALLBACK_LANGUAGE,
+  LANGUAGE_REGISTRY,
   SUPPORTED_LANGUAGES,
   type SupportedLanguage,
+  type TranslationResources,
 } from './types';
 
 const logger = createLogger('i18n');
 
-const RESOURCES = {
-  en: { translation: en },
-  ko: { translation: ko },
-} as const;
+const RESOURCE_ENTRIES: [SupportedLanguage, { translation: TranslationResources }][] =
+  LANGUAGE_REGISTRY.map(({ code, translation }) => [code, { translation }]);
+const RESOURCES = Object.fromEntries(RESOURCE_ENTRIES) as Record<
+  SupportedLanguage,
+  { translation: TranslationResources }
+>;
 
 export function detectDeviceLanguage(): SupportedLanguage {
   const code = Localization.getLocales()[0]?.languageCode;
@@ -44,5 +46,5 @@ i18next
 // (Localization.addLocaleListener 또는 AppState active 시점에 changeLanguage 호출)
 
 export { default as i18n } from 'i18next';
-export { SUPPORTED_LANGUAGES, FALLBACK_LANGUAGE };
+export { LANGUAGE_REGISTRY, SUPPORTED_LANGUAGES, FALLBACK_LANGUAGE };
 export type { SupportedLanguage };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -64,9 +64,7 @@
     "languageSection": "Language",
     "languageLabel": "App language",
     "languageDescription": "Auto follows your device setting",
-    "languageAuto": "Auto",
-    "languageKorean": "Korean",
-    "languageEnglish": "English"
+    "languageAuto": "Auto"
   },
   "map": {
     "originBadge": "Origin",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -64,9 +64,7 @@
     "languageSection": "언어",
     "languageLabel": "앱 언어",
     "languageDescription": "자동은 기기 설정을 따릅니다",
-    "languageAuto": "자동",
-    "languageKorean": "한국어",
-    "languageEnglish": "English"
+    "languageAuto": "자동"
   },
   "map": {
     "originBadge": "출발",
@@ -175,9 +173,13 @@
     "alarmShortArrival": "하차",
     "etaSubtextEstimated": "예상",
     "etaSubtextDuration": "소요",
+    "stopsToArrival_one": "{{count}}역 후 {{destination}} 도착",
     "stopsToArrival_other": "{{count}}역 후 {{destination}} 도착",
+    "stopsToTransfer_one": "{{count}}역 후 {{name}} 환승",
     "stopsToTransfer_other": "{{count}}역 후 {{name}} 환승",
+    "summaryWithStops_one": "→ {{destination}} · {{count}}역 후 도착{{etaSuffix}}",
     "summaryWithStops_other": "→ {{destination}} · {{count}}역 후 도착{{etaSuffix}}",
+    "summaryWithTransfer_one": "→ {{destination}} · {{count}}역 후 {{name}} 환승{{etaSuffix}}",
     "summaryWithTransfer_other": "→ {{destination}} · {{count}}역 후 {{name}} 환승{{etaSuffix}}",
     "summaryDestinationOnly": "→ {{destination}}{{etaSuffix}}",
     "etaSuffix": " · 약 {{min}}분"

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,7 +1,19 @@
-import type en from './locales/en.json';
+import en from './locales/en.json';
+import ko from './locales/ko.json';
 
-export const SUPPORTED_LANGUAGES = ['ko', 'en'] as const;
-export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+// 지원 언어를 한 곳에서 관리한다. 새 언어 추가 시 이 배열에 한 줄을 추가하고
+// 로케일 JSON 파일을 import 하면 RESOURCES/SUPPORTED_LANGUAGES/SupportedLanguage가
+// 자동으로 따라온다. nativeName은 화면 언어와 무관하게 그 언어 사용자가 자기 언어를
+// 알아볼 수 있도록 native name으로 표기한다 (예: ja → 日本語).
+export const LANGUAGE_REGISTRY = [
+  { code: 'ko', nativeName: '한국어', translation: ko },
+  { code: 'en', nativeName: 'English', translation: en },
+] as const;
+
+export const SUPPORTED_LANGUAGES = LANGUAGE_REGISTRY.map(
+  (l) => l.code,
+) as readonly SupportedLanguage[];
+export type SupportedLanguage = (typeof LANGUAGE_REGISTRY)[number]['code'];
 
 export const FALLBACK_LANGUAGE: SupportedLanguage = 'en';
 

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -4,11 +4,12 @@ import { Station } from '../types/station';
 import type { AlarmEvent } from '../utils/stationAlarm';
 import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY } from '../constants/storageKeys';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
+import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
 
 export type ThemeMode = 'auto' | 'light' | 'dark';
-export type LocalePreference = 'auto' | 'ko' | 'en';
+export type LocalePreference = 'auto' | SupportedLanguage;
 
-const LOCALE_PREFERENCES: readonly LocalePreference[] = ['auto', 'ko', 'en'];
+const LOCALE_PREFERENCES: readonly LocalePreference[] = ['auto', ...SUPPORTED_LANGUAGES];
 
 export type { AlarmEvent };
 


### PR DESCRIPTION
Closes #237

## 변경 요지

언어 추가를 **"레지스트리 한 줄 + 로케일 JSON 한 파일"** 로 끝낼 수 있도록 i18n 인프라를 정돈했다. 이번 PR은 **인프라 리팩토링 단독** — 새 언어(`ja`/`zh`)는 후속 PR2/PR3에서 추가한다.

### A. 언어 레지스트리 단일화 — `src/i18n/types.ts`
```ts
export const LANGUAGE_REGISTRY = [
  { code: 'ko', nativeName: '한국어',  translation: ko },
  { code: 'en', nativeName: 'English', translation: en },
] as const;
```
`SUPPORTED_LANGUAGES`, `SupportedLanguage`, `RESOURCES`, `LOCALE_PREFERENCES` 모두 이 배열에서 파생. 흩어져 있던 `'auto' | 'ko' | 'en'` 하드코딩 5~6곳 제거.

### B. 언어 설정 UI — `app/(tabs)/settings.tsx`
- 세그먼트 컨트롤 → **라디오 리스트** (`LocaleListSetting`). 옵션 5개+ 확장 대비.
- 라벨은 native name (한국어/English/日本語/中文 패턴 — Google·Apple 표준)
- `accessibilityRole="radiogroup"` / `"radio"` + `accessibilityState`로 VoiceOver/TalkBack 대응
- 테마·경로 설정의 `SegmentSetting`은 그대로 유지(옵션 수 적고 변동 없음)

### C. 부수 수정
- **시간 포맷 버그**: `toLocaleTimeString('ko-KR', ...)` → `toLocaleTimeString(i18n.language, ...)`. 영어 모드에서도 한국어 AM/PM이 표시되던 버그
- **ko.json 누락 키 보강**: `liveActivity.stopsToArrival_one` 등 `_one` 복수형 4개. 타입 정합성 검증 중 노출된 기존 버그(원래 `_other` fallback으로 보이고 있었음)
- 미사용 번역 키 제거: `settings.languageKorean`, `settings.languageEnglish`

## 범위 외 (후속 분리)

- **PR2**: `ja` 추가 — 레지스트리 1줄 + `ja.json` + Expo `locales/ja.json` + `stationDisplay.ts`의 `=== 'en'` 분기 처리 결정
- **PR3**: `zh` 추가 — 동일 패턴
- 별도: `ROUTE_CATEGORIES.label` 데드 한국어 라벨, iOS `.lproj`/Live Activity/Widget Swift 하드코딩, Android `values-*`

## 검증

- `npm run type-check` — 0 errors
- `npm test` — 737 tests pass, **커버리지 100% 유지** (lines/functions/branches/statements)
- code-reviewer 에이전트 P1(radiogroup)/P2(타입 캐스트 정돈, SUPPORTED_LANGUAGES readonly) 반영 완료

## 수동 테스트 체크리스트

- [ ] 설정 → 언어: Auto / 한국어 / English 3행 리스트, 라이트/다크 양쪽 색 대비 정상
- [ ] 각 행 탭 시 즉시 UI 텍스트 전환
- [ ] 앱 재시작 후 마지막 선택 영속화
- [ ] 자동 + 시스템 언어 일본어/프랑스어(미지원) → fallback `en`
- [ ] 홈 탭 상단 시간 — EN: AM/PM, KO: 오전/오후