### PR TITLE
chore(#737): bump version to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subway-now",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subway-now",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "audio-route": "file:./modules/audio-route",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-now",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- `package.json` 1.2.4 → 1.2.5 patch bump
- 태그 `v1.2.5` 생성

## 포함 변경 (1.2.4 이후)
- **#733 / PR #734** 정적 misfire 가드 D — speed=null fallback (positionStability) + station-passed 가드 + arrival-arriving 강등
- **#735 / PR #736** alarmLog batched/debounced write — JS thread freeze 회귀 해소

## Test plan
- [x] `npm version patch` 성공 (1.2.5)
- [ ] CI Type Check & Test pass
- [ ] CI SonarCloud pass
- [ ] 머지 후 실기기 회귀 검증 (별도 진행) — 정적 misfire 0건 + freeze 0건

Closes #737