### PR TITLE
chore(#372): 알람 발사 로그에 stamp 컨텍스트 추가

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -38,6 +38,14 @@ function formatLogLine(entry: AlarmLogEntry): string {
       `acc=${entry.location.accuracy ?? '-'} age=${entry.location.ageMs}ms`,
     );
   }
+  // #372 stamp — bg-scheduled 엔트리 진단용. 값이 있을 때만 노출(짧은 라인 우선).
+  if (entry.direction) parts.push(`dir=${entry.direction}`);
+  if (entry.usedTrainCode) parts.push(`train=${entry.usedTrainCode}`);
+  if (entry.selectedArrivalSeconds != null) {
+    parts.push(`eta=${entry.selectedArrivalSeconds}s`);
+  }
+  if (entry.expectedStationAtFire) parts.push(`exp=${entry.expectedStationAtFire}`);
+  if (entry.actualLastNotifiedStation) parts.push(`last=${entry.actualLastNotifiedStation}`);
   return parts.join(' | ');
 }
 

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -335,21 +335,23 @@ describe('DebugModal helpers', () => {
     expect(line).toContain('fired');
   });
 
+  function bgScheduledEntry(extra: Partial<AlarmLogEntry>): AlarmLogEntry {
+    return { ts: Date.now(), source: 'bg-scheduled', outcome: 'fired', ...extra };
+  }
+
   it('formatLogLine: #372 stamp 필드가 채워지면 dir/train/eta/exp/last를 표기한다', () => {
-    const entry: AlarmLogEntry = {
-      ts: Date.now(),
-      source: 'bg-scheduled',
-      outcome: 'fired',
-      phaseId: 'early',
-      kind: 'destination',
-      stationName: '강남',
-      direction: 'up',
-      usedTrainCode: 'T-42',
-      selectedArrivalSeconds: 600,
-      expectedStationAtFire: '강남',
-      actualLastNotifiedStation: '시청',
-    };
-    const line = __test__.formatLogLine(entry);
+    const line = __test__.formatLogLine(
+      bgScheduledEntry({
+        phaseId: 'early',
+        kind: 'destination',
+        stationName: '강남',
+        direction: 'up',
+        usedTrainCode: 'T-42',
+        selectedArrivalSeconds: 600,
+        expectedStationAtFire: '강남',
+        actualLastNotifiedStation: '시청',
+      }),
+    );
     expect(line).toContain('bg-scheduled');
     expect(line).toContain('dir=up');
     expect(line).toContain('train=T-42');
@@ -359,32 +361,24 @@ describe('DebugModal helpers', () => {
   });
 
   it('formatLogLine: stamp 필드가 null/미존재면 추가 토큰이 붙지 않는다', () => {
-    const entry: AlarmLogEntry = {
-      ts: Date.now(),
-      source: 'bg-scheduled',
-      outcome: 'fired',
-      direction: null,
-      usedTrainCode: null,
-      selectedArrivalSeconds: null,
-      expectedStationAtFire: null,
-      actualLastNotifiedStation: null,
-    };
-    const line = __test__.formatLogLine(entry);
-    expect(line).not.toContain('dir=');
-    expect(line).not.toContain('train=');
-    expect(line).not.toContain('eta=');
-    expect(line).not.toContain('exp=');
-    expect(line).not.toContain('last=');
+    const line = __test__.formatLogLine(
+      bgScheduledEntry({
+        direction: null,
+        usedTrainCode: null,
+        selectedArrivalSeconds: null,
+        expectedStationAtFire: null,
+        actualLastNotifiedStation: null,
+      }),
+    );
+    for (const token of ['dir=', 'train=', 'eta=', 'exp=', 'last=']) {
+      expect(line).not.toContain(token);
+    }
   });
 
   it('formatLogLine: selectedArrivalSeconds=0이어도 eta=0s로 표기 (0과 null 구분)', () => {
-    const entry: AlarmLogEntry = {
-      ts: Date.now(),
-      source: 'bg-scheduled',
-      outcome: 'fired',
-      selectedArrivalSeconds: 0,
-    };
-    expect(__test__.formatLogLine(entry)).toContain('eta=0s');
+    expect(
+      __test__.formatLogLine(bgScheduledEntry({ selectedArrivalSeconds: 0 })),
+    ).toContain('eta=0s');
   });
 
   it('formatLogLine: accuracy null이면 "-"로 표기', () => {

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -335,6 +335,58 @@ describe('DebugModal helpers', () => {
     expect(line).toContain('fired');
   });
 
+  it('formatLogLine: #372 stamp 필드가 채워지면 dir/train/eta/exp/last를 표기한다', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'bg-scheduled',
+      outcome: 'fired',
+      phaseId: 'early',
+      kind: 'destination',
+      stationName: '강남',
+      direction: 'up',
+      usedTrainCode: 'T-42',
+      selectedArrivalSeconds: 600,
+      expectedStationAtFire: '강남',
+      actualLastNotifiedStation: '시청',
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).toContain('bg-scheduled');
+    expect(line).toContain('dir=up');
+    expect(line).toContain('train=T-42');
+    expect(line).toContain('eta=600s');
+    expect(line).toContain('exp=강남');
+    expect(line).toContain('last=시청');
+  });
+
+  it('formatLogLine: stamp 필드가 null/미존재면 추가 토큰이 붙지 않는다', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'bg-scheduled',
+      outcome: 'fired',
+      direction: null,
+      usedTrainCode: null,
+      selectedArrivalSeconds: null,
+      expectedStationAtFire: null,
+      actualLastNotifiedStation: null,
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).not.toContain('dir=');
+    expect(line).not.toContain('train=');
+    expect(line).not.toContain('eta=');
+    expect(line).not.toContain('exp=');
+    expect(line).not.toContain('last=');
+  });
+
+  it('formatLogLine: selectedArrivalSeconds=0이어도 eta=0s로 표기 (0과 null 구분)', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'bg-scheduled',
+      outcome: 'fired',
+      selectedArrivalSeconds: 0,
+    };
+    expect(__test__.formatLogLine(entry)).toContain('eta=0s');
+  });
+
   it('formatLogLine: accuracy null이면 "-"로 표기', () => {
     const entry: AlarmLogEntry = {
       ts: Date.now(),

--- a/src/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/hooks/__tests__/useScheduledAlarms.test.ts
@@ -118,6 +118,7 @@ describe('useScheduledAlarms', () => {
       route: ROUTE,
       destinationName: '강남',
       nextStationEtaSeconds: 300, // min(300, 420)
+      stamp: { direction: 'up', usedTrainCode: 'U1' },
     });
   });
 
@@ -272,6 +273,29 @@ describe('useScheduledAlarms', () => {
 
     expect(mockedSchedule).toHaveBeenCalledWith(
       expect.objectContaining({ nextStationEtaSeconds: null }),
+    );
+  });
+
+  it('trainCode가 빈 문자열이면 stamp.usedTrainCode는 null로 위임한다', async () => {
+    const noTrainCode: StationArrival = {
+      ...ARRIVAL,
+      up: [{ ...ARRIVAL.up[0], trainCode: '' }],
+      down: [],
+    };
+    renderHook(() =>
+      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, arrival: noTrainCode }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stamp: { direction: 'up', usedTrainCode: null },
+      }),
     );
   });
 

