### PR TITLE
chore(#431): CI iOS 빌드에 ccache 도입 + 무용 DerivedData 캐시 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,19 +133,29 @@ jobs:
           key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: pods-${{ runner.os }}-
 
-      - name: CocoaPods 설치
-        run: cd ios && pod install
+      - name: CocoaPods 설치 (Manifest.lock 일치 시 스킵)
+        # pod install이 매번 돌면 Pods.xcodeproj가 재생성되어 Xcode 의존성 그래프가 무효화되고,
+        # 이는 incremental build 실패 + 풀 컴파일로 이어진다.
+        run: |
+          cd ios
+          if [ -f Pods/Manifest.lock ] && diff -q Podfile.lock Pods/Manifest.lock >/dev/null 2>&1; then
+            echo "Manifest.lock 일치 → pod install 스킵 (xcodeproj 재생성 방지)"
+          else
+            pod install
+          fi
 
-      - name: DerivedData 캐시
-        # 캐시 key에는 native binary에 영향 주는 파일만 포함한다.
-        # JS/TS 변경(src/**)은 xcodebuild build phase의 Metro 번들링(~30s)만 다시 돌면 되므로
-        # native 빌드 산출물(Pods, DerivedData)은 그대로 재사용 가능. src/**를 hash에 넣으면
-        # JS 한 줄 변경에도 풀 빌드(~15-20분)가 돌아 매우 비효율적이었음.
+      - name: ccache 설치
+        # DerivedData 캐시는 mtime/fingerprint mismatch로 incremental build에 활용되지 못한다.
+        # ccache는 컴파일러 wrapper로 source content hash 기반 .o 캐싱 → mtime 무관, 풀 컴파일이
+        # 돌아도 캐시된 .o를 즉시 반환. RN 프로젝트의 1600+ 파일 컴파일을 3-5분 수준으로 단축.
+        run: brew install ccache
+
+      - name: ccache 캐시
         uses: actions/cache@v4
         with:
-          path: ios/build
-          key: deriveddata-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock', 'package-lock.json', 'modules/**', 'targets/**', 'app.config.js') }}
-          restore-keys: deriveddata-${{ runner.os }}-
+          path: ~/Library/Caches/ccache
+          key: ccache-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock', 'package-lock.json') }}
+          restore-keys: ccache-${{ runner.os }}-
 
       - name: Mock env를 Xcode build phase로 주입
         # xcodebuild → build phase → Metro 체인의 env 전파 누락에 대비.
@@ -158,8 +168,15 @@ jobs:
         # CI에는 Metro dev server가 없으므로 JS 번들이 임베드된 Release 빌드를 사용.
         # Expo SDK 54의 Debug+simulator build phase는 FORCE_BUNDLING을 무시해 번들이 .app에 안 들어감.
         # Release는 항상 번들을 임베드하고 prod 동작과도 일치.
+        # ccache: clang/clang++을 wrapping해 source content hash 기반 .o 캐싱.
+        # ENABLE_USER_SCRIPT_SANDBOXING=NO는 Pods build phase 스크립트의 sandbox가 ccache 캐시 디렉터리
+        # 접근을 차단하지 않도록 (Expo 권장값과 일치).
         env:
           EXPO_PUBLIC_E2E_MOCK: 'true'
+          CCACHE_SLOPPINESS: 'clang_index_store,file_macro,time_macros,include_file_mtime,include_file_ctime,ivfsoverlay'
+          CCACHE_FILECLONE: 'true'
+          CCACHE_DEPEND: 'true'
+          CCACHE_MAXSIZE: '5G'
         run: |
           cd ios
           xcodebuild -workspace subwaynow.xcworkspace \
@@ -169,7 +186,17 @@ jobs:
             -destination "platform=iOS Simulator,name=${SIM_NAME}" \
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO \
+            ENABLE_USER_SCRIPT_SANDBOXING=NO \
+            CC="ccache clang" \
+            CXX="ccache clang++" \
+            LD=clang \
+            LDPLUSPLUS=clang++ \
             build
+
+      - name: ccache 통계 출력
+        # hit ratio 모니터링용. 첫 실행은 0%, 이후 80%+ 기대.
+        if: always()
+        run: ccache --show-stats || true
 
       - name: JS 번들에 mock sentinel이 inline되었는지 검증
         # Hermes bytecode는 숫자 리터럴을 보존하지 않으므로 좌표 grep 불가.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,9 @@ jobs:
         # CI에는 Metro dev server가 없으므로 JS 번들이 임베드된 Release 빌드를 사용.
         # Expo SDK 54의 Debug+simulator build phase는 FORCE_BUNDLING을 무시해 번들이 .app에 안 들어감.
         # Release는 항상 번들을 임베드하고 prod 동작과도 일치.
-        # ccache: clang/clang++을 wrapping해 source content hash 기반 .o 캐싱.
+        # ccache: Xcode 16의 explicit modules는 CC="ccache clang" 같은 비표준 wrapper를 거부한다.
+        # 정식 launcher 메커니즘(C_COMPILER_LAUNCHER + CLANG_ENABLE_EXPLICIT_MODULES_WITH_COMPILER_LAUNCHER)
+        # 을 사용해 explicit modules와 ccache를 동시 활용한다.
         # ENABLE_USER_SCRIPT_SANDBOXING=NO는 Pods build phase 스크립트의 sandbox가 ccache 캐시 디렉터리
         # 접근을 차단하지 않도록 (Expo 권장값과 일치).
         env:
@@ -187,10 +189,8 @@ jobs:
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO \
             ENABLE_USER_SCRIPT_SANDBOXING=NO \
-            CC="ccache clang" \
-            CXX="ccache clang++" \
-            LD=clang \
-            LDPLUSPLUS=clang++ \
+            C_COMPILER_LAUNCHER=ccache \
+            CLANG_ENABLE_EXPLICIT_MODULES_WITH_COMPILER_LAUNCHER=YES \
             build
 
       - name: ccache 통계 출력


### PR DESCRIPTION
## Summary

E2E Smoke 28–34분 문제의 근본 원인 해결. PR #430 로그 분석 결과:
- DerivedData 캐시는 primary key까지 hit인데도 빌드 단계에서 **1624 CompileC + 40 CompileSwift** 풀 컴파일 (17m 23s)
- 즉 1.6GB 캐시 다운로드/업로드만 하고 컴파일 결과를 0% 활용하는 순손실 상태

원인: pod install이 매 실행되어 Pods.xcodeproj가 재생성 → Xcode 의존성 그래프 무효화 → incremental build 불가. 또한 actions/cache의 tar 복원이 Xcode XCBuildData fingerprint와 mismatch.

## 변경

1. **ccache 도입** — clang/clang++ wrapper로 source content hash 기반 .o 캐싱. mtime 무관, 풀 컴파일이 돌아도 캐시된 .o를 즉시 반환.
   - `brew install ccache` step
   - `~/Library/Caches/ccache` 캐싱 (key: `ccache-macOS-${hashFiles(Podfile.lock, package-lock.json)}`)
   - xcodebuild에 `CC="ccache clang" CXX="ccache clang++" ENABLE_USER_SCRIPT_SANDBOXING=NO` 전달
   - `CCACHE_SLOPPINESS=clang_index_store,file_macro,time_macros,include_file_mtime,include_file_ctime,ivfsoverlay`
2. **DerivedData 캐시 제거** — 무용. 1.6GB 다운로드/업로드 시간 회수.
3. **pod install 조건부 스킵** — `Manifest.lock == Podfile.lock`이면 생략 (xcodeproj 재생성 방지).
4. **`ccache --show-stats` 진단 step** — hit ratio 모니터링.

## 기대 효과

- 빌드 17m 23s → **3–5분** (ccache hit ratio 80%+ 기준)
- 전체 E2E 28m → **8–12분**
- 첫 캐시 채우는 이 PR은 여전히 17분대 가능 (일회성)

## Test plan

- [x] yaml 문법 확인 (diff 검토)
- [ ] 이 PR 자체 E2E 실행 — ccache 캐시가 비어 있어 첫 실행은 17분대 유지, **ccache 캐시 저장 성공** 확인
- [ ] 다음 UI PR에서 ccache cache hit 로그 + `ccache --show-stats` hit ratio 80%+ 확인
- [ ] 다음 UI PR에서 빌드 step이 5분 이하로 단축되는지 확인

## 리스크

- ccache + Pods sandbox 충돌 → `ENABLE_USER_SCRIPT_SANDBOXING=NO`로 대응
- 첫 실행은 캐시 miss → 17분 유지 (예상된 일회성)
- ccache 캐시 비대화 → `CCACHE_MAXSIZE=5G`로 자동 LRU 정리

Closes #431