### PR TITLE
fix(#444): non-gps fusion source 전체에 거리 sanity gate

### DIFF
--- a/src/constants/realtime.ts
+++ b/src/constants/realtime.ts
@@ -5,13 +5,13 @@
  */
 export const MAX_ACTIVE_LINES = 3;
 
-// #445 positionTrainResult sticky gate.
-// 인접역 평균 800m+ 대비 보수치. positionTrain이 잡은 역과 user GPS가 이보다 멀면
-// 사용자가 그 역에 가까이 있지 않다고 판단해 fusion을 다음 우선순위로 강등한다.
-export const MAX_POSITION_TRAIN_DISTANCE_KM = 0.6;
-// positionTrain 역과 GPS-nearest 역 거리 차이 margin. GPS 노이즈 흡수용.
-// `positionTrainDist > gpsNearestDist + DELTA`이면 GPS-nearest 쪽이 더 신뢰 가능.
-export const MAX_POSITION_TRAIN_DELTA_KM = 0.2;
-// trainProgress 신선도. 7호선 역간 평균 100~120s의 절반.
+// #444/#445 fusion 거리 게이트 — non-gps source(positionTrain/fused/route) 공통 적용.
+// 인접역 평균 800m+ 대비 보수치. fusion이 잡은 역과 user GPS가 이보다 멀면
+// 사용자가 그 역에 가까이 있지 않다고 판단해 다음 우선순위로 강등한다.
+export const MAX_FUSION_DISTANCE_KM = 0.6;
+// fusion 역과 GPS-nearest 역 거리 차이 margin. GPS 노이즈 흡수용.
+// `fusionDist > gpsNearestDist + DELTA`이면 GPS-nearest 쪽이 더 신뢰 가능.
+export const MAX_FUSION_DELTA_KM = 0.2;
+// #445 positionTrain trainProgress 신선도. 7호선 역간 평균 100~120s의 절반.
 // 이 시간 이상 갱신 없으면 sticky 락(lastConfirmedTrainNo) 자체를 해제한다.
 export const POSITION_TRAIN_TTL_MS = 60_000;

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -420,6 +420,65 @@ describe('useFusedNearestStation', () => {
     });
   });
 
