### PR TITLE
fix(#578): POST /trips 재등록 시 backend advance 진행 상태 보존

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -130,6 +130,90 @@ describe('validateTrip', () => {
   });
 });
 
+describe('POST /trips (#578 — preserve advance progress on re-register)', () => {
+  const CREATED = 1_700_000_000_000;
+  function makeKvEnv(): Env {
+    return makeEnv({ TRIPS: new InMemoryKV() as unknown as Env['TRIPS'] });
+  }
+
+  function tripBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+      ...base(),
+      token: 'tok-578',
+      createdAt: CREATED,
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'intermediate' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('persists incoming trip on first register', async () => {
+    const env = makeKvEnv();
+    const res = await post('/trips', tripBody(), env);
+    expect(res.status).toBe(200);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(stored.waypoints).toHaveLength(3);
+  });
+
+  it('preserves advanced waypoints when same session re-registers (same createdAt)', async () => {
+    const env = makeKvEnv();
+    // 1) initial register
+    await post('/trips', tripBody(), env);
+    // 2) backend advance: shift first waypoint + set lastFiredPhase=undefined (mimics scheduled.ts)
+    const advanced = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    advanced.waypoints.shift();
+    advanced.lastFiredPhase = undefined;
+    advanced.lastEtaSeconds = 42;
+    await env.TRIPS.put('trip:tok-578', JSON.stringify(advanced));
+    // 3) device re-POSTs original payload (same createdAt)
+    const res = await post('/trips', tripBody(), env);
+    expect(res.status).toBe(200);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    // advance progress preserved
+    expect(finalTrip.waypoints).toHaveLength(2);
+    expect(finalTrip.waypoints[0].stationName).toBe('군자');
+    expect(finalTrip.lastEtaSeconds).toBe(42);
+  });
+
+  it('replaces trip entirely when createdAt differs (new session)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    const advanced = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    advanced.waypoints.shift();
+    await env.TRIPS.put('trip:tok-578', JSON.stringify(advanced));
+    // new trip session with different createdAt
+    await post('/trips', tripBody({ createdAt: CREATED + 10_000 }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(finalTrip.waypoints).toHaveLength(3);
+    expect(finalTrip.waypoints[0].stationName).toBe('중곡');
+  });
+
+  it('preserves existing apnsEnv when incoming omits it', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody({ apnsEnv: 'production' }), env);
+    await post('/trips', tripBody(), env); // no apnsEnv
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(finalTrip.apnsEnv).toBe('production');
+  });
+
+  it('returns 400 on invalid JSON', async () => {
+    const env = makeKvEnv();
+    const res = await post('/trips', 'not-json{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 on invalid trip body', async () => {
+    const env = makeKvEnv();
+    const res = await post('/trips', { token: '' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_trip' });
+  });
+});
+
 describe('POST /telemetry/silent-push', () => {
   const validBody = {
     token: 'aabbccdd11223344',

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -36,8 +36,23 @@ app.post('/trips', async (c) => {
     return c.json({ error: 'invalid_json' }, 400);
   }
 
-  const trip = validateTrip(body);
-  if (!trip) return c.json({ error: 'invalid_trip' }, 400);
+  const incoming = validateTrip(body);
+  if (!incoming) return c.json({ error: 'invalid_trip' }, 400);
+
+  // #578: 디바이스가 동일 trip을 반복 POST해도(예: GPS update마다 register) backend가 이미
+  // advance한 waypoints / lastFiredPhase / lastEtaSeconds를 덮어쓰지 않는다.
+  // 동일 세션 판별: 같은 token + 같은 createdAt. createdAt이 다르면 새 trip 세션이므로 전면 교체.
+  const existing = await getTrip(c.env.TRIPS, incoming.token);
+  const isSameSession = existing !== null && existing.createdAt === incoming.createdAt;
+  const trip = isSameSession
+    ? {
+        ...incoming,
+        waypoints: existing.waypoints,
+        lastFiredPhase: existing.lastFiredPhase,
+        lastEtaSeconds: existing.lastEtaSeconds,
+        apnsEnv: existing.apnsEnv ?? incoming.apnsEnv,
+      }
+    : incoming;
 
   await putTrip(c.env.TRIPS, trip);
   return c.json({ ok: true, token: trip.token });


### PR DESCRIPTION
## 무엇을
- `POST /trips` 핸들러가 기존 trip을 조회해 동일 세션이면 advance 진행 상태(waypoints / lastFiredPhase / lastEtaSeconds)를 보존, 새 세션이면 전면 교체
- 동일 세션 식별: `token` 일치 + `createdAt` 일치

## 왜
- 디바이스가 GPS update마다 POST /trips를 재등록(#581 별도)하면, 기존 핸들러는 incoming payload로 무조건 덮어쓰기 → backend `scheduled.ts`에서 advance한 waypoints가 다음 cycle에 원복
- 증상: 같은 trip의 같은 waypoint(중곡)에 5분 간격 imminent 알람 3회 반복 발사 (실측 2026-05-28)

## 어떻게
- `backend/alarm-worker/src/index.ts` POST /trips: `getTrip` → `createdAt` 비교 → 같은 세션이면 incoming + 기존 진행 상태 머지, 다르면 incoming 그대로 사용
- `apnsEnv`는 기존값 우선, incoming은 fallback (#482 self-heal 결과 보존)
- 대안 검토: 클라이언트 dedup(#581)만으로도 발생 빈도는 줄지만, backend invariant를 자체 방어하지 못해 다른 클라이언트 케이스에서 재현 가능 → 레이어별 책임 분리

## 테스트
- 첫 등록 / 동일 세션 보존 / 새 세션 교체 / apnsEnv 보존 / 400 (invalid JSON, invalid trip) 분기
- `backend/alarm-worker`: 185 tests pass, type-check 통과

## 후속
- #581 디바이스 측 dedup — 별도 트랙
- P2(race window, 머지 헬퍼 추출), P3(sessionId 명시 키) — 후속 이슈 후보

Closes #578