### PR TITLE
perf(#735): alarmLog AsyncStorage RMW 폭풍 — batched/debounced write

### DIFF
--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -22,12 +22,14 @@ const mockLogSilentPushReceived = jest.fn();
 const mockLogSilentPushRescheduleReceived = jest.fn();
 const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
+const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
   logSilentPushRescheduleReceived: (...args: unknown[]) =>
     mockLogSilentPushRescheduleReceived(...args),
   logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
+  flushAlarmLog: () => mockFlushAlarmLog(),
 }));
 
 const mockCheckGate = jest.fn();

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -24,6 +24,7 @@ import { APNS_TOKEN_KEY, DESTINATION_KEY } from '../constants/storageKeys';
 import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../utils/logger';
 import {
+  flushAlarmLog,
   logSilentPushReceived,
   logSilentPushRescheduleReceived,
   logSilentPushFired,
@@ -267,76 +268,83 @@ async function loadApnsToken(): Promise<string | null> {
  * Task 콜백 본체 — 단위 테스트가 직접 호출할 수 있도록 export.
  */
 export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
-  if (input.error) {
-    logger.error('silent push task error:', input.error.message);
-    return;
-  }
+  // #735 — BG task 시간 제약. 모든 종료 경로(early return, fire-with-gate, error)에서 적재된
+  // alarmLog pending이 OS suspend로 손실되지 않도록 try/finally로 명시 flush.
+  try {
+    if (input.error) {
+      logger.error('silent push task error:', input.error.message);
+      return;
+    }
 
-  const payload = extractPayload(input.data);
-  if (!payload) {
-    logger.info('payload missing or invalid — skip');
-    return;
-  }
-  const receivedAt = Date.now();
-  const apnsToken = await loadApnsToken();
+    const payload = extractPayload(input.data);
+    if (!payload) {
+      logger.info('payload missing or invalid — skip');
+      return;
+    }
+    const receivedAt = Date.now();
+    const apnsToken = await loadApnsToken();
 
-  // reschedule 분기 (#725). 백엔드는 사전 예약 알람(#584) 시각을 정정하려고 이 push를 보낸다.
-  // - 수신 신호는 받았다 알리고(`lastReceivedAt` 갱신)
-  // - ack로 P2c alert fallback을 차단한다.
-  //
-  // ackOutcome 3번째 인자는 'fired'를 보내지만, 사용자에게 알림이 실제 발사된 것은 아니다 —
-  // 백엔드 ackPending(`pendingPushes.ts`)이 outcome을 통계로 쓰지 않고 KV entry 삭제 신호로만
-  // 사용하므로 안전 (`outcome=fired` = "이 push는 처리 완료, alert fallback 발사 마라").
-  // reason 'reschedule-received'로 의도가 디버그 로그에 보존된다.
-  //
-  // 사전 예약 자체의 시각 조정은 별도 follow-up에서 다룬다 — 본 PR은 schema mismatch로 drop되던
-  // 수신을 회복시키는 것이 범위.
-  if (payload.kind === 'reschedule') {
+    // reschedule 분기 (#725). 백엔드는 사전 예약 알람(#584) 시각을 정정하려고 이 push를 보낸다.
+    // - 수신 신호는 받았다 알리고(`lastReceivedAt` 갱신)
+    // - ack로 P2c alert fallback을 차단한다.
+    //
+    // ackOutcome 3번째 인자는 'fired'를 보내지만, 사용자에게 알림이 실제 발사된 것은 아니다 —
+    // 백엔드 ackPending(`pendingPushes.ts`)이 outcome을 통계로 쓰지 않고 KV entry 삭제 신호로만
+    // 사용하므로 안전 (`outcome=fired` = "이 push는 처리 완료, alert fallback 발사 마라").
+    // reason 'reschedule-received'로 의도가 디버그 로그에 보존된다.
+    //
+    // 사전 예약 자체의 시각 조정은 별도 follow-up에서 다룬다 — 본 PR은 schema mismatch로 drop되던
+    // 수신을 회복시키는 것이 범위.
+    if (payload.kind === 'reschedule') {
+      logger.info(
+        `reschedule received: trainCode=${payload.trainCode} nextStation=${payload.nextStation} newEpoch=${payload.newArrivalTimeEpoch} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+      );
+      logSilentPushRescheduleReceived({
+        nextStation: payload.nextStation,
+        sentAt: payload.sentAt,
+        receivedAt,
+      });
+      ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
+      return;
+    }
+
     logger.info(
-      `reschedule received: trainCode=${payload.trainCode} nextStation=${payload.nextStation} newEpoch=${payload.newArrivalTimeEpoch} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+      `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
     );
-    logSilentPushRescheduleReceived({
-      nextStation: payload.nextStation,
+
+    // 측정 인프라 — 수신 시점 무조건 적재 (#478 PR 1-1).
+    logSilentPushReceived({
+      stationName: payload.nextWaypoint,
+      kind: payload.kind,
+      phaseId: payload.phase,
       sentAt: payload.sentAt,
       receivedAt,
     });
-    ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
-    return;
-  }
 
-  logger.info(
-    `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
-  );
+    // kind 미상은 발사 불가 — 알림 본문/dedup 키 결정 불가. 구 백엔드 호환은 received 로그에만.
+    if (!payload.kind) {
+      logSilentPushSkipped({
+        stationName: payload.nextWaypoint,
+        kind: undefined,
+        phaseId: payload.phase,
+        reason: 'payload-missing-kind',
+      });
+      ackOutcome(payload.pushId, apnsToken, 'skipped', 'payload-missing-kind');
+      logger.info('kind missing — skip fire');
+      return;
+    }
 
-  // 측정 인프라 — 수신 시점 무조건 적재 (#478 PR 1-1).
-  logSilentPushReceived({
-    stationName: payload.nextWaypoint,
-    kind: payload.kind,
-    phaseId: payload.phase,
-    sentAt: payload.sentAt,
-    receivedAt,
-  });
-
-  // kind 미상은 발사 불가 — 알림 본문/dedup 키 결정 불가. 구 백엔드 호환은 received 로그에만.
-  if (!payload.kind) {
-    logSilentPushSkipped({
-      stationName: payload.nextWaypoint,
-      kind: undefined,
-      phaseId: payload.phase,
-      reason: 'payload-missing-kind',
-    });
-    ackOutcome(payload.pushId, apnsToken, 'skipped', 'payload-missing-kind');
-    logger.info('kind missing — skip fire');
-    return;
-  }
-
-  try {
-    await fireWithGate(
-      payload as Required<Pick<SilentPushPayload, 'kind'>> & SilentPushPayload,
-      apnsToken,
-    );
-  } catch (e) {
-    logger.error('silent push fire 실패:', e);
+    try {
+      await fireWithGate(
+        payload as Required<Pick<SilentPushPayload, 'kind'>> & SilentPushPayload,
+        apnsToken,
+      );
+    } catch (e) {
+      logger.error('silent push fire 실패:', e);
+    }
+  } finally {
+    // pending 강제 flush — debounce timer 만료를 기다리면 BG task 종료 후라 손실.
+    await flushAlarmLog();
   }
 }
 

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -1,6 +1,18 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// #735 — react-native AppState 모킹 (alarmLog가 모듈 스코프에서 listener 등록).
+// jest.mock 팩토리는 hoist되어 import 이전에 적용 — 모듈 로드 시 등록되는 listener 호출이 안전하게 no-op.
+// 실제 AppState 전환 시뮬레이트는 alarmLog._simulateAppStateForTest()로 직접 트리거.
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
+  },
+}));
+
 import {
   appendAlarmLog,
+  flushAlarmLog,
+  resetAlarmLogForTest,
   getAlarmLog,
   clearAlarmLog,
   logFiredAlarm,
@@ -9,7 +21,10 @@ import {
   logFiredAlarmsHydrate,
   logSuppressedDedupAlarm,
   _resetDedupAlarmWindowForTests,
+  _simulateAppStateForTest,
   DEDUP_LOG_WINDOW_MS,
+  FLUSH_DEBOUNCE_MS,
+  FLUSH_MAX_DELAY_MS,
   logSuppressedDedupStation,
   logSuppressedGate,
   logSuppressedMovement,
@@ -60,17 +75,25 @@ function makeEntry(overrides: Partial<AlarmLogEntry> = {}): AlarmLogEntry {
 describe('alarmLog', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+    // #735 — 이전 테스트가 큐에 남긴 mockResolvedValueOnce/mockResolvedValue가 다음 테스트의
+    // getItem 호출을 오염시키지 않도록 명시 reset. clearAllMocks는 implementation을 안 지움.
+    (AsyncStorage.getItem as jest.Mock).mockReset();
+    (AsyncStorage.setItem as jest.Mock).mockReset().mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockReset().mockResolvedValue(undefined);
     _resetDedupAlarmWindowForTests();
+    // #735 — 모듈 스코프 pending/timer 격리.
+    resetAlarmLogForTest();
   });
 
-  describe('appendAlarmLog', () => {
-    it('기존 로그가 없으면 단일 엔트리로 저장한다', async () => {
+  describe('appendAlarmLog + flushAlarmLog (#735 batched write)', () => {
+    it('flush 전엔 storage write 안 함, flush 호출 후 단일 엔트리로 저장한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
       const entry = makeEntry();
 
-      await appendAlarmLog(entry);
+      appendAlarmLog(entry);
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+
+      await flushAlarmLog();
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(
         ALARM_LOG_KEY,
@@ -83,12 +106,28 @@ describe('alarmLog', () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(existing));
       const entry = makeEntry({ stationName: '강남' });
 
-      await appendAlarmLog(entry);
+      appendAlarmLog(entry);
+      await flushAlarmLog();
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(
         ALARM_LOG_KEY,
         JSON.stringify([...existing, entry]),
       );
+    });
+
+    it('여러 entry를 push 후 한 번에 flush — RMW 1회로 batch', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      appendAlarmLog(makeEntry({ stationName: 'A' }));
+      appendAlarmLog(makeEntry({ stationName: 'B' }));
+      appendAlarmLog(makeEntry({ stationName: 'C' }));
+
+      await flushAlarmLog();
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1);
+      expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved.map((e) => e.stationName)).toEqual(['A', 'B', 'C']);
     });
 
     it('BUFFER 크기 초과 시 가장 오래된 엔트리부터 drop한다 (FIFO)', async () => {
@@ -98,7 +137,8 @@ describe('alarmLog', () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(existing));
       const entry = makeEntry({ ts: 9999, stationName: '신규' });
 
-      await appendAlarmLog(entry);
+      appendAlarmLog(entry);
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -112,7 +152,8 @@ describe('alarmLog', () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json{{{');
       const entry = makeEntry();
 
-      await appendAlarmLog(entry);
+      appendAlarmLog(entry);
+      await flushAlarmLog();
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(
         ALARM_LOG_KEY,
@@ -124,7 +165,8 @@ describe('alarmLog', () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
       const entry = makeEntry();
 
-      await appendAlarmLog(entry);
+      appendAlarmLog(entry);
+      await flushAlarmLog();
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(
         ALARM_LOG_KEY,
@@ -135,7 +177,143 @@ describe('alarmLog', () => {
     it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
-      await expect(appendAlarmLog(makeEntry())).resolves.toBeUndefined();
+      appendAlarmLog(makeEntry());
+      await expect(flushAlarmLog()).resolves.toBeUndefined();
+    });
+
+    it('pending 없을 때 flush 호출은 no-op (storage 미접근)', async () => {
+      await flushAlarmLog();
+      expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('debounce: timer 만료까지 기다리면 자동 flush (FLUSH_DEBOUNCE_MS)', async () => {
+      jest.useFakeTimers();
+      try {
+        (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+        appendAlarmLog(makeEntry({ stationName: 'A' }));
+        expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
+
+        expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('debounce: 새 push가 들어오면 timer reset', async () => {
+      jest.useFakeTimers();
+      try {
+        (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+        appendAlarmLog(makeEntry({ stationName: 'A' }));
+        await jest.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS - 100);
+        appendAlarmLog(makeEntry({ stationName: 'B' }));
+        await jest.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS - 100);
+        expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(200);
+
+        expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+        const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+        const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+        expect(saved.map((e) => e.stationName)).toEqual(['A', 'B']);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('max-delay: 가장 오래된 pending이 FLUSH_MAX_DELAY_MS 도달하면 다음 append에서 즉시 flush', async () => {
+      const startTime = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(startTime);
+      try {
+        (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+        appendAlarmLog(makeEntry({ stationName: 'first' }));
+        // FLUSH_MAX_DELAY_MS 경과 시뮬레이트
+        (Date.now as jest.Mock).mockReturnValue(startTime + FLUSH_MAX_DELAY_MS);
+        appendAlarmLog(makeEntry({ stationName: 'second' }));
+
+        // void flushAlarmLog() 마이크로태스크 chain 모두 drain
+        await flushPromises();
+        await flushPromises();
+
+        expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+        const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+        const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+        expect(saved.map((e) => e.stationName)).toEqual(['first', 'second']);
+      } finally {
+        (Date.now as jest.Mock).mockRestore();
+      }
+    });
+
+    it('AppState background 전환 시 자동 flush', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      appendAlarmLog(makeEntry({ stationName: 'A' }));
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+
+      _simulateAppStateForTest('background');
+      await flushPromises();
+      await flushPromises();
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('AppState inactive 전환 시 자동 flush', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      appendAlarmLog(makeEntry({ stationName: 'A' }));
+
+      _simulateAppStateForTest('inactive');
+      await flushPromises();
+      await flushPromises();
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('AppState active 전환은 flush 안 함', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      appendAlarmLog(makeEntry({ stationName: 'A' }));
+
+      _simulateAppStateForTest('active');
+      await flushPromises();
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    // #735 review P1 fix: 동시 flush race로 lost-update 발생하지 않는지 검증.
+    // mutex 없으면 두 flush가 같은 storage 상태를 읽고 서로의 write를 덮어 E1이 사라진다.
+    it('동시 flushAlarmLog 호출 시 lost-update 없음 (mutex 직렬화)', async () => {
+      // getItem이 호출될 때마다 현재 setItem된 값을 reflect — 실제 storage 시뮬레이션.
+      let storage: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async () => storage);
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(async (_key: string, value: string) => {
+        storage = value;
+      });
+
+      appendAlarmLog(makeEntry({ stationName: 'E1' }));
+      const p1 = flushAlarmLog();
+      appendAlarmLog(makeEntry({ stationName: 'E2' }));
+      const p2 = flushAlarmLog();
+      await Promise.all([p1, p2]);
+
+      const finalSaved: AlarmLogEntry[] = storage ? JSON.parse(storage) : [];
+      expect(finalSaved.map((e) => e.stationName).sort()).toEqual(['E1', 'E2']);
+    });
+
+    it('인플라이트 flush 중에 추가 push가 없으면 recursive 재호출 안 함 (no-op)', async () => {
+      let storage: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async () => storage);
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(async (_key: string, value: string) => {
+        storage = value;
+      });
+
+      appendAlarmLog(makeEntry({ stationName: 'E1' }));
+      const p1 = flushAlarmLog();
+      const p2 = flushAlarmLog(); // 추가 append 없이 즉시 두 번째 flush
+      await Promise.all([p1, p2]);
+
+      // setItem은 1회만 (E1 1건 write). p2는 재귀 호출 skip.
+      expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(1);
     });
   });
 
@@ -173,7 +351,60 @@ describe('alarmLog', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('#735 pending이 있으면 persisted + pending 병합 반환 (UI 즉시 가시)', async () => {
+      const persisted = [makeEntry({ stationName: 'P1' })];
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(persisted));
+      appendAlarmLog(makeEntry({ stationName: 'Pend1' }));
+      appendAlarmLog(makeEntry({ stationName: 'Pend2' }));
+
+      const result = await getAlarmLog();
+
+      expect(result.map((e) => e.stationName)).toEqual(['P1', 'Pend1', 'Pend2']);
+    });
+
+    it('#735 병합 결과가 BUFFER 초과면 가장 오래된 것부터 drop', async () => {
+      const persisted = Array.from({ length: ALARM_LOG_BUFFER_SIZE }, (_, i) =>
+        makeEntry({ ts: i, stationName: `P-${i}` }),
+      );
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(persisted));
+      appendAlarmLog(makeEntry({ ts: 9999, stationName: 'NEW' }));
+
+      const result = await getAlarmLog();
+
+      expect(result).toHaveLength(ALARM_LOG_BUFFER_SIZE);
+      expect(result[0].ts).toBe(1);
+      expect(result[result.length - 1].stationName).toBe('NEW');
+    });
+
+    it('#735 AsyncStorage 실패 시에도 pending은 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      appendAlarmLog(makeEntry({ stationName: 'Pend1' }));
+
+      const result = await getAlarmLog();
+
+      expect(result.map((e) => e.stationName)).toEqual(['Pend1']);
+    });
   });
+
+  describe('clearAlarmLog (#735 pending도 초기화)', () => {
+    it('removeItem 호출 + pending 비움', async () => {
+      appendAlarmLog(makeEntry({ stationName: 'A' }));
+      await clearAlarmLog();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(ALARM_LOG_KEY);
+
+      // 직후 getAlarmLog는 pending 0 (storage empty)
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      const result = await getAlarmLog();
+      expect(result).toEqual([]);
+    });
+
+    it('AsyncStorage removeItem 실패해도 throw하지 않음', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('remove fail'));
+      await expect(clearAlarmLog()).resolves.toBeUndefined();
+    });
+  });
+
 
   describe('helpers', () => {
     const station: Station = {
@@ -192,7 +423,7 @@ describe('alarmLog', () => {
 
     it('logFiredAlarm: source + event를 outcome=fired로 적재한다', async () => {
       logFiredAlarm('fg', event);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -208,7 +439,7 @@ describe('alarmLog', () => {
 
     it('logFiredStationPassed: station.name과 kind=station-passed로 적재한다', async () => {
       logFiredStationPassed('bg', station);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -222,7 +453,7 @@ describe('alarmLog', () => {
 
     it('logSuppressedDedupStation: reason=dedup-station, kind=station-passed로 적재한다', async () => {
       logSuppressedDedupStation('fg', station);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -237,7 +468,7 @@ describe('alarmLog', () => {
 
     it('logSuppressedDedupAlarm: reason=dedup-alarm, phase+type+stationName 적재 (#580)', async () => {
       logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -256,19 +487,19 @@ describe('alarmLog', () => {
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
       try {
         logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
-        await flushPromises();
+        await flushAlarmLog();
         const callsAfterFirst = (AsyncStorage.setItem as jest.Mock).mock.calls.length;
 
         // 윈도우 내 재호출 — drop
         nowSpy.mockReturnValue(baseTs + DEDUP_LOG_WINDOW_MS - 1);
         logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
-        await flushPromises();
+        await flushAlarmLog();
         expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsAfterFirst);
 
         // 윈도우 경계 통과 — 통과
         nowSpy.mockReturnValue(baseTs + DEDUP_LOG_WINDOW_MS + 1);
         logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
-        await flushPromises();
+        await flushAlarmLog();
         expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsAfterFirst + 1);
       } finally {
         nowSpy.mockRestore();
@@ -281,8 +512,12 @@ describe('alarmLog', () => {
       logSuppressedDedupAlarm('fg', { phaseId: 'imminent', type: 'destination', stationName: '강남' });
       logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '역삼' });
       logSuppressedDedupAlarm('bg', { phaseId: 'early', type: 'destination', stationName: '강남' });
-      await flushPromises();
-      expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(5);
+      await flushAlarmLog();
+      // #735 — 모든 호출이 1회 batch RMW로 적재. setItem 1번, payload에 5건 모두 포함.
+      expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(1);
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved).toHaveLength(5);
     });
 
     it('#626 Map cap 초과 시 만료된 엔트리 sweep — 무한 성장 방지', async () => {
@@ -297,7 +532,7 @@ describe('alarmLog', () => {
             stationName: `s${i}`,
           });
         }
-        await flushPromises();
+        await flushAlarmLog();
         const callsBefore = (AsyncStorage.setItem as jest.Mock).mock.calls.length;
 
         // 윈도우 충분히 넘긴 후 새 키 1개 → sweep 발동, 기존 만료 엔트리 정리.
@@ -307,7 +542,7 @@ describe('alarmLog', () => {
           type: 'destination',
           stationName: 's-after',
         });
-        await flushPromises();
+        await flushAlarmLog();
         expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
       } finally {
         nowSpy.mockRestore();
@@ -316,7 +551,7 @@ describe('alarmLog', () => {
 
     it('logFiredAlarmsHydrate: destinationId + firedAlarmsCount 적재 (#580 race 진단)', async () => {
       logFiredAlarmsHydrate('dest-1', 2);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -330,7 +565,7 @@ describe('alarmLog', () => {
 
     it('logFiredAlarmsHydrate: destinationId=null도 그대로 기록', async () => {
       logFiredAlarmsHydrate(null, 0);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -350,7 +585,7 @@ describe('alarmLog', () => {
         actualLastNotifiedStation: 'S-7',
       };
       logScheduledAlarm(event, stamp);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -377,7 +612,7 @@ describe('alarmLog', () => {
         actualLastNotifiedStation: null,
       };
       logScheduledAlarm(event, stamp);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -394,7 +629,7 @@ describe('alarmLog', () => {
     it('logSuppressedGate: reason + location, source=bg 고정으로 적재한다', async () => {
       const location = { lat: 37.5, lng: 127.0, accuracy: 250, ageMs: 30_000 };
       logSuppressedGate('gate-accuracy', location);
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -415,7 +650,7 @@ describe('alarmLog', () => {
         phaseId: 'imminent',
         reason: 'movement-static-speed',
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -435,7 +670,7 @@ describe('alarmLog', () => {
         stationName: '사가정',
         reason: 'movement-low-accuracy',
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -457,7 +692,7 @@ describe('alarmLog', () => {
         sentAt: 1_700_000_000_000,
         receivedAt: 1_700_000_001_500,
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -481,7 +716,7 @@ describe('alarmLog', () => {
         sentAt: 1_700_000_000_000,
         receivedAt: 1_700_000_001_000,
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -496,7 +731,7 @@ describe('alarmLog', () => {
         sentAt: undefined,
         receivedAt: 1_700_000_001_000,
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -514,7 +749,7 @@ describe('alarmLog', () => {
         sentAt: 1_780_000_000_000,
         receivedAt: 1_780_000_001_500,
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -536,7 +771,7 @@ describe('alarmLog', () => {
         sentAt: undefined,
         receivedAt: 1_780_000_001_500,
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -553,7 +788,7 @@ describe('alarmLog', () => {
         locationSource: 'cache',
         locationAgeMs: 12_000,
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -581,7 +816,7 @@ describe('alarmLog', () => {
         locationSource: 'cache',
         locationAgeMs: 10_000,
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -604,7 +839,7 @@ describe('alarmLog', () => {
         phaseId: 'early',
         reason: 'gate-unknown-station',
       });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -616,7 +851,7 @@ describe('alarmLog', () => {
 
     it('logAlertFallbackFired: source=alert-fallback-fired, outcome=fired 적재 (#564)', async () => {
       logAlertFallbackFired({ stationName: '강남', kind: 'destination', phaseId: 'imminent' });
-      await flushPromises();
+      await flushAlarmLog();
 
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
@@ -634,7 +869,7 @@ describe('alarmLog', () => {
 
       // 호출 자체가 throw하면 안 됨 (void)
       expect(() => logFiredAlarm('fg', event)).not.toThrow();
-      await flushPromises();
+      await flushAlarmLog();
     });
   });
 

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -145,7 +145,7 @@ describe('alarmLog', () => {
       expect(saved).toHaveLength(ALARM_LOG_BUFFER_SIZE);
       // 가장 오래된 ts=0이 drop되고 새 엔트리가 마지막
       expect(saved[0].ts).toBe(1);
-      expect(saved[saved.length - 1].stationName).toBe('신규');
+      expect(saved.at(-1)?.stationName).toBe('신규');
     });
 
     it('손상된 JSON이 저장돼 있어도 빈 배열로 초기화 후 append한다', async () => {
@@ -297,7 +297,8 @@ describe('alarmLog', () => {
       await Promise.all([p1, p2]);
 
       const finalSaved: AlarmLogEntry[] = storage ? JSON.parse(storage) : [];
-      expect(finalSaved.map((e) => e.stationName).sort()).toEqual(['E1', 'E2']);
+      const names = finalSaved.map((e) => e.stationName ?? '');
+      expect(names.sort((a, b) => a.localeCompare(b))).toEqual(['E1', 'E2']);
     });
 
     it('인플라이트 flush 중에 추가 push가 없으면 recursive 재호출 안 함 (no-op)', async () => {
@@ -374,7 +375,7 @@ describe('alarmLog', () => {
 
       expect(result).toHaveLength(ALARM_LOG_BUFFER_SIZE);
       expect(result[0].ts).toBe(1);
-      expect(result[result.length - 1].stationName).toBe('NEW');
+      expect(result.at(-1)?.stationName).toBe('NEW');
     });
 
     it('#735 AsyncStorage 실패 시에도 pending은 반환', async () => {

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AppState, type AppStateStatus } from 'react-native';
 import { ALARM_LOG_KEY } from '../constants/storageKeys';
 import { createLogger } from './logger';
 import type { AlarmEvent } from './stationAlarm';
@@ -11,6 +12,19 @@ import type { Station } from '../types/station';
 //
 // Buffer 크기는 ALARM_LOG_BUFFER_SIZE 상수로 분리 — 늘리려면 한 곳만 수정.
 export const ALARM_LOG_BUFFER_SIZE = 200;
+
+// #735 — appendAlarmLog 배치 정책.
+// 기존: 매 호출마다 AsyncStorage RMW(get → parse → push → stringify → set) → JS thread 점유 (10-50ms × N).
+// 변경: in-memory pending에 push 후 debounce + max-delay로 1회 RMW 일괄 처리.
+//
+// FLUSH_DEBOUNCE_MS: 마지막 push로부터 이 시간 동안 추가 push가 없으면 flush.
+// FLUSH_MAX_DELAY_MS: 가장 오래된 pending이 이 시간에 도달하면 즉시 flush — 정상 종료가 아닌
+//   경로(앱 강제종료, BG task 만료)에서 손실 cap.
+//
+// AppState 'background'/'inactive' 진입 시 즉시 flush — OS suspend 전 적재 보장.
+// silentPushTask는 종료 직전 명시적으로 await flushAlarmLog() 호출 (BG task 시간 제약).
+export const FLUSH_DEBOUNCE_MS = 1_000;
+export const FLUSH_MAX_DELAY_MS = 5_000;
 
 // 'fg' / 'bg'는 v1 (FG GPS 평가 / BG location task gate). 'fg-evaluated' / 'bg-scheduled'는
 // v2 (#372)로 의미 명확화. 두 값 모두 union에 유지해 과거 저장 데이터를 손실 없이 읽는다.
@@ -444,11 +458,92 @@ export function logSuppressedMovement(input: {
 
 // ── CRUD ──
 
-export async function appendAlarmLog(entry: AlarmLogEntry): Promise<void> {
+// 모듈 스코프 mutable state (#735 batched write).
+// 단일 프로세스 단일 인스턴스 가정 — React Native 앱 1 process.
+//
+// 동시성: JS는 single-thread지만 *await 사이*에 다른 microtask가 끼어든다 → RMW race 가능.
+// flushInFlight Promise mutex로 두 개 이상의 flush가 동시에 getItem/setItem 사이클을 돌지 않도록
+// 직렬화한다. 단순 single-thread 가정만으론 lost-update가 발생한다 (review #1 발견).
+let pendingEntries: AlarmLogEntry[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let oldestPendingTs: number | null = null;
+let flushInFlight: Promise<void> | null = null;
+
+/**
+ * 알람 로그 1건 적재 (#735 — 동기 in-memory push).
+ *
+ * 기존 RMW 동작에서 변경: 즉시 storage write 안 함. 메모리 pending에 push하고 debounce/max-delay
+ * 정책에 따라 일괄 flush. UI(DebugModal)는 getAlarmLog()가 pending 병합해 반환하므로 즉시 가시.
+ *
+ * 호출자는 await 불필요 (void). 손실 cap을 더 줄여야 하는 critical 경로(silent push BG task 종료
+ * 직전 등)에서는 await flushAlarmLog() 명시 호출.
+ */
+export function appendAlarmLog(entry: AlarmLogEntry): void {
+  pendingEntries.push(entry);
+  if (oldestPendingTs == null) oldestPendingTs = Date.now();
+  scheduleFlush();
+}
+
+function scheduleFlush(): void {
+  // 가장 오래된 pending이 MAX_DELAY 도달했으면 즉시 flush.
+  // 기존 flushTimer는 doFlushOnce에서 클리어 — 본 위치에서 중복 클리어 불필요.
+  if (oldestPendingTs != null && Date.now() - oldestPendingTs >= FLUSH_MAX_DELAY_MS) {
+    void flushAlarmLog();
+    return;
+  }
+  if (flushTimer != null) clearTimeout(flushTimer);
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    void flushAlarmLog();
+  }, FLUSH_DEBOUNCE_MS);
+}
+
+/**
+ * 메모리 pending을 storage에 1회 RMW로 일괄 적재 (#735).
+ *
+ * 호출 시점:
+ *   1) scheduleFlush의 debounce timer 만료
+ *   2) MAX_DELAY 즉시 flush
+ *   3) AppState 'background'/'inactive' 진입 (모듈 스코프 listener)
+ *   4) silentPushTask 종료 직전 명시 호출 (BG task 시간 만료 직전 손실 방지)
+ *   5) 테스트
+ *
+ * 동시성 안전 (review P1 fix):
+ *   - 첫 호출자만 doFlushOnce()를 실제 실행하고, 그 promise를 flushInFlight에 저장.
+ *   - 중첩 호출자(다른 트리거가 동시에 flush 요청)는 같은 flushInFlight를 await한 뒤,
+ *     자신이 추가한 pending이 남아있으면 재귀 호출로 다음 RMW 사이클을 보장.
+ *   - JS single-thread는 동기 구간만 보호 — await 사이엔 다른 microtask가 끼어들어
+ *     두 doFlushOnce가 같은 storage 상태를 보고 서로의 write를 덮는 lost-update가 발생.
+ *     본 mutex 패턴이 RMW를 직렬화.
+ */
+export async function flushAlarmLog(): Promise<void> {
+  if (flushInFlight) {
+    await flushInFlight;
+    // 직전 flush 중에 우리(다른 caller)가 추가한 entry가 남아있으면 다음 cycle로 적재 보장.
+    if (pendingEntries.length > 0) await flushAlarmLog();
+    return;
+  }
+  if (pendingEntries.length === 0) return;
+  flushInFlight = doFlushOnce();
+  try {
+    await flushInFlight;
+  } finally {
+    flushInFlight = null;
+  }
+}
+
+async function doFlushOnce(): Promise<void> {
+  const toFlush = pendingEntries;
+  pendingEntries = [];
+  oldestPendingTs = null;
+  if (flushTimer != null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
   try {
     const raw = await AsyncStorage.getItem(ALARM_LOG_KEY);
     const existing: AlarmLogEntry[] = raw ? safeParse(raw) : [];
-    const next = [...existing, entry];
+    const next = [...existing, ...toFlush];
     // FIFO: 가장 오래된 것부터 drop
     const trimmed = next.length > ALARM_LOG_BUFFER_SIZE
       ? next.slice(next.length - ALARM_LOG_BUFFER_SIZE)
@@ -462,19 +557,49 @@ export async function appendAlarmLog(entry: AlarmLogEntry): Promise<void> {
 export async function getAlarmLog(): Promise<AlarmLogEntry[]> {
   try {
     const raw = await AsyncStorage.getItem(ALARM_LOG_KEY);
-    return raw ? safeParse(raw) : [];
+    const persisted: AlarmLogEntry[] = raw ? safeParse(raw) : [];
+    // #735 — pending 병합. UI는 최신 상태를 즉시 봐야 한다(flush 전 적재 entry 포함).
+    // pending은 시간순으로 push되므로 persisted 뒤에 concat.
+    if (pendingEntries.length === 0) return persisted;
+    const merged = [...persisted, ...pendingEntries];
+    return merged.length > ALARM_LOG_BUFFER_SIZE
+      ? merged.slice(merged.length - ALARM_LOG_BUFFER_SIZE)
+      : merged;
   } catch (e) {
     logger.error('알람 로그 읽기 실패:', e);
-    return [];
+    // storage 실패해도 pending은 노출 — 진단 가시성 유지.
+    return [...pendingEntries];
   }
 }
 
 export async function clearAlarmLog(): Promise<void> {
+  // #735 — pending도 초기화. flush race로 storage 비운 후 pending이 다시 적재되지 않도록.
+  pendingEntries = [];
+  oldestPendingTs = null;
+  if (flushTimer != null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
   try {
     await AsyncStorage.removeItem(ALARM_LOG_KEY);
   } catch (e) {
     logger.error('알람 로그 삭제 실패:', e);
   }
+}
+
+/**
+ * 테스트 전용 — 모듈 스코프 상태 초기화 (#735).
+ * pendingEntries / flushTimer / oldestPendingTs를 reset해 테스트 간 격리.
+ * production 호출 금지.
+ */
+export function resetAlarmLogForTest(): void {
+  pendingEntries = [];
+  oldestPendingTs = null;
+  if (flushTimer != null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  flushInFlight = null;
 }
 
 function safeParse(raw: string): AlarmLogEntry[] {
@@ -489,4 +614,23 @@ function safeParse(raw: string): AlarmLogEntry[] {
     logger.error('알람 로그 JSON 손상 — 빈 로그로 초기화');
     return [];
   }
+}
+
+// #735 — AppState 'background'/'inactive' 진입 시 자동 flush. OS suspend 전 pending 손실 방지.
+// 모듈 로드 시 1회 등록 (singleton). subscription.remove는 production에서 불필요 (앱 lifetime 동일).
+function handleAppStateChange(state: AppStateStatus): void {
+  if (state === 'background' || state === 'inactive') {
+    void flushAlarmLog();
+  }
+}
+AppState.addEventListener('change', handleAppStateChange);
+
+/**
+ * 테스트 전용 — AppState 전환 시뮬레이트 (#735).
+ * 모듈 스코프 listener 등록은 jest.mock 호이스팅과 race 발생하기 쉬워, 캡처된 listener를
+ * 외부에서 호출하기 어렵다. 테스트는 본 helper로 handleAppStateChange를 직접 트리거.
+ * production 호출 금지.
+ */
+export function _simulateAppStateForTest(state: AppStateStatus): void {
+  handleAppStateChange(state);
 }

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -150,7 +150,7 @@ export function logFiredAlarm(
   event: AlarmEvent,
   trigger?: AlarmLogTrigger,
 ): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source,
     outcome: 'fired',
@@ -167,7 +167,7 @@ export function logFiredAlarm(
  * 발사 자체는 expo-notifications가 처리하므로 별도 fire-time 로그는 없다.
  */
 export function logScheduledAlarm(event: AlarmEvent, stamp: AlarmLogStamp): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source: 'bg-scheduled',
     outcome: 'fired',
@@ -183,7 +183,7 @@ export function logScheduledAlarm(event: AlarmEvent, stamp: AlarmLogStamp): void
 }
 
 export function logFiredStationPassed(source: AlarmLogSource, station: Station): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source,
     outcome: 'fired',
@@ -193,7 +193,7 @@ export function logFiredStationPassed(source: AlarmLogSource, station: Station):
 }
 
 export function logSuppressedDedupStation(source: AlarmLogSource, station: Station): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source,
     outcome: 'suppressed',
@@ -211,7 +211,7 @@ export function logSuppressedDedupStation(source: AlarmLogSource, station: Stati
  * 회귀 패턴: fire 이후 destinationId 변동 없이 다시 0이 찍히면 storage write 손실/race 정황.
  */
 export function logFiredAlarmsHydrate(destinationId: string | null, firedAlarmsCount: number): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source: 'fg-hydrate',
     outcome: 'received',
@@ -258,7 +258,7 @@ export function logSuppressedDedupAlarm(
   if (last !== undefined && now - last < DEDUP_LOG_WINDOW_MS) return;
   lastDedupLogTs.set(key, now);
   sweepExpiredDedupEntries(now);
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: now,
     source,
     outcome: 'suppressed',
@@ -291,7 +291,7 @@ export function logSilentPushReceived(input: {
   // kind 미상(구 백엔드)이면 kind 필드 자체를 비워둔다.
   const mappedKind: AlarmLogKind | undefined =
     input.kind === 'intermediate' ? 'station-passed' : input.kind;
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: input.receivedAt,
     source: 'silent-push-received',
     outcome: 'received',
@@ -318,7 +318,7 @@ export function logSilentPushRescheduleReceived(input: {
   sentAt: number | undefined;
   receivedAt: number;
 }): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: input.receivedAt,
     source: 'silent-push-received',
     outcome: 'received',
@@ -340,7 +340,7 @@ export function logSilentPushFired(input: {
   locationSource: 'cache' | 'fresh';
   locationAgeMs: number;
 }): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source: 'silent-push-fired',
     outcome: 'fired',
@@ -369,7 +369,7 @@ export function logSilentPushSkipped(input: {
   locationSource?: 'cache' | 'fresh';
   locationAgeMs?: number;
 }): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source: 'silent-push-skipped',
     outcome: 'suppressed',
@@ -394,7 +394,7 @@ export function logAlertFallbackFired(input: {
   kind: AlarmLogKind;
   phaseId: AlarmPhaseId;
 }): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source: 'alert-fallback-fired',
     outcome: 'fired',
@@ -424,7 +424,7 @@ export function logSuppressedGate(
   reason: 'gate-age' | 'gate-accuracy' | 'gate-jump',
   location: AlarmLogLocation,
 ): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source: 'bg',
     outcome: 'suppressed',
@@ -445,7 +445,7 @@ export function logSuppressedMovement(input: {
   phaseId?: AlarmPhaseId;
   reason: Extract<AlarmLogReason, `movement-${string}`>;
 }): void {
-  void appendAlarmLog({
+  appendAlarmLog({
     ts: Date.now(),
     source: input.source,
     outcome: 'suppressed',
@@ -480,21 +480,26 @@ let flushInFlight: Promise<void> | null = null;
  */
 export function appendAlarmLog(entry: AlarmLogEntry): void {
   pendingEntries.push(entry);
-  if (oldestPendingTs == null) oldestPendingTs = Date.now();
+  oldestPendingTs ??= Date.now();
   scheduleFlush();
+}
+
+function fireAndForgetFlush(): void {
+  // logger가 doFlushOnce 내부에서 에러를 swallow하지만, 미처리 rejection은 catch로 차단.
+  flushAlarmLog().catch(() => {});
 }
 
 function scheduleFlush(): void {
   // 가장 오래된 pending이 MAX_DELAY 도달했으면 즉시 flush.
   // 기존 flushTimer는 doFlushOnce에서 클리어 — 본 위치에서 중복 클리어 불필요.
   if (oldestPendingTs != null && Date.now() - oldestPendingTs >= FLUSH_MAX_DELAY_MS) {
-    void flushAlarmLog();
+    fireAndForgetFlush();
     return;
   }
   if (flushTimer != null) clearTimeout(flushTimer);
   flushTimer = setTimeout(() => {
     flushTimer = null;
-    void flushAlarmLog();
+    fireAndForgetFlush();
   }, FLUSH_DEBOUNCE_MS);
 }
 
@@ -620,7 +625,7 @@ function safeParse(raw: string): AlarmLogEntry[] {
 // 모듈 로드 시 1회 등록 (singleton). subscription.remove는 production에서 불필요 (앱 lifetime 동일).
 function handleAppStateChange(state: AppStateStatus): void {
   if (state === 'background' || state === 'inactive') {
-    void flushAlarmLog();
+    fireAndForgetFlush();
   }
 }
 AppState.addEventListener('change', handleAppStateChange);

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -485,8 +485,9 @@ export function appendAlarmLog(entry: AlarmLogEntry): void {
 }
 
 function fireAndForgetFlush(): void {
-  // logger가 doFlushOnce 내부에서 에러를 swallow하지만, 미처리 rejection은 catch로 차단.
-  flushAlarmLog().catch(() => {});
+  // flushAlarmLog는 doFlushOnce 내부 try/catch로 모든 storage 에러를 swallow하므로 reject 안 함.
+  // 따라서 별도 .catch가 dead branch라 생략 — Promise floating은 의도된 fire-and-forget.
+  flushAlarmLog();
 }
 
 function scheduleFlush(): void {


### PR DESCRIPTION
## Summary

JS thread freeze 회귀(사용자: 스크롤만 동작, 탭 안 됨, 강제종료해야 복구) 분석 결과 `alarmLog`의 매-호출 RMW가 가장 유력한 원인으로 식별 (`Explore` 에이전트 분석 ~80%).

`appendAlarmLog`가 매 fired/suppressed 알람마다 200-entry 풀-RMW(get → parse → push → stringify → set)를 fire-and-forget으로 실행 → 빈도 분당 수십~수백 → JS thread 점유.

## 변경

### 동작 변경
- `appendAlarmLog(entry): void` (`Promise<void>` → `void`) — in-memory pending push
- 새 `flushAlarmLog(): Promise<void>` export — debounce 1s / max-delay 5s로 일괄 1회 RMW
- `getAlarmLog()` pending 병합 — UI(DebugModal) 즉시 가시
- `clearAlarmLog()` pending도 초기화
- AppState `'background'`/`'inactive'` 진입 시 자동 flush — OS suspend 전 손실 방지
- `silentPushTask.handleSilentPush` 전체를 try/finally로 감싸 종료 직전 `await flushAlarmLog()` — BG task 시간 만료 손실 방지

### review P1 fix — 동시 flush mutex
초안에서 "JS single-thread로 race 자연 회피" 주장 → reviewer가 실제 lost-update 재현.
`await getItem` 사이에 다른 microtask가 끼어들어 두 flush가 같은 storage 상태를 읽고 서로의 setItem을 덮습니다.

- `flushInFlight: Promise | null` mutex 도입
- 중첩 호출자는 in-flight를 await 후 자신의 pending이 남았으면 재귀 호출
- 회귀 테스트: 동시 flush lost-update 검증

### 테스트 helpers
- `resetAlarmLogForTest()` — 모듈 스코프 상태 초기화
- `_simulateAppStateForTest(state)` — AppState 시뮬레이트 (jest.mock 호이스팅 race 회피용)

## Test plan
- [x] 모든 신규 분기(debounce/max-delay/pending merge/AppState transition/concurrent flush mutex) 단위 테스트
- [x] 기존 호출자 테스트 시그니처 변경 반영
- [x] silentPushTask flushAlarmLog mock 추가
- [x] 2567 tests pass, 100% 커버리지 (lines/branches/functions/statements)
- [x] type-check pass
- [ ] 실기기 회귀: freeze 빈도 감소 확인 (사용자 측정 필요)

## 손실 cap
- 최근 ≤5초의 로그는 비정상 종료(앱 강제종료) 시 손실 가능 — 정상 lifecycle(AppState background, silent push BG task 종료)은 자동 flush로 보장
- 운영 측정 인프라용이라 5초 손실은 수용

## 후속 (별도 이슈)
- #2 `findTopNearestStations` 5564-station 매 fix 스캔 — position-delta threshold dedup
- #3 AppState 6+ 핸들러 thundering herd — 단일 coordinator로 consolidate

Closes #735