### PR TITLE
feat(#324): trackTrainProgress 유틸 추가

### DIFF
--- a/src/utils/__tests__/trackTrainProgress.test.ts
+++ b/src/utils/__tests__/trackTrainProgress.test.ts
@@ -1,6 +1,6 @@
 import type { CandidateTrain } from '../pickCandidateTrains';
 import type { LineNumber } from '../../types/station';
-import { trackTrainProgress } from '../trackTrainProgress';
+import { trackTrainProgress, type TrackTrainProgressInput } from '../trackTrainProgress';
 
 const LINE: LineNumber = '2';
 
@@ -21,6 +21,18 @@ function makeCandidate(overrides: Partial<CandidateTrain>): CandidateTrain {
 const NEAR_SICHEONG = { lat: 37.5636, lng: 126.9754 };
 const NEAR_EULJIRO_3GA = { lat: 37.5663, lng: 126.9917 };
 
+function pick(
+  pairs: Array<[string, string]>,
+  opts: Omit<TrackTrainProgressInput, 'candidates'> = {},
+) {
+  return trackTrainProgress({
+    candidates: pairs.map(([trainNo, currentStationName]) =>
+      makeCandidate({ trainNo, currentStationName }),
+    ),
+    ...opts,
+  });
+}
+
 describe('trackTrainProgress', () => {
   it('returns null for empty candidates', () => {
     expect(trackTrainProgress({ candidates: [] })).toBeNull();
@@ -39,130 +51,80 @@ describe('trackTrainProgress', () => {
   });
 
   it('returns null when single candidate station name is not on the line', () => {
-    const result = trackTrainProgress({
-      candidates: [makeCandidate({ currentStationName: '없는역' })],
-    });
-    expect(result).toBeNull();
+    expect(pick([['A', '없는역']])).toBeNull();
   });
 
   it('returns null when all multiple candidates fail station resolution', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'A', currentStationName: '없는역1' }),
-        makeCandidate({ trainNo: 'B', currentStationName: '없는역2' }),
-      ],
-    });
-    expect(result).toBeNull();
+    expect(pick([['A', '없는역1'], ['B', '없는역2']])).toBeNull();
   });
 
   it('drops to single when only one of many candidates resolves to a station', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'A', currentStationName: '없는역' }),
-        makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
-      ],
-    });
+    const result = pick([['A', '없는역'], ['B', '을지로입구']]);
     expect(result?.trainNo).toBe('B');
     expect(result?.confidence).toBe('single');
   });
 
   it('picks sticky when lastConfirmedTrainNo matches a resolved candidate', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
-        makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
-      ],
-      lastConfirmedTrainNo: 'B',
-      userLocation: NEAR_SICHEONG,
-    });
+    const result = pick(
+      [['A', '시청'], ['B', '을지로입구']],
+      { lastConfirmedTrainNo: 'B', userLocation: NEAR_SICHEONG },
+    );
     expect(result?.trainNo).toBe('B');
     expect(result?.confidence).toBe('sticky');
   });
 
   it('falls through to GPS when lastConfirmedTrainNo is not in candidates', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
-        makeCandidate({ trainNo: 'B', currentStationName: '을지로3가' }),
-      ],
-      lastConfirmedTrainNo: 'Z',
-      userLocation: NEAR_EULJIRO_3GA,
-    });
+    const result = pick(
+      [['A', '시청'], ['B', '을지로3가']],
+      { lastConfirmedTrainNo: 'Z', userLocation: NEAR_EULJIRO_3GA },
+    );
     expect(result?.trainNo).toBe('B');
     expect(result?.confidence).toBe('gps-disambiguated');
   });
 
   it('falls through to GPS when sticky candidate fails station resolution', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
-        makeCandidate({ trainNo: 'STICKY', currentStationName: '없는역' }),
-        makeCandidate({ trainNo: 'C', currentStationName: '을지로3가' }),
-      ],
-      lastConfirmedTrainNo: 'STICKY',
-      userLocation: NEAR_EULJIRO_3GA,
-    });
+    const result = pick(
+      [['A', '시청'], ['STICKY', '없는역'], ['C', '을지로3가']],
+      { lastConfirmedTrainNo: 'STICKY', userLocation: NEAR_EULJIRO_3GA },
+    );
     expect(result?.trainNo).toBe('C');
     expect(result?.confidence).toBe('gps-disambiguated');
   });
 
   it('picks closest candidate by haversine when only GPS is available', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'A', currentStationName: '을지로4가' }),
