### PR TITLE
feat(#327): 홈 현재역 카드에 source 신뢰도 배지 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -28,6 +28,7 @@ import { AlarmOverlay } from '../../src/components/AlarmOverlay';
 import { createLogger } from '../../src/utils/logger';
 import { useTheme, typography, spacing, radius } from '../../src/theme';
 import { LineBadge } from '../../src/components/LineBadge';
+import { SourceBadge } from '../../src/components/SourceBadge';
 import { ArrivalSourceNotice } from '../../src/components/ArrivalSourceNotice';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
@@ -371,6 +372,13 @@ export default function HomeScreen() {
                       {nearest.walkMin} min walk
                     </Text>
                   </>
+                )}
+                {!isCustomOrigin && (
+                  <SourceBadge
+                    source={source}
+                    locationUncertain={locationUncertain}
+                    testID="home-source-badge"
+                  />
                 )}
                 {__DEV__ && (
                   <>

--- a/src/components/SourceBadge.tsx
+++ b/src/components/SourceBadge.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, spacing, radius, withAlpha } from '../theme';
+import type { FusionSource } from '../utils/pickFusedStation';
+
+interface SourceBadgeProps {
+  source: FusionSource;
+  locationUncertain?: boolean;
+  testID?: string;
+}
+
+type BadgeKey = 'positionTrain' | 'routeProgress' | 'gpsOnly' | 'uncertain';
+
+// position/arrival은 모두 열차 데이터 기반이라 동일 그룹으로 묶는다.
+// 사용자에겐 "데이터 출처의 신뢰도"가 의미 있고, 내부 fusion 알고리즘 구분은 의미 없음.
+function resolveBadgeKey(source: FusionSource, locationUncertain: boolean): BadgeKey {
+  if (locationUncertain) return 'uncertain';
+  switch (source) {
+    case 'position-train':
+    case 'position':
+    case 'arrival':
+      return 'positionTrain';
+    case 'route-progress':
+      return 'routeProgress';
+    case 'gps':
+      return 'gpsOnly';
+    /* istanbul ignore next -- FusionSource 유니온이 위 case와 동기화되므로 도달 불가. 새 값 추가 시 컴파일 타임에 잡힘 */
+    default: {
+      const _exhaustive: never = source;
+      return _exhaustive;
+    }
+  }
+}
+
+export function SourceBadge({ source, locationUncertain = false, testID }: SourceBadgeProps) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const key = resolveBadgeKey(source, locationUncertain);
+
+  const palette: Record<BadgeKey, { bg: string; fg: string }> = {
+    positionTrain: { bg: withAlpha(colors.success, 0.13), fg: colors.success },
+    routeProgress: { bg: colors.hair, fg: colors.ink },
+    gpsOnly: { bg: withAlpha(colors.warn, 0.13), fg: colors.warn },
+    uncertain: { bg: colors.hair, fg: colors.muted },
+  };
+  const { bg, fg } = palette[key];
+
+  return (
+    <View style={[styles.badge, { backgroundColor: bg }]} testID={testID}>
+      <Text style={[styles.label, { color: fg }]}>{t(`source.${key}`)}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radius.pill,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+  },
+});

