### PR TITLE
feat(#711): BG_LAST_STATION_KEY로 FG 복귀 시 현재역 즉시 hydrate

### DIFF
--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -42,3 +42,9 @@ export const BOARDING_LOCK_KEY = 'subway-now:boarding-lock';
 // release/expiry 또는 새 Lock 시점에 일괄 cancel하기 위한 추적 큐.
 // 형식: string[] JSON.
 export const SCHEDULED_NOTIFICATIONS_KEY = 'subway-now:scheduled-notifications';
+// #711 — BG task가 마지막으로 평가한 nearest station + 평가 시각.
+// FG 복귀 직후 fresh fix가 들어오기 전 일시 공백을 메우기 위한 임시 hydrate 용도.
+// hydrate 시 locationUncertain=true는 유지 — fresh fix(applyLocation) 도착 시점에 해제된다.
+// 형식: {"station": Station, "distanceKm": number, "timestamp": number} JSON.
+// WhileInUse 권한 사용자에게는 BG task 자체가 동작하지 않으므로 graceful no-op (key 없음).
+export const BG_LAST_STATION_KEY = 'subway-now:bg-last-station';

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -1,9 +1,11 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import * as Location from 'expo-location';
 import { AppState } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNearestStation } from '../useNearestStation';
 import * as findNearestStationModule from '../../utils/findNearestStation';
 import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../constants/location';
+import { BG_LAST_STATION_KEY } from '../../constants/storageKeys';
 
 jest.mock('expo-location');
 
