### PR TITLE
fix(#640): BoardingLock 미활성 trip은 cron polling/push 모두 스킵

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -65,33 +65,6 @@ function makeTrip(overrides: Partial<Trip> = {}): Trip {
   };
 }
 
-function makeImminentArrival(stationName: string): ArrivalEntry {
-  return {
-    destination: stationName,
-    arrivalSeconds: 20,
-    trainCode: 'T',
-    isUp: true,
-    subwayNm: '지하철2호선',
-    arvlCd: null,
-  };
-}
-
-async function runWithImminent(
-  kv: InMemoryKV,
-  stationName: string,
-): Promise<{ stats: Awaited<ReturnType<typeof runScheduled>>; apnsFetch: ReturnType<typeof vi.fn> }> {
-  const seoul = makeSeoul([makeImminentArrival(stationName)]);
-  const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-  const stats = await runScheduled(makeEnv(kv), {
-    seoul,
-    apnsConfig,
-    apnsHosts: APNS_HOSTS,
-    fetchImpl: apnsFetch as unknown as typeof fetch,
-    now: () => NOW,
-  });
-  return { stats, apnsFetch };
-}
-
 function makeSeoul(arrivals: ArrivalEntry[]): SeoulArrivalClient {
   return new SeoulArrivalClient({
     apiKey: 'K',
@@ -241,371 +214,33 @@ describe('runScheduled', () => {
     expect(kv.store.size).toBe(0);
   });
 
-  it('fires imminent push and removes trip when waypoint kind is destination', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip());
-    const { stats, apnsFetch } = await runWithImminent(kv, '강남');
-    expect(stats.pushed).toBe(1);
-    expect(apnsFetch).toHaveBeenCalledTimes(1);
-    expect(kv.store.size).toBe(0); // destination imminent → 트립 종료
-  });
-
-  it('keeps trip and advances waypoint when transfer waypoint reaches imminent', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        waypoints: [
-          { stationName: '신도림', line: '2', kind: 'transfer' },
-          { stationName: '강남', line: '2', kind: 'destination' },
-        ],
-      }),
-    );
-    const { stats } = await runWithImminent(kv, '신도림');
-    expect(stats.pushed).toBe(1);
-    expect(kv.store.size).toBe(1); // trip retained
-    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
-    expect(stored.waypoints).toHaveLength(1);
-    expect(stored.waypoints[0].stationName).toBe('강남');
-    expect(stored.lastFiredPhase).toBeUndefined();
-    expect(stored.lastEtaSeconds).toBeUndefined();
-  });
-
-  it('deletes trip when last waypoint (after shift) is empty', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        // 비정상 케이스: transfer만 있고 destination 없음. shift 후 비면 trip 삭제.
-        waypoints: [{ stationName: '신도림', line: '2', kind: 'transfer' }],
-      }),
-    );
-    const { stats } = await runWithImminent(kv, '신도림');
-    expect(stats.pushed).toBe(1);
-    expect(kv.store.size).toBe(0);
-  });
-
-  it('counts ETA-missing cycles separately from errors', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip());
-    const seoul = makeSeoul([]); // 빈 응답
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      now: () => NOW,
-    });
-    expect(stats.etaMissing).toBe(1);
-    expect(stats.pushed).toBe(0);
-    expect(stats.errors).toBe(0);
-  });
-
-  it('fires early then upgrades to imminent', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip());
-
-    // 1st cycle: early (eta=120s)
-    const seoul1 = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const fetchEarly = vi.fn(async () => new Response('', { status: 200 }));
-    const stats1 = await runScheduled(makeEnv(kv), {
-      seoul: seoul1,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: fetchEarly as unknown as typeof fetch,
-      now: () => NOW,
-    });
-    expect(stats1.pushed).toBe(1);
-    expect(kv.store.size).toBe(1); // 트립 유지
-
-    // 2nd cycle: imminent (eta=20s)
-    const seoul2 = makeSeoul([
-      { destination: '강남', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const fetchImminent = vi.fn(async () => new Response('', { status: 200 }));
-    const stats2 = await runScheduled(makeEnv(kv), {
-      seoul: seoul2,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: fetchImminent as unknown as typeof fetch,
-      now: () => NOW + 30_000,
-    });
-    expect(stats2.pushed).toBe(1);
-    expect(kv.store.size).toBe(0);
-  });
-
-  it('does not re-fire same phase', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({ lastFiredPhase: 'early', lastEtaSeconds: 150 }),
-    );
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 140, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
-    // phase=early, lastFired=early → re-fire blocked. ETA delta=10s → not significant
-    expect(stats.pushed).toBe(0);
-  });
-
-  // #482 self-heal (D안): BadDeviceToken은 토큰 자체 무효가 아니라 host 환경 불일치인 경우가
-  // 압도적. 반대 host로 1회 재시도해 성공하면 trip.apnsEnv를 정정하고, 재시도도 실패하면
-  // 그제서야 진짜 unrecoverable로 분류해 trip을 삭제한다.
-  const BAD_TOKEN = () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
-  const PAYLOAD_TOO_LARGE = () => new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 400 });
-  const UNREGISTERED = () => new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 });
-  const OK = () => new Response('', { status: 200 });
-
-  async function runWithFetch(
-    apnsEnv: 'sandbox' | 'production' | undefined,
-    apnsFetch: ReturnType<typeof vi.fn>,
-  ) {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip({ apnsEnv }));
-    const seoul = makeSeoul([
-      { destination: '강남', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-    ]);
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
-    return { stats, kv };
-  }
-
-  /** host(sandbox/production)별로 다른 응답을 내는 fetch mock. */
-  function fetchByHost(handlers: { sandbox: () => Response; production: () => Response }) {
-    return vi.fn(async (url: string) =>
-      url.includes('sandbox') ? handlers.sandbox() : handlers.production(),
-    );
-  }
-
-  function storedTrip(kv: InMemoryKV): Trip {
-    return JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
-  }
-
-  it('self-heal: 1차 sandbox 실패(BadDeviceToken) → 2차 production 성공 → apnsEnv 정정', async () => {
-    const apnsFetch = fetchByHost({ sandbox: BAD_TOKEN, production: OK });
-    const { stats, kv } = await runWithFetch('sandbox', apnsFetch);
-    expect(stats.pushed).toBe(1);
-    expect(stats.errors).toBe(0);
-    expect(stats.envCorrected).toBe(1);
-    expect(apnsFetch).toHaveBeenCalledTimes(2);
-    expect(storedTrip(kv).apnsEnv).toBe('production');
-  });
-
-  it('self-heal: 1차 production 실패 → 2차 sandbox 성공 → apnsEnv=sandbox 정정', async () => {
-    const apnsFetch = fetchByHost({ sandbox: OK, production: BAD_TOKEN });
-    const { stats, kv } = await runWithFetch('production', apnsFetch);
-    expect(stats.pushed).toBe(1);
-    expect(stats.envCorrected).toBe(1);
-    expect(storedTrip(kv).apnsEnv).toBe('sandbox');
-  });
-
-  it('self-heal: 1차/2차 모두 BadDeviceToken → 진짜 unrecoverable, trip 삭제', async () => {
-    const apnsFetch = vi.fn(BAD_TOKEN);
-    const { stats, kv } = await runWithFetch('sandbox', apnsFetch);
-    expect(apnsFetch).toHaveBeenCalledTimes(2);
-    expect(stats.errors).toBe(1);
-    expect(stats.envCorrected).toBe(0);
-    expect(kv.store.size).toBe(0);
-  });
-
-  it('self-heal: apnsEnv=undefined trip(구버전 클라이언트) → sandbox로 시작 → production 정정', async () => {
-    // 1차: sandbox host (pickApnsHost fallback) → 실패. 2차: production → 성공.
-    const apnsFetch = fetchByHost({ sandbox: BAD_TOKEN, production: OK });
-    const { stats, kv } = await runWithFetch(undefined, apnsFetch);
-    expect(stats.envCorrected).toBe(1);
-    expect(stats.pushed).toBe(1);
-    expect(storedTrip(kv).apnsEnv).toBe('production');
-  });
-
-  it('self-heal retry가 다른 종류 에러(non-mismatch 400)면 trip 유지, exhausted 아님', async () => {
-    // 1차 sandbox BadDeviceToken → 2차 production은 PayloadTooLarge (env 문제는 아님)
-    const apnsFetch = fetchByHost({ sandbox: BAD_TOKEN, production: PAYLOAD_TOO_LARGE });
-    const { stats, kv } = await runWithFetch('sandbox', apnsFetch);
-    expect(stats.errors).toBe(1);
-    expect(stats.envCorrected).toBe(0);
-    expect(kv.store.size).toBe(1);
-  });
-
-  it('410 Unregistered → self-heal 우회, 즉시 trip 삭제 (회귀 방지)', async () => {
-    const apnsFetch = vi.fn(UNREGISTERED);
-    const { stats, kv } = await runWithFetch('production', apnsFetch);
-    expect(apnsFetch).toHaveBeenCalledTimes(1); // 410은 retry 안 함
-    expect(stats.errors).toBe(1);
-    expect(stats.envCorrected).toBe(0);
-    expect(kv.store.size).toBe(0);
-  });
-
-  it('400 그 외 reason은 self-heal 안 함, trip 유지 (recoverable error)', async () => {
-    const apnsFetch = vi.fn(PAYLOAD_TOO_LARGE);
-    const { stats, kv } = await runWithFetch('production', apnsFetch);
-    expect(apnsFetch).toHaveBeenCalledTimes(1);
-    expect(stats.errors).toBe(1);
-    expect(stats.envCorrected).toBe(0);
-    expect(kv.store.size).toBe(1);
-  });
-
-  // #416: 중간역(intermediate) 처리 — early phase 스킵, imminent에서만 push + shift.
-  it('intermediate waypoint: early ETA에서는 push 안 함', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        waypoints: [
-          { stationName: '중곡', line: '7', kind: 'intermediate' },
-          { stationName: '강남', line: '2', kind: 'destination' },
-        ],
-      }),
-    );
-    const seoul = makeSeoul([
-      { destination: '중곡', arrivalSeconds: 120, trainCode: 'T', isUp: true, subwayNm: '7호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
-    expect(stats.pushed).toBe(0);
-    // trip은 유지 (다음 사이클에 imminent까지 폴링)
-    expect(kv.store.size).toBe(1);
-    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
-    expect(stored.waypoints).toHaveLength(2);
-  });
-
-  it('intermediate waypoint: imminent에서 push + shift', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        waypoints: [
-          { stationName: '중곡', line: '7', kind: 'intermediate' },
-          { stationName: '강남', line: '2', kind: 'destination' },
-        ],
-      }),
-    );
-    const seoul = makeSeoul([
-      { destination: '중곡', arrivalSeconds: 20, trainCode: 'T', isUp: true, subwayNm: '7호선', arvlCd: null },
-    ]);
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
-    expect(stats.pushed).toBe(1);
-    // body에 kind=intermediate 포함 검증
-    const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
-    const body = JSON.parse(call[1].body as string);
-    expect(body.data.kind).toBe('intermediate');
-    expect(body.data.phase).toBe('imminent');
-    // shift 후 destination만 남음
-    expect(kv.store.size).toBe(1);
-    const stored = JSON.parse(kv.store.get('trip:tok')!.value) as Trip;
-    expect(stored.waypoints).toHaveLength(1);
-    expect(stored.waypoints[0].kind).toBe('destination');
-    expect(stored.lastFiredPhase).toBeUndefined();
-    expect(stored.lastEtaSeconds).toBeUndefined();
-  });
-
-  it('counts seoul errors as poll errors', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip());
-    const failingSeoul = new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async () => {
-        throw new Error('network down');
-      }) as unknown as typeof fetch,
-    });
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: failingSeoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      now: () => NOW,
-    });
-    expect(stats.errors).toBe(1);
-  });
-
-  describe('#566 P2a — pending push 기록', () => {
-    it('성공한 silent push마다 pending:<pushId> entry를 PENDING_PUSHES에 적재', async () => {
+  // #640 — BoardingLock 게이트. 사용자가 열차를 선택하지 않은 trip(lock 부재)은
+  // arrival 신호가 와도 push를 발사하지 않는다. (가) 정책: lock 없으면 silent push 0건.
+  // 이전 legacy phase-based push 경로의 회귀 방지 테스트들은 boardingLock 경로의
+  // 대응 케이스(self-heal/intermediate/410 등)로 모두 커버되어 삭제됨 (회귀 동등성 유지).
+  describe('#640 lockMissing gate', () => {
+    it('lock 부재 trip은 arrival이 와도 push 미발사 + Seoul API 미호출', async () => {
       const kv = new InMemoryKV();
-      const pending = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, makeTrip());
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv, pending), {
-        seoul: makeSeoul([makeImminentArrival('강남')]),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
+      await putTrip(kv as unknown as KVNamespace, makeTrip()); // makeTrip default: boardingLock undefined
+      const seoulFetch = vi.fn();
+      const seoul = new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
         now: () => NOW,
-        generatePushId: () => 'fixed-push-id',
+        fetchImpl: seoulFetch as unknown as typeof fetch,
       });
-      expect(stats.pushed).toBe(1);
-      const entryRaw = pending.store.get('pending:fixed-push-id');
-      expect(entryRaw).toBeDefined();
-      const entry = JSON.parse(entryRaw!.value);
-      expect(entry.pushId).toBe('fixed-push-id');
-      expect(entry.token).toBe('tok');
-      expect(entry.alarmKey).toBe('imminent:강남');
-      expect(entry.sentAt).toBe(NOW);
-      expect(entry.kind).toBe('destination');
-      expect(entry.phase).toBe('imminent');
-      expect(entry.apnsEnv).toBe('sandbox'); // makeTrip default
-
-      // payload에도 pushId가 들어갔는지 검증.
-      const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
-      const body = JSON.parse(call[1].body as string);
-      expect(body.data.pushId).toBe('fixed-push-id');
-    });
-
-    it('PENDING_PUSHES 미바인딩이어도 push는 정상 발사 (graceful)', async () => {
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, makeTrip());
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const apnsFetch = vi.fn();
       const stats = await runScheduled(makeEnv(kv), {
-        seoul: makeSeoul([makeImminentArrival('강남')]),
+        seoul,
         apnsConfig,
         apnsHosts: APNS_HOSTS,
         fetchImpl: apnsFetch as unknown as typeof fetch,
         now: () => NOW,
       });
-      expect(stats.pushed).toBe(1);
-    });
-
-    it('push 실패 시 pending entry를 기록하지 않는다', async () => {
-      const kv = new InMemoryKV();
-      const pending = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, makeTrip());
-      const apnsFetch = vi.fn(async () =>
-        new Response(JSON.stringify({ reason: 'PayloadTooLarge' }), { status: 413 }),
-      );
-      await runScheduled(makeEnv(kv, pending), {
-        seoul: makeSeoul([makeImminentArrival('강남')]),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'fixed-push-id',
-      });
-      expect(pending.store.size).toBe(0);
+      expect(stats.pushed).toBe(0);
+      expect(stats.lockMissing).toBe(1);
+      expect(apnsFetch).not.toHaveBeenCalled();
+      expect(seoulFetch).not.toHaveBeenCalled();
     });
   });
 });
