### PR TITLE
feat(#340): BGAppRefreshTask로 사전 예약 알람 갱신 (Phase 4 fallback)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -73,6 +73,7 @@ module.exports = {
       ],
       'expo-router',
       'expo-localization',
+      'expo-background-task',
       './modules/live-activity/app.plugin.js',
       '@bacons/apple-targets',
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "audio-route": "file:./modules/audio-route",
         "expo": "~54.0.33",
         "expo-av": "~16.0.8",
+        "expo-background-task": "~1.0.10",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.20",
         "expo-linking": "~8.0.11",
@@ -6532,6 +6533,18 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-background-task": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-background-task/-/expo-background-task-1.0.10.tgz",
+      "integrity": "sha512-EbPnuf52Ps/RJiaSFwqKGT6TkvMChv7bI0wF42eADbH3J2EMm5y5Qvj0oFmF1CBOwc3mUhqj63o7Pl6OLkGPZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-task-manager": "~14.0.9"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "audio-route": "file:./modules/audio-route",
     "expo": "~54.0.33",
     "expo-av": "~16.0.8",
+    "expo-background-task": "~1.0.10",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",
     "expo-linking": "~8.0.11",

--- a/src/hooks/__tests__/useAlarmRefreshTask.test.ts
+++ b/src/hooks/__tests__/useAlarmRefreshTask.test.ts
@@ -1,0 +1,103 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import type { Station } from '../../types/station';
+
+const mockRegister = jest.fn();
+const mockUnregister = jest.fn();
+
+jest.mock('../../tasks/alarmRefreshTask', () => ({
+  registerAlarmRefreshTask: (...args: unknown[]) => mockRegister(...args),
+  unregisterAlarmRefreshTask: (...args: unknown[]) => mockUnregister(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { useAlarmRefreshTask } from '../useAlarmRefreshTask';
+
+const destA: Station = {
+  id: 'a',
+  name: '강남',
+  line: '2',
+  lineColor: '#009246',
+  lat: 0,
+  lng: 0,
+};
+
+const destB: Station = {
+  id: 'b',
+  name: '시청',
+  line: '1',
+  lineColor: '#0052A4',
+  lat: 0,
+  lng: 0,
+};
+
+describe('useAlarmRefreshTask', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRegister.mockResolvedValue(undefined);
+    mockUnregister.mockResolvedValue(undefined);
+  });
+
+  it('destination이 있으면 register를 호출한다', async () => {
+    renderHook(() => useAlarmRefreshTask(destA));
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+    expect(mockUnregister).not.toHaveBeenCalled();
+  });
+
+  it('destination이 null이면 unregister만 호출한다', async () => {
+    renderHook(() => useAlarmRefreshTask(null));
+    await waitFor(() => {
+      expect(mockUnregister).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('언마운트 시 unregister를 호출한다', async () => {
+    const { unmount } = renderHook(() => useAlarmRefreshTask(destA));
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+    unmount();
+    await waitFor(() => expect(mockUnregister).toHaveBeenCalled());
+  });
+
+  it('destination이 바뀌면 unregister + register 가 다시 호출된다', async () => {
+    const { rerender } = renderHook(({ d }: { d: Station | null }) => useAlarmRefreshTask(d), {
+      initialProps: { d: destA },
+    });
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+    rerender({ d: destB });
+    await waitFor(() => {
+      expect(mockUnregister).toHaveBeenCalledTimes(1);
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('register 실패는 throw하지 않고 로그만 남긴다', async () => {
+    mockRegister.mockRejectedValueOnce(new Error('boom'));
+    renderHook(() => useAlarmRefreshTask(destA));
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+  });
+
+  it('unregister 실패는 throw하지 않고 로그만 남긴다 (null path)', async () => {
+    mockUnregister.mockRejectedValueOnce(new Error('boom'));
+    renderHook(() => useAlarmRefreshTask(null));
+    await waitFor(() => expect(mockUnregister).toHaveBeenCalled());
+  });
+
+  it('unregister 실패는 throw하지 않고 로그만 남긴다 (cleanup path)', async () => {
+    const { unmount } = renderHook(() => useAlarmRefreshTask(destA));
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+    mockUnregister.mockRejectedValueOnce(new Error('boom'));
+    unmount();
+    await waitFor(() => expect(mockUnregister).toHaveBeenCalled());
+  });
+});

--- a/src/hooks/useAlarmRefreshTask.ts
+++ b/src/hooks/useAlarmRefreshTask.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import type { Station } from '../types/station';
+import {
+  registerAlarmRefreshTask,
+  unregisterAlarmRefreshTask,
+} from '../tasks/alarmRefreshTask';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useAlarmRefreshTask');
+
+/**
+ * 활성 트립(destination set)에 한해 BGAppRefreshTask 등록.
+ * 트립 종료 / 언마운트 시 해제.
+ *
+ * Phase 1 fallback: silent push(Phase 2)를 받지 못하는 사용자도 OS가 앱을 깨워주는
+ * 시점에 사전 예약 알람이 갱신된다.
+ */
+export function useAlarmRefreshTask(destination: Station | null): void {
+  useEffect(() => {
+    if (!destination) {
+      unregisterAlarmRefreshTask().catch((e) =>
+        logger.error('해제 실패:', e),
+      );
+      return;
+    }
+
+    registerAlarmRefreshTask().catch((e) =>
+      logger.error('등록 실패:', e),
+    );
+
+    return () => {
+      unregisterAlarmRefreshTask().catch((e) =>
+        logger.error('해제 실패:', e),
+      );
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [destination?.id]);
+}

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -65,6 +65,35 @@ function getCallback(): () => Promise<number> {
   return (global as any).__bgRefreshCallback;
 }
 
+function mockStorage(values: {
+  destination?: unknown;
+  route?: unknown;
+  lastStation?: string | null;
+}) {
+  const map: Record<string, string | null> = {
+    'subway-now:destination':
+      values.destination === undefined
+        ? null
+        : typeof values.destination === 'string'
+          ? values.destination
+          : JSON.stringify(values.destination),
+    'subway-now:route':
+      values.route === undefined ? null : JSON.stringify(values.route),
+    'subway-now:last-notified-station': values.lastStation ?? null,
+  };
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    Promise.resolve(key in map ? map[key] : null),
+  );
+}
+
+function expectSchedulerCalledWith(nextStationEtaSeconds: number | null) {
+  expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
+    route,
+    destinationName: '시청',
+    nextStationEtaSeconds,
+  });
+}
+
 describe('alarmRefreshTask', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -85,132 +114,72 @@ describe('alarmRefreshTask', () => {
     });
 
     it('route가 없으면 스케줄러를 호출하지 않는다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination });
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
       expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
     });
 
     it('destination JSON 파싱 실패 시 Success(no-op) 반환', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve('not-json{');
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination: 'not-json{', route });
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
       expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
     });
 
     it('destination.name이 비어 있으면 스킵한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify({ id: 'x' }));
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination: { id: 'x' }, route });
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
       expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
     });
 
     it('활성 트립이 있고 현재역이 없으면 nextStationEtaSeconds=null로 스케줄러 호출', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        if (key === 'subway-now:last-notified-station') return Promise.resolve(null);
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination, route, lastStation: null });
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
       expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
-      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
-        route,
-        destinationName: '시청',
-        nextStationEtaSeconds: null,
-      });
+      expectSchedulerCalledWith(null);
     });
 
     it('현재역이 있으면 Arrival API의 up/down 중 가장 짧은 양수 ETA를 사용한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        if (key === 'subway-now:last-notified-station') return Promise.resolve('station-1');
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination, route, lastStation: 'station-1' });
       mockFetchArrivalInfo.mockResolvedValue({
         up: [{ arrivalSeconds: 600 }, { arrivalSeconds: 1200 }],
         down: [{ arrivalSeconds: 300 }],
       });
       await getCallback()();
       expect(mockFetchArrivalInfo).toHaveBeenCalledWith('강남');
