### PR TITLE
feat(#759): 도착 자동 release — 목적지 근접 + grace 후 lock 해제

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -38,6 +38,7 @@ import { useArrivalAutoClear } from '../../src/hooks/useArrivalAutoClear';
 import { useBoardingLockController } from '../../src/hooks/useBoardingLockController';
 import { useBoardingLockScheduler } from '../../src/hooks/useBoardingLockScheduler';
 import { useBoardingLockAdvancer } from '../../src/hooks/useBoardingLockAdvancer';
+import { useBoardingLockAutoRelease } from '../../src/hooks/useBoardingLockAutoRelease';
 import { BoardingLockBanner } from '../../src/components/BoardingLockBanner';
 import { MisBoardingBanner } from '../../src/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../../src/components/MisBoardingReselectModal';
@@ -241,6 +242,15 @@ export default function HomeScreen() {
     route,
     destinationName: destination?.name ?? null,
     currentStationName: result?.station.name ?? null,
+  });
+  // #759 — 목적지역 도착 grace 후 lock 자동 release. 명시 "하차" 버튼은 그대로 유지하며,
+  // 사용자가 누르지 않은 정상 도착 케이스만 처리. sleep mode와 무관.
+  useBoardingLockAutoRelease({
+    lock: boardingLock,
+    destinationId: destination?.id ?? null,
+    currentStation: result?.station ?? null,
+    distanceKm: result?.distanceKm ?? null,
+    releaseLock: releaseBoardingLock,
   });
   // #584 PR D3: lock.boardingLine 위치 데이터를 별도 구독 — fusion 캐시와 dedup되어 추가 비용 없음.
   // lock 없으면 line=null로 호출되어 polling이 자동 정지된다.

