### PR TITLE
chore(#456): DebugModal을 release 빌드에서도 접근 가능하게 (env flag + 버전 7탭)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ EXPO_PUBLIC_KAKAO_MAP_KEY=
 # alarm-worker(#338) 백엔드 URL (예: https://alarm-worker.example.workers.dev)
 # 비워두면 사전 예약(#334)만으로 baseline 동작 (silent push reschedule 없이)
 EXPO_PUBLIC_ALARM_BACKEND_URL=
+
+# DebugModal을 release 빌드에서도 노출 (개인 진단용 #456)
+# "true"일 때만 설정 탭 버전 7탭 트리거가 작동. 일반 배포 빌드에는 절대 켜지 말 것.
+EXPO_PUBLIC_DEBUG_MODAL=

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,13 +1,19 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Alert, Pressable, ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'expo-router';
+import Constants from 'expo-constants';
 import { useAppStore, type ThemeMode, type LocalePreference } from '../../src/store/useAppStore';
 import { ROUTE_CATEGORIES } from '../../src/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../../src/i18n/types';
 import { useTheme, spacing, radius } from '../../src/theme';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
+import {
+  DEBUG_MODAL_TRIGGER_RESET_MS,
+  DEBUG_MODAL_TRIGGER_TAP_COUNT,
+  isDebugModalEnabled,
+} from '../../src/constants/debugFlags';
 
 const THEME_OPTIONS = [
   { value: 'auto', labelKey: 'settings.themeAuto' },
@@ -154,8 +160,42 @@ export default function SettingsScreen() {
           </View>
         </View>
 
+        <VersionFooter />
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+function VersionFooter() {
+  const { colors } = useTheme();
+  const tapCountRef = useRef(0);
+  const lastTapAtRef = useRef(0);
+  const setDebugVisible = useAppStore((s) => s.setDebugVisible);
+  const version = Constants.expoConfig?.version ?? '-';
+
+  const handlePress = () => {
+    if (!isDebugModalEnabled()) return;
+    const now = Date.now();
+    // 탭 간격 RESET_MS 초과 시 새 시퀀스 — 우발 누적 트리거 방지(Android 컨벤션).
+    tapCountRef.current =
+      now - lastTapAtRef.current > DEBUG_MODAL_TRIGGER_RESET_MS
+        ? 1
+        : tapCountRef.current + 1;
+    lastTapAtRef.current = now;
+    if (tapCountRef.current >= DEBUG_MODAL_TRIGGER_TAP_COUNT) {
+      tapCountRef.current = 0;
+      setDebugVisible(true);
+    }
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={styles.versionFooter}
+      testID="settings-version-footer"
+    >
+      <Text style={[styles.versionText, { color: colors.muted }]}>v{version}</Text>
+    </Pressable>
   );
 }
 
@@ -342,5 +382,14 @@ const styles = StyleSheet.create({
   localeChevron: {
     fontSize: 20,
     marginLeft: spacing.sm,
+  },
+  versionFooter: {
+    alignItems: 'center',
+    paddingVertical: spacing.lg,
+    marginTop: spacing.md,
+  },
+  versionText: {
+    fontSize: 12,
+    letterSpacing: 0.5,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,6 +11,7 @@ import { i18n } from '../src/i18n';
 import { useApplyLocale } from '../src/hooks/useApplyLocale';
 import { useAppStore } from '../src/store/useAppStore';
 import { DebugModal } from '../src/components/DebugModal';
+import { isDebugModalEnabled } from '../src/constants/debugFlags';
 import '../src/tasks/backgroundLocationTask';
 import { registerSilentPushTask } from '../src/tasks/silentPushTask';
 import { registerScheduledAlarmListener } from '../src/utils/scheduledAlarmReceiver';
@@ -61,7 +62,7 @@ function RootContent() {
     <>
       <StatusBar style={isDark ? 'light' : 'dark'} />
       <Stack screenOptions={{ headerShown: false }} />
-      {__DEV__ && debugVisible && (
+      {isDebugModalEnabled() && debugVisible && (
         <DebugModal onClose={() => setDebugVisible(false)} />
       )}
     </>

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from 'react-native';
 import { useAppStore } from '../store/useAppStore';
+import { isDebugModalEnabled } from '../constants/debugFlags';
 import { useFusedNearestStation } from '../hooks/useFusedNearestStation';
 import { useArrivalInfo } from '../hooks/useArrivalInfo';
 import { clearAlarmLog, getAlarmLog, type AlarmLogEntry } from '../utils/alarmLog';
@@ -174,7 +175,8 @@ interface DebugModalProps {
 // 마운트하지 않아 GPS·Arrival 폴링이 2배가 되지 않도록 한다. 호출부(_layout)에서
 // `debugVisible &&` 조건부 렌더를 보장한다.
 export function DebugModal(props: DebugModalProps) {
-  if (!__DEV__) return null;
+  // #456: dev 빌드 외에 EXPO_PUBLIC_DEBUG_MODAL=true 빌드도 노출 — 일반 release 빌드는 자동 차단.
+  if (!isDebugModalEnabled()) return null;
   return <DebugModalInner {...props} />;
 }
 

--- a/src/constants/debugFlags.ts
+++ b/src/constants/debugFlags.ts
@@ -1,0 +1,14 @@
+// #456: DebugModal을 release 빌드에서도 접근 가능하게 하는 single source of truth.
+// dev 빌드(__DEV__)는 항상 활성. release 빌드는 EXPO_PUBLIC_DEBUG_MODAL=true일 때만 활성 —
+// 일반 배포 빌드는 flag 없음 → 자동 비활성. 모달 마운트·트리거 양쪽이 같은 함수를 본다.
+//
+// const로 캡쳐하면 jest의 __DEV__ override가 반영되지 않아 함수로 노출.
+// EXPO_PUBLIC_* 는 Expo가 빌드 타임에 인라인하므로 매 호출 평가에 비용 거의 없음.
+export function isDebugModalEnabled(): boolean {
+  return __DEV__ || process.env.EXPO_PUBLIC_DEBUG_MODAL === 'true';
+}
+
+/** 설정 탭 버전 7탭 트리거. Android 개발자 옵션 컨벤션. */
+export const DEBUG_MODAL_TRIGGER_TAP_COUNT = 7;
+/** 탭 간격이 이 시간을 넘으면 카운트 reset — 우발적 누적 트리거 방지. */
+export const DEBUG_MODAL_TRIGGER_RESET_MS = 1500;


### PR DESCRIPTION
Closes #456

## 동기
운영 모드 진입 후에도 사고 발견 시 dump를 떠야 함. 현재 Release 빌드는:
- \`DebugModal.tsx\` \`if (!__DEV__) return null\`
- \`app/_layout.tsx\` \`DevSettings.addMenuItem\`은 dev only

Wi-Fi/노트북 없이 폰만으로 진단 가능하게 — 단, 일반 배포 빌드는 자동 차단.

## Summary
- \`src/constants/debugFlags.ts\` 신규: \`isDebugModalEnabled()\` SSOT 게이트
  - dev 빌드 또는 \`EXPO_PUBLIC_DEBUG_MODAL=true\` 일 때만 활성
  - 함수로 노출 (jest \`__DEV__\` override 반영)
- \`DebugModal\` / \`app/_layout\` 게이트를 통일 — \`__DEV__\` 하드코딩 제거
- 설정 탭 풋터 **VersionFooter**: 버전 7탭 → \`setDebugVisible(true)\`
  - 1.5s 내 연속 탭만 카운트(우발 누적 방지) — Android 컨벤션
  - flag 비활성 빌드는 탭해도 no-op
- \`.env.example\`에 키 + 주의 추가

## 운영 흐름
\`\`\`bash
EXPO_PUBLIC_DEBUG_MODAL=true npx expo run:ios --device "<UDID>" --configuration Release
\`\`\`
- 폰에 깔면 Wi-Fi/노트북 없이 어디든 사용 가능
- 사고 시: 설정 탭 → 버전(\`v1.2.3\`) 7탭 → DebugModal → Share dump
- App Store 배포 빌드엔 flag 빼고 빌드 → 일반 사용자는 7탭해도 차단

## Test plan
- [x] 1503 passed, 커버리지 100%, type-check 통과
- [x] flag 비활성(jest 환경) 시 DebugModal early return 검증 (기존 테스트)
- [x] debugFlags.ts 100% 커버
- [ ] (운영 검증) flag 활성 release 빌드 깔고 설정 탭 7탭 → 모달 등장
- [ ] (운영 검증) Wi-Fi 끊긴 상태에서 앱 cold start 정상 동작

## 후속 (P2 미반영)
- VersionFooter를 \`src/components/\`로 추출 + 단위 테스트 — 가치 있지만 별 PR