### PR TITLE
feat(#745): ADR-008 Stage 2 통합 — ArrivalEtaStrategy 합성

### DIFF
--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -9,6 +9,7 @@ import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
 import { TRAIN_STATUS } from '../../constants/trainStatus';
 import { MOCK_STATIONS } from '../../testUtils/fixtures';
 import type { StationArrival, ArrivalInfo } from '../../api/arrivalApi';
+import type { Station } from '../../types/station';
 import type { LinePositions, TrainPosition } from '../../api/positionApi';
 import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
@@ -1148,25 +1149,19 @@ describe('useFusedNearestStation', () => {
       }
     });
 
-    it('다음 역이 GPS 후보가 아니면 ② skip → ③(ReanchoredHop)으로 fallback (line 133 return [])', () => {
+    // ② skip 시나리오 공통 헬퍼 — 두 테스트가 동일한 시드 패턴(LivePosition 신선 → 끊김 → ③ fallback)을
+    // 공유하지만 후보 슬롯/arrival 데이터/시간 진행만 다르므로 중복 setup을 helper로 추출 (SonarCloud CPD).
+    function runArrivalEtaSkipScenario(opts: {
+      candidates: Array<{ station: Station; distanceKm: number }>;
+      arrivalMock: (name: string | null) => ReturnType<typeof arrivalRet>;
+      disconnectAtMs: number;
+    }) {
       jest.useFakeTimers();
       try {
-        // 1+2단계: LivePosition 신선 두 번 (Effect 2의 lock-key race 우회) → lastObservedRef=idx 0
         jest.setSystemTime(T0_745);
         setupLooseAccuracyAt(yongmasan);
-        // 후보에 다음 역(중곡) 없음 — 그러나 pickArrivalsForStation 루프는 진입.
-        // 슬롯 stationName=용마산 vs station.name=중곡 → 모두 continue → 루프 종료 후 return [] (line 133).
-        mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-        // 슬롯에 arrival 데이터를 주입(중곡 외 다른 역) — line 127('!arrival') continue 분기가 아닌
-        // line 128(stationName !== station.name) continue 분기를 타도록 한다. 이 차이로 line 133 도달 후 branch 분기 모두 cover.
-        const arrivalAtYongmasan: StationArrival = {
-          up: [info(ARRIVAL_CODE.RUNNING, { trainCode: 'OTHER', line: '7' })],
-          down: [],
-        };
-        mockUseArrival.mockImplementation((name: string | null) => {
-          if (name === yongmasan.name) return arrivalRet(arrivalAtYongmasan);
-          return arrivalRet(null);
-        });
+        mockFindTop.mockReturnValue(opts.candidates);
+        mockUseArrival.mockImplementation(opts.arrivalMock);
         mockUsePositions.mockImplementation(() => ({
           positions: {
             line: '7' as const,
@@ -1180,74 +1175,52 @@ describe('useFusedNearestStation', () => {
         );
         jest.setSystemTime(T0_745 + 5_000);
         rerender(undefined);
-
-        // 3단계: LivePosition 끊김. ref={arcIndex:0} 보존. nextStationOnArc=junggok이지만 슬롯에 없음.
-        // pickArrivalsForStation 루프 → 모두 continue → return [] (line 133).
-        // ② skip → ③ ReanchoredHop이 idx 0+(elapsed/hopTime)으로 전진.
+        // LivePosition 끊김 → ② skip 분기 평가 후 ③ ReanchoredHop fallback 확인용.
         mockUsePositions.mockImplementation(() => ({
           positions: { line: '7' as const, trains: [] },
           loading: false,
           isMock: false,
         }));
-        jest.setSystemTime(T0_745 + 2 * 90_000);
+        jest.setSystemTime(opts.disconnectAtMs);
         rerender(undefined);
-
-        // ③ → boarding-lock-interp로 라벨.
         expect(result.current.source).toBe('boarding-lock-interp');
       } finally {
         jest.useRealTimers();
         mockUseArrival.mockReset();
         mockUsePositions.mockReset();
       }
+    }
+
+    it('다음 역이 GPS 후보가 아니면 ② skip → ③(ReanchoredHop)으로 fallback (line 133 return [])', () => {
+      // 후보에 다음 역(중곡) 없음 — 슬롯 stationName=용마산 vs station.name=중곡 → 모두 continue.
+      // 슬롯에 arrival 데이터를 주입(line 127 '!arrival' continue가 아닌 line 128 stationName 불일치 분기 cover).
+      const arrivalAtYongmasan: StationArrival = {
+        up: [info(ARRIVAL_CODE.RUNNING, { trainCode: 'OTHER', line: '7' })],
+        down: [],
+      };
+      runArrivalEtaSkipScenario({
+        candidates: [{ station: yongmasan, distanceKm: 0 }],
+        arrivalMock: (name) =>
+          name === yongmasan.name ? arrivalRet(arrivalAtYongmasan) : arrivalRet(null),
+        disconnectAtMs: T0_745 + 2 * 90_000,
+      });
     });
 
     it('다음 역 슬롯이 있어도 row.line이 모두 다른 호선이면 ② skip (matched.length=0 branch, line 131)', () => {
-      jest.useFakeTimers();
-      try {
-        // ref 시드(2 fresh render)
-        jest.setSystemTime(T0_745);
-        setupLooseAccuracyAt(yongmasan);
-        mockFindTop.mockReturnValue([
+      // 중곡 슬롯 arrival의 row.line='2', junggok.line='7' 불일치 → filter 빈 배열. RUNNING(99)으로 fused 픽업 차단.
+      const arrivalAtJunggokWrongLine: StationArrival = {
+        up: [info(ARRIVAL_CODE.RUNNING, { trainCode: '7093', line: '2' })],
+        down: [],
+      };
+      runArrivalEtaSkipScenario({
+        candidates: [
           { station: yongmasan, distanceKm: 0 },
           { station: junggok, distanceKm: 0.5 },
-        ]);
-        // 중곡 슬롯에 있는 arrival의 row.line이 모두 '2' — junggok.line='7'과 불일치 → filter 빈 배열.
-        // arrivalCode는 RUNNING(99)으로 priority 0 — fused가 이 row를 픽업하지 않도록 차단.
-        const arrivalAtJunggokWrongLine: StationArrival = {
-          up: [info(ARRIVAL_CODE.RUNNING, { trainCode: '7093', line: '2' })],
-          down: [],
-        };
-        mockUseArrival.mockImplementation((name: string | null) => {
-          if (name === junggok.name) return arrivalRet(arrivalAtJunggokWrongLine);
-          return arrivalRet(null);
-        });
-        mockUsePositions.mockImplementation(() => ({
-          positions: {
-            line: '7' as const,
-            trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: '7093' })],
-          },
-          loading: false,
-          isMock: false,
-        }));
-        const { result, rerender } = renderHook(() =>
-          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
-        );
-        jest.setSystemTime(T0_745 + 5_000);
-        rerender(undefined);
-        // 3단계: LivePosition 끊김. ② skip(matched=[]) → ③ ReanchoredHop이 idx 0+2=2(군자) 반환.
-        mockUsePositions.mockImplementation(() => ({
-          positions: { line: '7' as const, trains: [] },
-          loading: false,
-          isMock: false,
-        }));
-        jest.setSystemTime(T0_745 + 5_000 + 3 * 90_000);
-        rerender(undefined);
-        expect(result.current.source).toBe('boarding-lock-interp');
-      } finally {
-        jest.useRealTimers();
-        mockUseArrival.mockReset();
-        mockUsePositions.mockReset();
-      }
+        ],
+        arrivalMock: (name) =>
+          name === junggok.name ? arrivalRet(arrivalAtJunggokWrongLine) : arrivalRet(null),
+        disconnectAtMs: T0_745 + 5_000 + 3 * 90_000,
+      });
     });
 
     it('신규 폴링 없음 회귀 — 단일 렌더에서 useArrivalInfo 호출 횟수는 후보 슬롯 수(K=3)와 같다', () => {

--- a/src/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1052,4 +1052,243 @@ describe('useFusedNearestStation', () => {
       }
     });
   });
+
+  describe('#745 Strategy ② ArrivalEta 통합', () => {
+    const yongmasan = findStationByNameAndLine('용마산', '7')!;
+    const junggok = findStationByNameAndLine('중곡', '7')!;
+    const konkuk = findStationByNameAndLine('건대입구', '7')!;
+    const route = makeDirectRoute(4, '7');
+    const routeContext = { route, origin: yongmasan, destination: konkuk };
+    const T0_745 = 1_700_000_000_000;
+    const lock = {
+      destinationId: konkuk.id,
+      trainCode: '7093',
+      boardingStationId: yongmasan.id,
+      boardingLine: '7' as const,
+      boardedAt: T0_745,
+      expectedDurationMs: 30 * 60_000,
+    };
+
+    function setupLooseAccuracyAt(station: typeof yongmasan): void {
+      // accuracyMeters=1500 → fusionDistanceGate 면제 (지하 가정)
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: station.lat, lng: station.lng },
+          result: { station, distanceKm: 0 },
+          accuracyMeters: 1500,
+        }),
+      );
+    }
+
+    it('LivePosition stale + 다음 역 arrival 신선 → 결과 station이 다음 역(중곡)으로 전진 (drift=0)', () => {
+      jest.useFakeTimers();
+      try {
+        // 1단계: LivePosition 신선(t7093 at 용마산) → lastObservedRef seed
+        // Effect 1(LivePosition tracker)이 ref를 시드한 후 Effect 2(lock-key reset)가 첫 렌더에
+        // null→key 전환을 잡아 ref를 한 번 wipe 한다(#621 reset 의도). 두 번째 렌더로 Effect 1을
+        // 다시 트리거하면 ref가 안정적으로 idx=0에 박힌다 — 이 시점부터 Strategy ②가 활성.
+        jest.setSystemTime(T0_745);
+        setupLooseAccuracyAt(yongmasan);
+        mockFindTop.mockReturnValue([
+          { station: yongmasan, distanceKm: 0 },
+          { station: junggok, distanceKm: 0.5 },
+        ]);
+        const arrivalAtJunggok: StationArrival = {
+          up: [
+            info(ARRIVAL_CODE.ENTERING, {
+              trainCode: '7093',
+              line: '7',
+              receivedAtMs: T0_745 + 10_000,
+              arrivalSeconds: 14,
+            }),
+          ],
+          down: [],
+        };
+        // stationName 기반 mock — Strict Mode/effect 재호출에도 안정적으로 같은 값 반환.
+        mockUseArrival.mockImplementation((name: string | null) => {
+          if (name === junggok.name) return arrivalRet(arrivalAtJunggok);
+          return arrivalRet(null);
+        });
+        // 렌더마다 다른 reference로 positions 반환 — Effect 1(freshTrainProgress 변경) 재실행 유도.
+        mockUsePositions.mockImplementation(() => ({
+          positions: {
+            line: '7' as const,
+            trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: '7093' })],
+          },
+          loading: false,
+          isMock: false,
+        }));
+
+        const { result, rerender } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        expect(result.current.result?.station.id).toBe(yongmasan.id);
+
+        // 두 번째 LivePosition fresh 렌더 — Effect 2의 lock-key 리셋이 이미 정착했으므로
+        // Effect 1이 idx=0를 ref에 안정적으로 박는다.
+        jest.setSystemTime(T0_745 + 5_000);
+        rerender(undefined);
+
+        // 3단계: LivePosition 끊김. ref={arcIndex:0}이 보존된 상태에서 ② 활성 — 다음 역(중곡)
+        // arrival의 trainCode/ENTERING 매칭으로 결과가 junggok으로 전진.
+        mockUsePositions.mockImplementation(() => ({
+          positions: { line: '7' as const, trains: [] },
+          loading: false,
+          isMock: false,
+        }));
+        jest.setSystemTime(T0_745 + 15_000);
+        rerender(undefined);
+
+        // drift=0 — 결과 역이 lagged 용마산이 아니라 실제 위치(중곡).
+        expect(result.current.result?.station.id).toBe(junggok.id);
+      } finally {
+        jest.useRealTimers();
+        mockUseArrival.mockReset();
+        mockUsePositions.mockReset();
+      }
+    });
+
+    it('다음 역이 GPS 후보가 아니면 ② skip → ③(ReanchoredHop)으로 fallback (line 133 return [])', () => {
+      jest.useFakeTimers();
+      try {
+        // 1+2단계: LivePosition 신선 두 번 (Effect 2의 lock-key race 우회) → lastObservedRef=idx 0
+        jest.setSystemTime(T0_745);
+        setupLooseAccuracyAt(yongmasan);
+        // 후보에 다음 역(중곡) 없음 — 그러나 pickArrivalsForStation 루프는 진입.
+        // 슬롯 stationName=용마산 vs station.name=중곡 → 모두 continue → 루프 종료 후 return [] (line 133).
+        mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+        // 슬롯에 arrival 데이터를 주입(중곡 외 다른 역) — line 127('!arrival') continue 분기가 아닌
+        // line 128(stationName !== station.name) continue 분기를 타도록 한다. 이 차이로 line 133 도달 후 branch 분기 모두 cover.
+        const arrivalAtYongmasan: StationArrival = {
+          up: [info(ARRIVAL_CODE.RUNNING, { trainCode: 'OTHER', line: '7' })],
+          down: [],
+        };
+        mockUseArrival.mockImplementation((name: string | null) => {
+          if (name === yongmasan.name) return arrivalRet(arrivalAtYongmasan);
+          return arrivalRet(null);
+        });
+        mockUsePositions.mockImplementation(() => ({
+          positions: {
+            line: '7' as const,
+            trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: '7093' })],
+          },
+          loading: false,
+          isMock: false,
+        }));
+        const { result, rerender } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        jest.setSystemTime(T0_745 + 5_000);
+        rerender(undefined);
+
+        // 3단계: LivePosition 끊김. ref={arcIndex:0} 보존. nextStationOnArc=junggok이지만 슬롯에 없음.
+        // pickArrivalsForStation 루프 → 모두 continue → return [] (line 133).
+        // ② skip → ③ ReanchoredHop이 idx 0+(elapsed/hopTime)으로 전진.
+        mockUsePositions.mockImplementation(() => ({
+          positions: { line: '7' as const, trains: [] },
+          loading: false,
+          isMock: false,
+        }));
+        jest.setSystemTime(T0_745 + 2 * 90_000);
+        rerender(undefined);
+
+        // ③ → boarding-lock-interp로 라벨.
+        expect(result.current.source).toBe('boarding-lock-interp');
+      } finally {
+        jest.useRealTimers();
+        mockUseArrival.mockReset();
+        mockUsePositions.mockReset();
+      }
+    });
+
+    it('다음 역 슬롯이 있어도 row.line이 모두 다른 호선이면 ② skip (matched.length=0 branch, line 131)', () => {
+      jest.useFakeTimers();
+      try {
+        // ref 시드(2 fresh render)
+        jest.setSystemTime(T0_745);
+        setupLooseAccuracyAt(yongmasan);
+        mockFindTop.mockReturnValue([
+          { station: yongmasan, distanceKm: 0 },
+          { station: junggok, distanceKm: 0.5 },
+        ]);
+        // 중곡 슬롯에 있는 arrival의 row.line이 모두 '2' — junggok.line='7'과 불일치 → filter 빈 배열.
+        // arrivalCode는 RUNNING(99)으로 priority 0 — fused가 이 row를 픽업하지 않도록 차단.
+        const arrivalAtJunggokWrongLine: StationArrival = {
+          up: [info(ARRIVAL_CODE.RUNNING, { trainCode: '7093', line: '2' })],
+          down: [],
+        };
+        mockUseArrival.mockImplementation((name: string | null) => {
+          if (name === junggok.name) return arrivalRet(arrivalAtJunggokWrongLine);
+          return arrivalRet(null);
+        });
+        mockUsePositions.mockImplementation(() => ({
+          positions: {
+            line: '7' as const,
+            trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: '7093' })],
+          },
+          loading: false,
+          isMock: false,
+        }));
+        const { result, rerender } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        jest.setSystemTime(T0_745 + 5_000);
+        rerender(undefined);
+        // 3단계: LivePosition 끊김. ② skip(matched=[]) → ③ ReanchoredHop이 idx 0+2=2(군자) 반환.
+        mockUsePositions.mockImplementation(() => ({
+          positions: { line: '7' as const, trains: [] },
+          loading: false,
+          isMock: false,
+        }));
+        jest.setSystemTime(T0_745 + 5_000 + 3 * 90_000);
+        rerender(undefined);
+        expect(result.current.source).toBe('boarding-lock-interp');
+      } finally {
+        jest.useRealTimers();
+        mockUseArrival.mockReset();
+        mockUsePositions.mockReset();
+      }
+    });
+
+    it('신규 폴링 없음 회귀 — 단일 렌더에서 useArrivalInfo 호출 횟수는 후보 슬롯 수(K=3)와 같다', () => {
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0_745);
+        setupLooseAccuracyAt(yongmasan);
+        mockFindTop.mockReturnValue([
+          { station: yongmasan, distanceKm: 0 },
+          { station: junggok, distanceKm: 0.5 },
+        ]);
+        const arrivalAtJunggok: StationArrival = {
+          up: [
+            info(ARRIVAL_CODE.ENTERING, {
+              trainCode: '7093',
+              line: '7',
+              receivedAtMs: T0_745,
+              arrivalSeconds: 14,
+            }),
+          ],
+          down: [],
+        };
+        mockUseArrival.mockImplementation((name: string | null) => {
+          if (name === junggok.name) return arrivalRet(arrivalAtJunggok);
+          return arrivalRet(null);
+        });
+        mockUsePositions.mockReturnValue(positionRet(null));
+
+        // 호출 횟수만 검증 — Strategy ②가 도입돼도 hook slot 증설(=신규 폴링) 없음을 회귀로 고정.
+        // renderHook은 effect 적용을 위해 React가 2회 commit phase를 실행할 수 있어 단순 등호 대신
+        // (calls % K === 0) 형태로 검증해 K=3 슬롯 가정만 고정한다.
+        renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        const calls = mockUseArrival.mock.calls.length;
+        expect(calls % 3).toBe(0);
+        expect(calls).toBeLessThanOrEqual(6); // 정상 1~2회 commit (StrictMode 등).
+      } finally {
+        jest.useRealTimers();
+        mockUseArrival.mockReset();
+      }
+    });
+  });
 });

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -31,6 +31,7 @@ import {
   POSITION_TRAIN_TTL_MS,
 } from '../constants/realtime';
 import type { LinePositions } from '../api/positionApi';
