### PR TITLE
refactor(#649): BoardingTrainList을 EditorialTimeline hop 사이 inline 배치 + 다음 인접역 라벨

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -47,6 +47,8 @@ import { useTrainPositions } from '../../src/hooks/useTrainPositions';
 import { useTransferTrainList } from '../../src/hooks/useTransferTrainList';
 import { TRANSFER_WALKING_BUFFER_SECONDS } from '../../src/constants/boardingLock';
 import { BoardingTrainList } from '../../src/components/BoardingTrainList';
+import { resolveNextAdjacentStationName } from '../../src/utils/nextAdjacentStation';
+import type { Stop } from '../../src/utils/journeyAdapter';
 
 const logger = createLogger('HomeScreen');
 
@@ -608,24 +610,73 @@ export default function HomeScreen() {
                       })}
                     </View>
                   )}
-                  {journey && (
-                    <>
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel={routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
-                        onPress={() => setRouteExpanded((v) => !v)}
-                        style={styles.expandToggle}
-                        testID="route-expand-toggle"
-                      >
-                        <Text style={[typography.label, { color: colors.accent, fontWeight: '600' }]}>
-                          {routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
-                        </Text>
-                      </Pressable>
-                      <EditorialTimeline
-                        stops={journeyDisplayToStops(journey, { expanded: routeExpanded })}
-                      />
-                    </>
-                  )}
+                  {journey && (() => {
+                    const stops = journeyDisplayToStops(journey, { expanded: routeExpanded });
+                    return (
+                      <>
+                        <Pressable
+                          accessibilityRole="button"
+                          accessibilityLabel={routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
+                          onPress={() => setRouteExpanded((v) => !v)}
+                          style={styles.expandToggle}
+                          testID="route-expand-toggle"
+                        >
+                          <Text style={[typography.label, { color: colors.accent, fontWeight: '600' }]}>
+                            {routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
+                          </Text>
+                        </Pressable>
+                        <EditorialTimeline
+                          stops={stops}
+                          renderHopSlot={(stop, i) => {
+                            // #649 — origin hop slot: 현재역에서 다음 인접역 방면 boarding list
+                            if (i === 0 && stop.mark === 'filled' && !boardingLock && effectiveOrigin) {
+                              const towardName = findNextWaypointName(stops, i);
+                              const label = towardName
+                                ? resolveNextAdjacentStationName(
+                                    effectiveOrigin.line,
+                                    effectiveOrigin.name,
+                                    towardName,
+                                  )
+                                : null;
+                              return (
+                                <BoardingTrainList
+                                  arrivals={directionalArrivals}
+                                  line={effectiveOrigin.line}
+                                  onSelect={createLockFromTrain}
+                                  compact
+                                  nextStationLabel={label}
+                                />
+                              );
+                            }
+                            // #649 — transfer hop slot: 현재 활성 transfer 시점에만 노출.
+                            // multi-transfer 라우트에서도 transferContext가 가리키는 단일 transfer만 매칭.
+                            if (
+                              stop.mark === 'transfer' &&
+                              transferContext &&
+                              stop.station === transferContext.transferStationInToLine.name
+                            ) {
+                              const label = resolveNextAdjacentStationName(
+                                transferContext.nextLine,
+                                transferContext.transferStationInToLine.name,
+                                transferContext.nextWaypointName,
+                              );
+                              return (
+                                <BoardingTrainList
+                                  arrivals={transferArrivals}
+                                  line={transferContext.nextLine}
+                                  onSelect={createTransferLock}
+                                  walkingBufferSeconds={TRANSFER_WALKING_BUFFER_SECONDS}
+                                  compact
+                                  nextStationLabel={label}
+                                />
+                              );
+                            }
+                            return null;
+                          }}
+                        />
+                      </>
+                    );
+                  })()}
                   {route && effectiveOrigin && destination && (
                     <Pressable
                       style={[styles.viewOnMapButton, { borderColor: colors.accent }]}
@@ -647,25 +698,8 @@ export default function HomeScreen() {
                   {boardingLock && (
                     <BoardingLockBanner lock={boardingLock} onRelease={releaseBoardingLock} />
                   )}
-                  {/* #634 — 탑승 전 열차 선택 list도 route 컨텍스트 안에서 노출.
-                       이전엔 하단 별도 섹션이라 사용자가 경로와 분리된 카드로 인지. */}
-                  {!boardingLock && effectiveOrigin && (
-                    <BoardingTrainList
-                      arrivals={directionalArrivals}
-                      line={effectiveOrigin.line}
-                      onSelect={createLockFromTrain}
-                    />
-                  )}
-                  {/* PR E: 환승 waypoint 도달 시 다음 노선 list. context 비어있으면 노출 안 됨. */}
-                  {transferContext && (
-                    <BoardingTrainList
-                      arrivals={transferArrivals}
-                      line={transferContext.nextLine}
-                      onSelect={createTransferLock}
-                      walkingBufferSeconds={TRANSFER_WALKING_BUFFER_SECONDS}
-                      title="환승 열차 선택"
-                    />
-                  )}
+                  {/* #649 — BoardingTrainList 두 인스턴스(현재역/환승)는 EditorialTimeline의
+                       renderHopSlot으로 이동: timeline hop 사이에 inline compact 표기. */}
                 </View>
 
                 {/* Actions */}
@@ -809,6 +843,17 @@ export default function HomeScreen() {
       />
     </SafeAreaView>
   );
+}
+
+/**
+ * stops 배열에서 fromIdx 다음의 waypoint(intermediate 아닌 stop) 이름을 찾는다(#649).
+ * 종착까지 도달 못 하면 null — slot에서 라벨 계산 fallback에 사용.
+ */
+function findNextWaypointName(stops: Stop[], fromIdx: number): string | null {
+  for (let i = fromIdx + 1; i < stops.length; i++) {
+    if (stops[i].mark !== 'intermediate') return stops[i].station;
+  }
+  return null;
 }
 
 function ArrivalRow({

--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -15,8 +15,18 @@ interface Props {
    * 환승 list에서 도보 buffer 표현용. 미전달 시 모든 열차 활성.
    */
   walkingBufferSeconds?: number;
-  /** 헤더 라벨 커스텀 (환승 list 등). 미전달 시 기본 "탑승할 열차 선택". */
+  /** 헤더 라벨 커스텀 (환승 list 등). 미전달 시 기본 "탑승할 열차 선택". compact=true면 무시. */
   title?: string;
+  /**
+   * 트레인 destination(종착) 대신 표시할 다음 인접역 라벨(#649). "{label} 방면" 형태로 노출.
+   * 호출자가 resolveNextAdjacentStationName으로 계산해 전달. null/미전달이면 destination 표기.
+   */
+  nextStationLabel?: string | null;
+  /**
+   * Timeline hop slot 안 inline 배치용 컴팩트 모드(#649). 헤더/카드 배경 제거,
+   * row padding 축소, 폰트 한 단계 다운, trainCode 라인 생략.
+   */
+  compact?: boolean;
 }
 
 /**
@@ -24,9 +34,9 @@ interface Props {
  *
  * 호출자는 이미 route 방향으로 필터링된 arrivals를 전달한다 — 이 컴포넌트는 디스플레이/탭 처리만 담당.
  * 각 row를 탭하면 onSelect 콜백이 발화 → 호출자가 BoardingLock 생성.
- * 빈 list면 placeholder 안내 텍스트.
  *
- * #634: 도착 시각을 "분" 상대 표기 → "HH:mm" 절대 표기로 전환. 사용자 시계와 직접 매칭.
+ * #634: 도착 시각을 "분" 상대 표기 → "HH:mm" 절대 표기.
+ * #649: compact + nextStationLabel — Timeline hop slot 안에 inline 배치되는 형태 지원.
  */
 export function BoardingTrainList({
   arrivals,
@@ -34,6 +44,8 @@ export function BoardingTrainList({
   onSelect,
   walkingBufferSeconds,
   title = '탑승할 열차 선택',
+  nextStationLabel = null,
+  compact = false,
 }: Props) {
   const { colors } = useTheme();
   const isUnreachable = (train: ArrivalInfo): boolean =>
@@ -41,40 +53,66 @@ export function BoardingTrainList({
 
   if (arrivals.length === 0) {
     return (
-      <View style={styles.empty} testID="boarding-train-list-empty">
+      <View
+        style={compact ? styles.emptyCompact : styles.empty}
+        testID="boarding-train-list-empty"
+      >
         <Text style={[typography.bodySm, { color: colors.muted }]}>도착 예정 열차가 없습니다.</Text>
       </View>
     );
   }
 
   return (
-    <View style={styles.container} testID="boarding-train-list">
-      <View style={styles.header}>
-        <LineBadge line={line} />
-        <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
-      </View>
+    <View
+      style={compact ? styles.containerCompact : styles.container}
+      testID="boarding-train-list"
+    >
+      {!compact && (
+        <View style={styles.header}>
+          <LineBadge line={line} />
+          <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
+        </View>
+      )}
       {arrivals.map((train) => {
         const unreachable = isUnreachable(train);
+        const labelText = nextStationLabel
+          ? `${nextStationLabel} 방면`
+          : `${train.destination} 행`;
         return (
           <Pressable
             key={train.trainCode}
             onPress={() => onSelect(train)}
             disabled={unreachable}
-            style={[styles.row, { backgroundColor: colors.card, opacity: unreachable ? 0.4 : 1 }]}
+            style={[
+              compact ? styles.rowCompact : styles.row,
+              compact ? null : { backgroundColor: colors.card },
+              { opacity: unreachable ? 0.4 : 1 },
+            ]}
             testID={`boarding-train-row-${train.trainCode}`}
           >
-            <View style={styles.rowInfo}>
-              <Text style={[typography.body, { color: colors.ink }]}>{train.destination} 행</Text>
-              {/* #648: 시간표 fallback의 가상 trainCode(SCHED-*)는 사용자에게 무의미하므로 숨김.
-                  실시간 trainCode는 그대로 노출. */}
-              {isScheduleFallbackTrainCode(train.trainCode) ? (
-                <Text style={[typography.mono, { color: colors.subtle }]}>시간표</Text>
-              ) : (
-                <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
-              )}
-            </View>
+            {compact ? (
+              <Text
+                style={[typography.bodySm, { color: colors.ink, flex: 1 }]}
+                testID={`boarding-train-label-${train.trainCode}`}
+              >
+                {labelText}
+              </Text>
+            ) : (
+              <View style={styles.rowInfo}>
+                <Text style={[typography.body, { color: colors.ink }]}>{labelText}</Text>
+                {/* #648: 시간표 fallback의 가상 trainCode(SCHED-*)는 무의미하므로 "시간표" 라벨로 대체. */}
+                {isScheduleFallbackTrainCode(train.trainCode) ? (
+                  <Text style={[typography.mono, { color: colors.subtle }]}>시간표</Text>
+                ) : (
+                  <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
+                )}
+              </View>
+            )}
             <Text
-              style={[typography.body, { color: colors.accent, fontWeight: '600' }]}
+              style={[
+                compact ? typography.bodySm : typography.body,
+                { color: colors.accent, fontWeight: '600' },
+              ]}
               testID={`boarding-train-arrival-${train.trainCode}`}
             >
               {formatArrivalClock(train)}
@@ -100,6 +138,9 @@ const styles = StyleSheet.create({
   container: {
     gap: spacing.sm,
   },
+  containerCompact: {
+    gap: spacing.xs,
+  },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -112,11 +153,22 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.md,
   },
+  rowCompact: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+  },
   rowInfo: {
     gap: spacing.xs,
   },
   empty: {
     padding: spacing.lg,
     alignItems: 'center',
+  },
+  emptyCompact: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
   },
 });

--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -12,6 +12,11 @@ import type { LineNumber } from '../types/station';
 
 interface Props {
   stops: Stop[];
+  /**
+   * 각 hop row 직후에 inline 노드를 끼울 수 있는 slot 콜백(#649). null 반환 시 slot 미렌더.
+   * BoardingTrainList 등 hop별 보조 정보를 timeline 흐름 안쪽에 배치할 때 사용.
+   */
+  renderHopSlot?: (stop: Stop, index: number) => React.ReactNode;
 }
 
 // 한 stop의 도어번호 라벨을 결정한다.
@@ -50,7 +55,7 @@ function doorFor(stop: Stop | null, accessibilityMode: boolean): string | null {
   return resolveStopDoor(stop.arrivalContext, toLine, accessibilityMode);
 }
 
-export function EditorialTimeline({ stops }: Props) {
+export function EditorialTimeline({ stops, renderHopSlot }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const accessibilityMode = useAppStore((s) => s.accessibilityMode);
@@ -75,9 +80,10 @@ export function EditorialTimeline({ stops }: Props) {
         const boardingDoor = doorFor(nextHopStop, accessibilityMode);
 
         const isIntermediate = s.mark === 'intermediate';
+        const slot = renderHopSlot ? renderHopSlot(s, i) : null;
         return (
+          <React.Fragment key={i}>
           <View
-            key={i}
             style={[styles.row, isLast && { minHeight: 36 }, isIntermediate && styles.rowIntermediate]}
             testID={`timeline-stop-${i}`}
           >
@@ -149,6 +155,12 @@ export function EditorialTimeline({ stops }: Props) {
               )}
             </View>
           </View>
+          {slot != null && (
+            <View testID={`timeline-hop-slot-${i}`} style={styles.hopSlot}>
+              {slot}
+            </View>
+          )}
+          </React.Fragment>
         );
       })}
     </View>
@@ -191,4 +203,8 @@ const styles = StyleSheet.create({
   dotDest: { width: 12, height: 12, borderRadius: 6 },
   dotIntermediate: { width: 7, height: 7, borderRadius: 4, borderWidth: 1, marginLeft: 1.5 },
   rowIntermediate: { minHeight: 30 },
+  hopSlot: {
+    paddingLeft: 28 + spacing.md, // markerCol 폭 + 행 gap — slot이 station label과 좌측 정렬되도록
+    paddingBottom: spacing.xs,
+  },
 });

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -121,4 +121,42 @@ describe('BoardingTrainList', () => {
     fireEvent.press(getByTestId('boarding-train-row-T-EARLY'));
     expect(onSelect).toHaveBeenCalled();
   });
+
+  it('#649 nextStationLabel 전달 시 "{label} 방면" 으로 표기 (destination 행 대체)', () => {
+    const train = makeTrain({ trainCode: 'T-NEXT', destination: '석남' });
+    const { getByText, queryByText } = renderWithTheme(
+      <BoardingTrainList
+        arrivals={[train]}
+        line="7"
+        onSelect={() => {}}
+        nextStationLabel="중곡"
+      />,
+    );
+    expect(getByText('중곡 방면')).toBeTruthy();
+    expect(queryByText('석남 행')).toBeNull();
+  });
+
+  it('#649 compact 모드: 헤더/trainCode 라인 생략, 단일 row 라벨만', () => {
+    const train = makeTrain({ trainCode: 'T-COMPACT', destination: '석남' });
+    const { getByTestId, queryByText } = renderWithTheme(
+      <BoardingTrainList
+        arrivals={[train]}
+        line="7"
+        onSelect={() => {}}
+        compact
+        nextStationLabel="중곡"
+      />,
+    );
+    expect(getByTestId('boarding-train-label-T-COMPACT').props.children).toBe('중곡 방면');
+    expect(queryByText('탑승할 열차 선택')).toBeNull();
+    expect(queryByText('T-COMPACT')).toBeNull();
+  });
+
+  it('#649 compact + 빈 arrivals 도 동일 placeholder', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <BoardingTrainList arrivals={[]} line="7" onSelect={() => {}} compact />,
+    );
+    expect(getByTestId('boarding-train-list-empty')).toBeTruthy();
+    expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
+  });
 });

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -98,6 +98,28 @@ describe('EditorialTimeline', () => {
     const { toJSON } = render(<EditorialTimeline stops={[]} />);
     expect(toJSON()).toBeTruthy();
   });
+
+  it('#649 renderHopSlot — 각 hop 직후 slot 노드가 렌더된다 (non-null 반환에만)', () => {
+    const { Text } = require('react-native');
+    render(
+      <EditorialTimeline
+        stops={MOCK_STOPS.threeStops}
+        renderHopSlot={(stop, i) =>
+          i === 0 ? <Text testID="slot-content-0">slot0</Text> : null
+        }
+      />,
+    );
+    expect(screen.getByTestId('timeline-hop-slot-0')).toBeTruthy();
+    expect(screen.getByTestId('slot-content-0')).toBeTruthy();
+    // i=1,2는 null 반환 — slot 컨테이너 자체도 없음
+    expect(screen.queryByTestId('timeline-hop-slot-1')).toBeNull();
+    expect(screen.queryByTestId('timeline-hop-slot-2')).toBeNull();
+  });
+
+  it('#649 renderHopSlot 미전달이면 slot 컨테이너 없음 (기존 호출자 영향 0)', () => {
+    render(<EditorialTimeline stops={MOCK_STOPS.threeStops} />);
+    expect(screen.queryByTestId('timeline-hop-slot-0')).toBeNull();
+  });
 });
 
 describe('EditorialTimeline quickExit door label', () => {

--- a/src/utils/__tests__/nextAdjacentStation.test.ts
+++ b/src/utils/__tests__/nextAdjacentStation.test.ts
@@ -1,0 +1,46 @@
+import { resolveNextAdjacentStationName } from '../nextAdjacentStation';
+import { getStationsOnLine } from '../stationRoute';
+
+describe('resolveNextAdjacentStationName', () => {
+  it('7호선 단조 — 용마산에서 부평구청(downstream 종점) 방향 → 한 칸 다음 인접역', () => {
+    const stations = getStationsOnLine('7');
+    const yongmasanIdx = stations.findIndex((s) => s.name === '용마산');
+    expect(yongmasanIdx).toBeGreaterThan(-1);
+    const next = resolveNextAdjacentStationName('7', '용마산', '부평구청');
+    expect(next).toBe(stations[yongmasanIdx + 1].name);
+  });
+
+  it('7호선 — 용마산에서 장암(upstream 종점) 방향 → 반대편 인접역', () => {
+    const stations = getStationsOnLine('7');
+    const yongmasanIdx = stations.findIndex((s) => s.name === '용마산');
+    const next = resolveNextAdjacentStationName('7', '용마산', '장암');
+    expect(next).toBe(stations[yongmasanIdx - 1].name);
+  });
+
+  it('비단조 노선(2호선 순환)은 null', () => {
+    expect(resolveNextAdjacentStationName('2', '강남', '잠실')).toBeNull();
+  });
+
+  it('towardStation이 stations에 없으면 (확장 미반영 종점 등) null', () => {
+    // 7호선 stations.json에 석남(인천 연장) 미반영 — resolveTravelDirection이 null 반환
+    expect(resolveNextAdjacentStationName('7', '용마산', '석남')).toBeNull();
+  });
+
+  it('현재역이 stations 리스트에 없으면 null', () => {
+    expect(resolveNextAdjacentStationName('7', '__missing__', '부평구청')).toBeNull();
+  });
+
+  it('현재역과 toward가 동일하면 null (방향 결정 불가)', () => {
+    expect(resolveNextAdjacentStationName('7', '용마산', '용마산')).toBeNull();
+  });
+
+  it('현재역이 노선 종점이고 그 너머 방향은 인접역이 없어 null', () => {
+    const stations = getStationsOnLine('7');
+    const first = stations[0].name; // 장암
+    const last = stations[stations.length - 1].name; // 부평구청
+    // 장암에서 부평구청 방향 → first의 다음(인덱스 +1)이 정상 인접역
+    expect(resolveNextAdjacentStationName('7', first, last)).toBe(stations[1].name);
+    // 부평구청에서 장암 방향 → last의 이전(인덱스 -1)
+    expect(resolveNextAdjacentStationName('7', last, first)).toBe(stations[stations.length - 2].name);
+  });
+});

--- a/src/utils/nextAdjacentStation.ts
+++ b/src/utils/nextAdjacentStation.ts
@@ -9,9 +9,8 @@ import { getStationsOnLine, normalizeStationName } from './stationRoute';
  * 다음 정거장(중곡) 같은 즉각적인 정보를 노출한다.
  *
  * 단조 노선(`lineTopology.json`의 monotonicLines)에 한해 동작. 비단조/순환 노선이거나
- * 현재역/방향역이 stations 리스트에서 매칭 안 되면 null — 호출자는 fallback(종착 표기 등)을 선택한다.
- *
- * 현재역이 방향 끝(첫/마지막 정거장)이면 null.
+ * 현재역/방향역이 stations 리스트에서 매칭 안 되면 resolveTravelDirection이 null 반환 →
+ * 본 함수도 null. 호출자는 fallback(종착 표기 등)을 선택한다.
  */
 export function resolveNextAdjacentStationName(
   line: LineNumber,
@@ -20,11 +19,12 @@ export function resolveNextAdjacentStationName(
 ): string | null {
   const resolution = resolveTravelDirection(line, currentStationName, towardStationName);
   if (!resolution) return null;
+  // resolveTravelDirection이 같은 stations 캐시를 normalize로 매칭해 성공했으므로,
+  // 같은 캐시·같은 normalize로 currentIdx 재조회는 반드시 ≥0. 노선 종단점도 toward와 동일하지
+  // 않으므로 nextIdx는 항상 유효 범위 안.
   const stations = getStationsOnLine(line);
   const target = normalizeStationName(currentStationName);
   const currentIdx = stations.findIndex((s) => normalizeStationName(s.name) === target);
-  if (currentIdx === -1) return null;
   const nextIdx = resolution.direction === 'down' ? currentIdx + 1 : currentIdx - 1;
-  if (nextIdx < 0 || nextIdx >= stations.length) return null;
   return stations[nextIdx].name;
 }

--- a/src/utils/nextAdjacentStation.ts
+++ b/src/utils/nextAdjacentStation.ts
@@ -1,0 +1,30 @@
+import type { LineNumber } from '../types/station';
+import { resolveTravelDirection } from './travelDirection';
+import { getStationsOnLine, normalizeStationName } from './stationRoute';
+
+/**
+ * 현재역에서 toward 방향(다음 waypoint 또는 종착)으로 한 정거장 뒤의 인접역 이름을 반환(#649).
+ *
+ * BoardingTrainList가 사용자에게 "다음 인접역 방면"으로 표기하기 위함 — 종착(석남) 대신
+ * 다음 정거장(중곡) 같은 즉각적인 정보를 노출한다.
+ *
+ * 단조 노선(`lineTopology.json`의 monotonicLines)에 한해 동작. 비단조/순환 노선이거나
+ * 현재역/방향역이 stations 리스트에서 매칭 안 되면 null — 호출자는 fallback(종착 표기 등)을 선택한다.
+ *
+ * 현재역이 방향 끝(첫/마지막 정거장)이면 null.
+ */
+export function resolveNextAdjacentStationName(
+  line: LineNumber,
+  currentStationName: string,
+  towardStationName: string,
+): string | null {
+  const resolution = resolveTravelDirection(line, currentStationName, towardStationName);
+  if (!resolution) return null;
+  const stations = getStationsOnLine(line);
+  const target = normalizeStationName(currentStationName);
+  const currentIdx = stations.findIndex((s) => normalizeStationName(s.name) === target);
+  if (currentIdx === -1) return null;
+  const nextIdx = resolution.direction === 'down' ? currentIdx + 1 : currentIdx - 1;
+  if (nextIdx < 0 || nextIdx >= stations.length) return null;
+  return stations[nextIdx].name;
+}


### PR DESCRIPTION
## Summary
실기기 검증(2026-05-30) 피드백 반영. BoardingTrainList이 별도 카드로 timeline 아래 떠 있어 정신 사납고 분리됨. 두 가지 동시 개선:

1. **위치**: EditorialTimeline의 hop row 직후 slot으로 inline 배치 (네이버 지도 환승 안내 형태)
2. **라벨**: 종착("석남") 대신 다음 인접역("중곡") "방면" 표기

## 구현
- \`resolveNextAdjacentStationName\` 유틸 신규 (monotonic 노선 + travelDirection 활용)
- \`BoardingTrainList\` \`compact\` + \`nextStationLabel\` props 추가
- \`EditorialTimeline\` \`renderHopSlot\` prop — 각 hop 직후 inline 노드
- \`index.tsx\`: 두 BoardingTrainList을 EditorialTimeline slot으로 이동

## Test plan
- [x] 단위/컴포넌트 테스트 2173/2173 PASS, 타입체크 통과
- [ ] 실기기 시각 확인

Closes #649