### PR TITLE
chore(#365): bump version to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary

- `package.json` / `package-lock.json` 의 version을 1.2.2 → 1.2.3 으로 bump
- dev에 머지된 #361(키보드 fix), #363(EAS Remote)을 main에 릴리스하기 위한 사전 단계
- iOS `buildNumber` / Android `versionCode`는 EAS Remote가 관리하므로 손대지 않음

## Test plan

- [x] `npm test` 1259개 통과, 커버리지 100%
- [x] `npm run type-check` 통과

Closes #365