### PR TITLE
fix(#699): useStationAlarm setFiredAlarms await로 dedup race 차단

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1299,6 +1299,109 @@ describe('useStationAlarm', () => {
     });
   });
 
+  // #699: setFiredAlarms를 fire-and-forget으로 두면 다음 cycle(또는 BG silent push)이
+  // stale storage를 읽어 같은 phase를 재발사함 (실기기에서 destination 2분 차 더블 fire 캡처).
+  // fireAndLog가 setFiredAlarms를 await하는지, 그리고 같은 evaluator cycle 내에서 같은
+  // phase가 두 번 발사되지 않는지 회귀 가드한다.
+  describe('#699 setFiredAlarms await dedup', () => {
+    const route = makeDirectRoute(1, '2');
+
+    it('phase 발사 시 setFiredAlarms write 완료를 기다린 후 logFiredAlarm을 호출한다', async () => {
+      // storage write 지연을 시뮬레이션: 외부에서 release할 때까지 pending.
+      let releaseSetFired: (() => void) | undefined;
+      mockSetFiredAlarms.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          releaseSetFired = () => resolve();
+        }),
+      );
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      // setFiredAlarms는 호출되지만 아직 resolve 안 됨 → logFiredAlarm 미호출.
+      await waitFor(() => expect(mockSetFiredAlarms).toHaveBeenCalled());
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+
+      // storage write가 완료되면 그제서야 logFiredAlarm 진행.
+      releaseSetFired!();
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta'));
+    });
+
+    it('storage write 대기 중 두 번째 evaluation이 들어와도 같은 phase는 한 번만 발사된다', async () => {
+      let releaseSetFired: (() => void) | undefined;
+      mockSetFiredAlarms.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseSetFired = () => resolve();
+          }),
+      );
+      // 실제 evaluator 의미를 흉내: firedAlarms에 이미 키가 있으면 null.
+      mockEvaluateAlarmPhase.mockImplementation((_src: unknown, fired: Set<string>) =>
+        fired.has(`early:${destination.name}`) ? null : earlyDest,
+      );
+
+      const { rerender } = renderHook(
+        ({ loc }: { loc: { lat: number; lng: number } }) =>
+          useStationAlarm(
+            defaultInputs({
+              route,
+              destination,
+              userLocation: loc,
+              speedMps: 10,
+              accuracyMeters: 100,
+            }),
+          ),
+        { initialProps: { loc: { lat: 37.4, lng: 127.0 } } },
+      );
+
+      // 첫 evaluation: 발사 — setFiredAlarms 호출되었지만 pending.
+      await waitFor(() => expect(mockSetFiredAlarms).toHaveBeenCalledTimes(1));
+
+      // storage write가 아직 끝나지 않은 사이에 다음 evaluation 발생(GPS 좌표 갱신).
+      rerender({ loc: { lat: 37.401, lng: 127.001 } });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // sync firedAlarmsRef.current.add 덕분에 두 번째 evaluator는 dedup → 추가 발사 없음.
+      releaseSetFired!();
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
+      const etaCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'eta');
+      expect(etaCalls).toHaveLength(1);
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('setFiredAlarms가 reject되어도 notification은 발사된다 (영속화 실패 graceful)', async () => {
+      mockSetFiredAlarms.mockRejectedValueOnce(new Error('storage 실패'));
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta'));
+    });
+
+    it('imminent API 신호도 setFiredAlarms write 완료를 기다린 후 logFiredAlarm을 호출한다', async () => {
+      let releaseSetFired: (() => void) | undefined;
+      mockSetFiredAlarms.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          releaseSetFired = () => resolve();
+        }),
+      );
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() => expect(mockSetFiredAlarms).toHaveBeenCalled());
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+
+      releaseSetFired!();
+      await waitFor(() =>
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', imminentDest, 'api'),
+      );
+    });
+  });
+
   describe('#670/#672 첫 evaluation suppress 가드', () => {
     const route = makeDirectRoute(3, '2');
     // skipWarmupGuard 미전달 → production default(false) 적용. 첫 evaluation 보류 동작 확인.

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -70,6 +70,12 @@ export function useStationAlarm({
   skipWarmupGuard = false,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
+  // #699: firedAlarmsRef의 내용이 어느 destinationId에 속하는지 추적.
+  // destination 변경 직후엔 hydrate effect가 setFiredHydrated(false)를 호출하지만,
+  // 같은 render cycle의 ETA/API effect는 React state 전파 전이라 firedHydrated=true(stale)
+  // 클로저로 진입한다. ref id가 현재 destinationId와 다르면 stale state — phase 평가를 보류해
+  // 옛 ref로 새 destination에 잘못된 알람을 발사하는 race를 차단한다.
+  const firedAlarmsRefDestIdRef = useRef<string | null>(null);
   // #670/#672: ETA 평가 effect의 첫 trigger를 suppress.
   // fg-hydrate 직후 hydrate된 stale firedAlarms·nearestStation과 새 GPS 좌표가 동기화되기 전
   // 즉시 평가 분기로 진입하면 잘못된 phase 알람이 발사됨. 한 cycle 보류로 다음 deps 변경(좌표/
@@ -139,6 +145,7 @@ export function useStationAlarm({
       const stored = await getFiredAlarms(destinationId);
       if (cancelled) return;
       firedAlarmsRef.current = stored;
+      firedAlarmsRefDestIdRef.current = destinationId;
       // #580: hydration 시점 진단 — 같은 destinationId에서 size가 다시 0으로 떨어지면 storage race.
       logFiredAlarmsHydrate(destinationId, stored.size);
       setFiredHydrated(true);
@@ -150,12 +157,17 @@ export function useStationAlarm({
 
   // 알람 발사 + 로깅 헬퍼. ETA effect와 API 신호 effect가 동일 시퀀스를 수행하므로 통합.
   // route/destination은 호출자가 가드 후 non-null로 전달 — 함수 내부 가드 중복 제거.
-  function fireAndLog(
+  //
+  // #699: setFiredAlarms를 await — fire-and-forget이면 다음 evaluation(또는 destination
+  // 변경에 의한 re-hydrate, BG silent push의 storage read)이 stale state를 보고 같은
+  // phase를 재발사함(2분 간격 destination 더블 fire 회귀). sync ref add 직후 storage
+  // write 완료까지 기다려 FG/BG 단일 출처 일관성을 보장한다.
+  async function fireAndLog(
     rawEvent: AlarmEvent,
     trigger: 'api' | 'eta',
     activeRoute: NonNullable<Route>,
     activeDestination: Station,
-  ): void {
+  ): Promise<void> {
     // 좌/우 안내 방향. nearestStation 미정이면 direction 미부착(본문에 좌/우 라인 생략).
     const direction = nearestStation
       ? resolveAlarmDirection(rawEvent, {
@@ -165,15 +177,27 @@ export function useStationAlarm({
         })
       : undefined;
     const event = direction ? { ...rawEvent, direction } : rawEvent;
+    // sync ref add — 같은 hook 인스턴스의 다음 evaluation은 즉시 dedup됨.
     firedAlarmsRef.current.add(alarmKey(event));
-    // AsyncStorage에도 즉시 반영 — FG/BG 단일 출처 유지. destinationId scoped.
-    void setFiredAlarms(activeDestination.id, firedAlarmsRef.current);
+    // AsyncStorage write 완료까지 await — BG/재하이드레이션 race 차단(#699).
+    try {
+      await setFiredAlarms(activeDestination.id, firedAlarmsRef.current);
+    } catch (e) {
+      logger.error('firedAlarms 영속화 실패:', e);
+    }
     if (sleepModeRef.current) {
       setAlarmEvent(event);
     }
-    sendAlarmNotification(event, sleepModeRef.current, allowSpeakerRef.current, notificationSource).catch((e) =>
-      logger.error('알람 알림 실패:', e),
-    );
+    try {
+      await sendAlarmNotification(
+        event,
+        sleepModeRef.current,
+        allowSpeakerRef.current,
+        notificationSource,
+      );
+    } catch (e) {
+      logger.error('알람 알림 실패:', e);
+    }
     logFiredAlarm('fg', event, trigger);
   }
 
@@ -185,6 +209,10 @@ export function useStationAlarm({
     if (!firedHydrated) return;
 
     if (!route || !destination) return;
+
+    // #699: destination 변경 직후 firedAlarmsRef가 옛 destination 내용일 수 있다.
+    // hydrate가 완료되어 ref id가 현재 destinationId와 일치할 때까지 평가 보류.
+    if (firedAlarmsRefDestIdRef.current !== destination.id) return;
 
     // 알람 경로는 표시 경로보다 엄격한 정확도 게이트(MAX_ACCURACY_M=200m)를 적용한다.
     // useNearestStation은 지하 구간에서 정확도 1500m까지 표시용으로 수용하므로,
@@ -222,7 +250,10 @@ export function useStationAlarm({
       suppressed,
     );
     for (const event of suppressed) logSuppressedDedupAlarm('fg', event);
-    if (rawEvent) fireAndLog(rawEvent, 'eta', route, destination);
+    // #699: fireAndLog가 setFiredAlarms를 await하므로 promise를 명시적으로 흘려보낸다.
+    // sync firedAlarmsRef.current.add는 fireAndLog 내부 첫 동작이라 같은 hook 인스턴스
+    // 다음 evaluation은 await 중에도 dedup된다.
+    if (rawEvent) void fireAndLog(rawEvent, 'eta', route, destination);
   }, [
     route,
     destination?.id,
@@ -247,13 +278,18 @@ export function useStationAlarm({
   useEffect(() => {
     if (!firedHydrated) return;
     if (!route || !destination) return;
+    // #699: ETA effect와 동일 guard — destination 전환 race로 stale ref가 imminent를
+    // 잘못 발사하는 것을 차단한다.
+    if (firedAlarmsRefDestIdRef.current !== destination.id) return;
     if (!isImminentByArrivalCode(destinationArrival, trackedTrainCode)) return;
 
     const imminentKey = `imminent:${destination.name}`;
     if (firedAlarmsRef.current.has(imminentKey)) return;
 
     const rawEvent: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: destination.name };
-    fireAndLog(rawEvent, 'api', route, destination);
+    // #699: setFiredAlarms 영속화 완료를 await — silent push BG 핸들러가 같은 imminent를
+    // 재발사하지 않도록 storage가 sync된 후 다음 cycle 진입.
+    void fireAndLog(rawEvent, 'api', route, destination);
   }, [
     firedHydrated,
     route,


### PR DESCRIPTION
Closes #699

## Summary
- `fireAndLog`를 async로 전환하고 `setFiredAlarms` write 완료까지 await. fire-and-forget이면 BG silent push/destination 재하이드레이션이 stale storage를 읽어 같은 phase 알람을 2분 간격으로 재발사하는 실기기 회귀(destination early가 11:46 → 11:48 두 번 fire 캡처)를 차단.
- `firedAlarmsRefDestIdRef` 도입 — destination 전환 직후 ETA/imminent effect가 옛 destination의 ref 내용으로 새 destination 알람을 발사하는 race를 동일 가드로 차단(같은 render cycle에서 `setFiredHydrated(false)`가 클로저에 반영되지 않는 React 패턴 보완).
- `sendAlarmNotification`도 async chain 안에서 await + try/catch로 graceful 처리(이전 `.catch` 동작 보존).

## Root cause
`src/hooks/useStationAlarm.ts` 기존 `void setFiredAlarms(...)`: sync `firedAlarmsRef.current.add`로 같은 hook 인스턴스 내부 dedup은 동작하지만, 다음 cycle에서 storage를 다시 읽는 경로(BG silent push 핸들러, destination 변경 시 `getFiredAlarms` 재하이드레이션)는 write가 아직 안 끝난 storage를 읽어 빈 set으로 dedup 무효화 → 재발사.

## Test plan
- [x] `npm test` — 2439 passed, 100% coverage 유지
- [x] `npm run type-check` 통과
- [x] 회귀 가드 3건 추가:
  - phase 발사 시 setFiredAlarms write 완료를 기다린 후 logFiredAlarm 호출
  - storage write 대기 중 두 번째 evaluation이 들어와도 같은 phase는 한 번만 발사
  - imminent API 신호도 동일하게 await
  - (보조) setFiredAlarms reject 시 notification 발사 graceful
- [ ] 실기기: destination 알람 2분 차 더블 fire 회귀 미발생 확인 (TestFlight 배포 후)