### PR TITLE
fix(#242): Foreground/Background 알림 상태 단일 출처 동기화

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { useStationAlarm, type UseStationAlarmInputs } from '../useStationAlarm';
 import { useAppStore } from '../../store/useAppStore';
 import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../../utils/stationRoute';
@@ -25,6 +25,13 @@ jest.mock('../../utils/stationAlarm', () => {
 const mockResolveNextTarget = jest.fn();
 jest.mock('../../utils/stationPipeline', () => ({
   resolveNextTarget: (...args: unknown[]) => mockResolveNextTarget(...args),
+}));
+
+const mockGetLastNotifiedStationId = jest.fn();
+const mockSetLastNotifiedStationId = jest.fn();
+jest.mock('../../utils/notificationState', () => ({
+  getLastNotifiedStationId: (...args: unknown[]) => mockGetLastNotifiedStationId(...args),
+  setLastNotifiedStationId: (...args: unknown[]) => mockSetLastNotifiedStationId(...args),
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -73,6 +80,8 @@ describe('useStationAlarm', () => {
     useAppStore.setState({ sleepMode: false, allowSpeaker: true, alarmEvent: null });
     mockEvaluateAlarmPhase.mockReturnValue(null);
     mockResolveNextTarget.mockReturnValue(null);
+    mockGetLastNotifiedStationId.mockResolvedValue(null);
+    mockSetLastNotifiedStationId.mockResolvedValue(undefined);
   });
 
   it('does not evaluate when route is null', () => {
@@ -269,30 +278,34 @@ describe('useStationAlarm', () => {
       stopsToDestination: 3,
     };
 
-    it('fires when nearest station changes', () => {
+    it('fires when nearest station changes (notificationState dedup)', async () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', directTarget);
+
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', directTarget);
+      });
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('S1');
     });
 
-    it('does not fire when nearest station is unchanged', () => {
+    it('does not fire when stored lastNotifiedStationId equals nearest station', async () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
-      const { rerender } = renderHook(
-        ({ s }: { s: Station }) =>
-          useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
-        { initialProps: { s: station } },
-      );
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      mockGetLastNotifiedStationId.mockResolvedValue('S1');
 
-      rerender({ s: station });
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
+
+      await waitFor(() => {
+        expect(mockGetLastNotifiedStationId).toHaveBeenCalled();
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
-    it('fires again when nearest station changes to a different one', () => {
+    it('fires again when nearest station changes to a different one', async () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station1 = makeStation('S1', '역삼');
       const station2 = makeStation('S2', '선릉');
@@ -302,7 +315,9 @@ describe('useStationAlarm', () => {
           useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
         { initialProps: { s: station1 } },
       );
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      });
 
       const nextTarget = {
         nextStationName: '강남',
@@ -312,7 +327,9 @@ describe('useStationAlarm', () => {
       };
       mockResolveNextTarget.mockReturnValue(nextTarget);
       rerender({ s: station2 });
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
+      });
       expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', nextTarget);
     });
 
@@ -320,12 +337,14 @@ describe('useStationAlarm', () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('does not fire when route is null', () => {
       const station = makeStation('S1', '역삼');
       renderHook(() => useStationAlarm(defaultInputs({ destination, nearestStation: station })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('does not fire when destination is null', () => {
@@ -333,17 +352,20 @@ describe('useStationAlarm', () => {
       const station = makeStation('S1', '역삼');
       renderHook(() => useStationAlarm(defaultInputs({ route, nearestStation: station })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
-    it('passes null target when resolveNextTarget returns null', () => {
+    it('passes null target when resolveNextTarget returns null', async () => {
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(null);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', null);
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', null);
+      });
     });
 
-    it('handles sendStationPassedNotification rejection gracefully', () => {
+    it('handles sendStationPassedNotification rejection gracefully', async () => {
       mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 실패'));
       const route: DirectRoute = { type: 'direct', stops: 3 };
       const station = makeStation('S1', '역삼');
@@ -351,6 +373,22 @@ describe('useStationAlarm', () => {
       expect(() =>
         renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station }))),
       ).not.toThrow();
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+    });
+
+    it('handles getLastNotifiedStationId rejection gracefully', async () => {
+      mockGetLastNotifiedStationId.mockRejectedValueOnce(new Error('storage 실패'));
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue(directTarget);
+      expect(() =>
+        renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station }))),
+      ).not.toThrow();
+      await waitFor(() => {
+        expect(mockGetLastNotifiedStationId).toHaveBeenCalled();
+      });
     });
 
     it('transfer route에서 경로 외 노선의 역은 알림을 발송하지 않는다', () => {
@@ -379,9 +417,10 @@ describe('useStationAlarm', () => {
       });
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: offRouteStation })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
-    it('경로 외 역 다음에 경로상 역이 오면 알림을 발송한다 (ref 미갱신 검증)', () => {
+    it('경로 외 역 다음에 경로상 역이 오면 알림을 발송한다', async () => {
       const route: TransferRoute = {
         type: 'transfer',
         transferName: '시청',
@@ -415,8 +454,137 @@ describe('useStationAlarm', () => {
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
 
       rerender({ s: onRouteStation });
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      });
       expect(mockSendStationPassedNotification).toHaveBeenCalledWith('서울', '강남', transferTarget);
+    });
+
+    it('알림 발송 후에만 notificationState에 저장한다 (실패 시 재시도 가능)', async () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue(directTarget);
+      mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 발송 실패'));
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
+
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      // 알림 발송 실패 시 storage write를 하지 않아 다음 폴링에서 재시도 가능
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+    });
+
+    it('알림 발송이 성공하면 그 후에 notificationState에 저장한다', async () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue(directTarget);
+
+      const callOrder: string[] = [];
+      mockSendStationPassedNotification.mockImplementationOnce(async () => {
+        callOrder.push('notify');
+      });
+      mockSetLastNotifiedStationId.mockImplementationOnce(async () => {
+        callOrder.push('write');
+      });
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
+
+      await waitFor(() => {
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
+      });
+      expect(callOrder).toEqual(['notify', 'write']);
+    });
+
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    }
+
+    it('race: A→B→A 빠른 변동 시 가장 마지막 candidate에 대한 알림만 발송된다', async () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const stationA = makeStation('SA', '강남A');
+      const stationB = makeStation('SB', '강남B');
+      mockResolveNextTarget.mockReturnValue(directTarget);
+
+      const readA = deferred<string | null>();
+      const readB = deferred<string | null>();
+      const readA2 = deferred<string | null>();
+      mockGetLastNotifiedStationId
+        .mockReturnValueOnce(readA.promise)
+        .mockReturnValueOnce(readB.promise)
+        .mockReturnValueOnce(readA2.promise);
+
+      const { rerender } = renderHook(
+        ({ s }: { s: Station }) =>
+          useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
+        { initialProps: { s: stationA } },
+      );
+      rerender({ s: stationB });
+      rerender({ s: stationA });
+
+      // 세 IIFE 모두 read를 대기 중 — 이제 모두 resolve
+      readA.resolve(null);
+      readB.resolve(null);
+      readA2.resolve(null);
+
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      });
+      // 처음 두 IIFE는 cancelled 가드에 막혀 마지막(A) 한 번만 알림 발사
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남A', '강남', directTarget);
+    });
+
+    it('cancel 플래그: read 완료 전 언마운트되면 알림을 발송하지 않는다', async () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue(directTarget);
+
+      const read = deferred<string | null>();
+      mockGetLastNotifiedStationId.mockReturnValueOnce(read.promise);
+
+      const { unmount } = renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      unmount();
+      read.resolve(null);
+
+      // microtask 진행을 위해 한 사이클 양보
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+    });
+
+    it('cancel 플래그: notify 완료 전 언마운트되면 storage write를 하지 않는다', async () => {
+      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const station = makeStation('S1', '역삼');
+      mockResolveNextTarget.mockReturnValue(directTarget);
+
+      const notify = deferred<void>();
+      mockSendStationPassedNotification.mockReturnValueOnce(notify.promise);
+
+      const { unmount } = renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      // notify가 시작될 때까지 기다림
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+
+      unmount();
+      notify.resolve();
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -6,6 +6,7 @@ import { alarmKey, evaluateAlarmPhase } from '../utils/stationAlarm';
 import { distanceMetersBetween, estimateEtaSeconds } from '../utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
 import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
+import { getLastNotifiedStationId, setLastNotifiedStationId } from '../utils/notificationState';
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 
@@ -28,7 +29,6 @@ export function useStationAlarm({
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
-  const lastNotifiedStationIdRef = useRef<string | null>(null);
   const sleepMode = useAppStore((s) => s.sleepMode);
   const allowSpeaker = useAppStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
@@ -44,6 +44,7 @@ export function useStationAlarm({
   }, [allowSpeaker]);
 
   useEffect(() => {
+    let cancelled = false;
     const destinationName = destination?.name ?? null;
     if (destinationName !== prevDestRef.current) {
       firedAlarmsRef.current = new Set();
@@ -78,17 +79,38 @@ export function useStationAlarm({
     }
 
     // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
-    if (
-      nearestStation &&
-      route &&
-      isStationOnRoute(nearestStation, route) &&
-      nearestStation.id !== lastNotifiedStationIdRef.current
-    ) {
-      lastNotifiedStationIdRef.current = nearestStation.id;
-      const target = resolveNextTarget(route, destination.name);
-      sendStationPassedNotification(nearestStation.name, destination.name, target)
-        .catch((e) => logger.error('역 통과 알림 실패:', e));
+    // 알림 상태는 notificationState 모듈(AsyncStorage)을 단일 출처로 사용해
+    // Foreground/Background 양쪽에서 동일한 dedup이 적용된다.
+    // cancellation: 효과 cleanup이 cancelled를 true로 만들어 stale IIFE를 중단시킨다.
+    // A→B→A 빠른 변동 시 이전 IIFE들이 cancelled로 차단되고 최신 candidate만 알림을 보낸다.
+    if (nearestStation && route && isStationOnRoute(nearestStation, route)) {
+      const candidateStation = nearestStation;
+      const capturedRoute = route;
+      const capturedDestinationName = destination.name;
+
+      void (async () => {
+        try {
+          const lastId = await getLastNotifiedStationId();
+          if (cancelled) return;
+          if (candidateStation.id === lastId) return;
+          const target = resolveNextTarget(capturedRoute, capturedDestinationName);
+          // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
+          await sendStationPassedNotification(
+            candidateStation.name,
+            capturedDestinationName,
+            target,
+          );
+          if (cancelled) return;
+          await setLastNotifiedStationId(candidateStation.id);
+        } catch (e) {
+          logger.error('역 통과 알림 실패:', e);
+        }
+      })();
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     route,
     destination?.id,

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -94,13 +94,13 @@ function getTaskCallback(): TaskCallback {
   return (global as any).__bgTaskCallback as TaskCallback;
 }
 
-/** AsyncStorage.getItem 6개를 순서대로 모킹한다 (dest, sleep, fired, route, lastNotified, allowSpeaker) */
+/** AsyncStorage.getItem 5개를 순서대로 모킹한다 (dest, sleep, fired, route, allowSpeaker)
+ *  lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈로 read/write 한다. */
 function mockStorageValues(
   dest: string | null,
   sleep: string | null = null,
   fired: string | null = null,
   route: string | null = null,
-  lastNotified: string | null = null,
   allowSpeaker: string | null = null,
 ): void {
   (AsyncStorage.getItem as jest.Mock)
@@ -108,7 +108,6 @@ function mockStorageValues(
     .mockResolvedValueOnce(sleep)
     .mockResolvedValueOnce(fired)
     .mockResolvedValueOnce(route)
-    .mockResolvedValueOnce(lastNotified)
     .mockResolvedValueOnce(allowSpeaker);
 }
 
@@ -129,7 +128,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     jest.clearAllMocks();
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -183,7 +182,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent: null,
       nearest: { station: mockStation, distanceKm: 0.1 },
-      lastNotifiedStationId: null,
     });
 
     await taskCallback({
@@ -199,7 +197,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       sleepMode: false,
       allowSpeaker: true,
       storedRoute: null,
-      lastNotifiedStationId: null,
     }));
     expect(AsyncStorage.setItem).not.toHaveBeenCalled();
   });
@@ -209,7 +206,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it("sleepJson이 'true'이면 sleepMode=true로 processLocationUpdate를 호출한다", async () => {
     mockStorageValues(JSON.stringify(mockDestination), 'true');
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -224,7 +221,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it("sleepJson이 'false'이면 sleepMode=false로 processLocationUpdate를 호출한다", async () => {
     mockStorageValues(JSON.stringify(mockDestination), 'false');
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -239,9 +236,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── allowSpeaker 파싱 ──
 
   it("allowSpeakerJson이 'false'이면 allowSpeaker=false로 processLocationUpdate를 호출한다", async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, null, null, 'false');
+    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'false');
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -254,9 +251,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   });
 
   it("allowSpeakerJson이 'true'이면 allowSpeaker=true로 processLocationUpdate를 호출한다", async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, null, null, 'true');
+    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'true');
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -274,7 +271,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     const fired = ['destination:강남', 'transfer:시청'];
     mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(fired));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -291,7 +288,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it('ROUTE_KEY를 AsyncStorage에서 읽는다', async () => {
     mockStorageValues(JSON.stringify(mockDestination));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -305,7 +302,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     const storedRoute = { type: 'direct', stops: 3 };
     mockStorageValues(JSON.stringify(mockDestination), null, null, JSON.stringify(storedRoute));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -320,7 +317,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it('routeJson이 null이면 null storedRoute를 processLocationUpdate에 전달한다', async () => {
     mockStorageValues(JSON.stringify(mockDestination));
 
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -341,7 +338,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent,
       nearest: { station: mockStation, distanceKm: 0.1 },
-      lastNotifiedStationId: null,
     });
     mockAlarmKey.mockReturnValue('destination:시청');
 
@@ -369,7 +365,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent,
       nearest: { station: mockStation, distanceKm: 0.1 },
-      lastNotifiedStationId: null,
     });
     mockAlarmKey.mockReturnValue('transfer:강남');
 
@@ -405,7 +400,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('locations 배열의 마지막 요소를 사용한다', async () => {
     mockStorageValues(JSON.stringify(mockDestination));
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     const loc1 = makeLocation(37.1, 127.1);
     const loc2 = makeLocation(37.9, 127.9); // 마지막
@@ -484,64 +479,30 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     ).resolves.toBeUndefined();
   });
 
-  // ── LAST_NOTIFIED_STATION_KEY 관련 테스트 ──
+  // LAST_NOTIFIED_STATION_KEY 직접 read/write는 stationPipeline 내부 notificationState 모듈로 이관됨.
+  // 백그라운드 태스크는 더 이상 이 키를 직접 다루지 않으며, 관련 동작 검증은
+  // - stationPipeline.test.ts (read/write 시점)
+  // - notificationState.test.ts (실제 AsyncStorage I/O)
+  // 에서 커버한다.
 
-  it('LAST_NOTIFIED_STATION_KEY를 AsyncStorage에서 읽어 processLocationUpdate에 전달한다', async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'station-1');
-
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: 'station-1' });
-
-    await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028)] },
-      error: null,
-    });
-
-    expect(AsyncStorage.getItem).toHaveBeenCalledWith('subway-now:last-notified-station');
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
-      lastNotifiedStationId: 'station-1',
-    }));
-  });
-
-  it('lastNotifiedStationId가 변경되면 AsyncStorage에 저장한다', async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'station-1');
-
-    mockProcessLocationUpdate.mockResolvedValue({
-      alarmEvent: null,
-      nearest: null,
-      lastNotifiedStationId: 'station-2',
-    });
+  it('백그라운드 태스크는 LAST_NOTIFIED_STATION_KEY를 직접 read/write 하지 않는다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination));
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
       error: null,
     });
 
-    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-      'subway-now:last-notified-station',
-      'station-2',
-    );
-  });
-
-  it('lastNotifiedStationId가 변경되지 않으면 저장하지 않는다', async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'station-1');
-
-    mockProcessLocationUpdate.mockResolvedValue({
-      alarmEvent: null,
-      nearest: null,
-      lastNotifiedStationId: 'station-1',
-    });
-
-    await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028)] },
-      error: null,
-    });
-
-    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    expect(AsyncStorage.getItem).not.toHaveBeenCalledWith('subway-now:last-notified-station');
+    const setItemCalls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+    for (const [key] of setItemCalls) {
+      expect(key).not.toBe('subway-now:last-notified-station');
+    }
   });
 
   it('GPS speed가 양수이면 speedMps로 processLocationUpdate에 전달한다', async () => {
     mockStorageValues(JSON.stringify(mockDestination));
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028, { speed: 12.5 })] },
@@ -553,7 +514,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('GPS speed가 음수이면 speedMps를 null로 정규화한다', async () => {
     mockStorageValues(JSON.stringify(mockDestination));
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028, { speed: -1 })] },
@@ -563,20 +524,4 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({ speedMps: null }));
   });
 
