### PR TITLE
fix(#505): alarmRefreshTask 핸들러 no-op화 — 잔존 BG task 폭주 차단

### DIFF
--- a/src/hooks/useAlarmRefreshTask.ts
+++ b/src/hooks/useAlarmRefreshTask.ts
@@ -12,8 +12,8 @@ const logger = createLogger('useAlarmRefreshTask');
  * 활성 트립(destination set)에 한해 BGAppRefreshTask 등록.
  * 트립 종료 / 언마운트 시 해제.
  *
- * Phase 1 fallback: silent push(Phase 2)를 받지 못하는 사용자도 OS가 앱을 깨워주는
- * 시점에 사전 예약 알람이 갱신된다.
+ * #505: 핸들러는 no-op(즉시 self-unregister). 등록은 호환을 위해 유지하나
+ * OS가 깨워도 알람 발사 없음. 훅 자체는 #411에서 일괄 제거 예정 (호출처 없음).
  */
 export function useAlarmRefreshTask(destination: Station | null): void {
   useEffect(() => {

--- a/src/tasks/__tests__/alarmRefreshTask.test.ts
+++ b/src/tasks/__tests__/alarmRefreshTask.test.ts
@@ -1,5 +1,3 @@
-// jest.mock 팩토리는 변수 호이스팅보다 먼저 실행되므로, 팩토리 외부 변수를 참조하면
-// undefined가 된다. global 객체는 항상 접근 가능하므로 여기에 콜백을 저장한다.
 jest.mock('expo-task-manager', () => ({
   defineTask: (name: string, callback: Function) => {
     (global as any).__bgRefreshCallback = callback;
@@ -14,35 +12,6 @@ jest.mock('expo-background-task', () => ({
   BackgroundTaskResult: { Success: 1, Failed: 2 },
 }));
 
-jest.mock('@react-native-async-storage/async-storage', () => ({
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-}));
-
-const mockScheduleAlarmsForRoute = jest.fn();
-jest.mock('../../utils/alarmScheduler', () => ({
-  scheduleAlarmsForRoute: (...args: unknown[]) => mockScheduleAlarmsForRoute(...args),
-}));
-
-const mockFetchArrivalInfo = jest.fn();
-jest.mock('../../api/arrivalApi', () => ({
-  fetchArrivalInfo: (...args: unknown[]) => mockFetchArrivalInfo(...args),
-}));
-
-const mockGetLastFiredAlarmStationName = jest.fn();
-jest.mock('../../utils/notificationState', () => ({
-  getLastFiredAlarmStationName: (...args: unknown[]) => mockGetLastFiredAlarmStationName(...args),
-}));
-
-jest.mock('../../data/stations.json', () => [
-  { id: 'station-1', name: '강남', line: '2', lineColor: '#009246', lat: 0, lng: 0 },
-  { id: 'station-2', name: '시청', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
-  // 방향 판정용 line '1' 추가 stations (id 정렬상 station-2 < station-3 < station-4)
-  { id: 'station-3', name: '종각', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
-  { id: 'station-4', name: '종로3가', line: '1', lineColor: '#0052A4', lat: 0, lng: 0 },
-]);
-
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -52,7 +21,6 @@ jest.mock('../../utils/logger', () => ({
   }),
 }));
 
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
 import {
@@ -61,73 +29,13 @@ import {
   unregisterAlarmRefreshTask,
 } from '../alarmRefreshTask';
 
-const route = { type: 'direct', stops: 10, line: '1' } as const;
-const destination = {
-  id: 'station-2',
-  name: '시청',
-  line: '1',
-  lineColor: '#0052A4',
-  lat: 0,
-  lng: 0,
-};
-
 function getCallback(): () => Promise<number> {
   return (global as any).__bgRefreshCallback;
-}
-
-function mockStorage(values: {
-  destination?: unknown;
-  route?: unknown;
-  lastStation?: string | null;
-  tripTrainCode?: string | null;
-}) {
-  const destId =
-    typeof values.destination === 'object' && values.destination && 'id' in values.destination
-      ? (values.destination as { id: string }).id
-      : 'station-2';
-  const map: Record<string, string | null> = {
-    'subway-now:destination':
-      values.destination === undefined
-        ? null
-        : typeof values.destination === 'string'
-          ? values.destination
-          : JSON.stringify(values.destination),
-    'subway-now:route':
-      values.route === undefined ? null : JSON.stringify(values.route),
-    'subway-now:last-notified-station': values.lastStation ?? null,
-    // tripTrainCode는 destinationId:code 형식으로 저장됨
-    'subway-now:trip-train-code': values.tripTrainCode
-      ? `${destId}:${values.tripTrainCode}`
-      : null,
-  };
-  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
-    Promise.resolve(key in map ? map[key] : null),
-  );
-  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-  (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
-}
-
-const EMPTY_STAMP = {
-  direction: null,
-  usedTrainCode: null,
-} as const;
-
-function expectSchedulerCalledWith(
-  currentStationApproachEtaSeconds: number | null,
-  stamp: { direction: 'up' | 'down' | null; usedTrainCode: string | null } = EMPTY_STAMP,
-) {
-  expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
-    route,
-    destinationName: '시청',
-    currentStationApproachEtaSeconds,
-    stamp,
-  });
 }
 
 describe('alarmRefreshTask', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetLastFiredAlarmStationName.mockResolvedValue(null);
   });
 
   it('defineTask가 ALARM_REFRESH_TASK 이름으로 호출된다', () => {
@@ -135,203 +43,18 @@ describe('alarmRefreshTask', () => {
     expect((global as any).__bgRefreshCallback).toBeDefined();
   });
 
-  describe('태스크 콜백', () => {
-    it('destination이 없으면 Success를 반환하고 스케줄러를 호출하지 않는다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  describe('태스크 콜백 (#505 no-op)', () => {
+    it('호출되면 즉시 self-unregister를 시도하고 Success를 반환한다', async () => {
+      (BackgroundTask.unregisterTaskAsync as jest.Mock).mockResolvedValueOnce(undefined);
+      const result = await getCallback()();
+      expect(BackgroundTask.unregisterTaskAsync).toHaveBeenCalledWith(ALARM_REFRESH_TASK);
+      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+    });
+
+    it('self-unregister가 실패해도 Success를 반환한다', async () => {
+      (BackgroundTask.unregisterTaskAsync as jest.Mock).mockRejectedValueOnce(new Error('boom'));
       const result = await getCallback()();
       expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
-      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
-      expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
-    });
-
-    it('route가 없으면 스케줄러를 호출하지 않는다', async () => {
-      mockStorage({ destination });
-      const result = await getCallback()();
-      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
-      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
-    });
-
-    it('destination JSON 파싱 실패 시 Success(no-op) 반환', async () => {
-      mockStorage({ destination: 'not-json{', route });
-      const result = await getCallback()();
-      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
-      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
-    });
-
-    it('destination.name이 비어 있으면 스킵한다', async () => {
-      mockStorage({ destination: { id: 'x' }, route });
-      const result = await getCallback()();
-      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
-      expect(mockScheduleAlarmsForRoute).not.toHaveBeenCalled();
-    });
-
-    it('활성 트립이 있고 현재역이 없으면 currentStationApproachEtaSeconds=null로 스케줄러 호출', async () => {
-      mockStorage({ destination, route, lastStation: null });
-      const result = await getCallback()();
-      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
-      expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
-      expectSchedulerCalledWith(null);
-    });
-
-    it('현재역이 다른 노선(line 2)이면 direction null로 양방향 fallback ETA를 사용한다', async () => {
-      // station-1(강남, line 2)은 route(line 1)에 없음 → resolveTripDirection=null → 양방향 합산.
-      mockStorage({ destination, route, lastStation: 'station-1' });
-      mockFetchArrivalInfo.mockResolvedValue({
-        up: [{ arrivalSeconds: 600 }, { arrivalSeconds: 1200 }],
-        down: [{ arrivalSeconds: 300 }],
-      });
-      await getCallback()();
-      expect(mockFetchArrivalInfo).toHaveBeenCalledWith('강남');
-      // direction=null filter → up/down 합산 best-effort. stamp.direction은 의도(null) 그대로.
-      expectSchedulerCalledWith(300, { direction: null, usedTrainCode: null });
-    });
-
-    it('Arrival API가 모두 0/음수면 currentStationApproachEtaSeconds=null', async () => {
-      mockStorage({ destination, route, lastStation: 'station-1' });
-      mockFetchArrivalInfo.mockResolvedValue({
-        up: [{ arrivalSeconds: 0 }],
-        down: [{ arrivalSeconds: -1 }],
-      });
-      await getCallback()();
-      expectSchedulerCalledWith(null);
-    });
-
-    it('LAST_NOTIFIED_STATION id가 stations.json에 없으면 currentStation은 null', async () => {
-      mockStorage({ destination, route, lastStation: 'unknown-id' });
-      await getCallback()();
-      expect(mockFetchArrivalInfo).not.toHaveBeenCalled();
-      expectSchedulerCalledWith(null);
-    });
-
-    it('Arrival API 호출이 실패해도 static fallback으로 스케줄러를 호출한다', async () => {
-      mockStorage({ destination, route, lastStation: 'station-1' });
-      mockFetchArrivalInfo.mockRejectedValue(new Error('network'));
-      const result = await getCallback()();
-      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
-      expectSchedulerCalledWith(null);
-    });
-
-    it('진행 방향이 판정되면 해당 방향의 ETA만 사용한다 (반대방향 ETA 폐기)', async () => {
-      // 현재역 종로3가(station-4, idx 2) → 시청(station-2, idx 0): up 방향
-      mockStorage({ destination, route, lastStation: 'station-4' });
-      mockFetchArrivalInfo.mockResolvedValue({
-        up: [{ arrivalSeconds: 240 }], // 진행 방향
-        down: [{ arrivalSeconds: 30 }], // 반대 방향 — 더 빠르지만 무시되어야 함
-      });
-      await getCallback()();
-      expect(mockFetchArrivalInfo).toHaveBeenCalledWith('종로3가');
-      expectSchedulerCalledWith(240, { direction: 'up', usedTrainCode: null });
-    });
-
-    it('진행 방향이 "down"이면 arrival.down ETA만 사용한다', async () => {
-      // destination 종로3가(station-4, idx 2) 사용 — 현재 시청(idx 0) → 종로3가 = down 방향
-      const destDown = { ...destination, id: 'station-4', name: '종로3가' };
-      mockStorage({
-        destination: destDown,
-        route,
-        lastStation: 'station-2',
-      });
-      mockFetchArrivalInfo.mockResolvedValue({
-        up: [{ arrivalSeconds: 30 }], // 반대 방향
-        down: [{ arrivalSeconds: 180 }], // 진행 방향
-      });
-      await getCallback()();
-      expect(mockScheduleAlarmsForRoute).toHaveBeenCalledWith({
-        route,
-        destinationName: '종로3가',
-        currentStationApproachEtaSeconds: 180,
-        stamp: { direction: 'down', usedTrainCode: null },
-      });
-    });
-
-    it('fired name이 stations.json에 없으면 GPS id 폴백 경로로 진입한다', async () => {
-      mockStorage({ destination, route, lastStation: 'station-2' });
-      mockGetLastFiredAlarmStationName.mockResolvedValueOnce('존재하지않는역');
-      mockFetchArrivalInfo.mockResolvedValue({ up: [{ arrivalSeconds: 700 }], down: [] });
-      await getCallback()();
-      // fired name → no match → GPS station-2(시청) 사용
-      expect(mockFetchArrivalInfo).toHaveBeenCalledWith('시청');
-      expectSchedulerCalledWith(700);
-    });
-
-    it('사전 예약 알람 발화 이름이 있으면 GPS id를 무시하고 그 이름으로 Arrival API를 호출한다', async () => {
-      // firedName='시청' → station-2(line 1) 매칭. resolveTripDirection: route line 1,
-      // destination 시청, currIdx=nextIdx=0 → direction=null → 양방향 fallback ETA 사용.
-      mockStorage({ destination, route, lastStation: 'station-1' });
-      mockGetLastFiredAlarmStationName.mockResolvedValueOnce('시청');
-      mockFetchArrivalInfo.mockResolvedValue({ up: [{ arrivalSeconds: 500 }], down: [] });
-      await getCallback()();
-      expect(mockFetchArrivalInfo).toHaveBeenCalledWith('시청');
-      expectSchedulerCalledWith(500);
-    });
-
-    it('lock-in: trainCode가 저장되어 있지 않으면 첫 arrival의 방향-필터 trainCode를 저장한다', async () => {
-      // 종로3가(idx 2) → 시청(idx 0): up 방향
-      mockStorage({ destination, route, lastStation: 'station-4', tripTrainCode: null });
-      mockFetchArrivalInfo.mockResolvedValue({
-        up: [{ arrivalSeconds: 240, trainCode: 'T-UP-1' }],
-        down: [{ arrivalSeconds: 30, trainCode: 'T-DN-1' }],
-      });
-      await getCallback()();
-      // destination(station-2)의 id를 prefix로 저장. up 방향 min ETA의 trainCode 채택.
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-        'subway-now:trip-train-code',
-        'station-2:T-UP-1',
-      );
-    });
-
-    it('lock-in: 저장된 trainCode가 있으면 같은 코드의 ETA를 결정론적으로 채택한다', async () => {
-      mockStorage({
-        destination,
-        route,
-        lastStation: 'station-4',
-        tripTrainCode: 'T-UP-1',
-      });
-      // 새 응답: T-UP-1은 180초, 같은 방향에 더 빠른 T-UP-2(50초) 도착 — T-UP-1 채택
-      mockFetchArrivalInfo.mockResolvedValue({
-        up: [
-          { arrivalSeconds: 180, trainCode: 'T-UP-1' },
-          { arrivalSeconds: 50, trainCode: 'T-UP-2' },
-        ],
-        down: [{ arrivalSeconds: 30, trainCode: 'T-DN-1' }],
-      });
-      await getCallback()();
-      expectSchedulerCalledWith(180, { direction: 'up', usedTrainCode: 'T-UP-1' });
-      // 이미 저장된 코드라 trip-train-code key로 다시 setItem 호출하지 않는다
-      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
-        'subway-now:trip-train-code',
-        expect.anything(),
-      );
-    });
-
-    it('lock-in: 저장된 trainCode가 응답에 없으면 방향 fallback ETA 사용', async () => {
-      mockStorage({
-        destination,
-        route,
-        lastStation: 'station-4',
-        tripTrainCode: 'T-MISSING',
-      });
-      mockFetchArrivalInfo.mockResolvedValue({
-        up: [{ arrivalSeconds: 240, trainCode: 'T-UP-1' }],
-        down: [{ arrivalSeconds: 30, trainCode: 'T-DN-1' }],
-      });
-      await getCallback()();
-      // T-MISSING은 매치 실패 → up 방향 min = 240, trainCode=T-UP-1로 stamp
-      expectSchedulerCalledWith(240, { direction: 'up', usedTrainCode: 'T-UP-1' });
-    });
-
-    it('활성 트립이 없으면 저장된 trainCode를 클리어한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-      (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
-      await getCallback()();
-      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-train-code');
-    });
-
-    it('스케줄러가 throw 하면 Failed를 반환한다', async () => {
-      mockStorage({ destination, route });
-      mockScheduleAlarmsForRoute.mockRejectedValueOnce(new Error('boom'));
-      const result = await getCallback()();
-      expect(result).toBe(BackgroundTask.BackgroundTaskResult.Failed);
     });
   });
 

--- a/src/tasks/alarmRefreshTask.ts
+++ b/src/tasks/alarmRefreshTask.ts
@@ -1,123 +1,22 @@
 import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { DESTINATION_KEY, ROUTE_KEY, LAST_NOTIFIED_STATION_KEY } from '../constants/storageKeys';
-import { getLastFiredAlarmStationName } from '../utils/notificationState';
-import { scheduleAlarmsForRoute } from '../utils/alarmScheduler';
-import { fetchArrivalInfo } from '../api/arrivalApi';
-import { pickNextArrival, type NextArrivalPick } from '../utils/nextArrivalPick';
-import {
-  captureTripTrainCodeIfAbsent,
-  clearTripTrainCode,
-} from '../utils/tripTrainCode';
-import stationsData from '../data/stations.json';
-import type { Station } from '../types/station';
-import type { Route } from '../utils/stationRoute';
-import { resolveTripDirection } from '../utils/tripDirection';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('AlarmRefreshTask');
 
 export const ALARM_REFRESH_TASK = 'alarm-refresh-task';
 
-/**
- * BGAppRefreshTask. OS가 ~15분 주기로 깨워 활성 트립의 사전 예약 알람을 갱신.
- *
- * Phase 1 fallback — 알림 권한은 있으나 silent push(Phase 2)를 못 받는 사용자용.
- * iOS는 사용 빈도에 따라 OS가 호출 간격을 가감하므로 보장된 주기가 아니다.
- */
-const allStations = stationsData as Station[];
-const stationById = new Map<string, Station>(allStations.map((s) => [s.id, s]));
-
-async function readActiveTrip(): Promise<{ destination: Station; route: NonNullable<Route> } | null> {
-  const [destJson, routeJson] = await Promise.all([
-    AsyncStorage.getItem(DESTINATION_KEY),
-    AsyncStorage.getItem(ROUTE_KEY),
-  ]);
-  if (!destJson || !routeJson) return null;
-  try {
-    const destination = JSON.parse(destJson) as Station;
-    const route = JSON.parse(routeJson) as Route;
-    if (!destination?.name || !route) return null;
-    return { destination, route };
-  } catch (e) {
-    logger.error('활성 트립 파싱 실패:', e);
-    return null;
-  }
-}
-
-async function resolveCurrentStation(): Promise<Station | null> {
-  // 1순위: 사전 예약 알람 발화 이름(#371) — GPS LAST_NOTIFIED는 BG 위치 업데이트 끊긴 동안 stale.
-  // 동명이역은 첫 매칭 Station을 반환. 노선이 어긋나면 하류의 resolveTripDirection(#370)이
-  // direction=null로 안전 폴백 → 양방향 합산 ETA로 그레이스풀 다운그레이드.
-  const firedName = await getLastFiredAlarmStationName();
-  if (firedName) {
-    const byName = allStations.find((s) => s.name === firedName);
-    if (byName) return byName;
-  }
-  // 2순위: GPS LAST_NOTIFIED id.
-  const id = await AsyncStorage.getItem(LAST_NOTIFIED_STATION_KEY);
-  if (!id) return null;
-  return stationById.get(id) ?? null;
-}
-
+// #505: 이전 빌드(useScheduledAlarms 시절)에서 OS에 등록된 BGAppRefreshTask가
+// 새 빌드 부팅 후에도 한동안 살아남아 scheduleAlarmsForRoute를 호출, 알람 폭주를 유발했다.
+// 핸들러는 즉시 self-unregister만 수행한다. 알람 발사 경로는 silent push 단독(#478).
+// register/unregister export는 useAlarmRefreshTask 호환을 위해 유지 — #411에서 일괄 제거.
 TaskManager.defineTask(ALARM_REFRESH_TASK, async () => {
-  try {
-    const active = await readActiveTrip();
-    if (!active) {
-      // 활성 트립이 없으면 lock-in된 trainCode도 의미 없음 — 정리.
-      await clearTripTrainCode();
-      logger.info('활성 트립 없음 — 스킵');
-      return BackgroundTask.BackgroundTaskResult.Success;
-    }
-
-    // 진행 방향은 route + 현재역 ordinal로 판정(#370). null이면 양방향 fallback.
-    const currentStation = await resolveCurrentStation();
-    const direction = currentStation
-      ? resolveTripDirection(active.route, active.destination.name, currentStation.id)
-      : null;
-    let pick: NextArrivalPick = {
-      etaSeconds: null,
-      direction: null,
-      trainCode: null,
-      matchedByTrainCode: false,
-    };
-    if (currentStation) {
-      try {
-        const arrivals = await fetchArrivalInfo(currentStation.name);
-        // trainCode lock-in: 저장된 코드가 없으면 첫 valid arrival의 방향-필터 picker로 캡처.
-        const trainCode = await captureTripTrainCodeIfAbsent(
-          active.destination.id,
-          arrivals,
-          direction,
-        );
-        pick = pickNextArrival(arrivals, direction, { preferTrainCode: trainCode });
-      } catch (e) {
-        logger.warn('Arrival API 호출 실패 — static ETA fallback:', e);
-      }
-    }
-
-    await scheduleAlarmsForRoute({
-      route: active.route,
-      destinationName: active.destination.name,
-      currentStationApproachEtaSeconds: pick.etaSeconds,
-      // stamp.direction은 의도(filter)를 기록 — pick.direction(추론된 list)이 아닌 route-resolved.
-      stamp: { direction, usedTrainCode: pick.trainCode },
-    });
-    logger.info(
-      `알람 사전 예약 갱신 완료 — eta=${pick.etaSeconds} matched=${pick.matchedByTrainCode}`,
-    );
-    return BackgroundTask.BackgroundTaskResult.Success;
-  } catch (e) {
-    logger.error('알람 갱신 태스크 실패:', e);
-    return BackgroundTask.BackgroundTaskResult.Failed;
-  }
+  await BackgroundTask.unregisterTaskAsync(ALARM_REFRESH_TASK).catch((e) =>
+    logger.warn('self-unregister 실패:', e),
+  );
+  return BackgroundTask.BackgroundTaskResult.Success;
 });
 
-/**
- * 트립 시작 시 호출. iOS BGAppRefreshTask 등록.
- * minimumInterval은 OS 권고치(15분). 실제 호출은 OS 재량.
- */
 export async function registerAlarmRefreshTask(): Promise<void> {
   const isRegistered = await TaskManager.isTaskRegisteredAsync(ALARM_REFRESH_TASK);
   if (isRegistered) return;
@@ -125,9 +24,6 @@ export async function registerAlarmRefreshTask(): Promise<void> {
   logger.info('AlarmRefreshTask 등록');
 }
 
-/**
- * 트립 종료 시 호출.
- */
 export async function unregisterAlarmRefreshTask(): Promise<void> {
   const isRegistered = await TaskManager.isTaskRegisteredAsync(ALARM_REFRESH_TASK);
   if (!isRegistered) return;


### PR DESCRIPTION
## 배경
2026-05-21 #478/#489(silent push 단독 발화) 머지 후 실기기 회귀 검증(#410)에서 사용자 이동 없이 \`bg-scheduled\` 알람이 4건씩 5~60초 간격으로 24분간 폭주(약 200건). 앱 완전 종료 후 재기동하면 정지.

진단(코드 grep): 현재 dev 코드는 \`useScheduledAlarms\` / \`useAlarmRefreshTask\` 모두 마운트되지 않음. 그러나 \`app/_layout.tsx:20\`이 \`alarmRefreshTask\` 모듈을 import → \`TaskManager.defineTask\` (line 64) 자동 실행 → **이전 빌드에서 \`BackgroundTask.registerTaskAsync\`로 등록된 OS-level BG task가 살아있을 때 OS가 깨우면 핸들러 실행 → \`scheduleAlarmsForRoute\` 호출 → 알람 4건 예약 + \`logScheduledAlarm\` 기록**. \`_layout.tsx:40\` \`unregisterAlarmRefreshTask()\`가 부팅 시 1회 호출되지만 비동기 → race로 OS가 먼저 깨우면 폭주.

## 변경
- \`src/tasks/alarmRefreshTask.ts\`: \`defineTask\` 핸들러 본문을 **즉시 self-unregister + Success 반환**으로 교체. \`scheduleAlarmsForRoute\` 호출 경로 완전 차단. 미사용 import(\`AsyncStorage\`, \`stationsData\`, scheduler, arrival API 등) 일괄 제거.
- \`src/tasks/__tests__/alarmRefreshTask.test.ts\`: 폐기된 로직(arrival/trainCode/lock-in) 테스트 제거, no-op 핸들러 테스트 2건 추가 (unregister 성공/실패 모두 Success 반환).
- \`src/hooks/useAlarmRefreshTask.ts\`: 주석에 \`#505\` no-op 전환 명시 (호출처 없으므로 훅 자체는 #411에서 제거 예정).

## 영향
- \`registerAlarmRefreshTask\` / \`unregisterAlarmRefreshTask\` 시그니처 변경 없음 → \`useAlarmRefreshTask\` / \`_layout.tsx\` 호환 유지
- 새 빌드: 이전 OS-level BG task가 살아있어도 깨어나는 즉시 self-unregister → OS가 다시 깨우지 않음
- 신규 사용자: \`useAlarmRefreshTask\` 마운트가 없어 register 자체가 안 일어남 (영향 0)

## 검증
- \`npm test\`: **1625 tests, 109 suites 통과**, 커버리지 100% (lines/branches/functions/statements)
- \`npm run type-check\`: 오류 0건
- code-reviewer 통과 (P1 이상 이슈 없음, useAlarmRefreshTask 주석 권고 반영)

## 후속
- #506: silent push release 빌드 미수신 진단 (별도 P0)
- #411: \`useScheduledAlarms\`/\`alarmScheduler\`/\`scheduledAlarmReceiver\`/\`alarmRefreshTask\` 파일 전체 + \`useAlarmRefreshTask\` + \`_layout.tsx\` import 일괄 제거 (운영 관찰 1~2주 후)
- #410: 본 PR + #506 해결 후 실기기 회귀 재검증

Closes #505