### PR TITLE
fix(#791): BG 위치 권한 안내 Alert 영구 dismiss (AsyncStorage 영속)

### DIFF
--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -42,6 +42,10 @@ export const BOARDING_LOCK_KEY = 'subway-now:boarding-lock';
 // release/expiry 또는 새 Lock 시점에 일괄 cancel하기 위한 추적 큐.
 // 형식: string[] JSON.
 export const SCHEDULED_NOTIFICATIONS_KEY = 'subway-now:scheduled-notifications';
+// #791 — BG 위치 권한 거부 시 띄우는 안내 Alert를 사용자가 dismiss한 적이 있는지.
+// 'true' 또는 키 부재. 한 번 dismiss하면 앱 재시작 후에도 다시 노출하지 않는다.
+// 사용자는 첫 안내로 결정한 상태이므로 반복 노출은 스팸. (WhileInUse 1차 시나리오 정책 정렬)
+export const BG_PERMISSION_DENIED_DISMISSED_KEY = 'subway-now:bg-permission-denied-dismissed';
 // #711 — BG task가 마지막으로 평가한 nearest station + 평가 시각.
 // FG 복귀 직후 fresh fix가 들어오기 전 일시 공백을 메우기 위한 임시 hydrate 용도.
 // hydrate 시 locationUncertain=true는 유지 — fresh fix(applyLocation) 도착 시점에 해제된다.

--- a/src/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/hooks/__tests__/useBackgroundLocation.test.ts
@@ -1,5 +1,7 @@
-import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { Alert, Linking } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { BG_PERMISSION_DENIED_DISMISSED_KEY } from '../../constants/storageKeys';
 import type { Station } from '../../types/station';
 
 // ── Alert.alert / Linking.openSettings 모킹 ──
@@ -71,8 +73,10 @@ const mockDestination2: Station = {
 };
 
 describe('useBackgroundLocation', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
+    // #791: dismiss flag는 AsyncStorage(영속)에 저장되므로 매 테스트마다 초기화.
+    await AsyncStorage.clear();
     mockStopLocationUpdatesAsync.mockResolvedValue(undefined);
     mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
     mockIsTaskRegisteredAsync.mockResolvedValue(false);
@@ -183,6 +187,112 @@ describe('useBackgroundLocation', () => {
     });
 
     expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+  });
