### PR TITLE
feat(#480): 목적지 설정 모달에 내 위치 recenter 버튼 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -567,6 +567,9 @@ export default function HomeScreen() {
         recentDestination={recentDestination}
         userLat={userLocation?.lat ?? null}
         userLng={userLocation?.lng ?? null}
+        onRecenter={() => {
+          void refreshRef.current();
+        }}
       />
     </SafeAreaView>
   );

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -28,6 +28,7 @@ interface Props {
   readonly recentDestination?: Station | null;
   readonly userLat?: number | null;
   readonly userLng?: number | null;
+  readonly onRecenter?: () => void;
 }
 
 export function DestinationPicker({
@@ -37,9 +38,11 @@ export function DestinationPicker({
   userLat,
   userLng,
   recentDestination,
+  onRecenter,
 }: Props) {
   const [query, setQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
+  const [recenterNonce, setRecenterNonce] = useState(0);
   const openTimeRef = useRef<number | null>(null);
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -93,6 +96,7 @@ export function DestinationPicker({
             nearestStation={null}
             nearbyStations={mapStations}
             onStationPress={handleSelect}
+            recenterNonce={recenterNonce}
           />
         ) : (
           <View style={styles.mapFallback} testID="map-fallback">
@@ -132,6 +136,23 @@ export function DestinationPicker({
             </View>
           )}
         </View>
+
+        {mapAvailable && (
+          <TouchableOpacity
+            style={[
+              styles.recenterButton,
+              { backgroundColor: colors.card, borderColor: colors.hair },
+            ]}
+            onPress={() => {
+              onRecenter?.();
+              setRecenterNonce((n) => n + 1);
+            }}
+            accessibilityLabel={t('map.recenter')}
+            testID="recenter-button"
+          >
+            <Text style={[styles.recenterIcon, { color: colors.ink }]}>◎</Text>
+          </TouchableOpacity>
+        )}
       </View>
     </Modal>
   );
@@ -183,5 +204,25 @@ const styles = StyleSheet.create({
   dropdownWrap: {
     marginHorizontal: spacing.xl,
     marginTop: 4,
+  },
+  recenterButton: {
+    position: 'absolute',
+    right: spacing.lg,
+    bottom: spacing.xl,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+  recenterIcon: {
+    fontSize: 22,
+    lineHeight: 24,
   },
 });

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -136,6 +136,30 @@ describe('DestinationPicker', () => {
     debugSpy.mockRestore();
   });
 
+  it('좌표가 있으면 recenter 버튼을 렌더링한다', () => {
+    const { getByTestId } = render(<DestinationPicker {...mapProps} />);
+    expect(getByTestId('recenter-button')).toBeTruthy();
+  });
+
+  it('좌표가 없으면 recenter 버튼을 렌더링하지 않는다', () => {
+    const { queryByTestId } = render(<DestinationPicker {...defaultProps} />);
+    expect(queryByTestId('recenter-button')).toBeNull();
+  });
+
+  it('recenter 버튼 클릭 시 onRecenter 콜백을 호출한다', () => {
+    const onRecenter = jest.fn();
+    const { getByTestId } = render(
+      <DestinationPicker {...mapProps} onRecenter={onRecenter} />,
+    );
+    fireEvent.press(getByTestId('recenter-button'));
+    expect(onRecenter).toHaveBeenCalledTimes(1);
+  });
+
+  it('onRecenter 미제공 상태에서 recenter 버튼을 눌러도 오류가 없다', () => {
+    const { getByTestId } = render(<DestinationPicker {...mapProps} />);
+    expect(() => fireEvent.press(getByTestId('recenter-button'))).not.toThrow();
+  });
+
   it('검색창 포커스 시 드롭다운 표시 상태가 활성화된다', () => {
     const { getByTestId, queryByTestId } = render(<DestinationPicker {...defaultProps} />);
     fireEvent.changeText(getByTestId('search-input'), '강남');


### PR DESCRIPTION
## Summary
- `DestinationPicker` 우하단에 지도 탭과 동일한 ◎ recenter 버튼 추가
- 내부 `recenterNonce` state로 `StationMap` 카메라를 내 위치로 이동
- 옵셔널 `onRecenter` 콜백으로 부모의 GPS refresh 호출 (홈에서 `refreshRef.current()` 연결)

## Test plan
- [x] `npm test` — 1549/1549 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-review 에이전트 PASS
- [ ] 실기기에서 모달 열고 패닝 후 ◎ 탭 → 카메라 복귀 확인

Closes #480