### PR TITLE
feat(#289): 도착정보 UI 메타 배지 (막차/급행/진입) — Phase 2 Stage 4

### DIFF
--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -325,6 +325,42 @@ describe('fetchArrivalInfo', () => {
       expect(result.up.map((i) => i.arrivalCode)).toEqual([1, 0, -1, -1]);
     });
 
+    it('lstcarAt: "1" 또는 1 → isLastTrain true, 그외 false', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: 'A', barvlDt: 60, btrainNo: 'T1', updnLine: '상행', lstcarAt: '1' },
+            { trainLineNm: 'B', barvlDt: 60, btrainNo: 'T2', updnLine: '상행', lstcarAt: 1 },
+            { trainLineNm: 'C', barvlDt: 60, btrainNo: 'T3', updnLine: '상행', lstcarAt: '0' },
+            { trainLineNm: 'D', barvlDt: 60, btrainNo: 'T4', updnLine: '상행' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남', { maxPerDirection: 4 });
+      expect(result.up.map((i) => i.isLastTrain)).toEqual([true, true, false, false]);
+    });
+
+    it('btrainSttus → trainType 매핑', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: 'A', barvlDt: 60, btrainNo: 'T1', updnLine: '상행', btrainSttus: '급행' },
+            { trainLineNm: 'B', barvlDt: 60, btrainNo: 'T2', updnLine: '상행', btrainSttus: 'ITX' },
+            { trainLineNm: 'C', barvlDt: 60, btrainNo: 'T3', updnLine: '상행', btrainSttus: '특급' },
+            { trainLineNm: 'D', barvlDt: 60, btrainNo: 'T4', updnLine: '상행' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남', { maxPerDirection: 4 });
+      expect(result.up.map((i) => i.trainType)).toEqual(['express', 'itx', 'rapid', 'normal']);
+    });
+
     it('realtimeArrivalList가 빈 배열이면 Mock으로 fallback', async () => {
       process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
       global.fetch = jest.fn().mockResolvedValue({

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../utils/logger';
+import { parseTrainType, type TrainType } from '../constants/trainTypes';
 
 const log = createLogger('arrivalApi');
 
@@ -15,6 +16,10 @@ export interface ArrivalInfo {
    * 누락/비숫자는 -1. fusion 우선순위 판정에 사용 (constants/arrivalCodes.ts).
    */
   arrivalCode: number;
+  /** lstcarAt === '1'이면 막차. 사용자 안전성 표시용. */
+  isLastTrain: boolean;
+  /** btrainSttus 매핑. 'normal'은 라벨 빈 문자열로 배지 미표시. */
+  trainType: TrainType;
 }
 
 export interface StationArrival {
@@ -25,12 +30,12 @@ export interface StationArrival {
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
-    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 },
-    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
+    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
   ],
   down: [
-    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 },
-    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
+    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
   ],
   isMock: true,
 });
@@ -113,6 +118,8 @@ export async function fetchArrivalInfo(
         trainCode: item.btrainNo ?? '',
         receivedAtMs,
         arrivalCode: Number.isFinite(parsedCode) ? parsedCode : -1,
+        isLastTrain: item.lstcarAt === '1' || item.lstcarAt === 1,
+        trainType: parseTrainType(item.btrainSttus),
       };
       if (UP_DIRECTION_VALUES.includes(item.updnLine)) {
         up.push(info);

--- a/src/components/ArrivalStatusBadge.tsx
+++ b/src/components/ArrivalStatusBadge.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../theme';
+import { ARRIVAL_CODE } from '../constants/arrivalCodes';
+import { TRAIN_TYPE_LABEL, type TrainType } from '../constants/trainTypes';
+
+interface Props {
+  isLastTrain?: boolean;
+  trainType?: TrainType;
+  arrivalCode?: number;
+}
+
+/**
+ * Arrival 메타데이터(막차/급행/진입 상태)를 작은 배지로 표시.
+ * 표시할 배지가 없으면 null 반환해 row 시각 무게 보존.
+ */
+export function ArrivalStatusBadge({ isLastTrain, trainType, arrivalCode }: Props) {
+  const { colors } = useTheme();
+
+  // 표시 우선순위: 막차 > 도착/진입 상태 > 급행/특급/ITX
+  // 막차는 사용자 안전성 직결이라 항상 가장 두드러지게.
+  const badges: { label: string; color: string }[] = [];
+
+  if (isLastTrain) {
+    badges.push({ label: '막차', color: colors.danger });
+  }
+  if (arrivalCode === ARRIVAL_CODE.ARRIVED) {
+    badges.push({ label: '도착', color: colors.accent });
+  } else if (arrivalCode === ARRIVAL_CODE.ENTERING) {
+    badges.push({ label: '진입', color: colors.accent });
+  }
+  if (trainType && trainType !== 'normal') {
+    badges.push({ label: TRAIN_TYPE_LABEL[trainType], color: colors.accent });
+  }
+
+  if (badges.length === 0) return null;
+
+  return (
+    <View style={styles.row} testID="arrival-status-badge">
+      {badges.map((b) => (
+        <View key={b.label} style={[styles.badge, { borderColor: b.color }]}>
+          <Text style={[styles.text, { color: b.color }]}>{b.label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', gap: 4, marginTop: 2 },
+  badge: {
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 3,
+    borderWidth: 1,
+  },
+  // 한글/영문 혼용(ITX)이라 typography.label의 uppercase/letterSpacing은 적용하지 않는다.
+  text: { fontSize: 10, fontWeight: '700', letterSpacing: 0 },
+});

--- a/src/components/EditorialArrivalRow.tsx
+++ b/src/components/EditorialArrivalRow.tsx
@@ -4,6 +4,7 @@ import { useTheme, typography, spacing } from '../theme';
 import { useCountdown } from '../hooks/useCountdown';
 import type { ArrivalTrain } from '../utils/journeyAdapter';
 import { LineBadge, getLineColor } from './LineBadge';
+import { ArrivalStatusBadge } from './ArrivalStatusBadge';
 
 interface Props {
   train: ArrivalTrain;
@@ -32,6 +33,11 @@ export function EditorialArrivalRow({ train }: Props) {
             {train.subtext}
           </Text>
         )}
+        <ArrivalStatusBadge
+          isLastTrain={train.isLastTrain}
+          trainType={train.trainType}
+          arrivalCode={train.arrivalCode}
+        />
       </View>
       <LineBadge line={train.line} color={lineC} />
     </View>

--- a/src/components/__tests__/ArrivalStatusBadge.test.tsx
+++ b/src/components/__tests__/ArrivalStatusBadge.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import { ArrivalStatusBadge } from '../ArrivalStatusBadge';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+
+describe('ArrivalStatusBadge', () => {
+  it('표시할 배지가 없으면 null 반환', () => {
+    const { toJSON } = renderWithTheme(<ArrivalStatusBadge />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('isLastTrain → 막차 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge isLastTrain />);
+    expect(screen.getByText('막차')).toBeTruthy();
+  });
+
+  it('arrivalCode=ARRIVED → 도착 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.ARRIVED} />);
+    expect(screen.getByText('도착')).toBeTruthy();
+  });
+
+  it('arrivalCode=ENTERING → 진입 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.ENTERING} />);
+    expect(screen.getByText('진입')).toBeTruthy();
+  });
+
+  it('arrivalCode=DEPARTED 등 그외 코드는 도착/진입 배지 미표시', () => {
+    const { toJSON } = renderWithTheme(
+      <ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.DEPARTED} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('trainType=express → 급행 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge trainType="express" />);
+    expect(screen.getByText('급행')).toBeTruthy();
+  });
+
+  it('trainType=itx/rapid 라벨', () => {
+    renderWithTheme(<ArrivalStatusBadge trainType="itx" />);
+    expect(screen.getByText('ITX')).toBeTruthy();
+  });
+
+  it('trainType=rapid → 특급 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge trainType="rapid" />);
+    expect(screen.getByText('특급')).toBeTruthy();
+  });
+
+  it('trainType=normal → 배지 미표시', () => {
+    const { toJSON } = renderWithTheme(<ArrivalStatusBadge trainType="normal" />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('막차 + 도착 + 급행 동시 표시', () => {
+    renderWithTheme(
+      <ArrivalStatusBadge isLastTrain arrivalCode={ARRIVAL_CODE.ARRIVED} trainType="express" />,
+    );
+    expect(screen.getByText('막차')).toBeTruthy();
+    expect(screen.getByText('도착')).toBeTruthy();
+    expect(screen.getByText('급행')).toBeTruthy();
+  });
+});

--- a/src/constants/__tests__/trainTypes.test.ts
+++ b/src/constants/__tests__/trainTypes.test.ts
@@ -1,0 +1,30 @@
+import { parseTrainType, TRAIN_TYPE_LABEL } from '../trainTypes';
+
+describe('parseTrainType', () => {
+  it('급행/ITX/특급 정확히 매핑', () => {
+    expect(parseTrainType('급행')).toBe('express');
+    expect(parseTrainType('ITX')).toBe('itx');
+    expect(parseTrainType('특급')).toBe('rapid');
+  });
+
+  it('일반/누락/비문자열은 normal로 fallback', () => {
+    expect(parseTrainType('일반')).toBe('normal');
+    expect(parseTrainType('')).toBe('normal');
+    expect(parseTrainType(undefined)).toBe('normal');
+    expect(parseTrainType(null)).toBe('normal');
+    expect(parseTrainType(123)).toBe('normal');
+  });
+
+  it('앞뒤 공백 trim', () => {
+    expect(parseTrainType(' 급행 ')).toBe('express');
+  });
+});
+
+describe('TRAIN_TYPE_LABEL', () => {
+  it('각 타입의 라벨이 정의됨, normal은 빈 문자열', () => {
+    expect(TRAIN_TYPE_LABEL.express).toBe('급행');
+    expect(TRAIN_TYPE_LABEL.itx).toBe('ITX');
+    expect(TRAIN_TYPE_LABEL.rapid).toBe('특급');
+    expect(TRAIN_TYPE_LABEL.normal).toBe('');
+  });
+});

--- a/src/constants/trainTypes.ts
+++ b/src/constants/trainTypes.ts
@@ -1,0 +1,24 @@
+/**
+ * 서울 열린데이터 API `realtimeStationArrival.btrainSttus` 응답값 → 표준 타입 매핑.
+ * 스펙: scripts/서울시+지하철+실시간+도착정보.xls (열차종류: 급행, ITX, 일반, 특급)
+ */
+export type TrainType = 'express' | 'itx' | 'rapid' | 'normal';
+
+const BTRAIN_STTUS_TO_TYPE: Record<string, TrainType> = {
+  급행: 'express',
+  ITX: 'itx',
+  특급: 'rapid',
+};
+
+export function parseTrainType(btrainSttus: unknown): TrainType {
+  if (typeof btrainSttus !== 'string') return 'normal';
+  return BTRAIN_STTUS_TO_TYPE[btrainSttus.trim()] ?? 'normal';
+}
+
+/** UI 라벨. 데이터 주도 — 새 타입 추가 시 한 줄 변경. */
+export const TRAIN_TYPE_LABEL: Record<TrainType, string> = {
+  express: '급행',
+  itx: 'ITX',
+  rapid: '특급',
+  normal: '',
+};

--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -3,8 +3,8 @@ import { useArrivalCountdown } from '../useArrivalCountdown';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const mockArrival: StationArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
 };
 
 const mockArrivalMock: StationArrival = {
@@ -53,7 +53,7 @@ describe('useArrivalCountdown', () => {
 
   it('arrivalSeconds가 0 이하로 내려가지 않는다', () => {
     const nearArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
       down: [],
     };
 
@@ -84,8 +84,8 @@ describe('useArrivalCountdown', () => {
 
     // 새 API 데이터 도착
     const newArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
     };
 
     rerender({ arrival: newArrival });

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -13,8 +13,8 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
 };
 
 const mockArrivalWithMock = {
@@ -176,8 +176,8 @@ describe('useArrivalInfo', () => {
 
   it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
     const updatedArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
     };
 
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
@@ -295,11 +295,11 @@ describe('useArrivalInfo', () => {
 
   it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
     const staleArrival = {
-      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
       down: [],
     };
     const freshArrival = {
-      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
       down: [],
     };
 
@@ -376,8 +376,8 @@ describe('useArrivalInfo', () => {
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
     const freshArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0, arrivalCode: -1 }],
-      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
     };
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -41,6 +41,8 @@ function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInf
     trainCode: 'T1',
     receivedAtMs: 1_700_000_000_000,
     arrivalCode,
+    isLastTrain: false,
+    trainType: 'normal',
     ...overrides,
   };
 }

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -8,8 +8,8 @@ describe('BffArrivalProvider', () => {
   let provider: BffArrivalProvider;
 
   const VALID_DATA: StationArrival = {
-    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 }],
-    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 }],
+    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
   };
 
   function mockFetchOk(data: StationArrival) {

--- a/src/testUtils/fixtures.ts
+++ b/src/testUtils/fixtures.ts
@@ -22,6 +22,8 @@ export function makeArrivalInfo(overrides: Partial<ArrivalInfo> & { destination:
     trainCode: 'T001',
     receivedAtMs: 0,
     arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
     ...overrides,
   };
 }

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -82,8 +82,32 @@ describe('arrivalInfoToArrivalTrain', () => {
     const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toEqual([
-      { direction: '봉화산행', line: '6', arrivalAtMs: 1000000 + 134 * 1000, subtext: undefined },
+      {
+        direction: '봉화산행',
+        line: '6',
+        arrivalAtMs: 1000000 + 134 * 1000,
+        subtext: undefined,
+        isLastTrain: false,
+        trainType: 'normal',
+        arrivalCode: -1,
+      },
     ]);
+  });
+
+  it('should pass through meta fields (isLastTrain/trainType/arrivalCode)', () => {
+    const items = [
+      makeArrivalInfo({
+        destination: '봉화산행',
+        arrivalSeconds: 60,
+        isLastTrain: true,
+        trainType: 'express',
+        arrivalCode: 1,
+      }),
+    ];
+    const result = arrivalInfoToArrivalTrain(items, '상행', '6');
+    expect(result[0].isLastTrain).toBe(true);
+    expect(result[0].trainType).toBe('express');
+    expect(result[0].arrivalCode).toBe(1);
   });
 
   it('should use direction fallback when destination is empty', () => {

--- a/src/utils/__tests__/pickFusedStation.test.ts
+++ b/src/utils/__tests__/pickFusedStation.test.ts
@@ -15,6 +15,8 @@ function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInf
     trainCode: 'T1',
     receivedAtMs: NOW,
     arrivalCode,
+    isLastTrain: false,
+    trainType: 'normal',
     ...overrides,
   };
 }

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -21,6 +21,12 @@ export interface ArrivalTrain {
   line: string;
   arrivalAtMs: number;
   subtext?: string;
+  /** 막차 여부 — UI 안전성 배지. */
+  isLastTrain?: boolean;
+  /** 열차 타입 — 'normal'은 배지 미표시. */
+  trainType?: import('../constants/trainTypes').TrainType;
+  /** arvlCd — 0:진입, 1:도착, 2:출발 등. UI 진입/도착 배지용. */
+  arrivalCode?: number;
 }
 
 export interface HandoffNearest {
@@ -98,6 +104,9 @@ export function arrivalInfoToArrivalTrain(
     line,
     arrivalAtMs: now + item.arrivalSeconds * 1000,
     subtext: item.statusMessage || undefined,
+    isLastTrain: item.isLastTrain,
+    trainType: item.trainType,
+    arrivalCode: item.arrivalCode,
   }));
 }
 


### PR DESCRIPTION
## Summary

Phase 2의 마지막 단계. 응답에 이미 들어있지만 UI에 노출 안 되던 메타데이터를 배지로 표시.

- \`lstcarAt\` → 막차 배지 (사용자 안전성, 마지막 열차 놓침 방지)
- \`btrainSttus\` → 급행/특급/ITX 배지 (환승 판단)
- \`arvlCd\` (Stage 2 파싱 도입) → 도착/진입 배지 (시각적 카운트다운 보강)

추가 호출 0개. 기존 응답에서 채굴.

## Phase 2 완료 (이슈 #276)

| Stage | 이슈/PR | 효과 |
|---|---|---|
| 1 | #279/#281 | recptnDt 시차 보정 — 카운트다운 정확도 |
| 2 | #285/#286 | GPS+Arrival fusion 현재역 판정 — 지하 갱신 지연 우회 |
| 3 | #287/#288 | Arrival fusion 알람 트리거 — 지하 알람 누락 마감 |
| 4 | #289/이번 PR | 메타 배지 — 안전성/체감속도/선택권 |

## Test plan

- [x] \`npm run type-check\` 통과
- [x] \`npm test\` — 62 suites / 884 tests, 커버리지 100%
- [x] code-review P1 0건
- [ ] 막차 시간대(00:30+) 막차 배지 (실기기)
- [ ] 2호선·9호선 등 급행 운영 노선 급행 배지 (실기기)
- [ ] 한글 배지 letterSpacing 깨짐 없는지 확인 (실기기)

Closes #289