### PR TITLE
feat(#557): 즐겨찾기 집/회사 슬롯 도입

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Modal,
   ScrollView,
   StyleSheet,
   Text,
@@ -11,7 +12,14 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../src/store/useAppStore';
 import { LINE_NAMES } from '../../src/constants/lineColors';
-import type { FavoriteEntry, Station } from '../../src/types/station';
+import {
+  FAVORITE_SLOT_ICONS,
+  FAVORITE_SLOT_ROLES,
+  isFavoriteSlotRole,
+  type FavoriteEntry,
+  type FavoriteSlotRole,
+  type Station,
+} from '../../src/types/station';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
 import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../../src/utils/formatTime';
@@ -28,9 +36,11 @@ export default function FavoritesScreen() {
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
   const setFavoriteLabel = useAppStore((s) => s.setFavoriteLabel);
+  const setSlotFavorite = useAppStore((s) => s.setSlotFavorite);
   const loadFavorites = useAppStore((s) => s.loadFavorites);
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [slotPicker, setSlotPicker] = useState<FavoriteSlotRole | null>(null);
   const { colors } = useTheme();
   const { t } = useTranslation();
 
@@ -41,6 +51,19 @@ export default function FavoritesScreen() {
   const selectedStation = useMemo(
     () => favorites.find(({ station }) => station.id === selectedId)?.station ?? null,
     [favorites, selectedId],
+  );
+  const slotByRole = useMemo(() => {
+    const map = new Map<FavoriteSlotRole, FavoriteEntry>();
+    favorites.forEach((entry) => {
+      if (isFavoriteSlotRole(entry.role)) {
+        map.set(entry.role, entry);
+      }
+    });
+    return map;
+  }, [favorites]);
+  const generalFavorites = useMemo(
+    () => favorites.filter((entry) => entry.role === 'general'),
+    [favorites],
   );
   const { arrival: rawArrival } = useArrivalInfo(
     selectedStation?.name ?? null,
@@ -91,35 +114,62 @@ export default function FavoritesScreen() {
               />
             ))
           )
-        ) : favorites.length === 0 ? (
-          <View style={styles.empty} testID="favorites-empty">
-            <Text style={styles.emptyIcon}>⭐</Text>
-            <Text style={[styles.emptyTitle, { color: colors.ink }]}>{t('favorites.empty')}</Text>
-            <Text style={[styles.emptySubtitle, { color: colors.muted }]}>
-              {t('favorites.emptyDescription')}
-            </Text>
-          </View>
         ) : (
-          favorites.map((entry: FavoriteEntry) => {
-            const { id } = entry.station;
-            return (
-              <FavoriteCard
-                key={id}
-                entry={entry}
-                isExpanded={id === selectedId}
-                arrival={id === selectedId ? arrival : null}
-                onToggle={() => handleToggleSelect(id)}
-                onRemove={() => {
-                  if (selectedId === id) setSelectedId(null);
-                  removeFavorite(id);
-                }}
-                onSaveLabel={(label) => setFavoriteLabel(id, label)}
-                colors={colors}
-              />
-            );
-          })
+          <>
+            <View style={styles.slotRow}>
+              {FAVORITE_SLOT_ROLES.map((role) => (
+                <SlotCard
+                  key={role}
+                  role={role}
+                  entry={slotByRole.get(role) ?? null}
+                  onAssign={() => setSlotPicker(role)}
+                  onClear={() => setSlotFavorite(role, null)}
+                  colors={colors}
+                />
+              ))}
+            </View>
+            {generalFavorites.length === 0 ? (
+              <View style={styles.empty} testID="favorites-empty">
+                <Text style={styles.emptyIcon}>⭐</Text>
+                <Text style={[styles.emptyTitle, { color: colors.ink }]}>{t('favorites.empty')}</Text>
+                <Text style={[styles.emptySubtitle, { color: colors.muted }]}>
+                  {t('favorites.emptyDescription')}
+                </Text>
+              </View>
+            ) : (
+              generalFavorites.map((entry: FavoriteEntry) => {
+                const { id } = entry.station;
+                return (
+                  <FavoriteCard
+                    key={id}
+                    entry={entry}
+                    isExpanded={id === selectedId}
+                    arrival={id === selectedId ? arrival : null}
+                    onToggle={() => handleToggleSelect(id)}
+                    onRemove={() => {
+                      if (selectedId === id) setSelectedId(null);
+                      removeFavorite(id);
+                    }}
+                    onSaveLabel={(label) => setFavoriteLabel(id, label)}
+                    colors={colors}
+                  />
+                );
+              })
+            )}
+          </>
         )}
       </ScrollView>
