### PR TITLE
fix(#796): multi-transfer 환승역 정확 도착 timing의 잘못된 transfer 안내 차단

### DIFF
--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -478,7 +478,12 @@ export function useStationAlarm({
             logSuppressedDedupStation('fg', candidateStation);
             return;
           }
-          const target = resolveNextTarget(capturedRoute, capturedDestinationName);
+          // #796: candidateStation.line을 전달해 multi-transfer 환승역 정확 식별.
+          const target = resolveNextTarget(
+            capturedRoute,
+            capturedDestinationName,
+            candidateStation.line,
+          );
           // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
           await sendStationPassedNotification(
             candidateStation.name,

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -202,6 +202,38 @@ describe('processLocationUpdate', () => {
         expect.any(Array),
       );
     });
+
+    // #796 P1-1: resolveNextTarget도 같은 lock-degraded currentLine을 사용해야 함.
+    // BG GPS jitter로 nearest가 옆 노선 station(예: 5호선 군자)을 잡아도 lock(7호선) SSOT로
+    // segment 식별하여 다음-다음 transfer로 잘못 넘어가지 않는다.
+    it('#796 P1-1 lock 활성 시 resolveNextTarget의 currentLine도 lock.boardingLine 사용', async () => {
+      // 7→5→8 multi-transfer route. GPS는 5호선 군자 station(line='5')으로 jitter됐지만
+      // 실제 사용자는 7호선 탑승 중이라 lock.boardingLine='7'.
+      const multiRoute = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '군자', fromLine: '7', toLine: '5', stopsToTransfer: 0 },
+          { transferName: '천호', fromLine: '5', toLine: '8', stopsToTransfer: 6 },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      const stationOn5: Station = { ...mockStation, line: '5' };
+      mockFindNearestStation.mockReturnValue({ station: stationOn5, distanceKm: 0.1 });
+      mockFindRoute.mockReturnValue(multiRoute);
+      mockIsStationOnRoute.mockReturnValue(true);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockGetBoardingLock.mockResolvedValue(lockOnLine7);
+
+      await call();
+
+      // raw GPS line이라면 transfer[1]=천호로 잘못 넘어갔을 것 (segment[1].fromLine='5'와 매칭).
+      // lock SSOT 적용으로 transfer[0]=군자 안내가 유지된다.
+      expect(mockSendStationPassedNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ nextStationName: '군자', isTransfer: true }),
+        undefined,
+      );
+    });
   });
 
   it('passes null etaSeconds when speedMps is not provided', async () => {

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -873,4 +873,127 @@ describe('resolveNextTarget', () => {
       stopsToDestination: 11,
     });
   });
