### PR TITLE
feat(#634): BoardingTrainList HH:mm 절대 시각 + 경로 박스 안으로 이동

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -647,6 +647,25 @@ export default function HomeScreen() {
                   {boardingLock && (
                     <BoardingLockBanner lock={boardingLock} onRelease={releaseBoardingLock} />
                   )}
+                  {/* #634 — 탑승 전 열차 선택 list도 route 컨텍스트 안에서 노출.
+                       이전엔 하단 별도 섹션이라 사용자가 경로와 분리된 카드로 인지. */}
+                  {!boardingLock && effectiveOrigin && (
+                    <BoardingTrainList
+                      arrivals={directionalArrivals}
+                      line={effectiveOrigin.line}
+                      onSelect={createLockFromTrain}
+                    />
+                  )}
+                  {/* PR E: 환승 waypoint 도달 시 다음 노선 list. context 비어있으면 노출 안 됨. */}
+                  {transferContext && (
+                    <BoardingTrainList
+                      arrivals={transferArrivals}
+                      line={transferContext.nextLine}
+                      onSelect={createTransferLock}
+                      walkingBufferSeconds={TRANSFER_WALKING_BUFFER_SECONDS}
+                      title="환승 열차 선택"
+                    />
+                  )}
                 </View>
 
                 {/* Actions */}
@@ -721,26 +740,7 @@ export default function HomeScreen() {
               </View>
             )}
 
-            {/* Arrivals — 현재역(effectiveOrigin)이 확정되면 trip 유무와 무관하게 노출 */}
-            {/* #584 PR B — BoardingLock 진입점. #625에서 banner는 route 컨텍스트로 이동.
-                활성 lock 시 train list는 노출 안 함. */}
-            {destination && !boardingLock && effectiveOrigin && (
-              <BoardingTrainList
-                arrivals={directionalArrivals}
-                line={effectiveOrigin.line}
-                onSelect={createLockFromTrain}
-              />
-            )}
-            {/* PR E: 환승 waypoint 도달 시 다음 노선 list. context 비어있으면 노출 안 됨. */}
-            {transferContext && (
-              <BoardingTrainList
-                arrivals={transferArrivals}
-                line={transferContext.nextLine}
-                onSelect={createTransferLock}
-                walkingBufferSeconds={TRANSFER_WALKING_BUFFER_SECONDS}
-                title="환승 열차 선택"
-              />
-            )}
+            {/* #634: BoardingTrainList 두 인스턴스(현재역/환승)는 route 박스 안으로 이동됨. */}
             {effectiveOrigin && (
               <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
                 <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('home.arrivalInfoTitle')}</Text>

--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -3,6 +3,7 @@ import { useTheme, typography, spacing, radius } from '../theme';
 import { LineBadge } from './LineBadge';
 import type { ArrivalInfo } from '../api/arrivalApi';
 import type { LineNumber } from '../types/station';
+import { formatClockTime } from '../utils/formatTime';
 
 interface Props {
   arrivals: ArrivalInfo[];
@@ -23,6 +24,8 @@ interface Props {
  * 호출자는 이미 route 방향으로 필터링된 arrivals를 전달한다 — 이 컴포넌트는 디스플레이/탭 처리만 담당.
  * 각 row를 탭하면 onSelect 콜백이 발화 → 호출자가 BoardingLock 생성.
  * 빈 list면 placeholder 안내 텍스트.
+ *
+ * #634: 도착 시각을 "분" 상대 표기 → "HH:mm" 절대 표기로 전환. 사용자 시계와 직접 매칭.
  */
 export function BoardingTrainList({
   arrivals,
@@ -63,14 +66,27 @@ export function BoardingTrainList({
               <Text style={[typography.body, { color: colors.ink }]}>{train.destination} 행</Text>
               <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
             </View>
-            <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
-              {train.arrivalMinutes}분
+            <Text
+              style={[typography.body, { color: colors.accent, fontWeight: '600' }]}
+              testID={`boarding-train-arrival-${train.trainCode}`}
+            >
+              {formatArrivalClock(train)}
             </Text>
           </Pressable>
         );
       })}
     </View>
   );
+}
+
+/**
+ * 도착 시각 절대 표기(HH:mm) — #634.
+ * receivedAtMs(API fetch 시점) + arrivalSeconds로 절대 도착 시각 산출.
+ * receivedAtMs 0(mock/stale)이면 현재 시각 기준 fallback — 한 사이클 내에서는 결정적.
+ */
+function formatArrivalClock(train: ArrivalInfo): string {
+  const baseMs = train.receivedAtMs > 0 ? train.receivedAtMs : Date.now();
+  return formatClockTime(baseMs + train.arrivalSeconds * 1000);
 }
 
 const styles = StyleSheet.create({

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -27,7 +27,7 @@ describe('BoardingTrainList', () => {
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
   });
 
-  it('각 train마다 trainCode + destination + arrivalMinutes 렌더', () => {
+  it('각 train마다 trainCode + destination 렌더', () => {
     const trains = [makeTrain({ trainCode: 'T-A', destination: '강남', arrivalMinutes: 2 })];
     const { getByText, getByTestId } = renderWithTheme(
       <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
@@ -35,7 +35,29 @@ describe('BoardingTrainList', () => {
     expect(getByTestId('boarding-train-row-T-A')).toBeTruthy();
     expect(getByText('강남 행')).toBeTruthy();
     expect(getByText('T-A')).toBeTruthy();
-    expect(getByText('2분')).toBeTruthy();
+  });
+
+  it('#634 도착 시각을 receivedAtMs + arrivalSeconds 기반 HH:mm으로 표시', () => {
+    // 2026-01-01 03:05 + 180s = 2026-01-01 03:08
+    const base = new Date(2026, 0, 1, 3, 5).getTime();
+    const train = makeTrain({ trainCode: 'T-CLOCK', receivedAtMs: base, arrivalSeconds: 180 });
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+    );
+    expect(getByTestId('boarding-train-arrival-T-CLOCK').props.children).toBe('03:08');
+  });
+
+  it('#634 receivedAtMs=0(mock/stale)이면 현재 시각 기준 HH:mm 계산', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(new Date(2026, 0, 1, 10, 0).getTime());
+    try {
+      const train = makeTrain({ trainCode: 'T-NOW', receivedAtMs: 0, arrivalSeconds: 120 });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-arrival-T-NOW').props.children).toBe('10:02');
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('train row 탭 시 onSelect에 해당 train 전달', () => {


### PR DESCRIPTION
## Summary
- 탑승 전 열차 선택 list ETA 표기를 "2분"/"8분" → "08:31" 절대 시각으로 전환
- 두 BoardingTrainList(현재역 + 환승) 모두 route 박스 안으로 이동 — BoardingLockBanner 직후

## Test plan
- [x] \`npm test\` (138 suites, 2161 tests, 100% coverage)
- [x] \`npm run type-check\`
- [x] code-review: 머지 가능 (P0/P1 없음)
- [ ] 실기기: list가 경로 list 바로 아래에 보이는지 + HH:mm 자기 시계와 일치

## 후속 (별도 이슈)
- 환승 list \`title="환승 열차 선택"\` 한국어 하드코딩 (i18n 분리) — dev에 이미 있던 문제

Closes #634