### PR TITLE
chore(#443): fusion source 결정 추적 로그 + DEV 뱃지 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -76,7 +76,7 @@ export default function HomeScreen() {
     () => (route && tripOrigin && destination ? { route, origin: tripOrigin, destination } : undefined),
     [route, tripOrigin, destination],
   );
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence } = useFusedNearestStation(undefined, undefined, routeContext);
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext);
   // AppState listener는 단일-바인딩 패턴이라 deps에 refresh를 추가할 수 없다.
   // 최신 refresh 함수를 ref에 보관해 listener에서 호출한다.
   const refreshRef = useRef(refresh);
@@ -348,6 +348,17 @@ export default function HomeScreen() {
                     <Dot />
                     <Text style={[typography.bodySm, { color: colors.muted }]}>
                       {nearest.walkMin} min walk
+                    </Text>
+                  </>
+                )}
+                {__DEV__ && (
+                  <>
+                    <Dot />
+                    <Text
+                      style={[typography.bodySm, { color: colors.warn, fontWeight: '700' }]}
+                      testID="home-fusion-source-badge"
+                    >
+                      {source}·{confidence}
                     </Text>
                   </>
                 )}

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -14,6 +14,12 @@ import { useAppStore } from '../store/useAppStore';
 import { useFusedNearestStation } from '../hooks/useFusedNearestStation';
 import { useArrivalInfo } from '../hooks/useArrivalInfo';
 import { clearAlarmLog, getAlarmLog, type AlarmLogEntry } from '../utils/alarmLog';
+import {
+  clearFusionDebugEntries,
+  getFusionDebugEntries,
+  subscribeFusionDebug,
+  type FusionDebugEntry,
+} from '../utils/fusionDebugBuffer';
 import type { FusionConfidence, FusionSource } from '../utils/pickFusedStation';
 import type { NearestStationResult } from '../types/station';
 import { useTheme, spacing, radius, typography } from '../theme';
