### PR TITLE
feat(#327): BG/LA/푸시 본문에 데이터 출처 라벨 자백

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -160,6 +160,8 @@ export default function HomeScreen() {
     speedMps,
     accuracyMeters,
     arrivalConfidence: confidence,
+    fusionSource: source,
+    locationUncertain,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -30,6 +30,9 @@ export interface LiveActivityData {
   etaText?: string;
   etaSubtext?: string;
   distanceText?: string;
+  // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드해 전달.
+  // 누락 시 위젯/LA는 라벨 표시 생략 — 기존 인스턴스 호환 안전.
+  sourceLabel?: string;
 }
 
 const LiveActivityModule =

--- a/modules/live-activity/ios/SubwayActivityAttributes.swift
+++ b/modules/live-activity/ios/SubwayActivityAttributes.swift
@@ -32,6 +32,9 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var etaText: String?
         var etaSubtext: String?
         var distanceText: String?
+        // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드된 사용자 노출 텍스트.
+        // 누락 시 위젯은 라벨 표시 생략 — 기존 LA 인스턴스 호환 안전.
+        var sourceLabel: String?
     }
 }
 #endif

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,11 +5,13 @@ sonar.organization=handokei
 sonar.sources=src,app
 
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, i18n 번역 데이터)
-sonar.exclusions=assets/**,**/__tests__/**,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/i18n/locales/**
+# 디렉토리 패턴 + 파일 패턴 모두 명시 — SonarCloud가 일부 경로에서 디렉토리 와일드카드를
+# 제대로 적용하지 못하는 케이스를 대비해 *.test.ts(x) 파일 단위 패턴도 추가한다.
+sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/i18n/locales/**
 
 # 중복 분석 제외 — Swift 파일은 sonar.sources(src,app) 밖이라 분석 대상이 아니지만
 # CPD는 별도 패스로 동작할 수 있어 명시적으로 전체 Swift를 CPD에서 제외.
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**,**/__tests__/**
+sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx

--- a/src/components/SourceBadge.tsx
+++ b/src/components/SourceBadge.tsx
@@ -3,6 +3,11 @@ import { StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useTheme, spacing, radius, withAlpha } from '../theme';
 import type { FusionSource } from '../utils/pickFusedStation';
+import {
+  resolveNotificationSource,
+  notificationSourceI18nKey,
+  type NotificationSource,
+} from '../utils/notificationSource';
 
 interface SourceBadgeProps {
   source: FusionSource;
@@ -10,35 +15,12 @@ interface SourceBadgeProps {
   testID?: string;
 }
 
-type BadgeKey = 'positionTrain' | 'routeProgress' | 'gpsOnly' | 'uncertain';
-
-// position/arrival은 모두 열차 데이터 기반이라 동일 그룹으로 묶는다.
-// 사용자에겐 "데이터 출처의 신뢰도"가 의미 있고, 내부 fusion 알고리즘 구분은 의미 없음.
-function resolveBadgeKey(source: FusionSource, locationUncertain: boolean): BadgeKey {
-  if (locationUncertain) return 'uncertain';
-  switch (source) {
-    case 'position-train':
-    case 'position':
-    case 'arrival':
-      return 'positionTrain';
-    case 'route-progress':
-      return 'routeProgress';
-    case 'gps':
-      return 'gpsOnly';
-    /* istanbul ignore next -- FusionSource 유니온이 위 case와 동기화되므로 도달 불가. 새 값 추가 시 컴파일 타임에 잡힘 */
-    default: {
-      const _exhaustive: never = source;
-      return _exhaustive;
-    }
-  }
-}
-
 export function SourceBadge({ source, locationUncertain = false, testID }: SourceBadgeProps) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const key = resolveBadgeKey(source, locationUncertain);
+  const key = resolveNotificationSource(source, locationUncertain);
 
-  const palette: Record<BadgeKey, { bg: string; fg: string }> = {
+  const palette: Record<NotificationSource, { bg: string; fg: string }> = {
     positionTrain: { bg: withAlpha(colors.success, 0.13), fg: colors.success },
     routeProgress: { bg: colors.hair, fg: colors.ink },
     gpsOnly: { bg: withAlpha(colors.warn, 0.13), fg: colors.warn },
@@ -48,7 +30,7 @@ export function SourceBadge({ source, locationUncertain = false, testID }: Sourc
 
   return (
     <View style={[styles.badge, { backgroundColor: bg }]} testID={testID}>
-      <Text style={[styles.label, { color: fg }]}>{t(`source.${key}`)}</Text>
+      <Text style={[styles.label, { color: fg }]}>{t(notificationSourceI18nKey(key))}</Text>
     </View>
   );
 }

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -316,7 +316,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true),
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true, undefined),
     );
   });
 
@@ -331,6 +331,7 @@ describe('useStationAlarm', () => {
         { ...earlyDest, direction: 'up' },
         false,
         true,
+        undefined,
       ),
     );
   });
@@ -347,7 +348,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true),
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true, undefined),
     );
   });
 
@@ -363,7 +364,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true),
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true, undefined),
     );
   });
 
@@ -388,7 +389,7 @@ describe('useStationAlarm', () => {
       },
     );
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(earlyDest, false, true),
+      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(earlyDest, false, true, undefined),
     );
 
     mockEvaluateAlarmPhase.mockReturnValueOnce(imminentDest);
