### PR TITLE
refactor(#604): 환승 BoardingLock expectedDurationMs를 잔여 leg ride time으로 정밀화

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -243,7 +243,6 @@ export default function HomeScreen() {
     route,
     destinationName: destination?.name ?? null,
     currentStation: result?.station ?? null,
-    expectedDurationMinutes: staticEtaMinutes,
   });
   useBackgroundLocation(destination);
   useApnsTripRegistration({

--- a/src/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/hooks/__tests__/useTransferTrainList.test.tsx
@@ -71,7 +71,6 @@ describe('useTransferTrainList', () => {
         route,
         destinationName: '여의나루',
         currentStation: null,
-        expectedDurationMinutes: 20,
       }),
     );
     expect(result.current.context).toBeNull();
@@ -88,7 +87,6 @@ describe('useTransferTrainList', () => {
         route,
         destinationName: '여의나루',
         currentStation: gondeokOn6,
-        expectedDurationMinutes: 20,
       }),
     );
     expect(result.current.context).not.toBeNull();
@@ -105,13 +103,12 @@ describe('useTransferTrainList', () => {
         route,
         destinationName: '여의나루',
         currentStation: gondeokOn6,
-        expectedDurationMinutes: 20,
       }),
     );
     expect(result.current.arrivals).toEqual([]);
   });
 
