### PR TITLE
refactor(#446): 홈 origin 라벨 source별 분기, 비-gps 거리·도보 숨김

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -317,6 +317,8 @@ export default function HomeScreen() {
               <Text style={[typography.label, { color: colors.muted, marginBottom: 10 }]}>
                 {isCustomOrigin
                   ? t('home.originManual')
+                  : source !== 'gps'
+                  ? t('home.originEstimated')
                   : result && result.distanceKm <= 0.5
                   ? t('home.originCurrent')
                   : t('home.originNearest')}
@@ -339,7 +341,10 @@ export default function HomeScreen() {
               </View>
               <View style={styles.metaRow}>
                 <LineBadge line={effectiveOrigin.line} />
-                {!isCustomOrigin && nearest && (
+                {/* #446: source==='gps'일 때만 user↔station 거리/도보시간이 의미 있음.
+                    fusion 추정(positionTrain/arrival/route) 결과의 거리는 user↔추정역
+                    직선거리라 도보 안내로 표시하면 잘못된 정보가 됨 → 숨김. */}
+                {!isCustomOrigin && nearest && source === 'gps' && (
                   <>
                     <Dot />
                     <Text style={[typography.bodySm, { color: colors.muted }]}>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -26,6 +26,7 @@
     "originManual": "Origin (manual)",
     "originCurrent": "Current station",
     "originNearest": "Nearest station",
+    "originEstimated": "Estimated current station",
     "routeTo": "Route to",
     "estimatedSuffix": "EST",
     "destinationChange": "Change destination →",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -26,6 +26,7 @@
     "originManual": "出発駅(手動)",
     "originCurrent": "現在駅",
     "originNearest": "最寄り駅",
+    "originEstimated": "現在の推定駅",
     "routeTo": "目的地まで",
     "estimatedSuffix": "予想",
     "destinationChange": "目的地を変更 →",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -26,6 +26,7 @@
     "originManual": "출발역 (수동)",
     "originCurrent": "현재역",
     "originNearest": "가장 가까운 역",
+    "originEstimated": "현재 추정 역",
     "routeTo": "목적지까지",
     "estimatedSuffix": "예상",
     "destinationChange": "목적지 변경 →",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -26,6 +26,7 @@
     "originManual": "出发站(手动)",
     "originCurrent": "当前站",
     "originNearest": "最近站",
+    "originEstimated": "当前推定站",
     "routeTo": "前往",
     "estimatedSuffix": "预计",
     "destinationChange": "更改目的地 →",


### PR DESCRIPTION
Closes #446

> 현재역 신뢰성 트랙 (5/6) — 사용자에게 노출되는 표면 정합성 마무리.

## Summary
- 비-gps source(positionTrain/fused/route)일 때 origin 라벨을 "현재 추정 역"으로 변경
- 거리/도보시간 표기를 \`source==='gps'\`일 때만 노출 — 추정역의 user 직선거리는 도보 안내로 의미가 없어 표면에서 제거
- 4개 locale(ko/en/ja/zh)에 \`home.originEstimated\` 키 추가
- fusion 로직·알람·경로 그대로

## 동기
#444 게이트로 명백한 오발은 차단됐지만, fusion이 정상적으로 다른 역을 추정하는 케이스에서도 "가장 가까운 역 · 595m · 11min walk" 같은 잘못된 도보 안내가 노출될 수 있음. 표면 자체를 좁혀 사용자 신뢰성을 끝까지.

## Test plan
- [x] 1503 passed, 커버리지 100%, type-check 통과
- [x] isCustomOrigin 경로 변경 없음 (수동 설정 시 기존 동작 유지)
- [x] 4개 locale 동시 추가 — missing key 없음
- [ ] 실기기 시각 확인 (머지 후) — metaRow 레이아웃 깨지지 않는지

## 후속
- P2-1: 라벨 결정 헬퍼 추출 + 단위 테스트 (별도 refactor 이슈 가능)