+import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
 import type { BoardingLock } from '../types/boardingLock';
 import type { NearestStationResult, Station } from '../types/station';
 import type { ArrivalProvider, PositionProvider } from '../providers/types';
@@ -97,6 +98,37 @@ function matchPositionsForCandidate(
   for (const lp of positions) {
     if (!lp || lp.line !== candidate.station.line) continue;
     return lp.trains.filter((t) => t.statnNm === candidate.station.name);
+  }
+  return [];
+}
+
+interface CandidateArrivalSlot {
+  /** 폴링 시 사용한 후보 역명 — `useArrivalInfo`의 첫 인자와 동일. */
+  stationName: string | null;
+  arrival: StationArrival | null;
+}
+
+/**
+ * 다음 역(`arcStations[currentIdx+1]`)에 해당하는 ArrivalInfo 목록을 기존 `useArrivalInfo` 결과에서 추출.
+ *
+ * ADR-008 ② ArrivalEtaStrategy 입력(#745). 신규 폴링을 신설하지 않고 GPS 후보 슬롯(a0/a1/a2)에
+ * 이미 받아둔 `StationArrival`에서 `(stationName, line)` 매칭으로 한 슬롯만 골라 `up + down`을 concat한다.
+ *
+ * 다음 역이 GPS 후보가 아니면(사용자가 다음 역에 충분히 가깝지 않은 dead zone) 빈 배열 반환 — 그
+ * 사이클은 ② skip, ③(ReanchoredHop)이 자연 fallback. fusion 캐시 재사용만으로 ② 효과가 트립의
+ * 마지막 ~500m 구간에 집중되도록 설계된 의도(추가 폴링 없이 정확도 ↑).
+ */
+function pickArrivalsForStation(
+  station: Station | null,
+  slots: readonly CandidateArrivalSlot[],
+): readonly ArrivalInfo[] {
+  if (!station) return [];
+  for (const { stationName, arrival } of slots) {
+    if (!arrival) continue;
+    if (stationName !== station.name) continue;
+    // 같은 역명이라도 환승역이면 두 호선 응답이 섞일 수 있어 row.line으로 한 번 더 좁힌다.
+    const matched = [...arrival.up, ...arrival.down].filter((row) => row.line === station.line);
+    if (matched.length > 0) return matched;
   }
   return [];
 }
