### PR TITLE
feat(#776): 경로 ETA에 도보 시간(출발/도착) 합산

### DIFF
--- a/src/constants/eta.ts
+++ b/src/constants/eta.ts
@@ -1,0 +1,3 @@
+// 도보 평균 속도(m/s). 공공데이터포털 환승 소요시간(15044419)이 사용하는 1.2 m/s와 동일 기준.
+// calculateStaticETA의 출발/도착 walking 시간 합산에 사용.
+export const WALKING_SPEED_M_PER_S = 1.2;

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -264,6 +264,19 @@ describe('processLocationUpdate', () => {
     );
   });
 
+  // #776: 도보 시간 합산을 위해 currentLocation/originStation을 calculateStaticETA에 전달.
+  it('calculateStaticETA에 currentLocation(GPS)과 originStation(nearest 좌표)을 전달한다', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+
+    await call();
+
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(mockRoute, {
+      currentLocation: { lat: 37.498, lng: 127.028 },
+      originStation: { lat: mockStation.lat, lng: mockStation.lng },
+    });
+  });
+
   it('passes alarmEvent to updateStationNotification only when sleepMode is true', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
@@ -345,7 +358,7 @@ describe('processLocationUpdate', () => {
 
     expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
     expect(mockFindRoute).not.toHaveBeenCalled();
-    expect(mockCalculateStaticETA).toHaveBeenCalledWith(updatedRoute);
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(updatedRoute, expect.any(Object));
   });
 
   it('calls findRoute when no storedRoute is provided', async () => {

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -430,6 +430,102 @@ describe('calculateStaticETA', () => {
   });
 });
 
+describe('calculateStaticETA — 도보 시간 합산 (#776)', () => {
+  // 0.0009도 차이 ≈ 100m, 도보 1.2 m/s 기준 83.3초 ≈ 1.4분 → round(1.4)=1분
+  const userNearOrigin = { lat: 37.5, lng: 127.0 };
+  const originStationCoords = { lat: 37.5009, lng: 127.0 };
+  // 0.0065도 차이 ≈ 723m, 도보 1.2 m/s 기준 602초 ≈ 10.04분 → round(10.04)=10분
+  const destinationStationCoords = { lat: 37.6, lng: 127.0 };
+  const userFarFromDestStation = { lat: 37.6065, lng: 127.0 };
+
+  it('options 미지정 시 기존 동작 그대로 (도보 0분)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(calculateStaticETA(route)).toBe(13); // 3 + 10 + 0
+  });
+
+  it('currentLocation + originStation 페어로 출발 도보 시간을 합산한다', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 13(기존) + round(1.4)=1 → 14분
+    expect(
+      calculateStaticETA(route, {
+        currentLocation: userNearOrigin,
+        originStation: originStationCoords,
+      }),
+    ).toBe(14);
+  });
+
+  it('destination + destinationStation 페어로 하차 도보 시간을 합산한다', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 13(기존) + round(10.04)=10 → 23분
+    expect(
+      calculateStaticETA(route, {
+        destinationStation: destinationStationCoords,
+        destination: userFarFromDestStation,
+      }),
+    ).toBe(23);
+  });
+
+  it('출발 + 하차 도보 시간을 모두 합산한다', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 13 + 1(출발) + 10(하차) = 24분
+    expect(
+      calculateStaticETA(route, {
+        currentLocation: userNearOrigin,
+        originStation: originStationCoords,
+        destinationStation: destinationStationCoords,
+        destination: userFarFromDestStation,
+      }),
+    ).toBe(24);
+  });
+
+  it('currentLocation만 있고 originStation 누락이면 출발 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { currentLocation: userNearOrigin }),
+    ).toBe(13);
+  });
+
+  it('originStation만 있고 currentLocation 누락이면 출발 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { originStation: originStationCoords }),
+    ).toBe(13);
+  });
+
+  it('destination만 있고 destinationStation 누락이면 하차 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { destination: userFarFromDestStation }),
+    ).toBe(13);
+  });
+
+  it('destinationStation만 있고 destination 누락이면 하차 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { destinationStation: destinationStationCoords }),
+    ).toBe(13);
+  });
+
+  it('동일 좌표면 도보=0 (현위치가 출발역과 같은 점)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, {
+        currentLocation: originStationCoords,
+        originStation: originStationCoords,
+      }),
+    ).toBe(13);
+  });
+
+  it('route가 null이면 options 있어도 null 반환', () => {
+    expect(
+      calculateStaticETA(null, {
+        currentLocation: userNearOrigin,
+        originStation: originStationCoords,
+      }),
+    ).toBeNull();
+  });
+});
+
 describe('환승역별 실측 환승시간 반영', () => {
   // CSV 출처: 공공데이터포털 15044419 (보행속도 1.2 m/s 기준)
   // 교대(2↔3) 63초 vs 잠실(8↔2) 158초 — 같은 stops여도 travelMinutes 차이 발생

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -239,7 +239,13 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     }
   }
 
