### PR TITLE
feat(#478): silent push 단독 발화 + 위치 게이트 + 사전예약 회로 차단

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -18,7 +18,6 @@ import { useRouter } from 'expo-router';
 import { getStationDisplayName } from '../../src/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
-import { useScheduledAlarms } from '../../src/hooks/useScheduledAlarms';
 import { useTripOrigin } from '../../src/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import { useApnsTripRegistration } from '../../src/hooks/useApnsTripRegistration';
@@ -155,12 +154,6 @@ export default function HomeScreen() {
     speedMps,
     accuracyMeters,
     arrivalConfidence: confidence,
-  });
-  useScheduledAlarms({
-    route,
-    destination,
-    currentStation: result?.station ?? null,
-    arrival: rawArrival,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,16 +15,30 @@ import { isDebugModalEnabled } from '../src/constants/debugFlags';
 import '../src/tasks/backgroundLocationTask';
 import { registerSilentPushTask } from '../src/tasks/silentPushTask';
 import { registerScheduledAlarmListener } from '../src/utils/scheduledAlarmReceiver';
+import { cancelScheduledAlarms } from '../src/utils/alarmScheduler';
+import { unregisterAlarmRefreshTask } from '../src/tasks/alarmRefreshTask';
 
 const layoutLogger = createLogger('RootLayout');
 
 SplashScreen.preventAutoHideAsync();
 setupNotificationHandler();
-// iOS silent push BG task 등록 — APNs reschedule trigger 수신용.
+// iOS silent push BG task 등록 — APNs payload 수신용.
 // 권한/플랫폼 미지원 시 내부에서 graceful no-op.
 registerSilentPushTask().catch((e) => layoutLogger.warn('silent push task 등록 실패:', e));
-// 사전 예약 alarm: 알림 발화 시 FIRED_ALARMS/LAST_NOTIFIED_STATION 갱신 → FG 복귀 후 중복 발화 방지.
+// 사전 예약 alarm receiver는 잔존 예약 발사 시 FIRED_ALARMS 갱신만 담당.
 registerScheduledAlarmListener();
+// 부팅 시 1회 마이그레이션 — #478 PR 1-2 사전예약 폐기 시점:
+//   1) cancelScheduledAlarms: 이미 OS에 등록된 사전예약 DATE 트리거 해제
+//   2) unregisterAlarmRefreshTask: BGAppRefreshTask가 OS native level에 잔존해
+//      15분 주기로 scheduleAlarmsForRoute를 재호출하면 cleanup이 무력화됨.
+//      코드 import 여부와 무관하게 명시적으로 OS에서 unregister.
+// 두 호출 모두 stopgap 완전 제거(#411) 머지 시점에 같이 정리한다.
+cancelScheduledAlarms().catch((e) =>
+  layoutLogger.warn('잔존 사전예약 정리 실패(#478 마이그레이션):', e),
+);
+unregisterAlarmRefreshTask().catch((e) =>
+  layoutLogger.warn('잔존 alarmRefreshTask 정리 실패(#478 마이그레이션):', e),
+);
 
 // 프로덕션 빌드에서는 warn 이상만 출력
 if (!__DEV__) {

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -18,16 +18,32 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(),
 }));
 
-const mockSchedule = jest.fn();
-const mockCancel = jest.fn();
-jest.mock('../../utils/alarmScheduler', () => ({
-  scheduleAlarmsForRoute: (...args: unknown[]) => mockSchedule(...args),
-  cancelScheduledAlarms: (...args: unknown[]) => mockCancel(...args),
-}));
-
 const mockLogSilentPushReceived = jest.fn();
