### PR TITLE
feat(#252): 지도 마커/여정 타임라인 다국어 역명 표시 보완

### DIFF
--- a/src/components/JourneyTimeline.tsx
+++ b/src/components/JourneyTimeline.tsx
@@ -1,16 +1,22 @@
 import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { LINE_NAMES } from '../constants/lineColors';
 import type { JourneyDisplay } from '../utils/stationRoute';
-import type { LineNumber } from '../types/station';
+import type { LineNumber, Station } from '../types/station';
 import { useTheme, typography, spacing, radius } from '../theme';
+import { getStationDisplayNameByName } from '../utils/stationDisplay';
+import stationsData from '../data/stations.json';
 
 interface JourneyTimelineProps {
   journey: JourneyDisplay;
 }
 
+const STATIONS = stationsData as Station[];
+
 export function JourneyTimeline({ journey }: JourneyTimelineProps) {
   const { segments } = journey;
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   return (
     <View style={styles.container}>
@@ -24,7 +30,7 @@ export function JourneyTimeline({ journey }: JourneyTimelineProps) {
             {isFirst && (
               <View style={styles.stationRow}>
                 <View style={[styles.dot, { backgroundColor: segment.lineColor }]} testID="start-dot" />
-                <Text style={[styles.stationName, { color: colors.ink }]}>{segment.fromName}</Text>
+                <Text style={[styles.stationName, { color: colors.ink }]}>{getStationDisplayNameByName(segment.fromName, STATIONS)}</Text>
               </View>
             )}
 
@@ -34,21 +40,21 @@ export function JourneyTimeline({ journey }: JourneyTimelineProps) {
                 <View style={[styles.lineBadge, { backgroundColor: segment.lineColor }]}>
                   <Text style={styles.lineBadgeText}>{lineName}</Text>
                 </View>
-                <Text style={[styles.stopsText, { color: colors.muted }]}>{segment.stops}정거장</Text>
+                <Text style={[styles.stopsText, { color: colors.muted }]}>{t('route.stops', { count: segment.stops })}</Text>
               </View>
             </View>
 
             {!isLast && (
               <View style={styles.stationRow}>
                 <Text style={[styles.transferIcon, { color: colors.accent }]}>⇄</Text>
-                <Text style={[styles.transferName, { color: colors.accent }]}>{segment.toName}</Text>
+                <Text style={[styles.transferName, { color: colors.accent }]}>{getStationDisplayNameByName(segment.toName, STATIONS)}</Text>
               </View>
             )}
 
             {isLast && (
               <View style={styles.stationRow}>
                 <View style={[styles.dot, { backgroundColor: segment.lineColor }]} testID="end-dot" />
-                <Text style={[styles.stationName, { color: colors.ink }]}>{segment.toName}</Text>
+                <Text style={[styles.stationName, { color: colors.ink }]}>{getStationDisplayNameByName(segment.toName, STATIONS)}</Text>
               </View>
             )}
           </View>

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import ClusteredMapView from 'react-native-map-clustering';
 import { Marker, PROVIDER_DEFAULT } from 'react-native-maps';
 import type { Station } from '../types/station';
@@ -26,6 +27,7 @@ export function StationMap({
   onStationPress,
 }: StationMapProps) {
   const { colors } = useTheme();
+  const { i18n } = useTranslation();
   const [mapReady, setMapReady] = useState(false);
 
   const mapConfig = useMemo(
@@ -54,7 +56,7 @@ export function StationMap({
           const dotColor = isHighlighted ? colors.accent : station.lineColor;
           return (
             <Marker
-              key={station.id}
+              key={`${station.id}-${i18n.language}`}
               coordinate={{ latitude: station.lat, longitude: station.lng }}
               title={getStationDisplayName(station)}
               description={LINE_NAMES[station.line]}

--- a/src/components/__tests__/JourneyTimeline.test.tsx
+++ b/src/components/__tests__/JourneyTimeline.test.tsx
@@ -3,6 +3,9 @@ import { render } from '@testing-library/react-native';
 import { JourneyTimeline } from '../JourneyTimeline';
 import type { JourneyDisplay } from '../../utils/stationRoute';
 import type { LineNumber } from '../../types/station';
+import { installLanguageRestoreHook, setLang } from '../../testUtils/i18nLanguageOverride';
+
+installLanguageRestoreHook();
 
 const directJourney: JourneyDisplay = {
   segments: [
@@ -81,6 +84,35 @@ describe('JourneyTimeline', () => {
     expect(endDot.props.style).toEqual(
       expect.arrayContaining([expect.objectContaining({ backgroundColor: '#EF7C1C' })]),
     );
+  });
+
+  it('영어 모드에서 환승 여정 역명이 nameEn으로 표시된다', () => {
+    setLang('en');
+    const { getByText } = render(<JourneyTimeline journey={transferJourney} />);
+    expect(getByText('Gangnam')).toBeTruthy();
+    expect(getByText('Seoul Nat`l Univ. of Education')).toBeTruthy();
+    expect(getByText('Gyeongbokgung')).toBeTruthy();
+    expect(getByText('1 stop')).toBeTruthy();
+    expect(getByText('5 stops')).toBeTruthy();
+  });
+
+  it('영어 모드 + stations에 없는 역명은 원본 그대로 표시한다', () => {
+    setLang('en');
+    const unknownStationJourney: JourneyDisplay = {
+      segments: [
+        {
+          line: '2',
+          lineColor: '#009D3E',
+          fromName: '없는역A',
+          toName: '없는역B',
+          stops: 1,
+        },
+      ],
+      totalStops: 1,
+    };
+    const { getByText } = render(<JourneyTimeline journey={unknownStationJourney} />);
+    expect(getByText('없는역A')).toBeTruthy();
+    expect(getByText('없는역B')).toBeTruthy();
   });
 
   it('알 수 없는 노선이면 line 값을 그대로 표시한다', () => {

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { render, act, waitFor, fireEvent } from '@testing-library/react-native';
 import { StationMap } from '../StationMap';
 import type { Station } from '../../types/station';
+import { installLanguageRestoreHook, setLang } from '../../testUtils/i18nLanguageOverride';
+
+installLanguageRestoreHook();
 
 const mockStation: Station = {
   id: '2-022',
   name: '강남',
+  nameEn: 'Gangnam',
   line: '2',
   lineColor: '#009D3E',
   lat: 37.4979,
@@ -15,6 +19,7 @@ const mockStation: Station = {
 const anotherStation: Station = {
   id: '2-023',
   name: '선릉',
+  nameEn: 'Seolleung',
   line: '2',
   lineColor: '#009D3E',
   lat: 37.5044,
@@ -109,6 +114,19 @@ describe('StationMap', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
     expect(getByTestId('marker-2-022').props.tracksViewChanges).toBe(false);
     expect(getByTestId('marker-2-023').props.tracksViewChanges).toBe(false);
+  });
+
+  it('영어 모드에서 마커 라벨이 nameEn으로 표시된다', () => {
+    setLang('en');
+    const { getByText } = render(<StationMap {...baseProps} />);
+    expect(getByText('Gangnam')).toBeTruthy();
+    expect(getByText('Seolleung')).toBeTruthy();
+  });
+
+  it('영어 모드에서 마커 title이 nameEn으로 설정된다', () => {
+    setLang('en');
+    const { getByTestId } = render(<StationMap {...baseProps} />);
+    expect(getByTestId('marker-2-022').props.title).toBe('Gangnam');
   });
 
   it('buildMapConfig에 올바른 파라미터를 전달한다', () => {


### PR DESCRIPTION
## Summary

- 지도 마커 라벨/콜아웃이 언어 전환 시 즉시 갱신되도록 Marker key에 `i18n.language` 포함 (tracksViewChanges={false} 캐싱 우회)
- JourneyTimeline의 raw 한글 역명을 `getStationDisplayNameByName`으로 다국어화
- `{stops}정거장` 하드코딩을 `t('route.stops', { count })` i18n 키로 교체

## 범위 제외

기저 지도 타일 라벨(도로/POI)은 react-native-maps `PROVIDER_DEFAULT`가 OS 언어를 따르는 구조라 이번 범위 밖. 별도 이슈로 분리 (네이티브 빌드/앱 버전 업 필요).

## Test plan

- [x] `npm test` — 783 통과, 커버리지 100%
- [x] `npm run type-check` — 통과
- [x] code-reviewer 에이전트 통과 (blocking 이슈 없음)
- [ ] 시뮬레이터에서 Settings 언어 전환 → 지도 마커/콜아웃, 여정 타임라인 환승역명, "stops" 표기 모두 영문 갱신 확인
- [ ] 한국어로 복원 시 한글로 되돌아오는지 확인

Closes #252