### PR TITLE
fix(#754): useStationAlarm fireAndLog dedup race — 88회 destination burst 차단

### DIFF
--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -1930,4 +1930,89 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
     });
   });
+
+  // #754 — fireAndLog dedup race: await getBoardingLock() 동안 effect가 재실행돼
+  // 같은 rawEvent로 in-flight fireAndLog가 다수 누적되어도 사용자에게는 1회만 노출.
+  describe('#754 fireAndLog dedup race', () => {
+    it('진입 시 firedAlarmsRef에 키가 이미 있으면 즉시 return (in-flight entry dedup)', async () => {
+      // race 시뮬레이션: evaluateAlarmPhase mock이 firedAlarms를 honor 안 함으로써 같은
+      // rawEvent를 매 evaluation마다 반환 (production race에서 in-flight fireAndLog가 add 전에
+      // 다음 evaluation이 들어오는 상황과 동치). fireAndLog 진입 가드가 차단해야 한다.
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      mockGetBoardingLock.mockResolvedValue(null);
+      const route = makeDirectRoute(1, '2');
+
+      const { rerender } = renderHook(
+        ({ lat }: { lat: number }) =>
+          useStationAlarm(
+            defaultInputs({
+              route,
+              destination,
+              userLocation: { lat, lng: 127.0 },
+            }),
+          ),
+        { initialProps: { lat: 37.5 } },
+      );
+
+      // 첫 fire 완료까지 대기 — firedAlarmsRef에 'early:강남' 적재.
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
+
+      // mock이 firedAlarms를 무시하므로 evaluateAlarmPhase는 다시 같은 rawEvent 반환 → fireAndLog 호출.
+      // 진입 가드(has(key)=true)가 catch하지 않으면 88회 burst 회귀 — 추가 발사 없어야 한다.
+      rerender({ lat: 37.50001 });
+      rerender({ lat: 37.50002 });
+      rerender({ lat: 37.50003 });
+
+      // microtask + effect 사이클 flush. setTimeout(0)으로 macrotask queue까지 비운다.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
+    });
+
+    it('sleep-rule suppress 분기에서 firedAlarms.delete로 복구 → sleep 해제 후 다음 evaluation은 정상 발사', async () => {
+      const lock = {
+        destinationId: destination.id,
+        trainCode: 'T-1',
+        boardingStationId: 'S-BOARD',
+        boardingLine: '2' as const,
+        boardedAt: Date.now(),
+        expectedDurationMs: 60_000,
+      };
+      useAppStore.setState({ sleepMode: true });
+      mockGetBoardingLock.mockResolvedValue(lock);
+
+      const route = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '2',
+        toLine: '1',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+
+      const { rerender } = renderHook(
+        ({ lat }: { lat: number }) =>
+          useStationAlarm(
+            defaultInputs({
+              route,
+              destination,
+              userLocation: { lat, lng: 127.0 },
+            }),
+          ),
+        { initialProps: { lat: 37.5 } },
+      );
+
+      await waitFor(() => expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalled());
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+
+      // sleep OFF 토글 → firedAlarms.delete가 sync 적용됐다면 다음 evaluation은 정상 발사.
+      // delete가 빠지면 같은 키가 firedAlarms에 남아 진입 가드가 영구 봉쇄 → 회귀.
+      useAppStore.setState({ sleepMode: false });
+      rerender({ lat: 37.50001 });
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+    });
+  });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -188,9 +188,18 @@ export function useStationAlarm({
     activeRoute: NonNullable<Route>,
     activeDestination: Station,
   ): Promise<void> {
+    // #754 — in-flight dedup. 진입 즉시 firedAlarmsRef에 추가해 await 동안 effect가
+    // 재실행돼도 같은 키가 evaluateAlarmPhase에서 dedup된다. 같은 키가 이미 있으면
+    // 즉시 return — sync 입구에서 race window를 닫는다 (88회 burst 회귀 차단).
+    // sleep-rule suppress 분기에선 아래에서 delete로 복구해 sleep 토글 후 재발사 가능.
+    // alarmKey는 phaseId/stationName만 사용하므로 direction 조정 전후로 동일 키.
+    const key = alarmKey(rawEvent);
+    if (firedAlarmsRef.current.has(key)) return;
+    firedAlarmsRef.current.add(key);
+
     // #750: 공통 sleep 룰 게이트. scheduler가 사전 예약을 skip한 transfer를 FG polling이
-    // 우회 발사하던 회귀 차단. firedAlarms에 추가하지 않고 그냥 return — 다음 폴링이 다시 같은
-    // 게이트를 통과하지 못하므로 안전 (sleep OFF로 토글되면 그때 정상 발사 경로 진입).
+    // 우회 발사하던 회귀 차단. sleep으로 suppress된 키는 firedAlarmsRef에서 제거해 sleep OFF
+    // 토글 시 다음 evaluation이 정상 발사 경로로 진입할 수 있게 한다.
     // resolveAllTargets는 route가 활성이면 최소 1개 waypoint를 반환한다 — empty 분기 가드 불필요.
     const firstHopName = resolveAllTargets(activeRoute, activeDestination.name)[0].name;
     const isFirstHop = isSameStationName(firstHopName, rawEvent.stationName);
@@ -203,6 +212,9 @@ export function useStationAlarm({
         isFirstHop,
       })
     ) {
+      // delete는 ref만 갱신 — setFiredAlarms 호출 없음. 진입부 add도 ref만 갱신했으므로
+      // 같은 분기 내 add → delete는 storage 관점에서 net-zero (BG가 읽는 영속 상태 불변).
+      firedAlarmsRef.current.delete(key);
       logSuppressedSleepFirstTransfer({
         source: 'fg',
         stationName: rawEvent.stationName,
@@ -219,8 +231,6 @@ export function useStationAlarm({
         })
       : undefined;
     const event = direction ? { ...rawEvent, direction } : rawEvent;
-    // sync ref add — 같은 hook 인스턴스의 다음 evaluation은 즉시 dedup됨.
-    firedAlarmsRef.current.add(alarmKey(event));
     // AsyncStorage write 완료까지 await — BG/재하이드레이션 race 차단(#699).
     try {
       await setFiredAlarms(activeDestination.id, firedAlarmsRef.current);
@@ -293,8 +303,8 @@ export function useStationAlarm({
     );
     for (const event of suppressed) logSuppressedDedupAlarm('fg', event);
     // #699: fireAndLog가 setFiredAlarms를 await하므로 promise를 명시적으로 흘려보낸다.
-    // sync firedAlarmsRef.current.add는 fireAndLog 내부 첫 동작이라 같은 hook 인스턴스
-    // 다음 evaluation은 await 중에도 dedup된다.
+    // #754: in-flight dedup은 fireAndLog 진입부의 sync firedAlarmsRef.current.add(key) 가
+    // 보장한다 (await getBoardingLock 전에 set에 들어가므로 같은 키의 동시 호출은 즉시 return).
     if (rawEvent) {
       // #733 — Phase ETA path movement gate. early phase는 etaSeconds 무관, remainingStops<=1만
       // 검사하므로 fusion이 인접역으로 jitter하면 즉시 발사. snapshot 1/2에서 관측된 20:07:48 등


### PR DESCRIPTION
## Summary
- `useStationAlarm.ts` `fireAndLog` 진입부에 sync `firedAlarmsRef.current.add(alarmKey(rawEvent))` + `has(key)` 즉시 return 추가. `await getBoardingLock()` 이전 add라 effect re-entry로 들어온 in-flight 호출이 `evaluateAlarmPhase`의 자연 dedup(#580) 또는 진입 가드에서 차단됨.
- sleep-rule suppress 분기에서 `firedAlarmsRef.current.delete(key)`로 복구해 sleep OFF 토글 시 정상 발사 경로 보존. `delete`는 ref만 갱신 — 같은 분기 내 `add → delete`는 storage 관점에서 net-zero.
- 잘못된 주석(line 295-297) 정정 — 과거 주석은 sync add가 fireAndLog 첫 동작이라고 명시했으나 실제로는 `await getBoardingLock` 이후였음.
- 테스트 2건 추가: entry-dedup 분기 직접 cover + sleep-suppress → sleep OFF 후 발사 복귀.

## 증거 (production)
- 2026-06-02 19:49:59 ~ 19:50:02 (약 3초) 사이 `destination/early/성수` 알람 **88회 발사**. iOS coalesce로 잠금화면엔 Live Activity + 1건 notification만 노출됐지만 alarmLog 99 엔트리 중 88개 동일 이벤트.
- 사용자는 정적 상태 (`speed=-` m/s, `accuracy=8m`, `confidence=arrival-arriving`) — motion 신호가 잠깐 false로 튄 1 tick에서 1회 fire 조건이 race로 88회 burst.

## Root cause
`fireAndLog`가 `await getBoardingLock()` 이전에 `firedAlarmsRef.current.add`를 하지 않아 await 동안 effect 재실행 시 같은 rawEvent로 다중 in-flight 호출이 dedup 우회.

## Test plan
- [x] `npx jest src/hooks/__tests__/useStationAlarm.test.ts` — 95 passed (race 2건 포함)
- [x] `npm test` — 152 suites / 2713 tests passed, coverage 100% 통과
- [x] `npm run type-check` — 통과
- [x] code-review 에이전트 리뷰 통과 (P0 없음, P1-1 의도 주석 적용)
- [ ] 실기기 회귀 검증 — 동일 시나리오(정적 사용자 + 트립 선택)에서 destination 알람 1회만 발사 확인

Closes #754