@@ -384,6 +416,21 @@ export function useFusedNearestStation(
     }
   }, [boardingLock]);
 
+  // Strategy ②(ArrivalEta) 입력 — 신규 폴링 신설 금지(#745). currentIdxHint는 마지막 LivePosition
+  // 관측(lastObservedRef) 또는 채택된 estimate의 직전 idx로 자연스럽게 흐른다. 본 hook은
+  // lastObservedRef를 진입점으로 사용 — ①이 마지막에 본 위치를 기준으로 "다음 역"을 산정.
+  // null이면 ② skip(estimator 내부 처리).
+  const currentIdxHint = lastObservedRef.current?.arcIndex ?? null;
+  const nextStationOnArc =
+    currentIdxHint != null && currentIdxHint + 1 < arcStations.length
+      ? arcStations[currentIdxHint + 1]
+      : null;
+  const nextStationArrivals = pickArrivalsForStation(nextStationOnArc, [
+    { stationName: c0, arrival: a0.arrival },
+    { stationName: c1, arrival: a1.arrival },
+    { stationName: c2, arrival: a2.arrival },
+  ]);
+
   // useMemo로 감싸면 deps가 시간을 포함하지 않아 부모 리렌더가 없는 동안 stale.
   // estimator는 분기·정수 산술 위주 — render마다 직접 계산해도 무비용.
   const estimate = estimateStationProgress({
@@ -394,6 +441,9 @@ export function useFusedNearestStation(
     lockedTrainCode: lockedTrainCode ?? null,
     lastObserved: lastObservedRef.current,
     hopTimeMs: HOP_TIME_MS,
+    nextStationArrivals,
+    arrivalEtaTtlMs: POSITION_TRAIN_TTL_MS,
+    currentIdxHint,
   });
 
   // #662 invariant: estimate가 boardingLock이 active일 때만 만들어지고 arcStations(route segment)

--- a/src/utils/__tests__/stationProgressEstimator.test.ts
+++ b/src/utils/__tests__/stationProgressEstimator.test.ts
@@ -1,5 +1,7 @@
 import { arcIndexOfStation, estimateStationProgress } from '../stationProgressEstimator';
 import { HOP_TIME_MS } from '../../constants/boardingLock';
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import type { ArrivalInfo } from '../../api/arrivalApi';
 import type { BoardingLock } from '../../types/boardingLock';
 import type { Station } from '../../types/station';
 import type { TrainProgressResult } from '../trackTrainProgress';
@@ -40,6 +42,31 @@ function makeTrainProgress(
   };
 }
 
