### PR TITLE
fix(#665): 출발=환승역 stepper '0정거장' 표기 제거

### DIFF
--- a/src/utils/__tests__/journeyAdapter.test.ts
+++ b/src/utils/__tests__/journeyAdapter.test.ts
@@ -113,6 +113,38 @@ describe('journeyDisplayToStops', () => {
     );
   });
 
+  it('#665 출발=첫 환승역(stops=0)이면 transfer 노드를 출발에 흡수 + line은 다음 segment line', () => {
+    // 상봉(7) → 상봉(경의중앙) → 용산. 출발과 환승역이 같은 케이스.
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '7', lineColor: '#747F00', fromName: '상봉', toName: '상봉', stops: 0 },
+        { line: 'gyeongui', lineColor: '#77C4A3', fromName: '상봉', toName: '용산', stops: 7 },
+      ],
+      totalStops: 7,
+    };
+    const stops = journeyDisplayToStops(journey);
+    // 출발 노드 1개 + 도착 노드 1개 = 2개. transfer 노드는 출발에 흡수되어 별도 노드 없음.
+    expect(stops).toHaveLength(2);
+    // 출발 line이 첫 seg('7') 아니라 다음 seg('gyeongui') — 환승 후 노선 시각 표시.
+    expect(stops[0]).toEqual({ station: '상봉', line: 'gyeongui', mark: 'filled' });
+    expect(stops[1].mark).toBe('dest');
+    expect(stops[1].station).toBe('용산');
+  });
+
+  it('#665 출발역과 환승역 이름이 다르면 흡수하지 않음 (기존 동작 유지)', () => {
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '7', lineColor: '#747F00', fromName: '면목', toName: '상봉', stops: 1 },
+        { line: 'gyeongui', lineColor: '#77C4A3', fromName: '상봉', toName: '용산', stops: 7 },
+      ],
+      totalStops: 8,
+    };
+    const stops = journeyDisplayToStops(journey);
+    expect(stops).toHaveLength(3);
+    expect(stops[0].station).toBe('면목');
+    expect(stops[1].mark).toBe('transfer');
+  });
+
   describe('expanded option', () => {
     it('expanded: false (기본)이면 intermediate stop이 없다', () => {
       const stops = journeyDisplayToStops(MOCK_JOURNEYS.direct);

--- a/src/utils/journeyAdapter.ts
+++ b/src/utils/journeyAdapter.ts
@@ -87,12 +87,23 @@ export function journeyDisplayToStops(
     const isFirst = i === 0;
     const isLast = i === segments.length - 1;
 
+    // #665: 출발=첫 환승역(stops=0)인 경우 transfer 노드를 출발 노드에 흡수.
+    // 출발 마크의 line을 다음 segment의 line으로 두면 환승 후 노선이 시각적으로 그대로 표시되고
+    // "0정거장" 표기가 사라진다. 흡수 후에는 아래 transfer push 분기를 skip.
+    const isCollapsedZeroFirstHop =
+      isFirst && !isLast && seg.stops === 0 && isSameStationName(seg.fromName, seg.toName);
+
     if (isFirst) {
+      const nextSeg = segments[i + 1];
       stops.push({
         station: getStationDisplayNameByName(seg.fromName, allStations),
-        line: seg.line,
+        line: isCollapsedZeroFirstHop ? nextSeg.line : seg.line,
         mark: 'filled',
       });
+    }
+
+    if (isCollapsedZeroFirstHop) {
+      continue;
     }
 
     if (options.expanded) {


### PR DESCRIPTION
## Summary

출발역과 환승역이 같을 때(예: 상봉(7) → 상봉(경의중앙) → 용산) stepper에 "환승 · 경의중앙선 · 0정거장" 무의미한 노이즈 표시.

- 원인: `journeyAdapter.ts:114-124` 첫 segment stops=0 + fromName===toName 케이스 미처리.
- 해결: 출발 노드의 line을 다음 segment line으로 두고 transfer 노드를 출발에 흡수.

## Changes

- `src/utils/journeyAdapter.ts`: `isCollapsedZeroFirstHop` 가드 추가
- 결과: [상봉(경의중앙) filled] → [용산 dest] (transfer 노드 없음)
- 환승역=목적지 흡수(기존 #98 라인)와는 독립적 케이스

## 검증

- `npm run type-check` ✓
- `npm test` 2200 tests, 100% coverage ✓
- 신규 테스트 2건: 흡수 케이스 / 흡수 미적용(역명 다름) 케이스

Closes #665