### PR TITLE
feat(#308): 경로 기반 진행도 모델 (Phase A — Route-Locked Map Matching)

### DIFF
--- a/src/constants/routeProgress.ts
+++ b/src/constants/routeProgress.ts
@@ -1,0 +1,20 @@
+// 경로 밖 1.5km 이상 떨어진 GPS는 off-route로 간주해 진행도 보정에 사용하지 않는다.
+// 표시용 accuracy 게이트(MAX_ACCURACY_M_DISPLAY)와 동일. 큰 변경 시 location.ts와 함께 조정.
+export const MAX_PERP_M = 1500;
+
+// 지하철 운행 가능 최대 속도 + 여유. 200 km/h = 55.6 m/s.
+// 마지막 채택 관측 기준 implied speed가 이 값 초과면 GPS 점프로 판정해 그 관측을 거부한다.
+export const MAX_PLAUSIBLE_MPS = 55;
+
+// accuracyToWeight 시그모이드 스케일. acc=값 m에서 가중치 0.5.
+// 작게 잡을수록 GPS 신뢰가 빨리 떨어진다.
+export const ACCURACY_WEIGHT_SCALE_M = 300;
+
+// expo-location이 accuracy를 못 준 경우 대체 가중치(보수적).
+export const DEFAULT_ACCURACY_WEIGHT = 0.3;
+
+// 두 인접 역 사이 직선거리가 이 값을 넘으면 경로(arc) 자체를 invalid 처리.
+// 노선 정렬 데이터 오류(stationRoute의 id-string 정렬이 1D 인접성을 깨는 케이스)
+// defense-in-depth 가드. 실제 수도권 역간 최대 거리는 수인분당선 달월→사리 ~14km 정도이므로
+// 그 이상(예: 데이터 손상으로 다른 도시 좌표가 섞이는 경우)만 거른다.
+export const MAX_INTER_STATION_M = 20_000;

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -4,11 +4,13 @@ import { useNearestStation } from '../useNearestStation';
 import { useArrivalInfo } from '../useArrivalInfo';
 import { useTrainPositions } from '../useTrainPositions';
 import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../utils/stationRoute';
 import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
 import { TRAIN_STATUS } from '../../constants/trainStatus';
 import { MOCK_STATIONS } from '../../testUtils/fixtures';
 import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
 import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import type { DirectRoute } from '../../utils/stationRoute';
 
 jest.mock('../useNearestStation');
 jest.mock('../useArrivalInfo');
@@ -204,5 +206,74 @@ describe('useFusedNearestStation', () => {
     expect(result.current.userLocation).toEqual({ lat: 37.5, lng: 127.0 });
     expect(result.current.speedMps).toBe(1);
     expect(result.current.accuracyMeters).toBe(50);
+  });
+
+  describe('routeContext (Phase A — Route-Locked Map Matching)', () => {
+    const sagajeong = findStationByNameAndLine('사가정', '7')!;
+    const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+
+    it('경로 컨텍스트 + userLocation 있으면 진행도 기반 현재역으로 result 덮어쓴다', () => {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+        }),
+      );
+      mockFindTop.mockReturnValue([]);
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, {
+          route,
+          origin: sagajeong,
+          destination: childrenPark,
+        }),
+      );
+
+      expect(result.current.result?.station.id).toBe(sagajeong.id);
+      expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+      expect(result.current.confidence).toBe('route-progress');
+      expect(result.current.source).toBe('route-progress');
+    });
+
+    it('경로 컨텍스트 있어도 userLocation null이면 진행도 미초기화 → GPS fusion fallback', () => {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: null,
+          result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+        }),
+      );
+      mockFindTop.mockReturnValue([]);
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, {
+          route,
+          origin: sagajeong,
+          destination: childrenPark,
+        }),
+      );
+
+      expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
+
+    it('경로 컨텍스트 origin/destination 누락이면 GPS fusion fallback', () => {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+        }),
+      );
+      mockFindTop.mockReturnValue([]);
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, {
+          route,
+          origin: null,
+          destination: null,
+        }),
+      );
+
+      expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
   });
 });

