### PR TITLE
feat(#584): PR E — 환승 처리 (다음 노선 list + walking buffer)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -41,6 +41,8 @@ import { BoardingLockBanner } from '../../src/components/BoardingLockBanner';
 import { MisBoardingBanner } from '../../src/components/MisBoardingBanner';
 import { useMisBoardingDetector } from '../../src/hooks/useMisBoardingDetector';
 import { useTrainPositions } from '../../src/hooks/useTrainPositions';
+import { useTransferTrainList } from '../../src/hooks/useTransferTrainList';
+import { TRANSFER_WALKING_BUFFER_SECONDS } from '../../src/constants/boardingLock';
 import { BoardingTrainList } from '../../src/components/BoardingTrainList';
 
 const logger = createLogger('HomeScreen');
@@ -230,6 +232,18 @@ export default function HomeScreen() {
   const { detected: misBoardingDetected } = useMisBoardingDetector({
     lock: boardingLock,
     positions: lockLinePositions,
+  });
+  // #584 PR E: 활성 lock이 현재 leg의 transfer waypoint에 도달하면 다음 노선 도착 list 노출.
+  const {
+    context: transferContext,
+    arrivals: transferArrivals,
+    createTransferLock,
+  } = useTransferTrainList({
+    lock: boardingLock,
+    route,
+    destinationName: destination?.name ?? null,
+    currentStation: result?.station ?? null,
+    expectedDurationMinutes: staticEtaMinutes,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({
@@ -666,6 +680,16 @@ export default function HomeScreen() {
                 arrivals={directionalArrivals}
                 line={effectiveOrigin.line}
                 onSelect={createLockFromTrain}
+              />
+            )}
+            {/* PR E: 환승 waypoint 도달 시 다음 노선 list. context 비어있으면 노출 안 됨. */}
+            {transferContext && (
+              <BoardingTrainList
+                arrivals={transferArrivals}
+                line={transferContext.nextLine}
+                onSelect={createTransferLock}
+                walkingBufferSeconds={TRANSFER_WALKING_BUFFER_SECONDS}
+                title="환승 열차 선택"
               />
             )}
             {effectiveOrigin && (

--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -8,6 +8,13 @@ interface Props {
   arrivals: ArrivalInfo[];
   line: LineNumber;
   onSelect: (train: ArrivalInfo) => void;
+  /**
+   * 도착 시각이 이 값보다 빠른 열차는 disabled로 렌더 (#584 PR E). 단위: 초.
+   * 환승 list에서 도보 buffer 표현용. 미전달 시 모든 열차 활성.
+   */
+  walkingBufferSeconds?: number;
+  /** 헤더 라벨 커스텀 (환승 list 등). 미전달 시 기본 "탑승할 열차 선택". */
+  title?: string;
 }
 
 /**
@@ -17,8 +24,16 @@ interface Props {
  * 각 row를 탭하면 onSelect 콜백이 발화 → 호출자가 BoardingLock 생성.
  * 빈 list면 placeholder 안내 텍스트.
  */
-export function BoardingTrainList({ arrivals, line, onSelect }: Props) {
+export function BoardingTrainList({
+  arrivals,
+  line,
+  onSelect,
+  walkingBufferSeconds,
+  title = '탑승할 열차 선택',
+}: Props) {
   const { colors } = useTheme();
+  const isUnreachable = (train: ArrivalInfo): boolean =>
+    walkingBufferSeconds != null && train.arrivalSeconds < walkingBufferSeconds;
 
   if (arrivals.length === 0) {
     return (
@@ -32,24 +47,28 @@ export function BoardingTrainList({ arrivals, line, onSelect }: Props) {
     <View style={styles.container} testID="boarding-train-list">
       <View style={styles.header}>
         <LineBadge line={line} />
-        <Text style={[typography.label, { color: colors.muted }]}>탑승할 열차 선택</Text>
+        <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
       </View>
-      {arrivals.map((train) => (
-        <Pressable
-          key={train.trainCode}
-          onPress={() => onSelect(train)}
-          style={[styles.row, { backgroundColor: colors.card }]}
-          testID={`boarding-train-row-${train.trainCode}`}
-        >
-          <View style={styles.rowInfo}>
-            <Text style={[typography.body, { color: colors.ink }]}>{train.destination} 행</Text>
-            <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
-          </View>
-          <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
-            {train.arrivalMinutes}분
-          </Text>
-        </Pressable>
-      ))}
+      {arrivals.map((train) => {
+        const unreachable = isUnreachable(train);
+        return (
+          <Pressable
+            key={train.trainCode}
+            onPress={() => onSelect(train)}
+            disabled={unreachable}
+            style={[styles.row, { backgroundColor: colors.card, opacity: unreachable ? 0.4 : 1 }]}
+            testID={`boarding-train-row-${train.trainCode}`}
+          >
+            <View style={styles.rowInfo}>
+              <Text style={[typography.body, { color: colors.ink }]}>{train.destination} 행</Text>
+              <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
+            </View>
+            <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
+              {train.arrivalMinutes}분
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -55,4 +55,38 @@ describe('BoardingTrainList', () => {
     expect(getByText('탑승할 열차 선택')).toBeTruthy();
   });
 
+  it('title prop으로 헤더 커스텀 (환승 list 등)', () => {
+    const { getByText } = renderWithTheme(
+      <BoardingTrainList arrivals={[makeTrain()]} line="2" onSelect={() => {}} title="환승 열차 선택" />,
+    );
+    expect(getByText('환승 열차 선택')).toBeTruthy();
+  });
+
+  it('walkingBufferSeconds 미만 도착 train은 disabled — onSelect 호출 안 됨', () => {
+    const tooSoon = makeTrain({ trainCode: 'T-EARLY', arrivalSeconds: 60 });
+    const reachable = makeTrain({ trainCode: 'T-OK', arrivalSeconds: 240 });
+    const onSelect = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList
+        arrivals={[tooSoon, reachable]}
+        line="2"
+        onSelect={onSelect}
+        walkingBufferSeconds={180}
+      />,
+    );
+    fireEvent.press(getByTestId('boarding-train-row-T-EARLY'));
+    expect(onSelect).not.toHaveBeenCalled();
+    fireEvent.press(getByTestId('boarding-train-row-T-OK'));
+    expect(onSelect).toHaveBeenCalledWith(reachable);
+  });
+
+  it('walkingBufferSeconds 미전달이면 모든 train 활성', () => {
+    const tooSoon = makeTrain({ trainCode: 'T-EARLY', arrivalSeconds: 60 });
+    const onSelect = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList arrivals={[tooSoon]} line="2" onSelect={onSelect} />,
+    );
+    fireEvent.press(getByTestId('boarding-train-row-T-EARLY'));
+    expect(onSelect).toHaveBeenCalled();
+  });
 });

--- a/src/constants/boardingLock.ts
+++ b/src/constants/boardingLock.ts
@@ -8,3 +8,10 @@
  * fallback 적용 시 30 × 1.5 = 45분 후 자동 release.
  */
 export const FALLBACK_BOARDING_DURATION_MINUTES = 30;
+
+/**
+ * 환승역 도착 list에서 "지금 못 잡는" 열차로 표시(disabled)할 도보 buffer (#584 PR E).
+ * arrival.arrivalSeconds < TRANSFER_WALKING_BUFFER_SECONDS 인 첫 차는 비활성화.
+ * 평균 환승 도보 시간 — 정밀화는 후속.
+ */
+export const TRANSFER_WALKING_BUFFER_SECONDS = 180;

--- a/src/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/hooks/__tests__/useTransferTrainList.test.tsx
@@ -1,0 +1,190 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useTransferTrainList, filterArrivalsByDirection } from '../useTransferTrainList';
+import { useArrivalInfo } from '../useArrivalInfo';
+import { useBoardingLockStore } from '../../store/useBoardingLockStore';
+import { findStationByNameAndLine } from '../../utils/stationRoute';
+import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { TransferRoute } from '../../utils/stationRoute';
+import type { Station } from '../../types/station';
+
+jest.mock('../useArrivalInfo');
+const mockUseArrival = useArrivalInfo as jest.Mock;
+
+const mockCreateLock = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../store/useBoardingLockStore', () => {
+  const actual = jest.requireActual('../../store/useBoardingLockStore');
+  return {
+    ...actual,
+    useBoardingLockStore: ((selector?: (s: { createLock: jest.Mock }) => unknown) =>
+      selector ? selector({ createLock: mockCreateLock }) : { createLock: mockCreateLock }) as jest.Mock,
+  };
+});
+
+const lock: BoardingLock = {
+  destinationId: 'dest-X',
+  trainCode: 'T-OLD',
+  boardingStationId: 'stn-from',
+  boardingLine: '6',
+  boardedAt: 0,
+  expectedDurationMs: 1_000_000,
+};
+const route: TransferRoute = {
+  type: 'transfer',
+  transferName: '공덕',
+  fromLine: '6',
+  toLine: '5',
+  stopsToTransfer: 2,
+  stopsFromTransfer: 3,
+};
+const gondeokOn6 = findStationByNameAndLine('공덕', '6') as Station;
+
+function arrivalRet(arrival: StationArrival | null) {
+  return { arrival, loading: false, isMock: false };
+}
+
+function makeTrain(overrides: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: '여의나루',
+    arrivalMinutes: 5,
+    arrivalSeconds: 300,
+    statusMessage: '',
+    trainCode: 'T-NEW',
+    receivedAtMs: 0,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+describe('useTransferTrainList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+  });
+
+  it('context 미확정(currentStation=null) → context=null + arrivals=[]', () => {
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: null,
+        expectedDurationMinutes: 20,
+      }),
+    );
+    expect(result.current.context).toBeNull();
+    expect(result.current.arrivals).toEqual([]);
+  });
+
+  it('환승역 도달 + arrival up=2 train → arrivals 반환', () => {
+    const trains = [makeTrain({ trainCode: 'T-1' }), makeTrain({ trainCode: 'T-2' })];
+    mockUseArrival.mockReturnValue(arrivalRet({ up: trains, down: [] }));
+
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+        expectedDurationMinutes: 20,
+      }),
+    );
+    expect(result.current.context).not.toBeNull();
+    expect(result.current.context!.nextLine).toBe('5');
+    // direction에 따라 up/down/양방향 합산 — 적어도 2개는 노출
+    expect(result.current.arrivals.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('arrival=null이면 arrivals=[]', () => {
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+        expectedDurationMinutes: 20,
+      }),
+    );
+    expect(result.current.arrivals).toEqual([]);
+  });
+
+  it('createTransferLock 호출 → toLine 환승역 기준 새 lock 생성', () => {
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [makeTrain({ trainCode: 'NEW' })], down: [] }));
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+        expectedDurationMinutes: 20,
+      }),
+    );
+    act(() => result.current.createTransferLock(makeTrain({ trainCode: 'NEW' })));
+    expect(mockCreateLock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationId: 'dest-X',
+        trainCode: 'NEW',
+        boardingLine: '5',
+        boardingStationId: (findStationByNameAndLine('공덕', '5') as Station).id,
+        expectedDurationMs: 20 * 60_000,
+      }),
+    );
+  });
+
+  it('expectedDurationMinutes=null이면 fallback 30분 적용', () => {
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [makeTrain({})], down: [] }));
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+        expectedDurationMinutes: null,
+      }),
+    );
+    act(() => result.current.createTransferLock(makeTrain({ trainCode: 'X' })));
+    expect(mockCreateLock).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedDurationMs: 30 * 60_000 }),
+    );
+  });
+
+  it('context 없을 때 createTransferLock 호출은 no-op', () => {
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: null,
+        expectedDurationMinutes: 20,
+      }),
+    );
+    act(() => result.current.createTransferLock(makeTrain({})));
+    expect(mockCreateLock).not.toHaveBeenCalled();
+  });
+
+});
+
+describe('filterArrivalsByDirection', () => {
+  const up = makeTrain({ trainCode: 'UP' });
+  const down = makeTrain({ trainCode: 'DN' });
+  const arr: StationArrival = { up: [up], down: [down] };
+
+  it('null arrival → 빈 배열', () => {
+    expect(filterArrivalsByDirection(null, 'up')).toEqual([]);
+  });
+
+  it('direction=up → up만', () => {
+    expect(filterArrivalsByDirection(arr, 'up')).toEqual([up]);
+  });
+
+  it('direction=down → down만', () => {
+    expect(filterArrivalsByDirection(arr, 'down')).toEqual([down]);
+  });
+
+  it('direction=null → up+down 합산', () => {
+    expect(filterArrivalsByDirection(arr, null)).toEqual([up, down]);
+  });
+});

