### PR TITLE
chore(#312): iOS buildNumber 39 → 42

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -24,7 +24,7 @@ module.exports = {
       supportsTablet: false,
       bundleIdentifier: 'com.subwaynow.app',
       appleTeamId: '4755N5H4T4',
-      buildNumber: '39',
+      buildNumber: '42',
       infoPlist: {
         NSAppTransportSecurity: {
           NSExceptionDomains: {


### PR DESCRIPTION
## Summary
- TestFlight 업로드 실패 — 현재 buildNumber 39, ASC에 이미 41 존재해 Apple이 거부
- 41보다 큰 값(42)으로 단순 bump → 다음 `eas submit` 가능 상태로 복구
- autoIncrement는 `appVersionSource:"local"` 조합에서 빌드 후 로컬 파일을 다시 써 매 빌드마다 커밋 필요 → 진정한 자동화 아님. `appVersionSource:"remote"` 전환과 함께 별도 PR로 분리

## Test plan
- [x] npm test (1067/1067, 커버리지 100%)
- [x] npm run type-check
- [x] code-review 에이전트 통과 (P1 수용해 autoIncrement 분리)
- [ ] 머지 후 \`eas build --profile production --platform ios --auto-submit\` → TestFlight 업로드 성공 확인

Closes #312