@@ -780,6 +782,145 @@ describe('useNearestStation', () => {
 
     // MAX_STATION_DISTANCE_KM(1.0) 초과 → null
     expect(result.current.result).toBeNull();
+  });
+});
+
+describe('useNearestStation — #711 BG_LAST_STATION hydrate', () => {
+  // 공통 setup: granted + watch 마운트 — helper로 추출해 중복 ≤3% 유지 (SonarCloud)
+  async function mountAndWaitWatch() {
+    mockGranted();
+    const view = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+    return view;
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    // clearAllMocks는 implementation을 리셋하지 않는다 — 이전 describe의 mockLocation 잔류로
+    // refresh()가 강남역 좌표를 흘려보내 result가 오염되는 회귀를 방지.
+    (Location.getCurrentPositionAsync as jest.Mock).mockReset();
+    (Location.getCurrentPositionAsync as jest.Mock).mockRejectedValue(new Error('no-fix'));
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+    await AsyncStorage.clear();
+  });
+
+  it('FG 복귀 시 BG_LAST_STATION이 있으면 result를 임시 hydrate한다 (uncertain=true 유지)', async () => {
+    // BG task가 적재한 가짜 데이터 — 강남역 fixture
+    const bgPayload = {
+      station: {
+        id: 'gangnam-2',
+        name: '강남',
+        line: '2',
+        lineColor: '#009246',
+        lat: 37.498,
+        lng: 127.028,
+      },
+      distanceKm: 0.1,
+      timestamp: Date.now() - 10_000,
+    };
+    await AsyncStorage.setItem(BG_LAST_STATION_KEY, JSON.stringify(bgPayload));
+
+    const { result } = await mountAndWaitWatch();
+    // 초기 result는 null (fresh fix 아직 없음)
+    expect(result.current.result).toBeNull();
+
+    // FG 복귀 — refresh getCurrentPositionAsync는 deferred로 두어 hydrate가 먼저 관측되게 한다
+    let resolveFresh: ((v: unknown) => void) | null = null;
+    (Location.getCurrentPositionAsync as jest.Mock).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveFresh = (v) => resolve(v); }),
+    );
+
+    act(() => { appStateCallback?.('background'); });
+    await act(async () => { appStateCallback?.('active'); });
+
+    // hydrate 적용 대기
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.result?.station.name).toBe('강남');
+    // fresh fix 미도착 — uncertain 유지
+    expect(result.current.locationUncertain).toBe(true);
+
+    // fresh fix가 들어오면 applyLocation이 uncertain=false로 복귀 + result는 fresh로 교체
+    await act(async () => {
+      resolveFresh?.({
+        coords: { latitude: 37.498, longitude: 127.028, accuracy: 10 },
+        timestamp: Date.now(),
+      });
+    });
+    await waitFor(() => expect(result.current.locationUncertain).toBe(false));
+    expect(result.current.result?.station.name).toBe('강남');
+  });
+
+  it('FG 복귀 시 BG_LAST_STATION이 없으면 (WhileInUse 사용자) 조용히 no-op', async () => {
+    // key 없음 — graceful no-op
+    const { result } = await mountAndWaitWatch();
+
+    act(() => { appStateCallback?.('background'); });
+    await act(async () => { appStateCallback?.('active'); });
+
+    // hydrate되지 않음
+    expect(result.current.result).toBeNull();
+  });
+
+  it('FG 복귀 시 손상된 BG_LAST_STATION JSON은 graceful no-op', async () => {
+    await AsyncStorage.setItem(BG_LAST_STATION_KEY, 'not-json{{{');
+
+    const { result } = await mountAndWaitWatch();
+    act(() => { appStateCallback?.('background'); });
+    await act(async () => { appStateCallback?.('active'); });
+
+    // catch 분기로 흘러 result는 null 유지
+    expect(result.current.result).toBeNull();
+  });
+
+  it('FG 복귀 시 BG_LAST_STATION 스키마가 잘못되면 graceful no-op', async () => {
+    // station.id 누락 → 검증 실패
+    await AsyncStorage.setItem(
+      BG_LAST_STATION_KEY,
+      JSON.stringify({ station: { name: '?' }, distanceKm: 0.1 }),
+    );
+
+    const { result } = await mountAndWaitWatch();
+    act(() => { appStateCallback?.('background'); });
+    await act(async () => { appStateCallback?.('active'); });
+
+    expect(result.current.result).toBeNull();
+  });
+
+  it('FG 복귀 시 result가 이미 있으면 hydrate가 덮어쓰지 않는다 (race 가드)', async () => {
+    const bgPayload = {
+      station: {
+        id: 'other',
+        name: '시청',
+        line: '1',
+        lineColor: '#0052A4',
+        lat: 37.565,
+        lng: 126.977,
+      },
+      distanceKm: 0.5,
+      timestamp: Date.now() - 10_000,
+    };
+    await AsyncStorage.setItem(BG_LAST_STATION_KEY, JSON.stringify(bgPayload));
+
+    const { result } = await mountAndWaitWatch();
+    // 먼저 fresh fix로 강남역 채워둠
+    simulateGps(37.498, 127.028, { accuracy: 10 });
+    await waitFor(() => expect(result.current.result?.station.name).toBe('강남'));
+
+    act(() => { appStateCallback?.('background'); });
+    await act(async () => { appStateCallback?.('active'); });
+
+    // hydrate가 흘러도 prev ?? bg → 강남 유지
+    await waitFor(() => expect(Location.getCurrentPositionAsync).toHaveBeenCalled());
+    expect(result.current.result?.station.name).toBe('강남');
   });
 });
 

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import * as Location from 'expo-location';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NearestStationResult, Station } from '../types/station';
+import { BG_LAST_STATION_KEY } from '../constants/storageKeys';
 import { findNearestStations } from '../utils/findNearestStation';
 import {
   isAccuracyAcceptable,
@@ -37,6 +39,29 @@ interface UseNearestStationReturn {
   // 마지막 신뢰 fix로 정지된 상태. 호출자는 "위치 확인 중" 상태로 표시한다.
   locationUncertain: boolean;
   refresh: () => Promise<void>;
+}
+
+// #711: BG task가 최근 평가한 nearest station. FG 복귀 직후 fresh fix 도착 전 임시 hydrate에 사용.
+// WhileInUse 사용자는 BG task 미동작 → key 없음(null) → graceful no-op.
+async function readBgLastStation(): Promise<NearestStationResult | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_LAST_STATION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as { distanceKm?: unknown }).distanceKm === 'number' &&
+      (parsed as { station?: unknown }).station &&
+      typeof ((parsed as { station: { id?: unknown } }).station.id) === 'string'
+    ) {
+      const { station, distanceKm } = parsed as { station: Station; distanceKm: number };
+      return { station, distanceKm };
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 function applyNearestResult(
@@ -272,6 +297,16 @@ export function useNearestStation(): UseNearestStationReturn {
         // 명시적으로 uncertain 상태로 전환해 UI가 "위치 확인 중"을 표시하게 하고,
         // refresh()로 즉시 fresh fix를 요청한다. fresh fix가 들어오면 applyLocation이 uncertain을 해제.
         setLocationUncertain(true);
+        // #711: BG task가 최근 평가한 nearest를 임시 hydrate. fresh fix(refresh→applyLocation) 도착 전
+        // UI 공백을 메운다. uncertain=true는 유지 → "위치 확인 중" 표시 + hydrate된 역 정보 노출.
+        // race: hydrate가 applyLocation 후에 resolve되면 신선 fix를 덮어쓸 수 있어,
+        // result가 비어있을 때만 채운다 (prev ?? bg).
+        // WhileInUse 사용자는 key 부재 → readBgLastStation null → no-op.
+        void readBgLastStation().then((bg) => {
+          if (bg) {
+            setResult((prev) => prev ?? bg);
+          }
+        });
         void refresh();
       } else if (state === 'background') {
         stopWatch();

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -684,4 +684,40 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({ speedMps: null }));
   });
 
