### PR TITLE
feat(#416): 중간역 통과 알림 silent push 단일 경로 통합

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -166,6 +166,7 @@ export default function HomeScreen() {
     destination,
     nextStationEtaSeconds:
       nextTrainMinutes != null && nextTrainMinutes !== Infinity ? nextTrainMinutes * 60 : null,
+    currentStation: result?.station ?? null,
   });
 
   useEffect(() => {

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -61,7 +61,7 @@ describe('sendSilentPush', () => {
     );
     const result = await sendSilentPush({
       deviceToken: 'devicetoken-hex',
-      payload: { nextWaypoint: '강남', etaSeconds: 60, phase: 'early' },
+      payload: { nextWaypoint: '강남', etaSeconds: 60, phase: 'early', kind: 'destination' },
       config: makeConfig(),
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
@@ -78,6 +78,7 @@ describe('sendSilentPush', () => {
     expect(body.data.nextWaypoint).toBe('강남');
     expect(body.data.etaSeconds).toBe(60);
     expect(body.data.phase).toBe('early');
+    expect(body.data.kind).toBe('destination');
   });
 
   it('returns failure with reason', async () => {
@@ -86,7 +87,7 @@ describe('sendSilentPush', () => {
     );
     const result = await sendSilentPush({
       deviceToken: 'tok',
-      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent' },
+      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent', kind: 'destination' },
       config: makeConfig(),
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
@@ -99,7 +100,7 @@ describe('sendSilentPush', () => {
     const fetchImpl = vi.fn(async () => new Response('plain text', { status: 500 }));
     const result = await sendSilentPush({
       deviceToken: 'tok',
-      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent' },
+      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent', kind: 'destination' },
       config: makeConfig(),
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -48,6 +48,18 @@ describe('validateTrip', () => {
     ).toBeNull();
   });
 
+  it('accepts intermediate waypoint kind (#416)', () => {
+    const trip = validateTrip({
+      ...base(),
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
+    });
+    expect(trip).not.toBeNull();
+    expect(trip?.waypoints[0].kind).toBe('intermediate');
+  });
+
   it('rejects malformed waypoint', () => {
     expect(validateTrip({ ...base(), waypoints: [null] })).toBeNull();
     expect(

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -320,6 +320,71 @@ describe('runScheduled', () => {
     expect(kv.store.size).toBe(0);
   });
 
+  // #416: 중간역(intermediate) 처리 — early phase 스킵, imminent에서만 push + shift.
+  it('intermediate waypoint: early ETA에서는 push 안 함', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      }),
+    );
+    const seoul = makeSeoul([
+      { destination: '중곡', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '7호선' },
+    ]);
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBe(0);
+    // trip은 유지 (다음 사이클에 imminent까지 폴링)
+    expect(kv.store.size).toBe(1);
+    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
+    expect(stored.waypoints).toHaveLength(2);
+  });
+
+  it('intermediate waypoint: imminent에서 push + shift', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      }),
+    );
+    const seoul = makeSeoul([
+      { destination: '중곡', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '7호선' },
+    ]);
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBe(1);
+    // body에 kind=intermediate 포함 검증
+    const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.kind).toBe('intermediate');
+    expect(body.data.phase).toBe('imminent');
+    // shift 후 destination만 남음
+    expect(kv.store.size).toBe(1);
+    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
+    expect(stored.waypoints).toHaveLength(1);
+    expect(stored.waypoints[0].kind).toBe('destination');
+    expect(stored.lastFiredPhase).toBeUndefined();
+    expect(stored.lastEtaSeconds).toBeUndefined();
+  });
+
   it('counts seoul errors as poll errors', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeTrip());

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -30,6 +30,8 @@ export interface SilentPushPayload {
   nextWaypoint: string;
   etaSeconds: number;
   phase: AlarmPhase;
+  /** Waypoint 종류. 클라가 intermediate일 때만 즉시 알림 발사하도록 분기 (#416). */
+  kind: 'transfer' | 'destination' | 'intermediate';
 }
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
@@ -77,6 +79,7 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       nextWaypoint: options.payload.nextWaypoint,
       etaSeconds: options.payload.etaSeconds,
       phase: options.payload.phase,
+      kind: options.payload.kind,
     },
   });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -61,7 +61,7 @@ export function validateTrip(input: unknown): Trip | null {
     const wp = w as Record<string, unknown>;
     if (typeof wp.stationName !== 'string') return null;
     if (typeof wp.line !== 'string') return null;
-    if (wp.kind !== 'transfer' && wp.kind !== 'destination') return null;
+    if (wp.kind !== 'transfer' && wp.kind !== 'destination' && wp.kind !== 'intermediate') return null;
   }
 
   return {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -78,6 +78,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       const phase = evaluatePhase(eta);
       const etaChanged = isSignificantEtaChange(trip.lastEtaSeconds, eta);
       const phaseFires = phase !== null && shouldFire(phase, trip.lastFiredPhase);
+      // 중간역(intermediate)은 통과 시점(imminent)에만 발사. early phase / 정보 갱신용 push는 노이즈로 간주해 스킵.
+      const isIntermediate = waypoint.kind === 'intermediate';
 
       // 메모리 갱신: ETA가 의미있게 변하거나 phase가 발사된 경우만
       let dirty = false;
@@ -87,17 +89,29 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       }
 
       // Push 발사 조건:
-      // (1) 새 phase 도달 (phaseFires) — phaseFires는 phase !== null을 이미 포함
-      // (2) phase 미도달이지만 ETA 변동이 의미있게 발생 & 5분 이내 (사용자에게 정보 갱신)
-      const shouldPushPhase = phaseFires;
+      // (1) 새 phase 도달 — intermediate는 imminent에서만 허용
+      // (2) phase 미도달이지만 ETA 변동이 의미있게 발생 & 5분 이내 (intermediate는 제외)
+      const shouldPushPhase = phaseFires && (!isIntermediate || phase === 'imminent');
       const shouldPushEtaUpdate =
-        !shouldPushPhase && etaChanged && eta <= EARLY_THRESHOLD_SEC * 2;
+        !shouldPushPhase && !isIntermediate && etaChanged && eta <= EARLY_THRESHOLD_SEC * 2;
 
       if (shouldPushPhase || shouldPushEtaUpdate) {
         const pushPhase = phase ?? 'early';
+        log('push fired', {
+          token: trip.token.slice(0, 8),
+          kind: waypoint.kind,
+          phase: pushPhase,
+          station: waypoint.stationName,
+          etaSeconds: eta,
+        });
         const result = await sendSilentPush({
           deviceToken: trip.token,
-          payload: { nextWaypoint: waypoint.stationName, etaSeconds: eta, phase: pushPhase },
+          payload: {
+            nextWaypoint: waypoint.stationName,
+            etaSeconds: eta,
+            phase: pushPhase,
+            kind: waypoint.kind,
+          },
           config: deps.apnsConfig,
           fetchImpl: deps.fetchImpl,
           now,
@@ -116,15 +130,17 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
                 });
                 continue;
               }
-              // 환승역 imminent: 트립 유지하고 다음 waypoint로 진행.
+              // 환승역/중간역 imminent: 트립 유지하고 다음 waypoint로 진행.
               // dirty는 위(lastFiredPhase 갱신)에서 이미 true로 설정됨 → putTrip에서 shift된 상태가 저장된다.
               const completedStation = waypoint.stationName;
+              const completedKind = waypoint.kind;
               trip.waypoints.shift();
               trip.lastFiredPhase = undefined;
               trip.lastEtaSeconds = undefined;
               log('waypoint completed, advancing to next', {
                 token: trip.token.slice(0, 8),
                 completed: completedStation,
+                kind: completedKind,
                 remaining: trip.waypoints.length,
               });
               if (trip.waypoints.length === 0) {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -43,8 +43,8 @@ export interface Waypoint {
   stationName: string;
   /** 노선 키 (정확히 어느 호선에서 도착을 봐야 하는지) */
   line: LineNumber;
-  /** "transfer" — 환승 안내 / "destination" — 최종 도착 */
-  kind: 'transfer' | 'destination';
+  /** "transfer" — 환승 안내 / "destination" — 최종 도착 / "intermediate" — 중간역 통과 */
+  kind: 'transfer' | 'destination' | 'intermediate';
 }
 
 export interface Trip {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,4 +12,4 @@ sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,n
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**
+sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**,**/__tests__/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,4 +11,5 @@ sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,n
 # CPD는 별도 패스로 동작할 수 있어 명시적으로 전체 Swift를 CPD에서 제외.
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
-sonar.cpd.exclusions=**/*.swift,targets/**,modules/**
+# i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
+sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,8 @@ sonar.organization=handokei
 # 분석 대상
 sonar.sources=src,app
 
-# 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯)
-sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**
+# 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, i18n 번역 데이터)
+sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/i18n/locales/**
 
 # 중복 분석 제외 — Swift 파일은 sonar.sources(src,app) 밖이라 분석 대상이 아니지만
 # CPD는 별도 패스로 동작할 수 있어 명시적으로 전체 Swift를 CPD에서 제외.

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -17,7 +17,7 @@ const log = createLogger('alarmBackend');
 export interface AlarmWaypoint {
   stationName: string;
   line: string;
-  kind: 'transfer' | 'destination';
+  kind: 'transfer' | 'destination' | 'intermediate';
 }
 
 export interface RegisterTripPayload {

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -41,6 +41,25 @@ function deriveAlarmAtEpochMs(nextStationEtaSeconds: number | null, now: number)
   return now;
 }
 
+interface RegisterCallInputs {
+  token: string;
+  route: NonNullable<Route>;
+  destination: Station;
+  nextStationEtaSeconds: number | null;
+  currentStation: Station | null;
+}
+
+/** 두 호출처(token refresh / main effect)의 register 페이로드 빌드를 단일화. */
+async function callRegister(input: RegisterCallInputs) {
+  return registerActiveTrip({
+    token: input.token,
+    route: input.route,
+    destination: input.destination.id,
+    waypoints: routeToWaypoints(input.route, input.destination.name, input.currentStation),
+    alarmAtEpochMs: deriveAlarmAtEpochMs(input.nextStationEtaSeconds, Date.now()),
+  });
+}
+
 export function useApnsTripRegistration({
   route,
   destination,
@@ -91,12 +110,12 @@ export function useApnsTripRegistration({
           currentStation: cs,
         } = latestInputsRef.current;
         if (!r || !d) return;
-        await registerActiveTrip({
+        await callRegister({
           token,
           route: r,
-          destination: d.id,
-          waypoints: routeToWaypoints(r, d.name, cs),
-          alarmAtEpochMs: deriveAlarmAtEpochMs(eta, Date.now()),
+          destination: d,
+          nextStationEtaSeconds: eta,
+          currentStation: cs,
         });
       })();
     });
@@ -132,12 +151,12 @@ export function useApnsTripRegistration({
         return;
       }
 
-      const result = await registerActiveTrip({
+      const result = await callRegister({
         token,
         route,
-        destination: destination.id,
-        waypoints: routeToWaypoints(route, destination.name, currentStation),
-        alarmAtEpochMs: deriveAlarmAtEpochMs(nextStationEtaSeconds, Date.now()),
+        destination,
+        nextStationEtaSeconds,
+        currentStation,
       });
       if (cancelled) return;
       if (result.ok) {

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -25,6 +25,8 @@ export interface UseApnsTripRegistrationInputs {
   destination: Station | null;
   /** 첫 도착역까지 ETA(초). null이면 alarm scheduler와 동일하게 static fallback이 백엔드에서 진행. */
   nextStationEtaSeconds: number | null;
+  /** 현재 추정 출발역. 중간역(intermediate) 펼침에 사용 (#416). 미제공 또는 null이면 legacy 모드. */
+  currentStation?: Station | null;
 }
 
 /**
@@ -43,11 +45,12 @@ export function useApnsTripRegistration({
   route,
   destination,
   nextStationEtaSeconds,
+  currentStation = null,
 }: UseApnsTripRegistrationInputs): void {
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds });
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds };
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation };
   });
 
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
@@ -81,13 +84,18 @@ export function useApnsTripRegistration({
           logger.warn('persist refreshed token failed:', e);
         }
         // 활성 트립이 있으면 새 토큰으로 재등록한다.
-        const { route: r, destination: d, nextStationEtaSeconds: eta } = latestInputsRef.current;
+        const {
+          route: r,
+          destination: d,
+          nextStationEtaSeconds: eta,
+          currentStation: cs,
+        } = latestInputsRef.current;
         if (!r || !d) return;
         await registerActiveTrip({
           token,
           route: r,
           destination: d.id,
-          waypoints: routeToWaypoints(r, d.name),
+          waypoints: routeToWaypoints(r, d.name, cs),
           alarmAtEpochMs: deriveAlarmAtEpochMs(eta, Date.now()),
         });
       })();
@@ -128,7 +136,7 @@ export function useApnsTripRegistration({
         token,
         route,
         destination: destination.id,
-        waypoints: routeToWaypoints(route, destination.name),
+        waypoints: routeToWaypoints(route, destination.name, currentStation),
         alarmAtEpochMs: deriveAlarmAtEpochMs(nextStationEtaSeconds, Date.now()),
       });
       if (cancelled) return;
@@ -141,5 +149,7 @@ export function useApnsTripRegistration({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [route, destination?.id, nextStationEtaSeconds]);
+    // TODO(#416 follow-up): currentStation 변경 시 register 매번 호출되어 백엔드 trip 진행 상태(waypoints shift)가 reset될 수 있다.
+    // 멱등성 처리는 클라/백엔드 어디서 보장할지 실기기 검증 결과 보고 결정한다.
+  }, [route, destination?.id, nextStationEtaSeconds, currentStation?.id]);
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -167,6 +167,8 @@
     "atCurrentStation": "Currently at {{name}}",
     "approximateDistance": "~{{m}}m",
     "stationPassed": "Arrived at {{name}}",
+    "intermediatePassedTitle": "Passing station",
+    "intermediatePassedBody": "Passing through {{name}}",
     "stopsRemainingToDestination_one": "{{count}} stop to {{destination}}",
     "stopsRemainingToDestination_other": "{{count}} stops to {{destination}}",
     "stopsRemainingViaTransfer": "{{transferStops}} stops to {{transfer}} transfer · {{totalStops}} stops to {{destination}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -167,6 +167,8 @@
     "atCurrentStation": "現在 {{name}}",
     "approximateDistance": "約{{m}}m",
     "stationPassed": "{{name}}駅に到着",
+    "intermediatePassedTitle": "駅通過",
+    "intermediatePassedBody": "{{name}}駅を通過しています",
     "stopsRemainingToDestination_one": "{{destination}}まで残り{{count}}駅",
     "stopsRemainingToDestination_other": "{{destination}}まで残り{{count}}駅",
     "stopsRemainingViaTransfer": "{{transfer}}乗換まで{{transferStops}}駅 · {{destination}}まで{{totalStops}}駅",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -167,6 +167,8 @@
     "atCurrentStation": "현재 {{name}}역",
     "approximateDistance": "약 {{m}}m",
     "stationPassed": "{{name}}역 도착",
+    "intermediatePassedTitle": "역 통과",
+    "intermediatePassedBody": "{{name}}역을 지나고 있어요",
     "stopsRemainingToDestination_one": "{{destination}}까지 {{count}}정거장 남음",
     "stopsRemainingToDestination_other": "{{destination}}까지 {{count}}정거장 남음",
     "stopsRemainingViaTransfer": "{{transfer}} 환승까지 {{transferStops}}정거장 · {{destination}}까지 {{totalStops}}정거장",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -167,6 +167,8 @@
     "atCurrentStation": "当前 {{name}}",
     "approximateDistance": "约{{m}}m",
     "stationPassed": "已到达{{name}}",
+    "intermediatePassedTitle": "经过站点",
+    "intermediatePassedBody": "正在经过{{name}}站",
     "stopsRemainingToDestination_one": "距{{destination}}还有{{count}}站",
     "stopsRemainingToDestination_other": "距{{destination}}还有{{count}}站",
     "stopsRemainingViaTransfer": "距{{transfer}}换乘{{transferStops}}站 · 距{{destination}}{{totalStops}}站",

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -6,8 +6,10 @@ jest.mock('expo-task-manager', () => ({
 }));
 
 const mockRegisterTaskAsync = jest.fn();
+const mockScheduleNotificationAsync = jest.fn();
 jest.mock('expo-notifications', () => ({
   registerTaskAsync: (...args: unknown[]) => mockRegisterTaskAsync(...args),
+  scheduleNotificationAsync: (...args: unknown[]) => mockScheduleNotificationAsync(...args),
 }));
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -148,6 +150,29 @@ describe('silentPushTask', () => {
         }),
       ).toBeNull();
     });
+
+    it('kind=transfer/destination/intermediate면 그대로 전달', () => {
+      const variants: ReadonlyArray<'transfer' | 'destination' | 'intermediate'> = [
+        'transfer',
+        'destination',
+        'intermediate',
+      ];
+      for (const kind of variants) {
+        expect(
+          extractPayload({
+            notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind } },
+          }),
+        ).toEqual({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind });
+      }
+    });
+
+    it('kind가 알 수 없는 값이면 undefined로 정리 (legacy 호환)', () => {
+      expect(
+        extractPayload({
+          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'foo' } },
+        }),
+      ).toEqual({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: undefined });
+    });
   });
 
   describe('handleSilentPush', () => {
@@ -209,6 +234,31 @@ describe('silentPushTask', () => {
     it('schedule 내부 throw 시 graceful (throw 안 함)', async () => {
       mockSchedule.mockRejectedValue(new Error('boom'));
       await expect(handleSilentPush(reschedulePayload())).resolves.toBeUndefined();
+    });
+
+    it('kind=intermediate + phase=imminent → 즉시 알림 + reschedule 둘 다 호출 (#416)', async () => {
+      mockScheduleNotificationAsync.mockResolvedValue('id');
+      await handleSilentPush(
+        reschedulePayload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }),
+      );
+      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      const call = mockScheduleNotificationAsync.mock.calls[0][0];
+      // i18next mock가 기본 fallback으로 key 반환 또는 ko 로드 — 어느 쪽이든 station name이 body에 포함되어야 한다.
+      expect(JSON.stringify(call.content.body)).toContain('중곡');
+      expect(call.trigger).toBeNull();
+      expect(mockSchedule).toHaveBeenCalled();
+    });
+
+    it('kind=intermediate + phase=early → 즉시 알림 안 함, reschedule만', async () => {
+      await handleSilentPush(reschedulePayload({ kind: 'intermediate', phase: 'early' }));
+      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockSchedule).toHaveBeenCalled();
+    });
+
+    it('kind=destination + phase=imminent → 즉시 알림 안 함 (intermediate만 발사)', async () => {
+      await handleSilentPush(reschedulePayload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockSchedule).toHaveBeenCalled();
     });
   });
 

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -18,6 +18,7 @@
 import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import i18next from 'i18next';
 import type { Station } from '../types/station';
 import type { Route } from '../utils/stationRoute';
 import { scheduleAlarmsForRoute, cancelScheduledAlarms } from '../utils/alarmScheduler';
@@ -32,6 +33,8 @@ export interface SilentPushPayload {
   nextWaypoint: string;
   etaSeconds: number;
   phase: 'early' | 'imminent';
+  /** Waypoint 종류 (#416). intermediate면 통과 즉시 알림, 그 외는 reschedule만. 구 백엔드 호환을 위해 optional. */
+  kind?: 'transfer' | 'destination' | 'intermediate';
 }
 
 interface NotificationBackgroundTaskData {
@@ -57,11 +60,13 @@ export function extractPayload(
   const raw = notif.data ?? notif.request?.content?.data;
   if (!raw || typeof raw !== 'object') return null;
   const obj = raw as Record<string, unknown>;
-  const { nextWaypoint, etaSeconds, phase } = obj;
+  const { nextWaypoint, etaSeconds, phase, kind } = obj;
   if (typeof nextWaypoint !== 'string' || nextWaypoint.length === 0) return null;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
   if (phase !== 'early' && phase !== 'imminent') return null;
-  return { nextWaypoint, etaSeconds, phase };
+  const validKind =
+    kind === 'transfer' || kind === 'destination' || kind === 'intermediate' ? kind : undefined;
+  return { nextWaypoint, etaSeconds, phase, kind: validKind };
 }
 
 /**
@@ -78,6 +83,9 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     logger.info('payload missing or invalid — skip');
     return;
   }
+  logger.info(
+    `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds}`,
+  );
 
   try {
     const [destJson, routeJson] = await Promise.all([
@@ -99,6 +107,19 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       return;
     }
     if (!route || !destination) return;
+
+    // 중간역 통과(intermediate + imminent)는 통과 시점에 즉시 사용자 알림 표시 (#416).
+    // reschedule은 그대로 진행 — 다음 waypoint용 사전 예약을 갱신.
+    if (payload.kind === 'intermediate' && payload.phase === 'imminent') {
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: i18next.t('route.intermediatePassedTitle'),
+          body: i18next.t('route.intermediatePassedBody', { name: payload.nextWaypoint }),
+        },
+        trigger: null,
+      });
+      logger.info(`intermediate passed: ${payload.nextWaypoint}`);
+    }
 
     await cancelScheduledAlarms();
     const scheduled = await scheduleAlarmsForRoute({

--- a/src/utils/__tests__/routeWaypoints.test.ts
+++ b/src/utils/__tests__/routeWaypoints.test.ts
@@ -4,6 +4,14 @@ import type {
   TransferRoute,
   MultiTransferRoute,
 } from '../stationRoute';
+import { getStationsOnLine } from '../stationRoute';
+import type { LineNumber, Station } from '../../types/station';
+
+function stationById(line: LineNumber, id: string): Station {
+  const found = getStationsOnLine(line).find((s) => s.id === id);
+  if (!found) throw new Error(`fixture station missing: ${id}`);
+  return found;
+}
 
 describe('routeToWaypoints', () => {
   it('direct: 도착역 단일 waypoint (route.line)', () => {
@@ -82,5 +90,110 @@ describe('routeToWaypoints', () => {
     );
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ kind: 'destination', stationName: '상봉(시외버스터미널)', line: '7' });
+  });
+
+  // #416: currentStation이 주어지면 중간역을 intermediate waypoint로 포함시킨다.
+  describe('#416 intermediate 펼침', () => {
+    it('direct: 출발→도착 사이 중간역을 intermediate로 포함', () => {
+      // 1-001(소요산) → 1-005(지행): 사이에 동두천/보산/동두천중앙
+      const route: DirectRoute = { type: 'direct', stops: 4, line: '1' };
+      const origin = stationById('1', '1-001');
+      const result = routeToWaypoints(route, '지행', origin);
+      expect(result).toEqual([
+        { stationName: '동두천', line: '1', kind: 'intermediate' },
+        { stationName: '보산', line: '1', kind: 'intermediate' },
+        { stationName: '동두천중앙', line: '1', kind: 'intermediate' },
+        { stationName: '지행', line: '1', kind: 'destination' },
+      ]);
+    });
+
+    it('transfer: 환승 전/후 중간역을 모두 펼친다', () => {
+      // 1-038(대방) → 신도림(1↔2 환승) → 2-035(문래)
+      // 환승 전 1호선: 신길/영등포 / 환승 후 2호선: 문래는 신도림 바로 다음 (intermediates 없음)
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '신도림',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 1,
+      };
+      const origin = stationById('1', '1-038');
+      const result = routeToWaypoints(route, '문래', origin);
+      expect(result).toEqual([
+        { stationName: '신길', line: '1', kind: 'intermediate' },
+        { stationName: '영등포', line: '1', kind: 'intermediate' },
+        { stationName: '신도림', line: '1', kind: 'transfer' },
+        { stationName: '문래', line: '2', kind: 'destination' },
+      ]);
+    });
+
+    it('transfer 환승역=목적지: 출발→환승 중간역만 펼치고 destination 1개로 축약', () => {
+      // 1-038(대방) → 신도림(1) destination
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '신도림',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 0,
+      };
+      const origin = stationById('1', '1-038');
+      const result = routeToWaypoints(route, '신도림', origin);
+      expect(result).toEqual([
+        { stationName: '신길', line: '1', kind: 'intermediate' },
+        { stationName: '영등포', line: '1', kind: 'intermediate' },
+        { stationName: '신도림', line: '1', kind: 'destination' },
+      ]);
+    });
+
+    it('multi-transfer: 각 segment 사이의 중간역을 모두 펼친다', () => {
+      // origin=1-039(신길) → 신도림(1→2) → 문래(2) 두 번째 환승 → 3호선
+      // (테스트 시나리오: 두 환승 모두 인접 segment, 첫 segment에 신도림 직전 영등포 intermediate)
+      const route: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 2 },
+          { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 11 },
+        ],
+        stopsAfterLastTransfer: 0,
+      };
+      const origin = stationById('1', '1-039');
+      const result = routeToWaypoints(route, '교대', origin);
+      // 1호선: 신길→영등포→신도림 = pre intermediates [영등포]
+      // 2호선: 신도림→문래→영등포구청→당산→...→교대 = post intermediates 포함
+      expect(result[0]).toEqual({ stationName: '영등포', line: '1', kind: 'intermediate' });
+      expect(result[1]).toEqual({ stationName: '신도림', line: '1', kind: 'transfer' });
+      // 마지막은 destination=교대 (intermediate=False)
+      expect(result[result.length - 1]).toEqual({
+        stationName: '교대',
+        line: '2',
+        kind: 'destination',
+      });
+      // 모든 intermediate는 kind === 'intermediate'
+      const intermediates = result.filter((w) => w.kind === 'intermediate');
+      expect(intermediates.length).toBeGreaterThan(0);
+    });
+
+    it('currentStation의 line이 route와 안 맞으면 intermediates 펼침 없이 기존 동작', () => {
+      // 출발이 1호선인데 route가 2호선 direct
+      const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+      const origin = stationById('1', '1-001');
+      expect(routeToWaypoints(route, '강남', origin)).toEqual([
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ]);
+    });
+
+    it('currentStation=null은 기존 동작과 동일 (하위 호환)', () => {
+      const route: TransferRoute = {
+        type: 'transfer',
+        transferName: '신도림',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 4,
+      };
+      expect(routeToWaypoints(route, '강남', null)).toEqual(routeToWaypoints(route, '강남'));
+    });
   });
 });

--- a/src/utils/__tests__/routeWaypoints.test.ts
+++ b/src/utils/__tests__/routeWaypoints.test.ts
@@ -1,10 +1,12 @@
 import { routeToWaypoints } from '../routeWaypoints';
 import type {
   DirectRoute,
+  Route,
   TransferRoute,
   MultiTransferRoute,
 } from '../stationRoute';
 import { getStationsOnLine } from '../stationRoute';
+import type { AlarmWaypoint } from '../../api/alarmBackend';
 import type { LineNumber, Station } from '../../types/station';
 
 function stationById(line: LineNumber, id: string): Station {
@@ -12,6 +14,12 @@ function stationById(line: LineNumber, id: string): Station {
   if (!found) throw new Error(`fixture station missing: ${id}`);
   return found;
 }
+
+const wp = (
+  stationName: string,
+  line: LineNumber,
+  kind: AlarmWaypoint['kind'],
+): AlarmWaypoint => ({ stationName, line, kind });
 
 describe('routeToWaypoints', () => {
   it('direct: 도착역 단일 waypoint (route.line)', () => {
@@ -94,62 +102,82 @@ describe('routeToWaypoints', () => {
 
   // #416: currentStation이 주어지면 중간역을 intermediate waypoint로 포함시킨다.
   describe('#416 intermediate 펼침', () => {
-    it('direct: 출발→도착 사이 중간역을 intermediate로 포함', () => {
-      // 1-001(소요산) → 1-005(지행): 사이에 동두천/보산/동두천중앙
-      const route: DirectRoute = { type: 'direct', stops: 4, line: '1' };
-      const origin = stationById('1', '1-001');
-      const result = routeToWaypoints(route, '지행', origin);
-      expect(result).toEqual([
-        { stationName: '동두천', line: '1', kind: 'intermediate' },
-        { stationName: '보산', line: '1', kind: 'intermediate' },
-        { stationName: '동두천중앙', line: '1', kind: 'intermediate' },
-        { stationName: '지행', line: '1', kind: 'destination' },
-      ]);
-    });
+    interface ExpandCase {
+      name: string;
+      route: NonNullable<Route>;
+      destinationName: string;
+      origin: { line: LineNumber; id: string };
+      expected: AlarmWaypoint[];
+    }
 
-    it('transfer: 환승 전/후 중간역을 모두 펼친다', () => {
-      // 1-038(대방) → 신도림(1↔2 환승) → 2-035(문래)
-      // 환승 전 1호선: 신길/영등포 / 환승 후 2호선: 문래는 신도림 바로 다음 (intermediates 없음)
-      const route: TransferRoute = {
-        type: 'transfer',
-        transferName: '신도림',
-        fromLine: '1',
-        toLine: '2',
-        stopsToTransfer: 3,
-        stopsFromTransfer: 1,
-      };
-      const origin = stationById('1', '1-038');
-      const result = routeToWaypoints(route, '문래', origin);
-      expect(result).toEqual([
-        { stationName: '신길', line: '1', kind: 'intermediate' },
-        { stationName: '영등포', line: '1', kind: 'intermediate' },
-        { stationName: '신도림', line: '1', kind: 'transfer' },
-        { stationName: '문래', line: '2', kind: 'destination' },
-      ]);
-    });
+    const cases: ExpandCase[] = [
+      {
+        name: 'direct: 출발→도착 사이 중간역을 intermediate로 포함',
+        // 1-001(소요산) → 1-005(지행): 사이에 동두천/보산/동두천중앙
+        route: { type: 'direct', stops: 4, line: '1' } satisfies DirectRoute,
+        destinationName: '지행',
+        origin: { line: '1', id: '1-001' },
+        expected: [
+          wp('동두천', '1', 'intermediate'),
+          wp('보산', '1', 'intermediate'),
+          wp('동두천중앙', '1', 'intermediate'),
+          wp('지행', '1', 'destination'),
+        ],
+      },
+      {
+        name: 'transfer: 환승 전/후 중간역을 모두 펼친다',
+        // 1-038(대방) → 신도림(1↔2 환승) → 2-035(문래)
+        route: {
+          type: 'transfer',
+          transferName: '신도림',
+          fromLine: '1',
+          toLine: '2',
+          stopsToTransfer: 3,
+          stopsFromTransfer: 1,
+        } satisfies TransferRoute,
+        destinationName: '문래',
+        origin: { line: '1', id: '1-038' },
+        expected: [
+          wp('신길', '1', 'intermediate'),
+          wp('영등포', '1', 'intermediate'),
+          wp('신도림', '1', 'transfer'),
+          wp('문래', '2', 'destination'),
+        ],
+      },
+      {
+        name: 'transfer 환승역=목적지: 출발→환승 중간역만 펼치고 destination 1개로 축약',
+        route: {
+          type: 'transfer',
+          transferName: '신도림',
+          fromLine: '1',
+          toLine: '2',
+          stopsToTransfer: 3,
+          stopsFromTransfer: 0,
+        } satisfies TransferRoute,
+        destinationName: '신도림',
+        origin: { line: '1', id: '1-038' },
+        expected: [
+          wp('신길', '1', 'intermediate'),
+          wp('영등포', '1', 'intermediate'),
+          wp('신도림', '1', 'destination'),
+        ],
+      },
+      {
+        name: 'currentStation의 line이 route와 안 맞으면 intermediates 펼침 없이 기존 동작',
+        route: { type: 'direct', stops: 5, line: '2' } satisfies DirectRoute,
+        destinationName: '강남',
+        origin: { line: '1', id: '1-001' },
+        expected: [wp('강남', '2', 'destination')],
+      },
+    ];
 
-    it('transfer 환승역=목적지: 출발→환승 중간역만 펼치고 destination 1개로 축약', () => {
-      // 1-038(대방) → 신도림(1) destination
-      const route: TransferRoute = {
-        type: 'transfer',
-        transferName: '신도림',
-        fromLine: '1',
-        toLine: '2',
-        stopsToTransfer: 3,
-        stopsFromTransfer: 0,
-      };
-      const origin = stationById('1', '1-038');
-      const result = routeToWaypoints(route, '신도림', origin);
-      expect(result).toEqual([
-        { stationName: '신길', line: '1', kind: 'intermediate' },
-        { stationName: '영등포', line: '1', kind: 'intermediate' },
-        { stationName: '신도림', line: '1', kind: 'destination' },
-      ]);
+    it.each(cases)('$name', ({ route, destinationName, origin, expected }) => {
+      const station = stationById(origin.line, origin.id);
+      expect(routeToWaypoints(route, destinationName, station)).toEqual(expected);
     });
 
     it('multi-transfer: 각 segment 사이의 중간역을 모두 펼친다', () => {
-      // origin=1-039(신길) → 신도림(1→2) → 문래(2) 두 번째 환승 → 3호선
-      // (테스트 시나리오: 두 환승 모두 인접 segment, 첫 segment에 신도림 직전 영등포 intermediate)
+      // origin=1-039(신길) → 신도림(1→2) → 교대 (마지막 환승이 목적지)
       const route: MultiTransferRoute = {
         type: 'multi-transfer',
         transfers: [
@@ -158,30 +186,12 @@ describe('routeToWaypoints', () => {
         ],
         stopsAfterLastTransfer: 0,
       };
-      const origin = stationById('1', '1-039');
-      const result = routeToWaypoints(route, '교대', origin);
-      // 1호선: 신길→영등포→신도림 = pre intermediates [영등포]
-      // 2호선: 신도림→문래→영등포구청→당산→...→교대 = post intermediates 포함
-      expect(result[0]).toEqual({ stationName: '영등포', line: '1', kind: 'intermediate' });
-      expect(result[1]).toEqual({ stationName: '신도림', line: '1', kind: 'transfer' });
-      // 마지막은 destination=교대 (intermediate=False)
-      expect(result[result.length - 1]).toEqual({
-        stationName: '교대',
-        line: '2',
-        kind: 'destination',
-      });
-      // 모든 intermediate는 kind === 'intermediate'
-      const intermediates = result.filter((w) => w.kind === 'intermediate');
-      expect(intermediates.length).toBeGreaterThan(0);
-    });
-
-    it('currentStation의 line이 route와 안 맞으면 intermediates 펼침 없이 기존 동작', () => {
-      // 출발이 1호선인데 route가 2호선 direct
-      const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
-      const origin = stationById('1', '1-001');
-      expect(routeToWaypoints(route, '강남', origin)).toEqual([
-        { stationName: '강남', line: '2', kind: 'destination' },
-      ]);
+      const result = routeToWaypoints(route, '교대', stationById('1', '1-039'));
+      // 1호선 pre intermediates [영등포] + transfer 신도림 + ... + destination 교대
+      expect(result[0]).toEqual(wp('영등포', '1', 'intermediate'));
+      expect(result[1]).toEqual(wp('신도림', '1', 'transfer'));
+      expect(result[result.length - 1]).toEqual(wp('교대', '2', 'destination'));
+      expect(result.filter((w) => w.kind === 'intermediate').length).toBeGreaterThan(0);
     });
 
     it('currentStation=null은 기존 동작과 동일 (하위 호환)', () => {

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 
@@ -1148,5 +1148,45 @@ describe('환승역 이름 표기 불일치 회귀 — #401', () => {
     const single = candidates.find((c) => c.transferCount === 1);
     expect(single).toBeDefined();
     expect(normalizeStationName((single!.route as TransferRoute).transferName)).toBe(expectedName);
+  });
+});
+
+describe('getIntermediateStationNames', () => {
+  it('returns empty array when current and destination are the same', () => {
+    expect(getIntermediateStationNames('1-001', '1-001')).toEqual([]);
+  });
+
+  it('returns empty array for adjacent stations', () => {
+    // 1-001(소요산) → 1-002(동두천): 사이에 역 없음
+    expect(getIntermediateStationNames('1-001', '1-002')).toEqual([]);
+  });
+
+  it('returns intermediate station names in forward direction', () => {
+    // 1-001(소요산) → 1-005(지행): 동두천, 보산, 동두천중앙
+    expect(getIntermediateStationNames('1-001', '1-005')).toEqual([
+      '동두천',
+      '보산',
+      '동두천중앙',
+    ]);
+  });
+
+  it('returns intermediate station names in reverse direction', () => {
+    // 1-005(지행) → 1-001(소요산): 동두천중앙, 보산, 동두천 (역순)
+    expect(getIntermediateStationNames('1-005', '1-001')).toEqual([
+      '동두천중앙',
+      '보산',
+      '동두천',
+    ]);
+  });
+
+  it('returns null when stations are on different lines', () => {
+    const line1 = getStationsOnLine('1')[0];
+    const line2 = getStationsOnLine('2')[0];
+    expect(getIntermediateStationNames(line1.id, line2.id)).toBeNull();
+  });
+
+  it('returns null for unknown station id', () => {
+    expect(getIntermediateStationNames('1-001', 'unknown-id')).toBeNull();
+    expect(getIntermediateStationNames('unknown-id', '1-001')).toBeNull();
   });
 });

--- a/src/utils/routeWaypoints.ts
+++ b/src/utils/routeWaypoints.ts
@@ -3,51 +3,112 @@
  *
  * 백엔드 Waypoint는 `{stationName, line, kind}` 형태 — 백엔드가 도착정보 API를
  * 어느 호선에서 호출해야 하는지 알기 위해 line이 필요하다.
+ *
+ * `currentStation`이 주어지면 출발/환승/도착 사이의 중간역까지 펼쳐
+ * `kind: 'intermediate'` waypoint로 포함시킨다(#416). null이면 기존 동작과 동일하게
+ * transfer/destination만 반환한다.
  */
 
+import type { LineNumber, Station } from '../types/station';
 import type { Route } from './stationRoute';
-import { isSameStationName } from './stationRoute';
+import {
+  findStationByNameAndLine,
+  getIntermediateStationNames,
+  isSameStationName,
+} from './stationRoute';
 import type { AlarmWaypoint } from '../api/alarmBackend';
 
-/**
- * 환승역 도착 모니터링은 환승 전 호선에서 본다 (전 호선 도착정보로 그 역을 지나가는 시점 파악).
- * 최종 목적지는 마지막 구간의 호선에서 본다.
- */
+function intermediateWaypoints(
+  enabled: boolean,
+  line: LineNumber,
+  fromId: string | undefined,
+  toId: string | undefined,
+): AlarmWaypoint[] {
+  if (!enabled || !fromId || !toId) return [];
+  const names = getIntermediateStationNames(fromId, toId);
+  if (!names) return [];
+  return names.map((stationName) => ({ stationName, line, kind: 'intermediate' as const }));
+}
+
 export function routeToWaypoints(
   route: NonNullable<Route>,
   destinationName: string,
+  currentStation: Station | null = null,
 ): AlarmWaypoint[] {
+  // currentStation이 없으면 legacy 동작(transfer/destination만) — 하위 호환.
+  const enabled = currentStation !== null;
   if (route.type === 'direct') {
-    return [{ stationName: destinationName, line: route.line, kind: 'destination' }];
+    const destStation = findStationByNameAndLine(destinationName, route.line);
+    const intermediates = intermediateWaypoints(enabled, route.line, currentStation?.id, destStation?.id);
+    return [
+      ...intermediates,
+      { stationName: destinationName, line: route.line, kind: 'destination' },
+    ];
   }
 
   if (route.type === 'transfer') {
     if (isSameStationName(route.transferName, destinationName)) {
-      return [{ stationName: destinationName, line: route.fromLine, kind: 'destination' }];
+      const destFromLine = findStationByNameAndLine(route.transferName, route.fromLine);
+      const intermediates = intermediateWaypoints(
+        enabled,
+        route.fromLine,
+        currentStation?.id,
+        destFromLine?.id,
+      );
+      return [
+        ...intermediates,
+        { stationName: destinationName, line: route.fromLine, kind: 'destination' },
+      ];
     }
+    const transferFromLine = findStationByNameAndLine(route.transferName, route.fromLine);
+    const transferToLine = findStationByNameAndLine(route.transferName, route.toLine);
+    const destToLine = findStationByNameAndLine(destinationName, route.toLine);
+    const preIntermediates = intermediateWaypoints(
+      enabled,
+      route.fromLine,
+      currentStation?.id,
+      transferFromLine?.id,
+    );
+    const postIntermediates = intermediateWaypoints(
+      enabled,
+      route.toLine,
+      transferToLine?.id,
+      destToLine?.id,
+    );
     return [
+      ...preIntermediates,
       { stationName: route.transferName, line: route.fromLine, kind: 'transfer' },
+      ...postIntermediates,
       { stationName: destinationName, line: route.toLine, kind: 'destination' },
     ];
   }
 
-  const waypoints: AlarmWaypoint[] = route.transfers.map((seg) => {
+  // multi-transfer: segment마다 진행하며 각 사이의 intermediate를 펼친다.
+  // segment의 transferName이 destinationName과 같으면 그 segment에서 destination으로 마킹 후 조기 return —
+  // 이후 segment는 의미가 없으므로 (도착했으니 환승할 일도, post-intermediate도 없다).
+  const result: AlarmWaypoint[] = [];
+  let segmentStartStation: Station | undefined = currentStation ?? undefined;
+
+  for (const seg of route.transfers) {
     const isDestination = isSameStationName(seg.transferName, destinationName);
-    return {
+    const transferFromLine = findStationByNameAndLine(seg.transferName, seg.fromLine);
+    result.push(
+      ...intermediateWaypoints(enabled, seg.fromLine, segmentStartStation?.id, transferFromLine?.id),
+    );
+    result.push({
       stationName: isDestination ? destinationName : seg.transferName,
       line: seg.fromLine,
       kind: isDestination ? 'destination' : 'transfer',
-    };
-  });
+    });
+    if (isDestination) return result;
+    segmentStartStation = findStationByNameAndLine(seg.transferName, seg.toLine);
+  }
 
   const lastSegment = route.transfers[route.transfers.length - 1];
-  const lastWaypoint = waypoints[waypoints.length - 1];
-  if (lastSegment && lastWaypoint && lastWaypoint.kind !== 'destination') {
-    waypoints.push({
-      stationName: destinationName,
-      line: lastSegment.toLine,
-      kind: 'destination',
-    });
-  }
-  return waypoints;
+  const destToLine = findStationByNameAndLine(destinationName, lastSegment.toLine);
+  result.push(
+    ...intermediateWaypoints(enabled, lastSegment.toLine, segmentStartStation?.id, destToLine?.id),
+  );
+  result.push({ stationName: destinationName, line: lastSegment.toLine, kind: 'destination' });
+  return result;
 }

--- a/src/utils/routeWaypoints.ts
+++ b/src/utils/routeWaypoints.ts
@@ -10,7 +10,7 @@
  */
 
 import type { LineNumber, Station } from '../types/station';
-import type { Route } from './stationRoute';
+import type { DirectRoute, MultiTransferRoute, Route, TransferRoute } from './stationRoute';
 import {
   findStationByNameAndLine,
   getIntermediateStationNames,
@@ -18,16 +18,96 @@ import {
 } from './stationRoute';
 import type { AlarmWaypoint } from '../api/alarmBackend';
 
+interface Context {
+  destinationName: string;
+  currentStation: Station | null;
+  enabled: boolean;
+}
+
 function intermediateWaypoints(
-  enabled: boolean,
+  ctx: Context,
   line: LineNumber,
   fromId: string | undefined,
   toId: string | undefined,
 ): AlarmWaypoint[] {
-  if (!enabled || !fromId || !toId) return [];
+  if (!ctx.enabled || !fromId || !toId) return [];
   const names = getIntermediateStationNames(fromId, toId);
   if (!names) return [];
   return names.map((stationName) => ({ stationName, line, kind: 'intermediate' as const }));
+}
+
+function buildDirect(route: DirectRoute, ctx: Context): AlarmWaypoint[] {
+  const destStation = findStationByNameAndLine(ctx.destinationName, route.line);
+  const intermediates = intermediateWaypoints(
+    ctx,
+    route.line,
+    ctx.currentStation?.id,
+    destStation?.id,
+  );
+  return [
+    ...intermediates,
+    { stationName: ctx.destinationName, line: route.line, kind: 'destination' },
+  ];
+}
+
+function buildTransfer(route: TransferRoute, ctx: Context): AlarmWaypoint[] {
+  // 환승역 == 목적지 → fromLine으로 도착 처리.
+  if (isSameStationName(route.transferName, ctx.destinationName)) {
+    const destFromLine = findStationByNameAndLine(route.transferName, route.fromLine);
+    const intermediates = intermediateWaypoints(
+      ctx,
+      route.fromLine,
+      ctx.currentStation?.id,
+      destFromLine?.id,
+    );
+    return [
+      ...intermediates,
+      { stationName: ctx.destinationName, line: route.fromLine, kind: 'destination' },
+    ];
+  }
+  const transferFromLine = findStationByNameAndLine(route.transferName, route.fromLine);
+  const transferToLine = findStationByNameAndLine(route.transferName, route.toLine);
+  const destToLine = findStationByNameAndLine(ctx.destinationName, route.toLine);
+  return [
+    ...intermediateWaypoints(ctx, route.fromLine, ctx.currentStation?.id, transferFromLine?.id),
+    { stationName: route.transferName, line: route.fromLine, kind: 'transfer' },
+    ...intermediateWaypoints(ctx, route.toLine, transferToLine?.id, destToLine?.id),
+    { stationName: ctx.destinationName, line: route.toLine, kind: 'destination' },
+  ];
+}
+
+function buildMultiTransfer(route: MultiTransferRoute, ctx: Context): AlarmWaypoint[] {
+  // segment마다 진행하며 각 사이의 intermediate를 펼친다.
+  // segment.transferName === destinationName이면 그 segment에서 destination 마킹 후 조기 return.
+  const result: AlarmWaypoint[] = [];
+  let segmentStart: Station | undefined = ctx.currentStation ?? undefined;
+
+  for (const seg of route.transfers) {
+    const isDestination = isSameStationName(seg.transferName, ctx.destinationName);
+    const transferFromLine = findStationByNameAndLine(seg.transferName, seg.fromLine);
+    result.push(
+      ...intermediateWaypoints(ctx, seg.fromLine, segmentStart?.id, transferFromLine?.id),
+    );
+    result.push({
+      stationName: isDestination ? ctx.destinationName : seg.transferName,
+      line: seg.fromLine,
+      kind: isDestination ? 'destination' : 'transfer',
+    });
+    if (isDestination) return result;
+    segmentStart = findStationByNameAndLine(seg.transferName, seg.toLine);
+  }
+
+  const lastSegment = route.transfers[route.transfers.length - 1];
+  const destToLine = findStationByNameAndLine(ctx.destinationName, lastSegment.toLine);
+  result.push(
+    ...intermediateWaypoints(ctx, lastSegment.toLine, segmentStart?.id, destToLine?.id),
+  );
+  result.push({
+    stationName: ctx.destinationName,
+    line: lastSegment.toLine,
+    kind: 'destination',
+  });
+  return result;
 }
 
 export function routeToWaypoints(
@@ -36,79 +116,12 @@ export function routeToWaypoints(
   currentStation: Station | null = null,
 ): AlarmWaypoint[] {
   // currentStation이 없으면 legacy 동작(transfer/destination만) — 하위 호환.
-  const enabled = currentStation !== null;
-  if (route.type === 'direct') {
-    const destStation = findStationByNameAndLine(destinationName, route.line);
-    const intermediates = intermediateWaypoints(enabled, route.line, currentStation?.id, destStation?.id);
-    return [
-      ...intermediates,
-      { stationName: destinationName, line: route.line, kind: 'destination' },
-    ];
-  }
-
-  if (route.type === 'transfer') {
-    if (isSameStationName(route.transferName, destinationName)) {
-      const destFromLine = findStationByNameAndLine(route.transferName, route.fromLine);
-      const intermediates = intermediateWaypoints(
-        enabled,
-        route.fromLine,
-        currentStation?.id,
-        destFromLine?.id,
-      );
-      return [
-        ...intermediates,
-        { stationName: destinationName, line: route.fromLine, kind: 'destination' },
-      ];
-    }
-    const transferFromLine = findStationByNameAndLine(route.transferName, route.fromLine);
-    const transferToLine = findStationByNameAndLine(route.transferName, route.toLine);
-    const destToLine = findStationByNameAndLine(destinationName, route.toLine);
-    const preIntermediates = intermediateWaypoints(
-      enabled,
-      route.fromLine,
-      currentStation?.id,
-      transferFromLine?.id,
-    );
-    const postIntermediates = intermediateWaypoints(
-      enabled,
-      route.toLine,
-      transferToLine?.id,
-      destToLine?.id,
-    );
-    return [
-      ...preIntermediates,
-      { stationName: route.transferName, line: route.fromLine, kind: 'transfer' },
-      ...postIntermediates,
-      { stationName: destinationName, line: route.toLine, kind: 'destination' },
-    ];
-  }
-
-  // multi-transfer: segment마다 진행하며 각 사이의 intermediate를 펼친다.
-  // segment의 transferName이 destinationName과 같으면 그 segment에서 destination으로 마킹 후 조기 return —
-  // 이후 segment는 의미가 없으므로 (도착했으니 환승할 일도, post-intermediate도 없다).
-  const result: AlarmWaypoint[] = [];
-  let segmentStartStation: Station | undefined = currentStation ?? undefined;
-
-  for (const seg of route.transfers) {
-    const isDestination = isSameStationName(seg.transferName, destinationName);
-    const transferFromLine = findStationByNameAndLine(seg.transferName, seg.fromLine);
-    result.push(
-      ...intermediateWaypoints(enabled, seg.fromLine, segmentStartStation?.id, transferFromLine?.id),
-    );
-    result.push({
-      stationName: isDestination ? destinationName : seg.transferName,
-      line: seg.fromLine,
-      kind: isDestination ? 'destination' : 'transfer',
-    });
-    if (isDestination) return result;
-    segmentStartStation = findStationByNameAndLine(seg.transferName, seg.toLine);
-  }
-
-  const lastSegment = route.transfers[route.transfers.length - 1];
-  const destToLine = findStationByNameAndLine(destinationName, lastSegment.toLine);
-  result.push(
-    ...intermediateWaypoints(enabled, lastSegment.toLine, segmentStartStation?.id, destToLine?.id),
-  );
-  result.push({ stationName: destinationName, line: lastSegment.toLine, kind: 'destination' });
-  return result;
+  const ctx: Context = {
+    destinationName,
+    currentStation,
+    enabled: currentStation !== null,
+  };
+  if (route.type === 'direct') return buildDirect(route, ctx);
+  if (route.type === 'transfer') return buildTransfer(route, ctx);
+  return buildMultiTransfer(route, ctx);
 }

--- a/src/utils/routeWaypoints.ts
+++ b/src/utils/routeWaypoints.ts
@@ -24,6 +24,14 @@ interface Context {
   enabled: boolean;
 }
 
+function makeWaypoint(
+  stationName: string,
+  line: LineNumber,
+  kind: AlarmWaypoint['kind'],
+): AlarmWaypoint {
+  return { stationName, line, kind };
+}
+
 function intermediateWaypoints(
   ctx: Context,
   line: LineNumber,
@@ -33,7 +41,7 @@ function intermediateWaypoints(
   if (!ctx.enabled || !fromId || !toId) return [];
   const names = getIntermediateStationNames(fromId, toId);
   if (!names) return [];
-  return names.map((stationName) => ({ stationName, line, kind: 'intermediate' as const }));
+  return names.map((stationName) => makeWaypoint(stationName, line, 'intermediate'));
 }
 
 function buildDirect(route: DirectRoute, ctx: Context): AlarmWaypoint[] {
@@ -44,10 +52,7 @@ function buildDirect(route: DirectRoute, ctx: Context): AlarmWaypoint[] {
     ctx.currentStation?.id,
     destStation?.id,
   );
-  return [
-    ...intermediates,
-    { stationName: ctx.destinationName, line: route.line, kind: 'destination' },
-  ];
+  return [...intermediates, makeWaypoint(ctx.destinationName, route.line, 'destination')];
 }
 
 function buildTransfer(route: TransferRoute, ctx: Context): AlarmWaypoint[] {
@@ -60,19 +65,16 @@ function buildTransfer(route: TransferRoute, ctx: Context): AlarmWaypoint[] {
       ctx.currentStation?.id,
       destFromLine?.id,
     );
-    return [
-      ...intermediates,
-      { stationName: ctx.destinationName, line: route.fromLine, kind: 'destination' },
-    ];
+    return [...intermediates, makeWaypoint(ctx.destinationName, route.fromLine, 'destination')];
   }
   const transferFromLine = findStationByNameAndLine(route.transferName, route.fromLine);
   const transferToLine = findStationByNameAndLine(route.transferName, route.toLine);
   const destToLine = findStationByNameAndLine(ctx.destinationName, route.toLine);
   return [
     ...intermediateWaypoints(ctx, route.fromLine, ctx.currentStation?.id, transferFromLine?.id),
-    { stationName: route.transferName, line: route.fromLine, kind: 'transfer' },
+    makeWaypoint(route.transferName, route.fromLine, 'transfer'),
     ...intermediateWaypoints(ctx, route.toLine, transferToLine?.id, destToLine?.id),
-    { stationName: ctx.destinationName, line: route.toLine, kind: 'destination' },
+    makeWaypoint(ctx.destinationName, route.toLine, 'destination'),
   ];
 }
 
@@ -88,11 +90,13 @@ function buildMultiTransfer(route: MultiTransferRoute, ctx: Context): AlarmWaypo
     result.push(
       ...intermediateWaypoints(ctx, seg.fromLine, segmentStart?.id, transferFromLine?.id),
     );
-    result.push({
-      stationName: isDestination ? ctx.destinationName : seg.transferName,
-      line: seg.fromLine,
-      kind: isDestination ? 'destination' : 'transfer',
-    });
+    result.push(
+      makeWaypoint(
+        isDestination ? ctx.destinationName : seg.transferName,
+        seg.fromLine,
+        isDestination ? 'destination' : 'transfer',
+      ),
+    );
     if (isDestination) return result;
     segmentStart = findStationByNameAndLine(seg.transferName, seg.toLine);
   }
@@ -102,11 +106,7 @@ function buildMultiTransfer(route: MultiTransferRoute, ctx: Context): AlarmWaypo
   result.push(
     ...intermediateWaypoints(ctx, lastSegment.toLine, segmentStart?.id, destToLine?.id),
   );
-  result.push({
-    stationName: ctx.destinationName,
-    line: lastSegment.toLine,
-    kind: 'destination',
-  });
+  result.push(makeWaypoint(ctx.destinationName, lastSegment.toLine, 'destination'));
   return result;
 }
 

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -284,6 +284,32 @@ export function getRemainingStops(
   return Math.abs(destIdx - currentIdx);
 }
 
+// 같은 노선 위 두 역 사이의 중간역 이름 배열을 진행 방향대로 반환.
+// 양 끝점은 제외. 인접 역 또는 같은 역이면 빈 배열. 다른 노선/미존재 id면 null.
+export function getIntermediateStationNames(
+  fromId: string,
+  toId: string,
+): string[] | null {
+  const from = stationById.get(fromId);
+  const to = stationById.get(toId);
+  if (!from || !to) return null;
+  if (from.line !== to.line) return null;
+
+  const lineStations = getLineStationsCached(from.line);
+  const fromIdx = lineStations.findIndex((s) => s.id === fromId);
+  const toIdx = lineStations.findIndex((s) => s.id === toId);
+  /* istanbul ignore next -- stationById에 존재하면 같은 line의 lineStations에도 존재한다는 invariant */
+  if (fromIdx === -1 || toIdx === -1) return null;
+  if (fromIdx === toIdx) return [];
+
+  const step = fromIdx < toIdx ? 1 : -1;
+  const names: string[] = [];
+  for (let i = fromIdx + step; i !== toIdx; i += step) {
+    names.push(lineStations[i].name);
+  }
+  return names;
+}
+
 function buildNameIndex(stations: Station[]): Map<string, number> {
   const index = new Map<string, number>();
   for (let i = 0; i < stations.length; i++) {


### PR DESCRIPTION
## Summary

BG/잠금 상태에서 중간역 통과 알림이 발화되지 않던 문제를 silent push 단일 경로로 통합 해결.

- `routeToWaypoints(route, destinationName, currentStation)` — 출발/환승/도착 사이 모든 중간역을 `kind: 'intermediate'` waypoint로 펼침
- 백엔드 `scheduled.ts` — intermediate는 early phase 스킵, imminent에서만 push + 즉시 `waypoints.shift()`
- 클라 `silentPushTask` — `kind=intermediate + phase=imminent` 수신 시 i18next로 즉시 OS 알림 발사, reschedule 병행
- silent push payload에 `kind` 필드 추가 (백엔드 필수 / 클라 optional, 하위 호환)
- 진단 카운터 — 백엔드 push 발사 + 클라 수신 시점 구조화 로그 (silent push baseline 동시 측정)

## 설계 결정 — 옵션 A 정공법

옵션 B(클라 사전 예약 재활용)는 `#411`(stopgap 제거)과 정면 충돌 + 환승 imminent push 수신 전 첫 N개 중간역 누락 위험. 옵션 C(백엔드 payload K역 정보)도 진실 출처가 분산.

옵션 A(waypoints 확장)는 단일 진실 출처(백엔드), `#411` stopgap 제거 가능 경로, FG-only stationPassed effect를 silent push fallback으로 정리 가능. Seoul API 한도 해제로 비용 우려도 해소.

Route 타입은 건드리지 않고 `routeToWaypoints` 시그니처에 `currentStation`만 추가해 변경 범위를 최소화.

## 알려진 한계 (follow-up)

- `currentStation` 변경 시 `registerActiveTrip` 재호출 → 백엔드 trip 진행 상태(waypoints shift, lastFiredPhase) reset 가능. 실기기 검증 결과 보고 멱등성 처리 위치 결정. `useApnsTripRegistration.ts`에 TODO 주석 명시.
- 순환 노선(2호선) 중간역 추출은 기존 `getRemainingStops`와 동일한 단순 인덱스 방향 사용 — 별도 ADR/리팩 작업 필요. 본 PR 범위 외.
- `currentStation`의 line이 route와 불일치하면 intermediates 빈 배열로 silent fallback (테스트로 동작 보장).

## 검증

- 클라 `npm test`: **1486/1486 passed**, 커버리지 100%
- 클라 `npm run type-check`: pass
- 백엔드 `npm test` (vitest): **78/78 passed**
- 백엔드 `npm run type-check`: pass
- code-reviewer 에이전트: Critical 0, Warning 5 (i18n 정합성 / multi-transfer 주석 처리 완료, 나머지는 본 PR 범위 외 / 한계 명시)

## Test plan

- [x] CI `Type Check & Test` 통과 확인
- [x] CI `E2E Smoke` 통과 확인 (UI 영향 경로 변경됨)
- [x] 실기기 검증: 용마산→성수 같은 환승 경로에서 BG/잠금 상태로 중간역 통과 알림 발화 (이슈 본문의 4개 중간역)
- [x] 환승/하차/도착 임박 4건 회귀 없음 확인
- [ ] silent push 진단 로그(Worker logs + 클라 logger)에서 intermediate 발사/수신 카운트 일치 확인 → silent push baseline 데이터 수집

Closes #416
Refs #411 (stopgap 제거 후속), #410 (실기기 회귀 검증)