### PR TITLE
feat(#470): ArrivalSourceNotice 컴포넌트 + favorites source 분기

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -18,6 +18,8 @@ import { formatArrivalTime } from '../../src/utils/formatTime';
 import { getStationDisplayName, matchesStationQuery } from '../../src/utils/stationDisplay';
 import { useTheme, type ThemeColors } from '../../src/theme';
 import stationsData from '../../src/data/stations.json';
+import { ArrivalSourceNotice } from '../../src/components/ArrivalSourceNotice';
+import type { StationArrival } from '../../src/api/arrivalApi';
 
 const allStations = stationsData as Station[];
 
@@ -39,7 +41,10 @@ export default function FavoritesScreen() {
     () => favorites.find((f) => f.id === selectedId) ?? null,
     [favorites, selectedId],
   );
-  const { arrival: rawArrival } = useArrivalInfo(selectedStation?.name ?? null);
+  const { arrival: rawArrival } = useArrivalInfo(
+    selectedStation?.name ?? null,
+    selectedStation?.line ?? null,
+  );
   const arrival = useArrivalCountdown(rawArrival);
 
   const searchResults = useMemo(() => {
@@ -155,12 +160,15 @@ function FavoriteCard({
 }: {
   station: Station;
   isExpanded: boolean;
-  arrival: { up: { destination: string; arrivalSeconds: number; statusMessage: string }[]; down: { destination: string; arrivalSeconds: number; statusMessage: string }[] } | null;
+  arrival: StationArrival | null;
   onToggle: () => void;
   onRemove: () => void;
   colors: ThemeColors;
 }) {
   const { t } = useTranslation();
+  const showRows = arrival != null && arrival.source !== 'closed';
+  const emptyArrival =
+    showRows && arrival.up.length === 0 && arrival.down.length === 0;
   return (
     <View style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}>
       {/* Remove 버튼을 onToggle TouchableOpacity 밖 sibling으로 배치.
@@ -182,20 +190,18 @@ function FavoriteCard({
 
       {isExpanded && (
         <View style={[styles.arrivalSection, { borderTopColor: colors.hair }]}>
-          {arrival ? (
-            <>
-              {arrival.up.length > 0 && (
-                <ArrivalRow label={t('arrival.upbound')} items={arrival.up} colors={colors} />
-              )}
-              {arrival.down.length > 0 && (
-                <ArrivalRow label={t('arrival.downbound')} items={arrival.down} colors={colors} />
-              )}
-              {arrival.up.length === 0 && arrival.down.length === 0 && (
-                <Text style={[styles.noArrival, { color: colors.muted }]}>{t('home.noArrivalInfo')}</Text>
-              )}
-            </>
-          ) : (
+          {arrival == null && (
             <Text style={[styles.noArrival, { color: colors.muted }]}>{t('home.loading')}</Text>
+          )}
+          <ArrivalSourceNotice arrival={arrival} />
+          {showRows && arrival.up.length > 0 && (
+            <ArrivalRow label={t('arrival.upbound')} items={arrival.up} colors={colors} />
+          )}
+          {showRows && arrival.down.length > 0 && (
+            <ArrivalRow label={t('arrival.downbound')} items={arrival.down} colors={colors} />
+          )}
+          {emptyArrival && (
+            <Text style={[styles.noArrival, { color: colors.muted }]}>{t('home.noArrivalInfo')}</Text>
           )}
         </View>
       )}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -86,6 +86,7 @@ export default function HomeScreen() {
   useTripOrigin(destination, effectiveOrigin, setTripOrigin);
   const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(
     effectiveOrigin?.name ?? null,
+    effectiveOrigin?.line ?? null,
   );
   const arrival = useArrivalCountdown(rawArrival);
   const isFav = effectiveOrigin ? favorites.some((f) => f.id === effectiveOrigin.id) : false;

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -29,6 +29,7 @@ import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
 import { useTheme, typography, spacing, radius } from '../../src/theme';
 import { LineBadge } from '../../src/components/LineBadge';
+import { ArrivalSourceNotice } from '../../src/components/ArrivalSourceNotice';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
 const logger = createLogger('HomeScreen');
@@ -520,15 +521,7 @@ export default function HomeScreen() {
                 {arrivalLoading && !arrival && (
                   <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.loading')}</Text>
                 )}
-                {arrival?.source === 'closed' ? (
-                  <Text style={[styles.mockNotice, { color: colors.muted }]}>{t('home.closedNotice')}</Text>
-                ) : arrival?.source === 'schedule' ? (
-                  <Text style={[styles.mockNotice, { color: colors.warn }]} testID="arrival-schedule-notice">
-                    {t('home.scheduleNotice')}
-                  </Text>
-                ) : arrivalIsMock ? (
-                  <Text style={[styles.mockNotice, { color: colors.warn }]}>{t('home.mockNotice')}</Text>
-                ) : null}
+                <ArrivalSourceNotice arrival={arrival} />
                 {arrival && arrival.source !== 'closed' && (
                   <>
                     <ArrivalRow label={t('arrival.upbound')} items={arrival.up} />
@@ -769,10 +762,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     textAlign: 'right',
     marginTop: 2,
-  },
-  mockNotice: {
-    fontSize: 12,
-    marginBottom: 8,
   },
   icon: {
     fontSize: 48,

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../utils/logger';
 import { parseTrainType, type TrainType } from '../constants/trainTypes';
 import { findLineByStationName } from '../utils/stationLookup';
 import { buildScheduleArrival, hasHeadwayData } from '../utils/scheduleFallback';
+import type { LineNumber } from '../types/station';
 
 const log = createLogger('arrivalApi');
 
@@ -70,8 +71,17 @@ export function parseRecptnDt(recptnDt: unknown): number {
  * 역명으로 호선을 찾지 못하면(드문 케이스) 최후 수단으로 하드코딩 MOCK_ARRIVALS 반환.
  * fallback 발생은 항상 로깅한다 — 후속 Option B(시간표 ETL) 필요성을 데이터로 판단하기 위함.
  */
-function getFallbackArrival(stationName: string, reason: string): StationArrival {
-  const line = findLineByStationName(stationName);
+/**
+ * 실시간 응답을 얻지 못한 caller가 schedule fallback을 동일한 정책으로 사용하기 위한 진입점.
+ * (SeoulOpenApiProvider 외에 BffArrivalProvider도 공유 — provider 간 fallback 정책 일관성.)
+ */
+export function getFallbackArrival(
+  stationName: string,
+  reason: string,
+  lineHint?: LineNumber,
+): StationArrival {
+  // lineHint가 있으면 환승역에서 정확한 호선의 schedule을 사용. 없으면 역명으로 lookup.
+  const line = lineHint ?? findLineByStationName(stationName);
   if (!line || !hasHeadwayData(line)) {
     log.warn('schedule_fallback_unavailable', { station: stationName, line, reason });
     return MOCK_ARRIVALS;
@@ -82,6 +92,7 @@ function getFallbackArrival(stationName: string, reason: string): StationArrival
     line,
     reason,
     source: result.source,
+    fromHint: lineHint != null,
   });
   return result;
 }
@@ -89,18 +100,19 @@ function getFallbackArrival(stationName: string, reason: string): StationArrival
 export interface FetchArrivalOptions {
   timeoutMs?: number;
   maxPerDirection?: number;
+  lineHint?: LineNumber;
 }
 
 export async function fetchArrivalInfo(
   stationName: string,
   options?: FetchArrivalOptions,
 ): Promise<StationArrival> {
-  const { timeoutMs = 5000, maxPerDirection = 2 } = options ?? {};
+  const { timeoutMs = 5000, maxPerDirection = 2, lineHint } = options ?? {};
   const apiKey = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
 
   if (!apiKey) {
     log.warn('API key not set (EXPO_PUBLIC_SEOUL_DATA_API_KEY)');
-    return getFallbackArrival(stationName, 'no_api_key');
+    return getFallbackArrival(stationName, 'no_api_key', lineHint);
   }
 
   const controller = new AbortController();
@@ -111,7 +123,7 @@ export async function fetchArrivalInfo(
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
       log.warn(`HTTP ${response.status} for station "${stationName}"`);
-      return getFallbackArrival(stationName, `http_${response.status}`);
+      return getFallbackArrival(stationName, `http_${response.status}`, lineHint);
     }
 
     const data = await response.json();
@@ -162,12 +174,12 @@ export async function fetchArrivalInfo(
     };
     if (sliced.up.length === 0 && sliced.down.length === 0) {
       log.warn(`No arrivals for station "${stationName}"`);
-      return getFallbackArrival(stationName, 'empty_response');
+      return getFallbackArrival(stationName, 'empty_response', lineHint);
     }
     return sliced;
   } catch (e) {
     log.error(`Fetch failed for station "${stationName}":`, e);
-    return getFallbackArrival(stationName, 'fetch_error');
+    return getFallbackArrival(stationName, 'fetch_error', lineHint);
   } finally {
     clearTimeout(timeout);
   }

--- a/src/components/ArrivalSourceNotice.tsx
+++ b/src/components/ArrivalSourceNotice.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { StationArrival } from '../api/arrivalApi';
+import { useTheme } from '../theme';
+
+interface Props {
+  arrival: StationArrival | null;
+}
+
+/**
+ * 도착정보의 source(실시간/시간표/운행종료)에 따라 사용자에게 적절한 알림 텍스트를 노출.
+ * 홈/favorites/위젯 등 여러 화면에서 동일한 라벨 분기 로직을 공유하기 위해 분리.
+ * source가 'realtime'이거나 arrival이 null이면 null 반환.
+ */
+export function ArrivalSourceNotice({ arrival }: Props): ReactElement | null {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  if (!arrival) return null;
+
+  if (arrival.source === 'closed') {
+    return (
+      <Text
+        style={[styles.notice, { color: colors.muted }]}
+        testID="arrival-closed-notice"
+      >
+        {t('home.closedNotice')}
+      </Text>
+    );
+  }
+
+  if (arrival.source === 'schedule') {
+    return (
+      <Text
+        style={[styles.notice, { color: colors.warn }]}
+        testID="arrival-schedule-notice"
+      >
+        {t('home.scheduleNotice')}
+      </Text>
+    );
+  }
+
+  if (arrival.isMock) {
+    return (
+      <Text
+        style={[styles.notice, { color: colors.warn }]}
+        testID="arrival-mock-notice"
+      >
+        {t('home.mockNotice')}
+      </Text>
+    );
+  }
+
+  return null;
+}
+
+const styles = StyleSheet.create({
+  notice: {
+    fontSize: 12,
+    marginBottom: 8,
+  },
+});

--- a/src/components/__tests__/ArrivalSourceNotice.test.tsx
+++ b/src/components/__tests__/ArrivalSourceNotice.test.tsx
@@ -1,0 +1,41 @@
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import { ArrivalSourceNotice } from '../ArrivalSourceNotice';
+import type { StationArrival } from '../../api/arrivalApi';
+
+const base: StationArrival = { up: [], down: [] };
+
+describe('ArrivalSourceNotice', () => {
+  it('arrival이 null이면 아무것도 렌더하지 않는다', () => {
+    const { toJSON, queryByTestId } = renderWithTheme(<ArrivalSourceNotice arrival={null} />);
+    expect(toJSON()).toBeNull();
+    expect(queryByTestId('arrival-schedule-notice')).toBeNull();
+  });
+
+  it('source가 realtime이면 아무것도 렌더하지 않는다', () => {
+    const { toJSON } = renderWithTheme(
+      <ArrivalSourceNotice arrival={{ ...base, source: 'realtime' }} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('source가 closed면 closedNotice를 렌더', () => {
+    const { getByTestId } = renderWithTheme(
+      <ArrivalSourceNotice arrival={{ ...base, source: 'closed', isMock: true }} />,
+    );
+    expect(getByTestId('arrival-closed-notice')).toBeTruthy();
+  });
+
+  it('source가 schedule이면 scheduleNotice를 렌더', () => {
+    const { getByTestId } = renderWithTheme(
+      <ArrivalSourceNotice arrival={{ ...base, source: 'schedule', isMock: true }} />,
+    );
+    expect(getByTestId('arrival-schedule-notice')).toBeTruthy();
+  });
+
+  it('source 없고 isMock=true면 mockNotice를 렌더 (구버전 호환)', () => {
+    const { getByTestId } = renderWithTheme(
+      <ArrivalSourceNotice arrival={{ ...base, isMock: true }} />,
+    );
+    expect(getByTestId('arrival-mock-notice')).toBeTruthy();
+  });
+});

--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -84,6 +84,26 @@ describe('useArrivalInfo', () => {
     );
   });
 
+  it('lineHint가 주어지면 provider에 그대로 전달한다 (환승역 fallback 정확도)', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    renderHook(() => useArrivalInfo('서울역', '4'));
+
+    await waitFor(() =>
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('서울역', { lineHint: '4' })
+    );
+  });
+
+  it('lineHint가 null이면 undefined로 전달한다', async () => {
+    (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+    renderHook(() => useArrivalInfo('강남', null));
+
+    await waitFor(() =>
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('강남', { lineHint: undefined })
+    );
+  });
+
   it('stationName이 변경되면 새로운 역의 데이터를 가져온다', async () => {
     (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
 
@@ -93,13 +113,13 @@ describe('useArrivalInfo', () => {
     );
 
     await waitFor(() =>
-      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('강남', undefined)
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('강남', { lineHint: undefined })
     );
 
     rerender({ name: '역삼' });
 
     await waitFor(() =>
-      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('역삼', undefined)
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('역삼', { lineHint: undefined })
     );
   });
 

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { StationArrival } from '../api/arrivalApi';
 import type { ArrivalProvider } from '../providers/types';
+import type { LineNumber } from '../types/station';
 import { createArrivalProvider } from '../providers/factory';
 import { TtlCache } from '../utils/ttlCache';
 import { usePolling } from './usePolling';
@@ -31,6 +32,7 @@ interface UseArrivalInfoReturn {
 
 export function useArrivalInfo(
   stationName: string | null,
+  lineHint?: LineNumber | null,
   provider?: ArrivalProvider,
 ): UseArrivalInfoReturn {
   const [arrival, setArrival] = useState<StationArrival | null>(null);
@@ -39,6 +41,10 @@ export function useArrivalInfo(
   const arrivalRef = useRef<StationArrival | null>(null);
   const stationNameRef = useRef(stationName);
   stationNameRef.current = stationName;
+  // lineHint는 환승역 schedule fallback의 정확도용. 캐시 키에는 포함하지 않는다
+  // (같은 역의 실시간 응답은 호선 무관 동일하므로 캐시 공유가 더 효율적).
+  const lineHintRef = useRef(lineHint);
+  lineHintRef.current = lineHint;
 
   const updateArrival = useCallback((data: StationArrival) => {
     if (!arrivalEqual(arrivalRef.current, data)) {
@@ -73,7 +79,9 @@ export function useArrivalInfo(
 
     const poll = async () => {
       try {
-        const data = await providerRef.current.getArrival(stationName);
+        const data = await providerRef.current.getArrival(stationName, {
+          lineHint: lineHint ?? undefined,
+        });
         if (cancelled) return;
         if (!data.isMock) {
           arrivalCache.set(stationName, data);
@@ -91,13 +99,16 @@ export function useArrivalInfo(
     return () => {
       cancelled = true;
     };
-  }, [stationName]);
+    // lineHint가 바뀌면 즉시 refetch — stale hint로 5초간 잘못된 호선 schedule이 보이는 것 방지.
+  }, [stationName, lineHint]);
 
   usePolling(
     () => {
       const name = stationNameRef.current;
       if (!name) return;
-      providerRef.current.getArrival(name).then((data) => {
+      providerRef.current.getArrival(name, {
+        lineHint: lineHintRef.current ?? undefined,
+      }).then((data) => {
         if (name !== stationNameRef.current) return;
         if (!data.isMock) {
           arrivalCache.set(name, data);

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -126,12 +126,17 @@ export function useFusedNearestStation(
   }, [gps.userLocation]);
 
   // arrival 폴링: 후보 역명 단위 K=3 고정.
+  // 각 후보의 호선을 lineHint로 함께 전달해 schedule fallback이 환승역에서 정확한
+  // 호선을 사용하도록 한다 (#469).
   const c0 = candidates[0]?.station.name ?? null;
   const c1 = candidates[1]?.station.name ?? null;
   const c2 = candidates[2]?.station.name ?? null;
-  const a0 = useArrivalInfo(c0, arrivalProvider);
-  const a1 = useArrivalInfo(c1, arrivalProvider);
-  const a2 = useArrivalInfo(c2, arrivalProvider);
+  const h0 = candidates[0]?.station.line ?? null;
+  const h1 = candidates[1]?.station.line ?? null;
+  const h2 = candidates[2]?.station.line ?? null;
+  const a0 = useArrivalInfo(c0, h0, arrivalProvider);
+  const a1 = useArrivalInfo(c1, h1, arrivalProvider);
+  const a2 = useArrivalInfo(c2, h2, arrivalProvider);
 
   // position 폴링: 후보 역들의 호선만 dedup 후 K=3 고정 슬롯.
   // (대부분 1~2개 호선이지만 환승 인근에서 3개까지 가능)

--- a/src/providers/arrival/BffArrivalProvider.ts
+++ b/src/providers/arrival/BffArrivalProvider.ts
@@ -1,6 +1,6 @@
 import type { ArrivalProvider, ArrivalOptions } from '../types';
 import type { StationArrival } from '../../api/arrivalApi';
-import { MOCK_ARRIVALS } from '../../api/arrivalApi';
+import { getFallbackArrival } from '../../api/arrivalApi';
 
 export class BffArrivalProvider implements ArrivalProvider {
   constructor(private readonly baseUrl: string) {}
@@ -9,7 +9,7 @@ export class BffArrivalProvider implements ArrivalProvider {
     stationName: string,
     options?: ArrivalOptions,
   ): Promise<StationArrival> {
-    const { timeoutMs = 5000, maxPerDirection = 2 } = options ?? {};
+    const { timeoutMs = 5000, maxPerDirection = 2, lineHint } = options ?? {};
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -19,18 +19,18 @@ export class BffArrivalProvider implements ArrivalProvider {
       const response = await fetch(url, { signal: controller.signal });
 
       if (!response.ok) {
-        return MOCK_ARRIVALS;
+        return getFallbackArrival(stationName, `bff_http_${response.status}`, lineHint);
       }
 
       const data: StationArrival = await response.json();
 
       if (data.up.length === 0 && data.down.length === 0) {
-        return MOCK_ARRIVALS;
+        return getFallbackArrival(stationName, 'bff_empty_response', lineHint);
       }
 
-      return data;
+      return { ...data, source: data.source ?? 'realtime' };
     } catch {
-      return MOCK_ARRIVALS;
+      return getFallbackArrival(stationName, 'bff_fetch_error', lineHint);
     } finally {
       clearTimeout(timeout);
     }

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -1,5 +1,4 @@
 import { BffArrivalProvider } from '../BffArrivalProvider';
-import { MOCK_ARRIVALS } from '../../../api/arrivalApi';
 import type { StationArrival } from '../../../api/arrivalApi';
 import type { ArrivalOptions } from '../../types';
 
@@ -29,6 +28,11 @@ describe('BffArrivalProvider', () => {
     provider = new BffArrivalProvider(BASE_URL);
     global.fetch = jest.fn();
     jest.useFakeTimers();
+    // schedule fallback이 closed 시간대에 빈 배열을 반환하지 않도록 KST 15:00 weekday 고정.
+    jest.setSystemTime(new Date('2026-05-18T06:00:00Z'));
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -36,10 +40,10 @@ describe('BffArrivalProvider', () => {
     jest.restoreAllMocks();
   });
 
-  it('정상 응답 시 도착 데이터를 반환한다', async () => {
+  it('정상 응답 시 도착 데이터를 source=realtime과 함께 반환한다', async () => {
     mockFetchOk(VALID_DATA);
     const result = await callGetArrival();
-    expect(result).toEqual(VALID_DATA);
+    expect(result).toEqual({ ...VALID_DATA, source: 'realtime' });
   });
 
   it('기본 옵션으로 올바른 URL을 호출한다', async () => {
@@ -62,34 +66,45 @@ describe('BffArrivalProvider', () => {
     );
   });
 
-  it('응답이 ok가 아니면 MOCK_ARRIVALS를 반환한다', async () => {
+  it('응답이 ok가 아니면 schedule fallback으로 전환한다', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 500 });
     const result = await callGetArrival();
-    expect(result).toBe(MOCK_ARRIVALS);
+    expect(result.source).toBe('schedule');
+    expect(result.isMock).toBe(true);
   });
 
-  it('up/down 모두 빈 배열이면 MOCK_ARRIVALS를 반환한다', async () => {
+  it('up/down 모두 빈 배열이면 schedule fallback으로 전환한다', async () => {
     mockFetchOk({ up: [], down: [] });
     const result = await callGetArrival();
-    expect(result).toBe(MOCK_ARRIVALS);
+    expect(result.source).toBe('schedule');
+  });
+
+  it('lineHint를 schedule fallback에 전달한다', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 503 });
+    const result = await callGetArrival('서울역', { lineHint: '4' });
+    expect(result.source).toBe('schedule');
+    // 4호선 평일 offPeak headway 360s → 첫 차 180s
+    expect(result.up[0].arrivalSeconds).toBe(180);
   });
 
   it.each([
     { label: 'up만 있을 때', data: { up: VALID_DATA.up, down: [] } },
     { label: 'down만 있을 때', data: { up: [], down: VALID_DATA.down } },
-  ])('한 방향($label)에만 데이터가 있으면 그대로 반환한다', async ({ data }) => {
+  ])('한 방향($label)에만 데이터가 있으면 source=realtime으로 표시', async ({ data }) => {
     mockFetchOk(data);
     const result = await callGetArrival();
-    expect(result).toEqual(data);
+    expect(result.up).toEqual(data.up);
+    expect(result.down).toEqual(data.down);
+    expect(result.source).toBe('realtime');
   });
 
-  it('fetch 에러 시 MOCK_ARRIVALS를 반환한다', async () => {
+  it('fetch 에러 시 schedule fallback으로 전환한다', async () => {
     (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
     const result = await callGetArrival();
-    expect(result).toBe(MOCK_ARRIVALS);
+    expect(result.source).toBe('schedule');
   });
 
-  it('타임아웃 abort 시 MOCK_ARRIVALS를 반환한다', async () => {
+  it('타임아웃 abort 시 schedule fallback으로 전환한다', async () => {
     (global.fetch as jest.Mock).mockImplementationOnce(
       () => new Promise((_, reject) => {
         setTimeout(() => reject(new DOMException('Aborted', 'AbortError')), 6000);
@@ -100,7 +115,7 @@ describe('BffArrivalProvider', () => {
     jest.runAllTimers();
     const result = await resultPromise;
 
-    expect(result).toBe(MOCK_ARRIVALS);
+    expect(result.source).toBe('schedule');
   });
 
   it('특수 문자가 포함된 역명을 URL 인코딩한다', async () => {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -5,6 +5,11 @@ import type { LineNumber } from '../types/station';
 export interface ArrivalOptions {
   timeoutMs?: number;
   maxPerDirection?: number;
+  /**
+   * 호출자가 이미 알고 있는 노선. schedule fallback에서 stationName으로 다시 lookup하는
+   * 비용 + 환승역의 첫 매칭 부정확성을 회피하기 위한 힌트. realtime 성공 경로에는 영향 없음.
+   */
+  lineHint?: LineNumber;
 }
 
 export interface ArrivalProvider {


### PR DESCRIPTION
## Summary

#464 code-review P2-3 follow-up. #469 위에 스택된 PR (#469 머지 후 base를 dev로 변경).

- 신규 `src/components/ArrivalSourceNotice.tsx` — closed/schedule/isMock 라벨 분기 공통화
- Home + Favorites에 동일 컴포넌트 적용
- Favorites에 #469의 `lineHint` 전달 → 환승역 schedule fallback 정확도 향상
- Favorites의 `source='closed'` 시 ArrivalRow를 미렌더링하고 closedNotice만 표시
- Home의 orphan `mockNotice` 스타일 제거 (P2-1)

Closes #470

## 검증

- type-check ✅
- test 1550/1550 통과, 커버리지 100%
- code-review 에이전트 P1 0건, P2-1 반영 완료

## Test plan

- [x] CI Type Check & Test 통과
- [x] 새벽 시간대 favorites에서 closedNotice 표시
- [ ] API 키 제거 환경에서 favorites에 scheduleNotice 표시
- [x] 환승역(서울역) favorite으로 등록 후 lineHint 정확도 확인

## 비-목표

- P2-2 (FavoriteCard 변수명 명시) — 후속
- P2-3 (ArrivalSourceNotice jsdoc) — 후속
- P3-1 (인터페이스 ISP) — 위젯 통합 시점에 결정