### PR TITLE
fix(#482): APNs BadDeviceToken — dev/preview 빌드 silent push 미수신

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,8 @@ EXPO_PUBLIC_ALARM_BACKEND_URL=
 # DebugModal을 release 빌드에서도 노출 (개인 진단용 #456)
 # "true"일 때만 설정 탭 버전 7탭 트리거가 작동. 일반 배포 빌드에는 절대 켜지 말 것.
 EXPO_PUBLIC_DEBUG_MODAL=
+
+# APNs 토큰 환경 (#482). dev/preview 빌드는 sandbox 토큰을 발급받고,
+# production 빌드(TestFlight/App Store)는 production 토큰을 발급받는다.
+# 미설정 시 'sandbox' fallback. EAS production profile에서만 'production'으로 명시 설정.
+EXPO_PUBLIC_APNS_ENV=

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -113,7 +113,9 @@ describe('sendSilentPush', () => {
   });
 
   it('uses sandbox host when provided', async () => {
-    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      new Response('', { status: 200 }),
+    );
     await sendSilentPush({
       deviceToken: 'tok',
       payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'early', kind: 'destination' },

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -16,9 +16,10 @@ beforeAll(async () => {
   privateKeyPem = await exportPKCS8(privateKey);
 });
 
+const TEST_HOST = 'api.push.apple.com';
+
 function makeConfig(): ApnsConfig {
   return {
-    host: 'api.push.apple.com',
     keyId: 'KEY123',
     teamId: 'TEAM456',
     privateKeyPem,
@@ -63,12 +64,13 @@ describe('sendSilentPush', () => {
       deviceToken: 'devicetoken-hex',
       payload: { nextWaypoint: '강남', etaSeconds: 60, phase: 'early', kind: 'destination' },
       config: makeConfig(),
+      host: TEST_HOST,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(result.ok).toBe(true);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const [url, init] = fetchImpl.mock.calls[0];
-    expect(url).toContain('/3/device/devicetoken-hex');
+    expect(url).toBe(`https://${TEST_HOST}/3/device/devicetoken-hex`);
     const headers = (init as RequestInit).headers as Record<string, string>;
     expect(headers['apns-topic']).toBe('com.example.app');
     expect(headers['apns-push-type']).toBe('background');
@@ -89,6 +91,7 @@ describe('sendSilentPush', () => {
       deviceToken: 'tok',
       payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent', kind: 'destination' },
       config: makeConfig(),
+      host: TEST_HOST,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(result.ok).toBe(false);
@@ -102,9 +105,23 @@ describe('sendSilentPush', () => {
       deviceToken: 'tok',
       payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'imminent', kind: 'destination' },
       config: makeConfig(),
+      host: TEST_HOST,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(result.ok).toBe(false);
     expect(result.reason).toBeUndefined();
+  });
+
+  it('uses sandbox host when provided', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'early', kind: 'destination' },
+      config: makeConfig(),
+      host: 'api.sandbox.push.apple.com',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const [url] = fetchImpl.mock.calls[0];
+    expect(url).toBe('https://api.sandbox.push.apple.com/3/device/tok');
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -78,6 +78,16 @@ describe('validateTrip', () => {
     expect(trip?.lastFiredPhase).toBeUndefined();
   });
 
+  it('preserves valid apnsEnv', () => {
+    expect(validateTrip({ ...base(), apnsEnv: 'sandbox' })?.apnsEnv).toBe('sandbox');
+    expect(validateTrip({ ...base(), apnsEnv: 'production' })?.apnsEnv).toBe('production');
+  });
+
+  it('drops invalid apnsEnv', () => {
+    expect(validateTrip({ ...base(), apnsEnv: 'bogus' })?.apnsEnv).toBeUndefined();
+    expect(validateTrip(base())?.apnsEnv).toBeUndefined();
+  });
+
   it('rejects missing alarmAtEpochMs', () => {
     const b = base();
     delete b.alarmAtEpochMs;

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1,7 +1,7 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
-import { pickActiveWaypoint, pickBestEtaSeconds, runScheduled } from '../scheduled';
+import { pickActiveWaypoint, pickApnsHost, pickBestEtaSeconds, runScheduled } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
 import { putTrip } from '../trips';
 import type { Env, Trip } from '../types';
@@ -34,7 +34,6 @@ beforeAll(async () => {
   const { privateKey } = await generateKeyPair('ES256');
   const pem = await exportPKCS8(privateKey);
   apnsConfig = {
-    host: 'api.push.apple.com',
     keyId: 'K',
     teamId: 'T',
     privateKeyPem: pem,
@@ -46,10 +45,16 @@ beforeEach(() => resetApnsJwtCache());
 
 const NOW = 1_700_000_000_000;
 
+const APNS_HOSTS = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+} as const;
+
 function makeEnv(kv: InMemoryKV): Env {
   return {
     TRIPS: kv as unknown as KVNamespace,
-    APNS_HOST: 'api.push.apple.com',
+    APNS_HOST: APNS_HOSTS.production,
+    APNS_HOST_SANDBOX: APNS_HOSTS.sandbox,
     SEOUL_API_HOST: 'seoul.api',
     SEOUL_API_KEY: 'KEY',
     APNS_KEY_ID: 'K',
@@ -91,6 +96,7 @@ async function runWithImminent(
   const stats = await runScheduled(makeEnv(kv), {
     seoul,
     apnsConfig,
+    apnsHosts: APNS_HOSTS,
     fetchImpl: apnsFetch as unknown as typeof fetch,
     now: () => NOW,
   });
@@ -158,6 +164,18 @@ describe('pickBestEtaSeconds', () => {
   });
 });
 
+describe('pickApnsHost', () => {
+  it('returns sandbox host when apnsEnv is sandbox', () => {
+    expect(pickApnsHost('sandbox', APNS_HOSTS)).toBe(APNS_HOSTS.sandbox);
+  });
+  it('returns production host when apnsEnv is production', () => {
+    expect(pickApnsHost('production', APNS_HOSTS)).toBe(APNS_HOSTS.production);
+  });
+  it('returns production host when apnsEnv is undefined (backward compat)', () => {
+    expect(pickApnsHost(undefined, APNS_HOSTS)).toBe(APNS_HOSTS.production);
+  });
+});
+
 describe('runScheduled', () => {
   it('skips trips outside polling window', async () => {
     const kv = new InMemoryKV();
@@ -167,6 +185,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       fetchImpl: fetchSpy as unknown as typeof fetch,
       now: () => NOW,
     });
@@ -184,6 +203,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul: makeSeoul([]),
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       now: () => NOW + 10_000,
     });
     expect(stats.polled).toBe(0);
@@ -241,6 +261,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       now: () => NOW,
     });
     expect(stats.etaMissing).toBe(1);
@@ -260,6 +281,7 @@ describe('runScheduled', () => {
     const stats1 = await runScheduled(makeEnv(kv), {
       seoul: seoul1,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       fetchImpl: fetchEarly as unknown as typeof fetch,
       now: () => NOW,
     });
@@ -274,6 +296,7 @@ describe('runScheduled', () => {
     const stats2 = await runScheduled(makeEnv(kv), {
       seoul: seoul2,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       fetchImpl: fetchImminent as unknown as typeof fetch,
       now: () => NOW + 30_000,
     });
@@ -294,6 +317,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
     });
@@ -313,6 +337,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
     });
@@ -339,6 +364,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
     });
@@ -367,6 +393,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
     });
@@ -399,6 +426,7 @@ describe('runScheduled', () => {
     const stats = await runScheduled(makeEnv(kv), {
       seoul: failingSeoul,
       apnsConfig,
+      apnsHosts: APNS_HOSTS,
       now: () => NOW,
     });
     expect(stats.errors).toBe(1);

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -206,8 +206,8 @@ describe('pickApnsHost', () => {
   it('returns production host when apnsEnv is production', () => {
     expect(pickApnsHost('production', APNS_HOSTS)).toBe(APNS_HOSTS.production);
   });
-  it('returns production host when apnsEnv is undefined (backward compat)', () => {
-    expect(pickApnsHost(undefined, APNS_HOSTS)).toBe(APNS_HOSTS.production);
+  it('falls back to sandbox host when apnsEnv is undefined (#482 safe default)', () => {
+    expect(pickApnsHost(undefined, APNS_HOSTS)).toBe(APNS_HOSTS.sandbox);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -377,19 +377,20 @@ describe('runScheduled', () => {
   // #482 self-heal (D안): BadDeviceToken은 토큰 자체 무효가 아니라 host 환경 불일치인 경우가
   // 압도적. 반대 host로 1회 재시도해 성공하면 trip.apnsEnv를 정정하고, 재시도도 실패하면
   // 그제서야 진짜 unrecoverable로 분류해 trip을 삭제한다.
-  it('self-heal: 1차 sandbox 실패(BadDeviceToken) → 2차 production 성공 → apnsEnv 정정', async () => {
+  const BAD_TOKEN = () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
+  const PAYLOAD_TOO_LARGE = () => new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 400 });
+  const UNREGISTERED = () => new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 });
+  const OK = () => new Response('', { status: 200 });
+
+  async function runWithFetch(
+    apnsEnv: 'sandbox' | 'production' | undefined,
+    apnsFetch: ReturnType<typeof vi.fn>,
+  ) {
     const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'sandbox' }));
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv }));
     const seoul = makeSeoul([
       { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
     ]);
-    const apnsFetch = vi
-      .fn(async (url: string) => {
-        if (url.includes('sandbox')) {
-          return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
-        }
-        return new Response('', { status: 200 });
-      });
     const stats = await runScheduled(makeEnv(kv), {
       seoul,
       apnsConfig,
@@ -397,58 +398,41 @@ describe('runScheduled', () => {
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
     });
+    return { stats, kv };
+  }
+
+  /** host(sandbox/production)별로 다른 응답을 내는 fetch mock. */
+  function fetchByHost(handlers: { sandbox: () => Response; production: () => Response }) {
+    return vi.fn(async (url: string) =>
+      url.includes('sandbox') ? handlers.sandbox() : handlers.production(),
+    );
+  }
+
+  function storedTrip(kv: InMemoryKV): Trip {
+    return JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
+  }
+
+  it('self-heal: 1차 sandbox 실패(BadDeviceToken) → 2차 production 성공 → apnsEnv 정정', async () => {
+    const apnsFetch = fetchByHost({ sandbox: BAD_TOKEN, production: OK });
+    const { stats, kv } = await runWithFetch('sandbox', apnsFetch);
     expect(stats.pushed).toBe(1);
     expect(stats.errors).toBe(0);
     expect(stats.envCorrected).toBe(1);
     expect(apnsFetch).toHaveBeenCalledTimes(2);
-    // KV 정정 저장 확인 — 다음 cycle은 1-shot으로 production host 사용
-    expect(kv.store.size).toBe(1);
-    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
-    expect(stored.apnsEnv).toBe('production');
+    expect(storedTrip(kv).apnsEnv).toBe('production');
   });
 
   it('self-heal: 1차 production 실패 → 2차 sandbox 성공 → apnsEnv=sandbox 정정', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'production' }));
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi
-      .fn(async (url: string) => {
-        if (url.includes('sandbox')) {
-          return new Response('', { status: 200 });
-        }
-        return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
-      });
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    const apnsFetch = fetchByHost({ sandbox: OK, production: BAD_TOKEN });
+    const { stats, kv } = await runWithFetch('production', apnsFetch);
     expect(stats.pushed).toBe(1);
     expect(stats.envCorrected).toBe(1);
-    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
-    expect(stored.apnsEnv).toBe('sandbox');
+    expect(storedTrip(kv).apnsEnv).toBe('sandbox');
   });
 
   it('self-heal: 1차/2차 모두 BadDeviceToken → 진짜 unrecoverable, trip 삭제', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'sandbox' }));
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
-    );
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    const apnsFetch = vi.fn(BAD_TOKEN);
+    const { stats, kv } = await runWithFetch('sandbox', apnsFetch);
     expect(apnsFetch).toHaveBeenCalledTimes(2);
     expect(stats.errors).toBe(1);
     expect(stats.envCorrected).toBe(0);
@@ -456,103 +440,38 @@ describe('runScheduled', () => {
   });
 
   it('self-heal: apnsEnv=undefined trip(구버전 클라이언트) → sandbox로 시작 → production 정정', async () => {
-    const kv = new InMemoryKV();
-    // apnsEnv 필드 자체를 보내지 않은 구버전 클라이언트 trip
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: undefined }));
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi
-      .fn(async (url: string) => {
-        // 1차: sandbox host (pickApnsHost fallback) → 실패. 2차: production → 성공.
-        if (url.includes('sandbox')) {
-          return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
-        }
-        return new Response('', { status: 200 });
-      });
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    // 1차: sandbox host (pickApnsHost fallback) → 실패. 2차: production → 성공.
+    const apnsFetch = fetchByHost({ sandbox: BAD_TOKEN, production: OK });
+    const { stats, kv } = await runWithFetch(undefined, apnsFetch);
     expect(stats.envCorrected).toBe(1);
     expect(stats.pushed).toBe(1);
-    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
-    expect(stored.apnsEnv).toBe('production');
+    expect(storedTrip(kv).apnsEnv).toBe('production');
   });
 
   it('self-heal retry가 다른 종류 에러(non-mismatch 400)면 trip 유지, exhausted 아님', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'sandbox' }));
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
     // 1차 sandbox BadDeviceToken → 2차 production은 PayloadTooLarge (env 문제는 아님)
