### PR TITLE
feat(#566): backend pushId 발급 + 디바이스 ACK endpoint

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -68,6 +68,7 @@ describe('sendSilentPush', () => {
         phase: 'early',
         kind: 'destination',
         sentAt: 1_700_000_000_000,
+        pushId: 'push-uuid-1',
       },
       config: makeConfig(),
       host: TEST_HOST,
@@ -88,6 +89,7 @@ describe('sendSilentPush', () => {
     expect(body.data.phase).toBe('early');
     expect(body.data.kind).toBe('destination');
     expect(body.data.sentAt).toBe(1_700_000_000_000);
+    expect(body.data.pushId).toBe('push-uuid-1');
   });
 
   it('returns failure with reason', async () => {
@@ -102,6 +104,7 @@ describe('sendSilentPush', () => {
         phase: 'imminent',
         kind: 'destination',
         sentAt: 1_700_000_000_000,
+        pushId: 'p',
       },
       config: makeConfig(),
       host: TEST_HOST,
@@ -122,6 +125,7 @@ describe('sendSilentPush', () => {
         phase: 'imminent',
         kind: 'destination',
         sentAt: 1_700_000_000_000,
+        pushId: 'p',
       },
       config: makeConfig(),
       host: TEST_HOST,
@@ -137,7 +141,7 @@ describe('sendSilentPush', () => {
     );
     await sendSilentPush({
       deviceToken: 'tok',
-      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'early', kind: 'destination', sentAt: 0 },
+      payload: { nextWaypoint: 'X', etaSeconds: 10, phase: 'early', kind: 'destination', sentAt: 0, pushId: 'p' },
       config: makeConfig(),
       host: 'api.sandbox.push.apple.com',
       fetchImpl: fetchImpl as unknown as typeof fetch,

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
-import { app, validateTrip } from '../index';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { app, validatePushAck, validateTrip } from '../index';
+import { pendingKey } from '../pendingPushes';
 import type { AnalyticsEngineWriter, Env } from '../types';
+
+class InMemoryKV {
+  store = new Map<string, { value: string; expiresAt?: number }>();
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key)?.value ?? null;
+  }
+  async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
+    const expiresAt = options?.expirationTtl
+      ? Date.now() + options.expirationTtl * 1000
+      : undefined;
+    this.store.set(key, { value, expiresAt });
+  }
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
@@ -167,5 +184,126 @@ describe('POST /telemetry/silent-push', () => {
     const res = await post('/telemetry/silent-push', validBody, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
+  });
+});
+
+describe('validatePushAck (#566 P2a)', () => {
+  it('accepts valid fired ack', () => {
+    expect(validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'fired' })).toEqual({
+      pushId: 'p1',
+      token: 'tok',
+      outcome: 'fired',
+    });
+  });
+
+  it('accepts valid skipped ack with reason', () => {
+    expect(
+      validatePushAck({
+        pushId: 'p1',
+        token: 'tok',
+        outcome: 'skipped',
+        reason: 'gate-out-of-range',
+      }),
+    ).toEqual({
+      pushId: 'p1',
+      token: 'tok',
+      outcome: 'skipped',
+      reason: 'gate-out-of-range',
+    });
+  });
+
+  it('rejects non-object', () => {
+    expect(validatePushAck(null)).toBeNull();
+    expect(validatePushAck('string')).toBeNull();
+  });
+
+  it('rejects missing pushId', () => {
+    expect(validatePushAck({ token: 'tok', outcome: 'fired' })).toBeNull();
+  });
+
+  it('rejects empty pushId', () => {
+    expect(validatePushAck({ pushId: '', token: 'tok', outcome: 'fired' })).toBeNull();
+  });
+
+  it('rejects missing token', () => {
+    expect(validatePushAck({ pushId: 'p1', outcome: 'fired' })).toBeNull();
+  });
+
+  it('rejects empty token', () => {
+    expect(validatePushAck({ pushId: 'p1', token: '', outcome: 'fired' })).toBeNull();
+  });
+
+  it('rejects invalid outcome', () => {
+    expect(validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'bogus' })).toBeNull();
+  });
+
+  it('ignores non-string reason', () => {
+    const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'skipped', reason: 123 });
+    expect(ack).toEqual({ pushId: 'p1', token: 'tok', outcome: 'skipped' });
+  });
+});
+
+describe('POST /push/ack (#566 P2a)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('returns 400 on invalid JSON', async () => {
+    const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+    const res = await post('/push/ack', 'not-json{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 on invalid payload (missing token)', async () => {
+    const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+    const res = await post('/push/ack', { pushId: 'p1', outcome: 'fired' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('token 매칭 시 deleted=true로 entry 삭제', async () => {
+    await kv.put(pendingKey('p1'), JSON.stringify({ pushId: 'p1', token: 'real-token' }));
+    const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+    const res = await post(
+      '/push/ack',
+      { pushId: 'p1', token: 'real-token', outcome: 'fired' },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: true });
+    expect(kv.store.has(pendingKey('p1'))).toBe(false);
+  });
+
+  it('token 불일치 시 reason=token-mismatch로 삭제 안 함 (인증 차단)', async () => {
+    await kv.put(pendingKey('p1'), JSON.stringify({ pushId: 'p1', token: 'real-token' }));
+    const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+    const res = await post(
+      '/push/ack',
+      { pushId: 'p1', token: 'attacker', outcome: 'fired' },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: false, reason: 'token-mismatch' });
+    expect(kv.store.has(pendingKey('p1'))).toBe(true);
+  });
+
+  it('entry 만료/미존재 시 reason=not-found (idempotent)', async () => {
+    const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+    const res = await post(
+      '/push/ack',
+      { pushId: 'missing', token: 'tok', outcome: 'skipped' },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: false, reason: 'not-found' });
+  });
+
+  it('PENDING_PUSHES 미바인딩 시 reason=not-found (graceful)', async () => {
+    const env = makeEnv();
+    const res = await post('/push/ack', { pushId: 'p1', token: 'tok', outcome: 'fired' }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: false, reason: 'not-found' });
   });
 });

