### PR TITLE
feat(#559): 지도/목적지 모달에서도 집·회사 슬롯 지정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -48,6 +48,7 @@ export default function HomeScreen() {
   const loadCustomOrigin = useAppStore((s) => s.loadCustomOrigin);
   const addFavorite = useAppStore((s) => s.addFavorite);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
+  const setSlotFavorite = useAppStore((s) => s.setSlotFavorite);
   const favorites = useAppStore((s) => s.favorites);
   const loadFavorites = useAppStore((s) => s.loadFavorites);
   const destination = useAppStore((s) => s.destination);
@@ -657,6 +658,7 @@ export default function HomeScreen() {
         }}
         onClose={() => setPickerVisible(false)}
         favorites={favorites}
+        onAssignSlot={setSlotFavorite}
         userLat={userLocation?.lat ?? null}
         userLng={userLocation?.lng ?? null}
         onRecenter={() => {

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -17,7 +17,12 @@ import { getStationDisplayName } from '../../src/utils/stationDisplay';
 import { routeToCoordinates, type RouteCoordinatePath } from '../../src/utils/routeToCoordinates';
 import type { Route } from '../../src/utils/stationRoute';
 import { ROUTE_KEY } from '../../src/constants/storageKeys';
-import type { Station } from '../../src/types/station';
+import {
+  FAVORITE_SLOT_ICONS,
+  FAVORITE_SLOT_ROLES,
+  type FavoriteSlotRole,
+  type Station,
+} from '../../src/types/station';
 
 export default function MapScreen() {
   const { userLocation, result, loading, error, permissionDenied, refresh, accuracyMeters, locationUncertain } =
@@ -29,6 +34,8 @@ export default function MapScreen() {
   const destination = useAppStore((s) => s.destination);
   const setDestination = useAppStore((s) => s.setDestination);
   const setRecentDestination = useAppStore((s) => s.setRecentDestination);
+  const favorites = useAppStore((s) => s.favorites);
+  const setSlotFavorite = useAppStore((s) => s.setSlotFavorite);
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
   const [focusStation, setFocusStation] = useState<Station | null>(null);
   const [focusNonce, setFocusNonce] = useState(0);
@@ -180,6 +187,29 @@ export default function MapScreen() {
               <Text style={[styles.selectionButtonText, { color: colors.accent }]}>{t('map.setAsDestination')}</Text>
             </TouchableOpacity>
           </View>
+          <View style={styles.slotButtons}>
+            {FAVORITE_SLOT_ROLES.map((role) => {
+              const { station: slotStation } = favorites.find((f) => f.role === role) ?? {};
+              const isCurrent = slotStation?.id === selectedStation.id;
+              return (
+                <TouchableOpacity
+                  key={role}
+                  style={[styles.slotButton, { borderColor: colors.hair, backgroundColor: isCurrent ? colors.accent : colors.bg }]}
+                  onPress={() => {
+                    if (isCurrent) return;
+                    setSlotFavorite(role, selectedStation);
+                  }}
+                  disabled={isCurrent}
+                  testID={`assign-slot-${role}`}
+                >
+                  <Text style={styles.slotButtonIcon}>{FAVORITE_SLOT_ICONS[role]}</Text>
+                  <Text style={[styles.slotButtonText, { color: isCurrent ? colors.onAccent : colors.ink }]}>
+                    {isCurrent ? t('map.slotAlreadyAssigned', { label: t(`favorites.${role}`) }) : t('map.assignAsSlot', { label: t(`favorites.${role}`) })}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
         </View>
       )}
 
@@ -235,6 +265,28 @@ const styles = StyleSheet.create({
   selectionButtonText: {
     fontSize: 15,
     fontWeight: '700',
+  },
+  slotButtons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  slotButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 10,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+  slotButtonIcon: {
+    fontSize: 14,
+  },
+  slotButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
   },
   recenterButton: {
     position: 'absolute',

--- a/src/components/DestinationPicker.tsx
+++ b/src/components/DestinationPicker.tsx
@@ -10,7 +10,14 @@ import {
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import stations from '../data/stations.json';
-import { FAVORITE_SLOT_ICONS, isFavoriteSlotRole, type FavoriteEntry, type Station } from '../types/station';
+import {
+  FAVORITE_SLOT_ICONS,
+  FAVORITE_SLOT_ROLES,
+  isFavoriteSlotRole,
+  type FavoriteEntry,
+  type FavoriteSlotRole,
+  type Station,
+} from '../types/station';
 import { StationMap } from './StationMap';
 import { StationSuggestionList } from './StationSuggestionList';
 import { createLogger } from '../utils/logger';
@@ -30,6 +37,7 @@ interface Props {
   readonly userLat?: number | null;
   readonly userLng?: number | null;
   readonly onRecenter?: () => void;
+  readonly onAssignSlot?: (role: FavoriteSlotRole, station: Station) => void;
 }
 
 export function DestinationPicker({
@@ -40,10 +48,12 @@ export function DestinationPicker({
   userLng,
   favorites,
   onRecenter,
+  onAssignSlot,
 }: Props) {
   const [query, setQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const [recenterNonce, setRecenterNonce] = useState(0);
+  const [pendingSlot, setPendingSlot] = useState<FavoriteSlotRole | null>(null);
   const openTimeRef = useRef<number | null>(null);
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -73,6 +83,13 @@ export function DestinationPicker({
     return [...favorites].sort((a, b) => order[a.role] - order[b.role]);
   }, [favorites]);
 
+  // #559: 미설정 슬롯에 placeholder chip 노출 — 누르면 다음 선택 역을 슬롯에 저장하는 모드 진입.
+  const unassignedSlotRoles = useMemo(() => {
+    if (!onAssignSlot) return [];
+    const assigned = new Set((favorites ?? []).map((f) => f.role));
+    return FAVORITE_SLOT_ROLES.filter((role) => !assigned.has(role));
+  }, [favorites, onAssignSlot]);
+
   const suggestions = useMemo(() => {
     const q = query.trim();
     if (!q) return [];
@@ -86,12 +103,18 @@ export function DestinationPicker({
   function handleSelect(station: Station) {
     setQuery('');
     setShowDropdown(false);
+    if (pendingSlot && onAssignSlot) {
+      onAssignSlot(pendingSlot, station);
+      setPendingSlot(null);
+      return;
+    }
     onSelect(station);
   }
 
   function handleClose() {
     setQuery('');
     setShowDropdown(false);
+    setPendingSlot(null);
     onClose();
   }
 
@@ -122,6 +145,16 @@ export function DestinationPicker({
               <Text style={[styles.closeText, { color: colors.accent }]}>{t('common.close')}</Text>
             </TouchableOpacity>
           </View>
+          {pendingSlot && (
+            <View style={[styles.pendingBanner, { backgroundColor: colors.accent }]} testID="pending-slot-banner">
+              <Text style={[styles.pendingText, { color: colors.onAccent }]}>
+                {t('destinationPicker.pendingSlot', { label: t(`favorites.${pendingSlot}`) })}
+              </Text>
+              <TouchableOpacity onPress={() => setPendingSlot(null)} testID="pending-slot-cancel">
+                <Text style={[styles.pendingCancel, { color: colors.onAccent }]}>{t('common.cancel')}</Text>
+              </TouchableOpacity>
+            </View>
+          )}
           <TextInput
             style={[styles.input, { backgroundColor: colors.card, color: colors.ink, borderColor: colors.hair }]}
             placeholder={t('destinationPicker.searchPlaceholder')}
@@ -134,7 +167,7 @@ export function DestinationPicker({
             onFocus={() => setShowDropdown(true)}
             testID="search-input"
           />
-          {favoriteChips.length > 0 && !showDropdown && (
+          {(favoriteChips.length > 0 || unassignedSlotRoles.length > 0) && !showDropdown && (
             <ScrollView
               horizontal
               showsHorizontalScrollIndicator={false}
@@ -142,6 +175,26 @@ export function DestinationPicker({
               contentContainerStyle={styles.chipRow}
               testID="favorites-chip-row"
             >
+              {unassignedSlotRoles.map((role) => (
+                <TouchableOpacity
+                  key={`slot-placeholder-${role}`}
+                  style={[
+                    styles.chip,
+                    styles.chipPlaceholder,
+                    {
+                      backgroundColor: colors.card,
+                      borderColor: pendingSlot === role ? colors.accent : colors.hair,
+                    },
+                  ]}
+                  onPress={() => setPendingSlot(pendingSlot === role ? null : role)}
+                  testID={`slot-placeholder-chip-${role}`}
+                >
+                  <Text style={styles.chipIcon}>{FAVORITE_SLOT_ICONS[role]}</Text>
+                  <Text style={[styles.chipText, { color: colors.ink }]}>
+                    {t('destinationPicker.assignSlot', { label: t(`favorites.${role}`) })}
+                  </Text>
+                </TouchableOpacity>
+              ))}
               {favoriteChips.map(({ station, role, label }) => {
                 const isSlot = isFavoriteSlotRole(role);
                 const chipText = isSlot
@@ -263,6 +316,29 @@ const styles = StyleSheet.create({
   chipText: {
     fontSize: 14,
     fontWeight: '600',
+  },
+  chipPlaceholder: {
+    borderStyle: 'dashed',
+  },
+  pendingBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginHorizontal: spacing.xl,
+    marginTop: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.sm,
+  },
+  pendingText: {
+    fontSize: 14,
+    fontWeight: '600',
+    flex: 1,
+  },
+  pendingCancel: {
+    fontSize: 14,
+    fontWeight: '700',
+    paddingHorizontal: spacing.sm,
   },
   recenterButton: {
     position: 'absolute',

--- a/src/components/__tests__/DestinationPicker.test.tsx
+++ b/src/components/__tests__/DestinationPicker.test.tsx
@@ -272,6 +272,109 @@ describe('DestinationPicker', () => {
     expect(chips[2].props.testID).toBe(`favorite-chip-${general.id}`);
   });
 
+  it('미설정 슬롯이 있고 onAssignSlot이 제공되면 placeholder chip을 노출한다', () => {
+    const { getByTestId } = render(
+      <DestinationPicker {...defaultProps} favorites={[]} onAssignSlot={jest.fn()} />,
+    );
+    expect(getByTestId('slot-placeholder-chip-home')).toBeTruthy();
+    expect(getByTestId('slot-placeholder-chip-work')).toBeTruthy();
+  });
+
+  it('favorites prop이 없어도 onAssignSlot만 있으면 placeholder chip을 노출한다', () => {
+    const { getByTestId } = render(
+      <DestinationPicker {...defaultProps} onAssignSlot={jest.fn()} />,
+    );
+    expect(getByTestId('slot-placeholder-chip-home')).toBeTruthy();
+  });
+
+  it('onAssignSlot이 없으면 placeholder chip을 노출하지 않는다', () => {
+    const { queryByTestId } = render(
+      <DestinationPicker {...defaultProps} favorites={[]} />,
+    );
+    expect(queryByTestId('slot-placeholder-chip-home')).toBeNull();
+    expect(queryByTestId('slot-placeholder-chip-work')).toBeNull();
+  });
+
+  it('placeholder chip 탭 → 다음 선택 역이 onAssignSlot으로 전달되고 chip이 갱신된다', () => {
+    const onAssignSlot = jest.fn();
+    const onSelect = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <DestinationPicker
+        {...defaultProps}
+        favorites={[]}
+        onAssignSlot={onAssignSlot}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.press(getByTestId('slot-placeholder-chip-home'));
+    expect(getByTestId('pending-slot-banner')).toBeTruthy();
+    // 검색 결과 선택 → onAssignSlot이 호출되고 onSelect는 호출되지 않음
+    fireEvent.changeText(getByTestId('search-input'), '강남');
+    fireEvent.press(getByTestId(`suggestion-item-${mockStation.id}`));
+    expect(onAssignSlot).toHaveBeenCalledWith('home', mockStation);
+    expect(onSelect).not.toHaveBeenCalled();
+    // 배너는 사라짐
+    expect(queryByTestId('pending-slot-banner')).toBeNull();
+  });
+
+  it('placeholder chip을 다시 누르면 pending 모드가 해제된다', () => {
+    const { getByTestId, queryByTestId } = render(
+      <DestinationPicker {...defaultProps} favorites={[]} onAssignSlot={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('slot-placeholder-chip-home'));
+    expect(getByTestId('pending-slot-banner')).toBeTruthy();
+    fireEvent.press(getByTestId('slot-placeholder-chip-home'));
+    expect(queryByTestId('pending-slot-banner')).toBeNull();
+  });
+
+  it('pending banner의 취소 버튼이 모드를 해제한다', () => {
+    const { getByTestId, queryByTestId } = render(
+      <DestinationPicker {...defaultProps} favorites={[]} onAssignSlot={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('slot-placeholder-chip-home'));
+    fireEvent.press(getByTestId('pending-slot-cancel'));
+    expect(queryByTestId('pending-slot-banner')).toBeNull();
+  });
+
+  it('모달 닫기 시 pending 모드가 초기화된다', () => {
+    const onClose = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <DestinationPicker {...defaultProps} favorites={[]} onAssignSlot={jest.fn()} onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId('slot-placeholder-chip-home'));
+    fireEvent.press(getByTestId('close-button'));
+    expect(onClose).toHaveBeenCalled();
+    rerender(<DestinationPicker {...defaultProps} visible={true} favorites={[]} onAssignSlot={jest.fn()} onClose={onClose} />);
+    expect(queryByTestId('pending-slot-banner')).toBeNull();
+  });
+
+  it('이미 home/work가 모두 지정되어 있으면 placeholder chip을 노출하지 않는다', () => {
+    const home: Station = { ...mockStation };
+    const work: Station = { id: '2-021', name: '역삼', line: '2', lineColor: '#009D3E', lat: 37.5, lng: 127 };
+    const { queryByTestId } = render(
+      <DestinationPicker
+        {...defaultProps}
+        favorites={[
+          { station: home, role: 'home' },
+          { station: work, role: 'work' },
+        ]}
+        onAssignSlot={jest.fn()}
+      />,
+    );
+    expect(queryByTestId('slot-placeholder-chip-home')).toBeNull();
+    expect(queryByTestId('slot-placeholder-chip-work')).toBeNull();
+  });
+
+  it('지도 마커 탭으로도 슬롯 지정이 동작한다', () => {
+    const onAssignSlot = jest.fn();
+    const { getByTestId } = render(
+      <DestinationPicker {...mapProps} favorites={[]} onAssignSlot={onAssignSlot} />,
+    );
+    fireEvent.press(getByTestId('slot-placeholder-chip-work'));
+    fireEvent.press(getByTestId('marker-강남'));
+    expect(onAssignSlot).toHaveBeenCalledWith('work', expect.objectContaining({ id: '2-022' }));
+  });
+
   it('검색창 포커스 시 드롭다운 표시 상태가 활성화된다', () => {
     const { getByTestId, queryByTestId } = render(<DestinationPicker {...defaultProps} />);
     fireEvent.changeText(getByTestId('search-input'), '강남');

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -82,6 +82,8 @@
     "destinationBadge": "Destination",
     "setAsOrigin": "Set as origin",
     "setAsDestination": "Set as destination",
+    "assignAsSlot": "Save as {{label}}",
+    "slotAlreadyAssigned": "{{label}} ✓",
     "nearbyStationsHeader": "Nearby stations (within 1km)",
     "noNearbyStations": "No subway stations within 1km.",
     "recenter": "Recenter on my location",
@@ -115,7 +117,9 @@
   "destinationPicker": {
     "noLocation": "Location info unavailable.",
     "title": "Set destination",
-    "searchPlaceholder": "Search station name"
+    "searchPlaceholder": "Search station name",
+    "assignSlot": "Add {{label}}",
+    "pendingSlot": "The next station you pick will be saved as {{label}}"
   },
   "sleepModeGuide": {
     "title": "Sleep mode notice",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -82,6 +82,8 @@
     "destinationBadge": "目的地",
     "setAsOrigin": "出発駅に設定",
     "setAsDestination": "目的地に設定",
+    "assignAsSlot": "{{label}}として保存",
+    "slotAlreadyAssigned": "{{label}} ✓",
     "nearbyStationsHeader": "周辺の地下鉄駅 (1km以内)",
     "noNearbyStations": "1km以内に地下鉄駅がありません。",
     "recenter": "現在地に戻る",
@@ -115,7 +117,9 @@
   "destinationPicker": {
     "noLocation": "位置情報がありません。",
     "title": "目的地を設定",
-    "searchPlaceholder": "駅名を検索"
+    "searchPlaceholder": "駅名を検索",
+    "assignSlot": "{{label}}を追加",
+    "pendingSlot": "次に選ぶ駅を{{label}}として保存します"
   },
   "sleepModeGuide": {
     "title": "おやすみモードのご案内",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -82,6 +82,8 @@
     "destinationBadge": "도착",
     "setAsOrigin": "출발역으로 설정",
     "setAsDestination": "도착역으로 설정",
+    "assignAsSlot": "{{label}}으로 저장",
+    "slotAlreadyAssigned": "{{label}} ✓",
     "nearbyStationsHeader": "주변 지하철역 (1km 이내)",
     "noNearbyStations": "주변 1km 내 지하철역이 없습니다.",
     "recenter": "내 위치로 이동",
@@ -115,7 +117,9 @@
   "destinationPicker": {
     "noLocation": "위치 정보가 없습니다.",
     "title": "목적지 설정",
-    "searchPlaceholder": "역 이름 검색"
+    "searchPlaceholder": "역 이름 검색",
+    "assignSlot": "{{label}} 추가",
+    "pendingSlot": "다음에 선택하는 역을 {{label}}로 저장합니다"
   },
   "sleepModeGuide": {
     "title": "취침 모드 안내",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -82,6 +82,8 @@
     "destinationBadge": "目的地",
     "setAsOrigin": "设为出发站",
     "setAsDestination": "设为目的地",
+    "assignAsSlot": "保存为{{label}}",
+    "slotAlreadyAssigned": "{{label}} ✓",
     "nearbyStationsHeader": "附近地铁站(1km以内)",
     "noNearbyStations": "1km内没有地铁站。",
     "recenter": "返回当前位置",
@@ -115,7 +117,9 @@
   "destinationPicker": {
     "noLocation": "无位置信息。",
     "title": "设置目的地",
-    "searchPlaceholder": "搜索车站名称"
+    "searchPlaceholder": "搜索车站名称",
+    "assignSlot": "添加{{label}}",
+    "pendingSlot": "下次选择的车站将保存为{{label}}"
   },
   "sleepModeGuide": {
     "title": "睡眠模式提示",


### PR DESCRIPTION
## Summary
favorites 탭 외부에서도 집/회사 슬롯에 역을 지정할 수 있는 진입점 두 곳 추가.

- **목적지 설정 모달**: 미설정 슬롯이 있으면 placeholder chip(🏠 집 추가) 노출. 탭하면 pending 모드 진입 → 다음에 선택하는 역이 슬롯으로 저장됨. 상단 안내 배너 + 취소 버튼
- **지도 탭 selectionCard**: 역 선택 카드에 "집/회사로 저장" 버튼 2개. 이미 같은 슬롯에 같은 역이면 비활성+체크

## Why
#557로 슬롯 도입했지만 favorites 탭에서만 지정 가능 → 사용자가 지도에서 역을 찾아도 별도 탭으로 이동해야 함. 발견성/접근성 개선.

## Test plan
- [x] DestinationPicker: 슬롯 미설정 시 placeholder chip 노출, 설정되면 사라짐
- [x] placeholder chip 탭 → pending 배너 → 검색/지도 선택 시 onAssignSlot 호출
- [x] 슬롯 지정 모드 취소(다시 탭/배너 취소 버튼/모달 닫기)
- [x] 지도 탭 selectionCard 집/회사 버튼 동작 및 같은 역 비활성화
- [x] 1820 tests / 커버리지 100% / 타입체크 통과

Closes #559