### PR TITLE
feat(#291): realtimePosition API fusion — Phase 3 Stage 1+2

### DIFF
--- a/src/api/__tests__/positionApi.test.ts
+++ b/src/api/__tests__/positionApi.test.ts
@@ -1,0 +1,209 @@
+import { fetchTrainPositions, parsePositionRecvTime, MOCK_POSITIONS } from '../positionApi';
+
+describe('fetchTrainPositions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    jest.useRealTimers();
+  });
+
+  it('API 키가 없으면 mock 반환 (요청 line 보존)', async () => {
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+    expect(result.line).toBe('2');
+    expect(result.trains).toEqual([]);
+  });
+
+  const mockApi = (items: unknown[]) => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ realtimePositionList: items }),
+    } as Response);
+  };
+
+  it('정상 응답을 TrainPosition[]로 매핑', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:30Z'));
+    mockApi([
+      {
+        statnId: '1002000201',
+        statnNm: '강남',
+        trainNo: 'T100',
+        trainSttus: '1',
+        updnLine: '0',
+        statnTid: '1002000202',
+        statnTnm: '역삼',
+        directAt: '1', // 급행
+        lstcarAt: '0',
+        lastRecptnDt: '2026-05-12',
+        recptnDt: '12:00:00',
+      },
+    ]);
+
+    const result = await fetchTrainPositions('2');
+    expect(result.trains).toHaveLength(1);
+    const t = result.trains[0];
+    expect(t.statnId).toBe('1002000201');
+    expect(t.trainStatus).toBe(1);
+    expect(t.updnLine).toBe(0);
+    expect(t.terminalStationName).toBe('역삼');
+    expect(t.trainType).toBe('express');
+    expect(t.isLastTrain).toBe(false);
+    expect(t.receivedAtMs).toBe(Date.parse('2026-05-12T03:00:00Z'));
+  });
+
+  it('lstcarAt: "1" 또는 1 → isLastTrain true', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T1', trainSttus: 1, updnLine: 0, lstcarAt: '1' },
+      { statnId: '2', statnNm: 'B', trainNo: 'T2', trainSttus: 1, updnLine: 0, lstcarAt: 1 },
+      { statnId: '3', statnNm: 'C', trainNo: 'T3', trainSttus: 1, updnLine: 0 },
+    ]);
+
+    const result = await fetchTrainPositions('2');
+    expect(result.trains.map((t) => t.isLastTrain)).toEqual([true, true, false]);
+  });
+
+  it('directAt: 1=express, 7=rapid, 0/누락=normal', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: 1, updnLine: 0, directAt: 1 },
+      { statnId: '2', statnNm: 'B', trainNo: 'T', trainSttus: 1, updnLine: 0, directAt: 7 },
+      { statnId: '3', statnNm: 'C', trainNo: 'T', trainSttus: 1, updnLine: 0, directAt: 0 },
+      { statnId: '4', statnNm: 'D', trainNo: 'T', trainSttus: 1, updnLine: 0 },
+    ]);
+
+    const result = await fetchTrainPositions('2');
+    expect(result.trains.map((t) => t.trainType)).toEqual(['express', 'rapid', 'normal', 'normal']);
+  });
+
+  it('drift > 120s면 receivedAtMs=0(stale 강등)', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:05:00Z'));
+    mockApi([
+      {
+        statnId: '1',
+        statnNm: 'A',
+        trainNo: 'T',
+        trainSttus: 1,
+        updnLine: 0,
+        lastRecptnDt: '2026-05-12',
+        recptnDt: '12:00:00',
+      },
+    ]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].receivedAtMs).toBe(0);
+  });
+
+  it('빈 리스트 → mock fallback', async () => {
+    mockApi([]);
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('HTTP 실패 → mock fallback (line 보존)', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 } as Response);
+    const result = await fetchTrainPositions('5');
+    expect(result.isMock).toBe(true);
+    expect(result.line).toBe('5');
+  });
+
+  it('네트워크 에러 → mock fallback', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockRejectedValue(new Error('net'));
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('timeout 5s 초과 → mock fallback', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    jest.useFakeTimers();
+    global.fetch = jest.fn().mockImplementation((_url, opts?: RequestInit) => {
+      return new Promise((_res, rej) => {
+        opts?.signal?.addEventListener('abort', () =>
+          rej(new DOMException('aborted', 'AbortError')),
+        );
+      });
+    });
+    const promise = fetchTrainPositions('2');
+    jest.advanceTimersByTime(5000);
+    const result = await promise;
+    expect(result.isMock).toBe(true);
+  });
+
+  it('trainSttus / updnLine 비숫자 → -1', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: 'abc', updnLine: 'xyz' },
+    ]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].trainStatus).toBe(-1);
+    expect(result.trains[0].updnLine).toBe(-1);
+  });
+
+  it('MOCK_POSITIONS export', () => {
+    expect(MOCK_POSITIONS.isMock).toBe(true);
+    expect(MOCK_POSITIONS.trains).toEqual([]);
+  });
+
+  it('realtimePositionList 누락 → 빈 배열 → mock fallback', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('trainSttus / updnLine이 number 타입으로 와도 그대로 매핑', async () => {
+    mockApi([{ statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: 2, updnLine: 1 }]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].trainStatus).toBe(2);
+    expect(result.trains[0].updnLine).toBe(1);
+  });
+
+  it('statnId / statnNm / trainNo 누락 시 빈 문자열로 fallback', async () => {
+    mockApi([{ trainSttus: 1, updnLine: 0 }]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].statnId).toBe('');
+    expect(result.trains[0].statnNm).toBe('');
+    expect(result.trains[0].trainNo).toBe('');
+  });
+
+  it('trainSttus / updnLine이 객체(undefined 외 비스칼라)면 -1', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: { x: 1 }, updnLine: [] },
+    ]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].trainStatus).toBe(-1);
+    expect(result.trains[0].updnLine).toBe(-1);
+  });
+});
+
+describe('parsePositionRecvTime', () => {
+  it('풀 포맷 recptnDt만 와도 파싱', () => {
+    expect(parsePositionRecvTime('', '2026-05-12 12:00:00')).toBe(
+      Date.parse('2026-05-12T03:00:00Z'),
+    );
+  });
+
+  it('lastRecptnDt(날짜) + recptnDt(시각) 조합', () => {
+    expect(parsePositionRecvTime('2026-05-12', '12:00:00')).toBe(
+      Date.parse('2026-05-12T03:00:00Z'),
+    );
+  });
+
+  it('비문자열/빈 문자열은 0', () => {
+    expect(parsePositionRecvTime(undefined, undefined)).toBe(0);
+    expect(parsePositionRecvTime('2026-05-12', '')).toBe(0);
+    expect(parsePositionRecvTime(null, null)).toBe(0);
+  });
+
+  it('잘못된 포맷은 0', () => {
+    expect(parsePositionRecvTime('', 'not-a-date')).toBe(0);
+  });
+});

