### PR TITLE
chore(#413): lastKnown 캐시 거부 진단 로그

### DIFF
--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -471,7 +471,8 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('stale 캐시 위치(MAX_LOCATION_AGE_MS 초과)는 무시하고 watch만 시작한다', async () => {
+  it('stale 캐시 위치(MAX_LOCATION_AGE_MS 초과)는 무시하고 진단 로그를 남긴다', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     mockGranted();
     mockLastKnownLocation(37.4980, 127.0277, { ageMs: MAX_LOCATION_AGE_MS + 1 });
 
@@ -481,9 +482,16 @@ describe('useNearestStation', () => {
 
     // stale 캐시는 무시 → result는 null 유지 (watch 콜백 전까지)
     expect(result.current.result).toBeNull();
+    expect(logSpy).toHaveBeenCalledWith(
+      '[useNearestStation]',
+      'lastKnown rejected: stale',
+      expect.objectContaining({ cumulativeStale: 1 }),
+    );
+    logSpy.mockRestore();
   });
 
-  it('저정확도 캐시 위치(MAX_ACCURACY_M 초과)는 무시한다', async () => {
+  it('저정확도 캐시 위치(MAX_ACCURACY_M 초과)는 무시하고 진단 로그를 남긴다', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     mockGranted();
     mockLastKnownLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
 
@@ -492,6 +500,40 @@ describe('useNearestStation', () => {
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     expect(result.current.result).toBeNull();
+    expect(logSpy).toHaveBeenCalledWith(
+      '[useNearestStation]',
+      'lastKnown rejected: lowAccuracy',
+      expect.objectContaining({
+        accuracyMeters: MAX_ACCURACY_M + 1,
+        cumulativeLowAccuracy: 1,
+      }),
+    );
+    logSpy.mockRestore();
+  });
+
+  it('lastKnown 거부 카운터는 FG 재진입마다 누적된다', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockGranted();
+    mockLastKnownLocation(37.4980, 127.0277, { ageMs: MAX_LOCATION_AGE_MS + 1 });
+
+    renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // AppState 'active' 재진입으로 startWatch 재호출
+    await act(async () => {
+      appStateCallback?.('background');
+      appStateCallback?.('active');
+    });
+    await waitFor(() =>
+      expect(Location.getLastKnownPositionAsync).toHaveBeenCalledTimes(2),
+    );
+
+    expect(logSpy).toHaveBeenLastCalledWith(
+      '[useNearestStation]',
+      'lastKnown rejected: stale',
+      expect.objectContaining({ cumulativeStale: 2 }),
+    );
+    logSpy.mockRestore();
   });
 
   it('신선하고 정확한 캐시 위치는 사용한다', async () => {

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -6,6 +6,9 @@ import { findNearestStations } from '../utils/findNearestStation';
 import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../utils/locationGates';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../constants/e2e';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useNearestStation');
 
 const MIN_DISTANCE_CHANGE_KM = 0.003; // 3m — UI 갱신을 자주 흘려보낸다.
 
@@ -56,6 +59,10 @@ export function useNearestStation(): UseNearestStationReturn {
   const subscriptionRef = useRef<Location.LocationSubscription | null>(null);
   const lastStationIdRef = useRef<string | null>(null);
   const lastDistanceRef = useRef<number>(0);
+  // 진단용 누적 카운터: lastKnown 캐시 fix가 freshness/accuracy 게이트에서 거부된 횟수.
+  // BG→FG 전환마다 startWatch가 호출되므로 stale 위치 의심 시 운영 로그로 추적한다.
+  const lastKnownStaleCountRef = useRef<number>(0);
+  const lastKnownLowAccuracyCountRef = useRef<number>(0);
 
   const applyLocation = useCallback((coords: Location.LocationObjectCoords) => {
     const { latitude, longitude, speed, accuracy } = coords;
@@ -118,9 +125,25 @@ export function useNearestStation(): UseNearestStationReturn {
       // 캐시된 위치는 신선하고 알람 엄격 게이트(200m)를 통과하는 경우만 즉시 표시.
       // 콜드 스타트 시 부정확한 fix로 사용자에게 오정보를 주는 것을 방지.
       const lastKnown = await Location.getLastKnownPositionAsync();
-      if (lastKnown && isLocationFresh(lastKnown.timestamp) && isAccuracyAcceptable(lastKnown.coords.accuracy)) {
-        applyLocation(lastKnown.coords);
-        setLoading(false);
+      if (lastKnown) {
+        const fresh = isLocationFresh(lastKnown.timestamp);
+        const acceptable = isAccuracyAcceptable(lastKnown.coords.accuracy);
+        if (fresh && acceptable) {
+          applyLocation(lastKnown.coords);
+          setLoading(false);
+        } else if (!fresh) {
+          lastKnownStaleCountRef.current += 1;
+          logger.info('lastKnown rejected: stale', {
+            ageMs: Date.now() - lastKnown.timestamp,
+            cumulativeStale: lastKnownStaleCountRef.current,
+          });
+        } else {
+          lastKnownLowAccuracyCountRef.current += 1;
+          logger.info('lastKnown rejected: lowAccuracy', {
+            accuracyMeters: lastKnown.coords.accuracy,
+            cumulativeLowAccuracy: lastKnownLowAccuracyCountRef.current,
+          });
+        }
       }
 
       // 연속 GPS 스트리밍 — 지하 구간 horizontalAccuracy(300~1500m)도 표시용으로는 수용.


### PR DESCRIPTION
## Summary
- `useNearestStation` 의 `getLastKnownPositionAsync` cached fix가 freshness/accuracy 게이트로 거부될 때 사유별 누적 카운터(stale / lowAccuracy)와 함께 `logger.info` 진단 로그를 남긴다.
- BG→FG 전환마다 startWatch가 호출되므로 운영 환경에서 stale 위치 의심 시 빈도 추적 가능.

## 변경
- `src/hooks/useNearestStation.ts`
  - `createLogger('useNearestStation')` 도입
  - lastKnown 거부 분기 두 경로 추가: `!fresh` → `lastKnown rejected: stale`, `fresh && !acceptable` → `lastKnown rejected: lowAccuracy`
  - 누적 카운터는 `useRef`로 보관 (리렌더 유발 안 함)
- `src/hooks/__tests__/useNearestStation.test.ts`
  - 기존 stale/저정확도 케이스에 로그 출력 검증 추가
  - BG→FG 재진입 시 카운터 누적 케이스 신규 추가

## 로그 빈도
- `startWatch` 트리거: mount + AppState 'active' 전환만 → 자연스럽게 5건/분 미만

## Test plan
- [x] `npm test` 1392/1392 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 실기기 BG/FG 전환에서 로그 신호 확인 (#410 회귀 검증과 함께)

Closes #413