### PR TITLE
feat(#605): fusion 디버그 entry에 boarding-lock 매칭 stamp

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -102,7 +102,11 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
   const acc =
     entry.gpsAccuracyAtPushMeters != null ? `${Math.round(entry.gpsAccuracyAtPushMeters)}m` : '-';
   const cand = entry.candidates
-    .map((c) => `${CANDIDATE_SHORT[c.key] ?? c.key}=${c.stationName}`)
+    .map((c) => {
+      const base = `${CANDIDATE_SHORT[c.key] ?? c.key}=${c.stationName}`;
+      // boarding-lock 매칭 표기 — positionTrain candidate에 lockMatch=true가 찍히면 한눈에 식별.
+      return c.extra?.lockMatch === true ? `${base}[LOCK]` : base;
+    })
     .join(' ');
   const candPart = cand.length > 0 ? cand : '-';
   return `${time} | src=${entry.source} conf=${entry.confidence} | ${station} d=${d} acc=${acc} | ${candPart}`;

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -999,6 +999,51 @@ describe('formatFusionDebugLine', () => {
     expect(line).toContain('gp=용마산');
   });
 
+  it('fusion 엔트리: positionTrain candidate에 lockMatch=true면 [LOCK] 뱃지', () => {
+    const line = formatFusionDebugLine({
+      kind: 'fusion',
+      ts: 0,
+      source: 'boarding-lock',
+      confidence: 'boarding-lock',
+      stationName: '사가정',
+      line: '7',
+      distanceKm: 0.1,
+      gpsAccuracyAtPushMeters: 30,
+      candidates: [
+        {
+          key: 'positionTrain',
+          stationName: '사가정',
+          line: '7',
+          extra: { trainNo: 'T-LOCKED', lockedTrainCode: 'T-LOCKED', lockMatch: true },
+        },
+      ],
+    });
+    expect(line).toContain('pt=사가정[LOCK]');
+  });
+
+  it('fusion 엔트리: positionTrain lockMatch=false면 [LOCK] 뱃지 없음', () => {
+    const line = formatFusionDebugLine({
+      kind: 'fusion',
+      ts: 0,
+      source: 'position-train',
+      confidence: 'position-train',
+      stationName: '사가정',
+      line: '7',
+      distanceKm: 0.1,
+      gpsAccuracyAtPushMeters: 30,
+      candidates: [
+        {
+          key: 'positionTrain',
+          stationName: '사가정',
+          line: '7',
+          extra: { trainNo: 'T-OTHER', lockedTrainCode: 'T-LOCKED', lockMatch: false },
+        },
+      ],
+    });
+    expect(line).toContain('pt=사가정');
+    expect(line).not.toContain('[LOCK]');
+  });
+
   it('fusion 엔트리: 알 수 없는 candidate key는 raw key 그대로 표기', () => {
     const line = formatFusionDebugLine({
       kind: 'fusion',

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -224,6 +224,64 @@ describe('useFusedNearestStation', () => {
       expect(result.current.source).toBe('position-train');
     });
 
+    it('#605: positionTrain candidate.extra에 trainNo + lockedTrainCode + lockMatch 기록', () => {
+      const {
+        clearFusionDebugEntries,
+        getFusionDebugEntries,
+      } = jest.requireActual('../../utils/fusionDebugBuffer') as typeof import('../../utils/fusionDebugBuffer');
+      clearFusionDebugEntries();
+      setupPositionTrain('T-LOCKED');
+      renderHook(() => useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED'));
+      const entries = getFusionDebugEntries();
+      const last = entries[entries.length - 1];
+      expect(last.kind).toBe('fusion');
+      if (last.kind !== 'fusion') throw new Error('expected fusion entry');
+      const pt = last.candidates.find((c) => c.key === 'positionTrain');
+      expect(pt?.extra).toEqual({
+        trainNo: 'T-LOCKED',
+        lockedTrainCode: 'T-LOCKED',
+        lockMatch: true,
+      });
+    });
+
+    it('#605: lockedTrainCode 불일치 시 lockMatch=false 기록', () => {
+      const {
+        clearFusionDebugEntries,
+        getFusionDebugEntries,
+      } = jest.requireActual('../../utils/fusionDebugBuffer') as typeof import('../../utils/fusionDebugBuffer');
+      clearFusionDebugEntries();
+      setupPositionTrain('T-ACTUAL');
+      renderHook(() => useFusedNearestStation(undefined, undefined, undefined, 'T-OTHER'));
+      const entries = getFusionDebugEntries();
+      const last = entries[entries.length - 1];
+      if (last.kind !== 'fusion') throw new Error('expected fusion entry');
+      const pt = last.candidates.find((c) => c.key === 'positionTrain');
+      expect(pt?.extra).toEqual({
+        trainNo: 'T-ACTUAL',
+        lockedTrainCode: 'T-OTHER',
+        lockMatch: false,
+      });
+    });
+
+    it('#605: lockedTrainCode=null이면 extra.lockedTrainCode=null + lockMatch=false', () => {
+      const {
+        clearFusionDebugEntries,
+        getFusionDebugEntries,
+      } = jest.requireActual('../../utils/fusionDebugBuffer') as typeof import('../../utils/fusionDebugBuffer');
+      clearFusionDebugEntries();
+      setupPositionTrain('T-ANY');
+      renderHook(() => useFusedNearestStation(undefined, undefined, undefined, null));
+      const entries = getFusionDebugEntries();
+      const last = entries[entries.length - 1];
+      if (last.kind !== 'fusion') throw new Error('expected fusion entry');
+      const pt = last.candidates.find((c) => c.key === 'positionTrain');
+      expect(pt?.extra).toEqual({
+        trainNo: 'T-ANY',
+        lockedTrainCode: null,
+        lockMatch: false,
+      });
+    });
+
     it('lockedTrainCode 있어도 position-train 신호 없으면 승격 안 됨 (arrival/gps 분기 유지)', () => {
       // arrival만 있는 케이스 — boarding-lock은 position-train 채택 전제
       mockUseNearest.mockReturnValue(gpsBase());

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -306,9 +306,21 @@ export function useFusedNearestStation(
     if (lastDecisionKeyRef.current === decisionKey) return;
     lastDecisionKeyRef.current = decisionKey;
     const candidates: FusionCandidateMini[] = [];
-    if (positionTrainResult) {
+    if (positionTrainResult && trainProgress) {
       const { name, line } = positionTrainResult.station;
-      candidates.push({ key: 'positionTrain', stationName: name, line });
+      // boarding-lock 매칭 근거: 어느 trainNo가 어떤 lock과 비교됐는지 사후 재구성.
+      const { trainNo } = trainProgress;
+      const lockMatch = lockedTrainCode != null && trainNo === lockedTrainCode;
+      candidates.push({
+        key: 'positionTrain',
+        stationName: name,
+        line,
+        extra: {
+          trainNo,
+          lockedTrainCode: lockedTrainCode ?? null,
+          lockMatch,
+        },
+      });
     }
     if (fused) {
       const { name, line } = fused.result.station;
@@ -338,7 +350,7 @@ export function useFusedNearestStation(
       gpsAccuracyAtPushMeters: gps.accuracyMeters,
       candidates,
     });
-  }, [decisionKey, source, confidence, result, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters]);
+  }, [decisionKey, source, confidence, result, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, trainProgress, lockedTrainCode]);
 
   return {
     result,

--- a/src/utils/fusionDebugBuffer.ts
+++ b/src/utils/fusionDebugBuffer.ts
@@ -12,8 +12,9 @@ export interface FusionCandidateMini {
   key: 'positionTrain' | 'fused' | 'route' | 'gps';
   stationName: string;
   line: string;
-  /** 추가 정보 — 출처별 의미가 다를 수 있어 자유형으로 둠. */
-  extra?: Record<string, string | number>;
+  /** 추가 정보 — 출처별 의미가 다를 수 있어 자유형으로 둠.
+   *  null은 "값이 없는 컨텍스트"를 명시 (예: positionTrain의 lockedTrainCode=null = lock 비활성). */
+  extra?: Record<string, string | number | boolean | null>;
 }
 
 export interface FusionDecisionEntry {


### PR DESCRIPTION
## Summary
- positionTrain candidate에 `trainNo` / `lockedTrainCode` / `lockMatch` 기록 (#283 fusion debug buffer 확장)
- DebugModal fusion log 라인에 `[LOCK]` 뱃지 표기 — 한눈에 boarding-lock 매칭 식별
- `FusionCandidateMini.extra` 타입에 `boolean | null` 허용

## Why
#584 PR D2에서 `boarding-lock` 승격 분기가 들어갔지만 디버그 버퍼에 매칭 근거가 stamp되지 않아 회귀/의도 검증이 어려웠다. 결정 트리는 그대로 두고 측정 채널만 보강.

## Test plan
- [x] `npm test` — 2087 passed / 100% coverage
- [x] `npm run type-check` clean
- [x] 신규 케이스: lockedTrainCode 일치 / 불일치 / null 3분기 + `[LOCK]` 뱃지 on/off 2분기

Closes #605