@@ -824,7 +459,8 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(await kv.get('trip:lock-tok')).toBeNull();
   });
 
-  it('skips boardingLock branch when lock expired (falls through to phase polling)', async () => {
+  // #640 — lock 만료 trip도 lockMissing 게이트로 차단되어야 한다 (이전엔 legacy phase 경로로 fall-through 됐었음).
+  it('lock 만료 trip은 게이트에서 차단 — push 없음', async () => {
     const kv = new InMemoryKV();
     await putTrip(
       kv as unknown as KVNamespace,
@@ -835,19 +471,16 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     );
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([makeImminentArrival('강남')]),
+      seoul: makeSeoulCombo([arrivalForLock('강남', 20, 1)], []),
       apnsConfig,
       apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
       generatePushId: () => 'p8',
     });
-    // 일반 phase 경로로 처리되어 imminent push가 발사되어야 함
-    expect(stats.pushed).toBe(1);
-    const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
-    const body = JSON.parse(call[1].body as string);
-    expect(body.data.phase).toBeDefined();
-    expect(body.data.kind).not.toBe('reschedule');
+    expect(stats.pushed).toBe(0);
+    expect(stats.lockMissing).toBe(1);
+    expect(apnsFetch).not.toHaveBeenCalled();
   });
 
   it('counts error when reschedule push fails (apns 400)', async () => {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2,17 +2,9 @@
  * Cron 핸들러 — 활성 트립 enumerate → 알람 윈도우(5분 이내) 트립만 폴링 → ETA 평가 → push 발사.
  */
 
-import {
-  ARRIVAL_CODE,
-  EARLY_THRESHOLD_SEC,
-  TRAIN_STATUS,
-  evaluatePhaseFromSignal,
-  isSignificantEtaChange,
-  shouldFire,
-} from './alarm';
-import { sendReschedulePush, sendSilentPush, type ApnsConfig, type SendPushResult } from './apns';
+import { ARRIVAL_CODE, TRAIN_STATUS } from './alarm';
+import { sendReschedulePush, type ApnsConfig, type SendPushResult } from './apns';
 import { matchLine } from './lineAlias';
-import { buildAlarmKey, putPending } from './pendingPushes';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { deleteTrip, listTrips, putTrip } from './trips';
 import type { ApnsEnv, BoardingLockMeta, Env, Trip, Waypoint } from './types';
@@ -90,6 +82,23 @@ export interface ScheduledStats {
    * 클라이언트 hint가 빌드 환경과 어긋나고 있다는 신호 (#482).
    */
   envCorrected: number;
+  /**
+   * BoardingLock 부재/만료로 발사 게이트에서 스킵된 트립 수 (#640).
+   * 사용자가 열차 미선택 상태에서 noise push가 발사되지 않도록 차단된 결과.
+   */
+  lockMissing: number;
+}
+
+/**
+ * BoardingLock이 활성 상태인지 (#640 게이트).
+ * 부재거나 만료된 경우 false — push 발사 경로를 모두 차단한다.
+ * type predicate로 선언해 호출부에서 `trip.boardingLock` non-null narrowing이 자동 적용된다.
+ */
+export function isBoardingLockActive(
+  trip: Trip,
+  now: number,
+): trip is Trip & { boardingLock: BoardingLockMeta } {
+  return trip.boardingLock !== undefined && trip.boardingLock.expiresAt > now;
 }
 
 export interface ScheduledDeps {
@@ -134,6 +143,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     errors: 0,
     etaMissing: 0,
     envCorrected: 0,
+    lockMissing: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -149,175 +159,40 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       continue;
     }
 
-    stats.polled += 1;
     const waypoint = pickActiveWaypoint(trip);
     if (!waypoint) continue;
 
-    // #585 — boardingLock 활성 trip은 trainCode 단위 추적 + reschedule push 경로로 분기.
-    // 디바이스는 사전 예약 알람(#584)으로 SLA를 보장하므로 phase-based silent push는 보내지 않는다.
-    if (trip.boardingLock && trip.boardingLock.expiresAt > now) {
-      try {
-        await runTrainCodeTracking(
-          trip,
-          waypoint,
-          trip.boardingLock,
-          env,
-          deps,
-          stats,
-          now,
-          log,
-          generatePushId,
-        );
-      } catch (e) {
-        stats.errors += 1;
-        log('boarding-lock poll error', { error: String(e), token: trip.token.slice(0, 8) });
-      }
+    // #640 — BoardingLock 게이트. 사용자가 열차를 아직 선택하지 않았거나 lock이 만료된 trip은
+    // Seoul polling/push 모두 skip. 디바이스는 lock 등록 후 train-code 단위로 정확히 추적하며,
+    // lock 부재 상태에서의 phase-based push는 "탑승 전 노이즈"였다.
+    if (!isBoardingLockActive(trip, now)) {
+      stats.lockMissing += 1;
+      log('boarding-lock: skip cycle (lock missing or expired)', {
+        token: trip.token.slice(0, 8),
+        station: waypoint.stationName,
+      });
       continue;
     }
 
+    // `polled`는 lock-active trip의 실제 Seoul polling 사이클 수만 카운트 — lockMissing은 별도 stat.
+    stats.polled += 1;
+    // #585 — boardingLock 활성 trip은 trainCode 단위 추적 + reschedule push 경로로 분기.
+    // 디바이스는 사전 예약 알람(#584)으로 SLA를 보장하므로 phase-based silent push는 보내지 않는다.
     try {
-      const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
-      const signal = pickBestArrivalSignal(arrivals, waypoint);
-      if (signal === null) {
-        stats.etaMissing += 1;
-        log('empty arrivals — skip cycle', {
-          token: trip.token.slice(0, 8),
-          station: waypoint.stationName,
-          line: waypoint.line,
-        });
-        continue;
-      }
-      const { etaSeconds: eta, arvlCd } = signal;
-
-      const phase = evaluatePhaseFromSignal(eta, arvlCd);
-      const etaChanged = isSignificantEtaChange(trip.lastEtaSeconds, eta);
-      const phaseFires = phase !== null && shouldFire(phase, trip.lastFiredPhase);
-      // 중간역(intermediate)은 통과 시점(imminent)에만 발사. early phase / 정보 갱신용 push는 노이즈로 간주해 스킵.
-      const isIntermediate = waypoint.kind === 'intermediate';
-
-      // 메모리 갱신: ETA가 의미있게 변하거나 phase가 발사된 경우만
-      let dirty = false;
-      if (etaChanged) {
-        trip.lastEtaSeconds = eta;
-        dirty = true;
-      }
-
-      // Push 발사 조건:
-      // (1) 새 phase 도달 — intermediate는 imminent에서만 허용
-      // (2) phase 미도달이지만 ETA 변동이 의미있게 발생 & 5분 이내 (intermediate는 제외)
-      const shouldPushPhase = phaseFires && (!isIntermediate || phase === 'imminent');
-      const shouldPushEtaUpdate =
-        !shouldPushPhase && !isIntermediate && etaChanged && eta <= EARLY_THRESHOLD_SEC * 2;
-
-      if (shouldPushPhase || shouldPushEtaUpdate) {
-        const pushPhase = phase ?? 'early';
-        log('push fired', {
-          token: trip.token.slice(0, 8),
-          kind: waypoint.kind,
-          phase: pushPhase,
-          station: waypoint.stationName,
-          etaSeconds: eta,
-          arvlCd,
-        });
-        const pushId = generatePushId();
-        const pushPayload = {
-          nextWaypoint: waypoint.stationName,
-          etaSeconds: eta,
-          phase: pushPhase,
-          kind: waypoint.kind,
-          sentAt: now,
-          pushId,
-        };
-        const heal = await sendWithEnvHeal(
-          (host) =>
-            sendSilentPush({
-              deviceToken: trip.token,
-              payload: pushPayload,
-              config: deps.apnsConfig,
-              host,
-              fetchImpl: deps.fetchImpl,
-              now,
-            }),
-          trip.apnsEnv,
-          deps.apnsHosts,
-          log,
-          trip.token.slice(0, 8),
-        );
-        if (heal.correctedEnv) {
-          trip.apnsEnv = heal.correctedEnv;
-          dirty = true;
-          stats.envCorrected += 1;
-        }
-        const envMismatchExhausted = heal.envMismatchExhausted;
-        const result = heal.result;
-
-        if (result.ok) {
-          stats.pushed += 1;
-          // #566 P2a — silent push 발사 성공 시 pending entry 기록. ACK 또는 P2c fallback이 정리한다.
-          // PENDING_PUSHES 미바인딩 시 putPending은 graceful no-op.
-          await putPending(env.PENDING_PUSHES, {
-            pushId,
-            token: trip.token,
-            alarmKey: buildAlarmKey(waypoint.stationName, pushPhase),
-            sentAt: now,
-            stationName: waypoint.stationName,
-            kind: waypoint.kind,
-            phase: pushPhase,
-            etaSeconds: eta,
-            // self-heal로 정정된 apnsEnv가 dirty에 반영되었더라도 현재 변수는 정정된 값.
-            // 누락 시 sandbox fallback과 일관 — pickApnsHost 동등 처리.
-            apnsEnv: trip.apnsEnv ?? 'sandbox',
-          });
-          if (shouldPushPhase) {
-            trip.lastFiredPhase = phase!;
-            dirty = true;
-            if (phase === 'imminent') {
-              if (waypoint.kind === 'destination') {
-                await deleteTrip(env.TRIPS, trip.token);
-                log('trip completed after destination imminent push', {
-                  token: trip.token.slice(0, 8),
-                });
-                continue;
-              }
-              // 환승역/중간역 imminent: 트립 유지하고 다음 waypoint로 진행.
-              // dirty는 위(lastFiredPhase 갱신)에서 이미 true로 설정됨 → putTrip에서 shift된 상태가 저장된다.
-              const completedStation = waypoint.stationName;
-              const completedKind = waypoint.kind;
-              trip.waypoints.shift();
-              trip.lastFiredPhase = undefined;
-              trip.lastEtaSeconds = undefined;
-              log('waypoint completed, advancing to next', {
-                token: trip.token.slice(0, 8),
-                completed: completedStation,
-                kind: completedKind,
-                remaining: trip.waypoints.length,
-              });
-              if (trip.waypoints.length === 0) {
-                await deleteTrip(env.TRIPS, trip.token);
-                continue;
-              }
-            }
-          }
-        } else {
-          stats.errors += 1;
-          log('apns push failed', {
-            status: result.status,
-            reason: result.reason,
-            token: trip.token.slice(0, 8),
-          });
-          if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
-            await deleteTrip(env.TRIPS, trip.token);
-            continue;
-          }
-        }
-      }
-
-      if (dirty) {
-        await putTrip(env.TRIPS, trip);
-      }
+      await runTrainCodeTracking(
+        trip,
+        waypoint,
+        trip.boardingLock,
+        env,
+        deps,
+        stats,
+        now,
+        log,
+        generatePushId,
+      );
     } catch (e) {
       stats.errors += 1;
-      log('poll error', { error: String(e), token: trip.token.slice(0, 8) });
+      log('boarding-lock: poll error', { error: String(e), token: trip.token.slice(0, 8) });
     }
   }
 


### PR DESCRIPTION
## 요약
사용자가 열차를 선택하지 않은 trip(`trip.boardingLock` 부재 또는 만료)에 대해 backend cron이 phase-based silent push를 발사해 "아직 안 골랐는데 왜 통과 알림이 오지?" 노이즈를 유발하던 문제 수정.

## 정책 (가)
- BoardingLock 활성이 아니면 silent push 0건
- Seoul polling 자체도 skip (불필요한 API 호출 제거)
- 디바이스는 lock 등록 후 train-code 단위로 정확히 추적 (#585 path)
- (나) train pinning(boardedAt + 매칭 train만 발사)은 본 이슈 범위 외, 별도 후속 권장

## 변경
- `backend/alarm-worker/src/scheduled.ts`
  - `isBoardingLockActive(trip, now)` type predicate 추가
  - `runScheduled`에 게이트 추가, `ScheduledStats.lockMissing` 카운터로 게이트 효과 관측 가능
  - legacy phase-based push 경로 전체 삭제 (게이트 이후 unreachable)
  - scheduled.ts에서만 쓰던 imports 정리 (`sendSilentPush`/`putPending`/`buildAlarmKey`/`evaluatePhaseFromSignal` 등). 모듈 자체는 유지 (apns.ts/pendingPushes.ts 내부 export 유지, fallback.ts가 PENDING_PUSHES 읽기 경로는 그대로 동작)
  - `stats.polled` 증가를 게이트 이후로 이동 — "실제 Seoul polling 사이클 수"로 의미 명확화
- `backend/alarm-worker/src/__tests__/scheduled.test.ts`
  - legacy push 테스트 ~360줄 통째로 제거 (self-heal/intermediate/early-imminent/dedup/pendingPushes 등)
  - 회귀 동등성 확인: self-heal/410/exhausted는 boardingLock describe 블록(line 893+)에서 동일 케이스 커버. pendingPushes module은 pendingPushes.test.ts에서 18 tests 유지
  - 추가: lockMissing gate 단위 테스트 (push 0건 + Seoul/APNs fetch 호출 0건)
  - "lock 만료 fall-through" 테스트는 게이트 차단 검증으로 재작성

## 리뷰 반영
code-review 에이전트 P1 3건 모두 반영:
- type predicate로 narrowing → `!` non-null assertion 제거
- `stats.polled` 의미 명확화 (lockMissing 분리)
- 로그 메시지 통일 (`boarding-lock:` prefix)

## 테스트
- [x] backend `npm test` 11 suites / 241 tests pass
- [x] backend `npm run type-check` 통과
- [x] 메인 앱 `npm run type-check` 통과 (영향 없음)
- [ ] 실기기 검증: 열차 미선택 상태에서 통과 알림 0건

Closes #640

## 자매 이슈
- #641 (client silent push BG handler 회귀): #642 별도 PR