### PR TITLE
fix(#725): silent push reschedule kind drop — payload schema mismatch로 lastReceived 미갱신

### DIFF
--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -19,10 +19,13 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 }));
 
 const mockLogSilentPushReceived = jest.fn();
+const mockLogSilentPushRescheduleReceived = jest.fn();
 const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
+  logSilentPushRescheduleReceived: (...args: unknown[]) =>
+    mockLogSilentPushRescheduleReceived(...args),
   logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
 }));
@@ -284,6 +287,103 @@ describe('silentPushTask', () => {
           bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', pushId: 42 }),
         ),
       ).toMatchObject({ pushId: undefined });
+    });
+
+    // #725 — reschedule schema는 standard와 다르므로 별도 분기 검증.
+    describe('reschedule kind (#725)', () => {
+      it('정상 reschedule payload → RescheduleSilentPushPayload', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: '사가정',
+              newArrivalTimeEpoch: 1_780_000_000_000,
+              trainCode: '7610',
+              sentAt: 1_780_000_000_000,
+              pushId: 'uuid-rs',
+            }),
+          ),
+        ).toEqual({
+          kind: 'reschedule',
+          nextStation: '사가정',
+          newArrivalTimeEpoch: 1_780_000_000_000,
+          trainCode: '7610',
+          sentAt: 1_780_000_000_000,
+          pushId: 'uuid-rs',
+        });
+      });
+
+      it('nextStation 누락/빈 문자열이면 null', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ kind: 'reschedule', newArrivalTimeEpoch: 1, trainCode: 'X' }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: '',
+              newArrivalTimeEpoch: 1,
+              trainCode: 'X',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('newArrivalTimeEpoch 비숫자/Infinity이면 null', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: 'A',
+              newArrivalTimeEpoch: 'now',
+              trainCode: 'X',
+            }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: 'A',
+              newArrivalTimeEpoch: Infinity,
+              trainCode: 'X',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('trainCode 누락/빈 문자열이면 null', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ kind: 'reschedule', nextStation: 'A', newArrivalTimeEpoch: 1 }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: 'A',
+              newArrivalTimeEpoch: 1,
+              trainCode: '',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('sentAt/pushId 옵션 — 누락 시 undefined로 정리', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: 'A',
+              newArrivalTimeEpoch: 1,
+              trainCode: 'X',
+            }),
+          ),
+        ).toMatchObject({ sentAt: undefined, pushId: undefined });
+      });
     });
   });
 
