### PR TITLE
fix(#445): positionTrainResult 거리/TTL sanity gate

### DIFF
--- a/src/constants/realtime.ts
+++ b/src/constants/realtime.ts
@@ -4,3 +4,14 @@
  * 슬롯이 고정된다. 한 곳에서만 변경하도록 단일 출처로 관리.
  */
 export const MAX_ACTIVE_LINES = 3;
+
+// #445 positionTrainResult sticky gate.
+// 인접역 평균 800m+ 대비 보수치. positionTrain이 잡은 역과 user GPS가 이보다 멀면
+// 사용자가 그 역에 가까이 있지 않다고 판단해 fusion을 다음 우선순위로 강등한다.
+export const MAX_POSITION_TRAIN_DISTANCE_KM = 0.6;
+// positionTrain 역과 GPS-nearest 역 거리 차이 margin. GPS 노이즈 흡수용.
+// `positionTrainDist > gpsNearestDist + DELTA`이면 GPS-nearest 쪽이 더 신뢰 가능.
+export const MAX_POSITION_TRAIN_DELTA_KM = 0.2;
+// trainProgress 신선도. 7호선 역간 평균 100~120s의 절반.
+// 이 시간 이상 갱신 없으면 sticky 락(lastConfirmedTrainNo) 자체를 해제한다.
+export const POSITION_TRAIN_TTL_MS = 60_000;

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -144,7 +144,9 @@ describe('useFusedNearestStation', () => {
   });
 
   it('position-train: 단일 후보 trainNo → trackTrainProgress 채택 (source=position-train)', () => {
-    mockUseNearest.mockReturnValue(gpsBase());
+    // MOCK_STATIONS 좌표가 (37.5,127.0)으로 동일하고 trackTrainProgress는 stations.json의
+    // 실좌표를 조회한다. #445 거리 게이트와 충돌을 피하려고 accuracy를 게이트 면제 영역으로.
+    mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
     mockFindTop.mockReturnValue([
       { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
       { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
@@ -184,7 +186,8 @@ describe('useFusedNearestStation', () => {
   });
 
   it('position-train 다중 후보: lastConfirmedTrainNo 우선(sticky) — 이전 결과 유지', () => {
-    mockUseNearest.mockReturnValue(gpsBase());
+    // #445 거리 게이트 우회 — MOCK 좌표와 stations.json 실좌표가 다르므로.
+    mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
     mockFindTop.mockReturnValue([
       { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
     ]);
@@ -240,6 +243,181 @@ describe('useFusedNearestStation', () => {
     expect(result.current.userLocation).toEqual({ lat: 37.5, lng: 127.0 });
     expect(result.current.speedMps).toBe(1);
     expect(result.current.accuracyMeters).toBe(50);
+  });
+
+  describe('#445 positionTrainResult 거리/TTL sanity gate', () => {
+    const yongmasan = findStationByNameAndLine('용마산', '7')!;
+    const sagajeong = findStationByNameAndLine('사가정', '7')!;
+
+    function setup용마산GpsSagajeongTrain(opts: { accuracyMeters: number | null }) {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          accuracyMeters: opts.accuracyMeters,
+          result: { station: yongmasan, distanceKm: 0 },
+        }),
+      );
+      // GPS-nearest = 용마산. fusion 후보는 용마산만 (단순화) — line=7.
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      // line=7 positions에 사가정에 도착한 단일 열차.
+      mockUsePositions
+        .mockReturnValueOnce(
+          positionRet({
+            line: '7',
+            trains: [train(sagajeong.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-사가정' })],
+          }),
+        )
+        .mockReturnValueOnce(positionRet(null))
+        .mockReturnValueOnce(positionRet(null));
+    }
+
+    it('재현된 사고: GPS=용마산(정확도 양호) + positionTrain=사가정(>0.6km) → fusion 강등', () => {
+      setup용마산GpsSagajeongTrain({ accuracyMeters: 7 });
+      const { result } = renderHook(() => useFusedNearestStation());
+      // positionTrainResult가 null로 강등되고 fusion 우선순위가 다음으로 떨어진다.
+      expect(result.current.source).not.toBe('position-train');
+      // arrival/route 없으니 결국 gps 폴백 → 용마산.
+      expect(result.current.result?.station.name).toBe('용마산');
+    });
+
+    it('정확도 양호 + 절대 거리 OK + GPS-nearest 다른 station: 상대 margin 초과면 강등', () => {
+      // 절대 거리는 0.6km 이내(통과)지만 GPS-nearest와 비교했을 때 margin 초과로 강등하는 경로 검증.
+      // trackTrainProgress가 findStationByNameAndLine(stations.json 실좌표)을 쓰므로,
+      // 실좌표에서 0.3~0.6km 범위 안 동일선상 두 역이 필요. 7호선 사가정/면목 사용 가정 어렵 →
+      // findStationByNameAndLine을 한 번만 가로채 합성 좌표를 돌려준다.
+      const fakeStation = {
+        id: 'SAGA-FAKE',
+        name: '사가정',
+        line: '7' as const,
+        lineColor: '#747F00',
+        // user(용마산)에서 약 0.4km 떨어진 합성 좌표.
+        lat: yongmasan.lat + 0.0036,
+        lng: yongmasan.lng,
+      };
+      const here = { ...yongmasan, id: 'YHERE' };
+      const stationRouteModule = jest.requireActual('../../utils/stationRoute');
+      const spy = jest
+        .spyOn(stationRouteModule, 'findStationByNameAndLine')
+        .mockImplementation((...args) => {
+          const [name, line] = args as [string, string];
+          if (name === '사가정' && line === '7') return fakeStation;
+          return null;
+        });
+
+      try {
+        mockUseNearest.mockReturnValue(
+          gpsBase({
+            userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+            accuracyMeters: 10,
+            result: { station: here, distanceKm: 0 },
+          }),
+        );
+        // GPS-nearest = here(거리 0). positionTrain station = fake사가정(~0.4km).
+        // 0.4 > 0 + 0.2 → 상대 margin 초과 → 강등(line 232 hit).
+        mockFindTop.mockReturnValue([{ station: here, distanceKm: 0 }]);
+        mockUseArrival.mockReturnValue(arrivalRet(null));
+        mockUsePositions
+          .mockReturnValueOnce(
+            positionRet({
+              line: '7',
+              trains: [train('사가정', TRAIN_STATUS.ARRIVED, { trainNo: 'T-NEAR' })],
+            }),
+          )
+          .mockReturnValueOnce(positionRet(null))
+          .mockReturnValueOnce(positionRet(null));
+
+        const { result } = renderHook(() => useFusedNearestStation());
+        expect(result.current.source).not.toBe('position-train');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('지하 fix(accuracy > MAX_ACCURACY_M)면 거리 게이트 면제 → positionTrain 유지', () => {
+      setup용마산GpsSagajeongTrain({ accuracyMeters: 1500 });
+      const { result } = renderHook(() => useFusedNearestStation());
+      // 지하 가정. positionTrain이 살아서 사가정을 그대로 채택.
+      expect(result.current.source).toBe('position-train');
+      expect(result.current.result?.station.name).toBe('사가정');
+    });
+
+    it('accuracy null도 거리 게이트 면제 → positionTrain 유지', () => {
+      setup용마산GpsSagajeongTrain({ accuracyMeters: null });
+      const { result } = renderHook(() => useFusedNearestStation());
+      expect(result.current.source).toBe('position-train');
+    });
+
+    it('정상 mid-ride(user가 정확도 양호 + 절대 거리 ≤0.6km + margin OK): positionTrain 유지', () => {
+      // user는 사가정 근처(약 0.3km) — 절대 거리 통과, GPS-nearest도 사가정.
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: sagajeong.lat - 0.0027, lng: sagajeong.lng }, // ~300m 남쪽
+          accuracyMeters: 10,
+          result: { station: sagajeong, distanceKm: 0.3 },
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: sagajeong, distanceKm: 0.3 }]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      mockUsePositions
+        .mockReturnValueOnce(
+          positionRet({
+            line: '7',
+            trains: [train(sagajeong.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-OK' })],
+          }),
+        )
+        .mockReturnValueOnce(positionRet(null))
+        .mockReturnValueOnce(positionRet(null));
+
+      const { result } = renderHook(() => useFusedNearestStation());
+      expect(result.current.source).toBe('position-train');
+      expect(result.current.result?.station.name).toBe('사가정');
+    });
+
+    it('TTL: trainProgress가 갱신된 지 60s 초과면 fusion 강등 + sticky 락 해제', () => {
+      jest.useFakeTimers();
+      try {
+        // mockImplementation으로 안정 — 매 호출마다 동일한 positions 반환.
+        mockUseNearest.mockReturnValue(
+          gpsBase({
+            userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+            accuracyMeters: 1500, // 거리 게이트 면제 → TTL만 검사
+            result: { station: yongmasan, distanceKm: 0 },
+          }),
+        );
+        mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+        mockUseArrival.mockReturnValue(arrivalRet(null));
+        mockUsePositions.mockImplementation((line: string | null) => {
+          if (line === '7') {
+            return positionRet({
+              line: '7',
+              trains: [train(sagajeong.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-TTL' })],
+            });
+          }
+          return positionRet(null);
+        });
+
+        const { result, rerender } = renderHook(() => useFusedNearestStation());
+        expect(result.current.source).toBe('position-train');
+
+        // 시계만 진행. userLocation을 미세 변경해 useMemo 재계산 트리거.
+        jest.advanceTimersByTime(61_000);
+        mockUseNearest.mockReturnValue(
+          gpsBase({
+            userLocation: { lat: yongmasan.lat + 0.00001, lng: yongmasan.lng },
+            accuracyMeters: 1500,
+            result: { station: yongmasan, distanceKm: 0 },
+          }),
+        );
+        rerender(undefined);
+
+        // TTL 발동 → positionTrainResult=null → source는 다른 fallback.
+        expect(result.current.source).not.toBe('position-train');
+      } finally {
+        jest.useRealTimers();
+        mockUsePositions.mockReset();
+      }
+    });
   });
 
   describe('routeContext (Phase A — Route-Locked Map Matching)', () => {

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -13,8 +13,13 @@ import { pickFusedStation, type FusionConfidence, type FusionSource } from '../u
 import { pickCandidateTrains, type CandidateTrain } from '../utils/pickCandidateTrains';
 import { trackTrainProgress } from '../utils/trackTrainProgress';
 import { haversine } from '../utils/haversine';
-import { MAX_STATION_DISTANCE_KM } from '../constants/location';
-import { MAX_ACTIVE_LINES } from '../constants/realtime';
+import { MAX_ACCURACY_M, MAX_STATION_DISTANCE_KM } from '../constants/location';
+import {
+  MAX_ACTIVE_LINES,
+  MAX_POSITION_TRAIN_DELTA_KM,
+  MAX_POSITION_TRAIN_DISTANCE_KM,
+  POSITION_TRAIN_TTL_MS,
+} from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
 import type { NearestStationResult, Station } from '../types/station';
 import type { ArrivalProvider, PositionProvider } from '../providers/types';
@@ -181,8 +186,21 @@ export function useFusedNearestStation(
     [candidateTrains, gps.userLocation],
   );
 
+  // #445: trainProgress 갱신 시각 추적 + TTL 만료 후 첫 갱신에서 sticky 락 해제.
+  // 폴링 정지로 TTL이 지난 뒤 재개되면 trackTrainProgress가 stale sticky를 다시 픽업해
+  // 잘못된 락이 반복되는 사이클을 끊는다 — 다음 사이클은 새 후보로 정상 disambiguation.
+  const lastProgressTsRef = useRef<number>(0);
   useEffect(() => {
-    if (trainProgress) lastConfirmedTrainNoRef.current = trainProgress.trainNo;
+    if (!trainProgress) return;
+    const now = Date.now();
+    const prev = lastProgressTsRef.current;
+    const ttlExpired = prev !== 0 && now - prev > POSITION_TRAIN_TTL_MS;
+    if (ttlExpired) {
+      lastConfirmedTrainNoRef.current = undefined;
+    } else {
+      lastConfirmedTrainNoRef.current = trainProgress.trainNo;
+    }
+    lastProgressTsRef.current = now;
   }, [trainProgress]);
 
   const positionTrainResult: NearestStationResult | null = useMemo(() => {
@@ -193,8 +211,36 @@ export function useFusedNearestStation(
     const distanceKm = gps.userLocation
       ? haversine(gps.userLocation.lat, gps.userLocation.lng, station.lat, station.lng)
       : 0;
+
+    // #445 게이트: positionTrain 락이 사용자 실위치와 동떨어진 경우 강등.
+    // (1) TTL: trainProgress가 신선해야 함. stale하면 강등.
+    // (2) 거리 sanity: accuracy 양호(≤MAX_ACCURACY_M)할 때만 적용 — 지하 fix는 면제.
+    //   2a) 절대 거리 > MAX_POSITION_TRAIN_DISTANCE_KM
+    //   2b) GPS-nearest와 비교해 margin 초과
+    // ref가 0이면 effect가 첫 ts를 commit하기 전 — useMemo는 pure하게 두기 위해 면제.
+    if (
+      lastProgressTsRef.current !== 0 &&
+      Date.now() - lastProgressTsRef.current > POSITION_TRAIN_TTL_MS
+    ) {
+      return null;
+    }
+    if (
+      gps.userLocation &&
+      gps.accuracyMeters != null &&
+      gps.accuracyMeters <= MAX_ACCURACY_M
+    ) {
+      if (distanceKm > MAX_POSITION_TRAIN_DISTANCE_KM) return null;
+      const gpsNearest = candidates[0];
+      if (
+        gpsNearest &&
+        gpsNearest.station.id !== station.id &&
+        distanceKm > gpsNearest.distanceKm + MAX_POSITION_TRAIN_DELTA_KM
+      ) {
+        return null;
+      }
+    }
     return { station, distanceKm };
-  }, [trainProgress, gps.userLocation]);
+  }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates]);
 
   const routeResult: NearestStationResult | null = progress.position
     ? {


### PR DESCRIPTION
Closes #445

> 현재역 신뢰성 트랙 (2/6) — #443 관측 인프라로 확정된 사고 원인 직접 수정.

## 재현된 사고
DebugModal share dump에서 확인:
\`\`\`
GPS:    lat=37.5756, lng=127.0872, accuracy=7.21m   (= 용마산)
Nearest: 사가정 · 595m                              (= fused 결과, 잘못된 표시)
Fusion:  source=position-train
  fused: 사가정(7) · 595m
  gps:   용마산(7) · 225m                           (= GPS는 진실 파악)
\`\`\`
positionTrainResult가 곧 사가정에 도착하는 열차를 사용자가 탄 열차로 잘못 락하고 fused 결과를 덮어씀.

## Summary
positionTrainResult useMemo에 3중 게이트 추가:
- **절대 거리**: \`accuracy ≤ MAX_ACCURACY_M(200m)\` 일 때 station ↔ user > \`MAX_POSITION_TRAIN_DISTANCE_KM(0.6km)\` → 강등
- **상대 margin**: GPS-nearest와 다른 station이고 거리 차이 > \`MAX_POSITION_TRAIN_DELTA_KM(0.2km)\` → 강등. **이번 사고(595m vs 225m=370m 차이) 직접 잡음**
- **TTL**: \`POSITION_TRAIN_TTL_MS(60s)\` 갱신 없으면 강등 + 다음 갱신에서 sticky 락 해제

지하 fix(accuracy > 200m)는 거리 게이트 면제 — 기존 position-first fusion 의도(지하/GPS 지연 보정) 유지.

## 트레이드오프
- 보수적 임계값. 정상 fusion 손실 약간 증가 가능 (mid-ride 600m 이상 케이스)
- 이번 사고 + 더 큰 오발(상봉 2221m) 모두 차단
- #443 fusion 로그로 운영 데이터 보고 임계값 미세 조정 예정 (#447)

## Test plan
- [x] 재현된 사고 케이스 단위 테스트 (용마산 GPS + 사가정 trainProgress → 강등)
- [x] 절대/상대/TTL/면제(지하)/정상 mid-ride 5종
- [x] 기존 17개 + 신규 6개 = 1492 passed, 커버리지 100%
- [x] type-check 통과
- [ ] 실기기에서 사고 재현 시도 (머지 후) — 사가정 락 안 보이는지 확인

## 후속
- #447 GPS 게이트 재검토 (운영 로그 1주 수집 후)
- #444 fusion 거리 sanity gate 일반화 (positionTrain 외 source도)