### PR TITLE
fix(#452): station-passed effect deps에서 raw accuracyMeters 제거

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -928,5 +928,55 @@ describe('useStationAlarm', () => {
       });
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
+
+    // #452: deps에 raw accuracyMeters가 들어가면 GPS 노이즈로 매 fix 재실행되어
+    // dedup-suppressed 로그가 1초당 1줄씩 쌓여 alarm log ring buffer를 점령했다.
+    // 게이트 통과 영역 내부에서 accuracyMeters만 바뀔 때 effect가 추가 실행되지 않아야 한다.
+    it('#452: 같은 station에서 accuracyMeters만 바뀌어도 dedup-suppressed 로그가 추가되지 않는다', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(station.id);
+
+      const { rerender } = renderHook(
+        (props: UseStationAlarmInputs) => useStationAlarm(props),
+        {
+          initialProps: defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            accuracyMeters: 10,
+          }),
+        },
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedDedupStation).toHaveBeenCalledTimes(1);
+      });
+
+      // GPS 노이즈처럼 정확도만 게이트 통과 범위 내에서 변경.
+      rerender(
+        defaultInputs({
+          route,
+          destination,
+          nearestStation: station,
+          accuracyMeters: 25,
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      rerender(
+        defaultInputs({
+          route,
+          destination,
+          nearestStation: station,
+          accuracyMeters: 50,
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // 추가 호출 없음 — 게이트 boolean이 바뀌지 않는 한 effect가 재실행되지 않음.
+      // (await 후 검증으로 비동기 IIFE의 carryover 호출 가능성도 차단)
+      expect(mockLogSuppressedDedupStation).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -174,12 +174,15 @@ export function useStationAlarm({
   // dedup은 AsyncStorage(lastNotifiedStationId)를 단일 출처로 사용 — Foreground/Background
   // 양쪽에서 동일하게 적용된다. firedHydrated에 의존하지 않으므로 하이드레이션 완료가
   // station-passed를 재발사시키지 않는다.
+  // #452: deps에 raw accuracyMeters를 두면 GPS 노이즈로 매 fix 재실행 → dedup-suppressed
+  // 로그가 cap까지 차서 다른 진단을 밀어낸다. 게이트 통과 여부(boolean)만 dep로 둔다.
+  const accuracyOk = isAccuracyAcceptable(accuracyMeters);
+  const arrivalConfirmed = arrivalConfidence === 'arrival-confirmed';
+
   useEffect(() => {
     let cancelled = false;
     if (!route || !destination) return;
 
-    const accuracyOk = isAccuracyAcceptable(accuracyMeters);
-    const arrivalConfirmed = arrivalConfidence === 'arrival-confirmed';
     if (!accuracyOk && !arrivalConfirmed) return;
 
     // cancellation: 효과 cleanup이 cancelled를 true로 만들어 stale IIFE를 중단시킨다.
@@ -221,7 +224,7 @@ export function useStationAlarm({
     destination?.id,
     destination?.name,
     nearestStation?.id,
-    accuracyMeters,
-    arrivalConfidence,
+    accuracyOk,
+    arrivalConfirmed,
   ]);
 }


### PR DESCRIPTION
Closes #452

## 현상
DebugModal share dump의 Alarm log 200줄이 같은 station-passed dedup-suppressed 1초 단위 줄로 채워져 다른 진단 정보를 모두 밀어냄.

\`\`\`
20:58:32 ~ 21:01:51 (3분 19초, 200줄)
fg | suppressed | dedup-station | station-passed | 용마산
\`\`\`

## Summary
\`useStationAlarm\`의 station-passed effect deps에 raw \`accuracyMeters\`가 들어가 GPS 노이즈로 매 fix(2s) 마다 재실행됨. 게이트 통과 후 dedup이 catch해 푸시는 안 가지만 \`logSuppressedDedupStation\`이 매번 호출돼 alarm log를 점령.

- raw \`accuracyMeters\` / \`arrivalConfidence\` → 파생 boolean \`accuracyOk\` / \`arrivalConfirmed\`로 좁힘
- effect deps도 boolean으로 교체 — 게이트 통과 범위 내부 노이즈에 반응 안 함
- phase 알람 effect는 ETA 거리 계산에 raw 정확도가 필요해 분리 유지

## Test plan
- [x] 같은 station에서 accuracyMeters 10→25→50 변경 시 logSuppressedDedupStation 1회만 호출 (회귀 박제)
- [x] 기존 50 테스트 그대로 통과 (50/50 useStationAlarm)
- [x] 1503 passed 전체, 커버리지 100%, type-check 통과

## 후속
- 게이트 정책 단일화(P2-1) — 별도 refactor 이슈 가능