--- a/src/api/positionApi.ts
+++ b/src/api/positionApi.ts
@@ -1,0 +1,153 @@
+import { createLogger } from '../utils/logger';
+import { parseTrainTypeFromDirectAt, type TrainType } from '../constants/trainTypes';
+import { getLineApiName } from '../constants/lineApiNames';
+import type { LineNumber } from '../types/station';
+
+const log = createLogger('positionApi');
+
+/**
+ * realtimePosition 응답의 단일 열차 정보(앱 도메인 형태로 정규화).
+ * statnId가 fusion 신호의 핵심 — "이 열차가 지금 어느 역에 있나" 확정 정보.
+ */
+export interface TrainPosition {
+  statnId: string;
+  statnNm: string;
+  trainNo: string;
+  /** trainSttus: 0:진입, 1:도착, 2:출발, 3:전역출발 */
+  trainStatus: number;
+  /** 0:상행/내선, 1:하행/외선 */
+  updnLine: number;
+  /** 종착역 */
+  terminalStationId: string;
+  terminalStationName: string;
+  /** directAt 매핑(express/rapid/normal — ITX는 도착정보에서만) */
+  trainType: TrainType;
+  isLastTrain: boolean;
+  /** recptnDt 파싱 결과 — Stage 1과 같은 신선도 계약(0=알 수 없음). */
+  receivedAtMs: number;
+}
+
+export interface LinePositions {
+  line: LineNumber;
+  trains: TrainPosition[];
+  isMock?: boolean;
+}
+
+/** mock — API 키 없거나 실패 시 fallback. fusion 신호로 사용되지 않음(receivedAtMs=0). */
+export const MOCK_POSITIONS: Readonly<LinePositions> = Object.freeze({
+  line: '2' as LineNumber,
+  trains: [],
+  isMock: true,
+});
+
+/** 서울 열린데이터 API recptnDt 타임존(KST). arrivalApi와 동일 정책. */
+const SEOUL_API_TZ_OFFSET = '+09:00';
+/** drift 상한(s) — 비정상이면 stale로 강등. arrivalApi와 동일 정책. */
+const MAX_RECPTN_DRIFT_SEC = 120;
+
+/** "YYYY-MM-DD[ T]HH:mm:ss" 풀 포맷 판정 — 인식 못하는 입력은 0(알 수 없음)으로 강등한다. */
+const FULL_DATETIME_RE = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/;
+/** "HH:mm:ss" 시각 단독 — lastRecptnDt(날짜)와 합쳐 풀 포맷 구성. */
+const TIME_ONLY_RE = /^\d{2}:\d{2}:\d{2}/;
+
+/**
+ * realtimePosition은 lastRecptnDt(날짜)와 recptnDt(시각)를 분리해서 보낼 수 있다.
+ * 명세에 정확한 형식이 명시되지 않아 두 케이스 모두 대응:
+ *   - recptnDt가 "YYYY-MM-DD HH:mm:ss" 풀 포맷이면 그대로 파싱
+ *   - "HH:mm:ss"만 오면 lastRecptnDt와 합쳐 파싱
+ * 알 수 없는 포맷이면 0(=stale로 강등 — fusion에서 무시됨).
+ */
+export function parsePositionRecvTime(lastRecptnDt: unknown, recptnDt: unknown): number {
+  const recv = typeof recptnDt === 'string' ? recptnDt.trim() : '';
+  const date = typeof lastRecptnDt === 'string' ? lastRecptnDt.trim() : '';
+  if (!recv) return 0;
+  let full: string;
+  if (FULL_DATETIME_RE.test(recv)) {
+    full = recv;
+  } else if (TIME_ONLY_RE.test(recv) && date) {
+    full = `${date} ${recv}`;
+  } else {
+    return 0;
+  }
+  // 정규식 통과 후 Date.parse가 NaN이어도 호출자(parsedRecvMs > 0 검사)에서 자연스럽게 stale 강등.
+  return Date.parse(full.replace(' ', 'T') + SEOUL_API_TZ_OFFSET);
+}
+
+export interface FetchPositionOptions {
+  timeoutMs?: number;
+  /** 0~limit 범위로 호출 (호선당 최대 1000건이지만 일반적으로 100 충분). */
+  limit?: number;
+}
+
+export async function fetchTrainPositions(
+  line: LineNumber,
+  options?: FetchPositionOptions,
+): Promise<LinePositions> {
+  const { timeoutMs = 5000, limit = 100 } = options ?? {};
+  const apiKey = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+
+  if (!apiKey) {
+    log.warn('API key not set (EXPO_PUBLIC_SEOUL_DATA_API_KEY)');
+    return { ...MOCK_POSITIONS, line };
+  }
+
+  const apiName = getLineApiName(line);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const url = `http://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimePosition/0/${limit}/${encodeURIComponent(apiName)}`;
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      log.warn(`HTTP ${response.status} for line "${apiName}"`);
+      return { ...MOCK_POSITIONS, line };
+    }
+
+    const data = await response.json();
+    const items: any[] = data.realtimePositionList ?? [];
+
+    const now = Date.now();
+    const trains: TrainPosition[] = items.map((item) => {
+      const parsedRecvMs = parsePositionRecvTime(item.lastRecptnDt, item.recptnDt);
+      const driftSec = parsedRecvMs > 0 ? (now - parsedRecvMs) / 1000 : 0;
+      const isStale = parsedRecvMs > 0 && driftSec > MAX_RECPTN_DRIFT_SEC;
+      const receivedAtMs = isStale ? 0 : parsedRecvMs;
+
+      const parsedStatus =
+        typeof item.trainSttus === 'number'
+          ? item.trainSttus
+          : typeof item.trainSttus === 'string'
+            ? Number.parseInt(item.trainSttus, 10)
+            : NaN;
+      const parsedUpdn =
+        typeof item.updnLine === 'number'
+          ? item.updnLine
+          : typeof item.updnLine === 'string'
+            ? Number.parseInt(item.updnLine, 10)
+            : NaN;
+
+      return {
+        statnId: String(item.statnId ?? ''),
+        statnNm: String(item.statnNm ?? ''),
+        trainNo: String(item.trainNo ?? ''),
+        trainStatus: Number.isFinite(parsedStatus) ? parsedStatus : -1,
+        updnLine: Number.isFinite(parsedUpdn) ? parsedUpdn : -1,
+        terminalStationId: String(item.statnTid ?? ''),
+        terminalStationName: String(item.statnTnm ?? ''),
+        trainType: parseTrainTypeFromDirectAt(item.directAt),
+        isLastTrain: item.lstcarAt === '1' || item.lstcarAt === 1,
+        receivedAtMs,
+      };
+    });
+
+    if (trains.length === 0) {
+      log.warn(`No trains for line "${apiName}"`);
+      return { ...MOCK_POSITIONS, line };
+    }
+    return { line, trains };
+  } catch (e) {
+    log.error(`Fetch failed for line "${apiName}":`, e);
+    return { ...MOCK_POSITIONS, line };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/constants/__tests__/lineApiNames.test.ts
+++ b/src/constants/__tests__/lineApiNames.test.ts
@@ -1,0 +1,16 @@
+import { LINE_API_NAMES, getLineApiName } from '../lineApiNames';
+
+describe('lineApiNames', () => {
+  it('1~9호선 매핑 + 특수 노선', () => {
+    expect(getLineApiName('1')).toBe('1호선');
+    expect(getLineApiName('9')).toBe('9호선');
+    expect(getLineApiName('airport')).toBe('공항철도');
+    expect(getLineApiName('gyeongui')).toBe('경의중앙선');
+    expect(getLineApiName('bundang')).toBe('수인분당선');
+    expect(getLineApiName('sinbundang')).toBe('신분당선');
+  });
+
+  it('LINE_API_NAMES가 모든 LineNumber를 cover (객체 키 9+4=13)', () => {
+    expect(Object.keys(LINE_API_NAMES).length).toBe(13);
+  });
+});

--- a/src/constants/__tests__/trainStatus.test.ts
+++ b/src/constants/__tests__/trainStatus.test.ts
@@ -1,0 +1,20 @@
+import { TRAIN_STATUS, getTrainStatusPriority } from '../trainStatus';
+
+describe('trainStatus', () => {
+  it('상수가 스펙과 일치 (0:진입,1:도착,2:출발,3:전역출발)', () => {
+    expect(TRAIN_STATUS.ENTERING).toBe(0);
+    expect(TRAIN_STATUS.ARRIVED).toBe(1);
+    expect(TRAIN_STATUS.DEPARTED).toBe(2);
+    expect(TRAIN_STATUS.PREV_DEPARTED).toBe(3);
+  });
+
+  it('priority: ARRIVED(1)이 ENTERING(0)보다 강하고 그외는 0', () => {
+    expect(getTrainStatusPriority(TRAIN_STATUS.ARRIVED)).toBeGreaterThan(
+      getTrainStatusPriority(TRAIN_STATUS.ENTERING),
+    );
+    expect(getTrainStatusPriority(TRAIN_STATUS.DEPARTED)).toBe(0);
+    expect(getTrainStatusPriority(TRAIN_STATUS.PREV_DEPARTED)).toBe(0);
+    expect(getTrainStatusPriority(undefined)).toBe(0);
+    expect(getTrainStatusPriority(99)).toBe(0);
+  });
+});

--- a/src/constants/__tests__/trainTypes.test.ts
+++ b/src/constants/__tests__/trainTypes.test.ts
@@ -1,4 +1,4 @@
-import { parseTrainType, TRAIN_TYPE_LABEL } from '../trainTypes';
+import { parseTrainType, parseTrainTypeFromDirectAt, TRAIN_TYPE_LABEL } from '../trainTypes';
 
 describe('parseTrainType', () => {
   it('급행/ITX/특급 정확히 매핑', () => {
@@ -26,5 +26,25 @@ describe('TRAIN_TYPE_LABEL', () => {
     expect(TRAIN_TYPE_LABEL.itx).toBe('ITX');
     expect(TRAIN_TYPE_LABEL.rapid).toBe('특급');
     expect(TRAIN_TYPE_LABEL.normal).toBe('');
+  });
+});
+
+describe('parseTrainTypeFromDirectAt (realtimePosition API)', () => {
+  it('1=express, 7=rapid, 0=normal', () => {
+    expect(parseTrainTypeFromDirectAt(1)).toBe('express');
+    expect(parseTrainTypeFromDirectAt(7)).toBe('rapid');
+    expect(parseTrainTypeFromDirectAt(0)).toBe('normal');
+  });
+
+  it('숫자 문자열도 파싱', () => {
+    expect(parseTrainTypeFromDirectAt('1')).toBe('express');
+    expect(parseTrainTypeFromDirectAt('7')).toBe('rapid');
+  });
+
+  it('비숫자/누락은 normal', () => {
+    expect(parseTrainTypeFromDirectAt(undefined)).toBe('normal');
+    expect(parseTrainTypeFromDirectAt(null)).toBe('normal');
+    expect(parseTrainTypeFromDirectAt('abc')).toBe('normal');
+    expect(parseTrainTypeFromDirectAt(99)).toBe('normal');
   });
 });

--- a/src/constants/lineApiNames.ts
+++ b/src/constants/lineApiNames.ts
@@ -1,0 +1,29 @@
+import type { LineNumber } from '../types/station';
+
+/**
+ * 서울 열린데이터 API `realtimePosition` 호출 시 `subwayNm` 파라미터로 사용하는 호선명.
+ * 새 호선 추가 시 LineNumber 타입과 이 매핑 한 줄씩만 추가.
+ *
+ * 스펙 매핑(subwayId → 호선명):
+ *   1001:1호선 ~ 1009:9호선
+ *   1063:경의중앙선, 1065:공항철도, 1075:수인분당선, 1077:신분당선
+ */
+export const LINE_API_NAMES: Record<LineNumber, string> = {
+  '1': '1호선',
+  '2': '2호선',
+  '3': '3호선',
+  '4': '4호선',
+  '5': '5호선',
+  '6': '6호선',
+  '7': '7호선',
+  '8': '8호선',
+  '9': '9호선',
+  airport: '공항철도',
+  gyeongui: '경의중앙선',
+  bundang: '수인분당선',
+  sinbundang: '신분당선',
+};
+
+export function getLineApiName(line: LineNumber): string {
+  return LINE_API_NAMES[line];
+}

--- a/src/constants/trainStatus.ts
+++ b/src/constants/trainStatus.ts
@@ -1,0 +1,24 @@
+/**
+ * 서울 열린데이터 API `realtimePosition.trainSttus` 응답값.
+ * 스펙: scripts/서울시+지하철+실시간+열차+위치정보.xls
+ * 도착정보 API의 arvlCd와 의미는 비슷하지만 코드 체계가 더 단순(99 운행중 없음).
+ */
+export const TRAIN_STATUS = {
+  ENTERING: 0, // 진입
+  ARRIVED: 1, // 도착 — 사용자 = 해당 역에 있음 (확정)
+  DEPARTED: 2, // 출발
+  PREV_DEPARTED: 3, // 전역 출발
+} as const;
+
+/**
+ * fusion 우선순위 (높을수록 강한 신호) — arrivalCodes.ts와 같은 형태.
+ * trainSttus=1(도착)을 arvlCd=1과 동일 점수로 격상 — pickFusedStation에서 신호원 통합.
+ */
+const PRIORITY_BY_STATUS: Record<number, number> = {
+  [TRAIN_STATUS.ARRIVED]: 100,
+  [TRAIN_STATUS.ENTERING]: 80,
+};
+
+export function getTrainStatusPriority(status: number | undefined): number {
+  return PRIORITY_BY_STATUS[status ?? -1] ?? 0;
+}

--- a/src/constants/trainTypes.ts
+++ b/src/constants/trainTypes.ts
@@ -22,3 +22,23 @@ export const TRAIN_TYPE_LABEL: Record<TrainType, string> = {
   rapid: '특급',
   normal: '',
 };
+
+/**
+ * realtimePosition API의 `directAt` 응답값(숫자) → 같은 TrainType enum으로 통합.
+ * 스펙: 1:급행, 0:아님, 7:특급 (ITX는 directAt에 없음 — btrainSttus 텍스트로만 옴)
+ */
+const DIRECT_AT_TO_TYPE: Record<number, TrainType> = {
+  1: 'express',
+  7: 'rapid',
+};
+
+export function parseTrainTypeFromDirectAt(directAt: unknown): TrainType {
+  const n =
+    typeof directAt === 'number'
+      ? directAt
+      : typeof directAt === 'string'
+        ? Number.parseInt(directAt, 10)
+        : NaN;
+  if (!Number.isFinite(n)) return 'normal';
+  return DIRECT_AT_TO_TYPE[n] ?? 'normal';
+}

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -2,19 +2,24 @@ import { renderHook } from '@testing-library/react-native';
 import { useFusedNearestStation } from '../useFusedNearestStation';
 import { useNearestStation } from '../useNearestStation';
 import { useArrivalInfo } from '../useArrivalInfo';
+import { useTrainPositions } from '../useTrainPositions';
 import { findTopNearestStations } from '../../utils/findNearestStation';
 import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import { TRAIN_STATUS } from '../../constants/trainStatus';
 import { MOCK_STATIONS } from '../../testUtils/fixtures';
 import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
 
 jest.mock('../useNearestStation');
 jest.mock('../useArrivalInfo');
+jest.mock('../useTrainPositions');
 jest.mock('../../utils/findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
 }));
 
 const mockUseNearest = useNearestStation as jest.Mock;
 const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockUsePositions = useTrainPositions as jest.Mock;
 const mockFindTop = findTopNearestStations as jest.Mock;
 
 function gpsBase(overrides?: Record<string, unknown>) {
@@ -51,10 +56,35 @@ function arrivalRet(stationArrival: StationArrival | null = null) {
   return { arrival: stationArrival, loading: false, isMock: false };
 }
 
+function positionRet(positions: LinePositions | null = null) {
+  return { positions, loading: false, isMock: false };
+}
+
+function train(
+  statnNm: string,
+  trainStatus: number,
+  overrides?: Partial<TrainPosition>,
+): TrainPosition {
+  return {
+    statnId: '',
+    statnNm,
+    trainNo: 'T',
+    trainStatus,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
 describe('useFusedNearestStation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockUsePositions.mockReturnValue(positionRet(null));
   });
 
   it('userLocation null이면 후보 없음 → GPS 결과 그대로 + gps-only', () => {
@@ -108,6 +138,53 @@ describe('useFusedNearestStation', () => {
     const { result } = renderHook(() => useFusedNearestStation());
 
     expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+  });
+
+  it('position 신호: 후보 호선의 LinePositions에서 statnNm 매칭 트레인이 ARRIVED → 그 후보로 fusion (source=position)', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
+    ]);
+
+    // arrival 신호 없음
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+
+    // active lines: ['2', '3'] — useTrainPositions 3번 호출(l0='2', l1='3', l2=null)
+    mockUsePositions
+      .mockReturnValueOnce(positionRet({ line: '2', trains: [] })) // 강남에 매칭 없음
+      .mockReturnValueOnce(
+        positionRet({
+          line: '3',
+          trains: [train(MOCK_STATIONS.chungmuro.name, TRAIN_STATUS.ARRIVED)],
+        }),
+      )
+      .mockReturnValueOnce(positionRet(null));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+    expect(result.current.result?.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+    expect(result.current.confidence).toBe('arrival-confirmed');
+    expect(result.current.source).toBe('position');
+  });
+
+  it('arrival과 position 동시 ARRIVED → source=position 우선 (정확도 표시)', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+    mockUsePositions
+      .mockReturnValueOnce(
+        positionRet({
+          line: '2',
+          trains: [train(MOCK_STATIONS.gangnam.name, TRAIN_STATUS.ARRIVED)],
+        }),
+      )
+      .mockReturnValueOnce(positionRet(null))
+      .mockReturnValueOnce(positionRet(null));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+    expect(result.current.confidence).toBe('arrival-confirmed');
+    expect(result.current.source).toBe('position');
   });
 
   it('GPS pass-through 필드들(loading/error/permissionDenied/refresh 등)이 보존된다', () => {

--- a/src/hooks/__tests__/useTrainPositions.test.ts
+++ b/src/hooks/__tests__/useTrainPositions.test.ts
@@ -1,0 +1,241 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { AppState } from 'react-native';
+import { useTrainPositions, __resetPositionCacheForTests } from '../useTrainPositions';
+import * as positionApi from '../../api/positionApi';
+import type { LinePositions } from '../../api/positionApi';
+
+jest.mock('../../api/positionApi');
+
+let appStateCallback: ((state: string) => void) | null = null;
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
+  appStateCallback = listener as (state: string) => void;
+  return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>;
+});
+
+const sampleResponse: LinePositions = {
+  line: '2',
+  trains: [
+    {
+      statnId: 'X',
+      statnNm: 'X',
+      trainNo: 'T',
+      trainStatus: 1,
+      updnLine: 0,
+      terminalStationId: '',
+      terminalStationName: '',
+      trainType: 'normal',
+      isLastTrain: false,
+      receivedAtMs: 1_700_000_000_000,
+    },
+  ],
+};
+
+describe('useTrainPositions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    appStateCallback = null;
+    __resetPositionCacheForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('line=null이면 fetch 안 함', async () => {
+    const { result } = renderHook(() => useTrainPositions(null));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.positions).toBeNull();
+    expect(positionApi.fetchTrainPositions).not.toHaveBeenCalled();
+  });
+
+  it('line이 주어지면 데이터 가져옴', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { result } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(result.current.positions).toEqual(sampleResponse));
+    expect(result.current.isMock).toBe(false);
+  });
+
+  it('mock 응답이면 isMock=true, 캐시에 저장 안 됨', async () => {
+    const mockResp = { ...sampleResponse, isMock: true };
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(mockResp);
+    const { result } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(result.current.isMock).toBe(true));
+  });
+
+  it('5초 폴링', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalledTimes(2));
+  });
+
+  it('동일 line 두 hook 인스턴스가 캐시 공유 (모듈 싱글톤)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+
+    const { result: r1 } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(r1.current.positions).toEqual(sampleResponse));
+    const initialCalls = (positionApi.fetchTrainPositions as jest.Mock).mock.calls.length;
+
+    // 두 번째 인스턴스가 캐시에서 즉시 받아야 함
+    const { result: r2 } = renderHook(() => useTrainPositions('2'));
+    expect(r2.current.positions).toEqual(sampleResponse);
+    // 새로운 첫 폴링은 발생하지만, 캐시도 활용
+    expect((positionApi.fetchTrainPositions as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(
+      initialCalls,
+    );
+  });
+
+  it('line 변경 시 새 데이터 로드', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { result, rerender } = renderHook(
+      ({ line }: { line: '2' | '5' | null }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | '5' | null } },
+    );
+    await waitFor(() => expect(result.current.positions).toEqual(sampleResponse));
+
+    rerender({ line: '5' });
+    await waitFor(() => {
+      const calls = (positionApi.fetchTrainPositions as jest.Mock).mock.calls;
+      expect(calls.some((c) => c[0] === '5')).toBe(true);
+    });
+  });
+
+  it('line=null로 변경 시 positions 비움', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { result, rerender } = renderHook(
+      ({ line }: { line: '2' | null }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | null } },
+    );
+    await waitFor(() => expect(result.current.positions).toEqual(sampleResponse));
+
+    rerender({ line: null });
+    await waitFor(() => expect(result.current.positions).toBeNull());
+  });
+
+  it('Provider 내부 에러도 상태 안 깨짐 (try/catch fallback)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.positions).toBeNull();
+  });
+
+  it('AppState resume 시 캐시 clear', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    await act(async () => {
+      appStateCallback?.('background');
+      appStateCallback?.('active');
+    });
+    // resume 후 폴링 다시 → fetch 추가 호출
+    await waitFor(() =>
+      expect((positionApi.fetchTrainPositions as jest.Mock).mock.calls.length).toBeGreaterThan(1),
+    );
+  });
+
+  it('provider 주입 가능', async () => {
+    const provider = { getPositions: jest.fn().mockResolvedValue(sampleResponse) };
+    renderHook(() => useTrainPositions('2', provider));
+    await waitFor(() => expect(provider.getPositions).toHaveBeenCalledWith('2'));
+  });
+
+  it('동일 line으로 두 번 갱신해도 동일 positions면 setState 안 함 (cancellation 분기 커버)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { unmount } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    // unmount → cancelled=true → 다음 polling 응답 무시
+    unmount();
+  });
+
+  it('폴링 중 line이 null로 변경되면 폴링 콜백 early-return', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { rerender } = renderHook(
+      ({ line }: { line: '2' | null }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | null } },
+    );
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    rerender({ line: null });
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    // null 후로는 폴링이 더 이상 fetch 호출 안 함 — 이미 직전 값 외엔 추가 호출 없어야
+  });
+
+  it('초기 fetch 도중 unmount 시 cancelled로 setState 차단', async () => {
+    let resolveFn: (val: LinePositions) => void = () => {};
+    (positionApi.fetchTrainPositions as jest.Mock).mockReturnValueOnce(
+      new Promise<LinePositions>((res) => {
+        resolveFn = res;
+      }),
+    );
+    const { result, unmount } = renderHook(() => useTrainPositions('2'));
+    expect(result.current.loading).toBe(true);
+    unmount();
+    resolveFn(sampleResponse);
+    await Promise.resolve();
+    // crash 안 나면 cancelled 분기 통과
+  });
+
+  it('폴링 도중 line이 바뀌면 응답 무시 (usePolling 콜백, l !== lineRef.current)', async () => {
+    // 첫 fetch는 sample로 즉시 resolve해 초기 마운트 안정화
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce(sampleResponse);
+    const { rerender } = renderHook(
+      ({ line }: { line: '2' | '5' }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | '5' } },
+    );
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    // 다음 폴링은 pending으로 잡아둠
+    let resolvePoll: (v: LinePositions) => void = () => {};
+    (positionApi.fetchTrainPositions as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<LinePositions>((res) => {
+          resolvePoll = res;
+        }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(5000); // 폴링 발화 → l='2'로 fetch 시작
+    });
+    rerender({ line: '5' }); // l !== lineRef.current 만들기
+    // mock 응답으로 cache.set 분기까지 같이 커버
+    resolvePoll({ ...sampleResponse, isMock: true });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('폴링 결과가 mock이면 캐시 set 생략 (105 false 분기)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce({
+      ...sampleResponse,
+      isMock: true,
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    await Promise.resolve();
+  });
+
+  it('폴링 콜백 reject도 안전하게 처리 (catch 분기)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalledTimes(1));
+
+    // 두 번째 폴링은 reject
+    (positionApi.fetchTrainPositions as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    // crash 안 나면 통과
+  });
+});

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 import { useNearestStation } from './useNearestStation';
 import { useArrivalInfo } from './useArrivalInfo';