+
+  describe('#796 currentLine 기반 segment 식별 (multi-transfer 회귀)', () => {
+    it('회귀: multi-transfer 첫 환승역에 도착(stopsToTransfer=0)했어도 currentLine === fromLine이면 그 transfer 반환', () => {
+      // 2026-06-03 실기기 회귀: 군자(7→5) 정확 도착 시 천호(5→8)로 잘못 안내됨.
+      // updateRouteFromPosition이 군자_7호선에서 stopsToTransfer=0으로 갱신한 직후, 사용자는
+      // 아직 7호선에 있으나 legacy 로직은 transfers[1](천호)을 반환했음.
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '군자', fromLine: '7', toLine: '5', stopsToTransfer: 0 },
+          { transferName: '천호', fromLine: '5', toLine: '8', stopsToTransfer: 6 },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      expect(resolveNextTarget(route, '어린이대공원', '7')).toEqual({
+        nextStationName: '군자',
+        stopsToNextStation: 0,
+        isTransfer: true,
+        stopsToDestination: 8,
+      });
+    });
+
+    it('currentLine === segment[1].fromLine(5호선)이면 transfer[1] 반환 (환승 완료 후)', () => {
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '군자', fromLine: '7', toLine: '5', stopsToTransfer: 0 },
+          { transferName: '천호', fromLine: '5', toLine: '8', stopsToTransfer: 4 },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      expect(resolveNextTarget(route, '어린이대공원', '5')).toEqual({
+        nextStationName: '천호',
+        stopsToNextStation: 4,
+        isTransfer: true,
+        stopsToDestination: 6,
+      });
+    });
+
+    it('currentLine === lastTransfer.toLine(8호선)이면 destination 반환', () => {
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '군자', fromLine: '7', toLine: '5', stopsToTransfer: 0 },
+          { transferName: '천호', fromLine: '5', toLine: '8', stopsToTransfer: 0 },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      expect(resolveNextTarget(route, '어린이대공원', '8')).toEqual({
+        nextStationName: '어린이대공원',
+        stopsToNextStation: 2,
+        isTransfer: false,
+        stopsToDestination: 2,
+      });
+    });
+
+    it('currentLine 어느 segment에도 매칭 안 되면 legacy(stopsToTransfer>0) fallback', () => {
+      // 사용자가 route 밖 노선(예: 1호선)에 있는 비정상 케이스 — legacy로 안전하게 fallthrough.
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '군자', fromLine: '7', toLine: '5', stopsToTransfer: 3 },
+          { transferName: '천호', fromLine: '5', toLine: '8', stopsToTransfer: 6 },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      expect(resolveNextTarget(route, '어린이대공원', '1')).toEqual({
+        nextStationName: '군자',
+        stopsToNextStation: 3,
+        isTransfer: true,
+        stopsToDestination: 11,
+      });
+    });
+
+    it('single transfer: currentLine === fromLine 이면 stopsToTransfer=0이어도 transfer 안내 유지 (환승역 도착 timing)', () => {
+      // 동일한 회귀 패턴이 single transfer에서도 발생할 수 있음 — 환승역 정확 도착 시점.
+      const route = makeTransferRoute({
+        transferName: '군자', fromLine: '7', toLine: '5',
+        stopsToTransfer: 0, stopsFromTransfer: 9,
+      });
+      expect(resolveNextTarget(route, '이대', '7')).toEqual({
+        nextStationName: '군자',
+        stopsToNextStation: 0,
+        isTransfer: true,
+        stopsToDestination: 9,
+      });
+    });
+
+    it('single transfer: currentLine === toLine 이면 destination (환승 완료 후)', () => {
+      const route = makeTransferRoute({
+        transferName: '군자', fromLine: '7', toLine: '5',
+        stopsToTransfer: 0, stopsFromTransfer: 3,
+      });
+      expect(resolveNextTarget(route, '이대', '5')).toEqual({
+        nextStationName: '이대',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
+    });
+
+    it('single transfer: currentLine 미매칭이면 legacy fallback (stopsToTransfer > 0이면 transfer)', () => {
+      const route = makeTransferRoute({
+        transferName: '군자', fromLine: '7', toLine: '5',
+        stopsToTransfer: 2, stopsFromTransfer: 9,
+      });
+      expect(resolveNextTarget(route, '이대', '1')).toEqual({
+        nextStationName: '군자',
+        stopsToNextStation: 2,
+        isTransfer: true,
+        stopsToDestination: 11,
+      });
+    });
+
+    it('single transfer: currentLine 미매칭이면 legacy fallback (stopsToTransfer = 0이면 destination)', () => {
+      const route = makeTransferRoute({
+        transferName: '군자', fromLine: '7', toLine: '5',
+        stopsToTransfer: 0, stopsFromTransfer: 3,
+      });
+      expect(resolveNextTarget(route, '이대', '1')).toEqual({
+        nextStationName: '이대',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
+    });
+  });
 });

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -16,7 +16,7 @@ import {
 } from './alarmLog';
 import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
