### PR TITLE
chore(#622): #762/#764 진단 로그 제거 — root cause 확정 후 cleanup

### DIFF
--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -66,20 +66,6 @@ app.post('/trips', async (c) => {
   const incoming = validateTrip(body);
   if (!incoming) return c.json({ error: 'invalid_trip' }, 400);
 
-  // #762/#622 — transfer-leg sync 가설 확정용 진단 로그 (root cause 확정 후 제거).
-  // wrangler tail에서 hasBoardingLock=false면 client 누락(가설 A),
-  // true인데 cron이 lockMissing이면 backend merge drop(가설 C).
-  console.log(
-    JSON.stringify({
-      msg: 'POST /trips incoming',
-      tokenPrefix: tokenPrefix(incoming.token),
-      hasBoardingLock: incoming.boardingLock !== undefined,
-      trainCode: incoming.boardingLock?.trainCode,
-      line: incoming.boardingLock?.line,
-      segmentLen: incoming.boardingLock?.segmentStations.length,
-    }),
-  );
-
   // #578/#704: 디바이스가 동일 trip을 반복 POST해도(예: GPS update마다 register, 또는 cold restart
   // 후 같은 trip 재등록) backend가 이미 advance한 waypoints / 추적 baseline을 덮어쓰지 않는다.
   //
@@ -131,22 +117,6 @@ app.post('/trips', async (c) => {
     : baseTrip;
 
   await putTrip(c.env.TRIPS, trip);
-
-  // #764/#622 — putTrip 직후 trip 상태 진단 (root cause sub-step 좁힘용, 확정 후 제거).
-  // scheduled.ts의 `cron loaded trip` 로그와 cross-check해 KV 쓰기/읽기 사이에서
-  // boardingLock.trainCode가 어떻게 보이는지 확정한다. existing/incoming/final을 한 줄에 모아
-  // merge 분기(isSameSession / progressApplied)가 새 lock을 유지하는지 즉시 확인.
-  console.log(
-    JSON.stringify({
-      msg: 'PUT trip after merge',
-      tokenPrefix: tokenPrefix(trip.token),
-      isSameSession,
-      progressApplied: progressApplies,
-      incomingHasLock: incoming.boardingLock !== undefined,
-      existingHasLock: existing?.boardingLock !== undefined,
-      finalTrainCode: trip.boardingLock?.trainCode,
-    }),
-  );
 
   return c.json({ ok: true, token: trip.token });
 });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -180,15 +180,6 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     const waypoint = pickActiveWaypoint(trip);
     if (!waypoint) continue;
 
-    // #764/#622 — cron이 KV에서 읽은 trip의 boardingLock 추적 (root cause sub-step 좁힘용,
-    // 확정 후 제거). POST /trips의 `PUT trip after merge` 로그와 cross-check해 KV 쓰기/
-    // 읽기 사이에 trainCode가 어떻게 보이는지 한 사이클 단위로 확정한다.
-    log('cron loaded trip', {
-      token: trip.token.slice(0, 8),
-      loadedTrainCode: trip.boardingLock?.trainCode,
-      waypointStation: waypoint.stationName,
-    });
-
     // #640 — BoardingLock 게이트. 사용자가 열차를 아직 선택하지 않았거나 lock이 만료된 trip은
     // Seoul polling/push 모두 skip. 디바이스는 lock 등록 후 train-code 단위로 정확히 추적하며,
     // lock 부재 상태에서의 phase-based push는 "탑승 전 노이즈"였다.


### PR DESCRIPTION
## Summary

- PR #763 (#762) / PR #765 (#764) 머지 후 #771 hotfix로 transfer-leg sync root cause 확정 완료
- 진단 로그 3종 제거: `POST /trips incoming`, `PUT trip after merge`, `cron loaded trip`
- 주변 진단용 주석도 함께 정리
- 39 lines 삭제, import/주변 코드 변경 없음 (surgical)

Refs #622

## Why draft

첫차 이후 실기기에서 transfer trip을 재현해 wrangler tail로 #766(`cacheTtl=30`) + #767(debounce) 효과를 검증한 뒤 ready 전환할 예정. 검증 전 머지 방지 목적.

- 검증 통과 → ready for review 전환 후 머지
- 검증 실패 → close하고 진단 로그를 활용해 추가 fix 진행

## Test plan

- [x] `npm run type-check` (backend/alarm-worker) pass
- [x] `npm test` 305 tests pass
- [ ] 첫차 이후 transfer trip 재현 → wrangler tail에서 `lockMissing` 0건 확인
- [ ] #766/#767 효과 검증 완료 후 ready for review 전환