### PR TITLE
fix(#709): useBoardingLockScheduler cold restart 시 schedule 1회 보장

### DIFF
--- a/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -187,4 +187,69 @@ describe('useBoardingLockScheduler', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedSchedule).toHaveBeenCalledTimes(1);
   });
+
+  // #709 cold restart 회귀: lock 복원이 route보다 먼저 들어오면 같은 trainCode로 두 번째
+  // effect가 돌면서 early-return 되어 영구히 schedule 되지 않는 문제. 사전 예약 알람이
+  // 살아 있지 않으면 잠금화면/Focus 발사가 통째로 누락된다.
+  it('#709 cold restart: lock 먼저 복원되고 route 늦게 로드돼도 schedule 1회 보장', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route: null, destinationName: '강남' } },
+    );
+    // 1차: lock 있지만 route=null → schedule 호출 안 됨이 정상
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    // 2차: route 로드 (같은 trainCode 유지) → 이제는 schedule 1회 호출되어야 함
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedSchedule).toHaveBeenCalledTimes(1);
+      expect(mockedSchedule).toHaveBeenCalledWith({
+        lock: lockA,
+        route,
+        destinationName: '강남',
+        sleepMode: false,
+      });
+    });
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('#709 cold restart: destinationName 늦게 들어와도 schedule 1회 보장', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: null as string | null } },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedSchedule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('#709 schedule 성공 후 동일 props 재렌더는 중복 호출 없음', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('#709 lock release 후 같은 trainCode로 재진입하면 다시 schedule 한다', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: null, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledWith(lockA));
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(2));
+  });
 });

--- a/src/hooks/useBoardingLockScheduler.ts
+++ b/src/hooks/useBoardingLockScheduler.ts
@@ -33,6 +33,10 @@ export function useBoardingLockScheduler({
   destinationName,
 }: UseBoardingLockSchedulerInputs): void {
   const prevLockRef = useRef<BoardingLock | null>(null);
+  // #709 cold restart 보장: lock이 storage에서 먼저 hydrate되고 route/destination이
+  // 늦게 로드되는 케이스에서, 같은 trainCode라도 schedule이 아직 안 일어났다면 한 번은 보장.
+  // trainCode를 기록해 release 후 같은 trainCode 재진입 시 다시 schedule할 수 있게 한다.
+  const scheduledTrainCodeRef = useRef<string | null>(null);
   // 이미 예약된 알람은 sleep 토글에 영향받지 않는 trade-off — 토글 기반 재예약이 요구되면 별도 이슈.
   const sleepModeRef = useSleepModeRef();
 
@@ -40,24 +44,34 @@ export function useBoardingLockScheduler({
     const prev = prevLockRef.current;
     const prevTrain = prev?.trainCode ?? null;
     const nextTrain = lock?.trainCode ?? null;
+    const canSchedule = lock !== null && route !== null && destinationName !== null;
+    // 같은 trainCode인데도 schedule을 보장해야 하는 cold-restart 케이스:
+    // 직전 effect에서 route/destination이 미완비라 schedule을 건너뛰었고, 지금은 ready.
+    const needsColdRestartSchedule =
+      canSchedule && scheduledTrainCodeRef.current !== nextTrain;
 
-    if (prevTrain === nextTrain) {
-      // 같은 trainCode(또는 둘 다 null) — 재예약 없음. ref만 최신화하여 다음 비교 정확성 유지.
+    if (prevTrain === nextTrain && !needsColdRestartSchedule) {
+      // 같은 trainCode(또는 둘 다 null)이고 이미 해당 trainCode로 schedule 완료 — 재예약 없음.
       prevLockRef.current = lock;
       return;
     }
 
     const handleTransition = async (): Promise<void> => {
-      if (prev) {
+      // prev가 있고 trainCode가 실제로 바뀐 경우에만 cancel (cold-restart 보강 시엔 cancel 불필요).
+      if (prev && prevTrain !== nextTrain) {
         await cancelAllHopsForLock(prev);
       }
-      if (lock && route && destinationName) {
+      if (canSchedule) {
         await scheduleHopsForLock({
           lock,
           route,
           destinationName,
           sleepMode: sleepModeRef.current,
         });
+        scheduledTrainCodeRef.current = nextTrain;
+      } else if (nextTrain === null) {
+        // lock release — 다음 lock 진입 시 같은 trainCode라도 다시 schedule 가능하도록 reset.
+        scheduledTrainCodeRef.current = null;
       }
     };
     handleTransition().catch((e: unknown) => {


### PR DESCRIPTION
## Summary
- Cold restart에서 lock 복원 후 route ready 시점에 schedule이 한 번 보장되도록 hasScheduledRef 추가
- lock release 시 ref reset으로 같은 trainCode 재진입에도 동작
- 기존 trainCode 변화 시 reschedule 로직 회귀 없음

## Test plan
- [x] 100% 커버리지 유지
- [x] 타입체크 통과
- [x] cold restart 회귀 가드 테스트 추가
- [x] lock release 후 같은 trainCode 재진입 시 schedule 재발생 검증

Closes #709