### PR TITLE
feat(#283): dev 빌드 디버그 모달 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -273,9 +273,15 @@ export default function HomeScreen() {
           <>
             {/* Top meta */}
             <View style={styles.topMeta}>
-              <Text style={[typography.mono, { color: colors.subtle }]}>
-                {new Date().toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })}
-              </Text>
+              <Pressable
+                onLongPress={__DEV__ ? () => useAppStore.getState().setDebugVisible(true) : undefined}
+                delayLongPress={700}
+                testID="home-clock"
+              >
+                <Text style={[typography.mono, { color: colors.subtle }]}>
+                  {new Date().toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })}
+                </Text>
+              </Pressable>
               <Text style={[typography.label, { color: colors.subtle }]}>{isCustomOrigin ? t('home.manual') : t('home.live')}</Text>
             </View>
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { DevSettings } from 'react-native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
@@ -9,6 +10,7 @@ import { setMinLevel, createLogger } from '../src/utils/logger';
 import { i18n } from '../src/i18n';
 import { useApplyLocale } from '../src/hooks/useApplyLocale';
 import { useAppStore } from '../src/store/useAppStore';
+import { DebugModal } from '../src/components/DebugModal';
 import '../src/tasks/backgroundLocationTask';
 
 const layoutLogger = createLogger('RootLayout');
