### PR TITLE
feat(#777): 다음 열차 대기 시간을 arrival API 기반 동적값으로 전환

### DIFF
--- a/src/constants/eta.ts
+++ b/src/constants/eta.ts
@@ -1,0 +1,3 @@
+// 도보 평균 속도(m/s). 공공데이터포털 환승 소요시간(15044419)이 사용하는 1.2 m/s와 동일 기준.
+// calculateStaticETA의 출발/도착 walking 시간 합산에 사용.
+export const WALKING_SPEED_M_PER_S = 1.2;

--- a/src/constants/eta.ts
+++ b/src/constants/eta.ts
@@ -1,3 +1,8 @@
 // 도보 평균 속도(m/s). 공공데이터포털 환승 소요시간(15044419)이 사용하는 1.2 m/s와 동일 기준.
 // calculateStaticETA의 출발/도착 walking 시간 합산에 사용.
 export const WALKING_SPEED_M_PER_S = 1.2;
+
+// arrival API freshness TTL(ms). 60s 이상 지난 도착 정보는 stale로 간주하고
+// DEFAULT_WAIT_MINUTES fallback을 사용한다. silentPushTask의 POSITION_TRAIN_TTL_MS와 정렬 — Strategy
+// ①(LivePosition) 신선도와 같은 임계를 사용해 사용자에 노출되는 ETA 채택 경계가 자연스럽게 흐른다.
+export const ARRIVAL_FRESHNESS_MS = 60_000;

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -264,6 +264,19 @@ describe('processLocationUpdate', () => {
     );
   });
 
+  // #776: 도보 시간 합산을 위해 currentLocation/originStation을 calculateStaticETA에 전달.
+  it('calculateStaticETA에 currentLocation(GPS)과 originStation(nearest 좌표)을 전달한다', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+
+    await call();
+
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(mockRoute, {
+      currentLocation: { lat: 37.498, lng: 127.028 },
+      originStation: { lat: mockStation.lat, lng: mockStation.lng },
+    });
+  });
+
   it('passes alarmEvent to updateStationNotification only when sleepMode is true', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
@@ -345,7 +358,7 @@ describe('processLocationUpdate', () => {
 
     expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
     expect(mockFindRoute).not.toHaveBeenCalled();
-    expect(mockCalculateStaticETA).toHaveBeenCalledWith(updatedRoute);
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(updatedRoute, expect.any(Object));
   });
 
   it('calls findRoute when no storedRoute is provided', async () => {

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -430,6 +430,102 @@ describe('calculateStaticETA', () => {
   });
 });
 
+describe('calculateStaticETA — 도보 시간 합산 (#776)', () => {
+  // 0.0009도 차이 ≈ 100m, 도보 1.2 m/s 기준 83.3초 ≈ 1.4분 → round(1.4)=1분
+  const userNearOrigin = { lat: 37.5, lng: 127.0 };
+  const originStationCoords = { lat: 37.5009, lng: 127.0 };
+  // 0.0065도 차이 ≈ 723m, 도보 1.2 m/s 기준 602초 ≈ 10.04분 → round(10.04)=10분
+  const destinationStationCoords = { lat: 37.6, lng: 127.0 };
+  const userFarFromDestStation = { lat: 37.6065, lng: 127.0 };
+
+  it('options 미지정 시 기존 동작 그대로 (도보 0분)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(calculateStaticETA(route)).toBe(13); // 3 + 10 + 0
+  });
+
+  it('currentLocation + originStation 페어로 출발 도보 시간을 합산한다', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 13(기존) + round(1.4)=1 → 14분
+    expect(
+      calculateStaticETA(route, {
+        currentLocation: userNearOrigin,
+        originStation: originStationCoords,
+      }),
+    ).toBe(14);
+  });
+
+  it('destination + destinationStation 페어로 하차 도보 시간을 합산한다', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 13(기존) + round(10.04)=10 → 23분
+    expect(
+      calculateStaticETA(route, {
+        destinationStation: destinationStationCoords,
+        destination: userFarFromDestStation,
+      }),
+    ).toBe(23);
+  });
+
+  it('출발 + 하차 도보 시간을 모두 합산한다', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 13 + 1(출발) + 10(하차) = 24분
+    expect(
+      calculateStaticETA(route, {
+        currentLocation: userNearOrigin,
+        originStation: originStationCoords,
+        destinationStation: destinationStationCoords,
+        destination: userFarFromDestStation,
+      }),
+    ).toBe(24);
+  });
+
+  it('currentLocation만 있고 originStation 누락이면 출발 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { currentLocation: userNearOrigin }),
+    ).toBe(13);
+  });
+
+  it('originStation만 있고 currentLocation 누락이면 출발 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { originStation: originStationCoords }),
+    ).toBe(13);
+  });
+
+  it('destination만 있고 destinationStation 누락이면 하차 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { destination: userFarFromDestStation }),
+    ).toBe(13);
+  });
+
+  it('destinationStation만 있고 destination 누락이면 하차 도보=0 (graceful fallback)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, { destinationStation: destinationStationCoords }),
+    ).toBe(13);
+  });
+
+  it('동일 좌표면 도보=0 (현위치가 출발역과 같은 점)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, {
+        currentLocation: originStationCoords,
+        originStation: originStationCoords,
+      }),
+    ).toBe(13);
+  });
+
+  it('route가 null이면 options 있어도 null 반환', () => {
+    expect(
+      calculateStaticETA(null, {
+        currentLocation: userNearOrigin,
+        originStation: originStationCoords,
+      }),
+    ).toBeNull();
+  });
+});
+
 describe('환승역별 실측 환승시간 반영', () => {
   // CSV 출처: 공공데이터포털 15044419 (보행속도 1.2 m/s 기준)
   // 교대(2↔3) 63초 vs 잠실(8↔2) 158초 — 같은 stops여도 travelMinutes 차이 발생

--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -526,6 +526,103 @@ describe('calculateStaticETA — 도보 시간 합산 (#776)', () => {
   });
 });
 
