### PR TITLE
feat(#393): E2E mock mode 플래그 도입 (Phase 1)

### DIFF
--- a/docs/ci/e2e-revival-plan.md
+++ b/docs/ci/e2e-revival-plan.md
@@ -55,11 +55,13 @@ Phase 2A (#326 머지, dev에 포함) 이후 `useFusedNearestStation`은 `locati
 
 **완료 기준**: PR이 빨강불 노이즈 없이 머지 가능. dev/main은 그대로.
 
-### Phase 1 — E2E mock mode (별도 이슈)
-앱에 `EXPO_PUBLIC_E2E_MOCK=1` 플래그 도입:
-- `useFusedNearestStation`이 환경 변수 감지 시 고정 fixture (예: 강남역, accuracy=10m, confidence=high)로 단락.
-- `permissionDenied`/`locationUncertain` 분기를 우회.
-- 프로덕션 번들에는 dead-code-eliminate (env 비교가 빌드 시점 상수가 되도록).
+### Phase 1 — E2E mock mode (#393)
+앱에 `EXPO_PUBLIC_E2E_MOCK=true` 플래그 도입:
+- [x] `src/constants/e2e.ts` 신규 — `IS_E2E_MOCK` 빌드타임 상수 + 강남역 고정 fixture.
+- [x] `useNearestStation`이 mock 활성 시 권한/watch 흐름 우회 → 강남역(37.4980, 127.0277, accuracy 10m) 즉시 노출. 다운스트림 `useFusedNearestStation` / `useStationAlarm` / `useRouteProgress`는 자연 deterministic.
+- [x] `permissionDenied`/`locationUncertain` false 고정 → 홈 화면 게이트 통과.
+- [x] 프로덕션 번들에는 dead-code-eliminate (`process.env.EXPO_PUBLIC_E2E_MOCK === 'true'` 빌드 시점 상수).
+- [x] 테스트 1350 통과, 커버리지 100% 유지.
 
 **산출물**: 시뮬레이터 cold launch → 5초 내 destination-button 가시.
 

--- a/src/constants/__tests__/e2e.test.ts
+++ b/src/constants/__tests__/e2e.test.ts
@@ -1,0 +1,40 @@
+describe('constants/e2e', () => {
+  const originalEnv = process.env.EXPO_PUBLIC_E2E_MOCK;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXPO_PUBLIC_E2E_MOCK;
+    } else {
+      process.env.EXPO_PUBLIC_E2E_MOCK = originalEnv;
+    }
+    jest.resetModules();
+  });
+
+  it('EXPO_PUBLIC_E2E_MOCK이 "true"가 아닐 때 IS_E2E_MOCK은 false', () => {
+    delete process.env.EXPO_PUBLIC_E2E_MOCK;
+    jest.isolateModules(() => {
+      const { IS_E2E_MOCK } = require('../e2e');
+      expect(IS_E2E_MOCK).toBe(false);
+    });
+  });
+
+  it('EXPO_PUBLIC_E2E_MOCK="true" 일 때 IS_E2E_MOCK은 true', () => {
+    process.env.EXPO_PUBLIC_E2E_MOCK = 'true';
+    jest.isolateModules(() => {
+      const { IS_E2E_MOCK } = require('../e2e');
+      expect(IS_E2E_MOCK).toBe(true);
+    });
+  });
+
+  it('E2E_MOCK_LOCATION이 강남역 좌표', () => {
+    jest.isolateModules(() => {
+      const { E2E_MOCK_LOCATION } = require('../e2e');
+      expect(E2E_MOCK_LOCATION).toEqual({
+        latitude: 37.49799,
+        longitude: 127.027912,
+        accuracyMeters: 10,
+        speedMps: 0,
+      });
+    });
+  });
+});

--- a/src/constants/e2e.ts
+++ b/src/constants/e2e.ts
@@ -1,0 +1,18 @@
+/**
+ * E2E mock mode 빌드 타임 상수.
+ * EXPO_PUBLIC_E2E_MOCK=true로 빌드된 번들에서만 true.
+ * 프로덕션 빌드에서는 false 상수로 인라인되어 mock 분기가 dead-code-eliminate된다.
+ */
+export const IS_E2E_MOCK = process.env.EXPO_PUBLIC_E2E_MOCK === 'true';
+
+/**
+ * mock 모드에서 노출할 고정 좌표 — 강남역 2호선 (stations.json id "강남-2"와 동일).
+ * 좌표가 stations.json과 어긋나면 거리 임계값에서 미세 flake가 날 수 있으니
+ * 정본 데이터와 항상 일치시킨다.
+ */
+export const E2E_MOCK_LOCATION = {
+  latitude: 37.49799,
+  longitude: 127.027912,
+  accuracyMeters: 10,
+  speedMps: 0,
+} as const;

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -7,6 +7,19 @@ import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../
 
 jest.mock('expo-location');
 