+import { useTrainPositions } from './useTrainPositions';
 import { findTopNearestStations } from '../utils/findNearestStation';
-import { pickFusedStation, type FusionConfidence } from '../utils/pickFusedStation';
+import { findActiveLines } from '../utils/findActiveLines';
+import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import type { LinePositions } from '../api/positionApi';
 import type { NearestStationResult, Station } from '../types/station';
-import type { ArrivalProvider } from '../providers/types';
+import type { ArrivalProvider, PositionProvider } from '../providers/types';
 
 /**
  * fusion 후보 개수. K=3 고정 — Rules of Hooks로 useArrivalInfo를 동적 개수로 호출할 수 없어
@@ -15,12 +18,14 @@ import type { ArrivalProvider } from '../providers/types';
 const FUSION_CANDIDATE_LIMIT = 3;
 
 interface UseFusedNearestStationReturn {
-  /** GPS+arrival fusion으로 결정된 현재역. */
+  /** GPS+arrival+position fusion으로 결정된 현재역. */
   result: NearestStationResult | null;
   /** GPS 원본 result — 비교/디버깅용. */
   gpsResult: NearestStationResult | null;
-  /** fusion 신뢰도. arrival 신호로 확정/추정/없음. */
+  /** fusion 신뢰도. */
   confidence: FusionConfidence;
