### PR TITLE
feat(#584): PR D3 — 잘못 탑승 감지 + 재선택 UI

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -38,6 +38,9 @@ import { useBoardingLockController } from '../../src/hooks/useBoardingLockContro
 import { useBoardingLockScheduler } from '../../src/hooks/useBoardingLockScheduler';
 import { useBoardingLockAdvancer } from '../../src/hooks/useBoardingLockAdvancer';
 import { BoardingLockBanner } from '../../src/components/BoardingLockBanner';
+import { MisBoardingBanner } from '../../src/components/MisBoardingBanner';
+import { useMisBoardingDetector } from '../../src/hooks/useMisBoardingDetector';
+import { useTrainPositions } from '../../src/hooks/useTrainPositions';
 import { BoardingTrainList } from '../../src/components/BoardingTrainList';
 
 const logger = createLogger('HomeScreen');
@@ -220,6 +223,13 @@ export default function HomeScreen() {
     route,
     destinationName: destination?.name ?? null,
     currentStationName: result?.station.name ?? null,
+  });
+  // #584 PR D3: lock.boardingLine 위치 데이터를 별도 구독 — fusion 캐시와 dedup되어 추가 비용 없음.
+  // lock 없으면 line=null로 호출되어 polling이 자동 정지된다.
+  const { positions: lockLinePositions } = useTrainPositions(boardingLock?.boardingLine ?? null);
+  const { detected: misBoardingDetected } = useMisBoardingDetector({
+    lock: boardingLock,
+    positions: lockLinePositions,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({
@@ -645,6 +655,9 @@ export default function HomeScreen() {
 
             {/* Arrivals — 현재역(effectiveOrigin)이 확정되면 trip 유무와 무관하게 노출 */}
             {/* #584 PR B — BoardingLock 진입점. 활성 시 banner, 비활성 + destination 설정 시 train list. */}
+            {destination && boardingLock && misBoardingDetected && (
+              <MisBoardingBanner onReselect={releaseBoardingLock} />
+            )}
             {destination && boardingLock && (
               <BoardingLockBanner lock={boardingLock} onRelease={releaseBoardingLock} />
             )}

--- a/src/components/ActionBanner.tsx
+++ b/src/components/ActionBanner.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme, typography, spacing, radius } from '../theme';
+
+interface Props {
+  /** border + 액션 텍스트/테두리 색. accent(보통) 또는 warn(경고) 등 의도 색. */
+  accent: string;
+  /** 좌측 info 슬롯 — 헤더 라벨/메타 정보/추가 콘텐츠. */
+  children: ReactNode;
+  /** 우측 액션 버튼 라벨 (예: "하차", "재선택"). */
+  actionLabel: string;
+  onActionPress: () => void;
+  testID: string;
+  actionTestID: string;
+  /** 다음 요소와 분리 margin. 미전달 시 0. */
+  marginBottom?: number;
+}
+
+/**
+ * 좌측 info + 우측 action 버튼 구조의 공통 배너 (#584 PR D3 — Sonar 중복 감소).
+ *
+ * BoardingLockBanner / MisBoardingBanner 등 같은 레이아웃을 공유. children 슬롯으로
+ * info 영역을 자유롭게 채우고, 버튼은 라벨/색만 prop으로 받는다.
+ */
+export function ActionBanner({
+  accent,
+  children,
+  actionLabel,
+  onActionPress,
+  testID,
+  actionTestID,
+  marginBottom,
+}: Props) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.card, borderColor: accent, marginBottom: marginBottom ?? 0 },
+      ]}
+      testID={testID}
+    >
+      <View style={styles.info}>{children}</View>
+      <Pressable
+        onPress={onActionPress}
+        style={[styles.actionButton, { borderColor: accent }]}
+        testID={actionTestID}
+      >
+        <Text style={[typography.body, { color: accent, fontWeight: '600' }]}>{actionLabel}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    gap: spacing.md,
+  },
+  info: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  actionButton: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+});

--- a/src/components/BoardingLockBanner.tsx
+++ b/src/components/BoardingLockBanner.tsx
@@ -1,6 +1,7 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { useTheme, typography, spacing, radius } from '../theme';
+import { StyleSheet, Text, View } from 'react-native';
+import { useTheme, typography, spacing } from '../theme';
 import { LineBadge } from './LineBadge';
