### PR TITLE
fix(#534): trip 시작 시 route 대기 후 LA 첫 송출

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,6 +34,10 @@ import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 
 const logger = createLogger('HomeScreen');
 
+// #534: 첫 LA 송출 시 route 계산 완료를 기다리는 최대 시간. 이 시간을 넘기면 ETA 없이
+// destination-only로 송출해 경로 산출이 영구 실패하는 케이스에서도 LA가 뜨도록 한다.
+const FIRST_SEND_ROUTE_WAIT_MS = 1500;
+
 export default function HomeScreen() {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -61,6 +65,12 @@ export default function HomeScreen() {
   const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
   const prevDestIdRef = useRef<string | null>(null);
+  // #534: route 비동기 계산이 끝나기 전 첫 LA 송출이 일어나면 ETA-less 카드가 잠금화면에
+  // 박힌다. route 도착까지 첫 송출을 지연시키되, FIRST_SEND_ROUTE_WAIT_MS 내에 route가
+  // 안 오면 destination-only로 송출 (경로 산출 영구 실패 폴백 보존).
+  const firstSendWaitStartRef = useRef<number | null>(null);
+  const firstSendFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [firstSendFallbackTick, setFirstSendFallbackTick] = useState(0);
   const routePreference = useAppStore((s) => s.routePreference);
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
   const [categorized, setCategorized] = useState<CategorizedRoute[]>([]);
@@ -194,7 +204,13 @@ export default function HomeScreen() {
         void refreshRef.current();
       }
     });
-    return () => subscription.remove();
+    return () => {
+      subscription.remove();
+      if (firstSendFallbackTimerRef.current) {
+        clearTimeout(firstSendFallbackTimerRef.current);
+        firstSendFallbackTimerRef.current = null;
+      }
+    };
   }, []);
 
   useEffect(() => {
@@ -215,14 +231,42 @@ export default function HomeScreen() {
         clearAlarmNotification().catch((e) => logger.error('알림 해제 실패:', e));
         clearStationNotification().catch((e) => logger.error('알림 해제 실패:', e));
       }
+      firstSendWaitStartRef.current = null;
+      if (firstSendFallbackTimerRef.current) {
+        clearTimeout(firstSendFallbackTimerRef.current);
+        firstSendFallbackTimerRef.current = null;
+      }
       return;
     }
+    const isFirstSend = prevNotifKeyRef.current === undefined || prevNotifKeyRef.current === 'none';
     // route가 아직 계산되지 않은 짧은 윈도우(콜드 스타트, categorized async fill 중)에
     // 정상 payload를 한 번 송출한 뒤라면 destination-only로 덮어쓰지 말고 이전 payload를
-    // 유지한다. 단 첫 송출 전(아직 LiveActivity 미시작)이면 차라리 destination-only라도
-    // 띄워야 사용자 가시성이 확보된다 — 경로 산출이 영구 실패하는 케이스 대비.
-    if (!route && prevNotifKeyRef.current !== undefined && prevNotifKeyRef.current !== 'none') {
+    // 유지한다.
+    if (!route && !isFirstSend) {
       return;
+    }
+    // #534: 첫 송출이고 route가 아직 없으면 staticEta 계산 불가 → ETA-less LA가 박힌다.
+    // FIRST_SEND_ROUTE_WAIT_MS 내에 route가 도착하면 routeSig deps 변화로 자연 재발화되어
+    // ETA 포함 송출. 타임아웃 만료 시 setFirstSendFallbackTick으로 재발화시켜 폴백 송출.
+    if (!route && isFirstSend) {
+      if (firstSendWaitStartRef.current === null) {
+        firstSendWaitStartRef.current = Date.now();
+      }
+      const elapsed = Date.now() - firstSendWaitStartRef.current;
+      if (elapsed < FIRST_SEND_ROUTE_WAIT_MS) {
+        if (!firstSendFallbackTimerRef.current) {
+          firstSendFallbackTimerRef.current = setTimeout(() => {
+            firstSendFallbackTimerRef.current = null;
+            setFirstSendFallbackTick((n) => n + 1);
+          }, FIRST_SEND_ROUTE_WAIT_MS - elapsed);
+        }
+        return;
+      }
+    }
+    firstSendWaitStartRef.current = null;
+    if (firstSendFallbackTimerRef.current) {
+      clearTimeout(firstSendFallbackTimerRef.current);
+      firstSendFallbackTimerRef.current = null;
     }
     const key = `${effectiveOrigin.id}__${destination.id}__${routeSig}__${displayEta ?? ''}__${arrivalIsMock}__${alarmEvent?.type ?? ''}`;
     if (key === prevNotifKeyRef.current) return;
@@ -248,7 +292,7 @@ export default function HomeScreen() {
       );
     };
     update().catch((e) => logger.error('알림 업데이트 실패:', e));
-  }, [effectiveOrigin?.id, destination?.id, displayEta, arrivalIsMock, routeSig, alarmEvent, arrivedBanner]);
+  }, [effectiveOrigin?.id, destination?.id, displayEta, arrivalIsMock, routeSig, alarmEvent, arrivedBanner, firstSendFallbackTick]);
 
   useEffect(() => {
     if (arrivedBanner) {
@@ -256,6 +300,12 @@ export default function HomeScreen() {
       clearAlarmNotification().catch(console.error);
       clearAlarmEvent();
       prevNotifKeyRef.current = undefined;
+      // #534: arrived→재트립 진입 시 이전 트립의 대기 윈도우/타이머가 잔존하지 않도록 정리.
+      firstSendWaitStartRef.current = null;
+      if (firstSendFallbackTimerRef.current) {
+        clearTimeout(firstSendFallbackTimerRef.current);
+        firstSendFallbackTimerRef.current = null;
+      }
     }
   }, [arrivedBanner]);
 


### PR DESCRIPTION
## Summary
- Trip 생성 직후 잠금화면 Live Activity에 ETA("약 N분 소요")가 비어있던 회귀 수정
- 원인: `categorizeRoutes`가 `InteractionManager`로 비동기 실행되어 첫 `updateStationNotification` 발화 시점에 `route=null` → `staticEtaMinutes=null` → ETA-less LA가 잠금화면에 박힘
- 첫 송출일 때 `route`가 없으면 `FIRST_SEND_ROUTE_WAIT_MS`(1500ms)까지 송출 지연. `routeSig` deps 변화로 자연 재발화, 타임아웃 만료 시 `setFirstSendFallbackTick`으로 강제 재발화하여 destination-only 폴백 송출 (경로 산출 영구 실패 케이스 보존)
- `arrivedBanner` / `!effectiveOrigin || !destination` / 언마운트 경로에서 대기 윈도우·타이머 cleanup 추가

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 1696 passed, 100% coverage 유지
- [x] code-reviewer agent P0 없음, P1 방어 코드 반영
- [ ] 실기기(iPhone 13 mini, iOS 26.3.1) 회귀:
  - [ ] 출발/도착 설정 → 즉시 잠금 → LA 카드에 origin → destination + "약 N분 소요" **즉시** 표시
  - [ ] 약 5초 후 실시간 ETA로 자연 갱신 (퇴행 없음)
  - [ ] 도착 임박/환승 알람 정상 동작
  - [ ] 도착 → 재트립 시작 시 동일 동작 확인

Closes #534