### PR TITLE
fix(#462): firedAlarms cross-trip stale state로 인한 destination 알람 오발사

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -36,13 +36,11 @@ const mockGetLastNotifiedStationId = jest.fn();
 const mockSetLastNotifiedStationId = jest.fn();
 const mockGetFiredAlarms = jest.fn();
 const mockSetFiredAlarms = jest.fn();
-const mockClearFiredAlarms = jest.fn();
 jest.mock('../../utils/notificationState', () => ({
   getLastNotifiedStationId: (...args: unknown[]) => mockGetLastNotifiedStationId(...args),
   setLastNotifiedStationId: (...args: unknown[]) => mockSetLastNotifiedStationId(...args),
   getFiredAlarms: (...args: unknown[]) => mockGetFiredAlarms(...args),
   setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
-  clearFiredAlarms: (...args: unknown[]) => mockClearFiredAlarms(...args),
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -110,7 +108,6 @@ describe('useStationAlarm', () => {
     mockSetLastNotifiedStationId.mockResolvedValue(undefined);
     mockGetFiredAlarms.mockResolvedValue(new Set<string>());
     mockSetFiredAlarms.mockResolvedValue(undefined);
-    mockClearFiredAlarms.mockResolvedValue(undefined);
   });
 
   it('does not evaluate when route is null', () => {
@@ -386,7 +383,7 @@ describe('useStationAlarm', () => {
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
   });
 
-  it('resets fired alarms when destination changes', async () => {
+  it('destination 변경 시 새 destinationId로 re-hydrate 한다 (#462 destination scoped)', async () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(
@@ -394,14 +391,15 @@ describe('useStationAlarm', () => {
       { initialProps: { dest: destination } },
     );
     await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+    expect(mockGetFiredAlarms).toHaveBeenCalledWith(destination.id);
 
     const altEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '잠실' };
     mockEvaluateAlarmPhase.mockReturnValue(altEvent);
     rerender({ dest: altDestination });
     await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2));
     expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(altEvent, false, true);
-    // destination 변경 시 AsyncStorage의 firedAlarms도 클리어해 BG와 단일 출처를 유지한다.
-    expect(mockClearFiredAlarms).toHaveBeenCalled();
+    // destination 변경 → 새 id로 storage 재읽기 (저장된 entry는 옛 destinationId라 빈 set 반환 → 자동 isolation).
+    expect(mockGetFiredAlarms).toHaveBeenCalledWith(altDestination.id);
   });
 
   it('passes sleepMode to sendAlarmNotification', async () => {
@@ -836,45 +834,44 @@ describe('useStationAlarm', () => {
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
     });
 
-    it('FG에서 phase 발화 시 AsyncStorage에 setFiredAlarms로 동기화한다', async () => {
+    it('FG에서 phase 발화 시 setFiredAlarms(destinationId, set)로 동기화한다 (#462)', async () => {
       mockGetFiredAlarms.mockResolvedValueOnce(new Set());
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
 
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
 
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
-      expect(mockSetFiredAlarms).toHaveBeenCalledWith(
-        expect.any(Set),
-      );
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith(destination.id, expect.any(Set));
       // 발화된 alarmKey가 storage로 흘러갔는지 확인.
-      const lastCallArg = mockSetFiredAlarms.mock.calls.at(-1)?.[0] as Set<string>;
-      expect(lastCallArg.has(`early:${destination.name}`)).toBe(true);
-    });
-
-    it('destination 변경 시 AsyncStorage의 firedAlarms도 clear한다 (초기 바인드는 보존)', async () => {
-      // 첫 마운트 시 hydrate한 storage를 보존하기 위해 initial bind는 clear하지 않는다.
-      mockGetFiredAlarms.mockResolvedValueOnce(new Set([`early:${destination.name}`]));
-      const { rerender } = renderHook(
-        ({ dest }: { dest: Station }) =>
-          useStationAlarm(defaultInputs({ route, destination: dest })),
-        { initialProps: { dest: destination } },
-      );
-      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
-      // 초기 바인드는 clear 하지 않음 — BG 적재 firedAlarms 보존
-      expect(mockClearFiredAlarms).not.toHaveBeenCalled();
-
-      // 실제 변경(다른 destination)은 clear 한다
-      rerender({ dest: altDestination });
-      await waitFor(() => expect(mockClearFiredAlarms).toHaveBeenCalledTimes(1));
+      const lastCall = mockSetFiredAlarms.mock.calls.at(-1)!;
+      const lastSet = lastCall[1] as Set<string>;
+      expect(lastSet.has(`early:${destination.name}`)).toBe(true);
     });
 
     it('초기 바인드 시 BG가 적재한 firedAlarms를 보존한다 (storage clear 없음)', async () => {
       renderWithBgFired();
 
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
-      // BG 적재로 인해 evaluator가 null 반환 → 미발화. storage도 clear되지 않음.
+      // BG 적재로 인해 evaluator가 null 반환 → 미발화.
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
-      expect(mockClearFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it('destination 변경 직후 hydration 완료 전에는 evaluator가 호출되지 않는다 (race guard, #462)', async () => {
+      // hydration await 동안 effect가 phase 평가를 보류해야 한다.
+      let releaseHydration: (() => void) | undefined;
+      mockGetFiredAlarms.mockReturnValueOnce(
+        new Promise<Set<string>>((resolve) => {
+          releaseHydration = () => resolve(new Set());
+        }),
+      );
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      // hydration 미완료 상태에서 evaluator가 호출되면 안 됨.
+      await new Promise((r) => setImmediate(r));
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+
+      releaseHydration!();
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
     });
   });
 

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -12,7 +12,6 @@ import {
   setLastNotifiedStationId,
   getFiredAlarms,
   setFiredAlarms,
-  clearFiredAlarms,
 } from '../utils/notificationState';
 import { awaitInitialScheduledAlarmDrain } from '../utils/scheduledAlarmReceiver';
 import {
@@ -52,11 +51,11 @@ export function useStationAlarm({
   arrivalConfidence,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
-  const prevDestRef = useRef<string | null>(null);
   // firedAlarms hydration: BG가 AsyncStorage(FIRED_ALARMS_KEY)에 쓴 dedup 상태를
-  // FG 마운트 시 ref에 복원한다. hydrated=false인 동안 phase 평가를 보류해
+  // destination별로 격리해 복원한다(#462). hydrated=false인 동안 phase 평가를 보류해
   // 빈 ref로 false re-fire가 발생하지 않도록 가드한다.
   const [firedHydrated, setFiredHydrated] = useState(false);
+  const destinationId = destination?.id ?? null;
   const sleepMode = useAppStore((s) => s.sleepMode);
   const allowSpeaker = useAppStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
@@ -71,15 +70,17 @@ export function useStationAlarm({
     allowSpeakerRef.current = allowSpeaker;
   }, [allowSpeaker]);
 
-  // 마운트 시 한 번 — AsyncStorage에서 firedAlarms를 읽어 ref에 채운다.
-  // 이후 갱신은 destination 변경(클리어) / 발화(추가) 경로에서 동기적으로 처리.
+  // destination별 firedAlarms 하이드레이션 (#462).
+  // destination이 바뀌면 storage의 destinationId와 일치하지 않는 entry는 자동 빈 set 반환.
+  // → cross-trip stale state가 새 trip의 evaluator를 오염시키지 않는다.
   useEffect(() => {
     let cancelled = false;
+    setFiredHydrated(false);
     void (async () => {
       // 사전 예약 알람의 첫 drain이 완료된 후 read해야 cold start 직후
       // BG-fired 알람이 dedup set에 반영된 상태로 hydrate된다.
       await awaitInitialScheduledAlarmDrain();
-      const stored = await getFiredAlarms();
+      const stored = await getFiredAlarms(destinationId);
       if (cancelled) return;
       firedAlarmsRef.current = stored;
       setFiredHydrated(true);
@@ -87,28 +88,14 @@ export function useStationAlarm({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [destinationId]);
 
   // Phase 알람 효과: ETA 기반 phase 평가 + firedAlarms 갱신.
   // firedHydrated=false인 동안에는 보류 — BG가 이미 발화한 phase를 빈 ref로 재발화하는 것을 막는다.
   // station-passed와 분리: 하이드레이션 완료로 인한 effect 재실행이 station-passed 중복 발사를
   // 일으키지 않도록 한다(station-passed는 자체 lastNotifiedStationId dedup만 사용).
   useEffect(() => {
-    // 하이드레이션 전에는 destination 변경 감지를 건너뛴다 — 첫 마운트 시
-    // prevDestRef가 비어 있어 모든 destination이 "변경"으로 보이지만, 그때 storage를
-    // 클리어하면 BG가 써둔 firedAlarms hydration이 무의미해진다.
     if (!firedHydrated) return;
-
-    const destinationName = destination?.name ?? null;
-    if (destinationName !== prevDestRef.current) {
-      const isInitialBind = prevDestRef.current === null;
-      prevDestRef.current = destinationName;
-      if (!isInitialBind) {
-        firedAlarmsRef.current = new Set();
-        // AsyncStorage도 함께 비워 BG/FG 단일 출처를 유지한다.
-        void clearFiredAlarms();
-      }
-    }
 
     if (!route || !destination) return;
 
@@ -145,8 +132,8 @@ export function useStationAlarm({
         : undefined;
       const event = direction ? { ...rawEvent, direction } : rawEvent;
       firedAlarmsRef.current.add(alarmKey(event));
-      // AsyncStorage에도 즉시 반영 — FG/BG 단일 출처 유지.
-      void setFiredAlarms(firedAlarmsRef.current);
+      // AsyncStorage에도 즉시 반영 — FG/BG 단일 출처 유지. destinationId scoped.
+      void setFiredAlarms(destination.id, firedAlarmsRef.current);
       if (sleepModeRef.current) {
         setAlarmEvent(event);
       }

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -2,7 +2,8 @@ import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Station } from '../types/station';
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY } from '../constants/storageKeys';
+import { clearFiredAlarms } from '../utils/notificationState';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
 
@@ -103,7 +104,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station)).catch(noop);
     } else {
       AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
-      AsyncStorage.removeItem(FIRED_ALARMS_KEY).catch(noop);
+      clearFiredAlarms().catch(noop);
       AsyncStorage.removeItem(ROUTE_KEY).catch(noop);
     }
   },

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -32,6 +32,14 @@ jest.mock('../../utils/stationAlarm', () => ({
   alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
 }));
 
+// ── notificationState 모킹 (firedAlarms는 destination scoped, #462) ──
+const mockGetFiredAlarms = jest.fn();
+const mockSetFiredAlarms = jest.fn();
+jest.mock('../../utils/notificationState', () => ({
+  getFiredAlarms: (...args: unknown[]) => mockGetFiredAlarms(...args),
+  setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
+}));
+
 // ── alarmLog 모킹 ──
 const mockLogSuppressedGate = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
@@ -101,19 +109,18 @@ function getTaskCallback(): TaskCallback {
   return (global as any).__bgTaskCallback as TaskCallback;
 }
 
-/** AsyncStorage.getItem 5개를 순서대로 모킹한다 (dest, sleep, fired, route, allowSpeaker)
+/** AsyncStorage.getItem 4개를 순서대로 모킹한다 (dest, sleep, route, allowSpeaker)
+ *  firedAlarms는 notificationState helper로 분리되어 별도 mockGetFiredAlarms로 제어한다.
  *  lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈로 read/write 한다. */
 function mockStorageValues(
   dest: string | null,
   sleep: string | null = null,
-  fired: string | null = null,
   route: string | null = null,
   allowSpeaker: string | null = null,
 ): void {
   (AsyncStorage.getItem as jest.Mock)
     .mockResolvedValueOnce(dest)
     .mockResolvedValueOnce(sleep)
-    .mockResolvedValueOnce(fired)
     .mockResolvedValueOnce(route)
     .mockResolvedValueOnce(allowSpeaker);
 }
@@ -135,6 +142,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     jest.clearAllMocks();
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    mockGetFiredAlarms.mockResolvedValue(new Set());
+    mockSetFiredAlarms.mockResolvedValue(undefined);
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
   });
 
@@ -243,7 +252,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── allowSpeaker 파싱 ──
 
   it("allowSpeakerJson이 'false'이면 allowSpeaker=false로 processLocationUpdate를 호출한다", async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'false');
+    mockStorageValues(JSON.stringify(mockDestination), null, null, 'false');
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
@@ -258,7 +267,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   });
 
   it("allowSpeakerJson이 'true'이면 allowSpeaker=true로 processLocationUpdate를 호출한다", async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, null, 'true');
+    mockStorageValues(JSON.stringify(mockDestination), null, null, 'true');
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
@@ -274,9 +283,10 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   // ── firedAlarms 파싱 ──
 
-  it('firedJson이 있으면 파싱한 Set을 processLocationUpdate에 전달한다', async () => {
+  it('notificationState.getFiredAlarms(destinationId)로 읽어 processLocationUpdate에 전달한다 (#462)', async () => {
     const fired = ['destination:강남', 'transfer:시청'];
-    mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(fired));
+    mockStorageValues(JSON.stringify(mockDestination));
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set(fired));
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
@@ -285,6 +295,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
+    expect(mockGetFiredAlarms).toHaveBeenCalledWith(mockDestination.id);
     expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
       firedAlarms: new Set(fired),
     }));
@@ -307,7 +318,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('routeJson이 있으면 파싱한 route를 processLocationUpdate에 전달한다', async () => {
     const storedRoute = { type: 'direct', stops: 3, line: '2' };
-    mockStorageValues(JSON.stringify(mockDestination), null, null, JSON.stringify(storedRoute));
+    mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(storedRoute));
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
 
@@ -338,7 +349,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   // ── alarmEvent 있음: firedAlarms 저장 ──
 
-  it('alarmEvent가 있으면 alarmKey를 추가하고 AsyncStorage.setItem을 호출한다', async () => {
+  it('alarmEvent가 있으면 alarmKey를 추가하고 setFiredAlarms(destId, set)를 호출한다 (#462)', async () => {
     const alarmEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '시청' };
     mockStorageValues(JSON.stringify(mockDestination));
 
@@ -354,9 +365,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     });
 
     expect(mockAlarmKey).toHaveBeenCalledWith(alarmEvent);
-    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-      'subway-now:fired-alarms',
-      JSON.stringify(['destination:시청']),
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith(
+      mockDestination.id,
+      new Set(['destination:시청']),
     );
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:alarm-event',
@@ -366,8 +377,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('기존 firedAlarms에 alarmEvent 키를 추가하여 저장한다', async () => {
     const alarmEvent: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '강남' };
-    const existingFired = ['destination:시청'];
-    mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(existingFired));
+    mockStorageValues(JSON.stringify(mockDestination));
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set(['destination:시청']));
 
     mockProcessLocationUpdate.mockResolvedValue({
       alarmEvent,
@@ -380,9 +391,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       error: null,
     });
 
-    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-      'subway-now:fired-alarms',
-      JSON.stringify(['destination:시청', 'transfer:강남']),
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith(
+      mockDestination.id,
+      new Set(['destination:시청', 'transfer:강남']),
     );
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:alarm-event',
@@ -401,6 +412,18 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     });
 
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  it('destination에 id가 없으면 즉시 return한다 (#462)', async () => {
+    mockStorageValues(JSON.stringify({ name: '시청' }));
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    expect(mockGetFiredAlarms).not.toHaveBeenCalled();
   });
 
   // ── 마지막 location 선택 ──
@@ -430,10 +453,10 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   // 게이트 drop 시 destination/sleep/route 등 도메인 키는 절대 읽지 않는다.
   // (ALARM_LOG_KEY는 적재용으로 정상 read/write 됨 — B2 인프라)
+  // firedAlarms는 notificationState helper로 분리됐으므로 mockGetFiredAlarms 호출 여부로 검증.
   const DOMAIN_KEYS = [
     'subway-now:destination',
     'subway-now:sleep-mode',
-    'subway-now:fired-alarms',
     'subway-now:route',
     'subway-now:allow-speaker',
   ];

--- a/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -125,10 +125,29 @@ interface BgRunOptions {
   accuracy?: number | null;
 }
 
+// firedAlarms 저장 포맷(#462): { destinationId, alarms } — destination scoped.
+// 다른 destinationId가 저장돼 있으면 빈 set으로 간주하는 헬퍼 — 실제 production read 동작과 일치.
+function readFiredForDestination(destinationId: string): Set<string> {
+  const raw = mockStorage.get(FIRED_ALARMS_KEY);
+  if (!raw) return new Set();
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.destinationId === destinationId && Array.isArray(parsed.alarms)) {
+      return new Set(parsed.alarms);
+    }
+  } catch {
+    // ignore
+  }
+  return new Set();
+}
+
+function writeFiredForDestination(destinationId: string, alarms: Set<string>): void {
+  mockStorage.set(FIRED_ALARMS_KEY, JSON.stringify({ destinationId, alarms: [...alarms] }));
+}
+
 async function runFgPipelineAt(station: typeof fakeStation) {
   mockFindNearestStation.mockReturnValueOnce({ station, distanceKm: NEAR_STATION_KM });
-  const firedJson = mockStorage.get(FIRED_ALARMS_KEY);
-  const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
+  const firedAlarms = readFiredForDestination(fakeDestination.id);
   const result = await processLocationUpdate({
     lat: station.lat,
     lng: station.lng,
@@ -141,7 +160,7 @@ async function runFgPipelineAt(station: typeof fakeStation) {
   // 이 round-trip이 BG와의 dedup 단일 출처가 된다.
   if (result.alarmEvent) {
     firedAlarms.add(alarmKey(result.alarmEvent));
-    mockStorage.set(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms]));
+    writeFiredForDestination(fakeDestination.id, firedAlarms);
   }
   return result;
 }

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -4,10 +4,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from '../utils/stationPipeline';
 import { alarmKey } from '../utils/stationAlarm';
 import { createLogger } from '../utils/logger';
-import { DESTINATION_KEY, SLEEP_MODE_KEY, FIRED_ALARMS_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
+import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
 import { logSuppressedGate } from '../utils/alarmLog';
 import type { Route } from '../utils/stationRoute';
+import type { Station } from '../types/station';
 
 const logger = createLogger('BackgroundLocation');
 
@@ -44,10 +46,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const speedMps = speed != null && speed >= 0 ? speed : null;
 
   try {
-    const [destJson, sleepJson, firedJson, routeJson, allowSpeakerJson] = await Promise.all([
+    const [destJson, sleepJson, routeJson, allowSpeakerJson] = await Promise.all([
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(SLEEP_MODE_KEY),
-      AsyncStorage.getItem(FIRED_ALARMS_KEY),
       AsyncStorage.getItem(ROUTE_KEY),
       AsyncStorage.getItem(ALLOW_SPEAKER_KEY),
     ]);
@@ -57,16 +58,28 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       return;
     }
 
-    let destination;
+    let destinationRaw: unknown;
     try {
-      destination = JSON.parse(destJson);
+      destinationRaw = JSON.parse(destJson);
     } catch {
       logger.error('목적지 JSON 파싱 실패');
       return;
     }
+    // destinationId 누락 시 trip 식별 불가 → 처리 중단. 정상 trip은 항상 id를 갖는다.
+    if (
+      !destinationRaw ||
+      typeof destinationRaw !== 'object' ||
+      typeof (destinationRaw as { id?: unknown }).id !== 'string'
+    ) {
+      logger.error('목적지에 id가 없음');
+      return;
+    }
+    // 런타임 검증은 id 존재만 확인. Station 나머지 필드는 production write 시점에서 보장된다.
+    const destination = destinationRaw as Station;
     const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
     const allowSpeaker = allowSpeakerJson ? JSON.parse(allowSpeakerJson) === true : true;
-    const firedAlarms = new Set<string>(firedJson ? JSON.parse(firedJson) : []);
+    // destinationId scoped — 이전 trip의 stale entry는 빈 set으로 반환된다(#462).
+    const firedAlarms = await getFiredAlarms(destination.id);
     const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
 
     // lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈을 통해
@@ -86,7 +99,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     if (alarmEvent) {
       firedAlarms.add(alarmKey(alarmEvent));
       await Promise.all([
-        AsyncStorage.setItem(FIRED_ALARMS_KEY, JSON.stringify([...firedAlarms])),
+        setFiredAlarms(destination.id, firedAlarms),
         AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
       ]);
     }

--- a/src/utils/__tests__/notificationState.test.ts
+++ b/src/utils/__tests__/notificationState.test.ts
@@ -94,20 +94,39 @@ describe('notificationState', () => {
     });
   });
 
-  describe('getFiredAlarms', () => {
-    it('AsyncStorage에서 FIRED_ALARMS_KEY를 JSON 배열로 읽어 Set으로 반환한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(['a:X', 'b:Y']));
+  describe('getFiredAlarms (destination scoped, #462)', () => {
+    it('저장된 destinationId와 일치하면 alarms를 Set으로 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ destinationId: 'dest-1', alarms: ['a:X', 'b:Y'] }),
+      );
 
-      const result = await getFiredAlarms();
+      const result = await getFiredAlarms('dest-1');
 
       expect(AsyncStorage.getItem).toHaveBeenCalledWith(FIRED_ALARMS_KEY);
       expect(result).toEqual(new Set(['a:X', 'b:Y']));
     });
 
+    it('저장된 destinationId와 다르면 stale로 간주하고 빈 Set을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ destinationId: 'dest-1', alarms: ['a:X'] }),
+      );
+
+      const result = await getFiredAlarms('dest-2');
+
+      expect(result).toEqual(new Set());
+    });
+
+    it('destinationId가 null이면 빈 Set을 반환한다 (storage read 스킵)', async () => {
+      const result = await getFiredAlarms(null);
+
+      expect(result).toEqual(new Set());
+      expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    });
+
     it('null 저장소면 빈 Set을 반환한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
 
-      const result = await getFiredAlarms();
+      const result = await getFiredAlarms('dest-1');
 
       expect(result).toEqual(new Set());
     });
@@ -115,15 +134,15 @@ describe('notificationState', () => {
     it('JSON 파싱 실패 시 빈 Set을 반환한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
 
-      const result = await getFiredAlarms();
+      const result = await getFiredAlarms('dest-1');
 
       expect(result).toEqual(new Set());
     });
 
-    it('파싱은 됐지만 배열이 아니면 빈 Set을 반환한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
+    it('옛 포맷(배열)은 stale로 간주하고 빈 Set을 반환한다 (자동 migration)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(['a:X', 'b:Y']));
 
-      const result = await getFiredAlarms();
+      const result = await getFiredAlarms('dest-1');
 
       expect(result).toEqual(new Set());
     });
@@ -131,30 +150,31 @@ describe('notificationState', () => {
     it('AsyncStorage가 에러를 던지면 빈 Set을 반환한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
-      const result = await getFiredAlarms();
+      const result = await getFiredAlarms('dest-1');
 
       expect(result).toEqual(new Set());
     });
   });
 
-  describe('setFiredAlarms', () => {
-    it('Set을 JSON 배열로 직렬화해 FIRED_ALARMS_KEY로 저장한다', async () => {
+  describe('setFiredAlarms (destination scoped, #462)', () => {
+    it('destinationId와 alarms를 객체로 직렬화해 저장한다', async () => {
       (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
 
-      await setFiredAlarms(new Set(['a:X', 'b:Y']));
+      await setFiredAlarms('dest-1', new Set(['a:X', 'b:Y']));
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(
         FIRED_ALARMS_KEY,
         expect.any(String),
       );
       const written = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
-      expect(new Set(written)).toEqual(new Set(['a:X', 'b:Y']));
+      expect(written.destinationId).toBe('dest-1');
+      expect(new Set(written.alarms)).toEqual(new Set(['a:X', 'b:Y']));
     });
 
     it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
       (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
-      await expect(setFiredAlarms(new Set(['a:X']))).resolves.toBeUndefined();
+      await expect(setFiredAlarms('dest-1', new Set(['a:X']))).resolves.toBeUndefined();
     });
   });
 

--- a/src/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -1,9 +1,14 @@
 import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppState } from 'react-native';
 
 jest.mock('expo-notifications', () => ({
   addNotificationReceivedListener: jest.fn(),
   getPresentedNotificationsAsync: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
 }));
 
 jest.mock('../notificationState', () => ({
@@ -38,6 +43,9 @@ const mockSetFiredAlarms = setFiredAlarms as jest.Mock;
 const mockSetLastFiredAlarmStationName = setLastFiredAlarmStationName as jest.Mock;
 const mockAddListener = Notifications.addNotificationReceivedListener as jest.Mock;
 const mockGetPresented = Notifications.getPresentedNotificationsAsync as jest.Mock;
+const mockAsyncGetItem = AsyncStorage.getItem as jest.Mock;
+
+const DEST_JSON = JSON.stringify({ id: 'dest-1', name: '강남' });
 
 function flushAsync(): Promise<void> {
   return new Promise((r) => setImmediate(r));
@@ -52,6 +60,7 @@ beforeEach(async () => {
   mockSetFiredAlarms.mockResolvedValue(undefined);
   mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
   mockGetPresented.mockResolvedValue([]);
+  mockAsyncGetItem.mockResolvedValue(DEST_JSON);
   // 기본 AppState 스파이 — 각 테스트는 mockImplementationOnce로 추가 override 가능.
   appStateSpy = jest
     .spyOn(AppState, 'addEventListener')
@@ -72,6 +81,7 @@ beforeEach(async () => {
   mockSetFiredAlarms.mockResolvedValue(undefined);
   mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
   mockGetPresented.mockResolvedValue([]);
+  mockAsyncGetItem.mockResolvedValue(DEST_JSON);
   // 모든 케이스 공통: addNotificationReceivedListener 기본 핸들. 콜백 캡쳐가 필요한 케이스는 mockImplementationOnce로 override.
   mockAddListener.mockReturnValue({ remove: jest.fn() });
 });
@@ -97,7 +107,36 @@ describe('reconcileScheduledAlarmDelivery', () => {
 
     await reconcileScheduledAlarmDelivery('alarm:early:강남');
 
-    expect(mockSetFiredAlarms).toHaveBeenCalledWith(new Set(['early:시청', 'early:강남']));
+    expect(mockGetFiredAlarms).toHaveBeenCalledWith('dest-1');
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:시청', 'early:강남']));
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+  });
+
+  it('destination 미설정(trip 종료)이면 firedAlarms는 갱신하지 않고 lastStationName만 갱신한다 (#462)', async () => {
+    mockAsyncGetItem.mockResolvedValueOnce(null);
+
+    await reconcileScheduledAlarmDelivery('alarm:early:강남');
+
+    expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+  });
+
+  it('destination JSON 파싱 실패도 firedAlarms 갱신 스킵 처리한다', async () => {
+    mockAsyncGetItem.mockResolvedValueOnce('not-json');
+
+    await reconcileScheduledAlarmDelivery('alarm:early:강남');
+
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+  });
+
+  it('destination JSON에 id 필드가 없으면 firedAlarms 갱신 스킵', async () => {
+    mockAsyncGetItem.mockResolvedValueOnce(JSON.stringify({ name: '강남' }));
+
+    await reconcileScheduledAlarmDelivery('alarm:early:강남');
+
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
     expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
   });
 });
@@ -123,9 +162,9 @@ describe('registerScheduledAlarmListener', () => {
     await awaitInitialScheduledAlarmDrain();
     await flushAsync();
 
-    expect(mockGetFiredAlarms).toHaveBeenCalledTimes(1);
+    expect(mockGetFiredAlarms).toHaveBeenCalledWith('dest-1');
     expect(mockSetFiredAlarms).toHaveBeenCalledTimes(1);
-    expect(mockSetFiredAlarms).toHaveBeenCalledWith(new Set(['early:강남', 'imminent:강남']));
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남', 'imminent:강남']));
     expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledTimes(1);
     expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
 
@@ -167,7 +206,25 @@ describe('registerScheduledAlarmListener', () => {
     const handle = registerScheduledAlarmListener();
     await flushAsync();
 
-    expect(mockSetFiredAlarms).toHaveBeenCalledWith(new Set(['imminent:시청']));
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['imminent:시청']));
+    expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('시청');
+
+    handle.remove();
+  });
+
+  it('destinationId 미설정이면 drain은 fired set 갱신을 스킵하고 lastStationName만 갱신한다 (#462)', async () => {
+    mockAsyncGetItem.mockResolvedValue(null);
+    mockGetPresented.mockResolvedValueOnce([
+      { request: { identifier: 'current-station' } },
+      { request: { identifier: 'alarm:early:강남' } },
+      { request: { identifier: 'alarm:imminent:시청' } },
+    ]);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
     expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('시청');
 
     handle.remove();

--- a/src/utils/notificationState.ts
+++ b/src/utils/notificationState.ts
@@ -54,20 +54,42 @@ export function clearLastNotifiedStationId(): Promise<void> {
 // firedAlarms: 알람 phase 중복 발화 dedup 단일 출처.
 // Foreground 훅(useStationAlarm)과 Background task(backgroundLocationTask)가
 // 같은 키를 공유해, BG fired 알람이 FG 복귀 후 재발화되지 않도록 한다.
-export async function getFiredAlarms(): Promise<Set<string>> {
+//
+// #462: destinationId로 entry를 격리해 cross-trip leak을 차단한다. 저장 포맷은
+// `{ destinationId, alarms }` 객체. read 시점 destinationId가 저장된 것과 다르면
+// stale로 간주하고 빈 set을 반환한다. destinationId가 null이면 항상 빈 set.
+interface FiredAlarmsRecord {
+  destinationId: string;
+  alarms: string[];
+}
+
+function isFiredAlarmsRecord(value: unknown): value is FiredAlarmsRecord {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as FiredAlarmsRecord).destinationId === 'string' &&
+    Array.isArray((value as FiredAlarmsRecord).alarms)
+  );
+}
+
+export async function getFiredAlarms(destinationId: string | null): Promise<Set<string>> {
+  if (!destinationId) return new Set();
   const raw = await safeGetItem(FIRED_ALARMS_KEY);
   if (!raw) return new Set();
   try {
-    const parsed = JSON.parse(raw);
-    return new Set(Array.isArray(parsed) ? parsed : []);
+    const parsed: unknown = JSON.parse(raw);
+    if (!isFiredAlarmsRecord(parsed)) return new Set();
+    if (parsed.destinationId !== destinationId) return new Set();
+    return new Set(parsed.alarms);
   } catch (e) {
     logger.error(`${FIRED_ALARMS_KEY} 파싱 실패:`, e);
     return new Set();
   }
 }
 
-export function setFiredAlarms(keys: Set<string>): Promise<void> {
-  return safeSetItem(FIRED_ALARMS_KEY, JSON.stringify([...keys]));
+export function setFiredAlarms(destinationId: string, keys: Set<string>): Promise<void> {
+  const record: FiredAlarmsRecord = { destinationId, alarms: [...keys] };
+  return safeSetItem(FIRED_ALARMS_KEY, JSON.stringify(record));
 }
 
 export function clearFiredAlarms(): Promise<void> {

--- a/src/utils/scheduledAlarmReceiver.ts
+++ b/src/utils/scheduledAlarmReceiver.ts
@@ -1,4 +1,5 @@
 import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppState, type AppStateStatus } from 'react-native';
 import { parseScheduledAlarmIdentifier } from './alarmScheduler';
 import {
@@ -6,9 +7,25 @@ import {
   setFiredAlarms,
   setLastFiredAlarmStationName,
 } from './notificationState';
+import { DESTINATION_KEY } from '../constants/storageKeys';
 import { createLogger } from './logger';
 
 const logger = createLogger('ScheduledAlarmReceiver');
+
+/**
+ * 현재 trip의 destinationId를 AsyncStorage에서 읽는다. firedAlarms를 destinationId로
+ * 격리하기 위해(#462) 발화 reconcile 시점에 필요하다. 파싱 실패 또는 미설정이면 null.
+ */
+async function getCurrentDestinationId(): Promise<string | null> {
+  const raw = await AsyncStorage.getItem(DESTINATION_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.id === 'string' ? parsed.id : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * 사전 예약된 `alarm:` 알림이 OS에 의해 발사된 직후 클라이언트 상태를 갱신한다.
@@ -24,9 +41,14 @@ export async function reconcileScheduledAlarmDelivery(identifier: string): Promi
   const parsed = parseScheduledAlarmIdentifier(identifier);
   if (!parsed) return;
 
-  const fired = await getFiredAlarms();
-  fired.add(`${parsed.phaseId}:${parsed.stationName}`);
-  await setFiredAlarms(fired);
+  const destinationId = await getCurrentDestinationId();
+  // destinationId가 없으면 이미 trip이 종료/변경된 알람의 잔여 발화 — 상태 갱신 스킵.
+  // setLastFiredAlarmStationName은 trip 종속성이 약하므로 유지한다(다음 사이클 기준역 갱신용).
+  if (destinationId) {
+    const fired = await getFiredAlarms(destinationId);
+    fired.add(`${parsed.phaseId}:${parsed.stationName}`);
+    await setFiredAlarms(destinationId, fired);
+  }
   await setLastFiredAlarmStationName(parsed.stationName);
 }
 
@@ -43,20 +65,29 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
     return;
   }
 
-  const fired = await getFiredAlarms();
+  const destinationId = await getCurrentDestinationId();
   let lastStationName: string | null = null;
-  let firedChanged = false;
-  for (const n of presented) {
-    const parsed = parseScheduledAlarmIdentifier(n.request.identifier);
-    if (!parsed) continue;
-    const key = `${parsed.phaseId}:${parsed.stationName}`;
-    if (!fired.has(key)) {
-      fired.add(key);
-      firedChanged = true;
+  if (destinationId) {
+    const fired = await getFiredAlarms(destinationId);
+    let firedChanged = false;
+    for (const n of presented) {
+      const parsed = parseScheduledAlarmIdentifier(n.request.identifier);
+      if (!parsed) continue;
+      const key = `${parsed.phaseId}:${parsed.stationName}`;
+      if (!fired.has(key)) {
+        fired.add(key);
+        firedChanged = true;
+      }
+      lastStationName = parsed.stationName;
     }
-    lastStationName = parsed.stationName;
+    if (firedChanged) await setFiredAlarms(destinationId, fired);
+  } else {
+    // destinationId 미설정 — fired set 갱신은 스킵하고 lastStationName만 추출.
+    for (const n of presented) {
+      const parsed = parseScheduledAlarmIdentifier(n.request.identifier);
+      if (parsed) lastStationName = parsed.stationName;
+    }
   }
-  if (firedChanged) await setFiredAlarms(fired);
   if (lastStationName) await setLastFiredAlarmStationName(lastStationName);
 }
 


### PR DESCRIPTION
## Summary
경로 시작 직후 destination imminent 알람("신사에서 내리세요")이 즉시 발사되는 버그 해결.

**근본 원인**: firedAlarms가 destinationId 없이 저장되어 trip 간 stale state가 evaluator의 anyFired 체크를 오염시킴. 이전 trip에서 fire된 transfer 엔트리가 새 trip의 transfer name과 우연히 매치되거나, 또는 destination이 1정거장(stopsFromTransfer=1) 떨어진 경우 evaluator가 즉시 early phase를 trigger.

**해결**: AsyncStorage 저장 포맷을 `{ destinationId, alarms }` 객체로 변경 — read 시점 destinationId 불일치 시 빈 set 반환해 storage layer에서 자동 trip isolation.

- `getFiredAlarms`/`setFiredAlarms` 시그니처에 destinationId 추가
- `useStationAlarm`: destinationId 의존성으로 hydration. `prevDestRef`/`isInitialBind` 가드 제거
- `backgroundLocationTask`, `scheduledAlarmReceiver`: destinationId 검증 후 fired set 처리
- `useAppStore`: trip 종료 시 `clearFiredAlarms` helper 사용
- 옛 배열 포맷은 자동 stale 처리 → 마이그레이션 불필요

Closes #462

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (1511/1511, 커버리지 100%)
- [x] race guard 테스트 추가: destination 변경 직후 hydration 완료 전 phase 평가 보류 검증
- [x] 실기기에서 경로 시작 직후 destination 알람이 즉시 발사되지 않는지 확인
- [x] 같은 trip 내 BG→FG 전환 시 BG fired 알람이 FG에서 dedup되는지 확인 (회귀 방지)
- [x] 다른 destination으로 변경 후 새 trip 시작 시 stale 알람 영향 없는지 확인