### PR TITLE
refactor(#660): Route.seconds 필드 required 승격 + fixture helper

### DIFF
--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -7,6 +7,7 @@ import {
   __resetAlarmBackendDedup,
 } from '../alarmBackend';
 import type { RegisterTripPayload } from '../alarmBackend';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
@@ -22,7 +23,7 @@ const NOW = new Date('2026-05-13T12:00:00Z').getTime();
 
 const SAMPLE_PAYLOAD: RegisterTripPayload = {
   token: 'token-hex',
-  route: { type: 'direct', stops: 5, line: '2' },
+  route: makeDirectRoute(5, '2'),
   destination: '0228',
   waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
   alarmAtEpochMs: NOW + 60000,
@@ -84,7 +85,7 @@ describe('alarmBackend', () => {
 
       const payload: RegisterTripPayload = {
         token: 't',
-        route: { type: 'direct', stops: 1, line: '2' },
+        route: makeDirectRoute(1, '2'),
         destination: '0228',
         waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
         alarmAtEpochMs: NOW,

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -35,6 +35,7 @@ import { useApnsTripRegistration } from '../useApnsTripRegistration';
 import type { Station } from '../../types/station';
 import type { Route } from '../../utils/stationRoute';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../constants/storageKeys';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 const station: Station = {
   // stations.json 강남(2호선)과 id 일치 — #622 buildBoardingLockMeta가 boardingStationId로 조회.
@@ -46,7 +47,7 @@ const station: Station = {
   lineColor: '#00A84D',
 };
 
-const directRoute: Route = { type: 'direct', stops: 5, line: '2' };
+const directRoute: Route = makeDirectRoute(5, '2');
 
 describe('useApnsTripRegistration', () => {
   let listenerRemove: jest.Mock;
@@ -377,11 +378,11 @@ describe('useApnsTripRegistration', () => {
     const { rerender } = renderHook(
       ({ route }: { route: Route }) =>
         useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
-      { initialProps: { route: { type: 'direct', stops: 5, line: '2' } as Route } },
+      { initialProps: { route: makeDirectRoute(5, '2') as Route } },
     );
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
     // 내용 동일, reference만 신규
-    rerender({ route: { type: 'direct', stops: 5, line: '2' } as Route });
+    rerender({ route: makeDirectRoute(5, '2') as Route });
     await act(async () => {
       await Promise.resolve();
     });
@@ -418,13 +419,13 @@ describe('useApnsTripRegistration', () => {
     const { rerender } = renderHook(
       ({ route }: { route: Route }) =>
         useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
-      { initialProps: { route: { type: 'direct', stops: 5, line: '2' } as Route } },
+      { initialProps: { route: makeDirectRoute(5, '2') as Route } },
     );
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
     const first = mockRegister.mock.calls[0][0].createdAt as number;
 
     now = 1_700_000_500_000;
-    rerender({ route: { type: 'direct', stops: 6, line: '2' } as Route });
+    rerender({ route: makeDirectRoute(6, '2') as Route });
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
     expect(mockRegister.mock.calls[1][0].createdAt).toBe(1_700_000_500_000);
     expect(mockRegister.mock.calls[1][0].createdAt).not.toBe(first);
@@ -486,10 +487,10 @@ describe('useApnsTripRegistration', () => {
     const { rerender } = renderHook(
       ({ route }: { route: Route }) =>
         useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
-      { initialProps: { route: { type: 'direct', stops: 5, line: '2' } as Route } },
+      { initialProps: { route: makeDirectRoute(5, '2') as Route } },
     );
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-    rerender({ route: { type: 'direct', stops: 6, line: '2' } as Route });
+    rerender({ route: makeDirectRoute(6, '2') as Route });
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
   });
 

--- a/src/hooks/__tests__/useBoardingLockAdvancer.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockAdvancer.test.tsx
@@ -2,8 +2,8 @@ import { renderHook, waitFor } from '@testing-library/react-native';
 import { useBoardingLockAdvancer } from '../useBoardingLockAdvancer';
 import { advanceHopWindow } from '../../utils/boardingLockScheduler';
 import type { BoardingLock } from '../../types/boardingLock';
-import type { DirectRoute, TransferRoute } from '../../utils/stationRoute';
 import { useAppStore } from '../../store/useAppStore';
+import { makeDirectRoute, makeTransferRoute } from '../../testUtils/routeFixtures';
 
 jest.mock('../../utils/boardingLockScheduler', () => ({
   advanceHopWindow: jest.fn(),
@@ -30,15 +30,14 @@ const lockA: BoardingLock = {
 };
 const lockB: BoardingLock = { ...lockA, trainCode: 'B' };
 
-const directRoute: DirectRoute = { type: 'direct', stops: 2, line: '2' };
-const transferRoute: TransferRoute = {
-  type: 'transfer',
+const directRoute = makeDirectRoute(2, '2');
+const transferRoute = makeTransferRoute({
   transferName: '사당',
   fromLine: '2',
   toLine: '4',
   stopsToTransfer: 3,
   stopsFromTransfer: 4,
-};
+});
 
 type Props = Parameters<typeof useBoardingLockAdvancer>[0];
 

--- a/src/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockController.test.tsx
@@ -7,8 +7,8 @@ import {
 import { useBoardingLockStore } from '../../store/useBoardingLockStore';
 import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
 import type { Station } from '../../types/station';
-import type { DirectRoute } from '../../utils/stationRoute';
 import type { BoardingLock } from '../../types/boardingLock';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 const mockGetBoardingLock = jest.fn();
 const mockSetBoardingLock = jest.fn();
@@ -50,7 +50,7 @@ const stationA: Station = {
   lng: 127.0,
 };
 
-const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+const route = makeDirectRoute(5, '2');
 
 const upTrain = makeTrain({ trainCode: 'UP-1' });
 const downTrain = makeTrain({ trainCode: 'DN-1' });

--- a/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -5,8 +5,8 @@ import {
   scheduleHopsForLock,
 } from '../../utils/boardingLockScheduler';
 import type { BoardingLock } from '../../types/boardingLock';
-import type { DirectRoute } from '../../utils/stationRoute';
 import { useAppStore } from '../../store/useAppStore';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 jest.mock('../../utils/boardingLockScheduler', () => ({
   scheduleHopsForLock: jest.fn(),
@@ -34,7 +34,7 @@ const lockA: BoardingLock = {
   expectedDurationMs: 1000,
 };
 const lockB: BoardingLock = { ...lockA, trainCode: 'B' };
-const route: DirectRoute = { type: 'direct', stops: 2, line: '2' };
+const route = makeDirectRoute(2, '2');
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -10,7 +10,7 @@ import { TRAIN_STATUS } from '../../constants/trainStatus';
 import { MOCK_STATIONS } from '../../testUtils/fixtures';
 import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
 import type { LinePositions, TrainPosition } from '../../api/positionApi';
-import type { DirectRoute } from '../../utils/stationRoute';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 jest.mock('../useNearestStation');
 jest.mock('../useArrivalInfo');
@@ -665,7 +665,7 @@ describe('useFusedNearestStation', () => {
   describe('routeContext (Phase A — Route-Locked Map Matching)', () => {
     const sagajeong = findStationByNameAndLine('사가정', '7')!;
     const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
 
     it('경로 컨텍스트 + userLocation 있으면 진행도 기반 현재역으로 result 덮어쓴다', () => {
       mockUseNearest.mockReturnValue(
@@ -737,7 +737,7 @@ describe('useFusedNearestStation', () => {
     const gunja = findStationByNameAndLine('군자', '7')!;
     const oolinidae = findStationByNameAndLine('어린이대공원', '7')!;
     const konkuk = findStationByNameAndLine('건대입구', '7')!;
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
     const routeContext = { route, origin: yongmasan, destination: konkuk };
     const T0 = 1_700_000_000_000;
     const lock = {

--- a/src/hooks/__tests__/useRouteProgress.test.ts
+++ b/src/hooks/__tests__/useRouteProgress.test.ts
@@ -1,13 +1,14 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { useRouteProgress, type UseRouteProgressInputs } from '../useRouteProgress';
 import { findStationByNameAndLine } from '../../utils/stationRoute';
-import type { DirectRoute, Route } from '../../utils/stationRoute';
+import type { Route } from '../../utils/stationRoute';
 import type { Station } from '../../types/station';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 const sagajeong = findStationByNameAndLine('사가정', '7')!;
 const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
 const gunja = findStationByNameAndLine('군자', '7')!;
-const directRoute: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+const directRoute = makeDirectRoute(4, '7');
 
 function makeProps(overrides: Partial<UseRouteProgressInputs> = {}): UseRouteProgressInputs {
   return {
@@ -276,7 +277,7 @@ describe('useRouteProgress', () => {
     );
     expect(result.current.progressM).not.toBeNull();
 
-    const otherRoute: Route = { type: 'direct', stops: 1, line: '7' };
+    const otherRoute: Route = makeDirectRoute(1, '7');
     act(() => {
       rerender(
         makeProps({

--- a/src/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/hooks/__tests__/useScheduledAlarms.test.ts
@@ -8,9 +8,9 @@ import {
   cancelScheduledAlarms,
 } from '../../utils/alarmScheduler';
 import { TRIP_TRAIN_CODE_KEY } from '../../constants/storageKeys';
-import type { DirectRoute } from '../../utils/stationRoute';
 import type { Station } from '../../types/station';
 import type { StationArrival } from '../../api/arrivalApi';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 jest.mock('../../utils/alarmScheduler');
 jest.mock('../../utils/logger', () => ({
@@ -36,7 +36,7 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_type, listener) =>
   return { remove: mockRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
 });
 
-const ROUTE: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+const ROUTE = makeDirectRoute(10, '1');
 const DESTINATION: Station = {
   id: 'dest-1',
   name: '강남',
@@ -47,7 +47,7 @@ const DESTINATION: Station = {
 };
 
 // Line 1 fixtures — 방향 판정 테스트 공유. 같은 stations.json ordinal 위에서 up/down을 모두 표현.
-const LINE_1_ROUTE: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+const LINE_1_ROUTE = makeDirectRoute(10, '1');
 const SEOUL_STATION: Station = {
   id: '1-034', name: '서울역', line: '1', lat: 37.55, lng: 126.97, lineColor: '#0052A4',
 };
@@ -392,7 +392,7 @@ describe('useScheduledAlarms', () => {
       up: [{ ...ARRIVAL.up[0], arrivalSeconds: 30 }], // 반대방향(서쪽), 30초 후
       down: [{ ...ARRIVAL.down[0], arrivalSeconds: 240 }], // 진행방향(동쪽), 240초 후
     };
-    const ROUTE_L1: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const ROUTE_L1 = makeDirectRoute(10, '1');
     const DEST_L1: Station = {
       id: '1-034', name: '서울역', line: '1', lat: 37.55, lng: 126.97, lineColor: '#0052A4',
     };
@@ -424,7 +424,7 @@ describe('useScheduledAlarms', () => {
       up: [{ ...ARRIVAL.up[0], arrivalSeconds: 180 }],
       down: [{ ...ARRIVAL.down[0], arrivalSeconds: 60 }],
     };
-    const ROUTE_L1: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const ROUTE_L1 = makeDirectRoute(10, '1');
     const DEST_L1: Station = {
       id: '1-001', name: '소요산', line: '1', lat: 37.95, lng: 127.06, lineColor: '#0052A4',
     };
@@ -452,7 +452,7 @@ describe('useScheduledAlarms', () => {
   });
 
   it('currentStation이 노선 외(direction null)면 양방향 합산 fallback으로 위임한다', async () => {
-    const ROUTE_L1: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const ROUTE_L1 = makeDirectRoute(10, '1');
     const DEST_L1: Station = {
       id: '1-034', name: '서울역', line: '1', lat: 37.55, lng: 126.97, lineColor: '#0052A4',
     };

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1,9 +1,13 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useStationAlarm, type UseStationAlarmInputs } from '../useStationAlarm';
 import { useAppStore } from '../../store/useAppStore';
-import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../../utils/stationRoute';
 import type { Station } from '../../types/station';
 import type { AlarmEvent } from '../../utils/stationAlarm';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 const mockSendAlarmNotification = jest.fn().mockResolvedValue(undefined);
 const mockSendStationPassedNotification = jest.fn().mockResolvedValue(undefined);
@@ -141,13 +145,13 @@ describe('useStationAlarm', () => {
   });
 
   it('does not evaluate when destination is null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     renderHook(() => useStationAlarm(defaultInputs({ route })));
     expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
   });
 
   it('does not evaluate when accuracy exceeds the alarm gate (MAX_ACCURACY_M)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     renderHook(() =>
       useStationAlarm(
         defaultInputs({
@@ -163,7 +167,7 @@ describe('useStationAlarm', () => {
   });
 
   it('evaluates when accuracy is exactly the alarm gate (boundary inclusive)', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     renderHook(() =>
       useStationAlarm(
         defaultInputs({
@@ -179,7 +183,7 @@ describe('useStationAlarm', () => {
   });
 
   describe('arrival fusion 보조 트리거 (Stage 3)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     const onRouteStation = makeStation('S2-DST', '강남'); // route+dest 매칭
 
     it('GPS 게이트 차단 + arrivalConfidence=arrival-confirmed → station-passed 알람 발화', async () => {
@@ -285,7 +289,7 @@ describe('useStationAlarm', () => {
   });
 
   it('builds AlarmSource and calls evaluator', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     renderHook(() =>
       useStationAlarm(
         defaultInputs({
@@ -311,7 +315,7 @@ describe('useStationAlarm', () => {
   });
 
   it('passes null etaSeconds when speed is null', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     renderHook(() =>
       useStationAlarm(
         defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127.0 }, speedMps: null }),
@@ -328,7 +332,7 @@ describe('useStationAlarm', () => {
   });
 
   it('passes null etaSeconds when userLocation is null', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     renderHook(() => useStationAlarm(defaultInputs({ route, destination, speedMps: 10 })));
     await waitFor(() =>
       expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
@@ -341,7 +345,7 @@ describe('useStationAlarm', () => {
   });
 
   it('sends alarm notification with the full event', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
@@ -350,7 +354,7 @@ describe('useStationAlarm', () => {
   });
 
   it('attaches direction to the alarm event when nearestStation is set and direction resolves', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     const station = makeStation('S1', '역삼');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     mockResolveAlarmDirection.mockReturnValue('up');
@@ -366,14 +370,13 @@ describe('useStationAlarm', () => {
   });
 
   it('sends transfer alarm for transfer route', async () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '시청',
       fromLine: '1',
       toLine: '2',
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
-    };
+    });
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
@@ -382,14 +385,13 @@ describe('useStationAlarm', () => {
   });
 
   it('sends transfer alarm for multi-transfer route', async () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '시청', fromLine: '1', toLine: '3', stopsToTransfer: 1 },
         { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 3,
-    };
+    });
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
@@ -398,7 +400,7 @@ describe('useStationAlarm', () => {
   });
 
   it('does not fire the same alarm twice', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
@@ -407,7 +409,7 @@ describe('useStationAlarm', () => {
   });
 
   it('fires imminent after early for the same waypoint', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValueOnce(earlyDest);
     const { rerender } = renderHook(
       ({ inputs }: { inputs: UseStationAlarmInputs }) => useStationAlarm(inputs),
@@ -432,7 +434,7 @@ describe('useStationAlarm', () => {
   });
 
   it('destination 변경 시 새 destinationId로 re-hydrate 한다 (#462 destination scoped)', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(
       ({ dest }: { dest: Station }) => useStationAlarm(defaultInputs({ route, destination: dest })),
@@ -452,7 +454,7 @@ describe('useStationAlarm', () => {
 
   it('passes sleepMode to sendAlarmNotification', async () => {
     useAppStore.setState({ sleepMode: true });
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
@@ -462,7 +464,7 @@ describe('useStationAlarm', () => {
 
   it('sets alarmEvent in store when sleepMode is on', async () => {
     useAppStore.setState({ sleepMode: true });
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() => expect(useAppStore.getState().alarmEvent).toEqual(earlyDest));
@@ -470,7 +472,7 @@ describe('useStationAlarm', () => {
 
   it('does not set alarmEvent when sleepMode is off', async () => {
     useAppStore.setState({ sleepMode: false });
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
@@ -479,7 +481,7 @@ describe('useStationAlarm', () => {
 
   it('passes allowSpeaker=false from store', async () => {
     useAppStore.setState({ allowSpeaker: false });
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
@@ -488,7 +490,7 @@ describe('useStationAlarm', () => {
   });
 
   it('does not re-fire when sleepMode toggles after first fire', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
@@ -500,7 +502,7 @@ describe('useStationAlarm', () => {
 
   it('handles sendAlarmNotification rejection gracefully', () => {
     mockSendAlarmNotification.mockRejectedValueOnce(new Error('알림 실패'));
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     expect(() => renderHook(() => useStationAlarm(defaultInputs({ route, destination })))).not.toThrow();
   });
@@ -514,7 +516,7 @@ describe('useStationAlarm', () => {
     };
 
     it('fires when nearest station changes (notificationState dedup)', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
@@ -526,7 +528,7 @@ describe('useStationAlarm', () => {
     });
 
     it('does not fire when stored lastNotifiedStationId equals nearest station', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       mockGetLastNotifiedStationId.mockResolvedValue('S1');
@@ -541,7 +543,7 @@ describe('useStationAlarm', () => {
     });
 
     it('fires again when nearest station changes to a different one', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station1 = makeStation('S1', '역삼');
       const station2 = makeStation('S2', '선릉');
       mockResolveNextTarget.mockReturnValue(directTarget);
@@ -569,7 +571,7 @@ describe('useStationAlarm', () => {
     });
 
     it('does not fire when nearestStation is null', () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
@@ -583,7 +585,7 @@ describe('useStationAlarm', () => {
     });
 
     it('does not fire when destination is null', () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       renderHook(() => useStationAlarm(defaultInputs({ route, nearestStation: station })));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
@@ -591,7 +593,7 @@ describe('useStationAlarm', () => {
     });
 
     it('passes null target when resolveNextTarget returns null', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(null);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
@@ -602,7 +604,7 @@ describe('useStationAlarm', () => {
 
     it('handles sendStationPassedNotification rejection gracefully', async () => {
       mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 실패'));
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       expect(() =>
@@ -615,7 +617,7 @@ describe('useStationAlarm', () => {
 
     it('handles getLastNotifiedStationId rejection gracefully', async () => {
       mockGetLastNotifiedStationId.mockRejectedValueOnce(new Error('storage 실패'));
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       expect(() =>
@@ -627,14 +629,13 @@ describe('useStationAlarm', () => {
     });
 
     it('transfer route에서 경로 외 노선의 역은 알림을 발송하지 않는다', () => {
-      const route: TransferRoute = {
-        type: 'transfer',
+      const route = makeTransferRoute({
         transferName: '시청',
         fromLine: '1',
         toLine: '2',
         stopsToTransfer: 3,
         stopsFromTransfer: 5,
-      };
+      });
       // 4호선 역 (경로상 노선 1, 2가 아님)
       const offRouteStation: Station = {
         id: 'OFF-1',
@@ -659,7 +660,7 @@ describe('useStationAlarm', () => {
       // #195: PR #196의 isStationOnRoute(direct)가 항상 true였던 결함을 막는 통합 회귀.
       // 2호선 강남 → 2호선 잠실 direct 경로 진행 중 GPS가 9호선 한성백제를 잡아도
       // 거리 게이트(1km)는 통과하지만 isStationOnRoute(direct) → false로 알림 차단.
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const offRouteStation: Station = {
         id: 'OFF-9',
         name: '한성백제',
@@ -680,14 +681,13 @@ describe('useStationAlarm', () => {
     });
 
     it('경로 외 역 다음에 경로상 역이 오면 알림을 발송한다', async () => {
-      const route: TransferRoute = {
-        type: 'transfer',
+      const route = makeTransferRoute({
         transferName: '시청',
         fromLine: '1',
         toLine: '2',
         stopsToTransfer: 3,
         stopsFromTransfer: 5,
-      };
+      });
       const offRouteStation: Station = {
         id: 'OFF-1',
         name: '동대문',
@@ -720,7 +720,7 @@ describe('useStationAlarm', () => {
     });
 
     it('알림 발송 후에만 notificationState에 저장한다 (실패 시 재시도 가능)', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 발송 실패'));
@@ -735,7 +735,7 @@ describe('useStationAlarm', () => {
     });
 
     it('알림 발송이 성공하면 그 후에 notificationState에 저장한다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
 
@@ -764,7 +764,7 @@ describe('useStationAlarm', () => {
     }
 
     it('race: A→B→A 빠른 변동 시 가장 마지막 candidate에 대한 알림만 발송된다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const stationA = makeStation('SA', '강남A');
       const stationB = makeStation('SB', '강남B');
       mockResolveNextTarget.mockReturnValue(directTarget);
@@ -798,7 +798,7 @@ describe('useStationAlarm', () => {
     });
 
     it('cancel 플래그: read 완료 전 언마운트되면 알림을 발송하지 않는다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
 
@@ -821,7 +821,7 @@ describe('useStationAlarm', () => {
     });
 
     it('cancel 플래그: notify 완료 전 언마운트되면 storage write를 하지 않는다', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
 
@@ -851,7 +851,7 @@ describe('useStationAlarm', () => {
   // BG가 AsyncStorage(FIRED_ALARMS_KEY)에 fired 알람을 기록한 뒤 FG로 복귀하면
   // useStationAlarm은 시작 시 storage를 hydrate해 같은 phase를 재발화하지 않는다.
   describe('firedAlarms BG↔FG 단일 출처 (#336)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
 
     const renderWithBgFired = () => {
       // BG가 이미 발화: storage에 alarmKey가 있음.
@@ -925,7 +925,7 @@ describe('useStationAlarm', () => {
 
   // ── 알람 로그 적재 (B2 인프라) ──
   describe('appendAlarmLog 적재', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+    const route = makeDirectRoute(1, '2');
     const station = makeStation('S1', '강남', 37.498, 127.028);
 
     it('알람 발사 시 logFiredAlarm(fg, event, "eta")를 호출한다', async () => {
@@ -1026,7 +1026,7 @@ describe('useStationAlarm', () => {
   });
 
   describe('#396 API 신호 기반 imminent', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     const station = makeStation('S1', '시청');
 
     it('isImminentByArrivalCode가 true이고 미발사 상태면 imminent 알람 발사 + logFiredAlarm("fg", _, "api")', async () => {
@@ -1202,7 +1202,7 @@ describe('useStationAlarm', () => {
 
   describe('fusionSource 라벨 전파 (#327)', () => {
     it('fusionSource=gps 전달 시 sendAlarmNotification에 gpsOnly가 4번째 인자로 전달된다', async () => {
-      const route: DirectRoute = { type: 'direct', line: '2', stops: 5 };
+      const route = makeDirectRoute(5, '2');
       const destination = makeStation('D1', '강남');
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderHook(() =>
@@ -1214,7 +1214,7 @@ describe('useStationAlarm', () => {
     });
 
     it('locationUncertain=true 전달 시 source 무시하고 uncertain 전달', async () => {
-      const route: DirectRoute = { type: 'direct', line: '2', stops: 5 };
+      const route = makeDirectRoute(5, '2');
       const destination = makeStation('D1', '강남');
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderHook(() =>
@@ -1228,7 +1228,7 @@ describe('useStationAlarm', () => {
     });
 
     it('역 통과 알림에도 notificationSource가 전달된다', async () => {
-      const route: DirectRoute = { type: 'direct', line: '2', stops: 5 };
+      const route = makeDirectRoute(5, '2');
       const destination = makeStation('D1', '강남');
       const station = makeStation('S1', '역삼');
       const directTarget = {
@@ -1270,7 +1270,7 @@ describe('useStationAlarm', () => {
     });
 
     it('evaluateAlarmPhase가 suppressedOut에 push한 이벤트마다 logSuppressedDedupAlarm 호출', async () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       const suppressedEvent: AlarmEvent = {
         phaseId: 'early',
         type: 'destination',
@@ -1300,7 +1300,7 @@ describe('useStationAlarm', () => {
   });
 
   describe('#670/#672 첫 evaluation suppress 가드', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     // skipWarmupGuard 미전달 → production default(false) 적용. 첫 evaluation 보류 동작 확인.
     function inputsWithGuardDefault(loc: { lat: number; lng: number }): UseStationAlarmInputs {
       return {

--- a/src/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/hooks/__tests__/useTransferTrainList.test.tsx
@@ -5,8 +5,8 @@ import { useBoardingLockStore } from '../../store/useBoardingLockStore';
 import { findStationByNameAndLine } from '../../utils/stationRoute';
 import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
 import type { BoardingLock } from '../../types/boardingLock';
-import type { TransferRoute } from '../../utils/stationRoute';
 import type { Station } from '../../types/station';
+import { makeTransferRoute } from '../../testUtils/routeFixtures';
 
 jest.mock('../useArrivalInfo');
 const mockUseArrival = useArrivalInfo as jest.Mock;
@@ -29,14 +29,13 @@ const lock: BoardingLock = {
   boardedAt: 0,
   expectedDurationMs: 1_000_000,
 };
-const route: TransferRoute = {
-  type: 'transfer',
+const route = makeTransferRoute({
   transferName: '공덕',
   fromLine: '6',
   toLine: '5',
   stopsToTransfer: 2,
   stopsFromTransfer: 3,
-};
+});
 const gondeokOn6 = findStationByNameAndLine('공덕', '6') as Station;
 
 function arrivalRet(arrival: StationArrival | null) {

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -63,6 +63,7 @@ import '../../tasks/backgroundLocationTask';
 import { BACKGROUND_LOCATION_TASK } from '../../tasks/backgroundLocationTask';
 import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../constants/location';
 import { ALARM_EVENT_KEY } from '../../constants/storageKeys';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 // ── 픽스처 ──
 
@@ -321,7 +322,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   });
 
   it('routeJson이 있으면 파싱한 route를 processLocationUpdate에 전달한다', async () => {
-    const storedRoute = { type: 'direct', stops: 3, line: '2' };
+    const storedRoute = makeDirectRoute(3, '2');
     mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(storedRoute));
 
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });

--- a/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -109,6 +109,7 @@ import {
   FIRED_ALARMS_KEY,
 } from '../../constants/storageKeys';
 import { MAX_LOCATION_AGE_MS, MAX_ACCURACY_M } from '../../constants/location';
+import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 // ── 테스트 버퍼 상수: 임계값 안쪽/바깥쪽임을 이름으로 드러낸다 ──
 const FRESH_MARGIN_MS = 1_000;
@@ -224,7 +225,7 @@ beforeEach(() => {
   mockFindNearestStation.mockReset();
   mockFindRoute.mockReset();
   // 기본: 'early' phase가 트리거되지 않는 multi-stop direct route — 알림 발사만 검증
-  mockFindRoute.mockReturnValue({ type: 'direct', stops: 3, line: '2' });
+  mockFindRoute.mockReturnValue(makeDirectRoute(3, '2'));
   mockSendStationPassedNotification.mockClear();
   mockSendAlarmNotification.mockClear();
   mockUpdateStationNotification.mockClear();
@@ -279,7 +280,7 @@ describe('FG↔BG 통합: 알람 dedup (FIRED_ALARMS_KEY 단일 출처)', () => 
   beforeEach(() => {
     mockStorage.set(DESTINATION_KEY, JSON.stringify(fakeDestination));
     // 'early' phase 트리거: 도착역까지 1 정거장 (APPROACH_STOPS=1)
-    mockFindRoute.mockReturnValue({ type: 'direct', stops: 1, line: '2' });
+    mockFindRoute.mockReturnValue(makeDirectRoute(1, '2'));
   });
 
   it('FG에서 알람 발사 후 BG가 같은 phase 조건을 받으면 evaluateAlarmPhase가 dedup한다', async () => {
@@ -386,7 +387,7 @@ describe('FG↔BG 통합: swipe-kill 후 재진입 (AsyncStorage 영속성)', ()
   });
 
   it('BG 알람 발사 후 swipe-kill을 거쳐 FG 재진입해도 firedAlarms는 영속 dedup된다', async () => {
-    mockFindRoute.mockReturnValue({ type: 'direct', stops: 1, line: '2' });
+    mockFindRoute.mockReturnValue(makeDirectRoute(1, '2'));
     await runBgTaskAt(fakeStation);
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
     const firedJson = mockStorage.get(FIRED_ALARMS_KEY);

--- a/src/testUtils/routeFixtures.ts
+++ b/src/testUtils/routeFixtures.ts
@@ -1,0 +1,76 @@
+import type {
+  DirectRoute,
+  MultiTransferRoute,
+  TransferRoute,
+  TransferSegment,
+} from '../utils/stationRoute';
+import type { LineNumber } from '../types/station';
+
+/**
+ * 테스트용 평균 운행 시간 (초/정거장). production은 build-transfer-times.js 실측 lookup,
+ * fixture는 충분히 일관된 평균치(120s)로 충분 — getTravelMinutes 등 시간 계산이 의미를 잃지 않으면 됨.
+ */
+const STOP_FALLBACK_SECONDS = 120;
+
+export function makeDirectRoute(stops: number, line: LineNumber): DirectRoute {
+  return {
+    type: 'direct',
+    stops,
+    line,
+    travelSeconds: stops * STOP_FALLBACK_SECONDS,
+  };
+}
+
+export interface MakeTransferRouteInput {
+  transferName: string;
+  fromLine: LineNumber;
+  toLine: LineNumber;
+  stopsToTransfer: number;
+  stopsFromTransfer: number;
+}
+
+export function makeTransferRoute(input: MakeTransferRouteInput): TransferRoute {
+  return {
+    type: 'transfer',
+    transferName: input.transferName,
+    fromLine: input.fromLine,
+    toLine: input.toLine,
+    stopsToTransfer: input.stopsToTransfer,
+    stopsFromTransfer: input.stopsFromTransfer,
+    secondsToTransfer: input.stopsToTransfer * STOP_FALLBACK_SECONDS,
+    secondsFromTransfer: input.stopsFromTransfer * STOP_FALLBACK_SECONDS,
+  };
+}
+
+export interface MakeTransferSegmentInput {
+  transferName: string;
+  fromLine: LineNumber;
+  toLine: LineNumber;
+  stopsToTransfer: number;
+}
+
+export function makeTransferSegment(input: MakeTransferSegmentInput): TransferSegment {
+  return {
+    transferName: input.transferName,
+    fromLine: input.fromLine,
+    toLine: input.toLine,
+    stopsToTransfer: input.stopsToTransfer,
+    secondsToTransfer: input.stopsToTransfer * STOP_FALLBACK_SECONDS,
+  };
+}
+
+export interface MakeMultiTransferRouteInput {
+  transfers: MakeTransferSegmentInput[];
+  stopsAfterLastTransfer: number;
+}
+
+export function makeMultiTransferRoute(
+  input: MakeMultiTransferRouteInput,
+): MultiTransferRoute {
+  return {
+    type: 'multi-transfer',
+    transfers: input.transfers.map(makeTransferSegment),
+    stopsAfterLastTransfer: input.stopsAfterLastTransfer,
+    secondsAfterLastTransfer: input.stopsAfterLastTransfer * STOP_FALLBACK_SECONDS,
+  };
+}

--- a/src/utils/__tests__/alarmDirection.test.ts
+++ b/src/utils/__tests__/alarmDirection.test.ts
@@ -1,5 +1,10 @@
 import { resolveAlarmDirection } from '../alarmDirection';
 import type { Route } from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 jest.mock('../travelDirection', () => ({
   // 간단한 mock: from→to 쌍에 따라 미리 정한 결과를 반환. 시그니처는 { direction, fromStation, toStation }.
@@ -18,7 +23,7 @@ jest.mock('../stationRoute', () => ({
 
 describe('resolveAlarmDirection', () => {
   describe('direct route', () => {
-    const route: NonNullable<Route> = { type: 'direct', stops: 3, line: '1' };
+    const route: NonNullable<Route> = makeDirectRoute(3, '1');
 
     it('대상역이 목적지이면 source→destination 방향을 반환한다', () => {
       const dir = resolveAlarmDirection(
@@ -46,14 +51,13 @@ describe('resolveAlarmDirection', () => {
   });
 
   describe('transfer route', () => {
-    const route: NonNullable<Route> = {
-      type: 'transfer',
+    const route: NonNullable<Route> = makeTransferRoute({
       transferName: '동대문',
       fromLine: '1',
       toLine: '2',
       stopsToTransfer: 2,
       stopsFromTransfer: 4,
-    };
+    });
 
     it('대상역이 환승역이면 fromLine 기준 방향', () => {
       const dir = resolveAlarmDirection(
@@ -97,14 +101,13 @@ describe('resolveAlarmDirection', () => {
   });
 
   describe('multi-transfer route', () => {
-    const route: NonNullable<Route> = {
-      type: 'multi-transfer',
+    const route: NonNullable<Route> = makeMultiTransferRoute({
       transfers: [
         { transferName: '왕십리', fromLine: '1', toLine: '2', stopsToTransfer: 3 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
 
     it('첫 번째 환승은 sourceStationName 기준', () => {
       const dir = resolveAlarmDirection(
@@ -140,14 +143,13 @@ describe('resolveAlarmDirection', () => {
     });
 
     it('환승 매칭은 됐지만 방향 lookup이 null이면 undefined', () => {
-      const routeWithNullableLine: NonNullable<Route> = {
-        type: 'multi-transfer',
+      const routeWithNullableLine: NonNullable<Route> = makeMultiTransferRoute({
         transfers: [
           { transferName: '왕십리', fromLine: '3', toLine: '2', stopsToTransfer: 3 },
           { transferName: '교대', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
         ],
         stopsAfterLastTransfer: 4,
-      };
+      });
       const dir = resolveAlarmDirection(
         { type: 'transfer', stationName: '왕십리' },
         { route: routeWithNullableLine, destinationName: '강남', sourceStationName: '시청' },

--- a/src/utils/__tests__/alarmScheduler.test.ts
+++ b/src/utils/__tests__/alarmScheduler.test.ts
@@ -8,11 +8,11 @@ import {
 } from '../alarmScheduler';
 import { logScheduledAlarm } from '../alarmLog';
 import { getLastNotifiedStationId } from '../notificationState';
-import type {
-  DirectRoute,
-  TransferRoute,
-  MultiTransferRoute,
-} from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 jest.mock('expo-notifications');
 jest.mock('../logger', () => ({
@@ -79,7 +79,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('direct 경로는 도착역 1 waypoint × 2 phase = 2개 알람을 예약한다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -105,14 +105,13 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('transfer 경로는 환승 + 도착 = 2 waypoint × 2 phase = 4개 알람을 예약한다 (2(N+1), N=1)', async () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '동대문',
       fromLine: '1',
       toLine: '4',
       stopsToTransfer: 4,
       stopsFromTransfer: 6,
-    };
+    });
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -146,14 +145,13 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('multi-transfer 경로는 3 waypoint × 2 phase = 6개 알람을 예약한다 (N=2)', async () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 3 },
         { transferName: '서울역', fromLine: '4', toLine: '2', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 2,
-    };
+    });
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -173,7 +171,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('currentStationApproachEtaSeconds가 null이면 calculateStaticETA로 fallback한다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     // calculateStaticETA(direct stops=10) = 3 wait + 10*2 = 23 min = 1380s
     const result = await scheduleAlarmsForRoute({
       route,
@@ -188,7 +186,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('currentStationApproachEtaSeconds가 0 이하면 fallback을 사용한다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -200,7 +198,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('totalStops가 0이면 빈 배열을 반환한다 (이미 목적지)', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 0, line: '1' };
+    const route = makeDirectRoute(0, '1');
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -214,14 +212,13 @@ describe('scheduleAlarmsForRoute', () => {
 
   it('stops=0 waypoint(이미 도착한 환승역 등)는 두 phase 모두 건너뛰고 다음 waypoint만 예약한다', async () => {
     // 환승역에 이미 도착해 stopsToTransfer=0인 trip — transfer는 waypointEta=0이라 fire<=0으로 모두 skip.
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '동대문',
       fromLine: '1',
       toLine: '4',
       stopsToTransfer: 0,
       stopsFromTransfer: 5,
-    };
+    });
     const result = await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -241,7 +238,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('iOS에서는 interruptionLevel: timeSensitive를 포함한다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -261,7 +258,7 @@ describe('scheduleAlarmsForRoute', () => {
 
   it('Android에서는 channelId와 priority MAX를 포함한다', async () => {
     jest.replaceProperty(Platform, 'OS', 'android');
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -279,7 +276,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('scheduleNotificationAsync 호출 시 trigger.date에 fireDate가 전달된다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',
@@ -296,7 +293,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('now를 생략하면 Date.now()를 사용한다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     const before = Date.now();
     const result = await scheduleAlarmsForRoute({
       route,
@@ -313,7 +310,7 @@ describe('scheduleAlarmsForRoute', () => {
 
   // ── #372 stamp ──
   it('stamp + last-notified를 각 예약 알람에 함께 적재한다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
     mockedGetLastNotified.mockResolvedValueOnce('S-prev');
 
     await scheduleAlarmsForRoute({
@@ -348,7 +345,7 @@ describe('scheduleAlarmsForRoute', () => {
   });
 
   it('stamp 미지정이면 direction/usedTrainCode가 null로 기록된다', async () => {
-    const route: DirectRoute = { type: 'direct', stops: 10, line: '1' };
+    const route = makeDirectRoute(10, '1');
 
     await scheduleAlarmsForRoute({
       route,
@@ -372,14 +369,13 @@ describe('scheduleAlarmsForRoute', () => {
   it('skip된 phase(예: stops=0 waypoint)는 logScheduledAlarm을 호출하지 않는다', async () => {
     // stopsToTransfer=0이면 환승역 waypoint는 fireSeconds<=0으로 두 phase 모두 skip되어
     // log도 남기지 않는다. 도착역 phase 2회만 stamp된다.
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '동대문',
       fromLine: '1',
       toLine: '4',
       stopsToTransfer: 0,
       stopsFromTransfer: 5,
-    };
+    });
     await scheduleAlarmsForRoute({
       route,
       destinationName: '강남',

--- a/src/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/utils/__tests__/boardingLockScheduler.test.ts
@@ -16,6 +16,11 @@ import {
 } from '../scheduledNotificationsStorage';
 import type { BoardingLock } from '../../types/boardingLock';
 import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 jest.mock('expo-notifications');
 jest.mock('../scheduledNotificationsStorage', () => ({
@@ -72,24 +77,22 @@ const lock: BoardingLock = {
   expectedDurationMs: 600_000,
 };
 
-const directRoute: DirectRoute = { type: 'direct', stops: 2, line: '2' };
-const transferRoute: TransferRoute = {
-  type: 'transfer',
+const directRoute: DirectRoute = makeDirectRoute(2, '2');
+const transferRoute: TransferRoute = makeTransferRoute({
   transferName: '교대',
   fromLine: '2',
   toLine: '3',
   stopsToTransfer: 2,
   stopsFromTransfer: 3,
-};
-const multiRoute: MultiTransferRoute = {
-  type: 'multi-transfer',
+});
+const multiRoute: MultiTransferRoute = makeMultiTransferRoute({
   transfers: [
     { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 2 },
     { transferName: '약수', fromLine: '3', toLine: '6', stopsToTransfer: 2 },
     { transferName: '한강진', fromLine: '6', toLine: '7', stopsToTransfer: 1 },
   ],
   stopsAfterLastTransfer: 2,
-};
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -266,7 +269,7 @@ describe('scheduleHopsForLock', () => {
   it('빈 targets은 storage write도 빈 배열', async () => {
     // direct stops=0 → totalStops=0, but resolveAllTargets returns 1 entry with stops=0.
     // waypointEta=0 → 모든 phase에서 fireSeconds <= 0 → 예약 안 됨.
-    const zeroRoute: DirectRoute = { type: 'direct', stops: 0, line: '2' };
+    const zeroRoute: DirectRoute = makeDirectRoute(0, '2');
     await scheduleHopsForLock({ lock, route: zeroRoute, destinationName: '강남' });
     expect(mockedSchedule).not.toHaveBeenCalled();
   });

--- a/src/utils/__tests__/buildBoardingLockMeta.test.ts
+++ b/src/utils/__tests__/buildBoardingLockMeta.test.ts
@@ -1,52 +1,49 @@
 import { buildBoardingLockMeta, findSegmentEndStationName } from '../buildBoardingLockMeta';
 import { BOARDING_LOCK_EXPIRY_FACTOR } from '../../types/boardingLock';
 import type { BoardingLock } from '../../types/boardingLock';
-import type {
-  DirectRoute,
-  TransferRoute,
-  MultiTransferRoute,
-} from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 describe('findSegmentEndStationName', () => {
   it('direct route → destination', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route = makeDirectRoute(3, '2');
     expect(findSegmentEndStationName(route, '2', '강남')).toBe('강남');
   });
 
   it('transfer fromLine → transferName, toLine → destination', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '교대',
       fromLine: '3',
       toLine: '2',
       stopsToTransfer: 5,
       stopsFromTransfer: 2,
-    };
+    });
     expect(findSegmentEndStationName(route, '3', '강남')).toBe('교대');
     expect(findSegmentEndStationName(route, '2', '강남')).toBe('강남');
   });
 
   it('transfer 노선 어느 segment에도 일치 안 하면 null', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '교대',
       fromLine: '3',
       toLine: '2',
       stopsToTransfer: 5,
       stopsFromTransfer: 2,
-    };
+    });
     expect(findSegmentEndStationName(route, '7', '강남')).toBeNull();
   });
 
   it('multi-transfer: segment.fromLine 일치 → transferName, 마지막 toLine → destination', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '시청', fromLine: '1', toLine: '2', stopsToTransfer: 3 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 4 },
       ],
       stopsAfterLastTransfer: 5,
-    };
+    });
     expect(findSegmentEndStationName(route, '1', '대치')).toBe('시청');
     expect(findSegmentEndStationName(route, '2', '대치')).toBe('교대');
     expect(findSegmentEndStationName(route, '3', '대치')).toBe('대치');
@@ -54,11 +51,10 @@ describe('findSegmentEndStationName', () => {
   });
 
   it('multi-transfer transfers 비어있고 line 매칭 없으면 null', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [],
       stopsAfterLastTransfer: 5,
-    };
+    });
     expect(findSegmentEndStationName(route, '1', '대치')).toBeNull();
   });
 });
@@ -74,7 +70,7 @@ describe('buildBoardingLockMeta', () => {
   };
 
   it('subwayId 매핑 실패면 null (line이 알 수 없음)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '7' };
+    const route = makeDirectRoute(3, '7');
     const result = buildBoardingLockMeta({
       lock: { ...baseLock, boardingLine: 'unknown' as never },
       route,
@@ -85,14 +81,13 @@ describe('buildBoardingLockMeta', () => {
   });
 
   it('segmentStations 추론 불가하면 (boardingLine ≠ route segment) null', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '교대',
       fromLine: '3',
       toLine: '2',
       stopsToTransfer: 5,
       stopsFromTransfer: 2,
-    };
+    });
     const result = buildBoardingLockMeta({
       lock: { ...baseLock, boardingLine: '7' },
       route,
@@ -104,7 +99,7 @@ describe('buildBoardingLockMeta', () => {
 
   it('id 역순(startIdx > endIdx)이면 boarding→destination 순서로 reverse한다 — backend indexOf 의존', () => {
     // 7호선에서 사가정(상위 id) → 면목(하위 id)으로 이동 (위→아래 진행 가정).
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const route = makeDirectRoute(1, '7');
     const result = buildBoardingLockMeta({
       lock: { ...baseLock, boardingLine: '7' },
       route,
@@ -118,7 +113,7 @@ describe('buildBoardingLockMeta', () => {
   });
 
   it('boarding == destination이면 segmentStations 길이 1', () => {
-    const route: DirectRoute = { type: 'direct', stops: 0, line: '7' };
+    const route = makeDirectRoute(0, '7');
     const result = buildBoardingLockMeta({
       lock: { ...baseLock, boardingLine: '7' },
       route,
@@ -131,7 +126,7 @@ describe('buildBoardingLockMeta', () => {
 
   it('direct route + 같은 line: segmentStations에 출발/도착 포함된 station 시퀀스', () => {
     // 면목(7호선) → 용마산(7호선), 7호선에서 인접한 두 역.
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const route = makeDirectRoute(1, '7');
     const result = buildBoardingLockMeta({
       lock: { ...baseLock, boardingLine: '7' },
       route,
@@ -150,7 +145,7 @@ describe('buildBoardingLockMeta', () => {
   });
 
   it('알 수 없는 boardingStation/endStation이면 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const route = makeDirectRoute(1, '7');
     const result = buildBoardingLockMeta({
       lock: { ...baseLock, boardingLine: '7' },
       route,

--- a/src/utils/__tests__/findActiveTransferContext.test.ts
+++ b/src/utils/__tests__/findActiveTransferContext.test.ts
@@ -1,8 +1,12 @@
 import { findActiveTransferContext, resolveDirectionInLine } from '../findActiveTransferContext';
 import { findStationByNameAndLine, getStationsOnLine } from '../stationRoute';
 import type { BoardingLock } from '../../types/boardingLock';
-import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
 import type { Station } from '../../types/station';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 const lock: BoardingLock = {
   destinationId: 'd',
@@ -28,29 +32,28 @@ describe('findActiveTransferContext', () => {
   });
 
   it('destinationName=null이면 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '6' };
+    const route = makeDirectRoute(1, '6');
     expect(findActiveTransferContext(lock, route, null, gondeokOnLine6)).toBeNull();
   });
 
   it('currentStation=null이면 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '6' };
+    const route = makeDirectRoute(1, '6');
     expect(findActiveTransferContext(lock, route, '강남', null)).toBeNull();
   });
 
   it('direct route(환승 없음)는 항상 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '6' };
+    const route = makeDirectRoute(1, '6');
     expect(findActiveTransferContext(lock, route, '공덕', gondeokOnLine6)).toBeNull();
   });
 
   it('transfer route + 현재역이 환승역이면 toLine 컨텍스트 반환', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '공덕',
       fromLine: '6',
       toLine: '5',
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
-    };
+    });
     const ctx = findActiveTransferContext(lock, route, '여의나루', gondeokOnLine6);
     expect(ctx).not.toBeNull();
     expect(ctx!.nextLine).toBe('5');
@@ -64,40 +67,37 @@ describe('findActiveTransferContext', () => {
 
   it('transfer route + 환승역=목적지이면 alarmType=destination → null', () => {
     // transferName === destinationName 케이스는 resolveAllTargets가 destination으로 처리.
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '공덕',
       fromLine: '6',
       toLine: '5',
       stopsToTransfer: 2,
       stopsFromTransfer: 0,
-    };
+    });
     expect(findActiveTransferContext(lock, route, '공덕', gondeokOnLine6)).toBeNull();
   });
 
   it('transfer route + 현재역이 환승역이 아니면 null', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '공덕',
       fromLine: '6',
       toLine: '5',
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
-    };
+    });
     expect(findActiveTransferContext(lock, route, '여의나루', yeouinaru)).toBeNull();
   });
 
   it('환승 후 방향이 up인 케이스 (toLine 인덱스 역전)', () => {
     // 충무로(4→3 환승) → 종로3가(line 3 → line 1 환승). 3호선에서 충무로 인덱스 > 종로3가 인덱스
     // → resolveDirectionInLine은 'up' 반환.
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
         { transferName: '종로3가', fromLine: '3', toLine: '1', stopsToTransfer: 1 },
       ],
       stopsAfterLastTransfer: 1,
-    };
+    });
     const chungmuroOn4 = findStationByNameAndLine('충무로', '4') as Station;
     const ctx = findActiveTransferContext(lock, route, '서울역', chungmuroOn4);
     // direction이 'up' 또는 'down' — toLine 인덱스 검증. 실데이터 의존이라 둘 다 허용해
@@ -107,15 +107,14 @@ describe('findActiveTransferContext', () => {
   });
 
   it('multi-transfer route + 첫 환승역 도달 시 두 번째 leg 컨텍스트', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '공덕', fromLine: '6', toLine: '5', stopsToTransfer: 2 },
         // 두 번째 transfer는 임의 — 첫 번째만 검증 대상
         { transferName: '여의나루', fromLine: '5', toLine: '5', stopsToTransfer: 3 },
       ],
       stopsAfterLastTransfer: 1,
-    };
+    });
     const ctx = findActiveTransferContext(lock, route, '아무목적지', gondeokOnLine6);
     expect(ctx).not.toBeNull();
     expect(ctx!.nextLine).toBe('5');
@@ -125,14 +124,13 @@ describe('findActiveTransferContext', () => {
   });
 
   it('multi-transfer route + 두 번째 환승역 도달 시 completedTransferIdx=1', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
         { transferName: '종로3가', fromLine: '3', toLine: '1', stopsToTransfer: 1 },
       ],
       stopsAfterLastTransfer: 1,
-    };
+    });
     const jongno3 = findStationByNameAndLine('종로3가', '3') as Station;
     const ctx = findActiveTransferContext(lock, route, '서울역', jongno3);
     expect(ctx).not.toBeNull();
@@ -141,28 +139,26 @@ describe('findActiveTransferContext', () => {
   });
 
   it('currentStation이 어떤 waypoint와도 매칭되지 않으면 null (matchedIdx=-1)', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '공덕',
       fromLine: '6',
       toLine: '5',
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
-    };
+    });
     // 현재역은 효창공원앞(6호선) — route 어느 waypoint와도 매칭 안 됨
     const hyochang = findStationByNameAndLine('효창공원앞', '6') as Station;
     expect(findActiveTransferContext(lock, route, '여의나루', hyochang)).toBeNull();
   });
 
   it('환승 시 direction이 명시적으로 산출됨 (resolveDirectionInLine 성공 경로)', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '공덕',
       fromLine: '6',
       toLine: '5',
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
-    };
+    });
     const ctx = findActiveTransferContext(lock, route, '여의나루', gondeokOnLine6);
     expect(ctx).not.toBeNull();
     // 5호선 공덕→여의나루는 stations.json index가 다르므로 direction은 non-null
@@ -170,14 +166,13 @@ describe('findActiveTransferContext', () => {
   });
 
   it('lock.boardingLine이 이미 nextLine이면 null (환승 lock 교체 직후 재노출 방지)', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '공덕',
       fromLine: '6',
       toLine: '5',
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
-    };
+    });
     // lock이 이미 5호선으로 교체된 상태 (createTransferLock 직후)
     const transferredLock = { ...lock, boardingLine: '5' as const };
     expect(
@@ -202,14 +197,13 @@ describe('findActiveTransferContext', () => {
 
   it('toLine 측 환승역 station을 못 찾으면 null', () => {
     // 존재하지 않는 가짜 노선 매칭 — findStationByNameAndLine이 undefined 반환하는 경로 커버
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '존재하지않는역X',
       fromLine: '6',
       toLine: '5',
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
-    };
+    });
     const fakeCurrent: Station = { ...gondeokOnLine6, name: '존재하지않는역X' };
     expect(findActiveTransferContext(lock, route, '여의나루', fakeCurrent)).toBeNull();
   });

--- a/src/utils/__tests__/routeProgress.test.ts
+++ b/src/utils/__tests__/routeProgress.test.ts
@@ -5,12 +5,12 @@ import {
   type RouteArc,
 } from '../routeProgress';
 import { findStationByNameAndLine } from '../stationRoute';
-import type {
-  DirectRoute,
-  MultiTransferRoute,
-  TransferRoute,
-} from '../stationRoute';
 import type { Station } from '../../types/station';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
 const sagajeong = findStationByNameAndLine('사가정', '7')!;
@@ -28,7 +28,7 @@ describe('computeRouteArc', () => {
   });
 
   it('builds arc for direct route (forward — id ascending)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
     const arc = computeRouteArc(route, sagajeong, childrenPark);
     expect(arc).not.toBeNull();
     expect(arc!.stations[0].id).toBe(sagajeong.id);
@@ -39,7 +39,7 @@ describe('computeRouteArc', () => {
   });
 
   it('builds arc for direct route (reverse — id descending)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
     const arc = computeRouteArc(route, childrenPark, sagajeong);
     expect(arc).not.toBeNull();
     expect(arc!.stations[0].id).toBe(childrenPark.id);
@@ -47,7 +47,7 @@ describe('computeRouteArc', () => {
   });
 
   it('builds arc for direct route (origin === destination)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 0, line: '7' };
+    const route = makeDirectRoute(0, '7');
     const arc = computeRouteArc(route, gunja, gunja);
     expect(arc).not.toBeNull();
     expect(arc!.stations).toHaveLength(1);
@@ -56,26 +56,25 @@ describe('computeRouteArc', () => {
   });
 
   it('returns null when direct route origin id is not on the line', () => {
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
     const fake: Station = { ...gunja, id: 'nonexistent' };
     expect(computeRouteArc(route, fake, sagajeong)).toBeNull();
   });
 
   it('returns null when direct route destination id is not on the line', () => {
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
     const fake: Station = { ...sagajeong, id: 'nonexistent' };
     expect(computeRouteArc(route, gunja, fake)).toBeNull();
   });
 
   it('builds arc for transfer route', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '건대입구',
       fromLine: '7',
       toLine: '2',
       stopsToTransfer: 1,
       stopsFromTransfer: 4,
-    };
+    });
     const arc = computeRouteArc(route, childrenPark, jamsil2);
     expect(arc).not.toBeNull();
     expect(arc!.stations[0].id).toBe(childrenPark.id);
@@ -86,52 +85,48 @@ describe('computeRouteArc', () => {
   });
 
   it('returns null when transfer route has unknown transferName', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '존재하지않는역',
       fromLine: '7',
       toLine: '2',
       stopsToTransfer: 1,
       stopsFromTransfer: 4,
-    };
+    });
     expect(computeRouteArc(route, childrenPark, jamsil2)).toBeNull();
   });
 
   it('returns null when transfer route origin id is invalid', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '건대입구',
       fromLine: '7',
       toLine: '2',
       stopsToTransfer: 1,
       stopsFromTransfer: 4,
-    };
+    });
     const fakeOrigin: Station = { ...childrenPark, id: 'nonexistent' };
     expect(computeRouteArc(route, fakeOrigin, jamsil2)).toBeNull();
   });
 
   it('returns null when transfer route destination id is invalid', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '건대입구',
       fromLine: '7',
       toLine: '2',
       stopsToTransfer: 1,
       stopsFromTransfer: 4,
-    };
+    });
     const fakeDest: Station = { ...jamsil2, id: 'nonexistent' };
     expect(computeRouteArc(route, childrenPark, fakeDest)).toBeNull();
   });
 
   it('builds arc for multi-transfer route', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '건대입구', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
       ],
       stopsAfterLastTransfer: 1,
-    };
+    });
     const arc = computeRouteArc(route, sagajeong, expressBus3);
     expect(arc).not.toBeNull();
     expect(arc!.stations[0].id).toBe(sagajeong.id);
@@ -146,26 +141,24 @@ describe('computeRouteArc', () => {
   });
 
   it('returns null when multi-transfer route has unknown transferName', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '존재하지않는역', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
       ],
       stopsAfterLastTransfer: 1,
-    };
+    });
     expect(computeRouteArc(route, sagajeong, expressBus3)).toBeNull();
   });
 
   it('returns null when multi-transfer route origin id is invalid', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '건대입구', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
       ],
       stopsAfterLastTransfer: 1,
-    };
+    });
     const fakeOrigin: Station = { ...sagajeong, id: 'nonexistent' };
     expect(computeRouteArc(route, fakeOrigin, expressBus3)).toBeNull();
   });
@@ -179,20 +172,19 @@ describe('computeRouteArc', () => {
     const { findStationByNameAndLine: fsbnl } = require('../stationRoute');
     const ori = fsbnl('사가정', '7');
     const dst = fsbnl('어린이대공원', '7');
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
     expect(cra(route, ori, dst)).toBeNull();
     jest.resetModules();
   });
 
   it('returns null when multi-transfer route destination id is invalid', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '건대입구', fromLine: '7', toLine: '2', stopsToTransfer: 5 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 7 },
       ],
       stopsAfterLastTransfer: 1,
-    };
+    });
     const fakeDest: Station = { ...expressBus3, id: 'nonexistent' };
     expect(computeRouteArc(route, sagajeong, fakeDest)).toBeNull();
   });
@@ -200,7 +192,7 @@ describe('computeRouteArc', () => {
 
 describe('nearestArcPoint', () => {
   it('returns haversine distance for single-station arc', () => {
-    const arc = computeRouteArc({ type: 'direct', stops: 0, line: '7' }, gunja, gunja)!;
+    const arc = computeRouteArc(makeDirectRoute(0, '7'), gunja, gunja)!;
     const proj = nearestArcPoint(arc, gunja.lat + 0.001, gunja.lng);
     expect(proj.arcM).toBe(0);
     expect(proj.segmentIndex).toBe(0);
@@ -208,7 +200,7 @@ describe('nearestArcPoint', () => {
   });
 
   it('projects exactly at first station for a 2-station arc', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const route = makeDirectRoute(1, '7');
     const arc = computeRouteArc(route, gunja, childrenPark)!;
     const proj = nearestArcPoint(arc, gunja.lat, gunja.lng);
     expect(proj.arcM).toBeCloseTo(0, 1);
@@ -217,7 +209,7 @@ describe('nearestArcPoint', () => {
   });
 
   it('projects exactly at last station for a 2-station arc', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const route = makeDirectRoute(1, '7');
     const arc = computeRouteArc(route, gunja, childrenPark)!;
     const proj = nearestArcPoint(arc, childrenPark.lat, childrenPark.lng);
     // 등각도 평면 사영 segLenM과 haversine arcM 누적 사이 작은 오차 허용(<5m).
@@ -226,7 +218,7 @@ describe('nearestArcPoint', () => {
   });
 
   it('clamps to t=0 when point is behind first station', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const route = makeDirectRoute(1, '7');
     const arc = computeRouteArc(route, gunja, childrenPark)!;
     // 군자보다 더 북쪽(어린이대공원 반대 방향)으로 멀리 떨어진 점
     const dLat = gunja.lat - childrenPark.lat;
@@ -237,7 +229,7 @@ describe('nearestArcPoint', () => {
   });
 
   it('clamps to t=1 when point is past last station', () => {
-    const route: DirectRoute = { type: 'direct', stops: 1, line: '7' };
+    const route = makeDirectRoute(1, '7');
     const arc = computeRouteArc(route, gunja, childrenPark)!;
     const dLat = childrenPark.lat - gunja.lat;
     const dLng = childrenPark.lng - gunja.lng;
@@ -248,7 +240,7 @@ describe('nearestArcPoint', () => {
   });
 
   it('picks the closer segment for multi-segment arc', () => {
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route = makeDirectRoute(4, '7');
     const arc = computeRouteArc(route, sagajeong, childrenPark)!;
     // 어린이대공원 좌표 입력 → 마지막 segment에 사영되어야 함
     const proj = nearestArcPoint(arc, childrenPark.lat, childrenPark.lng);
@@ -273,11 +265,11 @@ describe('nearestArcPoint', () => {
 });
 
 describe('stationAtProgress', () => {
-  const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+  const route = makeDirectRoute(4, '7');
   const arc = computeRouteArc(route, sagajeong, childrenPark)!;
 
   it('returns single station when arc has only one station', () => {
-    const single = computeRouteArc({ type: 'direct', stops: 0, line: '7' }, gunja, gunja)!;
+    const single = computeRouteArc(makeDirectRoute(0, '7'), gunja, gunja)!;
     const info = stationAtProgress(single, 0);
     expect(info.current.id).toBe(gunja.id);
     expect(info.next).toBeNull();

--- a/src/utils/__tests__/routeToCoordinates.test.ts
+++ b/src/utils/__tests__/routeToCoordinates.test.ts
@@ -2,6 +2,11 @@ import { routeToCoordinates } from '../routeToCoordinates';
 import { findRoute } from '../stationRoute';
 import stationsData from '../../data/stations.json';
 import type { Station } from '../../types/station';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 const allStations = stationsData as Station[];
 const byId = (id: string) => allStations.find((s) => s.id === id)!;
@@ -82,14 +87,13 @@ describe('routeToCoordinates', () => {
 
   describe('multi-transfer route (2회 환승)', () => {
     it('transfers 배열의 각 환승역이 keyStations에 순서대로 포함된다', () => {
-      const route = {
-        type: 'multi-transfer' as const,
+      const route = makeMultiTransferRoute({
         transfers: [
-          { transferName: '사당', fromLine: '2' as const, toLine: '4' as const, stopsToTransfer: 4 },
-          { transferName: '동대문역사문화공원', fromLine: '4' as const, toLine: '5' as const, stopsToTransfer: 4 },
+          { transferName: '사당', fromLine: '2', toLine: '4', stopsToTransfer: 4 },
+          { transferName: '동대문역사문화공원', fromLine: '4', toLine: '5', stopsToTransfer: 4 },
         ],
         stopsAfterLastTransfer: 3,
-      };
+      });
       const origin = byId('2-022'); // 강남
       // 5호선에서 임의의 역
       const destination = allStations.find((s) => s.line === '5' && s.name === '광화문')!;
@@ -104,35 +108,33 @@ describe('routeToCoordinates', () => {
 
   describe('잘못된 입력으로 인한 null 반환', () => {
     it('transfer 환승역 이름을 찾을 수 없으면 null', () => {
-      const route = {
-        type: 'transfer' as const,
+      const route = makeTransferRoute({
         transferName: '존재하지않는역',
-        fromLine: '2' as const,
-        toLine: '6' as const,
+        fromLine: '2',
+        toLine: '6',
         stopsToTransfer: 1,
         stopsFromTransfer: 1,
-      };
+      });
       const origin = byId('2-022');
       const destination = byId('6-020');
       expect(routeToCoordinates(route, origin, destination)).toBeNull();
     });
 
     it('multi-transfer 환승역 이름을 찾을 수 없으면 null', () => {
-      const route = {
-        type: 'multi-transfer' as const,
+      const route = makeMultiTransferRoute({
         transfers: [
-          { transferName: '존재하지않는역', fromLine: '2' as const, toLine: '4' as const, stopsToTransfer: 1 },
-          { transferName: '동대문역사문화공원', fromLine: '4' as const, toLine: '5' as const, stopsToTransfer: 1 },
+          { transferName: '존재하지않는역', fromLine: '2', toLine: '4', stopsToTransfer: 1 },
+          { transferName: '동대문역사문화공원', fromLine: '4', toLine: '5', stopsToTransfer: 1 },
         ],
         stopsAfterLastTransfer: 1,
-      };
+      });
       const origin = byId('2-022');
       const destination = allStations.find((s) => s.line === '5' && s.name === '광화문')!;
       expect(routeToCoordinates(route, origin, destination)).toBeNull();
     });
 
     it('direct route인데 origin이 노선과 불일치하여 슬라이스 실패 시 null', () => {
-      const route = { type: 'direct' as const, line: '2' as const, stops: 1 };
+      const route = makeDirectRoute(1, '2');
       const origin = byId('6-020'); // 6호선 역을 2호선 direct에 넣음 → name이 2호선에 없음
       const destination = byId('2-022');
       expect(routeToCoordinates(route, origin, destination)).toBeNull();

--- a/src/utils/__tests__/routeWaypoints.test.ts
+++ b/src/utils/__tests__/routeWaypoints.test.ts
@@ -1,13 +1,13 @@
 import { routeToWaypoints } from '../routeWaypoints';
-import type {
-  DirectRoute,
-  Route,
-  TransferRoute,
-  MultiTransferRoute,
-} from '../stationRoute';
+import type { Route } from '../stationRoute';
 import { getStationsOnLine } from '../stationRoute';
 import type { AlarmWaypoint } from '../../api/alarmBackend';
 import type { LineNumber, Station } from '../../types/station';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 function stationById(line: LineNumber, id: string): Station {
   const found = getStationsOnLine(line).find((s) => s.id === id);
@@ -23,21 +23,20 @@ const wp = (
 
 describe('routeToWaypoints', () => {
   it('direct: 도착역 단일 waypoint (route.line)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const route = makeDirectRoute(5, '2');
     expect(routeToWaypoints(route, '강남')).toEqual([
       { stationName: '강남', line: '2', kind: 'destination' },
     ]);
   });
 
   it('transfer: 환승역(fromLine) + 도착역(toLine)', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '신도림',
       fromLine: '1',
       toLine: '2',
       stopsToTransfer: 3,
       stopsFromTransfer: 4,
-    };
+    });
     expect(routeToWaypoints(route, '강남')).toEqual([
       { stationName: '신도림', line: '1', kind: 'transfer' },
       { stationName: '강남', line: '2', kind: 'destination' },
@@ -45,28 +44,26 @@ describe('routeToWaypoints', () => {
   });
 
   it('transfer에서 목적지가 환승역과 같으면 destination 1개로 축약 (fromLine)', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '신도림',
       fromLine: '1',
       toLine: '2',
       stopsToTransfer: 3,
       stopsFromTransfer: 0,
-    };
+    });
     expect(routeToWaypoints(route, '신도림')).toEqual([
       { stationName: '신도림', line: '1', kind: 'destination' },
     ]);
   });
 
   it('multi-transfer: 각 환승 + 마지막 toLine으로 도착역 append', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 2 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 2,
-    };
+    });
     expect(routeToWaypoints(route, '경복궁')).toEqual([
       { stationName: '신도림', line: '1', kind: 'transfer' },
       { stationName: '교대', line: '2', kind: 'transfer' },
@@ -75,14 +72,13 @@ describe('routeToWaypoints', () => {
   });
 
   it('multi-transfer: 마지막 환승역이 곧 목적지면 그 환승역을 destination으로 마킹', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 2 },
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 0,
-    };
+    });
     expect(routeToWaypoints(route, '교대')).toEqual([
       { stationName: '신도림', line: '1', kind: 'transfer' },
       { stationName: '교대', line: '2', kind: 'destination' },
@@ -93,7 +89,7 @@ describe('routeToWaypoints', () => {
   // 같은 역이므로 destination 단일화로 축약되어야 한다 (== 비교는 거짓 → 분리되는 회귀 방지).
   it('transfer: transferName과 destinationName의 노선별 표기가 달라도 같은 역으로 축약', () => {
     const result = routeToWaypoints(
-      { type: 'transfer', transferName: '상봉', fromLine: '7', toLine: 'gyeongui', stopsToTransfer: 3, stopsFromTransfer: 0 },
+      makeTransferRoute({ transferName: '상봉', fromLine: '7', toLine: 'gyeongui', stopsToTransfer: 3, stopsFromTransfer: 0 }),
       '상봉(시외버스터미널)',
     );
     expect(result).toHaveLength(1);
@@ -114,7 +110,7 @@ describe('routeToWaypoints', () => {
       {
         name: 'direct: 출발→도착 사이 중간역을 intermediate로 포함',
         // 1-001(소요산) → 1-005(지행): 사이에 동두천/보산/동두천중앙
-        route: { type: 'direct', stops: 4, line: '1' } satisfies DirectRoute,
+        route: makeDirectRoute(4, '1'),
         destinationName: '지행',
         origin: { line: '1', id: '1-001' },
         expected: [
@@ -127,14 +123,13 @@ describe('routeToWaypoints', () => {
       {
         name: 'transfer: 환승 전/후 중간역을 모두 펼친다',
         // 1-038(대방) → 신도림(1↔2 환승) → 2-035(문래)
-        route: {
-          type: 'transfer',
+        route: makeTransferRoute({
           transferName: '신도림',
           fromLine: '1',
           toLine: '2',
           stopsToTransfer: 3,
           stopsFromTransfer: 1,
-        } satisfies TransferRoute,
+        }),
         destinationName: '문래',
         origin: { line: '1', id: '1-038' },
         expected: [
@@ -146,14 +141,13 @@ describe('routeToWaypoints', () => {
       },
       {
         name: 'transfer 환승역=목적지: 출발→환승 중간역만 펼치고 destination 1개로 축약',
-        route: {
-          type: 'transfer',
+        route: makeTransferRoute({
           transferName: '신도림',
           fromLine: '1',
           toLine: '2',
           stopsToTransfer: 3,
           stopsFromTransfer: 0,
-        } satisfies TransferRoute,
+        }),
         destinationName: '신도림',
         origin: { line: '1', id: '1-038' },
         expected: [
@@ -164,7 +158,7 @@ describe('routeToWaypoints', () => {
       },
       {
         name: 'currentStation의 line이 route와 안 맞으면 intermediates 펼침 없이 기존 동작',
-        route: { type: 'direct', stops: 5, line: '2' } satisfies DirectRoute,
+        route: makeDirectRoute(5, '2'),
         destinationName: '강남',
         origin: { line: '1', id: '1-001' },
         expected: [wp('강남', '2', 'destination')],
@@ -178,14 +172,13 @@ describe('routeToWaypoints', () => {
 
     it('multi-transfer: 각 segment 사이의 중간역을 모두 펼친다', () => {
       // origin=1-039(신길) → 신도림(1→2) → 교대 (마지막 환승이 목적지)
-      const route: MultiTransferRoute = {
-        type: 'multi-transfer',
+      const route = makeMultiTransferRoute({
         transfers: [
           { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 2 },
           { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 11 },
         ],
         stopsAfterLastTransfer: 0,
-      };
+      });
       const result = routeToWaypoints(route, '교대', stationById('1', '1-039'));
       // 1호선 pre intermediates [영등포] + transfer 신도림 + ... + destination 교대
       expect(result[0]).toEqual(wp('영등포', '1', 'intermediate'));
@@ -195,14 +188,13 @@ describe('routeToWaypoints', () => {
     });
 
     it('currentStation=null은 기존 동작과 동일 (하위 호환)', () => {
-      const route: TransferRoute = {
-        type: 'transfer',
+      const route = makeTransferRoute({
         transferName: '신도림',
         fromLine: '1',
         toLine: '2',
         stopsToTransfer: 3,
         stopsFromTransfer: 4,
-      };
+      });
       expect(routeToWaypoints(route, '강남', null)).toEqual(routeToWaypoints(route, '강남'));
     });
   });

--- a/src/utils/__tests__/stationAlarm.test.ts
+++ b/src/utils/__tests__/stationAlarm.test.ts
@@ -1,6 +1,11 @@
 import { alarmKey, evaluateAlarmPhase, resolveAllTargets, type AlarmEvent, type AlarmSource } from '../stationAlarm';
-import type { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
+import type { TransferRoute, MultiTransferRoute } from '../stationRoute';
 import type { LineNumber } from '../../types/station';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute as makeMultiTransferRouteFixture,
+  makeTransferRoute as makeTransferRouteFixture,
+} from '../../testUtils/routeFixtures';
 
 function makeTransferRoute(
   stopsToTransfer: number,
@@ -9,7 +14,13 @@ function makeTransferRoute(
   fromLine: LineNumber = '1',
   toLine: LineNumber = '2',
 ): TransferRoute {
-  return { type: 'transfer', transferName, fromLine, toLine, stopsToTransfer, stopsFromTransfer };
+  return makeTransferRouteFixture({
+    transferName,
+    fromLine,
+    toLine,
+    stopsToTransfer,
+    stopsFromTransfer,
+  });
 }
 
 function makeMultiRoute(
@@ -19,14 +30,13 @@ function makeMultiRoute(
   t1Name = '시청',
   t2Name = '충무로',
 ): MultiTransferRoute {
-  return {
-    type: 'multi-transfer',
+  return makeMultiTransferRouteFixture({
     transfers: [
       { transferName: t1Name, fromLine: '1', toLine: '3', stopsToTransfer: stops1 },
       { transferName: t2Name, fromLine: '3', toLine: '4', stopsToTransfer: stops2 },
     ],
     stopsAfterLastTransfer: stopsAfter,
-  };
+  });
 }
 
 function defaultCurrentLine(route: AlarmSource['route']): LineNumber | null {
@@ -57,7 +67,7 @@ describe('alarmKey', () => {
 
 describe('resolveAllTargets', () => {
   it('returns single destination for DirectRoute', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const route = makeDirectRoute(5, '2');
     expect(resolveAllTargets(route, '강남')).toEqual([
       { name: '강남', stops: 5, alarmType: 'destination', approachLine: '2' },
     ]);
@@ -125,7 +135,7 @@ describe('evaluateAlarmPhase', () => {
 
   describe('DirectRoute — early phase', () => {
     it('fires early at stops === 1', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toEqual({
         phaseId: 'early',
         type: 'destination',
@@ -134,12 +144,12 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('does not fire when stops > 1', () => {
-      const route: DirectRoute = { type: 'direct', stops: 2, line: '2' };
+      const route = makeDirectRoute(2, '2');
       expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toBeNull();
     });
 
     it('skips early when already fired', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       const fired = new Set(['early:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName }), fired)).toBeNull();
     });
@@ -147,7 +157,7 @@ describe('evaluateAlarmPhase', () => {
 
   describe('DirectRoute — imminent phase', () => {
     it('fires imminent after early when eta within 10s', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       const fired = new Set(['early:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 8 }), fired)).toEqual({
         phaseId: 'imminent',
@@ -157,13 +167,13 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('does not fire imminent when eta exceeds 10s', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       const fired = new Set(['early:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 30 }), fired)).toBeNull();
     });
 
     it('prefers early over imminent when both qualify and neither fired', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 5 }), new Set())).toEqual({
         phaseId: 'early',
         type: 'destination',
@@ -172,13 +182,13 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('skips imminent when already fired', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       const fired = new Set(['early:강남', 'imminent:강남']);
       expect(evaluateAlarmPhase(source({ route, destinationName, etaSeconds: 5 }), fired)).toBeNull();
     });
 
     it('does not fire imminent at stops 0 if remainingStops gate fails — gate allows 0 so it does fire', () => {
-      const route: DirectRoute = { type: 'direct', stops: 0, line: '2' };
+      const route = makeDirectRoute(0, '2');
       expect(evaluateAlarmPhase(source({ route, destinationName }), new Set())).toEqual({
         phaseId: 'early',
         type: 'destination',
@@ -353,7 +363,7 @@ describe('evaluateAlarmPhase', () => {
 
   describe('suppressedOut out-param (#580)', () => {
     it('phase 조건은 만족했지만 firedAlarms로 dedup된 이벤트를 suppressedOut에 push', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       const fired = new Set(['early:강남']);
       const suppressed: AlarmEvent[] = [];
       const event = evaluateAlarmPhase(
@@ -370,7 +380,7 @@ describe('evaluateAlarmPhase', () => {
 
     it('phase 조건 미충족이면 dedup이어도 suppressedOut에 적재하지 않음 (노이즈 제거)', () => {
       // stops=2 → early(stops<=1) 미충족. firedAlarms에 있어도 phase가 조건 미만이라 적재 안 함.
-      const route: DirectRoute = { type: 'direct', stops: 2, line: '2' };
+      const route = makeDirectRoute(2, '2');
       const fired = new Set(['early:강남']);
       const suppressed: AlarmEvent[] = [];
       evaluateAlarmPhase(source({ route, destinationName: '강남' }), fired, undefined, suppressed);
@@ -378,7 +388,7 @@ describe('evaluateAlarmPhase', () => {
     });
 
     it('suppressedOut 미전달 시 dedup은 silent (이전 동작)', () => {
-      const route: DirectRoute = { type: 'direct', stops: 1, line: '2' };
+      const route = makeDirectRoute(1, '2');
       const fired = new Set(['early:강남']);
       // suppressedOut 인자 생략 — 예외 없이 null 반환.
       expect(evaluateAlarmPhase(source({ route, destinationName: '강남' }), fired)).toBeNull();
@@ -387,7 +397,7 @@ describe('evaluateAlarmPhase', () => {
 
   describe('custom phases', () => {
     it('accepts a custom phase array', () => {
-      const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+      const route = makeDirectRoute(3, '2');
       const customPhases = [
         {
           id: 'early' as const,

--- a/src/utils/__tests__/stationNotification.test.ts
+++ b/src/utils/__tests__/stationNotification.test.ts
@@ -11,7 +11,11 @@ import {
   buildAlarmContent,
 } from '../stationNotification';
 import { Station } from '../../types/station';
-import { DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 jest.mock('expo-notifications');
 jest.mock('../logger', () => ({
@@ -90,23 +94,21 @@ const mockDestination: Station = {
   lng: 127.0163,
 };
 
-const directRoute: DirectRoute = { type: 'direct', stops: 4, line: '1' };
-const transferRoute: TransferRoute = {
-  type: 'transfer',
+const directRoute = makeDirectRoute(4, '1');
+const transferRoute = makeTransferRoute({
   transferName: '동대문',
   fromLine: '1',
   toLine: '4',
   stopsToTransfer: 3,
   stopsFromTransfer: 2,
-};
-const multiTransferRoute: MultiTransferRoute = {
-  type: 'multi-transfer',
+});
+const multiTransferRoute = makeMultiTransferRoute({
   transfers: [
     { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
     { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
   ],
   stopsAfterLastTransfer: 4,
-};
+});
 
 function expectNotificationContent(title: string, body: string) {
   expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -1,5 +1,10 @@
 import type { Station, NearestStationResult } from '../../types/station';
-import type { Route, DirectRoute, TransferRoute, MultiTransferRoute } from '../stationRoute';
+import type { Route, DirectRoute } from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 import type { AlarmEvent } from '../stationAlarm';
 
 const mockFindNearestStation = jest.fn();
@@ -89,7 +94,7 @@ const mockNearestResult: NearestStationResult = {
   distanceKm: 0.15,
 };
 
-const mockRoute: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+const mockRoute = makeDirectRoute(3, '2');
 const mockAlarmEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '시청' };
 
 function call(overrides: Partial<Parameters<typeof processLocationUpdate>[0]> = {}) {
@@ -263,7 +268,7 @@ describe('processLocationUpdate', () => {
   });
 
   it('falls back to findRoute when storedRoute exists but updateRouteFromPosition returns null', async () => {
-    const storedRoute: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const storedRoute = makeDirectRoute(5, '2');
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockUpdateRouteFromPosition.mockReturnValue(null);
     mockFindRoute.mockReturnValue(mockRoute);
@@ -275,8 +280,8 @@ describe('processLocationUpdate', () => {
   });
 
   it('uses updateRouteFromPosition result when storedRoute is provided and succeeds', async () => {
-    const storedRoute: DirectRoute = { type: 'direct', stops: 5, line: '2' };
-    const updatedRoute: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const storedRoute = makeDirectRoute(5, '2');
+    const updatedRoute = makeDirectRoute(3, '2');
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockUpdateRouteFromPosition.mockReturnValue(updatedRoute);
     mockCalculateStaticETA.mockReturnValue(6);
@@ -596,7 +601,7 @@ describe('resolveNextTarget', () => {
   });
 
   it('returns destination and stops for direct route', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const route = makeDirectRoute(5, '2');
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
       stopsToNextStation: 5,
@@ -606,10 +611,10 @@ describe('resolveNextTarget', () => {
   });
 
   it('returns transfer station for transfer route with stopsToTransfer > 0', () => {
-    const route: TransferRoute = {
-      type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
+    const route = makeTransferRoute({
+      transferName: '동대문', fromLine: '1', toLine: '4',
       stopsToTransfer: 3, stopsFromTransfer: 2,
-    };
+    });
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '동대문',
       stopsToNextStation: 3,
@@ -619,10 +624,10 @@ describe('resolveNextTarget', () => {
   });
 
   it('returns destination for transfer route with stopsToTransfer = 0', () => {
-    const route: TransferRoute = {
-      type: 'transfer', transferName: '동대문', fromLine: '1', toLine: '4',
+    const route = makeTransferRoute({
+      transferName: '동대문', fromLine: '1', toLine: '4',
       stopsToTransfer: 0, stopsFromTransfer: 2,
-    };
+    });
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
       stopsToNextStation: 2,
@@ -632,14 +637,13 @@ describe('resolveNextTarget', () => {
   });
 
   it('returns first transfer for multi-transfer route with stopsToTransfer > 0', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '잠실',
       stopsToNextStation: 3,
@@ -649,14 +653,13 @@ describe('resolveNextTarget', () => {
   });
 
   it('returns second transfer when first has stopsToTransfer = 0', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 0 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '시청',
       stopsToNextStation: 5,
@@ -671,14 +674,13 @@ describe('resolveNextTarget', () => {
   });
 
   it('returns destination when all transfers have stopsToTransfer = 0', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 0 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 0 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     expect(resolveNextTarget(route, '강남')).toEqual({
       nextStationName: '강남',
       stopsToNextStation: 4,
@@ -689,10 +691,10 @@ describe('resolveNextTarget', () => {
 
   it('회귀(#214): 환승 전 구간에서 stopsToDestination은 환승 후 구간을 포함한 총합이다', () => {
     // 용마산 → 군자(환승) → 이대 시나리오: 환승까지 2정거장, 환승 후 9정거장 → 총 11
-    const route: TransferRoute = {
-      type: 'transfer', transferName: '군자', fromLine: '7', toLine: '5',
+    const route = makeTransferRoute({
+      transferName: '군자', fromLine: '7', toLine: '5',
       stopsToTransfer: 2, stopsFromTransfer: 9,
-    };
+    });
     expect(resolveNextTarget(route, '이대')).toEqual({
       nextStationName: '군자',
       stopsToNextStation: 2,

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -1,6 +1,11 @@
 import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 describe('getStationsOnLine', () => {
   it('returns only stations on the given line, sorted by id', () => {
@@ -253,7 +258,7 @@ describe('buildJourneyDisplay', () => {
   });
 
   it('DirectRoute이면 세그먼트 1개를 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route: DirectRoute = makeDirectRoute(3, '2');
     const current = mockStation({ id: '2-022', name: '강남' });
     const dest = mockStation({ id: '2-025', name: '잠실' });
 
@@ -272,7 +277,7 @@ describe('buildJourneyDisplay', () => {
     // 시나리오: 건대입구(2/7 환승)에서 GPS가 2호선 entry를 current로 잡았으나
     // findRouteCandidatesByCategory 결과는 7호선 direct(같은 line) 경로가 우승.
     // 이전 버그: 표시가 current.line='2'를 그대로 사용해 "2호선 직통"으로 잘못 표기.
-    const route: DirectRoute = { type: 'direct', stops: 4, line: '7' };
+    const route: DirectRoute = makeDirectRoute(4, '7');
     const current = mockStation({ id: '2-012', name: '건대입구', line: '2', lineColor: '#009D3E' });
     const dest = mockStation({ id: '7-015', name: '용마산', line: '7', lineColor: '#747F00' });
 
@@ -283,7 +288,7 @@ describe('buildJourneyDisplay', () => {
 
   it('DirectRoute에서 LINE_COLORS에 없는 line이면 current.lineColor로 fallback', () => {
     const unknownLine = 'unknown-line' as unknown as LineNumber;
-    const route: DirectRoute = { type: 'direct', stops: 2, line: unknownLine };
+    const route: DirectRoute = makeDirectRoute(2, unknownLine);
     const current = mockStation({ name: 'A', line: unknownLine, lineColor: '#ABCDEF' });
     const dest = mockStation({ name: 'B', line: unknownLine });
 
@@ -292,14 +297,13 @@ describe('buildJourneyDisplay', () => {
   });
 
   it('MultiTransferRoute이면 세그먼트 3개를 반환한다', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     const current = mockStation({ name: '암사', line: '8', lineColor: '#E6186C' });
     const dest = mockStation({ name: '종각', line: '1', lineColor: '#0052A4' });
 
@@ -326,14 +330,13 @@ describe('buildJourneyDisplay', () => {
   });
 
   it('TransferRoute이면 세그먼트 2개를 반환한다', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route: TransferRoute = makeTransferRoute({
       transferName: '교대',
       fromLine: '2',
       toLine: '3',
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
-    };
+    });
     const current = mockStation({ name: '강남', line: '2', lineColor: '#009D3E' });
     const dest = mockStation({ name: '경복궁', line: '3', lineColor: '#EF7C1C' });
 
@@ -357,33 +360,31 @@ describe('buildJourneyDisplay', () => {
 
 describe('calculateETA', () => {
   it('DirectRoute일 때 대기시간 + 정거장*2분을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const route: DirectRoute = makeDirectRoute(5, '2');
     // 3분 대기 + 5*2분 = 13분
     expect(calculateETA(3, route)).toBe(13);
   });
 
   it('TransferRoute일 때 대기시간 + 정거장*2분 + 실측 환승시간을 반환한다', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route: TransferRoute = makeTransferRoute({
       transferName: '교대',
       fromLine: '2',
       toLine: '3',
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
-    };
+    });
     // 2분 대기 + 6*2분 + 교대(2↔3) 환승 63초 → round(13.05)=13분 → 총 15분
     expect(calculateETA(2, route)).toBe(15);
   });
 
   it('MultiTransferRoute일 때 환승별 실측 시간 합산을 반환한다', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     // 2분 대기 + 12*2분 + (잠실 158초 + 시청 84초) → round(28.0333)=28분 → 총 30분
     expect(calculateETA(2, route)).toBe(30);
   });
@@ -395,33 +396,31 @@ describe('calculateETA', () => {
 
 describe('calculateStaticETA', () => {
   it('DirectRoute일 때 기본대기3분 + 정거장*2분을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const route: DirectRoute = makeDirectRoute(5, '2');
     // 3분 대기 + 5*2분 = 13분
     expect(calculateStaticETA(route)).toBe(13);
   });
 
   it('TransferRoute일 때 기본대기3분 + 정거장*2분 + 실측 환승시간을 반환한다', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route: TransferRoute = makeTransferRoute({
       transferName: '교대',
       fromLine: '2',
       toLine: '3',
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
-    };
+    });
     // 3분 대기 + round(12 + 63/60) = 3 + 13 = 16분
     expect(calculateStaticETA(route)).toBe(16);
   });
 
   it('MultiTransferRoute일 때 기본대기3분 + 환승별 실측 시간 합산을 반환한다', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     // 3분 대기 + round(24 + 242/60) = 3 + 28 = 31분
     expect(calculateStaticETA(route)).toBe(31);
   });
@@ -435,37 +434,36 @@ describe('환승역별 실측 환승시간 반영', () => {
   // CSV 출처: 공공데이터포털 15044419 (보행속도 1.2 m/s 기준)
   // 교대(2↔3) 63초 vs 잠실(8↔2) 158초 — 같은 stops여도 travelMinutes 차이 발생
   it('동일 stops·다른 환승역이면 환승시간 차이가 travelMinutes에 반영된다', () => {
-    const fast: TransferRoute = {
-      type: 'transfer', transferName: '교대', fromLine: '2', toLine: '3',
+    const fast: TransferRoute = makeTransferRoute({
+      transferName: '교대', fromLine: '2', toLine: '3',
       stopsToTransfer: 2, stopsFromTransfer: 2,
-    };
-    const slow: TransferRoute = {
-      type: 'transfer', transferName: '잠실', fromLine: '8', toLine: '2',
+    });
+    const slow: TransferRoute = makeTransferRoute({
+      transferName: '잠실', fromLine: '8', toLine: '2',
       stopsToTransfer: 2, stopsFromTransfer: 2,
-    };
+    });
     // 둘 다 4 stops 동일. 교대 63초 round(9.05)=9, 잠실 158초 round(10.6333)=11. 차이 2분.
     expect(calculateETA(0, slow) - calculateETA(0, fast)).toBe(2);
   });
 
   it('테이블 미등록 환승역은 fallback 180초(3분)를 적용한다', () => {
     // CSV에 없는 가상의 환승역명. 정규화 후에도 매칭 실패해야 fallback이 적용된다.
-    const route: TransferRoute = {
-      type: 'transfer', transferName: '존재하지않는환승역', fromLine: '2', toLine: '3',
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '존재하지않는환승역', fromLine: '2', toLine: '3',
       stopsToTransfer: 1, stopsFromTransfer: 4,
-    };
+    });
     // 0분 대기 + round(5*2 + 180/60) = 13분
     expect(calculateETA(0, route)).toBe(13);
   });
 
   it('multi-transfer는 환승역별 실측 시간을 누적 합산한다', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 1 },
         { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
       ],
       stopsAfterLastTransfer: 3,
-    };
+    });
     // 3분 대기 + round((1+2+3)*2 + (63+133)/60) = 3 + round(15.2667) = 3 + 15 = 18분
     expect(calculateStaticETA(route)).toBe(18);
   });
@@ -495,72 +493,67 @@ describe('calculateRemainingLegETA', () => {
   });
 
   it('DirectRoute는 환승이 없어 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const route: DirectRoute = makeDirectRoute(5, '2');
     expect(calculateRemainingLegETA(route, 0)).toBeNull();
   });
 
   it('TransferRoute completedTransferIdx=0: 잔여 ride만 (stopsFromTransfer*2, wait 미포함)', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route: TransferRoute = makeTransferRoute({
       transferName: '교대',
       fromLine: '2',
       toLine: '3',
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
-    };
+    });
     // 5*2 = 10 (DEFAULT_WAIT 미포함 — 탭 시점부터의 ride time)
     expect(calculateRemainingLegETA(route, 0)).toBe(10);
   });
 
   it('TransferRoute에서 completedTransferIdx가 범위 밖이면 null', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route: TransferRoute = makeTransferRoute({
       transferName: '교대',
       fromLine: '2',
       toLine: '3',
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
-    };
+    });
     expect(calculateRemainingLegETA(route, 1)).toBeNull();
     expect(calculateRemainingLegETA(route, -1)).toBeNull();
   });
 
   it('MultiTransferRoute 첫 환승 직후(idx=0): 잔여 시청 환승 + 잔여 stops', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     // round((5+4)*2 + 시청 84초/60) = round(19.4) = 19
     expect(calculateRemainingLegETA(route, 0)).toBe(19);
   });
 
   it('MultiTransferRoute 마지막 환승 직후: 환승 0회 + stopsAfterLastTransfer만', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     // 4*2 = 8
     expect(calculateRemainingLegETA(route, 1)).toBe(8);
   });
 
   it('MultiTransferRoute 환승 3회 중 첫 환승 직후: 잔여 환승 2회 산식 검증', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
         { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
       ],
       stopsAfterLastTransfer: 6,
-    };
+    });
     // round((5+2+6)*2 + (시청 84초 + 서울역 133초)/60) = round(29.6167) = 30
     expect(calculateRemainingLegETA(route, 0)).toBe(30);
     // 두 번째 환승 직후: round((2+6)*2 + 서울역 133초/60) = round(18.2167) = 18
@@ -568,14 +561,13 @@ describe('calculateRemainingLegETA', () => {
   });
 
   it('MultiTransferRoute에서 범위 밖 인덱스는 null', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     expect(calculateRemainingLegETA(route, -1)).toBeNull();
     expect(calculateRemainingLegETA(route, 2)).toBeNull();
   });
@@ -589,39 +581,37 @@ describe('routeSignature', () => {
   });
 
   it('DirectRoute의 내용이 같으면 같은 signature를 반환한다 (reference 무관)', () => {
-    const a: DirectRoute = { type: 'direct', stops: 5, line: '2' };
-    const b: DirectRoute = { type: 'direct', stops: 5, line: '2' };
+    const a: DirectRoute = makeDirectRoute(5, '2');
+    const b: DirectRoute = makeDirectRoute(5, '2');
     expect(routeSignature(a)).toBe(routeSignature(b));
     expect(routeSignature(a)).toBe(['d', '2', 5].join(SEP));
   });
 
   it('DirectRoute의 stops가 다르면 다른 signature를 반환한다', () => {
-    const a: DirectRoute = { type: 'direct', stops: 5, line: '2' };
-    const b: DirectRoute = { type: 'direct', stops: 6, line: '2' };
+    const a: DirectRoute = makeDirectRoute(5, '2');
+    const b: DirectRoute = makeDirectRoute(6, '2');
     expect(routeSignature(a)).not.toBe(routeSignature(b));
   });
 
   it('TransferRoute는 transferName/노선/정거장수를 모두 반영한다', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route: TransferRoute = makeTransferRoute({
       transferName: '교대',
       fromLine: '2',
       toLine: '3',
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
-    };
+    });
     expect(routeSignature(route)).toBe(['t', '2', '3', '교대', 1, 5].join(SEP));
   });
 
   it('MultiTransferRoute는 모든 환승 segment + 마지막 정거장수를 반영한다', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
       ],
       stopsAfterLastTransfer: 4,
-    };
+    });
     const segs = ['8', '2', '잠실', 3].join(SEP) + SEP + ['2', '1', '시청', 5].join(SEP);
     expect(routeSignature(route)).toBe(['m', segs, 4].join(SEP));
   });
@@ -629,14 +619,13 @@ describe('routeSignature', () => {
 
 describe('buildJourneyDisplay — LINE_COLORS fallback', () => {
   it('알 수 없는 노선이면 station의 lineColor를 사용한다', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route: TransferRoute = makeTransferRoute({
       transferName: '환승역',
       fromLine: 'unknown1' as unknown as LineNumber,
       toLine: 'unknown2' as unknown as LineNumber,
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
-    };
+    });
     const current = mockStation({ lineColor: '#AAA' });
     const dest = mockStation({ lineColor: '#BBB' });
 
@@ -646,14 +635,13 @@ describe('buildJourneyDisplay — LINE_COLORS fallback', () => {
   });
 
   it('MultiTransferRoute에서 알 수 없는 노선이면 fallback lineColor를 사용한다', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '환승A', fromLine: 'unknown1' as unknown as LineNumber, toLine: 'unknown2' as unknown as LineNumber, stopsToTransfer: 1 },
         { transferName: '환승B', fromLine: 'unknown2' as unknown as LineNumber, toLine: 'unknown3' as unknown as LineNumber, stopsToTransfer: 2 },
       ],
       stopsAfterLastTransfer: 3,
-    };
+    });
     const current = mockStation({ lineColor: '#AAA' });
     const dest = mockStation({ lineColor: '#BBB' });
 
@@ -670,19 +658,19 @@ describe('getNextStationName', () => {
   });
 
   it('currentId가 유효하지 않으면 null을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
+    const route: DirectRoute = makeDirectRoute(2, '1');
     expect(getNextStationName('invalid-id', '1-003', route)).toBeNull();
   });
 
   it('destinationId가 유효하지 않으면 null을 반환한다', () => {
-    const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
+    const route: DirectRoute = makeDirectRoute(2, '1');
     expect(getNextStationName('1-001', 'invalid-id', route)).toBeNull();
   });
 
   describe('DirectRoute', () => {
     it('정방향으로 다음 역을 반환한다', () => {
       // 1호선: 소요산(1-001) → 보산(1-003), 중간에 동두천(1-002)
-      const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
+      const route: DirectRoute = makeDirectRoute(2, '1');
       const next = getNextStationName('1-001', '1-003', route);
       // 소요산 다음 역 (1-002)의 이름
       const line1 = getStationsOnLine('1');
@@ -692,7 +680,7 @@ describe('getNextStationName', () => {
 
     it('역방향으로 다음 역을 반환한다', () => {
       // 1호선: 보산(1-003) → 소요산(1-001)
-      const route: DirectRoute = { type: 'direct', stops: 2, line: '1' };
+      const route: DirectRoute = makeDirectRoute(2, '1');
       const next = getNextStationName('1-003', '1-001', route);
       const line1 = getStationsOnLine('1');
       const bosan = line1.findIndex((s) => s.id === '1-003');
@@ -700,7 +688,7 @@ describe('getNextStationName', () => {
     });
 
     it('같은 역이면 null을 반환한다 (currentIdx === targetIdx)', () => {
-      const route: DirectRoute = { type: 'direct', stops: 0, line: '1' };
+      const route: DirectRoute = makeDirectRoute(0, '1');
       expect(getNextStationName('1-001', '1-001', route)).toBeNull();
     });
 
@@ -710,14 +698,13 @@ describe('getNextStationName', () => {
     it('환승역 이름이 노선에 없으면 null을 반환한다 (targetIdx undefined)', () => {
       const line1 = getStationsOnLine('1');
       const line2 = getStationsOnLine('2');
-      const route: TransferRoute = {
-        type: 'transfer',
+      const route: TransferRoute = makeTransferRoute({
         transferName: '존재하지않는역',
         fromLine: '1',
         toLine: '2',
         stopsToTransfer: 1,
         stopsFromTransfer: 1,
-      };
+      });
       expect(getNextStationName(line1[0].id, line2[0].id, route)).toBeNull();
     });
 
@@ -729,14 +716,13 @@ describe('getNextStationName', () => {
       const gyodae3 = line3.find((s) => s.name === '교대')!;
       const destStation = line3[line3.indexOf(gyodae3) + 1];
 
-      const route: TransferRoute = {
-        type: 'transfer',
+      const route: TransferRoute = makeTransferRoute({
         transferName: '교대',
         fromLine: '2',
         toLine: '3',
         stopsToTransfer: 1,
         stopsFromTransfer: 1,
-      };
+      });
       const next = getNextStationName(gangnam.id, destStation.id, route);
       expect(next).toBe('교대');
     });
@@ -748,14 +734,13 @@ describe('getNextStationName', () => {
       const gyodaeIdx = line3.indexOf(gyodae3);
       const destStation = line3[gyodaeIdx + 2]; // 교대에서 2칸 뒤
 
-      const route: TransferRoute = {
-        type: 'transfer',
+      const route: TransferRoute = makeTransferRoute({
         transferName: '교대',
         fromLine: '2',
         toLine: '3',
         stopsToTransfer: 0,
         stopsFromTransfer: 2,
-      };
+      });
       const next = getNextStationName(gyodae3.id, destStation.id, route);
       expect(next).toBe(line3[gyodaeIdx + 1].name);
     });
@@ -787,12 +772,11 @@ describe('getNextStationName', () => {
         const [t1, t2] = realRoute.transfers;
         // 첫 번째 환승역에 있는 상태로 가공
         const modifiedRoute: MultiTransferRoute = {
-          type: 'multi-transfer',
+          ...realRoute,
           transfers: [
             { ...t1, stopsToTransfer: 0 },
             t2,
           ],
-          stopsAfterLastTransfer: realRoute.stopsAfterLastTransfer,
         };
         // 첫 번째 환승역은 t1.toLine(=중간노선)에도 있음
         const midLine = getStationsOnLine(t1.toLine);
@@ -816,12 +800,11 @@ describe('getNextStationName', () => {
       if (realRoute?.type === 'multi-transfer') {
         const [t1, t2] = realRoute.transfers;
         const modifiedRoute: MultiTransferRoute = {
-          type: 'multi-transfer',
+          ...realRoute,
           transfers: [
             { ...t1, stopsToTransfer: 0 },
             { ...t2, stopsToTransfer: 0 },
           ],
-          stopsAfterLastTransfer: realRoute.stopsAfterLastTransfer,
         };
         // 두 번째 환승역 위치에서 목적지 방향
         const destLine = getStationsOnLine(t2.toLine);
@@ -870,13 +853,13 @@ describe('findRoutes', () => {
 
 describe('pickRouteByPreference', () => {
   const c1: RouteCandidate = {
-    route: { type: 'direct', stops: 3, line: '2' },
+    route: makeDirectRoute(3, '2'),
     totalStops: 3,
     transferCount: 0,
     travelMinutes: 6,
   };
   const c2: RouteCandidate = {
-    route: { type: 'transfer', transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 2, stopsFromTransfer: 3 },
+    route: makeTransferRoute({ transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 2, stopsFromTransfer: 3 }),
     totalStops: 5,
     transferCount: 1,
     travelMinutes: 13,
@@ -891,8 +874,8 @@ describe('pickRouteByPreference', () => {
   });
 
   it('minTransfer에서 transferCount가 같으면 travelMinutes가 낮은 후보를 반환한다', () => {
-    const fast: RouteCandidate = { route: { type: 'transfer', transferName: 'A', fromLine: '1', toLine: '2', stopsToTransfer: 1, stopsFromTransfer: 2 }, totalStops: 3, transferCount: 1, travelMinutes: 9 };
-    const slow: RouteCandidate = { route: { type: 'transfer', transferName: 'B', fromLine: '1', toLine: '2', stopsToTransfer: 3, stopsFromTransfer: 4 }, totalStops: 7, transferCount: 1, travelMinutes: 17 };
+    const fast: RouteCandidate = { route: makeTransferRoute({ transferName: 'A', fromLine: '1', toLine: '2', stopsToTransfer: 1, stopsFromTransfer: 2 }), totalStops: 3, transferCount: 1, travelMinutes: 9 };
+    const slow: RouteCandidate = { route: makeTransferRoute({ transferName: 'B', fromLine: '1', toLine: '2', stopsToTransfer: 3, stopsFromTransfer: 4 }), totalStops: 7, transferCount: 1, travelMinutes: 17 };
     expect(pickRouteByPreference([slow, fast], 'minTransfer')).toBe(fast);
   });
 
@@ -948,7 +931,7 @@ describe('findRouteCandidatesByCategory', () => {
 
 describe('ROUTE_CATEGORIES comparators', () => {
   const makeCandidate = (transferCount: number, travelMinutes: number): RouteCandidate => ({
-    route: { type: 'direct', stops: Math.max(0, Math.floor(travelMinutes / 2)), line: '2' },
+    route: makeDirectRoute(Math.max(0, Math.floor(travelMinutes / 2)), '2'),
     totalStops: Math.max(0, Math.floor(travelMinutes / 2)),
     transferCount,
     travelMinutes,
@@ -1012,7 +995,7 @@ describe('updateRouteFromPosition', () => {
     it('현재 역에서 목적지까지 남은 정거장 수로 업데이트한다', () => {
       // 1호선: 소요산(1-001) → 보산(1-003): 2 stops
       // 현재 동두천(1-002)에 있으면 보산까지 1 stop
-      const storedRoute: DirectRoute = { type: 'direct', stops: 2, line: '1' };
+      const storedRoute: DirectRoute = makeDirectRoute(2, '1');
       const nearestStation = getStationsOnLine('1').find((s) => s.id === '1-002')!;
       const result = updateRouteFromPosition(storedRoute, nearestStation, '1-003');
       expect(result).not.toBeNull();
@@ -1023,7 +1006,7 @@ describe('updateRouteFromPosition', () => {
     });
 
     it('현재 역과 목적지가 다른 노선이면 null을 반환한다', () => {
-      const storedRoute: DirectRoute = { type: 'direct', stops: 3, line: '1' };
+      const storedRoute: DirectRoute = makeDirectRoute(3, '1');
       // 2호선 강남, 목적지는 1호선 시청
       const gangnam2 = getStationsOnLine('2').find((s) => s.name === '강남')!;
       const result = updateRouteFromPosition(storedRoute, gangnam2, '1-033');
@@ -1031,7 +1014,7 @@ describe('updateRouteFromPosition', () => {
     });
 
     it('같은 노선이지만 nearestStation ID가 유효하지 않으면 null을 반환한다', () => {
-      const storedRoute: DirectRoute = { type: 'direct', stops: 2, line: '1' };
+      const storedRoute: DirectRoute = makeDirectRoute(2, '1');
       const fakeStation = { id: 'invalid-id', name: '가짜역', line: '1' as const, lineColor: '#00288C', lat: 0, lng: 0 };
       const result = updateRouteFromPosition(storedRoute, fakeStation, '1-003');
       expect(result).toBeNull();
@@ -1043,14 +1026,13 @@ describe('updateRouteFromPosition', () => {
     // fromLine: '2', toLine: '3', transferName: '교대'
     // 교대(2호선): 2-023, 교대(3호선): 3-032
     // 목적지: 3호선 양재 3-034
-    const storedTransferRoute: TransferRoute = {
-      type: 'transfer',
+    const storedTransferRoute: TransferRoute = makeTransferRoute({
       transferName: '교대',
       fromLine: '2',
       toLine: '3',
       stopsToTransfer: 1,
       stopsFromTransfer: 2,
-    };
+    });
 
     it('fromLine에 있으면 환승역까지 남은 정거장으로 stopsToTransfer를 업데이트한다', () => {
       // 강남(2-022)에서 교대(2-023)까지 1 stop
@@ -1066,14 +1048,13 @@ describe('updateRouteFromPosition', () => {
     });
 
     it('fromLine에 있지만 transferName이 해당 노선에 존재하지 않으면 null을 반환한다', () => {
-      const invalidRoute: TransferRoute = {
-        type: 'transfer',
+      const invalidRoute: TransferRoute = makeTransferRoute({
         transferName: '존재하지않는환승역',
         fromLine: '2',
         toLine: '3',
         stopsToTransfer: 1,
         stopsFromTransfer: 2,
-      };
+      });
       const gangnam2 = getStationsOnLine('2').find((s) => s.name === '강남')!;
       const result = updateRouteFromPosition(invalidRoute, gangnam2, '3-034');
       expect(result).toBeNull();
@@ -1081,14 +1062,13 @@ describe('updateRouteFromPosition', () => {
 
     it('fromLine에 있고 transferName은 있지만 nearestStation ID가 유효하지 않으면 null을 반환한다', () => {
       // nearestStation의 id가 유효하지 않으면 getRemainingStops가 null을 반환
-      const route: TransferRoute = {
-        type: 'transfer',
+      const route: TransferRoute = makeTransferRoute({
         transferName: '교대',
         fromLine: '2',
         toLine: '3',
         stopsToTransfer: 1,
         stopsFromTransfer: 2,
-      };
+      });
       const fakeStation = { id: 'invalid-id', name: '가짜역', line: '2' as const, lineColor: '#009D3E', lat: 0, lng: 0 };
       const result = updateRouteFromPosition(route, fakeStation, '3-034');
       expect(result).toBeNull();
@@ -1126,14 +1106,13 @@ describe('updateRouteFromPosition', () => {
     // 8호선 → 2호선(잠실) → 1호선
     // t1: 8호선 → 2호선, transferName: '잠실'
     // t2: 2호선 → 1호선, transferName: '시청'
-    const storedMultiRoute: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const storedMultiRoute: MultiTransferRoute = makeMultiTransferRoute({
       transfers: [
         { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 4 },
         { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 10 },
       ],
       stopsAfterLastTransfer: 5,
-    };
+    });
 
     it('t1.fromLine(8호선)에 있으면 t1.stopsToTransfer를 업데이트한다', () => {
       // 8호선 암사(8-001)에서 잠실(8호선 8-005)까지 4 stops
@@ -1148,14 +1127,13 @@ describe('updateRouteFromPosition', () => {
     });
 
     it('t1.fromLine에 있지만 t1.transferName이 해당 노선에 없으면 null을 반환한다', () => {
-      const invalidMultiRoute: MultiTransferRoute = {
-        type: 'multi-transfer',
+      const invalidMultiRoute: MultiTransferRoute = makeMultiTransferRoute({
         transfers: [
           { transferName: '존재하지않는역', fromLine: '8', toLine: '2', stopsToTransfer: 4 },
           { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 10 },
         ],
         stopsAfterLastTransfer: 5,
-      };
+      });
       const amsa8 = getStationsOnLine('8').find((s) => s.id === '8-001')!;
       const result = updateRouteFromPosition(invalidMultiRoute, amsa8, '1-001');
       expect(result).toBeNull();
@@ -1180,14 +1158,13 @@ describe('updateRouteFromPosition', () => {
     });
 
     it('t1.toLine에 있지만 t2.transferName이 해당 노선에 없으면 null을 반환한다', () => {
-      const invalidMultiRoute: MultiTransferRoute = {
-        type: 'multi-transfer',
+      const invalidMultiRoute: MultiTransferRoute = makeMultiTransferRoute({
         transfers: [
           { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 4 },
           { transferName: '존재하지않는역', fromLine: '2', toLine: '1', stopsToTransfer: 10 },
         ],
         stopsAfterLastTransfer: 5,
-      };
+      });
       const jamsil2 = getStationsOnLine('2').find((s) => s.name === '잠실')!;
       const result = updateRouteFromPosition(invalidMultiRoute, jamsil2, '1-001');
       expect(result).toBeNull();
@@ -1238,31 +1215,29 @@ describe('isStationOnRoute', () => {
     lng: 0,
   });
 
-  const transferRoute: TransferRoute = {
-    type: 'transfer',
+  const transferRoute: TransferRoute = makeTransferRoute({
     transferName: '동대문',
     fromLine: '1',
     toLine: '4',
     stopsToTransfer: 3,
     stopsFromTransfer: 2,
-  };
+  });
 
-  const multiTransferRoute: MultiTransferRoute = {
-    type: 'multi-transfer',
+  const multiTransferRoute: MultiTransferRoute = makeMultiTransferRoute({
     transfers: [
       { transferName: '동대문', fromLine: '1', toLine: '4', stopsToTransfer: 2 },
       { transferName: '충무로', fromLine: '4', toLine: '3', stopsToTransfer: 3 },
     ],
     stopsAfterLastTransfer: 5,
-  };
+  });
 
   it('direct route — station.line이 route.line과 일치하면 true', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route: DirectRoute = makeDirectRoute(3, '2');
     expect(isStationOnRoute(makeStation('2'), route)).toBe(true);
   });
 
   it('direct route — station.line이 route.line과 다르면 false (#195 회귀 가드)', () => {
-    const route: DirectRoute = { type: 'direct', stops: 3, line: '2' };
+    const route: DirectRoute = makeDirectRoute(3, '2');
     expect(isStationOnRoute(makeStation('9'), route)).toBe(false);
   });
 

--- a/src/utils/__tests__/tripDirection.test.ts
+++ b/src/utils/__tests__/tripDirection.test.ts
@@ -1,59 +1,57 @@
 import { resolveTripDirection } from '../tripDirection';
-import type {
-  DirectRoute,
-  TransferRoute,
-  MultiTransferRoute,
-} from '../stationRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../testUtils/routeFixtures';
 
 describe('resolveTripDirection', () => {
   it('direct: next waypoint index > current index → "down"', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    const route = makeDirectRoute(5, '1');
     // 소요산(1-001, idx 0) → 서울역(1-034)
     expect(resolveTripDirection(route, '서울역', '1-001')).toBe('down');
   });
 
   it('direct: next waypoint index < current index → "up"', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    const route = makeDirectRoute(5, '1');
     expect(resolveTripDirection(route, '소요산', '1-034')).toBe('up');
   });
 
   it('current가 같은 station이면 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 0, line: '1' };
+    const route = makeDirectRoute(0, '1');
     expect(resolveTripDirection(route, '소요산', '1-001')).toBeNull();
   });
 
   it('current가 다른 노선이면 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    const route = makeDirectRoute(5, '1');
     expect(resolveTripDirection(route, '서울역', '7-015')).toBeNull();
   });
 
   it('next waypoint name이 line에 존재하지 않으면 null', () => {
-    const route: DirectRoute = { type: 'direct', stops: 5, line: '1' };
+    const route = makeDirectRoute(5, '1');
     expect(resolveTripDirection(route, '없는역이름XYZ', '1-001')).toBeNull();
   });
 
   it('transfer: 첫 leg은 fromLine + transferName으로 판정한다', () => {
-    const route: TransferRoute = {
-      type: 'transfer',
+    const route = makeTransferRoute({
       transferName: '서울역',
       fromLine: '1',
       toLine: '4',
       stopsToTransfer: 5,
       stopsFromTransfer: 3,
-    };
+    });
     // 소요산(1-001) → 서울역(1-034) = down
     expect(resolveTripDirection(route, '강남', '1-001')).toBe('down');
   });
 
   it('multi-transfer: transfers[0]의 fromLine + transferName으로 판정한다', () => {
-    const route: MultiTransferRoute = {
-      type: 'multi-transfer',
+    const route = makeMultiTransferRoute({
       transfers: [
         { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 5 },
         { transferName: '명동', fromLine: '4', toLine: '2', stopsToTransfer: 3 },
       ],
       stopsAfterLastTransfer: 2,
-    };
+    });
     expect(resolveTripDirection(route, '강남', '1-001')).toBe('down');
   });
 });

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -83,12 +83,8 @@ export interface DirectRoute {
   type: 'direct';
   stops: number;
   line: LineNumber;
-  /**
-   * #655: 실측 운행 시간(초). findRoutes/updateRouteFromPosition가 lookup으로 채운다.
-   * 외부에서 stops만 채워 만든 route(테스트 fixture)도 허용 — getTravelMinutes에서
-   * stops × STOP_FALLBACK_SECONDS로 fallback. 후속 정리는 follow-up 이슈에서 required로 승격.
-   */
-  travelSeconds?: number;
+  /** #655: 실측 운행 시간(초). findRoutes/updateRouteFromPosition가 lookup으로 채운다. */
+  travelSeconds: number;
 }
 
 export interface TransferRoute {
@@ -99,9 +95,9 @@ export interface TransferRoute {
   stopsToTransfer: number;
   stopsFromTransfer: number;
   /** #655: 실측 운행 시간(초). 의미는 {@link DirectRoute.travelSeconds} 참고. */
-  secondsToTransfer?: number;
+  secondsToTransfer: number;
   /** #655: 실측 운행 시간(초). 의미는 {@link DirectRoute.travelSeconds} 참고. */
-  secondsFromTransfer?: number;
+  secondsFromTransfer: number;
 }
 
 export interface TransferSegment {
@@ -110,7 +106,7 @@ export interface TransferSegment {
   toLine: LineNumber;
   stopsToTransfer: number;
   /** #655: 실측 운행 시간(초). 의미는 {@link DirectRoute.travelSeconds} 참고. */
-  secondsToTransfer?: number;
+  secondsToTransfer: number;
 }
 
 export interface MultiTransferRoute {
@@ -118,7 +114,7 @@ export interface MultiTransferRoute {
   transfers: TransferSegment[];
   stopsAfterLastTransfer: number;
   /** #655: 실측 운행 시간(초). 의미는 {@link DirectRoute.travelSeconds} 참고. */
-  secondsAfterLastTransfer?: number;
+  secondsAfterLastTransfer: number;
 }
 
 export type Route = DirectRoute | TransferRoute | MultiTransferRoute | null;
@@ -717,30 +713,24 @@ export function buildJourneyDisplay(
 
 const DEFAULT_WAIT_MINUTES = 3;
 
-// secondsXxx가 채워져 있으면 그대로, 없으면 stops × fallback(=120초). #655.
-// optional은 follow-up 이슈에서 required로 승격 예정.
-function segSeconds(seconds: number | undefined, stops: number): number {
-  return seconds ?? stops * STOP_FALLBACK_SECONDS;
-}
-
 // 반환값은 항상 정수 분. 호출처(메인 ETA 카운터/알림 body/Live Activity etaMinutes Swift Int? 디코딩)가
 // 정수 분 contract에 의존하므로, 구간별 실측 운행시간(초)과 환승역별 실측 환승시간(초)을 합산해
-// 분으로 환산한 결과를 마지막에 반올림한다. 구간 시간은 segSeconds, 환승 시간은 getTransferSeconds.
+// 분으로 환산한 결과를 마지막에 반올림한다. 환승 시간은 getTransferSeconds.
 function getTravelMinutes(route: NonNullable<Route>): number {
   if (route.type === 'direct') {
-    return Math.round(segSeconds(route.travelSeconds, route.stops) / 60);
+    return Math.round(route.travelSeconds / 60);
   }
 
   if (route.type === 'transfer') {
     const totalSeconds =
-      segSeconds(route.secondsToTransfer, route.stopsToTransfer) +
-      segSeconds(route.secondsFromTransfer, route.stopsFromTransfer) +
+      route.secondsToTransfer +
+      route.secondsFromTransfer +
       getTransferSeconds(route.fromLine, route.toLine, route.transferName);
     return Math.round(totalSeconds / 60);
   }
 
   const segmentSecondsSum = route.transfers.reduce(
-    (sum, t) => sum + segSeconds(t.secondsToTransfer, t.stopsToTransfer),
+    (sum, t) => sum + t.secondsToTransfer,
     0,
   );
   const transferSecSum = route.transfers.reduce(
@@ -748,9 +738,7 @@ function getTravelMinutes(route: NonNullable<Route>): number {
     0,
   );
   const totalSeconds =
-    segmentSecondsSum +
-    segSeconds(route.secondsAfterLastTransfer, route.stopsAfterLastTransfer) +
-    transferSecSum;
+    segmentSecondsSum + route.secondsAfterLastTransfer + transferSecSum;
   return Math.round(totalSeconds / 60);
 }
 
@@ -807,13 +795,11 @@ function getTransferLegs(
   if (route.type === 'transfer') {
     return {
       transferCount: 1,
-      afterTransferSeconds: [segSeconds(route.secondsFromTransfer, route.stopsFromTransfer)],
+      afterTransferSeconds: [route.secondsFromTransfer],
     };
   }
-  const after = route.transfers
-    .slice(1)
-    .map((t) => segSeconds(t.secondsToTransfer, t.stopsToTransfer));
-  after.push(segSeconds(route.secondsAfterLastTransfer, route.stopsAfterLastTransfer));
+  const after = route.transfers.slice(1).map((t) => t.secondsToTransfer);
+  after.push(route.secondsAfterLastTransfer);
   return { transferCount: route.transfers.length, afterTransferSeconds: after };
 }
 


### PR DESCRIPTION
## Summary

- `Route` 4개 인터페이스(`DirectRoute` / `TransferRoute` / `TransferSegment` / `MultiTransferRoute`)의 `secondsXxx` 필드를 모두 **required**로 승격.
- `segSeconds(seconds, stops) → seconds ?? stops × 120` fallback shim 제거. 모든 호출처가 직접 필드 접근.
- `src/testUtils/routeFixtures.ts` 신규 — `makeDirectRoute` / `makeTransferRoute` / `makeTransferSegment` / `makeMultiTransferRoute`. 내부적으로 `stops × 120`(테스트 평균치)로 seconds 채움.
- 25개 테스트 파일 inline route 객체(약 150개) → helper 호출 일괄 교체.

## 배경

#655에서 fixture 수정 비용 우려로 `secondsXxx`를 optional + fallback shim으로 도입. CLAUDE.md "Don't use feature flags or backwards-compatibility shims when you can just change the code" 위반 → follow-up으로 정리.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm test` 142 suites / 2277 tests pass
- [x] coverage 100% 복귀 (segSeconds dead branch 제거)
- [x] code-review agent P1 0건
- [x] production Route 생성자(`findRoutes` / `updateRouteFromPosition`)가 lookup으로 모두 채우는지 확인

Closes #660