### PR TITLE
chore(#314): v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- TestFlight 업로드 거부 ("You've already submitted this version of the app") 해소
- semver 1.2.0 → 1.2.1 (expo.version은 app.config.js가 package.json을 참조)

## Test plan
- [x] npm test (1067/1067, 커버리지 100%)
- [x] npm run type-check
- [ ] 머지 후 \`eas build --profile production --platform ios --auto-submit\` → TestFlight 업로드 성공 확인

Closes #314