### PR TITLE
fix(#527): GPS jump gate로 비현실 좌표 점프 drop

### DIFF
--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -13,3 +13,10 @@ export const MAX_ACCURACY_M = 200;
 // GPS 게이트의 영향 범위는 fallback 경로에 한정된다.
 export const MAX_ACCURACY_M_DISPLAY = 250;
 export const MAX_STATION_DISTANCE_KM = 1.0;
+// GPS jump gate (#527): 이전 fix 대비 물리적으로 불가능한 좌표 점프 차단.
+// 50 m/s: 지하철 최고 속도(~22 m/s) + 안전 마진. 표준 운행에선 절대 초과 불가.
+export const MAX_PLAUSIBLE_SPEED_MPS = 50;
+// 100m 미만 이동은 GPS 노이즈 범위로 간주하고 속도 검사를 면제.
+// 짧은 간격(< 1s) 두 fix가 거의 같은 위치일 때 d/dt가 비정상적으로 부풀어 false-positive
+// 차단이 발생하는 것을 막는다. 21:29 사고(25km)는 이 임계값보다 한참 위라 영향 없음.
+export const MIN_JUMP_DISTANCE_M = 100;

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -24,3 +24,6 @@ export const TRIP_TRAIN_CODE_KEY = 'subway-now:trip-train-code';
 // #498 — silent push 게이트 outcome 텔레메트리. 마지막 flush 시각(epoch ms).
 // 다음 flush는 이 시점 이후의 alarmLog 엔트리만 집계 → 중복 방지.
 export const TELEMETRY_LAST_FLUSH_KEY = 'subway-now:telemetry-last-flush';
+// #527 — BG 위치 task의 jump gate가 참조하는 직전 수용 fix.
+// 형식: {"lat":number,"lng":number,"timestamp":number} JSON.
+export const BG_LAST_FIX_KEY = 'subway-now:bg-last-fix';

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -71,7 +71,7 @@ const mockLocation = (lat: number, lng: number, opts: { accuracy?: number | null
 const simulateGps = (
   lat: number,
   lng: number,
-  opts: { speed?: number | null; accuracy?: number | null } = {},
+  opts: { speed?: number | null; accuracy?: number | null; timestamp?: number } = {},
 ) => {
   act(() => {
     watchCallback?.({
@@ -81,7 +81,7 @@ const simulateGps = (
         speed: opts.speed ?? null,
         accuracy: opts.accuracy ?? null,
       },
-      timestamp: Date.now(),
+      timestamp: opts.timestamp ?? Date.now(),
     });
   });
 };
@@ -419,14 +419,16 @@ describe('useNearestStation', () => {
     simulateGps(37.4980, 127.0277);
     await waitFor(() => expect(result.current.result).not.toBeNull());
 
-    // 이후 null 반환
+    // 이후 null 반환. 두 번째 좌표는 직전 fix와 100m 이내(노이즈 범위)로 두어
+    // jump gate(#527) 차단 없이 findNearestStations 분기를 검증한다.
     const spy = jest.spyOn(findNearestStationModule, 'findNearestStations').mockReturnValue(null);
-    simulateGps(37.0, 127.0);
-
-    await waitFor(() => expect(result.current.result).toBeNull());
-    expect(result.current.variants).toEqual([]);
-
-    spy.mockRestore();
+    try {
+      simulateGps(37.4981, 127.0278);
+      await waitFor(() => expect(result.current.result).toBeNull());
+      expect(result.current.variants).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('refresh 중 권한 거부 시 watch를 재시작하지 않는다', async () => {
@@ -583,6 +585,45 @@ describe('useNearestStation', () => {
     expect(drop).toBeDefined();
     expect(drop.speedMps).toBe(1.5);
     expect(drop.dropReason).toBe('low-accuracy-display');
+  });
+
+  it('jump gate(#527): 직전 fix 대비 비현실 점프는 setState 차단 + locationUncertain=true', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // 첫 fix: 효창공원앞 — 명시적 timestamp로 prev 고정
+    const t0 = 1_700_000_000_000;
+    simulateGps(37.5390, 126.9610, { accuracy: 30, timestamp: t0 });
+    await waitFor(() => expect(result.current.userLocation).not.toBeNull());
+    const initialLoc = result.current.userLocation;
+
+    // 두 번째 fix: 25km 떨어진 신내 — 8s 후 → 3125 m/s, 50 m/s 임계 초과
+    simulateGps(37.6128, 127.0966, { accuracy: 30, timestamp: t0 + 8_000 });
+
+    expect(result.current.userLocation).toEqual(initialLoc);
+    expect(result.current.locationUncertain).toBe(true);
+  });
+
+  it('jump gate(#527): jump drop 후 정상 fix가 들어오면 locationUncertain=false로 복귀한다 (P1 회귀)', async () => {
+    mockGranted();
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    const t0 = 1_700_000_000_000;
+    simulateGps(37.5390, 126.9610, { accuracy: 30, timestamp: t0 });
+    await waitFor(() => expect(result.current.locationUncertain).toBe(false));
+
+    simulateGps(37.6128, 127.0966, { accuracy: 30, timestamp: t0 + 8_000 });
+    expect(result.current.locationUncertain).toBe(true);
+
+    // 다음 정상 fix(직전 효창공원앞 근처)는 jump 통과 → uncertain 복귀
+    simulateGps(37.5391, 126.9611, { accuracy: 30, timestamp: t0 + 16_000 });
+    await waitFor(() => expect(result.current.locationUncertain).toBe(false));
   });
 
   it('uncertain 상태에서 정확한 좌표가 들어오면 locationUncertain=false로 복귀한다', async () => {

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -3,7 +3,13 @@ import { AppState } from 'react-native';
 import * as Location from 'expo-location';
 import { NearestStationResult, Station } from '../types/station';
 import { findNearestStations } from '../utils/findNearestStation';
-import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../utils/locationGates';
+import {
+  isAccuracyAcceptable,
+  isAccuracyAcceptableForDisplay,
+  isLocationFresh,
+  isPlausibleJump,
+  type FixSample,
+} from '../utils/locationGates';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../constants/e2e';
 import { createLogger } from '../utils/logger';
@@ -64,9 +70,23 @@ export function useNearestStation(): UseNearestStationReturn {
   // BG→FG 전환마다 startWatch가 호출되므로 stale 위치 의심 시 운영 로그로 추적한다.
   const lastKnownStaleCountRef = useRef<number>(0);
   const lastKnownLowAccuracyCountRef = useRef<number>(0);
+  // #527: jump gate가 참조하는 직전 수용 fix. accuracy 게이트는 fix 단위 절대값만 보고
+  // 이전 좌표와의 시공간 일관성은 확인하지 못한다 — 21:29 효창공원앞↔신내 25km/8s
+  // 텔레포트 사고를 차단하기 위해 useRef로 prev를 들고 비교한다.
+  const lastFixRef = useRef<FixSample | null>(null);
 
-  const applyLocation = useCallback((coords: Location.LocationObjectCoords) => {
+  const applyLocation = useCallback((coords: Location.LocationObjectCoords, timestamp: number) => {
     const { latitude, longitude, speed, accuracy } = coords;
+    const fix: FixSample = { lat: latitude, lng: longitude, timestamp };
+    if (!isPlausibleJump(lastFixRef.current, fix)) {
+      setLocationUncertain(true);
+      return;
+    }
+    lastFixRef.current = fix;
+    // jump/accuracy 게이트 모두 통과한 신뢰 fix — uncertain 상태에서 자동 복귀시킨다.
+    // (호출자 측 setLocationUncertain(false)에 의존하면 jump drop 직후 정상 fix가 들어와도
+    //  복귀 호출 경로가 없어 uncertain이 고착되는 결함 발생 — P1 회피.)
+    setLocationUncertain(false);
     const stationsResult = findNearestStations(latitude, longitude, MAX_STATION_DISTANCE_KM);
 
     const newId = stationsResult?.primary.id ?? null;
@@ -117,15 +137,18 @@ export function useNearestStation(): UseNearestStationReturn {
       setError(null);
       setPermissionDenied(false);
       setLocationUncertain(false);
-      applyLocation({
-        latitude: E2E_MOCK_LOCATION.latitude,
-        longitude: E2E_MOCK_LOCATION.longitude,
-        accuracy: E2E_MOCK_LOCATION.accuracyMeters,
-        speed: E2E_MOCK_LOCATION.speedMps,
-        altitude: null,
-        altitudeAccuracy: null,
-        heading: null,
-      });
+      applyLocation(
+        {
+          latitude: E2E_MOCK_LOCATION.latitude,
+          longitude: E2E_MOCK_LOCATION.longitude,
+          accuracy: E2E_MOCK_LOCATION.accuracyMeters,
+          speed: E2E_MOCK_LOCATION.speedMps,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+        },
+        Date.now(),
+      );
       setLoading(false);
       return;
     }
@@ -146,7 +169,7 @@ export function useNearestStation(): UseNearestStationReturn {
         const fresh = isLocationFresh(lastKnown.timestamp);
         const acceptable = isAccuracyAcceptable(lastKnown.coords.accuracy);
         if (fresh && acceptable) {
-          applyLocation(lastKnown.coords);
+          applyLocation(lastKnown.coords, lastKnown.timestamp);
           setLoading(false);
         } else if (!fresh) {
           lastKnownStaleCountRef.current += 1;
@@ -197,7 +220,7 @@ export function useNearestStation(): UseNearestStationReturn {
             return;
           }
           setLocationUncertain(false);
-          applyLocation(location.coords);
+          applyLocation(location.coords, location.timestamp);
         },
       );
       setLoading(false);
@@ -227,7 +250,7 @@ export function useNearestStation(): UseNearestStationReturn {
       const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
       if (isAccuracyAcceptableForDisplay(location.coords.accuracy)) {
         setLocationUncertain(false);
-        applyLocation(location.coords);
+        applyLocation(location.coords, location.timestamp);
       } else {
         setLocationUncertain(true);
       }

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -62,6 +62,7 @@ import type { AlarmEvent } from '../../utils/stationAlarm';
 import '../../tasks/backgroundLocationTask';
 import { BACKGROUND_LOCATION_TASK } from '../../tasks/backgroundLocationTask';
 import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
+import { ALARM_EVENT_KEY } from '../../constants/storageKeys';
 
 // ── 픽스처 ──
 
@@ -192,7 +193,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   // ── 목적지 설정 + alarmEvent 없음 ──
 
-  it('destJson이 있고 alarmEvent가 null이면 AsyncStorage.setItem을 호출하지 않는다', async () => {
+  it('destJson이 있고 alarmEvent가 null이면 ALARM_EVENT_KEY는 쓰지 않는다', async () => {
     mockStorageValues(JSON.stringify(mockDestination));
 
     mockProcessLocationUpdate.mockResolvedValue({
@@ -214,7 +215,10 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       allowSpeaker: true,
       storedRoute: null,
     }));
-    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    // alarmEvent가 없으므로 ALARM_EVENT_KEY는 기록되지 않는다.
+    // BG_LAST_FIX_KEY(#527 jump gate)는 fix 수용 시 항상 기록되므로 별도 검증.
+    const setItemCalls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+    expect(setItemCalls.every(([key]) => key !== ALARM_EVENT_KEY)).toBe(true);
   });
 
   // ── sleepMode 파싱 ──
@@ -515,6 +519,97 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       'gate-accuracy',
       expect.objectContaining({ accuracy }),
     );
+  });
+
+  // ── #527 jump gate: trip 컨텍스트(destJson 통과) 이후에만 동작 ──
+
+  it('비현실 점프(25km/8s)면 logSuppressedGate(gate-jump)를 호출하고 processLocationUpdate를 건너뛴다', async () => {
+    const prevTs = Date.now() - 8_000;
+    const prevFix = { lat: 37.5390, lng: 126.9610, timestamp: prevTs };
+    // dest, sleep, route, allowSpeaker, BG_LAST_FIX_KEY (readBgLastFix 5번째 호출)
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JSON.stringify(prevFix));
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.6128, 127.0966)] }, // 신내 ≈ 25km 떨어짐
+      error: null,
+    });
+
+    expect(mockLogSuppressedGate).toHaveBeenCalledWith(
+      'gate-jump',
+      expect.objectContaining({ lat: 37.6128, lng: 127.0966 }),
+    );
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  it('정상 이동이면 jump 게이트를 통과하고 BG_LAST_FIX_KEY를 갱신한다', async () => {
+    const prevTs = Date.now() - 30_000;
+    const prevFix = { lat: 37.498, lng: 127.027, timestamp: prevTs };
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JSON.stringify(prevFix));
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.499, 127.028)] }, // ≈ 130m 이동, 4.3 m/s
+      error: null,
+    });
+
+    expect(mockLogSuppressedGate).not.toHaveBeenCalled();
+    expect(mockProcessLocationUpdate).toHaveBeenCalled();
+    const setItemCalls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+    expect(setItemCalls.some(([key]) => key === 'subway-now:bg-last-fix')).toBe(true);
+  });
+
+  it('BG_LAST_FIX_KEY가 없으면(콜드스타트) jump 게이트를 통과한다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination));
+    // mockStorageValues는 4개만 mockOnce → 5번째 호출은 default(null)
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockLogSuppressedGate).not.toHaveBeenCalled();
+    expect(mockProcessLocationUpdate).toHaveBeenCalled();
+  });
+
+  it('BG_LAST_FIX_KEY가 손상된 JSON이면 prev=null로 처리하여 통과한다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('not-json');
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalled();
+  });
+
+  it('BG_LAST_FIX_KEY가 형식 불일치 객체면 prev=null로 처리하여 통과한다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(mockDestination))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalled();
   });
 
   it('accuracy가 임계값(MAX_ACCURACY_M) 이내면 통과한다', async () => {

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -6,14 +6,35 @@ import { alarmKey } from '../utils/stationAlarm';
 import { createLogger } from '../utils/logger';
 import { DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
-import { isAccuracyAcceptable, isLocationFresh } from '../utils/locationGates';
+import { isAccuracyAcceptable, isLocationFresh, isPlausibleJump, type FixSample } from '../utils/locationGates';
 import { logSuppressedGate } from '../utils/alarmLog';
+import { BG_LAST_FIX_KEY } from '../constants/storageKeys';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
 
 const logger = createLogger('BackgroundLocation');
 
 export const BACKGROUND_LOCATION_TASK = 'background-location-task';
+
+async function readBgLastFix(): Promise<FixSample | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_LAST_FIX_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as FixSample).lat === 'number' &&
+      typeof (parsed as FixSample).lng === 'number' &&
+      typeof (parsed as FixSample).timestamp === 'number'
+    ) {
+      return parsed as FixSample;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   if (error) {
@@ -78,6 +99,17 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     const destination = destinationRaw as Station;
     const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
     const allowSpeaker = allowSpeakerJson ? JSON.parse(allowSpeakerJson) === true : true;
+
+    // #527: BG task 호출 간 직전 수용 fix를 AsyncStorage로 들고 시공간 일관성을 검증한다.
+    // iOS deferred batch에서 stale 좌표가 섞여 들어오거나 OS가 부정확 fix를 보낼 때 발생하는
+    // 비현실 점프(예: 25km/8s)를 drop. trip이 없을 땐 의미가 없어 destJson 통과 이후로 미룬다.
+    const currFix: FixSample = { lat, lng, timestamp: latest.timestamp };
+    const prevFix = await readBgLastFix();
+    if (!isPlausibleJump(prevFix, currFix)) {
+      logSuppressedGate('gate-jump', { lat, lng, accuracy, ageMs });
+      return;
+    }
+    await AsyncStorage.setItem(BG_LAST_FIX_KEY, JSON.stringify(currFix));
     // destinationId scoped — 이전 trip의 stale entry는 빈 set으로 반환된다(#462).
     const firedAlarms = await getFiredAlarms(destination.id);
     const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;

--- a/src/utils/__tests__/locationGates.test.ts
+++ b/src/utils/__tests__/locationGates.test.ts
@@ -1,5 +1,10 @@
 import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../constants/location';
-import { isAccuracyAcceptable, isAccuracyAcceptableForDisplay, isLocationFresh } from '../locationGates';
+import {
+  isAccuracyAcceptable,
+  isAccuracyAcceptableForDisplay,
+  isLocationFresh,
+  isPlausibleJump,
+} from '../locationGates';
 
 describe('isLocationFresh', () => {
   const NOW = 1_700_000_000_000;
@@ -71,5 +76,43 @@ describe('isAccuracyAcceptableForDisplay', () => {
 
   it('알람 임계값을 초과해도 표시 임계값 이내면 true (지하 구간 가정)', () => {
     expect(isAccuracyAcceptableForDisplay(MAX_ACCURACY_M + 1)).toBe(true);
+  });
+});
+
+describe('isPlausibleJump', () => {
+  // 효창공원앞 ≈ (37.5390, 126.9610), 신내 ≈ (37.6128, 127.0966) — 대략 25km 떨어진 두 점
+  const HYOCHANG = { lat: 37.5390, lng: 126.9610 };
+  const SINNAE = { lat: 37.6128, lng: 127.0966 };
+
+  it('prev가 null이면 true (콜드 스타트)', () => {
+    expect(isPlausibleJump(null, { ...HYOCHANG, timestamp: 1_700_000_000_000 })).toBe(true);
+  });
+
+  it('정상 도보/주행: 30s 동안 200m → true', () => {
+    const prev = { lat: 37.5390, lng: 126.9610, timestamp: 1_700_000_000_000 };
+    // 약 200m 북쪽 (0.0018° lat ≈ 200m)
+    const curr = { lat: 37.5408, lng: 126.9610, timestamp: 1_700_000_030_000 };
+    expect(isPlausibleJump(prev, curr)).toBe(true);
+  });
+
+  it('비현실 점프: 8s 동안 25km → false (21:29 사고)', () => {
+    const prev = { ...HYOCHANG, timestamp: 1_700_000_000_000 };
+    const curr = { ...SINNAE, timestamp: 1_700_000_008_000 };
+    expect(isPlausibleJump(prev, curr)).toBe(false);
+  });
+
+  it('정지 시 GPS 노이즈: 5s 동안 5m → true', () => {
+    const prev = { lat: 37.5390, lng: 126.9610, timestamp: 1_700_000_000_000 };
+    // 약 5m 변동 (0.00005° lat ≈ 5.5m)
+    const curr = { lat: 37.53905, lng: 126.9610, timestamp: 1_700_000_005_000 };
+    expect(isPlausibleJump(prev, curr)).toBe(true);
+  });
+
+  it('timestamp 동일/역행: true (중복 fix 보호)', () => {
+    const prev = { ...HYOCHANG, timestamp: 1_700_000_000_000 };
+    const sameTs = { ...SINNAE, timestamp: 1_700_000_000_000 };
+    const earlier = { ...SINNAE, timestamp: 1_699_999_999_000 };
+    expect(isPlausibleJump(prev, sameTs)).toBe(true);
+    expect(isPlausibleJump(prev, earlier)).toBe(true);
   });
 });

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -34,6 +34,7 @@ export type AlarmLogReason =
   | 'dedup-station'
   | 'gate-age'
   | 'gate-accuracy'
+  | 'gate-jump'
   | 'gate-unknown-station'
   | 'gate-no-location'
   | 'gate-stale-location'
@@ -254,7 +255,7 @@ export function logSilentPushSkipped(input: {
 }
 
 export function logSuppressedGate(
-  reason: 'gate-age' | 'gate-accuracy',
+  reason: 'gate-age' | 'gate-accuracy' | 'gate-jump',
   location: AlarmLogLocation,
 ): void {
   void appendAlarmLog({

--- a/src/utils/locationGates.ts
+++ b/src/utils/locationGates.ts
@@ -1,4 +1,11 @@
-import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../constants/location';
+import {
+  MAX_ACCURACY_M,
+  MAX_ACCURACY_M_DISPLAY,
+  MAX_LOCATION_AGE_MS,
+  MAX_PLAUSIBLE_SPEED_MPS,
+  MIN_JUMP_DISTANCE_M,
+} from '../constants/location';
+import { haversine } from './haversine';
 
 export function isLocationFresh(timestamp: number | undefined): boolean {
   // expo-location 타입상 timestamp는 non-nullable이지만, 네이티브 deferred batch에서
@@ -13,4 +20,29 @@ export function isAccuracyAcceptable(accuracy: number | null | undefined): boole
 
 export function isAccuracyAcceptableForDisplay(accuracy: number | null | undefined): boolean {
   return accuracy == null || accuracy <= MAX_ACCURACY_M_DISPLAY;
+}
+
+export interface FixSample {
+  lat: number;
+  lng: number;
+  timestamp: number;
+}
+
+// 21:29 효창공원앞↔신내 25km/8s 텔레포트(#527) 같은 비현실 좌표 점프를 차단한다.
+// 게이트 통과 조건:
+//   - prev null (콜드스타트) → 통과
+//   - dtMs <= 0 (중복 fix) → 통과
+//   - 거리 < MIN_JUMP_DISTANCE_M → GPS 노이즈 범위로 간주, 속도 검사 면제
+//   - 거리 >= MIN_JUMP_DISTANCE_M → 속도 <= MAX_PLAUSIBLE_SPEED_MPS면 통과
+//
+// 플랜의 "짧은 Δt 보강(<5s && >500m)"은 현 속도 임계값(50 m/s)보다 항상 약한 조건이라
+// dead branch가 되어 제외. 운영에서 timestamp 노이즈 케이스 관찰되면 #495에서 재도입.
+export function isPlausibleJump(prev: FixSample | null, curr: FixSample): boolean {
+  if (!prev) return true;
+  const dtMs = curr.timestamp - prev.timestamp;
+  if (dtMs <= 0) return true;
+  const distanceM = haversine(prev.lat, prev.lng, curr.lat, curr.lng) * 1000;
+  if (distanceM < MIN_JUMP_DISTANCE_M) return true;
+  const speedMps = distanceM / (dtMs / 1000);
+  return speedMps <= MAX_PLAUSIBLE_SPEED_MPS;
 }


### PR DESCRIPTION
## Summary

- 2026-05-25 21:29 효창공원앞↔신내 25km/8s GPS 텔레포트 false-positive 알람을 차단하기 위해 `isPlausibleJump(prev, curr)` 추가
- FG(`useNearestStation`)는 `lastFixRef`(useRef), BG(`backgroundLocationTask`)는 `BG_LAST_FIX_KEY`(AsyncStorage)로 직전 수용 fix를 들고 시공간 일관성을 검증
- 임계값: `MAX_PLAUSIBLE_SPEED_MPS=50` (지하철 최고 ~22 m/s + 안전마진), `MIN_JUMP_DISTANCE_M=100` (그 이하는 GPS 노이즈로 간주, 속도 검사 면제)

## 진입점

| 위치 | prev 저장 | drop 시 동작 |
|---|---|---|
| `useNearestStation.applyLocation` | `useRef` | `setLocationUncertain(true)` |
| `backgroundLocationTask` (destJson 검증 후) | `AsyncStorage(BG_LAST_FIX_KEY)` | `logSuppressedGate('gate-jump')` |

> 플랜의 3번째 진입점(`stationPipeline`)은 BG task가 유일한 호출자라 중복이 되어 제외. silent push는 `silentPushLocationGate.ts`로 별도 게이트가 존재.

## 플랜 이탈

- "짧은 Δt 보강(Δt < 5s && Δd > 500m)" 제외 — 속도 임계값(50 m/s) 대비 항상 약한 조건이라 dead branch. 운영 관찰 후 #495에서 재도입 여부 결정
- `MIN_JUMP_DISTANCE_M=100` 추가 — 짧은 간격 두 fix가 거의 같은 위치일 때 d/dt가 부풀어 false-positive drop 발생. 21:29 사고(25km)는 한참 위라 영향 없음

## 코드 리뷰 반영

- **P1**: `applyLocation` 통과 시 `setLocationUncertain(false)` 자동 복귀 추가 + 회귀 테스트
- **P2**: `simulateGps`에 명시적 `timestamp` 옵션 추가 후 jump 테스트 결정성 확보

## 후속 (이 PR 범위 밖)

- BG task의 setItem 직후 OS kill race 시나리오 (P2) — 별도 이슈 검토
- FG jump drop도 `logSuppressedGate('gate-jump')` 기록 (P3) — 진단 일관성

## Test plan

- [x] `npm test` — 1669개 통과, 커버리지 100%
- [x] `npm run type-check` — 통과
- [ ] 실기기에서 다음 출퇴근 1회 — 21:29 같은 점프 시 알람 미발사 확인 (alarmLog `gate-jump` 적재 확인)

Closes #527