### PR TITLE
release: v1.2.0 — 다국어 / 실시간 열차 위치 / TTS 알람 / 정확도 개선

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -273,9 +273,15 @@ export default function HomeScreen() {
           <>
             {/* Top meta */}
             <View style={styles.topMeta}>
-              <Text style={[typography.mono, { color: colors.subtle }]}>
-                {new Date().toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })}
-              </Text>
+              <Pressable
+                onLongPress={__DEV__ ? () => useAppStore.getState().setDebugVisible(true) : undefined}
+                delayLongPress={700}
+                testID="home-clock"
+              >
+                <Text style={[typography.mono, { color: colors.subtle }]}>
+                  {new Date().toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })}
+                </Text>
+              </Pressable>
               <Text style={[typography.label, { color: colors.subtle }]}>{isCustomOrigin ? t('home.manual') : t('home.live')}</Text>
             </View>
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -30,7 +30,7 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
-  const { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh } = useNearestStation();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
@@ -130,6 +130,7 @@ export default function HomeScreen() {
     nearestStation: result?.station ?? null,
     userLocation,
     speedMps,
+    accuracyMeters,
   });
   useBackgroundLocation(destination);
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import { AppState, InteractionManager, Pressable, ScrollView, StyleSheet, Switch
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
-import { useNearestStation } from '../../src/hooks/useNearestStation';
+import { useFusedNearestStation } from '../../src/hooks/useFusedNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../../src/utils/formatTime';
@@ -30,7 +30,7 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useNearestStation();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useFusedNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -30,7 +30,7 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh } = useFusedNearestStation();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh, confidence } = useFusedNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
@@ -131,6 +131,7 @@ export default function HomeScreen() {
     userLocation,
     speedMps,
     accuracyMeters,
+    arrivalConfidence: confidence,
   });
   useBackgroundLocation(destination);
 

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
+import { useActiveLinePositions } from '../../src/hooks/useActiveLinePositions';
 import { StationMap } from '../../src/components/StationMap';
 import { LocationStateView } from '../../src/components/LocationStateView';
 import { StatusChip } from '../../src/components/StatusChip';
@@ -11,6 +12,11 @@ import { useTheme, spacing, radius } from '../../src/theme';
 import { useAppStore } from '../../src/store/useAppStore';
 import { LineBadge } from '../../src/components/LineBadge';
 import { getStationDisplayName } from '../../src/utils/stationDisplay';
+import { findTopNearestStations } from '../../src/utils/findNearestStation';
+import { findActiveLines } from '../../src/utils/findActiveLines';
+import { findTrainCoordinates, buildStationIndex } from '../../src/utils/findTrainCoordinates';
+import { MAX_STATION_DISTANCE_KM } from '../../src/constants/location';
+import { MAX_ACTIVE_LINES } from '../../src/constants/realtime';
 import type { Station } from '../../src/types/station';
 
 export default function MapScreen() {
@@ -26,6 +32,26 @@ export default function MapScreen() {
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
+
+  // Phase 3 Stage 3: 활성 호선의 실시간 열차 위치 → 지도 마커.
+  // 사용자 좌표 기준 후보 역들의 호선만 dedup해 K=3 폴링.
+  const activeLines = useMemo(() => {
+    if (!userLocation) return [];
+    const candidates = findTopNearestStations(
+      userLocation.lat,
+      userLocation.lng,
+      MAX_ACTIVE_LINES,
+      MAX_STATION_DISTANCE_KM,
+    );
+    return findActiveLines(candidates);
+  }, [userLocation?.lat, userLocation?.lng]);
+  const linePositions = useActiveLinePositions(activeLines);
+  // 528개 역 인덱스는 빌드 타임 고정 → 한 번만 만들고 폴링마다 재사용.
+  const stationIndex = useMemo(() => buildStationIndex(allStations), [allStations]);
+  const trainMarkers = useMemo(
+    () => findTrainCoordinates(linePositions, stationIndex),
+    [linePositions, stationIndex],
+  );
 
   if (permissionDenied || loading || !userLocation || error) {
     return (
@@ -59,6 +85,7 @@ export default function MapScreen() {
         nearbyStations={allStations}
         customOriginId={customOrigin?.id}
         onStationPress={(station) => setSelectedStation(station)}
+        trainMarkers={trainMarkers}
       />
 
       {/* 하단 역 선택 카드 */}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Alert, Pressable, ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +8,7 @@ import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../../src/i18n/types';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
+import { clearBgDiagnostics, getBgDiagnostics, type BgDiagnostics } from '../../src/utils/bgDiagnostics';
 
 const THEME_OPTIONS = [
   { value: 'auto', labelKey: 'settings.themeAuto' },
@@ -128,8 +129,86 @@ export default function SettingsScreen() {
             />
           </View>
         </View>
+
+        <BgDiagnosticsCard />
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+// #275 진단 패널. 가설 격리 완료 후 제거 예정 — i18n 생략(임시 surface).
+const DIAGNOSTIC_ROWS: readonly { key: keyof BgDiagnostics; label: string }[] = [
+  { key: 'taskFired', label: 'TASK FIRED' },
+  { key: 'gateAge', label: '게이트 컷 (오래된 좌표)' },
+  { key: 'gateAccuracy', label: '게이트 컷 (저정확도)' },
+  { key: 'pipelineEnter', label: 'PIPELINE ENTER' },
+  { key: 'pipelineExitNoDestination', label: 'PIPELINE EXIT (목적지 없음)' },
+  { key: 'alarmEnter', label: 'ALARM ENTER' },
+  { key: 'alarmPermDenied', label: 'ALARM 권한 거부 관찰' },
+  { key: 'stationPassedEnter', label: 'STATION PASSED ENTER' },
+];
+
+function BgDiagnosticsCard() {
+  const { colors } = useTheme();
+  const [snapshot, setSnapshot] = useState<BgDiagnostics | null>(null);
+
+  const refresh = useCallback(async () => {
+    setSnapshot(await getBgDiagnostics());
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleClear = useCallback(() => {
+    Alert.alert('진단 카운터 초기화', '카운터를 모두 0으로 되돌립니다.', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '초기화',
+        style: 'destructive',
+        onPress: async () => {
+          await clearBgDiagnostics();
+          await refresh();
+        },
+      },
+    ]);
+  }, [refresh]);
+
+  if (!snapshot) return null;
+
+  const lastTs = snapshot.lastTaskFiredTs;
+  const lastLabel = lastTs ? new Date(lastTs).toLocaleString() : '없음';
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.card }]}>
+      <Text style={[styles.sectionTitle, { color: colors.muted }]}>진단 (#275)</Text>
+      {DIAGNOSTIC_ROWS.map(({ key, label }) => (
+        <View key={key} style={styles.diagRow}>
+          <Text style={[styles.diagLabel, { color: colors.ink }]}>{label}</Text>
+          <Text style={[styles.diagValue, { color: colors.muted }]}>{String(snapshot[key])}</Text>
+        </View>
+      ))}
+      <View style={[styles.diagRow, { borderTopWidth: 1, borderTopColor: colors.hair, marginTop: spacing.sm, paddingTop: spacing.sm }]}>
+        <Text style={[styles.diagLabel, { color: colors.muted }]}>마지막 TASK FIRED</Text>
+        <Text style={[styles.diagValue, { color: colors.muted }]}>{lastLabel}</Text>
+      </View>
+      <View style={styles.diagActions}>
+        <Pressable
+          style={[styles.diagButton, { borderColor: colors.hair }]}
+          onPress={() => void refresh()}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.diagButtonText, { color: colors.ink }]}>새로고침</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.diagButton, { borderColor: colors.hair }]}
+          onPress={handleClear}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.diagButtonText, { color: colors.ink }]}>초기화</Text>
+        </Pressable>
+      </View>
+    </View>
   );
 }
 
@@ -316,5 +395,37 @@ const styles = StyleSheet.create({
   localeChevron: {
     fontSize: 20,
     marginLeft: spacing.sm,
+  },
+  diagRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  diagLabel: {
+    fontSize: 13,
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  diagValue: {
+    fontSize: 13,
+    fontVariant: ['tabular-nums'],
+    fontWeight: '600',
+  },
+  diagActions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  diagButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderRadius: radius.sm,
+    alignItems: 'center',
+  },
+  diagButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
   },
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,7 +8,12 @@ import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../../src/i18n/types';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
-import { clearBgDiagnostics, getBgDiagnostics, type BgDiagnostics } from '../../src/utils/bgDiagnostics';
+import {
+  BG_DIAGNOSTIC_ROWS,
+  clearBgDiagnostics,
+  getBgDiagnostics,
+  type BgDiagnostics,
+} from '../../src/utils/bgDiagnostics';
 
 const THEME_OPTIONS = [
   { value: 'auto', labelKey: 'settings.themeAuto' },
@@ -137,17 +142,6 @@ export default function SettingsScreen() {
 }
 
 // #275 진단 패널. 가설 격리 완료 후 제거 예정 — i18n 생략(임시 surface).
-const DIAGNOSTIC_ROWS: readonly { key: keyof BgDiagnostics; label: string }[] = [
-  { key: 'taskFired', label: 'TASK FIRED' },
-  { key: 'gateAge', label: '게이트 컷 (오래된 좌표)' },
-  { key: 'gateAccuracy', label: '게이트 컷 (저정확도)' },
-  { key: 'pipelineEnter', label: 'PIPELINE ENTER' },
-  { key: 'pipelineExitNoDestination', label: 'PIPELINE EXIT (목적지 없음)' },
-  { key: 'alarmEnter', label: 'ALARM ENTER' },
-  { key: 'alarmPermDenied', label: 'ALARM 권한 거부 관찰' },
-  { key: 'stationPassedEnter', label: 'STATION PASSED ENTER' },
-];
-
 function BgDiagnosticsCard() {
   const { colors } = useTheme();
   const [snapshot, setSnapshot] = useState<BgDiagnostics | null>(null);
@@ -182,33 +176,41 @@ function BgDiagnosticsCard() {
   return (
     <View style={[styles.card, { backgroundColor: colors.card }]}>
       <Text style={[styles.sectionTitle, { color: colors.muted }]}>진단 (#275)</Text>
-      {DIAGNOSTIC_ROWS.map(({ key, label }) => (
-        <View key={key} style={styles.diagRow}>
-          <Text style={[styles.diagLabel, { color: colors.ink }]}>{label}</Text>
-          <Text style={[styles.diagValue, { color: colors.muted }]}>{String(snapshot[key])}</Text>
-        </View>
+      {BG_DIAGNOSTIC_ROWS.map(({ key, label }) => (
+        <DiagRow key={key} label={label} value={String(snapshot[key])} colors={colors} />
       ))}
       <View style={[styles.diagRow, { borderTopWidth: 1, borderTopColor: colors.hair, marginTop: spacing.sm, paddingTop: spacing.sm }]}>
         <Text style={[styles.diagLabel, { color: colors.muted }]}>마지막 TASK FIRED</Text>
         <Text style={[styles.diagValue, { color: colors.muted }]}>{lastLabel}</Text>
       </View>
       <View style={styles.diagActions}>
-        <Pressable
-          style={[styles.diagButton, { borderColor: colors.hair }]}
-          onPress={() => void refresh()}
-          accessibilityRole="button"
-        >
-          <Text style={[styles.diagButtonText, { color: colors.ink }]}>새로고침</Text>
-        </Pressable>
-        <Pressable
-          style={[styles.diagButton, { borderColor: colors.hair }]}
-          onPress={handleClear}
-          accessibilityRole="button"
-        >
-          <Text style={[styles.diagButtonText, { color: colors.ink }]}>초기화</Text>
-        </Pressable>
+        <DiagButton label="새로고침" onPress={() => void refresh()} colors={colors} />
+        <DiagButton label="초기화" onPress={handleClear} colors={colors} />
       </View>
     </View>
+  );
+}
+
+type DiagColors = { readonly ink: string; readonly muted: string; readonly hair: string };
+
+function DiagRow({ label, value, colors }: { readonly label: string; readonly value: string; readonly colors: DiagColors }) {
+  return (
+    <View style={styles.diagRow}>
+      <Text style={[styles.diagLabel, { color: colors.ink }]}>{label}</Text>
+      <Text style={[styles.diagValue, { color: colors.muted }]}>{value}</Text>
+    </View>
+  );
+}
+
+function DiagButton({ label, onPress, colors }: { readonly label: string; readonly onPress: () => void; readonly colors: DiagColors }) {
+  return (
+    <Pressable
+      style={[styles.diagButton, { borderColor: colors.hair }]}
+      onPress={onPress}
+      accessibilityRole="button"
+    >
+      <Text style={[styles.diagButtonText, { color: colors.ink }]}>{label}</Text>
+    </Pressable>
   );
 }
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { DevSettings } from 'react-native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
@@ -9,6 +10,7 @@ import { setMinLevel, createLogger } from '../src/utils/logger';
 import { i18n } from '../src/i18n';
 import { useApplyLocale } from '../src/hooks/useApplyLocale';
 import { useAppStore } from '../src/store/useAppStore';
+import { DebugModal } from '../src/components/DebugModal';
 import '../src/tasks/backgroundLocationTask';
 
 const layoutLogger = createLogger('RootLayout');
@@ -19,11 +21,22 @@ setupNotificationHandler();
 // 프로덕션 빌드에서는 warn 이상만 출력
 if (!__DEV__) {
   setMinLevel('warn');
+} else {
+  // Fast Refresh 시 모듈 톱레벨이 재실행되며 menu item이 중복 등록되는 것을 방지.
+  const g = globalThis as { __SUBWAY_DEV_MENU_REGISTERED__?: boolean };
+  if (!g.__SUBWAY_DEV_MENU_REGISTERED__) {
+    g.__SUBWAY_DEV_MENU_REGISTERED__ = true;
+    DevSettings.addMenuItem('Subway debug', () => {
+      useAppStore.getState().setDebugVisible(true);
+    });
+  }
 }
 
 function RootContent() {
   const { isDark } = useTheme();
   const loadLocalePreference = useAppStore((s) => s.loadLocalePreference);
+  const debugVisible = useAppStore((s) => s.debugVisible);
+  const setDebugVisible = useAppStore((s) => s.setDebugVisible);
   const { i18n: i18nInstance } = useTranslation();
 
   useEffect(() => {
@@ -41,6 +54,9 @@ function RootContent() {
     <>
       <StatusBar style={isDark ? 'light' : 'dark'} />
       <Stack screenOptions={{ headerShown: false }} />
+      {__DEV__ && debugVisible && (
+        <DebugModal onClose={() => setDebugVisible(false)} />
+      )}
     </>
   );
 }

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -47,3 +47,18 @@ export function endLiveActivity(): Promise<void> {
 export function isLiveActivityEnabled(): boolean {
   return LiveActivityModule?.isLiveActivityEnabled() ?? false;
 }
+
+export function saveWidgetStation(
+  stationName: string,
+  lineColor: string,
+  distanceM: number,
+): Promise<void> {
+  return (
+    LiveActivityModule?.saveWidgetStation(stationName, lineColor, distanceM) ??
+    Promise.resolve()
+  );
+}
+
+export function clearWidgetStation(): Promise<void> {
+  return LiveActivityModule?.clearWidgetStation() ?? Promise.resolve();
+}

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -1,5 +1,11 @@
 import ExpoModulesCore
 import UIKit
+import WidgetKit
+
+private let APP_GROUP = "group.com.subwaynow.app"
+private let WIDGET_KEY_STATION_NAME = "stationName"
+private let WIDGET_KEY_LINE_COLOR = "lineColor"
+private let WIDGET_KEY_DISTANCE_M = "distanceM"
 
 public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
@@ -31,6 +37,26 @@ public class LiveActivityModule: Module {
                 return LiveActivityManager.isActivityEnabled()
             }
             return false
+        }
+
+        AsyncFunction("saveWidgetStation") { (stationName: String, lineColor: String, distanceM: Int) in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+            defaults.set(stationName, forKey: WIDGET_KEY_STATION_NAME)
+            defaults.set(lineColor, forKey: WIDGET_KEY_LINE_COLOR)
+            defaults.set(String(distanceM), forKey: WIDGET_KEY_DISTANCE_M)
+            if #available(iOS 14.0, *) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+
+        AsyncFunction("clearWidgetStation") { () -> Void in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+            defaults.removeObject(forKey: WIDGET_KEY_STATION_NAME)
+            defaults.removeObject(forKey: WIDGET_KEY_LINE_COLOR)
+            defaults.removeObject(forKey: WIDGET_KEY_DISTANCE_M)
+            if #available(iOS 14.0, *) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-location": "~19.0.8",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.23",
+        "expo-speech": "~14.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-task-manager": "~14.0.9",
@@ -7077,6 +7078,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-speech": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-14.0.8.tgz",
+      "integrity": "sha512-UjBFCFv58nutlLw92L7kUS0ZjbOOfaTdiEv/HbjvMrT6BfldoOLLBZbaEcEhDdZK36NY/kass0Kzxk+co6vxSQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "expo-location": "~19.0.8",
     "expo-notifications": "~0.32.16",
     "expo-router": "~6.0.23",
+    "expo-speech": "~14.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-task-manager": "~14.0.9",

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -325,6 +325,42 @@ describe('fetchArrivalInfo', () => {
       expect(result.up.map((i) => i.arrivalCode)).toEqual([1, 0, -1, -1]);
     });
 
+    it('lstcarAt: "1" 또는 1 → isLastTrain true, 그외 false', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: 'A', barvlDt: 60, btrainNo: 'T1', updnLine: '상행', lstcarAt: '1' },
+            { trainLineNm: 'B', barvlDt: 60, btrainNo: 'T2', updnLine: '상행', lstcarAt: 1 },
+            { trainLineNm: 'C', barvlDt: 60, btrainNo: 'T3', updnLine: '상행', lstcarAt: '0' },
+            { trainLineNm: 'D', barvlDt: 60, btrainNo: 'T4', updnLine: '상행' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남', { maxPerDirection: 4 });
+      expect(result.up.map((i) => i.isLastTrain)).toEqual([true, true, false, false]);
+    });
+
+    it('btrainSttus → trainType 매핑', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: 'A', barvlDt: 60, btrainNo: 'T1', updnLine: '상행', btrainSttus: '급행' },
+            { trainLineNm: 'B', barvlDt: 60, btrainNo: 'T2', updnLine: '상행', btrainSttus: 'ITX' },
+            { trainLineNm: 'C', barvlDt: 60, btrainNo: 'T3', updnLine: '상행', btrainSttus: '특급' },
+            { trainLineNm: 'D', barvlDt: 60, btrainNo: 'T4', updnLine: '상행' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남', { maxPerDirection: 4 });
+      expect(result.up.map((i) => i.trainType)).toEqual(['express', 'itx', 'rapid', 'normal']);
+    });
+
     it('realtimeArrivalList가 빈 배열이면 Mock으로 fallback', async () => {
       process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
       global.fetch = jest.fn().mockResolvedValue({

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -306,6 +306,35 @@ describe('fetchArrivalInfo', () => {
       expect(parseRecptnDt('')).toBe(0);
       expect(parseRecptnDt('not-a-date')).toBe(0);
     });
+
+    it('arvlCd: number / 숫자문자열 / 누락 / 비숫자 매핑', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: 'A', barvlDt: 60, btrainNo: 'T1', updnLine: '상행', arvlCd: 1 },
+            { trainLineNm: 'B', barvlDt: 60, btrainNo: 'T2', updnLine: '상행', arvlCd: '0' },
+            { trainLineNm: 'C', barvlDt: 60, btrainNo: 'T3', updnLine: '상행' },
+            { trainLineNm: 'D', barvlDt: 60, btrainNo: 'T4', updnLine: '상행', arvlCd: 'abc' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남', { maxPerDirection: 4 });
+      expect(result.up.map((i) => i.arrivalCode)).toEqual([1, 0, -1, -1]);
+    });
+
+    it('realtimeArrivalList가 빈 배열이면 Mock으로 fallback', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ realtimeArrivalList: [] }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.isMock).toBe(true);
+    });
   });
 
   it('trainLineNm, barvlDt, btrainNo가 undefined이면 기본값을 사용한다', async () => {

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -1,4 +1,4 @@
-import { fetchArrivalInfo, MOCK_ARRIVALS } from '../arrivalApi';
+import { fetchArrivalInfo, MOCK_ARRIVALS, parseRecptnDt } from '../arrivalApi';
 
 describe('fetchArrivalInfo', () => {
   beforeEach(() => {
@@ -230,6 +230,142 @@ describe('fetchArrivalInfo', () => {
     expect(result.up[0].arrivalMinutes).toBe(1);
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  });
+
+  describe('recptnDt 시차 보정', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    });
+
+    it('recptnDt가 30초 전이면 barvlDt에서 30초가 차감된다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // KST 2026-05-12 12:00:30 = UTC 2026-05-12 03:00:30
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:30Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 120,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:00',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(90); // 120 - 30
+      expect(result.up[0].arrivalMinutes).toBe(1);
+      expect(result.up[0].receivedAtMs).toBe(Date.parse('2026-05-12T03:00:00Z'));
+    });
+
+    it('recptnDt가 누락되면 보정 없이 raw barvlDt를 사용한다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: '소요산행', barvlDt: 120, btrainNo: 'T001', updnLine: '상행' },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(120);
+      expect(result.up[0].receivedAtMs).toBe(0);
+    });
+
+    it('보정량이 barvlDt를 초과하면 0으로 클램프된다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // 90초 전 데이터(=cap 이내) + barvlDt=60초 → -30으로 음수 → 0
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:01:30Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 60,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:00',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(0);
+      expect(result.up[0].arrivalMinutes).toBe(0);
+    });
+
+    it('recptnDt가 미래 시각(시계 어긋남)이면 보정 없이 raw 값을 사용한다', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // recptnDt가 현재보다 10초 미래 — driftSec 음수 → max(0, _)로 0 → 보정 없음
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:00Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 120,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:10',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(120);
+    });
+
+    it('drift가 MAX_RECPTN_DRIFT_SEC(120s) 초과면 stale로 강등(보정 없음, receivedAtMs=0)', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      // recptnDt가 5분(300s) 전 — 비정상 drift → stale 처리
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:05:00Z'));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            {
+              trainLineNm: '소요산행',
+              barvlDt: 600,
+              btrainNo: 'T001',
+              updnLine: '상행',
+              recptnDt: '2026-05-12 12:00:00',
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await fetchArrivalInfo('강남');
+      expect(result.up[0].arrivalSeconds).toBe(600); // 보정 없음
+      expect(result.up[0].receivedAtMs).toBe(0); // stale 강등
+    });
+
+    it('parseRecptnDt: 정상 KST 문자열을 epoch ms로 변환한다', () => {
+      expect(parseRecptnDt('2026-05-12 12:00:00')).toBe(Date.parse('2026-05-12T03:00:00Z'));
+    });
+
+    it('parseRecptnDt: 비문자열·빈 문자열·잘못된 포맷은 0을 반환한다', () => {
+      expect(parseRecptnDt(undefined)).toBe(0);
+      expect(parseRecptnDt(null)).toBe(0);
+      expect(parseRecptnDt(12345)).toBe(0);
+      expect(parseRecptnDt('')).toBe(0);
+      expect(parseRecptnDt('not-a-date')).toBe(0);
+    });
   });
 
   it('trainLineNm, barvlDt, btrainNo가 undefined이면 기본값을 사용한다', async () => {

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -233,126 +233,66 @@ describe('fetchArrivalInfo', () => {
   });
 
   describe('recptnDt 시차 보정', () => {
+    const mockArrivalAt = (
+      barvlDt: number,
+      recptnDt?: string,
+      nowIso?: string,
+    ) => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      if (nowIso) jest.useFakeTimers().setSystemTime(new Date(nowIso));
+      const item: Record<string, unknown> = {
+        trainLineNm: '소요산행',
+        barvlDt,
+        btrainNo: 'T001',
+        updnLine: '상행',
+      };
+      if (recptnDt !== undefined) item.recptnDt = recptnDt;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ realtimeArrivalList: [item] }),
+      } as Response);
+    };
+
     afterEach(() => {
       jest.useRealTimers();
       delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
     });
 
     it('recptnDt가 30초 전이면 barvlDt에서 30초가 차감된다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // KST 2026-05-12 12:00:30 = UTC 2026-05-12 03:00:30
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:30Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 120,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:00',
-            },
-          ],
-        }),
-      } as Response);
-
+      mockArrivalAt(120, '2026-05-12 12:00:00', '2026-05-12T03:00:30Z');
       const result = await fetchArrivalInfo('강남');
-      expect(result.up[0].arrivalSeconds).toBe(90); // 120 - 30
+      expect(result.up[0].arrivalSeconds).toBe(90);
       expect(result.up[0].arrivalMinutes).toBe(1);
       expect(result.up[0].receivedAtMs).toBe(Date.parse('2026-05-12T03:00:00Z'));
     });
 
     it('recptnDt가 누락되면 보정 없이 raw barvlDt를 사용한다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            { trainLineNm: '소요산행', barvlDt: 120, btrainNo: 'T001', updnLine: '상행' },
-          ],
-        }),
-      } as Response);
-
+      mockArrivalAt(120);
       const result = await fetchArrivalInfo('강남');
       expect(result.up[0].arrivalSeconds).toBe(120);
       expect(result.up[0].receivedAtMs).toBe(0);
     });
 
     it('보정량이 barvlDt를 초과하면 0으로 클램프된다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // 90초 전 데이터(=cap 이내) + barvlDt=60초 → -30으로 음수 → 0
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:01:30Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 60,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:00',
-            },
-          ],
-        }),
-      } as Response);
-
+      // 90초 전(cap 이내) + barvlDt=60 → 음수 → 0
+      mockArrivalAt(60, '2026-05-12 12:00:00', '2026-05-12T03:01:30Z');
       const result = await fetchArrivalInfo('강남');
       expect(result.up[0].arrivalSeconds).toBe(0);
       expect(result.up[0].arrivalMinutes).toBe(0);
     });
 
     it('recptnDt가 미래 시각(시계 어긋남)이면 보정 없이 raw 값을 사용한다', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // recptnDt가 현재보다 10초 미래 — driftSec 음수 → max(0, _)로 0 → 보정 없음
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:00Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 120,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:10',
-            },
-          ],
-        }),
-      } as Response);
-
+      mockArrivalAt(120, '2026-05-12 12:00:10', '2026-05-12T03:00:00Z');
       const result = await fetchArrivalInfo('강남');
       expect(result.up[0].arrivalSeconds).toBe(120);
     });
 
     it('drift가 MAX_RECPTN_DRIFT_SEC(120s) 초과면 stale로 강등(보정 없음, receivedAtMs=0)', async () => {
-      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
-      // recptnDt가 5분(300s) 전 — 비정상 drift → stale 처리
-      jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:05:00Z'));
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          realtimeArrivalList: [
-            {
-              trainLineNm: '소요산행',
-              barvlDt: 600,
-              btrainNo: 'T001',
-              updnLine: '상행',
-              recptnDt: '2026-05-12 12:00:00',
-            },
-          ],
-        }),
-      } as Response);
-
+      // 5분(300s) 전 — cap 초과
+      mockArrivalAt(600, '2026-05-12 12:00:00', '2026-05-12T03:05:00Z');
       const result = await fetchArrivalInfo('강남');
-      expect(result.up[0].arrivalSeconds).toBe(600); // 보정 없음
-      expect(result.up[0].receivedAtMs).toBe(0); // stale 강등
+      expect(result.up[0].arrivalSeconds).toBe(600);
+      expect(result.up[0].receivedAtMs).toBe(0);
     });
 
     it('parseRecptnDt: 정상 KST 문자열을 epoch ms로 변환한다', () => {

--- a/src/api/__tests__/positionApi.test.ts
+++ b/src/api/__tests__/positionApi.test.ts
@@ -1,0 +1,209 @@
+import { fetchTrainPositions, parsePositionRecvTime, MOCK_POSITIONS } from '../positionApi';
+
+describe('fetchTrainPositions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    jest.useRealTimers();
+  });
+
+  it('API 키가 없으면 mock 반환 (요청 line 보존)', async () => {
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+    expect(result.line).toBe('2');
+    expect(result.trains).toEqual([]);
+  });
+
+  const mockApi = (items: unknown[]) => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ realtimePositionList: items }),
+    } as Response);
+  };
+
+  it('정상 응답을 TrainPosition[]로 매핑', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:00:30Z'));
+    mockApi([
+      {
+        statnId: '1002000201',
+        statnNm: '강남',
+        trainNo: 'T100',
+        trainSttus: '1',
+        updnLine: '0',
+        statnTid: '1002000202',
+        statnTnm: '역삼',
+        directAt: '1', // 급행
+        lstcarAt: '0',
+        lastRecptnDt: '2026-05-12',
+        recptnDt: '12:00:00',
+      },
+    ]);
+
+    const result = await fetchTrainPositions('2');
+    expect(result.trains).toHaveLength(1);
+    const t = result.trains[0];
+    expect(t.statnId).toBe('1002000201');
+    expect(t.trainStatus).toBe(1);
+    expect(t.updnLine).toBe(0);
+    expect(t.terminalStationName).toBe('역삼');
+    expect(t.trainType).toBe('express');
+    expect(t.isLastTrain).toBe(false);
+    expect(t.receivedAtMs).toBe(Date.parse('2026-05-12T03:00:00Z'));
+  });
+
+  it('lstcarAt: "1" 또는 1 → isLastTrain true', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T1', trainSttus: 1, updnLine: 0, lstcarAt: '1' },
+      { statnId: '2', statnNm: 'B', trainNo: 'T2', trainSttus: 1, updnLine: 0, lstcarAt: 1 },
+      { statnId: '3', statnNm: 'C', trainNo: 'T3', trainSttus: 1, updnLine: 0 },
+    ]);
+
+    const result = await fetchTrainPositions('2');
+    expect(result.trains.map((t) => t.isLastTrain)).toEqual([true, true, false]);
+  });
+
+  it('directAt: 1=express, 7=rapid, 0/누락=normal', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: 1, updnLine: 0, directAt: 1 },
+      { statnId: '2', statnNm: 'B', trainNo: 'T', trainSttus: 1, updnLine: 0, directAt: 7 },
+      { statnId: '3', statnNm: 'C', trainNo: 'T', trainSttus: 1, updnLine: 0, directAt: 0 },
+      { statnId: '4', statnNm: 'D', trainNo: 'T', trainSttus: 1, updnLine: 0 },
+    ]);
+
+    const result = await fetchTrainPositions('2');
+    expect(result.trains.map((t) => t.trainType)).toEqual(['express', 'rapid', 'normal', 'normal']);
+  });
+
+  it('drift > 120s면 receivedAtMs=0(stale 강등)', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-12T03:05:00Z'));
+    mockApi([
+      {
+        statnId: '1',
+        statnNm: 'A',
+        trainNo: 'T',
+        trainSttus: 1,
+        updnLine: 0,
+        lastRecptnDt: '2026-05-12',
+        recptnDt: '12:00:00',
+      },
+    ]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].receivedAtMs).toBe(0);
+  });
+
+  it('빈 리스트 → mock fallback', async () => {
+    mockApi([]);
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('HTTP 실패 → mock fallback (line 보존)', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 } as Response);
+    const result = await fetchTrainPositions('5');
+    expect(result.isMock).toBe(true);
+    expect(result.line).toBe('5');
+  });
+
+  it('네트워크 에러 → mock fallback', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockRejectedValue(new Error('net'));
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('timeout 5s 초과 → mock fallback', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    jest.useFakeTimers();
+    global.fetch = jest.fn().mockImplementation((_url, opts?: RequestInit) => {
+      return new Promise((_res, rej) => {
+        opts?.signal?.addEventListener('abort', () =>
+          rej(new DOMException('aborted', 'AbortError')),
+        );
+      });
+    });
+    const promise = fetchTrainPositions('2');
+    jest.advanceTimersByTime(5000);
+    const result = await promise;
+    expect(result.isMock).toBe(true);
+  });
+
+  it('trainSttus / updnLine 비숫자 → -1', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: 'abc', updnLine: 'xyz' },
+    ]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].trainStatus).toBe(-1);
+    expect(result.trains[0].updnLine).toBe(-1);
+  });
+
+  it('MOCK_POSITIONS export', () => {
+    expect(MOCK_POSITIONS.isMock).toBe(true);
+    expect(MOCK_POSITIONS.trains).toEqual([]);
+  });
+
+  it('realtimePositionList 누락 → 빈 배열 → mock fallback', async () => {
+    process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+    const result = await fetchTrainPositions('2');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('trainSttus / updnLine이 number 타입으로 와도 그대로 매핑', async () => {
+    mockApi([{ statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: 2, updnLine: 1 }]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].trainStatus).toBe(2);
+    expect(result.trains[0].updnLine).toBe(1);
+  });
+
+  it('statnId / statnNm / trainNo 누락 시 빈 문자열로 fallback', async () => {
+    mockApi([{ trainSttus: 1, updnLine: 0 }]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].statnId).toBe('');
+    expect(result.trains[0].statnNm).toBe('');
+    expect(result.trains[0].trainNo).toBe('');
+  });
+
+  it('trainSttus / updnLine이 객체(undefined 외 비스칼라)면 -1', async () => {
+    mockApi([
+      { statnId: '1', statnNm: 'A', trainNo: 'T', trainSttus: { x: 1 }, updnLine: [] },
+    ]);
+    const result = await fetchTrainPositions('2');
+    expect(result.trains[0].trainStatus).toBe(-1);
+    expect(result.trains[0].updnLine).toBe(-1);
+  });
+});
+
+describe('parsePositionRecvTime', () => {
+  it('풀 포맷 recptnDt만 와도 파싱', () => {
+    expect(parsePositionRecvTime('', '2026-05-12 12:00:00')).toBe(
+      Date.parse('2026-05-12T03:00:00Z'),
+    );
+  });
+
+  it('lastRecptnDt(날짜) + recptnDt(시각) 조합', () => {
+    expect(parsePositionRecvTime('2026-05-12', '12:00:00')).toBe(
+      Date.parse('2026-05-12T03:00:00Z'),
+    );
+  });
+
+  it('비문자열/빈 문자열은 0', () => {
+    expect(parsePositionRecvTime(undefined, undefined)).toBe(0);
+    expect(parsePositionRecvTime('2026-05-12', '')).toBe(0);
+    expect(parsePositionRecvTime(null, null)).toBe(0);
+  });
+
+  it('잘못된 포맷은 0', () => {
+    expect(parsePositionRecvTime('', 'not-a-date')).toBe(0);
+  });
+});

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../utils/logger';
+import { parseTrainType, type TrainType } from '../constants/trainTypes';
 
 const log = createLogger('arrivalApi');
 