-    const apnsFetch = vi
-      .fn(async (url: string) => {
-        if (url.includes('sandbox')) {
-          return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
-        }
-        return new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 400 });
-      });
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    const apnsFetch = fetchByHost({ sandbox: BAD_TOKEN, production: PAYLOAD_TOO_LARGE });
+    const { stats, kv } = await runWithFetch('sandbox', apnsFetch);
     expect(stats.errors).toBe(1);
     expect(stats.envCorrected).toBe(0);
-    // PayloadTooLarge는 unrecoverable 아니고 exhausted도 아님 → trip 유지
     expect(kv.store.size).toBe(1);
   });
 
   it('410 Unregistered → self-heal 우회, 즉시 trip 삭제 (회귀 방지)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'production' }));
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
-    );
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
-    // 410은 retry 안 함 — 1번만 호출
-    expect(apnsFetch).toHaveBeenCalledTimes(1);
+    const apnsFetch = vi.fn(UNREGISTERED);
+    const { stats, kv } = await runWithFetch('production', apnsFetch);
+    expect(apnsFetch).toHaveBeenCalledTimes(1); // 410은 retry 안 함
     expect(stats.errors).toBe(1);
     expect(stats.envCorrected).toBe(0);
     expect(kv.store.size).toBe(0);
   });
 
   it('400 그 외 reason은 self-heal 안 함, trip 유지 (recoverable error)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'production' }));
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 400 }),
-    );
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
+    const apnsFetch = vi.fn(PAYLOAD_TOO_LARGE);
+    const { stats, kv } = await runWithFetch('production', apnsFetch);
     expect(apnsFetch).toHaveBeenCalledTimes(1);
     expect(stats.errors).toBe(1);
     expect(stats.envCorrected).toBe(0);
