### PR TITLE
feat(#293): 노선도 위 실시간 열차 위치 시각화 — Phase 3 Stage 3

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
+import { useActiveLinePositions } from '../../src/hooks/useActiveLinePositions';
 import { StationMap } from '../../src/components/StationMap';
 import { LocationStateView } from '../../src/components/LocationStateView';
 import { StatusChip } from '../../src/components/StatusChip';
@@ -11,6 +12,11 @@ import { useTheme, spacing, radius } from '../../src/theme';
 import { useAppStore } from '../../src/store/useAppStore';
 import { LineBadge } from '../../src/components/LineBadge';
 import { getStationDisplayName } from '../../src/utils/stationDisplay';
+import { findTopNearestStations } from '../../src/utils/findNearestStation';
+import { findActiveLines } from '../../src/utils/findActiveLines';
+import { findTrainCoordinates, buildStationIndex } from '../../src/utils/findTrainCoordinates';
+import { MAX_STATION_DISTANCE_KM } from '../../src/constants/location';
+import { MAX_ACTIVE_LINES } from '../../src/constants/realtime';
 import type { Station } from '../../src/types/station';
 
 export default function MapScreen() {
@@ -26,6 +32,26 @@ export default function MapScreen() {
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
+
+  // Phase 3 Stage 3: 활성 호선의 실시간 열차 위치 → 지도 마커.
+  // 사용자 좌표 기준 후보 역들의 호선만 dedup해 K=3 폴링.
+  const activeLines = useMemo(() => {
+    if (!userLocation) return [];
+    const candidates = findTopNearestStations(
+      userLocation.lat,
+      userLocation.lng,
+      MAX_ACTIVE_LINES,
+      MAX_STATION_DISTANCE_KM,
+    );
+    return findActiveLines(candidates);
+  }, [userLocation?.lat, userLocation?.lng]);
+  const linePositions = useActiveLinePositions(activeLines);
+  // 528개 역 인덱스는 빌드 타임 고정 → 한 번만 만들고 폴링마다 재사용.
+  const stationIndex = useMemo(() => buildStationIndex(allStations), [allStations]);
+  const trainMarkers = useMemo(
+    () => findTrainCoordinates(linePositions, stationIndex),
+    [linePositions, stationIndex],
+  );
 
   if (permissionDenied || loading || !userLocation || error) {
     return (
@@ -59,6 +85,7 @@ export default function MapScreen() {
         nearbyStations={allStations}
         customOriginId={customOrigin?.id}
         onStationPress={(station) => setSelectedStation(station)}
+        trainMarkers={trainMarkers}
       />
 
       {/* 하단 역 선택 카드 */}

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -4,10 +4,27 @@ import { useTranslation } from 'react-i18next';
 import ClusteredMapView from 'react-native-map-clustering';
 import { Marker, PROVIDER_DEFAULT } from 'react-native-maps';
 import type { Station } from '../types/station';
+import type { TrainMarker as TrainMarkerData } from '../utils/findTrainCoordinates';
 import { buildMapConfig } from '../utils/buildMapConfig';
 import { useTheme } from '../theme';
 import { LINE_NAMES } from '../constants/lineColors';
 import { getStationDisplayName } from '../utils/stationDisplay';
+import { TRAIN_STATUS } from '../constants/trainStatus';
+
+/** trainSttus → i18n 키. 데이터 주도 — 새 status 추가 시 한 줄. */
+type StatusKey =
+  | 'map.train.status.arrived'
+  | 'map.train.status.entering'
+  | 'map.train.status.departed'
+  | 'map.train.status.prevDeparted'
+  | 'map.train.status.running';
+const TRAIN_STATUS_I18N_KEY: Record<number, StatusKey> = {
+  [TRAIN_STATUS.ARRIVED]: 'map.train.status.arrived',
+  [TRAIN_STATUS.ENTERING]: 'map.train.status.entering',
+  [TRAIN_STATUS.DEPARTED]: 'map.train.status.departed',
+  [TRAIN_STATUS.PREV_DEPARTED]: 'map.train.status.prevDeparted',
+};
+const TRAIN_STATUS_FALLBACK_KEY: StatusKey = 'map.train.status.running';
 
 interface StationMapProps {
   userLat: number;
@@ -16,6 +33,8 @@ interface StationMapProps {
   nearbyStations: Station[];
   customOriginId?: string;
   onStationPress?: (station: Station) => void;
+  /** Phase 3 Stage 3: 활성 호선의 실시간 열차 위치. 없으면 표시 안 함. */
+  trainMarkers?: TrainMarkerData[];
 }
 
 export function StationMap({
@@ -25,9 +44,10 @@ export function StationMap({
   nearbyStations,
   customOriginId,
   onStationPress,
+  trainMarkers,
 }: StationMapProps) {
   const { colors } = useTheme();
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [mapReady, setMapReady] = useState(false);
 
   const mapConfig = useMemo(
@@ -82,6 +102,40 @@ export function StationMap({
             </Marker>
           );
         })}
+        {trainMarkers?.map((tm) => {
+          // 같은 역에 여러 트레인이 있을 수 있어 trainNo로 키 unique
+          const isArrived = tm.trainStatus === TRAIN_STATUS.ARRIVED;
+          const isEntering = tm.trainStatus === TRAIN_STATUS.ENTERING;
+          // 도착 = 강조(채워짐), 진입 = 외곽선만, 그외 = 흐림
+          const opacity = isArrived ? 1 : isEntering ? 0.85 : 0.5;
+          const statusKey = TRAIN_STATUS_I18N_KEY[tm.trainStatus] ?? TRAIN_STATUS_FALLBACK_KEY;
+          return (
+            <Marker
+              key={`train-${tm.line}-${tm.trainNo}`}
+              coordinate={{ latitude: tm.lat, longitude: tm.lng }}
+              title={t('map.train.terminalSuffix', { name: tm.terminalStationName })}
+              description={t('map.train.descriptionTemplate', {
+                trainNo: tm.trainNo,
+                status: t(statusKey),
+              })}
+              tracksViewChanges={false}
+              testID={`train-marker-${tm.trainNo}`}
+              anchor={{ x: 0.5, y: 0.5 }}
+            >
+              <View
+                style={[
+                  styles.trainMarker,
+                  {
+                    backgroundColor: isArrived ? tm.lineColor : 'transparent',
+                    borderColor: tm.lineColor,
+                    opacity,
+                  },
+                ]}
+                testID={`train-dot-${tm.trainNo}`}
+              />
+            </Marker>
+          );
+        })}
       </ClusteredMapView>
       {!mapReady && (
         <View style={styles.loading} testID="map-loading">
@@ -117,4 +171,11 @@ const styles = StyleSheet.create({
     marginTop: 2,
     textAlign: 'center',
   },
+  trainMarker: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    borderWidth: 2,
+  },
 });
+

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -140,4 +140,66 @@ describe('StationMap', () => {
     expect(result.stations[0].isNearest).toBe(true);
     expect(result.stations[1].isNearest).toBe(false);
   });
+
+  describe('trainMarkers (Phase 3 Stage 3)', () => {
+    const mkTrain = (trainNo: string, status: number) => ({
+      trainNo,
+      line: '2' as const,
+      lineColor: '#009D3E',
+      lat: 37.498,
+      lng: 127.028,
+      statnNm: '강남',
+      trainStatus: status,
+      updnLine: 0,
+      terminalStationName: '성수',
+    });
+
+    it('trainMarkers 미전달 시 train 마커 0개', () => {
+      const { queryAllByTestId } = render(<StationMap {...baseProps} />);
+      expect(queryAllByTestId(/^train-marker-/)).toHaveLength(0);
+    });
+
+    it('trainMarkers 전달 시 trainNo로 마커 렌더', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 1), mkTrain('T002', 0)]} />,
+      );
+      expect(getByTestId('train-marker-T001')).toBeTruthy();
+      expect(getByTestId('train-marker-T002')).toBeTruthy();
+    });
+
+    it('도착(1) description에 "도착"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 1)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('도착');
+    });
+
+    it('진입(0) description에 "진입"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 0)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('진입');
+    });
+
+    it('출발(2) description에 "출발"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 2)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('출발');
+    });
+
+    it('전역 출발(3) → "전역 출발"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 3)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('전역 출발');
+    });
+
+    it('알 수 없는 status → "운행 중"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 99)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('운행 중');
+    });
+  });
 });

