### PR TITLE
feat(#516): 환승역 현재역 카드에 모든 호선 표시

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -347,7 +347,11 @@ export default function HomeScreen() {
                 </TouchableOpacity>
               </View>
               <View style={styles.metaRow}>
-                <LineBadge line={effectiveOrigin.line} />
+                {originVariants.length > 0 ? (
+                  originVariants.map((v) => <LineBadge key={v.id} line={v.line} />)
+                ) : (
+                  <LineBadge line={effectiveOrigin.line} />
+                )}
                 {/* #446: source==='gps'일 때만 user↔station 거리/도보시간이 의미 있음.
                     fusion 추정(positionTrain/arrival/route) 결과의 거리는 user↔추정역
                     직선거리라 도보 안내로 표시하면 잘못된 정보가 됨 → 숨김. */}


### PR DESCRIPTION
## Summary
- 환승역(군자 5/7호선, 건대입구 2/7호선 등)에서 현재역 카드에 단일 호선만 노출되던 문제 해결
- `originVariants`(이미 환승역 경로 계산용으로 존재)를 `LineBadge` 배열로 렌더
- customOrigin / 단일노선 케이스는 `effectiveOrigin.line` 단일 fallback 유지
- React key는 variant station id 사용 (line 중복 방지)

## Test plan
- [x] `npm run type-check`
- [x] `npm test` — 109 suites / 1640 tests / coverage 100%
- [ ] 실기기 — 환승역 도착 시 모든 호선 배지 노출 확인
- [ ] 단일노선 역 회귀 없음 확인

Closes #516