### PR TITLE
chore(#564): alarmLog source 확장 — 채널별 도달률 측정 인프라

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -19,7 +19,12 @@ import {
   useSilentPushDiagnostics,
   type SilentPushDiagnostics,
 } from '../hooks/useSilentPushDiagnostics';
-import { clearAlarmLog, getAlarmLog, type AlarmLogEntry } from '../utils/alarmLog';
+import {
+  clearAlarmLog,
+  getAlarmLog,
+  summarizeAlarmLogBySource,
+  type AlarmLogEntry,
+} from '../utils/alarmLog';
 import {
   clearFusionDebugEntries,
   getFusionDebugEntries,
@@ -207,10 +212,24 @@ function buildDumpText(args: {
   }
   lines.push('');
   lines.push(`## Alarm log (${args.logs.length})`);
+  // #564 — source별 카운트 헤더(UI와 동일 포매터 공유). 빈 문자열이면 헤더 생략.
+  const sourcesLine = formatSourceCountsLine(args.logs);
+  if (sourcesLine) lines.push(`sources: ${sourcesLine}`);
   for (const entry of [...args.logs].reverse()) {
     lines.push(formatLogLine(entry));
   }
   return lines.join('\n');
+}
+
+/**
+ * Alarm log section header / dump 헤더에서 공유되는 source별 카운트 요약 문자열 (#564).
+ * 비어있으면 빈 문자열을 반환 → 호출부에서 falsy로 분기 가능.
+ */
+function formatSourceCountsLine(logs: readonly AlarmLogEntry[]): string {
+  const counts = summarizeAlarmLogBySource(logs);
+  const keys = Object.keys(counts).sort();
+  if (keys.length === 0) return '';
+  return keys.map((k) => `${k}=${counts[k]}`).join(', ');
 }
 
 interface DebugModalProps {
@@ -480,15 +499,24 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
             {logs.length === 0 ? (
               <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
             ) : (
-              [...logs].reverse().map((entry, idx) => (
+              <>
                 <Text
-                  key={`${entry.ts}-${idx}`}
-                  style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
+                  style={[typography.mono, { color: colors.subtle, marginBottom: spacing.xs }]}
                   selectable
+                  testID="debug-log-source-counts"
                 >
-                  {formatLogLine(entry)}
+                  {formatSourceCountsLine(logs)}
                 </Text>
-              ))
+                {[...logs].reverse().map((entry, idx) => (
+                  <Text
+                    key={`${entry.ts}-${idx}`}
+                    style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
+                    selectable
+                  >
+                    {formatLogLine(entry)}
+                  </Text>
+                ))}
+              </>
             )}
           </Section>
 
@@ -553,7 +581,14 @@ function KeyValue({
 }
 
 // Internal exports for tests — DO NOT use from app code.
-export const __test__ = { formatLogLine, buildDumpText, formatFusionDebugLine, formatTokenTail, formatAt };
+export const __test__ = {
+  formatLogLine,
+  buildDumpText,
+  formatFusionDebugLine,
+  formatTokenTail,
+  formatAt,
+  formatSourceCountsLine,
+};
 
 const styles = StyleSheet.create({
   container: { flex: 1 },

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -227,7 +227,7 @@ function buildDumpText(args: {
  */
 function formatSourceCountsLine(logs: readonly AlarmLogEntry[]): string {
   const counts = summarizeAlarmLogBySource(logs);
-  const keys = Object.keys(counts).sort();
+  const keys = Object.keys(counts).sort((a, b) => a.localeCompare(b));
   if (keys.length === 0) return '';
   return keys.map((k) => `${k}=${counts[k]}`).join(', ');
 }

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -139,6 +139,24 @@ describe('DebugModal', () => {
     expect(screen.getByTestId('debug-arrival-summary').props.children).toContain('청량리');
   });
 
+  it('Alarm log 섹션에 source별 카운트 라인을 표시한다 (#564)', async () => {
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: 1, source: 'fg', outcome: 'fired' },
+      { ts: 2, source: 'region-entry-fired', outcome: 'fired' },
+      { ts: 3, source: 'region-entry-fired', outcome: 'fired' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    const counts = screen.getByTestId('debug-log-source-counts');
+    expect(counts.props.children).toBe('fg=1, region-entry-fired=2');
+  });
+
+  it('로그가 비어있으면 source 카운트 라인을 렌더링하지 않는다 (#564)', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.queryByTestId('debug-log-source-counts')).toBeNull();
+  });
+
   it('userLocation이 null이면 "no location"을 표시한다', () => {
     mockUseFusedNearestStation.mockReturnValue({
       result: null,
@@ -605,6 +623,58 @@ describe('DebugModal helpers', () => {
     expect(dump).toContain('speed=- m/s');
     expect(dump).toContain('accuracy=- m');
     expect(dump).toContain('강남 · - m');
+  });
+
+  it('formatSourceCountsLine: 빈 로그면 빈 문자열을 반환한다 (#564)', () => {
+    expect(__test__.formatSourceCountsLine([])).toBe('');
+  });
+
+  it('formatSourceCountsLine: source별 카운트를 정렬해 표기한다 (#564)', () => {
+    const logs: AlarmLogEntry[] = [
+      { ts: 1, source: 'fg', outcome: 'fired' },
+      { ts: 2, source: 'fg', outcome: 'fired' },
+      { ts: 3, source: 'region-entry-fired', outcome: 'fired' },
+      { ts: 4, source: 'alert-fallback-fired', outcome: 'fired' },
+    ];
+    const line = __test__.formatSourceCountsLine(logs);
+    expect(line).toBe('alert-fallback-fired=1, fg=2, region-entry-fired=1');
+  });
+
+  it('buildDumpText: 로그가 있으면 sources 헤더에 source별 카운트를 표기한다 (#564)', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: baseFusion,
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: baseSilentPush,
+      logs: [
+        { ts: 1, source: 'region-entry-fired', outcome: 'fired' },
+        { ts: 2, source: 'alert-fallback-fired', outcome: 'fired' },
+      ],
+    });
+    expect(dump).toContain('sources: alert-fallback-fired=1, region-entry-fired=1');
+  });
+
+  it('buildDumpText: 로그가 없으면 sources 헤더를 추가하지 않는다 (#564)', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: baseFusion,
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: baseSilentPush,
+      logs: [],
+    });
+    expect(dump).not.toContain('sources:');
   });
 
   it('formatLogLine: location 없는 fired 엔트리는 acc/age를 포함하지 않는다', () => {

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -11,6 +11,10 @@ import {
   logSilentPushReceived,
   logSilentPushFired,
   logSilentPushSkipped,
+  logAlertFallbackFired,
+  logRegionEntryFired,
+  logRegionEntrySkipped,
+  summarizeAlarmLogBySource,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -419,12 +423,109 @@ describe('alarmLog', () => {
       expect(saved[0].distanceM).toBeUndefined();
     });
 
+    it('logAlertFallbackFired: source=alert-fallback-fired, outcome=fired 적재 (#564)', async () => {
+      logAlertFallbackFired({ stationName: '강남', kind: 'destination', phaseId: 'imminent' });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'alert-fallback-fired',
+        outcome: 'fired',
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('logRegionEntryFired: source=region-entry-fired, outcome=fired 적재 (#564)', async () => {
+      logRegionEntryFired({ stationName: '시청', kind: 'transfer', phaseId: 'early' });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'region-entry-fired',
+        outcome: 'fired',
+        stationName: '시청',
+        kind: 'transfer',
+        phaseId: 'early',
+      });
+    });
+
+    it('logRegionEntrySkipped: caller가 reason을 주입한다 (#564)', async () => {
+      logRegionEntrySkipped({
+        stationName: '시청',
+        kind: 'destination',
+        phaseId: 'imminent',
+        reason: 'dedup-station',
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'region-entry-skipped',
+        outcome: 'suppressed',
+        reason: 'dedup-station',
+        stationName: '시청',
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('logRegionEntrySkipped: dedup 외 reason도 그대로 적재 (#564)', async () => {
+      logRegionEntrySkipped({
+        stationName: '시청',
+        kind: 'destination',
+        phaseId: 'imminent',
+        reason: 'gate-unknown-station',
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].reason).toBe('gate-unknown-station');
+    });
+
     it('helper는 fire-and-forget: void 반환 + AsyncStorage 실패 시 throw 안 함', async () => {
       (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
       // 호출 자체가 throw하면 안 됨 (void)
       expect(() => logFiredAlarm('fg', event)).not.toThrow();
       await flushPromises();
+    });
+  });
+
+  describe('summarizeAlarmLogBySource (#564)', () => {
+    it('빈 배열이면 빈 객체를 반환한다', () => {
+      expect(summarizeAlarmLogBySource([])).toEqual({});
+    });
+
+    it('source별로 카운트를 집계한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'fg' }),
+        makeEntry({ source: 'fg' }),
+        makeEntry({ source: 'bg-scheduled' }),
+        makeEntry({ source: 'alert-fallback-fired' }),
+        makeEntry({ source: 'region-entry-fired' }),
+        makeEntry({ source: 'region-entry-skipped' }),
+        makeEntry({ source: 'region-entry-fired' }),
+      ];
+      expect(summarizeAlarmLogBySource(entries)).toEqual({
+        fg: 2,
+        'bg-scheduled': 1,
+        'alert-fallback-fired': 1,
+        'region-entry-fired': 2,
+        'region-entry-skipped': 1,
+      });
+    });
+
+    it('카운트 0인 source는 결과에 포함되지 않는다', () => {
+      const entries: AlarmLogEntry[] = [makeEntry({ source: 'fg' })];
+      const result = summarizeAlarmLogBySource(entries);
+      expect(result).toEqual({ fg: 1 });
+      expect(Object.keys(result)).not.toContain('bg');
     });
   });
 

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -16,6 +16,8 @@ export const ALARM_LOG_BUFFER_SIZE = 200;
 // v2 (#372)로 의미 명확화. 두 값 모두 union에 유지해 과거 저장 데이터를 손실 없이 읽는다.
 // 'silent-push-received'는 #478 측정 인프라 — silent push 도달 시점 기록.
 // 'silent-push-fired'/'silent-push-skipped'는 #478 PR 1-2 — 위치 게이트 통과/실패 발사.
+// 'alert-fallback-fired'/'region-entry-*'는 #564 — 다중 채널 BG 알람(채널 2 alert fallback /
+// 채널 3 Region Monitoring) 도달률 측정용. 발사 동작은 후속 PR에서 추가, 본 PR은 source 슬롯만.
 export type AlarmLogSource =
   | 'fg'
   | 'bg'
@@ -23,7 +25,10 @@ export type AlarmLogSource =
   | 'bg-scheduled'
   | 'silent-push-received'
   | 'silent-push-fired'
-  | 'silent-push-skipped';
+  | 'silent-push-skipped'
+  | 'alert-fallback-fired'
+  | 'region-entry-fired'
+  | 'region-entry-skipped';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(evaluateAlarmPhase의 firedAlarms 적중 케이스)은 후속 이슈에서 추가.
 // 그때까지 union에 선언하지 않아 "구현됐다"는 거짓 시그널을 피한다.
@@ -252,6 +257,82 @@ export function logSilentPushSkipped(input: {
     locationSource: input.locationSource,
     locationAgeMs: input.locationAgeMs,
   });
+}
+
+/**
+ * 채널 2 alert fallback 발사 1건 적재 (#564).
+ * 백엔드 ACK 타임아웃 후 alert push가 전달돼 발사된 경우. silent push와 다르게
+ * 클라 위치 게이트 없이 OS가 즉시 표시하므로 distance/threshold는 기록하지 않는다.
+ */
+export function logAlertFallbackFired(input: {
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId: AlarmPhaseId;
+}): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'alert-fallback-fired',
+    outcome: 'fired',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * 채널 3 Region Monitoring 진입 wake 발사 1건 적재 (#564).
+ */
+export function logRegionEntryFired(input: {
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId: AlarmPhaseId;
+}): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'region-entry-fired',
+    outcome: 'fired',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * 채널 3 Region Monitoring 진입 wake — 스킵된 1건 적재 (#564).
+ * reason은 caller가 주입(dedup-station / gate-unknown-station / ...).
+ * logSilentPushSkipped와 동일한 패턴: 향후 dedup 외 사유가 늘어나도 helper 분기 없이 호환.
+ */
+export function logRegionEntrySkipped(input: {
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId: AlarmPhaseId;
+  reason: AlarmLogReason;
+}): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'region-entry-skipped',
+    outcome: 'suppressed',
+    reason: input.reason,
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * 로그 엔트리들을 source별로 카운트한다 (#564).
+ * DebugModal 헤더/dump에 채널별 도달률 요약을 표기하기 위한 측정 인프라.
+ * 결과는 카운트가 0이 아닌 source만 포함 — 노이즈 줄이고 새 source가 추가돼도
+ * 코드 수정 없이 자동 반영된다 (UI는 데이터 주도).
+ */
+export function summarizeAlarmLogBySource(
+  entries: readonly AlarmLogEntry[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const entry of entries) {
+    counts[entry.source] = (counts[entry.source] ?? 0) + 1;
+  }
+  return counts;
 }
 
 export function logSuppressedGate(


### PR DESCRIPTION
## Summary
- 다중 채널 BG 알람(채널 2 alert fallback / 채널 3 Region Monitoring) 도달률을 측정하기 위한 인프라.
- `AlarmLogSource` union에 `alert-fallback-fired` / `region-entry-fired` / `region-entry-skipped` 추가.
- `logAlertFallbackFired` / `logRegionEntryFired` / `logRegionEntrySkipped` helper 추가 — `logSilentPushSkipped`와 동일한 caller-injected reason 패턴.
- `summarizeAlarmLogBySource` — entries만 순회하는 데이터 주도 집계. 새 source 추가 시 코드 수정 없이 자동 반영.
- DebugModal Alarm log 섹션 헤더와 dump 헤더에 source별 카운트 표기 (공통 포매터로 일원화).

본 PR은 source 슬롯과 측정 인프라만 추가한다. 실제 alert fallback / region entry 호출부 연결은 후속 이슈(P2*, P3*).

## Test plan
- [x] `npm test` — 1834개 통과, alarmLog/DebugModal 100% 커버리지 유지
- [x] `npm run type-check` 통과
- [x] code-review 에이전트 P2 피드백 반영 (DRY 일원화 + caller-injected reason)
- [ ] (후속 PR) 실제 alert fallback / region entry 발사 시점에 helper 호출

Closes #564