+const mockLogSilentPushFired = jest.fn();
+const mockLogSilentPushSkipped = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
+  logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
+  logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
+}));
+
+const mockCheckGate = jest.fn();
+jest.mock('../../utils/silentPushLocationGate', () => ({
+  checkSilentPushLocationGate: (...args: unknown[]) => mockCheckGate(...args),
+}));
+
+const mockGetFiredAlarms = jest.fn();
+const mockSetFiredAlarms = jest.fn();
+jest.mock('../../utils/notificationState', () => ({
+  getFiredAlarms: (...args: unknown[]) => mockGetFiredAlarms(...args),
+  setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
+}));
+
+jest.mock('../../utils/stationNotification', () => ({
+  buildAlarmContent: (event: { stationName: string; type: string; phaseId: string }) => ({
+    title: `[${event.type}/${event.phaseId}]`,
+    body: `${event.stationName} 알람`,
+  }),
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -39,6 +55,17 @@ jest.mock('../../utils/logger', () => ({
   }),
 }));
 
+// i18next는 키 그대로 반환 (intermediate 본문 빌더 검증용).
+jest.mock('i18next', () => ({
+  __esModule: true,
+  default: {
+    t: (key: string, opts?: { name?: string }) =>
+      opts?.name ? `${key}:${opts.name}` : key,
+  },
+  t: (key: string, opts?: { name?: string }) =>
+    opts?.name ? `${key}:${opts.name}` : key,
+}));
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   extractPayload,
@@ -46,12 +73,11 @@ import {
   registerSilentPushTask,
   SILENT_PUSH_TASK,
 } from '../silentPushTask';
-import { DESTINATION_KEY, ROUTE_KEY } from '../../constants/storageKeys';
+import { DESTINATION_KEY } from '../../constants/storageKeys';
 
 const destStation = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
-const route = { type: 'direct', stops: 5, line: '2' };
 
-function reschedulePayload(extra: Record<string, unknown> = {}) {
+function payload(extra: Record<string, unknown> = {}) {
   return {
     data: {
       notification: {
@@ -59,6 +85,7 @@ function reschedulePayload(extra: Record<string, unknown> = {}) {
           nextWaypoint: '강남',
           etaSeconds: 300,
           phase: 'early',
+          kind: 'destination',
           ...extra,
         },
       },
@@ -66,14 +93,23 @@ function reschedulePayload(extra: Record<string, unknown> = {}) {
   };
 }
 
+const PASSING_GATE = {
+  pass: true,
+  distanceM: 150,
+  thresholdM: 800,
+  locationSource: 'cache' as const,
+  locationAgeMs: 10_000,
+};
+
 describe('silentPushTask', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSchedule.mockResolvedValue([{ identifier: 'alarm:early:강남' }]);
-    mockCancel.mockResolvedValue(undefined);
+    mockScheduleNotificationAsync.mockResolvedValue('id');
+    mockCheckGate.mockResolvedValue(PASSING_GATE);
+    mockGetFiredAlarms.mockResolvedValue(new Set<string>());
+    mockSetFiredAlarms.mockResolvedValue(undefined);
     (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
       if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-      if (key === ROUTE_KEY) return JSON.stringify(route);
       return null;
     });
   });
@@ -95,23 +131,19 @@ describe('silentPushTask', () => {
     it('data 위치(notification.data) 우선', () => {
       expect(
         extractPayload({
-          notification: {
-            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early' },
-          },
+          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early' } },
         }),
-      ).toEqual({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' });
+      ).toMatchObject({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' });
     });
 
     it('data 없을 때 request.content.data 폴백', () => {
       expect(
         extractPayload({
           notification: {
-            request: {
-              content: { data: { nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' } },
-            },
+            request: { content: { data: { nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' } } },
           },
         }),
-      ).toEqual({ nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' });
+      ).toMatchObject({ nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' });
     });
 
     it('raw가 객체가 아니면 null', () => {
@@ -123,12 +155,12 @@ describe('silentPushTask', () => {
     it('nextWaypoint 누락/비문자열/빈문자열이면 null', () => {
       expect(
         extractPayload({
-          notification: { data: { nextWaypoint: '', etaSeconds: 1, phase: 'early' } },
+          notification: { data: { etaSeconds: 1, phase: 'early' } as Record<string, unknown> },
         }),
       ).toBeNull();
       expect(
         extractPayload({
-          notification: { data: { nextWaypoint: 123, etaSeconds: 1, phase: 'early' } },
+          notification: { data: { nextWaypoint: '', etaSeconds: 1, phase: 'early' } },
         }),
       ).toBeNull();
     });
@@ -136,14 +168,12 @@ describe('silentPushTask', () => {
     it('etaSeconds 비숫자/Infinity이면 null', () => {
       expect(
         extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: '1', phase: 'early' } },
+          notification: { data: { nextWaypoint: 'A', etaSeconds: '10', phase: 'early' } },
         }),
       ).toBeNull();
       expect(
         extractPayload({
-          notification: {
-            data: { nextWaypoint: 'A', etaSeconds: Infinity, phase: 'early' },
-          },
+          notification: { data: { nextWaypoint: 'A', etaSeconds: Infinity, phase: 'early' } },
         }),
       ).toBeNull();
     });
@@ -167,7 +197,7 @@ describe('silentPushTask', () => {
           extractPayload({
             notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind } },
           }),
-        ).toEqual({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind });
+        ).toMatchObject({ kind });
       }
     });
 
@@ -176,7 +206,7 @@ describe('silentPushTask', () => {
         extractPayload({
           notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'foo' } },
         }),
-      ).toEqual({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: undefined });
+      ).toMatchObject({ kind: undefined });
     });
 
     it('sentAt이 number면 그대로 전달 (#478)', () => {
@@ -186,13 +216,7 @@ describe('silentPushTask', () => {
             data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 1_700_000_000_000 },
           },
         }),
-      ).toEqual({
-        nextWaypoint: 'A',
-        etaSeconds: 1,
-        phase: 'early',
-        kind: undefined,
-        sentAt: 1_700_000_000_000,
-      });
+      ).toMatchObject({ sentAt: 1_700_000_000_000 });
     });
 
     it('sentAt이 비숫자/Infinity이면 undefined (구 백엔드 호환)', () => {
@@ -202,139 +226,191 @@ describe('silentPushTask', () => {
             data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 'now' },
           },
         }),
-      ).toEqual({
-        nextWaypoint: 'A',
-        etaSeconds: 1,
-        phase: 'early',
-        kind: undefined,
-        sentAt: undefined,
-      });
+      ).toMatchObject({ sentAt: undefined });
       expect(
         extractPayload({
           notification: {
             data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: Infinity },
           },
         }),
-      ).toEqual({
-        nextWaypoint: 'A',
-        etaSeconds: 1,
-        phase: 'early',
-        kind: undefined,
-        sentAt: undefined,
-      });
+      ).toMatchObject({ sentAt: undefined });
     });
   });
 
   describe('handleSilentPush', () => {
-    it('error 있으면 즉시 종료', async () => {
+    it('error 있으면 즉시 종료 (gate 호출 안 됨)', async () => {
       await handleSilentPush({ error: { message: 'boom' } });
-      expect(mockSchedule).not.toHaveBeenCalled();
-      expect(mockCancel).not.toHaveBeenCalled();
+      expect(mockCheckGate).not.toHaveBeenCalled();
+      expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
     });
 
     it('payload 없으면 skip', async () => {
       await handleSilentPush({ data: undefined });
-      expect(mockSchedule).not.toHaveBeenCalled();
+      expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
+      expect(mockCheckGate).not.toHaveBeenCalled();
     });
 
     it('invalid payload면 skip', async () => {
       await handleSilentPush({
         data: { notification: { data: { trigger: 'other' } } },
       });
-      expect(mockSchedule).not.toHaveBeenCalled();
-    });
-
-    it('destination/route AsyncStorage에 없으면 skip', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-      await handleSilentPush(reschedulePayload());
-      expect(mockCancel).not.toHaveBeenCalled();
-      expect(mockSchedule).not.toHaveBeenCalled();
-    });
-
-    it('정상: cancel 후 etaSeconds 로 reschedule', async () => {
-      await handleSilentPush(reschedulePayload({ etaSeconds: 420 }));
-      expect(mockCancel).toHaveBeenCalledTimes(1);
-      expect(mockSchedule).toHaveBeenCalledWith({
-        route,
-        destinationName: '강남',
-        currentStationApproachEtaSeconds: 420,
-      });
-    });
-
-    it('AsyncStorage 손상된 JSON이면 skip', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-        if (key === DESTINATION_KEY) return 'not-json{';
-        if (key === ROUTE_KEY) return JSON.stringify(route);
-        return null;
-      });
-      await handleSilentPush(reschedulePayload());
-      expect(mockSchedule).not.toHaveBeenCalled();
-    });
-
-    it('parse 결과 falsy(null)면 schedule 호출 안 함', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-        if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-        if (key === ROUTE_KEY) return 'null';
-        return null;
-      });
-      await handleSilentPush(reschedulePayload());
-      expect(mockSchedule).not.toHaveBeenCalled();
-    });
-
-    it('schedule 내부 throw 시 graceful (throw 안 함)', async () => {
-      mockSchedule.mockRejectedValue(new Error('boom'));
-      await expect(handleSilentPush(reschedulePayload())).resolves.toBeUndefined();
-    });
-
-    it('kind=intermediate + phase=imminent → 즉시 알림 + reschedule 둘 다 호출 (#416)', async () => {
-      mockScheduleNotificationAsync.mockResolvedValue('id');
-      await handleSilentPush(
-        reschedulePayload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }),
-      );
-      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
-      const call = mockScheduleNotificationAsync.mock.calls[0][0];
-      // i18next mock가 기본 fallback으로 key 반환 또는 ko 로드 — 어느 쪽이든 station name이 body에 포함되어야 한다.
-      expect(JSON.stringify(call.content.body)).toContain('중곡');
-      expect(call.trigger).toBeNull();
-      expect(mockSchedule).toHaveBeenCalled();
-    });
-
-    it('kind=intermediate + phase=early → 즉시 알림 안 함, reschedule만', async () => {
-      await handleSilentPush(reschedulePayload({ kind: 'intermediate', phase: 'early' }));
-      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      expect(mockSchedule).toHaveBeenCalled();
-    });
-
-    it('kind=destination + phase=imminent → 즉시 알림 안 함 (intermediate만 발사)', async () => {
-      await handleSilentPush(reschedulePayload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      expect(mockSchedule).toHaveBeenCalled();
+      expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
     });
 
     it('수신 시 logSilentPushReceived 호출 — sentAt 포함 (#478)', async () => {
       await handleSilentPush(
-        reschedulePayload({
-          kind: 'transfer',
-          phase: 'early',
-          nextWaypoint: '건대입구',
-          sentAt: 1_700_000_000_000,
-        }),
+        payload({ kind: 'transfer', phase: 'early', sentAt: 1_700_000_000_000 }),
       );
       expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
       const arg = mockLogSilentPushReceived.mock.calls[0][0];
-      expect(arg.stationName).toBe('건대입구');
-      expect(arg.kind).toBe('transfer');
-      expect(arg.phaseId).toBe('early');
       expect(arg.sentAt).toBe(1_700_000_000_000);
       expect(typeof arg.receivedAt).toBe('number');
     });
 
-    it('수신 시 logSilentPushReceived — 구 백엔드(sentAt 없음)도 호출, sentAt undefined', async () => {
-      await handleSilentPush(reschedulePayload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
-      const arg = mockLogSilentPushReceived.mock.calls[0][0];
-      expect(arg.sentAt).toBeUndefined();
-      expect(typeof arg.receivedAt).toBe('number');
+    it('kind 미상(구 백엔드)이면 received 적재 후 skip 적재 + 발사 안 함', async () => {
+      await handleSilentPush({
+        data: {
+          notification: {
+            data: { nextWaypoint: '강남', etaSeconds: 10, phase: 'imminent' },
+          },
+        },
+      });
+      expect(mockLogSilentPushReceived).toHaveBeenCalled();
+      expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'payload-missing-kind' }),
+      );
+      expect(mockCheckGate).not.toHaveBeenCalled();
+      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('게이트 통과 시 destination 즉시 발사 + fired 로그 + FIRED_ALARMS 갱신', async () => {
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+
+      expect(mockCheckGate).toHaveBeenCalledWith({
+        stationName: '강남',
+        kind: 'destination',
+        phase: 'imminent',
+      });
+      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      const call = mockScheduleNotificationAsync.mock.calls[0][0];
+      expect(call.trigger).toBeNull();
+      expect(call.content.body).toContain('강남');
+      expect(mockLogSilentPushFired).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stationName: '강남',
+          kind: 'destination',
+          phaseId: 'imminent',
+          distanceM: 150,
+          thresholdM: 800,
+          locationSource: 'cache',
+          locationAgeMs: 10_000,
+        }),
+      );
+      expect(mockSetFiredAlarms).toHaveBeenCalledTimes(1);
+      const [, savedSet] = mockSetFiredAlarms.mock.calls[0];
+      expect(Array.from(savedSet as Set<string>)).toEqual(['imminent:강남']);
+    });
+
+    it('intermediate는 i18n key로 본문 생성 + FIRED_ALARMS dedup 안 씀', async () => {
+      await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }));
+
+      const call = mockScheduleNotificationAsync.mock.calls[0][0];
+      expect(call.content.title).toBe('route.intermediatePassedTitle');
+      expect(call.content.body).toBe('route.intermediatePassedBody:중곡');
+      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockLogSilentPushFired).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'station-passed' }),
+      );
+    });
+
+    it('intermediate가 게이트 fail이면 skip 적재 kind=station-passed', async () => {
+      mockCheckGate.mockResolvedValue({ pass: false, reason: 'out-of-range' });
+      await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }));
+      expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'station-passed', reason: 'gate-out-of-range' }),
+      );
+    });
+
+    it('게이트 fail(out-of-range)이면 skip 적재 + 발사 안 함', async () => {
+      mockCheckGate.mockResolvedValue({
+        pass: false,
+        reason: 'out-of-range',
+        distanceM: 5_000,
+        thresholdM: 400,
+        locationSource: 'cache',
+        locationAgeMs: 5_000,
+      });
+
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+
+      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+      expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'gate-out-of-range',
+          distanceM: 5_000,
+          thresholdM: 400,
+        }),
+      );
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['unknown-station', 'gate-unknown-station'],
+      ['no-location', 'gate-no-location'],
+      ['stale-location', 'gate-stale-location'],
+      ['out-of-range', 'gate-out-of-range'],
+    ])('게이트 reason=%s → logSkipped reason=%s', async (gateReason, logReason) => {
+      mockCheckGate.mockResolvedValue({ pass: false, reason: gateReason });
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: logReason }),
+      );
+    });
+
+    it('FIRED_ALARMS에 이미 같은 키 있으면 발사 안 함 (dedup, GPS 발화와 키 공유)', async () => {
+      mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+    });
+
+    it('destination AsyncStorage 없으면 dedup 건너뛰고 발사 (보수적 진행)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it('destination JSON 손상 시 dedup 건너뛰고 발사', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue('not-json{');
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it('destination에 id 없으면 dedup 건너뛰고 발사', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify({ name: 'x' }));
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it('scheduleNotificationAsync throw 시 graceful (전체 throw 안 함)', async () => {
+      mockScheduleNotificationAsync.mockRejectedValue(new Error('boom'));
+      await expect(
+        handleSilentPush(payload({ kind: 'destination', phase: 'imminent' })),
+      ).resolves.toBeUndefined();
+    });
+
+    it('transfer + early — 기존 사전예약 호출(scheduleAlarmsForRoute) 없음', async () => {
+      await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
+      // 발사는 됨
+      expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+      // 사전예약은 import도 안 함 — 호출 검증은 import 부재로 충분하나, 추가 안전망:
+      // alarmScheduler 모듈을 jest.mock하지 않았기 때문에 호출 시 ReferenceError가 났을 것.
     });
   });
 

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -1,18 +1,18 @@
 /**
- * iOS silent push(BG) 핸들러 — alarm-worker(#338)가 보내는 reschedule 트리거.
+ * iOS silent push(BG) 핸들러 — alarm-worker 백엔드가 보내는 발사 신호.
  *
  * payload (백엔드 apns.ts SilentPushPayload와 1:1):
  * ```
  * aps: { 'content-available': 1 }
- * data: { nextWaypoint: "강남", etaSeconds: 420, phase: "early" }
+ * data: { nextWaypoint, etaSeconds, phase, kind, sentAt }
  * ```
  *
- * 동작:
- *   1. AsyncStorage에서 현재 route/destination 복원
- *   2. payload의 etaSeconds(다음 도착역까지)로 `scheduleAlarmsForRoute` 재호출
- *   3. 기존 예약을 cancelScheduledAlarms로 정리한 뒤 새 시각으로 다시 예약
- *
- * payload 형식이 맞지 않거나 route/destination이 없으면 graceful no-op.
+ * 동작 (#478 PR 1-2 — 사전예약 완전 폐기):
+ *   1. payload 검증 + 수신 로그 적재 (#478 측정 인프라)
+ *   2. 위치 게이트(`silentPushLocationGate`) 통과 여부 확인
+ *      - 통과: trigger:null 즉시 알림 발사 + FIRED_ALARMS dedup 갱신 + logSilentPushFired
+ *      - 실패: logSilentPushSkipped(reason)
+ *   3. 사전예약(scheduleAlarmsForRoute) 호출 없음
  */
 
 import * as Notifications from 'expo-notifications';
