### PR TITLE
fix(#336): firedAlarms BG/FG 단일 출처 통합

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -29,9 +29,15 @@ jest.mock('../../utils/stationPipeline', () => ({
 
 const mockGetLastNotifiedStationId = jest.fn();
 const mockSetLastNotifiedStationId = jest.fn();
+const mockGetFiredAlarms = jest.fn();
+const mockSetFiredAlarms = jest.fn();
+const mockClearFiredAlarms = jest.fn();
 jest.mock('../../utils/notificationState', () => ({
   getLastNotifiedStationId: (...args: unknown[]) => mockGetLastNotifiedStationId(...args),
   setLastNotifiedStationId: (...args: unknown[]) => mockSetLastNotifiedStationId(...args),
+  getFiredAlarms: (...args: unknown[]) => mockGetFiredAlarms(...args),
+  setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
+  clearFiredAlarms: (...args: unknown[]) => mockClearFiredAlarms(...args),
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -92,6 +98,9 @@ describe('useStationAlarm', () => {
     mockResolveNextTarget.mockReturnValue(null);
     mockGetLastNotifiedStationId.mockResolvedValue(null);
     mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+    mockGetFiredAlarms.mockResolvedValue(new Set<string>());
+    mockSetFiredAlarms.mockResolvedValue(undefined);
+    mockClearFiredAlarms.mockResolvedValue(undefined);
   });
 
   it('does not evaluate when route is null', () => {
@@ -121,7 +130,7 @@ describe('useStationAlarm', () => {
     expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
   });
 
-  it('evaluates when accuracy is exactly the alarm gate (boundary inclusive)', () => {
+  it('evaluates when accuracy is exactly the alarm gate (boundary inclusive)', async () => {
     const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() =>
       useStationAlarm(
@@ -134,7 +143,7 @@ describe('useStationAlarm', () => {
         }),
       ),
     );
-    expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
+    await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
   });
 
   describe('arrival fusion 보조 트리거 (Stage 3)', () => {
@@ -205,7 +214,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      expect(mockEvaluateAlarmPhase).toHaveBeenCalled();
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
     });
 
@@ -227,7 +236,7 @@ describe('useStationAlarm', () => {
     });
   });
 
-  it('builds AlarmSource and calls evaluator', () => {
+  it('builds AlarmSource and calls evaluator', async () => {
     const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() =>
       useStationAlarm(
@@ -239,46 +248,54 @@ describe('useStationAlarm', () => {
         }),
       ),
     );
-    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
-      expect.objectContaining({
-        route,
-        destinationName: '강남',
-        etaSeconds: expect.any(Number),
-      }),
-      expect.any(Set),
+    await waitFor(() =>
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          route,
+          destinationName: '강남',
+          etaSeconds: expect.any(Number),
+        }),
+        expect.any(Set),
+      ),
     );
   });
 
-  it('passes null etaSeconds when speed is null', () => {
+  it('passes null etaSeconds when speed is null', async () => {
     const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() =>
       useStationAlarm(
         defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127.0 }, speedMps: null }),
       ),
     );
-    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
-      expect.objectContaining({ etaSeconds: null }),
-      expect.any(Set),
+    await waitFor(() =>
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ etaSeconds: null }),
+        expect.any(Set),
+      ),
     );
   });
 
-  it('passes null etaSeconds when userLocation is null', () => {
+  it('passes null etaSeconds when userLocation is null', async () => {
     const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
     renderHook(() => useStationAlarm(defaultInputs({ route, destination, speedMps: 10 })));
-    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
-      expect.objectContaining({ etaSeconds: null }),
-      expect.any(Set),
+    await waitFor(() =>
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ etaSeconds: null }),
+        expect.any(Set),
+      ),
     );
   });
 
-  it('sends alarm notification with the full event', () => {
+  it('sends alarm notification with the full event', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true);
+    await waitFor(() =>
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true),
+    );
   });
 
