### PR TITLE
feat(#316): 지도 탭 역 검색 기능 추가

### DIFF
--- a/__mocks__/react-native-map-clustering.js
+++ b/__mocks__/react-native-map-clustering.js
@@ -1,12 +1,20 @@
 const React = require('react');
 const { View } = require('react-native');
 
-const ClusteredMapView = ({ children, testID, onMapReady, ...props }) => {
-  React.useEffect(() => { onMapReady?.(); }, []);
-  return React.createElement(View, { testID, ...props }, children);
-};
+const animateToRegionMock = jest.fn();
+
+const ClusteredMapView = React.forwardRef(
+  ({ children, testID, onMapReady, ...props }, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      animateToRegion: animateToRegionMock,
+    }));
+    React.useEffect(() => { onMapReady?.(); }, []);
+    return React.createElement(View, { testID, ...props }, children);
+  },
+);
 
 module.exports = {
   __esModule: true,
   default: ClusteredMapView,
+  __animateToRegionMock: animateToRegionMock,
 };

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useActiveLinePositions } from '../../src/hooks/useActiveLinePositions';
 import { StationMap } from '../../src/components/StationMap';
+import { MapSearchBar } from '../../src/components/MapSearchBar';
 import { LocationStateView } from '../../src/components/LocationStateView';
 import { StatusChip } from '../../src/components/StatusChip';
 import stationsData from '../../src/data/stations.json';
@@ -30,6 +31,8 @@ export default function MapScreen() {
   const setDestination = useAppStore((s) => s.setDestination);
   const setRecentDestination = useAppStore((s) => s.setRecentDestination);
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
+  const [focusStation, setFocusStation] = useState<Station | null>(null);
+  const [focusNonce, setFocusNonce] = useState(0);
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
 
@@ -78,6 +81,14 @@ export default function MapScreen() {
         </View>
       )}
 
+      <MapSearchBar
+        onSelect={(station) => {
+          setFocusStation(station);
+          setFocusNonce((n) => n + 1);
+          setSelectedStation(station);
+        }}
+      />
+
       <StationMap
         userLat={userLocation!.lat}
         userLng={userLocation!.lng}
