### PR TITLE
fix(#455): 지도 출발/도착역 중복 마커 클러스터 제거

### DIFF
--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -110,6 +110,7 @@ export default function MapScreen() {
         nearestStation={result?.station ?? null}
         nearbyStations={allStations}
         customOriginId={customOrigin?.id}
+        destinationId={destination?.id}
         onStationPress={(station) => setSelectedStation(station)}
         focusStation={focusStation}
         focusNonce={focusNonce}

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -5,7 +5,7 @@ import ClusteredMapView from 'react-native-map-clustering';
 import { Marker, Polyline, PROVIDER_DEFAULT } from 'react-native-maps';
 import type MapView from 'react-native-maps';
 import type { Station } from '../types/station';
-import type { RouteCoordinatePath, RouteStationRole } from '../utils/routeToCoordinates';
+import type { RouteCoordinatePath } from '../utils/routeToCoordinates';
 import { buildMapConfig } from '../utils/buildMapConfig';
 import { useTheme } from '../theme';
 import { LINE_BADGE_LABEL } from '../constants/lineColors';
@@ -17,6 +17,8 @@ interface StationMapProps {
   nearestStation: Station | null;
   nearbyStations: Station[];
   customOriginId?: string;
+  /** 경로 도착역 id. 베이스 마커에서 accent 강조를 적용한다. */
+  destinationId?: string;
   onStationPress?: (station: Station) => void;
   /** 검색 결과 선택 시 지도 카메라를 이동시킬 역. focusNonce가 변할 때마다 재이동한다. */
   focusStation?: Station | null;
@@ -32,11 +34,7 @@ const FOCUS_REGION_DELTA = 0.01;
 const FOCUS_ANIMATION_MS = 400;
 const ROUTE_POLYLINE_WIDTH = 5;
 const ROUTE_FIT_EDGE_PADDING = { top: 40, bottom: 40, left: 40, right: 40 };
-const ROUTE_MARKER_SIZE: Record<RouteStationRole, number> = {
-  origin: 18,
-  transfer: 16,
-  destination: 18,
-};
+const ROUTE_TRANSFER_MARKER_SIZE = 16;
 
 export function StationMap({
   userLat,
@@ -44,6 +42,7 @@ export function StationMap({
   nearestStation,
   nearbyStations,
   customOriginId,
+  destinationId,
   onStationPress,
   focusStation,
   focusNonce,
@@ -137,6 +136,7 @@ export function StationMap({
                     // customOriginId/nearestStation은 (역, 호선) 단위 식별자라 멤버 단위로 비교.
                     const isThisBadgeHighlighted =
                       s.id === customOriginId ||
+                      s.id === destinationId ||
                       (group.isNearest && nearestStation?.id === s.id);
                     return (
                       <View
@@ -178,10 +178,11 @@ export function StationMap({
             testID="route-polyline"
           />
         )}
-        {routeCoords?.keyStations.map(({ station, role }) => {
-          const size = ROUTE_MARKER_SIZE[role];
-          const bg = role === 'transfer' ? station.lineColor : colors.accent;
-          return (
+        {/* 출발/도착역은 베이스 역 마커에서 customOriginId/destinationId로 강조 표시하므로
+            같은 좌표에 마커를 중복 렌더해서 클러스터링되지 않도록 환승역만 오버레이. */}
+        {routeCoords?.keyStations
+          .filter(({ role }) => role === 'transfer')
+          .map(({ station, role }) => (
             <Marker
               key={`route-${role}-${station.id}`}
               coordinate={{ latitude: station.lat, longitude: station.lng }}
@@ -194,18 +195,17 @@ export function StationMap({
                 style={[
                   styles.routeMarkerDot,
                   {
-                    width: size,
-                    height: size,
-                    borderRadius: size / 2,
-                    backgroundColor: bg,
+                    width: ROUTE_TRANSFER_MARKER_SIZE,
+                    height: ROUTE_TRANSFER_MARKER_SIZE,
+                    borderRadius: ROUTE_TRANSFER_MARKER_SIZE / 2,
+                    backgroundColor: station.lineColor,
                     borderColor: colors.bg,
                   },
                 ]}
                 testID={`route-marker-dot-${role}-${station.id}`}
               />
             </Marker>
-          );
-        })}
+          ))}
       </ClusteredMapView>
       {!mapReady && (
         <View style={styles.loading} testID="map-loading">

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -452,14 +452,14 @@ describe('StationMap', () => {
       expect(queryByTestId(`route-marker-origin-${mockStation.id}`)).toBeNull();
     });
 
-    it('routeCoords 전달 시 polyline + 출발/환승/도착 마커 렌더', () => {
-      const { getByTestId } = render(
+    it('routeCoords 전달 시 polyline + 환승 마커만 오버레이 (출발/도착은 베이스 마커 재사용)', () => {
+      const { getByTestId, queryByTestId } = render(
         <StationMap {...baseProps} routeCoords={routeCoords} />,
       );
       expect(getByTestId('route-polyline')).toBeTruthy();
-      expect(getByTestId(`route-marker-origin-${mockStation.id}`)).toBeTruthy();
       expect(getByTestId(`route-marker-transfer-${transferStation.id}`)).toBeTruthy();
-      expect(getByTestId(`route-marker-destination-${destStation.id}`)).toBeTruthy();
+      expect(queryByTestId(`route-marker-origin-${mockStation.id}`)).toBeNull();
+      expect(queryByTestId(`route-marker-destination-${destStation.id}`)).toBeNull();
     });
 
     it('routeCoords 전달 시 fitToCoordinates 호출', async () => {
@@ -480,7 +480,7 @@ describe('StationMap', () => {
       expect(__fitToCoordinatesMock).not.toHaveBeenCalled();
     });
 
-    it('환승 마커는 노선 색, 출발/도착 마커는 accent 색을 사용', () => {
+    it('환승 마커는 노선 색을 사용', () => {
       const { getByTestId } = render(
         <StationMap {...baseProps} routeCoords={routeCoords} />,
       );
@@ -490,9 +490,21 @@ describe('StationMap', () => {
           expect.objectContaining({ backgroundColor: transferStation.lineColor }),
         ]),
       );
-      const originDot = getByTestId(`route-marker-dot-origin-${mockStation.id}`);
-      expect(originDot.props.style).toEqual(
-        expect.arrayContaining([expect.objectContaining({ backgroundColor: '#C8553D' })]),
+    });
+
+    it('destinationId 전달 시 베이스 마커의 도착역 배지가 accent 색으로 강조', () => {
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearbyStations={[mockStation, destStation]}
+          destinationId={destStation.id}
+        />,
+      );
+      const destBadge = getByTestId(`badge-${destStation.id}`);
+      expect(destBadge.props.style).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ backgroundColor: '#C8553D' }),
+        ]),
       );
     });
   });


### PR DESCRIPTION
## Summary
- 지도 탭에서 경로 표시 시 출발/도착역에 마커가 2개로 보여 클러스터링되어 "2" 배지가 노출되던 버그 수정
- 베이스 역 마커 + 경로 오버레이 마커가 같은 좌표에 이중 렌더되던 구조를 제거
- 경로 오버레이는 환승역만 렌더, 출발/도착역은 베이스 마커의 accent 강조로 대체 (`destinationId` prop 신설)

Closes #455

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (1504/1504, 커버리지 100%)
- [ ] 실기기 지도 탭에서 경로 표시 시 출발/도착역에 "2" 클러스터 배지 사라졌는지 확인
- [ ] 환승역에서는 노선색 점이 그대로 표시되는지 확인
- [ ] 출발/도착역 배지가 accent 색으로 강조되는지 확인