--- a/src/hooks/useScheduledAlarms.ts
+++ b/src/hooks/useScheduledAlarms.ts
@@ -7,6 +7,7 @@ import {
   cancelScheduledAlarms,
   scheduleAlarmsForRoute,
 } from '../utils/alarmScheduler';
+import { pickNextArrival } from '../utils/nextArrivalPick';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('useScheduledAlarms');
@@ -15,20 +16,6 @@ export interface UseScheduledAlarmsInputs {
   route: Route;
   destination: Station | null;
   arrival: StationArrival | null;
-}
-
-/**
- * 다음 도착역까지의 ETA(초)를 arrival 데이터에서 추출한다.
- * up/down 양방향에서 가장 빠른 양수 arrivalSeconds를 선택한다.
- * 데이터가 없거나 mock이면 null을 반환해 alarmScheduler의 static fallback으로 위임한다.
- */
-function pickNextStationEtaSeconds(arrival: StationArrival | null): number | null {
-  if (!arrival || arrival.isMock) return null;
-  const candidates = [...arrival.up, ...arrival.down]
-    .map((info) => info.arrivalSeconds)
-    .filter((sec) => sec > 0);
-  if (candidates.length === 0) return null;
-  return Math.min(...candidates);
 }
 
 /**
@@ -61,11 +48,12 @@ export function useScheduledAlarms({
     const currentDestination = destinationRef.current;
     if (!currentRoute || !currentDestination) return;
     if (appStateRef.current === 'active') return;
-    const etaSeconds = pickNextStationEtaSeconds(arrivalRef.current);
+    const { etaSeconds, direction, trainCode } = pickNextArrival(arrivalRef.current);
     await scheduleAlarmsForRoute({
       route: currentRoute,
       destinationName: currentDestination.name,
       nextStationEtaSeconds: etaSeconds,
+      stamp: { direction, usedTrainCode: trainCode },
     });
   };
 

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -89,12 +89,14 @@ function mockStorage(values: {
   );
 }
 
+const EMPTY_STAMP = {
+  direction: null,
+  usedTrainCode: null,
+} as const;
+
 function expectSchedulerCalledWith(
   currentStationApproachEtaSeconds: number | null,
-  stamp: { direction: 'up' | 'down' | null; usedTrainCode: string | null } = {
-    direction: null,
-    usedTrainCode: null,
-  },
+  stamp: { direction: 'up' | 'down' | null; usedTrainCode: string | null } = EMPTY_STAMP,
 ) {
   expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
     route,

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -86,11 +86,18 @@ function mockStorage(values: {
   );
 }
 
-function expectSchedulerCalledWith(nextStationEtaSeconds: number | null) {
+function expectSchedulerCalledWith(
+  nextStationEtaSeconds: number | null,
+  stamp: { direction: 'up' | 'down' | null; usedTrainCode: string | null } = {
+    direction: null,
+    usedTrainCode: null,
+  },
+) {
   expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
     route,
     destinationName: '시청',
     nextStationEtaSeconds,
+    stamp,
   });
 }
 
@@ -150,7 +157,8 @@ describe('alarmRefreshTask', () => {
       });
       await getCallback()();
       expect(mockFetchArrivalInfo).toHaveBeenCalledWith('강남');
-      expectSchedulerCalledWith(300);
+      // 가장 짧은 양수는 down[0]=300 → direction='down', trainCode 누락(mock) → null
+      expectSchedulerCalledWith(300, { direction: 'down', usedTrainCode: null });
     });
 
     it('Arrival API가 모두 0/음수면 nextStationEtaSeconds=null', async () => {

--- a/src/tasks/alarmRefreshTask.ts
+++ b/src/tasks/alarmRefreshTask.ts
@@ -3,7 +3,8 @@ import * as BackgroundTask from 'expo-background-task';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DESTINATION_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
 import { scheduleAlarmsForRoute } from '../utils/alarmScheduler';
-import { fetchArrivalInfo, type ArrivalInfo } from '../api/arrivalApi';
+import { fetchArrivalInfo } from '../api/arrivalApi';
+import { pickNextArrival, type NextArrivalPick } from '../utils/nextArrivalPick';
 import stationsData from '../data/stations.json';
 import type { Station } from '../types/station';
 import type { Route } from '../utils/stationRoute';
@@ -21,18 +22,6 @@ export const ALARM_REFRESH_TASK = 'alarm-refresh-task';
  */
 const allStations = stationsData as Station[];
 const stationById = new Map<string, Station>(allStations.map((s) => [s.id, s]));
