### PR TITLE
fix(#491): 지도 경로 환승역 마커 중복 제거

### DIFF
--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -34,7 +34,6 @@ const FOCUS_REGION_DELTA = 0.01;
 const FOCUS_ANIMATION_MS = 400;
 const ROUTE_POLYLINE_WIDTH = 5;
 const ROUTE_FIT_EDGE_PADDING = { top: 40, bottom: 40, left: 40, right: 40 };
-const ROUTE_TRANSFER_MARKER_SIZE = 16;
 
 export function StationMap({
   userLat,
@@ -96,6 +95,15 @@ export function StationMap({
     [userLat, userLng, nearestStation?.id, nearbyStations],
   );
 
+  // 경로상 환승역 id 집합. 베이스 마커에서 출발/도착과 동일하게 accent 강조한다.
+  const routeTransferIds = useMemo(() => {
+    const ids = new Set<string>();
+    routeCoords?.keyStations.forEach(({ station, role }) => {
+      if (role === 'transfer') ids.add(station.id);
+    });
+    return ids;
+  }, [routeCoords]);
+
   return (
     <View style={styles.map}>
       <ClusteredMapView
@@ -137,6 +145,7 @@ export function StationMap({
                     const isThisBadgeHighlighted =
                       s.id === customOriginId ||
                       s.id === destinationId ||
+                      routeTransferIds.has(s.id) ||
                       (group.isNearest && nearestStation?.id === s.id);
                     return (
                       <View
@@ -178,34 +187,6 @@ export function StationMap({
             testID="route-polyline"
           />
         )}
-        {/* 출발/도착역은 베이스 역 마커에서 customOriginId/destinationId로 강조 표시하므로
-            같은 좌표에 마커를 중복 렌더해서 클러스터링되지 않도록 환승역만 오버레이. */}
-        {routeCoords?.keyStations
-          .filter(({ role }) => role === 'transfer')
-          .map(({ station, role }) => (
-            <Marker
-              key={`route-${role}-${station.id}`}
-              coordinate={{ latitude: station.lat, longitude: station.lng }}
-              title={getStationDisplayName(station)}
-              tracksViewChanges={false}
-              anchor={{ x: 0.5, y: 0.5 }}
-              testID={`route-marker-${role}-${station.id}`}
-            >
-              <View
-                style={[
-                  styles.routeMarkerDot,
-                  {
-                    width: ROUTE_TRANSFER_MARKER_SIZE,
-                    height: ROUTE_TRANSFER_MARKER_SIZE,
-                    borderRadius: ROUTE_TRANSFER_MARKER_SIZE / 2,
-                    backgroundColor: station.lineColor,
-                    borderColor: colors.bg,
-                  },
-                ]}
-                testID={`route-marker-dot-${role}-${station.id}`}
-              />
-            </Marker>
-          ))}
       </ClusteredMapView>
       {!mapReady && (
         <View style={styles.loading} testID="map-loading">
@@ -266,9 +247,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#111111',
     textAlign: 'center',
-  },
-  routeMarkerDot: {
-    borderWidth: 3,
   },
 });
 

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -446,18 +446,22 @@ describe('StationMap', () => {
       ],
     };
 
-    it('routeCoords 미전달 시 polyline / 강조 마커가 없다', () => {
+    it('routeCoords 미전달 시 polyline / 점 오버레이가 없다', () => {
       const { queryByTestId } = render(<StationMap {...baseProps} />);
       expect(queryByTestId('route-polyline')).toBeNull();
-      expect(queryByTestId(`route-marker-origin-${mockStation.id}`)).toBeNull();
+      expect(queryByTestId(`route-marker-transfer-${transferStation.id}`)).toBeNull();
     });
 
-    it('routeCoords 전달 시 polyline + 환승 마커만 오버레이 (출발/도착은 베이스 마커 재사용)', () => {
+    it('routeCoords 전달 시 polyline만 오버레이하고 모든 키 역은 베이스 마커에서 재사용', () => {
       const { getByTestId, queryByTestId } = render(
-        <StationMap {...baseProps} routeCoords={routeCoords} />,
+        <StationMap
+          {...baseProps}
+          nearbyStations={[mockStation, transferStation, destStation]}
+          routeCoords={routeCoords}
+        />,
       );
       expect(getByTestId('route-polyline')).toBeTruthy();
-      expect(getByTestId(`route-marker-transfer-${transferStation.id}`)).toBeTruthy();
+      expect(queryByTestId(`route-marker-transfer-${transferStation.id}`)).toBeNull();
       expect(queryByTestId(`route-marker-origin-${mockStation.id}`)).toBeNull();
       expect(queryByTestId(`route-marker-destination-${destStation.id}`)).toBeNull();
     });
@@ -480,14 +484,50 @@ describe('StationMap', () => {
       expect(__fitToCoordinatesMock).not.toHaveBeenCalled();
     });
 
-    it('환승 마커는 노선 색을 사용', () => {
+    it('환승역 배지는 베이스 마커에서 accent 색으로 강조된다', () => {
       const { getByTestId } = render(
-        <StationMap {...baseProps} routeCoords={routeCoords} />,
+        <StationMap
+          {...baseProps}
+          nearbyStations={[mockStation, transferStation, destStation]}
+          routeCoords={routeCoords}
+        />,
       );
-      const transferDot = getByTestId(`route-marker-dot-transfer-${transferStation.id}`);
-      expect(transferDot.props.style).toEqual(
+      const transferBadge = getByTestId(`badge-${transferStation.id}`);
+      expect(transferBadge.props.style).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ backgroundColor: transferStation.lineColor }),
+          expect.objectContaining({ backgroundColor: '#C8553D' }),
+        ]),
+      );
+    });
+
+    it('환승역 그룹에서 route가 통과하는 호선의 배지만 accent로 강조', () => {
+      // (역, 호선) 단위 강조: 같은 물리역의 다른 호선은 노선 색 유지.
+      const transferOtherLine: Station = {
+        id: '2-329',
+        name: transferStation.name,
+        nameEn: transferStation.nameEn,
+        line: '2',
+        lineColor: '#00A84D',
+        lat: transferStation.lat,
+        lng: transferStation.lng,
+      };
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearbyStations={[mockStation, transferStation, transferOtherLine, destStation]}
+          routeCoords={routeCoords}
+        />,
+      );
+      const routedBadge = getByTestId(`badge-${transferStation.id}`);
+      const otherBadge = getByTestId(`badge-${transferOtherLine.id}`);
+      expect(routedBadge.props.style).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ backgroundColor: '#C8553D' }),
+        ]),
+      );
+      expect(otherBadge.props.style).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ backgroundColor: transferOtherLine.lineColor }),
         ]),
       );
     });