--- a/src/hooks/__tests__/useRouteProgress.test.ts
+++ b/src/hooks/__tests__/useRouteProgress.test.ts
@@ -1,0 +1,414 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useRouteProgress, type UseRouteProgressInputs } from '../useRouteProgress';
+import { findStationByNameAndLine } from '../../utils/stationRoute';
+import type { DirectRoute, Route } from '../../utils/stationRoute';
+import type { Station } from '../../types/station';
+
+const sagajeong = findStationByNameAndLine('사가정', '7')!;
+const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
+const gunja = findStationByNameAndLine('군자', '7')!;
+const directRoute: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+
+function makeProps(overrides: Partial<UseRouteProgressInputs> = {}): UseRouteProgressInputs {
+  return {
+    route: directRoute,
+    origin: sagajeong,
+    destination: childrenPark,
+    userLocation: null,
+    speedMps: null,
+    accuracyMeters: null,
+    ...overrides,
+  };
+}
+
+describe('useRouteProgress', () => {
+  it('returns null arc when route is null', () => {
+    const { result } = renderHook(() => useRouteProgress(makeProps({ route: null })));
+    expect(result.current.arc).toBeNull();
+    expect(result.current.progressM).toBeNull();
+    expect(result.current.position).toBeNull();
+  });
+
+  it('returns null arc when origin is null', () => {
+    const { result } = renderHook(() => useRouteProgress(makeProps({ origin: null })));
+    expect(result.current.arc).toBeNull();
+  });
+
+  it('returns null arc when destination is null', () => {
+    const { result } = renderHook(() => useRouteProgress(makeProps({ destination: null })));
+    expect(result.current.arc).toBeNull();
+  });
+
+  it('returns null progressM/position before first GPS observation', () => {
+    const { result } = renderHook(() => useRouteProgress(makeProps()));
+    expect(result.current.arc).not.toBeNull();
+    expect(result.current.progressM).toBeNull();
+    expect(result.current.position).toBeNull();
+  });
+
+  it('initializes progressM to projection arc on first GPS observation', () => {
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      { initialProps: makeProps() },
+    );
+    expect(result.current.progressM).toBeNull();
+
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    expect(result.current.progressM).not.toBeNull();
+    expect(result.current.progressM!).toBeLessThan(10);
+    expect(result.current.position?.current.id).toBe(sagajeong.id);
+  });
+
+  it('blends new GPS observation with dead-reckoning prediction', () => {
+    jest.useFakeTimers();
+    const startTime = 1_000_000_000;
+    jest.setSystemTime(startTime);
+
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 10,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+    const firstProgress = result.current.progressM;
+    expect(firstProgress).not.toBeNull();
+
+    // 200초 뒤(implied speed 검사 통과 충분) — 군자 좌표(앞으로 진행)
+    jest.setSystemTime(startTime + 200_000);
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: gunja.lat, lng: gunja.lng },
+          speedMps: 10,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    expect(result.current.progressM!).toBeGreaterThan(firstProgress!);
+    expect(result.current.position?.current.id).toBe(gunja.id);
+    jest.useRealTimers();
+  });
+
+  it('rejects GPS observation when off-route by more than 1.5km', () => {
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+    const baseline = result.current.progressM!;
+
+    // 명백히 경로 밖(여의도 근처) 좌표 — perp > 1.5km
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: 37.5219, lng: 126.9244 },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    // 관측은 무시 — dead reckoning만 적용되므로 큰 변화 없음(속도 0).
+    expect(Math.abs(result.current.progressM! - baseline)).toBeLessThan(100);
+  });
+
+  it('rejects GPS observation when implied speed exceeds 200 km/h', () => {
+    jest.useFakeTimers();
+    const startTime = 1_000_000_000;
+    jest.setSystemTime(startTime);
+
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+    const baseline = result.current.progressM!;
+
+    // 1초 뒤 어린이대공원 좌표(약 4km 떨어짐) — implied speed 4000m/s ≫ 55m/s, 점프로 판정
+    jest.setSystemTime(startTime + 1000);
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: childrenPark.lat, lng: childrenPark.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    // 관측 거부 — dead reckoning만(속도 0) → progress 거의 그대로
+    expect(Math.abs(result.current.progressM! - baseline)).toBeLessThan(100);
+    jest.useRealTimers();
+  });
+
+  it('uses last known speed when speedMps is null', () => {
+    jest.useFakeTimers();
+    const startTime = 1_000_000_000;
+    jest.setSystemTime(startTime);
+
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 15,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+
+    // 같은 좌표로 5초 뒤 speed null — dead reckoning 시 직전 속도 15 m/s 사용
+    jest.setSystemTime(startTime + 5000);
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: null,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    // dead reckoning은 5초 × 15 m/s = 75m 진행 예측
+    expect(result.current.progressM!).toBeGreaterThan(0);
+    jest.useRealTimers();
+  });
+
+  it('treats negative speedMps as missing and keeps last known speed', () => {
+    jest.useFakeTimers();
+    const startTime = 1_000_000_000;
+    jest.setSystemTime(startTime);
+
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 10,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+    expect(result.current.progressM).not.toBeNull();
+
+    jest.setSystemTime(startTime + 200_000);
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: gunja.lat, lng: gunja.lng },
+          speedMps: -1,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+    expect(result.current.position?.current.id).toBe(gunja.id);
+    jest.useRealTimers();
+  });
+
+  it('uses fallback weight when accuracyMeters is null', () => {
+    jest.useFakeTimers();
+    const startTime = 1_000_000_000;
+    jest.setSystemTime(startTime);
+
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: null,
+        }),
+      },
+    );
+    const firstProgress = result.current.progressM;
+
+    // 200초 뒤(implied speed 검사 통과) — null accuracy로 blend 경로 도달.
+    jest.setSystemTime(startTime + 200_000);
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: gunja.lat, lng: gunja.lng },
+          speedMps: 0,
+          accuracyMeters: null,
+        }),
+      );
+    });
+
+    expect(result.current.progressM).not.toBeNull();
+    expect(result.current.progressM!).not.toBe(firstProgress);
+    jest.useRealTimers();
+  });
+
+  it('resets state when route changes', () => {
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+    expect(result.current.progressM).not.toBeNull();
+
+    const otherRoute: Route = { type: 'direct', stops: 1, line: '7' };
+    act(() => {
+      rerender(
+        makeProps({
+          route: otherRoute,
+          origin: gunja,
+          destination: childrenPark,
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    // 새 경로(gunja→childrenPark)에서 sagajeong 사영 → off-route(perp 큼)지만
+    // 초기화 직후엔 off-route 게이트 우회로 사영점에 snap.
+    expect(result.current.progressM).not.toBeNull();
+  });
+
+  it('handles arc but missing userLocation gracefully on re-render', () => {
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+    expect(result.current.progressM).not.toBeNull();
+    const before = result.current.progressM;
+
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: null,
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    // userLocation null이면 effect early return — 상태 변경 없음.
+    expect(result.current.progressM).toBe(before);
+  });
+
+  it('snaps to origin (arc=0) when first observation is off-route', () => {
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      { initialProps: makeProps() },
+    );
+
+    // 첫 관측이 여의도 — 경로(어린이대공원→사가정)에서 매우 멀다(perp ≫ 1.5km)
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: 37.5219, lng: 126.9244 },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    expect(result.current.progressM).toBe(0);
+    expect(result.current.position?.current.id).toBe(sagajeong.id);
+  });
+
+  it('continues to reject consecutive GPS jumps (trusted baseline preserved)', () => {
+    jest.useFakeTimers();
+    const startTime = 1_000_000_000;
+    jest.setSystemTime(startTime);
+
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+    const baseline = result.current.progressM!;
+
+    // 5번 연속 점프 관측 — 모두 거부되어 progress 안정 유지
+    for (let i = 1; i <= 5; i++) {
+      jest.setSystemTime(startTime + i * 2000);
+      act(() => {
+        rerender(
+          makeProps({
+            userLocation: { lat: childrenPark.lat, lng: childrenPark.lng },
+            speedMps: 0,
+            accuracyMeters: 30,
+          }),
+        );
+      });
+    }
+
+    // dead reckoning만 누적 — 속도 0이므로 progress 거의 그대로
+    expect(Math.abs(result.current.progressM! - baseline)).toBeLessThan(100);
+    expect(result.current.position?.current.id).toBe(sagajeong.id);
+    jest.useRealTimers();
+  });
+
+  it('falls back to dead-reckoning when dt is 0 (same-tick observation)', () => {
+    jest.useFakeTimers();
+    const startTime = 1_000_000_000;
+    jest.setSystemTime(startTime);
+
+    const { result, rerender } = renderHook(
+      (p: UseRouteProgressInputs) => useRouteProgress(p),
+      {
+        initialProps: makeProps({
+          userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      },
+    );
+
+    // 시간 정지한 채로 새 관측 → dt=0이면 점프 거부 분기를 우회하고 바로 blend.
+    act(() => {
+      rerender(
+        makeProps({
+          userLocation: { lat: gunja.lat, lng: gunja.lng },
+          speedMps: 0,
+          accuracyMeters: 30,
+        }),
+      );
+    });
+
+    expect(result.current.position?.current.id).toBe(gunja.id);
+    jest.useRealTimers();
+  });
+});

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useNearestStation } from './useNearestStation';
 import { useArrivalInfo } from './useArrivalInfo';
 import { useTrainPositions } from './useTrainPositions';
+import { useRouteProgress } from './useRouteProgress';
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
@@ -10,6 +11,7 @@ import { MAX_ACTIVE_LINES } from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
 import type { NearestStationResult, Station } from '../types/station';
 import type { ArrivalProvider, PositionProvider } from '../providers/types';
+import type { Route } from '../utils/stationRoute';
 
 /**
  * fusion 후보 개수. MAX_ACTIVE_LINES와 동기화 — Rules of Hooks로 useArrivalInfo/useTrainPositions를
@@ -67,11 +69,34 @@ function matchPositionsForCandidate(
   return [];
 }
 
+/**
+ * 경로 컨텍스트가 제공되면 useRouteProgress(1D map matching)를 기본으로 사용해
+ * 단일 GPS 점프로 화면이 흔들리는 문제를 막는다. 경로가 없으면 기존 GPS+arrival fusion 유지.
+ */
+export interface FusedRouteContext {
+  route: Route;
+  origin: Station | null;
+  destination: Station | null;
+}
+
 export function useFusedNearestStation(
   arrivalProvider?: ArrivalProvider,
   positionProvider?: PositionProvider,
+  routeContext?: FusedRouteContext,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation();
+
+  // Phase A: 경로가 설정되면 진행도 기반 현재역으로 GPS 결과를 덮어쓴다.
+  // origin/destination이 빠지면 useRouteProgress가 arc를 만들지 못하고 null을 반환,
+  // 기존 GPS fusion이 자연 fallback으로 살아난다.
+  const progress = useRouteProgress({
+    route: routeContext?.route ?? null,
+    origin: routeContext?.origin ?? null,
+    destination: routeContext?.destination ?? null,
+    userLocation: gps.userLocation,
+    speedMps: gps.speedMps,
+    accuracyMeters: gps.accuracyMeters,
+  });
 
   // GPS 좌표 → 거리순 후보 N개. 좌표 갱신 시에만 재계산.
   const candidates = useMemo<NearestStationResult[]>(() => {
@@ -115,11 +140,18 @@ export function useFusedNearestStation(
     );
   }, [candidates, a0.arrival, a1.arrival, a2.arrival, p0.positions, p1.positions, p2.positions]);
 
+  const routeResult: NearestStationResult | null = progress.position
+    ? {
+        station: progress.position.current,
+        distanceKm: progress.position.distanceToCurrentM / 1000,
+      }
+    : null;
+
   return {
-    result: fused?.result ?? gps.result,
+    result: routeResult ?? fused?.result ?? gps.result,
     gpsResult: gps.result,
-    confidence: fused?.confidence ?? 'gps-only',
-    source: fused?.source ?? 'gps',
+    confidence: routeResult ? 'route-progress' : fused?.confidence ?? 'gps-only',
+    source: routeResult ? 'route-progress' : fused?.source ?? 'gps',
     variants: gps.variants,
     userLocation: gps.userLocation,
     speedMps: gps.speedMps,

--- a/src/hooks/useRouteProgress.ts
+++ b/src/hooks/useRouteProgress.ts
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  computeRouteArc,
+  nearestArcPoint,
+  stationAtProgress,
+  type RouteArc,
+  type RoutePositionInfo,
+} from '../utils/routeProgress';
+import type { Route } from '../utils/stationRoute';
+import type { Station } from '../types/station';
+import {
+  MAX_PERP_M,
+  MAX_PLAUSIBLE_MPS,
+  ACCURACY_WEIGHT_SCALE_M,
+  DEFAULT_ACCURACY_WEIGHT,
+} from '../constants/routeProgress';
+
+/**
+ * GPS 관측의 progress 갱신 가중치. 정확도가 좋을수록 GPS를 더 신뢰한다.
+ * acc=100m → w≈0.9, acc=300m → w≈0.5, acc=1000m → w≈0.08.
+ * accuracy null이면 expo-location이 값 못 준 경우라 보수적으로 DEFAULT_ACCURACY_WEIGHT.
+ */
+export function accuracyToWeight(accuracyMeters: number | null): number {
+  if (accuracyMeters == null) return DEFAULT_ACCURACY_WEIGHT;
+  const k = accuracyMeters / ACCURACY_WEIGHT_SCALE_M;
+  return 1 / (1 + k * k);
+}
+
+interface ProgressState {
+  /** dead-reckoning 포함 현재 진행도(m). 표시·position 계산에 사용. */
+  progressM: number;
+  /** 마지막 dead-reckoning tick 시각. progressM 진행 계산용. */
+  lastTickMs: number;
+  /** 마지막으로 채택된(blend된) progress(m). 점프 거부 baseline. */
+  lastTrustedProgressM: number;
+  /** 마지막 채택 관측 시각. 점프 거부 baseline. */
+  lastTrustedTickMs: number;
+  /** dead-reckoning에 쓸 직전 속도(m/s). */
+  speedMps: number;
+  initialized: boolean;
+}
+
+export interface UseRouteProgressInputs {
+  route: Route;
+  origin: Station | null;
+  destination: Station | null;
+  userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
+  accuracyMeters: number | null;
+}
+
+export interface UseRouteProgressReturn {
+  /** 경로 호출 가능한 arc 테이블. route/origin/destination 누락 또는 유효성 실패 시 null. */
+  arc: RouteArc | null;
+  /** 경로 위 진행도(m). 첫 GPS 관측 전엔 null. */
+  progressM: number | null;
+  /** progressM이 가리키는 현재/다음/이전 역 정보. null = 정보 없음. */
+  position: RoutePositionInfo | null;
+}
+
+/**
+ * 경로가 설정된 동안 사용자 상태를 1D 진행도로 추적한다.
+ * - 모션 모델: 직전 속도 × 경과 시간으로 progress 자동 증가(GPS tick 사이 보간).
+ * - 관측 모델: GPS 좌표를 경로에 사영해 progress 보정. accuracy 가중치로 dead-reckoning과 blend.
+ * - 점프 거부: implied speed가 200 km/h 초과면 그 관측은 무시(GPS 튐 방지).
+ *   baseline은 마지막 채택 관측 — 연속 점프도 끝까지 거부한다.
+ * - 경로 이탈: 경로에서 1.5km 이상 벗어난 좌표는 progress 보정에 쓰지 않음.
+ * - 초기화: 첫 관측이 경로 안(perp ≤ 1.5km)이면 사영점에 snap. 밖이면 origin(arc=0)에서 시작.
+ */
+export function useRouteProgress({
+  route,
+  origin,
+  destination,
+  userLocation,
+  speedMps,
+  accuracyMeters,
+}: UseRouteProgressInputs): UseRouteProgressReturn {
+  const arc = useMemo(() => {
+    if (!route || !origin || !destination) return null;
+    return computeRouteArc(route, origin, destination);
+  }, [route, origin, destination]);
+
+  const [progressM, setProgressM] = useState<number | null>(null);
+  const stateRef = useRef<ProgressState>({
+    progressM: 0,
+    lastTickMs: 0,
+    lastTrustedProgressM: 0,
+    lastTrustedTickMs: 0,
+    speedMps: 0,
+    initialized: false,
+  });
+
+  // arc 변경(경로 재설정) 시 상태 초기화. 다음 GPS 관측에서 첫 사영점 또는 origin으로 snap.
+  useEffect(() => {
+    stateRef.current = {
+      progressM: 0,
+      lastTickMs: 0,
+      lastTrustedProgressM: 0,
+      lastTrustedTickMs: 0,
+      speedMps: 0,
+      initialized: false,
+    };
+    setProgressM(null);
+  }, [arc]);
+
+  useEffect(() => {
+    if (!arc || !userLocation) return;
+    const proj = nearestArcPoint(arc, userLocation.lat, userLocation.lng);
+    const now = Date.now();
+    const current = stateRef.current;
+    const nextSpeed = speedMps != null && speedMps >= 0 ? speedMps : current.speedMps;
+
+    // 초기화: 첫 관측이 경로 안(perp ≤ MAX_PERP_M)이면 사영점에 snap.
+    // 밖이면 origin(arc=0)에서 시작 — 첫 관측 outlier로 진행도가 잘못 고정되는 사고 방지.
+    if (!current.initialized) {
+      const seedArcM = proj.perpDistanceM <= MAX_PERP_M ? proj.arcM : 0;
+      stateRef.current = {
+        progressM: seedArcM,
+        lastTickMs: now,
+        lastTrustedProgressM: seedArcM,
+        lastTrustedTickMs: now,
+        speedMps: nextSpeed,
+        initialized: true,
+      };
+      setProgressM(seedArcM);
+      return;
+    }
+
+    // 모션 모델: 직전 tick부터 dead reckoning.
+    const dt = (now - current.lastTickMs) / 1000;
+    const predicted = current.progressM + current.speedMps * dt;
+
+    // 경로 이탈: 관측 무시, dead reckoning만 적용. trusted baseline은 그대로.
+    if (proj.perpDistanceM > MAX_PERP_M) {
+      stateRef.current = {
+        ...current,
+        progressM: predicted,
+        lastTickMs: now,
+        speedMps: nextSpeed,
+      };
+      setProgressM(predicted);
+      return;
+    }
+
+    // 점프 거부: 마지막 채택 관측 기준 implied speed가 물리적으로 불가능하면 거부.
+    // baseline을 dead-reckoned predicted가 아닌 trusted로 유지해 연속 점프도 계속 차단.
+    const trustedDt = (now - current.lastTrustedTickMs) / 1000;
+    if (trustedDt > 0) {
+      const trustedDelta = Math.abs(proj.arcM - current.lastTrustedProgressM);
+      const impliedMps = trustedDelta / trustedDt;
+      if (impliedMps > MAX_PLAUSIBLE_MPS) {
+        stateRef.current = {
+          ...current,
+          progressM: predicted,
+          lastTickMs: now,
+          speedMps: nextSpeed,
+        };
+        setProgressM(predicted);
+        return;
+      }
+    }
+
+    const w = accuracyToWeight(accuracyMeters);
+    const blended = predicted * (1 - w) + proj.arcM * w;
+    stateRef.current = {
+      progressM: blended,
+      lastTickMs: now,
+      lastTrustedProgressM: blended,
+      lastTrustedTickMs: now,
+      speedMps: nextSpeed,
+      initialized: true,
+    };
+    setProgressM(blended);
+  }, [arc, userLocation?.lat, userLocation?.lng, speedMps, accuracyMeters]);
+
+  const position = useMemo<RoutePositionInfo | null>(() => {
+    if (!arc || progressM === null) return null;
+    return stationAtProgress(arc, progressM);
+  }, [arc, progressM]);
+
+  return { arc, progressM, position };
+}

--- a/src/utils/__tests__/routeProgress.test.ts
+++ b/src/utils/__tests__/routeProgress.test.ts
@@ -1,0 +1,331 @@
+import {
+  computeRouteArc,
+  nearestArcPoint,
+  stationAtProgress,
+  type RouteArc,
+} from '../routeProgress';
+import { findStationByNameAndLine } from '../stationRoute';
+import type {
+  DirectRoute,
+  MultiTransferRoute,
+  TransferRoute,
+} from '../stationRoute';
+import type { Station } from '../../types/station';
+
+const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
+const sagajeong = findStationByNameAndLine('사가정', '7')!;
+const gunja = findStationByNameAndLine('군자', '7')!;
+const konkukUni7 = findStationByNameAndLine('건대입구', '7')!;
+const konkukUni2 = findStationByNameAndLine('건대입구', '2')!;
+const jamsil2 = findStationByNameAndLine('잠실', '2')!;
+const gyodae2 = findStationByNameAndLine('교대', '2')!;
+const gyodae3 = findStationByNameAndLine('교대', '3')!;
+const expressBus3 = findStationByNameAndLine('고속터미널', '3')!;
+
+describe('computeRouteArc', () => {
+  it('returns null when route is null', () => {
+    expect(computeRouteArc(null, childrenPark, sagajeong)).toBeNull();
+  });
+
+  it('builds arc for direct route (forward — id ascending)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const arc = computeRouteArc(route, sagajeong, childrenPark);
+    expect(arc).not.toBeNull();
+    expect(arc!.stations[0].id).toBe(sagajeong.id);
+    expect(arc!.stations[arc!.stations.length - 1].id).toBe(childrenPark.id);
+    expect(arc!.arcM[0]).toBe(0);
+    expect(arc!.totalLengthM).toBeGreaterThan(0);
+    expect(arc!.arcM).toHaveLength(arc!.stations.length);
+  });
+
+  it('builds arc for direct route (reverse — id descending)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const arc = computeRouteArc(route, childrenPark, sagajeong);
+    expect(arc).not.toBeNull();
+    expect(arc!.stations[0].id).toBe(childrenPark.id);
+    expect(arc!.stations[arc!.stations.length - 1].id).toBe(sagajeong.id);
+  });
+
+  it('builds arc for direct route (origin === destination)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 0, line: '7' };
+    const arc = computeRouteArc(route, gunja, gunja);
+    expect(arc).not.toBeNull();
+    expect(arc!.stations).toHaveLength(1);
+    expect(arc!.totalLengthM).toBe(0);
+    expect(arc!.arcM).toEqual([0]);
+  });
+
+  it('returns null when direct route origin id is not on the line', () => {
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const fake: Station = { ...gunja, id: 'nonexistent' };
+    expect(computeRouteArc(route, fake, sagajeong)).toBeNull();
+  });
+
+  it('returns null when direct route destination id is not on the line', () => {
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const fake: Station = { ...sagajeong, id: 'nonexistent' };
+    expect(computeRouteArc(route, gunja, fake)).toBeNull();
+  });
+
+  it('builds arc for transfer route', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '건대입구',
+      fromLine: '7',
+      toLine: '2',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 4,
+    };
+    const arc = computeRouteArc(route, childrenPark, jamsil2);
+    expect(arc).not.toBeNull();
+    expect(arc!.stations[0].id).toBe(childrenPark.id);
+    expect(arc!.stations[arc!.stations.length - 1].id).toBe(jamsil2.id);
+    const ids = arc!.stations.map((s) => s.id);
+    expect(ids).toContain(konkukUni7.id);
+    expect(ids).toContain(konkukUni2.id);
+  });
+
+  it('returns null when transfer route has unknown transferName', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '존재하지않는역',
+      fromLine: '7',
+      toLine: '2',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 4,
+    };
+    expect(computeRouteArc(route, childrenPark, jamsil2)).toBeNull();
+  });
+
+  it('returns null when transfer route origin id is invalid', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '건대입구',
+      fromLine: '7',
+      toLine: '2',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 4,
+    };
+    const fakeOrigin: Station = { ...childrenPark, id: 'nonexistent' };
+    expect(computeRouteArc(route, fakeOrigin, jamsil2)).toBeNull();
+  });
+
+  it('returns null when transfer route destination id is invalid', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '건대입구',
+      fromLine: '7',
+      toLine: '2',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 4,
+    };
+    const fakeDest: Station = { ...jamsil2, id: 'nonexistent' };
+    expect(computeRouteArc(route, childrenPark, fakeDest)).toBeNull();
+  });
+
+  it('builds arc for multi-transfer route', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '건대입구', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
+      ],
+      stopsAfterLastTransfer: 1,
+    };
+    const arc = computeRouteArc(route, sagajeong, expressBus3);
+    expect(arc).not.toBeNull();
+    expect(arc!.stations[0].id).toBe(sagajeong.id);
+    expect(arc!.stations[arc!.stations.length - 1].id).toBe(expressBus3.id);
+    const ids = arc!.stations.map((s) => s.id);
+    expect(ids).toContain(konkukUni7.id);
+    expect(ids).toContain(konkukUni2.id);
+    expect(ids).toContain(gyodae2.id);
+    expect(ids).toContain(gyodae3.id);
+    // dedup: 같은 ID가 두 번 들어가지 않음
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('returns null when multi-transfer route has unknown transferName', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '존재하지않는역', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
+      ],
+      stopsAfterLastTransfer: 1,
+    };
+    expect(computeRouteArc(route, sagajeong, expressBus3)).toBeNull();
+  });
+
+  it('returns null when multi-transfer route origin id is invalid', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '건대입구', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
+      ],
+      stopsAfterLastTransfer: 1,
+    };
+    const fakeOrigin: Station = { ...sagajeong, id: 'nonexistent' };
+    expect(computeRouteArc(route, fakeOrigin, expressBus3)).toBeNull();
+  });
+
+  it('returns null when adjacent stations exceed MAX_INTER_STATION_M (data corruption guard)', () => {
+    jest.resetModules();
+    jest.doMock('../../constants/routeProgress', () => ({
+      MAX_INTER_STATION_M: 100,
+    }));
+    const { computeRouteArc: cra } = require('../routeProgress');
+    const { findStationByNameAndLine: fsbnl } = require('../stationRoute');
+    const ori = fsbnl('사가정', '7');
+    const dst = fsbnl('어린이대공원', '7');
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    expect(cra(route, ori, dst)).toBeNull();
+    jest.resetModules();
+  });
+
+  it('returns null when multi-transfer route destination id is invalid', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '건대입구', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
+      ],
+      stopsAfterLastTransfer: 1,
+    };
+    const fakeDest: Station = { ...expressBus3, id: 'nonexistent' };
+    expect(computeRouteArc(route, sagajeong, fakeDest)).toBeNull();
+  });
+});
+
+describe('nearestArcPoint', () => {
+  it('returns haversine distance for single-station arc', () => {
+    const arc = computeRouteArc({ type: 'direct', stops: 0, line: '7' }, gunja, gunja)!;
+    const proj = nearestArcPoint(arc, gunja.lat + 0.001, gunja.lng);
+    expect(proj.arcM).toBe(0);
+    expect(proj.segmentIndex).toBe(0);
+    expect(proj.perpDistanceM).toBeGreaterThan(0);
+  });
+
+  it('projects exactly at first station for a 2-station arc', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const arc = computeRouteArc(route, gunja, childrenPark)!;
+    const proj = nearestArcPoint(arc, gunja.lat, gunja.lng);
+    expect(proj.arcM).toBeCloseTo(0, 1);
+    expect(proj.perpDistanceM).toBeLessThan(5);
+    expect(proj.segmentIndex).toBe(0);
+  });
+
+  it('projects exactly at last station for a 2-station arc', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const arc = computeRouteArc(route, gunja, childrenPark)!;
+    const proj = nearestArcPoint(arc, childrenPark.lat, childrenPark.lng);
+    // 등각도 평면 사영 segLenM과 haversine arcM 누적 사이 작은 오차 허용(<5m).
+    expect(Math.abs(proj.arcM - arc.totalLengthM)).toBeLessThan(5);
+    expect(proj.perpDistanceM).toBeLessThan(5);
+  });
+
+  it('clamps to t=0 when point is behind first station', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const arc = computeRouteArc(route, gunja, childrenPark)!;
+    // 군자보다 더 북쪽(어린이대공원 반대 방향)으로 멀리 떨어진 점
+    const dLat = gunja.lat - childrenPark.lat;
+    const dLng = gunja.lng - childrenPark.lng;
+    const beyond = { lat: gunja.lat + dLat, lng: gunja.lng + dLng };
+    const proj = nearestArcPoint(arc, beyond.lat, beyond.lng);
+    expect(proj.arcM).toBeCloseTo(0, 1);
+  });
+
+  it('clamps to t=1 when point is past last station', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const arc = computeRouteArc(route, gunja, childrenPark)!;
+    const dLat = childrenPark.lat - gunja.lat;
+    const dLng = childrenPark.lng - gunja.lng;
+    const beyond = { lat: childrenPark.lat + dLat, lng: childrenPark.lng + dLng };
+    const proj = nearestArcPoint(arc, beyond.lat, beyond.lng);
+    // 등각도 평면 사영 segLenM과 haversine arcM 누적 사이 작은 오차 허용(<5m).
+    expect(Math.abs(proj.arcM - arc.totalLengthM)).toBeLessThan(5);
+  });
+
+  it('picks the closer segment for multi-segment arc', () => {
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const arc = computeRouteArc(route, sagajeong, childrenPark)!;
+    // 어린이대공원 좌표 입력 → 마지막 segment에 사영되어야 함
+    const proj = nearestArcPoint(arc, childrenPark.lat, childrenPark.lng);
+    expect(proj.segmentIndex).toBe(arc.stations.length - 2);
+    // 등각도 평면 사영 segLenM과 haversine arcM 누적 사이 작은 오차 허용(<5m).
+    expect(Math.abs(proj.arcM - arc.totalLengthM)).toBeLessThan(5);
+  });
+
+  it('handles degenerate segment (a === b) by leaving t at 0', () => {
+    // 동일 좌표를 가진 인공 station 두 개로 시작. 실제 데이터에선 발생하지 않으나
+    // 방어 코드 검증.
+    const dup: Station = { ...gunja };
+    const synthetic: RouteArc = {
+      stations: [dup, dup, childrenPark],
+      arcM: [0, 0, 2000],
+      totalLengthM: 2000,
+    };
+    const proj = nearestArcPoint(synthetic, gunja.lat, gunja.lng);
+    expect(proj.arcM).toBeCloseTo(0, 0);
+    expect(proj.perpDistanceM).toBeLessThan(5);
+  });
+});
+
+describe('stationAtProgress', () => {
+  const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+  const arc = computeRouteArc(route, sagajeong, childrenPark)!;
+
+  it('returns single station when arc has only one station', () => {
+    const single = computeRouteArc({ type: 'direct', stops: 0, line: '7' }, gunja, gunja)!;
+    const info = stationAtProgress(single, 0);
+    expect(info.current.id).toBe(gunja.id);
+    expect(info.next).toBeNull();
+    expect(info.prev).toBeNull();
+    expect(info.distanceToCurrentM).toBe(0);
+    expect(info.distanceToNextM).toBeNull();
+  });
+
+  it('returns first station with null prev at progress 0', () => {
+    const info = stationAtProgress(arc, 0);
+    expect(info.current.id).toBe(arc.stations[0].id);
+    expect(info.prev).toBeNull();
+    expect(info.next?.id).toBe(arc.stations[1].id);
+  });
+
+  it('returns last station with null next at progress totalLengthM', () => {
+    const info = stationAtProgress(arc, arc.totalLengthM);
+    expect(info.current.id).toBe(arc.stations[arc.stations.length - 1].id);
+    expect(info.next).toBeNull();
+    expect(info.prev?.id).toBe(arc.stations[arc.stations.length - 2].id);
+  });
+
+  it('clamps progress below 0', () => {
+    const info = stationAtProgress(arc, -5000);
+    expect(info.current.id).toBe(arc.stations[0].id);
+  });
+
+  it('clamps progress above totalLengthM', () => {
+    const info = stationAtProgress(arc, arc.totalLengthM + 5000);
+    expect(info.current.id).toBe(arc.stations[arc.stations.length - 1].id);
+  });
+
+  it('picks nearer station and reports neighbor stations', () => {
+    // station 2와 3 사이, station 2에 더 가까운 위치
+    const between = arc.arcM[2] + (arc.arcM[3] - arc.arcM[2]) * 0.3;
+    const info = stationAtProgress(arc, between);
+    expect(info.current.id).toBe(arc.stations[2].id);
+    expect(info.next?.id).toBe(arc.stations[3].id);
+    expect(info.prev?.id).toBe(arc.stations[1].id);
+    expect(info.distanceToNextM).toBeGreaterThan(0);
+  });
+
+  it('clamps distanceToNextM to 0 when progress exceeds next arc value', () => {
+    // station 2와 3 사이, station 3에 더 가까운 위치 → currentIdx=3
+    // 하지만 만약 p > arcM[3]이면 next는 station 4, arcM[4] - p > 0이라 정상.
+    // distanceToNextM은 항상 ≥ 0 (Math.max 보장).
+    const info = stationAtProgress(arc, arc.arcM[1]);
+    expect(info.current.id).toBe(arc.stations[1].id);
+    expect(info.distanceToNextM).toBe(arc.arcM[2] - arc.arcM[1]);
+  });
+});

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -6,15 +6,21 @@ import { getTrainStatusPriority } from '../constants/trainStatus';
 
 /**
  * fusion 결과 신뢰도 — UI/로깅용. 점수 ≥ 100이면 confirmed, 0 < x < 100이면 arriving.
- * 신호원(arrival/position)은 source 필드로 분리 식별.
+ * 신호원(arrival/position/route-progress)은 source 필드로 분리 식별.
+ * 'route-progress'는 1D map matching 진행도 기반(Phase A) — GPS 점프에 면역이지만
+ * 도착/위치 API와 달리 자체 검증 신호가 아니라 별도 confidence로 둔다.
  */