@@ -20,11 +20,21 @@ import * as TaskManager from 'expo-task-manager';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
 import type { Station } from '../types/station';
-import type { Route } from '../utils/stationRoute';
-import { scheduleAlarmsForRoute, cancelScheduledAlarms } from '../utils/alarmScheduler';
-import { DESTINATION_KEY, ROUTE_KEY } from '../constants/storageKeys';
+import { DESTINATION_KEY } from '../constants/storageKeys';
 import { createLogger } from '../utils/logger';
-import { logSilentPushReceived } from '../utils/alarmLog';
+import {
+  logSilentPushReceived,
+  logSilentPushFired,
+  logSilentPushSkipped,
+  type AlarmLogReason,
+} from '../utils/alarmLog';
+import {
+  checkSilentPushLocationGate,
+  type GateSkipReason,
+} from '../utils/silentPushLocationGate';
+import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
+import { buildAlarmContent } from '../utils/stationNotification';
+import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 
 const logger = createLogger('SilentPushTask');
 
@@ -34,12 +44,11 @@ export interface SilentPushPayload {
   nextWaypoint: string;
   etaSeconds: number;
   phase: 'early' | 'imminent';
-  /** Waypoint 종류 (#416). intermediate면 통과 즉시 알림, 그 외는 reschedule만. 구 백엔드 호환을 위해 optional. */
+  /** Waypoint 종류 (#416). transfer/destination/intermediate. 구 백엔드 호환 위해 optional. */
   kind?: 'transfer' | 'destination' | 'intermediate';
   /**
    * 백엔드 발사 시점 epoch ms (#478 측정 인프라).
-   * 클라 수신 시각과 비교해 silent push 도달 지연 측정. 구 백엔드 호환 위해 optional.
-   * 종료 조건: #478 PR 1-2(silent push 단독 발화) 머지 + 신 백엔드 배포 후 required로 승격.
+   * 종료 조건: 신 백엔드 배포 후 required로 승격.
    */
   sentAt?: number;
 }