-
-function pickNextStationEtaSeconds(arrivals: { up: ArrivalInfo[]; down: ArrivalInfo[] }): number | null {
-  // 방향 정보 없이 BG에서 가장 신뢰할 수 있는 신호는 "임박한 도착". up/down 합산해
-  // 양수 중 최소값을 다음 도착 ETA로 사용한다. 정확도는 reschedule(#335)이 보정.
-  let min: number | null = null;
-  for (const info of [...arrivals.up, ...arrivals.down]) {
-    if (info.arrivalSeconds > 0 && (min === null || info.arrivalSeconds < min)) {
-      min = info.arrivalSeconds;
-    }
-  }
-  return min;
-}
 
 async function readActiveTrip(): Promise<{ destination: Station; route: NonNullable<Route> } | null> {
   const [destJson, routeJson] = await Promise.all([
@@ -66,11 +55,11 @@ TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
     }
 
     const currentStationName = await resolveCurrentStationName();
-    let nextStationEtaSeconds: number | null = null;
+    let pick: NextArrivalPick = { etaSeconds: null, direction: null, trainCode: null };
     if (currentStationName) {
       try {
         const arrivals = await fetchArrivalInfo(currentStationName);
-        nextStationEtaSeconds = pickNextStationEtaSeconds(arrivals);
+        pick = pickNextArrival(arrivals);
       } catch (e) {
         logger.warn('Arrival API 호출 실패 — static ETA fallback:', e);
       }
@@ -79,7 +68,8 @@ TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
     await scheduleAlarmsForRoute({
       route: active.route,
       destinationName: active.destination.name,
-      nextStationEtaSeconds,
+      nextStationEtaSeconds: pick.etaSeconds,
+      stamp: { direction: pick.direction, usedTrainCode: pick.trainCode },
     });
     logger.info('알람 사전 예약 갱신 완료');
     return BackgroundTask.BackgroundTaskResult.Success;

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -5,10 +5,12 @@ import {
   clearAlarmLog,
   logFiredAlarm,
   logFiredStationPassed,
+  logScheduledAlarm,
   logSuppressedDedupStation,
   logSuppressedGate,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
+  type AlarmLogStamp,
 } from '../alarmLog';
 import { ALARM_LOG_KEY } from '../../constants/storageKeys';
 import type { AlarmEvent } from '../stationAlarm';
@@ -218,6 +220,56 @@ describe('alarmLog', () => {
         reason: 'dedup-station',
         stationName: station.name,
         kind: 'station-passed',
+      });
+    });
+
+    it('logScheduledAlarm: source=bg-scheduled, outcome=fired + stamp 필드 전부 적재한다', async () => {
+      const stamp: AlarmLogStamp = {
+        direction: 'up',
+        usedTrainCode: 'T-42',
+        selectedArrivalSeconds: 600,
+        expectedStationAtFire: '강남',
+        actualLastNotifiedStation: 'S-7',
+      };
+      logScheduledAlarm(event, stamp);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg-scheduled',
+        outcome: 'fired',
+        stationName: event.stationName,
+        kind: event.type,
+        phaseId: event.phaseId,
+        direction: 'up',
+        usedTrainCode: 'T-42',
+        selectedArrivalSeconds: 600,
+        expectedStationAtFire: '강남',
+        actualLastNotifiedStation: 'S-7',
+      });
+    });
+
+    it('logScheduledAlarm: stamp 필드가 null이면 null로 그대로 적재한다', async () => {
+      const stamp: AlarmLogStamp = {
+        direction: null,
+        usedTrainCode: null,
+        selectedArrivalSeconds: null,
+        expectedStationAtFire: null,
+        actualLastNotifiedStation: null,
+      };
+      logScheduledAlarm(event, stamp);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg-scheduled',
+        direction: null,
+        usedTrainCode: null,
+        selectedArrivalSeconds: null,
+        expectedStationAtFire: null,
+        actualLastNotifiedStation: null,
       });
     });
 

