### PR TITLE
feat(#623): 알람 kill switch + 잠금화면 dismiss 진동 정리

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -73,6 +73,8 @@ export default function HomeScreen() {
   const sleepMode = useAppStore((s) => s.sleepMode);
   const setSleepMode = useAppStore((s) => s.setSleepMode);
   const loadSleepMode = useAppStore((s) => s.loadSleepMode);
+  const alarmsKilled = useAppStore((s) => s.alarmsKilled);
+  const setAlarmsKilled = useAppStore((s) => s.setAlarmsKilled);
   const loadAllowSpeaker = useAppStore((s) => s.loadAllowSpeaker);
   const showSleepModeGuide = useSleepModeGuide();
   const alarmEvent = useAppStore((s) => s.alarmEvent);
@@ -650,6 +652,27 @@ export default function HomeScreen() {
                   <Pressable onPress={() => setDestination(null)} testID="destination-clear-button">
                     <Text style={[typography.bodySm, { color: colors.muted }]}>{t('home.destinationReset')}</Text>
                   </Pressable>
+                </View>
+
+                <Hr />
+
+                {/* Alarms kill switch (#623) */}
+                <View style={styles.sleepRow} testID="alarms-kill-row">
+                  <View>
+                    <Text style={[typography.bodySm, { color: alarmsKilled ? colors.danger : colors.ink, fontWeight: '700' }]}>
+                      {t('home.alarmsKill')}
+                    </Text>
+                    <Text style={[typography.mono, { color: colors.muted, marginTop: 2 }]}>
+                      {t('home.alarmsKillDescription')}
+                    </Text>
+                  </View>
+                  <Switch
+                    value={alarmsKilled}
+                    onValueChange={(value) => setAlarmsKilled(value)}
+                    trackColor={{ false: colors.hair, true: colors.danger }}
+                    thumbColor={colors.bg}
+                    testID="home-alarms-kill-switch"
+                  />
                 </View>
 
                 <Hr />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { DevSettings } from 'react-native';
+import * as Notifications from 'expo-notifications';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
@@ -18,6 +19,7 @@ import { registerSilentPushTask } from '../src/tasks/silentPushTask';
 import { registerScheduledAlarmListener } from '../src/utils/scheduledAlarmReceiver';
 import { cancelScheduledAlarms } from '../src/utils/alarmScheduler';
 import { unregisterAlarmRefreshTask } from '../src/tasks/alarmRefreshTask';
+import { stopVibration } from '../src/utils/alarmSound';
 
 const layoutLogger = createLogger('RootLayout');
 
@@ -58,12 +60,23 @@ if (!__DEV__) {
 function RootContent() {
   const { isDark } = useTheme();
   const loadLocalePreference = useAppStore((s) => s.loadLocalePreference);
+  const loadAlarmsKilled = useAppStore((s) => s.loadAlarmsKilled);
   const debugVisible = useAppStore((s) => s.debugVisible);
   const setDebugVisible = useAppStore((s) => s.setDebugVisible);
   const { i18n: i18nInstance } = useTranslation();
 
   useEffect(() => {
     loadLocalePreference();
+    loadAlarmsKilled();
+  }, []);
+
+  // #623 — 사용자가 잠금화면에서 노티 tap/dismiss할 때 진동이 안 멈추는 문제 해결.
+  // FG AlarmOverlay 외 경로(잠금화면 swipe)는 ResponseReceivedListener로만 잡힌다.
+  useEffect(() => {
+    const sub = Notifications.addNotificationResponseReceivedListener(() => {
+      stopVibration();
+    });
+    return () => sub.remove();
   }, []);
 
   useApplyLocale();

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -37,3 +37,6 @@ export const BOARDING_LOCK_KEY = 'subway-now:boarding-lock';
 // release/expiry 또는 새 Lock 시점에 일괄 cancel하기 위한 추적 큐.
 // 형식: string[] JSON.
 export const SCHEDULED_NOTIFICATIONS_KEY = 'subway-now:scheduled-notifications';
+// #623 — 글로벌 알람 kill switch. ON일 동안 모든 alarm fire/schedule 경로 차단.
+// 사용자가 잠금화면 dismiss로도 진동이 안 멈춰 100% 차단 토글 요청.
+export const ALARMS_KILLED_KEY = 'subway-now:alarms-killed';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -38,6 +38,8 @@
     "previousDestination": "Previous destination",
     "sleepMode": "Sleep mode",
     "sleepModeDescription": "Vibrate and notify 1 stop before transfer or arrival",
+    "alarmsKill": "Disable alarms",
+    "alarmsKillDescription": "When ON, vibration, sound, and pending alerts are instantly blocked",
     "arrivalInfoTitle": "Train arrivals",
     "loading": "Loading...",
     "mockNotice": "Showing estimated data — real-time unavailable",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -38,6 +38,8 @@
     "previousDestination": "前回の目的地",
     "sleepMode": "おやすみモード",
     "sleepModeDescription": "乗換・到着の1駅手前で振動・通知",
+    "alarmsKill": "アラーム停止",
+    "alarmsKillDescription": "ONの間、振動・音・予約済み通知をすべて即時遮断",
     "arrivalInfoTitle": "列車到着情報",
     "loading": "読み込み中...",
     "mockNotice": "リアルタイムデータが取得できないため予想データを表示しています",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -38,6 +38,8 @@
     "previousDestination": "이전 목적지",
     "sleepMode": "취침 모드",
     "sleepModeDescription": "환승·도착 1정거장 전 진동 · 알림",
+    "alarmsKill": "알람 끄기",
+    "alarmsKillDescription": "ON 시 진동·소리·예약 알림 모두 즉시 차단",
     "arrivalInfoTitle": "열차 도착 정보",
     "loading": "불러오는 중...",
     "mockNotice": "실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -38,6 +38,8 @@
     "previousDestination": "上次目的地",
     "sleepMode": "睡眠模式",
     "sleepModeDescription": "在换乘或到达前1站时震动并通知",
+    "alarmsKill": "关闭闹钟",
+    "alarmsKillDescription": "开启时立即阻止震动、声音和已安排的通知",
     "arrivalInfoTitle": "列车到达信息",
     "loading": "加载中...",
     "mockNotice": "无法获取实时数据,显示预测数据",

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -6,6 +6,13 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );
 
+jest.mock('../../utils/alarmKill', () => ({
+  killAllAlarms: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { killAllAlarms } from '../../utils/alarmKill';
+const mockKillAllAlarms = killAllAlarms as jest.Mock;
+
 const mockStation: Station = {
   id: '2-022',
   name: '강남',
@@ -26,7 +33,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false, alarmsKilled: false });
     jest.clearAllMocks();
   });
 
@@ -484,6 +491,45 @@ describe('useAppStore', () => {
 
     const { sleepMode } = useAppStore.getState();
     expect(sleepMode).toBe(false);
+  });
+
+  describe('alarmsKilled (#623 kill switch)', () => {
+    it('초기 alarmsKilled는 false', () => {
+      expect(useAppStore.getState().alarmsKilled).toBe(false);
+    });
+
+    it('setAlarmsKilled(true): 상태 + AsyncStorage 저장 + killAllAlarms 호출', async () => {
+      const { setAlarmsKilled } = useAppStore.getState();
+      await setAlarmsKilled(true);
+      expect(useAppStore.getState().alarmsKilled).toBe(true);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith('subway-now:alarms-killed', JSON.stringify(true));
+      expect(mockKillAllAlarms).toHaveBeenCalledTimes(1);
+    });
+
+    it('setAlarmsKilled(false): killAllAlarms 호출 안 함 (해제는 즉시 청소 불필요)', async () => {
+      const { setAlarmsKilled } = useAppStore.getState();
+      await setAlarmsKilled(false);
+      expect(useAppStore.getState().alarmsKilled).toBe(false);
+      expect(mockKillAllAlarms).not.toHaveBeenCalled();
+    });
+
+    it('loadAlarmsKilled: AsyncStorage true → 복원', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(true));
+      await useAppStore.getState().loadAlarmsKilled();
+      expect(useAppStore.getState().alarmsKilled).toBe(true);
+    });
+
+    it('loadAlarmsKilled: AsyncStorage 비어있으면 false 유지', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await useAppStore.getState().loadAlarmsKilled();
+      expect(useAppStore.getState().alarmsKilled).toBe(false);
+    });
+
+    it('loadAlarmsKilled: AsyncStorage 오류 시 false 유지', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+      await useAppStore.getState().loadAlarmsKilled();
+      expect(useAppStore.getState().alarmsKilled).toBe(false);
+    });
   });
 
   it('초기 customOrigin은 null이다', () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -7,7 +7,8 @@ function demoteSlotEntries(entries: FavoriteEntry[], role: FavoriteSlotRole): Fa
   return entries.map((f) => (f.role === role ? { ...f, role: 'general' as FavoriteRole } : f));
 }
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, ALARMS_KILLED_KEY } from '../constants/storageKeys';
+import { killAllAlarms } from '../utils/alarmKill';
 import { clearFiredAlarms } from '../utils/notificationState';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
