### PR TITLE
feat(#258): 알람 로그 인프라 (B2 측정 인프라)

### DIFF
--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -11,3 +11,4 @@ export const LAST_NOTIFIED_STATION_KEY = 'subway-now:last-notified-station';
 export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';
 export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
 export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';
+export const ALARM_LOG_KEY = 'subway-now:alarm-log';

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -47,6 +47,15 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
 
+const mockLogFiredAlarm = jest.fn();
+const mockLogFiredStationPassed = jest.fn();
+const mockLogSuppressedDedupStation = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
+  logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
+  logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
+}));
+
 const makeStation = (id: string, name: string, lat = 37.5, lng = 127.0): Station => ({
   id,
   name,
@@ -609,6 +618,58 @@ describe('useStationAlarm', () => {
       await Promise.resolve();
 
       expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── 알람 로그 적재 (B2 인프라) ──
+  describe('appendAlarmLog 적재', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const station = makeStation('S1', '강남', 37.498, 127.028);
+
+    it('알람 발사 시 logFiredAlarm(fg, event)를 호출한다', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => {
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest);
+      });
+    });
+
+    it('역 통과 알림 발사 시 logFiredStationPassed(fg, station)을 호출한다', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 1,
+        isTransfer: false,
+        stopsToDestination: 1,
+      });
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => {
+        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg', station);
+      });
+    });
+
+    it('lastNotifiedStationId 일치로 skip 시 logSuppressedDedupStation(fg, station)을 호출한다', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(station.id);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedDedupStation).toHaveBeenCalledWith('fg', station);
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -7,6 +7,11 @@ import { distanceMetersBetween, estimateEtaSeconds } from '../utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
 import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
 import { getLastNotifiedStationId, setLastNotifiedStationId } from '../utils/notificationState';
+import {
+  logFiredAlarm,
+  logFiredStationPassed,
+  logSuppressedDedupStation,
+} from '../utils/alarmLog';
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 
@@ -76,6 +81,7 @@ export function useStationAlarm({
       sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
         logger.error('알람 알림 실패:', e),
       );
+      logFiredAlarm('fg', event);
     }
 
     // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
