### PR TITLE
feat(#334): 사전 예약 알림 시스템 — alarmScheduler 인프라

### DIFF
--- a/src/utils/__tests__/alarmScheduler.test.ts
+++ b/src/utils/__tests__/alarmScheduler.test.ts
@@ -46,24 +46,24 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 600,
+      nextStationEtaSeconds: 600,
       now: NOW,
     });
 
     expect(result).toHaveLength(2);
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(2);
 
-    // early: waypoint ETA 600 - 90 = 510s 후
-    // imminent: 600 - 10 = 590s 후
+    // finalEta = 600 + (10-1)*90 = 1410s, destination ETA = 1410s
+    // early: 1410 - 90 = 1320s, imminent: 1410 - 10 = 1400s
     expect(result[0]).toMatchObject({
       identifier: 'alarm:early:강남',
       event: { phaseId: 'early', type: 'destination', stationName: '강남' },
-      fireDate: new Date(NOW + 510_000),
+      fireDate: new Date(NOW + 1_320_000),
     });
     expect(result[1]).toMatchObject({
       identifier: 'alarm:imminent:강남',
       event: { phaseId: 'imminent', type: 'destination', stationName: '강남' },
-      fireDate: new Date(NOW + 590_000),
+      fireDate: new Date(NOW + 1_400_000),
     });
   });
 
@@ -79,31 +79,32 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 1000,
+      nextStationEtaSeconds: 1000,
       now: NOW,
     });
 
     expect(result).toHaveLength(4);
 
-    // 환승역 waypoint ETA = (4/10) * 1000 = 400s
+    // finalEta = 1000 + (10-1)*90 = 1810s
+    // 환승역 ETA = (4/10) * 1810 = 724s
     expect(result[0]).toMatchObject({
       identifier: 'alarm:early:동대문',
       event: { phaseId: 'early', type: 'transfer', stationName: '동대문' },
-      fireDate: new Date(NOW + (400 - 90) * 1000),
+      fireDate: new Date(NOW + (724 - 90) * 1000),
     });
     expect(result[1]).toMatchObject({
       identifier: 'alarm:imminent:동대문',
-      fireDate: new Date(NOW + (400 - 10) * 1000),
+      fireDate: new Date(NOW + (724 - 10) * 1000),
     });
-    // 도착역 waypoint ETA = 1000s
+    // 도착역 ETA = 1810s
     expect(result[2]).toMatchObject({
       identifier: 'alarm:early:강남',
       event: { phaseId: 'early', type: 'destination', stationName: '강남' },
-      fireDate: new Date(NOW + (1000 - 90) * 1000),
+      fireDate: new Date(NOW + (1810 - 90) * 1000),
     });
     expect(result[3]).toMatchObject({
       identifier: 'alarm:imminent:강남',
-      fireDate: new Date(NOW + (1000 - 10) * 1000),
+      fireDate: new Date(NOW + (1810 - 10) * 1000),
     });
   });
 
@@ -119,7 +120,7 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 1000,
+      nextStationEtaSeconds: 1000,
       now: NOW,
     });
 
@@ -134,13 +135,13 @@ describe('scheduleAlarmsForRoute', () => {
     ]);
   });
 
-  it('arrivalEtaSeconds가 null이면 calculateStaticETA로 fallback한다', async () => {
+  it('nextStationEtaSeconds가 null이면 calculateStaticETA로 fallback한다', async () => {
     const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
     // calculateStaticETA(direct stops=10) = 3 wait + 10*2 = 23 min = 1380s
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: null,
+      nextStationEtaSeconds: null,
       now: NOW,
     });
 
@@ -149,12 +150,12 @@ describe('scheduleAlarmsForRoute', () => {
     expect(result[1].fireDate).toEqual(new Date(NOW + (1380 - 10) * 1000));
   });
 
-  it('arrivalEtaSeconds가 0 이하면 fallback을 사용한다', async () => {
+  it('nextStationEtaSeconds가 0 이하면 fallback을 사용한다', async () => {
     const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 0,
+      nextStationEtaSeconds: 0,
       now: NOW,
     });
     // staticETA fallback 적용 → 1380s
@@ -166,7 +167,7 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 600,
+      nextStationEtaSeconds: 600,
       now: NOW,
     });
 
@@ -176,26 +177,25 @@ describe('scheduleAlarmsForRoute', () => {
 
   it('phase 시각이 과거(now 이전)면 해당 알람은 건너뛴다', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '1' };
-    // ETA 5s → early(5-90=-85, skip), imminent(5-10=-5, skip) → 0개
+    // stops=1 → finalEta = 5 + 0*90 = 5s → early(5-90<0 skip), imminent(5-10<0 skip) → 0개
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 5,
+      nextStationEtaSeconds: 5,
       now: NOW,
     });
 
     expect(result).toEqual([]);
   });
 
