### PR TITLE
feat(#552): 즐겨찾기 별칭 라벨링 (집/회사)

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -11,7 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../src/store/useAppStore';
 import { LINE_NAMES } from '../../src/constants/lineColors';
-import { Station } from '../../src/types/station';
+import type { FavoriteEntry, Station } from '../../src/types/station';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../../src/utils/formatTime';
@@ -27,6 +27,7 @@ export default function FavoritesScreen() {
   const favorites = useAppStore((s) => s.favorites);
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
+  const setFavoriteLabel = useAppStore((s) => s.setFavoriteLabel);
   const loadFavorites = useAppStore((s) => s.loadFavorites);
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -38,7 +39,7 @@ export default function FavoritesScreen() {
   }, []);
 
   const selectedStation = useMemo(
-    () => favorites.find((f) => f.id === selectedId) ?? null,
+    () => favorites.find(({ station }) => station.id === selectedId)?.station ?? null,
     [favorites, selectedId],
   );
   const { arrival: rawArrival } = useArrivalInfo(
@@ -84,7 +85,7 @@ export default function FavoritesScreen() {
               <SearchResultCard
                 key={station.id}
                 station={station}
-                already={favorites.some((f) => f.id === station.id)}
+                already={favorites.some((f) => f.station.id === station.id)}
                 onAdd={() => addFavorite(station)}
                 colors={colors}
               />
@@ -99,20 +100,24 @@ export default function FavoritesScreen() {
             </Text>
           </View>
         ) : (
-          favorites.map((station: Station) => (
-            <FavoriteCard
-              key={station.id}
-              station={station}
-              isExpanded={station.id === selectedId}
-              arrival={station.id === selectedId ? arrival : null}
-              onToggle={() => handleToggleSelect(station.id)}
-              onRemove={() => {
-                if (selectedId === station.id) setSelectedId(null);
-                removeFavorite(station.id);
-              }}
-              colors={colors}
-            />
-          ))
+          favorites.map((entry: FavoriteEntry) => {
+            const { id } = entry.station;
+            return (
+              <FavoriteCard
+                key={id}
+                entry={entry}
+                isExpanded={id === selectedId}
+                arrival={id === selectedId ? arrival : null}
+                onToggle={() => handleToggleSelect(id)}
+                onRemove={() => {
+                  if (selectedId === id) setSelectedId(null);
+                  removeFavorite(id);
+                }}
+                onSaveLabel={(label) => setFavoriteLabel(id, label)}
+                colors={colors}
+              />
+            );
+          })
         )}
       </ScrollView>
     </SafeAreaView>
@@ -151,24 +156,39 @@ function SearchResultCard({
 }
 
 function FavoriteCard({
-  station,
+  entry,
   isExpanded,
   arrival,
   onToggle,
   onRemove,
+  onSaveLabel,
   colors,
 }: {
-  station: Station;
+  entry: FavoriteEntry;
   isExpanded: boolean;
   arrival: StationArrival | null;
   onToggle: () => void;
   onRemove: () => void;
+  onSaveLabel: (label?: string) => void;
   colors: ThemeColors;
 }) {
   const { t } = useTranslation();
+  const { station, label } = entry;
+  const [editing, setEditing] = useState(false);
+  const [draftLabel, setDraftLabel] = useState(label ?? '');
   const showRows = arrival != null && arrival.source !== 'closed';
   const emptyArrival =
     showRows && arrival.up.length === 0 && arrival.down.length === 0;
+  const stationDisplay = getStationDisplayName(station);
+  const handleSave = () => {
+    const trimmed = draftLabel.trim();
+    onSaveLabel(trimmed === '' ? undefined : trimmed);
+    setEditing(false);
+  };
+  const handleCancel = () => {
+    setDraftLabel(label ?? '');
+    setEditing(false);
+  };
   return (
     <View style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}>
       {/* Remove 버튼을 onToggle TouchableOpacity 밖 sibling으로 배치.
@@ -179,7 +199,12 @@ function FavoriteCard({
             <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
               <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
             </View>
-            <Text style={[styles.stationName, { color: colors.ink }]}>{getStationDisplayName(station)}</Text>
+            <Text style={[styles.stationName, { color: colors.ink }]}>
+              {label ?? stationDisplay}
+            </Text>
+            {label != null && (
+              <Text style={[styles.subStationName, { color: colors.muted }]}>{stationDisplay}</Text>
+            )}
           </View>
           <Text style={[styles.expandIcon, { color: colors.muted }]}>{isExpanded ? '▲' : '▼'}</Text>
         </TouchableOpacity>
@@ -190,6 +215,48 @@ function FavoriteCard({
 
       {isExpanded && (
         <View style={[styles.arrivalSection, { borderTopColor: colors.hair }]}>
+          <View style={styles.labelEditor}>
+            {editing ? (
+              <>
+                <TextInput
+                  style={[styles.labelInput, { backgroundColor: colors.bg, color: colors.ink, borderColor: colors.hair }]}
+                  value={draftLabel}
+                  onChangeText={setDraftLabel}
+                  placeholder={t('favorites.labelPlaceholder')}
+                  placeholderTextColor={colors.muted}
+                  autoFocus
+                  testID={`favorite-label-input-${station.id}`}
+                />
+                <TouchableOpacity
+                  style={[styles.labelButton, { backgroundColor: colors.accent }]}
+                  onPress={handleSave}
+                  testID={`favorite-label-save-${station.id}`}
+                >
+                  <Text style={[styles.labelButtonText, { color: colors.onAccent }]}>{t('favorites.saveLabel')}</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.labelButton, { backgroundColor: colors.card, borderColor: colors.hair, borderWidth: 1 }]}
+                  onPress={handleCancel}
+                  testID={`favorite-label-cancel-${station.id}`}
+                >
+                  <Text style={[styles.labelButtonText, { color: colors.ink }]}>{t('common.cancel')}</Text>
+                </TouchableOpacity>
+              </>
+            ) : (
+              <TouchableOpacity
+                style={[styles.labelButton, { backgroundColor: colors.card, borderColor: colors.hair, borderWidth: 1 }]}
+                onPress={() => {
+                  setDraftLabel(label ?? '');
+                  setEditing(true);
+                }}
+                testID={`favorite-label-edit-${station.id}`}
+              >
+                <Text style={[styles.labelButtonText, { color: colors.ink }]}>
+                  {label != null ? t('favorites.editLabel') : t('favorites.addLabel')}
+                </Text>
+              </TouchableOpacity>
+            )}
+          </View>
           {arrival == null && (
             <Text style={[styles.noArrival, { color: colors.muted }]}>{t('home.loading')}</Text>
           )}
@@ -319,6 +386,35 @@ const styles = StyleSheet.create({
   stationName: {
     fontSize: 20,
     fontWeight: '700',
+  },
+  subStationName: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  labelEditor: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  labelInput: {
+    flex: 1,
+    minWidth: 120,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    borderWidth: 1,
+  },
+  labelButton: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  labelButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
   },
   removeButton: {
     paddingHorizontal: 14,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -116,7 +116,7 @@ export default function HomeScreen() {
     effectiveOrigin?.line ?? null,
   );
   const arrival = useArrivalCountdown(rawArrival);
-  const isFav = effectiveOrigin ? favorites.some((f) => f.id === effectiveOrigin.id) : false;
+  const isFav = effectiveOrigin ? favorites.some((f) => f.station.id === effectiveOrigin.id) : false;
 
   // 환승역이면 모든 호선 변형에서 경로 계산 → 출발역 환승 없는 최적 경로 자동 선택
   const originVariants = !isCustomOrigin && variants.length > 1 ? variants : effectiveOrigin ? [effectiveOrigin] : [];

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import stations from '../data/stations.json';
-import type { Station } from '../types/station';
+import type { Station, FavoriteEntry } from '../types/station';
 import { StationMap } from './StationMap';
 import { StationSuggestionList } from './StationSuggestionList';
 import { createLogger } from '../utils/logger';
@@ -27,7 +27,7 @@ interface Props {
   readonly onSelect: (station: Station) => void;
   readonly onClose: () => void;
   readonly recentDestination?: Station | null;
-  readonly favorites?: readonly Station[];
+  readonly favorites?: readonly FavoriteEntry[];
   readonly userLat?: number | null;
   readonly userLng?: number | null;
   readonly onRecenter?: () => void;
@@ -67,11 +67,13 @@ export function DestinationPicker({
     return allStations;
   }, [userLat, userLng]);
 
-  // 즐겨찾기 chip — 빠른 선택용. recentDestination이 favorites에 포함되면 중복 제거.
+  // 즐겨찾기 chip — 빠른 선택용. label 없는 항목만 recentDestination과 dedup.
+  // label 있는 chip("집"/"회사")은 직전 목적지여도 의미가 있어 항상 표시.
   const favoriteChips = useMemo(() => {
     if (!favorites || favorites.length === 0) return [];
     const recentId = recentDestination?.id;
-    return recentId ? favorites.filter((f) => f.id !== recentId) : favorites;
+    if (!recentId) return favorites;
+    return favorites.filter(({ station, label }) => label != null || station.id !== recentId);
   }, [favorites, recentDestination]);
 
   const suggestions = useMemo(() => {
@@ -143,15 +145,15 @@ export function DestinationPicker({
               contentContainerStyle={styles.chipRow}
               testID="favorites-chip-row"
             >
-              {favoriteChips.map((fav) => (
+              {favoriteChips.map(({ station, label }) => (
                 <TouchableOpacity
-                  key={fav.id}
+                  key={station.id}
                   style={[styles.chip, { backgroundColor: colors.card, borderColor: colors.hair }]}
-                  onPress={() => handleSelect(fav)}
-                  testID={`favorite-chip-${fav.id}`}
+                  onPress={() => handleSelect(station)}
+                  testID={`favorite-chip-${station.id}`}
                 >
                   <Text style={[styles.chipText, { color: colors.ink }]}>
-                    {getStationDisplayName(fav)}
+                    {label ?? getStationDisplayName(station)}
                   </Text>
                 </TouchableOpacity>
               ))}

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -168,9 +168,9 @@ describe('DestinationPicker', () => {
     expect(queryByTestId('favorites-chip-row')).toBeNull();
   });
 
-  it('favorites가 있으면 chip을 렌더링하고 탭 시 onSelect를 호출한다', () => {
+  it('favorites가 있으면 chip을 렌더링하고 탭 시 onSelect를 Station으로 호출한다', () => {
     const onSelect = jest.fn();
-    const fav: Station = {
+    const favStation: Station = {
       id: '2-021',
       name: '역삼',
       line: '2',
@@ -179,15 +179,19 @@ describe('DestinationPicker', () => {
       lng: 127.0365,
     };
     const { getByTestId } = render(
-      <DestinationPicker {...defaultProps} favorites={[fav]} onSelect={onSelect} />,
+      <DestinationPicker
+        {...defaultProps}
+        favorites={[{ station: favStation }]}
+        onSelect={onSelect}
+      />,
     );
     expect(getByTestId('favorites-chip-row')).toBeTruthy();
-    fireEvent.press(getByTestId(`favorite-chip-${fav.id}`));
-    expect(onSelect).toHaveBeenCalledWith(fav);
+    fireEvent.press(getByTestId(`favorite-chip-${favStation.id}`));
+    expect(onSelect).toHaveBeenCalledWith(favStation);
   });
 
   it('검색어를 입력해 드롭다운이 열리면 favorites chip을 숨긴다', () => {
-    const fav: Station = {
+    const favStation: Station = {
       id: '2-021',
       name: '역삼',
       line: '2',
@@ -196,14 +200,14 @@ describe('DestinationPicker', () => {
       lng: 127.0365,
     };
     const { getByTestId, queryByTestId } = render(
-      <DestinationPicker {...defaultProps} favorites={[fav]} />,
+      <DestinationPicker {...defaultProps} favorites={[{ station: favStation }]} />,
     );
     expect(getByTestId('favorites-chip-row')).toBeTruthy();
     fireEvent.changeText(getByTestId('search-input'), '강남');
     expect(queryByTestId('favorites-chip-row')).toBeNull();
   });
 
-  it('recentDestination과 중복되는 즐겨찾기는 chip에서 제외한다', () => {
+  it('recentDestination과 중복되는 label 없는 즐겨찾기는 chip에서 제외한다', () => {
     const recent: Station = {
       id: '2-022',
       name: '강남',
@@ -223,12 +227,32 @@ describe('DestinationPicker', () => {
     const { queryByTestId, getByTestId } = render(
       <DestinationPicker
         {...defaultProps}
-        favorites={[recent, other]}
+        favorites={[{ station: recent }, { station: other }]}
         recentDestination={recent}
       />,
     );
     expect(queryByTestId(`favorite-chip-${recent.id}`)).toBeNull();
     expect(getByTestId(`favorite-chip-${other.id}`)).toBeTruthy();
+  });
+
+  it('label 있는 즐겨찾기는 recentDestination과 중복돼도 chip을 표시하고 label을 노출한다', () => {
+    const home: Station = {
+      id: '2-022',
+      name: '강남',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.498,
+      lng: 127.0279,
+    };
+    const { getByTestId, getByText } = render(
+      <DestinationPicker
+        {...defaultProps}
+        favorites={[{ station: home, label: '집' }]}
+        recentDestination={home}
+      />,
+    );
+    expect(getByTestId(`favorite-chip-${home.id}`)).toBeTruthy();
+    expect(getByText('집')).toBeTruthy();
   });
 
   it('검색창 포커스 시 드롭다운 표시 상태가 활성화된다', () => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -95,7 +95,11 @@
     "noSearchResults": "No search results",
     "empty": "No favorites yet",
     "emptyDescription": "Search stations above and add\nthem to your favorites.",
-    "remove": "Remove"
+    "remove": "Remove",
+    "addLabel": "Add label",
+    "editLabel": "Edit label",
+    "saveLabel": "Save",
+    "labelPlaceholder": "Home, Work, etc."
   },
   "alarmOverlay": {
     "transferTitle": "Transfer alert",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -95,7 +95,11 @@
     "noSearchResults": "検索結果がありません",
     "empty": "お気に入りはまだありません",
     "emptyDescription": "上の検索窓で駅を検索して\nお気に入りに追加できます。",
-    "remove": "削除"
+    "remove": "削除",
+    "addLabel": "ラベル追加",
+    "editLabel": "ラベル編集",
+    "saveLabel": "保存",
+    "labelPlaceholder": "自宅、会社など"
   },
   "alarmOverlay": {
     "transferTitle": "乗換アラーム",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -95,7 +95,11 @@
     "noSearchResults": "검색 결과가 없습니다",
     "empty": "즐겨찾기가 없습니다",
     "emptyDescription": "위 검색창에서 역을 검색해 즐겨찾기에\n추가할 수 있습니다.",
-    "remove": "삭제"
+    "remove": "삭제",
+    "addLabel": "별칭 추가",
+    "editLabel": "별칭 편집",
+    "saveLabel": "저장",
+    "labelPlaceholder": "집, 회사 등"
   },
   "alarmOverlay": {
     "transferTitle": "환승 알림",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -95,7 +95,11 @@
     "noSearchResults": "无搜索结果",
     "empty": "还没有收藏",
     "emptyDescription": "在上方搜索车站\n添加到收藏。",
-    "remove": "删除"
+    "remove": "删除",
+    "addLabel": "添加别名",
+    "editLabel": "编辑别名",
+    "saveLabel": "保存",
+    "labelPlaceholder": "家、公司等"
   },
   "alarmOverlay": {
     "transferTitle": "换乘提醒",

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -41,7 +41,24 @@ describe('useAppStore', () => {
 
     const { favorites } = useAppStore.getState();
     expect(favorites).toHaveLength(1);
-    expect(favorites[0].id).toBe('2-022');
+    expect(favorites[0].station.id).toBe('2-022');
+    expect(favorites[0].label).toBeUndefined();
+  });
+
+  it('addFavorite: label과 함께 추가하면 entry에 label이 저장된다', async () => {
+    const { addFavorite } = useAppStore.getState();
+    await addFavorite(mockStation, '집');
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites[0].label).toBe('집');
+  });
+
+  it('addFavorite: 빈 문자열 label은 무시한다', async () => {
+    const { addFavorite } = useAppStore.getState();
+    await addFavorite(mockStation, '');
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites[0].label).toBeUndefined();
   });
 
   it('동일한 역을 중복 추가해도 한 번만 저장된다', async () => {
@@ -71,13 +88,13 @@ describe('useAppStore', () => {
     expect(favorites).toHaveLength(1);
   });
 
-  it('addFavorite 호출 시 AsyncStorage에 저장한다', async () => {
+  it('addFavorite 호출 시 AsyncStorage에 FavoriteEntry로 저장한다', async () => {
     const { addFavorite } = useAppStore.getState();
     await addFavorite(mockStation);
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:favorites',
-      JSON.stringify([mockStation])
+      JSON.stringify([{ station: mockStation }])
     );
   });
 
@@ -89,13 +106,53 @@ describe('useAppStore', () => {
 
     expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
       'subway-now:favorites',
-      JSON.stringify([mockStation2])
+      JSON.stringify([{ station: mockStation2 }])
     );
   });
 
-  it('loadFavorites: AsyncStorage에서 데이터를 복원한다', async () => {
+  it('setFavoriteLabel: label 설정 시 entry가 업데이트되고 저장된다', async () => {
+    const { addFavorite, setFavoriteLabel } = useAppStore.getState();
+    await addFavorite(mockStation);
+    await setFavoriteLabel(mockStation.id, '회사');
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites[0].label).toBe('회사');
+    expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
+      'subway-now:favorites',
+      JSON.stringify([{ station: mockStation, label: '회사' }])
+    );
+  });
+
+  it('setFavoriteLabel: 빈 문자열/공백/undefined 입력 시 label을 제거한다', async () => {
+    const { addFavorite, setFavoriteLabel } = useAppStore.getState();
+    await addFavorite(mockStation, '집');
+    await setFavoriteLabel(mockStation.id, '   ');
+
+    let { favorites } = useAppStore.getState();
+    expect(favorites[0].label).toBeUndefined();
+
+    await setFavoriteLabel(mockStation.id, '집');
+    favorites = useAppStore.getState().favorites;
+    expect(favorites[0].label).toBe('집');
+
+    await setFavoriteLabel(mockStation.id, undefined);
+    favorites = useAppStore.getState().favorites;
+    expect(favorites[0].label).toBeUndefined();
+  });
+
+  it('setFavoriteLabel: 매칭되지 않는 stationId는 무시한다', async () => {
+    const { addFavorite, setFavoriteLabel } = useAppStore.getState();
+    await addFavorite(mockStation, '집');
+    await setFavoriteLabel('non-existent', '회사');
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites).toHaveLength(1);
+    expect(favorites[0].label).toBe('집');
+  });
+
+  it('loadFavorites: AsyncStorage에서 FavoriteEntry[] 데이터를 복원한다', async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify([mockStation])
+      JSON.stringify([{ station: mockStation, label: '집' }])
     );
 
     const { loadFavorites } = useAppStore.getState();
@@ -103,7 +160,51 @@ describe('useAppStore', () => {
 
     const { favorites } = useAppStore.getState();
     expect(favorites).toHaveLength(1);
-    expect(favorites[0].id).toBe('2-022');
+    expect(favorites[0].station.id).toBe('2-022');
+    expect(favorites[0].label).toBe('집');
+  });
+
+  it('loadFavorites: 기존 Station[] 포맷을 FavoriteEntry[]로 마이그레이션한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([mockStation, mockStation2])
+    );
+
+    const { loadFavorites } = useAppStore.getState();
+    await loadFavorites();
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites).toHaveLength(2);
+    expect(favorites[0].station.id).toBe('2-022');
+    expect(favorites[0].label).toBeUndefined();
+    expect(favorites[1].station.id).toBe('2-021');
+  });
+
+  it('loadFavorites: 배열이 아니거나 잘못된 항목은 건너뛴다', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify({ not: 'array' }))
+      .mockResolvedValueOnce(
+        JSON.stringify([
+          null,
+          { random: 'object' },
+          { station: null },
+          { station: { lat: 1, lng: 2 } }, // id 없음
+          { id: 42 }, // 잘못된 id 타입
+          { station: mockStation, label: '집' },
+          { station: mockStation2 }, // label 없는 FavoriteEntry
+        ]),
+      );
+
+    const { loadFavorites } = useAppStore.getState();
+    await loadFavorites();
+    expect(useAppStore.getState().favorites).toHaveLength(0);
+
+    await loadFavorites();
+    const { favorites } = useAppStore.getState();
+    expect(favorites).toHaveLength(2);
+    expect(favorites[0].station.id).toBe('2-022');
+    expect(favorites[0].label).toBe('집');
+    expect(favorites[1].station.id).toBe('2-021');
+    expect(favorites[1].label).toBeUndefined();
   });
 
   it('loadFavorites: AsyncStorage가 비어있으면 빈 배열을 유지한다', async () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Station } from '../types/station';
+import { Station, FavoriteEntry } from '../types/station';
 import type { AlarmEvent } from '../utils/stationAlarm';
 import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY } from '../constants/storageKeys';
 import { clearFiredAlarms } from '../utils/notificationState';
@@ -18,7 +18,7 @@ export type { AlarmEvent };
 const noop = () => {};
 
 interface AppState {
-  favorites: Station[];
+  favorites: FavoriteEntry[];
   destination: Station | null;
   recentDestination: Station | null;
   sleepMode: boolean;
@@ -30,8 +30,9 @@ interface AppState {
   alarmEvent: AlarmEvent | null;
   debugVisible: boolean;
   setDebugVisible: (visible: boolean) => void;
-  addFavorite: (station: Station) => Promise<void>;
+  addFavorite: (station: Station, label?: string) => Promise<void>;
   removeFavorite: (stationId: string) => Promise<void>;
+  setFavoriteLabel: (stationId: string, label?: string) => Promise<void>;
   loadFavorites: () => Promise<void>;
   setDestination: (station: Station | null) => void;
   loadDestination: () => Promise<void>;
@@ -78,23 +79,52 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       const raw = await AsyncStorage.getItem(FAVORITES_KEY);
       if (raw) {
-        set({ favorites: JSON.parse(raw) });
+        const parsed: unknown = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          // 마이그레이션: 기존 Station[] 포맷도 허용. entry.station 없으면 Station 원본으로 간주.
+          const migrated: FavoriteEntry[] = parsed
+            .map((item): FavoriteEntry | null => {
+              if (!item || typeof item !== 'object') return null;
+              if ('station' in item) {
+                const { station, label } = item as FavoriteEntry;
+                if (!station || typeof station.id !== 'string') return null;
+                return label != null ? { station, label } : { station };
+              }
+              if ('id' in item && typeof (item as Station).id === 'string') {
+                return { station: item as Station };
+              }
+              return null;
+            })
+            .filter((entry): entry is FavoriteEntry => entry !== null);
+          set({ favorites: migrated });
+        }
       }
     } catch {
       // 저장된 데이터 없음 — 빈 배열 유지
     }
   },
 
-  addFavorite: async (station: Station) => {
+  addFavorite: async (station: Station, label?: string) => {
     const current = get().favorites;
-    if (current.some((s) => s.id === station.id)) return;
-    const updated = [...current, station];
+    if (current.some((f) => f.station.id === station.id)) return;
+    const entry: FavoriteEntry = label != null && label !== '' ? { station, label } : { station };
+    const updated = [...current, entry];
     set({ favorites: updated });
     await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
   },
 
   removeFavorite: async (stationId: string) => {
-    const updated = get().favorites.filter((s) => s.id !== stationId);
+    const updated = get().favorites.filter((f) => f.station.id !== stationId);
+    set({ favorites: updated });
+    await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
+  },
+
+  setFavoriteLabel: async (stationId: string, label?: string) => {
+    const trimmed = label?.trim();
+    const updated = get().favorites.map((f) => {
+      if (f.station.id !== stationId) return f;
+      return trimmed ? { station: f.station, label: trimmed } : { station: f.station };
+    });
     set({ favorites: updated });
     await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
   },

--- a/src/types/station.ts
+++ b/src/types/station.ts
@@ -25,6 +25,11 @@ export interface Station {
   lng: number;
 }
 
+export interface FavoriteEntry {
+  station: Station;
+  label?: string;
+}
+
 export interface NearestStationResult {
   station: Station;
   distanceKm: number;


### PR DESCRIPTION
## Summary
- `FavoriteEntry { station, label? }` 타입 도입 → 즐겨찾기에 "집/회사" 같은 의미 라벨 부여
- DestinationPicker chip은 label 우선 노출. label 있는 chip은 recentDestination dedup에서 제외 → 직전 목적지가 유일 즐겨찾기여도 "집" chip이 사라지지 않음 (#545 후속)
- 즐겨찾기 화면 FavoriteCard에 인라인 라벨 편집 UI 추가
- 기존 `Station[]` 영속화 포맷은 `loadFavorites`에서 안전하게 마이그레이션 (id/station.id 형 검증 포함)

## Test plan
- [x] 기존 favorites (Station[]) 로드 시 label 누락 entry로 마이그레이션
- [x] label 있는 chip은 recentDestination dedup에서 제외
- [x] label 없는 chip은 기존 dedup 정책 유지
- [x] 라벨 편집/저장/취소 (빈 문자열 또는 공백만 입력 시 label 제거)
- [x] 손상된 영속화 데이터(null/잘못된 id 타입)는 건너뜀
- [x] 커버리지 100% / 타입체크 통과

Closes #552