### PR TITLE
chore(#506): TELEMETRY binding 임시 비활성화 — Workers Free plan 호환

### DIFF
--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -12,9 +12,15 @@ preview_id = "7e67683c147349ed90c16a28ae232e34"
 
 # #498 — silent push 게이트 outcome 텔레메트리. 클라가 누적한 카운터를 일별 query 가능하게 적재.
 # Privacy: 카운트만, token은 8자 prefix만. 개별 push 내용/좌표 미저장.
-[[analytics_engine_datasets]]
-binding = "TELEMETRY"
-dataset = "silent_push_telemetry"
+#
+# 임시 비활성화 (#506): Analytics Engine은 Workers Paid 전용. 현재 Free plan에서는
+# binding 선언만으로도 deploy가 실패한다(Cloudflare API 10089). 코드는 `if (writer)` 분기로
+# graceful — binding 없으면 런타임에 datapoint 적재만 skip하고 ok 응답한다.
+# 운영 통계(stop-rate / push→ack 비율) 수집 보류. silent push 본 기능엔 영향 없음.
+# 복원: Paid 전환 시 아래 3줄 주석 해제 후 `npx wrangler deploy`.
+# [[analytics_engine_datasets]]
+# binding = "TELEMETRY"
+# dataset = "silent_push_telemetry"
 
 # 1분마다 활성 트립 폴링
 [triggers]


### PR DESCRIPTION
## 배경
#506 silent push 진단 중, prod backend 재배포가 \`Cloudflare API 10089: You need to enable Analytics Engine\`로 실패. Analytics Engine은 **Workers Paid 전용**이라 Free plan에서는 binding 선언만으로도 deploy가 차단됨.

이로 인해 #487(APNs self-heal) 등 silent push 신규 코드가 prod에 못 올라가 있고, wrangler tail 진단 결과:
\`\`\`
push fired (사가정 eta=27s)
apns push failed status=400 BadDeviceToken
scanned:1 polled:1 pushed:0 errors:1
\`\`\`
**self-heal 코드 부재로 한 사이클 만에 trip 삭제 → 클라 재등록 → 무한 루프**.

## 변경
- \`backend/alarm-worker/wrangler.toml\` 의 \`[[analytics_engine_datasets]]\` 3줄 주석 처리
- 비활성화 사유 + 복원 절차 주석 명시

## 영향 (사망 부위)
- 백엔드가 클라 telemetry 카운터를 받아도 Analytics Engine에 **datapoint 적재 안 함**
- \`backend/alarm-worker/src/index.ts\`의 \`if (writer)\` 분기 false → graceful skip + \`{ok:true}\` 응답
- silent push 본 기능(발사/수신/게이트) 영향 없음
- 클라 DebugModal의 alarmLog source별 카운트도 정상 (로컬 데이터)

## 영향 (잃는 것)
- 미래 N주의 운영 통계 수집 기회 (stop-rate, push→ack 비율)
- #495(임계값 튜닝) / #496(백엔드 progress) 의사결정은 본인 체감/디바이스 alarmLog로만 진행

## 복원
Workers Paid 전환 시:
1. \`wrangler.toml\` 3줄 주석 해제
2. \`npx wrangler deploy\`
3. 그 시점부터 datapoint 누적 시작 (과거 데이터는 없음)

## 검증
- backend tests: 8 suites, 123 tests 통과 (TELEMETRY 이미 optional 타입)
- 머지 후 deploy 검증은 사용자가 \`npx wrangler deploy\`로 진행

## 다음 절차
1. 본 PR 머지
2. \`cd backend/alarm-worker && npx wrangler deploy\` → 성공 시 silent push 신규 코드 prod 반영
3. wrangler tail에서 \`apns env mismatch — retry with opposite host\` + \`apns env corrected\` 또는 \`pushed:1\` 확인
4. 클라 DebugModal에서 \`lastReceived\` 시각으로 갱신되는지 확인

## 관련
- 진단 추적: #506
- 도입: #498/PR #501 (텔레메트리 인프라)
- 복원 시 함께 검토할 후속: #495, #496

Refs #506