+import { ActionBanner } from './ActionBanner';
 import type { BoardingLock } from '../types/boardingLock';
 
 interface Props {
@@ -12,55 +13,31 @@ interface Props {
  * BoardingLock 활성 시 노출되는 배너 (#584 PR B).
  *
  * 사용자에게 어떤 열차/노선에 lock 되어 있는지 명시. "하차" 탭으로 즉시 release.
- * 이 PR에서는 lock 정보만 표시 — 알람과의 연결은 PR C/D에서 활성화.
+ * 공통 레이아웃은 ActionBanner 슬롯 패턴으로 위임 (#584 PR D3 Sonar 중복 해소).
  */
 export function BoardingLockBanner({ lock, onRelease }: Props) {
   const { colors } = useTheme();
   return (
-    <View
-      style={[styles.container, { backgroundColor: colors.card, borderColor: colors.accent }]}
+    <ActionBanner
+      accent={colors.accent}
       testID="boarding-lock-banner"
+      actionLabel="하차"
+      onActionPress={onRelease}
+      actionTestID="boarding-lock-release"
     >
-      <View style={styles.info}>
-        <Text style={[typography.label, { color: colors.muted }]}>탑승 중</Text>
-        <View style={styles.row}>
-          <LineBadge line={lock.boardingLine} />
-          <Text style={[typography.mono, { color: colors.ink }]}>{lock.trainCode}</Text>
-        </View>
+      <Text style={[typography.label, { color: colors.muted }]}>탑승 중</Text>
+      <View style={styles.row}>
+        <LineBadge line={lock.boardingLine} />
+        <Text style={[typography.mono, { color: colors.ink }]}>{lock.trainCode}</Text>
       </View>
-      <Pressable
-        onPress={onRelease}
-        style={[styles.releaseButton, { borderColor: colors.accent }]}
-        testID="boarding-lock-release"
-      >
-        <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>하차</Text>
-      </Pressable>
-    </View>
+    </ActionBanner>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: spacing.lg,
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    gap: spacing.md,
-  },
-  info: {
-    gap: spacing.xs,
-  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
-  },
-  releaseButton: {
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.sm,
-    borderRadius: radius.md,
-    borderWidth: 1,
   },
 });

--- a/src/components/MisBoardingBanner.tsx
+++ b/src/components/MisBoardingBanner.tsx
@@ -1,5 +1,6 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { useTheme, typography, spacing, radius } from '../theme';
+import { Text } from 'react-native';
+import { useTheme, typography, spacing } from '../theme';
+import { ActionBanner } from './ActionBanner';
 
 interface Props {
   onReselect: () => void;
@@ -8,53 +9,24 @@ interface Props {
 /**
  * BoardingLock의 trainCode가 실시간 위치 API에서 사라졌을 때 노출되는 경고 배너 (#584 PR D3).
  *
- * 사용자에게 잘못된 열차에 lock 되어 있을 가능성을 알리고, [재선택] 탭으로 lock 해제 진입점 제공.
  * 표시 조건/감지 로직은 useMisBoardingDetector가 담당 — 이 컴포넌트는 순수 표시 + 액션.
+ * 공통 레이아웃은 ActionBanner 슬롯 패턴으로 위임.
  */
 export function MisBoardingBanner({ onReselect }: Props) {
   const { colors } = useTheme();
   return (
-    <View
-      style={[styles.container, { backgroundColor: colors.card, borderColor: colors.warn }]}
+    <ActionBanner
+      accent={colors.warn}
       testID="mis-boarding-banner"
+      actionLabel="재선택"
+      onActionPress={onReselect}
+      actionTestID="mis-boarding-reselect"
+      marginBottom={spacing.md}
     >
-      <View style={styles.info}>
-        <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 미확인</Text>
-        <Text style={[typography.body, { color: colors.muted }]}>
-          선택한 열차를 찾을 수 없어요. 다른 열차였다면 다시 선택해주세요.
-        </Text>
-      </View>
-      <Pressable
-        onPress={onReselect}
-        style={[styles.reselectButton, { borderColor: colors.warn }]}
-        testID="mis-boarding-reselect"
-      >
-        <Text style={[typography.body, { color: colors.warn, fontWeight: '600' }]}>재선택</Text>
-      </Pressable>
-    </View>
+      <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 미확인</Text>
+      <Text style={[typography.body, { color: colors.muted }]}>
+        선택한 열차를 찾을 수 없어요. 다른 열차였다면 다시 선택해주세요.
+      </Text>
+    </ActionBanner>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: spacing.lg,
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    gap: spacing.md,
-    // BoardingLockBanner와 수직으로 붙지 않도록 분리 margin.
-    marginBottom: spacing.md,
-  },
-  info: {
-    flex: 1,
-    gap: spacing.xs,
-  },
-  reselectButton: {
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.sm,
-    borderRadius: radius.md,
-    borderWidth: 1,
-  },
-});

--- a/src/components/MisBoardingBanner.tsx
+++ b/src/components/MisBoardingBanner.tsx
@@ -1,0 +1,60 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme, typography, spacing, radius } from '../theme';
+
+interface Props {
+  onReselect: () => void;
+}
+
+/**
+ * BoardingLock의 trainCode가 실시간 위치 API에서 사라졌을 때 노출되는 경고 배너 (#584 PR D3).
+ *
+ * 사용자에게 잘못된 열차에 lock 되어 있을 가능성을 알리고, [재선택] 탭으로 lock 해제 진입점 제공.
+ * 표시 조건/감지 로직은 useMisBoardingDetector가 담당 — 이 컴포넌트는 순수 표시 + 액션.
+ */
+export function MisBoardingBanner({ onReselect }: Props) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.card, borderColor: colors.warn }]}
+      testID="mis-boarding-banner"
+    >
+      <View style={styles.info}>
+        <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 미확인</Text>
+        <Text style={[typography.body, { color: colors.muted }]}>
+          선택한 열차를 찾을 수 없어요. 다른 열차였다면 다시 선택해주세요.
+        </Text>
+      </View>
+      <Pressable
+        onPress={onReselect}
+        style={[styles.reselectButton, { borderColor: colors.warn }]}
+        testID="mis-boarding-reselect"
+      >
+        <Text style={[typography.body, { color: colors.warn, fontWeight: '600' }]}>재선택</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    gap: spacing.md,
+    // BoardingLockBanner와 수직으로 붙지 않도록 분리 margin.
+    marginBottom: spacing.md,
+  },
+  info: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  reselectButton: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+});

