### PR TITLE
feat(#317): 디버그 모달 fusion 신호 stamp 보강

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -11,9 +11,11 @@ import {
   View,
 } from 'react-native';
 import { useAppStore } from '../store/useAppStore';
-import { useNearestStation } from '../hooks/useNearestStation';
+import { useFusedNearestStation } from '../hooks/useFusedNearestStation';
 import { useArrivalInfo } from '../hooks/useArrivalInfo';
 import { clearAlarmLog, getAlarmLog, type AlarmLogEntry } from '../utils/alarmLog';
+import type { FusionConfidence, FusionSource } from '../utils/pickFusedStation';
+import type { NearestStationResult } from '../types/station';
 import { useTheme, spacing, radius, typography } from '../theme';
 
 function formatTime(ts: number): string {
@@ -39,12 +41,34 @@ function formatLogLine(entry: AlarmLogEntry): string {
   return parts.join(' | ');
 }
 
+function formatStationLabel(res: NearestStationResult | null): string {
+  if (!res) return '-';
+  return `${res.station.name}(${res.station.line}) · ${Math.round(res.distanceKm * 1000)}m`;
+}
+
+function fusedDiffersFromGps(
+  fused: NearestStationResult | null,
+  gps: NearestStationResult | null,
+): boolean {
+  if (!fused || !gps) return false;
+  return fused.station.id !== gps.station.id;
+}
+
 function buildDumpText(args: {
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
+  accuracyMeters: number | null;
   nearestName: string | null;
   nearestDistanceM: number | null;
   variants: string[];
+  fusion: {
+    confidence: FusionConfidence;
+    source: FusionSource;
+    fusedLabel: string;
+    gpsLabel: string;
+    differs: boolean;
+    candidateTrains: string[] | null;
+  };
   arrivalSummary: string;
   isMock: boolean;
   logs: AlarmLogEntry[];
@@ -55,7 +79,7 @@ function buildDumpText(args: {
   lines.push('## GPS');
   lines.push(
     args.userLocation
-      ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s`
+      ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`
       : '(no location)',
   );
   lines.push('');
@@ -67,6 +91,17 @@ function buildDumpText(args: {
   );
   if (args.variants.length > 0) {
     lines.push(`variants: ${args.variants.join(', ')}`);
+  }
+  lines.push('');
+  lines.push('## Fusion');
+  lines.push(`confidence=${args.fusion.confidence}, source=${args.fusion.source}`);
+  lines.push(`fused: ${args.fusion.fusedLabel}`);
+  lines.push(`gps:   ${args.fusion.gpsLabel}`);
+  if (args.fusion.differs) lines.push('(fused != gps)');
+  if (args.fusion.candidateTrains) {
+    lines.push(
+      `candidateTrains(${args.fusion.candidateTrains.length}): ${args.fusion.candidateTrains.join(', ') || '-'}`,
+    );
   }
   lines.push('');
   lines.push('## Arrival');
@@ -82,22 +117,40 @@ function buildDumpText(args: {
 
 interface DebugModalProps {
   onClose: () => void;
+  /**
+   * Phase 1 (Position-first fusion) 결정 신호. 후보 trainNo 목록.
+   * 현재는 useFusedNearestStation이 노출하지 않아 호출부가 명시적으로 전달.
+   * 미전달이면 섹션에서 "(n/a)"로 표기.
+   */
+  candidateTrains?: string[];
 }
 
 // 디버그 모달은 측정 인프라 — 관찰자 효과를 피하려고 모달이 열린 동안에만 마운트한다.
 // useNearestStation이 별도 Location.watch 구독을 띄우므로, 닫혔을 땐 컴포넌트 자체를
 // 마운트하지 않아 GPS·Arrival 폴링이 2배가 되지 않도록 한다. 호출부(_layout)에서
 // `debugVisible &&` 조건부 렌더를 보장한다.
-export function DebugModal({ onClose }: DebugModalProps) {
+export function DebugModal(props: DebugModalProps) {
   if (!__DEV__) return null;
-  return <DebugModalInner onClose={onClose} />;
+  return <DebugModalInner {...props} />;
 }
 
-function DebugModalInner({ onClose }: DebugModalProps) {
+function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
   const { colors } = useTheme();
-  const { result, variants, userLocation, speedMps } = useNearestStation();
+  const {
+    result,
+    gpsResult,
+    confidence,
+    source,
+    variants,
+    userLocation,
+    speedMps,
+    accuracyMeters,
+  } = useFusedNearestStation();
   const stationName = result?.station.name ?? null;
   const { arrival, isMock } = useArrivalInfo(stationName);
+  const fusedLabel = formatStationLabel(result);
+  const gpsLabel = formatStationLabel(gpsResult);
+  const differs = fusedDiffersFromGps(result, gpsResult);
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
 
   const refreshLogs = useCallback(async () => {
@@ -137,15 +190,40 @@ function DebugModalInner({ onClose }: DebugModalProps) {
     const message = buildDumpText({
       userLocation,
       speedMps,
+      accuracyMeters,
       nearestName: result?.station.name ?? null,
       nearestDistanceM,
       variants: variantNames,
+      fusion: {
+        confidence,
+        source,
+        fusedLabel,
+        gpsLabel,
+        differs,
+        candidateTrains: candidateTrains ?? null,
+      },
       arrivalSummary,
       isMock,
       logs,
     });
     void Share.share({ message });
-  }, [userLocation, speedMps, result, nearestDistanceM, variantNames, arrivalSummary, isMock, logs]);
+  }, [
+    userLocation,
+    speedMps,
+    accuracyMeters,
+    result,
+    nearestDistanceM,
+    variantNames,
+    confidence,
+    source,
+    fusedLabel,
+    gpsLabel,
+    differs,
+    candidateTrains,
+    arrivalSummary,
+    isMock,
+    logs,
+  ]);
 
   return (
     <Modal visible animationType="slide" onRequestClose={onClose} testID="debug-modal">
@@ -172,10 +250,39 @@ function DebugModalInner({ onClose }: DebugModalProps) {
                   value={speedMps != null ? `${speedMps.toFixed(2)} m/s` : '-'}
                   colors={colors}
                 />
+                <KeyValue
+                  label="accuracy"
+                  value={accuracyMeters != null ? `${accuracyMeters.toFixed(0)} m` : '-'}
+                  colors={colors}
+                />
               </>
             ) : (
               <Text style={[typography.mono, { color: colors.muted }]}>(no location)</Text>
             )}
+          </Section>
+
+          <Section title="Fusion" colors={colors}>
+            <KeyValue label="confidence" value={confidence} colors={colors} />
+            <KeyValue label="source" value={source} colors={colors} />
+            <KeyValue label="fused" value={fusedLabel} colors={colors} />
+            <KeyValue label="gps" value={gpsLabel} colors={colors} />
+            {differs && (
+              <Text
+                style={[typography.mono, { color: colors.warn, marginTop: spacing.xs }]}
+                testID="debug-fusion-diff"
+              >
+                fused != gps
+              </Text>
+            )}
+            <KeyValue
+              label="candidates"
+              value={
+                candidateTrains
+                  ? `${candidateTrains.length}: ${candidateTrains.join(', ') || '-'}`
+                  : '(n/a)'
+              }
+              colors={colors}
+            />
           </Section>
 
           <Section title="Nearest station" colors={colors}>

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -7,13 +7,13 @@ import type { AlarmLogEntry } from '../../utils/alarmLog';
 import type { Station, NearestStationResult } from '../../types/station';
 import type { StationArrival } from '../../api/arrivalApi';
 
-const mockUseNearestStation = jest.fn();
+const mockUseFusedNearestStation = jest.fn();
 const mockUseArrivalInfo = jest.fn();
 const mockGetAlarmLog = jest.fn();
 const mockClearAlarmLog = jest.fn();
 
-jest.mock('../../hooks/useNearestStation', () => ({
-  useNearestStation: () => mockUseNearestStation(),
+jest.mock('../../hooks/useFusedNearestStation', () => ({
+  useFusedNearestStation: () => mockUseFusedNearestStation(),
 }));
 jest.mock('../../hooks/useArrivalInfo', () => ({
   useArrivalInfo: (name: string | null) => mockUseArrivalInfo(name),
@@ -59,11 +59,15 @@ const baseArrival: StationArrival = {
 };
 
 const setupHookDefaults = () => {
-  mockUseNearestStation.mockReturnValue({
+  mockUseFusedNearestStation.mockReturnValue({
     result: baseResult,
+    gpsResult: baseResult,
+    confidence: 'gps-only',
+    source: 'gps',
     variants: [station, variantStation],
     userLocation: { lat: 37.5, lng: 127.0 },
     speedMps: 1.5,
+    accuracyMeters: 20,
     loading: false,
     error: null,
     permissionDenied: false,
@@ -117,11 +121,15 @@ describe('DebugModal', () => {
   });
 
   it('userLocation이 null이면 "no location"을 표시한다', () => {
-    mockUseNearestStation.mockReturnValue({
+    mockUseFusedNearestStation.mockReturnValue({
       result: null,
+      gpsResult: null,
+      confidence: 'gps-only',
+      source: 'gps',
       variants: [],
       userLocation: null,
       speedMps: null,
+      accuracyMeters: null,
       loading: false,
       error: null,
       permissionDenied: false,
@@ -159,18 +167,22 @@ describe('DebugModal', () => {
   });
 
   it('speedMps가 null이면 "-"를 표시한다', () => {
-    mockUseNearestStation.mockReturnValue({
+    mockUseFusedNearestStation.mockReturnValue({
       result: baseResult,
+      gpsResult: baseResult,
+      confidence: 'gps-only',
+      source: 'gps',
       variants: [],
       userLocation: { lat: 37.5, lng: 127.0 },
       speedMps: null,
+      accuracyMeters: null,
       loading: false,
       error: null,
       permissionDenied: false,
       refresh: jest.fn(),
     });
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
-    expect(screen.getByText('-')).toBeTruthy();
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
   });
 
   it('알람 로그 비어있으면 (empty) 표시', async () => {
@@ -233,6 +245,60 @@ describe('DebugModal', () => {
     expect(mockGetAlarmLog).toHaveBeenCalledTimes(1);
   });
 
+  it('Fusion 섹션에 confidence/source/accuracy를 표시한다', async () => {
+    mockUseFusedNearestStation.mockReturnValue({
+      result: baseResult,
+      gpsResult: baseResult,
+      confidence: 'arrival-confirmed',
+      source: 'arrival',
+      variants: [],
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 1,
+      accuracyMeters: 12,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('Fusion')).toBeTruthy();
+    expect(screen.getByText('arrival-confirmed')).toBeTruthy();
+    expect(screen.getByText('arrival')).toBeTruthy();
+    expect(screen.getByText('12 m')).toBeTruthy();
+    expect(screen.queryByTestId('debug-fusion-diff')).toBeNull();
+    expect(screen.getByText('(n/a)')).toBeTruthy();
+  });
+
+  it('fused와 gps station id가 다르면 diff 라인을 표시한다', () => {
+    const otherStation: Station = { ...station, id: '2-099', name: '역삼' };
+    mockUseFusedNearestStation.mockReturnValue({
+      result: { station, distanceKm: 0.05 },
+      gpsResult: { station: otherStation, distanceKm: 0.18 },
+      confidence: 'arrival-arriving',
+      source: 'arrival',
+      variants: [],
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 1,
+      accuracyMeters: 10,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByTestId('debug-fusion-diff')).toBeTruthy();
+  });
+
+  it('candidateTrains prop을 받으면 개수와 목록을 표시한다', () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} candidateTrains={['T1', 'T2']} />);
+    expect(screen.getByText('2: T1, T2')).toBeTruthy();
+  });
+
+  it('candidateTrains가 빈 배열이면 "0: -"으로 표시한다', () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} candidateTrains={[]} />);
+    expect(screen.getByText('0: -')).toBeTruthy();
+  });
+
   it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
@@ -280,32 +346,97 @@ describe('DebugModal helpers', () => {
     expect(__test__.formatLogLine(entry)).toContain('acc=-');
   });
 
+  const baseFusion = {
+    confidence: 'gps-only' as const,
+    source: 'gps' as const,
+    fusedLabel: '강남(2) · 123m',
+    gpsLabel: '강남(2) · 123m',
+    differs: false,
+    candidateTrains: null as string[] | null,
+  };
+
   it('buildDumpText: 모든 섹션 포함', () => {
     const dump = __test__.buildDumpText({
       userLocation: { lat: 37.5, lng: 127.0 },
       speedMps: 2,
+      accuracyMeters: 30,
       nearestName: '강남',
       nearestDistanceM: 123,
       variants: ['강남(2)'],
+      fusion: baseFusion,
       arrivalSummary: 'up: 청량리 · 90s',
       isMock: true,
       logs: [{ ts: Date.now(), source: 'fg', outcome: 'fired', stationName: '강남' }],
     });
     expect(dump).toContain('## GPS');
+    expect(dump).toContain('accuracy=30 m');
     expect(dump).toContain('## Nearest');
     expect(dump).toContain('variants: 강남(2)');
+    expect(dump).toContain('## Fusion');
+    expect(dump).toContain('confidence=gps-only');
+    expect(dump).toContain('source=gps');
     expect(dump).toContain('## Arrival');
     expect(dump).toContain('(MOCK)');
     expect(dump).toContain('## Alarm log (1)');
+  });
+
+  it('buildDumpText: fused != gps이면 diff 라인을 추가한다', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 2,
+      accuracyMeters: 30,
+      nearestName: '강남',
+      nearestDistanceM: 123,
+      variants: [],
+      fusion: { ...baseFusion, fusedLabel: '역삼(2) · 200m', differs: true },
+      arrivalSummary: 'x',
+      isMock: false,
+      logs: [],
+    });
+    expect(dump).toContain('(fused != gps)');
+  });
+
+  it('buildDumpText: candidateTrains를 받으면 개수와 목록을 표기한다', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: { ...baseFusion, candidateTrains: ['T101', 'T202'] },
+      arrivalSummary: 'x',
+      isMock: false,
+      logs: [],
+    });
+    expect(dump).toContain('candidateTrains(2): T101, T202');
+  });
+
+  it('buildDumpText: candidateTrains가 빈 배열이면 "-"로 표기', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: { ...baseFusion, candidateTrains: [] },
+      arrivalSummary: 'x',
+      isMock: false,
+      logs: [],
+    });
+    expect(dump).toContain('candidateTrains(0): -');
   });
 
   it('buildDumpText: 빈 상태 표기', () => {
     const dump = __test__.buildDumpText({
       userLocation: null,
       speedMps: null,
+      accuracyMeters: null,
       nearestName: null,
       nearestDistanceM: null,
       variants: [],
+      fusion: baseFusion,
       arrivalSummary: '(no arrival data)',
       isMock: false,
       logs: [],
@@ -314,21 +445,25 @@ describe('DebugModal helpers', () => {
     expect(dump).toContain('(no nearest station)');
     expect(dump).not.toContain('variants:');
     expect(dump).not.toContain('(MOCK)');
+    expect(dump).not.toContain('candidateTrains');
     expect(dump).toContain('## Alarm log (0)');
   });
 
-  it('buildDumpText: userLocation은 있고 speedMps만 null이면 "-" 표기', () => {
+  it('buildDumpText: userLocation은 있고 speedMps/accuracy만 null이면 "-" 표기', () => {
     const dump = __test__.buildDumpText({
       userLocation: { lat: 37.5, lng: 127.0 },
       speedMps: null,
+      accuracyMeters: null,
       nearestName: '강남',
       nearestDistanceM: null,
       variants: [],
+      fusion: baseFusion,
       arrivalSummary: 'x',
       isMock: false,
       logs: [],
     });
     expect(dump).toContain('speed=- m/s');
+    expect(dump).toContain('accuracy=- m');
     expect(dump).toContain('강남 · - m');
   });
 
@@ -347,9 +482,13 @@ describe('DebugModal helpers', () => {
 describe('DebugModal arrival edge cases', () => {
   const baseHooks = {
     result: baseResult,
+    gpsResult: baseResult,
+    confidence: 'gps-only' as const,
+    source: 'gps' as const,
     variants: [],
     userLocation: { lat: 37.5, lng: 127.0 },
     speedMps: 1,
+    accuracyMeters: 15,
     loading: false,
     error: null,
     permissionDenied: false,
@@ -359,7 +498,7 @@ describe('DebugModal arrival edge cases', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetAlarmLog.mockResolvedValue([]);
-    mockUseNearestStation.mockReturnValue(baseHooks);
+    mockUseFusedNearestStation.mockReturnValue(baseHooks);
   });
 
   it('up.statusMessage가 빈 문자열이면 괄호를 붙이지 않는다', () => {
@@ -383,11 +522,15 @@ describe('DebugModal share with null nearest', () => {
     jest.clearAllMocks();
     mockGetAlarmLog.mockResolvedValue([]);
     mockClearAlarmLog.mockResolvedValue(undefined);
-    mockUseNearestStation.mockReturnValue({
+    mockUseFusedNearestStation.mockReturnValue({
       result: null,
+      gpsResult: null,
+      confidence: 'gps-only',
+      source: 'gps',
       variants: [],
       userLocation: null,
       speedMps: null,
+      accuracyMeters: null,
       loading: false,
       error: null,
       permissionDenied: false,


### PR DESCRIPTION
## Summary
- 디버그 모달이 `useFusedNearestStation`을 사용하도록 전환해 fusion 신호(confidence / source / gps-vs-fused diff / accuracy)를 라이브 뷰에 노출
- `candidateTrains`를 옵셔널 prop으로 reserve — Phase 1 (Position-first fusion) 결정 신호 wiring 준비
- Share dump 텍스트에도 fusion 메타 포함

## Test plan
- [x] `npm test` — 1074 tests pass, 100% coverage
- [x] `npm run type-check` — pass
- [x] DebugModal.tsx 100% coverage (lines / branches / functions / statements)

## 비고
- 측정 인프라 — 정책 변경 없음. Phase 1 효과 측정용
- 다음 단계: Phase 1 PR에서 `candidateTrains` 실제 값 전달

Closes #317