### PR TITLE
fix(#701): in-flight Promise dedup으로 POST /trips race 차단

### DIFF
--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -203,6 +203,81 @@ describe('alarmBackend', () => {
         expect(body.boardingLock).toBeUndefined();
       });
 
+      it('#701 in-flight dedup: 동일 페이로드 동시 호출 시 fetch는 1번만 발사된다', async () => {
+        let resolveFetch: ((v: Response) => void) | null = null;
+        (global.fetch as jest.Mock).mockImplementationOnce(
+          () =>
+            new Promise<Response>((resolve) => {
+              resolveFetch = resolve;
+            }),
+        );
+
+        // 같은 ms에 3개 발사 (await 없이 Promise만 받기) — Cloudflare 로그 시나리오 재현.
+        const p1 = registerActiveTrip(SAMPLE_PAYLOAD);
+        const p2 = registerActiveTrip(SAMPLE_PAYLOAD);
+        const p3 = registerActiveTrip(SAMPLE_PAYLOAD);
+
+        // 첫 fetch 미해결 상태에서도 모두 동일 Promise를 공유해야 함.
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        resolveFetch!({ ok: true, status: 200 } as Response);
+        const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+        expect(r1).toEqual({ ok: true, status: 200 });
+        expect(r2).toEqual({ ok: true, status: 200 });
+        expect(r3).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('#701 in-flight 완료 후 lastRegisteredHash가 정상 set되어 후속 호출은 skipped', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        const followup = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(followup).toEqual({ ok: true, skipped: true });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('#701 다른 sessionKey 동시 호출은 병렬로 진행된다', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+        const p1 = registerActiveTrip(SAMPLE_PAYLOAD);
+        const p2 = registerActiveTrip({ ...SAMPLE_PAYLOAD, destination: '0229' });
+        const [r1, r2] = await Promise.all([p1, p2]);
+        expect(r1.ok).toBe(true);
+        expect(r2.ok).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('#701 in-flight 실패 시 후속 호출은 재시도 가능 (in-flight Map 정리)', async () => {
+        (global.fetch as jest.Mock)
+          .mockRejectedValueOnce(new Error('network'))
+          .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+        const first = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(first).toEqual({ ok: false });
+        const retry = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(retry).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('#701 clearActiveTrip 호출 시 in-flight Map까지 비워진다', async () => {
+        let resolveFetch: ((v: Response) => void) | null = null;
+        (global.fetch as jest.Mock).mockImplementationOnce(
+          () =>
+            new Promise<Response>((resolve) => {
+              resolveFetch = resolve;
+            }),
+        );
+        const p1 = registerActiveTrip(SAMPLE_PAYLOAD);
+        // clear 도중에도 in-flight Map은 비워져야 한다.
+        (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+        await clearActiveTrip('token-hex');
+        // pending register는 stale로 남지만 새 register 호출은 새 Promise를 만들어야 함.
+        (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+        const p2 = registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(p1).not.toBe(p2);
+        // resolve 원래 fetch
+        resolveFetch!({ ok: true, status: 200 } as Response);
+        await Promise.all([p1, p2]);
+      });
+
       it('URL 미설정 → 설정 사이클에서도 dedup이 stale state를 남기지 않는다', async () => {
         // URL 미설정으로 skip된 호출은 lastRegisteredHash를 건드리지 않아야 한다.
         delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -94,6 +94,17 @@ const ALARM_TIME_BUCKET_MS = 60 * 1000;
  */
 let lastRegisteredHash: string | null = null;
 
+/**
+ * In-flight register Promise dedup (#701).
+ *
+ * `lastRegisteredHash`만으로는 hash check ↔ fetch resolve 사이 round-trip 동안
+ * 동일 hash의 register가 동시 발사되면 모두 hash 미일치로 통과해 POST /trips가
+ * race로 폭주한다 (Cloudflare 로그: 같은 ms에 3개 도착). 모듈 레벨 Map에 hash →
+ * in-flight Promise를 보관해 같은 hash의 동시 호출은 첫 Promise를 공유한다.
+ * 완료 시 entry는 제거되고 결과는 `lastRegisteredHash`에 기록된다.
+ */
+const inFlightRegisters = new Map<string, Promise<AlarmBackendResult>>();
+
 function buildRegisterHash(body: {
   token: string;
   route: NonNullable<Route>;
@@ -118,9 +129,10 @@ function buildRegisterHash(body: {
   });
 }
 
-/** 테스트용 — 모듈 dedup 상태 초기화. */
+/** 테스트용 — 모듈 dedup 상태 초기화 (완료 캐시 + in-flight Map). */
 export function __resetAlarmBackendDedup(): void {
   lastRegisteredHash = null;
+  inFlightRegisters.clear();
 }
 
 function getBackendUrl(): string | null {
@@ -139,32 +151,11 @@ async function fetchWithTimeout(input: string, init: RequestInit): Promise<Respo
   }
 }
 
-/**
- * 활성 트립을 등록한다. 백엔드 URL이 없거나 호출이 실패해도 throw하지 않고
- * `{ok:false}`를 반환 — 알람 사전 예약(#334)은 그대로 동작한다.
- */
-export async function registerActiveTrip(
+async function performRegisterFetch(
+  base: string,
   payload: RegisterTripPayload,
+  hash: string,
 ): Promise<AlarmBackendResult> {
-  const base = getBackendUrl();
-  if (!base) {
-    log.info('ALARM_BACKEND_URL not set — skip register');
-    return { ok: false, skipped: true };
-  }
-
-  const hash = buildRegisterHash({
-    token: payload.token,
-    route: payload.route,
-    destination: payload.destination,
-    waypoints: payload.waypoints,
-    alarmAtEpochMs: payload.alarmAtEpochMs,
-    apnsEnv: payload.apnsEnv,
-    boardingLock: payload.boardingLock,
-  });
-  if (hash === lastRegisteredHash) {
-    return { ok: true, skipped: true };
-  }
-
   const createdAt = payload.createdAt ?? Date.now();
   const expiresAt = payload.expiresAt ?? createdAt + DEFAULT_TRIP_TTL_MS;
   const body = {
@@ -196,6 +187,50 @@ export async function registerActiveTrip(
     log.warn('register error', e);
     return { ok: false };
   }
+}
+
+/**
+ * 활성 트립을 등록한다. 백엔드 URL이 없거나 호출이 실패해도 throw하지 않고
+ * `{ok:false}`를 반환 — 알람 사전 예약(#334)은 그대로 동작한다.
+ *
+ * Dedup 2-layer (#581, #701):
+ *   1) `lastRegisteredHash` — 직전 성공 register의 hash와 동일하면 즉시 skip.
+ *   2) `inFlightRegisters` — 같은 hash로 이미 fetch 중이면 그 Promise를 공유 (race 차단).
+ */
+export function registerActiveTrip(
+  payload: RegisterTripPayload,
+): Promise<AlarmBackendResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip register');
+    return Promise.resolve({ ok: false, skipped: true });
+  }
+
+  const hash = buildRegisterHash({
+    token: payload.token,
+    route: payload.route,
+    destination: payload.destination,
+    waypoints: payload.waypoints,
+    alarmAtEpochMs: payload.alarmAtEpochMs,
+    apnsEnv: payload.apnsEnv,
+    boardingLock: payload.boardingLock,
+  });
+  if (hash === lastRegisteredHash) {
+    return Promise.resolve({ ok: true, skipped: true });
+  }
+
+  // 같은 hash로 이미 in-flight fetch가 있으면 그 Promise를 그대로 반환 — TOCTOU race
+  // (hash check ↔ fetch resolve 사이 동시 호출)로 POST /trips가 동시 발사되는 것을 차단.
+  const pending = inFlightRegisters.get(hash);
+  if (pending) {
+    return pending;
+  }
+
+  const promise = performRegisterFetch(base, payload, hash).finally(() => {
+    inFlightRegisters.delete(hash);
+  });
+  inFlightRegisters.set(hash, promise);
+  return promise;
 }
 
 /**
@@ -241,8 +276,10 @@ export async function sendPushAck(payload: PushAckPayload): Promise<AlarmBackend
 export async function clearActiveTrip(token: string): Promise<AlarmBackendResult> {
   // 트립 종료 후 동일 트립을 다시 시작할 수 있도록 dedup 캐시를 초기화한다.
   // URL 미설정/네트워크 실패 경로에서도 초기화해야 클라이언트가 register dedup에
-  // 의도치 않게 갇히지 않는다.
+  // 의도치 않게 갇히지 않는다. in-flight Promise까지 비워야 clear 직후 register가
+  // 이전 Promise를 재사용하지 않는다.
   lastRegisteredHash = null;
+  inFlightRegisters.clear();
 
   const base = getBackendUrl();
   if (!base) {


### PR DESCRIPTION
## Summary
- 같은 millisecond에 `POST /trips`가 3개 동시 발사되는 race를 모듈 레벨 in-flight Promise Map으로 차단 (Cloudflare 로그 측정 증거)
- Root cause: 기존 `lastRegisteredHash` dedup은 hash check ↔ fetch resolve 사이 round-trip 동안 동일 hash의 register가 동시 발사되면 모두 통과해 race 발생
- Fix: `inFlightRegisters = Map<hash, Promise<AlarmBackendResult>>` 도입 — pending Promise 있으면 fetch 시작 없이 공유, 완료 시 entry 제거 + `lastRegisteredHash` 기록 (in-flight 추적과 완료 캐시 분리)
- `useApnsTripRegistration`의 main effect와 `addPushTokenListener` IIFE 양쪽이 같은 dedup map을 공유 (alarmBackend 모듈 레벨이므로 자동)
- `clearActiveTrip` + `__resetAlarmBackendDedup`에서 in-flight Map까지 비움

## 변경 라인
- `src/api/alarmBackend.ts` (+89 / -26): `inFlightRegisters` Map, `performRegisterFetch` helper 추출, `registerActiveTrip` 재구성, clear 시 Map 비움
- `src/api/__tests__/alarmBackend.test.ts` (+75): in-flight race / 다른 sessionKey 병렬 / in-flight 실패 후 재시도 / clear 시 Map 비움 / lastRegisteredHash 정상 set 케이스

## Test plan
- [x] `npm test` — 2471 tests pass, coverage 100%
- [x] `npm run type-check` — clean
- [x] 동시 호출 (3개) 시 fetch 1번만 발사 검증
- [x] 다른 destination 동시 호출 시 병렬 진행 검증
- [x] in-flight 실패 시 후속 호출 재시도 가능 검증
- [ ] 실기기: 같은 ms `POST /trips` 중복 사라지는지 Cloudflare 로그 재확인

Closes #701