### PR TITLE
refactor(#703): useApnsTripRegistration deps에서 polling 필드 제거

### DIFF
--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -390,8 +390,41 @@ describe('useApnsTripRegistration', () => {
   });
 
   it('#589 — 같은 (token, route, destination)으로 재호출 시 동일 createdAt 전달', async () => {
+    // #703: eta 변경은 더 이상 재등록을 유발하지 않는다. 같은 세션 재등록은
+    // boardingLock 토글로 트리거 (session key = token+routeSig+destinationId, lock은 미포함).
+    const lock = {
+      destinationId: station.id,
+      trainCode: '7246',
+      boardingStationId: station.id,
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
     let now = 1_700_000_000_000;
     jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const { rerender } = renderHook(
+      ({ bl }: { bl: typeof lock | null }) =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          boardingLock: bl,
+        }),
+      { initialProps: { bl: null as typeof lock | null } },
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    const firstCreatedAt = mockRegister.mock.calls[0][0].createdAt as number;
+    expect(firstCreatedAt).toBe(1_700_000_000_000);
+
+    // boardingLock 추가 → 같은 session key 재등록
+    now = 1_700_000_999_999;
+    rerender({ bl: lock });
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    expect(mockRegister.mock.calls[1][0].createdAt).toBe(firstCreatedAt);
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('#703 — nextStationEtaSeconds만 바뀌면 register 재호출 안 함 (30s polling churn 차단)', async () => {
     const { rerender } = renderHook(
       ({ eta }: { eta: number }) =>
         useApnsTripRegistration({
@@ -402,15 +435,34 @@ describe('useApnsTripRegistration', () => {
       { initialProps: { eta: 120 } },
     );
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-    const firstCreatedAt = mockRegister.mock.calls[0][0].createdAt as number;
-    expect(firstCreatedAt).toBe(1_700_000_000_000);
-
-    // eta만 바뀌어 register effect 재실행 (같은 세션)
-    now = 1_700_000_999_999;
     rerender({ eta: 60 });
-    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
-    expect(mockRegister.mock.calls[1][0].createdAt).toBe(firstCreatedAt);
-    (Date.now as jest.Mock).mockRestore();
+    rerender({ eta: 30 });
+    rerender({ eta: null as unknown as number });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+  });
+
+  it('#703 — currentStation만 바뀌면 register 재호출 안 함', async () => {
+    const altStation: Station = { ...station, id: '2-023', name: '역삼' };
+    const { rerender } = renderHook(
+      ({ cs }: { cs: Station | null }) =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: cs,
+        }),
+      { initialProps: { cs: null as Station | null } },
+    );
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    rerender({ cs: station });
+    rerender({ cs: altStation });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockRegister).toHaveBeenCalledTimes(1);
   });
 
   it('#589 — route 내용 변경 시 새 createdAt 발급', async () => {

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -234,6 +234,10 @@ export function useApnsTripRegistration({
     // route 자체는 closure 안에서만 사용되므로 deps에 넣지 않는다.
     // boardingLock은 boardingLockSig(내용 기반)로 deps — 상위 컴포넌트가 새 object reference를
     // 내려도 같은 lock 내용이면 재등록 안 함. closure 안 actual boardingLock object 사용.
+    // #703: nextStationEtaSeconds / currentStation은 30s GPS·arrival polling으로 매번 바뀌므로
+    // deps에서 제외한다. 첫 register 후 backend cron(#704/#705)이 자체 progress KV로
+    // station-by-station advance를 영속화하므로 client 재등록이 불필요하다. latestInputsRef로
+    // token-refresh 경로는 여전히 최신값을 사용한다.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeSig, destination?.id, nextStationEtaSeconds, currentStation?.id, boardingLockSig]);
+  }, [routeSig, destination?.id, boardingLockSig]);
 }


### PR DESCRIPTION
## Summary
- `useApnsTripRegistration`의 register effect deps에서 30s polling 필드 두 개(`nextStationEtaSeconds`, `currentStation?.id`) 제거
- 변경 후 deps: `[routeSig, destination?.id, boardingLockSig]`
- 기존: GPS/Arrival 폴링 사이클(30s)마다 effect가 재실행되어 `POST /trips` 호출이 분당 폭주
- 이유: backend cron(#704/#705)이 자체 progress KV로 station-by-station advance를 영속화하므로 client 재등록 불필요. `isSameSession`(#589) 판정도 trainCode 기반으로 안정화됨
- token refresh 경로는 `latestInputsRef.current`로 항상 최신 eta/currentStation/boardingLock 사용 (회귀 없음)

## Test plan
- [x] `npx jest src/hooks/__tests__/useApnsTripRegistration.test.ts` — 32 tests pass
- [x] `npm test` — 2485 tests pass, 커버리지 100%
- [x] `npm run type-check` — 통과
- [x] 신규 회귀 테스트 2건 추가:
  - `#703 — nextStationEtaSeconds만 바뀌면 register 재호출 안 함`
  - `#703 — currentStation만 바뀌면 register 재호출 안 함`
- [x] 기존 `#589 동일 createdAt` 테스트는 같은 세션 재등록 트리거를 eta → boardingLock 토글로 교체 (eta는 더 이상 재등록 트리거가 아니므로)

Closes #703