### PR TITLE
fix(#580): phase alarm dedup 관찰성 + hydration race 진단 로깅

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -57,11 +57,15 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 );
 
 const mockLogFiredAlarm = jest.fn();
+const mockLogFiredAlarmsHydrate = jest.fn();
 const mockLogFiredStationPassed = jest.fn();
+const mockLogSuppressedDedupAlarm = jest.fn();
 const mockLogSuppressedDedupStation = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
+  logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
+  logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
   logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
 }));
 
@@ -281,6 +285,8 @@ describe('useStationAlarm', () => {
           etaSeconds: expect.any(Number),
         }),
         expect.any(Set),
+        undefined,
+        expect.any(Array),
       ),
     );
   });
@@ -296,6 +302,8 @@ describe('useStationAlarm', () => {
       expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
         expect.objectContaining({ etaSeconds: null }),
         expect.any(Set),
+        undefined,
+        expect.any(Array),
       ),
     );
   });
@@ -307,6 +315,8 @@ describe('useStationAlarm', () => {
       expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
         expect.objectContaining({ etaSeconds: null }),
         expect.any(Set),
+        undefined,
+        expect.any(Array),
       ),
     );
   });
@@ -1227,6 +1237,46 @@ describe('useStationAlarm', () => {
           'routeProgress',
         ),
       );
+    });
+  });
+
+  describe('phase alarm dedup 로깅 (#580)', () => {
+    it('하이드레이션 완료 시 destinationId + size로 logFiredAlarmsHydrate 호출', async () => {
+      const stored = new Set(['early:강남']);
+      mockGetFiredAlarms.mockResolvedValueOnce(stored);
+      renderHook(() => useStationAlarm(defaultInputs({ destination })));
+      await waitFor(() =>
+        expect(mockLogFiredAlarmsHydrate).toHaveBeenCalledWith(destination.id, 1),
+      );
+    });
+
+    it('evaluateAlarmPhase가 suppressedOut에 push한 이벤트마다 logSuppressedDedupAlarm 호출', async () => {
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const suppressedEvent: AlarmEvent = {
+        phaseId: 'early',
+        type: 'destination',
+        stationName: '강남',
+      };
+      mockEvaluateAlarmPhase.mockImplementation(
+        (_src: unknown, _fired: unknown, _phases: unknown, suppressed: AlarmEvent[]) => {
+          suppressed.push(suppressedEvent);
+          return null;
+        },
+      );
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+          }),
+        ),
+      );
+      await waitFor(() =>
+        expect(mockLogSuppressedDedupAlarm).toHaveBeenCalledWith('fg', suppressedEvent),
+      );
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -19,7 +19,9 @@ import {
 import { awaitInitialScheduledAlarmDrain } from '../utils/scheduledAlarmReceiver';
 import {
   logFiredAlarm,
+  logFiredAlarmsHydrate,
   logFiredStationPassed,
+  logSuppressedDedupAlarm,
   logSuppressedDedupStation,
 } from '../utils/alarmLog';
 import { useAppStore } from '../store/useAppStore';
@@ -126,6 +128,8 @@ export function useStationAlarm({
       const stored = await getFiredAlarms(destinationId);
       if (cancelled) return;
       firedAlarmsRef.current = stored;
+      // #580: hydration 시점 진단 — 같은 destinationId에서 size가 다시 0으로 떨어지면 storage race.
+      logFiredAlarmsHydrate(destinationId, stored.size);
       setFiredHydrated(true);
     })();
     return () => {
@@ -188,6 +192,7 @@ export function useStationAlarm({
       etaSeconds = estimateEtaSeconds(distM, speedMps);
     }
 
+    const suppressed: AlarmEvent[] = [];
     const rawEvent = evaluateAlarmPhase(
       {
         route,
@@ -196,7 +201,10 @@ export function useStationAlarm({
         currentLine: nearestStation?.line ?? null,
       },
       firedAlarmsRef.current,
+      undefined,
+      suppressed,
     );
+    for (const event of suppressed) logSuppressedDedupAlarm('fg', event);
     if (rawEvent) fireAndLog(rawEvent, 'eta', route, destination);
   }, [
     route,

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -6,6 +6,8 @@ import {
   logFiredAlarm,
   logFiredStationPassed,
   logScheduledAlarm,
+  logFiredAlarmsHydrate,
+  logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedGate,
   logSilentPushReceived,
@@ -227,6 +229,49 @@ describe('alarmLog', () => {
         reason: 'dedup-station',
         stationName: station.name,
         kind: 'station-passed',
+      });
+    });
+
+    it('logSuppressedDedupAlarm: reason=dedup-alarm, phase+type+stationName 적재 (#580)', async () => {
+      logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dedup-alarm',
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'early',
+      });
+    });
+
+    it('logFiredAlarmsHydrate: destinationId + firedAlarmsCount 적재 (#580 race 진단)', async () => {
+      logFiredAlarmsHydrate('dest-1', 2);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg-hydrate',
+        outcome: 'received',
+        destinationId: 'dest-1',
+        firedAlarmsCount: 2,
+      });
+    });
+
+    it('logFiredAlarmsHydrate: destinationId=null도 그대로 기록', async () => {
+      logFiredAlarmsHydrate(null, 0);
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg-hydrate',
+        destinationId: null,
+        firedAlarmsCount: 0,
       });
     });
 

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -351,6 +351,40 @@ describe('evaluateAlarmPhase', () => {
     });
   });
 
