### PR TITLE
fix(#497): Live Activity 시간/정거장 누락 + trip 재등록 폭주

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,7 +10,7 @@ import { formatArrivalTime } from '../../src/utils/formatTime';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
-import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
+import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
 import type { Station } from '../../src/types/station';
 import { EditorialTimeline } from '../../src/components/EditorialTimeline';
 import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/journeyAdapter';
@@ -64,8 +64,13 @@ export default function HomeScreen() {
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
   const [categorized, setCategorized] = useState<CategorizedRoute[]>([]);
   const [selectedKey, setSelectedKey] = useState<RoutePreference>(routePreference);
-  const route: Route =
-    categorized.find((r) => r.category.key === selectedKey)?.candidate.route ?? null;
+  // categorized/selectedKey가 동일하면 같은 reference를 유지해 하위 훅(LiveActivity,
+  // useApnsTripRegistration)의 useEffect가 매 렌더 재발사되는 churn을 막는다.
+  const route: Route = useMemo(
+    () => categorized.find((r) => r.category.key === selectedKey)?.candidate.route ?? null,
+    [categorized, selectedKey],
+  );
+  const routeSig = useMemo(() => routeSignature(route), [route]);
 
   // 트립 origin은 destination 설정 시점에 캡처되어 trip 동안 고정 (useTripOrigin 참조).
   // useFusedNearestStation 첫 호출 시점엔 routeContext=undefined로 GPS fusion fallback,
@@ -206,7 +211,14 @@ export default function HomeScreen() {
       }
       return;
     }
-    const key = `${effectiveOrigin.id}__${destination.id}__${displayEta ?? ''}__${arrivalIsMock}__${alarmEvent?.type ?? ''}`;
+    // route가 아직 계산되지 않은 짧은 윈도우(콜드 스타트, categorized async fill 중)에
+    // 정상 payload를 한 번 송출한 뒤라면 destination-only로 덮어쓰지 말고 이전 payload를
+    // 유지한다. 단 첫 송출 전(아직 LiveActivity 미시작)이면 차라리 destination-only라도
+    // 띄워야 사용자 가시성이 확보된다 — 경로 산출이 영구 실패하는 케이스 대비.
+    if (!route && prevNotifKeyRef.current !== undefined && prevNotifKeyRef.current !== 'none') {
+      return;
+    }
+    const key = `${effectiveOrigin.id}__${destination.id}__${routeSig}__${displayEta ?? ''}__${arrivalIsMock}__${alarmEvent?.type ?? ''}`;
     if (key === prevNotifKeyRef.current) return;
     prevNotifKeyRef.current = key;
 
@@ -230,7 +242,7 @@ export default function HomeScreen() {
       );
     };
     update().catch((e) => logger.error('알림 업데이트 실패:', e));
-  }, [effectiveOrigin?.id, destination?.id, displayEta, arrivalIsMock, route, alarmEvent]);
+  }, [effectiveOrigin?.id, destination?.id, displayEta, arrivalIsMock, routeSig, alarmEvent]);
 
   useEffect(() => {
     if (arrivedBanner) {

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -370,4 +370,30 @@ describe('useApnsTripRegistration', () => {
     expect(mockRegister.mock.calls[0][0].alarmAtEpochMs).toBe(fixed + 300 * 1000);
     (Date.now as jest.Mock).mockRestore();
   });
+
+  it('route 객체 reference만 바뀌고 내용이 같으면 register 재호출하지 않는다', async () => {
+    const { rerender } = renderHook(
+      ({ route }: { route: Route }) =>
+        useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+      { initialProps: { route: { type: 'direct', stops: 5, line: '2' } as Route } },
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    // 내용 동일, reference만 신규
+    rerender({ route: { type: 'direct', stops: 5, line: '2' } as Route });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+  });
+
+  it('route 내용이 바뀌면 register 재호출한다 (signature 변경)', async () => {
+    const { rerender } = renderHook(
+      ({ route }: { route: Route }) =>
+        useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+      { initialProps: { route: { type: 'direct', stops: 5, line: '2' } as Route } },
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    rerender({ route: { type: 'direct', stops: 6, line: '2' } as Route });
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+  });
 });

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -8,11 +8,12 @@
  * 권한 거부/토큰 실패 시 graceful skip — 사전 예약(#334)만으로 baseline 동작.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Station } from '../types/station';
 import type { Route } from '../utils/stationRoute';
+import { routeSignature } from '../utils/stationRoute';
 import { registerActiveTrip, clearActiveTrip } from '../api/alarmBackend';
 import { routeToWaypoints } from '../utils/routeWaypoints';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../constants/storageKeys';
@@ -68,6 +69,9 @@ export function useApnsTripRegistration({
   nextStationEtaSeconds,
   currentStation = null,
 }: UseApnsTripRegistrationInputs): void {
+  // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
+  // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
+  const routeSig = useMemo(() => routeSignature(route), [route]);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
   const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation });
   useEffect(() => {
@@ -169,8 +173,9 @@ export function useApnsTripRegistration({
     return () => {
       cancelled = true;
     };
+    // route는 routeSig(내용 기반)로 비교 — 동일 경로 재등록으로 백엔드 trip
+    // state(waypoints shift)가 reset되거나 워커 POST /trips가 분당 폭주하는 것을 방지.
+    // route 자체는 closure 안에서만 사용되므로 deps에 넣지 않는다.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    // TODO(#416 follow-up): currentStation 변경 시 register 매번 호출되어 백엔드 trip 진행 상태(waypoints shift)가 reset될 수 있다.
-    // 멱등성 처리는 클라/백엔드 어디서 보장할지 실기기 검증 결과 보고 결정한다.
-  }, [route, destination?.id, nextStationEtaSeconds, currentStation?.id]);
+  }, [routeSig, destination?.id, nextStationEtaSeconds, currentStation?.id]);
 }

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 
@@ -398,6 +398,52 @@ describe('calculateStaticETA', () => {
 
   it('route가 null이면 null을 반환한다', () => {
     expect(calculateStaticETA(null)).toBeNull();
+  });
+});
+
+describe('routeSignature', () => {
+  const SEP = '\x1f';
+
+  it('null이면 빈 문자열을 반환한다', () => {
+    expect(routeSignature(null)).toBe('');
+  });
+
+  it('DirectRoute의 내용이 같으면 같은 signature를 반환한다 (reference 무관)', () => {
+    const a: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const b: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    expect(routeSignature(a)).toBe(routeSignature(b));
+    expect(routeSignature(a)).toBe(['d', '2', 5].join(SEP));
+  });
+
+  it('DirectRoute의 stops가 다르면 다른 signature를 반환한다', () => {
+    const a: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const b: DirectRoute = { type: 'direct', stops: 6, line: '2' };
+    expect(routeSignature(a)).not.toBe(routeSignature(b));
+  });
+
+  it('TransferRoute는 transferName/노선/정거장수를 모두 반영한다', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    };
+    expect(routeSignature(route)).toBe(['t', '2', '3', '교대', 1, 5].join(SEP));
+  });
+
+  it('MultiTransferRoute는 모든 환승 segment + 마지막 정거장수를 반영한다', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    const segs = ['8', '2', '잠실', 3].join(SEP) + SEP + ['2', '1', '시청', 5].join(SEP);
+    expect(routeSignature(route)).toBe(['m', segs, 4].join(SEP));
   });
 });
 

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -605,6 +605,44 @@ export function calculateStaticETA(route: Route): number | null {
   return DEFAULT_WAIT_MINUTES + getTravelMinutes(route);
 }
 