-  it('lastNotifiedStationId가 null이면 저장하지 않는다', async () => {
-    mockStorageValues(JSON.stringify(mockDestination));
-
-    mockProcessLocationUpdate.mockResolvedValue({
-      alarmEvent: null,
-      nearest: null,
-      lastNotifiedStationId: null,
-    });
-
-    await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028)] },
-      error: null,
-    });
-
-    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
-  });
 });

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -4,7 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from '../utils/stationPipeline';
 import { alarmKey } from '../utils/stationAlarm';
 import { createLogger } from '../utils/logger';
-import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
 import type { Route } from '../utils/stationRoute';
 
@@ -31,12 +31,11 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const speedMps = speed != null && speed >= 0 ? speed : null;
 
   try {
-    const [destJson, sleepJson, firedJson, routeJson, lastNotifiedJson, allowSpeakerJson] = await Promise.all([
+    const [destJson, sleepJson, firedJson, routeJson, allowSpeakerJson] = await Promise.all([
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(SLEEP_MODE_KEY),
       AsyncStorage.getItem(FIRED_ALARMS_KEY),
       AsyncStorage.getItem(ROUTE_KEY),
-      AsyncStorage.getItem(LAST_NOTIFIED_STATION_KEY),
       AsyncStorage.getItem(ALLOW_SPEAKER_KEY),
     ]);
 
@@ -55,7 +54,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
     const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
 
-    const { alarmEvent, lastNotifiedStationId: newLastId } = await processLocationUpdate({
+    // lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈을 통해
+    // AsyncStorage에 직접 read/write 한다 (Foreground 훅과 단일 출처 공유).
+    const { alarmEvent } = await processLocationUpdate({
       lat: latitude,
       lng: longitude,
       destination,
@@ -63,23 +64,15 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       sleepMode,
       allowSpeaker,
       storedRoute,
-      lastNotifiedStationId: lastNotifiedJson,
       speedMps,
     });
 
-    const writes: Promise<void>[] = [];
     if (alarmEvent) {
       firedAlarms.add(alarmKey(alarmEvent));
-      writes.push(
+      await Promise.all([
         AsyncStorage.setItem(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms])),
         AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
-      );
-    }
-    if (newLastId && newLastId !== lastNotifiedJson) {
-      writes.push(AsyncStorage.setItem(LAST_NOTIFIED_STATION_KEY, newLastId));
-    }
-    if (writes.length > 0) {
-      await Promise.all(writes);
+      ]);
     }
 
     logger.info('백그라운드 위치 업데이트 완료:', latitude.toFixed(4), longitude.toFixed(4));

--- a/src/utils/__tests__/notificationState.test.ts
+++ b/src/utils/__tests__/notificationState.test.ts
@@ -1,0 +1,87 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getLastNotifiedStationId,
+  setLastNotifiedStationId,
+  clearLastNotifiedStationId,
+} from '../notificationState';
+import { LAST_NOTIFIED_STATION_KEY } from '../../constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe('notificationState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getLastNotifiedStationId', () => {
+    it('AsyncStorage에서 LAST_NOTIFIED_STATION_KEY 값을 읽어 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('station-1');
+
+      const result = await getLastNotifiedStationId();
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(LAST_NOTIFIED_STATION_KEY);
+      expect(result).toBe('station-1');
+    });
+
+    it('AsyncStorage가 null을 반환하면 null을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+      const result = await getLastNotifiedStationId();
+
+      expect(result).toBeNull();
+    });
+
+    it('AsyncStorage가 에러를 던지면 null을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      const result = await getLastNotifiedStationId();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setLastNotifiedStationId', () => {
+    it('AsyncStorage에 LAST_NOTIFIED_STATION_KEY로 값을 저장한다', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await setLastNotifiedStationId('station-2');
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(LAST_NOTIFIED_STATION_KEY, 'station-2');
+    });
+
+    it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      await expect(setLastNotifiedStationId('station-3')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearLastNotifiedStationId', () => {
+    it('AsyncStorage에서 LAST_NOTIFIED_STATION_KEY를 삭제한다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await clearLastNotifiedStationId();
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(LAST_NOTIFIED_STATION_KEY);
+    });
+
+    it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      await expect(clearLastNotifiedStationId()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -34,6 +34,13 @@ jest.mock('../stationNotification', () => ({
   sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
 }));
 
+const mockGetLastNotifiedStationId = jest.fn();
+const mockSetLastNotifiedStationId = jest.fn();
+jest.mock('../notificationState', () => ({
+  getLastNotifiedStationId: (...args: unknown[]) => mockGetLastNotifiedStationId(...args),
+  setLastNotifiedStationId: (...args: unknown[]) => mockSetLastNotifiedStationId(...args),
+}));
+
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
 
 const mockStation: Station = {
@@ -82,12 +89,14 @@ describe('processLocationUpdate', () => {
     mockCalculateStaticETA.mockReturnValue(10);
     mockEvaluateAlarmPhase.mockReturnValue(null);
     mockIsStationOnRoute.mockReturnValue(true);
+    mockGetLastNotifiedStationId.mockResolvedValue(null);
+    mockSetLastNotifiedStationId.mockResolvedValue(undefined);
   });
 
   it('returns null nearest and null alarm when findNearestStation returns null', async () => {
     mockFindNearestStation.mockReturnValue(null);
     const result = await call();
-    expect(result).toEqual({ alarmEvent: null, nearest: null, lastNotifiedStationId: null });
+    expect(result).toEqual({ alarmEvent: null, nearest: null });
     expect(mockFindRoute).not.toHaveBeenCalled();
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
@@ -260,11 +269,12 @@ describe('processLocationUpdate', () => {
     expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
   });
 
-  it('sends station-passed notification when station changes', async () => {
+  it('sends station-passed notification and writes to notificationState when station changes', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
+    mockGetLastNotifiedStationId.mockResolvedValue('other-station');
 
-    const result = await call({ lastNotifiedStationId: 'other-station' });
+    await call();
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', {
       nextStationName: '시청',
@@ -272,24 +282,26 @@ describe('processLocationUpdate', () => {
       isTransfer: false,
       stopsToDestination: 3,
     });
-    expect(result.lastNotifiedStationId).toBe('station-1');
+    expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('station-1');
   });
 
-  it('does not send station-passed notification when station is the same', async () => {
+  it('does not send station-passed notification when station is the same as stored', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
+    mockGetLastNotifiedStationId.mockResolvedValue('station-1');
 
-    const result = await call({ lastNotifiedStationId: 'station-1' });
+    await call();
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-    expect(result.lastNotifiedStationId).toBe('station-1');
+    expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
   });
 
-  it('sends station-passed notification when lastNotifiedStationId is null', async () => {
+  it('sends station-passed notification when stored lastNotifiedStationId is null', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
+    mockGetLastNotifiedStationId.mockResolvedValue(null);
 
-    const result = await call({ lastNotifiedStationId: null });
+    await call();
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', {
       nextStationName: '시청',
@@ -297,7 +309,7 @@ describe('processLocationUpdate', () => {
       isTransfer: false,
       stopsToDestination: 3,
     });
-    expect(result.lastNotifiedStationId).toBe('station-1');
+    expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('station-1');
   });
 
   it('does not mutate firedAlarms (responsibility moved to caller)', async () => {
@@ -325,25 +337,27 @@ describe('processLocationUpdate', () => {
     expect(result.nearest).toBe(mockNearestResult);
   });
 
-  it('경로 외 노선의 역이면 station-passed 알림을 보내지 않고 lastNotifiedStationId를 갱신하지 않는다', async () => {
+  it('경로 외 노선의 역이면 station-passed 알림을 보내지 않고 notificationState를 갱신하지 않는다', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
     mockIsStationOnRoute.mockReturnValue(false);
+    mockGetLastNotifiedStationId.mockResolvedValue('previous-station');
 
-    const result = await call({ lastNotifiedStationId: 'previous-station' });
+    await call();
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-    expect(result.lastNotifiedStationId).toBe('previous-station');
+    expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
   });
 
   it('route가 null이면 station-passed 알림을 보내지 않는다', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(null);
 
-    const result = await call({ lastNotifiedStationId: null });
+    await call();
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-    expect(result.lastNotifiedStationId).toBeNull();
+    expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+    expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
   });
 
   it('findNearestStation을 MAX_STATION_DISTANCE_KM(1.0)와 함께 호출한다', async () => {
@@ -354,17 +368,18 @@ describe('processLocationUpdate', () => {
     expect(mockFindNearestStation).toHaveBeenCalledWith(37.5, 127.0, 1.0);
   });
 
-  it('route 타입이 unknown(타입 오염)으로 resolveNextTarget이 null이면 알림 미발송 + ref 미갱신', async () => {
+  it('route 타입이 unknown(타입 오염)으로 resolveNextTarget이 null이면 알림 미발송 + notificationState 미갱신', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     // AsyncStorage 등에서 손상된 route가 들어온 케이스
     const corruptedRoute = { type: 'unknown', stops: 0 } as unknown as DirectRoute;
     mockFindRoute.mockReturnValue(corruptedRoute);
     mockIsStationOnRoute.mockReturnValue(true);
+    mockGetLastNotifiedStationId.mockResolvedValue('prev-station');
 
-    const result = await call({ lastNotifiedStationId: 'prev-station' });
+    await call();
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-    expect(result.lastNotifiedStationId).toBe('prev-station');
+    expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/notificationState.ts
+++ b/src/utils/notificationState.ts
@@ -1,0 +1,48 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+
+// Foreground/Background 양쪽에서 호출되는 알림 상태 저장소.
+// React 라이프사이클 외부(TaskManager 콜백)에서도 동작해야 하므로
+// 순수 함수 + AsyncStorage 단일 출처 구조를 유지한다.
+//
+// 새 알림 상태(예: 마지막 알람 phase)를 추가할 때는 storageKeys.ts에 키만 추가하고
+// 아래 generic helper를 통해 thin wrapper만 정의한다. try/catch 보일러플레이트 복붙 금지.
+const logger = createLogger('NotificationState');
+
+async function safeGetItem(key: string): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(key);
+  } catch (e) {
+    logger.error(`${key} 읽기 실패:`, e);
+    return null;
+  }
+}
+
+async function safeSetItem(key: string, value: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(key, value);
+  } catch (e) {
+    logger.error(`${key} 저장 실패:`, e);
+  }
+}
+
+async function safeRemoveItem(key: string): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(key);
+  } catch (e) {
+    logger.error(`${key} 삭제 실패:`, e);
+  }
+}
+
+export function getLastNotifiedStationId(): Promise<string | null> {
+  return safeGetItem(LAST_NOTIFIED_STATION_KEY);
+}
+
+export function setLastNotifiedStationId(id: string): Promise<void> {
+  return safeSetItem(LAST_NOTIFIED_STATION_KEY, id);
+}
+
+export function clearLastNotifiedStationId(): Promise<void> {
+  return safeRemoveItem(LAST_NOTIFIED_STATION_KEY);
+}

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -3,6 +3,7 @@ import { findRoute, calculateStaticETA, isStationOnRoute, updateRouteFromPositio
 import { evaluateAlarmPhase } from './stationAlarm';
 import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
 import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
+import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificationState';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
@@ -76,7 +77,6 @@ export function resolveNextTarget(route: Route, destinationName: string): NextTa
 export interface PipelineResult {
   alarmEvent: AlarmEvent | null;
   nearest: NearestStationResult | null;
-  lastNotifiedStationId: string | null;
 }
 
 export interface ProcessLocationInputs {
@@ -87,7 +87,6 @@ export interface ProcessLocationInputs {
   sleepMode: boolean;
   allowSpeaker?: boolean;
   storedRoute?: Route;
-  lastNotifiedStationId?: string | null;
   speedMps?: number | null;
 }
 
@@ -100,12 +99,11 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     sleepMode,
     allowSpeaker = true,
     storedRoute = null,
-    lastNotifiedStationId = null,
     speedMps = null,
   } = inputs;
 
   const nearest = findNearestStation(lat, lng, MAX_STATION_DISTANCE_KM);
-  if (!nearest) return { alarmEvent: null, nearest: null, lastNotifiedStationId };
+  if (!nearest) return { alarmEvent: null, nearest: null };
 
   let route: Route = null;
   if (storedRoute) {
@@ -128,16 +126,21 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   }
 
   // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
-  let newLastNotifiedStationId = lastNotifiedStationId;
-  if (route && isStationOnRoute(nearest.station, route) && nearest.station.id !== lastNotifiedStationId) {
-    const target = resolveNextTarget(route, destination.name);
-    if (target) {
-      newLastNotifiedStationId = nearest.station.id;
-      await sendStationPassedNotification(
-        nearest.station.name,
-        destination.name,
-        target,
-      );
+  // 알림 상태는 notificationState 모듈(AsyncStorage)을 단일 출처로 사용해
+  // Foreground/Background 양쪽에서 동일한 dedup이 적용된다.
+  if (route && isStationOnRoute(nearest.station, route)) {
+    const lastNotifiedStationId = await getLastNotifiedStationId();
+    if (nearest.station.id !== lastNotifiedStationId) {
+      const target = resolveNextTarget(route, destination.name);
+      if (target) {
+        // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
+        await sendStationPassedNotification(
+          nearest.station.name,
+          destination.name,
+          target,
+        );
+        await setLastNotifiedStationId(nearest.station.id);
+      }
     }
   }
 
@@ -152,5 +155,5 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     sleepMode ? alarmEvent : null,
   );
 
-  return { alarmEvent, nearest, lastNotifiedStationId: newLastNotifiedStationId };
+  return { alarmEvent, nearest };
 }


### PR DESCRIPTION
## Summary

`useStationAlarm`(메모리 `useRef`)과 `backgroundLocationTask`(AsyncStorage `LAST_NOTIFIED_STATION_KEY`)가 분리된 채널로 마지막 알림 역을 추적하던 구조를 폐기하고, 신규 `notificationState` 모듈을 통해 **AsyncStorage 단일 출처**로 통합.

- 신규 `src/utils/notificationState.ts` — `safeGetItem` / `safeSetItem` / `safeRemoveItem` generic helper + station-id wrapper. 향후 알림 상태 추가 시 thin wrapper만 정의(보일러플레이트 복붙 금지).
- `processLocationUpdate`: `lastNotifiedStationId` 파라미터/반환값 제거, 내부에서 notificationState read/write.
- `useStationAlarm`: `useRef` 제거, useEffect cleanup(`cancelled` 플래그)으로 stale IIFE 차단. A→B→A 빠른 변동 시 마지막 candidate만 알림 발송.
- 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
- `backgroundLocationTask`: `LAST_NOTIFIED_STATION_KEY` 직접 접근 코드 제거.

## Test plan

- [x] `src/utils/__tests__/notificationState.test.ts` — get/set/clear + AsyncStorage 에러 격리 검증
- [x] `src/utils/__tests__/stationPipeline.test.ts` — notificationState mock으로 read/write 시점 검증
- [x] `src/hooks/__tests__/useStationAlarm.test.ts` — race(A→B→A), cancellation(read 전/notify 전 unmount), 발송 실패 시 storage 미갱신, 발송 후 write 순서 검증
- [x] `src/tasks/__tests__/backgroundLocationTask.test.ts` — 키 직접 접근 미발생 네거티브 검증
- [x] `npm test` 커버리지 100% 통과 (747 tests)
- [x] `npm run type-check` 통과

Closes #242