### PR TITLE
feat(#779): ADR-008 Stage 3 — HOP_TIME_TABLE 도입 + DefaultHop 구현

### DIFF
--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -22,7 +22,7 @@ import {
   arcIndexOfStation,
   estimateStationProgress,
 } from '../utils/stationProgressEstimator';
-import { HOP_TIME_MS } from '../constants/boardingLock';
+import { hopTimeMsAt } from '../utils/hopTime';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import {
   MAX_ACTIVE_LINES,
@@ -438,6 +438,15 @@ export function useFusedNearestStation(
 
   // useMemo로 감싸면 deps가 시간을 포함하지 않아 부모 리렌더가 없는 동안 stale.
   // estimator는 분기·정수 산술 위주 — render마다 직접 계산해도 무비용.
+  // ADR-008 Stage 3(#779): boardingLock의 leg 노선(`boardingLine`)을 캡슐화한 hop time lookup을
+  // estimator에 주입. lock이 없으면 estimator 자체가 비활성이므로 boardingLine은 lock present 시점에만
+  // 의미가 있다 — null 분기에서는 fallback closure(uniform HOP_TIME_MS)를 넘겨 estimator의 ③④가
+  // 호출되더라도 안전하게 종료(lock null 가드에서 이미 차단).
+  const lockedLine = boardingLock?.boardingLine ?? null;
+  const hopTimeMsForHop = lockedLine
+    ? (fromIdx: number) => hopTimeMsAt(arcStations, fromIdx, lockedLine)
+    : /* istanbul ignore next — estimator는 lock null이면 line 245에서 early return하므로 sentinel 도달 불가 */
+      () => Number.POSITIVE_INFINITY;
   const estimate = estimateStationProgress({
     lock: boardingLock ?? null,
     arcStations,
@@ -445,7 +454,7 @@ export function useFusedNearestStation(
     trainProgress: freshTrainProgress,
     lockedTrainCode: lockedTrainCode ?? null,
     lastObserved: lastObservedRef.current,
-    hopTimeMs: HOP_TIME_MS,
+    hopTimeMsForHop,
     nextStationArrivals,
     arrivalEtaTtlMs: POSITION_TRAIN_TTL_MS,
     currentIdxHint,

--- a/src/utils/__tests__/hopTime.test.ts
+++ b/src/utils/__tests__/hopTime.test.ts
@@ -1,0 +1,78 @@
+import { hopTimeMsForSegment, hopTimeMsAt, hopsElapsedFrom } from '../hopTime';
+import { HOP_TIME_MS } from '../../constants/boardingLock';
+import type { Station } from '../../types/station';
+
+jest.mock('../stationRoute', () => ({
+  getStopSeconds: jest.fn(),
+}));
+
+import { getStopSeconds } from '../stationRoute';
+
+const mockedGetStopSeconds = getStopSeconds as jest.MockedFunction<typeof getStopSeconds>;
+
+const ARC: Station[] = [
+  { id: 'a', name: 'A', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: 'b', name: 'B', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+  { id: 'c', name: 'C', line: '7', lineColor: '#x', lat: 0, lng: 0 },
+];
+
+describe('hopTimeMsForSegment', () => {
+  beforeEach(() => mockedGetStopSeconds.mockReset());
+
+  it('returns getStopSeconds(line, from, to) × 1000', () => {
+    mockedGetStopSeconds.mockReturnValue(150);
+    expect(hopTimeMsForSegment('7', 'a', 'b')).toBe(150_000);
+    expect(mockedGetStopSeconds).toHaveBeenCalledWith('7', 'a', 'b');
+  });
+});
+
+describe('hopTimeMsAt', () => {
+  beforeEach(() => mockedGetStopSeconds.mockReset());
+
+  it('returns segment lookup for valid arc fromIdx', () => {
+    mockedGetStopSeconds.mockReturnValue(120);
+    expect(hopTimeMsAt(ARC, 0, '7')).toBe(120_000);
+    expect(mockedGetStopSeconds).toHaveBeenCalledWith('7', 'a', 'b');
+  });
+
+  it('returns HOP_TIME_MS fallback for negative fromIdx', () => {
+    expect(hopTimeMsAt(ARC, -1, '7')).toBe(HOP_TIME_MS);
+    expect(mockedGetStopSeconds).not.toHaveBeenCalled();
+  });
+
+  it('returns HOP_TIME_MS fallback at arc end (fromIdx === length - 1)', () => {
+    expect(hopTimeMsAt(ARC, ARC.length - 1, '7')).toBe(HOP_TIME_MS);
+    expect(mockedGetStopSeconds).not.toHaveBeenCalled();
+  });
+});
+
+describe('hopsElapsedFrom', () => {
+  const arcLen = 5;
+  const uniform = (_idx: number) => HOP_TIME_MS;
+
+  it('returns 0 for elapsed <= 0 (zero and negative)', () => {
+    expect(hopsElapsedFrom(arcLen, 0, 0, uniform)).toBe(0);
+    expect(hopsElapsedFrom(arcLen, 0, -1, uniform)).toBe(0);
+  });
+
+  it('returns floor(elapsed / HOP_TIME_MS) for uniform hop times', () => {
+    expect(hopsElapsedFrom(arcLen, 0, HOP_TIME_MS, uniform)).toBe(1);
+    expect(hopsElapsedFrom(arcLen, 0, HOP_TIME_MS * 2.5, uniform)).toBe(2);
+  });
+
+  it('accumulates segment-specific hop times (variable lookup)', () => {
+    const variable = (idx: number) => (idx === 0 ? 60_000 : 120_000);
+    // anchor=0, elapsed=180_000 → hop 0(60s) + hop 1(120s) = 180s, hops=2
+    expect(hopsElapsedFrom(arcLen, 0, 180_000, variable)).toBe(2);
+  });
+
+  it('uses HOP_TIME_MS fallback for hops beyond arc end (over-terminal grace)', () => {
+    // anchor=arcLen-1, cursor >= len-1 분기 → fallback HOP_TIME_MS로 계속 카운트
+    // elapsed = 3 * HOP_TIME_MS → hops=3 (종착 cap+grace 검사가 트리거되도록 정직히 누적)
+    expect(hopsElapsedFrom(arcLen, arcLen - 1, HOP_TIME_MS * 3, uniform)).toBe(3);
+  });
+
+  it('breaks when next partial hop would exceed elapsedMs (floor semantics)', () => {
+    expect(hopsElapsedFrom(arcLen, 0, HOP_TIME_MS - 1, uniform)).toBe(0);
+  });
+});

--- a/src/utils/__tests__/stationProgressEstimator.test.ts
+++ b/src/utils/__tests__/stationProgressEstimator.test.ts
@@ -6,6 +6,11 @@ import type { BoardingLock } from '../../types/boardingLock';
 import type { Station } from '../../types/station';
 import type { TrainProgressResult } from '../trackTrainProgress';
 
+// 기존 테스트들이 HOP_TIME_MS uniform 가정을 그대로 사용 — Stage 3에서도 estimator의 시간 적분
+// 로직 회귀를 검증하려면 동일한 시간 단위가 필요. lookup closure로 감싸 시그니처만 신규 형태로 맞춘다.
+// Strategy ③④의 segment별 누적 회귀는 별도 describe(Stage 3) 블록에서 가변 hop time으로 검증.
+const UNIFORM_HOP = (_fromIdx: number) => HOP_TIME_MS;
+
 const ARC: Station[] = [
   { id: '7-001', name: '용마산', line: '7', lineColor: '#x', lat: 0, lng: 0 },
   { id: '7-002', name: '중곡', line: '7', lineColor: '#x', lat: 0, lng: 0 },
@@ -78,7 +83,7 @@ describe('estimateStationProgress', () => {
           trainProgress: null,
           lockedTrainCode: null,
           lastObserved: null,
-          hopTimeMs: HOP_TIME_MS,
+          hopTimeMsForHop: UNIFORM_HOP,
           ...NO_ARRIVAL_INPUT,
         }),
       ).toBeNull();
@@ -93,7 +98,7 @@ describe('estimateStationProgress', () => {
           trainProgress: null,
           lockedTrainCode: '7093',
           lastObserved: null,
-          hopTimeMs: HOP_TIME_MS,
+          hopTimeMsForHop: UNIFORM_HOP,
           ...NO_ARRIVAL_INPUT,
         }),
       ).toBeNull();
@@ -110,7 +115,7 @@ describe('estimateStationProgress', () => {
           trainProgress: null,
           lockedTrainCode: '7093',
           lastObserved: null,
-          hopTimeMs: HOP_TIME_MS,
+          hopTimeMsForHop: UNIFORM_HOP,
           ...NO_ARRIVAL_INPUT,
         }),
       ).toBeNull();
@@ -126,7 +131,7 @@ describe('estimateStationProgress', () => {
         trainProgress: makeTrainProgress({ stationIdx: 2 }),
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
       expect(r).toEqual({
@@ -137,7 +142,7 @@ describe('estimateStationProgress', () => {
     });
 
     it('lockedTrainCode null이면 LivePosition skip', () => {
-      // lockedTrainCode 없으면 매칭 불가 → ReanchoredHop fallback (lastObserved도 없으니 boarding 앵커)
+      // lockedTrainCode 없으면 매칭 불가 → ③ skip(lastObs null) → ④ DefaultHop이 boardedAt 앵커로 fallback.
       const r = estimateStationProgress({
         lock: makeLock(),
         arcStations: ARC,
@@ -145,10 +150,10 @@ describe('estimateStationProgress', () => {
         trainProgress: makeTrainProgress({ stationIdx: 2 }),
         lockedTrainCode: null,
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
       expect(r?.station).toBe(ARC[0]); // boarding 앵커, elapsed=0
     });
 
@@ -160,10 +165,10 @@ describe('estimateStationProgress', () => {
         trainProgress: makeTrainProgress({ trainNo: '9999', stationIdx: 2 }),
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
       expect(r?.station).toBe(ARC[0]);
     });
 
@@ -183,10 +188,10 @@ describe('estimateStationProgress', () => {
         trainProgress: makeTrainProgress({ currentStation: offArc }),
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
     });
 
     it('trainProgress null이면 LivePosition skip', () => {
@@ -197,10 +202,10 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
     });
   });
 
@@ -215,7 +220,7 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 2, observedAtMs: observedAt },
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
       expect(r).toEqual({
@@ -225,25 +230,8 @@ describe('estimateStationProgress', () => {
       });
     });
 
-    it('lastObserved 없으면 boardedAt + boardingIdx 앵커로 fallback', () => {
-      const r = estimateStationProgress({
-        lock: makeLock(),
-        arcStations: ARC,
-        now: T0 + HOP_TIME_MS,
-        trainProgress: null,
-        lockedTrainCode: '7093',
-        lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
-        ...NO_ARRIVAL_INPUT,
-      });
-      expect(r).toEqual({
-        station: ARC[1],
-        index: 1,
-        strategy: 'reanchored-hop',
-      });
-    });
-
-    it('lastObserved 시각이 미래(시계 후진)면 ReanchoredHop skip → null', () => {
+    it('lastObserved 시각이 미래(시계 후진)면 ReanchoredHop skip → ④ DefaultHop fallback', () => {
+      // ③ skip(시계 후진) → ④에서 boardedAt 기준 elapsed=0이므로 idx=0(boarding).
       const r = estimateStationProgress({
         lock: makeLock(),
         arcStations: ARC,
@@ -251,28 +239,15 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 2, observedAtMs: T0 + 1_000 },
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
-      expect(r).toBeNull();
+      expect(r?.strategy).toBe('default-hop');
+      expect(r?.station).toBe(ARC[0]);
     });
 
-    it('boardedAt fallback 케이스에서 boardingStationId가 arc에 없으면 null', () => {
-      const r = estimateStationProgress({
-        lock: makeLock({ boardingStationId: '9-999' }),
-        arcStations: ARC,
-        now: T0,
-        trainProgress: null,
-        lockedTrainCode: '7093',
-        lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
-        ...NO_ARRIVAL_INPUT,
-      });
-      expect(r).toBeNull();
-    });
-
-    it('lastObserved.arcIndex가 범위 밖이면 boardedAt fallback', () => {
-      // lastObserved.arcIndex가 arc 길이보다 크면 잘못된 값 → boardedAt fallback으로 안전 복구
+    it('lastObserved.arcIndex가 범위 밖이면 ④ DefaultHop으로 fallback', () => {
+      // ③은 안전을 위해 범위 밖 lastObserved는 skip → ④가 boardedAt 앵커로 fallback.
       const r = estimateStationProgress({
         lock: makeLock(),
         arcStations: ARC,
@@ -280,15 +255,16 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 99, observedAtMs: T0 },
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
       expect(r?.station).toBe(ARC[1]); // boardingIdx(0) + 1 hop
     });
 
-    it('종착역 초과 cap + grace 초과 시 null', () => {
-      // 종착역 cap 후 grace 이상은 lock release 신호 → null
+    it('종착역 초과 cap + grace 초과 시 ③ null', () => {
+      // ③에서 종착역 cap+grace 초과 검출 → null. ④도 동일 boardedAt 기준이면 동일 결과지만, 본 케이스는
+      // lastObserved가 이미 cap 직전이라 ④의 boardedAt 적분과 분리해 검증한다.
       const lock = makeLock({ expectedDurationMs: 100 * HOP_TIME_MS });
       const observedAt = T0;
       const r = estimateStationProgress({
@@ -298,7 +274,7 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 0, observedAtMs: observedAt },
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
       expect(r).toBeNull();
@@ -315,7 +291,7 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 0, observedAtMs: observedAt },
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
       expect(r).toEqual({
@@ -323,6 +299,90 @@ describe('estimateStationProgress', () => {
         index: 4,
         strategy: 'reanchored-hop',
       });
+    });
+  });
+
+  describe('Strategy ④ DefaultHop — boardedAt + boardingStationId 앵커 (Stage 3/#779)', () => {
+    it('lastObserved 없으면 boardedAt + boardingIdx 앵커로 fallback', () => {
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0 + HOP_TIME_MS,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toEqual({
+        station: ARC[1],
+        index: 1,
+        strategy: 'default-hop',
+      });
+    });
+
+    it('boardingStationId가 arc에 없으면 ④ null', () => {
+      const r = estimateStationProgress({
+        lock: makeLock({ boardingStationId: '9-999' }),
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
+    it('boardedAt이 미래(시계 후진)면 ④ null', () => {
+      // now < boardedAt → elapsed < 0 → ④ null.
+      const lock = makeLock({ boardedAt: T0 + 60_000 });
+      const r = estimateStationProgress({
+        lock,
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
+    it('종착역 cap+grace 초과 시 ④ null', () => {
+      const lock = makeLock({ expectedDurationMs: 100 * HOP_TIME_MS });
+      const r = estimateStationProgress({
+        lock,
+        arcStations: ARC,
+        now: T0 + 100 * HOP_TIME_MS,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
+    it('segment별 hop time이 다르면 누적 시간 기준으로 hop 산정 (ADR-008 §④)', () => {
+      // lookup이 idx에 따라 가변 — 0→1: 60s, 1→2: 60s, 2→3: 120s, 3→4: 60s.
+      // elapsed=150s → 0+1(60s 소비) → 1+1(120s 소비) → 다음 hop 120s는 30s만 남아 stop. hops=2.
+      const variableHop = (fromIdx: number) =>
+        fromIdx === 2 ? 120_000 : 60_000;
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        arcStations: ARC,
+        now: T0 + 150_000,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMsForHop: variableHop,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r?.strategy).toBe('default-hop');
+      expect(r?.index).toBe(2);
     });
   });
 
@@ -336,7 +396,7 @@ describe('estimateStationProgress', () => {
         trainProgress: null, // ① stale
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 2, observedAtMs: T0 - 10_000 }, // ③도 가능하지만 ②가 우선
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [
           makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 14 }),
         ],
@@ -358,7 +418,7 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [
           makeArrival({ arrivalCode: ARRIVAL_CODE.PREV_ARRIVED, arrivalSeconds: 45 }),
         ],
@@ -382,7 +442,7 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 1, observedAtMs: observedAt },
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [
           makeArrival({
             arrivalCode: ARRIVAL_CODE.ENTERING,
@@ -395,7 +455,7 @@ describe('estimateStationProgress', () => {
       expect(r?.strategy).toBe('reanchored-hop');
     });
 
-    it('currentIdxHint null → ② skip → ReanchoredHop fallback', () => {
+    it('currentIdxHint null → ② skip → ③ lastObs null이라 ④ DefaultHop fallback', () => {
       const r = estimateStationProgress({
         lock: makeLock(),
         arcStations: ARC,
@@ -403,17 +463,17 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [
           makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 14 }),
         ],
         arrivalEtaTtlMs: ARRIVAL_TTL_MS,
         currentIdxHint: null,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
     });
 
-    it('lockedTrainCode null → ② skip(trainCode 매칭 불가) → ReanchoredHop', () => {
+    it('lockedTrainCode null → ② skip → ④ DefaultHop', () => {
       const r = estimateStationProgress({
         lock: makeLock(),
         arcStations: ARC,
@@ -421,17 +481,17 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: null,
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [
           makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING }),
         ],
         arrivalEtaTtlMs: ARRIVAL_TTL_MS,
         currentIdxHint: 2,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
     });
 
-    it('nextStationArrivals 빈 배열 → ② skip → ReanchoredHop', () => {
+    it('nextStationArrivals 빈 배열 → ② skip → ④ DefaultHop', () => {
       const r = estimateStationProgress({
         lock: makeLock(),
         arcStations: ARC,
@@ -439,15 +499,15 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [],
         arrivalEtaTtlMs: ARRIVAL_TTL_MS,
         currentIdxHint: 2,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
     });
 
-    it('trainCode 미일치 → ② skip → ReanchoredHop', () => {
+    it('trainCode 미일치 → ② skip → ④ DefaultHop', () => {
       const r = estimateStationProgress({
         lock: makeLock(),
         arcStations: ARC,
@@ -455,14 +515,14 @@ describe('estimateStationProgress', () => {
         trainProgress: null,
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [
           makeArrival({ trainCode: '9999', arrivalCode: ARRIVAL_CODE.ENTERING }),
         ],
         arrivalEtaTtlMs: ARRIVAL_TTL_MS,
         currentIdxHint: 2,
       });
-      expect(r?.strategy).toBe('reanchored-hop');
+      expect(r?.strategy).toBe('default-hop');
     });
   });
 
@@ -476,7 +536,7 @@ describe('estimateStationProgress', () => {
         trainProgress: makeTrainProgress({ stationIdx: 1 }), // LivePosition: idx 1
         lockedTrainCode: '7093',
         lastObserved: { arcIndex: 3, observedAtMs: observedAt }, // ReanchoredHop이 가능했다면 더 앞쪽
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
       // LivePosition 우선 — strategy='live-position', index=1.
@@ -495,7 +555,7 @@ describe('estimateStationProgress', () => {
         trainProgress: makeTrainProgress({ stationIdx: 1 }),
         lockedTrainCode: '7093',
         lastObserved: null,
-        hopTimeMs: HOP_TIME_MS,
+        hopTimeMsForHop: UNIFORM_HOP,
         nextStationArrivals: [
           makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 10 }),
         ],

--- a/src/utils/hopTime.ts
+++ b/src/utils/hopTime.ts
@@ -1,0 +1,82 @@
+import { getStopSeconds } from './stationRoute';
+import { HOP_TIME_MS } from '../constants/boardingLock';
+import type { LineNumber, Station } from '../types/station';
+
+/**
+ * ADR-008 Stage 3(#779) — hop time 데이터 룩업.
+ *
+ * `HOP_TIME_MS = 90_000` 매직넘버는 BoardingProgress estimator(③ ReanchoredHop / ④ DefaultHop)에서
+ * 시간 적분 기준값으로 쓰였으나 서울 지하철 실측은 노선·구간별 60~270초 분포 → ±45초 hop 편향이
+ * 누적되어 "현재역이 1~2개역 앞서감"의 한 축이 되었다(ADR-008 §② 참조).
+ *
+ * 본 모듈은 `src/data/stationTravelTimes.json`(#655 도입, 서울 열린데이터 StationDstncReqreTimeHm)을
+ * `getStopSeconds`로 룩업해 ms 단위 hop time을 돌려준다. 데이터 미커버 노선/구간(9호선/공항철도/
+ * 경의중앙선 등)은 `getStopSeconds` 내부에서 120s fallback이지만, estimator는 더 보수적인
+ * 90s(`HOP_TIME_MS`) graceful fallback이 필요한 케이스(예: arc 경계 밖)도 있어 본 모듈에서
+ * 케이스별로 분리한다.
+ *
+ * 데이터 보강은 별도 트랙(9호선 급행 등) — 본 PR scope 아님.
+ */
+
+/**
+ * line의 fromId → toId 단일 hop을 ms로 반환.
+ * `getStopSeconds`가 데이터 미스 시 `STOP_FALLBACK_SECONDS = 120` 반환 — 노선별 평균 보강은 후속.
+ */
+export function hopTimeMsForSegment(line: LineNumber, fromId: string, toId: string): number {
+  return getStopSeconds(line, fromId, toId) * 1000;
+}
+
+/**
+ * arcStations 위 `fromIdx`에서 다음 역으로의 hop time(ms). arc 경계(`fromIdx`가 마지막 인덱스
+ * 또는 음수)이거나 인접 두 역의 line이 다르면 `HOP_TIME_MS` graceful fallback.
+ *
+ * estimator의 ReanchoredHop / DefaultHop이 시간 적분 시 매 hop마다 호출 — segment별 누적으로
+ * "uniform 90s/hop" 대신 실측 가중 hop으로 흐름.
+ *
+ * line 인자: arc는 BoardingLock 1개 leg(단일 노선) 위에서 생성되므로 lock.boardingLine을 사용한다.
+ * 호출자는 lock으로부터 line을 추출해 전달 — 본 함수는 line 결정에 관여하지 않는다(SRP).
+ *
+ * 두 fallback의 의도적 분리:
+ *  - 경계 fallback = `HOP_TIME_MS`(90s) — estimator over-terminal grace의 종착 cap+grace 산식과 정렬.
+ *  - mid-arc 데이터 미스 = `STOP_FALLBACK_SECONDS`(120s, getStopSeconds 내부) — 노선 평균 보강 전 보수치.
+ */
+export function hopTimeMsAt(arcStations: readonly Station[], fromIdx: number, line: LineNumber): number {
+  if (fromIdx < 0 || fromIdx >= arcStations.length - 1) return HOP_TIME_MS;
+  const from = arcStations[fromIdx];
+  const to = arcStations[fromIdx + 1];
+  return hopTimeMsForSegment(line, from.id, to.id);
+}
+
+/**
+ * `anchorIdx`에서 출발해 `elapsedMs` 안에 통과한 hop 수. segment별 hop time을 누적한다 —
+ * uniform `Math.floor(elapsedMs / HOP_TIME_MS)` 대체.
+ *
+ * elapsedMs ≤ 0이면 0(시계 후진은 호출자가 별도 판정). 다음 hop의 누적 시간이 elapsedMs를 초과하면
+ * 거기서 멈춘다 — `floor` 의미 보존.
+ *
+ * `hopTimeMsForHop`은 `(fromIdx) => ms` closure. estimator가 `lock.boardingLine`을 캡슐화한 closure를
+ * 주입하므로 본 함수는 line 결정에 관여하지 않는다(SRP). 테스트에서는 monkeypatch가 쉬워진다.
+ *
+ * arc 끝을 넘는 hop(`fromIdx >= arcLength - 1`)도 `HOP_TIME_MS` 기본값으로 카운트한다 — 호출자(estimator)
+ * 가 종착 cap+grace 검사에서 "정상 trip 종료 후 추가로 흐른 hop"을 식별하려면 hops 카운트가 정직하게
+ * 누적되어야 한다(arc 끝에서 멈추면 cap이 트리거되지 않는다).
+ */
+export function hopsElapsedFrom(
+  arcLength: number,
+  anchorIdx: number,
+  elapsedMs: number,
+  hopTimeMsForHop: (fromIdx: number) => number,
+): number {
+  if (elapsedMs <= 0) return 0;
+  let consumed = 0;
+  let hops = 0;
+  let cursor = anchorIdx;
+  while (consumed < elapsedMs) {
+    const stepMs = cursor < arcLength - 1 ? hopTimeMsForHop(cursor) : HOP_TIME_MS;
+    if (consumed + stepMs > elapsedMs) break;
+    consumed += stepMs;
+    hops++;
+    cursor++;
+  }
+  return hops;
+}

--- a/src/utils/stationProgressEstimator.ts
+++ b/src/utils/stationProgressEstimator.ts
@@ -3,6 +3,7 @@ import type { ArrivalInfo } from '../api/arrivalApi';
 import type { Station } from '../types/station';
 import type { TrainProgressResult } from './trackTrainProgress';
 import { projectArrivalEtaStation } from './arrivalEtaProjection';
+import { hopsElapsedFrom } from './hopTime';
 
 /**
  * ADR-008 — 탑승 진행 추정(BoardingLock 활성 trip 중 현재역) 합성기.
@@ -11,14 +12,21 @@ import { projectArrivalEtaStation } from './arrivalEtaProjection';
  *  ① LivePosition   — realtimePosition으로 lock.trainCode 직접 발견 → 그 statnId (drift=0)
  *  ② ArrivalEta     — 다음 역 arrival에서 trainCode 발견 → arrivalSeconds로 ETA 투영 (Stage 2/#740)
  *  ③ ReanchoredHop  — ①②가 마지막으로 본 (역, 시각)에 재앵커 — 최대 1 hop만 적분
- *  ④ DefaultHop     — 노선/세그먼트 hop time 테이블 (Stage 3/#624)
+ *  ④ DefaultHop     — `lock.boardedAt + boardingStationId` 앵커 + segment별 hop time 테이블 (Stage 3/#779)
  *
- * Stage 1(#739)은 ①③. Stage 2(#745)에서 ②(projectArrivalEtaStation 합성) 도입. ④는 Stage 3까지
- * 명시적 빈 스텁으로 자리만 잡는다 — 후속 stage에서 채우면 그대로 합성 우선순위에 끼어든다(OCP).
+ * Stage 1(#739)은 ①③. Stage 2(#745)에서 ②(projectArrivalEtaStation 합성) 도입.
+ * Stage 3(#779)에서 ④ 구현 — `lock.boardedAt` 앵커가 살아있을 때만 도달(lastObserved 부재 케이스).
+ * ③/④ 모두 segment별 hop time을 `hopsElapsedFrom`으로 누적해 uniform 90s 가정을 제거(ADR-008 §④).
  *
- * 핵심 변경: 기존 `interpolateBoardingLockStation`은 `lock.boardedAt`을 시작 앵커로 N hop을 통째로
- * 적분 → 보간이 메꾸는 구간이 trip 전체였다. ReanchoredHop은 마지막 실관측 `(arcIndex, observedAtMs)`에
+ * 핵심 변경(Stage 1): 기존 `interpolateBoardingLockStation`은 `lock.boardedAt`을 시작 앵커로 N hop을
+ * 통째로 적분 → 보간이 메꾸는 구간이 trip 전체였다. ReanchoredHop은 마지막 실관측 `(arcIndex, observedAtMs)`에
  * 재앵커 → 폴링 간격(5초)마다 앵커가 갱신되므로 보간 구간이 최대 1 hop으로 줄어든다. (ADR-008 §③)
+ *
+ * Stage 3 변경(#779): `hopTimeMs` 단일 매직넘버 → `hopTimeMsForHop(fromIdx)` 룩업으로 시그니처 전환.
+ * `lock.boardingLine` 기준 `stationTravelTimes.json`(#655) 룩업, 미커버 노선/구간은 `hopTime.ts` 안에서
+ * 90s graceful fallback. ReanchoredHop과 DefaultHop의 책임을 명시적으로 분리:
+ *   - ReanchoredHop: lastObserved가 유효할 때만 동작(없으면 null)
+ *   - DefaultHop:    lastObserved 부재 시 `(boardedAt, boardingStationId)` 앵커로 fallback
  */
 
 /** estimator 입력 — Stage 2/3에서 ArrivalEta/HopTimeTable 신호 주입 시 입력 필드만 추가하면 된다. */
@@ -43,8 +51,14 @@ export interface StationProgressEstimatorInput {
    * 호출 측이 ref로 관리해 trainProgress 매칭이 끊긴 후에도 직전 관측을 보존한다.
    */
   lastObserved: { arcIndex: number; observedAtMs: number } | null;
-  /** Strategy ③④에서 사용할 hop 시간(ms). Stage 1은 HOP_TIME_MS 패스스루, Stage 3에서 lookup. */
-  hopTimeMs: number;
+  /**
+   * Strategy ③④에서 사용할 hop 시간 lookup. arc 위 `fromIdx`에서 다음 역으로의 hop ms를 반환.
+   *
+   * Stage 3(#779) — uniform `HOP_TIME_MS` 매직넘버를 segment별 lookup으로 대체.
+   * 호출자는 `lock.boardingLine`을 캡슐화한 closure를 전달한다(`(idx) => hopTimeMsAt(arc, idx, line)`).
+   * arc 경계/미커버 노선은 `hopTime.ts` 내부에서 `HOP_TIME_MS` graceful fallback.
+   */
+  hopTimeMsForHop: (fromIdx: number) => number;
   /**
    * Strategy ② 입력 (#745) — `arcStations[currentIdxHint + 1]` 역의 ArrivalInfo 목록.
    * `projectArrivalEtaStation`이 row별로 trainCode 매칭 + 신선도 필터링을 수행하므로 호출자는
@@ -136,54 +150,74 @@ function tryArrivalEta(
 }
 
 /**
- * Strategy ③ — lastObserved(또는 fallback으로 boardedAt+boardingIdx)에 재앵커 + 시간 적분.
+ * `anchorIdx`에서 `elapsedMs` 동안 segment별 hop time을 누적해 산출한 현재 arc 인덱스.
  *
- * 핵심: lastObserved가 있으면 `(observedAtMs, arcIndex)` 앵커, 없으면 `(boardedAt, boardingIdx)`.
+ * 시계 후진(elapsedMs < 0)이나 종착역 cap+grace 초과 시 null. cap 이내면 종착역으로 saturate.
+ * ReanchoredHop/DefaultHop이 공유 — anchor 종류(lastObserved vs boardedAt)만 다르고 시간 적분 로직은 동일.
+ */
+function projectIndexByHopTime(
+  arcStations: Station[],
+  anchorIdx: number,
+  elapsedMs: number,
+  hopTimeMsForHop: (fromIdx: number) => number,
+): number | null {
+  if (elapsedMs < 0) return null;
+  const hops = hopsElapsedFrom(arcStations.length, anchorIdx, elapsedMs, hopTimeMsForHop);
+  const lastIdx = arcStations.length - 1;
+  if (anchorIdx + hops > lastIdx + OVER_TERMINAL_GRACE_HOPS) return null;
+  return Math.min(anchorIdx + hops, lastIdx);
+}
+
+/**
+ * Strategy ③ — `lastObserved`(LivePosition 직전 관측)에 재앵커 + segment별 hop time 누적.
+ *
+ * lastObserved가 없거나 arc 범위 밖이면 본 전략 skip → 다음 전략(④ DefaultHop)에서 boardedAt fallback.
  * lastObserved는 LivePosition이 살아있던 동안 갱신되므로 보간 구간이 폴링 1회분(최대 1 hop)으로 제한된다.
  *
- * 시계 후진(now < anchorTs)이나 종착역 cap+grace 초과 시 null.
- *
- * 상위 가드(lock null, arc 비어있음, lock 만료)는 estimateStationProgress에서 차단되므로 여기서는
- * 시그니처에 lock 비-null만 명시(NonNullable) — 호출부와 함께 점검할 수 있도록 비공개 헬퍼로 유지.
+ * Stage 3(#779): 시간 적분이 segment별 실측 hop time(`hopTimeMsForHop`)을 사용 — 9호선 급행처럼
+ * 데이터가 없는 노선/구간은 lookup 내부에서 graceful 90s fallback.
  */
 function tryReanchoredHop(
-  input: StationProgressEstimatorInput & { lock: BoardingLock },
+  input: StationProgressEstimatorInput,
 ): StationProgressEstimate | null {
-  const { lock, arcStations, now, lastObserved, hopTimeMs } = input;
+  const { arcStations, now, lastObserved, hopTimeMsForHop } = input;
+  if (!lastObserved) return null;
+  if (lastObserved.arcIndex < 0 || lastObserved.arcIndex >= arcStations.length) return null;
 
-  let anchorIdx: number;
-  let anchorTs: number;
-  // lastObserved가 arc 범위를 벗어나면(잘못된 값) boardedAt fallback으로 안전 복구.
-  if (
-    lastObserved &&
-    lastObserved.arcIndex >= 0 &&
-    lastObserved.arcIndex < arcStations.length
-  ) {
-    anchorIdx = lastObserved.arcIndex;
-    anchorTs = lastObserved.observedAtMs;
-  } else {
-    const boardingIdx = arcStations.findIndex((s) => s.id === lock.boardingStationId);
-    if (boardingIdx === -1) return null;
-    anchorIdx = boardingIdx;
-    anchorTs = lock.boardedAt;
-  }
-
-  const elapsed = now - anchorTs;
-  if (elapsed < 0) return null;
-
-  const hopsElapsed = Math.floor(elapsed / hopTimeMs);
-  const lastIdx = arcStations.length - 1;
-  if (anchorIdx + hopsElapsed > lastIdx + OVER_TERMINAL_GRACE_HOPS) return null;
-  const idx = Math.min(anchorIdx + hopsElapsed, lastIdx);
+  const idx = projectIndexByHopTime(
+    arcStations,
+    lastObserved.arcIndex,
+    now - lastObserved.observedAtMs,
+    hopTimeMsForHop,
+  );
+  if (idx === null) return null;
   return { station: arcStations[idx], index: idx, strategy: 'reanchored-hop' };
 }
 
-/** Strategy ④ — Stage 3/#624에서 채울 예정. line/segment별 hop time 데이터 테이블 fallback. */
+/**
+ * Strategy ④ — `lock.boardedAt + lock.boardingStationId` 앵커 + segment별 hop time 누적.
+ *
+ * ①②③ 모두 fallback된 dead zone에서만 도달 (lastObserved도 없는 상태). Stage 3(#779)에서 ADR-008 §④
+ * "per-line/segment 데이터 테이블"을 구현 — uniform 90s 가정 제거.
+ *
+ * 상위 가드(lock null, arc 비어있음, lock 만료)는 estimateStationProgress에서 차단되므로
+ * 시그니처에 lock 비-null만 명시(NonNullable).
+ */
 function tryDefaultHop(
-  _input: StationProgressEstimatorInput,
+  input: StationProgressEstimatorInput & { lock: BoardingLock },
 ): StationProgressEstimate | null {
-  // Stage 3/#624 — HOP_TIME_TABLE lookup으로 line/segment별 정밀 hop time 대체.
-  return null;
+  const { lock, arcStations, now, hopTimeMsForHop } = input;
+  const boardingIdx = arcStations.findIndex((s) => s.id === lock.boardingStationId);
+  if (boardingIdx === -1) return null;
+
+  const idx = projectIndexByHopTime(
+    arcStations,
+    boardingIdx,
+    now - lock.boardedAt,
+    hopTimeMsForHop,
+  );
+  if (idx === null) return null;
+  return { station: arcStations[idx], index: idx, strategy: 'default-hop' };
 }
 
 /**
@@ -201,8 +235,8 @@ export function arcIndexOfStation(
 /**
  * 4단 전략을 우선순위대로 시도. 처음 채택된 전략의 결과를 반환.
  *
- * Stage 2(#745) 기준 ①(LivePosition) → ②(ArrivalEta) → ③(ReanchoredHop) → ④(스텁) 순.
- * ④는 후속 stage에서 채워지면 자연스레 끼어든다(OCP).
+ * Stage 3(#779) 기준 ①(LivePosition) → ②(ArrivalEta) → ③(ReanchoredHop) → ④(DefaultHop) 순.
+ * ③은 `lastObserved` 유효 시만 동작, ④는 `lock.boardedAt + boardingStationId` 앵커로 fallback.
  */
 export function estimateStationProgress(
   input: StationProgressEstimatorInput,
@@ -212,13 +246,14 @@ export function estimateStationProgress(
   if (arcStations.length === 0) return null;
   if (isBoardingLockExpired(lock, now)) return null;
 
-  // tryLivePosition은 lock과 무관 — trainProgress.trainNo === lockedTrainCode만 검사.
-  // tryReanchoredHop은 lock에 의존하므로 비-null 시그니처로 좁힌다.
+  // tryLivePosition/ArrivalEta/ReanchoredHop은 lock에 직접 의존하지 않으나 estimateStationProgress가
+  // 이미 lock 비-null을 보장해 호출 트리 전체가 active trip context. tryDefaultHop만 lock.boardedAt/
+  // boardingStationId를 사용하므로 시그니처에 명시(NonNullable)한다.
   const lockedInput = { ...input, lock };
   return (
     tryLivePosition(input) ??
     tryArrivalEta(input) ??
-    tryReanchoredHop(lockedInput) ??
-    tryDefaultHop(input)
+    tryReanchoredHop(input) ??
+    tryDefaultHop(lockedInput)
   );
 }


### PR DESCRIPTION
## Summary
- ADR-008 Stage 3 — `HOP_TIME_MS` 90s 매직넘버를 segment별 lookup으로 전환
- `tryDefaultHop` 실구현 (스텁 제거), ReanchoredHop과 함께 `projectIndexByHopTime` 공유 헬퍼 사용
- `stationTravelTimes.json` (#655) 기반 lookup → 노선/구간 추가 시 코드 수정 0
- 종착 초과 hop은 `HOP_TIME_MS`로 가상 카운트 → over-terminal grace 검사 의미 보존

## Test plan
- [x] hopTime 룩업 단위 테스트 (9 케이스)
- [x] tryDefaultHop / ReanchoredHop segment 누적 회귀 테스트
- [x] over-terminal grace 의미 보존 검증
- [x] 2771/2771 pass, coverage 100%
- [x] type-check 통과

## Out of scope
- `boardingLockScheduler.ts`의 `HOP_TIME_MS` 사용(line 15/26/154) — 알람 발사 시각 계산. 본 PR 머지 후 별도 follow-up. `hopTime.ts`의 public API가 이미 재사용 가능.

## Stacked
- base: dev (독립 트랙, #780 #776/#777/#778 ETA 시리즈와 별개)

Closes #779