### PR TITLE
feat(#282): iOS 홈 위젯 데이터 로드 브리지 구현

### DIFF
--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -47,3 +47,18 @@ export function endLiveActivity(): Promise<void> {
 export function isLiveActivityEnabled(): boolean {
   return LiveActivityModule?.isLiveActivityEnabled() ?? false;
 }
+
+export function saveWidgetStation(
+  stationName: string,
+  lineColor: string,
+  distanceM: number,
+): Promise<void> {
+  return (
+    LiveActivityModule?.saveWidgetStation(stationName, lineColor, distanceM) ??
+    Promise.resolve()
+  );
+}
+
+export function clearWidgetStation(): Promise<void> {
+  return LiveActivityModule?.clearWidgetStation() ?? Promise.resolve();
+}

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -1,5 +1,11 @@
 import ExpoModulesCore
 import UIKit
+import WidgetKit
+
+private let APP_GROUP = "group.com.subwaynow.app"
+private let WIDGET_KEY_STATION_NAME = "stationName"
+private let WIDGET_KEY_LINE_COLOR = "lineColor"
+private let WIDGET_KEY_DISTANCE_M = "distanceM"
 
 public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
@@ -31,6 +37,26 @@ public class LiveActivityModule: Module {
                 return LiveActivityManager.isActivityEnabled()
             }
             return false
+        }
+
+        AsyncFunction("saveWidgetStation") { (stationName: String, lineColor: String, distanceM: Int) in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+            defaults.set(stationName, forKey: WIDGET_KEY_STATION_NAME)
+            defaults.set(lineColor, forKey: WIDGET_KEY_LINE_COLOR)
+            defaults.set(String(distanceM), forKey: WIDGET_KEY_DISTANCE_M)
+            if #available(iOS 14.0, *) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+
+        AsyncFunction("clearWidgetStation") { () -> Void in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+            defaults.removeObject(forKey: WIDGET_KEY_STATION_NAME)
+            defaults.removeObject(forKey: WIDGET_KEY_LINE_COLOR)
+            defaults.removeObject(forKey: WIDGET_KEY_DISTANCE_M)
+            if #available(iOS 14.0, *) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
         }
     }
 }

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -44,6 +44,13 @@ jest.mock('../../../modules/live-activity', () => ({
   isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
 }));
 