--- a/src/constants/boardingLock.ts
+++ b/src/constants/boardingLock.ts
@@ -21,3 +21,26 @@ export const TRANSFER_WALKING_BUFFER_SECONDS = 180;
  * uniform 90s — 노선별/시간대별 정밀화는 후속(#624 hopTime lookup).
  */
 export const HOP_TIME_MS = 90_000;
+
+/**
+ * #759 — 도착 자동 release 트리거 임계값(m). 사용자가 목적지역과 같은 정거장으로 매칭되고
+ * fusion distance가 이 값 미만이면 "도착"으로 간주.
+ *
+ * 300m로 둔 이유:
+ *  - 역 구조물 내(개찰구/출구 보행 반경)에서 GPS 정확도는 50~150m 수준.
+ *  - 인접역과의 평균 거리는 600m 이상이라 옆 역으로 잘못 매칭되는 사고를 막을 마진.
+ *  - useArrivalAutoClear의 500m보다 보수적 — 자동 release는 lock 해제까지 가는 강한 effect라
+ *    더 보수적인 임계값 사용.
+ */
+export const ARRIVAL_PROXIMITY_THRESHOLD_M = 300;
+
+/**
+ * #759 — 도착 신호가 이 시간 이상 지속되어야 자동 release.
+ *
+ * 45_000ms로 둔 이유:
+ *  - fusion 폴링 주기 30s + 사용자가 실제로 하차해 개찰구를 통과하기까지 여유.
+ *  - GPS 흔들림으로 한두 사이클 인접역 표시 → 다시 목적지역 복귀하는 케이스에서 grace 만료 회피.
+ *  - 너무 짧으면(예: 15s) 정차 직전 한 사이클만 매칭되고 떠나도 release 발화 위험.
+ *  - 너무 길면(예: 90s) 사용자가 이미 하차해 다른 곳으로 이동 중인데 lock이 남는 시간이 길어짐.
+ */
+export const AUTO_RELEASE_GRACE_MS = 45_000;

--- a/src/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
@@ -1,0 +1,289 @@
+import { renderHook } from '@testing-library/react-native';
+import {
+  useBoardingLockAutoRelease,
+  type UseBoardingLockAutoReleaseInputs,
+} from '../useBoardingLockAutoRelease';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { Station } from '../../types/station';
+import {
+  ARRIVAL_PROXIMITY_THRESHOLD_M,
+  AUTO_RELEASE_GRACE_MS,
+} from '../../constants/boardingLock';
+
+const mockLoggerInfo = jest.fn();
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const lockA: BoardingLock = {
+  destinationId: 'dest-1',
+  trainCode: 'A',
+  boardingStationId: 'origin-1',
+  boardingLine: '2',
+  boardedAt: 1_000,
+  expectedDurationMs: 600_000,
+};
+const lockB: BoardingLock = { ...lockA, trainCode: 'B' };
+
+const destinationStation: Station = {
+  id: 'dest-1',
+  name: '강남',
+  line: '2',
+  lineColor: '#000',
+  lat: 37.5,
+  lng: 127.0,
+};
+const otherStation: Station = {
+  id: 'other-1',
+  name: '역삼',
+  line: '2',
+  lineColor: '#000',
+  lat: 37.5,
+  lng: 127.0,
+};
+
+type Inputs = UseBoardingLockAutoReleaseInputs;
+
+const T0 = 1_700_000_000_000;
+const proximityKm = (ARRIVAL_PROXIMITY_THRESHOLD_M - 1) / 1000;
+const farKm = (ARRIVAL_PROXIMITY_THRESHOLD_M + 50) / 1000;
+
+function withDateNow<T>(value: number, fn: () => T): T {
+  const spy = jest.spyOn(Date, 'now').mockReturnValue(value);
+  try {
+    return fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+function baseInputs(overrides: Partial<Inputs> = {}): Inputs {
+  return {
+    lock: lockA,
+    destinationId: 'dest-1',
+    currentStation: destinationStation,
+    distanceKm: proximityKm,
+    releaseLock: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('useBoardingLockAutoRelease', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lock=null이면 release 안 함', () => {
+    const releaseLock = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useBoardingLockAutoRelease(baseInputs({ lock: null, releaseLock })));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('destinationId=null이면 release 안 함', () => {
+    const releaseLock = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useBoardingLockAutoRelease(baseInputs({ destinationId: null, releaseLock })));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('currentStation=null이면 release 안 함', () => {
+    const releaseLock = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useBoardingLockAutoRelease(baseInputs({ currentStation: null, releaseLock })));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('distanceKm=null이면 release 안 함', () => {
+    const releaseLock = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useBoardingLockAutoRelease(baseInputs({ distanceKm: null, releaseLock })));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('현재역이 목적지와 다르면 release 안 함', () => {
+    const releaseLock = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() =>
+        useBoardingLockAutoRelease(baseInputs({ currentStation: otherStation, releaseLock })),
+      );
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('현재역 매칭이지만 거리가 임계값 이상이면 release 안 함', () => {
+    const releaseLock = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useBoardingLockAutoRelease(baseInputs({ distanceKm: farKm, releaseLock })));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('도착 조건 첫 진입에서는 release 안 함 (ts만 기록)', () => {
+    const releaseLock = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useBoardingLockAutoRelease(baseInputs({ releaseLock })));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('도착 지속 시간이 grace 미만이면 release 안 함', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock }),
+      }),
+    );
+    // grace 미만 시점에 fusion update — distanceKm을 살짝 바꿔 effect 재실행 트리거.
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS - 1, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('도착 지속 시간이 grace 이상이면 release 호출', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock }),
+      }),
+    );
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenCalledWith('도착 grace 충족 → lock 자동 release');
+  });
+
+  it('grace 만료 후 같은 조건 유지되어도 중복 release 안 함 (ref 리셋되어 새 카운트)', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock }),
+      }),
+    );
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+
+    // 추가 fusion update — release 직후라 ref가 null로 리셋. 새 ts를 기록만 함.
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS + 1_000, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.02 }));
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('도착 후 거리 이탈하면 카운터 리셋 — 재진입 시 grace 새로 대기', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock }),
+      }),
+    );
+    // grace 절반 시점에 이탈
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: farKm }));
+    });
+    // 재진입
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2 + 1_000, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm }));
+    });
+    // 처음 grace의 절반 + 1초만 더 흘렀음 → 아직 release 안 됨
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS - 1, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+
+    // 재진입 시점 + grace 만큼 더 흘러야 release
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2 + 1_000 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.02 }));
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('도착 후 다른 역으로 변경되면 카운터 리셋', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock }),
+      }),
+    );
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
+      rerender(baseInputs({ releaseLock, currentStation: otherStation }));
+    });
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock, currentStation: destinationStation }));
+    });
+    // 재진입 후 grace 만큼 안 흘렀음
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('trainCode 변경(새 trip/leg) 시 카운터 리셋 — 이전 trip ts 누수 차단', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock }),
+      }),
+    );
+    // 새 lock으로 교체
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
+      rerender(baseInputs({ releaseLock, lock: lockB }));
+    });
+    // 새 trip에서 grace 만큼 흘러야 release
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock, lock: lockB, distanceKm: proximityKm - 0.01 }));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock, lock: lockB, distanceKm: proximityKm - 0.02 }));
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('lock null → 활성으로 전환되어도 첫 활성 진입에서 ts만 기록 (즉시 release X)', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock, lock: null }),
+      }),
+    );
+    // 사용자가 막 탑승 — 도착 조건 충족하나 첫 진입
+    withDateNow(T0 + 100, () => {
+      rerender(baseInputs({ releaseLock }));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('lock 활성 → null로 전환 시 ref 리셋 (재활성 시 다시 grace 대기)', () => {
+    const releaseLock = jest.fn();
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
+        initialProps: baseInputs({ releaseLock }),
+      }),
+    );
+    // 사용자가 명시 하차로 lock 해제
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
+      rerender(baseInputs({ releaseLock, lock: null }));
+    });
+    // 같은 destination으로 다시 탑승
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock }));
+    });
+    // grace 새로 시작 — 아직 release 안 됨
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS + AUTO_RELEASE_GRACE_MS - 1, () => {
+      rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
+++ b/src/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
@@ -73,6 +73,16 @@ function baseInputs(overrides: Partial<Inputs> = {}): Inputs {
   };
 }
 
