### PR TITLE
feat(#319): pickCandidateTrains 유틸 추가

### DIFF
--- a/src/utils/__tests__/pickCandidateTrains.test.ts
+++ b/src/utils/__tests__/pickCandidateTrains.test.ts
@@ -1,0 +1,229 @@
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import type { LineNumber } from '../../types/station';
+import { pickCandidateTrains } from '../pickCandidateTrains';
+
+const LINE: LineNumber = '2';
+
+// 노선 2 정렬 순서: 시청, 을지로입구, 을지로3가, 을지로4가, 동대문역사문화공원, 신당, 상왕십리, 왕십리, 한양대, 뚝섬, 성수, 건대입구, 구의, 강변, 잠실나루
+function makeTrain(overrides: Partial<TrainPosition>): TrainPosition {
+  return {
+    statnId: 'X',
+    statnNm: '시청',
+    trainNo: '0001',
+    trainStatus: 1,
+    updnLine: 0,
+    terminalStationId: 'X',
+    terminalStationName: '성수',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_000,
+    ...overrides,
+  };
+}
+
+function makeLine(trains: TrainPosition[], line: LineNumber = LINE): LinePositions {
+  return { line, trains };
+}
+
+describe('pickCandidateTrains', () => {
+  it('returns [] when no positions match the requested line', () => {
+    const result = pickCandidateTrains({
+      positions: [makeLine([makeTrain({})], '1')],
+      line: LINE,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] for empty positions', () => {
+    expect(pickCandidateTrains({ positions: [], line: LINE })).toEqual([]);
+  });
+
+  it('rejects trains with unknown updnLine sentinel (-1 or other non-{0,1})', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'A', updnLine: -1 }),
+          makeTrain({ trainNo: 'B', updnLine: 2 }),
+          makeTrain({ trainNo: 'OK', updnLine: 0 }),
+        ]),
+      ],
+      line: LINE,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['OK']);
+  });
+
+  it('rejects stale trains (receivedAtMs <= 0)', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'A', receivedAtMs: 0 }),
+          makeTrain({ trainNo: 'B', receivedAtMs: -1 }),
+          makeTrain({ trainNo: 'C', receivedAtMs: 100 }),
+        ]),
+      ],
+      line: LINE,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['C']);
+  });
+
+  it('filters by direction when specified', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'UP', updnLine: 0 }),
+          makeTrain({ trainNo: 'DN', updnLine: 1 }),
+        ]),
+      ],
+      line: LINE,
+      direction: 1,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ trainNo: 'DN', direction: 1 });
+  });
+
+  it('passes both directions through when direction is undefined', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'UP', updnLine: 0, statnNm: '시청' }),
+          makeTrain({ trainNo: 'DN', updnLine: 1, statnNm: '을지로입구' }),
+        ]),
+      ],
+      line: LINE,
+    });
+    expect(result.map((t) => `${t.trainNo}:${t.direction}`)).toEqual(['DN:1', 'UP:0']);
+  });
+
+  it('keeps only trains within ±windowStations of anchor', () => {
+    // anchor=신당(idx 5), window=2 → idx 3..7
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'IN', statnNm: '동대문역사문화공원' }), // idx 4
+          makeTrain({ trainNo: 'EDGE', statnNm: '상왕십리' }), // idx 6
+          makeTrain({ trainNo: 'OUT', statnNm: '시청' }), // idx 0
+        ]),
+      ],
+      line: LINE,
+      anchorStationName: '신당',
+      windowStations: 2,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['EDGE', 'IN']);
+  });
+
+  it('skips window filter when anchor station is not on the line', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'A', statnNm: '시청' }),
+          makeTrain({ trainNo: 'B', statnNm: '강변' }),
+        ]),
+      ],
+      line: LINE,
+      anchorStationName: '없는역',
+      windowStations: 1,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['A', 'B']);
+  });
+
+  it('excludes trains whose statnNm is not on the line', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'GOOD', statnNm: '시청' }),
+          makeTrain({ trainNo: 'BAD', statnNm: '없는역' }),
+        ]),
+      ],
+      line: LINE,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['GOOD']);
+  });
+
+  it('sorts by |Δindex| from anchor with trainNo tie-break', () => {
+    // anchor=왕십리(idx 7)
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: '003', statnNm: '한양대' }), // |Δ|=1
+          makeTrain({ trainNo: '001', statnNm: '한양대' }), // |Δ|=1
+          makeTrain({ trainNo: '002', statnNm: '왕십리' }), // |Δ|=0
+        ]),
+      ],
+      line: LINE,
+      anchorStationName: '왕십리',
+      windowStations: 5,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['002', '001', '003']);
+  });
+
+  it('sorts by trainNo only when anchor is undefined', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'C', statnNm: '시청' }),
+          makeTrain({ trainNo: 'A', statnNm: '강변' }),
+          makeTrain({ trainNo: 'B', statnNm: '뚝섬' }),
+        ]),
+      ],
+      line: LINE,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('windowStations: 0 keeps only trains at the anchor station', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'AT', statnNm: '신당' }),
+          makeTrain({ trainNo: 'NEXT', statnNm: '상왕십리' }),
+        ]),
+      ],
+      line: LINE,
+      anchorStationName: '신당',
+      windowStations: 0,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['AT']);
+  });
+
+  it('clamps negative windowStations to 0', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({ trainNo: 'AT', statnNm: '신당' }),
+          makeTrain({ trainNo: 'NEAR', statnNm: '상왕십리' }),
+        ]),
+      ],
+      line: LINE,
+      anchorStationName: '신당',
+      windowStations: -1,
+    });
+    expect(result.map((t) => t.trainNo)).toEqual(['AT']);
+  });
+
+  it('maps fields correctly (trainNo/line/direction/currentStationName/trainStatus/receivedAtMs)', () => {
+    const result = pickCandidateTrains({
+      positions: [
+        makeLine([
+          makeTrain({
+            trainNo: '1234',
+            updnLine: 1,
+            statnNm: '뚝섬',
+            trainStatus: 2,
+            receivedAtMs: 9_999,
+          }),
+        ]),
+      ],
+      line: LINE,
+    });
+    expect(result).toEqual([
+      {
+        trainNo: '1234',
+        line: LINE,
+        direction: 1,
+        currentStationName: '뚝섬',
+        trainStatus: 2,
+        receivedAtMs: 9_999,
+      },
+    ]);
+  });
+});

