### PR TITLE
fix(#385): UIBackgroundModes에 remote-notification 추가

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -32,7 +32,7 @@ module.exports = {
             },
           },
         },
-        UIBackgroundModes: ['location'],
+        UIBackgroundModes: ['location', 'fetch', 'remote-notification'],
         ITSAppUsesNonExemptEncryption: false,
       },
     },
@@ -67,6 +67,7 @@ module.exports = {
         'expo-notifications',
         {
           sounds: ['./assets/sounds/alarm.wav'],
+          enableBackgroundRemoteNotifications: true,
         },
       ],
       'expo-router',


### PR DESCRIPTION
## Summary
- \`expo-notifications\` v0.32.16의 silent push task 등록 시 발생하던 \`Background remote notifications have not been configured\` 런타임 에러 제거
- \`app.config.js\`의 \`UIBackgroundModes\`에 \`remote-notification\` + \`fetch\` 추가
- \`expo-notifications\` 플러그인 옵션에 \`enableBackgroundRemoteNotifications: true\` 추가

## 비고
- \`ios/\`는 gitignore (prebuild 산출물). 다음 \`npx expo prebuild --platform ios\`에서 Info.plist에 자동 반영됨
- 본 PR은 silent push task **등록 자체의 에러만 제거**. End-to-end silent push는 \`EXPO_PUBLIC_ALARM_BACKEND_URL\` 설정 + 백엔드 가동 (#339) 필요

## Test plan
- [x] \`npm test\` 1345 통과, 커버리지 100%
- [x] \`npm run type-check\` 통과
- [x] code-reviewer (no issues)
- [ ] 실기기 재빌드 후 콘솔에 \`[SilentPushTask] silent push task registered\` info 로그
- [ ] \`failed to register silent push task\` warn 사라짐 확인

Closes #385