+describe('calculateStaticETA — 다음 열차 대기 동적화 (#777)', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('arrivalAtOrigin fresh이면 arrivalSeconds(분)를 대기로 사용', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // arrivalSeconds=120 → 2분, travel=10, walking=0 → 12분
+    expect(
+      calculateStaticETA(route, {
+        arrivalAtOrigin: { arrivalSeconds: 120, receivedAtMs: NOW - 10_000 },
+        nowMs: NOW,
+      }),
+    ).toBe(12);
+  });
+
+  it('arrivalSeconds가 크면 대기도 길어진다 (5분)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // arrivalSeconds=300 → 5분, total 15분
+    expect(
+      calculateStaticETA(route, {
+        arrivalAtOrigin: { arrivalSeconds: 300, receivedAtMs: NOW },
+        nowMs: NOW,
+      }),
+    ).toBe(15);
+  });
+
+  it('arrivalSeconds=0 (열차 방금 도착)이면 대기 0분', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 0 + 10 + 0 = 10
+    expect(
+      calculateStaticETA(route, {
+        arrivalAtOrigin: { arrivalSeconds: 0, receivedAtMs: NOW },
+        nowMs: NOW,
+      }),
+    ).toBe(10);
+  });
+
+  it('arrivalAtOrigin stale(>60s)이면 DEFAULT_WAIT_MINUTES fallback', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 60_001ms 경과 → stale, fallback 3분
+    expect(
+      calculateStaticETA(route, {
+        arrivalAtOrigin: { arrivalSeconds: 120, receivedAtMs: NOW - 60_001 },
+        nowMs: NOW,
+      }),
+    ).toBe(13);
+  });
+
+  it('receivedAtMs=0 (mock/누락 컨벤션)이면 DEFAULT_WAIT_MINUTES fallback', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, {
+        arrivalAtOrigin: { arrivalSeconds: 120, receivedAtMs: 0 },
+        nowMs: NOW,
+      }),
+    ).toBe(13);
+  });
+
+  it('arrivalSeconds 음수(비정상)이면 DEFAULT_WAIT_MINUTES fallback', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(
+      calculateStaticETA(route, {
+        arrivalAtOrigin: { arrivalSeconds: -1, receivedAtMs: NOW },
+        nowMs: NOW,
+      }),
+    ).toBe(13);
+  });
+
+  it('arrival + walking 동시 합산', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    const userNearOrigin = { lat: 37.5, lng: 127.0 };
+    const originStationCoords = { lat: 37.5009, lng: 127.0 }; // 도보 ~1.4분 → round 1
+    // wait=2(arrival 120s) + travel=10 + walk=1 = 13
+    expect(
+      calculateStaticETA(route, {
+        currentLocation: userNearOrigin,
+        originStation: originStationCoords,
+        arrivalAtOrigin: { arrivalSeconds: 120, receivedAtMs: NOW },
+        nowMs: NOW,
+      }),
+    ).toBe(13);
+  });
+
+  it('nowMs 미지정 시 Date.now() 사용', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    try {
+      expect(
+        calculateStaticETA(route, {
+          arrivalAtOrigin: { arrivalSeconds: 120, receivedAtMs: NOW - 10_000 },
+        }),
+      ).toBe(12);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe('환승역별 실측 환승시간 반영', () => {
   // CSV 출처: 공공데이터포털 15044419 (보행속도 1.2 m/s 기준)
   // 교대(2↔3) 63초 vs 잠실(8↔2) 158초 — 같은 stops여도 travelMinutes 차이 발생

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -110,6 +110,12 @@ export interface ProcessLocationInputs {
   fusionSource?: FusionSource;
   /** GPS 게이트 실패 등으로 위치가 불확실한 상태. true면 source를 무시하고 'uncertain' 라벨. */
   locationUncertain?: boolean;
+  /**
+   * #777 — 출발역(nearest.station)의 다음 열차 도착 정보. arrival API에서 추출.
+   * 호출자가 제공하면 calculateStaticETA가 동적 대기 시간으로 사용, 미제공 시 DEFAULT_WAIT_MINUTES fallback.
+   * 호출자(BG/FG) 통합은 점진적으로 진행 — 본 옵션이 없어도 회귀 없음.
+   */
+  arrivalAtOrigin?: { arrivalSeconds: number; receivedAtMs: number };
 }
 
 export async function processLocationUpdate(inputs: ProcessLocationInputs): Promise<PipelineResult> {
@@ -125,6 +131,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     source,
     fusionSource,
     locationUncertain = false,
+    arrivalAtOrigin,
   } = inputs;
 
   const notificationSource = fusionSource
@@ -242,9 +249,11 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   // #776: 도보 시간 합산. nearest.station을 출발역으로, 사용자 GPS(lat/lng)를 currentLocation으로.
   // 하차 도보는 미적용 — 현 시점 데이터 모델은 destination이 Station(=하차역)으로 사용자 최종 좌표와
   // 일치하므로 도보 0이 자명. 사용자 좌표를 별도로 보유하게 되면 destination/destinationStation 추가.
+  // #777: arrivalAtOrigin 호출자가 제공 시 calculateStaticETA가 다음 열차 대기를 동적으로 계산.
   const eta = calculateStaticETA(route, {
     currentLocation: { lat, lng },
     originStation: { lat: nearest.station.lat, lng: nearest.station.lng },
+    arrivalAtOrigin,
   });
   await updateStationNotification(
     nearest.station,

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -239,7 +239,13 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     }
   }
 
-  const eta = calculateStaticETA(route);
+  // #776: 도보 시간 합산. nearest.station을 출발역으로, 사용자 GPS(lat/lng)를 currentLocation으로.
+  // 하차 도보는 미적용 — 현 시점 데이터 모델은 destination이 Station(=하차역)으로 사용자 최종 좌표와
+  // 일치하므로 도보 0이 자명. 사용자 좌표를 별도로 보유하게 되면 destination/destinationStation 추가.
+  const eta = calculateStaticETA(route, {
+    currentLocation: { lat, lng },
+    originStation: { lat: nearest.station.lat, lng: nearest.station.lng },
+  });
   await updateStationNotification(
     nearest.station,
     Math.round(nearest.distanceKm * 1000),

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -3,10 +3,12 @@ import stationTravelTimesJson from '../data/stationTravelTimes.json';
 import transferTimes from '../data/transferTimes.json';
 import type { Station } from '../types/station';
 import { LINE_COLORS } from '../constants/lineColors';
+import { WALKING_SPEED_M_PER_S } from '../constants/eta';
 import type { LineNumber } from '../types/station';
 import { applyStationAlias } from '../data/stationAliases';
 import { createLogger } from './logger';
 import { normalizeStationName as baseNormalizeStationName } from './normalizeStationName';
+import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
 
 const logger = createLogger('StationRoute');
 
@@ -742,9 +744,62 @@ function getTravelMinutes(route: NonNullable<Route>): number {
   return Math.round(totalSeconds / 60);
 }
 
-export function calculateStaticETA(route: Route): number | null {
+/** lat/lng만 추출한 좌표 — Station 전체를 넘기지 않아 결합도를 낮춘다. */
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * calculateStaticETA에 도보 시간을 합산하기 위한 옵션. 누락된 페어는 walking=0으로
+ * graceful fallback (예: 위치 권한 미확보 시 currentLocation만 빠질 수 있음).
+ *
+ * - currentLocation + originStation 둘 다 있으면 출발 도보 시간 합산
+ * - destination + destinationStation 둘 다 있으면 하차 도보 시간 합산
+ */
+export interface StaticEtaWalkingOptions {
+  /** 사용자 현재 위치(GPS). originStation과 함께 있을 때 출발역까지 도보 시간 계산. */
+  currentLocation?: LatLng;
+  /** 경로의 출발 지하철역 좌표. currentLocation 없으면 미사용. */
+  originStation?: LatLng;
+  /** 사용자 최종 목적지(예: 사무실 좌표). destinationStation과 함께 있을 때 하차 도보 시간 계산. */
+  destination?: LatLng;
+  /** 경로의 하차 지하철역 좌표. destination 없으면 미사용. */
+  destinationStation?: LatLng;
+}
+
+// 한 페어(사용자 좌표 + 역 좌표)의 도보 시간(분). 누락 시 0.
+// estimateEtaSeconds를 재사용하되, 보행은 항상 WALKING_SPEED_M_PER_S(=1.2) 위쪽이라 null이 될 일이 없다.
+function calculateWalkingMinutes(from: LatLng | undefined, to: LatLng | undefined): number {
+  if (!from || !to) return 0;
+  const distM = distanceMetersBetween(from.lat, from.lng, to.lat, to.lng);
+  // WALKING_SPEED_M_PER_S(=1.2) >= MIN_VALID_SPEED_MPS(=0.5) 이므로 항상 number 반환.
+  // 타입 narrowing을 위해 ?? 0 — 향후 상수 변경 시 회귀 차단.
+  /* istanbul ignore next -- WALKING_SPEED_M_PER_S > MIN_VALID_SPEED_MPS 불변식상 null 경로 도달 불가 */
+  const seconds = estimateEtaSeconds(distM, WALKING_SPEED_M_PER_S) ?? 0;
+  return seconds / 60;
+}
+
+/**
+ * 경로 정적 ETA(분). 기본 대기 + 지하철 운행/환승 + (옵션) 출발/도착 도보 시간.
+ *
+ * - route=null이면 null
+ * - options 미지정 시 기존 동작 그대로 (도보 0분)
+ * - 페어가 부분적으로 누락되면 해당 도보 시간만 0 (예: currentLocation은 있는데 originStation이 없으면
+ *   출발 도보 0 — 사용자 위치 권한 미확보 등 부분 정보 상황에서 graceful fallback)
+ *
+ * 반환은 분 단위 정수 — 호출처(메인 ETA 카운터/알림 body 등)가 정수를 전제로 한다.
+ * 지하철 시간은 getTravelMinutes에서 이미 분 단위 정수, 도보 합계는 여기서 한 번 round 해 더한다.
+ */
+export function calculateStaticETA(
+  route: Route,
+  options: StaticEtaWalkingOptions = {},
+): number | null {
   if (!route) return null;
-  return DEFAULT_WAIT_MINUTES + getTravelMinutes(route);
+  const walkingMinutes =
+    calculateWalkingMinutes(options.currentLocation, options.originStation) +
+    calculateWalkingMinutes(options.destinationStation, options.destination);
+  return DEFAULT_WAIT_MINUTES + getTravelMinutes(route) + Math.round(walkingMinutes);
 }
 
 /**

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -3,7 +3,7 @@ import stationTravelTimesJson from '../data/stationTravelTimes.json';
 import transferTimes from '../data/transferTimes.json';
 import type { Station } from '../types/station';
 import { LINE_COLORS } from '../constants/lineColors';
-import { WALKING_SPEED_M_PER_S } from '../constants/eta';
+import { WALKING_SPEED_M_PER_S, ARRIVAL_FRESHNESS_MS } from '../constants/eta';
 import type { LineNumber } from '../types/station';
 import { applyStationAlias } from '../data/stationAliases';
 import { createLogger } from './logger';
@@ -713,6 +713,9 @@ export function buildJourneyDisplay(
   return { segments, totalStops };
 }
 
+// 출발역 다음 열차 대기 시간 fallback(분). arrivalAtOrigin이 없거나 stale일 때 사용.
+// 평시 평균값에 가깝지만 첨두/심야 편차로 실측과 2~7분 차이 가능 — #777에서 arrival 동적값으로
+// 전환했고 본 상수는 데이터 부재 시 회귀 방지 fallback 역할.
 const DEFAULT_WAIT_MINUTES = 3;
 
 // 반환값은 항상 정수 분. 호출처(메인 ETA 카운터/알림 body/Live Activity etaMinutes Swift Int? 디코딩)가
@@ -751,13 +754,17 @@ export interface LatLng {
 }
 
 /**
- * calculateStaticETA에 도보 시간을 합산하기 위한 옵션. 누락된 페어는 walking=0으로
- * graceful fallback (예: 위치 권한 미확보 시 currentLocation만 빠질 수 있음).
+ * calculateStaticETA 옵션. 누락된 필드는 graceful fallback(도보=0, 대기=DEFAULT_WAIT_MINUTES).
  *
+ * 도보 (#776):
  * - currentLocation + originStation 둘 다 있으면 출발 도보 시간 합산
  * - destination + destinationStation 둘 다 있으면 하차 도보 시간 합산
+ *
+ * 대기 (#777):
+ * - arrivalAtOrigin이 있고 freshness(60s) 통과 → arrivalSeconds를 분으로 환산해 사용
+ * - 없거나 stale → DEFAULT_WAIT_MINUTES fallback
  */
-export interface StaticEtaWalkingOptions {
+export interface StaticEtaOptions {
   /** 사용자 현재 위치(GPS). originStation과 함께 있을 때 출발역까지 도보 시간 계산. */
   currentLocation?: LatLng;
   /** 경로의 출발 지하철역 좌표. currentLocation 없으면 미사용. */
@@ -766,6 +773,14 @@ export interface StaticEtaWalkingOptions {
   destination?: LatLng;
   /** 경로의 하차 지하철역 좌표. destination 없으면 미사용. */
   destinationStation?: LatLng;
+  /**
+   * 출발역의 다음 열차 도착 정보. realtimePosition/arrival API에서 추출.
+   * `receivedAtMs <= 0`이거나 `nowMs - receivedAtMs > ARRIVAL_FRESHNESS_MS`이면 stale로 간주.
+   * 누락 또는 stale 시 DEFAULT_WAIT_MINUTES fallback (회귀 없음).
+   */
+  arrivalAtOrigin?: { arrivalSeconds: number; receivedAtMs: number };
+  /** freshness 계산용 현재 시각(ms). 미지정 시 Date.now() — 테스트에서 monkeypatch. */
+  nowMs?: number;
 }
 
 // 한 페어(사용자 좌표 + 역 좌표)의 도보 시간(분). 누락 시 0.
@@ -780,26 +795,42 @@ function calculateWalkingMinutes(from: LatLng | undefined, to: LatLng | undefine
   return seconds / 60;
 }
 
+// arrivalAtOrigin이 fresh하면 arrivalSeconds(초)를 분으로, 아니면 DEFAULT_WAIT_MINUTES.
+// 게이트: receivedAtMs<=0(mock/누락), 나이>ARRIVAL_FRESHNESS_MS(stale), arrivalSeconds<0(비정상).
+function resolveWaitMinutes(
+  arrivalAtOrigin: StaticEtaOptions['arrivalAtOrigin'],
+  nowMs: number,
+): number {
+  if (!arrivalAtOrigin) return DEFAULT_WAIT_MINUTES;
+  const { arrivalSeconds, receivedAtMs } = arrivalAtOrigin;
+  if (receivedAtMs <= 0) return DEFAULT_WAIT_MINUTES;
+  if (nowMs - receivedAtMs > ARRIVAL_FRESHNESS_MS) return DEFAULT_WAIT_MINUTES;
+  if (arrivalSeconds < 0) return DEFAULT_WAIT_MINUTES;
+  return arrivalSeconds / 60;
+}
+
 /**
- * 경로 정적 ETA(분). 기본 대기 + 지하철 운행/환승 + (옵션) 출발/도착 도보 시간.
+ * 경로 정적 ETA(분). 다음 열차 대기 + 지하철 운행/환승 + (옵션) 출발/도착 도보 시간.
  *
  * - route=null이면 null
- * - options 미지정 시 기존 동작 그대로 (도보 0분)
+ * - options 미지정 시 기존 동작과 동치 (도보 0, 대기 DEFAULT_WAIT_MINUTES) — 회귀 없음
  * - 페어가 부분적으로 누락되면 해당 도보 시간만 0 (예: currentLocation은 있는데 originStation이 없으면
  *   출발 도보 0 — 사용자 위치 권한 미확보 등 부분 정보 상황에서 graceful fallback)
+ * - arrivalAtOrigin fresh → arrivalSeconds 동적 사용, 없거나 stale → DEFAULT_WAIT_MINUTES
  *
  * 반환은 분 단위 정수 — 호출처(메인 ETA 카운터/알림 body 등)가 정수를 전제로 한다.
- * 지하철 시간은 getTravelMinutes에서 이미 분 단위 정수, 도보 합계는 여기서 한 번 round 해 더한다.
+ * 지하철 시간은 getTravelMinutes에서 이미 분 단위 정수, 대기/도보 합은 여기서 한 번 round 해 더한다.
  */
 export function calculateStaticETA(
   route: Route,
-  options: StaticEtaWalkingOptions = {},
+  options: StaticEtaOptions = {},
 ): number | null {
   if (!route) return null;
   const walkingMinutes =
     calculateWalkingMinutes(options.currentLocation, options.originStation) +
     calculateWalkingMinutes(options.destinationStation, options.destination);
-  return DEFAULT_WAIT_MINUTES + getTravelMinutes(route) + Math.round(walkingMinutes);
+  const waitMinutes = resolveWaitMinutes(options.arrivalAtOrigin, options.nowMs ?? Date.now());
+  return Math.round(waitMinutes) + getTravelMinutes(route) + Math.round(walkingMinutes);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `calculateStaticETA`의 `DEFAULT_WAIT_MINUTES = 3` 고정값 → `arrivalAtOrigin` fresh이면 동적, 아니면 fallback
- silentPushTask와 동일한 60s freshness TTL 정렬 (`ARRIVAL_FRESHNESS_MS`)
- `StaticEtaWalkingOptions` → `StaticEtaOptions` rename (walking + arrival 통합 옵션)
- 3중 게이트: `receivedAtMs<=0` (mock/누락) / 나이>60s (stale) / `arrivalSeconds<0` (비정상)
- 회귀 없음: `arrivalAtOrigin` 미제공 시 기존 `DEFAULT_WAIT_MINUTES` fallback

## Stacked
- 본 PR diff에 #776 변경 포함 — 머지 순서: #780(#776) → #781(#779) → 본 PR
- #780 머지 후 자동 rebase로 diff 자연 축소
- base: dev

## Test plan
- [x] arrival fresh/stale/누락/edge 시나리오 9 단위 테스트 추가
- [x] `nowMs` DI 패턴 + `Date.now()` spy 케이스
- [x] 2778/2778 pass, coverage 100%
- [x] type-check 통과

## Out of scope (follow-up)
- BG/FG 호출자(`backgroundLocationTask.ts`, `app/(tabs)/index.tsx`)에서 실제 arrival 전달 — 점진적 통합
- 후속 PR에서 결정: `useArrivalCountdown` 출력 vs raw arrival row 선택 (리뷰 P2-1)

Closes #777