### PR TITLE
feat(#584): PR D1 — advanceHopWindow wiring

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -35,6 +35,7 @@ import { useSleepModeGuide } from '../../src/hooks/useSleepModeGuide';
 import { useArrivalAutoClear } from '../../src/hooks/useArrivalAutoClear';
 import { useBoardingLockController } from '../../src/hooks/useBoardingLockController';
 import { useBoardingLockScheduler } from '../../src/hooks/useBoardingLockScheduler';
+import { useBoardingLockAdvancer } from '../../src/hooks/useBoardingLockAdvancer';
 import { BoardingLockBanner } from '../../src/components/BoardingLockBanner';
 import { BoardingTrainList } from '../../src/components/BoardingTrainList';
 
@@ -209,6 +210,12 @@ export default function HomeScreen() {
     lock: boardingLock,
     route,
     destinationName: destination?.name ?? null,
+  });
+  useBoardingLockAdvancer({
+    lock: boardingLock,
+    route,
+    destinationName: destination?.name ?? null,
+    currentStationName: result?.station.name ?? null,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({

--- a/src/hooks/__tests__/useBoardingLockAdvancer.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockAdvancer.test.tsx
@@ -1,0 +1,269 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useBoardingLockAdvancer } from '../useBoardingLockAdvancer';
+import { advanceHopWindow } from '../../utils/boardingLockScheduler';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { DirectRoute, TransferRoute } from '../../utils/stationRoute';
+
+jest.mock('../../utils/boardingLockScheduler', () => ({
+  advanceHopWindow: jest.fn(),
+}));
+const mockLoggerError = jest.fn();
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  }),
+}));
+
+const mockedAdvance = advanceHopWindow as jest.MockedFunction<typeof advanceHopWindow>;
+
+const lockA: BoardingLock = {
+  destinationId: 'd',
+  trainCode: 'A',
+  boardingStationId: 's',
+  boardingLine: '2',
+  boardedAt: 1,
+  expectedDurationMs: 1000,
+};
+const lockB: BoardingLock = { ...lockA, trainCode: 'B' };
+
+const directRoute: DirectRoute = { type: 'direct', stops: 2, line: '2' };
+const transferRoute: TransferRoute = {
+  type: 'transfer',
+  transferName: '사당',
+  fromLine: '2',
+  toLine: '4',
+  stopsToTransfer: 3,
+  stopsFromTransfer: 4,
+};
+
+type Props = Parameters<typeof useBoardingLockAdvancer>[0];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAdvance.mockResolvedValue(undefined);
+});
+
+describe('useBoardingLockAdvancer', () => {
+  it('lock=null이면 currentStationName이 waypoint여도 호출 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: null,
+        route: directRoute,
+        destinationName: '강남',
+        currentStationName: '강남',
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedAdvance).not.toHaveBeenCalled();
+  });
+
+  it('route=null이면 호출 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: null,
+        destinationName: '강남',
+        currentStationName: '강남',
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedAdvance).not.toHaveBeenCalled();
+  });
+
+  it('destinationName=null이면 호출 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: directRoute,
+        destinationName: null,
+        currentStationName: '강남',
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedAdvance).not.toHaveBeenCalled();
+  });
+
+  it('currentStationName=null이면 호출 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: directRoute,
+        destinationName: '강남',
+        currentStationName: null,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedAdvance).not.toHaveBeenCalled();
+  });
+
+  it('현재역이 waypoint와 매칭되지 않으면 호출 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: directRoute,
+        destinationName: '강남',
+        currentStationName: '역삼',
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedAdvance).not.toHaveBeenCalled();
+  });
+
+  it('도착역 waypoint 도달 시 advanceHopWindow를 호출', async () => {
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: directRoute,
+        destinationName: '강남',
+        currentStationName: '강남',
+      }),
+    );
+    await waitFor(() => {
+      expect(mockedAdvance).toHaveBeenCalledWith({
+        lock: lockA,
+        route: directRoute,
+        destinationName: '강남',
+        passedStationName: '강남',
+      });
+    });
+  });
+
+  it('환승역 waypoint 도달 시 호출', async () => {
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: transferRoute,
+        destinationName: '명동',
+        currentStationName: '사당',
+      }),
+    );
+    await waitFor(() => {
+      expect(mockedAdvance).toHaveBeenCalledWith({
+        lock: lockA,
+        route: transferRoute,
+        destinationName: '명동',
+        passedStationName: '사당',
+      });
+    });
+  });
+
+  it('같은 waypoint가 다시 들어와도 중복 호출 안 함', async () => {
+    const { rerender } = renderHook(
+      (props: Props) => useBoardingLockAdvancer(props),
+      {
+        initialProps: {
+          lock: lockA,
+          route: directRoute,
+          destinationName: '강남',
+          currentStationName: '강남',
+        },
+      },
+    );
+    await waitFor(() => expect(mockedAdvance).toHaveBeenCalledTimes(1));
+    // 동일 waypoint로 currentStationName이 다시 들어오는 케이스 — GPS churn 등.
+    // useEffect deps 변동을 강제하려면 객체 ref 변경 필요 — route 객체를 같은 내용으로 재할당.
+    rerender({
+      lock: lockA,
+      route: { ...directRoute },
+      destinationName: '강남',
+      currentStationName: '강남',
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it('다음 waypoint로 이동하면 호출이 다시 발생', async () => {
+    const { rerender } = renderHook(
+      (props: Props) => useBoardingLockAdvancer(props),
+      {
+        initialProps: {
+          lock: lockA,
+          route: transferRoute,
+          destinationName: '명동',
+          currentStationName: '사당',
+        },
+      },
+    );
+    await waitFor(() => expect(mockedAdvance).toHaveBeenCalledTimes(1));
+    rerender({
+      lock: lockA,
+      route: transferRoute,
+      destinationName: '명동',
+      currentStationName: '명동',
+    });
+    await waitFor(() => expect(mockedAdvance).toHaveBeenCalledTimes(2));
+    expect(mockedAdvance).toHaveBeenLastCalledWith({
+      lock: lockA,
+      route: transferRoute,
+      destinationName: '명동',
+      passedStationName: '명동',
+    });
+  });
+
+  it('trainCode 변경 시 중복 추적 ref가 초기화되어 같은 이름도 다시 호출', async () => {
+    const { rerender } = renderHook(
+      (props: Props) => useBoardingLockAdvancer(props),
+      {
+        initialProps: {
+          lock: lockA,
+          route: directRoute,
+          destinationName: '강남',
+          currentStationName: '강남',
+        },
+      },
+    );
+    await waitFor(() => expect(mockedAdvance).toHaveBeenCalledTimes(1));
+    rerender({
+      lock: lockB,
+      route: directRoute,
+      destinationName: '강남',
+      currentStationName: '강남',
+    });
+    await waitFor(() => expect(mockedAdvance).toHaveBeenCalledTimes(2));
+    expect(mockedAdvance).toHaveBeenLastCalledWith({
+      lock: lockB,
+      route: directRoute,
+      destinationName: '강남',
+      passedStationName: '강남',
+    });
+  });
+
+  it('isSameStationName 정규화로 매칭 — 매칭된 target.name이 전달됨', async () => {
+    // 도착역명은 짧은 표기, 현재역명은 노선별 부제 포함. normalizeStationName이 부제를 떼고 매칭.
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: directRoute,
+        destinationName: '상봉',
+        currentStationName: '상봉(시외버스터미널)',
+      }),
+    );
+    await waitFor(() => {
+      expect(mockedAdvance).toHaveBeenCalledWith({
+        lock: lockA,
+        route: directRoute,
+        destinationName: '상봉',
+        // resolveAllTargets가 보유한 정식 이름(=destinationName 그대로)을 전달.
+        passedStationName: '상봉',
+      });
+    });
+  });
+
+  it('advanceHopWindow rejection은 logger.error로 기록되고 throw 없음', async () => {
+    mockedAdvance.mockRejectedValueOnce(new Error('boom'));
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: directRoute,
+        destinationName: '강남',
+        currentStationName: '강남',
+      }),
+    );
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith('advanceHopWindow 실패:', expect.any(Error));
+    });
+  });
+});

