### PR TITLE
fix(#541): BG에서 trip이 사라지는 회귀 — destination 영속화 복원

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -51,6 +51,7 @@ export default function HomeScreen() {
   const loadFavorites = useAppStore((s) => s.loadFavorites);
   const destination = useAppStore((s) => s.destination);
   const setDestination = useAppStore((s) => s.setDestination);
+  const loadDestination = useAppStore((s) => s.loadDestination);
   const recentDestination = useAppStore((s) => s.recentDestination);
   const setRecentDestination = useAppStore((s) => s.setRecentDestination);
   const sleepMode = useAppStore((s) => s.sleepMode);
@@ -196,6 +197,9 @@ export default function HomeScreen() {
     loadCustomOrigin();
     loadRoutePreference();
     loadAlarmEvent();
+    // iOS가 BG에서 앱을 메모리 압박으로 종료하면 Zustand 상태는 휘발되지만
+    // DESTINATION_KEY는 디스크에 남는다. 콜드/웜 부팅 시 복원해 trip을 이어간다 (#541).
+    loadDestination();
     initStationNotification().catch((e) => logger.error('알림 초기화 실패:', e));
     registerSilentPushTask().catch((e) => logger.error('silent push task 등록 실패:', e));
     const subscription = AppState.addEventListener('change', (state) => {

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -178,6 +178,34 @@ describe('useAppStore', () => {
     // 에러 없이 완료
   });
 
+  it('loadDestination: AsyncStorage에 저장된 목적지를 상태로 복원한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockStation));
+
+    const { loadDestination } = useAppStore.getState();
+    await loadDestination();
+
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('subway-now:destination');
+    expect(useAppStore.getState().destination?.id).toBe('2-022');
+  });
+
+  it('loadDestination: 저장된 값이 없으면 destination이 null로 유지된다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { loadDestination } = useAppStore.getState();
+    await loadDestination();
+
+    expect(useAppStore.getState().destination).toBeNull();
+  });
+
+  it('loadDestination: AsyncStorage 실패 시 destination이 null로 유지된다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('읽기 실패'));
+
+    const { loadDestination } = useAppStore.getState();
+    await loadDestination();
+
+    expect(useAppStore.getState().destination).toBeNull();
+  });
+
   it('초기 recentDestination은 null이다', () => {
     const { recentDestination } = useAppStore.getState();
     expect(recentDestination).toBeNull();

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -34,6 +34,7 @@ interface AppState {
   removeFavorite: (stationId: string) => Promise<void>;
   loadFavorites: () => Promise<void>;
   setDestination: (station: Station | null) => void;
+  loadDestination: () => Promise<void>;
   setRecentDestination: (station: Station | null) => void;
   setCustomOrigin: (station: Station | null) => void;
   loadCustomOrigin: () => Promise<void>;
@@ -106,6 +107,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
       clearFiredAlarms().catch(noop);
       AsyncStorage.removeItem(ROUTE_KEY).catch(noop);
+    }
+  },
+
+  loadDestination: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(DESTINATION_KEY);
+      if (raw) {
+        set({ destination: JSON.parse(raw) });
+      }
+    } catch {
+      // 저장된 데이터 없음 — null 유지
     }
   },
 


### PR DESCRIPTION
## Summary

iOS가 BG 메모리 압박으로 앱을 종료하면 Zustand `destination`이 휘발되는데, 디스크의 `DESTINATION_KEY`를 다시 읽어오는 `loadDestination` 함수가 아예 없어 trip이 사라지는 회귀.

- **Root cause**: `useAppStore`에 `setDestination`은 디스크에 쓰지만 짝이 되는 loader가 누락.
- **Fix**:
  - `useAppStore`에 `loadDestination` 추가 (기존 `loadCustomOrigin` 패턴 그대로)
  - `app/(tabs)/index.tsx` 마운트 effect에서 호출
- **BG task 영향 없음**: `silentPushTask`/`scheduledAlarmReceiver`/`backgroundLocationTask`는 모두 `AsyncStorage.getItem(DESTINATION_KEY)`를 직접 호출 → Zustand 미경유.

## 의존 트랙 해소

- #542 (BG silent push 실기기 검증): 본 fix가 선행. trip 살아있어야 silent push 발사 조건 충족.
- #534/#506/#494: 모두 trip 의존 → 회복.

## Test plan

- [x] `npm test` 전체 1768/1768 pass, 100% 커버리지 유지
- [x] `npm run type-check` pass
- [x] code-reviewer P0/P1 없음
- [ ] **실기기 회귀 검증** (Release 빌드 설치 후):
  - [ ] 출발/도착 설정 → BG 진입 10분+ → FG 복귀 시 trip 유지
  - [ ] 콜드킬 후 재기동 시에도 destination 복원
  - [ ] 복원 후 silent push 발사 조건 충족 (별도 #542 트랙)

Closes #541