### PR TITLE
fix(#409): arvlCd 실측 신호 우선 phase 판정 + ETA fallback

### DIFF
--- a/backend/alarm-worker/src/__tests__/alarm.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarm.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ARRIVAL_CODE,
   EARLY_THRESHOLD_SEC,
   IMMINENT_THRESHOLD_SEC,
   evaluatePhase,
+  evaluatePhaseFromSignal,
   isSignificantEtaChange,
   shouldFire,
 } from '../alarm';
@@ -36,6 +38,38 @@ describe('shouldFire', () => {
   });
   it('blocks regression imminent → early', () => {
     expect(shouldFire('early', 'imminent')).toBe(false);
+  });
+});
+
+describe('evaluatePhaseFromSignal (#409 arvlCd + ETA fallback)', () => {
+  const FAR_ETA = EARLY_THRESHOLD_SEC + 100; // ETA만으론 null인 거리
+
+  it('arvlCd=ENTERING(0)이면 ETA와 무관하게 imminent', () => {
+    expect(evaluatePhaseFromSignal(FAR_ETA, ARRIVAL_CODE.ENTERING)).toBe('imminent');
+  });
+
+  it('arvlCd=ARRIVED(1)이면 ETA와 무관하게 imminent', () => {
+    expect(evaluatePhaseFromSignal(FAR_ETA, ARRIVAL_CODE.ARRIVED)).toBe('imminent');
+  });
+
+  it('arvlCd=PREV_ENTERING(4)이면 early', () => {
+    expect(evaluatePhaseFromSignal(FAR_ETA, ARRIVAL_CODE.PREV_ENTERING)).toBe('early');
+  });
+
+  it('arvlCd=PREV_ARRIVED(5)이면 early', () => {
+    expect(evaluatePhaseFromSignal(FAR_ETA, ARRIVAL_CODE.PREV_ARRIVED)).toBe('early');
+  });
+
+  it('arvlCd가 null이면 ETA fallback', () => {
+    expect(evaluatePhaseFromSignal(IMMINENT_THRESHOLD_SEC, null)).toBe('imminent');
+    expect(evaluatePhaseFromSignal(EARLY_THRESHOLD_SEC, null)).toBe('early');
+    expect(evaluatePhaseFromSignal(FAR_ETA, null)).toBeNull();
+  });
+
+  it('arvlCd가 비매칭 코드(2,3,99)면 ETA fallback', () => {
+    expect(evaluatePhaseFromSignal(10, 2)).toBe('imminent'); // ETA가 imminent
+    expect(evaluatePhaseFromSignal(150, 3)).toBe('early'); // ETA가 early
+    expect(evaluatePhaseFromSignal(FAR_ETA, 99)).toBeNull(); // ETA도 미달
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1,7 +1,7 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
-import { pickActiveWaypoint, pickBestEtaSeconds, runScheduled } from '../scheduled';
+import { pickActiveWaypoint, pickBestArrivalSignal, runScheduled } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
 import { putTrip } from '../trips';
 import type { Env, Trip } from '../types';
@@ -79,6 +79,7 @@ function makeImminentArrival(stationName: string): ArrivalEntry {
     trainCode: 'T',
     isUp: true,
     subwayNm: '지하철2호선',
+    arvlCd: null,
   };
 }
 
@@ -112,6 +113,7 @@ function makeSeoul(arrivals: ArrivalEntry[]): SeoulArrivalClient {
             trainLineNm: a.destination,
             btrainNo: a.trainCode,
             subwayNm: a.subwayNm,
+            arvlCd: a.arvlCd,
           })),
         }),
         { status: 200 },
@@ -129,32 +131,60 @@ describe('pickActiveWaypoint', () => {
   });
 });
 