+const ARRIVAL_TTL_MS = 60_000;
+
+function makeArrival(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
+  return {
+    destination: 'X',
+    arrivalMinutes: 0,
+    arrivalSeconds: 30,
+    statusMessage: '',
+    trainCode: '7093',
+    line: '7',
+    receivedAtMs: T0,
+    arrivalCode: ARRIVAL_CODE.ENTERING,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+/** Strategy ②(ArrivalEta) 입력이 모두 비어있는 기본값 — 기존 테스트 호환. */
+const NO_ARRIVAL_INPUT = {
+  nextStationArrivals: [] as readonly ArrivalInfo[],
+  arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+  currentIdxHint: null as number | null,
+};
+
 describe('estimateStationProgress', () => {
   describe('가드 — 모든 전략 비활성', () => {
     it('lock null이면 null', () => {
@@ -52,6 +79,7 @@ describe('estimateStationProgress', () => {
           lockedTrainCode: null,
           lastObserved: null,
           hopTimeMs: HOP_TIME_MS,
+          ...NO_ARRIVAL_INPUT,
         }),
       ).toBeNull();
     });
@@ -66,6 +94,7 @@ describe('estimateStationProgress', () => {
           lockedTrainCode: '7093',
           lastObserved: null,
           hopTimeMs: HOP_TIME_MS,
+          ...NO_ARRIVAL_INPUT,
         }),
       ).toBeNull();
     });
@@ -82,6 +111,7 @@ describe('estimateStationProgress', () => {
           lockedTrainCode: '7093',
           lastObserved: null,
           hopTimeMs: HOP_TIME_MS,
+          ...NO_ARRIVAL_INPUT,
         }),
       ).toBeNull();
     });