@@ -19,11 +21,22 @@ setupNotificationHandler();
 // 프로덕션 빌드에서는 warn 이상만 출력
 if (!__DEV__) {
   setMinLevel('warn');
+} else {
+  // Fast Refresh 시 모듈 톱레벨이 재실행되며 menu item이 중복 등록되는 것을 방지.
+  const g = globalThis as { __SUBWAY_DEV_MENU_REGISTERED__?: boolean };
+  if (!g.__SUBWAY_DEV_MENU_REGISTERED__) {
+    g.__SUBWAY_DEV_MENU_REGISTERED__ = true;
+    DevSettings.addMenuItem('Subway debug', () => {
+      useAppStore.getState().setDebugVisible(true);
+    });
+  }
 }
 
 function RootContent() {
   const { isDark } = useTheme();
   const loadLocalePreference = useAppStore((s) => s.loadLocalePreference);
+  const debugVisible = useAppStore((s) => s.debugVisible);
+  const setDebugVisible = useAppStore((s) => s.setDebugVisible);
   const { i18n: i18nInstance } = useTranslation();
 
   useEffect(() => {
@@ -41,6 +54,9 @@ function RootContent() {
     <>
       <StatusBar style={isDark ? 'light' : 'dark'} />
       <Stack screenOptions={{ headerShown: false }} />
+      {__DEV__ && debugVisible && (
+        <DebugModal onClose={() => setDebugVisible(false)} />
+      )}
     </>
   );
 }

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AppState,
+  Modal,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useAppStore } from '../store/useAppStore';
+import { useNearestStation } from '../hooks/useNearestStation';
+import { useArrivalInfo } from '../hooks/useArrivalInfo';
+import { clearAlarmLog, getAlarmLog, type AlarmLogEntry } from '../utils/alarmLog';
+import { useTheme, spacing, radius, typography } from '../theme';
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function formatLogLine(entry: AlarmLogEntry): string {
+  const parts: string[] = [
+    formatTime(entry.ts),
+    entry.source,
+    entry.outcome,
+  ];
+  if (entry.reason) parts.push(entry.reason);
+  if (entry.kind) parts.push(entry.kind);
+  if (entry.phaseId) parts.push(entry.phaseId);
+  if (entry.stationName) parts.push(entry.stationName);
+  if (entry.location) {
+    parts.push(
+      `acc=${entry.location.accuracy ?? '-'} age=${entry.location.ageMs}ms`,
+    );
+  }
+  return parts.join(' | ');
+}
+
+function buildDumpText(args: {
+  userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
+  nearestName: string | null;
+  nearestDistanceM: number | null;
+  variants: string[];
+  arrivalSummary: string;
+  isMock: boolean;
+  logs: AlarmLogEntry[];
+}): string {
+  const lines: string[] = [];
+  lines.push(`[Subway debug] ${new Date().toISOString()}`);
+  lines.push('');
+  lines.push('## GPS');
+  lines.push(
+    args.userLocation
+      ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s`
+      : '(no location)',
+  );
+  lines.push('');
+  lines.push('## Nearest');
+  lines.push(
+    args.nearestName
+      ? `${args.nearestName} · ${args.nearestDistanceM ?? '-'} m`
+      : '(no nearest station)',
+  );
+  if (args.variants.length > 0) {
+    lines.push(`variants: ${args.variants.join(', ')}`);
+  }
+  lines.push('');
+  lines.push('## Arrival');
+  lines.push(args.arrivalSummary);
+  if (args.isMock) lines.push('(MOCK)');
+  lines.push('');
+  lines.push(`## Alarm log (${args.logs.length})`);
+  for (const entry of [...args.logs].reverse()) {
+    lines.push(formatLogLine(entry));
+  }
+  return lines.join('\n');
+}
+
+interface DebugModalProps {
+  onClose: () => void;
+}
+
+// 디버그 모달은 측정 인프라 — 관찰자 효과를 피하려고 모달이 열린 동안에만 마운트한다.
+// useNearestStation이 별도 Location.watch 구독을 띄우므로, 닫혔을 땐 컴포넌트 자체를
+// 마운트하지 않아 GPS·Arrival 폴링이 2배가 되지 않도록 한다. 호출부(_layout)에서
+// `debugVisible &&` 조건부 렌더를 보장한다.
+export function DebugModal({ onClose }: DebugModalProps) {
+  if (!__DEV__) return null;
+  return <DebugModalInner onClose={onClose} />;
+}
+
+function DebugModalInner({ onClose }: DebugModalProps) {
+  const { colors } = useTheme();
+  const { result, variants, userLocation, speedMps } = useNearestStation();
+  const stationName = result?.station.name ?? null;
+  const { arrival, isMock } = useArrivalInfo(stationName);
+  const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
+
+  const refreshLogs = useCallback(async () => {
+    setLogs(await getAlarmLog());
+  }, []);
+
+  useEffect(() => {
+    void refreshLogs();
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void refreshLogs();
+    });
+    return () => sub.remove();
+  }, [refreshLogs]);
+
+  const handleClear = useCallback(async () => {
+    await clearAlarmLog();
+    await refreshLogs();
+  }, [refreshLogs]);
+
+  const arrivalSummary = (() => {
+    if (!arrival) return '(no arrival data)';
+    const up = arrival.up[0];
+    const down = arrival.down[0];
+    const upText = up
+      ? `up: ${up.destination} · ${Math.round(up.arrivalSeconds)}s${up.statusMessage ? ` (${up.statusMessage})` : ''}`
+      : 'up: -';
+    const downText = down
+      ? `down: ${down.destination} · ${Math.round(down.arrivalSeconds)}s${down.statusMessage ? ` (${down.statusMessage})` : ''}`
+      : 'down: -';
+    return `${upText}\n${downText}`;
+  })();
+
+  const nearestDistanceM = result ? Math.round(result.distanceKm * 1000) : null;
+  const variantNames = variants.map((v) => `${v.name}(${v.line})`);
+
+  const handleShare = useCallback(() => {
+    const message = buildDumpText({
+      userLocation,
+      speedMps,
+      nearestName: result?.station.name ?? null,
+      nearestDistanceM,
+      variants: variantNames,
+      arrivalSummary,
+      isMock,
+      logs,
+    });
+    void Share.share({ message });
+  }, [userLocation, speedMps, result, nearestDistanceM, variantNames, arrivalSummary, isMock, logs]);
+
+  return (
+    <Modal visible animationType="slide" onRequestClose={onClose} testID="debug-modal">
+      <View style={[styles.container, { backgroundColor: colors.bg }]}>
+        <View style={[styles.header, { borderBottomColor: colors.hair }]}>
+          <Text style={[typography.bodySm, { color: colors.ink, fontWeight: '700' }]}>
+            Subway debug
+          </Text>
+          <TouchableOpacity onPress={onClose} testID="debug-modal-close">
+            <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '700' }]}>
+              Close
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView contentContainerStyle={{ padding: spacing.xl }}>
+          <Section title="GPS" colors={colors}>
+            {userLocation ? (
+              <>
+                <KeyValue label="lat" value={String(userLocation.lat)} colors={colors} />
+                <KeyValue label="lng" value={String(userLocation.lng)} colors={colors} />
+                <KeyValue
+                  label="speed"
+                  value={speedMps != null ? `${speedMps.toFixed(2)} m/s` : '-'}
+                  colors={colors}
+                />
+              </>
+            ) : (
+              <Text style={[typography.mono, { color: colors.muted }]}>(no location)</Text>
+            )}
+          </Section>
+
+          <Section title="Nearest station" colors={colors}>
+            {result ? (
+              <>
+                <KeyValue label="name" value={result.station.name} colors={colors} />
+                <KeyValue label="line" value={String(result.station.line)} colors={colors} />
+                <KeyValue
+                  label="distance"
+                  value={`${nearestDistanceM} m`}
+                  colors={colors}
+                />
+                {variantNames.length > 0 && (
+                  <KeyValue
+                    label="variants"
+                    value={variantNames.join(', ')}
+                    colors={colors}
+                  />
+                )}
+              </>
+            ) : (
+              <Text style={[typography.mono, { color: colors.muted }]}>(no nearest)</Text>
+            )}
+          </Section>
+
+          <Section title="Arrival" colors={colors}>
+            <Text style={[typography.mono, { color: colors.ink }]} testID="debug-arrival-summary">
+              {arrivalSummary}
+            </Text>
+            {isMock && (
+              <Text style={[typography.mono, { color: colors.warn, marginTop: spacing.xs }]}>
+                MOCK
+              </Text>
+            )}
+          </Section>
+
+          <Section
+            title={`Alarm log (${logs.length})`}
+            colors={colors}
+            action={
+              <Pressable onPress={refreshLogs} testID="debug-log-refresh">
+                <Text style={[typography.bodySm, { color: colors.accent }]}>Refresh</Text>
+              </Pressable>
+            }
+          >
+            {logs.length === 0 ? (
+              <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
+            ) : (
+              [...logs].reverse().map((entry, idx) => (
+                <Text
+                  key={`${entry.ts}-${idx}`}
+                  style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
+                  selectable
+                >
+                  {formatLogLine(entry)}
+                </Text>
+              ))
+            )}
+          </Section>
+
+          <View style={styles.actions}>
+            <TouchableOpacity
+              style={[styles.actionButton, { borderColor: colors.accent }]}
+              onPress={handleClear}
+              testID="debug-clear-log"
+            >
+              <Text style={[styles.actionText, { color: colors.accent }]}>Clear log</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.accent }]}
+              onPress={handleShare}
+              testID="debug-share-dump"
+            >
+              <Text style={[styles.actionText, { color: colors.onAccent }]}>Share dump</Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+  colors: ReturnType<typeof useTheme>['colors'];
+  action?: React.ReactNode;
+}
+
+function Section({ title, children, colors, action }: SectionProps) {
+  return (
+    <View style={[styles.section, { backgroundColor: colors.card }]}>
+      <View style={styles.sectionHeader}>
+        <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
+        {action}
+      </View>
+      {children}
+    </View>
+  );
+}
+
+function KeyValue({
+  label,
+  value,
+  colors,
+}: {
+  label: string;
+  value: string;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  return (
+    <View style={styles.kvRow}>
+      <Text style={[typography.mono, { color: colors.subtle, width: 80 }]}>{label}</Text>
+      <Text style={[typography.mono, { color: colors.ink, flex: 1 }]} selectable>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+// Internal exports for tests — DO NOT use from app code.
+export const __test__ = { formatLogLine, buildDumpText };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.lg,
+    borderBottomWidth: 1,
+  },
+  section: {
+    padding: spacing.lg,
+    borderRadius: radius.md,
+    marginBottom: spacing.md,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  kvRow: {
+    flexDirection: 'row',
+    marginBottom: 2,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginTop: spacing.lg,
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    alignItems: 'center',
+  },
+  actionText: {
+    fontWeight: '700',
+    fontSize: 14,
+  },
+});

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -46,9 +46,15 @@ const variantStation: Station = {
 };
 
 const baseResult: NearestStationResult = { station, distanceKm: 0.123 };
+const arrivalDefaults = {
+  receivedAtMs: 0,
+  arrivalCode: -1,
+  isLastTrain: false,
+  trainType: 'normal' as const,
+};
 const baseArrival: StationArrival = {
-  up: [{ destination: '청량리', arrivalSeconds: 90, statusMessage: '진입', trainCode: 'U1', arrivalMinutes: 1 }],
-  down: [{ destination: '인천', arrivalSeconds: 240, statusMessage: '', trainCode: 'D1', arrivalMinutes: 4 }],
+  up: [{ destination: '청량리', arrivalSeconds: 90, statusMessage: '진입', trainCode: 'U1', arrivalMinutes: 1, ...arrivalDefaults }],
+  down: [{ destination: '인천', arrivalSeconds: 240, statusMessage: '', trainCode: 'D1', arrivalMinutes: 4, ...arrivalDefaults }],
   isMock: false,
 };
 
@@ -359,8 +365,8 @@ describe('DebugModal arrival edge cases', () => {
   it('up.statusMessage가 빈 문자열이면 괄호를 붙이지 않는다', () => {
     mockUseArrivalInfo.mockReturnValue({
       arrival: {
-        up: [{ destination: '청량리', arrivalSeconds: 60, statusMessage: '', trainCode: 'U', arrivalMinutes: 1 }],
-        down: [{ destination: '인천', arrivalSeconds: 120, statusMessage: '도착', trainCode: 'D', arrivalMinutes: 2 }],
+        up: [{ destination: '청량리', arrivalSeconds: 60, statusMessage: '', trainCode: 'U', arrivalMinutes: 1, ...arrivalDefaults }],
+        down: [{ destination: '인천', arrivalSeconds: 120, statusMessage: '도착', trainCode: 'D', arrivalMinutes: 2, ...arrivalDefaults }],
         isMock: false,
       },
       loading: false,

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -1,0 +1,402 @@
+import React from 'react';
+import { AppState, Share } from 'react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { DebugModal, __test__ } from '../DebugModal';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import type { AlarmLogEntry } from '../../utils/alarmLog';
+import type { Station, NearestStationResult } from '../../types/station';
+import type { StationArrival } from '../../api/arrivalApi';
+
+const mockUseNearestStation = jest.fn();
+const mockUseArrivalInfo = jest.fn();
+const mockGetAlarmLog = jest.fn();
+const mockClearAlarmLog = jest.fn();
+
+jest.mock('../../hooks/useNearestStation', () => ({
+  useNearestStation: () => mockUseNearestStation(),
+}));
+jest.mock('../../hooks/useArrivalInfo', () => ({
+  useArrivalInfo: (name: string | null) => mockUseArrivalInfo(name),
+}));
+jest.mock('../../utils/alarmLog', () => {
+  const actual = jest.requireActual('../../utils/alarmLog');
+  return {
+    ...actual,
+    getAlarmLog: () => mockGetAlarmLog(),
+    clearAlarmLog: () => mockClearAlarmLog(),
+  };
+});
+
+const station: Station = {
+  id: '2-022',
+  name: '강남',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+const variantStation: Station = {
+  id: '7-220',
+  name: '강남구청',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.5172,
+  lng: 127.0413,
+};
+
+const baseResult: NearestStationResult = { station, distanceKm: 0.123 };
+const baseArrival: StationArrival = {
+  up: [{ destination: '청량리', arrivalSeconds: 90, statusMessage: '진입', trainCode: 'U1', arrivalMinutes: 1 }],
+  down: [{ destination: '인천', arrivalSeconds: 240, statusMessage: '', trainCode: 'D1', arrivalMinutes: 4 }],
+  isMock: false,
+};
+
+const setupHookDefaults = () => {
+  mockUseNearestStation.mockReturnValue({
+    result: baseResult,
+    variants: [station, variantStation],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 1.5,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    refresh: jest.fn(),
+  });
+  mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
+  mockGetAlarmLog.mockResolvedValue([]);
+  mockClearAlarmLog.mockResolvedValue(undefined);
+};
+
+describe('DebugModal', () => {
+  let appStateListener: ((state: string) => void) | null = null;
+  const appStateRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListener = null;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_t, l) => {
+      appStateListener = l as (state: string) => void;
+      return { remove: appStateRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+    });
+    setupHookDefaults();
+  });
+
+  it('__DEV__가 false면 null을 반환한다', () => {
+    const g = global as unknown as { __DEV__: boolean };
+    const original = g.__DEV__;
+    g.__DEV__ = false;
+    const { toJSON } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(toJSON()).toBeNull();
+    g.__DEV__ = original;
+  });
+
+  it('GPS / Nearest / Arrival / Alarm log 섹션을 모두 표시한다', async () => {
+    const logEntry: AlarmLogEntry = {
+      ts: new Date('2026-05-12T10:00:00Z').getTime(),
+      source: 'fg',
+      outcome: 'fired',
+      kind: 'destination',
+      phaseId: 'early',
+      stationName: '강남',
+    };
+    mockGetAlarmLog.mockResolvedValue([logEntry]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('GPS')).toBeTruthy();
+    expect(screen.getByText('Nearest station')).toBeTruthy();
+    expect(screen.getByText('Arrival')).toBeTruthy();
+    expect(screen.getByText('Alarm log (1)')).toBeTruthy();
+    expect(screen.getByTestId('debug-arrival-summary').props.children).toContain('청량리');
+  });
+
+  it('userLocation이 null이면 "no location"을 표시한다', () => {
+    mockUseNearestStation.mockReturnValue({
+      result: null,
+      variants: [],
+      userLocation: null,
+      speedMps: null,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('(no location)')).toBeTruthy();
+    expect(screen.getByText('(no nearest)')).toBeTruthy();
+  });
+
+  it('arrival이 null이면 no arrival data를 표시한다', () => {
+    mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('(no arrival data)')).toBeTruthy();
+  });
+
+  it('isMock일 때 MOCK 배지를 표시한다', () => {
+    mockUseArrivalInfo.mockReturnValue({
+      arrival: { ...baseArrival, isMock: true },
+      loading: false,
+      isMock: true,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('MOCK')).toBeTruthy();
+  });
+
+  it('arrival up/down이 비어있어도 렌더링한다', () => {
+    mockUseArrivalInfo.mockReturnValue({
+      arrival: { up: [], down: [], isMock: false },
+      loading: false,
+      isMock: false,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByTestId('debug-arrival-summary').props.children).toBe('up: -\ndown: -');
+  });
+
+  it('speedMps가 null이면 "-"를 표시한다', () => {
+    mockUseNearestStation.mockReturnValue({
+      result: baseResult,
+      variants: [],
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('-')).toBeTruthy();
+  });
+
+  it('알람 로그 비어있으면 (empty) 표시', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('(empty)')).toBeTruthy();
+  });
+
+  it('Refresh 버튼이 로그를 다시 불러온다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    fireEvent.press(screen.getByTestId('debug-log-refresh'));
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(2));
+  });
+
+  it('Clear log 버튼이 로그를 비우고 재조회한다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-clear-log'));
+    });
+    expect(mockClearAlarmLog).toHaveBeenCalled();
+    expect(mockGetAlarmLog).toHaveBeenCalledTimes(2);
+  });
+
+  it('Close 버튼이 onClose를 호출한다', () => {
+    const onClose = jest.fn();
+    renderWithTheme(<DebugModal onClose={onClose} />);
+    fireEvent.press(screen.getByTestId('debug-modal-close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Share dump 버튼이 Share.share를 호출한다', async () => {
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    expect(shareSpy).toHaveBeenCalled();
+    expect(shareSpy.mock.calls[0][0].message).toContain('Subway debug');
+    shareSpy.mockRestore();
+  });
+
+  it('AppState active 복귀 시 로그를 다시 불러온다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    act(() => {
+      appStateListener?.('active');
+    });
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(2));
+  });
+
+  it('AppState active 외 상태에선 재조회하지 않는다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    act(() => {
+      appStateListener?.('background');
+    });
+    // 짧게 기다려도 호출 횟수가 늘지 않음
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockGetAlarmLog).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmount 시 AppState listener를 정리한다', async () => {
+    const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    unmount();
+    expect(appStateRemove).toHaveBeenCalled();
+  });
+});
+
+describe('DebugModal helpers', () => {
+  it('formatLogLine: location 포함 suppressed 엔트리', () => {
+    const entry: AlarmLogEntry = {
+      ts: new Date('2026-05-12T10:00:00Z').getTime(),
+      source: 'bg',
+      outcome: 'suppressed',
+      reason: 'gate-accuracy',
+      location: { lat: 37.5, lng: 127.0, accuracy: 80, ageMs: 1500 },
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).toContain('bg');
+    expect(line).toContain('suppressed');
+    expect(line).toContain('gate-accuracy');
+    expect(line).toContain('acc=80');
+    expect(line).toContain('age=1500ms');
+  });
+
+  it('formatLogLine: 최소 fired 엔트리', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'fg',
+      outcome: 'fired',
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).toContain('fg');
+    expect(line).toContain('fired');
+  });
+
+  it('formatLogLine: accuracy null이면 "-"로 표기', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'bg',
+      outcome: 'suppressed',
+      reason: 'gate-age',
+      location: { lat: 37.5, lng: 127.0, accuracy: null, ageMs: 5000 },
+    };
+    expect(__test__.formatLogLine(entry)).toContain('acc=-');
+  });
+
+  it('buildDumpText: 모든 섹션 포함', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 2,
+      nearestName: '강남',
+      nearestDistanceM: 123,
+      variants: ['강남(2)'],
+      arrivalSummary: 'up: 청량리 · 90s',
+      isMock: true,
+      logs: [{ ts: Date.now(), source: 'fg', outcome: 'fired', stationName: '강남' }],
+    });
+    expect(dump).toContain('## GPS');
+    expect(dump).toContain('## Nearest');
+    expect(dump).toContain('variants: 강남(2)');
+    expect(dump).toContain('## Arrival');
+    expect(dump).toContain('(MOCK)');
+    expect(dump).toContain('## Alarm log (1)');
+  });
+
+  it('buildDumpText: 빈 상태 표기', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      arrivalSummary: '(no arrival data)',
+      isMock: false,
+      logs: [],
+    });
+    expect(dump).toContain('(no location)');
+    expect(dump).toContain('(no nearest station)');
+    expect(dump).not.toContain('variants:');
+    expect(dump).not.toContain('(MOCK)');
+    expect(dump).toContain('## Alarm log (0)');
+  });
+
+  it('buildDumpText: userLocation은 있고 speedMps만 null이면 "-" 표기', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      nearestName: '강남',
+      nearestDistanceM: null,
+      variants: [],
+      arrivalSummary: 'x',
+      isMock: false,
+      logs: [],
+    });
+    expect(dump).toContain('speed=- m/s');
+    expect(dump).toContain('강남 · - m');
+  });
+
+  it('formatLogLine: location 없는 fired 엔트리는 acc/age를 포함하지 않는다', () => {
+    const line = __test__.formatLogLine({
+      ts: Date.now(),
+      source: 'fg',
+      outcome: 'fired',
+      stationName: '강남',
+    });
+    expect(line).not.toContain('acc=');
+    expect(line).not.toContain('age=');
+  });
+});
+
+describe('DebugModal arrival edge cases', () => {
+  const baseHooks = {
+    result: baseResult,
+    variants: [],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 1,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    refresh: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockUseNearestStation.mockReturnValue(baseHooks);
+  });
+
+  it('up.statusMessage가 빈 문자열이면 괄호를 붙이지 않는다', () => {
+    mockUseArrivalInfo.mockReturnValue({
+      arrival: {
+        up: [{ destination: '청량리', arrivalSeconds: 60, statusMessage: '', trainCode: 'U', arrivalMinutes: 1 }],
+        down: [{ destination: '인천', arrivalSeconds: 120, statusMessage: '도착', trainCode: 'D', arrivalMinutes: 2 }],
+        isMock: false,
+      },
+      loading: false,
+      isMock: false,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    const text = screen.getByTestId('debug-arrival-summary').props.children;
+    expect(text).toBe('up: 청량리 · 60s\ndown: 인천 · 120s (도착)');
+  });
+});
+
+describe('DebugModal share with null nearest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockClearAlarmLog.mockResolvedValue(undefined);
+    mockUseNearestStation.mockReturnValue({
+      result: null,
+      variants: [],
+      userLocation: null,
+      speedMps: null,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
+  });
+
+  it('result null인 상태로 Share dump를 호출해도 동작한다', async () => {
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    expect(shareSpy).toHaveBeenCalled();
+    expect(shareSpy.mock.calls[0][0].message).toContain('(no nearest station)');
+    shareSpy.mockRestore();
+  });
+});

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -26,7 +26,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false });
     jest.clearAllMocks();
   });
 