-    // 400 PayloadTooLarge는 unrecoverable이 아니므로 trip 유지
     expect(kv.store.size).toBe(1);
   });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2,6 +2,7 @@ import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
 import {
+  flipApnsEnv,
   pickActiveWaypoint,
   pickApnsHost,
   pickBestArrivalSignal,
@@ -199,6 +200,19 @@ describe('pickBestArrivalSignal (#409)', () => {
   });
 });
 
+describe('flipApnsEnv (#482 self-heal)', () => {
+  it('sandbox → production', () => {
+    expect(flipApnsEnv('sandbox')).toBe('production');
+  });
+  it('production → sandbox', () => {
+    expect(flipApnsEnv('production')).toBe('sandbox');
+  });
+  it('undefined → production (sandbox default 짝)', () => {
+    // pickApnsHost가 undefined를 sandbox로 시작하므로, flip은 production이 되어야 한다.
+    expect(flipApnsEnv(undefined)).toBe('production');
+  });
+});
+
 describe('pickApnsHost', () => {
   it('returns sandbox host when apnsEnv is sandbox', () => {
     expect(pickApnsHost('sandbox', APNS_HOSTS)).toBe(APNS_HOSTS.sandbox);
@@ -360,9 +374,68 @@ describe('runScheduled', () => {
     expect(stats.pushed).toBe(0);
   });
 
-  it('removes trip on BadDeviceToken', async () => {
+  // #482 self-heal (D안): BadDeviceToken은 토큰 자체 무효가 아니라 host 환경 불일치인 경우가
+  // 압도적. 반대 host로 1회 재시도해 성공하면 trip.apnsEnv를 정정하고, 재시도도 실패하면
+  // 그제서야 진짜 unrecoverable로 분류해 trip을 삭제한다.
+  it('self-heal: 1차 sandbox 실패(BadDeviceToken) → 2차 production 성공 → apnsEnv 정정', async () => {
     const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'sandbox' }));
+    const seoul = makeSeoul([
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+    ]);
+    const apnsFetch = vi
+      .fn(async (url: string) => {
+        if (url.includes('sandbox')) {
+          return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
+        }
+        return new Response('', { status: 200 });
+      });
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBe(1);
+    expect(stats.errors).toBe(0);
+    expect(stats.envCorrected).toBe(1);
+    expect(apnsFetch).toHaveBeenCalledTimes(2);
+    // KV 정정 저장 확인 — 다음 cycle은 1-shot으로 production host 사용
+    expect(kv.store.size).toBe(1);
+    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
+    expect(stored.apnsEnv).toBe('production');
+  });
+
+  it('self-heal: 1차 production 실패 → 2차 sandbox 성공 → apnsEnv=sandbox 정정', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'production' }));
+    const seoul = makeSeoul([
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+    ]);
+    const apnsFetch = vi
+      .fn(async (url: string) => {
+        if (url.includes('sandbox')) {
+          return new Response('', { status: 200 });
+        }
+        return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
+      });
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBe(1);
+    expect(stats.envCorrected).toBe(1);
+    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
+    expect(stored.apnsEnv).toBe('sandbox');
+  });
+
+  it('self-heal: 1차/2차 모두 BadDeviceToken → 진짜 unrecoverable, trip 삭제', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'sandbox' }));
     const seoul = makeSeoul([
       { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
     ]);
@@ -376,8 +449,111 @@ describe('runScheduled', () => {
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
     });
+    expect(apnsFetch).toHaveBeenCalledTimes(2);
     expect(stats.errors).toBe(1);
+    expect(stats.envCorrected).toBe(0);
     expect(kv.store.size).toBe(0);
+  });
+
+  it('self-heal: apnsEnv=undefined trip(구버전 클라이언트) → sandbox로 시작 → production 정정', async () => {
+    const kv = new InMemoryKV();
+    // apnsEnv 필드 자체를 보내지 않은 구버전 클라이언트 trip
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: undefined }));
+    const seoul = makeSeoul([
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+    ]);
+    const apnsFetch = vi
+      .fn(async (url: string) => {
+        // 1차: sandbox host (pickApnsHost fallback) → 실패. 2차: production → 성공.
+        if (url.includes('sandbox')) {
+          return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
+        }
+        return new Response('', { status: 200 });
+      });
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.envCorrected).toBe(1);
+    expect(stats.pushed).toBe(1);
+    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
+    expect(stored.apnsEnv).toBe('production');
+  });
+
+  it('self-heal retry가 다른 종류 에러(non-mismatch 400)면 trip 유지, exhausted 아님', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'sandbox' }));
+    const seoul = makeSeoul([
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+    ]);
+    // 1차 sandbox BadDeviceToken → 2차 production은 PayloadTooLarge (env 문제는 아님)
+    const apnsFetch = vi
+      .fn(async (url: string) => {
+        if (url.includes('sandbox')) {
+          return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
+        }
+        return new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 400 });
+      });
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.errors).toBe(1);
+    expect(stats.envCorrected).toBe(0);
+    // PayloadTooLarge는 unrecoverable 아니고 exhausted도 아님 → trip 유지
+    expect(kv.store.size).toBe(1);
+  });
+
+  it('410 Unregistered → self-heal 우회, 즉시 trip 삭제 (회귀 방지)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'production' }));
+    const seoul = makeSeoul([
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+    ]);
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
+    );
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // 410은 retry 안 함 — 1번만 호출
+    expect(apnsFetch).toHaveBeenCalledTimes(1);
+    expect(stats.errors).toBe(1);
+    expect(stats.envCorrected).toBe(0);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('400 그 외 reason은 self-heal 안 함, trip 유지 (recoverable error)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv: 'production' }));
+    const seoul = makeSeoul([
+      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+    ]);
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 400 }),
+    );
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(apnsFetch).toHaveBeenCalledTimes(1);
+    expect(stats.errors).toBe(1);
+    expect(stats.envCorrected).toBe(0);
+    // 400 PayloadTooLarge는 unrecoverable이 아니므로 trip 유지
+    expect(kv.store.size).toBe(1);
   });
 
   // #416: 중간역(intermediate) 처리 — early phase 스킵, imminent에서만 push + shift.

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -8,7 +8,11 @@
 import { importPKCS8, SignJWT } from 'jose';
 import type { AlarmPhase } from './alarm';
 
