### PR TITLE
refactor(#585): backend trainCode tracking + reschedule push 경로

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -4,6 +4,7 @@ import {
   buildApnsJwt,
   resetApnsJwtCache,
   sendAlertPush,
+  sendReschedulePush,
   sendSilentPush,
   type ApnsConfig,
 } from '../apns';
@@ -215,5 +216,58 @@ describe('sendAlertPush (#572 P2c)', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.reason).toBeUndefined();
+  });
+});
+
+describe('sendReschedulePush (#585)', () => {
+  beforeEach(() => resetApnsJwtCache());
+
+  it('posts background push with reschedule payload', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const result = await sendReschedulePush({
+      deviceToken: 'devicetoken-hex',
+      pushId: 'rsch-1',
+      trainCode: '7246',
+      nextStation: '중곡',
+      newArrivalTimeEpoch: 1_700_000_120_000,
+      sentAt: 1_700_000_000_000,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(true);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${TEST_HOST}/3/device/devicetoken-hex`);
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-push-type']).toBe('background');
+    expect(headers['apns-priority']).toBe('5');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps['content-available']).toBe(1);
+    expect(body.data).toEqual({
+      pushId: 'rsch-1',
+      kind: 'reschedule',
+      trainCode: '7246',
+      nextStation: '중곡',
+      newArrivalTimeEpoch: 1_700_000_120_000,
+      sentAt: 1_700_000_000_000,
+    });
+  });
+
+  it('returns failure with reason on non-2xx', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const result = await sendReschedulePush({
+      deviceToken: 't',
+      pushId: 'p',
+      trainCode: '7',
+      nextStation: 'x',
+      newArrivalTimeEpoch: 0,
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: false, status: 400, reason: 'BadDeviceToken' });
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -130,6 +130,137 @@ describe('validateTrip', () => {
   });
 });
 
+describe('validateTrip — boardingLock (#585)', () => {
+  function validLock(): Record<string, unknown> {
+    return {
+      trainCode: '7246',
+      line: '7',
+      subwayId: '1007',
+      selectedDepartureTime: 1_700_000_000_000,
+      segmentStations: ['용마산', '중곡', '군자'],
+      expiresAt: FUTURE,
+    };
+  }
+
+  it('accepts valid boardingLock', () => {
+    const trip = validateTrip({ ...base(), boardingLock: validLock() });
+    expect(trip?.boardingLock?.trainCode).toBe('7246');
+    expect(trip?.boardingLock?.segmentStations).toEqual(['용마산', '중곡', '군자']);
+  });
+
+  it('omits boardingLock when absent', () => {
+    expect(validateTrip(base())?.boardingLock).toBeUndefined();
+  });
+
+  it('drops boardingLock when non-object (trip survives)', () => {
+    const trip = validateTrip({ ...base(), boardingLock: 'bogus' });
+    expect(trip).not.toBeNull();
+    expect(trip?.boardingLock).toBeUndefined();
+  });
+
+  it.each([
+    ['trainCode missing', { trainCode: undefined }],
+    ['trainCode empty', { trainCode: '' }],
+    ['line missing', { line: undefined }],
+    ['line empty', { line: '' }],
+    ['subwayId missing', { subwayId: undefined }],
+    ['subwayId empty', { subwayId: '' }],
+    ['selectedDepartureTime not number', { selectedDepartureTime: 'now' }],
+    ['segmentStations not array', { segmentStations: 'A,B' }],
+    ['segmentStations empty', { segmentStations: [] }],
+    ['segmentStations contains non-string', { segmentStations: ['A', 1] }],
+    ['segmentStations contains empty string', { segmentStations: ['A', ''] }],
+    ['expiresAt not number', { expiresAt: 'soon' }],
+  ])('drops boardingLock when %s', (_label, override) => {
+    const trip = validateTrip({ ...base(), boardingLock: { ...validLock(), ...override } });
+    expect(trip).not.toBeNull();
+    expect(trip?.boardingLock).toBeUndefined();
+  });
+});
+
+describe('POST /trips — boardingLock merge (#585)', () => {
+  const CREATED = 1_700_000_000_000;
+  function makeKvEnv(): Env {
+    return makeEnv({ TRIPS: new InMemoryKV() as unknown as Env['TRIPS'] });
+  }
+  function lockBody(lockOverride?: Record<string, unknown> | null): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      ...base(),
+      token: 'tok-585',
+      createdAt: CREATED,
+    };
+    if (lockOverride !== null) {
+      body.boardingLock = {
+        trainCode: '7246',
+        line: '7',
+        subwayId: '1007',
+        selectedDepartureTime: CREATED,
+        segmentStations: ['용마산', '중곡', '군자'],
+        expiresAt: FUTURE,
+        ...lockOverride,
+      };
+    }
+    return body;
+  }
+
+  it('persists boardingLock on first register', async () => {
+    const env = makeKvEnv();
+    await post('/trips', lockBody(), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    expect(stored.boardingLock?.trainCode).toBe('7246');
+  });
+
+  it('incoming boardingLock wins on same-session re-register (transfer updates trainCode)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', lockBody({ trainCode: '7246' }), env);
+    await post('/trips', lockBody({ trainCode: '2317' }), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    expect(stored.boardingLock?.trainCode).toBe('2317');
+  });
+
+  it('omitted boardingLock clears existing lock (lock released)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', lockBody(), env);
+    await post('/trips', lockBody(null), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    expect(stored.boardingLock).toBeUndefined();
+  });
+
+  it('clears stale lastTrackedArrivalEpoch when both sides have no boardingLock (P3-3 회귀 방지)', async () => {
+    const env = makeKvEnv();
+    // 외부에서 lastTrackedArrivalEpoch가 남은 trip 직접 주입 (예: 잔여 backend 상태)
+    const seeded = { ...lockBody(null), lastTrackedArrivalEpoch: 1_234 };
+    await env.TRIPS.put('trip:tok-585', JSON.stringify(seeded));
+    await post('/trips', lockBody(null), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    expect(stored.lastTrackedArrivalEpoch).toBeUndefined();
+  });
+
+  it('preserves lastTrackedArrivalEpoch when same trainCode re-registered', async () => {
+    const env = makeKvEnv();
+    await post('/trips', lockBody(), env);
+    // backend 측에서 epoch을 갱신했다고 가정
+    const advanced = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    advanced.lastTrackedArrivalEpoch = 9_999;
+    await env.TRIPS.put('trip:tok-585', JSON.stringify(advanced));
+    // 같은 trainCode로 재등록
+    await post('/trips', lockBody(), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    expect(stored.lastTrackedArrivalEpoch).toBe(9_999);
+  });
+
+  it('resets lastTrackedArrivalEpoch when trainCode changed (transfer)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', lockBody({ trainCode: '7246' }), env);
+    const advanced = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    advanced.lastTrackedArrivalEpoch = 9_999;
+    await env.TRIPS.put('trip:tok-585', JSON.stringify(advanced));
+    await post('/trips', lockBody({ trainCode: '2317' }), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
+    expect(stored.lastTrackedArrivalEpoch).toBeUndefined();
+  });
+});
+
 describe('POST /trips (#578 — preserve advance progress on re-register)', () => {
   const CREATED = 1_700_000_000_000;
   function makeKvEnv(): Env {

--- a/backend/alarm-worker/src/__tests__/lineAlias.test.ts
+++ b/backend/alarm-worker/src/__tests__/lineAlias.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from 'vitest';
-import { LINE_ALIAS_MAP, matchLine } from '../lineAlias';
+import { LINE_ALIAS_MAP, canonicalLineName, matchLine } from '../lineAlias';
+
+describe('canonicalLineName (#585)', () => {
+  it.each([
+    ['1', '1호선'],
+    ['7', '7호선'],
+    ['gyeongui', '경의중앙선'],
+    ['bundang', '수인분당선'],
+    ['sinbundang', '신분당선'],
+    ['airport', '공항철도'],
+  ])('maps line="%s" → "%s"', (line, expected) => {
+    expect(canonicalLineName(line)).toBe(expected);
+  });
+
+  it('returns null for unknown line', () => {
+    expect(canonicalLineName('unknown')).toBeNull();
+  });
+});
 
 describe('matchLine', () => {
   it('returns false when subwayNm or line is empty', () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2,15 +2,17 @@ import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
 import {
+  RESCHEDULE_THRESHOLD_MS,
+  estimateArrivalFromPosition,
   flipApnsEnv,
   pickActiveWaypoint,
   pickApnsHost,
   pickBestArrivalSignal,
   runScheduled,
 } from '../scheduled';
-import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
+import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
-import type { Env, Trip } from '../types';
+import type { BoardingLockMeta, Env, Trip } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
 let apnsConfig: ApnsConfig;
@@ -605,5 +607,437 @@ describe('runScheduled', () => {
       });
       expect(pending.store.size).toBe(0);
     });
+  });
+});
+
+describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
+  function makeLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
+    return {
+      trainCode: '7246',
+      line: '7',
+      subwayId: '1007',
+      selectedDepartureTime: NOW,
+      segmentStations: ['용마산', '중곡', '군자'],
+      expiresAt: NOW + 60 * 60_000,
+      ...overrides,
+    };
+  }
+
+  function makeLockTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'lock-tok',
+      route: { type: 'direct', line: '7', stops: 2 },
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'destination' },
+      ],
+      boardingLock: makeLock(),
+      ...overrides,
+    });
+  }
+
+  /** Seoul API 응답 — arrivals와 positions를 URL 경로로 분기. */
+  function makeSeoulCombo(
+    arrivals: ArrivalEntry[],
+    positions: Array<Partial<PositionEntry> & { trainCode: string }>,
+  ): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes('/realtimePosition/')) {
+          return new Response(
+            JSON.stringify({
+              realtimePositionList: positions.map((p) => ({
+                trainNo: p.trainCode,
+                statnNm: p.stationName ?? '',
+                trainSttus: p.trainSttus ?? 0,
+                updnLine: p.isUp === false ? '하행' : '상행',
+                lastRecptnDt: '',
+              })),
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            realtimeArrivalList: arrivals.map((a) => ({
+              barvlDt: String(a.arrivalSeconds),
+              recptnDt: '',
+              updnLine: a.isUp ? '상행' : '하행',
+              trainLineNm: a.destination,
+              btrainNo: a.trainCode,
+              subwayNm: a.subwayNm,
+              arvlCd: a.arvlCd,
+            })),
+          }),
+          { status: 200 },
+        );
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  function arrivalForLock(stationName: string, seconds: number, arvlCd: number | null = null, trainCode = '7246'): ArrivalEntry {
+    return { destination: stationName, arrivalSeconds: seconds, trainCode, isUp: true, subwayNm: '지하철7호선', arvlCd };
+  }
+
+  it('fires reschedule push when trainCode matched in arrivals (no prior baseline)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p1',
+    });
+    expect(stats.pushed).toBe(1);
+    expect(apnsFetch).toHaveBeenCalledTimes(1);
+    const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.kind).toBe('reschedule');
+    expect(body.data.trainCode).toBe('7246');
+    expect(body.data.nextStation).toBe('중곡');
+    expect(body.data.newArrivalTimeEpoch).toBe(NOW + 120_000);
+    // baseline 저장 확인
+    const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+    expect(stored.lastTrackedArrivalEpoch).toBe(NOW + 120_000);
+  });
+
+  it('does not push when delta < threshold', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ lastTrackedArrivalEpoch: NOW + 120_000 }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 125)], []), // +5s delta
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p1',
+    });
+    expect(stats.pushed).toBe(0);
+    expect(apnsFetch).not.toHaveBeenCalled();
+  });
+
+  it('pushes again when delta >= threshold', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ lastTrackedArrivalEpoch: NOW + 120_000 }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 140)], []), // +20s delta
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p2',
+    });
+    expect(stats.pushed).toBe(1);
+  });
+
+  it('falls back to realtimePosition when trainCode not in arrivals', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo(
+        [arrivalForLock('중곡', 60, null, 'other-train')], // 다른 trainCode만 있음
+        [{ trainCode: '7246', stationName: '용마산', trainSttus: 0 }], // segmentStations[0]
+      ),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p3',
+    });
+    expect(stats.pushed).toBe(1);
+    // segmentStations idx 0(용마산) → 1(중곡), 1 hop × 90s
+    const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.newArrivalTimeEpoch).toBe(NOW + 90_000);
+  });
+
+  it('etaMissing when trainCode found nowhere', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p4',
+    });
+    expect(stats.etaMissing).toBe(1);
+    expect(stats.pushed).toBe(0);
+  });
+
+  it('advances waypoint and resets baseline when trainCode arrived (arvlCd=1)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ lastTrackedArrivalEpoch: NOW + 5000 }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p5',
+    });
+    const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+    expect(stored.waypoints).toHaveLength(1);
+    expect(stored.waypoints[0].stationName).toBe('군자');
+    expect(stored.lastTrackedArrivalEpoch).toBeUndefined();
+  });
+
+  it('deletes trip when destination arrived', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [{ stationName: '군자', line: '7', kind: 'destination' }],
+      }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p6',
+    });
+    expect(await kv.get('trip:lock-tok')).toBeNull();
+  });
+
+  it('deletes trip when last intermediate waypoint advanced beyond list', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+      }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p7',
+    });
+    expect(await kv.get('trip:lock-tok')).toBeNull();
+  });
+
+  it('skips boardingLock branch when lock expired (falls through to phase polling)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        boardingLock: makeLock({ expiresAt: NOW - 1 }),
+        waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+      }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([makeImminentArrival('강남')]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p8',
+    });
+    // 일반 phase 경로로 처리되어 imminent push가 발사되어야 함
+    expect(stats.pushed).toBe(1);
+    const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.phase).toBeDefined();
+    expect(body.data.kind).not.toBe('reschedule');
+  });
+
+  it('counts error when reschedule push fails (apns 400)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadFoo' }), { status: 400 }),
+    );
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 60)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p9',
+    });
+    expect(stats.errors).toBe(1);
+    expect(stats.pushed).toBe(0);
+  });
+
+  it('handles tracking exception (e.g. seoul throws)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const throwingSeoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () => {
+        throw new Error('boom');
+      }) as unknown as typeof fetch,
+    });
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: throwingSeoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.errors).toBe(1);
+  });
+
+  it('self-heals apns env mismatch (#482) — flips host + corrects trip.apnsEnv', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ apnsEnv: 'sandbox' }),
+    );
+    const apnsFetch = vi.fn();
+    apnsFetch
+      .mockImplementationOnce(async () =>
+        new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+      )
+      .mockImplementationOnce(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-heal',
+    });
+    expect(stats.pushed).toBe(1);
+    expect(stats.envCorrected).toBe(1);
+    expect(apnsFetch).toHaveBeenCalledTimes(2);
+    // 1차: sandbox host, 2차: production host
+    const url1 = (apnsFetch.mock.calls[0] as unknown as [string])[0];
+    const url2 = (apnsFetch.mock.calls[1] as unknown as [string])[0];
+    expect(url1).toContain(APNS_HOSTS.sandbox);
+    expect(url2).toContain(APNS_HOSTS.production);
+    const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+    expect(stored.apnsEnv).toBe('production');
+  });
+
+  it('deletes trip when both hosts return BadDeviceToken (envMismatchExhausted)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ apnsEnv: 'sandbox' }));
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-exhaust',
+    });
+    expect(await kv.get('trip:lock-tok')).toBeNull();
+  });
+
+  it('deletes trip on Unregistered (410)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-410',
+    });
+    expect(await kv.get('trip:lock-tok')).toBeNull();
+  });
+
+  it('skips push (no API call to APNs) when trainCode arrived at non-target station via position fallback (arrived=false)', async () => {
+    // segmentStations idx 0(용마산) → target 1(중곡), 1 hop. arrived=false (sttus=0 이동중).
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ lastTrackedArrivalEpoch: NOW + 90_000 }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo(
+        [],
+        [{ trainCode: '7246', stationName: '용마산', trainSttus: 0 }],
+      ),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBe(0);
+  });
+});
+
+describe('estimateArrivalFromPosition (#585)', () => {
+  const lock: BoardingLockMeta = {
+    trainCode: '7246',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: NOW,
+    segmentStations: ['용마산', '중곡', '군자', '어린이대공원'],
+    expiresAt: NOW + 60 * 60_000,
+  };
+
+  it('returns null epoch when current station not in segment', () => {
+    const train: PositionEntry = { trainCode: '7246', stationName: '아예다른역', trainSttus: 0, isUp: true, recptnMs: 0 };
+    expect(estimateArrivalFromPosition(train, '군자', lock, NOW)).toEqual({ epoch: null, arrived: false });
+  });
+
+  it('returns null epoch when target station not in segment', () => {
+    const train: PositionEntry = { trainCode: '7246', stationName: '용마산', trainSttus: 0, isUp: true, recptnMs: 0 };
+    expect(estimateArrivalFromPosition(train, '아예다른역', lock, NOW)).toEqual({ epoch: null, arrived: false });
+  });
+
+  it('estimates epoch by hop count × 90s', () => {
+    const train: PositionEntry = { trainCode: '7246', stationName: '용마산', trainSttus: 0, isUp: true, recptnMs: 0 };
+    // 용마산(0) → 어린이대공원(3) = 3 hops × 90_000ms
+    expect(estimateArrivalFromPosition(train, '어린이대공원', lock, NOW)).toEqual({ epoch: NOW + 270_000, arrived: false });
+  });
+
+  it('treats currentIdx >= targetIdx as already at/past target', () => {
+    const train: PositionEntry = { trainCode: '7246', stationName: '군자', trainSttus: 0, isUp: true, recptnMs: 0 };
+    const r = estimateArrivalFromPosition(train, '중곡', lock, NOW);
+    expect(r.epoch).toBe(NOW);
+    expect(r.arrived).toBe(false); // sttus가 ARRIVED 아니고 stationName도 target과 다름
+  });
+
+  it('reports arrived=true when sttus=ARRIVED at target station', () => {
+    const train: PositionEntry = { trainCode: '7246', stationName: '군자', trainSttus: 1, isUp: true, recptnMs: 0 };
+    expect(estimateArrivalFromPosition(train, '군자', lock, NOW)).toEqual({ epoch: NOW, arrived: true });
+  });
+});
+
+describe('RESCHEDULE_THRESHOLD_MS (#585)', () => {
+  it('is 15 seconds', () => {
+    expect(RESCHEDULE_THRESHOLD_MS).toBe(15_000);
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -803,42 +803,23 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(stored.lastTrackedArrivalEpoch).toBeUndefined();
   });
 
-  it('deletes trip when destination arrived', async () => {
+  it.each([
+    ['destination 도착 시 trip 삭제', '군자', 'destination'] as const,
+    ['마지막 intermediate 통과 후 빈 리스트면 trip 삭제', '중곡', 'intermediate'] as const,
+  ])('%s', async (_label, station, kind) => {
     const kv = new InMemoryKV();
     await putTrip(
       kv as unknown as KVNamespace,
-      makeLockTrip({
-        waypoints: [{ stationName: '군자', line: '7', kind: 'destination' }],
-      }),
+      makeLockTrip({ waypoints: [{ stationName: station, line: '7', kind }] }),
     );
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     await runScheduled(makeEnv(kv), {
-      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      seoul: makeSeoulCombo([arrivalForLock(station, 0, 1)], []),
       apnsConfig,
       apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
-      generatePushId: () => 'p6',
-    });
-    expect(await kv.get('trip:lock-tok')).toBeNull();
-  });
-
-  it('deletes trip when last intermediate waypoint advanced beyond list', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockTrip({
-        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
-      }),
-    );
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
-      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p7',
+      generatePushId: () => 'p-arrive',
     });
     expect(await kv.get('trip:lock-tok')).toBeNull();
   });

--- a/backend/alarm-worker/src/__tests__/seoul.test.ts
+++ b/backend/alarm-worker/src/__tests__/seoul.test.ts
@@ -140,6 +140,131 @@ describe('SeoulArrivalClient', () => {
     expect(arrivals[0].arrivalSeconds).toBe(120);
   });
 
+  describe('fetchPositions (#585)', () => {
+    function makePositionItem(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+      return {
+        trainNo: '7246',
+        statnNm: '중곡',
+        trainSttus: 1,
+        updnLine: '상행',
+        lastRecptnDt: '2025-01-15 10:30:00',
+        ...overrides,
+      };
+    }
+
+    it('parses position list for known line', async () => {
+      const fetchImpl = vi.fn(async () =>
+        makeResponse({ realtimePositionList: [makePositionItem(), makePositionItem({ trainNo: '7248', updnLine: '하행' })] }),
+      );
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const positions = await client.fetchPositions('7');
+      expect(positions).toHaveLength(2);
+      expect(positions[0].trainCode).toBe('7246');
+      expect(positions[0].stationName).toBe('중곡');
+      expect(positions[0].trainSttus).toBe(1);
+      expect(positions[0].isUp).toBe(true);
+      expect(positions[1].isUp).toBe(false);
+      expect(positions[0].recptnMs).toBe(FIXED_NOW);
+    });
+
+    it('returns empty array for unmapped line (no API call)', async () => {
+      const fetchImpl = vi.fn();
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const positions = await client.fetchPositions('unknown-line');
+      expect(positions).toEqual([]);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('caches positions within TTL', async () => {
+      const fetchImpl = vi.fn(async () => makeResponse({ realtimePositionList: [makePositionItem()] }));
+      let now = FIXED_NOW;
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => now,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await client.fetchPositions('7');
+      await client.fetchPositions('7');
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      now += 16_000;
+      await client.fetchPositions('7');
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns empty + short-caches on http error', async () => {
+      const fetchImpl = vi.fn(async () => makeResponse({}, false, 500));
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      expect(await client.fetchPositions('7')).toEqual([]);
+      await client.fetchPositions('7');
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips malformed items (null, no trainNo, non-object)', async () => {
+      const fetchImpl = vi.fn(async () =>
+        makeResponse({
+          realtimePositionList: [
+            null,
+            'string-item',
+            { statnNm: '중곡' }, // missing trainNo
+            { trainNo: 123 }, // wrong type
+            makePositionItem(),
+          ],
+        }),
+      );
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const positions = await client.fetchPositions('7');
+      expect(positions).toHaveLength(1);
+    });
+
+    it('handles missing realtimePositionList field', async () => {
+      const fetchImpl = vi.fn(async () => makeResponse({}));
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      expect(await client.fetchPositions('7')).toEqual([]);
+    });
+
+    it('defaults trainSttus / stationName when missing', async () => {
+      const fetchImpl = vi.fn(async () =>
+        makeResponse({ realtimePositionList: [{ trainNo: '7246' }] }),
+      );
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const positions = await client.fetchPositions('7');
+      expect(positions[0].stationName).toBe('');
+      expect(positions[0].trainSttus).toBeNull();
+      expect(positions[0].recptnMs).toBe(0);
+    });
+  });
+
   it('tracks call count', async () => {
     const fetchImpl = vi.fn(async () => makeResponse({ realtimeArrivalList: [] }));
     const client = new SeoulArrivalClient({

--- a/backend/alarm-worker/src/alarm.ts
+++ b/backend/alarm-worker/src/alarm.ts
@@ -32,6 +32,19 @@ export const ARRIVAL_CODE = {
   PREV_ARRIVED: 5,
 } as const;
 
+/**
+ * Seoul API `realtimePosition.trainSttus` 값 (#585).
+ * `ARRIVAL_CODE`(arvlCd)와 **다른 코드 체계** — 우연히 숫자가 일부 겹친다고 재사용 금지.
+ *   0: 진입 (approaching)
+ *   1: 도착 (arrived)
+ *   2: 출발 (departed)
+ */
+export const TRAIN_STATUS = {
+  APPROACHING: 0,
+  ARRIVED: 1,
+  DEPARTED: 2,
+} as const;
+
 const IMMINENT_CODES: readonly number[] = [ARRIVAL_CODE.ENTERING, ARRIVAL_CODE.ARRIVED];
 const EARLY_CODES: readonly number[] = [ARRIVAL_CODE.PREV_ENTERING, ARRIVAL_CODE.PREV_ARRIVED];
 

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -7,6 +7,7 @@
 
 import { importPKCS8, SignJWT } from 'jose';
 import type { AlarmPhase } from './alarm';
+import type { ReschedulePushPayload } from './types';
 
 /**
  * APNs JWT는 1시간 이내 재사용 가능. Worker 인스턴스 메모리에 캐시한다.
@@ -157,6 +158,61 @@ export async function sendAlertPush(options: SendAlertPushOptions): Promise<Send
       'apns-topic': options.config.bundleId,
       'apns-push-type': 'alert',
       'apns-priority': '10',
+      'content-type': 'application/json',
+    },
+    body,
+  });
+
+  if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
+/**
+ * Reschedule silent push (#585). 디바이스 사전 예약 알람(#584)의 도착 시각이 backend 관측과
+ * 어긋났을 때 발사. 디바이스는 받아서 기존 예약 cancel + newArrivalTimeEpoch로 재예약한다.
+ *
+ * silent push와 동일 헤더(background, priority 5)지만 payload의 `kind: 'reschedule'`로 구분.
+ * 일반 phase silent push와 달리 alert fallback 대상이 아니다 — 정정 신호 미도달 시 디바이스의
+ * 사전 예약이 SLA를 보장하므로 graceful.
+ */
+export interface SendReschedulePushOptions {
+  deviceToken: string;
+  pushId: string;
+  trainCode: string;
+  nextStation: string;
+  newArrivalTimeEpoch: number;
+  sentAt: number;
+  config: ApnsConfig;
+  host: string;
+  fetchImpl?: typeof fetch;
+  now?: number;
+}
+
+export async function sendReschedulePush(
+  options: SendReschedulePushOptions,
+): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
+
+  const payload: ReschedulePushPayload = {
+    pushId: options.pushId,
+    kind: 'reschedule',
+    trainCode: options.trainCode,
+    nextStation: options.nextStation,
+    newArrivalTimeEpoch: options.newArrivalTimeEpoch,
+    sentAt: options.sentAt,
+  };
+
+  const body = JSON.stringify({ aps: { 'content-available': 1 }, data: payload });
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${jwt}`,
+      'apns-topic': options.config.bundleId,
+      'apns-push-type': 'background',
+      'apns-priority': '5',
       'content-type': 'application/json',
     },
     body,

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -22,7 +22,7 @@ import {
   writeTelemetryDataPoints,
 } from './telemetry';
 import { deleteTrip, getTrip, putTrip } from './trips';
-import type { Env, Trip } from './types';
+import type { BoardingLockMeta, Env, Trip } from './types';
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -51,6 +51,14 @@ app.post('/trips', async (c) => {
         lastFiredPhase: existing.lastFiredPhase,
         lastEtaSeconds: existing.lastEtaSeconds,
         apnsEnv: existing.apnsEnv ?? incoming.apnsEnv,
+        // boardingLock이 바뀌면(예: 환승 후 새 trainCode) 추적 baseline도 리셋.
+        // 양쪽 모두 boardingLock이 있고 trainCode가 같을 때만 baseline 유지 — 둘 다 undefined인
+        // 경우 비교가 true로 평가돼 stale epoch이 살아남는 회귀를 막는다.
+        lastTrackedArrivalEpoch:
+          incoming.boardingLock &&
+          existing.boardingLock?.trainCode === incoming.boardingLock.trainCode
+            ? existing.lastTrackedArrivalEpoch
+            : undefined,
       }
     : incoming;
 
@@ -176,6 +184,34 @@ export function validateTrip(input: unknown): Trip | null {
       : undefined,
     lastEtaSeconds: typeof obj.lastEtaSeconds === 'number' ? obj.lastEtaSeconds : undefined,
     apnsEnv: obj.apnsEnv === 'sandbox' || obj.apnsEnv === 'production' ? obj.apnsEnv : undefined,
+    boardingLock: parseBoardingLock(obj.boardingLock),
+    lastTrackedArrivalEpoch:
+      typeof obj.lastTrackedArrivalEpoch === 'number' ? obj.lastTrackedArrivalEpoch : undefined,
+  };
+}
+
+/**
+ * BoardingLock metadata 파싱 (#585).
+ * 한 필드라도 어긋나면 boardingLock만 drop하고 trip은 살린다 — backend는 기존 anchor 폴링으로
+ * graceful fallback. 디바이스 schema 불일치로 trip 자체를 reject하면 알람이 통째로 죽으므로.
+ */
+function parseBoardingLock(raw: unknown): BoardingLockMeta | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.trainCode !== 'string' || o.trainCode.length === 0) return undefined;
+  if (typeof o.line !== 'string' || o.line.length === 0) return undefined;
+  if (typeof o.subwayId !== 'string' || o.subwayId.length === 0) return undefined;
+  if (typeof o.selectedDepartureTime !== 'number') return undefined;
+  if (!Array.isArray(o.segmentStations) || o.segmentStations.length === 0) return undefined;
+  if (!o.segmentStations.every((s) => typeof s === 'string' && s.length > 0)) return undefined;
+  if (typeof o.expiresAt !== 'number') return undefined;
+  return {
+    trainCode: o.trainCode,
+    line: o.line,
+    subwayId: o.subwayId,
+    selectedDepartureTime: o.selectedDepartureTime,
+    segmentStations: o.segmentStations as string[],
+    expiresAt: o.expiresAt,
   };
 }
 

--- a/backend/alarm-worker/src/lineAlias.ts
+++ b/backend/alarm-worker/src/lineAlias.ts
@@ -1,45 +1,64 @@
 /**
- * 클라이언트 line code(stations.json의 `line` 필드) → Seoul API `subwayNm` 후보 매핑.
+ * 클라이언트 line code(stations.json의 `line` 필드) → Seoul API 노선명 매핑.
  *
- * Seoul API는 "지하철1호선", "지하철경의중앙선" 등 한글명을 돌려준다.
- * 영문 코드(`gyeongui`, `airport` 등)는 substring 매칭으로는 절대 잡히지 않으므로
- * 명시적 alias 배열로 매칭한다. 숫자 호선("1"~"9")은 "지하철1호선" 같은 접미 형식 매칭.
+ * 단일 데이터 소스: `LINE_META`만 유지하고, 모든 헬퍼는 여기서 파생된다.
+ * 신규 노선은 이 맵에 한 줄만 추가하면 `canonicalLineName` / `matchLine` 양쪽에 자동 반영.
  *
- * 신규 노선은 이 맵에 alias를 추가하기만 하면 매칭에 반영된다.
+ * - `canonical`: realtimePosition API의 `subwayLine` URL 파라미터에 들어가는 정식명 ("1호선", "경의중앙선").
+ *   "지하철1호선" 접두형은 들어가지 않는다.
+ * - `aliases`: realtimeStationArrival 응답의 `subwayNm` 등 다른 형태 — substring 매칭에 사용.
  */
 
-export const LINE_ALIAS_MAP: Record<string, readonly string[]> = {
-  '1': ['지하철1호선', '1호선'],
-  '2': ['지하철2호선', '2호선'],
-  '3': ['지하철3호선', '3호선'],
-  '4': ['지하철4호선', '4호선'],
-  '5': ['지하철5호선', '5호선'],
-  '6': ['지하철6호선', '6호선'],
-  '7': ['지하철7호선', '7호선'],
-  '8': ['지하철8호선', '8호선'],
-  '9': ['지하철9호선', '9호선'],
-  gyeongui: ['경의중앙선', '지하철경의중앙선', '경의중앙'],
-  bundang: ['수인분당선', '지하철수인분당선', '분당선', '수인분당'],
-  sinbundang: ['신분당선', '지하철신분당선'],
-  airport: ['공항철도', '인천국제공항철도'],
+export interface LineMeta {
+  canonical: string;
+  aliases: readonly string[];
+}
+
+export const LINE_META: Record<string, LineMeta> = {
+  '1': { canonical: '1호선', aliases: ['지하철1호선'] },
+  '2': { canonical: '2호선', aliases: ['지하철2호선'] },
+  '3': { canonical: '3호선', aliases: ['지하철3호선'] },
+  '4': { canonical: '4호선', aliases: ['지하철4호선'] },
+  '5': { canonical: '5호선', aliases: ['지하철5호선'] },
+  '6': { canonical: '6호선', aliases: ['지하철6호선'] },
+  '7': { canonical: '7호선', aliases: ['지하철7호선'] },
+  '8': { canonical: '8호선', aliases: ['지하철8호선'] },
+  '9': { canonical: '9호선', aliases: ['지하철9호선'] },
+  gyeongui: { canonical: '경의중앙선', aliases: ['지하철경의중앙선', '경의중앙'] },
+  bundang: { canonical: '수인분당선', aliases: ['지하철수인분당선', '분당선', '수인분당'] },
+  sinbundang: { canonical: '신분당선', aliases: ['지하철신분당선'] },
+  airport: { canonical: '공항철도', aliases: ['인천국제공항철도'] },
 };
+
+/** realtimePosition URL 파라미터용 정식 노선명. 매핑 없으면 null. */
+export function canonicalLineName(line: string): string | null {
+  return LINE_META[line]?.canonical ?? null;
+}
+
+/**
+ * 기존 호환성 — LINE_META에서 파생되는 alias 목록. 신규 코드는 LINE_META를 직접 사용 권장.
+ */
+export const LINE_ALIAS_MAP: Record<string, readonly string[]> = Object.fromEntries(
+  Object.entries(LINE_META).map(([line, { canonical, aliases }]) => [line, [canonical, ...aliases]]),
+);
 
 /**
  * Seoul API의 subwayNm이 클라이언트 line code와 매칭되는지 판정한다.
  *
  * 우선순위:
- *   1. line code에 대응되는 alias 배열 중 하나가 subwayNm과 정확히 일치하거나
- *      subwayNm이 alias를 포함하면 true (예: subwayNm="지하철경의중앙선", alias="경의중앙선")
- *   2. alias 매핑이 없는 경우 (예: 신규 노선) substring 매칭으로 fallback
+ *   1. line code에 대응되는 `[canonical, ...aliases]` 중 하나가 subwayNm과 정확히 일치하거나
+ *      subwayNm이 alias를 포함하면 true
+ *   2. 매핑이 없는 경우 (예: 신규 노선) substring 매칭으로 fallback
  */
 export function matchLine(subwayNm: string, line: string): boolean {
   if (!subwayNm || !line) return false;
 
-  const aliases = LINE_ALIAS_MAP[line];
-  if (aliases) {
-    for (const alias of aliases) {
-      if (subwayNm === alias) return true;
-      if (subwayNm.includes(alias) || alias.includes(subwayNm)) return true;
+  const meta = LINE_META[line];
+  if (meta) {
+    const candidates = [meta.canonical, ...meta.aliases];
+    for (const name of candidates) {
+      if (subwayNm === name) return true;
+      if (subwayNm.includes(name) || name.includes(subwayNm)) return true;
     }
     return false;
   }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -10,7 +10,7 @@ import {
   isSignificantEtaChange,
   shouldFire,
 } from './alarm';
-import { sendReschedulePush, sendSilentPush, type ApnsConfig } from './apns';
+import { sendReschedulePush, sendSilentPush, type ApnsConfig, type SendPushResult } from './apns';
 import { matchLine } from './lineAlias';
 import { buildAlarmKey, putPending } from './pendingPushes';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
@@ -29,6 +29,53 @@ export const RESCHEDULE_THRESHOLD_MS = 15_000;
 
 /** boardingLock fallback에서 hop당 기본 소요(90s). 환승역 등 실제 hop은 후속 데이터로 정밀화. */
 const FALLBACK_HOP_SEC = 90;
+
+export interface EnvHealResult {
+  result: SendPushResult;
+  /** retry로 정정된 새 env. 정정 발생 시에만 set. */
+  correctedEnv?: ApnsEnv;
+  /** 양쪽 host 모두 BadDeviceToken — 토큰 자체 무효 신호. */
+  envMismatchExhausted: boolean;
+}
+
+/**
+ * APNs env mismatch self-heal (#482). 1차 호출 → BadDeviceToken이면 opposite host로 1회 retry.
+ * `sender`는 host를 받아 push를 보내는 클로저 — phase push / reschedule push 양쪽에서 재사용.
+ *
+ * 호출자 책임:
+ *   - correctedEnv set → trip.apnsEnv 갱신 + envCorrected stat 카운트
+ *   - envMismatchExhausted true → trip 삭제
+ *   - result.ok / !ok 분기는 각 경로별 후처리에 맡김
+ */
+export async function sendWithEnvHeal(
+  sender: (host: string) => Promise<SendPushResult>,
+  currentEnv: ApnsEnv | undefined,
+  apnsHosts: Record<ApnsEnv, string>,
+  log: Logger,
+  tokenForLog: string,
+): Promise<EnvHealResult> {
+  const initial = await sender(pickApnsHost(currentEnv, apnsHosts));
+  if (initial.ok || !isApnsEnvMismatch(initial.status, initial.reason)) {
+    return { result: initial, envMismatchExhausted: false };
+  }
+  const corrected = flipApnsEnv(currentEnv);
+  log('apns env mismatch — retry with opposite host', {
+    token: tokenForLog,
+    from: currentEnv ?? 'sandbox',
+    to: corrected,
+  });
+  const retry = await sender(apnsHosts[corrected]);
+  if (retry.ok) {
+    log('apns env corrected', { token: tokenForLog, to: corrected });
+    return { result: retry, correctedEnv: corrected, envMismatchExhausted: false };
+  }
+  return {
+    result: retry,
+    envMismatchExhausted: isApnsEnvMismatch(retry.status, retry.reason),
+  };
+}
+
+type Logger = (message: string, meta?: Record<string, unknown>) => void;
 
 export interface ScheduledStats {
   scanned: number;
@@ -181,50 +228,28 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           sentAt: now,
           pushId,
         };
-        let result = await sendSilentPush({
-          deviceToken: trip.token,
-          payload: pushPayload,
-          config: deps.apnsConfig,
-          host: pickApnsHost(trip.apnsEnv, deps.apnsHosts),
-          fetchImpl: deps.fetchImpl,
-          now,
-        });
-
-        // self-heal (#482): BadDeviceToken은 토큰 자체 무효가 아니라 host 환경 불일치인 경우가
-        // 압도적이다. 반대 host로 1회 재시도하고, 성공하면 trip.apnsEnv를 정정 저장한다.
-        // 양쪽 host 모두 BadDeviceToken을 내면 그제야 진짜 토큰 무효로 보고 trip을 삭제한다.
-        let envMismatchExhausted = false;
-        if (!result.ok && isApnsEnvMismatch(result.status, result.reason)) {
-          const correctedEnv = flipApnsEnv(trip.apnsEnv);
-          log('apns env mismatch — retry with opposite host', {
-            token: trip.token.slice(0, 8),
-            from: trip.apnsEnv ?? 'sandbox',
-            to: correctedEnv,
-          });
-          const retryResult = await sendSilentPush({
-            deviceToken: trip.token,
-            payload: pushPayload,
-            config: deps.apnsConfig,
-            host: deps.apnsHosts[correctedEnv],
-            fetchImpl: deps.fetchImpl,
-            now,
-          });
-          if (retryResult.ok) {
-            trip.apnsEnv = correctedEnv;
-            dirty = true;
-            stats.envCorrected += 1;
-            log('apns env corrected', {
-              token: trip.token.slice(0, 8),
-              to: correctedEnv,
-            });
-          } else if (isApnsEnvMismatch(retryResult.status, retryResult.reason)) {
-            // 양쪽 모두 BadDeviceToken — 토큰 자체가 무효
-            envMismatchExhausted = true;
-          }
-          // retry 결과를 최종 result로 승격 — 하단 success/error 분기가 일관되게 동작.
-          // retry가 다른 종류 에러(예: 410, PayloadTooLarge)면 그대로 그 경로에서 처리됨.
-          result = retryResult;
+        const heal = await sendWithEnvHeal(
+          (host) =>
+            sendSilentPush({
+              deviceToken: trip.token,
+              payload: pushPayload,
+              config: deps.apnsConfig,
+              host,
+              fetchImpl: deps.fetchImpl,
+              now,
+            }),
+          trip.apnsEnv,
+          deps.apnsHosts,
+          log,
+          trip.token.slice(0, 8),
+        );
+        if (heal.correctedEnv) {
+          trip.apnsEnv = heal.correctedEnv;
+          dirty = true;
+          stats.envCorrected += 1;
         }
+        const envMismatchExhausted = heal.envMismatchExhausted;
+        const result = heal.result;
 
         if (result.ok) {
           stats.pushed += 1;
@@ -339,8 +364,6 @@ export async function runTrainCodeTracking(
   await maybeReschedulePush(trip, waypoint, lock, estimate.epoch, env, deps, stats, now, log, generatePushId);
 }
 
-type Logger = (message: string, meta?: Record<string, unknown>) => void;
-
 /**
  * 다음 waypoint에 trainCode가 도착할 시각을 추정.
  *   1순위: arrivals에서 trainCode 매칭 → barvlDt
@@ -439,43 +462,33 @@ export async function maybeReschedulePush(
     previousEpoch: lastEpoch,
   });
 
-  const send = (host: string) =>
-    sendReschedulePush({
-      deviceToken: trip.token,
-      pushId,
-      trainCode: lock.trainCode,
-      nextStation: waypoint.stationName,
-      newArrivalTimeEpoch: newArrivalEpoch,
-      sentAt: now,
-      config: deps.apnsConfig,
-      host,
-      fetchImpl: deps.fetchImpl,
-      now,
-    });
-
-  let result = await send(pickApnsHost(trip.apnsEnv, deps.apnsHosts));
-  let envMismatchExhausted = false;
+  const heal = await sendWithEnvHeal(
+    (host) =>
+      sendReschedulePush({
+        deviceToken: trip.token,
+        pushId,
+        trainCode: lock.trainCode,
+        nextStation: waypoint.stationName,
+        newArrivalTimeEpoch: newArrivalEpoch,
+        sentAt: now,
+        config: deps.apnsConfig,
+        host,
+        fetchImpl: deps.fetchImpl,
+        now,
+      }),
+    trip.apnsEnv,
+    deps.apnsHosts,
+    log,
+    trip.token.slice(0, 8),
+  );
   let dirty = false;
-
-  // self-heal (#482): phase push 경로와 동일 정책. 양쪽 host 모두 BadDeviceToken이면 토큰 무효 판정.
-  if (!result.ok && isApnsEnvMismatch(result.status, result.reason)) {
-    const corrected = flipApnsEnv(trip.apnsEnv);
-    log('apns env mismatch — retry with opposite host', {
-      token: trip.token.slice(0, 8),
-      from: trip.apnsEnv ?? 'sandbox',
-      to: corrected,
-    });
-    const retry = await send(deps.apnsHosts[corrected]);
-    if (retry.ok) {
-      trip.apnsEnv = corrected;
-      dirty = true;
-      stats.envCorrected += 1;
-      log('apns env corrected', { token: trip.token.slice(0, 8), to: corrected });
-    } else if (isApnsEnvMismatch(retry.status, retry.reason)) {
-      envMismatchExhausted = true;
-    }
-    result = retry;
+  if (heal.correctedEnv) {
+    trip.apnsEnv = heal.correctedEnv;
+    dirty = true;
+    stats.envCorrected += 1;
   }
+  const envMismatchExhausted = heal.envMismatchExhausted;
+  const result = heal.result;
 
   if (result.ok) {
     stats.pushed += 1;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -5,19 +5,30 @@
 import {
   ARRIVAL_CODE,
   EARLY_THRESHOLD_SEC,
+  TRAIN_STATUS,
   evaluatePhaseFromSignal,
   isSignificantEtaChange,
   shouldFire,
 } from './alarm';
-import { sendSilentPush, type ApnsConfig } from './apns';
+import { sendReschedulePush, sendSilentPush, type ApnsConfig } from './apns';
 import { matchLine } from './lineAlias';
 import { buildAlarmKey, putPending } from './pendingPushes';
-import { SeoulArrivalClient, type ArrivalEntry } from './seoul';
+import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { deleteTrip, listTrips, putTrip } from './trips';
-import type { ApnsEnv, Env, Trip, Waypoint } from './types';
+import type { ApnsEnv, BoardingLockMeta, Env, Trip, Waypoint } from './types';
 
 /** 알람 윈도우: 알람 예상 시각 5분 이내인 트립만 폴링한다. */
 const POLLING_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * boardingLock 추적에서 reschedule push를 발사할 변동 임계치 (#585).
+ * 새 도착 예측이 마지막으로 디바이스에 통지한 값과 이 이상 어긋날 때만 push.
+ * 15s = Seoul API barvlDt 단위(60s)의 1/4 — 노이즈는 줄이고 의미있는 변동은 잡는다.
+ */
+export const RESCHEDULE_THRESHOLD_MS = 15_000;
+
+/** boardingLock fallback에서 hop당 기본 소요(90s). 환승역 등 실제 hop은 후속 데이터로 정밀화. */
+const FALLBACK_HOP_SEC = 90;
 
 export interface ScheduledStats {
   scanned: number;
@@ -94,6 +105,28 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     stats.polled += 1;
     const waypoint = pickActiveWaypoint(trip);
     if (!waypoint) continue;
+
+    // #585 — boardingLock 활성 trip은 trainCode 단위 추적 + reschedule push 경로로 분기.
+    // 디바이스는 사전 예약 알람(#584)으로 SLA를 보장하므로 phase-based silent push는 보내지 않는다.
+    if (trip.boardingLock && trip.boardingLock.expiresAt > now) {
+      try {
+        await runTrainCodeTracking(
+          trip,
+          waypoint,
+          trip.boardingLock,
+          env,
+          deps,
+          stats,
+          now,
+          log,
+          generatePushId,
+        );
+      } catch (e) {
+        stats.errors += 1;
+        log('boarding-lock poll error', { error: String(e), token: trip.token.slice(0, 8) });
+      }
+      continue;
+    }
 
     try {
       const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
@@ -268,6 +301,228 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     seoulCalls: deps.seoul.stats.callCount,
   });
   return stats;
+}
+
+/**
+ * boardingLock trip 추적 (#585).
+ *
+ * 3단계로 분리: estimate → arrival 시 waypoint 진행(early return) → 아니면 reschedule push.
+ * push가 trip 도착 시점에 의미 없으므로 도착 케이스를 먼저 처리해 dirty write를 단일화.
+ */
+export async function runTrainCodeTracking(
+  trip: Trip,
+  waypoint: Waypoint,
+  lock: BoardingLockMeta,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+  generatePushId: () => string,
+): Promise<void> {
+  const estimate = await estimateBoardingLockArrival(deps, lock, waypoint, now);
+  if (estimate === null) {
+    stats.etaMissing += 1;
+    log('boarding-lock: trainCode not found in arrivals or positions', {
+      token: trip.token.slice(0, 8),
+      trainCode: lock.trainCode,
+      station: waypoint.stationName,
+    });
+    return;
+  }
+
+  if (estimate.arrived) {
+    await advanceBoardingLockWaypoint(trip, waypoint, env, log);
+    return;
+  }
+
+  await maybeReschedulePush(trip, waypoint, lock, estimate.epoch, env, deps, stats, now, log, generatePushId);
+}
+
+type Logger = (message: string, meta?: Record<string, unknown>) => void;
+
+/**
+ * 다음 waypoint에 trainCode가 도착할 시각을 추정.
+ *   1순위: arrivals에서 trainCode 매칭 → barvlDt
+ *   2순위: positions에서 trainCode 위치 → segmentStations 인덱스 차이 기반
+ *   3순위: 둘 다 없음 → null
+ *
+ * arrived 판정: arrivals 경로는 arvlCd가 ENTERING(0, 진입) 또는 ARRIVED(1, 도착)인 경우.
+ * positions 경로는 estimateArrivalFromPosition이 sttus와 station 매치로 결정.
+ */
+export async function estimateBoardingLockArrival(
+  deps: ScheduledDeps,
+  lock: BoardingLockMeta,
+  waypoint: Waypoint,
+  now: number,
+): Promise<{ epoch: number; arrived: boolean } | null> {
+  const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
+  const matched = arrivals.find((a) => a.trainCode === lock.trainCode);
+  if (matched) {
+    return {
+      epoch: now + matched.arrivalSeconds * 1000,
+      arrived:
+        matched.arvlCd === ARRIVAL_CODE.ARRIVED || matched.arvlCd === ARRIVAL_CODE.ENTERING,
+    };
+  }
+  const positions = await deps.seoul.fetchPositions(lock.line);
+  const train = positions.find((p) => p.trainCode === lock.trainCode);
+  if (!train) return null;
+  const fallback = estimateArrivalFromPosition(train, waypoint.stationName, lock, now);
+  if (fallback.epoch === null) return null;
+  return { epoch: fallback.epoch, arrived: fallback.arrived };
+}
+
+/**
+ * waypoint 진행 처리. destination 도착 또는 last intermediate 통과 시 trip 삭제.
+ * baseline(lastTrackedArrivalEpoch)도 함께 리셋해 새 waypoint의 첫 push를 보장.
+ */
+export async function advanceBoardingLockWaypoint(
+  trip: Trip,
+  waypoint: Waypoint,
+  env: Env,
+  log: Logger,
+): Promise<void> {
+  if (waypoint.kind === 'destination') {
+    await deleteTrip(env.TRIPS, trip.token);
+    log('boarding-lock: destination arrived, trip cleared', {
+      token: trip.token.slice(0, 8),
+      station: waypoint.stationName,
+    });
+    return;
+  }
+  trip.waypoints.shift();
+  trip.lastTrackedArrivalEpoch = undefined;
+  log('boarding-lock: waypoint advanced', {
+    token: trip.token.slice(0, 8),
+    completed: waypoint.stationName,
+    kind: waypoint.kind,
+    remaining: trip.waypoints.length,
+  });
+  if (trip.waypoints.length === 0) {
+    await deleteTrip(env.TRIPS, trip.token);
+    return;
+  }
+  await putTrip(env.TRIPS, trip);
+}
+
+/**
+ * 임계치 이상 변동 시 reschedule silent push 발사. APNs env mismatch(#482) self-heal 포함.
+ * reschedule push는 alert fallback 대상이 아니므로 PENDING_PUSHES 미등록.
+ */
+export async function maybeReschedulePush(
+  trip: Trip,
+  waypoint: Waypoint,
+  lock: BoardingLockMeta,
+  newArrivalEpoch: number,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+  generatePushId: () => string,
+): Promise<void> {
+  const lastEpoch = trip.lastTrackedArrivalEpoch;
+  if (
+    lastEpoch !== undefined &&
+    Math.abs(newArrivalEpoch - lastEpoch) < RESCHEDULE_THRESHOLD_MS
+  ) {
+    return;
+  }
+
+  const pushId = generatePushId();
+  log('reschedule push', {
+    token: trip.token.slice(0, 8),
+    trainCode: lock.trainCode,
+    nextStation: waypoint.stationName,
+    newArrivalTimeEpoch: newArrivalEpoch,
+    previousEpoch: lastEpoch,
+  });
+
+  const send = (host: string) =>
+    sendReschedulePush({
+      deviceToken: trip.token,
+      pushId,
+      trainCode: lock.trainCode,
+      nextStation: waypoint.stationName,
+      newArrivalTimeEpoch: newArrivalEpoch,
+      sentAt: now,
+      config: deps.apnsConfig,
+      host,
+      fetchImpl: deps.fetchImpl,
+      now,
+    });
+
+  let result = await send(pickApnsHost(trip.apnsEnv, deps.apnsHosts));
+  let envMismatchExhausted = false;
+  let dirty = false;
+
+  // self-heal (#482): phase push 경로와 동일 정책. 양쪽 host 모두 BadDeviceToken이면 토큰 무효 판정.
+  if (!result.ok && isApnsEnvMismatch(result.status, result.reason)) {
+    const corrected = flipApnsEnv(trip.apnsEnv);
+    log('apns env mismatch — retry with opposite host', {
+      token: trip.token.slice(0, 8),
+      from: trip.apnsEnv ?? 'sandbox',
+      to: corrected,
+    });
+    const retry = await send(deps.apnsHosts[corrected]);
+    if (retry.ok) {
+      trip.apnsEnv = corrected;
+      dirty = true;
+      stats.envCorrected += 1;
+      log('apns env corrected', { token: trip.token.slice(0, 8), to: corrected });
+    } else if (isApnsEnvMismatch(retry.status, retry.reason)) {
+      envMismatchExhausted = true;
+    }
+    result = retry;
+  }
+
+  if (result.ok) {
+    stats.pushed += 1;
+    trip.lastTrackedArrivalEpoch = newArrivalEpoch;
+    dirty = true;
+  } else {
+    stats.errors += 1;
+    log('reschedule push failed', {
+      status: result.status,
+      reason: result.reason,
+      token: trip.token.slice(0, 8),
+    });
+    if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
+      await deleteTrip(env.TRIPS, trip.token);
+      return;
+    }
+  }
+
+  if (dirty) {
+    await putTrip(env.TRIPS, trip);
+  }
+}
+
+/**
+ * realtimePosition에서 trainCode 위치를 찾았을 때 다음 waypoint 도착 epoch을 추정한다.
+ * segmentStations에서 현재 위치 인덱스와 목표 인덱스의 차이 × hop time(90s default).
+ * 매핑 안 되면 epoch null — 호출자가 etaMissing 처리.
+ * 이미 도착(sttus=ARRIVED) + 목표역 일치이면 arrived=true.
+ */
+export function estimateArrivalFromPosition(
+  train: PositionEntry,
+  targetStation: string,
+  lock: BoardingLockMeta,
+  now: number,
+): { epoch: number | null; arrived: boolean } {
+  const currentIdx = lock.segmentStations.indexOf(train.stationName);
+  const targetIdx = lock.segmentStations.indexOf(targetStation);
+  if (currentIdx < 0 || targetIdx < 0) return { epoch: null, arrived: false };
+  // 이미 목표역에 도착했거나 지나친 경우
+  if (currentIdx >= targetIdx) {
+    return {
+      epoch: now,
+      arrived: train.trainSttus === TRAIN_STATUS.ARRIVED && train.stationName === targetStation,
+    };
+  }
+  const hops = targetIdx - currentIdx;
+  return { epoch: now + hops * FALLBACK_HOP_SEC * 1000, arrived: false };
 }
 
 /**

--- a/backend/alarm-worker/src/seoul.ts
+++ b/backend/alarm-worker/src/seoul.ts
@@ -7,10 +7,13 @@
  *   동일 사이클 내 중복 호출 차단이 주 목적)
  */
 
+import { canonicalLineName } from './lineAlias';
+
 const UP_DIRECTION_VALUES = ['상행', '내선'] as const;
 const SEOUL_API_TZ_OFFSET = '+09:00';
 const MAX_RECPTN_DRIFT_SEC = 120;
 const CACHE_TTL_MS = 15_000;
+const ERROR_CACHE_TTL_MS = 5_000;
 
 export interface ArrivalEntry {
   destination: string;
@@ -40,14 +43,67 @@ interface CacheEntry {
   data: ArrivalEntry[];
 }
 
+/** realtimePosition API의 1 train 항목 (#585 trainCode tracking). */
+export interface PositionEntry {
+  /** Seoul API trainNo / btrainNo (예: "7246") */
+  trainCode: string;
+  /** 현재 위치한 역명 */
+  stationName: string;
+  /** Seoul API trainSttus: 0:진입, 1:도착, 2:출발. `TRAIN_STATUS` 상수로 비교한다. 누락 시 null. */
+  trainSttus: number | null;
+  /** "상행"/"내선" 여부 */
+  isUp: boolean;
+  /** API 수신 시각 (epoch ms) — staleness 판정용. 누락 시 0. */
+  recptnMs: number;
+}
+
+interface PositionCacheEntry {
+  expiresAt: number;
+  data: PositionEntry[];
+}
+
 export class SeoulArrivalClient {
   private readonly cache = new Map<string, CacheEntry>();
+  private readonly positionCache = new Map<string, PositionCacheEntry>();
   private callCount = 0;
 
   constructor(private readonly options: FetchSeoulOptions) {}
 
   get stats(): { callCount: number; cacheSize: number } {
     return { callCount: this.callCount, cacheSize: this.cache.size };
+  }
+
+  /**
+   * realtimePosition(line) — 노선에 운행 중인 모든 열차 위치 (#585).
+   * 노선당 1 call로 trainCode 단위 추적이 가능하다.
+   * 캐시: 노선명 단위 15s (사이클 내 중복 호출 차단). 매핑 없는 line은 빈 배열.
+   */
+  async fetchPositions(line: string): Promise<PositionEntry[]> {
+    const lineName = canonicalLineName(line);
+    if (!lineName) return [];
+
+    const now = this.options.now?.() ?? Date.now();
+    const cached = this.positionCache.get(lineName);
+    if (cached && cached.expiresAt > now) return cached.data;
+
+    const fetchImpl = this.options.fetchImpl ?? fetch;
+    const url = `http://${this.options.host}/api/subway/${this.options.apiKey}/json/realtimePosition/0/100/${encodeURIComponent(lineName)}`;
+
+    this.callCount += 1;
+    const response = await fetchImpl(url);
+    if (!response.ok) {
+      this.positionCache.set(lineName, { expiresAt: now + ERROR_CACHE_TTL_MS, data: [] });
+      return [];
+    }
+
+    const data = (await response.json()) as { realtimePositionList?: unknown[] };
+    const items = Array.isArray(data.realtimePositionList) ? data.realtimePositionList : [];
+    const parsed = items
+      .map(parsePositionEntry)
+      .filter((e): e is PositionEntry => e !== null);
+
+    this.positionCache.set(lineName, { expiresAt: now + CACHE_TTL_MS, data: parsed });
+    return parsed;
   }
 
   async fetchArrivals(stationName: string): Promise<ArrivalEntry[]> {
@@ -64,7 +120,7 @@ export class SeoulArrivalClient {
     const response = await fetchImpl(url);
     if (!response.ok) {
       // 실패 시 빈 배열을 짧게 캐시해 폭주 방지
-      this.cache.set(stationName, { expiresAt: now + 5_000, data: [] });
+      this.cache.set(stationName, { expiresAt: now + ERROR_CACHE_TTL_MS, data: [] });
       return [];
     }
 
@@ -100,6 +156,22 @@ function parseEntry(raw: unknown, now: number): ArrivalEntry | null {
     isUp,
     subwayNm: typeof item.subwayNm === 'string' ? item.subwayNm : '',
     arvlCd: parseArvlCd(item.arvlCd),
+  };
+}
+
+function parsePositionEntry(raw: unknown): PositionEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const item = raw as Record<string, unknown>;
+  const trainCode = typeof item.trainNo === 'string' ? item.trainNo : '';
+  if (!trainCode) return null;
+  const stationName = typeof item.statnNm === 'string' ? item.statnNm : '';
+  const updnLine = typeof item.updnLine === 'string' ? item.updnLine : '';
+  return {
+    trainCode,
+    stationName,
+    trainSttus: parseArvlCd(item.trainSttus),
+    isUp: (UP_DIRECTION_VALUES as readonly string[]).includes(updnLine),
+    recptnMs: parseRecptnDt(item.lastRecptnDt),
   };
 }
 

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -71,6 +71,47 @@ export interface Trip {
    * 반드시 `apnsEnv: 'production'`을 명시한다.
    */
   apnsEnv?: ApnsEnv;
+  /**
+   * BoardingLock metadata (#584/#585). 디바이스가 사용자에게 탑승 열차를 확정받으면 보냄.
+   * 존재 시 backend는 trainCode 단위로 다음 hop 도착 시각을 추적하고, 변동 시 reschedule
+   * silent push로 디바이스 사전 예약을 정정한다. 없으면 기존 anchor waypoint 폴링으로 동작.
+   */
+  boardingLock?: BoardingLockMeta;
+  /**
+   * 마지막으로 디바이스에 reschedule push로 통지한 도착 시각 (epoch ms) — boardingLock 추적용.
+   * 새 관측이 이 값과 의미있게 어긋날 때만 push를 발사해 노이즈를 줄인다.
+   */
+  lastTrackedArrivalEpoch?: number;
+}
+
+/** Device가 확정한 탑승 열차 정보 (#584). */
+export interface BoardingLockMeta {
+  /** Seoul API btrainNo (예: "7246") */
+  trainCode: string;
+  /** 노선 (Waypoint.line과 동일 표기) */
+  line: LineNumber;
+  /** Seoul API subwayId (예: "1007") — 환승 노선 구분용 */
+  subwayId: string;
+  /** 사용자가 선택한 열차 출발 시각 (epoch ms) */
+  selectedDepartureTime: number;
+  /** 현 BoardingLock 구간 내 정차역 시퀀스 (출발역 → 구간 끝) */
+  segmentStations: string[];
+  /** Lock 자동 만료 시각 (epoch ms) */
+  expiresAt: number;
+}
+
+/**
+ * Reschedule silent push payload (#585).
+ * 디바이스가 사전 예약한 알람의 도착 시각이 backend 관측과 어긋날 때 발사.
+ * 디바이스는 이 push를 받아 기존 예약을 cancel하고 newArrivalTimeEpoch로 재예약한다.
+ */
+export interface ReschedulePushPayload {
+  pushId: string;
+  kind: 'reschedule';
+  trainCode: string;
+  nextStation: string;
+  newArrivalTimeEpoch: number;
+  sentAt: number;
 }
 
 /** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */


### PR DESCRIPTION
## Summary
- silent push의 역할을 "알람 발사"에서 "디바이스 사전 예약 정정 신호"로 격하 (#584 짝)
- boardingLock 활성 trip은 trainCode 단위 추적: arrivals 매칭 1순위, realtimePosition fallback
- |delta| >= 15s 변동 시에만 reschedule push, env mismatch self-heal(#482) 포함

## 변경 파일
- `types.ts`: BoardingLockMeta / ReschedulePushPayload / Trip.lastTrackedArrivalEpoch
- `index.ts`: validateTrip의 parseBoardingLock. isSameSession에서 trainCode 변경 시 baseline 리셋
- `alarm.ts`: TRAIN_STATUS 별도 정의 (ARRIVAL_CODE와 분리)
- `lineAlias.ts`: LINE_META 단일 소스 (canonical + aliases), 기존 LINE_ALIAS_MAP은 derive 호환 유지
- `seoul.ts`: fetchPositions(line) + PositionEntry
- `apns.ts`: sendReschedulePush (background priority 5, kind: 'reschedule')
- `scheduled.ts`: runTrainCodeTracking 경로 신설 (3 함수로 SRP 분할 + self-heal 인라인)

## 의도적 결정
- **PENDING_PUSHES 미등록**: reschedule push는 alert fallback 대상 아님. 디바이스 사전 예약(#584)이 SLA 보장 → graceful.
- **15초 sub-cycle 미구현**: 현재 cron 1분 cadence. Workers setTimeout은 wall time 위험 + DO 이전이 Phase 6으로 예정.
- **90s hop 고정**: realtimePosition fallback 경로의 hop time. 노선별 lookup은 trackingMissing 측정 누적 후 정밀화.
- **boardingLock 파싱 실패 시 trip은 살림**: 디바이스 schema 불일치로 알람 전체가 죽지 않게 graceful drop.

## Follow-up 이슈 후보
1. Phase 6: Durable Object alarm으로 15s sub-cycle 도입
2. hop time 노선별 lookup map
3. `stats.trackingMissing` 카운터 분리 (etaMissing 의미 오버로드 해소)
4. `validateTrip` logger 주입 (boardingLock drop 가시성)
5. `parseArvlCd` 리네임 / `parseTrainSttus` 분리
6. `runTrainCodeTracking`/`maybeReschedulePush` Context 객체화
7. reschedule self-heal helper 추출 (`sendWithEnvHeal()`) — phase push와 공유

## Test plan
- [x] npm test 243/243 통과
- [x] npm run type-check 깨끗
- [x] code-review 에이전트 머지 가능 판정 (P0/P1 0건)
- [ ] wrangler tail로 reschedule push 발사 실측 (#584 디바이스 후)

Closes #585