--- a/src/hooks/useTransferTrainList.ts
+++ b/src/hooks/useTransferTrainList.ts
@@ -1,0 +1,102 @@
+import { useCallback, useMemo } from 'react';
+import { useArrivalInfo } from './useArrivalInfo';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { findActiveTransferContext } from '../utils/findActiveTransferContext';
+import { FALLBACK_BOARDING_DURATION_MINUTES } from '../constants/boardingLock';
+import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
+import type { BoardingLock } from '../types/boardingLock';
+import type { Station } from '../types/station';
+import type { Route } from '../utils/stationRoute';
+import type { ArrivalProvider } from '../providers/types';
+import type { ActiveTransferContext } from '../utils/findActiveTransferContext';
+
+export interface UseTransferTrainListInputs {
+  lock: BoardingLock | null;
+  route: Route;
+  destinationName: string | null;
+  currentStation: Station | null;
+  /** 환승 후 새 lock의 expectedDurationMs 산출용. null이면 fallback 30분. */
+  expectedDurationMinutes: number | null;
+  arrivalProvider?: ArrivalProvider;
+}
+
+export interface UseTransferTrainListResult {
+  /** 환승 컨텍스트(=새 노선 list를 노출해야 하는 상태). 없으면 list 미노출. */
+  context: ActiveTransferContext | null;
+  /** 다음 노선 + 환승역 기준 도착 list, direction으로 필터된 결과. */
+  arrivals: ArrivalInfo[];
+  /** 사용자가 다음 열차 탭 시 호출 — 새 BoardingLock 생성 (기존 lock 자동 교체). */
+  createTransferLock: (train: ArrivalInfo) => void;
+}
+
+/**
+ * 환승 waypoint 도달 시 다음 노선의 도착 list + 새 lock 생성 진입점을 제공 (#584 PR E).
+ *
+ * - context는 findActiveTransferContext 결과 — 비활성 시 list 렌더 생략.
+ * - useArrivalInfo는 Rules of Hooks 준수를 위해 context 유무와 무관하게 호출. 매개변수가 null이면
+ *   useArrivalInfo 자체가 idle로 동작 — 추가 비용 없음.
+ * - direction이 'up'/'down'이면 해당 방향만, null이면 양방향 합산.
+ */
+export function useTransferTrainList({
+  lock,
+  route,
+  destinationName,
+  currentStation,
+  expectedDurationMinutes,
+  arrivalProvider,
+}: UseTransferTrainListInputs): UseTransferTrainListResult {
+  const context = useMemo(
+    () => findActiveTransferContext(lock, route, destinationName, currentStation),
+    [lock, route, destinationName, currentStation],
+  );
+
+  const transferStationName = context?.transferStationInToLine.name ?? null;
+  const transferLine = context?.nextLine ?? null;
+  const { arrival } = useArrivalInfo(transferStationName, transferLine, arrivalProvider);
+
+  const arrivals = useMemo<ArrivalInfo[]>(
+    () => filterByDirection(arrival, context?.direction ?? null),
+    [arrival, context],
+  );
+
+  const createLock = useBoardingLockStore((s) => s.createLock);
+  const createTransferLock = useCallback(
+    (train: ArrivalInfo) => {
+      if (!context || !lock) return;
+      // TODO(#584-followup): expectedDurationMinutes는 출발역 기준 전체 trip 시간이라 환승 후 lock
+      // 만료 타이머가 과대 추정됨. 잔여 leg(stopsFromTransfer 등) 기준 calculateTransferLegETA 도입 필요.
+      // 현재는 보수적(=과만료) 측으로 안전 — BOARDING_LOCK_EXPIRY_FACTOR(=1.5)로도 충분히 길어 알람은
+      // 정상 발사된 후 만료된다. 정밀화는 후속 PR.
+      const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
+      void createLock({
+        destinationId: lock.destinationId,
+        trainCode: train.trainCode,
+        boardingStationId: context.transferStationInToLine.id,
+        boardingLine: context.nextLine,
+        boardedAt: Date.now(),
+        expectedDurationMs: durationMin * 60_000,
+      });
+    },
+    [context, lock, expectedDurationMinutes, createLock],
+  );
+
+  return { context, arrivals, createTransferLock };
+}
+
+/** 테스트 노출용. 외부 호출자는 useTransferTrainList의 result.arrivals를 사용. */
+export function filterArrivalsByDirection(
+  arrival: StationArrival | null,
+  direction: 'up' | 'down' | null,
+): ArrivalInfo[] {
+  return filterByDirection(arrival, direction);
+}
+
+function filterByDirection(
+  arrival: StationArrival | null,
+  direction: 'up' | 'down' | null,
+): ArrivalInfo[] {
+  if (!arrival) return [];
+  if (direction === 'up') return arrival.up;
+  if (direction === 'down') return arrival.down;
+  return [...arrival.up, ...arrival.down];
+}