+  describe('#444 fused/route 거리 sanity gate', () => {
+    const yongmasan = findStationByNameAndLine('용마산', '7')!;
+
+    it('재현된 사고: GPS=용마산 / fused가 사가정 0s arrival로 채택 → fused 강등 → gps로 떨어짐', () => {
+      // mockFindTop으로 후보 직접 주입. trackTrainProgress 경로엔 positions가 없어
+      // findStationByNameAndLine 호출이 없으므로 스파이 불필요.
+      const fakeSagajeong = {
+        id: 'SAGA-FAKE',
+        name: '사가정',
+        line: '7' as const,
+        lineColor: '#747F00',
+        // user(용마산)에서 약 0.6km 떨어진 좌표 — 절대 게이트 경계.
+        lat: yongmasan.lat + 0.0054,
+        lng: yongmasan.lng,
+      };
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          accuracyMeters: 6,
+          result: { station: yongmasan, distanceKm: 0 },
+        }),
+      );
+      mockFindTop.mockReturnValue([
+        { station: yongmasan, distanceKm: 0 },
+        { station: fakeSagajeong, distanceKm: 0.6 },
+      ]);
+      mockUseArrival
+        .mockReturnValueOnce(arrivalRet(null))
+        .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }))
+        .mockReturnValueOnce(arrivalRet(null));
+      mockUsePositions.mockReturnValue(positionRet(null));
+
+      const { result } = renderHook(() => useFusedNearestStation());
+      // fused는 사가정을 채택하지만, #444 게이트가 강등 → gps로 폴백 → 용마산.
+      expect(result.current.source).toBe('gps');
+      expect(result.current.result?.station.id).toBe(yongmasan.id);
+    });
+
+    it('fused가 통과 가능한 거리(GPS-nearest와 동일 station)면 그대로 채택', () => {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          accuracyMeters: 10,
+          result: { station: yongmasan, distanceKm: 0 },
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUseArrival
+        .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }))
+        .mockReturnValueOnce(arrivalRet(null))
+        .mockReturnValueOnce(arrivalRet(null));
+      mockUsePositions.mockReturnValue(positionRet(null));
+
+      const { result } = renderHook(() => useFusedNearestStation());
+      expect(result.current.source).toBe('arrival');
+      expect(result.current.result?.station.id).toBe(yongmasan.id);
+    });
+  });
+
   describe('routeContext (Phase A — Route-Locked Map Matching)', () => {
     const sagajeong = findStationByNameAndLine('사가정', '7')!;
     const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -13,11 +13,12 @@ import { pickFusedStation, type FusionConfidence, type FusionSource } from '../u
 import { pickCandidateTrains, type CandidateTrain } from '../utils/pickCandidateTrains';
 import { trackTrainProgress } from '../utils/trackTrainProgress';
 import { haversine } from '../utils/haversine';
-import { MAX_ACCURACY_M, MAX_STATION_DISTANCE_KM } from '../constants/location';
+import { passesFusionDistanceGate } from '../utils/fusionDistanceGate';
+import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import {
   MAX_ACTIVE_LINES,
-  MAX_POSITION_TRAIN_DELTA_KM,
-  MAX_POSITION_TRAIN_DISTANCE_KM,
+  MAX_FUSION_DELTA_KM,
+  MAX_FUSION_DISTANCE_KM,
   POSITION_TRAIN_TTL_MS,
 } from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
@@ -212,11 +213,7 @@ export function useFusedNearestStation(
       ? haversine(gps.userLocation.lat, gps.userLocation.lng, station.lat, station.lng)
       : 0;
 
-    // #445 게이트: positionTrain 락이 사용자 실위치와 동떨어진 경우 강등.
-    // (1) TTL: trainProgress가 신선해야 함. stale하면 강등.
-    // (2) 거리 sanity: accuracy 양호(≤MAX_ACCURACY_M)할 때만 적용 — 지하 fix는 면제.
-    //   2a) 절대 거리 > MAX_POSITION_TRAIN_DISTANCE_KM
-    //   2b) GPS-nearest와 비교해 margin 초과
+    // #445 TTL: trainProgress가 신선해야 함. stale하면 강등.
     // ref가 0이면 effect가 첫 ts를 commit하기 전 — useMemo는 pure하게 두기 위해 면제.
     if (
       lastProgressTsRef.current !== 0 &&
@@ -224,22 +221,21 @@ export function useFusedNearestStation(
     ) {
       return null;
     }
+    // #444 거리 sanity — fused/route와 공통 헬퍼 재사용.
+    const candidate = { station, distanceKm };
     if (
-      gps.userLocation &&
-      gps.accuracyMeters != null &&
-      gps.accuracyMeters <= MAX_ACCURACY_M
+      !passesFusionDistanceGate({
+        candidate,
+        userLocation: gps.userLocation,
+        accuracyMeters: gps.accuracyMeters,
+        gpsNearest: candidates[0],
+        maxAbsoluteKm: MAX_FUSION_DISTANCE_KM,
+        maxDeltaKm: MAX_FUSION_DELTA_KM,
+      })
     ) {
-      if (distanceKm > MAX_POSITION_TRAIN_DISTANCE_KM) return null;
-      const gpsNearest = candidates[0];
-      if (
-        gpsNearest &&
-        gpsNearest.station.id !== station.id &&
-        distanceKm > gpsNearest.distanceKm + MAX_POSITION_TRAIN_DELTA_KM
-      ) {
-        return null;
-      }
+      return null;
     }
-    return { station, distanceKm };
+    return candidate;
   }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates]);
 
   const routeResult: NearestStationResult | null = progress.position
@@ -251,6 +247,19 @@ export function useFusedNearestStation(
 
   // 우선순위(Phase 1C 역전): position-train > position/arrival(fused) > route-progress > gps.
   // 기존: route-progress가 fused를 덮어쓰고 있었음.
+  // #444: fused/route도 채택 직전 거리 sanity 통과 검사 — 미통과 시 다음 우선순위로.
+  const gateOpts = {
+    userLocation: gps.userLocation,
+    accuracyMeters: gps.accuracyMeters,
+    gpsNearest: candidates[0],
+    maxAbsoluteKm: MAX_FUSION_DISTANCE_KM,
+    maxDeltaKm: MAX_FUSION_DELTA_KM,
+  };
+  const fusedPasses =
+    fused != null && passesFusionDistanceGate({ ...gateOpts, candidate: fused.result });
+  const routePasses =
+    routeResult != null && passesFusionDistanceGate({ ...gateOpts, candidate: routeResult });
+
   let result: NearestStationResult | null;
   let confidence: FusionConfidence;
   let source: FusionSource;
@@ -258,11 +267,11 @@ export function useFusedNearestStation(
     result = positionTrainResult;
     confidence = 'position-train';
     source = 'position-train';
-  } else if (fused) {
+  } else if (fused && fusedPasses) {
     result = fused.result;
     confidence = fused.confidence;
     source = fused.source;
-  } else if (routeResult) {
+  } else if (routeResult && routePasses) {
     result = routeResult;
     confidence = 'route-progress';
     source = 'route-progress';

--- a/src/utils/__tests__/fusionDistanceGate.test.ts
+++ b/src/utils/__tests__/fusionDistanceGate.test.ts
@@ -1,0 +1,123 @@
+import { passesFusionDistanceGate } from '../fusionDistanceGate';
+import { MAX_ACCURACY_M } from '../../constants/location';
+import type { NearestStationResult, Station } from '../../types/station';
+
+function makeStation(id: string, lat: number, lng: number): Station {
+  return { id, name: id, line: '7', lineColor: '#000', lat, lng };
+}
+
+function makeResult(id: string, lat: number, lng: number, distanceKm: number): NearestStationResult {
+  return { station: makeStation(id, lat, lng), distanceKm };
+}
+
+describe('passesFusionDistanceGate', () => {
+  const userLocation = { lat: 37.5, lng: 127.0 };
+  const candidate = makeResult('A', 37.5, 127.0, 0.5);
+  const gpsNearest = makeResult('B', 37.5, 127.0, 0.1);
+
+  it('userLocation 없으면 통과(검사 불가)', () => {
+    expect(
+      passesFusionDistanceGate({
+        candidate,
+        userLocation: null,
+        accuracyMeters: 10,
+        gpsNearest,
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(true);
+  });
+
+  it('accuracy null이면 통과', () => {
+    expect(
+      passesFusionDistanceGate({
+        candidate,
+        userLocation,
+        accuracyMeters: null,
+        gpsNearest,
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(true);
+  });
+
+  it('accuracy > MAX_ACCURACY_M(지하) 통과', () => {
+    expect(
+      passesFusionDistanceGate({
+        candidate,
+        userLocation,
+        accuracyMeters: MAX_ACCURACY_M + 1,
+        gpsNearest,
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(true);
+  });
+
+  it('절대 거리 초과 → 실패', () => {
+    expect(
+      passesFusionDistanceGate({
+        candidate: makeResult('A', 0, 0, 0.7),
+        userLocation,
+        accuracyMeters: 10,
+        gpsNearest,
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(false);
+  });
+
+  it('상대 margin 초과 → 실패', () => {
+    // candidate(A) 거리 0.5, gpsNearest(B) 거리 0.1, 0.5 > 0.1+0.2=0.3 → 실패
+    expect(
+      passesFusionDistanceGate({
+        candidate,
+        userLocation,
+        accuracyMeters: 10,
+        gpsNearest,
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(false);
+  });
+
+  it('gpsNearest 없으면 상대 검사 스킵', () => {
+    expect(
+      passesFusionDistanceGate({
+        candidate: makeResult('A', 0, 0, 0.5),
+        userLocation,
+        accuracyMeters: 10,
+        gpsNearest: undefined,
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(true);
+  });
+
+  it('gpsNearest와 같은 station이면 상대 검사 스킵', () => {
+    expect(
+      passesFusionDistanceGate({
+        candidate: makeResult('SAME', 0, 0, 0.5),
+        userLocation,
+        accuracyMeters: 10,
+        gpsNearest: makeResult('SAME', 0, 0, 0.1),
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(true);
+  });
+
+  it('모두 통과', () => {
+    expect(
+      passesFusionDistanceGate({
+        candidate: makeResult('A', 0, 0, 0.2),
+        userLocation,
+        accuracyMeters: 10,
+        gpsNearest,
+        maxAbsoluteKm: 0.6,
+        maxDeltaKm: 0.2,
+      }),
+    ).toBe(true);
+  });
+});
+

--- a/src/utils/fusionDistanceGate.ts
+++ b/src/utils/fusionDistanceGate.ts
@@ -1,0 +1,40 @@
+import { MAX_ACCURACY_M } from '../constants/location';
+import type { NearestStationResult } from '../types/station';
+
+// #444: fusion 결과(non-gps source)가 사용자 실위치와 동떨어진 station을 채택하지 않도록
+// 거리·정확도 sanity 검사. positionTrain/fused/route 우선순위에 공통 적용.
+// accuracy가 양호(≤ MAX_ACCURACY_M)할 때만 게이트가 의미 있음 — 지하 fix(±1.5km)는
+// 거리 비교 자체를 신뢰할 수 없어 면제(통과).
+
+export interface FusionDistanceGateInput {
+  /** fusion이 채택하려는 station + user GPS와의 거리(km). */
+  candidate: NearestStationResult;
+  userLocation: { lat: number; lng: number } | null;
+  accuracyMeters: number | null;
+  /** GPS-nearest 후보 — 상대 margin 비교용. 없으면 상대 검사 스킵. */
+  gpsNearest: NearestStationResult | undefined;
+  maxAbsoluteKm: number;
+  maxDeltaKm: number;
+}
+
+/**
+ * 후보 station이 GPS sanity 검사를 통과하는지.
+ * - userLocation 없거나 accuracy null/저조 → 통과(검사 불가)
+ * - 절대 거리 > maxAbsoluteKm → 실패
+ * - GPS-nearest와 다른 station이고 거리 차이 > maxDeltaKm → 실패
+ */
+export function passesFusionDistanceGate(input: FusionDistanceGateInput): boolean {
+  const { candidate, userLocation, accuracyMeters, gpsNearest, maxAbsoluteKm, maxDeltaKm } = input;
+  if (!userLocation) return true;
+  if (accuracyMeters == null || accuracyMeters > MAX_ACCURACY_M) return true;
+  if (candidate.distanceKm > maxAbsoluteKm) return false;
+  if (
+    gpsNearest &&
+    gpsNearest.station.id !== candidate.station.id &&
+    candidate.distanceKm > gpsNearest.distanceKm + maxDeltaKm
+  ) {
+    return false;
+  }
+  return true;
+}
+


### PR DESCRIPTION
Closes #444

> 현재역 신뢰성 트랙 (3/6) — #445의 마무리. DebugModal dump로 확정된 잔여 사고 차단.

## 잔여 사고
#450(#445) 머지 후 같은 위치에서 dump:
\`\`\`
GPS:    용마산 / 0.224km / accuracy 5.8m
Fused:  사가정 / 0.599km
source: position   ← position-train은 강등됐지만 fused가 사가정 채택
(fused != gps)
\`\`\`
positionTrain 게이트는 작동했으나 다음 우선순위(fused)에 sanity 없음 → arrival 0s 신호로 사가정 채택.

## Summary
- \`src/utils/fusionDistanceGate.ts\` 신규: \`passesFusionDistanceGate\` 순수 헬퍼
- \`useFusedNearestStation\` 우선순위 분기에서 positionTrain/fused/route 모두 채택 직전 같은 게이트 통과 검사
- positionTrain의 인라인 게이트 로직도 헬퍼 호출로 단순화 (중복 제거)
- 상수 \`MAX_POSITION_TRAIN_*\` → \`MAX_FUSION_*\` 리네임 (전 source 공통)

## 게이트 동작
1. accuracy null 또는 > MAX_ACCURACY_M(200m) → 통과 (지하 면제)
2. 절대 거리 > MAX_FUSION_DISTANCE_KM(0.6km) → 강등
3. GPS-nearest와 다른 station이고 거리 차이 > MAX_FUSION_DELTA_KM(0.2km) → 강등

이번 dump 케이스(0.599 vs 0.224, 차이 0.375 > 0.2): **상대 margin이 잡음.**

## Test plan
- [x] 헬퍼 단위 테스트 8종 (boundary: userLocation/accuracy/지하/절대/상대/gpsNearest 없음/같은 station/모두 통과)
- [x] 회귀: GPS=용마산 + fused=사가정 ARRIVED → source='gps' (용마산)
- [x] fused 통과 케이스 (같은 station) — source='arrival'
- [x] 1502 passed, 커버리지 100%, type-check 통과

## 후속
- 게이트 trip 측정 (DebugModal candidates extra에 gatePass 노출) — 별도 chore
- 임계값 실측 기반 조정 (#447)