### PR TITLE
feat(#584): PR A — BoardingLock 데이터 모델 + store

### DIFF
--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -30,3 +30,6 @@ export const BG_LAST_FIX_KEY = 'subway-now:bg-last-fix';
 // #574 P2e — 디바이스가 fire한 silent push의 pushId 집합. alert fallback race 시 중복 표시 차단.
 // 형식: {"[pushId]": timestamp} JSON. 5분 이상 된 항목은 add/read 시 cleanup.
 export const FIRED_PUSH_IDS_KEY = 'subway-now:fired-push-ids';
+// #584 PR A — 사용자가 명시적으로 확정한 탑승 열차/노선/시각. trip 종료 또는 자동 만료까지 유지.
+// 형식: BoardingLock JSON (src/types/boardingLock.ts).
+export const BOARDING_LOCK_KEY = 'subway-now:boarding-lock';

--- a/src/store/__tests__/useBoardingLockStore.test.ts
+++ b/src/store/__tests__/useBoardingLockStore.test.ts
@@ -1,0 +1,122 @@
+import { act } from '@testing-library/react-native';
+import { useBoardingLockStore } from '../useBoardingLockStore';
+import type { BoardingLock } from '../../types/boardingLock';
+
+const mockGetBoardingLock = jest.fn();
+const mockSetBoardingLock = jest.fn();
+const mockClearBoardingLock = jest.fn();
+
+jest.mock('../../utils/boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+  setBoardingLock: (...args: unknown[]) => mockSetBoardingLock(...args),
+  clearBoardingLock: (...args: unknown[]) => mockClearBoardingLock(...args),
+}));
+
+const sample: BoardingLock = {
+  destinationId: 'dest-1',
+  trainCode: 'T-100',
+  boardingStationId: 'stn-A',
+  boardingLine: '2',
+  boardedAt: 1_000_000,
+  expectedDurationMs: 600_000,
+};
+
+describe('useBoardingLockStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetBoardingLock.mockResolvedValue(undefined);
+    mockClearBoardingLock.mockResolvedValue(undefined);
+    useBoardingLockStore.setState({ lock: null });
+  });
+
+  it('초기 상태는 lock=null', () => {
+    expect(useBoardingLockStore.getState().lock).toBeNull();
+  });
+
+  describe('createLock', () => {
+    it('state + storage 양쪽 갱신', async () => {
+      await act(async () => {
+        await useBoardingLockStore.getState().createLock(sample);
+      });
+      expect(useBoardingLockStore.getState().lock).toEqual(sample);
+      expect(mockSetBoardingLock).toHaveBeenCalledWith(sample);
+    });
+
+    it('기존 Lock을 새 Lock으로 교체 (multi-transfer 전환 대비)', async () => {
+      await act(async () => {
+        await useBoardingLockStore.getState().createLock(sample);
+      });
+      const next: BoardingLock = { ...sample, trainCode: 'T-200', boardingLine: '7' };
+      await act(async () => {
+        await useBoardingLockStore.getState().createLock(next);
+      });
+      expect(useBoardingLockStore.getState().lock).toEqual(next);
+      expect(mockSetBoardingLock).toHaveBeenLastCalledWith(next);
+    });
+  });
+
+  describe('releaseLock', () => {
+    it('state=null + storage 정리', async () => {
+      useBoardingLockStore.setState({ lock: sample });
+      await act(async () => {
+        await useBoardingLockStore.getState().releaseLock();
+      });
+      expect(useBoardingLockStore.getState().lock).toBeNull();
+      expect(mockClearBoardingLock).toHaveBeenCalled();
+    });
+  });
+
+  describe('loadLock', () => {
+    it('storage 값 hydrate', async () => {
+      mockGetBoardingLock.mockResolvedValueOnce(sample);
+      await act(async () => {
+        await useBoardingLockStore.getState().loadLock();
+      });
+      expect(useBoardingLockStore.getState().lock).toEqual(sample);
+    });
+
+    it('storage가 비어있으면 lock=null 유지', async () => {
+      mockGetBoardingLock.mockResolvedValueOnce(null);
+      await act(async () => {
+        await useBoardingLockStore.getState().loadLock();
+      });
+      expect(useBoardingLockStore.getState().lock).toBeNull();
+    });
+  });
+
+  describe('checkExpiry', () => {
+    it('lock 없으면 false (no-op)', async () => {
+      const expired = await useBoardingLockStore.getState().checkExpiry();
+      expect(expired).toBe(false);
+      expect(mockClearBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('미만료면 false + 상태 유지', async () => {
+      useBoardingLockStore.setState({ lock: sample });
+      const expired = await useBoardingLockStore
+        .getState()
+        .checkExpiry(sample.boardedAt + sample.expectedDurationMs);
+      expect(expired).toBe(false);
+      expect(useBoardingLockStore.getState().lock).toEqual(sample);
+    });
+
+    it('만료 시 true 반환 + state/storage 정리', async () => {
+      useBoardingLockStore.setState({ lock: sample });
+      const wayAfter = sample.boardedAt + sample.expectedDurationMs * 2;
+      let expired = false;
+      await act(async () => {
+        expired = await useBoardingLockStore.getState().checkExpiry(wayAfter);
+      });
+      expect(expired).toBe(true);
+      expect(useBoardingLockStore.getState().lock).toBeNull();
+      expect(mockClearBoardingLock).toHaveBeenCalled();
+    });
+
+    it('now 미전달 시 Date.now() 사용', async () => {
+      useBoardingLockStore.setState({ lock: sample });
+      const expired = await useBoardingLockStore.getState().checkExpiry();
+      // sample.boardedAt=1_000_000은 1970년대 초 — 현재 시각이면 항상 만료.
+      expect(expired).toBe(true);
+    });
+  });
+});

--- a/src/store/useBoardingLockStore.ts
+++ b/src/store/useBoardingLockStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand';
+import type { BoardingLock } from '../types/boardingLock';
+import { isBoardingLockExpired } from '../types/boardingLock';
+import {
+  clearBoardingLock,
+  getBoardingLock,
+  setBoardingLock,
+} from '../utils/boardingLockStorage';
+
+/**
+ * BoardingLock 전역 store (#584 PR A).
+ *
+ * Single Lock only — trip 1개에 leg 1개. multi-transfer는 createLock으로 교체(PR E).
+ * 모든 mutation은 in-memory state + AsyncStorage 양쪽 동기 — Fusion/스케줄러가 둘 중 어디든
+ * 읽어도 같은 결과를 얻게 한다.
+ */
+export interface BoardingLockState {
+  lock: BoardingLock | null;
+  /** Trip 진입 또는 환승 전환 시 호출. 기존 Lock은 자동 교체. */
+  createLock: (lock: BoardingLock) => Promise<void>;
+  /** 사용자가 "하차" 탭하거나 trip 종료 시 호출. */
+  releaseLock: () => Promise<void>;
+  /** 앱 마운트 시 storage에서 복원. */
+  loadLock: () => Promise<void>;
+  /**
+   * 자동 만료 확인. 만료 시 lock=null로 상태 갱신 + storage 정리 후 true 반환.
+   * now 인자는 테스트 시각 주입용 — 기본 Date.now().
+   */
+  checkExpiry: (now?: number) => Promise<boolean>;
+}
+
+export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
+  lock: null,
+
+  createLock: async (lock: BoardingLock) => {
+    set({ lock });
+    await setBoardingLock(lock);
+  },
+
+  releaseLock: async () => {
+    set({ lock: null });
+    await clearBoardingLock();
+  },
+
+  loadLock: async () => {
+    const stored = await getBoardingLock();
+    set({ lock: stored });
+  },
+
+  checkExpiry: async (now: number = Date.now()) => {
+    const { lock } = get();
+    if (!lock) return false;
+    if (!isBoardingLockExpired(lock, now)) return false;
+    set({ lock: null });
+    await clearBoardingLock();
+    return true;
+  },
+}));

