### PR TITLE
fix(#514): 도착 후 Live Activity 부활 race 차단

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -201,6 +201,11 @@ export default function HomeScreen() {
     const currDestId = destination?.id ?? null;
     prevDestIdRef.current = currDestId;
 
+    // 도착 배너가 떠 있는 동안에는 LA가 막 종료된 직후 displayEta/alarmEvent 갱신으로
+    // updateStationNotification이 호출되어 LA가 부활하는 race를 막는다. arrivedBanner는
+    // 2초 후 setDestination(null)과 함께 false로 풀린다.
+    if (arrivedBanner) return;
+
     // 실시간 현황(Live Activity/알림)은 경로 진행 중일 때만 노출한다.
     if (!effectiveOrigin || !destination) {
       if (prevNotifKeyRef.current !== 'none') {
@@ -242,7 +247,7 @@ export default function HomeScreen() {
       );
     };
     update().catch((e) => logger.error('알림 업데이트 실패:', e));
-  }, [effectiveOrigin?.id, destination?.id, displayEta, arrivalIsMock, routeSig, alarmEvent]);
+  }, [effectiveOrigin?.id, destination?.id, displayEta, arrivalIsMock, routeSig, alarmEvent, arrivedBanner]);
 
   useEffect(() => {
     if (arrivedBanner) {


### PR DESCRIPTION
## Summary
- 도착 감지 → `arrivedBanner=true` → `clearStationNotification()` (LA end)
- 같은 2초 윈도우 안에 `displayEta`/`alarmEvent` 갱신이 들어오면 update useEffect가 `updateStationNotification()`을 호출해 LA가 부활하던 race 차단
- update useEffect 진입부에 `arrivedBanner` 가드 추가, deps에도 포함

## 동작 검증
- `arrivedBanner=true` 동안 update effect는 가드로 early return
- 2초 후 `setDestination(null)` + `setArrivedBanner(false)` 배치 → destination=null 분기로 진입해 정상 처리
- `clearStationNotification`은 멱등 (이미 ended LA에 대한 호출은 native 측 no-op)

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 109 suites / 1640 tests / coverage 100% 통과
- [ ] 실기기 회귀 검증 — 목적지 도착 → 잠금화면 LA 종료 확인
- [ ] 도착 직전 displayEta 갱신이 한 번 더 들어와도 LA가 부활하지 않는지 확인

Closes #514