### PR TITLE
feat(#279): 도착정보 recptnDt 시차 보정 — Phase 2 Stage 1

### DIFF
--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -1,4 +1,4 @@
-import { fetchArrivalInfo, MOCK_ARRIVALS } from '../arrivalApi';
+import { fetchArrivalInfo, MOCK_ARRIVALS, parseRecptnDt } from '../arrivalApi';
 
 describe('fetchArrivalInfo', () => {
   beforeEach(() => {
@@ -230,6 +230,142 @@ describe('fetchArrivalInfo', () => {
     expect(result.up[0].arrivalMinutes).toBe(1);
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
+  describe('recptnDt 시차 보정', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    });
+
+    it('recptnDt가 30초 전이면 barvlDt에서 30초가 차감된다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // KST 2026-05-12 12:00:30 = UTC 2026-05-12 03:00:30
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:30Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 120,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:00',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(90); // 120 - 30
+      expect(result.up[0].arrivalMinutes).toBe(1);
+      expect(result.up[0].receivedAtMs).toBe(Date.parse('2026-05-12T03:00:00Z'));
+    });
+
+    it('recptnDt가 누락되면 보정 없이 raw barvlDt를 사용한다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: '소요산행', barvlDt: 120, btrainNo: 'T001', updnLine: '상행' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(120);
+      expect(result.up[0].receivedAtMs).toBe(0);
+    });
+
+    it('보정량이 barvlDt를 초과하면 0으로 클램프된다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // 90초 전 데이터(=cap 이내) + barvlDt=60초 → -30으로 음수 → 0
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:01:30Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 60,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:00',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(0);
+      expect(result.up[0].arrivalMinutes).toBe(0);
+    });
+
+    it('recptnDt가 미래 시각(시계 어긋남)이면 보정 없이 raw 값을 사용한다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // recptnDt가 현재보다 10초 미래 — driftSec 음수 → max(0, _)로 0 → 보정 없음
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:00Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 120,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:10',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(120);
+    });
+
+    it('drift가 MAX_RECPTN_DRIFT_SEC(120s) 초과면 stale로 강등(보정 없음, receivedAtMs=0)', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // recptnDt가 5분(300s) 전 — 비정상 drift → stale 처리
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:05:00Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 600,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:00',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(600); // 보정 없음
+      expect(result.up[0].receivedAtMs).toBe(0); // stale 강등
+    });
+
+    it('parseRecptnDt: 정상 KST 문자열을 epoch ms로 변환한다', () => {
+      expect(parseRecptnDt('2026-05-12 12:00:00')).toBe(Date.parse('2026-05-12T03:00:00Z'));
+    });
+
+    it('parseRecptnDt: 비문자열·빈 문자열·잘못된 포맷은 0을 반환한다', () => {
+      expect(parseRecptnDt(undefined)).toBe(0);
+      expect(parseRecptnDt(null)).toBe(0);
+      expect(parseRecptnDt(12345)).toBe(0);
+      expect(parseRecptnDt('')).toBe(0);
+      expect(parseRecptnDt('not-a-date')).toBe(0);
+    });
   });
 
   it('trainLineNm, barvlDt, btrainNo가 undefined이면 기본값을 사용한다', async () => {

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -233,126 +233,66 @@ describe('fetchArrivalInfo', () => {
   });
 
   describe('recptnDt 시차 보정', () => {
+    const mockArrivalAt = (
+      barvlDt: number,
+      recptnDt?: string,
+      nowIso?: string,
+    ) => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      if (nowIso) jest.useFakeTimers().setSystemTime(new Date(nowIso));
+      const item: Record<string, unknown> = {
+        trainLineNm: '소요산행',
+        barvlDt,
+        btrainNo: 'T001',
+        updnLine: '상행',
+      };
+      if (recptnDt !== undefined) item.recptnDt = recptnDt;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ realtimeArrivalList: [item] }),
+      } as Response);
+    };
+
     afterEach(() => {
       jest.useRealTimers();
       delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
     });
 
     it('recptnDt가 30초 전이면 barvlDt에서 30초가 차감된다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // KST 2026-05-12 12:00:30 = UTC 2026-05-12 03:00:30
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:30Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 120,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:00',
-            },
-          ],
-        }),
-      } as Response);
-
+      mockArrivalAt(120, '2026-05-12 12:00:00', '2026-05-12T03:00:30Z');
       const result = await fetchArrivalInfo('강남');