-export type FusionConfidence = 'arrival-confirmed' | 'arrival-arriving' | 'gps-only';
+export type FusionConfidence =
+  | 'arrival-confirmed'
+  | 'arrival-arriving'
+  | 'route-progress'
+  | 'gps-only';
 
 /**
  * fusion 신호 출처. position이 가장 정확(실제 좌표), arrival은 추정(곧 도착),
- * gps는 거리 기반. 알람 dedup·로깅에서 source별 정책 분기에 사용.
+ * route-progress는 트랙 1D 진행도, gps는 거리 기반. 알람 dedup·로깅에서 source별 정책 분기에 사용.
  */
-export type FusionSource = 'position' | 'arrival' | 'gps';
+export type FusionSource = 'position' | 'arrival' | 'route-progress' | 'gps';
 
 export interface FusedStationResult {
   result: NearestStationResult;

--- a/src/utils/routeProgress.ts
+++ b/src/utils/routeProgress.ts
@@ -1,0 +1,219 @@
+import { haversine } from './haversine';
+import {
+  findStationByNameAndLine,
+  getStationsOnLine,
+  type Route,
+} from './stationRoute';
+import type { Station } from '../types/station';
+import { MAX_INTER_STATION_M } from '../constants/routeProgress';
+
+// 위도 1° ≒ 111.32km (적도 기준). 서울 위도(~37.5°)에서도 위도 방향 거리는 변하지 않음.
+// 경도 1°는 위도에 따라 cos(lat)배. 서울 시내(수십 km 범위)에서 등각도 평면 근사는
+// 오차 1m 이하로 충분히 정확하다.
+const METERS_PER_DEG_LAT = 111_320;
+
+function metersPerDegLng(lat: number): number {
+  return 111_320 * Math.cos((lat * Math.PI) / 180);
+}
+
+export interface RouteArc {
+  /** 경로 시작→끝 ordered station 시퀀스. 환승역은 노선별로 별도 Station 객체로 들어감. */
+  stations: Station[];
+  /** 누적 거리(m). length === stations.length, arcM[0] === 0. */
+  arcM: number[];
+  /** 경로 총 길이(m). */
+  totalLengthM: number;
+}
+
+export interface ArcProjection {
+  /** 경로 시작점부터 사영점까지 누적 거리(m). 0 ~ totalLengthM. */
+  arcM: number;
+  /** 사영점과 입력 좌표 사이 수직 거리(m). 경로에서 벗어난 정도. */
+  perpDistanceM: number;
+  /** 사영이 일어난 segment의 시작 station 인덱스. */
+  segmentIndex: number;
+}
+
+export interface RoutePositionInfo {
+  /** progressM에 가장 가까운 역(arc 기준 최단). */
+  current: Station;
+  /** progressM보다 arc가 큰 첫 번째 역. 없으면 null(목적지 통과). */
+  next: Station | null;
+  /** progressM보다 arc가 작은 마지막 역(current와 다르면). 없으면 null. */
+  prev: Station | null;
+  /** current 역과 progressM 사이 arc 거리(m). */
+  distanceToCurrentM: number;
+  /** next 역까지 arc 거리(m). next 없으면 null. */
+  distanceToNextM: number | null;
+}
+
+function stationsBetween(
+  line: Station['line'],
+  fromId: string,
+  toId: string,
+): Station[] | null {
+  const lineStations = getStationsOnLine(line);
+  const fromIdx = lineStations.findIndex((s) => s.id === fromId);
+  const toIdx = lineStations.findIndex((s) => s.id === toId);
+  if (fromIdx === -1 || toIdx === -1) return null;
+  if (fromIdx === toIdx) return [lineStations[fromIdx]];
+  if (fromIdx < toIdx) return lineStations.slice(fromIdx, toIdx + 1);
+  return lineStations.slice(toIdx, fromIdx + 1).reverse();
+}
+
+function appendSegment(stations: Station[], segment: Station[]): void {
+  // 환승 시 같은 station이 중복되지 않도록 boundary 제거.
+  if (stations.length > 0 && segment.length > 0 && stations[stations.length - 1].id === segment[0].id) {
+    stations.push(...segment.slice(1));
+  } else {
+    stations.push(...segment);
+  }
+}
+
+/**
+ * 경로(route) + 출발/도착 역으로 ordered station 시퀀스와 누적거리 테이블을 만든다.
+ * 좌표 기반(haversine)이라 실제 트랙 곡선은 반영되지 않지만, 역 사이 직선 근사로 충분.
+ * 환승 시 양 노선의 환승역을 모두 시퀀스에 넣어 노선 정보를 보존한다.
+ */
+export function computeRouteArc(
+  route: Route,
+  origin: Station,
+  destination: Station,
+): RouteArc | null {
+  if (!route) return null;
+
+  const stations: Station[] = [];
+
+  if (route.type === 'direct') {
+    const segment = stationsBetween(route.line, origin.id, destination.id);
+    if (!segment) return null;
+    appendSegment(stations, segment);
+  } else if (route.type === 'transfer') {
+    const fromTransfer = findStationByNameAndLine(route.transferName, route.fromLine);
+    const toTransfer = findStationByNameAndLine(route.transferName, route.toLine);
+    if (!fromTransfer || !toTransfer) return null;
+    const seg1 = stationsBetween(route.fromLine, origin.id, fromTransfer.id);
+    const seg2 = stationsBetween(route.toLine, toTransfer.id, destination.id);
+    if (!seg1 || !seg2) return null;
+    appendSegment(stations, seg1);
+    appendSegment(stations, seg2);
+  } else {
+    let currentStartId = origin.id;
+    for (const seg of route.transfers) {
+      const fromTransfer = findStationByNameAndLine(seg.transferName, seg.fromLine);
+      const toTransfer = findStationByNameAndLine(seg.transferName, seg.toLine);
+      if (!fromTransfer || !toTransfer) return null;
+      const subSeg = stationsBetween(seg.fromLine, currentStartId, fromTransfer.id);
+      if (!subSeg) return null;
+      appendSegment(stations, subSeg);
+      appendSegment(stations, [toTransfer]);
+      currentStartId = toTransfer.id;
+    }
+    const lastLine = route.transfers[route.transfers.length - 1].toLine;
+    const lastSeg = stationsBetween(lastLine, currentStartId, destination.id);
+    if (!lastSeg) return null;
+    appendSegment(stations, lastSeg);
+  }
+
+  const arcM: number[] = [0];
+  let total = 0;
+  for (let i = 1; i < stations.length; i++) {
+    const prev = stations[i - 1];
+    const curr = stations[i];
+    const segM = haversine(prev.lat, prev.lng, curr.lat, curr.lng) * 1000;
+    // 노선 정렬 데이터 오류 가드: 인접 역 사이 거리가 비정상이면 polyline이 신뢰 불가.
+    // arc 자체를 폐기해 호출부가 GPS-only fallback으로 빠지게 한다.
+    if (segM > MAX_INTER_STATION_M) return null;
+    total += segM;
+    arcM.push(total);
+  }
+
+  return { stations, arcM, totalLengthM: total };
+}
+
+/**
+ * (lat,lng)를 RouteArc polyline에 사영. 경로 위 가장 가까운 점의 arc 위치 + 수직 거리 반환.
+ * 등각도 평면 근사: segment별로 a 기준 로컬 미터 좌표로 변환 후 표준 점-선분 사영.
+ */
+export function nearestArcPoint(arc: RouteArc, lat: number, lng: number): ArcProjection {
+  const { stations, arcM } = arc;
+
+  if (stations.length === 1) {
+    const distM = haversine(lat, lng, stations[0].lat, stations[0].lng) * 1000;
+    return { arcM: 0, perpDistanceM: distM, segmentIndex: 0 };
+  }
+
+  let bestPerpM = Infinity;
+  let bestArcM = 0;
+  let bestSegIdx = 0;
+
+  for (let i = 0; i < stations.length - 1; i++) {
+    const a = stations[i];
+    const b = stations[i + 1];
+    const mPerLng = metersPerDegLng(a.lat);
+    const bx = (b.lng - a.lng) * mPerLng;
+    const by = (b.lat - a.lat) * METERS_PER_DEG_LAT;
+    const px = (lng - a.lng) * mPerLng;
+    const py = (lat - a.lat) * METERS_PER_DEG_LAT;
+    const segLenSq = bx * bx + by * by;
+    let t = 0;
+    if (segLenSq > 0) {
+      t = (px * bx + py * by) / segLenSq;
+      if (t < 0) t = 0;
+      else if (t > 1) t = 1;
+    }
+    const closestX = t * bx;
+    const closestY = t * by;
+    const perp = Math.hypot(px - closestX, py - closestY);
+    if (perp < bestPerpM) {
+      bestPerpM = perp;
+      const segLenM = Math.sqrt(segLenSq);
+      bestArcM = arcM[i] + t * segLenM;
+      bestSegIdx = i;
+    }
+  }
+
+  return { arcM: bestArcM, perpDistanceM: bestPerpM, segmentIndex: bestSegIdx };
+}
+
+/**
+ * progressM(경로 시작점부터 누적거리)에 해당하는 현재/다음/이전 역 정보.
+ * current = arc 기준 최단 거리 역. next/prev = 해당 역의 다음/이전 인덱스 역(경로 진행 방향).
+ */
+export function stationAtProgress(arc: RouteArc, progressM: number): RoutePositionInfo {
+  const { stations, arcM, totalLengthM } = arc;
+
+  if (stations.length === 1) {
+    return {
+      current: stations[0],
+      next: null,
+      prev: null,
+      distanceToCurrentM: 0,
+      distanceToNextM: null,
+    };
+  }
+
+  const p = Math.max(0, Math.min(progressM, totalLengthM));
+
+  let currentIdx = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < arcM.length; i++) {
+    const d = Math.abs(arcM[i] - p);
+    if (d < bestDist) {
+      bestDist = d;
+      currentIdx = i;
+    }
+  }
+
+  const next = currentIdx + 1 < stations.length ? stations[currentIdx + 1] : null;
+  const prev = currentIdx > 0 ? stations[currentIdx - 1] : null;
+  const distanceToNextM = next ? Math.max(0, arcM[currentIdx + 1] - p) : null;
+
+  return {
+    current: stations[currentIdx],
+    next,
+    prev,
+    distanceToCurrentM: Math.abs(arcM[currentIdx] - p),
+    distanceToNextM,
+  };
+}


