### PR TITLE
feat(#468): schedule fallback ETA anchoring (카운트다운 점프 방지)

### DIFF
--- a/src/hooks/__tests__/useArrivalCountdown.test.ts
+++ b/src/hooks/__tests__/useArrivalCountdown.test.ts
@@ -65,12 +65,26 @@ describe('useArrivalCountdown', () => {
     expect(result.current!.up[0].arrivalMinutes).toBe(0);
   });
 
-  it('isMock인 데이터는 카운트다운하지 않는다', () => {
+  it('source 없는 isMock 데이터(하드코딩 MOCK)는 카운트다운하지 않는다', () => {
     const { result } = renderHook(() => useArrivalCountdown(mockArrivalMock));
 
     act(() => { jest.advanceTimersByTime(3_000); });
 
     expect(result.current).toEqual(mockArrivalMock);
+  });
+
+  it('source=schedule fallback은 isMock=true여도 카운트다운한다 (이슈 #468)', () => {
+    const scheduleArrival: StationArrival = {
+      ...mockArrival,
+      isMock: true,
+      source: 'schedule',
+    };
+    const { result } = renderHook(() => useArrivalCountdown(scheduleArrival));
+
+    act(() => { jest.advanceTimersByTime(3_000); });
+
+    expect(result.current!.up[0].arrivalSeconds).toBe(117);
+    expect(result.current!.down[0].arrivalSeconds).toBe(87);
   });
 
   it('새 arrival 데이터가 들어오면 값이 리셋된다', () => {

--- a/src/hooks/useArrivalCountdown.ts
+++ b/src/hooks/useArrivalCountdown.ts
@@ -24,11 +24,12 @@ export function useArrivalCountdown(arrival: StationArrival | null): StationArri
     setDisplay(arrival);
   }, [arrival]);
 
-  // Countdown every second for non-mock data
-  const isMock = arrival?.isMock === true;
-  const hasArrival = arrival != null;
+  // 실시간 응답뿐 아니라 schedule fallback도 1초 카운트다운 진행 (이슈 #468).
+  // schedule은 isMock=true지만 wall-clock anchor 기반이라 폴링마다 연속 감소한다.
+  // 하드코딩 MOCK_ARRIVALS(source 없음)는 데모용 정적값이므로 종전대로 tick 제외.
+  const isCountable = arrival != null && (arrival.isMock !== true || arrival.source === 'schedule');
   useEffect(() => {
-    if (!hasArrival || isMock) return;
+    if (!isCountable) return;
 
     const id = setInterval(() => {
       const current = arrivalRef.current!;
@@ -42,7 +43,7 @@ export function useArrivalCountdown(arrival: StationArrival | null): StationArri
     }, COUNTDOWN_INTERVAL_MS);
 
     return () => clearInterval(id);
-  }, [hasArrival, isMock]);
+  }, [isCountable]);
 
   return display;
 }

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -83,8 +83,9 @@ describe('BffArrivalProvider', () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 503 });
     const result = await callGetArrival('서울역', { lineHint: '4' });
     expect(result.source).toBe('schedule');
