### PR TITLE
feat(#625): 탑승 카드를 route 컨텍스트 안으로 이동 + 절대 시각 HH:mm

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -639,6 +639,16 @@ export default function HomeScreen() {
                       </Text>
                     </Pressable>
                   )}
+                  {/* #625 — BoardingLock/MisBoarding 배너는 route 컨텍스트 안에서 노출.
+                       종전에는 sleep mode toggle 아래라 사용자가 route와 별도 카드로 인지하지
+                       못함 + 너무 멀리 떨어져 있었음. 이제 경로 표시 직후로 이동.
+                       외곽 {destination && ...} 가드 안쪽이라 destination 재가드 불필요. */}
+                  {boardingLock && misBoardingDetected && (
+                    <MisBoardingBanner onReselect={releaseBoardingLock} />
+                  )}
+                  {boardingLock && (
+                    <BoardingLockBanner lock={boardingLock} onRelease={releaseBoardingLock} />
+                  )}
                 </View>
 
                 {/* Actions */}
@@ -735,13 +745,8 @@ export default function HomeScreen() {
             )}
 
             {/* Arrivals — 현재역(effectiveOrigin)이 확정되면 trip 유무와 무관하게 노출 */}
-            {/* #584 PR B — BoardingLock 진입점. 활성 시 banner, 비활성 + destination 설정 시 train list. */}
-            {destination && boardingLock && misBoardingDetected && (
-              <MisBoardingBanner onReselect={releaseBoardingLock} />
-            )}
-            {destination && boardingLock && (
-              <BoardingLockBanner lock={boardingLock} onRelease={releaseBoardingLock} />
-            )}
+            {/* #584 PR B — BoardingLock 진입점. #625에서 banner는 route 컨텍스트로 이동.
+                활성 lock 시 train list는 노출 안 함. */}
             {destination && !boardingLock && effectiveOrigin && (
               <BoardingTrainList
                 arrivals={directionalArrivals}

--- a/src/components/BoardingLockBanner.tsx
+++ b/src/components/BoardingLockBanner.tsx
@@ -3,6 +3,7 @@ import { useTheme, typography, spacing } from '../theme';
 import { LineBadge } from './LineBadge';
 import { ActionBanner } from './ActionBanner';
 import type { BoardingLock } from '../types/boardingLock';
+import { formatClockTime } from '../utils/formatTime';
 
 interface Props {
   lock: BoardingLock;
@@ -10,10 +11,10 @@ interface Props {
 }
 
 /**
- * BoardingLock 활성 시 노출되는 배너 (#584 PR B).
+ * BoardingLock 활성 시 노출되는 배너 (#584 PR B / #625 컴팩트 + 절대 시각).
  *
- * 사용자에게 어떤 열차/노선에 lock 되어 있는지 명시. "하차" 탭으로 즉시 release.
- * 공통 레이아웃은 ActionBanner 슬롯 패턴으로 위임 (#584 PR D3 Sonar 중복 해소).
+ * "탑승" 라벨 + 노선/trainCode + 탑승 시각(HH:mm) + "하차" 액션.
+ * 시간은 0분/1분 같은 상대 표기 대신 사용자가 익숙한 절대 시각(#625) — 자기 시계와 매칭 용이.
  */
 export function BoardingLockBanner({ lock, onRelease }: Props) {
   const { colors } = useTheme();
@@ -25,10 +26,14 @@ export function BoardingLockBanner({ lock, onRelease }: Props) {
       onActionPress={onRelease}
       actionTestID="boarding-lock-release"
     >
-      <Text style={[typography.label, { color: colors.muted }]}>탑승 중</Text>
       <View style={styles.row}>
+        <Text style={[typography.label, { color: colors.muted }]}>탑승</Text>
         <LineBadge line={lock.boardingLine} />
         <Text style={[typography.mono, { color: colors.ink }]}>{lock.trainCode}</Text>
+        <Text style={[typography.mono, { color: colors.muted }]}>·</Text>
+        <Text style={[typography.mono, { color: colors.ink }]} testID="boarding-lock-time">
+          {formatClockTime(lock.boardedAt)}
+        </Text>
       </View>
     </ActionBanner>
   );

--- a/src/components/__tests__/BoardingLockBanner.test.tsx
+++ b/src/components/__tests__/BoardingLockBanner.test.tsx
@@ -19,7 +19,16 @@ describe('BoardingLockBanner', () => {
     );
     expect(getByTestId('boarding-lock-banner')).toBeTruthy();
     expect(getByText('T-100')).toBeTruthy();
-    expect(getByText('탑승 중')).toBeTruthy();
+    expect(getByText('탑승')).toBeTruthy();
+  });
+
+  it('#625 탑승 시각(boardedAt)을 HH:mm 절대 시각으로 표시', () => {
+    const { getByTestId } = renderWithTheme(
+      <BoardingLockBanner lock={lock} onRelease={() => {}} />,
+    );
+    const d = new Date(1_700_000_000_000);
+    const expected = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+    expect(getByTestId('boarding-lock-time').props.children).toBe(expected);
   });
 
   it('하차 버튼 탭 시 onRelease 호출', () => {

--- a/src/utils/__tests__/formatTime.test.ts
+++ b/src/utils/__tests__/formatTime.test.ts
@@ -1,4 +1,4 @@
-import { formatArrivalTime } from '../formatTime';
+import { formatArrivalTime, formatClockTime } from '../formatTime';
 
 describe('formatArrivalTime', () => {
   it('0초 이하이면 "곧 도착"을 반환한다', () => {
@@ -17,5 +17,21 @@ describe('formatArrivalTime', () => {
     expect(formatArrivalTime(90)).toBe('1분 30초');
     expect(formatArrivalTime(150)).toBe('2분 30초');
     expect(formatArrivalTime(300)).toBe('5분 0초');
+  });
+});
+
+describe('formatClockTime (#625)', () => {
+  it('HH:mm 24h 포맷, zero-padded', () => {
+    // 디바이스 timezone에 의존하므로 같은 epoch ms를 Date()로 환산해 비교.
+    const epoch = 1_700_000_000_000;
+    const d = new Date(epoch);
+    const expected = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+    expect(formatClockTime(epoch)).toBe(expected);
+  });
+
+  it('한 자리 시/분도 두 자리로 패딩', () => {
+    // 2026-01-01T03:05:00 UTC 같은 시각을 timezone-agnostic하게 검증.
+    const d = new Date(2026, 0, 1, 3, 5);
+    expect(formatClockTime(d.getTime())).toBe('03:05');
   });
 });

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -7,3 +7,15 @@ export function formatArrivalTime(seconds: number): string {
   if (min === 0) return i18next.t('time.seconds', { sec });
   return i18next.t('time.minutesAndSeconds', { min, sec });
 }
+
+/**
+ * epoch ms → "HH:mm" (24h, zero-padded). 사용자가 익숙한 절대 시각 표시 (#625).
+ * 디바이스 로컬 timezone 사용 — react-i18next의 locale-aware 포맷터는 다국어 의존을
+ * 늘리는데 비해 HH:mm은 모든 지원 언어에서 동일 표기.
+ */
+export function formatClockTime(epochMs: number): string {
+  const d = new Date(epochMs);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}


### PR DESCRIPTION
## Summary
- BoardingLockBanner를 sleep mode toggle 아래에서 route 박스 안으로 이동 (View on Map 직후)
- 단일 행 컴팩트 레이아웃: \`[탑승] [노선] trainCode · HH:mm · 하차\`
- 탑승 시각(boardedAt) HH:mm 절대 표기 — 사용자 시계와 직접 매칭

## Test plan
- [x] \`npm test\` (138 suites, 2153 tests, 100% coverage)
- [x] \`npm run type-check\`
- [x] code-review: P0/P1 없음, P2(layout cleanup) 반영
- [ ] 실기기: iPhone SE(375pt)에서 단일 행 wrap 여부 확인 (사용자)
- [ ] 실기기: 탑승 시각이 자기 시계와 일치하는지 확인

## 후속
- BoardingLockBanner "탑승" 라벨 i18n 분리는 별도 이슈 (기존 "탑승 중"도 하드코딩이었음)
- index.tsx integration test 추가는 별도 작업

Closes #625