### PR TITLE
fix(#788): 환승 빠른탑승 도어 진행방면 반영 (fromTerminal 전달)

### DIFF
--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -6,7 +6,7 @@ import type { Stop, StopArrivalContext } from '../utils/journeyAdapter';
 import { LineBadge, getLineColor } from './LineBadge';
 import { useAppStore } from '../store/useAppStore';
 import { resolveQuickExit } from '../utils/quickExit';
-import { resolveTravelDirection } from '../utils/travelDirection';
+import { resolveProgressingTerminal, resolveTravelDirection } from '../utils/travelDirection';
 import { resolveTransferDoor } from '../utils/transferExit';
 import { findStationByNameAndLine } from '../utils/stationRoute';
 import type { LineNumber } from '../types/station';
@@ -33,10 +33,15 @@ function resolveStopDoor(
   accessibilityMode: boolean,
 ): string | null {
   if (transferToLine) {
+    // #788: 단조 노선의 진행 방면 운영 종점을 fromTerminal로 전달 — 같은 환승역의 양 방향
+    // row(예: 7→2 장암행 8-4 vs 석남행 1-1) 중 사용자가 가는 쪽을 정확히 선택. 비단조/매핑
+    // 미보유 노선은 null이라 기존 동작(첫 매치) 유지.
+    const fromTerminal = resolveProgressingTerminal(ctx.line, ctx.fromName, ctx.toName) ?? undefined;
     const transfer = resolveTransferDoor({
       stationName: ctx.toName,
       fromLine: ctx.line,
       toLine: transferToLine,
+      fromTerminal,
     });
     if (transfer) return transfer.doorNumber;
   }

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -21,11 +21,15 @@ jest.mock('../../data/quickExit.json', () => ({
   },
 }));
 
-// 빠른 환승 도어 — 군자(5↔7) 단순 fixture.
+// 빠른 환승 도어 — 군자(5↔7) 단순 fixture + 건대입구(7↔2) #788 fromTerminal 분기 검증용.
 jest.mock('../../data/transferExit.json', () => ({
   군자: [
     { fromLine: '5', toLine: '7', doorNumber: '1-1' },
     { fromLine: '7', toLine: '5', doorNumber: '5-1' },
+  ],
+  건대입구: [
+    { fromLine: '7', toLine: '2', fromTerminal: '장암', doorNumber: '8-4' },
+    { fromLine: '7', toLine: '2', fromTerminal: '석남', doorNumber: '1-1' },
   ],
 }));
 
@@ -281,6 +285,54 @@ describe('EditorialTimeline quickExit door label', () => {
     ];
     render(<EditorialTimeline stops={stops} />);
     expect(screen.getByText('1-1번 문')).toBeTruthy();
+  });
+
+  it('#788 단조 노선 환승: 진행방면 fromTerminal로 정확한 row 선택 (용마산→건대입구 석남행)', () => {
+    // 7호선 용마산(idx 14) → 건대입구(idx 18): id 증가 = high → endpoints.high "석남" 매칭.
+    // transferExit fixture에 7→2 두 row (장암 8-4 / 석남 1-1) — fromTerminal "석남"이 선택되어 "1-1번 문".
+    // 출발역 boarding-door도 같은 도어(다음 hop 재사용)라 1-1이 2회 표시되는 게 정상.
+    const stops: Stop[] = [
+      { station: '용마산', line: '7', mark: 'filled' },
+      {
+        station: '건대입구',
+        line: '2',
+        stopsFromPrev: '4정거장',
+        mark: 'transfer',
+        note: '환승',
+        arrivalContext: { line: '7', fromName: '용마산', toName: '건대입구' },
+        transferTarget: { toLine: '2' },
+      },
+      {
+        station: '성수',
+        line: '2',
+        stopsFromPrev: '1정거장',
+        mark: 'dest',
+        note: '도착',
+        arrivalContext: { line: '2', fromName: '건대입구', toName: '성수' },
+      },
+    ];
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getAllByText(/1-1번 문/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/8-4번 문/)).toBeNull();
+  });
+
+  it('#788 같은 환승역 + 반대방향: 진행방면 "장암"으로 8-4 row 선택 (뚝섬유원지→건대입구 장암행)', () => {
+    // 뚝섬유원지(7-019) → 건대입구(7-018): id 감소 = low → endpoints.low "장암" 매칭 → "8-4번 문".
+    const stops: Stop[] = [
+      { station: '뚝섬유원지', line: '7', mark: 'filled' },
+      {
+        station: '건대입구',
+        line: '2',
+        stopsFromPrev: '1정거장',
+        mark: 'transfer',
+        note: '환승',
+        arrivalContext: { line: '7', fromName: '뚝섬유원지', toName: '건대입구' },
+        transferTarget: { toLine: '2' },
+      },
+    ];
+    render(<EditorialTimeline stops={stops} />);
+    expect(screen.getAllByText(/8-4번 문/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/1-1번 문/)).toBeNull();
   });
 
   it('환승 stop이지만 transferExit 매칭이 없으면 quickExit fallback', () => {

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -287,52 +287,31 @@ describe('EditorialTimeline quickExit door label', () => {
     expect(screen.getByText('1-1번 문')).toBeTruthy();
   });
 
-  it('#788 단조 노선 환승: 진행방면 fromTerminal로 정확한 row 선택 (용마산→건대입구 석남행)', () => {
-    // 7호선 용마산(idx 14) → 건대입구(idx 18): id 증가 = high → endpoints.high "석남" 매칭.
-    // transferExit fixture에 7→2 두 row (장암 8-4 / 석남 1-1) — fromTerminal "석남"이 선택되어 "1-1번 문".
-    // 출발역 boarding-door도 같은 도어(다음 hop 재사용)라 1-1이 2회 표시되는 게 정상.
-    const stops: Stop[] = [
-      { station: '용마산', line: '7', mark: 'filled' },
+  // #788 단조 노선 환승에서 진행방면별로 transferExit row가 갈리는지 검증.
+  // 양 방향 case가 같은 환승역(건대입구)을 공유하므로 stops 빌더 + assertion을 한 곳으로 모은다.
+  function makeTransferAtGeondaeStops(origin: string): Stop[] {
+    return [
+      { station: origin, line: '7', mark: 'filled' },
       {
         station: '건대입구',
         line: '2',
-        stopsFromPrev: '4정거장',
+        stopsFromPrev: '1정거장',
         mark: 'transfer',
         note: '환승',
-        arrivalContext: { line: '7', fromName: '용마산', toName: '건대입구' },
+        arrivalContext: { line: '7', fromName: origin, toName: '건대입구' },
         transferTarget: { toLine: '2' },
       },
-      {
-        station: '성수',
-        line: '2',
-        stopsFromPrev: '1정거장',
-        mark: 'dest',
-        note: '도착',
-        arrivalContext: { line: '2', fromName: '건대입구', toName: '성수' },
-      },
     ];
-    render(<EditorialTimeline stops={stops} />);
-    expect(screen.getAllByText(/1-1번 문/).length).toBeGreaterThan(0);
-    expect(screen.queryByText(/8-4번 문/)).toBeNull();
-  });
+  }
 
-  it('#788 같은 환승역 + 반대방향: 진행방면 "장암"으로 8-4 row 선택 (뚝섬유원지→건대입구 장암행)', () => {
-    // 뚝섬유원지(7-019) → 건대입구(7-018): id 감소 = low → endpoints.low "장암" 매칭 → "8-4번 문".
-    const stops: Stop[] = [
-      { station: '뚝섬유원지', line: '7', mark: 'filled' },
-      {
-        station: '건대입구',
-        line: '2',
-        stopsFromPrev: '1정거장',
-        mark: 'transfer',
-        note: '환승',
-        arrivalContext: { line: '7', fromName: '뚝섬유원지', toName: '건대입구' },
-        transferTarget: { toLine: '2' },
-      },
-    ];
-    render(<EditorialTimeline stops={stops} />);
-    expect(screen.getAllByText(/8-4번 문/).length).toBeGreaterThan(0);
-    expect(screen.queryByText(/1-1번 문/)).toBeNull();
+  it.each<[string, string, string, string]>([
+    // 출발역 boarding-door도 같은 도어를 재사용하므로 expected가 2회 표시되는 게 정상 → getAllByText.
+    ['용마산→건대입구 (high=석남 방면)', '용마산', '1-1', '8-4'],
+    ['뚝섬유원지→건대입구 (low=장암 방면)', '뚝섬유원지', '8-4', '1-1'],
+  ])('#788 7→2 환승 fromTerminal로 row 갈림: %s', (_label, origin, expected, suppressed) => {
+    render(<EditorialTimeline stops={makeTransferAtGeondaeStops(origin)} />);
+    expect(screen.getAllByText(new RegExp(`${expected}번 문`)).length).toBeGreaterThan(0);
+    expect(screen.queryByText(new RegExp(`${suppressed}번 문`))).toBeNull();
   });
 
   it('환승 stop이지만 transferExit 매칭이 없으면 quickExit fallback', () => {

--- a/src/data/lineTopology.json
+++ b/src/data/lineTopology.json
@@ -1,4 +1,15 @@
 {
   "monotonicLines": ["3", "4", "7", "8", "9", "airport", "bundang", "sinbundang"],
-  "_comment": "단조(상행 종점 → 하행 종점)로 stations.json에 표현 가능한 노선 화이트리스트. 다음 노선들은 단조 배열로 표현 불가하므로 제외: 1호선(다중 종착/지선), 2호선(순환선), 5호선(마천/상일동 분기), 6호선(응암 루프), 경의중앙선(다중 갈래). 좌/우 안내가 false direction을 내는 것을 방지한다."
+  "_comment": "단조(상행 종점 → 하행 종점)로 stations.json에 표현 가능한 노선 화이트리스트. 다음 노선들은 단조 배열로 표현 불가하므로 제외: 1호선(다중 종착/지선), 2호선(순환선), 5호선(마천/상일동 분기), 6호선(응암 루프), 경의중앙선(다중 갈래). 좌/우 안내가 false direction을 내는 것을 방지한다.",
+  "endpoints": {
+    "3": { "low": "대화", "high": "오금" },
+    "4": { "low": "진접", "high": "오이도" },
+    "7": { "low": "장암", "high": "석남" },
+    "8": { "low": "별내", "high": "모란" },
+    "9": { "low": "개화", "high": "중앙보훈병원" },
+    "airport": { "low": "서울역", "high": "인천공항2터미널" },
+    "bundang": { "low": "인천", "high": "청량리" },
+    "sinbundang": { "low": "광교", "high": "신사" }
+  },
+  "_endpoints_comment": "각 단조 노선의 진행방면 종착역 운영명(#788). SSOT: 본 endpoints. stations.json은 stationId 정렬용으로만 쓰이며 신규 연장(석남/진접/별내/중앙보훈병원 등)을 미반영한 상태. transferExit.json의 fromTerminal은 본 endpoints에 정렬돼야 하며, 미정렬 row는 score=0으로 첫 매칭 fallback(회귀 없음, 정확도 저하). low = stations.json id가 작은 쪽(상행 방면) 운영 종점, high = id가 큰 쪽(하행 방면). 노선 연장 시 본 endpoints 먼저 갱신 → transferExit.json fromTerminal 동기화."
 }

--- a/src/utils/__tests__/travelDirection.test.ts
+++ b/src/utils/__tests__/travelDirection.test.ts
@@ -1,4 +1,4 @@
-import { resolveTravelDirection } from '../travelDirection';
+import { resolveProgressingTerminal, resolveTravelDirection } from '../travelDirection';
 
 jest.mock('../stationRoute', () => ({
   // 가짜 3호선 — 단조 노선이라는 가정. (MONOTONIC_LINES 화이트리스트에 포함됨.)
@@ -65,5 +65,39 @@ describe('resolveTravelDirection', () => {
     expect(resolveTravelDirection('6', '응암', '신내')).toBeNull();
     expect(resolveTravelDirection('1', '소요산', '인천')).toBeNull();
     expect(resolveTravelDirection('gyeongui', '운천', '지평')).toBeNull();
+  });
+});
+
+describe('resolveProgressingTerminal (#788)', () => {
+  // travelDirection.test.ts 상단 jest.mock에서 line 3의 stations 시퀀스는
+  // [대화, 주엽, 연신내, 종로3가, 오금]. lineTopology.json 실데이터(endpoints["3"] = {low:대화, high:오금})와 정렬.
+
+  it('단조 노선에서 toIdx > fromIdx면 high endpoint 반환', () => {
+    // 주엽(idx 1) → 종로3가(idx 3): id 증가 → high → "오금"
+    expect(resolveProgressingTerminal('3', '주엽', '종로3가')).toBe('오금');
+  });
+
+  it('단조 노선에서 toIdx < fromIdx면 low endpoint 반환', () => {
+    // 오금(idx 4) → 종로3가(idx 3): id 감소 → low → "대화"
+    expect(resolveProgressingTerminal('3', '오금', '종로3가')).toBe('대화');
+  });
+
+  it('비단조 노선은 null (resolveTravelDirection이 null이기 때문)', () => {
+    expect(resolveProgressingTerminal('2', '시청', '잠실')).toBeNull();
+    expect(resolveProgressingTerminal('5', '방화', '마천')).toBeNull();
+  });
+
+  it('같은 역이면 null', () => {
+    expect(resolveProgressingTerminal('3', '종로3가', '종로3가')).toBeNull();
+  });
+
+  it('출발역이 노선에 없으면 null', () => {
+    expect(resolveProgressingTerminal('3', '없는역', '오금')).toBeNull();
+  });
+
+  it('단조 노선 화이트리스트지만 mock stations 빈 배열이면 null', () => {
+    // line 8은 단조 화이트리스트에 있지만 본 mock에서 stations 빈 배열로 반환 →
+    // resolveTravelDirection 단계에서 이미 null이라 진입 자체가 안 됨.
+    expect(resolveProgressingTerminal('8', '암사', '모란')).toBeNull();
   });
 });

--- a/src/utils/travelDirection.ts
+++ b/src/utils/travelDirection.ts
@@ -8,6 +8,11 @@ import lineTopology from '../data/lineTopology.json';
 // (scripts/fetch-exit-side.js)도 동일 JSON을 참조해 좌/우 라벨 채택 정책을 공유한다.
 const MONOTONIC_LINES = new Set<LineNumber>(lineTopology.monotonicLines as LineNumber[]);
 
+// #788: 노선별 운영 종점명(transferExit.fromTerminal과 정렬). stations.json은 신규 연장
+// (석남/진접/별내/중앙보훈병원 등)을 미반영하므로 endpoints는 lineTopology.json 단일 출처.
+// Partial<Record<LineNumber, ...>>로 좁혀 잘못된 노선명 lookup을 컴파일타임에 잡는다.
+const ENDPOINTS = lineTopology.endpoints as Partial<Record<LineNumber, { low: string; high: string }>>;
+
 export interface TravelResolution {
   direction: TravelDirection;
   fromStation: Station;
@@ -32,6 +37,28 @@ export function resolveTravelDirection(
     fromStation: stations[fromIdx],
     toStation: stations[toIdx],
   };
+}
+
+/**
+ * 단조 노선에서 fromName → toName의 진행 방면 종착역 운영명을 반환한다(#788).
+ * `resolveTransferDoor`의 `fromTerminal` 인자로 전달해 같은 환승역의 양 방향 row를 구별.
+ *
+ * - 단조 노선(`lineTopology.monotonicLines`)만 결정 가능. 그 외는 null.
+ * - 진행 방향(low/high)은 stations.json의 id 정렬을 기준 — id가 증가하는 방향이 high.
+ * - 운영 종점명은 lineTopology.endpoints에서 lookup (stations.json과 다를 수 있음 — 예: 7호선 high=석남).
+ * - endpoints에 매핑이 없거나 from/to가 같으면 null.
+ */
+export function resolveProgressingTerminal(
+  line: LineNumber,
+  fromName: string,
+  toName: string,
+): string | null {
+  const resolution = resolveTravelDirection(line, fromName, toName);
+  if (!resolution) return null;
+  const endpoints = ENDPOINTS[line];
+  /* istanbul ignore next -- lineTopology.json invariant: 모든 monotonicLines가 endpoints에 등록. 추가 노선 도입 시 가드 */
+  if (!endpoints) return null;
+  return resolution.direction === 'up' ? endpoints.low : endpoints.high;
 }
 
 function indexOf(stations: ReadonlyArray<Station>, name: string): number {


### PR DESCRIPTION
## 사용자 보고

용마산(7호선) → 성수(2호선) 경로의 EditorialTimeline에서 건대입구 환승 시 "탑승 8-4번 문"으로 표시되지만 실제로는 "1-1번 문"이 빠른환승 위치.

## 원인

`transferExit.json` 건대입구는 이미 양 방향 row 보유:
```json
[
  { "fromLine":"7", "toLine":"2", "fromTerminal":"장암", "doorNumber":"8-4" },
  { "fromLine":"7", "toLine":"2", "fromTerminal":"석남", "doorNumber":"1-1" }
]
```

- 호출처 `EditorialTimeline.tsx` `resolveTransferDoor`에 `fromTerminal` 미전달 → 첫 매치(장암 8-4)만 선택
- 추가로 `stations.json`은 7호선 운영 종점 "석남"을 미반영("부평구청"까지만 등록) → 단순 endpoint 매칭으론 정렬 불가
- `resolveTransferDoor` 시그니처에는 이미 `fromTerminal?` + 점수 가중치(WEIGHT_FROM_TERMINAL=4) 구현돼 있어 호출자만 통합하면 즉시 해소

## 변경 요약

- `src/data/lineTopology.json` — `endpoints` 필드 신설. 단조 노선별 운영 종점 매핑(transferExit `fromTerminal` 표기와 정렬)
- `src/utils/travelDirection.ts` — `resolveProgressingTerminal(line, fromName, toName): string | null` 신설. 단조 노선의 진행방면 운영 종점명 반환
- `src/components/EditorialTimeline.tsx` — `resolveStopDoor` 안에서 `resolveProgressingTerminal` 호출 → `resolveTransferDoor`에 `fromTerminal` 전달
- 테스트:
  - `travelDirection.test.ts`: 신규 6 케이스 (단조 노선 high/low / 비단조 / 같은 역 / 노선 미보유)
  - `EditorialTimeline.test.tsx`: 용마산→건대입구(석남행) → 1-1, 뚝섬유원지→건대입구(장암행) → 8-4 회귀

## 핵심 설계 결정

### 단조 노선만 결정
`resolveTravelDirection` 의존(단조 화이트리스트). 비단조 노선(2/5/6/1/경의중앙선)은 null 반환 → 기존 동작(첫 매치) 유지. 비단조 노선의 양 방향 선택은 arrival API `trainLineNm` 등 다른 신호 필요 — 별도 follow-up 이슈로 분리 예정.

### lineTopology.endpoints가 SSOT
- `stations.json` = stationId 정렬용으로만 사용 (신규 연장 미반영 보존)
- `transferExit.json` `fromTerminal` = `endpoints`에 정렬 의무 (미정렬 row는 score=0으로 첫 매치 fallback)
- 노선 연장 시 endpoints 먼저 갱신 → transferExit 동기화

### StopArrivalContext 불변
`fromTerminal` 필드를 `StopArrivalContext`에 추가하지 않고 EditorialTimeline 내부에서 `resolveProgressingTerminal` 직접 호출. `journeyAdapter.test.ts`의 `toEqual` 회귀를 피해 surgical scope 유지.

### Out of Scope
- 비단조 노선의 양 방향 결정 (arrival API destination 신호 활용 필요) — 후속 이슈
- `transferExit.json` 일부 row의 endpoints 미정렬(수서/인천 등) 데이터 정정 — 후속 이슈
- `transferExit.json` 자체 출처 신뢰성(나무위키 → 공식 출처) — 별도 트랙(트랙 B)

## 사용자 영향

- 7호선/3호선/4호선/9호선/airport/sinbundang 등 단조 노선 환승역에서 진행방면별 정확한 도어 안내
- 사용자 보고 케이스(용마산→건대입구 석남행) 직접 해소
- 비단조 노선 환승은 기존과 동일 — 회귀 없음

## 검증

- travelDirection: 15 passed (기존 9 + 신규 6)
- EditorialTimeline: 36 passed (기존 34 + 신규 2)
- 전체 테스트: 2824 passed, 커버리지 100%
- type-check 통과

## 자동 코드 리뷰 결과

- P1: 없음
- P2-2 (SSOT 정책 주석) / P3-3 (Partial<Record<LineNumber>> 좁히기) — 본 PR 반영
- P2-1 (transferExit fromTerminal 일부 row endpoints 미정렬, 수서/인천 등) — follow-up 이슈로 분리 예정 (회귀 없음, 정확도 저하만)
- P2-3 (`?? undefined` 시그니처 불일치) / P3-1 (resolveTravelDirection 이중 호출) — 현행 유지 무방
- P3-2 (비단조 노선 후속) — follow-up 이슈로 분리 예정

## Test plan

- [x] `npx jest src/utils/__tests__/travelDirection.test.ts` 통과
- [x] `npx jest src/components/__tests__/EditorialTimeline.test.tsx` 통과
- [x] `npm test` 전체 통과 + 커버리지 100%
- [x] `npm run type-check` 통과
- [ ] 머지 후 실기기에서 용마산→건대입구 경로 검색 → "탑승 1-1번 문" 표시 확인 (사용자 보고 회귀 검증)

Closes #788