@@ -47,6 +53,36 @@ function formatLogLine(entry: AlarmLogEntry): string {
   if (entry.expectedStationAtFire) parts.push(`exp=${entry.expectedStationAtFire}`);
   if (entry.actualLastNotifiedStation) parts.push(`last=${entry.actualLastNotifiedStation}`);
   return parts.join(' | ');
+}
+
+/** candidates key → 짧은 접두어. 새 key가 늘면 여기 한 줄만 추가하면 됨. */
+const CANDIDATE_SHORT: Record<string, string> = {
+  positionTrain: 'pt',
+  fused: 'fu',
+  route: 'rt',
+  gps: 'gp',
+};
+
+function formatFusionDebugLine(entry: FusionDebugEntry): string {
+  const time = formatTime(entry.ts);
+  if (entry.kind === 'gps') {
+    const station = entry.nearestStation
+      ? `${entry.nearestStation}(${entry.nearestLine ?? '-'})`
+      : '-';
+    const d = entry.nearestDistanceKm != null ? `${Math.round(entry.nearestDistanceKm * 1000)}m` : '-';
+    const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
+    const reason = entry.dropReason ? ` reason=${entry.dropReason}` : '';
+    return `${time} | ${entry.event} | ${station} d=${d} acc=${acc}${reason}`;
+  }
+  const station = entry.stationName ? `${entry.stationName}(${entry.line ?? '-'})` : '-';
+  const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
+  const acc =
+    entry.gpsAccuracyAtPushMeters != null ? `${Math.round(entry.gpsAccuracyAtPushMeters)}m` : '-';
+  const cand = entry.candidates
+    .map((c) => `${CANDIDATE_SHORT[c.key] ?? c.key}=${c.stationName}`)
+    .join(' ');
+  const candPart = cand.length > 0 ? cand : '-';
+  return `${time} | src=${entry.source} conf=${entry.confidence} | ${station} d=${d} acc=${acc} | ${candPart}`;
 }
 
 function formatStationLabel(res: NearestStationResult | null): string {
@@ -160,6 +196,13 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
   const gpsLabel = formatStationLabel(gpsResult);
   const differs = fusedDiffersFromGps(result, gpsResult);
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
+  const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
+    getFusionDebugEntries(),
+  );
+
+  useEffect(() => {
+    return subscribeFusionDebug(() => setFusionLogs([...getFusionDebugEntries()]));
+  }, []);
 
   const refreshLogs = useCallback(async () => {
     setLogs(await getAlarmLog());
@@ -328,6 +371,37 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
           </Section>
 
           <Section
+            title={`Fusion log (${fusionLogs.length})`}
+            colors={colors}
+            action={
+              <Pressable
+                onPress={() => {
+                  clearFusionDebugEntries();
+                  setFusionLogs([]);
+                }}
+                testID="debug-fusion-log-clear"
+              >
+                <Text style={[typography.bodySm, { color: colors.accent }]}>Clear</Text>
+              </Pressable>
+            }
+          >
+            {fusionLogs.length === 0 ? (
+              <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
+            ) : (
+              [...fusionLogs].reverse().map((entry, idx) => (
+                <Text
+                  key={`${entry.ts}-${idx}`}
+                  style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
+                  selectable
+                  testID="debug-fusion-log-entry"
+                >
+                  {formatFusionDebugLine(entry)}
+                </Text>
+              ))
+            )}
+          </Section>
+
+          <Section
             title={`Alarm log (${logs.length})`}
             colors={colors}
             action={
@@ -412,7 +486,7 @@ function KeyValue({
 }
 
 // Internal exports for tests — DO NOT use from app code.
-export const __test__ = { formatLogLine, buildDumpText };
+export const __test__ = { formatLogLine, buildDumpText, formatFusionDebugLine };
 
 const styles = StyleSheet.create({
   container: { flex: 1 },

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -188,7 +188,8 @@ describe('DebugModal', () => {
   it('알람 로그 비어있으면 (empty) 표시', async () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-    expect(screen.getByText('(empty)')).toBeTruthy();
+    // Fusion log + Alarm log 두 섹션이 비어있을 때 (empty)가 둘.
+    expect(screen.getAllByText('(empty)').length).toBeGreaterThanOrEqual(1);
   });
 
   it('Refresh 버튼이 로그를 다시 불러온다', async () => {
@@ -593,5 +594,213 @@ describe('DebugModal share with null nearest', () => {
     expect(shareSpy).toHaveBeenCalled();
     expect(shareSpy.mock.calls[0][0].message).toContain('(no nearest station)');
     shareSpy.mockRestore();
+  });
+});
+
+describe('DebugModal fusion log section', () => {
+  const { pushFusionDebugEntry, clearFusionDebugEntries } =
+    jest.requireActual('../../utils/fusionDebugBuffer');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearFusionDebugEntries();
+    setupHookDefaults();
+  });
+
+  it('비어있으면 (empty) 표시, 엔트리 push 시 라인을 노출한다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Fusion log (0)')).toBeTruthy();
+    act(() => {
+      pushFusionDebugEntry({
+        kind: 'fusion',
+        ts: new Date('2026-05-20T14:30:00Z').getTime(),
+        source: 'position-train',
+        confidence: 'position-train',
+        stationName: '사가정',
+        line: '7',
+        distanceKm: 0.817,
+        gpsAccuracyAtPushMeters: 25,
+        candidates: [
+          { key: 'positionTrain', stationName: '사가정', line: '7' },
+          { key: 'gps', stationName: '용마산', line: '7', extra: { distanceKm: 0.04 } },
+        ],
+      });
+    });
+    expect(screen.getByText('Fusion log (1)')).toBeTruthy();
+    const entries = screen.getAllByTestId('debug-fusion-log-entry');
+    expect(entries[0].props.children).toContain('src=position-train');
+    expect(entries[0].props.children).toContain('pt=사가정');
+    expect(entries[0].props.children).toContain('gp=용마산');
+  });
+
+  it('Clear 버튼이 fusion 로그를 비운다', async () => {
+    pushFusionDebugEntry({
+      kind: 'gps',
+      event: 'gps-fix',
+      ts: Date.now(),
+      lat: 37.5,
+      lng: 127.0,
+      accuracyMeters: 20,
+      speedMps: 0,
+      nearestStation: '용마산',
+      nearestLine: '7',
+      nearestDistanceKm: 0.05,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(screen.getByText('Fusion log (1)')).toBeTruthy());
+    act(() => {
+      fireEvent.press(screen.getByTestId('debug-fusion-log-clear'));
+    });
+    expect(screen.getByText('Fusion log (0)')).toBeTruthy();
+  });
+});
+
+describe('formatFusionDebugLine', () => {
+  const { formatFusionDebugLine } = __test__;
+
+  it('gps-fix 엔트리: station/distance/accuracy 포함', () => {
+    const line = formatFusionDebugLine({
+      kind: 'gps',
+      event: 'gps-fix',
+      ts: new Date('2026-05-20T14:30:00Z').getTime(),
+      lat: 37.5,
+      lng: 127.0,
+      accuracyMeters: 25,
+      speedMps: 0,
+      nearestStation: '용마산',
+      nearestLine: '7',
+      nearestDistanceKm: 0.04,
+    });
+    expect(line).toContain('gps-fix');
+    expect(line).toContain('용마산(7)');
+    expect(line).toContain('d=40m');
+    expect(line).toContain('acc=25m');
+    expect(line).not.toContain('reason=');
+  });
+
+  it('gps-drop 엔트리: 이벤트와 reason 표기', () => {
+    const line = formatFusionDebugLine({
+      kind: 'gps',
+      event: 'gps-drop',
+      ts: 0,
+      lat: 0,
+      lng: 0,
+      accuracyMeters: 1500,
+      speedMps: null,
+      nearestStation: null,
+      nearestLine: null,
+      nearestDistanceKm: null,
+      dropReason: 'low-accuracy-display',
+    });
+    expect(line).toContain('gps-drop');
+    expect(line).toContain('reason=low-accuracy-display');
+  });
+
+  it('gps 엔트리: nearestStation/distance/accuracy 누락 시 "-" 표기', () => {
+    const line = formatFusionDebugLine({
+      kind: 'gps',
+      event: 'gps-fix',
+      ts: 0,
+      lat: 0,
+      lng: 0,
+      accuracyMeters: null,
+      speedMps: null,
+      nearestStation: null,
+      nearestLine: null,
+      nearestDistanceKm: null,
+    });
+    expect(line).toContain('| - d=- acc=-');
+  });
+
+  it('fusion 엔트리: source/conf/station/cands 포함', () => {
+    const line = formatFusionDebugLine({
+      kind: 'fusion',
+      ts: 0,
+      source: 'gps',
+      confidence: 'gps-only',
+      stationName: '용마산',
+      line: '7',
+      distanceKm: 0.04,
+      gpsAccuracyAtPushMeters: 30,
+      candidates: [
+        { key: 'fused', stationName: '사가정', line: '7', extra: { source: 'arrival' } },
+        { key: 'route', stationName: '건대입구', line: '7' },
+        { key: 'gps', stationName: '용마산', line: '7', extra: { distanceKm: 0.04 } },
+      ],
+    });
+    expect(line).toContain('src=gps conf=gps-only');
+    expect(line).toContain('용마산(7)');
+    expect(line).toContain('fu=사가정');
+    expect(line).toContain('rt=건대입구');
+    expect(line).toContain('gp=용마산');
+  });
+
+  it('fusion 엔트리: 알 수 없는 candidate key는 raw key 그대로 표기', () => {
+    const line = formatFusionDebugLine({
+      kind: 'fusion',
+      ts: 0,
+      source: 'gps',
+      confidence: 'gps-only',
+      stationName: '용마산',
+      line: '7',
+      distanceKm: 0.04,
+      gpsAccuracyAtPushMeters: 30,
+      // @ts-expect-error — 미래 신호 추가를 가정한 unknown key
+      candidates: [{ key: 'future', stationName: 'X', line: '?' }],
+    });
+    expect(line).toContain('future=X');
+  });
+
+  it('gps 엔트리: nearestStation 있고 nearestLine 없으면 "-" 표기', () => {
+    const line = formatFusionDebugLine({
+      kind: 'gps',
+      event: 'gps-fix',
+      ts: 0,
+      lat: 0,
+      lng: 0,
+      accuracyMeters: 30,
+      speedMps: null,
+      nearestStation: '용마산',
+      nearestLine: null,
+      nearestDistanceKm: 0.04,
+    });
+    expect(line).toContain('용마산(-)');
+  });
+
+  it('fusion 엔트리: stationName 있고 line 없으면 "-" 표기', () => {
+    const line = formatFusionDebugLine({
+      kind: 'fusion',
+      ts: 0,
+      source: 'gps',
+      confidence: 'gps-only',
+      stationName: '용마산',
+      line: null,
+      distanceKm: 0.04,
+      gpsAccuracyAtPushMeters: 30,
+      candidates: [],
+    });
+    expect(line).toContain('용마산(-)');
+  });
+
+  it('fusion 엔트리: candidates 빈 배열이면 "-" placeholder, 다른 필드 null이면 "-"만', () => {
+    const line = formatFusionDebugLine({
+      kind: 'fusion',
+      ts: 0,
+      source: 'gps',
+      confidence: 'gps-only',
+      stationName: null,
+      line: null,
+      distanceKm: null,
+      gpsAccuracyAtPushMeters: null,
+      candidates: [],
+    });
+    expect(line).toContain('- d=- acc=-');
+    // 의미 단위: 후보 섹션은 "-" placeholder, 후보 접두어는 없음.
+    expect(line).toContain('| -');
+    expect(line).not.toContain('pt=');
+    expect(line).not.toContain('fu=');
+    expect(line).not.toContain('rt=');
+    expect(line).not.toContain('gp=');
   });
 });

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -562,6 +562,29 @@ describe('useNearestStation', () => {
     expect(result.current.locationUncertain).toBe(true);
   });
 
+  it('표시 게이트 drop 시 fusion debug buffer에 gps-drop 엔트리를 push (speed 양수 분기)', async () => {
+    const { pushFusionDebugEntry: _p, clearFusionDebugEntries, getFusionDebugEntries } =
+      jest.requireActual('../../utils/fusionDebugBuffer');
+    void _p;
+    clearFusionDebugEntries();
+    mockGranted();
+    renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.4980, 127.0277, {
+      accuracy: MAX_ACCURACY_M_DISPLAY + 1,
+      speed: 1.5,
+    });
+
+    const entries = getFusionDebugEntries();
+    const drop = entries.find(
+      (e: { kind: string; event?: string }) => e.kind === 'gps' && e.event === 'gps-drop',
+    );
+    expect(drop).toBeDefined();
+    expect(drop.speedMps).toBe(1.5);
+    expect(drop.dropReason).toBe('low-accuracy-display');
+  });
+
   it('uncertain 상태에서 정확한 좌표가 들어오면 locationUncertain=false로 복귀한다', async () => {
     mockGranted();
 

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -1,4 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
+import {
+  pushFusionDebugEntry,
+  type FusionCandidateMini,
+} from '../utils/fusionDebugBuffer';
 import { useNearestStation } from './useNearestStation';
 import { useArrivalInfo } from './useArrivalInfo';
 import { useTrainPositions } from './useTrainPositions';
@@ -221,6 +225,49 @@ export function useFusedNearestStation(
     confidence = 'gps-only';
     source = 'gps';
   }
+
+  // 측정(#443): 결정 변화(source/stationId/confidence) 시에만 push.
+  // render 중 side-effect 회피 + 의존성 누락 은폐 회피를 위해 결정 key를 ref로 비교.
+  const lastDecisionKeyRef = useRef<string | null>(null);
+  const resultStationId = result?.station.id ?? null;
+  const decisionKey = `${source}|${confidence}|${resultStationId}`;
+  useEffect(() => {
+    if (lastDecisionKeyRef.current === decisionKey) return;
+    lastDecisionKeyRef.current = decisionKey;
+    const candidates: FusionCandidateMini[] = [];
+    if (positionTrainResult) {
+      const { name, line } = positionTrainResult.station;
+      candidates.push({ key: 'positionTrain', stationName: name, line });
+    }
+    if (fused) {
+      const { name, line } = fused.result.station;
+      candidates.push({ key: 'fused', stationName: name, line, extra: { source: fused.source } });
+    }
+    if (routeResult) {
+      const { name, line } = routeResult.station;
+      candidates.push({ key: 'route', stationName: name, line });
+    }
+    if (gps.result) {
+      const { name, line } = gps.result.station;
+      candidates.push({
+        key: 'gps',
+        stationName: name,
+        line,
+        extra: { distanceKm: gps.result.distanceKm },
+      });
+    }
+    pushFusionDebugEntry({
+      kind: 'fusion',
+      ts: Date.now(),
+      source,
+      confidence,
+      stationName: result?.station.name ?? null,
+      line: result?.station.line ?? null,
+      distanceKm: result?.distanceKm ?? null,
+      gpsAccuracyAtPushMeters: gps.accuracyMeters,
+      candidates,
+    });
+  }, [decisionKey, source, confidence, result, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters]);
 
   return {
     result,

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -7,6 +7,7 @@ import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh }
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../constants/e2e';
 import { createLogger } from '../utils/logger';
+import { pushFusionDebugEntry } from '../utils/fusionDebugBuffer';
 
 const logger = createLogger('useNearestStation');
 
@@ -86,6 +87,22 @@ export function useNearestStation(): UseNearestStationReturn {
       lastDistanceRef.current = newDistance;
       applyNearestResult(stationsResult, setResult, setVariants);
     }
+    // 측정(#443): station 변화 시에만 push. 매 fix는 너무 자주 — 점프 시퀀스
+    // (사가정→을지로4가→용마산) 재구성엔 station 단위면 충분.
+    if (stationChanged || noStation) {
+      pushFusionDebugEntry({
+        kind: 'gps',
+        event: 'gps-fix',
+        ts: Date.now(),
+        lat: latitude,
+        lng: longitude,
+        accuracyMeters: accuracy ?? null,
+        speedMps: speed != null && speed >= 0 ? speed : null,
+        nearestStation: stationsResult?.primary.name ?? null,
+        nearestLine: stationsResult?.primary.line ?? null,
+        nearestDistanceKm: stationsResult?.distanceKm ?? null,
+      });
+    }
   }, []);
 
   const stopWatch = useCallback(() => {
@@ -161,6 +178,22 @@ export function useNearestStation(): UseNearestStationReturn {
         (location) => {
           if (!isAccuracyAcceptableForDisplay(location.coords.accuracy)) {
             setLocationUncertain(true);
+            // #443: 표시 게이트에 drop된 fix도 사후 진단에 필요(사가정 같은 부정확 fix로
+            // 락된 의심 시점을 식별). 이 분기는 accuracy가 non-null 임계 초과인 경우만.
+            const dropSpeed = location.coords.speed;
+            pushFusionDebugEntry({
+              kind: 'gps',
+              event: 'gps-drop',
+              ts: Date.now(),
+              lat: location.coords.latitude,
+              lng: location.coords.longitude,
+              accuracyMeters: location.coords.accuracy,
+              speedMps: dropSpeed != null && dropSpeed >= 0 ? dropSpeed : null,
+              nearestStation: null,
+              nearestLine: null,
+              nearestDistanceKm: null,
+              dropReason: 'low-accuracy-display',
+            });
             return;
           }
           setLocationUncertain(false);

--- a/src/utils/__tests__/fusionDebugBuffer.test.ts
+++ b/src/utils/__tests__/fusionDebugBuffer.test.ts
@@ -1,0 +1,107 @@
+import {
+  FUSION_DEBUG_BUFFER_CAPACITY,
+  clearFusionDebugEntries,
+  getFusionDebugEntries,
+  pushFusionDebugEntry,
+  subscribeFusionDebug,
+  type FusionDebugEntry,
+} from '../fusionDebugBuffer';
+
+function makeFusionEntry(overrides: Partial<FusionDebugEntry> = {}): FusionDebugEntry {
+  return {
+    kind: 'fusion',
+    ts: Date.now(),
+    source: 'gps',
+    confidence: 'gps-only',
+    stationName: '용마산',
+    line: '7',
+    distanceKm: 0.05,
+    gpsAccuracyAtPushMeters: 30,
+    candidates: [],
+    ...(overrides as object),
+  } as FusionDebugEntry;
+}
+
+describe('fusionDebugBuffer', () => {
+  beforeEach(() => {
+    clearFusionDebugEntries();
+  });
+
+  it('pushes and reads entries in order', () => {
+    pushFusionDebugEntry(makeFusionEntry({ stationName: 'A' }));
+    pushFusionDebugEntry(makeFusionEntry({ stationName: 'B' }));
+    const entries = getFusionDebugEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].kind).toBe('fusion');
+    expect((entries[0] as { stationName: string }).stationName).toBe('A');
+  });
+
+  it('caps at capacity, dropping oldest', () => {
+    for (let i = 0; i < FUSION_DEBUG_BUFFER_CAPACITY + 5; i++) {
+      pushFusionDebugEntry(makeFusionEntry({ stationName: `S${i}` }));
+    }
+    const entries = getFusionDebugEntries();
+    expect(entries).toHaveLength(FUSION_DEBUG_BUFFER_CAPACITY);
+    expect((entries[0] as { stationName: string }).stationName).toBe('S5');
+  });
+
+  it('clears entries', () => {
+    pushFusionDebugEntry(makeFusionEntry());
+    clearFusionDebugEntries();
+    expect(getFusionDebugEntries()).toHaveLength(0);
+  });
+
+  it('no-ops clear when already empty (no listener fire)', () => {
+    const listener = jest.fn();
+    const unsub = subscribeFusionDebug(listener);
+    clearFusionDebugEntries();
+    expect(listener).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it('notifies subscribers on push and clear, unsubscribe stops notifications', () => {
+    const listener = jest.fn();
+    const unsub = subscribeFusionDebug(listener);
+    pushFusionDebugEntry(makeFusionEntry());
+    expect(listener).toHaveBeenCalledTimes(1);
+    pushFusionDebugEntry(makeFusionEntry());
+    expect(listener).toHaveBeenCalledTimes(2);
+    clearFusionDebugEntries();
+    expect(listener).toHaveBeenCalledTimes(3);
+    unsub();
+    pushFusionDebugEntry(makeFusionEntry());
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it('accepts gps-fix and gps-drop entries', () => {
+    pushFusionDebugEntry({
+      kind: 'gps',
+      event: 'gps-fix',
+      ts: 1,
+      lat: 37.5,
+      lng: 127.0,
+      accuracyMeters: 20,
+      speedMps: 0,
+      nearestStation: '용마산',
+      nearestLine: '7',
+      nearestDistanceKm: 0.03,
+    });
+    pushFusionDebugEntry({
+      kind: 'gps',
+      event: 'gps-drop',
+      ts: 2,
+      lat: 37.5,
+      lng: 127.0,
+      accuracyMeters: 1500,
+      speedMps: null,
+      nearestStation: null,
+      nearestLine: null,
+      nearestDistanceKm: null,
+      dropReason: 'low-accuracy-display',
+    });
+    const entries = getFusionDebugEntries();
+    expect(entries).toHaveLength(2);
+    expect((entries[0] as { event: string }).event).toBe('gps-fix');
+    expect((entries[1] as { event: string }).event).toBe('gps-drop');
+  });
+});

--- a/src/utils/fusionDebugBuffer.ts
+++ b/src/utils/fusionDebugBuffer.ts
@@ -1,0 +1,86 @@
+import type { FusionConfidence, FusionSource } from './pickFusedStation';
+
+// 측정 인프라(#443): fusion 결정/GPS fix 이벤트를 in-memory ring buffer에 보관.
+// 외부 도구(Metro/Xcode) 없이 DebugModal에서 사후 재구성하기 위한 채널.
+// 콘솔 logger는 dev 빌드에서만 보이고 스탠드얼론 빌드/현장(지하철)에서는 확인 불가 —
+// 그 공백을 메우는 것이 목적.
+
+export const FUSION_DEBUG_BUFFER_CAPACITY = 200;
+
+/** 후보 신호 — 신호원이 늘면 key를 추가만 하면 됨(타입/포맷터 동시 수정 불필요). */
+export interface FusionCandidateMini {
+  key: 'positionTrain' | 'fused' | 'route' | 'gps';
+  stationName: string;
+  line: string;
+  /** 추가 정보 — 출처별 의미가 다를 수 있어 자유형으로 둠. */
+  extra?: Record<string, string | number>;
+}
+
+export interface FusionDecisionEntry {
+  kind: 'fusion';
+  ts: number;
+  source: FusionSource;
+  confidence: FusionConfidence;
+  stationName: string | null;
+  line: string | null;
+  distanceKm: number | null;
+  /** push 시점 GPS accuracy — 결정에 직접 쓰였는지와 무관. source가 gps가 아닐 때도
+   *  센서 컨디션 진단용으로 같이 본다. 이름에 출처(`gps`)와 시점(`AtPush`)을 박아 오독 방지. */
+  gpsAccuracyAtPushMeters: number | null;
+  /** 4개 우선순위 후보 raw — 왜 그 source가 선택됐는지 사후 재구성. */
+  candidates: FusionCandidateMini[];
+}
+
+export type GpsFixKind = 'gps-fix' | 'gps-drop';
+
+export interface GpsFixEntry {
+  kind: 'gps';
+  /** gps-fix: 표시 게이트 통과한 fix가 station 변화. gps-drop: 게이트가 거부. */
+  event: GpsFixKind;
+  ts: number;
+  lat: number;
+  lng: number;
+  accuracyMeters: number | null;
+  speedMps: number | null;
+  nearestStation: string | null;
+  nearestLine: string | null;
+  nearestDistanceKm: number | null;
+  /** drop 사유(있을 때만) — "low-accuracy" 등. */
+  dropReason?: string;
+}
+
+export type FusionDebugEntry = FusionDecisionEntry | GpsFixEntry;
+
+type Listener = () => void;
+
+const buffer: FusionDebugEntry[] = [];
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+export function pushFusionDebugEntry(entry: FusionDebugEntry): void {
+  buffer.push(entry);
+  if (buffer.length > FUSION_DEBUG_BUFFER_CAPACITY) {
+    buffer.splice(0, buffer.length - FUSION_DEBUG_BUFFER_CAPACITY);
+  }
+  emit();
+}
+
+export function getFusionDebugEntries(): readonly FusionDebugEntry[] {
+  return buffer;
+}
+
+export function clearFusionDebugEntries(): void {
+  if (buffer.length === 0) return;
+  buffer.length = 0;
+  emit();
+}
+
+export function subscribeFusionDebug(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
Closes #443

> 현재역 신뢰성 트랙 (1/6) — 진단 기반선 확보. 수정 로직 0줄, 관측만.

## Summary
- `src/utils/fusionDebugBuffer.ts` (신규): in-memory ring buffer(cap 200) + push/get/clear/subscribe. 외부 도구(Metro/Xcode) 없이 DebugModal에서 사후 재구성하기 위한 채널.
- `useFusedNearestStation`: 결정 변화(source/confidence/stationId) 시에만 push. candidates는 데이터 주도 배열(`Array<{key,stationName,line,extra?}>`)로 일반화 — 새 신호 추가 시 key만 추가.
- `useNearestStation`: station 변화 시 `gps-fix`, 표시 게이트(MAX_ACCURACY_M_DISPLAY) drop 시 `gps-drop` 엔트리(좌표/정확도/사유 포함) push.
- `DebugModal`: "Fusion log" 섹션 + Clear 버튼 + subscribe로 live 업데이트.
- `app/(tabs)/index.tsx`: `__DEV__` 가드로 source/confidence 작은 뱃지 표시.

## 설계 선택
- ring buffer 방식 — 콘솔 logger는 dev 빌드에서만 보이고 사고 현장(지하철)에선 확인 불가. DebugModal에서 폰만으로 확인 가능.
- 결정 키(`source|confidence|stationId`) ref 비교로 effect deps 누락 은폐 회피.
- candidates 배열화로 미래 신호 추가 시 타입/포맷터 다중 수정 불필요.

## 다음 단계
1단계로 이 PR 머지 → 실기기 재현 시 DebugModal에서 source 변천 캡처 → 원인 source 확정 → #444(거리 sanity gate)로 진행.

## Test plan
- [x] `src/utils/__tests__/fusionDebugBuffer.test.ts` — push/cap/clear/subscribe/no-op/gps-drop
- [x] `src/components/__tests__/DebugModal.test.tsx` — Fusion log 섹션/Clear/live/formatter 분기
- [x] `src/hooks/__tests__/useNearestStation.test.ts` — gps-drop 엔트리 push 검증
- [x] `npm test` 1486 passed, 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 실기기에서 DebugModal Fusion log 직접 확인 (머지 후)