+  /** fusion 신호 출처. position(가장 정확) > arrival(추정) > gps(거리). */
+  source: FusionSource;
   /** GPS 환승역 변형(같은 이름 다른 노선) — 기존 useNearestStation 호환. */
   variants: Station[];
   userLocation: { lat: number; lng: number } | null;
@@ -39,8 +44,30 @@ interface UseFusedNearestStationReturn {
  * 지하 구간 GPS 지연(이미 도착한 역인데 전역 표시)을 우회하는 것이 목적.
  * arrival 신호가 모두 약하면 GPS 최근접으로 자연 fallback.
  */
+/**
+ * 후보 역의 호선에 해당하는 LinePositions에서 해당 후보 역에 머무는 열차들을 추출.
+ *
+ * 매칭 키: `(line, statnNm)`.
+ * stations.json의 `id`(예: "1-001")는 자체 포맷이고 서울 API `statnId`(예: "1002000201")는
+ * 10자리 코드라 키 공간이 달라 직접 비교 불가. line은 외부 호출 시 이미 지정했으니 같은 lp 안에서는
+ * 역명만으로 충분 — 한 호선의 같은 역명은 유일(같은 호선에 동명역 없음).
+ *
+ * 빈 배열이면 신호 없음(매칭 실패).
+ */
+function matchPositionsForCandidate(
+  candidate: NearestStationResult,
+  positions: (LinePositions | null)[],
+): LinePositions['trains'] {
+  for (const lp of positions) {
+    if (!lp || lp.line !== candidate.station.line) continue;
+    return lp.trains.filter((t) => t.statnNm === candidate.station.name);
+  }
+  return [];
+}
+
 export function useFusedNearestStation(
-  provider?: ArrivalProvider,
+  arrivalProvider?: ArrivalProvider,
+  positionProvider?: PositionProvider,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation();
 
@@ -55,27 +82,42 @@ export function useFusedNearestStation(
     );
   }, [gps.userLocation]);
 
