### PR TITLE
fix(#766): cron KV read에 cacheTtl=10 적용 — POST 직후 새 boardingLock 즉시 반영

### DIFF
--- a/backend/alarm-worker/src/__tests__/inMemoryKv.ts
+++ b/backend/alarm-worker/src/__tests__/inMemoryKv.ts
@@ -8,7 +8,12 @@
 export class InMemoryKV {
   store = new Map<string, { value: string; expiresAt?: number }>();
 
-  async get(key: string): Promise<string | null> {
+  /**
+   * 실제 KV.get(key, options) 시그니처 호환 — 옵션은 cacheTtl 등 캐시 hint이고
+   * in-memory store는 캐싱 자체가 없어 무시한다. #766에서 cron paths가 cacheTtl을 전달하기
+   * 시작해 호환 인자가 필요해졌다.
+   */
+  async get(key: string, _options?: { cacheTtl?: number }): Promise<string | null> {
     const entry = this.store.get(key);
     if (!entry) return null;
     if (entry.expiresAt && entry.expiresAt < Date.now()) {

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -17,6 +17,13 @@ import type { ApnsEnv } from './types';
 const PENDING_PREFIX = 'pending:';
 export const PENDING_TTL_SEC = 60;
 
+/**
+ * cron read의 KV cacheTtl (#766). trips.ts와 같은 이유 — silent push 발사 직후 putPending된
+ * entry를 같은 cron 사이클(또는 다음)의 fallback이 못 보는 stale read를 방지.
+ * 기본 60s는 fallback이 막 발사된 push의 sentAt을 못 봐 임계 평가가 어긋날 위험이 있다.
+ */
+const CRON_READ_CACHE_TTL_SEC = 10;
+
 /** silent push 발사 1건의 추적 정보. P2c가 alert fallback 결정에 사용. */
 export interface PendingPush {
   pushId: string;
@@ -97,7 +104,9 @@ export async function* listPending(
   do {
     const result = await kv.list({ prefix: PENDING_PREFIX, cursor });
     for (const key of result.keys) {
-      const raw = await kv.get(key.name);
+      // #766 — cacheTtl=10s로 putPending 직후 옛 캐시 read 차단. cron 전용 enumerate라
+      // POST 경로 영향 없음.
+      const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
       if (!raw) continue;
       try {
         yield JSON.parse(raw) as PendingPush;

--- a/backend/alarm-worker/src/progress.ts
+++ b/backend/alarm-worker/src/progress.ts
@@ -38,8 +38,21 @@ export function progressKey(token: string): string {
   return `${PROGRESS_PREFIX}${token}`;
 }
 
-export async function getProgress(kv: KVNamespace, token: string): Promise<TripProgress | null> {
-  const raw = await kv.get(progressKey(token));
+/**
+ * caller가 KV `cacheTtl`을 지정하기 위한 옵션.
+ * cron path는 cacheTtl=10s를 명시해 PUT 직후 stale read를 방지한다 (#766).
+ * POST handler는 인자 없이 호출 — 기본 cacheTtl(60s)이 적용된다.
+ */
+export interface GetProgressOptions {
+  cacheTtl?: number;
+}
+
+export async function getProgress(
+  kv: KVNamespace,
+  token: string,
+  options?: GetProgressOptions,
+): Promise<TripProgress | null> {
+  const raw = await kv.get(progressKey(token), options);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as TripProgress;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -48,6 +48,13 @@ export const LA_PUSH_THRESHOLD_MS = 30_000;
  */
 export const MAX_CONSECUTIVE_ETA_MISSING = 5;
 
+/**
+ * cron이 progress KV를 read할 때의 cacheTtl (#766).
+ * POST `/trips`가 putProgress 직후 같은 cron 사이클에서 옛 값을 읽지 않도록 10s까지 단축.
+ * trips.ts/pendingPushes.ts의 cron read와 동일 정책.
+ */
+const CRON_PROGRESS_CACHE_TTL_SEC = 10;
+
 export interface EnvHealResult {
   result: SendPushResult;
   /** retry로 정정된 새 env. 정정 발생 시에만 set. */
@@ -234,7 +241,8 @@ async function mirrorProgress(
 ): Promise<void> {
   const trainCode = trip.boardingLock?.trainCode;
   if (!trainCode) return;
-  const existing = await getProgress(kv, trip.token);
+  // #766 — cron path는 cacheTtl=10s로 PUT 직후 stale read 방지.
+  const existing = await getProgress(kv, trip.token, { cacheTtl: CRON_PROGRESS_CACHE_TTL_SEC });
   const prevShifted = existing?.trainCode === trainCode ? existing.shiftedCount : 0;
   const next: TripProgress = {
     trainCode,

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -9,6 +9,13 @@ import type { Trip } from './types';
 
 const TRIP_PREFIX = 'trip:';
 
+/**
+ * cron read의 KV cacheTtl (#766). Workers KV의 기본 cacheTtl=60s에 의해 PUT 직후 옛 캐시가
+ * 60s까지 유지되는 stale read가 cron의 boardingLock 누락 회귀 root cause였다 (#765 진단 로그).
+ * cron 주기 자체가 60s이므로 10s까지는 사용자 영향이 미미하고, origin 비용은 60→6 reads/min/trip로 절감.
+ */
+const CRON_READ_CACHE_TTL_SEC = 10;
+
 export function tripKey(token: string): string {
   return `${TRIP_PREFIX}${token}`;
 }
@@ -37,7 +44,9 @@ export async function* listTrips(kv: KVNamespace): AsyncGenerator<Trip> {
   do {
     const result = await kv.list({ prefix: TRIP_PREFIX, cursor });
     for (const key of result.keys) {
-      const raw = await kv.get(key.name);
+      // #766 — cacheTtl=10s로 PUT 직후 옛 캐시 read 차단. 기본 60s는 cron이 boardingLock 갱신을
+      // 다음 사이클까지 못 보는 회귀(#765 evidence)를 유발했다.
+      const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
       if (!raw) continue;
       try {
         yield JSON.parse(raw) as Trip;


### PR DESCRIPTION
## Summary

Workers KV의 기본 `cacheTtl=60s`가 cron의 `boardingLock` 누락 회귀(#622/#766) root cause임이 #765 진단 로그로 확정됨.

```
23:52:04  PUT trip after merge → finalTrainCode=7415   ← POST 정상 merge
23:52:35  cron loaded trip     → loadedTrainCode=7411  ★ 31초 stale ★
23:53:35  cron loaded trip     → loadedTrainCode=7415  (91초 후 fresh)
```

cron이 `env.TRIPS.get(key)`를 옵션 없이 호출 → KV edge cache가 PUT 직후의 옛 값을 60s까지 반환. cron 주기 자체가 60s이므로 한 사이클을 통째로 stale 상태로 보내 silent push가 누락된다.

## 변경

- `trips.ts` `listTrips`: 함수 내부 `cacheTtl: 10` 박음 (cron 전용 enumerate)
- `pendingPushes.ts` `listPending`: 동일 패턴 (fallback cron 전용)
- `progress.ts` `getProgress`: optional `cacheTtl` 인자 추가 → cron caller(`scheduled.ts` `mirrorProgress`)만 `{ cacheTtl: 10 }` 전달, POST handler는 인자 없이 호출해 기본 동작 유지
- `getTrip` (POST 전용)은 변경하지 않음
- 테스트 더블 `InMemoryKV.get`은 옵션 인자 호환만 추가 (in-memory는 캐싱이 없어 무시)

## 정당화 — `cacheTtl=10` 선택 근거

| 옵션 | 효과 | 비용 | 결정 |
| --- | --- | --- | --- |
| `cacheTtl: 0` | stale 0초 | KV class B 60 reads/min/trip | 비용 과다 |
| `cacheTtl: 10` | stale ≤10초 | 6 reads/min/trip | **채택** |
| 기본(60) | stale ≤60초 | 1 reads/min/trip | 현재 회귀 원인 |

cron 주기가 60s라 stale ≤10s는 사용자 알람 시점 영향 미미. origin reads 비용은 60→6로 1/10.

## Test plan

- [x] `npm run type-check` 통과
- [x] `npm test` 305/305 통과 (회귀 없음)
- [ ] 머지 후 production deploy → 실기기 transfer trip에서 `cron loaded trip`의 `loadedTrainCode`가 동일 cron 사이클 안에서 `PUT trip after merge`의 `finalTrainCode`와 일치 확인
- [ ] 위 검증 통과하면 별도 PR로 `cron loaded trip` / `PUT trip after merge` 진단 로그 제거

Closes #766