@@ -15,6 +16,10 @@ export interface ArrivalInfo {
    * 누락/비숫자는 -1. fusion 우선순위 판정에 사용 (constants/arrivalCodes.ts).
    */
   arrivalCode: number;
+  /** lstcarAt === '1'이면 막차. 사용자 안전성 표시용. */
+  isLastTrain: boolean;
+  /** btrainSttus 매핑. 'normal'은 라벨 빈 문자열로 배지 미표시. */
+  trainType: TrainType;
 }
 
 export interface StationArrival {
@@ -25,12 +30,12 @@ export interface StationArrival {
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
-    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 },
-    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
+    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
   ],
   down: [
-    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 },
-    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
+    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' as const },
   ],
   isMock: true,
 });
@@ -113,6 +118,8 @@ export async function fetchArrivalInfo(
         trainCode: item.btrainNo ?? '',
         receivedAtMs,
         arrivalCode: Number.isFinite(parsedCode) ? parsedCode : -1,
+        isLastTrain: item.lstcarAt === '1' || item.lstcarAt === 1,
+        trainType: parseTrainType(item.btrainSttus),
       };
       if (UP_DIRECTION_VALUES.includes(item.updnLine)) {
         up.push(info);

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -10,6 +10,11 @@ export interface ArrivalInfo {
   trainCode: string;
   /** 데이터 생성 시각(epoch ms). 0이면 알 수 없음(mock 또는 누락). Stage 2 fusion 신호 신선도 판정용. */
   receivedAtMs: number;
+  /**
+   * arvlCd 응답값 — 0:진입, 1:도착, 2:출발, 3:전역출발, 4:전역진입, 5:전역도착, 99:운행중.
+   * 누락/비숫자는 -1. fusion 우선순위 판정에 사용 (constants/arrivalCodes.ts).
+   */
+  arrivalCode: number;
 }
 
 export interface StationArrival {
@@ -20,12 +25,12 @@ export interface StationArrival {
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
-    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 },
-    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0 },
+    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0, arrivalCode: -1 },
   ],
   down: [
-    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 },
-    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0 },
+    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 },
+    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0, arrivalCode: -1 },
   ],
   isMock: true,
 });
@@ -94,6 +99,12 @@ export async function fetchArrivalInfo(
       const receivedAtMs = isStale ? 0 : parsedRecvMs;
       const driftSec = isStale ? 0 : Math.max(0, rawDriftSec);
       const seconds = Math.max(0, Math.round(rawSeconds - driftSec));
+      const parsedCode =
+        typeof item.arvlCd === 'number'
+          ? item.arvlCd
+          : typeof item.arvlCd === 'string'
+            ? Number.parseInt(item.arvlCd, 10)
+            : NaN;
       const info: ArrivalInfo = {
         destination: item.trainLineNm ?? '',
         arrivalMinutes: Math.floor(seconds / 60),
@@ -101,6 +112,7 @@ export async function fetchArrivalInfo(
         statusMessage: item.arvlMsg2 ?? '',
         trainCode: item.btrainNo ?? '',
         receivedAtMs,
+        arrivalCode: Number.isFinite(parsedCode) ? parsedCode : -1,
       };
       if (UP_DIRECTION_VALUES.includes(item.updnLine)) {
         up.push(info);

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -8,6 +8,8 @@ export interface ArrivalInfo {
   arrivalSeconds: number;
   statusMessage: string;
   trainCode: string;
+  /** 데이터 생성 시각(epoch ms). 0이면 알 수 없음(mock 또는 누락). Stage 2 fusion 신호 신선도 판정용. */
+  receivedAtMs: number;
 }
 
 export interface StationArrival {
@@ -18,18 +20,34 @@ export interface StationArrival {
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
   up: [
-    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001' },
-    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002' },
+    { destination: '상행 종착역', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 },
+    { destination: '상행 종착역', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'UP-002', receivedAtMs: 0 },
   ],
   down: [
-    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001' },
-    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002' },
+    { destination: '하행 종착역', arrivalMinutes: 4, arrivalSeconds: 240, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 },
+    { destination: '하행 종착역', arrivalMinutes: 11, arrivalSeconds: 660, statusMessage: '', trainCode: 'DN-002', receivedAtMs: 0 },
   ],
   isMock: true,
 });
 
 /** 서울 열린데이터 API updnLine 응답값 — 상행/내선이면 up 방향 */
 const UP_DIRECTION_VALUES = ['상행', '내선'] as const;
+
+/** 서울 열린데이터 API recptnDt 타임존(KST 고정). */
+const SEOUL_API_TZ_OFFSET = '+09:00';
+
+/** recptnDt가 너무 오래된 경우 보정량이 비현실적이므로 stale로 강등한다. */
+const MAX_RECPTN_DRIFT_SEC = 120;
+
+/**
+ * recptnDt("YYYY-MM-DD HH:mm:ss", KST)를 epoch ms로 변환한다.
+ * 파싱 실패/누락 시 0(=알 수 없음)을 반환한다.
+ */
+export function parseRecptnDt(recptnDt: unknown): number {
+  if (typeof recptnDt !== 'string' || recptnDt.length === 0) return 0;
+  const ms = Date.parse(recptnDt.replace(' ', 'T') + SEOUL_API_TZ_OFFSET);
+  return Number.isFinite(ms) ? ms : 0;
+}
 
 export interface FetchArrivalOptions {
   timeoutMs?: number;
@@ -65,14 +83,24 @@ export async function fetchArrivalInfo(
     const up: ArrivalInfo[] = [];
     const down: ArrivalInfo[] = [];
 
+    const now = Date.now();
     for (const item of items) {
-      const seconds = Math.max(0, item.barvlDt ?? 0);
+      const rawSeconds = Math.max(0, item.barvlDt ?? 0);
+      // recptnDt(데이터 생성시각)와 현재시각의 차이만큼 열차가 더 진행한 것으로 보정.
+      // xls 스펙 주의사항에 명시된 처리. recptnDt 누락 또는 비정상 drift는 stale로 강등.
+      const parsedRecvMs = parseRecptnDt(item.recptnDt);
+      const rawDriftSec = parsedRecvMs > 0 ? (now - parsedRecvMs) / 1000 : 0;
+      const isStale = parsedRecvMs > 0 && rawDriftSec > MAX_RECPTN_DRIFT_SEC;
+      const receivedAtMs = isStale ? 0 : parsedRecvMs;
+      const driftSec = isStale ? 0 : Math.max(0, rawDriftSec);
+      const seconds = Math.max(0, Math.round(rawSeconds - driftSec));
       const info: ArrivalInfo = {
         destination: item.trainLineNm ?? '',
         arrivalMinutes: Math.floor(seconds / 60),
         arrivalSeconds: seconds,
         statusMessage: item.arvlMsg2 ?? '',
         trainCode: item.btrainNo ?? '',
+        receivedAtMs,
       };
       if (UP_DIRECTION_VALUES.includes(item.updnLine)) {
         up.push(info);

--- a/src/api/positionApi.ts
+++ b/src/api/positionApi.ts
@@ -1,0 +1,153 @@
+import { createLogger } from '../utils/logger';
+import { parseTrainTypeFromDirectAt, type TrainType } from '../constants/trainTypes';
+import { getLineApiName } from '../constants/lineApiNames';
+import type { LineNumber } from '../types/station';
+
+const log = createLogger('positionApi');
+
+/**
+ * realtimePosition 응답의 단일 열차 정보(앱 도메인 형태로 정규화).
+ * statnId가 fusion 신호의 핵심 — "이 열차가 지금 어느 역에 있나" 확정 정보.
+ */
+export interface TrainPosition {
+  statnId: string;
+  statnNm: string;
+  trainNo: string;
+  /** trainSttus: 0:진입, 1:도착, 2:출발, 3:전역출발 */
+  trainStatus: number;
+  /** 0:상행/내선, 1:하행/외선 */
+  updnLine: number;
+  /** 종착역 */
+  terminalStationId: string;
+  terminalStationName: string;
+  /** directAt 매핑(express/rapid/normal — ITX는 도착정보에서만) */
+  trainType: TrainType;
+  isLastTrain: boolean;
+  /** recptnDt 파싱 결과 — Stage 1과 같은 신선도 계약(0=알 수 없음). */
+  receivedAtMs: number;
+}
+
+export interface LinePositions {
+  line: LineNumber;
+  trains: TrainPosition[];
+  isMock?: boolean;
+}
+
+/** mock — API 키 없거나 실패 시 fallback. fusion 신호로 사용되지 않음(receivedAtMs=0). */
+export const MOCK_POSITIONS: Readonly<LinePositions> = Object.freeze({
+  line: '2' as LineNumber,
+  trains: [],
+  isMock: true,
+});
+
+/** 서울 열린데이터 API recptnDt 타임존(KST). arrivalApi와 동일 정책. */
+const SEOUL_API_TZ_OFFSET = '+09:00';
+/** drift 상한(s) — 비정상이면 stale로 강등. arrivalApi와 동일 정책. */
+const MAX_RECPTN_DRIFT_SEC = 120;
+
+/** "YYYY-MM-DD[ T]HH:mm:ss" 풀 포맷 판정 — 인식 못하는 입력은 0(알 수 없음)으로 강등한다. */
+const FULL_DATETIME_RE = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/;
+/** "HH:mm:ss" 시각 단독 — lastRecptnDt(날짜)와 합쳐 풀 포맷 구성. */
+const TIME_ONLY_RE = /^\d{2}:\d{2}:\d{2}/;
+
+/**
+ * realtimePosition은 lastRecptnDt(날짜)와 recptnDt(시각)를 분리해서 보낼 수 있다.
+ * 명세에 정확한 형식이 명시되지 않아 두 케이스 모두 대응:
+ *   - recptnDt가 "YYYY-MM-DD HH:mm:ss" 풀 포맷이면 그대로 파싱
+ *   - "HH:mm:ss"만 오면 lastRecptnDt와 합쳐 파싱
+ * 알 수 없는 포맷이면 0(=stale로 강등 — fusion에서 무시됨).
+ */
+export function parsePositionRecvTime(lastRecptnDt: unknown, recptnDt: unknown): number {
+  const recv = typeof recptnDt === 'string' ? recptnDt.trim() : '';
+  const date = typeof lastRecptnDt === 'string' ? lastRecptnDt.trim() : '';
+  if (!recv) return 0;
+  let full: string;
+  if (FULL_DATETIME_RE.test(recv)) {
+    full = recv;
+  } else if (TIME_ONLY_RE.test(recv) && date) {
+    full = `${date} ${recv}`;
+  } else {
+    return 0;
+  }
+  // 정규식 통과 후 Date.parse가 NaN이어도 호출자(parsedRecvMs > 0 검사)에서 자연스럽게 stale 강등.
+  return Date.parse(full.replace(' ', 'T') + SEOUL_API_TZ_OFFSET);
+}
+
+export interface FetchPositionOptions {
+  timeoutMs?: number;
+  /** 0~limit 범위로 호출 (호선당 최대 1000건이지만 일반적으로 100 충분). */
+  limit?: number;
+}
+
+export async function fetchTrainPositions(
+  line: LineNumber,
+  options?: FetchPositionOptions,
+): Promise<LinePositions> {
+  const { timeoutMs = 5000, limit = 100 } = options ?? {};
+  const apiKey = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+
+  if (!apiKey) {
+    log.warn('API key not set (EXPO_PUBLIC_SEOUL_DATA_API_KEY)');
+    return { ...MOCK_POSITIONS, line };
+  }
+
+  const apiName = getLineApiName(line);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const url = `http://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimePosition/0/${limit}/${encodeURIComponent(apiName)}`;
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      log.warn(`HTTP ${response.status} for line "${apiName}"`);
+      return { ...MOCK_POSITIONS, line };
+    }
+
+    const data = await response.json();
+    const items: any[] = data.realtimePositionList ?? [];
+
+    const now = Date.now();
+    const trains: TrainPosition[] = items.map((item) => {
+      const parsedRecvMs = parsePositionRecvTime(item.lastRecptnDt, item.recptnDt);
+      const driftSec = parsedRecvMs > 0 ? (now - parsedRecvMs) / 1000 : 0;
+      const isStale = parsedRecvMs > 0 && driftSec > MAX_RECPTN_DRIFT_SEC;
+      const receivedAtMs = isStale ? 0 : parsedRecvMs;
+
+      const parsedStatus =
+        typeof item.trainSttus === 'number'
+          ? item.trainSttus
+          : typeof item.trainSttus === 'string'
+            ? Number.parseInt(item.trainSttus, 10)
+            : NaN;
+      const parsedUpdn =
+        typeof item.updnLine === 'number'
+          ? item.updnLine
+          : typeof item.updnLine === 'string'
+            ? Number.parseInt(item.updnLine, 10)
+            : NaN;
+
+      return {
+        statnId: String(item.statnId ?? ''),
+        statnNm: String(item.statnNm ?? ''),
+        trainNo: String(item.trainNo ?? ''),
+        trainStatus: Number.isFinite(parsedStatus) ? parsedStatus : -1,
+        updnLine: Number.isFinite(parsedUpdn) ? parsedUpdn : -1,
+        terminalStationId: String(item.statnTid ?? ''),
+        terminalStationName: String(item.statnTnm ?? ''),
+        trainType: parseTrainTypeFromDirectAt(item.directAt),
+        isLastTrain: item.lstcarAt === '1' || item.lstcarAt === 1,
+        receivedAtMs,
+      };
+    });
+
+    if (trains.length === 0) {
+      log.warn(`No trains for line "${apiName}"`);
+      return { ...MOCK_POSITIONS, line };
+    }
+    return { line, trains };
+  } catch (e) {
+    log.error(`Fetch failed for line "${apiName}":`, e);
+    return { ...MOCK_POSITIONS, line };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/components/ArrivalStatusBadge.tsx
+++ b/src/components/ArrivalStatusBadge.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../theme';
+import { ARRIVAL_CODE } from '../constants/arrivalCodes';
+import { TRAIN_TYPE_LABEL, type TrainType } from '../constants/trainTypes';
+
+interface Props {
+  isLastTrain?: boolean;
+  trainType?: TrainType;
+  arrivalCode?: number;
+}
+
+/**
+ * Arrival 메타데이터(막차/급행/진입 상태)를 작은 배지로 표시.
+ * 표시할 배지가 없으면 null 반환해 row 시각 무게 보존.
+ */
+export function ArrivalStatusBadge({ isLastTrain, trainType, arrivalCode }: Props) {
+  const { colors } = useTheme();
+
+  // 표시 우선순위: 막차 > 도착/진입 상태 > 급행/특급/ITX
+  // 막차는 사용자 안전성 직결이라 항상 가장 두드러지게.
+  const badges: { label: string; color: string }[] = [];
+
+  if (isLastTrain) {
+    badges.push({ label: '막차', color: colors.danger });
+  }
+  if (arrivalCode === ARRIVAL_CODE.ARRIVED) {
+    badges.push({ label: '도착', color: colors.accent });
+  } else if (arrivalCode === ARRIVAL_CODE.ENTERING) {
+    badges.push({ label: '진입', color: colors.accent });
+  }
+  if (trainType && trainType !== 'normal') {
+    badges.push({ label: TRAIN_TYPE_LABEL[trainType], color: colors.accent });
+  }
+
+  if (badges.length === 0) return null;
+
+  return (
+    <View style={styles.row} testID="arrival-status-badge">
+      {badges.map((b) => (
+        <View key={b.label} style={[styles.badge, { borderColor: b.color }]}>
+          <Text style={[styles.text, { color: b.color }]}>{b.label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', gap: 4, marginTop: 2 },
+  badge: {
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 3,
+    borderWidth: 1,
+  },
+  // 한글/영문 혼용(ITX)이라 typography.label의 uppercase/letterSpacing은 적용하지 않는다.
+  text: { fontSize: 10, fontWeight: '700', letterSpacing: 0 },
+});

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AppState,
+  Modal,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useAppStore } from '../store/useAppStore';
+import { useNearestStation } from '../hooks/useNearestStation';
+import { useArrivalInfo } from '../hooks/useArrivalInfo';
+import { clearAlarmLog, getAlarmLog, type AlarmLogEntry } from '../utils/alarmLog';
+import { useTheme, spacing, radius, typography } from '../theme';
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function formatLogLine(entry: AlarmLogEntry): string {
+  const parts: string[] = [
+    formatTime(entry.ts),
+    entry.source,
+    entry.outcome,
+  ];
+  if (entry.reason) parts.push(entry.reason);
+  if (entry.kind) parts.push(entry.kind);
+  if (entry.phaseId) parts.push(entry.phaseId);
+  if (entry.stationName) parts.push(entry.stationName);
+  if (entry.location) {
+    parts.push(
+      `acc=${entry.location.accuracy ?? '-'} age=${entry.location.ageMs}ms`,
+    );
+  }
+  return parts.join(' | ');
+}
+
+function buildDumpText(args: {
+  userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
+  nearestName: string | null;
+  nearestDistanceM: number | null;
+  variants: string[];
+  arrivalSummary: string;
+  isMock: boolean;
+  logs: AlarmLogEntry[];
+}): string {
+  const lines: string[] = [];
+  lines.push(`[Subway debug] ${new Date().toISOString()}`);
+  lines.push('');
+  lines.push('## GPS');
+  lines.push(
+    args.userLocation
+      ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s`
+      : '(no location)',
+  );
+  lines.push('');
+  lines.push('## Nearest');
+  lines.push(
+    args.nearestName
+      ? `${args.nearestName} · ${args.nearestDistanceM ?? '-'} m`
+      : '(no nearest station)',
+  );
+  if (args.variants.length > 0) {
+    lines.push(`variants: ${args.variants.join(', ')}`);
+  }
+  lines.push('');
+  lines.push('## Arrival');
+  lines.push(args.arrivalSummary);
+  if (args.isMock) lines.push('(MOCK)');
+  lines.push('');
+  lines.push(`## Alarm log (${args.logs.length})`);
+  for (const entry of [...args.logs].reverse()) {
+    lines.push(formatLogLine(entry));
+  }
+  return lines.join('\n');
+}
+
+interface DebugModalProps {
+  onClose: () => void;
+}
+
+// 디버그 모달은 측정 인프라 — 관찰자 효과를 피하려고 모달이 열린 동안에만 마운트한다.
+// useNearestStation이 별도 Location.watch 구독을 띄우므로, 닫혔을 땐 컴포넌트 자체를
+// 마운트하지 않아 GPS·Arrival 폴링이 2배가 되지 않도록 한다. 호출부(_layout)에서
+// `debugVisible &&` 조건부 렌더를 보장한다.
+export function DebugModal({ onClose }: DebugModalProps) {
+  if (!__DEV__) return null;
+  return <DebugModalInner onClose={onClose} />;
+}
+
+function DebugModalInner({ onClose }: DebugModalProps) {
+  const { colors } = useTheme();
+  const { result, variants, userLocation, speedMps } = useNearestStation();
+  const stationName = result?.station.name ?? null;
+  const { arrival, isMock } = useArrivalInfo(stationName);
+  const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
+
+  const refreshLogs = useCallback(async () => {
+    setLogs(await getAlarmLog());
+  }, []);
+
+  useEffect(() => {
+    void refreshLogs();
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void refreshLogs();
+    });
+    return () => sub.remove();
+  }, [refreshLogs]);
+
+  const handleClear = useCallback(async () => {
+    await clearAlarmLog();
+    await refreshLogs();
+  }, [refreshLogs]);
+
+  const arrivalSummary = (() => {
+    if (!arrival) return '(no arrival data)';
+    const up = arrival.up[0];
+    const down = arrival.down[0];
+    const upText = up
+      ? `up: ${up.destination} · ${Math.round(up.arrivalSeconds)}s${up.statusMessage ? ` (${up.statusMessage})` : ''}`
+      : 'up: -';
+    const downText = down
+      ? `down: ${down.destination} · ${Math.round(down.arrivalSeconds)}s${down.statusMessage ? ` (${down.statusMessage})` : ''}`
+      : 'down: -';
+    return `${upText}\n${downText}`;
+  })();
+
+  const nearestDistanceM = result ? Math.round(result.distanceKm * 1000) : null;
+  const variantNames = variants.map((v) => `${v.name}(${v.line})`);
+
+  const handleShare = useCallback(() => {
+    const message = buildDumpText({
+      userLocation,
+      speedMps,
+      nearestName: result?.station.name ?? null,
+      nearestDistanceM,
+      variants: variantNames,
+      arrivalSummary,
+      isMock,
+      logs,
+    });
+    void Share.share({ message });
+  }, [userLocation, speedMps, result, nearestDistanceM, variantNames, arrivalSummary, isMock, logs]);
+
+  return (
+    <Modal visible animationType="slide" onRequestClose={onClose} testID="debug-modal">
+      <View style={[styles.container, { backgroundColor: colors.bg }]}>
+        <View style={[styles.header, { borderBottomColor: colors.hair }]}>
+          <Text style={[typography.bodySm, { color: colors.ink, fontWeight: '700' }]}>
+            Subway debug
+          </Text>
+          <TouchableOpacity onPress={onClose} testID="debug-modal-close">
+            <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '700' }]}>
+              Close
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView contentContainerStyle={{ padding: spacing.xl }}>
+          <Section title="GPS" colors={colors}>
+            {userLocation ? (
+              <>
+                <KeyValue label="lat" value={String(userLocation.lat)} colors={colors} />
+                <KeyValue label="lng" value={String(userLocation.lng)} colors={colors} />
+                <KeyValue
+                  label="speed"
+                  value={speedMps != null ? `${speedMps.toFixed(2)} m/s` : '-'}
+                  colors={colors}
+                />
+              </>
+            ) : (
+              <Text style={[typography.mono, { color: colors.muted }]}>(no location)</Text>
+            )}
+          </Section>
+
+          <Section title="Nearest station" colors={colors}>
+            {result ? (
+              <>
+                <KeyValue label="name" value={result.station.name} colors={colors} />
+                <KeyValue label="line" value={String(result.station.line)} colors={colors} />
+                <KeyValue
+                  label="distance"
+                  value={`${nearestDistanceM} m`}
+                  colors={colors}
+                />
+                {variantNames.length > 0 && (
+                  <KeyValue
+                    label="variants"
+                    value={variantNames.join(', ')}
+                    colors={colors}
+                  />
+                )}
+              </>
+            ) : (
+              <Text style={[typography.mono, { color: colors.muted }]}>(no nearest)</Text>
+            )}
+          </Section>
+
+          <Section title="Arrival" colors={colors}>
+            <Text style={[typography.mono, { color: colors.ink }]} testID="debug-arrival-summary">
+              {arrivalSummary}
+            </Text>
+            {isMock && (
+              <Text style={[typography.mono, { color: colors.warn, marginTop: spacing.xs }]}>
+                MOCK
+              </Text>
+            )}
+          </Section>
+
+          <Section
+            title={`Alarm log (${logs.length})`}
+            colors={colors}
+            action={
+              <Pressable onPress={refreshLogs} testID="debug-log-refresh">
+                <Text style={[typography.bodySm, { color: colors.accent }]}>Refresh</Text>
+              </Pressable>
+            }
+          >
+            {logs.length === 0 ? (
+              <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
+            ) : (
+              [...logs].reverse().map((entry, idx) => (
+                <Text
+                  key={`${entry.ts}-${idx}`}
+                  style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
+                  selectable
+                >
+                  {formatLogLine(entry)}
+                </Text>
+              ))
+            )}
+          </Section>
+
+          <View style={styles.actions}>
+            <TouchableOpacity
+              style={[styles.actionButton, { borderColor: colors.accent }]}
+              onPress={handleClear}
+              testID="debug-clear-log"
+            >
+              <Text style={[styles.actionText, { color: colors.accent }]}>Clear log</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.accent }]}
+              onPress={handleShare}
+              testID="debug-share-dump"
+            >
+              <Text style={[styles.actionText, { color: colors.onAccent }]}>Share dump</Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+  colors: ReturnType<typeof useTheme>['colors'];
+  action?: React.ReactNode;
+}
+
+function Section({ title, children, colors, action }: SectionProps) {
+  return (
+    <View style={[styles.section, { backgroundColor: colors.card }]}>
+      <View style={styles.sectionHeader}>
+        <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
+        {action}
+      </View>
+      {children}
+    </View>
+  );
+}
+
+function KeyValue({
+  label,
+  value,
+  colors,
+}: {
+  label: string;
+  value: string;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  return (
+    <View style={styles.kvRow}>
+      <Text style={[typography.mono, { color: colors.subtle, width: 80 }]}>{label}</Text>
+      <Text style={[typography.mono, { color: colors.ink, flex: 1 }]} selectable>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+// Internal exports for tests — DO NOT use from app code.
+export const __test__ = { formatLogLine, buildDumpText };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.lg,
+    borderBottomWidth: 1,
+  },
+  section: {
+    padding: spacing.lg,
+    borderRadius: radius.md,
+    marginBottom: spacing.md,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  kvRow: {
+    flexDirection: 'row',
+    marginBottom: 2,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginTop: spacing.lg,
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    alignItems: 'center',
+  },
+  actionText: {
+    fontWeight: '700',
+    fontSize: 14,
+  },
+});

--- a/src/components/EditorialArrivalRow.tsx
+++ b/src/components/EditorialArrivalRow.tsx
@@ -4,6 +4,7 @@ import { useTheme, typography, spacing } from '../theme';
 import { useCountdown } from '../hooks/useCountdown';
 import type { ArrivalTrain } from '../utils/journeyAdapter';
 import { LineBadge, getLineColor } from './LineBadge';
+import { ArrivalStatusBadge } from './ArrivalStatusBadge';
 
 interface Props {
   train: ArrivalTrain;
@@ -32,6 +33,11 @@ export function EditorialArrivalRow({ train }: Props) {
             {train.subtext}
           </Text>
         )}
+        <ArrivalStatusBadge
+          isLastTrain={train.isLastTrain}
+          trainType={train.trainType}
+          arrivalCode={train.arrivalCode}
+        />
       </View>
       <LineBadge line={train.line} color={lineC} />
     </View>

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -4,10 +4,27 @@ import { useTranslation } from 'react-i18next';
 import ClusteredMapView from 'react-native-map-clustering';
 import { Marker, PROVIDER_DEFAULT } from 'react-native-maps';
 import type { Station } from '../types/station';
+import type { TrainMarker as TrainMarkerData } from '../utils/findTrainCoordinates';
 import { buildMapConfig } from '../utils/buildMapConfig';
 import { useTheme } from '../theme';
 import { LINE_NAMES } from '../constants/lineColors';
 import { getStationDisplayName } from '../utils/stationDisplay';
+import { TRAIN_STATUS } from '../constants/trainStatus';
+
+/** trainSttus → i18n 키. 데이터 주도 — 새 status 추가 시 한 줄. */
+type StatusKey =
+  | 'map.train.status.arrived'
+  | 'map.train.status.entering'
+  | 'map.train.status.departed'
+  | 'map.train.status.prevDeparted'
+  | 'map.train.status.running';
+const TRAIN_STATUS_I18N_KEY: Record<number, StatusKey> = {
+  [TRAIN_STATUS.ARRIVED]: 'map.train.status.arrived',
+  [TRAIN_STATUS.ENTERING]: 'map.train.status.entering',
+  [TRAIN_STATUS.DEPARTED]: 'map.train.status.departed',
+  [TRAIN_STATUS.PREV_DEPARTED]: 'map.train.status.prevDeparted',
+};
+const TRAIN_STATUS_FALLBACK_KEY: StatusKey = 'map.train.status.running';
 
 interface StationMapProps {
   userLat: number;
@@ -16,6 +33,8 @@ interface StationMapProps {
   nearbyStations: Station[];
   customOriginId?: string;
   onStationPress?: (station: Station) => void;
+  /** Phase 3 Stage 3: 활성 호선의 실시간 열차 위치. 없으면 표시 안 함. */
+  trainMarkers?: TrainMarkerData[];
 }
 
 export function StationMap({
@@ -25,9 +44,10 @@ export function StationMap({
   nearbyStations,
   customOriginId,
   onStationPress,
+  trainMarkers,
 }: StationMapProps) {
   const { colors } = useTheme();
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [mapReady, setMapReady] = useState(false);
 
   const mapConfig = useMemo(
@@ -82,6 +102,40 @@ export function StationMap({
             </Marker>
           );
         })}
+        {trainMarkers?.map((tm) => {
+          // 같은 역에 여러 트레인이 있을 수 있어 trainNo로 키 unique
+          const isArrived = tm.trainStatus === TRAIN_STATUS.ARRIVED;
+          const isEntering = tm.trainStatus === TRAIN_STATUS.ENTERING;
+          // 도착 = 강조(채워짐), 진입 = 외곽선만, 그외 = 흐림
+          const opacity = isArrived ? 1 : isEntering ? 0.85 : 0.5;
+          const statusKey = TRAIN_STATUS_I18N_KEY[tm.trainStatus] ?? TRAIN_STATUS_FALLBACK_KEY;
+          return (
+            <Marker
+              key={`train-${tm.line}-${tm.trainNo}`}
+              coordinate={{ latitude: tm.lat, longitude: tm.lng }}
+              title={t('map.train.terminalSuffix', { name: tm.terminalStationName })}
+              description={t('map.train.descriptionTemplate', {
+                trainNo: tm.trainNo,
+                status: t(statusKey),
+              })}
+              tracksViewChanges={false}
+              testID={`train-marker-${tm.trainNo}`}
+              anchor={{ x: 0.5, y: 0.5 }}
+            >
+              <View
+                style={[
+                  styles.trainMarker,
+                  {
+                    backgroundColor: isArrived ? tm.lineColor : 'transparent',
+                    borderColor: tm.lineColor,
+                    opacity,
+                  },
+                ]}
+                testID={`train-dot-${tm.trainNo}`}
+              />
+            </Marker>
+          );
+        })}
       </ClusteredMapView>
       {!mapReady && (
         <View style={styles.loading} testID="map-loading">
@@ -117,4 +171,11 @@ const styles = StyleSheet.create({
     marginTop: 2,
     textAlign: 'center',
   },
+  trainMarker: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    borderWidth: 2,
+  },
 });
+

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -86,18 +86,17 @@ export function StationMap({
             >
               <View style={styles.markerContainer}>
                 <View
-                  style={[
-                    styles.markerDot,
-                    { backgroundColor: dotColor, borderColor: colors.card },
-                  ]}
+                  style={[styles.markerDot, { backgroundColor: dotColor }]}
                   testID={`dot-${station.id}`}
                 />
-                <Text
-                  style={[styles.markerLabel, { color: colors.ink }]}
-                  numberOfLines={1}
+                <View
+                  style={styles.markerLabelPill}
+                  testID={`label-pill-${station.id}`}
                 >
-                  {getStationDisplayName(station)}
-                </Text>
+                  <Text style={styles.markerLabel} numberOfLines={1}>
+                    {getStationDisplayName(station)}
+                  </Text>
+                </View>
               </View>
             </Marker>
           );
@@ -160,15 +159,28 @@ const styles = StyleSheet.create({
     maxWidth: 60,
   },
   markerDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    borderWidth: 1,
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    borderWidth: 2,
+    borderColor: '#ffffff',
+  },
+  markerLabelPill: {
+    marginTop: 3,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    borderRadius: 4,
+    backgroundColor: 'rgba(255,255,255,0.92)',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 1,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 1,
   },
   markerLabel: {
-    fontSize: 9,
+    fontSize: 12,
     fontWeight: '600',
-    marginTop: 2,
+    color: '#111111',
     textAlign: 'center',
   },
   trainMarker: {

--- a/src/components/__tests__/ArrivalStatusBadge.test.tsx
+++ b/src/components/__tests__/ArrivalStatusBadge.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import { ArrivalStatusBadge } from '../ArrivalStatusBadge';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+
+describe('ArrivalStatusBadge', () => {
+  it('표시할 배지가 없으면 null 반환', () => {
+    const { toJSON } = renderWithTheme(<ArrivalStatusBadge />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('isLastTrain → 막차 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge isLastTrain />);
+    expect(screen.getByText('막차')).toBeTruthy();
+  });
+
+  it('arrivalCode=ARRIVED → 도착 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.ARRIVED} />);
+    expect(screen.getByText('도착')).toBeTruthy();
+  });
+
+  it('arrivalCode=ENTERING → 진입 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.ENTERING} />);
+    expect(screen.getByText('진입')).toBeTruthy();
+  });
+
+  it('arrivalCode=DEPARTED 등 그외 코드는 도착/진입 배지 미표시', () => {
+    const { toJSON } = renderWithTheme(
+      <ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.DEPARTED} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('trainType=express → 급행 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge trainType="express" />);
+    expect(screen.getByText('급행')).toBeTruthy();
+  });
+
+  it('trainType=itx/rapid 라벨', () => {
+    renderWithTheme(<ArrivalStatusBadge trainType="itx" />);
+    expect(screen.getByText('ITX')).toBeTruthy();
+  });
+
+  it('trainType=rapid → 특급 배지', () => {
+    renderWithTheme(<ArrivalStatusBadge trainType="rapid" />);
+    expect(screen.getByText('특급')).toBeTruthy();
+  });
+
+  it('trainType=normal → 배지 미표시', () => {
+    const { toJSON } = renderWithTheme(<ArrivalStatusBadge trainType="normal" />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('막차 + 도착 + 급행 동시 표시', () => {
+    renderWithTheme(
+      <ArrivalStatusBadge isLastTrain arrivalCode={ARRIVAL_CODE.ARRIVED} trainType="express" />,
+    );
+    expect(screen.getByText('막차')).toBeTruthy();
+    expect(screen.getByText('도착')).toBeTruthy();
+    expect(screen.getByText('급행')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -46,9 +46,15 @@ const variantStation: Station = {
 };
 
 const baseResult: NearestStationResult = { station, distanceKm: 0.123 };
+const arrivalDefaults = {
+  receivedAtMs: 0,
+  arrivalCode: -1,
+  isLastTrain: false,
+  trainType: 'normal' as const,
+};
 const baseArrival: StationArrival = {
-  up: [{ destination: '청량리', arrivalSeconds: 90, statusMessage: '진입', trainCode: 'U1', arrivalMinutes: 1 }],
-  down: [{ destination: '인천', arrivalSeconds: 240, statusMessage: '', trainCode: 'D1', arrivalMinutes: 4 }],
+  up: [{ destination: '청량리', arrivalSeconds: 90, statusMessage: '진입', trainCode: 'U1', arrivalMinutes: 1, ...arrivalDefaults }],
+  down: [{ destination: '인천', arrivalSeconds: 240, statusMessage: '', trainCode: 'D1', arrivalMinutes: 4, ...arrivalDefaults }],
   isMock: false,
 };
 
@@ -359,8 +365,8 @@ describe('DebugModal arrival edge cases', () => {
   it('up.statusMessage가 빈 문자열이면 괄호를 붙이지 않는다', () => {
     mockUseArrivalInfo.mockReturnValue({
       arrival: {
-        up: [{ destination: '청량리', arrivalSeconds: 60, statusMessage: '', trainCode: 'U', arrivalMinutes: 1 }],
-        down: [{ destination: '인천', arrivalSeconds: 120, statusMessage: '도착', trainCode: 'D', arrivalMinutes: 2 }],
+        up: [{ destination: '청량리', arrivalSeconds: 60, statusMessage: '', trainCode: 'U', arrivalMinutes: 1, ...arrivalDefaults }],
+        down: [{ destination: '인천', arrivalSeconds: 120, statusMessage: '도착', trainCode: 'D', arrivalMinutes: 2, ...arrivalDefaults }],
         isMock: false,
       },
       loading: false,

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -1,0 +1,402 @@
+import React from 'react';
+import { AppState, Share } from 'react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { DebugModal, __test__ } from '../DebugModal';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import type { AlarmLogEntry } from '../../utils/alarmLog';
+import type { Station, NearestStationResult } from '../../types/station';
+import type { StationArrival } from '../../api/arrivalApi';
+
+const mockUseNearestStation = jest.fn();
+const mockUseArrivalInfo = jest.fn();
+const mockGetAlarmLog = jest.fn();
+const mockClearAlarmLog = jest.fn();
+
+jest.mock('../../hooks/useNearestStation', () => ({
+  useNearestStation: () => mockUseNearestStation(),
+}));
+jest.mock('../../hooks/useArrivalInfo', () => ({
+  useArrivalInfo: (name: string | null) => mockUseArrivalInfo(name),
+}));
+jest.mock('../../utils/alarmLog', () => {
+  const actual = jest.requireActual('../../utils/alarmLog');
+  return {
+    ...actual,
+    getAlarmLog: () => mockGetAlarmLog(),
+    clearAlarmLog: () => mockClearAlarmLog(),
+  };
+});
+
+const station: Station = {
+  id: '2-022',
+  name: '강남',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+const variantStation: Station = {
+  id: '7-220',
+  name: '강남구청',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.5172,
+  lng: 127.0413,
+};
+
+const baseResult: NearestStationResult = { station, distanceKm: 0.123 };
+const baseArrival: StationArrival = {
+  up: [{ destination: '청량리', arrivalSeconds: 90, statusMessage: '진입', trainCode: 'U1', arrivalMinutes: 1 }],
+  down: [{ destination: '인천', arrivalSeconds: 240, statusMessage: '', trainCode: 'D1', arrivalMinutes: 4 }],
+  isMock: false,
+};
+
+const setupHookDefaults = () => {
+  mockUseNearestStation.mockReturnValue({
+    result: baseResult,
+    variants: [station, variantStation],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 1.5,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    refresh: jest.fn(),
+  });
+  mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
+  mockGetAlarmLog.mockResolvedValue([]);
+  mockClearAlarmLog.mockResolvedValue(undefined);
+};
+
+describe('DebugModal', () => {
+  let appStateListener: ((state: string) => void) | null = null;
+  const appStateRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListener = null;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_t, l) => {
+      appStateListener = l as (state: string) => void;
+      return { remove: appStateRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+    });
+    setupHookDefaults();
+  });
+
+  it('__DEV__가 false면 null을 반환한다', () => {
+    const g = global as unknown as { __DEV__: boolean };
+    const original = g.__DEV__;
+    g.__DEV__ = false;
+    const { toJSON } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(toJSON()).toBeNull();
+    g.__DEV__ = original;
+  });
+
+  it('GPS / Nearest / Arrival / Alarm log 섹션을 모두 표시한다', async () => {
+    const logEntry: AlarmLogEntry = {
+      ts: new Date('2026-05-12T10:00:00Z').getTime(),
+      source: 'fg',
+      outcome: 'fired',
+      kind: 'destination',
+      phaseId: 'early',
+      stationName: '강남',
+    };
+    mockGetAlarmLog.mockResolvedValue([logEntry]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('GPS')).toBeTruthy();
+    expect(screen.getByText('Nearest station')).toBeTruthy();
+    expect(screen.getByText('Arrival')).toBeTruthy();
+    expect(screen.getByText('Alarm log (1)')).toBeTruthy();
+    expect(screen.getByTestId('debug-arrival-summary').props.children).toContain('청량리');
+  });
+
+  it('userLocation이 null이면 "no location"을 표시한다', () => {
+    mockUseNearestStation.mockReturnValue({
+      result: null,
+      variants: [],
+      userLocation: null,
+      speedMps: null,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('(no location)')).toBeTruthy();
+    expect(screen.getByText('(no nearest)')).toBeTruthy();
+  });
+
+  it('arrival이 null이면 no arrival data를 표시한다', () => {
+    mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('(no arrival data)')).toBeTruthy();
+  });
+
+  it('isMock일 때 MOCK 배지를 표시한다', () => {
+    mockUseArrivalInfo.mockReturnValue({
+      arrival: { ...baseArrival, isMock: true },
+      loading: false,
+      isMock: true,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('MOCK')).toBeTruthy();
+  });
+
+  it('arrival up/down이 비어있어도 렌더링한다', () => {
+    mockUseArrivalInfo.mockReturnValue({
+      arrival: { up: [], down: [], isMock: false },
+      loading: false,
+      isMock: false,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByTestId('debug-arrival-summary').props.children).toBe('up: -\ndown: -');
+  });
+
+  it('speedMps가 null이면 "-"를 표시한다', () => {
+    mockUseNearestStation.mockReturnValue({
+      result: baseResult,
+      variants: [],
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('-')).toBeTruthy();
+  });
+
+  it('알람 로그 비어있으면 (empty) 표시', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('(empty)')).toBeTruthy();
+  });
+
+  it('Refresh 버튼이 로그를 다시 불러온다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    fireEvent.press(screen.getByTestId('debug-log-refresh'));
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(2));
+  });
+
+  it('Clear log 버튼이 로그를 비우고 재조회한다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-clear-log'));
+    });
+    expect(mockClearAlarmLog).toHaveBeenCalled();
+    expect(mockGetAlarmLog).toHaveBeenCalledTimes(2);
+  });
+
+  it('Close 버튼이 onClose를 호출한다', () => {
+    const onClose = jest.fn();
+    renderWithTheme(<DebugModal onClose={onClose} />);
+    fireEvent.press(screen.getByTestId('debug-modal-close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Share dump 버튼이 Share.share를 호출한다', async () => {
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    expect(shareSpy).toHaveBeenCalled();
+    expect(shareSpy.mock.calls[0][0].message).toContain('Subway debug');
+    shareSpy.mockRestore();
+  });
+
+  it('AppState active 복귀 시 로그를 다시 불러온다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    act(() => {
+      appStateListener?.('active');
+    });
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(2));
+  });
+
+  it('AppState active 외 상태에선 재조회하지 않는다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
+    act(() => {
+      appStateListener?.('background');
+    });
+    // 짧게 기다려도 호출 횟수가 늘지 않음
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockGetAlarmLog).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmount 시 AppState listener를 정리한다', async () => {
+    const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    unmount();
+    expect(appStateRemove).toHaveBeenCalled();
+  });
+});
+
+describe('DebugModal helpers', () => {
+  it('formatLogLine: location 포함 suppressed 엔트리', () => {
+    const entry: AlarmLogEntry = {
+      ts: new Date('2026-05-12T10:00:00Z').getTime(),
+      source: 'bg',
+      outcome: 'suppressed',
+      reason: 'gate-accuracy',
+      location: { lat: 37.5, lng: 127.0, accuracy: 80, ageMs: 1500 },
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).toContain('bg');
+    expect(line).toContain('suppressed');
+    expect(line).toContain('gate-accuracy');
+    expect(line).toContain('acc=80');
+    expect(line).toContain('age=1500ms');
+  });
+
+  it('formatLogLine: 최소 fired 엔트리', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'fg',
+      outcome: 'fired',
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).toContain('fg');
+    expect(line).toContain('fired');
+  });
+
+  it('formatLogLine: accuracy null이면 "-"로 표기', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'bg',
+      outcome: 'suppressed',
+      reason: 'gate-age',
+      location: { lat: 37.5, lng: 127.0, accuracy: null, ageMs: 5000 },
+    };
+    expect(__test__.formatLogLine(entry)).toContain('acc=-');
+  });
+
+  it('buildDumpText: 모든 섹션 포함', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 2,
+      nearestName: '강남',
+      nearestDistanceM: 123,
+      variants: ['강남(2)'],
+      arrivalSummary: 'up: 청량리 · 90s',
+      isMock: true,
+      logs: [{ ts: Date.now(), source: 'fg', outcome: 'fired', stationName: '강남' }],
+    });
+    expect(dump).toContain('## GPS');
+    expect(dump).toContain('## Nearest');
+    expect(dump).toContain('variants: 강남(2)');
+    expect(dump).toContain('## Arrival');
+    expect(dump).toContain('(MOCK)');
+    expect(dump).toContain('## Alarm log (1)');
+  });
+
+  it('buildDumpText: 빈 상태 표기', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      arrivalSummary: '(no arrival data)',
+      isMock: false,
+      logs: [],
+    });
+    expect(dump).toContain('(no location)');
+    expect(dump).toContain('(no nearest station)');
+    expect(dump).not.toContain('variants:');
+    expect(dump).not.toContain('(MOCK)');
+    expect(dump).toContain('## Alarm log (0)');
+  });
+
+  it('buildDumpText: userLocation은 있고 speedMps만 null이면 "-" 표기', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      nearestName: '강남',
+      nearestDistanceM: null,
+      variants: [],
+      arrivalSummary: 'x',
+      isMock: false,
+      logs: [],
+    });
+    expect(dump).toContain('speed=- m/s');
+    expect(dump).toContain('강남 · - m');
+  });
+
+  it('formatLogLine: location 없는 fired 엔트리는 acc/age를 포함하지 않는다', () => {
+    const line = __test__.formatLogLine({
+      ts: Date.now(),
+      source: 'fg',
+      outcome: 'fired',
+      stationName: '강남',
+    });
+    expect(line).not.toContain('acc=');
+    expect(line).not.toContain('age=');
+  });
+});
+
+describe('DebugModal arrival edge cases', () => {
+  const baseHooks = {
+    result: baseResult,
+    variants: [],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 1,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    refresh: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockUseNearestStation.mockReturnValue(baseHooks);
+  });
+
+  it('up.statusMessage가 빈 문자열이면 괄호를 붙이지 않는다', () => {
+    mockUseArrivalInfo.mockReturnValue({
+      arrival: {
+        up: [{ destination: '청량리', arrivalSeconds: 60, statusMessage: '', trainCode: 'U', arrivalMinutes: 1 }],
+        down: [{ destination: '인천', arrivalSeconds: 120, statusMessage: '도착', trainCode: 'D', arrivalMinutes: 2 }],
+        isMock: false,
+      },
+      loading: false,
+      isMock: false,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    const text = screen.getByTestId('debug-arrival-summary').props.children;
+    expect(text).toBe('up: 청량리 · 60s\ndown: 인천 · 120s (도착)');
+  });
+});
+
+describe('DebugModal share with null nearest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockClearAlarmLog.mockResolvedValue(undefined);
+    mockUseNearestStation.mockReturnValue({
+      result: null,
+      variants: [],
+      userLocation: null,
+      speedMps: null,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
+  });
+
+  it('result null인 상태로 Share dump를 호출해도 동작한다', async () => {
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    expect(shareSpy).toHaveBeenCalled();
+    expect(shareSpy.mock.calls[0][0].message).toContain('(no nearest station)');
+    shareSpy.mockRestore();
+  });
+});

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -140,4 +140,66 @@ describe('StationMap', () => {
     expect(result.stations[0].isNearest).toBe(true);
     expect(result.stations[1].isNearest).toBe(false);
   });
+
+  describe('trainMarkers (Phase 3 Stage 3)', () => {
+    const mkTrain = (trainNo: string, status: number) => ({
+      trainNo,
+      line: '2' as const,
+      lineColor: '#009D3E',
+      lat: 37.498,
+      lng: 127.028,
+      statnNm: '강남',
+      trainStatus: status,
+      updnLine: 0,
+      terminalStationName: '성수',
+    });
+
+    it('trainMarkers 미전달 시 train 마커 0개', () => {
+      const { queryAllByTestId } = render(<StationMap {...baseProps} />);
+      expect(queryAllByTestId(/^train-marker-/)).toHaveLength(0);
+    });
+
+    it('trainMarkers 전달 시 trainNo로 마커 렌더', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 1), mkTrain('T002', 0)]} />,
+      );
+      expect(getByTestId('train-marker-T001')).toBeTruthy();
+      expect(getByTestId('train-marker-T002')).toBeTruthy();
+    });
+
+    it('도착(1) description에 "도착"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 1)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('도착');
+    });
+
+    it('진입(0) description에 "진입"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 0)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('진입');
+    });
+
+    it('출발(2) description에 "출발"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 2)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('출발');
+    });
+
+    it('전역 출발(3) → "전역 출발"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 3)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('전역 출발');
+    });
+
+    it('알 수 없는 status → "운행 중"', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} trainMarkers={[mkTrain('T001', 99)]} />,
+      );
+      expect(getByTestId('train-marker-T001').props.description).toContain('운행 중');
+    });
+  });
 });

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -82,6 +82,38 @@ describe('StationMap', () => {
     expect(getByTestId('station-map').props.showsUserLocation).toBe(true);
   });
 
