### PR TITLE
fix(#318): useNearestStation throttle 분리 — userLocation 즉시 갱신

### DIFF
--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -350,7 +350,7 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalled();
   });
 
-  it('같은 역 좌표 반복 시 setState는 최초 1회만 호출된다', async () => {
+  it('같은 역 좌표 반복 시 result/variants는 throttle되어 동일 reference를 유지한다', async () => {
     mockGranted();
 
     const { result } = renderHook(() => useNearestStation());
@@ -361,13 +361,38 @@ describe('useNearestStation', () => {
 
     await waitFor(() => expect(result.current.result?.station.name).toBe('강남'));
 
-    const firstLocation = result.current.userLocation;
+    const firstResult = result.current.result;
+    const firstVariants = result.current.variants;
 
-    // 같은 좌표로 다시 콜백 (거리 변화 <10m)
+    // 같은 좌표로 다시 콜백 (거리 변화 <3m) — 표시값은 throttle
     simulateGps(37.4980, 127.0277);
 
-    // userLocation이 변경되지 않아야 함
-    expect(result.current.userLocation).toBe(firstLocation);
+    expect(result.current.result).toBe(firstResult);
+    expect(result.current.variants).toBe(firstVariants);
+  });
+
+  it('3m 미만 이동이어도 userLocation/speedMps/accuracyMeters는 매 fix마다 갱신된다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, { speed: 1.2, accuracy: 15 });
+
+    await waitFor(() => expect(result.current.userLocation).not.toBeNull());
+
+    const firstResult = result.current.result;
+
+    // 1m 미만 이동 — throttle 안으로 떨어지는 변화
+    simulateGps(37.49801, 127.02771, { speed: 1.5, accuracy: 18 });
+
+    // raw 신호는 갱신
+    expect(result.current.userLocation).toEqual({ lat: 37.49801, lng: 127.02771 });
+    expect(result.current.speedMps).toBe(1.5);
+    expect(result.current.accuracyMeters).toBe(18);
+    // 표시값은 throttle 유지
+    expect(result.current.result).toBe(firstResult);
   });
 
   it('findNearestStations가 null을 반환하면 result가 null이 된다', async () => {

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -62,13 +62,16 @@ export function useNearestStation(): UseNearestStationReturn {
     const distanceDelta = Math.abs(newDistance - lastDistanceRef.current);
     const noStation = !stationsResult && lastStationIdRef.current !== null;
 
+    // raw 신호는 매 fix 즉시 갱신. useFusedNearestStation의 candidates 메모가
+    // userLocation 변화에 의존하므로 throttle 안에 두면 천천히 이동할 때 후보가 잠긴다.
     setSpeedMps(speed != null && speed >= 0 ? speed : null);
     setAccuracyMeters(accuracy ?? null);
+    setUserLocation({ lat: latitude, lng: longitude });
 
+    // 표시값(result/variants)은 3m throttle 유지 — 잦은 리렌더 방지.
     if (stationChanged || distanceDelta > MIN_DISTANCE_CHANGE_KM || noStation) {
       lastStationIdRef.current = newId;
       lastDistanceRef.current = newDistance;
-      setUserLocation({ lat: latitude, lng: longitude });
       applyNearestResult(stationsResult, setResult, setVariants);
     }
   }, []);


### PR DESCRIPTION
## Summary

- `applyLocation`에서 `setUserLocation`/`setSpeedMps`/`setAccuracyMeters`를 3m throttle 밖으로 이동해 매 fix 즉시 갱신
- `setResult`/`setVariants`(표시값)만 3m throttle 유지 → 잦은 리렌더 방지 의도 보존
- 회귀 테스트: 표시값 referential equality(`result`/`variants`)로 throttle 의도 검증
- 신규 테스트: 3m 미만 이동에서도 `userLocation`/`speedMps`/`accuracyMeters`가 매 fix 갱신됨을 보증

## 배경

`useFusedNearestStation`의 `candidates` 메모가 `userLocation` 변화에 의존하는데, 기존 코드는 3m throttle 게이트 안에서 `setUserLocation`을 호출했다. 천천히 이동(3m 미만 변화)할 때 `userLocation`이 갱신되지 않아 fusion 후보가 잠기고 옛 후보 역만 폴링되는 현상이 발생했다.

## Test plan

- [x] `npx jest src/hooks/__tests__/useNearestStation.test.ts` — 34/34 pass
- [x] `npm test` — 1068/1068 pass, 100% 커버리지
- [x] `npm run type-check` — 통과
- [x] 코드 리뷰(code-review agent) — P0/P1 없음, 머지 가능 판정

Closes #318