--- a/src/hooks/useBoardingLockAdvancer.ts
+++ b/src/hooks/useBoardingLockAdvancer.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import type { BoardingLock } from '../types/boardingLock';
+import type { Route } from '../utils/stationRoute';
+import { isSameStationName } from '../utils/stationRoute';
+import { resolveAllTargets } from '../utils/stationAlarm';
+import { advanceHopWindow } from '../utils/boardingLockScheduler';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useBoardingLockAdvancer');
+
+export interface UseBoardingLockAdvancerInputs {
+  lock: BoardingLock | null;
+  route: Route;
+  destinationName: string | null;
+  /** Fusion으로 결정된 현재역 이름. null이면 평가하지 않는다. */
+  currentStationName: string | null;
+}
+
+/**
+ * Fusion 현재역이 경로 waypoint에 도달하면 advanceHopWindow를 호출해 hop 윈도우를 전진시킨다 (#584 PR D).
+ *
+ * - lock/route/destinationName/currentStationName 중 하나라도 없으면 no-op.
+ * - resolveAllTargets와 동일한 waypoint 정의를 사용하므로 환승역/도착역이 자동 포함된다.
+ * - 같은 waypoint를 여러 번 통과 보고하지 않도록 마지막 advance된 waypoint name을 ref로 추적한다.
+ *   trainCode가 바뀌면(새 trip) ref를 초기화한다.
+ */
+export function useBoardingLockAdvancer({
+  lock,
+  route,
+  destinationName,
+  currentStationName,
+}: UseBoardingLockAdvancerInputs): void {
+  const lastAdvancedRef = useRef<string | null>(null);
+  const lastTrainCodeRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const trainCode = lock?.trainCode ?? null;
+    if (lastTrainCodeRef.current !== trainCode) {
+      lastTrainCodeRef.current = trainCode;
+      lastAdvancedRef.current = null;
+    }
+
+    if (!lock || !route || !destinationName || !currentStationName) return;
+
+    const targets = resolveAllTargets(route, destinationName);
+    const matched = targets.find((t) => isSameStationName(t.name, currentStationName));
+    if (!matched) return;
+    if (lastAdvancedRef.current === matched.name) return;
+
+    lastAdvancedRef.current = matched.name;
+    advanceHopWindow({
+      lock,
+      route,
+      destinationName,
+      passedStationName: matched.name,
+    }).catch((e: unknown) => {
+      logger.error('advanceHopWindow 실패:', e);
+    });
+  }, [lock, route, destinationName, currentStationName]);
+}

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -243,7 +243,13 @@ export interface AdvanceHopWindowParams {
   lock: BoardingLock;
   route: NonNullable<Route>;
   destinationName: string;
-  /** 통과한 waypoint 이름. resolveAllTargets에 등록된 이름과 일치해야 한다. */
+  /**
+   * 통과한 waypoint 이름.
+   * 내부에서 `t.name === passedStationName` strict equality로 매칭하므로 호출자는 반드시
+   * `resolveAllTargets`가 반환한 `target.name`(canonical)을 그대로 넘겨야 한다.
+   * 즉, `isSameStationName`으로 currentStation을 매칭한 다음 매칭된 target의 name을 전달한다 —
+   * raw `currentStationName`을 직접 전달하면 노선별 부제 등으로 silent miss(no-op)된다.
+   */
   passedStationName: string;
   now?: number;
   windowSize?: number;


### PR DESCRIPTION
## Summary
- `useBoardingLockAdvancer` hook 신설: Fusion 현재역(`useFusedNearestStation.result.station.name`)이 경로 waypoint에 도달하면 `advanceHopWindow`를 호출해 hop 윈도우를 전진시킨다.
- 매칭: `resolveAllTargets`로 waypoint 목록을 산출 → `isSameStationName`으로 정규화 매칭 → 매칭된 `target.name`(canonical)을 `passedStationName`으로 전달. `advanceHopWindow` 내부 `===` 비교 계약을 지킨다.
- 가드: `lock`/`route`/`destinationName`/`currentStationName` 중 하나라도 null → no-op. 같은 waypoint 재진입 dedup. `lock.trainCode` 변경 시 dedup ref 초기화.
- `AdvanceHopWindowParams.passedStationName` JSDoc 보강: strict equality 계약 명시.
- `app/(tabs)/index.tsx`에 1회 마운트.

## Stacked PR
- base = `feat/#584-pr-c-pre-schedule` (#598). PR C가 dev에 머지되면 이 PR을 dev로 rebase 후 머지.

## Test plan
- [x] `npm test` 전체 통과 (2023 tests, 127 suites)
- [x] 신규 hook 커버리지 100% (12 케이스 — lock/route/destinationName/currentStationName null, 미매칭, 도착역/환승역 매칭, 중복 dedup, 다음 waypoint 전진, trainCode 변경 후 재발화, isSameStationName 부제 정규화, advance rejection 로깅)
- [x] `npm run type-check` 통과
- [x] code-reviewer 1회 (P0 0건, P1 1건 — JSDoc 보강 반영)

Closes #584? No — PR D1만 끝. D2/E에서 fired 마킹·imminent 정정 등 잔여 작업 후 #584 close.