### PR TITLE
fix(#383): 백그라운드 알림 미발화 — 3 경로 동시 수정

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -32,7 +32,7 @@ module.exports = {
             },
           },
         },
-        UIBackgroundModes: ['location'],
+        UIBackgroundModes: ['location', 'fetch', 'remote-notification'],
         ITSAppUsesNonExemptEncryption: false,
       },
     },
@@ -67,6 +67,7 @@ module.exports = {
         'expo-notifications',
         {
           sounds: ['./assets/sounds/alarm.wav'],
+          enableBackgroundRemoteNotifications: true,
         },
       ],
       'expo-router',

--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { Alert, Linking } from 'react-native';
 import type { Station } from '../../types/station';
+
+// ── Alert.alert / Linking.openSettings 모킹 ──
+const mockAlertAlert = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+const mockOpenSettings = jest.spyOn(Linking, 'openSettings').mockResolvedValue();
 
 // ── expo-location 모킹 ──
 const mockRequestBackgroundPermissionsAsync = jest.fn();
@@ -140,6 +145,62 @@ describe('useBackgroundLocation', () => {
     });
 
     expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+  });
+
+  it('권한이 denied이면 안내 Alert를 띄우고 "설정 열기" 탭 시 Linking.openSettings를 호출한다 (#387)', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' });
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalled();
+    });
+
+    const [, , buttons] = mockAlertAlert.mock.calls[0]!;
+    expect(buttons).toHaveLength(2);
+    // 첫 번째 버튼은 닫기(cancel), 두 번째 버튼은 설정 열기.
+    const openSettingsBtn = (buttons as Array<{ onPress?: () => void }>)[1];
+    openSettingsBtn?.onPress?.();
+    expect(mockOpenSettings).toHaveBeenCalled();
+  });
+
+  it('같은 hook 라이프타임에서 denied가 반복돼도 Alert는 한 번만 노출한다 (#387)', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    const { rerender } = renderHook(
+      ({ dest }: { dest: Station | null }) => useBackgroundLocation(dest),
+      { initialProps: { dest: mockDestination as Station | null } },
+    );
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ dest: mockDestination2 });
+
+    await waitFor(() => {
+      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelled(unmount race) 상태에서는 denied여도 Alert를 띄우지 않는다 (#387)', async () => {
+    let resolvePermission!: (value: { status: string }) => void;
+    mockRequestBackgroundPermissionsAsync.mockReturnValueOnce(
+      new Promise<{ status: string }>((resolve) => {
+        resolvePermission = resolve;
+      }),
+    );
+
+    const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
+    unmount();
+    resolvePermission({ status: 'denied' });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAlertAlert).not.toHaveBeenCalled();
   });
 
   // ── 태스크가 이미 등록된 경우: GPS 추적 공백 방지를 위해 재시작하지 않음 ──

--- a/src/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/hooks/__tests__/useScheduledAlarms.test.ts
@@ -103,14 +103,18 @@ describe('useScheduledAlarms', () => {
     await AsyncStorage.removeItem(TRIP_TRAIN_CODE_KEY);
   });
 
-  it('마운트 시 active 상태면 cancel만 호출되고 schedule은 호출되지 않는다', async () => {
+  it('마운트 시 active 상태에서도 schedule을 호출한다 (#383)', async () => {
+    // #383: AppState='active'에서 schedule을 skip하던 정책 제거.
+    // FG에서도 사전 예약을 등록해 BG 진입 race를 차단한다.
     renderHook(() =>
       useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
 
     expect(mockedCancel).toHaveBeenCalled();
-    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ currentStationApproachEtaSeconds: 300 }),
+    );
   });
 
   it('background 전환 시 마지막 ETA로 재예약한다', async () => {
@@ -137,7 +141,9 @@ describe('useScheduledAlarms', () => {
     });
   });
 
