### PR TITLE
fix(#458): DebugModal에 useSafeAreaInsets 직접 적용 (Modal portal 우회)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -20,6 +20,20 @@ const i18next = require('i18next');
 const { initReactI18next } = require('react-i18next');
 const { LANGUAGE_REGISTRY, FALLBACK_LANGUAGE } = require('./src/i18n/types');
 
+// react-native-safe-area-context 모킹: 컴포넌트 테스트가 SafeAreaProvider 없이도
+// useSafeAreaInsets / SafeAreaView를 호출할 수 있게. inset은 0(노치 없는 환경)으로 가정.
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const inset = { top: 0, right: 0, bottom: 0, left: 0 };
+  return {
+    SafeAreaProvider: ({ children }) => React.createElement(React.Fragment, null, children),
+    SafeAreaView: ({ children, ...props }) => React.createElement(View, props, children),
+    useSafeAreaInsets: () => inset,
+    useSafeAreaFrame: () => ({ x: 0, y: 0, width: 0, height: 0 }),
+  };
+});
+
 i18next.use(initReactI18next).init({
   compatibilityJSON: 'v4',
   resources: Object.fromEntries(

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -10,7 +10,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAppStore } from '../store/useAppStore';
 import { isDebugModalEnabled } from '../constants/debugFlags';
 import { useFusedNearestStation } from '../hooks/useFusedNearestStation';
@@ -183,6 +183,9 @@ export function DebugModal(props: DebugModalProps) {
 
 function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
   const { colors } = useTheme();
+  // #458: RN Modal 안에서는 SafeAreaView가 안 먹는다(portal로 inset 컨텍스트 분리).
+  // 루트 SafeAreaProvider의 insets를 hook으로 직접 받아 헤더에 manual padding.
+  const insets = useSafeAreaInsets();
   const {
     result,
     gpsResult,
@@ -281,12 +284,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
 
   return (
     <Modal visible animationType="slide" onRequestClose={onClose} testID="debug-modal">
-      {/* #458: Modal은 safe area를 자동 처리하지 않아 헤더가 노치 아래로 침범 → Close 터치 불가.
-          SafeAreaView로 top/left/right edge만 보호. bottom은 ScrollView contentContainer가 처리. */}
-      <SafeAreaView
-        edges={['top', 'left', 'right']}
-        style={[styles.container, { backgroundColor: colors.bg }]}
-      >
+      <View style={[styles.container, { backgroundColor: colors.bg, paddingTop: insets.top }]}>
         <View style={[styles.header, { borderBottomColor: colors.hair }]}>
           <Text style={[typography.bodySm, { color: colors.ink, fontWeight: '700' }]}>
             Subway debug
@@ -450,7 +448,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
             </TouchableOpacity>
           </View>
         </ScrollView>
-      </SafeAreaView>
+      </View>
     </Modal>
   );
 }


### PR DESCRIPTION
Closes #458 (재시도)

#459에서 SafeAreaView로 감쌌지만 RN Modal은 portal로 렌더돼 inset 측정이 0으로 잡힘 → 헤더 여전히 노치 침범. useSafeAreaInsets() 훅으로 루트 provider의 inset을 React context로 직접 받아 manual paddingTop 적용.

## Test plan
- [x] 1503 passed (jest.setup.js에 safe-area-context mock 추가)
- [x] type-check 통과
- [ ] (실기기) iPhone 13 mini에서 Close 버튼 터치 가능 확인