### PR TITLE
feat(#584): PR B — 도착 list UI + Lock 생성 진입점

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -33,6 +33,9 @@ import { resolveNotificationSource } from '../../src/utils/notificationSource';
 import { ArrivalSourceNotice } from '../../src/components/ArrivalSourceNotice';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 import { useArrivalAutoClear } from '../../src/hooks/useArrivalAutoClear';
+import { useBoardingLockController } from '../../src/hooks/useBoardingLockController';
+import { BoardingLockBanner } from '../../src/components/BoardingLockBanner';
+import { BoardingTrainList } from '../../src/components/BoardingTrainList';
 
 const logger = createLogger('HomeScreen');
 
@@ -184,6 +187,22 @@ export default function HomeScreen() {
     arrivalConfidence: confidence,
     fusionSource: source,
     locationUncertain,
+  });
+
+  // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,
+  // alarm/Fusion과의 wiring은 후속 PR C/D에서 활성화된다.
+  const {
+    lock: boardingLock,
+    directionalArrivals,
+    createLockFromTrain,
+    releaseLock: releaseBoardingLock,
+  } = useBoardingLockController({
+    destinationId: destination?.id ?? null,
+    destinationName: destination?.name ?? null,
+    route,
+    arrival,
+    currentStation: result?.station ?? null,
+    expectedDurationMinutes: staticEtaMinutes,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({
@@ -608,6 +627,17 @@ export default function HomeScreen() {
             )}
 
             {/* Arrivals — 현재역(effectiveOrigin)이 확정되면 trip 유무와 무관하게 노출 */}
+            {/* #584 PR B — BoardingLock 진입점. 활성 시 banner, 비활성 + destination 설정 시 train list. */}
+            {destination && boardingLock && (
+              <BoardingLockBanner lock={boardingLock} onRelease={releaseBoardingLock} />
+            )}
+            {destination && !boardingLock && effectiveOrigin && (
+              <BoardingTrainList
+                arrivals={directionalArrivals}
+                line={effectiveOrigin.line}
+                onSelect={createLockFromTrain}
+              />
+            )}
             {effectiveOrigin && (
               <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
                 <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('home.arrivalInfoTitle')}</Text>

--- a/src/components/BoardingLockBanner.tsx
+++ b/src/components/BoardingLockBanner.tsx
@@ -1,0 +1,66 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme, typography, spacing, radius } from '../theme';
+import { LineBadge } from './LineBadge';
+import type { BoardingLock } from '../types/boardingLock';
+
+interface Props {
+  lock: BoardingLock;
+  onRelease: () => void;
+}
+
+/**
+ * BoardingLock 활성 시 노출되는 배너 (#584 PR B).
+ *
+ * 사용자에게 어떤 열차/노선에 lock 되어 있는지 명시. "하차" 탭으로 즉시 release.
+ * 이 PR에서는 lock 정보만 표시 — 알람과의 연결은 PR C/D에서 활성화.
+ */
+export function BoardingLockBanner({ lock, onRelease }: Props) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.card, borderColor: colors.accent }]}
+      testID="boarding-lock-banner"
+    >
+      <View style={styles.info}>
+        <Text style={[typography.label, { color: colors.muted }]}>탑승 중</Text>
+        <View style={styles.row}>
+          <LineBadge line={lock.boardingLine} />
+          <Text style={[typography.mono, { color: colors.ink }]}>{lock.trainCode}</Text>
+        </View>
+      </View>
+      <Pressable
+        onPress={onRelease}
+        style={[styles.releaseButton, { borderColor: colors.accent }]}
+        testID="boarding-lock-release"
+      >
+        <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>하차</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    gap: spacing.md,
+  },
+  info: {
+    gap: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  releaseButton: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+});

