### PR TITLE
feat(#295): 상하행 트레인 마커 좌우 오프셋 분리

### DIFF
--- a/src/constants/__tests__/trainMarkerOffset.test.ts
+++ b/src/constants/__tests__/trainMarkerOffset.test.ts
@@ -1,0 +1,29 @@
+import {
+  OFFSET_BY_UPDN,
+  TRAIN_MARKER_OFFSET_DEG,
+  UPDN_DOWN_OUTER,
+  UPDN_UP_INNER,
+  getMarkerOffset,
+} from '../trainMarkerOffset';
+
+describe('trainMarkerOffset', () => {
+  it('상수가 스펙과 일치 (0:상행/내선, 1:하행/외선)', () => {
+    expect(UPDN_UP_INNER).toBe(0);
+    expect(UPDN_DOWN_OUTER).toBe(1);
+  });
+
+  it('OFFSET_BY_UPDN: 상행은 서쪽(-), 하행은 동쪽(+), 위도 변화 없음', () => {
+    expect(OFFSET_BY_UPDN[UPDN_UP_INNER]).toEqual({ dLat: 0, dLng: -TRAIN_MARKER_OFFSET_DEG });
+    expect(OFFSET_BY_UPDN[UPDN_DOWN_OUTER]).toEqual({ dLat: 0, dLng: TRAIN_MARKER_OFFSET_DEG });
+  });
+
+  it('getMarkerOffset: 매핑된 값을 그대로 반환', () => {
+    expect(getMarkerOffset(UPDN_UP_INNER)).toEqual({ dLat: 0, dLng: -TRAIN_MARKER_OFFSET_DEG });
+    expect(getMarkerOffset(UPDN_DOWN_OUTER)).toEqual({ dLat: 0, dLng: TRAIN_MARKER_OFFSET_DEG });
+  });
+
+  it('getMarkerOffset: 미지 값(2, -1)은 0 오프셋', () => {
+    expect(getMarkerOffset(2)).toEqual({ dLat: 0, dLng: 0 });
+    expect(getMarkerOffset(-1)).toEqual({ dLat: 0, dLng: 0 });
+  });
+});

--- a/src/constants/trainMarkerOffset.ts
+++ b/src/constants/trainMarkerOffset.ts
@@ -1,0 +1,38 @@
+/**
+ * 같은 역에 상행+하행 트레인이 동시에 매칭되면 마커가 픽셀 단위로 완전히 겹쳐
+ * 시각적으로 구분되지 않는다. `updnLine` 기준으로 위경도를 ±N도 만큼 오프셋해
+ * 좌우로 분리한다(카카오/네이버 지도와 동일 패턴).
+ *
+ * 스펙: scripts/서울시+지하철+실시간+열차+위치정보.xls
+ *   - updnLine: 0 = 상행/내선, 1 = 하행/외선
+ *
+ * 단위: 위도/경도 도(degree). 서울 위도(37.5°) 기준 경도 1° ≈ 88km이므로
+ * 0.00018° ≈ 16m. 줌 레벨 5 이상에서 분리되어 보이도록 잡았다.
+ */
+export const TRAIN_MARKER_OFFSET_DEG = 0.00018;
+
+export const UPDN_UP_INNER = 0;
+export const UPDN_DOWN_OUTER = 1;
+
+export interface MarkerOffset {
+  dLat: number;
+  dLng: number;
+}
+
+/**
+ * updnLine → 위경도 오프셋. 미지 값(2 이상 또는 음수)은 오프셋 없음.
+ *
+ * 호선 방향성(N-S vs E-W)에 따라 트랙 수직 방향이 달라지지만, 대부분의 줌 레벨에서
+ * 경도 오프셋만으로도 시각적 분리가 충분하다. 호선별 차별화가 필요해지면 별도
+ * `OFFSET_BY_LINE` 매핑을 추가해 이 값을 override하는 방식으로 확장한다.
+ */
+export const OFFSET_BY_UPDN: Record<number, MarkerOffset> = {
+  [UPDN_UP_INNER]: { dLat: 0, dLng: -TRAIN_MARKER_OFFSET_DEG },
+  [UPDN_DOWN_OUTER]: { dLat: 0, dLng: TRAIN_MARKER_OFFSET_DEG },
+};
+
+const ZERO_OFFSET: MarkerOffset = { dLat: 0, dLng: 0 };
+
+export function getMarkerOffset(updnLine: number): MarkerOffset {
+  return OFFSET_BY_UPDN[updnLine] ?? ZERO_OFFSET;
+}

--- a/src/utils/__tests__/findTrainCoordinates.test.ts
+++ b/src/utils/__tests__/findTrainCoordinates.test.ts
@@ -1,5 +1,10 @@
 import { findTrainCoordinates, buildStationIndex } from '../findTrainCoordinates';
 import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import {
+  TRAIN_MARKER_OFFSET_DEG,
+  UPDN_DOWN_OUTER,
+  UPDN_UP_INNER,
+} from '../../constants/trainMarkerOffset';
 import type { Station } from '../../types/station';
 
 const NOW = 1_700_000_000_000;
@@ -32,15 +37,40 @@ describe('findTrainCoordinates', () => {
     expect(findTrainCoordinates([null], buildStationIndex(stations))).toEqual([]);
   });
 
-  it('LinePositions의 train을 (line, statnNm) 매칭으로 좌표 부여', () => {
+  it('LinePositions의 train을 (line, statnNm) 매칭으로 좌표 부여 (상행 → 서쪽 오프셋)', () => {
     const lp: LinePositions = { line: '2', trains: [train('강남', 1, { trainNo: 'X' })] };
     const result = findTrainCoordinates([lp], buildStationIndex(stations));
     expect(result).toHaveLength(1);
     expect(result[0].lat).toBe(37.498);
-    expect(result[0].lng).toBe(127.028);
+    expect(result[0].lng).toBeCloseTo(127.028 - TRAIN_MARKER_OFFSET_DEG, 10);
     expect(result[0].lineColor).toBe('#33A23D');
     expect(result[0].trainNo).toBe('X');
     expect(result[0].trainStatus).toBe(1);
+  });
+
+  it('같은 역에 상행+하행 동시 매칭 → 경도 오프셋으로 좌우 분리', () => {
+    const lp: LinePositions = {
+      line: '2',
+      trains: [
+        train('강남', 1, { trainNo: 'UP', updnLine: UPDN_UP_INNER }),
+        train('강남', 1, { trainNo: 'DOWN', updnLine: UPDN_DOWN_OUTER }),
+      ],
+    };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    const up = result.find((t) => t.trainNo === 'UP')!;
+    const down = result.find((t) => t.trainNo === 'DOWN')!;
+    expect(up.lat).toBe(37.498);
+    expect(down.lat).toBe(37.498);
+    expect(up.lng).toBeCloseTo(127.028 - TRAIN_MARKER_OFFSET_DEG, 10);
+    expect(down.lng).toBeCloseTo(127.028 + TRAIN_MARKER_OFFSET_DEG, 10);
+    expect(down.lng - up.lng).toBeCloseTo(2 * TRAIN_MARKER_OFFSET_DEG, 10);
+  });
+
+  it('updnLine이 매핑에 없는 값(예: 2) → 오프셋 0', () => {
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1, { updnLine: 2 })] };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result[0].lat).toBe(37.498);
+    expect(result[0].lng).toBe(127.028);
   });
 
   it('mock LinePositions는 통째로 무시', () => {

--- a/src/utils/findTrainCoordinates.ts
+++ b/src/utils/findTrainCoordinates.ts
@@ -1,4 +1,5 @@
 import type { LinePositions, TrainPosition } from '../api/positionApi';
+import { getMarkerOffset } from '../constants/trainMarkerOffset';
 import type { LineNumber, Station } from '../types/station';
 
 /** 지도 마커로 표시할 열차 정보 — TrainPosition + 좌표 + lineColor. */
@@ -62,12 +63,13 @@ export function findTrainCoordinates(
 }
 
 function toMarker(t: TrainPosition, s: Station): TrainMarker {
+  const { dLat, dLng } = getMarkerOffset(t.updnLine);
   return {
     trainNo: t.trainNo,
     line: s.line,
     lineColor: s.lineColor,
-    lat: s.lat,
-    lng: s.lng,
+    lat: s.lat + dLat,
+    lng: s.lng + dLng,
     statnNm: t.statnNm,
     trainStatus: t.trainStatus,
     updnLine: t.updnLine,


### PR DESCRIPTION
## Summary
- 같은 역에 상행+하행 트레인이 동시 매칭되면 마커가 픽셀 단위로 완전히 겹쳐 구분 불가했음
- `updnLine` 기준 데이터 주도 `OFFSET_BY_UPDN` 매핑으로 좌우 ~16m 분리 (서울 위도 기준 0.00018°)
- 미지 `updnLine` 값은 0 오프셋 (안전장치)

## 변경 파일
- 신규 `src/constants/trainMarkerOffset.ts` — `TRAIN_MARKER_OFFSET_DEG`, `OFFSET_BY_UPDN`, `getMarkerOffset`
- `src/utils/findTrainCoordinates.ts` — `toMarker`에서 오프셋 가산

## 검증
- [x] `npm run type-check` 통과
- [x] `npm test` 993 테스트 통과, 커버리지 100%
- [x] code-review 에이전트 통과 (P0/P1 없음)
- [ ] 실기기: 같은 역에 상행+하행 동시 ARRIVED 시 마커 시각적 분리

Closes #295