### PR TITLE
fix(#401): 환승역 노선별 표기 정규화로 우회 경로 버그 해결

### DIFF
--- a/src/utils/__tests__/routeWaypoints.test.ts
+++ b/src/utils/__tests__/routeWaypoints.test.ts
@@ -76,16 +76,11 @@ describe('routeToWaypoints', () => {
   // 환승역 표기가 노선별로 다른 경우(예: 7호선 "상봉" vs 경의중앙 "상봉(시외버스터미널)").
   // 같은 역이므로 destination 단일화로 축약되어야 한다 (== 비교는 거짓 → 분리되는 회귀 방지).
   it('transfer: transferName과 destinationName의 노선별 표기가 달라도 같은 역으로 축약', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
-      transferName: '상봉',
-      fromLine: '7',
-      toLine: 'gyeongui',
-      stopsToTransfer: 3,
-      stopsFromTransfer: 0,
-    };
-    expect(routeToWaypoints(route, '상봉(시외버스터미널)')).toEqual([
-      { stationName: '상봉(시외버스터미널)', line: '7', kind: 'destination' },
-    ]);
+    const result = routeToWaypoints(
+      { type: 'transfer', transferName: '상봉', fromLine: '7', toLine: 'gyeongui', stopsToTransfer: 3, stopsFromTransfer: 0 },
+      '상봉(시외버스터미널)',
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: 'destination', stationName: '상봉(시외버스터미널)', line: '7' });
   });
 });

--- a/src/utils/__tests__/routeWaypoints.test.ts
+++ b/src/utils/__tests__/routeWaypoints.test.ts
@@ -72,4 +72,20 @@ describe('routeToWaypoints', () => {
       { stationName: '교대', line: '2', kind: 'destination' },
     ]);
   });
+
+  // 환승역 표기가 노선별로 다른 경우(예: 7호선 "상봉" vs 경의중앙 "상봉(시외버스터미널)").
+  // 같은 역이므로 destination 단일화로 축약되어야 한다 (== 비교는 거짓 → 분리되는 회귀 방지).
+  it('transfer: transferName과 destinationName의 노선별 표기가 달라도 같은 역으로 축약', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '상봉',
+      fromLine: '7',
+      toLine: 'gyeongui',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 0,
+    };
+    expect(routeToWaypoints(route, '상봉(시외버스터미널)')).toEqual([
+      { stationName: '상봉(시외버스터미널)', line: '7', kind: 'destination' },
+    ]);
+  });
 });

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -90,6 +90,22 @@ describe('resolveAllTargets', () => {
       { name: '강남', stops: 3, alarmType: 'destination' },
     ]);
   });
