### PR TITLE
feat: TTS 음성 안내 (Phase 3 Stage 4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-location": "~19.0.8",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.23",
+        "expo-speech": "~14.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-task-manager": "~14.0.9",
@@ -7077,6 +7078,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-speech": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-14.0.8.tgz",
+      "integrity": "sha512-UjBFCFv58nutlLw92L7kUS0ZjbOOfaTdiEv/HbjvMrT6BfldoOLLBZbaEcEhDdZK36NY/kass0Kzxk+co6vxSQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "expo-location": "~19.0.8",
     "expo-notifications": "~0.32.16",
     "expo-router": "~6.0.23",
+    "expo-speech": "~14.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-task-manager": "~14.0.9",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -8,10 +8,10 @@ import zh from './locales/zh.json';
 // 자동으로 따라온다. nativeName은 화면 언어와 무관하게 그 언어 사용자가 자기 언어를
 // 알아볼 수 있도록 native name으로 표기한다 (예: ja → 日本語).
 export const LANGUAGE_REGISTRY = [
-  { code: 'ko', nativeName: '한국어', translation: ko },
-  { code: 'en', nativeName: 'English', translation: en },
-  { code: 'ja', nativeName: '日本語', translation: ja },
-  { code: 'zh', nativeName: '中文', translation: zh },
+  { code: 'ko', nativeName: '한국어', translation: ko, ttsLocale: 'ko-KR' },
+  { code: 'en', nativeName: 'English', translation: en, ttsLocale: 'en-US' },
+  { code: 'ja', nativeName: '日本語', translation: ja, ttsLocale: 'ja-JP' },
+  { code: 'zh', nativeName: '中文', translation: zh, ttsLocale: 'zh-CN' },
 ] as const;
 
 export const SUPPORTED_LANGUAGES = LANGUAGE_REGISTRY.map(

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -32,6 +32,11 @@ jest.mock('../alarmSound', () => ({
   stopVibration: () => mockStopVibration(),
 }));
 
+const mockSpeakAlarm = jest.fn();
+jest.mock('../tts', () => ({
+  speakAlarm: (...args: unknown[]) => mockSpeakAlarm(...args),
+}));
+
 const mockStartLiveActivity = jest.fn().mockResolvedValue(undefined);
 const mockUpdateLiveActivity = jest.fn().mockResolvedValue(undefined);
 const mockEndLiveActivity = jest.fn().mockResolvedValue(undefined);
@@ -577,6 +582,24 @@ describe('stationNotification', () => {
       await sendAlarmNotification(earlyDest);
       // 권한 거부여도 호출은 시도 (silent fail은 OS 단에서 발생)
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    });
+
+    it('TTS는 알람 body를 sleepMode/allowSpeaker와 함께 호출한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest, false, true);
+      expect(mockSpeakAlarm).toHaveBeenCalledWith('다음 역 강남에서 내리세요!', {
+        sleepMode: false,
+        allowSpeaker: true,
+      });
+    });
+
+    it('TTS는 silent 게이트(sleepMode/allowSpeaker)를 그대로 전달한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest, true, false);
+      expect(mockSpeakAlarm).toHaveBeenCalledWith('다음 역 강남에서 내리세요!', {
+        sleepMode: true,
+        allowSpeaker: false,
+      });
     });
   });
 