-import type { NearestStationResult, Station } from '../types/station';
+import type { LineNumber, NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
 import type { AlarmEvent } from './stationAlarm';
 import type { FusionSource } from './pickFusedStation';
@@ -29,7 +29,27 @@ export interface NextTarget {
   stopsToDestination: number;
 }
 
-export function resolveNextTarget(route: Route, destinationName: string): NextTarget | null {
+/**
+ * 현재 route 상태와 사용자 위치(currentLine)를 기반으로 다음 안내 타겟을 결정한다.
+ *
+ * #796 회귀(2026-06-03 실기기): multi-transfer에서 사용자가 첫 환승역에 도착한 순간
+ * `transfers[0].stopsToTransfer === 0`이 되는데, 기존 로직은 이를 "통과했다"로 해석해
+ * `transfers[1]`(다음-다음 환승)을 nextTarget으로 반환했다. 실제로는 두 가지 의미가 섞여 있다:
+ *   A. 사용자가 환승역에 정확히 도착 — 아직 fromLine에 있음, 환승해야 함
+ *   B. 사용자가 환승역을 지나 toLine으로 갈아탐 — 이미 통과
+ *
+ * 두 케이스를 데이터만으로는 구분할 수 없으므로 `currentLine`을 추가 신호로 받는다.
+ * - currentLine === transfers[i].fromLine: 사용자는 segment[i]에 있으며 transfer[i] 방향. 무조건 transfer[i] 반환.
+ * - currentLine === lastTransfer.toLine: 마지막 leg에 도달. destination 반환.
+ * - currentLine 미전달 또는 unmatch: legacy(`stopsToTransfer > 0`) fallback.
+ *
+ * legacy 경로는 backward compat — 호출자가 점진적으로 currentLine을 전달하도록 한다.
+ */
+export function resolveNextTarget(
+  route: Route,
+  destinationName: string,
+  currentLine?: LineNumber,
+): NextTarget | null {
   if (!route) return null;
 
   if (route.type === 'direct') {
@@ -43,6 +63,24 @@ export function resolveNextTarget(route: Route, destinationName: string): NextTa
 
   if (route.type === 'transfer') {
     const stopsToDestination = route.stopsToTransfer + route.stopsFromTransfer;
+    // currentLine === fromLine이면 사용자는 환승 전 segment에 있음. stopsToTransfer가 0(환승역 정확 도착)이어도 transfer 안내 유지.
+    if (currentLine === route.fromLine) {
+      return {
+        nextStationName: route.transferName,
+        stopsToNextStation: route.stopsToTransfer,
+        isTransfer: true,
+        stopsToDestination,
+      };
+    }
+    if (currentLine === route.toLine) {
+      return {
+        nextStationName: destinationName,
+        stopsToNextStation: route.stopsFromTransfer,
+        isTransfer: false,
+        stopsToDestination: route.stopsFromTransfer,
+      };
+    }
+    // currentLine 미전달 또는 unmatch — legacy 폴백.
     if (route.stopsToTransfer > 0) {
       return {
         nextStationName: route.transferName,
@@ -61,6 +99,34 @@ export function resolveNextTarget(route: Route, destinationName: string): NextTa
 
   if (route.type === 'multi-transfer') {
     const { transfers } = route;
+    // currentLine 우선 — 정확한 segment 식별.
+    if (currentLine !== undefined) {
+      for (let i = 0; i < transfers.length; i++) {
+        if (transfers[i].fromLine === currentLine) {
+          let remaining = route.stopsAfterLastTransfer;
+          for (let j = i; j < transfers.length; j++) {
+            remaining += transfers[j].stopsToTransfer;
+          }
+          return {
+            nextStationName: transfers[i].transferName,
+            stopsToNextStation: transfers[i].stopsToTransfer,
+            isTransfer: true,
+            stopsToDestination: remaining,
+          };
+        }
+      }
+      const lastTransfer = transfers[transfers.length - 1];
+      if (lastTransfer && currentLine === lastTransfer.toLine) {
+        return {
+          nextStationName: destinationName,
+          stopsToNextStation: route.stopsAfterLastTransfer,
+          isTransfer: false,
+          stopsToDestination: route.stopsAfterLastTransfer,
+        };
+      }
+      // unmatched currentLine — legacy로 fallthrough.
+    }
+    // Legacy: 첫 stopsToTransfer > 0인 transfer 반환. currentLine 없는 호출자(테스트/임시 콜) 보존.
     for (let i = 0; i < transfers.length; i++) {
       const t = transfers[i];
       if (t.stopsToTransfer > 0) {
@@ -214,7 +280,8 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   if (route && isStationOnRoute(nearest.station, route)) {
     const lastNotifiedStationId = await getLastNotifiedStationId();
     if (nearest.station.id !== lastNotifiedStationId) {
-      const target = resolveNextTarget(route, destination.name);
+      // #796: 현재 nearest.station.line을 전달해 multi-transfer 환승역 도착 timing의 segment 식별 정확화.
+      const target = resolveNextTarget(route, destination.name, nearest.station.line);
       if (target) {
         // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
         await sendStationPassedNotification(

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -280,8 +280,14 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   if (route && isStationOnRoute(nearest.station, route)) {
     const lastNotifiedStationId = await getLastNotifiedStationId();
     if (nearest.station.id !== lastNotifiedStationId) {
-      // #796: 현재 nearest.station.line을 전달해 multi-transfer 환승역 도착 timing의 segment 식별 정확화.
-      const target = resolveNextTarget(route, destination.name, nearest.station.line);
+      // #796: 환승역 도착 timing의 segment 정확 식별. evaluateAlarmPhase(:233)와 동일한
+      // currentLine 결정 — lock.boardingLine 우선 → BG GPS jitter로 nearest가 옆 노선 station을
+      // 잡아도 잘못된 다음-다음 transfer 안내를 차단. lock 없으면 nearest.station.line fallback.
+      const target = resolveNextTarget(
+        route,
+        destination.name,
+        lockForLineGuard?.boardingLine ?? nearest.station.line,
+      );
       if (target) {
         // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
         await sendStationPassedNotification(


### PR DESCRIPTION
## Summary
2026-06-03 실기기 트립 항목 2: 사용자가 첫 환승역(군자)에 정확히 도착했을 때 `transfers[0].stopsToTransfer === 0`이 되는 순간 `resolveNextTarget`이 `transfers[1]`(천호)로 잘못 넘어가던 회귀를 차단.

`stopsToTransfer === 0`은 두 가지 의미가 섞여 있음:
- (A) 환승역 정확 도착, 아직 fromLine 차내
- (B) 환승 완료, toLine으로 이동

데이터만으로 구분 불가 → `currentLine` 파라미터 추가로 segment 정확 식별.

## 변경 사항
- `resolveNextTarget(route, destinationName, currentLine?)` — optional currentLine
- multi-transfer + single transfer 양쪽 동일 정책: `currentLine === fromLine`이면 그 transfer 반환 (stopsToTransfer 값 무관)
- legacy(currentLine 미전달) 경로 보존 — 기존 단위 테스트 8건 그대로 통과
- caller 2곳에 currentLine 전달:
  - `stationPipeline.ts` — `lockForLineGuard?.boardingLine ?? nearest.station.line` (#707 lock SSOT와 통일)
  - `useStationAlarm.ts` — `candidateStation.line`

## 회귀 가드 (단위 + 통합)
- 망월사 multi-transfer 시나리오 (군자 정확 도착 + 천호로 잘못 안내 차단)
- BG GPS jitter (lock=7 + nearest=5 → 여전히 군자 안내, P1-1 review 반영)
- segment[1] 진입 후 정상 transition
- lastTransfer.toLine 도달 → destination 안내
- single transfer 환승역 도착 동일 케이스
- currentLine 미매칭 시 legacy fallback

## Test plan
- [x] stationPipeline 64/64 PASS (#796 가드 8건 + #796 P1-1 통합 1건)
- [x] 전체 테스트 2832/2832 PASS, 156/156 suites
- [x] `npm run type-check`
- [ ] 실기기: multi-transfer trip(7→5→8 형태) 첫 환승역 정확 도착 timing에서 다음-다음 transfer로 안내 안 됨

Closes #796