### PR TITLE
chore(#756): 사전예약 큐 dump + boardingLockScheduler transition trace — stale alarm 진단 인프라

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -31,6 +31,11 @@ import {
   subscribeFusionDebug,
   type FusionDebugEntry,
 } from '../utils/fusionDebugBuffer';
+import {
+  dumpScheduledNotifications,
+  formatScheduledNotificationLine,
+  type ScheduledNotificationDumpEntry,
+} from '../utils/scheduledNotificationsDump';
 import type { FusionConfidence, FusionSource } from '../utils/pickFusedStation';
 import type { NearestStationResult } from '../types/station';
 import { useTheme, spacing, radius, typography } from '../theme';
@@ -174,6 +179,8 @@ function buildDumpText(args: {
   isMock: boolean;
   silentPush: SilentPushDiagnostics;
   logs: AlarmLogEntry[];
+  // #756: OS 큐 dump. 미전달/null = DebugModal에서 한 번도 Refresh 안 한 상태.
+  scheduledDump?: ScheduledNotificationDumpEntry[] | null;
 }): string {
   const lines: string[] = [];
   lines.push(`[Subway debug] ${new Date().toISOString()}`);
@@ -213,6 +220,19 @@ function buildDumpText(args: {
   lines.push('## Silent Push');
   for (const { dumpKey, value } of silentPushDiagRows(args.silentPush)) {
     lines.push(`${dumpKey}=${value}`);
+  }
+  lines.push('');
+  // #756: 사용자가 Refresh 안 했으면 dump 섹션 자체를 "(not loaded)"로 명시해
+  // "비어있음"과 "load 안 함"을 dump 텍스트만 보고도 구분 가능하게.
+  // optional 필드 — undefined 도 null 과 동일 처리.
+  if (args.scheduledDump == null) {
+    lines.push('## Scheduled queue');
+    lines.push('(not loaded)');
+  } else {
+    lines.push(`## Scheduled queue (${args.scheduledDump.length})`);
+    for (const entry of args.scheduledDump) {
+      lines.push(formatScheduledNotificationLine(entry));
+    }
   }
   lines.push('');
   lines.push(`## Alarm log (${args.logs.length})`);
@@ -281,6 +301,13 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
     getFusionDebugEntries(),
   );
+  // #756: OS 큐 ground-truth dump. 호출 직후 한 번 비동기로 채워진다.
+  // null = 아직 한 번도 dump 안 한 상태 → "Tap Refresh" placeholder 노출.
+  const [scheduledDump, setScheduledDump] = useState<ScheduledNotificationDumpEntry[] | null>(null);
+
+  const refreshScheduledDump = useCallback(async () => {
+    setScheduledDump(await dumpScheduledNotifications());
+  }, []);
 
   useEffect(() => {
     return subscribeFusionDebug(() => setFusionLogs([...getFusionDebugEntries()]));
@@ -339,6 +366,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
       isMock,
       silentPush,
       logs,
+      scheduledDump,
     });
     void Share.share({ message });
   }, [
@@ -358,6 +386,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
     isMock,
     silentPush,
     logs,
+    scheduledDump,
   ]);
 
   return (
@@ -486,6 +515,39 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
                   testID="debug-fusion-log-entry"
                 >
                   {formatFusionDebugLine(entry)}
+                </Text>
+              ))
+            )}
+          </Section>
+
+          <Section
+            title={
+              scheduledDump
+                ? `Scheduled queue (${scheduledDump.length})`
+                : 'Scheduled queue'
+            }
+            colors={colors}
+            action={
+              <Pressable onPress={refreshScheduledDump} testID="debug-scheduled-dump-refresh">
+                <Text style={[typography.bodySm, { color: colors.accent }]}>Refresh</Text>
+              </Pressable>
+            }
+          >
+            {scheduledDump === null ? (
+              <Text style={[typography.mono, { color: colors.muted }]}>
+                (tap Refresh to load)
+              </Text>
+            ) : scheduledDump.length === 0 ? (
+              <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
+            ) : (
+              scheduledDump.map((entry) => (
+                <Text
+                  key={entry.identifier}
+                  style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
+                  selectable
+                  testID="debug-scheduled-dump-entry"
+                >
+                  {formatScheduledNotificationLine(entry)}
                 </Text>
               ))
             )}

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -226,13 +226,12 @@ function buildDumpText(args: {
   // "비어있음"과 "load 안 함"을 dump 텍스트만 보고도 구분 가능하게.
   // optional 필드 — undefined 도 null 과 동일 처리.
   if (args.scheduledDump == null) {
-    lines.push('## Scheduled queue');
-    lines.push('(not loaded)');
+    lines.push('## Scheduled queue', '(not loaded)');
   } else {
-    lines.push(`## Scheduled queue (${args.scheduledDump.length})`);
-    for (const entry of args.scheduledDump) {
-      lines.push(formatScheduledNotificationLine(entry));
-    }
+    lines.push(
+      `## Scheduled queue (${args.scheduledDump.length})`,
+      ...args.scheduledDump.map(formatScheduledNotificationLine),
+    );
   }
   lines.push('');
   lines.push(`## Alarm log (${args.logs.length})`);
@@ -533,24 +532,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
               </Pressable>
             }
           >
-            {scheduledDump === null ? (
-              <Text style={[typography.mono, { color: colors.muted }]}>
-                (tap Refresh to load)
-              </Text>
-            ) : scheduledDump.length === 0 ? (
-              <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
-            ) : (
-              scheduledDump.map((entry) => (
-                <Text
-                  key={entry.identifier}
-                  style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
-                  selectable
-                  testID="debug-scheduled-dump-entry"
-                >
-                  {formatScheduledNotificationLine(entry)}
-                </Text>
-              ))
-            )}
+            <ScheduledQueueBody dump={scheduledDump} colors={colors} />
           </Section>
 
           <Section
@@ -605,6 +587,39 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
         </ScrollView>
       </View>
     </Modal>
+  );
+}
+
+// #756: Scheduled queue 섹션 본문 — null/empty/non-empty 3가지 상태를 별도 컴포넌트로
+// 분리해 nested ternary를 피한다. dump 배열은 fire 시각 기준 정렬된 상태로 들어온다.
+function ScheduledQueueBody({
+  dump,
+  colors,
+}: {
+  dump: ScheduledNotificationDumpEntry[] | null;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  if (dump === null) {
+    return (
+      <Text style={[typography.mono, { color: colors.muted }]}>(tap Refresh to load)</Text>
+    );
+  }
+  if (dump.length === 0) {
+    return <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>;
+  }
+  return (
+    <>
+      {dump.map((entry) => (
+        <Text
+          key={entry.identifier}
+          style={[typography.mono, { color: colors.ink, marginBottom: 2 }]}
+          selectable
+          testID="debug-scheduled-dump-entry"
+        >
+          {formatScheduledNotificationLine(entry)}
+        </Text>
+      ))}
+    </>
   );
 }
 

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -595,10 +595,10 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
 function ScheduledQueueBody({
   dump,
   colors,
-}: {
+}: Readonly<{
   dump: ScheduledNotificationDumpEntry[] | null;
   colors: ReturnType<typeof useTheme>['colors'];
-}) {
+}>) {
   if (dump === null) {
     return (
       <Text style={[typography.mono, { color: colors.muted }]}>(tap Refresh to load)</Text>

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -1170,8 +1170,10 @@ describe('DebugModal — Silent Push 진단 섹션 (#506)', () => {
   });
 
   // #756: 사전예약 큐 dump — stale `bl:` 알람 진단용 새 섹션.
-  it('buildDumpText: scheduledDump null이면 "(not loaded)" 노출', () => {
-    const dump = __test__.buildDumpText({
+  // 3개 테스트가 동일 baseline args를 공유 — CPD 중복 회피용 helper.
+  type DumpArgs = Parameters<typeof __test__.buildDumpText>[0];
+  function scheduledDumpArgs(scheduledDump?: DumpArgs['scheduledDump']): DumpArgs {
+    return {
       userLocation: null,
       speedMps: null,
       accuracyMeters: null,
@@ -1190,59 +1192,26 @@ describe('DebugModal — Silent Push 진단 섹션 (#506)', () => {
       isMock: false,
       silentPush: baseSilentPushFull,
       logs: [],
-      scheduledDump: null,
-    });
+      ...(scheduledDump !== undefined ? { scheduledDump } : {}),
+    };
+  }
+
+  it('buildDumpText: scheduledDump null이면 "(not loaded)" 노출', () => {
+    const dump = __test__.buildDumpText(scheduledDumpArgs(null));
     expect(dump).toContain('## Scheduled queue');
     expect(dump).toContain('(not loaded)');
     expect(dump).not.toMatch(/## Scheduled queue \(\d+\)/);
   });
 
   it('buildDumpText: scheduledDump optional 미전달 시에도 "(not loaded)" 노출', () => {
-    const dump = __test__.buildDumpText({
-      userLocation: null,
-      speedMps: null,
-      accuracyMeters: null,
-      nearestName: null,
-      nearestDistanceM: null,
-      variants: [],
-      fusion: {
-        confidence: 'gps-only',
-        source: 'gps',
-        fusedLabel: '-',
-        gpsLabel: '-',
-        differs: false,
-        candidateTrains: null,
-      },
-      arrivalSummary: '-',
-      isMock: false,
-      silentPush: baseSilentPushFull,
-      logs: [],
-    });
+    const dump = __test__.buildDumpText(scheduledDumpArgs());
     expect(dump).toContain('## Scheduled queue');
     expect(dump).toContain('(not loaded)');
   });
 
   it('buildDumpText: scheduledDump 엔트리가 있으면 카운트와 라인 노출', () => {
-    const dump = __test__.buildDumpText({
-      userLocation: null,
-      speedMps: null,
-      accuracyMeters: null,
-      nearestName: null,
-      nearestDistanceM: null,
-      variants: [],
-      fusion: {
-        confidence: 'gps-only',
-        source: 'gps',
-        fusedLabel: '-',
-        gpsLabel: '-',
-        differs: false,
-        candidateTrains: null,
-      },
-      arrivalSummary: '-',
-      isMock: false,
-      silentPush: baseSilentPushFull,
-      logs: [],
-      scheduledDump: [
+    const dump = __test__.buildDumpText(
+      scheduledDumpArgs([
         {
           identifier: 'bl:T:1:early:군자',
           fireAtMs: new Date('2026-06-02T11:30:00Z').getTime(),
@@ -1255,8 +1224,8 @@ describe('DebugModal — Silent Push 진단 섹션 (#506)', () => {
           title: '환승 임박',
           body: '',
         },
-      ],
-    });
+      ]),
+    );
     expect(dump).toContain('## Scheduled queue (2)');
     expect(dump).toContain('bl:T:1:early:군자');
     expect(dump).toContain('bl:T:1:imminent:군자');

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -31,6 +31,15 @@ jest.mock('../../utils/alarmLog', () => {
     clearAlarmLog: () => mockClearAlarmLog(),
   };
 });
+
+const mockDumpScheduledNotifications = jest.fn();
+jest.mock('../../utils/scheduledNotificationsDump', () => {
+  const actual = jest.requireActual('../../utils/scheduledNotificationsDump');
+  return {
+    ...actual,
+    dumpScheduledNotifications: () => mockDumpScheduledNotifications(),
+  };
+});
 const station: Station = {
   id: '2-022',
   name: '강남',
@@ -95,6 +104,7 @@ const setupHookDefaults = () => {
   });
   mockGetAlarmLog.mockResolvedValue([]);
   mockClearAlarmLog.mockResolvedValue(undefined);
+  mockDumpScheduledNotifications.mockResolvedValue([]);
 };
 
 describe('DebugModal', () => {
@@ -1157,5 +1167,183 @@ describe('DebugModal — Silent Push 진단 섹션 (#506)', () => {
       logs: [],
     });
     expect(dump).toContain('taskRegistration=failed (not supported)');
+  });
+
+  // #756: 사전예약 큐 dump — stale `bl:` 알람 진단용 새 섹션.
+  it('buildDumpText: scheduledDump null이면 "(not loaded)" 노출', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: {
+        confidence: 'gps-only',
+        source: 'gps',
+        fusedLabel: '-',
+        gpsLabel: '-',
+        differs: false,
+        candidateTrains: null,
+      },
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: baseSilentPushFull,
+      logs: [],
+      scheduledDump: null,
+    });
+    expect(dump).toContain('## Scheduled queue');
+    expect(dump).toContain('(not loaded)');
+    expect(dump).not.toMatch(/## Scheduled queue \(\d+\)/);
+  });
+
+  it('buildDumpText: scheduledDump optional 미전달 시에도 "(not loaded)" 노출', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: {
+        confidence: 'gps-only',
+        source: 'gps',
+        fusedLabel: '-',
+        gpsLabel: '-',
+        differs: false,
+        candidateTrains: null,
+      },
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: baseSilentPushFull,
+      logs: [],
+    });
+    expect(dump).toContain('## Scheduled queue');
+    expect(dump).toContain('(not loaded)');
+  });
+
+  it('buildDumpText: scheduledDump 엔트리가 있으면 카운트와 라인 노출', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: {
+        confidence: 'gps-only',
+        source: 'gps',
+        fusedLabel: '-',
+        gpsLabel: '-',
+        differs: false,
+        candidateTrains: null,
+      },
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: baseSilentPushFull,
+      logs: [],
+      scheduledDump: [
+        {
+          identifier: 'bl:T:1:early:군자',
+          fireAtMs: new Date('2026-06-02T11:30:00Z').getTime(),
+          title: '환승 알림',
+          body: '...',
+        },
+        {
+          identifier: 'bl:T:1:imminent:군자',
+          fireAtMs: null,
+          title: '환승 임박',
+          body: '',
+        },
+      ],
+    });
+    expect(dump).toContain('## Scheduled queue (2)');
+    expect(dump).toContain('bl:T:1:early:군자');
+    expect(dump).toContain('bl:T:1:imminent:군자');
+    expect(dump).not.toContain('(not loaded)');
+  });
+});
+
+describe('DebugModal — Scheduled queue UI (#756)', () => {
+  let appStateListener: ((state: string) => void) | null = null;
+  const appStateRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListener = null;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_t, l) => {
+      appStateListener = l as (state: string) => void;
+      return { remove: appStateRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+    });
+    setupHookDefaults();
+  });
+
+  it('초기 마운트 상태에서는 "(tap Refresh to load)" placeholder', () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('(tap Refresh to load)')).toBeTruthy();
+    expect(screen.getByText('Scheduled queue')).toBeTruthy();
+  });
+
+  it('Refresh 누르면 dumpScheduledNotifications 호출 + 빈 결과면 "(empty)" 표시', async () => {
+    mockDumpScheduledNotifications.mockResolvedValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-scheduled-dump-refresh'));
+    });
+
+    await waitFor(() => expect(screen.getByText('Scheduled queue (0)')).toBeTruthy());
+    // "(empty)"는 Alarm log 섹션에도 등장 (logs=[])하므로 getByText 다중매칭 회피 — 카운트만 검증.
+    expect(screen.getAllByText('(empty)').length).toBeGreaterThanOrEqual(1);
+    expect(mockDumpScheduledNotifications).toHaveBeenCalledTimes(1);
+    expect(appStateListener).toBeTruthy();
+  });
+
+  it('Refresh 누르면 엔트리 라인이 렌더링된다', async () => {
+    mockDumpScheduledNotifications.mockResolvedValue([
+      {
+        identifier: 'bl:T:1:early:군자',
+        fireAtMs: new Date('2026-06-02T11:30:00Z').getTime(),
+        title: '환승 알림',
+        body: '...',
+      },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-scheduled-dump-refresh'));
+    });
+
+    await waitFor(() => expect(screen.getByText('Scheduled queue (1)')).toBeTruthy());
+    const entries = screen.getAllByTestId('debug-scheduled-dump-entry');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].props.children).toContain('bl:T:1:early:군자');
+  });
+
+  it('Refresh 후 Share dump 라인에 Scheduled queue 섹션 포함', async () => {
+    mockDumpScheduledNotifications.mockResolvedValue([
+      {
+        identifier: 'bl:T:0:imminent:장한평',
+        fireAtMs: 1000,
+        title: '목적지 임박',
+        body: '',
+      },
+    ]);
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-scheduled-dump-refresh'));
+    });
+    await waitFor(() => expect(screen.getByText('Scheduled queue (1)')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+    });
+
+    expect(shareSpy).toHaveBeenCalled();
+    const sharedMessage = shareSpy.mock.calls[0][0].message;
+    expect(sharedMessage).toContain('## Scheduled queue (1)');
+    expect(sharedMessage).toContain('bl:T:0:imminent:장한평');
   });
 });

