### PR TITLE
fix(#632): 탑승 직후 환승+sleep 알람 skip

### DIFF
--- a/src/hooks/__tests__/useBoardingLockAdvancer.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockAdvancer.test.tsx
@@ -3,6 +3,7 @@ import { useBoardingLockAdvancer } from '../useBoardingLockAdvancer';
 import { advanceHopWindow } from '../../utils/boardingLockScheduler';
 import type { BoardingLock } from '../../types/boardingLock';
 import type { DirectRoute, TransferRoute } from '../../utils/stationRoute';
+import { useAppStore } from '../../store/useAppStore';
 
 jest.mock('../../utils/boardingLockScheduler', () => ({
   advanceHopWindow: jest.fn(),
@@ -44,6 +45,7 @@ type Props = Parameters<typeof useBoardingLockAdvancer>[0];
 beforeEach(() => {
   jest.clearAllMocks();
   mockedAdvance.mockResolvedValue(undefined);
+  useAppStore.setState({ sleepMode: false });
 });
 
 describe('useBoardingLockAdvancer', () => {
@@ -127,6 +129,7 @@ describe('useBoardingLockAdvancer', () => {
         route: directRoute,
         destinationName: '강남',
         passedStationName: '강남',
+        sleepMode: false,
       });
     });
   });
@@ -146,6 +149,7 @@ describe('useBoardingLockAdvancer', () => {
         route: transferRoute,
         destinationName: '명동',
         passedStationName: '사당',
+        sleepMode: false,
       });
     });
   });
@@ -200,6 +204,7 @@ describe('useBoardingLockAdvancer', () => {
       route: transferRoute,
       destinationName: '명동',
       passedStationName: '명동',
+      sleepMode: false,
     });
   });
 
@@ -228,6 +233,7 @@ describe('useBoardingLockAdvancer', () => {
       route: directRoute,
       destinationName: '강남',
       passedStationName: '강남',
+      sleepMode: false,
     });
   });
 
@@ -248,6 +254,28 @@ describe('useBoardingLockAdvancer', () => {
         destinationName: '상봉',
         // resolveAllTargets가 보유한 정식 이름(=destinationName 그대로)을 전달.
         passedStationName: '상봉',
+        sleepMode: false,
+      });
+    });
+  });
+
+  it('#632 sleepMode=true 상태에서 advance 호출에 sleepMode=true 전달', async () => {
+    useAppStore.setState({ sleepMode: true });
+    renderHook(() =>
+      useBoardingLockAdvancer({
+        lock: lockA,
+        route: transferRoute,
+        destinationName: '명동',
+        currentStationName: '사당',
+      }),
+    );
+    await waitFor(() => {
+      expect(mockedAdvance).toHaveBeenCalledWith({
+        lock: lockA,
+        route: transferRoute,
+        destinationName: '명동',
+        passedStationName: '사당',
+        sleepMode: true,
       });
     });
   });

--- a/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../utils/boardingLockScheduler';
 import type { BoardingLock } from '../../types/boardingLock';
 import type { DirectRoute } from '../../utils/stationRoute';
+import { useAppStore } from '../../store/useAppStore';
 
 jest.mock('../../utils/boardingLockScheduler', () => ({
   scheduleHopsForLock: jest.fn(),
@@ -39,6 +40,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockedSchedule.mockResolvedValue([]);
   mockedCancel.mockResolvedValue(undefined);
+  useAppStore.setState({ sleepMode: false });
 });
 
 describe('useBoardingLockScheduler', () => {
@@ -61,6 +63,7 @@ describe('useBoardingLockScheduler', () => {
         lock: lockA,
         route,
         destinationName: '강남',
+        sleepMode: false,
       });
       expect(mockedCancel).not.toHaveBeenCalled();
     });
@@ -94,6 +97,7 @@ describe('useBoardingLockScheduler', () => {
         lock: lockB,
         route,
         destinationName: '강남',
+        sleepMode: false,
       });
     });
   });