-  const eta = calculateStaticETA(route);
+  // #776: 도보 시간 합산. nearest.station을 출발역으로, 사용자 GPS(lat/lng)를 currentLocation으로.
+  // 하차 도보는 미적용 — 현 시점 데이터 모델은 destination이 Station(=하차역)으로 사용자 최종 좌표와
+  // 일치하므로 도보 0이 자명. 사용자 좌표를 별도로 보유하게 되면 destination/destinationStation 추가.
+  const eta = calculateStaticETA(route, {
+    currentLocation: { lat, lng },
+    originStation: { lat: nearest.station.lat, lng: nearest.station.lng },
+  });
   await updateStationNotification(
     nearest.station,
     Math.round(nearest.distanceKm * 1000),

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -3,10 +3,12 @@ import stationTravelTimesJson from '../data/stationTravelTimes.json';
 import transferTimes from '../data/transferTimes.json';
 import type { Station } from '../types/station';
 import { LINE_COLORS } from '../constants/lineColors';
+import { WALKING_SPEED_M_PER_S } from '../constants/eta';
 import type { LineNumber } from '../types/station';
 import { applyStationAlias } from '../data/stationAliases';
 import { createLogger } from './logger';
 import { normalizeStationName as baseNormalizeStationName } from './normalizeStationName';
+import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
 
 const logger = createLogger('StationRoute');
 
@@ -742,9 +744,62 @@ function getTravelMinutes(route: NonNullable<Route>): number {
   return Math.round(totalSeconds / 60);
 }
 
-export function calculateStaticETA(route: Route): number | null {
+/** lat/lng만 추출한 좌표 — Station 전체를 넘기지 않아 결합도를 낮춘다. */
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * calculateStaticETA에 도보 시간을 합산하기 위한 옵션. 누락된 페어는 walking=0으로
+ * graceful fallback (예: 위치 권한 미확보 시 currentLocation만 빠질 수 있음).
+ *
+ * - currentLocation + originStation 둘 다 있으면 출발 도보 시간 합산
+ * - destination + destinationStation 둘 다 있으면 하차 도보 시간 합산
+ */
+export interface StaticEtaWalkingOptions {
+  /** 사용자 현재 위치(GPS). originStation과 함께 있을 때 출발역까지 도보 시간 계산. */
+  currentLocation?: LatLng;
+  /** 경로의 출발 지하철역 좌표. currentLocation 없으면 미사용. */
+  originStation?: LatLng;
+  /** 사용자 최종 목적지(예: 사무실 좌표). destinationStation과 함께 있을 때 하차 도보 시간 계산. */
+  destination?: LatLng;
+  /** 경로의 하차 지하철역 좌표. destination 없으면 미사용. */
+  destinationStation?: LatLng;
+}
+
+// 한 페어(사용자 좌표 + 역 좌표)의 도보 시간(분). 누락 시 0.
+// estimateEtaSeconds를 재사용하되, 보행은 항상 WALKING_SPEED_M_PER_S(=1.2) 위쪽이라 null이 될 일이 없다.
+function calculateWalkingMinutes(from: LatLng | undefined, to: LatLng | undefined): number {
+  if (!from || !to) return 0;
+  const distM = distanceMetersBetween(from.lat, from.lng, to.lat, to.lng);
+  // WALKING_SPEED_M_PER_S(=1.2) >= MIN_VALID_SPEED_MPS(=0.5) 이므로 항상 number 반환.
+  // 타입 narrowing을 위해 ?? 0 — 향후 상수 변경 시 회귀 차단.
+  /* istanbul ignore next -- WALKING_SPEED_M_PER_S > MIN_VALID_SPEED_MPS 불변식상 null 경로 도달 불가 */
+  const seconds = estimateEtaSeconds(distM, WALKING_SPEED_M_PER_S) ?? 0;
+  return seconds / 60;
+}
+
+/**
+ * 경로 정적 ETA(분). 기본 대기 + 지하철 운행/환승 + (옵션) 출발/도착 도보 시간.
+ *
+ * - route=null이면 null
+ * - options 미지정 시 기존 동작 그대로 (도보 0분)
+ * - 페어가 부분적으로 누락되면 해당 도보 시간만 0 (예: currentLocation은 있는데 originStation이 없으면
+ *   출발 도보 0 — 사용자 위치 권한 미확보 등 부분 정보 상황에서 graceful fallback)
+ *
+ * 반환은 분 단위 정수 — 호출처(메인 ETA 카운터/알림 body 등)가 정수를 전제로 한다.
+ * 지하철 시간은 getTravelMinutes에서 이미 분 단위 정수, 도보 합계는 여기서 한 번 round 해 더한다.
+ */
+export function calculateStaticETA(
+  route: Route,
+  options: StaticEtaWalkingOptions = {},
+): number | null {
   if (!route) return null;
-  return DEFAULT_WAIT_MINUTES + getTravelMinutes(route);
+  const walkingMinutes =
+    calculateWalkingMinutes(options.currentLocation, options.originStation) +
+    calculateWalkingMinutes(options.destinationStation, options.destination);
+  return DEFAULT_WAIT_MINUTES + getTravelMinutes(route) + Math.round(walkingMinutes);
 }
 
 /**


### PR DESCRIPTION
## Summary
- calculateStaticETA에 현위치→출발역, 도착역→목적지 도보 시간 합산
- 기존 estimateEtaSeconds 재사용
- currentLocation 누락 시 walking=0 graceful fallback

## Test plan
- [ ] walking 합산 단위 테스트 추가
- [ ] currentLocation null 시 fallback 동작 검증
- [ ] 100% coverage 유지
- [ ] type-check 통과

Closes #776