-  it('createTransferLock 호출 → toLine 환승역 기준 새 lock 생성', () => {
+  it('createTransferLock 호출 → toLine 환승역 + 잔여 leg 기준 ETA로 새 lock 생성 (#604)', () => {
     mockUseArrival.mockReturnValue(arrivalRet({ up: [makeTrain({ trainCode: 'NEW' })], down: [] }));
     const { result } = renderHook(() =>
       useTransferTrainList({
@@ -119,35 +116,18 @@ describe('useTransferTrainList', () => {
         route,
         destinationName: '여의나루',
         currentStation: gondeokOn6,
-        expectedDurationMinutes: 20,
       }),
     );
     act(() => result.current.createTransferLock(makeTrain({ trainCode: 'NEW' })));
+    // calculateRemainingLegETA(route, 0) = stopsFromTransfer(3)*MINUTES_PER_STOP(2) = 6분
     expect(mockCreateLock).toHaveBeenCalledWith(
       expect.objectContaining({
         destinationId: 'dest-X',
         trainCode: 'NEW',
         boardingLine: '5',
         boardingStationId: (findStationByNameAndLine('공덕', '5') as Station).id,
-        expectedDurationMs: 20 * 60_000,
+        expectedDurationMs: 6 * 60_000,
       }),
-    );
-  });
-
-  it('expectedDurationMinutes=null이면 fallback 30분 적용', () => {
-    mockUseArrival.mockReturnValue(arrivalRet({ up: [makeTrain({})], down: [] }));
-    const { result } = renderHook(() =>
-      useTransferTrainList({
-        lock,
-        route,
-        destinationName: '여의나루',
-        currentStation: gondeokOn6,
-        expectedDurationMinutes: null,
-      }),
-    );
-    act(() => result.current.createTransferLock(makeTrain({ trainCode: 'X' })));
-    expect(mockCreateLock).toHaveBeenCalledWith(
-      expect.objectContaining({ expectedDurationMs: 30 * 60_000 }),
     );
   });
 
@@ -158,7 +138,6 @@ describe('useTransferTrainList', () => {
         route,
         destinationName: '여의나루',
         currentStation: null,
-        expectedDurationMinutes: 20,
       }),
     );
     act(() => result.current.createTransferLock(makeTrain({})));

--- a/src/hooks/useTransferTrainList.ts
+++ b/src/hooks/useTransferTrainList.ts
@@ -3,6 +3,7 @@ import { useArrivalInfo } from './useArrivalInfo';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { findActiveTransferContext } from '../utils/findActiveTransferContext';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../constants/boardingLock';
+import { calculateRemainingLegETA } from '../utils/stationRoute';
 import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
 import type { BoardingLock } from '../types/boardingLock';
 import type { Station } from '../types/station';
@@ -15,8 +16,6 @@ export interface UseTransferTrainListInputs {
   route: Route;
   destinationName: string | null;
   currentStation: Station | null;
-  /** 환승 후 새 lock의 expectedDurationMs 산출용. null이면 fallback 30분. */
-  expectedDurationMinutes: number | null;
   arrivalProvider?: ArrivalProvider;
 }
 
@@ -42,7 +41,6 @@ export function useTransferTrainList({
   route,
   destinationName,
   currentStation,
-  expectedDurationMinutes,
   arrivalProvider,
 }: UseTransferTrainListInputs): UseTransferTrainListResult {
   const context = useMemo(
@@ -63,11 +61,14 @@ export function useTransferTrainList({
   const createTransferLock = useCallback(
     (train: ArrivalInfo) => {
       if (!context || !lock) return;
-      // TODO(#584-followup): expectedDurationMinutes는 출발역 기준 전체 trip 시간이라 환승 후 lock
-      // 만료 타이머가 과대 추정됨. 잔여 leg(stopsFromTransfer 등) 기준 calculateTransferLegETA 도입 필요.
-      // 현재는 보수적(=과만료) 측으로 안전 — BOARDING_LOCK_EXPIRY_FACTOR(=1.5)로도 충분히 길어 알람은
-      // 정상 발사된 후 만료된다. 정밀화는 후속 PR.
-      const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
+      // #604: 잔여 leg 기준 ETA로 lock의 expectedDurationMs를 정밀화. 전체 trip 시간으로 잡으면
+      // BOARDING_LOCK_EXPIRY_FACTOR(=1.5)와 곱해져 만료 타이머가 도착 후에도 한참 활성 상태로 남는다.
+      // calculateRemainingLegETA가 null이면(=route가 직접/idx 불일치 등 예기치 못한 상태) fallback.
+      const remainingMin = calculateRemainingLegETA(route, context.completedTransferIdx);
+      /* istanbul ignore next -- context가 있으면 route는 transfer/multi-transfer이고
+         completedTransferIdx는 resolveAllTargets로 산출된 유효 인덱스라 calculateRemainingLegETA는
+         항상 숫자를 반환한다. FALLBACK은 정합성 깨진 상태에 대한 방어 코드. */
+      const durationMin = remainingMin ?? FALLBACK_BOARDING_DURATION_MINUTES;
       void createLock({
         destinationId: lock.destinationId,
         trainCode: train.trainCode,
@@ -77,7 +78,7 @@ export function useTransferTrainList({
         expectedDurationMs: durationMin * 60_000,
       });
     },
-    [context, lock, expectedDurationMinutes, createLock],
+    [context, lock, route, createLock],
   );
 
   return { context, arrivals, createTransferLock };

--- a/src/utils/__tests__/findActiveTransferContext.test.ts
+++ b/src/utils/__tests__/findActiveTransferContext.test.ts
@@ -58,6 +58,8 @@ describe('findActiveTransferContext', () => {
     expect(ctx!.nextWaypointName).toBe('여의나루');
     // direction은 5호선 index 비교 결과 — 동작 검증만 (down/up/null 중 하나).
     expect(['up', 'down', null]).toContain(ctx!.direction);
+    // transfer 라우트: completedTransferIdx는 항상 0
+    expect(ctx!.completedTransferIdx).toBe(0);
   });
 
   it('transfer route + 환승역=목적지이면 alarmType=destination → null', () => {
@@ -118,6 +120,24 @@ describe('findActiveTransferContext', () => {
     expect(ctx).not.toBeNull();
     expect(ctx!.nextLine).toBe('5');
     expect(ctx!.nextWaypointName).toBe('여의나루');
+    // multi-transfer 첫 환승: completedTransferIdx=0
+    expect(ctx!.completedTransferIdx).toBe(0);
+  });
+
+  it('multi-transfer route + 두 번째 환승역 도달 시 completedTransferIdx=1', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
+        { transferName: '종로3가', fromLine: '3', toLine: '1', stopsToTransfer: 1 },
+      ],
+      stopsAfterLastTransfer: 1,
+    };
+    const jongno3 = findStationByNameAndLine('종로3가', '3') as Station;
+    const ctx = findActiveTransferContext(lock, route, '서울역', jongno3);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.completedTransferIdx).toBe(1);
+    expect(ctx!.nextLine).toBe('1');
   });
 
   it('currentStation이 어떤 waypoint와도 매칭되지 않으면 null (matchedIdx=-1)', () => {

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 
@@ -398,6 +398,98 @@ describe('calculateStaticETA', () => {
 
   it('route가 null이면 null을 반환한다', () => {
     expect(calculateStaticETA(null)).toBeNull();
+  });
+});
+
+describe('calculateRemainingLegETA', () => {
+  it('route가 null이면 null', () => {
+    expect(calculateRemainingLegETA(null, 0)).toBeNull();
+  });
+
+  it('DirectRoute는 환승이 없어 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    expect(calculateRemainingLegETA(route, 0)).toBeNull();
+  });
+
+  it('TransferRoute completedTransferIdx=0: 잔여 ride만 (stopsFromTransfer*2, wait 미포함)', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    };
+    // 5*2 = 10 (DEFAULT_WAIT 미포함 — 탭 시점부터의 ride time)
+    expect(calculateRemainingLegETA(route, 0)).toBe(10);
+  });
+
+  it('TransferRoute에서 completedTransferIdx가 범위 밖이면 null', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    };
+    expect(calculateRemainingLegETA(route, 1)).toBeNull();
+    expect(calculateRemainingLegETA(route, -1)).toBeNull();
+  });
+
+  it('MultiTransferRoute 첫 환승 직후(idx=0): 잔여 환승 1회 + 잔여 stops', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    // (5+4)*2 + 1*3 = 18 + 3 = 21
+    expect(calculateRemainingLegETA(route, 0)).toBe(21);
+  });
+
+  it('MultiTransferRoute 마지막 환승 직후: 환승 0회 + stopsAfterLastTransfer만', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    // 4*2 = 8
+    expect(calculateRemainingLegETA(route, 1)).toBe(8);
+  });
+
+  it('MultiTransferRoute 환승 3회 중 첫 환승 직후: 잔여 환승 2회 산식 검증', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+        { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 6,
+    };
+    // (5+2+6)*2 + 2*3 = 26 + 6 = 32
+    expect(calculateRemainingLegETA(route, 0)).toBe(32);
+    // 두 번째 환승 직후: (2+6)*2 + 1*3 = 19
+    expect(calculateRemainingLegETA(route, 1)).toBe(19);
+  });
+
+  it('MultiTransferRoute에서 범위 밖 인덱스는 null', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    expect(calculateRemainingLegETA(route, -1)).toBeNull();
+    expect(calculateRemainingLegETA(route, 2)).toBeNull();
   });
 });
 

