### PR TITLE
fix(#790): BoardingTrainList N번째 전 라벨이 API 실거리(arvlMsg2) 반영

### DIFF
--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -5,6 +5,7 @@ import type { ArrivalInfo } from '../api/arrivalApi';
 import type { LineNumber } from '../types/station';
 import { formatClockTime } from '../utils/formatTime';
 import { isScheduleFallbackTrainCode } from '../utils/scheduleFallback';
+import { parseArrivalDistance } from '../utils/arrivalStatusDistance';
 import { LINE_COLORS } from '../constants/lineColors';
 
 /** row 좌측 호선 색 stripe 두께(#664). 시각적 구분을 헤더 외에도 row마다 즉시 인지 가능하게. */
@@ -47,8 +48,10 @@ interface Props {
  *       compact 모드는 hop slot 안 inline이라 row borderRadius 없음(직각). stripe도 같은 정신으로
  *       직각 유지 — 일반 모드는 카드 radius와 어울리는 둥근 코너 stripe로 자연스럽게 처리됨.
  * #749: 2줄 row 레이아웃 — 첫째 줄 "{destination}행 · {nextStation}방면" (방면은 옵셔널),
- *       둘째 줄 "{index+1}번째 전 · {HH:mm} 도착 예정". 카운터는 호출자가 전달한 배열 순서를
- *       1-indexed로 변환. 같은 trainCode가 유지되는 동안 카운터 안정 → "같은 열차 지연" 신호.
+ *       둘째 줄 "{거리} · {HH:mm} 도착 예정". 거리는 #790에서 API 실측치로 교체.
+ * #790: 거리 표기를 API `arvlMsg2`에서 정규식 파싱한 실거리로 변경 (`parseArrivalDistance`).
+ *       비어있는 statusMessage(주로 mock/schedule fallback)는 기존 `${index+1}번째 전`로 fallback.
+ *       이는 사용자의 "역 개수" 직관과 배열 순번이 어긋나던 회귀(2026-06-03 실기기 보고)를 해소한다.
  */
 export function BoardingTrainList({
   arrivals,
@@ -94,7 +97,11 @@ export function BoardingTrainList({
         const metaText = nextStationLabel
           ? `${train.destination}행 · ${nextStationLabel}방면`
           : `${train.destination}행`;
-        const sequenceText = `${index + 1}번째 전`;
+        // #790: API arvlMsg2 기반 진짜 거리 표시. 비어있으면 배열 인덱스 fallback(이전 동작 유지 —
+        // 주로 mock/schedule fallback 경로). 실 응답에서는 항상 [N]번째 전역 패턴이 들어와
+        // 사용자 의도(역 개수)와 일치한다.
+        const parsedDistance = parseArrivalDistance(train.statusMessage);
+        const sequenceText = parsedDistance.length > 0 ? parsedDistance : `${index + 1}번째 전`;
         const arrivalText = `${formatArrivalClock(train)} 도착 예정`;
         return (
           <Pressable

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -205,6 +205,36 @@ describe('BoardingTrainList', () => {
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
   });
 
+  describe('#790 거리 표기 — API arvlMsg2 실측치', () => {
+    it('statusMessage "[4]번째 전역 (문정)" → "4번째 전"', () => {
+      const train = makeTrain({ trainCode: 'T-DIST', statusMessage: '[4]번째 전역 (문정)' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-sequence-T-DIST').props.children).toBe('4번째 전');
+    });
+
+    it('statusMessage "전역 출발"(비매칭)이면 원본 그대로 표시', () => {
+      const train = makeTrain({ trainCode: 'T-DEPARTED', statusMessage: '전역 출발' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-sequence-T-DEPARTED').props.children).toBe('전역 출발');
+    });
+
+    it('statusMessage 빈 문자열(mock/schedule)이면 index+1 fallback', () => {
+      const trains = [
+        makeTrain({ trainCode: 'T-MOCK-1', statusMessage: '' }),
+        makeTrain({ trainCode: 'T-MOCK-2', statusMessage: '' }),
+      ];
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-sequence-T-MOCK-1').props.children).toBe('1번째 전');
+      expect(getByTestId('boarding-train-sequence-T-MOCK-2').props.children).toBe('2번째 전');
+    });
+  });
+
   describe('#664 환승역 line 필터 + 호선 색 stripe', () => {
     function flattenStyle(style: unknown): Record<string, unknown> {
       if (Array.isArray(style)) return Object.assign({}, ...style.map(flattenStyle));

--- a/src/utils/__tests__/arrivalStatusDistance.test.ts
+++ b/src/utils/__tests__/arrivalStatusDistance.test.ts
@@ -1,0 +1,28 @@
+import { parseArrivalDistance } from '../arrivalStatusDistance';
+
+describe('parseArrivalDistance', () => {
+  it.each([
+    ['[4]번째 전역 (문정)', '4번째 전'],
+    ['[1]번째 전역 (홍대입구)', '1번째 전'],
+    ['[10]번째 전역', '10번째 전'],
+  ])('괄호 거리 패턴 매칭: "%s" → "%s"', (input, expected) => {
+    expect(parseArrivalDistance(input)).toBe(expected);
+  });
+
+  it.each([
+    ['전역 출발', '전역 출발'],
+    ['당역 도착', '당역 도착'],
+    ['진입', '진입'],
+    ['곧 도착', '곧 도착'],
+  ])('비매칭 비어있지 않은 메시지는 원본 그대로: "%s"', (input, expected) => {
+    expect(parseArrivalDistance(input)).toBe(expected);
+  });
+
+  it('빈 문자열은 빈 문자열 그대로 — 호출자가 fallback 결정', () => {
+    expect(parseArrivalDistance('')).toBe('');
+  });
+
+  it('숫자가 0이면 그대로 "0번째 전" — 가드 없이 통과 (이론상 발생 안하지만 정규화 일관성)', () => {
+    expect(parseArrivalDistance('[0]번째 전역')).toBe('0번째 전');
+  });
+});

--- a/src/utils/arrivalStatusDistance.ts
+++ b/src/utils/arrivalStatusDistance.ts
@@ -1,0 +1,24 @@
+/**
+ * Seoul 열린데이터 API `arvlMsg2`(=`ArrivalInfo.statusMessage`)에서 BoardingTrainList에 노출할
+ * 거리 표기를 추출한다.
+ *
+ * 입력 예 → 출력:
+ *   "[4]번째 전역 (문정)"  → "4번째 전"   (괄호 패턴 매칭)
+ *   "[1]번째 전역 (홍대입구)" → "1번째 전"
+ *   "전역 출발"           → "전역 출발"  (매칭 안 됨, 원본 유지)
+ *   "당역 도착"           → "당역 도착"
+ *   ""                  → ""         (정보 없음, 호출자가 fallback 결정)
+ *
+ * #790 회귀 — 기존 코드는 배열 인덱스 +1을 "N번째 전"으로 표시했고 사용자는 이를 실제 역 거리로
+ * 해석했다. 진짜 거리는 API 응답에 위 패턴으로 들어 있어 이 함수로 정규화한다.
+ *
+ * 정책: `[0]번째 전역`도 통과시켜 "0번째 전"으로 표기. Seoul API 명세상 0은 발생하지 않는다고
+ * 보지만, 만약 향후 "당역 도착" 대체로 들어오기 시작하면 UX 재검토 필요.
+ */
+const BRACKET_DISTANCE_RE = /\[(\d+)\]번째 전역/;
+
+export function parseArrivalDistance(statusMessage: string): string {
+  const match = BRACKET_DISTANCE_RE.exec(statusMessage);
+  if (match) return `${match[1]}번째 전`;
+  return statusMessage;
+}


### PR DESCRIPTION
## Summary
- 2026-06-03 실기기 트립에서 사용자가 보고한 회귀: BoardingTrainList의 "N번째 전" 라벨이 배열 인덱스(`index+1`)였고 사용자는 이를 **실제 역 거리**로 해석. 진짜 거리는 Seoul Open Data API `arvlMsg2`에 `[4]번째 전역 (문정)` 형태로 들어 있음.
- `parseArrivalDistance` 유틸 신설: 정규식 `\[(\d+)\]번째 전역` 매칭. 매칭 시 "N번째 전". 비매칭(곧 도착/전역 출발)은 statusMessage 원본. 빈 statusMessage(mock/schedule fallback)는 기존 `${index+1}번째 전`로 폴백(기존 mock UX 보존).
- 회귀 차단 테스트 3건 추가 (BoardingTrainList) + 유틸 단위 테스트 7건.

## Test plan
- [x] 단위 테스트 `arrivalStatusDistance.test.ts` 7건 PASS
- [x] BoardingTrainList 통합 테스트 23건 PASS (#790 회귀 가드 3건 포함)
- [x] 전체 테스트 2836/2836 PASS, 157/157 suites PASS
- [x] `npm run type-check` 통과
- [ ] 실기기 검증: BoardingTrainList row가 "[4]번째 전역 (문정)" → "4번째 전" 표시
- [ ] mock/schedule fallback 경로에서는 기존 동작(`1번째 전`, `2번째 전`) 유지

Closes #790