### PR TITLE
fix(#673): destination 알람 dismiss UX 분리 - 실수로 trip 삭제 방지

### DIFF
--- a/src/components/AlarmOverlay.tsx
+++ b/src/components/AlarmOverlay.tsx
@@ -31,8 +31,9 @@ export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps)
 
   // #633: dismiss 동작이 알람 종류별로 분기.
   //  - transfer: trip 유지. 진동/사운드 + 이 알람만 정지. 후속 도착 알람은 계속.
-  //  - destination: trip 종료. killAllAlarms로 진동/사운드/예약 전부 청소 + onEndTrip으로
-  //    BoardingLock release + destination clear까지 위임 (호출자 책임).
+  //  - destination: 메인 버튼은 trip 종료(killAllAlarms + onEndTrip), 보조 버튼은 trip 유지
+  //    (clearAlarmNotification만). #673: 잘못 발사된 destination 알람을 끌 때 trip이 사라지는
+  //    부작용을 사용자가 명시 선택으로 회피.
   const handleDismiss = async () => {
     if (isTransfer) {
       await clearAlarmNotification();
@@ -43,8 +44,21 @@ export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps)
     onDismiss();
   };
 
+  // #673: destination 알람에서만 노출되는 보조 액션 — 이 알람만 끄고 trip 유지.
+  const handleKeepTrip = async () => {
+    await clearAlarmNotification();
+    onDismiss();
+  };
+
+  // destination 알람: Android 백 버튼/스와이프 dismiss는 보수적으로 보조 액션(trip 유지)에 연결.
+  // 메인 버튼은 명시 탭만 trip 종료 — 실수 보호(#673).
+  const onRequestClose = isTransfer ? handleDismiss : handleKeepTrip;
+  const mainButtonLabel = isTransfer
+    ? t('alarmOverlay.dismiss')
+    : t('alarmOverlay.dismissAndEnd');
+
   return (
-    <Modal visible animationType="fade" testID="alarm-overlay" onRequestClose={handleDismiss}>
+    <Modal visible animationType="fade" testID="alarm-overlay" onRequestClose={onRequestClose}>
       <View style={[styles.container, { backgroundColor: colors.bg }]}>
         <Text style={[styles.title, { color: colors.accent }]}>{title}</Text>
         <Text style={[styles.station, { color: colors.ink }]}>{message}</Text>
@@ -54,8 +68,20 @@ export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps)
           testID="alarm-dismiss-button"
           activeOpacity={0.7}
         >
-          <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('alarmOverlay.dismiss')}</Text>
+          <Text style={[styles.buttonText, { color: colors.onAccent }]}>{mainButtonLabel}</Text>
         </TouchableOpacity>
+        {!isTransfer && (
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={handleKeepTrip}
+            testID="alarm-keep-trip-button"
+            activeOpacity={0.7}
+          >
+            <Text style={[styles.secondaryButtonText, { color: colors.muted }]}>
+              {t('alarmOverlay.keepTripOnly')}
+            </Text>
+          </TouchableOpacity>
+        )}
       </View>
     </Modal>
   );
@@ -89,5 +115,15 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: 28,
     fontWeight: '800',
+  },
+  secondaryButton: {
+    marginTop: spacing.xl,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+  },
+  secondaryButtonText: {
+    fontSize: 16,
+    fontWeight: '500',
+    textDecorationLine: 'underline',
   },
 });

--- a/src/components/__tests__/AlarmOverlay.test.tsx
+++ b/src/components/__tests__/AlarmOverlay.test.tsx
@@ -71,11 +71,87 @@ describe('AlarmOverlay', () => {
     });
   });
 