@@ -154,5 +158,33 @@ describe('useBoardingLockScheduler', () => {
     );
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('#632 sleepMode=true 상태에서 schedule에 sleepMode=true 전달', async () => {
+    useAppStore.setState({ sleepMode: true });
+    renderHook(() =>
+      useBoardingLockScheduler({ lock: lockA, route, destinationName: '강남' }),
+    );
+    await waitFor(() => {
+      expect(mockedSchedule).toHaveBeenCalledWith({
+        lock: lockA,
+        route,
+        destinationName: '강남',
+        sleepMode: true,
+      });
+    });
+  });
+
+  it('#632 sleepMode 토글은 effect를 재실행시키지 않는다 (ref capture)', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    useAppStore.setState({ sleepMode: true });
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSchedule).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/__tests__/useSleepModeRef.test.ts
+++ b/src/hooks/__tests__/useSleepModeRef.test.ts
@@ -1,0 +1,26 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useSleepModeRef } from '../useSleepModeRef';
+import { useAppStore } from '../../store/useAppStore';
+
+describe('useSleepModeRef', () => {
+  beforeEach(() => {
+    useAppStore.setState({ sleepMode: false });
+  });
+
+  it('현재 sleepMode 값을 ref로 노출한다', () => {
+    useAppStore.setState({ sleepMode: true });
+    const { result } = renderHook(() => useSleepModeRef());
+    expect(result.current.current).toBe(true);
+  });
+
+  it('store sleepMode 변경 시 ref.current가 다음 렌더에서 갱신된다', () => {
+    const { result, rerender } = renderHook(() => useSleepModeRef());
+    expect(result.current.current).toBe(false);
+
+    act(() => {
+      useAppStore.setState({ sleepMode: true });
+    });
+    rerender({});
+    expect(result.current.current).toBe(true);
+  });
+});

--- a/src/hooks/useBoardingLockAdvancer.ts
+++ b/src/hooks/useBoardingLockAdvancer.ts
@@ -5,7 +5,7 @@ import { isSameStationName } from '../utils/stationRoute';
 import { resolveAllTargets } from '../utils/stationAlarm';
 import { advanceHopWindow } from '../utils/boardingLockScheduler';
 import { createLogger } from '../utils/logger';
-import { useAppStore } from '../store/useAppStore';
+import { useSleepModeRef } from './useSleepModeRef';
 
 const logger = createLogger('useBoardingLockAdvancer');
 