--- a/src/utils/findActiveTransferContext.ts
+++ b/src/utils/findActiveTransferContext.ts
@@ -14,6 +14,14 @@ export interface ActiveTransferContext {
   nextWaypointName: string;
   /** toLine 기준 새 진행방향. 좌표/index 비교 실패 시 null — 양방향 합산 fallback. */
   direction: TripDirection | null;
+  /**
+   * 사용자가 방금 도달해서 환승을 끝낸 transfer의 인덱스 (#604).
+   * - transfer 라우트: 항상 0
+   * - multi-transfer 라우트: route.transfers 배열의 인덱스와 1:1 (resolveAllTargets가 같은 순서로 매핑)
+   * createTransferLock이 calculateRemainingLegETA(route, completedTransferIdx)로 잔여 ride time을
+   * 산출하는 데 사용. 잔여 leg는 idx+1번째 transfer부터 시작.
+   */
+  completedTransferIdx: number;
 }
 
 /**
@@ -65,6 +73,7 @@ export function findActiveTransferContext(
     nextLine,
     nextWaypointName: next.name,
     direction,
+    completedTransferIdx: matchedIdx,
   };
 }
 

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -605,6 +605,52 @@ export function calculateStaticETA(route: Route): number | null {
   return DEFAULT_WAIT_MINUTES + getTravelMinutes(route);
 }
 
+/**
+ * 환승 직후 잔여 ride time(분). #584 PR E 후속(#604).
+ *
+ * completedTransferIdx 번째 환승을 막 끝내고 새 열차에 탑승한 시점부터 도착역까지의 잔여 시간.
+ * BoardingLock의 expectedDurationMs는 boardedAt 이후 ride 시간을 의미하므로, 사용자가 list에서
+ * 열차를 탭하는 순간(=새 boardedAt)부터의 시간이 산출 대상. 따라서 첫 열차 대기(DEFAULT_WAIT)는
+ * 포함하지 않는다. 잔여 환승의 대기는 TRANSFER_MINUTES로 포함.
+ *
+ * - direct: 환승 없음 → null
+ * - transfer/multi-transfer: 0..transfers.length-1 범위만 유효
+ *
+ * 산식: 잔여 stops × MINUTES_PER_STOP + 잔여 환승 × TRANSFER_MINUTES
+ */
+export function calculateRemainingLegETA(
+  route: Route,
+  completedTransferIdx: number,
+): number | null {
+  if (!route) return null;
+  if (route.type === 'direct') return null;
+  const legs = getTransferLegs(route);
+  if (completedTransferIdx < 0 || completedTransferIdx >= legs.transferCount) return null;
+  const remainingTransferStops = legs.afterTransferStops
+    .slice(completedTransferIdx + 1)
+    .reduce((s, n) => s + n, 0);
+  const totalRemainingStops = legs.afterTransferStops[completedTransferIdx] + remainingTransferStops;
+  const remainingTransferEvents = legs.transferCount - 1 - completedTransferIdx;
+  return totalRemainingStops * MINUTES_PER_STOP + remainingTransferEvents * TRANSFER_MINUTES;
+}
+
+/**
+ * transfer/multi-transfer 라우트를 통일된 leg 표현으로 정규화. transferCount는 환승 횟수,
+ * afterTransferStops[i]는 i번째 환승을 끝낸 후 다음 waypoint(=다음 환승 또는 도착역)까지의 stops.
+ */
+function getTransferLegs(
+  route: Exclude<NonNullable<Route>, DirectRoute>,
+): { transferCount: number; afterTransferStops: number[] } {
+  if (route.type === 'transfer') {
+    return { transferCount: 1, afterTransferStops: [route.stopsFromTransfer] };
+  }
+  const after = route.transfers
+    .slice(1)
+    .map((t) => t.stopsToTransfer);
+  after.push(route.stopsAfterLastTransfer);
+  return { transferCount: route.transfers.length, afterTransferStops: after };
+}
+
 // ASCII Unit Separator(0x1F) — 사용자 데이터(역명/노선명)에 절대 등장하지 않는
 // 제어문자라 transferName 안에 구분자가 섞여도 signature 충돌이 구조적으로 불가능.
 const SIG_SEP = '\x1f';


