### PR TITLE
chore(#774): wrangler tail 캡처 스크립트 정식 도입 (운영 진단 도구)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "data:fetch-exit-side": "node scripts/fetch-exit-side.js",
     "data:fetch-quick-exit": "node scripts/fetch-quick-exit.js",
     "data:build-transfer-times": "node scripts/build-transfer-times.js",
+    "tail:capture": "scripts/capture-tail.sh",
     "e2e": "maestro test .maestro/flows/",
     "e2e:home": "maestro test .maestro/flows/home/",
     "e2e:favorites": "maestro test .maestro/flows/favorites/",

--- a/scripts/capture-tail.sh
+++ b/scripts/capture-tail.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Wrangler tail 캡처 — #622 transfer-leg sync 진단용.
+#
+# 사용:
+#   scripts/capture-tail.sh [label]
+#   예: scripts/capture-tail.sh transfer-test
+#   npm run tail:capture -- transfer-test    # ← npm 경유 시 -- 필수
+#
+# 요구사항: bash, npx(wrangler), 분석 시 jq (macOS: brew install jq)
+#
+# 동작:
+#   - backend/alarm-worker의 wrangler.toml에서 worker name 추출 (SSOT)
+#   - npx wrangler tail "$WORKER_NAME" --format=json
+#   - 표준출력 + 파일(tasks/wrangler-tail-<timestamp>-<label>.jsonl) 동시 기록
+#   - Ctrl+C로 종료
+#
+# 분석 팁 (jq 사용):
+#   - lockMissing 시점만:
+#       jq 'select(.event.outcome.lockMissing > 0)' tasks/wrangler-tail-*.jsonl
+#   - POST /trips 호출 시각:
+#       jq -r 'select(.event.request.url? | endswith("/trips")) | .event.rayId,.eventTimestamp' tasks/wrangler-tail-*.jsonl
+#   - reschedule push 발사:
+#       jq 'select(.logs[]?.message[]? | test("reschedule push"))' tasks/wrangler-tail-*.jsonl
+set -euo pipefail
+
+LABEL="${1:-capture}"
+if [[ ! "$LABEL" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "[capture-tail] label은 [A-Za-z0-9._-]만 허용됩니다: $LABEL" >&2
+  exit 2
+fi
+
+TS=$(date +%Y%m%d-%H%M%S)
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$REPO_ROOT/tasks/wrangler-tail-$TS-$LABEL.jsonl"
+
+WORKER_NAME=$(awk -F'"' '/^name *=/ {print $2; exit}' "$REPO_ROOT/backend/alarm-worker/wrangler.toml")
+if [[ -z "$WORKER_NAME" ]]; then
+  echo "[capture-tail] backend/alarm-worker/wrangler.toml에서 worker name을 추출하지 못했습니다." >&2
+  exit 1
+fi
+
+mkdir -p "$REPO_ROOT/tasks"
+
+echo "[capture-tail] worker: $WORKER_NAME"
+echo "[capture-tail] backend/alarm-worker → wrangler tail (json)"
+echo "[capture-tail] 저장 경로: $OUT"
+echo "[capture-tail] Ctrl+C로 종료"
+echo
+
+cd "$REPO_ROOT/backend/alarm-worker"
+npx wrangler tail "$WORKER_NAME" --format=json | tee "$OUT"


### PR DESCRIPTION
## Summary
- backend/alarm-worker의 wrangler tail을 stdout + `tasks/wrangler-tail-<ts>-<label>.jsonl` 동시 저장
- `npm run tail:capture -- <label>` alias로 발견성 향상
- 리뷰 권고 반영: wrangler.toml SSOT 활용, label sanitize, 헤더 주석 보강

#622 transfer-leg silent push 진단에 즉시 사용 + 향후 silent push/cron/KV 회귀 재사용.

## Test plan
- [ ] `bash -n scripts/capture-tail.sh` syntax OK
- [ ] `npm run type-check` 통과
- [ ] `git check-ignore tasks/wrangler-tail-sample.jsonl` 매칭 확인
- [ ] (실기기 단계) `npm run tail:capture -- transfer-test` 실행 시 wrangler tail 시작 + Ctrl+C 종료 시 jsonl 생성

Closes #774