### PR TITLE
feat(#706): backend consecutiveEtaMissing 카운터 + 자동 종료

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -136,6 +136,17 @@ describe('validateTrip', () => {
     delete b.route;
     expect(validateTrip(b)).toBeNull();
   });
+
+  // #706
+  it('preserves numeric consecutiveEtaMissing', () => {
+    expect(validateTrip({ ...base(), consecutiveEtaMissing: 3 })?.consecutiveEtaMissing).toBe(3);
+  });
+
+  it('drops non-number consecutiveEtaMissing (defaults to undefined → 0 at runtime)', () => {
+    expect(validateTrip({ ...base(), consecutiveEtaMissing: 'lots' })?.consecutiveEtaMissing).toBeUndefined();
+    // 필드 자체가 부재인 경우(구버전 trip): undefined로 보존, scheduled.ts가 ?? 0으로 fallback.
+    expect(validateTrip(base())?.consecutiveEtaMissing).toBeUndefined();
+  });
 });
 
 describe('validateTrip — boardingLock (#585)', () => {
@@ -330,6 +341,18 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     await post('/trips', tripBody(), env); // no apnsEnv
     const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
     expect(finalTrip.apnsEnv).toBe('production');
+  });
+
+  // #706 — re-register가 누적된 consecutiveEtaMissing을 0으로 지우면 자동 종료가 영원히 못 발동.
+  it('preserves backend-accumulated consecutiveEtaMissing on same-session re-register', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    const advanced = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    advanced.consecutiveEtaMissing = 4;
+    await env.TRIPS.put('trip:tok-578', JSON.stringify(advanced));
+    await post('/trips', tripBody(), env); // device sends payload w/o counter
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(finalTrip.consecutiveEtaMissing).toBe(4);
   });
 
   it('returns 400 on invalid JSON', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2,6 +2,7 @@ import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
 import {
+  MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
   estimateArrivalFromPosition,
   flipApnsEnv,
@@ -415,6 +416,149 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     });
     expect(stats.etaMissing).toBe(1);
     expect(stats.pushed).toBe(0);