@@ -86,6 +97,8 @@ export default function MapScreen() {
         customOriginId={customOrigin?.id}
         onStationPress={(station) => setSelectedStation(station)}
         trainMarkers={trainMarkers}
+        focusStation={focusStation}
+        focusNonce={focusNonce}
       />
 
       {/* 하단 역 선택 카드 */}

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -10,10 +10,10 @@ import {
 import { useTranslation } from 'react-i18next';
 import stations from '../data/stations.json';
 import type { Station } from '../types/station';
-import { LINE_NAMES } from '../constants/lineColors';
 import { StationMap } from './StationMap';
+import { StationSuggestionList } from './StationSuggestionList';
 import { createLogger } from '../utils/logger';
-import { getStationDisplayName, matchesStationQuery } from '../utils/stationDisplay';
+import { matchesStationQuery } from '../utils/stationDisplay';
 import { useTheme, spacing, radius } from '../theme';
 
 const logger = createLogger('DestinationPicker');
@@ -121,21 +121,14 @@ export function DestinationPicker({
             onFocus={() => setShowDropdown(true)}
             testID="search-input"
           />
-          {showDropdown && suggestions.length > 0 && (
-            <View style={[styles.dropdown, { backgroundColor: colors.card, borderColor: colors.hair }]} testID="suggestions-list">
-              {suggestions.map((s) => (
-                <TouchableOpacity
-                  key={s.id}
-                  style={[styles.suggestionItem, { borderBottomColor: colors.hair }]}
-                  onPress={() => handleSelect(s)}
-                  testID={`suggestion-item-${s.id}`}
-                >
-                  <Text style={[styles.suggestionName, { color: colors.ink }]}>{getStationDisplayName(s)}</Text>
-                  <View style={[styles.lineBadge, { backgroundColor: s.lineColor }]}>
-                    <Text style={styles.lineText}>{LINE_NAMES[s.line]}</Text>
-                  </View>
-                </TouchableOpacity>
-              ))}
+          {showDropdown && (
+            <View style={styles.dropdownWrap}>
+              <StationSuggestionList
+                suggestions={suggestions}
+                onSelect={handleSelect}
+                listTestID="suggestions-list"
+                itemTestIDPrefix="suggestion-item-"
+              />
             </View>
           )}
         </View>
@@ -187,32 +180,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     borderWidth: 1,
   },
-  dropdown: {
+  dropdownWrap: {
     marginHorizontal: spacing.xl,
     marginTop: 4,
-    borderRadius: radius.sm,
-    overflow: 'hidden',
-    borderWidth: 1,
-  },
-  suggestionItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-    borderBottomWidth: 1,
-  },
-  suggestionName: {
-    fontSize: 15,
-  },
-  lineBadge: {
-    borderRadius: 4,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: 2,
-  },
-  lineText: {
-    color: '#ffffff', // 노선색 배경 위 텍스트 — 항상 흰색 유지
-    fontSize: 12,
-    fontWeight: 'bold',
   },
 });

--- a/src/components/MapSearchBar.tsx
+++ b/src/components/MapSearchBar.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo, useState } from 'react';
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import stationsData from '../data/stations.json';
+import type { Station } from '../types/station';
+import { LINE_NAMES } from '../constants/lineColors';
+import { getStationDisplayName, matchesStationQuery } from '../utils/stationDisplay';
+import { useTheme, spacing, radius } from '../theme';
+
+const allStations = stationsData as Station[];
+const MAX_SUGGESTIONS = 8;
+
+interface Props {
+  readonly onSelect: (station: Station) => void;
+}
+
+export function MapSearchBar({ onSelect }: Props) {
+  const [query, setQuery] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  const suggestions = useMemo(() => {
+    const q = query.trim();
+    if (!q) return [];
+    const qLower = q.toLowerCase();
+    return allStations
+      .filter((s) => matchesStationQuery(s, q, qLower))
+      .slice(0, MAX_SUGGESTIONS);
+  }, [query]);
+
+  function handleSelect(station: Station) {
+    setQuery('');
+    setShowDropdown(false);
+    onSelect(station);
+  }
+
+  return (
+    <View style={styles.container} testID="map-search-bar">
+      <TextInput
+        style={[
+          styles.input,
+          { backgroundColor: colors.card, color: colors.ink, borderColor: colors.hair },
+        ]}
+        placeholder={t('map.search.placeholder')}
+        placeholderTextColor={colors.subtle}
+        value={query}
+        onChangeText={(text) => {
+          setQuery(text);
+          setShowDropdown(true);
+        }}
+        onFocus={() => setShowDropdown(true)}
+        testID="map-search-input"
+      />
+      {showDropdown && suggestions.length > 0 && (
+        <View
+          style={[styles.dropdown, { backgroundColor: colors.card, borderColor: colors.hair }]}
+          testID="map-search-suggestions"
+        >
+          {suggestions.map((s) => (
+            <TouchableOpacity
+              key={s.id}
+              style={[styles.suggestionItem, { borderBottomColor: colors.hair }]}
+              onPress={() => handleSelect(s)}
+              testID={`map-search-suggestion-${s.id}`}
+            >
+              <Text style={[styles.suggestionName, { color: colors.ink }]}>
+                {getStationDisplayName(s)}
+              </Text>
+              <View style={[styles.lineBadge, { backgroundColor: s.lineColor }]}>
+                <Text style={styles.lineText}>{LINE_NAMES[s.line]}</Text>
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.sm,
+  },
+  input: {
+    borderRadius: radius.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    fontSize: 16,
+    borderWidth: 1,
+  },
+  dropdown: {
+    marginTop: 4,
+    borderRadius: radius.sm,
+    overflow: 'hidden',
+    borderWidth: 1,
+  },
+  suggestionItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+  },
+  suggestionName: {
+    fontSize: 15,
+  },
+  lineBadge: {
+    borderRadius: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+  },
+  lineText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/MapSearchBar.tsx
+++ b/src/components/MapSearchBar.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo, useState } from 'react';
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TextInput, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import stationsData from '../data/stations.json';
 import type { Station } from '../types/station';
-import { LINE_NAMES } from '../constants/lineColors';
-import { getStationDisplayName, matchesStationQuery } from '../utils/stationDisplay';
+import { matchesStationQuery } from '../utils/stationDisplay';
 import { useTheme, spacing, radius } from '../theme';
+import { StationSuggestionList } from './StationSuggestionList';
 
 const allStations = stationsData as Station[];
 const MAX_SUGGESTIONS = 8;
@@ -24,9 +24,7 @@ export function MapSearchBar({ onSelect }: Props) {
     const q = query.trim();
     if (!q) return [];
     const qLower = q.toLowerCase();
-    return allStations
-      .filter((s) => matchesStationQuery(s, q, qLower))
-      .slice(0, MAX_SUGGESTIONS);
+    return allStations.filter((s) => matchesStationQuery(s, q, qLower)).slice(0, MAX_SUGGESTIONS);
   }, [query]);
 
   function handleSelect(station: Station) {
@@ -52,26 +50,14 @@ export function MapSearchBar({ onSelect }: Props) {
         onFocus={() => setShowDropdown(true)}
         testID="map-search-input"
       />
-      {showDropdown && suggestions.length > 0 && (
-        <View
-          style={[styles.dropdown, { backgroundColor: colors.card, borderColor: colors.hair }]}
-          testID="map-search-suggestions"
-        >
-          {suggestions.map((s) => (
-            <TouchableOpacity
-              key={s.id}
-              style={[styles.suggestionItem, { borderBottomColor: colors.hair }]}
-              onPress={() => handleSelect(s)}
-              testID={`map-search-suggestion-${s.id}`}
-            >
-              <Text style={[styles.suggestionName, { color: colors.ink }]}>
-                {getStationDisplayName(s)}
-              </Text>
-              <View style={[styles.lineBadge, { backgroundColor: s.lineColor }]}>
-                <Text style={styles.lineText}>{LINE_NAMES[s.line]}</Text>
-              </View>
-            </TouchableOpacity>
-          ))}
+      {showDropdown && (
+        <View style={styles.dropdownWrap}>
+          <StationSuggestionList
+            suggestions={suggestions}
+            onSelect={handleSelect}
+            listTestID="map-search-suggestions"
+            itemTestIDPrefix="map-search-suggestion-"
+          />
         </View>
       )}
     </View>
@@ -91,31 +77,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     borderWidth: 1,
   },
-  dropdown: {
+  dropdownWrap: {
     marginTop: 4,
-    borderRadius: radius.sm,
-    overflow: 'hidden',
-    borderWidth: 1,
-  },
-  suggestionItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-    borderBottomWidth: 1,
-  },
-  suggestionName: {
-    fontSize: 15,
-  },
-  lineBadge: {
-    borderRadius: 4,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: 2,
-  },
-  lineText: {
-    color: '#ffffff',
-    fontSize: 12,
-    fontWeight: 'bold',
   },
 });

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import ClusteredMapView from 'react-native-map-clustering';
 import { Marker, PROVIDER_DEFAULT } from 'react-native-maps';
+import type MapView from 'react-native-maps';
 import type { Station } from '../types/station';
 import type { TrainMarker as TrainMarkerData } from '../utils/findTrainCoordinates';
 import { buildMapConfig } from '../utils/buildMapConfig';
@@ -35,7 +36,14 @@ interface StationMapProps {
   onStationPress?: (station: Station) => void;
   /** Phase 3 Stage 3: 활성 호선의 실시간 열차 위치. 없으면 표시 안 함. */
   trainMarkers?: TrainMarkerData[];
+  /** 검색 결과 선택 시 지도 카메라를 이동시킬 역. focusNonce가 변할 때마다 재이동한다. */
+  focusStation?: Station | null;
+  /** 같은 역을 다시 선택해도 카메라가 다시 움직이도록 매 선택마다 변경되는 값. */
+  focusNonce?: number;
 }
+
+const FOCUS_REGION_DELTA = 0.01;
+const FOCUS_ANIMATION_MS = 400;
 
 export function StationMap({
   userLat,
@@ -45,10 +53,26 @@ export function StationMap({
   customOriginId,
   onStationPress,
   trainMarkers,
+  focusStation,
+  focusNonce,
 }: StationMapProps) {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
   const [mapReady, setMapReady] = useState(false);
+  const mapRef = useRef<MapView | null>(null);
+
+  useEffect(() => {
+    if (!focusStation) return;
+    mapRef.current?.animateToRegion(
+      {
+        latitude: focusStation.lat,
+        longitude: focusStation.lng,
+        latitudeDelta: FOCUS_REGION_DELTA,
+        longitudeDelta: FOCUS_REGION_DELTA,
+      },
+      FOCUS_ANIMATION_MS,
+    );
+  }, [focusStation?.id, focusNonce]);
 
   const mapConfig = useMemo(
     () => buildMapConfig({ userLat, userLng, nearestStation, nearbyStations }),
@@ -58,6 +82,7 @@ export function StationMap({
   return (
     <View style={styles.map}>
       <ClusteredMapView
+        ref={mapRef}
         provider={PROVIDER_DEFAULT}
         style={styles.map}
         initialRegion={{

--- a/src/components/StationSuggestionList.tsx
+++ b/src/components/StationSuggestionList.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { Station } from '../types/station';
+import { LINE_NAMES } from '../constants/lineColors';
+import { getStationDisplayName } from '../utils/stationDisplay';
+import { useTheme, spacing, radius } from '../theme';
+
+interface Props {
+  readonly suggestions: readonly Station[];
+  readonly onSelect: (station: Station) => void;
+  readonly listTestID: string;
+  readonly itemTestIDPrefix: string;
+}
+
+export function StationSuggestionList({ suggestions, onSelect, listTestID, itemTestIDPrefix }: Props) {
+  const { colors } = useTheme();
+  if (suggestions.length === 0) return null;
+  return (
+    <View
+      style={[styles.dropdown, { backgroundColor: colors.card, borderColor: colors.hair }]}
+      testID={listTestID}
+    >
+      {suggestions.map((s) => (
+        <TouchableOpacity
+          key={s.id}
+          style={[styles.item, { borderBottomColor: colors.hair }]}
+          onPress={() => onSelect(s)}
+          testID={`${itemTestIDPrefix}${s.id}`}
+        >
+          <Text style={[styles.name, { color: colors.ink }]}>{getStationDisplayName(s)}</Text>
+          <View style={[styles.lineBadge, { backgroundColor: s.lineColor }]}>
+            <Text style={styles.lineText}>{LINE_NAMES[s.line]}</Text>
+          </View>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dropdown: {
+    borderRadius: radius.sm,
+    overflow: 'hidden',
+    borderWidth: 1,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+  },
+  name: {
+    fontSize: 15,
+  },
+  lineBadge: {
+    borderRadius: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+  },
+  lineText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/__tests__/MapSearchBar.test.tsx
+++ b/src/components/__tests__/MapSearchBar.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { MapSearchBar } from '../MapSearchBar';
+
+describe('MapSearchBar', () => {
+  it('검색창을 렌더링한다', () => {
+    const { getByTestId } = render(<MapSearchBar onSelect={jest.fn()} />);
+    expect(getByTestId('map-search-input')).toBeTruthy();
+  });
+
+  it('초기 상태에서는 추천 목록을 렌더링하지 않는다', () => {
+    const { queryByTestId } = render(<MapSearchBar onSelect={jest.fn()} />);
+    expect(queryByTestId('map-search-suggestions')).toBeNull();
+  });
+
+  it('포커스만 받으면(검색어 없음) 추천을 보이지 않는다', () => {
+    const { getByTestId, queryByTestId } = render(<MapSearchBar onSelect={jest.fn()} />);
+    fireEvent(getByTestId('map-search-input'), 'focus');
+    expect(queryByTestId('map-search-suggestions')).toBeNull();
+  });
+
+  it('검색어 입력 시 일치하는 역의 추천 목록을 보여준다', () => {
+    const { getByTestId } = render(<MapSearchBar onSelect={jest.fn()} />);
+    fireEvent.changeText(getByTestId('map-search-input'), '강남');
+    expect(getByTestId('map-search-suggestions')).toBeTruthy();
+  });
+
+  it('공백만 입력 시 추천 목록을 보여주지 않는다', () => {
+    const { getByTestId, queryByTestId } = render(<MapSearchBar onSelect={jest.fn()} />);
+    fireEvent.changeText(getByTestId('map-search-input'), '   ');
+    expect(queryByTestId('map-search-suggestions')).toBeNull();
+  });
+
+  it('추천 항목 탭 시 onSelect를 호출하고 추천을 닫는다', () => {
+    const onSelect = jest.fn();
+    const { getByTestId, queryByTestId, getAllByTestId } = render(
+      <MapSearchBar onSelect={onSelect} />,
+    );
+    fireEvent.changeText(getByTestId('map-search-input'), '강남');
+    const items = getAllByTestId(/^map-search-suggestion-/);
+    fireEvent.press(items[0]);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ name: expect.any(String), id: expect.any(String) }),
+    );
+    expect(queryByTestId('map-search-suggestions')).toBeNull();
+  });
+
+  it('일치하지 않는 검색어는 추천을 보여주지 않는다', () => {
+    const { getByTestId, queryByTestId } = render(<MapSearchBar onSelect={jest.fn()} />);
+    fireEvent.changeText(getByTestId('map-search-input'), 'zzzzzzzz없는역명');
+    expect(queryByTestId('map-search-suggestions')).toBeNull();
+  });
+
+  it('추천 목록은 최대 8개로 제한된다', () => {
+    const { getByTestId, getAllByTestId } = render(<MapSearchBar onSelect={jest.fn()} />);
+    // 한글 단일 문자로 다수 매칭 유도
+    fireEvent.changeText(getByTestId('map-search-input'), '역');
+    const items = getAllByTestId(/^map-search-suggestion-/);
+    expect(items.length).toBeLessThanOrEqual(8);
+  });
+});

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -3,8 +3,14 @@ import { render, act, waitFor, fireEvent } from '@testing-library/react-native';
 import { StationMap } from '../StationMap';
 import type { Station } from '../../types/station';
 import { installLanguageRestoreHook, setLang } from '../../testUtils/i18nLanguageOverride';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __animateToRegionMock } = require('react-native-map-clustering');
 
 installLanguageRestoreHook();
+
+beforeEach(() => {
+  __animateToRegionMock.mockClear();
+});
 
 const mockStation: Station = {
   id: '2-022',
@@ -171,6 +177,63 @@ describe('StationMap', () => {
     });
     expect(result.stations[0].isNearest).toBe(true);
     expect(result.stations[1].isNearest).toBe(false);
+  });
+
+  describe('focusStation', () => {
+    it('focusStation 미전달 시 animateToRegion 호출 안 함', () => {
+      render(<StationMap {...baseProps} />);
+      expect(__animateToRegionMock).not.toHaveBeenCalled();
+    });
+
+    it('focusStation 전달 시 해당 좌표로 animateToRegion 호출', () => {
+      render(<StationMap {...baseProps} focusStation={anotherStation} />);
+      expect(__animateToRegionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          latitude: anotherStation.lat,
+          longitude: anotherStation.lng,
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('focusStation 변경 시 새 좌표로 재호출', () => {
+      const { rerender } = render(
+        <StationMap {...baseProps} focusStation={mockStation} />,
+      );
+      __animateToRegionMock.mockClear();
+      rerender(<StationMap {...baseProps} focusStation={anotherStation} />);
+      expect(__animateToRegionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          latitude: anotherStation.lat,
+          longitude: anotherStation.lng,
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('같은 역을 다시 선택해도 focusNonce 변경 시 재이동', () => {
+      const { rerender } = render(
+        <StationMap {...baseProps} focusStation={mockStation} focusNonce={1} />,
+      );
+      __animateToRegionMock.mockClear();
+      rerender(<StationMap {...baseProps} focusStation={mockStation} focusNonce={2} />);
+      expect(__animateToRegionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          latitude: mockStation.lat,
+          longitude: mockStation.lng,
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('focusStation을 null로 바꾸면 추가 호출 없음', () => {
+      const { rerender } = render(
+        <StationMap {...baseProps} focusStation={mockStation} />,
+      );
+      __animateToRegionMock.mockClear();
+      rerender(<StationMap {...baseProps} focusStation={null} />);
+      expect(__animateToRegionMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('trainMarkers (Phase 3 Stage 3)', () => {

--- a/src/components/__tests__/StationSuggestionList.test.tsx
+++ b/src/components/__tests__/StationSuggestionList.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { StationSuggestionList } from '../StationSuggestionList';
+import type { Station } from '../../types/station';
+
+const stations: Station[] = [
+  { id: '2-022', name: '강남', nameEn: 'Gangnam', line: '2', lineColor: '#009D3E', lat: 37.5, lng: 127.0 },
+  { id: '2-023', name: '선릉', nameEn: 'Seolleung', line: '2', lineColor: '#009D3E', lat: 37.5, lng: 127.0 },
+];
+
+describe('StationSuggestionList', () => {
+  it('suggestions가 비어 있으면 null을 반환한다', () => {
+    const { queryByTestId } = render(
+      <StationSuggestionList
+        suggestions={[]}
+        onSelect={jest.fn()}
+        listTestID="list"
+        itemTestIDPrefix="item-"
+      />,
+    );
+    expect(queryByTestId('list')).toBeNull();
+  });
+
+  it('각 역에 대해 prefix가 적용된 testID로 항목을 렌더링한다', () => {
+    const { getByTestId } = render(
+      <StationSuggestionList
+        suggestions={stations}
+        onSelect={jest.fn()}
+        listTestID="list"
+        itemTestIDPrefix="item-"
+      />,
+    );
+    expect(getByTestId('list')).toBeTruthy();
+    expect(getByTestId('item-2-022')).toBeTruthy();
+    expect(getByTestId('item-2-023')).toBeTruthy();
+  });
+
+  it('항목 탭 시 해당 역을 onSelect로 전달한다', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <StationSuggestionList
+        suggestions={stations}
+        onSelect={onSelect}
+        listTestID="list"
+        itemTestIDPrefix="item-"
+      />,
+    );
+    fireEvent.press(getByTestId('item-2-022'));
+    expect(onSelect).toHaveBeenCalledWith(stations[0]);
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -73,6 +73,9 @@
     "setAsDestination": "Set as destination",
     "nearbyStationsHeader": "Nearby stations (within 1km)",
     "noNearbyStations": "No subway stations within 1km.",
+    "search": {
+      "placeholder": "Search stations"
+    },
     "train": {
       "terminalSuffix": "To {{name}}",
       "descriptionTemplate": "Train {{trainNo}} · {{status}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -73,6 +73,9 @@
     "setAsDestination": "目的地に設定",
     "nearbyStationsHeader": "周辺の地下鉄駅 (1km以内)",
     "noNearbyStations": "1km以内に地下鉄駅がありません。",
+    "search": {
+      "placeholder": "駅名を検索"
+    },
     "train": {
       "terminalSuffix": "{{name}}行",
       "descriptionTemplate": "列車 {{trainNo}} · {{status}}",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -73,6 +73,9 @@
     "setAsDestination": "도착역으로 설정",
     "nearbyStationsHeader": "주변 지하철역 (1km 이내)",
     "noNearbyStations": "주변 1km 내 지하철역이 없습니다.",
+    "search": {
+      "placeholder": "역 이름 검색"
+    },
     "train": {
       "terminalSuffix": "{{name}}행",
       "descriptionTemplate": "열차 {{trainNo}} · {{status}}",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -73,6 +73,9 @@
     "setAsDestination": "设为目的地",
     "nearbyStationsHeader": "附近地铁站(1km以内)",
     "noNearbyStations": "1km内没有地铁站。",
+    "search": {
+      "placeholder": "搜索车站"
+    },
     "train": {
       "terminalSuffix": "开往{{name}}",
       "descriptionTemplate": "列车 {{trainNo}} · {{status}}",


### PR DESCRIPTION
## Summary
- 지도 탭 상단에 검색 입력란(`MapSearchBar`) 추가 — 한글/영문 부분일치, 최대 8개 추천
- 추천 탭 시 지도 카메라가 해당 역으로 이동(`animateToRegion`) + 기존 선택 카드(출발/도착 설정) 표시
- 같은 역 재선택도 동작하도록 `focusNonce` 도입

## 구현 노트
- 검색 로직은 `DestinationPicker`에서 검증된 `matchesStationQuery` 재사용
- `StationMap`에 `focusStation`, `focusNonce` prop 추가 (deps에 nonce 포함 → 동일 역 재선택 시 재이동)
- i18n 4개 로케일에 `map.search.placeholder` 추가
- `react-native-map-clustering` 목을 `forwardRef + animateToRegion` 노출로 교체

## Test plan
- [x] `npm test` — 78 suites, 1080 tests, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] 자동 코드 리뷰(P1 1건 — 동일 역 재선택 무시) 반영 후 재검증
- [ ] 실기기/시뮬레이터에서 검색 → 카메라 이동 → 출발/도착 설정 흐름 수동 확인

Closes #316