### PR TITLE
feat(#784): 경로 ETA arrival 옵션을 FG 호출자에서 실제 전달

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import { useAppStore } from '../../src/store/useAppStore';
 import { useBoardingLockStore } from '../../src/store/useBoardingLockStore';
 import { DestinationPicker } from '../../src/components/DestinationPicker';
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../../src/utils/stationRoute';
+import { pickArrivalAtOrigin } from '../../src/utils/pickArrivalAtOrigin';
 import { EditorialTimeline } from '../../src/components/EditorialTimeline';
 import { journeyDisplayToStops, nearestResultToNearest } from '../../src/utils/journeyAdapter';
 import { useRouter } from 'expo-router';
@@ -194,7 +195,19 @@ export default function HomeScreen() {
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
     ? calculateETA(nextTrainMinutes, route)
     : null;
-  const staticEtaMinutes = route ? calculateStaticETA(route) : null;
+  // #784: rawArrival(useArrivalInfo)을 직접 사용 — useArrivalCountdown(1Hz tick)은 receivedAtMs를
+  // 원본으로 유지하면서 arrivalSeconds만 차감해 60s 후 항상 stale로 판정되는 회귀 회피(옵션 B).
+  // 분 단위 정수 ETA라 tick 미반영 영향 없음. arrivalsAtTransfers는 환승역별 폴링 인프라가 없어
+  // undefined — leg당 DEFAULT_WAIT_MINUTES fallback 유지.
+  const staticEtaMinutes = route
+    ? calculateStaticETA(route, {
+        currentLocation: userLocation ?? undefined,
+        originStation: effectiveOrigin
+          ? { lat: effectiveOrigin.lat, lng: effectiveOrigin.lng }
+          : undefined,
+        arrivalAtOrigin: pickArrivalAtOrigin(rawArrival),
+      })
+    : null;
   const isRealtimeEta = etaMinutes !== null && !arrivalIsMock && arrival !== null;
   const displayEta = isRealtimeEta ? etaMinutes : staticEtaMinutes;
 

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -116,6 +116,11 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
 
     // lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈을 통해
     // AsyncStorage에 직접 read/write 한다 (Foreground 훅과 단일 출처 공유).
+    //
+    // #784: arrivalAtOrigin / arrivalsAtTransfers를 BG에서 미전달 — calculateStaticETA는 DEFAULT_WAIT_MINUTES
+    // fallback으로 흐른다. FG의 arrivalCache는 in-memory TtlCache(useArrivalInfo)라 BG 프로세스에서
+    // 접근 불가하고, BG 전용 arrival 폴링은 OS quota 비용 대비 효익이 작다 — BG는 notification 본문
+    // ETA 한 곳만 갱신. AsyncStorage 캐시 경로는 측정 결과 BG 정확도 ↑ 효과가 확인되면 후속 도입.
     const { alarmEvent, nearest } = await processLocationUpdate({
       lat,
       lng,

--- a/src/utils/__tests__/pickArrivalAtOrigin.test.ts
+++ b/src/utils/__tests__/pickArrivalAtOrigin.test.ts
@@ -1,0 +1,126 @@
+import { pickArrivalAtOrigin } from '../pickArrivalAtOrigin';
+import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
+
+function makeArrival(
+  arrivalSeconds: number,
+  receivedAtMs: number,
+  trainCode = 'T-1',
+): ArrivalInfo {
+  return {
+    destination: 'dest',
+    arrivalMinutes: Math.floor(arrivalSeconds / 60),
+    arrivalSeconds,
+    statusMessage: '',
+    trainCode,
+    line: '2',
+    receivedAtMs,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+  };
+}
+
+describe('pickArrivalAtOrigin', () => {
+  it('arrival=null이면 undefined', () => {
+    expect(pickArrivalAtOrigin(null)).toBeUndefined();
+  });
+
+  it('isMock=true면 undefined (정책상 mock 명시 제외)', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(120, 1000)],
+      down: [makeArrival(60, 1000)],
+      isMock: true,
+    };
+    expect(pickArrivalAtOrigin(arrival)).toBeUndefined();
+  });
+
+  it('up/down 모두 비어있으면 undefined', () => {
+    const arrival: StationArrival = { up: [], down: [] };
+    expect(pickArrivalAtOrigin(arrival)).toBeUndefined();
+  });
+
+  it('up만 있고 정상 row면 그 값 반환', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(180, 1700_000_000_000)],
+      down: [],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toEqual({
+      arrivalSeconds: 180,
+      receivedAtMs: 1700_000_000_000,
+    });
+  });
+
+  it('down만 있고 정상 row면 그 값 반환', () => {
+    const arrival: StationArrival = {
+      up: [],
+      down: [makeArrival(240, 1700_000_000_500)],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toEqual({
+      arrivalSeconds: 240,
+      receivedAtMs: 1700_000_000_500,
+    });
+  });
+
+  it('up/down 둘 다 있으면 빠른 쪽 선택 (down이 빠른 케이스)', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(300, 1700_000_000_000)],
+      down: [makeArrival(120, 1700_000_000_500)],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toEqual({
+      arrivalSeconds: 120,
+      receivedAtMs: 1700_000_000_500,
+    });
+  });
+
+  it('up/down 둘 다 있으면 빠른 쪽 선택 (up이 빠른 케이스)', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(90, 1700_000_000_700)],
+      down: [makeArrival(200, 1700_000_000_500)],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toEqual({
+      arrivalSeconds: 90,
+      receivedAtMs: 1700_000_000_700,
+    });
+  });
+
+  it('receivedAtMs<=0인 row는 skip', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(60, 0)], // 0 → skip
+      down: [makeArrival(120, 1700_000_000_000)],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toEqual({
+      arrivalSeconds: 120,
+      receivedAtMs: 1700_000_000_000,
+    });
+  });
+
+  it('arrivalSeconds<0인 row는 skip', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(-1, 1700_000_000_000)],
+      down: [makeArrival(180, 1700_000_000_500)],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toEqual({
+      arrivalSeconds: 180,
+      receivedAtMs: 1700_000_000_500,
+    });
+  });
+
+  it('첫 차만 평가 — 둘째 차가 더 빨라도 무시', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(300, 1700_000_000_000), makeArrival(60, 1700_000_000_000)],
+      down: [makeArrival(400, 1700_000_000_500)],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toEqual({
+      arrivalSeconds: 300,
+      receivedAtMs: 1700_000_000_000,
+    });
+  });
+
+  it('양 방향 첫 차 모두 비정상이면 undefined', () => {
+    const arrival: StationArrival = {
+      up: [makeArrival(60, 0)],
+      down: [makeArrival(-5, 1700_000_000_000)],
+    };
+    expect(pickArrivalAtOrigin(arrival)).toBeUndefined();
+  });
+});