@@ -56,8 +65,6 @@ interface NotificationBackgroundTaskData {
 
 /**
  * 알림 raw payload → 검증된 SilentPushPayload.
- * iOS expo-notifications BG는 APNs JSON의 `data` 필드를 그대로 전달한다.
- * 어디에 들어있든 nextWaypoint/etaSeconds/phase 세 필드 모두 형이 맞아야 통과한다.
  */
 export function extractPayload(
   data: NotificationBackgroundTaskData['data'],
@@ -79,6 +86,34 @@ export function extractPayload(
 }
 
 /**
+ * 게이트 skip reason → alarmLog reason 매핑.
+ * 1:1 매핑 — 다른 곳에서 재사용하지 않으므로 silentPushTask 내부에 둔다.
+ */
+function mapGateReason(reason: GateSkipReason): AlarmLogReason {
+  switch (reason) {
+    case 'unknown-station':
+      return 'gate-unknown-station';
+    case 'no-location':
+      return 'gate-no-location';
+    case 'stale-location':
+      return 'gate-stale-location';
+    case 'out-of-range':
+      return 'gate-out-of-range';
+  }
+}
+
+/**
+ * intermediate(중간역 통과) 알림 content. AlarmEvent 모델에 없는 종류라
+ * buildAlarmContent를 못 쓰고 별도 i18n 키로 빌드한다.
+ */
+function buildIntermediateContent(stationName: string): { title: string; body: string } {
+  return {
+    title: i18next.t('route.intermediatePassedTitle'),
+    body: i18next.t('route.intermediatePassedBody', { name: stationName }),
+  };
+}
+
+/**
  * Task 콜백 본체 — 단위 테스트가 직접 호출할 수 있도록 export.
  */
 export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
@@ -97,7 +132,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'}`,
   );
 
-  // #478 측정 인프라 — 도달 지연 측정용 적재. 동작 변경 없음.
+  // 측정 인프라 — 수신 시점 무조건 적재 (#478 PR 1-1).
   logSilentPushReceived({
     stationName: payload.nextWaypoint,
     kind: payload.kind,
@@ -106,49 +141,111 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     receivedAt,
   });
 
-  try {
-    const [destJson, routeJson] = await Promise.all([
-      AsyncStorage.getItem(DESTINATION_KEY),
-      AsyncStorage.getItem(ROUTE_KEY),
-    ]);
-    if (!destJson || !routeJson) {
-      logger.info('no active destination/route — skip reschedule');
-      return;
-    }
-
-    let destination: Station;
-    let route: Route;
-    try {
-      destination = JSON.parse(destJson) as Station;
-      route = JSON.parse(routeJson) as Route;
-    } catch (e) {
-      logger.error('failed to parse stored destination/route:', e);
-      return;
-    }
-    if (!route || !destination) return;
-
-    // 중간역 통과(intermediate + imminent)는 통과 시점에 즉시 사용자 알림 표시 (#416).
-    // reschedule은 그대로 진행 — 다음 waypoint용 사전 예약을 갱신.
-    if (payload.kind === 'intermediate' && payload.phase === 'imminent') {
-      await Notifications.scheduleNotificationAsync({
-        content: {
-          title: i18next.t('route.intermediatePassedTitle'),
-          body: i18next.t('route.intermediatePassedBody', { name: payload.nextWaypoint }),
-        },
-        trigger: null,
-      });
-      logger.info(`intermediate passed: ${payload.nextWaypoint}`);
-    }
-
-    await cancelScheduledAlarms();
-    const scheduled = await scheduleAlarmsForRoute({
-      route,
-      destinationName: destination.name,
-      currentStationApproachEtaSeconds: payload.etaSeconds,
+  // kind 미상은 발사 불가 — 알림 본문/dedup 키 결정 불가. 구 백엔드 호환은 received 로그에만.
+  if (!payload.kind) {
+    logSilentPushSkipped({
+      stationName: payload.nextWaypoint,
+      kind: undefined,
+      phaseId: payload.phase,
+      reason: 'payload-missing-kind',
     });
-    logger.info(`rescheduled ${scheduled.length} alarms via silent push`);
+    logger.info('kind missing — skip fire');
+    return;
+  }
+
+  try {
+    await fireWithGate(payload as Required<Pick<SilentPushPayload, 'kind'>> & SilentPushPayload);
   } catch (e) {
-    logger.error('silent push handling failed:', e);
+    logger.error('silent push fire 실패:', e);
+  }
+}
+
+/**
+ * 위치 게이트 통과 시 즉시 발사, 실패 시 logSilentPushSkipped.
+ * kind/dedup/i18n을 한 곳에서 처리.
+ */
+async function fireWithGate(
+  payload: SilentPushPayload & { kind: NonNullable<SilentPushPayload['kind']> },
+): Promise<void> {
+  const gate = await checkSilentPushLocationGate({
+    stationName: payload.nextWaypoint,
+    kind: payload.kind,
+    phase: payload.phase,
+  });
+
+  if (!gate.pass) {
+    logSilentPushSkipped({
+      stationName: payload.nextWaypoint,
+      kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
+      phaseId: payload.phase,
+      reason: mapGateReason(gate.reason!),
+      distanceM: gate.distanceM,
+      thresholdM: gate.thresholdM,
+      locationSource: gate.locationSource,
+      locationAgeMs: gate.locationAgeMs,
+    });
+    logger.info(`gate skip reason=${gate.reason} distance=${gate.distanceM ?? '-'}`);
+    return;
+  }
+
+  // FIRED_ALARMS dedup — destination scope. intermediate는 dedup 대상 아님(통과는 1회성).
+  // dedup 키는 alarmKey({phaseId, stationName}) — FG GPS 발화와 동일 출처 공유.
+  const destinationId = await loadDestinationId();
+  const dedupKey =
+    payload.kind === 'intermediate'
+      ? null
+      : alarmKey({ phaseId: payload.phase, stationName: payload.nextWaypoint });
+
+  if (dedupKey && destinationId) {
+    const fired = await getFiredAlarms(destinationId);
+    if (fired.has(dedupKey)) {
+      logger.info(`dedup: ${dedupKey} already fired — skip`);
+      return;
+    }
+    fired.add(dedupKey);
+    await setFiredAlarms(destinationId, fired);
+  }
+
+  const content =
+    payload.kind === 'intermediate'
+      ? buildIntermediateContent(payload.nextWaypoint)
+      : buildAlarmContent({
+          phaseId: payload.phase,
+          type: payload.kind,
+          stationName: payload.nextWaypoint,
+        } as AlarmEvent);
+
+  await Notifications.scheduleNotificationAsync({
+    content: { title: content.title, body: content.body },
+    trigger: null,
+  });
+
+  logSilentPushFired({
+    stationName: payload.nextWaypoint,
+    kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
+    phaseId: payload.phase,
+    distanceM: gate.distanceM!,
+    thresholdM: gate.thresholdM!,
+    locationSource: gate.locationSource!,
+    locationAgeMs: gate.locationAgeMs!,
+  });
+  logger.info(
+    `fired: kind=${payload.kind} phase=${payload.phase} station=${payload.nextWaypoint} distance=${gate.distanceM}m`,
+  );
+}
+
+/**
+ * AsyncStorage에서 destination.id만 안전하게 꺼낸다.
+ * 파싱 실패/구조 손상 시 null — dedup 건너뜀(발사는 진행).
+ */
+async function loadDestinationId(): Promise<string | null> {
+  try {
+    const json = await AsyncStorage.getItem(DESTINATION_KEY);
+    if (!json) return null;
+    const parsed = JSON.parse(json) as Partial<Station> | null;
+    return parsed && typeof parsed.id === 'string' ? parsed.id : null;
+  } catch {
+    return null;
   }
 }
 
@@ -157,7 +254,6 @@ TaskManager.defineTask(SILENT_PUSH_TASK, handleSilentPush);
 
 /**
  * 앱 초기화 시 호출 — Notifications가 BG payload를 이 task로 라우팅하도록 등록한다.
- * 이미 등록된 경우 no-op.
  */
 export async function registerSilentPushTask(): Promise<void> {
   try {

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -9,6 +9,8 @@ import {
   logSuppressedDedupStation,
   logSuppressedGate,
   logSilentPushReceived,
+  logSilentPushFired,
+  logSilentPushSkipped,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -344,6 +346,77 @@ describe('alarmLog', () => {
       expect(saved[0].kind).toBeUndefined();
       expect(saved[0].sentAt).toBeUndefined();
       expect(saved[0].receivedAt).toBe(1_700_000_001_000);
+    });
+
+    it('logSilentPushFired: 게이트 통과 후 발사 1건 적재 (#478 PR 1-2)', async () => {
+      logSilentPushFired({
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'imminent',
+        distanceM: 150,
+        thresholdM: 400,
+        locationSource: 'cache',
+        locationAgeMs: 12_000,
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'silent-push-fired',
+        outcome: 'fired',
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'imminent',
+        distanceM: 150,
+        thresholdM: 400,
+        locationSource: 'cache',
+        locationAgeMs: 12_000,
+      });
+    });
+
+    it('logSilentPushSkipped: reason + 거리/임계값 적재 (#478 PR 1-2)', async () => {
+      logSilentPushSkipped({
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'imminent',
+        reason: 'gate-out-of-range',
+        distanceM: 5_000,
+        thresholdM: 400,
+        locationSource: 'cache',
+        locationAgeMs: 10_000,
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'silent-push-skipped',
+        outcome: 'suppressed',
+        reason: 'gate-out-of-range',
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'imminent',
+        distanceM: 5_000,
+        thresholdM: 400,
+      });
+    });
+
+    it('logSilentPushSkipped: kind 미상 + 거리 정보 없을 때도 적재', async () => {
+      logSilentPushSkipped({
+        stationName: '강남',
+        kind: undefined,
+        phaseId: 'early',
+        reason: 'gate-unknown-station',
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].source).toBe('silent-push-skipped');
+      expect(saved[0].reason).toBe('gate-unknown-station');
+      expect(saved[0].kind).toBeUndefined();
+      expect(saved[0].distanceM).toBeUndefined();
     });
 
     it('helper는 fire-and-forget: void 반환 + AsyncStorage 실패 시 throw 안 함', async () => {

--- a/src/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/utils/__tests__/silentPushLocationGate.test.ts
@@ -1,0 +1,269 @@
+const mockGetLastKnownPositionAsync = jest.fn();
+const mockGetCurrentPositionAsync = jest.fn();
+
+jest.mock('expo-location', () => ({
+  getLastKnownPositionAsync: (...args: unknown[]) => mockGetLastKnownPositionAsync(...args),
+  getCurrentPositionAsync: (...args: unknown[]) => mockGetCurrentPositionAsync(...args),
+  Accuracy: { Balanced: 3 },
+}));
+
+const mockFindStationByName = jest.fn();
+jest.mock('../stationLookup', () => ({
+  findStationByName: (...args: unknown[]) => mockFindStationByName(...args),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import {
+  checkSilentPushLocationGate,
+  LOCATION_CACHE_TTL_MS,
+  FRESH_FETCH_TIMEOUT_MS,
+} from '../silentPushLocationGate';
+
+const GANGNAM = { id: '2-12', name: '강남', line: '2', lat: 37.4979, lng: 127.0276 };
+// 강남에서 ~330m 떨어진 좌표 (논현 방향)
+const NEAR_GANGNAM = { lat: 37.5009, lng: 127.0276 };
+// 강남에서 ~5km 떨어진 좌표 (정지 사용자 가정)
+const FAR_FROM_GANGNAM = { lat: 37.5500, lng: 127.0276 };
+
+function makePosition(lat: number, lng: number, ageMs: number) {
+  return {
+    coords: { latitude: lat, longitude: lng, accuracy: 50, altitude: null, heading: null, speed: null, altitudeAccuracy: null },
+    timestamp: Date.now() - ageMs,
+  };
+}
+
+describe('checkSilentPushLocationGate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-21T10:00:00Z'));
+    mockFindStationByName.mockReturnValue(GANGNAM);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stationName이 stations.json에 없으면 unknown-station skip', async () => {
+    mockFindStationByName.mockReturnValue(null);
+    const result = await checkSilentPushLocationGate({
+      stationName: '없는역',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('unknown-station');
+    expect(mockGetLastKnownPositionAsync).not.toHaveBeenCalled();
+  });
+
+  it('캐시 위치가 가까우면 pass (cache source, distance 표기)', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 10_000),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.pass).toBe(true);
+    expect(result.locationSource).toBe('cache');
+    expect(result.locationAgeMs).toBe(10_000);
+    expect(result.distanceM).toBeGreaterThan(0);
+    expect(result.thresholdM).toBe(400);
+  });
+
+  it('캐시 위치가 멀면 out-of-range skip + distance 기록', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('out-of-range');
+    expect(result.distanceM).toBeGreaterThan(400);
+    expect(result.thresholdM).toBe(400);
+  });
+
+  it('phase=early는 imminent보다 넓은 임계값(800m) 사용', async () => {
+    // 강남에서 ~500m 떨어진 좌표 (imminent에선 fail, early에선 pass 예상)
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(37.5025, 127.0276, 5_000),
+    );
+    const imminent = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'transfer',
+      phase: 'imminent',
+    });
+    expect(imminent.pass).toBe(false);
+
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(37.5025, 127.0276, 5_000),
+    );
+    const early = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'transfer',
+      phase: 'early',
+    });
+    expect(early.pass).toBe(true);
+    expect(early.thresholdM).toBe(800);
+  });
+
+  it('intermediate kind는 더 좁은 임계값 (imminent=300, early=600)', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 5_000),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'intermediate',
+      phase: 'imminent',
+    });
+    expect(result.thresholdM).toBe(300);
+  });
+
+  it('캐시가 없으면 fresh fetch fallback', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(null);
+    mockGetCurrentPositionAsync.mockResolvedValue(
+      makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 0),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.pass).toBe(true);
+    expect(result.locationSource).toBe('fresh');
+    expect(result.locationAgeMs).toBe(0);
+  });
+
+  it('캐시 throw 시에도 fresh fetch fallback', async () => {
+    mockGetLastKnownPositionAsync.mockRejectedValue(new Error('os error'));
+    mockGetCurrentPositionAsync.mockResolvedValue(
+      makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 0),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.pass).toBe(true);
+    expect(result.locationSource).toBe('fresh');
+  });
+
+  it('캐시 + fresh 모두 실패하면 no-location skip', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(null);
+    mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('no-location');
+  });
+
+  it('fresh fetch가 타임아웃 초과면 no-location skip', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(null);
+    // FRESH_FETCH_TIMEOUT_MS 동안 응답 없는 promise
+    mockGetCurrentPositionAsync.mockImplementation(() => new Promise(() => {}));
+    const promise = checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    await jest.advanceTimersByTimeAsync(FRESH_FETCH_TIMEOUT_MS + 100);
+    const result = await promise;
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('no-location');
+  });
+
+  it('캐시 ageMs가 TTL 초과면 stale-location skip', async () => {
+    // getLastKnownPositionAsync는 maxAge 옵션에도 불구하고 모킹에서 직접 반환 가능
+    // 실제 OS는 maxAge 초과 시 null을 반환하지만 방어적 게이트 동작 검증.
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, LOCATION_CACHE_TTL_MS + 5_000),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('stale-location');
+    expect(result.locationSource).toBe('cache');
+  });
+
+  it('캐시 timestamp가 미래(음수 age)면 0으로 clamp', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue({
+      coords: {
+        latitude: NEAR_GANGNAM.lat,
+        longitude: NEAR_GANGNAM.lng,
+        accuracy: 50,
+        altitude: null,
+        heading: null,
+        speed: null,
+        altitudeAccuracy: null,
+      },
+      timestamp: Date.now() + 10_000,
+    });
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.locationAgeMs).toBe(0);
+  });
+
+  it('timestamp가 null이면 ?? 0 fallback (큰 값 → stale)', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue({
+      coords: {
+        latitude: NEAR_GANGNAM.lat,
+        longitude: NEAR_GANGNAM.lng,
+        accuracy: 50,
+        altitude: null,
+        heading: null,
+        speed: null,
+        altitudeAccuracy: null,
+      },
+      timestamp: null,
+    });
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(result.reason).toBe('stale-location');
+  });
+
+  it('timestamp 누락(0) 시에도 Date.now()로 ageMs 계산 (큰 값 → stale)', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue({
+      coords: {
+        latitude: NEAR_GANGNAM.lat,
+        longitude: NEAR_GANGNAM.lng,
+        accuracy: 50,
+        altitude: null,
+        heading: null,
+        speed: null,
+        altitudeAccuracy: null,
+      },
+      timestamp: 0,
+    });
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    // timestamp=0이면 ageMs는 Date.now()와 같은 거대값 → stale
+    expect(result.reason).toBe('stale-location');
+  });
+});