--- a/src/components/__tests__/ActionBanner.test.tsx
+++ b/src/components/__tests__/ActionBanner.test.tsx
@@ -1,0 +1,84 @@
+import { Text } from 'react-native';
+import { fireEvent } from '@testing-library/react-native';
+import { ActionBanner } from '../ActionBanner';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+
+describe('ActionBanner', () => {
+  it('actionLabel 텍스트와 testID 부착', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={() => {}}
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    expect(getByTestId('banner')).toBeTruthy();
+    expect(getByTestId('banner-action')).toBeTruthy();
+    expect(getByText('실행')).toBeTruthy();
+    expect(getByText('info')).toBeTruthy();
+  });
+
+  it('액션 버튼 탭 → onActionPress 호출', () => {
+    const onActionPress = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={onActionPress}
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    fireEvent.press(getByTestId('banner-action'));
+    expect(onActionPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('marginBottom 미전달 시 0 적용', () => {
+    const { getByTestId } = renderWithTheme(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={() => {}}
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    const view = getByTestId('banner');
+    const flat = Array.isArray(view.props.style) ? view.props.style.flat() : [view.props.style];
+    const marginBottom = flat
+      .filter((s: unknown): s is { marginBottom?: number } => typeof s === 'object' && s !== null)
+      .map((s: { marginBottom?: number }) => s.marginBottom)
+      .find((m: number | undefined) => m !== undefined);
+    expect(marginBottom).toBe(0);
+  });
+
+  it('marginBottom prop 적용', () => {
+    const { getByTestId } = renderWithTheme(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={() => {}}
+        marginBottom={12}
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    const view = getByTestId('banner');
+    const flat = Array.isArray(view.props.style) ? view.props.style.flat() : [view.props.style];
+    const marginBottom = flat
+      .filter((s: unknown): s is { marginBottom?: number } => typeof s === 'object' && s !== null)
+      .map((s: { marginBottom?: number }) => s.marginBottom)
+      .find((m: number | undefined) => m !== undefined);
+    expect(marginBottom).toBe(12);
+  });
+});

--- a/src/components/__tests__/ActionBanner.test.tsx
+++ b/src/components/__tests__/ActionBanner.test.tsx
@@ -39,7 +39,10 @@ describe('ActionBanner', () => {
     expect(onActionPress).toHaveBeenCalledTimes(1);
   });
 
-  it('marginBottom 미전달 시 0 적용', () => {
+  it.each<[number | undefined, number]>([
+    [undefined, 0],
+    [12, 12],
+  ])('marginBottom prop=%s → 컨테이너 marginBottom=%s', (prop, expected) => {
     const { getByTestId } = renderWithTheme(
       <ActionBanner
         accent="#000"
@@ -47,6 +50,7 @@ describe('ActionBanner', () => {
         actionLabel="실행"
         actionTestID="banner-action"
         onActionPress={() => {}}
+        marginBottom={prop}
       >
         <Text>info</Text>
       </ActionBanner>,
@@ -57,28 +61,6 @@ describe('ActionBanner', () => {
       .filter((s: unknown): s is { marginBottom?: number } => typeof s === 'object' && s !== null)
       .map((s: { marginBottom?: number }) => s.marginBottom)
       .find((m: number | undefined) => m !== undefined);
-    expect(marginBottom).toBe(0);
-  });
-
-  it('marginBottom prop 적용', () => {
-    const { getByTestId } = renderWithTheme(
-      <ActionBanner
-        accent="#000"
-        testID="banner"
-        actionLabel="실행"
-        actionTestID="banner-action"
-        onActionPress={() => {}}
-        marginBottom={12}
-      >
-        <Text>info</Text>
-      </ActionBanner>,
-    );
-    const view = getByTestId('banner');
-    const flat = Array.isArray(view.props.style) ? view.props.style.flat() : [view.props.style];
-    const marginBottom = flat
-      .filter((s: unknown): s is { marginBottom?: number } => typeof s === 'object' && s !== null)
-      .map((s: { marginBottom?: number }) => s.marginBottom)
-      .find((m: number | undefined) => m !== undefined);
-    expect(marginBottom).toBe(12);
+    expect(marginBottom).toBe(expected);
   });
 });

--- a/src/components/__tests__/MisBoardingBanner.test.tsx
+++ b/src/components/__tests__/MisBoardingBanner.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent } from '@testing-library/react-native';
+import { MisBoardingBanner } from '../MisBoardingBanner';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+
+describe('MisBoardingBanner', () => {
+  it('경고 라벨과 재선택 버튼을 렌더', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <MisBoardingBanner onReselect={() => {}} />,
+    );
+    expect(getByTestId('mis-boarding-banner')).toBeTruthy();
+    expect(getByText('탑승 열차 미확인')).toBeTruthy();
+    expect(getByText('재선택')).toBeTruthy();
+  });
+
+  it('재선택 버튼 탭 시 onReselect 호출', () => {
+    const onReselect = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <MisBoardingBanner onReselect={onReselect} />,
+    );
+    fireEvent.press(getByTestId('mis-boarding-reselect'));
+    expect(onReselect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/useMisBoardingDetector.test.tsx
+++ b/src/hooks/__tests__/useMisBoardingDetector.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook, act, type RenderHookResult } from '@testing-library/react-native';
 import {
   useMisBoardingDetector,
   MIS_BOARDING_GRACE_MS,
@@ -35,171 +35,186 @@ const absentPositions: LinePositions = { line: '2', trains: [train('T-OTHER')] }
 const presentPositions: LinePositions = { line: '2', trains: [train('T-LOCK')] };
 
 type Props = Parameters<typeof useMisBoardingDetector>[0];
+type Result = ReturnType<typeof useMisBoardingDetector>;
+
+const afterGraceNow = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+
+/** 표준 mount: lock=baseLock, positions=absent, now=afterGrace 기본값. override로 변형. */
+function mount(initial: Partial<Props> = {}): RenderHookResult<Result, Props> {
+  return renderHook((props: Props) => useMisBoardingDetector(props), {
+    initialProps: {
+      lock: baseLock,
+      positions: absentPositions,
+      now: afterGraceNow,
+      ...initial,
+    },
+  });
+}
+
+/** rerender를 N회 — 매번 새 positions 객체로 effect 강제 발화. */
+function rerenderTimes(
+  rerender: (p: Props) => void,
+  props: Props,
+  times: number,
+): void {
+  for (let i = 0; i < times; i++) {
+    act(() => rerender({ ...props, positions: props.positions ? { ...props.positions } : null }));
+  }
+}
 
 describe('useMisBoardingDetector', () => {
   it('lock=null이면 항상 detected=false', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result } = renderHook(() =>
-      useMisBoardingDetector({ lock: null, positions: absentPositions, now }),
+    const { result } = mount({ lock: null });
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('grace 기간 내 absent는 카운터 미증가', () => {
+    const inGraceNow = () => baseLock.boardedAt + 100;
+    const { result, rerender } = mount({ now: inGraceNow });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: inGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD + 5,
     );
     expect(result.current.detected).toBe(false);
   });
 
-  it('grace 기간 내 absent는 카운터 미증가 (detected=false 유지)', () => {
-    const now = () => baseLock.boardedAt + 100;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+  it('grace 이후 absent threshold회 누적되면 detected=true', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 5; i++) {
-      rerender({ lock: baseLock, positions: { ...absentPositions }, now });
-    }
-    expect(result.current.detected).toBe(false);
-  });
-
-  it('grace 이후 absent 관측이 threshold회 누적되면 detected=true', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: absentPositions, now } },
-    );
-    // 첫 번째 mount = 1회 관측. threshold-1번 더 rerender.
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
-      act(() => {
-        rerender({ lock: baseLock, positions: { ...absentPositions }, now });
-      });
-    }
     expect(result.current.detected).toBe(true);
   });
 
   it('present 관측이 들어오면 카운터 reset + detected=false', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
-      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
-    }
     expect(result.current.detected).toBe(true);
 
-    act(() => rerender({ lock: baseLock, positions: presentPositions, now }));
+    act(() =>
+      rerender({ lock: baseLock, positions: presentPositions, now: afterGraceNow }),
+    );
     expect(result.current.detected).toBe(false);
   });
 
   it('lock.trainCode가 바뀌면 카운터/detected reset', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
-      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
-    }
     expect(result.current.detected).toBe(true);
 
-    const newLock = { ...baseLock, trainCode: 'T-NEW' };
-    act(() => rerender({ lock: newLock, positions: absentPositions, now }));
+    act(() =>
+      rerender({
+        lock: { ...baseLock, trainCode: 'T-NEW' },
+        positions: absentPositions,
+        now: afterGraceNow,
+      }),
+    );
     expect(result.current.detected).toBe(false);
   });
 
   it('lock → null이면 detected reset', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
-      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
-    }
     expect(result.current.detected).toBe(true);
 
-    act(() => rerender({ lock: null, positions: absentPositions, now }));
+    act(() =>
+      rerender({ lock: null, positions: absentPositions, now: afterGraceNow }),
+    );
     expect(result.current.detected).toBe(false);
   });
 
   it('positions.isMock=true는 no-signal로 처리되어 카운터 미증가', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
     const mockPositions: LinePositions = { ...absentPositions, isMock: true };
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: mockPositions, now } },
+    const { result, rerender } = mount({ positions: mockPositions });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mockPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD + 5,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 5; i++) {
-      act(() => rerender({ lock: baseLock, positions: { ...mockPositions }, now }));
-    }
     expect(result.current.detected).toBe(false);
   });
 
   it('positions=null이면 카운터 미증가', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: null, now } },