-  // 후보 K개에 대한 arrival 폴링 — hooks는 고정 순서 호출이 필요하므로 N=3 고정.
-  // 후보 부족 시 null로 호출 → useArrivalInfo 내부에서 no-op.
+  // arrival 폴링: 후보 역명 단위 K=3 고정.
   const c0 = candidates[0]?.station.name ?? null;
   const c1 = candidates[1]?.station.name ?? null;
   const c2 = candidates[2]?.station.name ?? null;
-  const a0 = useArrivalInfo(c0, provider);
-  const a1 = useArrivalInfo(c1, provider);
-  const a2 = useArrivalInfo(c2, provider);
+  const a0 = useArrivalInfo(c0, arrivalProvider);
+  const a1 = useArrivalInfo(c1, arrivalProvider);
+  const a2 = useArrivalInfo(c2, arrivalProvider);
+
+  // position 폴링: 후보 역들의 호선만 dedup 후 K=3 고정 슬롯.
+  // (대부분 1~2개 호선이지만 환승 인근에서 3개까지 가능)
+  const activeLines = useMemo(() => findActiveLines(candidates), [candidates]);
+  const l0 = activeLines[0] ?? null;
+  const l1 = activeLines[1] ?? null;
+  const l2 = activeLines[2] ?? null;
+  const p0 = useTrainPositions(l0, positionProvider);
+  const p1 = useTrainPositions(l1, positionProvider);
+  const p2 = useTrainPositions(l2, positionProvider);
 
   const fused = useMemo(() => {
     if (candidates.length === 0) return null;
     const arrivals = [a0.arrival, a1.arrival, a2.arrival];
+    const positions = [p0.positions, p1.positions, p2.positions];
     return pickFusedStation(
-      candidates.map((cand, i) => ({ candidate: cand, arrival: arrivals[i] ?? null })),
+      candidates.map((cand, i) => ({
+        candidate: cand,
+        arrival: arrivals[i] ?? null,
+        positionMatches: matchPositionsForCandidate(cand, positions),
+      })),
     );
-  }, [candidates, a0.arrival, a1.arrival, a2.arrival]);
+  }, [candidates, a0.arrival, a1.arrival, a2.arrival, p0.positions, p1.positions, p2.positions]);
 
   return {
     result: fused?.result ?? gps.result,
     gpsResult: gps.result,
     confidence: fused?.confidence ?? 'gps-only',
+    source: fused?.source ?? 'gps',
     variants: gps.variants,
     userLocation: gps.userLocation,
     speedMps: gps.speedMps,

--- a/src/hooks/useTrainPositions.ts
+++ b/src/hooks/useTrainPositions.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { LinePositions } from '../api/positionApi';
+import type { PositionProvider } from '../providers/types';
+import { createPositionProvider } from '../providers/factory';
+import { TtlCache } from '../utils/ttlCache';
+import { usePolling } from './usePolling';
+import type { LineNumber } from '../types/station';
+
+const POLL_INTERVAL_MS = 5_000;
+const CACHE_TTL_MS = 30_000;
+
+/**
+ * 모듈 스코프 싱글톤 — 같은 호선을 여러 hook 인스턴스가 폴링할 때 중복 호출 방지.
+ * useArrivalInfo와 동일 패턴.
+ */
+const positionCache = new TtlCache<LineNumber, LinePositions>(CACHE_TTL_MS);
+
+/** 테스트 격리용. */
+export function __resetPositionCacheForTests(): void {
+  positionCache.clear();
+}
+
+function positionsEqual(a: LinePositions | null, b: LinePositions): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+interface UseTrainPositionsReturn {
+  positions: LinePositions | null;
+  loading: boolean;
+  isMock: boolean;
+}
+
+/**
+ * 호선의 모든 운행 열차 위치를 폴링한다. line=null이면 비활성.
+ * 사용자 GPS 후보의 호선들에 대해 Hook 여러 개 호출(Phase 3 useFusedNearestStation 패턴).
+ */
+export function useTrainPositions(
+  line: LineNumber | null,
+  provider?: PositionProvider,
+): UseTrainPositionsReturn {
+  const [positions, setPositions] = useState<LinePositions | null>(null);
+  const [loading, setLoading] = useState(false);
+  const providerRef = useRef<PositionProvider>(provider ?? createPositionProvider());
+  const positionsRef = useRef<LinePositions | null>(null);
+  const lineRef = useRef(line);
+  lineRef.current = line;
+
+  const update = useCallback((data: LinePositions) => {
+    if (!positionsEqual(positionsRef.current, data)) {
+      positionsRef.current = data;
+      setPositions(data);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!line) {
+      positionsRef.current = null;
+      setPositions(null);
+      setLoading(false);
+      return;
+    }
+
+    const cached = positionCache.get(line);
+    if (cached) {
+      update(cached);
+      setLoading(false);
+    } else {
+      positionsRef.current = null;
+      setPositions(null);
+      setLoading(true);
+    }
+  }, [line, update]);
+
+  useEffect(() => {
+    if (!line) return;
+
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const data = await providerRef.current.getPositions(line);
+        if (cancelled) return;
+        if (!data.isMock) positionCache.set(line, data);
+        update(data);
+      } catch {
+        // Provider 내부에서 에러 처리
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [line, update]);
+
+  usePolling(
+    () => {
+      const l = lineRef.current;
+      if (!l) return;
+      providerRef.current
+        .getPositions(l)
+        .then((data) => {
+          if (l !== lineRef.current) return;
+          if (!data.isMock) positionCache.set(l, data);
+          update(data);
+          setLoading(false);
+        })
+        .catch(() => {});
+    },
+    POLL_INTERVAL_MS,
+    { onResume: () => positionCache.clear() },
+  );
+
+  return { positions, loading, isMock: positions?.isMock ?? false };
+}

--- a/src/providers/__tests__/factory.test.ts
+++ b/src/providers/__tests__/factory.test.ts
@@ -101,5 +101,16 @@ describe('providers/index re-exports', () => {
     expect(providersIndex.SeoulOpenApiProvider).toBeDefined();
     expect(providersIndex.BffArrivalProvider).toBeDefined();
     expect(providersIndex.MockArrivalProvider).toBeDefined();
+    expect(providersIndex.createPositionProvider).toBeDefined();
+    expect(providersIndex.SeoulOpenPositionProvider).toBeDefined();
+    expect(providersIndex.MockPositionProvider).toBeDefined();
+  });
+});
+
+describe('createPositionProvider', () => {
+  it('SeoulOpenPositionProvider 인스턴스를 반환한다', () => {
+    const { createPositionProvider } = require('../factory');
+    const { SeoulOpenPositionProvider } = require('../position/SeoulOpenPositionProvider');
+    expect(createPositionProvider()).toBeInstanceOf(SeoulOpenPositionProvider);
   });
 });

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,6 +1,7 @@
-import type { ArrivalProvider } from './types';
+import type { ArrivalProvider, PositionProvider } from './types';
 import { SeoulOpenApiProvider } from './arrival/SeoulOpenApiProvider';
 import { BffArrivalProvider } from './arrival/BffArrivalProvider';