+  });
+
+  // #706 — 운행 시간대 외(새벽 등)에 trainCode가 사라지면 trip이 무한 폴링됐던 회귀 방지.
+  // 연속 etaMissing 카운트 + 임계 초과 시 cleanupTripWithLa로 자동 종료.
+  describe('#706 consecutiveEtaMissing auto-end', () => {
+    it('increments counter and persists on etaMissing (no cleanup yet)', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p706a',
+      });
+      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+      expect(stored.consecutiveEtaMissing).toBe(1);
+    });
+
+    it('accumulates counter across cycles when etaMissing persists', async () => {
+      const kv = new InMemoryKV();
+      // 이미 3회 연속 miss 상태로 시작 → 한 번 더 miss → 4
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({ consecutiveEtaMissing: 3 }),
+      );
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p706b',
+      });
+      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+      expect(stored.consecutiveEtaMissing).toBe(4);
+    });
+
+    it('auto-ends trip when consecutiveEtaMissing reaches threshold', async () => {
+      const kv = new InMemoryKV();
+      // 임계치 -1 상태 → 한 번 더 miss → threshold 도달 → cleanup
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({ consecutiveEtaMissing: MAX_CONSECUTIVE_ETA_MISSING - 1 }),
+      );
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p706c',
+      });
+      expect(await kv.get('trip:lock-tok')).toBeNull();
+    });
+
+    it('resets counter to 0 when arrival estimate succeeds', async () => {
+      const kv = new InMemoryKV();
+      // 4회 miss 누적 상태에서 정상 estimate 들어옴 → reset
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({ consecutiveEtaMissing: 4 }),
+      );
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p706d',
+      });
+      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+      expect(stored.consecutiveEtaMissing).toBe(0);
+    });
+
+    it('resets counter when waypoint advances on arrival', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({ consecutiveEtaMissing: 2 }),
+      );
+      // arvlCd=1 → arrived → waypoint advance
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p706e',
+      });
+      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+      expect(stored.consecutiveEtaMissing).toBe(0);
+    });
+
+    it('does not resurrect trip when reschedule push hits 410 with prior miss accumulation', async () => {
+      // 회귀 가드: hadMissCount=true 상태에서 cleanupTripWithLa가 호출된 직후 reset persistance
+      // 경로가 putTrip을 다시 호출하면 삭제된 trip이 KV에 부활한다. cleanedUp 시그널로 차단.
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({ consecutiveEtaMissing: 2 }),
+      );
+      const apnsFetch = vi.fn(async () =>
+        new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
+      );
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p706g',
+      });
+      expect(await kv.get('trip:lock-tok')).toBeNull();
+    });
+
+    it('treats missing field as 0 (backward compat with existing trips)', async () => {
+      const kv = new InMemoryKV();
+      // consecutiveEtaMissing 미설정 (구버전 trip) → miss 1회 → 1
+      const trip = makeLockTrip();
+      delete (trip as unknown as Record<string, unknown>).consecutiveEtaMissing;
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p706f',
+      });
+      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+      expect(stored.consecutiveEtaMissing).toBe(1);
+    });
+  });
+
+  describe('MAX_CONSECUTIVE_ETA_MISSING (#706)', () => {
+    it('is 5', () => {
+      expect(MAX_CONSECUTIVE_ETA_MISSING).toBe(5);
+    });
   });
 
   it('advances waypoint and resets baseline when trainCode arrived (arvlCd=1)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -421,137 +421,102 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
   // #706 — 운행 시간대 외(새벽 등)에 trainCode가 사라지면 trip이 무한 폴링됐던 회귀 방지.
   // 연속 etaMissing 카운트 + 임계 초과 시 cleanupTripWithLa로 자동 종료.
   describe('#706 consecutiveEtaMissing auto-end', () => {
-    it('increments counter and persists on etaMissing (no cleanup yet)', async () => {
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, makeLockTrip());
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    /**
+     * #706 시나리오 표준 runner — `runScheduled` boilerplate(apnsConfig/apnsHosts/now/generatePushId)
+     * + `seoul=makeSeoulCombo(...)` + `fetchImpl=makeOkFetch()` 기본을 단일 진입점으로 압축.
+     * 각 테스트는 trip 상태 차이(consecutiveEtaMissing/waypoints)와 응답 차이(arrivals/apns status)에만 집중한다.
+     */
+    async function runMissScenario(
+      kv: InMemoryKV,
+      args: {
+        arrivals?: ArrivalEntry[];
+        apnsFetch?: ReturnType<typeof vi.fn>;
+      } = {},
+    ) {
+      const fetchImpl = args.apnsFetch ?? makeOkFetch();
       await runScheduled(makeEnv(kv), {
-        seoul: makeSeoulCombo([], []),
+        seoul: makeSeoulCombo(args.arrivals ?? [], []),
         apnsConfig,
         apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
         now: () => NOW,
-        generatePushId: () => 'p706a',
+        generatePushId: () => 'p706',
       });
-      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
-      expect(stored.consecutiveEtaMissing).toBe(1);
+    }
+
+    /** 표준 lock trip을 KV에 seed. trip 상태 override(consecutiveEtaMissing 등)만 받는다. */
+    async function seedLockTrip(kv: InMemoryKV, overrides: Partial<Trip> = {}) {
+      await putTrip(kv as unknown as KVNamespace, makeLockTrip(overrides));
+    }
+
+    /** KV에서 trip 읽기. 삭제된 경우 null. */
+    async function readStoredTrip(kv: InMemoryKV): Promise<Trip | null> {
+      const raw = await kv.get('trip:lock-tok');
+      return raw ? (JSON.parse(raw) as Trip) : null;
+    }
+
+    it('increments counter and persists on etaMissing (no cleanup yet)', async () => {
+      const kv = new InMemoryKV();
+      await seedLockTrip(kv);
+      await runMissScenario(kv);
+      expect((await readStoredTrip(kv))?.consecutiveEtaMissing).toBe(1);
     });
 
     it('accumulates counter across cycles when etaMissing persists', async () => {
-      const kv = new InMemoryKV();
       // 이미 3회 연속 miss 상태로 시작 → 한 번 더 miss → 4
-      await putTrip(
-        kv as unknown as KVNamespace,
-        makeLockTrip({ consecutiveEtaMissing: 3 }),
-      );
-      await runScheduled(makeEnv(kv), {
-        seoul: makeSeoulCombo([], []),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p706b',
-      });
-      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
-      expect(stored.consecutiveEtaMissing).toBe(4);
+      const kv = new InMemoryKV();
+      await seedLockTrip(kv, { consecutiveEtaMissing: 3 });
+      await runMissScenario(kv);
+      expect((await readStoredTrip(kv))?.consecutiveEtaMissing).toBe(4);
     });
 
     it('auto-ends trip when consecutiveEtaMissing reaches threshold', async () => {
-      const kv = new InMemoryKV();
       // 임계치 -1 상태 → 한 번 더 miss → threshold 도달 → cleanup
-      await putTrip(
-        kv as unknown as KVNamespace,
-        makeLockTrip({ consecutiveEtaMissing: MAX_CONSECUTIVE_ETA_MISSING - 1 }),
-      );
-      await runScheduled(makeEnv(kv), {
-        seoul: makeSeoulCombo([], []),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p706c',
-      });
-      expect(await kv.get('trip:lock-tok')).toBeNull();
+      const kv = new InMemoryKV();
+      await seedLockTrip(kv, { consecutiveEtaMissing: MAX_CONSECUTIVE_ETA_MISSING - 1 });
+      await runMissScenario(kv);
+      expect(await readStoredTrip(kv)).toBeNull();
     });
 
     it('resets counter to 0 when arrival estimate succeeds', async () => {
-      const kv = new InMemoryKV();
       // 4회 miss 누적 상태에서 정상 estimate 들어옴 → reset
-      await putTrip(
-        kv as unknown as KVNamespace,
-        makeLockTrip({ consecutiveEtaMissing: 4 }),
-      );
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      await runScheduled(makeEnv(kv), {
-        seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p706d',
-      });
-      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
-      expect(stored.consecutiveEtaMissing).toBe(0);
+      const kv = new InMemoryKV();
+      await seedLockTrip(kv, { consecutiveEtaMissing: 4 });
+      await runMissScenario(kv, { arrivals: [arrivalForLock('중곡', 120)] });
+      expect((await readStoredTrip(kv))?.consecutiveEtaMissing).toBe(0);
     });
 
     it('resets counter when waypoint advances on arrival', async () => {
+      // arvlCd=1 → arrived → waypoint advance + reset
       const kv = new InMemoryKV();
-      await putTrip(
-        kv as unknown as KVNamespace,
-        makeLockTrip({ consecutiveEtaMissing: 2 }),
-      );
-      // arvlCd=1 → arrived → waypoint advance
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      await runScheduled(makeEnv(kv), {
-        seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p706e',
-      });
-      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
-      expect(stored.consecutiveEtaMissing).toBe(0);
+      await seedLockTrip(kv, { consecutiveEtaMissing: 2 });
+      await runMissScenario(kv, { arrivals: [arrivalForLock('중곡', 0, 1)] });
+      expect((await readStoredTrip(kv))?.consecutiveEtaMissing).toBe(0);
     });
 
     it('does not resurrect trip when reschedule push hits 410 with prior miss accumulation', async () => {
       // 회귀 가드: hadMissCount=true 상태에서 cleanupTripWithLa가 호출된 직후 reset persistance
       // 경로가 putTrip을 다시 호출하면 삭제된 trip이 KV에 부활한다. cleanedUp 시그널로 차단.
       const kv = new InMemoryKV();
-      await putTrip(
-        kv as unknown as KVNamespace,
-        makeLockTrip({ consecutiveEtaMissing: 2 }),
-      );
+      await seedLockTrip(kv, { consecutiveEtaMissing: 2 });
       const apnsFetch = vi.fn(async () =>
         new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
       );
-      await runScheduled(makeEnv(kv), {
-        seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p706g',
+      await runMissScenario(kv, {
+        arrivals: [arrivalForLock('중곡', 120)],
+        apnsFetch,
       });
-      expect(await kv.get('trip:lock-tok')).toBeNull();
+      expect(await readStoredTrip(kv)).toBeNull();
     });
 
     it('treats missing field as 0 (backward compat with existing trips)', async () => {
-      const kv = new InMemoryKV();
       // consecutiveEtaMissing 미설정 (구버전 trip) → miss 1회 → 1
+      const kv = new InMemoryKV();
       const trip = makeLockTrip();
       delete (trip as unknown as Record<string, unknown>).consecutiveEtaMissing;
       await putTrip(kv as unknown as KVNamespace, trip);
-      await runScheduled(makeEnv(kv), {
-        seoul: makeSeoulCombo([], []),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p706f',
-      });
-      const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
-      expect(stored.consecutiveEtaMissing).toBe(1);
+      await runMissScenario(kv);
+      expect((await readStoredTrip(kv))?.consecutiveEtaMissing).toBe(1);
     });
   });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -89,6 +89,9 @@ app.post('/trips', async (c) => {
         // 디바이스가 trip을 re-POST해도 register/deregister로 채워둔 값을 유지한다.
         activityPushToken: existing.activityPushToken,
         activityState: existing.activityState,
+        // #706: 연속 etaMissing 카운터는 backend-only state — 디바이스가 같은 세션으로 re-register해도
+        // 누적치를 보존해야 자동 종료가 정상 동작 (re-register마다 0으로 초기화되면 무한 폴링 회귀).
+        consecutiveEtaMissing: existing.consecutiveEtaMissing,
       }
     : incoming;
 
@@ -297,6 +300,10 @@ export function validateTrip(input: unknown): Trip | null {
     boardingLock: parseBoardingLock(obj.boardingLock),
     lastTrackedArrivalEpoch:
       typeof obj.lastTrackedArrivalEpoch === 'number' ? obj.lastTrackedArrivalEpoch : undefined,
+    // #706: 디바이스는 이 필드를 보내지 않지만 기존 trip에서 같은 세션으로 re-register 될 때
+    // POST /trips merge 단계에서 existing 값을 보존한다 (consecutiveEtaMissing 누적이 유지되어야 자동 종료가 정상 동작).
+    consecutiveEtaMissing:
+      typeof obj.consecutiveEtaMissing === 'number' ? obj.consecutiveEtaMissing : undefined,
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -40,6 +40,13 @@ const FALLBACK_HOP_SEC = 90;
  */
 export const LA_PUSH_THRESHOLD_MS = 30_000;
 
+/**
+ * 연속 etaMissing 임계치 (#706). 한 trip이 N회 연속 trainCode 매칭 실패면 자동 종료.
+ * 운행 시간대 외(새벽)에 trainCode가 Seoul API에서 사라지면 무한 폴링하던 회귀(8h × 1/min) 방지.
+ * cron 주기 60s × 5회 = 5분 — 일시적 API 누락은 흡수하고 운행 종료/탈선 신호는 잡는다.
+ */
+export const MAX_CONSECUTIVE_ETA_MISSING = 5;
+
 export interface EnvHealResult {
   result: SendPushResult;
   /** retry로 정정된 새 env. 정정 발생 시에만 set. */
@@ -226,12 +233,34 @@ export async function runTrainCodeTracking(
   const estimate = await estimateBoardingLockArrival(deps, lock, waypoint, now);
   if (estimate === null) {
     stats.etaMissing += 1;
+    const previousMissCount = trip.consecutiveEtaMissing ?? 0;
+    const nextMissCount = previousMissCount + 1;
     log('boarding-lock: trainCode not found in arrivals or positions', {
       token: trip.token.slice(0, 8),
       trainCode: lock.trainCode,
       station: waypoint.stationName,
+      consecutiveEtaMissing: nextMissCount,
     });
+    if (nextMissCount >= MAX_CONSECUTIVE_ETA_MISSING) {
+      // #706 — 운행 시간대 외 무한 폴링 차단. cleanupTripWithLa가 LA dismissal + deleteTrip을 묶어 정리.
+      log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
+        token: trip.token.slice(0, 8),
+        trainCode: lock.trainCode,
+        station: waypoint.stationName,
+        threshold: MAX_CONSECUTIVE_ETA_MISSING,
+      });
+      await cleanupTripWithLa(trip, env, deps, stats, now, log);
+      return;
+    }
+    trip.consecutiveEtaMissing = nextMissCount;
+    await putTrip(env.TRIPS, trip);
     return;
+  }
+
+  // 성공 사이클 — 카운터가 누적된 상태였다면 reset하고 persist. 0이면 dirty write 회피.
+  const hadMissCount = (trip.consecutiveEtaMissing ?? 0) > 0;
+  if (hadMissCount) {
+    trip.consecutiveEtaMissing = 0;
   }
 
   if (estimate.arrived) {
@@ -239,9 +268,21 @@ export async function runTrainCodeTracking(
     return;
   }
 
-  await maybeReschedulePush(trip, waypoint, lock, estimate.epoch, env, deps, stats, now, log, generatePushId);
+  const { cleanedUp } = await maybeReschedulePush(
+    trip,
+    waypoint,
+    lock,
+    estimate.epoch,
+    env,
+    deps,
+    stats,
+    now,
+    log,
+    generatePushId,
+  );
+  // trip이 KV에서 삭제됐다면 후속 putTrip은 resurrection이 되므로 즉시 종료.
+  if (cleanedUp) return;
   // LA는 reschedule와 독립 평가 — reschedule 임계(15s) 미달이거나 push가 실패해도 LA 임계(30s)는 별도 게이트.
-  // maybeReschedulePush가 trip을 cleanup했다면 trip.activityPushToken이 undefined라 fireLiveActivityUpdate가 no-op.
   const laDirty = await maybeFireLiveActivityUpdate(
     trip,
     waypoint,
@@ -251,7 +292,7 @@ export async function runTrainCodeTracking(
     now,
     log,
   );
-  if (laDirty) {
+  if (laDirty || hadMissCount) {
     await putTrip(env.TRIPS, trip);
   }
 }
@@ -382,6 +423,9 @@ export async function maybeFireLiveActivityUpdate(
 /**
  * 임계치 이상 변동 시 reschedule silent push 발사. APNs env mismatch(#482) self-heal 포함.
  * reschedule push는 alert fallback 대상이 아니므로 PENDING_PUSHES 미등록.
+ *
+ * 반환값 `cleanedUp=true`는 trip이 KV에서 삭제됐음을 의미 — 호출자는 이후 putTrip을 호출하면 안 된다
+ * (삭제된 trip을 in-memory 상태로 resurrect하는 것을 방지). #706에서 counter reset과 충돌하지 않게 도입.
  */
 export async function maybeReschedulePush(
   trip: Trip,
@@ -394,13 +438,13 @@ export async function maybeReschedulePush(
   now: number,
   log: Logger,
   generatePushId: () => string,
-): Promise<void> {
+): Promise<{ cleanedUp: boolean }> {
   const lastEpoch = trip.lastTrackedArrivalEpoch;
   if (
     lastEpoch !== undefined &&
     Math.abs(newArrivalEpoch - lastEpoch) < RESCHEDULE_THRESHOLD_MS
   ) {
-    return;
+    return { cleanedUp: false };
   }
 
   const pushId = generatePushId();
@@ -454,13 +498,14 @@ export async function maybeReschedulePush(
     if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
       // #586 D — trip이 unrecoverable로 폐기되는 경로에서도 LA가 살아있으면 dismissal로 정리.
       await cleanupTripWithLa(trip, env, deps, stats, now, log);
-      return;
+      return { cleanedUp: true };
     }
   }
 
   if (dirty) {
     await putTrip(env.TRIPS, trip);
   }
+  return { cleanedUp: false };
 }
 
 /**

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -100,6 +100,14 @@ export interface Trip {
    * waypoint shift 시 reset(undefined) — 새 hop의 첫 update를 보장한다.
    */
   lastLaPushEpoch?: number;
+  /**
+   * 연속 etaMissing 카운트 (#706). 운행 시간대 외(새벽 등)에 trainCode가 Seoul API에서
+   * 사라져도 trip이 자동 종료되지 않아 무한 폴링하던 회귀(8h × 1/min) 방지용.
+   * runTrainCodeTracking이 estimate=null 받을 때마다 +1, 성공 시 0 reset.
+   * MAX_CONSECUTIVE_ETA_MISSING 초과 시 trip을 cleanup한다.
+   * 기존 trip(필드 부재)은 0으로 fallback (backward compat).
+   */
+  consecutiveEtaMissing?: number;
 }
 
 /** Device가 확정한 탑승 열차 정보 (#584). */


### PR DESCRIPTION
Closes #706

## Summary
- 운행 시간대 외(새벽 등) trainCode가 Seoul API에서 사라져도 trip이 자동 종료되지 않아 무한 폴링하던 회귀(8h × 1/min) 차단
- `Trip.consecutiveEtaMissing` 카운터 추가, `runTrainCodeTracking`이 estimate=null마다 +1 / 성공 시 0 reset
- 임계치 `MAX_CONSECUTIVE_ETA_MISSING=5` (cron 60s × 5회 = 5분) 초과 시 `cleanupTripWithLa`로 LA dismissal + KV delete

## Design notes
- **Dismissal 방식**: 새 push payload 추가 대신 기존 `cleanupTripWithLa`로 LA dismissal + deleteTrip 묶음 호출. 사용자 가시 정리는 LA dismissal이 담당(Dynamic Island/잠금화면 제거). 별도 `kind: 'auto-ended'` silent push는 client가 받을 valid kind에 포함되지 않아 PR 단순화 차원에서 후속 이슈로 분리. 디바이스의 사전 예약 알람은 trip 만료 시 자체 expiry로 처리.
- **임계 5회의 근거**: cron 60s × 5 = 5분. 일시적 Seoul API 누락은 흡수하면서 운행 종료/탈선 신호는 잡는다.
- **Backward compat**: 필드 부재(`undefined`) → `?? 0`으로 fallback. 구버전 trip(KV에 잔존)도 정상 동작.

## Resurrection guard
- `maybeReschedulePush`가 unrecoverable(410)에서 `cleanupTripWithLa`로 trip을 삭제할 때, 호출자가 reset된 in-memory state를 다시 `putTrip`하면 KV에 trip이 부활. 이를 막기 위해 `maybeReschedulePush`가 `{ cleanedUp }`을 반환하고 `runTrainCodeTracking`이 즉시 종료.

## Same-session preservation
- `validateTrip`에 `consecutiveEtaMissing` 파싱 추가 + `POST /trips` merge 로직이 `existing.consecutiveEtaMissing`을 보존. 디바이스가 같은 세션으로 re-register해도 누적치가 0으로 초기화되지 않아 자동 종료가 정상 동작.

## Regression guards (테스트 8건)
- 첫 miss → counter=1 + persist
- 누적 (3 → 4)
- 임계치 도달 → cleanup (KV에서 trip 제거)
- 성공 시 0 reset (estimate 들어옴)
- waypoint advance 시 reset
- 구버전 trip(필드 부재) → 0으로 fallback 후 1
- 410 + hadMissCount → trip resurrection 없음
- `MAX_CONSECUTIVE_ETA_MISSING === 5` 상수 검증
- `validateTrip` numeric/non-number/absent 경로
- `POST /trips` same-session counter 보존

## Test plan
- [x] backend `npm test` (vitest) 281 passed
- [x] backend `npm run type-check` clean
- [x] frontend `npm test` (jest, 100% coverage 강제) 2431 passed
- [x] frontend `npm run type-check` clean
- [ ] 실기기 회귀: 운행 시간대 외 trip 등록 → 약 5분 후 KV에서 자동 정리 확인 (wrangler tail로 `trip auto-ended` log 확인)