@@ -396,7 +397,7 @@ describe('useStationAlarm', () => {
       inputs: defaultInputs({ route, destination, userLocation: { lat: 37.49, lng: 127.025 }, speedMps: 20 }),
     });
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(imminentDest, false, true),
+      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(imminentDest, false, true, undefined),
     );
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
   });
@@ -415,7 +416,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(altEvent);
     rerender({ dest: altDestination });
     await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2));
-    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(altEvent, false, true);
+    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(altEvent, false, true, undefined);
     // destination 변경 → 새 id로 storage 재읽기 (저장된 entry는 옛 destinationId라 빈 set 반환 → 자동 isolation).
     expect(mockGetFiredAlarms).toHaveBeenCalledWith(altDestination.id);
   });
@@ -426,7 +427,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, true, true),
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, true, true, undefined),
     );
   });
 
@@ -453,7 +454,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, false),
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, false, undefined),
     );
   });
 
@@ -490,7 +491,7 @@ describe('useStationAlarm', () => {
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
 
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', directTarget);
+        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', directTarget, undefined);
       });
       expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('S1');
     });
@@ -535,7 +536,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => {
         expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
       });
-      expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', nextTarget);
+      expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', nextTarget, undefined);
     });
 
     it('does not fire when nearestStation is null', () => {
@@ -566,7 +567,7 @@ describe('useStationAlarm', () => {
       mockResolveNextTarget.mockReturnValue(null);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', null);
+        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', null, undefined);
       });
     });
 
@@ -686,7 +687,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => {
         expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
       });
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('서울', '강남', transferTarget);
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('서울', '강남', transferTarget, undefined);
     });
 
     it('알림 발송 후에만 notificationState에 저장한다 (실패 시 재시도 가능)', async () => {
@@ -764,7 +765,7 @@ describe('useStationAlarm', () => {
         expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
       });
       // 처음 두 IIFE는 cancelled 가드에 막혀 마지막(A) 한 번만 알림 발사
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남A', '강남', directTarget);
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남A', '강남', directTarget, undefined);
     });
 
     it('cancel 플래그: read 완료 전 언마운트되면 알림을 발송하지 않는다', async () => {
@@ -1099,6 +1100,7 @@ describe('useStationAlarm', () => {
           expect.objectContaining({ direction: 'up' }),
           expect.anything(),
           expect.anything(),
+          undefined,
         );
       });
     });