--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -1,0 +1,80 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme, typography, spacing, radius } from '../theme';
+import { LineBadge } from './LineBadge';
+import type { ArrivalInfo } from '../api/arrivalApi';
+import type { LineNumber } from '../types/station';
+
+interface Props {
+  arrivals: ArrivalInfo[];
+  line: LineNumber;
+  onSelect: (train: ArrivalInfo) => void;
+}
+
+/**
+ * 현재역 도착 list — 사용자가 탑승할 열차를 명시적으로 선택하는 진입점 (#584 PR B).
+ *
+ * 호출자는 이미 route 방향으로 필터링된 arrivals를 전달한다 — 이 컴포넌트는 디스플레이/탭 처리만 담당.
+ * 각 row를 탭하면 onSelect 콜백이 발화 → 호출자가 BoardingLock 생성.
+ * 빈 list면 placeholder 안내 텍스트.
+ */
+export function BoardingTrainList({ arrivals, line, onSelect }: Props) {
+  const { colors } = useTheme();
+
+  if (arrivals.length === 0) {
+    return (
+      <View style={styles.empty} testID="boarding-train-list-empty">
+        <Text style={[typography.bodySm, { color: colors.muted }]}>도착 예정 열차가 없습니다.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container} testID="boarding-train-list">
+      <View style={styles.header}>
+        <LineBadge line={line} />
+        <Text style={[typography.label, { color: colors.muted }]}>탑승할 열차 선택</Text>
+      </View>
+      {arrivals.map((train) => (
+        <Pressable
+          key={train.trainCode}
+          onPress={() => onSelect(train)}
+          style={[styles.row, { backgroundColor: colors.card }]}
+          testID={`boarding-train-row-${train.trainCode}`}
+        >
+          <View style={styles.rowInfo}>
+            <Text style={[typography.body, { color: colors.ink }]}>{train.destination} 행</Text>
+            <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
+          </View>
+          <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
+            {train.arrivalMinutes}분
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.lg,
+    borderRadius: radius.md,
+  },
+  rowInfo: {
+    gap: spacing.xs,
+  },
+  empty: {
+    padding: spacing.lg,
+    alignItems: 'center',
+  },
+});

--- a/src/components/__tests__/BoardingLockBanner.test.tsx
+++ b/src/components/__tests__/BoardingLockBanner.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent } from '@testing-library/react-native';
+import { BoardingLockBanner } from '../BoardingLockBanner';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import type { BoardingLock } from '../../types/boardingLock';
+
+const lock: BoardingLock = {
+  destinationId: 'dest-1',
+  trainCode: 'T-100',
+  boardingStationId: 'stn-A',
+  boardingLine: '2',
+  boardedAt: 1_700_000_000_000,
+  expectedDurationMs: 600_000,
+};
+
+describe('BoardingLockBanner', () => {
+  it('trainCode + line label을 렌더', () => {
+    const { getByText, getByTestId } = renderWithTheme(
+      <BoardingLockBanner lock={lock} onRelease={() => {}} />,
+    );
+    expect(getByTestId('boarding-lock-banner')).toBeTruthy();
+    expect(getByText('T-100')).toBeTruthy();
+    expect(getByText('탑승 중')).toBeTruthy();
+  });
+
+  it('하차 버튼 탭 시 onRelease 호출', () => {
+    const onRelease = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <BoardingLockBanner lock={lock} onRelease={onRelease} />,
+    );
+    fireEvent.press(getByTestId('boarding-lock-release'));
+    expect(onRelease).toHaveBeenCalledTimes(1);
+  });
+
+});

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent } from '@testing-library/react-native';
+import { BoardingTrainList } from '../BoardingTrainList';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import type { ArrivalInfo } from '../../api/arrivalApi';
+
+function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
+  return {
+    destination: '상행 종착역',
+    arrivalMinutes: 3,
+    arrivalSeconds: 180,
+    statusMessage: '',
+    trainCode: 'T-1',
+    receivedAtMs: 0,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+describe('BoardingTrainList', () => {
+  it('arrivals 비어있을 때 placeholder 렌더', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <BoardingTrainList arrivals={[]} line="2" onSelect={() => {}} />,
+    );
+    expect(getByTestId('boarding-train-list-empty')).toBeTruthy();
+    expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
+  });
+
+  it('각 train마다 trainCode + destination + arrivalMinutes 렌더', () => {
+    const trains = [makeTrain({ trainCode: 'T-A', destination: '강남', arrivalMinutes: 2 })];
+    const { getByText, getByTestId } = renderWithTheme(
+      <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
+    );
+    expect(getByTestId('boarding-train-row-T-A')).toBeTruthy();
+    expect(getByText('강남 행')).toBeTruthy();
+    expect(getByText('T-A')).toBeTruthy();
+    expect(getByText('2분')).toBeTruthy();
+  });
+
+  it('train row 탭 시 onSelect에 해당 train 전달', () => {
+    const train = makeTrain({ trainCode: 'T-B' });
+    const onSelect = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList arrivals={[train]} line="2" onSelect={onSelect} />,
+    );
+    fireEvent.press(getByTestId('boarding-train-row-T-B'));
+    expect(onSelect).toHaveBeenCalledWith(train);
+  });
+
+  it('탑승할 열차 선택 헤더 텍스트 표시', () => {
+    const { getByText } = renderWithTheme(
+      <BoardingTrainList arrivals={[makeTrain()]} line="2" onSelect={() => {}} />,
+    );
+    expect(getByText('탑승할 열차 선택')).toBeTruthy();
+  });
+
+});

