### PR TITLE
fix(#417): 환승역 출발 시 direct route 표시 호선 오인식 (용마산을 2호선으로)

### DIFF
--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -238,6 +238,29 @@ describe('buildJourneyDisplay', () => {
     expect(result!.totalStops).toBe(3);
   });
 
+  it('DirectRoute 표시는 current.line이 아닌 route.line을 따른다 (환승역 출발)', () => {
+    // 시나리오: 건대입구(2/7 환승)에서 GPS가 2호선 entry를 current로 잡았으나
+    // findRouteCandidatesByCategory 결과는 7호선 direct(같은 line) 경로가 우승.
+    // 이전 버그: 표시가 current.line='2'를 그대로 사용해 "2호선 직통"으로 잘못 표기.
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const current = mockStation({ id: '2-012', name: '건대입구', line: '2', lineColor: '#009D3E' });
+    const dest = mockStation({ id: '7-015', name: '용마산', line: '7', lineColor: '#747F00' });
+
+    const result = buildJourneyDisplay(route, current, dest);
+    expect(result!.segments[0].line).toBe('7');
+    expect(result!.segments[0].lineColor).toBe('#747F00');
+  });
+
+  it('DirectRoute에서 LINE_COLORS에 없는 line이면 current.lineColor로 fallback', () => {
+    const unknownLine = 'unknown-line' as unknown as LineNumber;
+    const route: DirectRoute = { type: 'direct', stops: 2, line: unknownLine };
+    const current = mockStation({ name: 'A', line: unknownLine, lineColor: '#ABCDEF' });
+    const dest = mockStation({ name: 'B', line: unknownLine });
+
+    const result = buildJourneyDisplay(route, current, dest);
+    expect(result!.segments[0].lineColor).toBe('#ABCDEF');
+  });
+
   it('MultiTransferRoute이면 세그먼트 3개를 반환한다', () => {
     const route: MultiTransferRoute = {
       type: 'multi-transfer',

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -494,11 +494,13 @@ export function buildJourneyDisplay(
   if (!route) return null;
 
   if (route.type === 'direct') {
+    // 환승역에서 출발할 경우 GPS가 가까운 호선 entry를 current로 잡지만,
+    // 실제 우승 경로는 다른 호선 entry에서 시작할 수 있다. 표시 호선은 route.line이 정답.
     return {
       segments: [
         {
-          line: current.line,
-          lineColor: current.lineColor,
+          line: route.line,
+          lineColor: LINE_COLORS[route.line] ?? current.lineColor,
           fromName: current.name,
           toName: destination.name,
           stops: route.stops,


### PR DESCRIPTION
## 배경
실기기에서 건대입구(2/7 환승)에서 용마산(7호선) 목적지 설정 시 화면이 **\"용마산 · 2호선 · 4정거장 · 직통\"** 으로 표시. 실제는 7호선 4정거장.

## 원인
\`src/utils/stationRoute.ts:496-510\` \`buildJourneyDisplay\` direct 분기:
\`\`\`ts
return {
  segments: [{
    line: current.line,           // ← 환승역에선 GPS 가까운 호선이라 wrong
    lineColor: current.lineColor,
    ...
  }]
};
\`\`\`

\`findRouteCandidatesByCategory(['2-012','7-019'], '7-015')\`는 7호선 direct (4 stops)가 transfer (overhead 포함)보다 짧다고 우승. route는 \`{type:'direct', line:'7'}\`로 정확하지만 표시가 \`current.line='2'\`를 그대로 사용해 inconsistent.

transfer 분기는 이미 \`route.fromLine\`/\`route.toLine\`을 사용 — direct만 누락된 패턴.

## 변경
- \`buildJourneyDisplay\` direct 분기: \`line: route.line\`, \`lineColor: LINE_COLORS[route.line] ?? current.lineColor\`로 교체
- 회귀 테스트: 환승역 출발 + direct on 다른 라인 시나리오 (용마산 case 그대로)
- LINE_COLORS 미매핑 fallback 테스트 (커버리지 100% 유지)

## 검증
- npm test: 1391 pass, 100% coverage
- npm run type-check: pass

## Test plan
- [x] 단위 회귀 테스트
- [ ] 실기기: 건대입구에서 용마산 설정 시 \"7호선\" 정확히 표시 + 환승 알림 정상 발화

## 관련
- 새 증상 #6 환승 알림 미발화 (호선 오표기 → waypoint 라인 오인 → 백엔드 매칭 실패)

Closes #417