@@ -586,5 +586,18 @@ describe('useAppStore', () => {
     useAppStore.setState({ localePreference: 'auto' });
     await useAppStore.getState().loadLocalePreference();
     expect(useAppStore.getState().localePreference).toBe('auto');
+  });
+
+  // ── debugVisible ──
+
+  it('초기 debugVisible은 false이다', () => {
+    expect(useAppStore.getState().debugVisible).toBe(false);
+  });
+
+  it('setDebugVisible: 상태를 토글한다', () => {
+    useAppStore.getState().setDebugVisible(true);
+    expect(useAppStore.getState().debugVisible).toBe(true);
+    useAppStore.getState().setDebugVisible(false);
+    expect(useAppStore.getState().debugVisible).toBe(false);
   });
 });

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -27,6 +27,8 @@ interface AppState {
   routePreference: RoutePreference;
   localePreference: LocalePreference;
   alarmEvent: AlarmEvent | null;
+  debugVisible: boolean;
+  setDebugVisible: (visible: boolean) => void;
   addFavorite: (station: Station) => Promise<void>;
   removeFavorite: (stationId: string) => Promise<void>;
   loadFavorites: () => Promise<void>;
@@ -60,6 +62,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   routePreference: 'optimal' as RoutePreference,
   localePreference: 'auto' as LocalePreference,
   alarmEvent: null,
+  debugVisible: false,
+
+  setDebugVisible: (visible: boolean) => {
+    set({ debugVisible: visible });
+  },
 
   loadFavorites: async () => {
     try {


### PR DESCRIPTION
## Summary

- dev 빌드 전용 디버그 모달 추가 — GPS/Nearest/Arrival/AlarmLog 4섹션 라이브 뷰
- 진입점 2개: 홈 시계 longPress(700ms) + DevSettings 흔들기 메뉴(`Subway debug`)
- 액션: Clear log / Share dump(시스템 공유 시트)
- 알람 정확도 로드맵 B2(측정 인프라)의 **출력 채널** — 적재된 측정값을 실기기에서 즉시 확인

## 설계 결정

- **`__DEV__` + `debugVisible` 조건부 마운트**: `useNearestStation`이 별도 `Location.watch` 구독을 띄우는 훅이므로, 모달이 닫혔을 땐 컴포넌트 자체를 mount하지 않아 GPS 폴링이 2배가 되지 않도록 했다(관찰자 효과 차단). 코드 리뷰 P1-1 반영.
- **DevSettings 중복 등록 가드**: Fast Refresh로 모듈 톱레벨이 재실행되면 menu가 누적 등록되므로 `globalThis` 플래그로 1회만 등록. 코드 리뷰 P1-2 반영.
- **zustand `debugVisible`**: 트리거 두 곳(`_layout` DevSettings 콜백 + 홈 시계)에서 공유하는 단일 visibility state. persist 제외.

## 범위 외 (별도 후속 이슈로 분리)

- `AlarmLogEntry` 스키마 확장 — fired 케이스에 발사 시점 location/arrival 컨텍스트 stamp. UI가 먼저 있어야 "어떤 필드가 진짜 부족한지" 사후 검증 가능.

Closes #283

## Test plan

- [x] `npm run type-check` 통과
- [x] `npm test` 967 tests 통과, 100% 커버리지
- [ ] dev client 빌드: 홈 시계 longPress 700ms → 모달 열림
- [ ] dev client 빌드: 흔들기 → DevSettings 메뉴에 "Subway debug" → 모달 열림
- [ ] dev client 빌드: Clear log → 알람 로그 비워짐
- [ ] dev client 빌드: Share dump → 시스템 공유 시트 / 텍스트에 4섹션 포함
- [ ] preview 빌드: 시계 longPress 무반응, DevSettings 메뉴 항목 없음