### PR TITLE
feat(#584): PR C — BoardingLock 사전 예약 scheduler

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,6 +34,7 @@ import { ArrivalSourceNotice } from '../../src/components/ArrivalSourceNotice';
 import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 import { useArrivalAutoClear } from '../../src/hooks/useArrivalAutoClear';
 import { useBoardingLockController } from '../../src/hooks/useBoardingLockController';
+import { useBoardingLockScheduler } from '../../src/hooks/useBoardingLockScheduler';
 import { BoardingLockBanner } from '../../src/components/BoardingLockBanner';
 import { BoardingTrainList } from '../../src/components/BoardingTrainList';
 
@@ -203,6 +204,11 @@ export default function HomeScreen() {
     arrival,
     currentStation: result?.station ?? null,
     expectedDurationMinutes: staticEtaMinutes,
+  });
+  useBoardingLockScheduler({
+    lock: boardingLock,
+    route,
+    destinationName: destination?.name ?? null,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -33,3 +33,7 @@ export const FIRED_PUSH_IDS_KEY = 'subway-now:fired-push-ids';
 // #584 PR A — 사용자가 명시적으로 확정한 탑승 열차/노선/시각. trip 종료 또는 자동 만료까지 유지.
 // 형식: BoardingLock JSON (src/types/boardingLock.ts).
 export const BOARDING_LOCK_KEY = 'subway-now:boarding-lock';
+// #584 PR C — boardingLockScheduler가 OS에 사전 예약한 알림 identifier 목록.
+// release/expiry 또는 새 Lock 시점에 일괄 cancel하기 위한 추적 큐.
+// 형식: string[] JSON.
+export const SCHEDULED_NOTIFICATIONS_KEY = 'subway-now:scheduled-notifications';

--- a/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -1,0 +1,158 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useBoardingLockScheduler } from '../useBoardingLockScheduler';
+import {
+  cancelAllHopsForLock,
+  scheduleHopsForLock,
+} from '../../utils/boardingLockScheduler';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { DirectRoute } from '../../utils/stationRoute';
+
+jest.mock('../../utils/boardingLockScheduler', () => ({
+  scheduleHopsForLock: jest.fn(),
+  cancelAllHopsForLock: jest.fn(),
+}));
+const mockLoggerError = jest.fn();
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  }),
+}));
+
+const mockedSchedule = scheduleHopsForLock as jest.MockedFunction<typeof scheduleHopsForLock>;
+const mockedCancel = cancelAllHopsForLock as jest.MockedFunction<typeof cancelAllHopsForLock>;
+
+const lockA: BoardingLock = {
+  destinationId: 'd',
+  trainCode: 'A',
+  boardingStationId: 's',
+  boardingLine: '2',
+  boardedAt: 1,
+  expectedDurationMs: 1000,
+};
+const lockB: BoardingLock = { ...lockA, trainCode: 'B' };
+const route: DirectRoute = { type: 'direct', stops: 2, line: '2' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedSchedule.mockResolvedValue([]);
+  mockedCancel.mockResolvedValue(undefined);
+});
+
+describe('useBoardingLockScheduler', () => {
+  it('초기 마운트 시 lock=null이면 cancel/schedule 둘 다 호출 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockScheduler({ lock: null, route, destinationName: '강남' }),
+    );
+    await waitFor(() => {
+      expect(mockedCancel).not.toHaveBeenCalled();
+      expect(mockedSchedule).not.toHaveBeenCalled();
+    });
+  });
+
+  it('초기 마운트 시 lock 있으면 schedule만 호출', async () => {
+    renderHook(() =>
+      useBoardingLockScheduler({ lock: lockA, route, destinationName: '강남' }),
+    );
+    await waitFor(() => {
+      expect(mockedSchedule).toHaveBeenCalledWith({
+        lock: lockA,
+        route,
+        destinationName: '강남',
+      });
+      expect(mockedCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  it('lock 신규 생성(null → A): schedule만', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: null, route, destinationName: '강남' } },
+    );
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedSchedule).toHaveBeenCalledTimes(1);
+      expect(mockedCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  it('lock 교체(A → B): A cancel 후 B schedule', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockB, route, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedCancel).toHaveBeenCalledWith(lockA);
+      expect(mockedSchedule).toHaveBeenCalledTimes(2);
+      expect(mockedSchedule).toHaveBeenLastCalledWith({
+        lock: lockB,
+        route,
+        destinationName: '강남',
+      });
+    });
+  });
+
+  it('lock 해제(A → null): cancel만, schedule 추가 없음', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: null, route, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedCancel).toHaveBeenCalledWith(lockA);
+    });
+    expect(mockedSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('같은 trainCode로 객체만 갱신되면 재호출 안 함', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: { ...lockA }, route, destinationName: '강남' });
+    // wait one tick
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSchedule).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('lock 있지만 route 또는 destinationName 미상이면 cancel만 호출 (이전 lock 있을 때)', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockB, route: null, destinationName: '강남' });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledWith(lockA));
+    expect(mockedSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('scheduleHopsForLock 실패는 logger.error로 기록되고 throw 없음', async () => {
+    mockedSchedule.mockRejectedValueOnce(new Error('boom'));
+    renderHook(() =>
+      useBoardingLockScheduler({ lock: lockA, route, destinationName: '강남' }),
+    );
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith('scheduler 전환 실패:', expect.any(Error));
+    });
+  });
+
+  it('lock 있지만 destinationName=null이면 schedule 호출 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockScheduler({ lock: lockA, route, destinationName: null }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useBoardingLockScheduler.ts
+++ b/src/hooks/useBoardingLockScheduler.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import type { BoardingLock } from '../types/boardingLock';
+import type { Route } from '../utils/stationRoute';
+import {
+  cancelAllHopsForLock,
+  scheduleHopsForLock,
+} from '../utils/boardingLockScheduler';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useBoardingLockScheduler');
+
+export interface UseBoardingLockSchedulerInputs {
+  lock: BoardingLock | null;
+  route: Route;
+  destinationName: string | null;
+}
+
+/**
+ * Lock 변화에 반응해 boardingLockScheduler를 호출한다 (#584 PR C).
+ *
+ * - 신규 Lock(또는 trainCode 변경) → 이전 Lock 알람 일괄 cancel + 새 Lock으로 사전 예약
+ * - Lock 해제(null) → 이전 Lock 알람 일괄 cancel
+ * - route/destination만 바뀐 경우는 재예약하지 않는다 — 동일 trip의 route 변동은 PR D에서
+ *   advanceHopWindow로 처리하는 것이 정확하기 때문이다.
+ *
+ * 호출 측은 1회만 마운트한다 (홈 탭). 다른 화면에서도 BoardingLockStore를 읽지만,
+ * scheduler 호출 책임은 단일 owner인 이 hook이 진다.
+ */
+export function useBoardingLockScheduler({
+  lock,
+  route,
+  destinationName,
+}: UseBoardingLockSchedulerInputs): void {
+  const prevLockRef = useRef<BoardingLock | null>(null);
+
+  useEffect(() => {
+    const prev = prevLockRef.current;
+    const prevTrain = prev?.trainCode ?? null;
+    const nextTrain = lock?.trainCode ?? null;
+
+    if (prevTrain === nextTrain) {
+      // 같은 trainCode(또는 둘 다 null) — 재예약 없음. ref만 최신화하여 다음 비교 정확성 유지.
+      prevLockRef.current = lock;
+      return;
+    }
+
+    const handleTransition = async (): Promise<void> => {
+      if (prev) {
+        await cancelAllHopsForLock(prev);
+      }
+      if (lock && route && destinationName) {
+        await scheduleHopsForLock({ lock, route, destinationName });
+      }
+    };
+    handleTransition().catch((e: unknown) => {
+      logger.error('scheduler 전환 실패:', e);
+    });
+    prevLockRef.current = lock;
+  }, [lock, route, destinationName]);
+}

--- a/src/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/utils/__tests__/boardingLockScheduler.test.ts
@@ -1,0 +1,427 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import {
+  advanceHopWindow,
+  boardingLockAlarmIdentifier,
+  cancelAllHopsForLock,
+  parseBoardingLockAlarmIdentifier,
+  purgeBoardingLockSchedulerQueue,
+  scheduleHopsForLock,
+} from '../boardingLockScheduler';
+import {
+  addScheduledNotificationIds,
+  getScheduledNotificationIds,
+  removeScheduledNotificationIds,
+  clearScheduledNotificationIds,
+} from '../scheduledNotificationsStorage';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
+
+jest.mock('expo-notifications');
+jest.mock('../scheduledNotificationsStorage', () => ({
+  addScheduledNotificationIds: jest.fn(),
+  removeScheduledNotificationIds: jest.fn(),
+  getScheduledNotificationIds: jest.fn(),
+  clearScheduledNotificationIds: jest.fn(),
+}));
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+jest.mock('../stationNotification', () => ({
+  buildAlarmContent: (event: { stationName: string; phaseId: string }) => ({
+    title: `T:${event.phaseId}`,
+    body: `B:${event.stationName}`,
+  }),
+}));
+
+const mockedSchedule = Notifications.scheduleNotificationAsync as jest.MockedFunction<
+  typeof Notifications.scheduleNotificationAsync
+>;
+const mockedCancel = Notifications.cancelScheduledNotificationAsync as jest.MockedFunction<
+  typeof Notifications.cancelScheduledNotificationAsync
+>;
+const mockedDismiss = Notifications.dismissNotificationAsync as jest.MockedFunction<
+  typeof Notifications.dismissNotificationAsync
+>;
+
+const mockedAdd = addScheduledNotificationIds as jest.MockedFunction<
+  typeof addScheduledNotificationIds
+>;
+const mockedRemove = removeScheduledNotificationIds as jest.MockedFunction<
+  typeof removeScheduledNotificationIds
+>;
+const mockedGet = getScheduledNotificationIds as jest.MockedFunction<
+  typeof getScheduledNotificationIds
+>;
+const mockedClear = clearScheduledNotificationIds as jest.MockedFunction<
+  typeof clearScheduledNotificationIds
+>;
+
+const NOW = new Date('2026-06-01T00:00:00Z').getTime();
+
+const lock: BoardingLock = {
+  destinationId: 'dest-1',
+  trainCode: 'T-100',
+  boardingStationId: 'stn-A',
+  boardingLine: '2',
+  boardedAt: NOW,
+  expectedDurationMs: 600_000,
+};
+
+const directRoute: DirectRoute = { type: 'direct', stops: 2, line: '2' };
+const transferRoute: TransferRoute = {
+  type: 'transfer',
+  transferName: '교대',
+  fromLine: '2',
+  toLine: '3',
+  stopsToTransfer: 2,
+  stopsFromTransfer: 3,
+};
+const multiRoute: MultiTransferRoute = {
+  type: 'multi-transfer',
+  transfers: [
+    { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 2 },
+    { transferName: '약수', fromLine: '3', toLine: '6', stopsToTransfer: 2 },
+    { transferName: '한강진', fromLine: '6', toLine: '7', stopsToTransfer: 1 },
+  ],
+  stopsAfterLastTransfer: 2,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGet.mockResolvedValue([]);
+  Object.defineProperty(Platform, 'OS', { configurable: true, value: 'ios' });
+});
+
+describe('boardingLockAlarmIdentifier / parse', () => {
+  it('round-trip 정상', () => {
+    const id = boardingLockAlarmIdentifier({
+      trainCode: 'T-100',
+      hopIndex: 2,
+      phase: 'imminent',
+      stationName: '강남',
+    });
+    expect(id).toBe('bl:T-100:2:imminent:강남');
+    expect(parseBoardingLockAlarmIdentifier(id)).toEqual({
+      trainCode: 'T-100',
+      hopIndex: 2,
+      phase: 'imminent',
+      stationName: '강남',
+    });
+  });
+
+  it('stationName에 콜론 포함 시 그대로 복원', () => {
+    const id = boardingLockAlarmIdentifier({
+      trainCode: 'T-1',
+      hopIndex: 0,
+      phase: 'early',
+      stationName: 'A:B',
+    });
+    expect(parseBoardingLockAlarmIdentifier(id)).toEqual({
+      trainCode: 'T-1',
+      hopIndex: 0,
+      phase: 'early',
+      stationName: 'A:B',
+    });
+  });
+
+  it('prefix 불일치는 null', () => {
+    expect(parseBoardingLockAlarmIdentifier('alarm:early:강남')).toBeNull();
+  });
+
+  it('필드 누락은 null', () => {
+    expect(parseBoardingLockAlarmIdentifier('bl:T-1:0:early')).toBeNull();
+    expect(parseBoardingLockAlarmIdentifier('bl::0:early:강남')).toBeNull();
+    expect(parseBoardingLockAlarmIdentifier('bl:T-1::early:강남')).toBeNull();
+    expect(parseBoardingLockAlarmIdentifier('bl:T-1:0:early:')).toBeNull();
+  });
+
+  it('hopIndex가 정수가 아니면 null', () => {
+    expect(parseBoardingLockAlarmIdentifier('bl:T-1:abc:early:강남')).toBeNull();
+    expect(parseBoardingLockAlarmIdentifier('bl:T-1:-1:early:강남')).toBeNull();
+    expect(parseBoardingLockAlarmIdentifier('bl:T-1:1.5:early:강남')).toBeNull();
+  });
+
+  it('phase가 알람 phase가 아니면 null', () => {
+    expect(parseBoardingLockAlarmIdentifier('bl:T-1:0:other:강남')).toBeNull();
+  });
+});
+
+describe('scheduleHopsForLock', () => {
+  it('direct route: destination waypoint 1개를 예약, early+imminent 모두 발사', async () => {
+    await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
+
+    // 2 stops * 90s = 180s; early lead = 90s, imminent lead = 45s → 둘 다 양수
+    expect(mockedSchedule).toHaveBeenCalledTimes(2);
+    expect(mockedAdd).toHaveBeenCalledWith([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+    ]);
+    const earlyCall = mockedSchedule.mock.calls[0][0];
+    expect(earlyCall.content.interruptionLevel).toBe('active');
+    const imminentCall = mockedSchedule.mock.calls[1][0];
+    expect(imminentCall.content.interruptionLevel).toBe('timeSensitive');
+  });
+
+  it('transfer route: 다음 3 hop = 환승역 + 도착역 모두 예약', async () => {
+    await scheduleHopsForLock({ lock, route: transferRoute, destinationName: '오금' });
+    // 2 waypoints: 교대(stops 2) + 오금(stops 3)
+    expect(mockedSchedule).toHaveBeenCalledTimes(4);
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids).toContain('bl:T-100:0:early:교대');
+    expect(ids).toContain('bl:T-100:0:imminent:교대');
+    expect(ids).toContain('bl:T-100:1:early:오금');
+    expect(ids).toContain('bl:T-100:1:imminent:오금');
+  });
+
+  it('multi-transfer: windowSize 3으로 잘림 — 4번째 waypoint(목적지)는 예약 안 됨', async () => {
+    await scheduleHopsForLock({ lock, route: multiRoute, destinationName: '온수' });
+    // targets = 교대, 약수, 한강진, 온수. window=3 → 온수 skip
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids.some((id) => id.includes(':2:'))).toBe(true); // 한강진(idx=2)
+    expect(ids.some((id) => id.includes(':3:'))).toBe(false); // 온수(idx=3) skip
+  });
+
+  it('windowSize 인자로 더 작게 지정 가능', async () => {
+    await scheduleHopsForLock({
+      lock,
+      route: transferRoute,
+      destinationName: '오금',
+      windowSize: 1,
+    });
+    expect(mockedSchedule).toHaveBeenCalledTimes(2); // 환승역만
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids.every((id) => id.includes(':0:'))).toBe(true);
+  });
+
+  it('과거 시각으로 산출되는 알람은 skip — now가 충분히 진행된 경우', async () => {
+    // direct stops=2 → waypointEta=180s. now를 boardedAt + 200초로 잡으면 둘 다 음수.
+    await scheduleHopsForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW + 200_000,
+    });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedAdd).toHaveBeenCalledWith([]);
+  });
+
+  it('android: channelId + priority 사용', async () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'android' });
+    await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
+    const call = mockedSchedule.mock.calls[0][0];
+    expect((call.content as { channelId?: string }).channelId).toBe('station-alarm');
+    expect((call.content as { priority?: unknown }).priority).toBe(
+      Notifications.AndroidNotificationPriority.MAX,
+    );
+  });
+
+  it('웹/기타 플랫폼은 platform 의존 필드 미설정', async () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'web' });
+    await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
+    const call = mockedSchedule.mock.calls[0][0];
+    expect((call.content as { channelId?: string }).channelId).toBeUndefined();
+    expect(call.content.interruptionLevel).toBeUndefined();
+  });
+
+  it('빈 targets은 storage write도 빈 배열', async () => {
+    // direct stops=0 → totalStops=0, but resolveAllTargets returns 1 entry with stops=0.
+    // waypointEta=0 → 모든 phase에서 fireSeconds <= 0 → 예약 안 됨.
+    const zeroRoute: DirectRoute = { type: 'direct', stops: 0, line: '2' };
+    await scheduleHopsForLock({ lock, route: zeroRoute, destinationName: '강남' });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+});
+
+describe('cancelAllHopsForLock', () => {
+  it('큐에서 같은 trainCode prefix만 cancel + remove', async () => {
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+      'bl:T-200:0:early:강남', // 다른 lock
+      'alarm:early:강남', // 다른 모듈
+    ]);
+    await cancelAllHopsForLock(lock);
+
+    expect(mockedCancel).toHaveBeenCalledTimes(2);
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:imminent:강남');
+    expect(mockedDismiss).toHaveBeenCalledTimes(2);
+    expect(mockedRemove).toHaveBeenCalledWith([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+    ]);
+  });
+
+  it('일치 없으면 cancel/remove 호출 안 함', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-200:0:early:강남']);
+    await cancelAllHopsForLock(lock);
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it('dismiss 실패는 silent — cancel은 계속 진행', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:강남']);
+    mockedDismiss.mockRejectedValueOnce(new Error('not delivered'));
+    await expect(cancelAllHopsForLock(lock)).resolves.toBeUndefined();
+    expect(mockedCancel).toHaveBeenCalled();
+  });
+});
+
+describe('purgeBoardingLockSchedulerQueue', () => {
+  it('큐가 비어있으면 no-op', async () => {
+    mockedGet.mockResolvedValueOnce([]);
+    await purgeBoardingLockSchedulerQueue();
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedClear).not.toHaveBeenCalled();
+  });
+
+  it('bl: prefix만 cancel하고 큐 전체 clear', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-1:0:early:A', 'alarm:early:A']);
+    await purgeBoardingLockSchedulerQueue();
+    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-1:0:early:A');
+    expect(mockedClear).toHaveBeenCalled();
+  });
+});
+
+describe('advanceHopWindow', () => {
+  it('passedStationName이 route에 없으면 no-op', async () => {
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '없는역',
+    });
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('큐에 빠진 hopIndex가 있으면 window 범위 안에서 모두 채워 예약 (out-of-order 호출 견고성)', async () => {
+    // multiRoute targets: 교대(0), 약수(1), 한강진(2), 온수(3).
+    // 0이 통과되고 큐에 1만 있는 상태에서 advance(0) → 2(한강진)도 채워야 한다.
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:교대',
+      'bl:T-100:1:early:약수',
+    ]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+    });
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:교대');
+    const newIds = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    // 1은 이미 있으므로 skip, 2(한강진)와 3(온수)는 채움. (windowSize=3 → 범위 [1..3])
+    expect(newIds.some((id) => id.startsWith('bl:T-100:1:'))).toBe(false);
+    expect(newIds.some((id) => id.startsWith('bl:T-100:2:'))).toBe(true);
+    expect(newIds.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
+  });
+
+  it('정상 호출(0 → 1): hopIndex 0 cancel + window 끝 hop만 새로 예약', async () => {
+    // multiRoute targets: 교대(0), 약수(1), 한강진(2), 온수(3). window=3 → 0,1,2 예약됨.
+    // 교대 통과 시: hopIndex 0 cancel + 새 hop = passedIndex(0) + window(3) = 3 (온수) 예약.
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:교대',
+      'bl:T-100:0:imminent:교대',
+      'bl:T-100:1:early:약수',
+      'bl:T-100:2:early:한강진',
+    ]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+    });
+    // cancel: hopIndex<=0 → 2개
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:교대');
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:imminent:교대');
+    expect(mockedCancel).not.toHaveBeenCalledWith('bl:T-100:1:early:약수');
+    expect(mockedRemove).toHaveBeenCalledWith([
+      'bl:T-100:0:early:교대',
+      'bl:T-100:0:imminent:교대',
+    ]);
+    // schedule: 온수 hopIndex=3
+    const newIds = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(newIds).toContain('bl:T-100:3:early:온수');
+    expect(newIds).toContain('bl:T-100:3:imminent:온수');
+    expect(mockedAdd).toHaveBeenCalledWith([
+      'bl:T-100:3:early:온수',
+      'bl:T-100:3:imminent:온수',
+    ]);
+  });
+
+  it('새 window 끝이 route 범위 밖이면 추가 예약 없음', async () => {
+    // direct route: targets=[강남(0)]. window=3 → nextHopIndex = 0+3 = 3, out of range.
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:강남']);
+    await advanceHopWindow({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      passedStationName: '강남',
+    });
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('cancel 대상 없을 때 remove 미호출, 그래도 다음 hop 예약은 시도', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-200:0:early:교대']); // 다른 lock
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+      windowSize: 3,
+    });
+    expect(mockedRemove).not.toHaveBeenCalled();
+    // 새 hop = 3 (온수) 예약 시도됨
+    expect(mockedSchedule).toHaveBeenCalled();
+  });
+
+  it('새 hop 시점이 과거면 schedule 호출 없음, add 호출 없음', async () => {
+    mockedGet.mockResolvedValueOnce([]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+      now: NOW + 10_000_000, // 충분히 미래로
+    });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it('android: 새 hop schedule 시 channelId + priority 사용', async () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'android' });
+    mockedGet.mockResolvedValueOnce([]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+    });
+    const call = mockedSchedule.mock.calls[0][0];
+    expect((call.content as { channelId?: string }).channelId).toBe('station-alarm');
+    expect((call.content as { priority?: unknown }).priority).toBe(
+      Notifications.AndroidNotificationPriority.MAX,
+    );
+  });
+
+  it('dismiss 실패는 silent', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:교대']);
+    mockedDismiss.mockRejectedValueOnce(new Error('no'));
+    await expect(
+      advanceHopWindow({
+        lock,
+        route: multiRoute,
+        destinationName: '온수',
+        passedStationName: '교대',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/__tests__/scheduledNotificationsStorage.test.ts
+++ b/src/utils/__tests__/scheduledNotificationsStorage.test.ts
@@ -1,0 +1,125 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  addScheduledNotificationIds,
+  clearScheduledNotificationIds,
+  getScheduledNotificationIds,
+  removeScheduledNotificationIds,
+} from '../scheduledNotificationsStorage';
+import { SCHEDULED_NOTIFICATIONS_KEY } from '../../constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const mockedGet = AsyncStorage.getItem as jest.MockedFunction<typeof AsyncStorage.getItem>;
+const mockedSet = AsyncStorage.setItem as jest.MockedFunction<typeof AsyncStorage.setItem>;
+const mockedRemove = AsyncStorage.removeItem as jest.MockedFunction<typeof AsyncStorage.removeItem>;
+
+describe('scheduledNotificationsStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getScheduledNotificationIds', () => {
+    it('값이 없으면 빈 배열 반환', async () => {
+      mockedGet.mockResolvedValueOnce(null);
+      await expect(getScheduledNotificationIds()).resolves.toEqual([]);
+    });
+
+    it('정상 JSON 배열을 그대로 반환', async () => {
+      mockedGet.mockResolvedValueOnce(JSON.stringify(['a', 'b']));
+      await expect(getScheduledNotificationIds()).resolves.toEqual(['a', 'b']);
+    });
+
+    it('형식 손상 시 빈 배열 반환', async () => {
+      mockedGet.mockResolvedValueOnce(JSON.stringify({ not: 'array' }));
+      await expect(getScheduledNotificationIds()).resolves.toEqual([]);
+    });
+
+    it('비-문자열 배열이면 빈 배열 반환', async () => {
+      mockedGet.mockResolvedValueOnce(JSON.stringify(['a', 1]));
+      await expect(getScheduledNotificationIds()).resolves.toEqual([]);
+    });
+
+    it('I/O 실패 시 빈 배열 반환', async () => {
+      mockedGet.mockRejectedValueOnce(new Error('boom'));
+      await expect(getScheduledNotificationIds()).resolves.toEqual([]);
+    });
+  });
+
+  describe('addScheduledNotificationIds', () => {
+    it('빈 배열은 storage I/O 하지 않음', async () => {
+      await addScheduledNotificationIds([]);
+      expect(mockedGet).not.toHaveBeenCalled();
+      expect(mockedSet).not.toHaveBeenCalled();
+    });
+
+    it('기존 값과 dedup하여 저장', async () => {
+      mockedGet.mockResolvedValueOnce(JSON.stringify(['a']));
+      await addScheduledNotificationIds(['a', 'b']);
+      expect(mockedSet).toHaveBeenCalledWith(
+        SCHEDULED_NOTIFICATIONS_KEY,
+        JSON.stringify(['a', 'b']),
+      );
+    });
+
+    it('저장 실패 시 throw 없음', async () => {
+      mockedGet.mockResolvedValueOnce(null);
+      mockedSet.mockRejectedValueOnce(new Error('disk'));
+      await expect(addScheduledNotificationIds(['a'])).resolves.toBeUndefined();
+    });
+  });
+
+  describe('removeScheduledNotificationIds', () => {
+    it('빈 배열은 no-op', async () => {
+      await removeScheduledNotificationIds([]);
+      expect(mockedGet).not.toHaveBeenCalled();
+    });
+
+    it('일치 항목 제거 후 저장', async () => {
+      mockedGet.mockResolvedValueOnce(JSON.stringify(['a', 'b', 'c']));
+      await removeScheduledNotificationIds(['b']);
+      expect(mockedSet).toHaveBeenCalledWith(
+        SCHEDULED_NOTIFICATIONS_KEY,
+        JSON.stringify(['a', 'c']),
+      );
+    });
+
+    it('제거 후 빈 결과면 removeItem 호출', async () => {
+      mockedGet.mockResolvedValueOnce(JSON.stringify(['a']));
+      await removeScheduledNotificationIds(['a']);
+      expect(mockedRemove).toHaveBeenCalledWith(SCHEDULED_NOTIFICATIONS_KEY);
+      expect(mockedSet).not.toHaveBeenCalled();
+    });
+
+    it('변동 없으면 I/O 하지 않음', async () => {
+      mockedGet.mockResolvedValueOnce(JSON.stringify(['a']));
+      await removeScheduledNotificationIds(['x']);
+      expect(mockedSet).not.toHaveBeenCalled();
+      expect(mockedRemove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearScheduledNotificationIds', () => {
+    it('removeItem 호출', async () => {
+      await clearScheduledNotificationIds();
+      expect(mockedRemove).toHaveBeenCalledWith(SCHEDULED_NOTIFICATIONS_KEY);
+    });
+
+    it('removeItem 실패 시 throw 없음', async () => {
+      mockedRemove.mockRejectedValueOnce(new Error('boom'));
+      await expect(clearScheduledNotificationIds()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -1,0 +1,311 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
+import { resolveAllTargets, type AlarmEvent, type CurrentTarget } from './stationAlarm';
+import type { Route } from './stationRoute';
+import { buildAlarmContent } from './stationNotification';
+import type { BoardingLock } from '../types/boardingLock';
+import {
+  addScheduledNotificationIds,
+  clearScheduledNotificationIds,
+  getScheduledNotificationIds,
+  removeScheduledNotificationIds,
+} from './scheduledNotificationsStorage';
+import { createLogger } from './logger';
+
+const logger = createLogger('BoardingLockScheduler');
+
+export const BOARDING_LOCK_ALARM_PREFIX = 'bl:';
+// alarmScheduler.ts / stationNotification.ts에도 같은 리터럴이 있다. 채널 설정을 옮길 일이
+// 생기면 src/constants/로 일괄 추출 — 현재는 surgical change 원칙상 PR D 진입 전 유지.
+const ALARM_CHANNEL_ID = 'station-alarm';
+
+/**
+ * 정거장당 추정 이동 시간(초). PR C v1은 uniform 90s — 노선별/시간대별 정밀화는 후속.
+ * 기존 alarmScheduler와 동일 값으로 두어 동시 동작 시 일관성 유지.
+ */
+const HOP_TIME_SECONDS = 90;
+
+/**
+ * Phase별 lead time. #584 SLA 설계(2026-05-28):
+ *  - early : 1정거장 전(=HOP_TIME) — barvlDt 60s 단위 ±30s 오차 흡수
+ *  - imminent : 45초 전 — timeSensitive interruption으로 BG 발사 보장
+ */
+const PHASE_LEAD_SECONDS: Record<AlarmPhaseId, number> = {
+  early: HOP_TIME_SECONDS,
+  imminent: 45,
+};
+
+/**
+ * iOS interruption level mapping. early는 평소(active), imminent는 timeSensitive로
+ * Focus/잠금화면 관통. critical Entitlement는 별도 진행 — 현재는 timeSensitive.
+ */
+const PHASE_INTERRUPTION: Record<AlarmPhaseId, 'active' | 'timeSensitive'> = {
+  early: 'active',
+  imminent: 'timeSensitive',
+};
+
+/** Per-Hop Adaptive Scheduling: 한 번에 큐에 두는 waypoint 수 (iOS 64 한도 안전). */
+const DEFAULT_WINDOW_SIZE = 3;
+
+export interface BoardingLockAlarmIdParts {
+  trainCode: string;
+  hopIndex: number;
+  phase: AlarmPhaseId;
+  stationName: string;
+}
+
+/**
+ * identifier 형식: `bl:${trainCode}:${hopIndex}:${phase}:${stationName}`.
+ *
+ * - trainCode: 같은 Lock 안에서 모든 hop 알람이 공유 → Lock 단위 cancel 가능.
+ * - hopIndex: waypoint별 cancel을 위한 인덱스 (역 통과 시 advanceHopWindow가 사용).
+ * - phase: 'early' | 'imminent' — interruption level이 다름.
+ * - stationName: 디버깅 가시성. parse는 처음 3개 ':'까지만 split.
+ */
+export function boardingLockAlarmIdentifier(parts: BoardingLockAlarmIdParts): string {
+  return `${BOARDING_LOCK_ALARM_PREFIX}${parts.trainCode}:${parts.hopIndex}:${parts.phase}:${parts.stationName}`;
+}
+
+export function parseBoardingLockAlarmIdentifier(
+  identifier: string,
+): BoardingLockAlarmIdParts | null {
+  if (!identifier.startsWith(BOARDING_LOCK_ALARM_PREFIX)) return null;
+  const rest = identifier.slice(BOARDING_LOCK_ALARM_PREFIX.length);
+  // stationName에 ':'이 포함될 가능성을 위해 앞쪽 3개까지만 split.
+  const segs: string[] = [];
+  let cursor = 0;
+  for (let i = 0; i < 3; i++) {
+    const next = rest.indexOf(':', cursor);
+    if (next === -1) return null;
+    segs.push(rest.slice(cursor, next));
+    cursor = next + 1;
+  }
+  const trainCode = segs[0];
+  const hopIndexRaw = segs[1];
+  const phase = segs[2];
+  const stationName = rest.slice(cursor);
+  if (!trainCode || !hopIndexRaw || !stationName) return null;
+  const hopIndex = Number(hopIndexRaw);
+  if (!Number.isInteger(hopIndex) || hopIndex < 0) return null;
+  if (phase !== 'early' && phase !== 'imminent') return null;
+  return { trainCode, hopIndex, phase, stationName };
+}
+
+/**
+ * 단일 hop(waypoint)에 대해 ALARM_PHASES 전체를 사전 예약하고 예약된 identifier 목록을 반환한다.
+ * scheduleHopsForLock와 advanceHopWindow가 공통 사용 — 알림 본문/플랫폼 분기/interruption level이
+ * 한 곳에서만 정의되도록 모은다.
+ *
+ * `arrivalMs - lead` 가 `observedMs` 이하면 해당 phase는 skip(과거 시각 가드).
+ */
+async function scheduleSingleHop(params: {
+  lock: BoardingLock;
+  target: CurrentTarget;
+  hopIndex: number;
+  arrivalMs: number;
+  observedMs: number;
+}): Promise<string[]> {
+  const { lock, target, hopIndex, arrivalMs, observedMs } = params;
+  const ids: string[] = [];
+  for (const phase of ALARM_PHASES) {
+    const fireMs = arrivalMs - PHASE_LEAD_SECONDS[phase.id] * 1000;
+    if (fireMs <= observedMs) continue;
+    const event: AlarmEvent = {
+      phaseId: phase.id,
+      type: target.alarmType,
+      stationName: target.name,
+    };
+    const identifier = boardingLockAlarmIdentifier({
+      trainCode: lock.trainCode,
+      hopIndex,
+      phase: phase.id,
+      stationName: target.name,
+    });
+    const { title, body } = buildAlarmContent(event);
+    await Notifications.scheduleNotificationAsync({
+      identifier,
+      content: {
+        title,
+        body,
+        sound: 'alarm.wav',
+        ...(Platform.OS === 'android' && {
+          channelId: ALARM_CHANNEL_ID,
+          priority: Notifications.AndroidNotificationPriority.MAX,
+        }),
+        ...(Platform.OS === 'ios' && { interruptionLevel: PHASE_INTERRUPTION[phase.id] }),
+      },
+      trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: new Date(fireMs) },
+    });
+    ids.push(identifier);
+  }
+  return ids;
+}
+
+/**
+ * 누적 stops 기반 절대 도착 시각(ms). hopIndex까지 모든 target의 stops를 합산해 lock.boardedAt에 더한다.
+ */
+function arrivalMsForHop(
+  lock: BoardingLock,
+  allTargets: CurrentTarget[],
+  hopIndex: number,
+): number {
+  let cumulativeStops = 0;
+  for (let i = 0; i <= hopIndex; i++) cumulativeStops += allTargets[i].stops;
+  return lock.boardedAt + cumulativeStops * HOP_TIME_SECONDS * 1000;
+}
+
+async function cancelAndDismiss(ids: string[]): Promise<void> {
+  for (const id of ids) {
+    await Notifications.cancelScheduledNotificationAsync(id);
+    try {
+      await Notifications.dismissNotificationAsync(id);
+    } catch {
+      // 미발사 알람은 dismiss 대상 아님 — 무시.
+    }
+  }
+}
+
+export interface ScheduleHopsParams {
+  lock: BoardingLock;
+  route: NonNullable<Route>;
+  destinationName: string;
+  /** 누적 ETA 기준점 (ms epoch). 기본 lock.boardedAt. */
+  now?: number;
+  /** 큐에 둘 waypoint 개수. 기본 3. */
+  windowSize?: number;
+}
+
+/**
+ * Lock 시작 시점에 호출 — 다음 windowSize개 waypoint에 대해 (early, imminent) 알람을 예약한다.
+ *
+ * 예약된 identifier는 모두 AsyncStorage 추적 큐에 추가된다. 이후 cancelAllHopsForLock 또는
+ * advanceHopWindow가 이 큐를 통해서만 cancel한다 — getAllScheduledNotifications를 호출하지 않는다.
+ *
+ * 과거 시각으로 산출되는 알람은 skip. waypoint stops=0(이미 도착)인 경우도 skip된다 (lead 차감 후 ≤0).
+ */
+export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<string[]> {
+  const { lock, route, destinationName, now, windowSize = DEFAULT_WINDOW_SIZE } = params;
+  const observedMs = now ?? lock.boardedAt;
+  const allTargets = resolveAllTargets(route, destinationName);
+  const lastIdx = Math.min(windowSize, allTargets.length);
+
+  const scheduledIds: string[] = [];
+  for (let hopIndex = 0; hopIndex < lastIdx; hopIndex++) {
+    const ids = await scheduleSingleHop({
+      lock,
+      target: allTargets[hopIndex],
+      hopIndex,
+      arrivalMs: arrivalMsForHop(lock, allTargets, hopIndex),
+      observedMs,
+    });
+    scheduledIds.push(...ids);
+  }
+
+  await addScheduledNotificationIds(scheduledIds);
+  logger.info(
+    `scheduled ${scheduledIds.length} alarms for lock ${lock.trainCode} (${lastIdx} hops)`,
+  );
+  return scheduledIds;
+}
+
+/**
+ * 추적 큐에서 prefix + trainCode가 일치하는 identifier를 모두 cancel + dismiss + 큐에서 제거.
+ *
+ * release/expiry 또는 새 Lock 전환 시 호출. 추적 큐 밖의 알람은 건드리지 않는다 — 다른 모듈이
+ * 같은 prefix로 예약했더라도 안전.
+ */
+export async function cancelAllHopsForLock(lock: BoardingLock): Promise<void> {
+  const current = await getScheduledNotificationIds();
+  const lockPrefix = `${BOARDING_LOCK_ALARM_PREFIX}${lock.trainCode}:`;
+  const toCancel = current.filter((id) => id.startsWith(lockPrefix));
+  if (toCancel.length === 0) return;
+
+  await cancelAndDismiss(toCancel);
+  await removeScheduledNotificationIds(toCancel);
+  logger.info(`cancelled ${toCancel.length} alarms for lock ${lock.trainCode}`);
+}
+
+/**
+ * 큐 전체를 비운다 — SCHEDULED_NOTIFICATIONS 키 안의 `bl:` prefix 항목만.
+ * 마운트 시점 위생 처리용 (예: app restart 후 stale 큐 정리). cancelAllHopsForLock과 동일하게
+ * 발사된 알람은 dismiss까지 시도한다.
+ */
+export async function purgeBoardingLockSchedulerQueue(): Promise<void> {
+  const current = await getScheduledNotificationIds();
+  if (current.length === 0) return;
+  const ours = current.filter((id) => id.startsWith(BOARDING_LOCK_ALARM_PREFIX));
+  await cancelAndDismiss(ours);
+  await clearScheduledNotificationIds();
+}
+
+export interface AdvanceHopWindowParams {
+  lock: BoardingLock;
+  route: NonNullable<Route>;
+  destinationName: string;
+  /** 통과한 waypoint 이름. resolveAllTargets에 등록된 이름과 일치해야 한다. */
+  passedStationName: string;
+  now?: number;
+  windowSize?: number;
+}
+
+/**
+ * 역 통과 시 호출 — `hopIndex <= passedIndex` 알람을 cancel하고, window `[passedIndex+1, passedIndex+windowSize]`
+ * 범위에서 현재 큐에 없는 hop을 모두 채워 예약한다.
+ *
+ * - 호출이 순서대로(0→1→2...) 들어오면 매번 1개 새 hop이 추가된다 — 일반 case.
+ * - 호출이 건너뛰며 들어와도(0→2) window가 비어 있던 슬롯까지 한 번에 채운다 — 견고성.
+ * - 새 window가 route 끝을 넘으면 추가 예약 없이 cancel만 수행한다.
+ *
+ * PR C에서는 정의만 — 호출자(Fusion station-pass)는 PR D에서 연결.
+ */
+export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<void> {
+  const { lock, route, destinationName, passedStationName, now, windowSize = DEFAULT_WINDOW_SIZE } =
+    params;
+
+  const allTargets = resolveAllTargets(route, destinationName);
+  const passedIndex = allTargets.findIndex((t) => t.name === passedStationName);
+  if (passedIndex === -1) return;
+
+  const current = await getScheduledNotificationIds();
+  const lockPrefix = `${BOARDING_LOCK_ALARM_PREFIX}${lock.trainCode}:`;
+
+  // 이번 lock의 현재 큐를 한 번만 파싱해 cancel/existing 양쪽에 활용.
+  const parsedCurrent = current
+    .filter((id) => id.startsWith(lockPrefix))
+    .map((id) => ({ id, parsed: parseBoardingLockAlarmIdentifier(id) }))
+    .filter((x): x is { id: string; parsed: BoardingLockAlarmIdParts } => x.parsed !== null);
+
+  const toCancel = parsedCurrent.filter((x) => x.parsed.hopIndex <= passedIndex).map((x) => x.id);
+  if (toCancel.length > 0) {
+    await cancelAndDismiss(toCancel);
+    await removeScheduledNotificationIds(toCancel);
+  }
+
+  const existingHopIndexes = new Set(
+    parsedCurrent
+      .filter((x) => x.parsed.hopIndex > passedIndex)
+      .map((x) => x.parsed.hopIndex),
+  );
+
+  const observedMs = now ?? lock.boardedAt;
+  const scheduledIds: string[] = [];
+  const windowEnd = Math.min(passedIndex + windowSize, allTargets.length - 1);
+  for (let hopIndex = passedIndex + 1; hopIndex <= windowEnd; hopIndex++) {
+    if (existingHopIndexes.has(hopIndex)) continue;
+    const ids = await scheduleSingleHop({
+      lock,
+      target: allTargets[hopIndex],
+      hopIndex,
+      arrivalMs: arrivalMsForHop(lock, allTargets, hopIndex),
+      observedMs,
+    });
+    scheduledIds.push(...ids);
+  }
+  if (scheduledIds.length > 0) {
+    await addScheduledNotificationIds(scheduledIds);
+  }
+  logger.info(
+    `advanced lock ${lock.trainCode}: cancelled ${toCancel.length}, scheduled ${scheduledIds.length}`,
+  );
+}

--- a/src/utils/scheduledNotificationsStorage.ts
+++ b/src/utils/scheduledNotificationsStorage.ts
@@ -1,0 +1,66 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SCHEDULED_NOTIFICATIONS_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+
+const logger = createLogger('ScheduledNotificationsStorage');
+
+/**
+ * boardingLockScheduler가 OS에 예약한 notification identifier를 추적한다 (#584 PR C).
+ *
+ * Lock 단위 cancel을 위해 prefix 매칭 대신 명시적 목록을 둔다 — Notifications.getAll*은
+ * 비싸고, 다른 모듈이 같은 prefix로 예약하지 않는다는 가정에 의존하지 않아도 된다.
+ *
+ * 파싱 실패한 레거시 값은 빈 목록으로 처리한다. 잘못된 상태로 cancel/dedup이 오염되는 것을
+ * 차단한다. I/O 실패는 warn만 — 다음 호출에서 자연 복구.
+ */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+export async function getScheduledNotificationIds(): Promise<string[]> {
+  try {
+    const raw = await AsyncStorage.getItem(SCHEDULED_NOTIFICATIONS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!isStringArray(parsed)) {
+      logger.error(`${SCHEDULED_NOTIFICATIONS_KEY} 형식 손상 — 무시`);
+      return [];
+    }
+    return parsed;
+  } catch (e) {
+    logger.warn(`${SCHEDULED_NOTIFICATIONS_KEY} 읽기 실패:`, e);
+    return [];
+  }
+}
+
+async function writeIds(ids: string[]): Promise<void> {
+  try {
+    if (ids.length === 0) {
+      await AsyncStorage.removeItem(SCHEDULED_NOTIFICATIONS_KEY);
+      return;
+    }
+    await AsyncStorage.setItem(SCHEDULED_NOTIFICATIONS_KEY, JSON.stringify(ids));
+  } catch (e) {
+    logger.warn(`${SCHEDULED_NOTIFICATIONS_KEY} 저장 실패:`, e);
+  }
+}
+
+export async function addScheduledNotificationIds(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const current = await getScheduledNotificationIds();
+  const merged = Array.from(new Set([...current, ...ids]));
+  await writeIds(merged);
+}
+
+export async function removeScheduledNotificationIds(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const current = await getScheduledNotificationIds();
+  const remove = new Set(ids);
+  const next = current.filter((id) => !remove.has(id));
+  if (next.length === current.length) return;
+  await writeIds(next);
+}
+
+export async function clearScheduledNotificationIds(): Promise<void> {
+  await writeIds([]);
+}


### PR DESCRIPTION
## 배경

#584 BoardingLock + 사전 예약 인프라의 PR C 슬라이스. PR A(모델)/PR B(UI)는 머지 완료, 본 PR은 Phase 2 = 사전 예약 scheduler.

## 변경

- **신규** \`src/utils/scheduledNotificationsStorage.ts\` — \`SCHEDULED_NOTIFICATIONS\` AsyncStorage CRUD (Lock 단위 cancel용 추적 큐)
- **신규** \`src/utils/boardingLockScheduler.ts\` — Lock 단위 hop 사전 예약, identifier 규칙, advanceHopWindow API
- **신규** \`src/hooks/useBoardingLockScheduler.ts\` — store 구독 → 생성/교체/해제 시 schedule/cancel
- \`src/constants/storageKeys.ts\` — \`SCHEDULED_NOTIFICATIONS_KEY\` 추가
- \`app/(tabs)/index.tsx\` — \`useBoardingLockScheduler\` 마운트 (3줄)

## 식별자/규칙

\`\`\`
identifier = bl:{trainCode}:{hopIndex}:{phase}:{stationName}
interruption level: early=active, imminent=timeSensitive
hop time: uniform 90s (v1) — barvlDt fetch는 후속
window size: 다음 3 waypoint
\`\`\`

## PR D 진입점

\`advanceHopWindow({ lock, route, destinationName, passedStationName })\` — Fusion station-pass에서 호출. window 범위 \`[passedIndex+1, passedIndex+windowSize]\`에서 큐에 없는 hop을 모두 채우므로 순차/skip 호출 모두 견고.

## 분할 정책 (의식적 제외)

- realtimeStationArrival barvlDt fetch → uniform 90s 추정으로 시작 (후속)
- Fusion 통합(boarding-lock priority, GPS 격하) → PR D
- 잘못 탑승 토스트/모달 → PR D
- 환승 시 새 Lock 전환 → PR E
- 기존 \`alarmScheduler.ts\`(prefix \`alarm:\`)는 그대로 — Lock 활성 시 비활성화는 PR D

## 검증

- [x] \`npm test\` 2011 tests pass, 100% coverage (lines/branches/functions/statements)
- [x] \`npm run type-check\` 통과
- [x] code-reviewer 에이전트 리뷰 후 반영
  - advanceHopWindow window 유지 견고성 (missing 슬롯 fill)
  - scheduleHopsForLock / advanceHopWindow 중복 → \`scheduleSingleHop\` 헬퍼 추출
  - purge에 dismiss 추가
  - hook scheduler 실패 logger.error

## Test plan

- [ ] BoardingLock 생성 → bl: prefix 알람이 OS 큐에 들어가는지 (Notifications.getAllScheduledNotificationsAsync 디버그)
- [ ] 하차 탭 → cancel + dismiss 동작 확인
- [ ] 자동 만료(boardedAt + expectedDurationMs × 1.5) → cancel 동작
- [ ] 앱 재시작 후에도 SCHEDULED_NOTIFICATIONS이 유지되는지

Closes #584 (Phase 2)