### PR TITLE
refactor(#626): dedup-alarm 로그 5초 윈도우로 FG 폴링 스팸 차단

### DIFF
--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -8,6 +8,8 @@ import {
   logScheduledAlarm,
   logFiredAlarmsHydrate,
   logSuppressedDedupAlarm,
+  _resetDedupAlarmWindowForTests,
+  DEDUP_LOG_WINDOW_MS,
   logSuppressedDedupStation,
   logSuppressedGate,
   logSilentPushReceived,
@@ -58,6 +60,7 @@ describe('alarmLog', () => {
     jest.clearAllMocks();
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
     (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+    _resetDedupAlarmWindowForTests();
   });
 
   describe('appendAlarmLog', () => {
@@ -244,6 +247,69 @@ describe('alarmLog', () => {
         kind: 'destination',
         phaseId: 'early',
       });
+    });
+
+    it('#626 같은 키 윈도우 내 재호출은 drop (FG polling 매초 평가 스팸 차단)', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      try {
+        logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
+        await flushPromises();
+        const callsAfterFirst = (AsyncStorage.setItem as jest.Mock).mock.calls.length;
+
+        // 윈도우 내 재호출 — drop
+        nowSpy.mockReturnValue(baseTs + DEDUP_LOG_WINDOW_MS - 1);
+        logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
+        await flushPromises();
+        expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsAfterFirst);
+
+        // 윈도우 경계 통과 — 통과
+        nowSpy.mockReturnValue(baseTs + DEDUP_LOG_WINDOW_MS + 1);
+        logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
+        await flushPromises();
+        expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsAfterFirst + 1);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('#626 다른 키(source/type/phase/station)는 별개 윈도우 — 모두 통과', async () => {
+      logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
+      logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'transfer', stationName: '강남' });
+      logSuppressedDedupAlarm('fg', { phaseId: 'imminent', type: 'destination', stationName: '강남' });
+      logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '역삼' });
+      logSuppressedDedupAlarm('bg', { phaseId: 'early', type: 'destination', stationName: '강남' });
+      await flushPromises();
+      expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(5);
+    });
+
+    it('#626 Map cap 초과 시 만료된 엔트리 sweep — 무한 성장 방지', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      try {
+        // cap(64)보다 많은 고유 키 적재 — 모두 첫 호출이므로 통과.
+        for (let i = 0; i < 70; i++) {
+          logSuppressedDedupAlarm('fg', {
+            phaseId: 'early',
+            type: 'destination',
+            stationName: `s${i}`,
+          });
+        }
+        await flushPromises();
+        const callsBefore = (AsyncStorage.setItem as jest.Mock).mock.calls.length;
+
+        // 윈도우 충분히 넘긴 후 새 키 1개 → sweep 발동, 기존 만료 엔트리 정리.
+        nowSpy.mockReturnValue(baseTs + DEDUP_LOG_WINDOW_MS * 2);
+        logSuppressedDedupAlarm('fg', {
+          phaseId: 'early',
+          type: 'destination',
+          stationName: 's-after',
+        });
+        await flushPromises();
+        expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it('logFiredAlarmsHydrate: destinationId + firedAlarmsCount 적재 (#580 race 진단)', async () => {

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -200,13 +200,42 @@ export function logFiredAlarmsHydrate(destinationId: string | null, firedAlarmsC
  * #580: phase alarm dedup 적중 1건 적재. destination/transfer phase가 firedAlarms로
  * 이미 발화된 것을 evaluateAlarmPhase가 인지해 재발화하지 않을 때 호출.
  * 발사 횟수 vs dedup 횟수 비율로 dedup이 정상 동작 중인지 운영 데이터로 확인 가능.
+ *
+ * #626: in-memory time-window dedup. FG polling cycle이 매초 같은 phase를 평가해
+ * dedup-alarm 로그가 alarmLog 버퍼를 채우는 회귀 차단 (alarmLog 46개 중 41개가 같은
+ * 이벤트인 케이스 관측). 같은 (source/type/phaseId/stationName)이 DEDUP_LOG_WINDOW_MS
+ * 안에 재호출되면 drop — dedup이 동작 중인지 운영 신호는 첫 1건으로 충분.
+ *
+ * 키에 type 포함 — 환승역에서 같은 phaseId가 destination/transfer 두 type으로 동시
+ * 평가될 때 한쪽이 다른 쪽을 silence하지 않게 (실제 firedAlarms도 type까지 구분함).
  */
+export const DEDUP_LOG_WINDOW_MS = 5_000;
+const lastDedupLogTs = new Map<string, number>();
+
+/**
+ * Map 무한 성장 방지. size가 cap을 넘으면 윈도우 만료된 엔트리 일괄 정리.
+ * 정상 trip(소스 × type × phase × 역 ~수십)에선 트리거 안 됨 — 비정상 입력 안전망.
+ */
+const DEDUP_LOG_MAP_CAP = 64;
+function sweepExpiredDedupEntries(now: number): void {
+  if (lastDedupLogTs.size <= DEDUP_LOG_MAP_CAP) return;
+  for (const [k, ts] of lastDedupLogTs) {
+    if (now - ts >= DEDUP_LOG_WINDOW_MS) lastDedupLogTs.delete(k);
+  }
+}
+
 export function logSuppressedDedupAlarm(
   source: AlarmLogSource,
   event: Pick<AlarmEvent, 'phaseId' | 'type' | 'stationName'>,
 ): void {
+  const now = Date.now();
+  const key = `${source}|${event.type}|${event.phaseId}|${event.stationName}`;
+  const last = lastDedupLogTs.get(key);
+  if (last !== undefined && now - last < DEDUP_LOG_WINDOW_MS) return;
+  lastDedupLogTs.set(key, now);
+  sweepExpiredDedupEntries(now);
   void appendAlarmLog({
-    ts: Date.now(),
+    ts: now,
     source,
     outcome: 'suppressed',
     reason: 'dedup-alarm',
@@ -214,6 +243,11 @@ export function logSuppressedDedupAlarm(
     kind: event.type,
     phaseId: event.phaseId,
   });
+}
+
+/** 테스트용 — 윈도우 캐시 리셋. */
+export function _resetDedupAlarmWindowForTests(): void {
+  lastDedupLogTs.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary
- \`logSuppressedDedupAlarm\`에 5초 in-memory time-window dedup 추가
- 같은 (source/type/phaseId/stationName) 키가 윈도우 안에 재호출되면 drop
- alarmLog 46개 중 41개가 동일 이벤트(\`fg suppressed dedup-alarm destination early 성수\`)로 채워지던 회귀 해결
- Map cap(64) + 만료 엔트리 sweep으로 무한 성장 방지

## Test plan
- [x] \`npm test\` (138 suites, 2153 tests, 100% coverage)
- [x] \`npm run type-check\`
- [x] code-review: 머지 가능 (P0/P1 없음), P2 (export 상수/Map cap/type 키) 모두 반영
- [ ] 실기기: alarmLog가 의미 있는 이벤트로만 채워지는지 확인

Closes #626