--- a/src/utils/pickArrivalAtOrigin.ts
+++ b/src/utils/pickArrivalAtOrigin.ts
@@ -1,0 +1,36 @@
+import type { StationArrival } from '../api/arrivalApi';
+import type { StaticEtaOptions } from './stationRoute';
+
+/**
+ * 출발역 arrival 응답에서 `calculateStaticETA`의 `arrivalAtOrigin` 옵션 값을 추출한다.
+ *
+ * 정책 (#784):
+ * - mock 데이터는 skip — receivedAtMs=0이라 어차피 stale 판정되지만 명시적으로도 제외해 의도 명확화
+ * - up/down 양 방향 첫 차 중 가장 빨리 오는 열차 선택 — 사용자가 둘 중 더 빠른 차를 탈 것이라는 가정
+ * - `receivedAtMs <= 0` 또는 `arrivalSeconds < 0`은 비정상 row로 skip
+ * - 후보가 없으면 undefined → 호출처는 `DEFAULT_WAIT_MINUTES` graceful fallback
+ *
+ * **책임 분리**: 본 helper는 비정상 row sanitize 전담 — 60s freshness 판정은 호출처
+ * (`resolveWaitMinutes` in `stationRoute.ts`)가 처리한다. raw `receivedAtMs`를 그대로 넘겨야
+ * freshness 게이트가 일관 적용된다.
+ *
+ * useArrivalCountdown(1Hz tick) 대신 useArrivalInfo raw row 직접 사용 — 옵션 B 채택 사유:
+ * countdown은 receivedAtMs를 원본으로 유지하면서 arrivalSeconds만 차감해 60s 후 항상 stale 판정.
+ * ETA는 분 단위 정수라 1Hz tick 미반영해도 표시값 변화 없음(receivedAtMs 신선도가 유일한 기준).
+ */
+export function pickArrivalAtOrigin(
+  arrival: StationArrival | null,
+): StaticEtaOptions['arrivalAtOrigin'] {
+  if (!arrival || arrival.isMock) return undefined;
+  let best: { arrivalSeconds: number; receivedAtMs: number } | undefined;
+  for (const list of [arrival.up, arrival.down]) {
+    const first = list[0];
+    if (!first) continue;
+    if (first.receivedAtMs <= 0) continue;
+    if (first.arrivalSeconds < 0) continue;
+    if (!best || first.arrivalSeconds < best.arrivalSeconds) {
+      best = { arrivalSeconds: first.arrivalSeconds, receivedAtMs: first.receivedAtMs };
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## 배경

#776/#777/#778 시리즈로 `calculateStaticETA`가 도보/대기/환승대기를 동적으로 받을 수 있게 됐고, `ProcessLocationInputs`에 옵션이 마련됐다. 그러나 FG 호출자(`app/(tabs)/index.tsx`)는 여전히 `calculateStaticETA(route)` (옵션 없음)으로 호출 중이라 dynamic ETA가 사실상 사용 안 됨. 본 PR로 시리즈 마무리.

## 변경 요약

- `src/utils/pickArrivalAtOrigin.ts` 신설 — `StationArrival`에서 양 방향 첫 차 중 빠른 쪽을 추출하는 pure helper
- `app/(tabs)/index.tsx`: `calculateStaticETA(route, { currentLocation, originStation, arrivalAtOrigin })`로 옵션 실제 전달
- `src/tasks/backgroundLocationTask.ts`: BG가 arrival 옵션을 미전달하는 정책 주석 추가 (코드 변경 없음)

## 핵심 설계

### Freshness 모델 — 옵션 B 채택
`useArrivalInfo` raw row 직접 참조 (`useArrivalCountdown` 1Hz tick 미사용). 사유:
- countdown은 `receivedAtMs`를 원본으로 유지하면서 `arrivalSeconds`만 차감 → 60s 후 항상 stale 판정으로 흐름
- 분 단위 정수 ETA라 1Hz tick 미반영해도 표시값 변화 없음
- 옵션 A(countdown 사용 + `receivedAtMs`도 갱신)는 다른 소비자(`arrivalEtaProjection`) 부작용 우려

### pickArrivalAtOrigin pure helper 분리
- screen component 직접 테스트가 까다로워 pure 함수로 분리
- 책임 분리: helper는 비정상 row sanitize만 — freshness 60s 게이트는 호출처(`resolveWaitMinutes`)
- 정책: up/down 양 방향 첫 차 중 가장 빠른 차 선택, mock/`receivedAtMs<=0`/`arrivalSeconds<0` skip

### arrivalsAtTransfers 미적용
- 환승역별 arrival 폴링 인프라가 현재 없음 (`useArrivalInfo`는 origin 1개만 폴링)
- multi-transfer 환승 후 대기는 leg당 `DEFAULT_WAIT_MINUTES`(3분) fallback 유지
- 후속 측정 후 인프라 도입 여부 결정 — 별도 follow-up 이슈로 트래킹 예정

### BG 미전달 정책
- FG `arrivalCache`는 in-memory `TtlCache`(cross-process 불가)
- BG 전용 arrival 폴링은 OS quota 비용 대비 효익 작음 — BG는 notification 본문 ETA 한 곳만 갱신
- AsyncStorage 캐시 경로는 측정 결과 BG 정확도 ↑ 효과가 확인되면 후속 도입

## 사용자 영향

- FG 표시 `displayEta`/`staticEtaMinutes`가 도보(출발역까지) + 다음 열차 실시간 대기를 반영 → 사용자 보고 "표시 32분 → 실제 48분" 류 오차 해소
- BoardingLock의 `expectedDurationMs`도 같은 값을 사용 → 자동 만료 정확도 동반 개선
- BG는 변경 없음 — notification 본문 ETA는 기존 fallback 유지 (회귀 없음)

## 검증

- `pickArrivalAtOrigin` 11 케이스 단위 테스트 (null/mock/empty/up-only/down-only/up<down/up>down/receivedAtMs=0/arrivalSeconds<0/둘째 차 무시/양쪽 비정상)
- 전체 테스트: 2808 passed
- 커버리지: 100% (lines/functions/branches/statements)
- type-check: 통과

## 자동 코드 리뷰 결과

- P1: 없음
- P2: 없음
- P3-1: `pickArrivalAtOrigin` JSDoc에 freshness 책임 위치 명시 — 본 PR 반영
- P3-2: arrivalsAtTransfers 미적용을 follow-up 이슈로 분리 권장 — 본 PR 머지 후 별도 이슈 생성 예정

## Test plan

- [x] `npx jest src/utils/__tests__/pickArrivalAtOrigin.test.ts` 통과
- [x] `npm test` 전체 통과 + 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 머지 후 실기기에서 displayEta 표시값 검증 (#785와 함께 한 사이클로 진행)

Closes #784