+/**
+ * rerender 지원 테스트의 공통 setup — T0에 hook을 마운트하고 rerender 함수를 돌려준다.
+ * SonarCloud CPD가 잡는 동일 4줄 renderHook 호출을 한 곳에 두어 중복을 제거한다.
+ */
+function mountAtT0(initial: Inputs) {
+  return withDateNow(T0, () =>
+    renderHook((p: Inputs) => useBoardingLockAutoRelease(p), { initialProps: initial }),
+  );
+}
+
 describe('useBoardingLockAutoRelease', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -138,11 +148,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('도착 지속 시간이 grace 미만이면 release 안 함', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock }));
     // grace 미만 시점에 fusion update — distanceKm을 살짝 바꿔 effect 재실행 트리거.
     withDateNow(T0 + AUTO_RELEASE_GRACE_MS - 1, () => {
       rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
@@ -152,11 +158,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('도착 지속 시간이 grace 이상이면 release 호출', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock }));
     withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
       rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
     });
@@ -166,11 +168,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('grace 만료 후 같은 조건 유지되어도 중복 release 안 함 (ref 리셋되어 새 카운트)', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock }));
     withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
       rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
     });
@@ -185,11 +183,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('도착 후 거리 이탈하면 카운터 리셋 — 재진입 시 grace 새로 대기', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock }));
     // grace 절반 시점에 이탈
     withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
       rerender(baseInputs({ releaseLock, distanceKm: farKm }));
@@ -213,11 +207,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('도착 후 다른 역으로 변경되면 카운터 리셋', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock }));
     withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
       rerender(baseInputs({ releaseLock, currentStation: otherStation }));
     });
