### PR TITLE
feat(#545): 목적지 설정 즐겨찾기 빠른 선택 chip

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -647,6 +647,7 @@ export default function HomeScreen() {
         }}
         onClose={() => setPickerVisible(false)}
         recentDestination={recentDestination}
+        favorites={favorites}
         userLat={userLocation?.lat ?? null}
         userLng={userLocation?.lng ?? null}
         onRecenter={() => {

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
+  ScrollView,
   StyleSheet,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
@@ -13,7 +14,7 @@ import type { Station } from '../types/station';
 import { StationMap } from './StationMap';
 import { StationSuggestionList } from './StationSuggestionList';
 import { createLogger } from '../utils/logger';
-import { matchesStationQuery } from '../utils/stationDisplay';
+import { matchesStationQuery, getStationDisplayName } from '../utils/stationDisplay';
 import { useTheme, spacing, radius } from '../theme';
 
 const logger = createLogger('DestinationPicker');
@@ -26,6 +27,7 @@ interface Props {
   readonly onSelect: (station: Station) => void;
   readonly onClose: () => void;
   readonly recentDestination?: Station | null;
+  readonly favorites?: readonly Station[];
   readonly userLat?: number | null;
   readonly userLng?: number | null;
   readonly onRecenter?: () => void;
@@ -38,6 +40,7 @@ export function DestinationPicker({
   userLat,
   userLng,
   recentDestination,
+  favorites,
   onRecenter,
 }: Props) {
   const [query, setQuery] = useState('');
@@ -63,6 +66,13 @@ export function DestinationPicker({
     if (!userLat || !userLng) return [];
     return allStations;
   }, [userLat, userLng]);
+
+  // 즐겨찾기 chip — 빠른 선택용. recentDestination이 favorites에 포함되면 중복 제거.
+  const favoriteChips = useMemo(() => {
+    if (!favorites || favorites.length === 0) return [];
+    const recentId = recentDestination?.id;
+    return recentId ? favorites.filter((f) => f.id !== recentId) : favorites;
+  }, [favorites, recentDestination]);
 
   const suggestions = useMemo(() => {
     const q = query.trim();
@@ -125,6 +135,28 @@ export function DestinationPicker({
             onFocus={() => setShowDropdown(true)}
             testID="search-input"
           />
+          {favoriteChips.length > 0 && !showDropdown && (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.chipScroll}
+              contentContainerStyle={styles.chipRow}
+              testID="favorites-chip-row"
+            >
+              {favoriteChips.map((fav) => (
+                <TouchableOpacity
+                  key={fav.id}
+                  style={[styles.chip, { backgroundColor: colors.card, borderColor: colors.hair }]}
+                  onPress={() => handleSelect(fav)}
+                  testID={`favorite-chip-${fav.id}`}
+                >
+                  <Text style={[styles.chipText, { color: colors.ink }]}>
+                    {getStationDisplayName(fav)}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          )}
           {showDropdown && (
             <View style={styles.dropdownWrap}>
               <StationSuggestionList
@@ -204,6 +236,23 @@ const styles = StyleSheet.create({
   dropdownWrap: {
     marginHorizontal: spacing.xl,
     marginTop: 4,
+  },
+  chipScroll: {
+    marginTop: spacing.sm,
+  },
+  chipRow: {
+    paddingHorizontal: spacing.xl,
+    gap: spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.pill,
+    borderWidth: 1,
+  },
+  chipText: {
+    fontSize: 14,
+    fontWeight: '600',
   },
   recenterButton: {
     position: 'absolute',

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -160,6 +160,77 @@ describe('DestinationPicker', () => {
     expect(() => fireEvent.press(getByTestId('recenter-button'))).not.toThrow();
   });
 
+  it('favorites가 비어있거나 미제공이면 chip 영역을 렌더링하지 않는다', () => {
+    const { queryByTestId, rerender } = render(<DestinationPicker {...defaultProps} />);
+    expect(queryByTestId('favorites-chip-row')).toBeNull();
+
+    rerender(<DestinationPicker {...defaultProps} favorites={[]} />);
+    expect(queryByTestId('favorites-chip-row')).toBeNull();
+  });
+
+  it('favorites가 있으면 chip을 렌더링하고 탭 시 onSelect를 호출한다', () => {
+    const onSelect = jest.fn();
+    const fav: Station = {
+      id: '2-021',
+      name: '역삼',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5006,
+      lng: 127.0365,
+    };
+    const { getByTestId } = render(
+      <DestinationPicker {...defaultProps} favorites={[fav]} onSelect={onSelect} />,
+    );
+    expect(getByTestId('favorites-chip-row')).toBeTruthy();
+    fireEvent.press(getByTestId(`favorite-chip-${fav.id}`));
+    expect(onSelect).toHaveBeenCalledWith(fav);
+  });
+
+  it('검색어를 입력해 드롭다운이 열리면 favorites chip을 숨긴다', () => {
+    const fav: Station = {
+      id: '2-021',
+      name: '역삼',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5006,
+      lng: 127.0365,
+    };
+    const { getByTestId, queryByTestId } = render(
+      <DestinationPicker {...defaultProps} favorites={[fav]} />,
+    );
+    expect(getByTestId('favorites-chip-row')).toBeTruthy();
+    fireEvent.changeText(getByTestId('search-input'), '강남');
+    expect(queryByTestId('favorites-chip-row')).toBeNull();
+  });
+
+  it('recentDestination과 중복되는 즐겨찾기는 chip에서 제외한다', () => {
+    const recent: Station = {
+      id: '2-022',
+      name: '강남',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.498,
+      lng: 127.0279,
+    };
+    const other: Station = {
+      id: '2-021',
+      name: '역삼',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5006,
+      lng: 127.0365,
+    };
+    const { queryByTestId, getByTestId } = render(
+      <DestinationPicker
+        {...defaultProps}
+        favorites={[recent, other]}
+        recentDestination={recent}
+      />,
+    );
+    expect(queryByTestId(`favorite-chip-${recent.id}`)).toBeNull();
+    expect(getByTestId(`favorite-chip-${other.id}`)).toBeTruthy();
+  });
+
   it('검색창 포커스 시 드롭다운 표시 상태가 활성화된다', () => {
     const { getByTestId, queryByTestId } = render(<DestinationPicker {...defaultProps} />);
     fireEvent.changeText(getByTestId('search-input'), '강남');


### PR DESCRIPTION
## Summary

목적지 설정 모달(DestinationPicker)에 등록된 즐겨찾기를 한 번 탭으로 선택할 수 있는 가로 스크롤 chip row를 추가. 매일 출퇴근 사용자의 검색/지도 탐색 부담 제거.

- `favorites?: readonly Station[]` prop 추가
- `recentDestination`과 중복되는 즐겨찾기는 chip에서 제외 (id 기준)
- 검색어 입력 → 드롭다운 열림 → chip 자동 숨김 (이중 노출 방지)
- 빈 favorites는 영역 미표시

## Test plan

- [x] `npm test` 전체 1769/1769 pass, 100% 커버리지 유지
- [x] `npm run type-check` pass
- [x] code-reviewer P0/P1 반영 (chip 숨김 + 불필요한 spread 제거)
- [ ] 실기기 확인: 목적지 모달 열면 즐겨찾기 chip 노출 + 탭 1회로 trip 시작

## Follow-up

- 향후 `destination`이 `recentDestination`과 분기하는 케이스 발생 시 destination도 chip에서 제외 검토 (현재 스코프 밖)
- "집/회사" 별칭 라벨링은 즐겨찾기 스키마 확장 필요 — 별도 이슈로

Closes #545