### PR TITLE
fix(#370): BG 사전 예약 알람의 방향 필터 + ETA 의미 오류 수정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -150,7 +150,12 @@ export default function HomeScreen() {
     accuracyMeters,
     arrivalConfidence: confidence,
   });
-  useScheduledAlarms({ route, destination, arrival: rawArrival });
+  useScheduledAlarms({
+    route,
+    destination,
+    currentStation: result?.station ?? null,
+    arrival: rawArrival,
+  });
   useBackgroundLocation(destination);
   useApnsTripRegistration({
     route,

--- a/src/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/hooks/__tests__/useScheduledAlarms.test.ts
@@ -92,7 +92,7 @@ describe('useScheduledAlarms', () => {
 
   it('마운트 시 active 상태면 cancel만 호출되고 schedule은 호출되지 않는다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
 
@@ -102,7 +102,7 @@ describe('useScheduledAlarms', () => {
 
   it('background 전환 시 마지막 ETA로 재예약한다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
     mockedCancel.mockClear();
@@ -117,13 +117,13 @@ describe('useScheduledAlarms', () => {
     expect(mockedSchedule).toHaveBeenCalledWith({
       route: ROUTE,
       destinationName: '강남',
-      nextStationEtaSeconds: 300, // min(300, 420)
+      currentStationApproachEtaSeconds: 300, // min(300, 420)
     });
   });
 
   it('active 복귀 시 예약을 모두 취소하고 재예약하지 않는다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
 
@@ -146,7 +146,7 @@ describe('useScheduledAlarms', () => {
 
   it('동일 AppState 이벤트가 연속되면 무시한다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
 
@@ -169,7 +169,7 @@ describe('useScheduledAlarms', () => {
 
   it('inactive 전환은 schedule/cancel을 트리거하지 않는다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
     mockedSchedule.mockClear();
@@ -190,6 +190,7 @@ describe('useScheduledAlarms', () => {
         useScheduledAlarms({
           route: ROUTE,
           destination: DESTINATION,
+          currentStation: null,
           arrival: props.arrival,
         }),
       { initialProps: { arrival: ARRIVAL } },
@@ -212,7 +213,7 @@ describe('useScheduledAlarms', () => {
 
     expect(mockedCancel).toHaveBeenCalled();
     expect(mockedSchedule).toHaveBeenCalledWith(
-      expect.objectContaining({ nextStationEtaSeconds: 150 }),
+      expect.objectContaining({ currentStationApproachEtaSeconds: 150 }),
     );
   });
 
@@ -222,6 +223,7 @@ describe('useScheduledAlarms', () => {
         useScheduledAlarms({
           route: ROUTE,
           destination: props.destination,
+          currentStation: null,
           arrival: ARRIVAL,
         }),
       { initialProps: { destination: DESTINATION as Station | null } },
@@ -242,9 +244,9 @@ describe('useScheduledAlarms', () => {
     expect(mockedSchedule).not.toHaveBeenCalled();
   });
 
-  it('arrival이 null이면 nextStationEtaSeconds=null로 위임한다', async () => {
+  it('arrival이 null이면 currentStationApproachEtaSeconds=null로 위임한다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: null }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: null }),
     );
     await flush();
     await act(async () => {
@@ -254,14 +256,14 @@ describe('useScheduledAlarms', () => {
     });
 
     expect(mockedSchedule).toHaveBeenCalledWith(
-      expect.objectContaining({ nextStationEtaSeconds: null }),
+      expect.objectContaining({ currentStationApproachEtaSeconds: null }),
     );
   });
 
-  it('arrival이 mock이면 nextStationEtaSeconds=null로 위임한다', async () => {
+  it('arrival이 mock이면 currentStationApproachEtaSeconds=null로 위임한다', async () => {
     const mockArrival: StationArrival = { ...ARRIVAL, isMock: true };
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: mockArrival }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: mockArrival }),
     );
     await flush();
     await act(async () => {
@@ -271,7 +273,7 @@ describe('useScheduledAlarms', () => {
     });
 
     expect(mockedSchedule).toHaveBeenCalledWith(
-      expect.objectContaining({ nextStationEtaSeconds: null }),
+      expect.objectContaining({ currentStationApproachEtaSeconds: null }),
     );
   });
 
@@ -281,7 +283,7 @@ describe('useScheduledAlarms', () => {
       down: [{ ...ARRIVAL.down[0], arrivalSeconds: -10 }],
     };
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: stale }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: stale }),
     );
     await flush();
     await act(async () => {
@@ -291,13 +293,13 @@ describe('useScheduledAlarms', () => {
     });
 
     expect(mockedSchedule).toHaveBeenCalledWith(
-      expect.objectContaining({ nextStationEtaSeconds: null }),
+      expect.objectContaining({ currentStationApproachEtaSeconds: null }),
     );
   });
 
   it('언마운트 시 예약을 모두 취소하고 AppState listener를 제거한다', async () => {
     const { unmount } = renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
     mockedCancel.mockClear();
@@ -310,7 +312,7 @@ describe('useScheduledAlarms', () => {
 
   it('route가 null이면 background에서도 schedule을 호출하지 않는다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: null, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: null, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
     mockedCancel.mockClear();
@@ -328,7 +330,7 @@ describe('useScheduledAlarms', () => {
   it('cancelScheduledAlarms 실패는 hook을 throw시키지 않는다 (입력 변동/언마운트 경로)', async () => {
     mockedCancel.mockRejectedValue(new Error('cancel fail'));
     const { unmount } = renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
     unmount();
@@ -338,7 +340,7 @@ describe('useScheduledAlarms', () => {
 
   it('cancelScheduledAlarms 실패는 active 전환 경로에서도 throw하지 않는다', async () => {
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
     await act(async () => {
@@ -358,10 +360,104 @@ describe('useScheduledAlarms', () => {
     expect(true).toBe(true);
   });
 
+  it('진행 방향이 "down"으로 판정되면 arrival.down ETA만 schedule에 전달한다 (반대방향 ETA 폐기)', async () => {
+    // 회귀: 반대방향 열차가 빨라도 사용자 방향 ETA를 채택해야 한다.
+    const WRONG_FAST_RIGHT_SLOW: StationArrival = {
+      up: [{ ...ARRIVAL.up[0], arrivalSeconds: 30 }], // 반대방향(서쪽), 30초 후
+      down: [{ ...ARRIVAL.down[0], arrivalSeconds: 240 }], // 진행방향(동쪽), 240초 후
+    };
+    const ROUTE_L1: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const DEST_L1: Station = {
+      id: '1-034', name: '서울역', line: '1', lat: 37.55, lng: 126.97, lineColor: '#0052A4',
+    };
+    const CURRENT_L1: Station = {
+      id: '1-001', name: '소요산', line: '1', lat: 37.95, lng: 127.06, lineColor: '#0052A4',
+    };
+    renderHook(() =>
+      useScheduledAlarms({
+        route: ROUTE_L1,
+        destination: DEST_L1,
+        currentStation: CURRENT_L1,
+        arrival: WRONG_FAST_RIGHT_SLOW,
+      }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ currentStationApproachEtaSeconds: 240 }),
+    );
+  });
+
+  it('진행 방향이 "up"이면 arrival.up ETA만 schedule에 전달한다', async () => {
+    const RIGHT_UP: StationArrival = {
+      up: [{ ...ARRIVAL.up[0], arrivalSeconds: 180 }],
+      down: [{ ...ARRIVAL.down[0], arrivalSeconds: 60 }],
+    };
+    const ROUTE_L1: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const DEST_L1: Station = {
+      id: '1-001', name: '소요산', line: '1', lat: 37.95, lng: 127.06, lineColor: '#0052A4',
+    };
+    const CURRENT_L1: Station = {
+      id: '1-034', name: '서울역', line: '1', lat: 37.55, lng: 126.97, lineColor: '#0052A4',
+    };
+    renderHook(() =>
+      useScheduledAlarms({
+        route: ROUTE_L1,
+        destination: DEST_L1,
+        currentStation: CURRENT_L1,
+        arrival: RIGHT_UP,
+      }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ currentStationApproachEtaSeconds: 180 }),
+    );
+  });
+
+  it('currentStation이 노선 외(direction null)면 양방향 합산 fallback으로 위임한다', async () => {
+    const ROUTE_L1: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const DEST_L1: Station = {
+      id: '1-034', name: '서울역', line: '1', lat: 37.55, lng: 126.97, lineColor: '#0052A4',
+    };
+    // 다른 노선 station을 current로 → direction null
+    const OFF_LINE: Station = {
+      id: '7-015', name: '용마산', line: '7', lat: 37.57, lng: 127.08, lineColor: '#747F00',
+    };
+    renderHook(() =>
+      useScheduledAlarms({
+        route: ROUTE_L1,
+        destination: DEST_L1,
+        currentStation: OFF_LINE,
+        arrival: ARRIVAL, // up=300, down=420
+      }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ currentStationApproachEtaSeconds: 300 }),
+    );
+  });
+
   it('scheduleAlarmsForRoute 실패는 background 전환 경로에서 throw하지 않는다', async () => {
     mockedSchedule.mockRejectedValueOnce(new Error('schedule fail'));
     renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: ARRIVAL }),
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
     await act(async () => {

--- a/src/hooks/useScheduledAlarms.ts
+++ b/src/hooks/useScheduledAlarms.ts
@@ -7,6 +7,7 @@ import {
   cancelScheduledAlarms,
   scheduleAlarmsForRoute,
 } from '../utils/alarmScheduler';
+import { resolveTripDirection, type TripDirection } from '../utils/tripDirection';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('useScheduledAlarms');
@@ -14,19 +15,28 @@ const logger = createLogger('useScheduledAlarms');
 export interface UseScheduledAlarmsInputs {
   route: Route;
   destination: Station | null;
+  /** 사용자의 현재 위치 station — 진행 방향 산출에 필요. null이면 양방향 fallback. */
+  currentStation: Station | null;
   arrival: StationArrival | null;
 }
 
 /**
- * 다음 도착역까지의 ETA(초)를 arrival 데이터에서 추출한다.
- * up/down 양방향에서 가장 빠른 양수 arrivalSeconds를 선택한다.
+ * 진행 방향 열차의 "현재역 도착까지 남은 ETA"(초)를 추출한다.
+ * direction이 null이면 양방향을 합산한 best-effort fallback을 반환한다(반대방향 오인 위험 있음).
  * 데이터가 없거나 mock이면 null을 반환해 alarmScheduler의 static fallback으로 위임한다.
  */
-function pickNextStationEtaSeconds(arrival: StationArrival | null): number | null {
+function pickCurrentStationApproachEtaSeconds(
+  arrival: StationArrival | null,
+  direction: TripDirection | null,
+): number | null {
   if (!arrival || arrival.isMock) return null;
-  const candidates = [...arrival.up, ...arrival.down]
-    .map((info) => info.arrivalSeconds)
-    .filter((sec) => sec > 0);
+  const trains =
+    direction === 'up'
+      ? arrival.up
+      : direction === 'down'
+        ? arrival.down
+        : [...arrival.up, ...arrival.down];
+  const candidates = trains.map((info) => info.arrivalSeconds).filter((sec) => sec > 0);
   if (candidates.length === 0) return null;
   return Math.min(...candidates);
 }
@@ -44,15 +54,18 @@ function pickNextStationEtaSeconds(arrival: StationArrival | null): number | nul
 export function useScheduledAlarms({
   route,
   destination,
+  currentStation,
   arrival,
 }: UseScheduledAlarmsInputs): void {
   const routeRef = useRef<Route>(route);
   const destinationRef = useRef<Station | null>(destination);
+  const currentStationRef = useRef<Station | null>(currentStation);
   const arrivalRef = useRef<StationArrival | null>(arrival);
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);
 
   routeRef.current = route;
   destinationRef.current = destination;
+  currentStationRef.current = currentStation;
   arrivalRef.current = arrival;
 
   const reschedule = async (): Promise<void> => {
@@ -61,11 +74,15 @@ export function useScheduledAlarms({
     const currentDestination = destinationRef.current;
     if (!currentRoute || !currentDestination) return;
     if (appStateRef.current === 'active') return;
-    const etaSeconds = pickNextStationEtaSeconds(arrivalRef.current);
+    const here = currentStationRef.current;
+    const direction = here
+      ? resolveTripDirection(currentRoute, currentDestination.name, here.id)
+      : null;
+    const approachEtaSeconds = pickCurrentStationApproachEtaSeconds(arrivalRef.current, direction);
     await scheduleAlarmsForRoute({
       route: currentRoute,
       destinationName: currentDestination.name,
-      nextStationEtaSeconds: etaSeconds,
+      currentStationApproachEtaSeconds: approachEtaSeconds,
     });
   };
 
@@ -94,7 +111,7 @@ export function useScheduledAlarms({
   useEffect(() => {
     reschedule().catch((e) => logger.error('입력 변동 재예약 실패:', e));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [route, destination?.id, arrival]);
+  }, [route, destination?.id, currentStation?.id, arrival]);
 
   // 언마운트 — 모두 취소.
   useEffect(() => {

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -31,6 +31,9 @@ jest.mock('../../api/arrivalApi', () => ({
 jest.mock('../../data/stations.json', () => [
   { id: 'station-1', name: '강남', line: '2', lineColor: '#009246', lat: 0, lng: 0 },
   { id: 'station-2', name: '시청', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
+  // 방향 판정용 line '1' 추가 stations (id 정렬상 station-2 < station-3 < station-4)
+  { id: 'station-3', name: '종각', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
+  { id: 'station-4', name: '종로3가', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
 ]);
 
 jest.mock('../../utils/logger', () => ({
@@ -86,11 +89,11 @@ function mockStorage(values: {
   );
 }
 
-function expectSchedulerCalledWith(nextStationEtaSeconds: number | null) {
+function expectSchedulerCalledWith(currentStationApproachEtaSeconds: number | null) {
   expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
     route,
     destinationName: '시청',
-    nextStationEtaSeconds,
+    currentStationApproachEtaSeconds,
   });
 }
 
@@ -134,7 +137,7 @@ describe('alarmRefreshTask', () => {
       expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
     });
 
-    it('활성 트립이 있고 현재역이 없으면 nextStationEtaSeconds=null로 스케줄러 호출', async () => {
+    it('활성 트립이 있고 현재역이 없으면 currentStationApproachEtaSeconds=null로 스케줄러 호출', async () => {
       mockStorage({ destination, route, lastStation: null });
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
@@ -153,7 +156,7 @@ describe('alarmRefreshTask', () => {
       expectSchedulerCalledWith(300);
     });
 
-    it('Arrival API가 모두 0/음수면 nextStationEtaSeconds=null', async () => {
+    it('Arrival API가 모두 0/음수면 currentStationApproachEtaSeconds=null', async () => {
       mockStorage({ destination, route, lastStation: 'station-1' });
       mockFetchArrivalInfo.mockResolvedValue({
         up: [{ arrivalSeconds: 0 }],
@@ -176,6 +179,38 @@ describe('alarmRefreshTask', () => {
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
       expectSchedulerCalledWith(null);
+    });
+
+    it('진행 방향이 판정되면 해당 방향의 ETA만 사용한다 (반대방향 ETA 폐기)', async () => {
+      // 현재역 종로3가(station-4, idx 2) → 시청(station-2, idx 0): up 방향
+      mockStorage({ destination, route, lastStation: 'station-4' });
+      mockFetchArrivalInfo.mockResolvedValue({
+        up: [{ arrivalSeconds: 240 }], // 진행 방향
+        down: [{ arrivalSeconds: 30 }], // 반대 방향 — 더 빠르지만 무시되어야 함
+      });
+      await getCallback()();
+      expect(mockFetchArrivalInfo).toHaveBeenCalledWith('종로3가');
+      expectSchedulerCalledWith(240);
+    });
+
+    it('진행 방향이 "down"이면 arrival.down ETA만 사용한다', async () => {
+      // destination 종로3가(station-4, idx 2) 사용 — 현재 시청(idx 0) → 종로3가 = down 방향
+      const destDown = { ...destination, id: 'station-4', name: '종로3가' };
+      mockStorage({
+        destination: destDown,
+        route,
+        lastStation: 'station-2',
+      });
+      mockFetchArrivalInfo.mockResolvedValue({
+        up: [{ arrivalSeconds: 30 }], // 반대 방향
+        down: [{ arrivalSeconds: 180 }], // 진행 방향
+      });
+      await getCallback()();
+      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
+        route,
+        destinationName: '종로3가',
+        currentStationApproachEtaSeconds: 180,
+      });
     });
 
     it('스케줄러가 throw 하면 Failed를 반환한다', async () => {

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -182,7 +182,7 @@ describe('silentPushTask', () => {
       expect(mockSchedule).toHaveBeenCalledWith({
         route,
         destinationName: '강남',
-        nextStationEtaSeconds: 420,
+        currentStationApproachEtaSeconds: 420,
       });
     });
 

--- a/src/tasks/alarmRefreshTask.ts
+++ b/src/tasks/alarmRefreshTask.ts
@@ -3,10 +3,11 @@ import * as BackgroundTask from 'expo-background-task';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DESTINATION_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
 import { scheduleAlarmsForRoute } from '../utils/alarmScheduler';
-import { fetchArrivalInfo, type ArrivalInfo } from '../api/arrivalApi';
+import { fetchArrivalInfo, type ArrivalInfo, type StationArrival } from '../api/arrivalApi';
 import stationsData from '../data/stations.json';
 import type { Station } from '../types/station';
 import type { Route } from '../utils/stationRoute';
+import { resolveTripDirection, type TripDirection } from '../utils/tripDirection';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('AlarmRefreshTask');
@@ -22,11 +23,20 @@ export const ALARM_REFRESH_TASK = 'alarm-refresh-task';
 const allStations = stationsData as Station[];
 const stationById = new Map<string, Station>(allStations.map((s) => [s.id, s]));
 
-function pickNextStationEtaSeconds(arrivals: { up: ArrivalInfo[]; down: ArrivalInfo[] }): number | null {
-  // 방향 정보 없이 BG에서 가장 신뢰할 수 있는 신호는 "임박한 도착". up/down 합산해
-  // 양수 중 최소값을 다음 도착 ETA로 사용한다. 정확도는 reschedule(#335)이 보정.
+function pickCurrentStationApproachEtaSeconds(
+  arrivals: { up: ArrivalInfo[]; down: ArrivalInfo[] },
+  direction: TripDirection | null,
+): number | null {
+  // 진행 방향이 정해지면 한쪽 list만 사용한다. 정해지지 않은 경계 케이스(환상선/노선 이탈)는
+  // 안전을 위해 양방향 합산 best-effort로 폴백한다.
+  const trains: ArrivalInfo[] =
+    direction === 'up'
+      ? arrivals.up
+      : direction === 'down'
+        ? arrivals.down
+        : [...arrivals.up, ...arrivals.down];
   let min: number | null = null;
-  for (const info of [...arrivals.up, ...arrivals.down]) {
+  for (const info of trains) {
     if (info.arrivalSeconds > 0 && (min === null || info.arrivalSeconds < min)) {
       min = info.arrivalSeconds;
     }
@@ -51,10 +61,10 @@ async function readActiveTrip(): Promise<{ destination: Station; route: NonNulla
   }
 }
 
-async function resolveCurrentStationName(): Promise<string | null> {
+async function resolveCurrentStation(): Promise<Station | null> {
   const id = await AsyncStorage.getItem(LAST_NOTIFIED_STATION_KEY);
   if (!id) return null;
-  return stationById.get(id)?.name ?? null;
+  return stationById.get(id) ?? null;
 }
 
 TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
@@ -65,12 +75,18 @@ TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
       return BackgroundTask.BackgroundTaskResult.Success;
     }
 
-    const currentStationName = await resolveCurrentStationName();
-    let nextStationEtaSeconds: number | null = null;
-    if (currentStationName) {
+    const currentStation = await resolveCurrentStation();
+    const direction = currentStation
+      ? resolveTripDirection(active.route, active.destination.name, currentStation.id)
+      : null;
+    let currentStationApproachEtaSeconds: number | null = null;
+    if (currentStation) {
       try {
-        const arrivals = await fetchArrivalInfo(currentStationName);
-        nextStationEtaSeconds = pickNextStationEtaSeconds(arrivals);
+        const arrivals: StationArrival = await fetchArrivalInfo(currentStation.name);
+        currentStationApproachEtaSeconds = pickCurrentStationApproachEtaSeconds(
+          arrivals,
+          direction,
+        );
       } catch (e) {
         logger.warn('Arrival API 호출 실패 — static ETA fallback:', e);
       }
@@ -79,7 +95,7 @@ TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
     await scheduleAlarmsForRoute({
       route: active.route,
       destinationName: active.destination.name,
-      nextStationEtaSeconds,
+      currentStationApproachEtaSeconds,
     });
     logger.info('알람 사전 예약 갱신 완료');
     return BackgroundTask.BackgroundTaskResult.Success;

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -104,7 +104,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     const scheduled = await scheduleAlarmsForRoute({
       route,
       destinationName: destination.name,
-      nextStationEtaSeconds: payload.etaSeconds,
+      currentStationApproachEtaSeconds: payload.etaSeconds,
     });
     logger.info(`rescheduled ${scheduled.length} alarms via silent push`);
   } catch (e) {

--- a/src/utils/__tests__/alarmScheduler.test.ts
+++ b/src/utils/__tests__/alarmScheduler.test.ts
@@ -46,24 +46,24 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 600,
+      currentStationApproachEtaSeconds: 600,
       now: NOW,
     });
 
     expect(result).toHaveLength(2);
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(2);
 
-    // finalEta = 600 + (10-1)*90 = 1410s, destination ETA = 1410s
-    // early: 1410 - 90 = 1320s, imminent: 1410 - 10 = 1400s
+    // finalEta = 600 + 10*90 = 1500s, destination ETA = 1500s
+    // early: 1500 - 90 = 1410s, imminent: 1500 - 10 = 1490s
     expect(result[0]).toMatchObject({
       identifier: 'alarm:early:강남',
       event: { phaseId: 'early', type: 'destination', stationName: '강남' },
-      fireDate: new Date(NOW + 1_320_000),
+      fireDate: new Date(NOW + 1_410_000),
     });
     expect(result[1]).toMatchObject({
       identifier: 'alarm:imminent:강남',
       event: { phaseId: 'imminent', type: 'destination', stationName: '강남' },
-      fireDate: new Date(NOW + 1_400_000),
+      fireDate: new Date(NOW + 1_490_000),
     });
   });
 
@@ -79,32 +79,32 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 1000,
+      currentStationApproachEtaSeconds: 1000,
       now: NOW,
     });
 
     expect(result).toHaveLength(4);
 
-    // finalEta = 1000 + (10-1)*90 = 1810s
-    // 환승역 ETA = (4/10) * 1810 = 724s
+    // finalEta = 1000 + 10*90 = 1900s
+    // 환승역 ETA = (4/10) * 1900 = 760s
     expect(result[0]).toMatchObject({
       identifier: 'alarm:early:동대문',
       event: { phaseId: 'early', type: 'transfer', stationName: '동대문' },
-      fireDate: new Date(NOW + (724 - 90) * 1000),
+      fireDate: new Date(NOW + (760 - 90) * 1000),
     });
     expect(result[1]).toMatchObject({
       identifier: 'alarm:imminent:동대문',
-      fireDate: new Date(NOW + (724 - 10) * 1000),
+      fireDate: new Date(NOW + (760 - 10) * 1000),
     });
-    // 도착역 ETA = 1810s
+    // 도착역 ETA = 1900s
     expect(result[2]).toMatchObject({
       identifier: 'alarm:early:강남',
       event: { phaseId: 'early', type: 'destination', stationName: '강남' },
-      fireDate: new Date(NOW + (1810 - 90) * 1000),
+      fireDate: new Date(NOW + (1900 - 90) * 1000),
     });
     expect(result[3]).toMatchObject({
       identifier: 'alarm:imminent:강남',
-      fireDate: new Date(NOW + (1810 - 10) * 1000),
+      fireDate: new Date(NOW + (1900 - 10) * 1000),
     });
   });
 
@@ -120,7 +120,7 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 1000,
+      currentStationApproachEtaSeconds: 1000,
       now: NOW,
     });
 
@@ -135,13 +135,13 @@ describe('scheduleAlarmsForRoute', () => {
     ]);
   });
 
-  it('nextStationEtaSeconds가 null이면 calculateStaticETA로 fallback한다', async () => {
+  it('currentStationApproachEtaSeconds가 null이면 calculateStaticETA로 fallback한다', async () => {
     const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
     // calculateStaticETA(direct stops=10) = 3 wait + 10*2 = 23 min = 1380s
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: null,
+      currentStationApproachEtaSeconds: null,
       now: NOW,
     });
 
@@ -150,12 +150,12 @@ describe('scheduleAlarmsForRoute', () => {
     expect(result[1].fireDate).toEqual(new Date(NOW + (1380 - 10) * 1000));
   });
 
-  it('nextStationEtaSeconds가 0 이하면 fallback을 사용한다', async () => {
+  it('currentStationApproachEtaSeconds가 0 이하면 fallback을 사용한다', async () => {
     const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 0,
+      currentStationApproachEtaSeconds: 0,
       now: NOW,
     });
     // staticETA fallback 적용 → 1380s
@@ -167,7 +167,7 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 600,
+      currentStationApproachEtaSeconds: 600,
       now: NOW,
     });
 
@@ -175,32 +175,32 @@ describe('scheduleAlarmsForRoute', () => {
     expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
   });
 
-  it('phase 시각이 과거(now 이전)면 해당 알람은 건너뛴다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '1' };
-    // stops=1 → finalEta = 5 + 0*90 = 5s → early(5-90<0 skip), imminent(5-10<0 skip) → 0개
+  it('stops=0 waypoint(이미 도착한 환승역 등)는 두 phase 모두 건너뛰고 다음 waypoint만 예약한다', async () => {
+    // 환승역에 이미 도착해 stopsToTransfer=0인 trip — transfer는 waypointEta=0이라 fire<=0으로 모두 skip.
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '동대문',
+      fromLine: '1',
+      toLine: '4',
+      stopsToTransfer: 0,
+      stopsFromTransfer: 5,
+    };
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 5,
+      currentStationApproachEtaSeconds: 60,
       now: NOW,
     });
 
-    expect(result).toEqual([]);
-  });
-
-  it('early만 미래이고 imminent가 과거면 한쪽만 예약한다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '1' };
-    // stops=1, ETA 50 → finalEta = 50s
-    // early: 50-90 = -40 skip, imminent: 50-10 = 40, 예약
-    const result = await scheduleAlarmsForRoute({
-      route,
-      destinationName: '강남',
-      nextStationEtaSeconds: 50,
-      now: NOW,
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0].identifier).toBe('alarm:imminent:강남');
+    // totalStops=5, finalEta = 60 + 5*90 = 510s
+    // 동대문 cumulative=0 → waypointEta=0 → 두 phase 모두 skip
+    // 강남 cumulative=5 → waypointEta=510s → early(420), imminent(500) 모두 예약
+    expect(result.map((r) => r.identifier)).toEqual([
+      'alarm:early:강남',
+      'alarm:imminent:강남',
+    ]);
+    expect(result[0].fireDate).toEqual(new Date(NOW + 420_000));
+    expect(result[1].fireDate).toEqual(new Date(NOW + 500_000));
   });
 
   it('iOS에서는 interruptionLevel: timeSensitive를 포함한다', async () => {
@@ -208,7 +208,7 @@ describe('scheduleAlarmsForRoute', () => {
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 600,
+      currentStationApproachEtaSeconds: 600,
       now: NOW,
     });
 
@@ -228,7 +228,7 @@ describe('scheduleAlarmsForRoute', () => {
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 600,
+      currentStationApproachEtaSeconds: 600,
       now: NOW,
     });
 
@@ -246,14 +246,14 @@ describe('scheduleAlarmsForRoute', () => {
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 600,
+      currentStationApproachEtaSeconds: 600,
       now: NOW,
     });
 
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         identifier: 'alarm:early:강남',
-        trigger: { type: 'date', date: new Date(NOW + 1_320_000) },
+        trigger: { type: 'date', date: new Date(NOW + 1_410_000) },
       }),
     );
   });
@@ -264,14 +264,14 @@ describe('scheduleAlarmsForRoute', () => {
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
-      nextStationEtaSeconds: 600,
+      currentStationApproachEtaSeconds: 600,
     });
     const after = Date.now();
 
-    // early fireDate ≈ now + 1320s
+    // early fireDate ≈ now + 1410s
     const fire = result[0].fireDate.getTime();
-    expect(fire).toBeGreaterThanOrEqual(before + 1_320_000);
-    expect(fire).toBeLessThanOrEqual(after + 1_320_000);
+    expect(fire).toBeGreaterThanOrEqual(before + 1_410_000);
+    expect(fire).toBeLessThanOrEqual(after + 1_410_000);
   });
 });
 

--- a/src/utils/__tests__/tripDirection.test.ts
+++ b/src/utils/__tests__/tripDirection.test.ts
@@ -1,0 +1,59 @@
+import { resolveTripDirection } from '../tripDirection';
+import type {
+  DirectRoute,
+  TransferRoute,
+  MultiTransferRoute,
+} from '../stationRoute';
+
+describe('resolveTripDirection', () => {
+  it('direct: next waypoint index > current index → "down"', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    // 소요산(1-001, idx 0) → 서울역(1-034)
+    expect(resolveTripDirection(route, '서울역', '1-001')).toBe('down');
+  });
+
+  it('direct: next waypoint index < current index → "up"', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    expect(resolveTripDirection(route, '소요산', '1-034')).toBe('up');
+  });
+
+  it('current가 같은 station이면 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 0, line: '1' };
+    expect(resolveTripDirection(route, '소요산', '1-001')).toBeNull();
+  });
+
+  it('current가 다른 노선이면 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    expect(resolveTripDirection(route, '서울역', '7-015')).toBeNull();
+  });
+
+  it('next waypoint name이 line에 존재하지 않으면 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    expect(resolveTripDirection(route, '없는역이름XYZ', '1-001')).toBeNull();
+  });
+
+  it('transfer: 첫 leg은 fromLine + transferName으로 판정한다', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '서울역',
+      fromLine: '1',
+      toLine: '4',
+      stopsToTransfer: 5,
+      stopsFromTransfer: 3,
+    };
+    // 소요산(1-001) → 서울역(1-034) = down
+    expect(resolveTripDirection(route, '강남', '1-001')).toBe('down');
+  });
+
+  it('multi-transfer: transfers[0]의 fromLine + transferName으로 판정한다', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 5 },
+        { transferName: '명동', fromLine: '4', toLine: '2', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 2,
+    };
+    expect(resolveTripDirection(route, '강남', '1-001')).toBe('down');
+  });
+});

--- a/src/utils/alarmScheduler.ts
+++ b/src/utils/alarmScheduler.ts
@@ -32,10 +32,11 @@ export interface ScheduleAlarmsParams {
   route: NonNullable<Route>;
   destinationName: string;
   /**
-   * Seoul Arrival API 첫 결과 — 다음 도착역까지 ETA(초).
+   * Seoul Arrival API 첫 결과 — 사용자 진행 방향의 열차가 **현재역에 도착하기까지** 남은 ETA(초).
+   * 호출자는 방향을 한쪽만 골라 넘겨야 한다 (반대방향 열차 ETA가 섞이면 안 됨).
    * null이면 calculateStaticETA로 목적지 ETA를 fallback 계산한다.
    */
-  nextStationEtaSeconds: number | null;
+  currentStationApproachEtaSeconds: number | null;
   /** 테스트에서 시각 주입용. 기본값은 Date.now(). */
   now?: number;
 }
@@ -50,13 +51,13 @@ export interface ScheduleAlarmsParams {
 export async function scheduleAlarmsForRoute(
   params: ScheduleAlarmsParams,
 ): Promise<ScheduledAlarm[]> {
-  const { route, destinationName, nextStationEtaSeconds, now = Date.now() } = params;
+  const { route, destinationName, currentStationApproachEtaSeconds, now = Date.now() } = params;
 
   const targets = resolveAllTargets(route, destinationName);
   const totalStops = targets.reduce((sum, t) => sum + t.stops, 0);
   if (totalStops === 0) return [];
 
-  const finalEtaSeconds = resolveFinalEtaSeconds(nextStationEtaSeconds, totalStops, route);
+  const finalEtaSeconds = resolveFinalEtaSeconds(currentStationApproachEtaSeconds, totalStops, route);
 
   const scheduled: ScheduledAlarm[] = [];
   let cumulativeStops = 0;
@@ -117,18 +118,23 @@ export async function cancelScheduledAlarms(): Promise<void> {
 }
 
 /**
- * 첫 도착역까지의 ETA로부터 최종 목적지 ETA를 추정한다.
- * API 값이 있으면: nextStation ETA + (남은 정거장 - 1) × 90s.
+ * "현재역에 열차가 도착하기까지 남은 시간"을 받아 최종 목적지 ETA를 추정한다.
+ *
+ * 의미: 사용자는 현재역 플랫폼에서 진행 방향 열차를 기다리는 중이라고 가정한다.
+ *   - approachEta(T)초 후 열차 도착 → 탑승
+ *   - 이후 totalStops 정거장 이동 × ONE_STOP_SECONDS
+ *   - 최종 ETA = T + totalStops × ONE_STOP_SECONDS
+ *
  * 환승 페널티는 무시한다 — Phase 1 baseline. 정확도는 reschedule(#335)이 보정.
- * 없으면 calculateStaticETA(분)로 fallback.
+ * approachEta가 없거나 0 이하이면 calculateStaticETA(분)로 fallback.
  */
 function resolveFinalEtaSeconds(
-  nextStationEtaSeconds: number | null,
+  currentStationApproachEtaSeconds: number | null,
   totalStops: number,
   route: NonNullable<Route>,
 ): number {
-  if (nextStationEtaSeconds != null && nextStationEtaSeconds > 0) {
-    return nextStationEtaSeconds + (totalStops - 1) * ONE_STOP_SECONDS;
+  if (currentStationApproachEtaSeconds != null && currentStationApproachEtaSeconds > 0) {
+    return currentStationApproachEtaSeconds + totalStops * ONE_STOP_SECONDS;
   }
   // calculateStaticETA는 NonNullable Route에 대해 항상 number를 반환한다.
   return (calculateStaticETA(route) as number) * 60;

--- a/src/utils/tripDirection.ts
+++ b/src/utils/tripDirection.ts
@@ -1,0 +1,43 @@
+import type { LineNumber } from '../types/station';
+import type { Route } from './stationRoute';
+import { getStationsOnLine } from './stationRoute';
+
+export type TripDirection = 'up' | 'down';
+
+/**
+ * 현재 위치 station id와 경로의 첫 구간을 비교해 진행 방향(상행/하행)을 유도한다.
+ *
+ * 노선별 station id 정렬상의 index를 기준으로 판정:
+ *   - 다음 waypoint index > 현재 station index → 'down'
+ *   - 그 반대 → 'up'
+ *   - 현재가 다른 노선이거나 인덱스 동일 → null (호출자는 양방향 합산으로 폴백)
+ *
+ * 환상선(2호선 등)은 index 단방향성이 깨질 수 있으므로 정확하지 않을 수 있다.
+ * 정확한 방향 정보를 강제할 수 없는 경계 케이스는 null로 안전 폴백한다.
+ */
+export function resolveTripDirection(
+  route: NonNullable<Route>,
+  destinationName: string,
+  currentStationId: string,
+): TripDirection | null {
+  const { line, nextWaypointName } = firstLeg(route, destinationName);
+  const lineStations = getStationsOnLine(line);
+  const currIdx = lineStations.findIndex((s) => s.id === currentStationId);
+  const nextIdx = lineStations.findIndex((s) => s.name === nextWaypointName);
+  if (currIdx < 0 || nextIdx < 0 || currIdx === nextIdx) return null;
+  return nextIdx > currIdx ? 'down' : 'up';
+}
+
+function firstLeg(
+  route: NonNullable<Route>,
+  destinationName: string,
+): { line: LineNumber; nextWaypointName: string } {
+  if (route.type === 'direct') {
+    return { line: route.line, nextWaypointName: destinationName };
+  }
+  if (route.type === 'transfer') {
+    return { line: route.fromLine, nextWaypointName: route.transferName };
+  }
+  const first = route.transfers[0];
+  return { line: first.fromLine, nextWaypointName: first.transferName };
+}


### PR DESCRIPTION
## 배경

잠금화면에서 3정거장 전에 "다음 역에서 내리세요" 알람이 발사되던 회귀 (예: 용마산 → 어린이대공원).
두 결함이 결합:
1. **방향 정보 폐기** — BG 알람 스케줄링이 `[...arrival.up, ...arrival.down]` 합산 최솟값을 채택해 반대방향 열차 ETA가 새어들어옴
2. **ETA 의미 재해석** — `pickNextStationEtaSeconds`가 돌려준 "현재역 다음 도착 열차 ETA"를 "다음 정거장까지 가는 시간"으로 재해석해 `+ (totalStops-1) × 90s`. 실제 9분 트립이 4분으로 잡혀 알람 조기 발사

## 변경

- `src/utils/tripDirection.ts` 신규 — currentStationId 와 route 첫 leg의 next waypoint index 비교로 진행 방향 유도. 환상선/노선 이탈 시 null → 호출자는 양방향 fallback
- `useScheduledAlarms` / `alarmRefreshTask` — 방향 인자로 한쪽 arrival 목록만 사용 (정확한 방향이면 strict, null이면 양방향 합산 best-effort)
- `scheduleAlarmsForRoute` 시그니처 정리:
  - `nextStationEtaSeconds` → `currentStationApproachEtaSeconds`
  - `T + (totalStops-1) × 90s` → `T + totalStops × ONE_STOP_SECONDS` (탑승 후 totalStops 정거장 이동 × 90s)
- `useScheduledAlarms` 입력에 `currentStation: Station | null` 추가. `app/(tabs)/index.tsx`에서 nearest station 전달

## 회귀 테스트

- `tripDirection.test.ts` — direct/transfer/multi-transfer 케이스별 방향 판정 + 노선 이탈 / 동일 station / 모르는 name 폴백
- `useScheduledAlarms.test.ts` — 반대방향 열차가 빨라도 진행 방향 ETA만 사용 (회귀 케이스), up/down 양쪽 + off-line fallback
- `alarmRefreshTask.test.ts` — up/down 방향 판정 추가
- `alarmScheduler.test.ts` — 새 시맨틱 수식 검증, stops=0 waypoint 두 phase 모두 skip

## Verification

- `npm run type-check` ✅
- `npm test` — 1270 / 1270, 커버리지 100%

## 후속 작업 (별도 이슈 권장)

- `useApnsTripRegistration` 도 같은 ETA 시맨틱 정리 필요 (`nextStationEtaSeconds` → `currentStationApproachEtaSeconds`) — 본 PR에서는 scope 분리
- `pickCurrentStationApproachEtaSeconds` 가 hook/task 두 곳에 복제 — 공용 유틸 추출

Closes #370