### PR TITLE
fix(#400): silent push 백엔드 정확도 통합 수정 (transfer 보존 + line alias + threshold)

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -163,22 +163,20 @@ function FavoriteCard({
   const { t } = useTranslation();
   return (
     <View style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}>
-      {/* Remove 버튼을 onToggle TouchableOpacity 밖 sibling으로 배치.
-          중첩 TouchableOpacity는 iOS에서 부모 a11y 흡수로 자식 testID가 maestro에서 안 잡혔다. */}
-      <View style={styles.cardRow}>
-        <TouchableOpacity style={styles.cardMain} onPress={onToggle} activeOpacity={0.7}>
-          <View style={styles.cardInfo}>
-            <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
-              <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
-            </View>
-            <Text style={[styles.stationName, { color: colors.ink }]}>{getStationDisplayName(station)}</Text>
+      <TouchableOpacity style={styles.cardMain} onPress={onToggle} activeOpacity={0.7}>
+        <View style={styles.cardInfo}>
+          <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
+            <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
           </View>
+          <Text style={[styles.stationName, { color: colors.ink }]}>{getStationDisplayName(station)}</Text>
+        </View>
+        <View style={styles.cardActions}>
           <Text style={[styles.expandIcon, { color: colors.muted }]}>{isExpanded ? '▲' : '▼'}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.removeButton, { backgroundColor: colors.card }]} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
-          <Text style={[styles.removeText, { color: colors.danger }]}>{t('favorites.remove')}</Text>
-        </TouchableOpacity>
-      </View>
+          <TouchableOpacity style={[styles.removeButton, { backgroundColor: colors.card }]} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
+            <Text style={[styles.removeText, { color: colors.danger }]}>{t('favorites.remove')}</Text>
+          </TouchableOpacity>
+        </View>
+      </TouchableOpacity>
 
       {isExpanded && (
         <View style={[styles.arrivalSection, { borderTopColor: colors.hair }]}>
@@ -280,20 +278,19 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     overflow: 'hidden',
   },
-  cardRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 16,
-    gap: 12,
-  },
   cardMain: {
-    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    padding: 16,
   },
   cardInfo: {
     flex: 1,
+  },
+  cardActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
   },
   expandIcon: {
     fontSize: 12,

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -163,20 +163,22 @@ function FavoriteCard({
   const { t } = useTranslation();
   return (
     <View style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}>
-      <TouchableOpacity style={styles.cardMain} onPress={onToggle} activeOpacity={0.7}>
-        <View style={styles.cardInfo}>
-          <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
-            <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
+      {/* Remove 버튼을 onToggle TouchableOpacity 밖 sibling으로 배치.
+          중첩 TouchableOpacity는 iOS에서 부모 a11y 흡수로 자식 testID가 maestro에서 안 잡혔다. */}
+      <View style={styles.cardRow}>
+        <TouchableOpacity style={styles.cardMain} onPress={onToggle} activeOpacity={0.7}>
+          <View style={styles.cardInfo}>
+            <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
+              <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
+            </View>
+            <Text style={[styles.stationName, { color: colors.ink }]}>{getStationDisplayName(station)}</Text>
           </View>
-          <Text style={[styles.stationName, { color: colors.ink }]}>{getStationDisplayName(station)}</Text>
-        </View>
-        <View style={styles.cardActions}>
           <Text style={[styles.expandIcon, { color: colors.muted }]}>{isExpanded ? '▲' : '▼'}</Text>
-          <TouchableOpacity style={[styles.removeButton, { backgroundColor: colors.card }]} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
-            <Text style={[styles.removeText, { color: colors.danger }]}>{t('favorites.remove')}</Text>
-          </TouchableOpacity>
-        </View>
-      </TouchableOpacity>
+        </TouchableOpacity>
+        <TouchableOpacity style={[styles.removeButton, { backgroundColor: colors.card }]} onPress={onRemove} testID={`favorite-remove-${station.id}`}>
+          <Text style={[styles.removeText, { color: colors.danger }]}>{t('favorites.remove')}</Text>
+        </TouchableOpacity>
+      </View>
 
       {isExpanded && (
         <View style={[styles.arrivalSection, { borderTopColor: colors.hair }]}>
@@ -278,19 +280,20 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     overflow: 'hidden',
   },
+  cardRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    gap: 12,
+  },
   cardMain: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: 16,
   },
   cardInfo: {
     flex: 1,
-  },
-  cardActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
   },
   expandIcon: {
     fontSize: 12,

--- a/backend/alarm-worker/src/__tests__/alarm.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarm.test.ts
@@ -12,9 +12,10 @@ describe('evaluatePhase', () => {
     expect(evaluatePhase(IMMINENT_THRESHOLD_SEC)).toBe('imminent');
     expect(evaluatePhase(0)).toBe('imminent');
   });
-  it('early between 31s and 180s', () => {
+  it('early between 31s and EARLY_THRESHOLD_SEC', () => {
     expect(evaluatePhase(IMMINENT_THRESHOLD_SEC + 1)).toBe('early');
     expect(evaluatePhase(EARLY_THRESHOLD_SEC)).toBe('early');
+    expect(evaluatePhase(240)).toBe('early');
   });
   it('null above early threshold', () => {
     expect(evaluatePhase(EARLY_THRESHOLD_SEC + 1)).toBeNull();

--- a/backend/alarm-worker/src/__tests__/lineAlias.test.ts
+++ b/backend/alarm-worker/src/__tests__/lineAlias.test.ts
@@ -7,41 +7,33 @@ describe('matchLine', () => {
     expect(matchLine('지하철2호선', '')).toBe(false);
   });
 
-  it('matches numeric line codes against Seoul API names', () => {
-    expect(matchLine('지하철1호선', '1')).toBe(true);
-    expect(matchLine('지하철9호선', '9')).toBe(true);
+  it.each([
+    ['지하철1호선', '1'],
+    ['지하철9호선', '9'],
+    ['경의중앙선', 'gyeongui'],
+    ['지하철경의중앙선', 'gyeongui'],
+    ['수인분당선', 'bundang'],
+    ['지하철수인분당선', 'bundang'],
+    ['분당선', 'bundang'],
+    ['신분당선', 'sinbundang'],
+    ['지하철신분당선', 'sinbundang'],
+    ['공항철도', 'airport'],
+    ['인천국제공항철도', 'airport'],
+  ])('matches subwayNm="%s" against line="%s"', (subwayNm, line) => {
+    expect(matchLine(subwayNm, line)).toBe(true);
   });
 
-  it('matches gyeongui code against various Seoul API spellings', () => {
-    expect(matchLine('경의중앙선', 'gyeongui')).toBe(true);
-    expect(matchLine('지하철경의중앙선', 'gyeongui')).toBe(true);
-  });
-
-  it('matches bundang code', () => {
-    expect(matchLine('수인분당선', 'bundang')).toBe(true);
-    expect(matchLine('지하철수인분당선', 'bundang')).toBe(true);
-    expect(matchLine('분당선', 'bundang')).toBe(true);
-  });
-
-  it('matches sinbundang code', () => {
-    expect(matchLine('신분당선', 'sinbundang')).toBe(true);
-    expect(matchLine('지하철신분당선', 'sinbundang')).toBe(true);
-  });
-
-  it('matches airport code', () => {
-    expect(matchLine('공항철도', 'airport')).toBe(true);
-    expect(matchLine('인천국제공항철도', 'airport')).toBe(true);
-  });
-
-  it('rejects mismatched lines for aliased codes', () => {
-    expect(matchLine('지하철1호선', 'gyeongui')).toBe(false);
-    expect(matchLine('경의중앙선', '1')).toBe(false);
+  it.each([
+    ['지하철1호선', 'gyeongui'],
+    ['경의중앙선', '1'],
+    ['A선', 'B'],
+  ])('rejects subwayNm="%s" against line="%s"', (subwayNm, line) => {
+    expect(matchLine(subwayNm, line)).toBe(false);
   });
 
   it('falls back to substring matching for unmapped line codes', () => {
     expect(matchLine('미래노선', '미래')).toBe(true);
     expect(matchLine('미래', '미래노선')).toBe(true);
-    expect(matchLine('A선', 'B')).toBe(false);
   });
 
   it('covers all line codes present in stations.json', () => {

--- a/backend/alarm-worker/src/__tests__/lineAlias.test.ts
+++ b/backend/alarm-worker/src/__tests__/lineAlias.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { LINE_ALIAS_MAP, matchLine } from '../lineAlias';
+
+describe('matchLine', () => {
+  it('returns false when subwayNm or line is empty', () => {
+    expect(matchLine('', '2')).toBe(false);
+    expect(matchLine('지하철2호선', '')).toBe(false);
+  });
+
+  it('matches numeric line codes against Seoul API names', () => {
+    expect(matchLine('지하철1호선', '1')).toBe(true);
+    expect(matchLine('지하철9호선', '9')).toBe(true);
+  });
+
+  it('matches gyeongui code against various Seoul API spellings', () => {
+    expect(matchLine('경의중앙선', 'gyeongui')).toBe(true);
+    expect(matchLine('지하철경의중앙선', 'gyeongui')).toBe(true);
+  });
+
+  it('matches bundang code', () => {
+    expect(matchLine('수인분당선', 'bundang')).toBe(true);
+    expect(matchLine('지하철수인분당선', 'bundang')).toBe(true);
+    expect(matchLine('분당선', 'bundang')).toBe(true);
+  });
+
+  it('matches sinbundang code', () => {
+    expect(matchLine('신분당선', 'sinbundang')).toBe(true);
+    expect(matchLine('지하철신분당선', 'sinbundang')).toBe(true);
+  });
+
+  it('matches airport code', () => {
+    expect(matchLine('공항철도', 'airport')).toBe(true);
+    expect(matchLine('인천국제공항철도', 'airport')).toBe(true);
+  });
+
+  it('rejects mismatched lines for aliased codes', () => {
+    expect(matchLine('지하철1호선', 'gyeongui')).toBe(false);
+    expect(matchLine('경의중앙선', '1')).toBe(false);
+  });
+
+  it('falls back to substring matching for unmapped line codes', () => {
+    expect(matchLine('미래노선', '미래')).toBe(true);
+    expect(matchLine('미래', '미래노선')).toBe(true);
+    expect(matchLine('A선', 'B')).toBe(false);
+  });
+
+  it('covers all line codes present in stations.json', () => {
+    const expected = [
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      'gyeongui',
+      'bundang',
+      'sinbundang',
+      'airport',
+    ];
+    for (const code of expected) {
+      expect(LINE_ALIAS_MAP[code]).toBeDefined();
+      expect(LINE_ALIAS_MAP[code].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -123,6 +123,14 @@ describe('pickBestEtaSeconds', () => {
     ];
     expect(pickBestEtaSeconds(arrivals, wp)).toBe(100);
   });
+  it('matches gyeongui line against 경의중앙선 subwayNm via alias map', () => {
+    const arrivals: ArrivalEntry[] = [
+      { destination: '용문', arrivalSeconds: 90, trainCode: 'G', isUp: true, subwayNm: '경의중앙선' },
+      { destination: '용문', arrivalSeconds: 200, trainCode: 'H', isUp: true, subwayNm: '지하철1호선' },
+    ];
+    const gyeonguiWp = { stationName: '회기', line: 'gyeongui', kind: 'destination' as const };
+    expect(pickBestEtaSeconds(arrivals, gyeonguiWp)).toBe(90);
+  });
 });
 
 describe('runScheduled', () => {
@@ -157,7 +165,7 @@ describe('runScheduled', () => {
     expect(kv.store.size).toBe(0);
   });
 
-  it('fires imminent push and removes trip', async () => {
+  it('fires imminent push and removes trip when waypoint kind is destination', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeTrip());
     const seoul = makeSeoul([
@@ -172,7 +180,74 @@ describe('runScheduled', () => {
     });
     expect(stats.pushed).toBe(1);
     expect(apnsFetch).toHaveBeenCalledTimes(1);
-    expect(kv.store.size).toBe(0); // imminent → 트립 종료
+    expect(kv.store.size).toBe(0); // destination imminent → 트립 종료
+  });
+
+  it('keeps trip and advances waypoint when transfer waypoint reaches imminent', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        waypoints: [
+          { stationName: '신도림', line: '2', kind: 'transfer' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      }),
+    );
+    const seoul = makeSeoul([
+      { destination: '신도림', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
+    ]);
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBe(1);
+    expect(kv.store.size).toBe(1); // trip retained
+    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
+    expect(stored.waypoints).toHaveLength(1);
+    expect(stored.waypoints[0].stationName).toBe('강남');
+    expect(stored.lastFiredPhase).toBeUndefined();
+    expect(stored.lastEtaSeconds).toBeUndefined();
+  });
+
+  it('deletes trip when last waypoint (after shift) is empty', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        // 비정상 케이스: transfer만 있고 destination 없음. shift 후 비면 trip 삭제.
+        waypoints: [{ stationName: '신도림', line: '2', kind: 'transfer' }],
+      }),
+    );
+    const seoul = makeSeoul([
+      { destination: '신도림', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
+    ]);
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBe(1);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('counts ETA-missing cycles separately from errors', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const seoul = makeSeoul([]); // 빈 응답
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      now: () => NOW,
+    });
+    expect(stats.etaMissing).toBe(1);
+    expect(stats.pushed).toBe(0);
+    expect(stats.errors).toBe(0);
   });
 
   it('fires early then upgrades to imminent', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -72,6 +72,31 @@ function makeTrip(overrides: Partial<Trip> = {}): Trip {
   };
 }
 
+function makeImminentArrival(stationName: string): ArrivalEntry {
+  return {
+    destination: stationName,
+    arrivalSeconds: 20,
+    trainCode: 'T',
+    isUp: true,
+    subwayNm: '지하철2호선',
+  };
+}
+
+async function runWithImminent(
+  kv: InMemoryKV,
+  stationName: string,
+): Promise<{ stats: Awaited<ReturnType<typeof runScheduled>>; apnsFetch: ReturnType<typeof vi.fn> }> {
+  const seoul = makeSeoul([makeImminentArrival(stationName)]);
+  const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+  const stats = await runScheduled(makeEnv(kv), {
+    seoul,
+    apnsConfig,
+    fetchImpl: apnsFetch as unknown as typeof fetch,
+    now: () => NOW,
+  });
+  return { stats, apnsFetch };
+}
+
 function makeSeoul(arrivals: ArrivalEntry[]): SeoulArrivalClient {
   return new SeoulArrivalClient({
     apiKey: 'K',
@@ -168,16 +193,7 @@ describe('runScheduled', () => {
   it('fires imminent push and removes trip when waypoint kind is destination', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeTrip());
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
-    ]);
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    const { stats, apnsFetch } = await runWithImminent(kv, '강남');
     expect(stats.pushed).toBe(1);
     expect(apnsFetch).toHaveBeenCalledTimes(1);
     expect(kv.store.size).toBe(0); // destination imminent → 트립 종료
@@ -194,16 +210,7 @@ describe('runScheduled', () => {
         ],
       }),
     );
-    const seoul = makeSeoul([
-      { destination: '신도림', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
-    ]);
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    const { stats } = await runWithImminent(kv, '신도림');
     expect(stats.pushed).toBe(1);
     expect(kv.store.size).toBe(1); // trip retained
     const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
@@ -222,16 +229,7 @@ describe('runScheduled', () => {
         waypoints: [{ stationName: '신도림', line: '2', kind: 'transfer' }],
       }),
     );
-    const seoul = makeSeoul([
-      { destination: '신도림', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
-    ]);
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    const { stats } = await runWithImminent(kv, '신도림');
     expect(stats.pushed).toBe(1);
     expect(kv.store.size).toBe(0);
   });

--- a/backend/alarm-worker/src/alarm.ts
+++ b/backend/alarm-worker/src/alarm.ts
@@ -3,7 +3,11 @@
  *
  * 백엔드는 stops 정보가 없으므로 ETA만으로 판정한다.
  * - imminent: etaSeconds <= 30 (도착 임박)
- * - early   : etaSeconds <= 180 (3분 이하)
+ * - early   : etaSeconds <= 240 (4분 이하)
+ *
+ * EARLY는 240으로 잡는다. cron 주기 1분 + Seoul API 갱신 지연 ~수십초가 누적되면
+ * 180초 경계에서 한 cycle 놓치고 ~60초 늦은 알림이 발생할 수 있어, 한 cycle만큼의
+ * 버퍼를 두어 그 가능성을 줄인다.
  *
  * 또한 ETA 변동 폭이 임계치(±60초) 이상이면 트립 메모리 갱신용으로 변동을 신호한다.
  */
@@ -11,7 +15,7 @@
 export type AlarmPhase = 'early' | 'imminent';
 
 export const IMMINENT_THRESHOLD_SEC = 30;
-export const EARLY_THRESHOLD_SEC = 180;
+export const EARLY_THRESHOLD_SEC = 240;
 export const ETA_DELTA_THRESHOLD_SEC = 60;
 
 const PHASE_ORDER: readonly AlarmPhase[] = ['early', 'imminent'];

--- a/backend/alarm-worker/src/lineAlias.ts
+++ b/backend/alarm-worker/src/lineAlias.ts
@@ -1,0 +1,48 @@
+/**
+ * 클라이언트 line code(stations.json의 `line` 필드) → Seoul API `subwayNm` 후보 매핑.
+ *
+ * Seoul API는 "지하철1호선", "지하철경의중앙선" 등 한글명을 돌려준다.
+ * 영문 코드(`gyeongui`, `airport` 등)는 substring 매칭으로는 절대 잡히지 않으므로
+ * 명시적 alias 배열로 매칭한다. 숫자 호선("1"~"9")은 "지하철1호선" 같은 접미 형식 매칭.
+ *
+ * 신규 노선은 이 맵에 alias를 추가하기만 하면 매칭에 반영된다.
+ */
+
+export const LINE_ALIAS_MAP: Record<string, readonly string[]> = {
+  '1': ['지하철1호선', '1호선'],
+  '2': ['지하철2호선', '2호선'],
+  '3': ['지하철3호선', '3호선'],
+  '4': ['지하철4호선', '4호선'],
+  '5': ['지하철5호선', '5호선'],
+  '6': ['지하철6호선', '6호선'],
+  '7': ['지하철7호선', '7호선'],
+  '8': ['지하철8호선', '8호선'],
+  '9': ['지하철9호선', '9호선'],
+  gyeongui: ['경의중앙선', '지하철경의중앙선', '경의중앙'],
+  bundang: ['수인분당선', '지하철수인분당선', '분당선', '수인분당'],
+  sinbundang: ['신분당선', '지하철신분당선'],
+  airport: ['공항철도', '인천국제공항철도'],
+};
+
+/**
+ * Seoul API의 subwayNm이 클라이언트 line code와 매칭되는지 판정한다.
+ *
+ * 우선순위:
+ *   1. line code에 대응되는 alias 배열 중 하나가 subwayNm과 정확히 일치하거나
+ *      subwayNm이 alias를 포함하면 true (예: subwayNm="지하철경의중앙선", alias="경의중앙선")
+ *   2. alias 매핑이 없는 경우 (예: 신규 노선) substring 매칭으로 fallback
+ */
+export function matchLine(subwayNm: string, line: string): boolean {
+  if (!subwayNm || !line) return false;
+
+  const aliases = LINE_ALIAS_MAP[line];
+  if (aliases) {
+    for (const alias of aliases) {
+      if (subwayNm === alias) return true;
+      if (subwayNm.includes(alias) || alias.includes(subwayNm)) return true;
+    }
+    return false;
+  }
+
+  return subwayNm.includes(line) || line.includes(subwayNm);
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -117,11 +117,11 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
                 continue;
               }
               // 환승역 imminent: 트립 유지하고 다음 waypoint로 진행.
+              // dirty는 위(lastFiredPhase 갱신)에서 이미 true로 설정됨 → putTrip에서 shift된 상태가 저장된다.
               const completedStation = waypoint.stationName;
               trip.waypoints.shift();
               trip.lastFiredPhase = undefined;
               trip.lastEtaSeconds = undefined;
-              dirty = true;
               log('waypoint completed, advancing to next', {
                 token: trip.token.slice(0, 8),
                 completed: completedStation,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -9,6 +9,7 @@ import {
   shouldFire,
 } from './alarm';
 import { sendSilentPush, type ApnsConfig } from './apns';
+import { matchLine } from './lineAlias';
 import { SeoulArrivalClient, type ArrivalEntry } from './seoul';
 import { deleteTrip, listTrips, putTrip } from './trips';
 import type { Env, Trip, Waypoint } from './types';
@@ -21,6 +22,8 @@ export interface ScheduledStats {
   polled: number;
   pushed: number;
   errors: number;
+  /** Seoul API 응답이 비어 ETA를 산출하지 못한 트립 수 (운영 가시성용). */
+  etaMissing: number;
 }
 
 export interface ScheduledDeps {
@@ -34,7 +37,13 @@ export interface ScheduledDeps {
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
   const now = deps.now?.() ?? Date.now();
   const log = deps.log ?? (() => undefined);
-  const stats: ScheduledStats = { scanned: 0, polled: 0, pushed: 0, errors: 0 };
+  const stats: ScheduledStats = {
+    scanned: 0,
+    polled: 0,
+    pushed: 0,
+    errors: 0,
+    etaMissing: 0,
+  };
 
   for await (const trip of listTrips(env.TRIPS)) {
     stats.scanned += 1;
@@ -56,7 +65,15 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     try {
       const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
       const eta = pickBestEtaSeconds(arrivals, waypoint);
-      if (eta === null) continue;
+      if (eta === null) {
+        stats.etaMissing += 1;
+        log('empty arrivals — skip cycle', {
+          token: trip.token.slice(0, 8),
+          station: waypoint.stationName,
+          line: waypoint.line,
+        });
+        continue;
+      }
 
       const phase = evaluatePhase(eta);
       const etaChanged = isSignificantEtaChange(trip.lastEtaSeconds, eta);
@@ -70,9 +87,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       }
 
       // Push 발사 조건:
-      // (1) 새 phase 도달 (phaseFires)
+      // (1) 새 phase 도달 (phaseFires) — phaseFires는 phase !== null을 이미 포함
       // (2) phase 미도달이지만 ETA 변동이 의미있게 발생 & 5분 이내 (사용자에게 정보 갱신)
-      const shouldPushPhase = phaseFires && phase !== null;
+      const shouldPushPhase = phaseFires;
       const shouldPushEtaUpdate =
         !shouldPushPhase && etaChanged && eta <= EARLY_THRESHOLD_SEC * 2;
 
@@ -92,9 +109,28 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
             trip.lastFiredPhase = phase!;
             dirty = true;
             if (phase === 'imminent') {
-              await deleteTrip(env.TRIPS, trip.token);
-              log('trip completed after imminent push', { token: trip.token.slice(0, 8) });
-              continue;
+              if (waypoint.kind === 'destination') {
+                await deleteTrip(env.TRIPS, trip.token);
+                log('trip completed after destination imminent push', {
+                  token: trip.token.slice(0, 8),
+                });
+                continue;
+              }
+              // 환승역 imminent: 트립 유지하고 다음 waypoint로 진행.
+              const completedStation = waypoint.stationName;
+              trip.waypoints.shift();
+              trip.lastFiredPhase = undefined;
+              trip.lastEtaSeconds = undefined;
+              dirty = true;
+              log('waypoint completed, advancing to next', {
+                token: trip.token.slice(0, 8),
+                completed: completedStation,
+                remaining: trip.waypoints.length,
+              });
+              if (trip.waypoints.length === 0) {
+                await deleteTrip(env.TRIPS, trip.token);
+                continue;
+              }
             }
           }
         } else {
@@ -145,23 +181,13 @@ export function pickBestEtaSeconds(
   waypoint: Waypoint,
 ): number | null {
   if (arrivals.length === 0) return null;
-  const matchingLine = arrivals.filter((a) => isLineMatch(a.subwayNm, waypoint.line));
+  const matchingLine = arrivals.filter((a) => matchLine(a.subwayNm, waypoint.line));
   const pool = matchingLine.length > 0 ? matchingLine : arrivals;
   const min = pool.reduce(
     (acc, cur) => (cur.arrivalSeconds < acc ? cur.arrivalSeconds : acc),
     Number.POSITIVE_INFINITY,
   );
   return Number.isFinite(min) ? min : null;
-}
-
-/**
- * 노선 매칭 — Seoul API는 "지하철1호선", "수도권2호선" 같은 형식.
- * waypoint.line은 "1", "2" 또는 "수인분당" 등의 키.
- * 둘 중 하나가 다른 쪽 문자열에 포함되면 매칭으로 간주한다.
- */
-function isLineMatch(subwayNm: string, line: string): boolean {
-  if (!subwayNm || !line) return false;
-  return subwayNm.includes(line) || line.includes(subwayNm);
 }
 
 function isUnrecoverableApnsError(status: number, reason: string | undefined): boolean {


### PR DESCRIPTION
## 배경

실기기 검증에서 9건 증상 관찰. PR #391/#399로 silent push 백엔드가 배포 완료된 상태이므로, BG 알림 정확도를 silent push 경로에서 해결한다. (사전 예약 stopgap은 이번 범위에서 유지)

## 변경

### A1+A2: 환승역 imminent → trip 보존 + waypoint 진행 (가장 중요)
`backend/alarm-worker/src/scheduled.ts`
- 기존: waypoint kind 무관하게 `imminent` 발사 후 `deleteTrip` → **환승역이 imminent로 잡히면 하차역 알림이 절대 안 옴**
- 수정: `kind === 'destination'`일 때만 trip 삭제. transfer면 `waypoints.shift()` + `lastFiredPhase`/`lastEtaSeconds` reset 후 진행. shift 결과 비면 방어적 삭제.
- 가설: 경의중앙선 하차/환승 누락 증상의 직접 원인

### A3: 영문 line code alias 매핑
`backend/alarm-worker/src/lineAlias.ts` (신규)
- `LINE_ALIAS_MAP: Record<string, readonly string[]>` — `gyeongui`/`bundang`/`sinbundang`/`airport` + `1`~`9`를 Seoul API `subwayNm` 후보 배열로
- `matchLine(subwayNm, line)` — alias 우선, 미매핑 코드는 substring fallback
- 신규 노선은 alias 한 줄 추가로 확장 (글로벌 규칙 3 — 데이터 주도)

### A5: EARLY_THRESHOLD_SEC 180 → 240
`backend/alarm-worker/src/alarm.ts`
- cron 1분 주기 + Seoul API 갱신 지연에서 경계 한 cycle 놓치는 ~60초 오차 흡수

### A6: ETA 산출 실패 가시성
- `etaMissing` 카운터 + warn 로그. (Seoul API 빈 응답 본격 fallback은 별도 이슈)

## 범위 외 (별도 이슈 예정)
- **PR B**: 위치 source 강건화 (지도 위치 버튼 fresh fix, BG→FG refresh) — \"통과 알림\" 카피/시점 이슈도 위치 stale의 결과이므로 PR B에서 자연 해결
- 사전 예약 stopgap 제거 (silent push 안정화 후)
- Seoul API 빈 응답 본격 fallback
- C: 도착 판정 잔존 지연 여부 확인

## 검증

- backend/alarm-worker: 67 tests pass, type-check pass
- root: 1350 tests pass (커버리지 100%), type-check pass
- code-reviewer 에이전트: P1 2건(중복 조건 제거, dirty 명시) + P2 2건(alias 양방향, 카운터 이름) 반영

## Test plan
- [x] 단위 테스트: transfer imminent에서 trip 미삭제 + 다음 waypoint active
- [x] 단위 테스트: shift 후 waypoints 비면 방어적 삭제
- [x] 단위 테스트: `pickBestEtaSeconds`가 `gyeongui` line을 `경의중앙선` subwayNm과 매칭
- [x] 단위 테스트: `etaMissing` 카운터가 errors와 분리됨
- [x] 단위 테스트: `evaluatePhase(240) === 'early'`
- [x] 실기기 운행 시간대 재검증 (환승 2~3정거장 경로, 경의중앙선 포함)
- [x] Worker tail 로그에서 transfer 보존/destination 삭제 흐름 확인

Closes #400