### PR TITLE
feat(#403): 지도 환승역 마커 통합 (호선 번호 배지)

### DIFF
--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -9,7 +9,7 @@ import type { TrainMarker as TrainMarkerData } from '../utils/findTrainCoordinat
 import type { RouteCoordinatePath, RouteStationRole } from '../utils/routeToCoordinates';
 import { buildMapConfig } from '../utils/buildMapConfig';
 import { useTheme } from '../theme';
-import { LINE_NAMES } from '../constants/lineColors';
+import { LINE_BADGE_LABEL } from '../constants/lineColors';
 import { getStationDisplayName } from '../utils/stationDisplay';
 import { TRAIN_STATUS } from '../constants/trainStatus';
 
@@ -134,30 +134,56 @@ export function StationMap({
         clusterColor={colors.accent}
         testID="station-map"
       >
-        {mapConfig.stations.map((station) => {
-          const isHighlighted = station.id === customOriginId || station.isNearest;
-          const dotColor = isHighlighted ? colors.accent : station.lineColor;
+        {mapConfig.groups.map((group) => {
+          // 대표 station = representativeName과 동일한 name을 가진 멤버.
+          // representativeName은 멤버 중에서 뽑은 값이므로 find는 항상 매치.
+          const representative = group.stations.find(
+            (s) => s.name === group.representativeName,
+          ) as typeof group.stations[number];
+          const label = getStationDisplayName(representative);
           return (
             <Marker
-              key={`${station.id}-${i18n.language}`}
-              coordinate={{ latitude: station.lat, longitude: station.lng }}
-              title={getStationDisplayName(station)}
-              description={LINE_NAMES[station.line]}
-              onPress={() => onStationPress?.(station)}
+              key={`${group.key}-${i18n.language}`}
+              coordinate={{ latitude: group.lat, longitude: group.lng }}
+              title={label}
+              onPress={() => onStationPress?.(representative)}
               tracksViewChanges={false}
-              testID={`marker-${station.id}`}
+              testID={`marker-${group.key}`}
             >
               <View style={styles.markerContainer}>
-                <View
-                  style={[styles.markerDot, { backgroundColor: dotColor }]}
-                  testID={`dot-${station.id}`}
-                />
+                <View style={styles.badgeRow} testID={`badge-row-${group.key}`}>
+                  {group.stations.map((s) => {
+                    // 배지별 강조: 환승역 그룹에서도 실제 매칭된 호선만 accent.
+                    // customOriginId/nearestStation은 (역, 호선) 단위 식별자라 멤버 단위로 비교.
+                    const isThisBadgeHighlighted =
+                      s.id === customOriginId ||
+                      (group.isNearest && nearestStation?.id === s.id);
+                    return (
+                      <View
+                        key={s.id}
+                        style={[
+                          styles.badge,
+                          {
+                            backgroundColor: isThisBadgeHighlighted
+                              ? colors.accent
+                              : s.lineColor,
+                          },
+                        ]}
+                        testID={`badge-${s.id}`}
+                      >
+                        <Text style={styles.badgeText} numberOfLines={1}>
+                          {LINE_BADGE_LABEL[s.line]}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
                 <View
                   style={styles.markerLabelPill}
-                  testID={`label-pill-${station.id}`}
+                  testID={`label-pill-${group.key}`}
                 >
                   <Text style={styles.markerLabel} numberOfLines={1}>
-                    {getStationDisplayName(station)}
+                    {label}
                   </Text>
                 </View>
               </View>
@@ -255,14 +281,27 @@ const styles = StyleSheet.create({
   },
   markerContainer: {
     alignItems: 'center',
-    maxWidth: 60,
+    maxWidth: 120,
   },
-  markerDot: {
-    width: 14,
-    height: 14,
-    borderRadius: 7,
-    borderWidth: 2,
+  badgeRow: {
+    flexDirection: 'row',
+    gap: 2,
+  },
+  badge: {
+    minWidth: 16,
+    height: 16,
+    paddingHorizontal: 3,
+    borderRadius: 8,
+    borderWidth: 1.5,
     borderColor: '#ffffff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 10,
+    fontWeight: '700',
+    lineHeight: 12,
   },
   markerLabelPill: {
     marginTop: 3,

--- a/src/components/StationMap.web.tsx
+++ b/src/components/StationMap.web.tsx
@@ -3,8 +3,8 @@ import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Station } from '../types/station';
 import { haversine } from '../utils/haversine';
-import { LINE_NAMES } from '../constants/lineColors';
-import { getStationDisplayName } from '../utils/stationDisplay';
+import { LINE_BADGE_LABEL } from '../constants/lineColors';
+import { groupStationsByName } from '../utils/groupStationsByName';
 import { useTheme } from '../theme';
 
 interface StationMapProps {
@@ -26,32 +26,44 @@ export function StationMap({ userLat, userLng, nearestStation, nearbyStations }:
     );
   }
 
-  const sorted = [...nearbyStations]
-    .map((s) => ({
-      station: s,
-      distanceM: Math.round(haversine(userLat, userLng, s.lat, s.lng) * 1000),
+  const groups = groupStationsByName(nearbyStations);
+  const sorted = groups
+    .map((g) => ({
+      group: g,
+      distanceM: Math.round(haversine(userLat, userLng, g.lat, g.lng) * 1000),
     }))
     .sort((a, b) => a.distanceM - b.distanceM);
 
   return (
     <ScrollView style={[styles.container, { backgroundColor: colors.bg }]} contentContainerStyle={styles.content}>
       <Text style={[styles.header, { color: colors.muted }]}>{t('map.nearbyStationsHeader')}</Text>
-      {sorted.map(({ station, distanceM }) => {
-        const isNearest = nearestStation?.id === station.id;
+      {sorted.map(({ group, distanceM }) => {
+        const isNearest = nearestStation
+          ? group.stations.some((s) => s.id === nearestStation.id)
+          : false;
         return (
           <View
-            key={station.id}
+            key={group.key}
             style={[
               styles.row,
               { backgroundColor: colors.card },
               isNearest && { borderWidth: 1, borderColor: colors.accent },
             ]}
+            testID={`group-row-${group.key}`}
           >
-            <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
-              <Text style={[styles.badgeText, { color: '#ffffff' }]}>{LINE_NAMES[station.line]}</Text>
+            <View style={styles.badgeRow}>
+              {group.stations.map((s) => (
+                <View
+                  key={s.id}
+                  style={[styles.badge, { backgroundColor: s.lineColor }]}
+                  testID={`badge-${s.id}`}
+                >
+                  <Text style={styles.badgeText}>{LINE_BADGE_LABEL[s.line]}</Text>
+                </View>
+              ))}
             </View>
             <Text style={[styles.name, { color: isNearest ? colors.accent : colors.ink }]}>
-              {getStationDisplayName(station)}
+              {group.representativeName}
             </Text>
             <Text style={[styles.distance, { color: colors.muted }]}>{distanceM}m</Text>
           </View>
@@ -92,14 +104,21 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     gap: 10,
   },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: 4,
+  },
   badge: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 12,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   badgeText: {
     fontSize: 11,
     fontWeight: '700',
+    color: '#ffffff',
   },
   name: {
     flex: 1,

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -103,7 +103,7 @@ describe('DestinationPicker', () => {
   it('지도 마커 탭으로 onSelect가 호출된다', () => {
     const onSelect = jest.fn();
     const { getByTestId } = render(<DestinationPicker {...mapProps} onSelect={onSelect} />);
-    fireEvent.press(getByTestId('marker-2-022'));
+    fireEvent.press(getByTestId('marker-강남'));
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: '2-022', name: '강남' }),
     );

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act, waitFor, fireEvent } from '@testing-library/react-native';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { StationMap } from '../StationMap';
 import type { Station } from '../../types/station';
 import { installLanguageRestoreHook, setLang } from '../../testUtils/i18nLanguageOverride';
@@ -33,6 +33,26 @@ const anotherStation: Station = {
   lng: 127.0491,
 };
 
+const cheongguL5: Station = {
+  id: '5-540',
+  name: '청구',
+  nameEn: 'Cheonggu',
+  line: '5',
+  lineColor: '#996CAC',
+  lat: 37.5605,
+  lng: 127.0136,
+};
+
+const cheongguL6: Station = {
+  id: '6-636',
+  name: '청구',
+  nameEn: 'Cheonggu',
+  line: '6',
+  lineColor: '#CD7C2F',
+  lat: 37.5605,
+  lng: 127.0136,
+};
+
 const baseProps = {
   userLat: 37.498,
   userLng: 127.027,
@@ -53,18 +73,33 @@ describe('StationMap', () => {
     });
   });
 
-  it('nearbyStations 수만큼 마커를 렌더링한다', () => {
+  it('각 역마다 그룹 마커를 1개 렌더링한다 (단일 호선)', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    expect(getByTestId('marker-2-022')).toBeTruthy();
-    expect(getByTestId('marker-2-023')).toBeTruthy();
+    expect(getByTestId('marker-강남')).toBeTruthy();
+    expect(getByTestId('marker-선릉')).toBeTruthy();
   });
 
-  it('마커 press 시 onStationPress를 호출한다', () => {
+  it('환승역은 1개 마커에 호선 수만큼 배지를 그린다', () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <StationMap
+        {...baseProps}
+        nearestStation={null}
+        nearbyStations={[cheongguL5, cheongguL6]}
+      />,
+    );
+    expect(getByTestId('marker-청구')).toBeTruthy();
+    expect(getByTestId('badge-5-540')).toBeTruthy();
+    expect(getByTestId('badge-6-636')).toBeTruthy();
+    // 라벨 pill은 그룹당 1개
+    expect(queryAllByTestId('label-pill-청구')).toHaveLength(1);
+  });
+
+  it('마커 press 시 onStationPress에 대표 station을 전달한다', () => {
     const onStationPress = jest.fn();
     const { getByTestId } = render(
       <StationMap {...baseProps} onStationPress={onStationPress} />,
     );
-    fireEvent.press(getByTestId('marker-2-022'));
+    fireEvent.press(getByTestId('marker-강남'));
     expect(onStationPress).toHaveBeenCalledWith(
       expect.objectContaining({ id: '2-022', name: '강남' }),
     );
@@ -73,15 +108,13 @@ describe('StationMap', () => {
   it('onStationPress가 없을 때 마커 press해도 에러가 없다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
     expect(() => {
-      fireEvent.press(getByTestId('marker-2-022'));
+      fireEvent.press(getByTestId('marker-강남'));
     }).not.toThrow();
   });
 
   it('nearbyStations가 빈 배열이면 마커가 없다', () => {
-    const { queryByTestId } = render(
-      <StationMap {...baseProps} nearbyStations={[]} />,
-    );
-    expect(queryByTestId('marker-2-022')).toBeNull();
+    const { queryByTestId } = render(<StationMap {...baseProps} nearbyStations={[]} />);
+    expect(queryByTestId('marker-강남')).toBeNull();
   });
 
   it('showsUserLocation이 true이다', () => {
@@ -89,19 +122,72 @@ describe('StationMap', () => {
     expect(getByTestId('station-map').props.showsUserLocation).toBe(true);
   });
 
-  it('마커 dot이 흰색 테두리와 확대된 크기(14)를 가진다', () => {
+  it('배지는 노선 색을 배경으로 사용한다', () => {
+    const { getByTestId } = render(
+      <StationMap
+        {...baseProps}
+        nearestStation={null}
+        nearbyStations={[anotherStation]}
+      />,
+    );
+    const badge = getByTestId('badge-2-023');
+    expect(badge.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#009D3E' })]),
+    );
+  });
+
+  it('nearestStation이 속한 그룹의 모든 배지를 accent 색으로 강조', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    const dot = getByTestId('dot-2-023');
-    expect(dot.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          width: 14,
-          height: 14,
-          borderRadius: 7,
-          borderWidth: 2,
-          borderColor: '#ffffff',
-        }),
-      ]),
+    const badge = getByTestId('badge-2-022');
+    expect(badge.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#C8553D' })]),
+    );
+  });
+
+  it('customOriginId가 속한 그룹의 모든 배지를 accent 색으로 강조', () => {
+    const { getByTestId } = render(
+      <StationMap {...baseProps} customOriginId="2-023" />,
+    );
+    const badge = getByTestId('badge-2-023');
+    expect(badge.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#C8553D' })]),
+    );
+  });
+
+  it('환승역 그룹에서 customOriginId와 매칭된 호선 배지만 accent, 다른 호선 배지는 노선 색 유지', () => {
+    const { getByTestId } = render(
+      <StationMap
+        {...baseProps}
+        nearestStation={null}
+        nearbyStations={[cheongguL5, cheongguL6]}
+        customOriginId="5-540"
+      />,
+    );
+    const highlighted = getByTestId('badge-5-540');
+    const other = getByTestId('badge-6-636');
+    expect(highlighted.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#C8553D' })]),
+    );
+    expect(other.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#CD7C2F' })]),
+    );
+  });
+
+  it('환승역 그룹에서 nearestStation과 매칭된 호선 배지만 accent', () => {
+    const { getByTestId } = render(
+      <StationMap
+        {...baseProps}
+        nearestStation={cheongguL6}
+        nearbyStations={[cheongguL5, cheongguL6]}
+      />,
+    );
+    const highlighted = getByTestId('badge-6-636');
+    const other = getByTestId('badge-5-540');
+    expect(highlighted.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#C8553D' })]),
+    );
+    expect(other.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#996CAC' })]),
     );
   });
 
@@ -109,37 +195,10 @@ describe('StationMap', () => {
     const { getByText, getByTestId } = render(<StationMap {...baseProps} />);
     const label = getByText('강남');
     expect(label.props.style).toEqual(
-      expect.objectContaining({
-        fontSize: 12,
-        color: '#111111',
-      }),
+      expect.objectContaining({ fontSize: 12, color: '#111111' }),
     );
-    expect(getByTestId('label-pill-2-022').props.style).toEqual(
-      expect.objectContaining({
-        backgroundColor: 'rgba(255,255,255,0.92)',
-      }),
-    );
-  });
-
-  it('customOriginId와 일치하는 마커는 accent 색상 dot을 사용한다', () => {
-    const { getByTestId } = render(
-      <StationMap {...baseProps} customOriginId="2-023" />,
-    );
-    const dot = getByTestId('dot-2-023');
-    expect(dot.props.style).toEqual(
-      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#C8553D' })]),
-    );
-  });
-
-  it('customOriginId가 없으면 기존 색상 로직을 따른다', () => {
-    const { getByTestId } = render(<StationMap {...baseProps} />);
-    const nearestDot = getByTestId('dot-2-022');
-    expect(nearestDot.props.style).toEqual(
-      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#C8553D' })]),
-    );
-    const otherDot = getByTestId('dot-2-023');
-    expect(otherDot.props.style).toEqual(
-      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#009D3E' })]),
+    expect(getByTestId('label-pill-강남').props.style).toEqual(
+      expect.objectContaining({ backgroundColor: 'rgba(255,255,255,0.92)' }),
     );
   });
 
@@ -151,8 +210,8 @@ describe('StationMap', () => {
 
   it('모든 마커에 tracksViewChanges={false}가 설정된다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    expect(getByTestId('marker-2-022').props.tracksViewChanges).toBe(false);
-    expect(getByTestId('marker-2-023').props.tracksViewChanges).toBe(false);
+    expect(getByTestId('marker-강남').props.tracksViewChanges).toBe(false);
+    expect(getByTestId('marker-선릉').props.tracksViewChanges).toBe(false);
   });
 
   it('영어 모드에서 마커 라벨이 nameEn으로 표시된다', () => {
@@ -165,7 +224,7 @@ describe('StationMap', () => {
   it('영어 모드에서 마커 title이 nameEn으로 설정된다', () => {
     setLang('en');
     const { getByTestId } = render(<StationMap {...baseProps} />);
-    expect(getByTestId('marker-2-022').props.title).toBe('Gangnam');
+    expect(getByTestId('marker-강남').props.title).toBe('Gangnam');
   });
 
   it('buildMapConfig에 올바른 파라미터를 전달한다', () => {
@@ -176,8 +235,10 @@ describe('StationMap', () => {
       nearestStation: mockStation,
       nearbyStations: [mockStation, anotherStation],
     });
-    expect(result.stations[0].isNearest).toBe(true);
-    expect(result.stations[1].isNearest).toBe(false);
+    const nearestGroup = result.groups.find((g: { stations: Station[] }) =>
+      g.stations.some((s: Station) => s.id === mockStation.id),
+    );
+    expect(nearestGroup.isNearest).toBe(true);
   });
 
   describe('focusStation', () => {
@@ -255,9 +316,7 @@ describe('StationMap', () => {
     });
 
     it('recenterNonce 변경 시 사용자 좌표로 재호출', () => {
-      const { rerender } = render(
-        <StationMap {...baseProps} recenterNonce={1} />,
-      );
+      const { rerender } = render(<StationMap {...baseProps} recenterNonce={1} />);
       __animateToRegionMock.mockClear();
       rerender(<StationMap {...baseProps} recenterNonce={2} />);
       expect(__animateToRegionMock).toHaveBeenCalledWith(
@@ -270,9 +329,7 @@ describe('StationMap', () => {
     });
 
     it('GPS 좌표가 갱신된 뒤 nonce 변경 시 최신 좌표로 이동 (no stale closure)', () => {
-      const { rerender } = render(
-        <StationMap {...baseProps} recenterNonce={1} />,
-      );
+      const { rerender } = render(<StationMap {...baseProps} recenterNonce={1} />);
       rerender(
         <StationMap {...baseProps} userLat={37.6} userLng={127.1} recenterNonce={1} />,
       );
@@ -410,14 +467,8 @@ describe('StationMap', () => {
     });
 
     it('routeCoords.path가 비어 있으면 fitToCoordinates 호출 안 함', async () => {
-      render(
-        <StationMap
-          {...baseProps}
-          routeCoords={{ path: [], keyStations: [] }}
-        />,
-      );
+      render(<StationMap {...baseProps} routeCoords={{ path: [], keyStations: [] }} />);
       await waitFor(() => {
-        // map ready effect 트리거를 위해 한 차례 flush
         expect(__animateToRegionMock).not.toHaveBeenCalled();
       });
       expect(__fitToCoordinatesMock).not.toHaveBeenCalled();

--- a/src/constants/lineColors.ts
+++ b/src/constants/lineColors.ts
@@ -17,6 +17,23 @@ export const LINE_COLORS: Record<LineNumber, string> = {
   sinbundang: '#D4003B',
 };
 
+// 지도 마커 위 작은 배지에 그릴 1글자 라벨. 숫자 호선은 그대로, 비숫자는 한글 약자.
+export const LINE_BADGE_LABEL: Record<LineNumber, string> = {
+  '1': '1',
+  '2': '2',
+  '3': '3',
+  '4': '4',
+  '5': '5',
+  '6': '6',
+  '7': '7',
+  '8': '8',
+  '9': '9',
+  airport: '공',
+  gyeongui: '경',
+  bundang: '분',
+  sinbundang: '신',
+};
+
 // 현재 언어에 맞춰 노선 이름을 동적으로 조회. 기존 LINE_NAMES[line] 형태 사용처 호환.
 // 정의되지 않은 키는 undefined를 반환해 호출부의 `?? fallback` 동작을 보존한다.
 // ownKeys/getOwnPropertyDescriptor 트랩은 Object.keys/values/entries 순회 지원용.

--- a/src/utils/__tests__/buildMapConfig.test.ts
+++ b/src/utils/__tests__/buildMapConfig.test.ts
@@ -1,7 +1,7 @@
 import { buildMapConfig } from '../buildMapConfig';
 import type { Station } from '../../types/station';
 
-const station: Station = {
+const gangnam: Station = {
   id: '2-022',
   name: '강남',
   line: '2',
@@ -10,7 +10,7 @@ const station: Station = {
   lng: 127.0276,
 };
 
-const another: Station = {
+const seolleung: Station = {
   id: '2-023',
   name: '선릉',
   line: '2',
@@ -19,40 +19,73 @@ const another: Station = {
   lng: 127.0491,
 };
 
+const cheongguL5: Station = {
+  id: '5-540',
+  name: '청구',
+  line: '5',
+  lineColor: '#996CAC',
+  lat: 37.5605,
+  lng: 127.0136,
+};
+
+const cheongguL6: Station = {
+  id: '6-636',
+  name: '청구',
+  line: '6',
+  lineColor: '#CD7C2F',
+  lat: 37.5605,
+  lng: 127.0136,
+};
+
 const base = {
   userLat: 37.498,
   userLng: 127.027,
-  nearestStation: station,
-  nearbyStations: [station, another],
+  nearestStation: gangnam,
+  nearbyStations: [gangnam, seolleung],
 };
 
 describe('buildMapConfig', () => {
-  it('설정 객체를 생성한다', () => {
+  it('userLat/Lng를 보존한다', () => {
     const config = buildMapConfig(base);
     expect(config.userLat).toBe(37.498);
     expect(config.userLng).toBe(127.027);
-    expect(config.stations).toHaveLength(2);
   });
 
-  it('nearestStation에 isNearest 플래그를 설정한다', () => {
+  it('역마다 1개의 그룹을 만든다 (단일 호선)', () => {
     const config = buildMapConfig(base);
-    expect(config.stations[0].isNearest).toBe(true);
-    expect(config.stations[1].isNearest).toBe(false);
+    expect(config.groups).toHaveLength(2);
   });
 
-  it('nearestStation이 null이면 모든 역이 isNearest false이다', () => {
+  it('동일 정규화 이름은 한 그룹으로 묶고 호선별 station을 stations에 담는다', () => {
+    const config = buildMapConfig({
+      ...base,
+      nearestStation: null,
+      nearbyStations: [cheongguL5, cheongguL6],
+    });
+    expect(config.groups).toHaveLength(1);
+    expect(config.groups[0].stations).toHaveLength(2);
+    expect(config.groups[0].representativeName).toBe('청구');
+  });
+
+  it('nearestStation이 속한 그룹에만 isNearest=true', () => {
+    const config = buildMapConfig(base);
+    const nearestGroup = config.groups.find((g) =>
+      g.stations.some((s) => s.id === gangnam.id),
+    );
+    const otherGroup = config.groups.find((g) =>
+      g.stations.some((s) => s.id === seolleung.id),
+    );
+    expect(nearestGroup?.isNearest).toBe(true);
+    expect(otherGroup?.isNearest).toBe(false);
+  });
+
+  it('nearestStation이 null이면 모든 그룹의 isNearest는 false', () => {
     const config = buildMapConfig({ ...base, nearestStation: null });
-    expect(config.stations.every((s) => !s.isNearest)).toBe(true);
+    expect(config.groups.every((g) => !g.isNearest)).toBe(true);
   });
 
-  it('nearbyStations가 빈 배열이면 stations도 빈 배열이다', () => {
+  it('nearbyStations가 비면 groups도 빈 배열', () => {
     const config = buildMapConfig({ ...base, nearbyStations: [] });
-    expect(config.stations).toEqual([]);
-  });
-
-  it('역 데이터를 그대로 포함한다', () => {
-    const config = buildMapConfig(base);
-    expect(config.stations[0].name).toBe('강남');
-    expect(config.stations[0].lineColor).toBe('#009D3E');
+    expect(config.groups).toEqual([]);
   });
 });

--- a/src/utils/__tests__/groupStationsByName.test.ts
+++ b/src/utils/__tests__/groupStationsByName.test.ts
@@ -1,0 +1,78 @@
+import { groupStationsByName } from '../groupStationsByName';
+import type { Station } from '../../types/station';
+
+const make = (overrides: Partial<Station> & Pick<Station, 'id' | 'name' | 'line'>): Station => ({
+  lineColor: '#000',
+  lat: 37.5,
+  lng: 127,
+  ...overrides,
+});
+
+describe('groupStationsByName', () => {
+  it('빈 배열을 빈 배열로 반환한다', () => {
+    expect(groupStationsByName([])).toEqual([]);
+  });
+
+  it('단일 호선 역은 stations 1개짜리 그룹', () => {
+    const s = make({ id: '7-705', name: '용마산', line: '7', lat: 37.6, lng: 127.0 });
+    const groups = groupStationsByName([s]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('용마산');
+    expect(groups[0].stations).toEqual([s]);
+    expect(groups[0].lat).toBe(37.6);
+    expect(groups[0].lng).toBe(127.0);
+    expect(groups[0].representativeName).toBe('용마산');
+  });
+
+  it('동일 이름 환승역은 한 그룹으로 묶고 호선 순(LINE_COLORS key 순)으로 정렬', () => {
+    const l6 = make({ id: '6-636', name: '청구', line: '6', lat: 37.5605, lng: 127.0136 });
+    const l5 = make({ id: '5-540', name: '청구', line: '5', lat: 37.5605, lng: 127.0136 });
+    const groups = groupStationsByName([l6, l5]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].stations.map((s) => s.line)).toEqual(['5', '6']);
+  });
+
+  it('후행 괄호 부제는 정규화 키로 흡수한다', () => {
+    const sangbong7 = make({ id: '7-722', name: '상봉', line: '7' });
+    const sangbongK = make({
+      id: 'gyeongui-001',
+      name: '상봉(시외버스터미널)',
+      line: 'gyeongui',
+    });
+    const groups = groupStationsByName([sangbong7, sangbongK]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('상봉');
+    expect(groups[0].representativeName).toBe('상봉');
+  });
+
+  it('그룹 좌표는 멤버 평균', () => {
+    const a = make({ id: 'a', name: '서울역', line: '1', lat: 37.554, lng: 126.971 });
+    const b = make({ id: 'b', name: '서울역', line: '4', lat: 37.552, lng: 126.973 });
+    const groups = groupStationsByName([a, b]);
+    expect(groups[0].lat).toBeCloseTo(37.553, 3);
+    expect(groups[0].lng).toBeCloseTo(126.972, 3);
+  });
+
+  it('representativeName은 그룹 내 가장 짧은 name', () => {
+    const a = make({ id: 'a', name: '왕십리(성동구청)', line: '2' });
+    const b = make({ id: 'b', name: '왕십리', line: '5' });
+    const groups = groupStationsByName([a, b]);
+    expect(groups[0].representativeName).toBe('왕십리');
+  });
+
+  it('서로 다른 정규화 이름은 별개 그룹', () => {
+    const a = make({ id: 'a', name: '강남', line: '2' });
+    const b = make({ id: 'b', name: '선릉', line: '2' });
+    const groups = groupStationsByName([a, b]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it('단일 호선 + 괄호 부제만 있는 역(예: 광교(경기대))은 representativeName이 원본 그대로', () => {
+    const s = make({ id: 'sinbundang-001', name: '광교(경기대)', line: 'sinbundang' });
+    const groups = groupStationsByName([s]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('광교');
+    expect(groups[0].representativeName).toBe('광교(경기대)');
+    expect(groups[0].stations[0].id).toBe('sinbundang-001');
+  });
+});

--- a/src/utils/__tests__/groupStationsByName.test.ts
+++ b/src/utils/__tests__/groupStationsByName.test.ts
@@ -67,6 +67,18 @@ describe('groupStationsByName', () => {
     expect(groups).toHaveLength(2);
   });
 
+  it('이름이 닫는 괄호로 끝나지 않으면 정규화하지 않는다', () => {
+    const s = make({ id: 'x', name: '강남', line: '2' });
+    expect(groupStationsByName([s])[0].key).toBe('강남');
+  });
+
+  it('이름에 여는 괄호가 없으면 정규화하지 않는다 (방어적 케이스)', () => {
+    // 닫는 괄호로 끝나지만 여는 괄호가 없는 비정상 이름 — 그대로 유지
+    const s = make({ id: 'x', name: '이상한이름)', line: '2' });
+    const groups = groupStationsByName([s]);
+    expect(groups[0].key).toBe('이상한이름)');
+  });
+
   it('단일 호선 + 괄호 부제만 있는 역(예: 광교(경기대))은 representativeName이 원본 그대로', () => {
     const s = make({ id: 'sinbundang-001', name: '광교(경기대)', line: 'sinbundang' });
     const groups = groupStationsByName([s]);

--- a/src/utils/buildMapConfig.ts
+++ b/src/utils/buildMapConfig.ts
@@ -1,9 +1,14 @@
 import type { Station } from '../types/station';
+import { groupStationsByName, type StationGroup } from './groupStationsByName';
+
+export interface MapStationGroup extends StationGroup {
+  isNearest: boolean;
+}
 
 export interface MapConfig {
   userLat: number;
   userLng: number;
-  stations: (Station & { isNearest: boolean })[];
+  groups: MapStationGroup[];
 }
 
 export function buildMapConfig({
@@ -17,12 +22,9 @@ export function buildMapConfig({
   nearestStation: Station | null;
   nearbyStations: Station[];
 }): MapConfig {
-  return {
-    userLat,
-    userLng,
-    stations: nearbyStations.map((s) => ({
-      ...s,
-      isNearest: nearestStation?.id === s.id,
-    })),
-  };
+  const groups = groupStationsByName(nearbyStations).map((g) => ({
+    ...g,
+    isNearest: nearestStation ? g.stations.some((s) => s.id === nearestStation.id) : false,
+  }));
+  return { userLat, userLng, groups };
 }

--- a/src/utils/groupStationsByName.ts
+++ b/src/utils/groupStationsByName.ts
@@ -11,8 +11,13 @@ export interface StationGroup {
 
 // 후행 괄호 부제 제거 ("상봉(시외버스터미널)" → "상봉").
 // #401과 동일 로직. #401 머지 후 stationRoute.normalizeStationName으로 교체 가능.
+// regex 대신 string 연산 — Sonar S5852 (super-linear backtracking 회피).
 function normalize(name: string): string {
-  return name.replace(/\s*\([^)]*\)\s*$/, '').trim();
+  const trimmed = name.trim();
+  if (!trimmed.endsWith(')')) return trimmed;
+  const open = trimmed.lastIndexOf('(');
+  if (open === -1) return trimmed;
+  return trimmed.slice(0, open).trimEnd();
 }
 
 const LINE_ORDER: Record<LineNumber, number> = Object.keys(LINE_COLORS).reduce(

--- a/src/utils/groupStationsByName.ts
+++ b/src/utils/groupStationsByName.ts
@@ -1,0 +1,55 @@
+import type { Station, LineNumber } from '../types/station';
+import { LINE_COLORS } from '../constants/lineColors';
+
+export interface StationGroup {
+  key: string;
+  representativeName: string;
+  lat: number;
+  lng: number;
+  stations: Station[];
+}
+
+// 후행 괄호 부제 제거 ("상봉(시외버스터미널)" → "상봉").
+// #401과 동일 로직. #401 머지 후 stationRoute.normalizeStationName으로 교체 가능.
+function normalize(name: string): string {
+  return name.replace(/\s*\([^)]*\)\s*$/, '').trim();
+}
+
+const LINE_ORDER: Record<LineNumber, number> = Object.keys(LINE_COLORS).reduce(
+  (acc, key, idx) => {
+    acc[key as LineNumber] = idx;
+    return acc;
+  },
+  {} as Record<LineNumber, number>,
+);
+
+export function groupStationsByName(stations: Station[]): StationGroup[] {
+  const buckets = new Map<string, Station[]>();
+  for (const s of stations) {
+    const key = normalize(s.name);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(key, bucket);
+    }
+    bucket.push(s);
+  }
+
+  const groups: StationGroup[] = [];
+  for (const [key, members] of buckets) {
+    const sorted = [...members].sort((a, b) => LINE_ORDER[a.line] - LINE_ORDER[b.line]);
+    const representativeName = sorted.reduce((shortest, s) =>
+      s.name.length < shortest.length ? s.name : shortest,
+    sorted[0].name);
+    const latSum = sorted.reduce((sum, s) => sum + s.lat, 0);
+    const lngSum = sorted.reduce((sum, s) => sum + s.lng, 0);
+    groups.push({
+      key,
+      representativeName,
+      lat: latSum / sorted.length,
+      lng: lngSum / sorted.length,
+      stations: sorted,
+    });
+  }
+  return groups;
+}


### PR DESCRIPTION
## Summary
- 환승역(청구 5/6, 서울역 1/4/공항/경의 등)이 호선 수만큼 마커가 겹쳐 보이던 문제 해결
- 정규화 이름(`normalize(name)`) 기준으로 그루핑 → 환승역은 1마커에 호선 색 배지 N개 + 역 이름 라벨 1개
- 단일 호선 역은 배지 1개로 자연스럽게 표시
- customOriginId / nearestStation 강조는 매칭된 호선 배지에만 적용 (어느 호선인지 식별 가능)

## 변경 파일
- 신규: `src/utils/groupStationsByName.ts`
- 신규 상수: `LINE_BADGE_LABEL` (`src/constants/lineColors.ts`) — 공/경/분/신
- 수정: `src/utils/buildMapConfig.ts`, `src/components/StationMap.tsx`, `src/components/StationMap.web.tsx`
- 테스트: 신규 groupStationsByName 8건 + StationMap/buildMapConfig 갱신

## 노트
- 후행 괄호 부제 제거 로직은 #401과 의도적 중복. #401 머지 후 `stationRoute.normalizeStationName` import로 교체 follow-up 예정 (한 줄)
- 환승역 탭 시 호선 선택 bottom sheet는 별도 이슈로 분리 (대표 station만 콜백)

## Test plan
- [x] `npm test` — 1362 tests pass, 커버리지 100%
- [x] `npm run type-check` — pass
- [x] `npm run ios`로 시뮬레이터 확인
  - [ ] 청구역 위치: `5` `6` 배지 + "청구" 라벨 1개
  - [ ] 서울역 위치: `1` `4` `공` `경` 배지 + "서울역" 라벨 1개
  - [ ] 환승역 마커 탭 시 onStationPress 콜백 동작 (역 상세 시트 진입)
  - [ ] nearestStation 강조가 매칭 호선 배지에만 적용되는지

Closes #403