### PR TITLE
fix(#543): FG 복귀 시 stale 위치 표시 제거

### DIFF
--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -282,6 +282,52 @@ describe('useNearestStation', () => {
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
   });
 
+  it('포그라운드 복귀 시 fresh fix를 요청하고 locationUncertain을 true로 전환한다 (#543)', async () => {
+    mockGranted();
+    // 초기 mount에서는 refresh가 호출되지 않으므로 mockLocation은 FG 복귀 후의 fresh fix에 사용.
+    mockLocation(37.498, 127.028, { accuracy: 10 });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    // 초기 fresh fix 들어오면 uncertain은 false로 시작
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+    simulateGps(37.498, 127.028, { accuracy: 10 });
+    await waitFor(() => expect(result.current.userLocation).not.toBeNull());
+    expect(result.current.locationUncertain).toBe(false);
+
+    // BG → FG 전환. active 핸들러가 동기적으로 setLocationUncertain(true)을 호출하므로
+    // refresh()의 await getCurrentPositionAsync 시점에 uncertain=true가 관측된다.
+    act(() => { appStateCallback?.('background'); });
+
+    // active 이벤트 직후 getCurrentPositionAsync 호출이 들어가야 한다 (refresh 경로).
+    const callsBeforeResume = (Location.getCurrentPositionAsync as jest.Mock).mock.calls.length;
+    // getCurrentPositionAsync을 deferred로 만들어 uncertain=true 구간을 관측한다.
+    let resolveFresh: ((value: unknown) => void) | null = null;
+    (Location.getCurrentPositionAsync as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFresh = (v) => resolve(v);
+        }),
+    );
+
+    await act(async () => { appStateCallback?.('active'); });
+
+    // 1) uncertain이 true로 즉시 전환됨
+    expect(result.current.locationUncertain).toBe(true);
+    // 2) refresh가 getCurrentPositionAsync를 호출했음
+    expect((Location.getCurrentPositionAsync as jest.Mock).mock.calls.length).toBe(callsBeforeResume + 1);
+
+    // 3) fresh fix가 들어오면 applyLocation이 uncertain=false로 복귀.
+    //    jump gate를 피하기 위해 직전 fix와 동일 좌표 사용 (테스트 의도: uncertain 복귀만 검증).
+    await act(async () => {
+      resolveFresh?.({
+        coords: { latitude: 37.498, longitude: 127.028, accuracy: 10 },
+        timestamp: Date.now(),
+      });
+    });
+    await waitFor(() => expect(result.current.locationUncertain).toBe(false));
+  });
+
   it('언마운트 시 AppState 리스너를 해제한다', async () => {
     mockGranted();
 
@@ -517,6 +563,9 @@ describe('useNearestStation', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     mockGranted();
     mockLastKnownLocation(37.4980, 127.0277, { ageMs: MAX_LOCATION_AGE_MS + 1 });
+    // FG 복귀 시 refresh()가 호출되어 getCurrentPositionAsync 정상 경로를 타도록 mock 설정.
+    // 미설정 시 catch 분기로 우회되어 카운터 누적 로직 검증이 무의미해진다 (#543 리뷰).
+    mockLocation(37.4980, 127.0277, { accuracy: 30 });
 
     renderHook(() => useNearestStation());
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -266,7 +266,11 @@ export function useNearestStation(): UseNearestStationReturn {
 
     const appStateSub = AppState.addEventListener('change', (state) => {
       if (state === 'active') {
-        startWatch();
+        // FG 복귀 시 result는 BG 진입 시점의 stale 위치 — 사용자가 그 사이 이동했을 수 있다 (#543).
+        // 명시적으로 uncertain 상태로 전환해 UI가 "위치 확인 중"을 표시하게 하고,
+        // refresh()로 즉시 fresh fix를 요청한다. fresh fix가 들어오면 applyLocation이 uncertain을 해제.
+        setLocationUncertain(true);
+        void refresh();
       } else if (state === 'background') {
         stopWatch();
       }
@@ -277,7 +281,7 @@ export function useNearestStation(): UseNearestStationReturn {
       stopWatch();
       appStateSub.remove();
     };
-  }, [startWatch, stopWatch]);
+  }, [startWatch, stopWatch, refresh]);
 
   return { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh };
 }


### PR DESCRIPTION
## Summary
BG → FG 전환 시 useNearestStation의 result가 BG 진입 시점 fix로 정지된 채 watchPosition 첫 콜백 도착까지 stale 위치를 그대로 표시해 사용자가 이동 중 실제 위치와 약 3개 역 차이로 인지하던 버그 수정.

## Fix
`AppState 'active'` 핸들러에서:
1. 즉시 `setLocationUncertain(true)` — UI가 "위치 확인 중" 표시
2. `refresh()` 호출 — `getCurrentPositionAsync` one-shot fresh fix
3. fresh fix 도착 시 `applyLocation`이 `setLocationUncertain(false)` → 정상 갱신

## Why this approach
- 이전: AppState 'active' → `startWatch()`만 호출. lastKnown이 freshness/accuracy 게이트 통과해야 즉시 표시. 통과 못하면 watchPosition 첫 콜백(최대 2s)까지 stale 표시.
- 변경: refresh()가 stopWatch → fresh one-shot → startWatch 순으로 동작. fresh fix는 즉시 적용.
- locationUncertain 마킹은 stale 표시 시간을 시각적으로도 "확인 중"으로 명시.

## Test plan
- [x] 기존 "FG 복귀 시 watchPositionAsync 재호출" 테스트 통과 유지
- [x] 신규: FG 복귀 시 getCurrentPositionAsync 호출 + uncertain=true 마킹 검증
- [x] 신규: deferred fresh fix 해결 시 uncertain=false 복귀 검증
- [x] lastKnown 거부 카운터 테스트: getCurrentPositionAsync mock 추가로 catch 경로 우회 제거 (리뷰 반영)
- [x] 1821 tests / 커버리지 100% / 타입체크 통과

## 분석 노트
BG 알람 시스템 전체 분석은 로컬 `tasks/bg-alarm-analysis.md` (gitignored).
- Track A: BG GPS + processLocationUpdate
- Track B: silent push + silentPushLocationGate
- "항상" 권한 / 강제 종료 / 지하 케이스별 동작 매트릭스

Closes #543