### PR TITLE
docs(#582): Channel 3 (Region Monitoring) 공식 폐기 — ADR-007

### DIFF
--- a/docs/decisions/ADR-007-channel-3-deprecated.md
+++ b/docs/decisions/ADR-007-channel-3-deprecated.md
@@ -1,0 +1,65 @@
+# ADR-007: BG 알람 Channel 3 (Region Monitoring) 공식 폐기
+
+- 상태: Accepted
+- 일자: 2026-05-28
+- 관련 이슈: #563 (PoC 트랙), #582 (본 결정)
+- 관련 메모리: `feedback_whileinuse_must_work`, `project_alarm_sla_architecture`
+
+## 컨텍스트
+
+`bg-alarm-multi-channel-plan.md`(2026-04-x)에서 BG 알람 도달 보장을 위해 4채널 아키텍처를 채택했다. 그 중 **채널 3 (Region Monitoring)** 은 push 채널을 우회해 iOS Location Services의 WiFi/cellular 기반 region 진입 감지를 활용하는 트랙이었다.
+
+#563은 이 채널의 본구현 전 신뢰도 검증 PoC였다.
+
+- 등록 API: `Location.startGeofencingAsync(taskName, regions[])`
+- 사용 권한: WhileInUse (프로젝트 1차 시나리오)
+- 검증 항목: 진입 wake 안정성, 지하 감지율, 환승 재등록 매끄러움
+
+## 실측 결과
+
+`Location.startGeofencingAsync()` 호출 시 SDK 레벨에서 즉시 실패:
+
+```
+state: failed
+count: 0
+error: "Calling the 'startGeofencingAsync' function has failed
+        → Caused by: Background location permission is required
+          to do this operation"
+```
+
+expo-location SDK (= iOS CoreLocation `startMonitoring(for:)`) 가 region 등록 시점에 **Background(Always) location 권한 entitlement를 요구한다.** WhileInUse 권한에서는 API 진입 자체가 거부되며 우회 경로 없음.
+
+진입 wake / 지하 감지율 / 환승 재등록 등 후속 측정 자체가 불가능.
+
+## 결정
+
+**채널 3 (Region Monitoring) 공식 폐기.**
+
+근거:
+1. 프로젝트 정책상 WhileInUse가 1차 시나리오 (메모리 `feedback_whileinuse_must_work`). 다수 사용자가 "사용하는 동안"을 선택하며 Always 권한 강제는 정책 위반.
+2. expo-location / iOS CoreLocation이 region monitoring API에 Background 권한을 강제 → SDK 레벨 우회 불가.
+3. 따라서 WhileInUse 사용자에게 채널 3은 작동할 수 없음 → 본구현 시 도달률 0%.
+
+## 대안 — Channel 3 자리에 들어갈 메인 BG 채널
+
+`project_alarm_sla_architecture` 메모(2026-05-28 결정)에 정합:
+
+| 트랙 | 역할 |
+|---|---|
+| **Local Notification 사전 예약 (BoardingLock + Per-Hop Adaptive Scheduling)** | 메인 BG 채널. OS 스케줄러가 예약 시각에 발사 — 네트워크/푸시 채널과 무관. WhileInUse + 저전력 + 지하 약신호 시나리오까지 커버. |
+| **Live Activity push update** | 보조 — 잠금화면/Dynamic Island 표시 갱신. |
+| 채널 1 (Silent push) | Reschedule 정정 역할로 재정의. |
+| 채널 2 (Alert push fallback) | 사후 fallback 그대로 유지. |
+| 채널 4 (BG GPS task) | Always 사용자 자동 활성, 그대로 유지. |
+
+관련 후속 이슈: #584 (BoardingLock 통합), #585 (Backend per-hop), #586 (Live Activity).
+
+## 영향
+
+- `tasks/bg-alarm-multi-channel-plan.md` 채널 3 섹션 strike-through + Phase 3 폐기 명시 (로컬 워킹 노트, 본 ADR이 최종 SoT).
+- `tasks/region-monitoring-poc-result.md` 본 결정의 원본 실측 데이터 (로컬).
+- PoC 코드(`src/tasks/regionMonitoringPocTask.ts`, `DebugModal` Region PoC 섹션) 정리는 별도 chore 이슈로 분리. 현재 상태에선 dead code이지만, 추후 채널 신뢰도 비교 측정이 필요해질 경우 참고가 될 수 있어 일괄 삭제는 보류.
+
+## Limitations
+
+본 결정은 **현 시점 iOS / expo-location SDK 동작에 기반**한다. Apple이 향후 WhileInUse에서 region monitoring을 허용하도록 정책을 변경하면 재검토 여지가 있다. 그러나 위 1번(WhileInUse 1차 시민 정책)은 외부 변화와 무관하게 유지된다.

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -34,6 +34,18 @@ import {
 import type { FusionConfidence, FusionSource } from '../utils/pickFusedStation';
 import type { NearestStationResult } from '../types/station';
 import { useTheme, spacing, radius, typography } from '../theme';
+import {
+  startRegionMonitoringPoc,
+  stopRegionMonitoringPoc,
+  getRegionPocStatus,
+  type PocRegion,
+} from '../tasks/regionMonitoringPocTask';
+import { findTopNearestStations } from '../utils/findNearestStation';
+
+// #563 PoC — 모니터링할 region 개수와 반경. Apple 권장 최소 100m, 앱당 한계 20개.
+// 5개는 실측 시 환승 1-2회 커버하면서 한계 대비 여유 보유.
+const REGION_POC_COUNT = 5;
+const REGION_POC_RADIUS_M = 150;
 
 function formatTime(ts: number): string {
   const d = new Date(ts);
@@ -277,6 +289,27 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
     getFusionDebugEntries(),
   );
+  // #563 PoC — region 모니터링 상태. start/stop 직후만 갱신(폴링 없음).
+  // 단일 객체 — getRegionPocStatus() 호출 1회로 정렬.
+  const [pocStatus, setPocStatus] = useState(() => getRegionPocStatus());
+
+  const handleRegionPocStart = useCallback(async () => {
+    if (!userLocation) return;
+    const nearest = findTopNearestStations(userLocation.lat, userLocation.lng, REGION_POC_COUNT);
+    const regions: PocRegion[] = nearest.map((r) => ({
+      identifier: r.station.name,
+      latitude: r.station.lat,
+      longitude: r.station.lng,
+      radius: REGION_POC_RADIUS_M,
+    }));
+    await startRegionMonitoringPoc(regions);
+    setPocStatus(getRegionPocStatus());
+  }, [userLocation]);
+
+  const handleRegionPocStop = useCallback(async () => {
+    await stopRegionMonitoringPoc();
+    setPocStatus(getRegionPocStatus());
+  }, []);
 
   useEffect(() => {
     return subscribeFusionDebug(() => setFusionLogs([...getFusionDebugEntries()]));
@@ -454,6 +487,71 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
             {silentPushDiagRows(silentPush).map(({ uiLabel, value }) => (
               <KeyValue key={uiLabel} label={uiLabel} value={value} colors={colors} />
             ))}
+          </Section>
+
+          <Section title="Region PoC (#563)" colors={colors}>
+            <View style={styles.kvRow}>
+              <Text style={[typography.mono, { color: colors.subtle, width: 80 }]}>state</Text>
+              <Text
+                style={[typography.mono, { color: colors.ink, flex: 1 }]}
+                selectable
+                testID="debug-region-poc-state"
+              >
+                {pocStatus.state}
+              </Text>
+            </View>
+            <View style={styles.kvRow}>
+              <Text style={[typography.mono, { color: colors.subtle, width: 80 }]}>count</Text>
+              <Text
+                style={[typography.mono, { color: colors.ink, flex: 1 }]}
+                selectable
+                testID="debug-region-poc-count"
+              >
+                {pocStatus.monitoredCount}
+              </Text>
+            </View>
+            {pocStatus.error && (
+              <View style={styles.kvRow}>
+                <Text style={[typography.mono, { color: colors.subtle, width: 80 }]}>error</Text>
+                <Text
+                  style={[typography.mono, { color: colors.ink, flex: 1 }]}
+                  selectable
+                  testID="debug-region-poc-error"
+                >
+                  {pocStatus.error}
+                </Text>
+              </View>
+            )}
+            <View style={[styles.actions, { marginTop: spacing.sm }]}>
+              <TouchableOpacity
+                style={[
+                  styles.actionButton,
+                  {
+                    borderColor: colors.accent,
+                    opacity: userLocation ? 1 : 0.4,
+                  },
+                ]}
+                onPress={handleRegionPocStart}
+                testID="debug-region-poc-start"
+              >
+                <Text style={[styles.actionText, { color: colors.accent }]}>
+                  Start ({REGION_POC_COUNT} nearest)
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.actionButton, { borderColor: colors.accent }]}
+                onPress={handleRegionPocStop}
+                testID="debug-region-poc-stop"
+              >
+                <Text style={[styles.actionText, { color: colors.accent }]}>Stop</Text>
+              </TouchableOpacity>
+            </View>
+            <Text
+              style={[typography.mono, { color: colors.subtle, marginTop: spacing.sm }]}
+            >
+              iOS Settings에서 BG App Refresh · 저전력 모드를 토글하며 region 진입 wake를 측정.
+              결과는 tasks/region-monitoring-poc-result.md에 누적.
+            </Text>
           </Section>
 
           <Section

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -12,6 +12,10 @@ const mockUseArrivalInfo = jest.fn();
 const mockUseSilentPushDiagnostics = jest.fn();
 const mockGetAlarmLog = jest.fn();
 const mockClearAlarmLog = jest.fn();
+const mockStartRegionPoc = jest.fn();
+const mockStopRegionPoc = jest.fn();
+const mockGetRegionPocStatus = jest.fn();
+const mockFindTopNearestStations = jest.fn();
 
 jest.mock('../../hooks/useFusedNearestStation', () => ({
   useFusedNearestStation: () => mockUseFusedNearestStation(),
@@ -31,6 +35,16 @@ jest.mock('../../utils/alarmLog', () => {
     clearAlarmLog: () => mockClearAlarmLog(),
   };
 });
+// #563 PoC — regionMonitoringPocTask는 모듈 import 시 TaskManager.defineTask를 호출하므로
+// 통째로 mock해 native dep 의존을 차단한다.
+jest.mock('../../tasks/regionMonitoringPocTask', () => ({
+  startRegionMonitoringPoc: (...args: unknown[]) => mockStartRegionPoc(...args),
+  stopRegionMonitoringPoc: () => mockStopRegionPoc(),
+  getRegionPocStatus: () => mockGetRegionPocStatus(),
+}));
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: (...args: unknown[]) => mockFindTopNearestStations(...args),
+}));
 
 const station: Station = {
   id: '2-022',
@@ -95,6 +109,10 @@ const setupHookDefaults = () => {
   });
   mockGetAlarmLog.mockResolvedValue([]);
   mockClearAlarmLog.mockResolvedValue(undefined);
+  mockGetRegionPocStatus.mockReturnValue({ state: 'unknown', error: null, monitoredCount: 0 });
+  mockStartRegionPoc.mockResolvedValue(undefined);
+  mockStopRegionPoc.mockResolvedValue(undefined);
+  mockFindTopNearestStations.mockReturnValue([]);
 };
 
 describe('DebugModal', () => {
@@ -375,6 +393,88 @@ describe('DebugModal', () => {
   it('candidateTrains가 빈 배열이면 "0: -"으로 표시한다', () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} candidateTrains={[]} />);
     expect(screen.getByText('0: -')).toBeTruthy();
+  });
+
+  describe('Region PoC (#563)', () => {
+    it('초기 status는 unknown, count 0, error는 노출되지 않음', () => {
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      expect(screen.getByText('Region PoC (#563)')).toBeTruthy();
+      expect(screen.getByTestId('debug-region-poc-state').props.children).toBe('unknown');
+      expect(screen.getByTestId('debug-region-poc-count').props.children).toBe(0);
+      expect(screen.queryByTestId('debug-region-poc-error')).toBeNull();
+    });
+
+    it('Start 버튼: nearest 5개를 PocRegion으로 변환해 startRegionMonitoringPoc 호출, status 갱신', async () => {
+      mockFindTopNearestStations.mockReturnValue([
+        { station: { ...station, name: 'A', lat: 1, lng: 2 }, distanceKm: 0.1 },
+        { station: { ...station, name: 'B', lat: 3, lng: 4 }, distanceKm: 0.2 },
+      ]);
+      // 마운트 시 1회 + 핸들러 1회 호출. 두 시점 모두 success를 반환.
+      mockGetRegionPocStatus.mockReturnValue({
+        state: 'success',
+        error: null,
+        monitoredCount: 2,
+      });
+
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('debug-region-poc-start'));
+      });
+      expect(mockFindTopNearestStations).toHaveBeenCalledWith(37.5, 127.0, 5);
+      expect(mockStartRegionPoc).toHaveBeenCalledWith([
+        { identifier: 'A', latitude: 1, longitude: 2, radius: 150 },
+        { identifier: 'B', latitude: 3, longitude: 4, radius: 150 },
+      ]);
+      expect(screen.getByTestId('debug-region-poc-state').props.children).toBe('success');
+      expect(screen.getByTestId('debug-region-poc-count').props.children).toBe(2);
+    });
+
+    it('Start 버튼: userLocation 없으면 press해도 early-return — startRegionMonitoringPoc 미호출', async () => {
+      mockUseFusedNearestStation.mockReturnValue({
+        result: null,
+        gpsResult: null,
+        confidence: 'gps-only',
+        source: 'gps',
+        variants: [],
+        userLocation: null,
+        speedMps: null,
+        accuracyMeters: null,
+        loading: false,
+        error: null,
+        permissionDenied: false,
+        refresh: jest.fn(),
+      });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('debug-region-poc-start'));
+      });
+      expect(mockStartRegionPoc).not.toHaveBeenCalled();
+      expect(mockFindTopNearestStations).not.toHaveBeenCalled();
+    });
+
+    it('Stop 버튼: stopRegionMonitoringPoc 호출 + status 갱신', async () => {
+      // 마운트 시 success 노출 → stop 후 unknown으로 전환.
+      mockGetRegionPocStatus
+        .mockReturnValueOnce({ state: 'success', error: null, monitoredCount: 5 })
+        .mockReturnValue({ state: 'unknown', error: null, monitoredCount: 0 });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      expect(screen.getByTestId('debug-region-poc-state').props.children).toBe('success');
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('debug-region-poc-stop'));
+      });
+      expect(mockStopRegionPoc).toHaveBeenCalled();
+      expect(screen.getByTestId('debug-region-poc-state').props.children).toBe('unknown');
+    });
+
+    it('error가 있으면 error 라벨이 노출된다', () => {
+      mockGetRegionPocStatus.mockReturnValue({
+        state: 'failed',
+        error: 'denied',
+        monitoredCount: 0,
+      });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      expect(screen.getByTestId('debug-region-poc-error').props.children).toBe('denied');
+    });
   });
 
   it('unmount 시 AppState listener를 정리한다', async () => {

--- a/src/tasks/__tests__/regionMonitoringPocTask.test.ts
+++ b/src/tasks/__tests__/regionMonitoringPocTask.test.ts
@@ -1,0 +1,209 @@
+// defineTask 콜백을 캡처해 직접 호출(다른 task 테스트와 동일 패턴).
+jest.mock('expo-task-manager', () => ({
+  defineTask: (name: string, callback: Function) => {
+    (global as any).__regionPocTaskCallback = callback;
+    (global as any).__regionPocTaskName = name;
+  },
+}));
+
+const mockStartGeofencing = jest.fn();
+const mockStopGeofencing = jest.fn();
+const mockHasStarted = jest.fn();
+
+jest.mock('expo-location', () => ({
+  GeofencingEventType: { Enter: 1, Exit: 2 },
+  startGeofencingAsync: (...args: unknown[]) => mockStartGeofencing(...args),
+  stopGeofencingAsync: (...args: unknown[]) => mockStopGeofencing(...args),
+  hasStartedGeofencingAsync: (...args: unknown[]) => mockHasStarted(...args),
+}));
+
+const mockLogRegionEntryFired = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  logRegionEntryFired: (...args: unknown[]) => mockLogRegionEntryFired(...args),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import {
+  REGION_POC_TASK,
+  startRegionMonitoringPoc,
+  stopRegionMonitoringPoc,
+  getRegionPocStatus,
+  __resetRegionPocStatusForTest,
+  type PocRegion,
+} from '../regionMonitoringPocTask';
+
+const region: PocRegion = {
+  identifier: '강남',
+  latitude: 37.498,
+  longitude: 127.028,
+  radius: 150,
+};
+
+function getTaskCallback(): (body: unknown) => Promise<void> {
+  return (global as any).__regionPocTaskCallback;
+}
+
+describe('regionMonitoringPocTask (#563 PoC)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetRegionPocStatusForTest();
+  });
+
+  it('defineTask가 REGION_POC_TASK 이름으로 등록된다', () => {
+    expect((global as any).__regionPocTaskName).toBe(REGION_POC_TASK);
+    expect(typeof getTaskCallback()).toBe('function');
+  });
+
+  it('초기 status는 unknown / error null / monitoredCount 0', () => {
+    expect(getRegionPocStatus()).toEqual({
+      state: 'unknown',
+      error: null,
+      monitoredCount: 0,
+    });
+  });
+
+  it('__resetRegionPocStatusForTest가 success 상태를 unknown으로 되돌린다', async () => {
+    mockStartGeofencing.mockResolvedValueOnce(undefined);
+    await startRegionMonitoringPoc([region]);
+    expect(getRegionPocStatus().state).toBe('success');
+    __resetRegionPocStatusForTest();
+    expect(getRegionPocStatus()).toEqual({
+      state: 'unknown',
+      error: null,
+      monitoredCount: 0,
+    });
+  });
+
+  describe('task callback', () => {
+    it('error 페이로드면 조기 종료(throw 없음)', async () => {
+      await expect(
+        getTaskCallback()({ error: { message: 'boom' }, data: null }),
+      ).resolves.toBeUndefined();
+      expect(mockLogRegionEntryFired).not.toHaveBeenCalled();
+    });
+
+    it('data 없으면 조기 종료', async () => {
+      await getTaskCallback()({ data: null });
+      expect(mockLogRegionEntryFired).not.toHaveBeenCalled();
+    });
+
+    it('Enter 이벤트면 logRegionEntryFired를 호출한다', async () => {
+      await getTaskCallback()({
+        data: { eventType: 1, region: { identifier: '강남' } },
+      });
+      expect(mockLogRegionEntryFired).toHaveBeenCalledWith({
+        stationName: '강남',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('Enter 이벤트인데 region.identifier가 없으면 (unknown)으로 적재한다', async () => {
+      await getTaskCallback()({
+        data: { eventType: 1, region: {} },
+      });
+      expect(mockLogRegionEntryFired).toHaveBeenCalledWith({
+        stationName: '(unknown)',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('Exit 이벤트는 alarmLog에 적재하지 않는다(source 없음)', async () => {
+      await getTaskCallback()({
+        data: { eventType: 2, region: { identifier: '강남' } },
+      });
+      expect(mockLogRegionEntryFired).not.toHaveBeenCalled();
+    });
+
+    it('알 수 없는 eventType은 무시한다', async () => {
+      await getTaskCallback()({
+        data: { eventType: 99, region: { identifier: '강남' } },
+      });
+      expect(mockLogRegionEntryFired).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('startRegionMonitoringPoc', () => {
+    it('startGeofencingAsync로 region 목록을 전달하고 status=success로 갱신', async () => {
+      mockStartGeofencing.mockResolvedValueOnce(undefined);
+      await startRegionMonitoringPoc([region]);
+      expect(mockStartGeofencing).toHaveBeenCalledWith(REGION_POC_TASK, [
+        {
+          identifier: '강남',
+          latitude: 37.498,
+          longitude: 127.028,
+          radius: 150,
+          notifyOnEnter: true,
+          notifyOnExit: true,
+        },
+      ]);
+      expect(getRegionPocStatus()).toEqual({
+        state: 'success',
+        error: null,
+        monitoredCount: 1,
+      });
+    });
+
+    it('startGeofencingAsync 실패 시 Error 메시지를 status.error에 담는다', async () => {
+      mockStartGeofencing.mockRejectedValueOnce(new Error('denied'));
+      await startRegionMonitoringPoc([region]);
+      expect(getRegionPocStatus()).toEqual({
+        state: 'failed',
+        error: 'denied',
+        monitoredCount: 0,
+      });
+    });
+
+    it('startGeofencingAsync 실패 시 Error가 아닌 값도 문자열로 포착', async () => {
+      mockStartGeofencing.mockRejectedValueOnce('plain-string-error');
+      await startRegionMonitoringPoc([region]);
+      expect(getRegionPocStatus().error).toBe('plain-string-error');
+    });
+  });
+
+  describe('stopRegionMonitoringPoc', () => {
+    it('running=true면 stopGeofencingAsync를 호출하고 status를 reset', async () => {
+      mockHasStarted.mockResolvedValueOnce(true);
+      mockStopGeofencing.mockResolvedValueOnce(undefined);
+      await stopRegionMonitoringPoc();
+      expect(mockStopGeofencing).toHaveBeenCalledWith(REGION_POC_TASK);
+      expect(getRegionPocStatus()).toEqual({
+        state: 'unknown',
+        error: null,
+        monitoredCount: 0,
+      });
+    });
+
+    it('running=false면 stop을 호출하지 않는다', async () => {
+      mockHasStarted.mockResolvedValueOnce(false);
+      await stopRegionMonitoringPoc();
+      expect(mockStopGeofencing).not.toHaveBeenCalled();
+    });
+
+    it('stop 중 실패 시 status.error에 담는다', async () => {
+      mockHasStarted.mockResolvedValueOnce(true);
+      mockStopGeofencing.mockRejectedValueOnce(new Error('stop-boom'));
+      await stopRegionMonitoringPoc();
+      expect(getRegionPocStatus()).toEqual({
+        state: 'failed',
+        error: 'stop-boom',
+        monitoredCount: 0,
+      });
+    });
+
+    it('hasStartedGeofencingAsync 실패도 동일 경로로 처리', async () => {
+      mockHasStarted.mockRejectedValueOnce('check-fail');
+      await stopRegionMonitoringPoc();
+      expect(getRegionPocStatus().error).toBe('check-fail');
+    });
+  });
+});

--- a/src/tasks/regionMonitoringPocTask.ts
+++ b/src/tasks/regionMonitoringPocTask.ts
@@ -1,0 +1,132 @@
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+import { createLogger } from '../utils/logger';
+import { logRegionEntryFired } from '../utils/alarmLog';
+
+// #563 PoC — iOS Region Monitoring을 WhileInUse 권한 + BG 진입 wake 환경에서 실측 검증한다.
+// PoC 임시 코드: 채널 3(Region Monitoring) 본구현 진입 전 신뢰도 측정용. 머지하지 않는다.
+//
+// 측정 항목 (issue #563):
+//   1. WhileInUse + BG 상태 진입 wake 안정성
+//   2. 지하 구간 감지율 (iOS WiFi BSSID DB 커버리지)
+//   3. 환승 시 region 재등록 매끄러움
+//   4. 저전력 모드 ON 상태 동작 여부
+//
+// 결과는 `tasks/region-monitoring-poc-result.md`에 누적.
+
+const logger = createLogger('RegionPoc');
+
+export const REGION_POC_TASK = 'region-monitoring-poc-task';
+
+/**
+ * PoC에서 모니터링할 region 1건. iOS는 region.identifier로 enter/exit를 식별하고
+ * 콜백에 identifier만 넘긴다 — caller는 분석을 쉽게 하려면 identifier에 한국어 역명을
+ * 그대로 넣는 것을 권장(예: '강남'). 역 id를 쓸 거면 PoC 분석 시 id↔이름 매핑이 별도 필요.
+ */
+export interface PocRegion {
+  identifier: string;
+  latitude: number;
+  longitude: number;
+  /** iOS 권장 최소 100m. 너무 작으면 지하 구간에서 거의 못 잡는다. */
+  radius: number;
+}
+
+/** Task 콜백에 흘러들어오는 expo-location geofencing 이벤트 페이로드. */
+interface PocEventData {
+  eventType: Location.GeofencingEventType;
+  region: {
+    identifier?: string;
+    latitude?: number;
+    longitude?: number;
+    radius?: number;
+  };
+}
+
+/**
+ * Region 진입/이탈 이벤트 핸들러.
+ * Enter는 production source `region-entry-fired`로 적재(측정 인프라 #564 재사용).
+ * Exit는 alarmLog에 적재할 source가 없어 logger.info로만 남긴다 — PoC 종료 후 console.app/Xcode에서 회수.
+ */
+async function handleRegionEvent({ data, error }: TaskManager.TaskManagerTaskBody<PocEventData>): Promise<void> {
+  if (error) {
+    logger.error('region task error:', error.message);
+    return;
+  }
+  if (!data) return;
+
+  const { eventType, region } = data;
+  const stationName = region.identifier ?? '(unknown)';
+  if (eventType === Location.GeofencingEventType.Enter) {
+    logger.info('region enter:', stationName);
+    logRegionEntryFired({ stationName, kind: 'station-passed', phaseId: 'imminent' });
+    return;
+  }
+  if (eventType === Location.GeofencingEventType.Exit) {
+    logger.info('region exit:', stationName);
+    return;
+  }
+  logger.warn('unknown region eventType:', eventType);
+}
+
+TaskManager.defineTask(REGION_POC_TASK, handleRegionEvent);
+
+// ── 등록 상태 추적 — DebugModal/진단용 (silent push 패턴 답습) ──
+export type PocRegistrationState = 'unknown' | 'success' | 'failed';
+interface PocStatus {
+  state: PocRegistrationState;
+  error: string | null;
+  monitoredCount: number;
+}
+let pocStatus: PocStatus = { state: 'unknown', error: null, monitoredCount: 0 };
+
+export function getRegionPocStatus(): PocStatus {
+  return pocStatus;
+}
+
+/** 테스트 격리용 — production code에선 호출 금지. */
+export function __resetRegionPocStatusForTest(): void {
+  pocStatus = { state: 'unknown', error: null, monitoredCount: 0 };
+}
+
+/**
+ * PoC region 모니터링을 시작한다.
+ * iOS 앱당 region 20개 한계 — caller가 5개 정도로 제한하는 것을 권장(여유 두고 측정).
+ */
+export async function startRegionMonitoringPoc(regions: readonly PocRegion[]): Promise<void> {
+  try {
+    await Location.startGeofencingAsync(
+      REGION_POC_TASK,
+      regions.map((r) => ({
+        identifier: r.identifier,
+        latitude: r.latitude,
+        longitude: r.longitude,
+        radius: r.radius,
+        // PoC 핵심 — Enter/Exit 모두 받아 분석.
+        notifyOnEnter: true,
+        notifyOnExit: true,
+      })),
+    );
+    pocStatus = { state: 'success', error: null, monitoredCount: regions.length };
+    logger.info(`region PoC started: ${regions.length} regions`);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    pocStatus = { state: 'failed', error: message, monitoredCount: 0 };
+    logger.warn('region PoC start failed:', e);
+  }
+}
+
+/** PoC region 모니터링을 중단한다(앱 재시작/PoC 종료 시 호출). */
+export async function stopRegionMonitoringPoc(): Promise<void> {
+  try {
+    const running = await Location.hasStartedGeofencingAsync(REGION_POC_TASK);
+    if (running) {
+      await Location.stopGeofencingAsync(REGION_POC_TASK);
+    }
+    pocStatus = { state: 'unknown', error: null, monitoredCount: 0 };
+    logger.info('region PoC stopped');
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    pocStatus = { state: 'failed', error: message, monitoredCount: 0 };
+    logger.warn('region PoC stop failed:', e);
+  }
+}


### PR DESCRIPTION
## 배경
#563 Region Monitoring PoC 실기기 검증 결과, `Location.startGeofencingAsync()`가 WhileInUse 권한에서 SDK 레벨로 실패:

\`\`\`
state: failed
error: "Background location permission is required to do this operation"
\`\`\`

iOS CoreLocation의 region monitoring API는 Always 권한 entitlement를 강제. WhileInUse가 1차 시민 정책이므로 채널 3은 작동 불가.

## 변경 사항
- **ADR-007** 추가: Channel 3 공식 폐기 결정 문서화 + 대안(BoardingLock 사전 예약, #584/#585/#586) 명시.
- 로컬 워킹 노트(`tasks/region-monitoring-poc-result.md`, `tasks/bg-alarm-multi-channel-plan.md`)는 별도 업데이트 (gitignored).

## 정리 범위 (의도적 비포함)
- PoC 코드(`src/tasks/regionMonitoringPocTask.ts`, DebugModal Region PoC 섹션) 삭제는 별도 chore 이슈로 분리. 추후 채널 비교 측정 시 참고 가능성 있어 일괄 삭제 보류.

## 검증
- [x] 1903 tests passing
- [x] tsc clean

Closes #582