### PR TITLE
fix(#368): Live Activity 잠금화면 중복 표시 제거

### DIFF
--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -8,7 +8,7 @@ import UIKit
 // 자동 링크된다.
 
 @available(iOS 16.2, *)
-class LiveActivityManager {
+actor LiveActivityManager {
     static let shared = LiveActivityManager()
     private var currentActivity: Activity<SubwayActivityAttributes>?
 
@@ -18,12 +18,27 @@ class LiveActivityManager {
         return ActivityAuthorizationInfo().areActivitiesEnabled
     }
 
-    /// 현재 추적 중인 Activity + 이전 세션에서 남은 고아 Activity 일괄 종료
+    /// 현재 추적 중인 Activity + 이전 세션에서 남은 고아 Activity 일괄 종료.
+    /// ActivityKit의 `.activities` 목록 반영 지연으로 1회 enumerate 후에도 잔여가 남는 경우가
+    /// 있어 잔여가 없거나 안전 상한에 도달할 때까지 반복한다.
     private func endAllActivities() async {
         currentActivity = nil
-        for activity in Activity<SubwayActivityAttributes>.activities {
-            await activity.end(dismissalPolicy: .immediate)
+        var attempts = 0
+        while !Activity<SubwayActivityAttributes>.activities.isEmpty && attempts < 3 {
+            for activity in Activity<SubwayActivityAttributes>.activities {
+                await activity.end(dismissalPolicy: .immediate)
+            }
+            attempts += 1
         }
+    }
+
+    /// 앱 재기동 등으로 currentActivity가 nil이지만 시스템에 살아있는 Activity가 남아 있다면 채택.
+    /// 채택하지 않으면 update()가 start() 경로로 빠져 새 Activity가 추가 생성된다.
+    /// `.stale`도 표시 중일 수 있으므로 채택 후 update로 freshen 한다.
+    private func adoptExistingActivityIfNeeded() {
+        guard currentActivity == nil else { return }
+        currentActivity = Activity<SubwayActivityAttributes>.activities
+            .first(where: { $0.activityState == .active || $0.activityState == .stale })
     }
 
     func start(data: [String: Any]) async throws {
@@ -66,6 +81,9 @@ class LiveActivityManager {
                 userInfo: [NSLocalizedDescriptionKey: "iPad에서는 Live Activity를 지원하지 않습니다"]
             )
         }
+
+        // 앱 재기동 시 시스템에 남아 있는 Activity를 채택해 새 request로 중복 생성하지 않음
+        adoptExistingActivityIfNeeded()
 
         // Activity 상태 검증: ended/dismissed면 재시작
         if let activity = currentActivity {


### PR DESCRIPTION
## Summary
- 잠금화면에 SubwayActivityAttributes Live Activity가 2개 동시 표시되던 버그 수정
- `LiveActivityManager`를 `actor`로 전환해 FG 폴링과 BG 위치 태스크의 동시 `updateLiveActivity()` 호출 race를 언어 차원에서 직렬화
- `update()` 진입 시 `currentActivity`가 nil이면 시스템의 `.active`/`.stale` Activity를 채택하도록 `adoptExistingActivityIfNeeded()` 추가 — 앱 재기동 시 새 `Activity.request`로 중복 생성되던 경로 제거
- `endAllActivities()`가 ActivityKit `.activities` 목록 반영 지연을 고려해 잔여가 없을 때까지(최대 3회) 반복 종료

## Why
- 위 카드: 거리/ETA/routeSummary 누락된 빈 카드, 아래 카드: 정상 카드가 동시에 표시되는 스크린샷 제보
- 원인 분석 결과 LiveActivityManager가 (1) 새 프로세스 시작 시 시스템 잔여 Activity를 채택하지 않아 update()→start() 경로로 빠져 새 request로 중복 생성, (2) class 기반 공유 가변 상태라 동시 호출 race 가능

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (1259 tests, 커버리지 100% 유지)
- [x] code-review 에이전트 통과 (P1 없음, P2 모두 반영)
- [ ] 실기기 시나리오 A: 앱 강제 종료 → 재실행 시 Live Activity 1개 유지
- [ ] 실기기 시나리오 B: FG + BG 동시 update 시 1개 유지
- [ ] 실기기 시나리오 C: 목적지 변경 시 카드 내용만 갱신

Closes #368