### PR TITLE
fix(#531): 영어 알람 카피 단축

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -184,13 +184,13 @@
   "alarms": {
     "earlyTransferBody": "Transfer at {{station}} (next stop)!",
     "earlyArrivalBody": "Exit at {{station}} (next stop)!",
-    "imminentTransferBody": "Arriving at {{station}}. Get ready to transfer!",
-    "imminentArrivalBody": "Arriving at {{station}}. Get ready to exit!",
+    "imminentTransferBody": "Arriving at {{station}} — transfer soon!",
+    "imminentArrivalBody": "Arriving at {{station}} — exit soon!",
     "exitSideLeft": "Exit on the left",
     "exitSideRight": "Exit on the right",
     "exitSideBoth": "Doors open on both sides",
-    "quickHintTransfer": "Get off at the spot closest to your transfer",
-    "quickHintArrival": "Get off at the spot closest to the exit"
+    "quickHintTransfer": "Stand near transfer exit",
+    "quickHintArrival": "Stand near station exit"
   },
   "liveActivity": {
     "alarmShortTransfer": "Transfer",


### PR DESCRIPTION
## Summary
- 영어 알람 본문이 iOS 잠금화면 2줄(~110자)을 초과해 잘리는 회귀 수정
- `imminentTransferBody` / `imminentArrivalBody` — "Arriving at {{station}} — X soon!" 패턴으로 통일
- `quickHintTransfer` / `quickHintArrival` — "Stand near {transfer|station} exit"로 단축
- 최장 케이스(Dongdaemun History & Culture Park + imminent transfer + exit-left + quick hint): 131자 → 104자

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 1751 passed
- [x] code-reviewer 톤 비대칭 P1 반영 (transfer/arrival 패턴 통일)
- [ ] 실기기/시뮬레이터에서 영어 로케일로 imminent transfer 알람 발화 시 lock screen 잘림 없는지 확인

Closes #531