### PR TITLE
fix(#579): destination/early 조기 오발화 — currentLine 기반 leg 게이트

### DIFF
--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -189,7 +189,12 @@ export function useStationAlarm({
     }
 
     const rawEvent = evaluateAlarmPhase(
-      { route, destinationName: destination.name, etaSeconds },
+      {
+        route,
+        destinationName: destination.name,
+        etaSeconds,
+        currentLine: nearestStation?.line ?? null,
+      },
       firedAlarmsRef.current,
     );
     if (rawEvent) fireAndLog(rawEvent, 'eta', route, destination);
@@ -206,6 +211,7 @@ export function useStationAlarm({
     firedHydrated,
     setAlarmEvent,
     nearestStation?.id,
+    nearestStation?.line,
   ]);
 
   // #396: 도착정보 API 신호로 imminent 발사.

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -29,9 +29,17 @@ function makeMultiRoute(
   };
 }
 
+function defaultCurrentLine(route: AlarmSource['route']): LineNumber | null {
+  if (!route) return null;
+  if (route.type === 'direct') return route.line;
+  if (route.type === 'transfer') return route.fromLine;
+  return route.transfers[0].fromLine;
+}
+
 function source(overrides: Partial<AlarmSource> & Pick<AlarmSource, 'route' | 'destinationName'>): AlarmSource {
   return {
     etaSeconds: null,
+    currentLine: defaultCurrentLine(overrides.route),
     ...overrides,
   };
 }
@@ -51,43 +59,43 @@ describe('resolveAllTargets', () => {
   it('returns single destination for DirectRoute', () => {
     const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
     expect(resolveAllTargets(route, '강남')).toEqual([
-      { name: '강남', stops: 5, alarmType: 'destination' },
+      { name: '강남', stops: 5, alarmType: 'destination', approachLine: '2' },
     ]);
   });
 
-  it('returns transfer + destination for TransferRoute', () => {
+  it('returns transfer + destination for TransferRoute with approachLine per leg', () => {
     expect(resolveAllTargets(makeTransferRoute(3, 5), '강남')).toEqual([
-      { name: '시청', stops: 3, alarmType: 'transfer' },
-      { name: '강남', stops: 5, alarmType: 'destination' },
+      { name: '시청', stops: 3, alarmType: 'transfer', approachLine: '1' },
+      { name: '강남', stops: 5, alarmType: 'destination', approachLine: '2' },
     ]);
   });
 
   it('collapses transfer when transferName equals destination', () => {
     expect(resolveAllTargets(makeTransferRoute(3, 0, '옥수', 'gyeongui', '3'), '옥수')).toEqual([
-      { name: '옥수', stops: 3, alarmType: 'destination' },
+      { name: '옥수', stops: 3, alarmType: 'destination', approachLine: 'gyeongui' },
     ]);
   });
 
-  it('returns all waypoints in order for MultiTransferRoute', () => {
+  it('returns all waypoints in order for MultiTransferRoute with approachLine per leg', () => {
     expect(resolveAllTargets(makeMultiRoute(5, 3, 2), '강남')).toEqual([
-      { name: '시청', stops: 5, alarmType: 'transfer' },
-      { name: '충무로', stops: 3, alarmType: 'transfer' },
-      { name: '강남', stops: 2, alarmType: 'destination' },
+      { name: '시청', stops: 5, alarmType: 'transfer', approachLine: '1' },
+      { name: '충무로', stops: 3, alarmType: 'transfer', approachLine: '3' },
+      { name: '강남', stops: 2, alarmType: 'destination', approachLine: '4' },
     ]);
   });
 
   it('marks first transfer as destination when name matches', () => {
     expect(resolveAllTargets(makeMultiRoute(1, 5, 3, '옥수'), '옥수')).toEqual([
-      { name: '옥수', stops: 1, alarmType: 'destination' },
-      { name: '충무로', stops: 5, alarmType: 'transfer' },
-      { name: '옥수', stops: 3, alarmType: 'destination' },
+      { name: '옥수', stops: 1, alarmType: 'destination', approachLine: '1' },
+      { name: '충무로', stops: 5, alarmType: 'transfer', approachLine: '3' },
+      { name: '옥수', stops: 3, alarmType: 'destination', approachLine: '4' },
     ]);
   });
 
   it('does not duplicate destination when last transfer name equals destination', () => {
     expect(resolveAllTargets(makeMultiRoute(5, 3, 0, '시청', '강남'), '강남')).toEqual([
-      { name: '시청', stops: 5, alarmType: 'transfer' },
-      { name: '강남', stops: 3, alarmType: 'destination' },
+      { name: '시청', stops: 5, alarmType: 'transfer', approachLine: '1' },
+      { name: '강남', stops: 3, alarmType: 'destination', approachLine: '3' },
     ]);
   });
 
@@ -95,15 +103,15 @@ describe('resolveAllTargets', () => {
   it('transferName과 destinationName이 노선별 표기 차이만 있으면 단일 destination으로 축약', () => {
     expect(
       resolveAllTargets(makeTransferRoute(3, 0, '상봉', 'gyeongui', '7'), '상봉(시외버스터미널)'),
-    ).toEqual([{ name: '상봉(시외버스터미널)', stops: 3, alarmType: 'destination' }]);
+    ).toEqual([{ name: '상봉(시외버스터미널)', stops: 3, alarmType: 'destination', approachLine: 'gyeongui' }]);
   });
 
   it('multi-transfer 마지막 환승역 표기 차이도 동일하게 축약', () => {
     expect(
       resolveAllTargets(makeMultiRoute(5, 3, 0, '시청', '왕십리'), '왕십리(성동구청)'),
     ).toEqual([
-      { name: '시청', stops: 5, alarmType: 'transfer' },
-      { name: '왕십리(성동구청)', stops: 3, alarmType: 'destination' },
+      { name: '시청', stops: 5, alarmType: 'transfer', approachLine: '1' },
+      { name: '왕십리(성동구청)', stops: 3, alarmType: 'destination', approachLine: '3' },
     ]);
   });
 });
@@ -208,11 +216,12 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('routes external eta to destination once transfer is passed (stops=0)', () => {
-      // 환승 통과(stops=0), 도착 1정거장 전, eta 5초 → 도착역 imminent 발사 가능
+      // 환승 통과(stops=0), 도착 1정거장 전, eta 5초 → 도착역 imminent 발사 가능.
+      // currentLine='2'는 user가 환승 후 toLine으로 이동했음을 의미.
       const fired = new Set(['early:시청', 'imminent:시청', 'early:강남']);
       expect(
         evaluateAlarmPhase(
-          source({ route: makeTransferRoute(0, 1), destinationName, etaSeconds: 5 }),
+          source({ route: makeTransferRoute(0, 1), destinationName, etaSeconds: 5, currentLine: '2' }),
           fired,
         ),
       ).toEqual({ phaseId: 'imminent', type: 'destination', stationName: '강남' });
@@ -228,9 +237,10 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('returns destination alarm after transfer early is fired and destination is close', () => {
+      // user가 toLine='2'로 이동한 직후. transfer/early는 이미 fired.
       const fired = new Set(['early:시청']);
       expect(
-        evaluateAlarmPhase(source({ route: makeTransferRoute(0, 1), destinationName }), fired),
+        evaluateAlarmPhase(source({ route: makeTransferRoute(0, 1), destinationName, currentLine: '2' }), fired),
       ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
     });
   });
@@ -243,16 +253,18 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('proceeds to second transfer after first is fired', () => {
+      // user는 두 번째 leg(line '3')로 이동.
       const fired = new Set(['early:시청']);
       expect(
-        evaluateAlarmPhase(source({ route: makeMultiRoute(0, 1, 3), destinationName }), fired),
+        evaluateAlarmPhase(source({ route: makeMultiRoute(0, 1, 3), destinationName, currentLine: '3' }), fired),
       ).toEqual({ phaseId: 'early', type: 'transfer', stationName: '충무로' });
     });
 
     it('proceeds to destination after both transfers fired', () => {
+      // user는 마지막 leg(line '4')로 이동.
       const fired = new Set(['early:시청', 'early:충무로']);
       expect(
-        evaluateAlarmPhase(source({ route: makeMultiRoute(0, 0, 1), destinationName }), fired),
+        evaluateAlarmPhase(source({ route: makeMultiRoute(0, 0, 1), destinationName, currentLine: '4' }), fired),
       ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
     });
 
@@ -268,16 +280,74 @@ describe('evaluateAlarmPhase', () => {
 
     it('fires alarms sequentially through full journey', () => {
       const fired = new Set<string>();
-      const step1 = evaluateAlarmPhase(source({ route: makeMultiRoute(1, 5, 3), destinationName }), fired);
+      // 1st leg (fromLine='1'): 시청 transfer/early
+      const step1 = evaluateAlarmPhase(source({ route: makeMultiRoute(1, 5, 3), destinationName, currentLine: '1' }), fired);
       expect(step1).toEqual({ phaseId: 'early', type: 'transfer', stationName: '시청' });
       fired.add(alarmKey(step1!));
 
-      const step2 = evaluateAlarmPhase(source({ route: makeMultiRoute(0, 1, 3), destinationName }), fired);
+      // 2nd leg (line='3'): 충무로 transfer/early
+      const step2 = evaluateAlarmPhase(source({ route: makeMultiRoute(0, 1, 3), destinationName, currentLine: '3' }), fired);
       expect(step2).toEqual({ phaseId: 'early', type: 'transfer', stationName: '충무로' });
       fired.add(alarmKey(step2!));
 
-      const step3 = evaluateAlarmPhase(source({ route: makeMultiRoute(0, 0, 1), destinationName }), fired);
+      // 3rd leg (line='4'): 강남 destination/early
+      const step3 = evaluateAlarmPhase(source({ route: makeMultiRoute(0, 0, 1), destinationName, currentLine: '4' }), fired);
       expect(step3).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
+    });
+  });
+
+  describe('currentLine gate (#579)', () => {
+    it('returns null when currentLine is null (GPS line unknown)', () => {
+      const route = makeTransferRoute(1, 5);
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '강남', currentLine: null }),
+          new Set(),
+        ),
+      ).toBeNull();
+    });
+
+    it('does not fire destination/early on transfer route when user is on fromLine even if stopsFromTransfer <= 1', () => {
+      // 용마산(7) → 건대입구(transfer) → 성수(2) 회귀: stopsFromTransfer=1이지만 user는 line 7에 있음.
+      // currentLine='7' 이면 destination 웨이포인트(approachLine='2')는 평가 대상이 아님.
+      const route = makeTransferRoute(3, 1, '건대입구', '7', '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '성수', currentLine: '7' }),
+          new Set(),
+        ),
+      ).toBeNull();
+    });
+
+    it('fires destination/early once user is on toLine and approaches', () => {
+      // 환승 완료 후 line 2에 있을 때 destination/early 발사.
+      const route = makeTransferRoute(0, 1, '건대입구', '7', '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '성수', currentLine: '2' }),
+          new Set(),
+        ),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '성수' });
+    });
+
+    it('fires transfer/early when user is on fromLine approaching transfer', () => {
+      const route = makeTransferRoute(1, 5, '건대입구', '7', '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '성수', currentLine: '7' }),
+          new Set(),
+        ),
+      ).toEqual({ phaseId: 'early', type: 'transfer', stationName: '건대입구' });
+    });
+
+    it('returns null when currentLine does not match any leg (GPS noise → other line)', () => {
+      const route = makeTransferRoute(1, 1, '건대입구', '7', '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '성수', currentLine: '5' }),
+          new Set(),
+        ),
+      ).toBeNull();
     });
   });
 

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -1,6 +1,7 @@
 import type { Route } from './stationRoute';
 import { isSameStationName } from './stationRoute';
 import type { TravelDirection } from '../types/exitSide';
