### PR TITLE
feat(#611): backend Live Activity token 저장 + APNs LA push 빌더

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -4,6 +4,7 @@ import {
   buildApnsJwt,
   resetApnsJwtCache,
   sendAlertPush,
+  sendLiveActivityUpdate,
   sendReschedulePush,
   sendSilentPush,
   type ApnsConfig,
@@ -269,5 +270,89 @@ describe('sendReschedulePush (#585)', () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(result).toEqual({ ok: false, status: 400, reason: 'BadDeviceToken' });
+  });
+});
+
+describe('sendLiveActivityUpdate (#586 C)', () => {
+  beforeEach(() => resetApnsJwtCache());
+
+  it('posts with LA headers + aps event/content-state (update default priority 10)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const result = await sendLiveActivityUpdate({
+      activityToken: 'activity-token-hex',
+      contentState: { nextStation: '강남', etaSeconds: 90 },
+      event: 'update',
+      timestamp: 1_700_000_000,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(true);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${TEST_HOST}/3/device/activity-token-hex`);
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-topic']).toBe('com.example.app.push-type.liveactivity');
+    expect(headers['apns-push-type']).toBe('liveactivity');
+    expect(headers['apns-priority']).toBe('10');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.event).toBe('update');
+    expect(body.aps.timestamp).toBe(1_700_000_000);
+    expect(body.aps['content-state']).toEqual({ nextStation: '강남', etaSeconds: 90 });
+    expect(body.aps['stale-date']).toBeUndefined();
+    expect(body.aps['dismissal-date']).toBeUndefined();
+  });
+
+  it('includes stale-date and dismissal-date for end event with priority 5', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendLiveActivityUpdate({
+      activityToken: 'tok',
+      contentState: {},
+      event: 'end',
+      timestamp: 100,
+      staleDate: 200,
+      dismissalDate: 300,
+      priority: 5,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-priority']).toBe('5');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.event).toBe('end');
+    expect(body.aps['stale-date']).toBe(200);
+    expect(body.aps['dismissal-date']).toBe(300);
+  });
+
+  it('defaults timestamp to now/1000 when omitted', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendLiveActivityUpdate({
+      activityToken: 'tok',
+      contentState: {},
+      event: 'update',
+      config: makeConfig(),
+      host: TEST_HOST,
+      now: 1_700_000_123_456,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.timestamp).toBe(1_700_000_123);
+  });
+
+  it('returns failure with reason on 410 (token invalid)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 410 }),
+    );
+    const result = await sendLiveActivityUpdate({
+      activityToken: 't',
+      contentState: {},
+      event: 'update',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: false, status: 410, reason: 'BadDeviceToken' });
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { app, validatePushAck, validateTrip } from '../index';
+import { app, validateLiveActivityRegister, validatePushAck, validateTrip } from '../index';
 import { pendingKey } from '../pendingPushes';
 import type { AnalyticsEngineWriter, Env } from '../types';
 import { InMemoryKV } from './inMemoryKv';
@@ -505,5 +505,143 @@ describe('POST /push/ack (#566 P2a)', () => {
     const res = await post('/push/ack', { pushId: 'p1', token: 'tok', outcome: 'fired' }, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, deleted: false, reason: 'not-found' });
+  });
+});
+
+describe('validateLiveActivityRegister (#586 C)', () => {
+  it('accepts valid payload', () => {
+    expect(
+      validateLiveActivityRegister({ tripToken: 'tt', activityPushToken: 'at' }),
+    ).toEqual({ tripToken: 'tt', activityPushToken: 'at' });
+  });
+
+  it('rejects non-object', () => {
+    expect(validateLiveActivityRegister(null)).toBeNull();
+    expect(validateLiveActivityRegister('x')).toBeNull();
+  });
+
+  it('rejects missing/empty tripToken', () => {
+    expect(validateLiveActivityRegister({ activityPushToken: 'at' })).toBeNull();
+    expect(
+      validateLiveActivityRegister({ tripToken: '', activityPushToken: 'at' }),
+    ).toBeNull();
+  });
+
+  it('rejects missing/empty activityPushToken', () => {
+    expect(validateLiveActivityRegister({ tripToken: 'tt' })).toBeNull();
+    expect(
+      validateLiveActivityRegister({ tripToken: 'tt', activityPushToken: '' }),
+    ).toBeNull();
+  });
+});
+
+describe('Live Activity endpoints (#586 C)', () => {
+  const CREATED = 1_700_000_000_000;
+  function makeKvEnv(): Env {
+    return makeEnv({ TRIPS: new InMemoryKV() as unknown as Env['TRIPS'] });
+  }
+  function tripBody(): Record<string, unknown> {
+    return { ...base(), token: 'tok-611', createdAt: CREATED };
+  }
+  async function del(path: string, env: Env): Promise<Response> {
+    return app.fetch(new Request(`http://example.com${path}`, { method: 'DELETE' }), env);
+  }
+
+  describe('POST /live-activity/register', () => {
+    it('returns 400 on invalid JSON', async () => {
+      const env = makeKvEnv();
+      const res = await post('/live-activity/register', 'not-json{', env);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_json' });
+    });
+
+    it('returns 400 on invalid payload', async () => {
+      const env = makeKvEnv();
+      const res = await post('/live-activity/register', { tripToken: '' }, env);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_payload' });
+    });
+
+    it('returns 404 when trip does not exist', async () => {
+      const env = makeKvEnv();
+      const res = await post(
+        '/live-activity/register',
+        { tripToken: 'nope', activityPushToken: 'at' },
+        env,
+      );
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'trip_not_found' });
+    });
+
+    it('persists activityPushToken and sets activityState=live', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+      const res = await post(
+        '/live-activity/register',
+        { tripToken: 'tok-611', activityPushToken: 'la-token' },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-611')) as string);
+      expect(stored.activityPushToken).toBe('la-token');
+      expect(stored.activityState).toBe('live');
+    });
+  });
+
+  describe('DELETE /live-activity/:tripToken', () => {
+    it('returns 200 deleted=false when trip does not exist (idempotent)', async () => {
+      const env = makeKvEnv();
+      const res = await del('/live-activity/nope', env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, deleted: false });
+    });
+
+    it('clears activityPushToken and sets activityState=ended', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+      await post(
+        '/live-activity/register',
+        { tripToken: 'tok-611', activityPushToken: 'la-token' },
+        env,
+      );
+      const res = await del('/live-activity/tok-611', env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, deleted: true });
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-611')) as string);
+      expect(stored.activityPushToken).toBeUndefined();
+      expect(stored.activityState).toBe('ended');
+    });
+  });
+
+  describe('POST /trips merge preserves LA fields (same session)', () => {
+    it('preserves activityPushToken and activityState across re-register', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+      await post(
+        '/live-activity/register',
+        { tripToken: 'tok-611', activityPushToken: 'la-token' },
+        env,
+      );
+      // device re-POSTs trip (without LA fields) — must not erase them
+      await post('/trips', tripBody(), env);
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-611')) as string);
+      expect(stored.activityPushToken).toBe('la-token');
+      expect(stored.activityState).toBe('live');
+    });
+
+    it('does not carry LA fields across new session (different createdAt)', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+      await post(
+        '/live-activity/register',
+        { tripToken: 'tok-611', activityPushToken: 'la-token' },
+        env,
+      );
+      await post('/trips', { ...tripBody(), createdAt: CREATED + 10_000 }, env);
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-611')) as string);
+      expect(stored.activityPushToken).toBeUndefined();
+      expect(stored.activityState).toBeUndefined();
+    });
   });
 });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -222,6 +222,77 @@ export async function sendReschedulePush(
   return parseApnsError(response);
 }
 
