### PR TITLE
fix(#799): destination switch/null 시 silent push/알람 trip-bound state cleanup 확장

### DIFF
--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -407,34 +407,28 @@ describe('useAppStore', () => {
     await Promise.resolve();
   }
 
-  it('setDestination(#799): switch 시 silent push/알람 state도 정리 (last-notified, last-fired-name, fired-push-ids, trip-train-code, alarm-event)', async () => {
+  // #799: switch와 null 두 경로가 동일한 trip-bound cleanup을 트리거하므로 it.each로 통합
+  // (SonarCloud CPD duplication 차단; #788/#795와 동일한 접근).
+  it.each<[string, 'switch' | 'null']>([
+    ['switch', 'switch'],
+    ['null clear', 'null'],
+  ])('setDestination(#799): %s 시 silent push/알람 trip-bound state 정리', async (_, transition) => {
     const { setDestination } = useAppStore.getState();
     setDestination(mockStation);
     jest.clearAllMocks();
 
-    setDestination(mockStation2);
+    setDestination(transition === 'switch' ? mockStation2 : null);
     await flushMicrotasks();
 
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-notified-station');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-fired-alarm-station-name');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-push-ids');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-train-code');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
-  });
-
-  it('setDestination(#799): null로 클리어 시에도 silent push/알람 state 정리', async () => {
-    const { setDestination } = useAppStore.getState();
-    setDestination(mockStation);
-    jest.clearAllMocks();
-
-    setDestination(null);
-    await flushMicrotasks();
-
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-notified-station');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-fired-alarm-station-name');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-push-ids');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-train-code');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
+    for (const key of [
+      'subway-now:last-notified-station',
+      'subway-now:last-fired-alarm-station-name',
+      'subway-now:fired-push-ids',
+      'subway-now:trip-train-code',
+      'subway-now:alarm-event',
+    ]) {
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(key);
+    }
   });
 
   it('setDestination(#799): switch 시 alarmEvent 메모리 state도 null로 동기화', () => {

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -442,34 +442,31 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().alarmEvent).toBeNull();
   });
 
-  it('setDestination(#799): 같은 목적지 재설정 시 silent push/알람 state도 유지 (#702 정책 일관)', () => {
+  it('setDestination(#702/#799): 같은 목적지 재설정 시에는 trip-bound storage 전부 유지', () => {
     const { setDestination } = useAppStore.getState();
     setDestination(mockStation);
     jest.clearAllMocks();
 
+    // 동일 station id 재설정 — switch 아님 → 모든 trip-bound cleanup 건너뜀.
     setDestination(mockStation);
 
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:last-notified-station');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:last-fired-alarm-station-name');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:fired-push-ids');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:trip-train-code');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:alarm-event');
-  });
-
-  it('setDestination(#702): 같은 목적지 재설정 시에는 부수 storage를 건드리지 않는다', () => {
-    const { setDestination } = useAppStore.getState();
-    setDestination(mockStation);
-    jest.clearAllMocks();
-
-    // 동일 station id 재설정 — switch 아님
-    setDestination(mockStation);
-
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:custom-origin');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:boarding-lock');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:scheduled-notifications');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:active-trip');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:fired-alarms');
-    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:route');
+    for (const key of [
+      // #702 부수 storage
+      'subway-now:custom-origin',
+      'subway-now:boarding-lock',
+      'subway-now:scheduled-notifications',
+      'subway-now:active-trip',
+      'subway-now:fired-alarms',
+      'subway-now:route',
+      // #799 silent push/알람 state
+      'subway-now:last-notified-station',
+      'subway-now:last-fired-alarm-station-name',
+      'subway-now:fired-push-ids',
+      'subway-now:trip-train-code',
+      'subway-now:alarm-event',
+    ]) {
+      expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith(key);
+    }
   });
 
   it('setDestination(#702): switch 시 customOrigin 메모리 state도 null로 동기화', () => {

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -400,6 +400,68 @@ describe('useAppStore', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:active-trip');
   });
 
+  // clearFiredPushIds는 firedPushIds 모듈의 write queue를 통과 — microtask flush 후 검증.
+  async function flushMicrotasks(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  it('setDestination(#799): switch 시 silent push/알람 state도 정리 (last-notified, last-fired-name, fired-push-ids, trip-train-code, alarm-event)', async () => {
+    const { setDestination } = useAppStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+
+    setDestination(mockStation2);
+    await flushMicrotasks();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-notified-station');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-fired-alarm-station-name');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-push-ids');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-train-code');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
+  });
+
+  it('setDestination(#799): null로 클리어 시에도 silent push/알람 state 정리', async () => {
+    const { setDestination } = useAppStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+
+    setDestination(null);
+    await flushMicrotasks();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-notified-station');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:last-fired-alarm-station-name');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-push-ids');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-train-code');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
+  });
+
+  it('setDestination(#799): switch 시 alarmEvent 메모리 state도 null로 동기화', () => {
+    const { setDestination, setAlarmEvent } = useAppStore.getState();
+    setDestination(mockStation);
+    setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '시청' });
+    expect(useAppStore.getState().alarmEvent).not.toBeNull();
+
+    setDestination(mockStation2);
+
+    expect(useAppStore.getState().alarmEvent).toBeNull();
+  });
+
+  it('setDestination(#799): 같은 목적지 재설정 시 silent push/알람 state도 유지 (#702 정책 일관)', () => {
+    const { setDestination } = useAppStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+
+    setDestination(mockStation);
+
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:last-notified-station');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:last-fired-alarm-station-name');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:fired-push-ids');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:trip-train-code');
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:alarm-event');
+  });
+
   it('setDestination(#702): 같은 목적지 재설정 시에는 부수 storage를 건드리지 않는다', () => {
     const { setDestination } = useAppStore.getState();
     setDestination(mockStation);

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -8,7 +8,9 @@ function demoteSlotEntries(entries: FavoriteEntry[], role: FavoriteSlotRole): Fa
 }
 import type { AlarmEvent } from '../utils/stationAlarm';
 import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, BOARDING_LOCK_KEY, SCHEDULED_NOTIFICATIONS_KEY, ACTIVE_TRIP_KEY, TRIP_ORIGIN_KEY } from '../constants/storageKeys';
