### PR TITLE
feat(#635): 출발역에 탑승 도어 라벨 (환승 가까운 칸)

### DIFF
--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -40,6 +40,16 @@ function resolveStopDoor(
   return result ? result.entry.doorNumber : null;
 }
 
+/**
+ * 한 stop의 도어 라벨(arrivalContext + transfer target 종합). 공통 래퍼 — boardingDoor/quickExitDoor
+ * 양쪽 결정 시 transferToLine 분기 중복을 제거 (#635 review P2-1).
+ */
+function doorFor(stop: Stop | null, accessibilityMode: boolean): string | null {
+  if (!stop?.arrivalContext) return null;
+  const toLine = stop.mark === 'transfer' ? stop.transferTarget?.toLine ?? null : null;
+  return resolveStopDoor(stop.arrivalContext, toLine, accessibilityMode);
+}
+
 export function EditorialTimeline({ stops }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -52,12 +62,17 @@ export function EditorialTimeline({ stops }: Props) {
         const nextLineC = !isLast
           ? (stops[i + 1].line != null ? getLineColor(stops[i + 1].line!) : colors.accent)
           : lineC;
-        // transferTarget은 mark === 'transfer'에만 의미가 있다. 환승→도착 흡수된 stop(mark='dest')은
-        // transferTarget이 남아 있을 수 있어도 도착 fallback(quickExit)만 적용한다.
-        const transferToLine = s.mark === 'transfer' ? s.transferTarget?.toLine ?? null : null;
-        const quickExitDoor = s.arrivalContext != null
-          ? resolveStopDoor(s.arrivalContext, transferToLine, accessibilityMode)
+        const quickExitDoor = doorFor(s, accessibilityMode);
+        // #635 — 출발역(첫 mark='filled')에서 탑승 시 어느 칸·문에 타야 다음 hop(환승/도착)에서
+        // 빠르게 내릴 수 있는지 표시. 같은 열차 = 같은 문 번호이므로 다음 hop stop의 도어를 그대로 재사용.
+        // 의미만 다름: 다음 stop에선 "내리는 위치", 출발역에선 "타는 위치".
+        // expanded 모드에선 origin과 첫 hop 사이에 intermediate stop들이 끼므로 인접 [i+1] 대신
+        // arrivalContext가 있는 첫 후속 stop을 찾는다 (review P1-1).
+        const isOrigin = i === 0 && s.mark === 'filled';
+        const nextHopStop = isOrigin
+          ? stops.slice(i + 1).find((st) => st.arrivalContext != null) ?? null
           : null;
+        const boardingDoor = doorFor(nextHopStop, accessibilityMode);
 
         const isIntermediate = s.mark === 'intermediate';
         return (
@@ -122,6 +137,14 @@ export function EditorialTimeline({ stops }: Props) {
                   testID={`quick-exit-door-${i}`}
                 >
                   {t('route.quickExitDoor', { door: quickExitDoor })}
+                </Text>
+              )}
+              {boardingDoor != null && (
+                <Text
+                  style={[typography.label, { color: colors.subtle, marginTop: 2 }]}
+                  testID={`boarding-door-${i}`}
+                >
+                  {t('route.boardingDoor', { door: boardingDoor })}
                 </Text>
               )}
             </View>

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -130,9 +130,63 @@ describe('EditorialTimeline quickExit door label', () => {
     expect(screen.queryByText('3-2번 문')).toBeNull();
   });
 
-  it('arrivalContext 없는 stop(filled)에는 라벨이 안 뜬다', () => {
+  it('arrivalContext 없는 stop(filled) 단독이면 라벨이 안 뜬다', () => {
     render(<EditorialTimeline stops={[{ station: '교대', line: '3', mark: 'filled' }]} />);
     expect(screen.queryByText(/번 문/)).toBeNull();
+  });
+
+  it('#635 출발역(filled) + 다음 stop 빠른 도어 → 출발역에도 "탑승 X-Y번 문" 라벨', () => {
+    // stopsWithQuickExit: 교대(filled, 3호선) → 경복궁(dest, 3호선). 다음 stop 도어 3-2.
+    render(<EditorialTimeline stops={stopsWithQuickExit} />);
+    expect(screen.getByText('탑승 3-2번 문')).toBeTruthy();
+    expect(screen.getByTestId('boarding-door-0')).toBeTruthy();
+    // 도착 stop은 원래 "3-2번 문"(탑승 prefix 없음) 그대로 유지
+    expect(screen.getByTestId('quick-exit-door-1')).toBeTruthy();
+  });
+
+  it('#635 출발역만 있고 다음 stop 없으면 boarding-door 라벨 안 뜬다', () => {
+    render(<EditorialTimeline stops={[{ station: '교대', line: '3', mark: 'filled' }]} />);
+    expect(screen.queryByTestId(/^boarding-door-/)).toBeNull();
+  });
+
+  it('#635 transfer stop인데 transferTarget 누락이면 quickExit fallback으로 도어 결정', () => {
+    // 군자는 transferExit fixture에 5→7=1-1 있지만 transferTarget 미전달 → fallback 경로.
+    // 군자는 quickExit fixture에 없으므로 fallback도 null → 라벨 미표시.
+    const stops: Stop[] = [
+      { station: '방화', line: '5', mark: 'filled' },
+      {
+        station: '군자',
+        line: '7',
+        stopsFromPrev: '20정거장',
+        mark: 'transfer',
+        note: '환승',
+        arrivalContext: { line: '5', fromName: '방화', toName: '군자' },
+        // transferTarget 의도적 누락
+      },
+    ];
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.queryByText(/번 문/)).toBeNull();
+  });
+
+  it('#635 expanded 모드 — origin과 첫 hop 사이에 intermediate stops 있어도 boarding 라벨 살아남음', () => {
+    // expanded 시 journeyAdapter가 intermediate stops 삽입. 인접 [i+1]은 intermediate (arrivalContext 없음).
+    // 코드는 arrivalContext 있는 첫 후속 stop을 찾아야 함.
+    const stops: Stop[] = [
+      { station: '교대', line: '3', mark: 'filled' },
+      { station: '남부터미널', line: '3', mark: 'intermediate' },
+      { station: '양재', line: '3', mark: 'intermediate' },
+      {
+        station: '경복궁',
+        line: '3',
+        stopsFromPrev: '5정거장',
+        mark: 'dest',
+        note: '도착',
+        arrivalContext: { line: '3', fromName: '교대', toName: '경복궁' },
+      },
+    ];
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getByText('탑승 3-2번 문')).toBeTruthy();
+    expect(screen.getByTestId('boarding-door-0')).toBeTruthy();
   });
 
   // 라벨 미표시 케이스 — fromName→toName 단일 segment fixture.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -178,7 +178,8 @@
     "stopsRemainingToDestination_one": "{{count}} stop to {{destination}}",
     "stopsRemainingToDestination_other": "{{count}} stops to {{destination}}",
     "stopsRemainingViaTransfer": "{{transferStops}} stops to {{transfer}} transfer · {{totalStops}} stops to {{destination}}",
-    "quickExitDoor": "Door {{door}}"
+    "quickExitDoor": "Door {{door}}",
+    "boardingDoor": "Board at door {{door}}"
   },
   "lines": {
     "1": "Line 1",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -178,7 +178,8 @@
     "stopsRemainingToDestination_one": "{{destination}}まで残り{{count}}駅",
     "stopsRemainingToDestination_other": "{{destination}}まで残り{{count}}駅",
     "stopsRemainingViaTransfer": "{{transfer}}乗換まで{{transferStops}}駅 · {{destination}}まで{{totalStops}}駅",
-    "quickExitDoor": "{{door}}番ドア"
+    "quickExitDoor": "{{door}}番ドア",
+    "boardingDoor": "{{door}}番ドアから乗車"
   },
   "lines": {
     "1": "1号線",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -178,7 +178,8 @@
     "stopsRemainingToDestination_one": "{{destination}}까지 {{count}}정거장 남음",
     "stopsRemainingToDestination_other": "{{destination}}까지 {{count}}정거장 남음",
     "stopsRemainingViaTransfer": "{{transfer}} 환승까지 {{transferStops}}정거장 · {{destination}}까지 {{totalStops}}정거장",
-    "quickExitDoor": "{{door}}번 문"
+    "quickExitDoor": "{{door}}번 문",
+    "boardingDoor": "탑승 {{door}}번 문"
   },
   "lines": {
     "1": "1호선",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -178,7 +178,8 @@
     "stopsRemainingToDestination_one": "距{{destination}}还有{{count}}站",
     "stopsRemainingToDestination_other": "距{{destination}}还有{{count}}站",
     "stopsRemainingViaTransfer": "距{{transfer}}换乘{{transferStops}}站 · 距{{destination}}{{totalStops}}站",
-    "quickExitDoor": "{{door}}号门"
+    "quickExitDoor": "{{door}}号门",
+    "boardingDoor": "{{door}}号门上车"
   },
   "lines": {
     "1": "1号线",


### PR DESCRIPTION
## Summary
- Route timeline 출발역(용마산 등) 옆에 "탑승 X-Y번 문" 라벨 추가
- 같은 열차 = 같은 문 번호 → 다음 hop의 quickExit/transferExit 도어 재사용
- 사용자가 출발역에서 어느 칸·문에 타야 첫 환승역에서 빠르게 내릴 수 있는지 명시

## Test plan
- [x] \`npm test\` (138 suites, 2163 tests, 100% coverage)
- [x] \`npm run type-check\`
- [x] code-review P1-1(expanded 모드에서 사라짐) + P2-1(헬퍼 추출) 반영
- [ ] 실기기: 용마산→건대입구(환승) 경로 시 용마산에 "탑승 8-4번 문" 표시

Closes #635