### PR DESCRIPTION
Closes #308

## 배경
사용자 보고: 실제는 어린이대공원역인데 사가정역으로 표시되고 흔들림. 두 역은 같은 7호선이지만 약 4km 떨어진 별개 구간. 기존 코드는 528개 전 역을 2D 거리로 단순 비교해 단일 GPS 샘플로 즉시 화면을 바꿈.

업계·학계 조사 결과 메이저 앱(카카오 FIN / 네이버 NBP)도 GPS 단독으로는 지하철 현재역을 풀지 않음. 학계 표준은 **트랙 1D map matching + particle filter/HMM**(Saab IEEE 2000, Heirich Hindawi 2016).

## 변경 (Phase A)

**Route-Locked Map Matching**: 경로가 설정된 동안 사용자 상태를 "경로 위 진행도(arcM)" 단일 값으로 모델링. 현재역 = 진행도에 가장 가까운 경로상 역.

- 모션 모델: 직전 속도 × 경과 시간으로 progress 자동 증가 (GPS tick 사이 보간).
- GPS observation: 좌표를 경로 polyline에 수직 사영. accuracy 가중치로 dead-reckoning과 blend.
- 점프 거부: 마지막 채택 관측 기준 implied speed가 200 km/h 초과면 그 관측 무시. 연속 점프도 trusted baseline으로 끝까지 차단.
- 경로 이탈: 경로에서 1.5km 이상 벗어난 좌표는 progress 보정에 쓰지 않음.
- 초기화: 첫 관측이 경로 안이면 사영점에 snap, 밖이면 origin(arc=0)에서 시작.