--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  ackPending,
+  buildAlarmKey,
+  getPending,
+  pendingKey,
+  PENDING_TTL_SEC,
+  putPending,
+  type PendingPush,
+} from '../pendingPushes';
+
+class InMemoryKV {
+  store = new Map<string, { value: string; expiresAt?: number }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
+    const expiresAt = options?.expirationTtl
+      ? Date.now() + options.expirationTtl * 1000
+      : undefined;
+    this.store.set(key, { value, expiresAt });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+function makeEntry(overrides: Partial<PendingPush> = {}): PendingPush {
+  return {
+    pushId: 'push-1',
+    token: 'devicetoken-hex',
+    alarmKey: '강남:destination:early',
+    sentAt: 1_700_000_000_000,
+    stationName: '강남',
+    kind: 'destination',
+    phase: 'early',
+    etaSeconds: 60,
+    ...overrides,
+  };
+}
+
+describe('pendingPushes (#566 P2a)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('pendingKey: pending: 접두어를 붙인다', () => {
+    expect(pendingKey('abc-def')).toBe('pending:abc-def');
+  });
+
+  it('buildAlarmKey: 디바이스 alarmKey와 동일한 ${phase}:${stationName} 형식', () => {
+    expect(buildAlarmKey('강남', 'early')).toBe('early:강남');
+    expect(buildAlarmKey('시청', 'imminent')).toBe('imminent:시청');
+  });
+
+  describe('putPending', () => {
+    it('KV에 pending:<pushId> 키로 저장하고 TTL을 60초로 둔다', async () => {
+      const entry = makeEntry({ pushId: 'p1' });
+      await putPending(kv as unknown as KVNamespace, entry);
+      const raw = kv.store.get('pending:p1');
+      expect(raw).toBeDefined();
+      expect(JSON.parse(raw!.value)).toEqual(entry);
+      expect(raw!.expiresAt).toBeDefined();
+      // TTL 정확히 60초 ± 1초 허용 (Date.now 시점 차이).
+      expect(raw!.expiresAt! - Date.now()).toBeGreaterThan((PENDING_TTL_SEC - 1) * 1000);
+      expect(raw!.expiresAt! - Date.now()).toBeLessThanOrEqual(PENDING_TTL_SEC * 1000);
+    });
+
+    it('PENDING_TTL_SEC가 60초로 노출된다', () => {
+      expect(PENDING_TTL_SEC).toBe(60);
+    });
+
+    it('kv === undefined면 graceful no-op (throw 없음)', async () => {
+      await expect(putPending(undefined, makeEntry())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getPending', () => {
+    it('저장된 entry를 그대로 반환', async () => {
+      const entry = makeEntry({ pushId: 'p1' });
+      await putPending(kv as unknown as KVNamespace, entry);
+      const loaded = await getPending(kv as unknown as KVNamespace, 'p1');
+      expect(loaded).toEqual(entry);
+    });
+
+    it('미존재 키는 null', async () => {
+      expect(await getPending(kv as unknown as KVNamespace, 'missing')).toBeNull();
+    });
+
+    it('손상된 JSON은 null', async () => {
+      await kv.put('pending:bad', 'not-json');
+      expect(await getPending(kv as unknown as KVNamespace, 'bad')).toBeNull();
+    });
+
+    it('kv === undefined면 graceful null', async () => {
+      expect(await getPending(undefined, 'p1')).toBeNull();
+    });
+  });
+
+  describe('ackPending', () => {
+    it('token 매칭 시 entry 삭제하고 deleted=true', async () => {
+      await putPending(
+        kv as unknown as KVNamespace,
+        makeEntry({ pushId: 'p1', token: 'devicetoken-hex' }),
+      );
+      const result = await ackPending(kv as unknown as KVNamespace, 'p1', 'devicetoken-hex');
+      expect(result).toEqual({ deleted: true });
+      expect(kv.store.has('pending:p1')).toBe(false);
+    });
+
+    it('token 불일치면 삭제하지 않고 reason=token-mismatch', async () => {
+      await putPending(
+        kv as unknown as KVNamespace,
+        makeEntry({ pushId: 'p1', token: 'real-token' }),
+      );
+      const result = await ackPending(kv as unknown as KVNamespace, 'p1', 'attacker-token');
+      expect(result).toEqual({ deleted: false, reason: 'token-mismatch' });
+      expect(kv.store.has('pending:p1')).toBe(true);
+    });
+
+    it('미존재 키는 reason=not-found (idempotent)', async () => {
+      const result = await ackPending(kv as unknown as KVNamespace, 'missing', 'tok');
+      expect(result).toEqual({ deleted: false, reason: 'not-found' });
+    });
+
+    it('kv === undefined면 reason=not-found 반환', async () => {
+      expect(await ackPending(undefined, 'p1', 'tok')).toEqual({
+        deleted: false,
+        reason: 'not-found',
+      });
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -56,7 +56,7 @@ const APNS_HOSTS = {
   sandbox: 'api.sandbox.push.apple.com',
 } as const;
 
-function makeEnv(kv: InMemoryKV): Env {
+function makeEnv(kv: InMemoryKV, pending?: InMemoryKV): Env {
   return {
     TRIPS: kv as unknown as KVNamespace,
     APNS_HOST: APNS_HOSTS.production,
@@ -67,6 +67,7 @@ function makeEnv(kv: InMemoryKV): Env {
     APNS_TEAM_ID: 'T',
     APNS_PRIVATE_KEY: apnsConfig.privateKeyPem,
     APNS_BUNDLE_ID: 'com.example.app',
+    PENDING_PUSHES: pending ? (pending as unknown as KVNamespace) : undefined,
   };
 }
 
@@ -560,5 +561,68 @@ describe('runScheduled', () => {
       now: () => NOW,
     });
     expect(stats.errors).toBe(1);
+  });
+
+  describe('#566 P2a — pending push 기록', () => {
+    it('성공한 silent push마다 pending:<pushId> entry를 PENDING_PUSHES에 적재', async () => {
+      const kv = new InMemoryKV();
+      const pending = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeTrip());
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv, pending), {
+        seoul: makeSeoul([makeImminentArrival('강남')]),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'fixed-push-id',
+      });
+      expect(stats.pushed).toBe(1);
+      const entryRaw = pending.store.get('pending:fixed-push-id');
+      expect(entryRaw).toBeDefined();
+      const entry = JSON.parse(entryRaw!.value);
+      expect(entry.pushId).toBe('fixed-push-id');
+      expect(entry.token).toBe('tok');
+      expect(entry.alarmKey).toBe('imminent:강남');
+      expect(entry.sentAt).toBe(NOW);
+      expect(entry.kind).toBe('destination');
+      expect(entry.phase).toBe('imminent');
+      // payload에도 pushId가 들어갔는지 검증.
+      const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.data.pushId).toBe('fixed-push-id');
+    });
+
+    it('PENDING_PUSHES 미바인딩이어도 push는 정상 발사 (graceful)', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeTrip());
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoul([makeImminentArrival('강남')]),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.pushed).toBe(1);
+    });
+
+    it('push 실패 시 pending entry를 기록하지 않는다', async () => {
+      const kv = new InMemoryKV();
+      const pending = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeTrip());
+      const apnsFetch = vi.fn(async () =>
+        new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 413 }),
+      );
+      await runScheduled(makeEnv(kv, pending), {
+        seoul: makeSeoul([makeImminentArrival('강남')]),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'fixed-push-id',
+      });
+      expect(pending.store.size).toBe(0);
+    });
   });
 });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -40,6 +40,12 @@ export interface SilentPushPayload {
    * 클라 수신 시각과 비교해 silent push 도달 지연 분포 측정용.
    */
   sentAt: number;
+  /**
+   * push 1건의 unique 식별자 (#566 P2a).
+   * 디바이스는 처리 결과를 `POST /push/ack`로 보낼 때 이 id를 echo한다.
+   * P2c가 30s 미ACK push를 alert fallback으로 재발사할 때 dedup 키로도 사용.
+   */
+  pushId: string;
 }
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
@@ -91,6 +97,7 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       phase: options.payload.phase,
       kind: options.payload.kind,
       sentAt: options.payload.sentAt,