--- a/src/utils/__tests__/stationLookup.test.ts
+++ b/src/utils/__tests__/stationLookup.test.ts
@@ -1,9 +1,9 @@
-import { findLineByStationName } from '../stationLookup';
+import { findLineByStationName, findStationByName } from '../stationLookup';
 
 jest.mock('../../data/stations.json', () => [
-  { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
-  { id: '4-001', name: '서울역', line: '4', lineColor: '#00A5DE', lat: 0, lng: 0 },
-  { id: '2-001', name: '강남', line: '2', lineColor: '#00A84D', lat: 0, lng: 0 },
+  { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.5547, lng: 126.9706 },
+  { id: '4-001', name: '서울역', line: '4', lineColor: '#00A5DE', lat: 37.5547, lng: 126.9706 },
+  { id: '2-001', name: '강남', line: '2', lineColor: '#00A84D', lat: 37.4979, lng: 127.0276 },
 ]);
 
 describe('findLineByStationName', () => {
@@ -17,5 +17,21 @@ describe('findLineByStationName', () => {
 
   it('returns null for unknown station names', () => {
     expect(findLineByStationName('없는역')).toBeNull();
+  });
+});
+
+describe('findStationByName', () => {
+  it('역명으로 첫 매칭 Station(좌표 포함) 반환', () => {
+    const result = findStationByName('강남');
+    expect(result).toMatchObject({ id: '2-001', name: '강남', lat: 37.4979, lng: 127.0276 });
+  });
+
+  it('환승역은 등록 순서상 첫 호선 반환', () => {
+    const result = findStationByName('서울역');
+    expect(result?.line).toBe('1');
+  });
+
+  it('없는 역명은 null', () => {
+    expect(findStationByName('없는역')).toBeNull();
   });
 });

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -14,13 +14,31 @@ export const ALARM_LOG_BUFFER_SIZE = 200;
 
 // 'fg' / 'bg'는 v1 (FG GPS 평가 / BG location task gate). 'fg-evaluated' / 'bg-scheduled'는
 // v2 (#372)로 의미 명확화. 두 값 모두 union에 유지해 과거 저장 데이터를 손실 없이 읽는다.
-// 'silent-push-received'는 #478 측정 인프라 — silent push 도달 시점 기록 (outcome은 항상
-// 'received', 동작 변경 없음).
-export type AlarmLogSource = 'fg' | 'bg' | 'fg-evaluated' | 'bg-scheduled' | 'silent-push-received';
+// 'silent-push-received'는 #478 측정 인프라 — silent push 도달 시점 기록.
+// 'silent-push-fired'/'silent-push-skipped'는 #478 PR 1-2 — 위치 게이트 통과/실패 발사.
+export type AlarmLogSource =
+  | 'fg'
+  | 'bg'
+  | 'fg-evaluated'
+  | 'bg-scheduled'
+  | 'silent-push-received'
+  | 'silent-push-fired'
+  | 'silent-push-skipped';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(evaluateAlarmPhase의 firedAlarms 적중 케이스)은 후속 이슈에서 추가.
 // 그때까지 union에 선언하지 않아 "구현됐다"는 거짓 시그널을 피한다.
-export type AlarmLogReason = 'dedup-station' | 'gate-age' | 'gate-accuracy';
+// 'gate-unknown-station' / 'gate-no-location' / 'gate-stale-location' / 'gate-out-of-range'는
+// #478 PR 1-2 silent push 위치 게이트 skip 사유.
+// 'payload-missing-kind'는 구 백엔드 payload에 kind 필드가 없어 발사 본문 결정 불가 → skip.
+export type AlarmLogReason =
+  | 'dedup-station'
+  | 'gate-age'
+  | 'gate-accuracy'
+  | 'gate-unknown-station'
+  | 'gate-no-location'
+  | 'gate-stale-location'
+  | 'gate-out-of-range'
+  | 'payload-missing-kind';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 
@@ -72,6 +90,12 @@ export interface AlarmLogEntry {
   // 두 시각 차로 도달 지연 분포 측정.
   sentAt?: number;
   receivedAt?: number;
+  // #478 PR 1-2 — silent push 위치 게이트 결과.
+  // silent-push-fired / silent-push-skipped 엔트리에서 사용.
+  distanceM?: number;
+  thresholdM?: number;
+  locationSource?: 'cache' | 'fresh';
+  locationAgeMs?: number;
 }
 
 const logger = createLogger('AlarmLog');
@@ -160,6 +184,62 @@ export function logSilentPushReceived(input: {
     phaseId: input.phaseId,
     sentAt: input.sentAt,
     receivedAt: input.receivedAt,
+  });
+}
+
+/**
+ * silent push가 위치 게이트 통과 → 즉시 발사한 1건 (#478 PR 1-2).
+ */
+export function logSilentPushFired(input: {
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId: AlarmPhaseId;
+  distanceM: number;
+  thresholdM: number;
+  locationSource: 'cache' | 'fresh';
+  locationAgeMs: number;
+}): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'silent-push-fired',
+    outcome: 'fired',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+    distanceM: input.distanceM,
+    thresholdM: input.thresholdM,
+    locationSource: input.locationSource,
+    locationAgeMs: input.locationAgeMs,
+  });
+}
+
+/**
+ * silent push 위치 게이트 실패 → 발사 skip 한 1건 (#478 PR 1-2).
+ * reason은 게이트 사유: gate-unknown-station / gate-no-location /
+ * gate-stale-location / gate-out-of-range.
+ */
+export function logSilentPushSkipped(input: {
+  stationName: string;
+  kind: AlarmLogKind | undefined;
+  phaseId: AlarmPhaseId;
+  reason: AlarmLogReason;
+  distanceM?: number;
+  thresholdM?: number;
+  locationSource?: 'cache' | 'fresh';
+  locationAgeMs?: number;
+}): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'silent-push-skipped',
+    outcome: 'suppressed',
+    reason: input.reason,
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+    distanceM: input.distanceM,
+    thresholdM: input.thresholdM,
+    locationSource: input.locationSource,
+    locationAgeMs: input.locationAgeMs,
   });
 }
 

