### PR TITLE
feat(#603): 잘못 탑승 감지 토스트 + 재선택 모달 UX

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
 import { useFusedNearestStation } from '../../src/hooks/useFusedNearestStation';
 import { useArrivalInfo } from '../../src/hooks/useArrivalInfo';
+import type { ArrivalInfo } from '../../src/api/arrivalApi';
 import { useArrivalCountdown } from '../../src/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../../src/utils/formatTime';
 import { LINE_NAMES } from '../../src/constants/lineColors';
@@ -39,6 +40,8 @@ import { useBoardingLockScheduler } from '../../src/hooks/useBoardingLockSchedul
 import { useBoardingLockAdvancer } from '../../src/hooks/useBoardingLockAdvancer';
 import { BoardingLockBanner } from '../../src/components/BoardingLockBanner';
 import { MisBoardingBanner } from '../../src/components/MisBoardingBanner';
+import { MisBoardingReselectModal } from '../../src/components/MisBoardingReselectModal';
+import { Toast } from '../../src/components/Toast';
 import { useMisBoardingDetector } from '../../src/hooks/useMisBoardingDetector';
 import { useTrainPositions } from '../../src/hooks/useTrainPositions';
 import { useTransferTrainList } from '../../src/hooks/useTransferTrainList';
@@ -233,6 +236,30 @@ export default function HomeScreen() {
     lock: boardingLock,
     positions: lockLinePositions,
   });
+  // #603: detected false→true 전환 시점에 토스트 + 모달 1회 발사. true가 유지되어도 중복 발사 X.
+  // banner는 그대로 노출되어 사용자가 닫은 뒤에도 잘못 탑승 상태를 알 수 있다.
+  const [misBoardingToastVisible, setMisBoardingToastVisible] = useState(false);
+  const [misBoardingModalVisible, setMisBoardingModalVisible] = useState(false);
+  const prevMisBoardingRef = useRef(false);
+  useEffect(() => {
+    if (misBoardingDetected && !prevMisBoardingRef.current) {
+      setMisBoardingToastVisible(true);
+      setMisBoardingModalVisible(true);
+    }
+    prevMisBoardingRef.current = misBoardingDetected;
+  }, [misBoardingDetected]);
+  const handleMisBoardingReselect = useCallback(
+    (train: ArrivalInfo) => {
+      createLockFromTrain(train);
+      setMisBoardingModalVisible(false);
+      setMisBoardingToastVisible(false);
+    },
+    [createLockFromTrain],
+  );
+  // setState setter는 stable 참조지만 인라인 화살표를 prop으로 넘기면 매 렌더 새 함수가 되어
+  // Toast의 5초 타이머 effect가 재설정된다(역 폴링 30s, 도착 갱신 등으로 리렌더 잦음).
+  const handleMisBoardingToastDismiss = useCallback(() => setMisBoardingToastVisible(false), []);
+  const handleMisBoardingModalClose = useCallback(() => setMisBoardingModalVisible(false), []);
   // #584 PR E: 활성 lock이 현재 leg의 transfer waypoint에 도달하면 다음 노선 도착 list 노출.
   const {
     context: transferContext,
@@ -438,6 +465,22 @@ export default function HomeScreen() {
           <Text style={styles.arrivedBannerText}>{t('home.arrived')}</Text>
         </View>
       )}
