### PR TITLE
fix(#275): 백그라운드 알림 미수신 진단 로그 추가

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Alert, Pressable, ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +8,7 @@ import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../../src/i18n/types';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
+import { clearBgDiagnostics, getBgDiagnostics, type BgDiagnostics } from '../../src/utils/bgDiagnostics';
 
 const THEME_OPTIONS = [
   { value: 'auto', labelKey: 'settings.themeAuto' },
@@ -128,8 +129,86 @@ export default function SettingsScreen() {
             />
           </View>
         </View>
+
+        <BgDiagnosticsCard />
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+// #275 진단 패널. 가설 격리 완료 후 제거 예정 — i18n 생략(임시 surface).
+const DIAGNOSTIC_ROWS: readonly { key: keyof BgDiagnostics; label: string }[] = [
+  { key: 'taskFired', label: 'TASK FIRED' },
+  { key: 'gateAge', label: '게이트 컷 (오래된 좌표)' },
+  { key: 'gateAccuracy', label: '게이트 컷 (저정확도)' },
+  { key: 'pipelineEnter', label: 'PIPELINE ENTER' },
+  { key: 'pipelineExitNoDestination', label: 'PIPELINE EXIT (목적지 없음)' },
+  { key: 'alarmEnter', label: 'ALARM ENTER' },
+  { key: 'alarmPermDenied', label: 'ALARM 권한 거부 관찰' },
+  { key: 'stationPassedEnter', label: 'STATION PASSED ENTER' },
+];
+
+function BgDiagnosticsCard() {
+  const { colors } = useTheme();
+  const [snapshot, setSnapshot] = useState<BgDiagnostics | null>(null);
+
+  const refresh = useCallback(async () => {
+    setSnapshot(await getBgDiagnostics());
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleClear = useCallback(() => {
+    Alert.alert('진단 카운터 초기화', '카운터를 모두 0으로 되돌립니다.', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '초기화',
+        style: 'destructive',
+        onPress: async () => {
+          await clearBgDiagnostics();
+          await refresh();
+        },
+      },
+    ]);
+  }, [refresh]);
+
+  if (!snapshot) return null;
+
+  const lastTs = snapshot.lastTaskFiredTs;
+  const lastLabel = lastTs ? new Date(lastTs).toLocaleString() : '없음';
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.card }]}>
+      <Text style={[styles.sectionTitle, { color: colors.muted }]}>진단 (#275)</Text>
+      {DIAGNOSTIC_ROWS.map(({ key, label }) => (
+        <View key={key} style={styles.diagRow}>
+          <Text style={[styles.diagLabel, { color: colors.ink }]}>{label}</Text>
+          <Text style={[styles.diagValue, { color: colors.muted }]}>{String(snapshot[key])}</Text>
+        </View>
+      ))}
+      <View style={[styles.diagRow, { borderTopWidth: 1, borderTopColor: colors.hair, marginTop: spacing.sm, paddingTop: spacing.sm }]}>
+        <Text style={[styles.diagLabel, { color: colors.muted }]}>마지막 TASK FIRED</Text>
+        <Text style={[styles.diagValue, { color: colors.muted }]}>{lastLabel}</Text>
+      </View>
+      <View style={styles.diagActions}>
+        <Pressable
+          style={[styles.diagButton, { borderColor: colors.hair }]}
+          onPress={() => void refresh()}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.diagButtonText, { color: colors.ink }]}>새로고침</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.diagButton, { borderColor: colors.hair }]}
+          onPress={handleClear}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.diagButtonText, { color: colors.ink }]}>초기화</Text>
+        </Pressable>
+      </View>
+    </View>
   );
 }
 