--- a/src/components/__tests__/SourceBadge.test.tsx
+++ b/src/components/__tests__/SourceBadge.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import * as RN from 'react-native';
+import i18next from 'i18next';
+import { SourceBadge } from '../SourceBadge';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+
+const mockUseColorScheme = jest.spyOn(RN, 'useColorScheme');
+
+describe('SourceBadge', () => {
+  beforeEach(() => {
+    mockUseColorScheme.mockReturnValue('light');
+  });
+
+  afterEach(() => {
+    mockUseColorScheme.mockReset();
+  });
+
+  it('position-train source → "열차 데이터" 라벨', () => {
+    renderWithTheme(<SourceBadge source="position-train" />);
+    expect(screen.getByText(i18next.t('source.positionTrain'))).toBeTruthy();
+  });
+
+  it('position source(fused) → "열차 데이터" 라벨로 묶임', () => {
+    renderWithTheme(<SourceBadge source="position" />);
+    expect(screen.getByText(i18next.t('source.positionTrain'))).toBeTruthy();
+  });
+
+  it('arrival source(fused) → "열차 데이터" 라벨로 묶임', () => {
+    renderWithTheme(<SourceBadge source="arrival" />);
+    expect(screen.getByText(i18next.t('source.positionTrain'))).toBeTruthy();
+  });
+
+  it('route-progress source → "경로 추정" 라벨', () => {
+    renderWithTheme(<SourceBadge source="route-progress" />);
+    expect(screen.getByText(i18next.t('source.routeProgress'))).toBeTruthy();
+  });
+
+  it('gps source → "GPS 추정" 라벨', () => {
+    renderWithTheme(<SourceBadge source="gps" />);
+    expect(screen.getByText(i18next.t('source.gpsOnly'))).toBeTruthy();
+  });
+
+  it('locationUncertain=true → source=position-train이어도 "위치 확인 중"', () => {
+    renderWithTheme(<SourceBadge source="position-train" locationUncertain={true} />);
+    expect(screen.getByText(i18next.t('source.uncertain'))).toBeTruthy();
+  });
+
+  it('locationUncertain=true → source=gps여도 "위치 확인 중"', () => {
+    renderWithTheme(<SourceBadge source="gps" locationUncertain={true} />);
+    expect(screen.getByText(i18next.t('source.uncertain'))).toBeTruthy();
+  });
+
+  it('locationUncertain=true → source=route-progress여도 "위치 확인 중"', () => {
+    renderWithTheme(<SourceBadge source="route-progress" locationUncertain={true} />);
+    expect(screen.getByText(i18next.t('source.uncertain'))).toBeTruthy();
+  });
+
+  it('testID를 전달한다', () => {
+    renderWithTheme(<SourceBadge source="gps" testID="my-badge" />);
+    expect(screen.getByTestId('my-badge')).toBeTruthy();
+  });
+
+  it('다크모드에서도 정상 렌더', () => {
+    mockUseColorScheme.mockReturnValue('dark');
+    renderWithTheme(<SourceBadge source="gps" />);
+    expect(screen.getByText(i18next.t('source.gpsOnly'))).toBeTruthy();
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -212,5 +212,11 @@
     "boundFor": "Bound for {{name}}",
     "innerLoop": "Inner Loop",
     "outerLoop": "Outer Loop"
+  },
+  "source": {
+    "positionTrain": "Train data",
+    "routeProgress": "Route est.",
+    "gpsOnly": "GPS est.",
+    "uncertain": "Locating…"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -212,5 +212,11 @@
     "boundFor": "{{name}}行き",
     "innerLoop": "内回り",
     "outerLoop": "外回り"
+  },
+  "source": {
+    "positionTrain": "列車データ",
+    "routeProgress": "経路推定",
+    "gpsOnly": "GPS推定",
+    "uncertain": "位置確認中"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -212,5 +212,11 @@
     "boundFor": "{{name}}행",
     "innerLoop": "내선순환",
     "outerLoop": "외선순환"
+  },
+  "source": {
+    "positionTrain": "열차 데이터",
+    "routeProgress": "경로 추정",
+    "gpsOnly": "GPS 추정",
+    "uncertain": "위치 확인 중"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -212,5 +212,11 @@
     "boundFor": "开往{{name}}",
     "innerLoop": "内环",
     "outerLoop": "外环"
+  },
+  "source": {
+    "positionTrain": "列车数据",
+    "routeProgress": "路径推算",
+    "gpsOnly": "GPS推算",
+    "uncertain": "定位中"
   }
 }

--- a/src/theme/__tests__/colorUtils.test.ts
+++ b/src/theme/__tests__/colorUtils.test.ts
@@ -1,0 +1,24 @@
+import { withAlpha } from '../colorUtils';
+
+describe('withAlpha', () => {
+  it('#RRGGBB hex를 rgba 문자열로 변환', () => {
+    expect(withAlpha('#22c55e', 0.13)).toBe('rgba(34, 197, 94, 0.13)');
+  });
+
+  it('대문자 hex도 처리', () => {
+    expect(withAlpha('#FF9F43', 0.5)).toBe('rgba(255, 159, 67, 0.5)');
+  });
+
+  it('hex 외 포맷(rgba)은 원본 그대로 반환 — 시각적 회귀 방지', () => {
+    expect(withAlpha('rgba(0,0,0,0.4)', 0.5)).toBe('rgba(0,0,0,0.4)');
+  });
+
+  it('shorthand hex(#abc)는 미지원 → 원본 반환', () => {
+    expect(withAlpha('#abc', 0.5)).toBe('#abc');
+  });
+
+  it('alpha=0 / alpha=1 모두 표현', () => {
+    expect(withAlpha('#000000', 0)).toBe('rgba(0, 0, 0, 0)');
+    expect(withAlpha('#ffffff', 1)).toBe('rgba(255, 255, 255, 1)');
+  });
+});

--- a/src/theme/colorUtils.ts
+++ b/src/theme/colorUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * #RRGGBB hex 토큰에 alpha를 입혀 rgba 문자열로 변환한다.
+ * hex 외 포맷(rgba, hsl 등)이면 원본을 그대로 반환해 시각적 회귀를 막는다.
+ *
+ * 단순 문자열 연결(`color + '22'`)은 토큰 포맷이 바뀌면 잘못된 색을 조용히
+ * 생성하므로 모든 alpha 합성은 이 헬퍼를 거친다.
+ */
+export function withAlpha(hex: string, alpha: number): string {
+  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!m) return hex;
+  const r = parseInt(m[1], 16);
+  const g = parseInt(m[2], 16);
+  const b = parseInt(m[3], 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,4 @@
 export { colors, lightColors, darkColors, font, typography, spacing, radius } from './theme';
 export type { ThemeColors } from './theme';
 export { ThemeProvider, useTheme } from './ThemeContext';
+export { withAlpha } from './colorUtils';


### PR DESCRIPTION
## Summary
- `useFusedNearestStation`의 `source`/`locationUncertain`을 홈 현재역 카드에 자백 배지로 노출
- 21:29 효창공원앞↔신내 같은 false-positive 사고 시 사용자가 데이터 출처를 즉시 확인 가능
- Phase B uncertainty UI 3 PR 중 첫 번째 (홈)

## Changes
- `SourceBadge` 컴포넌트 신규 — FusionSource 5종을 사용자 친화 3그룹(`positionTrain`/`routeProgress`/`gpsOnly`)으로 매핑, `locationUncertain` 오버라이드
- `withAlpha` 헬퍼 (`src/theme/colorUtils.ts`) — hex+alpha 합성을 안전한 rgba 변환으로 통일
- 홈 `app/(tabs)/index.tsx` `metaRow`에 배지 통합. `isCustomOrigin` 시 숨김
- 기존 `__DEV__` 디버그 텍스트(`testID="home-fusion-source-badge"`)는 별도 유지
- i18n: `source.{positionTrain, routeProgress, gpsOnly, uncertain}` × 4언어

## Test plan
- [x] `npm test` — 1689 tests pass, 커버리지 100%
- [x] `npm run type-check` — pass
- [x] code-reviewer 에이전트 리뷰 통과 (P1 없음, P2 2건 반영, P3 1건 반영)
- [ ] 실기기 회귀: 홈 화면에서 source별 배지 렌더 확인
- [ ] 다크모드 시각 확인

## Follow-up
- P2-3 (`hair` 토큰 시맨틱 불일치)는 색상 시스템에 `surfaceSubtle` 토큰 도입이 필요해 별도 이슈로 분리 예정
- PR 2 (지도 사용자 정확도 원), PR 3 (BG/LA/위젯/알람 본문 source 라벨)이 Phase B 후속

Closes #327