### PR TITLE
feat(#337): APNs device token 등록 + silent push 수신 핸들러 (Phase 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ EXPO_PUBLIC_SEOUL_DATA_API_KEY=
 # 카카오 Developers API 키 (https://developers.kakao.com)
 # 앱 등록 후 JavaScript 키 발급
 EXPO_PUBLIC_KAKAO_MAP_KEY=
+
+# alarm-worker(#338) 백엔드 URL (예: https://alarm-worker.example.workers.dev)
+# 비워두면 사전 예약(#334)만으로 baseline 동작 (silent push reschedule 없이)
+EXPO_PUBLIC_ALARM_BACKEND_URL=

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -19,6 +19,8 @@ import { initStationNotification, updateStationNotification, clearStationNotific
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
 import { useTripOrigin } from '../../src/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
+import { useApnsTripRegistration } from '../../src/hooks/useApnsTripRegistration';
+import { registerSilentPushTask } from '../../src/tasks/silentPushTask';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ROUTE_KEY } from '../../src/constants/storageKeys';
 import { AlarmOverlay } from '../../src/components/AlarmOverlay';
@@ -147,6 +149,12 @@ export default function HomeScreen() {
     arrivalConfidence: confidence,
   });
   useBackgroundLocation(destination);
+  useApnsTripRegistration({
+    route,
+    destination,
+    nextStationEtaSeconds:
+      nextTrainMinutes != null && nextTrainMinutes !== Infinity ? nextTrainMinutes * 60 : null,
+  });
 
   useEffect(() => {
     if (!loading) {
@@ -162,6 +170,7 @@ export default function HomeScreen() {
     loadRoutePreference();
     loadAlarmEvent();
     initStationNotification().catch((e) => logger.error('알림 초기화 실패:', e));
+    registerSilentPushTask().catch((e) => logger.error('silent push task 등록 실패:', e));
     const subscription = AppState.addEventListener('change', (state) => {
       if (state === 'active') {
         loadAlarmEvent();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,11 +12,15 @@ import { useApplyLocale } from '../src/hooks/useApplyLocale';
 import { useAppStore } from '../src/store/useAppStore';
 import { DebugModal } from '../src/components/DebugModal';
 import '../src/tasks/backgroundLocationTask';
+import { registerSilentPushTask } from '../src/tasks/silentPushTask';
 
 const layoutLogger = createLogger('RootLayout');
 
 SplashScreen.preventAutoHideAsync();
 setupNotificationHandler();
+// iOS silent push BG task 등록 — APNs reschedule trigger 수신용.
+// 권한/플랫폼 미지원 시 내부에서 graceful no-op.
+registerSilentPushTask().catch((e) => layoutLogger.warn('silent push task 등록 실패:', e));
 
 // 프로덕션 빌드에서는 warn 이상만 출력
 if (!__DEV__) {

--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -1,0 +1,154 @@
+import { registerActiveTrip, clearActiveTrip } from '../alarmBackend';
+import type { RegisterTripPayload } from '../alarmBackend';
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = global.fetch;
+const NOW = new Date('2026-05-13T12:00:00Z').getTime();
+
+const SAMPLE_PAYLOAD: RegisterTripPayload = {
+  token: 'token-hex',
+  route: { type: 'direct', stops: 5, line: '2' },
+  destination: '0228',
+  waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+  alarmAtEpochMs: NOW + 60000,
+  createdAt: NOW,
+  expiresAt: NOW + 1000,
+};
+
+describe('alarmBackend', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  describe('registerActiveTrip', () => {
+    it('URL 미설정 시 skipped=true 반환', async () => {
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result).toEqual({ ok: false, skipped: true });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('URL 빈 문자열도 미설정으로 취급', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = '';
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result.skipped).toBe(true);
+    });
+
+    it('정상 응답 시 ok=true, body에 트립 직렬화', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result).toEqual({ ok: true, status: 200 });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      // trailing slash 제거 확인
+      expect(url).toBe('https://api.test.dev/trips');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body)).toMatchObject({
+        token: 'token-hex',
+        destination: '0228',
+        alarmAtEpochMs: NOW + 60000,
+        createdAt: NOW,
+        expiresAt: NOW + 1000,
+      });
+    });
+
+    it('createdAt/expiresAt 미지정 시 기본값(now, +2시간)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+
+      const payload: RegisterTripPayload = {
+        token: 't',
+        route: { type: 'direct', stops: 1, line: '2' },
+        destination: '0228',
+        waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+        alarmAtEpochMs: NOW,
+      };
+      await registerActiveTrip(payload);
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.createdAt).toBe(NOW);
+      expect(body.expiresAt).toBe(NOW + 2 * 60 * 60 * 1000);
+    });
+
+    it('non-2xx 응답 시 ok=false + status', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 } as Response);
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result).toEqual({ ok: false, status: 500 });
+    });
+
+    it('fetch throw 시 ok=false 반환(throw 안 함)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result).toEqual({ ok: false });
+    });
+
+    it('타임아웃 시 AbortController가 abort를 호출한다', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      let capturedSignal: AbortSignal | undefined;
+      (global.fetch as jest.Mock).mockImplementation(async (_url, init) => {
+        capturedSignal = init.signal;
+        // 5초 후 timer가 abort()를 호출하도록 시각을 진행시킨다.
+        jest.advanceTimersByTime(5000);
+        return { ok: true, status: 200 } as Response;
+      });
+      await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+  });
+
+  describe('clearActiveTrip', () => {
+    it('URL 미설정 시 skipped=true', async () => {
+      const result = await clearActiveTrip('token-x');
+      expect(result.skipped).toBe(true);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('token 비어 있으면 ok=false (호출 안 함)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      const result = await clearActiveTrip('');
+      expect(result).toEqual({ ok: false });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('정상 응답 시 ok=true, URL에 token URL-encode', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      const result = await clearActiveTrip('a/b');
+      expect(result.ok).toBe(true);
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://api.test.dev/trips/a%2Fb');
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('non-2xx 응답 시 ok=false + status', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 } as Response);
+      const result = await clearActiveTrip('t');
+      expect(result).toEqual({ ok: false, status: 404 });
+    });
+
+    it('fetch throw 시 ok=false (throw 안 함)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+      const result = await clearActiveTrip('t');
+      expect(result).toEqual({ ok: false });
+    });
+  });
+});

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -1,0 +1,133 @@
+/**
+ * alarm-worker(#338) 백엔드 클라이언트.
+ *
+ * APNs device token + 활성 트립을 등록/해제한다. 백엔드는 cron으로 도착 정보를
+ * 폴링하고 적절한 시점에 silent push로 reschedule을 트리거한다.
+ *
+ * URL은 `EXPO_PUBLIC_ALARM_BACKEND_URL`로만 주입된다. 미설정 시 모든 호출은
+ * graceful skip(`{ok:false, skipped:true}`) — Phase 1 baseline(사전 예약만)으로 동작한다.
+ */
+
+import type { Route } from '../utils/stationRoute';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('alarmBackend');
+
+/** 백엔드 Trip.Waypoint와 동일 구조. backend/alarm-worker/src/types.ts와 동기화. */
+export interface AlarmWaypoint {
+  stationName: string;
+  line: string;
+  kind: 'transfer' | 'destination';
+}
+
+export interface RegisterTripPayload {
+  /** APNs device token (hex) */
+  token: string;
+  route: NonNullable<Route>;
+  /** 목적지 역 ID — stations.json id (예: "0228") */
+  destination: string;
+  waypoints: AlarmWaypoint[];
+  /** epoch ms — 트립 등록 시각 (기본: Date.now()) */
+  createdAt?: number;
+  /** epoch ms — 자동 만료 시각 (기본: createdAt + 2시간) */
+  expiresAt?: number;
+  /** epoch ms — 알람 발사 예상 시각 (5분 윈도우 진입 판정용) */
+  alarmAtEpochMs: number;
+}
+
+export interface AlarmBackendResult {
+  ok: boolean;
+  /** URL 미설정 등으로 호출이 건너뛰어진 경우 true. */
+  skipped?: boolean;
+  status?: number;
+}
+
+/** 기본 트립 TTL — 2시간. 백엔드 KV expiration과 정렬. */
+const DEFAULT_TRIP_TTL_MS = 2 * 60 * 60 * 1000;
+/** fetch 타임아웃 — 백엔드 응답 지연으로 알람 등록이 차단되지 않도록 짧게 유지. */
+const REQUEST_TIMEOUT_MS = 5000;
+
+function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * 활성 트립을 등록한다. 백엔드 URL이 없거나 호출이 실패해도 throw하지 않고
+ * `{ok:false}`를 반환 — 알람 사전 예약(#334)은 그대로 동작한다.
+ */
+export async function registerActiveTrip(
+  payload: RegisterTripPayload,
+): Promise<AlarmBackendResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip register');
+    return { ok: false, skipped: true };
+  }
+
+  const createdAt = payload.createdAt ?? Date.now();
+  const expiresAt = payload.expiresAt ?? createdAt + DEFAULT_TRIP_TTL_MS;
+  const body = {
+    token: payload.token,
+    route: payload.route,
+    destination: payload.destination,
+    waypoints: payload.waypoints,
+    createdAt,
+    expiresAt,
+    alarmAtEpochMs: payload.alarmAtEpochMs,
+  };
+
+  try {
+    const res = await fetchWithTimeout(`${base}/trips`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      log.warn(`register failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('register error', e);
+    return { ok: false };
+  }
+}
+
+/**
+ * 활성 트립을 해제한다. URL/네트워크 실패 시에도 throw하지 않는다 — 백엔드 KV는
+ * `expiresAt`으로 자동 정리되므로 클라이언트가 재시도 책임을 갖지 않는다.
+ */
+export async function clearActiveTrip(token: string): Promise<AlarmBackendResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip clear');
+    return { ok: false, skipped: true };
+  }
+  if (!token) return { ok: false };
+
+  try {
+    const res = await fetchWithTimeout(`${base}/trips/${encodeURIComponent(token)}`, {
+      method: 'DELETE',
+    });
+    if (!res.ok) {
+      log.warn(`clear failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('clear error', e);
+    return { ok: false };
+  }
+}

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -12,3 +12,5 @@ export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';
 export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
 export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';
 export const ALARM_LOG_KEY = 'subway-now:alarm-log';
+export const APNS_TOKEN_KEY = 'subway-now:apns-token';
+export const ACTIVE_TRIP_KEY = 'subway-now:active-trip';

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1,0 +1,372 @@
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+const mockGetDevicePushTokenAsync = jest.fn();
+const mockAddPushTokenListener = jest.fn();
+
+jest.mock('expo-notifications', () => ({
+  getDevicePushTokenAsync: (...args: unknown[]) => mockGetDevicePushTokenAsync(...args),
+  addPushTokenListener: (...args: unknown[]) => mockAddPushTokenListener(...args),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const mockRegister = jest.fn();
+const mockClear = jest.fn();
+jest.mock('../../api/alarmBackend', () => ({
+  registerActiveTrip: (...args: unknown[]) => mockRegister(...args),
+  clearActiveTrip: (...args: unknown[]) => mockClear(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useApnsTripRegistration } from '../useApnsTripRegistration';
+import type { Station } from '../../types/station';
+import type { Route } from '../../utils/stationRoute';
+import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../constants/storageKeys';
+
+const station: Station = {
+  id: '0228',
+  name: '강남',
+  line: '2',
+  lat: 37.5,
+  lng: 127.0,
+  lineColor: '#00A84D',
+};
+
+const directRoute: Route = { type: 'direct', stops: 5, line: '2' };
+
+describe('useApnsTripRegistration', () => {
+  let listenerRemove: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listenerRemove = jest.fn();
+    mockAddPushTokenListener.mockReturnValue({ remove: listenerRemove });
+    mockGetDevicePushTokenAsync.mockResolvedValue({ data: 'token-abc' });
+    mockRegister.mockResolvedValue({ ok: true });
+    mockClear.mockResolvedValue({ ok: true });
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      return null;
+    });
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('마운트 시 device push token을 발급해 AsyncStorage에 저장', async () => {
+    renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await waitFor(() => {
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(APNS_TOKEN_KEY, 'token-abc');
+    });
+  });
+
+  it('토큰 발급 실패 시 throw 없이 graceful', async () => {
+    mockGetDevicePushTokenAsync.mockRejectedValue(new Error('denied'));
+    renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await waitFor(() => expect(mockGetDevicePushTokenAsync).toHaveBeenCalled());
+    // 토큰 저장 안 됨
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(APNS_TOKEN_KEY, expect.anything());
+  });
+
+  it('토큰이 비어 있으면 저장하지 않는다', async () => {
+    mockGetDevicePushTokenAsync.mockResolvedValue({ data: '' });
+    renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await waitFor(() => expect(mockGetDevicePushTokenAsync).toHaveBeenCalled());
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(APNS_TOKEN_KEY, '');
+  });
+
+  it('route + destination 활성 시 registerActiveTrip 호출 + ACTIVE_TRIP_KEY 저장', async () => {
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    expect(mockRegister).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'token-abc',
+        destination: '0228',
+        waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+      }),
+    );
+    await waitFor(() =>
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(ACTIVE_TRIP_KEY, 'token-abc'),
+    );
+  });
+
+  it('register 실패 시 ACTIVE_TRIP_KEY 저장 안 함', async () => {
+    mockRegister.mockResolvedValue({ ok: false });
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(ACTIVE_TRIP_KEY, expect.anything());
+  });
+
+  it('토큰이 없으면 register skip', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('route/destination 없으면 + 이전 트립 있으면 clear', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      if (key === ACTIVE_TRIP_KEY) return 'token-abc';
+      return null;
+    });
+    renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await waitFor(() => expect(mockClear).toHaveBeenCalledWith('token-abc'));
+    await waitFor(() => expect(AsyncStorage.removeItem).toHaveBeenCalledWith(ACTIVE_TRIP_KEY));
+  });
+
+  it('route/destination 없고 이전 트립도 없으면 clear 안 함', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it('push token listener: 토큰 갱신 시 AsyncStorage 업데이트 + 활성 트립이면 재등록', async () => {
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    await waitFor(() => expect(mockAddPushTokenListener).toHaveBeenCalled());
+    const listener = mockAddPushTokenListener.mock.calls[0][0];
+
+    mockRegister.mockClear();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    await act(async () => {
+      listener({ data: 'token-NEW' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(APNS_TOKEN_KEY, 'token-NEW'),
+    );
+    await waitFor(() =>
+      expect(mockRegister).toHaveBeenCalledWith(
+        expect.objectContaining({ token: 'token-NEW' }),
+      ),
+    );
+  });
+
+  it('push token listener: 빈 토큰은 무시', async () => {
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    await waitFor(() => expect(mockAddPushTokenListener).toHaveBeenCalled());
+    const listener = mockAddPushTokenListener.mock.calls[0][0];
+
+    mockRegister.mockClear();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    act(() => listener({ data: '' }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(APNS_TOKEN_KEY, '');
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('push token listener: 활성 트립 없으면 재등록 안 함', async () => {
+    renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await waitFor(() => expect(mockAddPushTokenListener).toHaveBeenCalled());
+    const listener = mockAddPushTokenListener.mock.calls[0][0];
+
+    mockRegister.mockClear();
+    await act(async () => {
+      listener({ data: 'token-NEW' });
+      await Promise.resolve();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('push token listener: setItem 실패해도 graceful', async () => {
+    renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await waitFor(() => expect(mockAddPushTokenListener).toHaveBeenCalled());
+    const listener = mockAddPushTokenListener.mock.calls[0][0];
+
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk'));
+    await act(async () => {
+      listener({ data: 'token-NEW' });
+      await Promise.resolve();
+    });
+    // throw 없이 통과 — assertion 도달이 곧 성공.
+    expect(true).toBe(true);
+  });
+
+  it('unmount 시 listener.remove 호출', async () => {
+    const { unmount } = renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    await waitFor(() => expect(mockAddPushTokenListener).toHaveBeenCalled());
+    unmount();
+    expect(listenerRemove).toHaveBeenCalled();
+  });
+
+  it('nextStationEtaSeconds null이면 alarmAt = now', async () => {
+    const fixed = new Date('2026-05-13T12:00:00Z').getTime();
+    jest.spyOn(Date, 'now').mockReturnValue(fixed);
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: null,
+      }),
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+    expect(mockRegister.mock.calls[0][0].alarmAtEpochMs).toBe(fixed);
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('unmount 직후 getDevicePushTokenAsync resolve해도 setItem 호출 안 함', async () => {
+    let resolveToken!: (v: { data: string }) => void;
+    mockGetDevicePushTokenAsync.mockImplementation(
+      () => new Promise((res) => { resolveToken = res; }),
+    );
+    const { unmount } = renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    unmount();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    await act(async () => {
+      resolveToken({ data: 'late-token' });
+      await Promise.resolve();
+    });
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(APNS_TOKEN_KEY, 'late-token');
+  });
+
+  it('unmount 직후 getItem resolve해도 후속 동작 안 함 (register 분기)', async () => {
+    let resolveGet!: (v: string | null) => void;
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(
+      () => new Promise((res) => { resolveGet = res; }),
+    );
+    const { unmount } = renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    unmount();
+    mockRegister.mockClear();
+    await act(async () => {
+      resolveGet('token-abc');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('unmount 직후 getItem resolve해도 후속 동작 안 함 (clear 분기)', async () => {
+    let callCount = 0;
+    let resolvePrev!: (v: string | null) => void;
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      callCount++;
+      if (callCount === 1) return null; // APNS_TOKEN_KEY
+      return new Promise((res) => { resolvePrev = res; }); // ACTIVE_TRIP_KEY
+    });
+    const { unmount } = renderHook(() =>
+      useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+    );
+    // 첫 getItem(APNS_TOKEN_KEY)을 통과시키고 두 번째 getItem(ACTIVE_TRIP_KEY)에서 멈추기 위해 microtask 양보
+    await act(async () => {
+      await Promise.resolve();
+    });
+    unmount();
+    mockClear.mockClear();
+    await act(async () => {
+      resolvePrev('token-abc');
+      await Promise.resolve();
+    });
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it('unmount 직후 register resolve해도 ACTIVE_TRIP_KEY 저장 안 함', async () => {
+    let resolveReg!: (v: { ok: boolean }) => void;
+    mockRegister.mockImplementation(
+      () => new Promise((res) => { resolveReg = res; }),
+    );
+    const { unmount } = renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+    unmount();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    await act(async () => {
+      resolveReg({ ok: true });
+      await Promise.resolve();
+    });
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(ACTIVE_TRIP_KEY, 'token-abc');
+  });
+
+  it('nextStationEtaSeconds > 0 이면 alarmAt = now + eta*1000', async () => {
+    const fixed = new Date('2026-05-13T12:00:00Z').getTime();
+    jest.spyOn(Date, 'now').mockReturnValue(fixed);
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 300,
+      }),
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+    expect(mockRegister.mock.calls[0][0].alarmAtEpochMs).toBe(fixed + 300 * 1000);
+    (Date.now as jest.Mock).mockRestore();
+  });
+});

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -1,0 +1,145 @@
+/**
+ * APNs token 발급 → alarm-worker(#338)에 활성 트립 등록.
+ *
+ * 1. 마운트 시 `Notifications.getDevicePushTokenAsync()`로 device token 발급
+ * 2. `addPushTokenListener`로 토큰 갱신 감지 → 활성 트립 있으면 재등록
+ * 3. route + destination 변경 시 register, 둘 다 비면 clear
+ *
+ * 권한 거부/토큰 실패 시 graceful skip — 사전 예약(#334)만으로 baseline 동작.
+ */
+
+import { useEffect, useRef } from 'react';
+import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Station } from '../types/station';
+import type { Route } from '../utils/stationRoute';
+import { registerActiveTrip, clearActiveTrip } from '../api/alarmBackend';
+import { routeToWaypoints } from '../utils/routeWaypoints';
+import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../constants/storageKeys';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ApnsTripRegistration');
+
+export interface UseApnsTripRegistrationInputs {
+  route: Route;
+  destination: Station | null;
+  /** 첫 도착역까지 ETA(초). null이면 alarm scheduler와 동일하게 static fallback이 백엔드에서 진행. */
+  nextStationEtaSeconds: number | null;
+}
+
+/**
+ * `nextStationEtaSeconds`로부터 알람 발사 예상 epoch ms를 산출한다.
+ * 백엔드의 5분 윈도우 진입 판정용 — 정확하지 않아도 reschedule으로 보정된다.
+ */
+function deriveAlarmAtEpochMs(nextStationEtaSeconds: number | null, now: number): number {
+  if (nextStationEtaSeconds != null && nextStationEtaSeconds > 0) {
+    return now + nextStationEtaSeconds * 1000;
+  }
+  // 알 수 없으면 즉시 — 백엔드는 첫 폴링에서 윈도우 진입으로 판단.
+  return now;
+}
+
+export function useApnsTripRegistration({
+  route,
+  destination,
+  nextStationEtaSeconds,
+}: UseApnsTripRegistrationInputs): void {
+  // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds });
+  useEffect(() => {
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds };
+  });
+
+  // ── 토큰 발급 + 리스너 등록 (mount-once) ──
+  useEffect(() => {
+    let cancelled = false;
+    let subscription: { remove: () => void } | null = null;
+
+    (async () => {
+      try {
+        const tokenResp = await Notifications.getDevicePushTokenAsync();
+        if (cancelled) return;
+        const token = tokenResp.data;
+        if (!token || typeof token !== 'string') {
+          logger.info('device push token unavailable — skip');
+          return;
+        }
+        await AsyncStorage.setItem(APNS_TOKEN_KEY, token);
+        logger.info('apns token cached');
+      } catch (e) {
+        logger.warn('getDevicePushTokenAsync failed:', e);
+      }
+    })();
+
+    subscription = Notifications.addPushTokenListener((event) => {
+      const token = event?.data;
+      if (!token || typeof token !== 'string') return;
+      void (async () => {
+        try {
+          await AsyncStorage.setItem(APNS_TOKEN_KEY, token);
+        } catch (e) {
+          logger.warn('persist refreshed token failed:', e);
+        }
+        // 활성 트립이 있으면 새 토큰으로 재등록한다.
+        const { route: r, destination: d, nextStationEtaSeconds: eta } = latestInputsRef.current;
+        if (!r || !d) return;
+        await registerActiveTrip({
+          token,
+          route: r,
+          destination: d.id,
+          waypoints: routeToWaypoints(r, d.name),
+          alarmAtEpochMs: deriveAlarmAtEpochMs(eta, Date.now()),
+        });
+      })();
+    });
+
+    return () => {
+      cancelled = true;
+      subscription?.remove();
+    };
+  }, []);
+
+  // ── 활성 트립 register / clear ──
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+      if (cancelled) return;
+
+      // 트립 없음 → 이전에 등록된 토큰이 있다면 clear.
+      if (!route || !destination) {
+        const prevTokenRaw = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+        if (cancelled) return;
+        if (prevTokenRaw) {
+          await clearActiveTrip(prevTokenRaw);
+          await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
+        }
+        return;
+      }
+
+      // 트립 있음 → 토큰 없으면 graceful skip.
+      if (!token) {
+        logger.info('apns token not yet available — skip register');
+        return;
+      }
+
+      const result = await registerActiveTrip({
+        token,
+        route,
+        destination: destination.id,
+        waypoints: routeToWaypoints(route, destination.name),
+        alarmAtEpochMs: deriveAlarmAtEpochMs(nextStationEtaSeconds, Date.now()),
+      });
+      if (cancelled) return;
+      if (result.ok) {
+        await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [route, destination?.id, nextStationEtaSeconds]);
+}

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -1,0 +1,227 @@
+jest.mock('expo-task-manager', () => ({
+  defineTask: (name: string, callback: Function) => {
+    (global as any).__silentPushTaskName = name;
+    (global as any).__silentPushTaskCb = callback;
+  },
+}));
+
+const mockRegisterTaskAsync = jest.fn();
+jest.mock('expo-notifications', () => ({
+  registerTaskAsync: (...args: unknown[]) => mockRegisterTaskAsync(...args),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const mockSchedule = jest.fn();
+const mockCancel = jest.fn();
+jest.mock('../../utils/alarmScheduler', () => ({
+  scheduleAlarmsForRoute: (...args: unknown[]) => mockSchedule(...args),
+  cancelScheduledAlarms: (...args: unknown[]) => mockCancel(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  extractPayload,
+  handleSilentPush,
+  registerSilentPushTask,
+  SILENT_PUSH_TASK,
+} from '../silentPushTask';
+import { DESTINATION_KEY, ROUTE_KEY } from '../../constants/storageKeys';
+
+const destStation = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
+const route = { type: 'direct', stops: 5, line: '2' };
+
+function reschedulePayload(extra: Record<string, unknown> = {}) {
+  return {
+    data: {
+      notification: {
+        data: {
+          nextWaypoint: '강남',
+          etaSeconds: 300,
+          phase: 'early',
+          ...extra,
+        },
+      },
+    },
+  };
+}
+
+describe('silentPushTask', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSchedule.mockResolvedValue([{ identifier: 'alarm:early:강남' }]);
+    mockCancel.mockResolvedValue(undefined);
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+      if (key === ROUTE_KEY) return JSON.stringify(route);
+      return null;
+    });
+  });
+
+  it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
+    expect((global as any).__silentPushTaskName).toBe(SILENT_PUSH_TASK);
+    expect(typeof (global as any).__silentPushTaskCb).toBe('function');
+  });
+
+  describe('extractPayload', () => {
+    it('data 자체가 falsy면 null', () => {
+      expect(extractPayload(undefined)).toBeNull();
+    });
+
+    it('notification 없으면 null', () => {
+      expect(extractPayload({})).toBeNull();
+    });
+
+    it('data 위치(notification.data) 우선', () => {
+      expect(
+        extractPayload({
+          notification: {
+            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early' },
+          },
+        }),
+      ).toEqual({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' });
+    });
+
+    it('data 없을 때 request.content.data 폴백', () => {
+      expect(
+        extractPayload({
+          notification: {
+            request: {
+              content: { data: { nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' } },
+            },
+          },
+        }),
+      ).toEqual({ nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' });
+    });
+
+    it('raw가 객체가 아니면 null', () => {
+      expect(
+        extractPayload({ notification: { data: 'string' as unknown as Record<string, unknown> } }),
+      ).toBeNull();
+    });
+
+    it('nextWaypoint 누락/비문자열/빈문자열이면 null', () => {
+      expect(
+        extractPayload({
+          notification: { data: { nextWaypoint: '', etaSeconds: 1, phase: 'early' } },
+        }),
+      ).toBeNull();
+      expect(
+        extractPayload({
+          notification: { data: { nextWaypoint: 123, etaSeconds: 1, phase: 'early' } },
+        }),
+      ).toBeNull();
+    });
+
+    it('etaSeconds 비숫자/Infinity이면 null', () => {
+      expect(
+        extractPayload({
+          notification: { data: { nextWaypoint: 'A', etaSeconds: '1', phase: 'early' } },
+        }),
+      ).toBeNull();
+      expect(
+        extractPayload({
+          notification: {
+            data: { nextWaypoint: 'A', etaSeconds: Infinity, phase: 'early' },
+          },
+        }),
+      ).toBeNull();
+    });
+
+    it('phase가 early/imminent가 아니면 null', () => {
+      expect(
+        extractPayload({
+          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'late' } },
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('handleSilentPush', () => {
+    it('error 있으면 즉시 종료', async () => {
+      await handleSilentPush({ error: { message: 'boom' } });
+      expect(mockSchedule).not.toHaveBeenCalled();
+      expect(mockCancel).not.toHaveBeenCalled();
+    });
+
+    it('payload 없으면 skip', async () => {
+      await handleSilentPush({ data: undefined });
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
+    it('invalid payload면 skip', async () => {
+      await handleSilentPush({
+        data: { notification: { data: { trigger: 'other' } } },
+      });
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
+    it('destination/route AsyncStorage에 없으면 skip', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      await handleSilentPush(reschedulePayload());
+      expect(mockCancel).not.toHaveBeenCalled();
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
+    it('정상: cancel 후 etaSeconds 로 reschedule', async () => {
+      await handleSilentPush(reschedulePayload({ etaSeconds: 420 }));
+      expect(mockCancel).toHaveBeenCalledTimes(1);
+      expect(mockSchedule).toHaveBeenCalledWith({
+        route,
+        destinationName: '강남',
+        nextStationEtaSeconds: 420,
+      });
+    });
+
+    it('AsyncStorage 손상된 JSON이면 skip', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === DESTINATION_KEY) return 'not-json{';
+        if (key === ROUTE_KEY) return JSON.stringify(route);
+        return null;
+      });
+      await handleSilentPush(reschedulePayload());
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
+    it('parse 결과 falsy(null)면 schedule 호출 안 함', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+        if (key === ROUTE_KEY) return 'null';
+        return null;
+      });
+      await handleSilentPush(reschedulePayload());
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
+    it('schedule 내부 throw 시 graceful (throw 안 함)', async () => {
+      mockSchedule.mockRejectedValue(new Error('boom'));
+      await expect(handleSilentPush(reschedulePayload())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('registerSilentPushTask', () => {
+    it('Notifications.registerTaskAsync 호출', async () => {
+      mockRegisterTaskAsync.mockResolvedValue(undefined);
+      await registerSilentPushTask();
+      expect(mockRegisterTaskAsync).toHaveBeenCalledWith(SILENT_PUSH_TASK);
+    });
+
+    it('register 실패 시 throw 안 함', async () => {
+      mockRegisterTaskAsync.mockRejectedValue(new Error('not supported'));
+      await expect(registerSilentPushTask()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -1,0 +1,129 @@
+/**
+ * iOS silent push(BG) 핸들러 — alarm-worker(#338)가 보내는 reschedule 트리거.
+ *
+ * payload (백엔드 apns.ts SilentPushPayload와 1:1):
+ * ```
+ * aps: { 'content-available': 1 }
+ * data: { nextWaypoint: "강남", etaSeconds: 420, phase: "early" }
+ * ```
+ *
+ * 동작:
+ *   1. AsyncStorage에서 현재 route/destination 복원
+ *   2. payload의 etaSeconds(다음 도착역까지)로 `scheduleAlarmsForRoute` 재호출
+ *   3. 기존 예약을 cancelScheduledAlarms로 정리한 뒤 새 시각으로 다시 예약
+ *
+ * payload 형식이 맞지 않거나 route/destination이 없으면 graceful no-op.
+ */
+
+import * as Notifications from 'expo-notifications';
+import * as TaskManager from 'expo-task-manager';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Station } from '../types/station';
+import type { Route } from '../utils/stationRoute';
+import { scheduleAlarmsForRoute, cancelScheduledAlarms } from '../utils/alarmScheduler';
+import { DESTINATION_KEY, ROUTE_KEY } from '../constants/storageKeys';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('SilentPushTask');
+
+export const SILENT_PUSH_TASK = 'silent-push-reschedule';
+
+export interface SilentPushPayload {
+  nextWaypoint: string;
+  etaSeconds: number;
+  phase: 'early' | 'imminent';
+}
+
+interface NotificationBackgroundTaskData {
+  data?: {
+    notification?: {
+      data?: Record<string, unknown>;
+      request?: { content?: { data?: Record<string, unknown> } };
+    };
+  };
+  error?: { message: string } | null;
+}
+
+/**
+ * 알림 raw payload → 검증된 SilentPushPayload.
+ * iOS expo-notifications BG는 APNs JSON의 `data` 필드를 그대로 전달한다.
+ * 어디에 들어있든 nextWaypoint/etaSeconds/phase 세 필드 모두 형이 맞아야 통과한다.
+ */
+export function extractPayload(
+  data: NotificationBackgroundTaskData['data'],
+): SilentPushPayload | null {
+  const notif = data?.notification;
+  if (!notif) return null;
+  const raw = notif.data ?? notif.request?.content?.data;
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const { nextWaypoint, etaSeconds, phase } = obj;
+  if (typeof nextWaypoint !== 'string' || nextWaypoint.length === 0) return null;
+  if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
+  if (phase !== 'early' && phase !== 'imminent') return null;
+  return { nextWaypoint, etaSeconds, phase };
+}
+
+/**
+ * Task 콜백 본체 — 단위 테스트가 직접 호출할 수 있도록 export.
+ */
+export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
+  if (input.error) {
+    logger.error('silent push task error:', input.error.message);
+    return;
+  }
+
+  const payload = extractPayload(input.data);
+  if (!payload) {
+    logger.info('payload missing or invalid — skip');
+    return;
+  }
+
+  try {
+    const [destJson, routeJson] = await Promise.all([
+      AsyncStorage.getItem(DESTINATION_KEY),
+      AsyncStorage.getItem(ROUTE_KEY),
+    ]);
+    if (!destJson || !routeJson) {
+      logger.info('no active destination/route — skip reschedule');
+      return;
+    }
+
+    let destination: Station;
+    let route: Route;
+    try {
+      destination = JSON.parse(destJson) as Station;
+      route = JSON.parse(routeJson) as Route;
+    } catch (e) {
+      logger.error('failed to parse stored destination/route:', e);
+      return;
+    }
+    if (!route || !destination) return;
+
+    await cancelScheduledAlarms();
+    const scheduled = await scheduleAlarmsForRoute({
+      route,
+      destinationName: destination.name,
+      nextStationEtaSeconds: payload.etaSeconds,
+    });
+    logger.info(`rescheduled ${scheduled.length} alarms via silent push`);
+  } catch (e) {
+    logger.error('silent push handling failed:', e);
+  }
+}
+
+/** Task 등록 — 모듈 로드 시점에 한 번 실행. */
+TaskManager.defineTask(SILENT_PUSH_TASK, handleSilentPush);
+
+/**
+ * 앱 초기화 시 호출 — Notifications가 BG payload를 이 task로 라우팅하도록 등록한다.
+ * 이미 등록된 경우 no-op.
+ */
+export async function registerSilentPushTask(): Promise<void> {
+  try {
+    await Notifications.registerTaskAsync(SILENT_PUSH_TASK);
+    logger.info('silent push task registered');
+  } catch (e) {
+    logger.warn('failed to register silent push task:', e);
+  }
+}

--- a/src/utils/__tests__/routeWaypoints.test.ts
+++ b/src/utils/__tests__/routeWaypoints.test.ts
@@ -1,0 +1,75 @@
+import { routeToWaypoints } from '../routeWaypoints';
+import type {
+  DirectRoute,
+  TransferRoute,
+  MultiTransferRoute,
+} from '../stationRoute';
+
+describe('routeToWaypoints', () => {
+  it('direct: 도착역 단일 waypoint (route.line)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    expect(routeToWaypoints(route, '강남')).toEqual([
+      { stationName: '강남', line: '2', kind: 'destination' },
+    ]);
+  });
+
+  it('transfer: 환승역(fromLine) + 도착역(toLine)', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '신도림',
+      fromLine: '1',
+      toLine: '2',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 4,
+    };
+    expect(routeToWaypoints(route, '강남')).toEqual([
+      { stationName: '신도림', line: '1', kind: 'transfer' },
+      { stationName: '강남', line: '2', kind: 'destination' },
+    ]);
+  });
+
+  it('transfer에서 목적지가 환승역과 같으면 destination 1개로 축약 (fromLine)', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '신도림',
+      fromLine: '1',
+      toLine: '2',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 0,
+    };
+    expect(routeToWaypoints(route, '신도림')).toEqual([
+      { stationName: '신도림', line: '1', kind: 'destination' },
+    ]);
+  });
+
+  it('multi-transfer: 각 환승 + 마지막 toLine으로 도착역 append', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 2 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 2,
+    };
+    expect(routeToWaypoints(route, '경복궁')).toEqual([
+      { stationName: '신도림', line: '1', kind: 'transfer' },
+      { stationName: '교대', line: '2', kind: 'transfer' },
+      { stationName: '경복궁', line: '3', kind: 'destination' },
+    ]);
+  });
+
+  it('multi-transfer: 마지막 환승역이 곧 목적지면 그 환승역을 destination으로 마킹', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 2 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 0,
+    };
+    expect(routeToWaypoints(route, '교대')).toEqual([
+      { stationName: '신도림', line: '1', kind: 'transfer' },
+      { stationName: '교대', line: '2', kind: 'destination' },
+    ]);
+  });
+});

--- a/src/utils/routeWaypoints.ts
+++ b/src/utils/routeWaypoints.ts
@@ -1,0 +1,52 @@
+/**
+ * Route → alarm-worker(#338) Waypoint[] 변환.
+ *
+ * 백엔드 Waypoint는 `{stationName, line, kind}` 형태 — 백엔드가 도착정보 API를
+ * 어느 호선에서 호출해야 하는지 알기 위해 line이 필요하다.
+ */
+
+import type { Route } from './stationRoute';
+import type { AlarmWaypoint } from '../api/alarmBackend';
+
+/**
+ * 환승역 도착 모니터링은 환승 전 호선에서 본다 (전 호선 도착정보로 그 역을 지나가는 시점 파악).
+ * 최종 목적지는 마지막 구간의 호선에서 본다.
+ */
+export function routeToWaypoints(
+  route: NonNullable<Route>,
+  destinationName: string,
+): AlarmWaypoint[] {
+  if (route.type === 'direct') {
+    return [{ stationName: destinationName, line: route.line, kind: 'destination' }];
+  }
+
+  if (route.type === 'transfer') {
+    if (route.transferName === destinationName) {
+      return [{ stationName: destinationName, line: route.fromLine, kind: 'destination' }];
+    }
+    return [
+      { stationName: route.transferName, line: route.fromLine, kind: 'transfer' },
+      { stationName: destinationName, line: route.toLine, kind: 'destination' },
+    ];
+  }
+
+  const waypoints: AlarmWaypoint[] = route.transfers.map((seg) => {
+    const isDestination = seg.transferName === destinationName;
+    return {
+      stationName: isDestination ? destinationName : seg.transferName,
+      line: seg.fromLine,
+      kind: isDestination ? 'destination' : 'transfer',
+    };
+  });
+
+  const lastSegment = route.transfers[route.transfers.length - 1];
+  const lastWaypoint = waypoints[waypoints.length - 1];
+  if (lastSegment && lastWaypoint && lastWaypoint.kind !== 'destination') {
+    waypoints.push({
+      stationName: destinationName,
+      line: lastSegment.toLine,
+      kind: 'destination',
+    });
+  }
+  return waypoints;
+}


### PR DESCRIPTION
## Summary
- iOS APNs device token을 발급해 alarm-worker(#338)에 활성 트립을 register/clear
- Silent push(`content-available:1`, payload `{nextWaypoint, etaSeconds, phase}`) BG 수신 시 `cancelScheduledAlarms` → `scheduleAlarmsForRoute` 재호출로 사전 예약(#334) 갱신
- 권한 거부 / 토큰 발급 실패 / 백엔드 URL 미설정 모두 graceful skip — Phase 1 baseline으로 fallback

## 구현 노트
- payload 스펙은 백엔드 `backend/alarm-worker/src/types.ts`(Trip) + `apns.ts`(SilentPushPayload)와 1:1 호환
- `routeToWaypoints`: 환승은 `fromLine`, 도착은 마지막 구간 `toLine` 기준 — Worker가 어느 호선 도착정보를 폴링해야 하는지 명시
- `addPushTokenListener`로 토큰 갱신 감지 → 활성 트립이 있으면 새 토큰으로 자동 재등록
- `EXPO_PUBLIC_ALARM_BACKEND_URL` 미설정 시 모든 API 호출 skip — 신규 환경에서도 Phase 1만으로 동작

## 변경 파일
- `src/api/alarmBackend.ts` + 테스트
- `src/hooks/useApnsTripRegistration.ts` + 테스트
- `src/tasks/silentPushTask.ts` + 테스트
- `src/utils/routeWaypoints.ts` + 테스트
- `app/_layout.tsx`, `app/(tabs)/index.tsx` — task 등록 + hook 통합
- `src/constants/storageKeys.ts` — `APNS_TOKEN_KEY`, `ACTIVE_TRIP_KEY`
- `.env.example` — `EXPO_PUBLIC_ALARM_BACKEND_URL`

## Test plan
- [x] `npm test` — 100% 커버리지
- [x] `npm run type-check`
- [ ] 실기기: APNs 토큰 발급 확인 (Development build)
- [ ] 실기기: silent push 수신 시 알람 재예약 동작 (백엔드 #338 배포 후)
- [ ] 권한 거부 환경에서 앱 정상 동작 (Phase 1 fallback)

Closes #337