### PR TITLE
feat(#610): Live Activity push token register/deregister 채널

### DIFF
--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -2,6 +2,8 @@ import {
   registerActiveTrip,
   clearActiveTrip,
   sendPushAck,
+  registerLiveActivityToken,
+  clearLiveActivityToken,
   __resetAlarmBackendDedup,
 } from '../alarmBackend';
 import type { RegisterTripPayload } from '../alarmBackend';
@@ -284,6 +286,80 @@ describe('alarmBackend', () => {
       await sendPushAck(ACK);
       const [url] = (global.fetch as jest.Mock).mock.calls[0];
       expect(url).toBe('https://api.test.dev/push/ack');
+    });
+  });
+
+  describe('registerLiveActivityToken (#586 B)', () => {
+    it('URL 미설정 시 skipped=true 반환', async () => {
+      const result = await registerLiveActivityToken('trip-1', 'la-tok');
+      expect(result).toEqual({ ok: false, skipped: true });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('정상 응답 시 POST /live-activity/register body 직렬화', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      const result = await registerLiveActivityToken('trip-1', 'la-tok');
+      expect(result).toEqual({ ok: true, status: 200 });
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://api.test.dev/live-activity/register');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body)).toEqual({
+        tripToken: 'trip-1',
+        activityPushToken: 'la-tok',
+      });
+    });
+
+    it('non-2xx 응답 시 ok=false + status', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 } as Response);
+      const result = await registerLiveActivityToken('trip-1', 'la-tok');
+      expect(result).toEqual({ ok: false, status: 404 });
+    });
+
+    it('fetch throw 시 ok=false', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+      const result = await registerLiveActivityToken('trip-1', 'la-tok');
+      expect(result).toEqual({ ok: false });
+    });
+  });
+
+  describe('clearLiveActivityToken (#586 B)', () => {
+    it('URL 미설정 시 skipped=true 반환', async () => {
+      const result = await clearLiveActivityToken('trip-1');
+      expect(result).toEqual({ ok: false, skipped: true });
+    });
+
+    it('빈 tripToken은 ok=false (no fetch)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      const result = await clearLiveActivityToken('');
+      expect(result).toEqual({ ok: false });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('정상 응답 시 DELETE /live-activity/:tripToken (encoded)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      const result = await clearLiveActivityToken('trip/with space');
+      expect(result).toEqual({ ok: true, status: 200 });
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://api.test.dev/live-activity/trip%2Fwith%20space');
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('non-2xx 응답 시 ok=false + status', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 } as Response);
+      const result = await clearLiveActivityToken('trip-1');
+      expect(result).toEqual({ ok: false, status: 500 });
+    });
+
+    it('fetch throw 시 ok=false', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+      const result = await clearLiveActivityToken('trip-1');
+      expect(result).toEqual({ ok: false });
     });
   });
 });

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -231,3 +231,63 @@ export async function clearActiveTrip(token: string): Promise<AlarmBackendResult
     return { ok: false };
   }
 }
