### PR TITLE
fix(#621): BoardingLock 시간 interpolation — 지하 GPS stale ratchet forward

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -112,9 +112,11 @@ export default function HomeScreen() {
     [route, tripOrigin, destination],
   );
   // #584 PR D2: lock.trainCode를 fusion에 전달 — position-train이 같은 trainCode면 'boarding-lock' 승격.
-  // useBoardingLockController가 동일 store를 소비하지만 selector로 trainCode만 추출해 churn 최소화.
-  const lockedTrainCode = useBoardingLockStore((s) => s.lock?.trainCode ?? null);
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode);
+  // #621: lock 전체도 전달 — 지하 GPS stale 시 시간 interpolation으로 ratchet forward.
+  // 동일 store의 lock을 useBoardingLockController가 아래서 다시 소비하지만 selector라 churn 없음.
+  const fusionBoardingLock = useBoardingLockStore((s) => s.lock);
+  const lockedTrainCode = fusionBoardingLock?.trainCode ?? null;
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock);
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,

--- a/src/constants/boardingLock.ts
+++ b/src/constants/boardingLock.ts
@@ -15,3 +15,9 @@ export const FALLBACK_BOARDING_DURATION_MINUTES = 30;
  * 평균 환승 도보 시간 — 정밀화는 후속.
  */
 export const TRANSFER_WALKING_BUFFER_SECONDS = 180;
+
+/**
+ * 정거장당 추정 이동 시간 (ms). #584 PR C scheduler + #621 fusion interpolation 공유 상수.
+ * uniform 90s — 노선별/시간대별 정밀화는 후속(#624 hopTime lookup).
+ */
+export const HOP_TIME_MS = 90_000;

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -671,4 +671,212 @@ describe('useFusedNearestStation', () => {
       expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
     });
   });
+
+  describe('#621 BoardingLock 시간 interpolation (지하 GPS stale ratchet forward)', () => {
+    const yongmasan = findStationByNameAndLine('용마산', '7')!;
+    const junggok = findStationByNameAndLine('중곡', '7')!;
+    const gunja = findStationByNameAndLine('군자', '7')!;
+    const oolinidae = findStationByNameAndLine('어린이대공원', '7')!;
+    const konkuk = findStationByNameAndLine('건대입구', '7')!;
+    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const routeContext = { route, origin: yongmasan, destination: konkuk };
+    const T0 = 1_700_000_000_000;
+    const lock = {
+      destinationId: konkuk.id,
+      trainCode: '7093',
+      boardingStationId: yongmasan.id,
+      boardingLine: '7' as const,
+      boardedAt: T0,
+      expectedDurationMs: 30 * 60_000,
+    };
+
+    function setupGpsAt(station: typeof yongmasan) {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: station.lat, lng: station.lng },
+          result: { station, distanceKm: 0 },
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station, distanceKm: 0 }]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      mockUsePositions.mockReturnValue(positionRet(null));
+    }
+
+    it('GPS stale(용마산) + 3 hop 경과 → interp(어린이대공원)이 ratchet forward로 승격', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 3 * 90_000);
+        setupGpsAt(yongmasan);
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        expect(result.current.source).toBe('boarding-lock-interp');
+        expect(result.current.confidence).toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(oolinidae.id);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('GPS가 interp보다 앞(건대입구) → GPS 유지(역행 방지)', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 90_000);
+        setupGpsAt(konkuk);
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(konkuk.id);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('GPS=중곡(idx 1) + interp=중곡(idx 1) → tied. 채택 결과 유지(우회 안 함)', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 90_000);
+        setupGpsAt(junggok);
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        // tied → GPS 그대로 (boarding-lock 승격 X)
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(junggok.id);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('lock 없으면 기존 fusion 그대로', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 3 * 90_000);
+        setupGpsAt(yongmasan);
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, null, null),
+        );
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(yongmasan.id);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('routeContext 없으면 interp 비활성', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 3 * 90_000);
+        setupGpsAt(yongmasan);
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, undefined, '7093', lock),
+        );
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('GPS가 arc 밖(서울역 공항철도) + lock 활성 → interp가 채택됨', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 2 * 90_000);
+        // 7호선 arc와 무관한 역
+        setupGpsAt({ ...MOCK_STATIONS.seoulStation, line: 'airport' });
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        expect(result.current.source).toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(gunja.id);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('routeContext.origin null → arcStations 비어 interp 비활성', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 3 * 90_000);
+        setupGpsAt(yongmasan);
+        const { result } = renderHook(() =>
+          useFusedNearestStation(
+            undefined,
+            undefined,
+            { route, origin: null, destination: konkuk },
+            '7093',
+            lock,
+          ),
+        );
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('computeRouteArc null (origin/destination이 route.line에 없음) → interp 비활성', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 3 * 90_000);
+        setupGpsAt(yongmasan);
+        // route.line=7이지만 origin은 2호선 강남. stationsBetween이 null 반환 → arc null.
+        const { result } = renderHook(() =>
+          useFusedNearestStation(
+            undefined,
+            undefined,
+            { route, origin: MOCK_STATIONS.gangnam, destination: konkuk },
+            '7093',
+            lock,
+          ),
+        );
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('시간만 흐르면(부모 리렌더 없이) interp가 다음 hop으로 전진 — useMemo 캐시 회귀 가드', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0);
+        setupGpsAt(yongmasan);
+        const { result, rerender } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        // 탑승 직후: interp=용마산(idx 0), GPS=용마산 → tied. GPS 유지.
+        expect(result.current.result?.station.id).toBe(yongmasan.id);
+
+        // 시계만 진행. boardingLock/arcStations/GPS는 그대로 — 의존성이 안 바뀌어도
+        // interp이 새 now를 반영해야 한다. 부모 리렌더(rerender)는 한 번 발생시켜
+        // hook이 다시 호출되는 정상 사이클을 시뮬레이션.
+        jest.setSystemTime(T0 + 3 * 90_000);
+        rerender(undefined);
+        expect(result.current.source).toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(oolinidae.id);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('userLocation null + GPS result null → interp 단독 채택 (distanceKm=0)', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 90_000);
+        mockUseNearest.mockReturnValue(
+          gpsBase({ userLocation: null, result: null }),
+        );
+        mockFindTop.mockReturnValue([]);
+        mockUseArrival.mockReturnValue(arrivalRet(null));
+        mockUsePositions.mockReturnValue(positionRet(null));
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        expect(result.current.source).toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(junggok.id);
+        expect(result.current.result?.distanceKm).toBe(0);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
 });

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -14,6 +14,11 @@ import { pickCandidateTrains, type CandidateTrain } from '../utils/pickCandidate
 import { trackTrainProgress } from '../utils/trackTrainProgress';
 import { haversine } from '../utils/haversine';
 import { passesFusionDistanceGate } from '../utils/fusionDistanceGate';
