### PR TITLE
fix(#551): 도착 자동 해제 타이머 race 수정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState, InteractionManager, Pressable, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
@@ -32,6 +32,7 @@ import { SourceBadge } from '../../src/components/SourceBadge';
 import { resolveNotificationSource } from '../../src/utils/notificationSource';
 import { ArrivalSourceNotice } from '../../src/components/ArrivalSourceNotice';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
+import { useArrivalAutoClear } from '../../src/hooks/useArrivalAutoClear';
 
 const logger = createLogger('HomeScreen');
 
@@ -63,8 +64,6 @@ export default function HomeScreen() {
   const clearAlarmEvent = useAppStore((s) => s.clearAlarmEvent);
   const loadAlarmEvent = useAppStore((s) => s.loadAlarmEvent);
   const [pickerVisible, setPickerVisible] = useState(false);
-  const [arrivedBanner, setArrivedBanner] = useState(false);
-  const arrivedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
   const prevDestIdRef = useRef<string | null>(null);
   // #534: route 비동기 계산이 끝나기 전 첫 LA 송출이 일어나면 ETA-less 카드가 잠금화면에
@@ -98,6 +97,13 @@ export default function HomeScreen() {
     [route, tripOrigin, destination],
   );
   const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext);
+  const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
+  const { arrivedBanner } = useArrivalAutoClear({
+    currentStationName: result?.station.name,
+    distanceKm: result?.distanceKm,
+    destinationName: destination?.name,
+    onClear: handleArrivalClear,
+  });
   // AppState listener는 단일-바인딩 패턴이라 deps에 refresh를 추가할 수 없다.
   // 최신 refresh 함수를 ref에 보관해 listener에서 호출한다.
   const refreshRef = useRef(refresh);
@@ -321,20 +327,6 @@ export default function HomeScreen() {
       }
     }
   }, [arrivedBanner]);