+// ASCII Unit Separator(0x1F) — 사용자 데이터(역명/노선명)에 절대 등장하지 않는
+// 제어문자라 transferName 안에 구분자가 섞여도 signature 충돌이 구조적으로 불가능.
+const SIG_SEP = '\x1f';
+
+/**
+ * route의 내용 동일성을 비교하기 위한 stable signature.
+ * categorized recompute 등으로 route 객체 reference가 바뀌어도 내용이 같으면
+ * 동일 문자열을 반환 — useEffect deps/dedup key에 사용해 불필요한 재발사를 막는다.
+ */
+export function routeSignature(route: Route): string {
+  if (!route) return '';
+  switch (route.type) {
+    case 'direct':
+      return ['d', route.line, route.stops].join(SIG_SEP);
+    case 'transfer':
+      return [
+        't',
+        route.fromLine,
+        route.toLine,
+        route.transferName,
+        route.stopsToTransfer,
+        route.stopsFromTransfer,
+      ].join(SIG_SEP);
+    case 'multi-transfer': {
+      const segs = route.transfers
+        .map((s) => [s.fromLine, s.toLine, s.transferName, s.stopsToTransfer].join(SIG_SEP))
+        .join(SIG_SEP);
+      return ['m', segs, route.stopsAfterLastTransfer].join(SIG_SEP);
+    }
+    /* istanbul ignore next -- exhaustiveness guard: Route 유니온에 새 variant 추가 시
+       컴파일 타임 에러로 잡힘. 런타임 도달 불가. */
+    default: {
+      const _exhaustive: never = route;
+      return _exhaustive;
+    }
+  }
+}
+
 export function calculateETA(nextTrainMinutes: number, route: Route): number {
   if (!route) return nextTrainMinutes;
   return nextTrainMinutes + getTravelMinutes(route);


### PR DESCRIPTION
Closes #497

## 증상
- iOS Live Activity LockScreen에 **현재역 + \"→ 도착지\"** 두 줄만 표시
- 시간(`etaText`), 정거장 수(`routeSubtext`) 모두 누락
- 동반: 워커 `POST /trips` 분당 폭주 (10+ POST/min 관측)

## 원인
1. 콜드 스타트/categorized 비동기 채움 윈도우에 `route==null`로 `updateStationNotification` 호출 → `stationNotification.ts` destination-only 분기가 routeSubtext/etaText 미설정
2. `useApnsTripRegistration` deps에 route 객체 reference가 들어가, categorized recompute로 reference 바뀔 때마다 재등록 발사

## 변경
- `src/utils/stationRoute.ts`: `routeSignature(route)` 헬퍼 추가 — Unit Separator(0x1F) 사용으로 transferName 구분자 충돌 방지, switch + exhaustiveness guard
- `app/(tabs)/index.tsx`:
  - `route`/`routeSig`를 `useMemo`로 안정화
  - LiveActivity update useEffect: 이전 정상 payload가 있을 때만 route==null skip (첫 송출 전이면 destination-only라도 허용 — 경로 산출 영구 실패 대비)
  - dedup key에 routeSig 포함, deps에서 route → routeSig
- `src/hooks/useApnsTripRegistration.ts`: hook 내부에서 routeSig 메모화 후 deps로 사용 — #416 TODO 해소
- 테스트: routeSignature 5케이스 + useApnsTripRegistration reference flicker 2케이스

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 1595/1595 통과, 100% 커버리지 유지
- [ ] 실기기(dev) 트립 → LockScreen 시간·정거장 표시 확인
- [ ] 워커 로그 `POST /trips` 분당 1회 이하 확인

## 별개 트랙 (이번 PR 제외)
- 알람 5초 스팸 (#370~373)
- BadDeviceToken 재발 (#482 follow-up)