+      <SlotPickerModal
+        role={slotPicker}
+        onClose={() => setSlotPicker(null)}
+        onPick={(station) => {
+          if (slotPicker) {
+            setSlotFavorite(slotPicker, station);
+          }
+          setSlotPicker(null);
+        }}
+        colors={colors}
+      />
     </SafeAreaView>
   );
 }
@@ -273,6 +323,120 @@ function FavoriteCard({
         </View>
       )}
     </View>
+  );
+}
+
+function SlotCard({
+  role,
+  entry,
+  onAssign,
+  onClear,
+  colors,
+}: {
+  role: FavoriteSlotRole;
+  entry: FavoriteEntry | null;
+  onAssign: () => void;
+  onClear: () => void;
+  colors: ThemeColors;
+}) {
+  const { t } = useTranslation();
+  const label = t(`favorites.${role}`);
+  if (!entry) {
+    return (
+      <TouchableOpacity
+        style={[styles.slotCard, { backgroundColor: colors.card, borderColor: colors.hair }]}
+        onPress={onAssign}
+        testID={`slot-assign-${role}`}
+      >
+        <Text style={styles.slotIcon}>{FAVORITE_SLOT_ICONS[role]}</Text>
+        <Text style={[styles.slotLabel, { color: colors.ink }]}>{label}</Text>
+        <Text style={[styles.slotHint, { color: colors.muted }]}>{t('favorites.slotAssignHint')}</Text>
+      </TouchableOpacity>
+    );
+  }
+  const { station } = entry;
+  return (
+    <View style={[styles.slotCard, { backgroundColor: colors.card, borderColor: colors.hair, borderLeftColor: station.lineColor, borderLeftWidth: 4 }]}>
+      <TouchableOpacity style={styles.slotMain} onPress={onAssign} testID={`slot-change-${role}`}>
+        <Text style={styles.slotIcon}>{FAVORITE_SLOT_ICONS[role]}</Text>
+        <Text style={[styles.slotLabel, { color: colors.ink }]}>{label}</Text>
+        <Text style={[styles.slotStation, { color: colors.muted }]} numberOfLines={1}>
+          {getStationDisplayName(station)}
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onClear} testID={`slot-clear-${role}`} style={styles.slotClear}>
+        <Text style={[styles.slotClearText, { color: colors.danger }]}>×</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function SlotPickerModal({
+  role,
+  onClose,
+  onPick,
+  colors,
+}: {
+  role: FavoriteSlotRole | null;
+  onClose: () => void;
+  onPick: (station: Station) => void;
+  colors: ThemeColors;
+}) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState('');
+  useEffect(() => {
+    if (role == null) setQuery('');
+  }, [role]);
+  const results = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    const lower = trimmed.toLowerCase();
+    return allStations.filter((s) => matchesStationQuery(s, trimmed, lower)).slice(0, 20);
+  }, [query]);
+  const visible = role != null;
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+        <View style={styles.slotModalHeader}>
+          <Text style={[styles.slotModalTitle, { color: colors.ink }]}>
+            {role ? t('favorites.slotPickerTitle', { label: t(`favorites.${role}`) }) : ''}
+          </Text>
+          <TouchableOpacity onPress={onClose} testID="slot-picker-close">
+            <Text style={[styles.slotModalClose, { color: colors.accent }]}>{t('common.close')}</Text>
+          </TouchableOpacity>
+        </View>
+        <TextInput
+          style={[styles.searchInput, { backgroundColor: colors.card, color: colors.ink, borderColor: colors.hair, marginHorizontal: 24 }]}
+          placeholder={t('favorites.searchPlaceholder')}
+          placeholderTextColor={colors.muted}
+          value={query}
+          onChangeText={setQuery}
+          autoFocus
+          testID="slot-picker-search"
+        />
+        <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={{ padding: 24 }}>
+          {results.map((station) => (
+            <TouchableOpacity
+              key={station.id}
+              style={[styles.card, { backgroundColor: colors.card, borderLeftColor: station.lineColor }]}
+              onPress={() => onPick(station)}
+              testID={`slot-picker-result-${station.id}`}
+            >
+              <View style={styles.cardRow}>
+                <View style={styles.cardInfo}>
+                  <View style={[styles.badge, { backgroundColor: station.lineColor }]}>
+                    <Text style={styles.badgeText}>{LINE_NAMES[station.line]}</Text>
+                  </View>
+                  <Text style={[styles.stationName, { color: colors.ink }]}>
+                    {getStationDisplayName(station)}
+                  </Text>
+                </View>
+              </View>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      </SafeAreaView>
+    </Modal>
   );
 }
 
@@ -465,5 +629,64 @@ const styles = StyleSheet.create({
     fontSize: 13,
     textAlign: 'center',
     paddingVertical: 4,
+  },
+  slotRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginBottom: 16,
+  },
+  slotCard: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  slotMain: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  slotIcon: {
+    fontSize: 18,
+  },
+  slotLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  slotHint: {
+    fontSize: 12,
+    flexShrink: 1,
+  },
+  slotStation: {
+    fontSize: 13,
+    flexShrink: 1,
+  },
+  slotClear: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  slotClearText: {
+    fontSize: 22,
+    fontWeight: '700',
+    lineHeight: 24,
+  },
+  slotModalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+  },
+  slotModalTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  slotModalClose: {
+    fontSize: 16,
   },
 });

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import stations from '../data/stations.json';
-import type { Station, FavoriteEntry } from '../types/station';
+import { FAVORITE_SLOT_ICONS, isFavoriteSlotRole, type FavoriteEntry, type Station } from '../types/station';
 import { StationMap } from './StationMap';
 import { StationSuggestionList } from './StationSuggestionList';
 import { createLogger } from '../utils/logger';
