### PR TITLE
fix(#644): smoke E2E 회귀 — destination/sleep mode assertVisible 스크롤 누락

### DIFF
--- a/.maestro/flows/smoke/02_destination_set_clear.yaml
+++ b/.maestro/flows/smoke/02_destination_set_clear.yaml
@@ -36,17 +36,25 @@ name: "smoke - 목적지 설정 & 초기화"
 - tapOn:
     id: "suggestion-item-2-016"
 
-- assertVisible:
-    text: "잠실|Jamsil"
-- assertVisible:
-    id: "destination-clear-button"
+- extendedWaitUntil:
+    visible:
+      text: "잠실|Jamsil"
+    timeout: 10000
 
-# 초기화 — clear 후 ScrollView contentOffset이 즉시 클램프되지 않아
-# "목적지 설정" 버튼이 viewport 위쪽 밖에 머무를 수 있어 scrollUntilVisible 필요.
+# #634/#625 머지 후 route 박스 안에 BoardingTrainList/BoardingLockBanner가 들어와
+# 박스 높이가 크게 증가 → actionsRow(destination-clear-button)가 viewport 밖.
+# scrollUntilVisible로 실제 화면에 끌어올린 뒤 탭.
+- scrollUntilVisible:
+    element:
+      id: "destination-clear-button"
+    direction: DOWN
+    timeout: 15000
+
+# 초기화 — clear 후 ScrollView contentOffset이 남아 "목적지 설정"이 위쪽에 숨을 수 있음.
 - tapOn:
     id: "destination-clear-button"
 - scrollUntilVisible:
     element:
       text: "목적지 설정|Set destination"
     direction: UP
-    timeout: 5000
+    timeout: 10000

--- a/.maestro/flows/smoke/02_destination_set_clear.yaml
+++ b/.maestro/flows/smoke/02_destination_set_clear.yaml
@@ -41,8 +41,12 @@ name: "smoke - 목적지 설정 & 초기화"
 - assertVisible:
     id: "destination-clear-button"
 
-# 초기화
+# 초기화 — clear 후 ScrollView contentOffset이 즉시 클램프되지 않아
+# "목적지 설정" 버튼이 viewport 위쪽 밖에 머무를 수 있어 scrollUntilVisible 필요.
 - tapOn:
     id: "destination-clear-button"
-- assertVisible:
-    text: "목적지 설정|Set destination"
+- scrollUntilVisible:
+    element:
+      text: "목적지 설정|Set destination"
+    direction: UP
+    timeout: 5000

--- a/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
+++ b/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
@@ -36,6 +36,12 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 - tapOn:
     id: "suggestion-item-2-016"
 
+# 목적지 설정 확정 대기 (route 박스가 렌더되어야 sleep-mode-switch가 트리에 들어옴)
+- extendedWaitUntil:
+    visible:
+      text: "잠실|Jamsil"
+    timeout: 10000
+
 # #634/#625 머지 후 destination 박스 안에 BoardingTrainList/BoardingLockBanner가
 # 들어와 박스 높이가 크게 증가 → 가장 하단의 sleep-mode-switch가 viewport 밖.
 # assertVisible은 자동 스크롤하지 않으므로 scrollUntilVisible 사용.
@@ -43,7 +49,7 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
     element:
       id: "home-sleep-mode-switch"
     direction: DOWN
-    timeout: 5000
+    timeout: 15000
 - tapOn:
     id: "home-sleep-mode-switch"
 
@@ -68,4 +74,4 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
     element:
       id: "home-sleep-mode-switch"
     direction: DOWN
-    timeout: 5000
+    timeout: 15000

--- a/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
+++ b/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
@@ -36,8 +36,14 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 - tapOn:
     id: "suggestion-item-2-016"
 
-- assertVisible:
-    id: "home-sleep-mode-switch"
+# #634/#625 머지 후 destination 박스 안에 BoardingTrainList/BoardingLockBanner가
+# 들어와 박스 높이가 크게 증가 → 가장 하단의 sleep-mode-switch가 viewport 밖.
+# assertVisible은 자동 스크롤하지 않으므로 scrollUntilVisible 사용.
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+    timeout: 5000
 - tapOn:
     id: "home-sleep-mode-switch"
 
@@ -55,8 +61,11 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 - tapOn:
     id: "sleep-mode-switch"
 
-# 홈 탭 복귀
+# 홈 탭 복귀 — 동일 사유로 scroll 필요
 - tapOn:
     point: "12%,95%"
-- assertVisible:
-    id: "home-sleep-mode-switch"
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+    timeout: 5000


### PR DESCRIPTION
## Summary
- dev 브랜치 push/nightly E2E Smoke (mock mode)에서 2건 결정적 실패 차단.
- 코드 변경 없음. \`.maestro/flows/smoke/02_destination_set_clear.yaml\`, \`05_sleep_mode_toggle.yaml\` 의 assertVisible 직전 \`scrollUntilVisible\` 추가.

## 원인
#634(BoardingTrainList) / #625(탑승 카드 route 컨텍스트 내부 이동) 머지 후 destination 박스 높이가 크게 증가:
- \`home-sleep-mode-switch\` (하단)가 viewport 밖.
- destination clear 후 ScrollView contentOffset이 즉시 클램프되지 않아 \"목적지 설정\" 버튼이 viewport 밖.

Maestro \`assertVisible\`은 자동 스크롤하지 않음.

## 실패 run
- https://github.com/handokei/subway-now/actions/runs/26629913593
  - \`smoke - 목적지 설정 & 초기화\` — \`\"목적지 설정|Set destination\" is visible\` false
  - \`smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)\` — \`id: home-sleep-mode-switch is visible\` false

## Test plan
- [ ] PR push 후 \`E2E Smoke (mock mode)\` 잡 6/6 PASS
- [ ] 변경 yaml 외 다른 flow는 그대로 통과 유지

## 후속
- 통합 flow PR(\`chore/ci-smoke-consolidate\`, \`02_destination_sleep.yaml\`)도 동일 scrollUntilVisible 패턴으로 재편 후 머지.

Closes #644