--- a/src/utils/__tests__/alarmScheduler.test.ts
+++ b/src/utils/__tests__/alarmScheduler.test.ts
@@ -5,6 +5,8 @@ import {
   cancelScheduledAlarms,
   scheduledAlarmIdentifier,
 } from '../alarmScheduler';
+import { logScheduledAlarm } from '../alarmLog';
+import { getLastNotifiedStationId } from '../notificationState';
 import type {
   DirectRoute,
   TransferRoute,
@@ -20,6 +22,18 @@ jest.mock('../logger', () => ({
     error: jest.fn(),
   }),
 }));
+
+jest.mock('../alarmLog', () => ({
+  logScheduledAlarm: jest.fn(),
+}));
+jest.mock('../notificationState', () => ({
+  getLastNotifiedStationId: jest.fn(),
+}));
+
+const mockedLogScheduled = logScheduledAlarm as jest.MockedFunction<typeof logScheduledAlarm>;
+const mockedGetLastNotified = getLastNotifiedStationId as jest.MockedFunction<
+  typeof getLastNotifiedStationId
+>;
 
 const NOW = new Date('2026-05-13T12:00:00Z').getTime();
 
@@ -38,6 +52,7 @@ describe('scheduleAlarmsForRoute', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('id');
+    mockedGetLastNotified.mockResolvedValue(null);
     jest.replaceProperty(Platform, 'OS', 'ios');
   });
 
