### PR TITLE
fix(#750): 취침모드 첫 환승 알람 누수 — FG/BG/scheduler 공통 게이트

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -66,6 +66,7 @@ const mockLogFiredStationPassed = jest.fn();
 const mockLogSuppressedDedupAlarm = jest.fn();
 const mockLogSuppressedDedupStation = jest.fn();
 const mockLogSuppressedMovement = jest.fn();
+const mockLogSuppressedSleepFirstTransfer = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -73,6 +74,13 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
   logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
   logSuppressedMovement: (...args: unknown[]) => mockLogSuppressedMovement(...args),
+  logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
+    mockLogSuppressedSleepFirstTransfer(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../../utils/boardingLockStorage', () => ({
+  getBoardingLock: () => mockGetBoardingLock(),
 }));
 
 jest.mock('../../utils/scheduledAlarmReceiver', () => ({
@@ -139,6 +147,7 @@ describe('useStationAlarm', () => {
     mockIsImminentByArrivalCode.mockReturnValue(false);
     mockGetStoredTripTrainCode.mockResolvedValue(null);
     mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
+    mockGetBoardingLock.mockResolvedValue(null);
   });
 
   it('does not evaluate when route is null', () => {
@@ -507,6 +516,121 @@ describe('useStationAlarm', () => {
     const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     expect(() => renderHook(() => useStationAlarm(defaultInputs({ route, destination })))).not.toThrow();
+  });
+
+  // #750 — 공통 sleep 룰 게이트가 FG 즉시 발사 path도 차단한다.
+  // scheduler가 사전 예약을 skip한 transfer를 FG polling이 우회 발사하던 회귀.
+  describe('#750 sleep first-transfer 게이트', () => {
+    const lock = {
+      destinationId: destination.id,
+      trainCode: 'T-1',
+      boardingStationId: 'S-BOARD',
+      boardingLine: '2' as const,
+      boardedAt: Date.now(),
+      expectedDurationMs: 60_000,
+    };
+
+    it('sleep ON + lock 활성 + 첫 hop transfer → sendAlarmNotification 호출 X, suppression 로그', async () => {
+      useAppStore.setState({ sleepMode: true });
+      mockGetBoardingLock.mockResolvedValue(lock);
+      // transferRoute targets: [{name:'시청', alarmType:'transfer'}, {name:'강남', alarmType:'destination'}].
+      // earlyTransfer.stationName='시청'이 첫 hop과 일치 → suppress.
+      const route = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '2',
+        toLine: '1',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() =>
+        expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: '시청',
+          phaseId: 'early',
+        }),
+      );
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('sleep OFF + 첫 hop transfer → 정상 발사', async () => {
+      useAppStore.setState({ sleepMode: false });
+      mockGetBoardingLock.mockResolvedValue(lock);
+      const route = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '2',
+        toLine: '1',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock null → 게이트 비활성, 정상 발사', async () => {
+      useAppStore.setState({ sleepMode: true });
+      mockGetBoardingLock.mockResolvedValue(null);
+      const route = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '2',
+        toLine: '1',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock 활성 + destination 카테고리 → 정상 발사 (transfer 외 영향 없음)', async () => {
+      useAppStore.setState({ sleepMode: true });
+      mockGetBoardingLock.mockResolvedValue(lock);
+      const route = makeDirectRoute(1, '2');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock 활성 + imminent API path도 동일 게이트 적용 (firstHop transfer면 suppress)', async () => {
+      useAppStore.setState({ sleepMode: true });
+      mockGetBoardingLock.mockResolvedValue(lock);
+      // imminent path는 destination event를 발사하므로 게이트 trigger 안 됨 — 회귀 확인용.
+      // 별도 시나리오: imminent transfer는 phase 평가 한쪽뿐이라 case는 ETA effect에서 cover.
+      // 본 케이스는 imminent destination 정상 동작 검증 (다른 path가 transfer 차단하는 정책에 의해
+      // 우발 차단되지 않음).
+      const route = makeDirectRoute(1, '2');
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+      mockGetStoredTripTrainCode.mockResolvedValue('T-1');
+      mockUseArrivalInfo.mockReturnValue({
+        arrival: { arrivalCode: '1' },
+        loading: false,
+        isMock: false,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
   });
 
   describe('station-passed notification', () => {

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { isStationOnRoute } from '../utils/stationRoute';
+import { isStationOnRoute, isSameStationName } from '../utils/stationRoute';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
-import { alarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
+import { alarmKey, evaluateAlarmPhase, resolveAllTargets, type AlarmEvent } from '../utils/stationAlarm';
 import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
@@ -24,7 +24,10 @@ import {
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedMovement,
+  logSuppressedSleepFirstTransfer,
 } from '../utils/alarmLog';
+import { getBoardingLock } from '../utils/boardingLockStorage';
+import { shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../utils/movementGate';
 import type { PositionStability } from '../utils/positionStaticDetector';
 import { useAppStore } from '../store/useAppStore';
@@ -185,6 +188,28 @@ export function useStationAlarm({
     activeRoute: NonNullable<Route>,
     activeDestination: Station,
   ): Promise<void> {
+    // #750: 공통 sleep 룰 게이트. scheduler가 사전 예약을 skip한 transfer를 FG polling이
+    // 우회 발사하던 회귀 차단. firedAlarms에 추가하지 않고 그냥 return — 다음 폴링이 다시 같은
+    // 게이트를 통과하지 못하므로 안전 (sleep OFF로 토글되면 그때 정상 발사 경로 진입).
+    // resolveAllTargets는 route가 활성이면 최소 1개 waypoint를 반환한다 — empty 분기 가드 불필요.
+    const firstHopName = resolveAllTargets(activeRoute, activeDestination.name)[0].name;
+    const isFirstHop = isSameStationName(firstHopName, rawEvent.stationName);
+    const lock = await getBoardingLock();
+    if (
+      shouldSuppressBySleepRule({
+        lock,
+        event: { type: rawEvent.type, stationName: rawEvent.stationName },
+        sleepMode: sleepModeRef.current,
+        isFirstHop,
+      })
+    ) {
+      logSuppressedSleepFirstTransfer({
+        source: 'fg',
+        stationName: rawEvent.stationName,
+        phaseId: rawEvent.phaseId,
+      });
+      return;
+    }
     // 좌/우 안내 방향. nearestStation 미정이면 direction 미부착(본문에 좌/우 라인 생략).
     const direction = nearestStation
       ? resolveAlarmDirection(rawEvent, {

--- a/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -79,6 +79,9 @@ jest.mock('../../utils/stationRoute', () => ({
   calculateStaticETA: jest.fn(() => 10),
   updateRouteFromPosition: jest.fn(() => null),
   isStationOnRoute: jest.fn(() => true),
+  // #750 — stationPipeline의 sleep 게이트가 isSameStationName으로 첫 hop을 매칭.
+  // 결정적 fake: strict equality로 충분 (테스트는 동일 한국어 이름 사용).
+  isSameStationName: (a: string, b: string) => a === b,
 }));
 
 const mockSendAlarmNotification = jest.fn((..._args: unknown[]) => Promise.resolve());

--- a/src/utils/__tests__/shouldSuppressBySleepRule.test.ts
+++ b/src/utils/__tests__/shouldSuppressBySleepRule.test.ts
@@ -1,0 +1,83 @@
+import { shouldSuppressBySleepRule } from '../shouldSuppressBySleepRule';
+import type { BoardingLock } from '../../types/boardingLock';
+
+// #750 — 공통 게이트 단위 테스트.
+// 동일 규칙(="탑승/leg 시작 직후 첫 hop이 transfer + sleep ON → suppress")이
+// scheduler/FG/BG 3개 path에서 일관 적용되는지 검증한다.
+
+const lock: BoardingLock = {
+  destinationId: 'D1',
+  trainCode: 'T-1',
+  boardingStationId: 'S-BOARD',
+  boardingLine: '2',
+  boardedAt: 1_000_000,
+  expectedDurationMs: 60_000,
+};
+
+describe('shouldSuppressBySleepRule', () => {
+  it('transfer + sleep ON + firstHop=true → suppress', () => {
+    expect(
+      shouldSuppressBySleepRule({
+        lock,
+        event: { type: 'transfer', stationName: '교대' },
+        sleepMode: true,
+        isFirstHop: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('transfer + sleep ON + firstHop=false → fire (둘째 이후 hop은 영향 없음)', () => {
+    expect(
+      shouldSuppressBySleepRule({
+        lock,
+        event: { type: 'transfer', stationName: '약수' },
+        sleepMode: true,
+        isFirstHop: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('destination + sleep ON + firstHop=true → fire (destination 카테고리 영향 없음)', () => {
+    expect(
+      shouldSuppressBySleepRule({
+        lock,
+        event: { type: 'destination', stationName: '강남' },
+        sleepMode: true,
+        isFirstHop: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('station-passed + sleep ON + firstHop=true → fire (station-passed 카테고리 영향 없음)', () => {
+    expect(
+      shouldSuppressBySleepRule({
+        lock,
+        event: { type: 'station-passed', stationName: '교대' },
+        sleepMode: true,
+        isFirstHop: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('transfer + sleep OFF + firstHop=true → fire', () => {
+    expect(
+      shouldSuppressBySleepRule({
+        lock,
+        event: { type: 'transfer', stationName: '교대' },
+        sleepMode: false,
+        isFirstHop: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('lock=null + 모든 조합 → fire (게이트는 lock 활성 시에만 의미)', () => {
+    expect(
+      shouldSuppressBySleepRule({
+        lock: null,
+        event: { type: 'transfer', stationName: '교대' },
+        sleepMode: true,
+        isFirstHop: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -63,10 +63,15 @@ jest.mock('../notificationState', () => ({
 const mockLogFiredAlarm = jest.fn();
 const mockLogFiredStationPassed = jest.fn();
 const mockLogSuppressedDedupStation = jest.fn();
+const mockLogSuppressedDedupAlarm = jest.fn();
+const mockLogSuppressedSleepFirstTransfer = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
   logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
+  logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
+  logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
+    mockLogSuppressedSleepFirstTransfer(...args),
 }));
 
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
@@ -122,6 +127,12 @@ describe('processLocationUpdate', () => {
     mockSetLastNotifiedStationId.mockResolvedValue(undefined);
     // 기본: lock 없음 — BG path가 GPS line을 그대로 사용 (기존 동작).
     mockGetBoardingLock.mockResolvedValue(null);
+    // #750: 알람 발사 분기는 resolveAllTargets를 호출해 첫 hop을 산출한다.
+    // 기존 테스트에서 빈 배열을 반환하면 `[0].name`이 깨지므로 destination 매칭 default를 둔다.
+    // sleep 게이트 describe는 자체 beforeEach로 transfer-first 매핑을 덮어쓴다.
+    mockResolveAllTargets.mockReturnValue([
+      { name: '시청', stops: 3, alarmType: 'destination', approachLine: '2' },
+    ]);
   });
 
   it('returns null nearest and null alarm when findNearestStation returns null', async () => {
@@ -635,6 +646,109 @@ describe('processLocationUpdate', () => {
         expect.any(Object),
         'routeProgress',
       );
+    });
+  });
+
+  // #750 — BG 즉시 발사 path도 공통 sleep 룰 게이트를 통과해야 한다.
+  // scheduler가 사전 예약을 skip한 transfer를 BG silent push 등이 우회 발사하던 회귀.
+  describe('#750 sleep first-transfer 게이트', () => {
+    const lock = {
+      destinationId: 'station-2',
+      trainCode: 'T-1',
+      boardingStationId: 'station-1',
+      boardingLine: '2' as const,
+      boardedAt: Date.now(),
+      expectedDurationMs: 60_000,
+    };
+    const transferAlarm: AlarmEvent = {
+      phaseId: 'early',
+      type: 'transfer',
+      stationName: '교대',
+    };
+
+    beforeEach(() => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue(transferAlarm);
+      // 첫 hop 매칭용 — resolveAllTargets는 호출 순서에 따라 호출됨. transfer 알람 매칭 케이스에서
+      // alarmEvent 분기와 station-passed 분기 둘 다 사용 — 둘 다 같은 targets 반환하도록 통일.
+      mockResolveAllTargets.mockReturnValue([
+        { name: '교대', stops: 1, alarmType: 'transfer', approachLine: '2' },
+        { name: '시청', stops: 3, alarmType: 'destination', approachLine: '1' },
+      ]);
+    });
+
+    it('sleep ON + lock 활성 + 첫 hop transfer → sendAlarmNotification 호출 X, suppression 로그', async () => {
+      mockGetBoardingLock.mockResolvedValue(lock);
+      await call({ sleepMode: true });
+      expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: '교대',
+        phaseId: 'early',
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('sleep OFF + lock 활성 + 첫 hop transfer → 정상 발사', async () => {
+      mockGetBoardingLock.mockResolvedValue(lock);
+      await call({ sleepMode: false });
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock null → 게이트 비활성, 정상 발사', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      await call({ sleepMode: true });
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock 활성 + alarmEvent의 stationName이 첫 hop과 불일치 → 정상 발사 (둘째 hop은 영향 없음)', async () => {
+      mockGetBoardingLock.mockResolvedValue(lock);
+      // 둘째 hop transfer가 발사 시점에 trigger됐다고 가정 (자주 일어나지 않지만 회귀 가드).
+      mockEvaluateAlarmPhase.mockReturnValue({
+        phaseId: 'early',
+        type: 'transfer',
+        stationName: '시청', // 둘째 hop
+      });
+      await call({ sleepMode: true });
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock 활성 + destination 카테고리 → 정상 발사 (transfer 외 영향 없음)', async () => {
+      mockGetBoardingLock.mockResolvedValue(lock);
+      mockEvaluateAlarmPhase.mockReturnValue({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: '교대',
+      });
+      await call({ sleepMode: true });
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('route=null → 게이트 비활성, alarmEvent도 null이라 발사 자체 없음 (회귀 가드)', async () => {
+      // route 미존재 시 evaluateAlarmPhase가 null을 반환하므로 게이트 분기에 들어가지 않는다.
+      // 본 케이스는 alarmEvent=null path에서 sleep 게이트가 우발 동작하지 않는지 가드.
+      mockGetBoardingLock.mockResolvedValue(lock);
+      mockFindRoute.mockReturnValue(null);
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      await call({ sleepMode: true });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('route=null인데 evaluator가 alarmEvent 반환(비정상) → 게이트 분기 진입 안 함, 발사 안 함 (defensive guard)', async () => {
+      // evaluateAlarmPhase 계약상 route=null이면 null이지만, mock으로 비정상 케이스를 시뮬레이트해
+      // 발사 분기의 `alarmEvent && route` 가드 양쪽을 branch coverage로 확정한다.
+      mockGetBoardingLock.mockResolvedValue(lock);
+      mockFindRoute.mockReturnValue(null);
+      mockEvaluateAlarmPhase.mockReturnValue(transferAlarm);
+      await call({ sleepMode: true });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -72,7 +72,10 @@ export type AlarmLogReason =
   | 'movement-low-accuracy'
   | 'movement-static-speed'
   | 'movement-static-position'
-  | 'movement-motion-stationary';
+  | 'movement-motion-stationary'
+  // #750 — 공통 sleep 룰 게이트(shouldSuppressBySleepRule)가 차단한 발사.
+  // scheduler/FG/BG 3개 path 어디서든 같은 reason으로 적재 — 정책 단일 출처.
+  | 'sleep-first-transfer';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -454,6 +457,28 @@ export function logSuppressedMovement(input: {
     reason: input.reason,
     stationName: input.stationName,
     kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * 취침모드 첫 환승 알람 누수 차단 1건 적재 (#750).
+ * source는 호출 path를 식별: scheduler 사전예약은 'bg-scheduled', FG polling은 'fg',
+ * BG silent push 등은 'bg' / 'silent-push-skipped' 중 호출자가 결정.
+ * 알람 유형은 항상 transfer이므로 kind 고정 — 호출자가 다시 채울 필요 없음.
+ */
+export function logSuppressedSleepFirstTransfer(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  phaseId?: AlarmPhaseId;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'sleep-first-transfer',
+    stationName: input.stationName,
+    kind: 'transfer',
     phaseId: input.phaseId,
   });
 }

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -13,6 +13,8 @@ import {
 } from './scheduledNotificationsStorage';
 import { createLogger } from './logger';
 import { HOP_TIME_MS } from '../constants/boardingLock';
+import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
+import { logSuppressedSleepFirstTransfer } from './alarmLog';
 
 const logger = createLogger('BoardingLockScheduler');
 
@@ -154,14 +156,27 @@ function arrivalMsForHop(
 
 /**
  * 탑승/환승 직후 새 leg의 첫 hop이 transfer일 때 sleep ON이면 알람 skip(#632).
- * scheduleHopsForLock / advanceHopWindow가 공유하는 동일 조건 — 중복 제거.
+ * scheduleHopsForLock / advanceHopWindow가 공유하는 동일 조건 — 정책은 공통 게이트 위임.
+ *
+ * #750: 즉시 발사 path(FG/BG)도 동일 게이트를 사용하도록 `shouldSuppressBySleepRule`로 일원화.
+ * 본 helper는 scheduler 내부 호출부 단순화용 wrapper — 차단 시 alarmLog suppression entry도 기록.
  */
 function shouldSkipFirstTransferForSleep(
   isFirstNewHop: boolean,
   sleepMode: boolean,
-  hop: { alarmType: string },
+  hop: CurrentTarget,
+  lock: BoardingLock,
 ): boolean {
-  return isFirstNewHop && sleepMode && hop.alarmType === 'transfer';
+  const suppress = shouldSuppressBySleepRule({
+    lock,
+    event: { type: hop.alarmType, stationName: hop.name },
+    sleepMode,
+    isFirstHop: isFirstNewHop,
+  });
+  if (suppress) {
+    logSuppressedSleepFirstTransfer({ source: 'bg-scheduled', stationName: hop.name });
+  }
+  return suppress;
 }
 
 async function cancelAndDismiss(ids: string[]): Promise<void> {
@@ -207,7 +222,7 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
 
   const scheduledIds: string[] = [];
   for (let hopIndex = 0; hopIndex < lastIdx; hopIndex++) {
-    if (shouldSkipFirstTransferForSleep(hopIndex === 0, sleepMode, allTargets[hopIndex])) {
+    if (shouldSkipFirstTransferForSleep(hopIndex === 0, sleepMode, allTargets[hopIndex], lock)) {
       // 탑승 직후 첫 hop이 환승이고 sleep ON → 사용자가 노이즈로 느낀다(#632). 둘째 hop부터 정상 예약.
       continue;
     }
@@ -338,6 +353,7 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
         hopIndex === passedIndex + 1,
         sleepMode,
         allTargets[hopIndex],
+        lock,
       )
     ) {
       // "방금 진입한 새 leg의 첫 hop"이 transfer면 skip(#632). out-of-order advance(0→2 등 GPS 점프)에서도

--- a/src/utils/shouldSuppressBySleepRule.ts
+++ b/src/utils/shouldSuppressBySleepRule.ts
@@ -1,0 +1,49 @@
+import type { BoardingLock } from '../types/boardingLock';
+import type { AlarmType } from './stationAlarm';
+
+/**
+ * 공통 sleep 룰 게이트가 다루는 알람 카테고리.
+ * scheduler/FG/BG 경로 모두에서 적용되는 좁은 식별자 — 'transfer'일 때만 suppress 가능,
+ * 'destination' / 'station-passed'는 항상 fire 한다.
+ */
+export type SleepRuleEventType = AlarmType | 'station-passed';
+
+export interface SleepRuleEvent {
+  type: SleepRuleEventType;
+  stationName: string;
+}
+
+export interface SleepRuleInput {
+  lock: BoardingLock | null;
+  event: SleepRuleEvent;
+  sleepMode: boolean;
+  /**
+   * 호출자가 도출한 "이 알람이 현재 leg의 *첫* hop을 향하는가" 신호.
+   *
+   * - `scheduleHopsForLock` : 배치 안의 hopIndex === 0
+   * - `advanceHopWindow`     : hopIndex === passedIndex + 1
+   * - FG/BG 즉시 발사 path   : `lock.boardingStationId`가 사용자가 직전에 lock한 탑승역이므로
+   *                            "현재 노선의 다음 transfer"가 곧 첫 hop. 호출자는 자신이 보는
+   *                            event.stationName이 lock이 시작된 leg의 첫 transfer waypoint와
+   *                            일치하는지로 판단해 전달한다.
+   */
+  isFirstHop: boolean;
+}
+
+/**
+ * #750 — 취침모드 첫 환승 알람 누수 차단용 공통 게이트.
+ *
+ * 단일 정책: lock 활성 + sleep ON + event가 현재 leg의 첫 hop transfer면 suppress.
+ *
+ * 이전 구현(`boardingLockScheduler.shouldSkipFirstTransferForSleep`)은 scheduler에만
+ * 적용돼 폴링 기반 즉시 발사 path(useStationAlarm FG, stationPipeline BG)가 동일 조건에서
+ * 발사를 우회했다. 이 함수를 세 경로 공통으로 호출해 정책을 한 곳에서 결정한다.
+ *
+ * lock=null이면 규칙은 비활성(scheduler가 동작하지 않고 "첫 hop" 개념이 없는 자유 트립).
+ */
+export function shouldSuppressBySleepRule(input: SleepRuleInput): boolean {
+  if (!input.lock) return false;
+  if (!input.sleepMode) return false;
+  if (!input.isFirstHop) return false;
+  return input.event.type === 'transfer';
+}

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -11,8 +11,10 @@ import {
   logFiredStationPassed,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
+  logSuppressedSleepFirstTransfer,
   type AlarmLogSource,
 } from './alarmLog';
+import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import type { NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
@@ -166,9 +168,31 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
 
   for (const event of suppressed) logSuppressedDedupAlarm(source, event);
 
-  if (alarmEvent) {
-    await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);
-    logFiredAlarm(source, alarmEvent);
+  // alarmEvent && route 두 조건이 동시에 참일 때만 발사 분기 진입.
+  // evaluateAlarmPhase는 route=null이면 항상 null이라 사실상 alarmEvent != null이면 route != null.
+  // 명시 가드로 type narrowing 후 resolveAllTargets 호출 — non-null assertion 회피.
+  if (alarmEvent && route) {
+    // #750: 공통 sleep 룰 게이트. scheduler 사전 예약이 skip한 transfer를 BG 즉시 발사 path가
+    // 우회 발사하던 회귀 차단. 첫 hop 판정은 route의 첫 waypoint와 stationName 일치로 — lock
+    // 활성 동안 leg가 갱신되면 lock도 갱신되므로 route.targets[0]이 곧 현재 leg의 첫 hop.
+    const firstHopName = resolveAllTargets(route, destination.name)[0].name;
+    const isFirstHop = isSameStationName(firstHopName, alarmEvent.stationName);
+    const suppressBySleep = shouldSuppressBySleepRule({
+      lock: lockForLineGuard,
+      event: { type: alarmEvent.type, stationName: alarmEvent.stationName },
+      sleepMode,
+      isFirstHop,
+    });
+    if (suppressBySleep) {
+      logSuppressedSleepFirstTransfer({
+        source,
+        stationName: alarmEvent.stationName,
+        phaseId: alarmEvent.phaseId,
+      });
+    } else {
+      await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);
+      logFiredAlarm(source, alarmEvent);
+    }
   }
 
   // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)


### PR DESCRIPTION
## Summary

기존 `shouldSkipFirstTransferForSleep`은 scheduler path에만 적용돼 FG polling(`useStationAlarm`) + BG silent push(`stationPipeline`) 즉시 발사 경로가 동일 조건에서 알람을 우회 발사했음. 사용자가 짧은 trip 첫 환승(예: 성수→건대, 1정거장 후 7호선 환승) 생성 시 sleep ON인데 환승 알람 fired되는 회귀.

3개 경로 모두 공통 게이트 함수 한 곳에서 정책 결정.

## Scope

- `src/utils/shouldSuppressBySleepRule.ts` (신규) — 순수 함수 공통 게이트
- `boardingLockScheduler` — 기존 룰 자리를 새 게이트 호출로 일원화
- `useStationAlarm.fireAndLog` — 발사 직전 게이트 적용 (FG)
- `stationPipeline.processLocationUpdate` — `sendAlarmNotification` 직전 게이트 적용 (BG)
- 알람 로그 suppression reason `sleep-first-transfer` 추가

## Acceptance

- [x] sleep ON + 첫 hop transfer 조건에서 FG/BG/scheduler 모든 path에서 알람 미발사
- [x] 알람 로그에 `sleep-first-transfer` reason 기록
- [x] sleep OFF면 정상 발사 (회귀 없음)
- [x] 두번째 이후 hop transfer 알람은 정상 발사 (룰 first-only 보존)
- [x] station-passed/destination 영향 없음
- [x] 152 suites / 2695 tests 통과, 커버리지 100%, type-check 통과

## 회귀 보호

3계층 테스트:
1. 게이트 순수 함수 단위 — transfer/destination/station-passed × sleep ON/OFF × firstHop × lock null 조합
2. 각 path 회귀 — useStationAlarm/stationPipeline/scheduler 각각 sleep ON + first transfer 시나리오에서 발사 안 함 검증
3. 통합 — `foregroundBackgroundTransition.test.ts` 종합 회귀

## Out of scope (후속 후보)

- raw `sendAlarmNotification` 호출 자체를 구조적으로 막는 래퍼/lint rule — 현재는 게이트 호출 누락이 회귀 테스트로만 보호됨

Closes #750