@@ -53,6 +54,9 @@ interface AppState {
   loadLocalePreference: () => Promise<void>;
   setSleepMode: (enabled: boolean) => Promise<void>;
   loadSleepMode: () => Promise<void>;
+  alarmsKilled: boolean;
+  setAlarmsKilled: (enabled: boolean) => Promise<void>;
+  loadAlarmsKilled: () => Promise<void>;
   setAllowSpeaker: (enabled: boolean) => Promise<void>;
   loadAllowSpeaker: () => Promise<void>;
   accessibilityMode: boolean;
@@ -68,6 +72,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   destination: null,
   recentDestination: null,
   sleepMode: false,
+  alarmsKilled: false,
   allowSpeaker: true,
   customOrigin: null,
   themeMode: 'auto' as ThemeMode,
@@ -343,6 +348,26 @@ export const useAppStore = create<AppState>((set, get) => ({
       const raw = await AsyncStorage.getItem(SLEEP_MODE_KEY);
       if (raw) {
         set({ sleepMode: JSON.parse(raw) });
+      }
+    } catch {
+      // 저장된 데이터 없음 — false 유지
+    }
+  },
+
+  setAlarmsKilled: async (enabled: boolean) => {
+    set({ alarmsKilled: enabled });
+    await AsyncStorage.setItem(ALARMS_KILLED_KEY, JSON.stringify(enabled));
+    if (enabled) {
+      // 100% 차단 약속의 핵심 — 토글 즉시 진동/발사/예약 전부 청소.
+      await killAllAlarms();
+    }
+  },
+
+  loadAlarmsKilled: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(ALARMS_KILLED_KEY);
+      if (raw) {
+        set({ alarmsKilled: JSON.parse(raw) === true });
       }
     } catch {
       // 저장된 데이터 없음 — false 유지

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -28,6 +28,9 @@ jest.mock('../../utils/alarmLog', () => ({
 }));
 
 const mockCheckGate = jest.fn();
+jest.mock('../../utils/alarmKill', () => ({
+  isAlarmsKilled: jest.fn().mockResolvedValue(false),
+}));
 jest.mock('../../utils/silentPushLocationGate', () => ({
   checkSilentPushLocationGate: (...args: unknown[]) => mockCheckGate(...args),
 }));
@@ -276,6 +279,16 @@ describe('silentPushTask', () => {
       await handleSilentPush({ error: { message: 'boom' } });
       expect(mockCheckGate).not.toHaveBeenCalled();
       expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
+    });
+
+    it('#623 alarmsKilled=true면 즉시 종료 (payload extract 전)', async () => {
+      const { isAlarmsKilled } = jest.requireMock('../../utils/alarmKill');
+      isAlarmsKilled.mockResolvedValueOnce(true);
+      await handleSilentPush({
+        data: { notification: { data: { nextWaypoint: 'X', etaSeconds: 30, phase: 'early', kind: 'destination' } } },
+      });
+      expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
+      expect(mockCheckGate).not.toHaveBeenCalled();
     });
 
     it('payload 없으면 skip', async () => {

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -34,6 +34,7 @@ import {
   checkSilentPushLocationGate,
   type GateSkipReason,
 } from '../utils/silentPushLocationGate';
+import { isAlarmsKilled } from '../utils/alarmKill';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
 import { buildAlarmContent } from '../utils/stationNotification';
 import { type NotificationSource } from '../utils/notificationSource';
@@ -166,6 +167,10 @@ async function loadApnsToken(): Promise<string | null> {
 export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
   if (input.error) {
     logger.error('silent push task error:', input.error.message);
+    return;
+  }
+  if (await isAlarmsKilled()) {
+    logger.info('알람 차단됨 (alarmsKilled) — silent push skip');
     return;
   }
 

--- a/src/utils/__tests__/alarmKill.test.ts
+++ b/src/utils/__tests__/alarmKill.test.ts
@@ -1,0 +1,84 @@
+jest.mock('expo-notifications', () => ({
+  cancelAllScheduledNotificationsAsync: jest.fn(),
+  dismissAllNotificationsAsync: jest.fn(),
+}));
+jest.mock('../alarmSound', () => ({
+  stopVibration: jest.fn(),
+}));
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
+import { stopVibration } from '../alarmSound';
+import { isAlarmsKilled, killAllAlarms } from '../alarmKill';
+
+const mockedCancelAll = Notifications.cancelAllScheduledNotificationsAsync as jest.Mock;
+const mockedDismissAll = Notifications.dismissAllNotificationsAsync as jest.Mock;
+const mockedStopVib = stopVibration as jest.Mock;
+const mockedGetItem = AsyncStorage.getItem as jest.Mock;
+
+describe('alarmKill', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCancelAll.mockResolvedValue(undefined);
+    mockedDismissAll.mockResolvedValue(undefined);
+  });
+
+  describe('killAllAlarms', () => {
+    it('진동 중단 + dismissAll + cancelAllScheduled 모두 호출', async () => {
+      await killAllAlarms();
+      expect(mockedStopVib).toHaveBeenCalledTimes(1);
+      expect(mockedDismissAll).toHaveBeenCalledTimes(1);
+      expect(mockedCancelAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('stopVibration 실패해도 나머지 단계 계속', async () => {
+      mockedStopVib.mockImplementationOnce(() => {
+        throw new Error('vibrate-fail');
+      });
+      await killAllAlarms();
+      expect(mockedDismissAll).toHaveBeenCalledTimes(1);
+      expect(mockedCancelAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismissAll 실패해도 cancelAll은 호출', async () => {
+      mockedDismissAll.mockRejectedValueOnce(new Error('dismiss-fail'));
+      await killAllAlarms();
+      expect(mockedCancelAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancelAll 실패 — graceful (예외 propagate 안 함)', async () => {
+      mockedCancelAll.mockRejectedValueOnce(new Error('cancel-fail'));
+      await expect(killAllAlarms()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isAlarmsKilled', () => {
+    it('AsyncStorage true 저장 → true (#623 P0-2 BG-safe)', async () => {
+      mockedGetItem.mockResolvedValueOnce(JSON.stringify(true));
+      await expect(isAlarmsKilled()).resolves.toBe(true);
+    });
+
+    it('AsyncStorage false 저장 → false', async () => {
+      mockedGetItem.mockResolvedValueOnce(JSON.stringify(false));
+      await expect(isAlarmsKilled()).resolves.toBe(false);
+    });
+
+    it('AsyncStorage 비어있으면 false (default)', async () => {
+      mockedGetItem.mockResolvedValueOnce(null);
+      await expect(isAlarmsKilled()).resolves.toBe(false);
+    });
+
+    it('AsyncStorage 오류 시 false (fail-open으로 일관성 유지)', async () => {
+      mockedGetItem.mockRejectedValueOnce(new Error('storage'));
+      await expect(isAlarmsKilled()).resolves.toBe(false);
+    });
+
+    it('JSON 파싱 실패도 false', async () => {
+      mockedGetItem.mockResolvedValueOnce('not-json{');
+      await expect(isAlarmsKilled()).resolves.toBe(false);
+    });
+  });
+});

--- a/src/utils/__tests__/alarmSound.test.ts
+++ b/src/utils/__tests__/alarmSound.test.ts
@@ -12,12 +12,14 @@ describe('alarmSound', () => {
   });
 
   describe('vibrateAlarm', () => {
-    it('취침 모드: 반복 진동한다', () => {
+    it('취침 모드: 반복 진동 + 5초 뒤 자동 중지 (#623 잠금화면 dismiss 무력 회피)', () => {
       const cancelSpy = jest.spyOn(Vibration, 'cancel');
       const vibrateSpy = jest.spyOn(Vibration, 'vibrate');
       vibrateAlarm(true);
-      expect(cancelSpy).toHaveBeenCalled();
       expect(vibrateSpy).toHaveBeenCalledWith([0, 1000, 500, 1000, 500, 1000], true);
+      cancelSpy.mockClear();
+      jest.advanceTimersByTime(5000);
+      expect(cancelSpy).toHaveBeenCalled();
     });
 
     it('일반 모드: 1회 진동 후 5초 뒤 중지한다', () => {

--- a/src/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/utils/__tests__/boardingLockScheduler.test.ts
@@ -38,6 +38,9 @@ jest.mock('../stationNotification', () => ({
     body: `B:${event.stationName}`,
   }),
 }));
+jest.mock('../alarmKill', () => ({
+  isAlarmsKilled: jest.fn().mockResolvedValue(false),
+}));
 
 const mockedSchedule = Notifications.scheduleNotificationAsync as jest.MockedFunction<
   typeof Notifications.scheduleNotificationAsync
@@ -153,6 +156,27 @@ describe('boardingLockAlarmIdentifier / parse', () => {
 });
 
 describe('scheduleHopsForLock', () => {
+  it('#623 alarmsKilled=true면 schedule skip + 빈 배열 반환', async () => {
+    const { isAlarmsKilled } = jest.requireMock('../alarmKill');
+    isAlarmsKilled.mockResolvedValueOnce(true);
+    const ids = await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
+    expect(ids).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('#623 루프 중간에 alarmsKilled 토글되면 더 이상 예약 안 함', async () => {
+    const { isAlarmsKilled } = jest.requireMock('../alarmKill');
+    // 1) 진입 가드 통과 → 2) 첫 hop 직전 가드 통과 → 3) 두 번째 hop 직전 ON으로 break.
+    isAlarmsKilled
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    // transferRoute = 2 hops; 첫 hop만 schedule되고 두 번째는 break
+    await scheduleHopsForLock({ lock, route: transferRoute, destinationName: '오금' });
+    // early + imminent 2개만 등록 (첫 hop만)
+    expect(mockedSchedule).toHaveBeenCalledTimes(2);
+  });
+
   it('direct route: destination waypoint 1개를 예약, early+imminent 모두 발사', async () => {
     await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
 
@@ -291,6 +315,37 @@ describe('purgeBoardingLockSchedulerQueue', () => {
 });
 
 describe('advanceHopWindow', () => {
+  it('#623 alarmsKilled=true면 no-op', async () => {
+    const { isAlarmsKilled } = jest.requireMock('../alarmKill');
+    isAlarmsKilled.mockResolvedValueOnce(true);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+    });
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('#623 advance 루프 중간 토글: 첫 hop만 예약 후 break', async () => {
+    const { isAlarmsKilled } = jest.requireMock('../alarmKill');
+    // 진입 가드 false → 첫 iter false(schedule) → 둘째 iter true(break)
+    isAlarmsKilled
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mockedGet.mockResolvedValueOnce([]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+    });
+    // passedIndex=0 → window [1..3]. 첫 hop(1) early+imminent 2건만
+    expect(mockedSchedule).toHaveBeenCalledTimes(2);
+  });
+
   it('passedStationName이 route에 없으면 no-op', async () => {
     await advanceHopWindow({
       lock,

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -48,6 +48,9 @@ jest.mock('../../../modules/live-activity', () => ({
 }));
 
 const mockHasFiredPushId = jest.fn();
+jest.mock('../alarmKill', () => ({
+  isAlarmsKilled: jest.fn().mockResolvedValue(false),
+}));
 jest.mock('../firedPushIds', () => ({
   hasFiredPushId: (...args: unknown[]) => mockHasFiredPushId(...args),
 }));
@@ -658,6 +661,15 @@ describe('stationNotification', () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification(imminentDest, true);
       expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
+    });
+
+    it('#623 alarmsKilled=true면 schedule/vibrate 모두 skip', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      const { isAlarmsKilled } = jest.requireMock('../alarmKill');
+      isAlarmsKilled.mockResolvedValueOnce(true);
+      await sendAlarmNotification(earlyDest);
+      expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockVibrateAlarm).not.toHaveBeenCalled();
     });
 
     it('imminent + Android에서는 channelId와 priority MAX가 포함된다', async () => {

--- a/src/utils/alarmKill.ts
+++ b/src/utils/alarmKill.ts
@@ -1,0 +1,53 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
+import { stopVibration } from './alarmSound';
+import { createLogger } from './logger';
+import { ALARMS_KILLED_KEY } from '../constants/storageKeys';
+
+const logger = createLogger('AlarmKill');
+
+/**
+ * 모든 알람 fire/schedule 경로가 진입 직전에 호출하는 가드.
+ * true면 호출자는 즉시 return — 알림/예약/진동 모두 발생 안 함.
+ *
+ * #623 review P0-2: AsyncStorage 직접 read.
+ *  - BG silent push handler는 별도 JS context라 Zustand in-memory store가 hydration 안 됨.
+ *  - 사용자 "100% 차단" 약속을 BG에서도 지키려면 영속 저장소를 SSOT로.
+ *  - 실패 시 false fallback — kill switch off 측 안전(잘못 차단보다 일관성 우선).
+ */
+export async function isAlarmsKilled(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(ALARMS_KILLED_KEY);
+    return raw != null && JSON.parse(raw) === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * #623 — 모든 알람 채널 즉시 차단.
+ *
+ *  1) 진동 중단 (Vibration.cancel)
+ *  2) 발사된 알림 전체 dismiss
+ *  3) 예약된 알림 전체 cancel
+ *
+ * 호출은 fire-and-forget; 각 단계 실패는 로그만 남기고 다음 단계 진행한다 —
+ * 한 채널이 죽어도 나머지가 정리되도록.
+ */
+export async function killAllAlarms(): Promise<void> {
+  try {
+    stopVibration();
+  } catch (e) {
+    logger.warn('stopVibration 실패:', e);
+  }
+  try {
+    await Notifications.dismissAllNotificationsAsync();
+  } catch (e) {
+    logger.warn('dismissAllNotificationsAsync 실패:', e);
+  }
+  try {
+    await Notifications.cancelAllScheduledNotificationsAsync();
+  } catch (e) {
+    logger.warn('cancelAllScheduledNotificationsAsync 실패:', e);
+  }
+}

--- a/src/utils/alarmSound.ts
+++ b/src/utils/alarmSound.ts
@@ -1,14 +1,15 @@
 import { Vibration } from 'react-native';
 
 const VIBRATION_PATTERN = [0, 1000, 500, 1000, 500, 1000];
+// 잠금화면 swipe-dismiss는 iOS가 JS bridge를 깨우지 않아 외부에서 진동을 멈출 신호가 없다(#623).
+// 따라서 sleepMode 여부와 무관하게 항상 cap을 걸어 자동 종료 보장. AlarmOverlay/listener는
+// 추가 안전망일 뿐 — 진동 종료 약속의 SSOT는 이 timeout.
 const VIBRATION_DURATION_MS = 5000;
 
 export function vibrateAlarm(sleepMode: boolean): void {
   Vibration.cancel();
   Vibration.vibrate(VIBRATION_PATTERN, sleepMode);
-  if (!sleepMode) {
-    setTimeout(() => Vibration.cancel(), VIBRATION_DURATION_MS);
-  }
+  setTimeout(() => Vibration.cancel(), VIBRATION_DURATION_MS);
 }
 
 export function stopVibration(): void {

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -13,6 +13,7 @@ import {
 } from './scheduledNotificationsStorage';
 import { createLogger } from './logger';
 import { HOP_TIME_MS } from '../constants/boardingLock';
+import { isAlarmsKilled } from './alarmKill';
 
 const logger = createLogger('BoardingLockScheduler');
 
@@ -182,6 +183,10 @@ export interface ScheduleHopsParams {
  * 과거 시각으로 산출되는 알람은 skip. waypoint stops=0(이미 도착)인 경우도 skip된다 (lead 차감 후 ≤0).
  */
 export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<string[]> {
+  if (await isAlarmsKilled()) {
+    logger.info('알람 차단됨 (alarmsKilled) — schedule skip');
+    return [];
+  }
   const { lock, route, destinationName, now, windowSize = DEFAULT_WINDOW_SIZE } = params;
   const observedMs = now ?? lock.boardedAt;
   const allTargets = resolveAllTargets(route, destinationName);
@@ -189,6 +194,8 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
 
   const scheduledIds: string[] = [];
   for (let hopIndex = 0; hopIndex < lastIdx; hopIndex++) {
+    // 루프 도중 사용자가 kill switch ON 했을 수 있다 — 매 iteration마다 재확인.
+    if (await isAlarmsKilled()) break;
     const ids = await scheduleSingleHop({
       lock,
       target: allTargets[hopIndex],
@@ -263,6 +270,10 @@ export interface AdvanceHopWindowParams {
  * PR C에서는 정의만 — 호출자(Fusion station-pass)는 PR D에서 연결.
  */
 export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<void> {
+  if (await isAlarmsKilled()) {
+    logger.info('알람 차단됨 (alarmsKilled) — advance skip');
+    return;
+  }
   const { lock, route, destinationName, passedStationName, now, windowSize = DEFAULT_WINDOW_SIZE } =
     params;
 
@@ -296,6 +307,7 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   const windowEnd = Math.min(passedIndex + windowSize, allTargets.length - 1);
   for (let hopIndex = passedIndex + 1; hopIndex <= windowEnd; hopIndex++) {
     if (existingHopIndexes.has(hopIndex)) continue;
+    if (await isAlarmsKilled()) break;
     const ids = await scheduleSingleHop({
       lock,
       target: allTargets[hopIndex],

--- a/src/utils/stationNotification.ts
+++ b/src/utils/stationNotification.ts
@@ -13,6 +13,7 @@ import { createLogger } from './logger';
 import { getStationDisplayName, getStationDisplayNameByName } from './stationDisplay';
 import { saveStationToWidget, clearWidgetStation } from './widgetStorage';
 import { hasFiredPushId } from './firedPushIds';
+import { isAlarmsKilled } from './alarmKill';
 import stationsData from '../data/stations.json';
 import type { ExitSide } from '../types/exitSide';
 import { lookupExitSide } from './exitSide';
@@ -508,6 +509,10 @@ export async function sendAlarmNotification(
   allowSpeaker: boolean = true,
   source?: NotificationSource,
 ): Promise<void> {
+  if (await isAlarmsKilled()) {
+    notifLogger.info('알람 차단됨 (alarmsKilled) — 발사 skip');
+    return;
+  }
   const { title, body } = buildAlarmContent(event, source);
 
   await scheduleNotification(ALARM_NOTIFICATION_ID, {


### PR DESCRIPTION
## Summary
- "알람 끄기" 글로벌 토글 — ON 시 모든 알림/진동/예약 즉시 차단 + 모든 fire/schedule 경로 가드
- 잠금화면 swipe-dismiss 시 진동 종료 보장 — \`vibrateAlarm\` 5s cap (sleepMode 포함)
- BG silent push handler도 가드 — \`isAlarmsKilled\`를 AsyncStorage 기반 async로 (BG context Zustand 미hydration 회피)

## Test plan
- [x] \`npm test\` (137 suites, 2125 tests, 100% coverage)
- [x] \`npm run type-check\`
- [x] code-review agent P0/P1 반영:
  - P0-1: vibration 5s cap (잠금화면 swipe-dismiss는 OS 한계로 listener 도달 불가)
  - P0-2: isAlarmsKilled async — BG에서도 AsyncStorage SSOT
  - P1-2: schedule 루프 중간 토글 시 break
- [ ] 실기기: 알람 끄기 ON → 진동/예약/silent push 전부 차단 (사용자 검증)
- [ ] 실기기: 알람 발사 후 잠금화면에서 5초 안에 자동 정지 (사용자 검증)

Closes #623