### PR TITLE
feat(#749): BoardingTrainList 시퀀스 카운터 + ○○방면 노출 + 도착 시각 표기 정리

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -499,6 +499,7 @@ export default function HomeScreen() {
         line={effectiveOrigin?.line ?? null}
         onSelect={handleMisBoardingReselect}
         onClose={handleMisBoardingModalClose}
+        nextStationLabel={nextStationName}
       />
 
       <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>

--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -22,8 +22,8 @@ interface Props {
   /** 헤더 라벨 커스텀 (환승 list 등). 미전달 시 기본 "탑승할 열차 선택". compact=true면 무시. */
   title?: string;
   /**
-   * 트레인 destination(종착) 대신 표시할 다음 인접역 라벨(#649). "{label} 방면" 형태로 노출.
-   * 호출자가 resolveNextAdjacentStationName으로 계산해 전달. null/미전달이면 destination 표기.
+   * 다음 인접역 라벨(#649, #749). 종착과 같이 "{destination}행 · {label}방면" 형태로 노출.
+   * 호출자가 resolveNextAdjacentStationName으로 계산해 전달. null/미전달이면 종착만 표기.
    */
   nextStationLabel?: string | null;
   /**
@@ -46,6 +46,9 @@ interface Props {
  * #649: compact + nextStationLabel — Timeline hop slot 안에 inline 배치되는 형태 지원.
  *       compact 모드는 hop slot 안 inline이라 row borderRadius 없음(직각). stripe도 같은 정신으로
  *       직각 유지 — 일반 모드는 카드 radius와 어울리는 둥근 코너 stripe로 자연스럽게 처리됨.
+ * #749: 2줄 row 레이아웃 — 첫째 줄 "{destination}행 · {nextStation}방면" (방면은 옵셔널),
+ *       둘째 줄 "{index+1}번째 전 · {HH:mm} 도착 예정". 카운터는 호출자가 전달한 배열 순서를
+ *       1-indexed로 변환. 같은 trainCode가 유지되는 동안 카운터 안정 → "같은 열차 지연" 신호.
  */
 export function BoardingTrainList({
   arrivals,
@@ -86,11 +89,13 @@ export function BoardingTrainList({
           <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
         </View>
       )}
-      {filteredArrivals.map((train) => {
+      {filteredArrivals.map((train, index) => {
         const unreachable = isUnreachable(train);
-        const labelText = nextStationLabel
-          ? `${nextStationLabel} 방면`
-          : `${train.destination} 행`;
+        const metaText = nextStationLabel
+          ? `${train.destination}행 · ${nextStationLabel}방면`
+          : `${train.destination}행`;
+        const sequenceText = `${index + 1}번째 전`;
+        const arrivalText = `${formatArrivalClock(train)} 도착 예정`;
         return (
           <Pressable
             key={train.trainCode}
@@ -104,33 +109,41 @@ export function BoardingTrainList({
             ]}
             testID={`boarding-train-row-${train.trainCode}`}
           >
-            {compact ? (
-              <Text
-                style={[typography.bodySm, { color: colors.ink, flex: 1 }]}
-                testID={`boarding-train-label-${train.trainCode}`}
-              >
-                {labelText}
-              </Text>
-            ) : (
-              <View style={styles.rowInfo}>
-                <Text style={[typography.body, { color: colors.ink }]}>{labelText}</Text>
-                {/* #648: 시간표 fallback의 가상 trainCode(SCHED-*)는 무의미하므로 "시간표" 라벨로 대체. */}
-                {isScheduleFallbackTrainCode(train.trainCode) ? (
-                  <Text style={[typography.mono, { color: colors.subtle }]}>시간표</Text>
-                ) : (
-                  <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
-                )}
+            <View style={styles.rowContent}>
+              <View style={styles.rowMetaLine}>
+                <Text
+                  style={[
+                    compact ? typography.bodySm : typography.body,
+                    { color: colors.ink, flex: 1 },
+                  ]}
+                  testID={`boarding-train-meta-${train.trainCode}`}
+                >
+                  {metaText}
+                </Text>
+                {/* trainCode/시간표 배지는 일반 모드에서만 노출. compact는 timeline hop slot 안 inline이라 정보 밀도 최소화. */}
+                {!compact &&
+                  (isScheduleFallbackTrainCode(train.trainCode) ? (
+                    <Text style={[typography.mono, { color: colors.subtle }]}>시간표</Text>
+                  ) : (
+                    <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
+                  ))}
               </View>
-            )}
-            <Text
-              style={[
-                compact ? typography.bodySm : typography.body,
-                { color: colors.accent, fontWeight: '600' },
-              ]}
-              testID={`boarding-train-arrival-${train.trainCode}`}
-            >
-              {formatArrivalClock(train)}
-            </Text>
+              <View style={styles.rowDetailLine}>
+                <Text
+                  style={[typography.bodySm, { color: colors.muted }]}
+                  testID={`boarding-train-sequence-${train.trainCode}`}
+                >
+                  {sequenceText}
+                </Text>
+                <Text style={[typography.bodySm, { color: colors.subtle }]}>·</Text>
+                <Text
+                  style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}
+                  testID={`boarding-train-arrival-${train.trainCode}`}
+                >
+                  {arrivalText}
+                </Text>
+              </View>
+            </View>
           </Pressable>
         );
       })}
@@ -163,18 +176,27 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
     padding: spacing.lg,
     borderRadius: radius.md,
   },
   rowCompact: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
     paddingVertical: spacing.xs,
     paddingHorizontal: spacing.sm,
   },
-  rowInfo: {
+  rowContent: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  rowMetaLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  rowDetailLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: spacing.xs,
   },
   empty: {

--- a/src/components/MisBoardingReselectModal.tsx
+++ b/src/components/MisBoardingReselectModal.tsx
@@ -15,6 +15,11 @@ interface Props {
   onSelect: (train: ArrivalInfo) => void;
   /** 모달 자체 닫기 (취소 등). */
   onClose: () => void;
+  /**
+   * 다음 인접역 라벨(#749). BoardingTrainList에 forward — "{destination}행 · {label}방면" 표기.
+   * 호출자가 resolveNextAdjacentStationName으로 도출해 전달. null/미전달이면 종착만 노출.
+   */
+  nextStationLabel?: string | null;
 }
 
 /**
@@ -24,7 +29,14 @@ interface Props {
  * onSelect 콜백 → caller가 createLockFromTrain 호출 + 모달 close 처리.
  * 모달 자체 dismiss는 헤더의 [닫기] 버튼.
  */
-export function MisBoardingReselectModal({ visible, arrivals, line, onSelect, onClose }: Props) {
+export function MisBoardingReselectModal({
+  visible,
+  arrivals,
+  line,
+  onSelect,
+  onClose,
+  nextStationLabel = null,
+}: Props) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
 
@@ -52,7 +64,14 @@ export function MisBoardingReselectModal({ visible, arrivals, line, onSelect, on
           <Text style={[typography.bodySm, styles.help, { color: colors.muted }]}>
             현재역의 도착 list에서 실제 탑승한 열차를 선택해주세요.
           </Text>
-          {line && <BoardingTrainList arrivals={arrivals} line={line} onSelect={onSelect} />}
+          {line && (
+            <BoardingTrainList
+              arrivals={arrivals}
+              line={line}
+              onSelect={onSelect}
+              nextStationLabel={nextStationLabel}
+            />
+          )}
         </View>
       </View>
     </Modal>

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -29,14 +29,14 @@ describe('BoardingTrainList', () => {
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
   });
 
-  it('각 train마다 trainCode + destination 렌더', () => {
+  it('#749 각 train마다 종착(○○행) 표기 + 카운터 + 시각', () => {
     const trains = [makeTrain({ trainCode: 'T-A', destination: '강남', arrivalMinutes: 2 })];
-    const { getByText, getByTestId } = renderWithTheme(
+    const { getByTestId } = renderWithTheme(
       <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
     );
     expect(getByTestId('boarding-train-row-T-A')).toBeTruthy();
-    expect(getByText('강남 행')).toBeTruthy();
-    expect(getByText('T-A')).toBeTruthy();
+    expect(getByTestId('boarding-train-meta-T-A').props.children).toBe('강남행');
+    expect(getByTestId('boarding-train-sequence-T-A').props.children).toBe('1번째 전');
   });
 
   it('#634 도착 시각을 receivedAtMs + arrivalSeconds 기반 HH:mm으로 표시', () => {
@@ -46,7 +46,7 @@ describe('BoardingTrainList', () => {
     const { getByTestId } = renderWithTheme(
       <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
     );
-    expect(getByTestId('boarding-train-arrival-T-CLOCK').props.children).toBe('03:08');
+    expect(getByTestId('boarding-train-arrival-T-CLOCK').props.children).toBe('03:08 도착 예정');
   });
 
   it('#634 receivedAtMs=0(mock/stale)이면 현재 시각 기준 HH:mm 계산', () => {
@@ -56,7 +56,7 @@ describe('BoardingTrainList', () => {
       const { getByTestId } = renderWithTheme(
         <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
       );
-      expect(getByTestId('boarding-train-arrival-T-NOW').props.children).toBe('10:02');
+      expect(getByTestId('boarding-train-arrival-T-NOW').props.children).toBe('10:02 도착 예정');
     } finally {
       nowSpy.mockRestore();
     }
@@ -106,12 +106,12 @@ describe('BoardingTrainList', () => {
 
   it('#648 SCHED-* trainCode는 사용자에게 숨기고 "시간표" 라벨로 대체', () => {
     const fallback = makeTrain({ trainCode: 'SCHED-DN-1', destination: '석남', line: '7' });
-    const { getByText, queryByText } = renderWithTheme(
+    const { getByText, queryByText, getByTestId } = renderWithTheme(
       <BoardingTrainList arrivals={[fallback]} line="7" onSelect={() => {}} />,
     );
     expect(queryByText('SCHED-DN-1')).toBeNull();
     expect(getByText('시간표')).toBeTruthy();
-    expect(getByText('석남 행')).toBeTruthy();
+    expect(getByTestId('boarding-train-meta-SCHED-DN-1').props.children).toBe('석남행');
   });
 
   it('walkingBufferSeconds 미전달이면 모든 train 활성', () => {
@@ -124,9 +124,9 @@ describe('BoardingTrainList', () => {
     expect(onSelect).toHaveBeenCalled();
   });
 
-  it('#649 nextStationLabel 전달 시 "{label} 방면" 으로 표기 (destination 행 대체)', () => {
+  it('#749 nextStationLabel 전달 시 종착 + 방면 동시 표시 ("○○행 · ○○방면")', () => {
     const train = makeTrain({ trainCode: 'T-NEXT', destination: '석남', line: '7' });
-    const { getByText, queryByText } = renderWithTheme(
+    const { getByTestId } = renderWithTheme(
       <BoardingTrainList
         arrivals={[train]}
         line="7"
@@ -134,11 +134,39 @@ describe('BoardingTrainList', () => {
         nextStationLabel="중곡"
       />,
     );
-    expect(getByText('중곡 방면')).toBeTruthy();
-    expect(queryByText('석남 행')).toBeNull();
+    expect(getByTestId('boarding-train-meta-T-NEXT').props.children).toBe('석남행 · 중곡방면');
   });
 
-  it('#649 compact 모드: 헤더/trainCode 라인 생략, 단일 row 라벨만', () => {
+  it('#749 nextStationLabel null이면 종착만 표시 (방면 생략)', () => {
+    const train = makeTrain({ trainCode: 'T-NO-NEXT', destination: '석남', line: '7' });
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList
+        arrivals={[train]}
+        line="7"
+        onSelect={() => {}}
+        nextStationLabel={null}
+      />,
+    );
+    expect(getByTestId('boarding-train-meta-T-NO-NEXT').props.children).toBe('석남행');
+  });
+
+  it('#749 시퀀스 카운터는 arrivalSeconds 오름차순 정렬 후 1-indexed', () => {
+    // arrivals 입력 순서가 정렬 순서가 아니어도 카운터는 도착 시간 빠른 순부터.
+    // 정렬은 호출자 책임이라 동일 순서로 전달되었을 때의 카운터 매핑을 검증한다.
+    const trains = [
+      makeTrain({ trainCode: 'T-1ST', arrivalSeconds: 60 }),
+      makeTrain({ trainCode: 'T-2ND', arrivalSeconds: 180 }),
+      makeTrain({ trainCode: 'T-3RD', arrivalSeconds: 300 }),
+    ];
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
+    );
+    expect(getByTestId('boarding-train-sequence-T-1ST').props.children).toBe('1번째 전');
+    expect(getByTestId('boarding-train-sequence-T-2ND').props.children).toBe('2번째 전');
+    expect(getByTestId('boarding-train-sequence-T-3RD').props.children).toBe('3번째 전');
+  });
+
+  it('#749 compact 모드: 헤더/trainCode 라인 생략, 단일 row 종착·방면 라벨', () => {
     const train = makeTrain({ trainCode: 'T-COMPACT', destination: '석남', line: '7' });
     const { getByTestId, queryByText } = renderWithTheme(
       <BoardingTrainList
@@ -149,9 +177,24 @@ describe('BoardingTrainList', () => {
         nextStationLabel="중곡"
       />,
     );
-    expect(getByTestId('boarding-train-label-T-COMPACT').props.children).toBe('중곡 방면');
+    expect(getByTestId('boarding-train-meta-T-COMPACT').props.children).toBe('석남행 · 중곡방면');
     expect(queryByText('탑승할 열차 선택')).toBeNull();
     expect(queryByText('T-COMPACT')).toBeNull();
+  });
+
+  it('#749 compact 모드에서도 카운터 + 시각 표기', () => {
+    const train = makeTrain({ trainCode: 'T-CO-SEQ', destination: '석남', line: '7' });
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList
+        arrivals={[train]}
+        line="7"
+        onSelect={() => {}}
+        compact
+        nextStationLabel="중곡"
+      />,
+    );
+    expect(getByTestId('boarding-train-sequence-T-CO-SEQ').props.children).toBe('1번째 전');
+    expect(getByTestId('boarding-train-arrival-T-CO-SEQ')).toBeTruthy();
   });
 
   it('#649 compact + 빈 arrivals 도 동일 placeholder', () => {

--- a/src/components/__tests__/MisBoardingReselectModal.test.tsx
+++ b/src/components/__tests__/MisBoardingReselectModal.test.tsx
@@ -78,4 +78,19 @@ describe('MisBoardingReselectModal', () => {
     fireEvent.press(getByTestId('mis-boarding-reselect-close'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('#749 nextStationLabel을 BoardingTrainList로 forward — "○○행 · ○○방면" 표기', () => {
+    const train = makeTrain({ trainCode: 'C', destination: '도봉산', line: '7' });
+    const { getByTestId } = renderWithTheme(
+      <MisBoardingReselectModal
+        visible
+        arrivals={[train]}
+        line="7"
+        onSelect={() => {}}
+        onClose={() => {}}
+        nextStationLabel="사가정"
+      />,
+    );
+    expect(getByTestId('boarding-train-meta-C').props.children).toBe('도봉산행 · 사가정방면');
+  });
 });


### PR DESCRIPTION
Closes #749

## Summary
- row 레이아웃을 2줄 구조로 변경 — 첫째 줄 `{destination}행 · {nextStation}방면`(방면은 옵셔널), 둘째 줄 `{N}번째 전 · {HH:mm} 도착 예정`
- 시퀀스 카운터(`${index + 1}번째 전`) 도입 — 같은 trainCode가 유지되는 동안 카운터 안정 → "같은 열차의 진짜 지연" 신호로 활용
- 종착(`destination`) 항상 표시 + 방면(`nextStationLabel`) 옵셔널 동시 노출
- 호출처 일반화: `MisBoardingReselectModal`에 `nextStationLabel` prop 추가, HomeScreen이 기존 `nextStationName`(useMemo)을 재사용해 modal에 forward
- compact 모드(EditorialTimeline hop slot inline 배치) 호환 — trainCode/시간표 라벨 비노출 유지

## 변경 파일
- `src/components/BoardingTrainList.tsx` — 2줄 row 레이아웃, metaText/sequenceText/arrivalText 산출, testID 갱신
- `src/components/MisBoardingReselectModal.tsx` — `nextStationLabel` prop 추가 + forward
- `app/(tabs)/index.tsx` — modal 호출에 `nextStationLabel={nextStationName}` 전달 (origin hop slot 패턴은 #649 그대로 유지)
- `src/components/__tests__/BoardingTrainList.test.tsx` — #749 기대 동작 검증 (카운터·종착+방면 동시 표기·null 케이스·compact 회귀)
- `src/components/__tests__/MisBoardingReselectModal.test.tsx` — `nextStationLabel` forward 검증

## testID 변경
- `boarding-train-label-{trainCode}` 제거 → `boarding-train-meta-{trainCode}` (1줄째 종착·방면)
- 신규 `boarding-train-sequence-{trainCode}` (2줄째 카운터)
- 기존 `boarding-train-arrival-{trainCode}` 유지 (2줄째 시각, suffix `도착 예정` 추가)
- 외부(maestro/yaml/통합테스트) 사용 없음 확인 후 변경

## Code Review (high effort)
3 angles × 6 candidates, 1-vote verify 결과 surfaced findings 2건 — 모두 P2(minor), 새 코드의 functional bug는 없음:
1. HomeScreen이 modal에는 route 기반 `getNextStationName`을, origin hop slot에는 topology 기반 `resolveNextAdjacentStationName`을 사용 → 라벨 도출 함수가 다름. 그러나 modal은 boardingLock 활성 시에만, origin hop slot은 lock 없을 때만 노출돼 동시 노출되지 않음 → 사용자 영향 없음. 일관성 정리는 후속 cleanup 후보.
2. 첫 row가 `walkingBufferSeconds` 미만으로 disabled여도 "1번째 전"으로 표기됨 → 이슈 명세("정렬 순서 1-indexed")대로의 의도된 동작. UX적으로도 "이 열차는 못 타지만 다음 곧 옴" 의미 자연스러움.

## Test plan
- [x] `npm test` — 151 suites / 2681 tests pass, coverage 100%
- [x] `npm run type-check` 통과
- [ ] 실기기 회귀 검증 — origin hop slot 카운터/방면 표기, 환승 hop slot, MisBoarding modal 재선택