@@ -92,7 +98,10 @@ export function useStationAlarm({
         try {
           const lastId = await getLastNotifiedStationId();
           if (cancelled) return;
-          if (candidateStation.id === lastId) return;
+          if (candidateStation.id === lastId) {
+            logSuppressedDedupStation('fg', candidateStation);
+            return;
+          }
           const target = resolveNextTarget(capturedRoute, capturedDestinationName);
           // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
           await sendStationPassedNotification(
@@ -102,6 +111,7 @@ export function useStationAlarm({
           );
           if (cancelled) return;
           await setLastNotifiedStationId(candidateStation.id);
+          logFiredStationPassed('fg', candidateStation);
         } catch (e) {
           logger.error('역 통과 알림 실패:', e);
         }

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -32,6 +32,12 @@ jest.mock('../../utils/stationAlarm', () => ({
   alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
 }));
 
+// ── alarmLog 모킹 ──
+const mockLogSuppressedGate = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  logSuppressedGate: (...args: unknown[]) => mockLogSuppressedGate(...args),
+}));
+
 // ── logger 모킹 ──
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
@@ -422,8 +428,20 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   const runWithLocation = (location: unknown) =>
     taskCallback({ data: { locations: [location] }, error: null });
 
+  // 게이트 drop 시 destination/sleep/route 등 도메인 키는 절대 읽지 않는다.
+  // (ALARM_LOG_KEY는 적재용으로 정상 read/write 됨 — B2 인프라)
+  const DOMAIN_KEYS = [
+    'subway-now:destination',
+    'subway-now:sleep-mode',
+    'subway-now:fired-alarms',
+    'subway-now:route',
+    'subway-now:allow-speaker',
+  ];
   const expectGateBlocked = () => {
-    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    const getItemKeys = (AsyncStorage.getItem as jest.Mock).mock.calls.map(([k]) => k);
+    for (const key of DOMAIN_KEYS) {
+      expect(getItemKeys).not.toContain(key);
+    }
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
   };
 
@@ -452,6 +470,28 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it('저정확도 위치(accuracy MAX_ACCURACY_M 초과)는 무시한다', async () => {
     await runWithLocation(makeLocation(37.498, 127.028, { accuracy: MAX_ACCURACY_M + 1 }));
     expectGateBlocked();
+  });
+
+  // ── 알람 로그 적재 (B2 인프라) ──
+
+  it('stale 위치 게이트 drop 시 logSuppressedGate(gate-age, location)을 호출한다', async () => {
+    const ageMs = MAX_LOCATION_AGE_MS + 1_000;
+    await runWithLocation(makeLocation(37.498, 127.028, { ageMs }));
+
+    expect(mockLogSuppressedGate).toHaveBeenCalledWith(
+      'gate-age',
+      expect.objectContaining({ lat: 37.498, lng: 127.028 }),
+    );
+  });
+
+  it('저정확도 게이트 drop 시 logSuppressedGate(gate-accuracy, location)을 호출한다', async () => {
+    const accuracy = MAX_ACCURACY_M + 50;
+    await runWithLocation(makeLocation(37.498, 127.028, { accuracy }));
+
+    expect(mockLogSuppressedGate).toHaveBeenCalledWith(
+      'gate-accuracy',
+      expect.objectContaining({ accuracy }),
+    );
   });
 
   it('accuracy가 임계값(MAX_ACCURACY_M) 이내면 통과한다', async () => {

--- a/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -135,6 +135,7 @@ async function runFgPipelineAt(station: typeof fakeStation) {
     destination: fakeDestination,
     firedAlarms,
     sleepMode: false,
+    source: 'fg',
   });
   // FG의 useStationAlarm 훅이 알람 발사 후 FIRED_ALARMS_KEY를 갱신하는 동작을 시뮬레이션.
   // 이 round-trip이 BG와의 dedup 단일 출처가 된다.

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -6,6 +6,7 @@ import { alarmKey } from '../utils/stationAlarm';
 import { createLogger } from '../utils/logger';
 import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
+import { logSuppressedGate } from '../utils/alarmLog';
 import type { Route } from '../utils/stationRoute';
 
 const logger = createLogger('BackgroundLocation');
@@ -23,11 +24,20 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const latest = locations[locations.length - 1];
   if (!latest) return;
 
-  // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단
-  if (!isLocationFresh(latest.timestamp)) return;
-  if (!isAccuracyAcceptable(latest.coords.accuracy)) return;
+  // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단.
+  // 측정용으로 게이트 drop을 알람 로그에 fire-and-forget 적재 (B2 인프라).
+  const { latitude: lat, longitude: lng, accuracy } = latest.coords;
+  const ageMs = Date.now() - (latest.timestamp ?? 0);
+  if (!isLocationFresh(latest.timestamp)) {
+    logSuppressedGate('gate-age', { lat, lng, accuracy, ageMs });
+    return;
+  }
+  if (!isAccuracyAcceptable(accuracy)) {
+    logSuppressedGate('gate-accuracy', { lat, lng, accuracy, ageMs });
+    return;
+  }
 
-  const { latitude, longitude, speed } = latest.coords;
+  const { speed } = latest.coords;
   const speedMps = speed != null && speed >= 0 ? speed : null;
 
   try {
@@ -57,14 +67,15 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     // lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈을 통해
     // AsyncStorage에 직접 read/write 한다 (Foreground 훅과 단일 출처 공유).
     const { alarmEvent } = await processLocationUpdate({
-      lat: latitude,
-      lng: longitude,
+      lat,
+      lng,
       destination,
       firedAlarms,
       sleepMode,
       allowSpeaker,
       storedRoute,
       speedMps,
+      source: 'bg',
     });
 
     if (alarmEvent) {
@@ -75,7 +86,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       ]);
     }
 
-    logger.info('백그라운드 위치 업데이트 완료:', latitude.toFixed(4), longitude.toFixed(4));
+    logger.info('백그라운드 위치 업데이트 완료:', lat.toFixed(4), lng.toFixed(4));
   } catch (e) {
     logger.error('백그라운드 태스크 실패:', e);
   }

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -1,0 +1,261 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  appendAlarmLog,
+  getAlarmLog,
+  clearAlarmLog,
+  logFiredAlarm,
+  logFiredStationPassed,
+  logSuppressedDedupStation,
+  logSuppressedGate,
+  ALARM_LOG_BUFFER_SIZE,
+  type AlarmLogEntry,
+} from '../alarmLog';
+import { ALARM_LOG_KEY } from '../../constants/storageKeys';
+import type { AlarmEvent } from '../stationAlarm';
+import type { Station } from '../../types/station';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function makeEntry(overrides: Partial<AlarmLogEntry> = {}): AlarmLogEntry {
+  return {
+    ts: 1_700_000_000_000,
+    source: 'bg',
+    outcome: 'fired',
+    stationName: '강남',
+    kind: 'station-passed',
+    ...overrides,
+  };
+}
+
+describe('alarmLog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('appendAlarmLog', () => {
+    it('기존 로그가 없으면 단일 엔트리로 저장한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      const entry = makeEntry();
+
+      await appendAlarmLog(entry);
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        ALARM_LOG_KEY,
+        JSON.stringify([entry]),
+      );
+    });
+
+    it('기존 로그가 있으면 뒤에 append한다', async () => {
+      const existing = [makeEntry({ stationName: '시청' })];
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(existing));
+      const entry = makeEntry({ stationName: '강남' });
+
+      await appendAlarmLog(entry);
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        ALARM_LOG_KEY,
+        JSON.stringify([...existing, entry]),
+      );
+    });
+
+    it('BUFFER 크기 초과 시 가장 오래된 엔트리부터 drop한다 (FIFO)', async () => {
+      const existing: AlarmLogEntry[] = Array.from({ length: ALARM_LOG_BUFFER_SIZE }, (_, i) =>
+        makeEntry({ ts: i, stationName: `station-${i}` }),
+      );
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(existing));
+      const entry = makeEntry({ ts: 9999, stationName: '신규' });
+
+      await appendAlarmLog(entry);
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved).toHaveLength(ALARM_LOG_BUFFER_SIZE);
+      // 가장 오래된 ts=0이 drop되고 새 엔트리가 마지막
+      expect(saved[0].ts).toBe(1);
+      expect(saved[saved.length - 1].stationName).toBe('신규');
+    });
+
+    it('손상된 JSON이 저장돼 있어도 빈 배열로 초기화 후 append한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json{{{');
+      const entry = makeEntry();
+
+      await appendAlarmLog(entry);
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        ALARM_LOG_KEY,
+        JSON.stringify([entry]),
+      );
+    });
+
+    it('JSON.parse 결과가 배열이 아니면 빈 배열로 초기화한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
+      const entry = makeEntry();
+
+      await appendAlarmLog(entry);
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        ALARM_LOG_KEY,
+        JSON.stringify([entry]),
+      );
+    });
+
+    it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      await expect(appendAlarmLog(makeEntry())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getAlarmLog', () => {
+    it('AsyncStorage 값을 파싱해 반환한다', async () => {
+      const entries = [makeEntry({ stationName: 'A' }), makeEntry({ stationName: 'B' })];
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(entries));
+
+      const result = await getAlarmLog();
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(ALARM_LOG_KEY);
+      expect(result).toEqual(entries);
+    });
+
+    it('값이 없으면 빈 배열을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+      const result = await getAlarmLog();
+
+      expect(result).toEqual([]);
+    });
+
+    it('손상된 JSON이면 빈 배열을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+
+      const result = await getAlarmLog();
+
+      expect(result).toEqual([]);
+    });
+
+    it('AsyncStorage가 에러를 던지면 빈 배열을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      const result = await getAlarmLog();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('helpers', () => {
+    const station: Station = {
+      id: 'S1',
+      name: '강남',
+      line: '2',
+      lineColor: '#009246',
+      lat: 37.498,
+      lng: 127.028,
+    };
+    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '시청' };
+
+    beforeEach(() => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    });
+
+    it('logFiredAlarm: source + event를 outcome=fired로 적재한다', async () => {
+      logFiredAlarm('fg', event);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'fired',
+        stationName: event.stationName,
+        kind: event.type,
+        phaseId: event.phaseId,
+      });
+      expect(saved[0].ts).toBeGreaterThan(0);
+    });
+
+    it('logFiredStationPassed: station.name과 kind=station-passed로 적재한다', async () => {
+      logFiredStationPassed('bg', station);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'fired',
+        stationName: station.name,
+        kind: 'station-passed',
+      });
+    });
+
+    it('logSuppressedDedupStation: reason=dedup-station, kind=station-passed로 적재한다', async () => {
+      logSuppressedDedupStation('fg', station);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dedup-station',
+        stationName: station.name,
+        kind: 'station-passed',
+      });
+    });
+
+    it('logSuppressedGate: reason + location, source=bg 고정으로 적재한다', async () => {
+      const location = { lat: 37.5, lng: 127.0, accuracy: 250, ageMs: 30_000 };
+      logSuppressedGate('gate-accuracy', location);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'gate-accuracy',
+        location,
+      });
+    });
+
+    it('helper는 fire-and-forget: void 반환 + AsyncStorage 실패 시 throw 안 함', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      // 호출 자체가 throw하면 안 됨 (void)
+      expect(() => logFiredAlarm('fg', event)).not.toThrow();
+      await flushPromises();
+    });
+  });
+
+  describe('clearAlarmLog', () => {
+    it('AsyncStorage에서 ALARM_LOG_KEY를 삭제한다', async () => {
+      await clearAlarmLog();
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(ALARM_LOG_KEY);
+    });
+
+    it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      await expect(clearAlarmLog()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -41,6 +41,15 @@ jest.mock('../notificationState', () => ({
   setLastNotifiedStationId: (...args: unknown[]) => mockSetLastNotifiedStationId(...args),
 }));
 
+const mockLogFiredAlarm = jest.fn();
+const mockLogFiredStationPassed = jest.fn();
+const mockLogSuppressedDedupStation = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
+  logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
+  logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
+}));
+
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
 
 const mockStation: Station = {
@@ -76,6 +85,7 @@ function call(overrides: Partial<Parameters<typeof processLocationUpdate>[0]> = 
     destination: mockDestination,
     firedAlarms: new Set(),
     sleepMode: false,
+    source: 'bg',
     ...overrides,
   });
 }