--- a/src/utils/__tests__/tts.test.ts
+++ b/src/utils/__tests__/tts.test.ts
@@ -1,0 +1,69 @@
+import * as Speech from 'expo-speech';
+import i18next from 'i18next';
+import { speakAlarm } from '../tts';
+
+jest.mock('expo-speech', () => ({
+  speak: jest.fn(),
+}));
+
+jest.mock('i18next', () => ({
+  __esModule: true,
+  default: { language: 'ko' },
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe('speakAlarm', () => {
+  const mockSpeak = Speech.speak as jest.Mock;
+  const i18n = i18next as unknown as { language: string };
+
+  beforeEach(() => {
+    mockSpeak.mockReset();
+    i18n.language = 'ko';
+  });
+
+  it('허용 조건이면 i18n.language에 매핑된 locale로 발화한다', () => {
+    speakAlarm('테스트', { sleepMode: false, allowSpeaker: true });
+    expect(mockSpeak).toHaveBeenCalledWith('테스트', { language: 'ko-KR' });
+  });
+
+  it.each([
+    ['en', 'en-US'],
+    ['ja', 'ja-JP'],
+    ['zh', 'zh-CN'],
+  ])('language=%s이면 locale=%s로 발화한다', (lang, locale) => {
+    i18n.language = lang;
+    speakAlarm('x', { sleepMode: false, allowSpeaker: true });
+    expect(mockSpeak).toHaveBeenCalledWith('x', { language: locale });
+  });
+
+  it('알 수 없는 language는 en-US로 폴백한다', () => {
+    i18n.language = 'fr';
+    speakAlarm('x', { sleepMode: false, allowSpeaker: true });
+    expect(mockSpeak).toHaveBeenCalledWith('x', { language: 'en-US' });
+  });
+
+  it('sleepMode이면 발화하지 않는다', () => {
+    speakAlarm('x', { sleepMode: true, allowSpeaker: true });
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('allowSpeaker=false이면 발화하지 않는다', () => {
+    speakAlarm('x', { sleepMode: false, allowSpeaker: false });
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('Speech.speak가 throw해도 예외를 삼킨다', () => {
+    mockSpeak.mockImplementationOnce(() => {
+      throw new Error('tts engine failed');
+    });
+    expect(() => speakAlarm('x', { sleepMode: false, allowSpeaker: true })).not.toThrow();
+  });
+});

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -8,6 +8,7 @@ import type { AlarmEvent } from './stationAlarm';
 import type { NextTarget } from './stationPipeline';
 import * as LiveActivity from 'live-activity';
 import { vibrateAlarm, stopVibration } from './alarmSound';
+import { speakAlarm } from './tts';
 import { createLogger } from './logger';
 import { incrementBgDiagnostic } from './bgDiagnostics';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
@@ -421,6 +422,7 @@ export async function sendAlarmNotification(
     ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
   });
   vibrateAlarm(sleepMode);
+  speakAlarm(body, { sleepMode, allowSpeaker });
   notifLogger.info('알람 알림:', title, body);
 }
 

--- a/src/utils/tts.ts
+++ b/src/utils/tts.ts
@@ -1,0 +1,31 @@
+import * as Speech from 'expo-speech';
+import i18next from 'i18next';
+import { FALLBACK_LANGUAGE, LANGUAGE_REGISTRY } from '../i18n/types';
+import { createLogger } from './logger';
+
+const logger = createLogger('TTS');
+
+const FALLBACK_TTS_LOCALE =
+  LANGUAGE_REGISTRY.find((l) => l.code === FALLBACK_LANGUAGE)!.ttsLocale;
+
+function resolveTtsLocale(language: string): string {
+  return (
+    LANGUAGE_REGISTRY.find((l) => l.code === language)?.ttsLocale ?? FALLBACK_TTS_LOCALE
+  );
+}
+
+export interface TtsGate {
+  sleepMode: boolean;
+  allowSpeaker: boolean;
+}
+
+export function speakAlarm(text: string, gate: TtsGate): void {
+  if (gate.sleepMode || !gate.allowSpeaker) {
+    return;
+  }
+  try {
+    Speech.speak(text, { language: resolveTtsLocale(i18next.language) });
+  } catch (e) {
+    logger.error('speak failed:', e);
+  }
+}


### PR DESCRIPTION
## Summary

- 알람 발생 시 `expo-speech`로 음성 안내. 기존 알람 i18n body 그대로 재사용 (별도 TTS 키 없음).
- silent 게이트는 `sleepMode || !allowSpeaker` — 취침 모드/스피커 차단 시 no-op.
- `LANGUAGE_REGISTRY`에 `ttsLocale` 필드 추가해 i18n/TTS SSOT 통합 (코드 리뷰 P1 반영).

## Variables

- 신규: `src/utils/tts.ts` (`speakAlarm(text, gate)`)
- 변경: `src/utils/stationNotification.ts` (`sendAlarmNotification` 끝에서 `speakAlarm` 호출)
- 변경: `src/i18n/types.ts` (registry에 `ttsLocale`)
- 의존성: `expo-speech ~14.0.8`

## Test plan

- [x] \`npm test\` — 73 suites / 997 tests / 커버리지 100%
- [x] \`npm run type-check\` 통과
- [x] code-review 통과 (P1 반영, P2 큐잉은 #299로 분리)
- [ ] 실기기: 도착·환승 알람에서 음성 재생 확인 (이어폰)
- [ ] sleepMode/allowSpeaker=false에서 무음 확인

Closes #298