--- a/src/types/__tests__/boardingLock.test.ts
+++ b/src/types/__tests__/boardingLock.test.ts
@@ -1,0 +1,36 @@
+import {
+  BOARDING_LOCK_EXPIRY_FACTOR,
+  isBoardingLockExpired,
+  type BoardingLock,
+} from '../boardingLock';
+
+function makeLock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: 'dest-1',
+    trainCode: 'T-100',
+    boardingStationId: 'stn-A',
+    boardingLine: '2',
+    boardedAt: 1_000_000,
+    expectedDurationMs: 600_000, // 10분
+    ...overrides,
+  };
+}
+
+describe('isBoardingLockExpired', () => {
+  it('boardedAt 이전 시각이면 만료 아님 (defensive)', () => {
+    const lock = makeLock();
+    expect(isBoardingLockExpired(lock, lock.boardedAt - 1)).toBe(false);
+  });
+
+  it('expectedDurationMs 미만 경과면 만료 아님', () => {
+    const lock = makeLock();
+    expect(isBoardingLockExpired(lock, lock.boardedAt + lock.expectedDurationMs)).toBe(false);
+  });
+
+  it('expectedDurationMs × 1.5 = expiry 경계 (정확히 같으면 아직 만료 아님)', () => {
+    const lock = makeLock();
+    const boundary = lock.boardedAt + lock.expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR;
+    expect(isBoardingLockExpired(lock, boundary)).toBe(false);
+    expect(isBoardingLockExpired(lock, boundary + 1)).toBe(true);
+  });
+});