@@ -380,6 +390,51 @@ describe('processLocationUpdate', () => {
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+  });
+
+  // ── 알람 로그 적재 (B2 인프라) ──
+
+  describe('알람 로그 적재', () => {
+    it('알람 발사 시 logFiredAlarm(source, event)를 호출한다', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+      await call();
+
+      expect(mockLogFiredAlarm).toHaveBeenCalledWith('bg', mockAlarmEvent);
+    });
+
+    it('역 통과 알림 발사 시 logFiredStationPassed(source, station)를 호출한다', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+
+      await call();
+
+      expect(mockLogFiredStationPassed).toHaveBeenCalledWith('bg', mockStation);
+    });
+
+    it('lastNotifiedStationId 일치로 skip되면 logSuppressedDedupStation을 호출한다', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetLastNotifiedStationId.mockResolvedValue(mockStation.id);
+
+      await call();
+
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedDedupStation).toHaveBeenCalledWith('bg', mockStation);
+    });
+
+    it('source 인자가 fg면 fg로 전파된다', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+      await call({ source: 'fg' });
+
+      expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', mockAlarmEvent);
+    });
   });
 });
 

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -1,0 +1,139 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ALARM_LOG_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+import type { AlarmEvent } from './stationAlarm';
+import type { AlarmPhaseId } from './alarmPhases';
+import type { Station } from '../types/station';
+
+// 알람 발사/억제 이벤트를 AsyncStorage ring buffer로 적재한다.
+// false alarm 인지(B2) 및 차후 임계값 측정 기반 재조정(A)·GPS+Arrival fusion(C)의
+// 측정 인프라. 정책 변경 없이 관찰만 한다.
+//
+// Buffer 크기는 ALARM_LOG_BUFFER_SIZE 상수로 분리 — 늘리려면 한 곳만 수정.
+export const ALARM_LOG_BUFFER_SIZE = 200;
+
+export type AlarmLogSource = 'fg' | 'bg';
+export type AlarmLogOutcome = 'fired' | 'suppressed';
+// 'dedup-alarm'(evaluateAlarmPhase의 firedAlarms 적중 케이스)은 후속 이슈에서 추가.
+// 그때까지 union에 선언하지 않아 "구현됐다"는 거짓 시그널을 피한다.
+export type AlarmLogReason = 'dedup-station' | 'gate-age' | 'gate-accuracy';
+export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
+
+export interface AlarmLogLocation {
+  lat: number;
+  lng: number;
+  accuracy: number | null;
+  ageMs: number;
+}
+
+export interface AlarmLogEntry {
+  ts: number;
+  source: AlarmLogSource;
+  outcome: AlarmLogOutcome;
+  reason?: AlarmLogReason;
+  stationName?: string;
+  kind?: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+  location?: AlarmLogLocation;
+}
+
+const logger = createLogger('AlarmLog');
+
+// ── 적재 helper ──
+// 호출자는 `void log*(...)` 한 줄로 적재한다. ts/source/outcome 등 필드는
+// helper가 채운다 — 호출부에서 누락하거나 잘못 채우는 사고를 차단.
+// 모든 helper는 fire-and-forget: 실패해도 후속 정합성에 영향 없음(이미 swallow).
+
+export function logFiredAlarm(source: AlarmLogSource, event: AlarmEvent): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source,
+    outcome: 'fired',
+    stationName: event.stationName,
+    kind: event.type,
+    phaseId: event.phaseId,
+  });
+}
+
+export function logFiredStationPassed(source: AlarmLogSource, station: Station): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source,
+    outcome: 'fired',
+    stationName: station.name,
+    kind: 'station-passed',
+  });
+}
+
+export function logSuppressedDedupStation(source: AlarmLogSource, station: Station): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source,
+    outcome: 'suppressed',
+    reason: 'dedup-station',
+    stationName: station.name,
+    kind: 'station-passed',
+  });
+}
+
+export function logSuppressedGate(
+  reason: 'gate-age' | 'gate-accuracy',
+  location: AlarmLogLocation,
+): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg',
+    outcome: 'suppressed',
+    reason,
+    location,
+  });
+}
+
+// ── CRUD ──
+
+export async function appendAlarmLog(entry: AlarmLogEntry): Promise<void> {
+  try {
+    const raw = await AsyncStorage.getItem(ALARM_LOG_KEY);
+    const existing: AlarmLogEntry[] = raw ? safeParse(raw) : [];
+    const next = [...existing, entry];
+    // FIFO: 가장 오래된 것부터 drop
+    const trimmed = next.length > ALARM_LOG_BUFFER_SIZE
+      ? next.slice(next.length - ALARM_LOG_BUFFER_SIZE)
+      : next;
+    await AsyncStorage.setItem(ALARM_LOG_KEY, JSON.stringify(trimmed));
+  } catch (e) {
+    logger.error('알람 로그 적재 실패:', e);
+  }
+}
+
+export async function getAlarmLog(): Promise<AlarmLogEntry[]> {
+  try {
+    const raw = await AsyncStorage.getItem(ALARM_LOG_KEY);
+    return raw ? safeParse(raw) : [];
+  } catch (e) {
+    logger.error('알람 로그 읽기 실패:', e);
+    return [];
+  }
+}
+
+export async function clearAlarmLog(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(ALARM_LOG_KEY);
+  } catch (e) {
+    logger.error('알람 로그 삭제 실패:', e);
+  }
+}
+
+function safeParse(raw: string): AlarmLogEntry[] {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      logger.error('알람 로그 형태 손상(비배열) — 빈 로그로 초기화');
+      return [];
+    }
+    return parsed;
+  } catch {
+    logger.error('알람 로그 JSON 손상 — 빈 로그로 초기화');
+    return [];
+  }
+}

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -4,6 +4,12 @@ import { evaluateAlarmPhase } from './stationAlarm';
 import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
 import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
 import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificationState';
