### PR TITLE
feat(#310): useFusedNearestStation에 routeContext 주입 (앱 wiring)

### DIFF
--- a/.maestro/flows/location/04_route_locked_jump_rejection.yaml
+++ b/.maestro/flows/location/04_route_locked_jump_rejection.yaml
@@ -1,0 +1,70 @@
+appId: com.subwaynow.app
+name: "위치 - 경로 잠금 점프 거부 (#310)"
+# #308 진행도 모델 + #310 wiring 회귀 방지.
+# 사가정 → 어린이대공원 경로 설정 후 GPS를 어린이대공원 좌표로 순간 이동시켜도
+# (implied speed > 200km/h 이므로 점프 거부) 화면 역이 사가정으로 유지되는지 검증.
+---
+# 1. 사가정역(7호선) 좌표로 시작
+- setLocation:
+    latitude: 37.580894
+    longitude: 127.088478
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+# 사가정 감지 확인
+- extendedWaitUntil:
+    visible:
+      text: "사가정"
+    timeout: 15000
+
+# 2. 어린이대공원을 목적지로 설정 (트립 origin = 사가정 캡처)
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 10000
+
+- tapOn:
+    id: "destination-button"
+
+- assertVisible:
+    id: "search-input"
+
+- tapOn:
+    id: "search-input"
+- inputText: "어린이대공원"
+
+- assertVisible:
+    id: "suggestions-list"
+
+- tapOn:
+    id: "suggestion-item-7-018"
+
+# 목적지 설정 확인
+- assertVisible:
+    id: "destination-clear-button"
+
+# 3. GPS를 어린이대공원 좌표로 "점프" — 지하 GPS 튐 시뮬레이션
+# 사가정-어린이대공원 직선거리 약 3.7km. 30s 폴링 한 틱에 이동했다고 가정하면
+# implied speed ≈ 123 m/s ≈ 444 km/h → MAX_PLAUSIBLE_MPS(55 m/s) 초과 → 거부.
+- setLocation:
+    latitude: 37.548014
+    longitude: 127.074658
+
+# 4. 폴링 2~3틱(약 60~90s) 대기 후에도 origin hero가 여전히 사가정인지 확인
+- extendedWaitUntil:
+    visible:
+      text: "사가정"
+    timeout: 90000
+
+# 5. 화면 hero에 어린이대공원이 origin으로 뜨면 안 됨 (목적지 표시는 별개)
+# DestinationPicker가 닫힌 상태에서 어린이대공원은 "Route to" 섹션에만 보여야 한다.
+# hero 자리(현재역)에는 사가정이 그대로 — 위 단언으로 충분.

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,11 +11,13 @@ import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
+import type { Station } from '../../src/types/station';
 import { EditorialTimeline } from '../../src/components/EditorialTimeline';
 import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/journeyAdapter';
 import { getStationDisplayName } from '../../src/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
+import { useTripOrigin } from '../../src/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ROUTE_KEY } from '../../src/constants/storageKeys';
@@ -30,12 +32,9 @@ const logger = createLogger('HomeScreen');
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh, confidence } = useFusedNearestStation();
   const customOrigin = useAppStore((s) => s.customOrigin);
   const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
-  const isCustomOrigin = customOrigin !== null;
-  const effectiveOrigin = customOrigin ?? result?.station ?? null;
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
   const favorites = useAppStore((s) => s.favorites);
@@ -63,6 +62,20 @@ export default function HomeScreen() {
   const [selectedKey, setSelectedKey] = useState<RoutePreference>(routePreference);
   const route: Route =
     categorized.find((r) => r.category.key === selectedKey)?.candidate.route ?? null;
+
+  // 트립 origin은 destination 설정 시점에 캡처되어 trip 동안 고정 (useTripOrigin 참조).
+  // useFusedNearestStation 첫 호출 시점엔 routeContext=undefined로 GPS fusion fallback,
+  // 다음 렌더에서 useTripOrigin이 effectiveOrigin을 캡처해 setTripOrigin을 호출하면
+  // routeContext가 채워지고 useRouteProgress(1D map matching)가 활성화된다.
+  const [tripOrigin, setTripOrigin] = useState<Station | null>(null);
+  const routeContext = useMemo(
+    () => (route && tripOrigin && destination ? { route, origin: tripOrigin, destination } : undefined),
+    [route, tripOrigin, destination],
+  );
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh, confidence } = useFusedNearestStation(undefined, undefined, routeContext);
+  const isCustomOrigin = customOrigin !== null;
+  const effectiveOrigin = customOrigin ?? result?.station ?? null;
+  useTripOrigin(destination, effectiveOrigin, setTripOrigin);
   const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(
     route ? (effectiveOrigin?.name ?? null) : null,
   );

