### PR TITLE
feat(#303): 지도 역 마커 가독성 개선

### DIFF
--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -86,18 +86,17 @@ export function StationMap({
             >
               <View style={styles.markerContainer}>
                 <View
-                  style={[
-                    styles.markerDot,
-                    { backgroundColor: dotColor, borderColor: colors.card },
-                  ]}
+                  style={[styles.markerDot, { backgroundColor: dotColor }]}
                   testID={`dot-${station.id}`}
                 />
-                <Text
-                  style={[styles.markerLabel, { color: colors.ink }]}
-                  numberOfLines={1}
+                <View
+                  style={styles.markerLabelPill}
+                  testID={`label-pill-${station.id}`}
                 >
-                  {getStationDisplayName(station)}
-                </Text>
+                  <Text style={styles.markerLabel} numberOfLines={1}>
+                    {getStationDisplayName(station)}
+                  </Text>
+                </View>
               </View>
             </Marker>
           );
@@ -160,15 +159,28 @@ const styles = StyleSheet.create({
     maxWidth: 60,
   },
   markerDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    borderWidth: 1,
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    borderWidth: 2,
+    borderColor: '#ffffff',
+  },
+  markerLabelPill: {
+    marginTop: 3,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    borderRadius: 4,
+    backgroundColor: 'rgba(255,255,255,0.92)',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 1,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 1,
   },
   markerLabel: {
-    fontSize: 9,
+    fontSize: 12,
     fontWeight: '600',
-    marginTop: 2,
+    color: '#111111',
     textAlign: 'center',
   },
   trainMarker: {

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -82,6 +82,38 @@ describe('StationMap', () => {
     expect(getByTestId('station-map').props.showsUserLocation).toBe(true);
   });
 
+  it('마커 dot이 흰색 테두리와 확대된 크기(14)를 가진다', () => {
+    const { getByTestId } = render(<StationMap {...baseProps} />);
+    const dot = getByTestId('dot-2-023');
+    expect(dot.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          width: 14,
+          height: 14,
+          borderRadius: 7,
+          borderWidth: 2,
+          borderColor: '#ffffff',
+        }),
+      ]),
+    );
+  });
+
+  it('마커 라벨이 흰 pill 위에 검정 텍스트(#111, 12px)로 표시된다', () => {
+    const { getByText, getByTestId } = render(<StationMap {...baseProps} />);
+    const label = getByText('강남');
+    expect(label.props.style).toEqual(
+      expect.objectContaining({
+        fontSize: 12,
+        color: '#111111',
+      }),
+    );
+    expect(getByTestId('label-pill-2-022').props.style).toEqual(
+      expect.objectContaining({
+        backgroundColor: 'rgba(255,255,255,0.92)',
+      }),
+    );
+  });
+
   it('customOriginId와 일치하는 마커는 accent 색상 dot을 사용한다', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} customOriginId="2-023" />,


### PR DESCRIPTION
## Summary
- 마커 점 10→14px, 흰 테두리 2px로 베이스맵 대비 식별성 향상
- 역 이름 라벨을 흰 pill(rgba 0.92) 위 검정(#111) 12px로 표시
- 라벨/테두리 색을 테마에서 분리해 다크모드에서 라벨이 사라지던 문제 해결

## Test plan
- [x] `npm test -- StationMap` 23/23 통과
- [ ] iOS 시뮬레이터에서 라이트/다크 모두 마커·라벨 가독성 확인
- [ ] 환승역·트레인 마커·클러스터 회귀 없음 확인

Closes #303