@@ -97,6 +127,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: null,
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r).toEqual({
         station: ARC[2],
@@ -115,6 +146,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: null,
         lastObserved: null,
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r?.strategy).toBe('reanchored-hop');
       expect(r?.station).toBe(ARC[0]); // boarding 앵커, elapsed=0
@@ -129,6 +161,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: null,
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r?.strategy).toBe('reanchored-hop');
       expect(r?.station).toBe(ARC[0]);
@@ -151,6 +184,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: null,
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r?.strategy).toBe('reanchored-hop');
     });
@@ -164,6 +198,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: null,
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r?.strategy).toBe('reanchored-hop');
     });
@@ -181,6 +216,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 2, observedAtMs: observedAt },
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r).toEqual({
         station: ARC[4],
@@ -198,6 +234,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: null,
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r).toEqual({
         station: ARC[1],
@@ -215,6 +252,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 2, observedAtMs: T0 + 1_000 },
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r).toBeNull();
     });
@@ -228,6 +266,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: null,
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r).toBeNull();
     });
@@ -242,6 +281,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 99, observedAtMs: T0 },
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r?.strategy).toBe('reanchored-hop');
       expect(r?.station).toBe(ARC[1]); // boardingIdx(0) + 1 hop
@@ -259,6 +299,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 0, observedAtMs: observedAt },
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r).toBeNull();
     });