@@ -649,6 +749,69 @@ describe('silentPushTask', () => {
         );
         expect(mockScheduleNotificationAsync).toHaveBeenCalled();
         expect(mockSendPushAck).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('reschedule kind (#725)', () => {
+      function reschedulePayload(extra: Record<string, unknown> = {}) {
+        return {
+          data: {
+            data: {
+              data: {
+                kind: 'reschedule',
+                nextStation: '사가정',
+                newArrivalTimeEpoch: 1_780_000_000_000,
+                trainCode: '7610',
+                ...extra,
+              },
+              dataString: null,
+            },
+            notification: null,
+            aps: { 'content-available': 1 },
+          },
+        };
+      }
+
+      it('reschedule 수신 시 logSilentPushRescheduleReceived 호출 + standard 발사 경로 미진입', async () => {
+        await handleSilentPush(reschedulePayload({ sentAt: 1_780_000_000_000 }));
+        expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+        const arg = mockLogSilentPushRescheduleReceived.mock.calls[0][0];
+        expect(arg.nextStation).toBe('사가정');
+        expect(arg.sentAt).toBe(1_780_000_000_000);
+        expect(typeof arg.receivedAt).toBe('number');
+        // standard 발사 경로는 호출되지 않아야 함.
+        expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
+        expect(mockCheckGate).not.toHaveBeenCalled();
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
+      });
+
+      it('pushId 있으면 ack(fired, reschedule-received) 전송', async () => {
+        await handleSilentPush(reschedulePayload({ pushId: 'rs-uuid' }));
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'rs-uuid',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'fired',
+          reason: 'reschedule-received',
+        });
+      });
+
+      it('pushId 없으면 ack 호출 안 함 — 수신 통계는 그대로 적재', async () => {
+        await handleSilentPush(reschedulePayload());
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+        expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+      });
+
+      it('apnsToken null이면 pushId 있어도 ack skip — 수신 통계는 적재', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return null;
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          return null;
+        });
+        await handleSilentPush(reschedulePayload({ pushId: 'rs-uuid' }));
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+        expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -25,6 +25,7 @@ import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../utils/logger';
 import {
   logSilentPushReceived,
+  logSilentPushRescheduleReceived,
   logSilentPushFired,
   logSilentPushSkipped,
   type AlarmLogReason,
@@ -68,6 +69,23 @@ export interface SilentPushPayload {
 }
 
 /**
+ * Reschedule silent push payload (#725). 백엔드 `sendReschedulePush`가 일반 silent push와
+ * 다른 schema(`nextStation` / `newArrivalTimeEpoch` / `trainCode`)를 보낸다 — 별도 인터페이스로
+ * 모델링하고 `kind: 'reschedule'`을 discriminator로 사용해 union narrowing.
+ */
+export interface RescheduleSilentPushPayload {
+  kind: 'reschedule';
+  nextStation: string;
+  newArrivalTimeEpoch: number;
+  trainCode: string;
+  sentAt?: number;
+  pushId?: string;
+}
+
+/** extractPayload 결과 — standard silent push 또는 reschedule push. */
+export type ExtractedPayload = SilentPushPayload | RescheduleSilentPushPayload;
+
+/**
  * expo-notifications iOS의 `BackgroundEventTransformer.swift`가 APNs payload를
  * 다음과 같이 변환해 task 콜백에 전달한다:
  *   { data: { ...non-aps fields, dataString }, notification: <aps.alert | null>, aps: {...} }
@@ -88,11 +106,21 @@ interface NotificationBackgroundTaskData {
  *   - `taskData.data.data` (production: backend가 `data: { fields }` 발사 → Swift 변환 후 한 단계 더 nested)
  *   - `taskData.data` (backend가 flat payload 발사 시)
  *   - `taskData` (legacy / 일부 테스트 호환)
- * nextWaypoint가 string인 첫 후보를 반환.
+ *
+ * standard silent push는 `nextWaypoint` 필드로 식별, reschedule push(#725)는 `kind: 'reschedule'`
+ * 로 식별 (nextStation을 쓰므로 nextWaypoint가 없다).
  */
 function asPlainObject(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   return value as Record<string, unknown>;
+}
+
+function isStandardCandidate(rec: Record<string, unknown>): boolean {
+  return typeof rec.nextWaypoint === 'string' && (rec.nextWaypoint as string).length > 0;
+}
+
+function isRescheduleCandidate(rec: Record<string, unknown>): boolean {
+  return rec.kind === 'reschedule';
 }
 
 function findFieldsLayer(
@@ -110,7 +138,7 @@ function findFieldsLayer(
     candidates.push(root);
   }
   for (const rec of candidates) {
-    if (typeof rec.nextWaypoint === 'string' && rec.nextWaypoint.length > 0) return rec;
+    if (isStandardCandidate(rec) || isRescheduleCandidate(rec)) return rec;
   }
   return null;
 }
@@ -124,10 +152,19 @@ function findFieldsLayer(
  */
 export function extractPayload(
   taskData: NotificationBackgroundTaskData['data'],
-): SilentPushPayload | null {
+): ExtractedPayload | null {
   const obj = findFieldsLayer(taskData);
   if (!obj) return null;
-  // findFieldsLayer guarantees nextWaypoint is non-empty string.
+  // reschedule 분기 (#725) — schema가 standard와 다름. discriminator는 kind === 'reschedule'.
+  if (obj.kind === 'reschedule') return extractReschedulePayload(obj);
+  return extractStandardPayload(obj);
+}
+
+function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload | null {
+  // extractPayload가 obj.kind === 'reschedule' 분기를 먼저 처리하므로 여기 도달했다는 것은
+  // standard 경로. findFieldsLayer는 isStandardCandidate(nextWaypoint non-empty) 또는
+  // isRescheduleCandidate(kind='reschedule') 중 하나로 통과시키지만, kind='reschedule'
+  // 케이스는 위 분기에서 잡혔으므로 잔여 케이스는 isStandardCandidate가 보증한 것 — nextWaypoint 보장.
   const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
@@ -135,17 +172,39 @@ export function extractPayload(
   if (phase !== 'early' && phase !== 'imminent') return null;
   const validKind =
     kind === 'transfer' || kind === 'destination' || kind === 'intermediate' ? kind : undefined;
-  const validSentAt =
-    typeof sentAt === 'number' && Number.isFinite(sentAt) ? sentAt : undefined;
-  const validPushId = typeof pushId === 'string' && pushId.length > 0 ? pushId : undefined;
   return {
     nextWaypoint,
     etaSeconds,
     phase,
     kind: validKind,
-    sentAt: validSentAt,
-    pushId: validPushId,
+    sentAt: validSentAt(sentAt),
+    pushId: validPushId(pushId),
   };
+}
+
+function extractReschedulePayload(
+  obj: Record<string, unknown>,
+): RescheduleSilentPushPayload | null {
+  const { nextStation, newArrivalTimeEpoch, trainCode, sentAt, pushId } = obj;
+  if (typeof nextStation !== 'string' || nextStation.length === 0) return null;
+  if (typeof newArrivalTimeEpoch !== 'number' || !Number.isFinite(newArrivalTimeEpoch)) return null;
+  if (typeof trainCode !== 'string' || trainCode.length === 0) return null;
+  return {
+    kind: 'reschedule',
+    nextStation,
+    newArrivalTimeEpoch,
+    trainCode,
+    sentAt: validSentAt(sentAt),
+    pushId: validPushId(pushId),
+  };
+}
+
+function validSentAt(sentAt: unknown): number | undefined {
+  return typeof sentAt === 'number' && Number.isFinite(sentAt) ? sentAt : undefined;
+}
+
+function validPushId(pushId: unknown): string | undefined {
+  return typeof pushId === 'string' && pushId.length > 0 ? pushId : undefined;
 }
 
 /**
@@ -218,6 +277,32 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     return;
   }
   const receivedAt = Date.now();
+  const apnsToken = await loadApnsToken();
+
+  // reschedule 분기 (#725). 백엔드는 사전 예약 알람(#584) 시각을 정정하려고 이 push를 보낸다.
+  // - 수신 신호는 받았다 알리고(`lastReceivedAt` 갱신)
+  // - ack로 P2c alert fallback을 차단한다.
+  //
+  // ackOutcome 3번째 인자는 'fired'를 보내지만, 사용자에게 알림이 실제 발사된 것은 아니다 —
+  // 백엔드 ackPending(`pendingPushes.ts`)이 outcome을 통계로 쓰지 않고 KV entry 삭제 신호로만
+  // 사용하므로 안전 (`outcome=fired` = "이 push는 처리 완료, alert fallback 발사 마라").
+  // reason 'reschedule-received'로 의도가 디버그 로그에 보존된다.
+  //
+  // 사전 예약 자체의 시각 조정은 별도 follow-up에서 다룬다 — 본 PR은 schema mismatch로 drop되던
+  // 수신을 회복시키는 것이 범위.
+  if (payload.kind === 'reschedule') {
+    logger.info(
+      `reschedule received: trainCode=${payload.trainCode} nextStation=${payload.nextStation} newEpoch=${payload.newArrivalTimeEpoch} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+    );
+    logSilentPushRescheduleReceived({
+      nextStation: payload.nextStation,
+      sentAt: payload.sentAt,
+      receivedAt,
+    });
+    ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
+    return;
+  }
+
   logger.info(
     `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
   );
@@ -230,8 +315,6 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     sentAt: payload.sentAt,
     receivedAt,
   });
-
-  const apnsToken = await loadApnsToken();
 
   // kind 미상은 발사 불가 — 알림 본문/dedup 키 결정 불가. 구 백엔드 호환은 received 로그에만.
   if (!payload.kind) {

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -13,6 +13,7 @@ import {
   logSuppressedDedupStation,
   logSuppressedGate,
   logSilentPushReceived,
+  logSilentPushRescheduleReceived,
   logSilentPushFired,
   logSilentPushSkipped,
   logAlertFallbackFired,
@@ -459,6 +460,43 @@ describe('alarmLog', () => {
       expect(saved[0].kind).toBeUndefined();
       expect(saved[0].sentAt).toBeUndefined();
       expect(saved[0].receivedAt).toBe(1_700_000_001_000);
+    });
+
+    // #725 — reschedule silent push 수신 적재. source는 동일(silent-push-received)이라
+    // DebugModal `lastReceivedAt`이 자동 갱신. kind/phaseId는 reschedule 의미상 미적용.
+    it('logSilentPushRescheduleReceived: source=silent-push-received, kind/phaseId 미포함, sentAt/receivedAt 적재 (#725)', async () => {
+      logSilentPushRescheduleReceived({
+        nextStation: '사가정',
+        sentAt: 1_780_000_000_000,
+        receivedAt: 1_780_000_001_500,
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        ts: 1_780_000_001_500,
+        source: 'silent-push-received',
+        outcome: 'received',
+        stationName: '사가정',
+        sentAt: 1_780_000_000_000,
+        receivedAt: 1_780_000_001_500,
+      });
+      expect(saved[0].kind).toBeUndefined();
+      expect(saved[0].phaseId).toBeUndefined();
+    });
+
+    it('logSilentPushRescheduleReceived: sentAt 누락이면 undefined로 적재 (#725)', async () => {
+      logSilentPushRescheduleReceived({
+        nextStation: '사가정',
+        sentAt: undefined,
+        receivedAt: 1_780_000_001_500,
+      });
+      await flushPromises();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].sentAt).toBeUndefined();
     });
 
     it('logSilentPushFired: 게이트 통과 후 발사 1건 적재 (#478 PR 1-2)', async () => {

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -283,6 +283,31 @@ export function logSilentPushReceived(input: {
 }
 
 /**
+ * Reschedule silent push 수신 1건 적재 (#725).
+ *
+ * 일반 silent push와 source가 같지만(`silent-push-received` — DebugModal `lastReceivedAt`이
+ * 자동 갱신되도록), kind/phaseId는 reschedule 의미상 미적용. 추적은 stationName(=nextStation)과
+ * sentAt/receivedAt 지연 측정으로 충분.
+ *
+ * 별도 helper로 분리한 이유: AlarmLogKind/AlarmPhaseId 타입에 'reschedule'을 끼워 넣으면
+ * 호출자(다른 logSilentPush*)에 cascade 영향이 발생. 분리하면 reschedule만 isolated 경로.
+ */
+export function logSilentPushRescheduleReceived(input: {
+  nextStation: string;
+  sentAt: number | undefined;
+  receivedAt: number;
+}): void {
+  void appendAlarmLog({
+    ts: input.receivedAt,
+    source: 'silent-push-received',
+    outcome: 'received',
+    stationName: input.nextStation,
+    sentAt: input.sentAt,
+    receivedAt: input.receivedAt,
+  });
+}
+
+/**
  * silent push가 위치 게이트 통과 → 즉시 발사한 1건 (#478 PR 1-2).
  */
 export function logSilentPushFired(input: {


### PR DESCRIPTION
Closes #725

## 증상
backend가 `reschedule` silent push를 정상 발사(`pushed=1` × 4) — wrangler tail로 확인. 그러나 device DebugModal `lastReceived=(never)` 영구 유지. silentPushTask가 payload parsing 단계에서 drop — `logSilentPushReceived`조차 호출 안 됨.

## 근본 원인
backend `sendReschedulePush`의 payload schema가 standard silent push와 달랐다.

**backend** (`backend/alarm-worker/src/apns.ts:198-207`):
```
{ kind: 'reschedule', nextStation, newArrivalTimeEpoch, trainCode, sentAt, pushId }
// nextWaypoint, etaSeconds, phase 없음
```

**client extractPayload** (`src/tasks/silentPushTask.ts:131-148`):
```
const { nextWaypoint, etaSeconds, phase, kind, ... } = obj;
if (typeof etaSeconds !== 'number') return null;  // ← reschedule엔 etaSeconds 없음 → return null
```

→ payload parsing 1차 게이트에서 null → handleSilentPush 즉시 return → logSilentPushReceived 호출 안 됨 → DebugModal lastReceived 영구 (never).

## 변경
- `SilentPushPayload` (standard) + `RescheduleSilentPushPayload` (reschedule) + `ExtractedPayload` union 분리, `kind` discriminator로 narrowing
- `findFieldsLayer`가 `isStandardCandidate`(nextWaypoint non-empty) 또는 `isRescheduleCandidate`(kind='reschedule') 둘 다 인식
- `extractPayload` reschedule 분기 → `extractReschedulePayload`로 별도 schema 파싱. `validSentAt` / `validPushId` helper 추출 (DRY)
- `handleSilentPush` reschedule 분기 → `logSilentPushRescheduleReceived` 호출 (DebugModal lastReceived 자동 갱신) + `ackOutcome('fired', 'reschedule-received')`로 P2c alert fallback 차단
- `alarmLog.logSilentPushRescheduleReceived` helper 추가 — source=silent-push-received로 적재해 `useSilentPushDiagnostics`의 lastReceivedAt이 자동 갱신
- 사전 예약 알람 시각 *재예약* 적용 로직은 본 PR 범위 외 (별도 follow-up). 본 PR은 schema mismatch로 drop되던 수신 신호 회복이 범위. #584 사전 예약 SLA가 graceful degradation으로 알람 자체는 보장

## 검증
- 변경 파일 100% coverage 유지 (`silentPushTask.ts`, `alarmLog.ts`)
- 전체 `npm test` 144 suites / 2506 tests pass
- `npm run type-check` 통과
- reschedule extractPayload edge cases (nextStation 누락/빈, newArrivalTimeEpoch 비숫자/Infinity, trainCode 누락/빈, sentAt/pushId optional) 검증
- handleSilentPush reschedule 분기: logSilentPushRescheduleReceived 호출 + standard 발사 경로 미진입 + pushId 유무에 따른 ack 동작 + apnsToken null 처리

## Test plan
- [ ] Debug 빌드(`apnsEnv=sandbox`) + 실기기에서 reschedule push 발사 시 DebugModal `lastReceived` 갱신 확인
- [ ] wrangler tail에서 `reschedule push pushed=1` 확인
- [ ] Standard silent push 경로 회귀 없음 확인 (transfer/destination/intermediate)