-      expect(result.up[0].arrivalSeconds).toBe(90); // 120 - 30
+      expect(result.up[0].arrivalSeconds).toBe(90);
       expect(result.up[0].arrivalMinutes).toBe(1);
       expect(result.up[0].receivedAtMs).toBe(Date.parse('2026-05-12T03:00:00Z'));
     });
 
     it('recptnDt가 누락되면 보정 없이 raw barvlDt를 사용한다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            { trainLineNm: '소요산행', barvlDt: 120, btrainNo: 'T001', updnLine: '상행' },
-          ],
-        }),
-      } as Response);
-
+      mockArrivalAt(120);
       const result = await fetchArrivalInfo('강남');
       expect(result.up[0].arrivalSeconds).toBe(120);
       expect(result.up[0].receivedAtMs).toBe(0);
     });
 
     it('보정량이 barvlDt를 초과하면 0으로 클램프된다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // 90초 전 데이터(=cap 이내) + barvlDt=60초 → -30으로 음수 → 0
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:01:30Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 60,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:00',
-            },
-          ],
-        }),
-      } as Response);
-
+      // 90초 전(cap 이내) + barvlDt=60 → 음수 → 0
+      mockArrivalAt(60, '2026-05-12 12:00:00', '2026-05-12T03:01:30Z');
       const result = await fetchArrivalInfo('강남');
       expect(result.up[0].arrivalSeconds).toBe(0);
       expect(result.up[0].arrivalMinutes).toBe(0);
     });
 
     it('recptnDt가 미래 시각(시계 어긋남)이면 보정 없이 raw 값을 사용한다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // recptnDt가 현재보다 10초 미래 — driftSec 음수 → max(0, _)로 0 → 보정 없음
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:00Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 120,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:10',
-            },
-          ],
-        }),
-      } as Response);
-
+      mockArrivalAt(120, '2026-05-12 12:00:10', '2026-05-12T03:00:00Z');
       const result = await fetchArrivalInfo('강남');
       expect(result.up[0].arrivalSeconds).toBe(120);
     });
 
     it('drift가 MAX_RECPTN_DRIFT_SEC(120s) 초과면 stale로 강등(보정 없음, receivedAtMs=0)', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // recptnDt가 5분(300s) 전 — 비정상 drift → stale 처리
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:05:00Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 600,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:00',
-            },
-          ],
-        }),
-      } as Response);
-
+      // 5분(300s) 전 — cap 초과
+      mockArrivalAt(600, '2026-05-12 12:00:00', '2026-05-12T03:05:00Z');
       const result = await fetchArrivalInfo('강남');
-      expect(result.up[0].arrivalSeconds).toBe(600); // 보정 없음
-      expect(result.up[0].receivedAtMs).toBe(0); // stale 강등
+      expect(result.up[0].arrivalSeconds).toBe(600);
+      expect(result.up[0].receivedAtMs).toBe(0);
     });
 
     it('parseRecptnDt: 정상 KST 문자열을 epoch ms로 변환한다', () => {

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -8,6 +8,8 @@ export interface ArrivalInfo {
   arrivalSeconds: number;
   statusMessage: string;
   trainCode: string;
+  /** 데이터 생성 시각(epoch ms). 0이면 알 수 없음(mock 또는 누락). Stage 2 fusion 신호 신선도 판정용. */
+  receivedAtMs: number;
 }
 
 export interface StationArrival {
@@ -18,18 +20,34 @@ export interface StationArrival {
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
-    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001' },
-    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002' },
+    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 },
+    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0 },
   ],
   down: [
-    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001' },
-    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002' },
+    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 },
+    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0 },
   ],
   isMock: true,
 });
 
 /** 서울 열린데이터 API updnLine 응답값 — 상행/내선이면 up 방향 */
 const UP_DIRECTION_VALUES = ['상행', '내선'] as const;