--- a/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -19,11 +19,12 @@ jest.mock('../../utils/boardingLockScheduler', () => {
   };
 });
 const mockLoggerError = jest.fn();
+const mockLoggerWarn = jest.fn();
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
     info: jest.fn(),
-    warn: jest.fn(),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
     error: (...args: unknown[]) => mockLoggerError(...args),
   }),
 }));
@@ -272,5 +273,83 @@ describe('useBoardingLockScheduler', () => {
     await waitFor(() => expect(mockedCancel).toHaveBeenCalledWith(lockA));
     rerender({ lock: lockA, route, destinationName: '강남' });
     await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(2));
+  });
+
+  // #756 transition trace log — stale `bl:` 알람 누수 진단. effect 진입부에서 prev/next
+  // trainCode + sigPrev/sigNext + decision flags를 한 줄 logger.info로 노출.
+  // USB Console.app으로 trip 전환 시퀀스를 실시간 추적 가능.
+  describe('#756 transition trace log', () => {
+    it('lock=null 초기 마운트 — prev/next/scheduledTrain 모두 null, schedule 결정 없음', async () => {
+      renderHook(() =>
+        useBoardingLockScheduler({ lock: null, route, destinationName: '강남' }),
+      );
+      await waitFor(() => expect(mockLoggerWarn).toHaveBeenCalled());
+      const traceCall = mockLoggerWarn.mock.calls.find((c) =>
+        String(c[0]).startsWith('transition '),
+      );
+      expect(traceCall).toBeDefined();
+      const line = String(traceCall![0]);
+      expect(line).toContain('prevTrain=null');
+      expect(line).toContain('nextTrain=null');
+      expect(line).toContain('scheduledTrain=null');
+      expect(line).toContain('canSchedule=false');
+      expect(line).toContain('coldRestart=false');
+      expect(line).toContain('routeChange=false');
+    });
+
+    it('lock A 신규 — scheduledTrain=null (아직 schedule 안 됨), coldRestart=true', async () => {
+      renderHook(() =>
+        useBoardingLockScheduler({ lock: lockA, route, destinationName: '강남' }),
+      );
+      await waitFor(() => expect(mockLoggerWarn).toHaveBeenCalled());
+      const traceCall = mockLoggerWarn.mock.calls.find((c) =>
+        String(c[0]).startsWith('transition '),
+      );
+      const line = String(traceCall![0]);
+      expect(line).toContain('prevTrain=null');
+      expect(line).toContain('nextTrain=A');
+      // scheduledTrainCodeRef은 schedule 완료 후에야 갱신 — 첫 cycle에선 아직 null.
+      expect(line).toContain('scheduledTrain=null');
+      expect(line).toContain('coldRestart=true');
+      expect(line).toContain('routeChange=false');
+    });
+
+    it('lock A → B 교체 — prev=A, next=B, scheduledTrain=A (직전 schedule 성공 흔적)', async () => {
+      const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+      await awaitFirstSchedule();
+      mockLoggerWarn.mockClear();
+      rerender({ lock: lockB, route, destinationName: '강남' });
+      await waitFor(() => expect(mockLoggerWarn).toHaveBeenCalled());
+      const traceCall = mockLoggerWarn.mock.calls.find((c) =>
+        String(c[0]).startsWith('transition '),
+      );
+      const line = String(traceCall![0]);
+      expect(line).toContain('prevTrain=A');
+      expect(line).toContain('nextTrain=B');
+      // schedule 완료된 직후의 cycle이므로 scheduledTrainCodeRef = 'A'.
+      expect(line).toContain('scheduledTrain=A');
+    });
+
+    it('#708 같은 trainCode + route 변경 — routeChange=true 노출', async () => {
+      const transferRoute = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '2',
+        toLine: '1',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+      await awaitFirstSchedule();
+      mockLoggerWarn.mockClear();
+      rerender({ lock: lockA, route: transferRoute, destinationName: '강남' });
+      await waitFor(() => expect(mockLoggerWarn).toHaveBeenCalled());
+      const traceCall = mockLoggerWarn.mock.calls.find((c) =>
+        String(c[0]).startsWith('transition '),
+      );
+      const line = String(traceCall![0]);
+      expect(line).toContain('prevTrain=A');
+      expect(line).toContain('nextTrain=A');
+      expect(line).toContain('routeChange=true');
+    });
   });
 });