@@ -272,6 +287,75 @@ describe('scheduleAlarmsForRoute', () => {
     const fire = result[0].fireDate.getTime();
     expect(fire).toBeGreaterThanOrEqual(before + 1_320_000);
     expect(fire).toBeLessThanOrEqual(after + 1_320_000);
+  });
+
+  // ── #372 stamp ──
+  it('stamp + last-notified를 각 예약 알람에 함께 적재한다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    mockedGetLastNotified.mockResolvedValueOnce('S-prev');
+
+    await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      nextStationEtaSeconds: 600,
+      now: NOW,
+      stamp: { direction: 'up', usedTrainCode: 'T-99' },
+    });
+
+    expect(mockedLogScheduled).toHaveBeenCalledTimes(2);
+    expect(mockedLogScheduled).toHaveBeenNthCalledWith(
+      1,
+      { phaseId: 'early', type: 'destination', stationName: '강남' },
+      {
+        direction: 'up',
+        usedTrainCode: 'T-99',
+        selectedArrivalSeconds: 600,
+        expectedStationAtFire: '강남',
+        actualLastNotifiedStation: 'S-prev',
+      },
+    );
+    expect(mockedLogScheduled).toHaveBeenNthCalledWith(
+      2,
+      { phaseId: 'imminent', type: 'destination', stationName: '강남' },
+      expect.objectContaining({
+        direction: 'up',
+        usedTrainCode: 'T-99',
+        actualLastNotifiedStation: 'S-prev',
+      }),
+    );
+  });
+
+  it('stamp 미지정이면 direction/usedTrainCode가 null로 기록된다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+
+    await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      nextStationEtaSeconds: null,
+      now: NOW,
+    });
+
+    expect(mockedLogScheduled).toHaveBeenCalled();
+    expect(mockedLogScheduled).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        direction: null,
+        usedTrainCode: null,
+        selectedArrivalSeconds: null,
+        actualLastNotifiedStation: null,
+      }),
+    );
+  });
+
+  it('과거 시각 phase가 모두 skip되면 logScheduledAlarm이 호출되지 않는다', async () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '1' };
+    await scheduleAlarmsForRoute({
+      route,
+      destinationName: '강남',
+      nextStationEtaSeconds: 5,
+      now: NOW,
+    });
+    expect(mockedLogScheduled).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/__tests__/nextArrivalPick.test.ts
+++ b/src/utils/__tests__/nextArrivalPick.test.ts
@@ -1,0 +1,115 @@
+import { pickNextArrival } from '../nextArrivalPick';
+import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
+
+function info(overrides: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: 'D',
+    arrivalMinutes: 0,
+    arrivalSeconds: 100,
+    statusMessage: '',
+    trainCode: 'T-1',
+    receivedAtMs: 0,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+describe('pickNextArrival', () => {
+  it('arrival이 null이면 모두 null', () => {
+    expect(pickNextArrival(null)).toEqual({
+      etaSeconds: null,
+      direction: null,
+      trainCode: null,
+    });
+  });
+
+  it('isMock=true면 모두 null', () => {
+    const arrival: StationArrival = {
+      up: [info({ arrivalSeconds: 100 })],
+      down: [],
+      isMock: true,
+    };
+    expect(pickNextArrival(arrival)).toEqual({
+      etaSeconds: null,
+      direction: null,
+      trainCode: null,
+    });
+  });
+
+  it('up/down 양방향에서 가장 빠른 양수 arrivalSeconds를 선택한다', () => {
+    const arrival: StationArrival = {
+      up: [info({ arrivalSeconds: 300, trainCode: 'U1' })],
+      down: [info({ arrivalSeconds: 120, trainCode: 'D1' })],
+    };
+    expect(pickNextArrival(arrival)).toEqual({
+      etaSeconds: 120,
+      direction: 'down',
+      trainCode: 'D1',
+    });
+  });
+
+  it('동일 방향 내에서도 최소값을 선택한다', () => {
+    const arrival: StationArrival = {
+      up: [
+        info({ arrivalSeconds: 500, trainCode: 'U-late' }),
+        info({ arrivalSeconds: 80, trainCode: 'U-soon' }),
+      ],
+      down: [],
+    };
+    expect(pickNextArrival(arrival)).toEqual({
+      etaSeconds: 80,
+      direction: 'up',
+      trainCode: 'U-soon',
+    });
+  });
+
+  it('0 이하 arrivalSeconds는 후보에서 제외한다', () => {
+    const arrival: StationArrival = {
+      up: [info({ arrivalSeconds: 0 }), info({ arrivalSeconds: -5 })],
+      down: [info({ arrivalSeconds: 250, trainCode: 'D-only' })],
+    };
+    expect(pickNextArrival(arrival)).toEqual({
+      etaSeconds: 250,
+      direction: 'down',
+      trainCode: 'D-only',
+    });
+  });
+
+  it('양수 후보가 전혀 없으면 모두 null', () => {
+    const arrival: StationArrival = {
+      up: [info({ arrivalSeconds: 0 })],
+      down: [info({ arrivalSeconds: -1 })],
+    };
+    expect(pickNextArrival(arrival)).toEqual({
+      etaSeconds: null,
+      direction: null,
+      trainCode: null,
+    });
+  });
+
+  it('trainCode가 빈 문자열이면 null로 변환한다', () => {
+    const arrival: StationArrival = {
+      up: [info({ arrivalSeconds: 100, trainCode: '' })],
+      down: [],
+    };
+    expect(pickNextArrival(arrival)).toEqual({
+      etaSeconds: 100,
+      direction: 'up',
+      trainCode: null,
+    });
+  });
+
+  it('isMock 필드가 없는 입력 형태({up,down}만)도 동작한다', () => {
+    const result = pickNextArrival({
+      up: [info({ arrivalSeconds: 60, trainCode: 'fetch-T' })],
+      down: [],
+    });
+    expect(result).toEqual({
+      etaSeconds: 60,
+      direction: 'up',
+      trainCode: 'fetch-T',
+    });
+  });
+});

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -12,18 +12,42 @@ import type { Station } from '../types/station';
 // Buffer 크기는 ALARM_LOG_BUFFER_SIZE 상수로 분리 — 늘리려면 한 곳만 수정.
 export const ALARM_LOG_BUFFER_SIZE = 200;
 
-export type AlarmLogSource = 'fg' | 'bg';
+// 'fg' / 'bg'는 v1 (FG GPS 평가 / BG location task gate). 'fg-evaluated' / 'bg-scheduled'는
+// v2 (#372)로 의미 명확화. 두 값 모두 union에 유지해 과거 저장 데이터를 손실 없이 읽는다.
+export type AlarmLogSource = 'fg' | 'bg' | 'fg-evaluated' | 'bg-scheduled';
 export type AlarmLogOutcome = 'fired' | 'suppressed';
 // 'dedup-alarm'(evaluateAlarmPhase의 firedAlarms 적중 케이스)은 후속 이슈에서 추가.
 // 그때까지 union에 선언하지 않아 "구현됐다"는 거짓 시그널을 피한다.
 export type AlarmLogReason = 'dedup-station' | 'gate-age' | 'gate-accuracy';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
+export type AlarmLogDirection = 'up' | 'down';
 
 export interface AlarmLogLocation {
   lat: number;
   lng: number;
   accuracy: number | null;
   ageMs: number;
+}
+
+/**
+ * 사전 예약 알람에 첨부되는 컨텍스트 stamp (#372).
+ * "이 알람이 어떤 입력값으로 산출됐는가?"를 발사 시점 진단 없이도 알 수 있게 한다.
+ *
+ * 모든 필드는 null 허용 — caller가 모르면 그대로 null. (예: silent push BG는
+ * 방향/trainCode를 모른다.)
+ *
+ * 시점 주의:
+ *   - 사전 예약 알람은 expo-notifications OS 레벨로 발사되므로 fire-time hook이 없다.
+ *   - 따라서 `actualLastNotifiedStation`은 발사 시점 값이 아닌 **예약 시점 스냅샷**이다.
+ *   - 이름은 이슈 #372 스펙(`actualLastNotifiedStation`)을 유지하지만, 진단 시
+ *     "예약 직후 알고 있던 가장 최신 위치"로 해석해야 한다.
+ */
+export interface AlarmLogStamp {
+  direction: AlarmLogDirection | null;
+  usedTrainCode: string | null;
+  selectedArrivalSeconds: number | null;
+  expectedStationAtFire: string | null;
+  actualLastNotifiedStation: string | null;
 }
 
 export interface AlarmLogEntry {
@@ -35,6 +59,12 @@ export interface AlarmLogEntry {
   kind?: AlarmLogKind;
   phaseId?: AlarmPhaseId;
   location?: AlarmLogLocation;
+  // #372 — 사전 예약 알람 stamp. 모두 optional (구버전/일부 caller 호환).
+  direction?: AlarmLogDirection | null;
+  usedTrainCode?: string | null;
+  selectedArrivalSeconds?: number | null;
+  expectedStationAtFire?: string | null;
+  actualLastNotifiedStation?: string | null;
 }
 
 const logger = createLogger('AlarmLog');
@@ -52,6 +82,27 @@ export function logFiredAlarm(source: AlarmLogSource, event: AlarmEvent): void {
     stationName: event.stationName,
     kind: event.type,
     phaseId: event.phaseId,
+  });
+}
+
+/**
+ * 사전 예약(BG) 알람 1건의 stamp 컨텍스트를 적재한다 (#372).
+ * source는 항상 'bg-scheduled', outcome은 'fired'(사전 예약된 발사 예정 기록).
+ * 발사 자체는 expo-notifications가 처리하므로 별도 fire-time 로그는 없다.
+ */
+export function logScheduledAlarm(event: AlarmEvent, stamp: AlarmLogStamp): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg-scheduled',
+    outcome: 'fired',
+    stationName: event.stationName,
+    kind: event.type,
+    phaseId: event.phaseId,
+    direction: stamp.direction,
+    usedTrainCode: stamp.usedTrainCode,
+    selectedArrivalSeconds: stamp.selectedArrivalSeconds,
+    expectedStationAtFire: stamp.expectedStationAtFire,
+    actualLastNotifiedStation: stamp.actualLastNotifiedStation,
   });
 }
 

