### PR TITLE
chore(#764): backend POST/cron 진단 로그 — 가설 C sub-step 좁힘 (#622)

### DIFF
--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -131,6 +131,23 @@ app.post('/trips', async (c) => {
     : baseTrip;
 
   await putTrip(c.env.TRIPS, trip);
+
+  // #764/#622 — putTrip 직후 trip 상태 진단 (root cause sub-step 좁힘용, 확정 후 제거).
+  // scheduled.ts의 `cron loaded trip` 로그와 cross-check해 KV 쓰기/읽기 사이에서
+  // boardingLock.trainCode가 어떻게 보이는지 확정한다. existing/incoming/final을 한 줄에 모아
+  // merge 분기(isSameSession / progressApplied)가 새 lock을 유지하는지 즉시 확인.
+  console.log(
+    JSON.stringify({
+      msg: 'PUT trip after merge',
+      tokenPrefix: tokenPrefix(trip.token),
+      isSameSession,
+      progressApplied: progressApplies,
+      incomingHasLock: incoming.boardingLock !== undefined,
+      existingHasLock: existing?.boardingLock !== undefined,
+      finalTrainCode: trip.boardingLock?.trainCode,
+    }),
+  );
+
   return c.json({ ok: true, token: trip.token });
 });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -173,6 +173,15 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     const waypoint = pickActiveWaypoint(trip);
     if (!waypoint) continue;
 
+    // #764/#622 — cron이 KV에서 읽은 trip의 boardingLock 추적 (root cause sub-step 좁힘용,
+    // 확정 후 제거). POST /trips의 `PUT trip after merge` 로그와 cross-check해 KV 쓰기/
+    // 읽기 사이에 trainCode가 어떻게 보이는지 한 사이클 단위로 확정한다.
+    log('cron loaded trip', {
+      token: trip.token.slice(0, 8),
+      loadedTrainCode: trip.boardingLock?.trainCode,
+      waypointStation: waypoint.stationName,
+    });
+
     // #640 — BoardingLock 게이트. 사용자가 열차를 아직 선택하지 않았거나 lock이 만료된 trip은
     // Seoul polling/push 모두 skip. 디바이스는 lock 등록 후 train-code 단위로 정확히 추적하며,
     // lock 부재 상태에서의 phase-based push는 "탑승 전 노이즈"였다.


### PR DESCRIPTION
## Summary
- **index.ts** `putTrip` 직후: `PUT trip after merge` — isSameSession/progressApplied/incoming/existingHasLock/finalTrainCode
- **scheduled.ts** cron 각 trip 처리 시작: `cron loaded trip` — loadedTrainCode/waypointStation

두 줄을 cross-check해 KV 쓰기/읽기 사이에 trainCode 적용 여부를 한 사이클 단위로 확정.

## 배경 (#762 evidence)

PR #763 진단 로그로 가설 C 확정 — client는 `hasBoardingLock=true, trainCode=7411` 정확히 전송, 그 후 cron이 5분간 옛 trainCode=7409 추적:

```
23:29:52  POST → hasBoardingLock=FALSE  (1차)
23:29:53  POST → hasBoardingLock=TRUE  trainCode=7411  (1초 차이 2차)
23:30:35  cron → trainCode=7409 not found
23:32:35  trip auto-ended (trainCode=7409)
```

본 PR의 두 진단 로그로 root cause를 다음 중 하나로 좁힘:
- **(a) merge 분기 버그** — `PUT trip after merge`의 `finalTrainCode=7409` (or undefined) → 1차/2차 사이 same-session 분기로 lock이 날아감
- **(b) KV write/read stale** — `finalTrainCode=7411`인데 `cron loaded trip`의 `loadedTrainCode=7409` → KV eventually consistent 또는 쓰기 누락

## Test plan
- [x] backend `npm run type-check` pass
- [x] backend `npm test` pass (305 tests)
- [ ] deploy 후 transfer 시나리오 재현 → 두 로그 cross-check로 (a)/(b) 확정
- [ ] 확정 후 fix PR 별도 + 진단 로그(#762/#764) cleanup PR 한 번

Closes #764

(원본 #622 자체는 fix PR 머지 시 close.)