### PR TITLE
fix(#396): 도착정보 arrivalCode 기반 imminent 발사 (ETA-only 한계 해소)

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -69,6 +69,21 @@ jest.mock('../../utils/scheduledAlarmReceiver', () => ({
   awaitInitialScheduledAlarmDrain: jest.fn().mockResolvedValue(undefined),
 }));
 
+const mockIsImminentByArrivalCode = jest.fn();
+jest.mock('../../utils/imminentArrivalSignal', () => ({
+  isImminentByArrivalCode: (...args: unknown[]) => mockIsImminentByArrivalCode(...args),
+}));
+
+const mockGetStoredTripTrainCode = jest.fn();
+jest.mock('../../utils/tripTrainCode', () => ({
+  getStoredTripTrainCode: (...args: unknown[]) => mockGetStoredTripTrainCode(...args),
+}));
+
+const mockUseArrivalInfo = jest.fn();
+jest.mock('../useArrivalInfo', () => ({
+  useArrivalInfo: (...args: unknown[]) => mockUseArrivalInfo(...args),
+}));
+
 const makeStation = (id: string, name: string, lat = 37.5, lng = 127.0): Station => ({
   id,
   name,
@@ -108,6 +123,9 @@ describe('useStationAlarm', () => {
     mockSetLastNotifiedStationId.mockResolvedValue(undefined);
     mockGetFiredAlarms.mockResolvedValue(new Set<string>());
     mockSetFiredAlarms.mockResolvedValue(undefined);
+    mockIsImminentByArrivalCode.mockReturnValue(false);
+    mockGetStoredTripTrainCode.mockResolvedValue(null);
+    mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
   });
 
   it('does not evaluate when route is null', () => {
@@ -880,7 +898,7 @@ describe('useStationAlarm', () => {
     const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
     const station = makeStation('S1', '강남', 37.498, 127.028);
 
-    it('알람 발사 시 logFiredAlarm(fg, event)를 호출한다', async () => {
+    it('알람 발사 시 logFiredAlarm(fg, event, "eta")를 호출한다', async () => {
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
 
       renderHook(() =>
@@ -888,7 +906,7 @@ describe('useStationAlarm', () => {
       );
 
       await waitFor(() => {
-        expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest);
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta');
       });
     });
 
@@ -974,6 +992,180 @@ describe('useStationAlarm', () => {
       // 추가 호출 없음 — 게이트 boolean이 바뀌지 않는 한 effect가 재실행되지 않음.
       // (await 후 검증으로 비동기 IIFE의 carryover 호출 가능성도 차단)
       expect(mockLogSuppressedDedupStation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#396 API 신호 기반 imminent', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const station = makeStation('S1', '시청');
+
+    it('isImminentByArrivalCode가 true이고 미발사 상태면 imminent 알람 발사 + logFiredAlarm("fg", _, "api")', async () => {
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockUseArrivalInfo.mockReturnValue({
+        arrival: { up: [], down: [], isMock: false },
+        loading: false,
+        isMock: false,
+      });
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => {
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith(
+          'fg',
+          expect.objectContaining({ phaseId: 'imminent', stationName: '강남', type: 'destination' }),
+          'api',
+        );
+      });
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+    });
+
+    it('API 신호 false면 발사하지 않는다', async () => {
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(false);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      // hydration 완료 대기
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+
+      const apiCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'api');
+      expect(apiCalls).toHaveLength(0);
+    });
+
+    it('이미 imminent가 firedAlarms에 있으면 dedup으로 재발사하지 않는다', async () => {
+      mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+
+      const apiCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'api');
+      expect(apiCalls).toHaveLength(0);
+    });
+
+    it('hydration 완료 전에는 API 신호 평가를 보류한다', () => {
+      // getFiredAlarms를 영원히 pending 상태로 두면 firedHydrated가 false 유지
+      mockGetFiredAlarms.mockReturnValue(new Promise(() => {}));
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('sleepMode면 setAlarmEvent도 함께 호출', async () => {
+      useAppStore.setState({ sleepMode: true });
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+      const setAlarmEventSpy = jest.spyOn(useAppStore.getState(), 'setAlarmEvent');
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => {
+        expect(setAlarmEventSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ phaseId: 'imminent', stationName: '강남' }),
+        );
+      });
+      setAlarmEventSpy.mockRestore();
+    });
+
+    it('resolveAlarmDirection 결과가 있으면 event에 direction 포함', async () => {
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+      mockResolveAlarmDirection.mockReturnValue('up');
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => {
+        expect(mockSendAlarmNotification).toHaveBeenCalledWith(
+          expect.objectContaining({ direction: 'up' }),
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+    });
+
+    it('destination이 없으면 평가하지 않는다', async () => {
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() => useStationAlarm(defaultInputs({ route })));
+
+      await Promise.resolve();
+      const apiCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'api');
+      expect(apiCalls).toHaveLength(0);
+    });
+
+    it('nearestStation이 null이면 direction 미부착 (resolveAlarmDirection 호출 안 함)', async () => {
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: null })),
+      );
+
+      await waitFor(() => {
+        expect(mockSendAlarmNotification).toHaveBeenCalled();
+      });
+      // nearestStation null이면 direction 분기를 거치지 않음
+      const apiSendCall = mockSendAlarmNotification.mock.calls[0];
+      expect(apiSendCall[0]).not.toHaveProperty('direction');
+    });
+
+    it('sendAlarmNotification rejection은 logger.error로 swallowed (회귀 가드)', async () => {
+      mockSendAlarmNotification.mockRejectedValueOnce(new Error('boom'));
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+      );
+
+      await waitFor(() => {
+        expect(mockSendAlarmNotification).toHaveBeenCalled();
+      });
+      // rejection이 swallow돼 후속 로깅이 정상 호출되는지 확인
+      await waitFor(() => {
+        const apiCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'api');
+        expect(apiCalls.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('destinationId 없으면 trackedTrainCode를 null로 리셋한다', async () => {
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+
+      const { rerender } = renderHook(
+        ({ inputs }: { inputs: UseStationAlarmInputs }) => useStationAlarm(inputs),
+        { initialProps: { inputs: defaultInputs({ route, destination }) } },
+      );
+
+      await waitFor(() => expect(mockGetStoredTripTrainCode).toHaveBeenCalledWith('D1'));
+
+      rerender({ inputs: defaultInputs({ route, destination: null }) });
+
+      // destination null이면 effect는 setTrackedTrainCode(null) 호출 후 종료
+      // getStoredTripTrainCode 추가 호출 없음
+      const callCountBefore = mockGetStoredTripTrainCode.mock.calls.length;
+      await Promise.resolve();
+      expect(mockGetStoredTripTrainCode.mock.calls.length).toBe(callCountBefore);
     });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -7,6 +7,9 @@ import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
 import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
+import { isImminentByArrivalCode } from '../utils/imminentArrivalSignal';
+import { getStoredTripTrainCode } from '../utils/tripTrainCode';
+import { useArrivalInfo } from './useArrivalInfo';
 import {
   getLastNotifiedStationId,
   setLastNotifiedStationId,
@@ -56,6 +59,15 @@ export function useStationAlarm({
   // 빈 ref로 false re-fire가 발생하지 않도록 가드한다.
   const [firedHydrated, setFiredHydrated] = useState(false);
   const destinationId = destination?.id ?? null;
+  // #396: 목적지 역의 도착정보를 별도로 폴링. arrivalCode가 ENTERING/ARRIVED가 되는 순간
+  // imminent 신호로 사용. useArrivalInfo는 모듈 스코프 TtlCache를 공유해 추가 호출 비용이 적다.
+  const { arrival: destinationArrival } = useArrivalInfo(
+    destination?.name ?? null,
+    destination?.line ?? null,
+  );
+  // 트립에 lock된 사용자 열차 코드. AsyncStorage에서 비동기 로드. lock 실패 상태(null)면
+  // API 신호 평가는 보수적으로 false 반환 — 잘못된 train으로 imminent 오발사 방지.
+  const [trackedTrainCode, setTrackedTrainCode] = useState<string | null>(null);
   const sleepMode = useAppStore((s) => s.sleepMode);
   const allowSpeaker = useAppStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
@@ -69,6 +81,24 @@ export function useStationAlarm({
   useEffect(() => {
     allowSpeakerRef.current = allowSpeaker;
   }, [allowSpeaker]);
+
+  // #396: 트립 trainCode lock-in 상태를 destination 도착정보 갱신마다 재로드.
+  // lock-in은 첫 valid arrival 캡처 시점에 일어나므로, arrival이 들어올 때마다 확인하면
+  // lock 직후 곧바로 API 신호 평가에 반영된다. destinationId가 없으면 null.
+  useEffect(() => {
+    if (!destinationId) {
+      setTrackedTrainCode(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const code = await getStoredTripTrainCode(destinationId);
+      if (!cancelled) setTrackedTrainCode(code);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [destinationId, destinationArrival]);
 
   // destination별 firedAlarms 하이드레이션 (#462).
   // destination이 바뀌면 storage의 destinationId와 일치하지 않는 entry는 자동 빈 set 반환.
@@ -140,7 +170,7 @@ export function useStationAlarm({
       sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
         logger.error('알람 알림 실패:', e),
       );
-      logFiredAlarm('fg', event);
+      logFiredAlarm('fg', event, 'eta');
     }
   }, [
     route,
@@ -153,6 +183,47 @@ export function useStationAlarm({
     speedMps,
     accuracyMeters,
     firedHydrated,
+    setAlarmEvent,
+    nearestStation?.id,
+  ]);
+
+  // #396: 도착정보 API 신호로 imminent 발사.
+  // lock된 trainCode가 목적지 역에 진입/도착하면 즉시 발사 — speedMps/accuracy 무관.
+  // 기존 ETA 기반 effect와 firedAlarms를 공유하므로 한쪽이 먼저 발사하면 다른 쪽은 dedup된다.
+  // silent push(#478) 핸들러도 동일 isImminentByArrivalCode를 사용해 BG에서 같은 판정.
+  useEffect(() => {
+    if (!firedHydrated) return;
+    if (!route || !destination) return;
+    if (!isImminentByArrivalCode(destinationArrival, trackedTrainCode)) return;
+
+    const imminentKey = `imminent:${destination.name}`;
+    if (firedAlarmsRef.current.has(imminentKey)) return;
+
+    const rawEvent = { phaseId: 'imminent' as const, type: 'destination' as const, stationName: destination.name };
+    const direction = nearestStation
+      ? resolveAlarmDirection(rawEvent, {
+          route,
+          destinationName: destination.name,
+          sourceStationName: nearestStation.name,
+        })
+      : undefined;
+    const event = direction ? { ...rawEvent, direction } : rawEvent;
+    firedAlarmsRef.current.add(alarmKey(event));
+    void setFiredAlarms(destination.id, firedAlarmsRef.current);
+    if (sleepModeRef.current) {
+      setAlarmEvent(event);
+    }
+    sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
+      logger.error('알람 알림 실패:', e),
+    );
+    logFiredAlarm('fg', event, 'api');
+  }, [
+    firedHydrated,
+    route,
+    destination?.id,
+    destination?.name,
+    destinationArrival,
+    trackedTrainCode,
     setAlarmEvent,
     nearestStation?.id,
   ]);

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -121,22 +121,25 @@ export function useStationAlarm({
   }, [destinationId]);
 
   // 알람 발사 + 로깅 헬퍼. ETA effect와 API 신호 effect가 동일 시퀀스를 수행하므로 통합.
-  // 호출자가 route/destination 가드를 통과한 뒤 호출하는 전제. 내부에서 한 번 더 가드해
-  // 타입 좁히기와 안전 양쪽을 확보.
-  function fireAndLog(rawEvent: AlarmEvent, trigger: 'api' | 'eta'): void {
-    if (!route || !destination) return;
+  // route/destination은 호출자가 가드 후 non-null로 전달 — 함수 내부 가드 중복 제거.
+  function fireAndLog(
+    rawEvent: AlarmEvent,
+    trigger: 'api' | 'eta',
+    activeRoute: NonNullable<Route>,
+    activeDestination: Station,
+  ): void {
     // 좌/우 안내 방향. nearestStation 미정이면 direction 미부착(본문에 좌/우 라인 생략).
     const direction = nearestStation
       ? resolveAlarmDirection(rawEvent, {
-          route,
-          destinationName: destination.name,
+          route: activeRoute,
+          destinationName: activeDestination.name,
           sourceStationName: nearestStation.name,
         })
       : undefined;
     const event = direction ? { ...rawEvent, direction } : rawEvent;
     firedAlarmsRef.current.add(alarmKey(event));
     // AsyncStorage에도 즉시 반영 — FG/BG 단일 출처 유지. destinationId scoped.
-    void setFiredAlarms(destination.id, firedAlarmsRef.current);
+    void setFiredAlarms(activeDestination.id, firedAlarmsRef.current);
     if (sleepModeRef.current) {
       setAlarmEvent(event);
     }
@@ -176,7 +179,7 @@ export function useStationAlarm({
       { route, destinationName: destination.name, etaSeconds },
       firedAlarmsRef.current,
     );
-    if (rawEvent) fireAndLog(rawEvent, 'eta');
+    if (rawEvent) fireAndLog(rawEvent, 'eta', route, destination);
   }, [
     route,
     destination?.id,
@@ -205,7 +208,7 @@ export function useStationAlarm({
     if (firedAlarmsRef.current.has(imminentKey)) return;
 
     const rawEvent: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: destination.name };
-    fireAndLog(rawEvent, 'api');
+    fireAndLog(rawEvent, 'api', route, destination);
   }, [
     firedHydrated,
     route,

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { isStationOnRoute } from '../utils/stationRoute';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
-import { alarmKey, evaluateAlarmPhase } from '../utils/stationAlarm';
+import { alarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
 import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
@@ -120,6 +120,32 @@ export function useStationAlarm({
     };
   }, [destinationId]);
 
+  // 알람 발사 + 로깅 헬퍼. ETA effect와 API 신호 effect가 동일 시퀀스를 수행하므로 통합.
+  // 호출자가 route/destination 가드를 통과한 뒤 호출하는 전제. 내부에서 한 번 더 가드해
+  // 타입 좁히기와 안전 양쪽을 확보.
+  function fireAndLog(rawEvent: AlarmEvent, trigger: 'api' | 'eta'): void {
+    if (!route || !destination) return;
+    // 좌/우 안내 방향. nearestStation 미정이면 direction 미부착(본문에 좌/우 라인 생략).
+    const direction = nearestStation
+      ? resolveAlarmDirection(rawEvent, {
+          route,
+          destinationName: destination.name,
+          sourceStationName: nearestStation.name,
+        })
+      : undefined;
+    const event = direction ? { ...rawEvent, direction } : rawEvent;
+    firedAlarmsRef.current.add(alarmKey(event));
+    // AsyncStorage에도 즉시 반영 — FG/BG 단일 출처 유지. destinationId scoped.
+    void setFiredAlarms(destination.id, firedAlarmsRef.current);
+    if (sleepModeRef.current) {
+      setAlarmEvent(event);
+    }
+    sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
+      logger.error('알람 알림 실패:', e),
+    );
+    logFiredAlarm('fg', event, trigger);
+  }
+
   // Phase 알람 효과: ETA 기반 phase 평가 + firedAlarms 갱신.
   // firedHydrated=false인 동안에는 보류 — BG가 이미 발화한 phase를 빈 ref로 재발화하는 것을 막는다.
   // station-passed와 분리: 하이드레이션 완료로 인한 effect 재실행이 station-passed 중복 발사를
@@ -150,28 +176,7 @@ export function useStationAlarm({
       { route, destinationName: destination.name, etaSeconds },
       firedAlarmsRef.current,
     );
-    if (rawEvent) {
-      // 좌/우 안내를 위한 진행방향. 출발 anchor가 없거나(nearestStation 미정) 결정 불가하면
-      // direction은 undefined로 남고, 본문에 좌/우 라인이 추가되지 않는다.
-      const direction = nearestStation
-        ? resolveAlarmDirection(rawEvent, {
-            route,
-            destinationName: destination.name,
-            sourceStationName: nearestStation.name,
-          })
-        : undefined;
-      const event = direction ? { ...rawEvent, direction } : rawEvent;
-      firedAlarmsRef.current.add(alarmKey(event));
-      // AsyncStorage에도 즉시 반영 — FG/BG 단일 출처 유지. destinationId scoped.
-      void setFiredAlarms(destination.id, firedAlarmsRef.current);
-      if (sleepModeRef.current) {
-        setAlarmEvent(event);
-      }
-      sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
-        logger.error('알람 알림 실패:', e),
-      );
-      logFiredAlarm('fg', event, 'eta');
-    }
+    if (rawEvent) fireAndLog(rawEvent, 'eta');
   }, [
     route,
     destination?.id,
@@ -199,24 +204,8 @@ export function useStationAlarm({
     const imminentKey = `imminent:${destination.name}`;
     if (firedAlarmsRef.current.has(imminentKey)) return;
 
-    const rawEvent = { phaseId: 'imminent' as const, type: 'destination' as const, stationName: destination.name };
-    const direction = nearestStation
-      ? resolveAlarmDirection(rawEvent, {
-          route,
-          destinationName: destination.name,
-          sourceStationName: nearestStation.name,
-        })
-      : undefined;
-    const event = direction ? { ...rawEvent, direction } : rawEvent;
-    firedAlarmsRef.current.add(alarmKey(event));
-    void setFiredAlarms(destination.id, firedAlarmsRef.current);
-    if (sleepModeRef.current) {
-      setAlarmEvent(event);
-    }
-    sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
-      logger.error('알람 알림 실패:', e),
-    );
-    logFiredAlarm('fg', event, 'api');
+    const rawEvent: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: destination.name };
+    fireAndLog(rawEvent, 'api');
   }, [
     firedHydrated,
     route,

--- a/src/utils/__tests__/imminentArrivalSignal.test.ts
+++ b/src/utils/__tests__/imminentArrivalSignal.test.ts
@@ -1,0 +1,70 @@
+import { isImminentByArrivalCode } from '../imminentArrivalSignal';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
+
+function makeTrain(trainCode: string, arrivalCode: number): ArrivalInfo {
+  return {
+    destination: '',
+    arrivalMinutes: 0,
+    arrivalSeconds: 0,
+    statusMessage: '',
+    trainCode,
+    receivedAtMs: 0,
+    arrivalCode,
+    isLastTrain: false,
+    trainType: 'normal',
+  };
+}
+
+function makeArrival(up: ArrivalInfo[], down: ArrivalInfo[] = []): StationArrival {
+  return { up, down };
+}
+
+describe('isImminentByArrivalCode', () => {
+  it('arrival이 null이면 false', () => {
+    expect(isImminentByArrivalCode(null, 'T1')).toBe(false);
+  });
+
+  it('trainCode가 null이면 false (lock 실패 보수 정책)', () => {
+    const arrival = makeArrival([makeTrain('T1', ARRIVAL_CODE.ENTERING)]);
+    expect(isImminentByArrivalCode(arrival, null)).toBe(false);
+  });
+
+  it('매칭되는 trainCode가 없으면 false', () => {
+    const arrival = makeArrival([makeTrain('T1', ARRIVAL_CODE.ARRIVED)]);
+    expect(isImminentByArrivalCode(arrival, 'T2')).toBe(false);
+  });
+
+  it('매칭 train의 arrivalCode가 ENTERING(0)이면 true', () => {
+    const arrival = makeArrival([makeTrain('T1', ARRIVAL_CODE.ENTERING)]);
+    expect(isImminentByArrivalCode(arrival, 'T1')).toBe(true);
+  });
+
+  it('매칭 train의 arrivalCode가 ARRIVED(1)이면 true', () => {
+    const arrival = makeArrival([makeTrain('T1', ARRIVAL_CODE.ARRIVED)]);
+    expect(isImminentByArrivalCode(arrival, 'T1')).toBe(true);
+  });
+
+  it('매칭 train이 down 방향에 있어도 true', () => {
+    const arrival = makeArrival([], [makeTrain('T1', ARRIVAL_CODE.ENTERING)]);
+    expect(isImminentByArrivalCode(arrival, 'T1')).toBe(true);
+  });
+
+  it('매칭 train의 arrivalCode가 DEPARTED/RUNNING/전역 코드면 false', () => {
+    const cases = [
+      ARRIVAL_CODE.DEPARTED,
+      ARRIVAL_CODE.PREV_DEPARTED,
+      ARRIVAL_CODE.PREV_ENTERING,
+      ARRIVAL_CODE.PREV_ARRIVED,
+      ARRIVAL_CODE.RUNNING,
+    ];
+    for (const code of cases) {
+      const arrival = makeArrival([makeTrain('T1', code)]);
+      expect(isImminentByArrivalCode(arrival, 'T1')).toBe(false);
+    }
+  });
+
+  it('빈 up/down 배열은 false', () => {
+    expect(isImminentByArrivalCode(makeArrival([]), 'T1')).toBe(false);
+  });
+});

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -23,6 +23,9 @@ export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 export type AlarmLogReason = 'dedup-station' | 'gate-age' | 'gate-accuracy';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
+// #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
+// early phase 등 imminent 외 발사에선 미설정.
+export type AlarmLogTrigger = 'api' | 'eta';
 
 export interface AlarmLogLocation {
   lat: number;
@@ -72,6 +75,8 @@ export interface AlarmLogEntry {
   // 두 시각 차로 도달 지연 분포 측정.
   sentAt?: number;
   receivedAt?: number;
+  // #396 — imminent phase 발사 trigger 출처. 미설정은 트리거 무관(early 등) 또는 구버전 로그.
+  trigger?: AlarmLogTrigger;
 }
 
 const logger = createLogger('AlarmLog');
@@ -81,7 +86,11 @@ const logger = createLogger('AlarmLog');
 // helper가 채운다 — 호출부에서 누락하거나 잘못 채우는 사고를 차단.
 // 모든 helper는 fire-and-forget: 실패해도 후속 정합성에 영향 없음(이미 swallow).
 
-export function logFiredAlarm(source: AlarmLogSource, event: AlarmEvent): void {
+export function logFiredAlarm(
+  source: AlarmLogSource,
+  event: AlarmEvent,
+  trigger?: AlarmLogTrigger,
+): void {
   void appendAlarmLog({
     ts: Date.now(),
     source,
@@ -89,6 +98,7 @@ export function logFiredAlarm(source: AlarmLogSource, event: AlarmEvent): void {
     stationName: event.stationName,
     kind: event.type,
     phaseId: event.phaseId,
+    trigger,
   });
 }
 

--- a/src/utils/imminentArrivalSignal.ts
+++ b/src/utils/imminentArrivalSignal.ts
@@ -1,0 +1,24 @@
+import type { StationArrival } from '../api/arrivalApi';
+import { ARRIVAL_CODE } from '../constants/arrivalCodes';
+
+/**
+ * 도착정보 응답에서 lock된 사용자 열차의 arrivalCode가 "곧 도착"(ENTERING/ARRIVED)인지 판정.
+ *
+ * #396: 기존 ETA 기반 imminent는 speedMps null/<0.5 시 ETA가 null로 빠져 거의 발사 안 됨.
+ * API 신호는 GPS/속도와 무관하게 직접 "곧 도착"을 알려줘 본질적 해법.
+ *
+ * 보수 정책: trainCode가 null이면 false. lock 실패 상태에서 임의 train으로 판정하면
+ * 잘못된 imminent 발사 위험. 호출부는 ETA fallback을 별도로 두어 안전망을 확보한다.
+ *
+ * FG/BG 공유 — silent push(#478) 핸들러에서도 동일 import해 동일 판정에 쓴다.
+ */
+export function isImminentByArrivalCode(
+  arrival: StationArrival | null,
+  trainCode: string | null,
+): boolean {
+  if (!arrival || !trainCode) return false;
+  const trains = [...arrival.up, ...arrival.down];
+  const match = trains.find((t) => t.trainCode === trainCode);
+  if (!match) return false;
+  return match.arrivalCode === ARRIVAL_CODE.ENTERING || match.arrivalCode === ARRIVAL_CODE.ARRIVED;
+}


### PR DESCRIPTION
## 무엇을
- 목적지 역 도착정보의 lock된 사용자 열차 `arrivalCode`가 ENTERING(0)/ARRIVED(1)이 되면 imminent 알람 발사
- 기존 ETA 기반 imminent는 fallback으로 유지
- `logFiredAlarm`에 trigger='api'|'eta' 추가해 발사 출처 측정 가능

## 왜
- 사용자 보고: 트립당 알람 1회만 옴 (early만, imminent 누락)
- 진짜 원인은 `estimateEtaSeconds`가 `speedMps < 0.5`면 null 반환 → 열차 감속/정차에서 ETA null → imminent 평가 통과 못함
- API 직접 신호로 speed 의존성 제거가 본질적 해법
- Closes #396

## 어떻게
- `src/utils/imminentArrivalSignal.ts` 신규: 순수 함수 `isImminentByArrivalCode(arrival, trainCode)`. FG/BG 공유 — silent push(#478) 핸들러에서 동일 import 가능
- `useStationAlarm.ts`: 목적지 useArrivalInfo + tripTrainCode 비동기 로드 + 새 API 신호 effect
- 기존 ETA effect와 firedAlarms 공유 → 어느 쪽이 먼저 fire해도 dedup
- `alarmLog.logFiredAlarm` signature에 optional trigger 인자 추가 (backward compat 유지)
- 보수 정책: trainCode null(lock 실패)이면 API 신호 false → ETA fallback에 의존

## 의도적 제외 (후속 트랙)
- 환승역 imminent (transfer waypoint별 도착정보 폴링)
- 거리 기반 fallback (측정 후 판단)
- BG/잠금 imminent — #478 silent push에서 같은 함수 사용해 동일 판정 가능

## 테스트
- imminentArrivalSignal 8건 신규
- useStationAlarm #396 describe 10건 신규 + 기존 1건 trigger 인자 수정
- npm test 1577/1577 통과, 커버리지 100%
- npm run type-check 통과

Closes #396