### PR TITLE
fix(#502): iOS Apple Maps transit POI 끄기 — 경로 마커 중첩 제거

### DIFF
--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Platform, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import ClusteredMapView from 'react-native-map-clustering';
 import { Marker, Polyline, PROVIDER_DEFAULT } from 'react-native-maps';
@@ -118,6 +118,7 @@ export function StationMap({
         }}
         onMapReady={() => setMapReady(true)}
         showsUserLocation
+        showsPointsOfInterest={Platform.OS === 'ios' ? false : undefined}
         clusterColor={colors.accent}
         testID="station-map"
       >

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { StationMap } from '../StationMap';
 import type { Station } from '../../types/station';
@@ -64,6 +65,28 @@ describe('StationMap', () => {
   it('지도뷰를 렌더링한다', () => {
     const { getByTestId } = render(<StationMap {...baseProps} />);
     expect(getByTestId('station-map')).toBeTruthy();
+  });
+
+  it('iOS에서는 Apple Maps의 기본 POI(역명 등)를 끈다 — 경로 강조 마커와 중첩 방지', () => {
+    const originalOS = Platform.OS;
+    (Platform as { OS: typeof Platform.OS }).OS = 'ios';
+    try {
+      const { getByTestId } = render(<StationMap {...baseProps} />);
+      expect(getByTestId('station-map').props.showsPointsOfInterest).toBe(false);
+    } finally {
+      (Platform as { OS: typeof Platform.OS }).OS = originalOS;
+    }
+  });
+
+  it('Android에서는 POI 토글을 건드리지 않는다 (일반 POI 손실 방지)', () => {
+    const originalOS = Platform.OS;
+    (Platform as { OS: typeof Platform.OS }).OS = 'android';
+    try {
+      const { getByTestId } = render(<StationMap {...baseProps} />);
+      expect(getByTestId('station-map').props.showsPointsOfInterest).toBeUndefined();
+    } finally {
+      (Platform as { OS: typeof Platform.OS }).OS = originalOS;
+    }
   });
 
   it('onMapReady 후 로딩 인디케이터를 숨긴다', async () => {


### PR DESCRIPTION
## Summary
- 환승/도착역 좌표에 호선 색 점 + 콜아웃이 우리 배지 마커와 겹쳐 보이던 문제는 우리 마커 중복이 아니라 **Apple Maps(iOS, `PROVIDER_DEFAULT`)의 기본 transit POI** 때문.
- `ClusteredMapView`에 `showsPointsOfInterest={false}`를 **iOS 한정**으로 적용.
- Android(Google Maps)는 일반 POI(식당/랜드마크 등) 보존을 위해 `undefined`로 무영향.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (1609 passed, 커버리지 100%)
- [ ] iOS 실기기: 목적지 설정 후 지도 탭에서 환승/도착역의 둥근 점 + 콜아웃이 사라지고 배지 마커만 보이는지 확인 (논현, 신사 케이스 기준)
- [ ] Android 실기기: 주변 일반 POI(식당, 랜드마크)가 정상 표시되는지 확인

Closes #502