### PR TITLE
fix(#676): 비단조 노선에서 빠른 환승/하차 도어 라벨 표시

### DIFF
--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from '../store/useAppStore';
 import { resolveQuickExit } from '../utils/quickExit';
 import { resolveTravelDirection } from '../utils/travelDirection';
 import { resolveTransferDoor } from '../utils/transferExit';
+import { findStationByNameAndLine } from '../utils/stationRoute';
 import type { LineNumber } from '../types/station';
 
 interface Props {
@@ -21,7 +22,10 @@ interface Props {
 
 // 한 stop의 도어번호 라벨을 결정한다.
 // - 환승 stop이면 fromLine→toLine 빠른 환승 도어를 우선 사용 (transferExit.json).
-// - 매칭 없으면 단조 노선 + quickExit 데이터로 fallback (계단/EV 가까운 도어).
+// - 매칭 없으면 quickExit 데이터로 fallback (계단/EV 가까운 도어).
+//   · 단조 노선(MONOTONIC_LINES): direction 필터로 방면별 정확한 도어 선택.
+//   · 비단조 노선(1·2·5·6호선, 경의중앙선 등 — #676): direction 없이 station_id만으로 조회.
+//     좌/우 안내는 정확성 보장 불가라 생략되지만 도어 번호는 노선 무관 표시 가능.
 // - 둘 다 없으면 null — 라벨 미표시.
 function resolveStopDoor(
   ctx: StopArrivalContext,
@@ -37,11 +41,17 @@ function resolveStopDoor(
     if (transfer) return transfer.doorNumber;
   }
   const resolution = resolveTravelDirection(ctx.line, ctx.fromName, ctx.toName);
-  if (!resolution) return null;
-  const result = resolveQuickExit(resolution.toStation.id, {
-    accessibilityMode,
-    direction: resolution.direction,
-  });
+  if (resolution) {
+    const result = resolveQuickExit(resolution.toStation.id, {
+      accessibilityMode,
+      direction: resolution.direction,
+    });
+    return result ? result.entry.doorNumber : null;
+  }
+  // 비단조 노선 fallback: line + toName으로 station 직접 매칭 (stationRoute의 SSOT helper 재사용).
+  const station = findStationByNameAndLine(ctx.toName, ctx.line);
+  if (!station) return null;
+  const result = resolveQuickExit(station.id, { accessibilityMode });
   return result ? result.entry.doorNumber : null;
 }
 

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -7,11 +7,17 @@ import type { LineNumber } from '../../types/station';
 import { useAppStore } from '../../store/useAppStore';
 
 // 결정적 빠른하차 픽스처 — quickExit 라벨/모드 분기 검증용.
-// 3호선 경복궁(id 3-019)에만 상행 stairs/엘리베이터 엔트리 등록.
+// - 3호선 경복궁(id 3-019): 단조 노선 + direction 필터 케이스.
+// - 1호선 회기(id 1-024): #676 비단조 노선 fallback (direction 없이 도어 노출) 검증용.
+//   direction 미지정 엔트리도 섞어 — 비단조 fallback이 모든 엔트리를 그대로 채택하는지 확인.
 jest.mock('../../data/quickExit.json', () => ({
   '3-019': {
     stairs: [{ doorNumber: '3-2', direction: 'up' }],
     elevator: [{ doorNumber: '5-1', direction: 'up' }],
+  },
+  '1-024': {
+    stairs: [{ doorNumber: '7-3' }],
+    elevator: [{ doorNumber: '4-2' }],
   },
 }));
 
@@ -228,11 +234,27 @@ describe('EditorialTimeline quickExit door label', () => {
   }
 
   it.each<[string, LineNumber, string, string]>([
-    ['비단조 노선(2호선) — 데이터 있어도 라벨 미표시', '2', '강남', '경복궁'],
+    ['비단조 노선 + 도착역 quickExit 데이터 없음 — 라벨 미표시', '2', '강남', '시청'],
+    // '경복궁'은 3호선 역. getStationsOnLine('2')에 포함되지 않아 findStationByNameAndLine이 undefined →
+    // station_id를 얻지 못해 fallback도 라벨 미표시. (데이터 부재와 별개의 분기 — 결과만 동일)
+    ['비단조 노선 + 도착역이 해당 노선에 없음 — 라벨 미표시', '2', '강남', '경복궁'],
     ['단조 노선 + 도착역 데이터 없음 — 라벨 미표시', '3', '경복궁', '오금'],
   ])('%s', (_label, line, from, to) => {
     render(<EditorialTimeline stops={makeDestOnlyStops(line, from, to)} />);
     expect(screen.queryByText(/번 문/)).toBeNull();
+  });
+
+  // #676 — 비단조 노선이라도 도착역 station_id에 quickExit 데이터가 있으면 도어 라벨 표시.
+  it('#676 비단조 노선(1호선) + quickExit 데이터 있으면 direction 없이도 stairs 도어 라벨이 뜬다', () => {
+    render(<EditorialTimeline stops={makeDestOnlyStops('1', '시청', '회기')} />);
+    expect(screen.getByText('7-3번 문')).toBeTruthy();
+  });
+
+  it('#676 비단조 노선 fallback도 accessibilityMode ON 시 elevator 우선', () => {
+    useAppStore.setState({ accessibilityMode: true });
+    render(<EditorialTimeline stops={makeDestOnlyStops('1', '시청', '회기')} />);
+    expect(screen.getByText('4-2번 문')).toBeTruthy();
+    expect(screen.queryByText('7-3번 문')).toBeNull();
   });
 
   it('환승 stop이고 transferExit 매칭이 있으면 transferDoor가 quickExit보다 우선 표시', () => {


### PR DESCRIPTION
Closes #676

## Summary
- 비단조 노선(1·2·5·6호선, 경의중앙선)에서 빠른 환승/하차 도어 라벨이 안 뜨던 누락 케이스 수정
- `resolveStopDoor`에 fallback path 추가 — `resolveTravelDirection` null 시 `findStationByNameAndLine`으로 station_id 직접 매칭 후 `direction` 필터 없이 `resolveQuickExit` 호출
- 좌/우 안내는 정확성 보장 불가라 생략하되 **도어 번호는 노선 무관 표시** (정책: 거동 불편자 모드 OFF 일반 사용자도 빠른 환승 출입구 노출)

## 변경
- `src/components/EditorialTimeline.tsx` — `resolveStopDoor` fallback path. helper는 stationRoute의 SSOT `findStationByNameAndLine` 재사용 (코드리뷰 P1 반영)
- `src/components/__tests__/EditorialTimeline.test.tsx` — quickExit fixture에 1호선 회기('1-024') 엔트리 추가, 신규 4 케이스

## Test plan
- [x] `npm test` 전체 2187/2187 통과
- [x] EditorialTimeline.tsx 커버리지 100%
- [x] `npm run type-check` 통과
- [x] 코드 리뷰 에이전트 1회 반영 (findStationByNameAndLine 중복 제거)
- [ ] 실기기: 회기 → 용산 직통(경의중앙선) 경로에서 "X-Y번 문" 라벨 표시 확인
- [ ] 실기기: 거동 불편자 모드 OFF에서 도어 라벨 노출 확인, ON에서 elevator 우선 도어로 전환 확인