+    const { result, rerender } = mount({ positions: null });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: null, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD + 5,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 5; i++) {
-      act(() => rerender({ lock: baseLock, positions: null, now }));
-    }
     expect(result.current.detected).toBe(false);
   });
 
-  it('now 기본값(Date.now) 사용 — boardedAt이 과거라면 grace 통과', () => {
-    const longAgoLock = { ...baseLock, boardedAt: 0 }; // 1970
+  it('now 기본값(Date.now) 사용 — boardedAt 과거면 grace 통과', () => {
+    const longAgoLock = { ...baseLock, boardedAt: 0 };
     const { result, rerender } = renderHook(
       (props: Props) => useMisBoardingDetector(props),
       { initialProps: { lock: longAgoLock, positions: absentPositions } },
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
-      act(() => rerender({ lock: longAgoLock, positions: { ...absentPositions } }));
-    }
+    rerenderTimes(
+      rerender,
+      { lock: longAgoLock, positions: absentPositions },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
+    );
     expect(result.current.detected).toBe(true);
   });
 
-  it('동일 trainCode + 다른 boardedAt(=새 lock) → 카운터/감지 reset + grace 재적용', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+  it('동일 trainCode + 다른 boardedAt(=새 lock) → reset + grace 재적용', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
-      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
-    }
     expect(result.current.detected).toBe(true);
 
-    // 같은 trainCode를 다시 탭한 시뮬레이션 — boardedAt 갱신
     const refreshedLock = { ...baseLock, boardedAt: baseLock.boardedAt + 10_000 };
-    const stillInGraceNow = () => refreshedLock.boardedAt + 100;
+    const stillInGrace = () => refreshedLock.boardedAt + 100;
     act(() =>
-      rerender({ lock: refreshedLock, positions: absentPositions, now: stillInGraceNow }),
+      rerender({ lock: refreshedLock, positions: absentPositions, now: stillInGrace }),
     );
-    // 새 lock → detected reset + grace 안이라 누적도 안 됨
     expect(result.current.detected).toBe(false);
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 2; i++) {
-      act(() =>
-        rerender({ lock: refreshedLock, positions: { ...absentPositions }, now: stillInGraceNow }),
-      );
-    }
+    rerenderTimes(
+      rerender,
+      { lock: refreshedLock, positions: absentPositions, now: stillInGrace },
+      MIS_BOARDING_MISS_THRESHOLD + 2,
+    );
     expect(result.current.detected).toBe(false);
   });
 
