### PR TITLE
feat(#546): 경로 timeline 전체 역 보기 토글

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -77,6 +77,9 @@ export default function HomeScreen() {
   const loadRoutePreference = useAppStore((s) => s.loadRoutePreference);
   const [categorized, setCategorized] = useState<CategorizedRoute[]>([]);
   const [selectedKey, setSelectedKey] = useState<RoutePreference>(routePreference);
+  // #546: 경로 timeline을 출발/환승/도착 마커만 보일지(false), 모든 정거장을 펼쳐 보일지(true)
+  // 사용자가 토글한다. 세션 in-memory — 재기동 시 compact 기본.
+  const [routeExpanded, setRouteExpanded] = useState(false);
   // categorized/selectedKey가 동일하면 같은 reference를 유지해 하위 훅(LiveActivity,
   // useApnsTripRegistration)의 useEffect가 매 렌더 재발사되는 churn을 막는다.
   const route: Route = useMemo(
@@ -509,7 +512,22 @@ export default function HomeScreen() {
                     </View>
                   )}
                   {journey && (
-                    <EditorialTimeline stops={journeyDisplayToStops(journey)} />
+                    <>
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
+                        onPress={() => setRouteExpanded((v) => !v)}
+                        style={styles.expandToggle}
+                        testID="route-expand-toggle"
+                      >
+                        <Text style={[typography.label, { color: colors.accent, fontWeight: '600' }]}>
+                          {routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
+                        </Text>
+                      </Pressable>
+                      <EditorialTimeline
+                        stops={journeyDisplayToStops(journey, { expanded: routeExpanded })}
+                      />
+                    </>
                   )}
                   {route && effectiveOrigin && destination && (
                     <Pressable
@@ -764,6 +782,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: radius.md,
     alignItems: 'center',
+  },
+  expandToggle: {
+    alignSelf: 'flex-end',
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    marginBottom: spacing.xs,
   },
   sleepRow: {
     flexDirection: 'row',

--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -59,8 +59,13 @@ export function EditorialTimeline({ stops }: Props) {
           ? resolveStopDoor(s.arrivalContext, transferToLine, accessibilityMode)
           : null;
 
+        const isIntermediate = s.mark === 'intermediate';
         return (
-          <View key={i} style={[styles.row, isLast && { minHeight: 36 }]} testID={`timeline-stop-${i}`}>
+          <View
+            key={i}
+            style={[styles.row, isLast && { minHeight: 36 }, isIntermediate && styles.rowIntermediate]}
+            testID={`timeline-stop-${i}`}
+          >
             {!isLast && (
               <View
                 style={[
@@ -80,10 +85,21 @@ export function EditorialTimeline({ stops }: Props) {
               {s.mark === 'dest' && (
                 <View style={[styles.dotDest, { backgroundColor: lineC }]} testID="dest-dot" />
               )}
+              {s.mark === 'intermediate' && (
+                <View
+                  style={[styles.dotIntermediate, { borderColor: lineC, backgroundColor: colors.bg }]}
+                  testID="intermediate-dot"
+                />
+              )}
             </View>
 
             <View style={{ flex: 1 }}>
-              <Text style={[typography.body, { fontWeight: '600', color: colors.ink }]}>
+              <Text
+                style={[
+                  isIntermediate ? typography.bodySm : typography.body,
+                  { fontWeight: isIntermediate ? '400' : '600', color: isIntermediate ? colors.subtle : colors.ink },
+                ]}
+              >
                 {s.station}
               </Text>
               {s.note != null && (
@@ -94,7 +110,7 @@ export function EditorialTimeline({ stops }: Props) {
             </View>
 
             <View style={{ alignItems: 'flex-end' }}>
-              {s.line != null && <LineBadge line={s.line} color={lineC} />}
+              {!isIntermediate && s.line != null && <LineBadge line={s.line} color={lineC} />}
               {s.stopsFromPrev != null && (
                 <Text style={[typography.mono, { color: colors.subtle, marginTop: 2 }]}>
                   {s.stopsFromPrev}
@@ -150,4 +166,6 @@ const styles = StyleSheet.create({
   dot:     { width: 10, height: 10, borderRadius: 5 },
   dotRing: { width: 12, height: 12, borderRadius: 6, borderWidth: 2 },
   dotDest: { width: 12, height: 12, borderRadius: 6 },
+  dotIntermediate: { width: 7, height: 7, borderRadius: 4, borderWidth: 1, marginLeft: 1.5 },
+  rowIntermediate: { minHeight: 30 },
 });

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -204,6 +204,30 @@ describe('EditorialTimeline quickExit door label', () => {
   });
 });
 
+describe('intermediate stop 렌더링', () => {
+  it('intermediate mark는 intermediate-dot을 렌더링한다', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '교대', line: '2', mark: 'intermediate' },
+      { station: '서초', line: '2', stopsFromPrev: '2정거장', mark: 'dest', note: '도착' },
+    ];
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByTestId('intermediate-dot')).toBeTruthy();
+    expect(screen.getByText('교대')).toBeTruthy();
+  });
+
+  it('intermediate stop은 LineBadge를 렌더링하지 않는다', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '교대', line: '2', mark: 'intermediate' },
+      { station: '서초', line: '2', stopsFromPrev: '2정거장', mark: 'dest', note: '도착' },
+    ];
+    render(<EditorialTimeline stops={stops} />);
+    // 2호선 라벨은 출발/도착 stop 2개에서만 노출 (intermediate에서는 미노출)
+    expect(screen.getAllByText('2호선').length).toBe(2);
+  });
+});
+
 describe('mix', () => {
   it('should blend two colors at 50%', () => {
     expect(mix('#FF0000', '#0000FF', 0.5)).toBe('rgb(128,0,128)');

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -32,6 +32,8 @@
     "destinationChange": "Change destination →",
     "destinationReset": "Reset",
     "viewRouteOnMap": "View route on map",
+    "routeExpand": "Show all stops",
+    "routeCollapse": "Show key stops only",
     "destinationSet": "Set destination",
     "previousDestination": "Previous destination",
     "sleepMode": "Sleep mode",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -32,6 +32,8 @@
     "destinationChange": "目的地を変更 →",
     "destinationReset": "リセット",
     "viewRouteOnMap": "地図で経路を見る",
+    "routeExpand": "全駅を表示",
+    "routeCollapse": "主要駅のみ表示",
     "destinationSet": "目的地を設定",
     "previousDestination": "前回の目的地",
     "sleepMode": "おやすみモード",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -32,6 +32,8 @@
     "destinationChange": "목적지 변경 →",
     "destinationReset": "초기화",
     "viewRouteOnMap": "지도에서 경로 보기",
+    "routeExpand": "전체 역 보기",
+    "routeCollapse": "주요 역만 보기",
     "destinationSet": "목적지 설정",
     "previousDestination": "이전 목적지",
     "sleepMode": "취침 모드",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -32,6 +32,8 @@
     "destinationChange": "更改目的地 →",
     "destinationReset": "重置",
     "viewRouteOnMap": "在地图上查看路线",
+    "routeExpand": "显示所有车站",
+    "routeCollapse": "仅显示主要车站",
     "destinationSet": "设置目的地",
     "previousDestination": "上次目的地",
     "sleepMode": "睡眠模式",

--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -112,6 +112,75 @@ describe('journeyDisplayToStops', () => {
       expectedStop('dest', '군자', '5', '2정거장', '환승 → 도착', ctx('7', '건대입구', '군자'), '5'),
     );
   });
+
+  describe('expanded option', () => {
+    it('expanded: false (기본)이면 intermediate stop이 없다', () => {
+      const stops = journeyDisplayToStops(MOCK_JOURNEYS.direct);
+      expect(stops.some((s) => s.mark === 'intermediate')).toBe(false);
+    });
+
+    it('expanded: true이면 segment 사이의 중간 정거장이 intermediate로 삽입된다', () => {
+      // 강남(2-022) → 역삼(2-021): 인접 역이므로 중간역이 없다.
+      const adjacent = journeyDisplayToStops(MOCK_JOURNEYS.direct, { expanded: true });
+      expect(adjacent.filter((s) => s.mark === 'intermediate')).toHaveLength(0);
+
+      // 강남 → 서초(2-024)는 2호선에서 강남(2-022)→교대(2-023)→서초(2-024) 순서.
+      // 중간역 교대 1개가 intermediate로 삽입돼야 한다.
+      const journey: JourneyDisplay = {
+        segments: [{ line: '2', lineColor: '#009D3E', fromName: '강남', toName: '서초', stops: 2 }],
+        totalStops: 2,
+      };
+      const stops = journeyDisplayToStops(journey, { expanded: true });
+      const intermediates = stops.filter((s) => s.mark === 'intermediate');
+      expect(intermediates).toHaveLength(1);
+      expect(intermediates[0].station).toBe('교대');
+      expect(intermediates[0].line).toBe('2');
+      // intermediate는 stopsFromPrev/note/arrivalContext가 없는 슬림 형태
+      expect(intermediates[0].stopsFromPrev).toBeUndefined();
+      expect(intermediates[0].note).toBeUndefined();
+      expect(intermediates[0].arrivalContext).toBeUndefined();
+    });
+
+    it('expanded: 출발/intermediate/도착 순서가 보장된다', () => {
+      const journey: JourneyDisplay = {
+        segments: [{ line: '2', lineColor: '#009D3E', fromName: '강남', toName: '서초', stops: 2 }],
+        totalStops: 2,
+      };
+      const stops = journeyDisplayToStops(journey, { expanded: true });
+      expect(stops.map((s) => s.mark)).toEqual(['filled', 'intermediate', 'dest']);
+    });
+
+    it('expanded: 역방향(toName이 fromName보다 인덱스가 작음)에서도 from→to 순서로 중간역이 나열된다', () => {
+      // 역삼(2-021) → 강남(2-022)은 인접이라 중간역 없음. 더 긴 예: 서초(2-024) → 강남(2-022) (역방향).
+      // 정답 중간역: 교대(2-023).
+      const journey: JourneyDisplay = {
+        segments: [{ line: '2', lineColor: '#009D3E', fromName: '서초', toName: '강남', stops: 2 }],
+        totalStops: 2,
+      };
+      const stops = journeyDisplayToStops(journey, { expanded: true });
+      const intermediates = stops.filter((s) => s.mark === 'intermediate');
+      expect(intermediates.map((s) => s.station)).toEqual(['교대']);
+    });
+
+    it('expanded: seg.stops가 실제 중간역 수와 불일치하면 fallback (invariant guard)', () => {
+      // 강남(2-022) → 서초(2-024) 실제 중간역 = 1개(교대). seg.stops=99(허위)면 guard 발동 → 빈 배열.
+      const journey: JourneyDisplay = {
+        segments: [{ line: '2', lineColor: '#009D3E', fromName: '강남', toName: '서초', stops: 99 }],
+        totalStops: 99,
+      };
+      const stops = journeyDisplayToStops(journey, { expanded: true });
+      expect(stops.some((s) => s.mark === 'intermediate')).toBe(false);
+    });
+
+    it('expanded: 알 수 없는 역명은 중간역 없이 fallback (안전)', () => {
+      const journey: JourneyDisplay = {
+        segments: [{ line: '2', lineColor: '#009D3E', fromName: '없는역A', toName: '없는역B', stops: 0 }],
+        totalStops: 0,
+      };
+      const stops = journeyDisplayToStops(journey, { expanded: true });
+      expect(stops.some((s) => s.mark === 'intermediate')).toBe(false);
+    });
+  });
 });
 
 describe('arrivalInfoToArrivalTrain', () => {

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
-import type { JourneyDisplay } from './stationRoute';
+import type { JourneyDisplay, JourneySegment } from './stationRoute';
+import { getStationsOnLine, isSameStationName } from './stationRoute';
 import type { ArrivalInfo } from '../api/arrivalApi';
 import type { NearestStationResult, LineNumber, Station } from '../types/station';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
@@ -26,7 +27,7 @@ export interface Stop {
   station: string;
   line: string | null;
   stopsFromPrev?: string;
-  mark: 'filled' | 'transfer' | 'dest';
+  mark: 'filled' | 'transfer' | 'dest' | 'intermediate';
   note?: string;
   arrivalContext?: StopArrivalContext;
   transferTarget?: StopTransferTarget;
@@ -54,7 +55,28 @@ export interface HandoffNearest {
 
 const WALK_SPEED_M_PER_MIN = 80;
 
-export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
+// segment의 from/to 사이 중간 정거장을 노선 데이터에서 슬라이스한다.
+// id 정렬 순서가 곧 노선 순서라는 데이터 invariant에 의존한다 (stationRoute.ts).
+// stationRoute의 getIntermediateStationNames(fromId, toId)와 유사하지만 JourneySegment에는
+// id가 없어 name 기반 lookup이 필요하므로 별도 구현 유지.
+function intermediateStationsForSegment(seg: JourneySegment): Station[] {
+  const lineStations = getStationsOnLine(seg.line);
+  const fromIdx = lineStations.findIndex((s) => isSameStationName(s.name, seg.fromName));
+  const toIdx = lineStations.findIndex((s) => isSameStationName(s.name, seg.toName));
+  if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return [];
+  const [lo, hi] = fromIdx < toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
+  const slice = lineStations.slice(lo + 1, hi);
+  // 경로 탐색의 stops 카운트와 중간역 수가 불일치하면 invariant 위반(예: 향후 순환선
+  // wrap-around 최단경로 탐색이 도입될 때 stops=1인데 41개 역이 슬라이스되는 케이스).
+  // 안전하게 빈 배열 fallback.
+  if (slice.length !== seg.stops - 1) return [];
+  return fromIdx < toIdx ? slice : slice.slice().reverse();
+}
+
+export function journeyDisplayToStops(
+  journey: JourneyDisplay,
+  options: { readonly expanded?: boolean } = {},
+): Stop[] {
   const { segments } = journey;
   if (segments.length === 0) return [];
 
@@ -71,6 +93,16 @@ export function journeyDisplayToStops(journey: JourneyDisplay): Stop[] {
         line: seg.line,
         mark: 'filled',
       });
+    }
+
+    if (options.expanded) {
+      for (const mid of intermediateStationsForSegment(seg)) {
+        stops.push({
+          station: getStationDisplayName(mid),
+          line: seg.line,
+          mark: 'intermediate',
+        });
+      }
     }
 
     const arrivalContext: StopArrivalContext = {


### PR DESCRIPTION
## Summary

경로 카드 timeline에 \"전체 역 보기\" 토글 추가. Full 모드에서는 segment의 모든 중간 정거장이 슬림 row로 펼쳐져, 진행 방향(다음 역 이름)을 자연스럽게 확인 가능.

- \`journeyDisplayToStops(journey, { expanded })\` 옵션 도입
- \`Stop.mark\`에 \`'intermediate'\` 추가 — LineBadge / note / quickExit 없는 슬림 row
- 경로 카드 timeline 위 우측에 토글 Pressable (accessibilityRole/Label 포함)
- 토글 상태는 in-memory (세션 종료 시 compact 복귀)
- i18n 4 locale (ko/en/ja/zh)
- **invariant guard**: \`seg.stops - 1\`과 실제 슬라이스된 중간역 수가 불일치하면 빈 배열 fallback (순환선 wrap-around 등 향후 경로 탐색 확장 시 회귀 방지)

## Test plan

- [x] \`npm test\` 1776/1776 pass, 100% 커버리지 유지
- [x] \`npm run type-check\` pass
- [x] code-reviewer P0/P1 반영 (stops guard + 접근성 라벨 + 중복 사유 주석)
- [ ] 실기기 토글 동작 확인 (compact ↔ full)
- [ ] 환승/multi-transfer 경로에서 중간역 정확성

## Follow-up

- 토글 상태 영속화는 사용자 피드백 후 결정 (현재 in-memory만)
- compact 모드에 \"다음역: X\" 작은 라벨 추가 옵션 검토

Closes #546