### PR TITLE
feat: TTS 발화 큐잉/중첩 정책 (Phase 3 Stage 4 후속)

### DIFF
--- a/src/utils/__tests__/tts.test.ts
+++ b/src/utils/__tests__/tts.test.ts
@@ -4,6 +4,7 @@ import { speakAlarm } from '../tts';
 
 jest.mock('expo-speech', () => ({
   speak: jest.fn(),
+  stop: jest.fn(),
 }));
 
 jest.mock('i18next', () => ({
@@ -22,10 +23,12 @@ jest.mock('../logger', () => ({
 
 describe('speakAlarm', () => {
   const mockSpeak = Speech.speak as jest.Mock;
+  const mockStop = Speech.stop as jest.Mock;
   const i18n = i18next as unknown as { language: string };
 
   beforeEach(() => {
     mockSpeak.mockReset();
+    mockStop.mockReset();
     i18n.language = 'ko';
   });
 
@@ -65,5 +68,20 @@ describe('speakAlarm', () => {
       throw new Error('tts engine failed');
     });
     expect(() => speakAlarm('x', { sleepMode: false, allowSpeaker: true })).not.toThrow();
+  });
+
+  it('발화 직전 이전 발화를 중단해 최신 알람만 남긴다', () => {
+    speakAlarm('first', { sleepMode: false, allowSpeaker: true });
+    speakAlarm('second', { sleepMode: false, allowSpeaker: true });
+    expect(mockStop).toHaveBeenCalledTimes(2);
+    const stopOrder = mockStop.mock.invocationCallOrder[1];
+    const speakOrder = mockSpeak.mock.invocationCallOrder[1];
+    expect(stopOrder).toBeLessThan(speakOrder);
+  });
+
+  it('silent 게이트일 때는 stop도 호출하지 않는다', () => {
+    speakAlarm('x', { sleepMode: true, allowSpeaker: true });
+    speakAlarm('x', { sleepMode: false, allowSpeaker: false });
+    expect(mockStop).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/tts.ts
+++ b/src/utils/tts.ts
@@ -24,6 +24,7 @@ export function speakAlarm(text: string, gate: TtsGate): void {
     return;
   }
   try {
+    Speech.stop();
     Speech.speak(text, { language: resolveTtsLocale(i18next.language) });
   } catch (e) {
     logger.error('speak failed:', e);


### PR DESCRIPTION
## Summary

- Phase 3 Stage 4(#298) 후속. 환승→도착 등 연속 알람 시 expo-speech 기본 큐잉 동작으로 발화가 중첩되는 문제 해결.
- 정책: **"항상 최신 알람만"** — `speakAlarm` 내부에서 `Speech.speak` 직전 `Speech.stop()`을 호출해 이전 발화를 인터럽트. 가장 actionable한 최신 신호 우선.
- silent 게이트(sleepMode / allowSpeaker=false) 통과 시에는 stop도 호출하지 않아 외부 TTS 부작용 방지.

## Test plan

- [x] `npm test` — 1017 tests pass, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-review 에이전트: P1 없음, 머지 가능
- [ ] 실기기: 환승 알람 발화 중 도착 알람 시 도착 안내가 즉시 인터럽트하는지 확인

Closes #299