### PR TITLE
feat(#740): ADR-008 Stage 2 사전 작업 — arrivalEtaProjection 순수 함수

### DIFF
--- a/src/utils/__tests__/arrivalEtaProjection.test.ts
+++ b/src/utils/__tests__/arrivalEtaProjection.test.ts
@@ -1,0 +1,327 @@
+import { projectArrivalEtaStation } from '../arrivalEtaProjection';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import type { ArrivalInfo } from '../../api/arrivalApi';
+import type { Station } from '../../types/station';
+
+const ARC: Station[] = [
+  { id: '7-001', name: '용마산', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-002', name: '중곡', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-003', name: '군자', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-004', name: '어린이대공원', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: '7-005', name: '건대입구', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+];
+
+const T0 = 1_700_000_000_000;
+const TTL_MS = 60_000;
+const TRAIN_CODE = '7093';
+const OTHER_TRAIN_CODE = '9999';
+
+function makeArrival(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
+  return {
+    destination: '장암행',
+    arrivalMinutes: 0,
+    arrivalSeconds: 30,
+    statusMessage: '',
+    trainCode: TRAIN_CODE,
+    line: '7',
+    receivedAtMs: T0,
+    arrivalCode: ARRIVAL_CODE.ENTERING,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+describe('projectArrivalEtaStation', () => {
+  it('empty arrivals → null', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('trainCode 미일치 → null', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ trainCode: OTHER_TRAIN_CODE })],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('모든 row stale (receivedAtMs=0) → null', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ receivedAtMs: 0 })],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('모든 row TTL 초과 → null', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ receivedAtMs: T0 })],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: ARC,
+        nowMs: T0 + TTL_MS + 1,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('PREV_ARRIVED(5: 전역도착) → 열차가 currentIdx에 머묾', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.PREV_ARRIVED, arrivalSeconds: 46 })],
+      trainCode: TRAIN_CODE,
+      currentIdx: 2,
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: 2,
+      station: ARC[2],
+      etaSeconds: 46,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('ENTERING(0: 진입) → 열차가 다음 역(currentIdx+1)으로 이동', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 16 })],
+      trainCode: TRAIN_CODE,
+      currentIdx: 2,
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: 3,
+      station: ARC[3],
+      etaSeconds: 16,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('ARRIVED(1: 도착) → 열차가 다음 역(currentIdx+1)으로 이동', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.ARRIVED, arrivalSeconds: 0 })],
+      trainCode: TRAIN_CODE,
+      currentIdx: 2,
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: 3,
+      station: ARC[3],
+      etaSeconds: 0,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('알 수 없는 arrivalCode(2: 출발 등) → null (안전 fallback)', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.DEPARTED })],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('RUNNING(99) → null (현재 위치 신호 부적합)', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.RUNNING })],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('arrivalCode=-1 (누락) → null', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ arrivalCode: -1 })],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('일부 fresh + 일부 stale — fresh row 사용', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [
+        makeArrival({ receivedAtMs: 0, arrivalCode: ARRIVAL_CODE.ARRIVED, arrivalSeconds: 999 }),
+        makeArrival({ receivedAtMs: T0, arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 12 }),
+      ],
+      trainCode: TRAIN_CODE,
+      currentIdx: 1,
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: 2,
+      station: ARC[2],
+      etaSeconds: 12,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('fresh row 중 trainCode 매칭만 사용 (다른 trainCode는 무시)', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [
+        makeArrival({ trainCode: OTHER_TRAIN_CODE, arrivalCode: ARRIVAL_CODE.ARRIVED, arrivalSeconds: 1 }),
+        makeArrival({ trainCode: TRAIN_CODE, arrivalCode: ARRIVAL_CODE.PREV_ARRIVED, arrivalSeconds: 50 }),
+      ],
+      trainCode: TRAIN_CODE,
+      currentIdx: 1,
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: 1,
+      station: ARC[1],
+      etaSeconds: 50,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('종착 경계 — ENTERING이면서 currentIdx+1 >= arcStations.length → 마지막 인덱스 cap', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 10 })],
+      trainCode: TRAIN_CODE,
+      currentIdx: ARC.length - 1, // 마지막 역
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: ARC.length - 1,
+      station: ARC[ARC.length - 1],
+      etaSeconds: 10,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('종착 경계 — ARRIVED이면서 currentIdx+1 >= arcStations.length → 마지막 인덱스 cap', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.ARRIVED, arrivalSeconds: 0 })],
+      trainCode: TRAIN_CODE,
+      currentIdx: ARC.length - 1,
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: ARC.length - 1,
+      station: ARC[ARC.length - 1],
+      etaSeconds: 0,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('arcStations 비었으면 → null', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.PREV_ARRIVED })],
+        trainCode: TRAIN_CODE,
+        currentIdx: 0,
+        arcStations: [],
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('currentIdx가 arc 범위 밖이면 → null (안전 가드)', () => {
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.PREV_ARRIVED })],
+        trainCode: TRAIN_CODE,
+        currentIdx: -1,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+
+    expect(
+      projectArrivalEtaStation({
+        arrivals: [makeArrival({ arrivalCode: ARRIVAL_CODE.PREV_ARRIVED })],
+        trainCode: TRAIN_CODE,
+        currentIdx: ARC.length,
+        arcStations: ARC,
+        nowMs: T0,
+        ttlMs: TTL_MS,
+      }),
+    ).toBeNull();
+  });
+
+  it('TTL 경계 — nowMs - receivedAtMs == ttlMs 정확히는 fresh로 통과', () => {
+    const r = projectArrivalEtaStation({
+      arrivals: [makeArrival({ receivedAtMs: T0, arrivalCode: ARRIVAL_CODE.PREV_ARRIVED, arrivalSeconds: 30 })],
+      trainCode: TRAIN_CODE,
+      currentIdx: 1,
+      arcStations: ARC,
+      nowMs: T0 + TTL_MS,
+      ttlMs: TTL_MS,
+    });
+    expect(r).toEqual({
+      index: 1,
+      station: ARC[1],
+      etaSeconds: 30,
+      source: 'arrival-eta',
+    });
+  });
+
+  it('우선순위 — fresh trainCode 매칭 행이 여러 개면 첫 적격 행을 사용', () => {
+    // arrivals API가 동일 trainCode 행을 여러 개 줄 일은 드물지만, 정책을 테스트로 고정.
+    const r = projectArrivalEtaStation({
+      arrivals: [
+        makeArrival({ receivedAtMs: T0, arrivalCode: ARRIVAL_CODE.PREV_ARRIVED, arrivalSeconds: 11 }),
+        makeArrival({ receivedAtMs: T0, arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 22 }),
+      ],
+      trainCode: TRAIN_CODE,
+      currentIdx: 1,
+      arcStations: ARC,
+      nowMs: T0,
+      ttlMs: TTL_MS,
+    });
+    // 첫 행(PREV_ARRIVED) 사용 → 현재 idx 유지
+    expect(r).toEqual({
+      index: 1,
+      station: ARC[1],
+      etaSeconds: 11,
+      source: 'arrival-eta',
+    });
+  });
+});