@@ -316,5 +395,37 @@ const styles = StyleSheet.create({
   localeChevron: {
     fontSize: 20,
     marginLeft: spacing.sm,
+  },
+  diagRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  diagLabel: {
+    fontSize: 13,
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  diagValue: {
+    fontSize: 13,
+    fontVariant: ['tabular-nums'],
+    fontWeight: '600',
+  },
+  diagActions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  diagButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderRadius: radius.sm,
+    alignItems: 'center',
+  },
+  diagButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
   },
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,7 +8,12 @@ import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../../src/i18n/types';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
-import { clearBgDiagnostics, getBgDiagnostics, type BgDiagnostics } from '../../src/utils/bgDiagnostics';
+import {
+  BG_DIAGNOSTIC_ROWS,
+  clearBgDiagnostics,
+  getBgDiagnostics,
+  type BgDiagnostics,
+} from '../../src/utils/bgDiagnostics';
 
 const THEME_OPTIONS = [
   { value: 'auto', labelKey: 'settings.themeAuto' },
@@ -137,17 +142,6 @@ export default function SettingsScreen() {
 }
 
 // #275 진단 패널. 가설 격리 완료 후 제거 예정 — i18n 생략(임시 surface).
-const DIAGNOSTIC_ROWS: readonly { key: keyof BgDiagnostics; label: string }[] = [
-  { key: 'taskFired', label: 'TASK FIRED' },
-  { key: 'gateAge', label: '게이트 컷 (오래된 좌표)' },
-  { key: 'gateAccuracy', label: '게이트 컷 (저정확도)' },
-  { key: 'pipelineEnter', label: 'PIPELINE ENTER' },
-  { key: 'pipelineExitNoDestination', label: 'PIPELINE EXIT (목적지 없음)' },
-  { key: 'alarmEnter', label: 'ALARM ENTER' },
-  { key: 'alarmPermDenied', label: 'ALARM 권한 거부 관찰' },
-  { key: 'stationPassedEnter', label: 'STATION PASSED ENTER' },
-];
-
 function BgDiagnosticsCard() {
   const { colors } = useTheme();
   const [snapshot, setSnapshot] = useState<BgDiagnostics | null>(null);
@@ -182,33 +176,41 @@ function BgDiagnosticsCard() {
   return (
     <View style={[styles.card, { backgroundColor: colors.card }]}>
       <Text style={[styles.sectionTitle, { color: colors.muted }]}>진단 (#275)</Text>
-      {DIAGNOSTIC_ROWS.map(({ key, label }) => (
-        <View key={key} style={styles.diagRow}>
-          <Text style={[styles.diagLabel, { color: colors.ink }]}>{label}</Text>
-          <Text style={[styles.diagValue, { color: colors.muted }]}>{String(snapshot[key])}</Text>
-        </View>
+      {BG_DIAGNOSTIC_ROWS.map(({ key, label }) => (
+        <DiagRow key={key} label={label} value={String(snapshot[key])} colors={colors} />
       ))}
       <View style={[styles.diagRow, { borderTopWidth: 1, borderTopColor: colors.hair, marginTop: spacing.sm, paddingTop: spacing.sm }]}>
         <Text style={[styles.diagLabel, { color: colors.muted }]}>마지막 TASK FIRED</Text>
         <Text style={[styles.diagValue, { color: colors.muted }]}>{lastLabel}</Text>
       </View>
       <View style={styles.diagActions}>
-        <Pressable
-          style={[styles.diagButton, { borderColor: colors.hair }]}
-          onPress={() => void refresh()}
-          accessibilityRole="button"
-        >
-          <Text style={[styles.diagButtonText, { color: colors.ink }]}>새로고침</Text>
-        </Pressable>
-        <Pressable
-          style={[styles.diagButton, { borderColor: colors.hair }]}
-          onPress={handleClear}
-          accessibilityRole="button"
-        >
-          <Text style={[styles.diagButtonText, { color: colors.ink }]}>초기화</Text>
-        </Pressable>
+        <DiagButton label="새로고침" onPress={() => void refresh()} colors={colors} />
+        <DiagButton label="초기화" onPress={handleClear} colors={colors} />
       </View>
     </View>
+  );
+}
+
+type DiagColors = { readonly ink: string; readonly muted: string; readonly hair: string };
+
+function DiagRow({ label, value, colors }: { readonly label: string; readonly value: string; readonly colors: DiagColors }) {
+  return (
+    <View style={styles.diagRow}>
+      <Text style={[styles.diagLabel, { color: colors.ink }]}>{label}</Text>
+      <Text style={[styles.diagValue, { color: colors.muted }]}>{value}</Text>
+    </View>
+  );
+}
+
+function DiagButton({ label, onPress, colors }: { readonly label: string; readonly onPress: () => void; readonly colors: DiagColors }) {
+  return (
+    <Pressable
+      style={[styles.diagButton, { borderColor: colors.hair }]}
+      onPress={onPress}
+      accessibilityRole="button"
+    >
+      <Text style={[styles.diagButtonText, { color: colors.ink }]}>{label}</Text>
+    </Pressable>
   );
 }
 

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -12,3 +12,4 @@ export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';
 export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
 export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';
 export const ALARM_LOG_KEY = 'subway-now:alarm-log';
+export const BG_DIAGNOSTICS_KEY = 'subway-now:bg-diagnostics';

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -38,6 +38,12 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedGate: (...args: unknown[]) => mockLogSuppressedGate(...args),
 }));
 
+// ── bgDiagnostics 모킹 ──
+const mockIncrementBgDiagnostic = jest.fn();
+jest.mock('../../utils/bgDiagnostics', () => ({
+  incrementBgDiagnostic: (...args: unknown[]) => mockIncrementBgDiagnostic(...args),
+}));
+
 // ── logger 모킹 ──
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -24,6 +24,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const latest = locations[locations.length - 1];
   if (!latest) return;
 
+  // #275 진단: TaskManager가 백그라운드에서 실제로 깨어나 유효 데이터를 받았는지 확인.
+  // 이 로그가 안 찍히면 JS runtime이 깨어나지 못하는 가설 A.
+  logger.info('TASK FIRED', new Date().toISOString(), 'locations:', locations.length);
+
   // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단.
   // 측정용으로 게이트 drop을 알람 로그에 fire-and-forget 적재 (B2 인프라).
   const { latitude: lat, longitude: lng, accuracy } = latest.coords;
@@ -36,6 +40,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     logSuppressedGate('gate-accuracy', { lat, lng, accuracy, ageMs });
     return;
   }
+
+  // #275 진단: 게이트 통과 직후 마커. 이후 destJson 없음 등의 조기 리턴은 별도로 식별.
+  logger.info('PIPELINE ENTER', lat.toFixed(4), lng.toFixed(4), 'acc:', accuracy);
 
   const { speed } = latest.coords;
   const speedMps = speed != null && speed >= 0 ? speed : null;
@@ -50,7 +57,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     ]);
 
     // 경로(목적지) 없으면 백그라운드에서도 실시간 현황 알림을 띄우지 않는다.
-    if (!destJson) return;
+    if (!destJson) {
+      logger.info('PIPELINE EXIT no-destination');
+      return;
+    }
 
     let destination;
     try {

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../utils/logger';
 import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
 import { logSuppressedGate } from '../utils/alarmLog';
+import { incrementBgDiagnostic } from '../utils/bgDiagnostics';
 import type { Route } from '../utils/stationRoute';
 
 const logger = createLogger('BackgroundLocation');
@@ -25,8 +26,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   if (!latest) return;
 
   // #275 진단: TaskManager가 백그라운드에서 실제로 깨어나 유효 데이터를 받았는지 확인.
-  // 이 로그가 안 찍히면 JS runtime이 깨어나지 못하는 가설 A.
+  // 이 로그/카운터가 0이면 JS runtime이 깨어나지 못하는 가설 A.
   logger.info('TASK FIRED', new Date().toISOString(), 'locations:', locations.length);
+  incrementBgDiagnostic('taskFired', { stampTaskFired: true });
 
   // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단.
   // 측정용으로 게이트 drop을 알람 로그에 fire-and-forget 적재 (B2 인프라).
@@ -34,15 +36,18 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const ageMs = Date.now() - (latest.timestamp ?? 0);
   if (!isLocationFresh(latest.timestamp)) {
     logSuppressedGate('gate-age', { lat, lng, accuracy, ageMs });
+    incrementBgDiagnostic('gateAge');
     return;
   }
   if (!isAccuracyAcceptable(accuracy)) {
     logSuppressedGate('gate-accuracy', { lat, lng, accuracy, ageMs });
+    incrementBgDiagnostic('gateAccuracy');
     return;
   }
 
   // #275 진단: 게이트 통과 직후 마커. 이후 destJson 없음 등의 조기 리턴은 별도로 식별.
   logger.info('PIPELINE ENTER', lat.toFixed(4), lng.toFixed(4), 'acc:', accuracy);
+  incrementBgDiagnostic('pipelineEnter');
 
   const { speed } = latest.coords;
   const speedMps = speed != null && speed >= 0 ? speed : null;
@@ -59,6 +64,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     // 경로(목적지) 없으면 백그라운드에서도 실시간 현황 알림을 띄우지 않는다.
     if (!destJson) {
       logger.info('PIPELINE EXIT no-destination');
+      incrementBgDiagnostic('pipelineExitNoDestination');
       return;
     }
 

--- a/src/utils/__tests__/bgDiagnostics.test.ts
+++ b/src/utils/__tests__/bgDiagnostics.test.ts
@@ -1,10 +1,20 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
+  BG_DIAGNOSTIC_ROWS,
   incrementBgDiagnostic,
   getBgDiagnostics,
   clearBgDiagnostics,
+  type BgDiagnosticCounter,
+  type BgDiagnostics,
 } from '../bgDiagnostics';
 import { BG_DIAGNOSTICS_KEY } from '../../constants/storageKeys';
+
+function makeSnapshot(overrides: Partial<BgDiagnostics> = {}): BgDiagnostics {
+  const zeros = Object.fromEntries(
+    BG_DIAGNOSTIC_ROWS.map(({ key }) => [key, 0]),
+  ) as Record<BgDiagnosticCounter, number>;
+  return { ...zeros, lastTaskFiredTs: null, ...overrides };
+}
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
@@ -38,31 +48,16 @@ describe('bgDiagnostics', () => {
 
       const result = await getBgDiagnostics();
 
-      expect(result).toEqual({
-        taskFired: 0,
-        pipelineEnter: 0,
-        pipelineExitNoDestination: 0,
-        gateAge: 0,
-        gateAccuracy: 0,
-        alarmEnter: 0,
-        alarmPermDenied: 0,
-        stationPassedEnter: 0,
-        lastTaskFiredTs: null,
-      });
+      expect(result).toEqual(makeSnapshot());
     });
 
     it('저장값이 있으면 그대로 돌려준다', async () => {
-      const stored = {
+      const stored = makeSnapshot({
         taskFired: 3,
         pipelineEnter: 2,
-        pipelineExitNoDestination: 0,
         gateAge: 1,
-        gateAccuracy: 0,
-        alarmEnter: 0,
-        alarmPermDenied: 0,
-        stationPassedEnter: 0,
         lastTaskFiredTs: 1_700_000_000_000,
-      };
+      });
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stored));
 
       const result = await getBgDiagnostics();

--- a/src/utils/__tests__/bgDiagnostics.test.ts
+++ b/src/utils/__tests__/bgDiagnostics.test.ts
@@ -16,24 +16,10 @@ function makeSnapshot(overrides: Partial<BgDiagnostics> = {}): BgDiagnostics {
   return { ...zeros, lastTaskFiredTs: null, ...overrides };
 }
 
-jest.mock('@react-native-async-storage/async-storage', () => ({
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-}));
+jest.mock('@react-native-async-storage/async-storage', () => ({ getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn() }));
+jest.mock('../logger', () => ({ createLogger: () => ({ debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }) }));
 
-jest.mock('../logger', () => ({
-  createLogger: () => ({
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  }),
-}));
-
-function flushPromises(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
-}
+const flushPromises = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 describe('bgDiagnostics', () => {
   beforeEach(() => {

--- a/src/utils/__tests__/bgDiagnostics.test.ts
+++ b/src/utils/__tests__/bgDiagnostics.test.ts
@@ -1,0 +1,166 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  incrementBgDiagnostic,
+  getBgDiagnostics,
+  clearBgDiagnostics,
+} from '../bgDiagnostics';
+import { BG_DIAGNOSTICS_KEY } from '../../constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('bgDiagnostics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('getBgDiagnostics', () => {
+    it('저장된 값이 없으면 모두 0 인 기본 스냅샷을 돌려준다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+      const result = await getBgDiagnostics();
+
+      expect(result).toEqual({
+        taskFired: 0,
+        pipelineEnter: 0,
+        pipelineExitNoDestination: 0,
+        gateAge: 0,
+        gateAccuracy: 0,
+        alarmEnter: 0,
+        alarmPermDenied: 0,
+        stationPassedEnter: 0,
+        lastTaskFiredTs: null,
+      });
+    });
+
+    it('저장값이 있으면 그대로 돌려준다', async () => {
+      const stored = {
+        taskFired: 3,
+        pipelineEnter: 2,
+        pipelineExitNoDestination: 0,
+        gateAge: 1,
+        gateAccuracy: 0,
+        alarmEnter: 0,
+        alarmPermDenied: 0,
+        stationPassedEnter: 0,
+        lastTaskFiredTs: 1_700_000_000_000,
+      };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stored));
+
+      const result = await getBgDiagnostics();
+
+      expect(result).toEqual(stored);
+    });
+
+    it('JSON 파싱 실패 시 기본 스냅샷을 돌려준다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('!!!not-json');
+
+      const result = await getBgDiagnostics();
+
+      expect(result.taskFired).toBe(0);
+      expect(result.lastTaskFiredTs).toBeNull();
+    });
+  });
+
+  describe('incrementBgDiagnostic', () => {
+    it('카운터를 1 증가시켜 저장한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+      incrementBgDiagnostic('pipelineEnter');
+      await flushPromises();
+
+      const [, payload] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(payload).pipelineEnter).toBe(1);
+    });
+
+    it('stampTaskFired 옵션 시 lastTaskFiredTs를 갱신한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      const fixedNow = 1_700_000_001_234;
+      jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+
+      incrementBgDiagnostic('taskFired', { stampTaskFired: true });
+      await flushPromises();
+
+      const [key, payload] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(key).toBe(BG_DIAGNOSTICS_KEY);
+      const parsed = JSON.parse(payload);
+      expect(parsed.taskFired).toBe(1);
+      expect(parsed.lastTaskFiredTs).toBe(fixedNow);
+    });
+
+    it('읽기 실패 시 swallow 한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+
+      incrementBgDiagnostic('alarmEnter');
+      await flushPromises();
+
+      // getBgDiagnostics 내부 catch가 기본 스냅샷을 돌려주므로 setItem은 호출됨
+      expect(AsyncStorage.setItem).toHaveBeenCalled();
+    });
+
+    it('setItem 실패도 swallow 한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
+
+      incrementBgDiagnostic('gateAge');
+      await flushPromises();
+
+      // 예외가 호출자에게 전파되지 않아야 함
+      expect(AsyncStorage.setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe('직렬화 (race 방지)', () => {
+    it('연속 호출이 직렬화되어 카운터가 누락되지 않는다', async () => {
+      // 두 번 연속 호출. 첫 번째 getItem은 null, 두 번째 getItem은 첫 호출의 setItem 결과를 반환해야 함.
+      let stored: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(() => Promise.resolve(stored));
+      (AsyncStorage.setItem as jest.Mock).mockImplementation((_key: string, value: string) => {
+        stored = value;
+        return Promise.resolve();
+      });
+
+      incrementBgDiagnostic('taskFired');
+      incrementBgDiagnostic('taskFired');
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
+
+      const finalParsed = JSON.parse(stored ?? '{}');
+      expect(finalParsed.taskFired).toBe(2);
+    });
+  });
+
+  describe('clearBgDiagnostics', () => {
+    it('AsyncStorage에서 키를 제거한다', async () => {
+      await clearBgDiagnostics();
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(BG_DIAGNOSTICS_KEY);
+    });
+
+    it('removeItem 실패도 swallow 한다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('nope'));
+
+      await expect(clearBgDiagnostics()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -96,6 +96,7 @@ describe('stationNotification', () => {
     jest.clearAllMocks();
     (Notifications.setNotificationHandler as jest.Mock).mockReturnValue(undefined);
     (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
     (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
     (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('current-station');
     (Notifications.setNotificationChannelAsync as jest.Mock).mockResolvedValue(undefined);

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -13,6 +13,9 @@ import { Station } from '../../types/station';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 
 jest.mock('expo-notifications');
+jest.mock('../bgDiagnostics', () => ({
+  incrementBgDiagnostic: jest.fn(),
+}));
 jest.mock('../logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -567,6 +570,13 @@ describe('stationNotification', () => {
         content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: false, channelId: 'station-alarm-silent', priority: 'max' },
         trigger: null,
       });
+    });
+
+    it('#275 진단: 권한이 granted가 아니면 알림은 스케줄하되 진단 카운터를 알 수 있다', async () => {
+      (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValueOnce({ status: 'denied' });
+      await sendAlarmNotification(earlyDest);
+      // 권한 거부여도 호출은 시도 (silent fail은 OS 단에서 발생)
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
     });
   });
 

--- a/src/utils/bgDiagnostics.ts
+++ b/src/utils/bgDiagnostics.ts
@@ -3,30 +3,26 @@ import { BG_DIAGNOSTICS_KEY } from '../constants/storageKeys';
 import { createLogger } from './logger';
 
 // #275 진단 카운터. Console.app 접근 없이 앱 내에서 BG 동작 격리를 위해 사용.
-// 카운터 키는 closed union으로 고정해 오타로 인한 noise 카운터가 생기지 않게 한다.
-export type BgDiagnosticCounter =
-  | 'taskFired'
-  | 'pipelineEnter'
-  | 'pipelineExitNoDestination'
-  | 'gateAge'
-  | 'gateAccuracy'
-  | 'alarmEnter'
-  | 'alarmPermDenied'
-  | 'stationPassedEnter';
+// 카운터 키 + 사용자 노출 라벨을 한 곳에 두어 추가/제거 시 단일 지점만 갱신.
+export const BG_DIAGNOSTIC_ROWS = [
+  { key: 'taskFired', label: 'TASK FIRED' },
+  { key: 'gateAge', label: '게이트 컷 (오래된 좌표)' },
+  { key: 'gateAccuracy', label: '게이트 컷 (저정확도)' },
+  { key: 'pipelineEnter', label: 'PIPELINE ENTER' },
+  { key: 'pipelineExitNoDestination', label: 'PIPELINE EXIT (목적지 없음)' },
+  { key: 'alarmEnter', label: 'ALARM ENTER' },
+  { key: 'alarmPermDenied', label: 'ALARM 권한 거부 관찰' },
+  { key: 'stationPassedEnter', label: 'STATION PASSED ENTER' },
+] as const;
+
+export type BgDiagnosticCounter = (typeof BG_DIAGNOSTIC_ROWS)[number]['key'];
 
 export type BgDiagnostics = Record<BgDiagnosticCounter, number> & { lastTaskFiredTs: number | null };
 
 const EMPTY: BgDiagnostics = {
-  taskFired: 0,
-  pipelineEnter: 0,
-  pipelineExitNoDestination: 0,
-  gateAge: 0,
-  gateAccuracy: 0,
-  alarmEnter: 0,
-  alarmPermDenied: 0,
-  stationPassedEnter: 0,
+  ...Object.fromEntries(BG_DIAGNOSTIC_ROWS.map(({ key }) => [key, 0])),
   lastTaskFiredTs: null,
-};
+} as BgDiagnostics;
 
 const logger = createLogger('BgDiagnostics');
 

--- a/src/utils/bgDiagnostics.ts
+++ b/src/utils/bgDiagnostics.ts
@@ -1,0 +1,81 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { BG_DIAGNOSTICS_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+
+// #275 진단 카운터. Console.app 접근 없이 앱 내에서 BG 동작 격리를 위해 사용.
+// 카운터 키는 closed union으로 고정해 오타로 인한 noise 카운터가 생기지 않게 한다.
+export type BgDiagnosticCounter =
+  | 'taskFired'
+  | 'pipelineEnter'
+  | 'pipelineExitNoDestination'
+  | 'gateAge'
+  | 'gateAccuracy'
+  | 'alarmEnter'
+  | 'alarmPermDenied'
+  | 'stationPassedEnter';
+
+export type BgDiagnostics = Record<BgDiagnosticCounter, number> & { lastTaskFiredTs: number | null };
+
+const EMPTY: BgDiagnostics = {
+  taskFired: 0,
+  pipelineEnter: 0,
+  pipelineExitNoDestination: 0,
+  gateAge: 0,
+  gateAccuracy: 0,
+  alarmEnter: 0,
+  alarmPermDenied: 0,
+  stationPassedEnter: 0,
+  lastTaskFiredTs: null,
+};
+
+const logger = createLogger('BgDiagnostics');
+
+// fire-and-forget. 적재 실패가 후속 동작에 영향을 주면 안 됨.
+export function incrementBgDiagnostic(counter: BgDiagnosticCounter, options?: { stampTaskFired?: boolean }): void {
+  void mutate((current) => {
+    const next = { ...current, [counter]: current[counter] + 1 };
+    if (options?.stampTaskFired) {
+      next.lastTaskFiredTs = Date.now();
+    }
+    return next;
+  });
+}
+
+export async function getBgDiagnostics(): Promise<BgDiagnostics> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_DIAGNOSTICS_KEY);
+    if (!raw) return { ...EMPTY };
+    const parsed = JSON.parse(raw);
+    return { ...EMPTY, ...parsed };
+  } catch (e) {
+    logger.error('진단 카운터 읽기 실패:', e);
+    return { ...EMPTY };
+  }
+}
+
+export async function clearBgDiagnostics(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(BG_DIAGNOSTICS_KEY);
+  } catch (e) {
+    logger.error('진단 카운터 초기화 실패:', e);
+  }
+}
+
+// 같은 task wake에서 연속 호출 시 read-modify-write race로 ±1 손실이 생기지
+// 않도록 인메모리 promise 체인으로 직렬화한다. 진단 데이터의 정확도가
+// 판독 결론에 직결되므로 이 보장이 필요.
+let mutateQueue: Promise<void> = Promise.resolve();
+
+async function mutate(updater: (current: BgDiagnostics) => BgDiagnostics): Promise<void> {
+  const next = mutateQueue.then(async () => {
+    try {
+      const current = await getBgDiagnostics();
+      const updated = updater(current);
+      await AsyncStorage.setItem(BG_DIAGNOSTICS_KEY, JSON.stringify(updated));
+    } catch (e) {
+      logger.error('진단 카운터 적재 실패:', e);
+    }
+  });
+  mutateQueue = next;
+  await next;
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -9,6 +9,7 @@ import type { NextTarget } from './stationPipeline';
 import * as LiveActivity from 'live-activity';
 import { vibrateAlarm, stopVibration } from './alarmSound';
 import { createLogger } from './logger';
+import { incrementBgDiagnostic } from './bgDiagnostics';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
 import stationsData from '../data/stations.json';
 
@@ -340,6 +341,7 @@ export async function sendStationPassedNotification(
   // #275 진단: 함수 진입 자체를 기록. 트레일 로그(역 통과 알림:...)와 함께
   // 페어로 보면 scheduleNotification 단계에서 멈췄는지 분리 가능.
   notifLogger.info('STATION PASSED ENTER', stationName);
+  incrementBgDiagnostic('stationPassedEnter');
   // 사용자 노출 텍스트이므로 현재 언어로 변환. caller는 한글 역명을 그대로 전달.
   const displayStation = getStationDisplayNameByName(stationName, allStations);
   const displayDestination = getStationDisplayNameByName(destinationName, allStations);
@@ -401,6 +403,10 @@ export async function sendAlarmNotification(
   // OS 단 차단 가설(C)을 트레일 로그와 함께 격리.
   const perms = await Notifications.getPermissionsAsync();
   notifLogger.info('ALARM ENTER', event.phaseId, event.type, 'perm:', perms.status);
+  incrementBgDiagnostic('alarmEnter');
+  if (perms.status !== 'granted') {
+    incrementBgDiagnostic('alarmPermDenied');
+  }
   const { title, body } = buildAlarmContent(event);
 
   await scheduleNotification(ALARM_NOTIFICATION_ID, {

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -337,6 +337,9 @@ export async function sendStationPassedNotification(
   destinationName: string,
   target: NextTarget | null,
 ): Promise<void> {
+  // #275 진단: 함수 진입 자체를 기록. 트레일 로그(역 통과 알림:...)와 함께
+  // 페어로 보면 scheduleNotification 단계에서 멈췄는지 분리 가능.
+  notifLogger.info('STATION PASSED ENTER', stationName);
   // 사용자 노출 텍스트이므로 현재 언어로 변환. caller는 한글 역명을 그대로 전달.
   const displayStation = getStationDisplayNameByName(stationName, allStations);
   const displayDestination = getStationDisplayNameByName(destinationName, allStations);
@@ -394,6 +397,10 @@ export async function sendAlarmNotification(
   sleepMode: boolean = false,
   allowSpeaker: boolean = true,
 ): Promise<void> {
+  // #275 진단: 함수 진입 시점 기록. 권한 스냅샷 동반 기록으로
+  // OS 단 차단 가설(C)을 트레일 로그와 함께 격리.
+  const perms = await Notifications.getPermissionsAsync();
+  notifLogger.info('ALARM ENTER', event.phaseId, event.type, 'perm:', perms.status);
   const { title, body } = buildAlarmContent(event);
 
   await scheduleNotification(ALARM_NOTIFICATION_ID, {


### PR DESCRIPTION
## Summary
- 실기기 백그라운드에서 도착/환승 알람과 역 통과 알림이 모두 표시되지 않는 현상의 원인을 코드 수정 전 격리하기 위한 **진단 인프라**
- 로그 마커: `backgroundLocationTask`에 TASK FIRED / PIPELINE ENTER / PIPELINE EXIT no-destination, `stationNotification`에 STATION PASSED ENTER / ALARM ENTER(+ 권한 스냅샷)
- **앱 내 진단 카운터** (Mac Console.app 의존 없이 가설 격리): `bgDiagnostics` 모듈 + Settings 탭 `BgDiagnosticsCard` (새로고침/초기화). 인메모리 promise 체인으로 동일 wake 내 연속 increment 직렬화하여 ±1 오차 제거
- 동작 변경 없음, 진단 인프라만 추가

## 가설 격리 매트릭스
실기기 dev build 1사이클 후 Settings 탭 진단 카드에서 카운터 확인:

| 관찰 | 확정 가설 |
|---|---|
| `TASK FIRED` 0 | **A** — TaskManager가 BG에서 JS runtime을 못 깨움 |
| `TASK FIRED` 있음, `PIPELINE ENTER` 0, `게이트 컷` 다수 | **B** — 위치 게이트 임계값 (15s freshness / 200m accuracy) |
| `PIPELINE ENTER` 있고 `ALARM/STATION PASSED ENTER`도 있는데 알림만 안 뜸 | **C** — Time-Sensitive entitlement 부재 / Focus 차단 |
| `ALARM 권한 거부 관찰` > 0 | 권한 회귀 |

`마지막 TASK FIRED` 타임스탬프로 콜백 최종 wake 시각도 확인 가능.

## 사용 방법
1. EAS dev build 설치
2. Settings 탭 하단 "진단 (#275)" → **초기화**
3. 목적지 설정 → 백그라운드 진입 → 30분+ 이동
4. 포그라운드 복귀 → **새로고침**으로 카운터 확인

## Test plan
- [x] `npm test` 822/822 통과, 커버리지 100% (lines/functions/branches/statements)
- [x] `npm run type-check` 통과
- [x] code-reviewer 2회 통과 (P1 로그 위치 보정, P1 race 직렬화)
- [ ] 실기기 dev build 1사이클로 가설 확정 → 별도 PR로 수정
- [ ] 가설 확정/수정 후 본 진단 패널 제거

Closes #275