### PR TITLE
feat(#276): GPS 실시간성 개선 Phase 1 — 표시/알람 게이트 분리·watch 옵션 강화

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -30,7 +30,7 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
-  const { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh } = useNearestStation();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
@@ -130,6 +130,7 @@ export default function HomeScreen() {
     nearestStation: result?.station ?? null,
     userLocation,
     speedMps,
+    accuracyMeters,
   });
   useBackgroundLocation(destination);
 

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -2,6 +2,10 @@
 // BG `timeInterval`(30s, locationTracking.ts)보다 짧다 — stationary 상태에서 OS가
 // 캐시된 fix를 넘기면 의도적으로 drop. "실시간성 우선, 나쁜 좌표 거부" 정책.
 export const MAX_LOCATION_AGE_MS = 15_000;
-// 200m: 지하역 GPS 자연 열화 수용. 역간 평균 거리(800m+) 대비 안전 마진 충분.
+// 200m: 알람 트리거용 엄격 게이트. 역간 평균 거리(800m+) 대비 안전 마진.
+// false alarm 방지 위해 그대로 유지 — 알람 경로(useStationAlarm)에서만 사용.
 export const MAX_ACCURACY_M = 200;
+// 1500m: UI 표시용 완화 게이트. 지하 플랫폼/터널의 horizontalAccuracy(300~1500m)도
+// 일단 수용해 "추정 현재역"을 끊김 없이 보여준다. 알람은 별도 엄격 게이트로 차단.
+export const MAX_ACCURACY_M_DISPLAY = 1500;
 export const MAX_STATION_DISTANCE_KM = 1.0;

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -3,7 +3,7 @@ import * as Location from 'expo-location';
 import { AppState } from 'react-native';
 import { useNearestStation } from '../useNearestStation';
 import * as findNearestStationModule from '../../utils/findNearestStation';
-import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
+import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../constants/location';
 
 jest.mock('expo-location');
 
