### PR TITLE
chore(#715): .gitignore tasks/ root 한정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,5 @@ oauth-implementation.md
 subway-now_icon.png
 
 # 로컬 작업 노트 / 데이터 덤프 (이슈/PR 본문으로 관리)
-tasks/
+/tasks/
 scripts/CARD_SUBWAY_MONTH_*.csv


### PR DESCRIPTION
## Summary
- .gitignore의 `tasks/` 패턴이 leading slash 없어 모든 경로 매치
- `src/tasks/` 신규 파일이 자동 ignore되어 `git add` 거부되는 함정 발생
- `/tasks/`로 변경하여 repo root의 분석 문서 폴더만 ignore

## Test plan
- [x] `git check-ignore src/tasks/<new>` → not ignored
- [x] `git check-ignore tasks/<file>` → still ignored (`/tasks/` 매치)
- [x] type-check 통과

Closes #715