### PR TITLE
refactor(#785): boardingLockScheduler HOP_TIME_MS → segment lookup

### DIFF
--- a/src/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/utils/__tests__/boardingLockScheduler.test.ts
@@ -159,7 +159,8 @@ describe('scheduleHopsForLock', () => {
   it('direct route: destination waypoint 1개를 예약, early+imminent 모두 발사', async () => {
     await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
 
-    // 2 stops * 90s = 180s; early lead = 90s, imminent lead = 45s → 둘 다 양수
+    // fixture STOP_FALLBACK_SECONDS=120 → travelSeconds=240s. arrival=NOW+240k.
+    // #785: early lead=240/2=120s, imminent lead=45s → 둘 다 양수 → 2회 예약.
     expect(mockedSchedule).toHaveBeenCalledTimes(2);
     expect(mockedAdd).toHaveBeenCalledWith([
       'bl:T-100:0:early:강남',
@@ -203,7 +204,8 @@ describe('scheduleHopsForLock', () => {
   });
 
   it('과거 시각으로 산출되는 알람은 skip — now가 충분히 진행된 경우', async () => {
-    // direct stops=2 → waypointEta=180s. now를 boardedAt + 200초로 잡으면 둘 다 음수.
+    // fixture 120s/stop → arrival=240s. early fires at 240−120=120s, imminent at 240−45=195s.
+    // now=NOW+200s → 두 fire time 모두 ≤200s → 둘 다 skip.
     await scheduleHopsForLock({
       lock,
       route: directRoute,
@@ -268,8 +270,7 @@ describe('scheduleHopsForLock', () => {
   });
 
   it('빈 targets은 storage write도 빈 배열', async () => {
-    // direct stops=0 → totalStops=0, but resolveAllTargets returns 1 entry with stops=0.
-    // waypointEta=0 → 모든 phase에서 fireSeconds <= 0 → 예약 안 됨.
+    // direct stops=0 → travelSeconds=0 → arrival=NOW. 모든 fire time ≤ NOW → 예약 안 됨.
     const zeroRoute: DirectRoute = makeDirectRoute(0, '2');
     await scheduleHopsForLock({ lock, route: zeroRoute, destinationName: '강남' });
     expect(mockedSchedule).not.toHaveBeenCalled();
@@ -510,6 +511,133 @@ describe('advanceHopWindow', () => {
     });
     // 매칭됐다면 hopIndex=0 cancel이 발생한다 — 매칭 실패였다면 no-op.
     expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:교대');
+  });
+});
+
+describe('#785 segment lookup 기반 timing', () => {
+  // 픽스처는 STOP_FALLBACK_SECONDS=120 사용 — 기존 uniform 90s 가정과 다름.
+  // 본 describe는 alarm 발사 시각이 route.secondsXxx(=getStopSeconds 누적 결과) 기반으로
+  // 산출되는지를 검증한다. ADR-008 Stage 3 estimator의 segment 누적값과 정렬됨을 보장.
+  function triggerMsByIdentifier(suffixMatcher: (id: string) => boolean): number {
+    const call = mockedSchedule.mock.calls.find((c) => {
+      const id = c[0].identifier ?? '';
+      return suffixMatcher(id);
+    });
+    if (!call) throw new Error('matching schedule call not found');
+    const trigger = call[0].trigger as { date: Date };
+    return trigger.date.getTime();
+  }
+
+  it('direct route: arrival = boardedAt + travelSeconds(누적), early lead = legSeconds/stops', async () => {
+    // directRoute(2 stops, travelSeconds=240): arrival = NOW + 240_000.
+    // early lead = 240/2 = 120s → fires at NOW + 120_000.
+    await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
+    expect(triggerMsByIdentifier((id) => id.includes(':early:'))).toBe(NOW + 120_000);
+  });
+
+  it('direct route: imminent은 45s 고정 lead', async () => {
+    await scheduleHopsForLock({ lock, route: directRoute, destinationName: '강남' });
+    // arrival NOW+240_000 − 45_000 = NOW+195_000.
+    expect(triggerMsByIdentifier((id) => id.includes(':imminent:'))).toBe(NOW + 195_000);
+  });
+
+  it('transfer route: hop[1] arrival = secondsToTransfer + secondsFromTransfer', async () => {
+    // transferRoute: stopsToTransfer=2(240s), stopsFromTransfer=3(360s).
+    // hop[0] 교대: arrival=NOW+240_000, lead=120s → fires NOW+120_000.
+    // hop[1] 오금: arrival=NOW+600_000, lead=360/3=120s → fires NOW+480_000.
+    await scheduleHopsForLock({ lock, route: transferRoute, destinationName: '오금' });
+    expect(triggerMsByIdentifier((id) => id.endsWith(':교대') && id.includes(':early:'))).toBe(
+      NOW + 120_000,
+    );
+    expect(triggerMsByIdentifier((id) => id.endsWith(':오금') && id.includes(':early:'))).toBe(
+      NOW + 480_000,
+    );
+  });
+
+  it('transfer route: leg 별 secondsPerStop이 다르면 lead도 다름', async () => {
+    // 의도적으로 leg별 비대칭. stops=2/3 + seconds=200/600 → leg avg = 100s / 200s.
+    const skewedTransfer = makeTransferRoute({
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    });
+    skewedTransfer.secondsToTransfer = 200;
+    skewedTransfer.secondsFromTransfer = 600;
+    await scheduleHopsForLock({ lock, route: skewedTransfer, destinationName: '오금' });
+    // hop[0]: arrival = NOW + 200_000. lead = 200/2 = 100s → fires NOW+100_000.
+    expect(triggerMsByIdentifier((id) => id.endsWith(':교대') && id.includes(':early:'))).toBe(
+      NOW + 100_000,
+    );
+    // hop[1]: arrival = NOW + 800_000. lead = 600/3 = 200s → fires NOW+600_000.
+    expect(triggerMsByIdentifier((id) => id.endsWith(':오금') && id.includes(':early:'))).toBe(
+      NOW + 600_000,
+    );
+  });
+
+  it('multi-transfer: 각 leg 누적 + leg별 lead 적용', async () => {
+    // multiRoute targets: 교대(2,240s), 약수(2,240s), 한강진(1,120s), 온수(2,240s). window=3.
+    await scheduleHopsForLock({ lock, route: multiRoute, destinationName: '온수' });
+    // 교대: arrival NOW+240k, lead 120s → NOW+120k.
+    expect(triggerMsByIdentifier((id) => id.endsWith(':교대') && id.includes(':early:'))).toBe(
+      NOW + 120_000,
+    );
+    // 약수: arrival NOW+480k, lead 120s → NOW+360k.
+    expect(triggerMsByIdentifier((id) => id.endsWith(':약수') && id.includes(':early:'))).toBe(
+      NOW + 360_000,
+    );
+    // 한강진: arrival NOW+600k, lead 120s(1 hop이라 leg 전체) → NOW+480k.
+    expect(triggerMsByIdentifier((id) => id.endsWith(':한강진') && id.includes(':early:'))).toBe(
+      NOW + 480_000,
+    );
+  });
+
+  it('multi-transfer: transferName === destinationName 케이스 첫 leg만 사용', async () => {
+    // 목적지가 첫 환승역과 같으면 targets는 첫 환승역 하나만 — secondsToTransfer 적용.
+    const collapsedMulti = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 2 },
+        { transferName: '약수', fromLine: '3', toLine: '6', stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 0,
+    });
+    await scheduleHopsForLock({ lock, route: collapsedMulti, destinationName: '교대' });
+    // hop[0] 교대(목적지): arrival = NOW + 240_000, lead 120s → NOW+120_000.
+    expect(triggerMsByIdentifier((id) => id.endsWith(':교대') && id.includes(':early:'))).toBe(
+      NOW + 120_000,
+    );
+  });
+
+  it('stops=0 leg은 lead가 HOP_TIME_MS(90s)로 fallback (division-by-zero 방지)', async () => {
+    // arrival>0 + stops=0인 경계 케이스(collapsed transfer + legSeconds>0)로 fallback 분기를
+    // 실제로 트리거해서 lead=HOP_TIME_MS(=90_000)임을 fire time으로 단언.
+    // legSeconds=120 → arrival=NOW+120_000. early lead=90_000 → fires NOW+30_000.
+    const collapsedZeroStops = makeTransferRoute({
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 0,
+      stopsFromTransfer: 0,
+    });
+    collapsedZeroStops.secondsToTransfer = 120;
+    await scheduleHopsForLock({ lock, route: collapsedZeroStops, destinationName: '교대' });
+    expect(triggerMsByIdentifier((id) => id.includes(':early:'))).toBe(NOW + 30_000);
+  });
+
+  it('advanceHopWindow도 새 timing(누적 secondsXxx)로 예약', async () => {
+    mockedGet.mockResolvedValueOnce([]);
+    await advanceHopWindow({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      passedStationName: '교대',
+    });
+    // 교대(0) 통과 → 약수(1)/한강진(2)/온수(3) 예약. 온수 arrival = 240+240+120+240 = 840s.
+    // lead 120s → fires NOW+720_000.
+    expect(triggerMsByIdentifier((id) => id.endsWith(':온수') && id.includes(':early:'))).toBe(
+      NOW + 720_000,
+    );
   });
 });
 

--- a/src/utils/boardingLockScheduler.ts
+++ b/src/utils/boardingLockScheduler.ts
@@ -23,17 +23,13 @@ export const BOARDING_LOCK_ALARM_PREFIX = 'bl:';
 // 생기면 src/constants/로 일괄 추출 — 현재는 surgical change 원칙상 PR D 진입 전 유지.
 const ALARM_CHANNEL_ID = 'station-alarm';
 
-const HOP_TIME_SECONDS = HOP_TIME_MS / 1000;
-
 /**
- * Phase별 lead time. #584 SLA 설계(2026-05-28):
- *  - early : 1정거장 전(=HOP_TIME) — barvlDt 60s 단위 ±30s 오차 흡수
- *  - imminent : 45초 전 — timeSensitive interruption으로 BG 발사 보장
+ * imminent phase의 고정 lead time(초). 45초 전 — timeSensitive interruption으로 BG 발사 보장.
+ *
+ * early는 #785부터 leg별 segment 평균(legSeconds / legStops)으로 동적 산출되어 노선/시간대별
+ * 실측 hop time에 정렬된다 — 별도 상수 없음. {@link computeHopTimings} 참조.
  */
-const PHASE_LEAD_SECONDS: Record<AlarmPhaseId, number> = {
-  early: HOP_TIME_SECONDS,
-  imminent: 45,
-};
+const IMMINENT_LEAD_MS = 45_000;
 
 /**
  * iOS interruption level mapping. early는 평소(active), imminent는 timeSensitive로
@@ -97,18 +93,23 @@ export function parseBoardingLockAlarmIdentifier(
  * 한 곳에서만 정의되도록 모은다.
  *
  * `arrivalMs - lead` 가 `observedMs` 이하면 해당 phase는 skip(과거 시각 가드).
+ *
+ * `earlyLeadMs`: 본 hop의 "1정거장 전" 시간(ms). 노선/구간별 hop time에 따라 다르며 호출자가
+ * {@link computeHopTimings}로 산출해 전달한다. imminent는 {@link IMMINENT_LEAD_MS} 고정.
  */
 async function scheduleSingleHop(params: {
   lock: BoardingLock;
   target: CurrentTarget;
   hopIndex: number;
   arrivalMs: number;
+  earlyLeadMs: number;
   observedMs: number;
 }): Promise<string[]> {
-  const { lock, target, hopIndex, arrivalMs, observedMs } = params;
+  const { lock, target, hopIndex, arrivalMs, earlyLeadMs, observedMs } = params;
   const ids: string[] = [];
   for (const phase of ALARM_PHASES) {
-    const fireMs = arrivalMs - PHASE_LEAD_SECONDS[phase.id] * 1000;
+    const leadMs = leadMsForPhase(phase.id, earlyLeadMs);
+    const fireMs = arrivalMs - leadMs;
     if (fireMs <= observedMs) continue;
     const event: AlarmEvent = {
       phaseId: phase.id,
@@ -141,17 +142,66 @@ async function scheduleSingleHop(params: {
   return ids;
 }
 
+interface HopTiming {
+  /** 절대 도착 시각(ms epoch). lock.boardedAt + 0..=hopIndex leg seconds 누적. */
+  arrivalMs: number;
+  /** 이 hop의 early phase lead(ms). leg 평균 hop time = legSeconds / legStops. */
+  earlyLeadMs: number;
+}
+
 /**
- * 누적 stops 기반 절대 도착 시각(ms). hopIndex까지 모든 target의 stops를 합산해 lock.boardedAt에 더한다.
+ * #785: 각 hop에 대해 (arrivalMs, earlyLeadMs)를 산출. route의 leg 별 실측 secondsXxx
+ * 필드(=getStopSeconds 누적 결과)를 그대로 사용 — uniform 90s 대신 segment lookup 기반.
+ *
+ * - arrivalMs: lock.boardedAt + 0..=hopIndex leg seconds 누적
+ * - earlyLeadMs: legSeconds / legStops (해당 leg의 평균 hop time). legStops=0이면
+ *   {@link HOP_TIME_MS} graceful fallback — 일반적으로 nondist destination collapse 케이스.
+ *
+ * 본 함수는 route의 secondsXxx 캐시값에만 의존 — station 시퀀스 워킹 없음. estimator의
+ * segment 누적값과 일치하는 alarm 시각을 제공한다(ADR-008 Stage 3 정렬).
  */
-function arrivalMsForHop(
+function computeHopTimings(
   lock: BoardingLock,
+  route: NonNullable<Route>,
   allTargets: CurrentTarget[],
+): HopTiming[] {
+  const timings: HopTiming[] = [];
+  let cumulativeMs = lock.boardedAt;
+  for (let i = 0; i < allTargets.length; i++) {
+    const target = allTargets[i];
+    const legSeconds = legSecondsAt(route, i, target.name);
+    const legMs = legSeconds * 1000;
+    cumulativeMs += legMs;
+    const earlyLeadMs = target.stops > 0 ? legMs / target.stops : HOP_TIME_MS;
+    timings.push({ arrivalMs: cumulativeMs, earlyLeadMs });
+  }
+  return timings;
+}
+
+/**
+ * leg 인덱스에 해당하는 route 필드에서 실측 운행 시간(초)을 꺼낸다.
+ * `resolveAllTargets`의 leg 매핑과 1:1 정렬되어야 한다 — 매핑이 바뀌면 함께 갱신.
+ *
+ * `targetName`은 transfer 분기에서만 사용(collapsed transfer 구별). direct/multi-transfer는
+ * route 필드 + hopIndex만으로 결정 — 호출자는 매번 `target.name`을 넘기지만 다른 분기에서는 ignore.
+ */
+function legSecondsAt(
+  route: NonNullable<Route>,
   hopIndex: number,
+  targetName: string,
 ): number {
-  let cumulativeStops = 0;
-  for (let i = 0; i <= hopIndex; i++) cumulativeStops += allTargets[i].stops;
-  return lock.boardedAt + cumulativeStops * HOP_TIME_SECONDS * 1000;
+  if (route.type === 'direct') return route.travelSeconds;
+  if (route.type === 'transfer') {
+    // target[0]은 항상 transferName과 같음(={transfer 또는 collapsed destination}). target[1]은 환승 후 destination.
+    if (isSameStationName(route.transferName, targetName)) return route.secondsToTransfer;
+    return route.secondsFromTransfer;
+  }
+  if (hopIndex < route.transfers.length) return route.transfers[hopIndex].secondsToTransfer;
+  return route.secondsAfterLastTransfer;
+}
+
+function leadMsForPhase(phaseId: AlarmPhaseId, earlyLeadMs: number): number {
+  return phaseId === 'early' ? earlyLeadMs : IMMINENT_LEAD_MS;
 }
 
 /**
@@ -218,6 +268,7 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
     params;
   const observedMs = now ?? lock.boardedAt;
   const allTargets = resolveAllTargets(route, destinationName);
+  const timings = computeHopTimings(lock, route, allTargets);
   const lastIdx = Math.min(windowSize, allTargets.length);
 
   const scheduledIds: string[] = [];
@@ -230,7 +281,8 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
       lock,
       target: allTargets[hopIndex],
       hopIndex,
-      arrivalMs: arrivalMsForHop(lock, allTargets, hopIndex),
+      arrivalMs: timings[hopIndex].arrivalMs,
+      earlyLeadMs: timings[hopIndex].earlyLeadMs,
       observedMs,
     });
     scheduledIds.push(...ids);
@@ -344,6 +396,7 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   );
 
   const observedMs = now ?? lock.boardedAt;
+  const timings = computeHopTimings(lock, route, allTargets);
   const scheduledIds: string[] = [];
   const windowEnd = Math.min(passedIndex + windowSize, allTargets.length - 1);
   for (let hopIndex = passedIndex + 1; hopIndex <= windowEnd; hopIndex++) {
@@ -364,7 +417,8 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
       lock,
       target: allTargets[hopIndex],
       hopIndex,
-      arrivalMs: arrivalMsForHop(lock, allTargets, hopIndex),
+      arrivalMs: timings[hopIndex].arrivalMs,
+      earlyLeadMs: timings[hopIndex].earlyLeadMs,
       observedMs,
     });
     scheduledIds.push(...ids);


### PR DESCRIPTION
## 배경

`boardingLockScheduler`가 alarm 발사 시각/early lead를 균일 `HOP_TIME_MS = 90s` 기준으로 산출해 왔다. 9호선 급행/공항철도 등 노선별 실측 hop time(60~270s)과의 편차가 ±N hop 오차를 누적시키는 한 원인. ADR-008 Stage 3(#779)에서 estimator는 이미 segment lookup으로 전환됐으나, scheduler 쪽 alarm 시각이 따라가지 못해 "estimator는 정확, alarm은 90s 균일"이라는 비대칭이 남아있었다.

## 변경 요약

- `HOP_TIME_SECONDS` 상수 제거, `IMMINENT_LEAD_MS = 45_000` 신설 (early는 leg별 동적)
- `computeHopTimings(lock, route, allTargets)` 신설 — 각 hop의 `{arrivalMs, earlyLeadMs}` 반환
  - `arrivalMs` = `lock.boardedAt + 0..=hopIndex leg seconds 누적`
  - `earlyLeadMs` = `legSeconds / legStops` (leg 평균 hop time). `legStops=0`이면 `HOP_TIME_MS` graceful fallback
- `legSecondsAt(route, hopIndex, targetName)` 신설 — route 타입별 leg 시간 추출 (direct/transfer/multi-transfer)
- `scheduleSingleHop`에 `earlyLeadMs` 인자 추가, phase별 lead는 `leadMsForPhase` 헬퍼로 분기
- `scheduleHopsForLock`/`advanceHopWindow` 양쪽이 동일 `computeHopTimings` 사용 — 두 경로 timing SSOT

## 핵심 설계

- **데이터 소스**: `route.travelSeconds`/`secondsToTransfer`/`secondsFromTransfer`/`secondsAfterLastTransfer`. 이 값들은 `getStopSeconds`(=`hopTimeMsForSegment / 1000`) 누적으로 채워지므로 의미상 segment lookup. station 시퀀스 walking 불필요 → fixture 호환성도 자연 보존
- **확장성**: `legSecondsAt`의 multi-transfer 분기는 `transfers.length` 기반 인덱스 매칭 — N번 환승까지 코드 수정 없이 확장
- **fallback**: `HOP_TIME_MS`는 scheduler 내부에서 `stops=0` 경계만 처리 (division-by-zero 방지). 데이터 미커버 segment는 `getStopSeconds` 내부 120s fallback이 흡수

## 사용자 영향

- 노선별 hop time 편차(특히 9호선 급행, 공항철도)로 인한 알람 발사 시각 ±N hop 오차 해소
- 데이터 미커버 노선/구간은 graceful fallback 유지 — 회귀 없음

## 검증

- 신규 테스트 8 케이스 (`#785 segment lookup 기반 timing` describe):
  - direct: arrival/early/imminent fire time 단언
  - transfer: hop[1] 누적 arrival, leg별 비대칭 lead
  - multi-transfer: leg별 누적 + leg별 lead, collapsed transferName === destinationName
  - stops=0 fallback (collapsed + legSeconds>0): early lead=HOP_TIME_MS임을 fire time으로 단언
  - advanceHopWindow도 동일 timing 사용
- 전체 테스트: 2805 passed
- 커버리지: 100% (lines/functions/branches/statements)
- type-check: 통과

## 자동 코드 리뷰 결과

- P1: 없음
- P2-1/P2-2/P2-4 본 PR 반영 완료 (stale 주석, stops=0 fallback 단언 강화, JSDoc 명시)
- P2-3 (`legSecondsAt`을 `stationRoute.ts` SSOT로 이동) / P3-3 (`IMMINENT_LEAD_MS` 상수 위치) — surgical 원칙으로 본 PR 제외, 후속 정리 대상

## Test plan

- [x] `npx jest src/utils/__tests__/boardingLockScheduler.test.ts` 통과
- [x] `npm test` 전체 통과 + 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 머지 후 실기기에서 alarm 발사 시각 검증 (#784와 함께 한 사이클로 진행)

Closes #785