--- a/src/utils/silentPushLocationGate.ts
+++ b/src/utils/silentPushLocationGate.ts
@@ -1,0 +1,155 @@
+import * as Location from 'expo-location';
+import { haversine } from './haversine';
+import { findStationByName } from './stationLookup';
+import { createLogger } from './logger';
+
+const logger = createLogger('SilentPushLocationGate');
+
+// 위치 캐시 신뢰 TTL — 초과 시 stale로 간주하고 보수적 skip.
+// silent push imminent 알림은 도착 직전이라 60초 이상 stale 캐시로 발사하면
+// 사용자가 이미 통과/이전 역에 있을 위험.
+export const LOCATION_CACHE_TTL_MS = 60_000;
+
+// 콜드 GPS fetch 타임아웃 — BG 깨움 시 OS가 즉답 못 하면 보수적 skip.
+export const FRESH_FETCH_TIMEOUT_MS = 3_000;
+
+/**
+ * phase × kind별 발사 허용 거리(m).
+ * - early: 한 정거장 전 알림 → 다음 역이라도 게이트 통과해야 하므로 넓게
+ * - imminent: 도착 직전 → 좁게
+ * - intermediate: 이미 그 역 근처 통과 시점 → 가장 좁게
+ *
+ * 초안 값. 운영 alarmLog 데이터로 후속 조정(#478 follow-up).
+ */
+const THRESHOLDS_M = {
+  early: { transfer: 800, destination: 800, intermediate: 600 },
+  imminent: { transfer: 400, destination: 400, intermediate: 300 },
+} as const;
+
+export type GateKind = 'transfer' | 'destination' | 'intermediate';
+export type GatePhase = 'early' | 'imminent';
+
+export type GateSkipReason = 'unknown-station' | 'no-location' | 'stale-location' | 'out-of-range';
+export type GateLocationSource = 'cache' | 'fresh';
+
+export interface GateResult {
+  pass: boolean;
+  reason?: GateSkipReason;
+  distanceM?: number;
+  thresholdM?: number;
+  locationSource?: GateLocationSource;
+  locationAgeMs?: number;
+}
+
+interface UserPosition {
+  lat: number;
+  lng: number;
+  ageMs: number;
+  source: GateLocationSource;
+}
+
+/**
+ * Promise<T>에 timeout을 거는 헬퍼.
+ * silent push 핸들러는 BG에서 짧은 시간만 살아있으므로 GPS 콜드 fetch가
+ * 무한정 대기하면 안 된다.
+ */
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('gate-fetch-timeout')), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
+/**
+ * 1순위: OS-level 마지막 알려진 위치 (즉답, 무비용)
+ * 2순위: 콜드 GPS fetch (TIMEOUT 3s, 실패 시 null)
+ */
+async function resolveUserPosition(): Promise<UserPosition | null> {
+  try {
+    const last = await Location.getLastKnownPositionAsync({ maxAge: LOCATION_CACHE_TTL_MS });
+    if (last) {
+      const ageMs = Math.max(0, Date.now() - (last.timestamp ?? 0));
+      return {
+        lat: last.coords.latitude,
+        lng: last.coords.longitude,
+        ageMs,
+        source: 'cache',
+      };
+    }
+  } catch (e) {
+    logger.warn('getLastKnownPositionAsync 실패 — fresh fetch 시도:', e);
+  }
+  try {
+    const fresh = await withTimeout(
+      Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced }),
+      FRESH_FETCH_TIMEOUT_MS,
+    );
+    return {
+      lat: fresh.coords.latitude,
+      lng: fresh.coords.longitude,
+      ageMs: 0,
+      source: 'fresh',
+    };
+  } catch (e) {
+    logger.warn('getCurrentPositionAsync 실패/타임아웃:', e);
+    return null;
+  }
+}
+
+/**
+ * silent push 수신 시 "사용자가 실제로 그 역 근처에 있는지" 확인하는 게이트.
+ * pass=true면 알림 발사, false면 skip + alarmLog에 skipReason 기록.
+ *
+ * 정책:
+ *   1) stationName이 stations.json에 없으면 skip (unknown-station)
+ *   2) 위치 획득 실패 시 skip (no-location) — 보수적
+ *   3) 캐시가 TTL 초과면 skip (stale-location) — 보수적
+ *   4) phase/kind별 임계값 이내면 pass, 초과면 skip (out-of-range)
+ */
+export async function checkSilentPushLocationGate(input: {
+  stationName: string;
+  kind: GateKind;
+  phase: GatePhase;
+}): Promise<GateResult> {
+  const station = findStationByName(input.stationName);
+  if (!station) {
+    return { pass: false, reason: 'unknown-station' };
+  }
+
+  const pos = await resolveUserPosition();
+  if (!pos) {
+    return { pass: false, reason: 'no-location' };
+  }
+
+  if (pos.ageMs > LOCATION_CACHE_TTL_MS) {
+    return {
+      pass: false,
+      reason: 'stale-location',
+      locationSource: pos.source,
+      locationAgeMs: pos.ageMs,
+    };
+  }
+
+  // haversine은 km 반환 → m로 변환 후 임계값(m)과 비교.
+  const distanceM = Math.round(haversine(pos.lat, pos.lng, station.lat, station.lng) * 1000);
+  const thresholdM = THRESHOLDS_M[input.phase][input.kind];
+  const pass = distanceM <= thresholdM;
+
+  return {
+    pass,
+    reason: pass ? undefined : 'out-of-range',
+    distanceM,
+    thresholdM,
+    locationSource: pos.source,
+    locationAgeMs: pos.ageMs,
+  };
+}