-        makeCandidate({ trainNo: 'B', currentStationName: '시청' }),
-      ],
-      userLocation: NEAR_SICHEONG,
-    });
+    const result = pick(
+      [['A', '을지로4가'], ['B', '시청']],
+      { userLocation: NEAR_SICHEONG },
+    );
     expect(result?.trainNo).toBe('B');
     expect(result?.confidence).toBe('gps-disambiguated');
   });
 
   it('breaks GPS ties by trainNo ascending (later candidate wins)', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'Z', currentStationName: '시청' }),
-        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
-      ],
-      userLocation: NEAR_SICHEONG,
-    });
+    const result = pick(
+      [['Z', '시청'], ['A', '시청']],
+      { userLocation: NEAR_SICHEONG },
+    );
     expect(result?.trainNo).toBe('A');
     expect(result?.confidence).toBe('gps-disambiguated');
   });
 
   it('keeps closer candidate when later candidate is farther (or worse tie-break)', () => {
-    const result = trackTrainProgress({
-      candidates: [
-        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
-        makeCandidate({ trainNo: 'B', currentStationName: '을지로4가' }),
-        makeCandidate({ trainNo: 'Z', currentStationName: '시청' }),
-      ],
-      userLocation: NEAR_SICHEONG,
-    });
+    const result = pick(
+      [['A', '시청'], ['B', '을지로4가'], ['Z', '시청']],
+      { userLocation: NEAR_SICHEONG },
+    );
     expect(result?.trainNo).toBe('A');
     expect(result?.confidence).toBe('gps-disambiguated');
   });
 
   it('returns null when multiple candidates remain and no sticky/GPS hint exists', () => {
-    expect(
-      trackTrainProgress({
-        candidates: [
-          makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
-          makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
-        ],
-      }),
-    ).toBeNull();
+    expect(pick([['A', '시청'], ['B', '을지로입구']])).toBeNull();
   });
 
   it('treats userLocation === null the same as undefined', () => {
     expect(
-      trackTrainProgress({
-        candidates: [
-          makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
-          makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
-        ],
-        userLocation: null,
-      }),
+      pick([['A', '시청'], ['B', '을지로입구']], { userLocation: null }),
     ).toBeNull();
   });
 });

--- a/src/utils/__tests__/trackTrainProgress.test.ts
+++ b/src/utils/__tests__/trackTrainProgress.test.ts
@@ -73,48 +73,45 @@ describe('trackTrainProgress', () => {
     expect(result?.confidence).toBe('sticky');
   });
 
