### PR TITLE
feat(#613): [#586 E] Widget ContentState 폴백 보강 + backend schema 정렬

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -60,15 +60,47 @@ function makeTrip(overrides: Partial<Trip> = {}): Trip {
 
 const WAYPOINT: Waypoint = { stationName: '강남', line: '2', kind: 'destination' };
 
-describe('buildLiveActivityContentState', () => {
-  it('includes numeric/enum fields only (no text, no phase)', () => {
+describe('buildLiveActivityContentState (#613)', () => {
+  it('emits widget-aligned schema (stationName/lineName/lineColorHex/stopsRemaining/etaMinutes/alarmType)', () => {
     const cs = buildLiveActivityContentState(WAYPOINT, 90, 3, NOW);
     expect(cs).toEqual({
-      etaSeconds: 90,
-      kind: 'destination',
+      stationName: '강남',
+      alarmStationName: '강남',
+      lineName: '2호선',
+      lineColorHex: '#009D3E',
       stopsRemaining: 3,
-      arrivalAtSec: Math.floor(NOW / 1000) + 90,
+      etaMinutes: 2, // round(90/60) = 2
+      alarmType: 'destination',
     });
+  });
+
+  it('rounds etaSeconds to minutes and clamps negative to 0', () => {
+    expect(buildLiveActivityContentState(WAYPOINT, 29, 1, NOW).etaMinutes).toBe(0);
+    expect(buildLiveActivityContentState(WAYPOINT, 30, 1, NOW).etaMinutes).toBe(1);
+    expect(buildLiveActivityContentState(WAYPOINT, -5, 1, NOW).etaMinutes).toBe(0);
+  });
+
+  it('maps known line code to canonical name and color', () => {
+    const wp: Waypoint = { stationName: '서울', line: '1', kind: 'transfer' };
+    const cs = buildLiveActivityContentState(wp, 60, 2, NOW);
+    expect(cs.lineName).toBe('1호선');
+    expect(cs.lineColorHex).toBe('#0052A4');
+    expect(cs.alarmType).toBe('transfer');
+  });
+
+  it('falls back to raw line code and neutral color for unknown line', () => {
+    const wp: Waypoint = { stationName: '미지역', line: 'unknown', kind: 'intermediate' };
+    const cs = buildLiveActivityContentState(wp, 60, 2, NOW);
+    expect(cs.lineName).toBe('unknown');
+    expect(cs.lineColorHex).toBe('#888888');
+  });
+
+  it('does not include phase / etaSeconds / arrivalAtSec (removed in #613)', () => {
+    const cs = buildLiveActivityContentState(WAYPOINT, 90, 3, NOW);
+    expect(cs).not.toHaveProperty('phase');
+    expect(cs).not.toHaveProperty('etaSeconds');
+    expect(cs).not.toHaveProperty('kind');
+    expect(cs).not.toHaveProperty('arrivalAtSec');
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -61,46 +61,45 @@ function makeTrip(overrides: Partial<Trip> = {}): Trip {
 const WAYPOINT: Waypoint = { stationName: '강남', line: '2', kind: 'destination' };
 
 describe('buildLiveActivityContentState (#613)', () => {
-  it('emits widget-aligned schema (stationName/lineName/lineColorHex/stopsRemaining/etaMinutes/alarmType)', () => {
-    const cs = buildLiveActivityContentState(WAYPOINT, 90, 3, NOW);
+  it('emits widget-aligned schema (stationName/lineName/lineColorHex/stopsRemaining/etaMinutes)', () => {
+    const cs = buildLiveActivityContentState(WAYPOINT, 90, 3);
     expect(cs).toEqual({
       stationName: '강남',
-      alarmStationName: '강남',
       lineName: '2호선',
       lineColorHex: '#009D3E',
       stopsRemaining: 3,
       etaMinutes: 2, // round(90/60) = 2
-      alarmType: 'destination',
     });
   });
 
   it('rounds etaSeconds to minutes and clamps negative to 0', () => {
-    expect(buildLiveActivityContentState(WAYPOINT, 29, 1, NOW).etaMinutes).toBe(0);
-    expect(buildLiveActivityContentState(WAYPOINT, 30, 1, NOW).etaMinutes).toBe(1);
-    expect(buildLiveActivityContentState(WAYPOINT, -5, 1, NOW).etaMinutes).toBe(0);
+    expect(buildLiveActivityContentState(WAYPOINT, 29, 1).etaMinutes).toBe(0);
+    expect(buildLiveActivityContentState(WAYPOINT, 30, 1).etaMinutes).toBe(1);
+    expect(buildLiveActivityContentState(WAYPOINT, -5, 1).etaMinutes).toBe(0);
   });
 
   it('maps known line code to canonical name and color', () => {
     const wp: Waypoint = { stationName: '서울', line: '1', kind: 'transfer' };
-    const cs = buildLiveActivityContentState(wp, 60, 2, NOW);
+    const cs = buildLiveActivityContentState(wp, 60, 2);
     expect(cs.lineName).toBe('1호선');
     expect(cs.lineColorHex).toBe('#0052A4');
-    expect(cs.alarmType).toBe('transfer');
   });
 
   it('falls back to raw line code and neutral color for unknown line', () => {
     const wp: Waypoint = { stationName: '미지역', line: 'unknown', kind: 'intermediate' };
-    const cs = buildLiveActivityContentState(wp, 60, 2, NOW);
+    const cs = buildLiveActivityContentState(wp, 60, 2);
     expect(cs.lineName).toBe('unknown');
     expect(cs.lineColorHex).toBe('#888888');
   });
 
-  it('does not include phase / etaSeconds / arrivalAtSec (removed in #613)', () => {
-    const cs = buildLiveActivityContentState(WAYPOINT, 90, 3, NOW);
+  it('does not include phase / etaSeconds / arrivalAtSec / alarmType (omitted to avoid forcing widget urgent UI)', () => {
+    const cs = buildLiveActivityContentState(WAYPOINT, 90, 3);
     expect(cs).not.toHaveProperty('phase');
     expect(cs).not.toHaveProperty('etaSeconds');
     expect(cs).not.toHaveProperty('kind');
     expect(cs).not.toHaveProperty('arrivalAtSec');
+    expect(cs).not.toHaveProperty('alarmType');
+    expect(cs).not.toHaveProperty('alarmStationName');
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -766,19 +766,20 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     const body = parseLaBody(laCalls[0]);
     const contentState = body.aps['content-state'] as Record<string, unknown>;
     expect(body.aps.event).toBe('update');
-    // #613: widget-aligned schema. etaSeconds → etaMinutes, kind → alarmType,
+    // #613: widget-aligned schema. etaSeconds → etaMinutes.
     // stationName/lineName/lineColorHex은 widget non-optional 보장.
+    // alarmType은 omit — widget 긴급 모드(isUrgent)를 polling 정정마다 강제하지 않기 위함.
     expect(contentState.stationName).toBe('강남');
     expect(contentState.lineName).toBe('2호선');
     expect(contentState.lineColorHex).toBe('#009D3E');
-    expect(contentState.alarmType).toBe('destination');
     expect(contentState.stopsRemaining).toBe(1);
     expect(contentState.etaMinutes).toBe(2); // round(120/60) = 2
-    // phase / etaSeconds / kind / arrivalAtSec은 제거됨
+    // phase / etaSeconds / kind / arrivalAtSec / alarmType 모두 제거됨
     expect(contentState.phase).toBeUndefined();
     expect(contentState.etaSeconds).toBeUndefined();
     expect(contentState.kind).toBeUndefined();
     expect(contentState.arrivalAtSec).toBeUndefined();
+    expect(contentState.alarmType).toBeUndefined();
     const stored = JSON.parse((await kv.get('trip:la-tok')) as string) as Trip;
     expect(stored.lastLaPushEpoch).toBe(NOW + 120_000);
   });
@@ -925,9 +926,9 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     const body = parseLaBody(laCalls[0]);
     const contentState = body.aps['content-state'] as Record<string, unknown>;
     expect(body.aps.event).toBe('update');
-    // #613: widget-aligned schema.
+    // #613: widget-aligned schema. alarmType은 omit (긴급 모드 강제 회피).
     expect(contentState.stationName).toBe('강남');
-    expect(contentState.alarmType).toBe('destination');
+    expect(contentState.alarmType).toBeUndefined();
     expect(contentState.stopsRemaining).toBe(1);
     expect(contentState.etaMinutes).toBe(0); // shift 시점은 ETA 0
     // shift 시 lastLaPushEpoch는 reset되어 다음 polling cycle의 첫 estimate가 임계 검사 없이 push되도록 보장.

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -766,11 +766,19 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     const body = parseLaBody(laCalls[0]);
     const contentState = body.aps['content-state'] as Record<string, unknown>;
     expect(body.aps.event).toBe('update');
-    expect(contentState.etaSeconds).toBe(120);
-    expect(contentState.kind).toBe('destination');
+    // #613: widget-aligned schema. etaSeconds → etaMinutes, kind → alarmType,
+    // stationName/lineName/lineColorHex은 widget non-optional 보장.
+    expect(contentState.stationName).toBe('강남');
+    expect(contentState.lineName).toBe('2호선');
+    expect(contentState.lineColorHex).toBe('#009D3E');
+    expect(contentState.alarmType).toBe('destination');
     expect(contentState.stopsRemaining).toBe(1);
-    // phase 필드 비포함
+    expect(contentState.etaMinutes).toBe(2); // round(120/60) = 2
+    // phase / etaSeconds / kind / arrivalAtSec은 제거됨
     expect(contentState.phase).toBeUndefined();
+    expect(contentState.etaSeconds).toBeUndefined();
+    expect(contentState.kind).toBeUndefined();
+    expect(contentState.arrivalAtSec).toBeUndefined();
     const stored = JSON.parse((await kv.get('trip:la-tok')) as string) as Trip;
     expect(stored.lastLaPushEpoch).toBe(NOW + 120_000);
   });
@@ -917,9 +925,11 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     const body = parseLaBody(laCalls[0]);
     const contentState = body.aps['content-state'] as Record<string, unknown>;
     expect(body.aps.event).toBe('update');
-    expect(contentState.kind).toBe('destination');
+    // #613: widget-aligned schema.
+    expect(contentState.stationName).toBe('강남');
+    expect(contentState.alarmType).toBe('destination');
     expect(contentState.stopsRemaining).toBe(1);
-    expect(contentState.etaSeconds).toBe(0);
+    expect(contentState.etaMinutes).toBe(0); // shift 시점은 ETA 0
     // shift 시 lastLaPushEpoch는 reset되어 다음 polling cycle의 첫 estimate가 임계 검사 없이 push되도록 보장.
     const stored = JSON.parse((await kv.get('trip:la-tok')) as string) as Trip;
     expect(stored.lastLaPushEpoch).toBeUndefined();

--- a/backend/alarm-worker/src/lineAlias.ts
+++ b/backend/alarm-worker/src/lineAlias.ts
@@ -2,32 +2,40 @@
  * 클라이언트 line code(stations.json의 `line` 필드) → Seoul API 노선명 매핑.
  *
  * 단일 데이터 소스: `LINE_META`만 유지하고, 모든 헬퍼는 여기서 파생된다.
- * 신규 노선은 이 맵에 한 줄만 추가하면 `canonicalLineName` / `matchLine` 양쪽에 자동 반영.
+ * 신규 노선은 이 맵에 한 줄만 추가하면 `canonicalLineName` / `matchLine` /
+ * Live Activity ContentState(lineName/lineColorHex) 모두 자동 반영.
  *
  * - `canonical`: realtimePosition API의 `subwayLine` URL 파라미터에 들어가는 정식명 ("1호선", "경의중앙선").
- *   "지하철1호선" 접두형은 들어가지 않는다.
+ *   "지하철1호선" 접두형은 들어가지 않는다. Live Activity의 `lineName`도 이 값을 그대로 사용.
  * - `aliases`: realtimeStationArrival 응답의 `subwayNm` 등 다른 형태 — substring 매칭에 사용.
+ * - `color`: Live Activity 위젯 노선 색상 hex (예: "#0052A4"). frontend `src/constants/lineColors.ts`의
+ *   `LINE_COLORS`와 동일 값. 신규 노선 추가 시 양쪽 모두 갱신.
  */
 
 export interface LineMeta {
   canonical: string;
   aliases: readonly string[];
+  color: string;
 }
 
 export const LINE_META: Record<string, LineMeta> = {
-  '1': { canonical: '1호선', aliases: ['지하철1호선'] },
-  '2': { canonical: '2호선', aliases: ['지하철2호선'] },
-  '3': { canonical: '3호선', aliases: ['지하철3호선'] },
-  '4': { canonical: '4호선', aliases: ['지하철4호선'] },
-  '5': { canonical: '5호선', aliases: ['지하철5호선'] },
-  '6': { canonical: '6호선', aliases: ['지하철6호선'] },
-  '7': { canonical: '7호선', aliases: ['지하철7호선'] },
-  '8': { canonical: '8호선', aliases: ['지하철8호선'] },
-  '9': { canonical: '9호선', aliases: ['지하철9호선'] },
-  gyeongui: { canonical: '경의중앙선', aliases: ['지하철경의중앙선', '경의중앙'] },
-  bundang: { canonical: '수인분당선', aliases: ['지하철수인분당선', '분당선', '수인분당'] },
-  sinbundang: { canonical: '신분당선', aliases: ['지하철신분당선'] },
-  airport: { canonical: '공항철도', aliases: ['인천국제공항철도'] },
+  '1': { canonical: '1호선', aliases: ['지하철1호선'], color: '#0052A4' },
+  '2': { canonical: '2호선', aliases: ['지하철2호선'], color: '#009D3E' },
+  '3': { canonical: '3호선', aliases: ['지하철3호선'], color: '#EF7C1C' },
+  '4': { canonical: '4호선', aliases: ['지하철4호선'], color: '#00A2D1' },
+  '5': { canonical: '5호선', aliases: ['지하철5호선'], color: '#996CAC' },
+  '6': { canonical: '6호선', aliases: ['지하철6호선'], color: '#CD7C2F' },
+  '7': { canonical: '7호선', aliases: ['지하철7호선'], color: '#747F00' },
+  '8': { canonical: '8호선', aliases: ['지하철8호선'], color: '#E6186C' },
+  '9': { canonical: '9호선', aliases: ['지하철9호선'], color: '#BDB092' },
+  gyeongui: { canonical: '경의중앙선', aliases: ['지하철경의중앙선', '경의중앙'], color: '#77C4A3' },
+  bundang: {
+    canonical: '수인분당선',
+    aliases: ['지하철수인분당선', '분당선', '수인분당'],
+    color: '#F5A200',
+  },
+  sinbundang: { canonical: '신분당선', aliases: ['지하철신분당선'], color: '#D4003B' },
+  airport: { canonical: '공항철도', aliases: ['인천국제공항철도'], color: '#4B81BF' },
 };
 
 /** realtimePosition URL 파라미터용 정식 노선명. 매핑 없으면 null. */

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -1,17 +1,21 @@
 /**
- * Live Activity push 발사 헬퍼 (#586 D).
+ * Live Activity push 발사 헬퍼 (#586 D / #613).
  *
  * scheduled.ts와 HTTP DELETE handler 양쪽이 공유하는 LA 발사/종료/cleanup 로직.
  * - update: 의미있는 변화 시점에 content-state 갱신
  * - end:    trip 종료(만료/도착/취소) 시 dismissal
  * - 410 BadDeviceToken은 토큰 자체 무효 — trip.activityPushToken을 비우고 state='ended'로 전이
  *
- * content-state는 숫자/enum/epoch만 채운다 — 텍스트(stationName 등)는 디바이스 측 JS init 값 유지
- * (PR E의 widget이 누락 시 raw 필드 폴백). 이는 APNs LA payload 사이즈 절감 + 텍스트 i18n 의존 회피.
+ * content-state schema (#613)는 widget의 `SubwayActivityAttributes.ContentState`에 1:1 정렬.
+ * ActivityKit의 update는 content-state 전체 교체이므로, widget의 non-optional 필드
+ * (stationName, lineName, lineColorHex)는 backend가 반드시 채워야 decode 실패가 없다.
+ * 그 외 텍스트 필드(alarmBody/etaText/distanceText 등)는 비워 두고, widget이 `resolvedXxx`
+ * 폴백 helper로 raw 필드(etaMinutes, distanceM, alarmType 등)에서 derive 한다.
  */
 
 import { sendLiveActivityUpdate, type LiveActivityContentState } from './apns';
 import { pickApnsHost } from './apnsHost';
+import { LINE_META } from './lineAlias';
 import { deleteTrip } from './trips';
 import type { ApnsEnv, Env, Trip, Waypoint } from './types';
 
@@ -37,25 +41,34 @@ export interface LiveActivityDeps {
 }
 
 /**
- * content-state 페이로드 빌더.
+ * content-state 페이로드 빌더 (#613).
  *
- * phase 필드는 보내지 않는다 — dev에서 phase 개념은 제거되었고(boardingLock 단일 경로),
- * widget(SubwayActivityAttributes)도 phase에 의존하지 않는다. 텍스트는 디바이스 측 init 값을
- * 유지하므로 숫자/enum/epoch만 채운다.
+ * widget `SubwayActivityAttributes.ContentState`와 키가 정렬되어야 한다 (ActivityKit이
+ * update 시 content-state 전체를 교체하므로, 키 불일치는 widget decode 실패 또는 UI 누락으로
+ * 직결). distanceM은 backend가 모르므로 widget에서 optional로 두고 여기서는 채우지 않는다.
+ *
+ * phase 필드는 보내지 않는다 — dev에서 phase 개념은 제거됨(boardingLock 단일 경로).
  *
  * @param stopsRemaining 다음 hop까지 남은 정거장 수 — 호출자가 계산해 전달(폴링 전/후 시점에 따라 다름).
+ * @param _nowMs 현재 시각(epoch ms) — 시그니처 호환용. 현재 schema는 사용하지 않음.
  */
 export function buildLiveActivityContentState(
   waypoint: Waypoint,
   etaSeconds: number,
   stopsRemaining: number,
-  nowMs: number,
+  _nowMs: number,
 ): LiveActivityContentState {
+  const meta = LINE_META[waypoint.line];
   return {
-    etaSeconds,
-    kind: waypoint.kind,
+    stationName: waypoint.stationName,
+    alarmStationName: waypoint.stationName,
+    // LINE_META는 13개 노선을 모두 커버하지만, stations.json에 없는 신규 line code가 들어와도
+    // widget의 non-optional 필드가 비지 않도록 raw line code를 fallback으로 사용한다.
+    lineName: meta?.canonical ?? waypoint.line,
+    lineColorHex: meta?.color ?? '#888888',
     stopsRemaining,
-    arrivalAtSec: Math.floor(nowMs / 1000) + etaSeconds,
+    etaMinutes: Math.max(0, Math.round(etaSeconds / 60)),
+    alarmType: waypoint.kind,
   };
 }
 

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -47,28 +47,24 @@ export interface LiveActivityDeps {
  * update 시 content-state 전체를 교체하므로, 키 불일치는 widget decode 실패 또는 UI 누락으로
  * 직결). distanceM은 backend가 모르므로 widget에서 optional로 두고 여기서는 채우지 않는다.
  *
- * phase 필드는 보내지 않는다 — dev에서 phase 개념은 제거됨(boardingLock 단일 경로).
- *
- * @param stopsRemaining 다음 hop까지 남은 정거장 수 — 호출자가 계산해 전달(폴링 전/후 시점에 따라 다름).
- * @param _nowMs 현재 시각(epoch ms) — 시그니처 호환용. 현재 schema는 사용하지 않음.
+ * alarmType은 채우지 않는다 — backend는 알람을 트리거하지 않고(디바이스 사전 예약, #584) 정보 갱신만 함.
+ * widget의 긴급 모드(LockScreenView.isUrgent)는 alarmType 존재로 판정하므로, polling 정정마다
+ * 긴급 UI가 강제되지 않도록 omit. 알람 트리거 시점의 별도 텍스트 push에서 채우는 것이 정상 경로.
  */
 export function buildLiveActivityContentState(
   waypoint: Waypoint,
   etaSeconds: number,
   stopsRemaining: number,
-  _nowMs: number,
 ): LiveActivityContentState {
   const meta = LINE_META[waypoint.line];
   return {
     stationName: waypoint.stationName,
-    alarmStationName: waypoint.stationName,
     // LINE_META는 13개 노선을 모두 커버하지만, stations.json에 없는 신규 line code가 들어와도
     // widget의 non-optional 필드가 비지 않도록 raw line code를 fallback으로 사용한다.
     lineName: meta?.canonical ?? waypoint.line,
     lineColorHex: meta?.color ?? '#888888',
     stopsRemaining,
     etaMinutes: Math.max(0, Math.round(etaSeconds / 60)),
-    alarmType: waypoint.kind,
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -334,7 +334,6 @@ export async function advanceBoardingLockWaypoint(
       nextWaypoint,
       0,
       trip.waypoints.length,
-      now,
     );
     await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log);
   }
@@ -370,7 +369,6 @@ export async function maybeFireLiveActivityUpdate(
     waypoint,
     etaSeconds,
     trip.waypoints.length,
-    now,
   );
   const result = await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log);
   if (result.dirty) {

--- a/modules/live-activity/ios/SubwayActivityAttributes.swift
+++ b/modules/live-activity/ios/SubwayActivityAttributes.swift
@@ -40,49 +40,18 @@ struct SubwayActivityAttributes: ActivityAttributes {
     }
 }
 
-// #613: backend LA push update가 raw 필드(etaMinutes/distanceM/alarmType 등)만 보내는 경우의
-// 텍스트 폴백. 텍스트 필드가 채워져 있으면 그대로 쓰고, 비어 있으면 raw에서 derive한다.
-// 새 필드를 추가할 때는 여기 한 곳만 갱신하면 widget UI 전체가 같은 정책을 공유한다.
+// #613: backend LA push update는 텍스트 i18n 필드를 채우지 않는다 (한국어 강제 회피).
+// 위젯의 i18n-안전한 폴백은 universal unit ("m") 표시에만 한정한다. 다른 텍스트(alarmBody, etaText,
+// routeSubtext, alarmShortLabel)는 JS init에서 i18n으로 채워진 값을 유지하고, 누락 시 UI에서
+// 자연 hide — backend가 텍스트를 채우려면 Localizable.strings(ko/en/ja/zh) 인프라가 선행되어야 한다.
 @available(iOS 16.1, *)
 extension SubwayActivityAttributes.ContentState {
-    var resolvedAlarmBody: String? {
-        if let body = alarmBody { return body }
-        guard let type = alarmType else { return nil }
-        let station = alarmStationName ?? stationName
-        switch type {
-        case "destination": return "\(station) 곧 도착"
-        case "transfer": return "\(station) 환승"
-        case "intermediate": return "\(station) 통과"
-        default: return nil
-        }
-    }
-
-    var resolvedEtaText: String? {
-        if let text = etaText { return text }
-        guard let m = etaMinutes else { return nil }
-        return "\(m)분"
-    }
-
+    /// 거리 표시. distanceText(i18n) 우선, 없으면 raw distanceM에 universal "m" 단위.
+    /// 단위 "m"은 모든 로캘 공통이라 한국어 강제 위험이 없다.
     var resolvedDistanceText: String? {
         if let text = distanceText { return text }
-        guard let m = distanceM else { return nil }
-        return "\(m)m"
-    }
-
-    var resolvedRouteSubtext: String? {
-        if let text = routeSubtext { return text }
-        if let stops = stopsToTransfer, let name = transferStationName {
-            return "\(stops)정거장 후 \(name) 환승"
-        }
-        if let stops = stopsRemaining {
-            return "\(stops)정거장 남음"
-        }
+        if let m = distanceM { return "\(m)m" }
         return nil
-    }
-
-    var resolvedAlarmShortLabel: String? {
-        if let label = alarmShortLabel { return label }
-        return resolvedEtaText
     }
 }
 #endif

--- a/modules/live-activity/ios/SubwayActivityAttributes.swift
+++ b/modules/live-activity/ios/SubwayActivityAttributes.swift
@@ -19,7 +19,9 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var stopsToSecondTransfer: Int?
         var secondTransferStationName: String?
         var stopsAfterLastTransfer: Int?
-        var distanceM: Int
+        // #613: backend LA update push는 거리 정보를 채우지 않는다.
+        // optional로 두어 partial update에서 누락되어도 decode 실패가 없도록 한다.
+        var distanceM: Int?
         var etaMinutes: Int?
         var isMock: Bool?
         var alarmType: String?
@@ -35,6 +37,52 @@ struct SubwayActivityAttributes: ActivityAttributes {
         // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드된 사용자 노출 텍스트.
         // 누락 시 위젯은 라벨 표시 생략 — 기존 LA 인스턴스 호환 안전.
         var sourceLabel: String?
+    }
+}
+
+// #613: backend LA push update가 raw 필드(etaMinutes/distanceM/alarmType 등)만 보내는 경우의
+// 텍스트 폴백. 텍스트 필드가 채워져 있으면 그대로 쓰고, 비어 있으면 raw에서 derive한다.
+// 새 필드를 추가할 때는 여기 한 곳만 갱신하면 widget UI 전체가 같은 정책을 공유한다.
+@available(iOS 16.1, *)
+extension SubwayActivityAttributes.ContentState {
+    var resolvedAlarmBody: String? {
+        if let body = alarmBody { return body }
+        guard let type = alarmType else { return nil }
+        let station = alarmStationName ?? stationName
+        switch type {
+        case "destination": return "\(station) 곧 도착"
+        case "transfer": return "\(station) 환승"
+        case "intermediate": return "\(station) 통과"
+        default: return nil
+        }
+    }
+
+    var resolvedEtaText: String? {
+        if let text = etaText { return text }
+        guard let m = etaMinutes else { return nil }
+        return "\(m)분"
+    }
+
+    var resolvedDistanceText: String? {
+        if let text = distanceText { return text }
+        guard let m = distanceM else { return nil }
+        return "\(m)m"
+    }
+
+    var resolvedRouteSubtext: String? {
+        if let text = routeSubtext { return text }
+        if let stops = stopsToTransfer, let name = transferStationName {
+            return "\(stops)정거장 후 \(name) 환승"
+        }
+        if let stops = stopsRemaining {
+            return "\(stops)정거장 남음"
+        }
+        return nil
+    }
+
+    var resolvedAlarmShortLabel: String? {
+        if let label = alarmShortLabel { return label }
+        return resolvedEtaText
     }
 }
 #endif

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,targets/**,modules/**,src/i18n/locales/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx
+sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/i18n/locales/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -27,7 +27,7 @@ struct SubwayLiveActivityWidget: Widget {
                             .fontWeight(.bold)
                             .foregroundColor(.white)
                         if let alarmType = context.state.alarmType,
-                           let alarmBody = context.state.resolvedAlarmBody {
+                           let alarmBody = context.state.alarmBody {
                             Text(alarmBody)
                                 .font(.caption)
                                 .fontWeight(.semibold)
@@ -84,7 +84,7 @@ private struct LockScreenView: View {
     }
 
     var urgentText: String {
-        return state.resolvedAlarmBody ?? ""
+        return state.alarmBody ?? ""
     }
 
     var body: some View {
@@ -118,7 +118,7 @@ private struct LockScreenView: View {
 
                 Spacer()
 
-                Text(state.resolvedAlarmShortLabel ?? "")
+                Text(state.alarmShortLabel ?? "")
                     .font(.title3)
                     .fontWeight(.black)
                     .foregroundColor(.white)
@@ -173,7 +173,7 @@ private struct LockScreenView: View {
 
                 Spacer()
 
-                if let etaText = state.resolvedEtaText {
+                if let etaText = state.etaText {
                     VStack(spacing: 2) {
                         Text(etaText)
                             .font(.title3)
@@ -203,7 +203,7 @@ private struct LockScreenRouteView: View {
                 .fontWeight(.semibold)
                 .foregroundColor(.white)
 
-            if let subtext = state.resolvedRouteSubtext {
+            if let subtext = state.routeSubtext {
                 Text(subtext)
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -27,7 +27,7 @@ struct SubwayLiveActivityWidget: Widget {
                             .fontWeight(.bold)
                             .foregroundColor(.white)
                         if let alarmType = context.state.alarmType,
-                           let alarmBody = context.state.alarmBody {
+                           let alarmBody = context.state.resolvedAlarmBody {
                             Text(alarmBody)
                                 .font(.caption)
                                 .fontWeight(.semibold)
@@ -35,8 +35,9 @@ struct SubwayLiveActivityWidget: Widget {
                         } else if context.state.destinationName != nil {
                             ExpandedRouteView(state: context.state)
                         } else {
-                            Text(context.state.distanceText.map { "\(context.state.lineName) · \($0)" }
-                                 ?? "\(context.state.lineName) · \(context.state.distanceM)m")
+                            let distance = context.state.resolvedDistanceText
+                            Text(distance.map { "\(context.state.lineName) · \($0)" }
+                                 ?? context.state.lineName)
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
@@ -83,7 +84,7 @@ private struct LockScreenView: View {
     }
 
     var urgentText: String {
-        return state.alarmBody ?? ""
+        return state.resolvedAlarmBody ?? ""
     }
 
     var body: some View {
@@ -117,7 +118,7 @@ private struct LockScreenView: View {
 
                 Spacer()
 
-                Text(state.alarmShortLabel ?? "")
+                Text(state.resolvedAlarmShortLabel ?? "")
                     .font(.title3)
                     .fontWeight(.black)
                     .foregroundColor(.white)
@@ -157,7 +158,7 @@ private struct LockScreenView: View {
                     if state.destinationName != nil {
                         LockScreenRouteView(state: state)
                     } else {
-                        Text(state.distanceText ?? "\(state.distanceM)m")
+                        Text(state.resolvedDistanceText ?? "")
                             .font(.subheadline)
                             .foregroundColor(lineColor)
                     }
@@ -172,7 +173,7 @@ private struct LockScreenView: View {
 
                 Spacer()
 
-                if let etaText = state.etaText {
+                if let etaText = state.resolvedEtaText {
                     VStack(spacing: 2) {
                         Text(etaText)
                             .font(.title3)
@@ -202,7 +203,7 @@ private struct LockScreenRouteView: View {
                 .fontWeight(.semibold)
                 .foregroundColor(.white)
 
-            if let subtext = state.routeSubtext {
+            if let subtext = state.resolvedRouteSubtext {
                 Text(subtext)
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/targets/subway-widget/_shared/SubwayActivityAttributes.swift
+++ b/targets/subway-widget/_shared/SubwayActivityAttributes.swift
@@ -43,49 +43,18 @@ struct SubwayActivityAttributes: ActivityAttributes {
     }
 }
 
-// #613: backend LA push update가 raw 필드(etaMinutes/distanceM/alarmType 등)만 보내는 경우의
-// 텍스트 폴백. 텍스트 필드가 채워져 있으면 그대로 쓰고, 비어 있으면 raw에서 derive한다.
-// 새 필드를 추가할 때는 여기 한 곳만 갱신하면 widget UI 전체가 같은 정책을 공유한다.
+// #613: backend LA push update는 텍스트 i18n 필드를 채우지 않는다 (한국어 강제 회피).
+// 위젯의 i18n-안전한 폴백은 universal unit ("m") 표시에만 한정한다. 다른 텍스트(alarmBody, etaText,
+// routeSubtext, alarmShortLabel)는 JS init에서 i18n으로 채워진 값을 유지하고, 누락 시 UI에서
+// 자연 hide — backend가 텍스트를 채우려면 Localizable.strings(ko/en/ja/zh) 인프라가 선행되어야 한다.
 @available(iOS 16.1, *)
 extension SubwayActivityAttributes.ContentState {
-    var resolvedAlarmBody: String? {
-        if let body = alarmBody { return body }
-        guard let type = alarmType else { return nil }
-        let station = alarmStationName ?? stationName
-        switch type {
-        case "destination": return "\(station) 곧 도착"
-        case "transfer": return "\(station) 환승"
-        case "intermediate": return "\(station) 통과"
-        default: return nil
-        }
-    }
-
-    var resolvedEtaText: String? {
-        if let text = etaText { return text }
-        guard let m = etaMinutes else { return nil }
-        return "\(m)분"
-    }
-
+    /// 거리 표시. distanceText(i18n) 우선, 없으면 raw distanceM에 universal "m" 단위.
+    /// 단위 "m"은 모든 로캘 공통이라 한국어 강제 위험이 없다.
     var resolvedDistanceText: String? {
         if let text = distanceText { return text }
-        guard let m = distanceM else { return nil }
-        return "\(m)m"
-    }
-
-    var resolvedRouteSubtext: String? {
-        if let text = routeSubtext { return text }
-        if let stops = stopsToTransfer, let name = transferStationName {
-            return "\(stops)정거장 후 \(name) 환승"
-        }
-        if let stops = stopsRemaining {
-            return "\(stops)정거장 남음"
-        }
+        if let m = distanceM { return "\(m)m" }
         return nil
-    }
-
-    var resolvedAlarmShortLabel: String? {
-        if let label = alarmShortLabel { return label }
-        return resolvedEtaText
     }
 }
 #endif

--- a/targets/subway-widget/_shared/SubwayActivityAttributes.swift
+++ b/targets/subway-widget/_shared/SubwayActivityAttributes.swift
@@ -22,7 +22,9 @@ struct SubwayActivityAttributes: ActivityAttributes {
         var stopsToSecondTransfer: Int?
         var secondTransferStationName: String?
         var stopsAfterLastTransfer: Int?
-        var distanceM: Int
+        // #613: backend LA update push는 거리 정보를 채우지 않는다.
+        // optional로 두어 partial update에서 누락되어도 decode 실패가 없도록 한다.
+        var distanceM: Int?
         var etaMinutes: Int?
         var isMock: Bool?
         var alarmType: String?
@@ -38,6 +40,52 @@ struct SubwayActivityAttributes: ActivityAttributes {
         // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드된 사용자 노출 텍스트.
         // 누락 시 위젯은 라벨 표시 생략 — 기존 LA 인스턴스 호환 안전.
         var sourceLabel: String?
+    }
+}
+
+// #613: backend LA push update가 raw 필드(etaMinutes/distanceM/alarmType 등)만 보내는 경우의
+// 텍스트 폴백. 텍스트 필드가 채워져 있으면 그대로 쓰고, 비어 있으면 raw에서 derive한다.
+// 새 필드를 추가할 때는 여기 한 곳만 갱신하면 widget UI 전체가 같은 정책을 공유한다.
+@available(iOS 16.1, *)
+extension SubwayActivityAttributes.ContentState {
+    var resolvedAlarmBody: String? {
+        if let body = alarmBody { return body }
+        guard let type = alarmType else { return nil }
+        let station = alarmStationName ?? stationName
+        switch type {
+        case "destination": return "\(station) 곧 도착"
+        case "transfer": return "\(station) 환승"
+        case "intermediate": return "\(station) 통과"
+        default: return nil
+        }
+    }
+
+    var resolvedEtaText: String? {
+        if let text = etaText { return text }
+        guard let m = etaMinutes else { return nil }
+        return "\(m)분"
+    }
+
+    var resolvedDistanceText: String? {
+        if let text = distanceText { return text }
+        guard let m = distanceM else { return nil }
+        return "\(m)m"
+    }
+
+    var resolvedRouteSubtext: String? {
+        if let text = routeSubtext { return text }
+        if let stops = stopsToTransfer, let name = transferStationName {
+            return "\(stops)정거장 후 \(name) 환승"
+        }
+        if let stops = stopsRemaining {
+            return "\(stops)정거장 남음"
+        }
+        return nil
+    }
+
+    var resolvedAlarmShortLabel: String? {
+        if let label = alarmShortLabel { return label }
+        return resolvedEtaText
     }
 }
 #endif


### PR DESCRIPTION
## Summary

#612(PR #693 머지) backend buildLiveActivityContentState가 `{etaSeconds, kind, stopsRemaining, arrivalAtSec}`로 만들었는데 widget Swift ContentState 키(`etaMinutes, alarmType, stationName, lineName, lineColorHex` 등)와 0% 매칭이라 ActivityKit update 시 widget 표시 깨지는 위험.

본 PR이 두 가지 묶어 해결:
1. **Backend schema를 widget 키에 정렬** — `{stationName, lineName, lineColorHex, stopsRemaining, etaMinutes}` (widget 1:1)
2. **Widget i18n-안전한 폴백 보강** — `distanceM` optional 전환 + universal "m" 단위 `resolvedDistanceText` extension

## 확장성 결정

- `LINE_META`에 `color: string` 추가 — 노선 추가 시 한 줄(canonical/aliases/color)만 수정 → backend도 자동 line name + color 반영
- LINE_META lookup 실패 시 raw line code + `#888888` 중립색 fallback → widget non-optional decode 보장
- 한국어 강제 derive 제거 — Localizable.strings(ko/en/ja/zh) 인프라가 선행돼야 의미있는 i18n 폴백 가능, 그 전까지는 JS init이 채운 텍스트 우선

## 변경 파일

- `backend/alarm-worker/src/lineAlias.ts` — LineMeta에 `color` 필드 추가, 13 노선
- `backend/alarm-worker/src/liveActivity.ts` — buildLiveActivityContentState 재설계 (widget schema 정렬, alarmType omit)
- `backend/alarm-worker/src/scheduled.ts` — 호출부 시그니처 갱신
- `backend/alarm-worker/src/__tests__/liveActivity.test.ts` — 새 schema 검증
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` — LA-integration 단언 갱신
- `targets/subway-widget/_shared/SubwayActivityAttributes.swift` — distanceM optional + resolvedDistanceText
- `modules/live-activity/ios/SubwayActivityAttributes.swift` — mirror 동기화
- `targets/subway-widget/SubwayLiveActivityWidget.swift` — distanceM 옵셔널 처리

## 리뷰 P1 fix 내역 (2차 push)

- **P1-1**: backend alarmType omit (polling 정정마다 widget 긴급 모드 강제 회귀 차단)
- **P1-2**: Swift extension 한국어 강제 derive 제거 (4언어 i18n 회귀)
- **P1-3**: alarmShortLabel = etaText 의미 불일치 제거

## Test plan

- [x] Backend type-check pass
- [x] Backend test 270/270 pass
- [x] Frontend type-check pass
- [x] Frontend test 2431/2431 pass, coverage 100%
- [x] code-review agent 1차 P1 3건 반영
- [ ] 실기기 검증 (LA push 후 widget 표시 정상)

## 후속

- LA contentState i18n derive — Localizable.strings(widget extension target) 추가 후 fallback 재도입 (별도 PR)
- MIRROR 두 Swift 파일 동기화 CI 보장 (별도 PR)
- LINE_COLORS cross-build SSOT 강제 (별도 PR)

Closes #613
Part of #586