### PR TITLE
fix(#517): schedule fallback up/down half-headway 위상 분리

### DIFF
--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -167,6 +167,28 @@ describe('buildScheduleArrival', () => {
     expect(result.down.every((t) => t.destination === '인천')).toBe(true);
   });
 
+  it('up과 down은 서로 다른 ETA를 가진다 — half-headway 위상 분리 (#517)', () => {
+    // line 2 peak 헤드웨이 150s. 이 시각은 nowMs % 150_000 === 0 (격자 정렬 케이스).
+    // up=150s, down=75s로 분리되어야 한다. up/down이 같은 격자에 정렬되면 동일 ETA로
+    // 표시되어 디버그/UX에 혼란을 유발한다.
+    const now = new Date('2026-05-18T08:00:00+09:00');
+    const result = buildScheduleArrival('2', now);
+    expect(result.up[0].arrivalSeconds).not.toBe(result.down[0].arrivalSeconds);
+    // 각 방향 두 번째 트레인은 first + headway 관계 유지
+    expect(result.up[1].arrivalSeconds).toBe(result.up[0].arrivalSeconds + 150);
+    expect(result.down[1].arrivalSeconds).toBe(result.down[0].arrivalSeconds + 150);
+  });
+
+  it('down 트레인도 wall-clock 폴링(+5s)에서 연속 감소한다 (#517)', () => {
+    const t0 = new Date('2026-05-18T15:00:00.000+09:00');
+    const t5 = new Date(t0.getTime() + 5_000);
+    const r0 = buildScheduleArrival('2', t0);
+    const r5 = buildScheduleArrival('2', t5);
+    if (r0.down[0].arrivalSeconds > 5) {
+      expect(r5.down[0].arrivalSeconds).toBe(r0.down[0].arrivalSeconds - 5);
+    }
+  });
+
   it('2호선(순환선)은 내선/외선순환을 행선지로 사용한다 (#471)', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
     const result = buildScheduleArrival('2', now);

--- a/src/utils/scheduleFallback.ts
+++ b/src/utils/scheduleFallback.ts
@@ -131,17 +131,23 @@ export function buildScheduleArrival(line: LineNumber, now: Date): StationArriva
   const downTerminal = terminal?.down ?? '';
 
   const headwayMs = headway * 1000;
-  const remainder = nowMs % headwayMs;
-  const msUntilFirst = remainder === 0 ? headwayMs : headwayMs - remainder;
-  const first = Math.round(msUntilFirst / 1000);
-  const second = first + headway;
+  const nextDepartureSeconds = (anchorMs: number): number => {
+    const remainder = anchorMs % headwayMs;
+    const msUntilFirst = remainder === 0 ? headwayMs : headwayMs - remainder;
+    return Math.round(msUntilFirst / 1000);
+  };
+  const upFirst = nextDepartureSeconds(nowMs);
+  // #517: up과 down이 동일 격자에 정렬돼 같은 ETA로 표시되는 회귀를 막기 위해
+  // down 방향은 half-headway 만큼 위상을 어긋나게 한다. 실제 운영도 양방향이
+  // 정확히 동기화되어 있지 않으며, 디버그 시 dir 분기 검증을 가능하게 한다.
+  const downFirst = nextDepartureSeconds(nowMs + Math.floor(headwayMs / 2));
   const up = [
-    makeTrain(first, 'UP-1', nowMs, upTerminal),
-    makeTrain(second, 'UP-2', nowMs, upTerminal),
+    makeTrain(upFirst, 'UP-1', nowMs, upTerminal),
+    makeTrain(upFirst + headway, 'UP-2', nowMs, upTerminal),
   ];
   const down = [
-    makeTrain(first, 'DN-1', nowMs, downTerminal),
-    makeTrain(second, 'DN-2', nowMs, downTerminal),
+    makeTrain(downFirst, 'DN-1', nowMs, downTerminal),
+    makeTrain(downFirst + headway, 'DN-2', nowMs, downTerminal),
   ];
 
   return { up, down, isMock: true, source: 'schedule' };


### PR DESCRIPTION
## Summary
- MOCK 라벨이 붙은 schedule fallback 데이터에서 상행/하행이 동일 ETA로 표시되던 회귀 수정
- 원인: \`buildScheduleArrival\`이 양방향에 동일 wall-clock 격자(\`nowMs % headwayMs\`)를 anchor로 사용
- down 방향 anchor를 \`nowMs + headwayMs/2\`로 시프트하여 두 방향이 항상 다른 ETA를 가지도록 함
- 실시간 API 경로는 영향 없음 (이 PR은 fallback 경로만 변경)

## Trade-off
- half-headway 위상 분리는 결정적(deterministic)이라 폴링 연속성(#468) 회귀 없음
- 모든 현행 헤드웨이가 짝수초라 \`Math.floor(hMs/2)\` 보정도 안전
- 실제 운영도 양방향 발차가 정확히 동기화되어 있지 않으므로 더 현실적인 모델

## Test plan
- [x] \`npm run type-check\` 통과
- [x] \`npm test\` — 1753 passed, 100% coverage
- [x] up≠down 검증 + down 폴링 연속성 회귀 테스트 추가
- [x] code-reviewer agent P0 없음, P1 주석 보강 반영
- [ ] 시뮬레이터에서 schedule fallback 강제 활성 (운영시간 외 또는 API 실패) → 상하행 다른 ETA 노출 확인

Closes #517