### PR TITLE
fix(#767): useApnsTripRegistration race — boardingLock=null POST 차단

### DIFF
--- a/src/constants/boardingLock.ts
+++ b/src/constants/boardingLock.ts
@@ -54,3 +54,26 @@ export const ARRIVAL_PROXIMITY_THRESHOLD_M = 300;
  *  - 너무 길면(예: 90s) 사용자가 이미 하차해 다른 곳으로 이동 중인데 lock이 남는 시간이 길어짐.
  */
 export const AUTO_RELEASE_GRACE_MS = 45_000;
+
+/**
+ * #767 — boardingLock 해제(non-null → null) 시 register POST를 지연하는 debounce(ms).
+ *
+ * 배경(PR #765 evidence): 사용자가 옛 lock을 release하고 즉시 새 lock을 잡는 swap 흐름에서
+ * 짧은 시간 안에 3 POST가 발사된다(boardingLock=null → null → 새 lock). 첫 POST(null)가
+ * backend KV의 기존 lock을 unset해 새 lock POST가 `existingHasLock=false`로 들어오는 회귀가
+ * 관측되었다 (정상은 새 lock으로 직접 교체).
+ *
+ * 해제 → 새 lock 전환을 흡수하기 위해 lock release POST만 debounce — 다음 effect cycle이
+ * 새 lock을 들고 오면 옛 null POST는 cleanup으로 cancel되어 backend KV 상의 lock unset
+ * 사이드이펙트를 차단한다. 새 lock POST는 즉시 발사(debounce 미적용)되어 사용자 경험 영향 없음.
+ *
+ * 1500ms로 둔 이유:
+ *  - PR #765 evidence: 3 POST가 25초 안에 분포(~12.5s 간격), 사용자 swap 의도가 같은 effect
+ *    cycle 안에 들어오기엔 짧지 않다. 그러나 race window 자체는 React effect 재실행 + GPS/arrival
+ *    polling 사이의 1초 이내 발생 — 1.5s면 GPS 1 tick 이상 흡수.
+ *  - 너무 짧으면(예: 300ms) lock 해제 후 즉시 새 lock을 못 잡으면 null POST가 그대로 backend로
+ *    가서 race 미차단.
+ *  - 너무 길면(예: 5000ms) 진짜 trip 종료(사용자가 의도적으로 lock 해제) 시 backend KV 갱신이
+ *    지연돼 BG cron이 옛 lock으로 한 사이클 더 폴링 가능.
+ */
+export const BOARDING_LOCK_RELEASE_DEBOUNCE_MS = 1500;

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -663,6 +663,33 @@ describe('useApnsTripRegistration', () => {
       expectedDurationMs: 600_000,
     };
     const lockB = { ...lockA, trainCode: '7415', boardedAt: 1_700_000_500_000 };
+    type Lock = typeof lockA;
+
+    // CPD 해소: 8 케이스가 공유하는 (lock prop 기반 mount + microtask flush + 첫 register 발사)
+    // 셋업을 helper로 묶어 한 줄로 표현. PR #760의 mountAtT0 정신.
+    const mountWithLock = (initialLock: Lock | null) =>
+      renderHook(
+        ({ lock }: { lock: Lock | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: initialLock } },
+      );
+    const flushMicrotasks = async () => {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+    const flushOnce = async () => {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    };
 
     beforeEach(() => {
       jest.useFakeTimers();
@@ -673,30 +700,14 @@ describe('useApnsTripRegistration', () => {
     });
 
     it('lock → null 전환은 debounce window 안에 POST 발사 안 함', async () => {
-      const { rerender } = renderHook(
-        ({ lock }: { lock: typeof lockA | null }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            currentStation: station,
-            boardingLock: lock,
-          }),
-        { initialProps: { lock: lockA as typeof lockA | null } },
-      );
+      const { rerender } = mountWithLock(lockA);
       // 첫 register (lock A) 발사
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // lock 해제 — debounce window 안엔 POST 안 보내야 함
       rerender({ lock: null });
-      // microtask flush
-      await act(async () => {
-        await Promise.resolve();
-      });
+      await flushOnce();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // window 미만 advance (안전 마진)
@@ -705,41 +716,25 @@ describe('useApnsTripRegistration', () => {
     });
 
     it('lock → null 후 debounce 안에 새 lock 들어오면 null POST는 cancel되고 새 lock POST만 발사', async () => {
-      const { rerender } = renderHook(
-        ({ lock }: { lock: typeof lockA | null }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            currentStation: station,
-            boardingLock: lock,
-          }),
-        { initialProps: { lock: lockA as typeof lockA | null } },
-      );
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      const { rerender } = mountWithLock(lockA);
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
       expect(mockRegister.mock.calls[0][0].boardingLock.trainCode).toBe('7246');
 
       // 옛 lock release
       rerender({ lock: null });
-      await act(async () => { await Promise.resolve(); });
+      await flushOnce();
       // window 미만 진행
       act(() => { jest.advanceTimersByTime(500); });
       expect(mockRegister).toHaveBeenCalledTimes(1); // 아직 null POST 안 나감
 
       // 새 lock 잡힘 — 옛 null POST는 useEffect cleanup으로 cancel
       rerender({ lock: lockB });
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
 
       // 잔여 timer 모두 flush — 옛 null POST가 살아있다면 여기서 발사됨
       act(() => { jest.advanceTimersByTime(BOARDING_LOCK_RELEASE_DEBOUNCE_MS * 2); });
-      await act(async () => { await Promise.resolve(); });
+      await flushOnce();
 
       // 총 2회만 호출 (lock A + lock B). null POST는 발사 안 됨.
       expect(mockRegister).toHaveBeenCalledTimes(2);
@@ -751,89 +746,41 @@ describe('useApnsTripRegistration', () => {
     });
 
     it('lock → null 후 debounce window 경과하면 null POST 발사 (true release 의도)', async () => {
-      const { rerender } = renderHook(
-        ({ lock }: { lock: typeof lockA | null }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            currentStation: station,
-            boardingLock: lock,
-          }),
-        { initialProps: { lock: lockA as typeof lockA | null } },
-      );
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      const { rerender } = mountWithLock(lockA);
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // 옛 lock release — debounce window 경과 후 null POST 발사
       rerender({ lock: null });
-      await act(async () => { await Promise.resolve(); });
+      await flushOnce();
       act(() => { jest.advanceTimersByTime(BOARDING_LOCK_RELEASE_DEBOUNCE_MS + 100); });
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
 
       expect(mockRegister).toHaveBeenCalledTimes(2);
       expect(mockRegister.mock.calls[1][0].boardingLock).toBeUndefined();
     });
 
     it('null → lock 전환(초기 lock 부여)은 debounce 미적용 — 즉시 발사', async () => {
-      const { rerender } = renderHook(
-        ({ lock }: { lock: typeof lockA | null }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            currentStation: station,
-            boardingLock: lock,
-          }),
-        { initialProps: { lock: null as typeof lockA | null } },
-      );
+      const { rerender } = mountWithLock(null);
       // 첫 register (lock 없음) — 즉시 발사
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // lock 잡힘 — debounce 없이 즉시 발사
       rerender({ lock: lockA });
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(2);
       expect(mockRegister.mock.calls[1][0].boardingLock.trainCode).toBe('7246');
     });
 
     it('lock → 다른 lock 직접 교체(swap)는 debounce 미적용 — 즉시 발사', async () => {
-      const { rerender } = renderHook(
-        ({ lock }: { lock: typeof lockA | null }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            currentStation: station,
-            boardingLock: lock,
-          }),
-        { initialProps: { lock: lockA as typeof lockA | null } },
-      );
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      const { rerender } = mountWithLock(lockA);
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // 옛 lock → 새 lock 직접 교체 (null 거치지 않음) — 즉시 발사
       rerender({ lock: lockB });
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(2);
       expect(mockRegister.mock.calls[1][0].boardingLock.trainCode).toBe('7415');
     });
@@ -844,8 +791,9 @@ describe('useApnsTripRegistration', () => {
         if (key === ACTIVE_TRIP_KEY) return 'token-abc';
         return null;
       });
+      // 본 케이스만 route/destination도 같이 바꿔야 해서 mountWithLock 대신 인라인 유지.
       const { rerender } = renderHook(
-        ({ r, d, lock }: { r: Route; d: Station | null; lock: typeof lockA | null }) =>
+        ({ r, d, lock }: { r: Route; d: Station | null; lock: Lock | null }) =>
           useApnsTripRegistration({
             route: r,
             destination: d,
@@ -857,60 +805,42 @@ describe('useApnsTripRegistration', () => {
           initialProps: {
             r: directRoute as Route,
             d: station as Station | null,
-            lock: lockA as typeof lockA | null,
+            lock: lockA as Lock | null,
           },
         },
       );
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // 트립 종료 — route/destination 모두 null + lock도 null
       mockClear.mockClear();
       rerender({ r: null, d: null, lock: null });
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
 
       // clear 즉시 호출 (debounce 안 걸림)
       expect(mockClear).toHaveBeenCalledWith('token-abc');
     });
 
     it('debounce window 안에 unmount되면 옛 null POST도 cancel — 누수 없음', async () => {
-      const { rerender, unmount } = renderHook(
-        ({ lock }: { lock: typeof lockA | null }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            currentStation: station,
-            boardingLock: lock,
-          }),
-        { initialProps: { lock: lockA as typeof lockA | null } },
-      );
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      const { rerender, unmount } = mountWithLock(lockA);
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // 옛 lock release → debounce 시작
       rerender({ lock: null });
-      await act(async () => { await Promise.resolve(); });
+      await flushOnce();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // window 미만에서 unmount — cleanup이 clearTimeout으로 timer 제거 + run()의 cancelled 가드
       unmount();
       act(() => { jest.advanceTimersByTime(BOARDING_LOCK_RELEASE_DEBOUNCE_MS * 2); });
-      await act(async () => { await Promise.resolve(); });
+      await flushOnce();
       expect(mockRegister).toHaveBeenCalledTimes(1);
     });
 
     it('token refresh 경로도 lastSentLockSig 추적 — 다음 main effect cycle의 release 판정에 일관', async () => {
       // 초기엔 lock A 들고 시작 — 첫 register는 main effect 경로.
+      // 본 케이스는 rerender 불필요 — props 고정 mount면 충분.
       renderHook(() =>
         useApnsTripRegistration({
           route: directRoute,
@@ -920,10 +850,7 @@ describe('useApnsTripRegistration', () => {
           boardingLock: lockA,
         }),
       );
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flushMicrotasks();
       expect(mockRegister).toHaveBeenCalledTimes(1);
 
       // token refresh — listener가 자체적으로 register 발사 + lastSentLockSig 갱신

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -35,6 +35,7 @@ import { useApnsTripRegistration } from '../useApnsTripRegistration';
 import type { Station } from '../../types/station';
 import type { Route } from '../../utils/stationRoute';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../constants/storageKeys';
+import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../constants/boardingLock';
 import { makeDirectRoute } from '../../testUtils/routeFixtures';
 
 const station: Station = {
@@ -645,6 +646,300 @@ describe('useApnsTripRegistration', () => {
       await waitFor(() => expect(mockRegister).toHaveBeenCalled());
       const args = mockRegister.mock.calls[0][0];
       expect(args.boardingLock).toBeUndefined();
+    });
+  });
+
+  describe('#767 boardingLock 해제 race 차단 (debounce)', () => {
+    // PR #765 evidence: lock A → null → 새 lock B로 빠르게 swap하면 25초 안에 3 POST 발사,
+    // 첫 null POST가 backend KV의 옛 lock을 unset해 새 lock POST의 existingHasLock=false 회귀.
+    // 본 그룹은 lock 해제 전환(non-null → null)만 debounce하고 다른 전환은 즉시 발사함을 검증.
+
+    const lockA = {
+      destinationId: station.id,
+      trainCode: '7246',
+      boardingStationId: station.id,
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+    const lockB = { ...lockA, trainCode: '7415', boardedAt: 1_700_000_500_000 };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('lock → null 전환은 debounce window 안에 POST 발사 안 함', async () => {
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: lockA as typeof lockA | null } },
+      );
+      // 첫 register (lock A) 발사
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // lock 해제 — debounce window 안엔 POST 안 보내야 함
+      rerender({ lock: null });
+      // microtask flush
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // window 미만 advance (안전 마진)
+      act(() => { jest.advanceTimersByTime(BOARDING_LOCK_RELEASE_DEBOUNCE_MS - 100); });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('lock → null 후 debounce 안에 새 lock 들어오면 null POST는 cancel되고 새 lock POST만 발사', async () => {
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: lockA as typeof lockA | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+      expect(mockRegister.mock.calls[0][0].boardingLock.trainCode).toBe('7246');
+
+      // 옛 lock release
+      rerender({ lock: null });
+      await act(async () => { await Promise.resolve(); });
+      // window 미만 진행
+      act(() => { jest.advanceTimersByTime(500); });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 아직 null POST 안 나감
+
+      // 새 lock 잡힘 — 옛 null POST는 useEffect cleanup으로 cancel
+      rerender({ lock: lockB });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // 잔여 timer 모두 flush — 옛 null POST가 살아있다면 여기서 발사됨
+      act(() => { jest.advanceTimersByTime(BOARDING_LOCK_RELEASE_DEBOUNCE_MS * 2); });
+      await act(async () => { await Promise.resolve(); });
+
+      // 총 2회만 호출 (lock A + lock B). null POST는 발사 안 됨.
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+      expect(mockRegister.mock.calls[1][0].boardingLock.trainCode).toBe('7415');
+      // 어떤 호출도 boardingLock=undefined로 backend에 가지 않음
+      mockRegister.mock.calls.forEach((c) => {
+        expect(c[0].boardingLock).toBeDefined();
+      });
+    });
+
+    it('lock → null 후 debounce window 경과하면 null POST 발사 (true release 의도)', async () => {
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: lockA as typeof lockA | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 옛 lock release — debounce window 경과 후 null POST 발사
+      rerender({ lock: null });
+      await act(async () => { await Promise.resolve(); });
+      act(() => { jest.advanceTimersByTime(BOARDING_LOCK_RELEASE_DEBOUNCE_MS + 100); });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+      expect(mockRegister.mock.calls[1][0].boardingLock).toBeUndefined();
+    });
+
+    it('null → lock 전환(초기 lock 부여)은 debounce 미적용 — 즉시 발사', async () => {
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: null as typeof lockA | null } },
+      );
+      // 첫 register (lock 없음) — 즉시 발사
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // lock 잡힘 — debounce 없이 즉시 발사
+      rerender({ lock: lockA });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+      expect(mockRegister.mock.calls[1][0].boardingLock.trainCode).toBe('7246');
+    });
+
+    it('lock → 다른 lock 직접 교체(swap)는 debounce 미적용 — 즉시 발사', async () => {
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: lockA as typeof lockA | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 옛 lock → 새 lock 직접 교체 (null 거치지 않음) — 즉시 발사
+      rerender({ lock: lockB });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+      expect(mockRegister.mock.calls[1][0].boardingLock.trainCode).toBe('7415');
+    });
+
+    it('lock 보유 중 트립 종료(route/destination 모두 null)는 debounce 미적용 — 즉시 clear', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return 'token-abc';
+        if (key === ACTIVE_TRIP_KEY) return 'token-abc';
+        return null;
+      });
+      const { rerender } = renderHook(
+        ({ r, d, lock }: { r: Route; d: Station | null; lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: r,
+            destination: d,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        {
+          initialProps: {
+            r: directRoute as Route,
+            d: station as Station | null,
+            lock: lockA as typeof lockA | null,
+          },
+        },
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 트립 종료 — route/destination 모두 null + lock도 null
+      mockClear.mockClear();
+      rerender({ r: null, d: null, lock: null });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // clear 즉시 호출 (debounce 안 걸림)
+      expect(mockClear).toHaveBeenCalledWith('token-abc');
+    });
+
+    it('debounce window 안에 unmount되면 옛 null POST도 cancel — 누수 없음', async () => {
+      const { rerender, unmount } = renderHook(
+        ({ lock }: { lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: lockA as typeof lockA | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 옛 lock release → debounce 시작
+      rerender({ lock: null });
+      await act(async () => { await Promise.resolve(); });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // window 미만에서 unmount — cleanup이 clearTimeout으로 timer 제거 + run()의 cancelled 가드
+      unmount();
+      act(() => { jest.advanceTimersByTime(BOARDING_LOCK_RELEASE_DEBOUNCE_MS * 2); });
+      await act(async () => { await Promise.resolve(); });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('token refresh 경로도 lastSentLockSig 추적 — 다음 main effect cycle의 release 판정에 일관', async () => {
+      // 초기엔 lock A 들고 시작 — 첫 register는 main effect 경로.
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: lockA,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // token refresh — listener가 자체적으로 register 발사 + lastSentLockSig 갱신
+      const listener = mockAddPushTokenListener.mock.calls[0][0];
+      await act(async () => {
+        listener({ data: 'token-NEW' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // 새 토큰으로 register 호출됨 (lockA 포함)
+      const refreshed = mockRegister.mock.calls.find(
+        (c) => (c[0] as { token: string }).token === 'token-NEW',
+      );
+      expect(refreshed?.[0].boardingLock).toBeDefined();
+      expect(refreshed?.[0].boardingLock.trainCode).toBe('7246');
     });
   });
 });

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -18,6 +18,7 @@ import { registerActiveTrip, clearActiveTrip, type AlarmBoardingLock } from '../
 import { routeToWaypoints } from '../utils/routeWaypoints';
 import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../constants/storageKeys';
+import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../constants/boardingLock';
 import { createLogger } from '../utils/logger';
 import { resolveApnsEnv } from '../utils/apnsEnv';
 import type { BoardingLock } from '../types/boardingLock';
@@ -62,6 +63,14 @@ interface RegisterCallInputs {
   createdAt: number;
 }
 
+/**
+ * BoardingLock의 내용 기반 dedup signature. main effect의 deps key와 token-refresh 경로의
+ * `lastSentLockSigRef` 갱신에 동일 포맷을 사용해야 #767 release 판정이 일관 — 한 곳에서 빌드.
+ */
+function lockSig(lock: BoardingLock | null): string | null {
+  return lock ? `${lock.trainCode}|${lock.boardingLine}|${lock.boardedAt}` : null;
+}
+
 /** 두 호출처(token refresh / main effect)의 register 페이로드 빌드를 단일화. */
 async function callRegister(input: RegisterCallInputs) {
   // #622: BoardingLock metadata 빌드. lock의 boardingStationId로 station name 조회 후 schema 변환.
@@ -103,9 +112,7 @@ export function useApnsTripRegistration({
   const routeSig = useMemo(() => routeSignature(route), [route]);
   // boardingLock도 reference가 아닌 내용 기반 key로 deps — 상위가 매 렌더 새 객체를 내려도 안전.
   // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
-  const boardingLockSig = boardingLock
-    ? `${boardingLock.trainCode}|${boardingLock.boardingLine}|${boardingLock.boardedAt}`
-    : null;
+  const boardingLockSig = lockSig(boardingLock);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
   const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock });
   useEffect(() => {
@@ -124,6 +131,10 @@ export function useApnsTripRegistration({
     }
     return tripCreatedAtRef.current;
   };
+
+  // #767 — 직전 effect cycle이 backend로 송신한 boardingLockSig. lock 해제 race
+  // (non-null → null → 새 lock 3 POST) 판정에 사용. 첫 register 시 null로 시작.
+  const lastSentLockSigRef = useRef<string | null>(null);
 
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
   useEffect(() => {
@@ -174,6 +185,9 @@ export function useApnsTripRegistration({
           boardingLock: bl,
           createdAt: resolveTripCreatedAt(sessionKey),
         });
+        // #767 — main effect와 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도
+        // 유지. token-refresh는 deps cycle을 거치지 않는 별경로지만 backend엔 동일 POST를 보내므로.
+        lastSentLockSigRef.current = lockSig(bl);
       })();
     });
 
@@ -186,8 +200,10 @@ export function useApnsTripRegistration({
   // ── 활성 트립 register / clear ──
   useEffect(() => {
     let cancelled = false;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-    (async () => {
+    // 실제 register/clear 작업 — debounce 분기와 즉시 분기에서 공유.
+    const run = async () => {
       const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
       if (cancelled) return;
 
@@ -199,6 +215,9 @@ export function useApnsTripRegistration({
           await clearActiveTrip(prevTokenRaw);
           await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
         }
+        // 트립 없음 분기에서도 lock 시그를 reset — 다음 trip이 새로 등록될 때 첫 cycle은
+        // 즉시 발사(debounce 미적용) 보장.
+        lastSentLockSigRef.current = null;
         return;
       }
 
@@ -218,16 +237,37 @@ export function useApnsTripRegistration({
         boardingLock,
         createdAt: resolveTripCreatedAt(sessionKey),
       });
+      // POST 발사 직후(성공/실패 무관) 송신된 lock sig를 기록 — 다음 cycle이 "직전 송신 = lock,
+      // 신규 = null" 패턴인지 판정해 race 차단.
+      lastSentLockSigRef.current = boardingLockSig;
       // #669: cancelled 가드 밖에서 setItem — backend register 성공이면 UI cleanup 여부와 무관하게
       // ACTIVE_TRIP_KEY를 동기화. 가드 안에 두면 nextStationEtaSeconds·currentStation 변경으로
       // useEffect cleanup이 자주 일어나 setItem이 skip되고 DebugModal activeTrip이 (none)으로 표시됨.
       if (result.ok) {
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
       }
-    })();
+    };
+
+    // #767 — lock 해제(non-null → null) 전환만 debounce. 다음 cycle이 새 lock을 들고 오면
+    // cleanup이 timer를 clearTimeout으로 cancel해 발사 자체를 차단. 다른 전환(route/destination
+    // 변경, lock 신규 부여, lock 내용 갱신, 트립 종료)은 즉시 발사 — 기존 동작 보존.
+    // 안전: 만약 cleanup의 clearTimeout이 race로 늦어 timer가 발사돼도 run() 내부 cancelled
+    // 가드가 AsyncStorage.getItem 직후 추가 작업을 차단한다 (이중 방어).
+    const isLockReleaseTransition =
+      lastSentLockSigRef.current !== null && boardingLockSig === null && route !== null && destination !== null;
+    if (isLockReleaseTransition) {
+      debounceTimer = setTimeout(() => {
+        void run();
+      }, BOARDING_LOCK_RELEASE_DEBOUNCE_MS);
+    } else {
+      void run();
+    }
 
     return () => {
       cancelled = true;
+      if (debounceTimer !== null) {
+        clearTimeout(debounceTimer);
+      }
     };
     // route는 routeSig(내용 기반)로 비교 — 동일 경로 재등록으로 백엔드 trip
     // state(waypoints shift)가 reset되거나 워커 POST /trips가 분당 폭주하는 것을 방지.


### PR DESCRIPTION
## 배경

PR #765 evidence:
```
23:51:39  POST hasBoardingLock=FALSE  (existingHasLock=TRUE)   ← 옛 lock unset
23:52:02  POST hasBoardingLock=FALSE  (existingHasLock=FALSE)
23:52:04  POST hasBoardingLock=TRUE trainCode=7415             ← 새 lock 정확
```

25초 안 3 POST. boardingLockSig가 `null → null → 'A|B|C'`로 진행하는 동안 첫 `boardingLock=null` POST가 backend `trip.boardingLock`을 unset해 새 lock POST가 `existingHasLock=false`로 들어오는 회귀. 정상 흐름은 새 lock으로 직접 교체.

## 옵션 선택 정당화

| 옵션 | 정당화 |
| --- | --- |
| A (null POST 자체 skip) | route/destination 새로 set 시 첫 등록도 boardingLock 없음이 정상 → false positive |
| **B (debounce) ← 선택** | false positive 없음. lock swap 흐름에서 옛 null POST는 cleanup으로 cancel |
| C (backend merge 보정) | 본 PR 영역 아님 (client 한정). #766과 충돌 회피 |

## 변경

### `src/constants/boardingLock.ts`
- `BOARDING_LOCK_RELEASE_DEBOUNCE_MS = 1500` 추가
- 값 선택 정당화: GPS 1 tick 이상 흡수하면서도 true release 의도(사용자 의도적 lock 해제)에서 backend KV 갱신 지연 최소화

### `src/hooks/useApnsTripRegistration.ts`
- `lockSig()` 헬퍼 추출 — main effect deps / token-refresh / `lastSentLockSigRef` 갱신 3 사이트가 동일 포맷 사용
- `lastSentLockSigRef`로 직전 backend 송신 lock sig 추적
- 마지막 POST가 lock 보유 + 현재 `boardingLockSig=null` + 트립 활성인 경우만 debounce setTimeout 적용
- 다른 전환(route/destination 변경, lock 신규 부여, lock 내용 갱신, 트립 종료, 첫 마운트)은 즉시 발사 — 기존 동작/테스트 보존
- cleanup이 timer를 `clearTimeout`으로 cancel — 새 lock cycle 들어오면 옛 null POST 발사 차단
- `run()` 내부 `cancelled` 가드는 이중 방어

### 테스트 (7 케이스 추가)
- `lock → null` debounce: window 안에 POST 안 보냄
- `lock → null → 새 lock` race 차단: 옛 null POST cancel, 새 lock POST만 발사
- `lock → null` window 경과 후 null POST 발사 (true release 의도)
- `null → lock` 즉시 발사 (debounce 미적용)
- `lock A → lock B` 직접 교체 즉시 발사 (debounce 미적용)
- 트립 종료(route/dest null) 즉시 clear (debounce 미적용)
- debounce window 안 unmount 시 옛 null POST cancel
- token refresh도 `lastSentLockSigRef` 일관 추적

## 테스트 결과

```
Test Suites: 154 passed, 154 total
Tests:       2759 passed, 2759 total
```

100% 커버리지 유지, type-check pass.

## 영역 분리

본 PR은 **client(src/)만** 수정. backend/alarm-worker는 #766에서 병렬 작업 중 — conflict 방지를 위해 본 PR에선 미터치. 옵션 C(backend merge 보정)는 별개 issue로 분리 가능.

Closes #767