@@ -33,11 +33,8 @@ export function useBoardingLockAdvancer({
 }: UseBoardingLockAdvancerInputs): void {
   const lastAdvancedRef = useRef<string | null>(null);
   const lastTrainCodeRef = useRef<string | null>(null);
-  // advance 호출 시점의 sleepMode를 ref로 캡처(#632) — sleepMode 변경이 advance effect를
-  // 재실행시키지 않도록(역 통과 신호에만 반응) 의도적으로 deps에서 제외한다.
-  const sleepMode = useAppStore((s) => s.sleepMode);
-  const sleepModeRef = useRef(sleepMode);
-  sleepModeRef.current = sleepMode;
+  // 역 통과 신호에만 effect가 반응하도록 sleepMode는 ref로 캡처(#632).
+  const sleepModeRef = useSleepModeRef();
 
   useEffect(() => {
     const trainCode = lock?.trainCode ?? null;

--- a/src/hooks/useBoardingLockAdvancer.ts
+++ b/src/hooks/useBoardingLockAdvancer.ts
@@ -5,6 +5,7 @@ import { isSameStationName } from '../utils/stationRoute';
 import { resolveAllTargets } from '../utils/stationAlarm';
 import { advanceHopWindow } from '../utils/boardingLockScheduler';
 import { createLogger } from '../utils/logger';
+import { useAppStore } from '../store/useAppStore';
 
 const logger = createLogger('useBoardingLockAdvancer');
 
@@ -32,6 +33,11 @@ export function useBoardingLockAdvancer({
 }: UseBoardingLockAdvancerInputs): void {
   const lastAdvancedRef = useRef<string | null>(null);
   const lastTrainCodeRef = useRef<string | null>(null);
+  // advance 호출 시점의 sleepMode를 ref로 캡처(#632) — sleepMode 변경이 advance effect를
+  // 재실행시키지 않도록(역 통과 신호에만 반응) 의도적으로 deps에서 제외한다.
+  const sleepMode = useAppStore((s) => s.sleepMode);
+  const sleepModeRef = useRef(sleepMode);
+  sleepModeRef.current = sleepMode;
 
   useEffect(() => {
     const trainCode = lock?.trainCode ?? null;
@@ -53,6 +59,7 @@ export function useBoardingLockAdvancer({
       route,
       destinationName,
       passedStationName: matched.name,
+      sleepMode: sleepModeRef.current,
     }).catch((e: unknown) => {
       logger.error('advanceHopWindow 실패:', e);
     });

--- a/src/hooks/useBoardingLockScheduler.ts
+++ b/src/hooks/useBoardingLockScheduler.ts
@@ -6,7 +6,7 @@ import {
   scheduleHopsForLock,
 } from '../utils/boardingLockScheduler';
 import { createLogger } from '../utils/logger';
-import { useAppStore } from '../store/useAppStore';
+import { useSleepModeRef } from './useSleepModeRef';
 
 const logger = createLogger('useBoardingLockScheduler');
 
@@ -33,12 +33,8 @@ export function useBoardingLockScheduler({
   destinationName,
 }: UseBoardingLockSchedulerInputs): void {
   const prevLockRef = useRef<BoardingLock | null>(null);
-  // schedule 호출 시점의 sleepMode를 캡처해 #632 가드에 사용. ref로 읽어 sleepMode 토글이
-  // 본 effect를 재실행시키지 않게 한다. 탑승 후 사용자가 sleep을 토글해도 이미 예약된 알람은
-  // 그대로 유지되는 trade-off — 토글 기반 재예약이 요구되면 별도 이슈로 분리한다.
-  const sleepMode = useAppStore((s) => s.sleepMode);
-  const sleepModeRef = useRef(sleepMode);
-  sleepModeRef.current = sleepMode;
+  // 이미 예약된 알람은 sleep 토글에 영향받지 않는 trade-off — 토글 기반 재예약이 요구되면 별도 이슈.
+  const sleepModeRef = useSleepModeRef();
 
   useEffect(() => {
     const prev = prevLockRef.current;

--- a/src/hooks/useBoardingLockScheduler.ts
+++ b/src/hooks/useBoardingLockScheduler.ts
@@ -6,6 +6,7 @@ import {
   scheduleHopsForLock,
 } from '../utils/boardingLockScheduler';
 import { createLogger } from '../utils/logger';
+import { useAppStore } from '../store/useAppStore';
 
 const logger = createLogger('useBoardingLockScheduler');
 
@@ -32,6 +33,12 @@ export function useBoardingLockScheduler({
   destinationName,
 }: UseBoardingLockSchedulerInputs): void {
   const prevLockRef = useRef<BoardingLock | null>(null);
+  // schedule 호출 시점의 sleepMode를 캡처해 #632 가드에 사용. ref로 읽어 sleepMode 토글이
+  // 본 effect를 재실행시키지 않게 한다. 탑승 후 사용자가 sleep을 토글해도 이미 예약된 알람은
+  // 그대로 유지되는 trade-off — 토글 기반 재예약이 요구되면 별도 이슈로 분리한다.
+  const sleepMode = useAppStore((s) => s.sleepMode);
+  const sleepModeRef = useRef(sleepMode);
+  sleepModeRef.current = sleepMode;
 
   useEffect(() => {
     const prev = prevLockRef.current;
@@ -49,7 +56,12 @@ export function useBoardingLockScheduler({
         await cancelAllHopsForLock(prev);
       }
       if (lock && route && destinationName) {
-        await scheduleHopsForLock({ lock, route, destinationName });
+        await scheduleHopsForLock({
+          lock,
+          route,
+          destinationName,
+          sleepMode: sleepModeRef.current,
+        });
       }
     };
     handleTransition().catch((e: unknown) => {

--- a/src/hooks/useSleepModeRef.ts
+++ b/src/hooks/useSleepModeRef.ts
@@ -1,0 +1,13 @@
+import { useRef, type MutableRefObject } from 'react';
+import { useAppStore } from '../store/useAppStore';
+
+/**
+ * sleepMode를 ref로 노출 — 호출 시점 값을 캡처하되 effect deps에 sleepMode를 제외하기 위한 패턴(#632).
+ * 토글 시점에 effect 재실행 없이 다음 callback 호출 때 새 값이 반영된다.
+ */
+export function useSleepModeRef(): MutableRefObject<boolean> {
+  const sleepMode = useAppStore((s) => s.sleepMode);
+  const ref = useRef(sleepMode);
+  ref.current = sleepMode;
+  return ref;
+}

--- a/src/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/utils/__tests__/boardingLockScheduler.test.ts
@@ -228,46 +228,39 @@ describe('scheduleHopsForLock', () => {
     expect(call.content.interruptionLevel).toBeUndefined();
   });
 
-  it('#632 sleepMode=true + 첫 hop이 transfer면 그 hop schedule skip, 둘째 hop은 정상', async () => {
-    // transferRoute: targets = 교대(transfer, 2 stops), 오금(destination, 3 stops)
-    await scheduleHopsForLock({
-      lock,
-      route: transferRoute,
-      destinationName: '오금',
-      sleepMode: true,
-    });
-    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
-    expect(ids).not.toContain('bl:T-100:0:early:교대');
-    expect(ids).not.toContain('bl:T-100:0:imminent:교대');
-    expect(ids).toContain('bl:T-100:1:early:오금');
-    expect(ids).toContain('bl:T-100:1:imminent:오금');
-    expect(mockedAdd).toHaveBeenCalledWith([
-      'bl:T-100:1:early:오금',
-      'bl:T-100:1:imminent:오금',
-    ]);
-  });
+  describe('#632 sleepMode 가드', () => {
+    async function scheduleAndGetIds(
+      route: DirectRoute | TransferRoute,
+      dest: string,
+      sleepMode: boolean,
+    ): Promise<string[]> {
+      await scheduleHopsForLock({ lock, route, destinationName: dest, sleepMode });
+      return mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    }
 
-  it('#632 sleepMode=true + 첫 hop이 destination이면 정상 schedule (skip 없음)', async () => {
-    await scheduleHopsForLock({
-      lock,
-      route: directRoute,
-      destinationName: '강남',
-      sleepMode: true,
+    it('sleepMode=true + 첫 hop이 transfer면 그 hop skip, 둘째 hop은 정상', async () => {
+      const ids = await scheduleAndGetIds(transferRoute, '오금', true);
+      expect(ids).not.toContain('bl:T-100:0:early:교대');
+      expect(ids).not.toContain('bl:T-100:0:imminent:교대');
+      expect(ids).toContain('bl:T-100:1:early:오금');
+      expect(ids).toContain('bl:T-100:1:imminent:오금');
+      expect(mockedAdd).toHaveBeenCalledWith([
+        'bl:T-100:1:early:오금',
+        'bl:T-100:1:imminent:오금',
+      ]);
     });
-    expect(mockedSchedule).toHaveBeenCalledTimes(2);
-    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
-    expect(ids).toContain('bl:T-100:0:early:강남');
-    expect(ids).toContain('bl:T-100:0:imminent:강남');
-  });
 
-  it('#632 sleepMode=false + 첫 hop이 transfer여도 정상 schedule', async () => {
-    await scheduleHopsForLock({
-      lock,
-      route: transferRoute,
-      destinationName: '오금',
-      sleepMode: false,
+    it('sleepMode=true + 첫 hop이 destination이면 정상 schedule', async () => {
+      const ids = await scheduleAndGetIds(directRoute, '강남', true);
+      expect(mockedSchedule).toHaveBeenCalledTimes(2);
+      expect(ids).toContain('bl:T-100:0:early:강남');
+      expect(ids).toContain('bl:T-100:0:imminent:강남');
     });
-    expect(mockedSchedule).toHaveBeenCalledTimes(4);
+
+    it('sleepMode=false + 첫 hop이 transfer여도 정상 schedule', async () => {
+      await scheduleAndGetIds(transferRoute, '오금', false);
+      expect(mockedSchedule).toHaveBeenCalledTimes(4);
+    });
   });
 
   it('빈 targets은 storage write도 빈 배열', async () => {
@@ -466,51 +459,38 @@ describe('advanceHopWindow', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('#632 sleepMode=true + passedIndex+1 hop이 transfer면 그 hop만 skip, 그 다음은 정상', async () => {
-    // multiRoute: 교대(0,t), 약수(1,t), 한강진(2,t), 온수(3,d). 교대 통과 후 새 첫 hop=약수(transfer).
-    mockedGet.mockResolvedValueOnce([]);
-    await advanceHopWindow({
-      lock,
-      route: multiRoute,
-      destinationName: '온수',
-      passedStationName: '교대',
-      sleepMode: true,
-    });
-    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
-    expect(ids.some((id) => id.startsWith('bl:T-100:1:'))).toBe(false);
-    expect(ids.some((id) => id.startsWith('bl:T-100:2:'))).toBe(true);
-    expect(ids.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
-  });
+  describe('#632 sleepMode 가드', () => {
+    async function advanceAndGetIds(
+      route: TransferRoute | MultiTransferRoute,
+      dest: string,
+      passed: string,
+      sleepMode: boolean,
+    ): Promise<string[]> {
+      mockedGet.mockResolvedValueOnce([]);
+      await advanceHopWindow({ lock, route, destinationName: dest, passedStationName: passed, sleepMode });
+      return mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    }
 
-  it('#632 sleepMode=true + out-of-order advance(passedIndex 점프): 새 첫 hop(=passedIndex+1)만 skip 대상', async () => {
-    // multiRoute: 교대(0,t), 약수(1,t), 한강진(2,t), 온수(3,d).
-    // GPS 점프로 약수(1)를 건너뛰고 한강진(2) 직전에 advance(passedStationName=약수) — 큐는 비어있다.
-    // 새 hop 시작점 = 2 (한강진, transfer)이므로 그 hop만 skip되어야 함. hop 3(온수, destination)은 정상 schedule.
-    mockedGet.mockResolvedValueOnce([]);
-    await advanceHopWindow({
-      lock,
-      route: multiRoute,
-      destinationName: '온수',
-      passedStationName: '약수',
-      sleepMode: true,
+    it('sleepMode=true + passedIndex+1 hop이 transfer면 그 hop만 skip', async () => {
+      // multiRoute: 교대(0,t), 약수(1,t), 한강진(2,t), 온수(3,d). 교대 통과 후 새 첫 hop=약수(transfer).
+      const ids = await advanceAndGetIds(multiRoute, '온수', '교대', true);
+      expect(ids.some((id) => id.startsWith('bl:T-100:1:'))).toBe(false);
+      expect(ids.some((id) => id.startsWith('bl:T-100:2:'))).toBe(true);
+      expect(ids.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
     });
-    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
-    expect(ids.some((id) => id.startsWith('bl:T-100:2:'))).toBe(false);
-    expect(ids.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
-  });
 
-  it('#632 sleepMode=true + passedIndex+1 hop이 destination이면 정상 schedule', async () => {
-    // transferRoute: 교대(0,t), 오금(1,d). 교대 통과 후 새 첫 hop = 오금(destination) → skip 안 함.
-    mockedGet.mockResolvedValueOnce([]);
-    await advanceHopWindow({
-      lock,
-      route: transferRoute,
-      destinationName: '오금',
-      passedStationName: '교대',
-      sleepMode: true,
+    it('sleepMode=true + out-of-order advance: 새 첫 hop(=passedIndex+1)만 skip 대상', async () => {
+      // GPS 점프로 약수(1)를 건너뛰고 한강진(2) 직전에 advance — 새 hop 시작점=2(한강진, transfer) skip.
+      const ids = await advanceAndGetIds(multiRoute, '온수', '약수', true);
+      expect(ids.some((id) => id.startsWith('bl:T-100:2:'))).toBe(false);
+      expect(ids.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
     });
-    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
-    expect(ids).toContain('bl:T-100:1:early:오금');
-    expect(ids).toContain('bl:T-100:1:imminent:오금');
+
+    it('sleepMode=true + passedIndex+1 hop이 destination이면 정상 schedule', async () => {
+      // transferRoute: 교대(0,t), 오금(1,d). 새 첫 hop=오금(destination) → skip 안 함.
+      const ids = await advanceAndGetIds(transferRoute, '오금', '교대', true);
+      expect(ids).toContain('bl:T-100:1:early:오금');
+      expect(ids).toContain('bl:T-100:1:imminent:오금');
+    });
   });
 });

--- a/src/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/utils/__tests__/boardingLockScheduler.test.ts
@@ -228,6 +228,48 @@ describe('scheduleHopsForLock', () => {
     expect(call.content.interruptionLevel).toBeUndefined();
   });
 
+  it('#632 sleepMode=true + 첫 hop이 transfer면 그 hop schedule skip, 둘째 hop은 정상', async () => {
+    // transferRoute: targets = 교대(transfer, 2 stops), 오금(destination, 3 stops)
+    await scheduleHopsForLock({
+      lock,
+      route: transferRoute,
+      destinationName: '오금',
+      sleepMode: true,
+    });
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids).not.toContain('bl:T-100:0:early:교대');
+    expect(ids).not.toContain('bl:T-100:0:imminent:교대');
+    expect(ids).toContain('bl:T-100:1:early:오금');
+    expect(ids).toContain('bl:T-100:1:imminent:오금');
+    expect(mockedAdd).toHaveBeenCalledWith([
+      'bl:T-100:1:early:오금',
+      'bl:T-100:1:imminent:오금',
+    ]);
+  });
+
+  it('#632 sleepMode=true + 첫 hop이 destination이면 정상 schedule (skip 없음)', async () => {
+    await scheduleHopsForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      sleepMode: true,
+    });
+    expect(mockedSchedule).toHaveBeenCalledTimes(2);
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids).toContain('bl:T-100:0:early:강남');
+    expect(ids).toContain('bl:T-100:0:imminent:강남');
+  });
+
+  it('#632 sleepMode=false + 첫 hop이 transfer여도 정상 schedule', async () => {
+    await scheduleHopsForLock({
+      lock,
+      route: transferRoute,
+      destinationName: '오금',
+      sleepMode: false,
+    });
+    expect(mockedSchedule).toHaveBeenCalledTimes(4);
+  });
+
   it('빈 targets은 storage write도 빈 배열', async () => {
     // direct stops=0 → totalStops=0, but resolveAllTargets returns 1 entry with stops=0.
     // waypointEta=0 → 모든 phase에서 fireSeconds <= 0 → 예약 안 됨.
@@ -422,5 +464,53 @@ describe('advanceHopWindow', () => {
         passedStationName: '교대',
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it('#632 sleepMode=true + passedIndex+1 hop이 transfer면 그 hop만 skip, 그 다음은 정상', async () => {
+    // multiRoute: 교대(0,t), 약수(1,t), 한강진(2,t), 온수(3,d). 교대 통과 후 새 첫 hop=약수(transfer).
+    mockedGet.mockResolvedValueOnce([]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+      sleepMode: true,
+    });
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids.some((id) => id.startsWith('bl:T-100:1:'))).toBe(false);
+    expect(ids.some((id) => id.startsWith('bl:T-100:2:'))).toBe(true);
+    expect(ids.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
+  });
+
+  it('#632 sleepMode=true + out-of-order advance(passedIndex 점프): 새 첫 hop(=passedIndex+1)만 skip 대상', async () => {
+    // multiRoute: 교대(0,t), 약수(1,t), 한강진(2,t), 온수(3,d).
+    // GPS 점프로 약수(1)를 건너뛰고 한강진(2) 직전에 advance(passedStationName=약수) — 큐는 비어있다.
+    // 새 hop 시작점 = 2 (한강진, transfer)이므로 그 hop만 skip되어야 함. hop 3(온수, destination)은 정상 schedule.
+    mockedGet.mockResolvedValueOnce([]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '약수',
+      sleepMode: true,
+    });
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids.some((id) => id.startsWith('bl:T-100:2:'))).toBe(false);
+    expect(ids.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
+  });
+
+  it('#632 sleepMode=true + passedIndex+1 hop이 destination이면 정상 schedule', async () => {
+    // transferRoute: 교대(0,t), 오금(1,d). 교대 통과 후 새 첫 hop = 오금(destination) → skip 안 함.
+    mockedGet.mockResolvedValueOnce([]);
+    await advanceHopWindow({
+      lock,
+      route: transferRoute,
+      destinationName: '오금',
+      passedStationName: '교대',
+      sleepMode: true,
+    });
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids).toContain('bl:T-100:1:early:오금');
+    expect(ids).toContain('bl:T-100:1:imminent:오금');
   });
 });

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -415,6 +415,7 @@ describe('processLocationUpdate', () => {
         route: mockRoute,
         destinationName: '시청',
         passedStationName: '강남',
+        sleepMode: false,
       });
     });
 

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -152,6 +152,18 @@ function arrivalMsForHop(
   return lock.boardedAt + cumulativeStops * HOP_TIME_SECONDS * 1000;
 }
 
+/**
+ * 탑승/환승 직후 새 leg의 첫 hop이 transfer일 때 sleep ON이면 알람 skip(#632).
+ * scheduleHopsForLock / advanceHopWindow가 공유하는 동일 조건 — 중복 제거.
+ */
+function shouldSkipFirstTransferForSleep(
+  isFirstNewHop: boolean,
+  sleepMode: boolean,
+  hop: { alarmType: string },
+): boolean {
+  return isFirstNewHop && sleepMode && hop.alarmType === 'transfer';
+}
+
 async function cancelAndDismiss(ids: string[]): Promise<void> {
   for (const id of ids) {
     await Notifications.cancelScheduledNotificationAsync(id);
@@ -195,7 +207,7 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
 
   const scheduledIds: string[] = [];
   for (let hopIndex = 0; hopIndex < lastIdx; hopIndex++) {
-    if (hopIndex === 0 && sleepMode && allTargets[0].alarmType === 'transfer') {
+    if (shouldSkipFirstTransferForSleep(hopIndex === 0, sleepMode, allTargets[hopIndex])) {
       // 탑승 직후 첫 hop이 환승이고 sleep ON → 사용자가 노이즈로 느낀다(#632). 둘째 hop부터 정상 예약.
       continue;
     }
@@ -319,9 +331,11 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   for (let hopIndex = passedIndex + 1; hopIndex <= windowEnd; hopIndex++) {
     if (existingHopIndexes.has(hopIndex)) continue;
     if (
-      hopIndex === passedIndex + 1 &&
-      sleepMode &&
-      allTargets[hopIndex].alarmType === 'transfer'
+      shouldSkipFirstTransferForSleep(
+        hopIndex === passedIndex + 1,
+        sleepMode,
+        allTargets[hopIndex],
+      )
     ) {
       // "방금 진입한 새 leg의 첫 hop"이 transfer면 skip(#632). out-of-order advance(0→2 등 GPS 점프)에서도
       // 큐 채우기 시작점이 passedIndex+1이므로 의미가 일관 — 사용자에게 가장 가까운 새 transfer만 차단한다.

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -171,6 +171,11 @@ export interface ScheduleHopsParams {
   now?: number;
   /** 큐에 둘 waypoint 개수. 기본 3. */
   windowSize?: number;
+  /**
+   * 취침모드 ON 여부. true이고 batch의 첫 hop이 transfer면 그 hop의 alarm은 schedule skip.
+   * [[project-alarm-sla-architecture]] "1정거장 전 + 탑승 직후 환승 알람 skip" 요구사항(#632).
+   */
+  sleepMode?: boolean;
 }
 
 /**
@@ -182,13 +187,18 @@ export interface ScheduleHopsParams {
  * 과거 시각으로 산출되는 알람은 skip. waypoint stops=0(이미 도착)인 경우도 skip된다 (lead 차감 후 ≤0).
  */
 export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<string[]> {
-  const { lock, route, destinationName, now, windowSize = DEFAULT_WINDOW_SIZE } = params;
+  const { lock, route, destinationName, now, windowSize = DEFAULT_WINDOW_SIZE, sleepMode = false } =
+    params;
   const observedMs = now ?? lock.boardedAt;
   const allTargets = resolveAllTargets(route, destinationName);
   const lastIdx = Math.min(windowSize, allTargets.length);
 
   const scheduledIds: string[] = [];
   for (let hopIndex = 0; hopIndex < lastIdx; hopIndex++) {
+    if (hopIndex === 0 && sleepMode && allTargets[0].alarmType === 'transfer') {
+      // 탑승 직후 첫 hop이 환승이고 sleep ON → 사용자가 노이즈로 느낀다(#632). 둘째 hop부터 정상 예약.
+      continue;
+    }
     const ids = await scheduleSingleHop({
       lock,
       target: allTargets[hopIndex],
@@ -250,6 +260,11 @@ export interface AdvanceHopWindowParams {
   passedStationName: string;
   now?: number;
   windowSize?: number;
+  /**
+   * 취침모드 ON 여부. true이고 advance 직후의 첫 새 hop(=passedIndex+1)이 transfer면 그 hop은 skip.
+   * 환승 직후 새 leg 시작 시점에도 같은 노이즈가 반복되지 않도록 한다(#632).
+   */
+  sleepMode?: boolean;
 }
 
 /**
@@ -263,8 +278,15 @@ export interface AdvanceHopWindowParams {
  * PR C에서는 정의만 — 호출자(Fusion station-pass)는 PR D에서 연결.
  */
 export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<void> {
-  const { lock, route, destinationName, passedStationName, now, windowSize = DEFAULT_WINDOW_SIZE } =
-    params;
+  const {
+    lock,
+    route,
+    destinationName,
+    passedStationName,
+    now,
+    windowSize = DEFAULT_WINDOW_SIZE,
+    sleepMode = false,
+  } = params;
 
   const allTargets = resolveAllTargets(route, destinationName);
   const passedIndex = allTargets.findIndex((t) => t.name === passedStationName);
@@ -296,6 +318,15 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   const windowEnd = Math.min(passedIndex + windowSize, allTargets.length - 1);
   for (let hopIndex = passedIndex + 1; hopIndex <= windowEnd; hopIndex++) {
     if (existingHopIndexes.has(hopIndex)) continue;
+    if (
+      hopIndex === passedIndex + 1 &&
+      sleepMode &&
+      allTargets[hopIndex].alarmType === 'transfer'
+    ) {
+      // "방금 진입한 새 leg의 첫 hop"이 transfer면 skip(#632). out-of-order advance(0→2 등 GPS 점프)에서도
+      // 큐 채우기 시작점이 passedIndex+1이므로 의미가 일관 — 사용자에게 가장 가까운 새 transfer만 차단한다.
+      continue;
+    }
     const ids = await scheduleSingleHop({
       lock,
       target: allTargets[hopIndex],

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -197,6 +197,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
               route,
               destinationName: destination.name,
               passedStationName: matched.name,
+              sleepMode,
             });
           }
         }


### PR DESCRIPTION
## Summary
- 취침모드 ON 상태에서 탑승 직후 첫 hop이 환승역이면 BoardingLock scheduler가 그 환승 알람을 skip ([[project-alarm-sla-architecture]] 요구사항 구현 누락분).
- `scheduleHopsForLock` / `advanceHopWindow` 양쪽에 sleepMode 가드 추가. 둘째 hop부터는 정상 예약 — 도착 알람과 후속 환승 알람은 영향 없음.
- `useBoardingLockScheduler` / `useBoardingLockAdvancer`가 useAppStore에서 sleepMode를 ref로 캡처해 전달. effect deps에서 sleepMode를 의도적으로 제외해 토글이 재예약을 트리거하지 않게 한다 (trade-off는 코드 주석).
- `stationPipeline.processLocationUpdate`는 이미 sleepMode 스코프에 있어 그대로 전달.

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (2168 tests, coverage 100%)
- [x] scheduler 단위: sleepMode=true + first transfer → skip / first destination → 정상 / sleepMode=false → 정상
- [x] advance 단위: sleepMode=true + passedIndex+1 transfer → skip / out-of-order(점프) advance에서도 새 첫 hop만 skip / destination이면 정상
- [x] hook 단위: store sleepMode가 schedule/advance 인자에 반영, 토글이 effect 재실행을 트리거하지 않음
- [ ] 실기기: 출발역 인접 환승 trip + sleep ON → 환승 알람 안 울리고 도착 알람만 동작

Closes #632