+/**
+ * Live Activity update/end push (#586 C). ActivityKit Live Activity의 content-state를
+ * 갱신하거나 종료한다. 일반 silent/alert push와 헤더가 다르다:
+ *   - apns-topic: ${bundleId}.push-type.liveactivity
+ *   - apns-push-type: liveactivity
+ *   - apns-priority: 10 (기본) — 호출자가 5로 낮춰 비중요 update를 발사할 수 있음
+ *
+ * payload:
+ *   { aps: { timestamp, event: 'update'|'end', 'content-state': {...},
+ *            'stale-date'?, 'dismissal-date'? } }
+ *
+ * deviceToken 자리에는 `Trip.activityPushToken`을 넣는다. 410 응답은 caller가 trip의
+ * activityPushToken을 clear하는 신호 (실제 clear는 PR D에서 발사 path와 함께 구현).
+ */
+export interface LiveActivityContentState {
+  [key: string]: unknown;
+}
+
+export interface SendLiveActivityUpdateOptions {
+  activityToken: string;
+  contentState: LiveActivityContentState;
+  event: 'update' | 'end';
+  /** epoch seconds — APNs가 dedup/순서 보장에 사용. 누락 시 now. */
+  timestamp?: number;
+  /** epoch seconds — 이 시각 이후 content-state는 stale 표시. */
+  staleDate?: number;
+  /** epoch seconds — end 이벤트와 함께 보내면 Live Activity가 이 시각에 자동 dismiss. */
+  dismissalDate?: number;
+  /** APNs priority. 기본 10 (즉시 전송). 5로 보내면 throttle 대상이 됨. */
+  priority?: 5 | 10;
+  config: ApnsConfig;
+  host: string;
+  fetchImpl?: typeof fetch;
+  now?: number;
+}
+
+export async function sendLiveActivityUpdate(
+  options: SendLiveActivityUpdateOptions,
+): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.activityToken}`;
+  const nowSec = Math.floor((options.now ?? Date.now()) / 1000);
+
+  const aps: Record<string, unknown> = {
+    timestamp: options.timestamp ?? nowSec,
+    event: options.event,
+    'content-state': options.contentState,
+  };
+  if (options.staleDate !== undefined) aps['stale-date'] = options.staleDate;
+  if (options.dismissalDate !== undefined) aps['dismissal-date'] = options.dismissalDate;
+
+  const body = JSON.stringify({ aps });
+  const priority = options.priority ?? 10;
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${jwt}`,
+      'apns-topic': `${options.config.bundleId}.push-type.liveactivity`,
+      'apns-push-type': 'liveactivity',
+      'apns-priority': String(priority),
+      'content-type': 'application/json',
+    },
+    body,
+  });
+
+  if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
 async function parseApnsError(response: Response): Promise<SendPushResult> {
   let reason: string | undefined;
   try {

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -59,6 +59,10 @@ app.post('/trips', async (c) => {
           existing.boardingLock?.trainCode === incoming.boardingLock.trainCode
             ? existing.lastTrackedArrivalEpoch
             : undefined,
+        // #586 C: Live Activity token/state는 별도 endpoint(`/live-activity/register`)로 관리.
+        // 디바이스가 trip을 re-POST해도 register/deregister로 채워둔 값을 유지한다.
+        activityPushToken: existing.activityPushToken,
+        activityState: existing.activityState,
       }
     : incoming;
 
@@ -140,6 +144,76 @@ export function validatePushAck(input: unknown): PushAckPayload | null {
   const out: PushAckPayload = { pushId: obj.pushId, token: obj.token, outcome: obj.outcome };
   if (typeof obj.reason === 'string') out.reason = obj.reason;
   return out;
+}
+
+/**
+ * Live Activity push token 등록 (#586 C).
+ * 디바이스가 ActivityKit로 Live Activity를 시작하고 update token을 발급받으면 호출.
+ *
+ * Body: { tripToken, activityPushToken }
+ * Responses:
+ *   200 { ok: true } — 등록 성공
+ *   400 { error: 'invalid_json' | 'invalid_payload' }
+ *   404 { error: 'trip_not_found' } — 디바이스가 trip 등록 없이 호출
+ */
+app.post('/live-activity/register', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+  const payload = validateLiveActivityRegister(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const existing = await getTrip(c.env.TRIPS, payload.tripToken);
+  if (!existing) return c.json({ error: 'trip_not_found' }, 404);
+
+  const updated: Trip = {
+    ...existing,
+    activityPushToken: payload.activityPushToken,
+    activityState: 'live',
+  };
+  await putTrip(c.env.TRIPS, updated);
+  return c.json({ ok: true });
+});
+
+/**
+ * Live Activity 종료 — push token clear (#586 C).
+ * 디바이스가 Live Activity를 end하거나 사용자가 dismiss하면 호출.
+ * activityPushToken은 비우고 activityState='ended'를 남겨 D PR에서 dismissal push 재발사 dedup에 사용.
+ * 없는 trip은 idempotent — 200 deleted:false.
+ */
+app.delete('/live-activity/:tripToken', async (c) => {
+  const tripToken = c.req.param('tripToken');
+  if (!tripToken) return c.json({ error: 'missing_token' }, 400);
+  const existing = await getTrip(c.env.TRIPS, tripToken);
+  if (!existing) return c.json({ ok: true, deleted: false });
+
+  const updated: Trip = {
+    ...existing,
+    activityPushToken: undefined,
+    activityState: 'ended',
+  };
+  await putTrip(c.env.TRIPS, updated);
+  return c.json({ ok: true, deleted: true });
+});
+
+interface LiveActivityRegisterPayload {
+  tripToken: string;
+  activityPushToken: string;
+}
+
+export function validateLiveActivityRegister(
+  input: unknown,
+): LiveActivityRegisterPayload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.tripToken !== 'string' || obj.tripToken.length === 0) return null;
+  if (typeof obj.activityPushToken !== 'string' || obj.activityPushToken.length === 0) {
+    return null;
+  }
+  return { tripToken: obj.tripToken, activityPushToken: obj.activityPushToken };
 }
 
 app.delete('/trips/:token', async (c) => {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -82,6 +82,18 @@ export interface Trip {
    * 새 관측이 이 값과 의미있게 어긋날 때만 push를 발사해 노이즈를 줄인다.
    */
   lastTrackedArrivalEpoch?: number;
+  /**
+   * Live Activity push token (#586 C). ActivityKit가 발급하는 update token (hex).
+   * `POST /live-activity/register`로 등록되며, APNs LA push 발사 시 device token 자리에 사용한다.
+   * APNs 410(BadDeviceToken) 응답 시 발사 path에서 clear된다.
+   */
+  activityPushToken?: string;
+  /**
+   * Live Activity 수명 상태 (#586 C).
+   *   - 'live'  — register 시점. 정상적으로 update push를 보낼 수 있음.
+   *   - 'ended' — deregister 시점. dismissal payload 재발사 idempotency용 dedup 키.
+   */
+  activityState?: 'live' | 'ended';
 }
 
 /** Device가 확정한 탑승 열차 정보 (#584). */


### PR DESCRIPTION
## Summary
- `Trip.activityPushToken` / `activityState` (`'live'|'ended'`) 추가
- `sendLiveActivityUpdate` APNs 빌더 — `apns-push-type: liveactivity`, topic `${bundleId}.push-type.liveactivity`, event/stale-date/dismissal-date payload, priority 5|10 옵션
- `POST /live-activity/register` (없는 trip → 404) / `DELETE /live-activity/:tripToken` (idempotent, `activityState='ended'` 보존)
- `POST /trips` 동일 세션 merge에서 LA 필드 보존 (디바이스가 trip을 re-POST해도 token 안 날아감)
- 실제 LA push **발사 트리거는 PR D(#612)** 에서. 이 PR은 저장/등록 + 빌더만.

## Test plan
- [x] worker vitest run — 259/259 그린
- [x] `npm run type-check` (backend/alarm-worker) 통과
- [x] 신규 분기 커버: default priority/timestamp, stale/dismissal omitted, 410 reason path, validator falsy 4종, same-session vs new-session merge

Closes #611