--- a/src/constants/realtime.ts
+++ b/src/constants/realtime.ts
@@ -1,0 +1,6 @@
+/**
+ * Phase 3 fusion·시각화에서 동시에 처리하는 활성 호선/후보 역의 최대 개수.
+ * Rules of Hooks 제약으로 useArrivalInfo / useTrainPositions 호출을 동적 개수로 풀 수 없어
+ * 슬롯이 고정된다. 한 곳에서만 변경하도록 단일 출처로 관리.
+ */
+export const MAX_ACTIVE_LINES = 3;

--- a/src/hooks/__tests__/useActiveLinePositions.test.ts
+++ b/src/hooks/__tests__/useActiveLinePositions.test.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react-native';
+import { useActiveLinePositions } from '../useActiveLinePositions';
+import { useTrainPositions } from '../useTrainPositions';
+import type { LinePositions } from '../../api/positionApi';
+
+jest.mock('../useTrainPositions');
+
+const mockUse = useTrainPositions as jest.Mock;
+
+function positionRet(positions: LinePositions | null) {
+  return { positions, loading: false, isMock: false };
+}
+
+describe('useActiveLinePositions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUse.mockReturnValue(positionRet(null));
+  });
+
+  it('빈 activeLines → 3개 슬롯 모두 null로 호출', () => {
+    renderHook(() => useActiveLinePositions([]));
+    expect(mockUse).toHaveBeenNthCalledWith(1, null, undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(2, null, undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(3, null, undefined);
+  });
+
+  it('activeLines K=3 슬롯에 라인 분배', () => {
+    renderHook(() => useActiveLinePositions(['2', '3', '5']));
+    expect(mockUse).toHaveBeenNthCalledWith(1, '2', undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(2, '3', undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(3, '5', undefined);
+  });
+
+  it('K보다 많은 activeLines는 잘라냄', () => {
+    renderHook(() => useActiveLinePositions(['2', '3', '5', '7']));
+    // 4번째 호선은 슬롯이 없어 useTrainPositions 호출 0회
+    expect(mockUse).toHaveBeenCalledTimes(3);
+  });
+
+  it('각 슬롯의 positions를 배열로 반환', () => {
+    const lp2: LinePositions = { line: '2', trains: [] };
+    const lp3: LinePositions = { line: '3', trains: [] };
+    mockUse
+      .mockReturnValueOnce(positionRet(lp2))
+      .mockReturnValueOnce(positionRet(lp3))
+      .mockReturnValueOnce(positionRet(null));
+
+    const { result } = renderHook(() => useActiveLinePositions(['2', '3']));
+    expect(result.current).toEqual([lp2, lp3, null]);
+  });
+
+  it('provider 주입 시 그대로 useTrainPositions에 전달', () => {
+    const provider = { getPositions: jest.fn() };
+    renderHook(() => useActiveLinePositions(['2'], provider));
+    expect(mockUse).toHaveBeenCalledWith('2', provider);
+  });
+});

--- a/src/hooks/useActiveLinePositions.ts
+++ b/src/hooks/useActiveLinePositions.ts
@@ -1,0 +1,24 @@
+import { useTrainPositions } from './useTrainPositions';
+import type { LinePositions } from '../api/positionApi';
+import type { LineNumber } from '../types/station';
+import type { PositionProvider } from '../providers/types';
+
+/**
+ * 활성 호선 K=3 동시 폴링 — Phase 3 Stage 1+2의 useFusedNearestStation 패턴 동일.
+ * Rules of Hooks 제약으로 슬롯 개수 고정. activeLines가 그보다 적으면 null 슬롯으로 no-op.
+ *
+ * 호출 비용은 useTrainPositions 모듈 싱글톤 캐시(positionCache)가 line 단위로 dedup —
+ * useFusedNearestStation과 동시에 같은 호선을 폴링해도 한 번만 호출됨.
+ */
+export function useActiveLinePositions(
+  activeLines: LineNumber[],
+  provider?: PositionProvider,
+): (LinePositions | null)[] {
+  const l0 = activeLines[0] ?? null;
+  const l1 = activeLines[1] ?? null;
+  const l2 = activeLines[2] ?? null;
+  const p0 = useTrainPositions(l0, provider);
+  const p1 = useTrainPositions(l1, provider);
+  const p2 = useTrainPositions(l2, provider);
+  return [p0.positions, p1.positions, p2.positions];
+}

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -6,16 +6,18 @@ import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import { MAX_ACTIVE_LINES } from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
 import type { NearestStationResult, Station } from '../types/station';
 import type { ArrivalProvider, PositionProvider } from '../providers/types';
 
 /**
- * fusion 후보 개수. K=3 고정 — Rules of Hooks로 useArrivalInfo를 동적 개수로 호출할 수 없어
- * 명시적으로 풀어 쓴다(c0/c1/c2). 변경 시 본 파일의 hook 호출 라인도 함께 수정 필요.
- * 호출 비용은 useArrivalInfo의 모듈 스코프 캐시(arrivalCache)가 station name 단위로 dedup.
+ * fusion 후보 개수. MAX_ACTIVE_LINES와 동기화 — Rules of Hooks로 useArrivalInfo/useTrainPositions를
+ * 동적 개수로 호출할 수 없어 본 파일의 hook 호출 라인(c0/c1/c2, l0/l1/l2)도 같이 풀어 쓴다.
+ * 상수 변경 시 hook 호출도 함께 수정해야 한다(컴파일러가 catch 못함).
+ * 호출 비용은 모듈 스코프 캐시(arrivalCache/positionCache)가 station name·line 단위로 dedup.
  */
-const FUSION_CANDIDATE_LIMIT = 3;
+const FUSION_CANDIDATE_LIMIT = MAX_ACTIVE_LINES;
 
 interface UseFusedNearestStationReturn {
   /** GPS+arrival+position fusion으로 결정된 현재역. */

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "Set as origin",
     "setAsDestination": "Set as destination",
     "nearbyStationsHeader": "Nearby stations (within 1km)",
-    "noNearbyStations": "No subway stations within 1km."
+    "noNearbyStations": "No subway stations within 1km.",
+    "train": {
+      "terminalSuffix": "To {{name}}",
+      "descriptionTemplate": "Train {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "Arrived",
+        "entering": "Entering",
+        "departed": "Departed",
+        "prevDeparted": "Departed prev. station",
+        "running": "In service"
+      }
+    }
   },
   "favorites": {
     "title": "Favorites",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "出発駅に設定",
     "setAsDestination": "目的地に設定",
     "nearbyStationsHeader": "周辺の地下鉄駅 (1km以内)",
-    "noNearbyStations": "1km以内に地下鉄駅がありません。"
+    "noNearbyStations": "1km以内に地下鉄駅がありません。",
+    "train": {
+      "terminalSuffix": "{{name}}行",
+      "descriptionTemplate": "列車 {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "到着",
+        "entering": "進入",
+        "departed": "発車",
+        "prevDeparted": "前駅発車",
+        "running": "運行中"
+      }
+    }
   },
   "favorites": {
     "title": "お気に入り",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "출발역으로 설정",
     "setAsDestination": "도착역으로 설정",
     "nearbyStationsHeader": "주변 지하철역 (1km 이내)",
-    "noNearbyStations": "주변 1km 내 지하철역이 없습니다."
+    "noNearbyStations": "주변 1km 내 지하철역이 없습니다.",
+    "train": {
+      "terminalSuffix": "{{name}}행",
+      "descriptionTemplate": "열차 {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "도착",
+        "entering": "진입",
+        "departed": "출발",
+        "prevDeparted": "전역 출발",
+        "running": "운행 중"
+      }
+    }
   },
   "favorites": {
     "title": "즐겨찾기",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "设为出发站",
     "setAsDestination": "设为目的地",
     "nearbyStationsHeader": "附近地铁站(1km以内)",
-    "noNearbyStations": "1km内没有地铁站。"
+    "noNearbyStations": "1km内没有地铁站。",
+    "train": {
+      "terminalSuffix": "开往{{name}}",
+      "descriptionTemplate": "列车 {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "到达",
+        "entering": "进站",
+        "departed": "发车",
+        "prevDeparted": "前站发车",
+        "running": "运行中"
+      }
+    }
   },
   "favorites": {
     "title": "收藏",

--- a/src/utils/__tests__/findTrainCoordinates.test.ts
+++ b/src/utils/__tests__/findTrainCoordinates.test.ts
@@ -1,0 +1,94 @@
+import { findTrainCoordinates, buildStationIndex } from '../findTrainCoordinates';
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import type { Station } from '../../types/station';
+
+const NOW = 1_700_000_000_000;
+
+const stations: Station[] = [
+  { id: 'A', name: '강남', line: '2', lineColor: '#33A23D', lat: 37.498, lng: 127.028 },
+  { id: 'B', name: '역삼', line: '2', lineColor: '#33A23D', lat: 37.500, lng: 127.036 },
+  { id: 'C', name: '충무로', line: '3', lineColor: '#EF7C1C', lat: 37.561, lng: 126.994 },
+];
+
+function train(statnNm: string, status: number, overrides?: Partial<TrainPosition>): TrainPosition {
+  return {
+    statnId: '',
+    statnNm,
+    trainNo: 'T1',
+    trainStatus: status,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: NOW,
+    ...overrides,
+  };
+}
+
+describe('findTrainCoordinates', () => {
+  it('빈 입력 → 빈 배열', () => {
+    expect(findTrainCoordinates([], buildStationIndex(stations))).toEqual([]);
+    expect(findTrainCoordinates([null], buildStationIndex(stations))).toEqual([]);
+  });
+
+  it('LinePositions의 train을 (line, statnNm) 매칭으로 좌표 부여', () => {
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1, { trainNo: 'X' })] };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result).toHaveLength(1);
+    expect(result[0].lat).toBe(37.498);
+    expect(result[0].lng).toBe(127.028);
+    expect(result[0].lineColor).toBe('#33A23D');
+    expect(result[0].trainNo).toBe('X');
+    expect(result[0].trainStatus).toBe(1);
+  });
+
+  it('mock LinePositions는 통째로 무시', () => {
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1)], isMock: true };
+    expect(findTrainCoordinates([lp], buildStationIndex(stations))).toEqual([]);
+  });
+
+  it('stale(receivedAtMs<=0) 트레인 제외', () => {
+    const lp: LinePositions = {
+      line: '2',
+      trains: [train('강남', 1, { receivedAtMs: 0 }), train('역삼', 1)],
+    };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result.map((t) => t.statnNm)).toEqual(['역삼']);
+  });
+
+  it('역명 매칭 실패(unknown) 트레인 제외', () => {
+    const lp: LinePositions = {
+      line: '2',
+      trains: [train('강남', 1), train('없는역', 1)],
+    };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result).toHaveLength(1);
+    expect(result[0].statnNm).toBe('강남');
+  });
+
+  it('호선 인덱스에 없는 LinePositions 제외 (안전장치)', () => {
+    const lp: LinePositions = { line: 'airport', trains: [train('강남', 1)] };
+    expect(findTrainCoordinates([lp], buildStationIndex(stations))).toEqual([]);
+  });
+
+  it('동일 line+name 중복 station은 첫 번째만 인덱싱 (변형 안정성)', () => {
+    const dup = [
+      ...stations,
+      { id: 'A2', name: '강남', line: '2' as const, lineColor: '#33A23D', lat: 0, lng: 0 },
+    ];
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1)] };
+    const result = findTrainCoordinates([lp], buildStationIndex(dup));
+    expect(result[0].lat).toBe(37.498); // 첫 번째 stations[0] 우선
+  });
+
+  it('여러 호선 동시 처리', () => {
+    const lps: LinePositions[] = [
+      { line: '2', trains: [train('강남', 1)] },
+      { line: '3', trains: [train('충무로', 0)] },
+    ];
+    const result = findTrainCoordinates(lps, buildStationIndex(stations));
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.statnNm).sort()).toEqual(['강남', '충무로']);
+  });
+});

