### PR TITLE
fix(#371): BG 사전 예약 알람 발화 시 클라이언트 상태 동기화

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ import { useAppStore } from '../src/store/useAppStore';
 import { DebugModal } from '../src/components/DebugModal';
 import '../src/tasks/backgroundLocationTask';
 import { registerSilentPushTask } from '../src/tasks/silentPushTask';
+import { registerScheduledAlarmListener } from '../src/utils/scheduledAlarmReceiver';
 
 const layoutLogger = createLogger('RootLayout');
 
@@ -21,6 +22,8 @@ setupNotificationHandler();
 // iOS silent push BG task 등록 — APNs reschedule trigger 수신용.
 // 권한/플랫폼 미지원 시 내부에서 graceful no-op.
 registerSilentPushTask().catch((e) => layoutLogger.warn('silent push task 등록 실패:', e));
+// 사전 예약 alarm: 알림 발화 시 FIRED_ALARMS/LAST_NOTIFIED_STATION 갱신 → FG 복귀 후 중복 발화 방지.
+registerScheduledAlarmListener();
 
 // 프로덕션 빌드에서는 warn 이상만 출력
 if (!__DEV__) {

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -8,6 +8,11 @@ export const THEME_MODE_KEY = 'subway-now:theme-mode';
 export const ROUTE_PREFERENCE_KEY = 'subway-now:route-preference';
 export const ROUTE_KEY = 'subway-now:route';
 export const LAST_NOTIFIED_STATION_KEY = 'subway-now:last-notified-station';
+// 사전 예약 alarm: 알림 발사 시 기록되는 station name. alarmRefreshTask가 Arrival API
+// 기준역을 정할 때 사용. LAST_NOTIFIED_STATION_KEY(id 기반, GPS 추적)와 분리한 이유:
+// 사전 예약 알람은 동명이역 환경에서 노선을 식별할 수 없어 id로 매핑하면 잘못된 노선의
+// 좌표/메타로 후속 소비자가 오작동할 수 있다. name만 단일 출처로 둔다.
+export const LAST_FIRED_ALARM_STATION_NAME_KEY = 'subway-now:last-fired-alarm-station-name';
 export const ALLOW_SPEAKER_KEY = 'subway-now:allow-speaker';
 export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
 export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -62,6 +62,10 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
 }));
 
