### PR TITLE
chore(#762): backend POST /trips incoming.boardingLock 진단 로그

### DIFF
--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -66,6 +66,20 @@ app.post('/trips', async (c) => {
   const incoming = validateTrip(body);
   if (!incoming) return c.json({ error: 'invalid_trip' }, 400);
 
+  // #762/#622 — transfer-leg sync 가설 확정용 진단 로그 (root cause 확정 후 제거).
+  // wrangler tail에서 hasBoardingLock=false면 client 누락(가설 A),
+  // true인데 cron이 lockMissing이면 backend merge drop(가설 C).
+  console.log(
+    JSON.stringify({
+      msg: 'POST /trips incoming',
+      tokenPrefix: tokenPrefix(incoming.token),
+      hasBoardingLock: incoming.boardingLock !== undefined,
+      trainCode: incoming.boardingLock?.trainCode,
+      line: incoming.boardingLock?.line,
+      segmentLen: incoming.boardingLock?.segmentStations.length,
+    }),
+  );
+
   // #578/#704: 디바이스가 동일 trip을 반복 POST해도(예: GPS update마다 register, 또는 cold restart
   // 후 같은 trip 재등록) backend가 이미 advance한 waypoints / 추적 baseline을 덮어쓰지 않는다.
   //


### PR DESCRIPTION
## Summary
- backend `POST /trips` handler 진입 직후 incoming.boardingLock 한 줄 console.log
- 출력 키: tokenPrefix(prefix만) / hasBoardingLock / trainCode / line / segmentLen
- segmentStations 역명 비공개 — 길이만 노출
- 기존 `tokenPrefix` utility(`telemetry.ts:86`) 재사용

## 진단 흐름

머지 + `wrangler deploy` 후 `scripts/capture-tail.sh transfer-test`로 transfer trip 재현:

- `hasBoardingLock: false` → **가설 A 확정** (client buildBoardingLockMeta null 또는 payload 누락)
- `hasBoardingLock: true`인데 cron `lock missing` → **가설 C 확정** (backend validateTrip drop 또는 baseTrip merge 회로 회귀)

## Test plan
- [x] backend `npm run type-check` pass
- [x] backend `npm test` pass (305 tests)
- [ ] deploy 후 `scripts/capture-tail.sh` 1회 실행 → root cause 확정
- [ ] 확정 후 fix PR 별도 + 진단 로그 제거 PR 별도

Closes #762

(원본 #622 자체는 fix PR 머지 시 close.)