@@ -1166,6 +1168,65 @@ describe('useStationAlarm', () => {
       const callCountBefore = mockGetStoredTripTrainCode.mock.calls.length;
       await Promise.resolve();
       expect(mockGetStoredTripTrainCode.mock.calls.length).toBe(callCountBefore);
+    });
+  });
+
+  describe('fusionSource 라벨 전파 (#327)', () => {
+    it('fusionSource=gps 전달 시 sendAlarmNotification에 gpsOnly가 4번째 인자로 전달된다', async () => {
+      const route: DirectRoute = { type: 'direct', line: '2', stops: 5 };
+      const destination = makeStation('D1', '강남');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(defaultInputs({ route, destination, fusionSource: 'gps' })),
+      );
+      await waitFor(() =>
+        expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true, 'gpsOnly'),
+      );
+    });
+
+    it('locationUncertain=true 전달 시 source 무시하고 uncertain 전달', async () => {
+      const route: DirectRoute = { type: 'direct', line: '2', stops: 5 };
+      const destination = makeStation('D1', '강남');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({ route, destination, fusionSource: 'position-train', locationUncertain: true }),
+        ),
+      );
+      await waitFor(() =>
+        expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true, 'uncertain'),
+      );
+    });
+
+    it('역 통과 알림에도 notificationSource가 전달된다', async () => {
+      const route: DirectRoute = { type: 'direct', line: '2', stops: 5 };
+      const destination = makeStation('D1', '강남');
+      const station = makeStation('S1', '역삼');
+      const directTarget = {
+        nextStationName: '강남',
+        stopsToNextStation: 5,
+        isTransfer: false,
+        stopsToDestination: 5,
+      };
+      mockResolveNextTarget.mockReturnValue(directTarget);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            fusionSource: 'route-progress',
+          }),
+        ),
+      );
+      await waitFor(() =>
+        expect(mockSendStationPassedNotification).toHaveBeenCalledWith(
+          '역삼',
+          '강남',
+          directTarget,
+          'routeProgress',
+        ),
+      );
     });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -25,7 +25,8 @@ import {
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 import { isAccuracyAcceptable } from '../utils/locationGates';
-import type { FusionConfidence } from '../utils/pickFusedStation';
+import type { FusionConfidence, FusionSource } from '../utils/pickFusedStation';
+import { resolveNotificationSource } from '../utils/notificationSource';
 
 const logger = createLogger('StationAlarm');
 
@@ -42,6 +43,11 @@ export interface UseStationAlarmInputs {
    * (accuracy > 200m) 알람 누락 해소. ETA 기반 phase 알람은 거리 계산이 필요해 GPS 게이트 유지.
    */
   arrivalConfidence?: FusionConfidence;
+  /** 사용자 노출 알람 본문에 부착할 데이터 출처 (#327).
+   *  useFusedNearestStation의 source를 그대로 전달. 미지정 시 라벨 부착 안 함. */
+  fusionSource?: FusionSource;
+  /** GPS 게이트 실패 등으로 위치 불확실. true면 source 무시하고 'uncertain' 라벨. */
+  locationUncertain?: boolean;
 }
 
 export function useStationAlarm({
@@ -52,6 +58,8 @@ export function useStationAlarm({
   speedMps,
   accuracyMeters,
   arrivalConfidence,
+  fusionSource,
+  locationUncertain = false,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   // firedAlarms hydration: BG가 AsyncStorage(FIRED_ALARMS_KEY)에 쓴 dedup 상태를
@@ -143,7 +151,10 @@ export function useStationAlarm({
     if (sleepModeRef.current) {
       setAlarmEvent(event);
     }
-    sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current).catch((e) =>
+    const notificationSource = fusionSource
+      ? resolveNotificationSource(fusionSource, locationUncertain)
+      : undefined;
+    sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current, notificationSource).catch((e) =>
       logger.error('알람 알림 실패:', e),
     );
     logFiredAlarm('fg', event, trigger);
@@ -251,11 +262,15 @@ export function useStationAlarm({
             return;
           }
           const target = resolveNextTarget(capturedRoute, capturedDestinationName);
+          const notificationSource = fusionSource
+            ? resolveNotificationSource(fusionSource, locationUncertain)
+            : undefined;
           // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
           await sendStationPassedNotification(
             candidateStation.name,
             capturedDestinationName,
             target,
+            notificationSource,
           );
           if (cancelled) return;
           await setLastNotifiedStationId(candidateStation.id);

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { isStationOnRoute } from '../utils/stationRoute';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
@@ -76,6 +76,11 @@ export function useStationAlarm({
   // 트립에 lock된 사용자 열차 코드. AsyncStorage에서 비동기 로드. lock 실패 상태(null)면
   // API 신호 평가는 보수적으로 false 반환 — 잘못된 train으로 imminent 오발사 방지.
   const [trackedTrainCode, setTrackedTrainCode] = useState<string | null>(null);
+  // fusion source → 알람 본문 라벨. 두 effect(phase / station-passed)가 공유.
+  const notificationSource = useMemo(
+    () => (fusionSource ? resolveNotificationSource(fusionSource, locationUncertain) : undefined),
+    [fusionSource, locationUncertain],
+  );
   const sleepMode = useAppStore((s) => s.sleepMode);
   const allowSpeaker = useAppStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
@@ -151,9 +156,6 @@ export function useStationAlarm({
     if (sleepModeRef.current) {
       setAlarmEvent(event);
     }
-    const notificationSource = fusionSource
-      ? resolveNotificationSource(fusionSource, locationUncertain)
-      : undefined;
     sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current, notificationSource).catch((e) =>
       logger.error('알람 알림 실패:', e),
     );
@@ -262,9 +264,6 @@ export function useStationAlarm({
             return;
           }
           const target = resolveNextTarget(capturedRoute, capturedDestinationName);
-          const notificationSource = fusionSource
-            ? resolveNotificationSource(fusionSource, locationUncertain)
-            : undefined;
           // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
           await sendStationPassedNotification(
             candidateStation.name,

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -317,7 +317,7 @@ describe('silentPushTask', () => {
 
       const call = mockScheduleNotificationAsync.mock.calls[0][0];
       expect(call.content.title).toBe('route.intermediatePassedTitle');
-      expect(call.content.body).toBe('route.intermediatePassedBody:중곡');
+      expect(call.content.body).toBe('route.intermediatePassedBody:중곡 · source.positionTrain');
       expect(mockGetFiredAlarms).not.toHaveBeenCalled();
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
       expect(mockLogSilentPushFired).toHaveBeenCalledWith(

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -39,11 +39,12 @@ jest.mock('../../utils/notificationState', () => ({
   setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
 }));
 
+const mockBuildAlarmContent = jest.fn((event: { stationName: string; type: string; phaseId: string }, _source?: string) => ({
+  title: `[${event.type}/${event.phaseId}]`,
+  body: `${event.stationName} 알람`,
+}));
 jest.mock('../../utils/stationNotification', () => ({
-  buildAlarmContent: (event: { stationName: string; type: string; phaseId: string }) => ({
-    title: `[${event.type}/${event.phaseId}]`,
-    body: `${event.stationName} 알람`,
-  }),
+  buildAlarmContent: (...args: unknown[]) => mockBuildAlarmContent(...(args as Parameters<typeof mockBuildAlarmContent>)),
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -310,6 +311,14 @@ describe('silentPushTask', () => {
       expect(mockSetFiredAlarms).toHaveBeenCalledTimes(1);
       const [, savedSet] = mockSetFiredAlarms.mock.calls[0];
       expect(Array.from(savedSet as Set<string>)).toEqual(['imminent:강남']);
+    });
+
+    it('alarm 경로(destination/transfer)는 buildAlarmContent에 positionTrain source 전달 (#327)', async () => {
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockBuildAlarmContent).toHaveBeenCalledWith(
+        expect.objectContaining({ phaseId: 'imminent', type: 'destination' }),
+        'positionTrain',
+      );
     });
 
     it('intermediate는 i18n key로 본문 생성 + FIRED_ALARMS dedup 안 씀', async () => {

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -126,6 +126,9 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       storedRoute,
       speedMps,
       source: 'bg',
+      // BG task는 fusion을 쓰지 않고 raw GPS만 처리 → 사용자에게 'GPS 추정'을 자백.
+      // 실제 BG에서 train data를 쓰게 되면 caller에서 'position-train'으로 바꾼다.
+      fusionSource: 'gps',
     });
 
     if (alarmEvent) {

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -35,11 +35,11 @@ import {
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
 import { buildAlarmContent } from '../utils/stationNotification';
 import { notificationSourceI18nKey, type NotificationSource } from '../utils/notificationSource';
+import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 
 // silent push는 서버가 train data 기반으로 발사하므로 라벨도 'positionTrain'으로 고정.
 // 향후 GPS 게이트 경로 등 다른 출처가 생기면 인자화 한다.
 const SILENT_PUSH_SOURCE: NotificationSource = 'positionTrain';
-import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 
 const logger = createLogger('SilentPushTask');
 

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -34,6 +34,11 @@ import {
 } from '../utils/silentPushLocationGate';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
 import { buildAlarmContent } from '../utils/stationNotification';
+import { notificationSourceI18nKey, type NotificationSource } from '../utils/notificationSource';
+
+// silent push는 서버가 train data 기반으로 발사하므로 라벨도 'positionTrain'으로 고정.
+// 향후 GPS 게이트 경로 등 다른 출처가 생기면 인자화 한다.
+const SILENT_PUSH_SOURCE: NotificationSource = 'positionTrain';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 
 const logger = createLogger('SilentPushTask');
@@ -107,9 +112,10 @@ function mapGateReason(reason: GateSkipReason): AlarmLogReason {
  * buildAlarmContent를 못 쓰고 별도 i18n 키로 빌드한다.
  */
 function buildIntermediateContent(stationName: string): { title: string; body: string } {
+  const body = i18next.t('route.intermediatePassedBody', { name: stationName });
   return {
     title: i18next.t('route.intermediatePassedTitle'),
-    body: i18next.t('route.intermediatePassedBody', { name: stationName }),
+    body: `${body} · ${i18next.t(notificationSourceI18nKey(SILENT_PUSH_SOURCE))}`,
   };
 }
 
@@ -209,11 +215,14 @@ async function fireWithGate(
   const content =
     payload.kind === 'intermediate'
       ? buildIntermediateContent(payload.nextWaypoint)
-      : buildAlarmContent({
-          phaseId: payload.phase,
-          type: payload.kind,
-          stationName: payload.nextWaypoint,
-        } as AlarmEvent);
+      : buildAlarmContent(
+          {
+            phaseId: payload.phase,
+            type: payload.kind,
+            stationName: payload.nextWaypoint,
+          } as AlarmEvent,
+          SILENT_PUSH_SOURCE,
+        );
 
   await Notifications.scheduleNotificationAsync({
     content: { title: content.title, body: content.body },

--- a/src/utils/__tests__/notificationSource.test.ts
+++ b/src/utils/__tests__/notificationSource.test.ts
@@ -1,0 +1,45 @@
+import {
+  resolveNotificationSource,
+  notificationSourceI18nKey,
+} from '../notificationSource';
+
+describe('resolveNotificationSource', () => {
+  it('position-train → positionTrain', () => {
+    expect(resolveNotificationSource('position-train')).toBe('positionTrain');
+  });
+
+  it('position(fused) → positionTrain 그룹', () => {
+    expect(resolveNotificationSource('position')).toBe('positionTrain');
+  });
+
+  it('arrival(fused) → positionTrain 그룹', () => {
+    expect(resolveNotificationSource('arrival')).toBe('positionTrain');
+  });
+
+  it('route-progress → routeProgress', () => {
+    expect(resolveNotificationSource('route-progress')).toBe('routeProgress');
+  });
+
+  it('gps → gpsOnly', () => {
+    expect(resolveNotificationSource('gps')).toBe('gpsOnly');
+  });
+
+  it('locationUncertain=true → source와 무관하게 uncertain', () => {
+    expect(resolveNotificationSource('position-train', true)).toBe('uncertain');
+    expect(resolveNotificationSource('gps', true)).toBe('uncertain');
+    expect(resolveNotificationSource('route-progress', true)).toBe('uncertain');
+  });
+
+  it('locationUncertain 기본값 false', () => {
+    expect(resolveNotificationSource('gps')).toBe('gpsOnly');
+  });
+});
+
+describe('notificationSourceI18nKey', () => {
+  it('source. prefix 부착', () => {
+    expect(notificationSourceI18nKey('positionTrain')).toBe('source.positionTrain');
+    expect(notificationSourceI18nKey('routeProgress')).toBe('source.routeProgress');
+    expect(notificationSourceI18nKey('gpsOnly')).toBe('source.gpsOnly');
+    expect(notificationSourceI18nKey('uncertain')).toBe('source.uncertain');
+  });
+});

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -424,6 +424,29 @@ describe('stationNotification', () => {
         expect.not.objectContaining({ alarmType: expect.anything() })
       );
     });
+
+    it('source 인자 전달 시 sourceLabel을 i18n 빌드해 LA 데이터에 포함 (#327)', async () => {
+      await updateStationNotification(
+        mockStation,
+        154,
+        mockDestination,
+        directRoute,
+        12,
+        false,
+        null,
+        'gpsOnly',
+      );
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceLabel: 'GPS 추정' }),
+      );
+    });
+
+    it('source 미지정 시 sourceLabel은 포함되지 않음 (호환 안전)', async () => {
+      await updateStationNotification(mockStation, 154, mockDestination, directRoute);
+      expect(mockUpdateLiveActivity).toHaveBeenCalledWith(
+        expect.not.objectContaining({ sourceLabel: expect.anything() }),
+      );
+    });
   });
 
   describe('updateStationNotification (Android - expo-notifications)', () => {

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -8,6 +8,7 @@ import {
   sendAlarmNotification,
   clearAlarmNotification,
   sendStationPassedNotification,
+  buildAlarmContent,
 } from '../stationNotification';
 import { Station } from '../../types/station';
 import { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
@@ -801,6 +802,76 @@ describe('stationNotification', () => {
       mockClearWidgetStation.mockRejectedValueOnce(new Error('group missing'));
       await clearStationNotification();
       expect(mockEndLiveActivity).toHaveBeenCalled();
+    });
+  });
+
+  describe('source 라벨 자백 (#327)', () => {
+    const earlyDest = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
+
+    it('sendAlarmNotification source=positionTrain → body 끝에 "열차 데이터" 부착', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest, false, true, 'positionTrain');
+      expectAlarmNotification(
+        '하차 알림',
+        '다음 역 강남에서 하차하세요! · 열차 데이터',
+        { interruptionLevel: 'timeSensitive' },
+      );
+    });
+
+    it('sendAlarmNotification source=gpsOnly → "GPS 추정" 부착', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest, false, true, 'gpsOnly');
+      expectAlarmNotification(
+        '하차 알림',
+        '다음 역 강남에서 하차하세요! · GPS 추정',
+        { interruptionLevel: 'timeSensitive' },
+      );
+    });
+
+    it('sendAlarmNotification source=uncertain → "위치 확인 중" 부착', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest, false, true, 'uncertain');
+      expectAlarmNotification(
+        '하차 알림',
+        '다음 역 강남에서 하차하세요! · 위치 확인 중',
+        { interruptionLevel: 'timeSensitive' },
+      );
+    });
+
+    it('sendAlarmNotification source 미지정 → 라벨 부착 안 함 (회귀 안전)', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendAlarmNotification(earlyDest);
+      expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!', { interruptionLevel: 'timeSensitive' });
+    });
+
+    it('sendStationPassedNotification source=gpsOnly → body 끝에 라벨 부착', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendStationPassedNotification('역삼', '강남', null, 'gpsOnly');
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-passed',
+        content: { title: '역삼역 도착', body: '현재 역삼역 · GPS 추정' },
+        trigger: null,
+      });
+    });
+
+    it('sendStationPassedNotification source 미지정 → 라벨 부착 안 함', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await sendStationPassedNotification('역삼', '강남', null);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        identifier: 'station-passed',
+        content: { title: '역삼역 도착', body: '현재 역삼역' },
+        trigger: null,
+      });
+    });
+
+    it('buildAlarmContent도 source 인자를 받아 body suffix 부착', () => {
+      const { body } = buildAlarmContent(earlyDest, 'routeProgress');
+      expect(body).toBe('다음 역 강남에서 하차하세요! · 경로 추정');
+    });
+
+    it('buildAlarmContent source 미지정 → suffix 없음', () => {
+      const { body } = buildAlarmContent(earlyDest);
+      expect(body).toBe('다음 역 강남에서 하차하세요!');
     });
   });
 });

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -147,7 +147,7 @@ describe('processLocationUpdate', () => {
 
     await call();
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, false, true);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, false, true, undefined);
   });
 
   it('passes sleepMode and allowSpeaker to sendAlarmNotification', async () => {
@@ -157,7 +157,7 @@ describe('processLocationUpdate', () => {
 
     await call({ sleepMode: true, allowSpeaker: false });
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, true, false);
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, true, false, undefined);
   });
 
   it('does not call sendAlarmNotification when no alarm', async () => {
@@ -291,7 +291,7 @@ describe('processLocationUpdate', () => {
       stopsToNextStation: 3,
       isTransfer: false,
       stopsToDestination: 3,
-    });
+    }, undefined);
     expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('station-1');
   });
 