-  it('active 복귀 시 예약을 모두 취소하고 재예약하지 않는다', async () => {
+  it('active 복귀 전환은 schedule/cancel을 트리거하지 않는다 (#383)', async () => {
+    // #383: 'active' 진입 시 cancel하던 정책 제거. 이미 예약된 알람은 FG에서도 유지되며,
+    // FG GPS firing과의 중복은 scheduledAlarmReceiver의 FIRED_ALARMS dedup으로 처리.
     renderHook(() =>
       useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
@@ -156,7 +162,7 @@ describe('useScheduledAlarms', () => {
       await Promise.resolve();
     });
 
-    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).not.toHaveBeenCalled();
     expect(mockedSchedule).not.toHaveBeenCalled();
   });
 
@@ -378,28 +384,6 @@ describe('useScheduledAlarms', () => {
     expect(true).toBe(true);
   });
 
-  it('cancelScheduledAlarms 실패는 active 전환 경로에서도 throw하지 않는다', async () => {
-    renderHook(() =>
-      useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
-    );
-    await flush();
-    await act(async () => {
-      appStateCallback?.('background');
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    // 다음 cancel 호출(=active 전환)만 실패시킨다.
-    mockedCancel.mockRejectedValueOnce(new Error('active cancel fail'));
-    await act(async () => {
-      appStateCallback?.('active');
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(true).toBe(true);
-  });
-
   it('진행 방향이 "down"으로 판정되면 arrival.down ETA만 schedule에 전달한다 (반대방향 ETA 폐기)', async () => {
     // 회귀: 반대방향 열차가 빨라도 사용자 방향 ETA를 채택해야 한다.
     const WRONG_FAST_RIGHT_SLOW: StationArrival = {
@@ -513,8 +497,8 @@ describe('useScheduledAlarms', () => {
     expect(await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY)).toBe('1-034:D1');
   });
 
-  it('lock-in: FG(active) 상태에서도 lock-in을 캡처한다 — schedule만 skip', async () => {
-    // 초기 AppState = active. background 전환 없이 마운트 → 입력 변동 effect 1회만 작동.
+  it('lock-in: FG(active) 상태에서도 lock-in 캡처 + schedule을 함께 수행한다 (#383)', async () => {
+    // 초기 AppState = active. #383 이후로 FG에서도 schedule이 호출된다.
     renderHook(() =>
       useScheduledAlarms({
         route: LINE_1_ROUTE,
@@ -526,7 +510,7 @@ describe('useScheduledAlarms', () => {
     await flush();
 
     expect(await AsyncStorage.getItem(TRIP_TRAIN_CODE_KEY)).toBe('1-034:D1');
-    expect(mockedSchedule).not.toHaveBeenCalled(); // active 상태 → schedule은 skip
+    expect(mockedSchedule).toHaveBeenCalled();
   });
 
   it('lock-in: 다음 reschedule은 저장된 trainCode를 사용해 결정론적 ETA 채택', async () => {
@@ -592,11 +576,13 @@ describe('useScheduledAlarms', () => {
   });
 
   it('scheduleAlarmsForRoute 실패는 background 전환 경로에서 throw하지 않는다', async () => {
-    mockedSchedule.mockRejectedValueOnce(new Error('schedule fail'));
+    // 마운트 시 input-change effect의 schedule 호출(첫 1회)은 성공시키고,
+    // 그 다음의 background 전환 schedule 호출만 실패시켜 background catch를 검증한다.
     renderHook(() =>
       useScheduledAlarms({ route: ROUTE, destination: DESTINATION, currentStation: null, arrival: ARRIVAL }),
     );
     await flush();
+    mockedSchedule.mockRejectedValueOnce(new Error('schedule fail'));
     await act(async () => {
       appStateCallback?.('background');
       await Promise.resolve();

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { Alert, Linking } from 'react-native';
 import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +15,9 @@ const noop = () => {};
 
 export function useBackgroundLocation(destination: Station | null): void {
   const { t } = useTranslation();
+  // 같은 hook 라이프타임에서 destination이 여러 번 바뀌어도 권한 안내 모달은 한 번만 노출한다.
+  // 매번 띄우면 스팸성이 강하고, 사용자는 이미 첫 알림으로 결정한 상태다.
+  const deniedAlertShownRef = useRef(false);
 
   useEffect(() => {
     if (!destination) {
@@ -27,6 +31,17 @@ export function useBackgroundLocation(destination: Station | null): void {
       const { status } = await Location.requestBackgroundPermissionsAsync();
       if (status !== 'granted' || cancelled) {
         logger.info('백그라운드 위치 권한 거부 또는 취소됨');
+        if (status !== 'granted' && !cancelled && !deniedAlertShownRef.current) {
+          deniedAlertShownRef.current = true;
+          Alert.alert(
+            t('permissions.backgroundDeniedTitle'),
+            t('permissions.backgroundDeniedBody'),
+            [
+              { text: t('common.close'), style: 'cancel' },
+              { text: t('permissions.openSettings'), onPress: () => Linking.openSettings() },
+            ],
+          );
+        }
         return;
       }
 

--- a/src/hooks/useScheduledAlarms.ts
+++ b/src/hooks/useScheduledAlarms.ts
@@ -26,12 +26,15 @@ export interface UseScheduledAlarmsInputs {
 }
 
 /**
- * BG/포그라운드 전환과 ETA 변동에 맞춰 사전 예약 알람을 재예약한다.
+ * 입력 변동(ETA/경로/현재역) 또는 AppState 전환 시 사전 예약 알람을 재예약한다.
  *
- * 정책:
- * - 포그라운드(`active`): 예약 모두 취소. FG는 useStationAlarm이 GPS 기반 발화를 담당.
- * - 백그라운드(`background`): 마지막 route/destination/arrival 기준으로 재예약.
- * - 백그라운드 중 입력 변동: 즉시 cancel → reschedule.
+ * 정책 (#383 — AppState와 무관하게 항상 예약):
+ * - route + destination이 유효하면 AppState와 관계없이 즉시 예약.
+ *   FG에서 OS가 알람을 발사해도 scheduledAlarmReceiver의 FIRED_ALARMS dedup으로
+ *   useStationAlarm GPS 기반 발화와 충돌하지 않는다.
+ * - 'background' 전환 시: 사용자가 FG에서 빠르게 잠금화면으로 갈 때 input-change
+ *   effect가 미처 완료되지 못한 race를 차단하기 위한 idempotent safety net으로
+ *   reschedule 한 번 더 호출.
  * - route/destination이 null이면 항상 cancel만 수행 (route 종료).
  * - 언마운트: 모두 취소.
  *
@@ -69,7 +72,12 @@ export function useScheduledAlarms({
 
     await cancelScheduledAlarms();
     const currentRoute = routeRef.current;
-    if (!currentRoute || !currentDestination) return;
+    if (!currentRoute || !currentDestination) {
+      logger.info(
+        `skip reschedule appState=${appStateRef.current} reason=${!currentRoute ? 'no-route' : 'no-destination'}`,
+      );
+      return;
+    }
 
     // 진행 방향은 route + 현재역 ordinal로 결정한다 (#370). null이면 알 수 없음.
     // pickNextArrival에 filter로 전달해 반대방향 열차 ETA 오인을 차단.
@@ -86,13 +94,11 @@ export function useScheduledAlarms({
       direction,
     );
 
-    if (appStateRef.current === 'active') return;
-
     const pick = pickNextArrival(arrivalRef.current, direction, {
       preferTrainCode: trainCode,
     });
-    logger.debug(
-      `reschedule eta=${pick.etaSeconds} trainCode=${trainCode ?? 'none'} matched=${pick.matchedByTrainCode}`,
+    logger.info(
+      `reschedule appState=${appStateRef.current} eta=${pick.etaSeconds} trainCode=${trainCode ?? 'none'} matched=${pick.matchedByTrainCode}`,
     );
 
     await scheduleAlarmsForRoute({
@@ -105,16 +111,14 @@ export function useScheduledAlarms({
     });
   };
 
-  // AppState 전환 listener — 자체 등록 (중복 방지를 위해 다른 listener와 통합하지 않음).
+  // AppState 전환 listener — 'background' 진입 시 idempotent re-sync.
+  // FG에서 input-change effect가 비동기 reschedule을 채 완료하기 전에 OS가
+  // suspend되는 race를 차단하는 safety net 역할.
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state) => {
       const prev = appStateRef.current;
       appStateRef.current = state;
       if (state === prev) return;
-      if (state === 'active') {
-        cancelScheduledAlarms().catch((e) => logger.error('active 전환 취소 실패:', e));
-        return;
-      }
       if (state === 'background') {
         reschedule().catch((e) => logger.error('background 전환 재예약 실패:', e));
       }
@@ -125,7 +129,7 @@ export function useScheduledAlarms({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 입력 변동 시 재예약 — BG 상태에서만 의미가 있다. active면 reschedule이 내부에서 no-op.
+  // 입력 변동 시 재예약 — AppState와 무관하게 항상 schedule.
   // route/destination이 null이면 cancel만 발생.
   useEffect(() => {
     reschedule().catch((e) => logger.error('입력 변동 재예약 실패:', e));

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "Location permission required.",
     "locationRequiredDescription": "Please allow location permission in Settings.\nLocation permission is required to detect your current station.",
     "request": "Grant permission",
-    "locating": "Locating..."
+    "locating": "Locating...",
+    "backgroundDeniedTitle": "Background location required",
+    "backgroundDeniedBody": "To receive background alarms, set location access to \"Always\" in Settings.",
+    "openSettings": "Open Settings"
   },
   "home": {
     "arrived": "Arrived!",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "位置情報の許可が必要です。",
     "locationRequiredDescription": "設定で位置情報の利用を許可してください。\n現在の駅を検出するために位置情報が必要です。",
     "request": "許可する",
-    "locating": "位置情報を取得中..."
+    "locating": "位置情報を取得中...",
+    "backgroundDeniedTitle": "バックグラウンド位置情報の許可が必要です",
+    "backgroundDeniedBody": "バックグラウンドでアラームを受け取るには、設定で位置情報を「常に許可」にしてください。",
+    "openSettings": "設定を開く"
   },
   "home": {
     "arrived": "到着!",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "위치 권한이 필요합니다.",
     "locationRequiredDescription": "설정에서 위치 권한을 허용해 주세요.\n현재 탑승 중인 역을 감지하려면\n위치 권한이 필요합니다.",
     "request": "권한 요청",
-    "locating": "위치 확인 중..."
+    "locating": "위치 확인 중...",
+    "backgroundDeniedTitle": "백그라운드 위치 권한 필요",
+    "backgroundDeniedBody": "백그라운드에서 알람을 받으려면 설정에서 위치 권한을 '항상 허용'으로 설정해 주세요.",
+    "openSettings": "설정 열기"
   },
   "home": {
     "arrived": "도착!",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -16,7 +16,10 @@
     "locationRequiredShort": "需要位置权限。",
     "locationRequiredDescription": "请在设置中允许位置权限。\n要检测您当前的车站，需要位置权限。",
     "request": "授予权限",
-    "locating": "正在定位..."
+    "locating": "正在定位...",
+    "backgroundDeniedTitle": "需要后台位置权限",
+    "backgroundDeniedBody": "要在后台接收闹钟，请在设置中将位置访问设为\"始终允许\"。",
+    "openSettings": "打开设置"
   },
   "home": {
     "arrived": "已到达!",


### PR DESCRIPTION
## Summary
백그라운드에서 환승/도착 알림이 아예 발화되지 않던 문제를 한 PR로 해결. 3가지 차단 경로를 동시에 끊는다.

| 경로 | 변경 | 커밋 |
|------|------|------|
| **B: 사전 예약** ⭐ | \`useScheduledAlarms\`가 FG(active)에서 schedule을 skip하던 정책 제거 + 진단 로그 | 1번째 |
| **C: silent push** | \`UIBackgroundModes\`에 \`remote-notification\` + \`enableBackgroundRemoteNotifications: true\` | 2번째 |
| **A: BG GPS** | 권한 거부 시 \`Alert\` 안내 + \`Linking.openSettings()\` (i18n ko/en/ja/zh) | 3번째 |

## 배경
런타임 로그 진단으로 다음이 모두 차단되어 있었음:
- \`[AlarmScheduler] cancelled 0 scheduled alarms\` 반복 = 예약된 알람 0개
- \`[SilentPushTask] failed to register silent push task\`
- \`[BackgroundLocation] 백그라운드 위치 권한 거부 또는 취소됨\`

이전 분할 PR(#384, #386, #388) 및 중복 이슈(#385, #387)는 하나의 root cause라 통합. USB 실기기 테스트도 한 번에 가능.

## Test plan
- [x] \`npm test\` 1347 통과, 커버리지 100%
- [x] \`npm run type-check\` 통과
- [x] code-reviewer 3회 (각 변경별로 no issues)
- [ ] **USB 실기기 검증** — 이 PR 브랜치 체크아웃 후
  - [ ] \`npx expo prebuild --platform ios\` (PR-C의 Info.plist 동기화)
  - [ ] \`npx expo run:ios --device\` 빌드
  - [ ] 도착지 설정 즉시 콘솔에 \`[useScheduledAlarms] reschedule appState=active eta=… \` 로그 (경로 B 확인)
  - [ ] \`[SilentPushTask] silent push task registered\` info 로그, failed warn 사라짐 (경로 C 확인)
  - [ ] BG 위치 권한 거부 시 안내 모달 + "설정 열기" 동작 (경로 A 확인)
  - [ ] 잠금 후 ETA 도달 시점 알림 발화

## 후속
- silent push end-to-end는 \`EXPO_PUBLIC_ALARM_BACKEND_URL\` + 백엔드 가동 (#339) 필요. 본 PR은 등록 에러 제거 + 사전 예약(경로 B)으로 BG 알림 자체를 동작시키는 범위.

Closes #383