-      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
-        route,
-        destinationName: '시청',
-        nextStationEtaSeconds: 300,
-      });
+      expectSchedulerCalledWith(300);
     });
 
     it('Arrival API가 모두 0/음수면 nextStationEtaSeconds=null', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        if (key === 'subway-now:last-notified-station') return Promise.resolve('station-1');
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination, route, lastStation: 'station-1' });
       mockFetchArrivalInfo.mockResolvedValue({
         up: [{ arrivalSeconds: 0 }],
         down: [{ arrivalSeconds: -1 }],
       });
       await getCallback()();
-      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
-        route,
-        destinationName: '시청',
-        nextStationEtaSeconds: null,
-      });
+      expectSchedulerCalledWith(null);
     });
 
     it('LAST_NOTIFIED_STATION id가 stations.json에 없으면 currentStation은 null', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        if (key === 'subway-now:last-notified-station') return Promise.resolve('unknown-id');
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination, route, lastStation: 'unknown-id' });
       await getCallback()();
       expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
-      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
-        route,
-        destinationName: '시청',
-        nextStationEtaSeconds: null,
-      });
+      expectSchedulerCalledWith(null);
     });
 
     it('Arrival API 호출이 실패해도 static fallback으로 스케줄러를 호출한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        if (key === 'subway-now:last-notified-station') return Promise.resolve('station-1');
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination, route, lastStation: 'station-1' });
       mockFetchArrivalInfo.mockRejectedValue(new Error('network'));
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
-      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
-        route,
-        destinationName: '시청',
-        nextStationEtaSeconds: null,
-      });
+      expectSchedulerCalledWith(null);
     });
 
     it('스케줄러가 throw 하면 Failed를 반환한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
-        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
-        return Promise.resolve(null);
-      });
+      mockStorage({ destination, route });
       mockScheduleAlarmsForRoute.mockRejectedValueOnce(new Error('boom'));
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Failed);

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -1,0 +1,250 @@
+// jest.mock 팩토리는 변수 호이스팅보다 먼저 실행되므로, 팩토리 외부 변수를 참조하면
+// undefined가 된다. global 객체는 항상 접근 가능하므로 여기에 콜백을 저장한다.
+jest.mock('expo-task-manager', () => ({
+  defineTask: (name: string, callback: Function) => {
+    (global as any).__bgRefreshCallback = callback;
+    (global as any).__bgRefreshTaskName = name;
+  },
+  isTaskRegisteredAsync: jest.fn(),
+}));
+
+jest.mock('expo-background-task', () => ({
+  registerTaskAsync: jest.fn(),
+  unregisterTaskAsync: jest.fn(),
+  BackgroundTaskResult: { Success: 1, Failed: 2 },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+}));
+
+const mockScheduleAlarmsForRoute = jest.fn();
+jest.mock('../../utils/alarmScheduler', () => ({
+  scheduleAlarmsForRoute: (...args: unknown[]) => mockScheduleAlarmsForRoute(...args),
+}));
+
+const mockFetchArrivalInfo = jest.fn();
+jest.mock('../../api/arrivalApi', () => ({
+  fetchArrivalInfo: (...args: unknown[]) => mockFetchArrivalInfo(...args),
+}));
+
+jest.mock('../../data/stations.json', () => [
+  { id: 'station-1', name: '강남', line: '2', lineColor: '#009246', lat: 0, lng: 0 },
+  { id: 'station-2', name: '시청', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
+]);
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as TaskManager from 'expo-task-manager';
+import * as BackgroundTask from 'expo-background-task';
+import {
+  ALARM_REFRESH_TASK,
+  registerAlarmRefreshTask,
+  unregisterAlarmRefreshTask,
+} from '../alarmRefreshTask';
+
+const route = { type: 'direct', stops: 10, line: '1' } as const;
+const destination = {
+  id: 'station-2',
+  name: '시청',
+  line: '1',
+  lineColor: '#0052A4',
+  lat: 0,
+  lng: 0,
+};
+
+function getCallback(): () => Promise<number> {
+  return (global as any).__bgRefreshCallback;
+}
+
+describe('alarmRefreshTask', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('defineTask가 ALARM_REFRESH_TASK 이름으로 호출된다', () => {
+    expect((global as any).__bgRefreshTaskName).toBe(ALARM_REFRESH_TASK);
+    expect((global as any).__bgRefreshCallback).toBeDefined();
+  });
+
+  describe('태스크 콜백', () => {
+    it('destination이 없으면 Success를 반환하고 스케줄러를 호출하지 않는다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      const result = await getCallback()();
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
+      expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
+    });
+
+    it('route가 없으면 스케줄러를 호출하지 않는다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
+        return Promise.resolve(null);
+      });
+      const result = await getCallback()();
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
+    });
+
+    it('destination JSON 파싱 실패 시 Success(no-op) 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve('not-json{');
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        return Promise.resolve(null);
+      });
+      const result = await getCallback()();
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
+    });
+
+    it('destination.name이 비어 있으면 스킵한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify({ id: 'x' }));
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        return Promise.resolve(null);
+      });
+      const result = await getCallback()();
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
+    });
+
+    it('활성 트립이 있고 현재역이 없으면 nextStationEtaSeconds=null로 스케줄러 호출', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        if (key === 'subway-now:last-notified-station') return Promise.resolve(null);
+        return Promise.resolve(null);
+      });
+      const result = await getCallback()();
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+      expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
+      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
+        route,
+        destinationName: '시청',
+        nextStationEtaSeconds: null,
+      });
+    });
+
+    it('현재역이 있으면 Arrival API의 up/down 중 가장 짧은 양수 ETA를 사용한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        if (key === 'subway-now:last-notified-station') return Promise.resolve('station-1');
+        return Promise.resolve(null);
+      });
+      mockFetchArrivalInfo.mockResolvedValue({
+        up: [{ arrivalSeconds: 600 }, { arrivalSeconds: 1200 }],
+        down: [{ arrivalSeconds: 300 }],
+      });
+      await getCallback()();
+      expect(mockFetchArrivalInfo).toHaveBeenCalledWith('강남');
+      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
+        route,
+        destinationName: '시청',
+        nextStationEtaSeconds: 300,
+      });
+    });
+
+    it('Arrival API가 모두 0/음수면 nextStationEtaSeconds=null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        if (key === 'subway-now:last-notified-station') return Promise.resolve('station-1');
+        return Promise.resolve(null);
+      });
+      mockFetchArrivalInfo.mockResolvedValue({
+        up: [{ arrivalSeconds: 0 }],
+        down: [{ arrivalSeconds: -1 }],
+      });
+      await getCallback()();
+      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
+        route,
+        destinationName: '시청',
+        nextStationEtaSeconds: null,
+      });
+    });
+
+    it('LAST_NOTIFIED_STATION id가 stations.json에 없으면 currentStation은 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        if (key === 'subway-now:last-notified-station') return Promise.resolve('unknown-id');
+        return Promise.resolve(null);
+      });
+      await getCallback()();
+      expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
+      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
+        route,
+        destinationName: '시청',
+        nextStationEtaSeconds: null,
+      });
+    });
+
+    it('Arrival API 호출이 실패해도 static fallback으로 스케줄러를 호출한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        if (key === 'subway-now:last-notified-station') return Promise.resolve('station-1');
+        return Promise.resolve(null);
+      });
+      mockFetchArrivalInfo.mockRejectedValue(new Error('network'));
+      const result = await getCallback()();
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
+        route,
+        destinationName: '시청',
+        nextStationEtaSeconds: null,
+      });
+    });
+
+    it('스케줄러가 throw 하면 Failed를 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === 'subway-now:destination') return Promise.resolve(JSON.stringify(destination));
+        if (key === 'subway-now:route') return Promise.resolve(JSON.stringify(route));
+        return Promise.resolve(null);
+      });
+      mockScheduleAlarmsForRoute.mockRejectedValueOnce(new Error('boom'));
+      const result = await getCallback()();
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Failed);
+    });
+  });
+
+  describe('registerAlarmRefreshTask', () => {
+    it('이미 등록되어 있으면 재등록하지 않는다', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValueOnce(true);
+      await registerAlarmRefreshTask();
+      expect(BackgroundTask.registerTaskAsync).not.toHaveBeenCalled();
+    });
+
+    it('등록되어 있지 않으면 minimumInterval=15로 등록한다', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValueOnce(false);
+      await registerAlarmRefreshTask();
+      expect(BackgroundTask.registerTaskAsync).toHaveBeenCalledWith(
+        ALARM_REFRESH_TASK,
+        { minimumInterval: 15 },
+      );
+    });
+  });
+
+  describe('unregisterAlarmRefreshTask', () => {
+    it('등록되어 있지 않으면 unregister를 호출하지 않는다', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValueOnce(false);
+      await unregisterAlarmRefreshTask();
+      expect(BackgroundTask.unregisterTaskAsync).not.toHaveBeenCalled();
+    });
+
+    it('등록되어 있으면 unregister를 호출한다', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValueOnce(true);
+      await unregisterAlarmRefreshTask();
+      expect(BackgroundTask.unregisterTaskAsync).toHaveBeenCalledWith(ALARM_REFRESH_TASK);
+    });
+  });
+});