+      <Toast
+        visible={misBoardingToastVisible}
+        message="탑승 열차를 찾을 수 없어요. 다시 선택해주세요."
+        onDismiss={handleMisBoardingToastDismiss}
+        accent={colors.warn}
+        testID="mis-boarding-toast"
+      />
+      {/* line이 정해져야 list를 렌더 가능 — line null이면 모달 자체를 띄우지 않음 (빈 sheet 회피). */}
+      <MisBoardingReselectModal
+        visible={misBoardingModalVisible && effectiveOrigin?.line != null}
+        arrivals={directionalArrivals}
+        line={effectiveOrigin?.line ?? null}
+        onSelect={handleMisBoardingReselect}
+        onClose={handleMisBoardingModalClose}
+      />
+
       <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
         {effectiveOrigin ? (
           <>

--- a/src/components/MisBoardingReselectModal.tsx
+++ b/src/components/MisBoardingReselectModal.tsx
@@ -1,0 +1,83 @@
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme, typography, spacing, radius } from '../theme';
+import { BoardingTrainList } from './BoardingTrainList';
+import type { ArrivalInfo } from '../api/arrivalApi';
+import type { LineNumber } from '../types/station';
+
+interface Props {
+  visible: boolean;
+  /** 현재역 도착 list (route 방향 필터 후). 빈 배열이면 placeholder. */
+  arrivals: ArrivalInfo[];
+  /** 현재역 노선. BoardingTrainList 헤더의 LineBadge에 사용. */
+  line: LineNumber | null;
+  /** 사용자가 train 탭 시 — caller가 새 lock 생성 + modal close 처리. */
+  onSelect: (train: ArrivalInfo) => void;
+  /** 모달 자체 닫기 (취소 등). */
+  onClose: () => void;
+}
+
+/**
+ * 잘못 탑승 감지 시 노출되는 재선택 모달 (#603).
+ *
+ * BoardingTrainList를 재사용해 현재역 도착 list를 다시 노출. 사용자가 train 탭 →
+ * onSelect 콜백 → caller가 createLockFromTrain 호출 + 모달 close 처리.
+ * 모달 자체 dismiss는 헤더의 [닫기] 버튼.
+ */
+export function MisBoardingReselectModal({ visible, arrivals, line, onSelect, onClose }: Props) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      testID="mis-boarding-reselect-modal"
+    >
+      <View style={[styles.backdrop, { backgroundColor: colors.overlay }]}>
+        <View
+          style={[
+            styles.sheet,
+            { backgroundColor: colors.bg, paddingTop: spacing.lg, paddingBottom: insets.bottom + spacing.lg },
+          ]}
+        >
+          <View style={[styles.header, { borderBottomColor: colors.hair }]}>
+            <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 재선택</Text>
+            <Pressable onPress={onClose} testID="mis-boarding-reselect-close">
+              <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>닫기</Text>
+            </Pressable>
+          </View>
+          <Text style={[typography.bodySm, styles.help, { color: colors.muted }]}>
+            현재역의 도착 list에서 실제 탑승한 열차를 선택해주세요.
+          </Text>
+          {line && <BoardingTrainList arrivals={arrivals} line={line} onSelect={onSelect} />}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+    paddingHorizontal: spacing.lg,
+    gap: spacing.md,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBottom: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  help: {
+    paddingVertical: spacing.xs,
+  },
+});

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme, typography, spacing, radius } from '../theme';
+
+interface Props {
+  /** true일 때 노출. false면 unmount 또는 즉시 숨김. */
+  visible: boolean;
+  message: string;
+  /** auto-dismiss 시간(ms). 0이면 자동 해제 안 함. 기본 5000. */
+  durationMs?: number;
+  /** auto-dismiss 또는 사용자 탭 시 호출. caller가 visible state를 false로 내려야 함. */
+  onDismiss: () => void;
+  /** accent color. warn/danger/accent 등 의도 색. 기본 accent. */
+  accent?: string;
+  testID?: string;
+}
+
+/**
+ * 화면 상단에 띄우는 floating 알림 (#603).
+ *
+ * controlled component — caller가 visible state를 관리. durationMs 후 자동 onDismiss 호출.
+ * Pressable 전체가 dismiss 버튼이라 사용자가 어디든 탭하면 닫힘.
+ * 외부 토스트 라이브러리 회피 — 의존성 최소 + 테마 토큰 직접 사용.
+ */
+export function Toast({
+  visible,
+  message,
+  durationMs = 5000,
+  onDismiss,
+  accent,
+  testID,
+}: Props) {
+  const { colors } = useTheme();
+  const tone = accent ?? colors.accent;
+
+  useEffect(() => {
+    if (!visible || durationMs <= 0) return;
+    const handle = setTimeout(onDismiss, durationMs);
+    return () => clearTimeout(handle);
+  }, [visible, durationMs, onDismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <Pressable
+      onPress={onDismiss}
+      style={[styles.container, { backgroundColor: colors.card, borderColor: tone }]}
+      testID={testID}
+    >
+      <View style={[styles.accentStripe, { backgroundColor: tone }]} />
+      <Text style={[typography.body, styles.message, { color: colors.ink }]}>{message}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: spacing.xxl,
+    left: spacing.lg,
+    right: spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    overflow: 'hidden',
+    zIndex: 1000,
+  },
+  accentStripe: {
+    width: 4,
+    alignSelf: 'stretch',
+  },
+  message: {
+    flex: 1,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+  },
+});

