### PR TITLE
fix(#707): BG/silent push/lock 생성 3곳에 BoardingLock line 가드

### DIFF
--- a/src/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockController.test.tsx
@@ -25,6 +25,11 @@ jest.mock('../../utils/tripDirection', () => ({
   resolveTripDirection: (...args: unknown[]) => mockResolveTripDirection(...args),
 }));
 
+const mockFindStationByNameAndLine = jest.fn();
+jest.mock('../../utils/stationLookup', () => ({
+  findStationByNameAndLine: (...args: unknown[]) => mockFindStationByNameAndLine(...args),
+}));
+
 function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   return {
     destination: '종착',
@@ -72,6 +77,8 @@ describe('useBoardingLockController', () => {
     mockSetBoardingLock.mockResolvedValue(undefined);
     mockClearBoardingLock.mockResolvedValue(undefined);
     mockResolveTripDirection.mockReturnValue(null);
+    // Default: lookup miss — controller falls back to currentStation.id (이전 동작 유지).
+    mockFindStationByNameAndLine.mockReturnValue(null);
     useBoardingLockStore.setState({ lock: null });
   });
 
@@ -197,6 +204,37 @@ describe('useBoardingLockController', () => {
       });
       expect(mockSetBoardingLock).toHaveBeenCalledWith(
         expect.objectContaining({ trainCode: 'T-7', boardingLine: '7' }),
+      );
+    });
+
+    it('boardingStationId는 train.line 기준 정정 (#707) — 환승역에서 fusion 오인식된 옆 노선 id 제거', async () => {
+      // currentStation은 fusion이 line 2(id=stn-A)로 잘못 잠금. train.line='7' → 같은 역명에서 line 7 stop id로 교정.
+      mockFindStationByNameAndLine.mockReturnValue({
+        id: 'stn-A-line7',
+        name: '강남',
+        line: '7',
+        lineColor: '#000',
+        lat: 37.5,
+        lng: 127.0,
+      });
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain({ trainCode: 'T-7', line: '7' }));
+      });
+      expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
+      expect(mockSetBoardingLock).toHaveBeenCalledWith(
+        expect.objectContaining({ boardingStationId: 'stn-A-line7', boardingLine: '7' }),
+      );
+    });
+
+    it('정정 lookup 실패 시 currentStation.id로 폴백 (#707) — stations.json에 매칭 없는 가상 케이스도 안전', async () => {
+      mockFindStationByNameAndLine.mockReturnValue(null);
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain({ trainCode: 'T-X', line: '7' }));
+      });
+      expect(mockSetBoardingLock).toHaveBeenCalledWith(
+        expect.objectContaining({ boardingStationId: 'stn-A' }),
       );
     });
   });

--- a/src/hooks/useBoardingLockController.ts
+++ b/src/hooks/useBoardingLockController.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { resolveTripDirection } from '../utils/tripDirection';
+import { findStationByNameAndLine } from '../utils/stationLookup';
 import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
