### PR TITLE
feat(#609): Live Activity pushType:.token + push token/ended 이벤트 노출

### DIFF
--- a/modules/live-activity/__tests__/pushTokenListeners.test.ts
+++ b/modules/live-activity/__tests__/pushTokenListeners.test.ts
@@ -1,0 +1,75 @@
+import { Platform } from 'react-native';
+
+type Listener = (...args: unknown[]) => void;
+
+const mockAddListener =
+  jest.fn<{ remove: () => void }, [string, Listener]>();
+const mockRequireOptionalNativeModule = jest.fn();
+
+jest.mock('expo-modules-core', () => ({
+  __esModule: true,
+  requireOptionalNativeModule: (...args: unknown[]) =>
+    mockRequireOptionalNativeModule(...args),
+}));
+
+describe('live-activity push token / ended listeners', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockAddListener.mockReset();
+    mockRequireOptionalNativeModule.mockReset();
+  });
+
+  it('iOS: addPushTokenListener wires native addListener("onPushToken", cb)', () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'ios' });
+    const remove = jest.fn();
+    mockAddListener.mockReturnValue({ remove });
+    mockRequireOptionalNativeModule.mockReturnValue({ addListener: mockAddListener });
+
+    const mod = require('../index');
+    const cb = jest.fn();
+    const sub = mod.addPushTokenListener(cb);
+
+    expect(mockAddListener).toHaveBeenCalledWith('onPushToken', cb);
+    sub.remove();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('iOS: addActivityEndedListener wires native addListener("onActivityEnded", cb)', () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'ios' });
+    const remove = jest.fn();
+    mockAddListener.mockReturnValue({ remove });
+    mockRequireOptionalNativeModule.mockReturnValue({ addListener: mockAddListener });
+
+    const mod = require('../index');
+    const cb = jest.fn();
+    const sub = mod.addActivityEndedListener(cb);
+
+    expect(mockAddListener).toHaveBeenCalledWith('onActivityEnded', cb);
+    sub.remove();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-iOS: returns noop subscription without crashing', () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'android' });
+    mockRequireOptionalNativeModule.mockReturnValue(null);
+
+    const mod = require('../index');
+    const tokenSub = mod.addPushTokenListener(() => undefined);
+    const endedSub = mod.addActivityEndedListener(() => undefined);
+
+    expect(mockAddListener).not.toHaveBeenCalled();
+    expect(() => tokenSub.remove()).not.toThrow();
+    expect(() => endedSub.remove()).not.toThrow();
+  });
+
+  it('iOS but native module missing: returns noop subscription', () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'ios' });
+    mockRequireOptionalNativeModule.mockReturnValue(null);
+
+    const mod = require('../index');
+    const sub = mod.addPushTokenListener(() => undefined);
+
+    expect(mockAddListener).not.toHaveBeenCalled();
+    expect(() => sub.remove()).not.toThrow();
+  });
+});

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -1,4 +1,7 @@
-import { requireOptionalNativeModule } from 'expo-modules-core';
+import {
+  type EventSubscription,
+  requireOptionalNativeModule,
+} from 'expo-modules-core';
 import { Platform } from 'react-native';
 
 export interface LiveActivityData {
@@ -67,4 +70,30 @@ export function saveWidgetStation(
 
 export function clearWidgetStation(): Promise<void> {
   return LiveActivityModule?.clearWidgetStation() ?? Promise.resolve();
+}
+
+const NOOP_SUBSCRIPTION: EventSubscription = { remove: () => undefined };
+
+export interface PushTokenEvent {
+  token: string;
+}
+
+/**
+ * iOS 16.2+ Live Activity push token (hex string) 갱신 구독.
+ * 비 iOS / 모듈 미설치 환경에서는 no-op subscription 반환.
+ */
+export function addPushTokenListener(
+  listener: (event: PushTokenEvent) => void,
+): EventSubscription {
+  return LiveActivityModule?.addListener('onPushToken', listener) ?? NOOP_SUBSCRIPTION;
+}
+
+/**
+ * Activity가 `.ended` / `.dismissed`로 전이된 시점 구독.
+ * backend에서 token deregister 트리거로 사용 (이슈 #609 후속 PR B).
+ */
+export function addActivityEndedListener(
+  listener: () => void,
+): EventSubscription {
+  return LiveActivityModule?.addListener('onActivityEnded', listener) ?? NOOP_SUBSCRIPTION;
 }

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -11,6 +11,12 @@ import UIKit
 actor LiveActivityManager {
     static let shared = LiveActivityManager()
     private var currentActivity: Activity<SubwayActivityAttributes>?
+    private var pushTokenTask: Task<Void, Never>?
+    private var stateTask: Task<Void, Never>?
+
+    /// LiveActivityModule이 주입하는 이벤트 emitter. 메인 액터/스레드 안전성은 호출자가 보장한다.
+    var onPushTokenHex: ((String) -> Void)?
+    var onActivityEnded: (() -> Void)?
 
     private init() {}
 
@@ -18,10 +24,19 @@ actor LiveActivityManager {
         return ActivityAuthorizationInfo().areActivitiesEnabled
     }
 
+    func setEventHandlers(
+        onPushTokenHex: @escaping (String) -> Void,
+        onActivityEnded: @escaping () -> Void
+    ) {
+        self.onPushTokenHex = onPushTokenHex
+        self.onActivityEnded = onActivityEnded
+    }
+
     /// 현재 추적 중인 Activity + 이전 세션에서 남은 고아 Activity 일괄 종료.
     /// ActivityKit의 `.activities` 목록 반영 지연으로 1회 enumerate 후에도 잔여가 남는 경우가
     /// 있어 잔여가 없거나 안전 상한에 도달할 때까지 반복한다.
     private func endAllActivities() async {
+        cancelObservers()
         currentActivity = nil
         var attempts = 0
         while !Activity<SubwayActivityAttributes>.activities.isEmpty && attempts < 3 {
@@ -37,8 +52,54 @@ actor LiveActivityManager {
     /// `.stale`도 표시 중일 수 있으므로 채택 후 update로 freshen 한다.
     private func adoptExistingActivityIfNeeded() {
         guard currentActivity == nil else { return }
-        currentActivity = Activity<SubwayActivityAttributes>.activities
+        guard let adopted = Activity<SubwayActivityAttributes>.activities
             .first(where: { $0.activityState == .active || $0.activityState == .stale })
+        else { return }
+        currentActivity = adopted
+        startObservers(for: adopted)
+    }
+
+    private func cancelObservers() {
+        pushTokenTask?.cancel()
+        pushTokenTask = nil
+        stateTask?.cancel()
+        stateTask = nil
+    }
+
+    /// `pushType: .token`으로 시작된 Activity의 token / state 변화를 구독해 JS로 emit.
+    /// 기존 `pushType: nil` 인스턴스를 adopt한 경우 tokenUpdates가 즉시 끝나므로 noop.
+    private func startObservers(for activity: Activity<SubwayActivityAttributes>) {
+        cancelObservers()
+        pushTokenTask = Task { [weak self] in
+            for await tokenData in activity.pushTokenUpdates {
+                if Task.isCancelled { return }
+                let hex = tokenData.map { String(format: "%02x", $0) }.joined()
+                await self?.emitPushToken(hex)
+            }
+        }
+        stateTask = Task { [weak self] in
+            for await state in activity.activityStateUpdates {
+                if Task.isCancelled { return }
+                if state == .ended || state == .dismissed {
+                    await self?.emitActivityEnded()
+                    return
+                }
+            }
+        }
+    }
+
+    private func emitPushToken(_ hex: String) {
+        onPushTokenHex?(hex)
+        #if DEBUG
+        print("[LiveActivity] push token: \(hex)")
+        #endif
+    }
+
+    private func emitActivityEnded() {
+        onActivityEnded?()
+        #if DEBUG
+        print("[LiveActivity] ended")
+        #endif
     }
 
     func start(data: [String: Any]) async throws {
@@ -63,11 +124,13 @@ actor LiveActivityManager {
         let state = try decodeState(from: data)
         let attributes = SubwayActivityAttributes()
         let content = ActivityContent(state: state, staleDate: nil)
-        currentActivity = try Activity.request(
+        let activity = try Activity.request(
             attributes: attributes,
             content: content,
-            pushType: nil
+            pushType: .token
         )
+        currentActivity = activity
+        startObservers(for: activity)
         #if DEBUG
         print("[LiveActivity] started, destination=\(state.destinationName ?? "nil")")
         #endif
@@ -107,6 +170,14 @@ actor LiveActivityManager {
 
     func end() async {
         guard UIDevice.current.userInterfaceIdiom != .pad else { return }
+        // 명시적 종료 경로: backend가 token deregister 트리거를 받을 수 있도록
+        // observer cancel 이전에 직접 emit. JS / backend는 idempotent 처리 전제.
+        // (start() 내부 cleanup 경로는 다음 토큰이 backend를 upsert하므로 emit 불필요)
+        let hadActivity = currentActivity != nil
+            || !Activity<SubwayActivityAttributes>.activities.isEmpty
+        if hadActivity {
+            emitActivityEnded()
+        }
         await endAllActivities()
     }
 

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -11,6 +11,23 @@ public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
         Name("LiveActivity")
 
+        Events("onPushToken", "onActivityEnded")
+
+        OnCreate {
+            if #available(iOS 16.2, *) {
+                Task { [weak self] in
+                    await LiveActivityManager.shared.setEventHandlers(
+                        onPushTokenHex: { [weak self] hex in
+                            self?.sendEvent("onPushToken", ["token": hex])
+                        },
+                        onActivityEnded: { [weak self] in
+                            self?.sendEvent("onActivityEnded", [:])
+                        }
+                    )
+                }
+            }
+        }
+
         AsyncFunction("startLiveActivity") { (data: [String: Any]) in
             if #available(iOS 16.2, *) {
                 try await LiveActivityManager.shared.start(data: data)


### PR DESCRIPTION
## 개요

`modules/live-activity` native가 `pushType: .token`으로 Activity를 시작하고, 발급된 push token / activity state 변화를 JS로 emit. #586 의 PR A.

## 변경

- `LiveActivityManager`
  - `Activity.request(..., pushType: .token)` (iOS 16.2+ 가드 유지)
  - `pushTokenUpdates` / `activityStateUpdates` 구독 Task spawn → manager 콜백 hook
  - `endAllActivities()`에서 observer Task cancel (leak 방지)
  - 명시적 `end()` 경로: observer cancel 이전에 직접 `onActivityEnded` emit → backend deregister 트리거 손실 방지 (review P1 반영)
- `LiveActivityModule`
  - `Events("onPushToken", "onActivityEnded")` 선언
  - `OnCreate`에서 manager에 `sendEvent` 콜백 주입
- `modules/live-activity/index.ts`
  - `addPushTokenListener(cb)`, `addActivityEndedListener(cb)` export
  - non-iOS / 모듈 미설치 시 noop `EventSubscription` 반환
- 테스트: `__tests__/pushTokenListeners.test.ts` (iOS happy × 2, non-iOS noop, iOS-but-missing)

## 제약 / 후속

- 기존 `pushType: nil`로 살아남은 Activity를 adopt한 경우 tokenUpdates는 즉시 종료 → token 미발급 (이슈 본문의 점진 전환 전제)
- backend가 unknown token에 대한 deregister를 graceful하게 처리하도록 PR B에서 명시
- backend 등록 / 해지 연동은 PR B 범위

## 검증

- [x] `npm run type-check` 통과
- [x] `npm test` 2103 / 2103 통과, 커버리지 100% 유지
- [x] `code-review` 에이전트 리뷰 P1 1건 반영 완료
- [ ] 실기기: BoardingLock 생성 → Xcode 콘솔 `[LiveActivity] push token: <hex>` 확인

Closes #609