@@ -318,7 +318,7 @@ describe('processLocationUpdate', () => {
       stopsToNextStation: 3,
       isTransfer: false,
       stopsToDestination: 3,
-    });
+    }, undefined);
     expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('station-1');
   });
 
@@ -434,6 +434,83 @@ describe('processLocationUpdate', () => {
       await call({ source: 'fg' });
 
       expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', mockAlarmEvent);
+    });
+  });
+
+  describe('fusionSource 라벨 전파 (#327)', () => {
+    it('fusionSource=gps → sendAlarmNotification에 gpsOnly 전달', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+      await call({ fusionSource: 'gps' });
+
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
+        mockAlarmEvent,
+        false,
+        true,
+        'gpsOnly',
+      );
+    });
+
+    it('fusionSource=position-train → positionTrain 전달', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+      await call({ fusionSource: 'position-train' });
+
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
+        mockAlarmEvent,
+        false,
+        true,
+        'positionTrain',
+      );
+    });
+
+    it('locationUncertain=true → source 무시하고 uncertain 전달', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+      await call({ fusionSource: 'position-train', locationUncertain: true });
+
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
+        mockAlarmEvent,
+        false,
+        true,
+        'uncertain',
+      );
+    });
+
+    it('fusionSource 미지정 → sendAlarmNotification에 source 전달 안 함 (4번째 인자 undefined)', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+      await call();
+
+      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
+        mockAlarmEvent,
+        false,
+        true,
+        undefined,
+      );
+    });
+
+    it('역 통과 알림에도 notificationSource가 전달된다', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+
+      await call({ fusionSource: 'route-progress' });
+
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith(
+        mockStation.name,
+        mockDestination.name,
+        expect.any(Object),
+        'routeProgress',
+      );
     });
   });
 });

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -182,6 +182,7 @@ describe('processLocationUpdate', () => {
       12,
       undefined,
       null,
+      undefined,
     );
   });
 
