### PR TITLE
chore(#498): silent push 게이트 outcome 텔레메트리 인프라

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,7 @@ import { setupNotificationHandler, refreshNotificationChannels } from '../src/ut
 import { setMinLevel, createLogger } from '../src/utils/logger';
 import { i18n } from '../src/i18n';
 import { useApplyLocale } from '../src/hooks/useApplyLocale';
+import { useSilentPushTelemetry } from '../src/hooks/useSilentPushTelemetry';
 import { useAppStore } from '../src/store/useAppStore';
 import { DebugModal } from '../src/components/DebugModal';
 import { isDebugModalEnabled } from '../src/constants/debugFlags';

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1,5 +1,32 @@
-import { describe, expect, it } from 'vitest';
-import { validateTrip } from '../index';
+import { describe, expect, it, vi } from 'vitest';
+import { app, validateTrip } from '../index';
+import type { AnalyticsEngineWriter, Env } from '../types';
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    TRIPS: {} as Env['TRIPS'],
+    APNS_HOST: 'api.push.apple.com',
+    APNS_HOST_SANDBOX: 'api.sandbox.push.apple.com',
+    SEOUL_API_HOST: 'h',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: 'p',
+    APNS_BUNDLE_ID: 'b',
+    ...overrides,
+  };
+}
+
+async function post(path: string, body: unknown, env: Env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://example.com${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }),
+    env,
+  );
+}
 
 const FUTURE = Date.now() + 60 * 60 * 1000;
 
