### PR TITLE
feat(#429): 급행/특급/ITX 배지 시각적 강조 강화

### DIFF
--- a/src/components/ArrivalStatusBadge.tsx
+++ b/src/components/ArrivalStatusBadge.tsx
@@ -2,12 +2,23 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../theme';
 import { ARRIVAL_CODE } from '../constants/arrivalCodes';
-import { TRAIN_TYPE_LABEL, type TrainType } from '../constants/trainTypes';
+import {
+  TRAIN_TYPE_LABEL,
+  TRAIN_TYPE_VARIANT,
+  type BadgeVariant,
+  type TrainType,
+} from '../constants/trainTypes';
 
 interface Props {
   isLastTrain?: boolean;
   trainType?: TrainType;
   arrivalCode?: number;
+}
+
+interface Badge {
+  label: string;
+  color: string;
+  variant: BadgeVariant;
 }
 
 /**
@@ -17,31 +28,55 @@ interface Props {
 export function ArrivalStatusBadge({ isLastTrain, trainType, arrivalCode }: Props) {
   const { colors } = useTheme();
 
-  // 표시 우선순위: 막차 > 도착/진입 상태 > 급행/특급/ITX
-  // 막차는 사용자 안전성 직결이라 항상 가장 두드러지게.
-  const badges: { label: string; color: string }[] = [];
+  // 표시 우선순위: 급행 > 막차 > 도착/진입.
+  // 급행은 잘못된 열차 탑승을 방지하는 안전성 직결 정보이므로 filled로 가장 두드러지게.
+  const badges: Badge[] = [];
 
+  if (trainType && trainType !== 'normal') {
+    badges.push({
+      label: TRAIN_TYPE_LABEL[trainType],
+      color: colors.accent,
+      variant: TRAIN_TYPE_VARIANT[trainType],
+    });
+  }
   if (isLastTrain) {
-    badges.push({ label: '막차', color: colors.danger });
+    badges.push({ label: '막차', color: colors.danger, variant: 'outline' });
   }
   if (arrivalCode === ARRIVAL_CODE.ARRIVED) {
-    badges.push({ label: '도착', color: colors.accent });
+    badges.push({ label: '도착', color: colors.accent, variant: 'outline' });
   } else if (arrivalCode === ARRIVAL_CODE.ENTERING) {
-    badges.push({ label: '진입', color: colors.accent });
-  }
-  if (trainType && trainType !== 'normal') {
-    badges.push({ label: TRAIN_TYPE_LABEL[trainType], color: colors.accent });
+    badges.push({ label: '진입', color: colors.accent, variant: 'outline' });
   }
 
   if (badges.length === 0) return null;
 
   return (
     <View style={styles.row} testID="arrival-status-badge">
-      {badges.map((b) => (
-        <View key={b.label} style={[styles.badge, { borderColor: b.color }]}>
-          <Text style={[styles.text, { color: b.color }]}>{b.label}</Text>
-        </View>
-      ))}
+      {badges.map((b) => {
+        const filled = b.variant === 'filled';
+        return (
+          <View
+            key={b.label}
+            style={[
+              styles.badge,
+              filled
+                ? { backgroundColor: b.color, borderColor: b.color }
+                : { borderColor: b.color },
+            ]}
+            testID={`arrival-status-badge-${b.label}`}
+          >
+            <Text
+              style={[
+                styles.text,
+                filled ? styles.textFilled : null,
+                { color: filled ? colors.onAccent : b.color },
+              ]}
+            >
+              {b.label}
+            </Text>
+          </View>
+        );
+      })}
     </View>
   );
 }
@@ -56,4 +91,6 @@ const styles = StyleSheet.create({
   },
   // 한글/영문 혼용(ITX)이라 typography.label의 uppercase/letterSpacing은 적용하지 않는다.
   text: { fontSize: 10, fontWeight: '700', letterSpacing: 0 },
+  // filled variant는 안전성 직결 정보(급행) → 한 단계 더 키워 시선 끌어옴.
+  textFilled: { fontSize: 11 },
 });

--- a/src/components/__tests__/ArrivalStatusBadge.test.tsx
+++ b/src/components/__tests__/ArrivalStatusBadge.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { screen } from '@testing-library/react-native';
 import { ArrivalStatusBadge } from '../ArrivalStatusBadge';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
@@ -59,5 +60,53 @@ describe('ArrivalStatusBadge', () => {
     expect(screen.getByText('막차')).toBeTruthy();
     expect(screen.getByText('도착')).toBeTruthy();
     expect(screen.getByText('급행')).toBeTruthy();
+  });
+
+  it('급행 + 막차 동시 시 급행이 가장 먼저 표시 (안전성 직결 정보 우선)', () => {
+    renderWithTheme(<ArrivalStatusBadge isLastTrain trainType="express" />);
+    const row = screen.getByTestId('arrival-status-badge');
+    const labels = row.children
+      .map((c: unknown) => {
+        if (typeof c !== 'object' || c === null) return undefined;
+        const node = c as { props?: { testID?: string } };
+        return node.props?.testID;
+      })
+      .filter((id: string | undefined): id is string => typeof id === 'string');
+    expect(labels[0]).toBe('arrival-status-badge-급행');
+    expect(labels[1]).toBe('arrival-status-badge-막차');
+  });
+
+  describe('variant 스타일', () => {
+    it('급행 배지는 filled (배경색 채움)', () => {
+      renderWithTheme(<ArrivalStatusBadge trainType="express" />);
+      const badge = screen.getByTestId('arrival-status-badge-급행');
+      const style = StyleSheet.flatten(badge.props.style);
+      expect(style.backgroundColor).toBeDefined();
+      expect(style.backgroundColor).toBe(style.borderColor);
+    });
+
+    it('ITX/특급도 filled', () => {
+      renderWithTheme(<ArrivalStatusBadge trainType="itx" />);
+      const itx = screen.getByTestId('arrival-status-badge-ITX');
+      const itxStyle = Array.isArray(itx.props.style)
+        ? Object.assign({}, ...itx.props.style)
+        : itx.props.style;
+      expect(itxStyle.backgroundColor).toBeDefined();
+    });
+
+    it('막차 배지는 outline (배경색 없음)', () => {
+      renderWithTheme(<ArrivalStatusBadge isLastTrain />);
+      const badge = screen.getByTestId('arrival-status-badge-막차');
+      const style = StyleSheet.flatten(badge.props.style);
+      expect(style.backgroundColor).toBeUndefined();
+      expect(style.borderColor).toBeDefined();
+    });
+
+    it('도착/진입 배지는 outline', () => {
+      renderWithTheme(<ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.ENTERING} />);
+      const badge = screen.getByTestId('arrival-status-badge-진입');
+      const style = StyleSheet.flatten(badge.props.style);
+      expect(style.backgroundColor).toBeUndefined();
+    });
   });
 });

--- a/src/constants/__tests__/trainTypes.test.ts
+++ b/src/constants/__tests__/trainTypes.test.ts
@@ -1,4 +1,9 @@
-import { parseTrainType, parseTrainTypeFromDirectAt, TRAIN_TYPE_LABEL } from '../trainTypes';
+import {
+  parseTrainType,
+  parseTrainTypeFromDirectAt,
+  TRAIN_TYPE_LABEL,
+  TRAIN_TYPE_VARIANT,
+} from '../trainTypes';
 
 describe('parseTrainType', () => {
   it('급행/ITX/특급 정확히 매핑', () => {
@@ -26,6 +31,18 @@ describe('TRAIN_TYPE_LABEL', () => {
     expect(TRAIN_TYPE_LABEL.itx).toBe('ITX');
     expect(TRAIN_TYPE_LABEL.rapid).toBe('특급');
     expect(TRAIN_TYPE_LABEL.normal).toBe('');
+  });
+});
+
+describe('TRAIN_TYPE_VARIANT', () => {
+  it('급행/특급/ITX는 filled (안전성 직결 정보 강조)', () => {
+    expect(TRAIN_TYPE_VARIANT.express).toBe('filled');
+    expect(TRAIN_TYPE_VARIANT.itx).toBe('filled');
+    expect(TRAIN_TYPE_VARIANT.rapid).toBe('filled');
+  });
+
+  it('normal은 outline (사용되지 않지만 타입 완전성 확보)', () => {
+    expect(TRAIN_TYPE_VARIANT.normal).toBe('outline');
   });
 });
 

--- a/src/constants/trainTypes.ts
+++ b/src/constants/trainTypes.ts
@@ -24,6 +24,20 @@ export const TRAIN_TYPE_LABEL: Record<TrainType, string> = {
 };
 
 /**
+ * 배지 시각 variant. 급행/특급/ITX는 사용자가 잘못된 열차에 타지 않도록
+ * 안전성 직결 정보 → filled로 가장 두드러지게 표시한다.
+ * normal은 라벨 자체가 없어 사용되지 않는다.
+ */
+export type BadgeVariant = 'filled' | 'outline';
+
+export const TRAIN_TYPE_VARIANT: Record<TrainType, BadgeVariant> = {
+  express: 'filled',
+  itx: 'filled',
+  rapid: 'filled',
+  normal: 'outline',
+};
+
+/**
  * realtimePosition API의 `directAt` 응답값(숫자) → 같은 TrainType enum으로 통합.
  * 스펙: 1:급행, 0:아님, 7:특급 (ITX는 directAt에 없음 — btrainSttus 텍스트로만 옴)
  */


### PR DESCRIPTION
## Summary

급행/특급/ITX를 사용자가 한눈에 식별할 수 있도록 배지를 filled 스타일로 강조하고, 표시 우선순위를 안전성 직결 정보(급행) 우선으로 변경합니다.

### 변경 내역
- `src/constants/trainTypes.ts` — `BadgeVariant`, `TRAIN_TYPE_VARIANT` 추가. 새 trainType 추가 시 한 줄만 수정하면 동작.
- `src/components/ArrivalStatusBadge.tsx`
  - 급행/특급/ITX → **filled**: `colors.accent` 배경 + `colors.onAccent` 텍스트 + 11pt
  - 막차/도착/진입 → outline 유지 (기존 동작)
  - 표시 순서: 급행 > 막차 > 도착/진입
- 테스트 — variant 스타일 검증 4개 + 순서 회귀 방어 1개 + `TRAIN_TYPE_VARIANT` 단위 테스트 2개

### 설계 결정
- **`colors.onAccent` 사용** (테마 변경 시 대비 깨짐 방지). `colors.bg`는 우연의 일치일 뿐 의미상 부적절.
- **데이터 주도 variant** — `if/switch` 분기 없이 `TRAIN_TYPE_VARIANT[type]` lookup.
- **filled만 11pt** — 시각 위계 확보. outline은 10pt 유지.

## Test plan

- [x] `npm test` — 1469 tests passed, 커버리지 100%
- [x] `npm run type-check` — 0 errors
- [ ] 시뮬레이터 수동: 급행+막차 동시 도착 시 급행이 더 두드러져 보이는지

Closes #429