### PR TITLE
feat(#584): PR D2 — Fusion에 boarding-lock 라벨 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,6 +9,7 @@ import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../../src/utils/formatTime';
 import { LINE_NAMES } from '../../src/constants/lineColors';
 import { useAppStore } from '../../src/store/useAppStore';
+import { useBoardingLockStore } from '../../src/store/useBoardingLockStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
 import type { Station } from '../../src/types/station';
@@ -102,7 +103,10 @@ export default function HomeScreen() {
     () => (route && tripOrigin && destination ? { route, origin: tripOrigin, destination } : undefined),
     [route, tripOrigin, destination],
   );
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext);
+  // #584 PR D2: lock.trainCode를 fusion에 전달 — position-train이 같은 trainCode면 'boarding-lock' 승격.
+  // useBoardingLockController가 동일 store를 소비하지만 selector로 trainCode만 추출해 churn 최소화.
+  const lockedTrainCode = useBoardingLockStore((s) => s.lock?.trainCode ?? null);
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode);
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -173,6 +173,72 @@ describe('useFusedNearestStation', () => {
     expect(result.current.source).toBe('position-train');
   });
 
+  describe('#584 PR D2: boarding-lock 라벨', () => {
+    // 공통 setup: position-train 채택 시나리오. lockedTrainCode 인자만 바꿔가며 라벨 검증.
+    const setupPositionTrain = (overrideTrainNo: string) => {
+      mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
+      mockFindTop.mockReturnValue([
+        { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+        { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
+      ]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      mockUsePositions
+        .mockReturnValueOnce(positionRet({ line: '2', trains: [] }))
+        .mockReturnValueOnce(
+          positionRet({
+            line: '3',
+            trains: [
+              train(MOCK_STATIONS.chungmuro.name, TRAIN_STATUS.ARRIVED, {
+                trainNo: overrideTrainNo,
+              }),
+            ],
+          }),
+        )
+        .mockReturnValueOnce(positionRet(null));
+    };
+
+    it('lockedTrainCode가 position-train의 trainNo와 일치하면 boarding-lock으로 승격', () => {
+      setupPositionTrain('T-LOCKED');
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED'),
+      );
+      expect(result.current.confidence).toBe('boarding-lock');
+      expect(result.current.source).toBe('boarding-lock');
+    });
+
+    it('lockedTrainCode가 다르면 position-train 유지', () => {
+      setupPositionTrain('T-ACTUAL');
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-OTHER'),
+      );
+      expect(result.current.confidence).toBe('position-train');
+      expect(result.current.source).toBe('position-train');
+    });
+
+    it('lockedTrainCode=null이면 position-train 유지', () => {
+      setupPositionTrain('T-ANY');
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null),
+      );
+      expect(result.current.confidence).toBe('position-train');
+      expect(result.current.source).toBe('position-train');
+    });
+
+    it('lockedTrainCode 있어도 position-train 신호 없으면 승격 안 됨 (arrival/gps 분기 유지)', () => {
+      // arrival만 있는 케이스 — boarding-lock은 position-train 채택 전제
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+      mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+      mockUsePositions.mockReturnValue(positionRet(null));
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED'),
+      );
+      expect(result.current.confidence).toBe('arrival-confirmed');
+      expect(result.current.source).toBe('arrival');
+    });
+  });
+
   it('arrival 있고 position-train 후보 없으면 fused arrival 채택', () => {
     mockUseNearest.mockReturnValue(gpsBase());
     mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -197,6 +197,22 @@ describe('useStationAlarm', () => {
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
 
+    it('GPS 게이트 차단 + arrivalConfidence=boarding-lock → station-passed 알람 발화 (#584 PR D2)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'boarding-lock',
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+
     it('GPS 게이트 차단 + arrivalConfidence=arrival-arriving → 발화 안 함 (확정 아님)', () => {
       renderHook(() =>
         useStationAlarm(

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -99,6 +99,12 @@ export function useFusedNearestStation(
   arrivalProvider?: ArrivalProvider,
   positionProvider?: PositionProvider,
   routeContext?: FusedRouteContext,
+  /**
+   * 활성 BoardingLock의 trainCode. 사용자가 탭한 열차가 position-train으로 확인되면
+   * source/confidence를 'boarding-lock'으로 승격 — UI/알람 dedup에서 최고 신뢰 신호로 식별.
+   * null/undefined면 기존 우선순위 그대로.
+   */
+  lockedTrainCode?: string | null,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation();
 
@@ -270,8 +276,13 @@ export function useFusedNearestStation(
   let source: FusionSource;
   if (positionTrainResult) {
     result = positionTrainResult;
-    confidence = 'position-train';
-    source = 'position-train';
+    // #584 PR D2: position-train의 trainNo가 BoardingLock.trainCode와 일치하면 'boarding-lock'으로 승격.
+    // 사용자가 탭한 바로 그 열차가 실시간 위치 API에 잡힌 상태 — 최고 신뢰 신호.
+    // positionTrainResult가 non-null이면 trainProgress도 non-null (line 219 guard).
+    const lockMatch =
+      lockedTrainCode != null && trainProgress!.trainNo === lockedTrainCode;
+    confidence = lockMatch ? 'boarding-lock' : 'position-train';
+    source = lockMatch ? 'boarding-lock' : 'position-train';
   } else if (fused && fusedPasses) {
     result = fused.result;
     confidence = fused.confidence;

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -254,7 +254,10 @@ export function useStationAlarm({
   // #452: deps에 raw accuracyMeters를 두면 GPS 노이즈로 매 fix 재실행 → dedup-suppressed
   // 로그가 cap까지 차서 다른 진단을 밀어낸다. 게이트 통과 여부(boolean)만 dep로 둔다.
   const accuracyOk = isAccuracyAcceptable(accuracyMeters);
-  const arrivalConfirmed = arrivalConfidence === 'arrival-confirmed';
+  // #584 PR D2: boarding-lock(사용자가 탭한 열차를 실시간 위치 API로 확인)은 arrival-confirmed보다
+  // 더 강한 신호 — GPS 정확도 게이트도 같은 등급으로 통과시킨다.
+  const arrivalConfirmed =
+    arrivalConfidence === 'arrival-confirmed' || arrivalConfidence === 'boarding-lock';
 
   useEffect(() => {
     let cancelled = false;

--- a/src/utils/__tests__/notificationSource.test.ts
+++ b/src/utils/__tests__/notificationSource.test.ts
@@ -8,6 +8,7 @@ import type { FusionSource } from '../pickFusedStation';
 
 describe('resolveNotificationSource', () => {
   it.each<[FusionSource, NotificationSource]>([
+    ['boarding-lock', 'positionTrain'],
     ['position-train', 'positionTrain'],
     ['position', 'positionTrain'],
     ['arrival', 'positionTrain'],

--- a/src/utils/notificationSource.ts
+++ b/src/utils/notificationSource.ts
@@ -25,6 +25,7 @@ export function resolveNotificationSource(
 ): NotificationSource {
   if (locationUncertain) return 'uncertain';
   switch (source) {
+    case 'boarding-lock':
     case 'position-train':
     case 'position':
     case 'arrival':

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -11,6 +11,7 @@ import { getTrainStatusPriority } from '../constants/trainStatus';
  * 도착/위치 API와 달리 자체 검증 신호가 아니라 별도 confidence로 둔다.
  */
 export type FusionConfidence =
+  | 'boarding-lock'
   | 'position-train'
   | 'arrival-confirmed'
   | 'arrival-arriving'
@@ -24,6 +25,7 @@ export type FusionConfidence =
  * 알람 dedup·로깅에서 source별 정책 분기에 사용.
  */
 export type FusionSource =
+  | 'boarding-lock'
   | 'position-train'
   | 'position'
   | 'arrival'


### PR DESCRIPTION
## Summary
- `FusionConfidence` / `FusionSource` 유니온에 `'boarding-lock'` 추가.
- `useFusedNearestStation`에 4번째 optional param `lockedTrainCode?: string | null` 추가. position-train이 채택된 후 `trainProgress.trainNo === lockedTrainCode`이면 confidence/source를 `'boarding-lock'`으로 승격 — 사용자가 탭한 열차를 실시간 위치 API로 확인한 최고 신뢰 상태.
- `useStationAlarm.arrivalConfirmed` 게이트에 `'boarding-lock'` 포함 — GPS 정확도 낮을 때도 `arrival-confirmed`와 동등하게 station-passed 알람 발화.
- `notificationSource.ts` switch에 `boarding-lock` → `positionTrain` 매핑 추가.
- `app/(tabs)/index.tsx`에서 `useBoardingLockStore` selector로 `lockedTrainCode` 추출해 hook에 전달.

## Stacked PR
- base = `feat/#584-pr-d-fusion` (#599). PR D1이 dev에 머지되면 이 PR base를 자동으로 dev로 갱신(merge commit 정책 → force-push 불필요).

## 비범위
- GPS 격하 / 잘못 탑승 토스트는 PR D3.
- 디버그 모달의 `boarding-lock` 식별 표기는 [#283 후속]으로 분리.

## Test plan
- [x] `npm test` 2029 tests passed, 127 suites, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-reviewer (P1 1건 → 게이트 통과 반영 + 테스트 추가, P2 1건 → optional chain 정리)
- 신규/추가 케이스:
  - fused: lockedTrainCode 매칭 → `boarding-lock`, 불일치/null/non-position-train 유지
  - alarm: GPS 차단 + `boarding-lock` → station-passed 발화 (PR D2 게이트)
  - notificationSource: `boarding-lock` → `positionTrain` 그룹