### PR TITLE
fix(#670 #672): fg-hydrate 직후 stale state 알람 misfire 차단

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1301,26 +1301,28 @@ describe('useStationAlarm', () => {
 
   describe('#670/#672 첫 evaluation suppress 가드', () => {
     const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
-    const baseInputs = {
-      route,
-      destination,
-      userLocation: { lat: 37.4, lng: 127.0 },
-      speedMps: 10,
-      accuracyMeters: 100,
-      // production 가드 동작 검증을 위해 활성화.
-      skipWarmupGuard: false,
-    };
+    // skipWarmupGuard 미전달 → production default(false) 적용. 첫 evaluation 보류 동작 확인.
+    function inputsWithGuardDefault(loc: { lat: number; lng: number }): UseStationAlarmInputs {
+      return {
+        route,
+        destination,
+        nearestStation: null,
+        userLocation: loc,
+        speedMps: 10,
+        accuracyMeters: 100,
+      };
+    }
 
-    it('mount 직후 첫 evaluation trigger는 suppress', async () => {
-      renderHook(() => useStationAlarm(defaultInputs(baseInputs)));
+    it('mount 직후 첫 evaluation trigger는 suppress (default skipWarmupGuard=false)', async () => {
+      renderHook(() => useStationAlarm(inputsWithGuardDefault({ lat: 37.4, lng: 127.0 })));
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
 
     it('다음 deps 변경(좌표 갱신) 후 evaluate 호출됨', async () => {
       const { rerender } = renderHook(
-        ({ loc }: { loc: { lat: number; lng: number } | null }) =>
-          useStationAlarm(defaultInputs({ ...baseInputs, userLocation: loc })),
+        ({ loc }: { loc: { lat: number; lng: number } }) =>
+          useStationAlarm(inputsWithGuardDefault(loc)),
         { initialProps: { loc: { lat: 37.4, lng: 127.0 } } },
       );
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -112,6 +112,9 @@ function defaultInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStati
     userLocation: null,
     speedMps: null,
     accuracyMeters: null,
+    // 기본은 warmup 가드 우회 — 대부분 단위 테스트는 mount 직후 evaluate 검증.
+    // warmup 자체 동작은 별도 describe('#670/#672 warmup guard')에서 검증.
+    skipWarmupGuard: true,
     ...overrides,
   };
 }
@@ -1293,6 +1296,38 @@ describe('useStationAlarm', () => {
         expect(mockLogSuppressedDedupAlarm).toHaveBeenCalledWith('fg', suppressedEvent),
       );
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#670/#672 첫 evaluation suppress 가드', () => {
+    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const baseInputs = {
+      route,
+      destination,
+      userLocation: { lat: 37.4, lng: 127.0 },
+      speedMps: 10,
+      accuracyMeters: 100,
+      // production 가드 동작 검증을 위해 활성화.
+      skipWarmupGuard: false,
+    };
+
+    it('mount 직후 첫 evaluation trigger는 suppress', async () => {
+      renderHook(() => useStationAlarm(defaultInputs(baseInputs)));
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('다음 deps 변경(좌표 갱신) 후 evaluate 호출됨', async () => {
+      const { rerender } = renderHook(
+        ({ loc }: { loc: { lat: number; lng: number } | null }) =>
+          useStationAlarm(defaultInputs({ ...baseInputs, userLocation: loc })),
+        { initialProps: { loc: { lat: 37.4, lng: 127.0 } } },
+      );
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+      // 첫 suppress 이후 좌표가 한 번 더 갱신되면 evaluate 진입.
+      rerender({ loc: { lat: 37.41, lng: 127.01 } });
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
     });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -50,6 +50,11 @@ export interface UseStationAlarmInputs {
   fusionSource?: FusionSource;
   /** GPS 게이트 실패 등으로 위치 불확실. true면 source 무시하고 'uncertain' 라벨. */
   locationUncertain?: boolean;
+  /**
+   * 테스트 전용 — #670/#672 좌표 warmup 가드 비활성화.
+   * production 호출자는 미설정으로 둠. 단위 테스트에서 mount 직후 alarm 평가 검증 시 사용.
+   */
+  skipWarmupGuard?: boolean;
 }
 
 export function useStationAlarm({
@@ -62,8 +67,14 @@ export function useStationAlarm({
   arrivalConfidence,
   fusionSource,
   locationUncertain = false,
+  skipWarmupGuard = false,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
+  // #670/#672: ETA 평가 effect의 첫 trigger를 suppress.
+  // fg-hydrate 직후 hydrate된 stale firedAlarms·nearestStation과 새 GPS 좌표가 동기화되기 전
+  // 즉시 평가 분기로 진입하면 잘못된 phase 알람이 발사됨. 한 cycle 보류로 다음 deps 변경(좌표/
+  // hydrate state 갱신) 시 안정된 입력으로 평가.
+  const isFirstAlarmEvalRef = useRef(true);
   // firedAlarms hydration: BG가 AsyncStorage(FIRED_ALARMS_KEY)에 쓴 dedup 상태를
   // destination별로 격리해 복원한다(#462). hydrated=false인 동안 phase 평가를 보류해
   // 빈 ref로 false re-fire가 발생하지 않도록 가드한다.
@@ -181,6 +192,12 @@ export function useStationAlarm({
     // Phase 알람은 ETA 거리 계산이 필요해 GPS 게이트가 통과한 경우에만 평가한다.
     if (!isAccuracyAcceptable(accuracyMeters)) return;
 
+    // #670/#672: 첫 trigger suppress — fg-hydrate 직후 stale state 발사 차단.
+    if (!skipWarmupGuard && isFirstAlarmEvalRef.current) {
+      isFirstAlarmEvalRef.current = false;
+      return;
+    }
+
     let etaSeconds: number | null = null;
     if (userLocation) {
       const distM = distanceMetersBetween(
@@ -220,6 +237,7 @@ export function useStationAlarm({
     setAlarmEvent,
     nearestStation?.id,
     nearestStation?.line,
+    skipWarmupGuard,
   ]);
 
   // #396: 도착정보 API 신호로 imminent 발사.


### PR DESCRIPTION
## Summary

두 알람 misfire 사례가 같은 뿌리 (#670, #672):
- #670: `currentStation=상봉(stale)` + GPS 회기 위치 → 청량리 환승 early 발사 (사용자 미접근)
- #672: 한남(용산까지 3정거장)에서 destination early 발사 (사용자 설정 1정거장)

공통 원인: fg-hydrate 직후 hydrate된 stale `firedAlarms`/`nearestStation`과 새 GPS 좌표가 동기화되기 전 ETA effect가 즉시 평가 분기로 진입.

## Fix

`useStationAlarm`에 **첫 evaluation suppress 가드**:
- `isFirstAlarmEvalRef` ref로 첫 effect trigger 시점에 한 번 보류
- 다음 deps 변경(좌표 갱신, hydrate state 변경 등) 시점에 안정된 입력으로 평가
- production 첫 알람만 1 cycle 지연 — UX 무해

## Changes
- `useStationAlarm.ts`: `isFirstAlarmEvalRef` + 가드 한 줄, deps에 포함
- 테스트 전용 prop `skipWarmupGuard` — 기존 66건 단위 테스트 호환
- 신규 테스트 2건: 첫 cycle suppress / 두번째 cycle evaluate

## 검증

- type-check ✓, 2277 tests, 100% coverage ✓

## Test plan

- [ ] 실기기에서 trip 시작 후 stale state 발사 회귀 없음 확인
- [ ] BG → FG 복귀 시 즉시 알람 burst 없음 (#674 일부 해소)
- [ ] 합법 알람은 좌표 갱신 후 1 GPS cycle 지연으로 발사

Closes #670
Closes #672