-  it('detected=true 상태에서 present 후 absent threshold 재누적 시 다시 true', () => {
-    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
-    const { result, rerender } = renderHook(
-      (props: Props) => useMisBoardingDetector(props),
-      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+  it('detected=true 상태에서 present 후 absent 재누적 시 다시 true', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
     );
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
-      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
-    }
     expect(result.current.detected).toBe(true);
 
-    act(() => rerender({ lock: baseLock, positions: presentPositions, now }));
+    act(() =>
+      rerender({ lock: baseLock, positions: presentPositions, now: afterGraceNow }),
+    );
     expect(result.current.detected).toBe(false);
 
-    // 다시 absent 누적
-    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD; i++) {
-      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
-    }
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: absentPositions, now: afterGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD,
+    );
     expect(result.current.detected).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useMisBoardingDetector.test.tsx
+++ b/src/hooks/__tests__/useMisBoardingDetector.test.tsx
@@ -1,0 +1,205 @@
+import { renderHook, act } from '@testing-library/react-native';
+import {
+  useMisBoardingDetector,
+  MIS_BOARDING_GRACE_MS,
+  MIS_BOARDING_MISS_THRESHOLD,
+} from '../useMisBoardingDetector';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
+
+const baseLock: BoardingLock = {
+  destinationId: 'd',
+  trainCode: 'T-LOCK',
+  boardingStationId: 's',
+  boardingLine: '2',
+  boardedAt: 1_000_000,
+  expectedDurationMs: 1_800_000,
+};
+
+function train(trainNo: string): TrainPosition {
+  return {
+    statnId: '',
+    statnNm: '',
+    trainNo,
+    trainStatus: 0,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+  };
+}
+
+const absentPositions: LinePositions = { line: '2', trains: [train('T-OTHER')] };
+const presentPositions: LinePositions = { line: '2', trains: [train('T-LOCK')] };
+
+type Props = Parameters<typeof useMisBoardingDetector>[0];
+
+describe('useMisBoardingDetector', () => {
+  it('lock=null이면 항상 detected=false', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result } = renderHook(() =>
+      useMisBoardingDetector({ lock: null, positions: absentPositions, now }),
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('grace 기간 내 absent는 카운터 미증가 (detected=false 유지)', () => {
+    const now = () => baseLock.boardedAt + 100;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 5; i++) {
+      rerender({ lock: baseLock, positions: { ...absentPositions }, now });
+    }
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('grace 이후 absent 관측이 threshold회 누적되면 detected=true', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    );
+    // 첫 번째 mount = 1회 관측. threshold-1번 더 rerender.
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
+      act(() => {
+        rerender({ lock: baseLock, positions: { ...absentPositions }, now });
+      });
+    }
+    expect(result.current.detected).toBe(true);
+  });
+
+  it('present 관측이 들어오면 카운터 reset + detected=false', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
+      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
+    }
+    expect(result.current.detected).toBe(true);
+
+    act(() => rerender({ lock: baseLock, positions: presentPositions, now }));
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('lock.trainCode가 바뀌면 카운터/detected reset', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
+      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
+    }
+    expect(result.current.detected).toBe(true);
+
+    const newLock = { ...baseLock, trainCode: 'T-NEW' };
+    act(() => rerender({ lock: newLock, positions: absentPositions, now }));
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('lock → null이면 detected reset', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
+      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
+    }
+    expect(result.current.detected).toBe(true);
+
+    act(() => rerender({ lock: null, positions: absentPositions, now }));
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('positions.isMock=true는 no-signal로 처리되어 카운터 미증가', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const mockPositions: LinePositions = { ...absentPositions, isMock: true };
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: mockPositions, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 5; i++) {
+      act(() => rerender({ lock: baseLock, positions: { ...mockPositions }, now }));
+    }
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('positions=null이면 카운터 미증가', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: null, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 5; i++) {
+      act(() => rerender({ lock: baseLock, positions: null, now }));
+    }
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('now 기본값(Date.now) 사용 — boardedAt이 과거라면 grace 통과', () => {
+    const longAgoLock = { ...baseLock, boardedAt: 0 }; // 1970
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: longAgoLock, positions: absentPositions } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
+      act(() => rerender({ lock: longAgoLock, positions: { ...absentPositions } }));
+    }
+    expect(result.current.detected).toBe(true);
+  });
+
+  it('동일 trainCode + 다른 boardedAt(=새 lock) → 카운터/감지 reset + grace 재적용', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
+      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
+    }
+    expect(result.current.detected).toBe(true);
+
+    // 같은 trainCode를 다시 탭한 시뮬레이션 — boardedAt 갱신
+    const refreshedLock = { ...baseLock, boardedAt: baseLock.boardedAt + 10_000 };
+    const stillInGraceNow = () => refreshedLock.boardedAt + 100;
+    act(() =>
+      rerender({ lock: refreshedLock, positions: absentPositions, now: stillInGraceNow }),
+    );
+    // 새 lock → detected reset + grace 안이라 누적도 안 됨
+    expect(result.current.detected).toBe(false);
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD + 2; i++) {
+      act(() =>
+        rerender({ lock: refreshedLock, positions: { ...absentPositions }, now: stillInGraceNow }),
+      );
+    }
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('detected=true 상태에서 present 후 absent threshold 재누적 시 다시 true', () => {
+    const now = () => baseLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+    const { result, rerender } = renderHook(
+      (props: Props) => useMisBoardingDetector(props),
+      { initialProps: { lock: baseLock, positions: absentPositions, now } },
+    );
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD - 1; i++) {
+      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
+    }
+    expect(result.current.detected).toBe(true);
+
+    act(() => rerender({ lock: baseLock, positions: presentPositions, now }));
+    expect(result.current.detected).toBe(false);
+
+    // 다시 absent 누적
+    for (let i = 0; i < MIS_BOARDING_MISS_THRESHOLD; i++) {
+      act(() => rerender({ lock: baseLock, positions: { ...absentPositions }, now }));
+    }
+    expect(result.current.detected).toBe(true);
+  });
+});

