### PR TITLE
fix(#381): 목적지 변경 시 Live Activity 'Target is not foreground' 에러 수정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -209,9 +209,10 @@ export default function HomeScreen() {
     const destinationChanged = prevDestId != null && prevDestId !== currDestId;
     const update = async () => {
       if (destinationChanged) {
-        logger.info('목적지 변경 → 이전 알림 교체');
+        logger.info('목적지 변경 → 알람 알림 해제');
         await clearAlarmNotification();
-        await clearStationNotification();
+        // Live Activity는 end→start race로 "Target is not foreground" 실패를 유발하므로
+        // 종료하지 않고 updateStationNotification 내부의 update() 경로로만 갱신한다.
       }
       logger.info('알림 업데이트:', effectiveOrigin.name, `→ ${destination.name}`);
       await updateStationNotification(


### PR DESCRIPTION
## Summary

목적지(도착역) 변경 시 Live Activity가 `Target is not foreground` 에러로 갱신되지 못하고 일반 알림 fallback으로 떨어지던 버그를 수정합니다.

## 원인

`app/(tabs)/index.tsx` 의 목적지 변경 분기에서 `clearStationNotification()`(= `endLiveActivity`)을 호출한 직후 즉시 `updateStationNotification()`(= 새 `Activity.request()`)을 호출했습니다. ActivityKit은 `end(.immediate)` 직후 새 Activity 요청을 받으면 transition 정리가 끝나지 않아 "Target is not foreground"로 거부합니다.

## 변경

`app/(tabs)/index.tsx` — 목적지 변경 분기에서 `clearStationNotification()` 호출 제거.

`LiveActivityManager.update()` 는 이미 `.ended/.dismissed` 상태를 감지해 내부적으로 `start()` 로 재진입하는 안전망을 보유하므로, JS 레이어에서 별도로 종료할 필요가 없습니다.

알람 알림(`clearAlarmNotification`)은 destination 종속 채널이므로 유지합니다.

## Test plan

- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (1345 tests, 커버리지 100%)
- [x] code-reviewer 에이전트 P0 없음
- [ ] 실기기에서 도착역을 다른 역으로 연속 변경했을 때 잠금화면 Live Activity가 즉시 새 목적지로 갱신되는지 확인
- [ ] 도착역을 해제했을 때 Live Activity가 정상 종료되는지 확인
- [ ] 도착 시 arrivedBanner 분기에서 Live Activity가 정상 종료되는지 확인

Closes #381