### PR TITLE
feat(#700): TRIP_ORIGIN_KEY로 trip origin 영속화

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,7 +13,6 @@ import { useAppStore } from '../../src/store/useAppStore';
 import { useBoardingLockStore } from '../../src/store/useBoardingLockStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
-import type { Station } from '../../src/types/station';
 import { EditorialTimeline } from '../../src/components/EditorialTimeline';
 import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/journeyAdapter';
 import { useRouter } from 'expo-router';
@@ -108,7 +107,11 @@ export default function HomeScreen() {
   // useFusedNearestStation 첫 호출 시점엔 routeContext=undefined로 GPS fusion fallback,
   // 다음 렌더에서 useTripOrigin이 effectiveOrigin을 캡처해 setTripOrigin을 호출하면
   // routeContext가 채워지고 useRouteProgress(1D map matching)가 활성화된다.
-  const [tripOrigin, setTripOrigin] = useState<Station | null>(null);
+  // #700 — store SSOT로 이전. cold restart 시 loadTripOrigin이 영속값을 복원해
+  // 첫 GPS fix가 진짜 출발역과 다른 회귀를 차단한다.
+  const tripOrigin = useAppStore((s) => s.tripOrigin);
+  const setTripOrigin = useAppStore((s) => s.setTripOrigin);
+  const loadTripOrigin = useAppStore((s) => s.loadTripOrigin);
   const routeContext = useMemo(
     () => (route && tripOrigin && destination ? { route, origin: tripOrigin, destination } : undefined),
     [route, tripOrigin, destination],
@@ -132,7 +135,7 @@ export default function HomeScreen() {
   refreshRef.current = refresh;
   const isCustomOrigin = customOrigin !== null;
   const effectiveOrigin = customOrigin ?? result?.station ?? null;
-  useTripOrigin(destination, effectiveOrigin, setTripOrigin);
+  useTripOrigin(destination, effectiveOrigin, setTripOrigin, tripOrigin);
   const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(
     effectiveOrigin?.name ?? null,
     effectiveOrigin?.line ?? null,
@@ -300,7 +303,14 @@ export default function HomeScreen() {
     loadAlarmEvent();
     // iOS가 BG에서 앱을 메모리 압박으로 종료하면 Zustand 상태는 휘발되지만
     // DESTINATION_KEY는 디스크에 남는다. 콜드/웜 부팅 시 복원해 trip을 이어간다 (#541).
-    loadDestination();
+    // #700 — tripOrigin을 먼저 await으로 hydrate한 다음 destination을 set한다.
+    // 순서를 뒤집으면 destination이 먼저 truthy로 set되는 commit에서 effectiveOrigin이
+    // 캐시된 GPS로 이미 truthy → useTripOrigin capture effect가 잘못된 origin으로
+    // setter 호출 → 영속값(진짜 출발역) 덮어쓰기. 직렬화로 race를 차단한다.
+    void (async () => {
+      await loadTripOrigin();
+      await loadDestination();
+    })();
     initStationNotification().catch((e) => logger.error('알림 초기화 실패:', e));
     registerSilentPushTask().catch((e) => logger.error('silent push task 등록 실패:', e));
     const subscription = AppState.addEventListener('change', (state) => {

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -21,6 +21,11 @@ export const ALARM_LOG_KEY = 'subway-now:alarm-log';
 export const APNS_TOKEN_KEY = 'subway-now:apns-token';
 export const ACTIVE_TRIP_KEY = 'subway-now:active-trip';
 export const TRIP_TRAIN_CODE_KEY = 'subway-now:trip-train-code';
+// #700 — useTripOrigin이 destination set 순간 캡처하는 trip origin Station.
+// cold restart(앱 강제종료 후 재실행) 시 첫 GPS fix가 진짜 출발역과 다를 수 있어
+// route 계산이 잘못된 origin으로 일어나는 회귀를 막기 위해 영속화한다.
+// 형식: Station JSON. destination null 또는 새 destination set 시 클리어/재캡처.
+export const TRIP_ORIGIN_KEY = 'subway-now:trip-origin';
 // #498 — silent push 게이트 outcome 텔레메트리. 마지막 flush 시각(epoch ms).
 // 다음 flush는 이 시점 이후의 alarmLog 엔트리만 집계 → 중복 방지.
 export const TELEMETRY_LAST_FLUSH_KEY = 'subway-now:telemetry-last-flush';

--- a/src/hooks/__tests__/useTripOrigin.test.ts
+++ b/src/hooks/__tests__/useTripOrigin.test.ts
@@ -36,15 +36,16 @@ describe('useTripOrigin', () => {
     expect(setter).toHaveBeenCalledWith(stationA);
   });
 
-  it('첫 set 시 effectiveOrigin이 null이면 다음 렌더에서 lazily 캡처한다', () => {
+  it('첫 set 시 effectiveOrigin이 null이면 다음 렌더에서 lazily 캡처한다 (#700: 첫 호출에서 null setter는 영속 보호로 스킵)', () => {
     const setter = jest.fn();
     const { rerender } = renderHook(
       ({ dest, origin }: { dest: Station | null; origin: Station | null }) =>
         useTripOrigin(dest, origin, setter),
       { initialProps: { dest: stationB, origin: null } },
     );
-    expect(setter).toHaveBeenLastCalledWith(null);
-    setter.mockClear();
+    // #700 — destination이 truthy로 첫 set됐는데 effectiveOrigin이 null인 시점에
+    // setter(null)을 호출하면 hydration race로 영속값을 덮어쓸 수 있어 스킵한다.
+    expect(setter).not.toHaveBeenCalled();
     rerender({ dest: stationB, origin: stationA });
     expect(setter).toHaveBeenCalledWith(stationA);
   });
@@ -84,5 +85,95 @@ describe('useTripOrigin', () => {
     setter.mockClear();
     rerender({ dest: null, origin: stationA });
     expect(setter).toHaveBeenCalledWith(null);
+  });
+
+  // #700 — cold restart 회복: 영속화된 tripOrigin이 hydrate된 상태에서 마운트되면
+  // 첫 effect가 GPS 첫 fix(effectiveOrigin)로 덮어쓰지 않아야 한다.
+  // 그렇지 않으면 진짜 출발역과 다른 역이 origin으로 잡혀 route가 잘못 계산된다.
+  it('persistedTripOrigin이 있으면 마운트 시 effectiveOrigin으로 덮어쓰지 않는다 (cold restart hydration)', () => {
+    const setter = jest.fn();
+    // destination=stationB, 진짜 출발역=stationA(영속됨), GPS 첫 fix는 잘못된 stationC
+    renderHook(() => useTripOrigin(stationB, stationC, setter, stationA));
+    // 영속값이 있으므로 effectiveOrigin(stationC) 캡처를 스킵 — setter 미호출
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('persistedTripOrigin이 있어도 destination이 바뀌면 새 effectiveOrigin으로 재캡처한다', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ dest, origin, persisted }: { dest: Station | null; origin: Station | null; persisted: Station | null }) =>
+        useTripOrigin(dest, origin, setter, persisted),
+      { initialProps: { dest: stationB as Station | null, origin: stationA as Station | null, persisted: stationA as Station | null } },
+    );
+    setter.mockClear();
+    // destination이 stationC로 바뀜 → 영속값 무관하게 새 effectiveOrigin 캡처
+    rerender({ dest: stationC, origin: stationB, persisted: stationA });
+    expect(setter).toHaveBeenCalledWith(stationB);
+  });
+
+  it('persistedTripOrigin이 null이면 기존 캡처 로직대로 effectiveOrigin을 캡처한다', () => {
+    const setter = jest.fn();
+    // 영속값 없음 — 기존 동작 그대로
+    renderHook(() => useTripOrigin(stationB, stationA, setter, null));
+    expect(setter).toHaveBeenCalledWith(stationA);
+  });
+
+  it('persistedTripOrigin이 있어도 destination이 null이면 영속값을 무시하고 null 캡처', () => {
+    const setter = jest.fn();
+    // destination이 null인 상태에서 마운트 — 시드 조건 미충족
+    renderHook(() => useTripOrigin(null, stationA, setter, stationA));
+    // destination이 처음부터 null이므로 setter는 호출되지 않는다 (기존 noop 규칙)
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  // #700 — 진짜 race 회귀 가드: 마운트 시점엔 persisted=null(아직 hydrate 전),
+  // GPS도 아직 없음 → capture effect가 잘못 setter(null)을 보내 영속을 죽이면 안된다.
+  // 그 후 persisted가 hydrate되면 ref가 시드되어 잘못된 GPS가 와도 캡처를 스킵해야 한다.
+  it('hydration race: persisted가 늦게 hydrate돼도 영속을 덮어쓰지 않고 시드된다', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ persisted, origin }: { persisted: Station | null; origin: Station | null }) =>
+        useTripOrigin(stationB, origin, setter, persisted),
+      { initialProps: { persisted: null as Station | null, origin: null as Station | null } },
+    );
+    // 첫 렌더: persisted=null, origin=null — setter는 호출되지 않아야 함 (영속 보호)
+    expect(setter).not.toHaveBeenCalled();
+    // hydrate 완료: persisted=A로 도착
+    rerender({ persisted: stationA, origin: null });
+    // 시드만 일어나고 setter는 여전히 무호출 (이미 store에 A가 있으므로)
+    expect(setter).not.toHaveBeenCalled();
+    // 잘못된 GPS C가 도착 — 시드된 ref 덕에 캡처 스킵
+    rerender({ persisted: stationA, origin: stationC });
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('hydration race: persisted=null + effectiveOrigin null 첫 렌더 후 effectiveOrigin이 먼저 도착하면 lazy capture', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ origin }: { origin: Station | null }) =>
+        useTripOrigin(stationB, origin, setter, null),
+      { initialProps: { origin: null as Station | null } },
+    );
+    expect(setter).not.toHaveBeenCalled();
+    // persisted 없이 GPS가 먼저 도착 — lazy capture로 정상 캡처
+    rerender({ origin: stationA });
+    expect(setter).toHaveBeenCalledWith(stationA);
+  });
+
+  it('persistedTripOrigin이 시드된 후에는 다른 destination으로 바뀔 때 시드를 재적용하지 않는다', () => {
+    const setter = jest.fn();
+    const { rerender } = renderHook(
+      ({ dest, persisted }: { dest: Station | null; persisted: Station | null }) =>
+        useTripOrigin(dest, stationC, setter, persisted),
+      { initialProps: { dest: stationB as Station | null, persisted: stationA as Station | null } },
+    );
+    setter.mockClear();
+    // destination 변경 → 새 origin(stationC) 캡처
+    rerender({ dest: stationC, persisted: stationA });
+    expect(setter).toHaveBeenCalledWith(stationC);
+    setter.mockClear();
+    // persisted가 여전히 stationA지만 시드는 다시 적용되지 않음 (다른 dest)
+    rerender({ dest: stationC, persisted: stationA });
+    expect(setter).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useTripOrigin.ts
+++ b/src/hooks/useTripOrigin.ts
@@ -13,6 +13,9 @@ import type { Station } from '../types/station';
  * - destination 변경(또는 첫 set) → 그 시점의 effectiveOrigin으로 캡처
  * - 첫 캡처 시 effectiveOrigin이 아직 null이면 다음 effect에서 lazily 캡처
  * - destination이 같은 동안 effectiveOrigin이 바뀌어도 tripOrigin은 유지
+ * - #700 hydration: persistedTripOrigin이 있으면 첫 캡처를 그 값으로 갈음한다.
+ *   cold restart(앱 강제종료 후 재실행) 시 GPS 첫 fix가 진짜 출발역과 다른 경우
+ *   route가 잘못된 origin으로 계산되는 회귀를 막는다.
  *
  * setter 패턴 사용 — state 반환형보다 이 hook에서 적합한 이유:
  * routeContext가 useFusedNearestStation 호출 시점에 필요하고 tripOrigin은 그 호출 결과(effectiveOrigin)에
@@ -24,9 +27,23 @@ export function useTripOrigin(
   destination: Station | null,
   effectiveOrigin: Station | null,
   setTripOrigin: (origin: Station | null) => void,
+  persistedTripOrigin?: Station | null,
 ): void {
   const tripDestIdRef = useRef<string | null>(null);
   const tripOriginRef = useRef<Station | null>(null);
+
+  // #700 — 영속화된 origin이 store에서 hydrate되는 시점은 비동기(loadTripOrigin)다.
+  // 첫 렌더 시점엔 persistedTripOrigin이 아직 null일 수 있으므로 effect로 처리해
+  // hydrate가 완료된 시점에 ref를 시드한다. 단 이미 자체 캡처가 일어났으면(ref(origin)
+  // truthy) 시드를 스킵 — 진행 중인 trip의 origin을 stale persisted로 오염시키지 않게.
+  // hydration effect를 capture effect보다 먼저 선언해 마운트 시 시드 → 캡처 순서가
+  // 보장되도록 했다.
+  useEffect(() => {
+    if (!destination || !persistedTripOrigin) return;
+    if (tripOriginRef.current) return;
+    tripDestIdRef.current = destination.id;
+    tripOriginRef.current = persistedTripOrigin;
+  }, [destination, persistedTripOrigin]);
 
   useEffect(() => {
     const destId = destination?.id ?? null;
@@ -34,7 +51,12 @@ export function useTripOrigin(
       tripDestIdRef.current = destId;
       const next = destination ? effectiveOrigin : null;
       tripOriginRef.current = next;
-      setTripOrigin(next);
+      // #700 — destination이 truthy로 첫 set되는 순간 effectiveOrigin이 null이면
+      // setter(null)을 호출해 영속값까지 클리어해버리는 race가 있다 (loadTripOrigin이
+      // 늦게 도착하는 경우). null로의 명시적 클리어(destination null)는 그대로 보낸다.
+      if (next !== null || !destination) {
+        setTripOrigin(next);
+      }
       return;
     }
     if (destination && !tripOriginRef.current && effectiveOrigin) {

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -27,7 +27,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, tripOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false });
     jest.clearAllMocks();
   });
 
@@ -367,10 +367,13 @@ describe('useAppStore', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:destination');
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-alarms');
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:route');
+    // #700 — trip 종료 시 tripOrigin도 atomic하게 클리어
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-origin');
   });
 
   it('setDestination: AsyncStorage 실패 시에도 에러를 던지지 않는다', async () => {
     (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('저장 실패'));
+    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
     (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
     (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
 
@@ -382,6 +385,17 @@ describe('useAppStore', () => {
     setDestination(null);
     await new Promise((r) => setTimeout(r, 0));
     // 에러 없이 완료
+  });
+
+  it('setDestination(null): tripOrigin도 함께 클리어된다 (#700)', () => {
+    // tripOrigin이 trip 도중 캡처된 상태에서 trip 종료 시 stale origin이 남으면
+    // 다음 trip 시작 시 잘못된 route가 잠깐 노출된다.
+    const { setDestination, setTripOrigin } = useAppStore.getState();
+    setDestination(mockStation);
+    setTripOrigin(mockStation2);
+    expect(useAppStore.getState().tripOrigin?.id).toBe('2-021');
+    setDestination(null);
+    expect(useAppStore.getState().tripOrigin).toBeNull();
   });
 
   it('loadDestination: AsyncStorage에 저장된 목적지를 상태로 복원한다', async () => {
@@ -562,6 +576,73 @@ describe('useAppStore', () => {
 
     const { customOrigin } = useAppStore.getState();
     expect(customOrigin).toBeNull();
+  });
+
+  // #700 — tripOrigin 영속화 (cold restart 시 첫 GPS fix 회귀 차단)
+  it('초기 tripOrigin은 null이다', () => {
+    const { tripOrigin } = useAppStore.getState();
+    expect(tripOrigin).toBeNull();
+  });
+
+  it('setTripOrigin: 역을 설정하면 상태가 업데이트된다', () => {
+    const { setTripOrigin } = useAppStore.getState();
+    setTripOrigin(mockStation);
+
+    const { tripOrigin } = useAppStore.getState();
+    expect(tripOrigin?.id).toBe('2-022');
+  });
+
+  it('setTripOrigin: 역 설정 시 AsyncStorage에 저장하고 null 시 삭제한다', () => {
+    const { setTripOrigin } = useAppStore.getState();
+    setTripOrigin(mockStation);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:trip-origin',
+      JSON.stringify(mockStation),
+    );
+
+    jest.clearAllMocks();
+    setTripOrigin(null);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-origin');
+  });
+
+  it('setTripOrigin: AsyncStorage 실패 시에도 에러를 던지지 않는다', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('저장 실패'));
+    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
+
+    const { setTripOrigin } = useAppStore.getState();
+    setTripOrigin(mockStation);
+    await new Promise((r) => setTimeout(r, 0));
+
+    setTripOrigin(null);
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it('loadTripOrigin: AsyncStorage에서 영속화된 origin을 복원한다 (cold restart 회복)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockStation));
+
+    const { loadTripOrigin } = useAppStore.getState();
+    await loadTripOrigin();
+
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('subway-now:trip-origin');
+    expect(useAppStore.getState().tripOrigin?.id).toBe('2-022');
+  });
+
+  it('loadTripOrigin: AsyncStorage가 비어있으면 null을 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { loadTripOrigin } = useAppStore.getState();
+    await loadTripOrigin();
+
+    expect(useAppStore.getState().tripOrigin).toBeNull();
+  });
+
+  it('loadTripOrigin: AsyncStorage 오류 시 null을 유지한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+
+    const { loadTripOrigin } = useAppStore.getState();
+    await loadTripOrigin();
+
+    expect(useAppStore.getState().tripOrigin).toBeNull();
   });
 
   it('초기 themeMode는 auto이다', () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -7,7 +7,7 @@ function demoteSlotEntries(entries: FavoriteEntry[], role: FavoriteSlotRole): Fa
   return entries.map((f) => (f.role === role ? { ...f, role: 'general' as FavoriteRole } : f));
 }
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, TRIP_ORIGIN_KEY } from '../constants/storageKeys';
 import { clearFiredAlarms } from '../utils/notificationState';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
@@ -29,6 +29,9 @@ interface AppState {
   sleepMode: boolean;
   allowSpeaker: boolean;
   customOrigin: Station | null;
+  // #700 — useTripOrigin이 destination set 시점에 캡처한 origin. cold restart 시
+  // 첫 GPS fix가 진짜 출발역과 다른 회귀를 막기 위해 영속화한다 (TRIP_ORIGIN_KEY).
+  tripOrigin: Station | null;
   themeMode: ThemeMode;
   routePreference: RoutePreference;
   localePreference: LocalePreference;
@@ -45,6 +48,8 @@ interface AppState {
   setRecentDestination: (station: Station | null) => void;
   setCustomOrigin: (station: Station | null) => void;
   loadCustomOrigin: () => Promise<void>;
+  setTripOrigin: (station: Station | null) => void;
+  loadTripOrigin: () => Promise<void>;
   setThemeMode: (mode: ThemeMode) => Promise<void>;
   loadThemeMode: () => Promise<void>;
   setRoutePreference: (pref: RoutePreference) => Promise<void>;
@@ -70,6 +75,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   sleepMode: false,
   allowSpeaker: true,
   customOrigin: null,
+  tripOrigin: null,
   themeMode: 'auto' as ThemeMode,
   routePreference: 'optimal' as RoutePreference,
   localePreference: 'auto' as LocalePreference,
@@ -182,7 +188,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (station) {
       AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station)).catch(noop);
     } else {
+      // #700 — trip 종료 시 tripOrigin도 atomic하게 클리어. destination만 남기면
+      // 다음 trip 시작 시 stale origin이 잠깐 노출돼 route 계산이 흔들린다.
+      set({ tripOrigin: null });
       AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
+      AsyncStorage.removeItem(TRIP_ORIGIN_KEY).catch(noop);
       clearFiredAlarms().catch(noop);
       AsyncStorage.removeItem(ROUTE_KEY).catch(noop);
     }
@@ -217,6 +227,30 @@ export const useAppStore = create<AppState>((set, get) => ({
       const raw = await AsyncStorage.getItem(CUSTOM_ORIGIN_KEY);
       if (raw) {
         set({ customOrigin: JSON.parse(raw) });
+      }
+    } catch {
+      // 저장된 데이터 없음 — null 유지
+    }
+  },
+
+  // #700 — useTripOrigin이 캡처/클리어한 trip origin을 영속화.
+  // setDestination(null)은 자체적으로 tripOrigin도 클리어하므로 trip 종료 경로는
+  // 단일 진입점이지만, destination이 살아있는 동안 origin만 갱신되는 경우
+  // (캡처 / 재캡처 / lazy 캡처)는 이 액션이 단일 진입점.
+  setTripOrigin: (station: Station | null) => {
+    set({ tripOrigin: station });
+    if (station) {
+      AsyncStorage.setItem(TRIP_ORIGIN_KEY, JSON.stringify(station)).catch(noop);
+    } else {
+      AsyncStorage.removeItem(TRIP_ORIGIN_KEY).catch(noop);
+    }
+  },
+
+  loadTripOrigin: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(TRIP_ORIGIN_KEY);
+      if (raw) {
+        set({ tripOrigin: JSON.parse(raw) });
       }
     } catch {
       // 저장된 데이터 없음 — null 유지


### PR DESCRIPTION
## Summary
- 앱 강제종료 후 재실행 시 현재역이 시작점이 아니라 다른 역으로 표시되어 경로가 이상하게 보이던 회귀 fix
- 새 storage key `TRIP_ORIGIN_KEY`(`subway-now:trip-origin`) + atomic persist (`destination` 설정 시점 origin 캡쳐)
- `useTripOrigin` 보강: cold restart 시 첫 GPS fix를 origin으로 잘못 캡쳐하던 동작을 hydration effect로 차단 + `loadTripOrigin → loadDestination` await 직렬화로 race 차단

## Root cause
- `src/constants/storageKeys.ts` 전수조사 결과 trip origin 영속 key 부재
- `useTripOrigin`은 `useState` 로컬 전용 → cold restart에서 휘발
- 결과: 강종 후 재실행 시 첫 GPS fix가 진짜 출발역과 다른 역으로 origin이 캡쳐돼 route 계산이 어긋남

## 변경 요약
- `storageKeys`: `TRIP_ORIGIN_KEY` 추가
- `useAppStore`: `tripOrigin` state + `setTripOrigin/loadTripOrigin` 액션. `setDestination(null)` 시 trip origin도 atomic 클리어 (stale origin이 다음 trip 시작 시 잠깐 노출되는 것 차단)
- `useTripOrigin`: `persistedTripOrigin` 인자 추가, hydration effect로 ref 시드해 capture effect가 잘못된 GPS로 영속값 덮어쓰지 않게 함. capture effect 첫 분기에서 effectiveOrigin이 null이면 setter 호출 스킵 (영속 보호)
- `index.tsx`: 컴포넌트 로컬 `useState` 제거 → store SSOT 이전. mount 시 `loadTripOrigin → loadDestination` 순서로 await해 race window 차단

## Test plan
- [x] `npm test` 100% 커버리지 (lines/funcs/branches/statements 모두 100)
- [x] `npm run type-check` 통과
- [x] cold restart 시나리오: 영속화된 origin 복원 → route가 올바른 origin으로 계산되는지 검증
- [x] hydration race: persisted가 늦게 hydrate돼도 영속을 덮어쓰지 않고 시드되는지 검증
- [x] persisted=null + lazy capture / persisted 우선 시드 / destination 변경 시 재캡처 분기 모두 회귀 가드 추가

Closes #700