--- a/src/hooks/__tests__/useTripOrigin.test.ts
+++ b/src/hooks/__tests__/useTripOrigin.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-native';
+import { useTripOrigin } from '../useTripOrigin';
+import type { Station } from '../../types/station';
+
+function makeStation(id: string, name: string): Station {
+  return {
+    id,
+    name,
+    line: '7',
+    lineColor: '#000',
+    lat: 0,
+    lng: 0,
+  };
+}
+
+const stationA = makeStation('7-001', 'A');
+const stationB = makeStation('7-002', 'B');
+const stationC = makeStation('7-003', 'C');
+
+describe('useTripOrigin', () => {
+  it('destination이 처음부터 null이면 setter를 호출하지 않는다 (이미 null이므로 noop)', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ origin }: { origin: Station | null }) => useTripOrigin(null, origin, setter),
+      { initialProps: { origin: stationA as Station | null } },
+    );
+    expect(setter).not.toHaveBeenCalled();
+    rerender({ origin: stationB });
+    rerender({ origin: null });
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('destination이 처음 set되는 순간 effectiveOrigin을 캡처한다', () => {
+    const setter = jest.fn();
+    renderHook(() => useTripOrigin(stationB, stationA, setter));
+    expect(setter).toHaveBeenCalledWith(stationA);
+  });
+
+  it('첫 set 시 effectiveOrigin이 null이면 다음 렌더에서 lazily 캡처한다', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ dest, origin }: { dest: Station | null; origin: Station | null }) =>
+        useTripOrigin(dest, origin, setter),
+      { initialProps: { dest: stationB, origin: null } },
+    );
+    expect(setter).toHaveBeenLastCalledWith(null);
+    setter.mockClear();
+    rerender({ dest: stationB, origin: stationA });
+    expect(setter).toHaveBeenCalledWith(stationA);
+  });
+
+  it('destination이 같은 동안 effectiveOrigin이 바뀌어도 tripOrigin은 갱신하지 않는다', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ dest, origin }: { dest: Station | null; origin: Station | null }) =>
+        useTripOrigin(dest, origin, setter),
+      { initialProps: { dest: stationB, origin: stationA } },
+    );
+    expect(setter).toHaveBeenCalledWith(stationA);
+    setter.mockClear();
+    rerender({ dest: stationB, origin: stationC });
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('destination이 다른 역으로 바뀌면 새 effectiveOrigin으로 재캡처한다', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ dest, origin }: { dest: Station | null; origin: Station | null }) =>
+        useTripOrigin(dest, origin, setter),
+      { initialProps: { dest: stationB, origin: stationA } },
+    );
+    setter.mockClear();
+    rerender({ dest: stationC, origin: stationB });
+    expect(setter).toHaveBeenCalledWith(stationB);
+  });
+
+  it('destination이 null로 바뀌면 tripOrigin을 null로 클리어한다', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ dest, origin }: { dest: Station | null; origin: Station | null }) =>
+        useTripOrigin(dest, origin, setter),
+      { initialProps: { dest: stationB as Station | null, origin: stationA as Station | null } },
+    );
+    setter.mockClear();
+    rerender({ dest: null, origin: stationA });
+    expect(setter).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/hooks/useTripOrigin.ts
+++ b/src/hooks/useTripOrigin.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import type { Station } from '../types/station';
+
+/**
+ * destination이 설정/변경되는 순간의 origin을 캡처해 trip 동안 고정한다.
+ *
+ * useFusedNearestStation의 routeContext.origin에 매 폴링마다 흔들리는 effectiveOrigin을
+ * 직접 넘기면 useRouteProgress의 arc useMemo deps가 흔들려 진행도 state가 0으로 리셋된다
+ * (`useRouteProgress.ts`의 useEffect([arc])). 트립 단위로 안정된 origin이 필요.
+ *
+ * 캡처 규칙:
+ * - destination null → tripOrigin null
+ * - destination 변경(또는 첫 set) → 그 시점의 effectiveOrigin으로 캡처
+ * - 첫 캡처 시 effectiveOrigin이 아직 null이면 다음 effect에서 lazily 캡처
+ * - destination이 같은 동안 effectiveOrigin이 바뀌어도 tripOrigin은 유지
+ *
+ * setter 패턴 사용 — state 반환형보다 이 hook에서 적합한 이유:
+ * routeContext가 useFusedNearestStation 호출 시점에 필요하고 tripOrigin은 그 호출 결과(effectiveOrigin)에
+ * 의존하는 cycle 구조라, 호출 측이 이미 useState로 tripOrigin을 보관해야 한다. state 반환형으로 가면
+ * routeContext용 별도 useState+useEffect sync가 또 필요해 오히려 코드가 늘어난다. setter를 받아
+ * 호출 측 useState를 그대로 갱신하는 게 가장 단순하다.
+ */
+export function useTripOrigin(
+  destination: Station | null,
+  effectiveOrigin: Station | null,
+  setTripOrigin: (origin: Station | null) => void,
+): void {
+  const tripDestIdRef = useRef<string | null>(null);
+  const tripOriginRef = useRef<Station | null>(null);
+
+  useEffect(() => {
+    const destId = destination?.id ?? null;
+    if (destId !== tripDestIdRef.current) {
+      tripDestIdRef.current = destId;
+      const next = destination ? effectiveOrigin : null;
+      tripOriginRef.current = next;
+      setTripOrigin(next);
+      return;
+    }
+    if (destination && !tripOriginRef.current && effectiveOrigin) {
+      tripOriginRef.current = effectiveOrigin;
+      setTripOrigin(effectiveOrigin);
+    }
+  }, [destination, effectiveOrigin, setTripOrigin]);
+}


