### PR TITLE
fix(#741): destination 알람 dismiss UX 단순화 — 보조 버튼 제거 + 라벨 통일

### DIFF
--- a/src/components/AlarmOverlay.tsx
+++ b/src/components/AlarmOverlay.tsx
@@ -29,11 +29,14 @@ export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps)
   });
   const { colors } = useTheme();
 
-  // #633: dismiss 동작이 알람 종류별로 분기.
-  //  - transfer: trip 유지. 진동/사운드 + 이 알람만 정지. 후속 도착 알람은 계속.
-  //  - destination: 메인 버튼은 trip 종료(killAllAlarms + onEndTrip), 보조 버튼은 trip 유지
-  //    (clearAlarmNotification만). #673: 잘못 발사된 destination 알람을 끌 때 trip이 사라지는
-  //    부작용을 사용자가 명시 선택으로 회피.
+  // #741: dismiss UX 단순화 — 단일 버튼 + 통일 라벨("알람 끄기").
+  // 동작은 알람 종류별로 분기 유지:
+  //  - transfer: trip 유지. clearAlarmNotification만. 후속 도착 알람은 계속.
+  //  - destination: trip 종료. killAllAlarms + onEndTrip.
+  // Android 백 버튼/스와이프(onRequestClose)도 같은 분기를 따른다.
+  // 보조 버튼("이 알람만 끄기")은 #673에서 도입했으나 destination/lock을 건드리지 않아
+  // 다음 평가 사이클에 재발화 → 진동 재발생 회귀가 있어 제거. 미스파이어 root cause는
+  // ADR-008 #739, 정적 misfire 가드(#727/#733), 알람 misfire 큐(#370~#373)에서 처리.
   const handleDismiss = async () => {
     if (isTransfer) {
       await clearAlarmNotification();
@@ -44,21 +47,8 @@ export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps)
     onDismiss();
   };
 
-  // #673: destination 알람에서만 노출되는 보조 액션 — 이 알람만 끄고 trip 유지.
-  const handleKeepTrip = async () => {
-    await clearAlarmNotification();
-    onDismiss();
-  };
-
-  // destination 알람: Android 백 버튼/스와이프 dismiss는 보수적으로 보조 액션(trip 유지)에 연결.
-  // 메인 버튼은 명시 탭만 trip 종료 — 실수 보호(#673).
-  const onRequestClose = isTransfer ? handleDismiss : handleKeepTrip;
-  const mainButtonLabel = isTransfer
-    ? t('alarmOverlay.dismiss')
-    : t('alarmOverlay.dismissAndEnd');
-
   return (
-    <Modal visible animationType="fade" testID="alarm-overlay" onRequestClose={onRequestClose}>
+    <Modal visible animationType="fade" testID="alarm-overlay" onRequestClose={handleDismiss}>
       <View style={[styles.container, { backgroundColor: colors.bg }]}>
         <Text style={[styles.title, { color: colors.accent }]}>{title}</Text>
         <Text style={[styles.station, { color: colors.ink }]}>{message}</Text>
@@ -68,20 +58,10 @@ export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps)
           testID="alarm-dismiss-button"
           activeOpacity={0.7}
         >
-          <Text style={[styles.buttonText, { color: colors.onAccent }]}>{mainButtonLabel}</Text>
+          <Text style={[styles.buttonText, { color: colors.onAccent }]}>
+            {t('alarmOverlay.dismiss')}
+          </Text>
         </TouchableOpacity>
-        {!isTransfer && (
-          <TouchableOpacity
-            style={styles.secondaryButton}
-            onPress={handleKeepTrip}
-            testID="alarm-keep-trip-button"
-            activeOpacity={0.7}
-          >
-            <Text style={[styles.secondaryButtonText, { color: colors.muted }]}>
-              {t('alarmOverlay.keepTripOnly')}
-            </Text>
-          </TouchableOpacity>
-        )}
       </View>
     </Modal>
   );
@@ -115,15 +95,5 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: 28,
     fontWeight: '800',