--- a/src/hooks/useBoardingLockScheduler.ts
+++ b/src/hooks/useBoardingLockScheduler.ts
@@ -63,6 +63,28 @@ export function useBoardingLockScheduler({
       scheduledRouteSigRef.current !== null &&
       scheduledRouteSigRef.current !== nextSig;
 
+    // #756 transition trace — stale `bl:` 알람 누수 진단용.
+    //
+    // logger.warn으로 출력하는 이유: production TestFlight 빌드는 `app/_layout.tsx:48`에서
+    // `setMinLevel('warn')`이 적용돼 `info`가 출력 자체 차단된다. 진단 표적은 실기기 production
+    // 회귀이므로 warn으로 승격해 USB Console.app에서도 보이게 한다. trip 전환은 분당 0~1회 빈도라
+    // noise 영향 미미.
+    //
+    // 노출 키:
+    //  - prevTrain  : 직전 effect cycle의 lock.trainCode
+    //  - nextTrain  : 이번 cycle의 lock.trainCode
+    //  - scheduledTrain : 마지막 성공한 schedule의 trainCode (`scheduledTrainCodeRef.current`)
+    //                   prev와 다르면 H1 race(직전 cycle scheduling 실패) 신호.
+    //  - sigPrev/sigNext : 마지막 성공한 schedule의 routeSig vs 이번 cycle 계산값.
+    //  - canSchedule / coldRestart / routeChange : 이 cycle의 결정 flag.
+    logger.warn(
+      `transition prevTrain=${prevTrain ?? 'null'} nextTrain=${nextTrain ?? 'null'} scheduledTrain=${
+        scheduledTrainCodeRef.current ?? 'null'
+      } sigPrev=${scheduledRouteSigRef.current ?? 'null'} sigNext=${
+        nextSig ?? 'null'
+      } canSchedule=${canSchedule} coldRestart=${needsColdRestartSchedule} routeChange=${needsRouteChangeReschedule}`,
+    );
+
     if (
       prevTrain === nextTrain &&
       !needsColdRestartSchedule &&

--- a/src/utils/__tests__/scheduledNotificationsDump.test.ts
+++ b/src/utils/__tests__/scheduledNotificationsDump.test.ts
@@ -1,0 +1,185 @@
+import * as Notifications from 'expo-notifications';
+import {
+  dumpScheduledNotifications,
+  formatScheduledNotificationLine,
+} from '../scheduledNotificationsDump';
+
+jest.mock('expo-notifications', () => ({
+  getAllScheduledNotificationsAsync: jest.fn(),
+}));
+
+const mockGetAll = Notifications.getAllScheduledNotificationsAsync as jest.MockedFunction<
+  typeof Notifications.getAllScheduledNotificationsAsync
+>;
+
+function makeRequest(overrides: {
+  identifier: string;
+  triggerValue?: number | Date | null;
+  triggerType?: string;
+  title?: string;
+  body?: string;
+}): Notifications.NotificationRequest {
+  const { identifier, triggerValue, triggerType = 'date', title, body } = overrides;
+  return {
+    identifier,
+    content: {
+      title: title ?? null,
+      body: body ?? null,
+      data: {},
+      sound: null,
+      subtitle: null,
+      launchImageName: null,
+      badge: null,
+      attachments: [],
+      categoryIdentifier: null,
+      autoDismiss: true,
+      sticky: false,
+      interruptionLevel: undefined,
+      threadIdentifier: null,
+    } as unknown as Notifications.NotificationContent,
+    trigger:
+      triggerValue == null
+        ? null
+        : ({
+            type: triggerType,
+            value: triggerValue,
+          } as unknown as Notifications.NotificationTrigger),
+  };
+}
+
+describe('dumpScheduledNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns entries sorted by fireAtMs ascending', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({ identifier: 'bl:T:1:imminent:군자', triggerValue: 2000, title: '환승 임박' }),
+      makeRequest({ identifier: 'bl:T:1:early:군자', triggerValue: 1000, title: '환승 알림' }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result).toEqual([
+      {
+        identifier: 'bl:T:1:early:군자',
+        fireAtMs: 1000,
+        title: '환승 알림',
+        body: '',
+      },
+      {
+        identifier: 'bl:T:1:imminent:군자',
+        fireAtMs: 2000,
+        title: '환승 임박',
+        body: '',
+      },
+    ]);
+  });
+
+  it('parses Date trigger value as epoch ms', async () => {
+    const dateValue = new Date('2026-06-02T11:30:00Z');
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({ identifier: 'bl:T:0:early:장한평', triggerValue: dateValue }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].fireAtMs).toBe(dateValue.getTime());
+  });
+
+  it('sorts entries with null fireAtMs to the end (both comparator directions)', async () => {
+    // 양방향 분기 cover: [non-null, null, non-null] 순서로 만들면 insertion sort가 첫 사이클에서
+    // (a=null, b=non-null) 분기를 hit한다 (`a.fireAtMs == null` early return 분기).
+    // 마지막 (a=non-null, b=null) 분기도 후속 비교에서 hit.
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({ identifier: 'with-trigger-1', triggerValue: 3000 }),
+      makeRequest({ identifier: 'no-trigger', triggerValue: null }),
+      makeRequest({ identifier: 'with-trigger-2', triggerValue: 1000 }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result.map((e) => e.identifier)).toEqual([
+      'with-trigger-2',
+      'with-trigger-1',
+      'no-trigger',
+    ]);
+  });
+
+  it('null fireAtMs only — relative order preserved (sort returns 0 in tie)', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({ identifier: 'a', triggerValue: null }),
+      makeRequest({ identifier: 'b', triggerValue: null }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result.map((e) => e.identifier)).toEqual(['a', 'b']);
+  });
+
+  it('falls back to null for non-date trigger types', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({ identifier: 'interval', triggerValue: 1000, triggerType: 'timeInterval' }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].fireAtMs).toBeNull();
+  });
+
+  it('falls back to null for null trigger', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({ identifier: 'immediate', triggerValue: null }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].fireAtMs).toBeNull();
+  });
+
+  it('falls back to null for unrecognized trigger value type', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({
+        identifier: 'weird',
+        triggerValue: 'string-value' as unknown as number,
+        triggerType: 'date',
+      }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].fireAtMs).toBeNull();
+  });
+
+  it('returns empty array if OS call fails (graceful)', async () => {
+    mockGetAll.mockRejectedValueOnce(new Error('OS error'));
+
+    const result = await dumpScheduledNotifications();
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty content fields when missing', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({ identifier: 'no-content', triggerValue: 1000 }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].title).toBe('');
+    expect(result[0].body).toBe('');
+  });
+});
+
+describe('formatScheduledNotificationLine', () => {
+  it('formats with time + identifier + title', () => {
+    const line = formatScheduledNotificationLine({
+      identifier: 'bl:T:1:early:군자',
+      fireAtMs: new Date('2026-06-02T11:30:00Z').getTime(),
+      title: '환승 알림',
+      body: '...',
+    });
+    expect(line).toMatch(/^\d{2}:\d{2}:\d{2} \| bl:T:1:early:군자 \| 환승 알림$/);
+  });
+
+  it('renders --:--:-- when fireAtMs is null', () => {
+    const line = formatScheduledNotificationLine({
+      identifier: 'no-time',
+      fireAtMs: null,
+      title: 'X',
+      body: '',
+    });
+    expect(line).toBe('--:--:-- | no-time | X');
+  });
+});

