### PR TITLE
fix(#792): BoardingTrainList 종착/방면 라벨 중복 + i18n 누락

### DIFF
--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -2,10 +2,14 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme, typography, spacing, radius } from '../theme';
 import { LineBadge } from './LineBadge';
 import type { ArrivalInfo } from '../api/arrivalApi';
-import type { LineNumber } from '../types/station';
+import type { LineNumber, Station } from '../types/station';
 import { formatClockTime } from '../utils/formatTime';
 import { isScheduleFallbackTrainCode } from '../utils/scheduleFallback';
+import { buildDirectionMeta } from '../utils/trainLineDirection';
 import { LINE_COLORS } from '../constants/lineColors';
+import stationsData from '../data/stations.json';
+
+const allStations = stationsData as Station[];
 
 /** row 좌측 호선 색 stripe 두께(#664). 시각적 구분을 헤더 외에도 row마다 즉시 인지 가능하게. */
 const LINE_STRIPE_WIDTH = 3;
@@ -46,9 +50,12 @@ interface Props {
  * #649: compact + nextStationLabel — Timeline hop slot 안에 inline 배치되는 형태 지원.
  *       compact 모드는 hop slot 안 inline이라 row borderRadius 없음(직각). stripe도 같은 정신으로
  *       직각 유지 — 일반 모드는 카드 radius와 어울리는 둥근 코너 stripe로 자연스럽게 처리됨.
- * #749: 2줄 row 레이아웃 — 첫째 줄 "{destination}행 · {nextStation}방면" (방면은 옵셔널),
- *       둘째 줄 "{index+1}번째 전 · {HH:mm} 도착 예정". 카운터는 호출자가 전달한 배열 순서를
- *       1-indexed로 변환. 같은 trainCode가 유지되는 동안 카운터 안정 → "같은 열차 지연" 신호.
+ * #749: 2줄 row 레이아웃 — 첫째 줄 "{종착}{방면?}" (방면은 옵셔널), 둘째 줄 "{거리} · {HH:mm} 도착 예정".
+ *       카운터는 호출자가 전달한 배열 순서를 1-indexed로 변환. 같은 trainCode가 유지되는 동안
+ *       카운터 안정 → "같은 열차 지연" 신호.
+ * #792: 종착 표기는 `parseTrainLineDirection`로 i18n 정규화한다 (기존 하드코딩 "행" 부착 제거).
+ *       종착에 이미 다음역 명이 포함된 경우(예: "어린이대공원(세종대)방면"+"어린이대공원") "방면"
+ *       접미사를 생략해 라벨 중복("…방면행 · …방면")을 차단한다.
  */
 export function BoardingTrainList({
   arrivals,
@@ -91,9 +98,7 @@ export function BoardingTrainList({
       )}
       {filteredArrivals.map((train, index) => {
         const unreachable = isUnreachable(train);
-        const metaText = nextStationLabel
-          ? `${train.destination}행 · ${nextStationLabel}방면`
-          : `${train.destination}행`;
+        const metaText = buildDirectionMeta(train.destination, nextStationLabel, allStations);
         const sequenceText = `${index + 1}번째 전`;
         const arrivalText = `${formatArrivalClock(train)} 도착 예정`;
         return (

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -3,6 +3,7 @@ import { BoardingTrainList } from '../BoardingTrainList';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 import { LINE_COLORS } from '../../constants/lineColors';
 import type { ArrivalInfo } from '../../api/arrivalApi';
+import type { LineNumber } from '../../types/station';
 
 function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   return {
@@ -207,59 +208,26 @@ describe('BoardingTrainList', () => {
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
   });
 
+  // #792 라벨 dedup 회귀 가드 — 동일 BoardingTrainList 렌더 + assertion 패턴이라 it.each로 통합
+  // (SonarCloud CPD duplication 차단; 직전 PR #788과 동일한 접근).
   describe('#792 종착/방면 라벨 중복 제거', () => {
-    it('destination "어린이대공원(세종대)방면" + nextStationLabel "어린이대공원" → 접미사 생략 (중복 차단)', () => {
-      const train = makeTrain({
-        trainCode: 'T-DEDUP',
-        destination: '어린이대공원(세종대)방면',
-        line: '7',
-      });
+    it.each<[string, string, LineNumber, string | null, string]>([
+      ['방면 패턴 + 동일 역 dedup', '어린이대공원(세종대)방면', '7', '어린이대공원', '어린이대공원(세종대)방면'],
+      ['순환선 + nextStationLabel 없음 → 행 미부착', '내선순환', '2', null, '내선순환'],
+      ['일반 종착 + 다른 인접역 → 정상 부착', '도봉산행', '7', '중곡', '도봉산행 · 중곡방면'],
+      // 1호선 망월사 시뮬레이션 — 이전 includes() 기반 dedup이 false-positive로 "도봉산행"만 표시했음.
+      ['substring false-positive 방지 (도봉산행 + 도봉)', '도봉산행', '1', '도봉', '도봉산행 · 도봉방면'],
+    ])('%s', (_, destination, line, nextStationLabel, expected) => {
+      const train = makeTrain({ trainCode: 'T-792', destination, line });
       const { getByTestId } = renderWithTheme(
         <BoardingTrainList
           arrivals={[train]}
-          line="7"
+          line={line}
           onSelect={() => {}}
-          nextStationLabel="어린이대공원"
+          nextStationLabel={nextStationLabel}
         />,
       );
-      expect(getByTestId('boarding-train-meta-T-DEDUP').props.children).toBe(
-        '어린이대공원(세종대)방면',
-      );
-    });
-
-    it('destination "내선순환"은 parseTrainLineDirection으로 정규화되어 "행" 미부착', () => {
-      const train = makeTrain({ trainCode: 'T-LOOP', destination: '내선순환', line: '2' });
-      const { getByTestId } = renderWithTheme(
-        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
-      );
-      expect(getByTestId('boarding-train-meta-T-LOOP').props.children).toBe('내선순환');
-    });
-
-    it('destination "도봉산행"은 정규화 결과 그대로 표기, 다른 nextStationLabel은 정상 부착', () => {
-      const train = makeTrain({ trainCode: 'T-NORMAL', destination: '도봉산행', line: '7' });
-      const { getByTestId } = renderWithTheme(
-        <BoardingTrainList
-          arrivals={[train]}
-          line="7"
-          onSelect={() => {}}
-          nextStationLabel="중곡"
-        />,
-      );
-      expect(getByTestId('boarding-train-meta-T-NORMAL').props.children).toBe('도봉산행 · 중곡방면');
-    });
-
-    it('substring false-positive 방지: "도봉산행" + "도봉" → terminal 정확비교라 정상 부착', () => {
-      // 1호선 망월사 시뮬레이션. P1-1: 이전 includes() 기반 dedup은 false-positive로 "도봉산행"만 표시했음.
-      const train = makeTrain({ trainCode: 'T-PREFIX', destination: '도봉산행', line: '1' });
-      const { getByTestId } = renderWithTheme(
-        <BoardingTrainList
-          arrivals={[train]}
-          line="1"
-          onSelect={() => {}}
-          nextStationLabel="도봉"
-        />,
-      );
-      expect(getByTestId('boarding-train-meta-T-PREFIX').props.children).toBe('도봉산행 · 도봉방면');
+      expect(getByTestId('boarding-train-meta-T-792').props.children).toBe(expected);
     });
   });
 

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -30,7 +30,9 @@ describe('BoardingTrainList', () => {
   });
 
   it('#749 각 train마다 종착(○○행) 표기 + 카운터 + 시각', () => {
-    const trains = [makeTrain({ trainCode: 'T-A', destination: '강남', arrivalMinutes: 2 })];
+    // destination은 Seoul API trainLineNm 원본 포맷(예: "강남행"). #792에서 parseTrainLineDirection으로
+    // 정규화하므로 기존 raw 값을 그대로 전달.
+    const trains = [makeTrain({ trainCode: 'T-A', destination: '강남행', arrivalMinutes: 2 })];
     const { getByTestId } = renderWithTheme(
       <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
     );
@@ -105,7 +107,7 @@ describe('BoardingTrainList', () => {
   });
 
   it('#648 SCHED-* trainCode는 사용자에게 숨기고 "시간표" 라벨로 대체', () => {
-    const fallback = makeTrain({ trainCode: 'SCHED-DN-1', destination: '석남', line: '7' });
+    const fallback = makeTrain({ trainCode: 'SCHED-DN-1', destination: '석남행', line: '7' });
     const { getByText, queryByText, getByTestId } = renderWithTheme(
       <BoardingTrainList arrivals={[fallback]} line="7" onSelect={() => {}} />,
     );
@@ -125,7 +127,7 @@ describe('BoardingTrainList', () => {
   });
 
   it('#749 nextStationLabel 전달 시 종착 + 방면 동시 표시 ("○○행 · ○○방면")', () => {
-    const train = makeTrain({ trainCode: 'T-NEXT', destination: '석남', line: '7' });
+    const train = makeTrain({ trainCode: 'T-NEXT', destination: '석남행', line: '7' });
     const { getByTestId } = renderWithTheme(
       <BoardingTrainList
         arrivals={[train]}
@@ -138,7 +140,7 @@ describe('BoardingTrainList', () => {
   });
 
   it('#749 nextStationLabel null이면 종착만 표시 (방면 생략)', () => {
-    const train = makeTrain({ trainCode: 'T-NO-NEXT', destination: '석남', line: '7' });
+    const train = makeTrain({ trainCode: 'T-NO-NEXT', destination: '석남행', line: '7' });
     const { getByTestId } = renderWithTheme(
       <BoardingTrainList
         arrivals={[train]}
@@ -167,7 +169,7 @@ describe('BoardingTrainList', () => {
   });
 
   it('#749 compact 모드: 헤더/trainCode 라인 생략, 단일 row 종착·방면 라벨', () => {
-    const train = makeTrain({ trainCode: 'T-COMPACT', destination: '석남', line: '7' });
+    const train = makeTrain({ trainCode: 'T-COMPACT', destination: '석남행', line: '7' });
     const { getByTestId, queryByText } = renderWithTheme(
       <BoardingTrainList
         arrivals={[train]}
@@ -183,7 +185,7 @@ describe('BoardingTrainList', () => {
   });
 
   it('#749 compact 모드에서도 카운터 + 시각 표기', () => {
-    const train = makeTrain({ trainCode: 'T-CO-SEQ', destination: '석남', line: '7' });
+    const train = makeTrain({ trainCode: 'T-CO-SEQ', destination: '석남행', line: '7' });
     const { getByTestId } = renderWithTheme(
       <BoardingTrainList
         arrivals={[train]}
@@ -203,6 +205,62 @@ describe('BoardingTrainList', () => {
     );
     expect(getByTestId('boarding-train-list-empty')).toBeTruthy();
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
+  });
+
+  describe('#792 종착/방면 라벨 중복 제거', () => {
+    it('destination "어린이대공원(세종대)방면" + nextStationLabel "어린이대공원" → 접미사 생략 (중복 차단)', () => {
+      const train = makeTrain({
+        trainCode: 'T-DEDUP',
+        destination: '어린이대공원(세종대)방면',
+        line: '7',
+      });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="7"
+          onSelect={() => {}}
+          nextStationLabel="어린이대공원"
+        />,
+      );
+      expect(getByTestId('boarding-train-meta-T-DEDUP').props.children).toBe(
+        '어린이대공원(세종대)방면',
+      );
+    });
+
+    it('destination "내선순환"은 parseTrainLineDirection으로 정규화되어 "행" 미부착', () => {
+      const train = makeTrain({ trainCode: 'T-LOOP', destination: '내선순환', line: '2' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-meta-T-LOOP').props.children).toBe('내선순환');
+    });
+
+    it('destination "도봉산행"은 정규화 결과 그대로 표기, 다른 nextStationLabel은 정상 부착', () => {
+      const train = makeTrain({ trainCode: 'T-NORMAL', destination: '도봉산행', line: '7' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="7"
+          onSelect={() => {}}
+          nextStationLabel="중곡"
+        />,
+      );
+      expect(getByTestId('boarding-train-meta-T-NORMAL').props.children).toBe('도봉산행 · 중곡방면');
+    });
+
+    it('substring false-positive 방지: "도봉산행" + "도봉" → terminal 정확비교라 정상 부착', () => {
+      // 1호선 망월사 시뮬레이션. P1-1: 이전 includes() 기반 dedup은 false-positive로 "도봉산행"만 표시했음.
+      const train = makeTrain({ trainCode: 'T-PREFIX', destination: '도봉산행', line: '1' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="1"
+          onSelect={() => {}}
+          nextStationLabel="도봉"
+        />,
+      );
+      expect(getByTestId('boarding-train-meta-T-PREFIX').props.children).toBe('도봉산행 · 도봉방면');
+    });
   });
 
   describe('#664 환승역 line 필터 + 호선 색 stripe', () => {

--- a/src/components/__tests__/MisBoardingReselectModal.test.tsx
+++ b/src/components/__tests__/MisBoardingReselectModal.test.tsx
@@ -80,7 +80,8 @@ describe('MisBoardingReselectModal', () => {
   });
 
   it('#749 nextStationLabel을 BoardingTrainList로 forward — "○○행 · ○○방면" 표기', () => {
-    const train = makeTrain({ trainCode: 'C', destination: '도봉산', line: '7' });
+    // destination은 Seoul API trainLineNm 원본 포맷("도봉산행"). #792 parseTrainLineDirection 정규화.
+    const train = makeTrain({ trainCode: 'C', destination: '도봉산행', line: '7' });
     const { getByTestId } = renderWithTheme(
       <MisBoardingReselectModal
         visible

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -227,7 +227,8 @@
   "direction": {
     "boundFor": "Bound for {{name}}",
     "innerLoop": "Inner Loop",
-    "outerLoop": "Outer Loop"
+    "outerLoop": "Outer Loop",
+    "viaName": "via {{name}}"
   },
   "source": {
     "positionTrain": "Train data",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -227,7 +227,8 @@
   "direction": {
     "boundFor": "{{name}}行き",
     "innerLoop": "内回り",
-    "outerLoop": "外回り"
+    "outerLoop": "外回り",
+    "viaName": "{{name}}方面"
   },
   "source": {
     "positionTrain": "列車データ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -227,7 +227,8 @@
   "direction": {
     "boundFor": "{{name}}행",
     "innerLoop": "내선순환",
-    "outerLoop": "외선순환"
+    "outerLoop": "외선순환",
+    "viaName": "{{name}}방면"
   },
   "source": {
     "positionTrain": "열차 데이터",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -227,7 +227,8 @@
   "direction": {
     "boundFor": "开往{{name}}",
     "innerLoop": "内环",
-    "outerLoop": "外环"
+    "outerLoop": "外环",
+    "viaName": "{{name}}方向"
   },
   "source": {
     "positionTrain": "列车数据",

--- a/src/utils/__tests__/trainLineDirection.test.ts
+++ b/src/utils/__tests__/trainLineDirection.test.ts
@@ -1,11 +1,17 @@
 import i18next from 'i18next';
-import { parseTrainLineDirection } from '../trainLineDirection';
+import {
+  parseTrainLineDirection,
+  getTerminalStationName,
+  buildDirectionMeta,
+} from '../trainLineDirection';
 import type { Station } from '../../types/station';
 
 const stations: Station[] = [
   { id: '1-001', name: '소요산', nameEn: 'Soyosan', line: '1', lineColor: '#0052A4', lat: 37, lng: 127 },
   { id: '1-141', name: '구로', nameEn: 'Guro', line: '1', lineColor: '#0052A4', lat: 37, lng: 127 },
+  { id: '1-100', name: '도봉산', nameEn: 'Dobongsan', line: '1', lineColor: '#0052A4', lat: 37, lng: 127 },
   { id: '5-555', name: '없는역', line: '5', lineColor: '#996CAC', lat: 37, lng: 127 },
+  { id: '5-216', name: '어린이대공원', nameEn: 'Children\'s Grand Park', line: '5', lineColor: '#996CAC', lat: 37, lng: 127 },
 ];
 
 describe('parseTrainLineDirection', () => {
@@ -29,5 +35,98 @@ describe('parseTrainLineDirection', () => {
   ])('lang=%s, input=%s → %s', async (lang, input, expected) => {
     await i18next.changeLanguage(lang);
     expect(parseTrainLineDirection(input, stations)).toBe(expected);
+  });
+});
+
+describe('getTerminalStationName (#792)', () => {
+  // i18n에 독립적인 순수 추출 함수 — locale 전환 불필요.
+  it.each([
+    // 일반 종착
+    ['도봉산행', '도봉산'],
+    ['소요산행', '소요산'],
+    ['구로행', '구로'],
+    // 방면 패턴 (지선/분기)
+    ['어린이대공원방면', '어린이대공원'],
+    // 방면 + 괄호 별칭 (#792 회귀 원본)
+    ['어린이대공원(세종대)방면', '어린이대공원'],
+    ['응암(은평구청)방면', '응암'],
+  ])('terminal 추출: "%s" → "%s"', (input, expected) => {
+    expect(getTerminalStationName(input)).toBe(expected);
+  });
+
+  it.each([
+    // 순환선은 종착 없음
+    ['내선순환'],
+    ['외선순환'],
+    // 빈 문자열
+    [''],
+  ])('null 반환: "%s"', (input) => {
+    expect(getTerminalStationName(input)).toBeNull();
+  });
+
+  it('비정형 텍스트는 null (안전한 fallback — caller가 dedup 못 함)', () => {
+    expect(getTerminalStationName('급행임시')).toBeNull();
+    expect(getTerminalStationName('운행중')).toBeNull();
+  });
+});
+
+describe('buildDirectionMeta (#792)', () => {
+  afterEach(async () => {
+    await i18next.changeLanguage('ko');
+  });
+
+  describe('회귀 가드 — substring false-positive 방지', () => {
+    it('destination="도봉산행" + nextStationLabel="도봉" → 정상 부착 (terminal "도봉산" ≠ "도봉")', () => {
+      // 1호선 망월사 시뮬레이션. 이전 includes() 기반 dedup은 false-positive로 방면 정보를 누락했음.
+      expect(buildDirectionMeta('도봉산행', '도봉', stations)).toBe('도봉산행 · 도봉방면');
+    });
+
+    it('destination="도봉산행" + nextStationLabel="도봉산" → dedup (terminal 정확 일치)', () => {
+      expect(buildDirectionMeta('도봉산행', '도봉산', stations)).toBe('도봉산행');
+    });
+
+    it('destination="어린이대공원(세종대)방면" + nextStationLabel="어린이대공원" → dedup (#792 원본 회귀)', () => {
+      expect(buildDirectionMeta('어린이대공원(세종대)방면', '어린이대공원', stations)).toBe(
+        '어린이대공원(세종대)방면',
+      );
+    });
+  });
+
+  describe('순환선/nextStationLabel 미전달', () => {
+    it('nextStationLabel=null이면 종착만 표기', () => {
+      expect(buildDirectionMeta('소요산행', null, stations)).toBe('소요산행');
+    });
+
+    it('순환선은 terminal null이라 항상 부속 라벨 부착 (nextStationLabel 있을 때)', () => {
+      expect(buildDirectionMeta('내선순환', '신도림', stations)).toBe('내선순환 · 신도림방면');
+    });
+
+    it('순환선 + nextStationLabel=null → 순환선만', () => {
+      expect(buildDirectionMeta('내선순환', null, stations)).toBe('내선순환');
+    });
+  });
+
+  describe('다국어 (#792 P1-2)', () => {
+    it('en locale에서도 dedup 정상 동작 (terminal 비교는 i18n 독립)', async () => {
+      await i18next.changeLanguage('en');
+      expect(buildDirectionMeta('어린이대공원(세종대)방면', '어린이대공원', stations)).toBe(
+        '어린이대공원(세종대)방면',
+      );
+    });
+
+    it('en locale 부속 라벨은 "via {{name}}" 포맷', async () => {
+      await i18next.changeLanguage('en');
+      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('Bound for Soyosan · via 구로');
+    });
+
+    it('ja locale 부속 라벨은 "{{name}}方面" 포맷 (역명은 nameJa 없으면 nameEn fallback)', async () => {
+      await i18next.changeLanguage('ja');
+      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('Soyosan行き · 구로方面');
+    });
+
+    it('zh locale 부속 라벨은 "{{name}}方向" 포맷 (역명은 nameHanja 없으면 nameEn fallback)', async () => {
+      await i18next.changeLanguage('zh');
+      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('开往Soyosan · 구로方向');
+    });
   });
 });

--- a/src/utils/__tests__/trainLineDirection.test.ts
+++ b/src/utils/__tests__/trainLineDirection.test.ts
@@ -60,6 +60,10 @@ describe('getTerminalStationName (#792)', () => {
     ['외선순환'],
     // 빈 문자열
     [''],
+    // 접미사 단독 입력 — 역명 0길이라 null fallback
+    ['방면'],
+    ['(별칭)방면'],
+    ['행'],
   ])('null 반환: "%s"', (input) => {
     expect(getTerminalStationName(input)).toBeNull();
   });

--- a/src/utils/trainLineDirection.ts
+++ b/src/utils/trainLineDirection.ts
@@ -5,6 +5,7 @@ import { getStationDisplayNameByName } from './stationDisplay';
 // 서울 열린데이터 API의 trainLineNm 필드는 순수 역명이 아닌 방면 표현을 담는다:
 //   - "<역명>행" 일반 노선 (소요산행, 성수행, 광운대행 등)
 //   - "내선순환" / "외선순환" 2호선 순환선 특수
+//   - "<역명>방면" 또는 "<역명>(<별칭>)방면" — 종착이 본선 외 지선 분기 시 (#792 회귀에서 관찰)
 // 이 함수는 패턴을 인식해 현재 언어로 자연스러운 방면 표시를 반환한다.
 // 매칭 안 되는 입력은 원본을 그대로 반환 (fallback).
 export function parseTrainLineDirection(
@@ -23,4 +24,57 @@ export function parseTrainLineDirection(
   }
 
   return trainLineNm;
+}
+
+/**
+ * #792: 종착역의 "기준 역명"만 추출한다. dedup용 정확 비교 키.
+ *
+ * 패턴별 추출:
+ *   "도봉산행"               → "도봉산"
+ *   "어린이대공원(세종대)방면" → "어린이대공원"   (괄호 안 별칭/노선 표기 제거)
+ *   "어린이대공원방면"         → "어린이대공원"
+ *   "내선순환" / "외선순환"    → null            (순환선은 종착이 없음)
+ *   ""                       → null
+ *   "비정형 텍스트"            → null            (외부 호출자는 비교 못 함 → 안전한 fallback)
+ *
+ * 호출자(`buildDirectionMeta`)는 추출된 terminal이 nextStationLabel과 **정확히 같을 때만** dedup해
+ * substring false-positive(예: "도봉산행".includes("도봉")=true → 잘못된 dedup)를 방지한다.
+ */
+const BOUND_FOR_RE = /^(?<terminal>.+?)행$/;
+const VIA_NAME_RE = /^(?<terminal>.+?)(?:\([^)]*\))?방면$/;
+
+export function getTerminalStationName(trainLineNm: string): string | null {
+  if (!trainLineNm) return null;
+  if (trainLineNm === '내선순환' || trainLineNm === '외선순환') return null;
+
+  const viaMatch = VIA_NAME_RE.exec(trainLineNm);
+  if (viaMatch?.groups?.terminal) return viaMatch.groups.terminal;
+
+  const boundMatch = BOUND_FOR_RE.exec(trainLineNm);
+  if (boundMatch?.groups?.terminal) return boundMatch.groups.terminal;
+
+  return null;
+}
+
+/**
+ * #792: 종착·방면 라벨 빌더. parseTrainLineDirection으로 종착 표기 i18n 정규화 후, nextStationLabel과
+ * 종착 역명이 같으면 "방면" 접미사 생략(중복 차단). 다국어 부속 라벨은 `direction.viaName` 키 사용.
+ *
+ * 회귀 가드:
+ *   - destination="어린이대공원(세종대)방면", nextStationLabel="어린이대공원" → terminal 일치 → dedup ✓
+ *   - destination="도봉산행", nextStationLabel="도봉" → terminal "도봉산" ≠ "도봉" → 정상 부착 ✓
+ *     (이전 substring 기반은 false-positive로 dedup해 사용자에게 방면 정보 누락)
+ *   - destination="도봉산행", nextStationLabel="도봉산" → terminal 일치 → dedup ✓
+ *   - destination="내선순환" → terminal null → 항상 부속 라벨 부착 (단 nextStationLabel 있을 때)
+ */
+export function buildDirectionMeta(
+  destination: string,
+  nextStationLabel: string | null,
+  stations: readonly Station[],
+): string {
+  const direction = parseTrainLineDirection(destination, stations);
+  if (!nextStationLabel) return direction;
+  const terminal = getTerminalStationName(destination);
+  if (terminal !== null && terminal === nextStationLabel) return direction;
+  return `${direction} · ${i18next.t('direction.viaName', { name: nextStationLabel })}`;
 }

--- a/src/utils/trainLineDirection.ts
+++ b/src/utils/trainLineDirection.ts
@@ -39,20 +39,27 @@ export function parseTrainLineDirection(
  *
  * 호출자(`buildDirectionMeta`)는 추출된 terminal이 nextStationLabel과 **정확히 같을 때만** dedup해
  * substring false-positive(예: "도봉산행".includes("도봉")=true → 잘못된 dedup)를 방지한다.
+ *
+ * 구현 노트: `.+?` 같은 lazy quantifier + optional group 조합은 ReDoS(super-linear backtracking)
+ * 위험이라 sonar:typescript:S5852가 잡는다. suffix 매칭 + 단순 char-class 정규식으로 회피한다.
  */
-const BOUND_FOR_RE = /^(?<terminal>.+?)행$/;
-const VIA_NAME_RE = /^(?<terminal>.+?)(?:\([^)]*\))?방면$/;
+const TRAILING_PAREN_ALIAS_RE = /\([^()]*\)$/;
+const TERMINAL_SUFFIX_BOUND_FOR = '행';
+const TERMINAL_SUFFIX_VIA_NAME = '방면';
 
 export function getTerminalStationName(trainLineNm: string): string | null {
   if (!trainLineNm) return null;
   if (trainLineNm === '내선순환' || trainLineNm === '외선순환') return null;
 
-  const viaMatch = VIA_NAME_RE.exec(trainLineNm);
-  if (viaMatch?.groups?.terminal) return viaMatch.groups.terminal;
-
-  const boundMatch = BOUND_FOR_RE.exec(trainLineNm);
-  if (boundMatch?.groups?.terminal) return boundMatch.groups.terminal;
-
+  if (trainLineNm.endsWith(TERMINAL_SUFFIX_VIA_NAME)) {
+    const withoutSuffix = trainLineNm.slice(0, -TERMINAL_SUFFIX_VIA_NAME.length);
+    const withoutAlias = withoutSuffix.replace(TRAILING_PAREN_ALIAS_RE, '');
+    return withoutAlias.length > 0 ? withoutAlias : null;
+  }
+  if (trainLineNm.endsWith(TERMINAL_SUFFIX_BOUND_FOR)) {
+    const withoutSuffix = trainLineNm.slice(0, -TERMINAL_SUFFIX_BOUND_FOR.length);
+    return withoutSuffix.length > 0 ? withoutSuffix : null;
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- 2026-06-03 실기기 트립 항목 15/16: "도봉산행 - 어린이대공원(세종대)방면행 · 어린이대공원방면" 같은 라벨 중복.
- 1차 회귀(원본): `destination`에 "방면" 포함된 경우에도 "행" 자동 부착 + nextStationLabel과 destination station 이름 중복 부착.
- 2차 회귀(리뷰에서 추가 발견): substring 기반 dedup(`includes`)이 false-positive 발생. 1호선 망월사역에서 `destination="도봉산행"` + `nextStationLabel="도봉"` → `includes` 조건 매치 → 방면 정보 누락 (528개 역에서 66건 잠재 충돌).
- 3차 회귀: "방면" 접미사가 한국어 하드코딩 → 영문/일문/중문 locale에서 회귀 차단 동작 안 함.

## 변경 사항
- `parseTrainLineDirection` 모듈에 두 신 함수:
  - `getTerminalStationName(trainLineNm)`: "X행" / "X(Y)방면" 패턴에서 terminal 정확 추출. dedup용 정확 비교 키. 순환선/비정형은 null.
  - `buildDirectionMeta(destination, nextStationLabel, stations)`: parseTrainLineDirection으로 정규화 + terminal === nextStationLabel일 때만 dedup + i18n viaName 합성.
- `direction.viaName` i18n 키 4개 locale 추가 (ko: "{{name}}방면", en: "via {{name}}", ja: "{{name}}方面", zh: "{{name}}方向")
- BoardingTrainList는 utils의 `buildDirectionMeta` 호출만. 컴포넌트에서 stations.json 의존 제거 (caller로 전달).
- 테스트 fixture 정규화: 강남→강남행, 석남→석남행, 도봉산→도봉산행 (Seoul API 실제 응답 포맷)

## Test plan
- [x] `trainLineDirection.test.ts` parseTrainLineDirection + getTerminalStationName + buildDirectionMeta 27건 PASS
- [x] BoardingTrainList 통합 테스트 24건 PASS (#792 dedup 4건 + 망월사 false-positive 가드)
- [x] MisBoardingReselectModal 5/5 PASS (fixture 정규화 후)
- [x] en/ja/zh locale 단위 테스트 PASS (회귀 차단이 locale 독립)
- [x] 전체 테스트 2848/2848 PASS, 156/156 suites PASS
- [x] `npm run type-check` 통과
- [ ] 실기기 검증: 어린이대공원 방면 케이스 dedup
- [ ] 실기기 검증: 1호선 도봉산 방면 (망월사 시나리오) 정상 부착

Closes #792