### PR TITLE
chore(#512): Podfile fmt consteval 패치 (Xcode 26+ 호환)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -74,6 +74,7 @@ module.exports = {
       'expo-localization',
       'expo-background-task',
       './modules/live-activity/app.plugin.js',
+      './plugins/with-fmt-consteval-patch.js',
       '@bacons/apple-targets',
     ],
     extra: {

--- a/plugins/with-fmt-consteval-patch.js
+++ b/plugins/with-fmt-consteval-patch.js
@@ -1,0 +1,52 @@
+// Xcode 16+ clang의 엄격한 consteval 검증이 RN 0.81에 묶인 구버전 fmt(base.h)와
+// 충돌해 빌드 실패한다. -DFMT_USE_CONSTEVAL=0는 base.h 내부 #elif 체인이 무조건
+// 재정의하므로 무력. Podfile post_install 훅에서 base.h를 직접 sed 패치하여
+// FMT_CONSTEVAL을 consteval → constexpr로 강제한다.
+//
+// CNG 프로젝트라 ios/는 매 prebuild마다 재생성되므로 plugin으로 영구화.
+
+const { withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const SENTINEL = '# [fmt-consteval-patch]';
+
+const PATCH_SNIPPET = `
+    ${SENTINEL} Xcode 16+ clang의 엄격한 consteval 검증과 RN 0.81 fmt 충돌 우회.
+    # FMT_USE_CONSTEVAL은 fmt 내부 #elif 체인이 무조건 재정의하므로 -D로는 안 됨 → 헤더 직접 패치.
+    fmt_base_h = File.join(installer.sandbox.root, 'fmt', 'include', 'fmt', 'base.h')
+    if File.exist?(fmt_base_h)
+      content = File.read(fmt_base_h)
+      patched = content.gsub('#  define FMT_CONSTEVAL consteval', '#  define FMT_CONSTEVAL constexpr')
+      if patched != content
+        File.chmod(0644, fmt_base_h)
+        File.write(fmt_base_h, patched)
+        Pod::UI.puts "[fmt-consteval-patch] fmt/base.h: FMT_CONSTEVAL consteval → constexpr"
+      end
+    end
+`;
+
+module.exports = function withFmtConstevalPatch(config) {
+  return withDangerousMod(config, [
+    'ios',
+    async (cfg) => {
+      const podfilePath = path.join(cfg.modRequest.platformProjectRoot, 'Podfile');
+      let contents = fs.readFileSync(podfilePath, 'utf8');
+      if (contents.includes(SENTINEL)) return cfg;
+
+      // Expo의 기본 Podfile은 target 'subwaynow' 내부에 단일 post_install 블록을 갖는다.
+      // 그 블록 내부 react_native_post_install 호출 직후에 패치 스니펫을 삽입한다.
+      const anchor = /react_native_post_install\([\s\S]*?\)\n/;
+      const match = anchor.exec(contents);
+      if (!match) {
+        throw new Error(
+          '[fmt-consteval-patch] react_native_post_install 앵커를 찾지 못함 — Podfile 구조 변경 확인',
+        );
+      }
+      const insertAt = match.index + match[0].length;
+      contents = contents.slice(0, insertAt) + PATCH_SNIPPET + contents.slice(insertAt);
+      fs.writeFileSync(podfilePath, contents);
+      return cfg;
+    },
+  ]);
+};


### PR DESCRIPTION
Closes #512

## 문제
Xcode 26.5(clang 17+) 환경에서 RN 0.81.5의 fmt 라이브러리가 \`format-inl.h\`의 \`consteval\` 호출에서 빌드 실패. 본인 코드 무관, Apple ↔ RN 호환성 갭. Xcode 자동 업데이트로 모든 로컬 빌드가 막힘.

## 원인
- \`fmt/base.h\`가 \`__cpp_lib_is_constant_evaluated\` 등 조건 모두 만족 시 \`FMT_USE_CONSTEVAL=1\`로 강제 → \`FMT_CONSTEVAL consteval\`
- \`-DFMT_USE_CONSTEVAL=0\` 시도는 base.h 내부 \`#elif\` 체인이 무조건 재정의해 무력
- 헤더 직접 패치(consteval → constexpr) 외 우회 없음

## 변경
- \`plugins/with-fmt-consteval-patch.js\` — Expo config plugin (\`withDangerousMod\`)
  - Podfile의 \`react_native_post_install\` 호출 직후에 fmt/base.h sed 패치 스니펫 주입
  - Sentinel 마커로 중복 적용 방지, 멱등
  - chmod 0644로 읽기 전용 해제 후 write
- \`app.config.js\` — plugins 목록에 추가
- CNG 프로젝트(\`ios/\` gitignored)라 prebuild마다 적용 필요 → plugin으로 영구화

## 영향
- 빌드 차단 해소 (로컬 dev, EAS 빌드 모두)
- 런타임 동작 동일 (consteval은 컴파일 타임 검증만, constexpr로 낮춰도 함수 동작 불변)
- 향후 RN이 fmt 새 버전 업그레이드 시 패치 제거 (sentinel grep으로 추적 용이)

## Test plan
- [x] \`npx expo prebuild --platform ios --clean\` → Podfile에 패치 주입 확인
- [x] \`pod install\` → \`[fmt-consteval-patch]\` 로그 출력, fmt/base.h가 constexpr로 패치된 것 확인
- [x] 실기기 Release 빌드 성공 (별도 #506 worktree에서 동일 패치로 검증 완료)
- [x] \`npm test\` 1635/1635 통과
- [x] \`npm run type-check\` 통과