--- a/src/tasks/alarmRefreshTask.ts
+++ b/src/tasks/alarmRefreshTask.ts
@@ -1,0 +1,111 @@
+import * as TaskManager from 'expo-task-manager';
+import * as BackgroundTask from 'expo-background-task';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { DESTINATION_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
+import { scheduleAlarmsForRoute } from '../utils/alarmScheduler';
+import { fetchArrivalInfo, type ArrivalInfo } from '../api/arrivalApi';
+import stationsData from '../data/stations.json';
+import type { Station } from '../types/station';
+import type { Route } from '../utils/stationRoute';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('AlarmRefreshTask');
+
+export const ALARM_REFRESH_TASK = 'alarm-refresh-task';
+
+/**
+ * BGAppRefreshTask. OS가 ~15분 주기로 깨워 활성 트립의 사전 예약 알람을 갱신.
+ *
+ * Phase 1 fallback — 알림 권한은 있으나 silent push(Phase 2)를 못 받는 사용자용.
+ * iOS는 사용 빈도에 따라 OS가 호출 간격을 가감하므로 보장된 주기가 아니다.
+ */
+const allStations = stationsData as Station[];
+const stationById = new Map<string, Station>(allStations.map((s) => [s.id, s]));
+
+function pickNextStationEtaSeconds(arrivals: { up: ArrivalInfo[]; down: ArrivalInfo[] }): number | null {
+  // 방향 정보 없이 BG에서 가장 신뢰할 수 있는 신호는 "임박한 도착". up/down 합산해
+  // 양수 중 최소값을 다음 도착 ETA로 사용한다. 정확도는 reschedule(#335)이 보정.
+  let min: number | null = null;
+  for (const info of [...arrivals.up, ...arrivals.down]) {
+    if (info.arrivalSeconds > 0 && (min === null || info.arrivalSeconds < min)) {
+      min = info.arrivalSeconds;
+    }
+  }
+  return min;
+}
+
+async function readActiveTrip(): Promise<{ destination: Station; route: NonNullable<Route> } | null> {
+  const [destJson, routeJson] = await Promise.all([
+    AsyncStorage.getItem(DESTINATION_KEY),
+    AsyncStorage.getItem(ROUTE_KEY),
+  ]);
+  if (!destJson || !routeJson) return null;
+  try {
+    const destination = JSON.parse(destJson) as Station;
+    const route = JSON.parse(routeJson) as Route;
+    if (!destination?.name || !route) return null;
+    return { destination, route };
+  } catch (e) {
+    logger.error('활성 트립 파싱 실패:', e);
+    return null;
+  }
+}
+
+async function resolveCurrentStationName(): Promise<string | null> {
+  const id = await AsyncStorage.getItem(LAST_NOTIFIED_STATION_KEY);
+  if (!id) return null;
+  return stationById.get(id)?.name ?? null;
+}
+
+TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
+  try {
+    const active = await readActiveTrip();
+    if (!active) {
+      logger.info('활성 트립 없음 — 스킵');
+      return BackgroundTask.BackgroundTaskResult.Success;
+    }
+
+    const currentStationName = await resolveCurrentStationName();
+    let nextStationEtaSeconds: number | null = null;
+    if (currentStationName) {
+      try {
+        const arrivals = await fetchArrivalInfo(currentStationName);
+        nextStationEtaSeconds = pickNextStationEtaSeconds(arrivals);
+      } catch (e) {
+        logger.warn('Arrival API 호출 실패 — static ETA fallback:', e);
+      }
+    }
+
+    await scheduleAlarmsForRoute({
+      route: active.route,
+      destinationName: active.destination.name,
+      nextStationEtaSeconds,
+    });
+    logger.info('알람 사전 예약 갱신 완료');
+    return BackgroundTask.BackgroundTaskResult.Success;
+  } catch (e) {
+    logger.error('알람 갱신 태스크 실패:', e);
+    return BackgroundTask.BackgroundTaskResult.Failed;
+  }
+});
+
+/**
+ * 트립 시작 시 호출. iOS BGAppRefreshTask 등록.
+ * minimumInterval은 OS 권고치(15분). 실제 호출은 OS 재량.
+ */
+export async function registerAlarmRefreshTask(): Promise<void> {
+  const isRegistered = await TaskManager.isTaskRegisteredAsync(ALARM_REFRESH_TASK);
+  if (isRegistered) return;
+  await BackgroundTask.registerTaskAsync(ALARM_REFRESH_TASK, { minimumInterval: 15 });
+  logger.info('AlarmRefreshTask 등록');
+}
+
+/**
+ * 트립 종료 시 호출.
+ */
+export async function unregisterAlarmRefreshTask(): Promise<void> {
+  const isRegistered = await TaskManager.isTaskRegisteredAsync(ALARM_REFRESH_TASK);
+  if (!isRegistered) return;
+  await BackgroundTask.unregisterTaskAsync(ALARM_REFRESH_TASK);
+  logger.info('AlarmRefreshTask 해제');
+}