--- a/src/utils/stationLookup.ts
+++ b/src/utils/stationLookup.ts
@@ -12,3 +12,12 @@ export function findLineByStationName(name: string): LineNumber | null {
   const match = stations.find((s) => s.name === name);
   return match ? match.line : null;
 }
+
+/**
+ * 역명으로 첫 매칭되는 Station(좌표 포함)을 반환한다.
+ * 환승역은 호선별 lat/lng가 동일하므로 첫 매칭으로 충분하다.
+ * silent push 위치 게이트(#478)에서 사용.
+ */
+export function findStationByName(name: string): Station | null {
+  return stations.find((s) => s.name === name) ?? null;
+}


### PR DESCRIPTION
> **Stacked PR** — base는 #485(`feat/#478-silent-push-primary`, 측정 인프라). #485 머지 후 base를 dev로 변경.

## Summary

silent push를 BG 알림의 **단독 발화원**으로 전환. 사용자 명시 요구 "사전예약은 절대 하지 말고, 실제 위치에 있을 때만 알림"을 구현.

- silent push 수신 시 모든 (kind, phase) 조합에서 **위치 게이트 통과 시 즉시 발사**
- `scheduleAlarmsForRoute` / `cancelScheduledAlarms` 호출 완전 제거 (silentPushTask)
- `useScheduledAlarms` 마운트 제거 (app/(tabs)/index.tsx)
- 부팅 1회 마이그레이션: `cancelScheduledAlarms` + `unregisterAlarmRefreshTask` — 잔존 사전예약/BGAppRefresh 정리