@@ -66,7 +66,12 @@ export function DestinationPicker({
   }, [userLat, userLng]);
 
   // 즐겨찾기 chip — 항상 노출. trip 종료 후에도 다시 누를 수 있어야 한다 (#555).
-  const favoriteChips = favorites ?? [];
+  // home → work → general 순으로 정렬. home/work는 아이콘+라벨로 표시 (#557).
+  const favoriteChips = useMemo(() => {
+    if (!favorites || favorites.length === 0) return [];
+    const order: Record<string, number> = { home: 0, work: 1, general: 2 };
+    return [...favorites].sort((a, b) => order[a.role] - order[b.role]);
+  }, [favorites]);
 
   const suggestions = useMemo(() => {
     const q = query.trim();
@@ -137,18 +142,23 @@ export function DestinationPicker({
               contentContainerStyle={styles.chipRow}
               testID="favorites-chip-row"
             >
-              {favoriteChips.map(({ station, label }) => (
-                <TouchableOpacity
-                  key={station.id}
-                  style={[styles.chip, { backgroundColor: colors.card, borderColor: colors.hair }]}
-                  onPress={() => handleSelect(station)}
-                  testID={`favorite-chip-${station.id}`}
-                >
-                  <Text style={[styles.chipText, { color: colors.ink }]}>
-                    {label ?? getStationDisplayName(station)}
-                  </Text>
-                </TouchableOpacity>
-              ))}
+              {favoriteChips.map(({ station, role, label }) => {
+                const isSlot = isFavoriteSlotRole(role);
+                const chipText = isSlot
+                  ? t(`favorites.${role}`)
+                  : label ?? getStationDisplayName(station);
+                return (
+                  <TouchableOpacity
+                    key={station.id}
+                    style={[styles.chip, { backgroundColor: colors.card, borderColor: colors.hair }]}
+                    onPress={() => handleSelect(station)}
+                    testID={`favorite-chip-${station.id}`}
+                  >
+                    {isSlot && <Text style={styles.chipIcon}>{FAVORITE_SLOT_ICONS[role]}</Text>}
+                    <Text style={[styles.chipText, { color: colors.ink }]}>{chipText}</Text>
+                  </TouchableOpacity>
+                );
+              })}
             </ScrollView>
           )}
           {showDropdown && (
@@ -239,10 +249,16 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.sm,
     borderRadius: radius.pill,
     borderWidth: 1,
+    gap: 6,
+  },
+  chipIcon: {
+    fontSize: 14,
   },
   chipText: {
     fontSize: 14,

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -181,7 +181,7 @@ describe('DestinationPicker', () => {
     const { getByTestId } = render(
       <DestinationPicker
         {...defaultProps}
-        favorites={[{ station: favStation }]}
+        favorites={[{ station: favStation, role: 'general' }]}
         onSelect={onSelect}
       />,
     );
@@ -200,7 +200,7 @@ describe('DestinationPicker', () => {
       lng: 127.0365,
     };
     const { getByTestId, queryByTestId } = render(
-      <DestinationPicker {...defaultProps} favorites={[{ station: favStation }]} />,
+      <DestinationPicker {...defaultProps} favorites={[{ station: favStation, role: 'general' }]} />,
     );
     expect(getByTestId('favorites-chip-row')).toBeTruthy();
     fireEvent.changeText(getByTestId('search-input'), '강남');
@@ -219,11 +219,57 @@ describe('DestinationPicker', () => {
     const { getByTestId, getByText } = render(
       <DestinationPicker
         {...defaultProps}
-        favorites={[{ station: home, label: '집' }]}
+        favorites={[{ station: home, role: 'general', label: '집' }]}
       />,
     );
     expect(getByTestId(`favorite-chip-${home.id}`)).toBeTruthy();
     expect(getByText('집')).toBeTruthy();
+  });
+
+  it('home/work 슬롯 chip은 아이콘과 i18n 라벨(집/회사)을 노출하며 general 앞에 정렬된다', () => {
+    const home: Station = {
+      id: '2-022',
+      name: '강남',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.498,
+      lng: 127.0279,
+    };
+    const work: Station = {
+      id: '2-021',
+      name: '역삼',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5006,
+      lng: 127.0365,
+    };
+    const general: Station = {
+      id: '2-020',
+      name: '선릉',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5045,
+      lng: 127.0489,
+    };
+    const { getByText, getAllByTestId } = render(
+      <DestinationPicker
+        {...defaultProps}
+        favorites={[
+          { station: general, role: 'general' },
+          { station: home, role: 'home' },
+          { station: work, role: 'work' },
+        ]}
+      />,
+    );
+    expect(getByText('집')).toBeTruthy();
+    expect(getByText('회사')).toBeTruthy();
+    expect(getByText('🏠')).toBeTruthy();
+    expect(getByText('🏢')).toBeTruthy();
+    // 첫 chip은 home, 두 번째는 work, 세 번째는 general
+    const chips = getAllByTestId(/^favorite-chip-/);
+    expect(chips[0].props.testID).toBe(`favorite-chip-${home.id}`);
+    expect(chips[1].props.testID).toBe(`favorite-chip-${work.id}`);
+    expect(chips[2].props.testID).toBe(`favorite-chip-${general.id}`);
   });
 
   it('검색창 포커스 시 드롭다운 표시 상태가 활성화된다', () => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -99,7 +99,11 @@
     "addLabel": "Add label",
     "editLabel": "Edit label",
     "saveLabel": "Save",
-    "labelPlaceholder": "Home, Work, etc."
+    "labelPlaceholder": "Label",
+    "home": "Home",
+    "work": "Work",
+    "slotAssignHint": "Tap to assign",
+    "slotPickerTitle": "Set {{label}}"
   },
   "alarmOverlay": {
     "transferTitle": "Transfer alert",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -99,7 +99,11 @@
     "addLabel": "ラベル追加",
     "editLabel": "ラベル編集",
     "saveLabel": "保存",
-    "labelPlaceholder": "自宅、会社など"
+    "labelPlaceholder": "ラベル",
+    "home": "自宅",
+    "work": "会社",
+    "slotAssignHint": "タップして設定",
+    "slotPickerTitle": "{{label}}を設定"
   },
   "alarmOverlay": {
     "transferTitle": "乗換アラーム",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -99,7 +99,11 @@
     "addLabel": "별칭 추가",
     "editLabel": "별칭 편집",
     "saveLabel": "저장",
-    "labelPlaceholder": "집, 회사 등"
+    "labelPlaceholder": "별칭 입력",
+    "home": "집",
+    "work": "회사",
+    "slotAssignHint": "탭하여 지정",
+    "slotPickerTitle": "{{label}} 지정"
   },
   "alarmOverlay": {
     "transferTitle": "환승 알림",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -99,7 +99,11 @@
     "addLabel": "添加别名",
     "editLabel": "编辑别名",
     "saveLabel": "保存",
-    "labelPlaceholder": "家、公司等"
+    "labelPlaceholder": "别名",
+    "home": "家",
+    "work": "公司",
+    "slotAssignHint": "点击设置",
+    "slotPickerTitle": "设置{{label}}"
   },
   "alarmOverlay": {
     "transferTitle": "换乘提醒",

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -47,7 +47,7 @@ describe('useAppStore', () => {
 
   it('addFavorite: label과 함께 추가하면 entry에 label이 저장된다', async () => {
     const { addFavorite } = useAppStore.getState();
-    await addFavorite(mockStation, '집');
+    await addFavorite(mockStation, { label: '집' });
 
     const { favorites } = useAppStore.getState();
     expect(favorites[0].label).toBe('집');
@@ -55,7 +55,7 @@ describe('useAppStore', () => {
 
   it('addFavorite: 빈 문자열 label은 무시한다', async () => {
     const { addFavorite } = useAppStore.getState();
-    await addFavorite(mockStation, '');
+    await addFavorite(mockStation, { label: '' });
 
     const { favorites } = useAppStore.getState();
     expect(favorites[0].label).toBeUndefined();
@@ -94,7 +94,7 @@ describe('useAppStore', () => {
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:favorites',
-      JSON.stringify([{ station: mockStation }])
+      JSON.stringify([{ station: mockStation, role: 'general' }])
     );
   });
 
@@ -106,7 +106,7 @@ describe('useAppStore', () => {
 
     expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
       'subway-now:favorites',
-      JSON.stringify([{ station: mockStation2 }])
+      JSON.stringify([{ station: mockStation2, role: 'general' }])
     );
   });
 
@@ -119,13 +119,13 @@ describe('useAppStore', () => {
     expect(favorites[0].label).toBe('회사');
     expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
       'subway-now:favorites',
-      JSON.stringify([{ station: mockStation, label: '회사' }])
+      JSON.stringify([{ station: mockStation, role: 'general', label: '회사' }])
     );
   });
 
   it('setFavoriteLabel: 빈 문자열/공백/undefined 입력 시 label을 제거한다', async () => {
     const { addFavorite, setFavoriteLabel } = useAppStore.getState();
-    await addFavorite(mockStation, '집');
+    await addFavorite(mockStation, { label: '집' });
     await setFavoriteLabel(mockStation.id, '   ');
 
     let { favorites } = useAppStore.getState();
@@ -142,7 +142,7 @@ describe('useAppStore', () => {
 
   it('setFavoriteLabel: 매칭되지 않는 stationId는 무시한다', async () => {
     const { addFavorite, setFavoriteLabel } = useAppStore.getState();
-    await addFavorite(mockStation, '집');
+    await addFavorite(mockStation, { label: '집' });
     await setFavoriteLabel('non-existent', '회사');
 
     const { favorites } = useAppStore.getState();
@@ -205,6 +205,113 @@ describe('useAppStore', () => {
     expect(favorites[0].label).toBe('집');
     expect(favorites[1].station.id).toBe('2-021');
     expect(favorites[1].label).toBeUndefined();
+  });
+
+  it('addFavorite: role=home 옵션을 지정하면 home 슬롯으로 추가된다', async () => {
+    const { addFavorite } = useAppStore.getState();
+    await addFavorite(mockStation, { role: 'home' });
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites[0].role).toBe('home');
+  });
+
+  it('addFavorite: role=home 추가 시 기존 general entry는 그대로 유지된다', async () => {
+    const { addFavorite } = useAppStore.getState();
+    await addFavorite(mockStation);
+    await addFavorite(mockStation2, { role: 'home' });
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites.find((f) => f.station.id === mockStation.id)?.role).toBe('general');
+    expect(favorites.find((f) => f.station.id === mockStation2.id)?.role).toBe('home');
+  });
+
+  it('addFavorite: 같은 슬롯에 다른 역을 지정하면 기존 슬롯은 general로 강등된다', async () => {
+    const { addFavorite } = useAppStore.getState();
+    await addFavorite(mockStation, { role: 'home' });
+    await addFavorite(mockStation2, { role: 'home' });
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites.find((f) => f.station.id === mockStation.id)?.role).toBe('general');
+    expect(favorites.find((f) => f.station.id === mockStation2.id)?.role).toBe('home');
+  });
+
+  it('setSlotFavorite: 처음 home 슬롯 지정 시 새 entry로 추가된다', async () => {
+    const { setSlotFavorite } = useAppStore.getState();
+    await setSlotFavorite('home', mockStation);
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites).toHaveLength(1);
+    expect(favorites[0].role).toBe('home');
+    expect(favorites[0].station.id).toBe('2-022');
+  });
+
+  it('setSlotFavorite: 이미 즐겨찾기에 있는 역을 슬롯에 지정하면 role만 변경된다', async () => {
+    const { addFavorite, setSlotFavorite } = useAppStore.getState();
+    await addFavorite(mockStation, { label: '집' });
+    await setSlotFavorite('work', mockStation);
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites).toHaveLength(1);
+    expect(favorites[0].role).toBe('work');
+    expect(favorites[0].label).toBe('집');
+  });
+
+  it('setSlotFavorite: 다른 역이 이미 슬롯에 있으면 기존 entry는 general로 강등된다', async () => {
+    const { setSlotFavorite } = useAppStore.getState();
+    await setSlotFavorite('home', mockStation);
+    await setSlotFavorite('home', mockStation2);
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites).toHaveLength(2);
+    expect(favorites.find((f) => f.station.id === mockStation.id)?.role).toBe('general');
+    expect(favorites.find((f) => f.station.id === mockStation2.id)?.role).toBe('home');
+  });
+
+  it('setSlotFavorite: null 전달 시 슬롯이 비워지고 기존 entry는 general로 남는다', async () => {
+    const { setSlotFavorite } = useAppStore.getState();
+    await setSlotFavorite('home', mockStation);
+    await setSlotFavorite('home', null);
+
+    const { favorites } = useAppStore.getState();
+    expect(favorites).toHaveLength(1);
+    expect(favorites[0].role).toBe('general');
+  });
+
+  it('loadFavorites: home/work role이 정상 보존된다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([
+        { station: mockStation, role: 'home' },
+        { station: mockStation2, role: 'work' },
+      ]),
+    );
+
+    await useAppStore.getState().loadFavorites();
+    const { favorites } = useAppStore.getState();
+    expect(favorites[0].role).toBe('home');
+    expect(favorites[1].role).toBe('work');
+  });
+
+  it('loadFavorites: 잘못된 role 값은 general로 정규화된다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([{ station: mockStation, role: 'invalid' }]),
+    );
+
+    await useAppStore.getState().loadFavorites();
+    expect(useAppStore.getState().favorites[0].role).toBe('general');
+  });
+
+  it('loadFavorites: 동일 슬롯이 여러 entry에 중복되면 첫 항목만 유지하고 나머지는 general로 강등된다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([
+        { station: mockStation, role: 'home' },
+        { station: mockStation2, role: 'home' },
+      ]),
+    );
+
+    await useAppStore.getState().loadFavorites();
+    const { favorites } = useAppStore.getState();
+    expect(favorites[0].role).toBe('home');
+    expect(favorites[1].role).toBe('general');
   });
 
   it('loadFavorites: AsyncStorage가 비어있으면 빈 배열을 유지한다', async () => {

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -277,41 +277,38 @@ describe('useAppStore', () => {
     expect(favorites[0].role).toBe('general');
   });
 
-  it('loadFavorites: home/work role이 정상 보존된다', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify([
-        { station: mockStation, role: 'home' },
-        { station: mockStation2, role: 'work' },
-      ]),
-    );
+  it.each([
+    {
+      label: 'home/work role 보존',
+      stored: [
+        { station: '2-022', role: 'home' as const },
+        { station: '2-021', role: 'work' as const },
+      ],
+      expectedRoles: ['home', 'work'],
+    },
+    {
+      label: '잘못된 role은 general로 정규화',
+      stored: [{ station: '2-022', role: 'invalid' as unknown as 'general' }],
+      expectedRoles: ['general'],
+    },
+    {
+      label: '동일 슬롯 중복은 first-wins (나머지는 general 강등)',
+      stored: [
+        { station: '2-022', role: 'home' as const },
+        { station: '2-021', role: 'home' as const },
+      ],
+      expectedRoles: ['home', 'general'],
+    },
+  ])('loadFavorites: $label', async ({ stored, expectedRoles }) => {
+    const stationsById: Record<string, typeof mockStation> = {
+      '2-022': mockStation,
+      '2-021': mockStation2,
+    };
+    const payload = stored.map(({ station, role }) => ({ station: stationsById[station], role }));
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(payload));
 
     await useAppStore.getState().loadFavorites();
-    const { favorites } = useAppStore.getState();
-    expect(favorites[0].role).toBe('home');
-    expect(favorites[1].role).toBe('work');
-  });
-
-  it('loadFavorites: 잘못된 role 값은 general로 정규화된다', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify([{ station: mockStation, role: 'invalid' }]),
-    );
-
-    await useAppStore.getState().loadFavorites();
-    expect(useAppStore.getState().favorites[0].role).toBe('general');
-  });
-
-  it('loadFavorites: 동일 슬롯이 여러 entry에 중복되면 첫 항목만 유지하고 나머지는 general로 강등된다', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify([
-        { station: mockStation, role: 'home' },
-        { station: mockStation2, role: 'home' },
-      ]),
-    );
-
-    await useAppStore.getState().loadFavorites();
-    const { favorites } = useAppStore.getState();
-    expect(favorites[0].role).toBe('home');
-    expect(favorites[1].role).toBe('general');
+    expect(useAppStore.getState().favorites.map((f) => f.role)).toEqual(expectedRoles);
   });
 
   it('loadFavorites: AsyncStorage가 비어있으면 빈 배열을 유지한다', async () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Station, FavoriteEntry } from '../types/station';
