### PR TITLE
feat(#464): 현재역 도착정보를 trip 생성 전에도 표시 + 시간표 fallback

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -85,7 +85,7 @@ export default function HomeScreen() {
   const effectiveOrigin = customOrigin ?? result?.station ?? null;
   useTripOrigin(destination, effectiveOrigin, setTripOrigin);
   const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(
-    route ? (effectiveOrigin?.name ?? null) : null,
+    effectiveOrigin?.name ?? null,
   );
   const arrival = useArrivalCountdown(rawArrival);
   const isFav = effectiveOrigin ? favorites.some((f) => f.id === effectiveOrigin.id) : false;
@@ -512,17 +512,23 @@ export default function HomeScreen() {
               </View>
             )}
 
-            {/* Arrivals — 경로 선택된 경우에만 노출 */}
-            {route && (
+            {/* Arrivals — 현재역(effectiveOrigin)이 확정되면 trip 유무와 무관하게 노출 */}
+            {effectiveOrigin && (
               <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
                 <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('home.arrivalInfoTitle')}</Text>
                 {arrivalLoading && !arrival && (
                   <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.loading')}</Text>
                 )}
-                {arrivalIsMock && (
+                {arrival?.source === 'closed' ? (
+                  <Text style={[styles.mockNotice, { color: colors.muted }]}>{t('home.closedNotice')}</Text>
+                ) : arrival?.source === 'schedule' ? (
+                  <Text style={[styles.mockNotice, { color: colors.warn }]} testID="arrival-schedule-notice">
+                    {t('home.scheduleNotice')}
+                  </Text>
+                ) : arrivalIsMock ? (
                   <Text style={[styles.mockNotice, { color: colors.warn }]}>{t('home.mockNotice')}</Text>
-                )}
-                {arrival && (
+                ) : null}
+                {arrival && arrival.source !== 'closed' && (
                   <>
                     <ArrivalRow label={t('arrival.upbound')} items={arrival.up} />
                     <ArrivalRow label={t('arrival.downbound')} items={arrival.down} />

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -5,9 +5,14 @@ describe('fetchArrivalInfo', () => {
     jest.clearAllMocks();
     jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    // schedule fallback이 closed 시간대에 빈 배열을 반환하지 않도록 KST 15:00 평일로 고정.
+    // 내부 describe가 자신만의 setSystemTime을 호출하면 그게 우선한다.
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-18T06:00:00Z'));
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -370,6 +375,92 @@ describe('fetchArrivalInfo', () => {
 
       const result = await fetchArrivalInfo('강남');
       expect(result.isMock).toBe(true);
+    });
+  });
+
+  describe('schedule fallback', () => {
+    it('realtime 성공 시 source는 "realtime"', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          realtimeArrivalList: [
+            { trainLineNm: 'A', barvlDt: 60, btrainNo: 'T1', updnLine: '상행' },
+          ],
+        }),
+      } as Response);
+      const result = await fetchArrivalInfo('강남');
+      expect(result.source).toBe('realtime');
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    });
+
+    it('API 키 없음 + 알려진 역명이면 schedule fallback (source="schedule")', async () => {
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+      const result = await fetchArrivalInfo('강남');
+      expect(result.source).toBe('schedule');
+      expect(result.isMock).toBe(true);
+      expect(result.up.length).toBeGreaterThan(0);
+    });
+
+    it('HTTP 5xx + 알려진 역명이면 schedule fallback', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 } as Response);
+      const result = await fetchArrivalInfo('강남');
+      expect(result.source).toBe('schedule');
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    });
+
+    it('네트워크 에러 + 알려진 역명이면 schedule fallback', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockRejectedValue(new Error('net'));
+      const result = await fetchArrivalInfo('강남');
+      expect(result.source).toBe('schedule');
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    });
+
+    it('빈 응답 + 알려진 역명이면 schedule fallback', async () => {
+      process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY = 'test-key';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ realtimeArrivalList: [] }),
+      } as Response);
+      const result = await fetchArrivalInfo('강남');
+      expect(result.source).toBe('schedule');
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+    });
+
+    it('알 수 없는 역명이면 MOCK_ARRIVALS 최후 fallback (source 없음)', async () => {
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+      const result = await fetchArrivalInfo('존재하지않는역명12345');
+      expect(result.source).toBeUndefined();
+      expect(result.isMock).toBe(true);
+      expect(result.up).toEqual(MOCK_ARRIVALS.up);
+    });
+
+    it('역명은 알지만 headway 데이터 없는 노선이면 MOCK_ARRIVALS 최후 fallback', async () => {
+      // stations.json mocking 없이는 강제 케이스 만들기 어려우므로
+      // hasHeadwayData를 모킹해 line은 찾았지만 headway가 없는 분기를 검증.
+      jest.isolateModules(() => {
+        jest.doMock('../../utils/scheduleFallback', () => {
+          const actual = jest.requireActual('../../utils/scheduleFallback');
+          return { ...actual, hasHeadwayData: () => false };
+        });
+        const { fetchArrivalInfo: fn, MOCK_ARRIVALS: mock } = require('../arrivalApi');
+        delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+        return fn('강남').then((r: typeof mock) => {
+          expect(r.source).toBeUndefined();
+          expect(r.up).toEqual(mock.up);
+        });
+      });
+    });
+
+    it('closed 시간대(KST 03:00)에는 source="closed" + 빈 배열', async () => {
+      jest.setSystemTime(new Date('2026-05-18T18:00:00Z')); // KST 03:00 = 다음날 새벽
+      delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+      const result = await fetchArrivalInfo('강남');
+      expect(result.source).toBe('closed');
+      expect(result.up).toEqual([]);
+      expect(result.down).toEqual([]);
     });
   });
 

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -1,5 +1,7 @@
 import { createLogger } from '../utils/logger';
 import { parseTrainType, type TrainType } from '../constants/trainTypes';
