### PR TITLE
chore(#260): bump version to 1.2.0

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -24,7 +24,7 @@ module.exports = {
       supportsTablet: false,
       bundleIdentifier: 'com.subwaynow.app',
       appleTeamId: '4755N5H4T4',
-      buildNumber: '38',
+      buildNumber: '39',
       infoPlist: {
         NSAppTransportSecurity: {
           NSExceptionDomains: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
1.1.0 → **1.2.0** (minor). dev → main 릴리스 준비.

## 변경
- `package.json` version: 1.1.0 → 1.2.0
- `app.config.js` ios.buildNumber: 38 → 39

## 1.1.0 이후 주요 머지
**알람 신뢰성 (B1 + 백그라운드 큐 + B2)**
- #195/#248 DirectRoute에 line 추가 (false alarm 차단)
- #242/#243 알림 상태 단일 출처
- #244/#245 백그라운드 위치 추적 옵션 상수화 + Android timeInterval
- #249/#250 GPS 게이트 임계값 비대칭 조정 (200m / 15s)
- #251/#254 FG↔BG 통합 테스트 회귀 가드
- #258/#259 알람 로그 인프라 (B2)

**다국어 (i18n)**
- #230/#231 i18n Phase 6 — Live Activity 위젯 영문화
- #232/#233 i18n Phase 7 — trainLineNm 영문화
- #237/#239 다국어 인프라 정돈 (언어 레지스트리)
- #240/#241 일본어(ja) 지원
- #246/#247 중국어(zh) 지원
- #252/#255 지도 마커/여정 타임라인 다국어 역명
- #256/#257 언어 선택 UI collapsible 드롭다운

**UX**
- #234/#235 설정 화면 ScrollView 래핑
- #236/#238 경로 선택 시에만 실시간 도착 현황 노출

## Test plan
- [x] `npm test` — 810 tests pass, 100% coverage
- [x] `npm run type-check` pass
- [x] CI `Type Check & Test` pass 확인

## 후속
이 PR 머지 후 dev → main PR로 릴리스.

Closes #260