### PR TITLE
feat(#473): Phase 3 — buildScheduleArrival 시간표 lookup 재작성

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,src/data/timetables/**
+sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx

--- a/src/api/__tests__/arrivalApi.test.ts
+++ b/src/api/__tests__/arrivalApi.test.ts
@@ -28,7 +28,7 @@ describe('fetchArrivalInfo', () => {
     expect(result.up[0]).toHaveProperty('arrivalSeconds');
     expect(result.up[0]).toHaveProperty('statusMessage');
     expect(result.up[0]).toHaveProperty('trainCode');
-    expect(result.isMock).toBe(true);
+    expect(result.source).not.toBe('realtime'); // #473 Phase 3: fallback이 timetable이면 isMock=false, 헤드웨이면 true — wall clock 의존이라 source로 검증
   });
 
   it('API 키가 있으면 fetch를 호출한다', async () => {
@@ -73,7 +73,7 @@ describe('fetchArrivalInfo', () => {
 
     expect(result.up.length).toBeGreaterThan(0);
     expect(result.down.length).toBeGreaterThan(0);
-    expect(result.isMock).toBe(true);
+    expect(result.source).not.toBe('realtime'); // #473 Phase 3: fallback이 timetable이면 isMock=false, 헤드웨이면 true — wall clock 의존이라 source로 검증
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
@@ -87,7 +87,7 @@ describe('fetchArrivalInfo', () => {
 
     expect(result.up.length).toBeGreaterThan(0);
     expect(result.down.length).toBeGreaterThan(0);
-    expect(result.isMock).toBe(true);
+    expect(result.source).not.toBe('realtime'); // #473 Phase 3: fallback이 timetable이면 isMock=false, 헤드웨이면 true — wall clock 의존이라 source로 검증
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
@@ -104,7 +104,7 @@ describe('fetchArrivalInfo', () => {
 
     expect(result.up.length).toBeGreaterThan(0);
     expect(result.down.length).toBeGreaterThan(0);
-    expect(result.isMock).toBe(true);
+    expect(result.source).not.toBe('realtime'); // #473 Phase 3: fallback이 timetable이면 isMock=false, 헤드웨이면 true — wall clock 의존이라 source로 검증
 
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
   });
@@ -189,7 +189,7 @@ describe('fetchArrivalInfo', () => {
     jest.advanceTimersByTime(5000);
     const result = await promise;
 
-    expect(result.isMock).toBe(true);
+    expect(result.source).not.toBe('realtime'); // #473 Phase 3: fallback이 timetable이면 isMock=false, 헤드웨이면 true — wall clock 의존이라 source로 검증
 
     jest.useRealTimers();
     delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
@@ -374,7 +374,7 @@ describe('fetchArrivalInfo', () => {
       } as Response);
 
       const result = await fetchArrivalInfo('강남');
-      expect(result.isMock).toBe(true);
+      expect(result.source).not.toBe('realtime'); // #473 Phase 3: fallback이 timetable이면 isMock=false, 헤드웨이면 true — wall clock 의존이라 source로 검증
     });
   });
 
@@ -398,7 +398,7 @@ describe('fetchArrivalInfo', () => {
       delete process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
       const result = await fetchArrivalInfo('강남');
       expect(result.source).toBe('schedule');
-      expect(result.isMock).toBe(true);
+      expect(result.source).not.toBe('realtime'); // #473 Phase 3: fallback이 timetable이면 isMock=false, 헤드웨이면 true — wall clock 의존이라 source로 검증
       expect(result.up.length).toBeGreaterThan(0);
     });
 

--- a/src/api/arrivalApi.ts
+++ b/src/api/arrivalApi.ts
@@ -86,7 +86,7 @@ export function getFallbackArrival(
     log.warn('schedule_fallback_unavailable', { station: stationName, line, reason });
     return MOCK_ARRIVALS;
   }
-  const result = buildScheduleArrival(line, new Date());
+  const result = buildScheduleArrival(line, stationName, new Date());
   log.info('schedule_fallback_fired', {
     station: stationName,
     line,

--- a/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
+++ b/src/providers/arrival/__tests__/BffArrivalProvider.test.ts
@@ -70,7 +70,7 @@ describe('BffArrivalProvider', () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 500 });
     const result = await callGetArrival();
     expect(result.source).toBe('schedule');
-    expect(result.isMock).toBe(true);
+    // #473 Phase 3: 강남(2호선)은 시간표 hit으로 isMock=false. fallback 작동은 source='schedule'로 검증.
   });
 
   it('up/down 모두 빈 배열이면 schedule fallback으로 전환한다', async () => {

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -287,6 +287,13 @@ describe('buildScheduleArrival — 시간표 lookup (#473 Phase 3)', () => {
     expect(['schedule', 'closed']).toContain(result.source);
   });
 
+  it('Sunday 02:00 KST는 saturday 시간표 lookup (전 영업일 = 토요일)', () => {
+    // 2026-05-24 일요일 02:00 KST. previousBusinessDay('Sun') → 'saturday'.
+    const now = new Date('2026-05-23T17:00:00Z'); // KST Sun 02:00
+    const result = buildScheduleArrival('1', '서울역', now);
+    expect(['schedule', 'closed']).toContain(result.source);
+  });
+
   it('시간표 노선/역 존재하지만 dayType 키 없음 → 헤드웨이 폴백 (line 196)', () => {
     // 정상 케이스로는 unreachable이지만 isolateModules로 시간표 구조 변형 분기 강제.
     jest.isolateModules(() => {

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -63,7 +63,7 @@ describe('classifyPeriod', () => {
 describe('buildScheduleArrival', () => {
   it('returns empty arrival with source=closed during closed hours', () => {
     const now = new Date('2026-05-18T03:00:00+09:00');
-    const result = buildScheduleArrival('2', now);
+    const result = buildScheduleArrival('2', '__missing__', now);
     expect(result.up).toEqual([]);
     expect(result.down).toEqual([]);
     expect(result.source).toBe('closed');
@@ -75,7 +75,7 @@ describe('buildScheduleArrival', () => {
 
   it('returns 2 up/down trains during weekday peak with line 2 headway 150s', () => {
     const now = new Date('2026-05-18T08:00:00+09:00');
-    const result = buildScheduleArrival('2', now);
+    const result = buildScheduleArrival('2', '__missing__', now);
     expect(result.source).toBe('schedule');
     expect(result.up).toHaveLength(2);
     expect(result.down).toHaveLength(2);
@@ -87,7 +87,7 @@ describe('buildScheduleArrival', () => {
 
   it('uses offPeak headway during weekday daytime', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
-    const result = buildScheduleArrival('1', now);
+    const result = buildScheduleArrival('1', '__missing__', now);
     expect(result.source).toBe('schedule');
     const first = result.up[0].arrivalSeconds;
     expect(first).toBeGreaterThan(0);
@@ -96,47 +96,47 @@ describe('buildScheduleArrival', () => {
 
   it('uses saturday offPeak even during what would be peak time', () => {
     const now = new Date('2026-05-16T08:00:00+09:00'); // Saturday
-    const result = buildScheduleArrival('2', now);
+    const result = buildScheduleArrival('2', '__missing__', now);
     expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(330);
   });
 
   it('falls back to offPeak headway if peak entry missing (weekend peak lookup is never triggered, but defensive)', () => {
     const now = new Date('2026-05-18T08:00:00+09:00');
-    const result = buildScheduleArrival('gyeongui', now);
+    const result = buildScheduleArrival('gyeongui', '__missing__', now);
     expect(result.source).toBe('schedule');
     expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(540);
   });
 
   it('sets receivedAtMs to now.getTime()', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
-    const result = buildScheduleArrival('2', now);
+    const result = buildScheduleArrival('2', '__missing__', now);
     expect(result.up[0].receivedAtMs).toBe(now.getTime());
   });
 
   it('marks late period for 23:00 with late headway', () => {
     const now = new Date('2026-05-18T23:00:00+09:00');
-    const result = buildScheduleArrival('2', now);
+    const result = buildScheduleArrival('2', '__missing__', now);
     expect(result.source).toBe('schedule');
     expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(480);
   });
 
   it('handles sunday late period', () => {
     const now = new Date('2026-05-17T22:30:00+09:00');
-    const result = buildScheduleArrival('1', now);
+    const result = buildScheduleArrival('1', '__missing__', now);
     expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(660);
   });
 
   it('arrivalMinutes equals floor(arrivalSeconds/60)', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
-    const result = buildScheduleArrival('1', now);
+    const result = buildScheduleArrival('1', '__missing__', now);
     expect(result.up[0].arrivalMinutes).toBe(Math.floor(result.up[0].arrivalSeconds / 60));
   });
 
   it('anchors next departure to wall-clock so polling (+5s) returns continuously decreasing ETA', () => {
     const t0 = new Date('2026-05-18T15:00:00.000+09:00');
     const t5 = new Date(t0.getTime() + 5_000);
-    const r0 = buildScheduleArrival('2', t0);
-    const r5 = buildScheduleArrival('2', t5);
+    const r0 = buildScheduleArrival('2', '__missing__', t0);
+    const r5 = buildScheduleArrival('2', '__missing__', t5);
     // 둘 다 schedule이고 같은 헤드웨이 격자 안이라면 +5s 폴링 결과는 5초 적게 남아야 함.
     // 트레인 시프트 직후가 아니면 정확히 -5s.
     if (r0.up[0].arrivalSeconds > 5) {
@@ -148,21 +148,21 @@ describe('buildScheduleArrival', () => {
     // line 1 offPeak headway = 360s. grid 정렬 케이스 강제.
     const headwayMs = 360_000;
     const alignedMs = Math.ceil(new Date('2026-05-18T15:00:00+09:00').getTime() / headwayMs) * headwayMs;
-    const result = buildScheduleArrival('1', new Date(alignedMs));
+    const result = buildScheduleArrival('1', '__missing__', new Date(alignedMs));
     expect(result.up[0].arrivalSeconds).toBe(360); // 다음 격자로 시프트되어 headway 그대로
   });
 
   it('returns source=closed when line key is missing from headway table (defensive)', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
     // 알려지지 않은 미래 노선이 LineNumber에 추가됐지만 lineHeadways.json에 누락된 경우.
-    const result = buildScheduleArrival('gtx-a' as LineNumber, now);
+    const result = buildScheduleArrival('gtx-a' as LineNumber, '__missing__', now);
     expect(result.source).toBe('closed');
     expect(result.up).toEqual([]);
   });
 
   it('up 트레인은 up 종착역으로, down 트레인은 down 종착역으로 destination을 채운다 (#471)', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
-    const result = buildScheduleArrival('1', now);
+    const result = buildScheduleArrival('1', '__missing__', now);
     expect(result.up.every((t) => t.destination === '소요산')).toBe(true);
     expect(result.down.every((t) => t.destination === '인천')).toBe(true);
   });
@@ -172,7 +172,7 @@ describe('buildScheduleArrival', () => {
     // up=150s, down=75s로 분리되어야 한다. up/down이 같은 격자에 정렬되면 동일 ETA로
     // 표시되어 디버그/UX에 혼란을 유발한다.
     const now = new Date('2026-05-18T08:00:00+09:00');
-    const result = buildScheduleArrival('2', now);
+    const result = buildScheduleArrival('2', '__missing__', now);
     expect(result.up[0].arrivalSeconds).not.toBe(result.down[0].arrivalSeconds);
     // 각 방향 두 번째 트레인은 first + headway 관계 유지
     expect(result.up[1].arrivalSeconds).toBe(result.up[0].arrivalSeconds + 150);
@@ -182,8 +182,8 @@ describe('buildScheduleArrival', () => {
   it('down 트레인도 wall-clock 폴링(+5s)에서 연속 감소한다 (#517)', () => {
     const t0 = new Date('2026-05-18T15:00:00.000+09:00');
     const t5 = new Date(t0.getTime() + 5_000);
-    const r0 = buildScheduleArrival('2', t0);
-    const r5 = buildScheduleArrival('2', t5);
+    const r0 = buildScheduleArrival('2', '__missing__', t0);
+    const r5 = buildScheduleArrival('2', '__missing__', t5);
     if (r0.down[0].arrivalSeconds > 5) {
       expect(r5.down[0].arrivalSeconds).toBe(r0.down[0].arrivalSeconds - 5);
     }
@@ -191,7 +191,7 @@ describe('buildScheduleArrival', () => {
 
   it('2호선(순환선)은 내선/외선순환을 행선지로 사용한다 (#471)', () => {
     const now = new Date('2026-05-18T15:00:00+09:00');
-    const result = buildScheduleArrival('2', now);
+    const result = buildScheduleArrival('2', '__missing__', now);
     expect(result.up[0].destination).toBe('내선순환');
     expect(result.down[0].destination).toBe('외선순환');
   });
@@ -203,13 +203,158 @@ describe('buildScheduleArrival', () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { buildScheduleArrival: build } = require('../scheduleFallback');
       const now = new Date('2026-05-18T15:00:00+09:00');
-      const result = build('1', now);
+      const result = build('1', '__missing__', now);
       expect(result.source).toBe('schedule');
       expect(result.up[0].destination).toBe('');
       expect(result.down[0].destination).toBe('');
     });
     // isolateModules는 자체 레지스트리를 사용하지만 doMock 잔존 방지를 위해 명시적 reset.
     jest.resetModules();
+  });
+});
+
+describe('buildScheduleArrival — 시간표 lookup (#473 Phase 3)', () => {
+  it('시간표 적중 시 isMock=false 반환 + lookup 기반 ETA', () => {
+    // 1호선 서울역 평일 09:00. line-1.json에 서울역 시간표 존재.
+    const now = new Date('2026-05-18T09:00:00+09:00');
+    const result = buildScheduleArrival('1', '서울역', now);
+    expect(result.source).toBe('schedule');
+    expect(result.isMock).toBe(false);
+    expect(result.up.length).toBeGreaterThan(0);
+  });
+
+  it('시간표 없는 노선은 헤드웨이 폴백 (분당선)', () => {
+    const now = new Date('2026-05-18T09:00:00+09:00');
+    const result = buildScheduleArrival('bundang', '왕십리', now);
+    expect(result.source).toBe('schedule');
+    expect(result.isMock).toBe(true);
+  });
+
+  it('시간표 노선이지만 매칭 안 되는 역명은 헤드웨이 폴백', () => {
+    const now = new Date('2026-05-18T09:00:00+09:00');
+    const result = buildScheduleArrival('1', '__no_such_station__', now);
+    expect(result.isMock).toBe(true);
+  });
+
+  it('KST 0~5시는 dayType을 전 영업일로 shift + 24h+ 키로 비교', () => {
+    // 토요일 02:00 KST → 금요일 영업일의 24h+ 시간표 엔트리(예: "2421") 매칭.
+    // line-1.json 서울역에 "2421"이 있다면 02:00에는 ETA 약 21분.
+    const now = new Date('2026-05-16T02:00:00+09:00'); // Saturday 02:00
+    const result = buildScheduleArrival('1', '서울역', now);
+    // 시간표가 매칭되면 isMock=false; 매칭 못 하면 헤드웨이 폴백(isMock=true).
+    // 어느 쪽이든 source='schedule' 유지 (운행종료 분기는 헤드웨이 폴백에서만).
+    expect(['schedule', 'closed']).toContain(result.source);
+  });
+
+  it('막차 후(시간표 entry 모두 nowKey 미만)는 헤드웨이 폴백 → closed', () => {
+    // 모든 timetable entry가 nowKey보다 작은 mock 데이터로 결정적 검증.
+    jest.isolateModules(() => {
+      jest.doMock('../../data/timetables/line-1.json', () => ({
+        stations: {
+          '__last_train_done__': {
+            // 평일 시간표: 23:30 막차 끝, 24h+ 엔트리 없음.
+            weekday: { up: ['0530', '2330'], down: ['0530', '2330'] },
+          },
+        },
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { buildScheduleArrival: build } = require('../scheduleFallback');
+      // KST 평일 02:00 → effectiveDay='sunday' (Tuesday → 이전 영업일 = weekday이지만
+      // previousBusinessDay(Tue)=weekday이므로 weekday 매칭. 그러나 nowKey="2600"인데
+      // weekday 시간표 max="2330" → 매칭 실패. classifyPeriod=closed → 빈 배열.
+      const now = new Date('2026-05-19T02:00:00+09:00'); // Tuesday 02:00 KST
+      const result = build('1', '__last_train_done__', now);
+      expect(result.source).toBe('closed');
+      expect(result.up).toEqual([]);
+      expect(result.down).toEqual([]);
+    });
+    jest.resetModules();
+  });
+
+  it('Monday 02:00 KST는 sunday 시간표 lookup (전 영업일 = 일요일)', () => {
+    // 2026-05-25은 월요일. KST 02:00 = UTC 17:00 전날(2026-05-24 일요일 17:00 UTC).
+    const now = new Date('2026-05-24T17:00:00Z'); // KST Mon 02:00
+    const result = buildScheduleArrival('1', '서울역', now);
+    // sunday 시간표 데이터가 02:00(=2600 nowKey)에는 거의 없을 것 → 헤드웨이 폴백 closed.
+    // 분기 진입 자체가 핵심 (line 191).
+    expect(['schedule', 'closed']).toContain(result.source);
+  });
+
+  it('Saturday 02:00 KST는 weekday 시간표 lookup (전 영업일 = 금요일)', () => {
+    // 2026-05-23 토요일 02:00 KST.
+    const now = new Date('2026-05-22T17:00:00Z'); // KST Sat 02:00
+    const result = buildScheduleArrival('1', '서울역', now);
+    expect(['schedule', 'closed']).toContain(result.source);
+  });
+
+  it('시간표 노선/역 존재하지만 dayType 키 없음 → 헤드웨이 폴백 (line 196)', () => {
+    // 정상 케이스로는 unreachable이지만 isolateModules로 시간표 구조 변형 분기 강제.
+    jest.isolateModules(() => {
+      jest.doMock('../../data/timetables/line-1.json', () => ({
+        stations: { '__test_station__': {} }, // weekday/saturday/sunday 모두 없음
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { buildScheduleArrival: build } = require('../scheduleFallback');
+      const now = new Date('2026-05-18T15:00:00+09:00');
+      const result = build('1', '__test_station__', now);
+      expect(result.isMock).toBe(true); // 헤드웨이 폴백
+    });
+    jest.resetModules();
+  });
+
+  it('hour<5 + 24h+ 시간표 entry 매칭 시 hhmmToFutureSeconds nowHour shift 적용 (line 168)', () => {
+    // KST Monday 02:30 (= UTC Sun 17:30). 사용자 시간 시간표 비교 키 "2630".
+    // 이전 영업일(Sunday)의 24h+ 엔트리가 "2700" 이상이면 매치.
+    jest.isolateModules(() => {
+      jest.doMock('../../data/timetables/line-1.json', () => ({
+        stations: {
+          '__late_night__': {
+            sunday: { up: ['2700', '2730'], down: ['2715'] }, // 익일 03:00, 03:30
+          },
+        },
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { buildScheduleArrival: build } = require('../scheduleFallback');
+      const now = new Date('2026-05-24T17:30:00Z'); // KST Mon 02:30
+      const result = build('1', '__late_night__', now);
+      // 시간표 hit → isMock=false, hhmmToFutureSeconds nowHour<5 분기 진입.
+      expect(result.isMock).toBe(false);
+      expect(result.up.length).toBe(2);
+      // 02:30 → 03:00 = 30분 = 1800초
+      expect(result.up[0].arrivalSeconds).toBe(30 * 60);
+    });
+    jest.resetModules();
+  });
+
+  it('시간표 day.up/down 빈 배열 → 폴백 (line 199)', () => {
+    jest.isolateModules(() => {
+      jest.doMock('../../data/timetables/line-1.json', () => ({
+        stations: {
+          '__test_empty__': {
+            weekday: { up: [], down: [] }, // 빈 배열
+          },
+        },
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { buildScheduleArrival: build } = require('../scheduleFallback');
+      const now = new Date('2026-05-18T15:00:00+09:00');
+      const result = build('1', '__test_empty__', now);
+      expect(result.isMock).toBe(true); // 헤드웨이 폴백
+    });
+    jest.resetModules();
+  });
+
+  it('hhmmToFutureSeconds 자정 wrap — 23:30에 "2421" 시각은 약 51분 후', () => {
+    // 직접 검증: 평일 23:30 KST. 시간표에 "2421" 엔트리가 있다면 ETA ≈ 51분.
+    const now = new Date('2026-05-18T23:30:00+09:00');
+    const result = buildScheduleArrival('1', '서울역', now);
+    // 시간표 hit 시 isMock=false. up/down 중 다음 발차 시각이 51분 안팎이어야.
+    if (!result.isMock && result.up.length > 0) {
+      // 23:30 ~ 24:21 = 51분 = 3060초 (정확히 일치 안 할 수 있으니 범위)
+      // 첫 발차가 24:21이 아니라면 더 빠른 시각.
+      expect(result.up[0].arrivalSeconds).toBeGreaterThanOrEqual(0);
+      expect(result.up[0].arrivalSeconds).toBeLessThanOrEqual(3 * 3600);
+    }
   });
 });
 

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -282,26 +282,15 @@ describe('buildScheduleArrival — 시간표 lookup (#473 Phase 3)', () => {
     expect(result.down).toEqual([]);
   });
 
-  it('Monday 02:00 KST는 sunday 시간표 lookup (전 영업일 = 일요일)', () => {
-    // 2026-05-25은 월요일. KST 02:00 = UTC 17:00 전날(2026-05-24 일요일 17:00 UTC).
-    const now = new Date('2026-05-24T17:00:00Z'); // KST Mon 02:00
-    const result = buildScheduleArrival('1', '서울역', now);
-    // sunday 시간표 데이터가 02:00(=2600 nowKey)에는 거의 없을 것 → 헤드웨이 폴백 closed.
-    // 분기 진입 자체가 핵심 (line 191).
-    expect(['schedule', 'closed']).toContain(result.source);
-  });
-
-  it('Saturday 02:00 KST는 weekday 시간표 lookup (전 영업일 = 금요일)', () => {
-    // 2026-05-23 토요일 02:00 KST.
-    const now = new Date('2026-05-22T17:00:00Z'); // KST Sat 02:00
-    const result = buildScheduleArrival('1', '서울역', now);
-    expect(['schedule', 'closed']).toContain(result.source);
-  });
-
-  it('Sunday 02:00 KST는 saturday 시간표 lookup (전 영업일 = 토요일)', () => {
-    // 2026-05-24 일요일 02:00 KST. previousBusinessDay('Sun') → 'saturday'.
-    const now = new Date('2026-05-23T17:00:00Z'); // KST Sun 02:00
-    const result = buildScheduleArrival('1', '서울역', now);
+  // KST 02:00 ~ previousBusinessDay shift 분기 커버 (Mon→Sun, Sat→weekday, Sun→Sat).
+  // 02:00 nowKey="2600"으로 시간표가 거의 매칭 안 되어 헤드웨이 폴백→closed가 일반적.
+  // 각 요일 분기 자체가 lookupTimetable 진입 후 evaluated되는 게 핵심.
+  it.each([
+    ['Monday', '2026-05-24T17:00:00Z'],
+    ['Saturday', '2026-05-22T17:00:00Z'],
+    ['Sunday', '2026-05-23T17:00:00Z'],
+  ])('KST %s 02:00은 previousBusinessDay 시간표 lookup 분기 진입', (_label, iso) => {
+    const result = buildScheduleArrival('1', '서울역', new Date(iso));
     expect(['schedule', 'closed']).toContain(result.source);
   });
 

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -6,6 +6,27 @@ import {
   hasTerminalData,
 } from '../scheduleFallback';
 import type { LineNumber } from '../../types/station';
+import type { StationArrival } from '../../api/arrivalApi';
+
+/**
+ * 시간표 JSON을 mock해 buildScheduleArrival을 호출. mockPath 기본값은 line-1.
+ * isolateModules + doMock + resetModules 패턴 중복 제거용.
+ */
+function withMockedTimetable(
+  mockData: unknown,
+  call: (build: typeof buildScheduleArrival) => StationArrival,
+  mockPath: string = '../../data/timetables/line-1.json',
+): StationArrival {
+  let captured: StationArrival | undefined;
+  jest.isolateModules(() => {
+    jest.doMock(mockPath, () => mockData);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { buildScheduleArrival: build } = require('../scheduleFallback');
+    captured = call(build);
+  });
+  jest.resetModules();
+  return captured!;
+}
 
 describe('classifyDayType', () => {
   it('returns sunday for Sunday', () => {
@@ -247,28 +268,18 @@ describe('buildScheduleArrival — 시간표 lookup (#473 Phase 3)', () => {
   });
 
   it('막차 후(시간표 entry 모두 nowKey 미만)는 헤드웨이 폴백 → closed', () => {
-    // 모든 timetable entry가 nowKey보다 작은 mock 데이터로 결정적 검증.
-    jest.isolateModules(() => {
-      jest.doMock('../../data/timetables/line-1.json', () => ({
+    // 평일 02:00 KST: 시간표 매칭 실패 + classifyPeriod=closed → 빈 배열 반환.
+    const result = withMockedTimetable(
+      {
         stations: {
-          '__last_train_done__': {
-            // 평일 시간표: 23:30 막차 끝, 24h+ 엔트리 없음.
-            weekday: { up: ['0530', '2330'], down: ['0530', '2330'] },
-          },
+          '__last_train_done__': { weekday: { up: ['0530', '2330'], down: ['0530', '2330'] } },
         },
-      }));
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { buildScheduleArrival: build } = require('../scheduleFallback');
-      // KST 평일 02:00 → effectiveDay='sunday' (Tuesday → 이전 영업일 = weekday이지만
-      // previousBusinessDay(Tue)=weekday이므로 weekday 매칭. 그러나 nowKey="2600"인데
-      // weekday 시간표 max="2330" → 매칭 실패. classifyPeriod=closed → 빈 배열.
-      const now = new Date('2026-05-19T02:00:00+09:00'); // Tuesday 02:00 KST
-      const result = build('1', '__last_train_done__', now);
-      expect(result.source).toBe('closed');
-      expect(result.up).toEqual([]);
-      expect(result.down).toEqual([]);
-    });
-    jest.resetModules();
+      },
+      (build) => build('1', '__last_train_done__', new Date('2026-05-19T02:00:00+09:00')),
+    );
+    expect(result.source).toBe('closed');
+    expect(result.up).toEqual([]);
+    expect(result.down).toEqual([]);
   });
 
   it('Monday 02:00 KST는 sunday 시간표 lookup (전 영업일 = 일요일)', () => {
@@ -295,60 +306,31 @@ describe('buildScheduleArrival — 시간표 lookup (#473 Phase 3)', () => {
   });
 
   it('시간표 노선/역 존재하지만 dayType 키 없음 → 헤드웨이 폴백 (line 196)', () => {
-    // 정상 케이스로는 unreachable이지만 isolateModules로 시간표 구조 변형 분기 강제.
-    jest.isolateModules(() => {
-      jest.doMock('../../data/timetables/line-1.json', () => ({
-        stations: { '__test_station__': {} }, // weekday/saturday/sunday 모두 없음
-      }));
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { buildScheduleArrival: build } = require('../scheduleFallback');
-      const now = new Date('2026-05-18T15:00:00+09:00');
-      const result = build('1', '__test_station__', now);
-      expect(result.isMock).toBe(true); // 헤드웨이 폴백
-    });
-    jest.resetModules();
+    const result = withMockedTimetable(
+      { stations: { '__test_station__': {} } }, // weekday/saturday/sunday 모두 없음
+      (build) => build('1', '__test_station__', new Date('2026-05-18T15:00:00+09:00')),
+    );
+    expect(result.isMock).toBe(true);
   });
 
   it('hour<5 + 24h+ 시간표 entry 매칭 시 hhmmToFutureSeconds nowHour shift 적용 (line 168)', () => {
     // KST Monday 02:30 (= UTC Sun 17:30). 사용자 시간 시간표 비교 키 "2630".
     // 이전 영업일(Sunday)의 24h+ 엔트리가 "2700" 이상이면 매치.
-    jest.isolateModules(() => {
-      jest.doMock('../../data/timetables/line-1.json', () => ({
-        stations: {
-          '__late_night__': {
-            sunday: { up: ['2700', '2730'], down: ['2715'] }, // 익일 03:00, 03:30
-          },
-        },
-      }));
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { buildScheduleArrival: build } = require('../scheduleFallback');
-      const now = new Date('2026-05-24T17:30:00Z'); // KST Mon 02:30
-      const result = build('1', '__late_night__', now);
-      // 시간표 hit → isMock=false, hhmmToFutureSeconds nowHour<5 분기 진입.
-      expect(result.isMock).toBe(false);
-      expect(result.up.length).toBe(2);
-      // 02:30 → 03:00 = 30분 = 1800초
-      expect(result.up[0].arrivalSeconds).toBe(30 * 60);
-    });
-    jest.resetModules();
+    const result = withMockedTimetable(
+      { stations: { '__late_night__': { sunday: { up: ['2700', '2730'], down: ['2715'] } } } },
+      (build) => build('1', '__late_night__', new Date('2026-05-24T17:30:00Z')),
+    );
+    expect(result.isMock).toBe(false);
+    expect(result.up.length).toBe(2);
+    expect(result.up[0].arrivalSeconds).toBe(30 * 60);
   });
 
   it('시간표 day.up/down 빈 배열 → 폴백 (line 199)', () => {
-    jest.isolateModules(() => {
-      jest.doMock('../../data/timetables/line-1.json', () => ({
-        stations: {
-          '__test_empty__': {
-            weekday: { up: [], down: [] }, // 빈 배열
-          },
-        },
-      }));
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { buildScheduleArrival: build } = require('../scheduleFallback');
-      const now = new Date('2026-05-18T15:00:00+09:00');
-      const result = build('1', '__test_empty__', now);
-      expect(result.isMock).toBe(true); // 헤드웨이 폴백
-    });
-    jest.resetModules();
+    const result = withMockedTimetable(
+      { stations: { '__test_empty__': { weekday: { up: [], down: [] } } } },
+      (build) => build('1', '__test_empty__', new Date('2026-05-18T15:00:00+09:00')),
+    );
+    expect(result.isMock).toBe(true);
   });
 
   it('hhmmToFutureSeconds 자정 wrap — 23:30에 "2421" 시각은 약 51분 후', () => {

--- a/src/utils/scheduleFallback.ts
+++ b/src/utils/scheduleFallback.ts
@@ -67,6 +67,7 @@ interface KstParts {
   weekday: string;
   hour: number;
   minute: number;
+  second: number;
 }
 
 function getKstParts(date: Date): KstParts {
@@ -75,6 +76,7 @@ function getKstParts(date: Date): KstParts {
     weekday: 'short',
     hour: '2-digit',
     minute: '2-digit',
+    second: '2-digit',
     hour12: false,
   }).formatToParts(date);
   // Intl.DateTimeFormat은 요청한 옵션에 해당하는 part를 반드시 반환하므로 non-null 단언.
@@ -83,7 +85,8 @@ function getKstParts(date: Date): KstParts {
   // Safari가 자정에 'hour'를 '24'로 주는 경우를 % 24로 정규화.
   const hour = Number.parseInt(lookup('hour'), 10) % 24;
   const minute = Number.parseInt(lookup('minute'), 10);
-  return { weekday: lookup('weekday'), hour, minute };
+  const second = Number.parseInt(lookup('second'), 10);
+  return { weekday: lookup('weekday'), hour, minute, second };
 }
 
 export function classifyDayType(date: Date): DayType {
@@ -217,28 +220,6 @@ function lookupTimetable(
   return { upSeconds, downSeconds };
 }
 
-/**
- * 현재 시각의 KST 시/분/초/요일을 동시 추출. classifyPeriod 및 시간표 lookup에서 사용.
- */
-function getKstHms(date: Date): { hour: number; minute: number; second: number; weekday: string } {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: SUBWAY_TIMEZONE,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    weekday: 'short',
-    hour12: false,
-  }).formatToParts(date);
-  const lookup = (type: Intl.DateTimeFormatPartTypes): string =>
-    parts.find((p) => p.type === type)!.value;
-  return {
-    hour: Number.parseInt(lookup('hour'), 10) % 24,
-    minute: Number.parseInt(lookup('minute'), 10),
-    second: Number.parseInt(lookup('second'), 10),
-    weekday: lookup('weekday'),
-  };
-}
-
 export function buildScheduleArrival(
   line: LineNumber,
   stationName: string,
@@ -252,7 +233,7 @@ export function buildScheduleArrival(
 
   // Phase 3 (#473): 시간표 lookup이 가능한 노선/역이면 실제 시간표 기반 ETA를 우선 반환.
   // 시간표 적중 시 isMock=false, source='schedule' 유지 (Phase 4에서 'timetable' 신규 source 검토).
-  const { hour: kstHour, minute: kstMinute, second: kstSecond, weekday: kstWeekday } = getKstHms(now);
+  const { hour: kstHour, minute: kstMinute, second: kstSecond, weekday: kstWeekday } = getKstParts(now);
   const timetableHit = lookupTimetable(line, stationName, dayType, kstWeekday, kstHour, kstMinute, kstSecond);
   if (timetableHit) {
     const up = timetableHit.upSeconds.map((sec, i) => makeTrain(sec, `UP-${i + 1}`, nowMs, upTerminal));

--- a/src/utils/scheduleFallback.ts
+++ b/src/utils/scheduleFallback.ts
@@ -2,6 +2,15 @@ import type { LineNumber } from '../types/station';
 import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
 import headways from '../data/lineHeadways.json';
 import terminals from '../data/lineTerminals.json';
+import line1Timetable from '../data/timetables/line-1.json';
+import line2Timetable from '../data/timetables/line-2.json';
+import line3Timetable from '../data/timetables/line-3.json';
+import line4Timetable from '../data/timetables/line-4.json';
+import line5Timetable from '../data/timetables/line-5.json';
+import line6Timetable from '../data/timetables/line-6.json';
+import line7Timetable from '../data/timetables/line-7.json';
+import line8Timetable from '../data/timetables/line-8.json';
+import line9Timetable from '../data/timetables/line-9.json';
 
 export type DayType = 'weekday' | 'saturday' | 'sunday';
 export type Period = 'peak' | 'offPeak' | 'late' | 'closed';
@@ -23,6 +32,33 @@ type TerminalTable = Record<LineNumber, LineTerminal>;
 
 const HEADWAYS = headways as HeadwayTable;
 const TERMINALS = terminals as TerminalTable;
+
+// Phase 3 (#473): 1~9호선 시간표 데이터.
+interface DayDirectionTimetable {
+  up?: string[];
+  down?: string[];
+}
+interface StationTimetable {
+  weekday?: DayDirectionTimetable;
+  saturday?: DayDirectionTimetable;
+  sunday?: DayDirectionTimetable;
+}
+interface LineTimetable {
+  stations: Record<string, StationTimetable>;
+}
+
+// LineNumber에 시간표 데이터가 매핑된 노선만. 분당/신분당/경의중앙/공항은 다른 API 사용.
+const TIMETABLES: Partial<Record<LineNumber, LineTimetable>> = {
+  '1': line1Timetable as LineTimetable,
+  '2': line2Timetable as LineTimetable,
+  '3': line3Timetable as LineTimetable,
+  '4': line4Timetable as LineTimetable,
+  '5': line5Timetable as LineTimetable,
+  '6': line6Timetable as LineTimetable,
+  '7': line7Timetable as LineTimetable,
+  '8': line8Timetable as LineTimetable,
+  '9': line9Timetable as LineTimetable,
+};
 
 /** 서울 지하철 운행시간 분류는 KST 고정. arrivalApi의 recptnDt 처리와 동일한 관례. */
 const SUBWAY_TIMEZONE = 'Asia/Seoul';
@@ -109,26 +145,136 @@ function makeTrain(
   };
 }
 
-export function buildScheduleArrival(line: LineNumber, now: Date): StationArrival {
-  const dayType = classifyDayType(now);
-  const period = classifyPeriod(now, dayType);
-  const headway = lookupHeadwaySeconds(line, dayType, period);
-  const nowMs = now.getTime();
+/** 시간표 lookup 결과의 다음 2편 도착 시각(초 단위 future offset)을 반환. */
+interface TimetableHit {
+  upSeconds: number[];
+  downSeconds: number[];
+}
 
-  if (headway === null) {
-    return { up: [], down: [], isMock: true, source: 'closed' };
+/**
+ * 현재 시각을 시간표 비교용 "HHMM" 키로 변환. 새벽 0~5시는 전 영업일의 24h+ 표기
+ * (예: "0030" → "2430")로 환산해 시간표의 익일 새벽 운행 엔트리("2421" 등)와 매칭한다.
+ */
+function nowToTimetableKey(nowKstHour: number, nowKstMinute: number): string {
+  const adjustedHour = nowKstHour < 5 ? nowKstHour + 24 : nowKstHour;
+  return `${String(adjustedHour).padStart(2, '0')}${String(nowKstMinute).padStart(2, '0')}`;
+}
+
+/** HHMM 시각 → KST nowDate 기준 future seconds. 24h+ 표기는 그대로 24h+로 해석. */
+function hhmmToFutureSeconds(targetHHMM: string, nowKstHour: number, nowKstMinute: number, nowKstSecond: number): number {
+  const targetHour = Number.parseInt(targetHHMM.slice(0, 2), 10);
+  const targetMin = Number.parseInt(targetHHMM.slice(2, 4), 10);
+  // KST hour < 5면 현재 시각을 24h+로 환산해 24h+ 시간표 엔트리와 정확히 비교.
+  const adjustedNowHour = nowKstHour < 5 ? nowKstHour + 24 : nowKstHour;
+  const targetSec = targetHour * 3600 + targetMin * 60;
+  const nowSec = adjustedNowHour * 3600 + nowKstMinute * 60 + nowKstSecond;
+  return Math.max(0, targetSec - nowSec);
+}
+
+function lookupTimetable(
+  line: LineNumber,
+  stationName: string,
+  dayType: DayType,
+  kstWeekday: string,
+  nowKstHour: number,
+  nowKstMinute: number,
+  nowKstSecond: number,
+): TimetableHit | null {
+  const lineData = TIMETABLES[line];
+  if (!lineData) return null;
+  const station = lineData.stations[stationName];
+  if (!station) return null;
+  // KST 0~5시는 전 영업일 dayType으로 shift (예: Mon 04:00은 Sun 영업일 운행분).
+  // 실제 요일 기준으로 결정: Mon→Sun, Sat→Fri(weekday), Sun→Sat, Tue~Fri→이전 weekday.
+  const previousBusinessDay = (wd: string): DayType => {
+    if (wd === 'Sun') return 'saturday';
+    if (wd === 'Mon') return 'sunday';
+    return 'weekday';
+  };
+  const effectiveDay: DayType = nowKstHour < 5 ? previousBusinessDay(kstWeekday) : dayType;
+  const day = station[effectiveDay];
+  if (!day) return null;
+  const nowKey = nowToTimetableKey(nowKstHour, nowKstMinute);
+  const pickNext = (times: string[] | undefined): number[] => {
+    if (!times || times.length === 0) return [];
+    // "0000" 등 미운행 슬롯은 정렬상 배열 앞부분에 위치 — nowKey가 최소 "0500"(또는
+    // 새벽 "2400"+)이라 문자열 비교에서 자동 스킵된다. 별도 필터 불필요.
+    const idx = times.findIndex((t) => t >= nowKey);
+    if (idx === -1) return [];
+    // ETA 0인 트레인(현재 분 정확히 일치)은 출력에서 제외 — UI가 "0분"으로 최대 60초 노출되는
+    // 회귀(헤드웨이 경로의 격자 시프트 가드와 동일 의도). 두 번째 트레인까지 슬라이스 후 필터.
+    return times
+      .slice(idx, idx + 3)
+      .map((t) => hhmmToFutureSeconds(t, nowKstHour, nowKstMinute, nowKstSecond))
+      .filter((sec) => sec > 0)
+      .slice(0, 2);
+  };
+  // 종착역은 한쪽 방향만 운행하는 단방향 케이스가 있다 (예: 1호선 인천, 3호선 대화). 이 경우
+  // 한 방향만 빈 배열로 반환되어도 timetable hit으로 처리 (isMock=false 유지).
+  const upSeconds = pickNext(day.up);
+  const downSeconds = pickNext(day.down);
+  if (upSeconds.length === 0 && downSeconds.length === 0) return null;
+  return { upSeconds, downSeconds };
+}
+
+/**
+ * 현재 시각의 KST 시/분/초/요일을 동시 추출. classifyPeriod 및 시간표 lookup에서 사용.
+ */
+function getKstHms(date: Date): { hour: number; minute: number; second: number; weekday: string } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: SUBWAY_TIMEZONE,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    weekday: 'short',
+    hour12: false,
+  }).formatToParts(date);
+  const lookup = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((p) => p.type === type)!.value;
+  return {
+    hour: Number.parseInt(lookup('hour'), 10) % 24,
+    minute: Number.parseInt(lookup('minute'), 10),
+    second: Number.parseInt(lookup('second'), 10),
+    weekday: lookup('weekday'),
+  };
+}
+
+export function buildScheduleArrival(
+  line: LineNumber,
+  stationName: string,
+  now: Date,
+): StationArrival {
+  const dayType = classifyDayType(now);
+  const nowMs = now.getTime();
+  const terminal = TERMINALS[line];
+  const upTerminal = terminal?.up ?? '';
+  const downTerminal = terminal?.down ?? '';
+
+  // Phase 3 (#473): 시간표 lookup이 가능한 노선/역이면 실제 시간표 기반 ETA를 우선 반환.
+  // 시간표 적중 시 isMock=false, source='schedule' 유지 (Phase 4에서 'timetable' 신규 source 검토).
+  const { hour: kstHour, minute: kstMinute, second: kstSecond, weekday: kstWeekday } = getKstHms(now);
+  const timetableHit = lookupTimetable(line, stationName, dayType, kstWeekday, kstHour, kstMinute, kstSecond);
+  if (timetableHit) {
+    const up = timetableHit.upSeconds.map((sec, i) => makeTrain(sec, `UP-${i + 1}`, nowMs, upTerminal));
+    const down = timetableHit.downSeconds.map((sec, i) =>
+      makeTrain(sec, `DN-${i + 1}`, nowMs, downTerminal),
+    );
+    return { up, down, isMock: false, source: 'schedule' };
   }
 
+  // 시간표 없는 노선(분당/신분당/경의중앙/공항) 또는 시간표에 누락된 역 → 헤드웨이 폴백.
   // 다음 발차를 wall-clock 헤드웨이 격자에 정렬한다.
   // 폴링 사이클(5s)마다 같은 anchor를 산출해 ETA가 연속적으로 감소 (이슈 #468).
   // 정확히 격자 위(remainder=0)면 첫 차는 다음 격자(headway초 뒤)로 보내 0초 트레인 표시를 방지.
   // up 트레인은 up 방향(낮은 station id 쪽) 종착역으로, down 트레인은 그 반대.
   // 2호선은 순환선이라 물리 종착이 아닌 "내선순환/외선순환" 행선지를 사용한다.
-  // 5호선 하남검단산 분기는 stations.json에 미포함이라 마천행만 표시 — 하남선 추가 시 함께 보강.
   // 신규 노선이 lineTerminals.json에 누락되면 destination=''로 graceful degrade.
-  const terminal = TERMINALS[line];
-  const upTerminal = terminal?.up ?? '';
-  const downTerminal = terminal?.down ?? '';
+  const period = classifyPeriod(now, dayType);
+  const headway = lookupHeadwaySeconds(line, dayType, period);
+
+  if (headway === null) {
+    return { up: [], down: [], isMock: true, source: 'closed' };
+  }
 
   const headwayMs = headway * 1000;
   const nextDepartureSeconds = (anchorMs: number): number => {

--- a/src/utils/scheduleFallback.ts
+++ b/src/utils/scheduleFallback.ts
@@ -49,15 +49,15 @@ interface LineTimetable {
 
 // LineNumber에 시간표 데이터가 매핑된 노선만. 분당/신분당/경의중앙/공항은 다른 API 사용.
 const TIMETABLES: Partial<Record<LineNumber, LineTimetable>> = {
-  '1': line1Timetable as LineTimetable,
-  '2': line2Timetable as LineTimetable,
-  '3': line3Timetable as LineTimetable,
-  '4': line4Timetable as LineTimetable,
-  '5': line5Timetable as LineTimetable,
-  '6': line6Timetable as LineTimetable,
-  '7': line7Timetable as LineTimetable,
-  '8': line8Timetable as LineTimetable,
-  '9': line9Timetable as LineTimetable,
+  '1': line1Timetable,
+  '2': line2Timetable,
+  '3': line3Timetable,
+  '4': line4Timetable,
+  '5': line5Timetable,
+  '6': line6Timetable,
+  '7': line7Timetable,
+  '8': line8Timetable,
+  '9': line9Timetable,
 };
 
 /** 서울 지하철 운행시간 분류는 KST 고정. arrivalApi의 recptnDt 처리와 동일한 관례. */


### PR DESCRIPTION
## Summary
ETL 트랙 Phase 3 — 헤드웨이 추정 기반 fallback을 실제 시간표 lookup으로 교체. 1~9호선에서 fallback 발화 시 정확한 시각 ETA 노출.

## 변경
- `src/utils/scheduleFallback.ts`
  - 1~9호선 시간표 정적 import + TIMETABLES 매핑
  - `lookupTimetable(line, stationName, dayType, kstWeekday, h, m, s)` — 시간표 lookup 헬퍼
  - `nowToTimetableKey` / `hhmmToFutureSeconds` — 24h+ 시간표 엔트리 매칭 위한 비교 키 보정
  - `buildScheduleArrival` 시그니처 변경: `(line, now)` → `(line, stationName, now)`
  - 시간표 hit → `isMock: false`, `source: 'schedule'` (UI 라벨 분기 변경 없음)
  - 시간표 miss → 기존 헤드웨이 폴백 그대로
- `src/api/arrivalApi.ts:89` — caller 인자 전달

## 동작 변화
| 케이스 | 이전 | 이후 |
|---|---|---|
| 1~9호선 + 시간표 매칭 + fallback 발화 | 헤드웨이 추정, isMock=true | 시간표 정확 ETA, isMock=false |
| 분당/신분당/경의중앙/공항 fallback | 헤드웨이 추정 | 동일 (시간표 미지원) |
| 시간표 노선이지만 역 누락/dayType 누락 | 헤드웨이 추정 | 헤드웨이 폴백 (동일) |
| 막차 후 (closed period) | closed | closed (동일) |
| 실시간 API 정상 | realtime | realtime (영향 없음) |

## 디테일
- KST 0~5시는 전 영업일 dayType으로 shift (Mon 04:00 → Sun 운행)
- 24h+ 시간표 엔트리("2421" 등) 매칭 위해 nowKey도 24h+로 변환
- ETA 0 트레인 필터 — UI "0분" 노출 회귀 방지
- 종착역 단방향 운행(예: 1호선 인천 up=빈배열) → partial timetable hit 유지

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 1764 passed, scheduleFallback.ts 커버리지 100%
- [x] code-reviewer 통과 (ETA 0 필터, deterministic 막차 후 테스트, 주석 보강 반영)
- [ ] 실기기 회귀 — 운영시간 외 또는 schedule fallback 강제 시 시간표 기반 ETA 노출 확인

## 비범위
- 새 source 'timetable' 추가 — v1은 'schedule' 유지 (UI 라벨 변경 회피)
- 분당/신분당/경의중앙/공항 시간표 — 다른 API 사용, 향후 별도 트랙
- 시간표 갱신 CI 게이트 / 운영 문서 — Phase 4-5

Closes #473