--- a/src/utils/scheduledNotificationsDump.ts
+++ b/src/utils/scheduledNotificationsDump.ts
@@ -1,0 +1,81 @@
+/**
+ * iOS OS 큐에 사전 예약된 알림의 ground-truth dump (#756 진단 인프라).
+ *
+ * `useBoardingLockScheduler`가 destination 변경/trip 전환 시 `cancelAllHopsForLock`을
+ * 호출하지만, AsyncStorage scheduled-ids와 실제 OS 큐가 drift되는 회귀(stale `bl:` 알람
+ * 잔존) 진단용. DebugModal "큐 dump" 버튼이 본 함수를 호출해 한 줄 라인 목록을 노출한다.
+ *
+ * Notifications.getAllScheduledNotificationsAsync는 OS가 실제로 들고 있는 사전 예약
+ * 알림을 반환 — `bl:` 와 `alarm:` (legacy) 두 prefix 모두 포함된다. parse는 호출자 책임.
+ */
+
+import * as Notifications from 'expo-notifications';
+
+export interface ScheduledNotificationDumpEntry {
+  identifier: string;
+  /** OS 큐의 fire 시각 (epoch ms). 트리거 형식이 DATE가 아니면 null. */
+  fireAtMs: number | null;
+  /** 알림 본문 title. 없으면 빈 문자열. */
+  title: string;
+  /** 알림 본문 body. 없으면 빈 문자열. */
+  body: string;
+}
+
+/**
+ * iOS notification trigger는 union 타입이라 fire 시각 추출에 narrow가 필요하다.
+ * DATE 타입은 `value: number(epoch ms)` 또는 `value: Date`로 보고된다 — 둘 다 흡수.
+ * 다른 타입(time-interval/calendar 등)은 본 dump에서 fire 시각을 알 수 없어 null.
+ */
+function extractFireAtMs(trigger: Notifications.NotificationTrigger | null): number | null {
+  if (!trigger || typeof trigger !== 'object') return null;
+  if (!('type' in trigger) || trigger.type !== 'date') return null;
+  const value = (trigger as { value?: unknown }).value;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (value instanceof Date) return value.getTime();
+  return null;
+}
+
+/**
+ * 현재 OS 큐의 모든 사전 예약 알림을 dump.
+ * fire 시각 오름차순 정렬 — 가까운 미래 발사 알림부터 보이도록.
+ * OS 호출 실패 시 빈 배열 반환(graceful) — DebugModal이 에러로 죽지 않도록.
+ */
+export async function dumpScheduledNotifications(): Promise<ScheduledNotificationDumpEntry[]> {
+  let requests: Notifications.NotificationRequest[];
+  try {
+    requests = await Notifications.getAllScheduledNotificationsAsync();
+  } catch {
+    return [];
+  }
+  const entries = requests.map<ScheduledNotificationDumpEntry>((req) => ({
+    identifier: req.identifier,
+    fireAtMs: extractFireAtMs(req.trigger),
+    title: req.content.title ?? '',
+    body: req.content.body ?? '',
+  }));
+  // null fireAtMs는 정렬 끝으로 — 진단 시 "fire 시각 모르는 알림"이 일반 알림과 섞이지 않게.
+  entries.sort((a, b) => {
+    if (a.fireAtMs == null && b.fireAtMs == null) return 0;
+    if (a.fireAtMs == null) return 1;
+    if (b.fireAtMs == null) return -1;
+    return a.fireAtMs - b.fireAtMs;
+  });
+  return entries;
+}
+
+/**
+ * dump 1건을 한 줄 문자열로 — DebugModal UI 및 Share dump 텍스트가 공유한다.
+ * 형식: `HH:mm:ss | <identifier> | <title>` (body는 본문이 길어 dump 라인에선 생략 가능).
+ * fireAtMs=null이면 `--:--:--` 로 표시 — 호출자가 fire 시각 부재 신호를 즉시 인지하도록.
+ */
+export function formatScheduledNotificationLine(entry: ScheduledNotificationDumpEntry): string {
+  const time =
+    entry.fireAtMs == null
+      ? '--:--:--'
+      : new Date(entry.fireAtMs).toLocaleTimeString('en-GB', {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        });
+  return `${time} | ${entry.identifier} | ${entry.title}`;
+}


