### PR TITLE
release: v1.2.0 — LiveActivity podspec _shared 경로 수정

### DIFF
--- a/modules/live-activity/LiveActivity.podspec
+++ b/modules/live-activity/LiveActivity.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author         = 'subway-now'
   s.platform       = :ios, '15.1'
   s.source         = { path: '.' }
-  s.source_files   = 'ios/**/*.swift'
+  s.source_files   = ['ios/**/*.swift', '../../targets/subway-widget/_shared/*.swift']
   s.dependency 'ExpoModulesCore'
   s.weak_frameworks = ['ActivityKit']
 end


### PR DESCRIPTION
## Summary

v1.2.0 릴리스. 핵심 변경은 EAS iOS 빌드 실패 수정.

- **#265 / #266**: LiveActivity podspec에 `_shared` 경로 추가 — `cannot find type 'SubwayActivityAttributes' in scope` 빌드 에러 해결
- #230에서 도입한 `_shared` 단일 진실 소스 구조 유지

## 원인 (#265)

`@bacons/apple-targets`의 `_shared` 패턴은 widget 타겟에만 자동 링크. `LiveActivity`는 별도 CocoaPod로 빌드되어 podspec의 `source_files` 범위 밖이라 심볼을 찾지 못함.

## 머지 방법

⚠️ **반드시 merge commit으로 머지** (squash 금지 — lineage 끊기면 다음 릴리스에서 add/add conflict 발생).

## Test plan

- [x] CI Type Check & Test 통과
- [x] 머지 후 main에서 `eas build --profile production --platform ios` 성공
- [x] `eas submit --platform ios --latest` TestFlight 업로드
- [ ] App Store Connect에서 1.2.0 심사 제출

Closes #265