### PR TITLE
feat(#574): device alert push dedup (pushId + 5분 fired set)

### DIFF
--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -27,3 +27,6 @@ export const TELEMETRY_LAST_FLUSH_KEY = 'subway-now:telemetry-last-flush';
 // #527 — BG 위치 task의 jump gate가 참조하는 직전 수용 fix.
 // 형식: {"lat":number,"lng":number,"timestamp":number} JSON.
 export const BG_LAST_FIX_KEY = 'subway-now:bg-last-fix';
+// #574 P2e — 디바이스가 fire한 silent push의 pushId 집합. alert fallback race 시 중복 표시 차단.
+// 형식: {"[pushId]": timestamp} JSON. 5분 이상 된 항목은 add/read 시 cleanup.
+export const FIRED_PUSH_IDS_KEY = 'subway-now:fired-push-ids';

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -29,6 +29,7 @@ import {
   logSilentPushSkipped,
   type AlarmLogReason,
 } from '../utils/alarmLog';
+import { addFiredPushId } from '../utils/firedPushIds';
 import {
   checkSilentPushLocationGate,
   type GateSkipReason,
@@ -256,6 +257,8 @@ async function fireWithGate(
     if (fired.has(dedupKey)) {
       // 다른 채널(FG GPS 등)이 이미 발사 — backend 입장에선 fallback 불필요. ACK로 정리.
       ackOutcome(payload.pushId, apnsToken, 'skipped', 'dedup-already-fired');
+      // P2e — 동일 pushId의 alert가 race로 도달하면 FG에서 중복 표시 차단되도록 기록.
+      if (payload.pushId) void addFiredPushId(payload.pushId);
       logger.info(`dedup: ${dedupKey} already fired — skip`);
       return;
     }
@@ -290,6 +293,8 @@ async function fireWithGate(
     locationAgeMs: gate.locationAgeMs!,
   });
   ackOutcome(payload.pushId, apnsToken, 'fired');
+  // P2e — alert fallback이 race로 도달해도 FG에서 중복 표시 차단되도록 기록.
+  if (payload.pushId) void addFiredPushId(payload.pushId);
   logger.info(
     `fired: kind=${payload.kind} phase=${payload.phase} station=${payload.nextWaypoint} distance=${gate.distanceM}m`,
   );

--- a/src/utils/__tests__/firedPushIds.test.ts
+++ b/src/utils/__tests__/firedPushIds.test.ts
@@ -1,0 +1,186 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  addFiredPushId,
+  hasFiredPushId,
+  FIRED_PUSH_ID_TTL_MS,
+} from '../firedPushIds';
+import { FIRED_PUSH_IDS_KEY } from '../../constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const NOW = 1_700_000_000_000;
+
+describe('firedPushIds (#574 P2e)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('addFiredPushId', () => {
+    it('기존 storage가 없으면 단일 entry로 저장', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await addFiredPushId('p1', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ p1: NOW });
+    });
+
+    it('기존 entry에 추가', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ old: NOW - 1000 }),
+      );
+      await addFiredPushId('new', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ old: NOW - 1000, new: NOW });
+    });
+
+    it('TTL 초과 entry는 prune 후 저장', async () => {
+      const stale = NOW - FIRED_PUSH_ID_TTL_MS - 1;
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ stale_old: stale, recent: NOW - 1000 }),
+      );
+      await addFiredPushId('new', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ recent: NOW - 1000, new: NOW });
+    });
+
+    it('손상된 JSON은 빈 map으로 초기화 후 add', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json{');
+      await addFiredPushId('p1', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ p1: NOW });
+    });
+
+    it('비-객체 JSON(배열 등)도 빈 map으로 초기화', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(['a']));
+      await addFiredPushId('p1', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ p1: NOW });
+    });
+
+    it('비-숫자 ts 항목은 prune (구버전 호환)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ bad: 'string', good: NOW }),
+      );
+      await addFiredPushId('new', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ good: NOW, new: NOW });
+    });
+
+    it('AsyncStorage 실패 시 throw 안 함 (fire-and-forget)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(addFiredPushId('p1', NOW)).resolves.toBeUndefined();
+    });
+
+    it('setItem 실패도 swallow', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
+      await expect(addFiredPushId('p1', NOW)).resolves.toBeUndefined();
+    });
+
+    it('default now (인자 미주입)는 Date.now() 사용', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await addFiredPushId('p1');
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json).p1).toBe(NOW);
+      (Date.now as jest.Mock).mockRestore?.();
+    });
+  });
+
+  describe('hasFiredPushId', () => {
+    it('TTL 내 entry는 true', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ p1: NOW - 1000 }),
+      );
+      expect(await hasFiredPushId('p1', NOW)).toBe(true);
+    });
+
+    it('TTL 초과 entry는 false', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ p1: NOW - FIRED_PUSH_ID_TTL_MS - 1 }),
+      );
+      expect(await hasFiredPushId('p1', NOW)).toBe(false);
+    });
+
+    it('미존재 id는 false', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({}));
+      expect(await hasFiredPushId('missing', NOW)).toBe(false);
+    });
+
+    it('비-숫자 ts entry는 false (방어)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ p1: 'string' }),
+      );
+      expect(await hasFiredPushId('p1', NOW)).toBe(false);
+    });
+
+    it('AsyncStorage 실패 시 false (빈 map fallback)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      expect(await hasFiredPushId('p1', NOW)).toBe(false);
+    });
+
+    it('default now (인자 미주입)는 Date.now()', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ p1: NOW - 1000 }),
+      );
+      expect(await hasFiredPushId('p1')).toBe(true);
+      (Date.now as jest.Mock).mockRestore?.();
+    });
+  });
+
+  it('FIRED_PUSH_ID_TTL_MS는 5분으로 노출', () => {
+    expect(FIRED_PUSH_ID_TTL_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('AsyncStorage key는 storageKeys 상수', () => {
+    expect(FIRED_PUSH_IDS_KEY).toBe('subway-now:fired-push-ids');
+  });
+
+  describe('동시성 직렬화 큐', () => {
+    it('두 add가 동시에 진입해도 두 entry 모두 저장된다 (read-modify-write race 차단)', async () => {
+      let storage: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async () => storage);
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(async (_key, value) => {
+        storage = value;
+      });
+      // 동시 호출 — Promise.all로 발사. 큐가 없으면 두 read가 동일 빈 state 보고 마지막 write가 첫 entry 덮어씀.
+      await Promise.all([addFiredPushId('a', NOW), addFiredPushId('b', NOW + 1)]);
+      const final = JSON.parse(storage!);
+      expect(final).toEqual({ a: NOW, b: NOW + 1 });
+    });
+
+    it('add 후 has는 same-tick에서도 직전 write를 본다', async () => {
+      let storage: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async () => storage);
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(async (_key, value) => {
+        storage = value;
+      });
+      // 큐로 직렬화되므로 has는 add 이후 결과를 본다.
+      const addP = addFiredPushId('p1', NOW);
+      const hasP = hasFiredPushId('p1', NOW);
+      await Promise.all([addP, hasP]);
+      expect(await hasP).toBe(true);
+    });
+
+    it('AsyncStorage 실패는 add/has 모두 try/catch로 swallow하므로 큐가 끊기지 않는다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage-down'));
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage-down'));
+      // 실패 직후 정상 동작 — 큐 fulfilled 유지.
+      await addFiredPushId('after-error', NOW);
+      expect(await hasFiredPushId('after-error', NOW)).toBe(false); // storage 미반영이지만 throw 없음
+    });
+  });
+});

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -47,6 +47,11 @@ jest.mock('../../../modules/live-activity', () => ({
   isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
 }));
 