+import { findLineByStationName } from '../utils/stationLookup';
+import { buildScheduleArrival, hasHeadwayData } from '../utils/scheduleFallback';
 
 const log = createLogger('arrivalApi');
 
@@ -22,10 +24,14 @@ export interface ArrivalInfo {
   trainType: TrainType;
 }
 
+export type ArrivalSource = 'realtime' | 'schedule' | 'closed';
+
 export interface StationArrival {
   up: ArrivalInfo[];
   down: ArrivalInfo[];
   isMock?: boolean;
+  /** 데이터 출처. UI 라벨 분기(시간표 기준 / 운행 종료)에 사용. */
+  source?: ArrivalSource;
 }
 
 export const MOCK_ARRIVALS: Readonly<StationArrival> = Object.freeze({
@@ -59,6 +65,27 @@ export function parseRecptnDt(recptnDt: unknown): number {
   return Number.isFinite(ms) ? ms : 0;
 }
 
+/**
+ * 실시간 API 실패 시 시간표 기반 fallback을 만든다.
+ * 역명으로 호선을 찾지 못하면(드문 케이스) 최후 수단으로 하드코딩 MOCK_ARRIVALS 반환.
+ * fallback 발생은 항상 로깅한다 — 후속 Option B(시간표 ETL) 필요성을 데이터로 판단하기 위함.
+ */
+function getFallbackArrival(stationName: string, reason: string): StationArrival {
+  const line = findLineByStationName(stationName);
+  if (!line || !hasHeadwayData(line)) {
+    log.warn('schedule_fallback_unavailable', { station: stationName, line, reason });
+    return MOCK_ARRIVALS;
+  }
+  const result = buildScheduleArrival(line, new Date());
+  log.info('schedule_fallback_fired', {
+    station: stationName,
+    line,
+    reason,
+    source: result.source,
+  });
+  return result;
+}
+
 export interface FetchArrivalOptions {
   timeoutMs?: number;
   maxPerDirection?: number;
@@ -73,7 +100,7 @@ export async function fetchArrivalInfo(
 
   if (!apiKey) {
     log.warn('API key not set (EXPO_PUBLIC_SEOUL_DATA_API_KEY)');
-    return MOCK_ARRIVALS;
+    return getFallbackArrival(stationName, 'no_api_key');
   }
 
   const controller = new AbortController();
@@ -84,7 +111,7 @@ export async function fetchArrivalInfo(
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
       log.warn(`HTTP ${response.status} for station "${stationName}"`);
-      return MOCK_ARRIVALS;
+      return getFallbackArrival(stationName, `http_${response.status}`);
     }
 
     const data = await response.json();
@@ -128,15 +155,19 @@ export async function fetchArrivalInfo(
       }
     }
 
-    const sliced = { up: up.slice(0, maxPerDirection), down: down.slice(0, maxPerDirection) };
+    const sliced: StationArrival = {
+      up: up.slice(0, maxPerDirection),
+      down: down.slice(0, maxPerDirection),
+      source: 'realtime',
+    };
     if (sliced.up.length === 0 && sliced.down.length === 0) {
       log.warn(`No arrivals for station "${stationName}"`);
-      return MOCK_ARRIVALS;
+      return getFallbackArrival(stationName, 'empty_response');
     }
     return sliced;
   } catch (e) {
     log.error(`Fetch failed for station "${stationName}":`, e);
-    return MOCK_ARRIVALS;
+    return getFallbackArrival(stationName, 'fetch_error');
   } finally {
     clearTimeout(timeout);
   }

--- a/src/data/lineHeadways.json
+++ b/src/data/lineHeadways.json
@@ -1,0 +1,67 @@
+{
+  "1": {
+    "weekday": { "peak": 180, "offPeak": 360, "late": 600 },
+    "saturday": { "peak": 420, "offPeak": 420, "late": 660 },
+    "sunday": { "peak": 480, "offPeak": 480, "late": 660 }
+  },
+  "2": {
+    "weekday": { "peak": 150, "offPeak": 270, "late": 480 },
+    "saturday": { "peak": 330, "offPeak": 330, "late": 540 },
+    "sunday": { "peak": 360, "offPeak": 360, "late": 540 }
+  },
+  "3": {
+    "weekday": { "peak": 210, "offPeak": 360, "late": 600 },
+    "saturday": { "peak": 420, "offPeak": 420, "late": 660 },
+    "sunday": { "peak": 480, "offPeak": 480, "late": 660 }
+  },
+  "4": {
+    "weekday": { "peak": 200, "offPeak": 360, "late": 600 },
+    "saturday": { "peak": 420, "offPeak": 420, "late": 660 },
+    "sunday": { "peak": 480, "offPeak": 480, "late": 660 }
+  },
+  "5": {
+    "weekday": { "peak": 210, "offPeak": 360, "late": 600 },
+    "saturday": { "peak": 420, "offPeak": 420, "late": 660 },
+    "sunday": { "peak": 480, "offPeak": 480, "late": 660 }
+  },
+  "6": {
+    "weekday": { "peak": 240, "offPeak": 420, "late": 720 },
+    "saturday": { "peak": 480, "offPeak": 480, "late": 780 },
+    "sunday": { "peak": 540, "offPeak": 540, "late": 780 }
+  },
+  "7": {
+    "weekday": { "peak": 210, "offPeak": 360, "late": 600 },
+    "saturday": { "peak": 420, "offPeak": 420, "late": 660 },
+    "sunday": { "peak": 480, "offPeak": 480, "late": 660 }
+  },
+  "8": {
+    "weekday": { "peak": 240, "offPeak": 480, "late": 720 },
+    "saturday": { "peak": 540, "offPeak": 540, "late": 780 },
+    "sunday": { "peak": 600, "offPeak": 600, "late": 780 }
+  },
+  "9": {
+    "weekday": { "peak": 240, "offPeak": 480, "late": 720 },
+    "saturday": { "peak": 540, "offPeak": 540, "late": 780 },
+    "sunday": { "peak": 600, "offPeak": 600, "late": 780 }
+  },
+  "airport": {
+    "weekday": { "peak": 360, "offPeak": 480, "late": 720 },
+    "saturday": { "peak": 540, "offPeak": 540, "late": 780 },
+    "sunday": { "peak": 600, "offPeak": 600, "late": 780 }
+  },
+  "gyeongui": {
+    "weekday": { "peak": 540, "offPeak": 900, "late": 1200 },
+    "saturday": { "peak": 1080, "offPeak": 1080, "late": 1320 },
+    "sunday": { "peak": 1200, "offPeak": 1200, "late": 1320 }
+  },
+  "bundang": {
+    "weekday": { "peak": 360, "offPeak": 540, "late": 900 },
+    "saturday": { "peak": 660, "offPeak": 660, "late": 1020 },
+    "sunday": { "peak": 720, "offPeak": 720, "late": 1020 }
+  },
+  "sinbundang": {
+    "weekday": { "peak": 270, "offPeak": 360, "late": 540 },
+    "saturday": { "peak": 420, "offPeak": 420, "late": 600 },
+    "sunday": { "peak": 480, "offPeak": 480, "late": 600 }
+  }
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -39,6 +39,8 @@
     "arrivalInfoTitle": "Train arrivals",
     "loading": "Loading...",
     "mockNotice": "Showing estimated data — real-time unavailable",
+    "scheduleNotice": "Schedule-based · loading real-time",
+    "closedNotice": "Service hours have ended",
     "noArrivalInfo": "No arrival info",
     "notNearStationTitle": "Not near a subway station",
     "notNearStationDescription": "Your current station appears when you are within 500m of a subway station.\nYou can also set the origin manually from the Map tab.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -39,6 +39,8 @@
     "arrivalInfoTitle": "列車到着情報",
     "loading": "読み込み中...",
     "mockNotice": "リアルタイムデータが取得できないため予想データを表示しています",
+    "scheduleNotice": "時刻表基準 · リアルタイム情報取得中",
+    "closedNotice": "運行終了時間帯です",
     "noArrivalInfo": "到着情報なし",
     "notNearStationTitle": "地下鉄駅の近くではありません",
     "notNearStationDescription": "地下鉄駅から500m以内にいるとき、現在駅が表示されます。\n地図タブで出発駅を手動で設定することもできます。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -39,6 +39,8 @@
     "arrivalInfoTitle": "열차 도착 정보",
     "loading": "불러오는 중...",
     "mockNotice": "실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다",
+    "scheduleNotice": "시간표 기준 · 실시간 정보 불러오는 중",
+    "closedNotice": "운행이 종료된 시간대입니다",
     "noArrivalInfo": "도착 정보 없음",
     "notNearStationTitle": "지하철역 근처가 아닙니다",
     "notNearStationDescription": "지하철역 500m 이내에 있을 때\n현재 역이 표시됩니다.\n지도 탭에서 출발역을 직접 설정할 수 있습니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -39,6 +39,8 @@
     "arrivalInfoTitle": "列车到达信息",
     "loading": "加载中...",
     "mockNotice": "无法获取实时数据,显示预测数据",
+    "scheduleNotice": "时刻表基准 · 正在加载实时信息",
+    "closedNotice": "已结束运营时段",
     "noArrivalInfo": "无到达信息",
     "notNearStationTitle": "附近没有地铁站",
     "notNearStationDescription": "当您距离地铁站500m以内时,会显示当前站。\n您也可以在地图标签页手动设置出发站。",

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -1,0 +1,144 @@
+import { classifyDayType, classifyPeriod, buildScheduleArrival, hasHeadwayData } from '../scheduleFallback';
+import type { LineNumber } from '../../types/station';
+
+describe('classifyDayType', () => {
+  it('returns sunday for Sunday', () => {
+    expect(classifyDayType(new Date('2026-05-17T10:00:00+09:00'))).toBe('sunday');
+  });
+  it('returns saturday for Saturday', () => {
+    expect(classifyDayType(new Date('2026-05-16T10:00:00+09:00'))).toBe('saturday');
+  });
+  it('returns weekday for Monday through Friday', () => {
+    expect(classifyDayType(new Date('2026-05-18T10:00:00+09:00'))).toBe('weekday'); // Mon
+    expect(classifyDayType(new Date('2026-05-22T10:00:00+09:00'))).toBe('weekday'); // Fri
+  });
+});
+
+describe('classifyPeriod', () => {
+  const make = (h: number, m: number) => {
+    const d = new Date('2026-05-18T00:00:00+09:00');
+    d.setHours(h, m, 0, 0);
+    return d;
+  };
+
+  it('returns closed between 01:00 and 05:30', () => {
+    expect(classifyPeriod(make(1, 0), 'weekday')).toBe('closed');
+    expect(classifyPeriod(make(3, 30), 'weekday')).toBe('closed');
+    expect(classifyPeriod(make(5, 29), 'weekday')).toBe('closed');
+  });
+
+  it('returns late between 22:00 and 01:00', () => {
+    expect(classifyPeriod(make(22, 0), 'weekday')).toBe('late');
+    expect(classifyPeriod(make(23, 59), 'weekday')).toBe('late');
+    expect(classifyPeriod(make(0, 30), 'weekday')).toBe('late');
+  });
+
+  it('returns peak on weekday morning/evening rush', () => {
+    expect(classifyPeriod(make(7, 0), 'weekday')).toBe('peak');
+    expect(classifyPeriod(make(9, 29), 'weekday')).toBe('peak');
+    expect(classifyPeriod(make(18, 0), 'weekday')).toBe('peak');
+    expect(classifyPeriod(make(19, 59), 'weekday')).toBe('peak');
+  });
+
+  it('returns offPeak on weekend during rush window', () => {
+    expect(classifyPeriod(make(8, 0), 'saturday')).toBe('offPeak');
+    expect(classifyPeriod(make(19, 0), 'sunday')).toBe('offPeak');
+  });
+
+  it('returns offPeak in regular daytime', () => {
+    expect(classifyPeriod(make(5, 30), 'weekday')).toBe('offPeak');
+    expect(classifyPeriod(make(10, 0), 'weekday')).toBe('offPeak');
+    expect(classifyPeriod(make(15, 30), 'weekday')).toBe('offPeak');
+    expect(classifyPeriod(make(21, 59), 'weekday')).toBe('offPeak');
+  });
+});
+
+describe('buildScheduleArrival', () => {
+  it('returns empty arrival with source=closed during closed hours', () => {
+    const now = new Date('2026-05-18T03:00:00+09:00');
+    const result = buildScheduleArrival('2', now);
+    expect(result.up).toEqual([]);
+    expect(result.down).toEqual([]);
+    expect(result.source).toBe('closed');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('returns 2 up/down trains during weekday peak with line 2 headway 150s', () => {
+    const now = new Date('2026-05-18T08:00:00+09:00');
+    const result = buildScheduleArrival('2', now);
+    expect(result.source).toBe('schedule');
+    expect(result.up).toHaveLength(2);
+    expect(result.down).toHaveLength(2);
+    expect(result.up[0].arrivalSeconds).toBe(75);
+    expect(result.up[1].arrivalSeconds).toBe(225);
+  });
+
+  it('uses offPeak headway during weekday daytime', () => {
+    const now = new Date('2026-05-18T15:00:00+09:00');
+    const result = buildScheduleArrival('1', now);
+    expect(result.source).toBe('schedule');
+    expect(result.up[0].arrivalSeconds).toBe(180); // 360/2
+  });
+
+  it('uses saturday offPeak even during what would be peak time', () => {
+    const now = new Date('2026-05-16T08:00:00+09:00'); // Saturday
+    const result = buildScheduleArrival('2', now);
+    expect(result.up[0].arrivalSeconds).toBe(165); // 330/2
+  });
+
+  it('falls back to offPeak headway if peak entry missing (weekend peak lookup is never triggered, but defensive)', () => {
+    const now = new Date('2026-05-18T08:00:00+09:00');
+    const result = buildScheduleArrival('gyeongui', now);
+    expect(result.source).toBe('schedule');
+    expect(result.up[0].arrivalSeconds).toBe(270); // 540/2
+  });
+
+  it('sets receivedAtMs to now.getTime()', () => {
+    const now = new Date('2026-05-18T15:00:00+09:00');
+    const result = buildScheduleArrival('2', now);
+    expect(result.up[0].receivedAtMs).toBe(now.getTime());
+  });
+
+  it('marks late period for 23:00 with late headway', () => {
+    const now = new Date('2026-05-18T23:00:00+09:00');
+    const result = buildScheduleArrival('2', now);
+    expect(result.source).toBe('schedule');
+    expect(result.up[0].arrivalSeconds).toBe(240); // 480/2
+  });
+
+  it('handles sunday late period', () => {
+    const now = new Date('2026-05-17T22:30:00+09:00');
+    const result = buildScheduleArrival('1', now);
+    expect(result.up[0].arrivalSeconds).toBe(330); // 660/2
+  });
+
+  it('arrivalMinutes equals floor(arrivalSeconds/60)', () => {
+    const now = new Date('2026-05-18T15:00:00+09:00');
+    const result = buildScheduleArrival('1', now);
+    expect(result.up[0].arrivalMinutes).toBe(3); // floor(180/60)
+  });
+
+  it('returns source=closed when line key is missing from headway table (defensive)', () => {
+    const now = new Date('2026-05-18T15:00:00+09:00');
+    // 알려지지 않은 미래 노선이 LineNumber에 추가됐지만 lineHeadways.json에 누락된 경우.
+    const result = buildScheduleArrival('gtx-a' as LineNumber, now);
+    expect(result.source).toBe('closed');
+    expect(result.up).toEqual([]);
+  });
+});
+
+describe('hasHeadwayData', () => {
+  it('returns true for all current LineNumber values', () => {
+    const lines: LineNumber[] = [
+      '1', '2', '3', '4', '5', '6', '7', '8', '9',
+      'airport', 'gyeongui', 'bundang', 'sinbundang',
+    ];
+    for (const line of lines) {
+      expect(hasHeadwayData(line)).toBe(true);
+    }
+  });
+
+  it('returns false for an unknown line', () => {
+    expect(hasHeadwayData('gtx-a' as LineNumber)).toBe(false);
+  });
+});

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -15,10 +15,11 @@ describe('classifyDayType', () => {
 });
 
 describe('classifyPeriod', () => {
+  // KST 절대시각을 ISO 문자열로 만들어 호스트 타임존에 의존하지 않게 한다 (CI는 UTC).
   const make = (h: number, m: number) => {
-    const d = new Date('2026-05-18T00:00:00+09:00');
-    d.setHours(h, m, 0, 0);
-    return d;
+    const hh = String(h).padStart(2, '0');
+    const mm = String(m).padStart(2, '0');
+    return new Date(`2026-05-18T${hh}:${mm}:00+09:00`);
   };
 
   it('returns closed between 01:00 and 05:30', () => {

--- a/src/utils/__tests__/stationLookup.test.ts
+++ b/src/utils/__tests__/stationLookup.test.ts
@@ -1,0 +1,21 @@
+import { findLineByStationName } from '../stationLookup';
+
+jest.mock('../../data/stations.json', () => [
+  { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
+  { id: '4-001', name: '서울역', line: '4', lineColor: '#00A5DE', lat: 0, lng: 0 },
+  { id: '2-001', name: '강남', line: '2', lineColor: '#00A84D', lat: 0, lng: 0 },
+]);
+
+describe('findLineByStationName', () => {
+  it('returns the line of the first matching station', () => {
+    expect(findLineByStationName('강남')).toBe('2');
+  });
+
+  it('returns the first registered line for transfer stations', () => {
+    expect(findLineByStationName('서울역')).toBe('1');
+  });
+
+  it('returns null for unknown station names', () => {
+    expect(findLineByStationName('없는역')).toBeNull();
+  });
+});

--- a/src/utils/scheduleFallback.ts
+++ b/src/utils/scheduleFallback.ts
@@ -1,0 +1,108 @@
+import type { LineNumber } from '../types/station';
+import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
+import headways from '../data/lineHeadways.json';
+
+export type DayType = 'weekday' | 'saturday' | 'sunday';
+export type Period = 'peak' | 'offPeak' | 'late' | 'closed';
+
+interface DayHeadway {
+  peak: number;
+  offPeak: number;
+  late: number;
+}
+
+type HeadwayTable = Record<LineNumber, Record<DayType, DayHeadway>>;
+
+const HEADWAYS = headways as HeadwayTable;
+
+/** 서울 지하철 운행시간 분류는 KST 고정. arrivalApi의 recptnDt 처리와 동일한 관례. */
+const SUBWAY_TIMEZONE = 'Asia/Seoul';
+
+interface KstParts {
+  weekday: string;
+  hour: number;
+  minute: number;
+}
+
+function getKstParts(date: Date): KstParts {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: SUBWAY_TIMEZONE,
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+  // Intl.DateTimeFormat은 요청한 옵션에 해당하는 part를 반드시 반환하므로 non-null 단언.
+  const lookup = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((p) => p.type === type)!.value;
+  // Safari가 자정에 'hour'를 '24'로 주는 경우를 % 24로 정규화.
+  const hour = Number.parseInt(lookup('hour'), 10) % 24;
+  const minute = Number.parseInt(lookup('minute'), 10);
+  return { weekday: lookup('weekday'), hour, minute };
+}
+
+export function classifyDayType(date: Date): DayType {
+  const { weekday } = getKstParts(date);
+  if (weekday === 'Sun') return 'sunday';
+  if (weekday === 'Sat') return 'saturday';
+  return 'weekday';
+}
+
+export function classifyPeriod(date: Date, dayType: DayType): Period {
+  const { hour, minute } = getKstParts(date);
+  const minutes = hour * 60 + minute;
+  // closed: 01:00 ~ 05:30
+  if (minutes >= 60 && minutes < 330) return 'closed';
+  // late: 22:00 ~ 24:00 + 00:00 ~ 01:00
+  if (minutes >= 22 * 60 || minutes < 60) return 'late';
+  // weekday peak: 07:00 ~ 09:30, 18:00 ~ 20:00
+  if (dayType === 'weekday') {
+    const inMorningPeak = minutes >= 7 * 60 && minutes < 9 * 60 + 30;
+    const inEveningPeak = minutes >= 18 * 60 && minutes < 20 * 60;
+    if (inMorningPeak || inEveningPeak) return 'peak';
+  }
+  return 'offPeak';
+}
+
+/** LineNumber 확장 시 lineHeadways.json에 키 누락 가능 — 무결성 정적 검증용. */
+export function hasHeadwayData(line: LineNumber): boolean {
+  return Number.isFinite(HEADWAYS[line]?.weekday?.offPeak);
+}
+
+function lookupHeadwaySeconds(line: LineNumber, dayType: DayType, period: Period): number | null {
+  if (period === 'closed') return null;
+  const value = HEADWAYS[line]?.[dayType]?.[period];
+  return Number.isFinite(value) ? value : null;
+}
+
+function makeTrain(secondsFromNow: number, suffix: string, nowMs: number): ArrivalInfo {
+  return {
+    destination: '',
+    arrivalMinutes: Math.max(0, Math.floor(secondsFromNow / 60)),
+    arrivalSeconds: secondsFromNow,
+    statusMessage: '',
+    trainCode: `SCHED-${suffix}`,
+    receivedAtMs: nowMs,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+  };
+}
+
+export function buildScheduleArrival(line: LineNumber, now: Date): StationArrival {
+  const dayType = classifyDayType(now);
+  const period = classifyPeriod(now, dayType);
+  const headway = lookupHeadwaySeconds(line, dayType, period);
+  const nowMs = now.getTime();
+
+  if (headway === null) {
+    return { up: [], down: [], isMock: true, source: 'closed' };
+  }
+
+  const first = Math.round(headway / 2);
+  const second = first + headway;
+  const up = [makeTrain(first, 'UP-1', nowMs), makeTrain(second, 'UP-2', nowMs)];
+  const down = [makeTrain(first, 'DN-1', nowMs), makeTrain(second, 'DN-2', nowMs)];
+
+  return { up, down, isMock: true, source: 'schedule' };
+}

--- a/src/utils/stationLookup.ts
+++ b/src/utils/stationLookup.ts
@@ -1,0 +1,14 @@
+import stationsData from '../data/stations.json';
+import type { LineNumber, Station } from '../types/station';
+
+const stations = stationsData as Station[];
+
+/**
+ * 역명으로 첫 매칭되는 호선을 반환한다.
+ * 환승역의 경우 stations.json 등록 순서상 첫 호선이 반환된다 — schedule fallback은
+ * trip 전 화면에서만 의미가 있으므로 단일 호선 기준 표시로 충분하다.
+ */
+export function findLineByStationName(name: string): LineNumber | null {
+  const match = stations.find((s) => s.name === name);
+  return match ? match.line : null;
+}


### PR DESCRIPTION
## Summary

- 현재역 도착정보를 trip(목적지 설정) 생성 전에도 노출 ( 게이트 제거)
- 실시간 API 4개 실패 경로 모두 noise한 random mock 대신 **노선별 headway 기반 schedule fallback**으로 통합
- `source: 'realtime' | 'schedule' | 'closed'` 필드로 UI 라벨 3-state 분기 (시간표 기준 / 운행 종료)
- `schedule_fallback_fired` 로깅으로 후속 "전체 시간표 ETL(Option B)" 필요성을 데이터로 판단할 수 있게 함
- KST 고정 분류 (Intl.DateTimeFormat, Asia/Seoul) — 해외 환경 안전
- LineNumber 확장(GTX 등 미래 노선) 시 데이터 누락 방어 (`hasHeadwayData` 가드)
- 4언어 i18n (ko/en/ja/zh)

Closes #464

## 원인 (Root Cause)

| # | 위치 | 문제 |
|---|---|---|
| R1 | `app/(tabs)/index.tsx:88` | `useArrivalInfo`가 `route ?` 게이트로 막혀 trip 없으면 API 호출 불가 |
| R2 | `app/(tabs)/index.tsx:516` | 도착정보 UI가 `{route &&}`로 게이트 |
| R3 | `src/api/arrivalApi.ts` | 실패 시 random MOCK_ARRIVALS(2/4/8/11분 가짜값) 반환 — 사용자가 거짓 도착시각 보고 행동 가능 |
| R4 | 전역 | fallback 발생 추적 불가 → 후속 의사결정 불가 |

## 검증

- `npm run type-check` ✅
- `npm test` — 1535/1535 통과, 커버리지 100%
- code-review 에이전트 P1 2건 반영 (KST 타임존 / 노선 데이터 누락 방어)

## Test plan

- [ ] CI: `Type Check & Test` 통과 확인
- [ ] iOS 실기기 — API 키 있는 환경에서 `source: 'realtime'` 정상 표시
- [ ] iOS 시뮬레이터 — API 키 제거 후 `source: 'schedule'` + "시간표 기준" 라벨 노출
- [ ] 새벽 시간대(KST 02~05시) — `source: 'closed'` + "운행 종료" 메시지
- [ ] trip 생성 전 홈 화면에서 도착정보 섹션 노출 확인
- [ ] trip 생성 후에도 기존 동작 정상 (Live Activity, 알람)

## 비-목표 / 후속

- 전체 시간표 API ETL (Option B) — 별도 후속 이슈
- 막차 알림 — 별도 후속 이슈
- 위젯/Live Activity의 source 분기 — 별도 후속
- code-review P2 (stationLookup line hint, ETA anchoring, favorites 화면 source 분기, ja/zh 번역 다듬기) — 별도 follow-up