### PR TITLE
test(#671): 환승역 line 잠금 회귀 일반화 검증

### DIFF
--- a/src/hooks/__tests__/useFusedNearestStation.transferRegression.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.transferRegression.test.ts
@@ -101,6 +101,22 @@ function lockFor(lockSide: Station): BoardingLock {
 
 const transfers = enumerateTransferStations();
 
+function runTransferScenario(
+  lockSide: Station,
+  otherSide: Station,
+  arrivedOn: 'lockSide' | 'otherSide',
+) {
+  mockUseNearest.mockReturnValue(gpsAt(lockSide));
+  mockFindTop.mockReturnValue([
+    { station: lockSide, distanceKm: 0.05 },
+    { station: otherSide, distanceKm: 0.2 },
+  ]);
+  mockPositionsForCandidates(lockSide, otherSide, arrivedOn);
+  return renderHook(() =>
+    useFusedNearestStation(undefined, undefined, undefined, null, lockFor(lockSide)),
+  );
+}
+
 describe('#671 환승역 fusion line 잠금 회귀 가드', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -113,33 +129,13 @@ describe('#671 환승역 fusion line 잠금 회귀 가드', () => {
     const [lockSide, otherSide] = variants;
 
     it('lock.boardingLine과 다른 line이 position-train 잠금 시도 → 강등 → GPS fallback (lockSide)', () => {
-      mockUseNearest.mockReturnValue(gpsAt(lockSide));
-      mockFindTop.mockReturnValue([
-        { station: lockSide, distanceKm: 0.05 },
-        { station: otherSide, distanceKm: 0.2 },
-      ]);
-      mockPositionsForCandidates(lockSide, otherSide, 'otherSide');
-
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, null, lockFor(lockSide)),
-      );
-
+      const { result } = runTransferScenario(lockSide, otherSide, 'otherSide');
       expect(result.current.source).toBe('gps');
       expect(result.current.result?.station.line).toBe(lockSide.line);
     });
 
     it('lock.boardingLine과 같은 line이 position-train 잠금 → 유지', () => {
-      mockUseNearest.mockReturnValue(gpsAt(lockSide));
-      mockFindTop.mockReturnValue([
-        { station: lockSide, distanceKm: 0.05 },
-        { station: otherSide, distanceKm: 0.2 },
-      ]);
-      mockPositionsForCandidates(lockSide, otherSide, 'lockSide');
-
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, null, lockFor(lockSide)),
-      );
-
+      const { result } = runTransferScenario(lockSide, otherSide, 'lockSide');
       expect(result.current.source).toBe('position-train');
       expect(result.current.result?.station.line).toBe(lockSide.line);
     });

--- a/src/hooks/__tests__/useFusedNearestStation.transferRegression.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.transferRegression.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #671 — #662/#663/#664 fix의 데이터 주도 회귀 가드.
+ *
+ * stations.json의 모든 환승역(동명이역 양평 제외 73개)에 대해 다음 invariant 검증:
+ * - BoardingLock이 line A로 활성 + position-train이 line B로 잠금 시도 → 강등 (GPS fallback)
+ * - BoardingLock과 같은 line이면 position-train 유지
+ *
+ * stations.json 변경 시 새 환승역도 자동 검증 — 환승역별 가드 회귀 인프라.
+ */
+
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../useArrivalInfo';
+import { useTrainPositions } from '../useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { enumerateTransferStations } from '../../utils/transferStations';
+import { TRAIN_STATUS } from '../../constants/trainStatus';
+import type { TrainPosition, LinePositions } from '../../api/positionApi';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { Station } from '../../types/station';
+
+jest.mock('../useNearestStation');
+jest.mock('../useArrivalInfo');
+jest.mock('../useTrainPositions');
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+
+const mockUseNearest = useNearestStation as jest.Mock;
+const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockUsePositions = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+function gpsAt(station: Station) {
+  return {
+    result: { station, distanceKm: 0 },
+    variants: [station],
+    userLocation: { lat: station.lat, lng: station.lng },
+    speedMps: 0,
+    // 지하 fix 시뮬레이션 — passesFusionDistanceGate 면제로 line 가드만 검증
+    accuracyMeters: 1500,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    locationUncertain: false,
+    refresh: jest.fn(),
+  };
+}
+
+function arrivalRet() {
+  return { arrival: null, loading: false, isMock: false };
+}
+
+function positionRet(positions: LinePositions | null) {
+  return { positions, loading: false, isMock: false };
+}
+
+function arrivedTrain(statnNm: string, trainNo: string): TrainPosition {
+  return {
+    statnId: '',
+    statnNm,
+    trainNo,
+    trainStatus: TRAIN_STATUS.ARRIVED,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+  };
+}
+
+function mockPositionsForCandidates(
+  lockSide: Station,
+  otherSide: Station,
+  arrivedOn: 'lockSide' | 'otherSide',
+): void {
+  // candidates 순서: [lockSide, otherSide]. activeLines도 동일 순서로 dedup.
+  // useTrainPositions는 l0/l1/l2 슬롯 3개 — p2는 항상 null.
+  const lockTrain =
+    arrivedOn === 'lockSide' ? [arrivedTrain(lockSide.name, 'T-LOCK-SIDE')] : [];
+  const otherTrain =
+    arrivedOn === 'otherSide' ? [arrivedTrain(otherSide.name, 'T-OTHER-SIDE')] : [];
+  mockUsePositions
+    .mockReturnValueOnce(positionRet({ line: lockSide.line, trains: lockTrain }))
+    .mockReturnValueOnce(positionRet({ line: otherSide.line, trains: otherTrain }))
+    .mockReturnValueOnce(positionRet(null));
+}
+
+function lockFor(lockSide: Station): BoardingLock {
+  return {
+    destinationId: 'd1',
+    trainCode: 'T-LOCK',
+    boardingStationId: lockSide.id,
+    boardingLine: lockSide.line,
+    boardedAt: 1_700_000_000_000,
+    expectedDurationMs: 600_000,
+  };
+}
+
+const transfers = enumerateTransferStations();
+
+describe('#671 환승역 fusion line 잠금 회귀 가드', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet());
+    mockUsePositions.mockReturnValue(positionRet(null));
+  });
+
+  describe.each(transfers)('환승역 $name', ({ variants }) => {
+    // variants 첫 두 개를 lockSide/otherSide로 사용 — invariant는 line equality라 어느 쌍이든 동일.
+    const [lockSide, otherSide] = variants;
+
+    it('lock.boardingLine과 다른 line이 position-train 잠금 시도 → 강등 → GPS fallback (lockSide)', () => {
+      mockUseNearest.mockReturnValue(gpsAt(lockSide));
+      mockFindTop.mockReturnValue([
+        { station: lockSide, distanceKm: 0.05 },
+        { station: otherSide, distanceKm: 0.2 },
+      ]);
+      mockPositionsForCandidates(lockSide, otherSide, 'otherSide');
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, lockFor(lockSide)),
+      );
+
+      expect(result.current.source).toBe('gps');
+      expect(result.current.result?.station.line).toBe(lockSide.line);
+    });
+
+    it('lock.boardingLine과 같은 line이 position-train 잠금 → 유지', () => {
+      mockUseNearest.mockReturnValue(gpsAt(lockSide));
+      mockFindTop.mockReturnValue([
+        { station: lockSide, distanceKm: 0.05 },
+        { station: otherSide, distanceKm: 0.2 },
+      ]);
+      mockPositionsForCandidates(lockSide, otherSide, 'lockSide');
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, lockFor(lockSide)),
+      );
+
+      expect(result.current.source).toBe('position-train');
+      expect(result.current.result?.station.line).toBe(lockSide.line);
+    });
+  });
+});

