### PR TITLE
fix(#361): 지도 탭 역 검색 시 키보드 자동 해제

### DIFF
--- a/.maestro/flows/map/02_search_dismisses_keyboard.yaml
+++ b/.maestro/flows/map/02_search_dismisses_keyboard.yaml
@@ -1,0 +1,66 @@
+appId: com.subwaynow.app
+name: "지도 탭 - 역 검색 후 키보드 자동 해제"
+---
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
+    timeout: 15000
+
+# 지도 탭으로 이동
+- tapOn:
+    text: "지도"
+
+- extendedWaitUntil:
+    visible:
+      id: "recenter-button"
+    timeout: 10000
+
+# 검색창 탭 → 키보드 표시
+- tapOn:
+    id: "map-search-input"
+
+# 역명 입력
+- inputText: "강남"
+
+# 추천 목록 등장 대기
+- extendedWaitUntil:
+    visible:
+      id: "map-search-suggestions"
+    timeout: 5000
+
+# 추천 항목 첫 번째 탭 → 키보드가 닫히고 선택 카드가 나타나야 함
+- tapOn:
+    id: "map-search-suggestion-2-022"
+
+# 선택 카드의 도착역 버튼은 화면 하단에 위치 → 키보드가 닫혀야만 탭 가능
+- extendedWaitUntil:
+    visible:
+      id: "set-destination-button"
+    timeout: 5000
+
+- tapOn:
+    id: "set-destination-button"
+
+# 도착역 설정이 정상 동작 → 홈 탭으로 자동 전환됨을 확인
+- extendedWaitUntil:
+    visible:
+      text: "LIVE"
+    timeout: 10000
+
+- assertVisible:
+    id: "destination-clear-button"

--- a/src/components/MapSearchBar.tsx
+++ b/src/components/MapSearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { StyleSheet, TextInput, View } from 'react-native';
+import { Keyboard, StyleSheet, TextInput, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import stationsData from '../data/stations.json';
 import type { Station } from '../types/station';
@@ -28,6 +28,7 @@ export function MapSearchBar({ onSelect }: Props) {
   }, [query]);
 
   function handleSelect(station: Station) {
+    Keyboard.dismiss();
     setQuery('');
     setShowDropdown(false);
     onSelect(station);

--- a/src/components/__tests__/MapSearchBar.test.tsx
+++ b/src/components/__tests__/MapSearchBar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Keyboard } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 import { MapSearchBar } from '../MapSearchBar';
 
@@ -44,6 +45,18 @@ describe('MapSearchBar', () => {
       expect.objectContaining({ name: expect.any(String), id: expect.any(String) }),
     );
     expect(queryByTestId('map-search-suggestions')).toBeNull();
+  });
+
+  it('추천 항목 탭 시 키보드를 닫는다', () => {
+    const dismissSpy = jest.spyOn(Keyboard, 'dismiss');
+    const { getByTestId, getAllByTestId } = render(
+      <MapSearchBar onSelect={jest.fn()} />,
+    );
+    fireEvent.changeText(getByTestId('map-search-input'), '강남');
+    const items = getAllByTestId(/^map-search-suggestion-/);
+    fireEvent.press(items[0]);
+    expect(dismissSpy).toHaveBeenCalledTimes(1);
+    dismissSpy.mockRestore();
   });
 
   it('일치하지 않는 검색어는 추천을 보여주지 않는다', () => {


### PR DESCRIPTION
## Summary

- 지도 탭에서 역을 검색하고 추천 항목을 선택해도 키보드가 사라지지 않아 후속 조작이 차단되던 문제 수정
- `MapSearchBar.handleSelect`에서 `Keyboard.dismiss()`를 호출하도록 변경

## 원인

`src/components/MapSearchBar.tsx`의 `handleSelect`가 query/dropdown 상태만 정리하고 `Keyboard.dismiss()`를 호출하지 않아 TextInput 포커스가 유지됨. WebView 기반 지도가 영역 탭을 가로채므로 outside-tap으로도 dismiss되지 않아 사용자가 앱을 종료해야 하는 상황 발생.

## Test plan

- [x] `npm test` — 1261개 테스트 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-review 에이전트 통과 (P0/P1 없음)
- [x] 시뮬레이터: 지도 탭 → 검색창에 "강남" 입력 → 추천 "강남" 선택 → 키보드 즉시 닫힘 + 지도 이동 정상

Closes #361