### PR TITLE
fix(#577): FG GPS accuracy BestForNavigation → High

### DIFF
--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -214,7 +214,7 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('watchPositionAsync에 BestForNavigation·distanceInterval:0·timeInterval:2000을 전달한다', async () => {
+  it('watchPositionAsync에 High·distanceInterval:0·timeInterval:2000을 전달한다', async () => {
     mockGranted();
 
     renderHook(() => useNearestStation());
@@ -223,7 +223,7 @@ describe('useNearestStation', () => {
 
     expect(Location.watchPositionAsync).toHaveBeenCalledWith(
       {
-        accuracy: Location.Accuracy.BestForNavigation,
+        accuracy: Location.Accuracy.High,
         distanceInterval: 0,
         timeInterval: 2000,
       },

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -188,13 +188,15 @@ export function useNearestStation(): UseNearestStationReturn {
 
       // 연속 GPS 스트리밍 — 지하 구간 horizontalAccuracy(300~1500m)도 표시용으로는 수용.
       // 알람은 useStationAlarm에서 accuracyMeters로 별도 엄격 게이트.
-      // BestForNavigation + distanceInterval:0 + timeInterval:2000:
-      //  좌표를 최대한 자주 흘려보낸다 (foreground 한정, 화면 켜진 동안만 GPS 풀파워).
+      // High + distanceInterval:0 + timeInterval:2000:
+      //  좌표를 최대한 자주 흘려보낸다 (foreground 한정, 화면 켜진 동안만).
+      //  High는 GPS hardware fix가 없으면 WiFi BSSID / Cell tower triangulation으로 fallback
+      //  → 지하 구간에서도 ~50~100m 위치가 들어옴 (BestForNavigation은 fallback 없이 stale).
       // 참고: pausesUpdatesAutomatically / activityType은 expo-location foreground 옵션에
       //  노출되지 않아 적용 불가. background task 옵션에서만 사용 가능.
       subscriptionRef.current = await Location.watchPositionAsync(
         {
-          accuracy: Location.Accuracy.BestForNavigation,
+          accuracy: Location.Accuracy.High,
           distanceInterval: 0,
           timeInterval: 2000,
         },


### PR DESCRIPTION
## 무엇을
- `useNearestStation`의 `watchPositionAsync` accuracy를 `BestForNavigation` → `High`로 변경 (1줄)
- 주석에 결정 근거 명시, 테스트 expected enum 동기화

## 왜
- 지하 진입 시 GPS hardware fix가 끊겨 lastFix가 최대 12분 stale 유지되던 문제 (실측 #577)
- BestForNavigation은 GPS 전용 → 지하에서 fallback 없이 stale
- High는 WiFi BSSID + Cell tower triangulation fallback 활용 (~50–100m)

## 어떻게
- `src/hooks/useNearestStation.ts:197` accuracy enum 한 줄 변경
- 위 주석에 "왜 High인지" 명시 (지하 fallback 동작)
- 테스트 `useNearestStation에 High·distanceInterval:0·timeInterval:2000을 전달한다`로 expected 동기화
- 대안: 직접 fallback 구현(별 모듈) — YAGNI, expo-location 공식 추상화로 충분

## 테스트
- 추가/수정: watchPositionAsync expected enum 동기화
- `npm test` 전체 1871건 pass, 커버리지 100%
- `npm run type-check` 통과

## 후속 (별도 트랙)
- confidence 라벨 정밀화 (source=wifi/cell 식별)
- 실기기 회귀 검증 — 출근 통근 1회

Closes #577