### PR TITLE
fix(#669): activeTrip 표시 race - ACTIVE_TRIP_KEY setItem 가드 밖으로

### DIFF
--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -335,7 +335,7 @@ describe('useApnsTripRegistration', () => {
     expect(mockClear).not.toHaveBeenCalled();
   });
 
-  it('unmount 직후 register resolve해도 ACTIVE_TRIP_KEY 저장 안 함', async () => {
+  it('#669 unmount/deps 변경 후 register resolve도 ACTIVE_TRIP_KEY 저장 — race로 잃지 않음', async () => {
     let resolveReg!: (v: { ok: boolean }) => void;
     mockRegister.mockImplementation(
       () => new Promise((res) => { resolveReg = res; }),
@@ -354,7 +354,8 @@ describe('useApnsTripRegistration', () => {
       resolveReg({ ok: true });
       await Promise.resolve();
     });
-    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(ACTIVE_TRIP_KEY, 'token-abc');
+    // backend register 성공 → cleanup 후에도 ACTIVE_TRIP_KEY 동기화 (DebugModal activeTrip 정확도).
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(ACTIVE_TRIP_KEY, 'token-abc');
   });
 
   it('nextStationEtaSeconds > 0 이면 alarmAt = now + eta*1000', async () => {

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -218,7 +218,9 @@ export function useApnsTripRegistration({
         boardingLock,
         createdAt: resolveTripCreatedAt(sessionKey),
       });
-      if (cancelled) return;
+      // #669: cancelled 가드 밖에서 setItem — backend register 성공이면 UI cleanup 여부와 무관하게
+      // ACTIVE_TRIP_KEY를 동기화. 가드 안에 두면 nextStationEtaSeconds·currentStation 변경으로
+      // useEffect cleanup이 자주 일어나 setItem이 skip되고 DebugModal activeTrip이 (none)으로 표시됨.
       if (result.ok) {
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
       }


### PR DESCRIPTION
## Summary

DebugModal에 `activeTrip=(none)`인데 backend KV에는 trip 정상 등록 — 클라/backend 상태 불일치 (#622 진단 중 발견).

- 원인: `await callRegister → cancelled 가드 → setItem` 패턴. `nextStationEtaSeconds`/`currentStation` deps가 자주 바뀌어 cleanup 발생 → setItem skip.
- 해결: cancelled 가드 밖에서 setItem. backend register 성공 = KV 저장 완료니까 UI cleanup 여부와 무관하게 동기화.

## Changes
- `useApnsTripRegistration.ts`: setItem을 cancelled 가드 밖으로
- 기존 테스트 갱신: invariant 정반대로 (race로 잃지 않음 확인)

## 검증
- type-check ✓, 2275 tests, 100% coverage ✓

Closes #669