-  it('sends transfer alarm for transfer route', () => {
+  it('sends transfer alarm for transfer route', async () => {
     const route: TransferRoute = {
       type: 'transfer',
       transferName: '시청',
@@ -289,10 +306,12 @@ describe('useStationAlarm', () => {
     };
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true);
+    await waitFor(() =>
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true),
+    );
   });
 
-  it('sends transfer alarm for multi-transfer route', () => {
+  it('sends transfer alarm for multi-transfer route', async () => {
     const route: MultiTransferRoute = {
       type: 'multi-transfer',
       transfers: [
@@ -303,19 +322,21 @@ describe('useStationAlarm', () => {
     };
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true);
+    await waitFor(() =>
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true),
+    );
   });
 
-  it('does not fire the same alarm twice', () => {
+  it('does not fire the same alarm twice', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
     rerender({});
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('fires imminent after early for the same waypoint', () => {
+  it('fires imminent after early for the same waypoint', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValueOnce(earlyDest);
     const { rerender } = renderHook(
@@ -326,69 +347,80 @@ describe('useStationAlarm', () => {
         },
       },
     );
-    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(earlyDest, false, true);
+    await waitFor(() =>
+      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(earlyDest, false, true),
+    );
 
     mockEvaluateAlarmPhase.mockReturnValueOnce(imminentDest);
     rerender({
       inputs: defaultInputs({ route, destination, userLocation: { lat: 37.49, lng: 127.025 }, speedMps: 20 }),
     });
-    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(imminentDest, false, true);
+    await waitFor(() =>
+      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(imminentDest, false, true),
+    );
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
   });
 
-  it('resets fired alarms when destination changes', () => {
+  it('resets fired alarms when destination changes', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(
       ({ dest }: { dest: Station }) => useStationAlarm(defaultInputs({ route, destination: dest })),
       { initialProps: { dest: destination } },
     );
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
 
     const altEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '잠실' };
     mockEvaluateAlarmPhase.mockReturnValue(altEvent);
     rerender({ dest: altDestination });
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2));
     expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(altEvent, false, true);
+    // destination 변경 시 AsyncStorage의 firedAlarms도 클리어해 BG와 단일 출처를 유지한다.
+    expect(mockClearFiredAlarms).toHaveBeenCalled();
   });
 
-  it('passes sleepMode to sendAlarmNotification', () => {
+  it('passes sleepMode to sendAlarmNotification', async () => {
     useAppStore.setState({ sleepMode: true });
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, true, true);
+    await waitFor(() =>
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, true, true),
+    );
   });
 
-  it('sets alarmEvent in store when sleepMode is on', () => {
+  it('sets alarmEvent in store when sleepMode is on', async () => {
     useAppStore.setState({ sleepMode: true });
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(useAppStore.getState().alarmEvent).toEqual(earlyDest);
+    await waitFor(() => expect(useAppStore.getState().alarmEvent).toEqual(earlyDest));
   });
 
-  it('does not set alarmEvent when sleepMode is off', () => {
+  it('does not set alarmEvent when sleepMode is off', async () => {
     useAppStore.setState({ sleepMode: false });
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
     expect(useAppStore.getState().alarmEvent).toBeNull();
   });
 
-  it('passes allowSpeaker=false from store', () => {
+  it('passes allowSpeaker=false from store', async () => {
     useAppStore.setState({ allowSpeaker: false });
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, false);
+    await waitFor(() =>
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, false),
+    );
   });
 
-  it('does not re-fire when sleepMode toggles after first fire', () => {
+  it('does not re-fire when sleepMode toggles after first fire', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
 
     useAppStore.setState({ sleepMode: true });
     rerender({});
@@ -741,6 +773,96 @@ describe('useStationAlarm', () => {
       await Promise.resolve();
 
       expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── BG↔FG firedAlarms 단일 출처 (#336 회귀 가드) ──
+  // BG가 AsyncStorage(FIRED_ALARMS_KEY)에 fired 알람을 기록한 뒤 FG로 복귀하면
+  // useStationAlarm은 시작 시 storage를 hydrate해 같은 phase를 재발화하지 않는다.
+  describe('firedAlarms BG↔FG 단일 출처 (#336)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+
+    it('BG가 발화한 phase를 마운트 시 hydrate해 FG에서 재발화하지 않는다', async () => {
+      // BG가 이미 발화: storage에 alarmKey가 있음.
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set([`early:${destination.name}`]));
+      // evaluator가 동일 키 firedAlarms를 받으면 null 반환하는 실제 dedup 의미를 흉내.
+      mockEvaluateAlarmPhase.mockImplementation((_src: unknown, fired: Set<string>) =>
+        fired.has(`early:${destination.name}`) ? null : earlyDest,
+      );
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      // hydrated 이후 evaluator가 호출되더라도 동일 키가 들어있어 null 반환 → 미발화.
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('FG에서 phase 발화 시 AsyncStorage에 setFiredAlarms로 동기화한다', async () => {
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith(
+        expect.any(Set),
+      );
+      // 발화된 alarmKey가 storage로 흘러갔는지 확인.
+      const lastCallArg = mockSetFiredAlarms.mock.calls.at(-1)?.[0] as Set<string>;
+      expect(lastCallArg.has(`early:${destination.name}`)).toBe(true);
+    });
+
+    it('destination 변경 시 AsyncStorage의 firedAlarms도 clear한다 (초기 바인드는 보존)', async () => {
+      // 첫 마운트 시 hydrate한 storage를 보존하기 위해 initial bind는 clear하지 않는다.
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set([`early:${destination.name}`]));
+      const { rerender } = renderHook(
+        ({ dest }: { dest: Station }) =>
+          useStationAlarm(defaultInputs({ route, destination: dest })),
+        { initialProps: { dest: destination } },
+      );
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      // 초기 바인드는 clear 하지 않음 — BG 적재 firedAlarms 보존
+      expect(mockClearFiredAlarms).not.toHaveBeenCalled();
+
+      // 실제 변경(다른 destination)은 clear 한다
+      rerender({ dest: altDestination });
+      await waitFor(() => expect(mockClearFiredAlarms).toHaveBeenCalledTimes(1));
+    });
+
+    it('초기 바인드 시 BG가 적재한 firedAlarms를 보존한다 (storage clear 없음)', async () => {
+      // BG가 발화한 phase가 storage에 있는 상태로 FG가 destination을 가진 채 마운트.
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set([`early:${destination.name}`]));
+      mockEvaluateAlarmPhase.mockImplementation((_src: unknown, fired: Set<string>) =>
+        fired.has(`early:${destination.name}`) ? null : earlyDest,
+      );
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+      // BG 적재로 인해 evaluator가 null 반환 → 미발화. storage도 clear되지 않음.
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockClearFiredAlarms).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -782,15 +782,14 @@ describe('useStationAlarm', () => {
   describe('firedAlarms BG↔FG 단일 출처 (#336)', () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
 
-    it('BG가 발화한 phase를 마운트 시 hydrate해 FG에서 재발화하지 않는다', async () => {
+    const renderWithBgFired = () => {
       // BG가 이미 발화: storage에 alarmKey가 있음.
       mockGetFiredAlarms.mockResolvedValueOnce(new Set([`early:${destination.name}`]));
       // evaluator가 동일 키 firedAlarms를 받으면 null 반환하는 실제 dedup 의미를 흉내.
       mockEvaluateAlarmPhase.mockImplementation((_src: unknown, fired: Set<string>) =>
         fired.has(`early:${destination.name}`) ? null : earlyDest,
       );
-
-      renderHook(() =>
+      return renderHook(() =>
         useStationAlarm(
           defaultInputs({
             route,
@@ -801,6 +800,10 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
+    };
+
+    it('BG가 발화한 phase를 마운트 시 hydrate해 FG에서 재발화하지 않는다', async () => {
+      renderWithBgFired();
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       // hydrated 이후 evaluator가 호출되더라도 동일 키가 들어있어 null 반환 → 미발화.
@@ -841,23 +844,7 @@ describe('useStationAlarm', () => {
     });
 
     it('초기 바인드 시 BG가 적재한 firedAlarms를 보존한다 (storage clear 없음)', async () => {
-      // BG가 발화한 phase가 storage에 있는 상태로 FG가 destination을 가진 채 마운트.
-      mockGetFiredAlarms.mockResolvedValueOnce(new Set([`early:${destination.name}`]));
-      mockEvaluateAlarmPhase.mockImplementation((_src: unknown, fired: Set<string>) =>
-        fired.has(`early:${destination.name}`) ? null : earlyDest,
-      );
-
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation: { lat: 37.4, lng: 127.0 },
-            speedMps: 10,
-            accuracyMeters: 100,
-          }),
-        ),
-      );
+      renderWithBgFired();
 
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
       // BG 적재로 인해 evaluator가 null 반환 → 미발화. storage도 clear되지 않음.

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { isStationOnRoute } from '../utils/stationRoute';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
@@ -6,7 +6,13 @@ import { alarmKey, evaluateAlarmPhase } from '../utils/stationAlarm';
 import { distanceMetersBetween, estimateEtaSeconds } from '../utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
 import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
-import { getLastNotifiedStationId, setLastNotifiedStationId } from '../utils/notificationState';
+import {
+  getLastNotifiedStationId,
+  setLastNotifiedStationId,
+  getFiredAlarms,
+  setFiredAlarms,
+  clearFiredAlarms,
+} from '../utils/notificationState';
 import {
   logFiredAlarm,
   logFiredStationPassed,
@@ -45,6 +51,10 @@ export function useStationAlarm({
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   const prevDestRef = useRef<string | null>(null);
+  // firedAlarms hydration: BG가 AsyncStorage(FIRED_ALARMS_KEY)에 쓴 dedup 상태를
+  // FG 마운트 시 ref에 복원한다. hydrated=false인 동안 phase 평가를 보류해
+  // 빈 ref로 false re-fire가 발생하지 않도록 가드한다.
+  const [firedHydrated, setFiredHydrated] = useState(false);
   const sleepMode = useAppStore((s) => s.sleepMode);
   const allowSpeaker = useAppStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
@@ -59,12 +69,40 @@ export function useStationAlarm({
     allowSpeakerRef.current = allowSpeaker;
   }, [allowSpeaker]);
 
+  // 마운트 시 한 번 — AsyncStorage에서 firedAlarms를 읽어 ref에 채운다.
+  // 이후 갱신은 destination 변경(클리어) / 발화(추가) 경로에서 동기적으로 처리.
   useEffect(() => {
     let cancelled = false;
+    void (async () => {
+      const stored = await getFiredAlarms();
+      if (cancelled) return;
+      firedAlarmsRef.current = stored;
+      setFiredHydrated(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Phase 알람 효과: ETA 기반 phase 평가 + firedAlarms 갱신.
+  // firedHydrated=false인 동안에는 보류 — BG가 이미 발화한 phase를 빈 ref로 재발화하는 것을 막는다.
+  // station-passed와 분리: 하이드레이션 완료로 인한 effect 재실행이 station-passed 중복 발사를
+  // 일으키지 않도록 한다(station-passed는 자체 lastNotifiedStationId dedup만 사용).
+  useEffect(() => {
+    // 하이드레이션 전에는 destination 변경 감지를 건너뛴다 — 첫 마운트 시
+    // prevDestRef가 비어 있어 모든 destination이 "변경"으로 보이지만, 그때 storage를
+    // 클리어하면 BG가 써둔 firedAlarms hydration이 무의미해진다.
+    if (!firedHydrated) return;
+
     const destinationName = destination?.name ?? null;
     if (destinationName !== prevDestRef.current) {
-      firedAlarmsRef.current = new Set();
+      const isInitialBind = prevDestRef.current === null;
       prevDestRef.current = destinationName;
+      if (!isInitialBind) {
+        firedAlarmsRef.current = new Set();
+        // AsyncStorage도 함께 비워 BG/FG 단일 출처를 유지한다.
+        void clearFiredAlarms();
+      }
     }
 
     if (!route || !destination) return;
@@ -72,48 +110,65 @@ export function useStationAlarm({
     // 알람 경로는 표시 경로보다 엄격한 정확도 게이트(MAX_ACCURACY_M=200m)를 적용한다.
     // useNearestStation은 지하 구간에서 정확도 1500m까지 표시용으로 수용하므로,
     // 그대로 알람을 울리면 잘못된 역에서 false alarm이 발생한다.
-    // 단, arrivalConfidence='arrival-confirmed'(arvlCd=1 도착)는 선로 신호 기반이라
-    // GPS 게이트가 막혀도 station-passed 알람은 허용한다(지하 누락 해소).
+    // Phase 알람은 ETA 거리 계산이 필요해 GPS 게이트가 통과한 경우에만 평가한다.
+    if (!isAccuracyAcceptable(accuracyMeters)) return;
+
+    let etaSeconds: number | null = null;
+    if (userLocation) {
+      const distM = distanceMetersBetween(
+        userLocation.lat,
+        userLocation.lng,
+        destination.lat,
+        destination.lng,
+      );
+      etaSeconds = estimateEtaSeconds(distM, speedMps);
+    }
+
+    const event = evaluateAlarmPhase(
+      { route, destinationName: destination.name, etaSeconds },
+      firedAlarmsRef.current,
+    );
+    if (event) {
+      firedAlarmsRef.current.add(alarmKey(event));
+      // AsyncStorage에도 즉시 반영 — FG/BG 단일 출처 유지.
+      void setFiredAlarms(firedAlarmsRef.current);
+      if (sleepModeRef.current) {
+        setAlarmEvent(event);
+      }
+      sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
+        logger.error('알람 알림 실패:', e),
+      );
+      logFiredAlarm('fg', event);
+    }
+  }, [
+    route,
+    destination?.id,
+    destination?.name,
+    destination?.lat,
+    destination?.lng,
+    userLocation?.lat,
+    userLocation?.lng,
+    speedMps,
+    accuracyMeters,
+    firedHydrated,
+    setAlarmEvent,
+  ]);
+
+  // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.
+  // dedup은 AsyncStorage(lastNotifiedStationId)를 단일 출처로 사용 — Foreground/Background
+  // 양쪽에서 동일하게 적용된다. firedHydrated에 의존하지 않으므로 하이드레이션 완료가
+  // station-passed를 재발사시키지 않는다.
+  useEffect(() => {
+    let cancelled = false;
+    if (!route || !destination) return;
+
     const accuracyOk = isAccuracyAcceptable(accuracyMeters);
     const arrivalConfirmed = arrivalConfidence === 'arrival-confirmed';
     if (!accuracyOk && !arrivalConfirmed) return;
 
-    // Phase 알람은 ETA 거리 계산이 필요해 GPS 게이트가 통과한 경우에만 평가한다.
-    if (accuracyOk) {
-      let etaSeconds: number | null = null;
-      if (userLocation) {
-        const distM = distanceMetersBetween(
-          userLocation.lat,
-          userLocation.lng,
-          destination.lat,
-          destination.lng,
-        );
-        etaSeconds = estimateEtaSeconds(distM, speedMps);
-      }
-
-      const event = evaluateAlarmPhase(
-        { route, destinationName: destination.name, etaSeconds },
-        firedAlarmsRef.current,
-      );
-      if (event) {
-        firedAlarmsRef.current.add(alarmKey(event));
-        if (sleepModeRef.current) {
-          setAlarmEvent(event);
-        }
-        sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
-          logger.error('알람 알림 실패:', e),
-        );
-        logFiredAlarm('fg', event);
-      }
-    }
-
-    // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
-    // 알림 상태는 notificationState 모듈(AsyncStorage)을 단일 출처로 사용해
-    // Foreground/Background 양쪽에서 동일한 dedup이 적용된다 — GPS·arrival 양쪽 트리거가
-    // 같은 역에 대해 중복 발화하지 않는다.
     // cancellation: 효과 cleanup이 cancelled를 true로 만들어 stale IIFE를 중단시킨다.
     // A→B→A 빠른 변동 시 이전 IIFE들이 cancelled로 차단되고 최신 candidate만 알림을 보낸다.
-    if (nearestStation && route && isStationOnRoute(nearestStation, route)) {
+    if (nearestStation && isStationOnRoute(nearestStation, route)) {
       const candidateStation = nearestStation;
       const capturedRoute = route;
       const capturedDestinationName = destination.name;
@@ -149,12 +204,7 @@ export function useStationAlarm({
     route,
     destination?.id,
     destination?.name,
-    destination?.lat,
-    destination?.lng,
     nearestStation?.id,
-    userLocation?.lat,
-    userLocation?.lng,
-    speedMps,
     accuracyMeters,
     arrivalConfidence,
   ]);

--- a/src/utils/__tests__/notificationState.test.ts
+++ b/src/utils/__tests__/notificationState.test.ts
@@ -3,8 +3,11 @@ import {
   getLastNotifiedStationId,
   setLastNotifiedStationId,
   clearLastNotifiedStationId,
+  getFiredAlarms,
+  setFiredAlarms,
+  clearFiredAlarms,
 } from '../notificationState';
-import { LAST_NOTIFIED_STATION_KEY } from '../../constants/storageKeys';
+import { LAST_NOTIFIED_STATION_KEY, FIRED_ALARMS_KEY } from '../../constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
@@ -82,6 +85,86 @@ describe('notificationState', () => {
       (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
       await expect(clearLastNotifiedStationId()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getFiredAlarms', () => {
+    it('AsyncStorage에서 FIRED_ALARMS_KEY를 JSON 배열로 읽어 Set으로 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(['a:X', 'b:Y']));
+
+      const result = await getFiredAlarms();
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(FIRED_ALARMS_KEY);
+      expect(result).toEqual(new Set(['a:X', 'b:Y']));
+    });
+
+    it('null 저장소면 빈 Set을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+      const result = await getFiredAlarms();
+
+      expect(result).toEqual(new Set());
+    });
+
+    it('JSON 파싱 실패 시 빈 Set을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+
+      const result = await getFiredAlarms();
+
+      expect(result).toEqual(new Set());
+    });
+
+    it('파싱은 됐지만 배열이 아니면 빈 Set을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
+
+      const result = await getFiredAlarms();
+
+      expect(result).toEqual(new Set());
+    });
+
+    it('AsyncStorage가 에러를 던지면 빈 Set을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      const result = await getFiredAlarms();
+
+      expect(result).toEqual(new Set());
+    });
+  });
+
+  describe('setFiredAlarms', () => {
+    it('Set을 JSON 배열로 직렬화해 FIRED_ALARMS_KEY로 저장한다', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await setFiredAlarms(new Set(['a:X', 'b:Y']));
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        FIRED_ALARMS_KEY,
+        expect.any(String),
+      );
+      const written = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(new Set(written)).toEqual(new Set(['a:X', 'b:Y']));
+    });
+
+    it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      await expect(setFiredAlarms(new Set(['a:X']))).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearFiredAlarms', () => {
+    it('AsyncStorage에서 FIRED_ALARMS_KEY를 삭제한다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await clearFiredAlarms();
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(FIRED_ALARMS_KEY);
+    });
+
+    it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+
+      await expect(clearFiredAlarms()).resolves.toBeUndefined();
     });
   });
 });

--- a/src/utils/notificationState.ts
+++ b/src/utils/notificationState.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
+import { LAST_NOTIFIED_STATION_KEY, FIRED_ALARMS_KEY } from '../constants/storageKeys';
 import { createLogger } from './logger';
 
 // Foreground/Background 양쪽에서 호출되는 알림 상태 저장소.
@@ -45,4 +45,27 @@ export function setLastNotifiedStationId(id: string): Promise<void> {
 
 export function clearLastNotifiedStationId(): Promise<void> {
   return safeRemoveItem(LAST_NOTIFIED_STATION_KEY);
+}
+
+// firedAlarms: 알람 phase 중복 발화 dedup 단일 출처.
+// Foreground 훅(useStationAlarm)과 Background task(backgroundLocationTask)가
+// 같은 키를 공유해, BG fired 알람이 FG 복귀 후 재발화되지 않도록 한다.
+export async function getFiredAlarms(): Promise<Set<string>> {
+  const raw = await safeGetItem(FIRED_ALARMS_KEY);
+  if (!raw) return new Set();
+  try {
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed : []);
+  } catch (e) {
+    logger.error(`${FIRED_ALARMS_KEY} 파싱 실패:`, e);
+    return new Set();
+  }
+}
+
+export function setFiredAlarms(keys: Set<string>): Promise<void> {
+  return safeSetItem(FIRED_ALARMS_KEY, JSON.stringify([...keys]));
+}
+
+export function clearFiredAlarms(): Promise<void> {
+  return safeRemoveItem(FIRED_ALARMS_KEY);
 }


### PR DESCRIPTION
## Summary
- `firedAlarms` 중복 방지 출처를 `FIRED_ALARMS_KEY` AsyncStorage 단일 출처로 통합. BG가 발화한 알람이 FG 복귀 후 재발화되던 버그 해소.
- `notificationState`에 `getFiredAlarms`/`setFiredAlarms`/`clearFiredAlarms` helper 추가 (기존 패턴 따름).
- `useStationAlarm`을 phase 효과와 station-passed 효과로 분리해 hydration 재실행이 station-passed 중복 발사를 일으키지 않도록 가드. 초기 바인드는 BG 적재 firedAlarms를 보존하고, destination 변경 시에만 ref + storage 동시 clear.

## Test plan
- [x] `npm test` 1131 tests 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] 신규 회귀 테스트: BG fired → FG hydrate 후 재발화 안 됨, 발화 시 storage 동기화, 초기 바인드 보존
- [x] 기존 FG↔BG 통합 테스트(`foregroundBackgroundTransition.test.ts`) 회귀 없음

Closes #336