### PR TITLE
feat(#246): 중국어(zh) 지원 추가

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -13,6 +13,7 @@ module.exports = {
       ko: './locales/ko.json',
       en: './locales/en.json',
       ja: './locales/ja.json',
+      zh: './locales/zh.json',
     },
     splash: {
       image: './assets/splash/splash-ko-1284x2778.png',

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1,0 +1,9 @@
+{
+  "ios": {
+    "CFBundleDisplayName": "现在在哪",
+    "CFBundleName": "现在在哪"
+  },
+  "android": {
+    "app_name": "现在在哪"
+  }
+}

--- a/src/hooks/__tests__/useApplyLocale.test.ts
+++ b/src/hooks/__tests__/useApplyLocale.test.ts
@@ -15,9 +15,11 @@ describe('resolveLanguage', () => {
     ['ko', 'en', 'ko'],
     ['en', 'ko', 'en'],
     ['ja', 'ko', 'ja'],
+    ['zh', 'ko', 'zh'],
     ['auto', 'ko', 'ko'],
     ['auto', 'en', 'en'],
     ['auto', 'ja', 'ja'],
+    ['auto', 'zh', 'zh'],
     ['auto', 'fr', 'en'],
     ['auto', null, 'en'],
   ] as const)('resolveLanguage(%s, %s) === %s', (preference, os, expected) => {

--- a/src/i18n/__tests__/i18n.test.ts
+++ b/src/i18n/__tests__/i18n.test.ts
@@ -34,6 +34,11 @@ describe('detectDeviceLanguage', () => {
     expect(detectDeviceLanguage()).toBe('ja');
   });
 
+  it('returns zh when device language is zh', () => {
+    mockGetLocales.mockReturnValueOnce([{ languageCode: 'zh' }]);
+    expect(detectDeviceLanguage()).toBe('zh');
+  });
+
   it('falls back when device language is unsupported', () => {
     mockGetLocales.mockReturnValueOnce([{ languageCode: 'fr' }]);
     expect(detectDeviceLanguage()).toBe(FALLBACK_LANGUAGE);

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1,0 +1,194 @@
+{
+  "common": {
+    "retry": "重试",
+    "close": "关闭",
+    "confirm": "确定",
+    "cancel": "取消"
+  },
+  "tabs": {
+    "current": "当前",
+    "map": "地图",
+    "favorites": "收藏",
+    "settings": "设置"
+  },
+  "permissions": {
+    "locationRequiredTitle": "需要位置权限",
+    "locationRequiredShort": "需要位置权限。",
+    "locationRequiredDescription": "请在设置中允许位置权限。\n要检测您当前的车站，需要位置权限。",
+    "request": "授予权限",
+    "locating": "正在定位..."
+  },
+  "home": {
+    "arrived": "已到达!",
+    "live": "LIVE",
+    "manual": "MANUAL",
+    "originManual": "出发站(手动)",
+    "originCurrent": "当前站",
+    "originNearest": "最近站",
+    "switchToGps": "切换到GPS模式",
+    "routeTo": "前往",
+    "estimatedSuffix": "预计",
+    "destinationChange": "更改目的地 →",
+    "destinationReset": "重置",
+    "destinationSet": "设置目的地",
+    "previousDestination": "上次目的地",
+    "sleepMode": "睡眠模式",
+    "sleepModeDescription": "在换乘或到达前1站时震动并通知",
+    "arrivalInfoTitle": "列车到达信息",
+    "loading": "加载中...",
+    "mockNotice": "无法获取实时数据,显示预测数据",
+    "noArrivalInfo": "无到达信息",
+    "notNearStationTitle": "附近没有地铁站",
+    "notNearStationDescription": "当您距离地铁站500m以内时,会显示当前站。\n您也可以在地图标签页手动设置出发站。",
+    "refresh": "刷新"
+  },
+  "settings": {
+    "title": "设置",
+    "themeSection": "主题",
+    "themeAuto": "自动",
+    "themeLight": "浅色",
+    "themeDark": "深色",
+    "themeLabel": "深色模式",
+    "themeDescription": "自动会跟随设备设置",
+    "routeSection": "路线",
+    "routePreferenceLabel": "路线偏好",
+    "routePreferenceDescription": "选择默认路线搜索方式",
+    "alarmSection": "提醒",
+    "sleepModeLabel": "睡眠模式",
+    "sleepModeDescription": "连接耳机时播放唤醒铃声",
+    "speakerOutputLabel": "允许扬声器输出",
+    "speakerOutputDescription": "即使未连接耳机也通过扬声器播放铃声",
+    "speakerOffTitle": "关闭扬声器输出",
+    "speakerOffMessage": "关闭扬声器输出后,未连接耳机时只会震动。是否继续?",
+    "speakerOffConfirm": "关闭",
+    "languageSection": "语言",
+    "languageLabel": "应用语言",
+    "languageDescription": "自动会跟随设备设置",
+    "languageAuto": "自动"
+  },
+  "map": {
+    "originBadge": "出发",
+    "destinationBadge": "目的地",
+    "setAsOrigin": "设为出发站",
+    "setAsDestination": "设为目的地",
+    "nearbyStationsHeader": "附近地铁站(1km以内)",
+    "noNearbyStations": "1km内没有地铁站。"
+  },
+  "favorites": {
+    "title": "收藏",
+    "searchPlaceholder": "搜索车站名称...",
+    "noSearchResults": "无搜索结果",
+    "empty": "还没有收藏",
+    "emptyDescription": "在上方搜索车站\n添加到收藏。",
+    "remove": "删除"
+  },
+  "alarmOverlay": {
+    "transferTitle": "换乘提醒",
+    "arrivalTitle": "到达提醒",
+    "transferMessage": "在{{station}}\n换乘",
+    "arrivalMessage": "在{{station}}\n下车",
+    "dismiss": "关闭提醒"
+  },
+  "destinationPicker": {
+    "noLocation": "无位置信息。",
+    "title": "设置目的地",
+    "searchPlaceholder": "搜索车站名称"
+  },
+  "sleepModeGuide": {
+    "title": "睡眠模式提示",
+    "message": "如果未连接耳机,提醒可能通过扬声器播放。\n\n如不希望扬声器输出,请在 设置 > 提醒 中关闭'允许扬声器输出'。",
+    "confirm": "确定"
+  },
+  "background": {
+    "title": "正在检测地铁位置",
+    "body": "正在后台追踪当前车站"
+  },
+  "arrival": {
+    "upbound": "上行",
+    "downbound": "下行"
+  },
+  "notifications": {
+    "channelStation": "当前车站",
+    "channelTransferAlarm": "换乘/到达提醒",
+    "channelTransferAlarmSilent": "换乘/到达提醒(静音)",
+    "channelStationPass": "经过车站提醒",
+    "transferEarlyTitle": "换乘提醒",
+    "arrivalEarlyTitle": "到达提醒",
+    "transferImminentTitle": "即将换乘",
+    "arrivalImminentTitle": "即将到达"
+  },
+  "journey": {
+    "transferNote": "换乘",
+    "arrivalNote": "到达"
+  },
+  "routes": {
+    "optimal": "最快",
+    "minTransfer": "最少换乘"
+  },
+  "time": {
+    "arrivingSoon": "即将到达",
+    "minutesAndSeconds": "{{min}}分{{sec}}秒",
+    "seconds": "{{sec}}秒",
+    "approximateMinutes": "约{{min}}分钟",
+    "estimatedSuffix": " (预计)"
+  },
+  "route": {
+    "stops_one": "{{count}}站",
+    "stops_other": "{{count}}站",
+    "stopsLeft_one": "剩余{{count}}站",
+    "stopsLeft_other": "剩余{{count}}站",
+    "transferAfterStops": "{{stops}}站后在{{name}}换乘",
+    "minutesAndTransfers_one": "{{min}}分钟 · 换乘{{count}}次",
+    "minutesAndTransfers_other": "{{min}}分钟 · 换乘{{count}}次",
+    "directOnly": "{{min}}分钟 · 直达",
+    "currentStation": "{{name}}",
+    "atCurrentStation": "当前 {{name}}",
+    "approximateDistance": "约{{m}}m",
+    "stationPassed": "已通过{{name}}",
+    "stopsRemainingToDestination_one": "距{{destination}}还有{{count}}站",
+    "stopsRemainingToDestination_other": "距{{destination}}还有{{count}}站",
+    "stopsRemainingViaTransfer": "距{{transfer}}换乘{{transferStops}}站 · 距{{destination}}{{totalStops}}站"
+  },
+  "lines": {
+    "1": "1号线",
+    "2": "2号线",
+    "3": "3号线",
+    "4": "4号线",
+    "5": "5号线",
+    "6": "6号线",
+    "7": "7号线",
+    "8": "8号线",
+    "9": "9号线",
+    "airport": "机场铁路",
+    "gyeongui": "京义中央线",
+    "bundang": "盆唐线",
+    "sinbundang": "新盆唐线"
+  },
+  "alarms": {
+    "earlyTransferBody": "下一站 {{station}} 请换乘!",
+    "earlyArrivalBody": "下一站 {{station}} 请下车!",
+    "imminentTransferBody": "即将到达{{station}}。请准备换乘!",
+    "imminentArrivalBody": "即将到达{{station}}。请准备下车!"
+  },
+  "liveActivity": {
+    "alarmShortTransfer": "换乘",
+    "alarmShortArrival": "下车",
+    "etaSubtextEstimated": "预计",
+    "etaSubtextDuration": "用时",
+    "stopsToArrival_one": "距{{destination}}还有{{count}}站",
+    "stopsToArrival_other": "距{{destination}}还有{{count}}站",
+    "stopsToTransfer_one": "{{count}}站后在{{name}}换乘",
+    "stopsToTransfer_other": "{{count}}站后在{{name}}换乘",
+    "summaryWithStops_one": "→ {{destination}} · 还有{{count}}站到达{{etaSuffix}}",
+    "summaryWithStops_other": "→ {{destination}} · 还有{{count}}站到达{{etaSuffix}}",
+    "summaryWithTransfer_one": "→ {{destination}} · {{count}}站后在{{name}}换乘{{etaSuffix}}",
+    "summaryWithTransfer_other": "→ {{destination}} · {{count}}站后在{{name}}换乘{{etaSuffix}}",
+    "summaryDestinationOnly": "→ {{destination}}{{etaSuffix}}",
+    "etaSuffix": " · 约{{min}}分钟"
+  },
+  "direction": {
+    "boundFor": "开往{{name}}",
+    "innerLoop": "内环",
+    "outerLoop": "外环"
+  }
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,6 +1,7 @@
 import en from './locales/en.json';
 import ko from './locales/ko.json';
 import ja from './locales/ja.json';
+import zh from './locales/zh.json';
 
 // 지원 언어를 한 곳에서 관리한다. 새 언어 추가 시 이 배열에 한 줄을 추가하고
 // 로케일 JSON 파일을 import 하면 RESOURCES/SUPPORTED_LANGUAGES/SupportedLanguage가
@@ -10,6 +11,7 @@ export const LANGUAGE_REGISTRY = [
   { code: 'ko', nativeName: '한국어', translation: ko },
   { code: 'en', nativeName: 'English', translation: en },
   { code: 'ja', nativeName: '日本語', translation: ja },
+  { code: 'zh', nativeName: '中文', translation: zh },
 ] as const;
 
 export const SUPPORTED_LANGUAGES = LANGUAGE_REGISTRY.map(

--- a/src/utils/__tests__/stationDisplay.test.ts
+++ b/src/utils/__tests__/stationDisplay.test.ts
@@ -10,7 +10,7 @@ const stations: Station[] = [
 
 // 비한국어(en/ja 등)는 모두 동일 분기(nameEn fallback)를 타므로 데이터 주도로 검증한다.
 // zh 등 새 언어 추가 시 이 배열에 한 줄만 추가하면 동일 검증이 자동 적용된다.
-const NON_KO_LANGUAGES = ['en', 'ja'] as const;
+const NON_KO_LANGUAGES = ['en', 'ja', 'zh'] as const;
 
 installLanguageRestoreHook();
 


### PR DESCRIPTION
Closes #246

PR1(#239 인프라) + PR2(#241 일본어) 다국어 시리즈의 마지막 단계.

## 변경 요지

- `src/i18n/locales/zh.json` 신규 — `en.json` 키 전체를 중국어 간체로 풀 번역. 지하철 용어(地铁站·换乘·到达·上行/下行·内环/外环 등) 사용. 중국어는 문법적 복수형이 없어 `_one`/`_other` 동일 값
- `LANGUAGE_REGISTRY`에 `{ code: 'zh', nativeName: '中文', translation: zh }` 1줄 + import 1줄 추가
- `locales/zh.json` 신규 — Expo 앱 표시명 「现在在哪」(iOS/Android)
- `app.config.js` `locales` 매핑에 `zh: './locales/zh.json'` 추가
- 테스트:
  - `stationDisplay.test.ts`의 `NON_KO_LANGUAGES`에 `'zh'` 1줄 추가 — 모든 it.each 검증이 zh에도 자동 적용
  - `i18n.test.ts`에 zh 감지 케이스
  - `useApplyLocale.test.ts`에 zh 해석 케이스 (`zh→zh`, `auto+zh→zh`)

## 인프라 효과 검증

PR1에서 만든 `LANGUAGE_REGISTRY` 데이터 주도 패턴 + PR2에서 추출한 `testUtils/i18nLanguageOverride.ts` 헬퍼 덕분에 zh 추가는 **레지스트리 1줄 + 번역 JSON 1파일 + Expo locales 1파일 + app.config 1줄 + 테스트 데이터 배열 1줄** 로 완성. 검증 케이스를 새로 작성한 곳은 0건(데이터 추가로만 처리).

## 범위 외
- 번체(zh-TW) 분리 — 필요 시 동일 패턴으로 추가 가능
- 카카오맵 SDK 타일 자체 중국어화(SDK 제약)
- iOS Widget/Live Activity Swift 하드코딩(별도 네이티브 PR)

## 검증
- `npm run type-check` 0 errors
- `npm test` 759 tests pass, **커버리지 100% 유지**
- 워크트리(`../subway-now-issue246`)에서 격리 작업

## 수동 테스트 체크리스트
- [ ] 설정 → 언어: 「中文」 5번째 행 보임
- [ ] 선택 시 즉시 UI 전체 중국어 전환 (설정/홈/지도/즐겨찾기/도착정보/Live Activity)
- [ ] 시스템 언어가 중국어인 상태에서 「자동」 선택 → 중국어로 자동 적용
- [ ] 앱 표시명 — 중국어 시스템에서 「现在在哪」