### PR TITLE
test: DebugModal alarm log race fix — CI 간헐 실패 결정적 해소

### DIFF
--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -130,11 +130,12 @@ describe('DebugModal', () => {
     };
     mockGetAlarmLog.mockResolvedValue([logEntry]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
-    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    // setLogs(await getAlarmLog())의 await→setState→re-render race를 피하려면
+    // mock 호출 시점이 아니라 logs 의존 UI(Alarm log 카운트)가 나타날 때까지 대기.
+    expect(await screen.findByText('Alarm log (1)')).toBeTruthy();
     expect(screen.getByText('GPS')).toBeTruthy();
     expect(screen.getByText('Nearest station')).toBeTruthy();
     expect(screen.getByText('Arrival')).toBeTruthy();
-    expect(screen.getByText('Alarm log (1)')).toBeTruthy();
     expect(screen.getByTestId('debug-arrival-summary').props.children).toContain('청량리');
   });
 
@@ -145,8 +146,7 @@ describe('DebugModal', () => {
       { ts: 3, source: 'alert-fallback-fired', outcome: 'fired' },
     ]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
-    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-    const counts = screen.getByTestId('debug-log-source-counts');
+    const counts = await screen.findByTestId('debug-log-source-counts');
     expect(counts.props.children).toBe('alert-fallback-fired=2, fg=1');
   });
 


### PR DESCRIPTION
## Summary
CI의 \`Type Check & Test\`가 \`DebugModal.test.tsx\`에서 간헐 실패 (\`Unable to find an element with text: Alarm log (1)\`). 

원인: \`refreshLogs\`의 \`setLogs(await getAlarmLog())\`에서 \`await\` 분기점이 mock 호출 직후. 기존 테스트는 \`waitFor(mockGetAlarmLog 호출됨)\`을 사용 — 이건 await 들어가는 순간 resolve되지만 setState→re-render는 아직 flush 안 됨. 그래서 직후 sync \`getByText('Alarm log (1)')\`가 race로 실패. CI(느림)에서 노출.

- 첫 케이스(123줄): \`findByText('Alarm log (1)')\`로 변경 — UI state 등장까지 대기.
- 둘째 케이스(141줄): \`findByTestId('debug-log-source-counts')\`로 동일 처리.
- 다른 12개 동일 패턴은 후속에서 점진 정리. 결정적으로 fail하던 2건만 surgical 수정.

## Test plan
- [x] 로컬 \`npm test -- --testPathPattern=DebugModal\` 60/60 PASS
- [ ] PR CI 통과 (이전 #650 재발 케이스)

## 영향
- 실시간 동작 영향 0 (테스트 코드만 수정)
- 머지 후 #650, #642 등 다른 PR이 같은 flake로 fail하지 않음