--- a/src/components/__tests__/MisBoardingReselectModal.test.tsx
+++ b/src/components/__tests__/MisBoardingReselectModal.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent } from '@testing-library/react-native';
+import { MisBoardingReselectModal } from '../MisBoardingReselectModal';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import type { ArrivalInfo } from '../../api/arrivalApi';
+
+function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
+  return {
+    destination: '종착',
+    arrivalMinutes: 3,
+    arrivalSeconds: 180,
+    statusMessage: '',
+    trainCode: 'T-1',
+    receivedAtMs: 0,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+describe('MisBoardingReselectModal', () => {
+  it('visible=true + line 있으면 BoardingTrainList 렌더', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <MisBoardingReselectModal
+        visible
+        arrivals={[makeTrain({ trainCode: 'A' })]}
+        line="2"
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(getByTestId('mis-boarding-reselect-modal')).toBeTruthy();
+    expect(getByText('탑승 열차 재선택')).toBeTruthy();
+    expect(getByTestId('boarding-train-row-A')).toBeTruthy();
+  });
+
+  it('line=null이면 list 렌더 생략', () => {
+    const { queryByTestId } = renderWithTheme(
+      <MisBoardingReselectModal
+        visible
+        arrivals={[makeTrain()]}
+        line={null}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(queryByTestId('boarding-train-list')).toBeNull();
+  });
+
+  it('train 탭 시 onSelect에 train 전달', () => {
+    const train = makeTrain({ trainCode: 'B' });
+    const onSelect = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <MisBoardingReselectModal
+        visible
+        arrivals={[train]}
+        line="2"
+        onSelect={onSelect}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.press(getByTestId('boarding-train-row-B'));
+    expect(onSelect).toHaveBeenCalledWith(train);
+  });
+
+  it('닫기 버튼 탭 시 onClose 호출', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <MisBoardingReselectModal
+        visible
+        arrivals={[makeTrain()]}
+        line="2"
+        onSelect={() => {}}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByTestId('mis-boarding-reselect-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/Toast.test.tsx
+++ b/src/components/__tests__/Toast.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent } from '@testing-library/react-native';
+import { Toast } from '../Toast';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+
+describe('Toast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('visible=false면 렌더 안 됨', () => {
+    const { queryByTestId } = renderWithTheme(
+      <Toast visible={false} message="msg" onDismiss={() => {}} testID="t" />,
+    );
+    expect(queryByTestId('t')).toBeNull();
+  });
+
+  it('visible=true면 메시지 렌더', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <Toast visible message="잘못된 열차" onDismiss={() => {}} testID="t" />,
+    );
+    expect(getByTestId('t')).toBeTruthy();
+    expect(getByText('잘못된 열차')).toBeTruthy();
+  });
+
+  it('탭 시 onDismiss 호출', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <Toast visible message="msg" onDismiss={onDismiss} testID="t" />,
+    );
+    fireEvent.press(getByTestId('t'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('durationMs 후 자동 onDismiss 호출', () => {
+    const onDismiss = jest.fn();
+    renderWithTheme(
+      <Toast visible message="msg" onDismiss={onDismiss} durationMs={3000} testID="t" />,
+    );
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('durationMs=0이면 자동 dismiss 안 함', () => {
+    const onDismiss = jest.fn();
+    renderWithTheme(
+      <Toast visible message="msg" onDismiss={onDismiss} durationMs={0} testID="t" />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(100_000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('visible=false 변화 시 타이머 클린업', () => {
+    const onDismiss = jest.fn();
+    const { rerender } = renderWithTheme(
+      <Toast visible message="msg" onDismiss={onDismiss} durationMs={3000} testID="t" />,
+    );
+    rerender(<Toast visible={false} message="msg" onDismiss={onDismiss} durationMs={3000} testID="t" />);
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('accent 미전달 시 colors.accent 기본 사용', () => {
+    const { getByTestId } = renderWithTheme(
+      <Toast visible message="msg" onDismiss={() => {}} testID="t" />,
+    );
+    expect(getByTestId('t')).toBeTruthy();
+  });
+
+  it('accent prop 적용 (warn 등)', () => {
+    const { getByTestId } = renderWithTheme(
+      <Toast visible message="msg" onDismiss={() => {}} accent="#ff0000" testID="t" />,
+    );
+    expect(getByTestId('t')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- `Toast` 컴포넌트 신규 (controlled, 화면 상단 floating, auto-dismiss 5초 + tap-to-dismiss).
- `MisBoardingReselectModal` 신규 (RN Modal bottom sheet, `BoardingTrainList` 재사용).
- `app/(tabs)/index.tsx`: `misBoardingDetected` false→true 전환 effect로 토스트 + 모달 1회 발사. 재선택 시 `createLockFromTrain` 호출 + 두 UI 닫기.
- dismiss/close 핸들러 `useCallback` 메모이제이션 → 리렌더(역 폴링 30s 등)마다 Toast 타이머가 재설정되는 회귀 방지.
- `effectiveOrigin.line=null`이면 모달 자체 미노출(빈 sheet 회피).

## Closes
- Closes #603

## Test plan
- [x] `npm test` 2094 tests, 135 suites, 커버리지 100%
- [x] `npm run type-check` 통과
- [x] code-reviewer 1회 (P1 2건 — useCallback / line 가드 모두 반영)
- 케이스:
  - Toast: visible 토글, tap-dismiss, durationMs 자동 dismiss, durationMs=0 비활성, 리렌더 시 cleanup, accent 기본/prop
  - Modal: line 있을 때 list 렌더, line null이면 list 생략, train 탭 onSelect, 닫기 onClose

## 비범위
- 백그라운드 Local Notification 발사는 D3 spec("토스트 + 재선택 모달") 외라 미포함 — 필요 시 별도 이슈로.