@@ -201,7 +201,7 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('watchPositionAsync에 accuracy: High, distanceInterval: 10을 전달한다', async () => {
+  it('watchPositionAsync에 BestForNavigation·distanceInterval:0·timeInterval:2000을 전달한다', async () => {
     mockGranted();
 
     renderHook(() => useNearestStation());
@@ -209,7 +209,11 @@ describe('useNearestStation', () => {
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     expect(Location.watchPositionAsync).toHaveBeenCalledWith(
-      { accuracy: Location.Accuracy.High, distanceInterval: 10 },
+      {
+        accuracy: Location.Accuracy.BestForNavigation,
+        distanceInterval: 0,
+        timeInterval: 2000,
+      },
       expect.any(Function),
     );
   });
@@ -462,7 +466,21 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('watch 콜백 저정확도(MAX_ACCURACY_M 초과) 좌표는 setState하지 않는다', async () => {
+  it('watch 콜백 표시 게이트 초과(MAX_ACCURACY_M_DISPLAY 초과) 좌표는 setState하지 않는다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
+
+    // 표시 게이트 초과 → setState 차단
+    expect(result.current.result).toBeNull();
+    expect(result.current.userLocation).toBeNull();
+  });
+
+  it('watch 콜백 알람 게이트 초과지만 표시 게이트 통과 좌표는 setState한다 (지하 구간 가정)', async () => {
     mockGranted();
 
     const { result } = renderHook(() => useNearestStation());
@@ -471,9 +489,9 @@ describe('useNearestStation', () => {
 
     simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
 
-    // 저정확도라 result 갱신 안 됨
-    expect(result.current.result).toBeNull();
-    expect(result.current.userLocation).toBeNull();
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.result?.station.name).toBe('강남');
+    expect(result.current.accuracyMeters).toBe(MAX_ACCURACY_M + 1);
   });
 
   it('watch 콜백 accuracy가 null이면 통과한다', async () => {
@@ -489,9 +507,9 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('refresh 시 저정확도 좌표는 setState하지 않는다', async () => {
+  it('refresh 시 표시 게이트 초과 좌표는 setState하지 않는다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
+    mockLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -502,7 +520,7 @@ describe('useNearestStation', () => {
     });
 
     expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
-    // 저정확도라 result 갱신 안 됨
+    // 표시 게이트 초과 → result 갱신 안 됨
     expect(result.current.result).toBeNull();
   });
 

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -79,6 +79,7 @@ function defaultInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStati
     nearestStation: null,
     userLocation: null,
     speedMps: null,
+    accuracyMeters: null,
     ...overrides,
   };
 }
@@ -102,6 +103,38 @@ describe('useStationAlarm', () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     renderHook(() => useStationAlarm(defaultInputs({ route })));
     expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+  });
+
+  it('does not evaluate when accuracy exceeds the alarm gate (MAX_ACCURACY_M)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({
+          route,
+          destination,
+          userLocation: { lat: 37.4, lng: 127.0 },
+          speedMps: 10,
+          accuracyMeters: 500,
+        }),
+      ),
+    );
+    expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+  });
+
+  it('evaluates when accuracy is exactly the alarm gate (boundary inclusive)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({
+          route,
+          destination,
+          userLocation: { lat: 37.4, lng: 127.0 },
+          speedMps: 10,
+          accuracyMeters: 200,
+        }),
+      ),
+    );
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
   });
 
   it('builds AlarmSource and calls evaluator', () => {

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -3,17 +3,22 @@ import { AppState } from 'react-native';
 import * as Location from 'expo-location';
 import { NearestStationResult, Station } from '../types/station';
 import { findNearestStations } from '../utils/findNearestStation';
-import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
+import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../utils/locationGates';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 
-const DISTANCE_INTERVAL_M = 10;
-const MIN_DISTANCE_CHANGE_KM = 0.01; // 10m
+const MIN_DISTANCE_CHANGE_KM = 0.003; // 3m — UI 갱신을 자주 흘려보낸다.
 
+// userLocation/result는 표시용 완화 게이트(MAX_ACCURACY_M_DISPLAY=1500m)를 통과한 좌표로 갱신된다.
+// 알람 발화 경로에서 이 값을 ETA/거리 계산에 사용할 경우 반드시 accuracyMeters와 함께 묶어
+// 알람 엄격 게이트(isAccuracyAcceptable, MAX_ACCURACY_M=200m)를 먼저 통과시켜야 한다.
+// 예: useStationAlarm는 effect 진입부에서 isAccuracyAcceptable(accuracyMeters) early return으로
+// 이 계약을 강제한다.
 interface UseNearestStationReturn {
   result: NearestStationResult | null;
   variants: Station[];
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
+  accuracyMeters: number | null;
   loading: boolean;
   error: string | null;
   permissionDenied: boolean;
@@ -39,6 +44,7 @@ export function useNearestStation(): UseNearestStationReturn {
   const [variants, setVariants] = useState<Station[]>([]);
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [speedMps, setSpeedMps] = useState<number | null>(null);
+  const [accuracyMeters, setAccuracyMeters] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
@@ -47,7 +53,7 @@ export function useNearestStation(): UseNearestStationReturn {
   const lastDistanceRef = useRef<number>(0);
 
   const applyLocation = useCallback((coords: Location.LocationObjectCoords) => {
-    const { latitude, longitude, speed } = coords;
+    const { latitude, longitude, speed, accuracy } = coords;
     const stationsResult = findNearestStations(latitude, longitude, MAX_STATION_DISTANCE_KM);
 
     const newId = stationsResult?.primary.id ?? null;
@@ -57,6 +63,7 @@ export function useNearestStation(): UseNearestStationReturn {
     const noStation = !stationsResult && lastStationIdRef.current !== null;
 
     setSpeedMps(speed != null && speed >= 0 ? speed : null);
+    setAccuracyMeters(accuracy ?? null);
 
     if (stationChanged || distanceDelta > MIN_DISTANCE_CHANGE_KM || noStation) {
       lastStationIdRef.current = newId;
@@ -84,18 +91,28 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
 
-      // 캐시된 위치는 신선하고 정확한 경우만 즉시 표시 (stale/저정확도로 인한 false alarm 방지)
+      // 캐시된 위치는 신선하고 알람 엄격 게이트(200m)를 통과하는 경우만 즉시 표시.
+      // 콜드 스타트 시 부정확한 fix로 사용자에게 오정보를 주는 것을 방지.
       const lastKnown = await Location.getLastKnownPositionAsync();
       if (lastKnown && isLocationFresh(lastKnown.timestamp) && isAccuracyAcceptable(lastKnown.coords.accuracy)) {
         applyLocation(lastKnown.coords);
         setLoading(false);
       }
 
-      // 연속 GPS 스트리밍 시작 — 저정확도 좌표는 무시
+      // 연속 GPS 스트리밍 — 지하 구간 horizontalAccuracy(300~1500m)도 표시용으로는 수용.
+      // 알람은 useStationAlarm에서 accuracyMeters로 별도 엄격 게이트.
+      // BestForNavigation + distanceInterval:0 + timeInterval:2000:
+      //  좌표를 최대한 자주 흘려보낸다 (foreground 한정, 화면 켜진 동안만 GPS 풀파워).
+      // 참고: pausesUpdatesAutomatically / activityType은 expo-location foreground 옵션에
+      //  노출되지 않아 적용 불가. background task 옵션에서만 사용 가능.
       subscriptionRef.current = await Location.watchPositionAsync(
-        { accuracy: Location.Accuracy.High, distanceInterval: DISTANCE_INTERVAL_M },
+        {
+          accuracy: Location.Accuracy.BestForNavigation,
+          distanceInterval: 0,
+          timeInterval: 2000,
+        },
         (location) => {
-          if (!isAccuracyAcceptable(location.coords.accuracy)) return;
+          if (!isAccuracyAcceptableForDisplay(location.coords.accuracy)) return;
           applyLocation(location.coords);
         },
       );
@@ -120,7 +137,7 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
       const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
-      if (isAccuracyAcceptable(location.coords.accuracy)) {
+      if (isAccuracyAcceptableForDisplay(location.coords.accuracy)) {
         applyLocation(location.coords);
       }
     } catch {
@@ -148,5 +165,5 @@ export function useNearestStation(): UseNearestStationReturn {
     };
   }, [startWatch, stopWatch]);
 
-  return { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh };
+  return { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh };
 }

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/alarmLog';
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
+import { isAccuracyAcceptable } from '../utils/locationGates';
 
 const logger = createLogger('StationAlarm');
 
@@ -23,6 +24,7 @@ export interface UseStationAlarmInputs {
   nearestStation: Station | null;
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
+  accuracyMeters: number | null;
 }
 
 export function useStationAlarm({
@@ -31,6 +33,7 @@ export function useStationAlarm({
   nearestStation,
   userLocation,
   speedMps,
+  accuracyMeters,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
@@ -57,6 +60,11 @@ export function useStationAlarm({
     }
 
     if (!route || !destination) return;
+
+    // 알람 경로는 표시 경로보다 엄격한 정확도 게이트(MAX_ACCURACY_M=200m)를 적용한다.
+    // useNearestStation은 지하 구간에서 정확도 1500m까지 표시용으로 수용하므로,
+    // 그대로 알람을 울리면 잘못된 역에서 false alarm이 발생한다.
+    if (!isAccuracyAcceptable(accuracyMeters)) return;
 
     let etaSeconds: number | null = null;
     if (userLocation) {
@@ -131,5 +139,6 @@ export function useStationAlarm({
     userLocation?.lat,
     userLocation?.lng,
     speedMps,
+    accuracyMeters,
   ]);
 }

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -32,6 +32,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     logSuppressedGate('gate-age', { lat, lng, accuracy, ageMs });
     return;
   }
+  // BG task는 알람 발화 경로이므로 알람 엄격 게이트(MAX_ACCURACY_M=200m)를 유지한다.
+  // foreground watch의 표시용 완화 게이트(MAX_ACCURACY_M_DISPLAY=1500m)는 여기서 적용 금지.
+  // 여기서 게이트를 풀면 지하 구간 노이즈 좌표로 알람이 잘못 발화될 수 있다.
   if (!isAccuracyAcceptable(accuracy)) {
     logSuppressedGate('gate-accuracy', { lat, lng, accuracy, ageMs });
     return;

--- a/src/utils/__tests__/locationGates.test.ts
+++ b/src/utils/__tests__/locationGates.test.ts
@@ -1,5 +1,5 @@
-import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
-import { isAccuracyAcceptable, isLocationFresh } from '../locationGates';
+import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../constants/location';
+import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../locationGates';
 
 describe('isLocationFresh', () => {
   const NOW = 1_700_000_000_000;
@@ -49,5 +49,27 @@ describe('isAccuracyAcceptable', () => {
 
   it('임계값을 초과하면 false', () => {
     expect(isAccuracyAcceptable(MAX_ACCURACY_M + 1)).toBe(false);
+  });
+});
+
+describe('isAccuracyAcceptableForDisplay', () => {
+  it('null이면 true (accuracy 정보 없음 = 통과)', () => {
+    expect(isAccuracyAcceptableForDisplay(null)).toBe(true);
+  });
+
+  it('undefined면 true', () => {
+    expect(isAccuracyAcceptableForDisplay(undefined)).toBe(true);
+  });
+
+  it('표시 임계값과 정확히 같으면 true (경계 포함)', () => {
+    expect(isAccuracyAcceptableForDisplay(MAX_ACCURACY_M_DISPLAY)).toBe(true);
+  });
+
+  it('표시 임계값을 초과하면 false', () => {
+    expect(isAccuracyAcceptableForDisplay(MAX_ACCURACY_M_DISPLAY + 1)).toBe(false);
+  });
+
+  it('알람 임계값을 초과해도 표시 임계값 이내면 true (지하 구간 가정)', () => {
+    expect(isAccuracyAcceptableForDisplay(MAX_ACCURACY_M + 1)).toBe(true);
   });
 });

--- a/src/utils/locationGates.ts
+++ b/src/utils/locationGates.ts
@@ -1,4 +1,4 @@
-import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../constants/location';
+import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../constants/location';
 
 export function isLocationFresh(timestamp: number | undefined): boolean {
   // expo-location 타입상 timestamp는 non-nullable이지만, 네이티브 deferred batch에서
@@ -9,4 +9,8 @@ export function isLocationFresh(timestamp: number | undefined): boolean {
 
 export function isAccuracyAcceptable(accuracy: number | null | undefined): boolean {
   return accuracy == null || accuracy <= MAX_ACCURACY_M;
+}
+
+export function isAccuracyAcceptableForDisplay(accuracy: number | null | undefined): boolean {
+  return accuracy == null || accuracy <= MAX_ACCURACY_M_DISPLAY;
 }


### PR DESCRIPTION
## Summary
- 표시 게이트(`MAX_ACCURACY_M_DISPLAY=1500m`)와 알람 게이트(`MAX_ACCURACY_M=200m`) 분리. 지하 구간 GPS(정확도 300~1500m)에서도 "현재역"이 끊김 없이 갱신되도록 표시 경로만 완화하고, 알람 false alarm 정책은 그대로 유지.
- `useNearestStation` watch 옵션을 `BestForNavigation` + `distanceInterval:0` + `timeInterval:2000`으로 강화하여 좌표 흐름 latency 단축. `MIN_DISTANCE_CHANGE_KM` 0.01 → 0.003.
- `useStationAlarm`이 `accuracyMeters`를 받아 evaluate 전 엄격 게이트 early return → 표시 게이트 완화로 인한 false alarm 차단.

## 영향 범위
- **Foreground only**: `watchPositionAsync` 콜백 경로 (홈 화면 GPS 흐름).
- **Background task는 영향 없음**: `backgroundLocationTask.ts`는 알람 발화 경로이므로 엄격 게이트 유지. 정책을 주석으로 명시.

## 비범위 (후속 이슈)
- **Phase 2**: TOPIS "지하철 실시간 열차 위치정보" API fusion — 지하 깊은 구간에서 GPS 무관하게 현재역 결정. 별도 이슈로 진행.
- 코드 리뷰 P2 항목(`setSpeedMps`/`setAccuracyMeters` 매 콜백 호출 → 리렌더, `MIN_DISTANCE_CHANGE_KM` 상수 분리, `accuracyMeters` deps로 인한 알람 effect 빈도 등) — 후속 perf 이슈로 분리.

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 56 suites, 819 tests pass, 커버리지 100% (lines/functions/branches/statements)
- [ ] 실기기 검증 (개발 빌드): 지하철역 입장 latency 5회 측정, 기존 대비 단축 확인
- [ ] 환승역 통과 시 false alarm 0건 확인

Closes #276