-  it('early만 미래이고 imminent가 과거면 early만 예약한다', async () => {
+  it('early만 미래이고 imminent가 과거면 한쪽만 예약한다', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '1' };
-    // ETA 95s → early(95-90=5, 예약), imminent(95-10=85, 예약)
-    // ETA 8s → 둘 다 과거
-    // ETA 50s → early(50-90=-40 skip), imminent(50-10=40, 예약)
+    // stops=1, ETA 50 → finalEta = 50s
+    // early: 50-90 = -40 skip, imminent: 50-10 = 40, 예약
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 50,
+      nextStationEtaSeconds: 50,
       now: NOW,
     });
 
@@ -208,7 +208,7 @@ describe('scheduleAlarmsForRoute', () => {
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 600,
+      nextStationEtaSeconds: 600,
       now: NOW,
     });
 
@@ -228,7 +228,7 @@ describe('scheduleAlarmsForRoute', () => {
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 600,
+      nextStationEtaSeconds: 600,
       now: NOW,
     });
 
@@ -246,14 +246,14 @@ describe('scheduleAlarmsForRoute', () => {
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 600,
+      nextStationEtaSeconds: 600,
       now: NOW,
     });
 
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         identifier: 'alarm:early:강남',
-        trigger: { type: 'date', date: new Date(NOW + 510_000) },
+        trigger: { type: 'date', date: new Date(NOW + 1_320_000) },
       }),
     );
   });
@@ -264,14 +264,14 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      arrivalEtaSeconds: 600,
+      nextStationEtaSeconds: 600,
     });
     const after = Date.now();
 
-    // early fireDate ≈ now + 510s
+    // early fireDate ≈ now + 1320s
     const fire = result[0].fireDate.getTime();
-    expect(fire).toBeGreaterThanOrEqual(before + 510_000);
-    expect(fire).toBeLessThanOrEqual(after + 510_000);
+    expect(fire).toBeGreaterThanOrEqual(before + 1_320_000);
+    expect(fire).toBeLessThanOrEqual(after + 1_320_000);
   });
 });
 

