### PR TITLE
fix(#420): nightly e2e flow 안정화 — locale regex + 권한 + 진단

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,12 +102,26 @@ jobs:
       - name: Maestro gps 실행
         id: gps
         continue-on-error: true
-        run: maestro test .maestro/flows/gps/ --format junit --output maestro-gps.xml
+        run: maestro test .maestro/flows/gps/ --format junit --output maestro-gps.xml --debug-output ./maestro-debug-gps
+
+      - name: gps 시뮬레이터 화면 캡처
+        if: always()
+        run: |
+          mkdir -p ./diag-gps
+          xcrun simctl io booted screenshot ./diag-gps/last-screen.png || true
+          xcrun simctl spawn booted log show --last 2m --predicate 'process == "subwaynow"' --style compact > ./diag-gps/app.log 2>&1 || true
 
       - name: Maestro scenario 실행
         id: scenario
         continue-on-error: true
-        run: maestro test .maestro/flows/scenario/ --format junit --output maestro-scenario.xml
+        run: maestro test .maestro/flows/scenario/ --format junit --output maestro-scenario.xml --debug-output ./maestro-debug-scenario
+
+      - name: scenario 시뮬레이터 화면 캡처
+        if: always()
+        run: |
+          mkdir -p ./diag-scenario
+          xcrun simctl io booted screenshot ./diag-scenario/last-screen.png || true
+          xcrun simctl spawn booted log show --last 2m --predicate 'process == "subwaynow"' --style compact > ./diag-scenario/app.log 2>&1 || true
 
       - name: 최종 결과 집계
         if: always()
@@ -122,4 +136,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maestro-nightly-results
-          path: maestro-*.xml
+          path: |
+            maestro-*.xml
+            maestro-debug-gps/
+            maestro-debug-scenario/
+            diag-gps/
+            diag-scenario/

--- a/.maestro/flows/gps/01_near_station.yaml
+++ b/.maestro/flows/gps/01_near_station.yaml
@@ -19,14 +19,14 @@ name: "gps - 역 근처 (강남역)"
 
 - extendedWaitUntil:
     visible:
-      text: "현재역"
+      text: "현재역|Current station"
     timeout: 15000
 
 - assertVisible:
-    text: "강남"
+    text: "강남|Gangnam"
 - assertVisible:
     text: "Next trains"
 - assertVisible:
-    text: "상행"
+    text: "상행|Upbound"
 - assertVisible:
-    text: "하행"
+    text: "하행|Downbound"

--- a/.maestro/flows/gps/02_station_change.yaml
+++ b/.maestro/flows/gps/02_station_change.yaml
@@ -18,7 +18,7 @@ name: "gps - 역 변경 (강남 → 잠실)"
 
 - extendedWaitUntil:
     visible:
-      text: "강남"
+      text: "강남|Gangnam"
     timeout: 15000
 
 - setLocation:
@@ -27,5 +27,5 @@ name: "gps - 역 변경 (강남 → 잠실)"
 
 - extendedWaitUntil:
     visible:
-      text: "잠실"
+      text: "잠실|Jamsil"
     timeout: 70000

--- a/.maestro/flows/gps/03_jump_rejection.yaml
+++ b/.maestro/flows/gps/03_jump_rejection.yaml
@@ -19,7 +19,7 @@ name: "gps - 경로 잠금 점프 거부 (#310)"
 
 - extendedWaitUntil:
     visible:
-      text: "사가정"
+      text: "사가정|Sagajeong"
     timeout: 15000
 
 - extendedWaitUntil:
@@ -54,4 +54,4 @@ name: "gps - 경로 잠금 점프 거부 (#310)"
       - evalScript: maestro.wait(1000)
 
 - assertVisible:
-    text: "사가정"
+    text: "사가정|Sagajeong"

--- a/.maestro/flows/gps/04_no_station_nearby.yaml
+++ b/.maestro/flows/gps/04_no_station_nearby.yaml
@@ -18,8 +18,8 @@ name: "gps - 역에서 먼 곳"
 
 - extendedWaitUntil:
     visible:
-      text: "지하철역 근처가 아닙니다"
+      text: "지하철역 근처가 아닙니다|Not near a subway station"
     timeout: 15000
 
 - assertVisible:
-    text: "새로고침"
+    text: "새로고침|Refresh"

--- a/.maestro/flows/scenario/01_alarm_foreground_arrival.yaml
+++ b/.maestro/flows/scenario/01_alarm_foreground_arrival.yaml
@@ -9,6 +9,9 @@ name: "scenario - 포그라운드 도착 알람"
 - launchApp:
     appId: com.subwaynow.app
     clearState: true
+    permissions:
+      location: always
+      notifications: allow
 
 - tapOn:
     text: ".*localhost.*"

--- a/.maestro/flows/scenario/02_alarm_overlay_resume.yaml
+++ b/.maestro/flows/scenario/02_alarm_overlay_resume.yaml
@@ -8,6 +8,9 @@ name: "scenario - AlarmOverlay 해제"
 - launchApp:
     appId: com.subwaynow.app
     clearState: true
+    permissions:
+      location: always
+      notifications: allow
 
 - tapOn:
     text: ".*localhost.*"


### PR DESCRIPTION
## Summary
- gps 4 flow: Korean 어시션을 한/영 정규식으로 (smoke 패턴 동일)
- scenario/01, 02: `launchApp.permissions` 누락분 추가 (`location: always` + `notifications`)
- e2e.yml: maestro `--debug-output` + 시뮬레이터 screenshot/log 캡처 추가 (ci.yml 패턴 복제)

## Test plan
- [x] type-check, npm test 통과 (코드 변경 없음)
- [ ] 머지 전 nightly 수동 실행하여 9 flow 결과 확인 (scenario/03~05는 추가 진단 필요할 수 있음)

Closes #420