### PR DESCRIPTION
## Summary
- 경로 표시 시 환승역(예: 논현, 신사)이 좌표 한 곳에 두 개의 마커로 보이던 버그 수정
- 별도 점 오버레이 마커 제거, 베이스 마커의 accent 강조 조건에 환승역 id 추가

## 원인
- `StationMap.tsx`에서 환승역만 `routeMarkerDot` 오버레이로 별도 렌더 (anchor `(0.5, 0.5)`)
- 베이스 마커는 기본 anchor `(0.5, 1.0)` → 같은 좌표인데 anchor 차이로 시각적으로 어긋나 두 개로 보임
- 우회 원인: 베이스 마커의 `isThisBadgeHighlighted`가 origin/destination만 처리하고 transfer는 누락 → 별도 점으로 우회 강조한 상태

## 변경
- `routeTransferIds`(Set)를 도출하고 `isThisBadgeHighlighted`에 추가
- 기존 출발/도착과 동일한 `(역, 호선)` 단위 강조 패턴 재사용 → 환승 호선만 정확히 accent
- 환승역 그룹에서 route 통과 호선 vs 다른 호선 분기 케이스 테스트 추가

## Test plan
- [x] `npm test` — 1589 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 실기기: 목적지 설정 후 환승역 마커가 한 개만 보이는지, 환승 호선 배지가 accent인지 확인

Closes #491