+import {
+  logFiredAlarm,
+  logFiredStationPassed,
+  logSuppressedDedupStation,
+  type AlarmLogSource,
+} from './alarmLog';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
@@ -88,6 +94,9 @@ export interface ProcessLocationInputs {
   allowSpeaker?: boolean;
   storedRoute?: Route;
   speedMps?: number | null;
+  // 알람 로그 적재 시 발사 컨텍스트 — 호출자가 명시한다.
+  // 기본값을 두지 않아 컴파일러가 컨텍스트 분류 누락을 잡도록 한다.
+  source: AlarmLogSource;
 }
 
 export async function processLocationUpdate(inputs: ProcessLocationInputs): Promise<PipelineResult> {
@@ -100,6 +109,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     allowSpeaker = true,
     storedRoute = null,
     speedMps = null,
+    source,
   } = inputs;
 
   const nearest = findNearestStation(lat, lng, MAX_STATION_DISTANCE_KM);
@@ -123,6 +133,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
 
   if (alarmEvent) {
     await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker);
+    logFiredAlarm(source, alarmEvent);
   }
 
   // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
@@ -140,7 +151,10 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
           target,
         );
         await setLastNotifiedStationId(nearest.station.id);
+        logFiredStationPassed(source, nearest.station);
       }
+    } else {
+      logSuppressedDedupStation(source, nearest.station);
     }
   }
 


