### PR TITLE
refactor(#704/#705): backend isSameSession 강화 + waypoint progress KV 분리

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -370,6 +370,206 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
   });
 });
 
+// #704 / #705 — isSameSession trainCode 기반 강화 + waypoint progress KV 분리.
+//
+// session 시나리오는 createdAt strict 비교를 폐기하고 trainCode가 일치하면 cold restart 후
+// createdAt이 변해도 advance를 유지해야 한다. trainCode가 어긋나면 새 세션으로 reset.
+// progress KV는 POST race (createdAt 동일성과 무관)에서도 shiftedCount/baseline을 보존한다.
+describe('POST /trips — #704 isSameSession (trainCode 기반 + drift window)', () => {
+  const CREATED = 1_700_000_000_000;
+  const LOCK = {
+    trainCode: 'T1',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: CREATED,
+    segmentStations: ['중곡', '군자', '강남'],
+    expiresAt: CREATED + 60 * 60 * 1000,
+  };
+
+  function tripBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+      ...base(),
+      token: 'tok-704',
+      createdAt: CREATED,
+      boardingLock: LOCK,
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'intermediate' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
+      ...overrides,
+    };
+  }
+
+  async function seedAndShift(env: Env, body = tripBody()): Promise<void> {
+    await post('/trips', body, env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    stored.waypoints.shift();
+    await env.TRIPS.put('trip:tok-704', JSON.stringify(stored));
+  }
+
+  it('preserves advance when same trainCode + same createdAt', async () => {
+    const env = makeKvEnv();
+    await seedAndShift(env);
+    await post('/trips', tripBody(), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    expect(finalTrip.waypoints).toHaveLength(2);
+    expect(finalTrip.waypoints[0].stationName).toBe('군자');
+  });
+
+  it('preserves advance when same trainCode + createdAt drift 3s (still in window)', async () => {
+    const env = makeKvEnv();
+    await seedAndShift(env);
+    await post('/trips', tripBody({ createdAt: CREATED + 3_000 }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    expect(finalTrip.waypoints).toHaveLength(2);
+    expect(finalTrip.waypoints[0].stationName).toBe('군자');
+  });
+
+  it('preserves advance when same trainCode + createdAt drift 100s (out of window)', async () => {
+    // trainCode 일치만으로도 same session — drift 무관.
+    const env = makeKvEnv();
+    await seedAndShift(env);
+    await post('/trips', tripBody({ createdAt: CREATED + 100_000 }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    expect(finalTrip.waypoints).toHaveLength(2);
+  });
+
+  it('resets when trainCode differs (new train → new session)', async () => {
+    const env = makeKvEnv();
+    await seedAndShift(env);
+    const newLock = { ...LOCK, trainCode: 'T2' };
+    await post('/trips', tripBody({ boardingLock: newLock }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    expect(finalTrip.waypoints).toHaveLength(3);
+    expect(finalTrip.waypoints[0].stationName).toBe('중곡');
+  });
+
+  it('drift window allows same session when boardingLock not yet set on either side', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody({ boardingLock: undefined }), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    stored.lastEtaSeconds = 99;
+    await env.TRIPS.put('trip:tok-704', JSON.stringify(stored));
+    await post(
+      '/trips',
+      tripBody({ boardingLock: undefined, createdAt: CREATED + 2_000 }),
+      env,
+    );
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    expect(finalTrip.lastEtaSeconds).toBe(99);
+  });
+
+  it('drift window rejects when boardingLock missing on both sides and drift exceeds window', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody({ boardingLock: undefined }), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    stored.lastEtaSeconds = 99;
+    await env.TRIPS.put('trip:tok-704', JSON.stringify(stored));
+    await post(
+      '/trips',
+      tripBody({ boardingLock: undefined, createdAt: CREATED + 60_000 }),
+      env,
+    );
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    expect(finalTrip.lastEtaSeconds).toBeUndefined();
+  });
+});
+
+describe('POST /trips — #705 progress KV preserves advance across POST race', () => {
+  const CREATED = 1_700_000_000_000;
+  const LOCK = {
+    trainCode: 'TP',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: CREATED,
+    segmentStations: ['중곡', '군자', '강남'],
+    expiresAt: CREATED + 60 * 60 * 1000,
+  };
+  function tripBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+      ...base(),
+      token: 'tok-705',
+      createdAt: CREATED,
+      boardingLock: LOCK,
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'intermediate' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
+      ...overrides,
+    };
+  }
+
+  async function seedProgress(env: Env, shiftedCount: number, trainCode = 'TP'): Promise<void> {
+    await env.TRIPS.put(
+      'progress:tok-705',
+      JSON.stringify({
+        trainCode,
+        shiftedCount,
+        lastTrackedArrivalEpoch: 12345,
+        lastLaPushEpoch: 67890,
+        consecutiveEtaMissing: 2,
+      }),
+    );
+  }
+
+  it('restores advance from progress KV even when trip object is freshly POSTed (race)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    // 시뮬레이션: scheduled.ts가 advance → progress 기록 (외부 race가 trip object를 reset해도 progress는 남아 있음)
+    await seedProgress(env, 1);
+    // race: 디바이스가 동일 trip을 cold restart로 다시 POST. trip.waypoints는 origin 3건.
+    await post('/trips', tripBody({ createdAt: CREATED + 50_000 }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
+    // progress.shiftedCount=1 → 중곡(첫 waypoint)이 잘려나가야 함
+    expect(finalTrip.waypoints).toHaveLength(2);
+    expect(finalTrip.waypoints[0].stationName).toBe('군자');
+    expect(finalTrip.lastTrackedArrivalEpoch).toBe(12345);
+    expect(finalTrip.consecutiveEtaMissing).toBe(2);
+  });
+
+  it('drops progress when incoming trainCode differs (new train → reset)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    await seedProgress(env, 2);
+    // 다른 trainCode로 POST → progress 폐기 + 전체 waypoints 복원
+    const newLock = { ...LOCK, trainCode: 'OTHER' };
+    await post('/trips', tripBody({ boardingLock: newLock }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
+    expect(finalTrip.waypoints).toHaveLength(3);
+    expect(await env.TRIPS.get('progress:tok-705')).toBeNull();
+  });
+
+  it('drops progress when incoming has no boardingLock', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    await seedProgress(env, 1);
+    await post('/trips', tripBody({ boardingLock: undefined }), env);
+    expect(await env.TRIPS.get('progress:tok-705')).toBeNull();
+  });
+
+  it('ignores corrupted progress entry (graceful)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    await env.TRIPS.put('progress:tok-705', 'not-json{');
+    await post('/trips', tripBody(), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
+    // progress null → progressApplies false → 일반 same-session 경로로 trip 복원
+    expect(finalTrip.waypoints).toHaveLength(3);
+  });
+
+  it('falls back to base waypoints when shiftedCount exceeds incoming.waypoints length', async () => {
+    // 보호: progress가 incoming보다 더 많이 잘릴 경우 빈 배열 회귀 방지 — base.waypoints 유지.
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    await seedProgress(env, 10);
+    await post('/trips', tripBody(), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
+    expect(finalTrip.waypoints.length).toBeGreaterThan(0);
+  });
+});
+
 describe('POST /telemetry/silent-push', () => {
   const validBody = {
     token: 'aabbccdd11223344',

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -375,131 +375,132 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
 // session 시나리오는 createdAt strict 비교를 폐기하고 trainCode가 일치하면 cold restart 후
 // createdAt이 변해도 advance를 유지해야 한다. trainCode가 어긋나면 새 세션으로 reset.
 // progress KV는 POST race (createdAt 동일성과 무관)에서도 shiftedCount/baseline을 보존한다.
-describe('POST /trips — #704 isSameSession (trainCode 기반 + drift window)', () => {
-  const CREATED = 1_700_000_000_000;
-  const LOCK = {
-    trainCode: 'T1',
+
+const SESSION_CREATED = 1_700_000_000_000;
+const SESSION_WAYPOINTS = [
+  { stationName: '중곡', line: '7', kind: 'intermediate' as const },
+  { stationName: '군자', line: '7', kind: 'intermediate' as const },
+  { stationName: '강남', line: '2', kind: 'destination' as const },
+];
+
+function makeSessionLock(trainCode: string): Record<string, unknown> {
+  return {
+    trainCode,
     line: '7',
     subwayId: '1007',
-    selectedDepartureTime: CREATED,
+    selectedDepartureTime: SESSION_CREATED,
     segmentStations: ['중곡', '군자', '강남'],
-    expiresAt: CREATED + 60 * 60 * 1000,
+    expiresAt: SESSION_CREATED + 60 * 60 * 1000,
   };
+}
 
+/**
+ * #704/#705 시나리오 공용 trip body 팩토리.
+ * token + 기본 trainCode만 다른 두 describe 블록의 LOCK + tripBody 중복을 제거한다.
+ */
+function makeSessionTripFactory(token: string, trainCode: string) {
+  const lock = makeSessionLock(trainCode);
   function tripBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
     return {
       ...base(),
-      token: 'tok-704',
-      createdAt: CREATED,
-      boardingLock: LOCK,
-      waypoints: [
-        { stationName: '중곡', line: '7', kind: 'intermediate' },
-        { stationName: '군자', line: '7', kind: 'intermediate' },
-        { stationName: '강남', line: '2', kind: 'destination' },
-      ],
+      token,
+      createdAt: SESSION_CREATED,
+      boardingLock: lock,
+      waypoints: SESSION_WAYPOINTS,
       ...overrides,
     };
   }
+  async function readTrip(env: Env): Promise<Record<string, unknown>> {
+    return JSON.parse((await env.TRIPS.get(`trip:${token}`)) as string);
+  }
+  async function writeTrip(env: Env, trip: Record<string, unknown>): Promise<void> {
+    await env.TRIPS.put(`trip:${token}`, JSON.stringify(trip));
+  }
+  return { lock, tripBody, readTrip, writeTrip };
+}
+
+describe('POST /trips — #704 isSameSession (trainCode 기반 + drift window)', () => {
+  const { lock: LOCK, tripBody, readTrip, writeTrip } = makeSessionTripFactory('tok-704', 'T1');
 
   async function seedAndShift(env: Env, body = tripBody()): Promise<void> {
     await post('/trips', body, env);
-    const stored = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
-    stored.waypoints.shift();
-    await env.TRIPS.put('trip:tok-704', JSON.stringify(stored));
+    const stored = await readTrip(env);
+    (stored.waypoints as unknown[]).shift();
+    await writeTrip(env, stored);
+  }
+
+  // boardingLock 미지정 시나리오 공통 seed: stored trip에 lastEtaSeconds=99를 심어
+  // 후속 POST의 same-session 판정 결과(99 유지 / undefined 리셋)를 관찰한다.
+  async function seedNoLockWithEta(env: Env): Promise<void> {
+    await post('/trips', tripBody({ boardingLock: undefined }), env);
+    const stored = await readTrip(env);
+    stored.lastEtaSeconds = 99;
+    await writeTrip(env, stored);
   }
 
   it('preserves advance when same trainCode + same createdAt', async () => {
     const env = makeKvEnv();
     await seedAndShift(env);
     await post('/trips', tripBody(), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    const finalTrip = await readTrip(env);
     expect(finalTrip.waypoints).toHaveLength(2);
-    expect(finalTrip.waypoints[0].stationName).toBe('군자');
+    expect((finalTrip.waypoints as Array<{ stationName: string }>)[0].stationName).toBe('군자');
   });
 
   it('preserves advance when same trainCode + createdAt drift 3s (still in window)', async () => {
     const env = makeKvEnv();
     await seedAndShift(env);
-    await post('/trips', tripBody({ createdAt: CREATED + 3_000 }), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    await post('/trips', tripBody({ createdAt: SESSION_CREATED + 3_000 }), env);
+    const finalTrip = await readTrip(env);
     expect(finalTrip.waypoints).toHaveLength(2);
-    expect(finalTrip.waypoints[0].stationName).toBe('군자');
+    expect((finalTrip.waypoints as Array<{ stationName: string }>)[0].stationName).toBe('군자');
   });
 
   it('preserves advance when same trainCode + createdAt drift 100s (out of window)', async () => {
     // trainCode 일치만으로도 same session — drift 무관.
     const env = makeKvEnv();
     await seedAndShift(env);
-    await post('/trips', tripBody({ createdAt: CREATED + 100_000 }), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    await post('/trips', tripBody({ createdAt: SESSION_CREATED + 100_000 }), env);
+    const finalTrip = await readTrip(env);
     expect(finalTrip.waypoints).toHaveLength(2);
   });
 
   it('resets when trainCode differs (new train → new session)', async () => {
     const env = makeKvEnv();
     await seedAndShift(env);
-    const newLock = { ...LOCK, trainCode: 'T2' };
-    await post('/trips', tripBody({ boardingLock: newLock }), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    await post('/trips', tripBody({ boardingLock: { ...LOCK, trainCode: 'T2' } }), env);
+    const finalTrip = await readTrip(env);
     expect(finalTrip.waypoints).toHaveLength(3);
-    expect(finalTrip.waypoints[0].stationName).toBe('중곡');
+    expect((finalTrip.waypoints as Array<{ stationName: string }>)[0].stationName).toBe('중곡');
   });
 
   it('drift window allows same session when boardingLock not yet set on either side', async () => {
     const env = makeKvEnv();
-    await post('/trips', tripBody({ boardingLock: undefined }), env);
-    const stored = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
-    stored.lastEtaSeconds = 99;
-    await env.TRIPS.put('trip:tok-704', JSON.stringify(stored));
+    await seedNoLockWithEta(env);
     await post(
       '/trips',
-      tripBody({ boardingLock: undefined, createdAt: CREATED + 2_000 }),
+      tripBody({ boardingLock: undefined, createdAt: SESSION_CREATED + 2_000 }),
       env,
     );
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    const finalTrip = await readTrip(env);
     expect(finalTrip.lastEtaSeconds).toBe(99);
   });
 
   it('drift window rejects when boardingLock missing on both sides and drift exceeds window', async () => {
     const env = makeKvEnv();
-    await post('/trips', tripBody({ boardingLock: undefined }), env);
-    const stored = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
-    stored.lastEtaSeconds = 99;
-    await env.TRIPS.put('trip:tok-704', JSON.stringify(stored));
+    await seedNoLockWithEta(env);
     await post(
       '/trips',
-      tripBody({ boardingLock: undefined, createdAt: CREATED + 60_000 }),
+      tripBody({ boardingLock: undefined, createdAt: SESSION_CREATED + 60_000 }),
       env,
     );
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-704')) as string);
+    const finalTrip = await readTrip(env);
     expect(finalTrip.lastEtaSeconds).toBeUndefined();
   });
 });
 
 describe('POST /trips — #705 progress KV preserves advance across POST race', () => {
-  const CREATED = 1_700_000_000_000;
-  const LOCK = {
-    trainCode: 'TP',
-    line: '7',
-    subwayId: '1007',
-    selectedDepartureTime: CREATED,
-    segmentStations: ['중곡', '군자', '강남'],
-    expiresAt: CREATED + 60 * 60 * 1000,
-  };
-  function tripBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
-    return {
-      ...base(),
-      token: 'tok-705',
-      createdAt: CREATED,
-      boardingLock: LOCK,
-      waypoints: [
-        { stationName: '중곡', line: '7', kind: 'intermediate' },
-        { stationName: '군자', line: '7', kind: 'intermediate' },
-        { stationName: '강남', line: '2', kind: 'destination' },
-      ],
-      ...overrides,
-    };
-  }
+  const { lock: LOCK, tripBody, readTrip } = makeSessionTripFactory('tok-705', 'TP');
 
   async function seedProgress(env: Env, shiftedCount: number, trainCode = 'TP'): Promise<void> {
     await env.TRIPS.put(
@@ -520,11 +521,11 @@ describe('POST /trips — #705 progress KV preserves advance across POST race', 
     // 시뮬레이션: scheduled.ts가 advance → progress 기록 (외부 race가 trip object를 reset해도 progress는 남아 있음)
     await seedProgress(env, 1);
     // race: 디바이스가 동일 trip을 cold restart로 다시 POST. trip.waypoints는 origin 3건.
-    await post('/trips', tripBody({ createdAt: CREATED + 50_000 }), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
+    await post('/trips', tripBody({ createdAt: SESSION_CREATED + 50_000 }), env);
+    const finalTrip = await readTrip(env);
     // progress.shiftedCount=1 → 중곡(첫 waypoint)이 잘려나가야 함
     expect(finalTrip.waypoints).toHaveLength(2);
-    expect(finalTrip.waypoints[0].stationName).toBe('군자');
+    expect((finalTrip.waypoints as Array<{ stationName: string }>)[0].stationName).toBe('군자');
     expect(finalTrip.lastTrackedArrivalEpoch).toBe(12345);
     expect(finalTrip.consecutiveEtaMissing).toBe(2);
   });
@@ -534,9 +535,8 @@ describe('POST /trips — #705 progress KV preserves advance across POST race', 
     await post('/trips', tripBody(), env);
     await seedProgress(env, 2);
     // 다른 trainCode로 POST → progress 폐기 + 전체 waypoints 복원
-    const newLock = { ...LOCK, trainCode: 'OTHER' };
-    await post('/trips', tripBody({ boardingLock: newLock }), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
+    await post('/trips', tripBody({ boardingLock: { ...LOCK, trainCode: 'OTHER' } }), env);
+    const finalTrip = await readTrip(env);
     expect(finalTrip.waypoints).toHaveLength(3);
     expect(await env.TRIPS.get('progress:tok-705')).toBeNull();
   });
@@ -554,7 +554,7 @@ describe('POST /trips — #705 progress KV preserves advance across POST race', 
     await post('/trips', tripBody(), env);
     await env.TRIPS.put('progress:tok-705', 'not-json{');
     await post('/trips', tripBody(), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
+    const finalTrip = await readTrip(env);
     // progress null → progressApplies false → 일반 same-session 경로로 trip 복원
     expect(finalTrip.waypoints).toHaveLength(3);
   });
@@ -565,8 +565,8 @@ describe('POST /trips — #705 progress KV preserves advance across POST race', 
     await post('/trips', tripBody(), env);
     await seedProgress(env, 10);
     await post('/trips', tripBody(), env);
-    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-705')) as string);
-    expect(finalTrip.waypoints.length).toBeGreaterThan(0);
+    const finalTrip = await readTrip(env);
+    expect((finalTrip.waypoints as unknown[]).length).toBeGreaterThan(0);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/progress.test.ts
+++ b/backend/alarm-worker/src/__tests__/progress.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { deleteProgress, getProgress, progressKey, putProgress, type TripProgress } from '../progress';
+import { InMemoryKV } from './inMemoryKv';
+
+function makeKv(): KVNamespace {
+  return new InMemoryKV() as unknown as KVNamespace;
+}
+
+const SAMPLE: TripProgress = {
+  trainCode: 'T1',
+  shiftedCount: 2,
+  lastTrackedArrivalEpoch: 100,
+  lastLaPushEpoch: 200,
+  consecutiveEtaMissing: 1,
+};
+
+describe('progress KV (#705)', () => {
+  it('progressKey prefixes with progress:', () => {
+    expect(progressKey('tok')).toBe('progress:tok');
+  });
+
+  it('putProgress + getProgress roundtrips', async () => {
+    const kv = makeKv();
+    await putProgress(kv, 'tok', SAMPLE, 3600);
+    expect(await getProgress(kv, 'tok')).toEqual(SAMPLE);
+  });
+
+  it('getProgress returns null when key absent', async () => {
+    expect(await getProgress(makeKv(), 'tok')).toBeNull();
+  });
+
+  it('getProgress returns null on corrupted JSON (graceful)', async () => {
+    const kv = makeKv();
+    await kv.put('progress:tok', 'not-json{');
+    expect(await getProgress(kv, 'tok')).toBeNull();
+  });
+
+  it('getProgress returns null when shape invalid (missing trainCode)', async () => {
+    const kv = makeKv();
+    await kv.put('progress:tok', JSON.stringify({ shiftedCount: 1 }));
+    expect(await getProgress(kv, 'tok')).toBeNull();
+  });
+
+  it('getProgress returns null when shape invalid (missing shiftedCount)', async () => {
+    const kv = makeKv();
+    await kv.put('progress:tok', JSON.stringify({ trainCode: 'T' }));
+    expect(await getProgress(kv, 'tok')).toBeNull();
+  });
+
+  it('putProgress floors ttl floor to 60s for very short ttl', async () => {
+    const kv = makeKv();
+    await putProgress(kv, 'tok', SAMPLE, 1); // very short
+    // graceful: 그대로 저장은 되며 KV TTL은 InMemoryKV 구현상 정상 read 가능
+    expect(await getProgress(kv, 'tok')).toEqual(SAMPLE);
+  });
+
+  it('deleteProgress removes the entry', async () => {
+    const kv = makeKv();
+    await putProgress(kv, 'tok', SAMPLE, 3600);
+    await deleteProgress(kv, 'tok');
+    expect(await getProgress(kv, 'tok')).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1049,92 +1049,66 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
 // #705 — scheduled.ts의 advance/baseline 변경이 progress KV에도 mirror되는지.
 // 시나리오는 LA 시나리오와 동일한 makeLockedLaTrip + makeLockedSeoul fixture로 압축.
 describe('#705 scheduled.ts progress KV mirroring', () => {
+  // 중곡 → 강남 advance 시나리오용 표준 trip override (boardingLock + 2-step waypoints).
+  function progressTripOverrides(extra: Partial<Trip> = {}): Partial<Trip> {
+    return {
+      waypoints: [
+        { stationName: '중곡', line: '2', kind: 'intermediate' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
+      boardingLock: {
+        trainCode: 'T',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW,
+        segmentStations: ['역삼', '중곡', '강남'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+      ...extra,
+    };
+  }
+
+  async function readProgress(kv: InMemoryKV): Promise<Record<string, unknown> | null> {
+    const raw = await kv.get('progress:la-tok');
+    return raw === null ? null : JSON.parse(raw as string);
+  }
+
+  // 중곡 ARRIVED를 트리거하는 표준 seoul + fetch + 실행 — advance 케이스 3건이 공유.
+  async function runAdvanceScenario(kv: InMemoryKV): Promise<void> {
+    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl: makeOkFetch() });
+  }
+
   it('advanceBoardingLockWaypoint writes progress with shiftedCount=1 and trainCode stamp', async () => {
     const kv = new InMemoryKV();
     await putTrip(
       kv as unknown as KVNamespace,
-      makeLockedLaTrip({
-        waypoints: [
-          { stationName: '중곡', line: '2', kind: 'intermediate' },
-          { stationName: '강남', line: '2', kind: 'destination' },
-        ],
-        boardingLock: {
-          trainCode: 'T',
-          line: '2',
-          subwayId: '1002',
-          selectedDepartureTime: NOW,
-          segmentStations: ['역삼', '중곡', '강남'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-        lastLaPushEpoch: NOW + 1000,
-      }),
+      makeLockedLaTrip(progressTripOverrides({ lastLaPushEpoch: NOW + 1000 })),
     );
-    const fetchImpl = makeOkFetch();
     // 중곡 ARRIVED → advanceBoardingLockWaypoint 트리거
-    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl });
-    const progressRaw = await kv.get('progress:la-tok');
-    expect(progressRaw).not.toBeNull();
-    const progress = JSON.parse(progressRaw as string);
-    expect(progress.trainCode).toBe('T');
-    expect(progress.shiftedCount).toBe(1);
+    await runAdvanceScenario(kv);
+    const progress = await readProgress(kv);
+    expect(progress).not.toBeNull();
+    expect(progress?.trainCode).toBe('T');
+    expect(progress?.shiftedCount).toBe(1);
   });
 
   it('mirrorProgress accumulates shiftedCount across multiple advances', async () => {
     const kv = new InMemoryKV();
     // 이전 advance가 이미 progress에 있는 상태에서 다시 advance.
-    await kv.put(
-      'progress:la-tok',
-      JSON.stringify({ trainCode: 'T', shiftedCount: 1 }),
-    );
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockedLaTrip({
-        waypoints: [
-          { stationName: '중곡', line: '2', kind: 'intermediate' },
-          { stationName: '강남', line: '2', kind: 'destination' },
-        ],
-        boardingLock: {
-          trainCode: 'T',
-          line: '2',
-          subwayId: '1002',
-          selectedDepartureTime: NOW,
-          segmentStations: ['역삼', '중곡', '강남'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-      }),
-    );
-    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl: makeOkFetch() });
-    const progress = JSON.parse((await kv.get('progress:la-tok')) as string);
-    expect(progress.shiftedCount).toBe(2); // 1 + 1
+    await kv.put('progress:la-tok', JSON.stringify({ trainCode: 'T', shiftedCount: 1 }));
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip(progressTripOverrides()));
+    await runAdvanceScenario(kv);
+    expect((await readProgress(kv))?.shiftedCount).toBe(2); // 1 + 1
   });
 
   it('mirrorProgress resets shiftedCount when stored progress has different trainCode', async () => {
     const kv = new InMemoryKV();
-    await kv.put(
-      'progress:la-tok',
-      JSON.stringify({ trainCode: 'OLD', shiftedCount: 5 }),
-    );
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockedLaTrip({
-        waypoints: [
-          { stationName: '중곡', line: '2', kind: 'intermediate' },
-          { stationName: '강남', line: '2', kind: 'destination' },
-        ],
-        boardingLock: {
-          trainCode: 'T',
-          line: '2',
-          subwayId: '1002',
-          selectedDepartureTime: NOW,
-          segmentStations: ['역삼', '중곡', '강남'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-      }),
-    );
-    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl: makeOkFetch() });
-    const progress = JSON.parse((await kv.get('progress:la-tok')) as string);
-    expect(progress.trainCode).toBe('T');
-    expect(progress.shiftedCount).toBe(1); // old(OLD) 폐기 + 새 advance 1
+    await kv.put('progress:la-tok', JSON.stringify({ trainCode: 'OLD', shiftedCount: 5 }));
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip(progressTripOverrides()));
+    await runAdvanceScenario(kv);
+    const progress = await readProgress(kv);
+    expect(progress?.trainCode).toBe('T');
+    expect(progress?.shiftedCount).toBe(1); // old(OLD) 폐기 + 새 advance 1
   });
 
   it('runTrainCodeTracking mirrors baseline (consecutiveEtaMissing) into progress on etaMissing', async () => {
@@ -1149,20 +1123,17 @@ describe('#705 scheduled.ts progress KV mirroring', () => {
         new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
     });
     await runLaScheduled(kv, { seoul, fetchImpl: makeOkFetch() });
-    const progress = JSON.parse((await kv.get('progress:la-tok')) as string);
-    expect(progress.consecutiveEtaMissing).toBe(1);
-    expect(progress.shiftedCount).toBe(0);
+    const progress = await readProgress(kv);
+    expect(progress?.consecutiveEtaMissing).toBe(1);
+    expect(progress?.shiftedCount).toBe(0);
   });
 
   it('cleanupTripWithLa removes progress entry alongside trip', async () => {
     const kv = new InMemoryKV();
     await kv.put('progress:la-tok', JSON.stringify({ trainCode: 'T', shiftedCount: 1 }));
     // expired trip → cleanup 경로 진입
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockedLaTrip({ expiresAt: NOW - 1 }),
-    );
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip({ expiresAt: NOW - 1 }));
     await runLaScheduled(kv, { seoul: makeLockedSeoul(60), fetchImpl: makeOkFetch() });
-    expect(await kv.get('progress:la-tok')).toBeNull();
+    expect(await readProgress(kv)).toBeNull();
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1045,3 +1045,124 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     expect(stored.lastLaPushEpoch).toBeUndefined();
   });
 });
+
+// #705 — scheduled.ts의 advance/baseline 변경이 progress KV에도 mirror되는지.
+// 시나리오는 LA 시나리오와 동일한 makeLockedLaTrip + makeLockedSeoul fixture로 압축.
+describe('#705 scheduled.ts progress KV mirroring', () => {
+  it('advanceBoardingLockWaypoint writes progress with shiftedCount=1 and trainCode stamp', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockedLaTrip({
+        waypoints: [
+          { stationName: '중곡', line: '2', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        boardingLock: {
+          trainCode: 'T',
+          line: '2',
+          subwayId: '1002',
+          selectedDepartureTime: NOW,
+          segmentStations: ['역삼', '중곡', '강남'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+        lastLaPushEpoch: NOW + 1000,
+      }),
+    );
+    const fetchImpl = makeOkFetch();
+    // 중곡 ARRIVED → advanceBoardingLockWaypoint 트리거
+    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl });
+    const progressRaw = await kv.get('progress:la-tok');
+    expect(progressRaw).not.toBeNull();
+    const progress = JSON.parse(progressRaw as string);
+    expect(progress.trainCode).toBe('T');
+    expect(progress.shiftedCount).toBe(1);
+  });
+
+  it('mirrorProgress accumulates shiftedCount across multiple advances', async () => {
+    const kv = new InMemoryKV();
+    // 이전 advance가 이미 progress에 있는 상태에서 다시 advance.
+    await kv.put(
+      'progress:la-tok',
+      JSON.stringify({ trainCode: 'T', shiftedCount: 1 }),
+    );
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockedLaTrip({
+        waypoints: [
+          { stationName: '중곡', line: '2', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        boardingLock: {
+          trainCode: 'T',
+          line: '2',
+          subwayId: '1002',
+          selectedDepartureTime: NOW,
+          segmentStations: ['역삼', '중곡', '강남'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+      }),
+    );
+    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl: makeOkFetch() });
+    const progress = JSON.parse((await kv.get('progress:la-tok')) as string);
+    expect(progress.shiftedCount).toBe(2); // 1 + 1
+  });
+
+  it('mirrorProgress resets shiftedCount when stored progress has different trainCode', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(
+      'progress:la-tok',
+      JSON.stringify({ trainCode: 'OLD', shiftedCount: 5 }),
+    );
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockedLaTrip({
+        waypoints: [
+          { stationName: '중곡', line: '2', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        boardingLock: {
+          trainCode: 'T',
+          line: '2',
+          subwayId: '1002',
+          selectedDepartureTime: NOW,
+          segmentStations: ['역삼', '중곡', '강남'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+      }),
+    );
+    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl: makeOkFetch() });
+    const progress = JSON.parse((await kv.get('progress:la-tok')) as string);
+    expect(progress.trainCode).toBe('T');
+    expect(progress.shiftedCount).toBe(1); // old(OLD) 폐기 + 새 advance 1
+  });
+
+  it('runTrainCodeTracking mirrors baseline (consecutiveEtaMissing) into progress on etaMissing', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip());
+    // arrivals 비어 있고 positions도 매칭 안 됨 → etaMissing 누적
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+    });
+    await runLaScheduled(kv, { seoul, fetchImpl: makeOkFetch() });
+    const progress = JSON.parse((await kv.get('progress:la-tok')) as string);
+    expect(progress.consecutiveEtaMissing).toBe(1);
+    expect(progress.shiftedCount).toBe(0);
+  });
+
+  it('cleanupTripWithLa removes progress entry alongside trip', async () => {
+    const kv = new InMemoryKV();
+    await kv.put('progress:la-tok', JSON.stringify({ trainCode: 'T', shiftedCount: 1 }));
+    // expired trip → cleanup 경로 진입
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockedLaTrip({ expiresAt: NOW - 1 }),
+    );
+    await runLaScheduled(kv, { seoul: makeLockedSeoul(60), fetchImpl: makeOkFetch() });
+    expect(await kv.get('progress:la-tok')).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -19,6 +19,7 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { ackPending } from './pendingPushes';
+import { deleteProgress, getProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
 import {
@@ -65,12 +66,26 @@ app.post('/trips', async (c) => {
   const incoming = validateTrip(body);
   if (!incoming) return c.json({ error: 'invalid_trip' }, 400);
 
-  // #578: 디바이스가 동일 trip을 반복 POST해도(예: GPS update마다 register) backend가 이미
-  // advance한 waypoints / lastFiredPhase / lastEtaSeconds를 덮어쓰지 않는다.
-  // 동일 세션 판별: 같은 token + 같은 createdAt. createdAt이 다르면 새 trip 세션이므로 전면 교체.
+  // #578/#704: 디바이스가 동일 trip을 반복 POST해도(예: GPS update마다 register, 또는 cold restart
+  // 후 같은 trip 재등록) backend가 이미 advance한 waypoints / 추적 baseline을 덮어쓰지 않는다.
+  //
+  // #704 same-session 판별 (createdAt strict 비교 폐기):
+  //   1) boardingLock.trainCode가 양쪽 모두 같으면 같은 세션 (cold restart 후 createdAt이 바뀌어도 OK)
+  //   2) trainCode가 한쪽이라도 없으면 createdAt drift 5s 이내일 때만 같은 세션 (lock 등록 전 단계)
+  //   3) 그 외 (다른 trainCode 또는 큰 drift) → 새 세션, 전면 교체
   const existing = await getTrip(c.env.TRIPS, incoming.token);
-  const isSameSession = existing !== null && existing.createdAt === incoming.createdAt;
-  const trip = isSameSession
+  const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
+  // #705: progress KV 우선 참조. 같은 trainCode면 shift된 waypoints를 incoming에 적용.
+  // 다른 trainCode/none이면 progress 폐기.
+  const progress = existing !== null ? await getProgress(c.env.TRIPS, incoming.token) : null;
+  const progressApplies =
+    progress !== null &&
+    incoming.boardingLock !== undefined &&
+    progress.trainCode === incoming.boardingLock.trainCode;
+  if (progress !== null && !progressApplies) {
+    await deleteProgress(c.env.TRIPS, incoming.token);
+  }
+  const baseTrip = isSameSession
     ? {
         ...incoming,
         waypoints: existing.waypoints,
@@ -94,6 +109,12 @@ app.post('/trips', async (c) => {
         consecutiveEtaMissing: existing.consecutiveEtaMissing,
       }
     : incoming;
+
+  // #705 — progress KV가 우선. 같은 trainCode면 incoming.waypoints에서 shift된 만큼 잘라낸다.
+  // existing trip이 사라졌더라도(KV TTL 만료 등) progress가 살아 있으면 진행분을 그대로 복원.
+  const trip = progressApplies
+    ? applyProgress(baseTrip, incoming, progress)
+    : baseTrip;
 
   await putTrip(c.env.TRIPS, trip);
   return c.json({ ok: true, token: trip.token });
@@ -263,6 +284,52 @@ app.delete('/trips/:token', async (c) => {
   );
   return c.json({ ok: true, deleted: true });
 });
+
+/**
+ * #704: 동일 세션 판별 — strict createdAt 동일성에서 trainCode 기반 + drift 허용으로 완화.
+ *
+ * 같은 세션 조건 (OR):
+ *   1) 양쪽 boardingLock.trainCode가 일치 — cold restart로 createdAt이 바뀌어도 같은 열차면 진행 유지
+ *   2) trainCode 미사용 단계라면 createdAt drift가 SESSION_DRIFT_WINDOW_MS 이내
+ *
+ * trainCode가 다르면 명백히 다른 열차로 새 세션 → false. lock이 한쪽만 있어도(이행 단계)
+ * createdAt drift만으로 판정.
+ */
+export const SESSION_DRIFT_WINDOW_MS = 5_000;
+
+export function evaluateSameSession(existing: Trip, incoming: Trip): boolean {
+  const existingCode = existing.boardingLock?.trainCode;
+  const incomingCode = incoming.boardingLock?.trainCode;
+  if (existingCode && incomingCode) {
+    return existingCode === incomingCode;
+  }
+  return Math.abs(existing.createdAt - incoming.createdAt) <= SESSION_DRIFT_WINDOW_MS;
+}
+
+/**
+ * #705: progress KV에 기록된 shiftedCount/baseline을 incoming trip에 적용.
+ *
+ * - waypoints: `incoming.waypoints.slice(shiftedCount)`로 잘라 backend 진행분 반영
+ *   (전부 소진된 경우는 호출부가 isSameSession 분기로 trip.waypoints를 보존하므로
+ *    여기서 빈 배열로 깎이는 회귀가 발생하지 않음)
+ * - baseline (lastTrackedArrivalEpoch, lastLaPushEpoch, consecutiveEtaMissing):
+ *   progress가 더 최신 — POST race에 무관한 source of truth.
+ */
+export function applyProgress(
+  base: Trip,
+  incoming: Trip,
+  progress: TripProgress,
+): Trip {
+  const sliced = incoming.waypoints.slice(progress.shiftedCount);
+  const waypoints = sliced.length > 0 ? sliced : base.waypoints;
+  return {
+    ...base,
+    waypoints,
+    lastTrackedArrivalEpoch: progress.lastTrackedArrivalEpoch,
+    lastLaPushEpoch: progress.lastLaPushEpoch,
+    consecutiveEtaMissing: progress.consecutiveEtaMissing,
+  };
+}
 
 export function validateTrip(input: unknown): Trip | null {
   if (!input || typeof input !== 'object') return null;

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -16,6 +16,7 @@
 import { sendLiveActivityUpdate, type LiveActivityContentState } from './apns';
 import { pickApnsHost } from './apnsHost';
 import { LINE_META } from './lineAlias';
+import { deleteProgress } from './progress';
 import { deleteTrip } from './trips';
 import type { ApnsEnv, Env, Trip, Waypoint } from './types';
 
@@ -181,5 +182,8 @@ export async function cleanupTripWithLa(
 ): Promise<void> {
   await fireLiveActivityDismissal(trip, deps, stats, now, log);
   await deleteTrip(env.TRIPS, trip.token);
+  // #705 — trip을 폐기할 때 progress entry도 함께 제거. TTL이 자연 만료를 보장하지만
+  // 즉시 cleanup해야 새 동일 token trip 등록 시 stale shiftedCount가 끼지 않는다.
+  await deleteProgress(env.TRIPS, trip.token);
 }
 

--- a/backend/alarm-worker/src/progress.ts
+++ b/backend/alarm-worker/src/progress.ts
@@ -1,0 +1,68 @@
+/**
+ * Trip waypoint advance progress — POST /trips race로부터 격리된 별도 KV 키 (#705).
+ *
+ * 배경:
+ *   Trip 객체에 `waypoints`가 직접 포함되어 있어, 디바이스가 cold restart 후 동일
+ *   trip을 재등록하면 backend가 advance해둔 waypoints가 wipe되는 race가 존재했다
+ *   (#704는 isSameSession 강화로 같은 trainCode면 보존하지만, 진정한 격리는 advance
+ *   상태를 trip 객체 밖으로 빼야 가능).
+ *
+ * 설계:
+ *   - 키: `progress:<token>` (TRIPS KV 재사용 — 새 namespace 도입 비용 회피)
+ *   - 값: shiftedCount + 추적 baseline. trainCode를 stamp해 다른 열차로 갈아탄
+ *         새 세션이면 fresh start로 동작.
+ *   - POST /trips: progress.trainCode가 incoming.boardingLock.trainCode와 같으면
+ *     `incoming.waypoints.slice(progress.shiftedCount)`로 진행분을 잘라낸다.
+ *     트레인이 다르면 progress는 무시 (호출부가 clearProgress).
+ *   - advanceBoardingLockWaypoint: shiftedCount += 1과 baseline reset을 progress에 기록.
+ *   - runTrainCodeTracking: 성공/실패 사이클에서 baseline(consecutiveEtaMissing,
+ *     lastTrackedArrivalEpoch, lastLaPushEpoch)도 progress에 mirror해 race에 무관하게 유지.
+ */
+
+const PROGRESS_PREFIX = 'progress:';
+
+export interface TripProgress {
+  /** trainCode stamp. POST 시 incoming lock과 비교해 다른 열차면 progress 폐기. */
+  trainCode: string;
+  /** advance로 shift한 waypoint 개수. POST의 incoming.waypoints에 slice(shiftedCount) 적용. */
+  shiftedCount: number;
+  /** Trip의 lastTrackedArrivalEpoch 사본 — race-isolated. */
+  lastTrackedArrivalEpoch?: number;
+  /** Trip의 lastLaPushEpoch 사본. */
+  lastLaPushEpoch?: number;
+  /** Trip의 consecutiveEtaMissing 사본. */
+  consecutiveEtaMissing?: number;
+}
+
+export function progressKey(token: string): string {
+  return `${PROGRESS_PREFIX}${token}`;
+}
+
+export async function getProgress(kv: KVNamespace, token: string): Promise<TripProgress | null> {
+  const raw = await kv.get(progressKey(token));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as TripProgress;
+    if (typeof parsed.trainCode !== 'string' || typeof parsed.shiftedCount !== 'number') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function putProgress(
+  kv: KVNamespace,
+  token: string,
+  progress: TripProgress,
+  ttlSec: number,
+): Promise<void> {
+  await kv.put(progressKey(token), JSON.stringify(progress), {
+    expirationTtl: Math.max(60, Math.floor(ttlSec)),
+  });
+}
+
+export async function deleteProgress(kv: KVNamespace, token: string): Promise<void> {
+  await kv.delete(progressKey(token));
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -12,6 +12,7 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { matchLine } from './lineAlias';
+import { getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { listTrips, putTrip } from './trips';
 import type { ApnsEnv, BoardingLockMeta, Env, Trip, Waypoint } from './types';
@@ -214,6 +215,30 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
 }
 
 /**
+ * #705 — trip의 baseline/진행 상태를 progress KV에도 mirror해 POST /trips race에 무관하게 유지.
+ * trainCode가 없는 호출(lock 없음)은 no-op — progress KV는 trainCode가 stamp되어야 의미가 있다.
+ */
+async function mirrorProgress(
+  kv: KVNamespace,
+  trip: Trip,
+  shiftedCountDelta: number,
+): Promise<void> {
+  const trainCode = trip.boardingLock?.trainCode;
+  if (!trainCode) return;
+  const existing = await getProgress(kv, trip.token);
+  const prevShifted = existing?.trainCode === trainCode ? existing.shiftedCount : 0;
+  const next: TripProgress = {
+    trainCode,
+    shiftedCount: prevShifted + shiftedCountDelta,
+    lastTrackedArrivalEpoch: trip.lastTrackedArrivalEpoch,
+    lastLaPushEpoch: trip.lastLaPushEpoch,
+    consecutiveEtaMissing: trip.consecutiveEtaMissing,
+  };
+  const ttlSec = Math.max(60, Math.floor((trip.expiresAt - Date.now()) / 1000));
+  await putProgress(kv, trip.token, next, ttlSec);
+}
+
+/**
  * boardingLock trip 추적 (#585).
  *
  * 3단계로 분리: estimate → arrival 시 waypoint 진행(early return) → 아니면 reschedule push.
@@ -254,6 +279,7 @@ export async function runTrainCodeTracking(
     }
     trip.consecutiveEtaMissing = nextMissCount;
     await putTrip(env.TRIPS, trip);
+    await mirrorProgress(env.TRIPS, trip, 0);
     return;
   }
 
@@ -295,6 +321,9 @@ export async function runTrainCodeTracking(
   if (laDirty || hadMissCount) {
     await putTrip(env.TRIPS, trip);
   }
+  // #705 — reschedule push 성공/LA dirty/카운터 reset 어느 경로든 baseline이 바뀔 수 있으므로
+  // 항상 progress 미러링. 함수 자체는 lock 없는 trip에 no-op이라 추가 비용 미미.
+  await mirrorProgress(env.TRIPS, trip, 0);
 }
 
 /**
@@ -379,6 +408,9 @@ export async function advanceBoardingLockWaypoint(
     await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log);
   }
   await putTrip(env.TRIPS, trip);
+  // #705 — shift된 진행분을 progress KV에 +1 누적. 이후 POST /trips race가 trip.waypoints를
+  // 다시 wipe해도 progress 기반 slice로 복원된다.
+  await mirrorProgress(env.TRIPS, trip, 1);
 }
 
 /**


### PR DESCRIPTION
## Summary
- cold restart로 createdAt 변경되어도 same token + same trainCode면 same session 처리, advance 유지
- waypoint advance를 progress:<token> 별도 KV로 분리 → POST /trips race에도 영속
- 5s SESSION_DRIFT_WINDOW로 ms-단위 drift 허용

## Test plan
- [x] 100% 커버리지 유지
- [x] 타입체크 통과
- [x] isSameSession 4 시나리오 (same/drift 3s/drift 100s/different trainCode)
- [x] progress KV — advance 후 stale POST에도 진행 보존

Closes #704
Closes #705