--- a/src/types/boardingLock.ts
+++ b/src/types/boardingLock.ts
@@ -1,0 +1,32 @@
+import type { LineNumber } from './station';
+
+/**
+ * BoardingLock — 사용자가 명시적으로 탑승한 열차/노선/시각을 확정 (#584).
+ *
+ * GPS 추정의 본질적 부정확성을 보완: 환승역에서 어느 노선/방향인지 불명확한 문제를
+ * 사용자 의지로 lock한다. 이 Lock이 활성인 동안 Fusion은 GPS를 검증 채널로 격하하고,
+ * 사전 예약 알람의 lead time 계산에 trainCode + boardingLine을 사용한다.
+ *
+ * Multi-transfer trip은 leg마다 새 Lock으로 교체 (transfer 시점에서 갱신, PR E).
+ */
+export interface BoardingLock {
+  /** Trip 목적지 — Lock과 trip 1:1 매핑. destination 변경 시 Lock도 해제된다. */
+  destinationId: string;
+  /** 사용자가 탭한 열차의 trainCode. backend는 이 값으로 reschedule 정정을 보낸다. */
+  trainCode: string;
+  /** 탑승 역 id. trip 시작 시점 스냅샷. */
+  boardingStationId: string;
+  /** 탑승 시점 노선 — multi-transfer에서 현재 leg의 노선. */
+  boardingLine: LineNumber;
+  /** 탑승 시각 (ms epoch). 자동 만료 기준점. */
+  boardedAt: number;
+  /** 예상 trip(또는 현재 leg) 소요 시간(ms). 자동 만료 계산용. */
+  expectedDurationMs: number;
+}
+
+/** 자동 만료 안전 계수 — 예상 소요시간이 50% 초과되면 잘못된 Lock으로 보고 해제. */
+export const BOARDING_LOCK_EXPIRY_FACTOR = 1.5;
+
+export function isBoardingLockExpired(lock: BoardingLock, now: number): boolean {
+  return now > lock.boardedAt + lock.expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR;
+}

