### PR TITLE
feat(#285): GPS+Arrival fusion 기반 현재역 판정 — Phase 2 Stage 2

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import { AppState, InteractionManager, Pressable, ScrollView, StyleSheet, Switch
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
-import { useNearestStation } from '../../src/hooks/useNearestStation';
+import { useFusedNearestStation } from '../../src/hooks/useFusedNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../../src/utils/formatTime';
@@ -30,7 +30,7 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useNearestStation();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useFusedNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -306,6 +306,35 @@ describe('fetchArrivalInfo', () => {
       expect(parseRecptnDt('')).toBe(0);
       expect(parseRecptnDt('not-a-date')).toBe(0);
     });
+
+    it('arvlCd: number / 숫자문자열 / 누락 / 비숫자 매핑', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: 'A', barvlDt: 60, btrainNo: 'T1', updnLine: '상행', arvlCd: 1 },
+            { trainLineNm: 'B', barvlDt: 60, btrainNo: 'T2', updnLine: '상행', arvlCd: '0' },
+            { trainLineNm: 'C', barvlDt: 60, btrainNo: 'T3', updnLine: '상행' },
+            { trainLineNm: 'D', barvlDt: 60, btrainNo: 'T4', updnLine: '상행', arvlCd: 'abc' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남', { maxPerDirection: 4 });
+      expect(result.up.map((i) => i.arrivalCode)).toEqual([1, 0, -1, -1]);
+    });
+
+    it('realtimeArrivalList가 빈 배열이면 Mock으로 fallback', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ realtimeArrivalList: [] }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.isMock).toBe(true);
+    });
   });
 
   it('trainLineNm, barvlDt, btrainNo가 undefined이면 기본값을 사용한다', async () => {

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -10,6 +10,11 @@ export interface ArrivalInfo {
   trainCode: string;
   /** 데이터 생성 시각(epoch ms). 0이면 알 수 없음(mock 또는 누락). Stage 2 fusion 신호 신선도 판정용. */
   receivedAtMs: number;
+  /**
+   * arvlCd 응답값 — 0:진입, 1:도착, 2:출발, 3:전역출발, 4:전역진입, 5:전역도착, 99:운행중.
+   * 누락/비숫자는 -1. fusion 우선순위 판정에 사용 (constants/arrivalCodes.ts).
+   */
+  arrivalCode: number;
 }
 
 export interface StationArrival {
@@ -20,12 +25,12 @@ export interface StationArrival {
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
-    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 },
-    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0 },
+    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0, arrivalCode: -1 },
   ],
   down: [
-    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 },
-    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0 },
+    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0, arrivalCode: -1 },
   ],
   isMock: true,
 });
