### PR TITLE
fix(#555): 즐겨찾기 chip을 trip 종료 후에도 항상 노출

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -656,7 +656,6 @@ export default function HomeScreen() {
           setPickerVisible(false);
         }}
         onClose={() => setPickerVisible(false)}
-        recentDestination={recentDestination}
         favorites={favorites}
         userLat={userLocation?.lat ?? null}
         userLng={userLocation?.lng ?? null}

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -26,7 +26,6 @@ interface Props {
   readonly visible: boolean;
   readonly onSelect: (station: Station) => void;
   readonly onClose: () => void;
-  readonly recentDestination?: Station | null;
   readonly favorites?: readonly FavoriteEntry[];
   readonly userLat?: number | null;
   readonly userLng?: number | null;
@@ -39,7 +38,6 @@ export function DestinationPicker({
   onClose,
   userLat,
   userLng,
-  recentDestination,
   favorites,
   onRecenter,
 }: Props) {
@@ -67,14 +65,8 @@ export function DestinationPicker({
     return allStations;
   }, [userLat, userLng]);
 
-  // 즐겨찾기 chip — 빠른 선택용. label 없는 항목만 recentDestination과 dedup.
-  // label 있는 chip("집"/"회사")은 직전 목적지여도 의미가 있어 항상 표시.
-  const favoriteChips = useMemo(() => {
-    if (!favorites || favorites.length === 0) return [];
-    const recentId = recentDestination?.id;
-    if (!recentId) return favorites;
-    return favorites.filter(({ station, label }) => label != null || station.id !== recentId);
-  }, [favorites, recentDestination]);
+  // 즐겨찾기 chip — 항상 노출. trip 종료 후에도 다시 누를 수 있어야 한다 (#555).
+  const favoriteChips = favorites ?? [];
 
   const suggestions = useMemo(() => {
     const q = query.trim();

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -207,35 +207,7 @@ describe('DestinationPicker', () => {
     expect(queryByTestId('favorites-chip-row')).toBeNull();
   });
 
-  it('recentDestination과 중복되는 label 없는 즐겨찾기는 chip에서 제외한다', () => {
-    const recent: Station = {
-      id: '2-022',
-      name: '강남',
-      line: '2',
-      lineColor: '#009D3E',
-      lat: 37.498,
-      lng: 127.0279,
-    };
-    const other: Station = {
-      id: '2-021',
-      name: '역삼',
-      line: '2',
-      lineColor: '#009D3E',
-      lat: 37.5006,
-      lng: 127.0365,
-    };
-    const { queryByTestId, getByTestId } = render(
-      <DestinationPicker
-        {...defaultProps}
-        favorites={[{ station: recent }, { station: other }]}
-        recentDestination={recent}
-      />,
-    );
-    expect(queryByTestId(`favorite-chip-${recent.id}`)).toBeNull();
-    expect(getByTestId(`favorite-chip-${other.id}`)).toBeTruthy();
-  });
-
-  it('label 있는 즐겨찾기는 recentDestination과 중복돼도 chip을 표시하고 label을 노출한다', () => {
+  it('label 있는 즐겨찾기 chip은 label을 노출한다', () => {
     const home: Station = {
       id: '2-022',
       name: '강남',
@@ -248,7 +220,6 @@ describe('DestinationPicker', () => {
       <DestinationPicker
         {...defaultProps}
         favorites={[{ station: home, label: '집' }]}
-        recentDestination={home}
       />,
     );
     expect(getByTestId(`favorite-chip-${home.id}`)).toBeTruthy();


### PR DESCRIPTION
## Summary
- DestinationPicker의 즐겨찾기 chip dedup 정책 폐기 — trip 종료 후에도 chip이 항상 보이도록 변경
- label 유무와 무관하게 모든 즐겨찾기 chip 노출
- 미사용 `recentDestination` prop을 DestinationPicker에서 제거 (홈 화면 "이전 목적지" CTA는 그대로)

## Why
#552 머지 후 실사용에서 발견. label 미설정이 기본 상태라 "한 번 다녀온 즐겨찾기 chip이 사라져 다시 못 누름" 현상이 그대로 남음. dedup은 사용자 인지 모델과 맞지 않아 정책 자체를 폐기.

## Test plan
- [x] 즐겨찾기 chip이 recentDestination과 무관하게 모두 표시
- [x] label 있는 chip은 label로 노출
- [x] 1800 tests 통과 / 커버리지 100% / 타입체크 통과

Closes #555