+
+/**
+ * Live Activity push token 등록 (#586 B/C).
+ * native가 emit한 push token hex를 backend의 trip 레코드에 보관한다.
+ * URL 미설정/네트워크 실패는 throw 없이 `{ok:false}` — LA 자체는 정상 동작한다.
+ */
+export async function registerLiveActivityToken(
+  tripToken: string,
+  activityPushToken: string,
+): Promise<AlarmBackendResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip LA register');
+    return { ok: false, skipped: true };
+  }
+  try {
+    const res = await fetchWithTimeout(`${base}/live-activity/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tripToken, activityPushToken }),
+    });
+    if (!res.ok) {
+      log.warn(`LA register failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('LA register error', e);
+    return { ok: false };
+  }
+}
+
+/**
+ * Live Activity push token 해제 (#586 B/C).
+ * trip이 끝났거나 사용자가 LA를 dismiss했을 때 호출.
+ */
+export async function clearLiveActivityToken(
+  tripToken: string,
+): Promise<AlarmBackendResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip LA clear');
+    return { ok: false, skipped: true };
+  }
+  if (!tripToken) return { ok: false };
+  try {
+    const res = await fetchWithTimeout(
+      `${base}/live-activity/${encodeURIComponent(tripToken)}`,
+      { method: 'DELETE' },
+    );
+    if (!res.ok) {
+      log.warn(`LA clear failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('LA clear error', e);
+    return { ok: false };
+  }
+}

--- a/src/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/utils/__tests__/liveActivityPushChannel.test.ts
@@ -1,0 +1,137 @@
+const mockStartLiveActivity = jest.fn();
+const mockEndLiveActivity = jest.fn();
+const mockAddPushTokenListener = jest.fn();
+
+jest.mock('../../../modules/live-activity', () => ({
+  startLiveActivity: (...args: unknown[]) => mockStartLiveActivity(...args),
+  endLiveActivity: () => mockEndLiveActivity(),
+  addPushTokenListener: (...args: unknown[]) =>
+    mockAddPushTokenListener(...args),
+}));
+
+const mockRegisterLiveActivityToken = jest.fn();
+const mockClearLiveActivityToken = jest.fn();
+
+jest.mock('../../api/alarmBackend', () => ({
+  registerLiveActivityToken: (...args: unknown[]) =>
+    mockRegisterLiveActivityToken(...args),
+  clearLiveActivityToken: (...args: unknown[]) =>
+    mockClearLiveActivityToken(...args),
+}));
+
+import {
+  endLiveActivityWithDeregister,
+  startLiveActivityWithRegistration,
+} from '../liveActivityPushChannel';
+
+type TokenListener = (e: { token: string }) => void;
+
+interface ListenerHandle {
+  emit: (token: string) => void;
+  remove: jest.Mock;
+}
+
+function setupListener(): ListenerHandle {
+  const handle: ListenerHandle = {
+    emit: () => undefined,
+    remove: jest.fn(),
+  };
+  mockAddPushTokenListener.mockImplementation((cb: TokenListener) => {
+    handle.emit = (token: string) => cb({ token });
+    return { remove: handle.remove };
+  });
+  return handle;
+}
+
+const SAMPLE_DATA = {
+  stationName: '강남',
+  lineName: '2호선',
+  lineColorHex: '#00A84D',
+  distanceM: 0,
+};
+
+describe('liveActivityPushChannel', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockStartLiveActivity.mockReset();
+    mockEndLiveActivity.mockReset();
+    mockAddPushTokenListener.mockReset();
+    mockRegisterLiveActivityToken.mockReset();
+    mockClearLiveActivityToken.mockReset();
+    mockStartLiveActivity.mockResolvedValue(undefined);
+    mockEndLiveActivity.mockResolvedValue(undefined);
+    mockRegisterLiveActivityToken.mockResolvedValue({ ok: true });
+    mockClearLiveActivityToken.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('startLiveActivityWithRegistration', () => {
+    it('start 호출 후 token emit 시 backend register', async () => {
+      const handle = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(SAMPLE_DATA);
+      handle.emit('aabbcc');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-1', 'aabbcc');
+      expect(handle.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it('5s timeout 안에 token이 안 오면 subscription 정리 + register 미호출', async () => {
+      const handle = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      jest.advanceTimersByTime(5000);
+      expect(handle.remove).toHaveBeenCalledTimes(1);
+      expect(mockRegisterLiveActivityToken).not.toHaveBeenCalled();
+    });
+
+    it('token 도착 후 timer는 clearTimeout으로 cancel — 추가 register 없음', async () => {
+      const handle = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      jest.advanceTimersByTime(5000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('register fetch가 reject해도 throw하지 않음 (silent log)', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken.mockRejectedValue(new Error('net'));
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      // promise rejection이 unhandled 되지 않도록 microtask 비움
+      await Promise.resolve();
+    });
+
+    it('startLiveActivity가 throw하면 subscription/timer 정리 후 re-throw', async () => {
+      const handle = setupListener();
+      mockStartLiveActivity.mockRejectedValue(new Error('LA disabled'));
+      await expect(
+        startLiveActivityWithRegistration('trip-1', SAMPLE_DATA),
+      ).rejects.toThrow('LA disabled');
+      expect(handle.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('endLiveActivityWithDeregister', () => {
+    it('end 호출 + backend DELETE', async () => {
+      await endLiveActivityWithDeregister('trip-1');
+      expect(mockEndLiveActivity).toHaveBeenCalled();
+      expect(mockClearLiveActivityToken).toHaveBeenCalledWith('trip-1');
+    });
+
+    it('end가 throw해도 backend deregister는 시도', async () => {
+      mockEndLiveActivity.mockRejectedValue(new Error('end failed'));
+      await expect(endLiveActivityWithDeregister('trip-1')).rejects.toThrow(
+        'end failed',
+      );
+      expect(mockClearLiveActivityToken).toHaveBeenCalledWith('trip-1');
+    });
+
+    it('clear fetch가 reject해도 throw하지 않음 (silent log)', async () => {
+      mockClearLiveActivityToken.mockRejectedValue(new Error('net'));
+      await endLiveActivityWithDeregister('trip-1');
+      expect(mockEndLiveActivity).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/liveActivityPushChannel.ts
+++ b/src/utils/liveActivityPushChannel.ts
@@ -1,0 +1,80 @@
+/**
+ * Live Activity push channel (#586 B).
+ *
+ * native가 발급한 push token을 backend에 등록/해제하는 얇은 wrapper.
+ * - `startLiveActivityWithRegistration`: Activity 시작 + 1회성 token 구독 → backend POST
+ * - `endLiveActivityWithDeregister`: Activity 종료 + backend DELETE
+ *
+ * 정책
+ * - token emit이 비동기다. 5초 timeout 안에 안 오면 subscription 정리 후 silent skip.
+ *   (LA 자체는 정상 동작한다 — backend가 못 push할 뿐.)
+ * - 네트워크 실패는 silent log. 재시도하지 않는다 (다음 update 사이클이 자동 보정).
+ */
+
+import {
+  addPushTokenListener,
+  endLiveActivity,
+  startLiveActivity,
+  type LiveActivityData,
+  type PushTokenEvent,
+} from '../../modules/live-activity';
+import {
+  clearLiveActivityToken,
+  registerLiveActivityToken,
+} from '../api/alarmBackend';
+import { createLogger } from './logger';
+
+const log = createLogger('liveActivityPushChannel');
+
+/** token이 안 오면 subscription을 정리할 안전 timeout. */
+const PUSH_TOKEN_TIMEOUT_MS = 5000;
+
+/**
+ * Activity 시작과 동시에 token emit을 1회 기다려 backend에 register.
+ * Activity 시작 자체가 실패하면 throw — 호출 측의 기존 fallback(예: 일반 알림) 흐름을 유지.
+ */
+export async function startLiveActivityWithRegistration(
+  tripToken: string,
+  data: LiveActivityData,
+): Promise<void> {
+  let subscription!: { remove: () => void };
+  let timer!: ReturnType<typeof setTimeout>;
+  const cleanup = (): void => {
+    subscription.remove();
+    clearTimeout(timer);
+  };
+  subscription = addPushTokenListener((event: PushTokenEvent) => {
+    cleanup();
+    void registerLiveActivityToken(tripToken, event.token).catch((e) => {
+      log.warn('LA register threw', e);
+    });
+  });
+  timer = setTimeout(() => {
+    cleanup();
+    log.info('push token timeout — backend register skipped');
+  }, PUSH_TOKEN_TIMEOUT_MS);
+
+  try {
+    await startLiveActivity(data);
+  } catch (e) {
+    // start가 실패하면 token은 발급될 일이 없다 — 정리 후 re-throw.
+    cleanup();
+    throw e;
+  }
+}
+
+/**
+ * Activity 종료 + backend deregister.
+ * 종료 자체가 실패해도 backend deregister는 시도 — 양쪽 상태를 가능한 한 동기화.
+ */
+export async function endLiveActivityWithDeregister(
+  tripToken: string,
+): Promise<void> {
+  try {
+    await endLiveActivity();
+  } finally {
+    await clearLiveActivityToken(tripToken).catch((e) => {
+      log.warn('LA deregister threw', e);
+    });
+  }
+}


### PR DESCRIPTION
## 개요

native가 발급한 LA push token을 backend에 등록/해제하는 JS 채널. #586 의 PR B.

⚠️ Stacked PR: base는 `dev`가 아니라 `feat/#609-live-activity-push-token` (#615). #615 머지 후 base가 자동으로 dev로 변경됨.

## 변경

- `src/api/alarmBackend.ts`
  - `registerLiveActivityToken(tripToken, activityPushToken)` — `POST /live-activity/register`
  - `clearLiveActivityToken(tripToken)` — `DELETE /live-activity/:tripToken` (URL-encoded, 빈 토큰 사전 가드)
  - 기존 `registerActiveTrip`/`clearActiveTrip`의 graceful skip + fetchWithTimeout 패턴 재사용
- `src/utils/liveActivityPushChannel.ts` 신규
  - `startLiveActivityWithRegistration(tripToken, data)` — listener 사전 등록 후 startLiveActivity 호출. 5s 안에 token emit 시 register, 안 오면 정리 (silent skip)
  - `endLiveActivityWithDeregister(tripToken)` — end + clear (end 실패해도 clear 시도)

## 스코프 노트

이슈의 "stationNotification start/end 경로를 wrapper로 교체" / "boardingLockScheduler 연동"은 tripToken을 콜사이트까지 플러밍해야 해서 별도 follow-up. 본 PR은 채널 유틸 + backend client + 테스트로 한정.

## 검증

- [x] `npm run type-check` 통과
- [x] `npm test` 2120/2120 통과, 커버리지 100% 유지
- [x] code-review 에이전트 통과 (P1 0건)

Closes #610