--- a/src/utils/__tests__/findActiveTransferContext.test.ts
+++ b/src/utils/__tests__/findActiveTransferContext.test.ts
@@ -1,0 +1,181 @@
+import { findActiveTransferContext } from '../findActiveTransferContext';
+import { findStationByNameAndLine } from '../stationRoute';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
+import type { Station } from '../../types/station';
+
+const lock: BoardingLock = {
+  destinationId: 'd',
+  trainCode: 'T-1',
+  boardingStationId: 's',
+  boardingLine: '7',
+  boardedAt: 0,
+  expectedDurationMs: 1_000_000,
+};
+
+// stations.json 실데이터를 그대로 사용해 환승역 매칭/index 산출까지 검증.
+const gondeokOnLine6 = findStationByNameAndLine('공덕', '6') as Station;
+const gondeokOnLine5 = findStationByNameAndLine('공덕', '5') as Station;
+const yeouinaru = findStationByNameAndLine('여의나루', '5') as Station;
+
+describe('findActiveTransferContext', () => {
+  it('lock=null이면 null', () => {
+    expect(findActiveTransferContext(null, null, '강남', null)).toBeNull();
+  });
+
+  it('route=null이면 null', () => {
+    expect(findActiveTransferContext(lock, null, '강남', gondeokOnLine6)).toBeNull();
+  });
+
+  it('destinationName=null이면 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '6' };
+    expect(findActiveTransferContext(lock, route, null, gondeokOnLine6)).toBeNull();
+  });
+
+  it('currentStation=null이면 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '6' };
+    expect(findActiveTransferContext(lock, route, '강남', null)).toBeNull();
+  });
+
+  it('direct route(환승 없음)는 항상 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '6' };
+    expect(findActiveTransferContext(lock, route, '공덕', gondeokOnLine6)).toBeNull();
+  });
+
+  it('transfer route + 현재역이 환승역이면 toLine 컨텍스트 반환', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '공덕',
+      fromLine: '6',
+      toLine: '5',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    };
+    const ctx = findActiveTransferContext(lock, route, '여의나루', gondeokOnLine6);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.nextLine).toBe('5');
+    expect(ctx!.transferStationInToLine.id).toBe(gondeokOnLine5.id);
+    expect(ctx!.nextWaypointName).toBe('여의나루');
+    // direction은 5호선 index 비교 결과 — 동작 검증만 (down/up/null 중 하나).
+    expect(['up', 'down', null]).toContain(ctx!.direction);
+  });
+
+  it('transfer route + 환승역=목적지이면 alarmType=destination → null', () => {
+    // transferName === destinationName 케이스는 resolveAllTargets가 destination으로 처리.
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '공덕',
+      fromLine: '6',
+      toLine: '5',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 0,
+    };
+    expect(findActiveTransferContext(lock, route, '공덕', gondeokOnLine6)).toBeNull();
+  });
+
+  it('transfer route + 현재역이 환승역이 아니면 null', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '공덕',
+      fromLine: '6',
+      toLine: '5',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    };
+    expect(findActiveTransferContext(lock, route, '여의나루', yeouinaru)).toBeNull();
+  });
+
+  it('환승 후 방향이 up인 케이스 (toLine 인덱스 역전)', () => {
+    // 충무로(4→3 환승) → 종로3가(line 3 → line 1 환승). 3호선에서 충무로 인덱스 > 종로3가 인덱스
+    // → resolveDirectionInLine은 'up' 반환.
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
+        { transferName: '종로3가', fromLine: '3', toLine: '1', stopsToTransfer: 1 },
+      ],
+      stopsAfterLastTransfer: 1,
+    };
+    const chungmuroOn4 = findStationByNameAndLine('충무로', '4') as Station;
+    const ctx = findActiveTransferContext(lock, route, '서울역', chungmuroOn4);
+    // direction이 'up' 또는 'down' — toLine 인덱스 검증. 실데이터 의존이라 둘 다 허용해
+    // resolveDirectionInLine의 두 return 분기 중 하나는 확실히 커버.
+    expect(ctx).not.toBeNull();
+    expect(['up', 'down']).toContain(ctx!.direction);
+  });
+
+  it('multi-transfer route + 첫 환승역 도달 시 두 번째 leg 컨텍스트', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '공덕', fromLine: '6', toLine: '5', stopsToTransfer: 2 },
+        // 두 번째 transfer는 임의 — 첫 번째만 검증 대상
+        { transferName: '여의나루', fromLine: '5', toLine: '5', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 1,
+    };
+    const ctx = findActiveTransferContext(lock, route, '아무목적지', gondeokOnLine6);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.nextLine).toBe('5');
+    expect(ctx!.nextWaypointName).toBe('여의나루');
+  });
+
+  it('currentStation이 어떤 waypoint와도 매칭되지 않으면 null (matchedIdx=-1)', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '공덕',
+      fromLine: '6',
+      toLine: '5',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    };
+    // 현재역은 효창공원앞(6호선) — route 어느 waypoint와도 매칭 안 됨
+    const hyochang = findStationByNameAndLine('효창공원앞', '6') as Station;
+    expect(findActiveTransferContext(lock, route, '여의나루', hyochang)).toBeNull();
+  });
+
+  it('환승 시 direction이 명시적으로 산출됨 (resolveDirectionInLine 성공 경로)', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '공덕',
+      fromLine: '6',
+      toLine: '5',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    };
+    const ctx = findActiveTransferContext(lock, route, '여의나루', gondeokOnLine6);
+    expect(ctx).not.toBeNull();
+    // 5호선 공덕→여의나루는 stations.json index가 다르므로 direction은 non-null
+    expect(ctx!.direction === 'up' || ctx!.direction === 'down').toBe(true);
+  });
+
+  it('lock.boardingLine이 이미 nextLine이면 null (환승 lock 교체 직후 재노출 방지)', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '공덕',
+      fromLine: '6',
+      toLine: '5',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    };
+    // lock이 이미 5호선으로 교체된 상태 (createTransferLock 직후)
+    const transferredLock = { ...lock, boardingLine: '5' as const };
+    expect(
+      findActiveTransferContext(transferredLock, route, '여의나루', gondeokOnLine6),
+    ).toBeNull();
+  });
+
+  it('toLine 측 환승역 station을 못 찾으면 null', () => {
+    // 존재하지 않는 가짜 노선 매칭 — findStationByNameAndLine이 undefined 반환하는 경로 커버
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '존재하지않는역X',
+      fromLine: '6',
+      toLine: '5',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    };
+    const fakeCurrent: Station = { ...gondeokOnLine6, name: '존재하지않는역X' };
+    expect(findActiveTransferContext(lock, route, '여의나루', fakeCurrent)).toBeNull();
+  });
+});

