### PR TITLE
fix(#667): BoardingLockBanner trainCode raw 식별자 노출 제거

### DIFF
--- a/src/components/BoardingLockBanner.tsx
+++ b/src/components/BoardingLockBanner.tsx
@@ -13,8 +13,9 @@ interface Props {
 /**
  * BoardingLock 활성 시 노출되는 배너 (#584 PR B / #625 컴팩트 + 절대 시각).
  *
- * "탑승" 라벨 + 노선/trainCode + 탑승 시각(HH:mm) + "하차" 액션.
- * 시간은 0분/1분 같은 상대 표기 대신 사용자가 익숙한 절대 시각(#625) — 자기 시계와 매칭 용이.
+ * "탑승" 라벨 + 노선 + 탑승 시각(HH:mm) + "하차" 액션.
+ * trainCode raw 식별자(예: "5048", "SCHED-UP-1")는 사용자에게 무의미하므로 노출 안 함 (#667).
+ * 디버그용 trainCode는 DebugModal에서 확인 가능.
  */
 export function BoardingLockBanner({ lock, onRelease }: Props) {
   const { colors } = useTheme();
@@ -29,8 +30,6 @@ export function BoardingLockBanner({ lock, onRelease }: Props) {
       <View style={styles.row}>
         <Text style={[typography.label, { color: colors.muted }]}>탑승</Text>
         <LineBadge line={lock.boardingLine} />
-        <Text style={[typography.mono, { color: colors.ink }]}>{lock.trainCode}</Text>
-        <Text style={[typography.mono, { color: colors.muted }]}>·</Text>
         <Text style={[typography.mono, { color: colors.ink }]} testID="boarding-lock-time">
           {formatClockTime(lock.boardedAt)}
         </Text>

--- a/src/components/__tests__/BoardingLockBanner.test.tsx
+++ b/src/components/__tests__/BoardingLockBanner.test.tsx
@@ -13,13 +13,13 @@ const lock: BoardingLock = {
 };
 
 describe('BoardingLockBanner', () => {
-  it('trainCode + line label을 렌더', () => {
-    const { getByText, getByTestId } = renderWithTheme(
+  it('탑승 라벨 + 노선 배지 렌더 (trainCode raw 식별자는 노출 안 함 — #667)', () => {
+    const { getByText, getByTestId, queryByText } = renderWithTheme(
       <BoardingLockBanner lock={lock} onRelease={() => {}} />,
     );
     expect(getByTestId('boarding-lock-banner')).toBeTruthy();
-    expect(getByText('T-100')).toBeTruthy();
     expect(getByText('탑승')).toBeTruthy();
+    expect(queryByText('T-100')).toBeNull();
   });
 
   it('#625 탑승 시각(boardedAt)을 HH:mm 절대 시각으로 표시', () => {


### PR DESCRIPTION
## Summary

사용자 표현: "UI가 깔끔하지 못하고 더러움"

- `5048`, `SCHED-UP-1` 같은 trainCode는 사용자에게 무의미한 raw 식별자.
- BoardingLockBanner에서 trainCode 제거 → "탑승 [노선] HH:mm"으로 정리.
- 디버그용 trainCode는 DebugModal에서 확인 가능.

## Changes
- `BoardingLockBanner.tsx`: trainCode `<Text>` + 구분점 `·` 제거
- 기존 테스트 갱신 + queryByText로 미노출 검증

## 검증
- type-check ✓, 2275 tests, 100% coverage ✓

Closes #667