+import { SeoulOpenPositionProvider } from './position/SeoulOpenPositionProvider';
 
 export function createArrivalProvider(): ArrivalProvider {
   const useBff = process.env.EXPO_PUBLIC_USE_BFF === 'true';
@@ -11,4 +12,12 @@ export function createArrivalProvider(): ArrivalProvider {
   }
 
   return new SeoulOpenApiProvider();
+}
+
+/**
+ * Phase 3: realtimePosition Provider. BFF 도입 시 같은 인터페이스로 추가 가능
+ * (현재는 직접 호출만). 호출 비용은 useTrainPositions의 모듈 싱글톤 캐시가 호선 단위로 dedup.
+ */
+export function createPositionProvider(): PositionProvider {
+  return new SeoulOpenPositionProvider();
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,7 @@
-export type { ArrivalProvider, ArrivalOptions } from './types';
-export { createArrivalProvider } from './factory';
+export type { ArrivalProvider, ArrivalOptions, PositionProvider } from './types';
+export { createArrivalProvider, createPositionProvider } from './factory';
 export { SeoulOpenApiProvider } from './arrival/SeoulOpenApiProvider';
 export { BffArrivalProvider } from './arrival/BffArrivalProvider';
 export { MockArrivalProvider } from './arrival/MockProvider';
+export { SeoulOpenPositionProvider } from './position/SeoulOpenPositionProvider';
+export { MockPositionProvider } from './position/MockPositionProvider';

--- a/src/providers/position/MockPositionProvider.ts
+++ b/src/providers/position/MockPositionProvider.ts
@@ -1,0 +1,9 @@
+import type { PositionProvider } from '../types';
+import { MOCK_POSITIONS, type LinePositions } from '../../api/positionApi';
+import type { LineNumber } from '../../types/station';
+
+export class MockPositionProvider implements PositionProvider {
+  async getPositions(line: LineNumber): Promise<LinePositions> {
+    return { ...MOCK_POSITIONS, line };
+  }
+}

--- a/src/providers/position/SeoulOpenPositionProvider.ts
+++ b/src/providers/position/SeoulOpenPositionProvider.ts
@@ -1,0 +1,10 @@
+import { fetchTrainPositions } from '../../api/positionApi';
+import type { PositionProvider } from '../types';
+import type { FetchPositionOptions, LinePositions } from '../../api/positionApi';
+import type { LineNumber } from '../../types/station';
+
+export class SeoulOpenPositionProvider implements PositionProvider {
+  async getPositions(line: LineNumber, options?: FetchPositionOptions): Promise<LinePositions> {
+    return fetchTrainPositions(line, options);
+  }
+}

--- a/src/providers/position/__tests__/MockPositionProvider.test.ts
+++ b/src/providers/position/__tests__/MockPositionProvider.test.ts
@@ -1,0 +1,10 @@
+import { MockPositionProvider } from '../MockPositionProvider';
+
+describe('MockPositionProvider', () => {
+  it('mock positions 반환 + line 보존', async () => {
+    const provider = new MockPositionProvider();
+    const result = await provider.getPositions('5');
+    expect(result.isMock).toBe(true);
+    expect(result.line).toBe('5');
+  });
+});

--- a/src/providers/position/__tests__/SeoulOpenPositionProvider.test.ts
+++ b/src/providers/position/__tests__/SeoulOpenPositionProvider.test.ts
@@ -1,0 +1,15 @@
+import { SeoulOpenPositionProvider } from '../SeoulOpenPositionProvider';
+import * as positionApi from '../../../api/positionApi';
+
+jest.mock('../../../api/positionApi');
+
+describe('SeoulOpenPositionProvider', () => {
+  it('fetchTrainPositions로 위임한다', async () => {
+    const mock = positionApi.fetchTrainPositions as jest.Mock;
+    mock.mockResolvedValue({ line: '2', trains: [] });
+    const provider = new SeoulOpenPositionProvider();
+
+    await provider.getPositions('2', { timeoutMs: 1000 });
+    expect(mock).toHaveBeenCalledWith('2', { timeoutMs: 1000 });
+  });
+});

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,4 +1,6 @@
 import type { StationArrival } from '../api/arrivalApi';
+import type { LinePositions, FetchPositionOptions } from '../api/positionApi';
+import type { LineNumber } from '../types/station';
 
 export interface ArrivalOptions {
   timeoutMs?: number;
@@ -10,4 +12,9 @@ export interface ArrivalProvider {
     stationName: string,
     options?: ArrivalOptions,
   ): Promise<StationArrival>;
+}
+
+/** 호선 단위 실시간 열차위치 조회 — Phase 3. */
+export interface PositionProvider {
+  getPositions(line: LineNumber, options?: FetchPositionOptions): Promise<LinePositions>;
 }

--- a/src/utils/__tests__/findActiveLines.test.ts
+++ b/src/utils/__tests__/findActiveLines.test.ts
@@ -1,0 +1,22 @@
+import { findActiveLines } from '../findActiveLines';
+import { MOCK_STATIONS } from '../../testUtils/fixtures';
+
+describe('findActiveLines', () => {
+  it('빈 후보 → 빈 배열', () => {
+    expect(findActiveLines([])).toEqual([]);
+  });
+
+  it('호선 dedup, 거리순 보존', () => {
+    const lines = findActiveLines([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.2 }, // 같은 호선 → dedup
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
+      { station: MOCK_STATIONS.yeouinaru, distanceKm: 0.4 }, // line='5'
+    ]);
+    expect(lines).toEqual(['2', '3', '5']);
+  });
+
+  it('단일 호선 → 1개만 반환', () => {
+    expect(findActiveLines([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }])).toEqual(['2']);
+  });
+});