+
+/** 서울 열린데이터 API recptnDt 타임존(KST 고정). */
+const SEOUL_API_TZ_OFFSET = '+09:00';
+
+/** recptnDt가 너무 오래된 경우 보정량이 비현실적이므로 stale로 강등한다. */
+const MAX_RECPTN_DRIFT_SEC = 120;
+
+/**
+ * recptnDt("YYYY-MM-DD HH:mm:ss", KST)를 epoch ms로 변환한다.
+ * 파싱 실패/누락 시 0(=알 수 없음)을 반환한다.
+ */
+export function parseRecptnDt(recptnDt: unknown): number {
+  if (typeof recptnDt !== 'string' || recptnDt.length === 0) return 0;
+  const ms = Date.parse(recptnDt.replace(' ', 'T') + SEOUL_API_TZ_OFFSET);
+  return Number.isFinite(ms) ? ms : 0;
+}
 
 export interface FetchArrivalOptions {
   timeoutMs?: number;
@@ -65,14 +83,24 @@ export async function fetchArrivalInfo(
     const up: ArrivalInfo[] = [];
     const down: ArrivalInfo[] = [];
 
+    const now = Date.now();
     for (const item of items) {
-      const seconds = Math.max(0, item.barvlDt ?? 0);
+      const rawSeconds = Math.max(0, item.barvlDt ?? 0);
+      // recptnDt(데이터 생성시각)와 현재시각의 차이만큼 열차가 더 진행한 것으로 보정.
+      // xls 스펙 주의사항에 명시된 처리. recptnDt 누락 또는 비정상 drift는 stale로 강등.
+      const parsedRecvMs = parseRecptnDt(item.recptnDt);
+      const rawDriftSec = parsedRecvMs > 0 ? (now - parsedRecvMs) / 1000 : 0;
+      const isStale = parsedRecvMs > 0 && rawDriftSec > MAX_RECPTN_DRIFT_SEC;
+      const receivedAtMs = isStale ? 0 : parsedRecvMs;
+      const driftSec = isStale ? 0 : Math.max(0, rawDriftSec);
+      const seconds = Math.max(0, Math.round(rawSeconds - driftSec));
       const info: ArrivalInfo = {
         destination: item.trainLineNm ?? '',
         arrivalMinutes: Math.floor(seconds / 60),
         arrivalSeconds: seconds,
         statusMessage: item.arvlMsg2 ?? '',
         trainCode: item.btrainNo ?? '',
+        receivedAtMs,
       };
       if (UP_DIRECTION_VALUES.includes(item.updnLine)) {
         up.push(info);

--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -3,8 +3,8 @@ import { useArrivalCountdown } from '../useArrivalCountdown';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const mockArrival: StationArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001' }],
-  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002' }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
+  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
 };
 
 const mockArrivalMock: StationArrival = {
@@ -53,7 +53,7 @@ describe('useArrivalCountdown', () => {
 
   it('arrivalSeconds가 0 이하로 내려가지 않는다', () => {
     const nearArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0 }],
       down: [],
     };
 
@@ -84,8 +84,8 @@ describe('useArrivalCountdown', () => {
 
     // 새 API 데이터 도착
     const newArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001' }],
-      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
+      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
     };
 
     rerender({ arrival: newArrival });

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -13,8 +13,8 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001' }],
-  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002' }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
+  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
 };
 
 const mockArrivalWithMock = {
@@ -175,8 +175,8 @@ describe('useArrivalInfo', () => {
 
   it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
     const updatedArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001' }],
-      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
     };
 
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
@@ -294,11 +294,11 @@ describe('useArrivalInfo', () => {
 
   it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
     const staleArrival = {
-      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD' }],
+      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0 }],
       down: [],
     };
     const freshArrival = {
-      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW' }],
+      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0 }],
       down: [],
     };
 
@@ -375,8 +375,8 @@ describe('useArrivalInfo', () => {
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
     const freshArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003' }],
-      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0 }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0 }],
     };
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -8,8 +8,8 @@ describe('BffArrivalProvider', () => {
   let provider: BffArrivalProvider;
 
   const VALID_DATA: StationArrival = {
-    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001' }],
-    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001' }],
+    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 }],
+    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 }],
   };
 
   function mockFetchOk(data: StationArrival) {

--- a/src/testUtils/fixtures.ts
+++ b/src/testUtils/fixtures.ts
@@ -20,6 +20,7 @@ export function makeArrivalInfo(overrides: Partial<ArrivalInfo> & { destination:
     arrivalMinutes: Math.floor(overrides.arrivalSeconds / 60),
     statusMessage: '',
     trainCode: 'T001',
+    receivedAtMs: 0,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- 서울시 지하철 실시간 도착정보 API 응답의 `recptnDt`(데이터 생성시각)와 현재시각의 차이만큼 `barvlDt`(도착예정초)를 보정
- xls 스펙 주의사항에 명시된 처리: "현재시각 - recptnDt 만큼 열차가 더 진행한 것으로 보정해서 사용해야 합니다"
- `ArrivalInfo`에 `receivedAtMs` 신선도 필드 노출 (Phase 2 Stage 2 fusion 토대)
- 비정상 drift(120s 초과)는 stale로 강등 — "곧 도착" 오표시 방지

## 효과

- 카운트다운이 폴링 5초·BFF 캐시·네트워크 시차로 들쭉날쭉 튀는 현상 해소
- Phase 2 Stage 2(arrival fusion 현재역 판정)의 신호 정확도 토대

## Test plan

- [x] `npm run type-check` 통과
- [x] `npm test` — 837 tests, 커버리지 100% (`coverageThreshold` 자동 강제)
- [x] code-review 에이전트 P1 0건
- [ ] 실기기에서 카운트다운이 매끄럽게 줄어드는지 확인 (사용자 검증)

Closes #279