+const e2eState = { isMock: false };
+jest.mock('../../constants/e2e', () => ({
+  get IS_E2E_MOCK() {
+    return e2eState.isMock;
+  },
+  E2E_MOCK_LOCATION: {
+    latitude: 37.49799,
+    longitude: 127.027912,
+    accuracyMeters: 10,
+    speedMps: 0,
+  },
+}));
+
 const mockRemove = jest.fn();
 let appStateCallback: ((state: string) => void) | null = null;
 jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) => {
@@ -612,5 +625,49 @@ describe('useNearestStation', () => {
 
     // MAX_STATION_DISTANCE_KM(1.0) 초과 → null
     expect(result.current.result).toBeNull();
+  });
+});
+
+describe('useNearestStation — E2E mock mode', () => {
+  beforeEach(() => {
+    e2eState.isMock = true;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    e2eState.isMock = false;
+  });
+
+  it('권한 API를 호출하지 않고 즉시 강남역 fixture를 노출한다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(Location.requestForegroundPermissionsAsync).not.toHaveBeenCalled();
+    expect(Location.watchPositionAsync).not.toHaveBeenCalled();
+    expect(Location.getLastKnownPositionAsync).not.toHaveBeenCalled();
+    expect(result.current.permissionDenied).toBe(false);
+    expect(result.current.locationUncertain).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.userLocation).toEqual({ lat: 37.49799, lng: 127.027912 });
+    expect(result.current.accuracyMeters).toBe(10);
+    expect(result.current.speedMps).toBe(0);
+    expect(result.current.result?.station.name).toBe('강남');
+  });
+
+  it('refresh 호출 시에도 권한 API를 호출하지 않고 fixture 상태를 유지한다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(Location.requestForegroundPermissionsAsync).not.toHaveBeenCalled();
+    expect(Location.getCurrentPositionAsync).not.toHaveBeenCalled();
+    expect(result.current.result?.station.name).toBe('강남');
+    expect(result.current.locationUncertain).toBe(false);
+    expect(result.current.permissionDenied).toBe(false);
   });
 });

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -5,6 +5,7 @@ import { NearestStationResult, Station } from '../types/station';
 import { findNearestStations } from '../utils/findNearestStation';
 import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../utils/locationGates';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../constants/e2e';
 
 const MIN_DISTANCE_CHANGE_KM = 0.003; // 3m — UI 갱신을 자주 흘려보낸다.
 
@@ -88,6 +89,22 @@ export function useNearestStation(): UseNearestStationReturn {
   const startWatch = useCallback(async () => {
     subscriptionRef.current?.remove();
     subscriptionRef.current = null;
+    if (IS_E2E_MOCK) {
+      setError(null);
+      setPermissionDenied(false);
+      setLocationUncertain(false);
+      applyLocation({
+        latitude: E2E_MOCK_LOCATION.latitude,
+        longitude: E2E_MOCK_LOCATION.longitude,
+        accuracy: E2E_MOCK_LOCATION.accuracyMeters,
+        speed: E2E_MOCK_LOCATION.speedMps,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+      });
+      setLoading(false);
+      return;
+    }
     try {
       setError(null);
       const { status } = await Location.requestForegroundPermissionsAsync();
@@ -137,6 +154,10 @@ export function useNearestStation(): UseNearestStationReturn {
   // 수동 새로고침: watch 중지 → one-shot → watch 재시작
   const refresh = useCallback(async () => {
     stopWatch();
+    if (IS_E2E_MOCK) {
+      await startWatch();
+      return;
+    }
     let shouldRestart = true;
     try {
       setError(null);


### PR DESCRIPTION
## Summary
- `EXPO_PUBLIC_E2E_MOCK=true`로 빌드된 앱은 권한 요청·watch 흐름을 우회하고 강남역 좌표(stations.json 정본 `37.49799, 127.027912`)를 즉시 노출 → `locationUncertain` 게이트 통과 → 홈 콘텐츠/destination-button 즉시 가시.
- 분기 지점은 `useNearestStation` 진입부. 다운스트림 `useFusedNearestStation` / `useStationAlarm` / `useRouteProgress`는 자연 deterministic.
- 프로덕션 번들에는 `process.env.EXPO_PUBLIC_E2E_MOCK === 'true'`가 빌드 시점 상수로 인라인되어 dead-code-eliminate.

## 변경 파일
- `src/constants/e2e.ts` 신규: `IS_E2E_MOCK`, `E2E_MOCK_LOCATION`
- `src/hooks/useNearestStation.ts`: `startWatch`/`refresh` 진입부 mock 분기
- 테스트: `src/constants/__tests__/e2e.test.ts`, `src/hooks/__tests__/useNearestStation.test.ts` (e2eState getter 패턴)
- `docs/ci/e2e-revival-plan.md` Phase 1 체크 갱신

## Out of scope (#390 후속 이슈로 분리)
- `e2e.yml`/`ci.yml` 변경 — Phase 2~3 (#394, #395)
- flow 디렉토리 재편 — Phase 2 (#394)
- 알람 imminent 타이밍 버그 — #396

## Test plan
- [x] `npm test` — 1350 passed, coverage 100% (lines/functions/branches/statements)
- [x] `npm run type-check` — pass
- [x] 수동: `EXPO_PUBLIC_E2E_MOCK=true npm run ios` → cold launch 5초 내 `destination-button` 가시
- [x] 수동: 일반 `npm run ios` → 기존 권한/GPS 흐름 회귀 없음

Closes #393