+import type { LineNumber } from '../types/station';
 import { ALARM_PHASES, type AlarmContext, type AlarmPhase, type AlarmPhaseId } from './alarmPhases';
 
 export type AlarmType = 'destination' | 'transfer';
@@ -22,6 +23,11 @@ export interface CurrentTarget {
   name: string;
   stops: number;
   alarmType: AlarmType;
+  // 이 웨이포인트를 향해 사용자가 타고 가는 구간의 노선(approach line).
+  // 환승 1회 경로의 destination은 toLine, 환승 0회(direct)는 route.line이다.
+  // currentLine 게이트(#579)에서 이 값이 사용자가 실제로 탑승 중인 노선과 일치할 때만
+  // phase가 평가된다 — 환승 전 도착역 stops가 작더라도 다른 노선에서 발사되지 않는다.
+  approachLine: LineNumber;
 }
 
 /**
@@ -33,16 +39,16 @@ export function resolveAllTargets(
   destinationName: string,
 ): CurrentTarget[] {
   if (route.type === 'direct') {
-    return [{ name: destinationName, stops: route.stops, alarmType: 'destination' }];
+    return [{ name: destinationName, stops: route.stops, alarmType: 'destination', approachLine: route.line }];
   }
 
   if (route.type === 'transfer') {
     if (isSameStationName(route.transferName, destinationName)) {
-      return [{ name: destinationName, stops: route.stopsToTransfer, alarmType: 'destination' }];
+      return [{ name: destinationName, stops: route.stopsToTransfer, alarmType: 'destination', approachLine: route.fromLine }];
     }
     return [
-      { name: route.transferName, stops: route.stopsToTransfer, alarmType: 'transfer' },
-      { name: destinationName, stops: route.stopsFromTransfer, alarmType: 'destination' },
+      { name: route.transferName, stops: route.stopsToTransfer, alarmType: 'transfer', approachLine: route.fromLine },
+      { name: destinationName, stops: route.stopsFromTransfer, alarmType: 'destination', approachLine: route.toLine },
     ];
   }
 
@@ -51,14 +57,21 @@ export function resolveAllTargets(
     return {
       name: isDestination ? destinationName : t.transferName,
       stops: t.stopsToTransfer,
-      alarmType: isDestination ? 'destination' : 'transfer',
+      alarmType: isDestination ? ('destination' as const) : ('transfer' as const),
+      approachLine: t.fromLine,
     };
   });
   // MultiTransferRoute는 최소 2개 transfer로 구성되므로 targets는 항상 비어있지 않음.
-  const lastName = targets.at(-1)!.name;
+  const lastTransfer = route.transfers[route.transfers.length - 1];
+  const lastName = targets[targets.length - 1].name;
   const lastTransferIsDestination = isSameStationName(lastName, destinationName);
   if (!lastTransferIsDestination) {
-    targets.push({ name: destinationName, stops: route.stopsAfterLastTransfer, alarmType: 'destination' });
+    targets.push({
+      name: destinationName,
+      stops: route.stopsAfterLastTransfer,
+      alarmType: 'destination',
+      approachLine: lastTransfer.toLine,
+    });
   }
   return targets;
 }
@@ -67,6 +80,10 @@ export interface AlarmSource {
   route: Route;
   destinationName: string;
   etaSeconds: number | null;
+  // 사용자가 실제로 탑승 중인 노선 (nearestStation.line). #579 회귀 방지:
+  // approachLine이 일치하는 웨이포인트만 phase 평가 대상이 된다.
+  // GPS 미확정 등으로 노선을 알 수 없을 때만 명시적으로 null을 전달 — 모든 leg 평가가 skip된다.
+  currentLine: LineNumber | null;
 }
 
 /**
@@ -74,9 +91,11 @@ export interface AlarmSource {
  *
  * - etaSeconds는 최종 목적지 웨이포인트에만 적용된다 (GPS 거리 산출이 도착역 기준이므로).
  *   환승역은 정거장 수 기반(early) 으로만 평가된다.
- * - 어느 phase도 발사되지 않은 fresh 웨이포인트에서 트리거가 없으면 null을 반환한다.
- *   이미 한 번이라도 발사된 웨이포인트는 통과한 것으로 간주하고 다음으로 진행한다.
- *   환승 전 도착역 알람이 먼저 울리는 것을 막는다 (#152 회귀 방지).
+ * - currentLine(#579) approachLine이 일치하는 웨이포인트만 평가한다.
+ *   환승 전인데 다음 leg의 stopsFromTransfer가 작아서 도착역 알람이 먼저 울리는 회귀(#579)와
+ *   환승 전 도착역 알람이 먼저 울리는 회귀(#152)를 동시에 차단한다.
+ * - currentLine이 null이거나 어느 leg와도 일치하지 않으면 알람을 발사하지 않는다 (silent skip).
+ *   다음 GPS fix에서 leg가 일치하면 그때 발사된다.
  */
 export function evaluateAlarmPhase(
   source: AlarmSource,
@@ -84,13 +103,16 @@ export function evaluateAlarmPhase(
   phases: AlarmPhase[] = ALARM_PHASES,
 ): AlarmEvent | null {
   if (!source.route) return null;
+  const { currentLine } = source;
+  if (currentLine == null) return null;
 
   const targets = resolveAllTargets(source.route, source.destinationName);
 
   for (let i = 0; i < targets.length; i++) {
     const target = targets[i];
-    const isFinal = i === targets.length - 1;
+    if (target.approachLine !== currentLine) continue;
 
+    const isFinal = i === targets.length - 1;
     const context: AlarmContext = {
       remainingStops: target.stops,
       etaSeconds: isFinal ? source.etaSeconds : null,
@@ -102,9 +124,9 @@ export function evaluateAlarmPhase(
       if (!phase.evaluate(context)) continue;
       return { phaseId: phase.id, type: target.alarmType, stationName: target.name };
     }
-
-    const anyFired = phases.some((p) => firedAlarms.has(`${p.id}:${target.name}`));
-    if (!anyFired) return null;
+    // 매칭된 leg는 현재 사용자가 탑승 중인 구간 — 발사 조건 미달이면 다음 leg를 평가하지 않는다.
+    // 다음 leg는 user가 그 leg의 approachLine으로 이동한 다음 tick에 평가된다.
+    return null;
   }
 
   return null;

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -141,7 +141,12 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   const etaSeconds = estimateEtaSeconds(distanceToDestM, speedMps);
 
   const alarmEvent = evaluateAlarmPhase(
-    { route, destinationName: destination.name, etaSeconds },
+    {
+      route,
+      destinationName: destination.name,
+      etaSeconds,
+      currentLine: nearest.station.line,
+    },
     firedAlarms,
   );
 


### PR DESCRIPTION
## 문제
trip 등록 4분 만에 `destination/early` 오발화 (용마산→성수, 환승 1회 시나리오).

```
8:30:13  trip 등록 (용마산 → 성수, 환승 1회)
8:34:18  fg | fired | destination | early | 성수  ← 4분 만에 발사
```

## 원인
`evaluateAlarmPhase`가 `anyFired` 게이트로 leg 진행을 추정. transfer/early 발사 직후 같은 tick에서 `targets[1]`(destination)으로 진행하는데, `stopsFromTransfer=1`(건대입구→성수=1정거장)이라 destination/early가 즉시 평가 성공 → 사용자가 line 7에서 환승하지 않은 상태로 발사.

## 수정
- `CurrentTarget`에 `approachLine`(웨이포인트로 가는 leg의 노선) 추가
- `AlarmSource.currentLine`(=`nearestStation.line`) 추가
- `evaluateAlarmPhase`: `approachLine === currentLine`인 leg만 phase 평가. 매칭 안 되면 silent skip. 다음 GPS fix에서 user가 다른 leg로 이동하면 그때 평가.
- 기존 `anyFired` 누적 게이트 제거 — line 매칭으로 정합성 보장 + GPS 노이즈로 fired set이 오염돼도 회복 가능 (stateless).

## 검증
- [x] 회귀 테스트: 환승 전(fromLine) 위치에서 `stopsFromTransfer<=1`이어도 destination 미발사
- [x] toLine 이동 후 destination/early 정상 발사
- [x] currentLine이 null/제3노선이면 silent skip
- [x] multi-transfer 3-leg journey 시퀀셜 발사 (currentLine 전이)
- [x] 1887 tests passing, 100% coverage
- [x] tsc clean

Closes #579