+  describe('suppressedOut out-param (#580)', () => {
+    it('phase 조건은 만족했지만 firedAlarms로 dedup된 이벤트를 suppressedOut에 push', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const fired = new Set(['early:강남']);
+      const suppressed: AlarmEvent[] = [];
+      const event = evaluateAlarmPhase(
+        source({ route, destinationName: '강남' }),
+        fired,
+        undefined,
+        suppressed,
+      );
+      expect(event).toBeNull();
+      expect(suppressed).toEqual([
+        { phaseId: 'early', type: 'destination', stationName: '강남' },
+      ]);
+    });
+
+    it('phase 조건 미충족이면 dedup이어도 suppressedOut에 적재하지 않음 (노이즈 제거)', () => {
+      // stops=2 → early(stops<=1) 미충족. firedAlarms에 있어도 phase가 조건 미만이라 적재 안 함.
+      const route: DirectRoute = { type: 'direct', stops: 2, line: '2' };
+      const fired = new Set(['early:강남']);
+      const suppressed: AlarmEvent[] = [];
+      evaluateAlarmPhase(source({ route, destinationName: '강남' }), fired, undefined, suppressed);
+      expect(suppressed).toEqual([]);
+    });
+
+    it('suppressedOut 미전달 시 dedup은 silent (이전 동작)', () => {
+      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const fired = new Set(['early:강남']);
+      // suppressedOut 인자 생략 — 예외 없이 null 반환.
+      expect(evaluateAlarmPhase(source({ route, destinationName: '강남' }), fired)).toBeNull();
+    });
+  });
+
   describe('custom phases', () => {
     it('accepts a custom phase array', () => {
       const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -125,6 +125,8 @@ describe('processLocationUpdate', () => {
         etaSeconds: expect.any(Number),
       }),
       expect.any(Set),
+      undefined,
+      expect.any(Array),
     );
   });
 
@@ -137,6 +139,8 @@ describe('processLocationUpdate', () => {
     expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
       expect.objectContaining({ etaSeconds: null }),
       expect.any(Set),
+      undefined,
+      expect.any(Array),
     );
   });
 

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -28,15 +28,19 @@ export type AlarmLogSource =
   | 'silent-push-skipped'
   | 'alert-fallback-fired'
   | 'region-entry-fired'
-  | 'region-entry-skipped';
+  | 'region-entry-skipped'
+  // #580: useStationAlarm 하이드레이션 1회당 1엔트리. destinationId + 복원된 fired set 크기 기록.
+  // 두 번째 fire 직전에 ref가 비워졌는지 직접 관찰 — race 가설 확인용.
+  | 'fg-hydrate';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
-// 'dedup-alarm'(evaluateAlarmPhase의 firedAlarms 적중 케이스)은 후속 이슈에서 추가.
-// 그때까지 union에 선언하지 않아 "구현됐다"는 거짓 시그널을 피한다.
+// 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
+// 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
 // 'gate-unknown-station' / 'gate-no-location' / 'gate-stale-location' / 'gate-out-of-range'는
 // #478 PR 1-2 silent push 위치 게이트 skip 사유.
 // 'payload-missing-kind'는 구 백엔드 payload에 kind 필드가 없어 발사 본문 결정 불가 → skip.
 export type AlarmLogReason =
   | 'dedup-station'