--- a/src/utils/__tests__/transferStations.test.ts
+++ b/src/utils/__tests__/transferStations.test.ts
@@ -33,26 +33,26 @@ describe('enumerateTransferStations', () => {
   it('variant 쌍 거리가 maxPairDistanceKm를 초과하면 동명이역으로 제외', () => {
     // 1도 위경도 ≈ 111km — 명백히 임계 초과
     const groups = enumerateTransferStations([
-      stn('a', 'X', '1', 37.0, 127.0),
-      stn('b', 'X', '2', 38.0, 127.0),
+      stn('a', 'X', '1', 37, 127),
+      stn('b', 'X', '2', 38, 127),
     ]);
     expect(groups).toEqual([]);
   });
 
   it('maxPairDistanceKm 옵션으로 임계 조정', () => {
     const stations = [
-      stn('a', 'X', '1', 37.0, 127.0),
-      stn('b', 'X', '2', 37.005, 127.0), // 약 555m
+      stn('a', 'X', '1', 37, 127),
+      stn('b', 'X', '2', 37.005, 127), // 약 555m
     ];
     expect(enumerateTransferStations(stations, { maxPairDistanceKm: 0.3 })).toEqual([]);
-    expect(enumerateTransferStations(stations, { maxPairDistanceKm: 1.0 })).toHaveLength(1);
+    expect(enumerateTransferStations(stations, { maxPairDistanceKm: 1 })).toHaveLength(1);
   });
 
   it('3개 이상 variants도 모두 임계 내면 포함', () => {
     const groups = enumerateTransferStations([
-      stn('a', 'X', '1', 37.0, 127.0),
-      stn('b', 'X', '2', 37.0001, 127.0),
-      stn('c', 'X', '3', 37.0002, 127.0),
+      stn('a', 'X', '1', 37, 127),
+      stn('b', 'X', '2', 37.0001, 127),
+      stn('c', 'X', '3', 37.0002, 127),
     ]);
     expect(groups).toHaveLength(1);
     expect(groups[0].variants).toHaveLength(3);
@@ -60,9 +60,9 @@ describe('enumerateTransferStations', () => {
 
   it('3개 variants 중 한 쌍만 임계 초과해도 그룹 제외', () => {
     const groups = enumerateTransferStations([
-      stn('a', 'X', '1', 37.0, 127.0),
-      stn('b', 'X', '2', 37.0001, 127.0),
-      stn('c', 'X', '3', 38.0, 127.0), // a와 ~111km
+      stn('a', 'X', '1', 37, 127),
+      stn('b', 'X', '2', 37.0001, 127),
+      stn('c', 'X', '3', 38, 127), // a와 ~111km
     ]);
     expect(groups).toEqual([]);
   });

--- a/src/utils/__tests__/transferStations.test.ts
+++ b/src/utils/__tests__/transferStations.test.ts
@@ -1,0 +1,80 @@
+import { enumerateTransferStations } from '../transferStations';
+import type { Station } from '../../types/station';
+
+function stn(id: string, name: string, line: Station['line'], lat = 0, lng = 0): Station {
+  return { id, name, line, lineColor: '#000', lat, lng };
+}
+
+describe('enumerateTransferStations', () => {
+  it('같은 name + 다른 line variants 있으면 group 반환', () => {
+    const groups = enumerateTransferStations([
+      stn('a', 'X', '1'),
+      stn('b', 'X', '2'),
+    ]);
+    expect(groups).toEqual([
+      {
+        name: 'X',
+        variants: [
+          expect.objectContaining({ id: 'a', line: '1' }),
+          expect.objectContaining({ id: 'b', line: '2' }),
+        ],
+      },
+    ]);
+  });
+
+  it('단일 노선 역은 제외', () => {
+    expect(enumerateTransferStations([stn('a', 'Solo', '1')])).toEqual([]);
+  });
+
+  it('빈 입력은 빈 배열', () => {
+    expect(enumerateTransferStations([])).toEqual([]);
+  });
+
+  it('variant 쌍 거리가 maxPairDistanceKm를 초과하면 동명이역으로 제외', () => {
+    // 1도 위경도 ≈ 111km — 명백히 임계 초과
+    const groups = enumerateTransferStations([
+      stn('a', 'X', '1', 37.0, 127.0),
+      stn('b', 'X', '2', 38.0, 127.0),
+    ]);
+    expect(groups).toEqual([]);
+  });
+
+  it('maxPairDistanceKm 옵션으로 임계 조정', () => {
+    const stations = [
+      stn('a', 'X', '1', 37.0, 127.0),
+      stn('b', 'X', '2', 37.005, 127.0), // 약 555m
+    ];
+    expect(enumerateTransferStations(stations, { maxPairDistanceKm: 0.3 })).toEqual([]);
+    expect(enumerateTransferStations(stations, { maxPairDistanceKm: 1.0 })).toHaveLength(1);
+  });
+
+  it('3개 이상 variants도 모두 임계 내면 포함', () => {
+    const groups = enumerateTransferStations([
+      stn('a', 'X', '1', 37.0, 127.0),
+      stn('b', 'X', '2', 37.0001, 127.0),
+      stn('c', 'X', '3', 37.0002, 127.0),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].variants).toHaveLength(3);
+  });
+
+  it('3개 variants 중 한 쌍만 임계 초과해도 그룹 제외', () => {
+    const groups = enumerateTransferStations([
+      stn('a', 'X', '1', 37.0, 127.0),
+      stn('b', 'X', '2', 37.0001, 127.0),
+      stn('c', 'X', '3', 38.0, 127.0), // a와 ~111km
+    ]);
+    expect(groups).toEqual([]);
+  });
+
+  it('실제 stations.json — 73개 환승역 (양평 동명이역 제외) 모두 다른 line', () => {
+    const groups = enumerateTransferStations();
+    expect(groups).toHaveLength(73);
+    for (const group of groups) {
+      expect(group.variants.length).toBeGreaterThanOrEqual(2);
+      const lines = new Set(group.variants.map((v) => v.line));
+      expect(lines.size).toBe(group.variants.length);
+    }
+    expect(groups.find((g) => g.name === '양평')).toBeUndefined();
+  });
+});

--- a/src/utils/transferStations.ts
+++ b/src/utils/transferStations.ts
@@ -13,7 +13,7 @@ export interface EnumerateTransferStationsOptions {
 
 const ALL_STATIONS = stationsData as Station[];
 
-const DEFAULT_MAX_PAIR_DISTANCE_KM = 1.0;
+const DEFAULT_MAX_PAIR_DISTANCE_KM = 1;
 
 /**
  * 같은 이름을 공유하는 다른 노선 station을 환승역 단위로 묶어 반환.

--- a/src/utils/transferStations.ts
+++ b/src/utils/transferStations.ts
@@ -1,0 +1,57 @@
+import stationsData from '../data/stations.json';
+import type { Station } from '../types/station';
+import { haversine } from './haversine';
+
+export interface TransferStationGroup {
+  name: string;
+  variants: Station[];
+}
+
+export interface EnumerateTransferStationsOptions {
+  maxPairDistanceKm?: number;
+}
+
+const ALL_STATIONS = stationsData as Station[];
+
+const DEFAULT_MAX_PAIR_DISTANCE_KM = 1.0;
+
+/**
+ * 같은 이름을 공유하는 다른 노선 station을 환승역 단위로 묶어 반환.
+ * #662/#663/#664 회귀 가드 데이터 주도 테스트 인프라 (#671).
+ *
+ * `maxPairDistanceKm`(기본 1.0km): variants 중 어느 한 쌍이라도 이 거리를 넘으면 동명이역으로 보고 그룹 제외.
+ * 예) "양평"은 서울 5호선 ↔ 경기 경의중앙선 53km 떨어져 환승역 아님.
+ */
+export function enumerateTransferStations(
+  stations: Station[] = ALL_STATIONS,
+  options: EnumerateTransferStationsOptions = {},
+): TransferStationGroup[] {
+  const maxPairDistanceKm = options.maxPairDistanceKm ?? DEFAULT_MAX_PAIR_DISTANCE_KM;
+  const byName = new Map<string, Station[]>();
+  for (const station of stations) {
+    const variants = byName.get(station.name);
+    if (variants) {
+      variants.push(station);
+    } else {
+      byName.set(station.name, [station]);
+    }
+  }
+  const groups: TransferStationGroup[] = [];
+  for (const [name, variants] of byName) {
+    if (variants.length < 2) continue;
+    if (!variantsWithinDistance(variants, maxPairDistanceKm)) continue;
+    groups.push({ name, variants });
+  }
+  return groups;
+}
+
+function variantsWithinDistance(variants: Station[], maxKm: number): boolean {
+  for (let i = 0; i < variants.length; i += 1) {
+    for (let j = i + 1; j < variants.length; j += 1) {
+      const a = variants[i];
+      const b = variants[j];
+      if (haversine(a.lat, a.lng, b.lat, b.lng) > maxKm) return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- `enumerateTransferStations` utility 추가 — stations.json에서 같은 name + 다른 line variants를 환승역 그룹으로 묶음. `maxPairDistanceKm` (기본 1km)로 양평(53km 동명이역) 같은 케이스 데이터 기반 제외.
- `useFusedNearestStation.transferRegression.test.ts` 신규 — 73개 환승역 × 2 invariant = 146 케이스 데이터 주도. #662/#663/#664 fix의 회귀 가드.
- `transferStations.test.ts` 신규 — utility 단위 테스트 8 케이스.

## Test plan

- [x] `npx jest src/utils/__tests__/transferStations.test.ts` 8/8 pass
- [x] `npx jest src/hooks/__tests__/useFusedNearestStation.transferRegression.test.ts` 146/146 pass
- [x] `npm test` 144 suites / 2431 tests pass, 100% coverage
- [x] `npm run type-check` clean
- [x] code-review agent P1 0건

Invariant 정의:
1. `BoardingLock.boardingLine === A` + position-train이 line B에서 ARRIVED → 강등 → GPS fallback (lockSide line 유지)
2. `BoardingLock.boardingLine === A` + position-train이 line A에서 ARRIVED → 채택 유지

stations.json 변경(새 환승역 추가, 노선 연장) 시 자동으로 케이스 늘어남 — 회귀 가드 인프라.

Closes #671