### PR TITLE
chore(#690): bump version to 1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## 변경
- `package.json` / `package-lock.json` version 1.2.3 → 1.2.4

5/13 마지막 production 빌드(v1.2.3 build45) 이후 머지분을 새 TestFlight 빌드로 내보내기 위한 마케팅 버전 bump. iOS buildNumber/Android versionCode는 EAS Remote autoIncrement가 관리한다.

Closes #690