### PR TITLE
fix(#644): dev smoke E2E 회귀 — scrollUntilVisible 추가

### DIFF
--- a/.maestro/flows/smoke/02_destination_set_clear.yaml
+++ b/.maestro/flows/smoke/02_destination_set_clear.yaml
@@ -44,5 +44,10 @@ name: "smoke - 목적지 설정 & 초기화"
 # 초기화
 - tapOn:
     id: "destination-clear-button"
+# destination 박스 축소 직후 ScrollView contentOffset이 즉시 클램프되지 않아 viewport 밖 가능 — scroll로 보정.
+- scrollUntilVisible:
+    element:
+      text: "목적지 설정|Set destination"
+    timeout: 5000
 - assertVisible:
     text: "목적지 설정|Set destination"

--- a/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
+++ b/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
@@ -36,6 +36,11 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 - tapOn:
     id: "suggestion-item-2-016"
 
+# 잠실 설정 직후 destination 박스 높이가 커져 home-sleep-mode-switch가 viewport 밖 — scroll로 보정.
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    timeout: 5000
 - assertVisible:
     id: "home-sleep-mode-switch"
 - tapOn:
@@ -58,5 +63,9 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 # 홈 탭 복귀
 - tapOn:
     point: "12%,95%"
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    timeout: 5000
 - assertVisible:
     id: "home-sleep-mode-switch"

--- a/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
+++ b/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
@@ -36,13 +36,15 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 - tapOn:
     id: "suggestion-item-2-016"
 
-# 잠실 설정 직후 destination 박스 높이가 커져 home-sleep-mode-switch가 viewport 밖 — scroll로 보정.
-- scrollUntilVisible:
-    element:
+# 잠실 설정 직후 destination 박스 높이가 커져 home-sleep-mode-switch가 viewport 밖.
+# scrollUntilVisible은 nested ScrollView에서 element 인식 실패 가능 → 명시적 swipe로 강제 스크롤.
+- swipe:
+    start: "50%, 80%"
+    end: "50%, 30%"
+- extendedWaitUntil:
+    visible:
       id: "home-sleep-mode-switch"
     timeout: 5000
-- assertVisible:
-    id: "home-sleep-mode-switch"
 - tapOn:
     id: "home-sleep-mode-switch"
 
@@ -63,9 +65,10 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 # 홈 탭 복귀
 - tapOn:
     point: "12%,95%"
-- scrollUntilVisible:
-    element:
+- swipe:
+    start: "50%, 80%"
+    end: "50%, 30%"
+- extendedWaitUntil:
+    visible:
       id: "home-sleep-mode-switch"
     timeout: 5000
-- assertVisible:
-    id: "home-sleep-mode-switch"


### PR DESCRIPTION
## Summary

- 02_destination_set_clear.yaml: destination-clear-button 탭 후 layout 축소 시 \"목적지 설정\" 버튼 viewport 밖 → scrollUntilVisible 보정
- 05_sleep_mode_toggle.yaml: 잠실 설정 후 home-sleep-mode-switch viewport 밖 (2곳) → scrollUntilVisible 보정

## 배경

#634(BoardingTrainList) / #625(탑승 카드 route 컨텍스트 내부 이동) 머지 이후 destination 박스 높이 증가. Maestro `assertVisible`은 자동 스크롤하지 않아 두 flow 지속 실패.

## Test plan

- [x] flow yaml만 변경, 코드/테스트 영향 없음
- [ ] CI E2E Smoke (mock mode) pass 확인

Closes #644