### PR TITLE
chore(#391): wrangler.toml에 production/preview KV id 반영

### DIFF
--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -7,8 +7,8 @@ compatibility_flags = ["nodejs_compat"]
 # 생성: wrangler kv:namespace create TRIPS
 [[kv_namespaces]]
 binding = "TRIPS"
-id = "REPLACE_WITH_PRODUCTION_KV_ID"
-preview_id = "REPLACE_WITH_PREVIEW_KV_ID"
+id = "8d10a57ffe4c46e28a6df33ef0c86b68"
+preview_id = "7e67683c147349ed90c16a28ae232e34"
 
 # 1분마다 활성 트립 폴링
 [triggers]


### PR DESCRIPTION
## Summary

- Cloudflare KV 네임스페이스(`TRIPS` production + preview) 생성 후 실제 id로 placeholder 교체
- Worker 배포 + 시크릿 5종(`SEOUL_API_KEY`, `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_BUNDLE_ID`, `APNS_PRIVATE_KEY`) 등록 완료
- Cron `*/1 * * * *` 정상 실행, GET /health → 200 OK
- 앱(Release) → `POST /trips` Worker 도달 + KV에 trip 레코드 생성 확인 (스모크 통과)

KV id는 Cloudflare 공식 권장 패턴에 따라 wrangler.toml에 commit (secret 아님).

## Test plan

- [x] `npm run deploy` 성공
- [x] `wrangler secret list` 5종 확인
- [x] `curl /health` → 200
- [x] 앱 → POST /trips 도달 (wrangler tail 로그)
- [x] `wrangler kv key list --binding TRIPS` → trip 레코드 확인
- [x] CI Type Check & Test 통과

## 후속

silent push end-to-end 6 시나리오 검증은 #339에서 진행.

Closes #391