### PR TITLE
fix(#387): BG 위치 권한 거부 시 안내 모달

### DIFF
--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { Alert, Linking } from 'react-native';
 import type { Station } from '../../types/station';
+
+// ── Alert.alert / Linking.openSettings 모킹 ──
+const mockAlertAlert = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+const mockOpenSettings = jest.spyOn(Linking, 'openSettings').mockResolvedValue();
 
 // ── expo-location 모킹 ──
 const mockRequestBackgroundPermissionsAsync = jest.fn();
@@ -140,6 +145,62 @@ describe('useBackgroundLocation', () => {
     });
 
     expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+  });
+
+  it('권한이 denied이면 안내 Alert를 띄우고 "설정 열기" 탭 시 Linking.openSettings를 호출한다 (#387)', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' });
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalled();
+    });
+
+    const [, , buttons] = mockAlertAlert.mock.calls[0]!;
+    expect(buttons).toHaveLength(2);
+    // 첫 번째 버튼은 닫기(cancel), 두 번째 버튼은 설정 열기.
+    const openSettingsBtn = (buttons as Array<{ onPress?: () => void }>)[1];
+    openSettingsBtn?.onPress?.();
+    expect(mockOpenSettings).toHaveBeenCalled();
+  });
+
+  it('같은 hook 라이프타임에서 denied가 반복돼도 Alert는 한 번만 노출한다 (#387)', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    const { rerender } = renderHook(
+      ({ dest }: { dest: Station | null }) => useBackgroundLocation(dest),
+      { initialProps: { dest: mockDestination as Station | null } },
+    );
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ dest: mockDestination2 });
+
+    await waitFor(() => {
+      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelled(unmount race) 상태에서는 denied여도 Alert를 띄우지 않는다 (#387)', async () => {
+    let resolvePermission!: (value: { status: string }) => void;
+    mockRequestBackgroundPermissionsAsync.mockReturnValueOnce(
+      new Promise<{ status: string }>((resolve) => {
+        resolvePermission = resolve;
+      }),
+    );
+
+    const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
+    unmount();
+    resolvePermission({ status: 'denied' });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAlertAlert).not.toHaveBeenCalled();
   });
 
   // ── 태스크가 이미 등록된 경우: GPS 추적 공백 방지를 위해 재시작하지 않음 ──

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { Alert, Linking } from 'react-native';
 import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +15,9 @@ const noop = () => {};
 
 export function useBackgroundLocation(destination: Station | null): void {
   const { t } = useTranslation();
+  // 같은 hook 라이프타임에서 destination이 여러 번 바뀌어도 권한 안내 모달은 한 번만 노출한다.
+  // 매번 띄우면 스팸성이 강하고, 사용자는 이미 첫 알림으로 결정한 상태다.
+  const deniedAlertShownRef = useRef(false);
 
   useEffect(() => {
     if (!destination) {
@@ -27,6 +31,17 @@ export function useBackgroundLocation(destination: Station | null): void {
       const { status } = await Location.requestBackgroundPermissionsAsync();
       if (status !== 'granted' || cancelled) {
         logger.info('백그라운드 위치 권한 거부 또는 취소됨');
+        if (status !== 'granted' && !cancelled && !deniedAlertShownRef.current) {
+          deniedAlertShownRef.current = true;
+          Alert.alert(
+            t('permissions.backgroundDeniedTitle'),
+            t('permissions.backgroundDeniedBody'),
+            [
+              { text: t('common.close'), style: 'cancel' },
+              { text: t('permissions.openSettings'), onPress: () => Linking.openSettings() },
+            ],
+          );
+        }
         return;
       }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "Location permission required.",
     "locationRequiredDescription": "Please allow location permission in Settings.\nLocation permission is required to detect your current station.",
     "request": "Grant permission",
-    "locating": "Locating..."
+    "locating": "Locating...",
+    "backgroundDeniedTitle": "Background location required",
+    "backgroundDeniedBody": "To receive background alarms, set location access to \"Always\" in Settings.",
+    "openSettings": "Open Settings"
   },
   "home": {
     "arrived": "Arrived!",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "位置情報の許可が必要です。",
     "locationRequiredDescription": "設定で位置情報の利用を許可してください。\n現在の駅を検出するために位置情報が必要です。",
     "request": "許可する",
-    "locating": "位置情報を取得中..."
+    "locating": "位置情報を取得中...",
+    "backgroundDeniedTitle": "バックグラウンド位置情報の許可が必要です",
+    "backgroundDeniedBody": "バックグラウンドでアラームを受け取るには、設定で位置情報を「常に許可」にしてください。",
+    "openSettings": "設定を開く"
   },
   "home": {
     "arrived": "到着!",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "위치 권한이 필요합니다.",
     "locationRequiredDescription": "설정에서 위치 권한을 허용해 주세요.\n현재 탑승 중인 역을 감지하려면\n위치 권한이 필요합니다.",
     "request": "권한 요청",
-    "locating": "위치 확인 중..."
+    "locating": "위치 확인 중...",
+    "backgroundDeniedTitle": "백그라운드 위치 권한 필요",
+    "backgroundDeniedBody": "백그라운드에서 알람을 받으려면 설정에서 위치 권한을 '항상 허용'으로 설정해 주세요.",
+    "openSettings": "설정 열기"
   },
   "home": {
     "arrived": "도착!",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "需要位置权限。",
     "locationRequiredDescription": "请在设置中允许位置权限。\n要检测您当前的车站，需要位置权限。",
     "request": "授予权限",
-    "locating": "正在定位..."
+    "locating": "正在定位...",
+    "backgroundDeniedTitle": "需要后台位置权限",
+    "backgroundDeniedBody": "要在后台接收闹钟，请在设置中将位置访问设为\"始终允许\"。",
+    "openSettings": "打开设置"
   },
   "home": {
     "arrived": "已到达!",


### PR DESCRIPTION
## Summary
- 백그라운드 위치 권한이 거부됐을 때 사용자에게 \`Alert\`로 안내하고 \`Linking.openSettings()\`로 설정 앱 이동 옵션 제공
- 같은 hook 인스턴스 안에서는 1회만 노출 (\`useRef\` 기반, 스팸 방지)
- i18n 키 추가 (ko/en/ja/zh)

## 배경
런타임 로그 \`[BackgroundLocation] 백그라운드 위치 권한 거부 또는 취소됨\`만 silent하게 찍히고 사용자는 자신의 결정으로 BG 알람이 동작하지 않는다는 사실을 인지하지 못함.

## Test plan
- [x] \`npm test\` 1348 통과, useBackgroundLocation.ts 커버리지 100%
- [x] \`npm run type-check\` 통과
- [x] code-reviewer (no issues)
- [ ] 실기기: 도착지 설정 시 위치 권한 거부 → 안내 모달 노출
- [ ] "설정 열기" 탭 → iOS 설정 앱 이동 확인
- [ ] 같은 세션에서 도착지 변경 → 모달 재노출 없음

Closes #387