--- a/src/hooks/useMisBoardingDetector.ts
+++ b/src/hooks/useMisBoardingDetector.ts
@@ -1,0 +1,93 @@
+import { type MutableRefObject, useEffect, useRef, useState } from 'react';
+import type { BoardingLock } from '../types/boardingLock';
+import type { LinePositions } from '../api/positionApi';
+import { detectMisBoarding } from '../utils/detectMisBoarding';
+
+/**
+ * ref + state 이중관리의 동기 helper. 모듈 스코프에 두어 effect 클로저에서 stale 참조가
+ * 생기지 않게 한다. ref는 effect 내 분기에, state는 외부 노출에 쓰인다.
+ */
+function setDetectedSynced(
+  detectedRef: MutableRefObject<boolean>,
+  setDetectedState: (v: boolean) => void,
+  next: boolean,
+): void {
+  if (detectedRef.current === next) return;
+  detectedRef.current = next;
+  setDetectedState(next);
+}
+
+/** lock 생성 직후 캐시 지연으로 발생하는 false-positive를 막는 그레이스 기간(ms). */
+export const MIS_BOARDING_GRACE_MS = 60_000;
+/** absent 관측이 N회 연속이면 잘못 탑승으로 확정. positionApi 폴링 30s × 3 = 90s. */
+export const MIS_BOARDING_MISS_THRESHOLD = 3;
+
+export interface UseMisBoardingDetectorInputs {
+  lock: BoardingLock | null;
+  /** lock.boardingLine의 위치 데이터. lock이 없거나 호출자가 polling 안 하면 null. */
+  positions: LinePositions | null;
+  /** 테스트용 주입. 미전달 시 Date.now(). */
+  now?: () => number;
+}
+
+export interface UseMisBoardingDetectorResult {
+  /** absent threshold 도달 시 true. lock 해제/교체 시 false로 reset. */
+  detected: boolean;
+}
+
+/**
+ * BoardingLock에 명시된 trainCode가 실시간 위치 API에서 사라졌는지 감지 (#584 PR D3).
+ *
+ * - lock 생성 직후 grace 동안은 absent여도 무시 (positionApi 캐시/주기와 정합).
+ * - absent 관측이 threshold 회 연속이면 detected=true 한 번 발생.
+ * - present가 한 번이라도 들어오면 카운터 reset, detected=false.
+ * - lock의 trainCode 또는 boardedAt이 바뀌면 (=새 lock) 카운터+detected reset.
+ *
+ * detected 상태는 ref + state 이중관리 — ref는 effect 내 분기에 쓰고, state는 외부 노출용.
+ * detected를 effect deps에 두면 setDetected 호출 시 stale closure 경유로 카운터가 의도와 다르게
+ * 흐를 수 있어 ref로 분리한다.
+ */
+export function useMisBoardingDetector({
+  lock,
+  positions,
+  now = Date.now,
+}: UseMisBoardingDetectorInputs): UseMisBoardingDetectorResult {
+  const [detected, setDetectedState] = useState(false);
+  const detectedRef = useRef(false);
+  const consecutiveAbsentRef = useRef(0);
+  const trackedLockKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const updateDetected = (next: boolean): void =>
+      setDetectedSynced(detectedRef, setDetectedState, next);
+    // 새 lock(=trainCode + boardedAt 조합 변화) → 카운터/감지 reset.
+    // 같은 trainCode 재선택 시에도 boardedAt이 갱신되어 grace가 다시 적용된다.
+    const lockKey = lock ? `${lock.trainCode}:${lock.boardedAt}` : null;
+    if (trackedLockKeyRef.current !== lockKey) {
+      trackedLockKeyRef.current = lockKey;
+      consecutiveAbsentRef.current = 0;
+      updateDetected(false);
+    }
+
+    if (!lock || !positions) return;
+
+    const observation = detectMisBoarding(lock, positions);
+    if (observation === 'no-signal') return;
+
+    if (observation === 'present') {
+      consecutiveAbsentRef.current = 0;
+      updateDetected(false);
+      return;
+    }
+
+    // absent. grace 통과 후에만 카운터 증가.
+    if (now() - lock.boardedAt < MIS_BOARDING_GRACE_MS) return;
+
+    consecutiveAbsentRef.current += 1;
+    if (consecutiveAbsentRef.current >= MIS_BOARDING_MISS_THRESHOLD) {
+      updateDetected(true);
+    }
+  }, [lock, positions, now]);
+
+  return { detected };
+}