--- a/src/utils/__tests__/boardingLockStorage.test.ts
+++ b/src/utils/__tests__/boardingLockStorage.test.ts
@@ -1,0 +1,99 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  clearBoardingLock,
+  getBoardingLock,
+  setBoardingLock,
+} from '../boardingLockStorage';
+import { BOARDING_LOCK_KEY } from '../../constants/storageKeys';
+import type { BoardingLock } from '../../types/boardingLock';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const sample: BoardingLock = {
+  destinationId: 'dest-1',
+  trainCode: 'T-100',
+  boardingStationId: 'stn-A',
+  boardingLine: '2',
+  boardedAt: 1_700_000_000_000,
+  expectedDurationMs: 600_000,
+};
+
+describe('boardingLockStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getBoardingLock', () => {
+    it('AsyncStorage가 null이면 null 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      expect(await getBoardingLock()).toBeNull();
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(BOARDING_LOCK_KEY);
+    });
+
+    it('유효한 JSON을 파싱해 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(sample));
+      expect(await getBoardingLock()).toEqual(sample);
+    });
+
+    it('JSON 파싱 실패 시 null 반환 (오염된 페이로드 차단)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+      expect(await getBoardingLock()).toBeNull();
+    });
+
+    it('필수 필드 누락 시 null 반환', async () => {
+      const broken = { ...sample, trainCode: undefined };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getBoardingLock()).toBeNull();
+    });
+
+    it('루트가 객체가 아니면 null 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify('a string'));
+      expect(await getBoardingLock()).toBeNull();
+    });
+
+    it('AsyncStorage 오류 시 null 반환 (graceful)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      expect(await getBoardingLock()).toBeNull();
+    });
+  });
+
+  describe('setBoardingLock', () => {
+    it('Lock을 JSON 직렬화해 저장', async () => {
+      await setBoardingLock(sample);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        BOARDING_LOCK_KEY,
+        JSON.stringify(sample),
+      );
+    });
+
+    it('AsyncStorage 오류 시 throw 없이 swallow', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      await expect(setBoardingLock(sample)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearBoardingLock', () => {
+    it('BOARDING_LOCK_KEY 제거', async () => {
+      await clearBoardingLock();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(BOARDING_LOCK_KEY);
+    });
+
+    it('AsyncStorage 오류 시 swallow', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      await expect(clearBoardingLock()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/boardingLockStorage.ts
+++ b/src/utils/boardingLockStorage.ts
@@ -1,0 +1,59 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { BOARDING_LOCK_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+import type { BoardingLock } from '../types/boardingLock';
+
+const logger = createLogger('BoardingLockStorage');
+
+/**
+ * AsyncStorage BoardingLock CRUD (#584 PR A).
+ * 단일 Lock만 유지 — trip은 한 번에 하나, multi-transfer는 새 Lock으로 교체.
+ *
+ * Lock 구조 변경(필드 추가) 시 isBoardingLock 가드를 함께 갱신해야 한다. 파싱 실패한
+ * 레거시 페이로드는 빈 결과(null)로 처리 — 잘못된 상태로 dedup/예약 시스템이 오염되는 것을 차단한다.
+ */
+function isBoardingLock(value: unknown): value is BoardingLock {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.destinationId === 'string' &&
+    typeof v.trainCode === 'string' &&
+    typeof v.boardingStationId === 'string' &&
+    typeof v.boardingLine === 'string' &&
+    typeof v.boardedAt === 'number' &&
+    typeof v.expectedDurationMs === 'number'
+  );
+}
+
+export async function getBoardingLock(): Promise<BoardingLock | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BOARDING_LOCK_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isBoardingLock(parsed)) {
+      logger.error(`${BOARDING_LOCK_KEY} 형식 손상 — 무시`);
+      return null;
+    }
+    return parsed;
+  } catch (e) {
+    // 일시적 I/O 실패는 warn — 다음 호출에서 자연 복구.
+    logger.warn(`${BOARDING_LOCK_KEY} 읽기 실패:`, e);
+    return null;
+  }
+}
+
+export async function setBoardingLock(lock: BoardingLock): Promise<void> {
+  try {
+    await AsyncStorage.setItem(BOARDING_LOCK_KEY, JSON.stringify(lock));
+  } catch (e) {
+    logger.warn(`${BOARDING_LOCK_KEY} 저장 실패:`, e);
+  }
+}
+
+export async function clearBoardingLock(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(BOARDING_LOCK_KEY);
+  } catch (e) {
+    logger.warn(`${BOARDING_LOCK_KEY} 삭제 실패:`, e);
+  }
+}


### PR DESCRIPTION
## 범위 (#584 슬라이스 1/5)

BoardingLock 데이터 레이어만. UI/Fusion/scheduler 미연결 — 후속 PR에서 wiring.

## 변경

| 파일 | 내용 |
|---|---|
| \`src/types/boardingLock.ts\` | \`BoardingLock\` 인터페이스 + \`isBoardingLockExpired\` + \`BOARDING_LOCK_EXPIRY_FACTOR=1.5\` |
| \`src/utils/boardingLockStorage.ts\` | get/set/clear + 형식 가드 (\`isBoardingLock\`) |
| \`src/store/useBoardingLockStore.ts\` | Zustand: \`createLock\` (자동 교체) / \`releaseLock\` / \`loadLock\` / \`checkExpiry\` |
| \`src/constants/storageKeys.ts\` | \`BOARDING_LOCK_KEY\` |

## 설계 결정

- **단일 Lock 정책** — trip 1개 = leg 1개. multi-transfer는 새 Lock으로 교체 (PR E).
- **순수 함수 만료 판정** — \`isBoardingLockExpired(lock, now)\` + \`checkExpiry(now?)\`. 시계 의존성 격리.
- **graceful swallow** — I/O 실패는 warn, 형식 손상은 error. dedup 시스템 오염 방지.
- **expectedDurationMs × 1.5 안전 계수** — 잘못된 Lock이 무한 유지되는 것 차단.

## 후속 PR 예고

- PR B: 도착 list UI + Lock 생성 진입점
- PR C: 사전 예약 scheduler (이 Lock 사용)
- PR D: Fusion 통합 (boarding-lock priority)
- PR E: 환승 처리 (createLock 교체로 leg 전환)

## 검증

- [x] 1939 tests pass, 100% coverage
- [x] tsc clean
- [x] 사용자 영향 0 (UI 없음, 데이터만 정의)

Refs #584