### PR TITLE
chore(#359): 홈 탭에서 GPS 전환 버튼 + 시계 + LIVE/수동 라벨 제거

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -35,9 +35,8 @@ const logger = createLogger('HomeScreen');
 
 export default function HomeScreen() {
   const { colors } = useTheme();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const customOrigin = useAppStore((s) => s.customOrigin);
-  const setCustomOrigin = useAppStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
@@ -297,20 +296,6 @@ export default function HomeScreen() {
       <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
         {effectiveOrigin ? (
           <>
-            {/* Top meta */}
-            <View style={styles.topMeta}>
-              <Pressable
-                onLongPress={__DEV__ ? () => useAppStore.getState().setDebugVisible(true) : undefined}
-                delayLongPress={700}
-                testID="home-clock"
-              >
-                <Text style={[typography.mono, { color: colors.subtle }]}>
-                  {new Date().toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })}
-                </Text>
-              </Pressable>
-              <Text style={[typography.label, { color: colors.subtle }]}>{isCustomOrigin ? t('home.manual') : t('home.live')}</Text>
-            </View>
-
             {/* Hero: origin station */}
             <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxxl - 4 }}>
               <Text style={[typography.label, { color: colors.muted, marginBottom: 10 }]}>
@@ -351,15 +336,6 @@ export default function HomeScreen() {
                   </>
                 )}
               </View>
-              {isCustomOrigin && (
-                <TouchableOpacity
-                  style={[styles.gpsResetButton, { borderColor: colors.accent }]}
-                  onPress={() => setCustomOrigin(null)}
-                  testID="gps-reset-button"
-                >
-                  <Text style={[styles.gpsResetText, { color: colors.accent }]}>{t('home.switchToGps')}</Text>
-                </TouchableOpacity>
-              )}
             </View>
 
             <Hr />
@@ -611,13 +587,6 @@ const styles = StyleSheet.create({
     padding: spacing.xxl,
     minHeight: 400,
   },
-  topMeta: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: spacing.xxl,
-    paddingTop: spacing.lg,
-  },
   heroRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -647,18 +616,6 @@ const styles = StyleSheet.create({
   routePillSub: {
     fontSize: 11,
     marginTop: 2,
-  },
-  gpsResetButton: {
-    marginTop: spacing.md,
-    borderWidth: 1,
-    borderRadius: radius.sm,
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.xs,
-    alignSelf: 'flex-start',
-  },
-  gpsResetText: {
-    fontSize: 13,
-    fontWeight: '600',
   },
   actionsRow: {
     flexDirection: 'row',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -20,12 +20,9 @@
   },
   "home": {
     "arrived": "Arrived!",
-    "live": "LIVE",
-    "manual": "MANUAL",
     "originManual": "Origin (manual)",
     "originCurrent": "Current station",
     "originNearest": "Nearest station",
-    "switchToGps": "Switch to GPS mode",
     "routeTo": "Route to",
     "estimatedSuffix": "EST",
     "destinationChange": "Change destination →",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -20,12 +20,9 @@
   },
   "home": {
     "arrived": "到着!",
-    "live": "LIVE",
-    "manual": "手動",
     "originManual": "出発駅(手動)",
     "originCurrent": "現在駅",
     "originNearest": "最寄り駅",
-    "switchToGps": "GPSモードに切り替え",
     "routeTo": "目的地まで",
     "estimatedSuffix": "予想",
     "destinationChange": "目的地を変更 →",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -20,12 +20,9 @@
   },
   "home": {
     "arrived": "도착!",
-    "live": "LIVE",
-    "manual": "수동",
     "originManual": "출발역 (수동)",
     "originCurrent": "현재역",
     "originNearest": "가장 가까운 역",
-    "switchToGps": "GPS 모드로 전환",
     "routeTo": "목적지까지",
     "estimatedSuffix": "예상",
     "destinationChange": "목적지 변경 →",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -20,12 +20,9 @@
   },
   "home": {
     "arrived": "已到达!",
-    "live": "LIVE",
-    "manual": "MANUAL",
     "originManual": "出发站(手动)",
     "originCurrent": "当前站",
     "originNearest": "最近站",
-    "switchToGps": "切换到GPS模式",
     "routeTo": "前往",
     "estimatedSuffix": "预计",
     "destinationChange": "更改目的地 →",


### PR DESCRIPTION
## Summary
- 지도 탭 상단 StatusChip ✕ 해제 동선과 중복이던 홈의 'GPS로 전환' 버튼 제거
- 홈 상단 시계 + LIVE/수동 라벨 정리해 화면 간결화
- 시계의 __DEV__ long-press 디버그 트리거는 `_layout.tsx`의 `DevSettings.addMenuItem('Subway debug', ...)`로 동일 접근 가능 (손실 없음)

## Changes
- `app/(tabs)/index.tsx`: topMeta(시계+라벨), GPS 전환 버튼, 관련 스타일/unused import 제거
- `src/i18n/locales/{ko,en,ja,zh}.json`: `home.live`, `home.manual`, `home.switchToGps` 키 제거

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (1260 tests, coverage 100%)
- [x] code-review 에이전트 통과
- [ ] 수동: 홈 상단에 시계/라벨이 더 이상 보이지 않는지
- [ ] 수동: customOrigin 설정 후에도 홈에 GPS 전환 버튼이 없는지 (해제는 지도 탭 chip ✕로)

Closes #359