--- a/src/utils/__tests__/pickFusedStation.test.ts
+++ b/src/utils/__tests__/pickFusedStation.test.ts
@@ -114,4 +114,80 @@ describe('pickFusedStation', () => {
     const result = pickFusedStation([{ candidate: cand('gangnam', 0.1), arrival: mixed }]);
     expect(result?.confidence).toBe('arrival-confirmed');
   });
+
+  describe('position 신호 (Phase 3)', () => {
+    const train = (trainStatus: number, receivedAtMs = NOW) => ({
+      statnId: 'X',
+      statnNm: 'X',
+      trainNo: 'T',
+      trainStatus,
+      updnLine: 0,
+      terminalStationId: '',
+      terminalStationName: '',
+      trainType: 'normal' as const,
+      isLastTrain: false,
+      receivedAtMs,
+    });
+
+    it('positionMatches에 ARRIVED(1) 트레인 → arrival-confirmed + source=position', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), positionMatches: [train(1)] },
+      ]);
+      expect(result?.confidence).toBe('arrival-confirmed');
+      expect(result?.source).toBe('position');
+    });
+
+    it('positionMatches에 ENTERING(0) → arrival-arriving + source=position', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), positionMatches: [train(0)] },
+      ]);
+      expect(result?.confidence).toBe('arrival-arriving');
+      expect(result?.source).toBe('position');
+    });
+
+    it('arrival과 position 동시 ARRIVED → source=position 우선', () => {
+      const result = pickFusedStation([
+        {
+          candidate: cand('gangnam', 0.1),
+          arrival: arrival(ARRIVAL_CODE.ARRIVED),
+          positionMatches: [train(1)],
+        },
+      ]);
+      expect(result?.source).toBe('position');
+    });
+
+    it('positionMatches stale(receivedAtMs<=0)는 무시', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), positionMatches: [train(1, 0)] },
+      ]);
+      expect(result?.source).toBe('gps');
+    });
+
+    it('positionMatches 빈 배열/null → 신호 없음', () => {
+      const r1 = pickFusedStation([{ candidate: cand('gangnam', 0.1), positionMatches: [] }]);
+      const r2 = pickFusedStation([{ candidate: cand('gangnam', 0.1), positionMatches: null }]);
+      expect(r1?.source).toBe('gps');
+      expect(r2?.source).toBe('gps');
+    });
+
+    it('positionMatches에 여러 트레인 있으면 가장 강한 신호 채택', () => {
+      const result = pickFusedStation([
+        {
+          candidate: cand('gangnam', 0.1),
+          // ARRIVED → ENTERING 순서: 첫 번째 트레인이 더 강해 두 번째는 무시되는 분기 커버
+          positionMatches: [train(1), train(0)],
+        },
+      ]);
+      expect(result?.confidence).toBe('arrival-confirmed');
+    });
+
+    it('두 후보 중 position 신호가 있는 후보로 fusion 전환', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1) }, // 신호 없음
+        { candidate: cand('chungmuro', 0.3), positionMatches: [train(1)] },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+      expect(result?.source).toBe('position');
+    });
+  });
 });

--- a/src/utils/findActiveLines.ts
+++ b/src/utils/findActiveLines.ts
@@ -1,0 +1,20 @@
+import type { NearestStationResult } from '../types/station';
+import type { LineNumber } from '../types/station';
+
+/**
+ * fusion 후보 역들에서 호선만 dedup해 추출. realtimePosition은 호선 단위 호출이라
+ * 같은 호선의 후보가 여러 개여도 1번만 폴링하면 됨.
+ *
+ * 입력 순서(거리 가까운 → 먼)를 보존해 활성 호선 우선순위가 자연스럽게 GPS 거리로 정렬됨.
+ */
+export function findActiveLines(candidates: NearestStationResult[]): LineNumber[] {
+  const seen = new Set<LineNumber>();
+  const out: LineNumber[] = [];
+  for (const c of candidates) {
+    const line = c.station.line;
+    if (seen.has(line)) continue;
+    seen.add(line);
+    out.push(line);
+  }
+  return out;
+}

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -1,28 +1,41 @@
 import type { NearestStationResult } from '../types/station';
 import type { StationArrival } from '../api/arrivalApi';
+import type { LinePositions } from '../api/positionApi';
 import { getArrivalPriority } from '../constants/arrivalCodes';
+import { getTrainStatusPriority } from '../constants/trainStatus';
 
 /**
- * fusion 결과 신뢰도 — UI/로깅용. arrival 신호로 확정/추정된 경우 GPS-only보다 신선.
+ * fusion 결과 신뢰도 — UI/로깅용. 점수 ≥ 100이면 confirmed, 0 < x < 100이면 arriving.
+ * 신호원(arrival/position)은 source 필드로 분리 식별.
  */
 export type FusionConfidence = 'arrival-confirmed' | 'arrival-arriving' | 'gps-only';
+
+/**
+ * fusion 신호 출처. position이 가장 정확(실제 좌표), arrival은 추정(곧 도착),
+ * gps는 거리 기반. 알람 dedup·로깅에서 source별 정책 분기에 사용.
+ */
+export type FusionSource = 'position' | 'arrival' | 'gps';
 
 export interface FusedStationResult {
   result: NearestStationResult;
   confidence: FusionConfidence;
-  source: 'arrival' | 'gps';
+  source: FusionSource;
 }
 
