### PR TITLE
feat(#349): 경로 결과를 지도에서도 시각화

### DIFF
--- a/__mocks__/react-native-maps.js
+++ b/__mocks__/react-native-maps.js
@@ -1,17 +1,27 @@
 const React = require('react');
 const { View } = require('react-native');
 
-const MapView = ({ children, testID, onMapReady, ...props }) => {
+const fitToCoordinatesMock = jest.fn();
+
+const MapView = React.forwardRef(({ children, testID, onMapReady, ...props }, ref) => {
+  React.useImperativeHandle(ref, () => ({
+    fitToCoordinates: fitToCoordinatesMock,
+  }));
   React.useEffect(() => { onMapReady?.(); }, []);
   return React.createElement(View, { testID, ...props }, children);
-};
+});
 
 const Marker = ({ testID, onPress, children, ...props }) =>
   React.createElement(View, { testID, onPress, ...props }, children);
+
+const Polyline = ({ testID, ...props }) =>
+  React.createElement(View, { testID, ...props });
 
 module.exports = {
   __esModule: true,
   default: MapView,
   Marker,
+  Polyline,
   PROVIDER_DEFAULT: null,
+  __fitToCoordinatesMock: fitToCoordinatesMock,
 };

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
 import type { Station } from '../../src/types/station';
 import { EditorialTimeline } from '../../src/components/EditorialTimeline';
+import { RouteMap } from '../../src/components/RouteMap';
 import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/journeyAdapter';
 import { getStationDisplayName } from '../../src/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
@@ -417,6 +418,11 @@ export default function HomeScreen() {
                   )}
                   {journey && (
                     <EditorialTimeline stops={journeyDisplayToStops(journey)} />
+                  )}
+                  {route && effectiveOrigin && destination && (
+                    <View style={{ marginTop: spacing.xl, borderRadius: radius.md, overflow: 'hidden' }} testID="route-map-wrapper">
+                      <RouteMap route={route} origin={effectiveOrigin} destination={destination} />
+                    </View>
                   )}
                 </View>
 