+  | 'dedup-alarm'
   | 'gate-age'
   | 'gate-accuracy'
   | 'gate-jump'
@@ -107,6 +111,9 @@ export interface AlarmLogEntry {
   thresholdM?: number;
   locationSource?: 'cache' | 'fresh';
   locationAgeMs?: number;
+  // #580: fg-hydrate 엔트리 — destinationId + 복원된 fired set 크기.
+  destinationId?: string | null;
+  firedAlarmsCount?: number;
 }
 
 const logger = createLogger('AlarmLog');
@@ -171,6 +178,43 @@ export function logSuppressedDedupStation(source: AlarmLogSource, station: Stati
     reason: 'dedup-station',
     stationName: station.name,
     kind: 'station-passed',
+  });
+}
+
+/**
+ * #580: useStationAlarm 하이드레이션 1회당 1엔트리. dedup race 진단용.
+ *
+ * 두 번째 fire 발생 시점 직전에 ref가 비워졌는지(=fired set이 비어있었는지) 직접 관찰한다.
+ * 정상 동작: 하이드레이션 후 firedAlarmsCount는 이전 trip의 fired 누적치(>0)이거나 0(새 trip).
+ * 회귀 패턴: fire 이후 destinationId 변동 없이 다시 0이 찍히면 storage write 손실/race 정황.
+ */
+export function logFiredAlarmsHydrate(destinationId: string | null, firedAlarmsCount: number): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source: 'fg-hydrate',
+    outcome: 'received',
+    destinationId,
+    firedAlarmsCount,
+  });
+}
+
+/**
+ * #580: phase alarm dedup 적중 1건 적재. destination/transfer phase가 firedAlarms로
+ * 이미 발화된 것을 evaluateAlarmPhase가 인지해 재발화하지 않을 때 호출.
+ * 발사 횟수 vs dedup 횟수 비율로 dedup이 정상 동작 중인지 운영 데이터로 확인 가능.
+ */
+export function logSuppressedDedupAlarm(
+  source: AlarmLogSource,
+  event: Pick<AlarmEvent, 'phaseId' | 'type' | 'stationName'>,
+): void {
+  void appendAlarmLog({
+    ts: Date.now(),
+    source,
+    outcome: 'suppressed',
+    reason: 'dedup-alarm',
+    stationName: event.stationName,
+    kind: event.type,
+    phaseId: event.phaseId,
   });
 }
 

