### PR TITLE
feat(#728): 정적 misfire 가드 B — CMMotionActivity로 motion=stationary 알람 차단

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -34,6 +34,10 @@ module.exports = {
         },
         UIBackgroundModes: ['location', 'fetch', 'remote-notification'],
         ITSAppUsesNonExemptEncryption: false,
+        // #728 — CMMotionActivity 권한 사용 설명. 정적 misfire 가드(motionStationary 신호)로
+        // 정지 상태에서의 잘못된 알람 발사를 차단.
+        NSMotionUsageDescription:
+          '정지 상태에서 잘못된 알람이 울리지 않도록 움직임 감지를 사용합니다.',
       },
     },
     android: {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'expo-router';
 import { getStationDisplayName } from '../../src/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../../src/utils/stationNotification';
 import { useStationAlarm } from '../../src/hooks/useStationAlarm';
+import { useMotionActivity } from '../../src/hooks/useMotionActivity';
 import { useTripOrigin } from '../../src/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../../src/hooks/useBackgroundLocation';
 import { useApnsTripRegistration } from '../../src/hooks/useApnsTripRegistration';
@@ -121,7 +122,10 @@ export default function HomeScreen() {
   // 동일 store의 lock을 useBoardingLockController가 아래서 다시 소비하지만 selector라 churn 없음.
   const fusionBoardingLock = useBoardingLockStore((s) => s.lock);
   const lockedTrainCode = fusionBoardingLock?.trainCode ?? null;
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock);
+  // #728 — CMMotionActivity 신호. 권한 요청/폴링은 hook 내부에서 lifecycle 관리.
+  // 미지원/거절 시 false로 고정되어 기존 가드만 동작 (graceful fallback).
+  const motionStationary = useMotionActivity();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary);
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,
@@ -209,6 +213,7 @@ export default function HomeScreen() {
     fusionSource: source,
     locationUncertain,
     positionStability,
+    motionStationary,
   });
 
   // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,

--- a/modules/motion-activity/MotionActivity.podspec
+++ b/modules/motion-activity/MotionActivity.podspec
@@ -1,0 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'MotionActivity'
+  s.version        = package['version']
+  s.summary        = 'CMMotionActivity wrapper for subway-now static misfire guard (#728)'
+  s.homepage       = 'https://github.com/handokei/subway-now'
+  s.license        = 'MIT'
+  s.author         = 'subway-now'
+  s.platform       = :ios, '15.1'
+  s.source         = { path: '.' }
+  s.source_files   = 'ios/**/*.swift'
+  s.frameworks     = 'CoreMotion'
+  s.dependency 'ExpoModulesCore'
+end

--- a/modules/motion-activity/android/build.gradle
+++ b/modules/motion-activity/android/build.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+group = 'com.subwaynow.motionactivity'
+version = '1.0.0'
+
+android {
+  namespace "com.subwaynow.motionactivity"
+  compileSdkVersion safeExtGet("compileSdkVersion", 34)
+
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 23)
+    targetSdkVersion safeExtGet("targetSdkVersion", 34)
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+}
+
+int safeExtGet(String prop, Integer fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}

--- a/modules/motion-activity/android/src/main/java/com/subwaynow/motionactivity/MotionActivityModule.kt
+++ b/modules/motion-activity/android/src/main/java/com/subwaynow/motionactivity/MotionActivityModule.kt
@@ -1,0 +1,30 @@
+package com.subwaynow.motionactivity
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+/**
+ * #728 — Android stub.
+ *
+ * CMMotionActivity와 정확히 대응되는 무권한 API가 Android에는 없다.
+ * Google Activity Recognition API는 com.google.android.gms.location.ActivityRecognition 권한이
+ * 필요하고 GMS 의존성도 늘어남. iOS 우선 정책(CLAUDE.md / 메모리)에 따라 일단 stub.
+ *
+ * 모든 함수는 graceful fallback 값을 반환 — JS wrapper(motionActivity.ts)는 false로 인식.
+ * 향후 Activity Recognition API 통합 시 같은 인터페이스로 확장.
+ */
+class MotionActivityModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("MotionActivity")
+
+        Function("isAvailable") { false }
+
+        AsyncFunction("requestPermission") { false }
+
+        Function("startUpdates") { /* no-op */ }
+
+        Function("stopUpdates") { /* no-op */ }
+
+        Function("getCurrentStationary") { false }
+    }
+}

--- a/modules/motion-activity/expo-module.config.json
+++ b/modules/motion-activity/expo-module.config.json
@@ -1,0 +1,10 @@
+{
+  "platforms": ["ios", "android"],
+  "ios": {
+    "modules": ["MotionActivityModule"],
+    "podspecPath": "MotionActivity.podspec"
+  },
+  "android": {
+    "modules": ["com.subwaynow.motionactivity.MotionActivityModule"]
+  }
+}

--- a/modules/motion-activity/index.ts
+++ b/modules/motion-activity/index.ts
@@ -1,0 +1,7 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+const MotionActivityModule =
+  // jest/web/미지원 디바이스: null → JS wrapper(src/utils/motionActivity.ts)가 graceful fallback.
+  requireOptionalNativeModule('MotionActivity');
+
+export default MotionActivityModule;