@@ -194,7 +195,7 @@ describe('processLocationUpdate', () => {
     await call({ sleepMode: true });
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 150, mockDestination, mockRoute, 10, undefined, mockAlarmEvent,
+      mockStation, 150, mockDestination, mockRoute, 10, undefined, mockAlarmEvent, undefined,
     );
   });
 
@@ -206,7 +207,7 @@ describe('processLocationUpdate', () => {
     await call();
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 150, mockDestination, mockRoute, 10, undefined, null,
+      mockStation, 150, mockDestination, mockRoute, 10, undefined, null, undefined,
     );
   });
 
@@ -239,7 +240,7 @@ describe('processLocationUpdate', () => {
     await call();
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 457, mockDestination, mockRoute, 5, undefined, null,
+      mockStation, 457, mockDestination, mockRoute, 5, undefined, null, undefined,
     );
   });
 
@@ -342,7 +343,7 @@ describe('processLocationUpdate', () => {
     const result = await call();
 
     expect(mockUpdateStationNotification).toHaveBeenCalledWith(
-      mockStation, 150, mockDestination, null, null, undefined, null,
+      mockStation, 150, mockDestination, null, null, undefined, null, undefined,
     );
     expect(result.nearest).toBe(mockNearestResult);
   });

--- a/src/utils/notificationSource.ts
+++ b/src/utils/notificationSource.ts
@@ -41,10 +41,12 @@ export function resolveNotificationSource(
   }
 }
 