@@ -275,12 +316,153 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 0, observedAtMs: observedAt },
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       expect(r).toEqual({
         station: ARC[4],
         index: 4,
         strategy: 'reanchored-hop',
       });
+    });
+  });
+
+  describe('Strategy ② ArrivalEta — 다음 역 arrival로 ETA 투영 (#745)', () => {
+    it('LivePosition stale + ArrivalEta 신선(ENTERING) → ② 채택, strategy=arrival-eta', () => {
+      // currentIdxHint=2(군자). 다음 역=arcStations[3]=어린이대공원. ENTERING(0) → idx 2+1=3.
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null, // ① stale
+        lockedTrainCode: '7093',
+        lastObserved: { arcIndex: 2, observedAtMs: T0 - 10_000 }, // ③도 가능하지만 ②가 우선
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [
+          makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 14 }),
+        ],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: 2,
+      });
+      expect(r).toEqual({
+        station: ARC[3],
+        index: 3,
+        strategy: 'arrival-eta',
+      });
+    });
+
+    it('PREV_ARRIVED(5) → currentIdx 유지, strategy=arrival-eta', () => {
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [
+          makeArrival({ arrivalCode: ARRIVAL_CODE.PREV_ARRIVED, arrivalSeconds: 45 }),
+        ],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: 2,
+      });
+      expect(r).toEqual({
+        station: ARC[2],
+        index: 2,
+        strategy: 'arrival-eta',
+      });
+    });
+
+    it('ArrivalEta stale(TTL 초과) → ReanchoredHop으로 fallback', () => {
+      // arrival row receivedAtMs가 TTL 초과 → ② null → ③ ReanchoredHop 채택.
+      const observedAt = T0 - 200_000;
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: { arcIndex: 1, observedAtMs: observedAt },
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [
+          makeArrival({
+            arrivalCode: ARRIVAL_CODE.ENTERING,
+            receivedAtMs: T0 - ARRIVAL_TTL_MS - 1,
+          }),
+        ],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: 1,
+      });
+      expect(r?.strategy).toBe('reanchored-hop');
+    });
+
+    it('currentIdxHint null → ② skip → ReanchoredHop fallback', () => {
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [
+          makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 14 }),
+        ],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: null,
+      });
+      expect(r?.strategy).toBe('reanchored-hop');
+    });
+
+    it('lockedTrainCode null → ② skip(trainCode 매칭 불가) → ReanchoredHop', () => {
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [
+          makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING }),
+        ],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: 2,
+      });
+      expect(r?.strategy).toBe('reanchored-hop');
+    });
+
+    it('nextStationArrivals 빈 배열 → ② skip → ReanchoredHop', () => {
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: 2,
+      });
+      expect(r?.strategy).toBe('reanchored-hop');
+    });
+
+    it('trainCode 미일치 → ② skip → ReanchoredHop', () => {
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [
+          makeArrival({ trainCode: '9999', arrivalCode: ARRIVAL_CODE.ENTERING }),
+        ],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: 2,
+      });
+      expect(r?.strategy).toBe('reanchored-hop');
     });
   });
 
@@ -295,6 +477,7 @@ describe('estimateStationProgress', () => {
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 3, observedAtMs: observedAt }, // ReanchoredHop이 가능했다면 더 앞쪽
         hopTimeMs: HOP_TIME_MS,
+        ...NO_ARRIVAL_INPUT,
       });
       // LivePosition 우선 — strategy='live-position', index=1.
       expect(r).toEqual({
@@ -302,6 +485,24 @@ describe('estimateStationProgress', () => {
         index: 1,
         strategy: 'live-position',
       });
+    });
+
+    it('LivePosition 신선 + ArrivalEta도 가능 → LivePosition 우선 (① > ②)', () => {
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: makeTrainProgress({ stationIdx: 1 }),
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMs: HOP_TIME_MS,
+        nextStationArrivals: [
+          makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 10 }),
+        ],
+        arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+        currentIdxHint: 1,
+      });
+      expect(r?.strategy).toBe('live-position');
     });
   });
 });

--- a/src/utils/stationProgressEstimator.ts
+++ b/src/utils/stationProgressEstimator.ts
@@ -1,6 +1,8 @@
 import { isBoardingLockExpired, type BoardingLock } from '../types/boardingLock';
+import type { ArrivalInfo } from '../api/arrivalApi';
 import type { Station } from '../types/station';
 import type { TrainProgressResult } from './trackTrainProgress';
