### PR TITLE
fix(#195): DirectRoute line 필드로 경로 외 노선 false alarm 차단

### DIFF
--- a/src/components/__tests__/JourneyTimeline.test.tsx
+++ b/src/components/__tests__/JourneyTimeline.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { JourneyTimeline } from '../JourneyTimeline';
 import type { JourneyDisplay } from '../../utils/stationRoute';
+import type { LineNumber } from '../../types/station';
 
 const directJourney: JourneyDisplay = {
   segments: [
@@ -86,7 +87,7 @@ describe('JourneyTimeline', () => {
     const unknownLineJourney: JourneyDisplay = {
       segments: [
         {
-          line: 'unknown',
+          line: 'unknown' as unknown as LineNumber,
           lineColor: '#999999',
           fromName: '역A',
           toName: '역B',

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -90,13 +90,13 @@ describe('useStationAlarm', () => {
   });
 
   it('does not evaluate when destination is null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     renderHook(() => useStationAlarm(defaultInputs({ route })));
     expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
   });
 
   it('builds AlarmSource and calls evaluator', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() =>
       useStationAlarm(
         defaultInputs({
@@ -118,7 +118,7 @@ describe('useStationAlarm', () => {
   });
 
   it('passes null etaSeconds when speed is null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() =>
       useStationAlarm(
         defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127.0 }, speedMps: null }),
@@ -131,7 +131,7 @@ describe('useStationAlarm', () => {
   });
 
   it('passes null etaSeconds when userLocation is null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() => useStationAlarm(defaultInputs({ route, destination, speedMps: 10 })));
     expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
       expect.objectContaining({ etaSeconds: null }),
@@ -140,7 +140,7 @@ describe('useStationAlarm', () => {
   });
 
   it('sends alarm notification with the full event', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true);
@@ -175,7 +175,7 @@ describe('useStationAlarm', () => {
   });
 
   it('does not fire the same alarm twice', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
@@ -184,7 +184,7 @@ describe('useStationAlarm', () => {
   });
 
   it('fires imminent after early for the same waypoint', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValueOnce(earlyDest);
     const { rerender } = renderHook(
       ({ inputs }: { inputs: UseStationAlarmInputs }) => useStationAlarm(inputs),
@@ -205,7 +205,7 @@ describe('useStationAlarm', () => {
   });
 
   it('resets fired alarms when destination changes', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(
       ({ dest }: { dest: Station }) => useStationAlarm(defaultInputs({ route, destination: dest })),
@@ -222,7 +222,7 @@ describe('useStationAlarm', () => {
 
   it('passes sleepMode to sendAlarmNotification', () => {
     useAppStore.setState({ sleepMode: true });
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, true, true);
@@ -230,7 +230,7 @@ describe('useStationAlarm', () => {
 
   it('sets alarmEvent in store when sleepMode is on', () => {
     useAppStore.setState({ sleepMode: true });
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(useAppStore.getState().alarmEvent).toEqual(earlyDest);
@@ -238,7 +238,7 @@ describe('useStationAlarm', () => {
 
   it('does not set alarmEvent when sleepMode is off', () => {
     useAppStore.setState({ sleepMode: false });
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(useAppStore.getState().alarmEvent).toBeNull();
@@ -246,14 +246,14 @@ describe('useStationAlarm', () => {
 
   it('passes allowSpeaker=false from store', () => {
     useAppStore.setState({ allowSpeaker: false });
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, false);
   });
 
   it('does not re-fire when sleepMode toggles after first fire', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
@@ -265,7 +265,7 @@ describe('useStationAlarm', () => {
 
   it('handles sendAlarmNotification rejection gracefully', () => {
     mockSendAlarmNotification.mockRejectedValueOnce(new Error('알림 실패'));
-    const route: DirectRoute = { type: 'direct', stops: 1 };
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     expect(() => renderHook(() => useStationAlarm(defaultInputs({ route, destination })))).not.toThrow();
   });
@@ -279,7 +279,7 @@ describe('useStationAlarm', () => {
     };
 
     it('fires when nearest station changes (notificationState dedup)', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
@@ -291,7 +291,7 @@ describe('useStationAlarm', () => {
     });
 
     it('does not fire when stored lastNotifiedStationId equals nearest station', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       mockGetLastNotifiedStationId.mockResolvedValue('S1');
@@ -306,7 +306,7 @@ describe('useStationAlarm', () => {
     });
 
     it('fires again when nearest station changes to a different one', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station1 = makeStation('S1', '역삼');
       const station2 = makeStation('S2', '선릉');
       mockResolveNextTarget.mockReturnValue(directTarget);
@@ -334,7 +334,7 @@ describe('useStationAlarm', () => {
     });
 
     it('does not fire when nearestStation is null', () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
@@ -348,7 +348,7 @@ describe('useStationAlarm', () => {
     });
 
     it('does not fire when destination is null', () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       renderHook(() => useStationAlarm(defaultInputs({ route, nearestStation: station })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
@@ -356,7 +356,7 @@ describe('useStationAlarm', () => {
     });
 
     it('passes null target when resolveNextTarget returns null', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(null);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
@@ -367,7 +367,7 @@ describe('useStationAlarm', () => {
 
     it('handles sendStationPassedNotification rejection gracefully', async () => {
       mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 실패'));
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       expect(() =>
@@ -380,7 +380,7 @@ describe('useStationAlarm', () => {
 
     it('handles getLastNotifiedStationId rejection gracefully', async () => {
       mockGetLastNotifiedStationId.mockRejectedValueOnce(new Error('storage 실패'));
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       expect(() =>
@@ -414,6 +414,30 @@ describe('useStationAlarm', () => {
         stopsToNextStation: 3,
         isTransfer: true,
         stopsToDestination: 8,
+      });
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: offRouteStation })));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
+    });
+
+    it('direct route에서 경로 외 노선의 역은 알림을 발송하지 않는다 (#195 회귀 가드)', () => {
+      // #195: PR #196의 isStationOnRoute(direct)가 항상 true였던 결함을 막는 통합 회귀.
+      // 2호선 강남 → 2호선 잠실 direct 경로 진행 중 GPS가 9호선 한성백제를 잡아도
+      // 거리 게이트(1km)는 통과하지만 isStationOnRoute(direct) → false로 알림 차단.
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const offRouteStation: Station = {
+        id: 'OFF-9',
+        name: '한성백제',
+        line: '9',
+        lineColor: '#BB8336',
+        lat: 37.5,
+        lng: 127.0,
+      };
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '잠실',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
       });
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: offRouteStation })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
@@ -461,7 +485,7 @@ describe('useStationAlarm', () => {
     });
 
     it('알림 발송 후에만 notificationState에 저장한다 (실패 시 재시도 가능)', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 발송 실패'));
@@ -476,7 +500,7 @@ describe('useStationAlarm', () => {
     });
 
     it('알림 발송이 성공하면 그 후에 notificationState에 저장한다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
 
@@ -505,7 +529,7 @@ describe('useStationAlarm', () => {
     }
 
     it('race: A→B→A 빠른 변동 시 가장 마지막 candidate에 대한 알림만 발송된다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const stationA = makeStation('SA', '강남A');
       const stationB = makeStation('SB', '강남B');
       mockResolveNextTarget.mockReturnValue(directTarget);
@@ -539,7 +563,7 @@ describe('useStationAlarm', () => {
     });
 
     it('cancel 플래그: read 완료 전 언마운트되면 알림을 발송하지 않는다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
 
@@ -562,7 +586,7 @@ describe('useStationAlarm', () => {
     });
 
     it('cancel 플래그: notify 완료 전 언마운트되면 storage write를 하지 않는다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
 

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -299,7 +299,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   });
 
   it('routeJson이 있으면 파싱한 route를 processLocationUpdate에 전달한다', async () => {
-    const storedRoute = { type: 'direct', stops: 3 };
+    const storedRoute = { type: 'direct', stops: 3, line: '2' };
     mockStorageValues(JSON.stringify(mockDestination), null, null, JSON.stringify(storedRoute));
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -3,6 +3,7 @@ import {
   arrivalInfoToArrivalTrain,
   nearestResultToNearest,
 } from '../journeyAdapter';
+import type { JourneyDisplay } from '../stationRoute';
 import { MOCK_JOURNEYS, makeNearestResult, makeArrivalInfo } from '../../testUtils/fixtures';
 
 describe('journeyDisplayToStops', () => {
@@ -24,7 +25,7 @@ describe('journeyDisplayToStops', () => {
   });
 
   it('should convert a multi-transfer route (three segments)', () => {
-    const journey = {
+    const journey: JourneyDisplay = {
       segments: [
         { line: '1', lineColor: '#0052A4', fromName: '서울역', toName: '시청', stops: 1 },
         { line: '2', lineColor: '#009D3E', fromName: '시청', toName: '을지로3가', stops: 2 },
@@ -41,7 +42,7 @@ describe('journeyDisplayToStops', () => {
   });
 
   it('should handle special line numbers', () => {
-    const journey = {
+    const journey: JourneyDisplay = {
       segments: [
         { line: 'airport', lineColor: '#4B81BF', fromName: '서울역', toName: '인천공항', stops: 5 },
       ],

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -1,12 +1,13 @@
 import { alarmKey, evaluateAlarmPhase, resolveAllTargets, type AlarmEvent, type AlarmSource } from '../stationAlarm';
 import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
+import type { LineNumber } from '../../types/station';
 
 function makeTransferRoute(
   stopsToTransfer: number,
   stopsFromTransfer: number,
   transferName = '시청',
-  fromLine = '1',
-  toLine = '2',
+  fromLine: LineNumber = '1',
+  toLine: LineNumber = '2',
 ): TransferRoute {
   return { type: 'transfer', transferName, fromLine, toLine, stopsToTransfer, stopsFromTransfer };
 }
@@ -48,7 +49,7 @@ describe('alarmKey', () => {
 
 describe('resolveAllTargets', () => {
   it('returns single destination for DirectRoute', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5 };
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
     expect(resolveAllTargets(route, '강남')).toEqual([
       { name: '강남', stops: 5, alarmType: 'destination' },
     ]);
@@ -100,7 +101,7 @@ describe('evaluateAlarmPhase', () => {
 
   describe('DirectRoute — early phase', () => {
     it('fires early at stops === 1', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
       expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toEqual({
         phaseId: 'early',
         type: 'destination',
@@ -109,12 +110,12 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('does not fire when stops > 1', () => {
-      const route: DirectRoute = { type: 'direct', stops: 2 };
+      const route: DirectRoute = { type: 'direct', stops: 2, line: '2' };
       expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toBeNull();
     });
 
     it('skips early when already fired', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
       const fired = new Set(['early:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName }), fired)).toBeNull();
     });
@@ -122,7 +123,7 @@ describe('evaluateAlarmPhase', () => {
 
   describe('DirectRoute — imminent phase', () => {
     it('fires imminent after early when eta within 10s', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
       const fired = new Set(['early:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 8 }), fired)).toEqual({
         phaseId: 'imminent',
@@ -132,13 +133,13 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('does not fire imminent when eta exceeds 10s', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
       const fired = new Set(['early:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 30 }), fired)).toBeNull();
     });
 
     it('prefers early over imminent when both qualify and neither fired', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 5 }), new Set())).toEqual({
         phaseId: 'early',
         type: 'destination',
@@ -147,13 +148,13 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('skips imminent when already fired', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1 };
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
       const fired = new Set(['early:강남', 'imminent:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 5 }), fired)).toBeNull();
     });
 
     it('does not fire imminent at stops 0 if remainingStops gate fails — gate allows 0 so it does fire', () => {
-      const route: DirectRoute = { type: 'direct', stops: 0 };
+      const route: DirectRoute = { type: 'direct', stops: 0, line: '2' };
       expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toEqual({
         phaseId: 'early',
         type: 'destination',
@@ -266,7 +267,7 @@ describe('evaluateAlarmPhase', () => {
 
   describe('custom phases', () => {
     it('accepts a custom phase array', () => {
-      const route: DirectRoute = { type: 'direct', stops: 3 };
+      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
       const customPhases = [
         {
           id: 'early' as const,

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -59,7 +59,7 @@ const mockDestination: Station = {
   lng: 127.0163,
 };
 
-const directRoute: DirectRoute = { type: 'direct', stops: 4 };
+const directRoute: DirectRoute = { type: 'direct', stops: 4, line: '1' };
 const transferRoute: TransferRoute = {
   type: 'transfer',
   transferName: '동대문',

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -66,7 +66,7 @@ const mockNearestResult: NearestStationResult = {
   distanceKm: 0.15,
 };
 
-const mockRoute: DirectRoute = { type: 'direct', stops: 3 };
+const mockRoute: DirectRoute = { type: 'direct', stops: 3, line: '2' };
 const mockAlarmEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '시청' };
 
 function call(overrides: Partial<Parameters<typeof processLocationUpdate>[0]> = {}) {
@@ -234,7 +234,7 @@ describe('processLocationUpdate', () => {
   });
 
   it('falls back to findRoute when storedRoute exists but updateRouteFromPosition returns null', async () => {
-    const storedRoute: DirectRoute = { type: 'direct', stops: 5 };
+    const storedRoute: DirectRoute = { type: 'direct', stops: 5, line: '2' };
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockUpdateRouteFromPosition.mockReturnValue(null);
     mockFindRoute.mockReturnValue(mockRoute);
@@ -246,8 +246,8 @@ describe('processLocationUpdate', () => {
   });
 
   it('uses updateRouteFromPosition result when storedRoute is provided and succeeds', async () => {
-    const storedRoute: DirectRoute = { type: 'direct', stops: 5 };
-    const updatedRoute: DirectRoute = { type: 'direct', stops: 3 };
+    const storedRoute: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const updatedRoute: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockUpdateRouteFromPosition.mockReturnValue(updatedRoute);
     mockCalculateStaticETA.mockReturnValue(6);
@@ -389,7 +389,7 @@ describe('resolveNextTarget', () => {
   });
 
   it('returns destination and stops for direct route', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5 };
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
       stopsToNextStation: 5,

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,5 +1,5 @@
 import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES } from '../stationRoute';
-import type { Station } from '../../types/station';
+import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 
 describe('getStationsOnLine', () => {
@@ -13,10 +13,10 @@ describe('getStationsOnLine', () => {
   });
 
   it('returns empty array for unknown line', () => {
-    expect(getStationsOnLine('999')).toEqual([]);
+    expect(getStationsOnLine('999' as unknown as LineNumber)).toEqual([]);
   });
 
-  it.each([
+  it.each<[LineNumber, number]>([
     ['airport', 13],
     ['gyeongui', 57],
     ['bundang', 54],
@@ -219,7 +219,7 @@ describe('buildJourneyDisplay', () => {
   });
 
   it('DirectRoute이면 세그먼트 1개를 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     const current = mockStation({ id: '2-022', name: '강남' });
     const dest = mockStation({ id: '2-025', name: '잠실' });
 
@@ -300,7 +300,7 @@ describe('buildJourneyDisplay', () => {
 
 describe('calculateETA', () => {
   it('DirectRoute일 때 대기시간 + 정거장*2분을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5 };
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
     // 3분 대기 + 5*2분 = 13분
     expect(calculateETA(3, route)).toBe(13);
   });
@@ -338,7 +338,7 @@ describe('calculateETA', () => {
 
 describe('calculateStaticETA', () => {
   it('DirectRoute일 때 기본대기3분 + 정거장*2분을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5 };
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
     // 3분 대기 + 5*2분 = 13분
     expect(calculateStaticETA(route)).toBe(13);
   });
@@ -379,8 +379,8 @@ describe('buildJourneyDisplay — LINE_COLORS fallback', () => {
     const route: TransferRoute = {
       type: 'transfer',
       transferName: '환승역',
-      fromLine: 'unknown1' as string,
-      toLine: 'unknown2' as string,
+      fromLine: 'unknown1' as unknown as LineNumber,
+      toLine: 'unknown2' as unknown as LineNumber,
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
     };
@@ -396,8 +396,8 @@ describe('buildJourneyDisplay — LINE_COLORS fallback', () => {
     const route: MultiTransferRoute = {
       type: 'multi-transfer',
       transfers: [
-        { transferName: '환승A', fromLine: 'unknown1' as string, toLine: 'unknown2' as string, stopsToTransfer: 1 },
-        { transferName: '환승B', fromLine: 'unknown2' as string, toLine: 'unknown3' as string, stopsToTransfer: 2 },
+        { transferName: '환승A', fromLine: 'unknown1' as unknown as LineNumber, toLine: 'unknown2' as unknown as LineNumber, stopsToTransfer: 1 },
+        { transferName: '환승B', fromLine: 'unknown2' as unknown as LineNumber, toLine: 'unknown3' as unknown as LineNumber, stopsToTransfer: 2 },
       ],
       stopsAfterLastTransfer: 3,
     };
@@ -417,19 +417,19 @@ describe('getNextStationName', () => {
   });
 
   it('currentId가 유효하지 않으면 null을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 2 };
+    const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
     expect(getNextStationName('invalid-id', '1-003', route)).toBeNull();
   });
 
   it('destinationId가 유효하지 않으면 null을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 2 };
+    const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
     expect(getNextStationName('1-001', 'invalid-id', route)).toBeNull();
   });
 
   describe('DirectRoute', () => {
     it('정방향으로 다음 역을 반환한다', () => {
       // 1호선: 소요산(1-001) → 보산(1-003), 중간에 동두천(1-002)
-      const route: DirectRoute = { type: 'direct', stops: 2 };
+      const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
       const next = getNextStationName('1-001', '1-003', route);
       // 소요산 다음 역 (1-002)의 이름
       const line1 = getStationsOnLine('1');
@@ -439,7 +439,7 @@ describe('getNextStationName', () => {
 
     it('역방향으로 다음 역을 반환한다', () => {
       // 1호선: 보산(1-003) → 소요산(1-001)
-      const route: DirectRoute = { type: 'direct', stops: 2 };
+      const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
       const next = getNextStationName('1-003', '1-001', route);
       const line1 = getStationsOnLine('1');
       const bosan = line1.findIndex((s) => s.id === '1-003');
@@ -447,7 +447,7 @@ describe('getNextStationName', () => {
     });
 
     it('같은 역이면 null을 반환한다 (currentIdx === targetIdx)', () => {
-      const route: DirectRoute = { type: 'direct', stops: 0 };
+      const route: DirectRoute = { type: 'direct', stops: 0, line: '1' };
       expect(getNextStationName('1-001', '1-001', route)).toBeNull();
     });
 
@@ -617,7 +617,7 @@ describe('findRoutes', () => {
 
 describe('pickRouteByPreference', () => {
   const c1: RouteCandidate = {
-    route: { type: 'direct', stops: 3 },
+    route: { type: 'direct', stops: 3, line: '2' },
     totalStops: 3,
     transferCount: 0,
     travelMinutes: 6,
@@ -695,7 +695,7 @@ describe('findRouteCandidatesByCategory', () => {
 
 describe('ROUTE_CATEGORIES comparators', () => {
   const makeCandidate = (transferCount: number, travelMinutes: number): RouteCandidate => ({
-    route: { type: 'direct', stops: Math.max(0, Math.floor(travelMinutes / 2)) },
+    route: { type: 'direct', stops: Math.max(0, Math.floor(travelMinutes / 2)), line: '2' },
     totalStops: Math.max(0, Math.floor(travelMinutes / 2)),
     transferCount,
     travelMinutes,
@@ -759,7 +759,7 @@ describe('updateRouteFromPosition', () => {
     it('현재 역에서 목적지까지 남은 정거장 수로 업데이트한다', () => {
       // 1호선: 소요산(1-001) → 보산(1-003): 2 stops
       // 현재 동두천(1-002)에 있으면 보산까지 1 stop
-      const storedRoute: DirectRoute = { type: 'direct', stops: 2 };
+      const storedRoute: DirectRoute = { type: 'direct', stops: 2, line: '1' };
       const nearestStation = getStationsOnLine('1').find((s) => s.id === '1-002')!;
       const result = updateRouteFromPosition(storedRoute, nearestStation, '1-003');
       expect(result).not.toBeNull();
@@ -770,7 +770,7 @@ describe('updateRouteFromPosition', () => {
     });
 
     it('현재 역과 목적지가 다른 노선이면 null을 반환한다', () => {
-      const storedRoute: DirectRoute = { type: 'direct', stops: 3 };
+      const storedRoute: DirectRoute = { type: 'direct', stops: 3, line: '1' };
       // 2호선 강남, 목적지는 1호선 시청
       const gangnam2 = getStationsOnLine('2').find((s) => s.name === '강남')!;
       const result = updateRouteFromPosition(storedRoute, gangnam2, '1-033');
@@ -778,7 +778,7 @@ describe('updateRouteFromPosition', () => {
     });
 
     it('같은 노선이지만 nearestStation ID가 유효하지 않으면 null을 반환한다', () => {
-      const storedRoute: DirectRoute = { type: 'direct', stops: 2 };
+      const storedRoute: DirectRoute = { type: 'direct', stops: 2, line: '1' };
       const fakeStation = { id: 'invalid-id', name: '가짜역', line: '1' as const, lineColor: '#00288C', lat: 0, lng: 0 };
       const result = updateRouteFromPosition(storedRoute, fakeStation, '1-003');
       expect(result).toBeNull();
@@ -1003,9 +1003,14 @@ describe('isStationOnRoute', () => {
     stopsAfterLastTransfer: 5,
   };
 
-  it('direct route는 항상 true (fromLine 정보 없어 검증 불가)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3 };
-    expect(isStationOnRoute(makeStation('4'), route)).toBe(true);
+  it('direct route — station.line이 route.line과 일치하면 true', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    expect(isStationOnRoute(makeStation('2'), route)).toBe(true);
+  });
+
+  it('direct route — station.line이 route.line과 다르면 false (#195 회귀 가드)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    expect(isStationOnRoute(makeStation('9'), route)).toBe(false);
   });
 
   it('transfer route — fromLine 일치 시 true', () => {

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -12,7 +12,7 @@ const allStations = stations as Station[];
 const stationById = new Map<string, Station>(allStations.map((s) => [s.id, s]));
 const lineStationsCache = new Map<string, Station[]>();
 
-function getLineStationsCached(line: string): Station[] {
+function getLineStationsCached(line: LineNumber): Station[] {
   let cached = lineStationsCache.get(line);
   if (!cached) {
     cached = allStations.filter((s) => s.line === line).sort((a, b) => a.id.localeCompare(b.id));
@@ -24,7 +24,7 @@ function getLineStationsCached(line: string): Station[] {
 // 노선별 name→index 캐시 (성능 최적화: buildNameIndex 중복 호출 제거)
 const lineNameIndexCache = new Map<string, Map<string, number>>();
 
-function getLineNameIndexCached(line: string): Map<string, number> {
+function getLineNameIndexCached(line: LineNumber): Map<string, number> {
   let cached = lineNameIndexCache.get(line);
   if (!cached) {
     cached = buildNameIndex(getLineStationsCached(line));
@@ -36,21 +36,22 @@ function getLineNameIndexCached(line: string): Map<string, number> {
 export interface DirectRoute {
   type: 'direct';
   stops: number;
+  line: LineNumber;
 }
 
 export interface TransferRoute {
   type: 'transfer';
   transferName: string;
-  fromLine: string;
-  toLine: string;
+  fromLine: LineNumber;
+  toLine: LineNumber;
   stopsToTransfer: number;
   stopsFromTransfer: number;
 }
 
 export interface TransferSegment {
   transferName: string;
-  fromLine: string;
-  toLine: string;
+  fromLine: LineNumber;
+  toLine: LineNumber;
   stopsToTransfer: number;
 }
 
@@ -98,7 +99,7 @@ export const ROUTE_CATEGORIES: readonly RouteCategory[] = [
 ];
 
 export interface JourneySegment {
-  line: string;
+  line: LineNumber;
   lineColor: string;
   fromName: string;
   toName: string;
@@ -111,10 +112,10 @@ export interface JourneyDisplay {
 }
 
 // 환승 그래프: fromLine → toLine → 환승역 이름 목록
-const transferGraph = new Map<string, Map<string, string[]>>();
+const transferGraph = new Map<LineNumber, Map<LineNumber, string[]>>();
 
 function buildTransferGraph(): void {
-  const nameToLines = new Map<string, Set<string>>();
+  const nameToLines = new Map<string, Set<LineNumber>>();
   for (const s of allStations) {
     let lines = nameToLines.get(s.name);
     if (!lines) {
@@ -148,11 +149,11 @@ function buildTransferGraph(): void {
 
 buildTransferGraph();
 
-export function getStationsOnLine(line: string): Station[] {
+export function getStationsOnLine(line: LineNumber): Station[] {
   return getLineStationsCached(line);
 }
 
-export function findStationByNameAndLine(name: string, line: string): Station | undefined {
+export function findStationByNameAndLine(name: string, line: LineNumber): Station | undefined {
   return getLineStationsCached(line).find((s) => s.name === name);
 }
 
@@ -166,7 +167,10 @@ export function updateRouteFromPosition(
     const dest = stationById.get(destinationId);
     if (!dest || nearestStation.line !== dest.line) return null;
     const remaining = getRemainingStops(nearestStation.id, destinationId);
-    return remaining !== null ? { type: 'direct', stops: remaining } : null;
+    // dest.line을 채택해 stored가 invariant를 깨고 들어와도 자가 치유되도록 한다.
+    return remaining !== null
+      ? { type: 'direct', stops: remaining, line: dest.line }
+      : null;
   }
 
   if (storedRoute.type === 'transfer') {
@@ -216,13 +220,13 @@ export function updateRouteFromPosition(
 
 export function isStationOnRoute(station: Station, route: NonNullable<Route>): boolean {
   if (route.type === 'direct') {
-    // direct는 fromLine 정보가 없어서 노선 검증이 불가능 — 통과
-    return true;
+    return station.line === route.line;
   }
   if (route.type === 'transfer') {
     return station.line === route.fromLine || station.line === route.toLine;
   }
-  // multi-transfer
+  // multi-transfer: transfers[i].toLine === transfers[i+1].fromLine 이므로
+  // fromLine+toLine 합집합 검사로 중간 노선까지 누락 없이 모두 커버한다.
   for (const t of route.transfers) {
     if (station.line === t.fromLine || station.line === t.toLine) return true;
   }
@@ -280,7 +284,7 @@ export function findRoutes(currentId: string, destinationId: string): RouteCandi
     const lineStations = getLineStationsCached(current.line);
     const cIdx = lineStations.findIndex((s) => s.id === currentId);
     const dIdx = lineStations.findIndex((s) => s.id === destinationId);
-    const direct: DirectRoute = { type: 'direct', stops: Math.abs(dIdx - cIdx) };
+    const direct: DirectRoute = { type: 'direct', stops: Math.abs(dIdx - cIdx), line: current.line };
     const duration = performance.now() - start;
     logger.debug(`findRoutes(${currentId} → ${destinationId}): ${duration.toFixed(2)}ms`);
     return [toCandidate(direct)];
@@ -470,14 +474,14 @@ export function buildJourneyDisplay(
       segments: [
         {
           line: route.fromLine,
-          lineColor: LINE_COLORS[route.fromLine as LineNumber] ?? current.lineColor,
+          lineColor: LINE_COLORS[route.fromLine] ?? current.lineColor,
           fromName: current.name,
           toName: route.transferName,
           stops: route.stopsToTransfer,
         },
         {
           line: route.toLine,
-          lineColor: LINE_COLORS[route.toLine as LineNumber] ?? destination.lineColor,
+          lineColor: LINE_COLORS[route.toLine] ?? destination.lineColor,
           fromName: route.transferName,
           toName: destination.name,
           stops: route.stopsFromTransfer,
@@ -494,7 +498,7 @@ export function buildJourneyDisplay(
     const fallbackColor = i === 0 ? current.lineColor : '#888888';
     return {
       line: t.fromLine,
-      lineColor: LINE_COLORS[t.fromLine as LineNumber] ?? fallbackColor,
+      lineColor: LINE_COLORS[t.fromLine] ?? fallbackColor,
       fromName: prevName,
       toName: t.transferName,
       stops: t.stopsToTransfer,
@@ -503,7 +507,7 @@ export function buildJourneyDisplay(
   const lastTransfer = transfers[transfers.length - 1];
   segments.push({
     line: lastTransfer.toLine,
-    lineColor: LINE_COLORS[lastTransfer.toLine as LineNumber] ?? destination.lineColor,
+    lineColor: LINE_COLORS[lastTransfer.toLine] ?? destination.lineColor,
     fromName: lastTransfer.transferName,
     toName: destination.name,
     stops: route.stopsAfterLastTransfer,
@@ -540,7 +544,7 @@ export function calculateETA(nextTrainMinutes: number, route: Route): number {
 }
 
 function getNextStationOnLine(
-  line: string,
+  line: LineNumber,
   currentName: string,
   targetName: string,
 ): string | null {


### PR DESCRIPTION
## 배경

PR #196에서 GPS 신뢰성 게이트로 false 통과 알림 대부분을 차단했지만, `DirectRoute`에 노선 정보가 없어 `isStationOnRoute(station, direct)`가 항상 `true`를 반환하는 잔존 위험이 있었음.

### 시나리오

1. 2호선 강남 → 2호선 잠실 direct 경로 설정
2. GPS가 잠시 인접 9호선 한성백제를 최근접으로 잡음
3. 거리 게이트(1km) 통과 → `isStationOnRoute(direct)` 무조건 true → 9호선 역 통과 알림 발송

## 변경

### 핵심 — `isStationOnRoute(direct)` 노선 검증

- `DirectRoute`에 `line: LineNumber` 필드 추가
- `findRoutes`에서 direct 생성 시 `current.line`으로 채움
- `updateRouteFromPosition` direct 분기는 `dest.line`을 채택해 stored가 invariant를 깨고 들어와도 자가 치유
- `isStationOnRoute(direct)`: `station.line === route.line` 검증

### 부수 정리 — 노선 타입 일관성 (LineNumber로 통일)

`DirectRoute.line`만 좁히면 절반의 픽스이므로 같은 PR에서 마무리:
- `TransferRoute.fromLine/toLine`, `TransferSegment.fromLine/toLine`, `JourneySegment.line`: `string` → `LineNumber`
- 내부 헬퍼 시그니처 (`getLineStationsCached`, `getLineNameIndexCached`, `getStationsOnLine`, `findStationByNameAndLine`, `getNextStationOnLine`): `LineNumber`로 좁힘
- `transferGraph: Map<LineNumber, Map<LineNumber, string[]>>`, `nameToLines: Map<string, Set<LineNumber>>`
- `buildJourneyDisplay`의 `LINE_COLORS[... as LineNumber]` 단언 4건 제거

이제 `Station.line`/`DirectRoute.line`/`TransferRoute.from|toLine`/`JourneySegment.line` 사이 `string` 우회로가 없음.

### 회귀 가드

- **단위**: `isStationOnRoute` direct line 불일치 시 `false` (stationRoute.test.ts)
- **통합**: `useStationAlarm`에서 direct route + 경로 외 노선 nearestStation이면 알림 미발송 (#195 이슈 시나리오 미러링)
- 기존 transfer 회귀 가드와 같은 위치/형식

### 기타

- `isStationOnRoute` multi-transfer 분기에 의도 주석 추가 (`transfers[i].toLine === transfers[i+1].fromLine` invariant)
- `updateRouteFromPosition` direct에 `dest.line` 자가치유 의도 주석 추가

## 마이그레이션

`Route` 객체는 현재 AsyncStorage에 영속화되지 않음 (`useAppStore`는 `routePreference` 문자열만 저장). 따라서 본 PR은 마이그레이션 불필요. 향후 영속화 시점에 별도 가드 검토 (ADR 후속).

## 검증

- `npm run type-check` ✅
- `npm test` ✅ 53 suites / **749 passed** (+1 통합 회귀 가드) / 커버리지 100%
- `reviewer` 에이전트 ✅ 머지 가능 (P1/P2 모두 반영)

## Test plan

- [ ] CI Type Check & Test 통과
- [ ] 실기기: 2호선 강남→잠실 direct 경로 진행 중 GPS가 9호선 인접역을 잡아도 통과 알림 안 오는지
- [ ] 실기기: 정상 경로(같은 노선)에서는 매 역 통과 알림 정상 발송

Closes #195