### PR TITLE
chore(#363): EAS Remote Version Source + autoIncrement 도입

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,10 +47,50 @@ npx jest --testNamePattern="should return nearest station"
 
 **빌드 & 배포:**
 ```bash
-eas build --profile production --platform ios    # 프로덕션 빌드
+eas build --profile production --platform ios    # 프로덕션 빌드 (buildNumber 자동 +1)
 eas build --profile development --platform ios   # 개발 빌드 (실기기 테스트)
 eas submit --platform ios --latest               # TestFlight 업로드
 ```
+
+### 버전/빌드 번호 관리 정책
+
+| 값 | 의미 | 출처 (SSOT) | 변경 방법 |
+| --- | --- | --- | --- |
+| `version` (CFBundleShortVersionString) | 마케팅 버전 (예: 1.2.2) | `package.json` | 새 chore 이슈 → `npm version patch/minor/major` |
+| `ios.buildNumber` (CFBundleVersion) | iOS 빌드 번호 | **EAS Remote** | production 빌드 시 자동 +1 |
+| `android.versionCode` | Android 빌드 번호 | **EAS Remote** | production 빌드 시 자동 +1 |
+
+- `eas.json`: `appVersionSource: "remote"` + production 프로파일 `autoIncrement: true`.
+- `development` / `preview` 프로파일은 autoIncrement 미적용 → remote 마지막 값 재사용 (테스트 빌드가 production 카운터를 소진하지 않음).
+- `app.config.js`에는 `buildNumber` / `versionCode`를 두지 않는다. (remote 모드에서 무시되며 혼란만 유발)
+
+### EAS Remote Version 운영 명령
+
+```bash
+eas build:version:get --platform ios       # 현재 remote 값 확인
+eas build:version:set --platform ios       # 값 강제 지정 (예외 상황)
+eas build:version:sync                     # 로컬 → remote 동기화
+```
+
+### 1회성 마이그레이션 절차 (`appVersionSource: "local"` → `"remote"` 전환 시점)
+
+**중요: 이 절차는 PR `chore/#363` 머지 직후 단 한 번만 실행.**
+
+```bash
+# 1) 현재 remote 상태 확인
+eas build:version:get --platform ios
+eas build:version:get --platform android
+
+# 2) remote가 비어 있거나 직전 출시값(iOS 43, Android 1) 이하라면 baseline 명시 지정
+#    autoIncrement는 (remote 값) + 1 부터 발급하므로 안전치로 +1 해서 set
+eas build:version:set --platform ios       # 값: 44
+eas build:version:set --platform android   # 값: 2
+
+# 3) 첫 production 빌드로 검증 (buildNumber가 45, versionCode가 3으로 찍혀야 정상)
+eas build --profile production --platform ios
+```
+
+이 절차를 건너뛰면 autoIncrement 결과가 App Store 기존 빌드 번호 이하로 떨어져 다시 거부될 수 있다.
 
 ---
 

--- a/app.config.js
+++ b/app.config.js
@@ -24,7 +24,6 @@ module.exports = {
       supportsTablet: false,
       bundleIdentifier: 'com.subwaynow.app',
       appleTeamId: '4755N5H4T4',
-      buildNumber: '43',
       infoPlist: {
         NSAppTransportSecurity: {
           NSExceptionDomains: {
@@ -51,7 +50,6 @@ module.exports = {
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,
       package: 'com.subwaynow.app',
-      versionCode: 1,
     },
     web: {
       favicon: './assets/favicon.png',

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 18.8.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -11,7 +11,9 @@
     "preview": {
       "distribution": "internal"
     },
-    "production": {}
+    "production": {
+      "autoIncrement": true
+    }
   },
   "submit": {
     "production": {}


### PR DESCRIPTION
## Summary

- App Store Connect "You've already submitted this build of the app." 거부 사고의 **근본 원인**(buildNumber 수동 관리)을 EAS Remote Version Source + autoIncrement로 시스템 차원에서 차단
- `eas.json`을 `appVersionSource: "remote"` 로 전환, production 프로파일에 `autoIncrement: true`
- `app.config.js`에서 무의미해진 `buildNumber`/`versionCode` 하드코딩 제거
- CLAUDE.md에 버전/빌드 정책, 운영 명령, **1회성 마이그레이션 절차** 명시

## 정책 요약

| 값 | SSOT | 변경 방법 |
| --- | --- | --- |
| `version` (1.2.2) | `package.json` | `npm version` (chore 이슈) |
| `ios.buildNumber` | **EAS Remote** | production 빌드 시 자동 +1 |
| `android.versionCode` | **EAS Remote** | production 빌드 시 자동 +1 |

dev/preview 프로파일은 autoIncrement 미적용 → 테스트 빌드가 production 카운터를 소진하지 않음.

## 머지 직후 1회성 마이그레이션 (필수)

remote 카운터가 비어 있거나 이전 출시값(iOS 43, Android 1) 이하면 autoIncrement 결과가 App Store 기존 빌드 번호 이하로 떨어져 다시 거부될 수 있음. 머지 후 다음을 단 한 번 실행:

```bash
eas build:version:get --platform ios
eas build:version:get --platform android

# remote가 비어있거나 낮으면 안전치로 set
eas build:version:set --platform ios       # 값: 44
eas build:version:set --platform android   # 값: 2
```

이후 `eas build --profile production --platform ios` 결과로 buildNumber가 45로 찍히면 OK.

## Test plan

- [x] `npm run type-check` 통과
- [x] `npm test` 1259개 통과, 커버리지 100%
- [x] code-review 에이전트 통과 (P0 마이그레이션 절차 반영)
- [ ] 머지 후 마이그레이션 명령 실행
- [ ] 다음 프로덕션 빌드에서 buildNumber 자동 +1 확인

Closes #363