+const mockHasFiredPushId = jest.fn();
+jest.mock('../firedPushIds', () => ({
+  hasFiredPushId: (...args: unknown[]) => mockHasFiredPushId(...args),
+}));
+
 const mockSaveStationToWidget = jest.fn().mockResolvedValue(undefined);
 const mockClearWidgetStation = jest.fn().mockResolvedValue(undefined);
 jest.mock('../widgetStorage', () => ({
@@ -148,6 +153,52 @@ describe('stationNotification', () => {
 
       const silentAlarmResult = await handleNotification({ request: { identifier: 'station-alarm', content: { sound: null } } });
       expect(silentAlarmResult).toEqual({ shouldShowAlert: true, shouldShowBanner: true, shouldShowList: true, shouldPlaySound: false, shouldSetBadge: false });
+    });
+
+    it('#574 P2e — pushId가 firedPushIds에 있으면 모든 show 플래그 false로 suppress', async () => {
+      mockHasFiredPushId.mockResolvedValueOnce(true);
+      setupNotificationHandler();
+      const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+      const result = await handleNotification({
+        request: { identifier: 'station-alarm', content: { sound: 'alarm.wav', data: { pushId: 'p1' } } },
+      });
+      expect(mockHasFiredPushId).toHaveBeenCalledWith('p1');
+      expect(result).toEqual({
+        shouldShowAlert: false,
+        shouldShowBanner: false,
+        shouldShowList: false,
+        shouldPlaySound: false,
+        shouldSetBadge: false,
+      });
+    });
+
+    it('#574 P2e — pushId가 fired set에 없으면 정상 표시', async () => {
+      mockHasFiredPushId.mockResolvedValueOnce(false);
+      setupNotificationHandler();
+      const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+      const result = await handleNotification({
+        request: { identifier: 'station-alarm', content: { sound: 'alarm.wav', data: { pushId: 'fresh' } } },
+      });
+      expect(result.shouldShowAlert).toBe(true);
+      expect(result.shouldPlaySound).toBe(true);
+    });
+
+    it('#574 P2e — data 없거나 pushId 누락이면 정상 표시 (hasFiredPushId 호출 안 함)', async () => {
+      setupNotificationHandler();
+      const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+      const noData = await handleNotification({
+        request: { identifier: 'station-alarm', content: { sound: null } },
+      });
+      expect(noData.shouldShowAlert).toBe(true);
+      const dataNoPushId = await handleNotification({
+        request: { identifier: 'station-alarm', content: { sound: null, data: { other: 'x' } } },
+      });
+      expect(dataNoPushId.shouldShowAlert).toBe(true);
+      const emptyPushId = await handleNotification({
+        request: { identifier: 'station-alarm', content: { sound: null, data: { pushId: '' } } },
+      });
+      expect(emptyPushId.shouldShowAlert).toBe(true);
+      expect(mockHasFiredPushId).not.toHaveBeenCalled();
     });
   });
 

--- a/src/utils/firedPushIds.ts
+++ b/src/utils/firedPushIds.ts
@@ -1,0 +1,82 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { FIRED_PUSH_IDS_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+
+// #574 P2e — silent push fire/dedup 시점에 pushId를 기록하고, 동일 pushId의 alert push가
+// 도달했을 때 중복 표시를 차단한다. silent → ACK → 백엔드 KV 정리 사이의 race(~1s)에서
+// backend cron이 alert를 fallback 발사하는 경우를 대비.
+//
+// 한계: FG에서만 동작 (notification handler에서 suppress). BG는 iOS가 alert를 직접 표시해
+// JS 개입 불가 — P2e 의도된 trade-off.
+//
+// 형식: `{ "<pushId>": ts (epoch ms) }`. TTL FIRED_PUSH_ID_TTL_MS 초과 항목은 add 호출 시 cleanup.
+// AsyncStorage 실패는 dedup 효과만 잃을 뿐 silent push 본 처리에 무관 — caller는 fire-and-forget 호출.
+//
+// **동시성**: addFiredPushId 호출이 짧은 간격으로 두 번 발생하면 read-modify-write race로 entry가
+// 손실될 수 있다(두 호출이 같은 read 결과에 각자 항목을 더해 마지막 write가 이김). 이는 P2e 본 목적
+// (alert 중복 차단)을 직접 깨므로 모듈 내부 직렬화 큐로 write를 chain한다. has는 큐 끝에서 읽어
+// 가장 최신 상태를 본다.
+
+const logger = createLogger('FiredPushIds');
+
+/** 5분 — 30s 임계 + cron 1분 + 네트워크 지연 모두 커버하는 안전 마진. */
+export const FIRED_PUSH_ID_TTL_MS = 5 * 60 * 1000;
+
+type FiredMap = Record<string, number>;
+
+async function read(): Promise<FiredMap> {
+  try {
+    const raw = await AsyncStorage.getItem(FIRED_PUSH_IDS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as FiredMap;
+  } catch {
+    return {};
+  }
+}
+
+function prune(map: FiredMap, now: number): FiredMap {
+  const out: FiredMap = {};
+  for (const [id, ts] of Object.entries(map)) {
+    if (typeof ts === 'number' && now - ts < FIRED_PUSH_ID_TTL_MS) {
+      out[id] = ts;
+    }
+  }
+  return out;
+}
+
+// 모듈 스코프 write 큐. add/has를 chain해 동시 진입 race를 차단한다.
+// add/has 내부 task는 모두 자체 try/catch로 swallow하므로 큐는 항상 fulfilled로 진행한다.
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const next = writeQueue.then(task);
+  writeQueue = next;
+  return next;
+}
+
+export function addFiredPushId(pushId: string, now: number = Date.now()): Promise<void> {
+  return enqueue(async () => {
+    try {
+      const current = await read();
+      const pruned = prune(current, now);
+      pruned[pushId] = now;
+      await AsyncStorage.setItem(FIRED_PUSH_IDS_KEY, JSON.stringify(pruned));
+    } catch (e) {
+      logger.warn('addFiredPushId 실패 — dedup 한 사이클 손실:', e);
+    }
+  });
+}
+
+export function hasFiredPushId(
+  pushId: string,
+  now: number = Date.now(),
+): Promise<boolean> {
+  return enqueue(async () => {
+    const current = await read();
+    const ts = current[pushId];
+    if (typeof ts !== 'number') return false;
+    return now - ts < FIRED_PUSH_ID_TTL_MS;
+  });
+}

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -12,6 +12,7 @@ import { speakAlarm } from './tts';
 import { createLogger } from './logger';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
 import { saveStationToWidget, clearWidgetStation } from './widgetStorage';
+import { hasFiredPushId } from './firedPushIds';
 import stationsData from '../data/stations.json';
 import type { ExitSide } from '../types/exitSide';
 import { lookupExitSide } from './exitSide';
@@ -64,6 +65,17 @@ export function setupNotificationHandler(): void {
     handleNotification: async (notification) => {
       const isAlarm = notification.request.identifier === ALARM_NOTIFICATION_ID;
       const hasSound = notification.request.content.sound != null;
+      // #574 P2e — silent push가 이미 fired한 pushId의 alert fallback이 race로 도달했을 때
+      // FG에서 중복 표시 차단. BG에선 iOS가 직접 표시해 JS 개입 불가(P2e 한계 명시).
+      if (await isFallbackDuplicate(notification)) {
+        return {
+          shouldShowAlert: false,
+          shouldShowBanner: false,
+          shouldShowList: false,
+          shouldPlaySound: false,
+          shouldSetBadge: false,
+        };
+      }
       return {
         shouldShowAlert: true,
         shouldShowBanner: true,
@@ -73,6 +85,19 @@ export function setupNotificationHandler(): void {
       };
     },
   });
+}
+
+/**
+ * notification.request.content.data.pushId가 silent에서 이미 처리한 pushId면 true.
+ * APNs alert payload data 형식: `{ pushId: string }` (#572 sendAlertPush).
+ */
+async function isFallbackDuplicate(
+  notification: Notifications.Notification,
+): Promise<boolean> {
+  const data = notification.request.content.data as { pushId?: unknown } | undefined;
+  const pushId = data?.pushId;
+  if (typeof pushId !== 'string' || pushId.length === 0) return false;
+  return hasFiredPushId(pushId);
 }
 
 const STATION_CHANNEL_ID = 'station';


### PR DESCRIPTION
## Summary
- P2e — 다중 채널 BG 알람 채널 2 마지막 슬라이스. silent push 처리 후 동일 pushId의 alert가 race(~1s)로 도달해도 FG 중복 표시 차단
- 새 util \`firedPushIds.ts\` — AsyncStorage Map + TTL 5분 + **직렬화 큐**(read-modify-write race 차단)
- silentPushTask fire/dedup 경로에서 \`addFiredPushId\` fire-and-forget
- setupNotificationHandler: \`data.pushId\`가 fired set에 있으면 모든 show 플래그 false로 suppress

## 한계 (정직)
- BG에서 iOS가 alert를 직접 표시하면 JS 개입 불가 — FG dedup만 보장
- 실 운영에서 silent→ACK는 ~1s, fallback cron은 30s+1분이라 race 빈도 낮음. 이 PR은 네트워크 일시 단절 같은 edge 대비

## Test plan
- [x] \`npm test\` 1871 통과 (신규: firedPushIds 20건 + stationNotification handler 3건)
- [x] 100% 커버리지 유지, type-check 통과
- [x] code-review P1 1건 반영 (직렬화 큐로 race 차단)

## 후속 (별도 chore 이슈 권장)
- P2-1: APNs alert payload에 \`data.source: 'apns-alert'\` marker 추가해 dedup 대상 명확화 (현재는 pushId만)
- 큐 크기 상한(MAX_ITEMS) 추가 — prune 외 안전망

Closes #574