### PR TITLE
chore(#352): bump version to 1.2.2

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -24,7 +24,7 @@ module.exports = {
       supportsTablet: false,
       bundleIdentifier: 'com.subwaynow.app',
       appleTeamId: '4755N5H4T4',
-      buildNumber: '42',
+      buildNumber: '43',
       infoPlist: {
         NSAppTransportSecurity: {
           NSExceptionDomains: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- \`package.json\` / \`package-lock.json\` version 1.2.1 → 1.2.2
- \`app.config.js\` iOS buildNumber 42 → 43

PR #351 (지도 경로 시각화) 머지에 따른 릴리스용 버전 bump.

Closes #352

## Test plan
- [x] package.json, package-lock.json, app.config.js 동기화 확인
- [x] 머지 후 dev → main 릴리스 PR 생성