### PR TITLE
chore(#731): bump version to 1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- `package.json` 버전 1.2.3 → 1.2.4 patch bump
- 태그 `v1.2.4` 생성

## 포함 변경 (직전 마이너 v1.2.0 이후 누적)
- #710 scheduler route 변경 시 cancel/reschedule + advanceHopWindow canonical resolve
- #711 BG_LAST_STATION_KEY 신규 + FG 복귀 시 임시 hydrate
- #703 useApnsTripRegistration deps 정리
- #725 silent push reschedule kind drop fix
- #727 정적 misfire 가드 A — GPS 신호 기반 알람 차단

## Test plan
- [x] `npm version patch` 성공 (1.2.4)
- [ ] CI `Type Check & Test` pass
- [ ] CI `SonarCloud` pass
- [ ] 머지 후 로컬 실기기 회귀 검증 (별도 진행)

Closes #731