### PR TITLE
feat(#240): 일본어(ja) 지원 추가

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -12,6 +12,7 @@ module.exports = {
     locales: {
       ko: './locales/ko.json',
       en: './locales/en.json',
+      ja: './locales/ja.json',
     },
     splash: {
       image: './assets/splash/splash-ko-1284x2778.png',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -18,18 +18,16 @@ jest.mock('expo-localization', () => ({
 
 const i18next = require('i18next');
 const { initReactI18next } = require('react-i18next');
-const en = require('./src/i18n/locales/en.json');
-const ko = require('./src/i18n/locales/ko.json');
+const { LANGUAGE_REGISTRY, FALLBACK_LANGUAGE } = require('./src/i18n/types');
 
 i18next.use(initReactI18next).init({
   compatibilityJSON: 'v4',
-  resources: {
-    en: { translation: en },
-    ko: { translation: ko },
-  },
+  resources: Object.fromEntries(
+    LANGUAGE_REGISTRY.map((lang) => [lang.code, { translation: lang.translation }]),
+  ),
   lng: 'ko',
-  fallbackLng: 'en',
-  supportedLngs: ['ko', 'en'],
+  fallbackLng: FALLBACK_LANGUAGE,
+  supportedLngs: LANGUAGE_REGISTRY.map((lang) => lang.code),
   defaultNS: 'translation',
   interpolation: { escapeValue: false },
 });

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,0 +1,9 @@
+{
+  "ios": {
+    "CFBundleDisplayName": "いまどこ",
+    "CFBundleName": "いまどこ"
+  },
+  "android": {
+    "app_name": "いまどこ"
+  }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,3 +6,6 @@ sonar.sources=src,app
 
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯)
 sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**
+
+# 중복 분석 제외 — 번역 리소스는 본질적으로 같은 키 구조를 언어별로 복제하는 형태라 CPD가 의미 없음
+sonar.cpd.exclusions=src/i18n/locales/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,7 @@ sonar.organization=handokei
 # 분석 대상
 sonar.sources=src,app
 
-# 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯)
-sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**
-
-# 중복 분석 제외 — 번역 리소스 JSON은 본질적으로 같은 키 구조를 언어별로 복제하는 형태라 CPD가 의미 없음
-sonar.cpd.exclusions=**/*.json
+# 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, 번역 리소스 JSON)
+# 번역 JSON은 데이터 파일(코드가 아님)이고 언어별로 같은 키 구조를 복제하는 본질 때문에
+# CPD에서 중복으로 잡히지만 정작 의미 있는 분석 대상이 아니다.
+sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,**/locales/**,**/*.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,5 @@ sonar.organization=handokei
 # 분석 대상
 sonar.sources=src,app
 
-# 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, 번역 리소스 JSON)
-# 번역 JSON은 데이터 파일(코드가 아님)이고 언어별로 같은 키 구조를 복제하는 본질 때문에
-# CPD에서 중복으로 잡히지만 정작 의미 있는 분석 대상이 아니다.
-sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,**/locales/**,**/*.json
+# 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯)
+sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,5 +7,5 @@ sonar.sources=src,app
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯)
 sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**
 
-# 중복 분석 제외 — 번역 리소스는 본질적으로 같은 키 구조를 언어별로 복제하는 형태라 CPD가 의미 없음
-sonar.cpd.exclusions=src/i18n/locales/**
+# 중복 분석 제외 — 번역 리소스 JSON은 본질적으로 같은 키 구조를 언어별로 복제하는 형태라 CPD가 의미 없음
+sonar.cpd.exclusions=**/*.json

--- a/src/components/StationMap.web.tsx
+++ b/src/components/StationMap.web.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Station } from '../types/station';
 import { haversine } from '../utils/haversine';
 import { LINE_NAMES } from '../constants/lineColors';
@@ -15,11 +16,12 @@ interface StationMapProps {
 
 export function StationMap({ userLat, userLng, nearestStation, nearbyStations }: StationMapProps) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   if (nearbyStations.length === 0) {
     return (
       <View style={[styles.fallback, { backgroundColor: colors.bg }]}>
-        <Text style={[styles.emptyText, { color: colors.muted }]}>주변 1km 내 지하철역이 없습니다.</Text>
+        <Text style={[styles.emptyText, { color: colors.muted }]}>{t('map.noNearbyStations')}</Text>
       </View>
     );
   }
@@ -33,7 +35,7 @@ export function StationMap({ userLat, userLng, nearestStation, nearbyStations }:
 
   return (
     <ScrollView style={[styles.container, { backgroundColor: colors.bg }]} contentContainerStyle={styles.content}>
-      <Text style={[styles.header, { color: colors.muted }]}>주변 지하철역 (1km 이내)</Text>
+      <Text style={[styles.header, { color: colors.muted }]}>{t('map.nearbyStationsHeader')}</Text>
       {sorted.map(({ station, distanceM }) => {
         const isNearest = nearestStation?.id === station.id;
         return (

--- a/src/components/__tests__/StationMap.web.test.tsx
+++ b/src/components/__tests__/StationMap.web.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import i18next from 'i18next';
 import { StationMap } from '../StationMap.web';
 import { Station } from '../../types/station';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
@@ -31,14 +32,14 @@ const defaultProps = {
 describe('StationMap.web', () => {
   it('nearbyStations이 없으면 안내 문구를 렌더링한다', () => {
     const { getByText } = renderWithTheme(<StationMap {...defaultProps} />);
-    expect(getByText('주변 1km 내 지하철역이 없습니다.')).toBeTruthy();
+    expect(getByText(i18next.t('map.noNearbyStations'))).toBeTruthy();
   });
 
   it('nearbyStations이 있으면 역 목록과 헤더를 렌더링한다', () => {
     const { getByText } = renderWithTheme(
       <StationMap {...defaultProps} nearbyStations={[gangnam, sinnonhyeon]} />,
     );
-    expect(getByText('주변 지하철역 (1km 이내)')).toBeTruthy();
+    expect(getByText(i18next.t('map.nearbyStationsHeader'))).toBeTruthy();
     expect(getByText('강남')).toBeTruthy();
     expect(getByText('신논현')).toBeTruthy();
   });

--- a/src/hooks/__tests__/useApplyLocale.test.ts
+++ b/src/hooks/__tests__/useApplyLocale.test.ts
@@ -14,9 +14,11 @@ describe('resolveLanguage', () => {
   it.each([
     ['ko', 'en', 'ko'],
     ['en', 'ko', 'en'],
+    ['ja', 'ko', 'ja'],
     ['auto', 'ko', 'ko'],
     ['auto', 'en', 'en'],
-    ['auto', 'ja', 'en'],
+    ['auto', 'ja', 'ja'],
+    ['auto', 'fr', 'en'],
     ['auto', null, 'en'],
   ] as const)('resolveLanguage(%s, %s) === %s', (preference, os, expected) => {
     expect(resolveLanguage(preference as LocalePreference, os)).toBe(expected);

--- a/src/i18n/__tests__/i18n.test.ts
+++ b/src/i18n/__tests__/i18n.test.ts
@@ -29,8 +29,13 @@ describe('detectDeviceLanguage', () => {
     expect(detectDeviceLanguage()).toBe('en');
   });
 
-  it('falls back when device language is unsupported', () => {
+  it('returns ja when device language is ja', () => {
     mockGetLocales.mockReturnValueOnce([{ languageCode: 'ja' }]);
+    expect(detectDeviceLanguage()).toBe('ja');
+  });
+
+  it('falls back when device language is unsupported', () => {
+    mockGetLocales.mockReturnValueOnce([{ languageCode: 'fr' }]);
     expect(detectDeviceLanguage()).toBe(FALLBACK_LANGUAGE);
   });
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -70,7 +70,9 @@
     "originBadge": "Origin",
     "destinationBadge": "Destination",
     "setAsOrigin": "Set as origin",
-    "setAsDestination": "Set as destination"
+    "setAsDestination": "Set as destination",
+    "nearbyStationsHeader": "Nearby stations (within 1km)",
+    "noNearbyStations": "No subway stations within 1km."
   },
   "favorites": {
     "title": "Favorites",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1,0 +1,194 @@
+{
+  "common": {
+    "retry": "再試行",
+    "close": "閉じる",
+    "confirm": "OK",
+    "cancel": "キャンセル"
+  },
+  "tabs": {
+    "current": "現在",
+    "map": "地図",
+    "favorites": "お気に入り",
+    "settings": "設定"
+  },
+  "permissions": {
+    "locationRequiredTitle": "位置情報の許可が必要です",
+    "locationRequiredShort": "位置情報の許可が必要です。",
+    "locationRequiredDescription": "設定で位置情報の利用を許可してください。\n現在の駅を検出するために位置情報が必要です。",
+    "request": "許可する",
+    "locating": "位置情報を取得中..."
+  },
+  "home": {
+    "arrived": "到着!",
+    "live": "LIVE",
+    "manual": "手動",
+    "originManual": "出発駅(手動)",
+    "originCurrent": "現在駅",
+    "originNearest": "最寄り駅",
+    "switchToGps": "GPSモードに切り替え",
+    "routeTo": "目的地まで",
+    "estimatedSuffix": "予想",
+    "destinationChange": "目的地を変更 →",
+    "destinationReset": "リセット",
+    "destinationSet": "目的地を設定",
+    "previousDestination": "前回の目的地",
+    "sleepMode": "おやすみモード",
+    "sleepModeDescription": "乗換・到着の1駅手前で振動・通知",
+    "arrivalInfoTitle": "列車到着情報",
+    "loading": "読み込み中...",
+    "mockNotice": "リアルタイムデータが取得できないため予想データを表示しています",
+    "noArrivalInfo": "到着情報なし",
+    "notNearStationTitle": "地下鉄駅の近くではありません",
+    "notNearStationDescription": "地下鉄駅から500m以内にいるとき、現在駅が表示されます。\n地図タブで出発駅を手動で設定することもできます。",
+    "refresh": "更新"
+  },
+  "settings": {
+    "title": "設定",
+    "themeSection": "テーマ",
+    "themeAuto": "自動",
+    "themeLight": "ライト",
+    "themeDark": "ダーク",
+    "themeLabel": "ダークモード",
+    "themeDescription": "自動はデバイスの設定に従います",
+    "routeSection": "経路",
+    "routePreferenceLabel": "経路設定",
+    "routePreferenceDescription": "デフォルトの経路探索方法を選択します",
+    "alarmSection": "アラーム",
+    "sleepModeLabel": "おやすみモード",
+    "sleepModeDescription": "イヤホン接続時は起床アラーム音を鳴らします",
+    "speakerOutputLabel": "スピーカー出力を許可",
+    "speakerOutputDescription": "イヤホン未接続時もスピーカーでアラーム音を再生します",
+    "speakerOffTitle": "スピーカー出力をオフ",
+    "speakerOffMessage": "スピーカー出力をオフにすると、イヤホン未接続時は振動のみになります。続けますか?",
+    "speakerOffConfirm": "オフにする",
+    "languageSection": "言語",
+    "languageLabel": "アプリの言語",
+    "languageDescription": "自動はデバイスの設定に従います",
+    "languageAuto": "自動"
+  },
+  "map": {
+    "originBadge": "出発",
+    "destinationBadge": "目的地",
+    "setAsOrigin": "出発駅に設定",
+    "setAsDestination": "目的地に設定",
+    "nearbyStationsHeader": "周辺の地下鉄駅 (1km以内)",
+    "noNearbyStations": "1km以内に地下鉄駅がありません。"
+  },
+  "favorites": {
+    "title": "お気に入り",
+    "searchPlaceholder": "駅名を検索...",
+    "noSearchResults": "検索結果がありません",
+    "empty": "お気に入りはまだありません",
+    "emptyDescription": "上の検索窓で駅を検索して\nお気に入りに追加できます。",
+    "remove": "削除"
+  },
+  "alarmOverlay": {
+    "transferTitle": "乗換アラーム",
+    "arrivalTitle": "到着アラーム",
+    "transferMessage": "{{station}}で\n乗り換え",
+    "arrivalMessage": "{{station}}で\n下車",
+    "dismiss": "アラームを止める"
+  },
+  "destinationPicker": {
+    "noLocation": "位置情報がありません。",
+    "title": "目的地を設定",
+    "searchPlaceholder": "駅名を検索"
+  },
+  "sleepModeGuide": {
+    "title": "おやすみモードのご案内",
+    "message": "イヤホンが接続されていない場合、アラームがスピーカーで再生されることがあります。\n\nスピーカー出力を希望しない場合は、設定 > アラームで「スピーカー出力を許可」をオフにしてください。",
+    "confirm": "OK"
+  },
+  "background": {
+    "title": "地下鉄の位置を検出中",
+    "body": "バックグラウンドで現在駅を追跡しています"
+  },
+  "arrival": {
+    "upbound": "上り",
+    "downbound": "下り"
+  },
+  "notifications": {
+    "channelStation": "現在駅",
+    "channelTransferAlarm": "乗換・到着アラーム",
+    "channelTransferAlarmSilent": "乗換・到着アラーム (無音)",
+    "channelStationPass": "通過駅アラーム",
+    "transferEarlyTitle": "乗換アラーム",
+    "arrivalEarlyTitle": "到着アラーム",
+    "transferImminentTitle": "まもなく乗換",
+    "arrivalImminentTitle": "まもなく到着"
+  },
+  "journey": {
+    "transferNote": "乗換",
+    "arrivalNote": "到着"
+  },
+  "routes": {
+    "optimal": "最速",
+    "minTransfer": "乗換最少"
+  },
+  "time": {
+    "arrivingSoon": "まもなく到着",
+    "minutesAndSeconds": "{{min}}分{{sec}}秒",
+    "seconds": "{{sec}}秒",
+    "approximateMinutes": "約{{min}}分",
+    "estimatedSuffix": " (予想)"
+  },
+  "route": {
+    "stops_one": "{{count}}駅",
+    "stops_other": "{{count}}駅",
+    "stopsLeft_one": "残り{{count}}駅",
+    "stopsLeft_other": "残り{{count}}駅",
+    "transferAfterStops": "{{stops}}駅先の{{name}}で乗換",
+    "minutesAndTransfers_one": "{{min}}分 · 乗換{{count}}回",
+    "minutesAndTransfers_other": "{{min}}分 · 乗換{{count}}回",
+    "directOnly": "{{min}}分 · 直通",
+    "currentStation": "{{name}}",
+    "atCurrentStation": "現在 {{name}}",
+    "approximateDistance": "約{{m}}m",
+    "stationPassed": "{{name}}を通過",
+    "stopsRemainingToDestination_one": "{{destination}}まで残り{{count}}駅",
+    "stopsRemainingToDestination_other": "{{destination}}まで残り{{count}}駅",
+    "stopsRemainingViaTransfer": "{{transfer}}乗換まで{{transferStops}}駅 · {{destination}}まで{{totalStops}}駅"
+  },
+  "lines": {
+    "1": "1号線",
+    "2": "2号線",
+    "3": "3号線",
+    "4": "4号線",
+    "5": "5号線",
+    "6": "6号線",
+    "7": "7号線",
+    "8": "8号線",
+    "9": "9号線",
+    "airport": "空港鉄道",
+    "gyeongui": "京義中央線",
+    "bundang": "盆唐線",
+    "sinbundang": "新盆唐線"
+  },
+  "alarms": {
+    "earlyTransferBody": "次の駅 {{station}}で乗り換えてください!",
+    "earlyArrivalBody": "次の駅 {{station}}で下車してください!",
+    "imminentTransferBody": "まもなく{{station}}に到着します。乗換の準備をしてください!",
+    "imminentArrivalBody": "まもなく{{station}}に到着します。下車の準備をしてください!"
+  },
+  "liveActivity": {
+    "alarmShortTransfer": "乗換",
+    "alarmShortArrival": "下車",
+    "etaSubtextEstimated": "予想",
+    "etaSubtextDuration": "所要",
+    "stopsToArrival_one": "{{destination}}まで残り{{count}}駅",
+    "stopsToArrival_other": "{{destination}}まで残り{{count}}駅",
+    "stopsToTransfer_one": "{{count}}駅先の{{name}}で乗換",
+    "stopsToTransfer_other": "{{count}}駅先の{{name}}で乗換",
+    "summaryWithStops_one": "→ {{destination}} · 残り{{count}}駅で到着{{etaSuffix}}",
+    "summaryWithStops_other": "→ {{destination}} · 残り{{count}}駅で到着{{etaSuffix}}",
+    "summaryWithTransfer_one": "→ {{destination}} · {{count}}駅先の{{name}}で乗換{{etaSuffix}}",
+    "summaryWithTransfer_other": "→ {{destination}} · {{count}}駅先の{{name}}で乗換{{etaSuffix}}",
+    "summaryDestinationOnly": "→ {{destination}}{{etaSuffix}}",
+    "etaSuffix": " · 約{{min}}分"
+  },
+  "direction": {
+    "boundFor": "{{name}}行き",
+    "innerLoop": "内回り",
+    "outerLoop": "外回り"
+  }
+}

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -70,7 +70,9 @@
     "originBadge": "출발",
     "destinationBadge": "도착",
     "setAsOrigin": "출발역으로 설정",
-    "setAsDestination": "도착역으로 설정"
+    "setAsDestination": "도착역으로 설정",
+    "nearbyStationsHeader": "주변 지하철역 (1km 이내)",
+    "noNearbyStations": "주변 1km 내 지하철역이 없습니다."
   },
   "favorites": {
     "title": "즐겨찾기",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,5 +1,6 @@
 import en from './locales/en.json';
 import ko from './locales/ko.json';
+import ja from './locales/ja.json';
 
 // 지원 언어를 한 곳에서 관리한다. 새 언어 추가 시 이 배열에 한 줄을 추가하고
 // 로케일 JSON 파일을 import 하면 RESOURCES/SUPPORTED_LANGUAGES/SupportedLanguage가
@@ -8,6 +9,7 @@ import ko from './locales/ko.json';
 export const LANGUAGE_REGISTRY = [
   { code: 'ko', nativeName: '한국어', translation: ko },
   { code: 'en', nativeName: 'English', translation: en },
+  { code: 'ja', nativeName: '日本語', translation: ja },
 ] as const;
 
 export const SUPPORTED_LANGUAGES = LANGUAGE_REGISTRY.map(

--- a/src/testUtils/i18nLanguageOverride.ts
+++ b/src/testUtils/i18nLanguageOverride.ts
@@ -1,0 +1,20 @@
+import i18next from 'i18next';
+
+// i18next.language 를 일시적으로 덮어써 언어 의존 로직을 테스트하기 위한 헬퍼.
+// 호출하는 테스트 파일에서 `installLanguageRestoreHook()`을 파일 최상단에서 한 번 호출하면
+// 모든 it 사이에서 자동으로 원래 언어로 복원된다.
+
+export function setLang(lang: string): void {
+  Object.defineProperty(i18next, 'language', { value: lang, configurable: true });
+}
+
+export function installLanguageRestoreHook(): void {
+  // jest.setup.js가 i18next.init()으로 language descriptor를 항상 설치하므로 non-null 단언.
+  let original: PropertyDescriptor;
+  beforeEach(() => {
+    original = Object.getOwnPropertyDescriptor(i18next, 'language')!;
+  });
+  afterEach(() => {
+    Object.defineProperty(i18next, 'language', original);
+  });
+}

--- a/src/utils/__tests__/stationDisplay.test.ts
+++ b/src/utils/__tests__/stationDisplay.test.ts
@@ -8,6 +8,10 @@ const stations: Station[] = [
   { id: '5-555', name: '신기역', line: '5', lineColor: '#996CAC', lat: 37, lng: 127 },
 ];
 
+// 비한국어(en/ja 등)는 모두 동일 분기(nameEn fallback)를 타므로 데이터 주도로 검증한다.
+// zh 등 새 언어 추가 시 이 배열에 한 줄만 추가하면 동일 검증이 자동 적용된다.
+const NON_KO_LANGUAGES = ['en', 'ja'] as const;
+
 describe('getStationDisplayName', () => {
   let originalLanguageDescriptor: PropertyDescriptor | undefined;
 
@@ -25,29 +29,19 @@ describe('getStationDisplayName', () => {
     Object.defineProperty(i18next, 'language', { value: lang, configurable: true });
   }
 
-  it('영문 모드 + nameEn 존재 → 영문 표시', () => {
-    setLang('en');
+  it.each(NON_KO_LANGUAGES)('비한국어 모드(%s) + nameEn 존재 → nameEn 반환', (lang) => {
+    setLang(lang);
     expect(getStationDisplayName(stations[0])).toBe('Gangnam');
   });
 
-  it('영문 모드 + nameEn 누락 → 한글 fallback', () => {
-    setLang('en');
+  it.each(NON_KO_LANGUAGES)('비한국어 모드(%s) + nameEn 누락 → 한글 fallback', (lang) => {
+    setLang(lang);
     expect(getStationDisplayName(stations[2])).toBe('신기역');
   });
 
   it('한글 모드 → nameEn 있어도 한글 반환', () => {
     setLang('ko');
     expect(getStationDisplayName(stations[0])).toBe('강남');
-  });
-
-  it('일본어 모드 + nameEn 존재 → 영문(라틴 표기) fallback', () => {
-    setLang('ja');
-    expect(getStationDisplayName(stations[0])).toBe('Gangnam');
-  });
-
-  it('일본어 모드 + nameEn 누락 → 한글 fallback', () => {
-    setLang('ja');
-    expect(getStationDisplayName(stations[2])).toBe('신기역');
   });
 });
 
@@ -68,8 +62,8 @@ describe('getStationDisplayNameByName', () => {
     Object.defineProperty(i18next, 'language', { value: lang, configurable: true });
   }
 
-  it('영문 모드 + 매칭되는 nameEn → 영문 반환', () => {
-    setLang('en');
+  it.each(NON_KO_LANGUAGES)('비한국어 모드(%s) + 매칭되는 nameEn → 영문 반환', (lang) => {
+    setLang(lang);
     expect(getStationDisplayNameByName('강남', stations)).toBe('Gangnam');
   });
 
@@ -86,11 +80,6 @@ describe('getStationDisplayNameByName', () => {
   it('한글 모드 → 항상 입력 그대로', () => {
     setLang('ko');
     expect(getStationDisplayNameByName('강남', stations)).toBe('강남');
-  });
-
-  it('일본어 모드 → nameEn으로 lookup (라틴 표기 fallback)', () => {
-    setLang('ja');
-    expect(getStationDisplayNameByName('강남', stations)).toBe('Gangnam');
   });
 });
 

--- a/src/utils/__tests__/stationDisplay.test.ts
+++ b/src/utils/__tests__/stationDisplay.test.ts
@@ -39,6 +39,16 @@ describe('getStationDisplayName', () => {
     setLang('ko');
     expect(getStationDisplayName(stations[0])).toBe('강남');
   });
+
+  it('일본어 모드 + nameEn 존재 → 영문(라틴 표기) fallback', () => {
+    setLang('ja');
+    expect(getStationDisplayName(stations[0])).toBe('Gangnam');
+  });
+
+  it('일본어 모드 + nameEn 누락 → 한글 fallback', () => {
+    setLang('ja');
+    expect(getStationDisplayName(stations[2])).toBe('신기역');
+  });
 });
 
 describe('getStationDisplayNameByName', () => {
@@ -76,6 +86,11 @@ describe('getStationDisplayNameByName', () => {
   it('한글 모드 → 항상 입력 그대로', () => {
     setLang('ko');
     expect(getStationDisplayNameByName('강남', stations)).toBe('강남');
+  });
+
+  it('일본어 모드 → nameEn으로 lookup (라틴 표기 fallback)', () => {
+    setLang('ja');
+    expect(getStationDisplayNameByName('강남', stations)).toBe('Gangnam');
   });
 });
 

--- a/src/utils/__tests__/stationDisplay.test.ts
+++ b/src/utils/__tests__/stationDisplay.test.ts
@@ -1,6 +1,6 @@
-import i18next from 'i18next';
 import { getStationDisplayName, getStationDisplayNameByName, matchesStationQuery } from '../stationDisplay';
 import type { Station } from '../../types/station';
+import { installLanguageRestoreHook, setLang } from '../../testUtils/i18nLanguageOverride';
 
 const stations: Station[] = [
   { id: '2-022', name: '강남', nameEn: 'Gangnam', line: '2', lineColor: '#009D3E', lat: 37.5, lng: 127 },
@@ -12,23 +12,9 @@ const stations: Station[] = [
 // zh 등 새 언어 추가 시 이 배열에 한 줄만 추가하면 동일 검증이 자동 적용된다.
 const NON_KO_LANGUAGES = ['en', 'ja'] as const;
 
+installLanguageRestoreHook();
+
 describe('getStationDisplayName', () => {
-  let originalLanguageDescriptor: PropertyDescriptor | undefined;
-
-  beforeEach(() => {
-    originalLanguageDescriptor = Object.getOwnPropertyDescriptor(i18next, 'language');
-  });
-
-  afterEach(() => {
-    if (originalLanguageDescriptor) {
-      Object.defineProperty(i18next, 'language', originalLanguageDescriptor);
-    }
-  });
-
-  function setLang(lang: string) {
-    Object.defineProperty(i18next, 'language', { value: lang, configurable: true });
-  }
-
   it.each(NON_KO_LANGUAGES)('비한국어 모드(%s) + nameEn 존재 → nameEn 반환', (lang) => {
     setLang(lang);
     expect(getStationDisplayName(stations[0])).toBe('Gangnam');
@@ -46,22 +32,6 @@ describe('getStationDisplayName', () => {
 });
 
 describe('getStationDisplayNameByName', () => {
-  let originalLanguageDescriptor: PropertyDescriptor | undefined;
-
-  beforeEach(() => {
-    originalLanguageDescriptor = Object.getOwnPropertyDescriptor(i18next, 'language');
-  });
-
-  afterEach(() => {
-    if (originalLanguageDescriptor) {
-      Object.defineProperty(i18next, 'language', originalLanguageDescriptor);
-    }
-  });
-
-  function setLang(lang: string) {
-    Object.defineProperty(i18next, 'language', { value: lang, configurable: true });
-  }
-
   it.each(NON_KO_LANGUAGES)('비한국어 모드(%s) + 매칭되는 nameEn → 영문 반환', (lang) => {
     setLang(lang);
     expect(getStationDisplayNameByName('강남', stations)).toBe('Gangnam');

--- a/src/utils/stationDisplay.ts
+++ b/src/utils/stationDisplay.ts
@@ -2,10 +2,12 @@ import i18next from 'i18next';
 import type { Station } from '../types/station';
 
 // 역명을 현재 i18next 언어에 맞춰 표시한다.
-// - 영문 모드(`en`) + nameEn 존재 → 영문
-// - 그 외 → 한글 (nameEn 누락 시에도 한글로 fallback)
+// - 한국어(`ko`): 한글 그대로 (플랫폼 안내판과 일치)
+// - 그 외(en/ja/zh 등): `nameEn` (영문 표기) — 라틴 알파벳이 비한국어권 사용자에게 가장 보편적.
+//   `nameJa`/`nameZh` 데이터 도입은 528개 역 × N언어 비용이 매우 커서 별도 트랙.
+// nameEn 누락 시에는 한글로 fallback.
 export function getStationDisplayName(station: Pick<Station, 'name' | 'nameEn'>): string {
-  if (i18next.language === 'en' && station.nameEn) {
+  if (i18next.language !== 'ko' && station.nameEn) {
     return station.nameEn;
   }
   return station.name;
@@ -14,7 +16,7 @@ export function getStationDisplayName(station: Pick<Station, 'name' | 'nameEn'>)
 // stationName(한글)만 가진 위치에서 사용. 알람/알림 빌더처럼 Station 객체가 아닌 문자열만 들고
 // 있는 경우, name → nameEn 매핑을 위해 stations 데이터에서 lookup.
 export function getStationDisplayNameByName(name: string, stations: readonly Station[]): string {
-  if (i18next.language !== 'en') return name;
+  if (i18next.language === 'ko') return name;
   const found = stations.find((s) => s.name === name);
   return found?.nameEn ?? name;
 }


### PR DESCRIPTION
Closes #240

PR1(#239)에서 도입한 i18n 인프라 위에 실제 일본어를 추가하는 PR2.

## 변경 요지

### 언어 등록
- `src/i18n/locales/ja.json` 신규 — `en.json`의 모든 키를 일본어로 풀 번역. 정중체(です/ます), 駅·乗換·到着·上り/下り 등 일본 지하철 표현 사용. 일본어 복수형은 `_one`/`_other` 동일 값
- `LANGUAGE_REGISTRY`에 `{ code: 'ja', nativeName: '日本語', translation: ja }` 1줄 + import 1줄 추가
- `locales/ja.json` 신규 — Expo 앱 표시명 「いまどこ」(iOS/Android)
- `app.config.js` `locales` 매핑에 `ja: './locales/ja.json'` 추가

### 지도 i18n 마무리
- `src/components/StationMap.web.tsx`의 한국어 하드코딩 2건 → `t('map.noNearbyStations')`, `t('map.nearbyStationsHeader')` 키화. en/ko/ja 모두 키 추가
- `src/utils/stationDisplay.ts` 일반화: `=== 'en'` → `!== 'ko' && nameEn`. 일본인·중국인 사용자가 영문 표기(`nameEn`)로 역명을 인식할 수 있게 함. 한국어 모드는 그대로 `name`(플랫폼 안내판과 일치)
  - `nameJa`/`nameZh` 데이터 도입 안 하는 결정 — 528 역 × N 언어 데이터 작성 비용이 매우 크기 때문. PR3 이후 별도 트랙

### 테스트 인프라
- `jest.setup.js`를 `LANGUAGE_REGISTRY` 파생으로 리팩토링 — 앞으로 언어 추가 시 손볼 필요 없음
- `i18n.test.ts`에 ja 감지 케이스, `useApplyLocale.test.ts`에 ja 해석 케이스, `stationDisplay.test.ts`에 ja 분기 케이스 추가
- 기존 `StationMap.web.test.tsx`의 한국어 하드코딩 assert → `i18next.t(...)` 사용으로 교체

## 범위 외
- 카카오맵 SDK 타일 자체의 일본어화 — SDK 제약, Google Maps 등 프로바이더 전환 필요
- `kakaoMapLink.ts` 외부 링크 — Kakao 웹이 한국어 서비스라 그대로 Korean 전달
- iOS Widget/Live Activity Swift 하드코딩, Android `values-*` — 별도 네이티브 트랙
- 중국어(zh) — PR3로 분리

## 검증
- `npm run type-check` 0 errors
- `npm test` 743 tests pass, **커버리지 100% 유지**
- code-reviewer 에이전트 P1(jest.setup ja 누락 + 테스트 하드코딩) + P2(`setAsDestination` 자연스러운 일본어로 `目的地に設定`) 반영
- 후속 PR3 추가 비용: 레지스트리 1줄 + `zh.json` 1파일 + Expo `locales/zh.json` 1파일 + `app.config.js` 1줄

## 수동 테스트 체크리스트
- [ ] 설정 → 언어 → 「日本語」 4번째 행 보임
- [ ] 선택 시 즉시 UI 전체 일본어 전환 (설정/홈/지도/즐겨찾기/도착정보/Live Activity)
- [ ] 시스템 언어가 일본어인 상태에서 「자동」 선택 → 일본어로 자동 적용
- [ ] 영문 모드에서 역명 영문 표기, 일본어 모드에서도 동일하게 영문 표기, 한국어 모드만 한글 (`nameEn` 누락 역은 한글 fallback)
- [ ] 홈 탭 상단 시간 — 일본어 모드에서 일본식 24시간 또는 午前/午後 포맷
- [ ] 앱 표시명 — 일본어 시스템에서 「いまどこ」