--- a/src/utils/__tests__/findActiveTransferContext.test.ts
+++ b/src/utils/__tests__/findActiveTransferContext.test.ts
@@ -1,5 +1,5 @@
-import { findActiveTransferContext } from '../findActiveTransferContext';
-import { findStationByNameAndLine } from '../stationRoute';
+import { findActiveTransferContext, resolveDirectionInLine } from '../findActiveTransferContext';
+import { findStationByNameAndLine, getStationsOnLine } from '../stationRoute';
 import type { BoardingLock } from '../../types/boardingLock';
 import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 import type { Station } from '../../types/station';
@@ -163,6 +163,21 @@ describe('findActiveTransferContext', () => {
     expect(
       findActiveTransferContext(transferredLock, route, '여의나루', gondeokOnLine6),
     ).toBeNull();
+  });
+
+  describe('resolveDirectionInLine (직접 호출)', () => {
+    // 5호선 stations.json에서 첫 2개 역의 id/이름으로 양 방향 케이스 강제.
+    const line5 = getStationsOnLine('5');
+    const early = line5[0];
+    const late = line5[line5.length - 1];
+
+    it('nextIdx > currIdx → down', () => {
+      expect(resolveDirectionInLine('5', early.id, late.name)).toBe('down');
+    });
+
+    it('nextIdx < currIdx → up', () => {
+      expect(resolveDirectionInLine('5', late.id, early.name)).toBe('up');
+    });
   });
 
   it('toLine 측 환승역 station을 못 찾으면 null', () => {

--- a/src/utils/findActiveTransferContext.ts
+++ b/src/utils/findActiveTransferContext.ts
@@ -1,0 +1,87 @@
+import type { BoardingLock } from '../types/boardingLock';
+import type { LineNumber, Station } from '../types/station';
+import type { Route } from './stationRoute';
+import { findStationByNameAndLine, getStationsOnLine, isSameStationName } from './stationRoute';
+import { resolveAllTargets } from './stationAlarm';
+import type { TripDirection } from './tripDirection';
+
+export interface ActiveTransferContext {
+  /** toLine 기준의 환승역 Station 객체 (새 lock의 boardingStationId/Line 출처). */
+  transferStationInToLine: Station;
+  /** 환승 후 탑승할 노선. */
+  nextLine: LineNumber;
+  /** 환승 직후 다음 waypoint(=destination 또는 다음 transfer)의 이름. */
+  nextWaypointName: string;
+  /** toLine 기준 새 진행방향. 좌표/index 비교 실패 시 null — 양방향 합산 fallback. */
+  direction: TripDirection | null;
+}
+
+/**
+ * BoardingLock이 활성이고 사용자가 현재 leg의 transfer waypoint에 도달했으면 환승 컨텍스트를 반환 (#584 PR E).
+ *
+ * - lock/route/destinationName/currentStation 중 하나라도 없으면 null
+ * - resolveAllTargets로 waypoint 목록 산출 후 currentStation.name과 매칭되는 target 탐색
+ * - 매칭된 target이 transfer가 아니거나 그 다음 target이 없으면 null (도착역이거나 환승 없음)
+ * - 매칭된 target의 다음 target.approachLine을 nextLine으로 사용 — 환승 후 진행할 노선
+ * - direction은 transferStationInToLine.id ↔ nextWaypointName의 line stations index 비교로 산출
+ */
+export function findActiveTransferContext(
+  lock: BoardingLock | null,
+  route: Route,
+  destinationName: string | null,
+  currentStation: Station | null,
+): ActiveTransferContext | null {
+  if (!lock || !route || !destinationName || !currentStation) return null;
+
+  const targets = resolveAllTargets(route, destinationName);
+  const matchedIdx = targets.findIndex((t) => isSameStationName(t.name, currentStation.name));
+  if (matchedIdx === -1) return null;
+
+  const matched = targets[matchedIdx];
+  if (matched.alarmType !== 'transfer') return null;
+
+  const next = targets[matchedIdx + 1];
+  /* istanbul ignore next -- resolveAllTargets는 transfer가 매칭되면 그 다음 target(destination 또는
+     다음 transfer)이 항상 존재한다. 마지막 target이 transfer가 되려면 그 자체가 destination이어야
+     하는데 그 경우 alarmType==='destination'으로 위 가드에서 이미 차단됨. 방어 코드. */
+  if (!next) return null;
+
+  const nextLine = next.approachLine;
+  // lock이 이미 nextLine으로 교체된 상태(=환승 완료)면 context 재노출하지 않음.
+  // 사용자가 새 열차 탭 → createTransferLock → boardingLine=nextLine 갱신되었지만 GPS는 아직
+  // 환승역에 머무는 경우, 가드 없으면 같은 list가 다시 노출되어 lock 중복 생성 가능.
+  if (lock.boardingLine === nextLine) return null;
+  const transferStationInToLine = findStationByNameAndLine(matched.name, nextLine);
+  if (!transferStationInToLine) return null;
+
+  const direction = resolveDirectionInLine(
+    nextLine,
+    transferStationInToLine.id,
+    next.name,
+  );
+
+  return {
+    transferStationInToLine,
+    nextLine,
+    nextWaypointName: next.name,
+    direction,
+  };
+}
+
+/**
+ * 한 노선 내에서 from station id ↔ to station name의 index 비교로 방향 산출.
+ * tripDirection.ts의 resolveTripDirection은 route의 첫 leg만 보므로 환승 후 leg에는 쓸 수 없음 — 별도 유틸.
+ */
+function resolveDirectionInLine(
+  line: LineNumber,
+  fromStationId: string,
+  toStationName: string,
+): TripDirection | null {
+  const stations = getStationsOnLine(line);
+  const currIdx = stations.findIndex((s) => s.id === fromStationId);
+  const nextIdx = stations.findIndex((s) => s.name === toStationName);
+  /* istanbul ignore next -- 호출 직전 findStationByNameAndLine과 next.approachLine 일관성으로
+     실제 데이터에서는 도달 불가. 정합성 깨진 데이터를 위한 방어 코드. */
+  if (currIdx < 0 || nextIdx < 0 || currIdx === nextIdx) return null;
+  return nextIdx > currIdx ? 'down' : 'up';
+}

--- a/src/utils/findActiveTransferContext.ts
+++ b/src/utils/findActiveTransferContext.ts
@@ -71,8 +71,9 @@ export function findActiveTransferContext(
 /**
  * 한 노선 내에서 from station id ↔ to station name의 index 비교로 방향 산출.
  * tripDirection.ts의 resolveTripDirection은 route의 첫 leg만 보므로 환승 후 leg에는 쓸 수 없음 — 별도 유틸.
+ * 테스트 노출용 export — 실데이터 의존이라 정/역방향 양쪽 분기 강제하기 위해 직접 호출.
  */
-function resolveDirectionInLine(
+export function resolveDirectionInLine(
   line: LineNumber,
   fromStationId: string,
   toStationName: string,


### PR DESCRIPTION
## Summary
- `findActiveTransferContext` pure 유틸: 활성 lock의 transfer waypoint 도달 + nextLine 후보 + direction 산출. `lock.boardingLine === nextLine`이면 환승 완료로 보고 null 반환(같은 list 재노출 방지).
- `useTransferTrainList` 훅: context 활성 시 `useArrivalInfo(transferStationInToLine, nextLine)` 구독 + direction 필터. `createTransferLock`은 단일 lock 정책에 의해 기존 lock을 자동 교체.
- `BoardingTrainList`: `walkingBufferSeconds`/`title` props 추가. 미만 도착은 `disabled` + opacity 0.4 — 환승 도보 buffer 표현.
- 상수: `TRANSFER_WALKING_BUFFER_SECONDS = 180` (3분 default).
- `app/(tabs)/index.tsx`: BoardingTrainList를 재사용해 환승 list 렌더.

## Closes
- 환승 시 transfer/imminent + 다음 노선 list + 새 Lock 전환을 포함해 `Closes #584`.

## Stacked PR
- base = `feat/#584-pr-d3-misboarding` (#601). D3 → dev 머지 후 자동 갱신.

## Test plan
- [x] `npm test` 2076 tests, 132 suites, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-reviewer P0 1건(lock 교체 후 context 재노출 방지) + P1 TODO 코멘트로 반영
- 케이스:
  - `findActiveTransferContext`: 13 케이스(direct/transfer/multi-transfer + 환승 완료 후 가드 + 위·down 방향)
  - `useTransferTrainList`: 6 + filterArrivalsByDirection 4
  - `BoardingTrainList`: 6 (walkingBuffer disabled 검증 포함)

## Known followup
- `expectedDurationMs`는 출발역 기준 전체 trip 시간을 그대로 전달 — 환승 후 leg 잔여 시간보다 길지만 보수적이라 안전(BOARDING_LOCK_EXPIRY_FACTOR 1.5와 함께 알람 발사 후 자연 만료). 잔여 leg 기준 정밀화는 후속 PR.