### PR TITLE
fix(#666): 지나간 열차(arrivalSeconds<=0) 도착 목록 제외

### DIFF
--- a/src/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockController.test.tsx
@@ -122,6 +122,16 @@ describe('useBoardingLockController', () => {
       expect(mockResolveTripDirection).not.toHaveBeenCalled();
       expect(result.current.directionalArrivals).toEqual([upTrain, downTrain]);
     });
+
+    it('#666 arrivalSeconds <= 0 (지나간 열차)는 directionalArrivals에서 제외', () => {
+      const passed = makeTrain({ trainCode: 'PASSED', arrivalSeconds: 0 });
+      const future = makeTrain({ trainCode: 'FUTURE', arrivalSeconds: 180 });
+      const arrivalWithPast: StationArrival = { up: [passed, future], down: [] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: arrivalWithPast }),
+      );
+      expect(result.current.directionalArrivals).toEqual([future]);
+    });
   });
 
   describe('createLockFromTrain', () => {

--- a/src/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/hooks/__tests__/useTransferTrainList.test.tsx
@@ -167,4 +167,14 @@ describe('filterArrivalsByDirection', () => {
   it('direction=null → up+down 합산', () => {
     expect(filterArrivalsByDirection(arr, null)).toEqual([up, down]);
   });
+
+  it('#666 arrivalSeconds <= 0 (지나간 열차) 제외', () => {
+    const past = makeTrain({ trainCode: 'PAST', arrivalSeconds: 0 });
+    const negative = makeTrain({ trainCode: 'NEG', arrivalSeconds: -30 });
+    const future = makeTrain({ trainCode: 'OK', arrivalSeconds: 120 });
+    const mixed: StationArrival = { up: [past, future], down: [negative] };
+    expect(filterArrivalsByDirection(mixed, 'up')).toEqual([future]);
+    expect(filterArrivalsByDirection(mixed, 'down')).toEqual([]);
+    expect(filterArrivalsByDirection(mixed, null)).toEqual([future]);
+  });
 });

--- a/src/hooks/useBoardingLockController.ts
+++ b/src/hooks/useBoardingLockController.ts
@@ -86,9 +86,11 @@ export function useBoardingLockController({
 
   const directionalArrivals = useMemo<ArrivalInfo[]>(() => {
     if (!arrival) return [];
-    if (direction === 'up') return arrival.up;
-    if (direction === 'down') return arrival.down;
-    return [...arrival.up, ...arrival.down];
+    // #666 이미 지나간 열차(arrivalSeconds <= 0) 제외 — 사용자가 탭하면 lock 오발화.
+    const reachable = (t: ArrivalInfo): boolean => t.arrivalSeconds > 0;
+    if (direction === 'up') return arrival.up.filter(reachable);
+    if (direction === 'down') return arrival.down.filter(reachable);
+    return [...arrival.up, ...arrival.down].filter(reachable);
   }, [arrival, direction]);
 
   const createLockFromTrain = useCallback(

--- a/src/hooks/useTransferTrainList.ts
+++ b/src/hooks/useTransferTrainList.ts
@@ -97,7 +97,9 @@ function filterByDirection(
   direction: 'up' | 'down' | null,
 ): ArrivalInfo[] {
   if (!arrival) return [];
-  if (direction === 'up') return arrival.up;
-  if (direction === 'down') return arrival.down;
-  return [...arrival.up, ...arrival.down];
+  // #666 이미 지나간 열차(arrivalSeconds <= 0) 제외 — 환승 list에서도 동일 정책.
+  const reachable = (t: ArrivalInfo): boolean => t.arrivalSeconds > 0;
+  if (direction === 'up') return arrival.up.filter(reachable);
+  if (direction === 'down') return arrival.down.filter(reachable);
+  return [...arrival.up, ...arrival.down].filter(reachable);
 }


### PR DESCRIPTION
## Summary

현재 시각 11:08에 11:06 도착 열차가 BoardingTrainList에 노출 → 사용자가 탭하면 lock 오발화.

- 원인: `filterByDirection` / `directionalArrivals`에 `arrivalSeconds > 0` 가드 부재.
- 해결: 두 곳에 reachable 가드 추가.

## Changes
- `useBoardingLockController.ts`: `directionalArrivals` 필터
- `useTransferTrainList.ts`: `filterByDirection` 필터
- 신규 테스트 2건: 환승 list + boarding list 둘 다 지나간 열차 제외

## 검증
- type-check ✓, 2200 tests, 100% coverage ✓

Closes #666