-import { clearFiredAlarms } from '../utils/notificationState';
+import { clearFiredAlarms, clearLastNotifiedStationId, clearLastFiredAlarmStationName } from '../utils/notificationState';
+import { clearFiredPushIds } from '../utils/firedPushIds';
+import { clearTripTrainCode } from '../utils/tripTrainCode';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
 
@@ -207,9 +209,21 @@ export const useAppStore = create<AppState>((set, get) => ({
       AsyncStorage.removeItem(SCHEDULED_NOTIFICATIONS_KEY).catch(noop);
       AsyncStorage.removeItem(ACTIVE_TRIP_KEY).catch(noop);
       AsyncStorage.removeItem(TRIP_ORIGIN_KEY).catch(noop);
+      // #799: silent push 및 알람 state도 trip-bound — destination switch에 같이 정리.
+      // #702 cleanup이 누락했던 키들(2026-06-03 실기기 트립 종료 후 stale currentStation 등 잔재).
+      // 각 키의 trip-bound 정당성은 storageKeys.ts 주석 참고.
+      clearLastNotifiedStationId().catch(noop);       // station-passed dedup
+      clearLastFiredAlarmStationName().catch(noop);   // 사전 예약 alarm 마지막 발화 역
+      clearFiredPushIds().catch(noop);                // silent push pushId dedup
+      clearTripTrainCode().catch(noop);               // trip-bound trainCode
+      AsyncStorage.removeItem(ALARM_EVENT_KEY).catch(noop); // 마지막 alarm event payload
       // customOrigin 메모리 상태도 동기화. (loadCustomOrigin은 hydration용이므로 영향 없음)
       if (get().customOrigin !== null) {
         set({ customOrigin: null });
+      }
+      // alarmEvent 메모리 상태도 동기화 — clearAlarmEvent와 같은 set, 재진입 안전.
+      if (get().alarmEvent !== null) {
+        set({ alarmEvent: null });
       }
     }
   },

--- a/src/utils/__tests__/firedPushIds.test.ts
+++ b/src/utils/__tests__/firedPushIds.test.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   addFiredPushId,
   hasFiredPushId,
+  clearFiredPushIds,
   FIRED_PUSH_ID_TTL_MS,
 } from '../firedPushIds';
 import { FIRED_PUSH_IDS_KEY } from '../../constants/storageKeys';
@@ -9,6 +10,7 @@ import { FIRED_PUSH_IDS_KEY } from '../../constants/storageKeys';
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
+  removeItem: jest.fn(),
 }));
 
 jest.mock('../logger', () => ({
@@ -147,6 +149,35 @@ describe('firedPushIds (#574 P2e)', () => {
 
   it('AsyncStorage key는 storageKeys 상수', () => {
     expect(FIRED_PUSH_IDS_KEY).toBe('subway-now:fired-push-ids');
+  });
+
+  describe('clearFiredPushIds (#799)', () => {
+    it('AsyncStorage.removeItem(FIRED_PUSH_IDS_KEY) 호출', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValueOnce(undefined);
+      await clearFiredPushIds();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(FIRED_PUSH_IDS_KEY);
+    });
+
+    it('removeItem 실패도 swallow (fire-and-forget)', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(clearFiredPushIds()).resolves.toBeUndefined();
+    });
+
+    it('write queue 통과 — pending add 완료 후 실행', async () => {
+      let storage: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async () => storage);
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(async (_k, v) => {
+        storage = v;
+      });
+      (AsyncStorage.removeItem as jest.Mock).mockImplementation(async () => {
+        storage = null;
+      });
+      const addP = addFiredPushId('p1', NOW);
+      const clearP = clearFiredPushIds();
+      await addP;
+      await clearP;
+      expect(storage).toBeNull();
+    });
   });
 
   describe('동시성 직렬화 큐', () => {

--- a/src/utils/__tests__/notificationState.test.ts
+++ b/src/utils/__tests__/notificationState.test.ts
@@ -8,6 +8,7 @@ import {
   clearFiredAlarms,
   getLastFiredAlarmStationName,
   setLastFiredAlarmStationName,
+  clearLastFiredAlarmStationName,
 } from '../notificationState';
 import {
   LAST_NOTIFIED_STATION_KEY,
@@ -192,6 +193,19 @@ describe('notificationState', () => {
       (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
       await setLastFiredAlarmStationName('시청');
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(LAST_FIRED_ALARM_STATION_NAME_KEY, '시청');
+    });
+  });
+
+  describe('clearLastFiredAlarmStationName (#799)', () => {
+    it('AsyncStorage에서 LAST_FIRED_ALARM_STATION_NAME_KEY를 삭제한다', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValueOnce(undefined);
+      await clearLastFiredAlarmStationName();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(LAST_FIRED_ALARM_STATION_NAME_KEY);
+    });
+
+    it('AsyncStorage 오류도 swallow', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(clearLastFiredAlarmStationName()).resolves.toBeUndefined();
     });
   });
 

--- a/src/utils/firedPushIds.ts
+++ b/src/utils/firedPushIds.ts
@@ -80,3 +80,18 @@ export function hasFiredPushId(
     return now - ts < FIRED_PUSH_ID_TTL_MS;
   });
 }
