### PR TITLE
chore: PENDING_PUSHES KV binding 활성화 — 채널 2 가동

### DIFF
--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -13,11 +13,10 @@ preview_id = "7e67683c147349ed90c16a28ae232e34"
 # KV: pending silent pushes (#566 P2a)
 # 발사한 silent push 1건마다 pushId entry를 기록. P2c가 30s 미ACK push를 alert fallback으로 재발사.
 # 코드는 `if (env.PENDING_PUSHES)` 분기로 graceful — binding 없으면 모든 pending 경로가 no-op.
-# 활성화: `wrangler kv:namespace create PENDING_PUSHES` 후 아래 4줄 주석 해제 + id/preview_id 채움.
-# [[kv_namespaces]]
-# binding = "PENDING_PUSHES"
-# id = "<wrangler create 결과>"
-# preview_id = "<wrangler create --preview 결과>"
+[[kv_namespaces]]
+binding = "PENDING_PUSHES"
+id = "12e5eae8b5c94420b0efc1e89870c845"
+preview_id = "53a86628f78c48fa91fa954f84514df3"
 
 # #498 — silent push 게이트 outcome 텔레메트리. 클라가 누적한 카운터를 일별 query 가능하게 적재.
 # Privacy: 카운트만, token은 8자 prefix만. 개별 push 내용/좌표 미저장.


### PR DESCRIPTION
## Summary
\`wrangler kv:namespace create PENDING_PUSHES\` 결과 id를 \`wrangler.toml\`에 채워넣어 채널 2 (alert fallback)를 실제 운영에서 가동.

- production id: \`12e5eae8b5c94420b0efc1e89870c845\`
- preview id: \`53a86628f78c48fa91fa954f84514df3\`

코드는 #566 머지 이후 \`if (env.PENDING_PUSHES)\` graceful 분기 상태였음. 본 PR 머지 + \`npx wrangler deploy\` 하면 silent push 30s 미ACK → alert fallback이 실제 발사 시작.

## Test plan
- [x] backend vitest 179 통과, type-check 통과 (코드 변경 없음, 설정만)
- [ ] 머지 후 운영자: \`cd backend/alarm-worker && npx wrangler deploy\`
- [ ] 실기기에서 silent push 강제 ACK 실패(앱 강제 종료 등) → 30~90초 후 alert 도달 확인