### PR DESCRIPTION
## Summary

#584 PR E 후속. `createTransferLock`이 새 lock의 `expectedDurationMs`로 전체 trip 정적 ETA를 그대로 넘기던 문제를 잔여 leg ride time 기준으로 정밀화.

- `calculateRemainingLegETA(route, completedTransferIdx)` 신규 — 환승을 끝낸 지점부터 도착까지 잔여 stops + 잔여 환승 횟수로 산출. `DEFAULT_WAIT_MINUTES`는 미포함 (탭 시점이 boardedAt이라 첫 열차 대기 가산 불필요).
- `getTransferLegs` 헬퍼로 transfer/multi-transfer 통일 처리 — 환승 횟수 분기 없이 배열 순회로 일반화.
- `ActiveTransferContext.completedTransferIdx` 노출 (resolveAllTargets 매핑과 1:1).
- `useTransferTrainList`의 `expectedDurationMinutes` prop 제거, 내부에서 산출. PR E의 TODO 해결.

전체 trip 18분 → ×1.5 = 27분이던 만료 시각이, 잔여 ride 6분 → ×1.5 = 9분으로 정확해짐.

## Test plan

- [x] `npm test` 2090 passed, coverage 100%
- [x] `npm run type-check` pass
- [x] `calculateRemainingLegETA`: direct/transfer/multi-transfer(2회/3회) + 범위 밖 인덱스 케이스
- [x] `findActiveTransferContext`: completedTransferIdx 매핑 (transfer 0, multi-transfer 0/1)
- [x] `useTransferTrainList`: 잔여 ride time(6분)으로 lock 생성 검증
- [x] code-review 에이전트 리뷰 반영 (P2-1 네이밍, P2-2 가드 대칭, P2-3 wait 제거, P3-1 3-transfer 케이스)

Closes #604