### PR TITLE
fix(#733): 정적 misfire 가드 D — speed=null fallback + station-passed 가드

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -121,7 +121,7 @@ export default function HomeScreen() {
   // 동일 store의 lock을 useBoardingLockController가 아래서 다시 소비하지만 selector라 churn 없음.
   const fusionBoardingLock = useBoardingLockStore((s) => s.lock);
   const lockedTrainCode = fusionBoardingLock?.trainCode ?? null;
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock);
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock);
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,
@@ -208,6 +208,7 @@ export default function HomeScreen() {
     arrivalConfidence: confidence,
     fusionSource: source,
     locationUncertain,
+    positionStability,
   });
 
   // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,

--- a/src/hooks/__tests__/usePositionStability.test.ts
+++ b/src/hooks/__tests__/usePositionStability.test.ts
@@ -1,0 +1,140 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { usePositionStability } from '../usePositionStability';
+
+describe('usePositionStability', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('초기에 userLocation 없으면 unknown', () => {
+    const { result } = renderHook(() => usePositionStability(null));
+    expect(result.current).toBe('unknown');
+  });
+
+  it('userLocation null이 유지되면 stability도 unknown 유지', () => {
+    const { result, rerender } = renderHook(
+      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
+        usePositionStability(loc),
+      { initialProps: { loc: null } },
+    );
+    rerender({ loc: null });
+    expect(result.current).toBe('unknown');
+  });
+
+  it('sample 1개만 들어오면 unknown (minSamples 미달)', () => {
+    const { result, rerender } = renderHook(
+      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
+        usePositionStability(loc),
+      { initialProps: { loc: null } },
+    );
+
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_000_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
+    });
+    expect(result.current).toBe('unknown');
+  });
+
+  it('60s 윈도우에 같은 좌표 3개 들어오면 static', () => {
+    const { result, rerender } = renderHook(
+      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
+        usePositionStability(loc),
+      { initialProps: { loc: null } },
+    );
+
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_000_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
+    });
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_030_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.0871 } });
+    });
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_060_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
+    });
+
+    expect(result.current).toBe('static');
+  });
+
+  it('서로 떨어진 좌표 3개 들어오면 moving', () => {
+    const { result, rerender } = renderHook(
+      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
+        usePositionStability(loc),
+      { initialProps: { loc: null } },
+    );
+
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_000_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
+    });
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_030_000);
+      rerender({ loc: { lat: 37.58, lng: 127.087 } });
+    });
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_060_000);
+      rerender({ loc: { lat: 37.59, lng: 127.087 } });
+    });
+
+    expect(result.current).toBe('moving');
+  });
+
+  it('userLocation이 null 되면 sample 추가 안 되고 직전 stability 유지', () => {
+    const { result, rerender } = renderHook(
+      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
+        usePositionStability(loc),
+      { initialProps: { loc: null } },
+    );
+
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_000_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
+    });
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_030_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.0871 } });
+    });
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_060_000);
+      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
+    });
+    expect(result.current).toBe('static');
+
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_090_000);
+      rerender({ loc: null });
+    });
+    expect(result.current).toBe('static');
+  });
+
+  it('오래된 sample(prune window 초과)은 자동 제거 — buffer 누적 안 됨', () => {
+    const { result, rerender } = renderHook(
+      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
+        usePositionStability(loc),
+      { initialProps: { loc: null } },
+    );
+
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        (Date.now as jest.Mock).mockReturnValue(1_000_000 + i * 30_000);
+        rerender({ loc: { lat: 37.5756 + i * 0.0001, lng: 127.087 } });
+      });
+    }
+    expect(result.current).toBe('static');
+
+    // 5분 후 큰 점프 — 오래된 sample은 prune되어야 하므로 새로운 burst만 본다.
+    act(() => {
+      (Date.now as jest.Mock).mockReturnValue(1_400_000);
+      rerender({ loc: { lat: 37.6, lng: 127.1 } });
+    });
+    expect(result.current).toBe('unknown');
+  });
+});

--- a/src/hooks/__tests__/usePositionStability.test.ts
+++ b/src/hooks/__tests__/usePositionStability.test.ts
@@ -1,6 +1,23 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { usePositionStability } from '../usePositionStability';
 
+type Loc = { lat: number; lng: number } | null;
+type RenderRef = ReturnType<typeof renderHookWithLoc>;
+
+function renderHookWithLoc(initialLoc: Loc) {
+  return renderHook(
+    ({ loc }: { loc: Loc }) => usePositionStability(loc),
+    { initialProps: { loc: initialLoc } },
+  );
+}
+
+function pushAt(hook: RenderRef, ts: number, loc: Loc): void {
+  act(() => {
+    (Date.now as jest.Mock).mockReturnValue(ts);
+    hook.rerender({ loc });
+  });
+}
+
 describe('usePositionStability', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -18,123 +35,53 @@ describe('usePositionStability', () => {
   });
 
   it('userLocation null이 유지되면 stability도 unknown 유지', () => {
-    const { result, rerender } = renderHook(
-      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
-        usePositionStability(loc),
-      { initialProps: { loc: null } },
-    );
-    rerender({ loc: null });
-    expect(result.current).toBe('unknown');
+    const hook = renderHookWithLoc(null);
+    hook.rerender({ loc: null });
+    expect(hook.result.current).toBe('unknown');
   });
 
   it('sample 1개만 들어오면 unknown (minSamples 미달)', () => {
-    const { result, rerender } = renderHook(
-      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
-        usePositionStability(loc),
-      { initialProps: { loc: null } },
-    );
-
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_000_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
-    });
-    expect(result.current).toBe('unknown');
+    const hook = renderHookWithLoc(null);
+    pushAt(hook, 1_000_000, { lat: 37.5756, lng: 127.087 });
+    expect(hook.result.current).toBe('unknown');
   });
 
   it('60s 윈도우에 같은 좌표 3개 들어오면 static', () => {
-    const { result, rerender } = renderHook(
-      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
-        usePositionStability(loc),
-      { initialProps: { loc: null } },
-    );
-
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_000_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
-    });
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_030_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.0871 } });
-    });
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_060_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
-    });
-
-    expect(result.current).toBe('static');
+    const hook = renderHookWithLoc(null);
+    pushAt(hook, 1_000_000, { lat: 37.5756, lng: 127.087 });
+    pushAt(hook, 1_030_000, { lat: 37.5756, lng: 127.0871 });
+    pushAt(hook, 1_060_000, { lat: 37.5756, lng: 127.087 });
+    expect(hook.result.current).toBe('static');
   });
 
   it('서로 떨어진 좌표 3개 들어오면 moving', () => {
-    const { result, rerender } = renderHook(
-      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
-        usePositionStability(loc),
-      { initialProps: { loc: null } },
-    );
-
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_000_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
-    });
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_030_000);
-      rerender({ loc: { lat: 37.58, lng: 127.087 } });
-    });
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_060_000);
-      rerender({ loc: { lat: 37.59, lng: 127.087 } });
-    });
-
-    expect(result.current).toBe('moving');
+    const hook = renderHookWithLoc(null);
+    pushAt(hook, 1_000_000, { lat: 37.5756, lng: 127.087 });
+    pushAt(hook, 1_030_000, { lat: 37.58, lng: 127.087 });
+    pushAt(hook, 1_060_000, { lat: 37.59, lng: 127.087 });
+    expect(hook.result.current).toBe('moving');
   });
 
   it('userLocation이 null 되면 sample 추가 안 되고 직전 stability 유지', () => {
-    const { result, rerender } = renderHook(
-      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
-        usePositionStability(loc),
-      { initialProps: { loc: null } },
-    );
+    const hook = renderHookWithLoc(null);
+    pushAt(hook, 1_000_000, { lat: 37.5756, lng: 127.087 });
+    pushAt(hook, 1_030_000, { lat: 37.5756, lng: 127.0871 });
+    pushAt(hook, 1_060_000, { lat: 37.5756, lng: 127.087 });
+    expect(hook.result.current).toBe('static');
 
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_000_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
-    });
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_030_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.0871 } });
-    });
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_060_000);
-      rerender({ loc: { lat: 37.5756, lng: 127.087 } });
-    });
-    expect(result.current).toBe('static');
-
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_090_000);
-      rerender({ loc: null });
-    });
-    expect(result.current).toBe('static');
+    pushAt(hook, 1_090_000, null);
+    expect(hook.result.current).toBe('static');
   });
 
   it('오래된 sample(prune window 초과)은 자동 제거 — buffer 누적 안 됨', () => {
-    const { result, rerender } = renderHook(
-      ({ loc }: { loc: { lat: number; lng: number } | null }) =>
-        usePositionStability(loc),
-      { initialProps: { loc: null } },
-    );
-
+    const hook = renderHookWithLoc(null);
     for (let i = 0; i < 3; i++) {
-      act(() => {
-        (Date.now as jest.Mock).mockReturnValue(1_000_000 + i * 30_000);
-        rerender({ loc: { lat: 37.5756 + i * 0.0001, lng: 127.087 } });
-      });
+      pushAt(hook, 1_000_000 + i * 30_000, { lat: 37.5756 + i * 0.0001, lng: 127.087 });
     }
-    expect(result.current).toBe('static');
+    expect(hook.result.current).toBe('static');
 
     // 5분 후 큰 점프 — 오래된 sample은 prune되어야 하므로 새로운 burst만 본다.
-    act(() => {
-      (Date.now as jest.Mock).mockReturnValue(1_400_000);
-      rerender({ loc: { lat: 37.6, lng: 127.1 } });
-    });
-    expect(result.current).toBe('unknown');
+    pushAt(hook, 1_400_000, { lat: 37.6, lng: 127.1 });
+    expect(hook.result.current).toBe('unknown');
   });
 });

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1528,4 +1528,182 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
     });
   });