--- a/src/utils/__tests__/detectMisBoarding.test.ts
+++ b/src/utils/__tests__/detectMisBoarding.test.ts
@@ -1,0 +1,66 @@
+import { detectMisBoarding } from '../detectMisBoarding';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
+
+const lock: BoardingLock = {
+  destinationId: 'd',
+  trainCode: 'T-LOCK',
+  boardingStationId: 's',
+  boardingLine: '2',
+  boardedAt: 1_000_000,
+  expectedDurationMs: 1_800_000,
+};
+
+function train(overrides: Partial<TrainPosition>): TrainPosition {
+  return {
+    statnId: '',
+    statnNm: '',
+    trainNo: 'T-X',
+    trainStatus: 0,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function positions(overrides: Partial<LinePositions>): LinePositions {
+  return { line: '2', trains: [], ...overrides };
+}
+
+describe('detectMisBoarding', () => {
+  it('lock=null → no-signal', () => {
+    expect(detectMisBoarding(null, positions({}))).toBe('no-signal');
+  });
+
+  it('positions=null → no-signal', () => {
+    expect(detectMisBoarding(lock, null)).toBe('no-signal');
+  });
+
+  it('positions.isMock=true → no-signal (실측 아님)', () => {
+    expect(detectMisBoarding(lock, positions({ isMock: true }))).toBe('no-signal');
+  });
+
+  it('positions.line이 lock.boardingLine과 다르면 no-signal', () => {
+    expect(detectMisBoarding(lock, positions({ line: '3' }))).toBe('no-signal');
+  });
+
+  it('positions에 trainNo=lock.trainCode 존재 → present', () => {
+    expect(
+      detectMisBoarding(lock, positions({ trains: [train({ trainNo: 'T-LOCK' })] })),
+    ).toBe('present');
+  });
+
+  it('positions에 trainNo 부재 → absent', () => {
+    expect(
+      detectMisBoarding(lock, positions({ trains: [train({ trainNo: 'T-OTHER' })] })),
+    ).toBe('absent');
+  });
+
+  it('positions에 trains 빈 배열 → absent (관측은 됐지만 lock train 없음)', () => {
+    expect(detectMisBoarding(lock, positions({ trains: [] }))).toBe('absent');
+  });
+});

--- a/src/utils/detectMisBoarding.ts
+++ b/src/utils/detectMisBoarding.ts
@@ -1,0 +1,25 @@
+import type { BoardingLock } from '../types/boardingLock';
+import type { LinePositions } from '../api/positionApi';
+
+/**
+ * BoardingLock의 trainCode가 lock.boardingLine의 위치 데이터에서 관측되는지 검사 (#584 PR D3).
+ *
+ * - lock 또는 positions 없음 → 'no-signal' (탐지 보류 — 호출자가 카운터 미증가)
+ * - positions.line이 lock.boardingLine과 다름 → 'no-signal' (관측 불가)
+ * - positions에 trainNo == lock.trainCode 존재 → 'present'
+ * - positions는 있고 trainNo 부재 → 'absent'
+ *
+ * mock 데이터(isMock=true)는 'no-signal' — 실측이 아니므로 잘못 탑승 판단 근거가 될 수 없다.
+ */
+export type MisBoardingObservation = 'present' | 'absent' | 'no-signal';
+
+export function detectMisBoarding(
+  lock: BoardingLock | null,
+  positions: LinePositions | null,
+): MisBoardingObservation {
+  if (!lock || !positions) return 'no-signal';
+  if (positions.isMock) return 'no-signal';
+  if (positions.line !== lock.boardingLine) return 'no-signal';
+  const found = positions.trains.some((t) => t.trainNo === lock.trainCode);
+  return found ? 'present' : 'absent';
+}


### PR DESCRIPTION
## Summary
- `detectMisBoarding` 순수 함수: `lock.trainCode`가 `lock.boardingLine` 위치 데이터에 있는지 `present | absent | no-signal`로 분류 (mock/다른 노선은 no-signal).
- `useMisBoardingDetector` 훅: grace 60s + absent 3회 연속 → `detected=true`. `lock key = ${trainCode}:${boardedAt}` 조합으로 같은 trainCode 재선택해도 grace 재적용.
- `detected`는 ref + state 이중관리(`setDetectedSynced` 모듈 스코프 helper) — effect deps에서 `detected` 제거해 stale closure 회피.
- `MisBoardingBanner` 컴포넌트: `colors.warn` 경고 배너 + [재선택] = `releaseBoardingLock`.
- `app/(tabs)/index.tsx`: `useTrainPositions(lock.boardingLine)` 별도 구독 → 감지 → `BoardingLockBanner` 위에 조건부 렌더.

## Stacked PR
- base = `feat/#584-pr-d2-fusion-priority` (#600). D2가 dev에 머지되면 base 갱신.

## Test plan
- [x] `npm test` 2049 tests, 130 suites, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-reviewer 2회 (P0 stale closure / P1 grace 경로 / margin / 같은 trainCode reselect 모두 반영, 추가 P1 updateDetected 추출도 반영)
- 케이스:
  - 단위: present/absent/no-signal 4종 분기 + mock + line 불일치
  - 훅: grace 내 absent 무시, grace 후 threshold 누적, present reset, lock null reset, trainCode 변경 reset, boardedAt 변경 grace 재적용, mock positions 무시
  - 컴포넌트: 경고 라벨 + 재선택 버튼 호출

## 비범위
- 토스트(앱 상단 알림) UX는 별도 후속 — 배너로 충분히 발견 가능.
- GPS 격하는 D2(`boarding-lock` 라벨 승격)에서 처리됨.