-  it('falls through to GPS when lastConfirmedTrainNo is not in candidates', () => {
-    const result = pick(
-      [['A', '시청'], ['B', '을지로3가']],
-      { lastConfirmedTrainNo: 'Z', userLocation: NEAR_EULJIRO_3GA },
-    );
-    expect(result?.trainNo).toBe('B');
-    expect(result?.confidence).toBe('gps-disambiguated');
-  });
-
-  it('falls through to GPS when sticky candidate fails station resolution', () => {
-    const result = pick(
-      [['A', '시청'], ['STICKY', '없는역'], ['C', '을지로3가']],
-      { lastConfirmedTrainNo: 'STICKY', userLocation: NEAR_EULJIRO_3GA },
-    );
-    expect(result?.trainNo).toBe('C');
-    expect(result?.confidence).toBe('gps-disambiguated');
-  });
-
-  it('picks closest candidate by haversine when only GPS is available', () => {
-    const result = pick(
-      [['A', '을지로4가'], ['B', '시청']],
-      { userLocation: NEAR_SICHEONG },
-    );
-    expect(result?.trainNo).toBe('B');
-    expect(result?.confidence).toBe('gps-disambiguated');
-  });
-
-  it('breaks GPS ties by trainNo ascending (later candidate wins)', () => {
-    const result = pick(
-      [['Z', '시청'], ['A', '시청']],
-      { userLocation: NEAR_SICHEONG },
-    );
-    expect(result?.trainNo).toBe('A');
-    expect(result?.confidence).toBe('gps-disambiguated');
-  });
-
-  it('keeps closer candidate when later candidate is farther (or worse tie-break)', () => {
-    const result = pick(
-      [['A', '시청'], ['B', '을지로4가'], ['Z', '시청']],
-      { userLocation: NEAR_SICHEONG },
-    );
-    expect(result?.trainNo).toBe('A');
+  it.each<{
+    name: string;
+    pairs: Array<[string, string]>;
+    opts: Omit<TrackTrainProgressInput, 'candidates'>;
+    expected: string;
+  }>([
+    {
+      name: 'lastConfirmedTrainNo not in candidates → GPS',
+      pairs: [['A', '시청'], ['B', '을지로3가']],
+      opts: { lastConfirmedTrainNo: 'Z', userLocation: NEAR_EULJIRO_3GA },
+      expected: 'B',
+    },
+    {
+      name: 'sticky candidate fails station resolution → GPS',
+      pairs: [['A', '시청'], ['STICKY', '없는역'], ['C', '을지로3가']],
+      opts: { lastConfirmedTrainNo: 'STICKY', userLocation: NEAR_EULJIRO_3GA },
+      expected: 'C',
+    },
+    {
+      name: 'picks closest by haversine',
+      pairs: [['A', '을지로4가'], ['B', '시청']],
+      opts: { userLocation: NEAR_SICHEONG },
+      expected: 'B',
+    },
+    {
+      name: 'tie-break by trainNo ascending (later wins)',
+      pairs: [['Z', '시청'], ['A', '시청']],
+      opts: { userLocation: NEAR_SICHEONG },
+      expected: 'A',
+    },
+    {
+      name: 'keeps closer when later is farther (or worse tie-break)',
+      pairs: [['A', '시청'], ['B', '을지로4가'], ['Z', '시청']],
+      opts: { userLocation: NEAR_SICHEONG },
+      expected: 'A',
+    },
+  ])('gps-disambiguated: $name', ({ pairs, opts, expected }) => {
+    const result = pick(pairs, opts);
+    expect(result?.trainNo).toBe(expected);
     expect(result?.confidence).toBe('gps-disambiguated');
   });
 

--- a/src/utils/__tests__/trackTrainProgress.test.ts
+++ b/src/utils/__tests__/trackTrainProgress.test.ts
@@ -1,0 +1,168 @@
+import type { CandidateTrain } from '../pickCandidateTrains';
+import type { LineNumber } from '../../types/station';
+import { trackTrainProgress } from '../trackTrainProgress';
+
+const LINE: LineNumber = '2';
+
+function makeCandidate(overrides: Partial<CandidateTrain>): CandidateTrain {
+  return {
+    trainNo: '0001',
+    line: LINE,
+    direction: 0,
+    currentStationName: '시청',
+    trainStatus: 1,
+    receivedAtMs: 1_000,
+    ...overrides,
+  };
+}
+
+// 시청(37.563588, 126.975411), 을지로입구(37.566014, 126.982618),
+// 을지로3가(37.566306, 126.991696), 을지로4가(37.566595, 126.997817)
+const NEAR_SICHEONG = { lat: 37.5636, lng: 126.9754 };
+const NEAR_EULJIRO_3GA = { lat: 37.5663, lng: 126.9917 };
+
+describe('trackTrainProgress', () => {
+  it('returns null for empty candidates', () => {
+    expect(trackTrainProgress({ candidates: [] })).toBeNull();
+  });
+
+  it('returns single confidence when exactly one candidate maps to a station', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청', trainStatus: 2 })],
+    });
+    expect(result).toEqual({
+      trainNo: 'A',
+      currentStation: expect.objectContaining({ name: '시청', line: '2' }),
+      trainStatus: 2,
+      confidence: 'single',
+    });
+  });
+
+  it('returns null when single candidate station name is not on the line', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ currentStationName: '없는역' })],
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when all multiple candidates fail station resolution', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '없는역1' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '없는역2' }),
+      ],
+    });
+    expect(result).toBeNull();
+  });
+
+  it('drops to single when only one of many candidates resolves to a station', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '없는역' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
+      ],
+    });
+    expect(result?.trainNo).toBe('B');
+    expect(result?.confidence).toBe('single');
+  });
+
+  it('picks sticky when lastConfirmedTrainNo matches a resolved candidate', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
+      ],
+      lastConfirmedTrainNo: 'B',
+      userLocation: NEAR_SICHEONG,
+    });
+    expect(result?.trainNo).toBe('B');
+    expect(result?.confidence).toBe('sticky');
+  });
+
+  it('falls through to GPS when lastConfirmedTrainNo is not in candidates', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '을지로3가' }),
+      ],
+      lastConfirmedTrainNo: 'Z',
+      userLocation: NEAR_EULJIRO_3GA,
+    });
+    expect(result?.trainNo).toBe('B');
+    expect(result?.confidence).toBe('gps-disambiguated');
+  });
+
+  it('falls through to GPS when sticky candidate fails station resolution', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+        makeCandidate({ trainNo: 'STICKY', currentStationName: '없는역' }),
+        makeCandidate({ trainNo: 'C', currentStationName: '을지로3가' }),
+      ],
+      lastConfirmedTrainNo: 'STICKY',
+      userLocation: NEAR_EULJIRO_3GA,
+    });
+    expect(result?.trainNo).toBe('C');
+    expect(result?.confidence).toBe('gps-disambiguated');
+  });
+
+  it('picks closest candidate by haversine when only GPS is available', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '을지로4가' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '시청' }),
+      ],
+      userLocation: NEAR_SICHEONG,
+    });
+    expect(result?.trainNo).toBe('B');
+    expect(result?.confidence).toBe('gps-disambiguated');
+  });
+
+  it('breaks GPS ties by trainNo ascending (later candidate wins)', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'Z', currentStationName: '시청' }),
+        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+      ],
+      userLocation: NEAR_SICHEONG,
+    });
+    expect(result?.trainNo).toBe('A');
+    expect(result?.confidence).toBe('gps-disambiguated');
+  });
+
+  it('keeps closer candidate when later candidate is farther (or worse tie-break)', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '을지로4가' }),
+        makeCandidate({ trainNo: 'Z', currentStationName: '시청' }),
+      ],
+      userLocation: NEAR_SICHEONG,
+    });
+    expect(result?.trainNo).toBe('A');
+    expect(result?.confidence).toBe('gps-disambiguated');
+  });
+
+  it('returns null when multiple candidates remain and no sticky/GPS hint exists', () => {
+    expect(
+      trackTrainProgress({
+        candidates: [
+          makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+          makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it('treats userLocation === null the same as undefined', () => {
+    expect(
+      trackTrainProgress({
+        candidates: [
+          makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+          makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
+        ],
+        userLocation: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/utils/trackTrainProgress.ts
+++ b/src/utils/trackTrainProgress.ts
@@ -66,7 +66,8 @@ export function trackTrainProgress(
         r.station.lng,
       ),
     }));
-    const nearest = scored.reduce((min, cur) => {
+    const [first, ...rest] = scored;
+    const nearest = rest.reduce((min, cur) => {
       if (cur.distance < min.distance) return cur;
       if (
         cur.distance === min.distance &&
@@ -75,7 +76,7 @@ export function trackTrainProgress(
         return cur;
       }
       return min;
-    });
+    }, first);
     return toResult(nearest.resolved, 'gps-disambiguated');
   }
 

--- a/src/utils/trackTrainProgress.ts
+++ b/src/utils/trackTrainProgress.ts
@@ -1,0 +1,83 @@
+import type { CandidateTrain } from './pickCandidateTrains';
+import type { Station } from '../types/station';
+import { findStationByNameAndLine } from './stationRoute';
+import { haversine } from './haversine';
+
+export interface TrackTrainProgressInput {
+  candidates: CandidateTrain[];
+  userLocation?: { lat: number; lng: number } | null;
+  lastConfirmedTrainNo?: string;
+}
+
+export interface TrainProgressResult {
+  trainNo: string;
+  currentStation: Station;
+  trainStatus: number;
+  confidence: 'single' | 'gps-disambiguated' | 'sticky';
+}
+
+interface ResolvedCandidate {
+  candidate: CandidateTrain;
+  station: Station;
+}
+
+function toResult(
+  resolved: ResolvedCandidate,
+  confidence: TrainProgressResult['confidence'],
+): TrainProgressResult {
+  return {
+    trainNo: resolved.candidate.trainNo,
+    currentStation: resolved.station,
+    trainStatus: resolved.candidate.trainStatus,
+    confidence,
+  };
+}
+
+export function trackTrainProgress(
+  input: TrackTrainProgressInput,
+): TrainProgressResult | null {
+  const { candidates, userLocation, lastConfirmedTrainNo } = input;
+
+  if (candidates.length === 0) return null;
+
+  const resolved: ResolvedCandidate[] = [];
+  for (const candidate of candidates) {
+    const station = findStationByNameAndLine(candidate.currentStationName, candidate.line);
+    if (station) resolved.push({ candidate, station });
+  }
+
+  if (resolved.length === 0) return null;
+  if (resolved.length === 1) return toResult(resolved[0], 'single');
+
+  // sticky 판정은 station 해석에 성공한 후보(resolved)에서만 수행.
+  // lastConfirmedTrainNo가 station 해석 실패로 resolved에서 탈락한 경우 GPS fallthrough.
+  if (lastConfirmedTrainNo) {
+    const sticky = resolved.find((r) => r.candidate.trainNo === lastConfirmedTrainNo);
+    if (sticky) return toResult(sticky, 'sticky');
+  }
+
+  if (userLocation) {
+    const scored = resolved.map((r) => ({
+      resolved: r,
+      distance: haversine(
+        userLocation.lat,
+        userLocation.lng,
+        r.station.lat,
+        r.station.lng,
+      ),
+    }));
+    const nearest = scored.reduce((min, cur) => {
+      if (cur.distance < min.distance) return cur;
+      if (
+        cur.distance === min.distance &&
+        cur.resolved.candidate.trainNo.localeCompare(min.resolved.candidate.trainNo) < 0
+      ) {
+        return cur;
+      }
+      return min;
+    });
+    return toResult(nearest.resolved, 'gps-disambiguated');
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Phase 1B — `pickCandidateTrains` 결과에서 현재 열차/역 자동 결정 순수 함수 신설
- 결정 순서: `single` → `sticky(lastConfirmedTrainNo)` → `gps-disambiguated` → `null`
- station 해석 실패한 후보는 단계마다 스킵 (sticky/GPS 모두)
- GPS tie-break: 거리 동일 시 trainNo 사전순 (reduce 기반, 결정론적)

## Test plan
- [x] `npx jest src/utils/__tests__/trackTrainProgress.test.ts --coverage` 100/100/100/100 (13 cases)
- [x] `npm test` 전체 1101 통과
- [x] `npm run type-check` 통과
- [ ] CI Type Check & Test 통과 확인
- [ ] 호출처 없음 — Phase 1C(#325)에서 통합

Closes #324