### PR TITLE
feat(#504): 지도 줌아웃 시 주요 역만 표시

### DIFF
--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -10,6 +10,7 @@ import { buildMapConfig } from '../utils/buildMapConfig';
 import { useTheme } from '../theme';
 import { LINE_BADGE_LABEL } from '../constants/lineColors';
 import { getStationDisplayName } from '../utils/stationDisplay';
+import { isMajorGroup, MAJOR_ONLY_LATITUDE_DELTA } from '../utils/majorStation';
 
 interface StationMapProps {
   userLat: number;
@@ -34,6 +35,7 @@ const FOCUS_REGION_DELTA = 0.01;
 const FOCUS_ANIMATION_MS = 400;
 const ROUTE_POLYLINE_WIDTH = 5;
 const ROUTE_FIT_EDGE_PADDING = { top: 40, bottom: 40, left: 40, right: 40 };
+const INITIAL_LATITUDE_DELTA = 0.05;
 
 export function StationMap({
   userLat,
@@ -51,6 +53,7 @@ export function StationMap({
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
   const [mapReady, setMapReady] = useState(false);
+  const [latitudeDelta, setLatitudeDelta] = useState(INITIAL_LATITUDE_DELTA);
   const mapRef = useRef<MapView | null>(null);
   // nonce 트리거 effect에서 stale closure 없이 항상 최신 좌표를 쓰기 위한 ref.
   const userPosRef = useRef({ lat: userLat, lng: userLng });
@@ -104,6 +107,24 @@ export function StationMap({
     return ids;
   }, [routeCoords]);
 
+  // 줌아웃 상태에서는 작은 클러스터 동그라미(2~3개) 방지를 위해 주요 역만 노출.
+  // 사용자 맥락 보존: 최근접 역, 출발/도착 지정, 경로 환승역은 줌과 무관하게 표시.
+  const isZoomedOut = latitudeDelta > MAJOR_ONLY_LATITUDE_DELTA;
+  const visibleGroups = useMemo(() => {
+    if (!isZoomedOut) return mapConfig.groups;
+    return mapConfig.groups.filter((group) => {
+      if (group.isNearest) return true;
+      const pinned = group.stations.some(
+        (s) =>
+          s.id === customOriginId ||
+          s.id === destinationId ||
+          routeTransferIds.has(s.id),
+      );
+      if (pinned) return true;
+      return isMajorGroup(group);
+    });
+  }, [isZoomedOut, mapConfig.groups, customOriginId, destinationId, routeTransferIds]);
+
   return (
     <View style={styles.map}>
       <ClusteredMapView
@@ -113,15 +134,16 @@ export function StationMap({
         initialRegion={{
           latitude: userLat,
           longitude: userLng,
-          latitudeDelta: 0.05,
-          longitudeDelta: 0.05,
+          latitudeDelta: INITIAL_LATITUDE_DELTA,
+          longitudeDelta: INITIAL_LATITUDE_DELTA,
         }}
         onMapReady={() => setMapReady(true)}
+        onRegionChangeComplete={(region) => setLatitudeDelta(region.latitudeDelta)}
         showsUserLocation
         clusterColor={colors.accent}
         testID="station-map"
       >
-        {mapConfig.groups.map((group) => {
+        {visibleGroups.map((group) => {
           // 대표 station = representativeName과 동일한 name을 가진 멤버.
           // representativeName은 멤버 중에서 뽑은 값이므로 find는 항상 매치.
           const representative = group.stations.find(

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { render, waitFor, fireEvent, act } from '@testing-library/react-native';
 import { StationMap } from '../StationMap';
 import type { Station } from '../../types/station';
 import { installLanguageRestoreHook, setLang } from '../../testUtils/i18nLanguageOverride';
@@ -307,6 +307,132 @@ describe('StationMap', () => {
       g.stations.some((s: Station) => s.id === mockStation.id),
     );
     expect(nearestGroup.isNearest).toBe(true);
+  });
+
+  describe('주요 역 필터링 (줌 레벨)', () => {
+    // 2호선 종점(시청)과 일반 중간역(강남, 선릉) 조합으로 검증.
+    const endpoint: Station = {
+      id: '2-001',
+      name: '시청',
+      nameEn: 'City Hall',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5642,
+      lng: 126.9774,
+    };
+
+    function triggerZoom(node: { props: { onRegionChangeComplete?: (r: { latitudeDelta: number }) => void } }, delta: number) {
+      act(() => {
+        node.props.onRegionChangeComplete?.({ latitudeDelta: delta });
+      });
+    }
+
+    it('초기 줌(0.05)에서는 모든 그룹을 표시', () => {
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearestStation={null}
+          nearbyStations={[mockStation, anotherStation, endpoint]}
+        />,
+      );
+      expect(getByTestId('marker-강남')).toBeTruthy();
+      expect(getByTestId('marker-선릉')).toBeTruthy();
+      expect(getByTestId('marker-시청')).toBeTruthy();
+    });
+
+    it('줌아웃(latitudeDelta > 임계값) 시 일반 중간역 마커는 숨기고 종착역/환승역만 표시', () => {
+      const { getByTestId, queryByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearestStation={null}
+          nearbyStations={[mockStation, anotherStation, endpoint, cheongguL5, cheongguL6]}
+        />,
+      );
+      triggerZoom(getByTestId('station-map'), 0.2);
+      expect(queryByTestId('marker-강남')).toBeNull();
+      expect(queryByTestId('marker-선릉')).toBeNull();
+      expect(getByTestId('marker-시청')).toBeTruthy();
+      expect(getByTestId('marker-청구')).toBeTruthy();
+    });
+
+    it('줌아웃 후 다시 줌인하면 전체 역 복원', () => {
+      const { getByTestId, queryByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearestStation={null}
+          nearbyStations={[mockStation, anotherStation, endpoint]}
+        />,
+      );
+      triggerZoom(getByTestId('station-map'), 0.2);
+      expect(queryByTestId('marker-강남')).toBeNull();
+      triggerZoom(getByTestId('station-map'), 0.03);
+      expect(getByTestId('marker-강남')).toBeTruthy();
+      expect(getByTestId('marker-선릉')).toBeTruthy();
+    });
+
+    it('줌아웃 상태에서도 nearestStation 그룹은 유지', () => {
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearbyStations={[mockStation, anotherStation]}
+        />,
+      );
+      triggerZoom(getByTestId('station-map'), 0.2);
+      // mockStation(강남)이 nearest → 일반 중간역이지만 유지
+      expect(getByTestId('marker-강남')).toBeTruthy();
+    });
+
+    it('줌아웃 상태에서도 customOriginId 그룹은 유지', () => {
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearestStation={null}
+          nearbyStations={[mockStation, anotherStation]}
+          customOriginId="2-023"
+        />,
+      );
+      triggerZoom(getByTestId('station-map'), 0.2);
+      expect(getByTestId('marker-선릉')).toBeTruthy();
+    });
+
+    it('줌아웃 상태에서도 destinationId 그룹은 유지', () => {
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearestStation={null}
+          nearbyStations={[mockStation, anotherStation]}
+          destinationId="2-023"
+        />,
+      );
+      triggerZoom(getByTestId('station-map'), 0.2);
+      expect(getByTestId('marker-선릉')).toBeTruthy();
+    });
+
+    it('줌아웃 상태에서도 경로 환승역 그룹은 유지', () => {
+      const transferStation: Station = {
+        id: '3-329',
+        name: '교대',
+        nameEn: "Seoul Nat'l Univ. of Education",
+        line: '3',
+        lineColor: '#EF7C1C',
+        lat: 37.4933,
+        lng: 127.0146,
+      };
+      const routeCoords = {
+        path: [{ latitude: transferStation.lat, longitude: transferStation.lng }],
+        keyStations: [{ station: transferStation, role: 'transfer' as const }],
+      };
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          nearestStation={null}
+          nearbyStations={[mockStation, anotherStation, transferStation]}
+          routeCoords={routeCoords}
+        />,
+      );
+      triggerZoom(getByTestId('station-map'), 0.2);
+      expect(getByTestId('marker-교대')).toBeTruthy();
+    });
   });
 
   describe('focusStation', () => {

--- a/src/utils/__tests__/majorStation.test.ts
+++ b/src/utils/__tests__/majorStation.test.ts
@@ -1,0 +1,70 @@
+import {
+  isMajorGroup,
+  LINE_ENDPOINT_IDS,
+  MAJOR_ONLY_LATITUDE_DELTA,
+} from '../majorStation';
+import type { Station } from '../../types/station';
+import type { StationGroup } from '../groupStationsByName';
+
+const mid: Station = {
+  id: '2-022',
+  name: '강남',
+  nameEn: 'Gangnam',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+const otherLine: Station = {
+  id: 'sinbundang-013',
+  name: '강남',
+  nameEn: 'Gangnam',
+  line: 'sinbundang',
+  lineColor: '#D31145',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+// 2호선 종점
+const endpoint: Station = {
+  id: '2-001',
+  name: '시청',
+  nameEn: 'City Hall',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.5642,
+  lng: 126.9774,
+};
+
+function group(stations: Station[]): StationGroup {
+  return {
+    key: stations[0].name,
+    representativeName: stations[0].name,
+    lat: stations[0].lat,
+    lng: stations[0].lng,
+    stations,
+  };
+}
+
+describe('majorStation', () => {
+  it('환승역(멤버 2개 이상)은 major로 판정', () => {
+    expect(isMajorGroup(group([mid, otherLine]))).toBe(true);
+  });
+
+  it('종착역 단일 멤버는 major로 판정', () => {
+    expect(isMajorGroup(group([endpoint]))).toBe(true);
+  });
+
+  it('일반 단일역(중간역)은 major가 아님', () => {
+    expect(isMajorGroup(group([mid]))).toBe(false);
+  });
+
+  it('LINE_ENDPOINT_IDS는 stations.json의 호선별 첫/마지막 id를 포함', () => {
+    expect(LINE_ENDPOINT_IDS.has('2-001')).toBe(true);
+    expect(LINE_ENDPOINT_IDS.has('2-043')).toBe(true);
+    expect(LINE_ENDPOINT_IDS.has('2-022')).toBe(false);
+  });
+
+  it('MAJOR_ONLY_LATITUDE_DELTA는 초기 region(0.05)보다 큰 값', () => {
+    expect(MAJOR_ONLY_LATITUDE_DELTA).toBeGreaterThan(0.05);
+  });
+});

--- a/src/utils/majorStation.ts
+++ b/src/utils/majorStation.ts
@@ -1,0 +1,38 @@
+import stationsData from '../data/stations.json';
+import type { Station } from '../types/station';
+import type { StationGroup } from './groupStationsByName';
+
+const stations = stationsData as Station[];
+
+// stations.json은 호선별로 상행 종점 → 하행 종점 순서대로 정렬되어 있다는 계약에 의존.
+// 분기/루프 노선(1·2·5·6·경의중앙)의 일부 지선 종점은 누락될 수 있으나,
+// 줌아웃 표시 후보 결정 용도이므로 정확도보다 안정성을 우선한다.
+function buildEndpointIds(): Set<string> {
+  const byLine = new Map<string, Station[]>();
+  for (const s of stations) {
+    let arr = byLine.get(s.line);
+    if (!arr) {
+      arr = [];
+      byLine.set(s.line, arr);
+    }
+    arr.push(s);
+  }
+  const ids = new Set<string>();
+  for (const arr of byLine.values()) {
+    ids.add(arr[0].id);
+    ids.add(arr[arr.length - 1].id);
+  }
+  return ids;
+}
+
+export const LINE_ENDPOINT_IDS: ReadonlySet<string> = buildEndpointIds();
+
+// 줌아웃(latitudeDelta가 이 값보다 크면) 시 주요 역만 표시.
+// 초기 region(0.05, 서울 시내 약 5km×5km)에서는 전체 노출이 자연스럽고,
+// 그 이상으로 사용자가 의도적으로 축소했을 때만 잡음(2~3개 클러스터)을 제거.
+export const MAJOR_ONLY_LATITUDE_DELTA = 0.08;
+
+export function isMajorGroup(group: StationGroup): boolean {
+  if (group.stations.length >= 2) return true;
+  return group.stations.some((s) => LINE_ENDPOINT_IDS.has(s.id));
+}


### PR DESCRIPTION
## Summary
- 줌아웃 상태에서 작은 클러스터(2~3개) 동그라미가 무수히 떠 가독성이 떨어지는 문제 해소
- `latitudeDelta > 0.08`이면 환승역(멤버 ≥ 2) + 호선별 종점만 표시
- 사용자 맥락(nearestStation, customOriginId, destinationId, 경로 환승역)은 줌과 무관하게 항상 노출
- `src/utils/majorStation.ts` 신규: `LINE_ENDPOINT_IDS`, `isMajorGroup`, `MAJOR_ONLY_LATITUDE_DELTA`

## Test plan
- [x] `npm test` — 1619 passed, 커버리지 100%
- [x] `npm run type-check` — 통과
- [x] code-review 에이전트 P1 없음 (P2 두 건은 주석으로 반영)
- [ ] 실기기/시뮬레이터에서 줌아웃 시 일반 중간역 사라지고 환승역/종점만 남는지 확인
- [ ] 줌인 복귀 시 전체 역 복원되는지 확인
- [ ] nearest/origin/destination/route 지정 시 줌아웃에도 해당 역 유지되는지 확인

Closes #504