### PR TITLE
fix(#589): 클라이언트 trip createdAt 안정화 — backend isSameSession 가동

### DIFF
--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -386,6 +386,100 @@ describe('useApnsTripRegistration', () => {
     expect(mockRegister).toHaveBeenCalledTimes(1);
   });
 
+  it('#589 — 같은 (token, route, destination)으로 재호출 시 동일 createdAt 전달', async () => {
+    let now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const { rerender } = renderHook(
+      ({ eta }: { eta: number }) =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: eta,
+        }),
+      { initialProps: { eta: 120 } },
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    const firstCreatedAt = mockRegister.mock.calls[0][0].createdAt as number;
+    expect(firstCreatedAt).toBe(1_700_000_000_000);
+
+    // eta만 바뀌어 register effect 재실행 (같은 세션)
+    now = 1_700_000_999_999;
+    rerender({ eta: 60 });
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    expect(mockRegister.mock.calls[1][0].createdAt).toBe(firstCreatedAt);
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('#589 — route 내용 변경 시 새 createdAt 발급', async () => {
+    let now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const { rerender } = renderHook(
+      ({ route }: { route: Route }) =>
+        useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+      { initialProps: { route: { type: 'direct', stops: 5, line: '2' } as Route } },
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    const first = mockRegister.mock.calls[0][0].createdAt as number;
+
+    now = 1_700_000_500_000;
+    rerender({ route: { type: 'direct', stops: 6, line: '2' } as Route });
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    expect(mockRegister.mock.calls[1][0].createdAt).toBe(1_700_000_500_000);
+    expect(mockRegister.mock.calls[1][0].createdAt).not.toBe(first);
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('#589 — destination 변경 시 새 createdAt 발급', async () => {
+    let now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const altStation: Station = { ...station, id: '0229', name: '역삼' };
+    const { rerender } = renderHook(
+      ({ d }: { d: Station }) =>
+        useApnsTripRegistration({ route: directRoute, destination: d, nextStationEtaSeconds: 120 }),
+      { initialProps: { d: station } },
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    const first = mockRegister.mock.calls[0][0].createdAt as number;
+
+    now = 1_700_000_777_777;
+    rerender({ d: altStation });
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    expect(mockRegister.mock.calls[1][0].createdAt).toBe(1_700_000_777_777);
+    expect(mockRegister.mock.calls[1][0].createdAt).not.toBe(first);
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('#589 — token refresh 시 새 createdAt 발급 (새 세션 키)', async () => {
+    let now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    renderHook(() =>
+      useApnsTripRegistration({
+        route: directRoute,
+        destination: station,
+        nextStationEtaSeconds: 120,
+      }),
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    const first = mockRegister.mock.calls[0][0].createdAt as number;
+    const listener = mockAddPushTokenListener.mock.calls[0][0];
+
+    now = 1_700_000_333_333;
+    await act(async () => {
+      listener({ data: 'token-NEW' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(mockRegister).toHaveBeenCalledWith(expect.objectContaining({ token: 'token-NEW' })),
+    );
+    const refreshed = mockRegister.mock.calls.find(
+      (c) => (c[0] as { token: string }).token === 'token-NEW',
+    );
+    expect(refreshed?.[0].createdAt).toBe(1_700_000_333_333);
+    expect(refreshed?.[0].createdAt).not.toBe(first);
+    (Date.now as jest.Mock).mockRestore();
+  });
+
   it('route 내용이 바뀌면 register 재호출한다 (signature 변경)', async () => {
     const { rerender } = renderHook(
       ({ route }: { route: Route }) =>

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -49,6 +49,8 @@ interface RegisterCallInputs {
   destination: Station;
   nextStationEtaSeconds: number | null;
   currentStation: Station | null;
+  /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
+  createdAt: number;
 }
 
 /** 두 호출처(token refresh / main effect)의 register 페이로드 빌드를 단일화. */
@@ -60,6 +62,7 @@ async function callRegister(input: RegisterCallInputs) {
     waypoints: routeToWaypoints(input.route, input.destination.name, input.currentStation),
     alarmAtEpochMs: deriveAlarmAtEpochMs(input.nextStationEtaSeconds, Date.now()),
     apnsEnv: resolveApnsEnv(),
+    createdAt: input.createdAt,
   });
 }
 
@@ -77,6 +80,19 @@ export function useApnsTripRegistration({
   useEffect(() => {
     latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation };
   });
+
+  // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
+  // token+routeSig+destinationId)이 register를 여러 번 호출해도 동일 createdAt을
+  // 전달해야 backend의 waypoint advance 보존(#578)이 실제 가동된다.
+  const lastSessionKeyRef = useRef<string | null>(null);
+  const tripCreatedAtRef = useRef<number>(0);
+  const resolveTripCreatedAt = (sessionKey: string): number => {
+    if (lastSessionKeyRef.current !== sessionKey) {
+      lastSessionKeyRef.current = sessionKey;
+      tripCreatedAtRef.current = Date.now();
+    }
+    return tripCreatedAtRef.current;
+  };
 
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
   useEffect(() => {
@@ -116,12 +132,14 @@ export function useApnsTripRegistration({
           currentStation: cs,
         } = latestInputsRef.current;
         if (!r || !d) return;
+        const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
         await callRegister({
           token,
           route: r,
           destination: d,
           nextStationEtaSeconds: eta,
           currentStation: cs,
+          createdAt: resolveTripCreatedAt(sessionKey),
         });
       })();
     });
@@ -157,12 +175,14 @@ export function useApnsTripRegistration({
         return;
       }
 
+      const sessionKey = `${token}:${routeSig}:${destination.id}`;
       const result = await callRegister({
         token,
         route,
         destination,
         nextStationEtaSeconds,
         currentStation,
+        createdAt: resolveTripCreatedAt(sessionKey),
       });
       if (cancelled) return;
       if (result.ok) {


### PR DESCRIPTION
## 배경

PR #588(backend `isSameSession(token+createdAt)` defense)이 클라이언트 누락으로 dead code였음. `useApnsTripRegistration`이 매 register 호출마다 `createdAt`을 빠뜨려 `alarmBackend.ts`가 `Date.now()`로 새로 채움 → `isSameSession` 항상 false → #578 fix 회귀.

## 변경

- `useApnsTripRegistration`에 `lastSessionKeyRef`(`token:routeSig:destinationId`) + `tripCreatedAtRef` 추가
- 같은 세션 키이면 동일 `createdAt` 재사용, 다르면 `Date.now()`로 새 발급 → `registerActiveTrip`에 명시 전달
- 메인 effect + pushTokenListener 두 경로 모두 적용 (in-memory ref만 사용; AsyncStorage 영속화는 후속 옵션)

## 검증

- [x] 단위 테스트: 같은 (token, route, destination) 재호출 시 동일 `createdAt`
- [x] 단위 테스트: route 변경 시 새 `createdAt`
- [x] 단위 테스트: destination 변경 시 새 `createdAt`
- [x] 단위 테스트: token refresh 시 새 `createdAt`
- [x] `npm test` 1875 통과, 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 실측: wrangler tail에서 backend `isSameSession=true` 분기 진입 확인
- [ ] 실측: 출근 trip에서 같은 역 imminent 알람 1회만 발사 (#578 원본 증상 해소)

## 후속

- AsyncStorage 영속화(앱 재시작 시에도 같은 createdAt 유지)는 별도 이슈로 분리 가능 — 현재는 #581 디바이스 dedup이 보완.

Closes #589