### PR TITLE
fix(#804): EditorialTimeline marker dot을 connector와 column center 기준으로 정렬

### DIFF
--- a/src/components/EditorialTimeline.tsx
+++ b/src/components/EditorialTimeline.tsx
@@ -205,10 +205,12 @@ const styles = StyleSheet.create({
     position: 'relative',
     gap: spacing.md,
   },
-  markerCol: { width: 28, alignItems: 'flex-start', paddingLeft: 7 },
+  // #804 — dot 폭(10/12/7px)이 종류별로 달라도 markerCol(width 28) center에 자동 정렬되도록
+  // alignItems: 'center'. connector(width 1)도 같은 center(left 14)에 두면 dot/connector 어긋남 없음.
+  markerCol: { width: 28, alignItems: 'center' },
   connector: {
     position: 'absolute',
-    left: 13,
+    left: 14,
     top: 18,
     bottom: -6,
     width: 1,
@@ -216,7 +218,7 @@ const styles = StyleSheet.create({
   dot:     { width: 10, height: 10, borderRadius: 5 },
   dotRing: { width: 12, height: 12, borderRadius: 6, borderWidth: 2 },
   dotDest: { width: 12, height: 12, borderRadius: 6 },
-  dotIntermediate: { width: 7, height: 7, borderRadius: 4, borderWidth: 1, marginLeft: 1.5 },
+  dotIntermediate: { width: 7, height: 7, borderRadius: 4, borderWidth: 1 },
   rowIntermediate: { minHeight: 30 },
   hopSlot: {
     paddingLeft: 28 + spacing.md, // markerCol 폭 + 행 gap — slot이 station label과 좌측 정렬되도록

--- a/src/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/components/__tests__/EditorialTimeline.test.tsx
@@ -333,6 +333,46 @@ describe('EditorialTimeline quickExit door label', () => {
   });
 });
 
+describe('#804 marker/connector 정렬', () => {
+  const { StyleSheet } = require('react-native');
+
+  // dot에서 markerCol(width 28 + alignItems:'center') 부모를 거슬러 올라가 찾는다.
+  // RN test renderer가 중간 wrapper를 넣을 수 있어 단일 parent 의존 불가.
+  function findMarkerColStyle(dotEl: any): any {
+    let node = dotEl.parent;
+    while (node) {
+      const flat = StyleSheet.flatten(node.props?.style);
+      if (flat && flat.width === 28 && flat.alignItems != null) return flat;
+      node = node.parent;
+    }
+    return null;
+  }
+
+  // markerCol(width 28)이 alignItems: 'center'면 dot center = 14.
+  // connector(width 1, left 14)도 같은 center → dot 폭(10/12/7)과 무관하게 정렬됨.
+  it('markerCol은 alignItems: center로 dot 폭과 무관하게 column center 정렬', () => {
+    render(<EditorialTimeline stops={MOCK_STOPS.twoStops} />);
+    const dot = screen.getByTestId('filled-dot');
+    const style = findMarkerColStyle(dot);
+    expect(style).not.toBeNull();
+    expect(style.alignItems).toBe('center');
+    expect(style.width).toBe(28);
+    expect(style.paddingLeft).toBeUndefined();
+  });
+
+  it('intermediate dot에서 marginLeft hack(1.5)가 제거되어 column center에 그대로 놓인다', () => {
+    const stops: Stop[] = [
+      { station: '강남', line: '2', mark: 'filled' },
+      { station: '교대', line: '2', mark: 'intermediate' },
+      { station: '서초', line: '2', stopsFromPrev: '2정거장', mark: 'dest', note: '도착' },
+    ];
+    render(<EditorialTimeline stops={stops} />);
+    const intermediateDot = screen.getByTestId('intermediate-dot');
+    const style = StyleSheet.flatten(intermediateDot.props.style);
+    expect(style.marginLeft).toBeUndefined();
+  });
+});
+
 describe('intermediate stop 렌더링', () => {
   it('intermediate mark는 intermediate-dot을 렌더링한다', () => {
     const stops: Stop[] = [


### PR DESCRIPTION
Closes #804

## 변경
- markerCol: alignItems 'flex-start'+paddingLeft 7 → alignItems 'center'
- connector: left 13 → 14 (markerCol center 28/2)
- dotIntermediate: marginLeft 1.5 hack 제거

dot 폭(10/12/7px)과 무관하게 column center에 자동 정렬되도록.

## 검증
- [ ] EditorialTimeline 테스트 통과
- [ ] 커버리지 100%
- [ ] 실기기에서 dot/connector 정렬 확인