### PR TITLE
fix(#408): 역 통과 알림 카피 "통과" → "도착"

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -126,7 +126,7 @@
     "channelStation": "Current station",
     "channelTransferAlarm": "Transfer/arrival alert",
     "channelTransferAlarmSilent": "Transfer/arrival alert (silent)",
-    "channelStationPass": "Station pass alert",
+    "channelStationPass": "Station arrival alert",
     "transferEarlyTitle": "Transfer alert",
     "arrivalEarlyTitle": "Arrival alert",
     "transferImminentTitle": "Transfer imminent",
@@ -160,7 +160,7 @@
     "currentStation": "{{name}}",
     "atCurrentStation": "Currently at {{name}}",
     "approximateDistance": "~{{m}}m",
-    "stationPassed": "Passed {{name}}",
+    "stationPassed": "Arrived at {{name}}",
     "stopsRemainingToDestination_one": "{{count}} stop to {{destination}}",
     "stopsRemainingToDestination_other": "{{count}} stops to {{destination}}",
     "stopsRemainingViaTransfer": "{{transferStops}} stops to {{transfer}} transfer · {{totalStops}} stops to {{destination}}"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -126,7 +126,7 @@
     "channelStation": "現在駅",
     "channelTransferAlarm": "乗換・到着アラーム",
     "channelTransferAlarmSilent": "乗換・到着アラーム (無音)",
-    "channelStationPass": "通過駅アラーム",
+    "channelStationPass": "到着駅アラーム",
     "transferEarlyTitle": "乗換アラーム",
     "arrivalEarlyTitle": "到着アラーム",
     "transferImminentTitle": "まもなく乗換",
@@ -160,7 +160,7 @@
     "currentStation": "{{name}}",
     "atCurrentStation": "現在 {{name}}",
     "approximateDistance": "約{{m}}m",
-    "stationPassed": "{{name}}を通過",
+    "stationPassed": "{{name}}駅に到着",
     "stopsRemainingToDestination_one": "{{destination}}まで残り{{count}}駅",
     "stopsRemainingToDestination_other": "{{destination}}まで残り{{count}}駅",
     "stopsRemainingViaTransfer": "{{transfer}}乗換まで{{transferStops}}駅 · {{destination}}まで{{totalStops}}駅"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -126,7 +126,7 @@
     "channelStation": "현재 역",
     "channelTransferAlarm": "하차/환승 알림",
     "channelTransferAlarmSilent": "하차/환승 알림 (무음)",
-    "channelStationPass": "역 통과 알림",
+    "channelStationPass": "역 도착 알림",
     "transferEarlyTitle": "환승 알림",
     "arrivalEarlyTitle": "하차 알림",
     "transferImminentTitle": "환승 임박",
@@ -160,7 +160,7 @@
     "currentStation": "{{name}}역",
     "atCurrentStation": "현재 {{name}}역",
     "approximateDistance": "약 {{m}}m",
-    "stationPassed": "{{name}}역 통과",
+    "stationPassed": "{{name}}역 도착",
     "stopsRemainingToDestination_one": "{{destination}}까지 {{count}}정거장 남음",
     "stopsRemainingToDestination_other": "{{destination}}까지 {{count}}정거장 남음",
     "stopsRemainingViaTransfer": "{{transfer}} 환승까지 {{transferStops}}정거장 · {{destination}}까지 {{totalStops}}정거장"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -126,7 +126,7 @@
     "channelStation": "当前车站",
     "channelTransferAlarm": "换乘/到达提醒",
     "channelTransferAlarmSilent": "换乘/到达提醒(静音)",
-    "channelStationPass": "经过车站提醒",
+    "channelStationPass": "到达车站提醒",
     "transferEarlyTitle": "换乘提醒",
     "arrivalEarlyTitle": "到达提醒",
     "transferImminentTitle": "即将换乘",
@@ -160,7 +160,7 @@
     "currentStation": "{{name}}",
     "atCurrentStation": "当前 {{name}}",
     "approximateDistance": "约{{m}}m",
-    "stationPassed": "已通过{{name}}",
+    "stationPassed": "已到达{{name}}",
     "stopsRemainingToDestination_one": "距{{destination}}还有{{count}}站",
     "stopsRemainingToDestination_other": "距{{destination}}还有{{count}}站",
     "stopsRemainingViaTransfer": "距{{transfer}}换乘{{transferStops}}站 · 距{{destination}}{{totalStops}}站"

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -181,7 +181,7 @@ describe('stationNotification', () => {
         bypassDnd: true,
       });
       expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-passed', {
-        name: '역 통과 알림',
+        name: '역 도착 알림',
         importance: Notifications.AndroidImportance.DEFAULT,
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
       });
@@ -611,7 +611,7 @@ describe('stationNotification', () => {
       });
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-passed',
-        content: { title: '역삼역 통과', body: '강남까지 3정거장 남음' },
+        content: { title: '역삼역 도착', body: '강남까지 3정거장 남음' },
         trigger: null,
       });
     });
@@ -627,7 +627,7 @@ describe('stationNotification', () => {
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-passed',
         content: {
-          title: '용마산역 통과',
+          title: '용마산역 도착',
           body: '군자 환승까지 2정거장 · 이대까지 11정거장',
         },
         trigger: null,
@@ -639,7 +639,7 @@ describe('stationNotification', () => {
       await sendStationPassedNotification('역삼', '강남', null);
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-passed',
-        content: { title: '역삼역 통과', body: '현재 역삼역' },
+        content: { title: '역삼역 도착', body: '현재 역삼역' },
         trigger: null,
       });
     });
@@ -655,7 +655,7 @@ describe('stationNotification', () => {
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
         identifier: 'station-passed',
         content: {
-          title: '역삼역 통과',
+          title: '역삼역 도착',
           body: '강남까지 3정거장 남음',
           channelId: 'station-passed',
           priority: 'default',


### PR DESCRIPTION
## 배경
사용자 피드백: \"X역 통과\" 알림이 실제 통과 시점과 어긋나거나 그 단어 자체가 모호하다. 알림은 경로상 nearest station이 갱신될 때 발화되므로 \"도착\"이 멘탈 모델에 더 가까움.

## 변경
- `stationPassed` (본문 타이틀): \"{{name}}역 통과\" → \"{{name}}역 도착\"
- `channelStationPass` (Android 채널명): \"역 통과 알림\" → \"역 도착 알림\"
- ko/en/ja/zh 4종 일관 적용
- ja는 다른 locale과 일관성 위해 \"{{name}}駅に到着\"로 역명 명시
- `stationNotification.test.ts` 어서션 5건 갱신

## 검증
- npm test: 1387 pass, 100% coverage
- npm run type-check: pass

## Test plan
- [x] 단위/타입
- [x] 실기기: 역 진입 시 \"X역 도착\" 표시 확인 (ko/en/ja/zh)

Closes #408