-
-  useEffect(() => {
-    if (arrivedBanner) return;
-    if (result && destination && result.station.name === destination.name && result.distanceKm <= 0.5) {
-      setArrivedBanner(true);
-      arrivedTimeoutRef.current = setTimeout(() => {
-        setDestination(null);
-        setArrivedBanner(false);
-      }, 2000);
-    }
-    return () => {
-      if (arrivedTimeoutRef.current) clearTimeout(arrivedTimeoutRef.current);
-    };
-  }, [result?.station.name, destination?.name, result?.distanceKm]);
 
   if (permissionDenied) {
     return (

--- a/src/hooks/__tests__/useArrivalAutoClear.test.ts
+++ b/src/hooks/__tests__/useArrivalAutoClear.test.ts
@@ -1,0 +1,232 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useArrivalAutoClear, type UseArrivalAutoClearParams } from '../useArrivalAutoClear';
+
+type Params = UseArrivalAutoClearParams;
+
+const baseProps = (overrides: Partial<Params> = {}): Params => ({
+  currentStationName: undefined,
+  distanceKm: undefined,
+  destinationName: undefined,
+  onClear: jest.fn(),
+  ...overrides,
+});
+
+describe('useArrivalAutoClear', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('초기 상태에서는 arrivedBanner가 false다', () => {
+    const { result } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps(),
+    });
+    expect(result.current.arrivedBanner).toBe(false);
+  });
+
+  it('도착 조건 충족 시 arrivedBanner=true가 되고 2초 뒤 onClear가 호출되며 banner가 false로 돌아온다', () => {
+    const onClear = jest.fn();
+    const { result } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        destinationName: '용마산',
+        distanceKm: 0.3,
+        onClear,
+      }),
+    });
+
+    expect(result.current.arrivedBanner).toBe(true);
+    expect(onClear).not.toHaveBeenCalled();
+
+    act(() => { jest.advanceTimersByTime(2_000); });
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(result.current.arrivedBanner).toBe(false);
+  });
+
+  it('도착 후 2초 안에 distanceKm이 여러 번 바뀌어도 타이머가 살아남아 onClear가 호출된다 (#551 회귀)', () => {
+    const onClear = jest.fn();
+    const { result, rerender } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        destinationName: '용마산',
+        distanceKm: 0.3,
+        onClear,
+      }),
+    });
+
+    expect(result.current.arrivedBanner).toBe(true);
+
+    act(() => { jest.advanceTimersByTime(500); });
+    rerender(baseProps({ currentStationName: '용마산', destinationName: '용마산', distanceKm: 0.2, onClear }));
+    act(() => { jest.advanceTimersByTime(500); });
+    rerender(baseProps({ currentStationName: '용마산', destinationName: '용마산', distanceKm: 0.1, onClear }));
+    act(() => { jest.advanceTimersByTime(500); });
+    rerender(baseProps({ currentStationName: '용마산', destinationName: '용마산', distanceKm: 0.05, onClear }));
+
+    expect(onClear).not.toHaveBeenCalled();
+
+    act(() => { jest.advanceTimersByTime(500); });
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(result.current.arrivedBanner).toBe(false);
+  });
+
+  it('현재역이 목적지와 다르면 trigger하지 않는다', () => {
+    const onClear = jest.fn();
+    const { result } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '강남',
+        destinationName: '용마산',
+        distanceKm: 0.1,
+        onClear,
+      }),
+    });
+
+    act(() => { jest.advanceTimersByTime(3_000); });
+
+    expect(result.current.arrivedBanner).toBe(false);
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it('거리가 0.5km를 초과하면 trigger하지 않는다', () => {
+    const onClear = jest.fn();
+    const { result } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        destinationName: '용마산',
+        distanceKm: 0.6,
+        onClear,
+      }),
+    });
+
+    expect(result.current.arrivedBanner).toBe(false);
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it('destinationName이 없으면 trigger하지 않는다', () => {
+    const { result } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        distanceKm: 0.1,
+      }),
+    });
+
+    expect(result.current.arrivedBanner).toBe(false);
+  });
+
+  it('currentStationName이 없으면 trigger하지 않는다', () => {
+    const { result } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        destinationName: '용마산',
+        distanceKm: 0.1,
+      }),
+    });
+
+    expect(result.current.arrivedBanner).toBe(false);
+  });
+
+  it('distanceKm이 없으면 trigger하지 않는다', () => {
+    const { result } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        destinationName: '용마산',
+      }),
+    });
+
+    expect(result.current.arrivedBanner).toBe(false);
+  });
+
+  it('도착 트리거 이후 props가 같은 채로 rerender 되어도 새 타이머가 생기지 않는다', () => {
+    const onClear = jest.fn();
+    const props = baseProps({
+      currentStationName: '용마산',
+      destinationName: '용마산',
+      distanceKm: 0.3,
+      onClear,
+    });
+    const { rerender } = renderHook((p: Params) => useArrivalAutoClear(p), { initialProps: props });
+
+    rerender(props);
+    rerender(props);
+
+    act(() => { jest.advanceTimersByTime(2_000); });
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('타이머 발화 전 unmount 되면 pending timer가 정리된다 (onClear 미호출)', () => {
+    const onClear = jest.fn();
+    const { unmount } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        destinationName: '용마산',
+        distanceKm: 0.3,
+        onClear,
+      }),
+    });
+
+    act(() => { jest.advanceTimersByTime(500); });
+    unmount();
+    act(() => { jest.advanceTimersByTime(2_000); });
+
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it('도착 트리거 없는 상태로 unmount 되어도 안전하다', () => {
+    const { unmount } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps(),
+    });
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('도착 후 destination이 null로 리셋되었다가 다시 같은 목적지로 설정되면 재트리거된다', () => {
+    const onClear = jest.fn();
+    const { result, rerender } = renderHook((p: Params) => useArrivalAutoClear(p), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        destinationName: '용마산',
+        distanceKm: 0.3,
+        onClear,
+      }),
+    });
+
+    act(() => { jest.advanceTimersByTime(2_000); });
+    expect(onClear).toHaveBeenCalledTimes(1);
+
+    rerender(baseProps({ currentStationName: '용마산', destinationName: undefined, distanceKm: 0.3, onClear }));
+    rerender(baseProps({ currentStationName: '용마산', destinationName: '용마산', distanceKm: 0.3, onClear }));
+
+    expect(result.current.arrivedBanner).toBe(true);
+    act(() => { jest.advanceTimersByTime(2_000); });
+    expect(onClear).toHaveBeenCalledTimes(2);
+  });
+
+  it('onClear가 바뀌면 최신 콜백이 호출된다', () => {
+    const onClear1 = jest.fn();
+    const onClear2 = jest.fn();
+    const { rerender } = renderHook((props: Params) => useArrivalAutoClear(props), {
+      initialProps: baseProps({
+        currentStationName: '용마산',
+        destinationName: '용마산',
+        distanceKm: 0.3,
+        onClear: onClear1,
+      }),
+    });
+
+    rerender(baseProps({
+      currentStationName: '용마산',
+      destinationName: '용마산',
+      distanceKm: 0.3,
+      onClear: onClear2,
+    }));
+
+    act(() => { jest.advanceTimersByTime(2_000); });
+
+    expect(onClear1).not.toHaveBeenCalled();
+    expect(onClear2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useArrivalAutoClear.ts
+++ b/src/hooks/useArrivalAutoClear.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+
+const ARRIVAL_THRESHOLD_KM = 0.5;
+const CLEAR_DELAY_MS = 2000;
+
+export interface UseArrivalAutoClearParams {
+  currentStationName: string | undefined;
+  distanceKm: number | undefined;
+  destinationName: string | undefined;
+  onClear: () => void;
+}
+
+// #551: 도착 자동 해제 race.
+// 이전 구조는 effect cleanup에서 무조건 clearTimeout을 호출해, deps(distanceKm 등)가 바뀔 때마다
+// 2초 타이머가 지워지고 본문 재진입 시 arrivedBanner=true 가드로 새 타이머가 안 잡혀 영구 잔존했다.
+// 타이머는 일단 set되면 unmount 전까지 살아남도록 분리한다.
+export function useArrivalAutoClear({
+  currentStationName,
+  distanceKm,
+  destinationName,
+  onClear,
+}: UseArrivalAutoClearParams): { arrivedBanner: boolean } {
+  const [arrivedBanner, setArrivedBanner] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedForRef = useRef<string | null>(null);
+  const onClearRef = useRef(onClear);
+
+  useEffect(() => {
+    onClearRef.current = onClear;
+  }, [onClear]);
+
+  useEffect(() => {
+    if (destinationName == null) {
+      firedForRef.current = null;
+    }
+  }, [destinationName]);
+
+  useEffect(() => {
+    if (arrivedBanner) return;
+    if (
+      currentStationName != null &&
+      destinationName != null &&
+      currentStationName === destinationName &&
+      distanceKm != null &&
+      distanceKm <= ARRIVAL_THRESHOLD_KM &&
+      firedForRef.current !== destinationName
+    ) {
+      firedForRef.current = destinationName;
+      setArrivedBanner(true);
+      timeoutRef.current = setTimeout(() => {
+        onClearRef.current();
+        setArrivedBanner(false);
+        timeoutRef.current = null;
+      }, CLEAR_DELAY_MS);
+    }
+  }, [arrivedBanner, currentStationName, distanceKm, destinationName]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  return { arrivedBanner };
+}


### PR DESCRIPTION
## Summary
- 도착 시 2초 후 trip 자동 해제 타이머가 GPS 폴링으로 인한 deps 변경에 cleanup으로 무조건 clear되어 영구 잔존하던 race 수정
- 도착 자동 해제 로직을 `useArrivalAutoClear` 훅으로 추출, 타이머 cleanup을 unmount-only로 분리하고 `firedForRef`로 중복 트리거 방지
- 회귀 케이스 포함 13개 테스트로 hook 100% 커버리지

## Root cause
`app/(tabs)/index.tsx` 이전 코드는 `useEffect`의 cleanup이 deps(`distanceKm` 등) 변경마다 실행되어 2초 타이머를 무조건 `clearTimeout` 했다. 도착 직후 GPS 폴링으로 `distanceKm`이 변경되면 타이머가 지워지고, 본문 재진입 시 `arrivedBanner=true` 가드로 새 타이머가 잡히지 않아 영영 발화하지 못함.

## Test plan
- [x] `useArrivalAutoClear` race 회귀 테스트 (도착 후 distanceKm 여러 번 변경) 통과
- [x] 도착 트리거 / 미트리거 / unmount / 재트리거 경계 케이스
- [x] `npm test` 1793/1793 통과, 커버리지 100%
- [x] `npm run type-check` 통과

Closes #551