### PR TITLE
feat(#327): 지도 사용자 위치에 GPS 정확도 원 표시

### DIFF
--- a/__mocks__/react-native-maps.js
+++ b/__mocks__/react-native-maps.js
@@ -24,6 +24,9 @@ const MarkerAnimated = ({ testID, onPress, children, ...props }) =>
 const Polyline = ({ testID, ...props }) =>
   React.createElement(View, { testID, ...props });
 
+const Circle = ({ testID, ...props }) =>
+  React.createElement(View, { testID, ...props });
+
 class AnimatedRegion {
   constructor(region) {
     this._region = region;
@@ -40,6 +43,7 @@ module.exports = {
   Marker,
   MarkerAnimated,
   Polyline,
+  Circle,
   AnimatedRegion,
   PROVIDER_DEFAULT: null,
   __fitToCoordinatesMock: fitToCoordinatesMock,

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -20,7 +20,7 @@ import { ROUTE_KEY } from '../../src/constants/storageKeys';
 import type { Station } from '../../src/types/station';
 
 export default function MapScreen() {
-  const { userLocation, result, loading, error, permissionDenied, refresh } =
+  const { userLocation, result, loading, error, permissionDenied, refresh, accuracyMeters, locationUncertain } =
     useNearestStation();
   const allStations = stationsData as Station[];
   const { colors } = useTheme();
@@ -116,6 +116,8 @@ export default function MapScreen() {
         focusNonce={focusNonce}
         recenterNonce={recenterNonce}
         routeCoords={routeCoords}
+        accuracyMeters={accuracyMeters}
+        locationUncertain={locationUncertain}
       />
 
       <TouchableOpacity

--- a/src/components/StationMap.tsx
+++ b/src/components/StationMap.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Platform, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import MapView, { Marker, Polyline, PROVIDER_DEFAULT } from 'react-native-maps';
+import MapView, { Circle, Marker, Polyline, PROVIDER_DEFAULT } from 'react-native-maps';
 import type { Station } from '../types/station';
 import type { RouteCoordinatePath } from '../utils/routeToCoordinates';
 import { buildMapConfig } from '../utils/buildMapConfig';
-import { useTheme } from '../theme';
+import { useTheme, withAlpha } from '../theme';
 import { LINE_BADGE_LABEL } from '../constants/lineColors';
 import { getStationDisplayName } from '../utils/stationDisplay';
 
@@ -26,7 +26,14 @@ interface StationMapProps {
   recenterNonce?: number;
   /** 선택된 경로의 폴리라인 좌표 + 강조 마커. 있으면 지도에 오버레이로 표시. */
   routeCoords?: RouteCoordinatePath | null;
+  /** GPS 정확도 반경(m). 있으면 사용자 좌표 위에 신뢰도 원으로 표시. */
+  accuracyMeters?: number | null;
+  /** GPS 게이트 실패로 위치가 불확실한 상태. true면 원을 회색/투명도↓로 자백. */
+  locationUncertain?: boolean;
 }
+
+const ACCURACY_MIN_RADIUS_M = 10;
+const ACCURACY_STROKE_WIDTH = 1;
 
 const FOCUS_REGION_DELTA = 0.01;
 const FOCUS_ANIMATION_MS = 400;
@@ -50,6 +57,8 @@ export function StationMap({
   focusNonce,
   recenterNonce,
   routeCoords,
+  accuracyMeters,
+  locationUncertain = false,
 }: StationMapProps) {
   const { colors } = useTheme();
   const { t, i18n } = useTranslation();
@@ -144,6 +153,24 @@ export function StationMap({
         showsPointsOfInterest={Platform.OS === 'ios' ? false : undefined}
         testID="station-map"
       >
+        {/* 정확도 원을 마커보다 먼저 렌더 — 큰 반경에서 마커 탭 인식을 가리지 않도록.
+            accuracyMeters는 useNearestStation에서 마지막 정상 fix 기준 값을 유지하므로
+            locationUncertain일 때도 직전 반경을 muted 색으로 표시해 자백 효과를 낸다. */}
+        {accuracyMeters != null && accuracyMeters > 0 && (
+          <Circle
+            center={{ latitude: userLat, longitude: userLng }}
+            radius={Math.max(accuracyMeters, ACCURACY_MIN_RADIUS_M)}
+            strokeColor={
+              locationUncertain ? colors.muted : withAlpha(colors.accent, 0.6)
+            }
+            strokeWidth={ACCURACY_STROKE_WIDTH}
+            fillColor={withAlpha(
+              locationUncertain ? colors.muted : colors.accent,
+              locationUncertain ? 0.06 : 0.12,
+            )}
+            testID="accuracy-circle"
+          />
+        )}
         {visibleGroups.map((group) => {
           // 대표 station = representativeName과 동일한 name을 가진 멤버.
           // representativeName은 멤버 중에서 뽑은 값이므로 find는 항상 매치.

--- a/src/components/StationMap.web.tsx
+++ b/src/components/StationMap.web.tsx
@@ -12,6 +12,10 @@ interface StationMapProps {
   userLng: number;
   nearestStation: Station | null;
   nearbyStations: Station[];
+  // 네이티브 StationMap과 props 인터페이스 호환을 위해 선언만 미러한다.
+  // web fallback은 리스트 UI라 정확도 원/uncertain 시각 변경 없음.
+  accuracyMeters?: number | null;
+  locationUncertain?: boolean;
 }
 
 export function StationMap({ userLat, userLng, nearestStation, nearbyStations }: StationMapProps) {

--- a/src/components/__tests__/StationMap.test.tsx
+++ b/src/components/__tests__/StationMap.test.tsx
@@ -700,4 +700,67 @@ describe('StationMap', () => {
       );
     });
   });
+
+  describe('accuracy circle (#327)', () => {
+    it('accuracyMeters 미전달 시 정확도 원 렌더 안 함', () => {
+      const { queryByTestId } = render(<StationMap {...baseProps} />);
+      expect(queryByTestId('accuracy-circle')).toBeNull();
+    });
+
+    it('accuracyMeters=null 시 정확도 원 렌더 안 함', () => {
+      const { queryByTestId } = render(
+        <StationMap {...baseProps} accuracyMeters={null} />,
+      );
+      expect(queryByTestId('accuracy-circle')).toBeNull();
+    });
+
+    it('accuracyMeters=0 시 정확도 원 렌더 안 함', () => {
+      const { queryByTestId } = render(
+        <StationMap {...baseProps} accuracyMeters={0} />,
+      );
+      expect(queryByTestId('accuracy-circle')).toBeNull();
+    });
+
+    it('accuracyMeters>0 시 사용자 좌표에 원을 그린다', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} accuracyMeters={50} />,
+      );
+      const circle = getByTestId('accuracy-circle');
+      expect(circle.props.center).toEqual({
+        latitude: baseProps.userLat,
+        longitude: baseProps.userLng,
+      });
+      expect(circle.props.radius).toBe(50);
+    });
+
+    it('accuracyMeters<10 일 때 최소 반경 10m로 클램프', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} accuracyMeters={3} />,
+      );
+      expect(getByTestId('accuracy-circle').props.radius).toBe(10);
+    });
+
+    it('기본(locationUncertain=false) 시 accent 톤으로 표시', () => {
+      const { getByTestId } = render(
+        <StationMap {...baseProps} accuracyMeters={100} />,
+      );
+      const circle = getByTestId('accuracy-circle');
+      expect(circle.props.strokeColor).toBe('rgba(200, 85, 61, 0.6)');
+      expect(circle.props.fillColor).toBe('rgba(200, 85, 61, 0.12)');
+    });
+
+    it('locationUncertain=true 시 muted 회색 + 더 옅은 fill로 자백', () => {
+      const { getByTestId } = render(
+        <StationMap
+          {...baseProps}
+          accuracyMeters={100}
+          locationUncertain={true}
+        />,
+      );
+      const circle = getByTestId('accuracy-circle');
+      expect(circle.props.strokeColor).toBe('#6B6459');
+      expect(circle.props.fillColor).toBe('rgba(107, 100, 89, 0.06)');
+    });
+
+  });
 });


### PR DESCRIPTION
## Summary
- 지도 탭 사용자 위치에 GPS `accuracyMeters` 반경으로 Circle 표시 — 좌표 신뢰도를 시각적으로 자백
- `locationUncertain=true` 시 muted 회색 + 옅은 fill로 GPS 불확실 상태 명시
- Phase B uncertainty UI 3 PR 중 두 번째 (지도)

## Changes
- `src/components/StationMap.tsx` — `Circle` import, `accuracyMeters?` / `locationUncertain?` props 추가, MapView 최상단에 Circle 렌더
- `app/(tabs)/map.tsx` — `useNearestStation`의 `accuracyMeters`/`locationUncertain` 전달
- `src/components/StationMap.web.tsx` — props 인터페이스 미러 (web fallback은 리스트 UI라 시각 변경 없음)
- `__mocks__/react-native-maps.js` — `Circle` mock 추가
- 테스트 7케이스: 미전달/null/0/정상/최소클램프/기본색상/uncertain색상

## Design notes
- 최소 반경 10m 클램프 — 도심 GPS 5~15m 범위에서 점으로 수렴 방지
- Circle을 Markers보다 먼저 렌더 — 큰 반경에서 마커 탭 가리지 않게 z-order 조정
- PR 1의 `withAlpha` 헬퍼 재사용으로 일관된 alpha 합성

## Test plan
- [x] `npm test` — 1696 tests pass, 커버리지 100%
- [x] `npm run type-check` — pass
- [x] code-reviewer 에이전트 리뷰 (P1 없음, P2 2건 반영)
- [ ] 실기기 회귀: 지하/지상/실내 정확도별 원 크기/색 확인
- [ ] uncertain 상태에서 muted 색 전환 확인

Closes #327