### PR TITLE
feat(#778): 환승역에서 다음 열차 대기 시간 별도 합산

### DIFF
--- a/src/utils/__tests__/stationRoute.test.ts
+++ b/src/utils/__tests__/stationRoute.test.ts
@@ -409,8 +409,8 @@ describe('calculateStaticETA', () => {
       stopsToTransfer: 1,
       stopsFromTransfer: 5,
     });
-    // 3분 대기 + round(12 + 63/60) = 3 + 13 = 16분
-    expect(calculateStaticETA(route)).toBe(16);
+    // 출발 3분 대기 + 환승 leg 3분 대기(#778) + round(12 + 63/60)=13 = 19분
+    expect(calculateStaticETA(route)).toBe(19);
   });
 
   it('MultiTransferRoute일 때 기본대기3분 + 환승별 실측 시간 합산을 반환한다', () => {
@@ -421,8 +421,8 @@ describe('calculateStaticETA', () => {
       ],
       stopsAfterLastTransfer: 4,
     });
-    // 3분 대기 + round(24 + 242/60) = 3 + 28 = 31분
-    expect(calculateStaticETA(route)).toBe(31);
+    // 출발 3분 + 환승 2 leg × 3분(#778) + round(24 + 242/60)=28 = 37분
+    expect(calculateStaticETA(route)).toBe(37);
   });
 
   it('route가 null이면 null을 반환한다', () => {
@@ -657,8 +657,120 @@ describe('환승역별 실측 환승시간 반영', () => {
       ],
       stopsAfterLastTransfer: 3,
     });
-    // 3분 대기 + round((1+2+3)*2 + (63+133)/60) = 3 + round(15.2667) = 3 + 15 = 18분
-    expect(calculateStaticETA(route)).toBe(18);
+    // 출발 3분 + 환승 2 leg × 3분(#778) + round((1+2+3)*2 + (63+133)/60)=15 = 24분
+    expect(calculateStaticETA(route)).toBe(24);
+  });
+});
+
+describe('calculateStaticETA — 환승 후 다음 열차 대기 (#778)', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('TransferRoute에서 arrivalsAtTransfers[0] fresh이면 동적 대기로 사용', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    // 출발 3분(fallback) + 환승 leg 5분(arrivalSeconds=300) + travel 13 = 21
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: 300, receivedAtMs: NOW }],
+        nowMs: NOW,
+      }),
+    ).toBe(21);
+  });
+
+  it('MultiTransferRoute에서 각 leg마다 동적 합산', () => {
+    const route: MultiTransferRoute = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    });
+    // 출발 3분(fallback) + leg0 1분(60s) + leg1 2분(120s) + travel 28 = 34
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [
+          { arrivalSeconds: 60, receivedAtMs: NOW },
+          { arrivalSeconds: 120, receivedAtMs: NOW },
+        ],
+        nowMs: NOW,
+      }),
+    ).toBe(34);
+  });
+
+  it('일부 leg만 제공 시 누락 element는 leg당 DEFAULT_WAIT_MINUTES fallback', () => {
+    const route: MultiTransferRoute = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    });
+    // 출발 3분 + leg0 1분(60s) + leg1 3분(null → fallback) + travel 28 = 35
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: 60, receivedAtMs: NOW }, null],
+        nowMs: NOW,
+      }),
+    ).toBe(35);
+  });
+
+  it('arrivalsAtTransfers 빈 배열이면 leg마다 fallback (회귀 없음)', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    // 출발 3분 + 환승 3분(빈 배열 → undefined → fallback) + travel 13 = 19
+    expect(
+      calculateStaticETA(route, { arrivalsAtTransfers: [], nowMs: NOW }),
+    ).toBe(19);
+  });
+
+  it('DirectRoute에 arrivalsAtTransfers 전달해도 영향 없음 (transferCount=0)', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    // 출발 3분 + travel 10 = 13 (transferCount=0이라 배열 무시)
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: 600, receivedAtMs: NOW }],
+        nowMs: NOW,
+      }),
+    ).toBe(13);
+  });
+
+  it('stale element는 그 leg만 fallback', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    // 60_001ms 경과 → stale → fallback. 출발 3 + 환승 3 + travel 13 = 19
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: 300, receivedAtMs: NOW - 60_001 }],
+        nowMs: NOW,
+      }),
+    ).toBe(19);
+  });
+
+  it('합산 round 정책 — 개별 round했다면 +1되었을 케이스', () => {
+    const route: MultiTransferRoute = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '잠실', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    });
+    // 출발 3(fallback) + leg0 0.5(30s) + leg1 0.5(30s) = 4.0분 → round(4.0)=4
+    // 개별 round했다면 3 + 1 + 1 = 5 (잘못된 합산). 본 PR은 합산 후 round로 4.
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [
+          { arrivalSeconds: 30, receivedAtMs: NOW },
+          { arrivalSeconds: 30, receivedAtMs: NOW },
+        ],
+        nowMs: NOW,
+      }),
+    ).toBe(32); // wait 4 + travel 28
   });
 });
 

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -116,6 +116,11 @@ export interface ProcessLocationInputs {
    * 호출자(BG/FG) 통합은 점진적으로 진행 — 본 옵션이 없어도 회귀 없음.
    */
   arrivalAtOrigin?: { arrivalSeconds: number; receivedAtMs: number };
+  /**
+   * #778 — 각 환승역의 다음 열차 도착 정보 (transfer 순서). null/누락 element는 leg당 DEFAULT_WAIT_MINUTES fallback.
+   * 호출자가 환승 leg마다 arrival을 제공하면 calculateStaticETA가 동적으로 합산.
+   */
+  arrivalsAtTransfers?: ReadonlyArray<{ arrivalSeconds: number; receivedAtMs: number } | null>;
 }
 
 export async function processLocationUpdate(inputs: ProcessLocationInputs): Promise<PipelineResult> {
@@ -132,6 +137,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     fusionSource,
     locationUncertain = false,
     arrivalAtOrigin,
+    arrivalsAtTransfers,
   } = inputs;
 
   const notificationSource = fusionSource