+
+  describe('#733 Phase ETA path movement gate', () => {
+    const route = makeDirectRoute(1, '2');
+    const station = makeStation('S1', '역삼');
+
+    it('Phase rawEvent 있음 + speed=null + positionStability=static이면 차단 + movement-static-position 적재', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: null,
+            accuracyMeters: 50,
+            positionStability: 'static',
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: '시청',
+            kind: 'transfer',
+            phaseId: 'early',
+            reason: 'movement-static-position',
+          }),
+        );
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('Phase rawEvent 있음 + speed=0이면 차단 + movement-static-speed 적재', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 0,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            stationName: '강남',
+            kind: 'destination',
+            phaseId: 'early',
+            reason: 'movement-static-speed',
+          }),
+        );
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('Phase rawEvent 있음 + speed>=0.5(이동)이면 정상 발사 (positionStability=static 무시)', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 5,
+            accuracyMeters: 50,
+            positionStability: 'static',
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockSendAlarmNotification).toHaveBeenCalled(),
+      );
+    });
+  });
+
+  describe('#733 station-passed movement gate', () => {
+    const route = makeDirectRoute(1, '2');
+    const onRouteStation = makeStation('S2-DST', '강남');
+
+    it('station-passed + 정적 신호(speed=0) + 약한 arrival이면 차단 + movement-static-speed 적재', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 50,
+            speedMps: 0,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: '강남',
+            kind: 'station-passed',
+            reason: 'movement-static-speed',
+          }),
+        );
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('station-passed + speed=null + positionStability=static이면 차단 + movement-static-position 적재', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 50,
+            speedMps: null,
+            positionStability: 'static',
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            stationName: '강남',
+            kind: 'station-passed',
+            reason: 'movement-static-position',
+          }),
+        );
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('station-passed + 정적 신호 + arrivalConfirmed면 movement gate skip → 정상 발사', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 50,
+            speedMps: 0,
+            arrivalConfidence: 'arrival-confirmed',
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+
+    it('station-passed + 이동 신호(speed=5)면 정상 발사', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 50,
+            speedMps: 5,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+  });
 });

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1533,21 +1533,24 @@ describe('useStationAlarm', () => {
     const route = makeDirectRoute(1, '2');
     const station = makeStation('S1', '역삼');
 
-    it('Phase rawEvent 있음 + speed=null + positionStability=static이면 차단 + movement-static-position 적재', async () => {
-      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+    function renderPhaseHook(props: Partial<UseStationAlarmInputs>): void {
       renderHook(() =>
         useStationAlarm(
           defaultInputs({
             route,
             destination,
             nearestStation: station,
-            userLocation: { lat: 37.4, lng: 127.0 },
-            speedMps: null,
+            userLocation: { lat: 37.4, lng: 127 },
             accuracyMeters: 50,
-            positionStability: 'static',
+            ...props,
           }),
         ),
       );
+    }
+
+    it('Phase rawEvent 있음 + speed=null + positionStability=static이면 차단 + movement-static-position 적재', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+      renderPhaseHook({ speedMps: null, positionStability: 'static' });
 
       await waitFor(() => {
         expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
@@ -1565,18 +1568,7 @@ describe('useStationAlarm', () => {
 
     it('Phase rawEvent 있음 + speed=0이면 차단 + movement-static-speed 적재', async () => {
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            nearestStation: station,
-            userLocation: { lat: 37.4, lng: 127.0 },
-            speedMps: 0,
-            accuracyMeters: 50,
-          }),
-        ),
-      );
+      renderPhaseHook({ speedMps: 0 });
 
       await waitFor(() => {
         expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
@@ -1593,23 +1585,9 @@ describe('useStationAlarm', () => {
 
     it('Phase rawEvent 있음 + speed>=0.5(이동)이면 정상 발사 (positionStability=static 무시)', async () => {
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            nearestStation: station,
-            userLocation: { lat: 37.4, lng: 127.0 },
-            speedMps: 5,
-            accuracyMeters: 50,
-            positionStability: 'static',
-          }),
-        ),
-      );
+      renderPhaseHook({ speedMps: 5, positionStability: 'static' });
 
-      await waitFor(() =>
-        expect(mockSendAlarmNotification).toHaveBeenCalled(),
-      );
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
     });
   });
 
@@ -1617,7 +1595,7 @@ describe('useStationAlarm', () => {
     const route = makeDirectRoute(1, '2');
     const onRouteStation = makeStation('S2-DST', '강남');
 
-    it('station-passed + 정적 신호(speed=0) + 약한 arrival이면 차단 + movement-static-speed 적재', async () => {
+    function renderStationPassedHook(props: Partial<UseStationAlarmInputs>): void {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       renderHook(() =>
         useStationAlarm(
@@ -1626,10 +1604,14 @@ describe('useStationAlarm', () => {
             destination,
             nearestStation: onRouteStation,
             accuracyMeters: 50,
-            speedMps: 0,
+            ...props,
           }),
         ),
       );
+    }
+
+    it('station-passed + 정적 신호(speed=0) + 약한 arrival이면 차단 + movement-static-speed 적재', async () => {
+      renderStationPassedHook({ speedMps: 0 });
 
       await waitFor(() => {
         expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
@@ -1645,19 +1627,7 @@ describe('useStationAlarm', () => {
     });
 
     it('station-passed + speed=null + positionStability=static이면 차단 + movement-static-position 적재', async () => {
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            nearestStation: onRouteStation,
-            accuracyMeters: 50,
-            speedMps: null,
-            positionStability: 'static',
-          }),
-        ),
-      );
+      renderStationPassedHook({ speedMps: null, positionStability: 'static' });
 
       await waitFor(() => {
         expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
@@ -1672,36 +1642,13 @@ describe('useStationAlarm', () => {
     });
 
     it('station-passed + 정적 신호 + arrivalConfirmed면 movement gate skip → 정상 발사', async () => {
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            nearestStation: onRouteStation,
-            accuracyMeters: 50,
-            speedMps: 0,
-            arrivalConfidence: 'arrival-confirmed',
-          }),
-        ),
-      );
+      renderStationPassedHook({ speedMps: 0, arrivalConfidence: 'arrival-confirmed' });
 
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
     });
 
     it('station-passed + 이동 신호(speed=5)면 정상 발사', async () => {
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            nearestStation: onRouteStation,
-            accuracyMeters: 50,
-            speedMps: 5,
-          }),
-        ),
-      );
+      renderStationPassedHook({ speedMps: 5 });
 
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
     });

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -7,10 +7,12 @@ import { useNearestStation } from './useNearestStation';
 import { useArrivalInfo } from './useArrivalInfo';
 import { useTrainPositions } from './useTrainPositions';
 import { useRouteProgress } from './useRouteProgress';
+import { usePositionStability } from './usePositionStability';
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
 import { shouldDowngradeFusion } from '../utils/movementGate';
+import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../utils/pickCandidateTrains';
 import { trackTrainProgress } from '../utils/trackTrainProgress';
 import { haversine } from '../utils/haversine';
@@ -61,6 +63,12 @@ interface UseFusedNearestStationReturn {
   /** GPS 표시 게이트 drop으로 좌표가 정지된 상태. fusion에서 position/arrival 신호가 살아있어도
    *  GPS fallback 경로에 의존하는 호출자(예: 표시부)는 이 값으로 "위치 확인 중" UX를 띄울 수 있다. */
   locationUncertain: boolean;
+  /**
+   * #733 — 위치 이력 기반 정적/이동/판정불가. iOS가 speed=-1(미측정)을 보고하는 정적 케이스에서
+   * movementGate fallback 신호로 사용. 호출자(useStationAlarm 등)가 evaluateMovement에 전달해
+   * speed 부재 시에도 정적 misfire 차단을 가능하게 한다.
+   */
+  positionStability: PositionStability;
   refresh: () => Promise<void>;
 }
 
@@ -120,6 +128,9 @@ export function useFusedNearestStation(
   boardingLock?: BoardingLock | null,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation();
+  // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
+  // useNearestStation의 userLocation 변경마다 자동 누적/판정.
+  const positionStability = usePositionStability(gps.userLocation);
 
   // Phase A: 경로가 설정되면 진행도 기반 현재역으로 GPS 결과를 덮어쓴다.
   // origin/destination이 빠지면 useRouteProgress가 arc를 만들지 못하고 null을 반환,
@@ -367,13 +378,16 @@ export function useFusedNearestStation(
   }
 
   // #727 정적 misfire 가드 — shouldDowngradeFusion이 isStaticSpeedSignal + confidence가 fusion
-  // 승격 라벨(position-train / boarding-lock / boarding-lock-interp)인지 한 번에 평가.
+  // 승격 라벨(position-train / boarding-lock / boarding-lock-interp / arrival-arriving #733)인지 한 번에 평가.
   // 정적+accuracy 정상이면 gps-only로 강등 + result/source도 GPS 원본으로 되돌림.
+  //
+  // #733 — speedMps=null인 정적 사용자(iOS Core Location 미보고) 케이스에 positionStability 신호 fallback.
   if (
     shouldDowngradeFusion({
       confidence,
       speedMps: gps.speedMps,
       accuracyM: gps.accuracyMeters,
+      positionStability,
     })
   ) {
     confidence = 'gps-only';
@@ -449,6 +463,7 @@ export function useFusedNearestStation(
     error: gps.error,
     permissionDenied: gps.permissionDenied,
     locationUncertain: gps.locationUncertain,
+    positionStability,
     refresh: gps.refresh,
   };
 }

--- a/src/hooks/usePositionStability.ts
+++ b/src/hooks/usePositionStability.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  STATIC_WINDOW_MS,
+  classifyPositionStability,
+  type PositionSample,
+  type PositionStability,
+} from '../utils/positionStaticDetector';
+
+/** 이력 보존 윈도우 (ms). classify에서 사용하는 STATIC_WINDOW_MS의 배수 — 약간 길게 유지해
+ *  classify 직전 prune 후에도 minSamples를 충족하도록 한다. */
+const PRUNE_WINDOW_MS = STATIC_WINDOW_MS * 2;
+
+/** 메모리 보호: ref 배열 cap. 일반 GPS 폴링(30s)에서 PRUNE_WINDOW(120s) 4 sample 정도이므로
+ *  30은 burst를 흡수하면서도 메모리 폭주를 방지하는 안전망. */
+const MAX_BUFFER_SIZE = 30;
+
+/**
+ * userLocation 갱신마다 sample을 누적해 정적/이동/판정불가를 노출한다.
+ *
+ * 입력 `userLocation`이 null이면 sample 추가 없이 이전 stability 유지. (GPS 일시 끊김 시
+ * 직전 판정을 보존해 다음 cycle에 잘못된 'unknown'으로 reset되지 않도록.)
+ *
+ * 반환 결정성: classify 결과가 같으면 setState가 re-render를 트리거하지 않아 효율적.
+ */
+export function usePositionStability(
+  userLocation: { lat: number; lng: number } | null,
+): PositionStability {
+  const bufferRef = useRef<PositionSample[]>([]);
+  const [stability, setStability] = useState<PositionStability>('unknown');
+
+  useEffect(() => {
+    if (!userLocation) return;
+    const now = Date.now();
+    const pruned = bufferRef.current.filter((s) => now - s.ts <= PRUNE_WINDOW_MS);
+    pruned.push({ lat: userLocation.lat, lng: userLocation.lng, ts: now });
+    bufferRef.current = pruned.slice(-MAX_BUFFER_SIZE);
+    setStability(classifyPositionStability(bufferRef.current, now));
+  }, [userLocation]);
+
+  return stability;
+}

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -26,6 +26,7 @@ import {
   logSuppressedMovement,
 } from '../utils/alarmLog';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../utils/movementGate';
+import type { PositionStability } from '../utils/positionStaticDetector';
 import { useAppStore } from '../store/useAppStore';
 import { createLogger } from '../utils/logger';
 import { isAccuracyAcceptable } from '../utils/locationGates';
@@ -53,6 +54,12 @@ export interface UseStationAlarmInputs {
   /** GPS 게이트 실패 등으로 위치 불확실. true면 source 무시하고 'uncertain' 라벨. */
   locationUncertain?: boolean;
   /**
+   * #733 — useFusedNearestStation.positionStability 결과. iOS가 speed=-1(미측정)을 보고하는
+   * 정적 케이스에서 evaluateMovement가 'static-position' reason으로 차단할 수 있게 한다.
+   * 미전달이면 기존 동작 유지 (speed 신호만 사용).
+   */
+  positionStability?: PositionStability;
+  /**
    * 테스트 전용 — #670/#672 좌표 warmup 가드 비활성화.
    * production 호출자는 미설정으로 둠. 단위 테스트에서 mount 직후 alarm 평가 검증 시 사용.
    */
@@ -69,6 +76,7 @@ export function useStationAlarm({
   arrivalConfidence,
   fusionSource,
   locationUncertain = false,
+  positionStability,
   skipWarmupGuard = false,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
@@ -255,7 +263,30 @@ export function useStationAlarm({
     // #699: fireAndLog가 setFiredAlarms를 await하므로 promise를 명시적으로 흘려보낸다.
     // sync firedAlarmsRef.current.add는 fireAndLog 내부 첫 동작이라 같은 hook 인스턴스
     // 다음 evaluation은 await 중에도 dedup된다.
-    if (rawEvent) void fireAndLog(rawEvent, 'eta', route, destination);
+    if (rawEvent) {
+      // #733 — Phase ETA path movement gate. early phase는 etaSeconds 무관, remainingStops<=1만
+      // 검사하므로 fusion이 인접역으로 jitter하면 즉시 발사. snapshot 1/2에서 관측된 20:07:48 등
+      // 정적 transfer-early 회귀 차단.
+      const movement = evaluateMovement(
+        {
+          speedMps: speedMps ?? undefined,
+          accuracyM: accuracyMeters ?? undefined,
+        },
+        undefined,
+        positionStability,
+      );
+      if (!movement.reliable && movement.reason) {
+        logSuppressedMovement({
+          source: 'fg',
+          stationName: rawEvent.stationName,
+          kind: rawEvent.type,
+          phaseId: rawEvent.phaseId,
+          reason: MOVEMENT_TO_ALARM_LOG_REASON[movement.reason],
+        });
+        return;
+      }
+      void fireAndLog(rawEvent, 'eta', route, destination);
+    }
   }, [
     route,
     destination?.id,
@@ -270,6 +301,7 @@ export function useStationAlarm({
     setAlarmEvent,
     nearestStation?.id,
     nearestStation?.line,
+    positionStability,
     skipWarmupGuard,
   ]);
 
@@ -294,10 +326,15 @@ export function useStationAlarm({
     if (firedAlarmsRef.current.has(imminentKey)) return;
 
     // #727 정적 misfire 가드 — useStationAlarm은 timestamp 입력이 없으므로 speed/accuracy만 평가.
-    const movement = evaluateMovement({
-      speedMps: speedMps ?? undefined,
-      accuracyM: accuracyMeters ?? undefined,
-    });
+    // #733 — speed=null 시 positionStability fallback 사용.
+    const movement = evaluateMovement(
+      {
+        speedMps: speedMps ?? undefined,
+        accuracyM: accuracyMeters ?? undefined,
+      },
+      undefined,
+      positionStability,
+    );
     if (!movement.reliable && movement.reason) {
       logSuppressedMovement({
         source: 'fg',
@@ -324,6 +361,7 @@ export function useStationAlarm({
     nearestStation?.id,
     speedMps,
     accuracyMeters,
+    positionStability,
   ]);
 
   // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.
@@ -337,6 +375,22 @@ export function useStationAlarm({
   // 더 강한 신호 — GPS 정확도 게이트도 같은 등급으로 통과시킨다.
   const arrivalConfirmed =
     arrivalConfidence === 'arrival-confirmed' || arrivalConfidence === 'boarding-lock';
+  // #733 — station-passed effect용 movement 차단 사유.
+  // 메모이즈된 string|null만 deps에 두어 #452 회귀(accuracyMeters 노이즈로 매 fix 재실행) 회피.
+  // 같은 reason 문자열은 Object.is로 동일하게 비교되어 동일 분류 안에선 effect 재실행 안 함.
+  // 타입은 MOVEMENT_TO_ALARM_LOG_REASON 추론에 위임 — SSOT가 movementGate.ts (새 reason 추가 시
+  // 본 위치 수정 불필요, 컴파일러가 자동 cascade).
+  const movementSuppressionReason = useMemo(() => {
+    const m = evaluateMovement(
+      {
+        speedMps: speedMps ?? undefined,
+        accuracyM: accuracyMeters ?? undefined,
+      },
+      undefined,
+      positionStability,
+    );
+    return m.reliable ? null : MOVEMENT_TO_ALARM_LOG_REASON[m.reason];
+  }, [speedMps, accuracyMeters, positionStability]);
 
   useEffect(() => {
     let cancelled = false;
@@ -350,6 +404,22 @@ export function useStationAlarm({
       const candidateStation = nearestStation;
       const capturedRoute = route;
       const capturedDestinationName = destination.name;
+
+      // #733 — station-passed movement gate (S4 fix).
+      // 기존엔 accuracyOk/arrivalConfirmed만 검사 → fusion이 인접역으로 jitter하면 매번 발사.
+      // snapshot 2의 20:16:52 면목 알람(사용자 정적, backend trip 없음) 같은 회귀 차단.
+      // arrivalConfirmed(arrival-confirmed/boarding-lock) 강한 신호 시에는 movement gate skip —
+      // 지하 GPS 끊김 등에서 arrival API가 단독 신호일 때 알람 누락을 막기 위한 기존 정책 보존.
+      // deps에는 movementSuppressionReason(memoized string|null)만 사용해 #452 회귀 회피.
+      if (!arrivalConfirmed && movementSuppressionReason) {
+        logSuppressedMovement({
+          source: 'fg',
+          stationName: candidateStation.name,
+          kind: 'station-passed',
+          reason: movementSuppressionReason,
+        });
+        return;
+      }
 
       void (async () => {
         try {
@@ -386,5 +456,6 @@ export function useStationAlarm({
     nearestStation?.id,
     accuracyOk,
     arrivalConfirmed,
+    movementSuppressionReason,
   ]);
 }

--- a/src/utils/__tests__/movementGate.test.ts
+++ b/src/utils/__tests__/movementGate.test.ts
@@ -114,11 +114,12 @@ describe('movementGate', () => {
   });
 
   describe('MOVEMENT_TO_ALARM_LOG_REASON', () => {
-    it('4개 MovementReason 모두 매핑', () => {
+    it('5개 MovementReason 모두 매핑', () => {
       expect(MOVEMENT_TO_ALARM_LOG_REASON['no-location']).toBe('movement-no-location');
       expect(MOVEMENT_TO_ALARM_LOG_REASON['stale-timestamp']).toBe('movement-stale-timestamp');
       expect(MOVEMENT_TO_ALARM_LOG_REASON['low-accuracy']).toBe('movement-low-accuracy');
       expect(MOVEMENT_TO_ALARM_LOG_REASON['static-speed']).toBe('movement-static-speed');
+      expect(MOVEMENT_TO_ALARM_LOG_REASON['static-position']).toBe('movement-static-position');
     });
   });
 
@@ -139,7 +140,7 @@ describe('movementGate', () => {
       expect(isStaticSpeedSignal(10, 50)).toBe(false);
     });
 
-    it('null/undefined면 false (보수적 — 신호 부재 시 fusion 유지)', () => {
+    it('speed=null + positionStability 없으면 false (보수적 — 신호 부재 시 fusion 유지)', () => {
       expect(isStaticSpeedSignal(null)).toBe(false);
       expect(isStaticSpeedSignal(undefined)).toBe(false);
     });
@@ -152,13 +153,38 @@ describe('movementGate', () => {
     it('accuracy 경계값(MAX_ACCURACY_M)이면 speed=0이어도 true (지하 추정 X)', () => {
       expect(isStaticSpeedSignal(0, MAX_ACCURACY_M)).toBe(true);
     });
+
+    it('#733 — speed=null + positionStability=static이면 true (fallback)', () => {
+      expect(isStaticSpeedSignal(null, 50, 'static')).toBe(true);
+      expect(isStaticSpeedSignal(undefined, 50, 'static')).toBe(true);
+    });
+
+    it('#733 — speed=null + positionStability=moving이면 false', () => {
+      expect(isStaticSpeedSignal(null, 50, 'moving')).toBe(false);
+    });
+
+    it('#733 — speed=null + positionStability=unknown이면 false (보수적)', () => {
+      expect(isStaticSpeedSignal(null, 50, 'unknown')).toBe(false);
+    });
+
+    it('#733 — speed 측정값이 있으면 positionStability 무시 (speed가 우선)', () => {
+      // speed=2 → moving이지만 positionStability=static
+      expect(isStaticSpeedSignal(2, 50, 'static')).toBe(false);
+      // speed=0 → static + positionStability=moving
+      expect(isStaticSpeedSignal(0, 50, 'moving')).toBe(true);
+    });
+
+    it('#733 — accuracy noise는 positionStability fallback에도 적용', () => {
+      expect(isStaticSpeedSignal(null, MAX_ACCURACY_M + 1, 'static')).toBe(false);
+    });
   });
 
   describe('isFusionDowngradeTarget', () => {
-    it('fusion 승격 라벨 3종 모두 true', () => {
+    it('fusion 승격 라벨 4종 모두 true (#733: arrival-arriving 추가)', () => {
       expect(isFusionDowngradeTarget('position-train')).toBe(true);
       expect(isFusionDowngradeTarget('boarding-lock')).toBe(true);
       expect(isFusionDowngradeTarget('boarding-lock-interp')).toBe(true);
+      expect(isFusionDowngradeTarget('arrival-arriving')).toBe(true);
     });
 
     it('그 외 라벨은 false', () => {
@@ -186,6 +212,27 @@ describe('movementGate', () => {
       ).toBe(true);
     });
 
+    it('#733 — arrival-arriving + 정적 신호면 true (snapshot 2 회귀 fix)', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'arrival-arriving',
+          speedMps: 0,
+          accuracyM: 50,
+        }),
+      ).toBe(true);
+    });
+
+    it('#733 — arrival-arriving + speed=null + positionStability=static이면 true', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'arrival-arriving',
+          speedMps: null,
+          accuracyM: 50,
+          positionStability: 'static',
+        }),
+      ).toBe(true);
+    });
+
     it('승격 라벨이지만 정적 신호 아니면 false', () => {
       expect(
         shouldDowngradeFusion({ confidence: 'position-train', speedMps: 5, accuracyM: 50 }),
@@ -203,6 +250,59 @@ describe('movementGate', () => {
       expect(
         shouldDowngradeFusion({ confidence: 'arrival-confirmed', speedMps: 0, accuracyM: 50 }),
       ).toBe(false);
+    });
+
+    it('#733 — 승격 라벨 + speed=null + positionStability 없으면 false (보수)', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'position-train',
+          speedMps: null,
+          accuracyM: 50,
+        }),
+      ).toBe(false);
+    });
+
+    it('#733 — 승격 라벨 + speed=null + positionStability=moving이면 false', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'position-train',
+          speedMps: null,
+          accuracyM: 50,
+          positionStability: 'moving',
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('#733 — evaluateMovement positionStability fallback', () => {
+    it('speed 없음 + positionStability=static이면 reliable=false reason=static-position', () => {
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'static');
+      expect(m.reliable).toBe(false);
+      expect(m.reason).toBe('static-position');
+    });
+
+    it('speed 없음 + positionStability=moving이면 reliable=true', () => {
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'moving');
+      expect(m.reliable).toBe(true);
+    });
+
+    it('speed 없음 + positionStability=unknown이면 reliable=true (보수)', () => {
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'unknown');
+      expect(m.reliable).toBe(true);
+    });
+
+    it('speed 없음 + positionStability 미전달이면 reliable=true (기존 동작 유지)', () => {
+      const m = evaluateMovement({ accuracyM: 50 });
+      expect(m.reliable).toBe(true);
+    });
+
+    it('speed 측정값 있으면 positionStability 무시 — speed가 우선', () => {
+      // speed 정적 → static-speed (positionStability=moving이어도)
+      const m1 = evaluateMovement({ speedMps: 0, accuracyM: 50 }, undefined, 'moving');
+      expect(m1.reason).toBe('static-speed');
+      // speed 이동 → reliable (positionStability=static이어도)
+      const m2 = evaluateMovement({ speedMps: 5, accuracyM: 50 }, undefined, 'static');
+      expect(m2.reliable).toBe(true);
     });
   });
 });

--- a/src/utils/__tests__/positionStaticDetector.test.ts
+++ b/src/utils/__tests__/positionStaticDetector.test.ts
@@ -1,0 +1,114 @@
+import {
+  classifyPositionStability,
+  STATIC_MIN_SAMPLES,
+  STATIC_WINDOW_MS,
+  type PositionSample,
+} from '../positionStaticDetector';
+
+const NOW = 10_000_000;
+
+function sample(lat: number, lng: number, offsetMs: number): PositionSample {
+  return { lat, lng, ts: NOW - offsetMs };
+}
+
+describe('classifyPositionStability', () => {
+  it('빈 배열이면 unknown', () => {
+    expect(classifyPositionStability([], NOW)).toBe('unknown');
+  });
+
+  it('minSamples 미만이면 unknown', () => {
+    const samples: PositionSample[] = [
+      sample(37.5756, 127.087, 30_000),
+      sample(37.5756, 127.087, 0),
+    ];
+    expect(samples.length).toBeLessThan(STATIC_MIN_SAMPLES);
+    expect(classifyPositionStability(samples, NOW)).toBe('unknown');
+  });
+
+  it('windowMs 안의 sample만 계산에 포함 — 오래된 sample은 제외', () => {
+    const samples: PositionSample[] = [
+      // 윈도우 밖
+      sample(37.7, 127.5, STATIC_WINDOW_MS + 1_000),
+      sample(37.7, 127.5, STATIC_WINDOW_MS + 2_000),
+      // 윈도우 안
+      sample(37.5756, 127.087, 50_000),
+      sample(37.5756, 127.087, 30_000),
+      sample(37.5756, 127.087, 0),
+    ];
+    expect(classifyPositionStability(samples, NOW)).toBe('static');
+  });
+
+  it('윈도우 안에 minSamples 모이고 시간 폭 충분하면 spread로 판정', () => {
+    const samples: PositionSample[] = [
+      sample(37.5756, 127.087, 50_000),
+      sample(37.5757, 127.0871, 30_000),
+      sample(37.5756, 127.087, 0),
+    ];
+    expect(classifyPositionStability(samples, NOW)).toBe('static');
+  });
+
+  it('spread가 maxDeltaM 초과면 moving', () => {
+    const samples: PositionSample[] = [
+      sample(37.5756, 127.087, 50_000),
+      sample(37.58, 127.087, 30_000),
+      sample(37.59, 127.087, 0),
+    ];
+    expect(classifyPositionStability(samples, NOW)).toBe('moving');
+  });
+
+  it('spread가 정확히 maxDeltaM 경계 내(50m)면 static', () => {
+    // 위도 1° ≒ 111.0km. 50m = 0.00045°. 임계값 60m 이내.
+    const offsetDeg = 50 / 1000 / 111;
+    const samples: PositionSample[] = [
+      sample(37.5756, 127.087, 50_000),
+      sample(37.5756 + offsetDeg, 127.087, 30_000),
+      sample(37.5756, 127.087, 0),
+    ];
+    expect(classifyPositionStability(samples, NOW)).toBe('static');
+  });
+
+  it('spread가 maxDeltaM 임계값 외(70m)면 moving', () => {
+    const offsetDeg = 70 / 1000 / 111;
+    const samples: PositionSample[] = [
+      sample(37.5756, 127.087, 50_000),
+      sample(37.5756 + offsetDeg, 127.087, 30_000),
+      sample(37.5756, 127.087, 0),
+    ];
+    expect(classifyPositionStability(samples, NOW)).toBe('moving');
+  });
+
+  it('시간 폭이 windowMs * MIN_TIME_SPAN_RATIO 미만이면 unknown', () => {
+    const samples: PositionSample[] = [
+      sample(37.5756, 127.087, 5_000),
+      sample(37.5756, 127.087, 4_000),
+      sample(37.5756, 127.087, 3_000),
+    ];
+    expect(classifyPositionStability(samples, NOW)).toBe('unknown');
+  });
+
+  it('config로 임계값 override 가능 (윈도우/샘플/거리/타임스팬)', () => {
+    const samples: PositionSample[] = [
+      sample(37.5756, 127.087, 5_000),
+      sample(37.5756, 127.087, 3_000),
+      sample(37.5756, 127.087, 1_000),
+    ];
+    expect(
+      classifyPositionStability(samples, NOW, {
+        windowMs: 10_000,
+        minSamples: 2,
+        maxDeltaM: 10,
+        minTimeSpanRatio: 0.1,
+      }),
+    ).toBe('static');
+  });
+
+  it('now 미지정 시 Date.now() 사용 — 신선한 sample이면 정상 판정', () => {
+    const realNow = Date.now();
+    const samples: PositionSample[] = [
+      { lat: 37.5756, lng: 127.087, ts: realNow - 50_000 },
+      { lat: 37.5756, lng: 127.087, ts: realNow - 30_000 },
+      { lat: 37.5756, lng: 127.087, ts: realNow - 1_000 },
+    ];
+    expect(classifyPositionStability(samples)).toBe('static');
+  });
+});

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -51,10 +51,12 @@ export type AlarmLogReason =
   | 'lock-line-mismatch'
   | 'payload-missing-kind'
   // #727 — 정적 misfire 가드(movementGate.ts)가 차단한 발사.
+  // #733 — 'movement-static-position'은 speed 미측정 시 위치 이력(usePositionStability) 기반 정적 차단.
   | 'movement-no-location'
   | 'movement-stale-timestamp'
   | 'movement-low-accuracy'
-  | 'movement-static-speed';
+  | 'movement-static-speed'
+  | 'movement-static-position';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/utils/movementGate.ts
+++ b/src/utils/movementGate.ts
@@ -1,20 +1,28 @@
 /**
- * 정적 misfire 가드 (#727 PR A) — 모든 알람 발사 경로의 SSOT.
+ * 정적 misfire 가드 (#727 PR A → #733 PR D 확장) — 모든 알람 발사 경로의 SSOT.
  *
  * 알람 발사 4개 채널(useStationAlarm ETA / API imminent / silent push / 사전 예약) 가운데
  * ETA phase만 speed+accuracy 게이트를 갖고 있던 회귀를 보완. 사용자가 정적인데 다음의
  * 두 가지 경로로 알람이 잘못 발사되던 상황을 차단한다:
  *   1) API 도착정보 imminent — speedMps/accuracy 검증 없이 trackedTrainCode 매칭만으로 발사
  *   2) silent push — distance 게이트는 통과하지만 speed 무관
- *   3) fusion=position-train — 인근 통과 열차를 momentary lock 후 진행 추적 → 잘못된 lock
+ *   3) fusion=position-train/arrival-arriving — 인근 통과 열차를 momentary lock 후 진행 추적
  *   4) boardingLock 예약 — 정적인데 사용자가 열차 탭하면 사전 예약 생성
  *
  * 한계: 이미 예약된 사전 알람의 *발사 시점* 차단은 OS-level이라 본 helper 범위 외.
  *      PR C(#729 fire-time re-validation)에서 별도 처리.
  *
+ * #733 (PR D) 확장:
+ *   - speedMps가 null인 경우(iOS Core Location이 정적 사용자에게 speed=-1 보고하는 경우)
+ *     positionStability(usePositionStability) 신호로 fallback. 위치 이력이 정적이면 'static-position'으로 차단.
+ *   - FUSION_DOWNGRADE_TARGETS에 'arrival-arriving' 추가 — arrival ENTERING 신호로 fusion이
+ *     elevated 되어도 정적이면 강등 대상.
+ *
  * 입력 필드는 모두 옵션 — 호출자가 측정 가능한 신호만 전달하면 된다. 누락된 신호는
  * 해당 분기 검증을 skip (false negative보다 false positive 차단 우선).
  */
+
+import type { PositionStability } from './positionStaticDetector';
 
 /** 30s 이전 좌표는 stale로 간주 (Bumble Tech 권고). 새 location이 timestamp 동반일 때만 검증. */
 export const STALE_AGE_MS = 30_000;
@@ -29,7 +37,9 @@ export type MovementReason =
   | 'no-location'
   | 'stale-timestamp'
   | 'low-accuracy'
-  | 'static-speed';
+  | 'static-speed'
+  // #733 — speed 미측정 시 위치 이력(usePositionStability)으로 정적 확정.
+  | 'static-position';
 
 interface MovementSignalShared {
   speedMps?: number;
@@ -54,6 +64,7 @@ export const MOVEMENT_TO_ALARM_LOG_REASON = {
   'stale-timestamp': 'movement-stale-timestamp',
   'low-accuracy': 'movement-low-accuracy',
   'static-speed': 'movement-static-speed',
+  'static-position': 'movement-static-position',
 } as const satisfies Record<MovementReason, string>;
 
 /**
@@ -69,19 +80,31 @@ export const MOVEMENT_TO_ALARM_LOG_REASON = {
  *
  * evaluateMovement는 평가 순서가 stale > accuracy > speed라 accuracy>100m 케이스에서 static-speed
  * 분기를 못 탄다 — 단일 책임 helper로 분리해 정책 차이를 명시.
+ *
+ * #733 — speedMps가 null/undefined인 경우 `positionStability` fallback. iOS 정적 사용자에게서
+ * speed=-1(미측정)이 자주 발생하는 케이스 보강. positionStability='static'이면 정적 확정,
+ * 'moving'/'unknown'이면 보수적 false. accuracy 가드(MAX_ACCURACY_M)는 fallback 경로에도 적용.
  */
 export function isStaticSpeedSignal(
   speedMps: number | null | undefined,
   accuracyM?: number | null,
+  positionStability?: PositionStability,
 ): boolean {
-  if (speedMps == null || speedMps >= STATIC_SPEED_THRESHOLD_MPS) return false;
-  // accuracy 알 수 없으면 speed 신호 그대로 신뢰. 알 수 있고 임계값 초과면 noise로 판정.
   if (accuracyM != null && accuracyM > MAX_ACCURACY_M) return false;
-  return true;
+  if (speedMps != null) {
+    return speedMps < STATIC_SPEED_THRESHOLD_MPS;
+  }
+  return positionStability === 'static';
 }
 
-/** fusion downgrade(#727) 대상 confidence. 사용자 정적 신호가 잡히면 gps-only로 강등. */
-const FUSION_DOWNGRADE_TARGETS = ['position-train', 'boarding-lock', 'boarding-lock-interp'] as const;
+/** fusion downgrade(#727) 대상 confidence. 사용자 정적 신호가 잡히면 gps-only로 강등.
+ *  #733 — 'arrival-arriving' 추가. arrival ENTERING 신호로 fusion이 elevated 된 경우도 강등 대상. */
+const FUSION_DOWNGRADE_TARGETS = [
+  'position-train',
+  'boarding-lock',
+  'boarding-lock-interp',
+  'arrival-arriving',
+] as const;
 export type FusionDowngradeTarget = (typeof FUSION_DOWNGRADE_TARGETS)[number];
 
 export function isFusionDowngradeTarget(confidence: string): confidence is FusionDowngradeTarget {
@@ -89,18 +112,22 @@ export function isFusionDowngradeTarget(confidence: string): confidence is Fusio
 }
 
 /**
- * fusion downgrade 결정 (#727).
+ * fusion downgrade 결정 (#727 / #733).
  *   - 사용자가 정적(isStaticSpeedSignal)이고
- *   - 현재 confidence가 fusion 승격 라벨(position-train / boarding-lock / boarding-lock-interp)일 때만
+ *   - 현재 confidence가 fusion 승격 라벨(position-train / boarding-lock / boarding-lock-interp / arrival-arriving)일 때만
  * true. 호출자는 result/confidence/source를 gps 원본으로 되돌린다.
+ *
+ * #733 — speedMps가 null인 경우 positionStability fallback. snapshot 2(speed=null, fusion=arrival-arriving)
+ * 같은 회귀가 더 이상 fusion을 elevated 상태로 유지하지 못한다.
  */
 export function shouldDowngradeFusion(input: {
   confidence: string;
   speedMps: number | null | undefined;
   accuracyM: number | null | undefined;
+  positionStability?: PositionStability;
 }): boolean {
   if (!isFusionDowngradeTarget(input.confidence)) return false;
-  return isStaticSpeedSignal(input.speedMps, input.accuracyM);
+  return isStaticSpeedSignal(input.speedMps, input.accuracyM, input.positionStability);
 }
 
 export interface LocationSignalInput {
@@ -120,13 +147,15 @@ export interface LocationSignalInput {
  *   2. timestamp 있으면서 (now - timestamp) > STALE_AGE_MS → 'stale-timestamp'
  *   3. accuracyM 있으면서 > MAX_ACCURACY_M → 'low-accuracy'
  *   4. speedMps 있으면서 < STATIC_SPEED_THRESHOLD_MPS → 'static-speed'
- *   5. 그 외 → reliable=true
+ *   5. (#733) speedMps 없고 positionStability='static' → 'static-position'
+ *   6. 그 외 → reliable=true
  *
  * 호출자는 결과의 reason으로 logSuppressedGate/logSilentPushSkipped 등 적재.
  */
 export function evaluateMovement(
   loc: LocationSignalInput | null,
   now: number = Date.now(),
+  positionStability?: PositionStability,
 ): MovementSignal {
   if (!loc) return { reliable: false, reason: 'no-location' };
 
@@ -143,6 +172,12 @@ export function evaluateMovement(
 
   if (loc.speedMps != null && loc.speedMps < STATIC_SPEED_THRESHOLD_MPS) {
     return { reliable: false, reason: 'static-speed', speedMps: loc.speedMps };
+  }
+
+  // #733 — speed 미측정 시 위치 이력 fallback. positionStability가 명시적으로 'static'일 때만
+  // 차단. 'unknown'/'moving'은 신뢰성 없음 → 기존 path 유지 (reliable).
+  if (loc.speedMps == null && positionStability === 'static') {
+    return { reliable: false, reason: 'static-position' };
   }
 
   const result: MovementSignal = { reliable: true };

--- a/src/utils/positionStaticDetector.ts
+++ b/src/utils/positionStaticDetector.ts
@@ -1,0 +1,85 @@
+/**
+ * 위치 이력 기반 정적 판정 (#733).
+ *
+ * 배경: iOS Core Location은 정적 사용자에게 speed=-1(미측정)을 자주 보고한다.
+ * movementGate의 speed 기반 판정이 무력화되는 케이스(snapshot 2: speed=null,
+ * confidence=arrival-arriving)에서, 최근 좌표들의 spread로 정적 여부를 별도 판정한다.
+ *
+ * 알고리즘:
+ *   1. windowMs(60s) 안에 들어온 sample만 본다.
+ *   2. minSamples(3개) 미만이면 'unknown' — 데이터 부족.
+ *   3. 시간 폭이 windowMs * MIN_TIME_SPAN_RATIO 미만이면 'unknown' — 부분 윈도우.
+ *   4. 최대 pairwise haversine 거리가 maxDeltaM(60m) 이하이면 'static', 초과면 'moving'.
+ *
+ * 60m 기준은 STATIC_SPEED_THRESHOLD_MPS(0.5) * 60s(window) * 2(보수배수) ≈ 60m
+ *   — 정적 사용자가 GPS 지터(~12m accuracy)로 그려내는 spread를 흡수하는 임계값.
+ */
+
+import { haversine } from './haversine';
+
+/** 정적 판정에 필요한 시간 윈도우 (ms). 60s = 일반 GPS 폴링 2~3 cycle 보장. */
+export const STATIC_WINDOW_MS = 60_000;
+
+/** 정적 판정 최소 sample 개수. 3개 미만이면 'unknown' 반환. */
+export const STATIC_MIN_SAMPLES = 3;
+
+/** 정적 spread 허용 임계값 (m). 사람 걸음 0.5 m/s × 60s = 30m + GPS 지터 마진. */
+export const STATIC_MAX_DELTA_M = 60;
+
+/**
+ * 윈도우 시간 폭 최소 비율. fresh samples의 (newest - oldest) ts가
+ * windowMs * 이 비율 미만이면 'unknown' — 짧은 burst만 모인 경우 부분 판정 회피.
+ */
+export const MIN_TIME_SPAN_RATIO = 0.5;
+
+export type PositionStability = 'static' | 'moving' | 'unknown';
+
+export interface PositionSample {
+  lat: number;
+  lng: number;
+  /** epoch ms — sample 생성 시각. */
+  ts: number;
+}
+
+export interface PositionStaticConfig {
+  windowMs?: number;
+  minSamples?: number;
+  maxDeltaM?: number;
+  minTimeSpanRatio?: number;
+}
+
+/**
+ * 최근 N개 sample을 평가해 정적/이동/판정불가 분류.
+ *
+ * @param samples ts 오름차순 또는 임의 순서 (내부에서 windowMs로 필터, ts 비교)
+ * @param now     기준 시각 (테스트 결정성 위해 주입 가능). 기본 Date.now().
+ * @param config  임계값 override (테스트/튜닝용).
+ */
+export function classifyPositionStability(
+  samples: readonly PositionSample[],
+  now: number = Date.now(),
+  config: PositionStaticConfig = {},
+): PositionStability {
+  const windowMs = config.windowMs ?? STATIC_WINDOW_MS;
+  const minSamples = config.minSamples ?? STATIC_MIN_SAMPLES;
+  const maxDeltaM = config.maxDeltaM ?? STATIC_MAX_DELTA_M;
+  const minTimeSpanRatio = config.minTimeSpanRatio ?? MIN_TIME_SPAN_RATIO;
+
+  const fresh = samples.filter((s) => now - s.ts <= windowMs);
+  if (fresh.length < minSamples) return 'unknown';
+
+  const tsValues = fresh.map((s) => s.ts);
+  const oldestTs = Math.min(...tsValues);
+  const newestTs = Math.max(...tsValues);
+  if (newestTs - oldestTs < windowMs * minTimeSpanRatio) return 'unknown';
+
+  let maxDeltaKm = 0;
+  for (let i = 0; i < fresh.length; i++) {
+    for (let j = i + 1; j < fresh.length; j++) {
+      const d = haversine(fresh[i].lat, fresh[i].lng, fresh[j].lat, fresh[j].lng);
+      if (d > maxDeltaKm) maxDeltaKm = d;
+    }
+  }
+  const maxDeltaMeters = maxDeltaKm * 1000;
+  return maxDeltaMeters <= maxDeltaM ? 'static' : 'moving';
+}


### PR DESCRIPTION
## Summary

PR A(#727/#730) 머지 후 실기기 검증에서 발견된 새 회귀를 종합 수정합니다.

### 근본 원인
`#727` 가드 4채널이 `speedMps` 단일 신호에 의존 → iOS가 speed=-1(미측정)을 보고하면 모든 가드 동시 무력화:
```
speedMps=null
  ├─ shouldDowngradeFusion → false → fusion이 boarding-lock/arrival-arriving 유지 → 열차 위치 추적
  └─ evaluateMovement → reliable=true → API imminent/silent push 모두 통과
```

### 사용자 증거 (2026-06-01 KST)
| 시각 | 경로 | 알람 | 비고 |
|------|------|------|------|
| 20:07:48 | fg | transfer/early + station-passed 상봉 | 사용자 용마산 정적 |
| 20:08:31~39 | fg | station-passed 용마산/상봉/용마산 | fusion jitter |
| **20:16:52** | fg | station-passed 면목 | **backend trip auto-ended 후 — 100% client-side 회귀** |

snapshot 1: `speed=2 m/s, fusion=position-train`
snapshot 2: `speed=null, fusion=arrival-arriving` ← 모든 speed 가드 우회

## 변경 사항

### 신규
- `src/utils/positionStaticDetector.ts` — 최근 N개 GPS 좌표 spread로 정적/이동/판정불가 분류
- `src/hooks/usePositionStability.ts` — ref buffer 누적 + classify 노출

### 수정
- `src/utils/movementGate.ts`:
  - `FUSION_DOWNGRADE_TARGETS`에 `'arrival-arriving'` 추가
  - `isStaticSpeedSignal`/`shouldDowngradeFusion`/`evaluateMovement` 시그니처에 옵셔널 `positionStability` — speed=null 시 fallback
  - 새 reason `'static-position'`
- `src/utils/alarmLog.ts` — `movement-static-position` reason 추가
- `src/hooks/useFusedNearestStation.ts` — `usePositionStability` 호출, 반환값 노출, `shouldDowngradeFusion` 전달
- `src/hooks/useStationAlarm.ts` — 3개 경로(API imminent / Phase ETA / station-passed)에 movement gate. station-passed는 #452 회귀 방지 위해 memoized reason만 deps에 사용, `arrivalConfirmed` 시 skip
- `app/(tabs)/index.tsx` — wiring

## Test plan
- [x] 새 파일 100% 커버리지 (positionStaticDetector / usePositionStability)
- [x] movementGate 확장(speed=null + positionStability 모든 조합) 검증
- [x] useStationAlarm Phase ETA / station-passed 신규 gate 검증
- [x] arrivalConfirmed bypass 정책 유지 검증
- [x] #452 회귀 방지 (memoized reason deps)
- [x] 2590 tests pass, type-check 통과
- [ ] 실기기 회귀: 집 정적 5~10분 + 열차 선택 → `movement-static-position`/`movement-static-speed` entry 출현, 알람 0건

## 후속 (별도 이슈)
- Per-fire diagnostics — alarmLog 엔트리에 speed/accuracy/confidence 스냅샷 첨부
- STATIC_SPEED_THRESHOLD_MPS 재캘리브레이션 (실측 후)
- boarding-lock 시간 한계 (사용자 GPS N분간 정적 시 suspend)

Closes #733