--- a/src/utils/alarmScheduler.ts
+++ b/src/utils/alarmScheduler.ts
@@ -5,6 +5,8 @@ import { alarmKey, resolveAllTargets, type AlarmEvent } from './stationAlarm';
 import { calculateStaticETA, type Route } from './stationRoute';
 import { buildAlarmContent } from './stationNotification';
 import { createLogger } from './logger';
+import { logScheduledAlarm, type AlarmLogDirection } from './alarmLog';
+import { getLastNotifiedStationId } from './notificationState';
 
 const logger = createLogger('AlarmScheduler');
 
@@ -36,6 +38,14 @@ export interface ScheduleAlarmsParams {
    * null이면 calculateStaticETA로 목적지 ETA를 fallback 계산한다.
    */
   nextStationEtaSeconds: number | null;
+  /**
+   * 관찰용 컨텍스트 stamp (#372). 발사 시점 진단을 위해 alarmLog에 함께 적재한다.
+   * 정책에는 영향을 주지 않으며, 모르는 caller는 생략하면 모든 필드 null로 기록된다.
+   */
+  stamp?: {
+    direction: AlarmLogDirection | null;
+    usedTrainCode: string | null;
+  };
   /** 테스트에서 시각 주입용. 기본값은 Date.now(). */
   now?: number;
 }
