### PR TITLE
fix(#708/#710): scheduler route 변경 cancel + advanceHopWindow canonical resolve

### DIFF
--- a/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -31,6 +31,16 @@ jest.mock('../../utils/logger', () => ({
 const mockedSchedule = scheduleHopsForLock as jest.MockedFunction<typeof scheduleHopsForLock>;
 const mockedCancel = cancelAllHopsForLock as jest.MockedFunction<typeof cancelAllHopsForLock>;
 
+type SchedulerProps = Parameters<typeof useBoardingLockScheduler>[0];
+
+function renderScheduler(initialProps: SchedulerProps) {
+  return renderHook((props: SchedulerProps) => useBoardingLockScheduler(props), { initialProps });
+}
+
+async function awaitFirstSchedule() {
+  await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+}
+
 const lockA: BoardingLock = {
   destinationId: 'd',
   trainCode: 'A',
@@ -76,11 +86,7 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('lock 신규 생성(null → A): schedule만', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: null, route, destinationName: '강남' } },
-    );
+    const { rerender } = renderScheduler({ lock: null, route, destinationName: '강남' });
     rerender({ lock: lockA, route, destinationName: '강남' });
     await waitFor(() => {
       expect(mockedSchedule).toHaveBeenCalledTimes(1);
@@ -89,12 +95,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('lock 교체(A → B): A cancel 후 B schedule', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: lockB, route, destinationName: '강남' });
     await waitFor(() => {
       expect(mockedCancel).toHaveBeenCalledWith(lockA);
@@ -109,12 +111,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('lock 해제(A → null): cancel만, schedule 추가 없음', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: null, route, destinationName: '강남' });
     await waitFor(() => {
       expect(mockedCancel).toHaveBeenCalledWith(lockA);
@@ -123,12 +121,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('같은 trainCode로 객체만 갱신되면 재호출 안 함', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: { ...lockA }, route, destinationName: '강남' });
     // wait one tick
     await new Promise((r) => setTimeout(r, 0));
@@ -137,12 +131,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('lock 있지만 route 또는 destinationName 미상이면 cancel만 호출 (이전 lock 있을 때)', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: lockB, route: null, destinationName: '강남' });
     await waitFor(() => expect(mockedCancel).toHaveBeenCalledWith(lockA));
     expect(mockedSchedule).toHaveBeenCalledTimes(1);
@@ -182,12 +172,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('#632 sleepMode 토글은 effect를 재실행시키지 않는다 (ref capture)', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     useAppStore.setState({ sleepMode: true });
     rerender({ lock: lockA, route, destinationName: '강남' });
     await new Promise((r) => setTimeout(r, 0));
@@ -198,11 +184,7 @@ describe('useBoardingLockScheduler', () => {
   // effect가 돌면서 early-return 되어 영구히 schedule 되지 않는 문제. 사전 예약 알람이
   // 살아 있지 않으면 잠금화면/Focus 발사가 통째로 누락된다.
   it('#709 cold restart: lock 먼저 복원되고 route 늦게 로드돼도 schedule 1회 보장', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route: null, destinationName: '강남' } },
-    );
+    const { rerender } = renderScheduler({ lock: lockA, route: null, destinationName: '강남' });
     // 1차: lock 있지만 route=null → schedule 호출 안 됨이 정상
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedSchedule).not.toHaveBeenCalled();
@@ -221,11 +203,7 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('#709 cold restart: destinationName 늦게 들어와도 schedule 1회 보장', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: null as string | null } },
-    );
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: null as string | null });
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedSchedule).not.toHaveBeenCalled();
     rerender({ lock: lockA, route, destinationName: '강남' });
