### PR TITLE
test(#251): FG↔BG 전환 시나리오 통합 테스트 추가

### DIFF
--- a/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -1,0 +1,290 @@
+/**
+ * FG↔BG 전환 시나리오 통합 테스트.
+ *
+ * 단위 테스트(stationPipeline / backgroundLocationTask / notificationState)는 각자
+ * 자기 모듈만 보지만, 큐 #242/#244/#249에서 도입된 정책 — 단일 출처 dedup, 게이트
+ * 비대칭(BG timeInterval 30s × MAX_LOCATION_AGE_MS 15s, MAX_ACCURACY_M 200m) — 은
+ * 모듈 간 **결합**에서 의미를 가진다. 이 테스트는 다음 모듈들을 실제로 함께
+ * 돌려서 그 결합 자체를 회귀 가드한다.
+ *
+ *   - `notificationState`     (실제)
+ *   - `locationGates`         (실제)
+ *   - `stationPipeline`       (실제)
+ *   - `backgroundLocationTask`(실제 defineTask 콜백)
+ *   - `stationAlarm`          (실제 evaluateAlarmPhase / alarmKey)
+ *
+ * 외부 boundary만 mock:
+ *   - AsyncStorage → 인메모리 Map (FG/BG가 같은 저장소 공유)
+ *   - findNearestStation / stationRoute / stationNotification → 결정적 fake
+ */
+
+// ── AsyncStorage: FG/BG 단일 출처 검증을 위해 인메모리 Map으로 구현 ──
+const mockStorage = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(mockStorage.get(key) ?? null)),
+  setItem: jest.fn((key: string, value: string) => {
+    mockStorage.set(key, value);
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((key: string) => {
+    mockStorage.delete(key);
+    return Promise.resolve();
+  }),
+}));
+
+// ── TaskManager: BG task 콜백 캡처 ──
+jest.mock('expo-task-manager', () => ({
+  defineTask: (name: string, callback: Function) => {
+    (global as any).__bgTaskCallback = callback;
+    (global as any).__bgTaskName = name;
+  },
+}));
+
+jest.mock('expo-location', () => ({}));
+
+// ── 외부 boundary fake: 결정적 동작 ──
+const fakeStation = {
+  id: 'station-1',
+  name: '강남',
+  line: '2' as const,
+  lineColor: '#009246',
+  lat: 37.498,
+  lng: 127.028,
+};
+const fakeNextStation = {
+  id: 'station-2',
+  name: '역삼',
+  line: '2' as const,
+  lineColor: '#009246',
+  lat: 37.5,
+  lng: 127.04,
+};
+const fakeDestination = {
+  id: 'station-9',
+  name: '시청',
+  line: '1' as const,
+  lineColor: '#0052A4',
+  lat: 37.565,
+  lng: 126.977,
+};
+
+const mockFindNearestStation = jest.fn();
+jest.mock('../../utils/findNearestStation', () => ({
+  findNearestStation: (...args: unknown[]) => mockFindNearestStation(...args),
+}));
+
+const mockFindRoute = jest.fn();
+jest.mock('../../utils/stationRoute', () => ({
+  findRoute: (...args: unknown[]) => mockFindRoute(...args),
+  calculateStaticETA: jest.fn(() => 10),
+  updateRouteFromPosition: jest.fn(() => null),
+  isStationOnRoute: jest.fn(() => true),
+}));
+
+const mockSendAlarmNotification = jest.fn((..._args: unknown[]) => Promise.resolve());
+const mockSendStationPassedNotification = jest.fn((..._args: unknown[]) => Promise.resolve());
+const mockUpdateStationNotification = jest.fn((..._args: unknown[]) => Promise.resolve());
+jest.mock('../../utils/stationNotification', () => ({
+  sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
+  sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
+  updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+// ── 모듈 import (defineTask 실행 시점) ──
+import '../../tasks/backgroundLocationTask';
+import { processLocationUpdate } from '../../utils/stationPipeline';
+import { alarmKey } from '../../utils/stationAlarm';
+import {
+  DESTINATION_KEY,
+  LAST_NOTIFIED_STATION_KEY,
+  FIRED_ALARMS_KEY,
+} from '../../constants/storageKeys';
+import { MAX_LOCATION_AGE_MS, MAX_ACCURACY_M } from '../../constants/location';
+
+// ── 테스트 버퍼 상수: 임계값 안쪽/바깥쪽임을 이름으로 드러낸다 ──
+const FRESH_MARGIN_MS = 1_000;
+const STALE_MARGIN_MS = 5_000;
+const NEAR_STATION_KM = 0.05;
+const ACCURATE_MARGIN_M = 50;
+
+type TaskCtx = { data: unknown; error: { message: string } | null };
+type TaskCallback = (ctx: TaskCtx) => Promise<void>;
+const bgTask = (): TaskCallback => (global as any).__bgTaskCallback as TaskCallback;
+
+interface BgRunOptions {
+  ageMs?: number;
+  accuracy?: number | null;
+}
+
+async function runFgPipelineAt(station: typeof fakeStation) {
+  mockFindNearestStation.mockReturnValueOnce({ station, distanceKm: NEAR_STATION_KM });
+  const firedJson = mockStorage.get(FIRED_ALARMS_KEY);
+  const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
+  const result = await processLocationUpdate({
+    lat: station.lat,
+    lng: station.lng,
+    destination: fakeDestination,
+    firedAlarms,
+    sleepMode: false,
+  });
+  // FG의 useStationAlarm 훅이 알람 발사 후 FIRED_ALARMS_KEY를 갱신하는 동작을 시뮬레이션.
+  // 이 round-trip이 BG와의 dedup 단일 출처가 된다.
+  if (result.alarmEvent) {
+    firedAlarms.add(alarmKey(result.alarmEvent));
+    mockStorage.set(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms]));
+  }
+  return result;
+}
+
+async function runBgTaskAt(station: typeof fakeStation, opts: BgRunOptions = {}) {
+  mockFindNearestStation.mockReturnValueOnce({ station, distanceKm: NEAR_STATION_KM });
+  return bgTask()({
+    data: {
+      locations: [
+        {
+          coords: {
+            latitude: station.lat,
+            longitude: station.lng,
+            altitude: null,
+            accuracy: opts.accuracy ?? null,
+            altitudeAccuracy: null,
+            heading: null,
+            speed: null,
+          },
+          timestamp: Date.now() - (opts.ageMs ?? 0),
+        },
+      ],
+    },
+    error: null,
+  });
+}
+
+beforeEach(() => {
+  mockStorage.clear();
+  mockFindNearestStation.mockReset();
+  mockFindRoute.mockReset();
+  // 기본: 'early' phase가 트리거되지 않는 multi-stop direct route — 알림 발사만 검증
+  mockFindRoute.mockReturnValue({ type: 'direct', stops: 3, line: '2' });
+  mockSendStationPassedNotification.mockClear();
+  mockSendAlarmNotification.mockClear();
+  mockUpdateStationNotification.mockClear();
+});
+
+describe('FG↔BG 통합: 알림 dedup (notificationState 단일 출처)', () => {
+  beforeEach(() => {
+    mockStorage.set(DESTINATION_KEY, JSON.stringify(fakeDestination));
+  });
+
+  it('FG에서 알림 발사 후 BG가 같은 역 받으면 중복 발사하지 않는다', async () => {
+    await runFgPipelineAt(fakeStation);
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeStation.id);
+
+    await runBgTaskAt(fakeStation);
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('BG에서 알림 발사 후 FG가 같은 역 받으면 중복 발사하지 않는다', async () => {
+    await runBgTaskAt(fakeStation);
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeStation.id);
+
+    await runFgPipelineAt(fakeStation);
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('FG 알림 후 다른 역으로 진입하면 FG/BG 어디서 받든 새 알림이 발사된다', async () => {
+    await runFgPipelineAt(fakeStation);
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+
+    await runBgTaskAt(fakeNextStation);
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeNextStation.id);
+  });
+
+  it('AsyncStorage가 비어 있는 cold start(swipe-kill 직후)에는 BG 첫 콜백이 알림을 발사한다', async () => {
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBeUndefined();
+
+    await runBgTaskAt(fakeStation);
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeStation.id);
+  });
+});
+
+describe('FG↔BG 통합: 알람 dedup (FIRED_ALARMS_KEY 단일 출처)', () => {
+  beforeEach(() => {
+    mockStorage.set(DESTINATION_KEY, JSON.stringify(fakeDestination));
+    // 'early' phase 트리거: 도착역까지 1 정거장 (APPROACH_STOPS=1)
+    mockFindRoute.mockReturnValue({ type: 'direct', stops: 1, line: '2' });
+  });
+
+  it('FG에서 알람 발사 후 BG가 같은 phase 조건을 받으면 evaluateAlarmPhase가 dedup한다', async () => {
+    await runFgPipelineAt(fakeStation);
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    expect(mockStorage.get(FIRED_ALARMS_KEY)).toBeDefined();
+
+    await runBgTaskAt(fakeStation);
+
+    // BG가 FIRED_ALARMS_KEY를 읽어 firedAlarms Set으로 만들고,
+    // evaluateAlarmPhase가 동일 키를 보고 null 반환 → sendAlarmNotification 무호출.
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('BG에서 알람 발사 후 FG가 같은 phase 조건을 받으면 dedup된다', async () => {
+    await runBgTaskAt(fakeStation);
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    const firedJson = mockStorage.get(FIRED_ALARMS_KEY);
+    expect(firedJson).toBeDefined();
+
+    await runFgPipelineAt(fakeStation);
+
+    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FG↔BG 통합: 게이트 비대칭 (BG timeInterval 30s × age 15s, accuracy 200m)', () => {
+  beforeEach(() => {
+    mockStorage.set(DESTINATION_KEY, JSON.stringify(fakeDestination));
+  });
+
+  it('age < MAX_LOCATION_AGE_MS인 신선한 좌표는 BG 게이트를 통과해 알림으로 이어진다', async () => {
+    await runBgTaskAt(fakeStation, { ageMs: MAX_LOCATION_AGE_MS - FRESH_MARGIN_MS });
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('age > MAX_LOCATION_AGE_MS인 stale 좌표(BG timeInterval 30s로 인한 캐시 fix)는 게이트가 drop한다', async () => {
+    await runBgTaskAt(fakeStation, { ageMs: MAX_LOCATION_AGE_MS + STALE_MARGIN_MS });
+
+    expect(mockFindNearestStation).not.toHaveBeenCalled();
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBeUndefined();
+  });
+
+  it('accuracy <= MAX_ACCURACY_M인 좌표는 BG 게이트를 통과한다', async () => {
+    await runBgTaskAt(fakeStation, { accuracy: MAX_ACCURACY_M - ACCURATE_MARGIN_M });
+
+    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('accuracy > MAX_ACCURACY_M인 저정확도 좌표는 BG 게이트가 drop한다', async () => {
+    await runBgTaskAt(fakeStation, { accuracy: MAX_ACCURACY_M + ACCURATE_MARGIN_M });
+
+    expect(mockFindNearestStation).not.toHaveBeenCalled();
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
백그라운드 알림 신뢰성 4-issue 큐의 **마지막(4번)** 항목. 큐 #242/#244/#249에서 도입된 정책들이 모듈 단위 테스트로는 잡히지 않는 **결합 회귀**를 일으키지 않도록 통합 테스트 1개 파일을 추가합니다.

src 코드 무수정. 테스트 파일 1개 추가만.

## 큐 진행 상태
| # | 이슈 | 상태 |
|---|---|---|
| 1 | #242 알림 상태 단일 출처 | ✅ |
| 2 | #244 위치 추적 옵션 상수화 | ✅ |
| 3 | #249 GPS 게이트 임계값 조정 | ✅ |
| 4 | **이 PR** FG↔BG 통합 테스트 | 🟡 |

## 테스트 구조
실제 모듈 결합을 통과시키고 boundary만 mock:

| 실제 사용 | Mock |
|---|---|
| `notificationState` (AsyncStorage round-trip) | `findNearestStation` (역 그래프 의존성 차단) |
| `locationGates` (age/accuracy 게이트) | `stationRoute` (528개 역 그래프 차단) |
| `stationPipeline` | `stationNotification` (네이티브 의존 차단) |
| `stationAlarm` (실제 `evaluateAlarmPhase`/`alarmKey`) | `expo-task-manager`/`expo-location` |
| `backgroundLocationTask` (실제 defineTask 콜백) | |

AsyncStorage는 **인메모리 Map**으로 FG/BG가 같은 키 공간을 공유. 이것이 단일 출처 dedup의 본질이라 mock 단순 함수가 아니라 의도적으로 Map.

## 시나리오 (3 describe × 10 tests)

### 1. 알림 dedup (`notificationState` 단일 출처)
- FG 발사 후 BG 동일 역 → 중복 없음
- BG 발사 후 FG 동일 역 → 중복 없음
- 다른 역 진입 시 새 알림 발사
- Cold start(swipe-kill 직후) → 첫 BG 콜백이 정상 발사

### 2. 알람 dedup (`FIRED_ALARMS_KEY` 단일 출처)
- FG에서 'early' phase 알람 발사 → `FIRED_ALARMS_KEY` 갱신 → BG가 같은 phase 조건 받으면 `evaluateAlarmPhase`가 set 보고 null 반환
- BG → FG 역방향도 동일

### 3. 게이트 비대칭 (BG `timeInterval` 30s × age 15s × accuracy 200m)
- 신선한 좌표(age < 15s) 통과
- Stale 좌표(age > 15s, OS 캐시 fix) drop — `LAST_NOTIFIED_STATION_KEY` 미설정까지 단언
- 정확도 게이트 양방향 (< 200m 통과, > 200m drop)

## 회귀 가드 검증 (개념적)
- 큐 #242 회귀(notificationState를 모듈-로컬 변수로 되돌리기) → FG↔BG dedup 테스트 실패
- 큐 #244/#249 회귀(`MAX_LOCATION_AGE_MS`를 BG `timeInterval`보다 크게) → stale drop 테스트 실패
- `MAX_ACCURACY_M` 게이트 제거 → accuracy drop 테스트 실패

## 후속 (큐 종료 이후)
- 목적지 변경 시 `LAST_NOTIFIED_STATION_KEY` 리셋 정책 가드는 별도 이슈로 분리(리뷰 P2-4)
- 큐 메모리 파일 정리 후 다음 트랙(알람 정확도 로드맵 B2)으로 전환

## Test plan
- [x] `npm test` — 787 tests pass, 100% coverage
- [x] `npm run type-check` pass
- [x] code-review 에이전트 통과 (P1 없음, P2 핵심 3건 반영)
- [ ] CI `Type Check & Test` pass 확인

Closes #251