+export type SourceI18nKey = `source.${NotificationSource}`;
+
 /**
- * i18n 키 prefix. caller가 t('source.' + key) 형태로 사용.
- * 예: i18next.t(`source.${key}`).
+ * i18n 키 prefix. caller가 t(notificationSourceI18nKey(key)) 형태로 사용.
+ * 반환 타입을 template literal union으로 좁혀 i18next strict 타입에 통과시킨다.
  */
-export function notificationSourceI18nKey(key: NotificationSource): string {
+export function notificationSourceI18nKey(key: NotificationSource): SourceI18nKey {
   return `source.${key}`;
 }

--- a/src/utils/notificationSource.ts
+++ b/src/utils/notificationSource.ts
@@ -1,0 +1,50 @@
+import type { FusionSource } from './pickFusedStation';
+
+/**
+ * 사용자에게 노출되는 데이터 출처 그룹 (#327 Phase B).
+ * FusionSource 5종을 4그룹으로 묶어 라벨/색에 일관되게 사용한다.
+ *
+ * - positionTrain: 열차 데이터 기반 (position-train / position / arrival)
+ * - routeProgress: 경로 진행 추정
+ * - gpsOnly: GPS 거리 기반 추정
+ * - uncertain: 위치 확인 중 (locationUncertain 우선)
+ */
+export type NotificationSource =
+  | 'positionTrain'
+  | 'routeProgress'
+  | 'gpsOnly'
+  | 'uncertain';
+
+/**
+ * FusionSource + locationUncertain → 사용자 노출 그룹 매핑.
+ * locationUncertain은 source를 덮어쓴다(가장 약한 신뢰도가 우선).
+ */
+export function resolveNotificationSource(
+  source: FusionSource,
+  locationUncertain: boolean = false,
+): NotificationSource {
+  if (locationUncertain) return 'uncertain';
+  switch (source) {
+    case 'position-train':
+    case 'position':
+    case 'arrival':
+      return 'positionTrain';
+    case 'route-progress':
+      return 'routeProgress';
+    case 'gps':
+      return 'gpsOnly';
+    /* istanbul ignore next -- FusionSource 유니온이 위 case와 동기화되므로 도달 불가. 새 값 추가 시 컴파일 타임에 잡힘 */
+    default: {
+      const _exhaustive: never = source;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * i18n 키 prefix. caller가 t('source.' + key) 형태로 사용.
+ * 예: i18next.t(`source.${key}`).
+ */
+export function notificationSourceI18nKey(key: NotificationSource): string {
+  return `source.${key}`;
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -16,6 +16,14 @@ import stationsData from '../data/stations.json';
 import type { ExitSide } from '../types/exitSide';
 import { lookupExitSide } from './exitSide';
 import { hasQuickExitData } from './quickExit';
+import { notificationSourceI18nKey, type NotificationSource } from './notificationSource';
+
+/** 알람/통과 본문 끝에 데이터 출처를 자백하는 라벨을 부착한다.
+ *  source 미지정 시 라벨 생략 — 기존 caller 회귀 안전. */
+function appendNotificationSource(body: string, source?: NotificationSource): string {
+  if (!source) return body;
+  return `${body} · ${i18next.t(notificationSourceI18nKey(source))}`;
+}
 
 const allStations = stationsData as Station[];
 
@@ -391,6 +399,7 @@ export async function sendStationPassedNotification(
   stationName: string,
   destinationName: string,
   target: NextTarget | null,
+  source?: NotificationSource,
 ): Promise<void> {
   // 사용자 노출 텍스트이므로 현재 언어로 변환. caller는 한글 역명을 그대로 전달.
   const displayStation = getStationDisplayNameByName(stationName, allStations);
@@ -411,6 +420,7 @@ export async function sendStationPassedNotification(
       count: target.stopsToDestination,
     });
   }
+  body = appendNotificationSource(body, source);
 
   await scheduleNotification(STATION_PASSED_NOTIFICATION_ID, {
     title: i18next.t('route.stationPassed', { name: displayStation }),
@@ -440,19 +450,24 @@ const ALARM_MESSAGE_BUILDERS: Record<AlarmPhaseId, (stationName: string, isTrans
   }),
 };
 
-export function buildAlarmContent(event: AlarmEvent): { title: string; body: string } {
+export function buildAlarmContent(
+  event: AlarmEvent,
+  source?: NotificationSource,
+): { title: string; body: string } {
   const { title, body } = ALARM_MESSAGE_BUILDERS[event.phaseId](event.stationName, event.type === 'transfer');
   const withSide = appendExitSide(body, resolveExitSide(event));
   const withHint = appendQuickHint(withSide, resolveQuickHint(event));
-  return { title, body: withHint };
+  const withSource = appendNotificationSource(withHint, source);
+  return { title, body: withSource };
 }
 
 export async function sendAlarmNotification(
   event: AlarmEvent,
   sleepMode: boolean = false,
   allowSpeaker: boolean = true,
+  source?: NotificationSource,
 ): Promise<void> {
-  const { title, body } = buildAlarmContent(event);
+  const { title, body } = buildAlarmContent(event, source);
 
   await scheduleNotification(ALARM_NOTIFICATION_ID, {
     title,

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -213,6 +213,7 @@ function buildLiveActivityData(
   etaMinutes?: number | null,
   isMock?: boolean,
   alarmEvent?: AlarmEvent | null,
+  source?: NotificationSource,
 ): LiveActivity.LiveActivityData {
   // station layer: 항상 포함. Live Activity는 사용자 노출이므로 현재 언어로 표시.
   const data: LiveActivity.LiveActivityData = {
@@ -273,6 +274,12 @@ function buildLiveActivityData(
     );
   }
 
+  // source 라벨도 JS에서 i18n으로 빌드해 native로 전달 (#327).
+  // alarmBody 등 다른 사용자 노출 텍스트와 동일 패턴.
+  if (source) {
+    data.sourceLabel = i18next.t(notificationSourceI18nKey(source));
+  }
+
   // 사용자 노출 텍스트 빌드 — Widget이 직접 조립하지 않도록 JS에서 미리 i18n.
   data.distanceText = i18next.t('route.approximateDistance', { m: distanceM });
   if (etaMinutes != null) {
@@ -326,6 +333,7 @@ export async function updateStationNotification(
   etaMinutes?: number | null,
   isMock?: boolean,
   alarmEvent?: AlarmEvent | null,
+  source?: NotificationSource,
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
 
@@ -344,7 +352,7 @@ export async function updateStationNotification(
       notifLogger.info('알림 예약 완료:', title, body);
       return;
     }
-    const data = buildLiveActivityData(currentStation, distanceM, destination, route, etaMinutes, isMock, alarmEvent);
+    const data = buildLiveActivityData(currentStation, distanceM, destination, route, etaMinutes, isMock, alarmEvent, source);
     try {
       liveActivityLogger.info('업데이트 요청');
       await LiveActivity.updateLiveActivity(data);

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -265,7 +265,9 @@ function buildLiveActivityData(
     const side = resolveExitSide(alarmEvent);
     const withSide = appendExitSide(rawBody, side);
     const hint = resolveQuickHint(alarmEvent);
-    data.alarmBody = appendQuickHint(withSide, hint);
+    // alarmBody에도 source suffix 부착 — Dynamic Island expanded 등 sourceLabel을
+    // 별도 표시하지 않는 표면에서도 출처를 자백한다 (sourceLabel은 비알람 상태용).
+    data.alarmBody = appendNotificationSource(appendQuickHint(withSide, hint), source);
     if (side) {
       data.alarmExitSide = side;
     }

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -182,6 +182,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     eta,
     undefined,
     sleepMode ? alarmEvent : null,
+    notificationSource,
   );
 
   return { alarmEvent, nearest };

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -14,6 +14,8 @@ import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
 import type { AlarmEvent } from './stationAlarm';
+import type { FusionSource } from './pickFusedStation';
+import { resolveNotificationSource } from './notificationSource';
 
 export interface NextTarget {
   nextStationName: string;
@@ -97,6 +99,12 @@ export interface ProcessLocationInputs {
   // 알람 로그 적재 시 발사 컨텍스트 — 호출자가 명시한다.
   // 기본값을 두지 않아 컴파일러가 컨텍스트 분류 누락을 잡도록 한다.
   source: AlarmLogSource;
+  /** 사용자 노출 알람 본문에 부착할 데이터 출처 (#327).
+   *  FG는 useFusedNearestStation의 source, BG는 'gps', silent push는 'position-train'.
+   *  미지정 시 라벨 부착 안 함 — 점진 적용 안전. */
+  fusionSource?: FusionSource;
+  /** GPS 게이트 실패 등으로 위치가 불확실한 상태. true면 source를 무시하고 'uncertain' 라벨. */
+  locationUncertain?: boolean;
 }
 
 export async function processLocationUpdate(inputs: ProcessLocationInputs): Promise<PipelineResult> {
@@ -110,7 +118,13 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     storedRoute = null,
     speedMps = null,
     source,
+    fusionSource,
+    locationUncertain = false,
   } = inputs;
+
+  const notificationSource = fusionSource
+    ? resolveNotificationSource(fusionSource, locationUncertain)
+    : undefined;
 
   const nearest = findNearestStation(lat, lng, MAX_STATION_DISTANCE_KM);
   if (!nearest) return { alarmEvent: null, nearest: null };
@@ -132,7 +146,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   );
 
   if (alarmEvent) {
-    await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker);
+    await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);
     logFiredAlarm(source, alarmEvent);
   }
 
@@ -149,6 +163,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
           nearest.station.name,
           destination.name,
           target,
+          notificationSource,
         );
         await setLastNotifiedStationId(nearest.station.id);
         logFiredStationPassed(source, nearest.station);

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -161,6 +161,13 @@ private struct LockScreenView: View {
                             .font(.subheadline)
                             .foregroundColor(lineColor)
                     }
+
+                    // 데이터 출처 자백 (#327). 없으면 표시 생략.
+                    if let sourceLabel = state.sourceLabel {
+                        Text(sourceLabel)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 Spacer()

--- a/targets/subway-widget/_shared/SubwayActivityAttributes.swift
+++ b/targets/subway-widget/_shared/SubwayActivityAttributes.swift
@@ -35,6 +35,9 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var etaText: String?
         var etaSubtext: String?
         var distanceText: String?
+        // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드된 사용자 노출 텍스트.
+        // 누락 시 위젯은 라벨 표시 생략 — 기존 LA 인스턴스 호환 안전.
+        var sourceLabel: String?
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- 사용자가 보는 모든 표면(FG/BG/잠금화면/Live Activity/푸시 본문)에 데이터 출처를 자백
- 21:29 false-positive 같은 사고 시 BG 알람에도 "GPS 추정"이 박혀 사용자가 즉시 의심 가능
- Phase B uncertainty UI 3 PR 중 마지막 (BG)

## Commits (6)
1. `refactor`: FusionSource→NotificationSource 매핑을 공용 헬퍼(`src/utils/notificationSource.ts`)로 추출 + SourceBadge 리팩토링
2. `feat`: `stationNotification.ts` 시그니처 확장 — `buildAlarmContent`/`sendAlarmNotification`/`sendStationPassedNotification`에 `source?` 추가, body 끝에 `· 라벨` suffix 부착
3. `feat`: `stationPipeline.ts`에 `fusionSource`/`locationUncertain` 전파
4. `feat`: 호출부 3곳 source 전달
   - `useStationAlarm`: `useFusedNearestStation`의 source 사용
   - `backgroundLocationTask`: `'gps'` 명시 (BG는 raw GPS only)
   - `silentPushTask`: `'positionTrain'` 고정 (서버 train data 기반)
5. `feat`: Live Activity `sourceLabel` 필드 (네이티브 MIRROR 2 파일 + Widget UI)
6. `refactor`: code-reviewer P2 4건 반영

## Design decisions
- **silent push 라벨**: 항상 `'positionTrain'` — 서버 train data 기반. `gate.locationSource`(cache/fresh)는 데이터 출처와 무관해 매핑 불필요
- **위젯(SubwayWidget)은 source 라벨 스킵** — 항상 GPS라 노이즈. LA + 푸시만 라벨링
- **알람 본문 영어 잘림은 별도 이슈** #531로 분리 — source 추가는 +12자(기존 131자 → 143자)로 영어 사용자에게 영향이지만 source 추가가 원인은 아님

## 알람 본문 길이 실측 (4언어, source 포함)
| 언어 | 최장 케이스 | iOS 2줄(~100자) |
|---|---|---|
| ko | 70자 | OK |
| en | 143자 | 잘림 (기존 131자 → #531에서 해소) |
| ja | 74자 | OK |
| zh | 47자 | OK |

## Native changes (⚠️ 실기기 dev build 회귀 필요)
- `SubwayActivityAttributes.swift` MIRROR 2 파일에 `sourceLabel: String?` 추가
  - `targets/subway-widget/_shared/` (app + widget extension)
  - `modules/live-activity/ios/` (CocoaPod 컴파일 단위)
- `SubwayLiveActivityWidget.swift` LockScreenView에 sourceLabel 표시 (`caption2`, `secondary`)
- LA ContentState wire format은 optional 필드 추가라 기존 활성 LA 호환 안전

## Test plan
- [x] `npm test` — 1723 tests pass, 커버리지 100%
- [x] `npm run type-check` — pass
- [x] code-reviewer 에이전트 리뷰 (P1 없음, P2 4건 반영)
- [ ] **실기기 dev build 회귀**: trip 시작 → 알람 본문에 source 라벨 확인, 잠금화면 LA sourceLabel 표시 확인
- [ ] 4언어(ko/en/ja/zh) source 라벨 시각 확인
- [ ] uncertain 상태에서 "위치 확인 중" 라벨 발화 확인 (단, 알람 게이트로 차단되므로 거의 발화 안 됨 — station-passed 위주)

## Follow-up
- #531: 영어 알람 카피 단축 (lock screen 2줄 잘림 해소)

Closes #327
Closes #475