--- a/src/utils/pickCandidateTrains.ts
+++ b/src/utils/pickCandidateTrains.ts
@@ -1,0 +1,71 @@
+import type { LinePositions } from '../api/positionApi';
+import type { LineNumber } from '../types/station';
+import { getStationsOnLine } from './stationRoute';
+
+export interface CandidateTrain {
+  trainNo: string;
+  line: LineNumber;
+  direction: 0 | 1;
+  currentStationName: string;
+  trainStatus: number;
+  receivedAtMs: number;
+}
+
+export interface PickCandidateTrainsInput {
+  positions: LinePositions[];
+  line: LineNumber;
+  direction?: 0 | 1;
+  anchorStationName?: string;
+  windowStations?: number;
+}
+
+const DEFAULT_WINDOW_STATIONS = 3;
+
+export function pickCandidateTrains(input: PickCandidateTrainsInput): CandidateTrain[] {
+  const { positions, line, direction, anchorStationName, windowStations } = input;
+
+  const linePositions = positions.find((p) => p.line === line);
+  if (!linePositions) return [];
+
+  const stationsOnLine = getStationsOnLine(line);
+  const nameToIndex = new Map<string, number>();
+  stationsOnLine.forEach((s, i) => nameToIndex.set(s.name, i));
+
+  const window = Math.max(0, windowStations ?? DEFAULT_WINDOW_STATIONS);
+  const anchorIdx =
+    anchorStationName !== undefined ? nameToIndex.get(anchorStationName) : undefined;
+
+  const candidates: Array<{ candidate: CandidateTrain; sortKey: number }> = [];
+
+  for (const train of linePositions.trains) {
+    if (train.receivedAtMs <= 0) continue;
+    // positionApi가 파싱 실패 시 updnLine=-1을 sentinel로 내보낸다. 방향 모름은 후보에서 제외.
+    if (train.updnLine !== 0 && train.updnLine !== 1) continue;
+    if (direction !== undefined && train.updnLine !== direction) continue;
+
+    const stationIdx = nameToIndex.get(train.statnNm);
+    if (stationIdx === undefined) continue;
+
+    if (anchorIdx !== undefined && Math.abs(stationIdx - anchorIdx) > window) continue;
+
+    const sortKey = anchorIdx !== undefined ? Math.abs(stationIdx - anchorIdx) : 0;
+    candidates.push({
+      candidate: {
+        trainNo: train.trainNo,
+        line,
+        direction: train.updnLine,
+        currentStationName: train.statnNm,
+        trainStatus: train.trainStatus,
+        receivedAtMs: train.receivedAtMs,
+      },
+      sortKey,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (a.sortKey !== b.sortKey) return a.sortKey - b.sortKey;
+    return a.candidate.trainNo.localeCompare(b.candidate.trainNo);
+  });
+
+  return candidates.map((c) => c.candidate);
+}


### PR DESCRIPTION
## Summary
- Track B Phase 1-A: realtimePosition 결과에서 탑승 가능 trainNo 후보를 추리는 순수 함수 신규
- 필터: 방향, anchor 역 ±N 정거장 윈도우, stale(receivedAtMs<=0), updnLine sentinel(-1) 거부
- 정렬: anchor 인덱스 |Δ| 오름차순, tie-break trainNo 사전순
- 호출처 없음 — 다음 이슈에서 통합 예정

## 변경 파일
- 신규 `src/utils/pickCandidateTrains.ts`
- 신규 `src/utils/__tests__/pickCandidateTrains.test.ts` (14 cases, 100% coverage)

## Test plan
- [x] `npm test` 1081 pass / 100% coverage 유지
- [x] `npm run type-check` 통과
- [x] code-review 에이전트 P1 반영 (`updnLine` sentinel 누수 차단)

Closes #319