+import { computeRouteArc } from '../utils/routeProgress';
+import {
+  arcIndexOfStation,
+  interpolateBoardingLockStation,
+} from '../utils/boardingLockInterpolation';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import {
   MAX_ACTIVE_LINES,
@@ -22,6 +27,7 @@ import {
   POSITION_TRAIN_TTL_MS,
 } from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
+import type { BoardingLock } from '../types/boardingLock';
 import type { NearestStationResult, Station } from '../types/station';
 import type { ArrivalProvider, PositionProvider } from '../providers/types';
 import type { Route } from '../utils/stationRoute';
@@ -105,6 +111,12 @@ export function useFusedNearestStation(
    * null/undefined면 기존 우선순위 그대로.
    */
   lockedTrainCode?: string | null,
+  /**
+   * 활성 BoardingLock 전체 객체 (#621). 지하 GPS dead zone에서 GPS/realtimePosition API가
+   * stale일 때 경과 시간 기반 interpolation으로 현재역을 ratchet forward 한다.
+   * routeContext + boardingLock 둘 다 있어야 동작 — 한쪽이라도 없으면 기존 fusion 그대로.
+   */
+  boardingLock?: BoardingLock | null,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation();
 
@@ -295,6 +307,46 @@ export function useFusedNearestStation(
     result = gps.result;
     confidence = 'gps-only';
     source = 'gps';
+  }
+
+  // #621 BoardingLock 시간 interpolation — 지하 GPS stale ratchet forward.
+  // arc상 시간 interp 위치가 현 채택된 결과보다 앞이거나, 채택 결과가 arc 밖이면 override.
+  // 채택 결과가 더 앞이면 그대로(실제 신호 우선) — 역행 방지(monotone forward).
+  // confidence/source는 #584 PR D2의 'boarding-lock'(position-train + trainCode 매칭)과
+  // 구분하기 위해 'boarding-lock-interp' 별도 라벨 사용 — 측정·디버그 인프라에서 구분 가능.
+  const arcStations = useMemo<Station[]>(() => {
+    if (!routeContext || !routeContext.origin || !routeContext.destination) return [];
+    const arc = computeRouteArc(
+      routeContext.route,
+      routeContext.origin,
+      routeContext.destination,
+    );
+    return arc?.stations ?? [];
+  }, [routeContext]);
+
+  // useMemo로 감싸면 deps가 시간을 포함하지 않아 부모 리렌더가 없는 동안 stale.
+  // interp는 findIndex 1회 + 정수 산술 — render마다 직접 계산해도 무비용.
+  const interpResult = interpolateBoardingLockStation({
+    lock: boardingLock ?? null,
+    arcStations,
+    now: Date.now(),
+  });
+
+  if (interpResult && arcStations.length > 0) {
+    const chosenIdx = arcIndexOfStation(arcStations, result?.station ?? null);
+    if (chosenIdx === -1 || interpResult.index > chosenIdx) {
+      const distanceKm = gps.userLocation
+        ? haversine(
+            gps.userLocation.lat,
+            gps.userLocation.lng,
+            interpResult.station.lat,
+            interpResult.station.lng,
+          )
+        : 0;
+      result = { station: interpResult.station, distanceKm };
+      confidence = 'boarding-lock-interp';
+      source = 'boarding-lock-interp';
+    }
   }
 
   // 측정(#443): 결정 변화(source/stationId/confidence) 시에만 push.

--- a/src/utils/__tests__/boardingLockInterpolation.test.ts
+++ b/src/utils/__tests__/boardingLockInterpolation.test.ts
@@ -1,0 +1,151 @@
+import {
+  arcIndexOfStation,
+  interpolateBoardingLockStation,
+} from '../boardingLockInterpolation';
+import { HOP_TIME_MS } from '../../constants/boardingLock';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { Station } from '../../types/station';
+
+const ARC: Station[] = [
+  { id: '7-001', name: '용마산', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-002', name: '중곡', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-003', name: '군자', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-004', name: '어린이대공원', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-005', name: '건대입구', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+];
+
+const T0 = 1_700_000_000_000;
+
+function makeLock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: '2-011',
+    trainCode: '7093',
+    boardingStationId: '7-001',
+    boardingLine: '7',
+    boardedAt: T0,
+    expectedDurationMs: 10 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+describe('interpolateBoardingLockStation', () => {
+  it('lock null이면 null', () => {
+    expect(interpolateBoardingLockStation({ lock: null, arcStations: ARC, now: T0 })).toBeNull();
+  });
+
+  it('arcStations 비면 null', () => {
+    expect(
+      interpolateBoardingLockStation({ lock: makeLock(), arcStations: [], now: T0 }),
+    ).toBeNull();
+  });
+
+  it('boardingStationId가 arc에 없으면 null', () => {
+    expect(
+      interpolateBoardingLockStation({
+        lock: makeLock({ boardingStationId: '9-999' }),
+        arcStations: ARC,
+        now: T0,
+      }),
+    ).toBeNull();
+  });
+
+  it('lock 만료면 null (expectedDurationMs * 1.5 초과)', () => {
+    const lock = makeLock({ expectedDurationMs: 60_000 });
+    const expired = T0 + 60_000 * 1.5 + 1;
+    expect(
+      interpolateBoardingLockStation({ lock, arcStations: ARC, now: expired }),
+    ).toBeNull();
+  });
+
+  it('경과 시간이 음수(시계 후진)면 null', () => {
+    expect(
+      interpolateBoardingLockStation({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0 - 1,
+      }),
+    ).toBeNull();
+  });
+
+  it('탑승 직후(elapsed=0)는 boarding station 반환', () => {
+    const r = interpolateBoardingLockStation({ lock: makeLock(), arcStations: ARC, now: T0 });
+    expect(r).toEqual({ station: ARC[0], index: 0 });
+  });
+
+  it('1 hop 경과 시 다음 역', () => {
+    const r = interpolateBoardingLockStation({
+      lock: makeLock(),
+      arcStations: ARC,
+      now: T0 + HOP_TIME_MS,
+    });
+    expect(r).toEqual({ station: ARC[1], index: 1 });
+  });
+
+  it('3 hop 경과 — 중간 역', () => {
+    const r = interpolateBoardingLockStation({
+      lock: makeLock(),
+      arcStations: ARC,
+      now: T0 + 3 * HOP_TIME_MS,
+    });
+    expect(r).toEqual({ station: ARC[3], index: 3 });
+  });
+
+  it('arc 끝을 넘는 경과 시간 — 마지막 역으로 cap (만료 전)', () => {
+    // expectedDurationMs를 충분히 크게 잡아 만료 가드(*1.5)에 안 걸리게 한다.
+    const lock = makeLock({ expectedDurationMs: 100 * HOP_TIME_MS });
+    const r = interpolateBoardingLockStation({
+      lock,
+      arcStations: ARC,
+      now: T0 + (ARC.length - 1 + 1) * HOP_TIME_MS,
+    });
+    expect(r).toEqual({ station: ARC[4], index: 4 });
+  });
+
+  it('종착역 cap 후 OVER_TERMINAL_GRACE_HOPS(2) 초과 → null (영구 고정 회피)', () => {
+    const lock = makeLock({ expectedDurationMs: 100 * HOP_TIME_MS });
+    // ARC length 5, boardingIdx=0 → lastIdx=4. hopsElapsed=7 > 4+2 → null.
+    const r = interpolateBoardingLockStation({
+      lock,
+      arcStations: ARC,
+      now: T0 + 7 * HOP_TIME_MS,
+    });
+    expect(r).toBeNull();
+  });
+
+  it('종착역 cap 후 grace hop(2) 이내는 종착역 유지', () => {
+    const lock = makeLock({ expectedDurationMs: 100 * HOP_TIME_MS });
+    // hopsElapsed=6, lastIdx=4, lastIdx+grace=6 → cap된 종착역 반환
+    const r = interpolateBoardingLockStation({
+      lock,
+      arcStations: ARC,
+      now: T0 + 6 * HOP_TIME_MS,
+    });
+    expect(r).toEqual({ station: ARC[4], index: 4 });
+  });
+
+  it('boardingStationId가 중간이면 그 위치 기준으로 hop 추가', () => {
+    const r = interpolateBoardingLockStation({
+      lock: makeLock({ boardingStationId: '7-003' }),
+      arcStations: ARC,
+      now: T0 + HOP_TIME_MS,
+    });
+    expect(r).toEqual({ station: ARC[3], index: 3 });
+  });
+});
+
+describe('arcIndexOfStation', () => {
+  it('null 입력 시 -1', () => {
+    expect(arcIndexOfStation(ARC, null)).toBe(-1);
+    expect(arcIndexOfStation(ARC, undefined)).toBe(-1);
+  });
+
+  it('arc에 있는 station이면 인덱스 반환', () => {
+    expect(arcIndexOfStation(ARC, ARC[2])).toBe(2);
+  });
+
+  it('arc에 없는 station이면 -1', () => {
+    expect(
+      arcIndexOfStation(ARC, { id: 'x', name: 'x', line: '1', lineColor: '', lat: 0, lng: 0 }),
+    ).toBe(-1);
+  });
+});

--- a/src/utils/boardingLockInterpolation.ts
+++ b/src/utils/boardingLockInterpolation.ts
@@ -1,0 +1,68 @@
+import { HOP_TIME_MS } from '../constants/boardingLock';
+import { isBoardingLockExpired, type BoardingLock } from '../types/boardingLock';
+import type { Station } from '../types/station';
+
+export interface BoardingLockInterpolationResult {
+  station: Station;
+  /** arcStations 내 위치 (0 = 탑승역). */
+  index: number;
+}
+
+/**
+ * 종착역 고정 회귀 방지(#621 review P1-2). 종점 도달 후 추가로 흐른 hop이
+ * 이 값을 넘으면 interp를 무효화 — release/만료 처리 책임을 호출자에게 돌려준다.
+ * 안전 마진: 종점에서 lock release까지의 일반적 지연(통보, 사용자 인지)을 흡수.
+ */
+const OVER_TERMINAL_GRACE_HOPS = 2;
+
+/**
+ * BoardingLock 활성 시 경과 시간 기반으로 현재역을 추정한다 (#621).
+ *
+ * 지하 GPS dead zone에서 실제 신호(GPS/realtimePosition API)가 stale일 때 fusion이
+ * "용마산 5분 고정" 같은 회귀를 일으키는 것을 막는 floor 신호.
+ *
+ * idx = boardingIdx + floor((now - boardedAt) / HOP_TIME_MS)
+ * stations 끝을 넘으면 마지막 역으로 cap. OVER_TERMINAL_GRACE_HOPS 초과면 null.
+ *
+ * 반환 null 케이스:
+ *  - lock null
+ *  - lock 만료 (isBoardingLockExpired)
+ *  - boardingStationId가 arcStations에 없음 (route 변경 등)
+ *  - 경과 시간이 음수 (시계 후진)
+ *  - 종착역 cap 후 OVER_TERMINAL_GRACE_HOPS 추가 경과 (영구 고정 회피)
+ */
+export function interpolateBoardingLockStation(input: {
+  lock: BoardingLock | null;
+  arcStations: Station[];
+  now: number;
+}): BoardingLockInterpolationResult | null {
+  const { lock, arcStations, now } = input;
+  if (!lock) return null;
+  if (isBoardingLockExpired(lock, now)) return null;
+  if (arcStations.length === 0) return null;
+
+  const elapsed = now - lock.boardedAt;
+  if (elapsed < 0) return null;
+
+  const boardingIdx = arcStations.findIndex((s) => s.id === lock.boardingStationId);
+  if (boardingIdx === -1) return null;
+
+  const hopsElapsed = Math.floor(elapsed / HOP_TIME_MS);
+  const lastIdx = arcStations.length - 1;
+  // 종착역을 OVER_TERMINAL_GRACE_HOPS 이상 초과한 경과 시간이면 interp 자체를 무효.
+  if (boardingIdx + hopsElapsed > lastIdx + OVER_TERMINAL_GRACE_HOPS) return null;
+  const idx = Math.min(boardingIdx + hopsElapsed, lastIdx);
+  return { station: arcStations[idx], index: idx };
+}
+
+/**
+ * arcStations에서 station.id 기준 인덱스. 미발견은 -1.
+ * fusion에서 GPS/position-train 결과가 경로상 어느 위치인지 비교용.
+ */
+export function arcIndexOfStation(
+  arcStations: Station[],
+  station: Station | null | undefined,
+): number {
+  if (!station) return -1;
+  return arcStations.findIndex((s) => s.id === station.id);
+}

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -12,6 +12,7 @@ import {
   removeScheduledNotificationIds,
 } from './scheduledNotificationsStorage';
 import { createLogger } from './logger';
+import { HOP_TIME_MS } from '../constants/boardingLock';
 
 const logger = createLogger('BoardingLockScheduler');
 
@@ -20,11 +21,7 @@ export const BOARDING_LOCK_ALARM_PREFIX = 'bl:';
 // 생기면 src/constants/로 일괄 추출 — 현재는 surgical change 원칙상 PR D 진입 전 유지.
 const ALARM_CHANNEL_ID = 'station-alarm';
 
-/**
- * 정거장당 추정 이동 시간(초). PR C v1은 uniform 90s — 노선별/시간대별 정밀화는 후속.
- * 기존 alarmScheduler와 동일 값으로 두어 동시 동작 시 일관성 유지.
- */
-const HOP_TIME_SECONDS = 90;
+const HOP_TIME_SECONDS = HOP_TIME_MS / 1000;
 
 /**
  * Phase별 lead time. #584 SLA 설계(2026-05-28):

--- a/src/utils/notificationSource.ts
+++ b/src/utils/notificationSource.ts
@@ -26,6 +26,7 @@ export function resolveNotificationSource(
   if (locationUncertain) return 'uncertain';
   switch (source) {
     case 'boarding-lock':
+    case 'boarding-lock-interp':
     case 'position-train':
     case 'position':
     case 'arrival':

--- a/src/utils/pickFusedStation.ts
+++ b/src/utils/pickFusedStation.ts
@@ -12,6 +12,7 @@ import { getTrainStatusPriority } from '../constants/trainStatus';
  */
 export type FusionConfidence =
   | 'boarding-lock'
+  | 'boarding-lock-interp'
   | 'position-train'
   | 'arrival-confirmed'
   | 'arrival-arriving'
@@ -26,6 +27,7 @@ export type FusionConfidence =
  */
 export type FusionSource =
   | 'boarding-lock'
+  | 'boarding-lock-interp'
   | 'position-train'
   | 'position'
   | 'arrival'


### PR DESCRIPTION
## Summary
- 지하 GPS dead zone + realtimePosition API lag로 현재역이 5분+ stale 고정되는 회귀 fix
- BoardingLock 활성 시 \`boardedAt + elapsed × HOP_TIME_MS\`로 arc상 floor 위치 계산 → 단조 전진(monotone forward) ratchet
- fusion 우선순위 사슬 끝에 override로 부착 — 기존 결정 흐름 무영향

## Test plan
- [x] \`npm test\` (137 suites, 2129 tests, 100% coverage)
- [x] \`npm run type-check\`
- [x] code-review agent P1 3건 반영:
  - P1-1: useMemo deps 제거 — Date.now() ratchet 보장
  - P1-2: OVER_TERMINAL_GRACE_HOPS(2) 가드 — 종착역 영구 고정 회피
  - P1-3: source/confidence 'boarding-lock-interp' 별도 라벨 — 디버그/측정 인프라 구분
- [ ] 실기기: 지하 구간 진입 후 현재역이 시간 흐름 따라 실제 진행과 동기화 (사용자 검증)

Closes #621