--- a/src/utils/arrivalEtaProjection.ts
+++ b/src/utils/arrivalEtaProjection.ts
@@ -1,0 +1,113 @@
+import type { ArrivalInfo } from '../api/arrivalApi';
+import type { Station } from '../types/station';
+import { ARRIVAL_CODE } from '../constants/arrivalCodes';
+
+/**
+ * ADR-008 ② ArrivalEtaStrategy의 순수 함수 코어 (Stage 2, #740).
+ *
+ * Live position이 stale일 때, 다음 역의 도착 정보(`realtimeStationArrival`)에서
+ * `trainCode === input.trainCode`인 row를 골라 `arrivalSeconds`로 실측 ETA를 얻고,
+ * `arrivalCode`로 현재역 인덱스를 정밀 판정한다.
+ *
+ * 90초 추측 적분(HOP_TIME_MS)을 사용하지 않는다 — 실제 API가 제공하는 ETA만 신뢰.
+ *
+ * 디코딩 (`src/constants/arrivalCodes.ts`와 일치):
+ *  - PREV_ARRIVED(5): 열차가 전역까지 도착 — 현재 추정 인덱스 유지 (열차가 currentIdx에 있음)
+ *  - ENTERING(0):     열차가 다음 역으로 진입 중 — currentIdx + 1
+ *  - ARRIVED(1):      열차가 다음 역에 도착 — currentIdx + 1
+ *  - 그 외(2/3/4/99/-1): 위치 신호로 부적합 → null
+ *
+ * Strategy 합성은 Stage 1(#739)의 `stationProgressEstimator`에서 수행한다.
+ * 이 모듈은 순수 함수만 제공한다.
+ */
+
+export interface ArrivalEtaProjectionInput {
+  /** 다음 역(arcStations[currentIdx + 1])의 ArrivalInfo 목록. */
+  arrivals: readonly ArrivalInfo[];
+  /** lock.trainCode — 매칭 대상 열차 식별자. */
+  trainCode: string;
+  /** 현재 추정 인덱스 (arcStations 내). */
+  currentIdx: number;
+  /** 경로 arc 역 목록. */
+  arcStations: readonly Station[];
+  /** 현재 시각 (epoch ms). */
+  nowMs: number;
+  /**
+   * 신선도 임계. `nowMs - receivedAtMs > ttlMs`면 stale row로 스킵.
+   *
+   * 계약 차이: Strategy ①(LivePosition)은 호출자가 게이트 통과 신호만 non-null로 넘기는
+   * 외부 필터 계약인 반면, ②는 raw arrivals 배열을 받아 row별 내부 필터링을 수행한다 —
+   * arrival API row가 trainCode 섞여 들어오므로 row 단위 검사가 자연스럽다.
+   */
+  ttlMs: number;
+}
+
+export interface ArrivalEtaProjectionResult {
+  /** arcStations 내 추정 인덱스. */
+  index: number;
+  /** index에 해당하는 역. */
+  station: Station;
+  /** 매칭 row의 `arrivalSeconds` (다음 역까지 남은 초). */
+  etaSeconds: number;
+  /** 신호 출처 라벨. estimator 합성 단에서 confidence 매핑에 사용. */
+  source: 'arrival-eta';
+}
+
+/**
+ * `arrivalCode`가 위치 신호로 사용 가능하면 그에 따른 인덱스 오프셋을 반환한다.
+ *  - PREV_ARRIVED(5) → 0 (currentIdx 유지 — 열차가 currentIdx 직전 도착)
+ *  - ENTERING(0) / ARRIVED(1) → 1 (다음 역 이동 확정)
+ *  - 그 외(DEPARTED/PREV_DEPARTED/PREV_ENTERING/RUNNING) → null
+ *
+ * PREV_ENTERING(4) 의도적 null: 의미상 currentIdx+0가 타당하지만, "전역 진입" 신호는
+ * 다음 hop으로 곧 바뀔 transient 상태라 적용 시점이 모호하다. 명확히 확정되는 코드(0/1/5)만
+ * 위치 신호로 사용 — 후속 stage에서 ETA seconds까지 결합할 때 재평가 (보수적 정책).
+ */
+function decodeIndexOffset(arrivalCode: number): number | null {
+  if (arrivalCode === ARRIVAL_CODE.PREV_ARRIVED) return 0;
+  if (arrivalCode === ARRIVAL_CODE.ENTERING) return 1;
+  if (arrivalCode === ARRIVAL_CODE.ARRIVED) return 1;
+  return null;
+}
+
+/**
+ * `arrival` row가 (1) 지정 trainCode 매칭, (2) 신선도 통과, (3) 디코딩 가능한
+ * arrivalCode인지 확인한다. 적격이면 인덱스 오프셋을, 아니면 null을 반환.
+ */
+function evaluateRow(
+  arrival: ArrivalInfo,
+  trainCode: string,
+  nowMs: number,
+  ttlMs: number,
+): number | null {
+  if (arrival.trainCode !== trainCode) return null;
+  // receivedAtMs === 0은 mock/누락 컨벤션 (parseRecptnDt). 항상 stale로 취급.
+  if (arrival.receivedAtMs <= 0) return null;
+  if (nowMs - arrival.receivedAtMs > ttlMs) return null;
+  return decodeIndexOffset(arrival.arrivalCode);
+}
+
+export function projectArrivalEtaStation(
+  input: ArrivalEtaProjectionInput,
+): ArrivalEtaProjectionResult | null {
+  const { arrivals, trainCode, currentIdx, arcStations, nowMs, ttlMs } = input;
+
+  if (arcStations.length === 0) return null;
+  if (currentIdx < 0 || currentIdx >= arcStations.length) return null;
+
+  for (const arrival of arrivals) {
+    const offset = evaluateRow(arrival, trainCode, nowMs, ttlMs);
+    if (offset === null) continue;
+    // 종착 경계: currentIdx + 1이 arc 밖이면 마지막 인덱스로 cap.
+    const lastIdx = arcStations.length - 1;
+    const index = Math.min(currentIdx + offset, lastIdx);
+    return {
+      index,
+      station: arcStations[index],
+      etaSeconds: arrival.arrivalSeconds,
+      source: 'arrival-eta',
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

ADR-008 Strategy ②(ArrivalEtaStrategy)의 순수 함수 코어를 미리 구현. `realtimeStationArrival`로 `trainCode === lock.trainCode` row의 `arrivalSeconds` + `arrivalCode`를 사용해 현재역을 정밀 판정한다. 90초 추측 적분을 실 API ETA로 대체.

이 PR은 **estimator/hook 미수정** — Stage 1(#739) 머지 후 별도 후속 PR에서 합성.

## Stacked on #739

base = `feat/#739-station-progress-estimator-stage1`. Stage 1이 dev로 머지되면:
1. 이 PR의 base를 `dev`로 변경
2. rebase

## Scope

- `src/utils/arrivalEtaProjection.ts` (신규)
  - input: `{ arrivals, trainCode, currentIdx, arcStations, nowMs, ttlMs }`
  - 처리: trainCode 매칭 + 신선도(`receivedAtMs > 0` && `nowMs - receivedAtMs <= ttlMs`) + `arrivalCode` 디코딩 + 종착 cap
  - output: `{ index, station, etaSeconds, source: 'arrival-eta' }` | null
  - 결과 필드명을 Stage 1 `StationProgressEstimate.index`와 통일 — 합성 시 변환 래퍼 불필요
- `src/utils/__tests__/arrivalEtaProjection.test.ts` (신규)

## Out of scope (Stage 2 통합 후속 PR)

- `stationProgressEstimator.ts`의 `tryArrivalEta` 스텁 → `projectArrivalEtaStation` 호출 교체
- `useFusedNearestStation` 다음 역 arrival 주입
- `useArrivalInfo`와 dedup 설계 (신규 폴링 신설 금지)

## Acceptance

- [x] `arrivalCode` 5/0/1/그외 매핑 검증
- [x] `trainCode` 미일치, `receivedAtMs=0`, TTL 경계, `currentIdx` 범위, 종착 cap, 다중 row 첫 적격 우선 — 모두 테스트
- [x] 2623건 테스트 통과 + 커버리지 100% (신규 모듈 포함)
- [x] type-check 통과

## Code review

`code-reviewer` 에이전트 1회 — P1 2건 본 PR에서 fix 후 재검증:
1. `stationIndex` 필드명을 Stage 1과 통일(`index`)
2. `ttlMs` 신선도 계약 비대칭(① 외부 필터 vs ② row별 내부 필터) 문서화

P2 2건은 후속 정리 (PREV_ENTERING null 처리 의도 코멘트 추가됨 / clock 후진 처리는 현재 정책 유지).

## Test plan

- [ ] Stage 1 머지 후 합성 PR에서 실제 ETA 신호로 현재역 정확도 측정
- [ ] arrivalCode 신선/stale 경계 실데이터로 확인 (TTL 임계값 튜닝 가능성)

Closes #740