+      pushId: options.payload.pushId,
     },
   });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -4,6 +4,7 @@
  * Routes:
  *   POST   /trips            트립 등록 (body: Trip 일부)
  *   DELETE /trips/:token     트립 해제
+ *   POST   /push/ack         silent push 처리 결과 ACK (#566 P2a)
  *   GET    /health           헬스체크
  *
  * scheduled():
@@ -11,6 +12,7 @@
  */
 
 import { Hono } from 'hono';
+import { ackPending } from './pendingPushes';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
 import {
@@ -72,6 +74,49 @@ app.post('/telemetry/silent-push', async (c) => {
   );
   return c.json({ ok: true });
 });
+
+/**
+ * silent push 처리 결과 ACK (#566 P2a).
+ * 디바이스가 push를 받고 처리(fired 또는 skipped)하면 pushId + 자신의 device token을 함께 보낸다.
+ * 백엔드는 KV에 저장된 pending.token과 비교 후 매칭 시에만 entry를 삭제 — 임의 echo로 인한
+ * fallback 무력화 차단.
+ *
+ * Body: { pushId, token, outcome: 'fired'|'skipped', reason? }
+ * Response: { ok: true, deleted: boolean, reason?: 'not-found'|'token-mismatch' }
+ *
+ * deleted=false는 정상 — push가 이미 만료(60s 초과)되거나 token 매칭 실패. 클라는 재전송 불필요.
+ */
+app.post('/push/ack', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+  const ack = validatePushAck(body);
+  if (!ack) return c.json({ error: 'invalid_payload' }, 400);
+
+  const result = await ackPending(c.env.PENDING_PUSHES, ack.pushId, ack.token);
+  return c.json({ ok: true, ...result });
+});
+
+interface PushAckPayload {
+  pushId: string;
+  token: string;
+  outcome: 'fired' | 'skipped';
+  reason?: string;
+}
+
+export function validatePushAck(input: unknown): PushAckPayload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.pushId !== 'string' || obj.pushId.length === 0) return null;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (obj.outcome !== 'fired' && obj.outcome !== 'skipped') return null;
+  const out: PushAckPayload = { pushId: obj.pushId, token: obj.token, outcome: obj.outcome };
+  if (typeof obj.reason === 'string') out.reason = obj.reason;
+  return out;
+}
 
 app.delete('/trips/:token', async (c) => {
   const token = c.req.param('token');

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -1,0 +1,99 @@
+/**
+ * KV CRUD for pending silent pushes (#566 P2a).
+ *
+ * 발사한 silent push 1건마다 `pending:<pushId>` entry를 기록한다.
+ * P2c가 이 entry를 폴링해 30s 안에 디바이스 ACK가 안 오면 alert push fallback을 발사한다.
+ * 디바이스 ACK 도달 시 P2a /push/ack 라우트가 entry를 삭제한다.
+ *
+ * 모든 함수는 `kv === undefined`(미바인딩)일 때 graceful no-op — 개발 환경 호환.
+ *
+ * Key format: pending:<pushId>
+ * TTL: 60s (Cloudflare KV 최소값). P2c는 30s 임계는 sentAt 시각 기준으로 판단.
+ */
+
+import type { AlarmPhase } from './alarm';
+
+const PENDING_PREFIX = 'pending:';
+export const PENDING_TTL_SEC = 60;
+
+/** silent push 발사 1건의 추적 정보. P2c가 alert fallback 결정에 사용. */
+export interface PendingPush {
+  pushId: string;
+  /** APNs device token — fallback 재발사 시 사용. */
+  token: string;
+  /** dedup 식별자 — 디바이스 FIRED_ALARMS와 매칭. `${stationName}:${kind}:${phase}` 형태. */
+  alarmKey: string;
+  /** 백엔드 발사 시점 epoch ms. P2c가 30s 임계 판단. */
+  sentAt: number;
+  /** alert fallback 본문 생성용 메타 (P2c/P2d에서 사용). */
+  stationName: string;
+  kind: 'transfer' | 'destination' | 'intermediate';
+  phase: AlarmPhase;
+  etaSeconds: number;
+}
+
+export function pendingKey(pushId: string): string {
+  return `${PENDING_PREFIX}${pushId}`;
+}
+
+/**
+ * dedup 식별자 빌드. 디바이스 측 `alarmKey(event)`와 **바이트 동일** 결과를 낸다.
+ * 디바이스: `${phaseId}:${stationName}` (src/utils/stationAlarm.ts).
+ * 디바이스는 type/kind를 키에 포함하지 않으므로 백엔드도 마찬가지로 처리해야 P2e dedup이 매칭된다.
+ * kind 자체는 PendingPush 본문에 유지 — P2c가 alert 본문 생성에 사용.
+ */
+export function buildAlarmKey(stationName: string, phase: AlarmPhase): string {
+  return `${phase}:${stationName}`;
+}
+
+export async function putPending(
+  kv: KVNamespace | undefined,
+  entry: PendingPush,
+): Promise<void> {
+  if (!kv) return;
+  await kv.put(pendingKey(entry.pushId), JSON.stringify(entry), {
+    expirationTtl: PENDING_TTL_SEC,
+  });
+}
+
+export async function getPending(
+  kv: KVNamespace | undefined,
+  pushId: string,
+): Promise<PendingPush | null> {
+  if (!kv) return null;
+  const raw = await kv.get(pendingKey(pushId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PendingPush;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * ACK 처리 결과.
+ * - `deleted: true` — 디바이스가 발급된 token으로 정상 ACK, entry 삭제 완료
+ * - `deleted: false, reason: 'not-found'` — entry가 만료/이미 처리됨 (idempotent OK)
+ * - `deleted: false, reason: 'token-mismatch'` — 다른 디바이스가 임의 pushId echo (인증 실패)
+ */
+export interface AckResult {
+  deleted: boolean;
+  reason?: 'not-found' | 'token-mismatch';
+}
+
+/**
+ * ACK 처리. caller가 device token도 함께 보내야 임의 pushId echo로 인한 fallback 무력화를 차단한다.
+ * KV에 저장된 pending.token과 매칭하지 않으면 삭제하지 않는다.
+ */
+export async function ackPending(
+  kv: KVNamespace | undefined,
+  pushId: string,
+  token: string,
+): Promise<AckResult> {
+  if (!kv) return { deleted: false, reason: 'not-found' };
+  const entry = await getPending(kv, pushId);
+  if (!entry) return { deleted: false, reason: 'not-found' };
+  if (entry.token !== token) return { deleted: false, reason: 'token-mismatch' };
+  await kv.delete(pendingKey(pushId));
+  return { deleted: true };
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -11,6 +11,7 @@ import {
 } from './alarm';
 import { sendSilentPush, type ApnsConfig } from './apns';
 import { matchLine } from './lineAlias';
+import { buildAlarmKey, putPending } from './pendingPushes';
 import { SeoulArrivalClient, type ArrivalEntry } from './seoul';
 import { deleteTrip, listTrips, putTrip } from './trips';
 import type { ApnsEnv, Env, Trip, Waypoint } from './types';
@@ -41,6 +42,8 @@ export interface ScheduledDeps {
   fetchImpl?: typeof fetch;
   now?: () => number;
   log?: (message: string, meta?: Record<string, unknown>) => void;
+  /** pushId 발급 — 테스트에선 결정적 값을 주입한다. 기본은 crypto.randomUUID. */
+  generatePushId?: () => string;
 }
 
 /**
@@ -65,6 +68,7 @@ export function flipApnsEnv(env: ApnsEnv | undefined): ApnsEnv {
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
   const now = deps.now?.() ?? Date.now();
   const log = deps.log ?? (() => undefined);
+  const generatePushId = deps.generatePushId ?? (() => crypto.randomUUID());
   const stats: ScheduledStats = {
     scanned: 0,
     polled: 0,
@@ -135,12 +139,14 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           etaSeconds: eta,
           arvlCd,
         });
+        const pushId = generatePushId();
         const pushPayload = {
           nextWaypoint: waypoint.stationName,
           etaSeconds: eta,
           phase: pushPhase,
           kind: waypoint.kind,
           sentAt: now,
+          pushId,
         };
         let result = await sendSilentPush({
           deviceToken: trip.token,
@@ -189,6 +195,18 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
 
         if (result.ok) {
           stats.pushed += 1;
+          // #566 P2a — silent push 발사 성공 시 pending entry 기록. ACK 또는 P2c fallback이 정리한다.
+          // PENDING_PUSHES 미바인딩 시 putPending은 graceful no-op.
+          await putPending(env.PENDING_PUSHES, {
+            pushId,
+            token: trip.token,
+            alarmKey: buildAlarmKey(waypoint.stationName, pushPhase),
+            sentAt: now,
+            stationName: waypoint.stationName,
+            kind: waypoint.kind,
+            phase: pushPhase,
+            etaSeconds: eta,
+          });
           if (shouldPushPhase) {
             trip.lastFiredPhase = phase!;
             dirty = true;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -96,6 +96,13 @@ export interface Env {
    * 미바인딩 시 endpoint는 graceful no-op (개발 환경 호환).
    */
   TELEMETRY?: AnalyticsEngineWriter;
+  /**
+   * 발사한 silent push의 pending 추적 (#566 P2a).
+   * P2c에서 30s 미ACK push를 alert로 fallback 발사하기 위한 그릇.
+   * 미바인딩 시 모든 pending 경로는 graceful no-op (개발 환경 호환).
+   * 생성: `wrangler kv:namespace create PENDING_PUSHES`
+   */
+  PENDING_PUSHES?: KVNamespace;
   /** Production APNs host (예: api.push.apple.com) */
   APNS_HOST: string;
   /** Sandbox APNs host (예: api.sandbox.push.apple.com) — dev/preview 빌드 토큰용 */

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -10,6 +10,15 @@ binding = "TRIPS"
 id = "8d10a57ffe4c46e28a6df33ef0c86b68"
 preview_id = "7e67683c147349ed90c16a28ae232e34"
 
+# KV: pending silent pushes (#566 P2a)
+# 발사한 silent push 1건마다 pushId entry를 기록. P2c가 30s 미ACK push를 alert fallback으로 재발사.
+# 코드는 `if (env.PENDING_PUSHES)` 분기로 graceful — binding 없으면 모든 pending 경로가 no-op.
+# 활성화: `wrangler kv:namespace create PENDING_PUSHES` 후 아래 4줄 주석 해제 + id/preview_id 채움.
+# [[kv_namespaces]]
+# binding = "PENDING_PUSHES"
+# id = "<wrangler create 결과>"
+# preview_id = "<wrangler create --preview 결과>"
+
 # #498 — silent push 게이트 outcome 텔레메트리. 클라가 누적한 카운터를 일별 query 가능하게 적재.
 # Privacy: 카운트만, token은 8자 prefix만. 개별 push 내용/좌표 미저장.
 #


### PR DESCRIPTION
## Summary
- 다중 채널 BG 알람 채널 2(alert push fallback)의 첫 슬라이스 — **그릇만 마련, 실제 발사는 P2c**
- `SilentPushPayload`에 `pushId` 필드 추가, APNs body `data.pushId` 전송
- 새 KV namespace `PENDING_PUSHES` (wrangler.toml 주석 추가, TELEMETRY 패턴)
- `pendingPushes.ts`: KV CRUD + `buildAlarmKey` (디바이스 `src/utils/stationAlarm.ts` 형식 \`\${phase}:\${stationName}\`과 동일)
- `scheduled.ts`: silent push 성공 시 \`putPending\`, \`generatePushId\` deps 주입
- 새 라우트 \`POST /push/ack\` — **token 매칭 인증**으로 임의 pushId echo 무력화 차단

## Test plan
- [x] vitest 154 통과 (신규: pendingPushes 16건 + /push/ack 8건 + scheduled pending 3건)
- [x] type-check 통과
- [x] code-review P1 두 건 반영 (ACK 인증 부재 + alarmKey 디바이스 불일치)
- [ ] 머지 후: \`wrangler kv:namespace create PENDING_PUSHES\` 실행, wrangler.toml binding 주석 해제
- [ ] 디바이스 측은 P2b에서 ACK 전송 구현

## 후속 이슈로 분리할 P2
- BadDeviceToken self-heal 재시도 시 동일 pushId 재사용 (현재는 트립이 첫 호출에서 dirty=false라 도달하지 않음 — P2c 작업 시 재검토)
- PENDING_PUSHES 미바인딩 시 silent no-op — putPending 경로에 1회 warn log
- \`ackPending\` KV 2회 왕복 — token 검증 위해 필수 비용

Closes #566