### PR TITLE
fix(#326): MAX_ACCURACY_M_DISPLAY 인하 + locationUncertain 노출 (Phase 2A)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -76,7 +76,7 @@ export default function HomeScreen() {
     () => (route && tripOrigin && destination ? { route, origin: tripOrigin, destination } : undefined),
     [route, tripOrigin, destination],
   );
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh, confidence } = useFusedNearestStation(undefined, undefined, routeContext);
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence } = useFusedNearestStation(undefined, undefined, routeContext);
   const isCustomOrigin = customOrigin !== null;
   const effectiveOrigin = customOrigin ?? result?.station ?? null;
   useTripOrigin(destination, effectiveOrigin, setTripOrigin);
@@ -505,6 +505,15 @@ export default function HomeScreen() {
               </View>
             )}
           </>
+        ) : locationUncertain ? (
+          <View style={styles.center} testID="location-uncertain">
+            <Text style={styles.icon}>📍</Text>
+            <Text style={[styles.title, { color: colors.ink }]}>{t('home.locationUncertainTitle')}</Text>
+            <Text style={[styles.subtitle, { color: colors.muted }]}>{t('home.locationUncertainDescription')}</Text>
+            <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+              <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('home.refresh')}</Text>
+            </TouchableOpacity>
+          </View>
         ) : (
           <View style={styles.center}>
             <Text style={styles.icon}>🚶</Text>

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -5,7 +5,11 @@ export const MAX_LOCATION_AGE_MS = 15_000;
 // 200m: 알람 트리거용 엄격 게이트. 역간 평균 거리(800m+) 대비 안전 마진.
 // false alarm 방지 위해 그대로 유지 — 알람 경로(useStationAlarm)에서만 사용.
 export const MAX_ACCURACY_M = 200;
-// 1500m: UI 표시용 완화 게이트. 지하 플랫폼/터널의 horizontalAccuracy(300~1500m)도
-// 일단 수용해 "추정 현재역"을 끊김 없이 보여준다. 알람은 별도 엄격 게이트로 차단.
-export const MAX_ACCURACY_M_DISPLAY = 1500;
+// 250m: UI 표시용 게이트. Apple Core Location 가이드(100m 초과는 통상 필터링)와
+// 역간 평균 거리(800m+)를 함께 고려한 보수 값. 부정확 fix(±1.5km)로 엉뚱한 역을
+// 단정하는 사고를 방지. 이 게이트로 drop된 동안은 useNearestStation이 result를
+// 갱신하지 않고 locationUncertain=true로 노출해 호출자가 "위치 확인 중" 상태로 표시한다.
+// Position-first fusion(useFusedNearestStation)이 활성화되면 realtimePosition이 우선이므로
+// GPS 게이트의 영향 범위는 fallback 경로에 한정된다.
+export const MAX_ACCURACY_M_DISPLAY = 250;
 export const MAX_STATION_DISTANCE_KM = 1.0;

--- a/src/constants/routeProgress.ts
+++ b/src/constants/routeProgress.ts
@@ -1,5 +1,5 @@
 // 경로 밖 1.5km 이상 떨어진 GPS는 off-route로 간주해 진행도 보정에 사용하지 않는다.
-// 표시용 accuracy 게이트(MAX_ACCURACY_M_DISPLAY)와 동일. 큰 변경 시 location.ts와 함께 조정.
+// MAX_ACCURACY_M_DISPLAY와는 별개 개념(이쪽은 사영 perpendicular 거리, 저쪽은 단일 fix accuracy).
 export const MAX_PERP_M = 1500;
 
 // 지하철 운행 가능 최대 속도 + 여유. 200 km/h = 55.6 m/s.

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -34,6 +34,7 @@ function gpsBase(overrides?: Record<string, unknown>) {
     loading: false,
     error: null,
     permissionDenied: false,
+    locationUncertain: false,
     refresh: jest.fn(),
     ...overrides,
   };
@@ -215,10 +216,16 @@ describe('useFusedNearestStation', () => {
     expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
   });
 
-  it('GPS pass-through 필드들(loading/error/permissionDenied/refresh 등)이 보존된다', () => {
+  it('GPS pass-through 필드들(loading/error/permissionDenied/locationUncertain/refresh 등)이 보존된다', () => {
     const refresh = jest.fn();
     mockUseNearest.mockReturnValue(
-      gpsBase({ loading: true, error: 'GPS err', permissionDenied: true, refresh }),
+      gpsBase({
+        loading: true,
+        error: 'GPS err',
+        permissionDenied: true,
+        locationUncertain: true,
+        refresh,
+      }),
     );
     mockFindTop.mockReturnValue([]);
 
@@ -227,6 +234,7 @@ describe('useFusedNearestStation', () => {
     expect(result.current.loading).toBe(true);
     expect(result.current.error).toBe('GPS err');
     expect(result.current.permissionDenied).toBe(true);
+    expect(result.current.locationUncertain).toBe(true);
     expect(result.current.refresh).toBe(refresh);
     expect(result.current.variants).toEqual([MOCK_STATIONS.gangnam]);
     expect(result.current.userLocation).toEqual({ lat: 37.5, lng: 127.0 });

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -491,7 +491,23 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('watch 콜백 표시 게이트 초과(MAX_ACCURACY_M_DISPLAY 초과) 좌표는 setState하지 않는다', async () => {
+  it('watch 콜백 표시 게이트 초과(MAX_ACCURACY_M_DISPLAY 초과) 좌표는 setState하지 않고 locationUncertain=true', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    expect(result.current.locationUncertain).toBe(false);
+    simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
+
+    // 표시 게이트 초과 → setState 차단 + uncertain 노출
+    expect(result.current.result).toBeNull();
+    expect(result.current.userLocation).toBeNull();
+    expect(result.current.locationUncertain).toBe(true);
+  });
+
+  it('uncertain 상태에서 정확한 좌표가 들어오면 locationUncertain=false로 복귀한다', async () => {
     mockGranted();
 
     const { result } = renderHook(() => useNearestStation());
@@ -499,10 +515,11 @@ describe('useNearestStation', () => {
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
+    expect(result.current.locationUncertain).toBe(true);
 
-    // 표시 게이트 초과 → setState 차단
-    expect(result.current.result).toBeNull();
-    expect(result.current.userLocation).toBeNull();
+    simulateGps(37.4980, 127.0277, { accuracy: 30 });
+    await waitFor(() => expect(result.current.locationUncertain).toBe(false));
+    expect(result.current.result?.station.name).toBe('강남');
   });
 
   it('watch 콜백 알람 게이트 초과지만 표시 게이트 통과 좌표는 setState한다 (지하 구간 가정)', async () => {
@@ -532,7 +549,7 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
-  it('refresh 시 표시 게이트 초과 좌표는 setState하지 않는다', async () => {
+  it('refresh 시 표시 게이트 초과 좌표는 setState하지 않고 locationUncertain=true', async () => {
     mockGranted();
     mockLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
 
@@ -545,8 +562,28 @@ describe('useNearestStation', () => {
     });
 
     expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
-    // 표시 게이트 초과 → result 갱신 안 됨
+    // 표시 게이트 초과 → result 갱신 안 됨 + uncertain 노출
     expect(result.current.result).toBeNull();
+    expect(result.current.locationUncertain).toBe(true);
+  });
+
+  it('refresh 시 정확한 좌표가 들어오면 locationUncertain=false로 복귀한다', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
+    expect(result.current.locationUncertain).toBe(true);
+
+    mockLocation(37.4980, 127.0277, { accuracy: 30 });
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.locationUncertain).toBe(false);
+    expect(result.current.result?.station.name).toBe('강남');
   });
 
   it('timestamp가 없는 캐시 위치는 무시한다', async () => {

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -41,6 +41,9 @@ interface UseFusedNearestStationReturn {
   loading: boolean;
   error: string | null;
   permissionDenied: boolean;
+  /** GPS 표시 게이트 drop으로 좌표가 정지된 상태. fusion에서 position/arrival 신호가 살아있어도
+   *  GPS fallback 경로에 의존하는 호출자(예: 표시부)는 이 값으로 "위치 확인 중" UX를 띄울 수 있다. */
+  locationUncertain: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -231,6 +234,7 @@ export function useFusedNearestStation(
     loading: gps.loading,
     error: gps.error,
     permissionDenied: gps.permissionDenied,
+    locationUncertain: gps.locationUncertain,
     refresh: gps.refresh,
   };
 }

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -22,6 +22,9 @@ interface UseNearestStationReturn {
   loading: boolean;
   error: string | null;
   permissionDenied: boolean;
+  // true: 직전 좌표가 표시 게이트(MAX_ACCURACY_M_DISPLAY)에 의해 drop되어 result가
+  // 마지막 신뢰 fix로 정지된 상태. 호출자는 "위치 확인 중" 상태로 표시한다.
+  locationUncertain: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -48,6 +51,7 @@ export function useNearestStation(): UseNearestStationReturn {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
+  const [locationUncertain, setLocationUncertain] = useState(false);
   const subscriptionRef = useRef<Location.LocationSubscription | null>(null);
   const lastStationIdRef = useRef<string | null>(null);
   const lastDistanceRef = useRef<number>(0);
@@ -115,7 +119,11 @@ export function useNearestStation(): UseNearestStationReturn {
           timeInterval: 2000,
         },
         (location) => {
-          if (!isAccuracyAcceptableForDisplay(location.coords.accuracy)) return;
+          if (!isAccuracyAcceptableForDisplay(location.coords.accuracy)) {
+            setLocationUncertain(true);
+            return;
+          }
+          setLocationUncertain(false);
           applyLocation(location.coords);
         },
       );
@@ -141,7 +149,10 @@ export function useNearestStation(): UseNearestStationReturn {
       setPermissionDenied(false);
       const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
       if (isAccuracyAcceptableForDisplay(location.coords.accuracy)) {
+        setLocationUncertain(false);
         applyLocation(location.coords);
+      } else {
+        setLocationUncertain(true);
       }
     } catch {
       setError('위치를 가져오는 데 실패했습니다.');
@@ -168,5 +179,5 @@ export function useNearestStation(): UseNearestStationReturn {
     };
   }, [startWatch, stopWatch]);
 
-  return { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, refresh };
+  return { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -38,6 +38,8 @@
     "noArrivalInfo": "No arrival info",
     "notNearStationTitle": "Not near a subway station",
     "notNearStationDescription": "Your current station appears when you are within 500m of a subway station.\nYou can also set the origin manually from the Map tab.",
+    "locationUncertainTitle": "Locating",
+    "locationUncertainDescription": "GPS accuracy is low,\nso we can't pinpoint your location.\nWe'll retry automatically.",
     "refresh": "Refresh"
   },
   "settings": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -38,6 +38,8 @@
     "noArrivalInfo": "到着情報なし",
     "notNearStationTitle": "地下鉄駅の近くではありません",
     "notNearStationDescription": "地下鉄駅から500m以内にいるとき、現在駅が表示されます。\n地図タブで出発駅を手動で設定することもできます。",
+    "locationUncertainTitle": "位置確認中",
+    "locationUncertainDescription": "GPSの精度が低いため、\n現在地を特定できません。\nしばらくしてから自動で再試行します。",
     "refresh": "更新"
   },
   "settings": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -38,6 +38,8 @@
     "noArrivalInfo": "도착 정보 없음",
     "notNearStationTitle": "지하철역 근처가 아닙니다",
     "notNearStationDescription": "지하철역 500m 이내에 있을 때\n현재 역이 표시됩니다.\n지도 탭에서 출발역을 직접 설정할 수 있습니다.",
+    "locationUncertainTitle": "위치 확인 중",
+    "locationUncertainDescription": "현재 GPS 정확도가 낮아\n위치를 단정할 수 없습니다.\n잠시 후 자동으로 다시 확인합니다.",
     "refresh": "새로고침"
   },
   "settings": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -38,6 +38,8 @@
     "noArrivalInfo": "无到达信息",
     "notNearStationTitle": "附近没有地铁站",
     "notNearStationDescription": "当您距离地铁站500m以内时,会显示当前站。\n您也可以在地图标签页手动设置出发站。",
+    "locationUncertainTitle": "正在定位",
+    "locationUncertainDescription": "GPS精度较低,\n暂时无法确定您的位置。\n稍后将自动重试。",
     "refresh": "刷新"
   },
   "settings": {


### PR DESCRIPTION
## 무엇을
- GPS 표시 게이트 `MAX_ACCURACY_M_DISPLAY`를 1500m → **250m**로 인하
- `useNearestStation`에 `locationUncertain: boolean` 상태 추가 (게이트 drop 동안 result 정지 + 플래그 노출)
- 홈 화면이 effectiveOrigin 없고 `locationUncertain=true`이면 "위치 확인 중" UX 표시

## 왜
- 기존 1500m는 지하 부정확 fix(±1.5km)도 통과시켜 엉뚱한 역을 단정 표시하는 사고 원인
- Apple Core Location 가이드(100m 초과 통상 필터링) + 역간 평균 거리(800m+) 기준 보수 값
- Phase 1(#325 Position-first fusion) 머지로 GPS 비중이 줄어든 시점 — fallback 경로 안전성 강화에 적합
- Closes #326

## 어떻게
- `src/constants/location.ts`: 임계값 인하 + 근거 주석
- `src/hooks/useNearestStation.ts`: watch 콜백 + refresh 양쪽에서 게이트 drop 시 `setLocationUncertain(true)`, 통과 시 false로 대칭 처리. 권한 거부/loading은 기존 early-return이 우선.
- `src/hooks/useFusedNearestStation.ts`: 패스스루 + JSDoc으로 "fallback 경로 의존 호출자만 사용" 명시
- `app/(tabs)/index.tsx`: `effectiveOrigin ? hero : locationUncertain ? 위치확인중 : notNearStation` 3분기. fusion이 살아있을 때 hero UI 우선이라 fusion 결과를 가리지 않음.
- `src/constants/routeProgress.ts`: `MAX_PERP_M`(perpendicular 거리)이 accuracy 게이트와 별개 개념임을 코멘트로 정정

## 테스트
- locationUncertain 전이 4가지 회귀 가드: watch drop→true, watch good→false, refresh drop→true, refresh good→false
- `useFusedNearestStation` 패스스루 테스트 보강
- `npm test` 1345/1345 통과, 커버리지 100% 유지
- `npm run type-check` 통과

## 후속
- Phase 2B(#327): fusion source/confidence + GPS uncertainty 통합 시각화

Closes #326