### PR TITLE
fix(#249): GPS 게이트 임계값 조정 (정확도 200m / 신선도 15s)

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -1,3 +1,7 @@
-export const MAX_LOCATION_AGE_MS = 30_000;
-export const MAX_ACCURACY_M = 150;
+// 15s: 환승 알람은 역 통과 시점과 동기화돼야 하므로 오래된 좌표를 강하게 거부한다.
+// BG `timeInterval`(30s, locationTracking.ts)보다 짧다 — stationary 상태에서 OS가
+// 캐시된 fix를 넘기면 의도적으로 drop. "실시간성 우선, 나쁜 좌표 거부" 정책.
+export const MAX_LOCATION_AGE_MS = 15_000;
+// 200m: 지하역 GPS 자연 열화 수용. 역간 평균 거리(800m+) 대비 안전 마진 충분.
+export const MAX_ACCURACY_M = 200;
 export const MAX_STATION_DISTANCE_KM = 1.0;

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -3,6 +3,7 @@ import * as Location from 'expo-location';
 import { AppState } from 'react-native';
 import { useNearestStation } from '../useNearestStation';
 import * as findNearestStationModule from '../../utils/findNearestStation';
+import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
 
 jest.mock('expo-location');
 
@@ -428,9 +429,9 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('stale 캐시 위치(30초 초과)는 무시하고 watch만 시작한다', async () => {
+  it('stale 캐시 위치(MAX_LOCATION_AGE_MS 초과)는 무시하고 watch만 시작한다', async () => {
     mockGranted();
-    mockLastKnownLocation(37.4980, 127.0277, { ageMs: 60_000 });
+    mockLastKnownLocation(37.4980, 127.0277, { ageMs: MAX_LOCATION_AGE_MS + 1 });
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -440,9 +441,9 @@ describe('useNearestStation', () => {
     expect(result.current.result).toBeNull();
   });
 
-  it('저정확도 캐시 위치(150m 초과)는 무시한다', async () => {
+  it('저정확도 캐시 위치(MAX_ACCURACY_M 초과)는 무시한다', async () => {
     mockGranted();
-    mockLastKnownLocation(37.4980, 127.0277, { accuracy: 200 });
+    mockLastKnownLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -461,14 +462,14 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('watch 콜백 저정확도(150m 초과) 좌표는 setState하지 않는다', async () => {
+  it('watch 콜백 저정확도(MAX_ACCURACY_M 초과) 좌표는 setState하지 않는다', async () => {
     mockGranted();
 
     const { result } = renderHook(() => useNearestStation());
 
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
-    simulateGps(37.4980, 127.0277, { accuracy: 200 });
+    simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
 
     // 저정확도라 result 갱신 안 됨
     expect(result.current.result).toBeNull();
@@ -490,7 +491,7 @@ describe('useNearestStation', () => {
 
   it('refresh 시 저정확도 좌표는 setState하지 않는다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277, { accuracy: 200 });
+    mockLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
 
     const { result } = renderHook(() => useNearestStation());
 

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -47,6 +47,7 @@ import type { AlarmEvent } from '../../utils/stationAlarm';
 // 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
 import '../../tasks/backgroundLocationTask';
 import { BACKGROUND_LOCATION_TASK } from '../../tasks/backgroundLocationTask';
+import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
 
 // ── 픽스처 ──
 
@@ -426,8 +427,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
   };
 
-  it('stale 위치(timestamp 30초 초과)는 무시한다', async () => {
-    await runWithLocation(makeLocation(37.498, 127.028, { ageMs: 60_000 }));
+  it('stale 위치(timestamp MAX_LOCATION_AGE_MS 초과)는 무시한다', async () => {
+    await runWithLocation(makeLocation(37.498, 127.028, { ageMs: MAX_LOCATION_AGE_MS + 1 }));
     expectGateBlocked();
   });
 
@@ -448,16 +449,16 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     expectGateBlocked();
   });
 
-  it('저정확도 위치(accuracy 150m 초과)는 무시한다', async () => {
-    await runWithLocation(makeLocation(37.498, 127.028, { accuracy: 200 }));
+  it('저정확도 위치(accuracy MAX_ACCURACY_M 초과)는 무시한다', async () => {
+    await runWithLocation(makeLocation(37.498, 127.028, { accuracy: MAX_ACCURACY_M + 1 }));
     expectGateBlocked();
   });
 
-  it('accuracy가 임계값(150m) 이내면 통과한다', async () => {
+  it('accuracy가 임계값(MAX_ACCURACY_M) 이내면 통과한다', async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
     await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028, { accuracy: 100 })] },
+      data: { locations: [makeLocation(37.498, 127.028, { accuracy: MAX_ACCURACY_M - 50 })] },
       error: null,
     });
 

--- a/src/utils/__tests__/locationGates.test.ts
+++ b/src/utils/__tests__/locationGates.test.ts
@@ -1,0 +1,53 @@
+import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
+import { isAccuracyAcceptable, isLocationFresh } from '../locationGates';
+
+describe('isLocationFresh', () => {
+  const NOW = 1_700_000_000_000;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(NOW));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('timestamp가 undefined면 false', () => {
+    expect(isLocationFresh(undefined)).toBe(false);
+  });
+
+  it('현재 시각이면 true', () => {
+    expect(isLocationFresh(NOW)).toBe(true);
+  });
+
+  it('임계값과 정확히 같은 age면 true (경계 포함)', () => {
+    expect(isLocationFresh(NOW - MAX_LOCATION_AGE_MS)).toBe(true);
+  });
+
+  it('임계값을 1ms 초과하면 false', () => {
+    expect(isLocationFresh(NOW - MAX_LOCATION_AGE_MS - 1)).toBe(false);
+  });
+});
+
+describe('isAccuracyAcceptable', () => {
+  it('null이면 true (accuracy 정보 없음 = 통과)', () => {
+    expect(isAccuracyAcceptable(null)).toBe(true);
+  });
+
+  it('undefined면 true', () => {
+    expect(isAccuracyAcceptable(undefined)).toBe(true);
+  });
+
+  it('임계값과 정확히 같으면 true (경계 포함)', () => {
+    expect(isAccuracyAcceptable(MAX_ACCURACY_M)).toBe(true);
+  });
+
+  it('임계값보다 작으면 true', () => {
+    expect(isAccuracyAcceptable(MAX_ACCURACY_M - 1)).toBe(true);
+  });
+
+  it('임계값을 초과하면 false', () => {
+    expect(isAccuracyAcceptable(MAX_ACCURACY_M + 1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
백그라운드 알림 신뢰성 4-issue 큐의 3번 항목. 지하철 도메인 특성을 반영해 GPS 게이트 임계값을 비대칭 조정.

| 상수 | 변경 | 방향 | 근거 |
|---|---|---|---|
| `MAX_ACCURACY_M` | 150 → 200 | 완화 | 깊은 지하역(강남/종로3가 등)에서 GPS accuracy가 150m을 초과해 모든 좌표가 거부되던 케이스 수용. 역간 평균 거리(800m+) 대비 200m는 안전. |
| `MAX_LOCATION_AGE_MS` | 30_000 → 15_000 | 강화 | 환승 알람은 역 통과 시점과 동기화돼야 함 — 30초 전 좌표를 허용하면 이미 다음 역으로 넘어간 뒤 알람이 갈 수 있음. "실시간성 우선, 나쁜 좌표 거부" 정책 일관. |

## 변경 내역
- `src/constants/location.ts` — 임계값 조정 + 결정 근거 주석 추가 (BG `timeInterval`(30s)과의 의도적 비대칭 명시)
- `src/utils/__tests__/locationGates.test.ts` (신규) — `isLocationFresh`, `isAccuracyAcceptable` 단위 테스트 추가 (경계값/null 처리 100% 커버, 기존엔 통합 경로로만 간접 검증)
- 기존 테스트(`useNearestStation`, `backgroundLocationTask`) — 하드코딩 임계값을 상수 참조로 일반화 → 차후 조정 시 테스트 수정 불필요

## BG `timeInterval`(30s)과의 관계
신선도 15s < BG timeInterval 30s 인 비대칭은 의도적입니다. stationary 상태에서 OS가 캐시된 fix를 30s 가까이 묵혀서 넘기면 의도적으로 drop — 정지 중인 사용자에게는 알람이 발사되지 않는 게 정답이고, 이동 중이라면 GPS는 통상 콜백 직전에 갱신되어 fix age는 5초 이내입니다. 사용자 정의 "실시간성 우선" 정책과 일관.

## 큐 진행 상태
- ✅ #242 알림 상태 단일화
- ✅ #244 위치 추적 옵션 상수화
- ✅ **이 PR** #249 GPS 게이트 임계값 조정
- 🔲 FG↔BG 통합 테스트

## Test plan
- [x] `npm test` — 762 tests pass, 100% coverage (lines/functions/branches/statements)
- [x] `npm run type-check` pass
- [x] CI `Type Check & Test` 통과 확인
- [ ] BG/FG 동작 회귀 — 다음 큐 4번에서 통합 테스트로 보강

Closes #249