### PR TITLE
fix(#383): FG에서도 사전 예약 알람 등록

### DIFF
--- a/src/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/hooks/__tests__/useScheduledAlarms.test.ts
@@ -103,14 +103,18 @@ describe('useScheduledAlarms', () => {
     await AsyncStorage.removeItem(TRIP_TRAIN_CODE_KEY);
   });
 
-  it('마운트 시 active 상태면 cancel만 호출되고 schedule은 호출되지 않는다', async () => {
+  it('마운트 시 active 상태에서도 schedule을 호출한다 (#383)', async () => {
+    // #383: AppState='active'에서 schedule을 skip하던 정책 제거.
+    // FG에서도 사전 예약을 등록해 BG 진입 race를 차단한다.
     renderHook(() =>
       useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
 
     expect(mockedCancel).toHaveBeenCalled();
-    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ currentStationApproachEtaSeconds: 300 }),
+    );
   });
 
   it('background 전환 시 마지막 ETA로 재예약한다', async () => {
@@ -137,7 +141,9 @@ describe('useScheduledAlarms', () => {
     });
   });
 
-  it('active 복귀 시 예약을 모두 취소하고 재예약하지 않는다', async () => {
+  it('active 복귀 전환은 schedule/cancel을 트리거하지 않는다 (#383)', async () => {
+    // #383: 'active' 진입 시 cancel하던 정책 제거. 이미 예약된 알람은 FG에서도 유지되며,
+    // FG GPS firing과의 중복은 scheduledAlarmReceiver의 FIRED_ALARMS dedup으로 처리.
     renderHook(() =>
       useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
@@ -156,7 +162,7 @@ describe('useScheduledAlarms', () => {
       await Promise.resolve();
     });
 
-    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).not.toHaveBeenCalled();
     expect(mockedSchedule).not.toHaveBeenCalled();
   });
 
@@ -378,28 +384,6 @@ describe('useScheduledAlarms', () => {
     expect(true).toBe(true);
   });
 
-  it('cancelScheduledAlarms 실패는 active 전환 경로에서도 throw하지 않는다', async () => {
-    renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
-    );
-    await flush();
-    await act(async () => {
-      appStateCallback?.('background');
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    // 다음 cancel 호출(=active 전환)만 실패시킨다.
-    mockedCancel.mockRejectedValueOnce(new Error('active cancel fail'));
-    await act(async () => {
-      appStateCallback?.('active');
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(true).toBe(true);
-  });
-
   it('진행 방향이 "down"으로 판정되면 arrival.down ETA만 schedule에 전달한다 (반대방향 ETA 폐기)', async () => {
     // 회귀: 반대방향 열차가 빨라도 사용자 방향 ETA를 채택해야 한다.
     const WRONG_FAST_RIGHT_SLOW: StationArrival = {
@@ -513,8 +497,8 @@ describe('useScheduledAlarms', () => {
     expect(await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY)).toBe('1-034:D1');
   });
 
-  it('lock-in: FG(active) 상태에서도 lock-in을 캡처한다 — schedule만 skip', async () => {
-    // 초기 AppState = active. background 전환 없이 마운트 → 입력 변동 effect 1회만 작동.
+  it('lock-in: FG(active) 상태에서도 lock-in 캡처 + schedule을 함께 수행한다 (#383)', async () => {
+    // 초기 AppState = active. #383 이후로 FG에서도 schedule이 호출된다.
     renderHook(() =>
       useScheduledAlarms({
         route: LINE_1_ROUTE,
@@ -526,7 +510,7 @@ describe('useScheduledAlarms', () => {
     await flush();
 
     expect(await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY)).toBe('1-034:D1');
-    expect(mockedSchedule).not.toHaveBeenCalled(); // active 상태 → schedule은 skip
+    expect(mockedSchedule).toHaveBeenCalled();
   });
 
   it('lock-in: 다음 reschedule은 저장된 trainCode를 사용해 결정론적 ETA 채택', async () => {
@@ -592,11 +576,13 @@ describe('useScheduledAlarms', () => {
   });
 
   it('scheduleAlarmsForRoute 실패는 background 전환 경로에서 throw하지 않는다', async () => {
-    mockedSchedule.mockRejectedValueOnce(new Error('schedule fail'));
+    // 마운트 시 input-change effect의 schedule 호출(첫 1회)은 성공시키고,
+    // 그 다음의 background 전환 schedule 호출만 실패시켜 background catch를 검증한다.
     renderHook(() =>
       useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
+    mockedSchedule.mockRejectedValueOnce(new Error('schedule fail'));
     await act(async () => {
       appStateCallback?.('background');
       await Promise.resolve();

--- a/src/hooks/useScheduledAlarms.ts
+++ b/src/hooks/useScheduledAlarms.ts
@@ -26,12 +26,15 @@ export interface UseScheduledAlarmsInputs {
 }
 
 /**
- * BG/포그라운드 전환과 ETA 변동에 맞춰 사전 예약 알람을 재예약한다.
+ * 입력 변동(ETA/경로/현재역) 또는 AppState 전환 시 사전 예약 알람을 재예약한다.
  *
- * 정책:
- * - 포그라운드(`active`): 예약 모두 취소. FG는 useStationAlarm이 GPS 기반 발화를 담당.
- * - 백그라운드(`background`): 마지막 route/destination/arrival 기준으로 재예약.
- * - 백그라운드 중 입력 변동: 즉시 cancel → reschedule.
+ * 정책 (#383 — AppState와 무관하게 항상 예약):
+ * - route + destination이 유효하면 AppState와 관계없이 즉시 예약.
+ *   FG에서 OS가 알람을 발사해도 scheduledAlarmReceiver의 FIRED_ALARMS dedup으로
+ *   useStationAlarm GPS 기반 발화와 충돌하지 않는다.
+ * - 'background' 전환 시: 사용자가 FG에서 빠르게 잠금화면으로 갈 때 input-change
+ *   effect가 미처 완료되지 못한 race를 차단하기 위한 idempotent safety net으로
+ *   reschedule 한 번 더 호출.
  * - route/destination이 null이면 항상 cancel만 수행 (route 종료).
  * - 언마운트: 모두 취소.
  *
@@ -69,7 +72,12 @@ export function useScheduledAlarms({
 
     await cancelScheduledAlarms();
     const currentRoute = routeRef.current;
-    if (!currentRoute || !currentDestination) return;
+    if (!currentRoute || !currentDestination) {
+      logger.info(
+        `skip reschedule appState=${appStateRef.current} reason=${!currentRoute ? 'no-route' : 'no-destination'}`,
+      );
+      return;
+    }
 
     // 진행 방향은 route + 현재역 ordinal로 결정한다 (#370). null이면 알 수 없음.
     // pickNextArrival에 filter로 전달해 반대방향 열차 ETA 오인을 차단.
@@ -86,13 +94,11 @@ export function useScheduledAlarms({
       direction,
     );
 
-    if (appStateRef.current === 'active') return;
-
     const pick = pickNextArrival(arrivalRef.current, direction, {
       preferTrainCode: trainCode,
     });
-    logger.debug(
-      `reschedule eta=${pick.etaSeconds} trainCode=${trainCode ?? 'none'} matched=${pick.matchedByTrainCode}`,
+    logger.info(
+      `reschedule appState=${appStateRef.current} eta=${pick.etaSeconds} trainCode=${trainCode ?? 'none'} matched=${pick.matchedByTrainCode}`,
     );
 
     await scheduleAlarmsForRoute({
@@ -105,16 +111,14 @@ export function useScheduledAlarms({
     });
   };
 
-  // AppState 전환 listener — 자체 등록 (중복 방지를 위해 다른 listener와 통합하지 않음).
+  // AppState 전환 listener — 'background' 진입 시 idempotent re-sync.
+  // FG에서 input-change effect가 비동기 reschedule을 채 완료하기 전에 OS가
+  // suspend되는 race를 차단하는 safety net 역할.
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state) => {
       const prev = appStateRef.current;
       appStateRef.current = state;
       if (state === prev) return;
-      if (state === 'active') {
-        cancelScheduledAlarms().catch((e) => logger.error('active 전환 취소 실패:', e));
-        return;
-      }
       if (state === 'background') {
         reschedule().catch((e) => logger.error('background 전환 재예약 실패:', e));
       }
@@ -125,7 +129,7 @@ export function useScheduledAlarms({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 입력 변동 시 재예약 — BG 상태에서만 의미가 있다. active면 reschedule이 내부에서 no-op.
+  // 입력 변동 시 재예약 — AppState와 무관하게 항상 schedule.
   // route/destination이 null이면 cancel만 발생.
   useEffect(() => {
     reschedule().catch((e) => logger.error('입력 변동 재예약 실패:', e));


### PR DESCRIPTION
## Summary
- 백그라운드 알림 미발화의 근본 원인이던 FG schedule skip 정책 제거
- `useScheduledAlarms`가 AppState와 무관하게 입력 유효 시 항상 예약 (FG GPS 발화와의 중복은 기존 dedup이 처리)
- `background` 전환 시 idempotent safety net 유지, skip 사유 진단 로그 추가

## 배경
런타임 로그에서 `[AlarmScheduler] cancelled 0 scheduled alarms` 반복 = **예약된 알람이 0개** 상태로 BG 진입. 원인은 `useScheduledAlarms.ts` line 89의 `if (appStateRef.current === 'active') return;`로 FG에서 예약이 막혀 있어, OS가 빠르게 suspend하면 `background` transition listener의 비동기 reschedule이 완료되기 전에 앱이 멈춤.

## Test plan
- [x] `npm test` 1344개 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-reviewer 에이전트 리뷰 (no issues)
- [ ] 실기기: 출발/도착 설정 후 콘솔에 `[useScheduledAlarms] reschedule appState=active eta=... ` 즉시 찍힘 확인
- [ ] 실기기: 잠금 후 ETA 도달 시점 알림 발화 확인
- [ ] 실기기: FG에서 알람 시간 도달 시 dedup으로 중복 발화 없는지 확인

## 후속 작업
- 경로 C(silent push Info.plist) 별도 이슈
- 경로 A(BG 위치 권한 UX) 별도 이슈

Closes #383