### PR TITLE
chore(#427): CI E2E smoke 트리거/캐시 비효율 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ jobs:
           files=$(git diff --name-only "$base"...HEAD || echo "")
           echo "Changed files vs $base:"
           echo "$files"
-          SKIP_RE='^(src/i18n/|src/testUtils/|backend/|docs/|scripts/|tasks/|img/|subway/|locales/|__mocks__/|\.maestro/manual/|\.maestro/flows/(gps|scenario)/|\.github/workflows/e2e\.yml$|eas\.json$|jest\.setup\.js$|sonar-project\.properties$|\.env\.example$|\.gitignore$|\.prettierrc.*$|\.eslintrc.*$|\.editorconfig$|.*\.md$|.*\.txt$)'
+          # 추가 스킵 후보:
+          # - src/types/      : 타입 전용, 런타임 영향 없음 (tsc로 type 체크에서 잡힘)
+          # - src/data/       : 정적 데이터. mock smoke는 stations.json을 우회 (강남 fixture 단락)
+          # - src/__tests__/, src/**/__tests__/ : 테스트 코드는 앱 번들 미포함, jest로 별도 검증
+          SKIP_RE='^(src/i18n/|src/testUtils/|src/types/|src/data/|src/(.+/)?__tests__/|backend/|docs/|scripts/|tasks/|img/|subway/|locales/|__mocks__/|\.maestro/manual/|\.maestro/flows/(gps|scenario)/|\.github/workflows/e2e\.yml$|eas\.json$|jest\.setup\.js$|sonar-project\.properties$|\.env\.example$|\.gitignore$|\.prettierrc.*$|\.eslintrc.*$|\.editorconfig$|.*\.md$|.*\.txt$)'
           relevant=$(echo "$files" | grep -v '^$' | grep -vE "$SKIP_RE" || true)
           if [ -z "$relevant" ] && [ -n "$files" ]; then
             echo "ui_affected=false" >> "$GITHUB_OUTPUT"
@@ -133,10 +137,14 @@ jobs:
         run: cd ios && pod install
 
       - name: DerivedData 캐시
+        # 캐시 key에는 native binary에 영향 주는 파일만 포함한다.
+        # JS/TS 변경(src/**)은 xcodebuild build phase의 Metro 번들링(~30s)만 다시 돌면 되므로
+        # native 빌드 산출물(Pods, DerivedData)은 그대로 재사용 가능. src/**를 hash에 넣으면
+        # JS 한 줄 변경에도 풀 빌드(~15-20분)가 돌아 매우 비효율적이었음.
         uses: actions/cache@v4
         with:
           path: ios/build
-          key: deriveddata-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock', 'package-lock.json', 'modules/**', 'targets/**', 'app.config.js', 'src/**/*.ts', 'src/**/*.tsx') }}
+          key: deriveddata-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock', 'package-lock.json', 'modules/**', 'targets/**', 'app.config.js') }}
           restore-keys: deriveddata-${{ runner.os }}-
 
       - name: Mock env를 Xcode build phase로 주입


### PR DESCRIPTION
## Summary

PR #426 (데이터/유틸/ADR 변경)에서 E2E Smoke가 34분 소요. 두 비효율 동시 수정:

### 1) SKIP_RE 확장 — `ci.yml:37`
다음 경로 추가:
- `src/types/` — 타입 전용, 런타임 영향 없음
- `src/data/` — 정적 데이터, mock smoke는 stations.json을 강남 fixture로 단락
- `src/__tests__/`, `src/**/__tests__/` — 테스트는 앱 번들에 미포함, jest로 별도 검증

PR #426 같은 데이터/유틸 PR은 이제 E2E 자체가 스킵됩니다.

### 2) DerivedData 캐시 key 축소 — `ci.yml:141`
`'src/**/*.ts'`, `'src/**/*.tsx'`를 hash에서 제거. JS 한 줄만 바뀌어도 캐시 미스 → 풀 native 빌드(~15–20분) 돌던 문제 해소. native 영향 경로(`Podfile.lock`, `package-lock.json`, `modules/**`, `targets/**`, `app.config.js`)만 남김. JS는 xcodebuild build phase의 Metro 번들링으로 ~30s 안에 다시 만들어집니다.

## 로컬 검증

정규식 dry run으로 의도된 동작 확인:
- PR #426 변경 파일(`src/data/expressStops.ts`, `src/utils/__tests__/expressLookup.test.ts`, `docs/decisions/ADR-005-*.md`) → 전부 SKIP
- UI/native 파일(`src/components/*`, `src/hooks/*`, `app/*`, `modules/*`) → 정상 TRIG

## 기대 효과

- 데이터/유틸/타입/테스트 전용 PR: E2E 자체 스킵 → 30분 절약
- 진짜 UI PR: native 캐시 hit으로 ~15–20분 → ~5분

## Test plan

- [ ] 이 PR 자체에서 `Type Check & Test` 통과 확인
- [ ] 이 PR은 `.github/workflows/ci.yml` 변경이라 E2E 트리거됨 (자기 자신 검증). E2E도 통과해야 정규식이 valid yaml임을 보장.
- [ ] 머지 후 후속 데이터/유틸 PR에서 ui_affected=false 판정 + E2E 스킵 로그 확인.

Closes #427