+  it('마커 dot이 흰색 테두리와 확대된 크기(14)를 가진다', () => {
+    const { getByTestId } = render(<StationMap {...baseProps} />);
+    const dot = getByTestId('dot-2-023');
+    expect(dot.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          width: 14,
+          height: 14,
+          borderRadius: 7,
+          borderWidth: 2,
+          borderColor: '#ffffff',
+        }),
+      ]),
+    );
+  });
+
+  it('마커 라벨이 흰 pill 위에 검정 텍스트(#111, 12px)로 표시된다', () => {
+    const { getByText, getByTestId } = render(<StationMap {...baseProps} />);
+    const label = getByText('강남');
+    expect(label.props.style).toEqual(
+      expect.objectContaining({
+        fontSize: 12,
+        color: '#111111',
+      }),
+    );
+    expect(getByTestId('label-pill-2-022').props.style).toEqual(
+      expect.objectContaining({
+        backgroundColor: 'rgba(255,255,255,0.92)',
+      }),
+    );
+  });
+
   it('customOriginId와 일치하는 마커는 accent 색상 dot을 사용한다', () => {
     const { getByTestId } = render(
       <StationMap {...baseProps} customOriginId="2-023" />,

--- a/src/constants/__tests__/arrivalCodes.test.ts
+++ b/src/constants/__tests__/arrivalCodes.test.ts
@@ -1,0 +1,35 @@
+import { ARRIVAL_CODE, getArrivalPriority } from '../arrivalCodes';
+
+describe('arrivalCodes', () => {
+  it('ARRIVAL_CODE 매핑이 xls 스펙과 일치한다', () => {
+    expect(ARRIVAL_CODE.ENTERING).toBe(0);
+    expect(ARRIVAL_CODE.ARRIVED).toBe(1);
+    expect(ARRIVAL_CODE.DEPARTED).toBe(2);
+    expect(ARRIVAL_CODE.PREV_DEPARTED).toBe(3);
+    expect(ARRIVAL_CODE.PREV_ENTERING).toBe(4);
+    expect(ARRIVAL_CODE.PREV_ARRIVED).toBe(5);
+    expect(ARRIVAL_CODE.RUNNING).toBe(99);
+  });
+
+  it('getArrivalPriority: 1(도착) > 0(진입) > 5(전역도착) > 4(전역진입)', () => {
+    expect(getArrivalPriority(ARRIVAL_CODE.ARRIVED)).toBeGreaterThan(
+      getArrivalPriority(ARRIVAL_CODE.ENTERING),
+    );
+    expect(getArrivalPriority(ARRIVAL_CODE.ENTERING)).toBeGreaterThan(
+      getArrivalPriority(ARRIVAL_CODE.PREV_ARRIVED),
+    );
+    expect(getArrivalPriority(ARRIVAL_CODE.PREV_ARRIVED)).toBeGreaterThan(
+      getArrivalPriority(ARRIVAL_CODE.PREV_ENTERING),
+    );
+    expect(getArrivalPriority(ARRIVAL_CODE.PREV_ENTERING)).toBeGreaterThan(0);
+  });
+
+  it('getArrivalPriority: 출발/전역출발/운행중/누락은 0', () => {
+    expect(getArrivalPriority(ARRIVAL_CODE.DEPARTED)).toBe(0);
+    expect(getArrivalPriority(ARRIVAL_CODE.PREV_DEPARTED)).toBe(0);
+    expect(getArrivalPriority(ARRIVAL_CODE.RUNNING)).toBe(0);
+    expect(getArrivalPriority(undefined)).toBe(0);
+    expect(getArrivalPriority(-1)).toBe(0);
+    expect(getArrivalPriority(42)).toBe(0);
+  });
+});

--- a/src/constants/__tests__/lineApiNames.test.ts
+++ b/src/constants/__tests__/lineApiNames.test.ts
@@ -1,0 +1,16 @@
+import { LINE_API_NAMES, getLineApiName } from '../lineApiNames';
+
+describe('lineApiNames', () => {
+  it('1~9호선 매핑 + 특수 노선', () => {
+    expect(getLineApiName('1')).toBe('1호선');
+    expect(getLineApiName('9')).toBe('9호선');
+    expect(getLineApiName('airport')).toBe('공항철도');
+    expect(getLineApiName('gyeongui')).toBe('경의중앙선');
+    expect(getLineApiName('bundang')).toBe('수인분당선');
+    expect(getLineApiName('sinbundang')).toBe('신분당선');
+  });
+
+  it('LINE_API_NAMES가 모든 LineNumber를 cover (객체 키 9+4=13)', () => {
+    expect(Object.keys(LINE_API_NAMES).length).toBe(13);
+  });
+});

--- a/src/constants/__tests__/trainMarkerOffset.test.ts
+++ b/src/constants/__tests__/trainMarkerOffset.test.ts
@@ -1,0 +1,29 @@
+import {
+  OFFSET_BY_UPDN,
+  TRAIN_MARKER_OFFSET_DEG,
+  UPDN_DOWN_OUTER,
+  UPDN_UP_INNER,
+  getMarkerOffset,
+} from '../trainMarkerOffset';
+
+describe('trainMarkerOffset', () => {
+  it('상수가 스펙과 일치 (0:상행/내선, 1:하행/외선)', () => {
+    expect(UPDN_UP_INNER).toBe(0);
+    expect(UPDN_DOWN_OUTER).toBe(1);
+  });
+
+  it('OFFSET_BY_UPDN: 상행은 서쪽(-), 하행은 동쪽(+), 위도 변화 없음', () => {
+    expect(OFFSET_BY_UPDN[UPDN_UP_INNER]).toEqual({ dLat: 0, dLng: -TRAIN_MARKER_OFFSET_DEG });
+    expect(OFFSET_BY_UPDN[UPDN_DOWN_OUTER]).toEqual({ dLat: 0, dLng: TRAIN_MARKER_OFFSET_DEG });
+  });
+
+  it('getMarkerOffset: 매핑된 값을 그대로 반환', () => {
+    expect(getMarkerOffset(UPDN_UP_INNER)).toEqual({ dLat: 0, dLng: -TRAIN_MARKER_OFFSET_DEG });
+    expect(getMarkerOffset(UPDN_DOWN_OUTER)).toEqual({ dLat: 0, dLng: TRAIN_MARKER_OFFSET_DEG });
+  });
+
+  it('getMarkerOffset: 미지 값(2, -1)은 0 오프셋', () => {
+    expect(getMarkerOffset(2)).toEqual({ dLat: 0, dLng: 0 });
+    expect(getMarkerOffset(-1)).toEqual({ dLat: 0, dLng: 0 });
+  });
+});

--- a/src/constants/__tests__/trainStatus.test.ts
+++ b/src/constants/__tests__/trainStatus.test.ts
@@ -1,0 +1,20 @@
+import { TRAIN_STATUS, getTrainStatusPriority } from '../trainStatus';
+
+describe('trainStatus', () => {
+  it('상수가 스펙과 일치 (0:진입,1:도착,2:출발,3:전역출발)', () => {
+    expect(TRAIN_STATUS.ENTERING).toBe(0);
+    expect(TRAIN_STATUS.ARRIVED).toBe(1);
+    expect(TRAIN_STATUS.DEPARTED).toBe(2);
+    expect(TRAIN_STATUS.PREV_DEPARTED).toBe(3);
+  });
+
+  it('priority: ARRIVED(1)이 ENTERING(0)보다 강하고 그외는 0', () => {
+    expect(getTrainStatusPriority(TRAIN_STATUS.ARRIVED)).toBeGreaterThan(
+      getTrainStatusPriority(TRAIN_STATUS.ENTERING),
+    );
+    expect(getTrainStatusPriority(TRAIN_STATUS.DEPARTED)).toBe(0);
+    expect(getTrainStatusPriority(TRAIN_STATUS.PREV_DEPARTED)).toBe(0);
+    expect(getTrainStatusPriority(undefined)).toBe(0);
+    expect(getTrainStatusPriority(99)).toBe(0);
+  });
+});

--- a/src/constants/__tests__/trainTypes.test.ts
+++ b/src/constants/__tests__/trainTypes.test.ts
@@ -1,4 +1,4 @@
-import { parseTrainType, TRAIN_TYPE_LABEL } from '../trainTypes';
+import { parseTrainType, parseTrainTypeFromDirectAt, TRAIN_TYPE_LABEL } from '../trainTypes';
 
 describe('parseTrainType', () => {
   it('급행/ITX/특급 정확히 매핑', () => {
@@ -26,5 +26,25 @@ describe('TRAIN_TYPE_LABEL', () => {
     expect(TRAIN_TYPE_LABEL.itx).toBe('ITX');
     expect(TRAIN_TYPE_LABEL.rapid).toBe('특급');
     expect(TRAIN_TYPE_LABEL.normal).toBe('');
+  });
+});
+
+describe('parseTrainTypeFromDirectAt (realtimePosition API)', () => {
+  it('1=express, 7=rapid, 0=normal', () => {
+    expect(parseTrainTypeFromDirectAt(1)).toBe('express');
+    expect(parseTrainTypeFromDirectAt(7)).toBe('rapid');
+    expect(parseTrainTypeFromDirectAt(0)).toBe('normal');
+  });
+
+  it('숫자 문자열도 파싱', () => {
+    expect(parseTrainTypeFromDirectAt('1')).toBe('express');
+    expect(parseTrainTypeFromDirectAt('7')).toBe('rapid');
+  });
+
+  it('비숫자/누락은 normal', () => {
+    expect(parseTrainTypeFromDirectAt(undefined)).toBe('normal');
+    expect(parseTrainTypeFromDirectAt(null)).toBe('normal');
+    expect(parseTrainTypeFromDirectAt('abc')).toBe('normal');
+    expect(parseTrainTypeFromDirectAt(99)).toBe('normal');
   });
 });

--- a/src/constants/__tests__/trainTypes.test.ts
+++ b/src/constants/__tests__/trainTypes.test.ts
@@ -1,0 +1,30 @@
+import { parseTrainType, TRAIN_TYPE_LABEL } from '../trainTypes';
+
+describe('parseTrainType', () => {
+  it('급행/ITX/특급 정확히 매핑', () => {
+    expect(parseTrainType('급행')).toBe('express');
+    expect(parseTrainType('ITX')).toBe('itx');
+    expect(parseTrainType('특급')).toBe('rapid');
+  });
+
+  it('일반/누락/비문자열은 normal로 fallback', () => {
+    expect(parseTrainType('일반')).toBe('normal');
+    expect(parseTrainType('')).toBe('normal');
+    expect(parseTrainType(undefined)).toBe('normal');
+    expect(parseTrainType(null)).toBe('normal');
+    expect(parseTrainType(123)).toBe('normal');
+  });
+
+  it('앞뒤 공백 trim', () => {
+    expect(parseTrainType(' 급행 ')).toBe('express');
+  });
+});
+
+describe('TRAIN_TYPE_LABEL', () => {
+  it('각 타입의 라벨이 정의됨, normal은 빈 문자열', () => {
+    expect(TRAIN_TYPE_LABEL.express).toBe('급행');
+    expect(TRAIN_TYPE_LABEL.itx).toBe('ITX');
+    expect(TRAIN_TYPE_LABEL.rapid).toBe('특급');
+    expect(TRAIN_TYPE_LABEL.normal).toBe('');
+  });
+});

--- a/src/constants/arrivalCodes.ts
+++ b/src/constants/arrivalCodes.ts
@@ -1,0 +1,29 @@
+/**
+ * 서울 열린데이터 API `realtimeStationArrival` arvlCd 응답값.
+ * 스펙: scripts/서울시+지하철+실시간+도착정보.xls
+ */
+export const ARRIVAL_CODE = {
+  ENTERING: 0, // 진입 — 사용자 ≈ 해당 역 (수 초 내)
+  ARRIVED: 1, // 도착 — 사용자 = 해당 역에 있음 (확정)
+  DEPARTED: 2, // 출발
+  PREV_DEPARTED: 3, // 전역 출발
+  PREV_ENTERING: 4, // 전역 진입
+  PREV_ARRIVED: 5, // 전역 도착
+  RUNNING: 99, // 운행중
+} as const;
+
+/**
+ * fusion 판정 우선순위 (높을수록 강한 신호).
+ * 1(도착) > 0(진입) > 5(전역도착) > 4(전역진입) > 그외 0.
+ * 그외(2 출발, 3 전역출발, 99 운행중)는 "현재 위치" 신호로 부적합 → 0.
+ */
+const PRIORITY_BY_CODE: Record<number, number> = {
+  [ARRIVAL_CODE.ARRIVED]: 100,
+  [ARRIVAL_CODE.ENTERING]: 80,
+  [ARRIVAL_CODE.PREV_ARRIVED]: 50,
+  [ARRIVAL_CODE.PREV_ENTERING]: 40,
+};
+
+export function getArrivalPriority(code: number | undefined): number {
+  return PRIORITY_BY_CODE[code ?? -1] ?? 0;
+}

--- a/src/constants/lineApiNames.ts
+++ b/src/constants/lineApiNames.ts
@@ -1,0 +1,29 @@
+import type { LineNumber } from '../types/station';
+
+/**
+ * 서울 열린데이터 API `realtimePosition` 호출 시 `subwayNm` 파라미터로 사용하는 호선명.
+ * 새 호선 추가 시 LineNumber 타입과 이 매핑 한 줄씩만 추가.
+ *
+ * 스펙 매핑(subwayId → 호선명):
+ *   1001:1호선 ~ 1009:9호선
+ *   1063:경의중앙선, 1065:공항철도, 1075:수인분당선, 1077:신분당선
+ */
+export const LINE_API_NAMES: Record<LineNumber, string> = {
+  '1': '1호선',
+  '2': '2호선',
+  '3': '3호선',
+  '4': '4호선',
+  '5': '5호선',
+  '6': '6호선',
+  '7': '7호선',
+  '8': '8호선',
+  '9': '9호선',
+  airport: '공항철도',
+  gyeongui: '경의중앙선',
+  bundang: '수인분당선',
+  sinbundang: '신분당선',
+};
+
+export function getLineApiName(line: LineNumber): string {
+  return LINE_API_NAMES[line];
+}

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -2,6 +2,10 @@
 // BG `timeInterval`(30s, locationTracking.ts)보다 짧다 — stationary 상태에서 OS가
 // 캐시된 fix를 넘기면 의도적으로 drop. "실시간성 우선, 나쁜 좌표 거부" 정책.
 export const MAX_LOCATION_AGE_MS = 15_000;
-// 200m: 지하역 GPS 자연 열화 수용. 역간 평균 거리(800m+) 대비 안전 마진 충분.
+// 200m: 알람 트리거용 엄격 게이트. 역간 평균 거리(800m+) 대비 안전 마진.
+// false alarm 방지 위해 그대로 유지 — 알람 경로(useStationAlarm)에서만 사용.
 export const MAX_ACCURACY_M = 200;
+// 1500m: UI 표시용 완화 게이트. 지하 플랫폼/터널의 horizontalAccuracy(300~1500m)도
+// 일단 수용해 "추정 현재역"을 끊김 없이 보여준다. 알람은 별도 엄격 게이트로 차단.
+export const MAX_ACCURACY_M_DISPLAY = 1500;
 export const MAX_STATION_DISTANCE_KM = 1.0;

--- a/src/constants/realtime.ts
+++ b/src/constants/realtime.ts
@@ -1,0 +1,6 @@
+/**
+ * Phase 3 fusion·시각화에서 동시에 처리하는 활성 호선/후보 역의 최대 개수.
+ * Rules of Hooks 제약으로 useArrivalInfo / useTrainPositions 호출을 동적 개수로 풀 수 없어
+ * 슬롯이 고정된다. 한 곳에서만 변경하도록 단일 출처로 관리.
+ */
+export const MAX_ACTIVE_LINES = 3;

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -12,3 +12,4 @@ export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';
 export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
 export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';
 export const ALARM_LOG_KEY = 'subway-now:alarm-log';
+export const BG_DIAGNOSTICS_KEY = 'subway-now:bg-diagnostics';

--- a/src/constants/trainMarkerOffset.ts
+++ b/src/constants/trainMarkerOffset.ts
@@ -1,0 +1,38 @@
+/**
+ * 같은 역에 상행+하행 트레인이 동시에 매칭되면 마커가 픽셀 단위로 완전히 겹쳐
+ * 시각적으로 구분되지 않는다. `updnLine` 기준으로 위경도를 ±N도 만큼 오프셋해
+ * 좌우로 분리한다(카카오/네이버 지도와 동일 패턴).
+ *
+ * 스펙: scripts/서울시+지하철+실시간+열차+위치정보.xls
+ *   - updnLine: 0 = 상행/내선, 1 = 하행/외선
+ *
+ * 단위: 위도/경도 도(degree). 서울 위도(37.5°) 기준 경도 1° ≈ 88km이므로
+ * 0.00018° ≈ 16m. 줌 레벨 5 이상에서 분리되어 보이도록 잡았다.
+ */
+export const TRAIN_MARKER_OFFSET_DEG = 0.00018;
+
+export const UPDN_UP_INNER = 0;
+export const UPDN_DOWN_OUTER = 1;
+
+export interface MarkerOffset {
+  dLat: number;
+  dLng: number;
+}
+
+/**
+ * updnLine → 위경도 오프셋. 미지 값(2 이상 또는 음수)은 오프셋 없음.
+ *
+ * 호선 방향성(N-S vs E-W)에 따라 트랙 수직 방향이 달라지지만, 대부분의 줌 레벨에서
+ * 경도 오프셋만으로도 시각적 분리가 충분하다. 호선별 차별화가 필요해지면 별도
+ * `OFFSET_BY_LINE` 매핑을 추가해 이 값을 override하는 방식으로 확장한다.
+ */
+export const OFFSET_BY_UPDN: Record<number, MarkerOffset> = {
+  [UPDN_UP_INNER]: { dLat: 0, dLng: -TRAIN_MARKER_OFFSET_DEG },
+  [UPDN_DOWN_OUTER]: { dLat: 0, dLng: TRAIN_MARKER_OFFSET_DEG },
+};
+
+const ZERO_OFFSET: MarkerOffset = { dLat: 0, dLng: 0 };
+
+export function getMarkerOffset(updnLine: number): MarkerOffset {
+  return OFFSET_BY_UPDN[updnLine] ?? ZERO_OFFSET;
+}

--- a/src/constants/trainStatus.ts
+++ b/src/constants/trainStatus.ts
@@ -1,0 +1,24 @@
+/**
+ * 서울 열린데이터 API `realtimePosition.trainSttus` 응답값.
+ * 스펙: scripts/서울시+지하철+실시간+열차+위치정보.xls
+ * 도착정보 API의 arvlCd와 의미는 비슷하지만 코드 체계가 더 단순(99 운행중 없음).
+ */
+export const TRAIN_STATUS = {
+  ENTERING: 0, // 진입
+  ARRIVED: 1, // 도착 — 사용자 = 해당 역에 있음 (확정)
+  DEPARTED: 2, // 출발
+  PREV_DEPARTED: 3, // 전역 출발
+} as const;
+
+/**
+ * fusion 우선순위 (높을수록 강한 신호) — arrivalCodes.ts와 같은 형태.
+ * trainSttus=1(도착)을 arvlCd=1과 동일 점수로 격상 — pickFusedStation에서 신호원 통합.
+ */
+const PRIORITY_BY_STATUS: Record<number, number> = {
+  [TRAIN_STATUS.ARRIVED]: 100,
+  [TRAIN_STATUS.ENTERING]: 80,
+};
+
+export function getTrainStatusPriority(status: number | undefined): number {
+  return PRIORITY_BY_STATUS[status ?? -1] ?? 0;
+}

--- a/src/constants/trainTypes.ts
+++ b/src/constants/trainTypes.ts
@@ -1,0 +1,24 @@
+/**
+ * 서울 열린데이터 API `realtimeStationArrival.btrainSttus` 응답값 → 표준 타입 매핑.
+ * 스펙: scripts/서울시+지하철+실시간+도착정보.xls (열차종류: 급행, ITX, 일반, 특급)
+ */
+export type TrainType = 'express' | 'itx' | 'rapid' | 'normal';
+
+const BTRAIN_STTUS_TO_TYPE: Record<string, TrainType> = {
+  급행: 'express',
+  ITX: 'itx',
+  특급: 'rapid',
+};
+
+export function parseTrainType(btrainSttus: unknown): TrainType {
+  if (typeof btrainSttus !== 'string') return 'normal';
+  return BTRAIN_STTUS_TO_TYPE[btrainSttus.trim()] ?? 'normal';
+}
+
+/** UI 라벨. 데이터 주도 — 새 타입 추가 시 한 줄 변경. */
+export const TRAIN_TYPE_LABEL: Record<TrainType, string> = {
+  express: '급행',
+  itx: 'ITX',
+  rapid: '특급',
+  normal: '',
+};

--- a/src/constants/trainTypes.ts
+++ b/src/constants/trainTypes.ts
@@ -22,3 +22,23 @@ export const TRAIN_TYPE_LABEL: Record<TrainType, string> = {
   rapid: '특급',
   normal: '',
 };
+
+/**
+ * realtimePosition API의 `directAt` 응답값(숫자) → 같은 TrainType enum으로 통합.
+ * 스펙: 1:급행, 0:아님, 7:특급 (ITX는 directAt에 없음 — btrainSttus 텍스트로만 옴)
+ */
+const DIRECT_AT_TO_TYPE: Record<number, TrainType> = {
+  1: 'express',
+  7: 'rapid',
+};
+
+export function parseTrainTypeFromDirectAt(directAt: unknown): TrainType {
+  const n =
+    typeof directAt === 'number'
+      ? directAt
+      : typeof directAt === 'string'
+        ? Number.parseInt(directAt, 10)
+        : NaN;
+  if (!Number.isFinite(n)) return 'normal';
+  return DIRECT_AT_TO_TYPE[n] ?? 'normal';
+}

--- a/src/hooks/__tests__/useActiveLinePositions.test.ts
+++ b/src/hooks/__tests__/useActiveLinePositions.test.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react-native';
+import { useActiveLinePositions } from '../useActiveLinePositions';
+import { useTrainPositions } from '../useTrainPositions';
+import type { LinePositions } from '../../api/positionApi';
+
+jest.mock('../useTrainPositions');
+
+const mockUse = useTrainPositions as jest.Mock;
+
+function positionRet(positions: LinePositions | null) {
+  return { positions, loading: false, isMock: false };
+}
+
+describe('useActiveLinePositions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUse.mockReturnValue(positionRet(null));
+  });
+
+  it('빈 activeLines → 3개 슬롯 모두 null로 호출', () => {
+    renderHook(() => useActiveLinePositions([]));
+    expect(mockUse).toHaveBeenNthCalledWith(1, null, undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(2, null, undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(3, null, undefined);
+  });
+
+  it('activeLines K=3 슬롯에 라인 분배', () => {
+    renderHook(() => useActiveLinePositions(['2', '3', '5']));
+    expect(mockUse).toHaveBeenNthCalledWith(1, '2', undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(2, '3', undefined);
+    expect(mockUse).toHaveBeenNthCalledWith(3, '5', undefined);
+  });
+
+  it('K보다 많은 activeLines는 잘라냄', () => {
+    renderHook(() => useActiveLinePositions(['2', '3', '5', '7']));
+    // 4번째 호선은 슬롯이 없어 useTrainPositions 호출 0회
+    expect(mockUse).toHaveBeenCalledTimes(3);
+  });
+
+  it('각 슬롯의 positions를 배열로 반환', () => {
+    const lp2: LinePositions = { line: '2', trains: [] };
+    const lp3: LinePositions = { line: '3', trains: [] };
+    mockUse
+      .mockReturnValueOnce(positionRet(lp2))
+      .mockReturnValueOnce(positionRet(lp3))
+      .mockReturnValueOnce(positionRet(null));
+
+    const { result } = renderHook(() => useActiveLinePositions(['2', '3']));
+    expect(result.current).toEqual([lp2, lp3, null]);
+  });
+
+  it('provider 주입 시 그대로 useTrainPositions에 전달', () => {
+    const provider = { getPositions: jest.fn() };
+    renderHook(() => useActiveLinePositions(['2'], provider));
+    expect(mockUse).toHaveBeenCalledWith('2', provider);
+  });
+});

--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -3,8 +3,8 @@ import { useArrivalCountdown } from '../useArrivalCountdown';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const mockArrival: StationArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
 };
 
 const mockArrivalMock: StationArrival = {
@@ -53,7 +53,7 @@ describe('useArrivalCountdown', () => {
 
   it('arrivalSeconds가 0 이하로 내려가지 않는다', () => {
     const nearArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
       down: [],
     };
 
@@ -84,8 +84,8 @@ describe('useArrivalCountdown', () => {
 
     // 새 API 데이터 도착
     const newArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
     };
 
     rerender({ arrival: newArrival });

--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -3,8 +3,8 @@ import { useArrivalCountdown } from '../useArrivalCountdown';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const mockArrival: StationArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001' }],
-  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002' }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
+  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
 };
 
 const mockArrivalMock: StationArrival = {
@@ -53,7 +53,7 @@ describe('useArrivalCountdown', () => {
 
   it('arrivalSeconds가 0 이하로 내려가지 않는다', () => {
     const nearArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0 }],
       down: [],
     };
 
@@ -84,8 +84,8 @@ describe('useArrivalCountdown', () => {
 
     // 새 API 데이터 도착
     const newArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001' }],
-      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
+      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
     };
 
     rerender({ arrival: newArrival });

--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -3,8 +3,8 @@ import { useArrivalCountdown } from '../useArrivalCountdown';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const mockArrival: StationArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
-  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+  down: [{ destination: '인천행', arrivalMinutes: 1, arrivalSeconds: 90, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
 };
 
 const mockArrivalMock: StationArrival = {
@@ -53,7 +53,7 @@ describe('useArrivalCountdown', () => {
 
   it('arrivalSeconds가 0 이하로 내려가지 않는다', () => {
     const nearArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 0, arrivalSeconds: 2, statusMessage: '곧 도착', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
       down: [],
     };
 
@@ -84,8 +84,8 @@ describe('useArrivalCountdown', () => {
 
     // 새 API 데이터 도착
     const newArrival: StationArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
-      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 3, arrivalSeconds: 200, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+      down: [{ destination: '인천행', arrivalMinutes: 2, arrivalSeconds: 150, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
     };
 
     rerender({ arrival: newArrival });

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -13,8 +13,8 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
 };
 
 const mockArrivalWithMock = {
@@ -176,8 +176,8 @@ describe('useArrivalInfo', () => {
 
   it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
     const updatedArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
-      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
     };
 
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
@@ -295,11 +295,11 @@ describe('useArrivalInfo', () => {
 
   it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
     const staleArrival = {
-      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
       down: [],
     };
     const freshArrival = {
-      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
       down: [],
     };
 
@@ -376,8 +376,8 @@ describe('useArrivalInfo', () => {
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
     const freshArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0, arrivalCode: -1 }],
-      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0, arrivalCode: -1 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
     };
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -13,8 +13,8 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001' }],
-  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002' }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
+  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
 };
 
 const mockArrivalWithMock = {
@@ -175,8 +175,8 @@ describe('useArrivalInfo', () => {
 
   it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
     const updatedArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001' }],
-      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
     };
 
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
@@ -294,11 +294,11 @@ describe('useArrivalInfo', () => {
 
   it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
     const staleArrival = {
-      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD' }],
+      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0 }],
       down: [],
     };
     const freshArrival = {
-      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW' }],
+      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0 }],
       down: [],
     };
 
@@ -375,8 +375,8 @@ describe('useArrivalInfo', () => {
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
     const freshArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003' }],
-      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004' }],
+      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0 }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0 }],
     };
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { AppState } from 'react-native';
-import { useArrivalInfo } from '../useArrivalInfo';
+import { useArrivalInfo, __resetArrivalCacheForTests } from '../useArrivalInfo';
 import * as arrivalApiModule from '../../api/arrivalApi';
 
 jest.mock('../../api/arrivalApi');
@@ -13,8 +13,8 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
 });
 
 const mockArrival = {
-  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0 }],
-  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+  up: [{ destination: '소요산행', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '전역 출발', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+  down: [{ destination: '인천행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
 };
 
 const mockArrivalWithMock = {
@@ -27,6 +27,7 @@ describe('useArrivalInfo', () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     appStateCallback = null;
+    __resetArrivalCacheForTests();
   });
 
   afterEach(() => {
@@ -175,8 +176,8 @@ describe('useArrivalInfo', () => {
 
   it('캐시 표시 후 백그라운드 갱신이 데이터를 업데이트한다', async () => {
     const updatedArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0 }],
-      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'T001', receivedAtMs: 0, arrivalCode: -1 }],
+      down: [{ destination: '인천행', arrivalMinutes: 8, arrivalSeconds: 480, statusMessage: '', trainCode: 'T002', receivedAtMs: 0, arrivalCode: -1 }],
     };
 
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
@@ -294,11 +295,11 @@ describe('useArrivalInfo', () => {
 
   it('폴링 중 stationName이 변경되면 이전 폴링 응답을 무시한다', async () => {
     const staleArrival = {
-      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0 }],
+      up: [{ destination: '이전역', arrivalMinutes: 99, arrivalSeconds: 5940, statusMessage: '', trainCode: 'OLD', receivedAtMs: 0, arrivalCode: -1 }],
       down: [],
     };
     const freshArrival = {
-      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0 }],
+      up: [{ destination: '새역', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'NEW', receivedAtMs: 0, arrivalCode: -1 }],
       down: [],
     };
 
@@ -375,8 +376,8 @@ describe('useArrivalInfo', () => {
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {
     const freshArrival = {
-      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0 }],
-      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0 }],
+      up: [{ destination: '소요산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'T003', receivedAtMs: 0, arrivalCode: -1 }],
+      down: [{ destination: '인천행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'T004', receivedAtMs: 0, arrivalCode: -1 }],
     };
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -2,19 +2,24 @@ import { renderHook } from '@testing-library/react-native';
 import { useFusedNearestStation } from '../useFusedNearestStation';
 import { useNearestStation } from '../useNearestStation';
 import { useArrivalInfo } from '../useArrivalInfo';
+import { useTrainPositions } from '../useTrainPositions';
 import { findTopNearestStations } from '../../utils/findNearestStation';
 import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import { TRAIN_STATUS } from '../../constants/trainStatus';
 import { MOCK_STATIONS } from '../../testUtils/fixtures';
 import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
 
 jest.mock('../useNearestStation');
 jest.mock('../useArrivalInfo');
+jest.mock('../useTrainPositions');
 jest.mock('../../utils/findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
 }));
 
 const mockUseNearest = useNearestStation as jest.Mock;
 const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockUsePositions = useTrainPositions as jest.Mock;
 const mockFindTop = findTopNearestStations as jest.Mock;
 
 function gpsBase(overrides?: Record<string, unknown>) {
@@ -51,10 +56,35 @@ function arrivalRet(stationArrival: StationArrival | null = null) {
   return { arrival: stationArrival, loading: false, isMock: false };
 }
 
+function positionRet(positions: LinePositions | null = null) {
+  return { positions, loading: false, isMock: false };
+}
+
+function train(
+  statnNm: string,
+  trainStatus: number,
+  overrides?: Partial<TrainPosition>,
+): TrainPosition {
+  return {
+    statnId: '',
+    statnNm,
+    trainNo: 'T',
+    trainStatus,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
 describe('useFusedNearestStation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockUsePositions.mockReturnValue(positionRet(null));
   });
 
   it('userLocation null이면 후보 없음 → GPS 결과 그대로 + gps-only', () => {
@@ -108,6 +138,53 @@ describe('useFusedNearestStation', () => {
     const { result } = renderHook(() => useFusedNearestStation());
 
     expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+  });
+
+  it('position 신호: 후보 호선의 LinePositions에서 statnNm 매칭 트레인이 ARRIVED → 그 후보로 fusion (source=position)', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
+    ]);
+
+    // arrival 신호 없음
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+
+    // active lines: ['2', '3'] — useTrainPositions 3번 호출(l0='2', l1='3', l2=null)
+    mockUsePositions
+      .mockReturnValueOnce(positionRet({ line: '2', trains: [] })) // 강남에 매칭 없음
+      .mockReturnValueOnce(
+        positionRet({
+          line: '3',
+          trains: [train(MOCK_STATIONS.chungmuro.name, TRAIN_STATUS.ARRIVED)],
+        }),
+      )
+      .mockReturnValueOnce(positionRet(null));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+    expect(result.current.result?.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+    expect(result.current.confidence).toBe('arrival-confirmed');
+    expect(result.current.source).toBe('position');
+  });
+
+  it('arrival과 position 동시 ARRIVED → source=position 우선 (정확도 표시)', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+    mockUsePositions
+      .mockReturnValueOnce(
+        positionRet({
+          line: '2',
+          trains: [train(MOCK_STATIONS.gangnam.name, TRAIN_STATUS.ARRIVED)],
+        }),
+      )
+      .mockReturnValueOnce(positionRet(null))
+      .mockReturnValueOnce(positionRet(null));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+    expect(result.current.confidence).toBe('arrival-confirmed');
+    expect(result.current.source).toBe('position');
   });
 
   it('GPS pass-through 필드들(loading/error/permissionDenied/refresh 등)이 보존된다', () => {

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../useArrivalInfo';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import { MOCK_STATIONS } from '../../testUtils/fixtures';
+import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+
+jest.mock('../useNearestStation');
+jest.mock('../useArrivalInfo');
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+
+const mockUseNearest = useNearestStation as jest.Mock;
+const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+function gpsBase(overrides?: Record<string, unknown>) {
+  return {
+    result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+    variants: [MOCK_STATIONS.gangnam],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 1,
+    accuracyMeters: 50,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    refresh: jest.fn(),
+    ...overrides,
+  };
+}
+
+function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: 'X',
+    arrivalMinutes: 0,
+    arrivalSeconds: 0,
+    statusMessage: '',
+    trainCode: 'T1',
+    receivedAtMs: 1_700_000_000_000,
+    arrivalCode,
+    ...overrides,
+  };
+}
+
+function arrivalRet(stationArrival: StationArrival | null = null) {
+  return { arrival: stationArrival, loading: false, isMock: false };
+}
+
+describe('useFusedNearestStation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+  });
+
+  it('userLocation null이면 후보 없음 → GPS 결과 그대로 + gps-only', () => {
+    mockUseNearest.mockReturnValue(gpsBase({ userLocation: null, result: null }));
+    mockFindTop.mockReturnValue([]);
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.confidence).toBe('gps-only');
+  });
+
+  it('arrival 신호 없으면 GPS 최근접 + gps-only', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
+    ]);
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result.current.confidence).toBe('gps-only');
+  });
+
+  it('인접 후보 arvlCd=1이면 그 역으로 fusion 전환', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
+      { station: MOCK_STATIONS.yeouinaru, distanceKm: 0.5 },
+    ]);
+
+    // 후보 0,1,2 순서대로 useArrivalInfo 호출됨
+    mockUseArrival
+      .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.RUNNING)], down: [] }))
+      .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }))
+      .mockReturnValueOnce(arrivalRet(null));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.result?.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+    expect(result.current.confidence).toBe('arrival-confirmed');
+  });
+
+  it('GPS 원본은 gpsResult로 노출된다 (디버깅용)', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+  });
+
+  it('GPS pass-through 필드들(loading/error/permissionDenied/refresh 등)이 보존된다', () => {
+    const refresh = jest.fn();
+    mockUseNearest.mockReturnValue(
+      gpsBase({ loading: true, error: 'GPS err', permissionDenied: true, refresh }),
+    );
+    mockFindTop.mockReturnValue([]);
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBe('GPS err');
+    expect(result.current.permissionDenied).toBe(true);
+    expect(result.current.refresh).toBe(refresh);
+    expect(result.current.variants).toEqual([MOCK_STATIONS.gangnam]);
+    expect(result.current.userLocation).toEqual({ lat: 37.5, lng: 127.0 });
+    expect(result.current.speedMps).toBe(1);
+    expect(result.current.accuracyMeters).toBe(50);
+  });
+});

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -41,6 +41,8 @@ function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInf
     trainCode: 'T1',
     receivedAtMs: 1_700_000_000_000,
     arrivalCode,
+    isLastTrain: false,
+    trainType: 'normal',
     ...overrides,
   };
 }

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -3,7 +3,7 @@ import * as Location from 'expo-location';
 import { AppState } from 'react-native';
 import { useNearestStation } from '../useNearestStation';
 import * as findNearestStationModule from '../../utils/findNearestStation';
-import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
+import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../constants/location';
 
 jest.mock('expo-location');
 
@@ -201,7 +201,7 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('watchPositionAsync에 accuracy: High, distanceInterval: 10을 전달한다', async () => {
+  it('watchPositionAsync에 BestForNavigation·distanceInterval:0·timeInterval:2000을 전달한다', async () => {
     mockGranted();
 
     renderHook(() => useNearestStation());
@@ -209,7 +209,11 @@ describe('useNearestStation', () => {
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     expect(Location.watchPositionAsync).toHaveBeenCalledWith(
-      { accuracy: Location.Accuracy.High, distanceInterval: 10 },
+      {
+        accuracy: Location.Accuracy.BestForNavigation,
+        distanceInterval: 0,
+        timeInterval: 2000,
+      },
       expect.any(Function),
     );
   });
@@ -462,7 +466,21 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('watch 콜백 저정확도(MAX_ACCURACY_M 초과) 좌표는 setState하지 않는다', async () => {
+  it('watch 콜백 표시 게이트 초과(MAX_ACCURACY_M_DISPLAY 초과) 좌표는 setState하지 않는다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
+
+    // 표시 게이트 초과 → setState 차단
+    expect(result.current.result).toBeNull();
+    expect(result.current.userLocation).toBeNull();
+  });
+
+  it('watch 콜백 알람 게이트 초과지만 표시 게이트 통과 좌표는 setState한다 (지하 구간 가정)', async () => {
     mockGranted();
 
     const { result } = renderHook(() => useNearestStation());
@@ -471,9 +489,9 @@ describe('useNearestStation', () => {
 
     simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
 
-    // 저정확도라 result 갱신 안 됨
-    expect(result.current.result).toBeNull();
-    expect(result.current.userLocation).toBeNull();
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.result?.station.name).toBe('강남');
+    expect(result.current.accuracyMeters).toBe(MAX_ACCURACY_M + 1);
   });
 
   it('watch 콜백 accuracy가 null이면 통과한다', async () => {
@@ -489,9 +507,9 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('refresh 시 저정확도 좌표는 setState하지 않는다', async () => {
+  it('refresh 시 표시 게이트 초과 좌표는 setState하지 않는다', async () => {
     mockGranted();
-    mockLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
+    mockLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -502,7 +520,7 @@ describe('useNearestStation', () => {
     });
 
     expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
-    // 저정확도라 result 갱신 안 됨
+    // 표시 게이트 초과 → result 갱신 안 됨
     expect(result.current.result).toBeNull();
   });
 

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -79,6 +79,7 @@ function defaultInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStati
     nearestStation: null,
     userLocation: null,
     speedMps: null,
+    accuracyMeters: null,
     ...overrides,
   };
 }
@@ -102,6 +103,38 @@ describe('useStationAlarm', () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     renderHook(() => useStationAlarm(defaultInputs({ route })));
     expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+  });
+
+  it('does not evaluate when accuracy exceeds the alarm gate (MAX_ACCURACY_M)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({
+          route,
+          destination,
+          userLocation: { lat: 37.4, lng: 127.0 },
+          speedMps: 10,
+          accuracyMeters: 500,
+        }),
+      ),
+    );
+    expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+  });
+
+  it('evaluates when accuracy is exactly the alarm gate (boundary inclusive)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({
+          route,
+          destination,
+          userLocation: { lat: 37.4, lng: 127.0 },
+          speedMps: 10,
+          accuracyMeters: 200,
+        }),
+      ),
+    );
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
   });
 
   it('builds AlarmSource and calls evaluator', () => {

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -137,6 +137,96 @@ describe('useStationAlarm', () => {
     expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
   });
 
+  describe('arrival fusion 보조 트리거 (Stage 3)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const onRouteStation = makeStation('S2-DST', '강남'); // route+dest 매칭
+
+    it('GPS 게이트 차단 + arrivalConfidence=arrival-confirmed → station-passed 알람 발화', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500, // GPS 게이트 차단
+            arrivalConfidence: 'arrival-confirmed',
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // Phase 알람은 GPS 필요하므로 호출 안 됨
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('GPS 게이트 차단 + arrivalConfidence=arrival-arriving → 발화 안 함 (확정 아님)', () => {
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'arrival-arriving',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('GPS 게이트 차단 + arrivalConfidence=gps-only → 발화 안 함 (회귀 안전)', () => {
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'gps-only',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('GPS 통과 + arrivalConfidence 없음(undefined) → Phase + station-passed 모두 평가 (backward compat)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+            // arrivalConfidence 미전달
+          }),
+        ),
+      );
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+
+    it('arrival-confirmed 트리거도 lastNotifiedStationId dedup 적용 (GPS와 중복 발화 방지)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'arrival-confirmed',
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockLogSuppressedDedupStation).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
   it('builds AlarmSource and calls evaluator', () => {
     const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() =>

--- a/src/hooks/__tests__/useTrainPositions.test.ts
+++ b/src/hooks/__tests__/useTrainPositions.test.ts
@@ -1,0 +1,241 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { AppState } from 'react-native';
+import { useTrainPositions, __resetPositionCacheForTests } from '../useTrainPositions';
+import * as positionApi from '../../api/positionApi';
+import type { LinePositions } from '../../api/positionApi';
+
+jest.mock('../../api/positionApi');
+
+let appStateCallback: ((state: string) => void) | null = null;
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
+  appStateCallback = listener as (state: string) => void;
+  return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>;
+});
+
+const sampleResponse: LinePositions = {
+  line: '2',
+  trains: [
+    {
+      statnId: 'X',
+      statnNm: 'X',
+      trainNo: 'T',
+      trainStatus: 1,
+      updnLine: 0,
+      terminalStationId: '',
+      terminalStationName: '',
+      trainType: 'normal',
+      isLastTrain: false,
+      receivedAtMs: 1_700_000_000_000,
+    },
+  ],
+};
+
+describe('useTrainPositions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    appStateCallback = null;
+    __resetPositionCacheForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('line=null이면 fetch 안 함', async () => {
+    const { result } = renderHook(() => useTrainPositions(null));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.positions).toBeNull();
+    expect(positionApi.fetchTrainPositions).not.toHaveBeenCalled();
+  });
+
+  it('line이 주어지면 데이터 가져옴', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { result } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(result.current.positions).toEqual(sampleResponse));
+    expect(result.current.isMock).toBe(false);
+  });
+
+  it('mock 응답이면 isMock=true, 캐시에 저장 안 됨', async () => {
+    const mockResp = { ...sampleResponse, isMock: true };
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(mockResp);
+    const { result } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(result.current.isMock).toBe(true));
+  });
+
+  it('5초 폴링', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalledTimes(2));
+  });
+
+  it('동일 line 두 hook 인스턴스가 캐시 공유 (모듈 싱글톤)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+
+    const { result: r1 } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(r1.current.positions).toEqual(sampleResponse));
+    const initialCalls = (positionApi.fetchTrainPositions as jest.Mock).mock.calls.length;
+
+    // 두 번째 인스턴스가 캐시에서 즉시 받아야 함
+    const { result: r2 } = renderHook(() => useTrainPositions('2'));
+    expect(r2.current.positions).toEqual(sampleResponse);
+    // 새로운 첫 폴링은 발생하지만, 캐시도 활용
+    expect((positionApi.fetchTrainPositions as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(
+      initialCalls,
+    );
+  });
+
+  it('line 변경 시 새 데이터 로드', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { result, rerender } = renderHook(
+      ({ line }: { line: '2' | '5' | null }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | '5' | null } },
+    );
+    await waitFor(() => expect(result.current.positions).toEqual(sampleResponse));
+
+    rerender({ line: '5' });
+    await waitFor(() => {
+      const calls = (positionApi.fetchTrainPositions as jest.Mock).mock.calls;
+      expect(calls.some((c) => c[0] === '5')).toBe(true);
+    });
+  });
+
+  it('line=null로 변경 시 positions 비움', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { result, rerender } = renderHook(
+      ({ line }: { line: '2' | null }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | null } },
+    );
+    await waitFor(() => expect(result.current.positions).toEqual(sampleResponse));
+
+    rerender({ line: null });
+    await waitFor(() => expect(result.current.positions).toBeNull());
+  });
+
+  it('Provider 내부 에러도 상태 안 깨짐 (try/catch fallback)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.positions).toBeNull();
+  });
+
+  it('AppState resume 시 캐시 clear', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    await act(async () => {
+      appStateCallback?.('background');
+      appStateCallback?.('active');
+    });
+    // resume 후 폴링 다시 → fetch 추가 호출
+    await waitFor(() =>
+      expect((positionApi.fetchTrainPositions as jest.Mock).mock.calls.length).toBeGreaterThan(1),
+    );
+  });
+
+  it('provider 주입 가능', async () => {
+    const provider = { getPositions: jest.fn().mockResolvedValue(sampleResponse) };
+    renderHook(() => useTrainPositions('2', provider));
+    await waitFor(() => expect(provider.getPositions).toHaveBeenCalledWith('2'));
+  });
+
+  it('동일 line으로 두 번 갱신해도 동일 positions면 setState 안 함 (cancellation 분기 커버)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { unmount } = renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    // unmount → cancelled=true → 다음 polling 응답 무시
+    unmount();
+  });
+
+  it('폴링 중 line이 null로 변경되면 폴링 콜백 early-return', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValue(sampleResponse);
+    const { rerender } = renderHook(
+      ({ line }: { line: '2' | null }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | null } },
+    );
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    rerender({ line: null });
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    // null 후로는 폴링이 더 이상 fetch 호출 안 함 — 이미 직전 값 외엔 추가 호출 없어야
+  });
+
+  it('초기 fetch 도중 unmount 시 cancelled로 setState 차단', async () => {
+    let resolveFn: (val: LinePositions) => void = () => {};
+    (positionApi.fetchTrainPositions as jest.Mock).mockReturnValueOnce(
+      new Promise<LinePositions>((res) => {
+        resolveFn = res;
+      }),
+    );
+    const { result, unmount } = renderHook(() => useTrainPositions('2'));
+    expect(result.current.loading).toBe(true);
+    unmount();
+    resolveFn(sampleResponse);
+    await Promise.resolve();
+    // crash 안 나면 cancelled 분기 통과
+  });
+
+  it('폴링 도중 line이 바뀌면 응답 무시 (usePolling 콜백, l !== lineRef.current)', async () => {
+    // 첫 fetch는 sample로 즉시 resolve해 초기 마운트 안정화
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce(sampleResponse);
+    const { rerender } = renderHook(
+      ({ line }: { line: '2' | '5' }) => useTrainPositions(line),
+      { initialProps: { line: '2' as '2' | '5' } },
+    );
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    // 다음 폴링은 pending으로 잡아둠
+    let resolvePoll: (v: LinePositions) => void = () => {};
+    (positionApi.fetchTrainPositions as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<LinePositions>((res) => {
+          resolvePoll = res;
+        }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(5000); // 폴링 발화 → l='2'로 fetch 시작
+    });
+    rerender({ line: '5' }); // l !== lineRef.current 만들기
+    // mock 응답으로 cache.set 분기까지 같이 커버
+    resolvePoll({ ...sampleResponse, isMock: true });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('폴링 결과가 mock이면 캐시 set 생략 (105 false 분기)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalled());
+
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce({
+      ...sampleResponse,
+      isMock: true,
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    await Promise.resolve();
+  });
+
+  it('폴링 콜백 reject도 안전하게 처리 (catch 분기)', async () => {
+    (positionApi.fetchTrainPositions as jest.Mock).mockResolvedValueOnce(sampleResponse);
+    renderHook(() => useTrainPositions('2'));
+    await waitFor(() => expect(positionApi.fetchTrainPositions).toHaveBeenCalledTimes(1));
+
+    // 두 번째 폴링은 reject
+    (positionApi.fetchTrainPositions as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    // crash 안 나면 통과
+  });
+});

--- a/src/hooks/useActiveLinePositions.ts
+++ b/src/hooks/useActiveLinePositions.ts
@@ -1,0 +1,24 @@
+import { useTrainPositions } from './useTrainPositions';
+import type { LinePositions } from '../api/positionApi';
+import type { LineNumber } from '../types/station';
+import type { PositionProvider } from '../providers/types';
+
+/**
+ * 활성 호선 K=3 동시 폴링 — Phase 3 Stage 1+2의 useFusedNearestStation 패턴 동일.
+ * Rules of Hooks 제약으로 슬롯 개수 고정. activeLines가 그보다 적으면 null 슬롯으로 no-op.
+ *
+ * 호출 비용은 useTrainPositions 모듈 싱글톤 캐시(positionCache)가 line 단위로 dedup —
+ * useFusedNearestStation과 동시에 같은 호선을 폴링해도 한 번만 호출됨.
+ */
+export function useActiveLinePositions(
+  activeLines: LineNumber[],
+  provider?: PositionProvider,
+): (LinePositions | null)[] {
+  const l0 = activeLines[0] ?? null;
+  const l1 = activeLines[1] ?? null;
+  const l2 = activeLines[2] ?? null;
+  const p0 = useTrainPositions(l0, provider);
+  const p1 = useTrainPositions(l1, provider);
+  const p2 = useTrainPositions(l2, provider);
+  return [p0.positions, p1.positions, p2.positions];
+}

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -8,6 +8,17 @@ import { usePolling } from './usePolling';
 const POLL_INTERVAL_MS = 5_000;
 const CACHE_TTL_MS = 30_000;
 
+/**
+ * 모듈 스코프 싱글톤 — fusion에서 동일 station name을 여러 hook 인스턴스가 폴링할 때
+ * 중복 네트워크 호출을 막기 위한 공유 캐시.
+ */
+const arrivalCache = new TtlCache<string, StationArrival>(CACHE_TTL_MS);
+
+/** 테스트 격리용 — useArrivalInfo 사용처 외에는 호출하지 말 것. */
+export function __resetArrivalCacheForTests(): void {
+  arrivalCache.clear();
+}
+
 function arrivalEqual(a: StationArrival | null, b: StationArrival): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
@@ -24,7 +35,6 @@ export function useArrivalInfo(
 ): UseArrivalInfoReturn {
   const [arrival, setArrival] = useState<StationArrival | null>(null);
   const [loading, setLoading] = useState(false);
-  const cacheRef = useRef(new TtlCache<string, StationArrival>(CACHE_TTL_MS));
   const providerRef = useRef<ArrivalProvider>(provider ?? createArrivalProvider());
   const arrivalRef = useRef<StationArrival | null>(null);
   const stationNameRef = useRef(stationName);
@@ -45,7 +55,7 @@ export function useArrivalInfo(
       return;
     }
 
-    const cached = cacheRef.current.get(stationName);
+    const cached = arrivalCache.get(stationName);
     if (cached) {
       updateArrival(cached);
       setLoading(false);
@@ -66,7 +76,7 @@ export function useArrivalInfo(
         const data = await providerRef.current.getArrival(stationName);
         if (cancelled) return;
         if (!data.isMock) {
-          cacheRef.current.set(stationName, data);
+          arrivalCache.set(stationName, data);
         }
         updateArrival(data);
       } catch {
@@ -90,14 +100,14 @@ export function useArrivalInfo(
       providerRef.current.getArrival(name).then((data) => {
         if (name !== stationNameRef.current) return;
         if (!data.isMock) {
-          cacheRef.current.set(name, data);
+          arrivalCache.set(name, data);
         }
         updateArrival(data);
         setLoading(false);
       }).catch(() => {});
     },
     POLL_INTERVAL_MS,
-    { onResume: () => cacheRef.current.clear() },
+    { onResume: () => arrivalCache.clear() },
   );
 
   return { arrival, loading, isMock: arrival?.isMock ?? false };

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -6,16 +6,18 @@ import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import { MAX_ACTIVE_LINES } from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
 import type { NearestStationResult, Station } from '../types/station';
 import type { ArrivalProvider, PositionProvider } from '../providers/types';
 
 /**
- * fusion 후보 개수. K=3 고정 — Rules of Hooks로 useArrivalInfo를 동적 개수로 호출할 수 없어
- * 명시적으로 풀어 쓴다(c0/c1/c2). 변경 시 본 파일의 hook 호출 라인도 함께 수정 필요.
- * 호출 비용은 useArrivalInfo의 모듈 스코프 캐시(arrivalCache)가 station name 단위로 dedup.
+ * fusion 후보 개수. MAX_ACTIVE_LINES와 동기화 — Rules of Hooks로 useArrivalInfo/useTrainPositions를
+ * 동적 개수로 호출할 수 없어 본 파일의 hook 호출 라인(c0/c1/c2, l0/l1/l2)도 같이 풀어 쓴다.
+ * 상수 변경 시 hook 호출도 함께 수정해야 한다(컴파일러가 catch 못함).
+ * 호출 비용은 모듈 스코프 캐시(arrivalCache/positionCache)가 station name·line 단위로 dedup.
  */
-const FUSION_CANDIDATE_LIMIT = 3;
+const FUSION_CANDIDATE_LIMIT = MAX_ACTIVE_LINES;
 
 interface UseFusedNearestStationReturn {
   /** GPS+arrival+position fusion으로 결정된 현재역. */

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 import { useNearestStation } from './useNearestStation';
 import { useArrivalInfo } from './useArrivalInfo';
+import { useTrainPositions } from './useTrainPositions';
 import { findTopNearestStations } from '../utils/findNearestStation';
-import { pickFusedStation, type FusionConfidence } from '../utils/pickFusedStation';
+import { findActiveLines } from '../utils/findActiveLines';
+import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import type { LinePositions } from '../api/positionApi';
 import type { NearestStationResult, Station } from '../types/station';
-import type { ArrivalProvider } from '../providers/types';
+import type { ArrivalProvider, PositionProvider } from '../providers/types';
 
 /**
  * fusion 후보 개수. K=3 고정 — Rules of Hooks로 useArrivalInfo를 동적 개수로 호출할 수 없어
@@ -15,12 +18,14 @@ import type { ArrivalProvider } from '../providers/types';
 const FUSION_CANDIDATE_LIMIT = 3;
 
 interface UseFusedNearestStationReturn {
-  /** GPS+arrival fusion으로 결정된 현재역. */
+  /** GPS+arrival+position fusion으로 결정된 현재역. */
   result: NearestStationResult | null;
   /** GPS 원본 result — 비교/디버깅용. */
   gpsResult: NearestStationResult | null;
-  /** fusion 신뢰도. arrival 신호로 확정/추정/없음. */
+  /** fusion 신뢰도. */
   confidence: FusionConfidence;
+  /** fusion 신호 출처. position(가장 정확) > arrival(추정) > gps(거리). */
+  source: FusionSource;
   /** GPS 환승역 변형(같은 이름 다른 노선) — 기존 useNearestStation 호환. */
   variants: Station[];
   userLocation: { lat: number; lng: number } | null;
@@ -39,8 +44,30 @@ interface UseFusedNearestStationReturn {
  * 지하 구간 GPS 지연(이미 도착한 역인데 전역 표시)을 우회하는 것이 목적.
  * arrival 신호가 모두 약하면 GPS 최근접으로 자연 fallback.
  */
+/**
+ * 후보 역의 호선에 해당하는 LinePositions에서 해당 후보 역에 머무는 열차들을 추출.
+ *
+ * 매칭 키: `(line, statnNm)`.
+ * stations.json의 `id`(예: "1-001")는 자체 포맷이고 서울 API `statnId`(예: "1002000201")는
+ * 10자리 코드라 키 공간이 달라 직접 비교 불가. line은 외부 호출 시 이미 지정했으니 같은 lp 안에서는
+ * 역명만으로 충분 — 한 호선의 같은 역명은 유일(같은 호선에 동명역 없음).
+ *
+ * 빈 배열이면 신호 없음(매칭 실패).
+ */
+function matchPositionsForCandidate(
+  candidate: NearestStationResult,
+  positions: (LinePositions | null)[],
+): LinePositions['trains'] {
+  for (const lp of positions) {
+    if (!lp || lp.line !== candidate.station.line) continue;
+    return lp.trains.filter((t) => t.statnNm === candidate.station.name);
+  }
+  return [];
+}
+
 export function useFusedNearestStation(
-  provider?: ArrivalProvider,
+  arrivalProvider?: ArrivalProvider,
+  positionProvider?: PositionProvider,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation();
 
@@ -55,27 +82,42 @@ export function useFusedNearestStation(
     );
   }, [gps.userLocation]);
 
-  // 후보 K개에 대한 arrival 폴링 — hooks는 고정 순서 호출이 필요하므로 N=3 고정.
-  // 후보 부족 시 null로 호출 → useArrivalInfo 내부에서 no-op.
+  // arrival 폴링: 후보 역명 단위 K=3 고정.
   const c0 = candidates[0]?.station.name ?? null;
   const c1 = candidates[1]?.station.name ?? null;
   const c2 = candidates[2]?.station.name ?? null;
-  const a0 = useArrivalInfo(c0, provider);
-  const a1 = useArrivalInfo(c1, provider);
-  const a2 = useArrivalInfo(c2, provider);
+  const a0 = useArrivalInfo(c0, arrivalProvider);
+  const a1 = useArrivalInfo(c1, arrivalProvider);
+  const a2 = useArrivalInfo(c2, arrivalProvider);
+
+  // position 폴링: 후보 역들의 호선만 dedup 후 K=3 고정 슬롯.
+  // (대부분 1~2개 호선이지만 환승 인근에서 3개까지 가능)
+  const activeLines = useMemo(() => findActiveLines(candidates), [candidates]);
+  const l0 = activeLines[0] ?? null;
+  const l1 = activeLines[1] ?? null;
+  const l2 = activeLines[2] ?? null;
+  const p0 = useTrainPositions(l0, positionProvider);
+  const p1 = useTrainPositions(l1, positionProvider);
+  const p2 = useTrainPositions(l2, positionProvider);
 
   const fused = useMemo(() => {
     if (candidates.length === 0) return null;
     const arrivals = [a0.arrival, a1.arrival, a2.arrival];
+    const positions = [p0.positions, p1.positions, p2.positions];
     return pickFusedStation(
-      candidates.map((cand, i) => ({ candidate: cand, arrival: arrivals[i] ?? null })),
+      candidates.map((cand, i) => ({
+        candidate: cand,
+        arrival: arrivals[i] ?? null,
+        positionMatches: matchPositionsForCandidate(cand, positions),
+      })),
     );
-  }, [candidates, a0.arrival, a1.arrival, a2.arrival]);
+  }, [candidates, a0.arrival, a1.arrival, a2.arrival, p0.positions, p1.positions, p2.positions]);
 
   return {
     result: fused?.result ?? gps.result,
     gpsResult: gps.result,
     confidence: fused?.confidence ?? 'gps-only',
+    source: fused?.source ?? 'gps',
     variants: gps.variants,
     userLocation: gps.userLocation,
     speedMps: gps.speedMps,

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { useNearestStation } from './useNearestStation';
+import { useArrivalInfo } from './useArrivalInfo';
+import { findTopNearestStations } from '../utils/findNearestStation';
+import { pickFusedStation, type FusionConfidence } from '../utils/pickFusedStation';
+import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import type { NearestStationResult, Station } from '../types/station';
+import type { ArrivalProvider } from '../providers/types';
+
+/**
+ * fusion 후보 개수. K=3 고정 — Rules of Hooks로 useArrivalInfo를 동적 개수로 호출할 수 없어
+ * 명시적으로 풀어 쓴다(c0/c1/c2). 변경 시 본 파일의 hook 호출 라인도 함께 수정 필요.
+ * 호출 비용은 useArrivalInfo의 모듈 스코프 캐시(arrivalCache)가 station name 단위로 dedup.
+ */
+const FUSION_CANDIDATE_LIMIT = 3;
+
+interface UseFusedNearestStationReturn {
+  /** GPS+arrival fusion으로 결정된 현재역. */
+  result: NearestStationResult | null;
+  /** GPS 원본 result — 비교/디버깅용. */
+  gpsResult: NearestStationResult | null;
+  /** fusion 신뢰도. arrival 신호로 확정/추정/없음. */
+  confidence: FusionConfidence;
+  /** GPS 환승역 변형(같은 이름 다른 노선) — 기존 useNearestStation 호환. */
+  variants: Station[];
+  userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
+  accuracyMeters: number | null;
+  loading: boolean;
+  error: string | null;
+  permissionDenied: boolean;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * GPS 후보 상위 N개에 대해 realtimeStationArrival을 동시 폴링하고,
+ * arvlCd 우선순위로 현재역을 fusion해 반환한다.
+ *
+ * 지하 구간 GPS 지연(이미 도착한 역인데 전역 표시)을 우회하는 것이 목적.
+ * arrival 신호가 모두 약하면 GPS 최근접으로 자연 fallback.
+ */
+export function useFusedNearestStation(
+  provider?: ArrivalProvider,
+): UseFusedNearestStationReturn {
+  const gps = useNearestStation();
+
+  // GPS 좌표 → 거리순 후보 N개. 좌표 갱신 시에만 재계산.
+  const candidates = useMemo<NearestStationResult[]>(() => {
+    if (!gps.userLocation) return [];
+    return findTopNearestStations(
+      gps.userLocation.lat,
+      gps.userLocation.lng,
+      FUSION_CANDIDATE_LIMIT,
+      MAX_STATION_DISTANCE_KM,
+    );
+  }, [gps.userLocation]);
+
+  // 후보 K개에 대한 arrival 폴링 — hooks는 고정 순서 호출이 필요하므로 N=3 고정.
+  // 후보 부족 시 null로 호출 → useArrivalInfo 내부에서 no-op.
+  const c0 = candidates[0]?.station.name ?? null;
+  const c1 = candidates[1]?.station.name ?? null;
+  const c2 = candidates[2]?.station.name ?? null;
+  const a0 = useArrivalInfo(c0, provider);
+  const a1 = useArrivalInfo(c1, provider);
+  const a2 = useArrivalInfo(c2, provider);
+
+  const fused = useMemo(() => {
+    if (candidates.length === 0) return null;
+    const arrivals = [a0.arrival, a1.arrival, a2.arrival];
+    return pickFusedStation(
+      candidates.map((cand, i) => ({ candidate: cand, arrival: arrivals[i] ?? null })),
+    );
+  }, [candidates, a0.arrival, a1.arrival, a2.arrival]);
+
+  return {
+    result: fused?.result ?? gps.result,
+    gpsResult: gps.result,
+    confidence: fused?.confidence ?? 'gps-only',
+    variants: gps.variants,
+    userLocation: gps.userLocation,
+    speedMps: gps.speedMps,
+    accuracyMeters: gps.accuracyMeters,
+    loading: gps.loading,
+    error: gps.error,
+    permissionDenied: gps.permissionDenied,
+    refresh: gps.refresh,
+  };
+}

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -3,17 +3,22 @@ import { AppState } from 'react-native';
 import * as Location from 'expo-location';
 import { NearestStationResult, Station } from '../types/station';
 import { findNearestStations } from '../utils/findNearestStation';
-import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
+import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../utils/locationGates';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 
-const DISTANCE_INTERVAL_M = 10;
-const MIN_DISTANCE_CHANGE_KM = 0.01; // 10m
+const MIN_DISTANCE_CHANGE_KM = 0.003; // 3m — UI 갱신을 자주 흘려보낸다.
 
+// userLocation/result는 표시용 완화 게이트(MAX_ACCURACY_M_DISPLAY=1500m)를 통과한 좌표로 갱신된다.
+// 알람 발화 경로에서 이 값을 ETA/거리 계산에 사용할 경우 반드시 accuracyMeters와 함께 묶어
+// 알람 엄격 게이트(isAccuracyAcceptable, MAX_ACCURACY_M=200m)를 먼저 통과시켜야 한다.
+// 예: useStationAlarm는 effect 진입부에서 isAccuracyAcceptable(accuracyMeters) early return으로
+// 이 계약을 강제한다.
 interface UseNearestStationReturn {
   result: NearestStationResult | null;
   variants: Station[];
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
+  accuracyMeters: number | null;
   loading: boolean;
   error: string | null;
   permissionDenied: boolean;
@@ -39,6 +44,7 @@ export function useNearestStation(): UseNearestStationReturn {
   const [variants, setVariants] = useState<Station[]>([]);
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [speedMps, setSpeedMps] = useState<number | null>(null);
+  const [accuracyMeters, setAccuracyMeters] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
@@ -47,7 +53,7 @@ export function useNearestStation(): UseNearestStationReturn {
   const lastDistanceRef = useRef<number>(0);
 
   const applyLocation = useCallback((coords: Location.LocationObjectCoords) => {
-    const { latitude, longitude, speed } = coords;
+    const { latitude, longitude, speed, accuracy } = coords;
     const stationsResult = findNearestStations(latitude, longitude, MAX_STATION_DISTANCE_KM);
 
     const newId = stationsResult?.primary.id ?? null;
@@ -57,6 +63,7 @@ export function useNearestStation(): UseNearestStationReturn {
     const noStation = !stationsResult && lastStationIdRef.current !== null;
 
     setSpeedMps(speed != null && speed >= 0 ? speed : null);
+    setAccuracyMeters(accuracy ?? null);
 
     if (stationChanged || distanceDelta > MIN_DISTANCE_CHANGE_KM || noStation) {
       lastStationIdRef.current = newId;
@@ -84,18 +91,28 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
 
-      // 캐시된 위치는 신선하고 정확한 경우만 즉시 표시 (stale/저정확도로 인한 false alarm 방지)
+      // 캐시된 위치는 신선하고 알람 엄격 게이트(200m)를 통과하는 경우만 즉시 표시.
+      // 콜드 스타트 시 부정확한 fix로 사용자에게 오정보를 주는 것을 방지.
       const lastKnown = await Location.getLastKnownPositionAsync();
       if (lastKnown && isLocationFresh(lastKnown.timestamp) && isAccuracyAcceptable(lastKnown.coords.accuracy)) {
         applyLocation(lastKnown.coords);
         setLoading(false);
       }
 
-      // 연속 GPS 스트리밍 시작 — 저정확도 좌표는 무시
+      // 연속 GPS 스트리밍 — 지하 구간 horizontalAccuracy(300~1500m)도 표시용으로는 수용.
+      // 알람은 useStationAlarm에서 accuracyMeters로 별도 엄격 게이트.
+      // BestForNavigation + distanceInterval:0 + timeInterval:2000:
+      //  좌표를 최대한 자주 흘려보낸다 (foreground 한정, 화면 켜진 동안만 GPS 풀파워).
+      // 참고: pausesUpdatesAutomatically / activityType은 expo-location foreground 옵션에
+      //  노출되지 않아 적용 불가. background task 옵션에서만 사용 가능.
       subscriptionRef.current = await Location.watchPositionAsync(
-        { accuracy: Location.Accuracy.High, distanceInterval: DISTANCE_INTERVAL_M },
+        {
+          accuracy: Location.Accuracy.BestForNavigation,
+          distanceInterval: 0,
+          timeInterval: 2000,
+        },
         (location) => {
-          if (!isAccuracyAcceptable(location.coords.accuracy)) return;
+          if (!isAccuracyAcceptableForDisplay(location.coords.accuracy)) return;
           applyLocation(location.coords);
         },
       );
@@ -120,7 +137,7 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
       const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
-      if (isAccuracyAcceptable(location.coords.accuracy)) {
+      if (isAccuracyAcceptableForDisplay(location.coords.accuracy)) {
         applyLocation(location.coords);
       }
     } catch {
@@ -148,5 +165,5 @@ export function useNearestStation(): UseNearestStationReturn {
     };
   }, [startWatch, stopWatch]);
 
-  return { result, variants, userLocation, speedMps, loading, error, permissionDenied, refresh };
+  return { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh };
 }

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/alarmLog';
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
+import { isAccuracyAcceptable } from '../utils/locationGates';
 
 const logger = createLogger('StationAlarm');
 
@@ -23,6 +24,7 @@ export interface UseStationAlarmInputs {
   nearestStation: Station | null;
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
+  accuracyMeters: number | null;
 }
 
 export function useStationAlarm({
@@ -31,6 +33,7 @@ export function useStationAlarm({
   nearestStation,
   userLocation,
   speedMps,
+  accuracyMeters,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
@@ -57,6 +60,11 @@ export function useStationAlarm({
     }
 
     if (!route || !destination) return;
+
+    // 알람 경로는 표시 경로보다 엄격한 정확도 게이트(MAX_ACCURACY_M=200m)를 적용한다.
+    // useNearestStation은 지하 구간에서 정확도 1500m까지 표시용으로 수용하므로,
+    // 그대로 알람을 울리면 잘못된 역에서 false alarm이 발생한다.
+    if (!isAccuracyAcceptable(accuracyMeters)) return;
 
     let etaSeconds: number | null = null;
     if (userLocation) {
@@ -131,5 +139,6 @@ export function useStationAlarm({
     userLocation?.lat,
     userLocation?.lng,
     speedMps,
+    accuracyMeters,
   ]);
 }

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -15,6 +15,7 @@ import {
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 import { isAccuracyAcceptable } from '../utils/locationGates';
+import type { FusionConfidence } from '../utils/pickFusedStation';
 
 const logger = createLogger('StationAlarm');
 
@@ -25,6 +26,12 @@ export interface UseStationAlarmInputs {
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
   accuracyMeters: number | null;
+  /**
+   * useFusedNearestStation의 신뢰도. 'arrival-confirmed'(arvlCd=1 도착 신호)면
+   * GPS accuracy 게이트가 막혀도 station-passed 알람을 발화한다 — 지하 깊은 구간
+   * (accuracy > 200m) 알람 누락 해소. ETA 기반 phase 알람은 거리 계산이 필요해 GPS 게이트 유지.
+   */
+  arrivalConfidence?: FusionConfidence;
 }
 
 export function useStationAlarm({
@@ -34,6 +41,7 @@ export function useStationAlarm({
   userLocation,
   speedMps,
   accuracyMeters,
+  arrivalConfidence,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
@@ -64,37 +72,45 @@ export function useStationAlarm({
     // 알람 경로는 표시 경로보다 엄격한 정확도 게이트(MAX_ACCURACY_M=200m)를 적용한다.
     // useNearestStation은 지하 구간에서 정확도 1500m까지 표시용으로 수용하므로,
     // 그대로 알람을 울리면 잘못된 역에서 false alarm이 발생한다.
-    if (!isAccuracyAcceptable(accuracyMeters)) return;
+    // 단, arrivalConfidence='arrival-confirmed'(arvlCd=1 도착)는 선로 신호 기반이라
+    // GPS 게이트가 막혀도 station-passed 알람은 허용한다(지하 누락 해소).
+    const accuracyOk = isAccuracyAcceptable(accuracyMeters);
+    const arrivalConfirmed = arrivalConfidence === 'arrival-confirmed';
+    if (!accuracyOk && !arrivalConfirmed) return;
 
-    let etaSeconds: number | null = null;
-    if (userLocation) {
-      const distM = distanceMetersBetween(
-        userLocation.lat,
-        userLocation.lng,
-        destination.lat,
-        destination.lng,
-      );
-      etaSeconds = estimateEtaSeconds(distM, speedMps);
-    }
-
-    const event = evaluateAlarmPhase(
-      { route, destinationName: destination.name, etaSeconds },
-      firedAlarmsRef.current,
-    );
-    if (event) {
-      firedAlarmsRef.current.add(alarmKey(event));
-      if (sleepModeRef.current) {
-        setAlarmEvent(event);
+    // Phase 알람은 ETA 거리 계산이 필요해 GPS 게이트가 통과한 경우에만 평가한다.
+    if (accuracyOk) {
+      let etaSeconds: number | null = null;
+      if (userLocation) {
+        const distM = distanceMetersBetween(
+          userLocation.lat,
+          userLocation.lng,
+          destination.lat,
+          destination.lng,
+        );
+        etaSeconds = estimateEtaSeconds(distM, speedMps);
       }
-      sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
-        logger.error('알람 알림 실패:', e),
+
+      const event = evaluateAlarmPhase(
+        { route, destinationName: destination.name, etaSeconds },
+        firedAlarmsRef.current,
       );
-      logFiredAlarm('fg', event);
+      if (event) {
+        firedAlarmsRef.current.add(alarmKey(event));
+        if (sleepModeRef.current) {
+          setAlarmEvent(event);
+        }
+        sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
+          logger.error('알람 알림 실패:', e),
+        );
+        logFiredAlarm('fg', event);
+      }
     }
 
     // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
     // 알림 상태는 notificationState 모듈(AsyncStorage)을 단일 출처로 사용해
-    // Foreground/Background 양쪽에서 동일한 dedup이 적용된다.
+    // Foreground/Background 양쪽에서 동일한 dedup이 적용된다 — GPS·arrival 양쪽 트리거가
+    // 같은 역에 대해 중복 발화하지 않는다.
     // cancellation: 효과 cleanup이 cancelled를 true로 만들어 stale IIFE를 중단시킨다.
     // A→B→A 빠른 변동 시 이전 IIFE들이 cancelled로 차단되고 최신 candidate만 알림을 보낸다.
     if (nearestStation && route && isStationOnRoute(nearestStation, route)) {
@@ -140,5 +156,6 @@ export function useStationAlarm({
     userLocation?.lng,
     speedMps,
     accuracyMeters,
+    arrivalConfidence,
   ]);
 }

--- a/src/hooks/useTrainPositions.ts
+++ b/src/hooks/useTrainPositions.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { LinePositions } from '../api/positionApi';
+import type { PositionProvider } from '../providers/types';
+import { createPositionProvider } from '../providers/factory';
+import { TtlCache } from '../utils/ttlCache';
+import { usePolling } from './usePolling';
+import type { LineNumber } from '../types/station';
+
+const POLL_INTERVAL_MS = 5_000;
+const CACHE_TTL_MS = 30_000;
+
+/**
+ * 모듈 스코프 싱글톤 — 같은 호선을 여러 hook 인스턴스가 폴링할 때 중복 호출 방지.
+ * useArrivalInfo와 동일 패턴.
+ */
+const positionCache = new TtlCache<LineNumber, LinePositions>(CACHE_TTL_MS);
+
+/** 테스트 격리용. */
+export function __resetPositionCacheForTests(): void {
+  positionCache.clear();
+}
+
+function positionsEqual(a: LinePositions | null, b: LinePositions): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+interface UseTrainPositionsReturn {
+  positions: LinePositions | null;
+  loading: boolean;
+  isMock: boolean;
+}
+
+/**
+ * 호선의 모든 운행 열차 위치를 폴링한다. line=null이면 비활성.
+ * 사용자 GPS 후보의 호선들에 대해 Hook 여러 개 호출(Phase 3 useFusedNearestStation 패턴).
+ */
+export function useTrainPositions(
+  line: LineNumber | null,
+  provider?: PositionProvider,
+): UseTrainPositionsReturn {
+  const [positions, setPositions] = useState<LinePositions | null>(null);
+  const [loading, setLoading] = useState(false);
+  const providerRef = useRef<PositionProvider>(provider ?? createPositionProvider());
+  const positionsRef = useRef<LinePositions | null>(null);
+  const lineRef = useRef(line);
+  lineRef.current = line;
+
+  const update = useCallback((data: LinePositions) => {
+    if (!positionsEqual(positionsRef.current, data)) {
+      positionsRef.current = data;
+      setPositions(data);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!line) {
+      positionsRef.current = null;
+      setPositions(null);
+      setLoading(false);
+      return;
+    }
+
+    const cached = positionCache.get(line);
+    if (cached) {
+      update(cached);
+      setLoading(false);
+    } else {
+      positionsRef.current = null;
+      setPositions(null);
+      setLoading(true);
+    }
+  }, [line, update]);
+
+  useEffect(() => {
+    if (!line) return;
+
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const data = await providerRef.current.getPositions(line);
+        if (cancelled) return;
+        if (!data.isMock) positionCache.set(line, data);
+        update(data);
+      } catch {
+        // Provider 내부에서 에러 처리
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [line, update]);
+
+  usePolling(
+    () => {
+      const l = lineRef.current;
+      if (!l) return;
+      providerRef.current
+        .getPositions(l)
+        .then((data) => {
+          if (l !== lineRef.current) return;
+          if (!data.isMock) positionCache.set(l, data);
+          update(data);
+          setLoading(false);
+        })
+        .catch(() => {});
+    },
+    POLL_INTERVAL_MS,
+    { onResume: () => positionCache.clear() },
+  );
+
+  return { positions, loading, isMock: positions?.isMock ?? false };
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "Set as origin",
     "setAsDestination": "Set as destination",
     "nearbyStationsHeader": "Nearby stations (within 1km)",
-    "noNearbyStations": "No subway stations within 1km."
+    "noNearbyStations": "No subway stations within 1km.",
+    "train": {
+      "terminalSuffix": "To {{name}}",
+      "descriptionTemplate": "Train {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "Arrived",
+        "entering": "Entering",
+        "departed": "Departed",
+        "prevDeparted": "Departed prev. station",
+        "running": "In service"
+      }
+    }
   },
   "favorites": {
     "title": "Favorites",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "Transfer",
-    "arrivalNote": "Arrival"
+    "arrivalNote": "Arrival",
+    "transferArrivalNote": "Transfer → Arrival"
   },
   "routes": {
     "optimal": "Fastest",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "乗換",
-    "arrivalNote": "到着"
+    "arrivalNote": "到着",
+    "transferArrivalNote": "乗換 → 到着"
   },
   "routes": {
     "optimal": "最速",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "出発駅に設定",
     "setAsDestination": "目的地に設定",
     "nearbyStationsHeader": "周辺の地下鉄駅 (1km以内)",
-    "noNearbyStations": "1km以内に地下鉄駅がありません。"
+    "noNearbyStations": "1km以内に地下鉄駅がありません。",
+    "train": {
+      "terminalSuffix": "{{name}}行",
+      "descriptionTemplate": "列車 {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "到着",
+        "entering": "進入",
+        "departed": "発車",
+        "prevDeparted": "前駅発車",
+        "running": "運行中"
+      }
+    }
   },
   "favorites": {
     "title": "お気に入り",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "환승",
-    "arrivalNote": "도착"
+    "arrivalNote": "도착",
+    "transferArrivalNote": "환승 → 도착"
   },
   "routes": {
     "optimal": "최적경로",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "출발역으로 설정",
     "setAsDestination": "도착역으로 설정",
     "nearbyStationsHeader": "주변 지하철역 (1km 이내)",
-    "noNearbyStations": "주변 1km 내 지하철역이 없습니다."
+    "noNearbyStations": "주변 1km 내 지하철역이 없습니다.",
+    "train": {
+      "terminalSuffix": "{{name}}행",
+      "descriptionTemplate": "열차 {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "도착",
+        "entering": "진입",
+        "departed": "출발",
+        "prevDeparted": "전역 출발",
+        "running": "운행 중"
+      }
+    }
   },
   "favorites": {
     "title": "즐겨찾기",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -119,7 +119,8 @@
   },
   "journey": {
     "transferNote": "换乘",
-    "arrivalNote": "到达"
+    "arrivalNote": "到达",
+    "transferArrivalNote": "换乘 → 到达"
   },
   "routes": {
     "optimal": "最快",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -72,7 +72,18 @@
     "setAsOrigin": "设为出发站",
     "setAsDestination": "设为目的地",
     "nearbyStationsHeader": "附近地铁站(1km以内)",
-    "noNearbyStations": "1km内没有地铁站。"
+    "noNearbyStations": "1km内没有地铁站。",
+    "train": {
+      "terminalSuffix": "开往{{name}}",
+      "descriptionTemplate": "列车 {{trainNo}} · {{status}}",
+      "status": {
+        "arrived": "到达",
+        "entering": "进站",
+        "departed": "发车",
+        "prevDeparted": "前站发车",
+        "running": "运行中"
+      }
+    }
   },
   "favorites": {
     "title": "收藏",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -8,10 +8,10 @@ import zh from './locales/zh.json';
 // 자동으로 따라온다. nativeName은 화면 언어와 무관하게 그 언어 사용자가 자기 언어를
 // 알아볼 수 있도록 native name으로 표기한다 (예: ja → 日本語).
 export const LANGUAGE_REGISTRY = [
-  { code: 'ko', nativeName: '한국어', translation: ko },
-  { code: 'en', nativeName: 'English', translation: en },
-  { code: 'ja', nativeName: '日本語', translation: ja },
-  { code: 'zh', nativeName: '中文', translation: zh },
+  { code: 'ko', nativeName: '한국어', translation: ko, ttsLocale: 'ko-KR' },
+  { code: 'en', nativeName: 'English', translation: en, ttsLocale: 'en-US' },
+  { code: 'ja', nativeName: '日本語', translation: ja, ttsLocale: 'ja-JP' },
+  { code: 'zh', nativeName: '中文', translation: zh, ttsLocale: 'zh-CN' },
 ] as const;
 
 export const SUPPORTED_LANGUAGES = LANGUAGE_REGISTRY.map(

--- a/src/providers/__tests__/factory.test.ts
+++ b/src/providers/__tests__/factory.test.ts
@@ -101,5 +101,16 @@ describe('providers/index re-exports', () => {
     expect(providersIndex.SeoulOpenApiProvider).toBeDefined();
     expect(providersIndex.BffArrivalProvider).toBeDefined();
     expect(providersIndex.MockArrivalProvider).toBeDefined();
+    expect(providersIndex.createPositionProvider).toBeDefined();
+    expect(providersIndex.SeoulOpenPositionProvider).toBeDefined();
+    expect(providersIndex.MockPositionProvider).toBeDefined();
+  });
+});
+
+describe('createPositionProvider', () => {
+  it('SeoulOpenPositionProvider 인스턴스를 반환한다', () => {
+    const { createPositionProvider } = require('../factory');
+    const { SeoulOpenPositionProvider } = require('../position/SeoulOpenPositionProvider');
+    expect(createPositionProvider()).toBeInstanceOf(SeoulOpenPositionProvider);
   });
 });

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -8,8 +8,8 @@ describe('BffArrivalProvider', () => {
   let provider: BffArrivalProvider;
 
   const VALID_DATA: StationArrival = {
-    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001' }],
-    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001' }],
+    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 }],
+    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 }],
   };
 
   function mockFetchOk(data: StationArrival) {

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -8,8 +8,8 @@ describe('BffArrivalProvider', () => {
   let provider: BffArrivalProvider;
 
   const VALID_DATA: StationArrival = {
-    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 }],
-    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 }],
+    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
   };
 
   function mockFetchOk(data: StationArrival) {

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -8,8 +8,8 @@ describe('BffArrivalProvider', () => {
   let provider: BffArrivalProvider;
 
   const VALID_DATA: StationArrival = {
-    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0 }],
-    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0 }],
+    up: [{ destination: '서울역', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'UP-001', receivedAtMs: 0, arrivalCode: -1 }],
+    down: [{ destination: '인천역', arrivalMinutes: 5, arrivalSeconds: 300, statusMessage: '', trainCode: 'DN-001', receivedAtMs: 0, arrivalCode: -1 }],
   };
 
   function mockFetchOk(data: StationArrival) {

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,6 +1,7 @@
-import type { ArrivalProvider } from './types';
+import type { ArrivalProvider, PositionProvider } from './types';
 import { SeoulOpenApiProvider } from './arrival/SeoulOpenApiProvider';
 import { BffArrivalProvider } from './arrival/BffArrivalProvider';
+import { SeoulOpenPositionProvider } from './position/SeoulOpenPositionProvider';
 
 export function createArrivalProvider(): ArrivalProvider {
   const useBff = process.env.EXPO_PUBLIC_USE_BFF === 'true';
@@ -11,4 +12,12 @@ export function createArrivalProvider(): ArrivalProvider {
   }
 
   return new SeoulOpenApiProvider();
+}
+
+/**
+ * Phase 3: realtimePosition Provider. BFF 도입 시 같은 인터페이스로 추가 가능
+ * (현재는 직접 호출만). 호출 비용은 useTrainPositions의 모듈 싱글톤 캐시가 호선 단위로 dedup.
+ */
+export function createPositionProvider(): PositionProvider {
+  return new SeoulOpenPositionProvider();
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,7 @@
-export type { ArrivalProvider, ArrivalOptions } from './types';
-export { createArrivalProvider } from './factory';
+export type { ArrivalProvider, ArrivalOptions, PositionProvider } from './types';
+export { createArrivalProvider, createPositionProvider } from './factory';
 export { SeoulOpenApiProvider } from './arrival/SeoulOpenApiProvider';
 export { BffArrivalProvider } from './arrival/BffArrivalProvider';
 export { MockArrivalProvider } from './arrival/MockProvider';
+export { SeoulOpenPositionProvider } from './position/SeoulOpenPositionProvider';
+export { MockPositionProvider } from './position/MockPositionProvider';

--- a/src/providers/position/MockPositionProvider.ts
+++ b/src/providers/position/MockPositionProvider.ts
@@ -1,0 +1,9 @@
+import type { PositionProvider } from '../types';
+import { MOCK_POSITIONS, type LinePositions } from '../../api/positionApi';
+import type { LineNumber } from '../../types/station';
+
+export class MockPositionProvider implements PositionProvider {
+  async getPositions(line: LineNumber): Promise<LinePositions> {
+    return { ...MOCK_POSITIONS, line };
+  }
+}

--- a/src/providers/position/SeoulOpenPositionProvider.ts
+++ b/src/providers/position/SeoulOpenPositionProvider.ts
@@ -1,0 +1,10 @@
+import { fetchTrainPositions } from '../../api/positionApi';
+import type { PositionProvider } from '../types';
+import type { FetchPositionOptions, LinePositions } from '../../api/positionApi';
+import type { LineNumber } from '../../types/station';
+
+export class SeoulOpenPositionProvider implements PositionProvider {
+  async getPositions(line: LineNumber, options?: FetchPositionOptions): Promise<LinePositions> {
+    return fetchTrainPositions(line, options);
+  }
+}

--- a/src/providers/position/__tests__/MockPositionProvider.test.ts
+++ b/src/providers/position/__tests__/MockPositionProvider.test.ts
@@ -1,0 +1,10 @@
+import { MockPositionProvider } from '../MockPositionProvider';
+
+describe('MockPositionProvider', () => {
+  it('mock positions 반환 + line 보존', async () => {
+    const provider = new MockPositionProvider();
+    const result = await provider.getPositions('5');
+    expect(result.isMock).toBe(true);
+    expect(result.line).toBe('5');
+  });
+});

--- a/src/providers/position/__tests__/SeoulOpenPositionProvider.test.ts
+++ b/src/providers/position/__tests__/SeoulOpenPositionProvider.test.ts
@@ -1,0 +1,15 @@
+import { SeoulOpenPositionProvider } from '../SeoulOpenPositionProvider';
+import * as positionApi from '../../../api/positionApi';
+
+jest.mock('../../../api/positionApi');
+
+describe('SeoulOpenPositionProvider', () => {
+  it('fetchTrainPositions로 위임한다', async () => {
+    const mock = positionApi.fetchTrainPositions as jest.Mock;
+    mock.mockResolvedValue({ line: '2', trains: [] });
+    const provider = new SeoulOpenPositionProvider();
+
+    await provider.getPositions('2', { timeoutMs: 1000 });
+    expect(mock).toHaveBeenCalledWith('2', { timeoutMs: 1000 });
+  });
+});

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,4 +1,6 @@
 import type { StationArrival } from '../api/arrivalApi';
+import type { LinePositions, FetchPositionOptions } from '../api/positionApi';
+import type { LineNumber } from '../types/station';
 
 export interface ArrivalOptions {
   timeoutMs?: number;
@@ -10,4 +12,9 @@ export interface ArrivalProvider {
     stationName: string,
     options?: ArrivalOptions,
   ): Promise<StationArrival>;
+}
+
+/** 호선 단위 실시간 열차위치 조회 — Phase 3. */
+export interface PositionProvider {
+  getPositions(line: LineNumber, options?: FetchPositionOptions): Promise<LinePositions>;
 }

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -26,7 +26,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false });
     jest.clearAllMocks();
   });
 
@@ -586,5 +586,18 @@ describe('useAppStore', () => {
     useAppStore.setState({ localePreference: 'auto' });
     await useAppStore.getState().loadLocalePreference();
     expect(useAppStore.getState().localePreference).toBe('auto');
+  });
+
+  // ── debugVisible ──
+
+  it('초기 debugVisible은 false이다', () => {
+    expect(useAppStore.getState().debugVisible).toBe(false);
+  });
+
+  it('setDebugVisible: 상태를 토글한다', () => {
+    useAppStore.getState().setDebugVisible(true);
+    expect(useAppStore.getState().debugVisible).toBe(true);
+    useAppStore.getState().setDebugVisible(false);
+    expect(useAppStore.getState().debugVisible).toBe(false);
   });
 });

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -27,6 +27,8 @@ interface AppState {
   routePreference: RoutePreference;
   localePreference: LocalePreference;
   alarmEvent: AlarmEvent | null;
+  debugVisible: boolean;
+  setDebugVisible: (visible: boolean) => void;
   addFavorite: (station: Station) => Promise<void>;
   removeFavorite: (stationId: string) => Promise<void>;
   loadFavorites: () => Promise<void>;
@@ -60,6 +62,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   routePreference: 'optimal' as RoutePreference,
   localePreference: 'auto' as LocalePreference,
   alarmEvent: null,
+  debugVisible: false,
+
+  setDebugVisible: (visible: boolean) => {
+    set({ debugVisible: visible });
+  },
 
   loadFavorites: async () => {
     try {

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -38,6 +38,12 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedGate: (...args: unknown[]) => mockLogSuppressedGate(...args),
 }));
 
+// ── bgDiagnostics 모킹 ──
+const mockIncrementBgDiagnostic = jest.fn();
+jest.mock('../../utils/bgDiagnostics', () => ({
+  incrementBgDiagnostic: (...args: unknown[]) => mockIncrementBgDiagnostic(...args),
+}));
+
 // ── logger 모킹 ──
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -32,6 +32,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     logSuppressedGate('gate-age', { lat, lng, accuracy, ageMs });
     return;
   }
+  // BG task는 알람 발화 경로이므로 알람 엄격 게이트(MAX_ACCURACY_M=200m)를 유지한다.
+  // foreground watch의 표시용 완화 게이트(MAX_ACCURACY_M_DISPLAY=1500m)는 여기서 적용 금지.
+  // 여기서 게이트를 풀면 지하 구간 노이즈 좌표로 알람이 잘못 발화될 수 있다.
   if (!isAccuracyAcceptable(accuracy)) {
     logSuppressedGate('gate-accuracy', { lat, lng, accuracy, ageMs });
     return;

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -24,6 +24,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const latest = locations[locations.length - 1];
   if (!latest) return;
 
+  // #275 진단: TaskManager가 백그라운드에서 실제로 깨어나 유효 데이터를 받았는지 확인.
+  // 이 로그가 안 찍히면 JS runtime이 깨어나지 못하는 가설 A.
+  logger.info('TASK FIRED', new Date().toISOString(), 'locations:', locations.length);
+
   // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단.
   // 측정용으로 게이트 drop을 알람 로그에 fire-and-forget 적재 (B2 인프라).
   const { latitude: lat, longitude: lng, accuracy } = latest.coords;
@@ -36,6 +40,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     logSuppressedGate('gate-accuracy', { lat, lng, accuracy, ageMs });
     return;
   }
+
+  // #275 진단: 게이트 통과 직후 마커. 이후 destJson 없음 등의 조기 리턴은 별도로 식별.
+  logger.info('PIPELINE ENTER', lat.toFixed(4), lng.toFixed(4), 'acc:', accuracy);
 
   const { speed } = latest.coords;
   const speedMps = speed != null && speed >= 0 ? speed : null;
@@ -50,7 +57,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     ]);
 
     // 경로(목적지) 없으면 백그라운드에서도 실시간 현황 알림을 띄우지 않는다.
-    if (!destJson) return;
+    if (!destJson) {
+      logger.info('PIPELINE EXIT no-destination');
+      return;
+    }
 
     let destination;
     try {

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../utils/logger';
 import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
 import { logSuppressedGate } from '../utils/alarmLog';
+import { incrementBgDiagnostic } from '../utils/bgDiagnostics';
 import type { Route } from '../utils/stationRoute';
 
 const logger = createLogger('BackgroundLocation');
@@ -25,8 +26,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   if (!latest) return;
 
   // #275 진단: TaskManager가 백그라운드에서 실제로 깨어나 유효 데이터를 받았는지 확인.
-  // 이 로그가 안 찍히면 JS runtime이 깨어나지 못하는 가설 A.
+  // 이 로그/카운터가 0이면 JS runtime이 깨어나지 못하는 가설 A.
   logger.info('TASK FIRED', new Date().toISOString(), 'locations:', locations.length);
+  incrementBgDiagnostic('taskFired', { stampTaskFired: true });
 
   // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단.
   // 측정용으로 게이트 drop을 알람 로그에 fire-and-forget 적재 (B2 인프라).
@@ -34,15 +36,18 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const ageMs = Date.now() - (latest.timestamp ?? 0);
   if (!isLocationFresh(latest.timestamp)) {
     logSuppressedGate('gate-age', { lat, lng, accuracy, ageMs });
+    incrementBgDiagnostic('gateAge');
     return;
   }
   if (!isAccuracyAcceptable(accuracy)) {
     logSuppressedGate('gate-accuracy', { lat, lng, accuracy, ageMs });
+    incrementBgDiagnostic('gateAccuracy');
     return;
   }
 
   // #275 진단: 게이트 통과 직후 마커. 이후 destJson 없음 등의 조기 리턴은 별도로 식별.
   logger.info('PIPELINE ENTER', lat.toFixed(4), lng.toFixed(4), 'acc:', accuracy);
+  incrementBgDiagnostic('pipelineEnter');
 
   const { speed } = latest.coords;
   const speedMps = speed != null && speed >= 0 ? speed : null;
@@ -59,6 +64,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     // 경로(목적지) 없으면 백그라운드에서도 실시간 현황 알림을 띄우지 않는다.
     if (!destJson) {
       logger.info('PIPELINE EXIT no-destination');
+      incrementBgDiagnostic('pipelineExitNoDestination');
       return;
     }
 

--- a/src/testUtils/fixtures.ts
+++ b/src/testUtils/fixtures.ts
@@ -20,6 +20,7 @@ export function makeArrivalInfo(overrides: Partial<ArrivalInfo> & { destination:
     arrivalMinutes: Math.floor(overrides.arrivalSeconds / 60),
     statusMessage: '',
     trainCode: 'T001',
+    receivedAtMs: 0,
     ...overrides,
   };
 }

--- a/src/testUtils/fixtures.ts
+++ b/src/testUtils/fixtures.ts
@@ -22,6 +22,8 @@ export function makeArrivalInfo(overrides: Partial<ArrivalInfo> & { destination:
     trainCode: 'T001',
     receivedAtMs: 0,
     arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
     ...overrides,
   };
 }

--- a/src/testUtils/fixtures.ts
+++ b/src/testUtils/fixtures.ts
@@ -21,6 +21,7 @@ export function makeArrivalInfo(overrides: Partial<ArrivalInfo> & { destination:
     statusMessage: '',
     trainCode: 'T001',
     receivedAtMs: 0,
+    arrivalCode: -1,
     ...overrides,
   };
 }

--- a/src/utils/__tests__/bgDiagnostics.test.ts
+++ b/src/utils/__tests__/bgDiagnostics.test.ts
@@ -1,10 +1,20 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
+  BG_DIAGNOSTIC_ROWS,
   incrementBgDiagnostic,
   getBgDiagnostics,
   clearBgDiagnostics,
+  type BgDiagnosticCounter,
+  type BgDiagnostics,
 } from '../bgDiagnostics';
 import { BG_DIAGNOSTICS_KEY } from '../../constants/storageKeys';
+
+function makeSnapshot(overrides: Partial<BgDiagnostics> = {}): BgDiagnostics {
+  const zeros = Object.fromEntries(
+    BG_DIAGNOSTIC_ROWS.map(({ key }) => [key, 0]),
+  ) as Record<BgDiagnosticCounter, number>;
+  return { ...zeros, lastTaskFiredTs: null, ...overrides };
+}
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
@@ -38,31 +48,16 @@ describe('bgDiagnostics', () => {
 
       const result = await getBgDiagnostics();
 
-      expect(result).toEqual({
-        taskFired: 0,
-        pipelineEnter: 0,
-        pipelineExitNoDestination: 0,
-        gateAge: 0,
-        gateAccuracy: 0,
-        alarmEnter: 0,
-        alarmPermDenied: 0,
-        stationPassedEnter: 0,
-        lastTaskFiredTs: null,
-      });
+      expect(result).toEqual(makeSnapshot());
     });
 
     it('저장값이 있으면 그대로 돌려준다', async () => {
-      const stored = {
+      const stored = makeSnapshot({
         taskFired: 3,
         pipelineEnter: 2,
-        pipelineExitNoDestination: 0,
         gateAge: 1,
-        gateAccuracy: 0,
-        alarmEnter: 0,
-        alarmPermDenied: 0,
-        stationPassedEnter: 0,
         lastTaskFiredTs: 1_700_000_000_000,
-      };
+      });
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stored));
 
       const result = await getBgDiagnostics();

--- a/src/utils/__tests__/bgDiagnostics.test.ts
+++ b/src/utils/__tests__/bgDiagnostics.test.ts
@@ -16,24 +16,10 @@ function makeSnapshot(overrides: Partial<BgDiagnostics> = {}): BgDiagnostics {
   return { ...zeros, lastTaskFiredTs: null, ...overrides };
 }
 
-jest.mock('@react-native-async-storage/async-storage', () => ({
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-}));
+jest.mock('@react-native-async-storage/async-storage', () => ({ getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn() }));
+jest.mock('../logger', () => ({ createLogger: () => ({ debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }) }));
 
-jest.mock('../logger', () => ({
-  createLogger: () => ({
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  }),
-}));
-
-function flushPromises(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
-}
+const flushPromises = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 describe('bgDiagnostics', () => {
   beforeEach(() => {

--- a/src/utils/__tests__/bgDiagnostics.test.ts
+++ b/src/utils/__tests__/bgDiagnostics.test.ts
@@ -1,0 +1,166 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  incrementBgDiagnostic,
+  getBgDiagnostics,
+  clearBgDiagnostics,
+} from '../bgDiagnostics';
+import { BG_DIAGNOSTICS_KEY } from '../../constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('bgDiagnostics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('getBgDiagnostics', () => {
+    it('저장된 값이 없으면 모두 0 인 기본 스냅샷을 돌려준다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+      const result = await getBgDiagnostics();
+
+      expect(result).toEqual({
+        taskFired: 0,
+        pipelineEnter: 0,
+        pipelineExitNoDestination: 0,
+        gateAge: 0,
+        gateAccuracy: 0,
+        alarmEnter: 0,
+        alarmPermDenied: 0,
+        stationPassedEnter: 0,
+        lastTaskFiredTs: null,
+      });
+    });
+
+    it('저장값이 있으면 그대로 돌려준다', async () => {
+      const stored = {
+        taskFired: 3,
+        pipelineEnter: 2,
+        pipelineExitNoDestination: 0,
+        gateAge: 1,
+        gateAccuracy: 0,
+        alarmEnter: 0,
+        alarmPermDenied: 0,
+        stationPassedEnter: 0,
+        lastTaskFiredTs: 1_700_000_000_000,
+      };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stored));
+
+      const result = await getBgDiagnostics();
+
+      expect(result).toEqual(stored);
+    });
+
+    it('JSON 파싱 실패 시 기본 스냅샷을 돌려준다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('!!!not-json');
+
+      const result = await getBgDiagnostics();
+
+      expect(result.taskFired).toBe(0);
+      expect(result.lastTaskFiredTs).toBeNull();
+    });
+  });
+
+  describe('incrementBgDiagnostic', () => {
+    it('카운터를 1 증가시켜 저장한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+      incrementBgDiagnostic('pipelineEnter');
+      await flushPromises();
+
+      const [, payload] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(payload).pipelineEnter).toBe(1);
+    });
+
+    it('stampTaskFired 옵션 시 lastTaskFiredTs를 갱신한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      const fixedNow = 1_700_000_001_234;
+      jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+
+      incrementBgDiagnostic('taskFired', { stampTaskFired: true });
+      await flushPromises();
+
+      const [key, payload] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(key).toBe(BG_DIAGNOSTICS_KEY);
+      const parsed = JSON.parse(payload);
+      expect(parsed.taskFired).toBe(1);
+      expect(parsed.lastTaskFiredTs).toBe(fixedNow);
+    });
+
+    it('읽기 실패 시 swallow 한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+
+      incrementBgDiagnostic('alarmEnter');
+      await flushPromises();
+
+      // getBgDiagnostics 내부 catch가 기본 스냅샷을 돌려주므로 setItem은 호출됨
+      expect(AsyncStorage.setItem).toHaveBeenCalled();
+    });
+
+    it('setItem 실패도 swallow 한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
+
+      incrementBgDiagnostic('gateAge');
+      await flushPromises();
+
+      // 예외가 호출자에게 전파되지 않아야 함
+      expect(AsyncStorage.setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe('직렬화 (race 방지)', () => {
+    it('연속 호출이 직렬화되어 카운터가 누락되지 않는다', async () => {
+      // 두 번 연속 호출. 첫 번째 getItem은 null, 두 번째 getItem은 첫 호출의 setItem 결과를 반환해야 함.
+      let stored: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(() => Promise.resolve(stored));
+      (AsyncStorage.setItem as jest.Mock).mockImplementation((_key: string, value: string) => {
+        stored = value;
+        return Promise.resolve();
+      });
+
+      incrementBgDiagnostic('taskFired');
+      incrementBgDiagnostic('taskFired');
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
+
+      const finalParsed = JSON.parse(stored ?? '{}');
+      expect(finalParsed.taskFired).toBe(2);
+    });
+  });
+
+  describe('clearBgDiagnostics', () => {
+    it('AsyncStorage에서 키를 제거한다', async () => {
+      await clearBgDiagnostics();
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(BG_DIAGNOSTICS_KEY);
+    });
+
+    it('removeItem 실패도 swallow 한다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('nope'));
+
+      await expect(clearBgDiagnostics()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/__tests__/findActiveLines.test.ts
+++ b/src/utils/__tests__/findActiveLines.test.ts
@@ -1,0 +1,22 @@
+import { findActiveLines } from '../findActiveLines';
+import { MOCK_STATIONS } from '../../testUtils/fixtures';
+
+describe('findActiveLines', () => {
+  it('빈 후보 → 빈 배열', () => {
+    expect(findActiveLines([])).toEqual([]);
+  });
+
+  it('호선 dedup, 거리순 보존', () => {
+    const lines = findActiveLines([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.2 }, // 같은 호선 → dedup
+      { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
+      { station: MOCK_STATIONS.yeouinaru, distanceKm: 0.4 }, // line='5'
+    ]);
+    expect(lines).toEqual(['2', '3', '5']);
+  });
+
+  it('단일 호선 → 1개만 반환', () => {
+    expect(findActiveLines([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }])).toEqual(['2']);
+  });
+});

--- a/src/utils/__tests__/findNearestStation.test.ts
+++ b/src/utils/__tests__/findNearestStation.test.ts
@@ -1,4 +1,4 @@
-import { findNearestStation, findNearestStations } from '../findNearestStation';
+import { findNearestStation, findNearestStations, findTopNearestStations } from '../findNearestStation';
 
 // haversine을 모킹하여 어떤 역이 가장 가깝게 계산되는지 완전히 제어한다.
 // stations.json 데이터가 크므로 haversine 결과를 고정하여 루프 분기를 독립적으로 검증한다.
@@ -184,5 +184,45 @@ describe('findNearestStations', () => {
     expect(result).not.toBeNull();
     expect(result!.distanceKm).toBe(0.2);
     expect(result!.variants.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('findTopNearestStations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('limit=0이면 빈 배열을 반환한다', () => {
+    mockHaversine.mockReturnValue(0.1);
+    expect(findTopNearestStations(37.5, 127.0, 0)).toEqual([]);
+  });
+
+  it('거리순 상위 N개를 반환하되 같은 이름 환승역은 한 번만 포함된다', () => {
+    // 모든 호출에 distance를 호출 인덱스 비례로 할당해 정렬 검증.
+    let calls = 0;
+    mockHaversine.mockImplementation(() => {
+      calls += 1;
+      return calls * 0.01;
+    });
+
+    const result = findTopNearestStations(37.5, 127.0, 3);
+
+    expect(result.length).toBe(3);
+    expect(result[0].distanceKm).toBeLessThanOrEqual(result[1].distanceKm);
+    expect(result[1].distanceKm).toBeLessThanOrEqual(result[2].distanceKm);
+    const names = result.map((r) => r.station.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('maxDistanceKm 초과 항목은 제외된다', () => {
+    mockHaversine.mockReturnValue(5);
+    expect(findTopNearestStations(37.5, 127.0, 3, 1.0)).toEqual([]);
+  });
+
+  it('실데이터 528개보다 limit가 크면 가능한 만큼만 반환된다', () => {
+    mockHaversine.mockReturnValue(0.1);
+    const result = findTopNearestStations(37.5, 127.0, 9999, 1.0);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThan(9999);
   });
 });

--- a/src/utils/__tests__/findTrainCoordinates.test.ts
+++ b/src/utils/__tests__/findTrainCoordinates.test.ts
@@ -1,0 +1,94 @@
+import { findTrainCoordinates, buildStationIndex } from '../findTrainCoordinates';
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import type { Station } from '../../types/station';
+
+const NOW = 1_700_000_000_000;
+
+const stations: Station[] = [
+  { id: 'A', name: '강남', line: '2', lineColor: '#33A23D', lat: 37.498, lng: 127.028 },
+  { id: 'B', name: '역삼', line: '2', lineColor: '#33A23D', lat: 37.500, lng: 127.036 },
+  { id: 'C', name: '충무로', line: '3', lineColor: '#EF7C1C', lat: 37.561, lng: 126.994 },
+];
+
+function train(statnNm: string, status: number, overrides?: Partial<TrainPosition>): TrainPosition {
+  return {
+    statnId: '',
+    statnNm,
+    trainNo: 'T1',
+    trainStatus: status,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: NOW,
+    ...overrides,
+  };
+}
+
+describe('findTrainCoordinates', () => {
+  it('빈 입력 → 빈 배열', () => {
+    expect(findTrainCoordinates([], buildStationIndex(stations))).toEqual([]);
+    expect(findTrainCoordinates([null], buildStationIndex(stations))).toEqual([]);
+  });
+
+  it('LinePositions의 train을 (line, statnNm) 매칭으로 좌표 부여', () => {
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1, { trainNo: 'X' })] };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result).toHaveLength(1);
+    expect(result[0].lat).toBe(37.498);
+    expect(result[0].lng).toBe(127.028);
+    expect(result[0].lineColor).toBe('#33A23D');
+    expect(result[0].trainNo).toBe('X');
+    expect(result[0].trainStatus).toBe(1);
+  });
+
+  it('mock LinePositions는 통째로 무시', () => {
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1)], isMock: true };
+    expect(findTrainCoordinates([lp], buildStationIndex(stations))).toEqual([]);
+  });
+
+  it('stale(receivedAtMs<=0) 트레인 제외', () => {
+    const lp: LinePositions = {
+      line: '2',
+      trains: [train('강남', 1, { receivedAtMs: 0 }), train('역삼', 1)],
+    };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result.map((t) => t.statnNm)).toEqual(['역삼']);
+  });
+
+  it('역명 매칭 실패(unknown) 트레인 제외', () => {
+    const lp: LinePositions = {
+      line: '2',
+      trains: [train('강남', 1), train('없는역', 1)],
+    };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result).toHaveLength(1);
+    expect(result[0].statnNm).toBe('강남');
+  });
+
+  it('호선 인덱스에 없는 LinePositions 제외 (안전장치)', () => {
+    const lp: LinePositions = { line: 'airport', trains: [train('강남', 1)] };
+    expect(findTrainCoordinates([lp], buildStationIndex(stations))).toEqual([]);
+  });
+
+  it('동일 line+name 중복 station은 첫 번째만 인덱싱 (변형 안정성)', () => {
+    const dup = [
+      ...stations,
+      { id: 'A2', name: '강남', line: '2' as const, lineColor: '#33A23D', lat: 0, lng: 0 },
+    ];
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1)] };
+    const result = findTrainCoordinates([lp], buildStationIndex(dup));
+    expect(result[0].lat).toBe(37.498); // 첫 번째 stations[0] 우선
+  });
+
+  it('여러 호선 동시 처리', () => {
+    const lps: LinePositions[] = [
+      { line: '2', trains: [train('강남', 1)] },
+      { line: '3', trains: [train('충무로', 0)] },
+    ];
+    const result = findTrainCoordinates(lps, buildStationIndex(stations));
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.statnNm).sort()).toEqual(['강남', '충무로']);
+  });
+});

--- a/src/utils/__tests__/findTrainCoordinates.test.ts
+++ b/src/utils/__tests__/findTrainCoordinates.test.ts
@@ -1,5 +1,10 @@
 import { findTrainCoordinates, buildStationIndex } from '../findTrainCoordinates';
 import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import {
+  TRAIN_MARKER_OFFSET_DEG,
+  UPDN_DOWN_OUTER,
+  UPDN_UP_INNER,
+} from '../../constants/trainMarkerOffset';
 import type { Station } from '../../types/station';
 
 const NOW = 1_700_000_000_000;
@@ -32,15 +37,40 @@ describe('findTrainCoordinates', () => {
     expect(findTrainCoordinates([null], buildStationIndex(stations))).toEqual([]);
   });
 
-  it('LinePositions의 train을 (line, statnNm) 매칭으로 좌표 부여', () => {
+  it('LinePositions의 train을 (line, statnNm) 매칭으로 좌표 부여 (상행 → 서쪽 오프셋)', () => {
     const lp: LinePositions = { line: '2', trains: [train('강남', 1, { trainNo: 'X' })] };
     const result = findTrainCoordinates([lp], buildStationIndex(stations));
     expect(result).toHaveLength(1);
     expect(result[0].lat).toBe(37.498);
-    expect(result[0].lng).toBe(127.028);
+    expect(result[0].lng).toBeCloseTo(127.028 - TRAIN_MARKER_OFFSET_DEG, 10);
     expect(result[0].lineColor).toBe('#33A23D');
     expect(result[0].trainNo).toBe('X');
     expect(result[0].trainStatus).toBe(1);
+  });
+
+  it('같은 역에 상행+하행 동시 매칭 → 경도 오프셋으로 좌우 분리', () => {
+    const lp: LinePositions = {
+      line: '2',
+      trains: [
+        train('강남', 1, { trainNo: 'UP', updnLine: UPDN_UP_INNER }),
+        train('강남', 1, { trainNo: 'DOWN', updnLine: UPDN_DOWN_OUTER }),
+      ],
+    };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    const up = result.find((t) => t.trainNo === 'UP')!;
+    const down = result.find((t) => t.trainNo === 'DOWN')!;
+    expect(up.lat).toBe(37.498);
+    expect(down.lat).toBe(37.498);
+    expect(up.lng).toBeCloseTo(127.028 - TRAIN_MARKER_OFFSET_DEG, 10);
+    expect(down.lng).toBeCloseTo(127.028 + TRAIN_MARKER_OFFSET_DEG, 10);
+    expect(down.lng - up.lng).toBeCloseTo(2 * TRAIN_MARKER_OFFSET_DEG, 10);
+  });
+
+  it('updnLine이 매핑에 없는 값(예: 2) → 오프셋 0', () => {
+    const lp: LinePositions = { line: '2', trains: [train('강남', 1, { updnLine: 2 })] };
+    const result = findTrainCoordinates([lp], buildStationIndex(stations));
+    expect(result[0].lat).toBe(37.498);
+    expect(result[0].lng).toBe(127.028);
   });
 
   it('mock LinePositions는 통째로 무시', () => {

--- a/src/utils/__tests__/findTrainCoordinates.test.ts
+++ b/src/utils/__tests__/findTrainCoordinates.test.ts
@@ -89,6 +89,6 @@ describe('findTrainCoordinates', () => {
     ];
     const result = findTrainCoordinates(lps, buildStationIndex(stations));
     expect(result).toHaveLength(2);
-    expect(result.map((t) => t.statnNm).sort()).toEqual(['강남', '충무로']);
+    expect(result.map((t) => t.statnNm).sort((a, b) => a.localeCompare(b))).toEqual(['강남', '충무로']);
   });
 });

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -82,8 +82,32 @@ describe('arrivalInfoToArrivalTrain', () => {
     const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toEqual([
-      { direction: '봉화산행', line: '6', arrivalAtMs: 1000000 + 134 * 1000, subtext: undefined },
+      {
+        direction: '봉화산행',
+        line: '6',
+        arrivalAtMs: 1000000 + 134 * 1000,
+        subtext: undefined,
+        isLastTrain: false,
+        trainType: 'normal',
+        arrivalCode: -1,
+      },
     ]);
+  });
+
+  it('should pass through meta fields (isLastTrain/trainType/arrivalCode)', () => {
+    const items = [
+      makeArrivalInfo({
+        destination: '봉화산행',
+        arrivalSeconds: 60,
+        isLastTrain: true,
+        trainType: 'express',
+        arrivalCode: 1,
+      }),
+    ];
+    const result = arrivalInfoToArrivalTrain(items, '상행', '6');
+    expect(result[0].isLastTrain).toBe(true);
+    expect(result[0].trainType).toBe('express');
+    expect(result[0].arrivalCode).toBe(1);
   });
 
   it('should use direction fallback when destination is empty', () => {

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -56,6 +56,22 @@ describe('journeyDisplayToStops', () => {
   it('should return empty array for empty segments', () => {
     expect(journeyDisplayToStops({ segments: [], totalStops: 0 })).toEqual([]);
   });
+
+  it('환승역이 곧 목적지이면 도착 노드를 환승 노드에 흡수한다', () => {
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '2', lineColor: '#009D3E', fromName: '삼성', toName: '건대입구', stops: 7 },
+        { line: '7', lineColor: '#747F00', fromName: '건대입구', toName: '군자', stops: 2 },
+        { line: '5', lineColor: '#996CAC', fromName: '군자', toName: '군자', stops: 0 },
+      ],
+      totalStops: 9,
+    };
+    const stops = journeyDisplayToStops(journey);
+    expect(stops).toHaveLength(3);
+    expect(stops[0]).toEqual({ station: '삼성', line: '2', mark: 'filled' });
+    expect(stops[1]).toEqual({ station: '건대입구', line: '7', stopsFromPrev: '7정거장', mark: 'transfer', note: '환승' });
+    expect(stops[2]).toEqual({ station: '군자', line: '5', stopsFromPrev: '2정거장', mark: 'dest', note: '환승 → 도착' });
+  });
 });
 
 describe('arrivalInfoToArrivalTrain', () => {

--- a/src/utils/__tests__/locationGates.test.ts
+++ b/src/utils/__tests__/locationGates.test.ts
@@ -1,5 +1,5 @@
-import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
-import { isAccuracyAcceptable, isLocationFresh } from '../locationGates';
+import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../constants/location';
+import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../locationGates';
 
 describe('isLocationFresh', () => {
   const NOW = 1_700_000_000_000;
@@ -49,5 +49,27 @@ describe('isAccuracyAcceptable', () => {
 
   it('임계값을 초과하면 false', () => {
     expect(isAccuracyAcceptable(MAX_ACCURACY_M + 1)).toBe(false);
+  });
+});
+
+describe('isAccuracyAcceptableForDisplay', () => {
+  it('null이면 true (accuracy 정보 없음 = 통과)', () => {
+    expect(isAccuracyAcceptableForDisplay(null)).toBe(true);
+  });
+
+  it('undefined면 true', () => {
+    expect(isAccuracyAcceptableForDisplay(undefined)).toBe(true);
+  });
+
+  it('표시 임계값과 정확히 같으면 true (경계 포함)', () => {
+    expect(isAccuracyAcceptableForDisplay(MAX_ACCURACY_M_DISPLAY)).toBe(true);
+  });
+
+  it('표시 임계값을 초과하면 false', () => {
+    expect(isAccuracyAcceptableForDisplay(MAX_ACCURACY_M_DISPLAY + 1)).toBe(false);
+  });
+
+  it('알람 임계값을 초과해도 표시 임계값 이내면 true (지하 구간 가정)', () => {
+    expect(isAccuracyAcceptableForDisplay(MAX_ACCURACY_M + 1)).toBe(true);
   });
 });

--- a/src/utils/__tests__/pickFusedStation.test.ts
+++ b/src/utils/__tests__/pickFusedStation.test.ts
@@ -1,0 +1,115 @@
+import { pickFusedStation } from '../pickFusedStation';
+import type { NearestStationResult } from '../../types/station';
+import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import { MOCK_STATIONS } from '../../testUtils/fixtures';
+
+const NOW = 1_700_000_000_000; // 신선한 receivedAtMs
+
+function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: 'X',
+    arrivalMinutes: 0,
+    arrivalSeconds: 0,
+    statusMessage: '',
+    trainCode: 'T1',
+    receivedAtMs: NOW,
+    arrivalCode,
+    ...overrides,
+  };
+}
+
+function arrival(...codes: number[]): StationArrival {
+  return { up: codes.map((c) => info(c)), down: [] };
+}
+
+function cand(stationKey: keyof typeof MOCK_STATIONS, distanceKm: number): NearestStationResult {
+  return { station: MOCK_STATIONS[stationKey], distanceKm };
+}
+
+describe('pickFusedStation', () => {
+  it('빈 후보면 null', () => {
+    expect(pickFusedStation([])).toBeNull();
+  });
+
+  it('arrival 신호 없으면 GPS 최근접 + gps-only', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: null },
+      { candidate: cand('chungmuro', 0.3), arrival: null },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result?.confidence).toBe('gps-only');
+    expect(result?.source).toBe('gps');
+  });
+
+  it('arvlCd=1(도착)인 후보가 있으면 GPS 최근접보다 우선', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.RUNNING) },
+      { candidate: cand('chungmuro', 0.3), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+    expect(result?.confidence).toBe('arrival-confirmed');
+    expect(result?.source).toBe('arrival');
+  });
+
+  it('arvlCd=0(진입)은 arrival-arriving 신뢰도', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ENTERING) },
+    ]);
+    expect(result?.confidence).toBe('arrival-arriving');
+    expect(result?.source).toBe('arrival');
+  });
+
+  it('1(도착) > 0(진입) 우선순위', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ENTERING) },
+      { candidate: cand('chungmuro', 0.3), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+  });
+
+  it('mock 데이터(isMock)는 신호로 사용되지 않는다', () => {
+    const mockArrival: StationArrival = { ...arrival(ARRIVAL_CODE.ARRIVED), isMock: true };
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: null },
+      { candidate: cand('chungmuro', 0.3), arrival: mockArrival },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result?.source).toBe('gps');
+  });
+
+  it('receivedAtMs=0(stale)인 신호는 무시된다', () => {
+    const stale: StationArrival = { up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: 0 })], down: [] };
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: null },
+      { candidate: cand('chungmuro', 0.3), arrival: stale },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result?.source).toBe('gps');
+  });
+
+  it('동점이면 먼저 발견된 후보 유지(첫 항목 = GPS 최근접)', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+      { candidate: cand('chungmuro', 0.3), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+    ]);
+    expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+  });
+
+  it('출발(2)/전역출발(3)/운행중(99)은 신호 점수 0', () => {
+    const result = pickFusedStation([
+      { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.DEPARTED, ARRIVAL_CODE.RUNNING) },
+    ]);
+    expect(result?.confidence).toBe('gps-only');
+    expect(result?.source).toBe('gps');
+  });
+
+  it('up/down 모두에서 최댓값을 찾는다', () => {
+    const mixed: StationArrival = {
+      up: [info(ARRIVAL_CODE.ENTERING)],
+      down: [info(ARRIVAL_CODE.ARRIVED)],
+    };
+    const result = pickFusedStation([{ candidate: cand('gangnam', 0.1), arrival: mixed }]);
+    expect(result?.confidence).toBe('arrival-confirmed');
+  });
+});