@@ -100,10 +101,15 @@ export function useBoardingLockController({
       // #663: boardingLine은 사용자가 실제로 탭한 train의 line을 사용. currentStation.line은 fusion
       // 추정이라 환승역에서 옆 노선으로 잘못 잠긴 상태일 수 있다 (#662). train.line은 어댑터가 subwayId로
       // 결정해 row마다 정확. fusion이 잘못돼 있어도 lock만은 정답을 유지 — backend sync(#622) 정확도 보장.
+      // #707: boardingStationId도 같은 이유로 정정. 환승역에서 fusion이 옆 노선 stop id로 잠긴 상태면
+      // backend가 그 id로 reschedule 계산해 잘못된 leg 알람을 보낼 수 있다. 같은 역명에서 train.line으로
+      // 정확 매칭되는 stop id를 사용. 매칭 실패(데이터 누락 가상 케이스)는 currentStation.id로 안전 폴백.
+      const correctedStation = findStationByNameAndLine(currentStation.name, train.line);
+      const boardingStationId = correctedStation?.id ?? currentStation.id;
       void createLock({
         destinationId,
         trainCode: train.trainCode,
-        boardingStationId: currentStation.id,
+        boardingStationId,
         boardingLine: train.line,
         boardedAt: Date.now(),
         expectedDurationMs: durationMin * 60_000,

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -61,6 +61,18 @@ jest.mock('../../api/alarmBackend', () => ({
   sendPushAck: (...args: unknown[]) => mockSendPushAck(...args),
 }));
 
+const mockGetBoardingLock = jest.fn();
+jest.mock('../../utils/boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+}));
+
+const mockFindStationByNameAndLine = jest.fn();
+const mockFindStationByName = jest.fn();
+jest.mock('../../utils/stationLookup', () => ({
+  findStationByNameAndLine: (...args: unknown[]) => mockFindStationByNameAndLine(...args),
+  findStationByName: (...args: unknown[]) => mockFindStationByName(...args),
+}));
+
 // i18next는 키 그대로 반환 (intermediate 본문 빌더 검증용).
 jest.mock('i18next', () => ({
   __esModule: true,
@@ -139,6 +151,11 @@ describe('silentPushTask', () => {
       return null;
     });
     mockSendPushAck.mockResolvedValue({ ok: true });
+    // 기본: lock 없음 → line 가드 미적용 (기존 동작).
+    mockGetBoardingLock.mockResolvedValue(null);
+    // 기본: stationLookup miss는 가드에 영향 없음(lock 없을 때 호출되지 않음).
+    mockFindStationByNameAndLine.mockReturnValue(null);
+    mockFindStationByName.mockReturnValue(null);
   });
 
   it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
@@ -449,6 +466,99 @@ describe('silentPushTask', () => {
       expect(mockScheduleNotificationAsync).toHaveBeenCalled();
       // 사전예약은 import도 안 함 — 호출 검증은 import 부재로 충분하나, 추가 안전망:
       // alarmScheduler 모듈을 jest.mock하지 않았기 때문에 호출 시 ReferenceError가 났을 것.
+    });
+
+    describe('#707 BoardingLock line 가드', () => {
+      const lockOnLine7 = {
+        destinationId: '0228',
+        trainCode: 'T-7',
+        boardingStationId: 'station-on-7',
+        boardingLine: '7' as const,
+        boardedAt: 1_700_000_000_000,
+        expectedDurationMs: 600_000,
+      };
+
+      it('lock 활성 + nextWaypoint가 lock.boardingLine에 정차 안 함 → skip + ack(lock-line-mismatch)', async () => {
+        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
+        // line 7에는 없음, 다른 line에는 존재 → 라인 mismatch.
+        mockFindStationByNameAndLine.mockReturnValue(null);
+        mockFindStationByName.mockReturnValue({ id: 'other-line-stop', name: '강남', line: '2' });
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-mismatch' }),
+        );
+
+        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lock-line-mismatch', kind: 'destination' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-mismatch',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'lock-line-mismatch',
+        });
+      });
+
+      it('lock 활성 + nextWaypoint가 lock.boardingLine에 정차(환승역 양쪽 호선 stop 존재) → 통과 후 발사', async () => {
+        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
+        // line 7 stop이 존재 → 환승역에서 line 7로도 정차하는 정상 케이스(transfer 등).
+        mockFindStationByNameAndLine.mockReturnValue({
+          id: 'stop-on-7',
+          name: '강남',
+          line: '7',
+        });
+
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
+
+        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('lock 활성 + nextWaypoint가 stations.json 어디에도 없으면 line 가드는 통과시키고 일반 게이트가 unknown-station으로 처리', async () => {
+        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
+        mockFindStationByNameAndLine.mockReturnValue(null);
+        mockFindStationByName.mockReturnValue(null);
+        // 일반 게이트가 unknown-station 반환 가정.
+        mockCheckGate.mockResolvedValue({ pass: false, reason: 'unknown-station' });
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-unknown' }),
+        );
+
+        // line 가드의 skip 사유가 아닌, 기존 게이트 사유로 분류돼야 한다.
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'gate-unknown-station' }),
+        );
+        expect(mockLogSilentPushSkipped).not.toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lock-line-mismatch' }),
+        );
+      });
+
+      it('lock 없음 → line 가드 skip (lookup 호출 안 됨, 기존 게이트 흐름)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockFindStationByNameAndLine).not.toHaveBeenCalled();
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+      });
+
+      it('intermediate kind도 lock line mismatch 시 station-passed로 skip 적재', async () => {
+        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
+        mockFindStationByNameAndLine.mockReturnValue(null);
+        mockFindStationByName.mockReturnValue({ id: 'x', name: '중곡', line: '5' });
+
+        await handleSilentPush(
+          payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }),
+        );
+
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: 'station-passed', reason: 'lock-line-mismatch' }),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      });
     });
 
     describe('#568 P2b — push ACK', () => {

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -38,6 +38,8 @@ import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
 import { buildAlarmContent } from '../utils/stationNotification';
 import { type NotificationSource } from '../utils/notificationSource';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
+import { getBoardingLock } from '../utils/boardingLockStorage';
+import { findStationByName, findStationByNameAndLine } from '../utils/stationLookup';
 
 // silent push는 서버가 train data 기반으로 발사하므로 라벨도 'positionTrain'으로 고정.
 // 향후 GPS 게이트 경로 등 다른 출처가 생기면 인자화 한다.
@@ -262,6 +264,30 @@ async function fireWithGate(
   payload: SilentPushPayload & { kind: NonNullable<SilentPushPayload['kind']> },
   apnsToken: string | null,
 ): Promise<void> {
+  // #707: BoardingLock 활성 시 nextWaypoint가 lock.boardingLine에 정차하는지 검증.
+  // 백엔드 SilentPushPayload(alarm-worker/src/apns.ts)는 line/expectedLine 필드를 보내지 않으므로
+  // 환승역 등에서 같은 nextWaypoint name이 여러 line stop을 가질 수 있다 — stations.json 매칭으로
+  // 다른 line stop만 존재하면 다른 leg/노선의 silent push로 판정해 차단.
+  // station name 자체가 stations.json에 없으면 line 가드는 통과시키고 일반 게이트의 unknown-station로 위임.
+  const lock = await getBoardingLock();
+  if (lock) {
+    const onBoardingLine = findStationByNameAndLine(payload.nextWaypoint, lock.boardingLine);
+    if (!onBoardingLine && findStationByName(payload.nextWaypoint)) {
+      const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
+      logSilentPushSkipped({
+        stationName: payload.nextWaypoint,
+        kind: logKind,
+        phaseId: payload.phase,
+        reason: 'lock-line-mismatch',
+      });
+      ackOutcome(payload.pushId, apnsToken, 'skipped', 'lock-line-mismatch');
+      logger.info(
+        `lock line mismatch skip: nextWaypoint=${payload.nextWaypoint} boardingLine=${lock.boardingLine}`,
+      );
+      return;
+    }
+  }
+
   const gate = await checkSilentPushLocationGate({
     stationName: payload.nextWaypoint,
     kind: payload.kind,

--- a/src/utils/__tests__/stationLookup.test.ts
+++ b/src/utils/__tests__/stationLookup.test.ts
@@ -1,4 +1,8 @@
-import { findLineByStationName, findStationByName } from '../stationLookup';
+import {
+  findLineByStationName,
+  findStationByName,
+  findStationByNameAndLine,
+} from '../stationLookup';
 
 jest.mock('../../data/stations.json', () => [
   { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.5547, lng: 126.9706 },
@@ -33,5 +37,21 @@ describe('findStationByName', () => {
 
   it('없는 역명은 null', () => {
     expect(findStationByName('없는역')).toBeNull();
+  });
+});
+
+describe('findStationByNameAndLine (#707)', () => {
+  it('환승역에서 line 일치하는 Station 반환', () => {
+    expect(findStationByNameAndLine('서울역', '1')).toMatchObject({ id: '1-001', line: '1' });
+    expect(findStationByNameAndLine('서울역', '4')).toMatchObject({ id: '4-001', line: '4' });
+  });
+
+  it('역명은 있지만 해당 line에는 정차하지 않으면 null', () => {
+    // 강남은 line 2에만 등록 — line 1로 조회하면 null.
+    expect(findStationByNameAndLine('강남', '1')).toBeNull();
+  });
+
+  it('없는 역명은 null', () => {
+    expect(findStationByNameAndLine('없는역', '2')).toBeNull();
   });
 });

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -120,6 +120,8 @@ describe('processLocationUpdate', () => {
     mockIsStationOnRoute.mockReturnValue(true);
     mockGetLastNotifiedStationId.mockResolvedValue(null);
     mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+    // 기본: lock 없음 — BG path가 GPS line을 그대로 사용 (기존 동작).
+    mockGetBoardingLock.mockResolvedValue(null);
   });
 
   it('returns null nearest and null alarm when findNearestStation returns null', async () => {
@@ -147,6 +149,48 @@ describe('processLocationUpdate', () => {
       undefined,
       expect.any(Array),
     );
+  });
+
+  describe('#707 BoardingLock line 가드 (BG path)', () => {
+    const lockOnLine7 = {
+      destinationId: 'station-2',
+      trainCode: 'T-7',
+      boardingStationId: 'station-0',
+      boardingLine: '7' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+
+    it('lock 활성이면 currentLine은 lock.boardingLine으로 강등 (raw GPS line 무시)', async () => {
+      // GPS는 환승역에서 옆 노선(line 2)으로 잘못 잠긴 상태이지만 사용자는 line 7 탑승 중.
+      mockFindNearestStation.mockReturnValue(mockNearestResult); // station.line = '2'
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetBoardingLock.mockResolvedValue(lockOnLine7);
+
+      await call();
+
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ currentLine: '7' }),
+        expect.any(Set),
+        undefined,
+        expect.any(Array),
+      );
+    });
+
+    it('lock 없으면 currentLine은 nearest.station.line 사용 (기존 동작 유지)', async () => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult); // station.line = '2'
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetBoardingLock.mockResolvedValue(null);
+
+      await call();
+
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ currentLine: '2' }),
+        expect.any(Set),
+        undefined,
+        expect.any(Array),
+      );
+    });
   });
 
   it('passes null etaSeconds when speedMps is not provided', async () => {

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -36,6 +36,8 @@ export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'gate-unknown-station' / 'gate-no-location' / 'gate-stale-location' / 'gate-out-of-range'는
 // #478 PR 1-2 silent push 위치 게이트 skip 사유.
 // 'payload-missing-kind'는 구 백엔드 payload에 kind 필드가 없어 발사 본문 결정 불가 → skip.
+// 'lock-line-mismatch'는 BoardingLock 활성 시 nextWaypoint가 lock.boardingLine에 정차하지
+// 않는 다른 leg/노선의 silent push로 판정돼 차단된 케이스 (#707).
 export type AlarmLogReason =
   | 'dedup-station'
   | 'dedup-alarm'
@@ -46,6 +48,7 @@ export type AlarmLogReason =
   | 'gate-no-location'
   | 'gate-stale-location'
   | 'gate-out-of-range'
+  | 'lock-line-mismatch'
   | 'payload-missing-kind';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';

--- a/src/utils/stationLookup.ts
+++ b/src/utils/stationLookup.ts
@@ -21,3 +21,17 @@ export function findLineByStationName(name: string): LineNumber | null {
 export function findStationByName(name: string): Station | null {
   return stations.find((s) => s.name === name) ?? null;
 }
+
+/**
+ * 역명 + 노선 정확 매칭 Station 반환 (#707).
+ * 환승역(예: 강남=line 2 & sinbundang)에서 실제 탑승 중인 노선의 stop id를 가져올 때 사용.
+ *
+ * 용도:
+ *  - BoardingLock 생성 시 boardingStationId가 train.line 기준 station id가 되도록 정정.
+ *  - silent push 게이트에서 nextWaypoint가 lock.boardingLine에 정차하는지 line-mismatch 가드.
+ *
+ * 매칭 실패(역명 없음 또는 해당 line에 정차 안 함) 시 null.
+ */
+export function findStationByNameAndLine(name: string, line: LineNumber): Station | null {
+  return stations.find((s) => s.name === name && s.line === line) ?? null;
+}

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -143,13 +143,21 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   const distanceToDestM = distanceMetersBetween(lat, lng, destination.lat, destination.lng);
   const etaSeconds = estimateEtaSeconds(distanceToDestM, speedMps);
 
+  // #707: BoardingLock 활성 시 currentLine을 lock.boardingLine으로 강등.
+  // BG path는 fusion이 없어 nearest.station.line(raw GPS 최근접)이 환승역에서 옆 노선으로
+  // 잘못 잡힐 수 있다. 사용자가 명시 탭한 lock.boardingLine을 source of truth로 신뢰 —
+  // evaluateAlarmPhase의 approachLine 게이트(#579)와 맞물려 잘못된 leg 알람 발사를 차단.
+  // lock 없으면 기존 동작(GPS line) 유지.
+  const lockForLineGuard = await getBoardingLock();
+  const currentLine = lockForLineGuard?.boardingLine ?? nearest.station.line;
+
   const suppressed: AlarmEvent[] = [];
   const alarmEvent = evaluateAlarmPhase(
     {
       route,
       destinationName: destination.name,
       etaSeconds,
-      currentLine: nearest.station.line,
+      currentLine,
     },
     firedAlarms,
     undefined,


### PR DESCRIPTION
## Summary
- 환승역(예: line N/M)에서 N호선 lock 활성 시 BG path/silent push/lock 생성 시점 모두 line 가드
- 기존 #662 FG fusion 가드를 BG/silent path까지 확장
- lock 없는 경우 기존 동작 그대로 (graceful fallback)

## Test plan
- [x] 100% 커버리지 유지
- [x] 타입체크 통과
- [x] 환승역 lock 시 BG 평가 currentLine=lock.boardingLine 검증
- [x] silent push line mismatch skip + ack 검증
- [x] lock 생성 시 station id 정정 검증

Closes #707