--- a/src/components/RouteMap.tsx
+++ b/src/components/RouteMap.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import MapView, { Marker, Polyline, PROVIDER_DEFAULT } from 'react-native-maps';
+import type { Route } from '../utils/stationRoute';
+import type { Station } from '../types/station';
+import { routeToCoordinates, type RouteStationRole } from '../utils/routeToCoordinates';
+import { getStationDisplayName } from '../utils/stationDisplay';
+import { useTheme } from '../theme';
+
+interface RouteMapProps {
+  route: Route;
+  origin: Station;
+  destination: Station;
+}
+
+const FIT_EDGE_PADDING = { top: 40, bottom: 40, left: 40, right: 40 };
+const POLYLINE_WIDTH = 5;
+const ROLE_MARKER_SIZE: Record<RouteStationRole, number> = {
+  origin: 16,
+  transfer: 14,
+  destination: 16,
+};
+
+export function RouteMap({ route, origin, destination }: RouteMapProps) {
+  const { colors } = useTheme();
+  const [mapReady, setMapReady] = useState(false);
+  const mapRef = useRef<MapView | null>(null);
+
+  const coords = useMemo(
+    () => routeToCoordinates(route, origin, destination),
+    [route, origin.id, destination.id],
+  );
+
+  useEffect(() => {
+    if (!mapReady || !coords || coords.path.length === 0) return;
+    mapRef.current?.fitToCoordinates(coords.path, {
+      edgePadding: FIT_EDGE_PADDING,
+      animated: false,
+    });
+  }, [mapReady, coords]);
+
+  if (!coords) return null;
+
+  const polylineColor = colors.accent;
+
+  return (
+    <View style={styles.container} testID="route-map-container">
+      <MapView
+        ref={mapRef}
+        provider={PROVIDER_DEFAULT}
+        style={styles.map}
+        initialRegion={{
+          latitude: origin.lat,
+          longitude: origin.lng,
+          latitudeDelta: 0.1,
+          longitudeDelta: 0.1,
+        }}
+        onMapReady={() => setMapReady(true)}
+        testID="route-map"
+      >
+        <Polyline
+          coordinates={coords.path}
+          strokeColor={polylineColor}
+          strokeWidth={POLYLINE_WIDTH}
+          testID="route-polyline"
+        />
+        {coords.keyStations.map(({ station, role }) => (
+          <Marker
+            key={`${role}-${station.id}`}
+            coordinate={{ latitude: station.lat, longitude: station.lng }}
+            title={getStationDisplayName(station)}
+            tracksViewChanges={false}
+            anchor={{ x: 0.5, y: 0.5 }}
+            testID={`route-marker-${role}-${station.id}`}
+          >
+            <View
+              style={[
+                styles.markerDot,
+                {
+                  width: ROLE_MARKER_SIZE[role],
+                  height: ROLE_MARKER_SIZE[role],
+                  borderRadius: ROLE_MARKER_SIZE[role] / 2,
+                  backgroundColor: role === 'transfer' ? station.lineColor : colors.accent,
+                },
+              ]}
+              testID={`route-marker-dot-${role}-${station.id}`}
+            />
+            <Text style={[styles.markerLabel, { color: colors.ink }]} numberOfLines={1}>
+              {getStationDisplayName(station)}
+            </Text>
+          </Marker>
+        ))}
+      </MapView>
+      {!mapReady && (
+        <View style={styles.loading} testID="route-map-loading">
+          <ActivityIndicator color={colors.muted} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    height: 220,
+    overflow: 'hidden',
+  },
+  map: {
+    flex: 1,
+  },
+  loading: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  markerDot: {
+    borderWidth: 2,
+    borderColor: '#ffffff',
+  },
+  markerLabel: {
+    marginTop: 2,
+    fontSize: 11,
+    fontWeight: '600',
+    textAlign: 'center',
+    maxWidth: 80,
+  },
+});

--- a/src/components/__tests__/RouteMap.test.tsx
+++ b/src/components/__tests__/RouteMap.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { RouteMap } from '../RouteMap';
+import { findRoute } from '../../utils/stationRoute';
+import stationsData from '../../data/stations.json';
+import type { Station } from '../../types/station';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __fitToCoordinatesMock } = require('react-native-maps');
+
+const allStations = stationsData as Station[];
+const byId = (id: string) => allStations.find((s) => s.id === id)!;
+
+beforeEach(() => {
+  __fitToCoordinatesMock.mockClear();
+});
+
+describe('RouteMap', () => {
+  it('route가 null이면 아무것도 렌더링하지 않는다', () => {
+    const origin = byId('2-022');
+    const destination = byId('2-019');
+    const { queryByTestId } = render(
+      <RouteMap route={null} origin={origin} destination={destination} />,
+    );
+    expect(queryByTestId('route-map-container')).toBeNull();
+  });
+
+  it('direct route는 origin/destination 두 개의 마커만 표시한다', () => {
+    const origin = byId('2-022');
+    const destination = byId('2-019');
+    const route = findRoute(origin.id, destination.id);
+    const { getByTestId, queryAllByTestId } = render(
+      <RouteMap route={route} origin={origin} destination={destination} />,
+    );
+    expect(getByTestId('route-map')).toBeTruthy();
+    expect(getByTestId(`route-marker-origin-${origin.id}`)).toBeTruthy();
+    expect(getByTestId(`route-marker-destination-${destination.id}`)).toBeTruthy();
+    expect(queryAllByTestId(/^route-marker-transfer-/)).toHaveLength(0);
+  });
+
+  it('transfer route는 환승역 마커도 표시한다', () => {
+    const origin = byId('2-022');
+    const destination = byId('6-020');
+    const route = findRoute(origin.id, destination.id);
+    const { queryAllByTestId, getByTestId } = render(
+      <RouteMap route={route} origin={origin} destination={destination} />,
+    );
+    expect(getByTestId('route-polyline')).toBeTruthy();
+    expect(queryAllByTestId(/^route-marker-transfer-/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('mapReady 후 fitToCoordinates를 호출한다', async () => {
+    const origin = byId('2-022');
+    const destination = byId('2-019');
+    const route = findRoute(origin.id, destination.id);
+    render(<RouteMap route={route} origin={origin} destination={destination} />);
+    await waitFor(() => expect(__fitToCoordinatesMock).toHaveBeenCalled());
+    const [coords, opts] = __fitToCoordinatesMock.mock.calls[0];
+    expect(Array.isArray(coords)).toBe(true);
+    expect(coords.length).toBeGreaterThan(0);
+    expect(opts).toMatchObject({ animated: false });
+  });
+
+  it('mapReady 전에는 로딩 인디케이터를 표시한다 — onMapReady 후 사라진다', async () => {
+    const origin = byId('2-022');
+    const destination = byId('2-019');
+    const route = findRoute(origin.id, destination.id);
+    const { queryByTestId } = render(
+      <RouteMap route={route} origin={origin} destination={destination} />,
+    );
+    await waitFor(() => {
+      expect(queryByTestId('route-map-loading')).toBeNull();
+    });
+  });
+
+  it('transfer 마커는 해당 역의 lineColor를 사용한다', () => {
+    const origin = byId('2-022');
+    const destination = byId('6-020');
+    const route = findRoute(origin.id, destination.id);
+    const { queryAllByTestId } = render(
+      <RouteMap route={route} origin={origin} destination={destination} />,
+    );
+    const transferDots = queryAllByTestId(/^route-marker-dot-transfer-/);
+    expect(transferDots.length).toBeGreaterThan(0);
+    // line color가 적용된 dot인지만 확인 (구체 색상은 데이터 의존)
+    const styles = transferDots[0].props.style as Array<Record<string, unknown>>;
+    const merged = styles.reduce((acc, s) => ({ ...acc, ...s }), {});
+    expect(typeof merged.backgroundColor).toBe('string');
+  });
+
+  it('coords가 null인 경우 컴포넌트를 렌더링하지 않고 fitToCoordinates도 호출하지 않는다', () => {
+    // 잘못된 환승역 이름을 가진 route → routeToCoordinates가 null 반환 → 컴포넌트가 null 렌더
+    const origin = byId('2-022');
+    const destination = byId('6-020');
+    const badRoute = {
+      type: 'transfer' as const,
+      transferName: '존재하지않는역',
+      fromLine: '2' as const,
+      toLine: '6' as const,
+      stopsToTransfer: 1,
+      stopsFromTransfer: 1,
+    };
+    const { queryByTestId } = render(
+      <RouteMap route={badRoute} origin={origin} destination={destination} />,
+    );
+    // null 렌더이므로 MapView 자체가 존재하지 않으며 fitToCoordinates도 호출되지 않는다
+    expect(queryByTestId('route-map')).toBeNull();
+    expect(queryByTestId('route-map-container')).toBeNull();
+    expect(__fitToCoordinatesMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/routeToCoordinates.test.ts
+++ b/src/utils/__tests__/routeToCoordinates.test.ts
@@ -1,0 +1,141 @@
+import { routeToCoordinates } from '../routeToCoordinates';
+import { findRoute } from '../stationRoute';
+import stationsData from '../../data/stations.json';
+import type { Station } from '../../types/station';
+
+const allStations = stationsData as Station[];
+const byId = (id: string) => allStations.find((s) => s.id === id)!;
+
+describe('routeToCoordinates', () => {
+  it('route가 null이면 null을 반환한다', () => {
+    const origin = byId('2-022');
+    const destination = byId('2-019');
+    expect(routeToCoordinates(null, origin, destination)).toBeNull();
+  });
+
+  describe('direct route (동일 노선)', () => {
+    const origin = byId('2-022'); // 강남
+    const destination = byId('2-019'); // 삼성
+    const route = findRoute(origin.id, destination.id);
+
+    it('출발/도착 사이 모든 역 좌표를 path에 포함한다', () => {
+      const result = routeToCoordinates(route, origin, destination);
+      expect(result).not.toBeNull();
+      expect(result!.path.length).toBeGreaterThanOrEqual(2);
+      expect(result!.path[0]).toEqual({ latitude: origin.lat, longitude: origin.lng });
+      const last = result!.path[result!.path.length - 1];
+      expect(last).toEqual({ latitude: destination.lat, longitude: destination.lng });
+    });
+
+    it('keyStations은 origin과 destination 두 개', () => {
+      const result = routeToCoordinates(route, origin, destination);
+      expect(result!.keyStations).toEqual([
+        { station: origin, role: 'origin' },
+        { station: destination, role: 'destination' },
+      ]);
+    });
+  });
+
+  describe('transfer route (단일 환승)', () => {
+    const origin = byId('2-022'); // 강남
+    const destination = byId('6-020'); // 녹사평
+    const route = findRoute(origin.id, destination.id);
+
+    it('출발 → 환승역 → 도착 좌표 시퀀스를 생성한다', () => {
+      const result = routeToCoordinates(route, origin, destination);
+      expect(result).not.toBeNull();
+      expect(result!.path[0]).toEqual({ latitude: origin.lat, longitude: origin.lng });
+      const last = result!.path[result!.path.length - 1];
+      expect(last).toEqual({ latitude: destination.lat, longitude: destination.lng });
+    });
+
+    it('keyStations에 transfer 역이 포함된다', () => {
+      const result = routeToCoordinates(route, origin, destination);
+      const roles = result!.keyStations.map((k) => k.role);
+      expect(roles).toEqual(['origin', 'transfer', 'destination']);
+    });
+  });
+
+  it('두 세그먼트 경계에서 환승역 좌표가 중복되지 않는다', () => {
+    const origin = byId('2-022');
+    const destination = byId('6-020');
+    const route = findRoute(origin.id, destination.id);
+    const result = routeToCoordinates(route, origin, destination)!;
+    const stringified = result.path.map((p) => `${p.latitude},${p.longitude}`);
+    const unique = new Set(stringified);
+    expect(unique.size).toBe(stringified.length);
+  });
+
+  describe('역방향 (toIdx < fromIdx)', () => {
+    it('인덱스가 큰 역에서 작은 역으로 가는 직통도 좌표를 생성한다', () => {
+      const origin = byId('2-019'); // 삼성 (idx 큼)
+      const destination = byId('2-022'); // 강남 (idx 작음)
+      const route = findRoute(origin.id, destination.id);
+      const result = routeToCoordinates(route, origin, destination)!;
+      expect(result.path[0]).toEqual({ latitude: origin.lat, longitude: origin.lng });
+      expect(result.path[result.path.length - 1]).toEqual({
+        latitude: destination.lat,
+        longitude: destination.lng,
+      });
+    });
+  });
+
+  describe('multi-transfer route (2회 환승)', () => {
+    it('transfers 배열의 각 환승역이 keyStations에 순서대로 포함된다', () => {
+      const route = {
+        type: 'multi-transfer' as const,
+        transfers: [
+          { transferName: '사당', fromLine: '2' as const, toLine: '4' as const, stopsToTransfer: 4 },
+          { transferName: '동대문역사문화공원', fromLine: '4' as const, toLine: '5' as const, stopsToTransfer: 4 },
+        ],
+        stopsAfterLastTransfer: 3,
+      };
+      const origin = byId('2-022'); // 강남
+      // 5호선에서 임의의 역
+      const destination = allStations.find((s) => s.line === '5' && s.name === '광화문')!;
+      const result = routeToCoordinates(route, origin, destination);
+      expect(result).not.toBeNull();
+      const roles = result!.keyStations.map((k) => k.role);
+      expect(roles).toEqual(['origin', 'transfer', 'transfer', 'destination']);
+      const names = result!.keyStations.map((k) => k.station.name);
+      expect(names).toEqual([origin.name, '사당', '동대문역사문화공원', destination.name]);
+    });
+  });
+
+  describe('잘못된 입력으로 인한 null 반환', () => {
+    it('transfer 환승역 이름을 찾을 수 없으면 null', () => {
+      const route = {
+        type: 'transfer' as const,
+        transferName: '존재하지않는역',
+        fromLine: '2' as const,
+        toLine: '6' as const,
+        stopsToTransfer: 1,
+        stopsFromTransfer: 1,
+      };
+      const origin = byId('2-022');
+      const destination = byId('6-020');
+      expect(routeToCoordinates(route, origin, destination)).toBeNull();
+    });
+
+    it('multi-transfer 환승역 이름을 찾을 수 없으면 null', () => {
+      const route = {
+        type: 'multi-transfer' as const,
+        transfers: [
+          { transferName: '존재하지않는역', fromLine: '2' as const, toLine: '4' as const, stopsToTransfer: 1 },
+          { transferName: '동대문역사문화공원', fromLine: '4' as const, toLine: '5' as const, stopsToTransfer: 1 },
+        ],
+        stopsAfterLastTransfer: 1,
+      };
+      const origin = byId('2-022');
+      const destination = allStations.find((s) => s.line === '5' && s.name === '광화문')!;
+      expect(routeToCoordinates(route, origin, destination)).toBeNull();
+    });
+
+    it('direct route인데 origin이 노선과 불일치하여 슬라이스 실패 시 null', () => {
+      const route = { type: 'direct' as const, line: '2' as const, stops: 1 };
+      const origin = byId('6-020'); // 6호선 역을 2호선 direct에 넣음 → name이 2호선에 없음
+      const destination = byId('2-022');
+      expect(routeToCoordinates(route, origin, destination)).toBeNull();
+    });
+  });
+});

--- a/src/utils/routeToCoordinates.ts
+++ b/src/utils/routeToCoordinates.ts
@@ -1,0 +1,101 @@
+import type { LineNumber, Station } from '../types/station';
+import type { Route } from './stationRoute';
+import { findStationByNameAndLine, getStationsOnLine } from './stationRoute';
+
+export type RouteStationRole = 'origin' | 'transfer' | 'destination';
+
+export interface RouteKeyStation {
+  station: Station;
+  role: RouteStationRole;
+}
+
+export interface RouteCoordinatePath {
+  /** 경로를 따라가는 좌표 시퀀스. Polyline 그리기에 사용. */
+  path: { latitude: number; longitude: number }[];
+  /** 출발/환승/도착 마커로 강조할 역 목록 (순서 보존). */
+  keyStations: RouteKeyStation[];
+}
+
+interface Segment {
+  line: LineNumber;
+  fromStation: Station;
+  toStation: Station;
+}
+
+/** 두 역 사이 해당 노선의 역들을 순서대로 반환 (양 끝 포함). */
+function sliceLine(line: LineNumber, fromName: string, toName: string): Station[] {
+  const lineStations = getStationsOnLine(line);
+  const fromIdx = lineStations.findIndex((s) => s.name === fromName);
+  const toIdx = lineStations.findIndex((s) => s.name === toName);
+  if (fromIdx === -1 || toIdx === -1) return [];
+  const step = toIdx >= fromIdx ? 1 : -1;
+  const slice: Station[] = [];
+  for (let i = fromIdx; i !== toIdx + step; i += step) {
+    slice.push(lineStations[i]);
+  }
+  return slice;
+}
+
+/** Route를 세그먼트(노선/시작역/끝역) 시퀀스로 변환. 환승 N개 일반화. */
+function buildSegments(route: NonNullable<Route>, origin: Station, destination: Station): Segment[] {
+  if (route.type === 'direct') {
+    return [{ line: route.line, fromStation: origin, toStation: destination }];
+  }
+
+  if (route.type === 'transfer') {
+    const transferFrom = findStationByNameAndLine(route.transferName, route.fromLine);
+    const transferTo = findStationByNameAndLine(route.transferName, route.toLine);
+    if (!transferFrom || !transferTo) return [];
+    return [
+      { line: route.fromLine, fromStation: origin, toStation: transferFrom },
+      { line: route.toLine, fromStation: transferTo, toStation: destination },
+    ];
+  }
+
+  // multi-transfer
+  const segments: Segment[] = [];
+  const { transfers } = route;
+  let segStart = origin;
+  for (let i = 0; i < transfers.length; i++) {
+    const t = transfers[i];
+    const transferStart = findStationByNameAndLine(t.transferName, t.fromLine);
+    const transferNext = findStationByNameAndLine(t.transferName, t.toLine);
+    if (!transferStart || !transferNext) return [];
+    segments.push({ line: t.fromLine, fromStation: segStart, toStation: transferStart });
+    segStart = transferNext;
+  }
+  const lastTransfer = transfers[transfers.length - 1];
+  segments.push({ line: lastTransfer.toLine, fromStation: segStart, toStation: destination });
+  return segments;
+}
+
+export function routeToCoordinates(
+  route: Route,
+  origin: Station,
+  destination: Station,
+): RouteCoordinatePath | null {
+  if (!route) return null;
+  const segments = buildSegments(route, origin, destination);
+  if (segments.length === 0) return null;
+
+  const path: { latitude: number; longitude: number }[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const slice = sliceLine(seg.line, seg.fromStation.name, seg.toStation.name);
+    if (slice.length === 0) return null;
+    // 첫 세그먼트 외에는 시작점이 직전 세그먼트의 끝점(환승역)과 동일하므로 중복 제거
+    const start = i === 0 ? 0 : 1;
+    for (let j = start; j < slice.length; j++) {
+      path.push({ latitude: slice[j].lat, longitude: slice[j].lng });
+    }
+  }
+
+  const keyStations: RouteKeyStation[] = [{ station: origin, role: 'origin' }];
+  // 각 세그먼트 사이의 환승역 (마지막 세그먼트 끝은 도착역이므로 제외)
+  for (let i = 0; i < segments.length - 1; i++) {
+    keyStations.push({ station: segments[i].toStation, role: 'transfer' });
+  }
+  keyStations.push({ station: destination, role: 'destination' });
+
+  return { path, keyStations };
+}


### PR DESCRIPTION
## Summary
- 도착지 설정 후 경로를 텍스트(EditorialTimeline) 외에 지도에서도 볼 수 있도록 미니 RouteMap을 홈 탭 경로 카드에 임베드
- `routeToCoordinates` 유틸로 direct/transfer/multi-transfer Route → 좌표 시퀀스 + 출발/환승/도착 keyStations 변환 (transfers 배열 순회로 환승 N개 일반화)
- `RouteMap` 컴포넌트는 Polyline + 역할별 마커 표시 + 마운트 시 fitToCoordinates로 카메라 자동 맞춤

Closes #349

## Test plan
- [x] `routeToCoordinates`: direct/transfer/multi-transfer/역방향/null/잘못된 환승역 — 11 케이스
- [x] `RouteMap`: 렌더링, 마커 개수(direct=2, transfer≥3), Polyline, fitToCoordinates 호출, 로딩 인디케이터, transfer 마커 색상, coords null 시 미렌더 — 7 케이스
- [x] 신규 두 파일 100% 커버리지 (lines/functions/branches/statements)
- [ ] 실기기에서 경로 설정 후 미니 지도 표시 확인 (수동)