+jest.mock('../../utils/scheduledAlarmReceiver', () => ({
+  awaitInitialScheduledAlarmDrain: jest.fn().mockResolvedValue(undefined),
+}));
+
 const makeStation = (id: string, name: string, lat = 37.5, lng = 127.0): Station => ({
   id,
   name,

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -13,6 +13,7 @@ import {
   setFiredAlarms,
   clearFiredAlarms,
 } from '../utils/notificationState';
+import { awaitInitialScheduledAlarmDrain } from '../utils/scheduledAlarmReceiver';
 import {
   logFiredAlarm,
   logFiredStationPassed,
@@ -74,6 +75,9 @@ export function useStationAlarm({
   useEffect(() => {
     let cancelled = false;
     void (async () => {
+      // 사전 예약 알람의 첫 drain이 완료된 후 read해야 cold start 직후
+      // BG-fired 알람이 dedup set에 반영된 상태로 hydrate된다.
+      await awaitInitialScheduledAlarmDrain();
       const stored = await getFiredAlarms();
       if (cancelled) return;
       firedAlarmsRef.current = stored;

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -28,6 +28,11 @@ jest.mock('../../api/arrivalApi', () => ({
   fetchArrivalInfo: (...args: unknown[]) => mockFetchArrivalInfo(...args),
 }));
 
+const mockGetLastFiredAlarmStationName = jest.fn();
+jest.mock('../../utils/notificationState', () => ({
+  getLastFiredAlarmStationName: (...args: unknown[]) => mockGetLastFiredAlarmStationName(...args),
+}));
+
 jest.mock('../../data/stations.json', () => [
   { id: 'station-1', name: '강남', line: '2', lineColor: '#009246', lat: 0, lng: 0 },
   { id: 'station-2', name: '시청', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
@@ -97,6 +102,7 @@ function expectSchedulerCalledWith(nextStationEtaSeconds: number | null) {
 describe('alarmRefreshTask', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetLastFiredAlarmStationName.mockResolvedValue(null);
   });
 
   it('defineTask가 ALARM_REFRESH_TASK 이름으로 호출된다', () => {
@@ -176,6 +182,15 @@ describe('alarmRefreshTask', () => {
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
       expectSchedulerCalledWith(null);
+    });
+
+    it('사전 예약 알람 발화 이름이 있으면 GPS id를 무시하고 그 이름으로 Arrival API를 호출한다', async () => {
+      mockStorage({ destination, route, lastStation: 'station-1' });
+      mockGetLastFiredAlarmStationName.mockResolvedValueOnce('시청');
+      mockFetchArrivalInfo.mockResolvedValue({ up: [{ arrivalSeconds: 500 }], down: [] });
+      await getCallback()();
+      expect(mockFetchArrivalInfo).toHaveBeenCalledWith('시청');
+      expectSchedulerCalledWith(500);
     });
 
     it('스케줄러가 throw 하면 Failed를 반환한다', async () => {

--- a/src/tasks/alarmRefreshTask.ts
+++ b/src/tasks/alarmRefreshTask.ts
@@ -2,6 +2,7 @@ import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DESTINATION_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
+import { getLastFiredAlarmStationName } from '../utils/notificationState';
 import { scheduleAlarmsForRoute } from '../utils/alarmScheduler';
 import { fetchArrivalInfo, type ArrivalInfo } from '../api/arrivalApi';
 import stationsData from '../data/stations.json';
@@ -52,6 +53,10 @@ async function readActiveTrip(): Promise<{ destination: Station; route: NonNulla
 }
 
 async function resolveCurrentStationName(): Promise<string | null> {
+  // 사전 예약 알람 발화 기록을 1순위로 사용한다 — GPS 기반 LAST_NOTIFIED_STATION_KEY는
+  // BG에서 위치 업데이트가 끊긴 동안 stale일 수 있다. 알람이 한 번도 안 울렸으면 GPS 기록으로 fallback.
+  const firedName = await getLastFiredAlarmStationName();
+  if (firedName) return firedName;
   const id = await AsyncStorage.getItem(LAST_NOTIFIED_STATION_KEY);
   if (!id) return null;
   return stationById.get(id)?.name ?? null;

--- a/src/utils/__tests__/alarmScheduler.test.ts
+++ b/src/utils/__tests__/alarmScheduler.test.ts
@@ -4,6 +4,7 @@ import {
   scheduleAlarmsForRoute,
   cancelScheduledAlarms,
   scheduledAlarmIdentifier,
+  parseScheduledAlarmIdentifier,
 } from '../alarmScheduler';
 import type {
   DirectRoute,
@@ -31,6 +32,27 @@ describe('scheduledAlarmIdentifier', () => {
     expect(scheduledAlarmIdentifier({ phaseId: 'imminent', stationName: '시청' })).toBe(
       'alarm:imminent:시청',
     );
+  });
+});
+
+describe('parseScheduledAlarmIdentifier', () => {
+  it('alarm: prefix가 없으면 null', () => {
+    expect(parseScheduledAlarmIdentifier('current-station')).toBeNull();
+  });
+  it('phaseId가 빈 문자열이면 null', () => {
+    expect(parseScheduledAlarmIdentifier('alarm::강남')).toBeNull();
+  });
+  it('콜론이 없으면 null', () => {
+    expect(parseScheduledAlarmIdentifier('alarm:onlyphase')).toBeNull();
+  });
+  it('stationName이 비어 있으면 null', () => {
+    expect(parseScheduledAlarmIdentifier('alarm:early:')).toBeNull();
+  });
+  it('유효한 identifier를 파싱한다', () => {
+    expect(parseScheduledAlarmIdentifier('alarm:early:강남')).toEqual({
+      phaseId: 'early',
+      stationName: '강남',
+    });
   });
 });
 

--- a/src/utils/__tests__/notificationState.test.ts
+++ b/src/utils/__tests__/notificationState.test.ts
@@ -6,8 +6,14 @@ import {
   getFiredAlarms,
   setFiredAlarms,
   clearFiredAlarms,
+  getLastFiredAlarmStationName,
+  setLastFiredAlarmStationName,
 } from '../notificationState';
-import { LAST_NOTIFIED_STATION_KEY, FIRED_ALARMS_KEY } from '../../constants/storageKeys';
+import {
+  LAST_NOTIFIED_STATION_KEY,
+  FIRED_ALARMS_KEY,
+  LAST_FIRED_ALARM_STATION_NAME_KEY,
+} from '../../constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
@@ -149,6 +155,23 @@ describe('notificationState', () => {
       (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
       await expect(setFiredAlarms(new Set(['a:X']))).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getLastFiredAlarmStationName', () => {
+    it('AsyncStorage에서 LAST_FIRED_ALARM_STATION_NAME_KEY 값을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('강남');
+      const result = await getLastFiredAlarmStationName();
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(LAST_FIRED_ALARM_STATION_NAME_KEY);
+      expect(result).toBe('강남');
+    });
+  });
+
+  describe('setLastFiredAlarmStationName', () => {
+    it('AsyncStorage에 LAST_FIRED_ALARM_STATION_NAME_KEY로 값을 저장한다', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+      await setLastFiredAlarmStationName('시청');
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(LAST_FIRED_ALARM_STATION_NAME_KEY, '시청');
     });
   });
 

--- a/src/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -1,0 +1,264 @@
+import * as Notifications from 'expo-notifications';
+import { AppState } from 'react-native';
+
+jest.mock('expo-notifications', () => ({
+  addNotificationReceivedListener: jest.fn(),
+  getPresentedNotificationsAsync: jest.fn(),
+}));
+
+jest.mock('../notificationState', () => ({
+  getFiredAlarms: jest.fn(),
+  setFiredAlarms: jest.fn(),
+  setLastFiredAlarmStationName: jest.fn(),
+}));
+
+const mockErrorSpy = jest.fn();
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: (...args: unknown[]) => mockErrorSpy(...args),
+  }),
+}));
+
+import {
+  reconcileScheduledAlarmDelivery,
+  registerScheduledAlarmListener,
+  awaitInitialScheduledAlarmDrain,
+} from '../scheduledAlarmReceiver';
+import {
+  getFiredAlarms,
+  setFiredAlarms,
+  setLastFiredAlarmStationName,
+} from '../notificationState';
+
+const mockGetFiredAlarms = getFiredAlarms as jest.Mock;
+const mockSetFiredAlarms = setFiredAlarms as jest.Mock;
+const mockSetLastFiredAlarmStationName = setLastFiredAlarmStationName as jest.Mock;
+const mockAddListener = Notifications.addNotificationReceivedListener as jest.Mock;
+const mockGetPresented = Notifications.getPresentedNotificationsAsync as jest.Mock;
+
+function flushAsync(): Promise<void> {
+  return new Promise((r) => setImmediate(r));
+}
+
+let appStateSpy: jest.SpyInstance;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  mockErrorSpy.mockClear();
+  mockGetFiredAlarms.mockResolvedValue(new Set());
+  mockSetFiredAlarms.mockResolvedValue(undefined);
+  mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
+  mockGetPresented.mockResolvedValue([]);
+  // 기본 AppState 스파이 — 각 테스트는 mockImplementationOnce로 추가 override 가능.
+  appStateSpy = jest
+    .spyOn(AppState, 'addEventListener')
+    .mockReturnValue({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
+
+  // singleton 가드 리셋: 이전 테스트의 모듈 등록 상태를 해제한다.
+  mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+  const handle = registerScheduledAlarmListener();
+  await awaitInitialScheduledAlarmDrain();
+  handle.remove();
+  mockAddListener.mockReset();
+  mockGetPresented.mockReset();
+  mockGetFiredAlarms.mockReset();
+  mockSetFiredAlarms.mockReset();
+  mockSetLastFiredAlarmStationName.mockReset();
+  mockErrorSpy.mockClear();
+  mockGetFiredAlarms.mockResolvedValue(new Set());
+  mockSetFiredAlarms.mockResolvedValue(undefined);
+  mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
+  mockGetPresented.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  appStateSpy.mockRestore();
+});
+
+describe('reconcileScheduledAlarmDelivery', () => {
+  it('alarm: prefix가 아닌 identifier는 무시한다', async () => {
+    await reconcileScheduledAlarmDelivery('current-station');
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+  });
+
+  it('잘못된 포맷은 무시한다', async () => {
+    await reconcileScheduledAlarmDelivery('alarm:onlyphase');
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+  });
+
+  it('FIRED_ALARMS에 phase:station을 추가하고 LAST_FIRED_ALARM_STATION_NAME을 갱신한다', async () => {
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set(['early:시청']));
+
+    await reconcileScheduledAlarmDelivery('alarm:early:강남');
+
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith(new Set(['early:시청', 'early:강남']));
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+  });
+});
+
+describe('registerScheduledAlarmListener', () => {
+  it('등록 시점에 delivered 알람을 batch drain하고 fired set + last station을 한 번만 write한다', async () => {
+    mockGetPresented.mockResolvedValueOnce([
+      { request: { identifier: 'alarm:early:강남' } },
+      { request: { identifier: 'current-station' } },
+      { request: { identifier: 'alarm:imminent:강남' } },
+    ]);
+    const notifRemove = jest.fn();
+    mockAddListener.mockReturnValueOnce({ remove: notifRemove });
+    const appStateRemove = jest.fn();
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockReturnValueOnce({ remove: appStateRemove } as ReturnType<typeof AppState.addEventListener>);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+    await flushAsync();
+
+    expect(mockGetFiredAlarms).toHaveBeenCalledTimes(1);
+    expect(mockSetFiredAlarms).toHaveBeenCalledTimes(1);
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith(new Set(['early:강남', 'imminent:강남']));
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledTimes(1);
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+
+    handle.remove();
+    expect(notifRemove).toHaveBeenCalled();
+    expect(appStateRemove).toHaveBeenCalled();
+  });
+
+  it('drain에 매칭되는 alarm이 없으면 write를 생략한다', async () => {
+    mockGetPresented.mockResolvedValueOnce([
+      { request: { identifier: 'current-station' } },
+    ]);
+    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+
+    handle.remove();
+  });
+
+  it('이미 fired set에 있는 키는 firedChanged를 트리거하지 않는다', async () => {
+    mockGetPresented.mockResolvedValueOnce([
+      { request: { identifier: 'alarm:early:강남' } },
+    ]);
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set(['early:강남']));
+    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    // lastStationName은 매칭되어 갱신.
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+
+    handle.remove();
+  });
+
+  it('알림 수신 콜백이 reconcile을 호출한다', async () => {
+    mockAddListener.mockImplementationOnce((cb) => {
+      void cb({ request: { identifier: 'alarm:imminent:시청' } });
+      return { remove: jest.fn() };
+    });
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
+
+    const handle = registerScheduledAlarmListener();
+    await flushAsync();
+
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith(new Set(['imminent:시청']));
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('시청');
+
+    handle.remove();
+  });
+
+  it('AppState change "active" 진입 시 delivered 알람을 다시 drain한다', async () => {
+    let appStateHandler: ((state: string) => void) | undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(((event, cb) => {
+      if (event === 'change') appStateHandler = cb as (s: string) => void;
+      return { remove: jest.fn() };
+    }) as typeof AppState.addEventListener);
+    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+    mockGetPresented.mockResolvedValueOnce([
+      { request: { identifier: 'alarm:early:서울역' } },
+    ]);
+    appStateHandler!('active');
+    await flushAsync();
+
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('서울역');
+
+    handle.remove();
+  });
+
+  it('AppState change가 active가 아니면 drain하지 않는다', async () => {
+    let appStateHandler: ((state: string) => void) | undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(((event, cb) => {
+      if (event === 'change') appStateHandler = cb as (s: string) => void;
+      return { remove: jest.fn() };
+    }) as typeof AppState.addEventListener);
+    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+    mockGetPresented.mockClear();
+    appStateHandler!('background');
+    await flushAsync();
+
+    expect(mockGetPresented).not.toHaveBeenCalled();
+
+    handle.remove();
+  });
+
+  it('getPresentedNotificationsAsync가 던지면 error 로그를 남기고 계속한다', async () => {
+    mockGetPresented.mockRejectedValueOnce(new Error('os 오류'));
+    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockErrorSpy).toHaveBeenCalled();
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+
+    handle.remove();
+  });
+
+  it('중복 호출은 idempotent — 첫 핸들을 그대로 반환한다', async () => {
+    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
+
+    const h1 = registerScheduledAlarmListener();
+    const h2 = registerScheduledAlarmListener();
+
+    expect(h1).toBe(h2);
+    expect(mockAddListener).toHaveBeenCalledTimes(1);
+
+    h1.remove();
+  });
+});
+
+describe('awaitInitialScheduledAlarmDrain', () => {
+  it('리스너가 등록되지 않았으면 즉시 resolve한다', async () => {
+    await expect(awaitInitialScheduledAlarmDrain()).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -72,6 +72,8 @@ beforeEach(async () => {
   mockSetFiredAlarms.mockResolvedValue(undefined);
   mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
   mockGetPresented.mockResolvedValue([]);
+  // 모든 케이스 공통: addNotificationReceivedListener 기본 핸들. 콜백 캡쳐가 필요한 케이스는 mockImplementationOnce로 override.
+  mockAddListener.mockReturnValue({ remove: jest.fn() });
 });
 
 afterEach(() => {
@@ -101,18 +103,21 @@ describe('reconcileScheduledAlarmDelivery', () => {
 });
 
 describe('registerScheduledAlarmListener', () => {
+  function captureAppStateHandler(): { getHandler: () => (state: string) => void } {
+    let handler: ((state: string) => void) | undefined;
+    appStateSpy.mockImplementation(((event, cb) => {
+      if (event === 'change') handler = cb as (s: string) => void;
+      return { remove: jest.fn() };
+    }) as typeof AppState.addEventListener);
+    return { getHandler: () => handler! };
+  }
+
   it('등록 시점에 delivered 알람을 batch drain하고 fired set + last station을 한 번만 write한다', async () => {
     mockGetPresented.mockResolvedValueOnce([
       { request: { identifier: 'alarm:early:강남' } },
       { request: { identifier: 'current-station' } },
       { request: { identifier: 'alarm:imminent:강남' } },
     ]);
-    const notifRemove = jest.fn();
-    mockAddListener.mockReturnValueOnce({ remove: notifRemove });
-    const appStateRemove = jest.fn();
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockReturnValueOnce({ remove: appStateRemove } as ReturnType<typeof AppState.addEventListener>);
 
     const handle = registerScheduledAlarmListener();
     await awaitInitialScheduledAlarmDrain();
@@ -125,18 +130,10 @@ describe('registerScheduledAlarmListener', () => {
     expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
 
     handle.remove();
-    expect(notifRemove).toHaveBeenCalled();
-    expect(appStateRemove).toHaveBeenCalled();
   });
 
   it('drain에 매칭되는 alarm이 없으면 write를 생략한다', async () => {
-    mockGetPresented.mockResolvedValueOnce([
-      { request: { identifier: 'current-station' } },
-    ]);
-    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
+    mockGetPresented.mockResolvedValueOnce([{ request: { identifier: 'current-station' } }]);
 
     const handle = registerScheduledAlarmListener();
     await awaitInitialScheduledAlarmDrain();
@@ -148,14 +145,8 @@ describe('registerScheduledAlarmListener', () => {
   });
 
   it('이미 fired set에 있는 키는 firedChanged를 트리거하지 않는다', async () => {
-    mockGetPresented.mockResolvedValueOnce([
-      { request: { identifier: 'alarm:early:강남' } },
-    ]);
+    mockGetPresented.mockResolvedValueOnce([{ request: { identifier: 'alarm:early:강남' } }]);
     mockGetFiredAlarms.mockResolvedValueOnce(new Set(['early:강남']));
-    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
 
     const handle = registerScheduledAlarmListener();
     await awaitInitialScheduledAlarmDrain();
@@ -172,9 +163,6 @@ describe('registerScheduledAlarmListener', () => {
       void cb({ request: { identifier: 'alarm:imminent:시청' } });
       return { remove: jest.fn() };
     });
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
 
     const handle = registerScheduledAlarmListener();
     await flushAsync();
@@ -186,19 +174,12 @@ describe('registerScheduledAlarmListener', () => {
   });
 
   it('AppState change "active" 진입 시 delivered 알람을 다시 drain한다', async () => {
-    let appStateHandler: ((state: string) => void) | undefined;
-    jest.spyOn(AppState, 'addEventListener').mockImplementation(((event, cb) => {
-      if (event === 'change') appStateHandler = cb as (s: string) => void;
-      return { remove: jest.fn() };
-    }) as typeof AppState.addEventListener);
-    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+    const cap = captureAppStateHandler();
 
     const handle = registerScheduledAlarmListener();
     await awaitInitialScheduledAlarmDrain();
-    mockGetPresented.mockResolvedValueOnce([
-      { request: { identifier: 'alarm:early:서울역' } },
-    ]);
-    appStateHandler!('active');
+    mockGetPresented.mockResolvedValueOnce([{ request: { identifier: 'alarm:early:서울역' } }]);
+    cap.getHandler()('active');
     await flushAsync();
 
     expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('서울역');
@@ -207,17 +188,12 @@ describe('registerScheduledAlarmListener', () => {
   });
 
   it('AppState change가 active가 아니면 drain하지 않는다', async () => {
-    let appStateHandler: ((state: string) => void) | undefined;
-    jest.spyOn(AppState, 'addEventListener').mockImplementation(((event, cb) => {
-      if (event === 'change') appStateHandler = cb as (s: string) => void;
-      return { remove: jest.fn() };
-    }) as typeof AppState.addEventListener);
-    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
+    const cap = captureAppStateHandler();
 
     const handle = registerScheduledAlarmListener();
     await awaitInitialScheduledAlarmDrain();
     mockGetPresented.mockClear();
-    appStateHandler!('background');
+    cap.getHandler()('background');
     await flushAsync();
 
     expect(mockGetPresented).not.toHaveBeenCalled();
@@ -227,10 +203,6 @@ describe('registerScheduledAlarmListener', () => {
 
   it('getPresentedNotificationsAsync가 던지면 error 로그를 남기고 계속한다', async () => {
     mockGetPresented.mockRejectedValueOnce(new Error('os 오류'));
-    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
 
     const handle = registerScheduledAlarmListener();
     await awaitInitialScheduledAlarmDrain();
@@ -242,11 +214,6 @@ describe('registerScheduledAlarmListener', () => {
   });
 
   it('중복 호출은 idempotent — 첫 핸들을 그대로 반환한다', async () => {
-    mockAddListener.mockReturnValueOnce({ remove: jest.fn() });
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockReturnValueOnce({ remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>);
-
     const h1 = registerScheduledAlarmListener();
     const h2 = registerScheduledAlarmListener();
 

--- a/src/utils/alarmScheduler.ts
+++ b/src/utils/alarmScheduler.ts
@@ -22,6 +22,27 @@ export function scheduledAlarmIdentifier(event: Pick<AlarmEvent, 'phaseId' | 'st
   return `${SCHEDULED_ALARM_PREFIX}${alarmKey(event)}`;
 }
 
+export interface ParsedScheduledAlarmIdentifier {
+  phaseId: string;
+  stationName: string;
+}
+
+/**
+ * scheduledAlarmIdentifier()의 역연산. prefix가 다르거나 phaseId/stationName이 비어 있으면 null.
+ * 사전 예약 알람을 OS에서 수신했을 때 phase/역 정보를 복원하는 유일한 경로다.
+ */
+export function parseScheduledAlarmIdentifier(
+  identifier: string,
+): ParsedScheduledAlarmIdentifier | null {
+  if (!identifier.startsWith(SCHEDULED_ALARM_PREFIX)) return null;
+  const rest = identifier.slice(SCHEDULED_ALARM_PREFIX.length);
+  const colon = rest.indexOf(':');
+  if (colon <= 0) return null;
+  const stationName = rest.slice(colon + 1);
+  if (!stationName) return null;
+  return { phaseId: rest.slice(0, colon), stationName };
+}
+
 export interface ScheduledAlarm {
   identifier: string;
   event: AlarmEvent;

--- a/src/utils/notificationState.ts
+++ b/src/utils/notificationState.ts
@@ -1,5 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { LAST_NOTIFIED_STATION_KEY, FIRED_ALARMS_KEY } from '../constants/storageKeys';
+import {
+  LAST_NOTIFIED_STATION_KEY,
+  FIRED_ALARMS_KEY,
+  LAST_FIRED_ALARM_STATION_NAME_KEY,
+} from '../constants/storageKeys';
 import { createLogger } from './logger';
 
 // Foreground/Background 양쪽에서 호출되는 알림 상태 저장소.
@@ -68,4 +72,14 @@ export function setFiredAlarms(keys: Set<string>): Promise<void> {
 
 export function clearFiredAlarms(): Promise<void> {
   return safeRemoveItem(FIRED_ALARMS_KEY);
+}
+
+// 사전 예약 alarm: 발화 시 갱신되는 마지막 발화 역 이름.
+// id 기반 LAST_NOTIFIED_STATION_KEY와 분리한다(storageKeys.ts 주석 참고).
+export function getLastFiredAlarmStationName(): Promise<string | null> {
+  return safeGetItem(LAST_FIRED_ALARM_STATION_NAME_KEY);
+}
+
+export function setLastFiredAlarmStationName(name: string): Promise<void> {
+  return safeSetItem(LAST_FIRED_ALARM_STATION_NAME_KEY, name);
 }

--- a/src/utils/scheduledAlarmReceiver.ts
+++ b/src/utils/scheduledAlarmReceiver.ts
@@ -1,0 +1,112 @@
+import * as Notifications from 'expo-notifications';
+import { AppState, type AppStateStatus } from 'react-native';
+import { parseScheduledAlarmIdentifier } from './alarmScheduler';
+import {
+  getFiredAlarms,
+  setFiredAlarms,
+  setLastFiredAlarmStationName,
+} from './notificationState';
+import { createLogger } from './logger';
+
+const logger = createLogger('ScheduledAlarmReceiver');
+
+/**
+ * 사전 예약된 `alarm:` 알림이 OS에 의해 발사된 직후 클라이언트 상태를 갱신한다.
+ * 사전 예약 알람은 클라이언트 콜백을 거치지 않으므로(`alarmScheduler.ts`), 이 함수가
+ * FG/BG 양쪽 발화 모두에 대한 상태 동기화 단일 진입점이다.
+ *
+ * - FIRED_ALARMS_KEY에 `phaseId:stationName` 추가 → FG 복귀 시 useStationAlarm 하이드레이션이
+ *   해당 phase를 이미 발화된 것으로 간주해 중복 발화를 막는다.
+ * - LAST_FIRED_ALARM_STATION_NAME_KEY를 해당 역 이름으로 갱신 → BGAppRefreshTask가
+ *   다음 사이클에서 Arrival API를 올바른 기준역으로 호출.
+ */
+export async function reconcileScheduledAlarmDelivery(identifier: string): Promise<void> {
+  const parsed = parseScheduledAlarmIdentifier(identifier);
+  if (!parsed) return;
+
+  const fired = await getFiredAlarms();
+  fired.add(`${parsed.phaseId}:${parsed.stationName}`);
+  await setFiredAlarms(fired);
+  await setLastFiredAlarmStationName(parsed.stationName);
+}
+
+/**
+ * presented tray에 남아있는 사전 예약 알람들을 일괄 reconcile한다.
+ * fired set은 한 번 read해서 누적 후 한 번만 write — N번 round-trip 회피.
+ */
+async function drainDeliveredScheduledAlarms(): Promise<void> {
+  let presented: Notifications.Notification[];
+  try {
+    presented = await Notifications.getPresentedNotificationsAsync();
+  } catch (e) {
+    logger.error('delivered 알람 조회 실패:', e);
+    return;
+  }
+
+  const fired = await getFiredAlarms();
+  let lastStationName: string | null = null;
+  let firedChanged = false;
+  for (const n of presented) {
+    const parsed = parseScheduledAlarmIdentifier(n.request.identifier);
+    if (!parsed) continue;
+    const key = `${parsed.phaseId}:${parsed.stationName}`;
+    if (!fired.has(key)) {
+      fired.add(key);
+      firedChanged = true;
+    }
+    lastStationName = parsed.stationName;
+  }
+  if (firedChanged) await setFiredAlarms(fired);
+  if (lastStationName) await setLastFiredAlarmStationName(lastStationName);
+}
+
+export interface ScheduledAlarmListenerHandle {
+  remove: () => void;
+}
+
+let registered: ScheduledAlarmListenerHandle | null = null;
+let initialDrainPromise: Promise<void> | null = null;
+
+/**
+ * 마운트 시점에 시작된 첫 drain의 완료 Promise.
+ * useStationAlarm 하이드레이션이 firedAlarms를 읽기 전에 이 promise를 await해서
+ * cold start 직후 drain ↔ hydration race로 인한 중복 발화를 막는다.
+ * 리스너가 아직 등록되지 않은 경우 즉시 resolve.
+ */
+export function awaitInitialScheduledAlarmDrain(): Promise<void> {
+  return initialDrainPromise ?? Promise.resolve();
+}
+
+/**
+ * 사전 예약 `alarm:` 알림 수신 리스너 등록. 멱등 — 중복 호출은 첫 핸들을 그대로 반환한다.
+ *
+ * 두 발화 경로를 모두 커버한다:
+ * 1) FG 수신 — addNotificationReceivedListener가 즉시 reconcile.
+ * 2) BG 발사 후 FG 복귀 — AppState 'active' 진입 시 delivered tray를 drain.
+ *    (addNotificationReceivedListener는 BG 발화분을 replay하지 않음.)
+ * 등록 시점에도 1회 drain해 콜드 스타트 직전에 발사된 알람을 흡수한다.
+ */
+export function registerScheduledAlarmListener(): ScheduledAlarmListenerHandle {
+  if (registered) return registered;
+
+  initialDrainPromise = drainDeliveredScheduledAlarms();
+
+  const notifSub = Notifications.addNotificationReceivedListener((notification) => {
+    void reconcileScheduledAlarmDelivery(notification.request.identifier);
+  });
+
+  const onAppStateChange = (state: AppStateStatus): void => {
+    if (state === 'active') void drainDeliveredScheduledAlarms();
+  };
+  const appStateSub = AppState.addEventListener('change', onAppStateChange);
+
+  registered = {
+    remove: () => {
+      notifSub.remove();
+      appStateSub.remove();
+      registered = null;
+      initialDrainPromise = null;
+    },
+  };
+  return registered;
+}


### PR DESCRIPTION
## Summary
- `scheduledAlarmReceiver` 신규 — `addNotificationReceivedListener` + AppState `active` drain으로 OS 발사된 사전 예약 알람을 클라이언트 상태에 reconcile. `FIRED_ALARMS_KEY` 갱신으로 FG 복귀 시 중복 발화 차단.
- 새 storage key `LAST_FIRED_ALARM_STATION_NAME_KEY` — 동명이역(同名異驛) id 매핑 문제를 회피하기 위해 name 기반으로 마지막 발화 역을 분리 저장. `alarmRefreshTask`가 다음 사이클 Arrival API 기준역을 정확히 찾음.
- `parseScheduledAlarmIdentifier`를 `alarmScheduler.ts`로 통합 — `SCHEDULED_ALARM_PREFIX` 단일 출처.
- `awaitInitialScheduledAlarmDrain()` Promise export — `useStationAlarm` 하이드레이션이 drain 완료 후 `getFiredAlarms()`를 읽어 cold start race 차단.
- `drainDeliveredScheduledAlarms`는 단일 read → 누적 → 단일 write로 batch 처리. 모듈 스코프 singleton 가드로 Fast Refresh 시 중복 등록 방지.

Closes #371

## Test plan
- [x] `npm test` — 1279 tests pass, 100% coverage
- [x] `npm run type-check` — pass
- [x] code-review 1차/2차 통과 (P1 3건 + P2 2건 모두 반영, 신규 결함 없음)
- [ ] 실기기 검증: 트립 시작 → 백그라운드 → 사전 예약 알람 발사 → FG 복귀 시 동일 phase 재발화 없는지 확인
- [ ] BGAppRefresh 발화 후 Arrival API가 마지막 발화 역 기준으로 호출되는지 로그 확인