### PR DESCRIPTION
## Summary
알람 정확도 로드맵 B2 트랙. false alarm 인지 메커니즘 — 알람 발사/억제 이벤트를 AsyncStorage ring buffer로 적재.
**정책 변경 없이 관찰만**. A 트랙(임계값 측정 기반 재조정), C 트랙(GPS+Arrival fusion)의 측정 토대.

## 진행 상태
- ✅ B1 (#195, PR #248)
- ✅ 백그라운드 알림 신뢰성 큐 (#242/#244/#249/#251)
- 🟡 **이 PR** B2 알람 로그 인프라
- 🔲 A: 임계값 측정 기반 재조정 (B2 데이터 1~2주 후)
- 🔲 C: GPS+Arrival fusion

## 변경 내역

### 신규 모듈 `src/utils/alarmLog.ts`
- `AlarmLogEntry`: ts/source/outcome/reason/stationName/kind/phaseId/location 데이터 모델
- ring buffer FIFO (`ALARM_LOG_BUFFER_SIZE = 200`)
- `safeParse`: JSON 손상 / 비배열 모두 빈 배열로 폴백 (측정 인프라가 정합성 자원 오염 차단)
- CRUD: `appendAlarmLog` / `getAlarmLog` / `clearAlarmLog`

### Helper (호출부 보일러플레이트 제거)
- `logFiredAlarm(source, event)` — `AlarmEvent` 자동 매핑
- `logFiredStationPassed(source, station)`
- `logSuppressedDedupStation(source, station)`
- `logSuppressedGate(reason, location)` — source='bg' 고정
- 모두 **fire-and-forget** (`void` 반환) + ts/source 자동 채움 → 호출자 실수 차단

### 적재 지점
| 위치 | 시점 | helper |
|---|---|---|
| `useStationAlarm` (FG) | 알람 발사 | `logFiredAlarm('fg', event)` |
| `useStationAlarm` (FG) | 역 통과 발사 | `logFiredStationPassed('fg', station)` |
| `useStationAlarm` (FG) | 역 dedup skip | `logSuppressedDedupStation('fg', station)` |
| `stationPipeline` (BG) | 알람 발사 | `logFiredAlarm(source, event)` |
| `stationPipeline` (BG) | 역 통과 발사 | `logFiredStationPassed(source, station)` |
| `stationPipeline` (BG) | 역 dedup skip | `logSuppressedDedupStation(source, station)` |
| `backgroundLocationTask` | 게이트 age drop | `logSuppressedGate('gate-age', location)` |
| `backgroundLocationTask` | 게이트 accuracy drop | `logSuppressedGate('gate-accuracy', location)` |

### `stationPipeline.source` required 필드 강제
- 묵시적 기본값 제거 → 호출자가 명시. 컴파일러가 컨텍스트 분류 누락을 잡도록.
- `backgroundLocationTask`는 `source: 'bg'` 명시.

## 리뷰 반영
- P1-1: 객체 리터럴 8곳 복붙 → helper 4개로 추출
- P1-2: `'dedup-alarm'` union 거짓 시그널 → 제거(후속 이슈)
- P1-3: `latest.timestamp` 한쪽만 `?? 0` 비대칭 → `ageMs` 단일 계산으로 통일
- P2-1: `source` required 강제
- P2-2: 적재 호출 fire-and-forget 통일 (await 제거)
- P2-3: buffer 크기 50 → 200 (stationary 게이트 drop 누적 대비)

## 스코프 제외 (후속 이슈)
- **dedup-alarm 적재**: `evaluateAlarmPhase`의 `firedAlarms` 적중 케이스. 시그니처 확장 필요해 분리.
- **dev 빌드 디버그 모달** (`app/(modals)/alarm-log.tsx`): 데이터 인프라와 UI 분리. `getAlarmLog` API는 노출됨.

## Test plan
- [x] `npm test` — 810 tests pass, 100% coverage (lines/functions/branches/statements)
- [x] `npm run type-check` pass
- [x] code-review 에이전트 통과 (P1 3건 모두 반영)
- [ ] CI `Type Check & Test` pass 확인

Closes #258