### PR DESCRIPTION
## Summary

알림 권한이 있으나 silent push(Phase 2)를 받지 못하는 사용자를 위한 fallback. iOS BGAppRefreshTask로 OS가 앱을 깨우는 시점마다 활성 트립의 사전 예약 알람을 갱신한다.

- `src/tasks/alarmRefreshTask.ts` — `expo-background-task`로 등록/해제, 콜백에서 Arrival API 호출 후 `scheduleAlarmsForRoute` 재호출
- `src/hooks/useAlarmRefreshTask.ts` — destination 유무에 따라 등록/해제를 자동 관리하는 React 훅
- `app.config.js` — `expo-background-task` 플러그인 등록 (iOS BG entitlement)

## Design notes (정직히)

- iOS BGAppRefreshTask는 OS 재량 — 15분 보장 X. 사용 빈도가 낮으면 거의 호출되지 않음. 어디까지나 fallback.
- 현재역 결정은 `LAST_NOTIFIED_STATION_KEY`를 재사용 (FG/BG location task가 단일 출처로 기록).
- Arrival API 실패 / 현재역 없음 / 모두 0초 → `nextStationEtaSeconds=null`로 스케줄러의 staticETA fallback 사용.
- `Failed` 반환은 스케줄러 throw 시에만 (OS 재시도 backoff 트리거). 데이터 부재/파싱 실패는 `Success`(no-op).

## Acceptance Criteria

- [x] 활성 트립 동안 BGAppRefreshTask가 등록됨 — `useAlarmRefreshTask`가 destination 변경에 따라 register/unregister
- [x] OS 호출 시 Arrival API 호출 + 예약 갱신
- [x] 트립 종료 시 unregister (effect cleanup + null path)
- [x] 테스트 100% 커버리지 (1168 tests pass)

## Test plan

- [x] `npm test` — 100% 커버리지
- [x] `npm run type-check`
- [ ] Dev build에서 `BackgroundTask.triggerTaskWorkerForTestingAsync()`로 콜백 수동 트리거 확인
- [ ] 실기기에서 destination 설정 → 백그라운드 진입 → 15분+ 후 알람 재예약 시각 갱신 확인

Closes #340