+import { projectArrivalEtaStation } from './arrivalEtaProjection';
 
 /**
  * ADR-008 — 탑승 진행 추정(BoardingLock 활성 trip 중 현재역) 합성기.
@@ -11,8 +13,8 @@ import type { TrainProgressResult } from './trackTrainProgress';
  *  ③ ReanchoredHop  — ①②가 마지막으로 본 (역, 시각)에 재앵커 — 최대 1 hop만 적분
  *  ④ DefaultHop     — 노선/세그먼트 hop time 테이블 (Stage 3/#624)
  *
- * Stage 1(#739)은 ①③만 실구현. ②④는 명시적 TODO 스텁(null 반환)으로 자리만 잡는다 — 인터페이스가
- * 안정화되면 후속 stage에서 채우면 그대로 합성 우선순위에 끼어든다(OCP).
+ * Stage 1(#739)은 ①③. Stage 2(#745)에서 ②(projectArrivalEtaStation 합성) 도입. ④는 Stage 3까지
+ * 명시적 TODO 스텁으로 자리만 잡는다 — 후속 stage에서 채우면 그대로 합성 우선순위에 끼어든다(OCP).
  *
  * 핵심 변경: 기존 `interpolateBoardingLockStation`은 `lock.boardedAt`을 시작 앵커로 N hop을 통째로
  * 적분 → 보간이 메꾸는 구간이 trip 전체였다. ReanchoredHop은 마지막 실관측 `(arcIndex, observedAtMs)`에
@@ -43,6 +45,25 @@ export interface StationProgressEstimatorInput {
   lastObserved: { arcIndex: number; observedAtMs: number } | null;
   /** Strategy ③④에서 사용할 hop 시간(ms). Stage 1은 HOP_TIME_MS 패스스루, Stage 3에서 lookup. */
   hopTimeMs: number;
+  /**
+   * Strategy ② 입력 (#745) — `arcStations[currentIdxHint + 1]` 역의 ArrivalInfo 목록.
+   * `projectArrivalEtaStation`이 row별로 trainCode 매칭 + 신선도 필터링을 수행하므로 호출자는
+   * raw 배열을 그대로 전달한다 (호선/방향 사전 필터링은 호출자 책임). null/빈배열이면 ② skip.
+   */
+  nextStationArrivals: readonly ArrivalInfo[];
+  /**
+   * Strategy ②의 신선도 TTL(ms). row의 `nowMs - receivedAtMs > ttlMs`면 stale로 스킵.
+   * Stage 2 기준값은 `POSITION_TRAIN_TTL_MS`(60s)와 동일 — Strategy ①(LivePosition) 신선도
+   * 기준과 정렬해 채택 경계가 자연스럽게 ①→②→③로 흐르도록 한다(통합된 신선도 게이트).
+   * 후속 stage에서 측정 데이터 기반으로 별도 임계 사용 가능.
+   */
+  arrivalEtaTtlMs: number;
+  /**
+   * Strategy ② 진입점 인덱스 — 호출자가 직전 사이클의 채택 idx 또는 lastObserved.arcIndex로 전달.
+   * null이면 ② skip(다음 역을 가리킬 기준점 없음). null이 아니어도 `currentIdx + 1`이 arc 밖이면
+   * `projectArrivalEtaStation`이 종착 cap 처리로 마지막 인덱스를 반환한다.
+   */
+  currentIdxHint: number | null;
 }
 
 export type StationProgressStrategy =
@@ -77,12 +98,41 @@ function tryLivePosition(
   return { station: arcStations[idx], index: idx, strategy: 'live-position' };
 }
 