@@ -50,13 +60,19 @@ export interface ScheduleAlarmsParams {
 export async function scheduleAlarmsForRoute(
   params: ScheduleAlarmsParams,
 ): Promise<ScheduledAlarm[]> {
-  const { route, destinationName, nextStationEtaSeconds, now = Date.now() } = params;
+  const { route, destinationName, nextStationEtaSeconds, stamp, now = Date.now() } = params;
 
   const targets = resolveAllTargets(route, destinationName);
   const totalStops = targets.reduce((sum, t) => sum + t.stops, 0);
   if (totalStops === 0) return [];
 
   const finalEtaSeconds = resolveFinalEtaSeconds(nextStationEtaSeconds, totalStops, route);
+
+  // 발사 시점 비교용으로, 예약 직전 LAST_NOTIFIED_STATION을 한 번만 읽는다.
+  // 발사 시 실제 값과 다르면 "예상한 위치와 실제 위치가 어긋났다"는 진단 신호.
+  const actualLastNotifiedStation = await getLastNotifiedStationId();
+  const stampDirection = stamp?.direction ?? null;
+  const stampTrainCode = stamp?.usedTrainCode ?? null;
 
   const scheduled: ScheduledAlarm[] = [];
   let cumulativeStops = 0;
@@ -94,6 +110,17 @@ export async function scheduleAlarmsForRoute(
       });
 
       scheduled.push({ identifier, event, fireDate });
+
+      logScheduledAlarm(event, {
+        direction: stampDirection,
+        usedTrainCode: stampTrainCode,
+        selectedArrivalSeconds: nextStationEtaSeconds,
+        // 발사 시 사용자가 도착해 있어야 하는 역 = 알람 대상 역 직전.
+        // 현재 스케줄러는 station ordinal 정보를 갖지 않아 target.name으로 기록한다.
+        // 진단 시 stationName과 함께 보면 "어느 알람이었나"가 명확해진다.
+        expectedStationAtFire: target.name,
+        actualLastNotifiedStation,
+      });
     }
   }
 