@@ -235,12 +213,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('#709 schedule 성공 후 동일 props 재렌더는 중복 호출 없음', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: lockA, route, destinationName: '강남' });
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedSchedule).toHaveBeenCalledTimes(1);
@@ -256,12 +230,8 @@ describe('useBoardingLockScheduler', () => {
       stopsToTransfer: 2,
       stopsFromTransfer: 3,
     });
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: lockA, route: altRoute, destinationName: '강남' });
     await waitFor(() => {
       expect(mockedCancel).toHaveBeenCalledWith(lockA);
@@ -276,12 +246,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('#708 같은 trainCode + destinationName 변경 시 cancel 후 reschedule', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: lockA, route, destinationName: '잠실' });
     await waitFor(() => {
       expect(mockedCancel).toHaveBeenCalledWith(lockA);
@@ -291,12 +257,8 @@ describe('useBoardingLockScheduler', () => {
 
   it('#708 route signature 동일 (객체만 새로 생성) → 재예약 없음', async () => {
     const sameShape = makeDirectRoute(2, '2');
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: lockA, route: sameShape, destinationName: '강남' });
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedSchedule).toHaveBeenCalledTimes(1);
@@ -304,12 +266,8 @@ describe('useBoardingLockScheduler', () => {
   });
 
   it('#709 lock release 후 같은 trainCode로 재진입하면 다시 schedule 한다', async () => {
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
-        useBoardingLockScheduler(props),
-      { initialProps: { lock: lockA, route, destinationName: '강남' } },
-    );
-    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
     rerender({ lock: null, route, destinationName: '강남' });
     await waitFor(() => expect(mockedCancel).toHaveBeenCalledWith(lockA));
     rerender({ lock: lockA, route, destinationName: '강남' });

--- a/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -6,12 +6,18 @@ import {
 } from '../../utils/boardingLockScheduler';
 import type { BoardingLock } from '../../types/boardingLock';
 import { useAppStore } from '../../store/useAppStore';
-import { makeDirectRoute } from '../../testUtils/routeFixtures';
+import { makeDirectRoute, makeTransferRoute } from '../../testUtils/routeFixtures';
 
-jest.mock('../../utils/boardingLockScheduler', () => ({
-  scheduleHopsForLock: jest.fn(),
-  cancelAllHopsForLock: jest.fn(),
-}));
+jest.mock('../../utils/boardingLockScheduler', () => {
+  const actual = jest.requireActual('../../utils/boardingLockScheduler');
+  return {
+    scheduleHopsForLock: jest.fn(),
+    cancelAllHopsForLock: jest.fn(),
+    // routeSignature는 실제 구현을 그대로 사용 — hook이 이 결과로 변경 감지를 하므로
+    // mocking하면 트레이드가 의미를 잃는다.
+    routeSignature: actual.routeSignature,
+  };
+});
 const mockLoggerError = jest.fn();
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
@@ -238,6 +244,63 @@ describe('useBoardingLockScheduler', () => {
     rerender({ lock: lockA, route, destinationName: '강남' });
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  // #708 같은 trainCode 안에서 route/destination이 바뀌면 사전 예약된 hop이 stale 상태가 된다.
+  // signature 비교로 cancel → reschedule을 강제한다.
+  it('#708 같은 trainCode + route 구조 변경 시 cancel 후 reschedule', async () => {
+    const altRoute = makeTransferRoute({
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    });
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockA, route: altRoute, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedCancel).toHaveBeenCalledWith(lockA);
+      expect(mockedSchedule).toHaveBeenCalledTimes(2);
+      expect(mockedSchedule).toHaveBeenLastCalledWith({
+        lock: lockA,
+        route: altRoute,
+        destinationName: '강남',
+        sleepMode: false,
+      });
+    });
+  });
+
+  it('#708 같은 trainCode + destinationName 변경 시 cancel 후 reschedule', async () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockA, route, destinationName: '잠실' });
+    await waitFor(() => {
+      expect(mockedCancel).toHaveBeenCalledWith(lockA);
+      expect(mockedSchedule).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('#708 route signature 동일 (객체만 새로 생성) → 재예약 없음', async () => {
+    const sameShape = makeDirectRoute(2, '2');
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useBoardingLockScheduler>[0]) =>
+        useBoardingLockScheduler(props),
+      { initialProps: { lock: lockA, route, destinationName: '강남' } },
+    );
+    await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockA, route: sameShape, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSchedule).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).not.toHaveBeenCalled();
   });
 
   it('#709 lock release 후 같은 trainCode로 재진입하면 다시 schedule 한다', async () => {

--- a/src/hooks/useBoardingLockScheduler.ts
+++ b/src/hooks/useBoardingLockScheduler.ts
@@ -3,6 +3,7 @@ import type { BoardingLock } from '../types/boardingLock';
 import type { Route } from '../utils/stationRoute';
 import {
   cancelAllHopsForLock,
+  routeSignature,
   scheduleHopsForLock,
 } from '../utils/boardingLockScheduler';
 import { createLogger } from '../utils/logger';
@@ -37,6 +38,10 @@ export function useBoardingLockScheduler({
   // 늦게 로드되는 케이스에서, 같은 trainCode라도 schedule이 아직 안 일어났다면 한 번은 보장.
   // trainCode를 기록해 release 후 같은 trainCode 재진입 시 다시 schedule할 수 있게 한다.
   const scheduledTrainCodeRef = useRef<string | null>(null);
+  // #708 같은 trainCode 안에서도 route/destination이 바뀌면 사전 예약된 hop이 stale이 되어
+  // 잘못된 역에서 알람이 발사된다. scheduled 시점의 signature를 기억해 차이가 생기면
+  // cancel → reschedule 한다.
+  const scheduledRouteSigRef = useRef<string | null>(null);
   // 이미 예약된 알람은 sleep 토글에 영향받지 않는 trade-off — 토글 기반 재예약이 요구되면 별도 이슈.
   const sleepModeRef = useSleepModeRef();
 
@@ -45,20 +50,35 @@ export function useBoardingLockScheduler({
     const prevTrain = prev?.trainCode ?? null;
     const nextTrain = lock?.trainCode ?? null;
     const canSchedule = lock !== null && route !== null && destinationName !== null;
+    const nextSig = routeSignature(route, destinationName);
     // 같은 trainCode인데도 schedule을 보장해야 하는 cold-restart 케이스:
     // 직전 effect에서 route/destination이 미완비라 schedule을 건너뛰었고, 지금은 ready.
     const needsColdRestartSchedule =
       canSchedule && scheduledTrainCodeRef.current !== nextTrain;
+    // #708 trainCode는 동일하지만 route/destination 구조가 변해 hop 시퀀스가 달라졌다.
+    // 사전 예약을 한 번 비우고 새 signature로 다시 예약한다.
+    const needsRouteChangeReschedule =
+      canSchedule &&
+      scheduledTrainCodeRef.current === nextTrain &&
+      scheduledRouteSigRef.current !== null &&
+      scheduledRouteSigRef.current !== nextSig;
 
-    if (prevTrain === nextTrain && !needsColdRestartSchedule) {
-      // 같은 trainCode(또는 둘 다 null)이고 이미 해당 trainCode로 schedule 완료 — 재예약 없음.
+    if (
+      prevTrain === nextTrain &&
+      !needsColdRestartSchedule &&
+      !needsRouteChangeReschedule
+    ) {
+      // 같은 trainCode이고 schedule도 최신 — 재예약 없음.
       prevLockRef.current = lock;
       return;
     }
 
     const handleTransition = async (): Promise<void> => {
-      // prev가 있고 trainCode가 실제로 바뀐 경우에만 cancel (cold-restart 보강 시엔 cancel 불필요).
-      if (prev && prevTrain !== nextTrain) {
+      // prev가 있고 (trainCode 변경 OR route signature 변경)인 경우에만 cancel.
+      // cold-restart(같은 trainCode + 이전엔 미예약)는 cancel할 게 없으므로 skip.
+      const shouldCancelPrev =
+        prev !== null && (prevTrain !== nextTrain || needsRouteChangeReschedule);
+      if (shouldCancelPrev && prev) {
         await cancelAllHopsForLock(prev);
       }
       if (canSchedule) {
@@ -69,9 +89,11 @@ export function useBoardingLockScheduler({
           sleepMode: sleepModeRef.current,
         });
         scheduledTrainCodeRef.current = nextTrain;
+        scheduledRouteSigRef.current = nextSig;
       } else if (nextTrain === null) {
         // lock release — 다음 lock 진입 시 같은 trainCode라도 다시 schedule 가능하도록 reset.
         scheduledTrainCodeRef.current = null;
+        scheduledRouteSigRef.current = null;
       }
     };
     handleTransition().catch((e: unknown) => {

--- a/src/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/utils/__tests__/boardingLockScheduler.test.ts
@@ -6,6 +6,7 @@ import {
   cancelAllHopsForLock,
   parseBoardingLockAlarmIdentifier,
   purgeBoardingLockSchedulerQueue,
+  routeSignature,
   scheduleHopsForLock,
 } from '../boardingLockScheduler';
 import {
@@ -495,5 +496,53 @@ describe('advanceHopWindow', () => {
       expect(ids).toContain('bl:T-100:1:early:오금');
       expect(ids).toContain('bl:T-100:1:imminent:오금');
     });
+  });
+
+  // #710: 호출자가 raw GPS station.name(노선별 부제 포함)을 넘겨도 canonical resolve.
+  it('#710 passedStationName이 노선별 부제 포함이어도 정규화 매칭으로 advance', async () => {
+    // multiRoute targets[0].name = '교대'. raw GPS가 '교대(법원·검찰청)' 등으로 들어오는 케이스.
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:교대']);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대(법원·검찰청)',
+    });
+    // 매칭됐다면 hopIndex=0 cancel이 발생한다 — 매칭 실패였다면 no-op.
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:교대');
+  });
+});
+
+describe('routeSignature', () => {
+  it('route=null이면 null', () => {
+    expect(routeSignature(null, '강남')).toBeNull();
+  });
+
+  it('destinationName=null이면 null', () => {
+    expect(routeSignature(directRoute, null)).toBeNull();
+  });
+
+  it('같은 구조의 다른 객체는 동일 signature', () => {
+    const a = makeDirectRoute(2, '2');
+    const b = makeDirectRoute(2, '2');
+    expect(routeSignature(a, '강남')).toBe(routeSignature(b, '강남'));
+  });
+
+  it('stops가 다르면 signature 다름', () => {
+    const a = makeDirectRoute(2, '2');
+    const b = makeDirectRoute(3, '2');
+    expect(routeSignature(a, '강남')).not.toBe(routeSignature(b, '강남'));
+  });
+
+  it('환승 추가되면 signature 다름', () => {
+    expect(routeSignature(directRoute, '강남')).not.toBe(
+      routeSignature(transferRoute, '오금'),
+    );
+  });
+
+  it('destinationName이 다르면 signature 다름', () => {
+    expect(routeSignature(directRoute, '강남')).not.toBe(
+      routeSignature(directRoute, '잠실'),
+    );
   });
 });

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -2,7 +2,7 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
 import { resolveAllTargets, type AlarmEvent, type CurrentTarget } from './stationAlarm';
-import type { Route } from './stationRoute';
+import { isSameStationName, type Route } from './stationRoute';
 import { buildAlarmContent } from './stationNotification';
 import type { BoardingLock } from '../types/boardingLock';
 import {
@@ -301,7 +301,10 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   } = params;
 
   const allTargets = resolveAllTargets(route, destinationName);
-  const passedIndex = allTargets.findIndex((t) => t.name === passedStationName);
+  // #710: 호출자가 raw GPS station.name(노선별 부제 포함)을 전달해도 silent miss(no-op)되지
+  // 않도록 정규화 비교한다. resolveAllTargets는 canonical name을 반환하므로 매칭만 안전하게
+  // 흡수하면 된다 — 이후 schedule/identifier는 그대로 canonical name을 사용한다.
+  const passedIndex = allTargets.findIndex((t) => isSameStationName(t.name, passedStationName));
   if (passedIndex === -1) return;
 
   const current = await getScheduledNotificationIds();
@@ -356,4 +359,20 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   logger.info(
     `advanced lock ${lock.trainCode}: cancelled ${toCancel.length}, scheduled ${scheduledIds.length}`,
   );
+}
+
+/**
+ * #708: route + destinationName이 만드는 hop 시퀀스의 구조적 signature.
+ *
+ * 같은 trainCode 안에서도 환승 경로 재산정/목적지 변경/노선 갈아탐으로 waypoint가 달라지면
+ * 사전 예약된 알람은 stale이 되어 잘못된 역에서 발사된다. signature가 바뀌면 호출자(scheduler
+ * hook)는 cancel→reschedule을 수행해야 한다.
+ *
+ * waypoint(name + stops)만 직렬화 — phase lead 등 schedule 결정값은 동일 코드라 영향 없다.
+ * route=null이거나 destinationName 미상이면 null (scheduler가 미준비로 다룬다).
+ */
+export function routeSignature(route: Route, destinationName: string | null): string | null {
+  if (!route || !destinationName) return null;
+  const targets = resolveAllTargets(route, destinationName);
+  return targets.map((t) => `${t.name}:${t.stops}`).join('|');
 }


### PR DESCRIPTION
## Summary

- **#708** `useBoardingLockScheduler`: 같은 `trainCode` 안에서도 `route` / `destinationName` 구조가 바뀌면 사전 예약된 hop이 stale이 되어 잘못된 역에서 알람이 발사되던 회귀를 차단. 새 헬퍼 `routeSignature(route, dest)` 결과를 ref에 기억해 변경 감지 시 `cancelAllHopsForLock(prev)` → `scheduleHopsForLock(new)`.
- **#710** `advanceHopWindow`: `passedStationName` 매칭을 strict equality → `isSameStationName`으로 정규화. 호출자가 raw GPS `station.name`(노선별 부제 포함)을 전달해도 silent miss(no-op)되지 않도록 흡수. 환승역 station-passed 발사 후 큐가 정상 비워짐.
- `routeSignature(route, destinationName)` 헬퍼 추가 — waypoint `name:stops` join 직렬화.

## 회귀 가드

- `useBoardingLockScheduler.test.tsx`
  - #708 같은 trainCode + route 구조 변경 시 `cancelAllHopsForLock(prev)` + `scheduleHopsForLock(new)` 1회씩 발생
  - #708 같은 trainCode + destinationName 변경 시도 동일하게 cancel + reschedule
  - #708 같은 구조의 다른 객체로 rerender 시 재예약 없음 (signature 동일)
- `boardingLockScheduler.test.ts`
  - #710 `passedStationName: '교대(법원·검찰청)'` 같은 부제 포함 이름이어도 `targets[0].name='교대'` 매칭으로 hop 0 cancel
  - `routeSignature` null/구조 변경/destination 변경에 대해 결정적

## Test plan

- [x] `npm test` 100% coverage 통과 (2476 tests)
- [x] `npm run type-check` 통과
- [ ] CI `Type Check & Test` pass
- [ ] 실기기: 환승 경로 재산정 시 stale 알람 발사 없음 확인

Closes #708
Closes #710