@@ -98,5 +125,47 @@ describe('validateTrip', () => {
     const b = base();
     delete b.route;
     expect(validateTrip(b)).toBeNull();
+  });
+});
+
+describe('POST /telemetry/silent-push', () => {
+  const validBody = {
+    token: 'aabbccdd11223344',
+    since: 0,
+    until: 1000,
+    received: 3,
+    fired: 2,
+    skipped: 1,
+    skipReasons: { 'gate-out-of-range': 1 },
+  };
+
+  it('returns 400 on invalid JSON', async () => {
+    const env = makeEnv();
+    const res = await post('/telemetry/silent-push', 'not-json{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const env = makeEnv();
+    const res = await post('/telemetry/silent-push', { token: '' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('writes to TELEMETRY binding when present', async () => {
+    const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
+    const env = makeEnv({ TELEMETRY: writer });
+    const res = await post('/telemetry/silent-push', validBody, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(writer.writeDataPoint).toHaveBeenCalled();
+  });
+
+  it('still returns ok when TELEMETRY binding absent (graceful)', async () => {
+    const env = makeEnv();
+    const res = await post('/telemetry/silent-push', validBody, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
   });
 });

--- a/backend/alarm-worker/src/__tests__/telemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/telemetry.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  tokenPrefix,
+  validateTelemetryUpload,
+  writeTelemetryDataPoints,
+  type TelemetryUpload,
+} from '../telemetry';
+
+function base(): Record<string, unknown> {
+  return {
+    token: 'aabbccdd11223344',
+    since: 1_000,
+    until: 2_000,
+    received: 5,
+    fired: 3,
+    skipped: 2,
+    skipReasons: {
+      'gate-out-of-range': 1,
+      'payload-missing-kind': 1,
+    },
+  };
+}
+
+describe('validateTelemetryUpload', () => {
+  it('accepts a valid payload', () => {
+    const result = validateTelemetryUpload(base());
+    expect(result).not.toBeNull();
+    expect(result?.received).toBe(5);
+    expect(result?.skipReasons['gate-out-of-range']).toBe(1);
+  });
+
+  it('rejects non-object', () => {
+    expect(validateTelemetryUpload(null)).toBeNull();
+    expect(validateTelemetryUpload('x')).toBeNull();
+  });
+
+  it('rejects missing/empty token', () => {
+    expect(validateTelemetryUpload({ ...base(), token: '' })).toBeNull();
+    const noToken = base();
+    delete noToken.token;
+    expect(validateTelemetryUpload(noToken)).toBeNull();
+  });
+
+  it('rejects non-integer / negative counters', () => {
+    expect(validateTelemetryUpload({ ...base(), received: -1 })).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), received: 1.5 })).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), received: NaN })).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), received: 'x' })).toBeNull();
+  });
+
+  it('rejects when each counter field invalid', () => {
+    expect(validateTelemetryUpload({ ...base(), since: -1 })).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), until: -1 })).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), fired: -1 })).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), skipped: -1 })).toBeNull();
+  });
+
+  it('rejects when until < since', () => {
+    expect(validateTelemetryUpload({ ...base(), since: 2000, until: 1000 })).toBeNull();
+  });
+
+  it('rejects when skipReasons is missing or wrong type', () => {
+    const missing = base();
+    delete missing.skipReasons;
+    expect(validateTelemetryUpload(missing)).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), skipReasons: 'x' })).toBeNull();
+    expect(validateTelemetryUpload({ ...base(), skipReasons: null })).toBeNull();
+  });
+
+  it('rejects invalid skipReasons value', () => {
+    expect(
+      validateTelemetryUpload({ ...base(), skipReasons: { 'gate-out-of-range': -1 } }),
+    ).toBeNull();
+    expect(
+      validateTelemetryUpload({ ...base(), skipReasons: { 'gate-out-of-range': 1.5 } }),
+    ).toBeNull();
+  });
+
+  it('drops unknown skipReason keys', () => {
+    const result = validateTelemetryUpload({
+      ...base(),
+      skipReasons: { 'gate-out-of-range': 1, 'unknown-reason': 99 },
+    });
+    expect(result?.skipReasons['gate-out-of-range']).toBe(1);
+    expect(result?.skipReasons['unknown-reason']).toBeUndefined();
+  });
+
+  it('preserves missing known reasons as absent (not zero)', () => {
+    const result = validateTelemetryUpload({ ...base(), skipReasons: {} });
+    expect(result?.skipReasons).toEqual({});
+  });
+});
+
+describe('tokenPrefix', () => {
+  it('returns first 8 chars', () => {
+    expect(tokenPrefix('aabbccdd11223344')).toBe('aabbccdd');
+  });
+
+  it('returns whole string when shorter than 8', () => {
+    expect(tokenPrefix('abc')).toBe('abc');
+  });
+});
+
+describe('writeTelemetryDataPoints', () => {
+  function makeWriter() {
+    return { writeDataPoint: vi.fn() };
+  }
+
+  const payload: TelemetryUpload = {
+    token: 'aabbccdd11223344',
+    since: 0,
+    until: 1,
+    received: 5,
+    fired: 3,
+    skipped: 2,
+    skipReasons: {
+      'gate-out-of-range': 1,
+      'payload-missing-kind': 1,
+    },
+  };
+
+  it('writes one data point per non-zero counter', () => {
+    const writer = makeWriter();
+    writeTelemetryDataPoints(writer, payload);
+    // received + fired + skipped + 2 reasons = 5
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(5);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain('received');
+    expect(labels).toContain('fired');
+    expect(labels).toContain('skipped');
+    expect(labels).toContain('skipped:gate-out-of-range');
+    expect(labels).toContain('skipped:payload-missing-kind');
+  });
+
+  it('skips zero counters', () => {
+    const writer = makeWriter();
+    writeTelemetryDataPoints(writer, {
+      ...payload,
+      received: 0,
+      fired: 0,
+      skipped: 0,
+      skipReasons: {},
+    });
+    expect(writer.writeDataPoint).not.toHaveBeenCalled();
+  });
+
+  it('includes token prefix in blobs and indexes', () => {
+    const writer = makeWriter();
+    writeTelemetryDataPoints(writer, payload);
+    const first = writer.writeDataPoint.mock.calls[0][0];
+    expect(first.blobs[1]).toBe('aabbccdd');
+    expect(first.indexes[0]).toBe('aabbccdd');
+    expect(first.doubles[0]).toBeGreaterThan(0);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -13,10 +13,15 @@
 import { Hono } from 'hono';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
+import {
+  tokenPrefix,
+  validateTelemetryUpload,
+  writeTelemetryDataPoints,
+} from './telemetry';
 import { deleteTrip, getTrip, putTrip } from './trips';
 import type { Env, Trip } from './types';
 
-const app = new Hono<{ Bindings: Env }>();
+export const app = new Hono<{ Bindings: Env }>();
 
 app.get('/health', (c) => c.json({ ok: true }));
 
@@ -33,6 +38,39 @@ app.post('/trips', async (c) => {
 
   await putTrip(c.env.TRIPS, trip);
   return c.json({ ok: true, token: trip.token });
+});
+
+/**
+ * silent push 게이트 outcome 텔레메트리 (#498).
+ * 클라가 30분 주기로 alarmLog 카운트를 누적 upload한다.
+ * Trip 존재 여부는 확인하지 않는다 — 만료된 trip의 텔레메트리도 보존(데이터 완전성).
+ */
+app.post('/telemetry/silent-push', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateTelemetryUpload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const writer = c.env.TELEMETRY;
+  if (writer) {
+    writeTelemetryDataPoints(writer, payload);
+  }
+  console.log(
+    JSON.stringify({
+      msg: 'telemetry uploaded',
+      tokenPrefix: tokenPrefix(payload.token),
+      received: payload.received,
+      fired: payload.fired,
+      skipped: payload.skipped,
+      sink: writer ? 'ae' : 'none',
+    }),
+  );
+  return c.json({ ok: true });
 });
 
 app.delete('/trips/:token', async (c) => {

--- a/backend/alarm-worker/src/telemetry.ts
+++ b/backend/alarm-worker/src/telemetry.ts
@@ -1,0 +1,121 @@
+/**
+ * silent push 게이트 outcome 텔레메트리 적재 (#498).
+ *
+ * 클라(`src/utils/telemetryAggregation.ts`)가 alarmLog의 silent-push-* 엔트리를
+ * 30분 주기로 집계해 POST한 카운터를 Cloudflare Analytics Engine에 적재한다.
+ *
+ * Privacy: 개별 push 내용/시각/위치 좌표는 포함하지 않는다. 카운트만.
+ * token은 8자 prefix만 blob에 남겨 anonymous aggregate에 사용. 전체 token은 저장하지 않는다.
+ */
+
+import type { AnalyticsEngineWriter } from './types';
+
+/**
+ * 클라이언트가 보내는 telemetry upload payload.
+ * 카운터는 모두 0 이상 정수.
+ */
+export interface TelemetryUpload {
+  /** APNs device token (hex). prefix(8자)만 anonymous aggregate에 사용. */
+  token: string;
+  /** 이전 flush 시각(epoch ms). 첫 flush는 0. */
+  since: number;
+  /** 현재 flush 시각(epoch ms). */
+  until: number;
+  /** silent-push-received 카운트 (분모). */
+  received: number;
+  /** silent-push-fired 카운트 (게이트 통과 → 발사). */
+  fired: number;
+  /** silent-push-skipped 카운트 (게이트 차단). */
+  skipped: number;
+  /** skipped의 reason별 카운트. 알려진 키만 집계, 나머지는 무시. */
+  skipReasons: Record<string, number>;
+}
+
+const KNOWN_SKIP_REASONS = [
+  'gate-unknown-station',
+  'gate-no-location',
+  'gate-stale-location',
+  'gate-out-of-range',
+  'payload-missing-kind',
+] as const;
+
+export type KnownSkipReason = (typeof KNOWN_SKIP_REASONS)[number];
+
+function isFiniteNonNegativeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && Number.isInteger(value);
+}
+
+/**
+ * payload 검증. 형태가 깨졌으면 null, 정상이면 정규화된 객체.
+ * - 음수/NaN/소수 reject (카운터는 자연수)
+ * - skipReasons는 객체만 허용, 알려진 키만 보존
+ */
+export function validateTelemetryUpload(input: unknown): TelemetryUpload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (!isFiniteNonNegativeInt(obj.since)) return null;
+  if (!isFiniteNonNegativeInt(obj.until)) return null;
+  if (obj.until < obj.since) return null;
+  if (!isFiniteNonNegativeInt(obj.received)) return null;
+  if (!isFiniteNonNegativeInt(obj.fired)) return null;
+  if (!isFiniteNonNegativeInt(obj.skipped)) return null;
+  if (!obj.skipReasons || typeof obj.skipReasons !== 'object') return null;
+
+  const rawReasons = obj.skipReasons as Record<string, unknown>;
+  const skipReasons: Record<string, number> = {};
+  for (const key of KNOWN_SKIP_REASONS) {
+    const v = rawReasons[key];
+    if (v === undefined) continue;
+    if (!isFiniteNonNegativeInt(v)) return null;
+    skipReasons[key] = v;
+  }
+
+  return {
+    token: obj.token,
+    since: obj.since,
+    until: obj.until,
+    received: obj.received,
+    fired: obj.fired,
+    skipped: obj.skipped,
+    skipReasons,
+  };
+}
+
+/** anonymous aggregate용 token prefix. 전체 토큰은 절대 로그/AE에 적재하지 않는다. */
+export function tokenPrefix(token: string): string {
+  return token.slice(0, 8);
+}
+
+/**
+ * Analytics Engine에 카운터별 data point를 적재한다.
+ * 0인 카운터는 skip — query 노이즈 감소.
+ *
+ * Schema:
+ *   blob1 = source label (예: 'received', 'fired', 'skipped:gate-out-of-range')
+ *   blob2 = token prefix (8자)
+ *   double1 = count
+ *   index1 = token prefix (sampling용)
+ */
+export function writeTelemetryDataPoints(
+  writer: AnalyticsEngineWriter,
+  payload: TelemetryUpload,
+): void {
+  const prefix = tokenPrefix(payload.token);
+  const write = (label: string, count: number): void => {
+    if (count <= 0) return;
+    writer.writeDataPoint({
+      blobs: [label, prefix],
+      doubles: [count],
+      indexes: [prefix],
+    });
+  };
+
+  write('received', payload.received);
+  write('fired', payload.fired);
+  write('skipped', payload.skipped);
+  for (const reason of KNOWN_SKIP_REASONS) {
+    const count = payload.skipReasons[reason] ?? 0;
+    write(`skipped:${reason}`, count);
+  }
+}

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -76,8 +76,26 @@ export interface Trip {
 /** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */
 export type ApnsEnv = 'sandbox' | 'production';
 
+/**
+ * Cloudflare Analytics Engine writer. Minimal surface — Worker types에 의존하지 않게 별도 선언.
+ * 실제 binding은 wrangler.toml의 `[[analytics_engine_datasets]]`로 주입.
+ */
+export interface AnalyticsEngineWriter {
+  writeDataPoint(point: {
+    blobs?: string[];
+    doubles?: number[];
+    indexes?: string[];
+  }): void;
+}
+
 export interface Env {
   TRIPS: KVNamespace;
+  /**
+   * silent push 게이트 outcome 텔레메트리 (#498).
+   * 클라가 30분 주기로 upload하는 카운터를 Analytics Engine에 적재.
+   * 미바인딩 시 endpoint는 graceful no-op (개발 환경 호환).
+   */
+  TELEMETRY?: AnalyticsEngineWriter;
   /** Production APNs host (예: api.push.apple.com) */
   APNS_HOST: string;
   /** Sandbox APNs host (예: api.sandbox.push.apple.com) — dev/preview 빌드 토큰용 */

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -10,6 +10,12 @@ binding = "TRIPS"
 id = "8d10a57ffe4c46e28a6df33ef0c86b68"
 preview_id = "7e67683c147349ed90c16a28ae232e34"
 
+# #498 — silent push 게이트 outcome 텔레메트리. 클라가 누적한 카운터를 일별 query 가능하게 적재.
+# Privacy: 카운트만, token은 8자 prefix만. 개별 push 내용/좌표 미저장.
+[[analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "silent_push_telemetry"
+
 # 1분마다 활성 트립 폴링
 [triggers]
 crons = ["*/1 * * * *"]

--- a/docs/decisions/ADR-006-silent-push-telemetry.md
+++ b/docs/decisions/ADR-006-silent-push-telemetry.md
@@ -1,0 +1,40 @@
+# ADR-006: silent push 게이트 outcome 텔레메트리 + privacy 정책
+
+- 상태: Accepted
+- 일자: 2026-05-22
+- 관련 이슈: #498 (인프라), #499 (의사결정), #495 (임계값 튜닝), #496 (백엔드 progress)
+
+## 컨텍스트
+
+#478 PR1-2(PR #489)에서 silent push 수신 시 클라가 위치 게이트로 발사를 차단할 수 있게 됐다. 게이트 결과는 `src/utils/alarmLog.ts` ring buffer(200 entries)에 남지만 디바이스 로컬에 머물러 운영자가 집계할 수 없다.
+
+#495(임계값 튜닝)와 #496(백엔드 progress 활성화 여부) 결정에 다음 두 지표가 필요하다.
+
+- 정지 사용자 비율 = `silent-push-skipped` / `silent-push-received`
+- 백엔드 발사 → 클라 차단 비율 = sum(skipped) / 백엔드 `ScheduledStats.pushed`
+
+## 결정
+
+클라가 30분 주기로 alarmLog의 `silent-push-*` 카운트를 누적해 `POST /telemetry/silent-push`로 백엔드에 올린다. 백엔드는 Cloudflare Analytics Engine(`silent_push_telemetry` dataset)에 카운터별 data point로 적재해 SQL로 일별 집계할 수 있게 한다.
+
+- 트리거: 마운트 / 30분 주기 / AppState 'active' 진입
+- 실패 시: graceful skip + `TELEMETRY_LAST_FLUSH_KEY` 미갱신 → 다음 flush 재시도
+- 동작 변경 없음: 임계값/게이트 정책은 #495에서 데이터 본 뒤 결정
+
+## Privacy 정책
+
+본 텔레메트리는 다음 원칙을 따른다.
+
+1. **카운트만 전송한다.** 개별 push 내용·시각·위치 좌표·역 이름은 payload에 포함하지 않는다. 모든 필드는 자연수 카운터.
+2. **APNs token은 8자 prefix만 백엔드에 영구 저장한다.** 전체 token은 적재되지 않으며 anonymous aggregate (sampling key) 용도로만 사용된다. 로그에도 동일 prefix만 남긴다.
+3. **사용자가 push 권한을 거부하면 token이 없어 flush가 skip되고 데이터는 0건 수집된다.** opt-out 경로가 자연스럽게 보장된다.
+4. **Trip 존재 여부는 검증하지 않는다.** 만료된 trip 사용자의 텔레메트리도 보존해 데이터 완전성을 우선한다. 이는 위 1~2번 원칙 하에서 추가 PII를 노출하지 않는다.
+
+## Limitations (알려진 손실)
+
+- **Ring buffer 압박 시 silent loss**: 클라 alarmLog는 200 entries FIFO ring buffer. 한 flush 주기(30분) 동안 silent push가 200건을 초과하는 비정상 트래픽에선 오래된 entry가 trim되어 카운터가 누락된다. 정상 운영(주기당 수 건~수십 건)에선 발생하지 않는다.
+- **R-M-W 비원자성**: flush는 `since` 읽기 → upload → `since` 쓰기. 동시 호출은 모듈 스코프 in-flight guard로 직렬화한다.
+
+## 후속
+
+#498 머지 후 1-2주 운영 데이터를 모으는 #499에서 분포 표를 산출해 #495·#496의 결정을 확정한다.

--- a/src/api/__tests__/telemetryBackend.test.ts
+++ b/src/api/__tests__/telemetryBackend.test.ts
@@ -1,0 +1,90 @@
+import { uploadSilentPushTelemetry } from '../telemetryBackend';
+import type { SilentPushTelemetryPayload } from '../../utils/telemetryAggregation';
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = global.fetch;
+
+const PAYLOAD: SilentPushTelemetryPayload = {
+  since: 0,
+  until: 1_000,
+  received: 3,
+  fired: 2,
+  skipped: 1,
+  skipReasons: { 'gate-out-of-range': 1 },
+};
+
+describe('uploadSilentPushTelemetry', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  it('URL 미설정이면 skipped=true', async () => {
+    const result = await uploadSilentPushTelemetry('token', PAYLOAD);
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('빈 token도 skipped=true', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    const result = await uploadSilentPushTelemetry('', PAYLOAD);
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('정상 응답 시 ok=true, body 직렬화 확인', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    const result = await uploadSilentPushTelemetry('tok', PAYLOAD);
+    expect(result).toEqual({ ok: true, status: 200 });
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test/telemetry/silent-push');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.token).toBe('tok');
+    expect(body.received).toBe(3);
+    expect(body.skipReasons).toEqual({ 'gate-out-of-range': 1 });
+  });
+
+  it('!res.ok 응답 시 ok=false + status', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+    const result = await uploadSilentPushTelemetry('tok', PAYLOAD);
+    expect(result).toEqual({ ok: false, status: 500 });
+  });
+
+  it('fetch throw 시 ok=false', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    const result = await uploadSilentPushTelemetry('tok', PAYLOAD);
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('타임아웃 발동 시 abort → ok=false', async () => {
+    jest.useFakeTimers();
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    );
+    const promise = uploadSilentPushTelemetry('tok', PAYLOAD);
+    await jest.advanceTimersByTimeAsync(6000);
+    const result = await promise;
+    expect(result).toEqual({ ok: false });
+    jest.useRealTimers();
+  });
+});

--- a/src/api/telemetryBackend.ts
+++ b/src/api/telemetryBackend.ts
@@ -1,0 +1,77 @@
+/**
+ * alarm-worker /telemetry/silent-push 클라이언트 (#498).
+ *
+ * 클라가 30분 주기로 alarmLog 카운터를 누적 upload — 실패 시 graceful skip.
+ * 동작 변경 없음 — 순수 측정 인프라.
+ */
+
+import type { SilentPushTelemetryPayload } from '../utils/telemetryAggregation';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('telemetryBackend');
+
+export interface TelemetryUploadResult {
+  ok: boolean;
+  /** URL 미설정 등으로 호출이 건너뛰어진 경우 true. */
+  skipped?: boolean;
+  status?: number;
+}
+
+/** fetch 타임아웃 — 텔레메트리는 후속 알람 흐름에 영향 주지 않게 짧게 끊는다. */
+const REQUEST_TIMEOUT_MS = 5000;
+
+function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function uploadSilentPushTelemetry(
+  token: string,
+  payload: SilentPushTelemetryPayload,
+): Promise<TelemetryUploadResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip telemetry upload');
+    return { ok: false, skipped: true };
+  }
+  if (!token) {
+    return { ok: false, skipped: true };
+  }
+
+  const body = {
+    token,
+    since: payload.since,
+    until: payload.until,
+    received: payload.received,
+    fired: payload.fired,
+    skipped: payload.skipped,
+    skipReasons: payload.skipReasons,
+  };
+
+  try {
+    const res = await fetchWithTimeout(`${base}/telemetry/silent-push`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      log.warn(`telemetry upload failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('telemetry upload error', e);
+    return { ok: false };
+  }
+}

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -21,3 +21,6 @@ export const ALARM_LOG_KEY = 'subway-now:alarm-log';
 export const APNS_TOKEN_KEY = 'subway-now:apns-token';
 export const ACTIVE_TRIP_KEY = 'subway-now:active-trip';
 export const TRIP_TRAIN_CODE_KEY = 'subway-now:trip-train-code';
+// #498 — silent push 게이트 outcome 텔레메트리. 마지막 flush 시각(epoch ms).
+// 다음 flush는 이 시점 이후의 alarmLog 엔트리만 집계 → 중복 방지.
+export const TELEMETRY_LAST_FLUSH_KEY = 'subway-now:telemetry-last-flush';

--- a/src/hooks/__tests__/useSilentPushTelemetry.test.ts
+++ b/src/hooks/__tests__/useSilentPushTelemetry.test.ts
@@ -1,0 +1,242 @@
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const mockUpload = jest.fn();
+jest.mock('../../api/telemetryBackend', () => ({
+  uploadSilentPushTelemetry: (...args: unknown[]) => mockUpload(...args),
+}));
+
+const mockGetAlarmLog = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  getAlarmLog: (...args: unknown[]) => mockGetAlarmLog(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const appStateListeners: Array<(state: string) => void> = [];
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: (_type: string, cb: (state: string) => void) => {
+      appStateListeners.push(cb);
+      return { remove: jest.fn() };
+    },
+  },
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  useSilentPushTelemetry,
+  flushSilentPushTelemetry,
+  TELEMETRY_FLUSH_INTERVAL_MS,
+} from '../useSilentPushTelemetry';
+import { APNS_TOKEN_KEY, TELEMETRY_LAST_FLUSH_KEY } from '../../constants/storageKeys';
+import type { AlarmLogEntry } from '../../utils/alarmLog';
+
+function silentPushReceivedEntry(ts: number): AlarmLogEntry {
+  return { ts, source: 'silent-push-received', outcome: 'received' };
+}
+
+describe('flushSilentPushTelemetry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListeners.length = 0;
+  });
+
+  it('APNs 토큰 없으면 skip', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    await flushSilentPushTelemetry(1000);
+    expect(mockGetAlarmLog).not.toHaveBeenCalled();
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('카운터가 모두 0이면 upload 안 하고 since만 갱신', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      if (key === TELEMETRY_LAST_FLUSH_KEY) return '500';
+      return null;
+    });
+    mockGetAlarmLog.mockResolvedValue([]);
+    await flushSilentPushTelemetry(1000);
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(TELEMETRY_LAST_FLUSH_KEY, '1000');
+  });
+
+  it('upload 성공 시 since 갱신', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      if (key === TELEMETRY_LAST_FLUSH_KEY) return '500';
+      return null;
+    });
+    mockGetAlarmLog.mockResolvedValue([silentPushReceivedEntry(600)]);
+    mockUpload.mockResolvedValue({ ok: true });
+    await flushSilentPushTelemetry(1000);
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(mockUpload.mock.calls[0][0]).toBe('token-abc');
+    const payload = mockUpload.mock.calls[0][1];
+    expect(payload.since).toBe(500);
+    expect(payload.until).toBe(1000);
+    expect(payload.received).toBe(1);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(TELEMETRY_LAST_FLUSH_KEY, '1000');
+  });
+
+  it('upload 실패 시 since 유지', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      if (key === TELEMETRY_LAST_FLUSH_KEY) return '500';
+      return null;
+    });
+    mockGetAlarmLog.mockResolvedValue([silentPushReceivedEntry(600)]);
+    mockUpload.mockResolvedValue({ ok: false });
+    await flushSilentPushTelemetry(1000);
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(TELEMETRY_LAST_FLUSH_KEY, '1000');
+  });
+
+  it('since 저장값이 손상되면 0으로 fallback', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      if (key === TELEMETRY_LAST_FLUSH_KEY) return 'not-a-number';
+      return null;
+    });
+    mockGetAlarmLog.mockResolvedValue([silentPushReceivedEntry(100)]);
+    mockUpload.mockResolvedValue({ ok: true });
+    await flushSilentPushTelemetry(1000);
+    expect(mockUpload).toHaveBeenCalled();
+    const payload = mockUpload.mock.calls[0][1];
+    expect(payload.since).toBe(0);
+  });
+
+  it('since 저장값이 음수면 0으로 fallback', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      if (key === TELEMETRY_LAST_FLUSH_KEY) return '-100';
+      return null;
+    });
+    mockGetAlarmLog.mockResolvedValue([silentPushReceivedEntry(100)]);
+    mockUpload.mockResolvedValue({ ok: true });
+    await flushSilentPushTelemetry(1000);
+    expect(mockUpload.mock.calls[0][1].since).toBe(0);
+  });
+
+  it('since 저장값 없으면 0', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      return null;
+    });
+    mockGetAlarmLog.mockResolvedValue([silentPushReceivedEntry(100)]);
+    mockUpload.mockResolvedValue({ ok: true });
+    await flushSilentPushTelemetry(1000);
+    expect(mockUpload.mock.calls[0][1].since).toBe(0);
+  });
+
+  it('default now (Date.now) 사용', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    // token 없음 → skip path지만 default 인자 경로는 실행됨
+    await expect(flushSilentPushTelemetry()).resolves.toBeUndefined();
+  });
+
+  it('in-flight guard: 동시 호출은 동일 promise로 직렬화', async () => {
+    // getItem이 resolve되기 전 2번 호출 → 두 번째는 첫 번째와 같은 promise를 받아야 한다.
+    let resolveToken!: (v: string | null) => void;
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(
+      (key: string) =>
+        new Promise<string | null>((resolve) => {
+          if (key === APNS_TOKEN_KEY) {
+            resolveToken = resolve;
+          } else {
+            resolve(null);
+          }
+        }),
+    );
+    const p1 = flushSilentPushTelemetry(1000);
+    const p2 = flushSilentPushTelemetry(2000);
+    expect(p1).toBe(p2);
+    resolveToken(null);
+    await p1;
+    // 첫 번째 완료 후엔 새 promise가 생성되어야 함
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const p3 = flushSilentPushTelemetry(3000);
+    expect(p3).not.toBe(p1);
+    await p3;
+  });
+});
+
+describe('useSilentPushTelemetry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListeners.length = 0;
+    jest.useFakeTimers();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockUpload.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('마운트 시 1회 flush 실행', async () => {
+    renderHook(() => useSilentPushTelemetry());
+    // initial useEffect runs flush — token 없음 path만 검증
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(APNS_TOKEN_KEY);
+    });
+  });
+
+  it('30분 경과 시 추가 flush', async () => {
+    renderHook(() => useSilentPushTelemetry());
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    const initialCalls = (AsyncStorage.getItem as jest.Mock).mock.calls.length;
+    act(() => {
+      jest.advanceTimersByTime(TELEMETRY_FLUSH_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect((AsyncStorage.getItem as jest.Mock).mock.calls.length).toBeGreaterThan(initialCalls);
+    });
+  });
+
+  it('AppState active 진입 시 flush', async () => {
+    renderHook(() => useSilentPushTelemetry());
+    await waitFor(() => expect(appStateListeners.length).toBeGreaterThan(0));
+    const beforeCount = (AsyncStorage.getItem as jest.Mock).mock.calls.length;
+    act(() => {
+      appStateListeners[0]('active');
+    });
+    await waitFor(() => {
+      expect((AsyncStorage.getItem as jest.Mock).mock.calls.length).toBeGreaterThan(beforeCount);
+    });
+  });
+
+  it('AppState background 전환은 flush 안 함', async () => {
+    renderHook(() => useSilentPushTelemetry());
+    await waitFor(() => expect(appStateListeners.length).toBeGreaterThan(0));
+    const beforeCount = (AsyncStorage.getItem as jest.Mock).mock.calls.length;
+    act(() => {
+      appStateListeners[0]('background');
+    });
+    // 동기 micro-tick 후에도 호출 수 동일
+    await Promise.resolve();
+    expect((AsyncStorage.getItem as jest.Mock).mock.calls.length).toBe(beforeCount);
+  });
+
+  it('flush throw해도 unhandled 안 됨', async () => {
+    mockGetAlarmLog.mockRejectedValue(new Error('boom'));
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === APNS_TOKEN_KEY) return 'token-abc';
+      return null;
+    });
+    expect(() => renderHook(() => useSilentPushTelemetry())).not.toThrow();
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+  });
+});

--- a/src/hooks/useSilentPushTelemetry.ts
+++ b/src/hooks/useSilentPushTelemetry.ts
@@ -1,0 +1,89 @@
+/**
+ * silent push 게이트 outcome 텔레메트리 flush 훅 (#498).
+ *
+ * 알람 로그(silent-push-*)를 30분 주기 + 마운트 + AppState 'active' 진입 시
+ * 백엔드 /telemetry/silent-push로 누적 upload한다.
+ *
+ * 동작 변경 없음 — 순수 측정 인프라.
+ * APNs token이 없으면(권한 거부) silently skip → 데이터 0건.
+ * Upload 실패 시 since(`TELEMETRY_LAST_FLUSH_KEY`)는 유지 → 다음 flush에서 재시도.
+ *   재집계 시 알람 로그에 새 entries는 무한 누적되지 않고 ring buffer(200)로 trim되므로
+ *   중복 위험은 한정적이다. 정확도보다 운영 단순성을 우선.
+ */
+
+import { useCallback, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { APNS_TOKEN_KEY, TELEMETRY_LAST_FLUSH_KEY } from '../constants/storageKeys';
+import { getAlarmLog } from '../utils/alarmLog';
+import {
+  aggregateSilentPushEntries,
+  isEmptyTelemetry,
+} from '../utils/telemetryAggregation';
+import { uploadSilentPushTelemetry } from '../api/telemetryBackend';
+import { usePolling } from './usePolling';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('useSilentPushTelemetry');
+
+export const TELEMETRY_FLUSH_INTERVAL_MS = 30 * 60 * 1000;
+
+// 모듈 스코프 in-flight guard.
+// flush는 since 읽기 → upload → since 쓰기로 비원자 R-M-W이다. mount/interval/AppState
+// 'active' 트리거가 가까이 겹치면 동일 since를 두 호출이 읽어 같은 윈도우를 중복 upload할
+// 위험이 있다 — 측정 인프라에서 중복 카운트는 데이터 해석을 왜곡한다.
+// 진행 중이면 같은 promise를 재사용해 결과적으로 한 사이클 내 flush가 1회만 일어나게 한다.
+let inFlight: Promise<void> | null = null;
+
+/**
+ * Visible-for-testing flush 1회 실행.
+ * 호출자가 직접 부르지 않아도 훅이 mount/interval/resume 시점에 호출한다.
+ * 동시 호출은 in-flight guard로 직렬화된다.
+ */
+export function flushSilentPushTelemetry(now: number = Date.now()): Promise<void> {
+  if (inFlight) return inFlight;
+  inFlight = doFlush(now).finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+async function doFlush(now: number): Promise<void> {
+  const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+  if (!token) {
+    log.info('no APNs token — skip telemetry flush');
+    return;
+  }
+
+  const sinceRaw = await AsyncStorage.getItem(TELEMETRY_LAST_FLUSH_KEY);
+  const since = sinceRaw ? Number(sinceRaw) : 0;
+  const safeSince = Number.isFinite(since) && since >= 0 ? since : 0;
+
+  const entries = await getAlarmLog();
+  const payload = aggregateSilentPushEntries(entries, safeSince, now);
+  if (isEmptyTelemetry(payload)) {
+    // 보낼 카운트가 없으면 since 갱신만 — 다음 flush 부담 감소.
+    await AsyncStorage.setItem(TELEMETRY_LAST_FLUSH_KEY, String(now));
+    return;
+  }
+
+  const result = await uploadSilentPushTelemetry(token, payload);
+  if (result.ok) {
+    await AsyncStorage.setItem(TELEMETRY_LAST_FLUSH_KEY, String(now));
+  }
+  // 실패 시 since 유지 — 다음 flush에서 재시도.
+}
+
+export function useSilentPushTelemetry(): void {
+  const flush = useCallback(() => {
+    void flushSilentPushTelemetry().catch((e) => log.warn('flush error', e));
+  }, []);
+
+  useEffect(() => {
+    flush();
+  }, [flush]);
+
+  // onResume은 의도적으로 생략. usePolling은 AppState 'active' 전환 시 callback을
+  // 자동 호출하므로, onResume까지 같은 flush로 두면 한 번의 resume에 2회 동시 호출되어
+  // in-flight guard가 두 번째를 첫 번째 promise로 재사용하긴 하지만 호출 자체가 낭비.
+  usePolling(flush, TELEMETRY_FLUSH_INTERVAL_MS);
+}

--- a/src/utils/__tests__/telemetryAggregation.test.ts
+++ b/src/utils/__tests__/telemetryAggregation.test.ts
@@ -1,0 +1,113 @@
+import {
+  aggregateSilentPushEntries,
+  isEmptyTelemetry,
+} from '../telemetryAggregation';
+import type { AlarmLogEntry } from '../alarmLog';
+
+function entry(partial: Partial<AlarmLogEntry> & Pick<AlarmLogEntry, 'ts' | 'source' | 'outcome'>): AlarmLogEntry {
+  return { ...partial };
+}
+
+describe('aggregateSilentPushEntries', () => {
+  const entries: AlarmLogEntry[] = [
+    entry({ ts: 50, source: 'silent-push-received', outcome: 'received' }),
+    entry({ ts: 100, source: 'silent-push-received', outcome: 'received' }),
+    entry({ ts: 150, source: 'silent-push-fired', outcome: 'fired' }),
+    entry({
+      ts: 200,
+      source: 'silent-push-skipped',
+      outcome: 'suppressed',
+      reason: 'gate-out-of-range',
+    }),
+    entry({
+      ts: 210,
+      source: 'silent-push-skipped',
+      outcome: 'suppressed',
+      reason: 'gate-out-of-range',
+    }),
+    entry({
+      ts: 220,
+      source: 'silent-push-skipped',
+      outcome: 'suppressed',
+      reason: 'payload-missing-kind',
+    }),
+    entry({ ts: 230, source: 'silent-push-skipped', outcome: 'suppressed' }),
+    // non silent-push 항목은 무시
+    entry({ ts: 240, source: 'fg', outcome: 'fired' }),
+    entry({ ts: 250, source: 'bg', outcome: 'suppressed', reason: 'gate-age' }),
+  ];
+
+  it('counts entries by source and skip reason', () => {
+    const payload = aggregateSilentPushEntries(entries, 0, 300);
+    expect(payload.received).toBe(2);
+    expect(payload.fired).toBe(1);
+    expect(payload.skipped).toBe(4);
+    expect(payload.skipReasons['gate-out-of-range']).toBe(2);
+    expect(payload.skipReasons['payload-missing-kind']).toBe(1);
+  });
+
+  it('respects since (exclusive) and until (inclusive)', () => {
+    const payload = aggregateSilentPushEntries(entries, 100, 210);
+    // ts > 100 && ts <= 210: 150,200,210
+    expect(payload.received).toBe(0);
+    expect(payload.fired).toBe(1);
+    expect(payload.skipped).toBe(2);
+  });
+
+  it('ignores non silent-push entries (default case)', () => {
+    const payload = aggregateSilentPushEntries(entries, 235, 300);
+    expect(payload.received).toBe(0);
+    expect(payload.fired).toBe(0);
+    expect(payload.skipped).toBe(0);
+  });
+
+  it('handles empty entries', () => {
+    const payload = aggregateSilentPushEntries([], 0, 1000);
+    expect(payload).toEqual({
+      since: 0,
+      until: 1000,
+      received: 0,
+      fired: 0,
+      skipped: 0,
+      skipReasons: {},
+    });
+  });
+
+  it('skipReasons omits keys for skip entries without reason', () => {
+    const payload = aggregateSilentPushEntries(
+      [entry({ ts: 1, source: 'silent-push-skipped', outcome: 'suppressed' })],
+      0,
+      10,
+    );
+    expect(payload.skipped).toBe(1);
+    expect(Object.keys(payload.skipReasons)).toHaveLength(0);
+  });
+});
+
+describe('isEmptyTelemetry', () => {
+  it('true when all zero', () => {
+    expect(
+      isEmptyTelemetry({
+        since: 0,
+        until: 1,
+        received: 0,
+        fired: 0,
+        skipped: 0,
+        skipReasons: {},
+      }),
+    ).toBe(true);
+  });
+
+  it('false when any counter non-zero', () => {
+    expect(
+      isEmptyTelemetry({
+        since: 0,
+        until: 1,
+        received: 0,
+        fired: 0,
+        skipped: 1,
+        skipReasons: {},
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/utils/telemetryAggregation.ts
+++ b/src/utils/telemetryAggregation.ts
@@ -1,0 +1,64 @@
+/**
+ * silent push 게이트 outcome 카운터 집계 (#498).
+ *
+ * alarmLog의 silent-push-* 엔트리에서 since(exclusive) 이후 항목만 골라
+ * { received, fired, skipped, skipReasons }로 집계한다. 백엔드 /telemetry/silent-push
+ * payload 형식 그대로.
+ *
+ * 동작 변경 없음 — 순수 측정 집계 함수.
+ */
+
+import type { AlarmLogEntry, AlarmLogReason } from './alarmLog';
+
+export interface SilentPushTelemetryPayload {
+  /** 이전 flush 시각(epoch ms). 첫 flush는 0. */
+  since: number;
+  /** 현재 flush 시각(epoch ms). entries.ts <= until만 포함. */
+  until: number;
+  received: number;
+  fired: number;
+  skipped: number;
+  /** skipped의 reason별 카운트. 0인 reason은 키 자체 생략. */
+  skipReasons: Partial<Record<AlarmLogReason, number>>;
+}
+
+export function aggregateSilentPushEntries(
+  entries: AlarmLogEntry[],
+  since: number,
+  until: number,
+): SilentPushTelemetryPayload {
+  let received = 0;
+  let fired = 0;
+  let skipped = 0;
+  const skipReasons: Partial<Record<AlarmLogReason, number>> = {};
+
+  for (const entry of entries) {
+    if (entry.ts <= since) continue;
+    if (entry.ts > until) continue;
+    switch (entry.source) {
+      case 'silent-push-received':
+        received += 1;
+        break;
+      case 'silent-push-fired':
+        fired += 1;
+        break;
+      case 'silent-push-skipped': {
+        skipped += 1;
+        const reason = entry.reason;
+        if (reason) {
+          skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return { since, until, received, fired, skipped, skipReasons };
+}
+
+/** 모든 카운터가 0이면 upload할 의미가 없음 — flush 호출 측에서 skip 판단. */
+export function isEmptyTelemetry(payload: SilentPushTelemetryPayload): boolean {
+  return payload.received === 0 && payload.fired === 0 && payload.skipped === 0;
+}


### PR DESCRIPTION
## Summary
- 백엔드 `POST /telemetry/silent-push` + Cloudflare Analytics Engine 적재로 silent-push-received/fired/skipped 카운터를 운영자가 일별 query 가능하게 한다.
- 클라가 alarmLog의 `silent-push-*` 엔트리를 30분 주기 + 마운트 + AppState active 진입 시 누적 upload (in-flight guard로 동시 호출 직렬화, 실패 시 since 유지 재시도).
- Privacy: 카운트만 전송, token은 8자 prefix만 백엔드에 적재. ADR-006으로 문서화.
- 동작 변경 없음 — `#495`(임계값 튜닝)/`#496`(백엔드 progress 활성화) 의사결정을 위한 측정 인프라. `#499`에서 1-2주 운영 데이터로 결정.

## Test plan
- [x] 클라: `npm test` 통과 (1634 tests, 100% coverage)
- [x] 클라: `npm run type-check` 통과
- [x] 백엔드: `npm test` 통과 (123 tests)
- [x] 백엔드: `npm run type-check` 통과
- [x] code-review 에이전트 P1(resume 이중 호출) 수정 — `onResume` 제거 + in-flight guard 추가
- [ ] 배포 후 1-2일 내 Cloudflare Analytics Engine에 데이터 적재 확인

Closes #498