### PR TITLE
feat(#269): dedup-alarm 별도 buffer 적재 + write-time 압축

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,3 +6,7 @@ sonar.sources=src,app
 
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯)
 sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**
+
+# 중복 분석 제외 — Live Activity ActivityKit 구조체는 widget 타겟과 CocoaPod 모듈에서
+# 동일 정의를 요구하므로 의도된 중복. CocoaPod 격리상 _shared 자동 링크 범위 밖이라 불가피.
+sonar.cpd.exclusions=targets/**,modules/**


### PR DESCRIPTION
Closes #269

## 배경
PR #259(B2 측정 인프라)에서 알람 로그가 깔렸으나 `evaluateAlarmPhase`의 `firedAlarms` 적중(=알람 단위 dedup) 케이스는 의도적으로 미적재였다(`alarmLog.ts:17-18` 주석). 이 신호 없이는 dedup이 실제로 몇 번 작동했나 측정 불가 → B2→A 임계값 튜닝의 근거 부족.

## 핵심 설계 결정

**1. dedup 전용 ring buffer 분리** (`ALARM_DEDUP_LOG_KEY`)
- fired/gate 메인 buffer에 dedup이 섞이면 BG 30s 폴링 누적 시 측정 데이터(fired/gate 200건 ring)가 FIFO로 밀려 손실
- 구조적 격리로 측정 인프라 무결성 보장

**2. write-time consolidation (run-length 압축)**
- 마지막 엔트리와 `(source, outcome, reason, phaseId, stationName)` 동일 시 새 엔트리 추가 X, `lastTs`/`count` 갱신
- 분석 시 후처리 0 — 같은 키 연속 적중 횟수와 첫/마지막 시각이 즉시 읽힘

**3. `evaluateAlarmPhase` 순수성 유지**
- 반환 타입을 `{ fire: AlarmEvent | null, dedupHits: DedupHit[] }` union으로 변경
- caller가 `dedupHits` 순회해서 `logSuppressedDedupAlarm` 호출
- **fire 사이클에서는 `dedupHits: []` 드롭** — "early dedup → imminent fire"는 정상 phase 승격이지 사용자가 알람 못 받은 케이스가 아님 → 측정 노이즈

**4. 모듈 레벨 직렬화 큐**
- 한 사이클의 dedupHits 여러 건이 fire-and-forget으로 in-flight되면 read-modify-write 인터리브로 consolidation 어긋남
- `dedupWriteQueue: Promise<unknown>` chain으로 직렬화

## 변경 파일
- `src/constants/storageKeys.ts` — `ALARM_DEDUP_LOG_KEY`
- `src/utils/alarmLog.ts` — enum/스키마 확장, dedup buffer helper, 직렬화 큐
- `src/utils/stationAlarm.ts` — `AlarmEvaluationResult` union 반환
- `src/hooks/useStationAlarm.ts` — FG dedupHits 적재
- `src/utils/stationPipeline.ts` — BG dedupHits 적재
- 4개 테스트 파일 갱신 + 새 케이스 추가

## 검증
- `npm run type-check` ✅
- `npm test` — 56 suites, 837 tests, 100% coverage ✅
- code-review 에이전트 P1/P2 지적 모두 반영 (P1-1: dedupHits 드롭, P1-2: 직렬화 큐, P2-3: outcome 비교)

## 명시적으로 분리한 후속 리팩토링
- 메인/dedup buffer 팩토리 일반화 (P2-1) — 별도 리팩토링 PR 예정
- `AlarmLogEntry` discriminated union 분리 (P2-2) — 별도 PR 예정

## 수동 검증 (dev 빌드 시)
알람 받은 역에 머무르며 BG에서 30s 후 위치 update가 들어왔을 때:
- 별도 dedup buffer에 1건 적재 + count 증가만 일어나는지
- fired buffer는 영향 없는지