### PR TITLE
feat(#348): 지도 탭에 "내 위치로 이동" 버튼

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -33,6 +33,8 @@ export default function MapScreen() {
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
   const [focusStation, setFocusStation] = useState<Station | null>(null);
   const [focusNonce, setFocusNonce] = useState(0);
+  const [recenterNonce, setRecenterNonce] = useState(0);
+  const [selectionCardHeight, setSelectionCardHeight] = useState(0);
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
 
@@ -99,11 +101,32 @@ export default function MapScreen() {
         trainMarkers={trainMarkers}
         focusStation={focusStation}
         focusNonce={focusNonce}
+        recenterNonce={recenterNonce}
       />
+
+      <TouchableOpacity
+        style={[
+          styles.recenterButton,
+          {
+            backgroundColor: colors.card,
+            borderColor: colors.hair,
+            bottom: spacing.xl + (selectedStation ? selectionCardHeight : insets.bottom),
+          },
+        ]}
+        onPress={() => setRecenterNonce((n) => n + 1)}
+        accessibilityLabel={t('map.recenter')}
+        testID="recenter-button"
+      >
+        <Text style={[styles.recenterIcon, { color: colors.ink }]}>◎</Text>
+      </TouchableOpacity>
 
       {/* 하단 역 선택 카드 */}
       {selectedStation && (
-        <View style={[styles.selectionCard, { backgroundColor: colors.card, borderColor: colors.hair, paddingBottom: spacing.xl + insets.bottom }]} testID="selection-card">
+        <View
+          style={[styles.selectionCard, { backgroundColor: colors.card, borderColor: colors.hair, paddingBottom: spacing.xl + insets.bottom }]}
+          onLayout={(e) => setSelectionCardHeight(e.nativeEvent.layout.height)}
+          testID="selection-card"
+        >
           <View style={styles.selectionHeader}>
             <View style={{ flex: 1 }}>
               <Text style={[styles.selectionName, { color: colors.ink }]}>{getStationDisplayName(selectedStation)}</Text>
@@ -191,5 +214,24 @@ const styles = StyleSheet.create({
   selectionButtonText: {
     fontSize: 15,
     fontWeight: '700',
+  },
+  recenterButton: {
+    position: 'absolute',
+    right: spacing.lg,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+  recenterIcon: {
+    fontSize: 22,
+    lineHeight: 24,
   },
 });

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -40,6 +40,8 @@ interface StationMapProps {
   focusStation?: Station | null;
   /** 같은 역을 다시 선택해도 카메라가 다시 움직이도록 매 선택마다 변경되는 값. */
   focusNonce?: number;
+  /** 값이 변할 때마다 사용자 좌표(userLat/userLng)로 카메라를 다시 이동시킨다. */
+  recenterNonce?: number;
 }
 
 const FOCUS_REGION_DELTA = 0.01;
@@ -55,11 +57,15 @@ export function StationMap({
   trainMarkers,
   focusStation,
   focusNonce,
+  recenterNonce,
 }: StationMapProps) {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
   const [mapReady, setMapReady] = useState(false);
   const mapRef = useRef<MapView | null>(null);
+  // nonce 트리거 effect에서 stale closure 없이 항상 최신 좌표를 쓰기 위한 ref.
+  const userPosRef = useRef({ lat: userLat, lng: userLng });
+  userPosRef.current = { lat: userLat, lng: userLng };
 
   useEffect(() => {
     if (!focusStation) return;
@@ -73,6 +79,19 @@ export function StationMap({
       FOCUS_ANIMATION_MS,
     );
   }, [focusStation?.id, focusNonce]);
+
+  useEffect(() => {
+    if (recenterNonce === undefined) return;
+    mapRef.current?.animateToRegion(
+      {
+        latitude: userPosRef.current.lat,
+        longitude: userPosRef.current.lng,
+        latitudeDelta: FOCUS_REGION_DELTA,
+        longitudeDelta: FOCUS_REGION_DELTA,
+      },
+      FOCUS_ANIMATION_MS,
+    );
+  }, [recenterNonce]);
 
   const mapConfig = useMemo(
     () => buildMapConfig({ userLat, userLng, nearestStation, nearbyStations }),

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -236,6 +236,56 @@ describe('StationMap', () => {
     });
   });
 
+  describe('recenterNonce', () => {
+    it('recenterNonce 미전달 시 animateToRegion 호출 안 함', () => {
+      render(<StationMap {...baseProps} />);
+      expect(__animateToRegionMock).not.toHaveBeenCalled();
+    });
+
+    it('recenterNonce 전달 시 사용자 좌표로 animateToRegion 호출', () => {
+      render(<StationMap {...baseProps} recenterNonce={1} />);
+      expect(__animateToRegionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          latitude: baseProps.userLat,
+          longitude: baseProps.userLng,
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('recenterNonce 변경 시 사용자 좌표로 재호출', () => {
+      const { rerender } = render(
+        <StationMap {...baseProps} recenterNonce={1} />,
+      );
+      __animateToRegionMock.mockClear();
+      rerender(<StationMap {...baseProps} recenterNonce={2} />);
+      expect(__animateToRegionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          latitude: baseProps.userLat,
+          longitude: baseProps.userLng,
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('GPS 좌표가 갱신된 뒤 nonce 변경 시 최신 좌표로 이동 (no stale closure)', () => {
+      const { rerender } = render(
+        <StationMap {...baseProps} recenterNonce={1} />,
+      );
+      rerender(
+        <StationMap {...baseProps} userLat={37.6} userLng={127.1} recenterNonce={1} />,
+      );
+      __animateToRegionMock.mockClear();
+      rerender(
+        <StationMap {...baseProps} userLat={37.6} userLng={127.1} recenterNonce={2} />,
+      );
+      expect(__animateToRegionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: 37.6, longitude: 127.1 }),
+        expect.any(Number),
+      );
+    });
+  });
+
   describe('trainMarkers (Phase 3 Stage 3)', () => {
     const mkTrain = (trainNo: string, status: number) => ({
       trainNo,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -73,6 +73,7 @@
     "setAsDestination": "Set as destination",
     "nearbyStationsHeader": "Nearby stations (within 1km)",
     "noNearbyStations": "No subway stations within 1km.",
+    "recenter": "Recenter on my location",
     "search": {
       "placeholder": "Search stations"
     },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -73,6 +73,7 @@
     "setAsDestination": "目的地に設定",
     "nearbyStationsHeader": "周辺の地下鉄駅 (1km以内)",
     "noNearbyStations": "1km以内に地下鉄駅がありません。",
+    "recenter": "現在地に戻る",
     "search": {
       "placeholder": "駅名を検索"
     },

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -73,6 +73,7 @@
     "setAsDestination": "도착역으로 설정",
     "nearbyStationsHeader": "주변 지하철역 (1km 이내)",
     "noNearbyStations": "주변 1km 내 지하철역이 없습니다.",
+    "recenter": "내 위치로 이동",
     "search": {
       "placeholder": "역 이름 검색"
     },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -73,6 +73,7 @@
     "setAsDestination": "设为目的地",
     "nearbyStationsHeader": "附近地铁站(1km以内)",
     "noNearbyStations": "1km内没有地铁站。",
+    "recenter": "返回当前位置",
     "search": {
       "placeholder": "搜索车站"
     },


### PR DESCRIPTION
## Summary
- 지도 탭 우측 하단에 네이버/카카오맵식 "내 위치로 이동" floating 버튼 추가
- `StationMap`에 `recenterNonce` prop 추가 — 기존 `focusStation/focusNonce` 패턴과 동일한 방식으로 카메라 재이동
- `userPosRef`로 stale closure 방지 (GPS 갱신 후 nonce 트리거 시에도 최신 좌표 보장)
- `selectionCard`가 떠 있을 땐 `onLayout` 실측 높이로 버튼 위치 동적 조정 (매직넘버 없음)
- ko/en/ja/zh `map.recenter` 접근성 라벨 추가

## Test plan
- [x] `npm test` — 1242 passed, 100% 커버리지
- [x] `npm run type-check` — pass
- [x] 자체 code-review (P1 2건 → 모두 수정 후 재리뷰 통과)
- [ ] 시뮬레이터에서 버튼 탭 시 카메라가 GPS 위치로 부드럽게 이동하는지
- [ ] selectionCard 떠 있을 때 버튼이 카드 위로 올라가는지

Closes #348