--- a/src/utils/stationAlarm.ts
+++ b/src/utils/stationAlarm.ts
@@ -96,11 +96,15 @@ export interface AlarmSource {
  *   환승 전 도착역 알람이 먼저 울리는 회귀(#152)를 동시에 차단한다.
  * - currentLine이 null이거나 어느 leg와도 일치하지 않으면 알람을 발사하지 않는다 (silent skip).
  *   다음 GPS fix에서 leg가 일치하면 그때 발사된다.
+ * - #580 옵셔널 out-param `suppressedOut`: phase 조건은 만족했으나 firedAlarms로 dedup된 이벤트를
+ *   배열에 push. caller가 alarmLog에 'dedup-alarm' 엔트리를 적재해 dedup 동작을 관찰 가능하게 한다.
+ *   미전달이면 dedup은 silent (이전 동작 유지).
  */
 export function evaluateAlarmPhase(
   source: AlarmSource,
   firedAlarms: Set<string>,
   phases: AlarmPhase[] = ALARM_PHASES,
+  suppressedOut?: AlarmEvent[],
 ): AlarmEvent | null {
   if (!source.route) return null;
   const { currentLine } = source;
@@ -120,7 +124,14 @@ export function evaluateAlarmPhase(
 
     for (const phase of phases) {
       const key = `${phase.id}:${target.name}`;
-      if (firedAlarms.has(key)) continue;
+      if (firedAlarms.has(key)) {
+        // dedup hit. phase 조건도 만족했을 때만 suppressed로 적재 — "조건 미충족이지만 dedup된"
+        // 케이스(예: imminent eta>10s)는 노이즈라 기록하지 않는다.
+        if (suppressedOut && phase.evaluate(context)) {
+          suppressedOut.push({ phaseId: phase.id, type: target.alarmType, stationName: target.name });
+        }
+        continue;
+      }
       if (!phase.evaluate(context)) continue;
       return { phaseId: phase.id, type: target.alarmType, stationName: target.name };
     }

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -7,6 +7,7 @@ import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificati
 import {
   logFiredAlarm,
   logFiredStationPassed,
+  logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   type AlarmLogSource,
 } from './alarmLog';
@@ -140,6 +141,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   const distanceToDestM = distanceMetersBetween(lat, lng, destination.lat, destination.lng);
   const etaSeconds = estimateEtaSeconds(distanceToDestM, speedMps);
 
+  const suppressed: AlarmEvent[] = [];
   const alarmEvent = evaluateAlarmPhase(
     {
       route,
@@ -148,7 +150,11 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       currentLine: nearest.station.line,
     },
     firedAlarms,
+    undefined,
+    suppressed,
   );
+
+  for (const event of suppressed) logSuppressedDedupAlarm(source, event);
 
   if (alarmEvent) {
     await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);


### PR DESCRIPTION
## 배경
2026-05-28 출근 trip에서 destination/early가 두 번 발사 (8:34:18, 8:41:29). 사용자 가설: alarmKey가 kind를 빼고 있음 → \`${kind}:${phase ?? 'none'}:${stationName}\` 형식으로 통일.

## 진단
alarmKey 형식 자체는 \`${phase}:${station}\` 으로 이미 unique (같은 stationName+phase는 collision 없음). 실제 root cause는 **firedAlarmsRef가 재발사 직전에 리셋된 정황** — 가능 원인:
- 컴포넌트 unmount/remount + AsyncStorage write race로 storage 미반영 상태에서 hydrate
- destinationId 일시 null → 복원 시 빈 set으로 하이드레이션

key 형식 변경은 storage migration 위험만 안고 실제 race는 못 잡음 → **관찰성 우선 채택**.

## 변경
1. **dedup 관찰성** — \`evaluateAlarmPhase\`에 옵셔널 \`suppressedOut: AlarmEvent[]\` out-param 추가. dedup hit 시 push. 호출부(useStationAlarm / stationPipeline)에서 \`logSuppressedDedupAlarm\`으로 적재.
2. **hydration 진단** — \`logFiredAlarmsHydrate(destinationId, size)\` 추가. 하이드레이션 1회당 1엔트리. **같은 destinationId에서 size가 다시 0으로 떨어지는 케이스가 보이면 storage race**.
3. \`AlarmLogReason\`에 \`'dedup-alarm'\`, \`AlarmLogSource\`에 \`'fg-hydrate'\` 추가. \`AlarmLogEntry\`에 \`destinationId\`, \`firedAlarmsCount\` 필드 추가.

## 의도적 비포함
- alarmKey 형식 변경 — 사용자 가설보다 보수적. 형식 변경 없이 race 진단 우선.
- station-passed 통합 — 별도 메커니즘(lastNotifiedStationId) 그대로.

## 검증
- [x] 1916 tests pass, 100% coverage, tsc clean
- [x] evaluateAlarmPhase: suppressedOut push / 미전달 시 silent 동작 / 조건 미충족 시 적재 안 함
- [x] useStationAlarm: 하이드레이션 + dedup 로깅 단위 테스트
- [x] alarmLog: 새 helper 둘 다 직접 테스트

## 후속 (이번 PR 후 데이터 수집 후 별도 fix 이슈)
- 다음 trip 디버그 dump에서 \`fg-hydrate\` 엔트리 + \`fired\` 시점 비교 → race 패턴 확인 시 storage write를 await로 동기화하는 fix.

Closes #580