### PR TITLE
chore(#548): 로컬 작업 노트/CSV gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ subway/
 Live\ Activity.md
 oauth-implementation.md
 subway-now_icon.png
+
+# 로컬 작업 노트 / 데이터 덤프 (이슈/PR 본문으로 관리)
+tasks/
+scripts/CARD_SUBWAY_MONTH_*.csv


### PR DESCRIPTION
## Summary

`tasks/`(로컬 작업 노트, 이슈/PR 본문에서 관리)와 `scripts/CARD_SUBWAY_MONTH_*.csv`(대용량 데이터 덤프)를 gitignore 추가. `git add -A`로 우발 커밋되는 사고 방지.

Closes #548