-  },
-  secondaryButton: {
-    marginTop: spacing.xl,
-    paddingHorizontal: spacing.xl,
-    paddingVertical: spacing.md,
-  },
-  secondaryButtonText: {
-    fontSize: 16,
-    fontWeight: '500',
-    textDecorationLine: 'underline',
   },
 });

--- a/src/components/__tests__/AlarmOverlay.test.tsx
+++ b/src/components/__tests__/AlarmOverlay.test.tsx
@@ -68,41 +68,31 @@ describe('AlarmOverlay', () => {
     });
   });
 
-  it('환승 알람의 메인 버튼은 "알람 끄기" 텍스트', () => {
+  it('#741 환승 알람의 메인 버튼은 "알람 끄기" 텍스트', () => {
     expect(renderAlarm('transfer', '시청').getByText('알람 끄기')).toBeTruthy();
   });
 
-  it('도착 알람의 메인 버튼은 "내림 (트립 종료)" 텍스트 — UX 의도 명확화', () => {
-    expect(renderAlarm('destination', '강남').getByText('내림 (트립 종료)')).toBeTruthy();
+  it('#741 도착 알람의 메인 버튼도 "알람 끄기" 텍스트 — 라벨 통일', () => {
+    expect(renderAlarm('destination', '강남').getByText('알람 끄기')).toBeTruthy();
   });
 
-  describe('#673 destination 알람 dismiss 분리', () => {
-    it('도착 알람에서 보조 액션 "이 알람만 끄기" 버튼이 노출', () => {
-      expect(renderAlarm('destination', '강남').getByTestId('alarm-keep-trip-button')).toBeTruthy();
+  describe('#741 보조 버튼 제거 — 단일 액션 UX', () => {
+    it('도착 알람에서 보조 버튼이 노출되지 않는다 (회귀 가드)', () => {
+      expect(renderAlarm('destination', '강남').queryByTestId('alarm-keep-trip-button')).toBeNull();
     });
 
-    it('환승 알람에서는 보조 액션 미노출', () => {
+    it('환승 알람에서도 보조 버튼이 노출되지 않는다', () => {
       expect(renderAlarm('transfer', '시청').queryByTestId('alarm-keep-trip-button')).toBeNull();
     });
 
-    it('도착 알람 보조 액션 → clearAlarmNotification만, killAllAlarms·onEndTrip 호출 안 함', async () => {
-      const { getByTestId } = renderAlarm('destination', '강남');
-      fireEvent.press(getByTestId('alarm-keep-trip-button'));
-      await waitFor(() => {
-        expect(mockClearAlarmNotification).toHaveBeenCalled();
-        expect(mockKillAllAlarms).not.toHaveBeenCalled();
-        expect(mockEndTrip).not.toHaveBeenCalled();
-        expect(mockDismiss).toHaveBeenCalled();
-      });
-    });
-
-    it('도착 알람 onRequestClose(Android 백 버튼)는 trip 유지 동작 (보조 액션과 동일)', async () => {
+    it('도착 알람 onRequestClose(Android 백 버튼/스와이프)도 trip 종료 동작 — handleDismiss로 통일', async () => {
       const rendered = renderAlarm('destination', '강남');
       await triggerModalClose(rendered);
       await waitFor(() => {
-        expect(mockClearAlarmNotification).toHaveBeenCalled();
-        expect(mockKillAllAlarms).not.toHaveBeenCalled();
-        expect(mockEndTrip).not.toHaveBeenCalled();
+        expect(mockKillAllAlarms).toHaveBeenCalled();
+        expect(mockEndTrip).toHaveBeenCalled();
+        expect(mockClearAlarmNotification).not.toHaveBeenCalled();
+        expect(mockDismiss).toHaveBeenCalled();
       });
     });
 
@@ -111,7 +101,9 @@ describe('AlarmOverlay', () => {
       await triggerModalClose(rendered);
       await waitFor(() => {
         expect(mockClearAlarmNotification).toHaveBeenCalled();
+        expect(mockKillAllAlarms).not.toHaveBeenCalled();
         expect(mockEndTrip).not.toHaveBeenCalled();
+        expect(mockDismiss).toHaveBeenCalled();
       });
     });
   });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -112,9 +112,7 @@
     "arrivalTitle": "Arrival alert",
     "transferMessage": "Transfer at\n{{station}}",
     "arrivalMessage": "Exit at\n{{station}}",
-    "dismiss": "Dismiss alarm",
-    "dismissAndEnd": "Exit (end trip)",
-    "keepTripOnly": "Dismiss only (keep trip)"
+    "dismiss": "Dismiss alarm"
   },
   "destinationPicker": {
     "noLocation": "Location info unavailable.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -112,9 +112,7 @@
     "arrivalTitle": "到着アラーム",
     "transferMessage": "{{station}}で\n乗り換え",
     "arrivalMessage": "{{station}}で\n下車",
-    "dismiss": "アラームを止める",
-    "dismissAndEnd": "下車（旅程終了）",
-    "keepTripOnly": "このアラームのみ停止（旅程は維持）"
+    "dismiss": "アラームを止める"
   },
   "destinationPicker": {
     "noLocation": "位置情報がありません。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -112,9 +112,7 @@
     "arrivalTitle": "하차 알림",
     "transferMessage": "{{station}}에서\n환승하세요",
     "arrivalMessage": "{{station}}에서\n내리세요",
-    "dismiss": "알람 끄기",
-    "dismissAndEnd": "내림 (트립 종료)",
-    "keepTripOnly": "이 알람만 끄기 (트립 유지)"
+    "dismiss": "알람 끄기"
   },
   "destinationPicker": {
     "noLocation": "위치 정보가 없습니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -112,9 +112,7 @@
     "arrivalTitle": "到达提醒",
     "transferMessage": "在{{station}}\n换乘",
     "arrivalMessage": "在{{station}}\n下车",
-    "dismiss": "关闭提醒",
-    "dismissAndEnd": "下车（结束行程）",
-    "keepTripOnly": "仅关闭此提醒（保留行程）"
+    "dismiss": "关闭提醒"
   },
   "destinationPicker": {
     "noLocation": "无位置信息。",


### PR DESCRIPTION
## Summary
- destination 알람 오버레이의 보조 버튼 "이 알람만 끄기 (트립 유지)" 제거 — PR #673이 도입했으나 `clearAlarmNotification()`만 호출하고 destination/lock을 건드리지 않아 다음 알람 평가 사이클에 같은 조건으로 재발화 → 진동 재발생 회귀.
- destination/transfer 모두 단일 버튼 "알람 끄기" 라벨로 통일. "(트립 종료)"/"(트립 유지)" 괄호 라벨 제거.
- Android 백 버튼/스와이프(`onRequestClose`)도 destination에서 종료 동작(killAllAlarms + onEndTrip)으로 통일.
- i18n 4 locale(ko/en/ja/zh)에서 `alarmOverlay.dismissAndEnd`, `alarmOverlay.keepTripOnly` 키 삭제.

미스파이어 자체의 root cause는 ADR-008 #739, 정적 misfire 가드(#727/#733), 알람 misfire 큐(#370~#373)에서 처리 중. 이 PR은 UX band-aid 제거에 한정.

## Behavior change
| 알람 타입 | 메인 버튼 탭 | 백 버튼/스와이프 |
| --- | --- | --- |
| transfer | `clearAlarmNotification` (trip 유지) — 변동 없음 | `clearAlarmNotification` — 변동 없음 |
| destination | `killAllAlarms` + `onEndTrip` — 변동 없음 | `killAllAlarms` + `onEndTrip` (이전엔 trip 유지였음) |

## Test plan
- [x] `npm test` — 148 suites / 2610 tests / 커버리지 100% 통과
- [x] `npm run type-check` 통과
- [x] AlarmOverlay 10/10 통과 (라벨 통일 2건 + 보조 버튼 미노출 회귀 가드 2건 + onRequestClose 동작 통일 1건 갱신)
- [ ] 실기기 회귀: destination 알람 발화 → 메인 버튼/백 버튼 모두 trip 종료 + 후속 알람 미발화 확인
- [ ] 실기기 회귀: transfer 알람 발화 → 메인 버튼 탭 후 후속 도착 알람 정상 동작 확인

Closes #741