### PR TITLE
fix(#770): cron KV cacheTtl 10 → 30 hotfix — production cron 회복

### DIFF
--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -18,11 +18,12 @@ const PENDING_PREFIX = 'pending:';
 export const PENDING_TTL_SEC = 60;
 
 /**
- * cron read의 KV cacheTtl (#766). trips.ts와 같은 이유 — silent push 발사 직후 putPending된
+ * cron read의 KV cacheTtl (#766/#770). trips.ts와 같은 이유 — silent push 발사 직후 putPending된
  * entry를 같은 cron 사이클(또는 다음)의 fallback이 못 보는 stale read를 방지.
  * 기본 60s는 fallback이 막 발사된 push의 sentAt을 못 봐 임계 평가가 어긋날 위험이 있다.
+ * Cloudflare KV cacheTtl 최소값은 30s(#770 hotfix) — 그보다 작으면 런타임에서 `Invalid cache_ttl` 던짐.
  */
-const CRON_READ_CACHE_TTL_SEC = 10;
+const CRON_READ_CACHE_TTL_SEC = 30;
 
 /** silent push 발사 1건의 추적 정보. P2c가 alert fallback 결정에 사용. */
 export interface PendingPush {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -49,11 +49,12 @@ export const LA_PUSH_THRESHOLD_MS = 30_000;
 export const MAX_CONSECUTIVE_ETA_MISSING = 5;
 
 /**
- * cron이 progress KV를 read할 때의 cacheTtl (#766).
- * POST `/trips`가 putProgress 직후 같은 cron 사이클에서 옛 값을 읽지 않도록 10s까지 단축.
- * trips.ts/pendingPushes.ts의 cron read와 동일 정책.
+ * cron이 progress KV를 read할 때의 cacheTtl (#766/#770).
+ * POST `/trips`가 putProgress 직후 같은 cron 사이클에서 옛 값을 읽지 않도록 30s까지 단축.
+ * trips.ts/pendingPushes.ts의 cron read와 동일 정책. Cloudflare KV는 cacheTtl<30s 시
+ * 런타임에서 `Invalid cache_ttl` 던짐(#770 hotfix).
  */
-const CRON_PROGRESS_CACHE_TTL_SEC = 10;
+const CRON_PROGRESS_CACHE_TTL_SEC = 30;
 
 export interface EnvHealResult {
   result: SendPushResult;

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -10,11 +10,12 @@ import type { Trip } from './types';
 const TRIP_PREFIX = 'trip:';
 
 /**
- * cron read의 KV cacheTtl (#766). Workers KV의 기본 cacheTtl=60s에 의해 PUT 직후 옛 캐시가
+ * cron read의 KV cacheTtl (#766/#770). Workers KV의 기본 cacheTtl=60s에 의해 PUT 직후 옛 캐시가
  * 60s까지 유지되는 stale read가 cron의 boardingLock 누락 회귀 root cause였다 (#765 진단 로그).
- * cron 주기 자체가 60s이므로 10s까지는 사용자 영향이 미미하고, origin 비용은 60→6 reads/min/trip로 절감.
+ * Cloudflare Workers KV의 cacheTtl 최소값은 30s — 그보다 작으면 런타임에서 `Invalid cache_ttl` 던짐(#770).
+ * cron 주기 자체가 60s이므로 30s 단축으로도 첫 cron 사이클의 stale window가 사라진다.
  */
-const CRON_READ_CACHE_TTL_SEC = 10;
+const CRON_READ_CACHE_TTL_SEC = 30;
 
 export function tripKey(token: string): string {
   return `${TRIP_PREFIX}${token}`;


### PR DESCRIPTION
## Summary
- Cloudflare Workers KV `cacheTtl` 최소값은 **30s**. PR #768(#766)에서 10s 적용 → deploy 직후 cron 전면 fail
- 세 상수 일괄 10 → 30: `trips.ts`, `pendingPushes.ts`, `scheduled.ts`

## 회귀

\`\`\`
01:06:35 Exception Thrown
Error: KV GET failed: 400 Invalid cache_ttl of 10. Cache TTL must be at least 30.
\`\`\`

- cron `scheduled run complete` exception thrown
- 활성 trip silent push 0건
- transfer/일반 trip 모두 추적 fail

## 정당화

30s는 KV API 허용 최소. cron 주기 60s 안에서:
- PUT 직후 0~30s 안 cron → stale 가능
- 30s 후 cron → fresh

#766 의도(stale window 축소)는 유지. 60s → 30s 단축으로 첫 cron 사이클에서 fresh read 보장.

## Test plan
- [x] backend `npm run type-check` pass
- [x] backend `npm test` pass (305 tests)
- [ ] deploy 후 wrangler tail에서 `KV GET failed` 0건 + `cron loaded trip` 정상 출력 확인
- [ ] transfer trip 재현 → `loadedTrainCode`가 PUT `finalTrainCode`와 30s 안에 일치

Closes #770