+import { Station, FavoriteEntry, FavoriteRole, FavoriteSlotRole, isFavoriteSlotRole } from '../types/station';
+
+// 슬롯(home/work) 단일성 invariant — 새 entry가 해당 슬롯을 차지하기 전에 기존 entry는 general로 강등한다.
+function demoteSlotEntries(entries: FavoriteEntry[], role: FavoriteSlotRole): FavoriteEntry[] {
+  return entries.map((f) => (f.role === role ? { ...f, role: 'general' as FavoriteRole } : f));
+}
 import type { AlarmEvent } from '../utils/stationAlarm';
 import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY } from '../constants/storageKeys';
 import { clearFiredAlarms } from '../utils/notificationState';
@@ -30,9 +35,10 @@ interface AppState {
   alarmEvent: AlarmEvent | null;
   debugVisible: boolean;
   setDebugVisible: (visible: boolean) => void;
-  addFavorite: (station: Station, label?: string) => Promise<void>;
+  addFavorite: (station: Station, options?: { role?: FavoriteRole; label?: string }) => Promise<void>;
   removeFavorite: (stationId: string) => Promise<void>;
   setFavoriteLabel: (stationId: string, label?: string) => Promise<void>;
+  setSlotFavorite: (role: FavoriteSlotRole, station: Station | null) => Promise<void>;
   loadFavorites: () => Promise<void>;
   setDestination: (station: Station | null) => void;
   loadDestination: () => Promise<void>;
@@ -81,22 +87,35 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (raw) {
         const parsed: unknown = JSON.parse(raw);
         if (Array.isArray(parsed)) {
-          // 마이그레이션: 기존 Station[] 포맷도 허용. entry.station 없으면 Station 원본으로 간주.
+          // 마이그레이션: Station[] / role 없는 FavoriteEntry[] 모두 허용.
           const migrated: FavoriteEntry[] = parsed
             .map((item): FavoriteEntry | null => {
               if (!item || typeof item !== 'object') return null;
               if ('station' in item) {
-                const { station, label } = item as FavoriteEntry;
+                const { station, label, role } = item as FavoriteEntry;
                 if (!station || typeof station.id !== 'string') return null;
-                return label != null ? { station, label } : { station };
+                const normalizedRole: FavoriteRole =
+                  role === 'home' || role === 'work' ? role : 'general';
+                return label != null
+                  ? { station, role: normalizedRole, label }
+                  : { station, role: normalizedRole };
               }
               if ('id' in item && typeof (item as Station).id === 'string') {
-                return { station: item as Station };
+                return { station: item as Station, role: 'general' };
               }
               return null;
             })
             .filter((entry): entry is FavoriteEntry => entry !== null);
-          set({ favorites: migrated });
+          // home/work 중복 발생 시 첫 항목만 유지하고 나머지는 general로 강등.
+          const seenRoles = new Set<FavoriteSlotRole>();
+          const deduped = migrated.map<FavoriteEntry>((entry) => {
+            if (entry.role === 'home' || entry.role === 'work') {
+              if (seenRoles.has(entry.role)) return { ...entry, role: 'general' };
+              seenRoles.add(entry.role);
+            }
+            return entry;
+          });
+          set({ favorites: deduped });
         }
       }
     } catch {
@@ -104,11 +123,15 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  addFavorite: async (station: Station, label?: string) => {
+  addFavorite: async (station: Station, options) => {
     const current = get().favorites;
     if (current.some((f) => f.station.id === station.id)) return;
-    const entry: FavoriteEntry = label != null && label !== '' ? { station, label } : { station };
-    const updated = [...current, entry];
+    const role: FavoriteRole = options?.role ?? 'general';
+    const label = options?.label;
+    const adjusted = isFavoriteSlotRole(role) ? demoteSlotEntries(current, role) : current;
+    const entry: FavoriteEntry =
+      label != null && label !== '' ? { station, role, label } : { station, role };
+    const updated = [...adjusted, entry];
     set({ favorites: updated });
     await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
   },
@@ -123,8 +146,33 @@ export const useAppStore = create<AppState>((set, get) => ({
     const trimmed = label?.trim();
     const updated = get().favorites.map((f) => {
       if (f.station.id !== stationId) return f;
-      return trimmed ? { station: f.station, label: trimmed } : { station: f.station };
+      if (trimmed) return { ...f, label: trimmed };
+      // label만 제거하고 station/role 등 다른 필드는 그대로 보존.
+      const { label: _removed, ...rest } = f;
+      return rest;
     });
+    set({ favorites: updated });
+    await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
+  },
+
+  // 집/회사 슬롯 지정 — 한 슬롯엔 하나의 역만. null이면 슬롯 비움(해당 entry는 general로 강등).
+  setSlotFavorite: async (role: FavoriteSlotRole, station: Station | null) => {
+    const current = get().favorites;
+    const demoted = demoteSlotEntries(current, role);
+    if (station == null) {
+      set({ favorites: demoted });
+      await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(demoted));
+      return;
+    }
+    const existingIdx = demoted.findIndex((f) => f.station.id === station.id);
+    const updated: FavoriteEntry[] = (() => {
+      if (existingIdx >= 0) {
+        const next = [...demoted];
+        next[existingIdx] = { ...next[existingIdx], role };
+        return next;
+      }
+      return [...demoted, { station, role }];
+    })();
     set({ favorites: updated });
     await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(updated));
   },

--- a/src/types/station.ts
+++ b/src/types/station.ts
@@ -25,8 +25,23 @@ export interface Station {
   lng: number;
 }
 
+export type FavoriteRole = 'home' | 'work' | 'general';
+
+export const FAVORITE_SLOT_ROLES = ['home', 'work'] as const;
+export type FavoriteSlotRole = (typeof FAVORITE_SLOT_ROLES)[number];
+
+export const FAVORITE_SLOT_ICONS: Record<FavoriteSlotRole, string> = {
+  home: '🏠',
+  work: '🏢',
+};
+
+export function isFavoriteSlotRole(role: FavoriteRole): role is FavoriteSlotRole {
+  return (FAVORITE_SLOT_ROLES as readonly FavoriteRole[]).includes(role);
+}
+
 export interface FavoriteEntry {
   station: Station;
+  role: FavoriteRole;
   label?: string;
 }
 


### PR DESCRIPTION
## Summary
카카오맵/네이버지도 패턴처럼 **집/회사를 미리 정의된 슬롯**으로 제공.

- `FavoriteRole = 'home' | 'work' | 'general'` 도입. 슬롯 단일성은 `demoteSlotEntries` 헬퍼로 invariant 단일화
- `setSlotFavorite(role, station|null)` 액션 신설, `addFavorite(station, { role?, label? })`로 옵션화
- DestinationPicker chip은 home → work → general 순으로 정렬, home/work는 🏠/🏢 + 라벨(집/회사) 노출
- favorites 탭 상단에 슬롯 카드 + 검색 모달, 본문은 일반 즐겨찾기(자유 라벨 편집 유지)
- 기존 FavoriteEntry는 `role: 'general'`로 안전 마이그레이션. 잘못된 role/슬롯 중복도 정규화

## Why
#552 후속 — 자유 라벨은 발견성 낮아 chip이 계속 역이름으로만 노출됨. 사용자 인지 모델("집"/"회사")에 맞춰 슬롯 UX로 전환.

## Test plan
- [x] 기존 FavoriteEntry[] → role='general' 마이그레이션
- [x] home/work 단일성 (재지정 시 기존 entry는 general 강등)
- [x] DestinationPicker chip 순서/아이콘/라벨
- [x] favorites 탭 슬롯 카드 미설정/설정 분기
- [x] 잘못된 role, 슬롯 중복 입력 정규화
- [x] 1811 tests / 커버리지 100% / 타입체크 통과

Closes #557