+const mockSaveStationToWidget = jest.fn().mockResolvedValue(undefined);
+const mockClearWidgetStation = jest.fn().mockResolvedValue(undefined);
+jest.mock('../widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSaveStationToWidget(...args),
+  clearWidgetStation: () => mockClearWidgetStation(),
+}));
+
 const mockStation: Station = {
   id: 'si-cheong-1',
   name: '시청',
@@ -655,6 +662,36 @@ describe('stationNotification', () => {
     it('dismiss 실패해도 에러를 던지지 않는다', async () => {
       (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
       await expect(clearAlarmNotification()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('widget storage 연동', () => {
+    beforeEach(() => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      mockSaveStationToWidget.mockResolvedValue(undefined);
+      mockClearWidgetStation.mockResolvedValue(undefined);
+    });
+
+    it('updateStationNotification은 saveStationToWidget을 km 단위로 호출한다', async () => {
+      await updateStationNotification(mockStation, 250);
+      expect(mockSaveStationToWidget).toHaveBeenCalledWith(mockStation, 0.25);
+    });
+
+    it('saveStationToWidget이 실패해도 updateLiveActivity는 호출된다', async () => {
+      mockSaveStationToWidget.mockRejectedValueOnce(new Error('group missing'));
+      await updateStationNotification(mockStation, 100);
+      expect(mockUpdateLiveActivity).toHaveBeenCalled();
+    });
+
+    it('clearStationNotification은 clearWidgetStation을 호출한다', async () => {
+      await clearStationNotification();
+      expect(mockClearWidgetStation).toHaveBeenCalled();
+    });
+
+    it('clearWidgetStation이 실패해도 endLiveActivity는 호출된다', async () => {
+      mockClearWidgetStation.mockRejectedValueOnce(new Error('group missing'));
+      await clearStationNotification();
+      expect(mockEndLiveActivity).toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/__tests__/widgetStorage.test.ts
+++ b/src/utils/__tests__/widgetStorage.test.ts
@@ -1,0 +1,82 @@
+import { Platform } from 'react-native';
+import { saveStationToWidget, clearWidgetStation } from '../widgetStorage';
+import { Station } from '../../types/station';
+
+const mockSave = jest.fn().mockResolvedValue(undefined);
+const mockClear = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../modules/live-activity', () => ({
+  saveWidgetStation: (...args: unknown[]) => mockSave(...args),
+  clearWidgetStation: () => mockClear(),
+}));
+
+const station: Station = {
+  id: '2-001',
+  name: '강남',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+describe('widgetStorage (native)', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    // 모듈 스코프 dedupe 캐시 리셋
+    await clearWidgetStation();
+    mockClear.mockClear();
+  });
+
+  describe('saveStationToWidget', () => {
+    it('iOS에서 station 정보와 m 단위 거리로 native 함수를 호출한다', async () => {
+      await saveStationToWidget(station, 0.123);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 123);
+    });
+
+    it('음수 거리는 0으로 보정된다', async () => {
+      await saveStationToWidget(station, -0.5);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 0);
+    });
+
+    it('iOS가 아니면 native 호출 없이 종료된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await saveStationToWidget(station, 0.1);
+      expect(mockSave).not.toHaveBeenCalled();
+    });
+
+    it('같은 역에 대해 연속 호출하면 한 번만 native에 전달된다', async () => {
+      await saveStationToWidget(station, 0.1);
+      await saveStationToWidget(station, 0.2);
+      await saveStationToWidget(station, 0.3);
+      expect(mockSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('역이 바뀌면 다시 native에 전달된다', async () => {
+      const other: Station = { ...station, id: '2-002', name: '역삼' };
+      await saveStationToWidget(station, 0.1);
+      await saveStationToWidget(other, 0.2);
+      expect(mockSave).toHaveBeenCalledTimes(2);
+    });
+
+    it('clearWidgetStation 이후엔 같은 역도 다시 전달된다', async () => {
+      await saveStationToWidget(station, 0.1);
+      await clearWidgetStation();
+      await saveStationToWidget(station, 0.2);
+      expect(mockSave).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('clearWidgetStation', () => {
+    it('iOS에서 native clear를 호출한다', async () => {
+      await clearWidgetStation();
+      expect(mockClear).toHaveBeenCalled();
+    });
+
+    it('iOS가 아니면 native 호출 없이 종료된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await clearWidgetStation();
+      expect(mockClear).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -11,6 +11,7 @@ import { vibrateAlarm, stopVibration } from './alarmSound';
 import { createLogger } from './logger';
 import { incrementBgDiagnostic } from './bgDiagnostics';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
+import { saveStationToWidget, clearWidgetStation } from './widgetStorage';
 import stationsData from '../data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -274,6 +275,10 @@ export async function updateStationNotification(
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
 
+  await saveStationToWidget(currentStation, distanceM / 1000).catch((e) =>
+    notifLogger.error('위젯 저장 실패:', e),
+  );
+
   if (Platform.OS === 'ios') {
     const liveActivityEnabled = LiveActivity.isLiveActivityEnabled();
     liveActivityLogger.info('isLiveActivityEnabled:', liveActivityEnabled);
@@ -311,6 +316,9 @@ async function dismissStationPassedNotification(): Promise<void> {
 }
 
 export async function clearStationNotification(): Promise<void> {
+  await clearWidgetStation().catch((e) =>
+    notifLogger.error('위젯 해제 실패:', e),
+  );
   if (Platform.OS === 'ios') {
     if (!LiveActivity.isLiveActivityEnabled()) {
       notifLogger.info('알림 해제 (Live Activity 비활성)');

--- a/src/utils/widgetStorage.ts
+++ b/src/utils/widgetStorage.ts
@@ -1,0 +1,27 @@
+import { Platform } from 'react-native';
+import * as LiveActivity from 'live-activity';
+import { Station } from '../types/station';
+
+// 동일 역 머무는 동안 매 GPS 폴링마다 WidgetCenter.reloadAllTimelines 가
+// 호출되는 낭비를 막기 위한 station.id 기준 dedupe.
+let lastStationId: string | null = null;
+
+export async function saveStationToWidget(
+  station: Station,
+  distanceKm: number,
+): Promise<void> {
+  if (Platform.OS !== 'ios') return;
+  if (station.id === lastStationId) return;
+  lastStationId = station.id;
+  await LiveActivity.saveWidgetStation(
+    station.name,
+    station.lineColor,
+    Math.max(0, Math.round(distanceKm * 1000)),
+  );
+}
+
+export async function clearWidgetStation(): Promise<void> {
+  lastStationId = null;
+  if (Platform.OS !== 'ios') return;
+  await LiveActivity.clearWidgetStation();
+}


### PR DESCRIPTION
## Summary
- iOS 홈 위젯이 항상 placeholder("감지 중") 만 표시되던 문제 해결
- RN → App Groups UserDefaults 쓰기 + `WidgetCenter.reloadAllTimelines()` 호출하는 native 브리지 추가
- `station.id` 기준 dedupe 로 동일 역 머무는 동안 불필요한 reload 차단

## 변경
- `modules/live-activity/ios/LiveActivityModule.swift` — `saveWidgetStation` / `clearWidgetStation` AsyncFunction
- `modules/live-activity/index.ts` — TS 래퍼
- `src/utils/widgetStorage.ts` (신규) — Platform 가드 + dedupe + 음수 거리 보정
- `src/utils/stationNotification.ts` — update/clear 진입부에서 호출 (.catch 로 격리)

## Test plan
- [x] `npm test` — 842 passed, 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] iOS dev build 실기기에서 위젯 추가 → 역 이름/거리/노선 색이 표시되는지 확인
- [ ] 다른 역으로 이동 시 즉시 갱신 (timeline policy 15분 이전 reload)
- [ ] 같은 역 머무는 동안 reload 호출이 1회만 발생 (dedupe 동작)
- [ ] 목적지 도착 시 위젯이 "감지 중" 으로 비워지는지 확인

Closes #282