### PR DESCRIPTION
## Summary

#308 Phase A에서 도입된 경로 기반 1D map matching 인프라(`useRouteProgress`, `useFusedNearestStation`의 routeContext 옵셔널 파라미터)가 머지됐으나, `app/(tabs)/index.tsx`에서 `useFusedNearestStation()`를 routeContext 없이 호출 중이라 진행도 모델이 한 번도 활성화되지 않았다. 이번 PR이 wiring을 채워 지하 GPS 튐으로 발생하는 **사가정↔어린이대공원 점프 버그**를 막는다.

- `useTripOrigin` hook 신설 — destination 설정 시점에 effectiveOrigin을 캡처해 trip 동안 고정
- `useFusedNearestStation`에 `{ route, origin: tripOrigin, destination }` routeContext 주입
- 6 케이스 단위 테스트 (100% 커버리지 유지)

## 왜 트립 origin을 따로 캡처하는가

`effectiveOrigin = customOrigin ?? result?.station`은 매 fusion 폴링마다 흔들릴 수 있다. 이걸 그대로 routeContext.origin에 넘기면 `useRouteProgress`의 arc useMemo deps가 흔들려 progress state가 0으로 리셋되는 회귀(arc 재계산 시 `useEffect([arc])`가 stateRef 초기화)가 발생한다. 따라서 trip 단위로 안정된 origin이 필요.

## setter 패턴을 선택한 이유

`tripOrigin ↔ effectiveOrigin ↔ result ↔ routeContext` 의 cycle 구조라 호출 측이 이미 useState로 tripOrigin을 보관해야 한다. state 반환형으로 가면 routeContext용 별도 useState+useEffect sync가 또 필요해져 오히려 코드가 늘어남.

## Test plan

- [x] `npm test` — 1073/1073 passed, 100% 커버리지 유지
- [x] `npm run type-check` — 통과
- [ ] 실기기: 사가정역 부근에서 어린이대공원 방향 경로 설정 후 지하 진입 시 점프 발생 안 함
- [ ] 디버그 모달(#283)에서 confidence가 `route-progress`로 표시되는지
- [ ] 목적지 해제 시 GPS fusion으로 자연 복귀

## 후속 (별개 이슈)

- Phase B: arrival/position 신호 → progress 보정 격상
- 알람 트리거를 progress + distanceToNextM 기반으로 전환 (accuracy 200m 게이트 우회)
- customOrigin이 트립 도중 바뀌는 경우 routeContext.origin stale 처리 (P2)
- `useFusedNearestStation` 시그니처를 options 객체로 리팩토링 (P2, 별도 chore)

Closes #310