--- a/src/utils/__tests__/pickFusedStation.test.ts
+++ b/src/utils/__tests__/pickFusedStation.test.ts
@@ -114,4 +114,80 @@ describe('pickFusedStation', () => {
     const result = pickFusedStation([{ candidate: cand('gangnam', 0.1), arrival: mixed }]);
     expect(result?.confidence).toBe('arrival-confirmed');
   });
+
+  describe('position 신호 (Phase 3)', () => {
+    const train = (trainStatus: number, receivedAtMs = NOW) => ({
+      statnId: 'X',
+      statnNm: 'X',
+      trainNo: 'T',
+      trainStatus,
+      updnLine: 0,
+      terminalStationId: '',
+      terminalStationName: '',
+      trainType: 'normal' as const,
+      isLastTrain: false,
+      receivedAtMs,
+    });
+
+    it('positionMatches에 ARRIVED(1) 트레인 → arrival-confirmed + source=position', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), positionMatches: [train(1)] },
+      ]);
+      expect(result?.confidence).toBe('arrival-confirmed');
+      expect(result?.source).toBe('position');
+    });
+
+    it('positionMatches에 ENTERING(0) → arrival-arriving + source=position', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), positionMatches: [train(0)] },
+      ]);
+      expect(result?.confidence).toBe('arrival-arriving');
+      expect(result?.source).toBe('position');
+    });
+
+    it('arrival과 position 동시 ARRIVED → source=position 우선', () => {
+      const result = pickFusedStation([
+        {
+          candidate: cand('gangnam', 0.1),
+          arrival: arrival(ARRIVAL_CODE.ARRIVED),
+          positionMatches: [train(1)],
+        },
+      ]);
+      expect(result?.source).toBe('position');
+    });
+
+    it('positionMatches stale(receivedAtMs<=0)는 무시', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), positionMatches: [train(1, 0)] },
+      ]);
+      expect(result?.source).toBe('gps');
+    });
+
+    it('positionMatches 빈 배열/null → 신호 없음', () => {
+      const r1 = pickFusedStation([{ candidate: cand('gangnam', 0.1), positionMatches: [] }]);
+      const r2 = pickFusedStation([{ candidate: cand('gangnam', 0.1), positionMatches: null }]);
+      expect(r1?.source).toBe('gps');
+      expect(r2?.source).toBe('gps');
+    });
+
+    it('positionMatches에 여러 트레인 있으면 가장 강한 신호 채택', () => {
+      const result = pickFusedStation([
+        {
+          candidate: cand('gangnam', 0.1),
+          // ARRIVED → ENTERING 순서: 첫 번째 트레인이 더 강해 두 번째는 무시되는 분기 커버
+          positionMatches: [train(1), train(0)],
+        },
+      ]);
+      expect(result?.confidence).toBe('arrival-confirmed');
+    });
+
+    it('두 후보 중 position 신호가 있는 후보로 fusion 전환', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1) }, // 신호 없음
+        { candidate: cand('chungmuro', 0.3), positionMatches: [train(1)] },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+      expect(result?.source).toBe('position');
+    });
+  });
 });