-describe('pickBestEtaSeconds', () => {
+describe('pickBestArrivalSignal (#409)', () => {
   const wp = { stationName: '강남', line: '2', kind: 'destination' as const };
   it('returns null when no arrivals', () => {
-    expect(pickBestEtaSeconds([], wp)).toBeNull();
+    expect(pickBestArrivalSignal([], wp)).toBeNull();
   });
-  it('matches by subwayNm and picks min', () => {
+  it('arvlCd 신호 없으면 min ETA fallback (라인 매칭 후)', () => {
     const arrivals: ArrivalEntry[] = [
-      { destination: 'A', arrivalSeconds: 200, trainCode: '1', isUp: true, subwayNm: '지하철2호선' },
-      { destination: 'B', arrivalSeconds: 60, trainCode: '2', isUp: true, subwayNm: '지하철2호선' },
-      { destination: 'C', arrivalSeconds: 30, trainCode: '3', isUp: true, subwayNm: '지하철9호선' },
+      { destination: 'A', arrivalSeconds: 200, trainCode: '1', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+      { destination: 'B', arrivalSeconds: 60, trainCode: '2', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+      { destination: 'C', arrivalSeconds: 30, trainCode: '3', isUp: true, subwayNm: '지하철9호선', arvlCd: null },
     ];
-    expect(pickBestEtaSeconds(arrivals, wp)).toBe(60);
+    expect(pickBestArrivalSignal(arrivals, wp)).toEqual({ etaSeconds: 60, arvlCd: null });
   });
-  it('falls back to all arrivals when no line match', () => {
+  it('라인 매칭 실패 시 전체 arrivals로 fallback', () => {
     const arrivals: ArrivalEntry[] = [
-      { destination: 'A', arrivalSeconds: 100, trainCode: '1', isUp: true, subwayNm: '지하철9호선' },
+      { destination: 'A', arrivalSeconds: 100, trainCode: '1', isUp: true, subwayNm: '지하철9호선', arvlCd: null },
     ];
-    expect(pickBestEtaSeconds(arrivals, wp)).toBe(100);
+    expect(pickBestArrivalSignal(arrivals, wp)).toEqual({ etaSeconds: 100, arvlCd: null });
   });
-  it('matches gyeongui line against 경의중앙선 subwayNm via alias map', () => {
+  it('gyeongui line은 경의중앙선 alias로 매칭', () => {
     const arrivals: ArrivalEntry[] = [
-      { destination: '용문', arrivalSeconds: 90, trainCode: 'G', isUp: true, subwayNm: '경의중앙선' },
-      { destination: '용문', arrivalSeconds: 200, trainCode: 'H', isUp: true, subwayNm: '지하철1호선' },
+      { destination: '용문', arrivalSeconds: 90, trainCode: 'G', isUp: true, subwayNm: '경의중앙선', arvlCd: null },
+      { destination: '용문', arrivalSeconds: 200, trainCode: 'H', isUp: true, subwayNm: '지하철1호선', arvlCd: null },
     ];
     const gyeonguiWp = { stationName: '회기', line: 'gyeongui', kind: 'destination' as const };
-    expect(pickBestEtaSeconds(arrivals, gyeonguiWp)).toBe(90);
+    expect(pickBestArrivalSignal(arrivals, gyeonguiWp)).toEqual({ etaSeconds: 90, arvlCd: null });
+  });
+  it('arvlCd=0 (ENTERING)이 있으면 ETA가 더 큰 train이라도 우선 선택 (imminent 실측)', () => {
+    const arrivals: ArrivalEntry[] = [
+      { destination: 'A', arrivalSeconds: 30, trainCode: '1', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+      { destination: 'B', arrivalSeconds: 120, trainCode: '2', isUp: true, subwayNm: '지하철2호선', arvlCd: 0 },
+    ];
+    expect(pickBestArrivalSignal(arrivals, wp)).toEqual({ etaSeconds: 120, arvlCd: 0 });
+  });
+  it('arvlCd=1 (ARRIVED)이 있으면 ETA가 더 빠른 비-신호 train보다 우선', () => {
+    const arrivals: ArrivalEntry[] = [
+      { destination: 'A', arrivalSeconds: 50, trainCode: '1', isUp: true, subwayNm: '지하철2호선', arvlCd: 99 },
+      { destination: 'B', arrivalSeconds: 80, trainCode: '2', isUp: true, subwayNm: '지하철2호선', arvlCd: 1 },
+    ];
+    expect(pickBestArrivalSignal(arrivals, wp)).toEqual({ etaSeconds: 80, arvlCd: 1 });
+  });
+  it('arvlCd=4/5 (PREV_*)는 early 신호로 선택, imminent 신호 없을 때만', () => {
+    const arrivals: ArrivalEntry[] = [
+      { destination: 'A', arrivalSeconds: 300, trainCode: '1', isUp: true, subwayNm: '지하철2호선', arvlCd: 4 },
+      { destination: 'B', arrivalSeconds: 60, trainCode: '2', isUp: true, subwayNm: '지하철2호선', arvlCd: 99 },
+    ];
+    expect(pickBestArrivalSignal(arrivals, wp)).toEqual({ etaSeconds: 300, arvlCd: 4 });
+  });
+  it('imminent 신호가 있으면 early 신호보다 우선', () => {
+    const arrivals: ArrivalEntry[] = [
+      { destination: 'A', arrivalSeconds: 200, trainCode: '1', isUp: true, subwayNm: '지하철2호선', arvlCd: 5 },
+      { destination: 'B', arrivalSeconds: 100, trainCode: '2', isUp: true, subwayNm: '지하철2호선', arvlCd: 0 },
+    ];
+    expect(pickBestArrivalSignal(arrivals, wp)).toEqual({ etaSeconds: 100, arvlCd: 0 });
   });
 });
 
@@ -254,7 +284,7 @@ describe('runScheduled', () => {
 
     // 1st cycle: early (eta=120s)
     const seoul1 = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
     ]);
     const fetchEarly = vi.fn(async () => new Response('', { status: 200 }));
     const stats1 = await runScheduled(makeEnv(kv), {
@@ -268,7 +298,7 @@ describe('runScheduled', () => {
 
     // 2nd cycle: imminent (eta=20s)
     const seoul2 = makeSeoul([
-      { destination: '강남', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
+      { destination: '강남', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
     ]);
     const fetchImminent = vi.fn(async () => new Response('', { status: 200 }));
     const stats2 = await runScheduled(makeEnv(kv), {
@@ -288,7 +318,7 @@ describe('runScheduled', () => {
       makeTrip({ lastFiredPhase: 'early', lastEtaSeconds: 150 }),
     );
     const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 140, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
+      { destination: '강남', arrivalSeconds: 140, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
     ]);
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
@@ -305,7 +335,7 @@ describe('runScheduled', () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeTrip());
     const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선' },
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
     ]);
     const apnsFetch = vi.fn(async () =>
       new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
@@ -333,7 +363,7 @@ describe('runScheduled', () => {
       }),
     );
     const seoul = makeSeoul([
-      { destination: '중곡', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '7호선' },
+      { destination: '중곡', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '7호선', arvlCd: null },
     ]);
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
@@ -361,7 +391,7 @@ describe('runScheduled', () => {
       }),
     );
     const seoul = makeSeoul([
-      { destination: '중곡', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '7호선' },
+      { destination: '중곡', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '7호선', arvlCd: null },
     ]);
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {

--- a/backend/alarm-worker/src/__tests__/seoul.test.ts
+++ b/backend/alarm-worker/src/__tests__/seoul.test.ts
@@ -51,6 +51,30 @@ describe('SeoulArrivalClient', () => {
     expect(arrivals[0].arrivalSeconds).toBe(120);
   });
 
+  it('arvlCd 파싱 — number / numeric string / 누락 (#409)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      makeResponse({
+        realtimeArrivalList: [
+          makeItem({ arvlCd: 0 }),
+          makeItem({ arvlCd: '1' }),
+          makeItem({ arvlCd: 'invalid' }),
+          makeItem(), // arvlCd 누락
+        ],
+      }),
+    );
+    const client = new SeoulArrivalClient({
+      apiKey: 'KEY',
+      host: 'example.com',
+      now: () => FIXED_NOW,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const arrivals = await client.fetchArrivals('서울역');
+    expect(arrivals[0].arvlCd).toBe(0);
+    expect(arrivals[1].arvlCd).toBe(1);
+    expect(arrivals[2].arvlCd).toBeNull();
+    expect(arrivals[3].arvlCd).toBeNull();
+  });
+
   it('caches within TTL', async () => {
     const fetchImpl = vi.fn(async () => makeResponse({ realtimeArrivalList: [makeItem()] }));
     let now = FIXED_NOW;

--- a/backend/alarm-worker/src/alarm.ts
+++ b/backend/alarm-worker/src/alarm.ts
@@ -1,15 +1,21 @@
 /**
  * 알람 phase 판정 로직 — 앱 측 alarmPhases.ts와 동일 의미.
  *
- * 백엔드는 stops 정보가 없으므로 ETA만으로 판정한다.
- * - imminent: etaSeconds <= 30 (도착 임박)
- * - early   : etaSeconds <= 240 (4분 이하)
+ * #409: ETA 예측 오차로 인한 ~1분 지연을 줄이기 위해 Seoul API의 `arvlCd` 실측
+ * 신호를 우선 사용한다. arvlCd가 phase trigger에 매칭되지 않으면 ETA 임계값 기반
+ * fallback. 두 신호의 합집합으로 발화 → polling 경계 오차 영향 최소화.
  *
- * EARLY는 240으로 잡는다. cron 주기 1분 + Seoul API 갱신 지연 ~수십초가 누적되면
- * 180초 경계에서 한 cycle 놓치고 ~60초 늦은 알림이 발생할 수 있어, 한 cycle만큼의
- * 버퍼를 두어 그 가능성을 줄인다.
+ * 우선순위:
+ *   1. arvlCd ∈ {0 ENTERING, 1 ARRIVED}             → imminent (실측, 오차 거의 0)
+ *   2. arvlCd ∈ {4 PREV_ENTERING, 5 PREV_ARRIVED}   → early    (1정거장 전 실측)
+ *   3. etaSeconds <= IMMINENT_THRESHOLD_SEC          → imminent (ETA fallback)
+ *   4. etaSeconds <= EARLY_THRESHOLD_SEC             → early    (ETA fallback)
+ *   5. 그 외                                          → null
  *
- * 또한 ETA 변동 폭이 임계치(±60초) 이상이면 트립 메모리 갱신용으로 변동을 신호한다.
+ * EARLY 임계값 240은 cron 주기 1분 + Seoul API 갱신 지연 흡수용 버퍼. arvlCd 도입
+ * 이후엔 fallback 경로에서만 의미.
+ *
+ * ETA 변동 폭이 임계치(±60초) 이상이면 트립 메모리 갱신용으로 변동을 신호한다.
  */
 
 export type AlarmPhase = 'early' | 'imminent';
@@ -18,12 +24,43 @@ export const IMMINENT_THRESHOLD_SEC = 30;
 export const EARLY_THRESHOLD_SEC = 240;
 export const ETA_DELTA_THRESHOLD_SEC = 60;
 
+/** Seoul API arvlCd 값. src/constants/arrivalCodes.ts와 동일 의미 (백엔드 카피). */
+export const ARRIVAL_CODE = {
+  ENTERING: 0,
+  ARRIVED: 1,
+  PREV_ENTERING: 4,
+  PREV_ARRIVED: 5,
+} as const;
+
+const IMMINENT_CODES: readonly number[] = [ARRIVAL_CODE.ENTERING, ARRIVAL_CODE.ARRIVED];
+const EARLY_CODES: readonly number[] = [ARRIVAL_CODE.PREV_ENTERING, ARRIVAL_CODE.PREV_ARRIVED];
+
 const PHASE_ORDER: readonly AlarmPhase[] = ['early', 'imminent'];
 
+/**
+ * ETA 단독 phase 판정 (legacy / fallback).
+ * arvlCd가 의미있는 신호를 못 주는 케이스에서만 단독 호출.
+ */
 export function evaluatePhase(etaSeconds: number): AlarmPhase | null {
   if (etaSeconds <= IMMINENT_THRESHOLD_SEC) return 'imminent';
   if (etaSeconds <= EARLY_THRESHOLD_SEC) return 'early';
   return null;
+}
+
+/**
+ * arvlCd 실측 신호 + ETA fallback 결합 phase 판정 (#409).
+ * arvlCd가 phase trigger에 해당하면 즉시 반환, 아니면 evaluatePhase(eta)로 fallback.
+ * arvlCd가 null이거나 비매칭 코드(2 출발, 3 전역출발, 99 운행중)일 땐 ETA fallback.
+ */
+export function evaluatePhaseFromSignal(
+  etaSeconds: number,
+  arvlCd: number | null,
+): AlarmPhase | null {
+  if (arvlCd !== null) {
+    if (IMMINENT_CODES.includes(arvlCd)) return 'imminent';
+    if (EARLY_CODES.includes(arvlCd)) return 'early';
+  }
+  return evaluatePhase(etaSeconds);
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3,8 +3,9 @@
  */
 
 import {
+  ARRIVAL_CODE,
   EARLY_THRESHOLD_SEC,
-  evaluatePhase,
+  evaluatePhaseFromSignal,
   isSignificantEtaChange,
   shouldFire,
 } from './alarm';
@@ -64,8 +65,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
 
     try {
       const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
-      const eta = pickBestEtaSeconds(arrivals, waypoint);
-      if (eta === null) {
+      const signal = pickBestArrivalSignal(arrivals, waypoint);
+      if (signal === null) {
         stats.etaMissing += 1;
         log('empty arrivals — skip cycle', {
           token: trip.token.slice(0, 8),
@@ -74,8 +75,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
         });
         continue;
       }
+      const { etaSeconds: eta, arvlCd } = signal;
 
-      const phase = evaluatePhase(eta);
+      const phase = evaluatePhaseFromSignal(eta, arvlCd);
       const etaChanged = isSignificantEtaChange(trip.lastEtaSeconds, eta);
       const phaseFires = phase !== null && shouldFire(phase, trip.lastFiredPhase);
       // 중간역(intermediate)은 통과 시점(imminent)에만 발사. early phase / 정보 갱신용 push는 노이즈로 간주해 스킵.
@@ -103,6 +105,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           phase: pushPhase,
           station: waypoint.stationName,
           etaSeconds: eta,
+          arvlCd,
         });
         const result = await sendSilentPush({
           deviceToken: trip.token,
@@ -188,22 +191,49 @@ export function pickActiveWaypoint(trip: Trip): Waypoint | null {
   return trip.waypoints[0];
 }
 
+export interface ArrivalSignal {
+  etaSeconds: number;
+  arvlCd: number | null;
+}
+
 /**
- * arrivals 중 waypoint의 line과 매칭되는 가장 빠른 ETA(seconds)를 반환.
- * 매칭 실패 시 가장 빠른 도착으로 fallback. 모두 없으면 null.
+ * arrivals 중 waypoint의 line과 매칭되는 trains에서 phase trigger에 가장 적합한 신호를 선택 (#409).
+ *
+ * 선택 순서:
+ *   1. arvlCd ∈ {0, 1} (해당 역 진입/도착) — imminent phase 직결, 즉시 채택
+ *   2. arvlCd ∈ {4, 5} (전역 진입/도착) — early phase 직결, 즉시 채택
+ *   3. 위 둘 모두 없으면 min ETA의 train을 채택 (ETA fallback 경로)
+ *
+ * 라인 매칭 실패 시 전체 arrivals로 fallback. 모두 없으면 null.
  */
-export function pickBestEtaSeconds(
+export function pickBestArrivalSignal(
   arrivals: readonly ArrivalEntry[],
   waypoint: Waypoint,
-): number | null {
+): ArrivalSignal | null {
   if (arrivals.length === 0) return null;
   const matchingLine = arrivals.filter((a) => matchLine(a.subwayNm, waypoint.line));
   const pool = matchingLine.length > 0 ? matchingLine : arrivals;
-  const min = pool.reduce(
-    (acc, cur) => (cur.arrivalSeconds < acc ? cur.arrivalSeconds : acc),
-    Number.POSITIVE_INFINITY,
+
+  // 1순위: imminent 실측 신호 (해당 역 진입/도착).
+  const imminentTrain = pool.find(
+    (a) => a.arvlCd === ARRIVAL_CODE.ENTERING || a.arvlCd === ARRIVAL_CODE.ARRIVED,
   );
-  return Number.isFinite(min) ? min : null;
+  if (imminentTrain) {
+    return { etaSeconds: imminentTrain.arrivalSeconds, arvlCd: imminentTrain.arvlCd };
+  }
+  // 2순위: early 실측 신호 (전역 진입/도착).
+  const earlyTrain = pool.find(
+    (a) => a.arvlCd === ARRIVAL_CODE.PREV_ENTERING || a.arvlCd === ARRIVAL_CODE.PREV_ARRIVED,
+  );
+  if (earlyTrain) {
+    return { etaSeconds: earlyTrain.arrivalSeconds, arvlCd: earlyTrain.arvlCd };
+  }
+  // 3순위: 실측 신호 없음 → min ETA fallback (기존 동작 유지).
+  let best = pool[0];
+  for (const cur of pool) {
+    if (cur.arrivalSeconds < best.arrivalSeconds) best = cur;
+  }
+  return { etaSeconds: best.arrivalSeconds, arvlCd: best.arvlCd };
 }
 
 function isUnrecoverableApnsError(status: number, reason: string | undefined): boolean {

--- a/backend/alarm-worker/src/seoul.ts
+++ b/backend/alarm-worker/src/seoul.ts
@@ -20,6 +20,12 @@ export interface ArrivalEntry {
   isUp: boolean;
   /** 노선명 (예: "지하철1호선") — Seoul API의 subwayNm */
   subwayNm: string;
+  /**
+   * 도착 코드 (Seoul API arvlCd, #409): 0:진입, 1:도착, 2:출발, 3:전역출발,
+   * 4:전역진입, 5:전역도착, 99:운행중. 누락/파싱 실패 시 null.
+   * ETA 예측 대신 실측 신호로 phase 판정하기 위한 핵심 필드.
+   */
+  arvlCd: number | null;
 }
 
 export interface FetchSeoulOptions {
@@ -93,7 +99,18 @@ function parseEntry(raw: unknown, now: number): ArrivalEntry | null {
     trainCode: typeof item.btrainNo === 'string' ? item.btrainNo : '',
     isUp,
     subwayNm: typeof item.subwayNm === 'string' ? item.subwayNm : '',
+    arvlCd: parseArvlCd(item.arvlCd),
   };
+}
+
+/** Seoul API는 arvlCd를 number 또는 numeric string으로 반환 — 둘 다 수용. */
+function parseArvlCd(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string') {
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
 }
 
 export function parseRecptnDt(recptnDt: unknown): number {


### PR DESCRIPTION
## Summary
도착 알림 ~1분 지연의 근본 원인이던 ETA 단독 phase 판정을 Seoul API arvlCd 실측 신호로 교체. arvlCd 없을 땐 기존 ETA 임계값 fallback 유지.

**변경**
- `seoul.ts`: ArrivalEntry에 `arvlCd` 필드 추가, number/numeric string/누락 모두 수용
- `alarm.ts`: `ARRIVAL_CODE` 상수 + `evaluatePhaseFromSignal(eta, arvlCd)` 신규
  - arvlCd ∈ {0 ENTERING, 1 ARRIVED} → **imminent** (실측, 오차 거의 0)
  - arvlCd ∈ {4 PREV_ENTERING, 5 PREV_ARRIVED} → **early** (1정거장 전 실측)
  - 그 외 → ETA 임계값 fallback
- `scheduled.ts`: `pickBestEtaSeconds` → `pickBestArrivalSignal`로 변경, 폴링 루프가 ArrivalSignal({eta, arvlCd}) 사용
- `push fired` 로그에 arvlCd 진단 필드 추가

**효과**
- cron 1분 경계 + Seoul API 갱신 지연으로 발생하던 phase trigger 누락 → 실측 신호로 즉시 발화
- ETA 예측 오차 자체가 발화 시점에 영향을 안 주게 됨

Closes #409

## Test plan
- [x] `npm test` 통과 (89/89, alarm-worker vitest)
- [x] `npx tsc --noEmit` 통과
- [ ] 실기기에서 도착 알림이 실제 도착 ±15초 이내 발화 확인 (Done 기준)
- [ ] 운영에서 `wrangler tail`로 `push fired` 로그의 arvlCd 분포 확인 (실측 신호 비율 vs ETA fallback 비율)