### PR TITLE
feat(#287): Arrival fusion 기반 알람 보조 트리거 — Phase 2 Stage 3

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -30,7 +30,7 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useFusedNearestStation();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh, confidence } = useFusedNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
@@ -131,6 +131,7 @@ export default function HomeScreen() {
     userLocation,
     speedMps,
     accuracyMeters,
+    arrivalConfidence: confidence,
   });
   useBackgroundLocation(destination);
 

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -137,6 +137,96 @@ describe('useStationAlarm', () => {
     expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
   });
 
+  describe('arrival fusion 보조 트리거 (Stage 3)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const onRouteStation = makeStation('S2-DST', '강남'); // route+dest 매칭
+
+    it('GPS 게이트 차단 + arrivalConfidence=arrival-confirmed → station-passed 알람 발화', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500, // GPS 게이트 차단
+            arrivalConfidence: 'arrival-confirmed',
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // Phase 알람은 GPS 필요하므로 호출 안 됨
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('GPS 게이트 차단 + arrivalConfidence=arrival-arriving → 발화 안 함 (확정 아님)', () => {
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'arrival-arriving',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('GPS 게이트 차단 + arrivalConfidence=gps-only → 발화 안 함 (회귀 안전)', () => {
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'gps-only',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('GPS 통과 + arrivalConfidence 없음(undefined) → Phase + station-passed 모두 평가 (backward compat)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+            // arrivalConfidence 미전달
+          }),
+        ),
+      );
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+
+    it('arrival-confirmed 트리거도 lastNotifiedStationId dedup 적용 (GPS와 중복 발화 방지)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'arrival-confirmed',
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockLogSuppressedDedupStation).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
   it('builds AlarmSource and calls evaluator', () => {
     const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() =>

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -15,6 +15,7 @@ import {
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 import { isAccuracyAcceptable } from '../utils/locationGates';
+import type { FusionConfidence } from '../utils/pickFusedStation';
 
 const logger = createLogger('StationAlarm');
 
@@ -25,6 +26,12 @@ export interface UseStationAlarmInputs {
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
   accuracyMeters: number | null;
+  /**
+   * useFusedNearestStation의 신뢰도. 'arrival-confirmed'(arvlCd=1 도착 신호)면
+   * GPS accuracy 게이트가 막혀도 station-passed 알람을 발화한다 — 지하 깊은 구간
+   * (accuracy > 200m) 알람 누락 해소. ETA 기반 phase 알람은 거리 계산이 필요해 GPS 게이트 유지.
+   */
+  arrivalConfidence?: FusionConfidence;
 }
 
 export function useStationAlarm({
@@ -34,6 +41,7 @@ export function useStationAlarm({
   userLocation,
   speedMps,
   accuracyMeters,
+  arrivalConfidence,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
@@ -64,37 +72,45 @@ export function useStationAlarm({
     // 알람 경로는 표시 경로보다 엄격한 정확도 게이트(MAX_ACCURACY_M=200m)를 적용한다.
     // useNearestStation은 지하 구간에서 정확도 1500m까지 표시용으로 수용하므로,
     // 그대로 알람을 울리면 잘못된 역에서 false alarm이 발생한다.
-    if (!isAccuracyAcceptable(accuracyMeters)) return;
+    // 단, arrivalConfidence='arrival-confirmed'(arvlCd=1 도착)는 선로 신호 기반이라
+    // GPS 게이트가 막혀도 station-passed 알람은 허용한다(지하 누락 해소).
+    const accuracyOk = isAccuracyAcceptable(accuracyMeters);
+    const arrivalConfirmed = arrivalConfidence === 'arrival-confirmed';
+    if (!accuracyOk && !arrivalConfirmed) return;
 
-    let etaSeconds: number | null = null;
-    if (userLocation) {
-      const distM = distanceMetersBetween(
-        userLocation.lat,
-        userLocation.lng,
-        destination.lat,
-        destination.lng,
-      );
-      etaSeconds = estimateEtaSeconds(distM, speedMps);
-    }
-
-    const event = evaluateAlarmPhase(
-      { route, destinationName: destination.name, etaSeconds },
-      firedAlarmsRef.current,
-    );
-    if (event) {
-      firedAlarmsRef.current.add(alarmKey(event));
-      if (sleepModeRef.current) {
-        setAlarmEvent(event);
+    // Phase 알람은 ETA 거리 계산이 필요해 GPS 게이트가 통과한 경우에만 평가한다.
+    if (accuracyOk) {
+      let etaSeconds: number | null = null;
+      if (userLocation) {
+        const distM = distanceMetersBetween(
+          userLocation.lat,
+          userLocation.lng,
+          destination.lat,
+          destination.lng,
+        );
+        etaSeconds = estimateEtaSeconds(distM, speedMps);
       }
-      sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
-        logger.error('알람 알림 실패:', e),
+
+      const event = evaluateAlarmPhase(
+        { route, destinationName: destination.name, etaSeconds },
+        firedAlarmsRef.current,
       );
-      logFiredAlarm('fg', event);
+      if (event) {
+        firedAlarmsRef.current.add(alarmKey(event));
+        if (sleepModeRef.current) {
+          setAlarmEvent(event);
+        }
+        sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
+          logger.error('알람 알림 실패:', e),
+        );
+        logFiredAlarm('fg', event);
+      }
     }
 
     // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
     // 알림 상태는 notificationState 모듈(AsyncStorage)을 단일 출처로 사용해
-    // Foreground/Background 양쪽에서 동일한 dedup이 적용된다.
+    // Foreground/Background 양쪽에서 동일한 dedup이 적용된다 — GPS·arrival 양쪽 트리거가
+    // 같은 역에 대해 중복 발화하지 않는다.
     // cancellation: 효과 cleanup이 cancelled를 true로 만들어 stale IIFE를 중단시킨다.
     // A→B→A 빠른 변동 시 이전 IIFE들이 cancelled로 차단되고 최신 candidate만 알림을 보낸다.
     if (nearestStation && route && isStationOnRoute(nearestStation, route)) {
@@ -140,5 +156,6 @@ export function useStationAlarm({
     userLocation?.lng,
     speedMps,
     accuracyMeters,
+    arrivalConfidence,
   ]);
 }


### PR DESCRIPTION
## Summary

- 지하 깊은 구간(시청·종각 등)에서 GPS accuracy > 200m로 알람 게이트가 영구 차단되던 문제 해결
- \`arvlCd=1\`(도착) 신호를 station-passed 알람의 보조 트리거로 추가 — 선로 신호 기반이라 GPS와 독립
- Phase 알람은 ETA 거리 계산 필요해 GPS 게이트 유지, station-passed만 GPS OR arrival-confirmed
- \`arrival-arriving\`은 거부 — arvlCd=1 확정 신호만 허용 (보수적, false alarm 최소)
- dedup은 \`lastNotifiedStationId\` 단일 AsyncStorage 출처로 GPS·arrival 양쪽 통합
- code-review P1 1건 (FusionConfidence 타입 SSOT) 반영

## 효과

이슈 #276이 처음 제기한 "지하 알람 누락" 케이스 마감. Phase 2 4단계 중 가장 사용자 가시성 높은 변경.

## Test plan

- [x] \`npm run type-check\` 통과
- [x] \`npm test\` — 60 suites / 867 tests, 커버리지 100%
- [x] code-review P1 0건
- [ ] 실기기 지하 구간 알람 발화 확인 (시청·종각·을지로입구)
- [ ] arrival API 키 미설정 환경에서 회귀 안전 (arrivalConfidence='gps-only' → 기존 동작)

Closes #287