--- a/modules/motion-activity/ios/MotionActivityModule.swift
+++ b/modules/motion-activity/ios/MotionActivityModule.swift
@@ -1,0 +1,92 @@
+import ExpoModulesCore
+import CoreMotion
+
+/**
+ * #728 — CMMotionActivity wrapper.
+ *
+ * 정적 misfire 가드(`evaluateMovement`, `shouldDowngradeFusion`)의 `motionStationary` 신호 제공.
+ * speed=0.69 m/s 같은 임계 우회 phantom과 destination/transfer 카테고리 보호.
+ *
+ * 권한: NSMotionUsageDescription (Info.plist). startActivityUpdates 첫 호출 시 OS prompt.
+ * 미지원/거절: JS wrapper(motionActivity.ts)가 graceful fallback (suppress 안 함).
+ *
+ * Confidence 정책: low는 stationary로 인정하지 않음 — 보수적 (false positive 차단 우선).
+ *   - high/medium + stationary=true → true
+ *   - low confidence → false (모르는 상태)
+ *   - 그 외(walking/automotive/cycling/running) → false
+ */
+public class MotionActivityModule: Module {
+    private let manager = CMMotionActivityManager()
+    private var latestStationary: Bool = false
+    private var isUpdating: Bool = false
+
+    public func definition() -> ModuleDefinition {
+        Name("MotionActivity")
+
+        Function("isAvailable") { () -> Bool in
+            return CMMotionActivityManager.isActivityAvailable()
+        }
+
+        // 권한 요청 — startActivityUpdates를 임시로 호출해 OS prompt를 발동시키고,
+        // authorizationStatus 변화로 결과 판정. iOS는 별도 requestAuthorization API가 없어
+        // 첫 데이터 요청이 곧 권한 요청.
+        AsyncFunction("requestPermission") { (promise: Promise) in
+            if !CMMotionActivityManager.isActivityAvailable() {
+                promise.resolve(false)
+                return
+            }
+            let status = CMMotionActivityManager.authorizationStatus()
+            switch status {
+            case .authorized:
+                promise.resolve(true)
+            case .denied, .restricted:
+                promise.resolve(false)
+            case .notDetermined:
+                // 짧은 query로 prompt 발동. 응답이 오면 authorizationStatus를 다시 본다.
+                let now = Date()
+                let from = now.addingTimeInterval(-1)
+                self.manager.queryActivityStarting(from: from, to: now, to: .main) { _, _ in
+                    let next = CMMotionActivityManager.authorizationStatus()
+                    promise.resolve(next == .authorized)
+                }
+            @unknown default:
+                promise.resolve(false)
+            }
+        }
+
+        Function("startUpdates") {
+            if self.isUpdating { return }
+            guard CMMotionActivityManager.isActivityAvailable() else { return }
+            self.isUpdating = true
+            self.manager.startActivityUpdates(to: .main) { [weak self] activity in
+                guard let self = self, let activity = activity else { return }
+                self.latestStationary = self.isStationaryWithConfidence(activity)
+            }
+        }
+
+        Function("stopUpdates") {
+            if !self.isUpdating { return }
+            self.manager.stopActivityUpdates()
+            self.isUpdating = false
+            self.latestStationary = false
+        }
+
+        Function("getCurrentStationary") { () -> Bool in
+            return self.latestStationary
+        }
+    }
+
+    /// CMMotionActivity에서 신뢰 가능한 stationary 판정.
+    /// low confidence는 false (보수적) — false positive 차단 우선.
+    private func isStationaryWithConfidence(_ activity: CMMotionActivity) -> Bool {
+        guard activity.stationary else { return false }
+        switch activity.confidence {
+        case .high, .medium:
+            return true
+        case .low:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+}

--- a/modules/motion-activity/package.json
+++ b/modules/motion-activity/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "motion-activity",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-task-manager": "~14.0.9",
         "i18next": "~26.1.0",
         "live-activity": "file:./modules/live-activity",
+        "motion-activity": "file:./modules/motion-activity",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-i18next": "~17.0.7",
@@ -52,6 +53,9 @@
       "version": "1.0.0"
     },
     "modules/live-activity": {
+      "version": "1.0.0"
+    },
+    "modules/motion-activity": {
       "version": "1.0.0"
     },
     "node_modules/@0no-co/graphql.web": {
@@ -11833,6 +11837,10 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/motion-activity": {
+      "resolved": "modules/motion-activity",
+      "link": true
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
     "audio-route": "file:./modules/audio-route",
+    "motion-activity": "file:./modules/motion-activity",
     "expo": "~54.0.33",
     "expo-av": "~16.0.8",
     "expo-background-task": "~1.0.10",

--- a/src/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
@@ -116,4 +116,33 @@ describe('useFusedNearestStation — #727 fusion downgrade', () => {
 
     expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
   });
+
+  // #728 — motionStationary 신호로 speed=null 경로의 강등.
+  // useFusedNearestStation 6번째 positional 인자: motionStationary.
+  describe('#728 motionStationary downgrade', () => {
+    it('speed=null + motionStationary=true → 강등 (positionStability 없이)', () => {
+      mockUseNearest.mockReturnValue(gpsBase(null, 50));
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, true),
+      );
+      expect(result.current.confidence).toBe('gps-only');
+      expect(result.current.source).toBe('gps');
+    });
+
+    it('speed=null + motionStationary=false → 유지', () => {
+      mockUseNearest.mockReturnValue(gpsBase(null, 50));
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, false),
+      );
+      expect(result.current.confidence).toBe('position-train');
+    });
+
+    it('speed=null + motionStationary=true + accuracy noise(>100m) → 유지 (지하 GPS 보호)', () => {
+      mockUseNearest.mockReturnValue(gpsBase(null, 1500));
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, true),
+      );
+      expect(result.current.confidence).toBe('position-train');
+    });
+  });
 });

