### PR TITLE
feat(#425): 급행 정차역 데이터셋 + 조회 유틸 추가

### DIFF
--- a/docs/decisions/ADR-005-express-stops-dataset.md
+++ b/docs/decisions/ADR-005-express-stops-dataset.md
@@ -1,0 +1,54 @@
+# ADR-005: 급행 정차역 데이터셋
+
+- 상태: Accepted
+- 일자: 2026-05-19
+- 관련 이슈: #425
+
+## 컨텍스트
+
+`stations.json`은 모든 역에 대한 좌표/노선/이름만 제공하고, 어느 역이 급행/특급/ITX 정차역인지 알 수 있는 메타데이터가 없다. 사용자가 현재 보는 역이 급행 통과역인지 알 수 없어 다음 문제가 발생한다:
+
+- 통과역에서 급행 도착 알림만 보고 헛되이 대기
+- 목적지가 통과역인데 급행에 탑승해 지나침
+- 급행 다음 정차역 미리보기, 급행 필터 등 후속 기능이 불가능
+
+## 결정
+
+급행 정차역을 별도 정적 데이터셋(`src/data/expressStops.ts`)으로 관리한다.
+
+### 데이터 구조
+
+```ts
+Partial<Record<LineNumber, Partial<Record<TrainType, ReadonlySet<stationName>>>>>
+```
+
+- **노선 키는 `LineNumber` 타입 (`src/types/station.ts`)**: stations.json의 `line` 필드 값과 동일(`'1'`·`'9'`·`'bundang'`·`'gyeongui'`·`'airport'` 등). 컴파일 타임 타입 검증.
+- **역 키는 `stations.json`의 `name`**: station id는 API/내부 데이터 갱신으로 변동될 수 있어 더 안정적인 이름으로 join. 일부 역은 부제 포함 이름(`'이촌(국립중앙박물관)'`, `'왕십리(성동구청)'`)으로 등록되어 있으므로 stations.json 표기와 정확히 일치시킨다.
+- **TrainType별 분리**: ITX와 특급이 다른 정차 패턴을 갖는 경우를 자연스럽게 표현.
+- **노선/타입 단위 누락 허용**: 8호선처럼 급행이 없는 노선은 단순히 키가 없다.
+- **stations.json 미포함 역은 등록하지 않음**: 1호선 경부선 수원 이남, 9호선 가락시장/올림픽공원, 경춘선 등은 stations.json에서 해당 노선으로 등록되지 않아 매칭이 일어나지 않으므로 데이터셋에서도 제외한다. stations.json 확장 시 별도 PR로 함께 추가.
+
+### 조회 유틸 (`src/utils/expressLookup.ts`)
+
+- `isExpressStop(name, line, type)`: 데이터가 없거나 `normal`이면 `true` — "알 수 없을 때 통과라고 단정하지 않음"이 사용자 안전성 측면에서 더 보수적.
+- `getExpressStopsOnLine(line, type)`: 빈 셋 fallback. `normal`은 빈 셋(의미 없음).
+
+## 대안
+
+1. **station id 기반 매핑** — 거부. stations.json 형식이 바뀌면 일일이 갱신 필요.
+2. **stations.json에 `expressTypes: string[]` 필드 추가** — 거부. 528개 역 중 급행 관련 역은 ~100개로 sparse하다. 단일 데이터셋이 검토/갱신에 유리.
+3. **외부 API에서 매번 조회** — 거부. 서울 열린데이터 API는 정차 패턴을 안정적으로 노출하지 않으며, 30초 폴링마다 비용 증가.
+
+## 갱신 정책
+
+- 노선 운영사(서울교통공사·코레일·공항철도)의 시간표가 변경되면 PR 형태로 갱신.
+- 출처 변경 시 본 ADR의 "출처" 섹션 갱신.
+- 신규 노선/급행 패턴 추가 시: `expressStops.ts`에 키 추가만으로 동작 (코드 변경 불필요).
+
+## 출처
+
+- 서울교통공사 공식 시간표 (https://www.seoulmetro.co.kr) — 1·9호선
+- 코레일 광역철도 시간표 (https://www.letskorail.com) — 경부/경인 1호선 급행, 경춘선, 수인분당선, 경의중앙선
+- 공항철도 직통열차 안내 (https://www.arex.or.kr) — 공항철도
+
+기준일: 2026-05-19.

--- a/src/data/expressStops.ts
+++ b/src/data/expressStops.ts
@@ -1,0 +1,71 @@
+/**
+ * 노선별 급행/특급/ITX 정차역 목록.
+ *
+ * 키는 `LineNumber` (`src/types/station.ts`)와 `stations.json`의 `name`이다.
+ * 새 노선/타입을 추가할 때는 이 파일 한 곳만 수정한다.
+ *
+ * 출처/갱신 정책: docs/decisions/ADR-005-express-stops-dataset.md
+ * 기준일: 2026-05-19
+ *
+ * 주의: `stations.json`에 존재하는 역만 포함한다. 1호선 경부선 수원 이남 구간,
+ * 9호선 가락시장/올림픽공원 등은 stations.json에서 해당 노선으로 등록되지 않아
+ * 의도적으로 제외한다(앱이 그 역들을 모르므로 매칭 자체가 발생하지 않음).
+ * stations.json 보완 시 이 목록도 함께 확장한다.
+ */
+
+import type { TrainType } from '../constants/trainTypes';
+import type { LineNumber } from '../types/station';
+
+export type ExpressStopsByType = Partial<Record<TrainType, ReadonlySet<string>>>;
+
+const set = (names: readonly string[]): ReadonlySet<string> => new Set(names);
+
+export const EXPRESS_STOPS: Partial<Record<LineNumber, ExpressStopsByType>> = {
+  // 1호선 — 경부선(서울역↔영등포) + 경인선(용산↔동인천) 급행 합집합.
+  // 경부선 수원 이남(안양·수원·천안 등)은 stations.json 미포함으로 제외.
+  '1': {
+    express: set([
+      '서울역', '영등포',
+      '용산', '노량진', '신도림', '구로', '개봉', '역곡', '부천', '송내',
+      '부평', '백운', '동암', '주안', '제물포', '동인천',
+    ]),
+  },
+
+  // 9호선 급행 — 가락시장/올림픽공원은 stations.json에 9호선으로 미등록(제외).
+  '9': {
+    express: set([
+      '개화', '김포공항', '마곡나루', '가양', '염창', '당산', '여의도',
+      '노량진', '동작', '고속터미널', '신논현', '선정릉', '삼성중앙',
+      '봉은사', '종합운동장', '석촌', '한성백제', '둔촌오륜', '중앙보훈병원',
+    ]),
+  },
+
+  // 수인분당선 급행 (왕십리 ↔ 수원). 선릉 → 수서 구간은 직통(한티/도곡 비정차).
+  bundang: {
+    express: set([
+      '왕십리', '청량리', '선릉', '수서', '모란',
+      '야탑', '서현', '수내', '정자', '미금', '오리', '죽전', '기흥',
+      '영통', '수원',
+    ]),
+  },
+
+  // 경의중앙선 급행 (문산 ↔ 용문). 일부 역은 stations.json에 부제 포함 이름으로 등록됨.
+  gyeongui: {
+    express: set([
+      '문산', '금촌', '운정', '일산', '디지털미디어시티', '홍대입구',
+      '공덕', '서울역', '용산', '이촌(국립중앙박물관)', '옥수',
+      '왕십리(성동구청)', '청량리(서울시립대입구)', '회기',
+      '상봉(시외버스터미널)', '망우',
+      '구리', '도농', '덕소', '팔당', '양수', '국수', '양평', '용문',
+    ]),
+  },
+
+  // 공항철도 직통열차 (서울역 ↔ 인천공항).
+  // ITX·특급 카테고리 매핑이 애매해 `rapid`로 분류.
+  airport: {
+    rapid: set(['서울역', '인천공항1터미널', '인천공항2터미널']),
+  },
+
+  // 경춘선 ITX-청춘/특급은 LineNumber 타입과 stations.json에 미포함.
+  // 데이터 확장 후 별도 이슈로 추가.
+};

--- a/src/utils/__tests__/expressLookup.test.ts
+++ b/src/utils/__tests__/expressLookup.test.ts
@@ -1,0 +1,98 @@
+import { getExpressStopsOnLine, isExpressStop } from '../expressLookup';
+import stations from '../../data/stations.json';
+import type { Station } from '../../types/station';
+
+describe('getExpressStopsOnLine', () => {
+  it('1호선 급행 정차역 셋 반환', () => {
+    const stops = getExpressStopsOnLine('1', 'express');
+    expect(stops.has('용산')).toBe(true);
+    expect(stops.has('신도림')).toBe(true);
+    expect(stops.has('영등포')).toBe(true);
+  });
+
+  it('9호선 급행 정차역 셋 반환', () => {
+    const stops = getExpressStopsOnLine('9', 'express');
+    expect(stops.has('여의도')).toBe(true);
+    expect(stops.has('고속터미널')).toBe(true);
+  });
+
+  it('공항철도 직통은 rapid 카테고리', () => {
+    const rapid = getExpressStopsOnLine('airport', 'rapid');
+    expect(rapid.has('서울역')).toBe(true);
+    expect(rapid.has('인천공항1터미널')).toBe(true);
+    expect(getExpressStopsOnLine('airport', 'express').size).toBe(0);
+  });
+
+  it('normal은 항상 빈 셋', () => {
+    expect(getExpressStopsOnLine('1', 'normal').size).toBe(0);
+    expect(getExpressStopsOnLine('9', 'normal').size).toBe(0);
+  });
+
+  it('미존재 노선/타입은 빈 셋', () => {
+    expect(getExpressStopsOnLine('8', 'express').size).toBe(0);
+    expect(getExpressStopsOnLine('1', 'itx').size).toBe(0);
+  });
+});
+
+describe('isExpressStop', () => {
+  it('급행 정차역은 true', () => {
+    expect(isExpressStop('용산', '1', 'express')).toBe(true);
+    expect(isExpressStop('여의도', '9', 'express')).toBe(true);
+  });
+
+  it('급행 통과역은 false', () => {
+    expect(isExpressStop('대방', '1', 'express')).toBe(false);
+    expect(isExpressStop('등촌', '9', 'express')).toBe(false);
+  });
+
+  it('normal은 모든 역에서 true', () => {
+    expect(isExpressStop('대방', '1', 'normal')).toBe(true);
+    expect(isExpressStop('미존재역', '5', 'normal')).toBe(true);
+  });
+
+  it('데이터 없는 노선은 보수적으로 true (잘못된 경고 방지)', () => {
+    expect(isExpressStop('아무역', '8', 'express')).toBe(true);
+    expect(isExpressStop('아무역', '1', 'itx')).toBe(true);
+  });
+});
+
+describe('expressStops dataset integrity vs stations.json', () => {
+  it('expressStops에 등록된 모든 역이 stations.json의 해당 노선에 실제 존재', () => {
+    const typed = stations as Station[];
+    const namesByLine = new Map<string, Set<string>>();
+    for (const s of typed) {
+      const bag = namesByLine.get(s.line) ?? new Set<string>();
+      bag.add(s.name);
+      namesByLine.set(s.line, bag);
+    }
+
+    const lines = ['1', '9', 'bundang', 'gyeongui', 'airport'] as const;
+    const trainTypes = ['express', 'itx', 'rapid'] as const;
+
+    for (const line of lines) {
+      for (const t of trainTypes) {
+        const stops = getExpressStopsOnLine(line, t);
+        for (const name of stops) {
+          expect({ line, type: t, name, exists: namesByLine.get(line)?.has(name) ?? false })
+            .toEqual({ line, type: t, name, exists: true });
+        }
+      }
+    }
+  });
+
+  it('노선별 급행 정차역 수 고정 (실수로 추가/삭제 시 회귀 알림)', () => {
+    expect(getExpressStopsOnLine('1', 'express').size).toBe(16);
+    expect(getExpressStopsOnLine('9', 'express').size).toBe(19);
+    expect(getExpressStopsOnLine('bundang', 'express').size).toBe(15);
+    expect(getExpressStopsOnLine('gyeongui', 'express').size).toBe(24);
+    expect(getExpressStopsOnLine('airport', 'rapid').size).toBe(3);
+  });
+
+  it('1호선 신도림 역이 stations.json에 존재하고 급행 정차역으로 인식', () => {
+    const sindorim = (stations as Station[]).find(
+      (s) => s.line === '1' && s.name === '신도림',
+    );
+    expect(sindorim).toBeDefined();
+    expect(isExpressStop(sindorim!.name, sindorim!.line, 'express')).toBe(true);
+  });
+});

--- a/src/utils/expressLookup.ts
+++ b/src/utils/expressLookup.ts
@@ -1,0 +1,38 @@
+import type { TrainType } from '../constants/trainTypes';
+import type { LineNumber } from '../types/station';
+import { EXPRESS_STOPS } from '../data/expressStops';
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+/**
+ * 주어진 노선에서 trainType이 정차하는 역 이름 셋을 반환한다.
+ * 데이터가 없는 노선/타입이면 빈 셋.
+ * `normal`은 모든 역에 정차하므로 빈 셋 — 호출자는 normal일 때 이 함수 대신
+ * `isExpressStop`을 사용한다.
+ */
+export function getExpressStopsOnLine(
+  line: LineNumber,
+  trainType: TrainType,
+): ReadonlySet<string> {
+  if (trainType === 'normal') return EMPTY;
+  return EXPRESS_STOPS[line]?.[trainType] ?? EMPTY;
+}
+
+/**
+ * 해당 역이 trainType의 정차역인지 판단.
+ * - `normal`: 모든 역에 정차하므로 항상 true.
+ * - 데이터 미보유 노선/타입: 보수적으로 true (잘못된 '통과' 경고로 사용자를 오도하지 않기 위함).
+ * - 데이터가 존재하는 노선/타입: 셋 멤버십으로 정확히 판정.
+ *
+ * 후속 UI에서 "이 역 통과" 경고를 띄울 때는 이 함수가 false인 경우에만 표시하면 안전하다.
+ */
+export function isExpressStop(
+  stationName: string,
+  line: LineNumber,
+  trainType: TrainType,
+): boolean {
+  if (trainType === 'normal') return true;
+  const stops = EXPRESS_STOPS[line]?.[trainType];
+  if (!stops) return true;
+  return stops.has(stationName);
+}


### PR DESCRIPTION
## Summary

급행/특급/ITX 정차역을 데이터 주도 방식으로 관리할 수 있는 foundation을 추가합니다. 후속 UI 작업(배지 강조, 통과역 경고, 급행 필터, 다음 정차역 미리보기)의 기반입니다.

- `src/data/expressStops.ts` — 1·9호선, 수인분당선, 경의중앙선, 공항철도 급행/직통 정차역. `Partial<Record<LineNumber, Partial<Record<TrainType, ReadonlySet<stationName>>>>>` 구조로 컴파일 타임 타입 검증.
- `src/utils/expressLookup.ts` — `isExpressStop(name, line, type)`, `getExpressStopsOnLine(line, type)` 순수 함수. 데이터 없는 노선/타입은 보수적으로 `true` 반환(잘못된 통과 경고 방지).
- `docs/decisions/ADR-005-express-stops-dataset.md` — 데이터 구조/출처/갱신 정책.

## 주요 설계 결정

1. **역 키는 `stations.json`의 `name`** — station id 변동 영향 차단. 일부 역(`'이촌(국립중앙박물관)'` 등 부제 포함)은 stations.json 표기와 정확히 일치.
2. **노선 키는 `LineNumber` 타입** — `'bundang'`, `'gyeongui'`, `'airport'` 등 stations.json의 `line` 필드와 동일.
3. **stations.json에 없는 역은 등록하지 않음** — 1호선 경부선 수원 이남, 9호선 가락시장/올림픽공원, 경춘선 등. stations.json 확장 시 별도 PR로 함께 추가.

## 테스트

- 단위 테스트: getExpressStopsOnLine / isExpressStop 분기 100% 커버.
- **Integration test**: 데이터셋의 모든 (line, type, name)을 stations.json과 cross-check.
- **노선별 정차역 수 고정 테스트**: 향후 실수로 역이 추가/삭제될 경우 회귀 알림.

## Test plan

- [x] `npm test` — 1403 tests passed, 커버리지 100%
- [x] `npm run type-check` — 0 errors
- [ ] 후속 PR에서 UI 연결 시 시뮬레이터 검증 (이 PR은 foundation only, 소비처 없음)

Closes #425