### PR TITLE
fix(#641): silent push BG handler가 production payload를 인식하도록 extractPayload 재작성

### DIFF
--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -86,19 +86,35 @@ const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 
 const destStation = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
 
+/**
+ * expo-notifications iOS BG task payload 모양을 그대로 재현 (#641).
+ * Swift `BackgroundEventTransformer`가 `{aps, data:{fields}}` → `{data:{data:{fields}, dataString}, notification:null, aps}`
+ * 로 변환하므로 실기기에서는 fields가 `taskData.data.data.<field>`에 위치한다.
+ */
+function bgFields(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    nextWaypoint: '강남',
+    etaSeconds: 300,
+    phase: 'early',
+    kind: 'destination',
+    ...extra,
+  };
+}
 function payload(extra: Record<string, unknown> = {}) {
   return {
     data: {
-      notification: {
-        data: {
-          nextWaypoint: '강남',
-          etaSeconds: 300,
-          phase: 'early',
-          kind: 'destination',
-          ...extra,
-        },
-      },
+      data: { data: bgFields(extra), dataString: null },
+      notification: null,
+      aps: { 'content-available': 1 },
     },
+  };
+}
+/** extractPayload 단위 테스트용 — handleSilentPush input 전체가 아니라 taskData만 빌드. */
+function bgTaskData(fields: Record<string, unknown>) {
+  return {
+    data: { data: fields, dataString: null },
+    notification: null,
+    aps: { 'content-available': 1 },
   };
 }
 
@@ -135,65 +151,60 @@ describe('silentPushTask', () => {
       expect(extractPayload(undefined)).toBeNull();
     });
 
-    it('notification 없으면 null', () => {
+    it('비어 있는 객체면 null', () => {
       expect(extractPayload({})).toBeNull();
     });
 
-    it('data 위치(notification.data) 우선', () => {
+    // #641 — production iOS BG task payload (Swift `BackgroundEventTransformer` 출력).
+    it('production 모양(taskData.data.data.fields) → 필드 추출', () => {
       expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early' } },
-        }),
+        extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' })),
       ).toMatchObject({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' });
     });
 
-    it('data 없을 때 request.content.data 폴백', () => {
+    // backend가 flat payload(`{aps, ...flat}`)를 보내는 경우 — Swift 변환 후 `taskData.data.flat`.
+    it('flat payload 모양(taskData.data.fields) → 필드 추출', () => {
       expect(
         extractPayload({
-          notification: {
-            request: { content: { data: { nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' } } },
-          },
+          data: { nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' },
+          notification: null,
+          aps: { 'content-available': 1 },
         }),
       ).toMatchObject({ nextWaypoint: 'B', etaSeconds: 2, phase: 'imminent' });
     });
 
-    it('raw가 객체가 아니면 null', () => {
+    // legacy/방어 — 일부 호출처가 fields를 root로 직접 줄 수도 있다.
+    it('root 직접 모양(taskData.fields)도 fallback으로 처리', () => {
       expect(
-        extractPayload({ notification: { data: 'string' as unknown as Record<string, unknown> } }),
+        extractPayload({ nextWaypoint: 'C', etaSeconds: 3, phase: 'early' }),
+      ).toMatchObject({ nextWaypoint: 'C', etaSeconds: 3, phase: 'early' });
+    });
+
+    it('nextWaypoint 없거나 빈 문자열이면 null', () => {
+      expect(extractPayload(bgTaskData({ etaSeconds: 1, phase: 'early' }))).toBeNull();
+      expect(
+        extractPayload(bgTaskData({ nextWaypoint: '', etaSeconds: 1, phase: 'early' })),
       ).toBeNull();
     });
 
-    it('nextWaypoint 누락/비문자열/빈문자열이면 null', () => {
+    it('data가 string 등 비객체면 null', () => {
       expect(
-        extractPayload({
-          notification: { data: { etaSeconds: 1, phase: 'early' } as Record<string, unknown> },
-        }),
-      ).toBeNull();
-      expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: '', etaSeconds: 1, phase: 'early' } },
-        }),
+        extractPayload({ data: 'string' } as unknown as Record<string, unknown>),
       ).toBeNull();
     });
 
     it('etaSeconds 비숫자/Infinity이면 null', () => {
       expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: '10', phase: 'early' } },
-        }),
+        extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: '10', phase: 'early' })),
       ).toBeNull();
       expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: Infinity, phase: 'early' } },
-        }),
+        extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: Infinity, phase: 'early' })),
       ).toBeNull();
     });
 
     it('phase가 early/imminent가 아니면 null', () => {
       expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'late' } },