-    // 4호선 평일 offPeak headway 360s → 첫 차 180s
-    expect(result.up[0].arrivalSeconds).toBe(180);
+    // 4호선 평일 offPeak headway 360s → wall-clock anchor 기반이라 (0, 360] 범위
+    expect(result.up[0].arrivalSeconds).toBeGreaterThan(0);
+    expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(360);
   });
 
   it.each([

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -64,34 +64,41 @@ describe('buildScheduleArrival', () => {
     expect(result.isMock).toBe(true);
   });
 
+  // wall-clock anchor 기반이므로 정확한 값은 nowMs % headway에 의존.
+  // 시간대별 헤드웨이 분류와 anchor 범위(0 < first <= headway, second = first + headway)를 검증.
+
   it('returns 2 up/down trains during weekday peak with line 2 headway 150s', () => {
     const now = new Date('2026-05-18T08:00:00+09:00');
     const result = buildScheduleArrival('2', now);
     expect(result.source).toBe('schedule');
     expect(result.up).toHaveLength(2);
     expect(result.down).toHaveLength(2);
-    expect(result.up[0].arrivalSeconds).toBe(75);
-    expect(result.up[1].arrivalSeconds).toBe(225);
+    const first = result.up[0].arrivalSeconds;
+    expect(first).toBeGreaterThan(0);
+    expect(first).toBeLessThanOrEqual(150);
+    expect(result.up[1].arrivalSeconds).toBe(first + 150);
   });
 
   it('uses offPeak headway during weekday daytime', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
     const result = buildScheduleArrival('1', now);
     expect(result.source).toBe('schedule');
-    expect(result.up[0].arrivalSeconds).toBe(180); // 360/2
+    const first = result.up[0].arrivalSeconds;
+    expect(first).toBeGreaterThan(0);
+    expect(first).toBeLessThanOrEqual(360);
   });
 
   it('uses saturday offPeak even during what would be peak time', () => {
     const now = new Date('2026-05-16T08:00:00+09:00'); // Saturday
     const result = buildScheduleArrival('2', now);
-    expect(result.up[0].arrivalSeconds).toBe(165); // 330/2
+    expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(330);
   });
 
   it('falls back to offPeak headway if peak entry missing (weekend peak lookup is never triggered, but defensive)', () => {
     const now = new Date('2026-05-18T08:00:00+09:00');
     const result = buildScheduleArrival('gyeongui', now);
     expect(result.source).toBe('schedule');
-    expect(result.up[0].arrivalSeconds).toBe(270); // 540/2
+    expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(540);
   });
 
   it('sets receivedAtMs to now.getTime()', () => {
@@ -104,19 +111,39 @@ describe('buildScheduleArrival', () => {
     const now = new Date('2026-05-18T23:00:00+09:00');
     const result = buildScheduleArrival('2', now);
     expect(result.source).toBe('schedule');
-    expect(result.up[0].arrivalSeconds).toBe(240); // 480/2
+    expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(480);
   });
 
   it('handles sunday late period', () => {
     const now = new Date('2026-05-17T22:30:00+09:00');
     const result = buildScheduleArrival('1', now);
-    expect(result.up[0].arrivalSeconds).toBe(330); // 660/2
+    expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(660);
   });
 
   it('arrivalMinutes equals floor(arrivalSeconds/60)', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
     const result = buildScheduleArrival('1', now);
-    expect(result.up[0].arrivalMinutes).toBe(3); // floor(180/60)
+    expect(result.up[0].arrivalMinutes).toBe(Math.floor(result.up[0].arrivalSeconds / 60));
+  });
+
+  it('anchors next departure to wall-clock so polling (+5s) returns continuously decreasing ETA', () => {
+    const t0 = new Date('2026-05-18T15:00:00.000+09:00');
+    const t5 = new Date(t0.getTime() + 5_000);
+    const r0 = buildScheduleArrival('2', t0);
+    const r5 = buildScheduleArrival('2', t5);
+    // 둘 다 schedule이고 같은 헤드웨이 격자 안이라면 +5s 폴링 결과는 5초 적게 남아야 함.
+    // 트레인 시프트 직후가 아니면 정확히 -5s.
+    if (r0.up[0].arrivalSeconds > 5) {
+      expect(r5.up[0].arrivalSeconds).toBe(r0.up[0].arrivalSeconds - 5);
+    }
+  });
+
+  it('shifts next-departure anchor when nowMs lies exactly on grid (no 0s train shown)', () => {
+    // line 1 offPeak headway = 360s. grid 정렬 케이스 강제.
+    const headwayMs = 360_000;
+    const alignedMs = Math.ceil(new Date('2026-05-18T15:00:00+09:00').getTime() / headwayMs) * headwayMs;
+    const result = buildScheduleArrival('1', new Date(alignedMs));
+    expect(result.up[0].arrivalSeconds).toBe(360); // 다음 격자로 시프트되어 headway 그대로
   });
 
   it('returns source=closed when line key is missing from headway table (defensive)', () => {

--- a/src/utils/scheduleFallback.ts
+++ b/src/utils/scheduleFallback.ts
@@ -99,7 +99,13 @@ export function buildScheduleArrival(line: LineNumber, now: Date): StationArriva
     return { up: [], down: [], isMock: true, source: 'closed' };
   }
 
-  const first = Math.round(headway / 2);
+  // 다음 발차를 wall-clock 헤드웨이 격자에 정렬한다.
+  // 폴링 사이클(5s)마다 같은 anchor를 산출해 ETA가 연속적으로 감소 (이슈 #468).
+  // 정확히 격자 위(remainder=0)면 첫 차는 다음 격자(headway초 뒤)로 보내 0초 트레인 표시를 방지.
+  const headwayMs = headway * 1000;
+  const remainder = nowMs % headwayMs;
+  const msUntilFirst = remainder === 0 ? headwayMs : headwayMs - remainder;
+  const first = Math.round(msUntilFirst / 1000);
   const second = first + headway;
   const up = [makeTrain(first, 'UP-1', nowMs), makeTrain(second, 'UP-2', nowMs)];
   const down = [makeTrain(first, 'DN-1', nowMs), makeTrain(second, 'DN-2', nowMs)];


### PR DESCRIPTION
## 무엇을
- `buildScheduleArrival`: wall-clock 헤드웨이 격자 anchor 도입
- `useArrivalCountdown`: `source === 'schedule'`일 때도 1초 카운트다운 활성화

## 왜
- 기존: `first = headway/2` 고정값 → 5s 폴링마다 같은 ETA 반환 → 사용자에겐 "줄지 않는 시간"
- 추가로 `useArrivalCountdown`가 `isMock===true`이면 1초 ticking을 skip → schedule fallback 표시 시 카운트다운 없음
- Closes #468

## 어떻게
- `buildScheduleArrival`: `nowMs % headwayMs`로 다음 발차 격자 산출 → 폴링 사이클이 짧아도 ETA가 연속 감소
- grid 정렬 경계(remainder=0)는 다음 격자로 시프트해 0초 트레인 표시 방지
- `useArrivalCountdown`: `isCountable = !isMock || source === 'schedule'`. 하드코딩 MOCK(`source` 없음)은 종전대로 정적 유지

## 테스트
- 고정값(`75`, `180` 등) 검증을 범위/관계 검증으로 일반화
- +5s 폴링 연속성 회귀
- grid 정렬 경계 시프트 회귀
- schedule source 카운트다운 / 하드코딩 MOCK 비카운트다운 분기 회귀
- `npm test` 1548/1548 통과, 커버리지 100%
- `npm run type-check` 통과

Closes #468