+
+  // #791: dismiss 플래그가 AsyncStorage에 영속 저장되어 앱 재시작 후에도 Alert가 다시 뜨지 않는다.
+  it('#791 첫 denied Alert 후 dismiss 플래그가 AsyncStorage에 저장된다', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await AsyncStorage.getItem(BG_PERMISSION_DENIED_DISMISSED_KEY)).toBe('true');
+  });
+
+  it('#791 새 hook instance(앱 재시작 시나리오)에서도 dismiss 플래그가 있으면 Alert 미노출', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    await AsyncStorage.setItem(BG_PERMISSION_DENIED_DISMISSED_KEY, 'true');
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
+    });
+    // 권한 요청은 여전히 일어나지만 Alert는 띄우지 않는다.
+    expect(mockAlertAlert).not.toHaveBeenCalled();
+  });
+
+  it('#791 AsyncStorage getItem 오류는 "미노출 이력 없음"으로 처리 → Alert 정상 노출', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    const getItemSpy = jest
+      .spyOn(AsyncStorage, 'getItem')
+      .mockRejectedValueOnce(new Error('storage corrupt'));
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+    });
+
+    getItemSpy.mockRestore();
+  });
+
+  it('#791 AsyncStorage setItem 오류는 silent — Alert는 여전히 노출', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    const setItemSpy = jest
+      .spyOn(AsyncStorage, 'setItem')
+      .mockRejectedValueOnce(new Error('disk full'));
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+    });
+
+    setItemSpy.mockRestore();
+  });
+
+  it('#791 hydrate 도중 unmount되면 Alert를 띄우지 않는다 (cancelled 가드)', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    let resolveGetItem!: (value: string | null) => void;
+    const getItemSpy = jest.spyOn(AsyncStorage, 'getItem').mockReturnValueOnce(
+      new Promise<string | null>((resolve) => {
+        resolveGetItem = resolve;
+      }),
+    );
+
+    const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
+    });
+
+    unmount();
+    resolveGetItem(null);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAlertAlert).not.toHaveBeenCalled();
+    getItemSpy.mockRestore();
+  });
+
+  it('#791 setItem(dismiss 저장) 도중 unmount되면 storage는 갱신되지만 Alert는 미노출', async () => {
+    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    let resolveSetItem!: () => void;
+    const setItemSpy = jest.spyOn(AsyncStorage, 'setItem').mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSetItem = resolve;
+      }),
+    );
+
+    const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(setItemSpy).toHaveBeenCalledWith(BG_PERMISSION_DENIED_DISMISSED_KEY, 'true');
+    });
+
+    unmount();
+    resolveSetItem();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAlertAlert).not.toHaveBeenCalled();
+    setItemSpy.mockRestore();
   });
 
   it('cancelled(unmount race) 상태에서는 denied여도 Alert를 띄우지 않는다 (#387)', async () => {

--- a/src/hooks/useBackgroundLocation.ts
+++ b/src/hooks/useBackgroundLocation.ts
@@ -1,11 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { Alert, Linking } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
 import { useTranslation } from 'react-i18next';
 import type { Station } from '../types/station';
 import { BACKGROUND_LOCATION_TASK } from '../tasks/backgroundLocationTask';
 import { LOCATION_TRACKING_OPTIONS } from '../constants/locationTracking';
+import { BG_PERMISSION_DENIED_DISMISSED_KEY } from '../constants/storageKeys';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('BackgroundLocation');
@@ -13,11 +15,29 @@ const logger = createLogger('BackgroundLocation');
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
+/**
+ * BG 권한 거부 안내 Alert 노출 이력을 AsyncStorage에서 조회한다 (#791).
+ * 키 부재/오류는 "안내 안 함"으로 간주 — 안내를 한 번 더 보는 비용 < 영구 스팸 비용.
+ */
+async function isDeniedAlertDismissed(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_PERMISSION_DENIED_DISMISSED_KEY);
+    return raw === 'true';
+  } catch {
+    return false;
+  }
+}
+
+async function markDeniedAlertDismissed(): Promise<void> {
+  try {
+    await AsyncStorage.setItem(BG_PERMISSION_DENIED_DISMISSED_KEY, 'true');
+  } catch (e) {
+    logger.warn('BG 권한 안내 dismiss flag 저장 실패', e);
+  }
+}
+
 export function useBackgroundLocation(destination: Station | null): void {
   const { t } = useTranslation();
-  // 같은 hook 라이프타임에서 destination이 여러 번 바뀌어도 권한 안내 모달은 한 번만 노출한다.
-  // 매번 띄우면 스팸성이 강하고, 사용자는 이미 첫 알림으로 결정한 상태다.
-  const deniedAlertShownRef = useRef(false);
 
   useEffect(() => {
     if (!destination) {
@@ -31,8 +51,16 @@ export function useBackgroundLocation(destination: Station | null): void {
       const { status } = await Location.requestBackgroundPermissionsAsync();
       if (status !== 'granted' || cancelled) {
         logger.info('백그라운드 위치 권한 거부 또는 취소됨');
-        if (status !== 'granted' && !cancelled && !deniedAlertShownRef.current) {
-          deniedAlertShownRef.current = true;
+        if (status !== 'granted' && !cancelled) {
+          // #791: 영구 dismiss 플래그를 AsyncStorage에서 확인. 한 번 안내를 받은 사용자에게
+          // 매 destination 변경/앱 재시작마다 같은 Alert를 띄우는 것은 스팸 + WhileInUse 1차
+          // 시나리오 정책 위반. dismiss 이력이 있으면 silent.
+          const dismissed = await isDeniedAlertDismissed();
+          if (cancelled || dismissed) return;
+          await markDeniedAlertDismissed();
+          // setItem await 동안 cleanup이 실행됐을 수 있음. dismissed 플래그는 storage에 들어가도
+          // Alert 발사는 차단(정책: 누락 1회 허용 > 스팸).
+          if (cancelled) return;
           Alert.alert(
             t('permissions.backgroundDeniedTitle'),
             t('permissions.backgroundDeniedBody'),


### PR DESCRIPTION
## Summary
- 2026-06-03 실기기 트립 항목 13: BG 위치 권한 거부 후 띄우는 안내 Alert가 **앱 재시작마다 다시 노출**. 원인: `useRef`는 hook lifetime이라 앱 재시작 시 false로 초기화 → 무한 반복.
- `BG_PERMISSION_DENIED_DISMISSED_KEY` AsyncStorage 키 신설. 한 번 안내된 사용자는 앱 재시작 후에도 재노출 안 됨.
- WhileInUse 1차 시나리오 정책 정렬 ([[feedback_whileinuse_must_work]]). Always 강요 회피.
- `setItem` 이후 cleanup race도 명시적 가드 (cancelled 체크 한 줄 추가). Storage 오류는 "이력 없음"으로 fallback (영구 스팸 회피).

## Test plan
- [x] 단위 테스트 18/18 PASS (저장/재로드/getItem 오류/setItem 오류/cancelled race × 2케이스)
- [x] 전체 테스트 2829/2829 PASS, 156/156 suites PASS
- [x] `npm run type-check` 통과
- [ ] 실기기 검증: BG 권한 거부 → Alert 1회 노출 → 닫기 → 다른 destination 변경 시 미노출
- [ ] 앱 강제종료 후 재실행 → 같은 destination 다시 설정 → Alert 미노출

Closes #791