-        }),
+        extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'late' })),
       ).toBeNull();
     });
 
@@ -205,68 +216,56 @@ describe('silentPushTask', () => {
       ];
       for (const kind of variants) {
         expect(
-          extractPayload({
-            notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind } },
-          }),
+          extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind })),
         ).toMatchObject({ kind });
       }
     });
 
     it('kind가 알 수 없는 값이면 undefined로 정리 (legacy 호환)', () => {
       expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'foo' } },
-        }),
+        extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'foo' })),
       ).toMatchObject({ kind: undefined });
     });
 
     it('sentAt이 number면 그대로 전달 (#478)', () => {
       expect(
-        extractPayload({
-          notification: {
-            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 1_700_000_000_000 },
-          },
-        }),
+        extractPayload(
+          bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 1_700_000_000_000 }),
+        ),
       ).toMatchObject({ sentAt: 1_700_000_000_000 });
     });
 
     it('sentAt이 비숫자/Infinity이면 undefined (구 백엔드 호환)', () => {
       expect(
-        extractPayload({
-          notification: {
-            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 'now' },
-          },
-        }),
+        extractPayload(
+          bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: 'now' }),
+        ),
       ).toMatchObject({ sentAt: undefined });
       expect(
-        extractPayload({
-          notification: {
-            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: Infinity },
-          },
-        }),
+        extractPayload(
+          bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', sentAt: Infinity }),
+        ),
       ).toMatchObject({ sentAt: undefined });
     });
 
     it('pushId가 non-empty string이면 그대로 전달 (#566)', () => {
       expect(
-        extractPayload({
-          notification: {
-            data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: 'uuid-x' },
-          },
-        }),
+        extractPayload(
+          bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: 'uuid-x' }),
+        ),
       ).toMatchObject({ pushId: 'uuid-x' });
     });
 
     it('pushId가 빈 문자열/비문자열이면 undefined (구 백엔드 호환)', () => {
       expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: '' } },
-        }),
+        extractPayload(
+          bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: '' }),
+        ),
       ).toMatchObject({ pushId: undefined });
       expect(
-        extractPayload({
-          notification: { data: { nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: 42 } },
-        }),
+        extractPayload(
+          bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: 42 }),
+        ),
       ).toMatchObject({ pushId: undefined });
     });
   });
