### PR TITLE
feat(#356): 지도 탭에서 도착역 설정 시 홈 탭 자동 전환

### DIFF
--- a/.maestro/flows/map/01_set_destination_auto_switch.yaml
+++ b/.maestro/flows/map/01_set_destination_auto_switch.yaml
@@ -1,0 +1,53 @@
+appId: com.subwaynow.app
+name: "지도 탭 - 도착역 설정 후 홈 탭 자동 전환"
+---
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
+    timeout: 15000
+
+# 지도 탭으로 이동
+- tapOn:
+    text: "지도"
+
+- extendedWaitUntil:
+    visible:
+      id: "recenter-button"
+    timeout: 10000
+
+# 사용자 위치 근처 역(강남) 마커 탭 → 선택 카드 등장
+- tapOn:
+    text: "강남"
+
+- extendedWaitUntil:
+    visible:
+      id: "set-destination-button"
+    timeout: 5000
+
+# 도착역으로 설정 → 홈 탭으로 자동 전환되어야 함
+- tapOn:
+    id: "set-destination-button"
+
+# 홈 탭(현재 역) UI가 보이는지 확인
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
+    timeout: 10000
+
+- assertVisible:
+    id: "destination-clear-button"

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
+import { router } from 'expo-router';
 import { useNearestStation } from '../../src/hooks/useNearestStation';
 import { useActiveLinePositions } from '../../src/hooks/useActiveLinePositions';
 import { StationMap } from '../../src/components/StationMap';
@@ -153,6 +154,7 @@ export default function MapScreen() {
                 setRecentDestination(selectedStation);
                 setDestination(selectedStation);
                 setSelectedStation(null);
+                router.navigate('/(tabs)');
               }}
               testID="set-destination-button"
             >


### PR DESCRIPTION
## Summary
- 지도 탭의 "도착역으로 설정" 버튼 누르면 자동으로 홈(현재 역) 탭으로 전환
- customOrigin이 이미 설정돼 있으면 유지, 없으면 GPS 기반 가장 가까운 역이 출발역으로 표시
- 별도 출발역 등록 로직 없이 기존 `effectiveOrigin = customOrigin ?? GPS-nearest` 패턴 그대로 활용

## Changes
- `app/(tabs)/map.tsx`: 도착역 버튼 핸들러에 `router.navigate('/(tabs)')` 추가
- `.maestro/flows/map/01_set_destination_auto_switch.yaml`: 도착역 설정 → 홈 탭 자동 전환 E2E flow 추가

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (1260 tests, coverage 100%)
- [x] code-review 에이전트 통과
- [x] 수동: customOrigin 없을 때 — 지도 탭 → 역 마커 탭 → "도착역으로 설정" → 홈 탭 전환 → GPS 가장 가까운 역이 출발역
- [ ] 수동: customOrigin 있을 때 — 출발역 먼저 지정 → 도착역 설정 → 홈 탭 전환 → customOrigin 유지

Closes #356