--- a/src/hooks/__tests__/useMotionActivity.test.ts
+++ b/src/hooks/__tests__/useMotionActivity.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #728 — useMotionActivity 훅 테스트.
+ *
+ * 동작:
+ *   1. mount 시 isMotionActivitySupported가 true면 requestPermission → startUpdates
+ *   2. 권한 부여되면 폴링 (POLL_INTERVAL_MS)으로 getCurrentMotionStationary 결과 상태 동기화
+ *   3. 미지원/거절 시 stationary는 항상 false (suppress 안 함)
+ *   4. unmount 시 stopUpdates
+ */
+
+const mockSupported = jest.fn();
+const mockRequest = jest.fn();
+const mockStart = jest.fn();
+const mockStop = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock('../../utils/motionActivity', () => ({
+  isMotionActivitySupported: () => mockSupported(),
+  requestMotionActivityPermission: () => mockRequest(),
+  startMotionActivityUpdates: () => mockStart(),
+  stopMotionActivityUpdates: () => mockStop(),
+  getCurrentMotionStationary: () => mockGet(),
+}));
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useMotionActivity } from '../useMotionActivity';
+
+describe('useMotionActivity (#728)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSupported.mockReset();
+    mockRequest.mockReset();
+    mockStart.mockReset();
+    mockStop.mockReset();
+    mockGet.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('미지원 디바이스 — stationary 항상 false, start/stop 호출 안 함', async () => {
+    mockSupported.mockReturnValue(false);
+    const { result, unmount } = renderHook(() => useMotionActivity());
+    await waitFor(() => expect(mockSupported).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+    unmount();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('권한 거절 — stationary false, startUpdates 호출 안 함', async () => {
+    mockSupported.mockReturnValue(true);
+    mockRequest.mockResolvedValue(false);
+    const { result, unmount } = renderHook(() => useMotionActivity());
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+    expect(mockStart).not.toHaveBeenCalled();
+    unmount();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('지원 + 권한 부여 — startUpdates 호출, 폴링으로 상태 sync', async () => {
+    mockSupported.mockReturnValue(true);
+    mockRequest.mockResolvedValue(true);
+    mockGet.mockReturnValue(false);
+
+    const { result, unmount } = renderHook(() => useMotionActivity());
+    await waitFor(() => expect(mockStart).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+
+    // 폴링 한 번 — 여전히 false
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+    expect(result.current).toBe(false);
+
+    // native가 stationary=true 신호 — 다음 폴링에서 반영
+    mockGet.mockReturnValue(true);
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+    await waitFor(() => expect(result.current).toBe(true));
+
+    // 다시 false
+    mockGet.mockReturnValue(false);
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+    await waitFor(() => expect(result.current).toBe(false));
+
+    unmount();
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('mount 직후 즉시 한 번 평가 — getCurrentMotionStationary가 true면 초기값 true', async () => {
+    mockSupported.mockReturnValue(true);
+    mockRequest.mockResolvedValue(true);
+    mockGet.mockReturnValue(true);
+
+    const { result } = renderHook(() => useMotionActivity());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('unmount 시 stopUpdates 호출 (cleanup)', async () => {
+    mockSupported.mockReturnValue(true);
+    mockRequest.mockResolvedValue(true);
+    mockGet.mockReturnValue(false);
+
+    const { unmount } = renderHook(() => useMotionActivity());
+    await waitFor(() => expect(mockStart).toHaveBeenCalled());
+    unmount();
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1653,4 +1653,157 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
     });
   });
+
+  // #728 — CMMotionActivity motionStationary 신호. 3개 effect(Phase ETA / API imminent / station-passed)
+  // 전부 동일 가드 적용. speed=0.69(임계 우회) phantom과 destination/transfer 카테고리 무방비 회귀를 잡는다.
+  describe('#728 motionStationary gate', () => {
+    const route = makeDirectRoute(1, '2');
+    const onRouteStation = makeStation('S2-DST', '강남');
+
+    it('API imminent + motionStationary=true (speed=0.69 임계 우회) → 차단 + movement-motion-stationary 적재', async () => {
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 0.69, // 임계값 0.5 우회
+            accuracyMeters: 50,
+            motionStationary: true,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: '강남',
+            kind: 'destination',
+            phaseId: 'imminent',
+            reason: 'movement-motion-stationary',
+          }),
+        );
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('Phase rawEvent (early destination) + motionStationary=true → 차단 + movement-motion-stationary 적재', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: '강남',
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            userLocation: { lat: 37.4, lng: 127 },
+            speedMps: 1.5, // 이동으로 보이는 speed지만 motion=stationary
+            accuracyMeters: 50,
+            motionStationary: true,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            stationName: '강남',
+            kind: 'destination',
+            phaseId: 'early',
+            reason: 'movement-motion-stationary',
+          }),
+        );
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('station-passed + motionStationary=true → 차단 + movement-motion-stationary 적재', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 0.69, // 임계 우회 phantom
+            accuracyMeters: 50,
+            motionStationary: true,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            stationName: '강남',
+            kind: 'station-passed',
+            reason: 'movement-motion-stationary',
+          }),
+        );
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('motionStationary=false면 차단 안 함 (이동 신호 정상)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 5,
+            accuracyMeters: 50,
+            motionStationary: false,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+
+    it('motionStationary 미전달 — 기존 동작 유지 (graceful fallback)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 5,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+
+    it('station-passed + motionStationary=true + arrivalConfirmed면 motion gate skip → 정상 발사', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      // arrivalConfirmed는 motion gate 자체를 우회 (기존 정책 — arrival API 단독 신호 보호).
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 0,
+            accuracyMeters: 50,
+            motionStationary: true,
+            arrivalConfidence: 'arrival-confirmed',
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+  });
 });

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -126,6 +126,11 @@ export function useFusedNearestStation(
    * routeContext + boardingLock 둘 다 있어야 동작 — 한쪽이라도 없으면 기존 fusion 그대로.
    */
   boardingLock?: BoardingLock | null,
+  /**
+   * #728 — CMMotionActivity(iOS) motion=stationary 신호. shouldDowngradeFusion이 speed=null인
+   * 정적 사용자 케이스에서 positionStability보다 우선 적용. 미전달이면 기존 동작 유지.
+   */
+  motionStationary?: boolean,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation();
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
@@ -388,6 +393,7 @@ export function useFusedNearestStation(
       speedMps: gps.speedMps,
       accuracyM: gps.accuracyMeters,
       positionStability,
+      motionStationary,
     })
   ) {
     confidence = 'gps-only';

--- a/src/hooks/useMotionActivity.ts
+++ b/src/hooks/useMotionActivity.ts
@@ -1,0 +1,64 @@
+/**
+ * #728 — CMMotionActivity 신호 React hook.
+ *
+ * 동작:
+ *   1. mount 시 isMotionActivitySupported 확인 → true면 권한 요청
+ *   2. 권한 부여되면 startMotionActivityUpdates + 폴링으로 stationary 상태 sync
+ *   3. 미지원/거절 케이스는 false 유지 — 호출자(useStationAlarm 등)는 motion 가드 비활성화로 인식
+ *   4. unmount 시 stopMotionActivityUpdates로 cleanup
+ *
+ * 폴링 간격(POLL_INTERVAL_MS): 5초 — 알람 평가 주기(30초)보다 짧아 stale 우려 적음.
+ *   너무 짧으면 native 부하, 너무 길면 motion 변화 누락. 5초가 절충점.
+ *
+ * 반환값: stationary boolean. true면 사용자 정적 확정.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  isMotionActivitySupported,
+  requestMotionActivityPermission,
+  startMotionActivityUpdates,
+  stopMotionActivityUpdates,
+  getCurrentMotionStationary,
+} from '../utils/motionActivity';
+
+/** 폴링 주기 — 너무 짧으면 native 부하, 너무 길면 motion 변화 누락. 5s는 절충점. */
+const POLL_INTERVAL_MS = 5_000;
+
+export function useMotionActivity(): boolean {
+  const [stationary, setStationary] = useState<boolean>(false);
+  const startedRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const init = async () => {
+      if (!isMotionActivitySupported()) return;
+      const granted = await requestMotionActivityPermission();
+      if (cancelled || !granted) return;
+
+      startMotionActivityUpdates();
+      startedRef.current = true;
+
+      // 초기 1회 + 인터벌 폴링. native가 cache한 최신 activity를 sync.
+      setStationary(getCurrentMotionStationary());
+      intervalId = setInterval(() => {
+        setStationary(getCurrentMotionStationary());
+      }, POLL_INTERVAL_MS);
+    };
+
+    void init();
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== null) clearInterval(intervalId);
+      if (startedRef.current) {
+        stopMotionActivityUpdates();
+        startedRef.current = false;
+      }
+    };
+  }, []);
+
+  return stationary;
+}

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -60,6 +60,12 @@ export interface UseStationAlarmInputs {
    */
   positionStability?: PositionStability;
   /**
+   * #728 — CMMotionActivity(iOS) motion=stationary 신호. true면 OS 가속도계가 사용자 정적으로 판정.
+   * evaluateMovement가 'motion-stationary' reason으로 모든 카테고리(destination/transfer/station-passed)
+   * 알람을 차단. 미전달/false면 기존 가드만 동작 (graceful fallback).
+   */
+  motionStationary?: boolean;
+  /**
    * 테스트 전용 — #670/#672 좌표 warmup 가드 비활성화.
    * production 호출자는 미설정으로 둠. 단위 테스트에서 mount 직후 alarm 평가 검증 시 사용.
    */
@@ -77,6 +83,7 @@ export function useStationAlarm({
   fusionSource,
   locationUncertain = false,
   positionStability,
+  motionStationary,
   skipWarmupGuard = false,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
@@ -267,6 +274,7 @@ export function useStationAlarm({
       // #733 — Phase ETA path movement gate. early phase는 etaSeconds 무관, remainingStops<=1만
       // 검사하므로 fusion이 인접역으로 jitter하면 즉시 발사. snapshot 1/2에서 관측된 20:07:48 등
       // 정적 transfer-early 회귀 차단.
+      // #728 — motionStationary 추가. speed=0.69 m/s 임계 우회 phantom과 destination/transfer 카테고리 보호.
       const movement = evaluateMovement(
         {
           speedMps: speedMps ?? undefined,
@@ -274,6 +282,7 @@ export function useStationAlarm({
         },
         undefined,
         positionStability,
+        motionStationary,
       );
       if (!movement.reliable && movement.reason) {
         logSuppressedMovement({
@@ -302,6 +311,7 @@ export function useStationAlarm({
     nearestStation?.id,
     nearestStation?.line,
     positionStability,
+    motionStationary,
     skipWarmupGuard,
   ]);
 
@@ -327,6 +337,7 @@ export function useStationAlarm({
 
     // #727 정적 misfire 가드 — useStationAlarm은 timestamp 입력이 없으므로 speed/accuracy만 평가.
     // #733 — speed=null 시 positionStability fallback 사용.
+    // #728 — motionStationary 추가. API imminent 경로의 destination 카테고리 보호 (13:53:53 회귀).
     const movement = evaluateMovement(
       {
         speedMps: speedMps ?? undefined,
@@ -334,6 +345,7 @@ export function useStationAlarm({
       },
       undefined,
       positionStability,
+      motionStationary,
     );
     if (!movement.reliable && movement.reason) {
       logSuppressedMovement({
@@ -362,6 +374,7 @@ export function useStationAlarm({
     speedMps,
     accuracyMeters,
     positionStability,
+    motionStationary,
   ]);
 
   // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.
@@ -388,9 +401,10 @@ export function useStationAlarm({
       },
       undefined,
       positionStability,
+      motionStationary,
     );
     return m.reliable ? null : MOVEMENT_TO_ALARM_LOG_REASON[m.reason];
-  }, [speedMps, accuracyMeters, positionStability]);
+  }, [speedMps, accuracyMeters, positionStability, motionStationary]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -66,6 +66,12 @@ jest.mock('../../api/alarmBackend', () => ({
   sendPushAck: (...args: unknown[]) => mockSendPushAck(...args),
 }));
 
+// #728 — motionActivity 신호. 기본 false (=== "stationary 아님"), 특정 테스트에서만 true로 override.
+const mockGetMotionStationary = jest.fn(() => false);
+jest.mock('../../utils/motionActivity', () => ({
+  getCurrentMotionStationary: () => mockGetMotionStationary(),
+}));
+
 const mockGetBoardingLock = jest.fn();
 jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
@@ -850,6 +856,72 @@ describe('silentPushTask', () => {
             kind: 'station-passed',
             reason: 'movement-static-speed',
           }),
+        );
+      });
+    });
+
+    // #728 — CMMotionActivity motion=stationary가 BG silent push 발사도 차단.
+    // FG에서 useMotionActivity가 startUpdates를 호출했다면 native cache에 최신 activity가 있고,
+    // BG handleSilentPush 진입 시 getCurrentMotionStationary가 그 값을 보고한다.
+    describe('#728 motion-stationary 가드 (CMMotionActivity)', () => {
+      it('motionStationary=true + speed=0.69 (임계 우회) → movement-motion-stationary로 skip', async () => {
+        mockGetMotionStationary.mockReturnValue(true);
+        mockCheckGate.mockResolvedValue({
+          ...PASSING_GATE,
+          speedMps: 0.69, // STATIC_SPEED_THRESHOLD_MPS=0.5 우회
+          accuracyM: 30,
+        });
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'motion-skip' }),
+        );
+
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: 'movement-motion-stationary',
+            stationName: '강남',
+            kind: 'destination',
+            phaseId: 'imminent',
+          }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'motion-skip',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'movement-motion-stationary',
+        });
+      });
+
+      it('motionStationary=false (default) — 기존 speed/accuracy 가드만 동작', async () => {
+        // 명시적으로 false 설정 — speed/accuracy 정상이면 정상 발사
+        mockGetMotionStationary.mockReturnValue(false);
+        mockCheckGate.mockResolvedValue({
+          ...PASSING_GATE,
+          speedMps: 5,
+          accuracyM: 30,
+        });
+
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('motionStationary=true는 speed 정상값보다 우선 — 차단', async () => {
+        mockGetMotionStationary.mockReturnValue(true);
+        mockCheckGate.mockResolvedValue({
+          ...PASSING_GATE,
+          speedMps: 5, // 명백한 이동 신호인데 motion=stationary
+          accuracyM: 30,
+        });
+
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'movement-motion-stationary' }),
         );
       });
     });

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -32,6 +32,7 @@ import {
   type AlarmLogReason,
 } from '../utils/alarmLog';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../utils/movementGate';
+import { getCurrentMotionStationary } from '../utils/motionActivity';
 import { addFiredPushId } from '../utils/firedPushIds';
 import {
   checkSilentPushLocationGate,
@@ -406,10 +407,19 @@ async function fireWithGate(
   // #727 — 정적 misfire 가드. gate는 거리/freshness만 검증하지만 사용자가 정적이면 잘못된
   // trainCode/fusion lock으로 잘못 발사될 수 있다. expo-location LocationObject의 speed/
   // accuracy가 있으면 평가 — 미측정(`speed === -1` 등)이면 skip하고 graceful pass.
-  const movement = evaluateMovement({
-    speedMps: gate.speedMps,
-    accuracyM: gate.accuracyM,
-  });
+  // #728 — CMMotionActivity motion=stationary 신호 동시 적용. BG에선 hook 못쓰니 직접 호출 — native
+  // module이 startUpdates된 상태(FG에서 useMotionActivity가 시작)에서 latest cache된 값을 반환.
+  // 권한 미부여/미지원/native fault 시 false → 기존 가드만 동작 (graceful fallback).
+  const motionStationary = getCurrentMotionStationary();
+  const movement = evaluateMovement(
+    {
+      speedMps: gate.speedMps,
+      accuracyM: gate.accuracyM,
+    },
+    undefined,
+    undefined,
+    motionStationary,
+  );
   if (!movement.reliable && movement.reason) {
     const movementReason = MOVEMENT_TO_ALARM_LOG_REASON[movement.reason];
     logSilentPushSkipped({

--- a/src/utils/__tests__/motionActivity.test.ts
+++ b/src/utils/__tests__/motionActivity.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #728 — CMMotionActivity JS wrapper 테스트.
+ *
+ * native module이 jest 환경에서 null이라 graceful fallback이 핵심:
+ *   - 미지원/권한 거절 시 isMotionStationary는 false (== "not known stationary" → suppress 안 함)
+ *   - 호출 자체는 throw 없이 안전
+ *
+ * native 호출의 성공/실패 시나리오는 module spy로 시뮬레이션.
+ */
+
+const mockNativeModule = {
+  isAvailable: jest.fn(),
+  requestPermission: jest.fn(),
+  startUpdates: jest.fn(),
+  stopUpdates: jest.fn(),
+  getCurrentStationary: jest.fn(),
+};
+
+const mockedRequire = jest.fn();
+
+jest.mock('expo-modules-core', () => ({
+  requireOptionalNativeModule: (...args: unknown[]) => mockedRequire(...args),
+}));
+
+import {
+  isMotionActivitySupported,
+  requestMotionActivityPermission,
+  startMotionActivityUpdates,
+  stopMotionActivityUpdates,
+  getCurrentMotionStationary,
+} from '../motionActivity';
+
+describe('motionActivity (#728)', () => {
+  beforeEach(() => {
+    mockedRequire.mockReset();
+    mockNativeModule.isAvailable.mockReset();
+    mockNativeModule.requestPermission.mockReset();
+    mockNativeModule.startUpdates.mockReset();
+    mockNativeModule.stopUpdates.mockReset();
+    mockNativeModule.getCurrentStationary.mockReset();
+  });
+
+  describe('native module 없음 (jest 기본 / 미지원 디바이스)', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(null);
+    });
+
+    it('isMotionActivitySupported() → false', () => {
+      expect(isMotionActivitySupported()).toBe(false);
+    });
+
+    it('requestMotionActivityPermission() → false (no-op)', async () => {
+      await expect(requestMotionActivityPermission()).resolves.toBe(false);
+    });
+
+    it('startMotionActivityUpdates() — throw 없이 graceful', () => {
+      expect(() => startMotionActivityUpdates()).not.toThrow();
+    });
+
+    it('stopMotionActivityUpdates() — throw 없이 graceful', () => {
+      expect(() => stopMotionActivityUpdates()).not.toThrow();
+    });
+
+    it('getCurrentMotionStationary() → false (모르는 상태는 suppress 안 함)', () => {
+      expect(getCurrentMotionStationary()).toBe(false);
+    });
+  });
+
+  describe('native module 있음 (iOS 디바이스)', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(mockNativeModule);
+    });
+
+    it('isMotionActivitySupported() — native isAvailable 위임 true', () => {
+      mockNativeModule.isAvailable.mockReturnValue(true);
+      expect(isMotionActivitySupported()).toBe(true);
+      expect(mockNativeModule.isAvailable).toHaveBeenCalled();
+    });
+
+    it('isMotionActivitySupported() — native가 false 반환하면 false', () => {
+      mockNativeModule.isAvailable.mockReturnValue(false);
+      expect(isMotionActivitySupported()).toBe(false);
+    });
+
+    it('isMotionActivitySupported() — native 예외 시 false (graceful)', () => {
+      mockNativeModule.isAvailable.mockImplementation(() => {
+        throw new Error('available-fail');
+      });
+      expect(isMotionActivitySupported()).toBe(false);
+    });
+
+    it('requestMotionActivityPermission() — 권한 부여 시 true', async () => {
+      mockNativeModule.requestPermission.mockResolvedValue(true);
+      await expect(requestMotionActivityPermission()).resolves.toBe(true);
+    });
+
+    it('requestMotionActivityPermission() — 권한 거절 시 false', async () => {
+      mockNativeModule.requestPermission.mockResolvedValue(false);
+      await expect(requestMotionActivityPermission()).resolves.toBe(false);
+    });
+
+    it('requestMotionActivityPermission() — native 예외 시 false (graceful)', async () => {
+      mockNativeModule.requestPermission.mockRejectedValue(new Error('perm-fail'));
+      await expect(requestMotionActivityPermission()).resolves.toBe(false);
+    });
+
+    it('startMotionActivityUpdates() — native startUpdates 호출', () => {
+      startMotionActivityUpdates();
+      expect(mockNativeModule.startUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('startMotionActivityUpdates() — native 예외 graceful', () => {
+      mockNativeModule.startUpdates.mockImplementation(() => {
+        throw new Error('start-fail');
+      });
+      expect(() => startMotionActivityUpdates()).not.toThrow();
+    });
+
+    it('stopMotionActivityUpdates() — native stopUpdates 호출', () => {
+      stopMotionActivityUpdates();
+      expect(mockNativeModule.stopUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('stopMotionActivityUpdates() — native 예외 graceful', () => {
+      mockNativeModule.stopUpdates.mockImplementation(() => {
+        throw new Error('stop-fail');
+      });
+      expect(() => stopMotionActivityUpdates()).not.toThrow();
+    });
+
+    it('getCurrentMotionStationary() — true 보고', () => {
+      mockNativeModule.getCurrentStationary.mockReturnValue(true);
+      expect(getCurrentMotionStationary()).toBe(true);
+    });
+
+    it('getCurrentMotionStationary() — false 보고', () => {
+      mockNativeModule.getCurrentStationary.mockReturnValue(false);
+      expect(getCurrentMotionStationary()).toBe(false);
+    });
+
+    it('getCurrentMotionStationary() — native 예외 시 false (graceful)', () => {
+      mockNativeModule.getCurrentStationary.mockImplementation(() => {
+        throw new Error('get-fail');
+      });
+      expect(getCurrentMotionStationary()).toBe(false);
+    });
+
+    it('getCurrentMotionStationary() — non-boolean 반환 시 false (방어)', () => {
+      mockNativeModule.getCurrentStationary.mockReturnValue(undefined);
+      expect(getCurrentMotionStationary()).toBe(false);
+    });
+  });
+});

--- a/src/utils/__tests__/movementGate.test.ts
+++ b/src/utils/__tests__/movementGate.test.ts
@@ -114,12 +114,13 @@ describe('movementGate', () => {
   });
 
   describe('MOVEMENT_TO_ALARM_LOG_REASON', () => {
-    it('5개 MovementReason 모두 매핑', () => {
+    it('6개 MovementReason 모두 매핑 (#728: motion-stationary 추가)', () => {
       expect(MOVEMENT_TO_ALARM_LOG_REASON['no-location']).toBe('movement-no-location');
       expect(MOVEMENT_TO_ALARM_LOG_REASON['stale-timestamp']).toBe('movement-stale-timestamp');
       expect(MOVEMENT_TO_ALARM_LOG_REASON['low-accuracy']).toBe('movement-low-accuracy');
       expect(MOVEMENT_TO_ALARM_LOG_REASON['static-speed']).toBe('movement-static-speed');
       expect(MOVEMENT_TO_ALARM_LOG_REASON['static-position']).toBe('movement-static-position');
+      expect(MOVEMENT_TO_ALARM_LOG_REASON['motion-stationary']).toBe('movement-motion-stationary');
     });
   });
 
@@ -303,6 +304,156 @@ describe('movementGate', () => {
       // speed 이동 → reliable (positionStability=static이어도)
       const m2 = evaluateMovement({ speedMps: 5, accuracyM: 50 }, undefined, 'static');
       expect(m2.reliable).toBe(true);
+    });
+  });
+
+  // #728 — CMMotionActivity motion=stationary 신호 가드.
+  // 핵심 동기: 16:14:22 디바이스 로그의 station-passed | 용마산 회귀.
+  // snapshot speed=0.69 m/s (느린 도보)로 STATIC_SPEED_THRESHOLD_MPS=0.5 우회 → 잘못 발사.
+  // motion=stationary 신호로 임계값 우회 케이스를 잡는다. 또한 destination/transfer 카테고리도 보호.
+  describe('#728 — evaluateMovement motionStationary 가드', () => {
+    it('motionStationary=true이면 reliable=false reason=motion-stationary (다른 신호 정상)', () => {
+      const now = 1_000_000;
+      const m = evaluateMovement(
+        { timestamp: now, accuracyM: 50, speedMps: 1.5 },
+        now,
+        undefined,
+        true,
+      );
+      expect(m.reliable).toBe(false);
+      expect(m.reason).toBe('motion-stationary');
+    });
+
+    it('motionStationary=true 임계 우회 케이스 (16:14:22 회귀) — speed=0.69 m/s 차단', () => {
+      const now = 1_000_000;
+      const m = evaluateMovement(
+        { timestamp: now, accuracyM: 50, speedMps: 0.69 },
+        now,
+        undefined,
+        true,
+      );
+      expect(m.reliable).toBe(false);
+      expect(m.reason).toBe('motion-stationary');
+    });
+
+    it('motionStationary=false면 차단 안 함 (다른 신호 정상)', () => {
+      const now = 1_000_000;
+      const m = evaluateMovement(
+        { timestamp: now, accuracyM: 50, speedMps: 1.5 },
+        now,
+        undefined,
+        false,
+      );
+      expect(m.reliable).toBe(true);
+    });
+
+    it('motionStationary=undefined면 기존 동작 유지 (미전달 graceful fallback)', () => {
+      const now = 1_000_000;
+      const m = evaluateMovement(
+        { timestamp: now, accuracyM: 50, speedMps: 1.5 },
+        now,
+      );
+      expect(m.reliable).toBe(true);
+    });
+
+    it('평가 순서: stale > accuracy > motion-stationary > speed > position', () => {
+      const now = 1_000_000;
+      // stale 위반 + motionStationary=true → stale이 먼저 잡혀야 함
+      const m1 = evaluateMovement(
+        { timestamp: now - STALE_AGE_MS - 1, accuracyM: 50, speedMps: 5 },
+        now,
+        undefined,
+        true,
+      );
+      expect(m1.reason).toBe('stale-timestamp');
+
+      // accuracy 위반 + motionStationary=true → accuracy가 먼저
+      const m2 = evaluateMovement(
+        { timestamp: now, accuracyM: 999, speedMps: 5 },
+        now,
+        undefined,
+        true,
+      );
+      expect(m2.reason).toBe('low-accuracy');
+
+      // stale/accuracy 정상 + motionStationary=true + speed=0(static-speed도 위반) → motion이 먼저
+      // (motion이 speed보다 우선 — 임계 우회 회귀 차단이 핵심 동기)
+      const m3 = evaluateMovement(
+        { timestamp: now, accuracyM: 50, speedMps: 0 },
+        now,
+        undefined,
+        true,
+      );
+      expect(m3.reason).toBe('motion-stationary');
+
+      // motionStationary=true + speed=null + positionStability=static → motion이 먼저
+      const m4 = evaluateMovement(
+        { timestamp: now, accuracyM: 50 },
+        now,
+        'static',
+        true,
+      );
+      expect(m4.reason).toBe('motion-stationary');
+    });
+  });
+
+  describe('#728 — isStaticSpeedSignal motionStationary fallback', () => {
+    it('motionStationary=true이면 speed=null이어도 true (positionStability 없이)', () => {
+      expect(isStaticSpeedSignal(null, 50, undefined, true)).toBe(true);
+      expect(isStaticSpeedSignal(undefined, 50, undefined, true)).toBe(true);
+    });
+
+    it('motionStationary=true는 speed 정상값보다 약함 (speed가 우선)', () => {
+      // speed=5 정상이면 motionStationary=true여도 false (fusion downgrade는 명확한 정적만)
+      expect(isStaticSpeedSignal(5, 50, undefined, true)).toBe(false);
+    });
+
+    it('motionStationary=false + speed=null이면 false (보수)', () => {
+      expect(isStaticSpeedSignal(null, 50, undefined, false)).toBe(false);
+    });
+
+    it('motionStationary=true이지만 accuracy noise면 false (지하 GPS 노이즈 보호)', () => {
+      expect(isStaticSpeedSignal(null, MAX_ACCURACY_M + 1, undefined, true)).toBe(false);
+    });
+
+    it('motionStationary=true + positionStability=moving이면 true (motion이 우선)', () => {
+      // speed 미측정인 경우 motion이 positionStability보다 우선 — OS 가속도계가 더 신뢰성 있음
+      expect(isStaticSpeedSignal(null, 50, 'moving', true)).toBe(true);
+    });
+  });
+
+  describe('#728 — shouldDowngradeFusion motionStationary', () => {
+    it('승격 라벨 + motionStationary=true (speed=null) → true', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'position-train',
+          speedMps: null,
+          accuracyM: 50,
+          motionStationary: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('승격 라벨 아니면 motionStationary=true여도 false', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'gps-only',
+          speedMps: null,
+          accuracyM: 50,
+          motionStationary: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('승격 라벨 + motionStationary=false (다른 신호도 정상) → false', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'position-train',
+          speedMps: 5,
+          accuracyM: 50,
+          motionStationary: false,
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -66,11 +66,13 @@ export type AlarmLogReason =
   | 'payload-missing-kind'
   // #727 — 정적 misfire 가드(movementGate.ts)가 차단한 발사.
   // #733 — 'movement-static-position'은 speed 미측정 시 위치 이력(usePositionStability) 기반 정적 차단.
+  // #728 — 'movement-motion-stationary'는 CMMotionActivity(iOS) motion=stationary 신호 기반.
   | 'movement-no-location'
   | 'movement-stale-timestamp'
   | 'movement-low-accuracy'
   | 'movement-static-speed'
-  | 'movement-static-position';
+  | 'movement-static-position'
+  | 'movement-motion-stationary';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/utils/motionActivity.ts
+++ b/src/utils/motionActivity.ts
@@ -1,0 +1,83 @@
+/**
+ * #728 — CMMotionActivity(iOS) wrapper.
+ *
+ * 목적: 가속도계 기반 motion=stationary 신호를 JS 레이어에 안전하게 노출.
+ * movementGate(`evaluateMovement`, `shouldDowngradeFusion`)의 `motionStationary` 입력으로 사용.
+ *
+ * 모든 API는 graceful — native module 부재(jest/web/미지원 디바이스), 권한 거절, 예외 모두
+ * `false` / no-op로 처리한다. "모르는 상태"는 알람 suppress 안 함 (false positive 차단 우선).
+ *
+ * Android: CMMotionActivity와 정확히 대응되는 무권한 API가 없어 native module은 stub(false 반환).
+ *          향후 Activity Recognition API 통합 시 같은 인터페이스로 확장 가능.
+ *
+ * 인터페이스:
+ *   - isMotionActivitySupported(): 디바이스 가속도계 + Motion 권한 지원 여부
+ *   - requestMotionActivityPermission(): 사용자에게 권한 prompt (iOS NSMotionUsageDescription)
+ *   - startMotionActivityUpdates(): activity 폴링 시작 — 앱 사용 중 한 번만 호출
+ *   - stopMotionActivityUpdates(): 폴링 중지
+ *   - getCurrentMotionStationary(): 마지막 보고된 stationary 상태 (boolean, default false)
+ */
+
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+interface MotionActivityNative {
+  isAvailable(): boolean;
+  requestPermission(): Promise<boolean>;
+  startUpdates(): void;
+  stopUpdates(): void;
+  getCurrentStationary(): boolean;
+}
+
+function getNativeModule(): MotionActivityNative | null {
+  return requireOptionalNativeModule<MotionActivityNative>('MotionActivity') ?? null;
+}
+
+export function isMotionActivitySupported(): boolean {
+  const module = getNativeModule();
+  if (!module) return false;
+  try {
+    return module.isAvailable();
+  } catch {
+    return false;
+  }
+}
+
+export async function requestMotionActivityPermission(): Promise<boolean> {
+  const module = getNativeModule();
+  if (!module) return false;
+  try {
+    return await module.requestPermission();
+  } catch {
+    return false;
+  }
+}
+
+export function startMotionActivityUpdates(): void {
+  const module = getNativeModule();
+  if (!module) return;
+  try {
+    module.startUpdates();
+  } catch {
+    // graceful — 시작 실패는 후속 getCurrentMotionStationary가 false 반환으로 자연 fallback
+  }
+}
+
+export function stopMotionActivityUpdates(): void {
+  const module = getNativeModule();
+  if (!module) return;
+  try {
+    module.stopUpdates();
+  } catch {
+    // graceful — 중지 실패는 lifecycle 관점에서 무해
+  }
+}
+
+export function getCurrentMotionStationary(): boolean {
+  const module = getNativeModule();
+  if (!module) return false;
+  try {
+    return module.getCurrentStationary() === true;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/movementGate.ts
+++ b/src/utils/movementGate.ts
@@ -1,5 +1,5 @@
 /**
- * 정적 misfire 가드 (#727 PR A → #733 PR D 확장) — 모든 알람 발사 경로의 SSOT.
+ * 정적 misfire 가드 (#727 PR A → #733 PR D → #728 PR B 확장) — 모든 알람 발사 경로의 SSOT.
  *
  * 알람 발사 4개 채널(useStationAlarm ETA / API imminent / silent push / 사전 예약) 가운데
  * ETA phase만 speed+accuracy 게이트를 갖고 있던 회귀를 보완. 사용자가 정적인데 다음의
@@ -17,6 +17,13 @@
  *     positionStability(usePositionStability) 신호로 fallback. 위치 이력이 정적이면 'static-position'으로 차단.
  *   - FUSION_DOWNGRADE_TARGETS에 'arrival-arriving' 추가 — arrival ENTERING 신호로 fusion이
  *     elevated 되어도 정적이면 강등 대상.
+ *
+ * #728 (PR B) 확장:
+ *   - CMMotionActivity(iOS) motion=stationary 신호 추가. OS 가속도계 기반 정적 판정.
+ *   - 평가 순서: stale > accuracy > **motion-stationary** > speed > position.
+ *     motion이 speed보다 우선 — 16:14:22 회귀에서 snapshot speed=0.69 m/s가 STATIC_SPEED_THRESHOLD_MPS=0.5를
+ *     우회한 phantom 케이스를 잡기 위함. destination/transfer 카테고리도 같은 가드로 보호.
+ *   - 권한 거절/미지원: motionStationary 미전달 → 기존 가드만 동작 (graceful fallback).
  *
  * 입력 필드는 모두 옵션 — 호출자가 측정 가능한 신호만 전달하면 된다. 누락된 신호는
  * 해당 분기 검증을 skip (false negative보다 false positive 차단 우선).
@@ -39,7 +46,10 @@ export type MovementReason =
   | 'low-accuracy'
   | 'static-speed'
   // #733 — speed 미측정 시 위치 이력(usePositionStability)으로 정적 확정.
-  | 'static-position';
+  | 'static-position'
+  // #728 — CMMotionActivity(iOS) motion=stationary 신호. OS 가속도계 기반 정적 판정.
+  // speed=0.69 m/s 같은 임계 우회 phantom과 destination/transfer 카테고리 무방비 회귀를 동시에 차단.
+  | 'motion-stationary';
 
 interface MovementSignalShared {
   speedMps?: number;
@@ -65,6 +75,7 @@ export const MOVEMENT_TO_ALARM_LOG_REASON = {
   'low-accuracy': 'movement-low-accuracy',
   'static-speed': 'movement-static-speed',
   'static-position': 'movement-static-position',
+  'motion-stationary': 'movement-motion-stationary',
 } as const satisfies Record<MovementReason, string>;
 
 /**
@@ -84,16 +95,24 @@ export const MOVEMENT_TO_ALARM_LOG_REASON = {
  * #733 — speedMps가 null/undefined인 경우 `positionStability` fallback. iOS 정적 사용자에게서
  * speed=-1(미측정)이 자주 발생하는 케이스 보강. positionStability='static'이면 정적 확정,
  * 'moving'/'unknown'이면 보수적 false. accuracy 가드(MAX_ACCURACY_M)는 fallback 경로에도 적용.
+ *
+ * #728 — speedMps가 null/undefined인 경우 motionStationary(CMMotionActivity) 신호를 positionStability보다
+ * 우선 적용. motion=true면 즉시 정적 확정. motion 신호는 OS 가속도계 기반이라 GPS 좌표 이력보다
+ * 신뢰성 있다. accuracy 가드는 motion fallback 경로에도 동일 적용 (지하 GPS 노이즈 보호).
  */
 export function isStaticSpeedSignal(
   speedMps: number | null | undefined,
   accuracyM?: number | null,
   positionStability?: PositionStability,
+  motionStationary?: boolean,
 ): boolean {
   if (accuracyM != null && accuracyM > MAX_ACCURACY_M) return false;
   if (speedMps != null) {
     return speedMps < STATIC_SPEED_THRESHOLD_MPS;
   }
+  // #728 — speed 미측정 시 motion 신호(OS 가속도계)가 위치 이력보다 우선.
+  // CMMotionActivity는 직접 측정값이라 noisy한 GPS 좌표 이력보다 신뢰 가능.
+  if (motionStationary === true) return true;
   return positionStability === 'static';
 }
 
@@ -125,9 +144,16 @@ export function shouldDowngradeFusion(input: {
   speedMps: number | null | undefined;
   accuracyM: number | null | undefined;
   positionStability?: PositionStability;
+  /** #728 — CMMotionActivity stationary 신호. speed=null 경로에서 positionStability보다 우선. */
+  motionStationary?: boolean;
 }): boolean {
   if (!isFusionDowngradeTarget(input.confidence)) return false;
-  return isStaticSpeedSignal(input.speedMps, input.accuracyM, input.positionStability);
+  return isStaticSpeedSignal(
+    input.speedMps,
+    input.accuracyM,
+    input.positionStability,
+    input.motionStationary,
+  );
 }
 
 export interface LocationSignalInput {
@@ -146,9 +172,12 @@ export interface LocationSignalInput {
  *   1. loc === null → 'no-location'
  *   2. timestamp 있으면서 (now - timestamp) > STALE_AGE_MS → 'stale-timestamp'
  *   3. accuracyM 있으면서 > MAX_ACCURACY_M → 'low-accuracy'
- *   4. speedMps 있으면서 < STATIC_SPEED_THRESHOLD_MPS → 'static-speed'
- *   5. (#733) speedMps 없고 positionStability='static' → 'static-position'
- *   6. 그 외 → reliable=true
+ *   4. (#728) motionStationary === true → 'motion-stationary'
+ *      - speed/position 신호보다 우선. 16:14:22 회귀(speed=0.69 임계 우회)와
+ *        destination/transfer 카테고리 무방비를 동시 차단하는 핵심 신호.
+ *   5. speedMps 있으면서 < STATIC_SPEED_THRESHOLD_MPS → 'static-speed'
+ *   6. (#733) speedMps 없고 positionStability='static' → 'static-position'
+ *   7. 그 외 → reliable=true
  *
  * 호출자는 결과의 reason으로 logSuppressedGate/logSilentPushSkipped 등 적재.
  */
@@ -156,6 +185,7 @@ export function evaluateMovement(
   loc: LocationSignalInput | null,
   now: number = Date.now(),
   positionStability?: PositionStability,
+  motionStationary?: boolean,
 ): MovementSignal {
   if (!loc) return { reliable: false, reason: 'no-location' };
 
@@ -168,6 +198,13 @@ export function evaluateMovement(
 
   if (loc.accuracyM != null && loc.accuracyM > MAX_ACCURACY_M) {
     return { reliable: false, reason: 'low-accuracy', accuracyM: loc.accuracyM };
+  }
+
+  // #728 — CMMotionActivity 정적 신호. speed/position보다 우선.
+  // 핵심 동기: speed=0.69 m/s (임계값 0.5 우회 phantom) 같은 회귀를 잡고,
+  // destination/transfer 카테고리도 같은 가드로 보호.
+  if (motionStationary === true) {
+    return { reliable: false, reason: 'motion-stationary' };
   }
 
   if (loc.speedMps != null && loc.speedMps < STATIC_SPEED_THRESHOLD_MPS) {


### PR DESCRIPTION
## Summary

PR A(#727)/D(#733) 정적 가드가 station-passed 전용이라 destination/transfer 카테고리 phantom을 못 막는 한계를 하드웨어 motion 신호로 보강. iOS Core Motion의 isStationary로 모든 알람 카테고리 게이팅.

## 로그 증거 (디바이스 + wrangler)

```
13:53:53  fg | fired | destination | early | 용마산   ← 정적 상태에서 통과 (직전 1초 station-passed는 movement-static-speed로 막힘)
16:14:22  fg | fired | station-passed | 용마산        ← snapshot speed 0.69 m/s (느린 도보, 진짜 trip 이동 아님). 16:14:03과 16:15:22엔 막혔는데 그 사이 잠깐 임계 우회
```

PR A/D는 speed 임계 기반이라 (a) 카테고리 누수 (b) 임계 우회 두 갭이 있음. CMMotionActivity는 (a) 모든 카테고리에 적용 (b) 하드웨어 motion=stationary로 도보 jitter 차단.

## Scope

- `modules/motion-activity/` (신규) — iOS Swift / Android Kotlin 네이티브 모듈, `CMMotionActivityManager` 래퍼
- `src/utils/motionActivity.ts` — 네이티브 JS 어댑터, `requireOptionalNativeModule`로 graceful fallback
- `src/hooks/useMotionActivity.ts` — 권한 요청 + 5초 폴링 + cleanup
- `src/utils/movementGate.ts` — motion=stationary 검사 추가, 기존 PR A/D와 OR 관계
- `src/hooks/useFusedNearestStation.ts` + `useStationAlarm.ts` — motion 신호 주입
- `src/tasks/silentPushTask.ts` — BG 컨텍스트 motion 활용
- `src/utils/alarmLog.ts` — suppression reason `motion-stationary` 추가
- `app.config.js` — Info.plist `NSMotionUsageDescription`

## Out of scope / 알려진 한계 (후속 개선 후보)

- **BG cold launch 시 motion 신호 stale** — JS hook이 mount되기 전 silent push 도착하면 `startMotionActivityUpdates`가 안 불려 motion gate 무력. 기존 PR A/D 가드 fallback으로 동작 (false negative 허용)
- **권한 prompt 응답 지연 retry 없음** — 일반적 expo 권한 패턴

## Acceptance

- [x] 정적 motion 상태 시 모든 카테고리(station-passed/transfer/destination) 알람 suppress
- [x] 권한 거절/미지원 시 graceful fallback (기존 가드만 동작)
- [x] 알람 로그에 `motion-stationary` reason 기록
- [x] 2654건 테스트 통과 + 커버리지 100% (신규 모듈 포함)
- [x] type-check 통과

## 실기기 검증 필요 (수동)

- [ ] Motion 권한 prompt 노출 + 부여/거절 양쪽 동작
- [ ] 실제 정지 → walking 전환 시 motion gate 해제 확인
- [ ] 권한 거절 시 기존 PR A/D 가드만으로 동작 (회귀 없음)
- [ ] iOS 빌드 — `cd ios && pod install` 또는 EAS 빌드로 native 모듈 통합 확인
- [ ] phantom 알람 시나리오 재현 → suppress 확인 (정적 상태에서 30초 이상 폴링)

## Code review

`code-reviewer` 에이전트 1회 — 6건 발견:
- F1 (useMotionActivity cleanup race) — line 39 cancelled 체크 존재, 단일스레드 JS interleave 불가로 **false positive** 판정
- F2/F3 (BG cold launch motion stale) — 위 "알려진 한계"에 명시
- F4 (prompt 응답 지연 retry 없음) — 일반적 패턴
- F5 (`getNativeModule()` lookup 빈도) — 테스트 mock 편의 의도, 코멘트로 명시 가능
- F6 (`modules/motion-activity/index.ts` dead export) — npm entry이지만 등록 사이드 이펙트만, 안전 위해 유지

P0/P1 머지 블로커 없음.

Closes #728