### PR TITLE
fix(#797): 환승역 useArrivalInfo·BoardingTrainList 호선이 trip 방향 추종

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -50,6 +50,7 @@ import { TRANSFER_WALKING_BUFFER_SECONDS, BOARDING_PROXIMITY_THRESHOLD_M } from 
 import { BoardingTrainList } from '../../src/components/BoardingTrainList';
 import { BoardingLockHopCard } from '../../src/components/BoardingLockHopCard';
 import { resolveNextAdjacentStationName } from '../../src/utils/nextAdjacentStation';
+import { getApproachLine } from '../../src/utils/approachLine';
 import type { Stop } from '../../src/utils/journeyAdapter';
 
 const logger = createLogger('HomeScreen');
@@ -142,9 +143,12 @@ export default function HomeScreen() {
   const isCustomOrigin = customOrigin !== null;
   const effectiveOrigin = customOrigin ?? result?.station ?? null;
   useTripOrigin(destination, effectiveOrigin, setTripOrigin, tripOrigin);
+  // #797: 환승역에서 nearest.station.line이 trip 방향과 어긋나는 회귀 차단.
+  // BoardingLock(사용자 선택) > Route(구조적 SSOT) > station.line fallback.
+  const approachLine = getApproachLine(route, fusionBoardingLock, effectiveOrigin);
   const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(
     effectiveOrigin?.name ?? null,
-    effectiveOrigin?.line ?? null,
+    approachLine,
   );
   const arrival = useArrivalCountdown(rawArrival);
   const isFav = effectiveOrigin ? favorites.some((f) => f.station.id === effectiveOrigin.id) : false;
@@ -709,7 +713,9 @@ export default function HomeScreen() {
                               return (
                                 <BoardingTrainList
                                   arrivals={directionalArrivals}
-                                  line={effectiveOrigin.line}
+                                  // #797: approachLine 우선 — 환승역에서 effectiveOrigin.line이 trip 방향과
+                                  // 어긋날 때 BoardingLock·route SSOT로 정확한 호선 표시.
+                                  line={approachLine ?? effectiveOrigin.line}
                                   onSelect={createLockFromTrain}
                                   compact
                                   nextStationLabel={label}

--- a/src/utils/__tests__/approachLine.test.ts
+++ b/src/utils/__tests__/approachLine.test.ts
@@ -1,0 +1,147 @@
+import { getApproachLine } from '../approachLine';
+import type {
+  Route,
+  DirectRoute,
+  TransferRoute,
+  MultiTransferRoute,
+} from '../stationRoute';
+import type { BoardingLock } from '../../types/boardingLock';
+import type { Station } from '../../types/station';
+
+function makeStation(line: Station['line'], overrides: Partial<Station> = {}): Station {
+  return {
+    id: '8-008',
+    name: '천호',
+    line,
+    lineColor: '#000',
+    lat: 37,
+    lng: 127,
+    ...overrides,
+  };
+}
+
+function makeLock(boardingLine: BoardingLock['boardingLine'], overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: 'dest',
+    trainCode: 'T1',
+    boardingStationId: '8-008',
+    boardingLine,
+    boardedAt: Date.now(),
+    expectedDurationMs: 600_000,
+    ...overrides,
+  };
+}
+
+function makeDirect(line: DirectRoute['line'], stops = 5): DirectRoute {
+  return { type: 'direct', stops, line, travelSeconds: 0 };
+}
+
+function makeTransfer(
+  fromLine: TransferRoute['fromLine'],
+  toLine: TransferRoute['toLine'],
+  stopsToTransfer = 3,
+): TransferRoute {
+  return {
+    type: 'transfer',
+    transferName: '군자',
+    fromLine,
+    toLine,
+    stopsToTransfer,
+    stopsFromTransfer: 5,
+    secondsToTransfer: 0,
+    secondsFromTransfer: 0,
+  };
+}
+
+function makeMulti(
+  segments: Array<{ from: MultiTransferRoute['transfers'][0]['fromLine']; to: MultiTransferRoute['transfers'][0]['toLine']; name: string; stops: number }>,
+  stopsAfterLastTransfer = 2,
+): MultiTransferRoute {
+  return {
+    type: 'multi-transfer',
+    transfers: segments.map((s) => ({
+      transferName: s.name,
+      fromLine: s.from,
+      toLine: s.to,
+      stopsToTransfer: s.stops,
+      secondsToTransfer: 0,
+    })),
+    stopsAfterLastTransfer,
+    secondsAfterLastTransfer: 0,
+  };
+}
+
+describe('getApproachLine', () => {
+  describe('BoardingLock SSOT (우선순위 1)', () => {
+    it('lock 존재 시 route/station 무시하고 lock.boardingLine 반환', () => {
+      const lock = makeLock('8');
+      const route = makeDirect('2');
+      const station = makeStation('5');
+      expect(getApproachLine(route, lock, station)).toBe('8');
+    });
+
+    it('lock 단독 (route/station null)도 boardingLine 반환', () => {
+      expect(getApproachLine(null, makeLock('5'), null)).toBe('5');
+    });
+  });
+
+  describe('Route 기반 (우선순위 2)', () => {
+    it('direct route → route.line', () => {
+      expect(getApproachLine(makeDirect('7'), null, makeStation('2'))).toBe('7');
+    });
+
+    it('transfer route, stopsToTransfer > 0 → fromLine (환승 전)', () => {
+      expect(getApproachLine(makeTransfer('7', '5', 3), null, null)).toBe('7');
+    });
+
+    it('transfer route, stopsToTransfer === 0 → toLine (환승 도착/완료)', () => {
+      expect(getApproachLine(makeTransfer('7', '5', 0), null, null)).toBe('5');
+    });
+
+    it('multi-transfer, 첫 segment의 stopsToTransfer > 0 → 그 fromLine', () => {
+      const route = makeMulti([
+        { name: '군자', from: '7', to: '5', stops: 3 },
+        { name: '천호', from: '5', to: '8', stops: 6 },
+      ]);
+      expect(getApproachLine(route, null, null)).toBe('7');
+    });
+
+    it('multi-transfer, 첫 segment의 stopsToTransfer === 0 → 두 번째 fromLine (= midLine)', () => {
+      const route = makeMulti([
+        { name: '군자', from: '7', to: '5', stops: 0 },
+        { name: '천호', from: '5', to: '8', stops: 6 },
+      ]);
+      expect(getApproachLine(route, null, null)).toBe('5');
+    });
+
+    it('multi-transfer, 모든 segment stopsToTransfer === 0 → lastTransfer.toLine (#797 회귀)', () => {
+      // 2026-06-03 트립 시나리오: 천호(5→8) 환승 완료 후 8호선 마지막 leg.
+      // boardingLock 없이도 route만으로 8호선임을 추정해야 함.
+      const route = makeMulti([
+        { name: '군자', from: '7', to: '5', stops: 0 },
+        { name: '천호', from: '5', to: '8', stops: 0 },
+      ]);
+      expect(getApproachLine(route, null, null)).toBe('8');
+    });
+
+    it('multi-transfer, transfers 배열 비어있으면 fallback (station.line)', () => {
+      const route: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [],
+        stopsAfterLastTransfer: 0,
+        secondsAfterLastTransfer: 0,
+      };
+      expect(getApproachLine(route, null, makeStation('2'))).toBe('2');
+    });
+  });
+
+  describe('Fallback (우선순위 3)', () => {
+    it('route null + lock null → currentStation.line', () => {
+      expect(getApproachLine(null, null, makeStation('7'))).toBe('7');
+    });
+
+    it('route null + lock null + station null → null', () => {
+      expect(getApproachLine(null, null, null)).toBeNull();
+    });
+  });
+});

--- a/src/utils/approachLine.ts
+++ b/src/utils/approachLine.ts
@@ -1,0 +1,44 @@
+import type { Route } from './stationRoute';
+import type { BoardingLock } from '../types/boardingLock';
+import type { LineNumber, Station } from '../types/station';
+
+/**
+ * #797: 현재 사용자가 탑승 중(또는 탑승 예정)인 노선을 trip route + BoardingLock SSOT로 결정한다.
+ *
+ * 회귀(2026-06-03 실기기): 환승역에서 useFusedNearestStation이 같은 이름·다른 노선 station 중
+ * 임의로 하나를 골라 `currentStation.line`이 trip 방향과 어긋났다(예: 천호 8호선 trip인데 5호선
+ * station 매칭 → BoardingTrainList가 5호선 arrivals 노출).
+ *
+ * 우선순위:
+ *   1. **BoardingLock 존재** → `boardingLock.boardingLine` (사용자가 명시 선택한 leg, 가장 강한 신호)
+ *   2. **Route + segment 진행도** → 다음 환승 전이면 fromLine, 환승 도착(stopsToTransfer===0)이면 toLine
+ *   3. **fallback** → `currentStation?.line ?? null`
+ *
+ * stopsToTransfer===0의 의미 모호성(환승역 정확 도착 vs 환승 완료)은 BoardingLock이 있으면 1번에서
+ * 해소된다. lock 없는 케이스는 "transferring or transferred"로 추정 → toLine 안내가 더 유용
+ * (사용자가 다음 leg arrivals를 봐야 함).
+ */
+export function getApproachLine(
+  route: Route,
+  boardingLock: BoardingLock | null,
+  currentStation: Station | null,
+): LineNumber | null {
+  if (boardingLock) return boardingLock.boardingLine;
+
+  if (route) {
+    if (route.type === 'direct') return route.line;
+
+    if (route.type === 'transfer') {
+      return route.stopsToTransfer > 0 ? route.fromLine : route.toLine;
+    }
+
+    // route.type === 'multi-transfer' — 위 두 분기로 exhaustive 좁혀짐.
+    for (const t of route.transfers) {
+      if (t.stopsToTransfer > 0) return t.fromLine;
+    }
+    const last = route.transfers[route.transfers.length - 1];
+    if (last) return last.toLine;
+  }
+
+  return currentStation?.line ?? null;
+}


### PR DESCRIPTION
## Summary
2026-06-03 실기기 트립 항목 8: 천호(5/8호선 환승역)에서 8호선 trip이지만 BoardingTrainList가 5호선 마천/방화 응답 표시. useFusedNearestStation이 같은 이름·다른 노선 station 중 임의로 골라 `effectiveOrigin.line`이 trip 방향과 어긋난 회귀.

`getApproachLine(route, lock, station)` SSOT 유틸로 정확한 "현재 탑승 노선" 결정:
1. BoardingLock 존재 → boardingLock.boardingLine (사용자 명시 선택)
2. Route + segment 진행도 → 첫 stopsToTransfer > 0인 segment의 fromLine, 모두 0이면 lastTransfer.toLine
3. fallback → currentStation.line

## 변경 사항
- `src/utils/approachLine.ts` (신규) — getApproachLine 유틸
- `app/(tabs)/index.tsx` — useArrivalInfo lineHint + BoardingTrainList line prop을 approachLine으로 교체

## Test plan
- [x] approachLine 11건 PASS (lock/route/fallback 우선순위 + 다양한 segment 단계, 100% 커버)
- [x] 전체 테스트 2835/2835 PASS, 157/157 suites
- [x] `npm run type-check`
- [ ] 실기기: 천호 8호선 trip에서 BoardingTrainList가 8호선 마천/방화/모란 등 노출

## 영향 범위 분석
- 다른 useArrivalInfo 호출자(useFusedNearestStation/useTransferTrainList/useStationAlarm/favorites/DebugModal) 모두 자체 SSOT 사용 → 회귀 영향 없음
- index.tsx의 origin slot 한 곳만 변경

Closes #797