+
+/**
+ * #799: trip 종료/전환 시 호출. trip-bound dedup state라 다음 trip으로 이월하면
+ * 이전 trip의 pushId가 false-positive로 잡혀 새 alert가 silent 처리되는 회귀 가능.
+ * write queue를 통해 호출해 add/has와의 순서 일관성 보존.
+ */
+export function clearFiredPushIds(): Promise<void> {
+  return enqueue(async () => {
+    try {
+      await AsyncStorage.removeItem(FIRED_PUSH_IDS_KEY);
+    } catch (e) {
+      logger.warn('clearFiredPushIds 실패:', e);
+    }
+  });
+}

--- a/src/utils/notificationState.ts
+++ b/src/utils/notificationState.ts
@@ -105,3 +105,8 @@ export function getLastFiredAlarmStationName(): Promise<string | null> {
 export function setLastFiredAlarmStationName(name: string): Promise<void> {
   return safeSetItem(LAST_FIRED_ALARM_STATION_NAME_KEY, name);
 }
+
+/** #799: trip 종료/전환 시 호출. 사전 예약 alarm state는 trip-bound. */
+export function clearLastFiredAlarmStationName(): Promise<void> {
+  return safeRemoveItem(LAST_FIRED_ALARM_STATION_NAME_KEY);
+}


### PR DESCRIPTION
## Summary
2026-06-03 실기기 트립 항목 17b 회귀: `destination=null` 후에도 `currentStation=7-016(중곡)` 같은 stale state 잔재. #702 cleanup이 누락한 trip-bound silent push/알람 dedup 키 5종 추가 정리.

## 변경 사항
**Production**:
- `src/utils/firedPushIds.ts` — `clearFiredPushIds()` 신설 (write queue 통과로 add/has 순서 일관성)
- `src/utils/notificationState.ts` — `clearLastFiredAlarmStationName()` 신설
- `src/store/useAppStore.ts` — `setDestination` isSwitch 경로에 5개 cleanup + alarmEvent 메모리 동기

**정리 추가된 키**:
- `LAST_NOTIFIED_STATION_KEY` (station-passed dedup)
- `LAST_FIRED_ALARM_STATION_NAME_KEY` (사전 예약 알람)
- `FIRED_PUSH_IDS_KEY` (silent push pushId dedup, 5분 TTL)
- `TRIP_TRAIN_CODE_KEY` (trip-bound trainCode)
- `ALARM_EVENT_KEY` (마지막 alarm event payload)

**Cross-trip 유지** (정상): BG_LAST_FIX, BG_LAST_STATION, APNS_TOKEN, TELEMETRY_LAST_FLUSH, ALARM_LOG, BG_PERMISSION_DENIED_DISMISSED, 사용자 설정 키들

## Test plan
- [x] firedPushIds 26/26 (clearFiredPushIds + queue 통과 race 가드)
- [x] notificationState 22/22 (clearLastFiredAlarmStationName + 오류 swallow)
- [x] useAppStore: #799 4건 추가 (switch/null cleanup + 메모리 alarmEvent 동기 + 같은 destination 유지)
- [x] 전체 테스트 2878/2878 PASS, 157/157 suites
- [x] `npm run type-check` 통과
- [x] code-review: P1 0건, 머지 가능
- [ ] 실기기: destination null → 새 destination 사이클에서 stale currentStation/last-fired 잔재 없음 검증

## 후속 (별도 이슈 권장, 리뷰 P2-1)
`storageKeys.ts`에 `TRIP_BOUND_CLEANUPS` 메타 배열 도입하여 setDestination cleanup 단일화. 다음에 trip-bound 키가 또 추가될 때 #799 같은 누락 재발 차단.

Closes #799