### PR TITLE
chore(#415): E2E Smoke를 paths 게이팅으로 분리 (25분 병목 해소)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,43 @@ on:
     branches: [main, dev]
 
 jobs:
+  changes:
+    name: 변경 경로 판정 (e2e 게이팅)
+    runs-on: ubuntu-latest
+    outputs:
+      ui_affected: ${{ steps.detect.outputs.ui_affected }}
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: UI 영향 경로 판정
+        id: detect
+        # 변경 파일이 모두 SKIP_RE에만 매칭되면 e2e-smoke를 스킵한다.
+        # 기준: smoke flow가 검증하지 못하는 영역(백엔드/i18n/문서/nightly-only flow 등)은 25분 macOS runner를 낭비하지 않는다.
+        # 의심스러우면 트리거(보수적).
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --depth=1 origin "${{ github.base_ref }}"
+            base="origin/${{ github.base_ref }}"
+          else
+            base="HEAD^"
+          fi
+          files=$(git diff --name-only "$base"...HEAD || echo "")
+          echo "Changed files vs $base:"
+          echo "$files"
+          SKIP_RE='^(src/i18n/|backend/|docs/|scripts/|tasks/|\.maestro/manual/|\.maestro/flows/(gps|scenario)/|\.github/workflows/e2e\.yml$|.*\.md$|.*\.txt$)'
+          relevant=$(echo "$files" | grep -v '^$' | grep -vE "$SKIP_RE" || true)
+          if [ -z "$relevant" ] && [ -n "$files" ]; then
+            echo "ui_affected=false" >> "$GITHUB_OUTPUT"
+            echo "→ e2e-smoke SKIPPED (UI-무관 경로만 변경)"
+          else
+            echo "ui_affected=true" >> "$GITHUB_OUTPUT"
+            echo "→ e2e-smoke 실행"
+          fi
+
   test:
     name: Type Check & Test
     runs-on: ubuntu-latest
@@ -33,7 +70,9 @@ jobs:
   e2e-smoke:
     name: E2E Smoke (mock mode)
     # PR 머지 게이트. EXPO_PUBLIC_E2E_MOCK=1로 useNearestStation을 강남 고정 fixture로 단락 → 5분 내 결정성.
-    needs: test
+    # changes.ui_affected=false면 자동 스킵 (i18n/백엔드/문서 PR은 smoke가 검증할 게 없음 → 25분 낭비 방지).
+    needs: [test, changes]
+    if: needs.changes.outputs.ui_affected == 'true'
     runs-on: macos-14
     timeout-minutes: 45
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           files=$(git diff --name-only "$base"...HEAD || echo "")
           echo "Changed files vs $base:"
           echo "$files"
-          SKIP_RE='^(src/i18n/|backend/|docs/|scripts/|tasks/|\.maestro/manual/|\.maestro/flows/(gps|scenario)/|\.github/workflows/e2e\.yml$|.*\.md$|.*\.txt$)'
+          SKIP_RE='^(src/i18n/|src/testUtils/|backend/|docs/|scripts/|tasks/|img/|subway/|locales/|__mocks__/|\.maestro/manual/|\.maestro/flows/(gps|scenario)/|\.github/workflows/e2e\.yml$|eas\.json$|jest\.setup\.js$|sonar-project\.properties$|\.env\.example$|\.gitignore$|\.prettierrc.*$|\.eslintrc.*$|\.editorconfig$|.*\.md$|.*\.txt$)'
           relevant=$(echo "$files" | grep -v '^$' | grep -vE "$SKIP_RE" || true)
           if [ -z "$relevant" ] && [ -n "$files" ]; then
             echo "ui_affected=false" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,8 @@ perf/#이슈번호-대상         예: perf/#139-map-clustering
 
 ### PR 머지 규칙
 - **CI 통과 필수 확인** — `gh pr checks <PR번호>`로 `Type Check & Test` pass 확인 후 머지
-- `E2E Smoke (mock mode)`는 ci.yml에서 PR마다 실행되며 안정화(연속 20회 green) 후 branch protection required로 승격 예정 (Phase 4)
+- `E2E Smoke (mock mode)`는 ci.yml의 `changes` job이 UI 영향 경로 변경을 감지한 PR에서만 실행 (i18n/백엔드/문서 PR은 자동 스킵). 안정화 후 branch protection required로 승격 예정 (Phase 4)
+- E2E 스킵 기준 경로 (변경되어도 smoke 미실행): `src/i18n/`, `backend/`, `docs/`, `scripts/`, `tasks/`, `.maestro/manual/`, `.maestro/flows/{gps,scenario}/`, `.github/workflows/e2e.yml`, `*.md`, `*.txt`
 - nightly의 gps/scenario(`e2e.yml`)는 PR 게이트 아님. 실기기 수동 회귀는 `.maestro/manual/`
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ perf/#이슈번호-대상         예: perf/#139-map-clustering
 ### PR 머지 규칙
 - **CI 통과 필수 확인** — `gh pr checks <PR번호>`로 `Type Check & Test` pass 확인 후 머지
 - `E2E Smoke (mock mode)`는 ci.yml의 `changes` job이 UI 영향 경로 변경을 감지한 PR에서만 실행 (i18n/백엔드/문서 PR은 자동 스킵). 안정화 후 branch protection required로 승격 예정 (Phase 4)
-- E2E 스킵 기준 경로 (변경되어도 smoke 미실행): `src/i18n/`, `backend/`, `docs/`, `scripts/`, `tasks/`, `.maestro/manual/`, `.maestro/flows/{gps,scenario}/`, `.github/workflows/e2e.yml`, `*.md`, `*.txt`
+- E2E 스킵 기준 경로 (변경되어도 smoke 미실행): `src/i18n/`, `src/testUtils/`, `backend/`, `docs/`, `scripts/`, `tasks/`, `img/`, `subway/`, `locales/`(top), `__mocks__/`, `.maestro/manual/`, `.maestro/flows/{gps,scenario}/`, `.github/workflows/e2e.yml`, `eas.json`, `jest.setup.js`, `sonar-project.properties`, `.env.example`, `.gitignore`, `.prettierrc*`, `.eslintrc*`, `.editorconfig`, `*.md`, `*.txt`
 - nightly의 gps/scenario(`e2e.yml`)는 PR 게이트 아님. 실기기 수동 회귀는 `.maestro/manual/`
 
 ---


### PR DESCRIPTION
## 배경
\`ci.yml\`의 \`e2e-smoke\` job이 PR마다 평균 25분 소요 (macOS-14 + iOS simulator + Maestro). i18n-only / 백엔드-only / 문서-only PR에도 25분이 붙어 작업 흐름 병목.

실측: 최근 5회 e2e-smoke 평균 25분 (21~28분). 캐시 적중률 높여도 19~22분이 한계.

## 변경

### 1) \`changes\` job 추가
- 변경 파일 git diff로 판정 → \`ui_affected\` boolean output 노출
- 스킵 경로(SKIP_RE)에만 매칭되면 \`ui_affected=false\`
- 의심스러우면 트리거(보수적)

### 2) \`e2e-smoke\`에 조건부 실행
\`\`\`yaml
needs: [test, changes]
if: needs.changes.outputs.ui_affected == 'true'
\`\`\`

### 스킵 경로
| 경로 | 이유 |
|---|---|
| \`src/i18n/\` | 카피 변경, smoke flow 텍스트 어서션과 무관 |
| \`backend/\` | Cloudflare Worker, RN 앱과 격리 |
| \`docs/\` | 문서만 |
| \`scripts/\` | 빌드 외 보조 스크립트 |
| \`tasks/\` | lessons.md 등 메타 |
| \`.maestro/manual/\` | 수동 회귀, CI 게이트 아님 |
| \`.maestro/flows/{gps,scenario}/\` | nightly 전용 |
| \`.github/workflows/e2e.yml\` | nightly 워크플로 자체 |
| \`*.md\`, \`*.txt\` | 문서 |

### 의도적 트리거 유지
- \`ci.yml\` 자체 변경 → 워크플로 회귀 검증 필요
- \`src/**/*.{ts,tsx}\` (i18n 제외) → 화면 영향 가능
- \`app/**\`, \`ios/**\`, \`android/**\`, \`modules/**\` → 화면/네이티브
- \`package.json\`, \`app.config.js\` → deps/구성
- \`.maestro/flows/smoke/**\` → smoke flow 자체

## 검증
- 본 PR은 \`ci.yml\` 변경이라 e2e-smoke가 **트리거되어야 함** → 회귀 자가 검증
- 머지 후 다음 i18n-only PR(예: PR #414)에서 e2e 스킵 확인

## 향후
- 안정화 후 branch protection required로 승격 (#398 후속)
- skip-e2e 라벨 escape hatch는 별도 이슈로 (필요 시점)

Closes #415