### PR TITLE
fix(#624): BG에서도 waypoint 통과 시 사전예약 알람 능동 cancel

### DIFF
--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -22,7 +22,7 @@ jest.mock('../stationRoute', () => ({
 
 const mockEvaluateAlarmPhase = jest.fn();
 const mockAlarmKey = jest.fn();
-const mockResolveAllTargets = jest.fn(() => []);
+const mockResolveAllTargets = jest.fn((..._args: unknown[]) => [] as Array<{ name: string; stops: number; alarmType: 'destination' | 'transfer'; approachLine: string }>);
 jest.mock('../stationAlarm', () => ({
   evaluateAlarmPhase: (...args: unknown[]) => mockEvaluateAlarmPhase(...args),
   alarmKey: (...args: unknown[]) => mockAlarmKey(...args),

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -11,18 +11,32 @@ const mockFindRoute = jest.fn();
 const mockCalculateStaticETA = jest.fn();
 const mockUpdateRouteFromPosition = jest.fn();
 const mockIsStationOnRoute = jest.fn();
+const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
 jest.mock('../stationRoute', () => ({
   findRoute: (...args: unknown[]) => mockFindRoute(...args),
   calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
   updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
   isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
+  isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
 }));
 
 const mockEvaluateAlarmPhase = jest.fn();
 const mockAlarmKey = jest.fn();
+const mockResolveAllTargets = jest.fn(() => []);
 jest.mock('../stationAlarm', () => ({
   evaluateAlarmPhase: (...args: unknown[]) => mockEvaluateAlarmPhase(...args),
   alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
+  resolveAllTargets: (...args: unknown[]) => mockResolveAllTargets(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../boardingLockStorage', () => ({
+  getBoardingLock: () => mockGetBoardingLock(),
+}));
+
+const mockAdvanceHopWindow = jest.fn().mockResolvedValue(undefined);
+jest.mock('../boardingLockScheduler', () => ({
+  advanceHopWindow: (...args: unknown[]) => mockAdvanceHopWindow(...args),
 }));
 
 const mockSendAlarmNotification = jest.fn();
@@ -373,6 +387,61 @@ describe('processLocationUpdate', () => {
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
+  });
+
+  describe('#624 BG-safe stale alarm cancel (BoardingLock advance)', () => {
+    const mockLock = {
+      destinationId: 'station-2',
+      trainCode: 'T-100',
+      boardingStationId: 'station-0',
+      boardingLine: '2',
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+
+    it('lock 있고 nearest station이 waypoint이면 advanceHopWindow 호출', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetLastNotifiedStationId.mockResolvedValue('other-station');
+      mockGetBoardingLock.mockResolvedValue(mockLock);
+      mockResolveAllTargets.mockReturnValue([
+        { name: '강남', stops: 1, alarmType: 'destination', approachLine: '2' },
+      ]);
+
+      await call();
+
+      expect(mockAdvanceHopWindow).toHaveBeenCalledWith({
+        lock: mockLock,
+        route: mockRoute,
+        destinationName: '시청',
+        passedStationName: '강남',
+      });
+    });
+
+    it('lock 있고 nearest가 waypoint가 아니면 advanceHopWindow 호출 안 함 (no-op)', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetLastNotifiedStationId.mockResolvedValue('other-station');
+      mockGetBoardingLock.mockResolvedValue(mockLock);
+      mockResolveAllTargets.mockReturnValue([
+        { name: '다른역', stops: 1, alarmType: 'destination', approachLine: '2' },
+      ]);
+
+      await call();
+
+      expect(mockAdvanceHopWindow).not.toHaveBeenCalled();
+    });
+
+    it('lock 없으면 advanceHopWindow 호출 안 함', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetLastNotifiedStationId.mockResolvedValue('other-station');
+      mockGetBoardingLock.mockResolvedValue(null);
+
+      await call();
+
+      expect(mockAdvanceHopWindow).not.toHaveBeenCalled();
+    });
   });
 
   it('findNearestStation을 MAX_STATION_DISTANCE_KM(1.0)와 함께 호출한다', async () => {

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -1,8 +1,10 @@
 import { findNearestStation } from './findNearestStation';
-import { findRoute, calculateStaticETA, isStationOnRoute, updateRouteFromPosition } from './stationRoute';
-import { evaluateAlarmPhase } from './stationAlarm';
+import { findRoute, calculateStaticETA, isSameStationName, isStationOnRoute, updateRouteFromPosition } from './stationRoute';
+import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
 import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
 import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
+import { advanceHopWindow } from './boardingLockScheduler';
+import { getBoardingLock } from './boardingLockStorage';
 import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificationState';
 import {
   logFiredAlarm,
@@ -178,6 +180,26 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         );
         await setLastNotifiedStationId(nearest.station.id);
         logFiredStationPassed(source, nearest.station);
+
+        // #624 BG-safe stale alarm 차단 — 통과한 waypoint의 pre-scheduled bl:* 알람을
+        // 능동 cancel. useBoardingLockAdvancer는 FG only(React hook)지만 stationPipeline은
+        // backgroundLocationTask에서도 호출되어 BG에서도 동일 청소가 일어난다.
+        // advanceHopWindow는 idempotent — FG advancer와 중복 호출돼도 안전.
+        // dedup 가드(lastNotifiedStationId) 안쪽에 위치 — 동일 station 재보고 시
+        // reentrant advance 방지. dedup 구조 리팩터 시 advance가 silent하게 사라지지 않게 주의.
+        const lock = await getBoardingLock();
+        if (lock && route) {
+          const targets = resolveAllTargets(route, destination.name);
+          const matched = targets.find((t) => isSameStationName(t.name, nearest.station.name));
+          if (matched) {
+            await advanceHopWindow({
+              lock,
+              route,
+              destinationName: destination.name,
+              passedStationName: matched.name,
+            });
+          }
+        }
       }
     } else {
       logSuppressedDedupStation(source, nearest.station);


### PR DESCRIPTION
## Summary
- stationPipeline에 BoardingLock advance 호출 추가 — FG/BG 모두 호출되는 경로
- 통과한 waypoint의 \`bl:*\` 사전예약 알람이 OS 발사 전 cancel → "이미 도착했는데 imminent 알람 늦게" 회귀 차단 (BG 포함)
- 기존 \`useBoardingLockAdvancer\`(FG only)는 redundant safety로 유지. \`advanceHopWindow\` idempotent

## 폐기 + 재설계 경위
종전 단기 가드(setNotificationHandler에 stale suppress)는 리뷰에서 결함 발견:
- \`handleNotification\`은 FG에서만 호출 → 잠금화면 BG 발사라는 표적 시나리오에 정확히 무력
- 100% coverage여도 cosmetic
- 폐기 후 BG-safe 경로(stationPipeline)에 능동 cancel 방식으로 재설계

## Test plan
- [x] \`npm test\` (137 suites, 2132 tests, 100% coverage)
- [x] \`npm run type-check\`
- [x] code-review agent: P0/P1 없음, 머지 가능 판정
- [ ] 실기기: 잠금 상태에서 waypoint 통과 시 stale imminent 안 뜨는지 확인

## 한계 (후속)
- 중간역(non-waypoint) 통과는 advance 트리거 안 함 — arc position 기반 재추정은 BoardingLock interpolation(#621)과 묶어 후속 이슈

Closes #624