### PR TITLE
feat(#612): backend per-hop tick LA push 발사 + gating + dismissal

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -535,6 +535,32 @@ describe('validateLiveActivityRegister (#586 C)', () => {
   });
 });
 
+describe('DELETE /trips/:token — LA dismissal (#586 D)', () => {
+  const CREATED = 1_700_000_000_000;
+  function makeKvEnv(): Env {
+    return makeEnv({ TRIPS: new InMemoryKV() as unknown as Env['TRIPS'] });
+  }
+  async function del(path: string, env: Env): Promise<Response> {
+    return app.fetch(new Request(`http://example.com${path}`, { method: 'DELETE' }), env);
+  }
+
+  it('returns 200 deleted=false when trip missing (no LA fire)', async () => {
+    const env = makeKvEnv();
+    const res = await del('/trips/nope', env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: false });
+  });
+
+  it('deletes the trip from KV when no LA token attached', async () => {
+    const env = makeKvEnv();
+    await post('/trips', { ...base(), token: 'tok-d', createdAt: CREATED }, env);
+    const res = await del('/trips/tok-d', env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: true });
+    expect(await env.TRIPS.get('trip:tok-d')).toBeNull();
+  });
+});
+
 describe('Live Activity endpoints (#586 C)', () => {
   const CREATED = 1_700_000_000_000;
   function makeKvEnv(): Env {

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -1,0 +1,310 @@
+import { generateKeyPair, exportPKCS8 } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import {
+  LA_STALE_DURATION_SEC,
+  buildLiveActivityContentState,
+  cleanupTripWithLa,
+  fireLiveActivityDismissal,
+  fireLiveActivityUpdate,
+  type LiveActivityDeps,
+  type LiveActivityStats,
+} from '../liveActivity';
+import type { ApnsEnv, Env, Trip, Waypoint } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+let apnsConfig: ApnsConfig;
+
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair('ES256');
+  const pem = await exportPKCS8(privateKey);
+  apnsConfig = {
+    keyId: 'K',
+    teamId: 'T',
+    privateKeyPem: pem,
+    bundleId: 'com.example.app',
+  };
+});
+
+beforeEach(() => resetApnsJwtCache());
+
+const NOW = 1_700_000_000_000;
+const APNS_HOSTS: Record<ApnsEnv, string> = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+};
+
+function makeStats(): LiveActivityStats {
+  return { laPushSent: 0, laPushFailed: 0, laTokenCleared: 0 };
+}
+
+function makeDeps(fetchImpl: typeof fetch): LiveActivityDeps {
+  return { apnsConfig, apnsHosts: APNS_HOSTS, fetchImpl };
+}
+
+function makeTrip(overrides: Partial<Trip> = {}): Trip {
+  return {
+    token: 'devtoken',
+    route: { type: 'direct', line: '2', stops: 3 },
+    destination: 'dst',
+    waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+    expiresAt: NOW + 3_600_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 60_000,
+    activityPushToken: 'la-token',
+    activityState: 'live',
+    apnsEnv: 'sandbox',
+    ...overrides,
+  };
+}
+
+const WAYPOINT: Waypoint = { stationName: '강남', line: '2', kind: 'destination' };
+
+describe('buildLiveActivityContentState', () => {
+  it('includes numeric/enum fields only (no text)', () => {
+    const cs = buildLiveActivityContentState(WAYPOINT, 90, 'early', 3, NOW);
+    expect(cs).toEqual({
+      etaSeconds: 90,
+      phase: 'early',
+      kind: 'destination',
+      stopsRemaining: 3,
+      arrivalAtSec: Math.floor(NOW / 1000) + 90,
+    });
+  });
+});
+
+describe('fireLiveActivityUpdate', () => {
+  it('no-ops when activityPushToken is missing', async () => {
+    const fetchImpl = vi.fn();
+    const stats = makeStats();
+    const trip = makeTrip({ activityPushToken: undefined });
+    const r = await fireLiveActivityUpdate(
+      trip,
+      { etaSeconds: 1 },
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(r.dirty).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(stats.laPushSent).toBe(0);
+  });
+
+  it('no-ops when activityState is not live (ended)', async () => {
+    const fetchImpl = vi.fn();
+    const stats = makeStats();
+    const trip = makeTrip({ activityState: 'ended' });
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(r.dirty).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('posts to LA endpoint with staleDate = now/1000 + 90 and increments laPushSent on success', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = makeStats();
+    const trip = makeTrip();
+    await fireLiveActivityUpdate(
+      trip,
+      { etaSeconds: 30 },
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`https://${APNS_HOSTS.sandbox}/3/device/la-token`);
+    const body = JSON.parse(init.body as string);
+    expect(body.aps.event).toBe('update');
+    expect(body.aps['stale-date']).toBe(Math.floor(NOW / 1000) + LA_STALE_DURATION_SEC);
+    expect(stats.laPushSent).toBe(1);
+    expect(stats.laPushFailed).toBe(0);
+  });
+
+  it('uses production host when apnsEnv=production', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const trip = makeTrip({ apnsEnv: 'production' });
+    await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+    );
+    const [url] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`https://${APNS_HOSTS.production}/3/device/la-token`);
+  });
+
+  it('clears token + sets ended on 410 (dirty=true)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 410 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip();
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(r.dirty).toBe(true);
+    expect(trip.activityPushToken).toBeUndefined();
+    expect(trip.activityState).toBe('ended');
+    expect(stats.laPushFailed).toBe(1);
+    expect(stats.laTokenCleared).toBe(1);
+  });
+
+  it('does not clear on non-410 failure (dirty=false)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'InternalServerError' }), { status: 500 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip();
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(r.dirty).toBe(false);
+    expect(trip.activityPushToken).toBe('la-token');
+    expect(stats.laPushFailed).toBe(1);
+    expect(stats.laTokenCleared).toBe(0);
+  });
+});
+
+describe('fireLiveActivityDismissal', () => {
+  it('no-ops when no token', async () => {
+    const fetchImpl = vi.fn();
+    const trip = makeTrip({ activityPushToken: undefined });
+    await fireLiveActivityDismissal(
+      trip,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when state is already ended', async () => {
+    const fetchImpl = vi.fn();
+    const trip = makeTrip({ activityState: 'ended' });
+    await fireLiveActivityDismissal(
+      trip,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('sends end event with dismissalDate=now/1000 and transitions trip to ended on success', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = makeStats();
+    const trip = makeTrip();
+    await fireLiveActivityDismissal(
+      trip,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.aps.event).toBe('end');
+    expect(body.aps['dismissal-date']).toBe(Math.floor(NOW / 1000));
+    expect(trip.activityPushToken).toBeUndefined();
+    expect(trip.activityState).toBe('ended');
+    expect(stats.laPushSent).toBe(1);
+  });
+
+  it('still transitions to ended even when push fails (best-effort)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 410 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip();
+    await fireLiveActivityDismissal(
+      trip,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(trip.activityPushToken).toBeUndefined();
+    expect(trip.activityState).toBe('ended');
+    expect(stats.laPushFailed).toBe(1);
+    expect(stats.laTokenCleared).toBe(1);
+  });
+
+  it('increments laPushFailed but not laTokenCleared on non-410 failure', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'ServerUnavailable' }), { status: 503 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip();
+    await fireLiveActivityDismissal(
+      trip,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(stats.laPushFailed).toBe(1);
+    expect(stats.laTokenCleared).toBe(0);
+  });
+});
+
+describe('cleanupTripWithLa', () => {
+  it('fires dismissal then deletes trip from KV', async () => {
+    const kv = new InMemoryKV();
+    await kv.put('trip:devtoken', JSON.stringify(makeTrip()));
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = makeStats();
+    await cleanupTripWithLa(
+      makeTrip(),
+      env,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(stats.laPushSent).toBe(1);
+    expect(await kv.get('trip:devtoken')).toBeNull();
+  });
+
+  it('still deletes trip when no LA token (no push fired)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({ activityPushToken: undefined });
+    await kv.put('trip:devtoken', JSON.stringify(trip));
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    const fetchImpl = vi.fn();
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(await kv.get('trip:devtoken')).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1022,3 +1022,233 @@ describe('RESCHEDULE_THRESHOLD_MS (#585)', () => {
     expect(RESCHEDULE_THRESHOLD_MS).toBe(15_000);
   });
 });
+
+describe('runScheduled — Live Activity push integration (#586 D)', () => {
+  function tripWithLa(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      activityPushToken: 'la-token',
+      activityState: 'live',
+      apnsEnv: 'sandbox',
+      ...overrides,
+    });
+  }
+
+  function makeArrival(stationName: string, eta: number, arvlCd: number | null = null): ArrivalEntry {
+    return {
+      destination: stationName,
+      arrivalSeconds: eta,
+      trainCode: 'T',
+      isUp: true,
+      subwayNm: '지하철2호선',
+      arvlCd,
+    };
+  }
+
+  // APNs LA push는 host topic으로 식별: ${bundleId}.push-type.liveactivity
+  function isLaCall(_url: string, init: RequestInit | undefined): boolean {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    return headers['apns-push-type'] === 'liveactivity';
+  }
+
+  it('fires LA update when ETA changes significantly and trip has LA token', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      tripWithLa({ lastEtaSeconds: 200, lastFiredPhase: 'early' }),
+    );
+    // ETA 200 → 100 (Δ100 ≥ 60s). 100s는 여전히 early phase (≤240s) — phase 비전이.
+    // LA gate: etaChanged || phaseFires → true. silent push도 함께 발사되지만 imminent가 아니라 trip 유지.
+    const seoul = makeSeoul([makeArrival('강남', 100)]);
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.laPushSent).toBeGreaterThanOrEqual(1);
+    const laCalls = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) =>
+      isLaCall(c[0], c[1]),
+    );
+    expect(laCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not fire LA when trip has no activity token', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({ lastEtaSeconds: 200, lastFiredPhase: 'early' }),
+    );
+    const seoul = makeSeoul([makeArrival('강남', 100)]);
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.laPushSent).toBe(0);
+    const laCalls = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) =>
+      isLaCall(c[0], c[1]),
+    );
+    expect(laCalls.length).toBe(0);
+  });
+
+  it('skips LA when waypoint is intermediate', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      tripWithLa({
+        waypoints: [
+          { stationName: '중곡', line: '2', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        lastEtaSeconds: 200,
+      }),
+    );
+    const seoul = makeSeoul([makeArrival('중곡', 60)]);
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.laPushSent).toBe(0);
+  });
+
+  it('fires LA dismissal on destination imminent and clears trip', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, tripWithLa());
+    const seoul = makeSeoul([makeArrival('강남', 20, 1)]); // ARRIVED
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushed).toBeGreaterThanOrEqual(1);
+    // dismissal call: event='end'
+    const laCalls = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) =>
+      isLaCall(c[0], c[1]),
+    );
+    expect(laCalls.length).toBeGreaterThanOrEqual(1);
+    const lastCall = laCalls[laCalls.length - 1];
+    const lastBody = JSON.parse(lastCall[1].body as string);
+    expect(lastBody.aps.event).toBe('end');
+    expect(await kv.get('trip:tok')).toBeNull();
+  });
+
+  it('fires LA dismissal on trip expiry', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(
+      'trip:tok',
+      JSON.stringify(
+        tripWithLa({ expiresAt: NOW + 5_000, alarmAtEpochMs: NOW - 1 }),
+      ),
+    );
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW + 10_000, // past expiry
+    });
+    expect(stats.laPushSent).toBe(1);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.event).toBe('end');
+    expect(await kv.get('trip:tok')).toBeNull();
+  });
+
+  it('410 on LA update clears activityPushToken and persists to KV', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      tripWithLa({ lastEtaSeconds: 200, lastFiredPhase: 'early' }),
+    );
+    // ETA 100s (early 유지) — trip 삭제되지 않으므로 KV에 LA token clear 결과를 검증할 수 있다.
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (isLaCall(url, init)) {
+        return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 410 });
+      }
+      return new Response('', { status: 200 });
+    });
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([makeArrival('강남', 100)]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.laTokenCleared).toBe(1);
+    const stored = JSON.parse((await kv.get('trip:tok')) as string) as Trip;
+    expect(stored.activityPushToken).toBeUndefined();
+    expect(stored.activityState).toBe('ended');
+  });
+});
+
+describe('runScheduled — boardingLock LA integration (#586 D)', () => {
+  function lockedTripWithLa(): Trip {
+    return makeTrip({
+      activityPushToken: 'la-token',
+      activityState: 'live',
+      apnsEnv: 'sandbox',
+      waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+      boardingLock: {
+        trainCode: 'T',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW,
+        segmentStations: ['역삼', '강남'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+    });
+  }
+
+  it('fires LA dismissal when destination arrived under boardingLock', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, lockedTripWithLa());
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: '0',
+                recptnDt: '',
+                updnLine: '상행',
+                trainLineNm: '강남',
+                btrainNo: 'T',
+                subwayNm: '지하철2호선',
+                arvlCd: 1, // ARRIVED
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.laPushSent).toBe(1);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.event).toBe('end');
+    expect(await kv.get('trip:tok')).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/apnsHost.ts
+++ b/backend/alarm-worker/src/apnsHost.ts
@@ -1,0 +1,19 @@
+/**
+ * APNs host 선택 정책 (#482) — scheduled.ts와 liveActivity.ts가 공유하는 SSOT.
+ *
+ * - 누락된 apnsEnv는 sandbox로 fallback. 구버전 클라이언트(필드 없음)가 production host로
+ *   잘못 보내져 BadDeviceToken을 받는 회귀를 막기 위함. App Store/TestFlight 빌드는
+ *   반드시 명시적으로 'production'을 보내야 한다.
+ * - `flipApnsEnv`는 self-heal에서 1차 host와 반대 host로 retry할 때 사용. undefined는
+ *   sandbox로 시작했으므로 production으로 뒤집는다.
+ */
+
+import type { ApnsEnv } from './types';
+
+export function pickApnsHost(apnsEnv: ApnsEnv | undefined, hosts: Record<ApnsEnv, string>): string {
+  return hosts[apnsEnv ?? 'sandbox'];
+}
+
+export function flipApnsEnv(env: ApnsEnv | undefined): ApnsEnv {
+  return (env ?? 'sandbox') === 'sandbox' ? 'production' : 'sandbox';
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -13,6 +13,11 @@
 
 import { Hono } from 'hono';
 import { runFallbackPushes } from './fallback';
+import {
+  cleanupTripWithLa,
+  type LiveActivityDeps,
+  type LiveActivityStats,
+} from './liveActivity';
 import { ackPending } from './pendingPushes';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
@@ -21,8 +26,29 @@ import {
   validateTelemetryUpload,
   writeTelemetryDataPoints,
 } from './telemetry';
-import { deleteTrip, getTrip, putTrip } from './trips';
+import { getTrip, putTrip } from './trips';
 import type { BoardingLockMeta, Env, Trip } from './types';
+
+/**
+ * HTTP DELETE 같은 단일 trip 정리 진입점에서 LA dismissal 발사하기 위한 deps.
+ * scheduled.ts와 동일 ApnsConfig/hosts를 env에서 재구성한다.
+ */
+function buildLaDeps(env: Env): LiveActivityDeps {
+  return {
+    apnsConfig: {
+      keyId: env.APNS_KEY_ID,
+      teamId: env.APNS_TEAM_ID,
+      privateKeyPem: env.APNS_PRIVATE_KEY,
+      bundleId: env.APNS_BUNDLE_ID,
+    },
+    apnsHosts: { production: env.APNS_HOST, sandbox: env.APNS_HOST_SANDBOX },
+  };
+}
+
+/** scheduled cycle 통계와 분리된, 단일 HTTP 정리용 throwaway stats. */
+function makeLaStats(): LiveActivityStats {
+  return { laPushSent: 0, laPushFailed: 0, laTokenCleared: 0 };
+}
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -221,7 +247,17 @@ app.delete('/trips/:token', async (c) => {
   if (!token) return c.json({ error: 'missing_token' }, 400);
   const existing = await getTrip(c.env.TRIPS, token);
   if (!existing) return c.json({ ok: true, deleted: false });
-  await deleteTrip(c.env.TRIPS, token);
+  // 활성 LA가 있으면 dismissal push 발사 후 KV 삭제. cleanupTripWithLa가 두 동작을 묶는다.
+  // logger는 worker console.log로 직결 — HTTP-driven cleanup의 dismissal 실패가 silent loss로
+  // 사라지지 않게 운영 가시성 확보.
+  await cleanupTripWithLa(
+    existing,
+    c.env,
+    buildLaDeps(c.env),
+    makeLaStats(),
+    Date.now(),
+    (msg, meta) => console.log(JSON.stringify({ msg, ...meta })),
+  );
   return c.json({ ok: true, deleted: true });
 });
 

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -1,0 +1,173 @@
+/**
+ * Live Activity push 발사 헬퍼 (#586 D).
+ *
+ * scheduled.ts와 HTTP DELETE handler 양쪽이 공유하는 LA 발사/종료/cleanup 로직.
+ * - update: 의미있는 변화 시점에 content-state 갱신
+ * - end:    trip 종료(만료/도착/취소) 시 dismissal
+ * - 410 BadDeviceToken은 토큰 자체 무효 — trip.activityPushToken을 비우고 state='ended'로 전이
+ *
+ * content-state는 숫자/enum/epoch만 채운다 — 텍스트(stationName 등)는 디바이스 측 JS init 값 유지
+ * (PR E의 widget이 누락 시 raw 필드 폴백). 이는 APNs LA payload 사이즈 절감 + 텍스트 i18n 의존 회피.
+ */
+
+import { sendLiveActivityUpdate, type LiveActivityContentState } from './apns';
+import { pickApnsHost } from './apnsHost';
+import { deleteTrip } from './trips';
+import type { ApnsEnv, Env, Trip, Waypoint } from './types';
+
+/**
+ * stale-date까지 클라이언트가 last content-state를 신뢰할 수 있는 시간(초).
+ * cron 주기(60s)의 약 1.5배 — 한 사이클 누락(네트워크 일시 단절 등)을 흡수.
+ * cron 주기가 바뀌면 함께 검토 대상.
+ */
+export const LA_STALE_DURATION_SEC = 90;
+
+type Logger = (message: string, meta?: Record<string, unknown>) => void;
+
+export interface LiveActivityStats {
+  laPushSent: number;
+  laPushFailed: number;
+  laTokenCleared: number;
+}
+
+export interface LiveActivityDeps {
+  apnsConfig: import('./apns').ApnsConfig;
+  apnsHosts: Record<ApnsEnv, string>;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * content-state 페이로드 빌더.
+ * @param stopsRemaining 다음 hop까지 남은 정거장 수 — 호출자가 계산해 전달(폴링 전/후 시점에 따라 다름).
+ */
+export function buildLiveActivityContentState(
+  waypoint: Waypoint,
+  etaSeconds: number,
+  phase: 'early' | 'imminent',
+  stopsRemaining: number,
+  nowMs: number,
+): LiveActivityContentState {
+  return {
+    etaSeconds,
+    phase,
+    kind: waypoint.kind,
+    stopsRemaining,
+    arrivalAtSec: Math.floor(nowMs / 1000) + etaSeconds,
+  };
+}
+
+export interface LiveActivityFireResult {
+  /** trip의 activityPushToken/activityState가 변경되어 putTrip이 필요한지. */
+  dirty: boolean;
+}
+
+/**
+ * LA update push 발사. trip에 activity token이 없거나 state가 live가 아니면 no-op.
+ * 410 응답 시 token clear + state='ended'로 전이 (dirty=true).
+ *
+ * silent/reschedule push의 env-heal(#482)은 LA에 적용하지 않는다 — LA token은 register 시점에
+ * 디바이스가 apnsEnv를 확정 통지(`POST /live-activity/register`가 trip의 apnsEnv를 신뢰)하므로,
+ * 토큰/환경 불일치는 곧 토큰 자체 무효를 의미. 410 분기에서 단순 clear로 흡수.
+ */
+export async function fireLiveActivityUpdate(
+  trip: Trip,
+  contentState: LiveActivityContentState,
+  deps: LiveActivityDeps,
+  stats: LiveActivityStats,
+  now: number,
+  log: Logger,
+): Promise<LiveActivityFireResult> {
+  if (!trip.activityPushToken || trip.activityState !== 'live') {
+    return { dirty: false };
+  }
+  const host = pickApnsHost(trip.apnsEnv, deps.apnsHosts);
+  const result = await sendLiveActivityUpdate({
+    activityToken: trip.activityPushToken,
+    contentState,
+    event: 'update',
+    staleDate: Math.floor(now / 1000) + LA_STALE_DURATION_SEC,
+    config: deps.apnsConfig,
+    host,
+    fetchImpl: deps.fetchImpl,
+    now,
+  });
+  if (result.ok) {
+    stats.laPushSent += 1;
+    return { dirty: false };
+  }
+  stats.laPushFailed += 1;
+  log('la update failed', {
+    token: trip.token.slice(0, 8),
+    status: result.status,
+    reason: result.reason,
+  });
+  if (result.status === 410) {
+    trip.activityPushToken = undefined;
+    trip.activityState = 'ended';
+    stats.laTokenCleared += 1;
+    return { dirty: true };
+  }
+  return { dirty: false };
+}
+
+/**
+ * LA dismissal push 발사 — event='end' + dismissalDate=now. trip 정리 직전에 호출.
+ * 토큰이 없거나 state가 이미 ended면 no-op. push 결과와 무관하게 trip 객체의
+ * activity 필드는 비우고 state='ended'로 전이 (다음 cycle에서 중복 시도 차단).
+ *
+ * 호출자 책임: 이후 deleteTrip이 trip을 KV에서 제거하므로 dirty 플래그 신경 안 써도 됨.
+ * `cleanupTripWithLa` wrapper가 두 동작을 묶어 처리.
+ */
+export async function fireLiveActivityDismissal(
+  trip: Trip,
+  deps: LiveActivityDeps,
+  stats: LiveActivityStats,
+  now: number,
+  log: Logger,
+): Promise<void> {
+  if (!trip.activityPushToken || trip.activityState !== 'live') return;
+  const host = pickApnsHost(trip.apnsEnv, deps.apnsHosts);
+  const nowSec = Math.floor(now / 1000);
+  const result = await sendLiveActivityUpdate({
+    activityToken: trip.activityPushToken,
+    contentState: {},
+    event: 'end',
+    staleDate: nowSec,
+    dismissalDate: nowSec,
+    config: deps.apnsConfig,
+    host,
+    fetchImpl: deps.fetchImpl,
+    now,
+  });
+  if (result.ok) {
+    stats.laPushSent += 1;
+  } else {
+    stats.laPushFailed += 1;
+    log('la dismissal failed', {
+      token: trip.token.slice(0, 8),
+      status: result.status,
+      reason: result.reason,
+    });
+    if (result.status === 410) stats.laTokenCleared += 1;
+  }
+  // 결과 무관 — 로컬 trip 상태를 ended로 전이. dismissal은 best-effort이며 trip은 곧 삭제됨.
+  trip.activityPushToken = undefined;
+  trip.activityState = 'ended';
+}
+
+/**
+ * trip 정리 wrapper — LA dismissal(있을 때만) + deleteTrip을 단일 진입점으로.
+ * scheduled.ts의 모든 deleteTrip 호출 + HTTP DELETE /trips/:token이 공유.
+ */
+export async function cleanupTripWithLa(
+  trip: Trip,
+  env: Env,
+  deps: LiveActivityDeps,
+  stats: LiveActivityStats,
+  now: number,
+  log: Logger,
+): Promise<void> {
+  await fireLiveActivityDismissal(trip, deps, stats, now, log);
+  await deleteTrip(env.TRIPS, trip.token);
+}
+

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -11,10 +11,17 @@ import {
   shouldFire,
 } from './alarm';
 import { sendReschedulePush, sendSilentPush, type ApnsConfig, type SendPushResult } from './apns';
+import { flipApnsEnv, pickApnsHost } from './apnsHost';
 import { matchLine } from './lineAlias';
 import { buildAlarmKey, putPending } from './pendingPushes';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
-import { deleteTrip, listTrips, putTrip } from './trips';
+import { listTrips, putTrip } from './trips';
+import {
+  buildLiveActivityContentState,
+  cleanupTripWithLa,
+  fireLiveActivityUpdate,
+  type LiveActivityStats,
+} from './liveActivity';
 import type { ApnsEnv, BoardingLockMeta, Env, Trip, Waypoint } from './types';
 
 /** 알람 윈도우: 알람 예상 시각 5분 이내인 트립만 폴링한다. */
@@ -77,7 +84,7 @@ export async function sendWithEnvHeal(
 
 type Logger = (message: string, meta?: Record<string, unknown>) => void;
 
-export interface ScheduledStats {
+export interface ScheduledStats extends LiveActivityStats {
   scanned: number;
   polled: number;
   pushed: number;
@@ -104,24 +111,9 @@ export interface ScheduledDeps {
   generatePushId?: () => string;
 }
 
-/**
- * trip의 apnsEnv → APNs host 선택. 누락 시 sandbox fallback —
- * 구버전 클라이언트가 필드를 안 보낼 때 production host로 잘못 전송되어
- * `BadDeviceToken`을 받던 #482 회귀를 막기 위함. App Store/TestFlight 빌드는
- * 반드시 명시적으로 'production'을 보내야 한다.
- */
-export function pickApnsHost(apnsEnv: ApnsEnv | undefined, hosts: Record<ApnsEnv, string>): string {
-  return hosts[apnsEnv ?? 'sandbox'];
-}
-
-/**
- * APNs env를 반대편으로 뒤집는다. BadDeviceToken self-heal에서 1차 시도 host와
- * 반대 host로 재시도할 때 사용 (#482 D안). 누락(undefined)은 sandbox로 시작했으므로
- * production으로 뒤집는다 — `pickApnsHost`의 sandbox fallback과 짝.
- */
-export function flipApnsEnv(env: ApnsEnv | undefined): ApnsEnv {
-  return (env ?? 'sandbox') === 'sandbox' ? 'production' : 'sandbox';
-}
+// pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
+// 기존 import 호환을 위해 re-export.
+export { flipApnsEnv, pickApnsHost };
 
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
   const now = deps.now?.() ?? Date.now();
@@ -134,13 +126,16 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     errors: 0,
     etaMissing: 0,
     envCorrected: 0,
+    laPushSent: 0,
+    laPushFailed: 0,
+    laTokenCleared: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
     stats.scanned += 1;
 
     if (trip.expiresAt <= now) {
-      await deleteTrip(env.TRIPS, trip.token);
+      await cleanupTripWithLa(trip, env, deps, stats, now, log);
       continue;
     }
 
@@ -273,7 +268,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
             dirty = true;
             if (phase === 'imminent') {
               if (waypoint.kind === 'destination') {
-                await deleteTrip(env.TRIPS, trip.token);
+                await cleanupTripWithLa(trip, env, deps, stats, now, log);
                 log('trip completed after destination imminent push', {
                   token: trip.token.slice(0, 8),
                 });
@@ -293,7 +288,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
                 remaining: trip.waypoints.length,
               });
               if (trip.waypoints.length === 0) {
-                await deleteTrip(env.TRIPS, trip.token);
+                await cleanupTripWithLa(trip, env, deps, stats, now, log);
                 continue;
               }
             }
@@ -306,10 +301,32 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
             token: trip.token.slice(0, 8),
           });
           if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
-            await deleteTrip(env.TRIPS, trip.token);
+            await cleanupTripWithLa(trip, env, deps, stats, now, log);
             continue;
           }
         }
+      }
+
+      // LA update: silent push와 동일 gating(phase 전이 또는 ETA 60s+ 변동). intermediate는 LA에서 의미 없으므로 스킵.
+      // 발사가 안 일어났어도 ETA가 의미있게 변하면 LA는 갱신해야 함 — silent push와 독립적인 채널.
+      if (
+        trip.activityPushToken &&
+        trip.activityState === 'live' &&
+        !isIntermediate &&
+        (etaChanged || phaseFires)
+      ) {
+        // laPhase 우선순위: 이번 tick의 신호 → 직전 발사 기억 → 초기값 early.
+        // 신호 없는 cycle에서도 LA content-state는 마지막으로 알려진 phase를 유지해야 한다.
+        const laPhase = phase ?? trip.lastFiredPhase ?? 'early';
+        const contentState = buildLiveActivityContentState(
+          waypoint,
+          eta,
+          laPhase,
+          trip.waypoints.length,
+          now,
+        );
+        const la = await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log);
+        if (la.dirty) dirty = true;
       }
 
       if (dirty) {
@@ -357,7 +374,7 @@ export async function runTrainCodeTracking(
   }
 
   if (estimate.arrived) {
-    await advanceBoardingLockWaypoint(trip, waypoint, env, log);
+    await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
     return;
   }
 
@@ -404,10 +421,13 @@ export async function advanceBoardingLockWaypoint(
   trip: Trip,
   waypoint: Waypoint,
   env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
   log: Logger,
 ): Promise<void> {
   if (waypoint.kind === 'destination') {
-    await deleteTrip(env.TRIPS, trip.token);
+    await cleanupTripWithLa(trip, env, deps, stats, now, log);
     log('boarding-lock: destination arrived, trip cleared', {
       token: trip.token.slice(0, 8),
       station: waypoint.stationName,
@@ -423,7 +443,7 @@ export async function advanceBoardingLockWaypoint(
     remaining: trip.waypoints.length,
   });
   if (trip.waypoints.length === 0) {
-    await deleteTrip(env.TRIPS, trip.token);
+    await cleanupTripWithLa(trip, env, deps, stats, now, log);
     return;
   }
   await putTrip(env.TRIPS, trip);
@@ -502,7 +522,7 @@ export async function maybeReschedulePush(
       token: trip.token.slice(0, 8),
     });
     if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
-      await deleteTrip(env.TRIPS, trip.token);
+      await cleanupTripWithLa(trip, env, deps, stats, now, log);
       return;
     }
   }


### PR DESCRIPTION
## Summary
- `liveActivity.ts` — `buildContentState` / `fireLiveActivityUpdate` / `fireLiveActivityDismissal` / `cleanupTripWithLa`. content-state는 숫자/enum/epoch만(텍스트는 widget JS 초기값에 위임 — PR E).
- `apnsHost.ts` — `pickApnsHost` / `flipApnsEnv`를 SSOT로 추출(scheduled.ts와 liveActivity.ts 공유, #482 정책).
- `scheduled.ts` — `ScheduledStats`에 `laPushSent/laPushFailed/laTokenCleared` 추가. 모든 `deleteTrip` 사이트 → `cleanupTripWithLa`. silent push 분기 후 gating(`!intermediate && (etaChanged || phaseFires)`)으로 LA update 발사. `staleDate = now + 90s`.
- `index.ts` — `DELETE /trips/:token`도 `cleanupTripWithLa` 사용. dismissal 실패는 worker console로 로깅.
- LA push에 env-heal(#482) 미적용 — register 시점에 `apnsEnv`가 확정되므로 토큰/환경 불일치는 곧 토큰 무효(410 분기에서 흡수).
- 실제 widget 표시 + ContentState 텍스트 fallback은 PR E(#613).

## Stacked PR
Base는 **PR C(#616 / `feat/#611-backend-la-token-apns-builder`)**. PR C 머지 후 dev로 자동 rebase.

## Test plan
- [x] `npm test` (backend/alarm-worker) — 282/282 그린
- [x] `npm run type-check` 통과
- [x] 신규 분기 커버: LA update 발사/410 token clear/non-410 retain, dismissal success/410/non-410, cleanup w/wo LA token, intermediate skip, no-token skip, boardingLock dest dismissal, expiry dismissal, HTTP DELETE w/o LA

Closes #612