-/** Strategy ② — TODO Stage 2/#740. 다음 역 arrival의 trainCode 매칭으로 ETA 투영. */
+/**
+ * Strategy ② — 다음 역 arrival의 `trainCode` 매칭 row를 `projectArrivalEtaStation`으로 투영.
+ *
+ * lockedTrainCode 없거나 currentIdxHint 없으면 매칭 기준점 부재로 skip.
+ * `projectArrivalEtaStation`이 내부에서 (1) trainCode 매칭, (2) receivedAtMs 신선도, (3) arrivalCode
+ * 디코딩(5/0/1)을 처리해 적격 row가 없으면 null — 그대로 다음 전략으로 흐른다.
+ */
 function tryArrivalEta(
-  _input: StationProgressEstimatorInput,
+  input: StationProgressEstimatorInput,
 ): StationProgressEstimate | null {
-  // TODO Stage 2/#740 — 다음 역 arrival의 arrivalSeconds로 ETA 투영.
-  return null;
+  const {
+    nextStationArrivals,
+    lockedTrainCode,
+    currentIdxHint,
+    arcStations,
+    now,
+    arrivalEtaTtlMs,
+  } = input;
+  if (lockedTrainCode == null) return null;
+  if (currentIdxHint == null) return null;
+  if (nextStationArrivals.length === 0) return null;
+  const projected = projectArrivalEtaStation({
+    arrivals: nextStationArrivals,
+    trainCode: lockedTrainCode,
+    currentIdx: currentIdxHint,
+    arcStations,
+    nowMs: now,
+    ttlMs: arrivalEtaTtlMs,
+  });
+  if (!projected) return null;
+  return {
+    station: projected.station,
+    index: projected.index,
+    strategy: 'arrival-eta',
+  };
 }
 
 /**
@@ -151,8 +201,8 @@ export function arcIndexOfStation(
 /**
  * 4단 전략을 우선순위대로 시도. 처음 채택된 전략의 결과를 반환.
  *
- * Stage 1은 ①(LivePosition) → ②(스텁) → ③(ReanchoredHop) → ④(스텁) 순. ②④가 자리만 잡혀 있어
- * 후속 stage가 그대로 끼어들 수 있다.
+ * Stage 2(#745) 기준 ①(LivePosition) → ②(ArrivalEta) → ③(ReanchoredHop) → ④(스텁) 순.
+ * ④는 후속 stage에서 채워지면 자연스레 끼어든다(OCP).
  */
 export function estimateStationProgress(
   input: StationProgressEstimatorInput,

--- a/src/utils/stationProgressEstimator.ts
+++ b/src/utils/stationProgressEstimator.ts
@@ -14,7 +14,7 @@ import { projectArrivalEtaStation } from './arrivalEtaProjection';
  *  ④ DefaultHop     — 노선/세그먼트 hop time 테이블 (Stage 3/#624)
  *
  * Stage 1(#739)은 ①③. Stage 2(#745)에서 ②(projectArrivalEtaStation 합성) 도입. ④는 Stage 3까지
- * 명시적 TODO 스텁으로 자리만 잡는다 — 후속 stage에서 채우면 그대로 합성 우선순위에 끼어든다(OCP).
+ * 명시적 빈 스텁으로 자리만 잡는다 — 후속 stage에서 채우면 그대로 합성 우선순위에 끼어든다(OCP).
  *
  * 핵심 변경: 기존 `interpolateBoardingLockStation`은 `lock.boardedAt`을 시작 앵커로 N hop을 통째로
  * 적분 → 보간이 메꾸는 구간이 trip 전체였다. ReanchoredHop은 마지막 실관측 `(arcIndex, observedAtMs)`에
@@ -178,11 +178,11 @@ function tryReanchoredHop(
   return { station: arcStations[idx], index: idx, strategy: 'reanchored-hop' };
 }
 
-/** Strategy ④ — TODO Stage 3/#624. line/segment별 hop time 데이터 테이블 fallback. */
+/** Strategy ④ — Stage 3/#624에서 채울 예정. line/segment별 hop time 데이터 테이블 fallback. */
 function tryDefaultHop(
   _input: StationProgressEstimatorInput,
 ): StationProgressEstimate | null {
-  // TODO Stage 3/#624 — HOP_TIME_TABLE lookup으로 line/segment별 정밀 hop time 대체.
+  // Stage 3/#624 — HOP_TIME_TABLE lookup으로 line/segment별 정밀 hop time 대체.
   return null;
 }
 


### PR DESCRIPTION
## Summary

ADR-008 Stage 2 마지막 단계. #743(`projectArrivalEtaStation` 순수 함수)을 estimator의 ② 전략으로 합성하고, `useFusedNearestStation`에서 다음 역 arrival 데이터를 estimator에 주입한다.

## Scope

- `stationProgressEstimator.ts` — `tryArrivalEta` 스텁 → `projectArrivalEtaStation` 호출.
  `StationProgressEstimatorInput`에 다음 필드 추가:
  - `nextStationArrivals: readonly ArrivalInfo[]` — 다음 역의 raw arrivals (호출자가 line 필터)
  - `arrivalEtaTtlMs: number` — Strategy ② 신선도 임계 (`POSITION_TRAIN_TTL_MS` 패스스루)
  - `currentIdxHint: number | null` — 호출자가 직전 사이클 인덱스 제공 (null이면 ② skip)
- `useFusedNearestStation.ts`:
  - `pickArrivalsForStation(stationId, line)` 헬퍼로 기존 `arrivals` 데이터에서 다음 역 arrival 추출
  - `currentIdxHint = lastObservedRef.current?.arcIndex ?? null` — LivePosition이 마지막에 성공한 인덱스 활용
  - **신규 폴링 신설 없음** — 기존 `useArrivalInfo` 결과 재사용만

## 알려진 race (pre-existing, 새 버그 아님)

- **1-cycle transfer race** — `currentIdxHint`가 lock 교체 순간 OLD trip의 arcIndex를 가리킴. Strategy ③도 같은 race 가지고 있고 본 PR이 ②에 동일하게 inherited. 1 render cycle 후 자동 해소
- **first-mount Effect 1/2 ordering** — 첫 사이클에 ② 발화 불가 (`lastObservedRef`가 lock 키 reset effect 이후 설정). pre-existing #621 패턴

## Acceptance

- [x] LivePosition 신선 시 drift = 0
- [x] LivePosition stale + ArrivalEta 신선 시 drift = 0
- [x] 둘 다 stale 시 ReanchoredHop fallback
- [x] 신규 네트워크 호출 없음
- [x] 2640건 테스트 통과, 커버리지 100%
- [x] type-check 통과

## Code review

`code-reviewer` debate-style 검토 — 3건 검토 후 모두 "pre-existing pattern, PR이 새로 도입 X" 판정. 머지 블로커 없음.

## Test plan

- [ ] 실기기: 지하 dead zone에서 ArrivalEta 채택 확인 (현재역 추적 drift 측정)
- [ ] 환승 시점 1-cycle race 영향 관측 (보통 1초 이내라 사용자 인지 불가 예상)

## ADR-008 진행

- ✅ Stage 1 (#742): estimator + Strategy ①③
- ✅ Stage 2-prep (#743): `arrivalEtaProjection` 순수 함수
- 🔄 Stage 2 통합 (이 PR): ② 합성
- ⏳ Stage 3 (#624): `HOP_TIME_TABLE` 데이터 테이블
- ⏳ Stage 4 (#622): `BffProgressProvider` 서버 위임

Closes #745