@@ -94,6 +99,12 @@ export async function fetchArrivalInfo(
       const receivedAtMs = isStale ? 0 : parsedRecvMs;
       const driftSec = isStale ? 0 : Math.max(0, rawDriftSec);
       const seconds = Math.max(0, Math.round(rawSeconds - driftSec));
+      const parsedCode =
+        typeof item.arvlCd === 'number'
+          ? item.arvlCd
+          : typeof item.arvlCd === 'string'
+            ? Number.parseInt(item.arvlCd, 10)
+            : NaN;
       const info: ArrivalInfo = {
         destination: item.trainLineNm ?? '',
         arrivalMinutes: Math.floor(seconds / 60),
@@ -101,6 +112,7 @@ export async function fetchArrivalInfo(
         statusMessage: item.arvlMsg2 ?? '',
         trainCode: item.btrainNo ?? '',
         receivedAtMs,
+        arrivalCode: Number.isFinite(parsedCode) ? parsedCode : -1,
       };
       if (UP_DIRECTION_VALUES.includes(item.updnLine)) {
         up.push(info);

--- a/src/constants/__tests__/arrivalCodes.test.ts
+++ b/src/constants/__tests__/arrivalCodes.test.ts
@@ -1,0 +1,35 @@
+import { ARRIVAL_CODE, getArrivalPriority } from '../arrivalCodes';
+
+describe('arrivalCodes', () => {
+  it('ARRIVAL_CODE 매핑이 xls 스펙과 일치한다', () => {
+    expect(ARRIVAL_CODE.ENTERING).toBe(0);
+    expect(ARRIVAL_CODE.ARRIVED).toBe(1);
+    expect(ARRIVAL_CODE.DEPARTED).toBe(2);
+    expect(ARRIVAL_CODE.PREV_DEPARTED).toBe(3);
+    expect(ARRIVAL_CODE.PREV_ENTERING).toBe(4);
+    expect(ARRIVAL_CODE.PREV_ARRIVED).toBe(5);
+    expect(ARRIVAL_CODE.RUNNING).toBe(99);
+  });
+
+  it('getArrivalPriority: 1(도착) > 0(진입) > 5(전역도착) > 4(전역진입)', () => {
+    expect(getArrivalPriority(ARRIVAL_CODE.ARRIVED)).toBeGreaterThan(
+      getArrivalPriority(ARRIVAL_CODE.ENTERING),
+    );
+    expect(getArrivalPriority(ARRIVAL_CODE.ENTERING)).toBeGreaterThan(
+      getArrivalPriority(ARRIVAL_CODE.PREV_ARRIVED),
+    );
+    expect(getArrivalPriority(ARRIVAL_CODE.PREV_ARRIVED)).toBeGreaterThan(
+      getArrivalPriority(ARRIVAL_CODE.PREV_ENTERING),
+    );
+    expect(getArrivalPriority(ARRIVAL_CODE.PREV_ENTERING)).toBeGreaterThan(0);
+  });
+
+  it('getArrivalPriority: 출발/전역출발/운행중/누락은 0', () => {
+    expect(getArrivalPriority(ARRIVAL_CODE.DEPARTED)).toBe(0);
+    expect(getArrivalPriority(ARRIVAL_CODE.PREV_DEPARTED)).toBe(0);
+    expect(getArrivalPriority(ARRIVAL_CODE.RUNNING)).toBe(0);
+    expect(getArrivalPriority(undefined)).toBe(0);
+    expect(getArrivalPriority(-1)).toBe(0);
+    expect(getArrivalPriority(42)).toBe(0);
+  });
+});

--- a/src/constants/arrivalCodes.ts
+++ b/src/constants/arrivalCodes.ts
@@ -1,0 +1,29 @@
+/**
+ * 서울 열린데이터 API `realtimeStationArrival` arvlCd 응답값.
+ * 스펙: scripts/서울시+지하철+실시간+도착정보.xls
+ */
+export const ARRIVAL_CODE = {
+  ENTERING: 0, // 진입 — 사용자 ≈ 해당 역 (수 초 내)
+  ARRIVED: 1, // 도착 — 사용자 = 해당 역에 있음 (확정)
+  DEPARTED: 2, // 출발
+  PREV_DEPARTED: 3, // 전역 출발
+  PREV_ENTERING: 4, // 전역 진입
+  PREV_ARRIVED: 5, // 전역 도착
+  RUNNING: 99, // 운행중
+} as const;
+
+/**
+ * fusion 판정 우선순위 (높을수록 강한 신호).
+ * 1(도착) > 0(진입) > 5(전역도착) > 4(전역진입) > 그외 0.
+ * 그외(2 출발, 3 전역출발, 99 운행중)는 "현재 위치" 신호로 부적합 → 0.
+ */
+const PRIORITY_BY_CODE: Record<number, number> = {
+  [ARRIVAL_CODE.ARRIVED]: 100,
+  [ARRIVAL_CODE.ENTERING]: 80,
+  [ARRIVAL_CODE.PREV_ARRIVED]: 50,
+  [ARRIVAL_CODE.PREV_ENTERING]: 40,
+};
+
+export function getArrivalPriority(code: number | undefined): number {
+  return PRIORITY_BY_CODE[code ?? -1] ?? 0;
+}

--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -3,8 +3,8 @@ import { useArrivalCountdown } from '../useArrivalCountdown';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const mockArrival: StationArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
-  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
 };
 
 const mockArrivalMock: StationArrival = {
@@ -53,7 +53,7 @@ describe('useArrivalCountdown', () => {
 
   it('arrivalSeconds가 0 이하로 내려가지 않는다', () => {
     const nearArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
       down: [],
     };
 
@@ -84,8 +84,8 @@ describe('useArrivalCountdown', () => {
 
     // 새 API 데이터 도착
     const newArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
-      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
     };
 
     rerender({ arrival: newArrival });

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { AppState } from 'react-native';
-import { useArrivalInfo } from '../useArrivalInfo';
+import { useArrivalInfo, __resetArrivalCacheForTests } from '../useArrivalInfo';
 import * as arrivalApiModule from '../../api/arrivalApi';
 
 jest.mock('../../api/arrivalApi');
@@ -13,8 +13,8 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
-  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
 };
 
 const mockArrivalWithMock = {
@@ -27,6 +27,7 @@ describe('useArrivalInfo', () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     appStateCallback = null;
+    __resetArrivalCacheForTests();
   });
 
   afterEach(() => {
@@ -175,8 +176,8 @@ describe('useArrivalInfo', () => {
 
   it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
     const updatedArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
-      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
     };
 
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
@@ -294,11 +295,11 @@ describe('useArrivalInfo', () => {
 
   it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
     const staleArrival = {
-      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0 }],
+      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0, arrivalCode: -1 }],
       down: [],
     };
     const freshArrival = {
-      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0 }],
+      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0, arrivalCode: -1 }],
       down: [],
     };
 
@@ -375,8 +376,8 @@ describe('useArrivalInfo', () => {
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
     const freshArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0 }],
-      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0, arrivalCode: -1 }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0, arrivalCode: -1 }],
     };
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../useArrivalInfo';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import { MOCK_STATIONS } from '../../testUtils/fixtures';
+import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+
+jest.mock('../useNearestStation');
+jest.mock('../useArrivalInfo');
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+
+const mockUseNearest = useNearestStation as jest.Mock;
+const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+function gpsBase(overrides?: Record<string, unknown>) {
+  return {
+    result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+    variants: [MOCK_STATIONS.gangnam],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 1,
+    accuracyMeters: 50,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    refresh: jest.fn(),
+    ...overrides,
+  };
+}
+
+function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: 'X',
+    arrivalMinutes: 0,
+    arrivalSeconds: 0,
+    statusMessage: '',
+    trainCode: 'T1',
+    receivedAtMs: 1_700_000_000_000,
+    arrivalCode,
+    ...overrides,
+  };
+}
+
+function arrivalRet(stationArrival: StationArrival | null = null) {
+  return { arrival: stationArrival, loading: false, isMock: false };
+}
+
+describe('useFusedNearestStation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+  });
+
+  it('userLocation null이면 후보 없음 → GPS 결과 그대로 + gps-only', () => {
+    mockUseNearest.mockReturnValue(gpsBase({ userLocation: null, result: null }));
+    mockFindTop.mockReturnValue([]);
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.confidence).toBe('gps-only');
+  });
+
+  it('arrival 신호 없으면 GPS 최근접 + gps-only', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
+    ]);
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result.current.confidence).toBe('gps-only');
+  });
+
+  it('인접 후보 arvlCd=1이면 그 역으로 fusion 전환', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
+      { station: MOCK_STATIONS.yeouinaru, distanceKm: 0.5 },
+    ]);
+
+    // 후보 0,1,2 순서대로 useArrivalInfo 호출됨
+    mockUseArrival
+      .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.RUNNING)], down: [] }))
+      .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }))
+      .mockReturnValueOnce(arrivalRet(null));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.result?.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+    expect(result.current.confidence).toBe('arrival-confirmed');
+  });
+
+  it('GPS 원본은 gpsResult로 노출된다 (디버깅용)', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+  });
+
+  it('GPS pass-through 필드들(loading/error/permissionDenied/refresh 등)이 보존된다', () => {
+    const refresh = jest.fn();
+    mockUseNearest.mockReturnValue(
+      gpsBase({ loading: true, error: 'GPS err', permissionDenied: true, refresh }),
+    );
+    mockFindTop.mockReturnValue([]);
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBe('GPS err');
+    expect(result.current.permissionDenied).toBe(true);
+    expect(result.current.refresh).toBe(refresh);
+    expect(result.current.variants).toEqual([MOCK_STATIONS.gangnam]);
+    expect(result.current.userLocation).toEqual({ lat: 37.5, lng: 127.0 });
+    expect(result.current.speedMps).toBe(1);
+    expect(result.current.accuracyMeters).toBe(50);
+  });
+});

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -8,6 +8,17 @@ import { usePolling } from './usePolling';
 const POLL_INTERVAL_MS = 5_000;
 const CACHE_TTL_MS = 30_000;
 
