### PR TITLE
fix(#280): 환승역이 곧 목적지인 경로의 0정거장 도착 노드 흡수

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "Transfer",
-    "arrivalNote": "Arrival"
+    "arrivalNote": "Arrival",
+    "transferArrivalNote": "Transfer → Arrival"
   },
   "routes": {
     "optimal": "Fastest",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "乗換",
-    "arrivalNote": "到着"
+    "arrivalNote": "到着",
+    "transferArrivalNote": "乗換 → 到着"
   },
   "routes": {
     "optimal": "最速",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "환승",
-    "arrivalNote": "도착"
+    "arrivalNote": "도착",
+    "transferArrivalNote": "환승 → 도착"
   },
   "routes": {
     "optimal": "최적경로",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "换乘",
-    "arrivalNote": "到达"
+    "arrivalNote": "到达",
+    "transferArrivalNote": "换乘 → 到达"
   },
   "routes": {
     "optimal": "最快",

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -56,6 +56,22 @@ describe('journeyDisplayToStops', () => {
   it('should return empty array for empty segments', () => {
     expect(journeyDisplayToStops({ segments: [], totalStops: 0 })).toEqual([]);
   });
+
+  it('환승역이 곧 목적지이면 도착 노드를 환승 노드에 흡수한다', () => {
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '2', lineColor: '#009D3E', fromName: '삼성', toName: '건대입구', stops: 7 },
+        { line: '7', lineColor: '#747F00', fromName: '건대입구', toName: '군자', stops: 2 },
+        { line: '5', lineColor: '#996CAC', fromName: '군자', toName: '군자', stops: 0 },
+      ],
+      totalStops: 9,
+    };
+    const stops = journeyDisplayToStops(journey);
+    expect(stops).toHaveLength(3);
+    expect(stops[0]).toEqual({ station: '삼성', line: '2', mark: 'filled' });
+    expect(stops[1]).toEqual({ station: '건대입구', line: '7', stopsFromPrev: '7정거장', mark: 'transfer', note: '환승' });
+    expect(stops[2]).toEqual({ station: '군자', line: '5', stopsFromPrev: '2정거장', mark: 'dest', note: '환승 → 도착' });
+  });
 });
 
 describe('arrivalInfoToArrivalTrain', () => {

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -60,13 +60,23 @@ export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
         note: i18next.t('journey.transferNote'),
       });
     } else {
-      stops.push({
-        station: getStationDisplayNameByName(seg.toName, allStations),
-        line: seg.line,
-        stopsFromPrev: i18next.t('route.stops', { count: seg.stops }),
-        mark: 'dest',
-        note: i18next.t('journey.arrivalNote'),
-      });
+      // 환승역이 곧 목적지인 케이스(0정거장 도착 노드 잉여)는 직전 환승 노드를 도착으로 흡수.
+      // 언어 독립성을 위해 표시명이 아닌 원본 역명(toName)으로 비교한다.
+      // stopsFromPrev는 환승 노드의 기존 값(직전 segment의 정거장 수)을 그대로 유지.
+      const prevSeg = segments[i - 1];
+      const prev = stops[stops.length - 1];
+      if (seg.stops === 0 && prev?.mark === 'transfer' && prevSeg?.toName === seg.toName) {
+        prev.mark = 'dest';
+        prev.note = i18next.t('journey.transferArrivalNote');
+      } else {
+        stops.push({
+          station: getStationDisplayNameByName(seg.toName, allStations),
+          line: seg.line,
+          stopsFromPrev: i18next.t('route.stops', { count: seg.stops }),
+          mark: 'dest',
+          note: i18next.t('journey.arrivalNote'),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Closes #280

## Summary
- 마지막 segment의 stops가 0이고 직전 환승 노드와 동일한 역인 경우, 환승 노드의 `mark`를 `dest`로 갱신하고 별도 도착 노드 push를 생략
- raw `toName` 비교로 표시명/언어에 독립적
- 새 i18n 키 `journey.transferArrivalNote` 4개 locale(ko/en/ja/zh) 추가

## Test plan
- [x] `npm test` — 831/831 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] 군자(환승=목적지) 케이스 테스트 추가
- [ ] CI `Type Check & Test` 그린 확인 후 머지