@@ -250,10 +256,12 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   // 하차 도보는 미적용 — 현 시점 데이터 모델은 destination이 Station(=하차역)으로 사용자 최종 좌표와
   // 일치하므로 도보 0이 자명. 사용자 좌표를 별도로 보유하게 되면 destination/destinationStation 추가.
   // #777: arrivalAtOrigin 호출자가 제공 시 calculateStaticETA가 다음 열차 대기를 동적으로 계산.
+  // #778: arrivalsAtTransfers 호출자가 제공 시 환승 leg마다 동적, 미제공 시 leg당 DEFAULT_WAIT_MINUTES.
   const eta = calculateStaticETA(route, {
     currentLocation: { lat, lng },
     originStation: { lat: nearest.station.lat, lng: nearest.station.lng },
     arrivalAtOrigin,
+    arrivalsAtTransfers,
   });
   await updateStationNotification(
     nearest.station,

--- a/src/utils/stationRoute.ts
+++ b/src/utils/stationRoute.ts
@@ -779,6 +779,14 @@ export interface StaticEtaOptions {
    * 누락 또는 stale 시 DEFAULT_WAIT_MINUTES fallback (회귀 없음).
    */
   arrivalAtOrigin?: { arrivalSeconds: number; receivedAtMs: number };
+  /**
+   * #778 — 각 환승역의 다음 열차 도착 정보 (transfer 순서, 0 = 첫 환승).
+   * - transfer route: [0] 한 개
+   * - multi-transfer route: [0..transfers.length-1]
+   * - 누락된 element나 stale은 leg당 DEFAULT_WAIT_MINUTES fallback (회귀 없음)
+   * `transferTimes.json`은 도보만 포함 — 환승 후 다음 열차 대기는 본 필드로만 합산
+   */
+  arrivalsAtTransfers?: ReadonlyArray<{ arrivalSeconds: number; receivedAtMs: number } | null>;
   /** freshness 계산용 현재 시각(ms). 미지정 시 Date.now() — 테스트에서 monkeypatch. */
   nowMs?: number;
 }
@@ -809,28 +817,68 @@ function resolveWaitMinutes(
   return arrivalSeconds / 60;
 }
 
+// transfer 횟수: direct=0, transfer=1, multi-transfer=transfers.length.
+// exhaustive switch — 새 Route variant 추가 시 컴파일 시점에 누락 차단.
+function getTransferCount(route: NonNullable<Route>): number {
+  switch (route.type) {
+    case 'direct':
+      return 0;
+    case 'transfer':
+      return 1;
+    case 'multi-transfer':
+      return route.transfers.length;
+    /* istanbul ignore next — Route union이 exhaustive하므로 도달 불가, 새 variant 추가 시 컴파일 차단 */
+    default: {
+      const _exhaustive: never = route;
+      return _exhaustive;
+    }
+  }
+}
+
+// 환승 leg마다 fresh arrival이면 동적, 아니면 DEFAULT_WAIT_MINUTES — 합산해서 분으로 반환.
+// transferCount=0 (direct)이면 0. 누락 element는 fallback.
+function resolveTransferWaitMinutes(
+  arrivalsAtTransfers: StaticEtaOptions['arrivalsAtTransfers'],
+  transferCount: number,
+  nowMs: number,
+): number {
+  let total = 0;
+  for (let i = 0; i < transferCount; i++) {
+    total += resolveWaitMinutes(arrivalsAtTransfers?.[i] ?? undefined, nowMs);
+  }
+  return total;
+}
+
 /**
- * 경로 정적 ETA(분). 다음 열차 대기 + 지하철 운행/환승 + (옵션) 출발/도착 도보 시간.
+ * 경로 정적 ETA(분). 다음 열차 대기 + 지하철 운행/환승 + (옵션) 출발/도착 도보 + 환승 후 대기.
  *
  * - route=null이면 null
- * - options 미지정 시 기존 동작과 동치 (도보 0, 대기 DEFAULT_WAIT_MINUTES) — 회귀 없음
+ * - options 미지정 시 기존 동작 동치 (도보 0, 출발 대기 DEFAULT_WAIT_MINUTES, 환승 대기 leg당 DEFAULT_WAIT_MINUTES)
  * - 페어가 부분적으로 누락되면 해당 도보 시간만 0 (예: currentLocation은 있는데 originStation이 없으면
  *   출발 도보 0 — 사용자 위치 권한 미확보 등 부분 정보 상황에서 graceful fallback)
  * - arrivalAtOrigin fresh → arrivalSeconds 동적 사용, 없거나 stale → DEFAULT_WAIT_MINUTES
+ * - #778: arrivalsAtTransfers[i] fresh → 해당 환승 leg wait 동적, 없거나 stale → leg당 DEFAULT_WAIT_MINUTES
  *
  * 반환은 분 단위 정수 — 호출처(메인 ETA 카운터/알림 body 등)가 정수를 전제로 한다.
- * 지하철 시간은 getTravelMinutes에서 이미 분 단위 정수, 대기/도보 합은 여기서 한 번 round 해 더한다.
+ * 지하철 시간은 getTravelMinutes에서 이미 분 단위 정수, 대기(출발+환승)는 합산해 한 번 round.
  */
 export function calculateStaticETA(
   route: Route,
   options: StaticEtaOptions = {},
 ): number | null {
   if (!route) return null;
+  const nowMs = options.nowMs ?? Date.now();
   const walkingMinutes =
     calculateWalkingMinutes(options.currentLocation, options.originStation) +
     calculateWalkingMinutes(options.destinationStation, options.destination);
-  const waitMinutes = resolveWaitMinutes(options.arrivalAtOrigin, options.nowMs ?? Date.now());
-  return Math.round(waitMinutes) + getTravelMinutes(route) + Math.round(walkingMinutes);
+  const originWaitMinutes = resolveWaitMinutes(options.arrivalAtOrigin, nowMs);
+  const transferWaitMinutes = resolveTransferWaitMinutes(
+    options.arrivalsAtTransfers,
+    getTransferCount(route),
+    nowMs,
+  );
+  const totalWaitMinutes = originWaitMinutes + transferWaitMinutes;
+  return Math.round(totalWaitMinutes) + getTravelMinutes(route) + Math.round(walkingMinutes);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `calculateStaticETA`에 `arrivalsAtTransfers` 옵션 추가 — 환승 leg마다 fresh arrival 시 동적 wait
- 미제공/stale element는 leg당 `DEFAULT_WAIT_MINUTES`(3분) fallback (회귀 없음)
- 출발 + 환승 대기 합산 후 한 번 round (누적 오차 제거)
- transfer 1회 +3분, multi-transfer N회 +3*N분 자동 정정

## 영향 분석
| 호출자 | 자동 영향 | 비고 |
|---|---|---|
| `stationPipeline.processLocationUpdate` | 옵션만 추가 (전달 안 함) | 회귀 없음 |
| `alarmScheduler.resolveFinalEtaSeconds` (fallback path) | transfer route는 +leg×3분 자동 합산 | **approachEta 미가용 시에만 발화** → 정정 |
| BG/FG 호출자에서 실제 arrival 전달 | 별도 follow-up | 점진적 통합 |

## Test plan
- [x] transfer/multi-transfer/누락/stale/direct/round 정책 시나리오 7건
- [x] 기존 transfer expected 값 정정 (16→19, 31→37, 18→24)
- [x] 2785/2785 pass, coverage 100%
- [x] type-check 통과

## Stacked
- base: dev (#776/#777 머지 후 diff 자동 정리)
- 시리즈 마지막 — 경로 ETA 정확도 P0→P1→P2 완료

Closes #778