### PR TITLE
feat(#325): Position-first fusion 통합 — useFusedNearestStation 우선순위 역전

### DIFF
--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -142,51 +142,77 @@ describe('useFusedNearestStation', () => {
     expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
   });
 
-  it('position 신호: 후보 호선의 LinePositions에서 statnNm 매칭 트레인이 ARRIVED → 그 후보로 fusion (source=position)', () => {
+  it('position-train: 단일 후보 trainNo → trackTrainProgress 채택 (source=position-train)', () => {
     mockUseNearest.mockReturnValue(gpsBase());
     mockFindTop.mockReturnValue([
       { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
       { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
     ]);
 
-    // arrival 신호 없음
     mockUseArrival.mockReturnValue(arrivalRet(null));
 
-    // active lines: ['2', '3'] — useTrainPositions 3번 호출(l0='2', l1='3', l2=null)
     mockUsePositions
-      .mockReturnValueOnce(positionRet({ line: '2', trains: [] })) // 강남에 매칭 없음
+      .mockReturnValueOnce(positionRet({ line: '2', trains: [] }))
       .mockReturnValueOnce(
         positionRet({
           line: '3',
-          trains: [train(MOCK_STATIONS.chungmuro.name, TRAIN_STATUS.ARRIVED)],
+          trains: [
+            train(MOCK_STATIONS.chungmuro.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-CHU' }),
+          ],
         }),
       )
       .mockReturnValueOnce(positionRet(null));
 
     const { result } = renderHook(() => useFusedNearestStation());
-    expect(result.current.result?.station.id).toBe(MOCK_STATIONS.chungmuro.id);
-    expect(result.current.confidence).toBe('arrival-confirmed');
-    expect(result.current.source).toBe('position');
+    expect(result.current.result?.station.name).toBe(MOCK_STATIONS.chungmuro.name);
+    expect(result.current.result?.station.line).toBe('3');
+    expect(result.current.confidence).toBe('position-train');
+    expect(result.current.source).toBe('position-train');
   });
 
-  it('arrival과 position 동시 ARRIVED → source=position 우선 (정확도 표시)', () => {
+  it('arrival 있고 position-train 후보 없으면 fused arrival 채택', () => {
     mockUseNearest.mockReturnValue(gpsBase());
     mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
 
     mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
-    mockUsePositions
-      .mockReturnValueOnce(
-        positionRet({
-          line: '2',
-          trains: [train(MOCK_STATIONS.gangnam.name, TRAIN_STATUS.ARRIVED)],
-        }),
-      )
-      .mockReturnValueOnce(positionRet(null))
-      .mockReturnValueOnce(positionRet(null));
+    mockUsePositions.mockReturnValue(positionRet(null));
 
     const { result } = renderHook(() => useFusedNearestStation());
     expect(result.current.confidence).toBe('arrival-confirmed');
-    expect(result.current.source).toBe('position');
+    expect(result.current.source).toBe('arrival');
+  });
+
+  it('position-train 다중 후보: lastConfirmedTrainNo 우선(sticky) — 이전 결과 유지', () => {
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([
+      { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+    ]);
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+
+    // 첫 렌더: 단일 트레인 T-1 → sticky 시드
+    mockUsePositions.mockReturnValue(
+      positionRet({
+        line: '2',
+        trains: [train(MOCK_STATIONS.gangnam.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-1' })],
+      }),
+    );
+    const { result, rerender } = renderHook(() => useFusedNearestStation());
+    expect(result.current.confidence).toBe('position-train');
+
+    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS 없이도 sticky로 T-1 유지.
+    mockUsePositions.mockReturnValue(
+      positionRet({
+        line: '2',
+        trains: [
+          train(MOCK_STATIONS.gangnam.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-1' }),
+          train(MOCK_STATIONS.chungmuro.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-2' }),
+        ],
+      }),
+    );
+    mockUseNearest.mockReturnValue(gpsBase({ userLocation: null }));
+    rerender(undefined);
+    expect(result.current.source).toBe('position-train');
+    expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
   });
 
   it('GPS pass-through 필드들(loading/error/permissionDenied/refresh 등)이 보존된다', () => {

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useNearestStation } from './useNearestStation';
 import { useArrivalInfo } from './useArrivalInfo';
 import { useTrainPositions } from './useTrainPositions';
@@ -6,6 +6,9 @@ import { useRouteProgress } from './useRouteProgress';
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
+import { pickCandidateTrains, type CandidateTrain } from '../utils/pickCandidateTrains';
+import { trackTrainProgress } from '../utils/trackTrainProgress';
+import { haversine } from '../utils/haversine';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import { MAX_ACTIVE_LINES } from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
@@ -140,6 +143,52 @@ export function useFusedNearestStation(
     );
   }, [candidates, a0.arrival, a1.arrival, a2.arrival, p0.positions, p1.positions, p2.positions]);
 
+  // Phase 1C: Position-first fusion.
+  // 후보 trainNo들(pickCandidateTrains) → trackTrainProgress로 단일 trainNo·현재역 결정.
+  // anchor = 각 호선의 GPS 최근접 후보. 후보 1개로 단정되거나 GPS로 disambiguation되면 채택.
+  const lastConfirmedTrainNoRef = useRef<string | undefined>(undefined);
+  const candidateTrains = useMemo<CandidateTrain[]>(() => {
+    const lps: (LinePositions | null)[] = [p0.positions, p1.positions, p2.positions];
+    const out: CandidateTrain[] = [];
+    for (const lp of lps) {
+      if (!lp) continue;
+      const anchor = candidates.find((c) => c.station.line === lp.line)?.station.name;
+      out.push(
+        ...pickCandidateTrains({
+          positions: [lp],
+          line: lp.line,
+          anchorStationName: anchor,
+        }),
+      );
+    }
+    return out;
+  }, [candidates, p0.positions, p1.positions, p2.positions]);
+
+  const trainProgress = useMemo(
+    () =>
+      trackTrainProgress({
+        candidates: candidateTrains,
+        userLocation: gps.userLocation,
+        lastConfirmedTrainNo: lastConfirmedTrainNoRef.current,
+      }),
+    [candidateTrains, gps.userLocation],
+  );
+
+  useEffect(() => {
+    if (trainProgress) lastConfirmedTrainNoRef.current = trainProgress.trainNo;
+  }, [trainProgress]);
+
+  const positionTrainResult: NearestStationResult | null = useMemo(() => {
+    if (!trainProgress) return null;
+    const station = trainProgress.currentStation;
+    // userLocation 부재(sticky 케이스 등) 시 placeholder 0. 신뢰도 보조 신호로 사용 금지 —
+    // distanceKm은 화면 표시용이며 알람/정확도 판단은 source=='position-train'으로만 분기.
+    const distanceKm = gps.userLocation
+      ? haversine(gps.userLocation.lat, gps.userLocation.lng, station.lat, station.lng)
+      : 0;
+    return { station, distanceKm };
+  }, [trainProgress, gps.userLocation]);
+
   const routeResult: NearestStationResult | null = progress.position
     ? {
         station: progress.position.current,
@@ -147,11 +196,34 @@ export function useFusedNearestStation(
       }
     : null;
 
+  // 우선순위(Phase 1C 역전): position-train > position/arrival(fused) > route-progress > gps.
+  // 기존: route-progress가 fused를 덮어쓰고 있었음.
+  let result: NearestStationResult | null;
+  let confidence: FusionConfidence;
+  let source: FusionSource;
+  if (positionTrainResult) {
+    result = positionTrainResult;
+    confidence = 'position-train';
+    source = 'position-train';
+  } else if (fused) {
+    result = fused.result;
+    confidence = fused.confidence;
+    source = fused.source;
+  } else if (routeResult) {
+    result = routeResult;
+    confidence = 'route-progress';
+    source = 'route-progress';
+  } else {
+    result = gps.result;
+    confidence = 'gps-only';
+    source = 'gps';
+  }
+
   return {
-    result: routeResult ?? fused?.result ?? gps.result,
+    result,
     gpsResult: gps.result,
-    confidence: routeResult ? 'route-progress' : fused?.confidence ?? 'gps-only',
-    source: routeResult ? 'route-progress' : fused?.source ?? 'gps',
+    confidence,
+    source,
     variants: gps.variants,
     userLocation: gps.userLocation,
     speedMps: gps.speedMps,

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -11,16 +11,24 @@ import { getTrainStatusPriority } from '../constants/trainStatus';
  * 도착/위치 API와 달리 자체 검증 신호가 아니라 별도 confidence로 둔다.
  */
 export type FusionConfidence =
+  | 'position-train'
   | 'arrival-confirmed'
   | 'arrival-arriving'
   | 'route-progress'
   | 'gps-only';
 
 /**
- * fusion 신호 출처. position이 가장 정확(실제 좌표), arrival은 추정(곧 도착),
- * route-progress는 트랙 1D 진행도, gps는 거리 기반. 알람 dedup·로깅에서 source별 정책 분기에 사용.
+ * fusion 신호 출처. position-train이 가장 정확(특정 trainNo 추적 → 현재역),
+ * position은 station 단위 trainSttus 직접 매칭, arrival은 추정(곧 도착),
+ * route-progress는 트랙 1D 진행도, gps는 거리 기반.
+ * 알람 dedup·로깅에서 source별 정책 분기에 사용.
  */
-export type FusionSource = 'position' | 'arrival' | 'route-progress' | 'gps';
+export type FusionSource =
+  | 'position-train'
+  | 'position'
+  | 'arrival'
+  | 'route-progress'
+  | 'gps';
 
 export interface FusedStationResult {
   result: NearestStationResult;


### PR DESCRIPTION
## Summary
- `FusionSource`/`FusionConfidence`에 `position-train` 추가
- `trackTrainProgress` 통합 — 단일/sticky/gps-disambiguated trainNo로 현재역 결정
- 우선순위 역전: `position-train > position > arrival > route-progress > gps`
- `route-progress`가 fused를 덮어쓰던 로직 제거 → 자연 fallback으로 격하
- if-else 분기로 `result`/`confidence`/`source` 정합성 컴파일러 보장

## Test plan
- [x] `npm test` 1114 passed, 100% 커버리지
- [x] `npm run type-check` 통과
- [x] 회귀: route 미설정 시 기존 GPS+arrival fusion 동작 유지
- [x] 회귀: route 설정 + fused/position-train 없으면 route-progress 사용

## 측정
- 머지 후 약 1주간 디버그 모달(#322) 로그로 `source` 분포 / `confidence` 변화 측정
- 결과에 따라 Phase 2~4 우선순위 결정

Closes #325