### PR TITLE
fix(#406): FG 복귀/지도 위치 버튼에서 fresh GPS fix 강제

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -77,6 +77,10 @@ export default function HomeScreen() {
     [route, tripOrigin, destination],
   );
   const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence } = useFusedNearestStation(undefined, undefined, routeContext);
+  // AppState listener는 단일-바인딩 패턴이라 deps에 refresh를 추가할 수 없다.
+  // 최신 refresh 함수를 ref에 보관해 listener에서 호출한다.
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
   const isCustomOrigin = customOrigin !== null;
   const effectiveOrigin = customOrigin ?? result?.station ?? null;
   useTripOrigin(destination, effectiveOrigin, setTripOrigin);
@@ -182,6 +186,10 @@ export default function HomeScreen() {
     const subscription = AppState.addEventListener('change', (state) => {
       if (state === 'active') {
         loadAlarmEvent();
+        // BG에서 watchPositionAsync가 멈춘 동안 캐시된 stale 위치가 화면에 남는 것을
+        // 방지하기 위해 FG 복귀 즉시 fresh GPS fix를 요청한다. WhileInUse 권한 환경에서
+        // 특히 중요 — BG GPS가 없으므로 FG 복귀가 위치 갱신의 유일한 트리거다.
+        void refreshRef.current();
       }
     });
     return () => subscription.remove();

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -153,7 +153,11 @@ export default function MapScreen() {
             bottom: spacing.xl + (selectedStation ? selectionCardHeight : insets.bottom),
           },
         ]}
-        onPress={() => setRecenterNonce((n) => n + 1)}
+        onPress={() => {
+          // 카메라 이동만으로는 stale userLocation에서 벗어날 수 없으므로 fresh GPS fix를 함께 요청.
+          void refresh();
+          setRecenterNonce((n) => n + 1);
+        }}
         accessibilityLabel={t('map.recenter')}
         testID="recenter-button"
       >


### PR DESCRIPTION
## 배경

실기기 검증에서 위치 stale 증상 관찰:
- BG→FG 전환해도 화면에 cached/stale 위치가 남음 (녹사평 stuck)
- 지도 \"위치 버튼\"을 눌러도 같은 위치로만 카메라가 이동, 새 fix 안 옴
- WhileInUse 권한 사용자(대다수)는 BG GPS가 없어 FG 복귀가 위치 갱신의 유일한 트리거

PR #402(silent push 백엔드 정확도) 후속. FG 위치 source 강건화.

## 변경

### B1. 지도 recenter 버튼 — fresh GPS fix 강제
`app/(tabs)/map.tsx`
- `onPress` 핸들러에 `void refresh()` 추가. 카메라 이동(`setRecenterNonce`)은 그대로
- 기존엔 stale `userLocation` state로만 카메라 이동 → stale 상태 해소 불가능

### B2. AppState 'active' — fresh GPS fix 강제
`app/(tabs)/index.tsx`
- AppState 핸들러에서 `loadAlarmEvent()` 후 `void refreshRef.current()` 호출
- 기존 단일-바인딩 useEffect 패턴을 유지하기 위해 `useRef`로 최신 refresh 참조

## 범위 외 (별도 이슈)
- \"통과\" 알림 카피 정정 (필요 시 별도 작은 PR)
- 사전 예약 stopgap 제거 (silent push 안정화 후)
- B3 진단 로그 — 가치 대비 노이즈로 생략. 필요 시 별도

## 검증
- npm test: 1350 pass, 100% coverage
- npm run type-check: pass
- code-reviewer: P1 없음 (외과적 변경, 이슈와 완전히 직결)

## Test plan
- [x] 단위/타입 (자동)
- [x] 실기기: BG→FG 복귀 시 위치 즉시 갱신 확인
- [x] 실기기: 지도 위치 버튼 클릭 시 새 GPS fix 확인
- [x] 실기기: WhileInUse 권한 환경에서 동일 동작 확인

Closes #406