-/** APNs JWT는 1시간 이내 재사용 가능. Worker 인스턴스 메모리에 캐시한다. */
+/**
+ * APNs JWT는 1시간 이내 재사용 가능. Worker 인스턴스 메모리에 캐시한다.
+ * JWT는 host와 독립적(keyId/teamId 만으로 서명)이므로 self-heal에서
+ * sandbox↔production host를 바꿔도 동일 JWT를 재사용한다.
+ */
 interface JwtCache {
   token: string;
   expiresAt: number;

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -19,7 +19,6 @@ const JWT_TTL_MS = 50 * 60 * 1000; // 50분 (APNs는 1시간이지만 여유)
 let jwtCache: JwtCache | null = null;
 
 export interface ApnsConfig {
-  host: string;
   keyId: string;
   teamId: string;
   privateKeyPem: string;
@@ -58,6 +57,8 @@ export interface SendPushOptions {
   deviceToken: string;
   payload: SilentPushPayload;
   config: ApnsConfig;
+  /** APNs 엔드포인트 host. trip의 apnsEnv에 따라 sandbox/production 중 선택해 전달. */
+  host: string;
   fetchImpl?: typeof fetch;
   now?: number;
 }
@@ -71,7 +72,7 @@ export interface SendPushResult {
 export async function sendSilentPush(options: SendPushOptions): Promise<SendPushResult> {
   const jwt = await buildApnsJwt(options.config, options.now);
   const fetchImpl = options.fetchImpl ?? fetch;
-  const url = `https://${options.config.host}/3/device/${options.deviceToken}`;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
 
   const body = JSON.stringify({
     aps: { 'content-available': 1 },

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -76,6 +76,7 @@ export function validateTrip(input: unknown): Trip | null {
       ? obj.lastFiredPhase
       : undefined,
     lastEtaSeconds: typeof obj.lastEtaSeconds === 'number' ? obj.lastEtaSeconds : undefined,
+    apnsEnv: obj.apnsEnv === 'sandbox' || obj.apnsEnv === 'production' ? obj.apnsEnv : undefined,
   };
 }
 
@@ -89,11 +90,14 @@ export default {
     await runScheduled(env, {
       seoul,
       apnsConfig: {
-        host: env.APNS_HOST,
         keyId: env.APNS_KEY_ID,
         teamId: env.APNS_TEAM_ID,
         privateKeyPem: env.APNS_PRIVATE_KEY,
         bundleId: env.APNS_BUNDLE_ID,
+      },
+      apnsHosts: {
+        production: env.APNS_HOST,
+        sandbox: env.APNS_HOST_SANDBOX,
       },
       log: (msg, meta) => console.log(JSON.stringify({ msg, ...meta })),
     });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -29,9 +29,19 @@ export interface ScheduledStats {
 export interface ScheduledDeps {
   seoul: SeoulArrivalClient;
   apnsConfig: ApnsConfig;
+  /** APNs host 매핑. trip.apnsEnv에 따라 선택. */
+  apnsHosts: { production: string; sandbox: string };
   fetchImpl?: typeof fetch;
   now?: () => number;
   log?: (message: string, meta?: Record<string, unknown>) => void;
+}
+
+/** trip의 apnsEnv → APNs host 선택. 누락 시 production fallback (이전 클라이언트 호환). */
+export function pickApnsHost(
+  apnsEnv: Trip['apnsEnv'],
+  hosts: { production: string; sandbox: string },
+): string {
+  return apnsEnv === 'sandbox' ? hosts.sandbox : hosts.production;
 }
 
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
@@ -113,6 +123,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
             kind: waypoint.kind,
           },
           config: deps.apnsConfig,
+          host: pickApnsHost(trip.apnsEnv, deps.apnsHosts),
           fetchImpl: deps.fetchImpl,
           now,
         });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -13,7 +13,7 @@ import { sendSilentPush, type ApnsConfig } from './apns';
 import { matchLine } from './lineAlias';
 import { SeoulArrivalClient, type ArrivalEntry } from './seoul';
 import { deleteTrip, listTrips, putTrip } from './trips';
-import type { Env, Trip, Waypoint } from './types';
+import type { ApnsEnv, Env, Trip, Waypoint } from './types';
 
 /** 알람 윈도우: 알람 예상 시각 5분 이내인 트립만 폴링한다. */
 const POLLING_WINDOW_MS = 5 * 60 * 1000;
@@ -31,18 +31,20 @@ export interface ScheduledDeps {
   seoul: SeoulArrivalClient;
   apnsConfig: ApnsConfig;
   /** APNs host 매핑. trip.apnsEnv에 따라 선택. */
-  apnsHosts: { production: string; sandbox: string };
+  apnsHosts: Record<ApnsEnv, string>;
   fetchImpl?: typeof fetch;
   now?: () => number;
   log?: (message: string, meta?: Record<string, unknown>) => void;
 }
 
-/** trip의 apnsEnv → APNs host 선택. 누락 시 production fallback (이전 클라이언트 호환). */
-export function pickApnsHost(
-  apnsEnv: Trip['apnsEnv'],
-  hosts: { production: string; sandbox: string },
-): string {
-  return apnsEnv === 'sandbox' ? hosts.sandbox : hosts.production;
+/**
+ * trip의 apnsEnv → APNs host 선택. 누락 시 sandbox fallback —
+ * 구버전 클라이언트가 필드를 안 보낼 때 production host로 잘못 전송되어
+ * `BadDeviceToken`을 받던 #482 회귀를 막기 위함. App Store/TestFlight 빌드는
+ * 반드시 명시적으로 'production'을 보내야 한다.
+ */
+export function pickApnsHost(apnsEnv: ApnsEnv | undefined, hosts: Record<ApnsEnv, string>): string {
+  return hosts[apnsEnv ?? 'sandbox'];
 }
 
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -25,6 +25,12 @@ export interface ScheduledStats {
   errors: number;
   /** Seoul API 응답이 비어 ETA를 산출하지 못한 트립 수 (운영 가시성용). */
   etaMissing: number;
+  /**
+   * BadDeviceToken으로 1차 host에서 거부됐다가 반대 host로 self-heal 성공해
+   * `trip.apnsEnv`를 정정한 카운트. 운영 메트릭 — 이 값이 0이 아니면
+   * 클라이언트 hint가 빌드 환경과 어긋나고 있다는 신호 (#482).
+   */
+  envCorrected: number;
 }
 
 export interface ScheduledDeps {
@@ -47,6 +53,15 @@ export function pickApnsHost(apnsEnv: ApnsEnv | undefined, hosts: Record<ApnsEnv
   return hosts[apnsEnv ?? 'sandbox'];
 }
 
+/**
+ * APNs env를 반대편으로 뒤집는다. BadDeviceToken self-heal에서 1차 시도 host와
+ * 반대 host로 재시도할 때 사용 (#482 D안). 누락(undefined)은 sandbox로 시작했으므로
+ * production으로 뒤집는다 — `pickApnsHost`의 sandbox fallback과 짝.
+ */
+export function flipApnsEnv(env: ApnsEnv | undefined): ApnsEnv {
+  return (env ?? 'sandbox') === 'sandbox' ? 'production' : 'sandbox';
+}
+
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
   const now = deps.now?.() ?? Date.now();
   const log = deps.log ?? (() => undefined);
@@ -56,6 +71,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     pushed: 0,
     errors: 0,
     etaMissing: 0,
+    envCorrected: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -119,19 +135,56 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           etaSeconds: eta,
           arvlCd,
         });
-        const result = await sendSilentPush({
+        const pushPayload = {
+          nextWaypoint: waypoint.stationName,
+          etaSeconds: eta,
+          phase: pushPhase,
+          kind: waypoint.kind,
+        };
+        let result = await sendSilentPush({
           deviceToken: trip.token,
-          payload: {
-            nextWaypoint: waypoint.stationName,
-            etaSeconds: eta,
-            phase: pushPhase,
-            kind: waypoint.kind,
-          },
+          payload: pushPayload,
           config: deps.apnsConfig,
           host: pickApnsHost(trip.apnsEnv, deps.apnsHosts),
           fetchImpl: deps.fetchImpl,
           now,
         });
+
+        // self-heal (#482): BadDeviceToken은 토큰 자체 무효가 아니라 host 환경 불일치인 경우가
+        // 압도적이다. 반대 host로 1회 재시도하고, 성공하면 trip.apnsEnv를 정정 저장한다.
+        // 양쪽 host 모두 BadDeviceToken을 내면 그제야 진짜 토큰 무효로 보고 trip을 삭제한다.
+        let envMismatchExhausted = false;
+        if (!result.ok && isApnsEnvMismatch(result.status, result.reason)) {
+          const correctedEnv = flipApnsEnv(trip.apnsEnv);
+          log('apns env mismatch — retry with opposite host', {
+            token: trip.token.slice(0, 8),
+            from: trip.apnsEnv ?? 'sandbox',
+            to: correctedEnv,
+          });
+          const retryResult = await sendSilentPush({
+            deviceToken: trip.token,
+            payload: pushPayload,
+            config: deps.apnsConfig,
+            host: deps.apnsHosts[correctedEnv],
+            fetchImpl: deps.fetchImpl,
+            now,
+          });
+          if (retryResult.ok) {
+            trip.apnsEnv = correctedEnv;
+            dirty = true;
+            stats.envCorrected += 1;
+            log('apns env corrected', {
+              token: trip.token.slice(0, 8),
+              to: correctedEnv,
+            });
+          } else if (isApnsEnvMismatch(retryResult.status, retryResult.reason)) {
+            // 양쪽 모두 BadDeviceToken — 토큰 자체가 무효
+            envMismatchExhausted = true;
+          }
+          // retry 결과를 최종 result로 승격 — 하단 success/error 분기가 일관되게 동작.
+          // retry가 다른 종류 에러(예: 410, PayloadTooLarge)면 그대로 그 경로에서 처리됨.
+          result = retryResult;
+        }
 
         if (result.ok) {
           stats.pushed += 1;
@@ -172,7 +225,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
             reason: result.reason,
             token: trip.token.slice(0, 8),
           });
-          if (isUnrecoverableApnsError(result.status, result.reason)) {
+          if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
             await deleteTrip(env.TRIPS, trip.token);
             continue;
           }
@@ -249,8 +302,19 @@ export function pickBestArrivalSignal(
   return { etaSeconds: best.arrivalSeconds, arvlCd: best.arvlCd };
 }
 
-function isUnrecoverableApnsError(status: number, reason: string | undefined): boolean {
+/**
+ * BadDeviceToken은 self-heal 분기에서 처리한다 (#482 D안).
+ * unrecoverable로 분류되는 것은 토큰 자체가 만료/취소된 경우뿐.
+ */
+function isUnrecoverableApnsError(status: number, _reason: string | undefined): boolean {
   if (status === 410) return true; // Unregistered
-  if (status === 400 && reason === 'BadDeviceToken') return true;
   return false;
+}
+
+/**
+ * APNs 토큰 환경(sandbox/production)과 host가 어긋났을 때 Apple이 내는 시그널.
+ * 이 조건에 한해서만 self-heal retry를 시도한다.
+ */
+function isApnsEnvMismatch(status: number, reason: string | undefined): boolean {
+  return status === 400 && reason === 'BadDeviceToken';
 }

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -66,10 +66,15 @@ export interface Trip {
   lastEtaSeconds?: number;
   /**
    * APNs 토큰의 환경(sandbox / production). 클라이언트가 빌드 환경에 맞춰 전달.
-   * 누락 시 production으로 간주(이전 클라이언트와 후방 호환).
+   * 누락 시 sandbox로 간주 — 구버전 클라이언트(dev/preview)가 필드를 안 보내는 경우
+   * production host로 잘못 가지 않도록 안전한 기본값. App Store/TestFlight 빌드는
+   * 반드시 `apnsEnv: 'production'`을 명시한다.
    */
-  apnsEnv?: 'sandbox' | 'production';
+  apnsEnv?: ApnsEnv;
 }
+
+/** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */
+export type ApnsEnv = 'sandbox' | 'production';
 
 export interface Env {
   TRIPS: KVNamespace;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -64,11 +64,19 @@ export interface Trip {
   lastFiredPhase?: 'early' | 'imminent';
   /** 마지막 폴링 시 관측 ETA(seconds). 변동 감지용. */
   lastEtaSeconds?: number;
+  /**
+   * APNs 토큰의 환경(sandbox / production). 클라이언트가 빌드 환경에 맞춰 전달.
+   * 누락 시 production으로 간주(이전 클라이언트와 후방 호환).
+   */
+  apnsEnv?: 'sandbox' | 'production';
 }
 
 export interface Env {
   TRIPS: KVNamespace;
+  /** Production APNs host (예: api.push.apple.com) */
   APNS_HOST: string;
+  /** Sandbox APNs host (예: api.sandbox.push.apple.com) — dev/preview 빌드 토큰용 */
+  APNS_HOST_SANDBOX: string;
   SEOUL_API_HOST: string;
   SEOUL_API_KEY: string;
   APNS_KEY_ID: string;

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -22,4 +22,5 @@ crons = ["*/1 * * * *"]
 # - APNS_BUNDLE_ID         : 앱 번들 ID (예: com.handokei.subwaynow)
 [vars]
 APNS_HOST = "api.push.apple.com"
+APNS_HOST_SANDBOX = "api.sandbox.push.apple.com"
 SEOUL_API_HOST = "swopenapi.seoul.go.kr"

--- a/eas.json
+++ b/eas.json
@@ -6,13 +6,22 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_APNS_ENV": "sandbox"
+      }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_APNS_ENV": "sandbox"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_APNS_ENV": "production"
+      }
     }
   },
   "submit": {

--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -21,6 +21,7 @@ const SAMPLE_PAYLOAD: RegisterTripPayload = {
   alarmAtEpochMs: NOW + 60000,
   createdAt: NOW,
   expiresAt: NOW + 1000,
+  apnsEnv: 'sandbox',
 };
 
 describe('alarmBackend', () => {
@@ -65,6 +66,7 @@ describe('alarmBackend', () => {
         alarmAtEpochMs: NOW + 60000,
         createdAt: NOW,
         expiresAt: NOW + 1000,
+        apnsEnv: 'sandbox',
       });
     });
 
@@ -78,6 +80,7 @@ describe('alarmBackend', () => {
         destination: '0228',
         waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
         alarmAtEpochMs: NOW,
+        apnsEnv: 'sandbox',
       };
       await registerActiveTrip(payload);
       const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -33,6 +33,8 @@ export interface RegisterTripPayload {
   expiresAt?: number;
   /** epoch ms — 알람 발사 예상 시각 (5분 윈도우 진입 판정용) */
   alarmAtEpochMs: number;
+  /** APNs 토큰 환경 — backend가 sandbox/production host를 선택. */
+  apnsEnv: 'sandbox' | 'production';
 }
 
 export interface AlarmBackendResult {
@@ -86,6 +88,7 @@ export async function registerActiveTrip(
     createdAt,
     expiresAt,
     alarmAtEpochMs: payload.alarmAtEpochMs,
+    apnsEnv: payload.apnsEnv,
   };
 
   try {

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Route } from '../utils/stationRoute';
+import type { ApnsEnv } from '../utils/apnsEnv';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger('alarmBackend');
@@ -34,7 +35,7 @@ export interface RegisterTripPayload {
   /** epoch ms — 알람 발사 예상 시각 (5분 윈도우 진입 판정용) */
   alarmAtEpochMs: number;
   /** APNs 토큰 환경 — backend가 sandbox/production host를 선택. */
-  apnsEnv: 'sandbox' | 'production';
+  apnsEnv: ApnsEnv;
 }
 
 export interface AlarmBackendResult {

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -107,6 +107,7 @@ describe('useApnsTripRegistration', () => {
         token: 'token-abc',
         destination: '0228',
         waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+        apnsEnv: expect.stringMatching(/^(sandbox|production)$/) as unknown as 'sandbox' | 'production',
       }),
     );
     await waitFor(() =>

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -17,6 +17,7 @@ import { registerActiveTrip, clearActiveTrip } from '../api/alarmBackend';
 import { routeToWaypoints } from '../utils/routeWaypoints';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../constants/storageKeys';
 import { createLogger } from '../utils/logger';
+import { resolveApnsEnv } from '../utils/apnsEnv';
 
 const logger = createLogger('ApnsTripRegistration');
 
@@ -57,6 +58,7 @@ async function callRegister(input: RegisterCallInputs) {
     destination: input.destination.id,
     waypoints: routeToWaypoints(input.route, input.destination.name, input.currentStation),
     alarmAtEpochMs: deriveAlarmAtEpochMs(input.nextStationEtaSeconds, Date.now()),
+    apnsEnv: resolveApnsEnv(),
   });
 }
 

--- a/src/utils/__tests__/apnsEnv.test.ts
+++ b/src/utils/__tests__/apnsEnv.test.ts
@@ -1,0 +1,33 @@
+import { resolveApnsEnv } from '../apnsEnv';
+
+describe('resolveApnsEnv', () => {
+  const original = process.env.EXPO_PUBLIC_APNS_ENV;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.EXPO_PUBLIC_APNS_ENV;
+    } else {
+      process.env.EXPO_PUBLIC_APNS_ENV = original;
+    }
+  });
+
+  it('returns production when env explicitly set to production', () => {
+    process.env.EXPO_PUBLIC_APNS_ENV = 'production';
+    expect(resolveApnsEnv()).toBe('production');
+  });
+
+  it('returns sandbox when env explicitly set to sandbox', () => {
+    process.env.EXPO_PUBLIC_APNS_ENV = 'sandbox';
+    expect(resolveApnsEnv()).toBe('sandbox');
+  });
+
+  it('falls back to sandbox when env is unset', () => {
+    delete process.env.EXPO_PUBLIC_APNS_ENV;
+    expect(resolveApnsEnv()).toBe('sandbox');
+  });
+
+  it('falls back to sandbox when env has unknown value', () => {
+    process.env.EXPO_PUBLIC_APNS_ENV = 'bogus';
+    expect(resolveApnsEnv()).toBe('sandbox');
+  });
+});

--- a/src/utils/apnsEnv.ts
+++ b/src/utils/apnsEnv.ts
@@ -1,0 +1,17 @@
+/**
+ * APNs 토큰 환경(sandbox / production) 판별.
+ *
+ * 빌드 환경별 기본값:
+ * - `EXPO_PUBLIC_APNS_ENV`를 명시 설정 → 그 값을 신뢰
+ * - 미설정 + `__DEV__` true → 'sandbox' (Expo dev client / development build)
+ * - 미설정 + `__DEV__` false → 'sandbox' (preview/internal distribution도 sandbox 토큰을 받음)
+ *
+ * production은 반드시 EAS production profile에서 `EXPO_PUBLIC_APNS_ENV=production` 명시 필요.
+ * 미설정 시 sandbox로 떨어지는 것이 안전 — production host로 sandbox 토큰을 보내면
+ * BadDeviceToken으로 거부되어 trip이 즉시 삭제되기 때문.
+ */
+export function resolveApnsEnv(): 'sandbox' | 'production' {
+  const raw = process.env.EXPO_PUBLIC_APNS_ENV;
+  if (raw === 'production' || raw === 'sandbox') return raw;
+  return 'sandbox';
+}

--- a/src/utils/apnsEnv.ts
+++ b/src/utils/apnsEnv.ts
@@ -1,16 +1,18 @@
 /**
- * APNs 토큰 환경(sandbox / production) 판별.
+ * APNs 토큰 환경(sandbox / production) 판별 (#482).
  *
- * 빌드 환경별 기본값:
- * - `EXPO_PUBLIC_APNS_ENV`를 명시 설정 → 그 값을 신뢰
- * - 미설정 + `__DEV__` true → 'sandbox' (Expo dev client / development build)
- * - 미설정 + `__DEV__` false → 'sandbox' (preview/internal distribution도 sandbox 토큰을 받음)
+ * 정책:
+ * - `EXPO_PUBLIC_APNS_ENV`가 'sandbox' 또는 'production'으로 명시되면 그 값을 신뢰
+ * - 그 외(미설정/오타) → 'sandbox' fallback
  *
- * production은 반드시 EAS production profile에서 `EXPO_PUBLIC_APNS_ENV=production` 명시 필요.
- * 미설정 시 sandbox로 떨어지는 것이 안전 — production host로 sandbox 토큰을 보내면
- * BadDeviceToken으로 거부되어 trip이 즉시 삭제되기 때문.
+ * 이유: iOS는 dev/preview/internal distribution 빌드에 sandbox APNs 토큰을 발급하고,
+ * 이를 production host로 보내면 `BadDeviceToken`(400)으로 거부된다. 'production'은
+ * App Store/TestFlight 빌드에서만 의미가 있으므로, EAS production profile에서
+ * `EXPO_PUBLIC_APNS_ENV=production`을 반드시 명시 설정해야 한다.
  */
-export function resolveApnsEnv(): 'sandbox' | 'production' {
+export type ApnsEnv = 'sandbox' | 'production';
+
+export function resolveApnsEnv(): ApnsEnv {
   const raw = process.env.EXPO_PUBLIC_APNS_ENV;
   if (raw === 'production' || raw === 'sandbox') return raw;
   return 'sandbox';


### PR DESCRIPTION
## 배경

운영 로그에서 silent push 발사 시 일관되게 `apns push failed status=400 reason=BadDeviceToken` 관측. `isUnrecoverableApnsError`로 분류되어 trip이 즉시 삭제되고, 다음 cycle에서 클라이언트가 새 trip을 등록하는 패턴이 반복됨.

```
{"msg":"push fired","token":"e25e1158","kind":"intermediate","phase":"imminent","station":"중곡","etaSeconds":29}
{"msg":"apns push failed","status":400,"reason":"BadDeviceToken","token":"e25e1158"}
```

## 원인

APNs 토큰 환경 불일치:
- Backend `wrangler.toml`: `APNS_HOST = "api.push.apple.com"` (production 고정)
- Client: `Notifications.getDevicePushTokenAsync()`는 빌드 환경(dev/preview/production)에 따라 sandbox/production 토큰을 다르게 발급
- sandbox 토큰을 production host로 전송 → 400 BadDeviceToken
- dev/preview 빌드에서는 silent push 경로 전체가 구조적으로 무력화 → 사전 예약(#334) 경로만 동작

## 변경 — D안 (A안 + 백엔드 self-heal)

### A안 부분 — 클라이언트 hint
- `Trip.apnsEnv?: 'sandbox' | 'production'` 추가
- `src/utils/apnsEnv.ts` — `EXPO_PUBLIC_APNS_ENV` 기반 결정 (미설정 시 sandbox 안전 fallback)
- `useApnsTripRegistration.ts`에서 trip 등록 시 동봉
- `eas.json` 각 profile에 명시:
  - `development`/`preview`: `EXPO_PUBLIC_APNS_ENV=sandbox`
  - `production`: `EXPO_PUBLIC_APNS_ENV=production`

### D안 부분 — 백엔드 self-heal (운영 견고화)
- `wrangler.toml`에 `APNS_HOST_SANDBOX` 추가
- `apns.ts`: `SendPushOptions.host`로 호출 시점 host 선택 (config.host 제거)
- `scheduled.ts`:
  - `pickApnsHost(trip.apnsEnv, hosts)` — trip 힌트 기반 host 선택, undefined 시 sandbox fallback
  - **self-heal**: 1차 시도가 `BadDeviceToken`이면 반대 host로 1회 재시도. 성공 시 `trip.apnsEnv`를 정정해 KV에 저장 (다음 cycle부터 1-shot). 양쪽 모두 BadDeviceToken이면 진짜 unrecoverable로 분류해 trip 삭제
  - `isUnrecoverableApnsError` 의미 좁힘 — 410 Unregistered만 즉시 unrecoverable, BadDeviceToken은 self-heal 분기로 이동
  - `ScheduledStats.envCorrected` 카운터 + `apns env corrected` 로그 (운영 메트릭 — 0이 아니면 클라 hint가 빌드 환경과 어긋난다는 신호)

## D안을 선택한 이유

A 단독은 운영 위험:
- EAS profile 추가/리네이밍 시 env var 누락 → 무한 BadDeviceToken (지금 #482와 동일 증상)
- iOS provisioning profile/인증서 갱신 시 환경 변동에 따로 대응 필요
- 사람 실수 100% 의존

D안은 클라 hint가 틀려도 백엔드가 자동 정정 + 학습. 클라가 잘못 분류해도 토큰당 첫 push만 1회 retry이고 이후는 1-shot. 운영 메트릭으로 misclassification 비율 관측 가능.

## Done 기준

- [x] type-check 통과 (client + backend)
- [x] 백엔드 테스트 통과 (104 tests)
- [x] 클라이언트 테스트 100% coverage (1556 tests)
- [ ] dev 빌드에서 silent push 도달 확인 (#410 실기기 회귀)
- [ ] production 빌드 회귀 없음 (TestFlight)

## 후속

- #485 (sentAt/receivedAt 측정) — silent push 도달 지연 측정으로 self-heal 효과 검증
- #478 (silent push 단독 발화원 전환) — #482 머지 후 진입 가능
- #411 (사전 예약 stopgap 제거) — #478 + 1-2주 운영 관찰 후

Closes #482