### PR TITLE
fix(#265): LiveActivity podspec에 _shared 경로 추가

### DIFF
--- a/modules/live-activity/LiveActivity.podspec
+++ b/modules/live-activity/LiveActivity.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author         = 'subway-now'
   s.platform       = :ios, '15.1'
   s.source         = { path: '.' }
-  s.source_files   = 'ios/**/*.swift'
+  s.source_files   = ['ios/**/*.swift', '../../targets/subway-widget/_shared/*.swift']
   s.dependency 'ExpoModulesCore'
   s.weak_frameworks = ['ActivityKit']
 end


### PR DESCRIPTION
## Summary

- EAS iOS 빌드 실패 (`cannot find type 'SubwayActivityAttributes' in scope`) 수정
- `LiveActivity.podspec`의 `source_files`에 `_shared` 경로 추가
- #230에서 도입한 단일 진실 소스 구조는 그대로 유지

## 원인

`@bacons/apple-targets`의 `_shared` 패턴은 widget 타겟에는 자동 링크되지만, `LiveActivity`는 별도 CocoaPod 프레임워크로 빌드되어 podspec `source_files`(`ios/**/*.swift`) 범위 밖이라 심볼을 못 찾음.

v1.1.0은 #230 리팩토링 이전 커밋이라 정상 빌드되었고, 1.2.0이 이후 첫 EAS 빌드라 처음 표면화됨.

## 변경 파일

- `modules/live-activity/LiveActivity.podspec` — `source_files`에 `../../targets/subway-widget/_shared/*.swift` 추가 (한 줄)

다른 코드/로직/UI 변경 없음.

## Test plan

- [x] CI Type Check & Test 통과
- [ ] EAS production 빌드 재시도하여 성공 확인

Closes #265