### PR TITLE
feat(#568): 디바이스 silentPushTask가 발사/스킵 결과를 백엔드 /push/ack로 전송

### DIFF
--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -1,4 +1,4 @@
-import { registerActiveTrip, clearActiveTrip } from '../alarmBackend';
+import { registerActiveTrip, clearActiveTrip, sendPushAck } from '../alarmBackend';
 import type { RegisterTripPayload } from '../alarmBackend';
 
 jest.mock('../../utils/logger', () => ({
@@ -152,6 +152,58 @@ describe('alarmBackend', () => {
       (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
       const result = await clearActiveTrip('t');
       expect(result).toEqual({ ok: false });
+    });
+  });
+
+  describe('sendPushAck (#568 P2b)', () => {
+    const ACK = {
+      pushId: 'push-1',
+      token: 'devicetoken-hex',
+      outcome: 'fired' as const,
+    };
+
+    it('URL 미설정 시 skipped=true 반환, fetch 미호출', async () => {
+      const result = await sendPushAck(ACK);
+      expect(result.skipped).toBe(true);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('정상 응답 시 ok=true + POST /push/ack에 payload 그대로 전달', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      const result = await sendPushAck({ ...ACK, outcome: 'skipped', reason: 'gate-out-of-range' });
+      expect(result.ok).toBe(true);
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://api.test.dev/push/ack');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body)).toEqual({
+        pushId: 'push-1',
+        token: 'devicetoken-hex',
+        outcome: 'skipped',
+        reason: 'gate-out-of-range',
+      });
+    });
+
+    it('non-2xx 응답 시 ok=false + status', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 400 } as Response);
+      const result = await sendPushAck(ACK);
+      expect(result).toEqual({ ok: false, status: 400 });
+    });
+
+    it('fetch throw 시 ok=false (throw 안 함)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+      const result = await sendPushAck(ACK);
+      expect(result).toEqual({ ok: false });
+    });
+
+    it('trailing slash가 URL에 있어도 정상 처리', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      await sendPushAck(ACK);
+      const [url] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://api.test.dev/push/ack');
     });
   });
 });

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -110,6 +110,42 @@ export async function registerActiveTrip(
 }
 
 /**
+ * silent push 처리 결과 ACK (#568 P2b). 백엔드 #566 P2a `/push/ack` endpoint 호출.
+ * 백엔드가 pushId 발급 시 KV에 저장한 token과 매칭해 임의 echo를 차단하므로
+ * caller는 디바이스의 APNs token을 함께 전달해야 한다.
+ * URL 미설정/네트워크 실패 시 throw 없이 `{ok:false}` — 본 silent push 처리는 영향 없음.
+ */
+export interface PushAckPayload {
+  pushId: string;
+  token: string;
+  outcome: 'fired' | 'skipped';
+  reason?: string;
+}
+
+export async function sendPushAck(payload: PushAckPayload): Promise<AlarmBackendResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip push ack');
+    return { ok: false, skipped: true };
+  }
+  try {
+    const res = await fetchWithTimeout(`${base}/push/ack`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      log.warn(`push ack failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('push ack error', e);
+    return { ok: false };
+  }
+}
+
+/**
  * 활성 트립을 해제한다. URL/네트워크 실패 시에도 throw하지 않는다 — 백엔드 KV는
  * `expiresAt`으로 자동 정리되므로 클라이언트가 재시도 책임을 갖지 않는다.
  */

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -56,6 +56,11 @@ jest.mock('../../utils/logger', () => ({
   }),
 }));
 
+const mockSendPushAck = jest.fn();
+jest.mock('../../api/alarmBackend', () => ({
+  sendPushAck: (...args: unknown[]) => mockSendPushAck(...args),
+}));
+
 // i18next는 키 그대로 반환 (intermediate 본문 빌더 검증용).
 jest.mock('i18next', () => ({
   __esModule: true,
@@ -75,7 +80,9 @@ import {
   registerSilentPushTask,
   SILENT_PUSH_TASK,
 } from '../silentPushTask';
-import { DESTINATION_KEY } from '../../constants/storageKeys';
+import { APNS_TOKEN_KEY, DESTINATION_KEY } from '../../constants/storageKeys';
+
+const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 
 const destStation = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
 
@@ -112,8 +119,10 @@ describe('silentPushTask', () => {
     mockSetFiredAlarms.mockResolvedValue(undefined);
     (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
       if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+      if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
       return null;
     });
+    mockSendPushAck.mockResolvedValue({ ok: true });
   });
 
   it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
@@ -236,6 +245,29 @@ describe('silentPushTask', () => {
           },
         }),
       ).toMatchObject({ sentAt: undefined });
+    });
+
+    it('pushId가 non-empty string이면 그대로 전달 (#566)', () => {
+      expect(
+        extractPayload({
+          notification: {
+            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: 'uuid-x' },
+          },
+        }),
+      ).toMatchObject({ pushId: 'uuid-x' });
+    });
+
+    it('pushId가 빈 문자열/비문자열이면 undefined (구 백엔드 호환)', () => {
+      expect(
+        extractPayload({
+          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: '' } },
+        }),
+      ).toMatchObject({ pushId: undefined });
+      expect(
+        extractPayload({
+          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: 42 } },
+        }),
+      ).toMatchObject({ pushId: undefined });
     });
   });
 
@@ -422,6 +454,96 @@ describe('silentPushTask', () => {
       expect(mockScheduleNotificationAsync).toHaveBeenCalled();
       // 사전예약은 import도 안 함 — 호출 검증은 import 부재로 충분하나, 추가 안전망:
       // alarmScheduler 모듈을 jest.mock하지 않았기 때문에 호출 시 ReferenceError가 났을 것.
+    });
+
+    describe('#568 P2b — push ACK', () => {
+      it('fire 성공 시 sendPushAck(outcome=fired) 호출, reason 없음', async () => {
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-fire' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-fire',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'fired',
+        });
+      });
+
+      it('게이트 fail 시 sendPushAck(outcome=skipped, reason=게이트사유)', async () => {
+        mockCheckGate.mockResolvedValue({
+          pass: false,
+          reason: 'out-of-range',
+          distanceM: 5_000,
+          thresholdM: 400,
+        });
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-gate' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-gate',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'gate-out-of-range',
+        });
+      });
+
+      it('FIRED_ALARMS dedup 시 sendPushAck(outcome=skipped, reason=dedup-already-fired)', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-dedup' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-dedup',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'dedup-already-fired',
+        });
+      });
+
+      it('payload-missing-kind 시 sendPushAck(outcome=skipped, reason=payload-missing-kind)', async () => {
+        await handleSilentPush({
+          data: {
+            notification: {
+              data: { nextWaypoint: '강남', etaSeconds: 10, phase: 'imminent', pushId: 'p-kind' },
+            },
+          },
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-kind',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'payload-missing-kind',
+        });
+      });
+
+      it('pushId 누락(구 백엔드)이면 ACK skip', async () => {
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+      });
+
+      it('APNs token 없으면 ACK skip (token 인증 불가)', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return null;
+          return null;
+        });
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-no-token' }),
+        );
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+      });
+
+      it('APNS_TOKEN_KEY 읽기 throw해도 ACK 단순 skip — 본 처리는 정상 진행', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) throw new Error('storage boom');
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          return null;
+        });
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-throw' }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -20,7 +20,8 @@ import * as TaskManager from 'expo-task-manager';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
 import type { Station } from '../types/station';
-import { DESTINATION_KEY } from '../constants/storageKeys';
+import { APNS_TOKEN_KEY, DESTINATION_KEY } from '../constants/storageKeys';
+import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../utils/logger';
 import {
   logSilentPushReceived,
@@ -56,6 +57,11 @@ export interface SilentPushPayload {
    * 종료 조건: 신 백엔드 배포 후 required로 승격.
    */
   sentAt?: number;
+  /**
+   * Push 1건의 unique 식별자 (#566 P2a). 디바이스는 이 값을 `/push/ack`로 echo한다.
+   * 구 백엔드 호환 위해 optional — 누락 시 ACK skip(P2c fallback이 발사할 가능성 감수).
+   */
+  pushId?: string;
 }
 
 interface NotificationBackgroundTaskData {
@@ -79,7 +85,7 @@ export function extractPayload(
   const raw = notif.data ?? notif.request?.content?.data;
   if (!raw || typeof raw !== 'object') return null;
   const obj = raw as Record<string, unknown>;
-  const { nextWaypoint, etaSeconds, phase, kind, sentAt } = obj;
+  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId } = obj;
   if (typeof nextWaypoint !== 'string' || nextWaypoint.length === 0) return null;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
   if (phase !== 'early' && phase !== 'imminent') return null;
@@ -87,7 +93,15 @@ export function extractPayload(
     kind === 'transfer' || kind === 'destination' || kind === 'intermediate' ? kind : undefined;
   const validSentAt =
     typeof sentAt === 'number' && Number.isFinite(sentAt) ? sentAt : undefined;
-  return { nextWaypoint, etaSeconds, phase, kind: validKind, sentAt: validSentAt };
+  const validPushId = typeof pushId === 'string' && pushId.length > 0 ? pushId : undefined;
+  return {
+    nextWaypoint,
+    etaSeconds,
+    phase,
+    kind: validKind,
+    sentAt: validSentAt,
+    pushId: validPushId,
+  };
 }
 
 /**
@@ -121,6 +135,31 @@ function buildIntermediateContent(stationName: string): { title: string; body: s
 }
 
 /**
+ * 백엔드 P2c fallback에서 이 push가 alert로 재발사되지 않도록 처리 결과를 통보한다 (#568 P2b).
+ * fire-and-forget — 실패해도 silent push 본 처리 흐름에는 영향 없음.
+ * 누락 입력(pushId/token 중 하나라도 null/undefined)은 그대로 skip한다:
+ *   - pushId 누락 = 구 백엔드 호환 경로
+ *   - token 누락 = APNs 권한 미부여/저장 실패
+ */
+function ackOutcome(
+  pushId: string | undefined,
+  token: string | null,
+  outcome: 'fired' | 'skipped',
+  reason?: string,
+): void {
+  if (!pushId || !token) return;
+  void sendPushAck({ pushId, token, outcome, reason });
+}
+
+async function loadApnsToken(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(APNS_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Task 콜백 본체 — 단위 테스트가 직접 호출할 수 있도록 export.
  */
 export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
@@ -136,7 +175,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
   }
   const receivedAt = Date.now();
   logger.info(
-    `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'}`,
+    `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
   );
 
   // 측정 인프라 — 수신 시점 무조건 적재 (#478 PR 1-1).
@@ -148,6 +187,8 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     receivedAt,
   });
 
+  const apnsToken = await loadApnsToken();
+
   // kind 미상은 발사 불가 — 알림 본문/dedup 키 결정 불가. 구 백엔드 호환은 received 로그에만.
   if (!payload.kind) {
     logSilentPushSkipped({
@@ -156,12 +197,16 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       phaseId: payload.phase,
       reason: 'payload-missing-kind',
     });
+    ackOutcome(payload.pushId, apnsToken, 'skipped', 'payload-missing-kind');
     logger.info('kind missing — skip fire');
     return;
   }
 
   try {
-    await fireWithGate(payload as Required<Pick<SilentPushPayload, 'kind'>> & SilentPushPayload);
+    await fireWithGate(
+      payload as Required<Pick<SilentPushPayload, 'kind'>> & SilentPushPayload,
+      apnsToken,
+    );
   } catch (e) {
     logger.error('silent push fire 실패:', e);
   }
@@ -173,6 +218,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
  */
 async function fireWithGate(
   payload: SilentPushPayload & { kind: NonNullable<SilentPushPayload['kind']> },
+  apnsToken: string | null,
 ): Promise<void> {
   const gate = await checkSilentPushLocationGate({
     stationName: payload.nextWaypoint,
@@ -181,16 +227,18 @@ async function fireWithGate(
   });
 
   if (!gate.pass) {
+    const reason = mapGateReason(gate.reason!);
     logSilentPushSkipped({
       stationName: payload.nextWaypoint,
       kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
       phaseId: payload.phase,
-      reason: mapGateReason(gate.reason!),
+      reason,
       distanceM: gate.distanceM,
       thresholdM: gate.thresholdM,
       locationSource: gate.locationSource,
       locationAgeMs: gate.locationAgeMs,
     });
+    ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
     logger.info(`gate skip reason=${gate.reason} distance=${gate.distanceM ?? '-'}`);
     return;
   }
@@ -206,6 +254,8 @@ async function fireWithGate(
   if (dedupKey && destinationId) {
     const fired = await getFiredAlarms(destinationId);
     if (fired.has(dedupKey)) {
+      // 다른 채널(FG GPS 등)이 이미 발사 — backend 입장에선 fallback 불필요. ACK로 정리.
+      ackOutcome(payload.pushId, apnsToken, 'skipped', 'dedup-already-fired');
       logger.info(`dedup: ${dedupKey} already fired — skip`);
       return;
     }
@@ -239,6 +289,7 @@ async function fireWithGate(
     locationSource: gate.locationSource!,
     locationAgeMs: gate.locationAgeMs!,
   });
+  ackOutcome(payload.pushId, apnsToken, 'fired');
   logger.info(
     `fired: kind=${payload.kind} phase=${payload.phase} station=${payload.nextWaypoint} distance=${gate.distanceM}m`,
   );


### PR DESCRIPTION
## Summary
- P2b — 다중 채널 BG 알람 채널 2 두 번째 슬라이스. 선행 #566(머지됨)의 ACK endpoint 활용
- 디바이스가 silent push 처리 직후 \`POST /push/ack\` 호출 → 백엔드 PENDING_PUSHES entry 정리 → P2c가 30s 미ACK push만 alert로 fallback
- 4개 outcome 경로에서 ACK 전송 (fired / gate-skip / dedup / payload-missing-kind), fire-and-forget
- APNs token을 ACK body에 동봉 (#566 token 인증으로 임의 echo 차단)

## Test plan
- [x] \`npm test\` 1848 통과 (신규: alarmBackend.test 5건 + silentPushTask.test 9건)
- [x] \`npm run type-check\` 통과
- [x] 100% 커버리지 유지
- [x] code-review P1 0건, P2 3건은 후속 chore로 분리 권장
- [ ] 머지 후 디바이스 빌드로 실제 ACK round-trip 검증 (P2c 작업 전 베이스라인)

## 후속 (별도 chore 이슈 권장)
- ACK reason/outcome 리터럴을 \`src/constants/pushAck.ts\` 상수로 분리 (백엔드와 1:1 계약 명시)
- loadApnsToken 모듈 스코프 캐시 (silent push마다 AsyncStorage I/O 회피)

Closes #568