### PR DESCRIPTION
## Summary
- 신규 유틸 `dumpScheduledNotifications` — `Notifications.getAllScheduledNotificationsAsync()` 결과를 fire 시각 기준 정렬해 `identifier | fireDate | title` 한 줄로 포맷팅. OS 호출 실패 시 빈 배열로 graceful degrade.
- DebugModal에 "Scheduled queue" 섹션 + Refresh 버튼 + Share dump 텍스트 포함. 미Refresh 상태는 "(not loaded)"로 명시해 "비어있음"과 명확히 구분.
- `useBoardingLockScheduler` effect 진입부에 transition trace `logger.warn` 1줄. production 빌드(`setMinLevel('warn')`)에서도 출력되도록 warn으로 승격. 7개 키 노출 — `prevTrain` / `nextTrain` / `scheduledTrain`(마지막 성공 schedule 흔적) / `sigPrev` / `sigNext` / `canSchedule` / `coldRestart` / `routeChange`.

## 진단 사용 시나리오

1. 정적 상태에서 destination X (다른 환승역 경로) 설정 → 트립 시작 → DebugModal "Refresh" → Share dump 캡쳐 1장
2. destination Y로 변경 → 다시 Refresh → Share dump 캡쳐 2장
3. 두 dump의 "## Scheduled queue" 섹션 비교:
   - X의 ids가 2장 모두에 잔존 → cancel 누락
   - USB Console.app에서 동시간대 `[useBoardingLockScheduler] transition ...` 로그 확인해 어느 분기에서 cancel이 일어났는지 (또는 안 일어났는지) 식별

이 정보로 H1 race / H2 routeSig 미초기화 / H3 storage drift / H4 legacy alarm: prefix 중 어느 가설인지 결정.

## Test plan
- [x] `npm test` — 153 suites / 2733 tests passed, coverage 100% 유지
- [x] `npm run type-check` — 통과
- [x] code-review 에이전트 P1 (`logger.info` → `warn` 승격, `scheduledTrain` 키 추가) 반영
- [ ] dev 빌드 실기기 marshal → "Refresh" 버튼 동작 + dump 텍스트 확인
- [ ] production TestFlight 빌드에서 USB Console.app으로 `transition ...` warn 라인 확인 (#754 PR 검증과 함께)

## 후속

진단 결과에 따라:
- H2/H3/H4 식별 시 surgical fix (별도 이슈)
- H1 race 확정 시 `useBoardingLockScheduler` 의 prev/handleTransition race 차단 fix
- 결과 불명확 시 `purgeBoardingLockSchedulerQueue()` defensive 호출 (별도 이슈)

Closes #756