-  it('알람 끄기 버튼 텍스트를 표시한다', () => {
-    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+  it('환승 알람의 메인 버튼은 "알람 끄기" 텍스트', () => {
+    const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
     const { getByText } = render(
       <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
     );
     expect(getByText('알람 끄기')).toBeTruthy();
+  });
+
+  it('도착 알람의 메인 버튼은 "내림 (트립 종료)" 텍스트 — UX 의도 명확화', () => {
+    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+    const { getByText } = render(
+      <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
+    );
+    expect(getByText('내림 (트립 종료)')).toBeTruthy();
+  });
+
+  describe('#673 destination 알람 dismiss 분리', () => {
+    it('도착 알람에서 보조 액션 "이 알람만 끄기" 버튼이 노출', () => {
+      const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+      const { getByTestId } = render(
+        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
+      );
+      expect(getByTestId('alarm-keep-trip-button')).toBeTruthy();
+    });
+
+    it('환승 알람에서는 보조 액션 미노출', () => {
+      const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
+      const { queryByTestId } = render(
+        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
+      );
+      expect(queryByTestId('alarm-keep-trip-button')).toBeNull();
+    });
+
+    it('도착 알람 보조 액션 → clearAlarmNotification만, killAllAlarms·onEndTrip 호출 안 함', async () => {
+      const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+      const { getByTestId } = render(
+        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
+      );
+
+      fireEvent.press(getByTestId('alarm-keep-trip-button'));
+
+      await waitFor(() => {
+        expect(mockClearAlarmNotification).toHaveBeenCalled();
+        expect(mockKillAllAlarms).not.toHaveBeenCalled();
+        expect(mockEndTrip).not.toHaveBeenCalled();
+        expect(mockDismiss).toHaveBeenCalled();
+      });
+    });
+
+    it('도착 알람 onRequestClose(Android 백 버튼)는 trip 유지 동작(보조 액션과 동일)', async () => {
+      const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+      const { UNSAFE_getByType } = render(
+        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
+      );
+      // Modal의 onRequestClose를 직접 호출 — react-native testing-library가 fireEvent로 백 버튼
+      // 시뮬레이션 미지원이라 prop 직접 트리거.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Modal } = require('react-native');
+      const modal = UNSAFE_getByType(Modal);
+      await modal.props.onRequestClose();
+      await waitFor(() => {
+        expect(mockClearAlarmNotification).toHaveBeenCalled();
+        expect(mockKillAllAlarms).not.toHaveBeenCalled();
+        expect(mockEndTrip).not.toHaveBeenCalled();
+        expect(mockDismiss).toHaveBeenCalled();
+      });
+    });
+
+    it('환승 알람 onRequestClose는 기존 동작(clearAlarmNotification, trip 유지)', async () => {
+      const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
+      const { UNSAFE_getByType } = render(
+        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Modal } = require('react-native');
+      const modal = UNSAFE_getByType(Modal);
+      await modal.props.onRequestClose();
+      await waitFor(() => {
+        expect(mockClearAlarmNotification).toHaveBeenCalled();
+        expect(mockEndTrip).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/components/__tests__/AlarmOverlay.test.tsx
+++ b/src/components/__tests__/AlarmOverlay.test.tsx
@@ -13,40 +13,42 @@ jest.mock('../../utils/stationNotification', () => ({
   clearAlarmNotification: () => mockClearAlarmNotification(),
 }));
 
-describe('AlarmOverlay', () => {
-  const mockDismiss = jest.fn();
-  const mockEndTrip = jest.fn();
+const mockDismiss = jest.fn();
+const mockEndTrip = jest.fn();
 
+function renderAlarm(type: AlarmEvent['type'], stationName: string) {
+  const event: AlarmEvent = { phaseId: 'early', type, stationName };
+  return render(
+    <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
+  );
+}
+
+async function triggerModalClose(rendered: ReturnType<typeof renderAlarm>) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Modal } = require('react-native');
+  await rendered.UNSAFE_getByType(Modal).props.onRequestClose();
+}
+
+describe('AlarmOverlay', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('하차 알림을 표시한다', () => {
-    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
-    const { getByText } = render(
-      <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-    );
+    const { getByText } = renderAlarm('destination', '강남');
     expect(getByText('하차 알림')).toBeTruthy();
     expect(getByText('강남에서\n내리세요')).toBeTruthy();
   });
 
   it('환승 알림을 표시한다', () => {
-    const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
-    const { getByText } = render(
-      <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-    );
+    const { getByText } = renderAlarm('transfer', '시청');
     expect(getByText('환승 알림')).toBeTruthy();
     expect(getByText('시청에서\n환승하세요')).toBeTruthy();
   });
 
   it('#633 환승 알람 dismiss → trip 유지. clearAlarmNotification만 호출, onEndTrip X', async () => {
-    const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
-    const { getByTestId } = render(
-      <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-    );
-
+    const { getByTestId } = renderAlarm('transfer', '시청');
     fireEvent.press(getByTestId('alarm-dismiss-button'));
-
     await waitFor(() => {
       expect(mockClearAlarmNotification).toHaveBeenCalled();
       expect(mockKillAllAlarms).not.toHaveBeenCalled();
@@ -56,13 +58,8 @@ describe('AlarmOverlay', () => {
   });
 
   it('#633 도착 알람 dismiss → trip 종료. killAllAlarms + onEndTrip 호출', async () => {
-    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
-    const { getByTestId } = render(
-      <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-    );
-
+    const { getByTestId } = renderAlarm('destination', '강남');
     fireEvent.press(getByTestId('alarm-dismiss-button'));
-
     await waitFor(() => {
       expect(mockKillAllAlarms).toHaveBeenCalled();
       expect(mockEndTrip).toHaveBeenCalled();
@@ -72,46 +69,25 @@ describe('AlarmOverlay', () => {
   });
 
   it('환승 알람의 메인 버튼은 "알람 끄기" 텍스트', () => {
-    const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
-    const { getByText } = render(
-      <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-    );
-    expect(getByText('알람 끄기')).toBeTruthy();
+    expect(renderAlarm('transfer', '시청').getByText('알람 끄기')).toBeTruthy();
   });
 
   it('도착 알람의 메인 버튼은 "내림 (트립 종료)" 텍스트 — UX 의도 명확화', () => {
-    const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
-    const { getByText } = render(
-      <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-    );
-    expect(getByText('내림 (트립 종료)')).toBeTruthy();
+    expect(renderAlarm('destination', '강남').getByText('내림 (트립 종료)')).toBeTruthy();
   });
 
   describe('#673 destination 알람 dismiss 분리', () => {
     it('도착 알람에서 보조 액션 "이 알람만 끄기" 버튼이 노출', () => {
-      const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
-      const { getByTestId } = render(
-        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-      );
-      expect(getByTestId('alarm-keep-trip-button')).toBeTruthy();
+      expect(renderAlarm('destination', '강남').getByTestId('alarm-keep-trip-button')).toBeTruthy();
     });
 
     it('환승 알람에서는 보조 액션 미노출', () => {
-      const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
-      const { queryByTestId } = render(
-        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-      );
-      expect(queryByTestId('alarm-keep-trip-button')).toBeNull();
+      expect(renderAlarm('transfer', '시청').queryByTestId('alarm-keep-trip-button')).toBeNull();
     });
 
     it('도착 알람 보조 액션 → clearAlarmNotification만, killAllAlarms·onEndTrip 호출 안 함', async () => {
-      const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
-      const { getByTestId } = render(
-        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-      );
-
+      const { getByTestId } = renderAlarm('destination', '강남');
       fireEvent.press(getByTestId('alarm-keep-trip-button'));
-
       await waitFor(() => {
         expect(mockClearAlarmNotification).toHaveBeenCalled();
         expect(mockKillAllAlarms).not.toHaveBeenCalled();
@@ -120,34 +96,19 @@ describe('AlarmOverlay', () => {
       });
     });
 
-    it('도착 알람 onRequestClose(Android 백 버튼)는 trip 유지 동작(보조 액션과 동일)', async () => {
-      const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
-      const { UNSAFE_getByType } = render(
-        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-      );
-      // Modal의 onRequestClose를 직접 호출 — react-native testing-library가 fireEvent로 백 버튼
-      // 시뮬레이션 미지원이라 prop 직접 트리거.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { Modal } = require('react-native');
-      const modal = UNSAFE_getByType(Modal);
-      await modal.props.onRequestClose();
+    it('도착 알람 onRequestClose(Android 백 버튼)는 trip 유지 동작 (보조 액션과 동일)', async () => {
+      const rendered = renderAlarm('destination', '강남');
+      await triggerModalClose(rendered);
       await waitFor(() => {
         expect(mockClearAlarmNotification).toHaveBeenCalled();
         expect(mockKillAllAlarms).not.toHaveBeenCalled();
         expect(mockEndTrip).not.toHaveBeenCalled();
-        expect(mockDismiss).toHaveBeenCalled();
       });
     });
 
     it('환승 알람 onRequestClose는 기존 동작(clearAlarmNotification, trip 유지)', async () => {
-      const event: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
-      const { UNSAFE_getByType } = render(
-        <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-      );
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { Modal } = require('react-native');
-      const modal = UNSAFE_getByType(Modal);
-      await modal.props.onRequestClose();
+      const rendered = renderAlarm('transfer', '시청');
+      await triggerModalClose(rendered);
       await waitFor(() => {
         expect(mockClearAlarmNotification).toHaveBeenCalled();
         expect(mockEndTrip).not.toHaveBeenCalled();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -112,7 +112,9 @@
     "arrivalTitle": "Arrival alert",
     "transferMessage": "Transfer at\n{{station}}",
     "arrivalMessage": "Exit at\n{{station}}",
-    "dismiss": "Dismiss alarm"
+    "dismiss": "Dismiss alarm",
+    "dismissAndEnd": "Exit (end trip)",
+    "keepTripOnly": "Dismiss only (keep trip)"
   },
   "destinationPicker": {
     "noLocation": "Location info unavailable.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -112,7 +112,9 @@
     "arrivalTitle": "到着アラーム",
     "transferMessage": "{{station}}で\n乗り換え",
     "arrivalMessage": "{{station}}で\n下車",
-    "dismiss": "アラームを止める"
+    "dismiss": "アラームを止める",
+    "dismissAndEnd": "下車（旅程終了）",
+    "keepTripOnly": "このアラームのみ停止（旅程は維持）"
   },
   "destinationPicker": {
     "noLocation": "位置情報がありません。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -112,7 +112,9 @@
     "arrivalTitle": "하차 알림",
     "transferMessage": "{{station}}에서\n환승하세요",
     "arrivalMessage": "{{station}}에서\n내리세요",
-    "dismiss": "알람 끄기"
+    "dismiss": "알람 끄기",
+    "dismissAndEnd": "내림 (트립 종료)",
+    "keepTripOnly": "이 알람만 끄기 (트립 유지)"
   },
   "destinationPicker": {
     "noLocation": "위치 정보가 없습니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -112,7 +112,9 @@
     "arrivalTitle": "到达提醒",
     "transferMessage": "在{{station}}\n换乘",
     "arrivalMessage": "在{{station}}\n下车",
-    "dismiss": "关闭提醒"
+    "dismiss": "关闭提醒",
+    "dismissAndEnd": "下车（结束行程）",
+    "keepTripOnly": "仅关闭此提醒（保留行程）"
   },
   "destinationPicker": {
     "noLocation": "无位置信息。",


### PR DESCRIPTION
## Summary

사용자 보고 (2026-05-30): "방금 실제 도착하지 않았는데 알람 뜨면서 내리라고 하면서 알람끄기 하니까 트립 삭제 됨"

- 원인: destination early 알람이 잘못된 시점 발사(#672) + dismiss = trip 종료 단일 액션. 사용자가 알람만 끄려는 의도였는데 trip 통째 삭제.
- 해결: destination 알람에 보조 액션 "이 알람만 끄기 (트립 유지)" 추가. 메인 버튼은 명시 라벨 "내림 (트립 종료)"으로 의도 분리.

## Changes

- `AlarmOverlay.tsx`:
  - 메인 버튼 라벨: destination일 때 `alarmOverlay.dismissAndEnd` ("내림 (트립 종료)"), transfer는 기존 `alarmOverlay.dismiss`
  - 보조 버튼: destination일 때만 노출. `handleKeepTrip` = `clearAlarmNotification + onDismiss` (trip 유지)
  - Android 백 버튼/스와이프(`onRequestClose`): destination에서는 보조 액션(trip 유지)에 연결 — 실수 보호
- i18n 4개 locale (ko/en/ja/zh)에 `dismissAndEnd`, `keepTripOnly` 키 추가
- 환승 알람은 기존 단일 버튼 동작 그대로

## 의존
- 독립 PR. dev 기준.

## 검증

- `npm run type-check` ✓
- `npm test` 2204 tests, 100% coverage ✓
- 신규 테스트: 보조 버튼 노출(destination만) / 환승 미노출 / 보조 버튼 trip 유지 동작 / Android 백 버튼 destination도 trip 유지 / 환승 백 버튼 기존 동작 / 메인 버튼 라벨 분기

## Test plan

- [ ] destination early 발사 → 메인 "내림 (트립 종료)" 탭 → trip 종료
- [ ] destination 발사 → 보조 "이 알람만 끄기" 탭 → trip 유지, 알람만 정지
- [ ] Android 백 버튼/스와이프로 닫아도 trip 유지 (destination만)
- [ ] 환승 알람은 단일 버튼 그대로

Closes #673