--- a/src/utils/__tests__/pickFusedStation.test.ts
+++ b/src/utils/__tests__/pickFusedStation.test.ts
@@ -15,6 +15,8 @@ function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInf
     trainCode: 'T1',
     receivedAtMs: NOW,
     arrivalCode,
+    isLastTrain: false,
+    trainType: 'normal',
     ...overrides,
   };
 }

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -96,6 +96,7 @@ describe('stationNotification', () => {
     jest.clearAllMocks();
     (Notifications.setNotificationHandler as jest.Mock).mockReturnValue(undefined);
     (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
     (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
     (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('current-station');
     (Notifications.setNotificationChannelAsync as jest.Mock).mockResolvedValue(undefined);

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -44,6 +44,13 @@ jest.mock('../../../modules/live-activity', () => ({
   isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
 }));
 
+const mockSaveStationToWidget = jest.fn().mockResolvedValue(undefined);
+const mockClearWidgetStation = jest.fn().mockResolvedValue(undefined);
+jest.mock('../widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSaveStationToWidget(...args),
+  clearWidgetStation: () => mockClearWidgetStation(),
+}));
+
 const mockStation: Station = {
   id: 'si-cheong-1',
   name: '시청',
@@ -655,6 +662,36 @@ describe('stationNotification', () => {
     it('dismiss 실패해도 에러를 던지지 않는다', async () => {
       (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
       await expect(clearAlarmNotification()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('widget storage 연동', () => {
+    beforeEach(() => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      mockSaveStationToWidget.mockResolvedValue(undefined);
+      mockClearWidgetStation.mockResolvedValue(undefined);
+    });
+
+    it('updateStationNotification은 saveStationToWidget을 km 단위로 호출한다', async () => {
+      await updateStationNotification(mockStation, 250);
+      expect(mockSaveStationToWidget).toHaveBeenCalledWith(mockStation, 0.25);
+    });
+
+    it('saveStationToWidget이 실패해도 updateLiveActivity는 호출된다', async () => {
+      mockSaveStationToWidget.mockRejectedValueOnce(new Error('group missing'));
+      await updateStationNotification(mockStation, 100);
+      expect(mockUpdateLiveActivity).toHaveBeenCalled();
+    });
+
+    it('clearStationNotification은 clearWidgetStation을 호출한다', async () => {
+      await clearStationNotification();
+      expect(mockClearWidgetStation).toHaveBeenCalled();
+    });
+
+    it('clearWidgetStation이 실패해도 endLiveActivity는 호출된다', async () => {
+      mockClearWidgetStation.mockRejectedValueOnce(new Error('group missing'));
+      await clearStationNotification();
+      expect(mockEndLiveActivity).toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -13,6 +13,9 @@ import { Station } from '../../types/station';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 
 jest.mock('expo-notifications');
+jest.mock('../bgDiagnostics', () => ({
+  incrementBgDiagnostic: jest.fn(),
+}));
 jest.mock('../logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -567,6 +570,13 @@ describe('stationNotification', () => {
         content: { title: '하차 알림', body: '다음 역 강남에서 내리세요!', sound: false, channelId: 'station-alarm-silent', priority: 'max' },
         trigger: null,
       });
+    });
+
+    it('#275 진단: 권한이 granted가 아니면 알림은 스케줄하되 진단 카운터를 알 수 있다', async () => {
+      (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValueOnce({ status: 'denied' });
+      await sendAlarmNotification(earlyDest);
+      // 권한 거부여도 호출은 시도 (silent fail은 OS 단에서 발생)
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
     });
   });
 

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -32,6 +32,11 @@ jest.mock('../alarmSound', () => ({
   stopVibration: () => mockStopVibration(),
 }));
 
+const mockSpeakAlarm = jest.fn();
+jest.mock('../tts', () => ({
+  speakAlarm: (...args: unknown[]) => mockSpeakAlarm(...args),
+}));
+
 const mockStartLiveActivity = jest.fn().mockResolvedValue(undefined);
 const mockUpdateLiveActivity = jest.fn().mockResolvedValue(undefined);
 const mockEndLiveActivity = jest.fn().mockResolvedValue(undefined);
@@ -577,6 +582,24 @@ describe('stationNotification', () => {
       await sendAlarmNotification(earlyDest);
       // 권한 거부여도 호출은 시도 (silent fail은 OS 단에서 발생)
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    });
+
+    it('TTS는 알람 body를 sleepMode/allowSpeaker와 함께 호출한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest, false, true);
+      expect(mockSpeakAlarm).toHaveBeenCalledWith('다음 역 강남에서 내리세요!', {
+        sleepMode: false,
+        allowSpeaker: true,
+      });
+    });
+
+    it('TTS는 silent 게이트(sleepMode/allowSpeaker)를 그대로 전달한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest, true, false);
+      expect(mockSpeakAlarm).toHaveBeenCalledWith('다음 역 강남에서 내리세요!', {
+        sleepMode: true,
+        allowSpeaker: false,
+      });
     });
   });
 

--- a/src/utils/__tests__/tts.test.ts
+++ b/src/utils/__tests__/tts.test.ts
@@ -4,6 +4,7 @@ import { speakAlarm } from '../tts';
 
 jest.mock('expo-speech', () => ({
   speak: jest.fn(),
+  stop: jest.fn(),
 }));
 
 jest.mock('i18next', () => ({
@@ -22,10 +23,12 @@ jest.mock('../logger', () => ({
 
 describe('speakAlarm', () => {
   const mockSpeak = Speech.speak as jest.Mock;
+  const mockStop = Speech.stop as jest.Mock;
   const i18n = i18next as unknown as { language: string };
 
   beforeEach(() => {
     mockSpeak.mockReset();
+    mockStop.mockReset();
     i18n.language = 'ko';
   });
 
@@ -65,5 +68,20 @@ describe('speakAlarm', () => {
       throw new Error('tts engine failed');
     });
     expect(() => speakAlarm('x', { sleepMode: false, allowSpeaker: true })).not.toThrow();
+  });
+
+  it('발화 직전 이전 발화를 중단해 최신 알람만 남긴다', () => {
+    speakAlarm('first', { sleepMode: false, allowSpeaker: true });
+    speakAlarm('second', { sleepMode: false, allowSpeaker: true });
+    expect(mockStop).toHaveBeenCalledTimes(2);
+    const stopOrder = mockStop.mock.invocationCallOrder[1];
+    const speakOrder = mockSpeak.mock.invocationCallOrder[1];
+    expect(stopOrder).toBeLessThan(speakOrder);
+  });
+
+  it('silent 게이트일 때는 stop도 호출하지 않는다', () => {
+    speakAlarm('x', { sleepMode: true, allowSpeaker: true });
+    speakAlarm('x', { sleepMode: false, allowSpeaker: false });
+    expect(mockStop).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/__tests__/tts.test.ts
+++ b/src/utils/__tests__/tts.test.ts
@@ -1,0 +1,69 @@
+import * as Speech from 'expo-speech';
+import i18next from 'i18next';
+import { speakAlarm } from '../tts';
+
+jest.mock('expo-speech', () => ({
+  speak: jest.fn(),
+}));
+
+jest.mock('i18next', () => ({
+  __esModule: true,
+  default: { language: 'ko' },
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe('speakAlarm', () => {
+  const mockSpeak = Speech.speak as jest.Mock;
+  const i18n = i18next as unknown as { language: string };
+
+  beforeEach(() => {
+    mockSpeak.mockReset();
+    i18n.language = 'ko';
+  });
+
+  it('허용 조건이면 i18n.language에 매핑된 locale로 발화한다', () => {
+    speakAlarm('테스트', { sleepMode: false, allowSpeaker: true });
+    expect(mockSpeak).toHaveBeenCalledWith('테스트', { language: 'ko-KR' });
+  });
+
+  it.each([
+    ['en', 'en-US'],
+    ['ja', 'ja-JP'],
+    ['zh', 'zh-CN'],
+  ])('language=%s이면 locale=%s로 발화한다', (lang, locale) => {
+    i18n.language = lang;
+    speakAlarm('x', { sleepMode: false, allowSpeaker: true });
+    expect(mockSpeak).toHaveBeenCalledWith('x', { language: locale });
+  });
+
+  it('알 수 없는 language는 en-US로 폴백한다', () => {
+    i18n.language = 'fr';
+    speakAlarm('x', { sleepMode: false, allowSpeaker: true });
+    expect(mockSpeak).toHaveBeenCalledWith('x', { language: 'en-US' });
+  });
+
+  it('sleepMode이면 발화하지 않는다', () => {
+    speakAlarm('x', { sleepMode: true, allowSpeaker: true });
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('allowSpeaker=false이면 발화하지 않는다', () => {
+    speakAlarm('x', { sleepMode: false, allowSpeaker: false });
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('Speech.speak가 throw해도 예외를 삼킨다', () => {
+    mockSpeak.mockImplementationOnce(() => {
+      throw new Error('tts engine failed');
+    });
+    expect(() => speakAlarm('x', { sleepMode: false, allowSpeaker: true })).not.toThrow();
+  });
+});

--- a/src/utils/__tests__/widgetStorage.test.ts
+++ b/src/utils/__tests__/widgetStorage.test.ts
@@ -1,0 +1,82 @@
+import { Platform } from 'react-native';
+import { saveStationToWidget, clearWidgetStation } from '../widgetStorage';
+import { Station } from '../../types/station';
+
+const mockSave = jest.fn().mockResolvedValue(undefined);
+const mockClear = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../modules/live-activity', () => ({
+  saveWidgetStation: (...args: unknown[]) => mockSave(...args),
+  clearWidgetStation: () => mockClear(),
+}));
+
+const station: Station = {
+  id: '2-001',
+  name: '강남',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+describe('widgetStorage (native)', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    // 모듈 스코프 dedupe 캐시 리셋
+    await clearWidgetStation();
+    mockClear.mockClear();
+  });
+
+  describe('saveStationToWidget', () => {
+    it('iOS에서 station 정보와 m 단위 거리로 native 함수를 호출한다', async () => {
+      await saveStationToWidget(station, 0.123);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 123);
+    });
+
+    it('음수 거리는 0으로 보정된다', async () => {
+      await saveStationToWidget(station, -0.5);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 0);
+    });
+
+    it('iOS가 아니면 native 호출 없이 종료된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await saveStationToWidget(station, 0.1);
+      expect(mockSave).not.toHaveBeenCalled();
+    });
+
+    it('같은 역에 대해 연속 호출하면 한 번만 native에 전달된다', async () => {
+      await saveStationToWidget(station, 0.1);
+      await saveStationToWidget(station, 0.2);
+      await saveStationToWidget(station, 0.3);
+      expect(mockSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('역이 바뀌면 다시 native에 전달된다', async () => {
+      const other: Station = { ...station, id: '2-002', name: '역삼' };
+      await saveStationToWidget(station, 0.1);
+      await saveStationToWidget(other, 0.2);
+      expect(mockSave).toHaveBeenCalledTimes(2);
+    });
+
+    it('clearWidgetStation 이후엔 같은 역도 다시 전달된다', async () => {
+      await saveStationToWidget(station, 0.1);
+      await clearWidgetStation();
+      await saveStationToWidget(station, 0.2);
+      expect(mockSave).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('clearWidgetStation', () => {
+    it('iOS에서 native clear를 호출한다', async () => {
+      await clearWidgetStation();
+      expect(mockClear).toHaveBeenCalled();
+    });
+
+    it('iOS가 아니면 native 호출 없이 종료된다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await clearWidgetStation();
+      expect(mockClear).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/bgDiagnostics.ts
+++ b/src/utils/bgDiagnostics.ts
@@ -3,30 +3,26 @@ import { BG_DIAGNOSTICS_KEY } from '../constants/storageKeys';
 import { createLogger } from './logger';
 
 // #275 진단 카운터. Console.app 접근 없이 앱 내에서 BG 동작 격리를 위해 사용.
-// 카운터 키는 closed union으로 고정해 오타로 인한 noise 카운터가 생기지 않게 한다.
-export type BgDiagnosticCounter =
-  | 'taskFired'
-  | 'pipelineEnter'
-  | 'pipelineExitNoDestination'
-  | 'gateAge'
-  | 'gateAccuracy'
-  | 'alarmEnter'
-  | 'alarmPermDenied'
-  | 'stationPassedEnter';
+// 카운터 키 + 사용자 노출 라벨을 한 곳에 두어 추가/제거 시 단일 지점만 갱신.
+export const BG_DIAGNOSTIC_ROWS = [
+  { key: 'taskFired', label: 'TASK FIRED' },
+  { key: 'gateAge', label: '게이트 컷 (오래된 좌표)' },
+  { key: 'gateAccuracy', label: '게이트 컷 (저정확도)' },
+  { key: 'pipelineEnter', label: 'PIPELINE ENTER' },
+  { key: 'pipelineExitNoDestination', label: 'PIPELINE EXIT (목적지 없음)' },
+  { key: 'alarmEnter', label: 'ALARM ENTER' },
+  { key: 'alarmPermDenied', label: 'ALARM 권한 거부 관찰' },
+  { key: 'stationPassedEnter', label: 'STATION PASSED ENTER' },
+] as const;
+
+export type BgDiagnosticCounter = (typeof BG_DIAGNOSTIC_ROWS)[number]['key'];
 
 export type BgDiagnostics = Record<BgDiagnosticCounter, number> & { lastTaskFiredTs: number | null };
 
 const EMPTY: BgDiagnostics = {
-  taskFired: 0,
-  pipelineEnter: 0,
-  pipelineExitNoDestination: 0,
-  gateAge: 0,
-  gateAccuracy: 0,
-  alarmEnter: 0,
-  alarmPermDenied: 0,
-  stationPassedEnter: 0,
+  ...Object.fromEntries(BG_DIAGNOSTIC_ROWS.map(({ key }) => [key, 0])),
   lastTaskFiredTs: null,
-};
+} as BgDiagnostics;
 
 const logger = createLogger('BgDiagnostics');
 

--- a/src/utils/bgDiagnostics.ts
+++ b/src/utils/bgDiagnostics.ts
@@ -1,0 +1,81 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { BG_DIAGNOSTICS_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+
+// #275 진단 카운터. Console.app 접근 없이 앱 내에서 BG 동작 격리를 위해 사용.
+// 카운터 키는 closed union으로 고정해 오타로 인한 noise 카운터가 생기지 않게 한다.
+export type BgDiagnosticCounter =
+  | 'taskFired'
+  | 'pipelineEnter'
+  | 'pipelineExitNoDestination'
+  | 'gateAge'
+  | 'gateAccuracy'
+  | 'alarmEnter'
+  | 'alarmPermDenied'
+  | 'stationPassedEnter';
+
+export type BgDiagnostics = Record<BgDiagnosticCounter, number> & { lastTaskFiredTs: number | null };
+
+const EMPTY: BgDiagnostics = {
+  taskFired: 0,
+  pipelineEnter: 0,
+  pipelineExitNoDestination: 0,
+  gateAge: 0,
+  gateAccuracy: 0,
+  alarmEnter: 0,
+  alarmPermDenied: 0,
+  stationPassedEnter: 0,
+  lastTaskFiredTs: null,
+};
+
+const logger = createLogger('BgDiagnostics');
+
+// fire-and-forget. 적재 실패가 후속 동작에 영향을 주면 안 됨.
+export function incrementBgDiagnostic(counter: BgDiagnosticCounter, options?: { stampTaskFired?: boolean }): void {
+  void mutate((current) => {
+    const next = { ...current, [counter]: current[counter] + 1 };
+    if (options?.stampTaskFired) {
+      next.lastTaskFiredTs = Date.now();
+    }
+    return next;
+  });
+}
+
+export async function getBgDiagnostics(): Promise<BgDiagnostics> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_DIAGNOSTICS_KEY);
+    if (!raw) return { ...EMPTY };
+    const parsed = JSON.parse(raw);
+    return { ...EMPTY, ...parsed };
+  } catch (e) {
+    logger.error('진단 카운터 읽기 실패:', e);
+    return { ...EMPTY };
+  }
+}
+
+export async function clearBgDiagnostics(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(BG_DIAGNOSTICS_KEY);
+  } catch (e) {
+    logger.error('진단 카운터 초기화 실패:', e);
+  }
+}
+
+// 같은 task wake에서 연속 호출 시 read-modify-write race로 ±1 손실이 생기지
+// 않도록 인메모리 promise 체인으로 직렬화한다. 진단 데이터의 정확도가
+// 판독 결론에 직결되므로 이 보장이 필요.
+let mutateQueue: Promise<void> = Promise.resolve();
+
+async function mutate(updater: (current: BgDiagnostics) => BgDiagnostics): Promise<void> {
+  const next = mutateQueue.then(async () => {
+    try {
+      const current = await getBgDiagnostics();
+      const updated = updater(current);
+      await AsyncStorage.setItem(BG_DIAGNOSTICS_KEY, JSON.stringify(updated));
+    } catch (e) {
+      logger.error('진단 카운터 적재 실패:', e);
+    }
+  });
+  mutateQueue = next;
+  await next;
+}

--- a/src/utils/findActiveLines.ts
+++ b/src/utils/findActiveLines.ts
@@ -1,0 +1,20 @@
+import type { NearestStationResult } from '../types/station';
+import type { LineNumber } from '../types/station';
+
+/**
+ * fusion 후보 역들에서 호선만 dedup해 추출. realtimePosition은 호선 단위 호출이라
+ * 같은 호선의 후보가 여러 개여도 1번만 폴링하면 됨.
+ *
+ * 입력 순서(거리 가까운 → 먼)를 보존해 활성 호선 우선순위가 자연스럽게 GPS 거리로 정렬됨.
+ */
+export function findActiveLines(candidates: NearestStationResult[]): LineNumber[] {
+  const seen = new Set<LineNumber>();
+  const out: LineNumber[] = [];
+  for (const c of candidates) {
+    const line = c.station.line;
+    if (seen.has(line)) continue;
+    seen.add(line);
+    out.push(line);
+  }
+  return out;
+}

--- a/src/utils/findNearestStation.ts
+++ b/src/utils/findNearestStation.ts
@@ -42,3 +42,30 @@ export function findNearestStations(
     isTransfer: variants.length > 1,
   };
 }
+
+/**
+ * 사용자 좌표 기준 거리순 상위 N개 역(이름 중복 제거 — 환승역은 한 번만).
+ * fusion 후보 추출에 사용. 거리 기준이지 노선 기준이 아니다.
+ */
+export function findTopNearestStations(
+  lat: number,
+  lng: number,
+  limit: number,
+  maxDistanceKm?: number,
+): NearestStationResult[] {
+  if (limit <= 0) return [];
+  const ranked = stations
+    .map((s) => ({ station: s, distanceKm: haversine(lat, lng, s.lat, s.lng) }))
+    .filter((r) => maxDistanceKm == null || r.distanceKm <= maxDistanceKm)
+    .sort((a, b) => a.distanceKm - b.distanceKm);
+
+  const seen = new Set<string>();
+  const out: NearestStationResult[] = [];
+  for (const r of ranked) {
+    if (seen.has(r.station.name)) continue;
+    seen.add(r.station.name);
+    out.push(r);
+    if (out.length >= limit) break;
+  }
+  return out;
+}

--- a/src/utils/findTrainCoordinates.ts
+++ b/src/utils/findTrainCoordinates.ts
@@ -1,4 +1,5 @@
 import type { LinePositions, TrainPosition } from '../api/positionApi';
+import { getMarkerOffset } from '../constants/trainMarkerOffset';
 import type { LineNumber, Station } from '../types/station';
 
 /** 지도 마커로 표시할 열차 정보 — TrainPosition + 좌표 + lineColor. */
@@ -62,12 +63,13 @@ export function findTrainCoordinates(
 }
 
 function toMarker(t: TrainPosition, s: Station): TrainMarker {
+  const { dLat, dLng } = getMarkerOffset(t.updnLine);
   return {
     trainNo: t.trainNo,
     line: s.line,
     lineColor: s.lineColor,
-    lat: s.lat,
-    lng: s.lng,
+    lat: s.lat + dLat,
+    lng: s.lng + dLng,
     statnNm: t.statnNm,
     trainStatus: t.trainStatus,
     updnLine: t.updnLine,

--- a/src/utils/findTrainCoordinates.ts
+++ b/src/utils/findTrainCoordinates.ts
@@ -1,0 +1,76 @@
+import type { LinePositions, TrainPosition } from '../api/positionApi';
+import type { LineNumber, Station } from '../types/station';
+
+/** 지도 마커로 표시할 열차 정보 — TrainPosition + 좌표 + lineColor. */
+export interface TrainMarker {
+  trainNo: string;
+  line: LineNumber;
+  lineColor: string;
+  /** 매칭된 역의 좌표(역 위치에 마커 표시 — 열차가 그 역에 있다는 의미). */
+  lat: number;
+  lng: number;
+  statnNm: string;
+  /** trainSttus: 0:진입, 1:도착, 2:출발, 3:전역출발 */
+  trainStatus: number;
+  updnLine: number;
+  terminalStationName: string;
+}
+
+/**
+ * (line, name) → Station 빠른 조회 인덱스. stations 배열은 빌드 타임 고정이므로
+ * 호출자가 한 번 만들어 캐시 후 findTrainCoordinates에 주입한다(매 폴링마다 528개 재빌드 방지).
+ */
+export type StationIndex = Map<LineNumber, Map<string, Station>>;
+
+export function buildStationIndex(stations: Station[]): StationIndex {
+  const indexByLine: StationIndex = new Map();
+  for (const s of stations) {
+    let lineIdx = indexByLine.get(s.line);
+    if (!lineIdx) {
+      lineIdx = new Map();
+      indexByLine.set(s.line, lineIdx);
+    }
+    if (!lineIdx.has(s.name)) lineIdx.set(s.name, s);
+  }
+  return indexByLine;
+}
+
+/**
+ * LinePositions의 각 train을 stations 좌표로 매핑한다.
+ * 매칭 키: `(line, statnNm)` — Phase 3 Stage 1+2 fusion과 같은 정책.
+ *
+ * 매칭 실패(역명 미상)인 트레인은 제외 — 좌표 없이 마커를 그릴 수 없음.
+ * stale(receivedAtMs<=0) 트레인도 제외 — fusion 정책 일관.
+ */
+export function findTrainCoordinates(
+  positions: (LinePositions | null)[],
+  index: StationIndex,
+): TrainMarker[] {
+  const out: TrainMarker[] = [];
+  for (const lp of positions) {
+    if (!lp || lp.isMock) continue;
+    const lineIdx = index.get(lp.line);
+    if (!lineIdx) continue;
+    for (const t of lp.trains) {
+      if (t.receivedAtMs <= 0) continue;
+      const station = lineIdx.get(t.statnNm);
+      if (!station) continue;
+      out.push(toMarker(t, station));
+    }
+  }
+  return out;
+}
+
+function toMarker(t: TrainPosition, s: Station): TrainMarker {
+  return {
+    trainNo: t.trainNo,
+    line: s.line,
+    lineColor: s.lineColor,
+    lat: s.lat,
+    lng: s.lng,
+    statnNm: t.statnNm,
+    trainStatus: t.trainStatus,
+    updnLine: t.updnLine,
+    terminalStationName: t.terminalStationName,
+  };
+}

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -21,6 +21,12 @@ export interface ArrivalTrain {
   line: string;
   arrivalAtMs: number;
   subtext?: string;
+  /** 막차 여부 — UI 안전성 배지. */
+  isLastTrain?: boolean;
+  /** 열차 타입 — 'normal'은 배지 미표시. */
+  trainType?: import('../constants/trainTypes').TrainType;
+  /** arvlCd — 0:진입, 1:도착, 2:출발 등. UI 진입/도착 배지용. */
+  arrivalCode?: number;
 }
 
 export interface HandoffNearest {
@@ -98,6 +104,9 @@ export function arrivalInfoToArrivalTrain(
     line,
     arrivalAtMs: now + item.arrivalSeconds * 1000,
     subtext: item.statusMessage || undefined,
+    isLastTrain: item.isLastTrain,
+    trainType: item.trainType,
+    arrivalCode: item.arrivalCode,
   }));
 }
 

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -60,13 +60,23 @@ export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
         note: i18next.t('journey.transferNote'),
       });
     } else {
-      stops.push({
-        station: getStationDisplayNameByName(seg.toName, allStations),
-        line: seg.line,
-        stopsFromPrev: i18next.t('route.stops', { count: seg.stops }),
-        mark: 'dest',
-        note: i18next.t('journey.arrivalNote'),
-      });
+      // 환승역이 곧 목적지인 케이스(0정거장 도착 노드 잉여)는 직전 환승 노드를 도착으로 흡수.
+      // 언어 독립성을 위해 표시명이 아닌 원본 역명(toName)으로 비교한다.
+      // stopsFromPrev는 환승 노드의 기존 값(직전 segment의 정거장 수)을 그대로 유지.
+      const prevSeg = segments[i - 1];
+      const prev = stops[stops.length - 1];
+      if (seg.stops === 0 && prev?.mark === 'transfer' && prevSeg?.toName === seg.toName) {
+        prev.mark = 'dest';
+        prev.note = i18next.t('journey.transferArrivalNote');
+      } else {
+        stops.push({
+          station: getStationDisplayNameByName(seg.toName, allStations),
+          line: seg.line,
+          stopsFromPrev: i18next.t('route.stops', { count: seg.stops }),
+          mark: 'dest',
+          note: i18next.t('journey.arrivalNote'),
+        });
+      }
     }
   }
 

--- a/src/utils/locationGates.ts
+++ b/src/utils/locationGates.ts
@@ -1,4 +1,4 @@
-import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../constants/location';
+import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../constants/location';
 
 export function isLocationFresh(timestamp: number | undefined): boolean {
   // expo-location 타입상 timestamp는 non-nullable이지만, 네이티브 deferred batch에서
@@ -9,4 +9,8 @@ export function isLocationFresh(timestamp: number | undefined): boolean {
 
 export function isAccuracyAcceptable(accuracy: number | null | undefined): boolean {
   return accuracy == null || accuracy <= MAX_ACCURACY_M;
+}
+
+export function isAccuracyAcceptableForDisplay(accuracy: number | null | undefined): boolean {
+  return accuracy == null || accuracy <= MAX_ACCURACY_M_DISPLAY;
 }

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -1,28 +1,41 @@
 import type { NearestStationResult } from '../types/station';
 import type { StationArrival } from '../api/arrivalApi';
+import type { LinePositions } from '../api/positionApi';
 import { getArrivalPriority } from '../constants/arrivalCodes';
+import { getTrainStatusPriority } from '../constants/trainStatus';
 
 /**
- * fusion 결과 신뢰도 — UI/로깅용. arrival 신호로 확정/추정된 경우 GPS-only보다 신선.
+ * fusion 결과 신뢰도 — UI/로깅용. 점수 ≥ 100이면 confirmed, 0 < x < 100이면 arriving.
+ * 신호원(arrival/position)은 source 필드로 분리 식별.
  */
 export type FusionConfidence = 'arrival-confirmed' | 'arrival-arriving' | 'gps-only';
+
+/**
+ * fusion 신호 출처. position이 가장 정확(실제 좌표), arrival은 추정(곧 도착),
+ * gps는 거리 기반. 알람 dedup·로깅에서 source별 정책 분기에 사용.
+ */
+export type FusionSource = 'position' | 'arrival' | 'gps';
 
 export interface FusedStationResult {
   result: NearestStationResult;
   confidence: FusionConfidence;
-  source: 'arrival' | 'gps';
+  source: FusionSource;
 }
 
-interface CandidateArrival {
+export interface FusionCandidate {
   candidate: NearestStationResult;
-  arrival: StationArrival | null;
+  /** 도착정보 신호 (Phase 2). null이면 신호 없음. */
+  arrival?: StationArrival | null;
+  /**
+   * 위치정보 신호 (Phase 3). 후보 역의 호선에 해당하는 LinePositions 중
+   * 후보 역(statnId)에 머무는 열차들. 호출자가 후보별로 매칭해 전달한다.
+   * null이면 신호 없음(미호출/실패/mock).
+   */
+  positionMatches?: LinePositions['trains'] | null;
 }
 
-/**
- * recptnDt 보정 거친 신호 중 가장 강한 priority 점수를 반환.
- * mock/누락(receivedAtMs=0) 신호는 무시 — Stage 1에서 stale로 강등됨.
- */
-function bestPriorityForArrival(arrival: StationArrival | null): number {
+/** mock/stale 무시 + arvlCd 우선순위 최댓값. */
+function bestPriorityForArrival(arrival: StationArrival | null | undefined): number {
   if (!arrival || arrival.isMock) return 0;
   let best = 0;
   for (const list of [arrival.up, arrival.down]) {
@@ -35,46 +48,78 @@ function bestPriorityForArrival(arrival: StationArrival | null): number {
   return best;
 }
 
-function confidenceFromPriority(priority: number): FusionConfidence {
-  if (priority >= 100) return 'arrival-confirmed'; // arvlCd=1 도착
-  if (priority > 0) return 'arrival-arriving';
-  return 'gps-only';
+/** stale(receivedAtMs<=0) 무시 + trainSttus 우선순위 최댓값. */
+function bestPriorityForPosition(
+  trains: LinePositions['trains'] | null | undefined,
+): number {
+  if (!trains || trains.length === 0) return 0;
+  let best = 0;
+  for (const t of trains) {
+    if (t.receivedAtMs <= 0) continue;
+    const p = getTrainStatusPriority(t.trainStatus);
+    if (p > best) best = p;
+  }
+  return best;
 }
 
 /**
- * 후보 역들의 arrival 신호로 fusion한 현재역을 결정한다.
+ * priority > 0 케이스만 호출됨 — gps-only(=priority 0)는 호출자가 early-return으로 처리.
+ * 100점 이상은 ARRIVED(도착 확정) 신호, 그외는 진입/전역 신호로 분류.
+ */
+function confidenceFromPriority(priority: number): FusionConfidence {
+  return priority >= 100 ? 'arrival-confirmed' : 'arrival-arriving';
+}
+
+/**
+ * 후보 역들의 신호(arrival + position)로 fusion한 현재역을 결정한다.
  *
- * 입력 계약: candidates는 거리 오름차순 — `[0]`이 GPS 최근접이어야 함.
- *  (동점 시 거리 가까운 쪽이 자동 선택되도록 순회 순서로 invariant 유지)
+ * 입력 계약: candidates는 거리 오름차순 — `[0]`이 GPS 최근접.
  *
  * 규칙:
- * 1) priority 점수 최댓값을 가진 후보 선택 (arvlCd 1 > 0 > 5 > 4)
- * 2) 동점이면 더 먼저 들어온(=거리 가까운) 후보 유지
- * 3) 모두 0이면 GPS 최근접(=candidates[0]) 사용
- * 4) 후보가 비어있으면 null 반환 — 호출자가 GPS-only 분기로 fallback
+ * 1) 각 후보의 점수 = max(arrival 점수, position 점수). 두 신호원이 같은 priority enum 사용.
+ * 2) 점수 최댓값 후보 선택. 동점이면 거리 가까운(=먼저 들어온) 후보 유지.
+ * 3) source 분류: position 점수 > 0 우선(가장 정확) > arrival 점수 > 0 > GPS.
+ *    같은 점수라도 신호원이 다르면 정확도 순(position > arrival)으로 source 라벨 결정.
+ * 4) 모두 0이면 GPS 최근접 사용.
+ * 5) 후보가 비어있으면 null.
  */
 export function pickFusedStation(
-  candidates: CandidateArrival[],
+  candidates: FusionCandidate[],
 ): FusedStationResult | null {
   if (candidates.length === 0) return null;
 
-  let winner = candidates[0];
-  let winnerPriority = bestPriorityForArrival(winner.arrival);
-
-  for (let i = 1; i < candidates.length; i++) {
-    const p = bestPriorityForArrival(candidates[i].arrival);
+  let winnerIdx = 0;
+  let winnerPriority = -1;
+  let winnerArrScore = 0;
+  let winnerPosScore = 0;
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i];
+    const arrScore = bestPriorityForArrival(c.arrival);
+    const posScore = bestPriorityForPosition(c.positionMatches);
+    const p = Math.max(arrScore, posScore);
     if (p > winnerPriority) {
-      winner = candidates[i];
+      winnerIdx = i;
       winnerPriority = p;
+      winnerArrScore = arrScore;
+      winnerPosScore = posScore;
     }
   }
 
-  const source = winnerPriority > 0 ? 'arrival' : 'gps';
-  // arrival 신호가 없으면 GPS 최근접(=candidates[0])이 정답.
-  const finalResult = source === 'arrival' ? winner.candidate : candidates[0].candidate;
+  if (winnerPriority <= 0) {
+    return {
+      result: candidates[0].candidate,
+      confidence: 'gps-only',
+      source: 'gps',
+    };
+  }
+
+  // source 라벨은 winning priority에 실제로 기여한 신호원.
+  // 두 신호원이 같은 점수로 동점이면 정확도 우선(position) — UI/로깅에서 더 신뢰 표시.
+  const source: FusionSource =
+    winnerPosScore >= winnerArrScore ? 'position' : 'arrival';
 
   return {
-    result: finalResult,
+    result: candidates[winnerIdx].candidate,
     confidence: confidenceFromPriority(winnerPriority),
     source,
   };

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -1,0 +1,81 @@
+import type { NearestStationResult } from '../types/station';
+import type { StationArrival } from '../api/arrivalApi';
+import { getArrivalPriority } from '../constants/arrivalCodes';
+
+/**
+ * fusion 결과 신뢰도 — UI/로깅용. arrival 신호로 확정/추정된 경우 GPS-only보다 신선.
+ */
+export type FusionConfidence = 'arrival-confirmed' | 'arrival-arriving' | 'gps-only';
+
+export interface FusedStationResult {
+  result: NearestStationResult;
+  confidence: FusionConfidence;
+  source: 'arrival' | 'gps';
+}
+
+interface CandidateArrival {
+  candidate: NearestStationResult;
+  arrival: StationArrival | null;
+}
+
+/**
+ * recptnDt 보정 거친 신호 중 가장 강한 priority 점수를 반환.
+ * mock/누락(receivedAtMs=0) 신호는 무시 — Stage 1에서 stale로 강등됨.
+ */
+function bestPriorityForArrival(arrival: StationArrival | null): number {
+  if (!arrival || arrival.isMock) return 0;
+  let best = 0;
+  for (const list of [arrival.up, arrival.down]) {
+    for (const info of list) {
+      if (info.receivedAtMs <= 0) continue;
+      const p = getArrivalPriority(info.arrivalCode);
+      if (p > best) best = p;
+    }
+  }
+  return best;
+}
+
+function confidenceFromPriority(priority: number): FusionConfidence {
+  if (priority >= 100) return 'arrival-confirmed'; // arvlCd=1 도착
+  if (priority > 0) return 'arrival-arriving';
+  return 'gps-only';
+}
+
+/**
+ * 후보 역들의 arrival 신호로 fusion한 현재역을 결정한다.
+ *
+ * 입력 계약: candidates는 거리 오름차순 — `[0]`이 GPS 최근접이어야 함.
+ *  (동점 시 거리 가까운 쪽이 자동 선택되도록 순회 순서로 invariant 유지)
+ *
+ * 규칙:
+ * 1) priority 점수 최댓값을 가진 후보 선택 (arvlCd 1 > 0 > 5 > 4)
+ * 2) 동점이면 더 먼저 들어온(=거리 가까운) 후보 유지
+ * 3) 모두 0이면 GPS 최근접(=candidates[0]) 사용
+ * 4) 후보가 비어있으면 null 반환 — 호출자가 GPS-only 분기로 fallback
+ */
+export function pickFusedStation(
+  candidates: CandidateArrival[],
+): FusedStationResult | null {
+  if (candidates.length === 0) return null;
+
+  let winner = candidates[0];
+  let winnerPriority = bestPriorityForArrival(winner.arrival);
+
+  for (let i = 1; i < candidates.length; i++) {
+    const p = bestPriorityForArrival(candidates[i].arrival);
+    if (p > winnerPriority) {
+      winner = candidates[i];
+      winnerPriority = p;
+    }
+  }
+
+  const source = winnerPriority > 0 ? 'arrival' : 'gps';
+  // arrival 신호가 없으면 GPS 최근접(=candidates[0])이 정답.
+  const finalResult = source === 'arrival' ? winner.candidate : candidates[0].candidate;
+
+  return {
+    result: finalResult,
+    confidence: confidenceFromPriority(winnerPriority),
+    source,
+  };
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -8,6 +8,7 @@ import type { AlarmEvent } from './stationAlarm';
 import type { NextTarget } from './stationPipeline';
 import * as LiveActivity from 'live-activity';
 import { vibrateAlarm, stopVibration } from './alarmSound';
+import { speakAlarm } from './tts';
 import { createLogger } from './logger';
 import { incrementBgDiagnostic } from './bgDiagnostics';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
@@ -421,6 +422,7 @@ export async function sendAlarmNotification(
     ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
   });
   vibrateAlarm(sleepMode);
+  speakAlarm(body, { sleepMode, allowSpeaker });
   notifLogger.info('알람 알림:', title, body);
 }
 

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -11,6 +11,7 @@ import { vibrateAlarm, stopVibration } from './alarmSound';
 import { createLogger } from './logger';
 import { incrementBgDiagnostic } from './bgDiagnostics';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
+import { saveStationToWidget, clearWidgetStation } from './widgetStorage';
 import stationsData from '../data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -274,6 +275,10 @@ export async function updateStationNotification(
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
 
+  await saveStationToWidget(currentStation, distanceM / 1000).catch((e) =>
+    notifLogger.error('위젯 저장 실패:', e),
+  );
+
   if (Platform.OS === 'ios') {
     const liveActivityEnabled = LiveActivity.isLiveActivityEnabled();
     liveActivityLogger.info('isLiveActivityEnabled:', liveActivityEnabled);
@@ -311,6 +316,9 @@ async function dismissStationPassedNotification(): Promise<void> {
 }
 
 export async function clearStationNotification(): Promise<void> {
+  await clearWidgetStation().catch((e) =>
+    notifLogger.error('위젯 해제 실패:', e),
+  );
   if (Platform.OS === 'ios') {
     if (!LiveActivity.isLiveActivityEnabled()) {
       notifLogger.info('알림 해제 (Live Activity 비활성)');

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -9,6 +9,7 @@ import type { NextTarget } from './stationPipeline';
 import * as LiveActivity from 'live-activity';
 import { vibrateAlarm, stopVibration } from './alarmSound';
 import { createLogger } from './logger';
+import { incrementBgDiagnostic } from './bgDiagnostics';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
 import stationsData from '../data/stations.json';
 
@@ -340,6 +341,7 @@ export async function sendStationPassedNotification(
   // #275 진단: 함수 진입 자체를 기록. 트레일 로그(역 통과 알림:...)와 함께
   // 페어로 보면 scheduleNotification 단계에서 멈췄는지 분리 가능.
   notifLogger.info('STATION PASSED ENTER', stationName);
+  incrementBgDiagnostic('stationPassedEnter');
   // 사용자 노출 텍스트이므로 현재 언어로 변환. caller는 한글 역명을 그대로 전달.
   const displayStation = getStationDisplayNameByName(stationName, allStations);
   const displayDestination = getStationDisplayNameByName(destinationName, allStations);
@@ -401,6 +403,10 @@ export async function sendAlarmNotification(
   // OS 단 차단 가설(C)을 트레일 로그와 함께 격리.
   const perms = await Notifications.getPermissionsAsync();
   notifLogger.info('ALARM ENTER', event.phaseId, event.type, 'perm:', perms.status);
+  incrementBgDiagnostic('alarmEnter');
+  if (perms.status !== 'granted') {
+    incrementBgDiagnostic('alarmPermDenied');
+  }
   const { title, body } = buildAlarmContent(event);
 
   await scheduleNotification(ALARM_NOTIFICATION_ID, {

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -337,6 +337,9 @@ export async function sendStationPassedNotification(
   destinationName: string,
   target: NextTarget | null,
 ): Promise<void> {
+  // #275 진단: 함수 진입 자체를 기록. 트레일 로그(역 통과 알림:...)와 함께
+  // 페어로 보면 scheduleNotification 단계에서 멈췄는지 분리 가능.
+  notifLogger.info('STATION PASSED ENTER', stationName);
   // 사용자 노출 텍스트이므로 현재 언어로 변환. caller는 한글 역명을 그대로 전달.
   const displayStation = getStationDisplayNameByName(stationName, allStations);
   const displayDestination = getStationDisplayNameByName(destinationName, allStations);
@@ -394,6 +397,10 @@ export async function sendAlarmNotification(
   sleepMode: boolean = false,
   allowSpeaker: boolean = true,
 ): Promise<void> {
+  // #275 진단: 함수 진입 시점 기록. 권한 스냅샷 동반 기록으로
+  // OS 단 차단 가설(C)을 트레일 로그와 함께 격리.
+  const perms = await Notifications.getPermissionsAsync();
+  notifLogger.info('ALARM ENTER', event.phaseId, event.type, 'perm:', perms.status);
   const { title, body } = buildAlarmContent(event);
 
   await scheduleNotification(ALARM_NOTIFICATION_ID, {

--- a/src/utils/tts.ts
+++ b/src/utils/tts.ts
@@ -1,0 +1,31 @@
+import * as Speech from 'expo-speech';
+import i18next from 'i18next';
+import { FALLBACK_LANGUAGE, LANGUAGE_REGISTRY } from '../i18n/types';
+import { createLogger } from './logger';
+
+const logger = createLogger('TTS');
+
+const FALLBACK_TTS_LOCALE =
+  LANGUAGE_REGISTRY.find((l) => l.code === FALLBACK_LANGUAGE)!.ttsLocale;
+
+function resolveTtsLocale(language: string): string {
+  return (
+    LANGUAGE_REGISTRY.find((l) => l.code === language)?.ttsLocale ?? FALLBACK_TTS_LOCALE
+  );
+}
+
+export interface TtsGate {
+  sleepMode: boolean;
+  allowSpeaker: boolean;
+}
+
+export function speakAlarm(text: string, gate: TtsGate): void {
+  if (gate.sleepMode || !gate.allowSpeaker) {
+    return;
+  }
+  try {
+    Speech.speak(text, { language: resolveTtsLocale(i18next.language) });
+  } catch (e) {
+    logger.error('speak failed:', e);
+  }
+}

--- a/src/utils/tts.ts
+++ b/src/utils/tts.ts
@@ -24,6 +24,7 @@ export function speakAlarm(text: string, gate: TtsGate): void {
     return;
   }
   try {
+    Speech.stop();
     Speech.speak(text, { language: resolveTtsLocale(i18next.language) });
   } catch (e) {
     logger.error('speak failed:', e);

--- a/src/utils/widgetStorage.ts
+++ b/src/utils/widgetStorage.ts
@@ -1,0 +1,27 @@
+import { Platform } from 'react-native';
+import * as LiveActivity from 'live-activity';
+import { Station } from '../types/station';
+
+// 동일 역 머무는 동안 매 GPS 폴링마다 WidgetCenter.reloadAllTimelines 가
+// 호출되는 낭비를 막기 위한 station.id 기준 dedupe.
+let lastStationId: string | null = null;
+
+export async function saveStationToWidget(
+  station: Station,
+  distanceKm: number,
+): Promise<void> {
+  if (Platform.OS !== 'ios') return;
+  if (station.id === lastStationId) return;
+  lastStationId = station.id;
+  await LiveActivity.saveWidgetStation(
+    station.name,
+    station.lineColor,
+    Math.max(0, Math.round(distanceKm * 1000)),
+  );
+}
+
+export async function clearWidgetStation(): Promise<void> {
+  lastStationId = null;
+  if (Platform.OS !== 'ios') return;
+  await LiveActivity.clearWidgetStation();
+}


### PR DESCRIPTION
## v1.2.0 릴리스

v1.0.x 이후 누적된 dev 변경분을 main에 반영합니다. TestFlight `1.2.0 (41)` 빌드와 동일한 코드 상태입니다.

### ✨ 새로운 기능
- 다국어 지원 (한/영/일/중) — 역명·알림·위젯·Live Activity까지 전 영역
- 노선도 위 실시간 열차 위치 시각화 (#293, #295)
- TTS 음성 알람 + 큐잉/중첩 정책 (#298, #299)
- 도착 정보 메타 배지 (#289)
- GPS + 도착정보 융합으로 현재역 자동 감지 정확도 개선 (#285, #287, #291)
- 디버그 모달 (#283)
- 알람 로그 측정 인프라 (#258)
- 위젯 로드 브리지 (#282)
- 지도 역 마커 가독성 개선 (#303)

### 🐛 버그 수정 & 안정성
- GPS 게이트 임계값 튜닝 — 정확도 200m / 신선도 15s (#249)
- 백그라운드 위치 추적 옵션 보강 (#244, #275)
- Foreground/Background 알림 상태 단일 출처 동기화 (#242)
- 환승역 도착정보 병합 (#280)
- 경로 외 노선 false alarm 차단 (#195)
- 환승 알림에 최종 목적지까지 총 정거장 수 표시 (#214)
- 다크모드 영구 저장 (#213)
- Live Activity podspec 공유 모듈 (#265, #270)
- 열차 마커 겹침 보정 (#295)

### 🚀 배포
- App Store Connect 빌드: `1.2.0 (41)` (이미 TestFlight 업로드 완료)

Closes #260

---

**머지 방식**: merge commit (squash 금지 — dev↔main lineage 유지)