+/**
+ * 모듈 스코프 싱글톤 — fusion에서 동일 station name을 여러 hook 인스턴스가 폴링할 때
+ * 중복 네트워크 호출을 막기 위한 공유 캐시.
+ */
+const arrivalCache = new TtlCache<string, StationArrival>(CACHE_TTL_MS);
+
+/** 테스트 격리용 — useArrivalInfo 사용처 외에는 호출하지 말 것. */
+export function __resetArrivalCacheForTests(): void {
+  arrivalCache.clear();
+}
+
 function arrivalEqual(a: StationArrival | null, b: StationArrival): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
@@ -24,7 +35,6 @@ export function useArrivalInfo(
 ): UseArrivalInfoReturn {
   const [arrival, setArrival] = useState<StationArrival | null>(null);
   const [loading, setLoading] = useState(false);
-  const cacheRef = useRef(new TtlCache<string, StationArrival>(CACHE_TTL_MS));
   const providerRef = useRef<ArrivalProvider>(provider ?? createArrivalProvider());
   const arrivalRef = useRef<StationArrival | null>(null);
   const stationNameRef = useRef(stationName);
@@ -45,7 +55,7 @@ export function useArrivalInfo(
       return;
     }
 
-    const cached = cacheRef.current.get(stationName);
+    const cached = arrivalCache.get(stationName);
     if (cached) {
       updateArrival(cached);
       setLoading(false);
@@ -66,7 +76,7 @@ export function useArrivalInfo(
         const data = await providerRef.current.getArrival(stationName);
         if (cancelled) return;
         if (!data.isMock) {
-          cacheRef.current.set(stationName, data);
+          arrivalCache.set(stationName, data);
         }
         updateArrival(data);
       } catch {
@@ -90,14 +100,14 @@ export function useArrivalInfo(
       providerRef.current.getArrival(name).then((data) => {
         if (name !== stationNameRef.current) return;
         if (!data.isMock) {
-          cacheRef.current.set(name, data);
+          arrivalCache.set(name, data);
         }
         updateArrival(data);
         setLoading(false);
       }).catch(() => {});
     },
     POLL_INTERVAL_MS,
-    { onResume: () => cacheRef.current.clear() },
+    { onResume: () => arrivalCache.clear() },
   );
 
   return { arrival, loading, isMock: arrival?.isMock ?? false };

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { useNearestStation } from './useNearestStation';
+import { useArrivalInfo } from './useArrivalInfo';
+import { findTopNearestStations } from '../utils/findNearestStation';
+import { pickFusedStation, type FusionConfidence } from '../utils/pickFusedStation';
+import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import type { NearestStationResult, Station } from '../types/station';
+import type { ArrivalProvider } from '../providers/types';
+
+/**
+ * fusion 후보 개수. K=3 고정 — Rules of Hooks로 useArrivalInfo를 동적 개수로 호출할 수 없어
+ * 명시적으로 풀어 쓴다(c0/c1/c2). 변경 시 본 파일의 hook 호출 라인도 함께 수정 필요.
+ * 호출 비용은 useArrivalInfo의 모듈 스코프 캐시(arrivalCache)가 station name 단위로 dedup.
+ */
+const FUSION_CANDIDATE_LIMIT = 3;
+
+interface UseFusedNearestStationReturn {
+  /** GPS+arrival fusion으로 결정된 현재역. */
+  result: NearestStationResult | null;
+  /** GPS 원본 result — 비교/디버깅용. */
+  gpsResult: NearestStationResult | null;
+  /** fusion 신뢰도. arrival 신호로 확정/추정/없음. */
+  confidence: FusionConfidence;
+  /** GPS 환승역 변형(같은 이름 다른 노선) — 기존 useNearestStation 호환. */
+  variants: Station[];
+  userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
+  accuracyMeters: number | null;
+  loading: boolean;
+  error: string | null;
+  permissionDenied: boolean;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * GPS 후보 상위 N개에 대해 realtimeStationArrival을 동시 폴링하고,
+ * arvlCd 우선순위로 현재역을 fusion해 반환한다.
+ *
+ * 지하 구간 GPS 지연(이미 도착한 역인데 전역 표시)을 우회하는 것이 목적.
+ * arrival 신호가 모두 약하면 GPS 최근접으로 자연 fallback.
+ */
+export function useFusedNearestStation(
+  provider?: ArrivalProvider,
+): UseFusedNearestStationReturn {
+  const gps = useNearestStation();
+
+  // GPS 좌표 → 거리순 후보 N개. 좌표 갱신 시에만 재계산.
+  const candidates = useMemo<NearestStationResult[]>(() => {
+    if (!gps.userLocation) return [];
+    return findTopNearestStations(
+      gps.userLocation.lat,
+      gps.userLocation.lng,
+      FUSION_CANDIDATE_LIMIT,
+      MAX_STATION_DISTANCE_KM,
+    );
+  }, [gps.userLocation]);
+
+  // 후보 K개에 대한 arrival 폴링 — hooks는 고정 순서 호출이 필요하므로 N=3 고정.
+  // 후보 부족 시 null로 호출 → useArrivalInfo 내부에서 no-op.
+  const c0 = candidates[0]?.station.name ?? null;
+  const c1 = candidates[1]?.station.name ?? null;
+  const c2 = candidates[2]?.station.name ?? null;
+  const a0 = useArrivalInfo(c0, provider);
+  const a1 = useArrivalInfo(c1, provider);
+  const a2 = useArrivalInfo(c2, provider);
+
+  const fused = useMemo(() => {
+    if (candidates.length === 0) return null;
+    const arrivals = [a0.arrival, a1.arrival, a2.arrival];
+    return pickFusedStation(
+      candidates.map((cand, i) => ({ candidate: cand, arrival: arrivals[i] ?? null })),
+    );
+  }, [candidates, a0.arrival, a1.arrival, a2.arrival]);
+
+  return {
+    result: fused?.result ?? gps.result,
+    gpsResult: gps.result,
+    confidence: fused?.confidence ?? 'gps-only',
+    variants: gps.variants,
+    userLocation: gps.userLocation,
+    speedMps: gps.speedMps,
+    accuracyMeters: gps.accuracyMeters,
+    loading: gps.loading,
+    error: gps.error,
+    permissionDenied: gps.permissionDenied,
+    refresh: gps.refresh,
+  };
+}

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -8,8 +8,8 @@ describe('BffArrivalProvider', () => {
   let provider: BffArrivalProvider;
 
   const VALID_DATA: StationArrival = {
-    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 }],
-    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 }],
+    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 }],
+    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 }],
   };
 
   function mockFetchOk(data: StationArrival) {

--- a/src/testUtils/fixtures.ts
+++ b/src/testUtils/fixtures.ts
@@ -21,6 +21,7 @@ export function makeArrivalInfo(overrides: Partial<ArrivalInfo> & { destination:
     statusMessage: '',
     trainCode: 'T001',
     receivedAtMs: 0,
+    arrivalCode: -1,
     ...overrides,
   };
 }

--- a/src/utils/__tests__/findNearestStation.test.ts
+++ b/src/utils/__tests__/findNearestStation.test.ts
@@ -1,4 +1,4 @@
-import { findNearestStation, findNearestStations } from '../findNearestStation';
+import { findNearestStation, findNearestStations, findTopNearestStations } from '../findNearestStation';
 
 // haversine을 모킹하여 어떤 역이 가장 가깝게 계산되는지 완전히 제어한다.
 // stations.json 데이터가 크므로 haversine 결과를 고정하여 루프 분기를 독립적으로 검증한다.
@@ -184,5 +184,45 @@ describe('findNearestStations', () => {
     expect(result).not.toBeNull();
     expect(result!.distanceKm).toBe(0.2);
     expect(result!.variants.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('findTopNearestStations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('limit=0이면 빈 배열을 반환한다', () => {
+    mockHaversine.mockReturnValue(0.1);
+    expect(findTopNearestStations(37.5, 127.0, 0)).toEqual([]);
+  });
+
+  it('거리순 상위 N개를 반환하되 같은 이름 환승역은 한 번만 포함된다', () => {
+    // 모든 호출에 distance를 호출 인덱스 비례로 할당해 정렬 검증.
+    let calls = 0;
+    mockHaversine.mockImplementation(() => {
+      calls += 1;
+      return calls * 0.01;
+    });
+
+    const result = findTopNearestStations(37.5, 127.0, 3);
+
+    expect(result.length).toBe(3);
+    expect(result[0].distanceKm).toBeLessThanOrEqual(result[1].distanceKm);
+    expect(result[1].distanceKm).toBeLessThanOrEqual(result[2].distanceKm);
+    const names = result.map((r) => r.station.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('maxDistanceKm 초과 항목은 제외된다', () => {
+    mockHaversine.mockReturnValue(5);
+    expect(findTopNearestStations(37.5, 127.0, 3, 1.0)).toEqual([]);
+  });
+
+  it('실데이터 528개보다 limit가 크면 가능한 만큼만 반환된다', () => {
+    mockHaversine.mockReturnValue(0.1);
+    const result = findTopNearestStations(37.5, 127.0, 9999, 1.0);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThan(9999);
   });
 });

--- a/src/utils/__tests__/pickFusedStation.test.ts
+++ b/src/utils/__tests__/pickFusedStation.test.ts
@@ -1,0 +1,115 @@
+import { pickFusedStation } from '../pickFusedStation';
+import type { NearestStationResult } from '../../types/station';
+import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import { MOCK_STATIONS } from '../../testUtils/fixtures';
+
+const NOW = 1_700_000_000_000; // 신선한 receivedAtMs
+
+function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: 'X',
+    arrivalMinutes: 0,
+    arrivalSeconds: 0,
+    statusMessage: '',
+    trainCode: 'T1',
+    receivedAtMs: NOW,
+    arrivalCode,
+    ...overrides,
+  };
+}
+
+function arrival(...codes: number[]): StationArrival {
+  return { up: codes.map((c) => info(c)), down: [] };
+}
+
+function cand(stationKey: keyof typeof MOCK_STATIONS, distanceKm: number): NearestStationResult {
+  return { station: MOCK_STATIONS[stationKey], distanceKm };
+}
+
+describe('pickFusedStation', () => {
+  it('빈 후보면 null', () => {
+    expect(pickFusedStation([])).toBeNull();
+  });
+
+  it('arrival 신호 없으면 GPS 최근접 + gps-only', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: null },
+      { candidate: cand('chungmuro', 0.3), arrival: null },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result?.confidence).toBe('gps-only');
+    expect(result?.source).toBe('gps');
+  });
+
+  it('arvlCd=1(도착)인 후보가 있으면 GPS 최근접보다 우선', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.RUNNING) },
+      { candidate: cand('chungmuro', 0.3), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+    expect(result?.confidence).toBe('arrival-confirmed');
+    expect(result?.source).toBe('arrival');
+  });
+
+  it('arvlCd=0(진입)은 arrival-arriving 신뢰도', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ENTERING) },
+    ]);
+    expect(result?.confidence).toBe('arrival-arriving');
+    expect(result?.source).toBe('arrival');
+  });
+
+  it('1(도착) > 0(진입) 우선순위', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ENTERING) },
+      { candidate: cand('chungmuro', 0.3), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+  });
+
+  it('mock 데이터(isMock)는 신호로 사용되지 않는다', () => {
+    const mockArrival: StationArrival = { ...arrival(ARRIVAL_CODE.ARRIVED), isMock: true };
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: null },
+      { candidate: cand('chungmuro', 0.3), arrival: mockArrival },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result?.source).toBe('gps');
+  });
+
+  it('receivedAtMs=0(stale)인 신호는 무시된다', () => {
+    const stale: StationArrival = { up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: 0 })], down: [] };
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: null },
+      { candidate: cand('chungmuro', 0.3), arrival: stale },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result?.source).toBe('gps');
+  });
+
+  it('동점이면 먼저 발견된 후보 유지(첫 항목 = GPS 최근접)', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+      { candidate: cand('chungmuro', 0.3), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+  });
+
+  it('출발(2)/전역출발(3)/운행중(99)은 신호 점수 0', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.DEPARTED, ARRIVAL_CODE.RUNNING) },
+    ]);
+    expect(result?.confidence).toBe('gps-only');
+    expect(result?.source).toBe('gps');
+  });
+
+  it('up/down 모두에서 최댓값을 찾는다', () => {
+    const mixed: StationArrival = {
+      up: [info(ARRIVAL_CODE.ENTERING)],
+      down: [info(ARRIVAL_CODE.ARRIVED)],
+    };
+    const result = pickFusedStation([{ candidate: cand('gangnam', 0.1), arrival: mixed }]);
+    expect(result?.confidence).toBe('arrival-confirmed');
+  });
+});