--- a/src/utils/__tests__/alarmScheduler.test.ts
+++ b/src/utils/__tests__/alarmScheduler.test.ts
@@ -1,0 +1,310 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import {
+  scheduleAlarmsForRoute,
+  cancelScheduledAlarms,
+  scheduledAlarmIdentifier,
+} from '../alarmScheduler';
+import type {
+  DirectRoute,
+  TransferRoute,
+  MultiTransferRoute,
+} from '../stationRoute';
+
+jest.mock('expo-notifications');
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const NOW = new Date('2026-05-13T12:00:00Z').getTime();
+
+describe('scheduledAlarmIdentifier', () => {
+  it('phaseId와 stationName을 prefix와 결합한 id를 반환한다', () => {
+    expect(scheduledAlarmIdentifier({ phaseId: 'early', stationName: '강남' })).toBe(
+      'alarm:early:강남',
+    );
+    expect(scheduledAlarmIdentifier({ phaseId: 'imminent', stationName: '시청' })).toBe(
+      'alarm:imminent:시청',
+    );
+  });
+});
+
+describe('scheduleAlarmsForRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('id');
+    jest.replaceProperty(Platform, 'OS', 'ios');
+  });
+
+  it('direct 경로는 도착역 1 waypoint × 2 phase = 2개 알람을 예약한다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 600,
+      now: NOW,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(2);
+
+    // early: waypoint ETA 600 - 90 = 510s 후
+    // imminent: 600 - 10 = 590s 후
+    expect(result[0]).toMatchObject({
+      identifier: 'alarm:early:강남',
+      event: { phaseId: 'early', type: 'destination', stationName: '강남' },
+      fireDate: new Date(NOW + 510_000),
+    });
+    expect(result[1]).toMatchObject({
+      identifier: 'alarm:imminent:강남',
+      event: { phaseId: 'imminent', type: 'destination', stationName: '강남' },
+      fireDate: new Date(NOW + 590_000),
+    });
+  });
+
+  it('transfer 경로는 환승 + 도착 = 2 waypoint × 2 phase = 4개 알람을 예약한다 (2(N+1), N=1)', async () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '동대문',
+      fromLine: '1',
+      toLine: '4',
+      stopsToTransfer: 4,
+      stopsFromTransfer: 6,
+    };
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 1000,
+      now: NOW,
+    });
+
+    expect(result).toHaveLength(4);
+
+    // 환승역 waypoint ETA = (4/10) * 1000 = 400s
+    expect(result[0]).toMatchObject({
+      identifier: 'alarm:early:동대문',
+      event: { phaseId: 'early', type: 'transfer', stationName: '동대문' },
+      fireDate: new Date(NOW + (400 - 90) * 1000),
+    });
+    expect(result[1]).toMatchObject({
+      identifier: 'alarm:imminent:동대문',
+      fireDate: new Date(NOW + (400 - 10) * 1000),
+    });
+    // 도착역 waypoint ETA = 1000s
+    expect(result[2]).toMatchObject({
+      identifier: 'alarm:early:강남',
+      event: { phaseId: 'early', type: 'destination', stationName: '강남' },
+      fireDate: new Date(NOW + (1000 - 90) * 1000),
+    });
+    expect(result[3]).toMatchObject({
+      identifier: 'alarm:imminent:강남',
+      fireDate: new Date(NOW + (1000 - 10) * 1000),
+    });
+  });
+
+  it('multi-transfer 경로는 3 waypoint × 2 phase = 6개 알람을 예약한다 (N=2)', async () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 3 },
+        { transferName: '서울역', fromLine: '4', toLine: '2', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 2,
+    };
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 1000,
+      now: NOW,
+    });
+
+    expect(result).toHaveLength(6);
+    expect(result.map((r) => r.identifier)).toEqual([
+      'alarm:early:동대문',
+      'alarm:imminent:동대문',
+      'alarm:early:서울역',
+      'alarm:imminent:서울역',
+      'alarm:early:강남',
+      'alarm:imminent:강남',
+    ]);
+  });
+
+  it('arrivalEtaSeconds가 null이면 calculateStaticETA로 fallback한다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    // calculateStaticETA(direct stops=10) = 3 wait + 10*2 = 23 min = 1380s
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: null,
+      now: NOW,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].fireDate).toEqual(new Date(NOW + (1380 - 90) * 1000));
+    expect(result[1].fireDate).toEqual(new Date(NOW + (1380 - 10) * 1000));
+  });
+
+  it('arrivalEtaSeconds가 0 이하면 fallback을 사용한다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 0,
+      now: NOW,
+    });
+    // staticETA fallback 적용 → 1380s
+    expect(result[0].fireDate).toEqual(new Date(NOW + (1380 - 90) * 1000));
+  });
+
+  it('totalStops가 0이면 빈 배열을 반환한다 (이미 목적지)', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 0, line: '1' };
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 600,
+      now: NOW,
+    });
+
+    expect(result).toEqual([]);
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('phase 시각이 과거(now 이전)면 해당 알람은 건너뛴다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '1' };
+    // ETA 5s → early(5-90=-85, skip), imminent(5-10=-5, skip) → 0개
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 5,
+      now: NOW,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('early만 미래이고 imminent가 과거면 early만 예약한다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '1' };
+    // ETA 95s → early(95-90=5, 예약), imminent(95-10=85, 예약)
+    // ETA 8s → 둘 다 과거
+    // ETA 50s → early(50-90=-40 skip), imminent(50-10=40, 예약)
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 50,
+      now: NOW,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].identifier).toBe('alarm:imminent:강남');
+  });
+
+  it('iOS에서는 interruptionLevel: timeSensitive를 포함한다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 600,
+      now: NOW,
+    });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          sound: 'alarm.wav',
+          interruptionLevel: 'timeSensitive',
+        }),
+      }),
+    );
+  });
+
+  it('Android에서는 channelId와 priority MAX를 포함한다', async () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 600,
+      now: NOW,
+    });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          channelId: 'station-alarm',
+        }),
+      }),
+    );
+  });
+
+  it('scheduleNotificationAsync 호출 시 trigger.date에 fireDate가 전달된다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 600,
+      now: NOW,
+    });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifier: 'alarm:early:강남',
+        trigger: { type: 'date', date: new Date(NOW + 510_000) },
+      }),
+    );
+  });
+
+  it('now를 생략하면 Date.now()를 사용한다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const before = Date.now();
+    const result = await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      arrivalEtaSeconds: 600,
+    });
+    const after = Date.now();
+
+    // early fireDate ≈ now + 510s
+    const fire = result[0].fireDate.getTime();
+    expect(fire).toBeGreaterThanOrEqual(before + 510_000);
+    expect(fire).toBeLessThanOrEqual(after + 510_000);
+  });
+});
+
+describe('cancelScheduledAlarms', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('alarm: prefix를 가진 알림만 취소한다', async () => {
+    (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([
+      { identifier: 'alarm:early:강남' },
+      { identifier: 'alarm:imminent:강남' },
+      { identifier: 'current-station' },
+      { identifier: 'station-passed' },
+    ]);
+
+    await cancelScheduledAlarms();
+
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledTimes(2);
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('alarm:early:강남');
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith(
+      'alarm:imminent:강남',
+    );
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalledWith(
+      'current-station',
+    );
+  });
+
+  it('예약된 알람이 없으면 cancel을 호출하지 않는다', async () => {
+    (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+
+    await cancelScheduledAlarms();
+
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/alarmScheduler.ts
+++ b/src/utils/alarmScheduler.ts
@@ -1,7 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
-import { resolveAllTargets, type AlarmEvent } from './stationAlarm';
+import { alarmKey, resolveAllTargets, type AlarmEvent } from './stationAlarm';
 import { calculateStaticETA, type Route } from './stationRoute';
 import { buildAlarmContent } from './stationNotification';
 import { createLogger } from './logger';
@@ -19,7 +19,7 @@ const PHASE_LEAD_SECONDS: Record<AlarmPhaseId, number> = {
 };
 
 export function scheduledAlarmIdentifier(event: Pick<AlarmEvent, 'phaseId' | 'stationName'>): string {
-  return `${SCHEDULED_ALARM_PREFIX}${event.phaseId}:${event.stationName}`;
+  return `${SCHEDULED_ALARM_PREFIX}${alarmKey(event)}`;
 }
 
 export interface ScheduledAlarm {
@@ -31,8 +31,11 @@ export interface ScheduledAlarm {
 export interface ScheduleAlarmsParams {
   route: NonNullable<Route>;
   destinationName: string;
-  /** Seoul Arrival API 첫 결과(초). null이면 calculateStaticETA로 fallback. */
-  arrivalEtaSeconds: number | null;
+  /**
+   * Seoul Arrival API 첫 결과 — 다음 도착역까지 ETA(초).
+   * null이면 calculateStaticETA로 목적지 ETA를 fallback 계산한다.
+   */
+  nextStationEtaSeconds: number | null;
   /** 테스트에서 시각 주입용. 기본값은 Date.now(). */
   now?: number;
 }
@@ -47,13 +50,13 @@ export interface ScheduleAlarmsParams {
 export async function scheduleAlarmsForRoute(
   params: ScheduleAlarmsParams,
 ): Promise<ScheduledAlarm[]> {
-  const { route, destinationName, arrivalEtaSeconds, now = Date.now() } = params;
+  const { route, destinationName, nextStationEtaSeconds, now = Date.now() } = params;
 
   const targets = resolveAllTargets(route, destinationName);
   const totalStops = targets.reduce((sum, t) => sum + t.stops, 0);
   if (totalStops === 0) return [];
 
-  const finalEtaSeconds = resolveFinalEtaSeconds(arrivalEtaSeconds, route);
+  const finalEtaSeconds = resolveFinalEtaSeconds(nextStationEtaSeconds, totalStops, route);
 
   const scheduled: ScheduledAlarm[] = [];
   let cumulativeStops = 0;
@@ -113,12 +116,19 @@ export async function cancelScheduledAlarms(): Promise<void> {
   logger.info(`cancelled ${cancelled} scheduled alarms`);
 }
 
+/**
+ * 첫 도착역까지의 ETA로부터 최종 목적지 ETA를 추정한다.
+ * API 값이 있으면: nextStation ETA + (남은 정거장 - 1) × 90s.
+ * 환승 페널티는 무시한다 — Phase 1 baseline. 정확도는 reschedule(#335)이 보정.
+ * 없으면 calculateStaticETA(분)로 fallback.
+ */
 function resolveFinalEtaSeconds(
-  arrivalEtaSeconds: number | null,
+  nextStationEtaSeconds: number | null,
+  totalStops: number,
   route: NonNullable<Route>,
 ): number {
-  if (arrivalEtaSeconds != null && arrivalEtaSeconds > 0) {
-    return arrivalEtaSeconds;
+  if (nextStationEtaSeconds != null && nextStationEtaSeconds > 0) {
+    return nextStationEtaSeconds + (totalStops - 1) * ONE_STOP_SECONDS;
   }
   // calculateStaticETA는 NonNullable Route에 대해 항상 number를 반환한다.
   return (calculateStaticETA(route) as number) * 60;

--- a/src/utils/alarmScheduler.ts
+++ b/src/utils/alarmScheduler.ts
@@ -1,0 +1,125 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
+import { resolveAllTargets, type AlarmEvent } from './stationAlarm';
+import { calculateStaticETA, type Route } from './stationRoute';
+import { buildAlarmContent } from './stationNotification';
+import { createLogger } from './logger';
+
+const logger = createLogger('AlarmScheduler');
+
+const SCHEDULED_ALARM_PREFIX = 'alarm:';
+const ONE_STOP_SECONDS = 90;
+const IMMINENT_LEAD_SECONDS = 10;
+const ALARM_CHANNEL_ID = 'station-alarm';
+
+const PHASE_LEAD_SECONDS: Record<AlarmPhaseId, number> = {
+  early: ONE_STOP_SECONDS,
+  imminent: IMMINENT_LEAD_SECONDS,
+};
+
+export function scheduledAlarmIdentifier(event: Pick<AlarmEvent, 'phaseId' | 'stationName'>): string {
+  return `${SCHEDULED_ALARM_PREFIX}${event.phaseId}:${event.stationName}`;
+}
+
+export interface ScheduledAlarm {
+  identifier: string;
+  event: AlarmEvent;
+  fireDate: Date;
+}
+
+export interface ScheduleAlarmsParams {
+  route: NonNullable<Route>;
+  destinationName: string;
+  /** Seoul Arrival API 첫 결과(초). null이면 calculateStaticETA로 fallback. */
+  arrivalEtaSeconds: number | null;
+  /** 테스트에서 시각 주입용. 기본값은 Date.now(). */
+  now?: number;
+}
+
+/**
+ * route + destination ETA → 각 waypoint별 (early, imminent) 두 phase에 대해
+ * 절대 시각으로 사전 예약. BG에서 "사용 중" 권한만으로도 알람이 발사된다.
+ *
+ * waypoint별 시각은 누적 정거장 수 비율로 finalEtaSeconds를 안분한다.
+ * 과거 시각으로 산출된 알람은 건너뛴다.
+ */
+export async function scheduleAlarmsForRoute(
+  params: ScheduleAlarmsParams,
+): Promise<ScheduledAlarm[]> {
+  const { route, destinationName, arrivalEtaSeconds, now = Date.now() } = params;
+
+  const targets = resolveAllTargets(route, destinationName);
+  const totalStops = targets.reduce((sum, t) => sum + t.stops, 0);
+  if (totalStops === 0) return [];
+
+  const finalEtaSeconds = resolveFinalEtaSeconds(arrivalEtaSeconds, route);
+
+  const scheduled: ScheduledAlarm[] = [];
+  let cumulativeStops = 0;
+
+  for (const target of targets) {
+    cumulativeStops += target.stops;
+    const waypointEtaSeconds = (cumulativeStops / totalStops) * finalEtaSeconds;
+
+    for (const phase of ALARM_PHASES) {
+      const fireSeconds = waypointEtaSeconds - PHASE_LEAD_SECONDS[phase.id];
+      if (fireSeconds <= 0) continue;
+
+      const event: AlarmEvent = {
+        phaseId: phase.id,
+        type: target.alarmType,
+        stationName: target.name,
+      };
+      const identifier = scheduledAlarmIdentifier(event);
+      const fireDate = new Date(now + fireSeconds * 1000);
+      const { title, body } = buildAlarmContent(event);
+
+      await Notifications.scheduleNotificationAsync({
+        identifier,
+        content: {
+          title,
+          body,
+          sound: 'alarm.wav',
+          ...(Platform.OS === 'android' && {
+            channelId: ALARM_CHANNEL_ID,
+            priority: Notifications.AndroidNotificationPriority.MAX,
+          }),
+          ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
+        },
+        trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: fireDate },
+      });
+
+      scheduled.push({ identifier, event, fireDate });
+    }
+  }
+
+  logger.info(`scheduled ${scheduled.length} alarms for ${targets.length} waypoints`);
+  return scheduled;
+}
+
+/**
+ * 본 모듈이 예약한 알람만 취소한다 (prefix로 필터). 다른 알림은 건드리지 않는다.
+ */
+export async function cancelScheduledAlarms(): Promise<void> {
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let cancelled = 0;
+  for (const req of all) {
+    if (req.identifier.startsWith(SCHEDULED_ALARM_PREFIX)) {
+      await Notifications.cancelScheduledNotificationAsync(req.identifier);
+      cancelled++;
+    }
+  }
+  logger.info(`cancelled ${cancelled} scheduled alarms`);
+}
+
+function resolveFinalEtaSeconds(
+  arrivalEtaSeconds: number | null,
+  route: NonNullable<Route>,
+): number {
+  if (arrivalEtaSeconds != null && arrivalEtaSeconds > 0) {
+    return arrivalEtaSeconds;
+  }
+  // calculateStaticETA는 NonNullable Route에 대해 항상 number를 반환한다.
+  return (calculateStaticETA(route) as number) * 60;
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -394,7 +394,7 @@ const ALARM_MESSAGE_BUILDERS: Record<AlarmPhaseId, (stationName: string, isTrans
   }),
 };
 
-function buildAlarmContent(event: AlarmEvent): { title: string; body: string } {
+export function buildAlarmContent(event: AlarmEvent): { title: string; body: string } {
   return ALARM_MESSAGE_BUILDERS[event.phaseId](event.stationName, event.type === 'transfer');
 }
 


### PR DESCRIPTION
## Summary

- 신규 `src/utils/alarmScheduler.ts`: `scheduleAlarmsForRoute` / `cancelScheduledAlarms` / `scheduledAlarmIdentifier` 추가
- route를 순회해 waypoint별 시각을 계산하고 `Notifications.scheduleNotificationAsync({ trigger: { type: 'date', date } })`로 사전 예약 → iOS "사용 중" 권한만으로도 BG 알람 동작 baseline 확보
- identifier 규약 `alarm:{phaseId}:{stationName}` — `alarmKey()` 함수 재사용으로 런타임 규약과 동기화
- 산식:
  - `finalEta = nextStationEtaSeconds + (totalStops − 1) × 90s` (API 값 우선) / `calculateStaticETA × 60s` fallback
  - waypoint ETA는 누적 정거장 비율로 안분
  - `early = waypoint ETA − 90s`, `imminent = waypoint ETA − 10s`
- direct/transfer/multi-transfer 환승 N회 경로는 정확히 2(N+1)개 알림 예약
- 과거 시각으로 산출된 알람은 건너뜀
- `stationNotification.ts`의 `buildAlarmContent`를 export해 content 빌더 공유 (중복 금지)

## 코드 리뷰 반영 (2번째 커밋)
- `arrivalEtaSeconds` → `nextStationEtaSeconds`로 개명. "Seoul Arrival API 첫 결과"가 다음역까지 ETA임을 명확히 함.
- `scheduledAlarmIdentifier`는 `alarmKey()` 재사용으로 DRY.

## Test plan

- [x] `npm test` 통과 (1133/1133, coverage 100%)
- [x] `npm run type-check` 통과
- [x] `scheduledAlarmIdentifier` 규약 검증
- [x] direct / transfer / multi-transfer 경로 각각 2(N+1)개 예약 검증
- [x] phase 시각 산식 (early −90s, imminent −10s) 검증
- [x] `nextStationEtaSeconds` null/0 → `calculateStaticETA` fallback 검증
- [x] 과거 시각 phase 건너뜀 / 일부만 미래인 케이스 검증
- [x] iOS `interruptionLevel: timeSensitive` / Android `channelId` 검증
- [x] `cancelScheduledAlarms` — `alarm:` prefix 알림만 취소, 다른 알림은 보존
- [ ] 실기기 BG 시각 검증 (별도 QA)

## 제외 (별개 이슈)
- reschedule 트리거(arrival 변경/FG 복귀) — #335
- FG↔BG firedAlarms 단일 출처 통합 — #336
- silent push 백엔드 — #337/#338

Closes #334