-interface CandidateArrival {
+export interface FusionCandidate {
   candidate: NearestStationResult;
-  arrival: StationArrival | null;
+  /** 도착정보 신호 (Phase 2). null이면 신호 없음. */
+  arrival?: StationArrival | null;
+  /**
+   * 위치정보 신호 (Phase 3). 후보 역의 호선에 해당하는 LinePositions 중
+   * 후보 역(statnId)에 머무는 열차들. 호출자가 후보별로 매칭해 전달한다.
+   * null이면 신호 없음(미호출/실패/mock).
+   */
+  positionMatches?: LinePositions['trains'] | null;
 }
 
-/**
- * recptnDt 보정 거친 신호 중 가장 강한 priority 점수를 반환.
- * mock/누락(receivedAtMs=0) 신호는 무시 — Stage 1에서 stale로 강등됨.
- */
-function bestPriorityForArrival(arrival: StationArrival | null): number {
+/** mock/stale 무시 + arvlCd 우선순위 최댓값. */
+function bestPriorityForArrival(arrival: StationArrival | null | undefined): number {
   if (!arrival || arrival.isMock) return 0;
   let best = 0;
   for (const list of [arrival.up, arrival.down]) {
@@ -35,46 +48,78 @@ function bestPriorityForArrival(arrival: StationArrival | null): number {
   return best;
 }
 
-function confidenceFromPriority(priority: number): FusionConfidence {
-  if (priority >= 100) return 'arrival-confirmed'; // arvlCd=1 도착
-  if (priority > 0) return 'arrival-arriving';
-  return 'gps-only';
+/** stale(receivedAtMs<=0) 무시 + trainSttus 우선순위 최댓값. */
+function bestPriorityForPosition(
+  trains: LinePositions['trains'] | null | undefined,
+): number {
+  if (!trains || trains.length === 0) return 0;
+  let best = 0;
+  for (const t of trains) {
+    if (t.receivedAtMs <= 0) continue;
+    const p = getTrainStatusPriority(t.trainStatus);
+    if (p > best) best = p;
+  }
+  return best;
 }
 
 /**
- * 후보 역들의 arrival 신호로 fusion한 현재역을 결정한다.
+ * priority > 0 케이스만 호출됨 — gps-only(=priority 0)는 호출자가 early-return으로 처리.
+ * 100점 이상은 ARRIVED(도착 확정) 신호, 그외는 진입/전역 신호로 분류.
+ */
+function confidenceFromPriority(priority: number): FusionConfidence {
+  return priority >= 100 ? 'arrival-confirmed' : 'arrival-arriving';
+}
+
+/**
+ * 후보 역들의 신호(arrival + position)로 fusion한 현재역을 결정한다.
  *
- * 입력 계약: candidates는 거리 오름차순 — `[0]`이 GPS 최근접이어야 함.
- *  (동점 시 거리 가까운 쪽이 자동 선택되도록 순회 순서로 invariant 유지)
+ * 입력 계약: candidates는 거리 오름차순 — `[0]`이 GPS 최근접.
  *
  * 규칙:
- * 1) priority 점수 최댓값을 가진 후보 선택 (arvlCd 1 > 0 > 5 > 4)
- * 2) 동점이면 더 먼저 들어온(=거리 가까운) 후보 유지
- * 3) 모두 0이면 GPS 최근접(=candidates[0]) 사용
- * 4) 후보가 비어있으면 null 반환 — 호출자가 GPS-only 분기로 fallback
+ * 1) 각 후보의 점수 = max(arrival 점수, position 점수). 두 신호원이 같은 priority enum 사용.
+ * 2) 점수 최댓값 후보 선택. 동점이면 거리 가까운(=먼저 들어온) 후보 유지.
+ * 3) source 분류: position 점수 > 0 우선(가장 정확) > arrival 점수 > 0 > GPS.
+ *    같은 점수라도 신호원이 다르면 정확도 순(position > arrival)으로 source 라벨 결정.
+ * 4) 모두 0이면 GPS 최근접 사용.
+ * 5) 후보가 비어있으면 null.
  */
 export function pickFusedStation(
-  candidates: CandidateArrival[],
+  candidates: FusionCandidate[],
 ): FusedStationResult | null {
   if (candidates.length === 0) return null;
 
-  let winner = candidates[0];
-  let winnerPriority = bestPriorityForArrival(winner.arrival);
-
-  for (let i = 1; i < candidates.length; i++) {
-    const p = bestPriorityForArrival(candidates[i].arrival);
+  let winnerIdx = 0;
+  let winnerPriority = -1;
+  let winnerArrScore = 0;
+  let winnerPosScore = 0;
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i];
+    const arrScore = bestPriorityForArrival(c.arrival);
+    const posScore = bestPriorityForPosition(c.positionMatches);
+    const p = Math.max(arrScore, posScore);
     if (p > winnerPriority) {
-      winner = candidates[i];
+      winnerIdx = i;
       winnerPriority = p;
+      winnerArrScore = arrScore;
+      winnerPosScore = posScore;
     }
   }
 
-  const source = winnerPriority > 0 ? 'arrival' : 'gps';
-  // arrival 신호가 없으면 GPS 최근접(=candidates[0])이 정답.
-  const finalResult = source === 'arrival' ? winner.candidate : candidates[0].candidate;
+  if (winnerPriority <= 0) {
+    return {
+      result: candidates[0].candidate,
+      confidence: 'gps-only',
+      source: 'gps',
+    };
+  }
+
+  // source 라벨은 winning priority에 실제로 기여한 신호원.
+  // 두 신호원이 같은 점수로 동점이면 정확도 우선(position) — UI/로깅에서 더 신뢰 표시.
+  const source: FusionSource =
+    winnerPosScore >= winnerArrScore ? 'position' : 'arrival';
 
   return {
-    result: finalResult,
+    result: candidates[winnerIdx].candidate,
     confidence: confidenceFromPriority(winnerPriority),
     source,
   };


### PR DESCRIPTION
## Summary

Phase 2 (#276 이슈, PR #281/#286/#288/#290) 완료 후속. 서울시 \`realtimePosition\` API(스펙: \`scripts/서울시+지하철+실시간+열차+위치정보.xls\`)를 fusion 신호원으로 추가해 추정에서 확정으로 한 단계 업그레이드.

## 변경 요약

| 영역 | 변경 |
|---|---|
| API | 신규 \`positionApi\` (호선 단위 호출, recptnDt 보정) |
| Provider | PositionProvider 인터페이스 + Seoul/Mock 구현 (Arrival과 동형) |
| 상수 | \`lineApiNames\`, \`trainStatus\` (priority 매핑이 \`arrivalCodes.ts\`와 동일 형태) |
| 통합 | \`directAt\` 숫자형을 도착정보 텍스트와 같은 \`TrainType\` enum으로 합치기 |
| 훅 | \`useTrainPositions\` (모듈 싱글톤 캐시, Phase 2 동일 패턴) |
| Fusion | \`pickFusedStation\` 확장 — \`positionMatches\` optional, \`FusionSource\`에 'position' 추가, source는 winning 신호원이 실제 기여한 쪽으로 결정 |

## 확장성 설계

- 신호원 추가에 같은 패턴 — \`getPriority\` 함수 + 모듈 싱글톤 캐시 + Provider 인터페이스
- 새 호선 추가는 \`LineNumber\` + \`LINE_API_NAMES\` 한 줄씩
- 매칭 키는 \`(line, statnNm)\` — stations.json \`id\`와 서울 API \`statnId\`가 키 공간 다름

## 효과

- 현재역 정확도: 추정 → **확정** (TOPIS 선로 신호 직접)
- 호출 비용: 활성 호선 1~3회 vs 후보 역 3회 — 비슷하거나 적음
- Phase 2 알람 fusion이 position 신호로도 자동 격상 (useStationAlarm 변경 없음)

## Test plan

- [x] type-check 통과
- [x] \`npm test\` — 69 suites / 941 tests, 커버리지 100%
- [x] code-review P1 1건(ID 키 불일치) + P2 2건(source 라벨, recptnDt 정규식) 반영
- [ ] 실기기: 지하 구간에서 source='position' 진입 확인
- [ ] 회귀: API 키 미설정 시 기존 동작 유지

Closes #291