## 위치 게이트 (`src/utils/silentPushLocationGate.ts`)

- 위치 획득 우선순위
  1. `Location.getLastKnownPositionAsync(maxAge=60s)` — OS-level 캐시, 즉답
  2. `Location.getCurrentPositionAsync(timeout=3s)` — 콜드 fetch
  3. 둘 다 실패 → `no-location` skip
- 게이트 임계값 (m, 초안)
  | phase | transfer/destination | intermediate |
  | --- | --- | --- |
  | early | 800 | 600 |
  | imminent | 400 | 300 |
- Skip reason: `unknown-station` / `no-location` / `stale-location` / `out-of-range`
- 캐시 TTL 초과 시 보수적 skip — "정지 시 헛 알림 0건" 정책

## dedup 통합

silent push와 GPS(`useStationAlarm`) 발화가 동일 `FIRED_ALARMS` 키 공유:
- 키: `alarmKey({phaseId, stationName})`
- destination scope (`getFiredAlarms(destinationId)`)
- silent push가 먼저 도착하면 GPS 발화 skip, GPS가 먼저면 silent push skip
- intermediate(통과 알림)는 dedup 안 씀 — 1회성

## 사전예약 코드 처리

본 PR에서 **삭제하지 않음** — 롤백 안전 + #411로 위임.
- `useScheduledAlarms.ts`, `alarmScheduler.ts`, `alarmRefreshTask.ts` 파일 그대로 유지
- 마운트만 제거 → 호출 경로 끊김
- OS native level 잔존 task는 부팅 시 `unregisterAlarmRefreshTask`로 명시 unregister (code-review 지적 반영)

## alarmLog 확장

| 신규 source | 의미 |
| --- | --- |
| `silent-push-fired` | 게이트 통과 + 발사 |
| `silent-push-skipped` | 게이트 실패 |

| 신규 reason | 의미 |
| --- | --- |
| `gate-unknown-station` | stations.json에 없음 |
| `gate-no-location` | 위치 획득 실패 |
| `gate-stale-location` | 캐시 TTL 초과 |
| `gate-out-of-range` | 거리 임계값 초과 |
| `payload-missing-kind` | 구 백엔드 payload (kind 없음) |

신규 필드 `distanceM`, `thresholdM`, `locationSource`, `locationAgeMs` — 운영 튜닝용.

## code-review 반영

- **P1-1 (수정 완료)**: 부팅 시 `unregisterAlarmRefreshTask` 호출 추가 — 코드 import 무관하게 OS native level 잔존 BG task 정리
- **P1-2 (수정 완료)**: kind 미상 케이스에 `payload-missing-kind` 신규 reason 분리 — `gate-unknown-station`과 의미 충돌 해소
- P2/P3는 후속 이슈로 분리 권장 (임계값 상수 분리, 동명이역 line 매칭, GateResult discriminated union)

## 정책 결정 — R3/R4

- **R3 stale 캐시**: TTL 60s 초과 시 보수적 skip (사용자 명시 정책 — 실제 위치 우선)
- **R4 임계값**: 400/800/300/600m 초안 — 운영 alarmLog로 후속 튜닝 (#478 follow-up)
- **R5 dedup**: silent push와 GPS가 단일 `alarmKey` 키 공유 — 출처별 분리 없음

## 알려진 한계 (후속 이슈)

- **강제종료(swipe-kill)**: silent push가 OS 단에서 drop → 알림 zero. 별도 이슈: alert push 전환
- **지하 오프라인**: APNs 큐잉 TTL 초과 시 미수신. 별도 이슈: geofence 보완
- **백엔드 progress 인지**: 정지 사용자에게 push 안 보내기 — 별도 이슈

## Test plan

- [x] 클라 jest 1577/1577 pass + 커버리지 100% (lines/functions/branches/statements)
- [x] type-check pass
- [x] code-reviewer 통과 (P1 2건 반영)
- [ ] CI Type Check & Test 통과
- [ ] 실기기 검증 (#410 9항목 + #339 시나리오 재정의)
  - [ ] 환승 알림 잠금화면 정상 발화 (위치 일치)
  - [ ] 정지 상태 30분 — 헛 알림 0건
  - [ ] 강제종료 케이스 — 알림 zero (의도 동작, 후속 이슈)

Relates to #478