+  // ── #711: BG_LAST_STATION_KEY write ──
+
+  it('#711: nearest가 있으면 BG_LAST_STATION_KEY에 station/distanceKm/timestamp를 적재한다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination));
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent: null,
+      nearest: { station: mockStation, distanceKm: 0.42 },
+    });
+
+    const fixTs = Date.now();
+    const loc = makeLocation(37.498, 127.028);
+    loc.timestamp = fixTs;
+
+    await taskCallback({ data: { locations: [loc] }, error: null });
+
+    const setItemCalls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+    const bgLastCall = setItemCalls.find(([key]) => key === 'subway-now:bg-last-station');
+    expect(bgLastCall).toBeDefined();
+    const payload = JSON.parse(bgLastCall![1]);
+    expect(payload.station.id).toBe(mockStation.id);
+    expect(payload.distanceKm).toBe(0.42);
+    expect(payload.timestamp).toBe(fixTs);
+  });
+
+  it('#711: nearest가 null이면 BG_LAST_STATION_KEY를 쓰지 않는다', async () => {
+    mockStorageValues(JSON.stringify(mockDestination));
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    await taskCallback({
+      data: { locations: [makeLocation(37.498, 127.028)] },
+      error: null,
+    });
+
+    const setItemCalls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+    expect(setItemCalls.every(([key]) => key !== 'subway-now:bg-last-station')).toBe(true);
+  });
 });

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -8,7 +8,7 @@ import { DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEA
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { isAccuracyAcceptable, isLocationFresh, isPlausibleJump, type FixSample } from '../utils/locationGates';
 import { logSuppressedGate } from '../utils/alarmLog';
-import { BG_LAST_FIX_KEY } from '../constants/storageKeys';
+import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY } from '../constants/storageKeys';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
 
@@ -116,7 +116,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
 
     // lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈을 통해
     // AsyncStorage에 직접 read/write 한다 (Foreground 훅과 단일 출처 공유).
-    const { alarmEvent } = await processLocationUpdate({
+    const { alarmEvent, nearest } = await processLocationUpdate({
       lat,
       lng,
       destination,
@@ -137,6 +137,20 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
         setFiredAlarms(destination.id, firedAlarms),
         AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
       ]);
+    }
+
+    // #711: BG task가 평가한 nearest를 BG_LAST_STATION_KEY에 적재.
+    // FG 복귀 시 useNearestStation이 fresh fix 도착 전 임시 hydrate에 사용한다.
+    // null nearest(역 1km 밖)도 동일 정책으로 처리할 필요는 없다 — 메모리 상 result도 null로 보존됨이 자연스러움.
+    if (nearest) {
+      await AsyncStorage.setItem(
+        BG_LAST_STATION_KEY,
+        JSON.stringify({
+          station: nearest.station,
+          distanceKm: nearest.distanceKm,
+          timestamp: latest.timestamp,
+        }),
+      );
     }
 
     logger.info('백그라운드 위치 업데이트 완료:', lat.toFixed(4), lng.toFixed(4));


### PR DESCRIPTION
## Summary
- BG에서 이동했는데 FG 복귀 시 현재역이 stale로 잠깐 멈춰 보이던 문제 fix
- 새 storage key BG_LAST_STATION_KEY 추가
- backgroundLocationTask가 nearest station 평가 직후 write
- useNearestStation AppState 'active' handler가 fresh fix 도착 전 임시 hydrate

## Test plan
- [x] 100% 커버리지 유지 (144 suites / 2473 tests)
- [x] 타입체크 통과
- [x] FG 복귀 시 BG_LAST_STATION 즉시 hydrate 후 fresh fix로 갱신 검증
- [x] WhileInUse 사용자 graceful no-op

Closes #711