+
+  // 노선별 표기 차이를 정규화 흡수해서 단일 destination으로 축약 (#401 회귀 방지).
+  it('transferName과 destinationName이 노선별 표기 차이만 있으면 단일 destination으로 축약', () => {
+    expect(
+      resolveAllTargets(makeTransferRoute(3, 0, '상봉', 'gyeongui', '7'), '상봉(시외버스터미널)'),
+    ).toEqual([{ name: '상봉(시외버스터미널)', stops: 3, alarmType: 'destination' }]);
+  });
+
+  it('multi-transfer 마지막 환승역 표기 차이도 동일하게 축약', () => {
+    expect(
+      resolveAllTargets(makeMultiRoute(5, 3, 0, '시청', '왕십리'), '왕십리(성동구청)'),
+    ).toEqual([
+      { name: '시청', stops: 5, alarmType: 'transfer' },
+      { name: '왕십리(성동구청)', stops: 3, alarmType: 'destination' },
+    ]);
+  });
 });
 
 describe('evaluateAlarmPhase', () => {

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1055,6 +1055,10 @@ describe('normalizeStationName', () => {
   it('괄호 앞 공백도 함께 제거한다', () => {
     expect(normalizeStationName('테스트 (부제)')).toBe('테스트');
   });
+
+  it('역명이 모두 괄호로 시작하면 원본을 반환한다 (방어)', () => {
+    expect(normalizeStationName('(부제)')).toBe('(부제)');
+  });
 });
 
 describe('isSameStationName', () => {

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 
@@ -170,9 +170,13 @@ describe('findRoute', () => {
     const gyeongui = getStationsOnLine('gyeongui');
     const line2 = getStationsOnLine('2');
     const gyeonguiHongdae = gyeongui.find((s) => s.name === '홍대입구');
-    const line2First = line2[0];
+    // 합정(2-038)은 홍대입구(2-039) 바로 옆 → 홍대입구 환승이 명확히 최단.
+    // line2[0](시청)은 정규화 fallback 적용 후 왕십리 환승이 더 짧아 후보 다양화로 인해
+    // 단일 환승역 단정 의미가 사라짐. 테스트 의도(경의중앙↔2호선 환승) 유지하면서 결정성 확보.
+    const hapjeong = line2.find((s) => s.name === '합정');
     expect(gyeonguiHongdae).toBeDefined();
-    const route = findRoute(gyeonguiHongdae!.id, line2First.id);
+    expect(hapjeong).toBeDefined();
+    const route = findRoute(gyeonguiHongdae!.id, hapjeong!.id);
     expect(route?.type).toBe('transfer');
     if (route?.type === 'transfer') {
       expect(route.transferName).toBe('홍대입구');
@@ -1033,5 +1037,89 @@ describe('isStationOnRoute', () => {
 
   it('multi-transfer route — 어느 환승 구간에도 없으면 false', () => {
     expect(isStationOnRoute(makeStation('7'), multiTransferRoute)).toBe(false);
+  });
+});
+
+describe('normalizeStationName', () => {
+  it('후행 괄호 부제를 제거한다', () => {
+    expect(normalizeStationName('상봉(시외버스터미널)')).toBe('상봉');
+    expect(normalizeStationName('왕십리(성동구청)')).toBe('왕십리');
+    expect(normalizeStationName('청량리(서울시립대입구)')).toBe('청량리');
+  });
+
+  it('괄호 없는 이름은 그대로 반환한다', () => {
+    expect(normalizeStationName('용마산')).toBe('용마산');
+    expect(normalizeStationName('상봉')).toBe('상봉');
+  });
+
+  it('괄호 앞 공백도 함께 제거한다', () => {
+    expect(normalizeStationName('테스트 (부제)')).toBe('테스트');
+  });
+});
+
+describe('isSameStationName', () => {
+  it('정확 일치', () => {
+    expect(isSameStationName('상봉', '상봉')).toBe(true);
+  });
+  it('정규화 후 일치', () => {
+    expect(isSameStationName('상봉', '상봉(시외버스터미널)')).toBe(true);
+    expect(isSameStationName('왕십리(성동구청)', '왕십리')).toBe(true);
+  });
+  it('다른 역은 false', () => {
+    expect(isSameStationName('상봉', '용마산')).toBe(false);
+  });
+});
+
+describe('findStationByNameAndLine — 정규화 fallback', () => {
+  it('정확 이름이 없으면 정규화 비교로 매칭한다', () => {
+    // 경의중앙 상봉은 "상봉(시외버스터미널)"로 등록되어 있음
+    const station = findStationByNameAndLine('상봉', 'gyeongui');
+    expect(station).toBeDefined();
+    expect(station?.id).toBe('gyeongui-039');
+  });
+
+  it('정확 이름이 있으면 그대로 반환한다', () => {
+    expect(findStationByNameAndLine('상봉', '7')?.id).toBe('7-012');
+  });
+
+  it('정규화 후에도 매칭이 없으면 undefined', () => {
+    expect(findStationByNameAndLine('존재하지않는역', '1')).toBeUndefined();
+  });
+});
+
+describe('환승역 이름 표기 불일치 회귀 — #401', () => {
+  it('용마산(7) → 중랑(경의중앙): 상봉 1회 환승 후보가 포함된다', () => {
+    const candidates = findRoutes('7-015', 'gyeongui-038');
+    const single = candidates.find((c) => c.transferCount === 1);
+    expect(single).toBeDefined();
+    expect((single!.route as TransferRoute).type).toBe('transfer');
+    expect(normalizeStationName((single!.route as TransferRoute).transferName)).toBe('상봉');
+  });
+
+  it('용마산 → 중랑: 1회 환승이 2회 환승보다 빠르다 (또는 동등)', () => {
+    const candidates = findRoutes('7-015', 'gyeongui-038');
+    const single = candidates.find((c) => c.transferCount === 1);
+    const multi = candidates.find((c) => c.transferCount === 2);
+    expect(single).toBeDefined();
+    if (multi) {
+      expect(single!.travelMinutes).toBeLessThanOrEqual(multi.travelMinutes);
+    }
+  });
+
+  // 괄호 부제가 붙은 다중 노선 환승역들 — 양방향 모두 1회 환승 후보가 잡혀야 함
+  // (한쪽 노선만 정규화 키가 등록되는 비대칭 인덱스 문제 회귀 방지)
+  it.each<[string, string, string]>([
+    // [from id, to id, expected normalized transfer name]
+    ['7-015', 'gyeongui-038', '상봉'],       // 7 → 경의중앙 (상봉 환승)
+    ['gyeongui-038', '7-015', '상봉'],       // 역방향: 경의중앙 → 7
+    ['3-034', 'sinbundang-012', '양재'],      // 3 → 신분당 자기환승은 candidate.line 비교에 의존
+    ['sinbundang-012', '3-034', '양재'],      // 역방향
+    ['4-022', 'gyeongui-029', '이촌'],        // 4 → 경의중앙
+    ['gyeongui-029', '4-022', '이촌'],        // 역방향
+  ])('정규화 환승 매칭 (양방향): %s → %s 는 %s 환승 후보를 갖는다', (fromId, toId, expectedName) => {
+    const candidates = findRoutes(fromId, toId);
+    const single = candidates.find((c) => c.transferCount === 1);
+    expect(single).toBeDefined();
+    expect(normalizeStationName((single!.route as TransferRoute).transferName)).toBe(expectedName);
   });
 });

--- a/src/utils/routeWaypoints.ts
+++ b/src/utils/routeWaypoints.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Route } from './stationRoute';
+import { isSameStationName } from './stationRoute';
 import type { AlarmWaypoint } from '../api/alarmBackend';
 
 /**
@@ -21,7 +22,7 @@ export function routeToWaypoints(
   }
 
   if (route.type === 'transfer') {
-    if (route.transferName === destinationName) {
+    if (isSameStationName(route.transferName, destinationName)) {
       return [{ stationName: destinationName, line: route.fromLine, kind: 'destination' }];
     }
     return [
@@ -31,7 +32,7 @@ export function routeToWaypoints(
   }
 
   const waypoints: AlarmWaypoint[] = route.transfers.map((seg) => {
-    const isDestination = seg.transferName === destinationName;
+    const isDestination = isSameStationName(seg.transferName, destinationName);
     return {
       stationName: isDestination ? destinationName : seg.transferName,
       line: seg.fromLine,

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -51,7 +51,7 @@ export function resolveAllTargets(
     };
   });
   // MultiTransferRoute는 최소 2개 transfer로 구성되므로 targets는 항상 비어있지 않음.
-  const lastName = targets[targets.length - 1].name;
+  const lastName = targets.at(-1)!.name;
   const lastTransferIsDestination = isSameStationName(lastName, destinationName);
   if (!lastTransferIsDestination) {
     targets.push({ name: destinationName, stops: route.stopsAfterLastTransfer, alarmType: 'destination' });

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -1,4 +1,5 @@
 import type { Route } from './stationRoute';
+import { isSameStationName } from './stationRoute';
 import { ALARM_PHASES, type AlarmContext, type AlarmPhase, type AlarmPhaseId } from './alarmPhases';
 
 export type AlarmType = 'destination' | 'transfer';
@@ -32,7 +33,7 @@ export function resolveAllTargets(
   }
 
   if (route.type === 'transfer') {
-    if (route.transferName === destinationName) {
+    if (isSameStationName(route.transferName, destinationName)) {
       return [{ name: destinationName, stops: route.stopsToTransfer, alarmType: 'destination' }];
     }
     return [
@@ -42,14 +43,16 @@ export function resolveAllTargets(
   }
 
   const targets: CurrentTarget[] = route.transfers.map((t) => {
-    const isDestination = t.transferName === destinationName;
+    const isDestination = isSameStationName(t.transferName, destinationName);
     return {
       name: isDestination ? destinationName : t.transferName,
       stops: t.stopsToTransfer,
       alarmType: isDestination ? 'destination' : 'transfer',
     };
   });
-  const lastTransferIsDestination = targets[targets.length - 1]?.name === destinationName;
+  // MultiTransferRoute는 최소 2개 transfer로 구성되므로 targets는 항상 비어있지 않음.
+  const lastName = targets[targets.length - 1].name;
+  const lastTransferIsDestination = isSameStationName(lastName, destinationName);
   if (!lastTransferIsDestination) {
     targets.push({ name: destinationName, stops: route.stopsAfterLastTransfer, alarmType: 'destination' });
   }

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -33,6 +33,14 @@ function getLineNameIndexCached(line: LineNumber): Map<string, number> {
   return cached;
 }
 
+// 노선별 표기 불일치를 흡수하는 인덱스 조회 헬퍼.
+// 1차 정확 일치, 실패 시 정규화 후 재시도.
+function lookupNameIdx(idx: Map<string, number>, name: string): number | undefined {
+  const hit = idx.get(name);
+  if (hit !== undefined) return hit;
+  return idx.get(normalizeStationName(name));
+}
+
 export interface DirectRoute {
   type: 'direct';
   stops: number;
@@ -111,37 +119,53 @@ export interface JourneyDisplay {
   totalStops: number;
 }
 
-// 환승 그래프: fromLine → toLine → 환승역 이름 목록
+// 후행 괄호 부제(예: "상봉(시외버스터미널)" → "상봉")를 제거해
+// 동일 환승역이 노선별로 다른 표기로 등록되어도 매칭이 성립하도록 한다.
+export function normalizeStationName(name: string): string {
+  return name.replace(/\s*\([^)]*\)\s*$/, '').trim();
+}
+
+// 노선별 표기 차이를 흡수한 역 이름 동일성 비교.
+// 예: "상봉" === "상봉(시외버스터미널)" (각각 7호선/경의중앙선 등록명)
+export function isSameStationName(a: string, b: string): boolean {
+  if (a === b) return true;
+  return normalizeStationName(a) === normalizeStationName(b);
+}
+
+// 환승 그래프: fromLine → toLine → 환승역 이름 목록 (fromLine 쪽 실제 station.name)
 const transferGraph = new Map<LineNumber, Map<LineNumber, string[]>>();
 
 function buildTransferGraph(): void {
-  const nameToLines = new Map<string, Set<LineNumber>>();
+  const normalizedToStations = new Map<string, Station[]>();
   for (const s of allStations) {
-    let lines = nameToLines.get(s.name);
-    if (!lines) {
-      lines = new Set();
-      nameToLines.set(s.name, lines);
+    const key = normalizeStationName(s.name);
+    let group = normalizedToStations.get(key);
+    if (!group) {
+      group = [];
+      normalizedToStations.set(key, group);
     }
-    lines.add(s.line);
+    group.push(s);
   }
 
-  for (const [name, lines] of nameToLines) {
-    if (lines.size < 2) continue;
-    const lineArr = Array.from(lines);
-    for (let i = 0; i < lineArr.length; i++) {
-      for (let j = 0; j < lineArr.length; j++) {
-        if (i === j) continue;
-        let toMap = transferGraph.get(lineArr[i]);
+  for (const group of normalizedToStations.values()) {
+    const distinctLines = new Set(group.map((s) => s.line));
+    if (distinctLines.size < 2) continue;
+    for (const from of group) {
+      for (const to of group) {
+        if (from.line === to.line) continue;
+        let toMap = transferGraph.get(from.line);
         if (!toMap) {
           toMap = new Map();
-          transferGraph.set(lineArr[i], toMap);
+          transferGraph.set(from.line, toMap);
         }
-        let names = toMap.get(lineArr[j]);
+        let names = toMap.get(to.line);
         if (!names) {
           names = [];
-          toMap.set(lineArr[j], names);
+          toMap.set(to.line, names);
         }
-        names.push(name);
+        // fromLine 쪽 실제 이름을 저장 → findRoutes가 fromLine에서 candidate를 찾을 때 그대로 매칭.
+        // 반대편 toLine 쪽 조회는 findStationByNameAndLine의 정규화 fallback이 처리.
+        names.push(from.name);
       }
     }
   }
@@ -154,7 +178,12 @@ export function getStationsOnLine(line: LineNumber): Station[] {
 }
 
 export function findStationByNameAndLine(name: string, line: LineNumber): Station | undefined {
-  return getLineStationsCached(line).find((s) => s.name === name);
+  const stations = getLineStationsCached(line);
+  const exact = stations.find((s) => s.name === name);
+  if (exact) return exact;
+  // 정규화 fallback: 노선별 표기 불일치(예: "상봉" vs "상봉(시외버스터미널)") 흡수.
+  const normalized = normalizeStationName(name);
+  return stations.find((s) => normalizeStationName(s.name) === normalized);
 }
 
 export function updateRouteFromPosition(
@@ -253,7 +282,12 @@ export function getRemainingStops(
 function buildNameIndex(stations: Station[]): Map<string, number> {
   const index = new Map<string, number>();
   for (let i = 0; i < stations.length; i++) {
-    index.set(stations[i].name, i);
+    const { name } = stations[i];
+    index.set(name, i);
+    // 정규화 키도 함께 등록 → 노선별 표기 불일치 흡수.
+    // 한 노선 내 동일 정규화 이름 충돌은 데이터 특성상 없음 (역명은 노선 내 유일).
+    const normalized = normalizeStationName(name);
+    if (normalized !== name) index.set(normalized, i);
   }
   return index;
 }
@@ -303,7 +337,7 @@ export function findRoutes(currentId: string, destinationId: string): RouteCandi
 
   for (let i = 0; i < currentLineStations.length; i++) {
     const candidate = currentLineStations[i];
-    const transferDestIdx = destNameIndex.get(candidate.name);
+    const transferDestIdx = lookupNameIdx(destNameIndex, candidate.name);
     if (transferDestIdx === undefined) continue;
 
     const stopsToTransfer = Math.abs(i - currentIdx);
@@ -408,8 +442,8 @@ function findMultiTransferRoute(
 
     // 첫 번째 환승: 현재노선 → 중간노선
     for (const t1Name of transfer1Names) {
-      const t1CurrentIdx = currentNameIndex.get(t1Name);
-      const t1MidIdx = midNameIndex.get(t1Name);
+      const t1CurrentIdx = lookupNameIdx(currentNameIndex, t1Name);
+      const t1MidIdx = lookupNameIdx(midNameIndex, t1Name);
       /* istanbul ignore next -- 환승 그래프가 같은 데이터에서 빌드되므로 undefined 불가 */
       if (t1CurrentIdx === undefined || t1MidIdx === undefined) continue;
 
@@ -417,8 +451,8 @@ function findMultiTransferRoute(
 
       // 두 번째 환승: 중간노선 → 목적지노선
       for (const t2Name of transfer2Names) {
-        const t2MidIdx = midNameIndex.get(t2Name);
-        const t2DestIdx = destNameIndex.get(t2Name);
+        const t2MidIdx = lookupNameIdx(midNameIndex, t2Name);
+        const t2DestIdx = lookupNameIdx(destNameIndex, t2Name);
         /* istanbul ignore next */
         if (t2MidIdx === undefined || t2DestIdx === undefined) continue;
 
@@ -549,8 +583,8 @@ function getNextStationOnLine(
   targetName: string,
 ): string | null {
   const nameIndex = getLineNameIndexCached(line);
-  const currentIdx = nameIndex.get(currentName);
-  const targetIdx = nameIndex.get(targetName);
+  const currentIdx = lookupNameIdx(nameIndex, currentName);
+  const targetIdx = lookupNameIdx(nameIndex, targetName);
   if (currentIdx === undefined || targetIdx === undefined) return null;
   if (currentIdx === targetIdx) return null;
 

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -121,8 +121,13 @@ export interface JourneyDisplay {
 
 // 후행 괄호 부제(예: "상봉(시외버스터미널)" → "상봉")를 제거해
 // 동일 환승역이 노선별로 다른 표기로 등록되어도 매칭이 성립하도록 한다.
+// 정규식 대신 lastIndexOf로 구현 (ReDoS 회피 + 의도 명시).
 export function normalizeStationName(name: string): string {
-  return name.replace(/\s*\([^)]*\)\s*$/, '').trim();
+  const trimmed = name.trim();
+  if (!trimmed.endsWith(')')) return trimmed;
+  const open = trimmed.lastIndexOf('(');
+  if (open <= 0) return trimmed;
+  return trimmed.slice(0, open).trimEnd();
 }
 
 // 노선별 표기 차이를 흡수한 역 이름 동일성 비교.


### PR DESCRIPTION
Closes #401

## Summary
- stations.json은 같은 환승역을 노선별로 다른 표기로 보관함 (예: 7호선 `"상봉"` vs 경의중앙선 `"상봉(시외버스터미널)"`). 기존 `buildTransferGraph()`는 정확 일치 기준이라 7↔경의중앙 환승역 목록에 상봉이 누락 → 용마산→중랑 검색 시 1회 환승 후보가 빠지고 옥수 우회 50분+ 경로가 1순위로 선택됨.
- 동일 패턴 잠재 버그 7건: 왕십리·청량리·이촌·양재·양재시민의숲·광교·광교중앙.

## Changes
- `normalizeStationName(name)` / `isSameStationName(a, b)` 유틸 신규 — 후행 ` (...)` 제거 후 비교.
- `buildTransferGraph()`: 정규화 키로 그룹핑하고 `transferGraph`에 fromLine 쪽 실제 station.name 저장 (조회 호환성 유지).
- `buildNameIndex()`: 원본 + 정규화 키 동시 등록.
- `lookupNameIdx()` 헬퍼로 `findRoutes` 단일 환승, `findMultiTransferRoute` t1/t2, `getNextStationOnLine` 4개 인덱스 조회 사이트에 정규화 fallback 일관 적용 → 역방향/다중 환승 경유까지 모두 해소.
- `findStationByNameAndLine()`: 정확 일치 실패 시 정규화 fallback.
- `routeWaypoints.ts` / `stationAlarm.ts`: `transferName === destinationName` 비교를 `isSameStationName`으로 교체 → 같은 환승역이 표기 차이로 분리되어 알람이 중복되거나 destination이 누락되는 회귀 차단.

## Test plan
- [x] 신규 단위 테스트: `normalizeStationName`, `isSameStationName`, `findStationByNameAndLine` 정규화 fallback
- [x] 회귀 테스트 (양방향): 7↔경의중앙(상봉), 3↔신분당(양재), 4↔경의중앙(이촌) 모두 1회 환승 후보 보유
- [x] `routeWaypoints` / `stationAlarm`: 표기 차이 환승역 = 도착역인 케이스 단일 destination으로 축약
- [x] 기존 1364개 테스트 전부 통과 → 1370개 통과 (신규 6건 추가)
- [x] stationRoute/routeWaypoints/stationAlarm 모두 커버리지 100%
- [x] `npm run type-check` 통과
- [x] 수동 확인: 출발 용마산 / 도착 중랑 → 1순위가 상봉 환승, 1회 환승, ~20분대 경로로 노출