### PR TITLE
fix(#702): setDestination switch 시 부수 storage 자동 클리어

### DIFF
--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -369,10 +369,81 @@ describe('useAppStore', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:route');
   });
 
+  it('setDestination(#702): 목적지 switch 시 부수 storage(customOrigin/lock/scheduled/active-trip) 자동 클리어', () => {
+    const { setDestination } = useAppStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+
+    // 다른 역으로 switch
+    setDestination(mockStation2);
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:custom-origin');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:boarding-lock');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:scheduled-notifications');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:active-trip');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-alarms');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:route');
+  });
+
+  it('setDestination(#702): null로 클리어 시에도 부수 storage 자동 클리어', () => {
+    const { setDestination } = useAppStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+
+    setDestination(null);
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:custom-origin');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:boarding-lock');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:scheduled-notifications');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:active-trip');
+  });
+
+  it('setDestination(#702): 같은 목적지 재설정 시에는 부수 storage를 건드리지 않는다', () => {
+    const { setDestination } = useAppStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+
+    // 동일 station id 재설정 — switch 아님
+    setDestination(mockStation);
+
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:custom-origin');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:boarding-lock');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:scheduled-notifications');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:active-trip');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:fired-alarms');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:route');
+  });
+
+  it('setDestination(#702): switch 시 customOrigin 메모리 state도 null로 동기화', () => {
+    const { setDestination, setCustomOrigin } = useAppStore.getState();
+    setDestination(mockStation);
+    setCustomOrigin(mockStation2);
+    expect(useAppStore.getState().customOrigin?.id).toBe('2-021');
+
+    setDestination(mockStation2);
+
+    expect(useAppStore.getState().customOrigin).toBeNull();
+  });
+
+  it('setDestination(#702): loadDestination(hydration)은 부수 storage를 클리어하지 않는다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockStation));
+    jest.clearAllMocks();
+
+    const { loadDestination } = useAppStore.getState();
+    await loadDestination();
+
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalled();
+    expect(useAppStore.getState().destination?.id).toBe('2-022');
+  });
+
   it('setDestination: AsyncStorage 실패 시에도 에러를 던지지 않는다', async () => {
+    const setItemImpl = (AsyncStorage.setItem as jest.Mock).getMockImplementation();
+    const removeItemImpl = (AsyncStorage.removeItem as jest.Mock).getMockImplementation();
     (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('저장 실패'));
-    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
-    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
+    // setDestination(null) switch는 DESTINATION_KEY/fired/route/customOrigin/lock/scheduled/active-trip = 7 removeItem
+    for (let i = 0; i < 8; i++) {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
+    }
 
     const { setDestination } = useAppStore.getState();
     setDestination(mockStation);
@@ -381,7 +452,9 @@ describe('useAppStore', () => {
 
     setDestination(null);
     await new Promise((r) => setTimeout(r, 0));
-    // 에러 없이 완료
+    // 에러 없이 완료 — implementation 복원 (다른 테스트 영향 방지)
+    (AsyncStorage.setItem as jest.Mock).mockImplementation(setItemImpl);
+    (AsyncStorage.removeItem as jest.Mock).mockImplementation(removeItemImpl);
   });
 
   it('loadDestination: AsyncStorage에 저장된 목적지를 상태로 복원한다', async () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -7,7 +7,7 @@ function demoteSlotEntries(entries: FavoriteEntry[], role: FavoriteSlotRole): Fa
   return entries.map((f) => (f.role === role ? { ...f, role: 'general' as FavoriteRole } : f));
 }
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, BOARDING_LOCK_KEY, SCHEDULED_NOTIFICATIONS_KEY, ACTIVE_TRIP_KEY } from '../constants/storageKeys';
 import { clearFiredAlarms } from '../utils/notificationState';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
@@ -178,13 +178,29 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   setDestination: (station: Station | null) => {
+    const prev = get().destination;
+    const isSwitch = (prev?.id ?? null) !== (station?.id ?? null);
     set({ destination: station });
     if (station) {
       AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station)).catch(noop);
     } else {
       AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
+    }
+    // destination switch(목적지 자체가 바뀌었을 때) — 부수 상태/storage 자동 클리어.
+    // 같은 destination 재설정 시에는 진행 중인 trip/lock/스케줄을 유지한다.
+    // 주의: 여기서는 storage만 정리한다. BoardingLock 메모리 release 및 예약 알림 cancel은
+    // useBoardingLockController가 destinationId 변경 감지로 처리한다 (store 분리 유지).
+    if (isSwitch) {
       clearFiredAlarms().catch(noop);
       AsyncStorage.removeItem(ROUTE_KEY).catch(noop);
+      AsyncStorage.removeItem(CUSTOM_ORIGIN_KEY).catch(noop);
+      AsyncStorage.removeItem(BOARDING_LOCK_KEY).catch(noop);
+      AsyncStorage.removeItem(SCHEDULED_NOTIFICATIONS_KEY).catch(noop);
+      AsyncStorage.removeItem(ACTIVE_TRIP_KEY).catch(noop);
+      // customOrigin 메모리 상태도 동기화. (loadCustomOrigin은 hydration용이므로 영향 없음)
+      if (get().customOrigin !== null) {
+        set({ customOrigin: null });
+      }
     }
   },
 


### PR DESCRIPTION
## Summary
- `setDestination`이 실제 목적지 변경(switch) 시 `customOrigin` / `boarding-lock` / `scheduled-notifications` / `active-trip` / `fired-alarms` / `route` storage를 일괄 클리어
- 같은 목적지 재설정(`id` 동일)은 no-op — 진행 중 trip/lock 보존
- `customOrigin` 메모리 state도 동시에 null로 동기화 (UI 일관성)
- `loadDestination`(hydration)은 `set` 직접 호출이라 영향 없음 — discriminator 불필요
- BoardingLock 메모리 release 및 OS 예약 알림 cancel은 기존 `useBoardingLockController`(destinationId 변경 감지)가 담당 — store/controller 분리 유지

## 회귀 가드 시나리오
- 다른 역으로 switch → 6개 storage key removeItem 호출 확인
- null로 클리어 → 부수 storage 4개 removeItem 호출 확인
- 동일 목적지 재설정 → 부수 storage 미호출 (no-op)
- switch 시 customOrigin state null 동기화 확인
- `loadDestination`은 removeItem 호출하지 않음 (hydration 보호)
- AsyncStorage 전체 실패 케이스도 noop catch로 throw 없음

## Test plan
- [x] `npm test` — 2440 passed, coverage 100%
- [x] `npm run type-check` 통과

Closes #702