--- a/src/utils/findNearestStation.ts
+++ b/src/utils/findNearestStation.ts
@@ -42,3 +42,30 @@ export function findNearestStations(
     isTransfer: variants.length > 1,
   };
 }
+
+/**
+ * 사용자 좌표 기준 거리순 상위 N개 역(이름 중복 제거 — 환승역은 한 번만).
+ * fusion 후보 추출에 사용. 거리 기준이지 노선 기준이 아니다.
+ */
+export function findTopNearestStations(
+  lat: number,
+  lng: number,
+  limit: number,
+  maxDistanceKm?: number,
+): NearestStationResult[] {
+  if (limit <= 0) return [];
+  const ranked = stations
+    .map((s) => ({ station: s, distanceKm: haversine(lat, lng, s.lat, s.lng) }))
+    .filter((r) => maxDistanceKm == null || r.distanceKm <= maxDistanceKm)
+    .sort((a, b) => a.distanceKm - b.distanceKm);
+
+  const seen = new Set<string>();
+  const out: NearestStationResult[] = [];
+  for (const r of ranked) {
+    if (seen.has(r.station.name)) continue;
+    seen.add(r.station.name);
+    out.push(r);
+    if (out.length >= limit) break;
+  }
+  return out;
+}

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -1,0 +1,81 @@
+import type { NearestStationResult } from '../types/station';
+import type { StationArrival } from '../api/arrivalApi';
+import { getArrivalPriority } from '../constants/arrivalCodes';
+
+/**
+ * fusion 결과 신뢰도 — UI/로깅용. arrival 신호로 확정/추정된 경우 GPS-only보다 신선.
+ */
+export type FusionConfidence = 'arrival-confirmed' | 'arrival-arriving' | 'gps-only';
+
+export interface FusedStationResult {
+  result: NearestStationResult;
+  confidence: FusionConfidence;
+  source: 'arrival' | 'gps';
+}
+
+interface CandidateArrival {
+  candidate: NearestStationResult;
+  arrival: StationArrival | null;
+}
+
+/**
+ * recptnDt 보정 거친 신호 중 가장 강한 priority 점수를 반환.
+ * mock/누락(receivedAtMs=0) 신호는 무시 — Stage 1에서 stale로 강등됨.
+ */
+function bestPriorityForArrival(arrival: StationArrival | null): number {
+  if (!arrival || arrival.isMock) return 0;
+  let best = 0;
+  for (const list of [arrival.up, arrival.down]) {
+    for (const info of list) {
+      if (info.receivedAtMs <= 0) continue;
+      const p = getArrivalPriority(info.arrivalCode);
+      if (p > best) best = p;
+    }
+  }
+  return best;
+}
+
+function confidenceFromPriority(priority: number): FusionConfidence {
+  if (priority >= 100) return 'arrival-confirmed'; // arvlCd=1 도착
+  if (priority > 0) return 'arrival-arriving';
+  return 'gps-only';
+}
+
+/**
+ * 후보 역들의 arrival 신호로 fusion한 현재역을 결정한다.
+ *
+ * 입력 계약: candidates는 거리 오름차순 — `[0]`이 GPS 최근접이어야 함.
+ *  (동점 시 거리 가까운 쪽이 자동 선택되도록 순회 순서로 invariant 유지)
+ *
+ * 규칙:
+ * 1) priority 점수 최댓값을 가진 후보 선택 (arvlCd 1 > 0 > 5 > 4)
+ * 2) 동점이면 더 먼저 들어온(=거리 가까운) 후보 유지
+ * 3) 모두 0이면 GPS 최근접(=candidates[0]) 사용
+ * 4) 후보가 비어있으면 null 반환 — 호출자가 GPS-only 분기로 fallback
+ */
+export function pickFusedStation(
+  candidates: CandidateArrival[],
+): FusedStationResult | null {
+  if (candidates.length === 0) return null;
+
+  let winner = candidates[0];
+  let winnerPriority = bestPriorityForArrival(winner.arrival);
+
+  for (let i = 1; i < candidates.length; i++) {
+    const p = bestPriorityForArrival(candidates[i].arrival);
+    if (p > winnerPriority) {
+      winner = candidates[i];
+      winnerPriority = p;
+    }
+  }
+
+  const source = winnerPriority > 0 ? 'arrival' : 'gps';
+  // arrival 신호가 없으면 GPS 최근접(=candidates[0])이 정답.
+  const finalResult = source === 'arrival' ? winner.candidate : candidates[0].candidate;
+
+  return {
+    result: finalResult,
+    confidence: confidenceFromPriority(winnerPriority),
+    source,
+  };
+}


### PR DESCRIPTION
## Summary

- 지하 구간 GPS 5~30초 지연으로 "이미 도착한 역"이 늦게 갱신되던 문제 해결
- 서울시 실시간 도착정보 API의 \`arvlCd\` (도착코드) 신호를 GPS 후보 상위 3개와 fusion해 GPS 지연 우회
- arrival 신호 우선순위: \`1(도착)\` > \`0(진입)\` > \`5(전역도착)\` > \`4(전역진입)\` > GPS 최근접
- HomeScreen만 적용, map.tsx는 GPS-only 유지 (회귀 표면적 최소화)
- \`useArrivalInfo\` 캐시를 모듈 스코프 싱글톤으로 승격해 fusion N개 폴링 시 동일 역 중복 호출 방지
- code-review P1 2건(캐시 미공유, 거짓 일반화) 반영

## Test plan

- [x] \`npm run type-check\` 통과
- [x] \`npm test\` — 60 suites / 861 tests, 커버리지 100%
- [x] code-review P1 0건
- [ ] 실기기 지하 구간 갱신 latency 측정 (목표: 30s → 5s)
- [ ] API 키 미설정 환경에서 GPS 단독 동작 회귀 확인

Closes #285