### PR TITLE
chore(#478): silent push 도달 지연 측정 인프라 (sentAt/receivedAt)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -61,7 +61,13 @@ describe('sendSilentPush', () => {
     );
     const result = await sendSilentPush({
       deviceToken: 'devicetoken-hex',
-      payload: { nextWaypoint: '강남', etaSeconds: 60, phase: 'early', kind: 'destination' },
+      payload: {
+        nextWaypoint: '강남',
+        etaSeconds: 60,
+        phase: 'early',
+        kind: 'destination',
+        sentAt: 1_700_000_000_000,
+      },
       config: makeConfig(),
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
@@ -79,6 +85,7 @@ describe('sendSilentPush', () => {
     expect(body.data.etaSeconds).toBe(60);
     expect(body.data.phase).toBe('early');
     expect(body.data.kind).toBe('destination');
+    expect(body.data.sentAt).toBe(1_700_000_000_000);
   });
 
   it('returns failure with reason', async () => {
@@ -87,7 +94,13 @@ describe('sendSilentPush', () => {
     );
     const result = await sendSilentPush({
       deviceToken: 'tok',
-      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent', kind: 'destination' },
+      payload: {
+        nextWaypoint: 'X',
+        etaSeconds: 10,
+        phase: 'imminent',
+        kind: 'destination',
+        sentAt: 1_700_000_000_000,
+      },
       config: makeConfig(),
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
@@ -100,7 +113,13 @@ describe('sendSilentPush', () => {
     const fetchImpl = vi.fn(async () => new Response('plain text', { status: 500 }));
     const result = await sendSilentPush({
       deviceToken: 'tok',
-      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent', kind: 'destination' },
+      payload: {
+        nextWaypoint: 'X',
+        etaSeconds: 10,
+        phase: 'imminent',
+        kind: 'destination',
+        sentAt: 1_700_000_000_000,
+      },
       config: makeConfig(),
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -32,6 +32,11 @@ export interface SilentPushPayload {
   phase: AlarmPhase;
   /** Waypoint 종류. 클라가 intermediate일 때만 즉시 알림 발사하도록 분기 (#416). */
   kind: 'transfer' | 'destination' | 'intermediate';
+  /**
+   * 백엔드 발사 시점 epoch ms (#478 측정 인프라).
+   * 클라 수신 시각과 비교해 silent push 도달 지연 분포 측정용.
+   */
+  sentAt: number;
 }
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
@@ -80,6 +85,7 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       etaSeconds: options.payload.etaSeconds,
       phase: options.payload.phase,
       kind: options.payload.kind,
+      sentAt: options.payload.sentAt,
     },
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -111,6 +111,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
             etaSeconds: eta,
             phase: pushPhase,
             kind: waypoint.kind,
+            sentAt: now,
           },
           config: deps.apnsConfig,
           fetchImpl: deps.fetchImpl,

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -25,6 +25,11 @@ jest.mock('../../utils/alarmScheduler', () => ({
   cancelScheduledAlarms: (...args: unknown[]) => mockCancel(...args),
 }));
 
+const mockLogSilentPushReceived = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
+}));
+
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -173,6 +178,51 @@ describe('silentPushTask', () => {
         }),
       ).toEqual({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: undefined });
     });
+
+    it('sentAt이 number면 그대로 전달 (#478)', () => {
+      expect(
+        extractPayload({
+          notification: {
+            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 1_700_000_000_000 },
+          },
+        }),
+      ).toEqual({
+        nextWaypoint: 'A',
+        etaSeconds: 1,
+        phase: 'early',
+        kind: undefined,
+        sentAt: 1_700_000_000_000,
+      });
+    });
+
+    it('sentAt이 비숫자/Infinity이면 undefined (구 백엔드 호환)', () => {
+      expect(
+        extractPayload({
+          notification: {
+            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 'now' },
+          },
+        }),
+      ).toEqual({
+        nextWaypoint: 'A',
+        etaSeconds: 1,
+        phase: 'early',
+        kind: undefined,
+        sentAt: undefined,
+      });
+      expect(
+        extractPayload({
+          notification: {
+            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: Infinity },
+          },
+        }),
+      ).toEqual({
+        nextWaypoint: 'A',
+        etaSeconds: 1,
+        phase: 'early',
+        kind: undefined,
+        sentAt: undefined,
+      });
+    });
   });
 
   describe('handleSilentPush', () => {
@@ -259,6 +309,32 @@ describe('silentPushTask', () => {
       await handleSilentPush(reschedulePayload({ kind: 'destination', phase: 'imminent' }));
       expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
       expect(mockSchedule).toHaveBeenCalled();
+    });
+
+    it('수신 시 logSilentPushReceived 호출 — sentAt 포함 (#478)', async () => {
+      await handleSilentPush(
+        reschedulePayload({
+          kind: 'transfer',
+          phase: 'early',
+          nextWaypoint: '건대입구',
+          sentAt: 1_700_000_000_000,
+        }),
+      );
+      expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
+      const arg = mockLogSilentPushReceived.mock.calls[0][0];
+      expect(arg.stationName).toBe('건대입구');
+      expect(arg.kind).toBe('transfer');
+      expect(arg.phaseId).toBe('early');
+      expect(arg.sentAt).toBe(1_700_000_000_000);
+      expect(typeof arg.receivedAt).toBe('number');
+    });
+
+    it('수신 시 logSilentPushReceived — 구 백엔드(sentAt 없음)도 호출, sentAt undefined', async () => {
+      await handleSilentPush(reschedulePayload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
+      const arg = mockLogSilentPushReceived.mock.calls[0][0];
+      expect(arg.sentAt).toBeUndefined();
+      expect(typeof arg.receivedAt).toBe('number');
     });
   });
 

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -24,6 +24,7 @@ import type { Route } from '../utils/stationRoute';
 import { scheduleAlarmsForRoute, cancelScheduledAlarms } from '../utils/alarmScheduler';
 import { DESTINATION_KEY, ROUTE_KEY } from '../constants/storageKeys';
 import { createLogger } from '../utils/logger';
+import { logSilentPushReceived } from '../utils/alarmLog';
 
 const logger = createLogger('SilentPushTask');
 
@@ -35,6 +36,12 @@ export interface SilentPushPayload {
   phase: 'early' | 'imminent';
   /** Waypoint 종류 (#416). intermediate면 통과 즉시 알림, 그 외는 reschedule만. 구 백엔드 호환을 위해 optional. */
   kind?: 'transfer' | 'destination' | 'intermediate';
+  /**
+   * 백엔드 발사 시점 epoch ms (#478 측정 인프라).
+   * 클라 수신 시각과 비교해 silent push 도달 지연 측정. 구 백엔드 호환 위해 optional.
+   * 종료 조건: #478 PR 1-2(silent push 단독 발화) 머지 + 신 백엔드 배포 후 required로 승격.
+   */
+  sentAt?: number;
 }
 
 interface NotificationBackgroundTaskData {
@@ -60,13 +67,15 @@ export function extractPayload(
   const raw = notif.data ?? notif.request?.content?.data;
   if (!raw || typeof raw !== 'object') return null;
   const obj = raw as Record<string, unknown>;
-  const { nextWaypoint, etaSeconds, phase, kind } = obj;
+  const { nextWaypoint, etaSeconds, phase, kind, sentAt } = obj;
   if (typeof nextWaypoint !== 'string' || nextWaypoint.length === 0) return null;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
   if (phase !== 'early' && phase !== 'imminent') return null;
   const validKind =
     kind === 'transfer' || kind === 'destination' || kind === 'intermediate' ? kind : undefined;
-  return { nextWaypoint, etaSeconds, phase, kind: validKind };
+  const validSentAt =
+    typeof sentAt === 'number' && Number.isFinite(sentAt) ? sentAt : undefined;
+  return { nextWaypoint, etaSeconds, phase, kind: validKind, sentAt: validSentAt };
 }
 
 /**
@@ -83,9 +92,19 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     logger.info('payload missing or invalid — skip');
     return;
   }
+  const receivedAt = Date.now();
   logger.info(
-    `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds}`,
+    `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'}`,
   );
+
+  // #478 측정 인프라 — 도달 지연 측정용 적재. 동작 변경 없음.
+  logSilentPushReceived({
+    stationName: payload.nextWaypoint,
+    kind: payload.kind,
+    phaseId: payload.phase,
+    sentAt: payload.sentAt,
+    receivedAt,
+  });
 
   try {
     const [destJson, routeJson] = await Promise.all([

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -8,6 +8,7 @@ import {
   logScheduledAlarm,
   logSuppressedDedupStation,
   logSuppressedGate,
+  logSilentPushReceived,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -286,6 +287,63 @@ describe('alarmLog', () => {
         reason: 'gate-accuracy',
         location,
       });
+    });
+
+    it('logSilentPushReceived: source=silent-push-received, outcome=received, sentAt/receivedAt 적재 (#478)', async () => {
+      logSilentPushReceived({
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'early',
+        sentAt: 1_700_000_000_000,
+        receivedAt: 1_700_000_001_500,
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        ts: 1_700_000_001_500,
+        source: 'silent-push-received',
+        outcome: 'received',
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'early',
+        sentAt: 1_700_000_000_000,
+        receivedAt: 1_700_000_001_500,
+      });
+    });
+
+    it('logSilentPushReceived: intermediate → station-passed로 매핑 (#478/#416)', async () => {
+      logSilentPushReceived({
+        stationName: '중곡',
+        kind: 'intermediate',
+        phaseId: 'imminent',
+        sentAt: 1_700_000_000_000,
+        receivedAt: 1_700_000_001_000,
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].kind).toBe('station-passed');
+    });
+
+    it('logSilentPushReceived: kind/sentAt 미상이면 kind 미포함 + sentAt undefined (#478 구 백엔드 호환)', async () => {
+      logSilentPushReceived({
+        stationName: '강남',
+        kind: undefined,
+        phaseId: 'early',
+        sentAt: undefined,
+        receivedAt: 1_700_000_001_000,
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].source).toBe('silent-push-received');
+      expect(saved[0].kind).toBeUndefined();
+      expect(saved[0].sentAt).toBeUndefined();
+      expect(saved[0].receivedAt).toBe(1_700_000_001_000);
     });
 
     it('helper는 fire-and-forget: void 반환 + AsyncStorage 실패 시 throw 안 함', async () => {

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -14,8 +14,10 @@ export const ALARM_LOG_BUFFER_SIZE = 200;
 
 // 'fg' / 'bg'는 v1 (FG GPS 평가 / BG location task gate). 'fg-evaluated' / 'bg-scheduled'는
 // v2 (#372)로 의미 명확화. 두 값 모두 union에 유지해 과거 저장 데이터를 손실 없이 읽는다.
-export type AlarmLogSource = 'fg' | 'bg' | 'fg-evaluated' | 'bg-scheduled';
-export type AlarmLogOutcome = 'fired' | 'suppressed';
+// 'silent-push-received'는 #478 측정 인프라 — silent push 도달 시점 기록 (outcome은 항상
+// 'received', 동작 변경 없음).
+export type AlarmLogSource = 'fg' | 'bg' | 'fg-evaluated' | 'bg-scheduled' | 'silent-push-received';
+export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(evaluateAlarmPhase의 firedAlarms 적중 케이스)은 후속 이슈에서 추가.
 // 그때까지 union에 선언하지 않아 "구현됐다"는 거짓 시그널을 피한다.
 export type AlarmLogReason = 'dedup-station' | 'gate-age' | 'gate-accuracy';
@@ -65,6 +67,11 @@ export interface AlarmLogEntry {
   selectedArrivalSeconds?: number | null;
   expectedStationAtFire?: string | null;
   actualLastNotifiedStation?: string | null;
+  // #478 — silent push 측정 인프라. silent-push-received 엔트리에서만 사용.
+  // sentAt: 백엔드 발사 시점(payload), receivedAt: 클라 수신 시점.
+  // 두 시각 차로 도달 지연 분포 측정.
+  sentAt?: number;
+  receivedAt?: number;
 }
 
 const logger = createLogger('AlarmLog');
@@ -124,6 +131,35 @@ export function logSuppressedDedupStation(source: AlarmLogSource, station: Stati
     reason: 'dedup-station',
     stationName: station.name,
     kind: 'station-passed',
+  });
+}
+
+/**
+ * silent push 수신 1건 적재 (#478 측정 인프라).
+ * sentAt(백엔드 payload)와 receivedAt(클라 수신 시점) 차로 도달 지연 측정.
+ * sentAt이 없으면(구 백엔드) undefined로 기록 — 추후 백엔드 배포 전후 분리 분석 가능.
+ * 동작 변경 없음 — 데이터만 모은다.
+ */
+export function logSilentPushReceived(input: {
+  stationName: string;
+  kind: AlarmLogKind | 'intermediate' | undefined;
+  phaseId: AlarmPhaseId;
+  sentAt: number | undefined;
+  receivedAt: number;
+}): void {
+  // 'intermediate'는 station-passed에 매핑 (#416 silent push intermediate 흐름).
+  // kind 미상(구 백엔드)이면 kind 필드 자체를 비워둔다.
+  const mappedKind: AlarmLogKind | undefined =
+    input.kind === 'intermediate' ? 'station-passed' : input.kind;
+  void appendAlarmLog({
+    ts: input.receivedAt,
+    source: 'silent-push-received',
+    outcome: 'received',
+    stationName: input.stationName,
+    kind: mappedKind,
+    phaseId: input.phaseId,
+    sentAt: input.sentAt,
+    receivedAt: input.receivedAt,
   });
 }
 


### PR DESCRIPTION
## Summary

이슈 #478의 첫 PR(1-1) — silent push 도달 지연을 측정하기 위한 데이터 컬럼만 추가한다. **동작 변경 없음**.

- 백엔드 APNs payload에 `sentAt: number` 추가 (`apns.ts:35`, `scheduled.ts:117`)
- 클라 `silentPushTask`가 수신 시 `receivedAt = Date.now()` 캡처 후 `logSilentPushReceived` 적재
- `alarmLog` 확장
  - 신규 source `'silent-push-received'` + outcome `'received'`
  - 신규 필드 `sentAt?`, `receivedAt?`
  - 신규 helper `logSilentPushReceived` (intermediate kind → station-passed 매핑)

## 왜 측정 인프라부터

PR 1-2(silent push 단독 발화)는 silent push가 BG 알림의 실제 발화원이 되도록 전환한다. 그 전에 도달 지연 분포를 알아야 다음을 결정할 수 있다:
- iOS throttling 영향 (분당 ~3회 제한 가능)
- 환승 trip에서 연속 push 발사 안정성
- 사전예약 회로 차단 시 발생 가능한 미수신 비율

본 PR이 데이터를 모으고, 운영 1~2일 후 #478 PR 1-2에서 단독 발화로 전환한다.

## 결정 사항

- **`sentAt` 비대칭** — 백엔드는 required, 클라는 optional. 신 백엔드 배포 전 구 백엔드 호환을 위한 한시적 비대칭. PR 1-2 머지 + 신 백엔드 배포 후 required로 승격 (주석 명시).
- **'intermediate' 매핑** — `AlarmLogKind`에 없으므로 `station-passed`로 매핑. #416 의미와 일관.
- **`receivedAt` 시점** — `handleSilentPush` 진입 직후 캡처. AsyncStorage I/O 지연이 측정값에 섞이지 않게.

## Test plan

- [x] 백엔드 vitest 78/78 pass + type-check pass
- [x] 클라 jest 1547/1547 pass + 커버리지 100% + type-check pass
- [x] code-reviewer 통과 (P0/P1 0건, P2-2 sentAt 종료 조건 주석만 반영)
- [ ] 운영 배포 후 alarmLog에 silent-push-received 엔트리 정상 적재 확인
- [ ] wrangler tail 로그와 클라 receivedAt 매칭으로 도달 지연 분포 1~2일 관찰

Relates to #478