@@ -286,7 +285,7 @@ describe('silentPushTask', () => {
 
     it('invalid payload면 skip', async () => {
       await handleSilentPush({
-        data: { notification: { data: { trigger: 'other' } } },
+        data: bgTaskData({ trigger: 'other' }),
       });
       expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
     });
@@ -303,11 +302,7 @@ describe('silentPushTask', () => {
 
     it('kind 미상(구 백엔드)이면 received 적재 후 skip 적재 + 발사 안 함', async () => {
       await handleSilentPush({
-        data: {
-          notification: {
-            data: { nextWaypoint: '강남', etaSeconds: 10, phase: 'imminent' },
-          },
-        },
+        data: bgTaskData({ nextWaypoint: '강남', etaSeconds: 10, phase: 'imminent' }),
       });
       expect(mockLogSilentPushReceived).toHaveBeenCalled();
       expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
@@ -501,11 +496,12 @@ describe('silentPushTask', () => {
 
       it('payload-missing-kind 시 sendPushAck(outcome=skipped, reason=payload-missing-kind)', async () => {
         await handleSilentPush({
-          data: {
-            notification: {
-              data: { nextWaypoint: '강남', etaSeconds: 10, phase: 'imminent', pushId: 'p-kind' },
-            },
-          },
+          data: bgTaskData({
+            nextWaypoint: '강남',
+            etaSeconds: 10,
+            phase: 'imminent',
+            pushId: 'p-kind',
+          }),
         });
         expect(mockSendPushAck).toHaveBeenCalledWith({
           pushId: 'p-kind',

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -65,29 +65,70 @@ export interface SilentPushPayload {
   pushId?: string;
 }
 
+/**
+ * expo-notifications iOS의 `BackgroundEventTransformer.swift`가 APNs payload를
+ * 다음과 같이 변환해 task 콜백에 전달한다:
+ *   { data: { ...non-aps fields, dataString }, notification: <aps.alert | null>, aps: {...} }
+ *
+ * 우리 백엔드(alarm-worker)는 `{ aps: {...}, data: { <fields> } }`로 발사하므로
+ * 변환 결과는 `taskData.data.data.<field>`에 우리 fields가 위치한다.
+ * (#641 — silent push BG handler 회귀: 과거에는 `notification.data` 경로를 읽다 보니
+ *  silent push가 alert를 동반하지 않아 `notification`이 null인 production payload에서
+ *  항상 null로 떨어졌다.)
+ */
 interface NotificationBackgroundTaskData {
-  data?: {
-    notification?: {
-      data?: Record<string, unknown>;
-      request?: { content?: { data?: Record<string, unknown> } };
-    };
-  };
+  data?: Record<string, unknown>;
   error?: { message: string } | null;
 }
 
 /**
+ * payload 안에서 fields 레이어를 찾는다.
+ *   - `taskData.data.data` (production: backend가 `data: { fields }` 발사 → Swift 변환 후 한 단계 더 nested)
+ *   - `taskData.data` (backend가 flat payload 발사 시)
+ *   - `taskData` (legacy / 일부 테스트 호환)
+ * nextWaypoint가 string인 첫 후보를 반환.
+ */
+function asPlainObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function findFieldsLayer(
+  taskData: NotificationBackgroundTaskData['data'],
+): Record<string, unknown> | null {
+  const candidates: Array<Record<string, unknown>> = [];
+  const root = asPlainObject(taskData);
+  if (root) {
+    const level1 = asPlainObject(root.data);
+    if (level1) {
+      const level2 = asPlainObject(level1.data);
+      if (level2) candidates.push(level2);
+      candidates.push(level1);
+    }
+    candidates.push(root);
+  }
+  for (const rec of candidates) {
+    if (typeof rec.nextWaypoint === 'string' && rec.nextWaypoint.length > 0) return rec;
+  }
+  return null;
+}
+
+/**
  * 알림 raw payload → 검증된 SilentPushPayload.
+ *
+ * 입력은 expo-notifications BG task가 전달하는 `NotificationTaskPayload`이다.
+ * 우리 backend가 `{ aps, data: { fields } }` 형태로 발사하므로 fields는
+ * `root.data.<field>` 위치에 있다. flat payload 호환을 위해 root 직접도 fallback.
  */
 export function extractPayload(
-  data: NotificationBackgroundTaskData['data'],
+  taskData: NotificationBackgroundTaskData['data'],
 ): SilentPushPayload | null {
-  const notif = data?.notification;
-  if (!notif) return null;
-  const raw = notif.data ?? notif.request?.content?.data;
-  if (!raw || typeof raw !== 'object') return null;
-  const obj = raw as Record<string, unknown>;
-  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId } = obj;
-  if (typeof nextWaypoint !== 'string' || nextWaypoint.length === 0) return null;
+  const obj = findFieldsLayer(taskData);
+  if (!obj) return null;
+  // findFieldsLayer guarantees nextWaypoint is non-empty string.
+  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId } = obj as {
+    nextWaypoint: string;
+  } & Record<string, unknown>;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
   if (phase !== 'early' && phase !== 'imminent') return null;
   const validKind =


### PR DESCRIPTION
## 요약
실기기에서 silent push가 도착해도 client BG handler가 모두 skip되어 backend의 60초 alert fallback이 모든 push마다 발사되던 회귀(#641) 수정.

## 근본 원인
expo-notifications iOS `BackgroundEventTransformer.swift`가 silent push(`aps.alert` 없음)를 변환할 때 `result["notification"] = NSNull()`로 세팅. 우리 `extractPayload`는 `data?.notification`이 falsy면 즉시 null 리턴 → `logSilentPushReceived` 호출 **전에** short-circuit → 디버그 패널 `lastReceived=(never)`로 영구 표시.

실제 production payload 모양:
```
taskData = {
  data: { data: { <backend fields> }, dataString: null },
  notification: null,
  aps: { 'content-available': 1 }
}
```
fields는 `taskData.data.data.<field>` (3-deep). 기존 코드는 `taskData.notification.data`만 찾고 있었음.

## 변경
- `src/tasks/silentPushTask.ts`: `extractPayload`를 후보 레이어 순회 방식으로 재작성 (`data.data` → `data` → root). `asPlainObject` 가드 + `findFieldsLayer` 헬퍼 분리.
- `src/tasks/__tests__/silentPushTask.test.ts`: 테스트 픽스처 `payload()`를 swift 변환 출력 모양으로 교체, `bgTaskData()` 단위 헬퍼 추가. production/flat/root 3-shape 모두 검증.

## 테스트
- [x] `npm test` 138 suites / 2150 tests pass, 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 실기기 회귀 검증: silent push 도달 시 디버그 패널 `lastReceived` 카운터 증가, backend alert fallback 0건

Closes #641