### PR TITLE
feat(#572): backend 30s ACK 타임아웃 → alert push fallback 발사

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -1,6 +1,12 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildApnsJwt, resetApnsJwtCache, sendSilentPush, type ApnsConfig } from '../apns';
+import {
+  buildApnsJwt,
+  resetApnsJwtCache,
+  sendAlertPush,
+  sendSilentPush,
+  type ApnsConfig,
+} from '../apns';
 
 let privateKeyPem = '';
 
@@ -148,5 +154,66 @@ describe('sendSilentPush', () => {
     });
     const [url] = fetchImpl.mock.calls[0];
     expect(url).toBe('https://api.sandbox.push.apple.com/3/device/tok');
+  });
+});
+
+const TEST_HOST_2 = 'api.push.apple.com';
+
+describe('sendAlertPush (#572 P2c)', () => {
+  beforeEach(() => resetApnsJwtCache());
+
+  it('posts with alert-type headers + aps.alert + data.pushId', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const result = await sendAlertPush({
+      deviceToken: 'devicetoken-hex',
+      title: '도착 임박',
+      body: '곧 강남에 도착합니다.',
+      pushId: 'p-alert-1',
+      config: makeConfig(),
+      host: TEST_HOST_2,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(true);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${TEST_HOST_2}/3/device/devicetoken-hex`);
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-topic']).toBe('com.example.app');
+    expect(headers['apns-push-type']).toBe('alert');
+    expect(headers['apns-priority']).toBe('10');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.alert).toEqual({ title: '도착 임박', body: '곧 강남에 도착합니다.' });
+    expect(body.aps.sound).toBe('default');
+    expect(body.data.pushId).toBe('p-alert-1');
+  });
+
+  it('returns failure with reason on non-2xx', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const result = await sendAlertPush({
+      deviceToken: 't',
+      title: 'T',
+      body: 'B',
+      pushId: 'p',
+      config: makeConfig(),
+      host: TEST_HOST_2,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: false, status: 400, reason: 'BadDeviceToken' });
+  });
+
+  it('handles non-json error body', async () => {
+    const fetchImpl = vi.fn(async () => new Response('plain text', { status: 500 }));
+    const result = await sendAlertPush({
+      deviceToken: 't',
+      title: 'T',
+      body: 'B',
+      pushId: 'p',
+      config: makeConfig(),
+      host: TEST_HOST_2,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBeUndefined();
   });
 });

--- a/backend/alarm-worker/src/__tests__/fallback.test.ts
+++ b/backend/alarm-worker/src/__tests__/fallback.test.ts
@@ -3,34 +3,13 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FALLBACK_THRESHOLD_MS, runFallbackPushes } from '../fallback';
 import { pendingKey, putPending, type PendingPush } from '../pendingPushes';
 import type { Env } from '../types';
+import { InMemoryKV } from './inMemoryKv';
 
 let privateKeyPem = '';
 beforeAll(async () => {
   const { privateKey } = await generateKeyPair('ES256', { extractable: true });
   privateKeyPem = await exportPKCS8(privateKey);
 });
-
-class InMemoryKV {
-  store = new Map<string, { value: string; expiresAt?: number }>();
-  async get(key: string): Promise<string | null> {
-    return this.store.get(key)?.value ?? null;
-  }
-  async put(key: string, value: string): Promise<void> {
-    this.store.set(key, { value });
-  }
-  async delete(key: string): Promise<void> {
-    this.store.delete(key);
-  }
-  async list(options?: { prefix?: string }): Promise<{
-    keys: { name: string }[];
-    list_complete: boolean;
-    cursor: string;
-  }> {
-    const prefix = options?.prefix ?? '';
-    const keys = [...this.store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name }));
-    return { keys, list_complete: true, cursor: '' };
-  }
-}
 
 const NOW = 1_700_000_000_000;
 const APNS_HOSTS = {

--- a/backend/alarm-worker/src/__tests__/fallback.test.ts
+++ b/backend/alarm-worker/src/__tests__/fallback.test.ts
@@ -1,0 +1,253 @@
+import { generateKeyPair, exportPKCS8 } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FALLBACK_THRESHOLD_MS, runFallbackPushes } from '../fallback';
+import { pendingKey, putPending, type PendingPush } from '../pendingPushes';
+import type { Env } from '../types';
+
+let privateKeyPem = '';
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair('ES256', { extractable: true });
+  privateKeyPem = await exportPKCS8(privateKey);
+});
+
+class InMemoryKV {
+  store = new Map<string, { value: string; expiresAt?: number }>();
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key)?.value ?? null;
+  }
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, { value });
+  }
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+  async list(options?: { prefix?: string }): Promise<{
+    keys: { name: string }[];
+    list_complete: boolean;
+    cursor: string;
+  }> {
+    const prefix = options?.prefix ?? '';
+    const keys = [...this.store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name }));
+    return { keys, list_complete: true, cursor: '' };
+  }
+}
+
+const NOW = 1_700_000_000_000;
+const APNS_HOSTS = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+} as const;
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: {} as Env['TRIPS'],
+    PENDING_PUSHES: kv as unknown as KVNamespace,
+    APNS_HOST: APNS_HOSTS.production,
+    APNS_HOST_SANDBOX: APNS_HOSTS.sandbox,
+    SEOUL_API_HOST: 'h',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: privateKeyPem,
+    APNS_BUNDLE_ID: 'com.example.app',
+  };
+}
+
+function makeEntry(overrides: Partial<PendingPush> = {}): PendingPush {
+  return {
+    pushId: 'push-1',
+    token: 'devicetoken-hex',
+    alarmKey: 'imminent:강남',
+    sentAt: NOW - FALLBACK_THRESHOLD_MS, // 임계 정확히 도달
+    stationName: '강남',
+    kind: 'destination',
+    phase: 'imminent',
+    etaSeconds: 30,
+    apnsEnv: 'sandbox',
+    ...overrides,
+  };
+}
+
+const apnsConfig = () => ({
+  keyId: 'K',
+  teamId: 'T',
+  privateKeyPem,
+  bundleId: 'com.example.app',
+});
+
+describe('runFallbackPushes (#572 P2c)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('PENDING_PUSHES 미바인딩이면 scanned=0으로 종료 (graceful)', async () => {
+    const env = { ...makeEnv(kv), PENDING_PUSHES: undefined };
+    const fetchImpl = vi.fn();
+    const stats = await runFallbackPushes(env, {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats).toEqual({ scanned: 0, pushed: 0, errors: 0, deferred: 0 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('임계 미달 entry는 deferred 카운트만 + 발사 안 함', async () => {
+    await putPending(
+      kv as unknown as KVNamespace,
+      makeEntry({ sentAt: NOW - (FALLBACK_THRESHOLD_MS - 1) }),
+    );
+    const fetchImpl = vi.fn();
+    const stats = await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats).toEqual({ scanned: 1, pushed: 0, errors: 0, deferred: 1 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(kv.store.has(pendingKey('push-1'))).toBe(true);
+  });
+
+  it('임계 초과 entry는 alert 발사 + 발사 후 entry 삭제', async () => {
+    await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-fire' }));
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats).toEqual({ scanned: 1, pushed: 1, errors: 0, deferred: 0 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`https://${APNS_HOSTS.sandbox}/3/device/devicetoken-hex`);
+    const body = JSON.parse(init.body as string);
+    expect(body.aps.alert.title).toBe('도착 임박');
+    expect(body.aps.alert.body).toContain('강남');
+    expect(body.data.pushId).toBe('p-fire');
+    expect(kv.store.has(pendingKey('p-fire'))).toBe(false);
+  });
+
+  it('apnsEnv=production이면 production host로 발사', async () => {
+    await putPending(
+      kv as unknown as KVNamespace,
+      makeEntry({ pushId: 'p-prod', apnsEnv: 'production' }),
+    );
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const [url] = fetchImpl.mock.calls[0] as unknown as [string];
+    expect(url).toBe(`https://${APNS_HOSTS.production}/3/device/devicetoken-hex`);
+  });
+
+  it('intermediate kind는 phase 무관 단일 본문', async () => {
+    await putPending(
+      kv as unknown as KVNamespace,
+      makeEntry({ kind: 'intermediate', stationName: '중곡', phase: 'imminent' }),
+    );
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.aps.alert.title).toBe('역 통과');
+    expect(body.aps.alert.body).toBe('중곡역을 지나고 있어요');
+  });
+
+  it('영구 실패(BadDeviceToken)는 entry 즉시 삭제 + errors 카운트', async () => {
+    await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-perm' }));
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const stats = await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats).toEqual({ scanned: 1, pushed: 0, errors: 1, deferred: 0 });
+    expect(kv.store.has(pendingKey('p-perm'))).toBe(false);
+  });
+
+  it('영구 실패(Unregistered 410)도 entry 즉시 삭제', async () => {
+    await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-410' }));
+    const fetchImpl = vi.fn(async () => new Response('', { status: 410 }));
+    await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(kv.store.has(pendingKey('p-410'))).toBe(false);
+  });
+
+  it('transient 실패(5xx)는 entry 유지 — KV TTL이 자연 정리하며 다음 cron에서 재시도 보존', async () => {
+    await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-transient' }));
+    const fetchImpl = vi.fn(async () => new Response('', { status: 503 }));
+    const stats = await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.errors).toBe(1);
+    expect(kv.store.has(pendingKey('p-transient'))).toBe(true);
+  });
+
+  it('구 entry(apnsEnv 누락 — #566 머지 직후 KV)는 sandbox로 발사 (마이그레이션 안전망)', async () => {
+    const entryRaw = JSON.stringify({
+      pushId: 'p-legacy',
+      token: 'devicetoken-hex',
+      alarmKey: 'imminent:강남',
+      sentAt: NOW - FALLBACK_THRESHOLD_MS,
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+      etaSeconds: 30,
+      // apnsEnv 누락 — 구 entry
+    });
+    await kv.put(pendingKey('p-legacy'), entryRaw);
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${APNS_HOSTS.sandbox}/3/device/devicetoken-hex`);
+  });
+
+  it('성공 발사 후 재실행 시 동일 entry로 재발사 안 함 (dedup)', async () => {
+    await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-once' }));
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const deps = {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    };
+    await runFallbackPushes(makeEnv(kv), deps);
+    await runFallbackPushes(makeEnv(kv), deps);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('default deps (now/log 미주입)도 동작', async () => {
+    const stats = await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+    });
+    expect(stats.scanned).toBe(0);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/inMemoryKv.ts
+++ b/backend/alarm-worker/src/__tests__/inMemoryKv.ts
@@ -1,0 +1,47 @@
+/**
+ * Cloudflare KVNamespace의 in-memory test double.
+ * 여러 테스트 파일이 공유 — 동일 코드 중복으로 Sonar duplication에 잡히지 않게 단일 정의.
+ *
+ * 의도적으로 KVNamespace 일부 메서드(get/put/delete/list)만 구현 —
+ * 실제 KV의 완전한 호환이 아닌, 테스트가 사용하는 표면만 mimic.
+ */
+export class InMemoryKV {
+  store = new Map<string, { value: string; expiresAt?: number }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number },
+  ): Promise<void> {
+    const expiresAt = options?.expirationTtl
+      ? Date.now() + options.expirationTtl * 1000
+      : undefined;
+    this.store.set(key, { value, expiresAt });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async list(options?: { prefix?: string; cursor?: string }): Promise<{
+    keys: { name: string }[];
+    list_complete: boolean;
+    cursor: string;
+  }> {
+    const prefix = options?.prefix ?? '';
+    const keys = [...this.store.keys()]
+      .filter((k) => k.startsWith(prefix))
+      .map((name) => ({ name }));
+    return { keys, list_complete: true, cursor: '' };
+  }
+}

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2,22 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { app, validatePushAck, validateTrip } from '../index';
 import { pendingKey } from '../pendingPushes';
 import type { AnalyticsEngineWriter, Env } from '../types';
-
-class InMemoryKV {
-  store = new Map<string, { value: string; expiresAt?: number }>();
-  async get(key: string): Promise<string | null> {
-    return this.store.get(key)?.value ?? null;
-  }
-  async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
-    const expiresAt = options?.expirationTtl
-      ? Date.now() + options.expirationTtl * 1000
-      : undefined;
-    this.store.set(key, { value, expiresAt });
-  }
-  async delete(key: string): Promise<void> {
-    this.store.delete(key);
-  }
-}
+import { InMemoryKV } from './inMemoryKv';
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {

--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -11,42 +11,7 @@ import {
   type PendingPush,
 } from '../pendingPushes';
 
-class InMemoryKV {
-  store = new Map<string, { value: string; expiresAt?: number }>();
-
-  async get(key: string): Promise<string | null> {
-    const entry = this.store.get(key);
-    if (!entry) return null;
-    if (entry.expiresAt && entry.expiresAt < Date.now()) {
-      this.store.delete(key);
-      return null;
-    }
-    return entry.value;
-  }
-
-  async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
-    const expiresAt = options?.expirationTtl
-      ? Date.now() + options.expirationTtl * 1000
-      : undefined;
-    this.store.set(key, { value, expiresAt });
-  }
-
-  async delete(key: string): Promise<void> {
-    this.store.delete(key);
-  }
-
-  async list(options?: { prefix?: string; cursor?: string }): Promise<{
-    keys: { name: string }[];
-    list_complete: boolean;
-    cursor: string;
-  }> {
-    const prefix = options?.prefix ?? '';
-    const keys = [...this.store.keys()]
-      .filter((k) => k.startsWith(prefix))
-      .map((name) => ({ name }));
-    return { keys, list_complete: true, cursor: '' };
-  }
-}
+import { InMemoryKV } from './inMemoryKv';
 
 function makeEntry(overrides: Partial<PendingPush> = {}): PendingPush {
   return {
@@ -131,7 +96,7 @@ describe('pendingPushes (#566 P2a)', () => {
       for await (const entry of listPending(kv as unknown as KVNamespace)) {
         out.push(entry.pushId);
       }
-      expect(out.sort()).toEqual(['a', 'b']);
+      expect(out.sort((a, b) => a.localeCompare(b))).toEqual(['a', 'b']);
     });
 
     it('listPending: kv === undefined면 빈 generator', async () => {

--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -3,9 +3,11 @@ import {
   ackPending,
   buildAlarmKey,
   getPending,
+  listPending,
   pendingKey,
   PENDING_TTL_SEC,
   putPending,
+  removePending,
   type PendingPush,
 } from '../pendingPushes';
 
@@ -32,18 +34,31 @@ class InMemoryKV {
   async delete(key: string): Promise<void> {
     this.store.delete(key);
   }
+
+  async list(options?: { prefix?: string; cursor?: string }): Promise<{
+    keys: { name: string }[];
+    list_complete: boolean;
+    cursor: string;
+  }> {
+    const prefix = options?.prefix ?? '';
+    const keys = [...this.store.keys()]
+      .filter((k) => k.startsWith(prefix))
+      .map((name) => ({ name }));
+    return { keys, list_complete: true, cursor: '' };
+  }
 }
 
 function makeEntry(overrides: Partial<PendingPush> = {}): PendingPush {
   return {
     pushId: 'push-1',
     token: 'devicetoken-hex',
-    alarmKey: '강남:destination:early',
+    alarmKey: 'early:강남',
     sentAt: 1_700_000_000_000,
     stationName: '강남',
     kind: 'destination',
     phase: 'early',
     etaSeconds: 60,
+    apnsEnv: 'sandbox',
     ...overrides,
   };
 }
@@ -104,6 +119,43 @@ describe('pendingPushes (#566 P2a)', () => {
 
     it('kv === undefined면 graceful null', async () => {
       expect(await getPending(undefined, 'p1')).toBeNull();
+    });
+  });
+
+  describe('listPending / removePending (#572 P2c)', () => {
+    it('listPending: prefix scan으로 모든 pending entry를 yield', async () => {
+      await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'a' }));
+      await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'b' }));
+      await kv.put('other:c', 'unrelated');
+      const out: string[] = [];
+      for await (const entry of listPending(kv as unknown as KVNamespace)) {
+        out.push(entry.pushId);
+      }
+      expect(out.sort()).toEqual(['a', 'b']);
+    });
+
+    it('listPending: kv === undefined면 빈 generator', async () => {
+      const out: string[] = [];
+      for await (const e of listPending(undefined)) out.push(e.pushId);
+      expect(out).toEqual([]);
+    });
+
+    it('listPending: 손상된 JSON entry는 skip', async () => {
+      await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'good' }));
+      await kv.put(pendingKey('bad'), 'not-json{');
+      const out: string[] = [];
+      for await (const e of listPending(kv as unknown as KVNamespace)) out.push(e.pushId);
+      expect(out).toEqual(['good']);
+    });
+
+    it('removePending: 무조건 삭제 (token 인증 없음)', async () => {
+      await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p1' }));
+      await removePending(kv as unknown as KVNamespace, 'p1');
+      expect(kv.store.has(pendingKey('p1'))).toBe(false);
+    });
+
+    it('removePending: kv === undefined면 no-op', async () => {
+      await expect(removePending(undefined, 'p1')).resolves.toBeUndefined();
     });
   });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -587,6 +587,8 @@ describe('runScheduled', () => {
       expect(entry.sentAt).toBe(NOW);
       expect(entry.kind).toBe('destination');
       expect(entry.phase).toBe('imminent');
+      expect(entry.apnsEnv).toBe('sandbox'); // makeTrip default
+
       // payload에도 pushId가 들어갔는지 검증.
       const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
       const body = JSON.parse(call[1].body as string);

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -11,28 +11,7 @@ import {
 import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
 import { putTrip } from '../trips';
 import type { Env, Trip } from '../types';
-
-class InMemoryKV {
-  store = new Map<string, { value: string }>();
-  async get(key: string): Promise<string | null> {
-    return this.store.get(key)?.value ?? null;
-  }
-  async put(key: string, value: string): Promise<void> {
-    this.store.set(key, { value });
-  }
-  async delete(key: string): Promise<void> {
-    this.store.delete(key);
-  }
-  async list(options?: { prefix?: string }): Promise<{
-    keys: { name: string }[];
-    list_complete: boolean;
-    cursor: string;
-  }> {
-    const prefix = options?.prefix ?? '';
-    const keys = [...this.store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name }));
-    return { keys, list_complete: true, cursor: '' };
-  }
-}
+import { InMemoryKV } from './inMemoryKv';
 
 let apnsConfig: ApnsConfig;
 

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -1,47 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { deleteTrip, getTrip, listTrips, putTrip, tripKey } from '../trips';
 import type { Trip } from '../types';
-
-class InMemoryKV {
-  store = new Map<string, { value: string; expiresAt?: number }>();
-
-  async get(key: string): Promise<string | null> {
-    const entry = this.store.get(key);
-    if (!entry) return null;
-    if (entry.expiresAt && entry.expiresAt < Date.now()) {
-      this.store.delete(key);
-      return null;
-    }
-    return entry.value;
-  }
-
-  async put(
-    key: string,
-    value: string,
-    options?: { expirationTtl?: number },
-  ): Promise<void> {
-    const expiresAt = options?.expirationTtl
-      ? Date.now() + options.expirationTtl * 1000
-      : undefined;
-    this.store.set(key, { value, expiresAt });
-  }
-
-  async delete(key: string): Promise<void> {
-    this.store.delete(key);
-  }
-
-  async list(options?: { prefix?: string; cursor?: string }): Promise<{
-    keys: { name: string }[];
-    list_complete: boolean;
-    cursor: string;
-  }> {
-    const prefix = options?.prefix ?? '';
-    const keys = [...this.store.keys()]
-      .filter((k) => k.startsWith(prefix))
-      .map((name) => ({ name }));
-    return { keys, list_complete: true, cursor: '' };
-  }
-}
+import { InMemoryKV } from './inMemoryKv';
 
 function makeTrip(overrides: Partial<Trip> = {}): Trip {
   return {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -114,6 +114,59 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
   });
 
   if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
+/**
+ * Alert push 발사 (#572 P2c). silent push와 헤더/payload가 다르다:
+ *   - apns-push-type: alert (silent은 background)
+ *   - apns-priority: 10 (silent은 5)
+ *   - aps.alert: { title, body } (silent은 content-available)
+ *   - aps.sound: default
+ *
+ * data.pushId는 silent과 동일 — 디바이스 P2e가 dedup에 사용.
+ */
+export interface SendAlertPushOptions {
+  deviceToken: string;
+  title: string;
+  body: string;
+  pushId: string;
+  config: ApnsConfig;
+  host: string;
+  fetchImpl?: typeof fetch;
+  now?: number;
+}
+
+export async function sendAlertPush(options: SendAlertPushOptions): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
+
+  const body = JSON.stringify({
+    aps: {
+      alert: { title: options.title, body: options.body },
+      sound: 'default',
+    },
+    data: { pushId: options.pushId },
+  });
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${jwt}`,
+      'apns-topic': options.config.bundleId,
+      'apns-push-type': 'alert',
+      'apns-priority': '10',
+      'content-type': 'application/json',
+    },
+    body,
+  });
+
+  if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
+async function parseApnsError(response: Response): Promise<SendPushResult> {
   let reason: string | undefined;
   try {
     const data = (await response.json()) as { reason?: string };

--- a/backend/alarm-worker/src/fallback.ts
+++ b/backend/alarm-worker/src/fallback.ts
@@ -1,0 +1,124 @@
+/**
+ * Alert push fallback 발사 (#572 P2c).
+ *
+ * silent push가 30s 안에 디바이스 ACK되지 않으면 alert push로 fallback 발사한다.
+ * cron 1회 실행 = 한 trip을 처리하는 scheduled.ts의 한 사이클에 이어 runFallbackPushes를 호출.
+ *
+ * 30s 임계는 sentAt 시각 기준 — cron 자체는 1분 단위라 첫 폴링까지 최대 60s 지연 발생 가능.
+ * 사용자 입장에선 알람 못 받는 것보단 60s 늦게라도 받는 게 낫다는 절충.
+ *
+ * 발사 후 entry는 즉시 삭제 — 다음 cron에서 재발사 방지 (KV TTL 60s에 의존하지 않음).
+ * 발사 실패도 entry 삭제 — 재시도 폭주 방지 (다음 silent push 사이클에서 자연 회복).
+ */
+
+import { sendAlertPush, type ApnsConfig, type SendPushResult } from './apns';
+import { buildAlertContent } from './alertContent';
+import { listPending, removePending, type PendingPush } from './pendingPushes';
+import type { ApnsEnv, Env } from './types';
+
+/** silent push 발사 시점에서 30s 이상 지나면 fallback 후보. */
+export const FALLBACK_THRESHOLD_MS = 30_000;
+
+export interface FallbackDeps {
+  apnsConfig: ApnsConfig;
+  /** APNs host 매핑. trip의 apnsEnv를 모르는 fallback 경로는 sandbox로 보낸다 (이미 token 검증된 entry). */
+  apnsHosts: Record<ApnsEnv, string>;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  log?: (message: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface FallbackStats {
+  scanned: number;
+  pushed: number;
+  errors: number;
+  /** 임계 미달로 다음 cron까지 미룬 수. 운영 가시성용. */
+  deferred: number;
+}
+
+/**
+ * PENDING_PUSHES KV를 스캔하며 30s 임계 초과 entry를 alert로 fallback 발사한다.
+ * scheduled.ts와 분리 — 동일 cron에서 실행되어도 모듈 책임이 명확.
+ */
+export async function runFallbackPushes(env: Env, deps: FallbackDeps): Promise<FallbackStats> {
+  const now = deps.now?.() ?? Date.now();
+  const log = deps.log ?? (() => undefined);
+  const stats: FallbackStats = { scanned: 0, pushed: 0, errors: 0, deferred: 0 };
+
+  for await (const entry of listPending(env.PENDING_PUSHES)) {
+    stats.scanned += 1;
+    if (now - entry.sentAt < FALLBACK_THRESHOLD_MS) {
+      stats.deferred += 1;
+      continue;
+    }
+
+    log('alert fallback fire', {
+      pushId: entry.pushId,
+      station: entry.stationName,
+      ageMs: Math.max(0, now - entry.sentAt),
+    });
+    const result = await sendOneFallback(entry, deps);
+    if (result.ok) {
+      stats.pushed += 1;
+      await removePending(env.PENDING_PUSHES, entry.pushId);
+    } else {
+      stats.errors += 1;
+      log('alert fallback failed', {
+        pushId: entry.pushId,
+        status: result.status,
+        reason: result.reason,
+      });
+      // 영구 실패만 즉시 삭제 — transient 실패는 entry 유지하고 KV TTL(60s)이 자연 정리.
+      // 다음 cron에서 1회 더 시도 기회를 보존 (사용자 알람 손실 최소화).
+      if (isUnrecoverableAlertError(result.status, result.reason)) {
+        await removePending(env.PENDING_PUSHES, entry.pushId);
+      }
+    }
+  }
+
+  log('fallback run complete', { ...stats });
+  return stats;
+}
+
+/**
+ * 한 pending entry를 alert로 발사한다.
+ * intermediate kind는 phase 무관 단일 본문 — alertContent의 discriminated union이 강제.
+ */
+async function sendOneFallback(
+  entry: PendingPush,
+  deps: FallbackDeps,
+): Promise<SendPushResult> {
+  const content =
+    entry.kind === 'intermediate'
+      ? buildAlertContent({ kind: 'intermediate', stationName: entry.stationName })
+      : buildAlertContent({
+          kind: entry.kind,
+          phase: entry.phase,
+          stationName: entry.stationName,
+        });
+  // #566 머지 직후 KV에 남아있던 구 entry는 apnsEnv 필드가 없을 수 있다.
+  // scheduled.ts의 `?? 'sandbox'` 패턴과 정합 — 잘못된 host 발사로 entry가 통째로 소실되는 것을 막는다.
+  const env = entry.apnsEnv ?? 'sandbox';
+  return sendAlertPush({
+    deviceToken: entry.token,
+    title: content.title,
+    body: content.body,
+    pushId: entry.pushId,
+    config: deps.apnsConfig,
+    host: deps.apnsHosts[env],
+    fetchImpl: deps.fetchImpl,
+  });
+}
+
+/**
+ * Alert push 영구 실패 분류 — transient 에러는 entry 유지로 다음 cron에서 재시도 보존.
+ * scheduled.ts의 `isUnrecoverableApnsError`와 같은 의도지만 alert 경로에서는 self-heal이 없어
+ * BadDeviceToken도 영구로 본다 (silent이 self-heal 후 putPending한 entry이므로 host는 검증됨,
+ * BadDeviceToken이 떨어진다면 토큰 자체가 무효).
+ */
+function isUnrecoverableAlertError(status: number, reason: string | undefined): boolean {
+  if (status === 410) return true; // Unregistered
+  if (status === 400 && reason === 'BadDeviceToken') return true;
+  if (status === 400 && reason === 'PayloadTooLarge') return true;
+  return false;
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { Hono } from 'hono';
+import { runFallbackPushes } from './fallback';
 import { ackPending } from './pendingPushes';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
@@ -170,19 +171,18 @@ export default {
       apiKey: env.SEOUL_API_KEY,
       host: env.SEOUL_API_HOST,
     });
-    await runScheduled(env, {
-      seoul,
-      apnsConfig: {
-        keyId: env.APNS_KEY_ID,
-        teamId: env.APNS_TEAM_ID,
-        privateKeyPem: env.APNS_PRIVATE_KEY,
-        bundleId: env.APNS_BUNDLE_ID,
-      },
-      apnsHosts: {
-        production: env.APNS_HOST,
-        sandbox: env.APNS_HOST_SANDBOX,
-      },
-      log: (msg, meta) => console.log(JSON.stringify({ msg, ...meta })),
-    });
+    const apnsConfig = {
+      keyId: env.APNS_KEY_ID,
+      teamId: env.APNS_TEAM_ID,
+      privateKeyPem: env.APNS_PRIVATE_KEY,
+      bundleId: env.APNS_BUNDLE_ID,
+    };
+    const apnsHosts = { production: env.APNS_HOST, sandbox: env.APNS_HOST_SANDBOX };
+    const log = (msg: string, meta?: Record<string, unknown>) =>
+      console.log(JSON.stringify({ msg, ...meta }));
+
+    await runScheduled(env, { seoul, apnsConfig, apnsHosts, log });
+    // #572 P2c — silent push 30s 미ACK entry를 alert로 fallback. 같은 cron 사이클에서 실행.
+    await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
   },
 };

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -12,6 +12,7 @@
  */
 
 import type { AlarmPhase } from './alarm';
+import type { ApnsEnv } from './types';
 
 const PENDING_PREFIX = 'pending:';
 export const PENDING_TTL_SEC = 60;
@@ -30,6 +31,8 @@ export interface PendingPush {
   kind: 'transfer' | 'destination' | 'intermediate';
   phase: AlarmPhase;
   etaSeconds: number;
+  /** APNs host 선택 (sandbox/production). silent push가 self-heal로 정정된 경우 정정된 값을 보관. */
+  apnsEnv: ApnsEnv;
 }
 
 export function pendingKey(pushId: string): string {
@@ -79,6 +82,43 @@ export async function getPending(
 export interface AckResult {
   deleted: boolean;
   reason?: 'not-found' | 'token-mismatch';
+}
+
+/**
+ * P2c fallback 발사 경로용 — KV의 pending entry를 enumerate한다.
+ * trips.ts의 listTrips와 동일 패턴: prefix scan + cursor 페이지네이션.
+ * 손상된 JSON entry는 스킵 (TTL로 자동 정리됨).
+ */
+export async function* listPending(
+  kv: KVNamespace | undefined,
+): AsyncGenerator<PendingPush> {
+  if (!kv) return;
+  let cursor: string | undefined;
+  do {
+    const result = await kv.list({ prefix: PENDING_PREFIX, cursor });
+    for (const key of result.keys) {
+      const raw = await kv.get(key.name);
+      if (!raw) continue;
+      try {
+        yield JSON.parse(raw) as PendingPush;
+      } catch {
+        // 손상된 entry는 스킵.
+      }
+    }
+    cursor = result.list_complete ? undefined : result.cursor;
+  } while (cursor);
+}
+
+/**
+ * P2c가 alert fallback 발사 후 호출 — entry 삭제로 다음 cron에서 재발사 방지.
+ * ackPending과 달리 token 인증 없이 무조건 삭제 (caller가 백엔드 cron이므로 인증 불필요).
+ */
+export async function removePending(
+  kv: KVNamespace | undefined,
+  pushId: string,
+): Promise<void> {
+  if (!kv) return;
+  await kv.delete(pendingKey(pushId));
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -206,6 +206,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
             kind: waypoint.kind,
             phase: pushPhase,
             etaSeconds: eta,
+            // self-heal로 정정된 apnsEnv가 dirty에 반영되었더라도 현재 변수는 정정된 값.
+            // 누락 시 sandbox fallback과 일관 — pickApnsHost 동등 처리.
+            apnsEnv: trip.apnsEnv ?? 'sandbox',
           });
           if (shouldPushPhase) {
             trip.lastFiredPhase = phase!;


### PR DESCRIPTION
## Summary
- P2c — 다중 채널 BG 알람 채널 2 마지막 핵심. silent push가 30s 안에 디바이스 ACK 없으면 alert로 재발사
- 새 모듈 \`fallback.ts\` — KV scan + 30s 임계 + buildAlertContent + sendAlertPush
- 영구 실패(410/BadDeviceToken/PayloadTooLarge)만 entry 즉시 삭제. **Transient(5xx)는 유지** → 다음 cron 1회 재시도 보존
- 구 entry(\`#566\` 머지 직후 apnsEnv 누락) backward-compat sandbox fallback — 운영 마이그레이션 사고 방지

## Test plan
- [x] vitest 179 통과 (신규: fallback 10건 + apns alert 3건 + pendingPushes list/remove 5건)
- [x] type-check 통과
- [x] code-review P1 두 건 반영 (구 entry apnsEnv 누락 + transient 실패 entry 유지)
- [ ] 머지 후 \`wrangler kv:namespace create PENDING_PUSHES\` + binding 활성화, 실기기 P2b ACK 미도달 시 alert 도달 확인

## 후속 (별도 chore 이슈 권장)
- \`removePending\` raw delete를 fallback 내부 함수로 흡수 (export 표면 축소)
- \`runScheduled\` ↔ \`runFallbackPushes\` 병렬화 (Promise.all)
- Cloudflare cron 단위(1분) 한계 — 30s 정밀도 필요 시 Durable Object 도입

## 후속 채널 2 작업
- **P2e** 디바이스가 alert push를 받았을 때 FIRED_ALARMS dedup (silent이 살짝 늦게 도달한 경우 중복 알림 방지) — 디바이스 작업

Closes #572