### PR TITLE
fix(#648): SCHED-* fallback trainCode 노출 차단 — '시간표' 라벨로 대체

### DIFF
--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -4,6 +4,7 @@ import { LineBadge } from './LineBadge';
 import type { ArrivalInfo } from '../api/arrivalApi';
 import type { LineNumber } from '../types/station';
 import { formatClockTime } from '../utils/formatTime';
+import { isScheduleFallbackTrainCode } from '../utils/scheduleFallback';
 
 interface Props {
   arrivals: ArrivalInfo[];
@@ -64,7 +65,13 @@ export function BoardingTrainList({
           >
             <View style={styles.rowInfo}>
               <Text style={[typography.body, { color: colors.ink }]}>{train.destination} 행</Text>
-              <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
+              {/* #648: 시간표 fallback의 가상 trainCode(SCHED-*)는 사용자에게 무의미하므로 숨김.
+                  실시간 trainCode는 그대로 노출. */}
+              {isScheduleFallbackTrainCode(train.trainCode) ? (
+                <Text style={[typography.mono, { color: colors.subtle }]}>시간표</Text>
+              ) : (
+                <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
+              )}
             </View>
             <Text
               style={[typography.body, { color: colors.accent, fontWeight: '600' }]}

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -102,6 +102,16 @@ describe('BoardingTrainList', () => {
     expect(onSelect).toHaveBeenCalledWith(reachable);
   });
 
+  it('#648 SCHED-* trainCode는 사용자에게 숨기고 "시간표" 라벨로 대체', () => {
+    const fallback = makeTrain({ trainCode: 'SCHED-DN-1', destination: '석남' });
+    const { getByText, queryByText } = renderWithTheme(
+      <BoardingTrainList arrivals={[fallback]} line="7" onSelect={() => {}} />,
+    );
+    expect(queryByText('SCHED-DN-1')).toBeNull();
+    expect(getByText('시간표')).toBeTruthy();
+    expect(getByText('석남 행')).toBeTruthy();
+  });
+
   it('walkingBufferSeconds 미전달이면 모든 train 활성', () => {
     const tooSoon = makeTrain({ trainCode: 'T-EARLY', arrivalSeconds: 60 });
     const onSelect = jest.fn();

--- a/src/utils/__tests__/scheduleFallback.test.ts
+++ b/src/utils/__tests__/scheduleFallback.test.ts
@@ -4,6 +4,8 @@ import {
   buildScheduleArrival,
   hasHeadwayData,
   hasTerminalData,
+  isScheduleFallbackTrainCode,
+  SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX,
 } from '../scheduleFallback';
 import type { LineNumber } from '../../types/station';
 import type { StationArrival } from '../../api/arrivalApi';
@@ -365,5 +367,18 @@ describe('hasTerminalData', () => {
 
   it('returns false for an unknown line', () => {
     expect(hasTerminalData('gtx-a' as LineNumber)).toBe(false);
+  });
+});
+
+describe('isScheduleFallbackTrainCode', () => {
+  it('SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX 로 시작하는 코드만 true', () => {
+    expect(isScheduleFallbackTrainCode(`${SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX}DN-1`)).toBe(true);
+    expect(isScheduleFallbackTrainCode(`${SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX}UP-2`)).toBe(true);
+  });
+
+  it('실시간 trainCode(숫자 등)는 false', () => {
+    expect(isScheduleFallbackTrainCode('7273')).toBe(false);
+    expect(isScheduleFallbackTrainCode('')).toBe(false);
+    expect(isScheduleFallbackTrainCode('SC')).toBe(false);
   });
 });

--- a/src/utils/scheduleFallback.ts
+++ b/src/utils/scheduleFallback.ts
@@ -129,6 +129,17 @@ function lookupHeadwaySeconds(line: LineNumber, dayType: DayType, period: Period
   return Number.isFinite(value) ? value : null;
 }
 
+/**
+ * 시간표 fallback이 생성한 가상 trainCode prefix. 실시간 API가 빈약한 시간대에 사용되며,
+ * BoardingTrainList 등 UI에서 사용자에게 노출하지 않기 위한 식별자(#648).
+ */
+export const SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX = 'SCHED-';
+
+/** trainCode가 시간표 fallback에서 만들어진 가상 코드인지 판별(#648). */
+export function isScheduleFallbackTrainCode(trainCode: string): boolean {
+  return trainCode.startsWith(SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX);
+}
+
 function makeTrain(
   secondsFromNow: number,
   suffix: string,
@@ -140,7 +151,7 @@ function makeTrain(
     arrivalMinutes: Math.max(0, Math.floor(secondsFromNow / 60)),
     arrivalSeconds: secondsFromNow,
     statusMessage: '',
-    trainCode: `SCHED-${suffix}`,
+    trainCode: `${SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX}${suffix}`,
     receivedAtMs: nowMs,
     arrivalCode: -1,
     isLastTrain: false,


### PR DESCRIPTION
## Summary
- 실시간 도착 API가 빈약한 시간대(예: 새벽)에 \`scheduleFallback.ts\`가 생성하는 가상 trainCode \`SCHED-DN-1\` 등이 BoardingTrainList row에 그대로 노출돼 사용자에게 의미 불명 텍스트로 보였음.
- \`SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX\` 상수 + \`isScheduleFallbackTrainCode\` 헬퍼 추출 후 컴포넌트에서 분기 — fallback은 \"시간표\"로 대체.
- 실시간 trainCode(예: \`7273\`)는 변동 없음.

## 발견 경로
2026-05-30 04:38 용마산역 7호선 실기기 검증 중 \`SCHED-DN-1\` / \`SCHED-DN-2\` 두 row 모두 노출됨.

## Test plan
- [x] 단위 테스트: \`isScheduleFallbackTrainCode\` true/false 케이스
- [x] 컴포넌트 테스트: SCHED-* trainCode → \"시간표\" 라벨, 실시간 코드는 그대로
- [x] 전체 테스트 2164/2164 PASS, 타입체크 통과

Closes #648