### PR TITLE
fix(#476): nextTrainMinutes에 isMock 가드 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -127,14 +127,14 @@ export default function HomeScreen() {
     [route, effectiveOrigin?.id, destination?.id],
   );
   const nextTrainMinutes = useMemo(() => {
-    if (!arrival) return null;
+    if (!arrival || arrivalIsMock) return null;
     const directions = [arrival.up, arrival.down];
     const minutes = directions.map((trains) => {
       const first = trains[0];
       return first?.arrivalSeconds != null ? Math.floor(first.arrivalSeconds / 60) : Infinity;
     });
     return Math.min(...minutes);
-  }, [arrival]);
+  }, [arrival, arrivalIsMock]);
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
     ? calculateETA(nextTrainMinutes, route)
     : null;


### PR DESCRIPTION
## 배경
`#464`에서 schedule fallback이 trip 진행 중에도 더 자주 등장 가능(빈 응답/HTTP 5xx). 현재 `nextTrainMinutes`가 `arrival.isMock`을 무시하고 `useApnsTripRegistration`에 전달 → fake ETA로 사전 예약 alarm epoch 계산.

## 변경
- `app/(tabs)/index.tsx`의 `nextTrainMinutes` useMemo에 `arrivalIsMock` 가드 추가
- isMock이면 `null` 반환 → APNs 사전 예약은 staticETA path로 자연 폴백
- `useScheduledAlarms`의 기존 isMock 가드 패턴과 일관성

## 확인
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (커버리지 100%)
- [x] code-reviewer 리뷰 — 본 변경에 지적사항 없음

Closes #476