--- a/src/constants/boardingLock.ts
+++ b/src/constants/boardingLock.ts
@@ -1,0 +1,10 @@
+/**
+ * BoardingLock 관련 상수 — PR C/D에서 scheduler/알람도 참조해 drift 방지 (#584).
+ */
+
+/**
+ * trip ETA 미상 시 lock 생성에 사용할 fallback 지속시간(분).
+ * 자동 만료는 expectedDurationMs × BOARDING_LOCK_EXPIRY_FACTOR(=1.5)이므로
+ * fallback 적용 시 30 × 1.5 = 45분 후 자동 release.
+ */
+export const FALLBACK_BOARDING_DURATION_MINUTES = 30;

--- a/src/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockController.test.tsx
@@ -1,0 +1,283 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { AppState } from 'react-native';
+import {
+  useBoardingLockController,
+  type UseBoardingLockControllerInputs,
+} from '../useBoardingLockController';
+import { useBoardingLockStore } from '../../store/useBoardingLockStore';
+import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
+import type { Station } from '../../types/station';
+import type { DirectRoute } from '../../utils/stationRoute';
+import type { BoardingLock } from '../../types/boardingLock';
+
+const mockGetBoardingLock = jest.fn();
+const mockSetBoardingLock = jest.fn();
+const mockClearBoardingLock = jest.fn();
+
+jest.mock('../../utils/boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+  setBoardingLock: (...args: unknown[]) => mockSetBoardingLock(...args),
+  clearBoardingLock: (...args: unknown[]) => mockClearBoardingLock(...args),
+}));
+
+const mockResolveTripDirection = jest.fn();
+jest.mock('../../utils/tripDirection', () => ({
+  resolveTripDirection: (...args: unknown[]) => mockResolveTripDirection(...args),
+}));
+
+function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
+  return {
+    destination: '종착',
+    arrivalMinutes: 3,
+    arrivalSeconds: 180,
+    statusMessage: '',
+    trainCode: 'T-1',
+    receivedAtMs: 0,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+const stationA: Station = {
+  id: 'stn-A',
+  name: '강남',
+  line: '2',
+  lineColor: '#000',
+  lat: 37.5,
+  lng: 127.0,
+};
+
+const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+
+const upTrain = makeTrain({ trainCode: 'UP-1' });
+const downTrain = makeTrain({ trainCode: 'DN-1' });
+const arrival: StationArrival = { up: [upTrain], down: [downTrain] };
+
+const defaultInputs: UseBoardingLockControllerInputs = {
+  destinationId: 'dest-1',
+  destinationName: '성수',
+  route,
+  arrival,
+  currentStation: stationA,
+  expectedDurationMinutes: 20,
+};
+
+describe('useBoardingLockController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBoardingLock.mockResolvedValue(null);
+    mockSetBoardingLock.mockResolvedValue(undefined);
+    mockClearBoardingLock.mockResolvedValue(undefined);
+    mockResolveTripDirection.mockReturnValue(null);
+    useBoardingLockStore.setState({ lock: null });
+  });
+
+  it('마운트 시 loadLock 호출 → storage에서 복원', async () => {
+    const stored: BoardingLock = {
+      destinationId: 'dest-1',
+      trainCode: 'T-100',
+      boardingStationId: 'stn-A',
+      boardingLine: '2',
+      boardedAt: Date.now(),
+      expectedDurationMs: 600_000,
+    };
+    mockGetBoardingLock.mockResolvedValueOnce(stored);
+    const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+    await waitFor(() => expect(result.current.lock).toEqual(stored));
+  });
+
+  describe('directionalArrivals', () => {
+    it("direction='up'이면 arrival.up만", () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      expect(result.current.directionalArrivals).toEqual([upTrain]);
+    });
+
+    it("direction='down'이면 arrival.down만", () => {
+      mockResolveTripDirection.mockReturnValue('down');
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      expect(result.current.directionalArrivals).toEqual([downTrain]);
+    });
+
+    it('direction 미정이면 up+down 합집합', () => {
+      mockResolveTripDirection.mockReturnValue(null);
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      expect(result.current.directionalArrivals).toEqual([upTrain, downTrain]);
+    });
+
+    it('arrival null이면 빈 배열', () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: null }),
+      );
+      expect(result.current.directionalArrivals).toEqual([]);
+    });
+
+    it('route/destinationName/currentStation 누락이면 direction null로 폴백 → 합집합', () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, route: null }),
+      );
+      expect(mockResolveTripDirection).not.toHaveBeenCalled();
+      expect(result.current.directionalArrivals).toEqual([upTrain, downTrain]);
+    });
+  });
+
+  describe('createLockFromTrain', () => {
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    });
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('expectedDurationMinutes를 ms로 변환해 lock 생성', async () => {
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain({ trainCode: 'T-X' }));
+      });
+      expect(mockSetBoardingLock).toHaveBeenCalledWith({
+        destinationId: 'dest-1',
+        trainCode: 'T-X',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: 1_700_000_000_000,
+        expectedDurationMs: 20 * 60_000,
+      });
+    });
+
+    it('expectedDurationMinutes null이면 fallback 30분', async () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, expectedDurationMinutes: null }),
+      );
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain());
+      });
+      expect(mockSetBoardingLock).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedDurationMs: 30 * 60_000 }),
+      );
+    });
+
+    it('destinationId 또는 currentStation 누락이면 no-op', async () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, destinationId: null }),
+      );
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain());
+      });
+      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('currentStation null이어도 no-op', async () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, currentStation: null }),
+      );
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain());
+      });
+      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('releaseLock', () => {
+    it('store releaseLock으로 위임 — storage clear', async () => {
+      useBoardingLockStore.setState({
+        lock: {
+          destinationId: 'dest-1',
+          trainCode: 'T-1',
+          boardingStationId: 'stn-A',
+          boardingLine: '2',
+          boardedAt: Date.now(),
+          expectedDurationMs: 600_000,
+        },
+      });
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.releaseLock();
+      });
+      await waitFor(() => expect(mockClearBoardingLock).toHaveBeenCalled());
+    });
+  });
+
+  describe('destination 변경 자동 release', () => {
+    it('현재 lock의 destinationId가 input.destinationId와 다르면 자동 release', async () => {
+      const stale: BoardingLock = {
+        destinationId: 'dest-old',
+        trainCode: 'T-1',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+      };
+      mockGetBoardingLock.mockResolvedValueOnce(stale);
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await waitFor(() => expect(mockClearBoardingLock).toHaveBeenCalled());
+    });
+
+    it('같은 destinationId면 release 안 함', async () => {
+      const matching: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: 'T-1',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+      };
+      mockGetBoardingLock.mockResolvedValueOnce(matching);
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await waitFor(() => expect(useBoardingLockStore.getState().lock).toEqual(matching));
+      expect(mockClearBoardingLock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AppState 만료 검사', () => {
+    it("AppState 'active' 진입 시 checkExpiry 트리거 → 만료된 lock 정리", async () => {
+      const expiredLock: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: 'T-1',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: 1, // 매우 과거 → 항상 만료
+        expectedDurationMs: 1,
+      };
+      useBoardingLockStore.setState({ lock: expiredLock });
+      const listeners: Array<(s: 'active' | 'background') => void> = [];
+      jest.spyOn(AppState, 'addEventListener').mockImplementation(((event: string, h: (s: 'active' | 'background') => void) => {
+        listeners.push(h);
+        return { remove: jest.fn() };
+      }) as never);
+
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await waitFor(() => expect(listeners.length).toBeGreaterThan(0));
+      await act(async () => {
+        listeners[0]('active');
+      });
+      await waitFor(() => expect(mockClearBoardingLock).toHaveBeenCalled());
+    });
+
+    it("'background' 진입은 checkExpiry 트리거 안 함", async () => {
+      const listeners: Array<(s: 'active' | 'background') => void> = [];
+      jest.spyOn(AppState, 'addEventListener').mockImplementation(((event: string, h: (s: 'active' | 'background') => void) => {
+        listeners.push(h);
+        return { remove: jest.fn() };
+      }) as never);
+
+      useBoardingLockStore.setState({ lock: null });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await waitFor(() => expect(listeners.length).toBeGreaterThan(0));
+      mockClearBoardingLock.mockClear();
+      await act(async () => {
+        listeners[0]('background');
+      });
+      expect(mockClearBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('unmount 시 AppState listener remove', async () => {
+      const remove = jest.fn();
+      jest.spyOn(AppState, 'addEventListener').mockReturnValue({ remove } as never);
+      const { unmount } = renderHook(() => useBoardingLockController(defaultInputs));
+      unmount();
+      expect(remove).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useBoardingLockController.ts
+++ b/src/hooks/useBoardingLockController.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { resolveTripDirection } from '../utils/tripDirection';
+import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
+import type { Route } from '../utils/stationRoute';
+import type { Station } from '../types/station';
+import type { BoardingLock } from '../types/boardingLock';
+import { FALLBACK_BOARDING_DURATION_MINUTES } from '../constants/boardingLock';
+
+export interface UseBoardingLockControllerInputs {
+  destinationId: string | null;
+  destinationName: string | null;
+  route: Route;
+  arrival: StationArrival | null;
+  currentStation: Station | null;
+  /**
+   * 정적 ETA(분). createLock 시 expectedDurationMs 계산에 사용된다.
+   * null이면 fallback 30분 — 잘못된 Lock이라도 자동 만료(× 1.5)가 작동한다.
+   */
+  expectedDurationMinutes: number | null;
+}
+
+export interface UseBoardingLockControllerResult {
+  lock: BoardingLock | null;
+  /** route 진행 방향으로 필터된 도착 list. 방향 미상이면 up+down 합집합. */
+  directionalArrivals: ArrivalInfo[];
+  /** 사용자가 도착 list에서 열차 탭 시 호출. lock 생성을 위한 컨텍스트가 부족하면 no-op. */
+  createLockFromTrain: (train: ArrivalInfo) => void;
+  /** 명시 하차. lock 없는 상태에서 호출돼도 안전. */
+  releaseLock: () => void;
+}
+
+/**
+ * BoardingLock 제어 hook (#584 PR B).
+ *
+ * 책임:
+ *  - 마운트 시 storage에서 lock 복원
+ *  - destination 변경 시 stale lock 자동 release (다른 trip의 lock이 남는 것 차단)
+ *  - AppState 'active' 진입 시 만료 검사
+ *  - route 진행 방향으로 도착 list 필터링 — UI에 전달
+ *  - 열차 탭 → BoardingLock 생성 (current station + line + 정적 ETA × 60_000 ms)
+ *
+ * 이번 PR 범위: UI 진입점 wiring. Fusion/scheduler 통합은 PR C/D.
+ */
+export function useBoardingLockController({
+  destinationId,
+  destinationName,
+  route,
+  arrival,
+  currentStation,
+  expectedDurationMinutes,
+}: UseBoardingLockControllerInputs): UseBoardingLockControllerResult {
+  const lock = useBoardingLockStore((s) => s.lock);
+  const loadLock = useBoardingLockStore((s) => s.loadLock);
+  const createLock = useBoardingLockStore((s) => s.createLock);
+  const releaseLock = useBoardingLockStore((s) => s.releaseLock);
+  const checkExpiry = useBoardingLockStore((s) => s.checkExpiry);
+
+  // 마운트 시 storage hydrate.
+  useEffect(() => {
+    void loadLock();
+  }, [loadLock]);
+
+  // destination 변경 → stale lock release. 같은 destination이면 그대로 유지(앱 재시작 등).
+  useEffect(() => {
+    if (lock && lock.destinationId !== destinationId) {
+      void releaseLock();
+    }
+  }, [lock, destinationId, releaseLock]);
+
+  // AppState active 진입 시 만료 검사 + 마운트 직후 1회.
+  useEffect(() => {
+    void checkExpiry();
+    const handler = (state: AppStateStatus): void => {
+      if (state === 'active') void checkExpiry();
+    };
+    const sub = AppState.addEventListener('change', handler);
+    return () => sub.remove();
+  }, [checkExpiry]);
+
+  const direction = useMemo(() => {
+    if (!route || !destinationName || !currentStation) return null;
+    return resolveTripDirection(route, destinationName, currentStation.id);
+  }, [route, destinationName, currentStation]);
+
+  const directionalArrivals = useMemo<ArrivalInfo[]>(() => {
+    if (!arrival) return [];
+    if (direction === 'up') return arrival.up;
+    if (direction === 'down') return arrival.down;
+    return [...arrival.up, ...arrival.down];
+  }, [arrival, direction]);
+
+  const createLockFromTrain = useCallback(
+    (train: ArrivalInfo) => {
+      if (!destinationId || !currentStation) return;
+      const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
+      void createLock({
+        destinationId,
+        trainCode: train.trainCode,
+        boardingStationId: currentStation.id,
+        boardingLine: currentStation.line,
+        boardedAt: Date.now(),
+        expectedDurationMs: durationMin * 60_000,
+      });
+    },
+    [destinationId, currentStation, expectedDurationMinutes, createLock],
+  );
+
+  const release = useCallback(() => {
+    void releaseLock();
+  }, [releaseLock]);
+
+  return {
+    lock,
+    directionalArrivals,
+    createLockFromTrain,
+    releaseLock: release,
+  };
+}


### PR DESCRIPTION
## 범위 (#584 슬라이스 2/5)

PR A에서 만든 BoardingLock 모델 위에 사용자 진입점 UI를 얹는다. **알람과는 미연결** — 사용자가 열차를 탭해 Lock이 생성돼도 알람 동작은 PR C 머지 후 활성화.

## 변경

| 파일 | 내용 |
|---|---|
| \`components/BoardingLockBanner.tsx\` | 활성 lock 표시 + 하차 버튼 |
| \`components/BoardingTrainList.tsx\` | 방향 필터된 train list, tap → onSelect 콜백 |
| \`hooks/useBoardingLockController.ts\` | mount hydrate / AppState 만료 검사 / destination 변경 자동 release / 방향 필터 (\`resolveTripDirection\`) / createLockFromTrain |
| \`app/(tabs)/index.tsx\` | controller 호출 + 조건부 렌더 (lock 활성 시 banner, 비활성 + destination set 시 train list) |
| \`constants/boardingLock.ts\` | \`FALLBACK_BOARDING_DURATION_MINUTES=30\` (PR C/D scheduler drift 방지) |

## 설계 결정

- **방향 필터** — \`resolveTripDirection\`으로 'up'/'down' 판정. 미정이면 \`up+down\` 합집합으로 degrade — UI 항상 동작.
- **destination 변경 자동 release** — stale lock 누수를 데이터 주도로 차단.
- **AppState 'active' → checkExpiry** — 백그라운드에서 trip 종료된 lock 자동 정리.
- **expectedDurationMs = staticEtaMinutes × 60_000** — fallback 30분 적용 시 자동 만료 45분 (1.5×).

## 후속 PR 예고

- PR C: 사전 예약 scheduler — Lock 생성 시 알람 예약 발사
- PR D: Fusion 통합 + 잘못 탑승 토스트/재선택 모달
- PR E: 환승 시 새 Lock 전환

## 검증

- [x] 1961 tests pass, 100% coverage
- [x] tsc clean
- [x] 사용자: 도착 list 탭 → banner 표시 → 하차 버튼으로 release 가능
- [x] 알람 동작은 아직 변화 없음 (기존 GPS 기반 그대로)

Refs #584