### PR TITLE
feat(#335): ETA/AppState 트리거 기반 사전 예약 알람 재예약

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,6 +17,7 @@ import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/j
 import { getStationDisplayName } from '../../src/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
+import { useScheduledAlarms } from '../../src/hooks/useScheduledAlarms';
 import { useTripOrigin } from '../../src/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -146,6 +147,7 @@ export default function HomeScreen() {
     accuracyMeters,
     arrivalConfidence: confidence,
   });
+  useScheduledAlarms({ route, destination, arrival: rawArrival });
   useBackgroundLocation(destination);
 
   useEffect(() => {

--- a/src/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/hooks/__tests__/useScheduledAlarms.test.ts
@@ -1,0 +1,375 @@
+import { renderHook } from '@testing-library/react-native';
+import { act } from 'react';
+import { AppState } from 'react-native';
+import { useScheduledAlarms } from '../useScheduledAlarms';
+import {
+  scheduleAlarmsForRoute,
+  cancelScheduledAlarms,
+} from '../../utils/alarmScheduler';
+import type { DirectRoute } from '../../utils/stationRoute';
+import type { Station } from '../../types/station';
+import type { StationArrival } from '../../api/arrivalApi';
+
+jest.mock('../../utils/alarmScheduler');
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const mockedSchedule = scheduleAlarmsForRoute as jest.MockedFunction<
+  typeof scheduleAlarmsForRoute
+>;
+const mockedCancel = cancelScheduledAlarms as jest.MockedFunction<
+  typeof cancelScheduledAlarms
+>;
+
+const mockRemove = jest.fn();
+let appStateCallback: ((state: string) => void) | null = null;
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
+  appStateCallback = listener as (state: string) => void;
+  return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+});
+
+const ROUTE: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+const DESTINATION: Station = {
+  id: 'dest-1',
+  name: '강남',
+  line: '2',
+  lat: 37.5,
+  lng: 127.0,
+  lineColor: '#000',
+};
+const ARRIVAL: StationArrival = {
+  up: [
+    {
+      destination: '상행',
+      arrivalMinutes: 5,
+      arrivalSeconds: 300,
+      statusMessage: '',
+      trainCode: 'U1',
+      receivedAtMs: 0,
+      arrivalCode: -1,
+      isLastTrain: false,
+      trainType: 'normal',
+    },
+  ],
+  down: [
+    {
+      destination: '하행',
+      arrivalMinutes: 7,
+      arrivalSeconds: 420,
+      statusMessage: '',
+      trainCode: 'D1',
+      receivedAtMs: 0,
+      arrivalCode: -1,
+      isLastTrain: false,
+      trainType: 'normal',
+    },
+  ],
+};
+
+async function flush(): Promise<void> {
+  // 비동기 reschedule 체인을 한 틱 흘려보낸다.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useScheduledAlarms', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateCallback = null;
+    mockedSchedule.mockResolvedValue([]);
+    mockedCancel.mockResolvedValue();
+    // 초기 AppState는 active로 가정 — RN 기본값.
+    (AppState as { currentState: string }).currentState = 'active';
+  });
+
+  it('마운트 시 active 상태면 cancel만 호출되고 schedule은 호출되지 않는다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+
+    expect(mockedCancel).toHaveBeenCalled();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('background 전환 시 마지막 ETA로 재예약한다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+    mockedCancel.mockClear();
+
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedSchedule).toHaveBeenCalledWith({
+      route: ROUTE,
+      destinationName: '강남',
+      nextStationEtaSeconds: 300, // min(300, 420)
+    });
+  });
+
+  it('active 복귀 시 예약을 모두 취소하고 재예약하지 않는다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    mockedCancel.mockClear();
+    mockedSchedule.mockClear();
+
+    await act(async () => {
+      appStateCallback?.('active');
+      await Promise.resolve();
+    });
+
+    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('동일 AppState 이벤트가 연속되면 무시한다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    mockedSchedule.mockClear();
+    mockedCancel.mockClear();
+
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('inactive 전환은 schedule/cancel을 트리거하지 않는다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+    mockedSchedule.mockClear();
+    mockedCancel.mockClear();
+
+    await act(async () => {
+      appStateCallback?.('inactive');
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('background에서 arrival이 변하면 재예약한다', async () => {
+    const { rerender } = renderHook(
+      (props: { arrival: StationArrival | null }) =>
+        useScheduledAlarms({
+          route: ROUTE,
+          destination: DESTINATION,
+          arrival: props.arrival,
+        }),
+      { initialProps: { arrival: ARRIVAL } },
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    mockedSchedule.mockClear();
+    mockedCancel.mockClear();
+
+    const NEXT: StationArrival = {
+      ...ARRIVAL,
+      up: [{ ...ARRIVAL.up[0], arrivalSeconds: 150 }],
+    };
+    rerender({ arrival: NEXT });
+    await flush();
+
+    expect(mockedCancel).toHaveBeenCalled();
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ nextStationEtaSeconds: 150 }),
+    );
+  });
+
+  it('background에서 destination이 null이 되면 schedule 없이 cancel만 호출한다', async () => {
+    const { rerender } = renderHook(
+      (props: { destination: Station | null }) =>
+        useScheduledAlarms({
+          route: ROUTE,
+          destination: props.destination,
+          arrival: ARRIVAL,
+        }),
+      { initialProps: { destination: DESTINATION as Station | null } },
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    mockedSchedule.mockClear();
+    mockedCancel.mockClear();
+
+    rerender({ destination: null });
+    await flush();
+
+    expect(mockedCancel).toHaveBeenCalled();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('arrival이 null이면 nextStationEtaSeconds=null로 위임한다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: null }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ nextStationEtaSeconds: null }),
+    );
+  });
+
+  it('arrival이 mock이면 nextStationEtaSeconds=null로 위임한다', async () => {
+    const mockArrival: StationArrival = { ...ARRIVAL, isMock: true };
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: mockArrival }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ nextStationEtaSeconds: null }),
+    );
+  });
+
+  it('arrival의 모든 arrivalSeconds가 0 이하면 null로 위임한다', async () => {
+    const stale: StationArrival = {
+      up: [{ ...ARRIVAL.up[0], arrivalSeconds: 0 }],
+      down: [{ ...ARRIVAL.down[0], arrivalSeconds: -10 }],
+    };
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: stale }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ nextStationEtaSeconds: null }),
+    );
+  });
+
+  it('언마운트 시 예약을 모두 취소하고 AppState listener를 제거한다', async () => {
+    const { unmount } = renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+    mockedCancel.mockClear();
+
+    unmount();
+
+    expect(mockedCancel).toHaveBeenCalled();
+    expect(mockRemove).toHaveBeenCalled();
+  });
+
+  it('route가 null이면 background에서도 schedule을 호출하지 않는다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: null, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+    mockedCancel.mockClear();
+
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedCancel).toHaveBeenCalled();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('cancelScheduledAlarms 실패는 hook을 throw시키지 않는다 (입력 변동/언마운트 경로)', async () => {
+    mockedCancel.mockRejectedValue(new Error('cancel fail'));
+    const { unmount } = renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+    unmount();
+    await flush();
+    expect(true).toBe(true);
+  });
+
+  it('cancelScheduledAlarms 실패는 active 전환 경로에서도 throw하지 않는다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 다음 cancel 호출(=active 전환)만 실패시킨다.
+    mockedCancel.mockRejectedValueOnce(new Error('active cancel fail'));
+    await act(async () => {
+      appStateCallback?.('active');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('scheduleAlarmsForRoute 실패는 background 전환 경로에서 throw하지 않는다', async () => {
+    mockedSchedule.mockRejectedValueOnce(new Error('schedule fail'));
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(true).toBe(true);
+  });
+});

--- a/src/hooks/useScheduledAlarms.ts
+++ b/src/hooks/useScheduledAlarms.ts
@@ -1,0 +1,105 @@
+import { useEffect, useRef } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import type { Route } from '../utils/stationRoute';
+import type { Station } from '../types/station';
+import type { StationArrival } from '../api/arrivalApi';
+import {
+  cancelScheduledAlarms,
+  scheduleAlarmsForRoute,
+} from '../utils/alarmScheduler';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useScheduledAlarms');
+
+export interface UseScheduledAlarmsInputs {
+  route: Route;
+  destination: Station | null;
+  arrival: StationArrival | null;
+}
+
+/**
+ * 다음 도착역까지의 ETA(초)를 arrival 데이터에서 추출한다.
+ * up/down 양방향에서 가장 빠른 양수 arrivalSeconds를 선택한다.
+ * 데이터가 없거나 mock이면 null을 반환해 alarmScheduler의 static fallback으로 위임한다.
+ */
+function pickNextStationEtaSeconds(arrival: StationArrival | null): number | null {
+  if (!arrival || arrival.isMock) return null;
+  const candidates = [...arrival.up, ...arrival.down]
+    .map((info) => info.arrivalSeconds)
+    .filter((sec) => sec > 0);
+  if (candidates.length === 0) return null;
+  return Math.min(...candidates);
+}
+
+/**
+ * BG/포그라운드 전환과 ETA 변동에 맞춰 사전 예약 알람을 재예약한다.
+ *
+ * 정책:
+ * - 포그라운드(`active`): 예약 모두 취소. FG는 useStationAlarm이 GPS 기반 발화를 담당.
+ * - 백그라운드(`background`): 마지막 route/destination/arrival 기준으로 재예약.
+ * - 백그라운드 중 입력 변동: 즉시 cancel → reschedule.
+ * - route/destination이 null이면 항상 cancel만 수행 (route 종료).
+ * - 언마운트: 모두 취소.
+ */
+export function useScheduledAlarms({
+  route,
+  destination,
+  arrival,
+}: UseScheduledAlarmsInputs): void {
+  const routeRef = useRef<Route>(route);
+  const destinationRef = useRef<Station | null>(destination);
+  const arrivalRef = useRef<StationArrival | null>(arrival);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  routeRef.current = route;
+  destinationRef.current = destination;
+  arrivalRef.current = arrival;
+
+  const reschedule = async (): Promise<void> => {
+    await cancelScheduledAlarms();
+    const currentRoute = routeRef.current;
+    const currentDestination = destinationRef.current;
+    if (!currentRoute || !currentDestination) return;
+    if (appStateRef.current === 'active') return;
+    const etaSeconds = pickNextStationEtaSeconds(arrivalRef.current);
+    await scheduleAlarmsForRoute({
+      route: currentRoute,
+      destinationName: currentDestination.name,
+      nextStationEtaSeconds: etaSeconds,
+    });
+  };
+
+  // AppState 전환 listener — 자체 등록 (중복 방지를 위해 다른 listener와 통합하지 않음).
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      const prev = appStateRef.current;
+      appStateRef.current = state;
+      if (state === prev) return;
+      if (state === 'active') {
+        cancelScheduledAlarms().catch((e) => logger.error('active 전환 취소 실패:', e));
+        return;
+      }
+      if (state === 'background') {
+        reschedule().catch((e) => logger.error('background 전환 재예약 실패:', e));
+      }
+    });
+    return () => {
+      subscription.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 입력 변동 시 재예약 — BG 상태에서만 의미가 있다. active면 reschedule이 내부에서 no-op.
+  // route/destination이 null이면 cancel만 발생.
+  useEffect(() => {
+    reschedule().catch((e) => logger.error('입력 변동 재예약 실패:', e));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [route, destination?.id, arrival]);
+
+  // 언마운트 — 모두 취소.
+  useEffect(() => {
+    return () => {
+      cancelScheduledAlarms().catch((e) => logger.error('언마운트 취소 실패:', e));
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- `useScheduledAlarms` 훅 신설 — route/destination/arrival 변동과 AppState background/active 전환을 트리거로 `scheduleAlarmsForRoute` / `cancelScheduledAlarms` 재호출.
- AppState `background` 진입 시 마지막 ETA로 재예약, `active` 복귀 시 모두 취소(FG는 `useStationAlarm`이 담당).
- `app/(tabs)/index.tsx`에 한 줄 마운트, 단위 테스트 15건 / 100% 커버리지.

## Test plan
- [x] `npm test` (1161 통과, 100% 커버리지)
- [x] `npm run type-check`
- [ ] 실기기 BG 전환 시 사전 예약 알람 재예약 동작 확인 (#334 머지 직후 함께 검증)

Closes #335