### PR TITLE
fix(#622): client BoardingLock → backend RegisterTrip sync

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -282,6 +282,7 @@ export default function HomeScreen() {
     nextStationEtaSeconds:
       nextTrainMinutes != null && nextTrainMinutes !== Infinity ? nextTrainMinutes * 60 : null,
     currentStation: result?.station ?? null,
+    boardingLock,
   });
 
   useEffect(() => {

--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -171,6 +171,37 @@ describe('alarmBackend', () => {
         expect(reregister).toEqual({ ok: true, status: 200 });
       });
 
+      it('boardingLock 송신: body에 포함 + key 변경 시 재등록 (#622)', async () => {
+        const lock = {
+          trainCode: '7246',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['면목', '용마산'],
+          expiresAt: NOW + 600_000,
+        };
+        const first = await registerActiveTrip({ ...SAMPLE_PAYLOAD, boardingLock: lock });
+        expect(first.ok).toBe(true);
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.boardingLock).toEqual(lock);
+
+        // 동일 lock 재호출 → dedup
+        const dup = await registerActiveTrip({ ...SAMPLE_PAYLOAD, boardingLock: lock });
+        expect(dup).toEqual({ ok: true, skipped: true });
+
+        // 다른 trainCode → 재등록
+        const newLock = { ...lock, trainCode: '7301' };
+        const reregister = await registerActiveTrip({ ...SAMPLE_PAYLOAD, boardingLock: newLock });
+        expect(reregister).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('boardingLock 없으면 body에 미포함', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.boardingLock).toBeUndefined();
+      });
+
       it('URL 미설정 → 설정 사이클에서도 dedup이 stale state를 남기지 않는다', async () => {
         // URL 미설정으로 skip된 호출은 lastRegisteredHash를 건드리지 않아야 한다.
         delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -21,6 +21,26 @@ export interface AlarmWaypoint {
   kind: 'transfer' | 'destination' | 'intermediate';
 }
 
+/**
+ * 백엔드 Trip.boardingLock과 동일 구조 (#622). backend/alarm-worker/src/types.ts의
+ * `BoardingLockMeta`와 schema 동기화 — backend parseBoardingLock(index.ts:272)이 모든 필드를 검증한다.
+ * 한 필드라도 어긋나면 backend가 boardingLock만 drop하고 trip은 살린다.
+ */
+export interface AlarmBoardingLock {
+  /** Seoul API btrainNo (예: "7246") — 사용자가 탭한 열차. */
+  trainCode: string;
+  /** 현재 leg의 노선 (Waypoint.line과 동일 표기). */
+  line: string;
+  /** Seoul API subwayId (예: "1007") — 환승 노선 구분용. */
+  subwayId: string;
+  /** 사용자가 선택한 열차 출발 시각 (epoch ms) — 보통 client BoardingLock.boardedAt. */
+  selectedDepartureTime: number;
+  /** 현 BoardingLock 구간 내 정차역 시퀀스 (출발역 → 구간 끝). backend가 indexOf로 위치 계산. */
+  segmentStations: string[];
+  /** Lock 자동 만료 시각 (epoch ms). */
+  expiresAt: number;
+}
+
 export interface RegisterTripPayload {
   /** APNs device token (hex) */
   token: string;
@@ -36,6 +56,11 @@ export interface RegisterTripPayload {
   alarmAtEpochMs: number;
   /** APNs 토큰 환경 — backend가 sandbox/production host를 선택. */
   apnsEnv: ApnsEnv;
+  /**
+   * BoardingLock metadata (#622). 사용자가 탑승 열차를 확정한 경우 함께 보내 backend가 trainCode
+   * 기준으로 추적·reschedule 가능. 없으면 backend는 기존 anchor waypoint 폴링으로 fallback.
+   */
+  boardingLock?: AlarmBoardingLock;
 }
 
 export interface AlarmBackendResult {
@@ -76,6 +101,7 @@ function buildRegisterHash(body: {
   waypoints: AlarmWaypoint[];
   alarmAtEpochMs: number;
   apnsEnv: ApnsEnv;
+  boardingLock?: AlarmBoardingLock;
 }): string {
   return JSON.stringify({
     token: body.token,
@@ -84,6 +110,11 @@ function buildRegisterHash(body: {
     waypoints: body.waypoints,
     alarmBucket: Math.floor(body.alarmAtEpochMs / ALARM_TIME_BUCKET_MS),
     apnsEnv: body.apnsEnv,
+    // boardingLock 변경 — trainCode/line 또는 segmentStations 갱신 시 즉시 재등록 보장.
+    // expiresAt은 dedup 대상 아님 (시간 흐름으로 자연 변동).
+    boardingLockKey: body.boardingLock
+      ? `${body.boardingLock.trainCode}|${body.boardingLock.line}|${body.boardingLock.subwayId}|${body.boardingLock.segmentStations.join(',')}`
+      : null,
   });
 }
 
@@ -128,6 +159,7 @@ export async function registerActiveTrip(
     waypoints: payload.waypoints,
     alarmAtEpochMs: payload.alarmAtEpochMs,
     apnsEnv: payload.apnsEnv,
+    boardingLock: payload.boardingLock,
   });
   if (hash === lastRegisteredHash) {
     return { ok: true, skipped: true };
@@ -144,6 +176,8 @@ export async function registerActiveTrip(
     expiresAt,
     alarmAtEpochMs: payload.alarmAtEpochMs,
     apnsEnv: payload.apnsEnv,
+    // boardingLock은 있을 때만 송신 (없으면 backend는 기존 anchor 폴링).
+    ...(payload.boardingLock ? { boardingLock: payload.boardingLock } : {}),
   };
 
   try {

--- a/src/constants/__tests__/lineApiNames.test.ts
+++ b/src/constants/__tests__/lineApiNames.test.ts
@@ -1,4 +1,4 @@
-import { LINE_API_NAMES, getLineApiName, subwayIdToLine } from '../lineApiNames';
+import { LINE_API_NAMES, getLineApiName, subwayIdToLine, lineToSubwayId } from '../lineApiNames';
 
 describe('lineApiNames', () => {
   it('1~9호선 매핑 + 특수 노선', () => {
@@ -49,6 +49,18 @@ describe('lineApiNames', () => {
       expect(subwayIdToLine({})).toBeNull();
       expect(subwayIdToLine([])).toBeNull();
       expect(subwayIdToLine(true)).toBeNull();
+    });
+
+    it('lineToSubwayId는 subwayIdToLine의 round-trip을 만족한다', () => {
+      for (const id of ['1001', '1002', '1009', '1063', '1077']) {
+        const line = subwayIdToLine(id);
+        expect(line).not.toBeNull();
+        expect(lineToSubwayId(line!)).toBe(id);
+      }
+    });
+
+    it('lineToSubwayId: 매핑 없는 line은 null', () => {
+      expect(lineToSubwayId('unknown' as never)).toBeNull();
     });
 
     it('SUBWAY_ID_TO_LINE 값 집합이 LINE_API_NAMES 키 집합(모든 LineNumber)을 완전 커버한다 — 신규 노선 추가 시 동기화 누락 방지', () => {

--- a/src/constants/lineApiNames.ts
+++ b/src/constants/lineApiNames.ts
@@ -58,3 +58,19 @@ export function subwayIdToLine(value: unknown): LineNumber | null {
   if (typeof value !== 'string' && typeof value !== 'number') return null;
   return SUBWAY_ID_TO_LINE[String(value)] ?? null;
 }
+
+/**
+ * LineNumber → subwayId 역방향. backend BoardingLockMeta.subwayId 송신용 (#622).
+ * 매핑 누락 시 null — 호출자가 송신 차단 또는 graceful skip.
+ */
+const LINE_TO_SUBWAY_ID: Record<LineNumber, string> = Object.entries(SUBWAY_ID_TO_LINE).reduce(
+  (acc, [id, line]) => {
+    acc[line] = id;
+    return acc;
+  },
+  {} as Record<LineNumber, string>,
+);
+
+export function lineToSubwayId(line: LineNumber): string | null {
+  return LINE_TO_SUBWAY_ID[line] ?? null;
+}

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -37,7 +37,8 @@ import type { Route } from '../../utils/stationRoute';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../constants/storageKeys';
 
 const station: Station = {
-  id: '0228',
+  // stations.json 강남(2호선)과 id 일치 — #622 buildBoardingLockMeta가 boardingStationId로 조회.
+  id: '2-022',
   name: '강남',
   line: '2',
   lat: 37.5,
@@ -105,7 +106,7 @@ describe('useApnsTripRegistration', () => {
     expect(mockRegister).toHaveBeenCalledWith(
       expect.objectContaining({
         token: 'token-abc',
-        destination: '0228',
+        destination: '2-022',
         waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
         apnsEnv: expect.stringMatching(/^(sandbox|production)$/) as unknown as 'sandbox' | 'production',
       }),
@@ -489,5 +490,107 @@ describe('useApnsTripRegistration', () => {
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
     rerender({ route: { type: 'direct', stops: 6, line: '2' } as Route });
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+  });
+
+  describe('#622 boardingLock 송신', () => {
+    // 강남(2-022)이 stations.json에 실제 존재해야 segmentStations 추론 성공.
+    // buildBoardingLockMeta는 boardingStationId('2-022')로 lookup 후 segment를 만든다.
+    const lockFor7 = {
+      destinationId: station.id,
+      trainCode: '7246',
+      boardingStationId: station.id, // 강남 (2호선) — boardingLine=2와 일치
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+
+    it('boardingLock 전달 시 callRegister payload.boardingLock에 schema 변환된 객체 포함', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: lockFor7,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+      const args = mockRegister.mock.calls[0][0];
+      expect(args.boardingLock).toBeDefined();
+      expect(args.boardingLock).toMatchObject({
+        trainCode: '7246',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: lockFor7.boardedAt,
+      });
+      expect(args.boardingLock.segmentStations.length).toBeGreaterThan(0);
+    });
+
+    it('boardingLock null이면 payload.boardingLock 누락', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: null,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+      const args = mockRegister.mock.calls[0][0];
+      expect(args.boardingLock).toBeUndefined();
+    });
+
+    it('boardingLock 내용이 같으면 reference만 달라도 재등록 안 함 (sig 기반 deps)', async () => {
+      const sameContent = { ...lockFor7 };
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockFor7 }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: lockFor7 } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      rerender({ lock: sameContent }); // 새 object reference, 같은 내용
+      // 한 틱 대기해도 추가 호출 없어야 함
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('boardingLock 변경 시 재등록 (deps 포함 확인)', async () => {
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockFor7 | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: null as typeof lockFor7 | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      rerender({ lock: lockFor7 });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    });
+
+    it('boardingLock 있지만 boardingStationId가 stations.json에 없으면 meta 없이 송신', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: { ...lockFor7, boardingStationId: '__no_such_id__' },
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+      const args = mockRegister.mock.calls[0][0];
+      expect(args.boardingLock).toBeUndefined();
+    });
   });
 });

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -13,12 +13,14 @@ import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Station } from '../types/station';
 import type { Route } from '../utils/stationRoute';
-import { routeSignature } from '../utils/stationRoute';
-import { registerActiveTrip, clearActiveTrip } from '../api/alarmBackend';
+import { routeSignature, getStationById } from '../utils/stationRoute';
+import { registerActiveTrip, clearActiveTrip, type AlarmBoardingLock } from '../api/alarmBackend';
 import { routeToWaypoints } from '../utils/routeWaypoints';
+import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../constants/storageKeys';
 import { createLogger } from '../utils/logger';
 import { resolveApnsEnv } from '../utils/apnsEnv';
+import type { BoardingLock } from '../types/boardingLock';
 
 const logger = createLogger('ApnsTripRegistration');
 
@@ -29,6 +31,12 @@ export interface UseApnsTripRegistrationInputs {
   nextStationEtaSeconds: number | null;
   /** 현재 추정 출발역. 중간역(intermediate) 펼침에 사용 (#416). 미제공 또는 null이면 legacy 모드. */
   currentStation?: Station | null;
+  /**
+   * 활성 BoardingLock (#622). 사용자가 탑승 열차를 확정하면 backend가 trainCode 단위로 추적·
+   * reschedule할 수 있게 schema 변환 후 register payload에 포함한다. null이면 backend는 기존
+   * anchor waypoint 폴링으로 fallback.
+   */
+  boardingLock?: BoardingLock | null;
 }
 
 /**
@@ -49,12 +57,28 @@ interface RegisterCallInputs {
   destination: Station;
   nextStationEtaSeconds: number | null;
   currentStation: Station | null;
+  boardingLock: BoardingLock | null;
   /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
   createdAt: number;
 }
 
 /** 두 호출처(token refresh / main effect)의 register 페이로드 빌드를 단일화. */
 async function callRegister(input: RegisterCallInputs) {
+  // #622: BoardingLock metadata 빌드. lock의 boardingStationId로 station name 조회 후 schema 변환.
+  // 조회/추론 실패 시 null → backend는 anchor waypoint 폴링으로 fallback (기존 동작).
+  let boardingLockMeta: AlarmBoardingLock | null = null;
+  if (input.boardingLock) {
+    const boardingStation = getStationById(input.boardingLock.boardingStationId);
+    if (boardingStation) {
+      boardingLockMeta = buildBoardingLockMeta({
+        lock: input.boardingLock,
+        route: input.route,
+        destinationName: input.destination.name,
+        boardingStationName: boardingStation.name,
+      });
+    }
+  }
+
   return registerActiveTrip({
     token: input.token,
     route: input.route,
@@ -63,6 +87,7 @@ async function callRegister(input: RegisterCallInputs) {
     alarmAtEpochMs: deriveAlarmAtEpochMs(input.nextStationEtaSeconds, Date.now()),
     apnsEnv: resolveApnsEnv(),
     createdAt: input.createdAt,
+    ...(boardingLockMeta ? { boardingLock: boardingLockMeta } : {}),
   });
 }
 
@@ -71,14 +96,20 @@ export function useApnsTripRegistration({
   destination,
   nextStationEtaSeconds,
   currentStation = null,
+  boardingLock = null,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
   // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
   const routeSig = useMemo(() => routeSignature(route), [route]);
+  // boardingLock도 reference가 아닌 내용 기반 key로 deps — 상위가 매 렌더 새 객체를 내려도 안전.
+  // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
+  const boardingLockSig = boardingLock
+    ? `${boardingLock.trainCode}|${boardingLock.boardingLine}|${boardingLock.boardedAt}`
+    : null;
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation });
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation };
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock };
   });
 
   // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
@@ -130,6 +161,7 @@ export function useApnsTripRegistration({
           destination: d,
           nextStationEtaSeconds: eta,
           currentStation: cs,
+          boardingLock: bl,
         } = latestInputsRef.current;
         if (!r || !d) return;
         const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
@@ -139,6 +171,7 @@ export function useApnsTripRegistration({
           destination: d,
           nextStationEtaSeconds: eta,
           currentStation: cs,
+          boardingLock: bl,
           createdAt: resolveTripCreatedAt(sessionKey),
         });
       })();
@@ -182,6 +215,7 @@ export function useApnsTripRegistration({
         destination,
         nextStationEtaSeconds,
         currentStation,
+        boardingLock,
         createdAt: resolveTripCreatedAt(sessionKey),
       });
       if (cancelled) return;
@@ -196,6 +230,8 @@ export function useApnsTripRegistration({
     // route는 routeSig(내용 기반)로 비교 — 동일 경로 재등록으로 백엔드 trip
     // state(waypoints shift)가 reset되거나 워커 POST /trips가 분당 폭주하는 것을 방지.
     // route 자체는 closure 안에서만 사용되므로 deps에 넣지 않는다.
+    // boardingLock은 boardingLockSig(내용 기반)로 deps — 상위 컴포넌트가 새 object reference를
+    // 내려도 같은 lock 내용이면 재등록 안 함. closure 안 actual boardingLock object 사용.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeSig, destination?.id, nextStationEtaSeconds, currentStation?.id]);
+  }, [routeSig, destination?.id, nextStationEtaSeconds, currentStation?.id, boardingLockSig]);
 }

--- a/src/utils/__tests__/buildBoardingLockMeta.test.ts
+++ b/src/utils/__tests__/buildBoardingLockMeta.test.ts
@@ -1,0 +1,162 @@
+import { buildBoardingLockMeta, findSegmentEndStationName } from '../buildBoardingLockMeta';
+import { BOARDING_LOCK_EXPIRY_FACTOR } from '../../types/boardingLock';
+import type { BoardingLock } from '../../types/boardingLock';
+import type {
+  DirectRoute,
+  TransferRoute,
+  MultiTransferRoute,
+} from '../stationRoute';
+
+describe('findSegmentEndStationName', () => {
+  it('direct route → destination', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    expect(findSegmentEndStationName(route, '2', '강남')).toBe('강남');
+  });
+
+  it('transfer fromLine → transferName, toLine → destination', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '3',
+      toLine: '2',
+      stopsToTransfer: 5,
+      stopsFromTransfer: 2,
+    };
+    expect(findSegmentEndStationName(route, '3', '강남')).toBe('교대');
+    expect(findSegmentEndStationName(route, '2', '강남')).toBe('강남');
+  });
+
+  it('transfer 노선 어느 segment에도 일치 안 하면 null', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '3',
+      toLine: '2',
+      stopsToTransfer: 5,
+      stopsFromTransfer: 2,
+    };
+    expect(findSegmentEndStationName(route, '7', '강남')).toBeNull();
+  });
+
+  it('multi-transfer: segment.fromLine 일치 → transferName, 마지막 toLine → destination', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '시청', fromLine: '1', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 4 },
+      ],
+      stopsAfterLastTransfer: 5,
+    };
+    expect(findSegmentEndStationName(route, '1', '대치')).toBe('시청');
+    expect(findSegmentEndStationName(route, '2', '대치')).toBe('교대');
+    expect(findSegmentEndStationName(route, '3', '대치')).toBe('대치');
+    expect(findSegmentEndStationName(route, '7', '대치')).toBeNull();
+  });
+
+  it('multi-transfer transfers 비어있고 line 매칭 없으면 null', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [],
+      stopsAfterLastTransfer: 5,
+    };
+    expect(findSegmentEndStationName(route, '1', '대치')).toBeNull();
+  });
+});
+
+describe('buildBoardingLockMeta', () => {
+  const baseLock: BoardingLock = {
+    destinationId: '0228',
+    trainCode: '7246',
+    boardingStationId: '0228', // dummy
+    boardingLine: '7',
+    boardedAt: 1_700_000_000_000,
+    expectedDurationMs: 600_000, // 10분
+  };
+
+  it('subwayId 매핑 실패면 null (line이 알 수 없음)', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '7' };
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, boardingLine: 'unknown' as never },
+      route,
+      destinationName: '용마산',
+      boardingStationName: '면목',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('segmentStations 추론 불가하면 (boardingLine ≠ route segment) null', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '교대',
+      fromLine: '3',
+      toLine: '2',
+      stopsToTransfer: 5,
+      stopsFromTransfer: 2,
+    };
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, boardingLine: '7' },
+      route,
+      destinationName: '강남',
+      boardingStationName: '면목',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('id 역순(startIdx > endIdx)이면 boarding→destination 순서로 reverse한다 — backend indexOf 의존', () => {
+    // 7호선에서 사가정(상위 id) → 면목(하위 id)으로 이동 (위→아래 진행 가정).
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, boardingLine: '7' },
+      route,
+      destinationName: '면목',
+      boardingStationName: '사가정',
+    });
+    expect(result).not.toBeNull();
+    // boarding이 segmentStations[0], destination이 last여야 한다.
+    expect(result!.segmentStations[0]).toBe('사가정');
+    expect(result!.segmentStations[result!.segmentStations.length - 1]).toBe('면목');
+  });
+
+  it('boarding == destination이면 segmentStations 길이 1', () => {
+    const route: DirectRoute = { type: 'direct', stops: 0, line: '7' };
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, boardingLine: '7' },
+      route,
+      destinationName: '면목',
+      boardingStationName: '면목',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.segmentStations).toEqual(['면목']);
+  });
+
+  it('direct route + 같은 line: segmentStations에 출발/도착 포함된 station 시퀀스', () => {
+    // 면목(7호선) → 용마산(7호선), 7호선에서 인접한 두 역.
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, boardingLine: '7' },
+      route,
+      destinationName: '용마산',
+      boardingStationName: '면목',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.trainCode).toBe('7246');
+    expect(result!.line).toBe('7');
+    expect(result!.subwayId).toBe('1007');
+    expect(result!.selectedDepartureTime).toBe(baseLock.boardedAt);
+    expect(result!.expiresAt).toBe(baseLock.boardedAt + 600_000 * BOARDING_LOCK_EXPIRY_FACTOR);
+    expect(result!.segmentStations.length).toBeGreaterThanOrEqual(2);
+    expect(result!.segmentStations).toContain('면목');
+    expect(result!.segmentStations).toContain('용마산');
+  });
+
+  it('알 수 없는 boardingStation/endStation이면 null', () => {
+    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, boardingLine: '7' },
+      route,
+      destinationName: '__no_such_station__',
+      boardingStationName: '면목',
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/src/utils/buildBoardingLockMeta.ts
+++ b/src/utils/buildBoardingLockMeta.ts
@@ -1,0 +1,115 @@
+import type { BoardingLock } from '../types/boardingLock';
+import { BOARDING_LOCK_EXPIRY_FACTOR } from '../types/boardingLock';
+import type { Route } from './stationRoute';
+import { getStationsOnLine, findStationByNameAndLine } from './stationRoute';
+import { lineToSubwayId } from '../constants/lineApiNames';
+import type { Station } from '../types/station';
+import type { LineNumber } from '../types/station';
+import type { AlarmBoardingLock } from '../api/alarmBackend';
+
+/**
+ * 현재 BoardingLock leg의 끝 역(다음 환승역 또는 최종 도착역) 이름을 결정한다.
+ * - direct: 도착역
+ * - transfer: boardingLine == fromLine이면 transferName, toLine이면 도착역
+ * - multi-transfer: transfers 배열에서 boardingLine==fromLine인 segment의 transferName.
+ *   마지막 segment의 toLine이면 도착역.
+ * 매칭 실패 시 null (lock 노선이 route segment 어느 것에도 일치 안 함 — 비정상).
+ */
+export function findSegmentEndStationName(
+  route: NonNullable<Route>,
+  boardingLine: LineNumber,
+  destinationName: string,
+): string | null {
+  if (route.type === 'direct') return destinationName;
+  if (route.type === 'transfer') {
+    if (boardingLine === route.fromLine) return route.transferName;
+    if (boardingLine === route.toLine) return destinationName;
+    return null;
+  }
+  // multi-transfer
+  for (const t of route.transfers) {
+    if (t.fromLine === boardingLine) return t.transferName;
+  }
+  const last = route.transfers[route.transfers.length - 1];
+  if (last && last.toLine === boardingLine) return destinationName;
+  return null;
+}
+
+/**
+ * 현재 leg의 정차역 시퀀스(출발역 → 구간 끝, 양끝 포함)를 line 순서대로 추출한다.
+ * backend가 `lock.segmentStations.indexOf(stationName)`로 위치/목표 인덱스를 계산하므로
+ * 사용자가 통과하는 모든 역이 포함되어야 한다.
+ */
+function buildSegmentStations(
+  route: NonNullable<Route>,
+  boardingStationName: string,
+  boardingLine: LineNumber,
+  destinationName: string,
+): string[] | null {
+  const endName = findSegmentEndStationName(route, boardingLine, destinationName);
+  if (!endName) return null;
+
+  const boardingStation = findStationByNameAndLine(boardingStationName, boardingLine);
+  const endStation = findStationByNameAndLine(endName, boardingLine);
+  if (!boardingStation || !endStation) return null;
+
+  const lineStations: Station[] = getStationsOnLine(boardingLine);
+  const startIdx = lineStations.findIndex((s) => s.id === boardingStation.id);
+  const endIdx = lineStations.findIndex((s) => s.id === endStation.id);
+  /* istanbul ignore next -- findStationByNameAndLine이 찾은 station은 같은 line의 lineStations에
+     반드시 포함된다는 invariant. 방어 가드만 남기고 unreachable. */
+  if (startIdx === -1 || endIdx === -1) return null;
+
+  if (startIdx === endIdx) return [lineStations[startIdx].name];
+  // backend `estimateArrivalFromPosition`은 `segmentStations.indexOf(currentStation) >= indexOf(target)`
+  // 이면 "이미 도착"으로 판정 — boarding이 [0], destination이 [length-1] 순서여야 한다.
+  // lineStations의 id 순서가 진행 방향과 반대인 경우 reverse로 boarding→destination 정렬.
+  // 2호선 순환선의 wrap-around(시계/반시계 더 짧은 길) 케이스는 별도 follow-up으로 처리 (#622 후속).
+  const goesForward = startIdx < endIdx;
+  const slice = goesForward
+    ? lineStations.slice(startIdx, endIdx + 1)
+    : lineStations.slice(endIdx, startIdx + 1).slice().reverse();
+  return slice.map((s) => s.name);
+}
+
+/**
+ * client BoardingLock → backend AlarmBoardingLock 변환 (#622).
+ * 한 필드라도 추론 실패 시 null — backend로 보낼 만큼 정합한 schema가 안 만들어졌다는 뜻.
+ * 호출자는 null을 받으면 payload.boardingLock 자체를 생략하면 된다(backend는 기존 anchor 폴링).
+ *
+ * destination station은 caller가 별도 제공 — boardingStation은 lock에 id만 있어 lookup이 필요한
+ * 반면 destination은 이미 Station 객체로 들어와 있어 lookup 비용 절약.
+ */
+export function buildBoardingLockMeta({
+  lock,
+  route,
+  destinationName,
+  boardingStationName,
+}: {
+  lock: BoardingLock;
+  route: NonNullable<Route>;
+  destinationName: string;
+  boardingStationName: string;
+}): AlarmBoardingLock | null {
+  const subwayId = lineToSubwayId(lock.boardingLine);
+  if (!subwayId) return null;
+
+  const segmentStations = buildSegmentStations(
+    route,
+    boardingStationName,
+    lock.boardingLine,
+    destinationName,
+  );
+  if (!segmentStations || segmentStations.length === 0) return null;
+
+  const expiresAt = lock.boardedAt + lock.expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR;
+
+  return {
+    trainCode: lock.trainCode,
+    line: lock.boardingLine,
+    subwayId,
+    selectedDepartureTime: lock.boardedAt,
+    segmentStations,
+    expiresAt,
+  };
+}

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -181,6 +181,11 @@ export function getStationsOnLine(line: LineNumber): Station[] {
   return getLineStationsCached(line);
 }
 
+/** stations.json id로 단일 Station 조회. 미존재 시 undefined. */
+export function getStationById(id: string): Station | undefined {
+  return stationById.get(id);
+}
+
 export function findStationByNameAndLine(name: string, line: LineNumber): Station | undefined {
   const stations = getLineStationsCached(line);
   const exact = stations.find((s) => s.name === name);


### PR DESCRIPTION
## Summary

BG silent push 0건 회귀 (#622). wrangler tail evidence: `scanned=1, polled=0, pushed=0, lockMissing=1` — backend가 모든 trip을 `boarding-lock: skip cycle`로 skip.

- 원인: client `useApnsTripRegistration.callRegister` payload + `RegisterTripPayload` 타입에 `boardingLock` 필드 부재. backend는 `#640 isBoardingLockActive` 게이트에서 모든 trip skip.
- 해결: client `BoardingLock` → backend `BoardingLockMeta` schema 변환 후 register payload에 포함.

## Schema 매핑

| backend `BoardingLockMeta` | source |
|---|---|
| trainCode | client.trainCode |
| line | client.boardingLine |
| subwayId | `lineToSubwayId(boardingLine)` 신규 역매핑 |
| selectedDepartureTime | client.boardedAt |
| segmentStations | route + boardingStationId로 추론, boarding→destination 진행 방향 |
| expiresAt | `boardedAt + expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR` |

## Changes

- `src/constants/lineApiNames.ts`: `lineToSubwayId(line)` 역방향 매핑
- `src/api/alarmBackend.ts`: `AlarmBoardingLock` 타입 + `RegisterTripPayload.boardingLock` + body 전송 + dedup hash key 포함
- `src/utils/stationRoute.ts`: `getStationById(id)` 노출
- `src/utils/buildBoardingLockMeta.ts` 신규: schema 변환 + `findSegmentEndStationName` 헬퍼
- `src/hooks/useApnsTripRegistration.ts`: `boardingLock` 인자, `boardingLockSig` 기반 deps (reference churn 차단)
- `app/(tabs)/index.tsx`: useBoardingLockController의 lock 전달

## 검증

- `npm run type-check` ✓
- `npm test` 2218 tests, 100% coverage ✓
- 신규 테스트: lineToSubwayId round-trip / buildBoardingLockMeta(direct/transfer/multi-transfer + reverse 정렬) / alarmBackend(boardingLock body+dedup) / useApnsTripRegistration(전달·재등록·sig 안정성)

## Follow-up (별도 이슈)

- 2호선 순환선 wrap-around (시계/반시계 더 짧은 길) — 현재는 id 단방향 슬라이스 + reverse. wrap-around 케이스는 anchor 폴링으로 fallback (silent push 자체는 동작). 정밀화는 후속.

## Test plan

- [ ] EAS production 빌드 실기기에서 BoardingLock 활성 trip → wrangler tail에 `polled>0, pushed>0` 확인
- [ ] 다른 노선(7호선/경의중앙 등) trip에서 segmentStations가 올바른 진행 방향으로 송신
- [ ] lock 없는 trip은 기존 anchor 폴링으로 정상 동작 (body.boardingLock 누락 확인)

Closes #622