### PR TITLE
fix(#581): trip register dedup (hash + 60s alarm bucket)

### DIFF
--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -1,4 +1,9 @@
-import { registerActiveTrip, clearActiveTrip, sendPushAck } from '../alarmBackend';
+import {
+  registerActiveTrip,
+  clearActiveTrip,
+  sendPushAck,
+  __resetAlarmBackendDedup,
+} from '../alarmBackend';
 import type { RegisterTripPayload } from '../alarmBackend';
 
 jest.mock('../../utils/logger', () => ({
@@ -29,6 +34,7 @@ describe('alarmBackend', () => {
     jest.useFakeTimers().setSystemTime(NOW);
     delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
     global.fetch = jest.fn();
+    __resetAlarmBackendDedup();
   });
 
   afterEach(() => {
@@ -100,6 +106,80 @@ describe('alarmBackend', () => {
       (global.fetch as jest.Mock).mockRejectedValue(new Error('network'));
       const result = await registerActiveTrip(SAMPLE_PAYLOAD);
       expect(result).toEqual({ ok: false });
+    });
+
+    describe('dedup (#581)', () => {
+      beforeEach(() => {
+        process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+        (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      });
+
+      it('동일 페이로드 두 번 호출 시 두 번째는 fetch 안 함 + skipped=true', async () => {
+        const first = await registerActiveTrip(SAMPLE_PAYLOAD);
+        const second = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(first).toEqual({ ok: true, status: 200 });
+        expect(second).toEqual({ ok: true, skipped: true });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('alarmAtEpochMs가 60초 버킷 내 jitter 면 dedup된다', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        const jitter = await registerActiveTrip({
+          ...SAMPLE_PAYLOAD,
+          alarmAtEpochMs: SAMPLE_PAYLOAD.alarmAtEpochMs + 30_000,
+        });
+        expect(jitter.skipped).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('alarmAtEpochMs가 다른 버킷으로 넘어가면 재등록된다', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        const next = await registerActiveTrip({
+          ...SAMPLE_PAYLOAD,
+          alarmAtEpochMs: SAMPLE_PAYLOAD.alarmAtEpochMs + 120_000,
+        });
+        expect(next).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('destination 변경 시 재등록된다', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        const next = await registerActiveTrip({ ...SAMPLE_PAYLOAD, destination: '0229' });
+        expect(next.ok).toBe(true);
+        expect(next.skipped).toBeUndefined();
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('등록 실패(non-2xx)는 해시를 저장하지 않아 다음 호출에서 재시도된다', async () => {
+        (global.fetch as jest.Mock)
+          .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+          .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+        const first = await registerActiveTrip(SAMPLE_PAYLOAD);
+        const retry = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(first).toEqual({ ok: false, status: 500 });
+        expect(retry).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('clearActiveTrip 호출 후엔 같은 페이로드도 다시 등록된다', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        await clearActiveTrip('token-hex');
+        (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+        const reregister = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(reregister).toEqual({ ok: true, status: 200 });
+      });
+
+      it('URL 미설정 → 설정 사이클에서도 dedup이 stale state를 남기지 않는다', async () => {
+        // URL 미설정으로 skip된 호출은 lastRegisteredHash를 건드리지 않아야 한다.
+        delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+        const skipped = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(skipped.skipped).toBe(true);
+
+        process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+        const real = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(real).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('타임아웃 시 AbortController가 abort를 호출한다', async () => {

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -49,6 +49,48 @@ export interface AlarmBackendResult {
 const DEFAULT_TRIP_TTL_MS = 2 * 60 * 60 * 1000;
 /** fetch 타임아웃 — 백엔드 응답 지연으로 알람 등록이 차단되지 않도록 짧게 유지. */
 const REQUEST_TIMEOUT_MS = 5000;
+/**
+ * register dedup 시 `alarmAtEpochMs`를 묶는 버킷(ms).
+ *
+ * `alarmAtEpochMs = now + ETA*1000`이므로 Open API ETA가 30~60초 단위로 흔들리면
+ * 매 GPS 폴링마다 다른 값이 된다. 버킷 단위(60s)로 떨어뜨려 동일 트립의 잔jitter를
+ * 흡수한다. 정확한 발사 시각은 백엔드 cron이 reschedule로 자체 보정한다.
+ */
+const ALARM_TIME_BUCKET_MS = 60 * 1000;
+
+/**
+ * 마지막으로 백엔드에 성공적으로 등록된 트립 페이로드의 해시.
+ *
+ * 디바이스 hook(`useApnsTripRegistration`)이 GPS/ETA 변동마다 useEffect를
+ * 재실행하는 경우 의미상 동일한 페이로드로 POST /trips가 분당 수회 폭주한다(#581).
+ * 모듈 레벨에 마지막 해시를 보관해 동일 페이로드는 fetch 없이 `{ok:true, skipped:true}`로
+ * 응답한다. `clearActiveTrip` 호출 시 초기화되어 같은 트립의 재등록(예: 사용자가
+ * 트립을 종료 후 곧바로 다시 시작)도 정상 동작한다.
+ */
+let lastRegisteredHash: string | null = null;
+
+function buildRegisterHash(body: {
+  token: string;
+  route: NonNullable<Route>;
+  destination: string;
+  waypoints: AlarmWaypoint[];
+  alarmAtEpochMs: number;
+  apnsEnv: ApnsEnv;
+}): string {
+  return JSON.stringify({
+    token: body.token,
+    route: body.route,
+    destination: body.destination,
+    waypoints: body.waypoints,
+    alarmBucket: Math.floor(body.alarmAtEpochMs / ALARM_TIME_BUCKET_MS),
+    apnsEnv: body.apnsEnv,
+  });
+}
+
+/** 테스트용 — 모듈 dedup 상태 초기화. */
+export function __resetAlarmBackendDedup(): void {
+  lastRegisteredHash = null;
+}
 
 function getBackendUrl(): string | null {
   const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
@@ -79,6 +121,18 @@ export async function registerActiveTrip(
     return { ok: false, skipped: true };
   }
 
+  const hash = buildRegisterHash({
+    token: payload.token,
+    route: payload.route,
+    destination: payload.destination,
+    waypoints: payload.waypoints,
+    alarmAtEpochMs: payload.alarmAtEpochMs,
+    apnsEnv: payload.apnsEnv,
+  });
+  if (hash === lastRegisteredHash) {
+    return { ok: true, skipped: true };
+  }
+
   const createdAt = payload.createdAt ?? Date.now();
   const expiresAt = payload.expiresAt ?? createdAt + DEFAULT_TRIP_TTL_MS;
   const body = {
@@ -102,6 +156,7 @@ export async function registerActiveTrip(
       log.warn(`register failed status=${res.status}`);
       return { ok: false, status: res.status };
     }
+    lastRegisteredHash = hash;
     return { ok: true, status: res.status };
   } catch (e) {
     log.warn('register error', e);
@@ -150,6 +205,11 @@ export async function sendPushAck(payload: PushAckPayload): Promise<AlarmBackend
  * `expiresAt`으로 자동 정리되므로 클라이언트가 재시도 책임을 갖지 않는다.
  */
 export async function clearActiveTrip(token: string): Promise<AlarmBackendResult> {
+  // 트립 종료 후 동일 트립을 다시 시작할 수 있도록 dedup 캐시를 초기화한다.
+  // URL 미설정/네트워크 실패 경로에서도 초기화해야 클라이언트가 register dedup에
+  // 의도치 않게 갇히지 않는다.
+  lastRegisteredHash = null;
+
   const base = getBackendUrl();
   if (!base) {
     log.info('ALARM_BACKEND_URL not set — skip clear');


### PR DESCRIPTION
## Summary
- `registerActiveTrip`에 모듈 레벨 `lastRegisteredHash` dedup 추가 — 동일 페이로드 두 번째 호출은 fetch 없이 `{ok:true, skipped:true}` 반환
- `alarmAtEpochMs`는 60s 버킷으로 묶어 Open API ETA jitter(30~60s) 흡수
- 성공 응답(ok=true)에서만 해시 저장 → 실패한 등록은 다음 호출에서 자연 재시도
- `clearActiveTrip`은 URL 미설정 경로 포함 항상 dedup 캐시 초기화 → 트립 종료 후 같은 트립 재시작 가능

## 배경
오늘(2026-05-28) wrangler tail에서 trip 등록 후 GPS update / route 갱신마다 `POST /trips`가 분당 수회 폭주(40초 안에 4회 등). 디바이스 hook은 이미 `routeSignature`로 메모화돼 있지만 `nextStationEtaSeconds` 변동으로 useEffect가 재실행되는 잔jitter는 남아 있었음. API 레이어 dedup이 가장 surgical.

## 결정
- 해시 입력: `token + route + destination + waypoints + apnsEnv + Math.floor(alarmAtEpochMs / 60_000)`
- `alarmAtEpochMs` 절대값 대신 60s 버킷 — 정확한 발사 시각은 백엔드 cron이 reschedule로 보정
- 실패 시 hash 미저장 — 재시도 자연 보장
- 모듈 레벨 state 선택 (호출처가 hook 1개라 factory 도입은 over-engineering)

## 검증
- [x] dedup 단위 테스트 7개 추가 (동일/jitter 흡수/버킷 이탈/destination 변경/실패→재시도/clear 후 재등록/URL skip은 stale state 안 남김)
- [x] `npm test` — 1878 pass, alarmBackend.ts 커버리지 100%
- [x] `npm run type-check` clean
- [ ] 실측: 다음 빌드에서 wrangler tail로 trip당 POST /trips 1-2회 감소 확인

## 후속 (별도 이슈 권고)
- token rotation 시 stale token row가 백엔드 KV에 남는 경로 — #581 범위 밖
- `ALARM_TIME_BUCKET_MS` 상수를 `src/constants/`로 이동 + backend reschedule 주기와 cross-ref
- `routeSignature`를 API 레이어 hash에도 재사용해 SSOT 일관

Closes #581