--- a/src/utils/nextArrivalPick.ts
+++ b/src/utils/nextArrivalPick.ts
@@ -1,4 +1,7 @@
-import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
+import type { ArrivalInfo } from '../api/arrivalApi';
+
+// StationArrival을 caller가 함께 import할 수 있도록 re-export.
+export type { StationArrival } from '../api/arrivalApi';
 
 export interface NextArrivalPick {
   etaSeconds: number | null;
@@ -29,12 +32,7 @@ export function pickNextArrival(
   filterDirection: 'up' | 'down' | null = null,
 ): NextArrivalPick {
   if (!arrival || arrival.isMock) return EMPTY_PICK;
-  const directions: Array<'up' | 'down'> =
-    filterDirection === 'up'
-      ? ['up']
-      : filterDirection === 'down'
-        ? ['down']
-        : ['up', 'down'];
+  const directions = directionsToSearch(filterDirection);
   let pick: { info: ArrivalInfo; direction: 'up' | 'down' } | null = null;
   for (const direction of directions) {
     for (const info of arrival[direction]) {
@@ -52,5 +50,8 @@ export function pickNextArrival(
   };
 }
 
-// 타입 export — caller가 StationArrival을 직접 다루지 않을 때 사용.
-export type { StationArrival };
+function directionsToSearch(filter: 'up' | 'down' | null): Array<'up' | 'down'> {
+  if (filter === 'up') return ['up'];
+  if (filter === 'down') return ['down'];
+  return ['up', 'down'];
+}

--- a/src/utils/nextArrivalPick.ts
+++ b/src/utils/nextArrivalPick.ts
@@ -1,0 +1,46 @@
+import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
+
+export interface NextArrivalPick {
+  etaSeconds: number | null;
+  direction: 'up' | 'down' | null;
+  trainCode: string | null;
+}
+
+const EMPTY_PICK: NextArrivalPick = {
+  etaSeconds: null,
+  direction: null,
+  trainCode: null,
+};
+
+/**
+ * up/down 양방향에서 가장 빠른 양수 arrivalSeconds를 선택하고, 함께 방향/trainCode를
+ * 반환한다. 사전 예약 알람의 stamp(#372) 산출에 공통 사용된다.
+ *
+ * isMock arrival은 명시적으로 null을 반환 — alarmScheduler의 staticETA fallback으로 위임.
+ *
+ * 입력 형태가 두 가지 (StationArrival, 또는 fetch 결과 {up, down})를 모두 수용하기 위해
+ * isMock을 optional로 둔다.
+ */
+export function pickNextArrival(
+  arrival: { up: ArrivalInfo[]; down: ArrivalInfo[]; isMock?: boolean } | null,
+): NextArrivalPick {
+  if (!arrival || arrival.isMock) return EMPTY_PICK;
+  let pick: { info: ArrivalInfo; direction: 'up' | 'down' } | null = null;
+  for (const direction of ['up', 'down'] as const) {
+    for (const info of arrival[direction]) {
+      if (info.arrivalSeconds <= 0) continue;
+      if (pick === null || info.arrivalSeconds < pick.info.arrivalSeconds) {
+        pick = { info, direction };
+      }
+    }
+  }
+  if (!pick) return EMPTY_PICK;
+  return {
+    etaSeconds: pick.info.arrivalSeconds,
+    direction: pick.direction,
+    trainCode: pick.info.trainCode || null,
+  };
+}
+
+// 타입 export — caller가 StationArrival을 직접 다루지 않을 때 사용.
+export type { StationArrival };


### PR DESCRIPTION
## 무엇을
- 사전 예약(BG) 알람의 fired 로그 엔트리에 진단용 stamp 컨텍스트(`direction` / `usedTrainCode` / `selectedArrivalSeconds` / `expectedStationAtFire` / `actualLastNotifiedStation`)를 추가.
- `AlarmLogSource`에 `'fg-evaluated' | 'bg-scheduled'` 보강 (legacy `'fg'`/`'bg'` 호환 유지).

## 왜
- #283 후속. 잠금화면 잘못된 "다음 역" 알림 회귀(용마산→어린이대공원) 분석 시, 어떤 입력값으로 ETA가 산출됐는지 발사 시점 컨텍스트가 없어 추측에 의존했다.
- 다음 회귀 발생 시 알람 로그 한 줄로 1분 안에 원인을 좁힐 수 있게 한다. 정책 변경 없이 **관찰만** 추가.

Closes #372

## 어떻게
- `src/utils/alarmLog.ts`: `AlarmLogEntry`에 optional stamp 필드 5개 추가. `AlarmLogStamp` 인터페이스 + `logScheduledAlarm(event, stamp)` helper 신설.
- `src/utils/alarmScheduler.ts`: `ScheduleAlarmsParams.stamp?: {direction, usedTrainCode}` optional 파라미터 추가. 예약 시점에 `getLastNotifiedStationId()`를 1회 스냅샷 캡쳐해 각 phase 엔트리에 함께 적재.
- `src/utils/nextArrivalPick.ts` (신규): `pickNextArrival`을 추출해 `useScheduledAlarms`와 `alarmRefreshTask`가 공유. BG 갱신 경로(`alarmRefreshTask`)에도 stamp 전달 — 알 수 있는 컨텍스트는 정직하게 기록한다.
- `src/components/DebugModal.tsx`: `formatLogLine`에 `dir=` / `train=` / `eta=` / `exp=` / `last=` 토큰을 값이 있을 때만 추가 (null과 0 구분).
- `actualLastNotifiedStation`은 이슈 스펙 이름을 유지하지만, 사전 예약 알람 특성상 **예약 시점 스냅샷**임을 `AlarmLogStamp` docstring에 명시.

## 테스트
- 신규: `nextArrivalPick.test.ts` (8 케이스 — null/mock/방향 분기/empty trainCode).
- 보강: `alarmLog`(logScheduledAlarm × 2), `alarmScheduler`(stamp 적재 × 3), `useScheduledAlarms`(trainCode 빈문자열), `DebugModal`(stamp 표기 × 3, eta=0s 경계), `alarmRefreshTask`(stamp 전달 확인).
- `npm test` 1276개 통과, 커버리지 100% (lines/functions/branches/statements).
- `npm run type-check` 통과.