### 신규/변경 파일
- `src/utils/routeProgress.ts` (신규): `computeRouteArc`, `nearestArcPoint`, `stationAtProgress` 순수 함수
- `src/hooks/useRouteProgress.ts` (신규): 진행도 상태 머신
- `src/hooks/useFusedNearestStation.ts`: optional `routeContext` prop. progress.position이 있으면 result 덮어쓴다
- `src/constants/routeProgress.ts` (신규): 임계값 분리
- `src/utils/pickFusedStation.ts`: FusionSource/Confidence에 `'route-progress'` 추가

## 본 PR 범위 밖 (별도 이슈)
- 앱 화면(app/(tabs)/index.tsx)에 routeContext 실제 주입 — 트립 origin 캡처 로직 필요.
- Phase B: arrival/position observation을 progress 보정으로 통합.
- 알람 누락 문제(별개 이슈).

## Test Plan
- [x] `npm run type-check` 통과
- [x] `npm test`: 77 suites, 1067 tests, 커버리지 100% (lines/funcs/branches/statements)
- [x] code-review agent 통과 (P1 4건 수정: trusted baseline, 첫 관측 off-route 안전, 인접역 거리 가드, route-progress source/confidence)
- [ ] 실기기 회귀: 어린이대공원 ↔ 사가정 점프 재현 시 화면 안정 (Phase A 단독으론 wiring 없어서 후속 PR 필요)