@@ -230,11 +220,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('trainCode 변경(새 trip/leg) 시 카운터 리셋 — 이전 trip ts 누수 차단', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock }));
     // 새 lock으로 교체
     withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
       rerender(baseInputs({ releaseLock, lock: lockB }));
@@ -253,11 +239,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('lock null → 활성으로 전환되어도 첫 활성 진입에서 ts만 기록 (즉시 release X)', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock, lock: null }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock, lock: null }));
     // 사용자가 막 탑승 — 도착 조건 충족하나 첫 진입
     withDateNow(T0 + 100, () => {
       rerender(baseInputs({ releaseLock }));
@@ -267,11 +249,7 @@ describe('useBoardingLockAutoRelease', () => {
 
   it('lock 활성 → null로 전환 시 ref 리셋 (재활성 시 다시 grace 대기)', () => {
     const releaseLock = jest.fn();
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: Inputs) => useBoardingLockAutoRelease(p), {
-        initialProps: baseInputs({ releaseLock }),
-      }),
-    );
+    const { rerender } = mountAtT0(baseInputs({ releaseLock }));
     // 사용자가 명시 하차로 lock 해제
     withDateNow(T0 + AUTO_RELEASE_GRACE_MS / 2, () => {
       rerender(baseInputs({ releaseLock, lock: null }));

--- a/src/hooks/useBoardingLockAutoRelease.ts
+++ b/src/hooks/useBoardingLockAutoRelease.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react';
+import type { BoardingLock } from '../types/boardingLock';
+import type { Station } from '../types/station';
+import {
+  ARRIVAL_PROXIMITY_THRESHOLD_M,
+  AUTO_RELEASE_GRACE_MS,
+} from '../constants/boardingLock';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useBoardingLockAutoRelease');
+
+export interface UseBoardingLockAutoReleaseInputs {
+  /** 활성 BoardingLock. null이면 평가하지 않음. */
+  lock: BoardingLock | null;
+  /** 목적지 id. lock.destinationId와 비교는 store/controller가 이미 수행하므로 본 hook은 매칭 판정용. */
+  destinationId: string | null;
+  /** Fusion으로 결정된 현재역. */
+  currentStation: Station | null;
+  /** Fusion 현재역까지 거리(km). useFusedNearestStation의 result.distanceKm. */
+  distanceKm: number | null;
+  /** Lock 해제 액션. useBoardingLockController.releaseLock 또는 store releaseLock 위임. */
+  releaseLock: () => void;
+}
+
+/**
+ * 도착 자동 release hook (#759).
+ *
+ * 활성 BoardingLock + 도착 신호 지속 시 lock을 자동 해제한다.
+ *
+ * 트리거 조건:
+ *  - lock active
+ *  - fusion currentStation.id == destination
+ *  - distance < ARRIVAL_PROXIMITY_THRESHOLD_M
+ *  - 위 셋이 AUTO_RELEASE_GRACE_MS 이상 지속
+ *
+ * 동작:
+ *  - 진입 시 첫 ts ref 기록.
+ *  - 매 fusion update에서 (a) 조건 지속 + 경과시간 ≥ grace → releaseLock + ref 리셋.
+ *    (b) 조건 미충족 → ref 리셋 (다음 진입에서 새로 카운트 시작).
+ *  - lock.trainCode 변경(새 trip/leg) 시 ref 리셋 — 이전 trip의 진입 ts가 새 trip에 흘러가지 않음.
+ *
+ * 환승 trip의 마지막 hop도 동일 처리 — destinationId 기준으로 매칭하므로 환승 시점 leg의 도착이
+ * 아닌 trip 최종 도착에서만 발화한다.
+ *
+ * sleep mode와 무관: release는 알람 발화가 아니라 lock 라이프사이클 정리.
+ *
+ * useArrivalAutoClear와의 책임 분리:
+ *  - useArrivalAutoClear — 도착 banner UX + setDestination(null) (UI 도착 처리)
+ *  - 본 hook — lock 자동 release (라이프사이클 정리)
+ *  - 임계값/grace가 다른 이유: 자동 release는 lock 해제까지 가는 강한 effect라 300m/45s로 보수적.
+ *    UI banner는 500m/2s로 빠른 시각 피드백.
+ */
+export function useBoardingLockAutoRelease({
+  lock,
+  destinationId,
+  currentStation,
+  distanceKm,
+  releaseLock,
+}: UseBoardingLockAutoReleaseInputs): void {
+  const firstArrivedAtRef = useRef<number | null>(null);
+  const lastTrainCodeRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const trainCode = lock?.trainCode ?? null;
+    if (lastTrainCodeRef.current !== trainCode) {
+      lastTrainCodeRef.current = trainCode;
+      firstArrivedAtRef.current = null;
+    }
+
+    if (!lock || !destinationId || !currentStation || distanceKm == null) {
+      firstArrivedAtRef.current = null;
+      return;
+    }
+
+    const stationMatched = currentStation.id === destinationId;
+    const proximityOk = distanceKm * 1000 < ARRIVAL_PROXIMITY_THRESHOLD_M;
+    if (!stationMatched || !proximityOk) {
+      firstArrivedAtRef.current = null;
+      return;
+    }
+
+    const now = Date.now();
+    if (firstArrivedAtRef.current === null) {
+      firstArrivedAtRef.current = now;
+      return;
+    }
+
+    if (now - firstArrivedAtRef.current >= AUTO_RELEASE_GRACE_MS) {
+      firstArrivedAtRef.current = null;
+      logger.info('도착 grace 충족 → lock 자동 release');
+      releaseLock();
+    }
+  }, [lock, destinationId, currentStation, distanceKm, releaseLock]);
+}


### PR DESCRIPTION
## Summary

- `useBoardingLockAutoRelease` 신규 hook 추가 — fusion 현재역 == destination + 거리 < `ARRIVAL_PROXIMITY_THRESHOLD_M`(300m) + `AUTO_RELEASE_GRACE_MS`(45s) 지속 시 `releaseLock()` 자동 호출
- 이탈 / 역 변경 / lock 교체(새 trainCode) 시 진입 ts ref 리셋 — 누수 차단
- 환승 trip 마지막 hop도 `destinationId` 매칭으로 자연 처리(transferCount 분기 없음)
- sleep mode 무관 (release는 알람 발화가 아닌 라이프사이클 정리)
- `app/(tabs)/index.tsx`에서 `useBoardingLockController` 옆에 마운트

## 결정 정당화

- **300m 임계값**: useArrivalAutoClear의 500m보다 보수적. 자동 release는 lock 해제까지 가는 강한 effect라 인접역 평균 거리(>600m) 대비 마진 확보.
- **45s grace**: fusion 폴링 30s + 사용자 하차/개찰구 통과 여유. 15s는 한 사이클만 매칭되고 떠나도 발화 위험, 90s는 이미 하차한 사용자에게 lock이 너무 오래 남음.
- **별도 hook으로 분리**: `useArrivalAutoClear` 재사용 옵션 검토했으나 임계값/grace가 달라(banner=500m/2s vs release=300m/45s) 책임 분리가 명확. controller에 합치지 않은 이유는 controller가 이미 storage/AppState/director 등 다 책임지고 있어 SRP 위반 우려.

## Test plan

- [x] hook 단위 테스트 15개 (lock null / dest null / station null / distance null / 역 불일치 / 거리 초과 / 첫 진입 / grace 미만 / grace 도달 / 중복 release 차단 / 이탈 후 재진입 / 역 변경 후 재진입 / trainCode 변경 / null→active 첫 진입 / active→null 후 재활성)
- [x] 전체 테스트 2,726 PASS, 커버리지 100% 유지
- [x] type-check 통과
- [ ] 실기기에서 목적지역 근접 시 grace 후 lock 자동 해제 확인
- [ ] 환승 trip 마지막 hop에서도 동일 동작 확인
- [ ] sleep mode 무관 동작 확인 (sleep on에서도 release 발화)
- [ ] 명시 "하차" 버튼은 여전히 즉시 release

Closes #759