### PR TITLE
feat(#373): trainCode lock-in 측정 인프라

### DIFF
--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -19,3 +19,4 @@ export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';
 export const ALARM_LOG_KEY = 'subway-now:alarm-log';
 export const APNS_TOKEN_KEY = 'subway-now:apns-token';
 export const ACTIVE_TRIP_KEY = 'subway-now:active-trip';
+export const TRIP_TRAIN_CODE_KEY = 'subway-now:trip-train-code';

--- a/src/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/hooks/__tests__/useScheduledAlarms.test.ts
@@ -1,11 +1,13 @@
 import { renderHook } from '@testing-library/react-native';
 import { act } from 'react';
 import { AppState } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useScheduledAlarms } from '../useScheduledAlarms';
 import {
   scheduleAlarmsForRoute,
   cancelScheduledAlarms,
 } from '../../utils/alarmScheduler';
+import { TRIP_TRAIN_CODE_KEY } from '../../constants/storageKeys';
 import type { DirectRoute } from '../../utils/stationRoute';
 import type { Station } from '../../types/station';
 import type { StationArrival } from '../../api/arrivalApi';
@@ -42,6 +44,15 @@ const DESTINATION: Station = {
   lat: 37.5,
   lng: 127.0,
   lineColor: '#000',
+};
+
+// Line 1 fixtures — 방향 판정 테스트 공유. 같은 stations.json ordinal 위에서 up/down을 모두 표현.
+const LINE_1_ROUTE: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+const SEOUL_STATION: Station = {
+  id: '1-034', name: '서울역', line: '1', lat: 37.55, lng: 126.97, lineColor: '#0052A4',
+};
+const SOYOSAN: Station = {
+  id: '1-001', name: '소요산', line: '1', lat: 37.95, lng: 127.06, lineColor: '#0052A4',
 };
 const ARRIVAL: StationArrival = {
   up: [
@@ -81,13 +92,15 @@ async function flush(): Promise<void> {
 }
 
 describe('useScheduledAlarms', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     appStateCallback = null;
     mockedSchedule.mockResolvedValue([]);
     mockedCancel.mockResolvedValue();
     // 초기 AppState는 active로 가정 — RN 기본값.
     (AppState as { currentState: string }).currentState = 'active';
+    // trainCode lock-in 잔여 상태가 다음 테스트로 누수되지 않도록 정리.
+    await AsyncStorage.removeItem(TRIP_TRAIN_CODE_KEY);
   });
 
   it('마운트 시 active 상태면 cancel만 호출되고 schedule은 호출되지 않는다', async () => {
@@ -479,6 +492,103 @@ describe('useScheduledAlarms', () => {
     expect(mockedSchedule).toHaveBeenCalledWith(
       expect.objectContaining({ currentStationApproachEtaSeconds: 300 }),
     );
+  });
+
+  it('lock-in: 첫 reschedule에서 destinationId + 사용자 방향 첫 trainCode를 저장한다', async () => {
+    renderHook(() =>
+      useScheduledAlarms({
+        route: LINE_1_ROUTE,
+        destination: SEOUL_STATION,
+        currentStation: SOYOSAN,
+        arrival: ARRIVAL,
+      }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY)).toBe('1-034:D1');
+  });
+
+  it('lock-in: FG(active) 상태에서도 lock-in을 캡처한다 — schedule만 skip', async () => {
+    // 초기 AppState = active. background 전환 없이 마운트 → 입력 변동 effect 1회만 작동.
+    renderHook(() =>
+      useScheduledAlarms({
+        route: LINE_1_ROUTE,
+        destination: SEOUL_STATION,
+        currentStation: SOYOSAN,
+        arrival: ARRIVAL,
+      }),
+    );
+    await flush();
+
+    expect(await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY)).toBe('1-034:D1');
+    expect(mockedSchedule).not.toHaveBeenCalled(); // active 상태 → schedule은 skip
+  });
+
+  it('lock-in: 다음 reschedule은 저장된 trainCode를 사용해 결정론적 ETA 채택', async () => {
+    // 미리 lock-in된 trainCode가 있는 상태에서 시작 (같은 destinationId)
+    await AsyncStorage.setItem(TRIP_TRAIN_CODE_KEY, '1-034:D1');
+
+    // 새 arrival에서 D1은 99초, 같은 방향에 더 빠른 D2(50초) 등장 — D1을 채택해야 함
+    const NEXT: StationArrival = {
+      up: [{ ...ARRIVAL.up[0], trainCode: 'U2', arrivalSeconds: 30 }],
+      down: [
+        { ...ARRIVAL.down[0], trainCode: 'D1', arrivalSeconds: 99 },
+        { ...ARRIVAL.down[0], trainCode: 'D2', arrivalSeconds: 50 },
+      ],
+    };
+
+    renderHook(() =>
+      useScheduledAlarms({
+        route: LINE_1_ROUTE,
+        destination: SEOUL_STATION,
+        currentStation: SOYOSAN,
+        arrival: NEXT,
+      }),
+    );
+    await flush();
+    await act(async () => {
+      appStateCallback?.('background');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ currentStationApproachEtaSeconds: 99 }),
+    );
+  });
+
+  it('destination이 변하면 trainCode lock을 클리어한다', async () => {
+    await AsyncStorage.setItem(TRIP_TRAIN_CODE_KEY, 'dest-1:OLD');
+    const OTHER_DEST: Station = { ...DESTINATION, id: 'dest-2', name: '잠실' };
+
+    const { rerender } = renderHook(
+      (props: { destination: Station }) =>
+        useScheduledAlarms({
+          route: ROUTE,
+          destination: props.destination,
+          currentStation: null,
+          arrival: ARRIVAL,
+        }),
+      { initialProps: { destination: DESTINATION } },
+    );
+    await flush();
+
+    // 처음 마운트에서 prevDest === initial dest 이므로 클리어되지 않음 — OLD 유지
+    expect(await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY)).toBe('dest-1:OLD');
+
+    // destination 변경 → 다음 reschedule에서 OLD 클리어. 이어서 새 트립의 lock-in 캡처가
+    // 같은 사이클에서 일어날 수 있으므로 raw 값을 null로 단정하지 말고, OLD 코드가
+    // 더 이상 dest-1로 접근되지 않는지를 검증한다.
+    rerender({ destination: OTHER_DEST });
+    await flush();
+
+    const raw = await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY);
+    expect(raw?.startsWith('dest-1:')).not.toBe(true);
   });
 
   it('scheduleAlarmsForRoute 실패는 background 전환 경로에서 throw하지 않는다', async () => {

--- a/src/hooks/useScheduledAlarms.ts
+++ b/src/hooks/useScheduledAlarms.ts
@@ -9,6 +9,10 @@ import {
 } from '../utils/alarmScheduler';
 import { pickNextArrival } from '../utils/nextArrivalPick';
 import { resolveTripDirection } from '../utils/tripDirection';
+import {
+  captureTripTrainCodeIfAbsent,
+  clearTripTrainCode,
+} from '../utils/tripTrainCode';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('useScheduledAlarms');
@@ -30,6 +34,10 @@ export interface UseScheduledAlarmsInputs {
  * - 백그라운드 중 입력 변동: 즉시 cancel → reschedule.
  * - route/destination이 null이면 항상 cancel만 수행 (route 종료).
  * - 언마운트: 모두 취소.
+ *
+ * trainCode lock-in(#373 PoC): 트립 시작 후 첫 valid arrival에서 사용자 방향
+ * 첫 trainCode를 저장. 이후 reschedule마다 같은 trainCode의 ETA를 우선 채택.
+ * 매칭 실패 시 방향별 min ETA fallback. destination 변경/제거 시 lock 클리어.
  */
 export function useScheduledAlarms({
   route,
@@ -42,6 +50,7 @@ export function useScheduledAlarms({
   const currentStationRef = useRef<Station | null>(currentStation);
   const arrivalRef = useRef<StationArrival | null>(arrival);
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+  const prevDestinationIdRef = useRef<string | null>(destination?.id ?? null);
 
   routeRef.current = route;
   destinationRef.current = destination;
@@ -49,18 +58,43 @@ export function useScheduledAlarms({
   arrivalRef.current = arrival;
 
   const reschedule = async (): Promise<void> => {
+    // destination 변경(또는 null화) 감지 → trainCode lock 클리어 후 진행.
+    // reschedule 내부에서 처리해 별도 effect와의 race 조건을 차단한다.
+    const currentDestination = destinationRef.current;
+    const currDestId = currentDestination?.id ?? null;
+    if (prevDestinationIdRef.current !== currDestId) {
+      prevDestinationIdRef.current = currDestId;
+      await clearTripTrainCode();
+    }
+
     await cancelScheduledAlarms();
     const currentRoute = routeRef.current;
-    const currentDestination = destinationRef.current;
     if (!currentRoute || !currentDestination) return;
-    if (appStateRef.current === 'active') return;
+
     // 진행 방향은 route + 현재역 ordinal로 결정한다 (#370). null이면 알 수 없음.
     // pickNextArrival에 filter로 전달해 반대방향 열차 ETA 오인을 차단.
     const here = currentStationRef.current;
     const direction = here
       ? resolveTripDirection(currentRoute, currentDestination.name, here.id)
       : null;
-    const pick = pickNextArrival(arrivalRef.current, direction);
+
+    // trainCode lock-in 캡처는 active/background와 무관하게 실행한다 — FG 첫 valid arrival에서도
+    // lock이 걸려야 BG 갱신이 결정론적 ETA를 사용한다.
+    const trainCode = await captureTripTrainCodeIfAbsent(
+      currentDestination.id,
+      arrivalRef.current,
+      direction,
+    );
+
+    if (appStateRef.current === 'active') return;
+
+    const pick = pickNextArrival(arrivalRef.current, direction, {
+      preferTrainCode: trainCode,
+    });
+    logger.debug(
+      `reschedule eta=${pick.etaSeconds} trainCode=${trainCode ?? 'none'} matched=${pick.matchedByTrainCode}`,
+    );
+
     await scheduleAlarmsForRoute({
       route: currentRoute,
       destinationName: currentDestination.name,

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -16,6 +16,8 @@ jest.mock('expo-background-task', () => ({
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
 }));
 
 const mockScheduleAlarmsForRoute = jest.fn();
@@ -77,7 +79,12 @@ function mockStorage(values: {
   destination?: unknown;
   route?: unknown;
   lastStation?: string | null;
+  tripTrainCode?: string | null;
 }) {
+  const destId =
+    typeof values.destination === 'object' && values.destination && 'id' in values.destination
+      ? (values.destination as { id: string }).id
+      : 'station-2';
   const map: Record<string, string | null> = {
     'subway-now:destination':
       values.destination === undefined
@@ -88,10 +95,16 @@ function mockStorage(values: {
     'subway-now:route':
       values.route === undefined ? null : JSON.stringify(values.route),
     'subway-now:last-notified-station': values.lastStation ?? null,
+    // tripTrainCode는 destinationId:code 형식으로 저장됨
+    'subway-now:trip-train-code': values.tripTrainCode
+      ? `${destId}:${values.tripTrainCode}`
+      : null,
   };
   (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
     Promise.resolve(key in map ? map[key] : null),
   );
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
 }
 
 const EMPTY_STAMP = {
@@ -250,6 +263,68 @@ describe('alarmRefreshTask', () => {
       await getCallback()();
       expect(mockFetchArrivalInfo).toHaveBeenCalledWith('시청');
       expectSchedulerCalledWith(500);
+    });
+
+    it('lock-in: trainCode가 저장되어 있지 않으면 첫 arrival의 방향-필터 trainCode를 저장한다', async () => {
+      // 종로3가(idx 2) → 시청(idx 0): up 방향
+      mockStorage({ destination, route, lastStation: 'station-4', tripTrainCode: null });
+      mockFetchArrivalInfo.mockResolvedValue({
+        up: [{ arrivalSeconds: 240, trainCode: 'T-UP-1' }],
+        down: [{ arrivalSeconds: 30, trainCode: 'T-DN-1' }],
+      });
+      await getCallback()();
+      // destination(station-2)의 id를 prefix로 저장. up 방향 min ETA의 trainCode 채택.
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        'subway-now:trip-train-code',
+        'station-2:T-UP-1',
+      );
+    });
+
+    it('lock-in: 저장된 trainCode가 있으면 같은 코드의 ETA를 결정론적으로 채택한다', async () => {
+      mockStorage({
+        destination,
+        route,
+        lastStation: 'station-4',
+        tripTrainCode: 'T-UP-1',
+      });
+      // 새 응답: T-UP-1은 180초, 같은 방향에 더 빠른 T-UP-2(50초) 도착 — T-UP-1 채택
+      mockFetchArrivalInfo.mockResolvedValue({
+        up: [
+          { arrivalSeconds: 180, trainCode: 'T-UP-1' },
+          { arrivalSeconds: 50, trainCode: 'T-UP-2' },
+        ],
+        down: [{ arrivalSeconds: 30, trainCode: 'T-DN-1' }],
+      });
+      await getCallback()();
+      expectSchedulerCalledWith(180, { direction: 'up', usedTrainCode: 'T-UP-1' });
+      // 이미 저장된 코드라 trip-train-code key로 다시 setItem 호출하지 않는다
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+        'subway-now:trip-train-code',
+        expect.anything(),
+      );
+    });
+
+    it('lock-in: 저장된 trainCode가 응답에 없으면 방향 fallback ETA 사용', async () => {
+      mockStorage({
+        destination,
+        route,
+        lastStation: 'station-4',
+        tripTrainCode: 'T-MISSING',
+      });
+      mockFetchArrivalInfo.mockResolvedValue({
+        up: [{ arrivalSeconds: 240, trainCode: 'T-UP-1' }],
+        down: [{ arrivalSeconds: 30, trainCode: 'T-DN-1' }],
+      });
+      await getCallback()();
+      // T-MISSING은 매치 실패 → up 방향 min = 240, trainCode=T-UP-1로 stamp
+      expectSchedulerCalledWith(240, { direction: 'up', usedTrainCode: 'T-UP-1' });
+    });
+
+    it('활성 트립이 없으면 저장된 trainCode를 클리어한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+      await getCallback()();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-train-code');
     });
 
     it('스케줄러가 throw 하면 Failed를 반환한다', async () => {

--- a/src/tasks/alarmRefreshTask.ts
+++ b/src/tasks/alarmRefreshTask.ts
@@ -6,6 +6,10 @@ import { getLastFiredAlarmStationName } from '../utils/notificationState';
 import { scheduleAlarmsForRoute } from '../utils/alarmScheduler';
 import { fetchArrivalInfo } from '../api/arrivalApi';
 import { pickNextArrival, type NextArrivalPick } from '../utils/nextArrivalPick';
+import {
+  captureTripTrainCodeIfAbsent,
+  clearTripTrainCode,
+} from '../utils/tripTrainCode';
 import stationsData from '../data/stations.json';
 import type { Station } from '../types/station';
 import type { Route } from '../utils/stationRoute';
@@ -61,6 +65,8 @@ TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
   try {
     const active = await readActiveTrip();
     if (!active) {
+      // 활성 트립이 없으면 lock-in된 trainCode도 의미 없음 — 정리.
+      await clearTripTrainCode();
       logger.info('활성 트립 없음 — 스킵');
       return BackgroundTask.BackgroundTaskResult.Success;
     }
@@ -70,11 +76,22 @@ TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
     const direction = currentStation
       ? resolveTripDirection(active.route, active.destination.name, currentStation.id)
       : null;
-    let pick: NextArrivalPick = { etaSeconds: null, direction: null, trainCode: null };
+    let pick: NextArrivalPick = {
+      etaSeconds: null,
+      direction: null,
+      trainCode: null,
+      matchedByTrainCode: false,
+    };
     if (currentStation) {
       try {
         const arrivals = await fetchArrivalInfo(currentStation.name);
-        pick = pickNextArrival(arrivals, direction);
+        // trainCode lock-in: 저장된 코드가 없으면 첫 valid arrival의 방향-필터 picker로 캡처.
+        const trainCode = await captureTripTrainCodeIfAbsent(
+          active.destination.id,
+          arrivals,
+          direction,
+        );
+        pick = pickNextArrival(arrivals, direction, { preferTrainCode: trainCode });
       } catch (e) {
         logger.warn('Arrival API 호출 실패 — static ETA fallback:', e);
       }
@@ -87,7 +104,9 @@ TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
       // stamp.direction은 의도(filter)를 기록 — pick.direction(추론된 list)이 아닌 route-resolved.
       stamp: { direction, usedTrainCode: pick.trainCode },
     });
-    logger.info('알람 사전 예약 갱신 완료');
+    logger.info(
+      `알람 사전 예약 갱신 완료 — eta=${pick.etaSeconds} matched=${pick.matchedByTrainCode}`,
+    );
     return BackgroundTask.BackgroundTaskResult.Success;
   } catch (e) {
     logger.error('알람 갱신 태스크 실패:', e);

--- a/src/utils/__tests__/nextArrivalPick.test.ts
+++ b/src/utils/__tests__/nextArrivalPick.test.ts
@@ -1,28 +1,21 @@
 import { pickNextArrival } from '../nextArrivalPick';
 import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
+import { makeArrivalInfo } from '../../testUtils/fixtures';
 
-function info(overrides: Partial<ArrivalInfo>): ArrivalInfo {
-  return {
-    destination: 'D',
-    arrivalMinutes: 0,
-    arrivalSeconds: 100,
-    statusMessage: '',
-    trainCode: 'T-1',
-    receivedAtMs: 0,
-    arrivalCode: -1,
-    isLastTrain: false,
-    trainType: 'normal',
-    ...overrides,
-  };
+function info(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
+  return makeArrivalInfo({ destination: 'D', arrivalSeconds: 100, trainCode: 'T-1', ...overrides });
 }
+
+const EMPTY = {
+  etaSeconds: null,
+  direction: null,
+  trainCode: null,
+  matchedByTrainCode: false,
+};
 
 describe('pickNextArrival', () => {
   it('arrival이 null이면 모두 null', () => {
-    expect(pickNextArrival(null)).toEqual({
-      etaSeconds: null,
-      direction: null,
-      trainCode: null,
-    });
+    expect(pickNextArrival(null)).toEqual(EMPTY);
   });
 
   it('isMock=true면 모두 null', () => {
@@ -31,11 +24,7 @@ describe('pickNextArrival', () => {
       down: [],
       isMock: true,
     };
-    expect(pickNextArrival(arrival)).toEqual({
-      etaSeconds: null,
-      direction: null,
-      trainCode: null,
-    });
+    expect(pickNextArrival(arrival)).toEqual(EMPTY);
   });
 
   it('up/down 양방향에서 가장 빠른 양수 arrivalSeconds를 선택한다', () => {
@@ -47,6 +36,7 @@ describe('pickNextArrival', () => {
       etaSeconds: 120,
       direction: 'down',
       trainCode: 'D1',
+      matchedByTrainCode: false,
     });
   });
 
@@ -62,6 +52,7 @@ describe('pickNextArrival', () => {
       etaSeconds: 80,
       direction: 'up',
       trainCode: 'U-soon',
+      matchedByTrainCode: false,
     });
   });
 
@@ -74,6 +65,7 @@ describe('pickNextArrival', () => {
       etaSeconds: 250,
       direction: 'down',
       trainCode: 'D-only',
+      matchedByTrainCode: false,
     });
   });
 
@@ -82,11 +74,7 @@ describe('pickNextArrival', () => {
       up: [info({ arrivalSeconds: 0 })],
       down: [info({ arrivalSeconds: -1 })],
     };
-    expect(pickNextArrival(arrival)).toEqual({
-      etaSeconds: null,
-      direction: null,
-      trainCode: null,
-    });
+    expect(pickNextArrival(arrival)).toEqual(EMPTY);
   });
 
   it('trainCode가 빈 문자열이면 null로 변환한다', () => {
@@ -98,6 +86,7 @@ describe('pickNextArrival', () => {
       etaSeconds: 100,
       direction: 'up',
       trainCode: null,
+      matchedByTrainCode: false,
     });
   });
 
@@ -110,6 +99,7 @@ describe('pickNextArrival', () => {
       etaSeconds: 240,
       direction: 'up',
       trainCode: 'U-real',
+      matchedByTrainCode: false,
     });
   });
 
@@ -122,6 +112,7 @@ describe('pickNextArrival', () => {
       etaSeconds: 180,
       direction: 'down',
       trainCode: 'D-real',
+      matchedByTrainCode: false,
     });
   });
 
@@ -130,11 +121,7 @@ describe('pickNextArrival', () => {
       up: [info({ arrivalSeconds: 0 })],
       down: [info({ arrivalSeconds: 300, trainCode: 'D' })],
     };
-    expect(pickNextArrival(arrival, 'up')).toEqual({
-      etaSeconds: null,
-      direction: null,
-      trainCode: null,
-    });
+    expect(pickNextArrival(arrival, 'up')).toEqual(EMPTY);
   });
 
   it('isMock 필드가 없는 입력 형태({up,down}만)도 동작한다', () => {
@@ -146,6 +133,114 @@ describe('pickNextArrival', () => {
       etaSeconds: 60,
       direction: 'up',
       trainCode: 'fetch-T',
+      matchedByTrainCode: false,
+    });
+  });
+
+  describe('preferTrainCode (#373 lock-in)', () => {
+    const arrival: StationArrival = {
+      up: [
+        info({ arrivalSeconds: 180, trainCode: 'T-UP-1' }),
+        info({ arrivalSeconds: 50, trainCode: 'T-UP-2' }),
+      ],
+      down: [info({ arrivalSeconds: 30, trainCode: 'T-DN-1' })],
+    };
+
+    it('preferTrainCode가 매치되면 해당 ETA를 결정론적으로 채택하고 matchedByTrainCode=true', () => {
+      // 같은 방향에 더 빠른 T-UP-2(50초) 있어도 lock-in 코드 T-UP-1(180초)을 채택.
+      expect(pickNextArrival(arrival, 'up', { preferTrainCode: 'T-UP-1' })).toEqual({
+        etaSeconds: 180,
+        direction: 'up',
+        trainCode: 'T-UP-1',
+        matchedByTrainCode: true,
+      });
+    });
+
+    it('preferTrainCode 매치 실패 시 방향별 min ETA로 fallback (matchedByTrainCode=false)', () => {
+      expect(pickNextArrival(arrival, 'up', { preferTrainCode: 'T-MISSING' })).toEqual({
+        etaSeconds: 50,
+        direction: 'up',
+        trainCode: 'T-UP-2',
+        matchedByTrainCode: false,
+      });
+    });
+
+    it('preferTrainCode가 null이면 기본 min ETA 동작', () => {
+      expect(pickNextArrival(arrival, 'up', { preferTrainCode: null })).toEqual({
+        etaSeconds: 50,
+        direction: 'up',
+        trainCode: 'T-UP-2',
+        matchedByTrainCode: false,
+      });
+    });
+
+    it('preferTrainCode가 빈 문자열이면 기본 min ETA 동작 (truthy 체크)', () => {
+      expect(pickNextArrival(arrival, 'up', { preferTrainCode: '' })).toEqual({
+        etaSeconds: 50,
+        direction: 'up',
+        trainCode: 'T-UP-2',
+        matchedByTrainCode: false,
+      });
+    });
+
+    it('preferTrainCode 매치값이 stale 상한(1200초)을 초과하면 fallback', () => {
+      const stale: StationArrival = {
+        up: [
+          info({ arrivalSeconds: 1500, trainCode: 'T-UP-1' }), // 상한 초과 → 강등
+          info({ arrivalSeconds: 80, trainCode: 'T-UP-2' }),
+        ],
+        down: [],
+      };
+      expect(pickNextArrival(stale, 'up', { preferTrainCode: 'T-UP-1' })).toEqual({
+        etaSeconds: 80,
+        direction: 'up',
+        trainCode: 'T-UP-2',
+        matchedByTrainCode: false,
+      });
+    });
+
+    it('preferTrainCode 매치값이 정확히 상한(1200초)이면 채택', () => {
+      const boundary: StationArrival = {
+        up: [info({ arrivalSeconds: 1200, trainCode: 'T-UP-1' })],
+        down: [],
+      };
+      expect(pickNextArrival(boundary, 'up', { preferTrainCode: 'T-UP-1' })).toEqual({
+        etaSeconds: 1200,
+        direction: 'up',
+        trainCode: 'T-UP-1',
+        matchedByTrainCode: true,
+      });
+    });
+
+    it('preferTrainCode 매치값이 0 이하면 fallback', () => {
+      const expired: StationArrival = {
+        up: [
+          info({ arrivalSeconds: 0, trainCode: 'T-UP-1' }), // 진입/통과 — 후보 제외
+          info({ arrivalSeconds: 90, trainCode: 'T-UP-2' }),
+        ],
+        down: [],
+      };
+      expect(pickNextArrival(expired, 'up', { preferTrainCode: 'T-UP-1' })).toEqual({
+        etaSeconds: 90,
+        direction: 'up',
+        trainCode: 'T-UP-2',
+        matchedByTrainCode: false,
+      });
+    });
+
+    it('filterDirection이 null이면 양방향에서 preferTrainCode 매치 시도', () => {
+      // direction null → up/down 둘 다 검색. T-DN-1이 down에 있어도 매치.
+      expect(pickNextArrival(arrival, null, { preferTrainCode: 'T-DN-1' })).toEqual({
+        etaSeconds: 30,
+        direction: 'down',
+        trainCode: 'T-DN-1',
+        matchedByTrainCode: true,
+      });
+    });
+
+    it('preferTrainCode + isMock=true면 모두 null (mock 우선 차단)', () => {
+      const mock: StationArrival = { ...arrival, isMock: true };
+      expect(pickNextArrival(mock, 'up', { preferTrainCode: 'T-UP-1' })).toEqual(EMPTY);
     });
   });
 });

--- a/src/utils/__tests__/tripTrainCode.test.ts
+++ b/src/utils/__tests__/tripTrainCode.test.ts
@@ -1,0 +1,134 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  captureTripTrainCodeIfAbsent,
+  clearTripTrainCode,
+  getStoredTripTrainCode,
+  setTripTrainCode,
+} from '../tripTrainCode';
+import { TRIP_TRAIN_CODE_KEY } from '../../constants/storageKeys';
+import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+import { makeArrivalInfo } from '../../testUtils/fixtures';
+
+function info(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
+  return makeArrivalInfo({ destination: 'D', arrivalSeconds: 100, trainCode: 'T-1', ...overrides });
+}
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe('tripTrainCode', () => {
+  beforeEach(async () => {
+    await AsyncStorage.removeItem(TRIP_TRAIN_CODE_KEY);
+    jest.restoreAllMocks();
+  });
+
+  it('set → get 라운드트립 (같은 destinationId)', async () => {
+    await setTripTrainCode('dest-1', 'T1234');
+    expect(await getStoredTripTrainCode('dest-1')).toBe('T1234');
+  });
+
+  it('다른 destinationId로 get하면 null — 다른 트립의 lock은 자동 거부', async () => {
+    await setTripTrainCode('dest-1', 'T1234');
+    expect(await getStoredTripTrainCode('dest-2')).toBeNull();
+  });
+
+  it('clear 이후에는 null', async () => {
+    await setTripTrainCode('dest-1', 'T1234');
+    await clearTripTrainCode();
+    expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+  });
+
+  it('저장된 값이 없으면 null', async () => {
+    expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+  });
+
+  it('seprator가 없는 잘못된 형식이면 null', async () => {
+    await AsyncStorage.setItem(TRIP_TRAIN_CODE_KEY, 'malformed-no-separator');
+    expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+  });
+
+  it('seprator가 첫 문자면 destinationId가 빈 문자열 → null', async () => {
+    await AsyncStorage.setItem(TRIP_TRAIN_CODE_KEY, ':T1234');
+    expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+  });
+
+  it('trainCode가 빈 문자열이면 null', async () => {
+    await AsyncStorage.setItem(TRIP_TRAIN_CODE_KEY, 'dest-1:');
+    expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+  });
+
+  it('AsyncStorage.getItem 실패 시 null로 안전 폴백', async () => {
+    jest
+      .spyOn(AsyncStorage, 'getItem')
+      .mockRejectedValueOnce(new Error('storage error'));
+    expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+  });
+
+  it('AsyncStorage.setItem 실패 시 throw하지 않는다', async () => {
+    jest
+      .spyOn(AsyncStorage, 'setItem')
+      .mockRejectedValueOnce(new Error('storage error'));
+    await expect(setTripTrainCode('dest-1', 'T1')).resolves.toBeUndefined();
+  });
+
+  it('AsyncStorage.removeItem 실패 시 throw하지 않는다', async () => {
+    jest
+      .spyOn(AsyncStorage, 'removeItem')
+      .mockRejectedValueOnce(new Error('storage error'));
+    await expect(clearTripTrainCode()).resolves.toBeUndefined();
+  });
+
+  describe('captureTripTrainCodeIfAbsent', () => {
+    const arrival: StationArrival = {
+      up: [info({ arrivalSeconds: 240, trainCode: 'T-UP' })],
+      down: [info({ arrivalSeconds: 30, trainCode: 'T-DN' })],
+    };
+
+    it('저장된 코드가 있으면 그대로 반환하고 setItem 호출하지 않는다', async () => {
+      await setTripTrainCode('dest-1', 'EXISTING');
+      const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+      setSpy.mockClear();
+      const result = await captureTripTrainCodeIfAbsent('dest-1', arrival, 'up');
+      expect(result).toBe('EXISTING');
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('저장된 코드가 없으면 방향-필터 min-ETA trainCode를 캡처해 저장한다', async () => {
+      const result = await captureTripTrainCodeIfAbsent('dest-1', arrival, 'up');
+      expect(result).toBe('T-UP');
+      expect(await getStoredTripTrainCode('dest-1')).toBe('T-UP');
+    });
+
+    it('arrival이 null이면 캡처 후보 없음 → null 반환, 저장 안 함', async () => {
+      const result = await captureTripTrainCodeIfAbsent('dest-1', null, 'up');
+      expect(result).toBeNull();
+      expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+    });
+
+    it('해당 방향에 양수 후보가 없으면 null 반환, 저장 안 함', async () => {
+      const empty: StationArrival = {
+        up: [info({ arrivalSeconds: 0, trainCode: 'T-UP' })],
+        down: [info({ arrivalSeconds: 100, trainCode: 'T-DN' })],
+      };
+      const result = await captureTripTrainCodeIfAbsent('dest-1', empty, 'up');
+      expect(result).toBeNull();
+      expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+    });
+
+    it('picker의 trainCode가 빈 문자열이면 null 반환, 저장 안 함', async () => {
+      const blank: StationArrival = {
+        up: [info({ arrivalSeconds: 100, trainCode: '' })],
+        down: [],
+      };
+      const result = await captureTripTrainCodeIfAbsent('dest-1', blank, 'up');
+      expect(result).toBeNull();
+      expect(await getStoredTripTrainCode('dest-1')).toBeNull();
+    });
+  });
+});

--- a/src/utils/nextArrivalPick.ts
+++ b/src/utils/nextArrivalPick.ts
@@ -7,32 +7,80 @@ export interface NextArrivalPick {
   etaSeconds: number | null;
   direction: 'up' | 'down' | null;
   trainCode: string | null;
+  /** preferTrainCode 매치로 결정론적 ETA를 채택했는지 (#373 PoC 측정용). */
+  matchedByTrainCode: boolean;
 }
 
 const EMPTY_PICK: NextArrivalPick = {
   etaSeconds: null,
   direction: null,
   trainCode: null,
+  matchedByTrainCode: false,
 };
 
 /**
+ * trainCode 매치가 비현실적으로 큰 값을 반환했을 때 stale로 강등할 상한선.
+ * 서울 지하철 인접역 평균 ETA의 ~12배. 이 이상이면 진입 신호로 보기 어렵다.
+ */
+const MAX_PLAUSIBLE_APPROACH_SECONDS = 1200;
+
+export interface PickOptions {
+  /**
+   * #373 PoC: trainCode lock-in. 일치하는 trainCode의 ETA를 우선 채택한다.
+   * 매칭 실패 또는 상한 초과 시 방향별 min ETA로 fallback.
+   */
+  preferTrainCode?: string | null;
+}
+
+/**
  * 진행 방향 열차의 가장 빠른 양수 arrivalSeconds를 선택하고, 함께 방향/trainCode를 반환한다.
- * 사전 예약 알람의 ETA 선택(#370) + stamp(#372)에 공통 사용된다.
+ * 사전 예약 알람의 ETA 선택(#370) + stamp(#372) + trainCode lock-in(#373)에 공통 사용된다.
  *
  * `filterDirection`이 주어지면 그 방향 list만 검색한다 — 반대방향 열차 ETA 오인 회피(#370).
  * null이면 양방향 best-effort fallback (환상선/노선 이탈 등 방향 미판정 경계 케이스).
  *
- * isMock arrival은 명시적으로 null을 반환 — alarmScheduler의 staticETA fallback으로 위임.
+ * `options.preferTrainCode`가 주어지면 해당 trainCode를 가진 열차의 ETA를 우선 채택한다.
+ * 매칭 실패 시 기존 방식(방향별 min ETA)으로 fallback — 회귀 안전.
  *
- * 입력 형태가 두 가지(StationArrival, 또는 fetch 결과 {up, down})를 모두 수용하기 위해
- * isMock을 optional로 둔다.
+ * isMock arrival은 명시적으로 null을 반환 — alarmScheduler의 staticETA fallback으로 위임.
  */
 export function pickNextArrival(
   arrival: { up: ArrivalInfo[]; down: ArrivalInfo[]; isMock?: boolean } | null,
   filterDirection: 'up' | 'down' | null = null,
+  options?: PickOptions,
 ): NextArrivalPick {
   if (!arrival || arrival.isMock) return EMPTY_PICK;
   const directions = directionsToSearch(filterDirection);
+
+  const preferCode = options?.preferTrainCode ?? null;
+  if (preferCode) {
+    const matched = findByTrainCode(arrival, directions, preferCode);
+    if (matched) {
+      // preferCode가 truthy일 때만 진입하고, findByTrainCode가 string-equality로 매치하므로
+      // matched.info.trainCode는 항상 preferCode와 동일한 비어있지 않은 문자열이다.
+      return {
+        etaSeconds: matched.info.arrivalSeconds,
+        direction: matched.direction,
+        trainCode: matched.info.trainCode,
+        matchedByTrainCode: true,
+      };
+    }
+  }
+
+  const pick = pickMinEta(arrival, directions);
+  if (!pick) return EMPTY_PICK;
+  return {
+    etaSeconds: pick.info.arrivalSeconds,
+    direction: pick.direction,
+    trainCode: pick.info.trainCode || null,
+    matchedByTrainCode: false,
+  };
+}
+
+function pickMinEta(
+  arrival: { up: ArrivalInfo[]; down: ArrivalInfo[] },
+  directions: Array<'up' | 'down'>,
+): { info: ArrivalInfo; direction: 'up' | 'down' } | null {
   let pick: { info: ArrivalInfo; direction: 'up' | 'down' } | null = null;
   for (const direction of directions) {
     for (const info of arrival[direction]) {
@@ -42,12 +90,26 @@ export function pickNextArrival(
       }
     }
   }
-  if (!pick) return EMPTY_PICK;
-  return {
-    etaSeconds: pick.info.arrivalSeconds,
-    direction: pick.direction,
-    trainCode: pick.info.trainCode || null,
-  };
+  return pick;
+}
+
+function findByTrainCode(
+  arrival: { up: ArrivalInfo[]; down: ArrivalInfo[] },
+  directions: Array<'up' | 'down'>,
+  trainCode: string,
+): { info: ArrivalInfo; direction: 'up' | 'down' } | null {
+  for (const direction of directions) {
+    for (const info of arrival[direction]) {
+      if (
+        info.trainCode === trainCode &&
+        info.arrivalSeconds > 0 &&
+        info.arrivalSeconds <= MAX_PLAUSIBLE_APPROACH_SECONDS
+      ) {
+        return { info, direction };
+      }
+    }
+  }
+  return null;
 }
 
 function directionsToSearch(filter: 'up' | 'down' | null): Array<'up' | 'down'> {

--- a/src/utils/tripTrainCode.ts
+++ b/src/utils/tripTrainCode.ts
@@ -1,0 +1,82 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TRIP_TRAIN_CODE_KEY } from '../constants/storageKeys';
+import { pickNextArrival, type StationArrival } from './nextArrivalPick';
+import { createLogger } from './logger';
+
+const logger = createLogger('TripTrainCode');
+
+/**
+ * 한 트립 내내 추종할 열차 고유번호(btrainNo)를 destination id에 묶어 저장한다.
+ *
+ * 저장 형태: `${destinationId}:${trainCode}` — `:`로 1회 split해 구분.
+ * destinationId에 `:`가 들어와도 trainCode 쪽으로 흡수되어 매치는 영향받지 않는다.
+ *
+ * 라이프사이클:
+ *   - lock-in: 트립 시작 후 첫 valid arrival에서 사용자 방향 첫 trainCode를 destination과
+ *     함께 저장. 캡처는 active/background 상관없이 진행한다 — FG에서도 캡처되어야
+ *     PoC 측정 가치가 있음.
+ *   - 사용: get할 때 destinationId를 같이 넘기고, 저장된 destinationId가 일치할 때만
+ *     trainCode를 돌려준다. 다른 트립의 잔여 코드는 자동으로 무시된다.
+ *   - 클리어: destination 변경/제거 시, 또는 활성 트립 자체가 사라졌을 때.
+ */
+
+const SEPARATOR = ':';
+
+export async function getStoredTripTrainCode(
+  destinationId: string,
+): Promise<string | null> {
+  try {
+    const raw = await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY);
+    if (!raw) return null;
+    const sepIdx = raw.indexOf(SEPARATOR);
+    if (sepIdx <= 0) return null;
+    const storedDest = raw.slice(0, sepIdx);
+    if (storedDest !== destinationId) return null;
+    const code = raw.slice(sepIdx + 1);
+    return code || null;
+  } catch (e) {
+    logger.warn('읽기 실패:', e);
+    return null;
+  }
+}
+
+export async function setTripTrainCode(
+  destinationId: string,
+  code: string,
+): Promise<void> {
+  try {
+    await AsyncStorage.setItem(
+      TRIP_TRAIN_CODE_KEY,
+      `${destinationId}${SEPARATOR}${code}`,
+    );
+  } catch (e) {
+    logger.warn('저장 실패:', e);
+  }
+}
+
+export async function clearTripTrainCode(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(TRIP_TRAIN_CODE_KEY);
+  } catch (e) {
+    logger.warn('삭제 실패:', e);
+  }
+}
+
+/**
+ * destination에 저장된 trainCode가 있으면 그대로 반환. 없으면 현재 arrival에서 사용자 방향
+ * min-ETA 열차의 trainCode를 캡처해 저장한 뒤 반환. 캡처 후보가 없으면 null.
+ *
+ * useScheduledAlarms / alarmRefreshTask 양쪽이 같은 캡처 사이클을 공유한다.
+ */
+export async function captureTripTrainCodeIfAbsent(
+  destinationId: string,
+  arrival: StationArrival | null,
+  direction: 'up' | 'down' | null,
+): Promise<string | null> {
+  const existing = await getStoredTripTrainCode(destinationId);
+  if (existing) return existing;
+  const candidate = pickNextArrival(arrival, direction).trainCode;
+  if (!candidate) return null;
+  await setTripTrainCode(destinationId, candidate);
+  return candidate;
+}


### PR DESCRIPTION
## 무엇을

`trainCode` lock-in의 **측정 인프라** 슬라이스. *결정론적 ETA 전환*이 아니라, 매치율과 ETA 오차를 수집해 다음 캡처 정책을 데이터로 결정하기 위한 토대.

## 정확한 범위 (정직)

캡처 정책은 "트립 시작 시 사용자 방향 *min-ETA* 열차의 trainCode를 lock"이다. **사용자가 실제 탑승한 열차를 식별하지 않는다.** 사용자가 빠른 열차를 보내고 *느린* 열차에 탑승한 경우, lock은 빠른 열차를 잡고 그 열차의 ETA를 결정론적으로 추종 → 여전히 일찍 발사 가능.

본 PR이 **해결하지 않는 것** (의도적 명시):
- 본 사고(용마산→어린이대공원 3정거장 전 거짓 알람) — #370(A)이 이미 해결.
- Sibling failure(사용자가 느린 열차 탑승 시 같은 방향 min ETA 잘못 잡는 케이스) — 캡처 정책 한계로 본 PR에선 미차단.

## 변경

- `src/utils/tripTrainCode.ts` 신규 — destinationId에 묶인 lock 저장소. `${destId}:${code}` 포맷, indexOf(':') 1회 split. 다른 트립의 잔여 코드는 자동 무시.
- `src/utils/nextArrivalPick.ts` 확장 — `preferTrainCode` 옵션 + `matchedByTrainCode` 반환. 매치 우선, 매치 실패/상한(`MAX_PLAUSIBLE_APPROACH_SECONDS = 1200s`) 초과 시 방향별 min ETA fallback.
- `useScheduledAlarms` — destination 변경 inline clear(race-safe). lock 캡처를 active guard 위로 끌어올려 FG에서도 캡처(BG가 이후 결정론 ETA 참조).
- `alarmRefreshTask` — 같은 lock 사이클. 활성 트립 없을 때 자동 클리어.

## 회귀 안전

- `preferTrainCode` 미지정 호출은 #372 stamp 경로와 100% 동일 — `pickMinEta` 보조로 분리해 검증.
- 기존 호출부(`alarmScheduler` stamp 적재 등) 영향 없음.

## 재작업 사유

원본 D는 자체 picker(`approachEta.ts`)를 도입했으나, PR 생성 후 머지된 #372가 dev에 `nextArrivalPick`을 신설하면서 picker 2개 공존 위기. 이번 force-push에서 dev base로 rebase 후 `approachEta`를 폐기하고 `nextArrivalPick`에 옵션 합류. picker 1개로 일원화.

## 테스트

- `npm test` ✅ 1338 / 1338 통과, 커버리지 100% (lines/branches/functions/statements)
- `npm run type-check` ✅
- `src/utils/__tests__/nextArrivalPick.test.ts` 신규 케이스: preferTrainCode 매치/fallback/상한/0이하/양방향/isMock 우선 차단
- `src/utils/__tests__/tripTrainCode.test.ts`: destId 일치/불일치, separator 처리
- `src/hooks/__tests__/useScheduledAlarms.test.ts`: FG 캡처, BG 결정론, destination 변경 클리어
- `src/tasks/__tests__/alarmRefreshTask.test.ts`: lock-in 캡처/사용/fallback, 활성 트립 없을 때 클리어

## 후속 (이번 PR 범위 밖)

- 캡처 정책 정교화 — 데이터 누적 후 별도 이슈로 분리 (예: 지연 lock-in, 열차 위치 API fusion).
- `matchedByTrainCode`를 alarmLog stamp에 적재 — #372 후속.

Closes #373