--- a/src/utils/__tests__/findTrainCoordinates.test.ts
+++ b/src/utils/__tests__/findTrainCoordinates.test.ts
@@ -89,6 +89,6 @@ describe('findTrainCoordinates', () => {
     ];
     const result = findTrainCoordinates(lps, buildStationIndex(stations));
     expect(result).toHaveLength(2);
-    expect(result.map((t) => t.statnNm).sort()).toEqual(['강남', '충무로']);
+    expect(result.map((t) => t.statnNm).sort((a, b) => a.localeCompare(b))).toEqual(['강남', '충무로']);
   });
 });

--- a/src/utils/findTrainCoordinates.ts
+++ b/src/utils/findTrainCoordinates.ts
@@ -1,0 +1,76 @@
+import type { LinePositions, TrainPosition } from '../api/positionApi';
+import type { LineNumber, Station } from '../types/station';
+
+/** 지도 마커로 표시할 열차 정보 — TrainPosition + 좌표 + lineColor. */
+export interface TrainMarker {
+  trainNo: string;
+  line: LineNumber;
+  lineColor: string;
+  /** 매칭된 역의 좌표(역 위치에 마커 표시 — 열차가 그 역에 있다는 의미). */
+  lat: number;
+  lng: number;
+  statnNm: string;
+  /** trainSttus: 0:진입, 1:도착, 2:출발, 3:전역출발 */
+  trainStatus: number;
+  updnLine: number;
+  terminalStationName: string;
+}
+
+/**
+ * (line, name) → Station 빠른 조회 인덱스. stations 배열은 빌드 타임 고정이므로
+ * 호출자가 한 번 만들어 캐시 후 findTrainCoordinates에 주입한다(매 폴링마다 528개 재빌드 방지).
+ */
+export type StationIndex = Map<LineNumber, Map<string, Station>>;
+
+export function buildStationIndex(stations: Station[]): StationIndex {
+  const indexByLine: StationIndex = new Map();
+  for (const s of stations) {
+    let lineIdx = indexByLine.get(s.line);
+    if (!lineIdx) {
+      lineIdx = new Map();
+      indexByLine.set(s.line, lineIdx);
+    }
+    if (!lineIdx.has(s.name)) lineIdx.set(s.name, s);
+  }
+  return indexByLine;
+}
+
+/**
+ * LinePositions의 각 train을 stations 좌표로 매핑한다.
+ * 매칭 키: `(line, statnNm)` — Phase 3 Stage 1+2 fusion과 같은 정책.
+ *
+ * 매칭 실패(역명 미상)인 트레인은 제외 — 좌표 없이 마커를 그릴 수 없음.
+ * stale(receivedAtMs<=0) 트레인도 제외 — fusion 정책 일관.
+ */
+export function findTrainCoordinates(
+  positions: (LinePositions | null)[],
+  index: StationIndex,
+): TrainMarker[] {
+  const out: TrainMarker[] = [];
+  for (const lp of positions) {
+    if (!lp || lp.isMock) continue;
+    const lineIdx = index.get(lp.line);
+    if (!lineIdx) continue;
+    for (const t of lp.trains) {
+      if (t.receivedAtMs <= 0) continue;
+      const station = lineIdx.get(t.statnNm);
+      if (!station) continue;
+      out.push(toMarker(t, station));
+    }
+  }
+  return out;
+}
+
+function toMarker(t: TrainPosition, s: Station): TrainMarker {
+  return {
+    trainNo: t.trainNo,
+    line: s.line,
+    lineColor: s.lineColor,
+    lat: s.lat,
+    lng: s.lng,
+    statnNm: t.statnNm,
+    trainStatus: t.trainStatus,
+    updnLine: t.updnLine,
+    terminalStationName: t.terminalStationName,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 3 Stage 1+2(PR #292)의 \`realtimePosition\` 데이터를 map 화면 마커로 시각화. 카카오/네이버 수준 UX. **추가 API 호출 0개** — useTrainPositions 모듈 싱글톤 캐시가 useFusedNearestStation과 같은 호선이면 자동 dedup.

## 변경

| 영역 | 변경 |
|---|---|
| 시각화 | StationMap에 \`trainMarkers\` prop. 도착=채움 / 진입=외곽선 / 그외=흐림 |
| 매핑 | \`findTrainCoordinates\` — \`(line, statnNm)\` 매칭(fusion과 일관). StationIndex 분리로 폴링마다 528개 인덱스 재빌드 안 함 |
| 폴링 wrapper | \`useActiveLinePositions\` K=3 슬롯 |
| 상수 | \`MAX_ACTIVE_LINES\` 단일 출처 (useFusedNearestStation도 참조) |
| i18n | \`map.train.*\` 4개 언어 추가, 데이터 주도 키 매핑 |

## 효과

- 사용자가 "내 주변 열차가 지금 어디" 한눈에
- Phase 3 Stage 1+2와 같은 호선이면 폴링 dedup → 비용 0

## Test plan

- [x] type-check 통과
- [x] 71 suites / 961 tests, 커버리지 100%
- [x] code-review P1(i18n) + P2-1(상수) + P2-4(인덱스) 즉시 반영
- [ ] 실기기: 활성 호선 1~3개에서 마커 표시 + 5초 갱신
- [ ] 실기기: 진입/도착/출발 시각 구분
- [ ] 실기기: API 키 미설정 시 마커 0개 (회귀 안전)

## Follow-up

- #295: 같은 역 상하행 트레인 겹침 분리 (P2-2 후속, 별도 PR)

Closes #293