### PR TITLE
fix(#806): 알람 dismiss와 trip release 분리 — dismiss는 BoardingLock 유지

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -884,16 +884,10 @@ export default function HomeScreen() {
       </ScrollView>
 
       {alarmEvent && (
-        <AlarmOverlay
-          event={alarmEvent}
-          onDismiss={clearAlarmEvent}
-          // #633: 도착 알람 dismiss 시 trip 종료. lock release + destination clear.
-          // 환승 알람은 AlarmOverlay 내부에서 trip 유지하며 진동만 정지.
-          onEndTrip={() => {
-            releaseBoardingLock();
-            setDestination(null);
-          }}
-        />
+        // #806: dismiss는 알람 UI/진동만 끄고 trip(BoardingLock)은 유지.
+        // 한 정거장 전(early) destination 알람을 끄면 trip이 종료되던 회귀의 fix.
+        // trip release는 도착 자동 release(useBoardingLockAutoRelease, #759)에 위임한다.
+        <AlarmOverlay event={alarmEvent} onDismiss={clearAlarmEvent} />
       )}
 
       <DestinationPicker

--- a/src/components/AlarmOverlay.tsx
+++ b/src/components/AlarmOverlay.tsx
@@ -13,14 +13,9 @@ const allStations = stationsData as Station[];
 interface AlarmOverlayProps {
   event: AlarmEvent;
   onDismiss: () => void;
-  /**
-   * 도착 알람 dismiss 시 호출 — trip 종료 처리(lock release + destination clear).
-   * 환승 알람 dismiss는 trip 유지이므로 호출 안 함.
-   */
-  onEndTrip: () => void;
 }
 
-export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps) {
+export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
   const isTransfer = event.type === 'transfer';
   const { t } = useTranslation();
   const title = t(isTransfer ? 'alarmOverlay.transferTitle' : 'alarmOverlay.arrivalTitle');
@@ -29,20 +24,22 @@ export function AlarmOverlay({ event, onDismiss, onEndTrip }: AlarmOverlayProps)
   });
   const { colors } = useTheme();
 
-  // #741: dismiss UX 단순화 — 단일 버튼 + 통일 라벨("알람 끄기").
-  // 동작은 알람 종류별로 분기 유지:
-  //  - transfer: trip 유지. clearAlarmNotification만. 후속 도착 알람은 계속.
-  //  - destination: trip 종료. killAllAlarms + onEndTrip.
-  // Android 백 버튼/스와이프(onRequestClose)도 같은 분기를 따른다.
-  // 보조 버튼("이 알람만 끄기")은 #673에서 도입했으나 destination/lock을 건드리지 않아
-  // 다음 평가 사이클에 재발화 → 진동 재발생 회귀가 있어 제거. 미스파이어 root cause는
-  // ADR-008 #739, 정적 misfire 가드(#727/#733), 알람 misfire 큐(#370~#373)에서 처리.
+  // #806: dismiss는 알람 UI/진동만 끄고 trip(BoardingLock)은 절대 release하지 않는다.
+  //   한 정거장 전(early) destination 알람을 끄면 trip이 종료되던 회귀의 fix.
+  //   trip release는 도착역 station-passed 또는 자동 하차(useBoardingLockAutoRelease, #759)가
+  //   감지한 시점에만 트리거 — dismiss는 그 라이프사이클에 관여하지 않는다.
+  //
+  // 분기는 알람 종류별로 후속 알람 정리 범위만 다르다:
+  //  - transfer: clearAlarmNotification만 — 후속 도착 알람(예약/발사 예정)을 보존.
+  //  - destination: killAllAlarms — 같은 도착역 후속 phase(imminent 등) 예약을 함께 차단,
+  //    같은 trip 안에서 도착 알람을 재발사하지 않도록.
+  //
+  // Android 백 버튼/스와이프(onRequestClose)도 동일 분기.
   const handleDismiss = async () => {
     if (isTransfer) {
       await clearAlarmNotification();
     } else {
       await killAllAlarms();
-      onEndTrip();
     }
     onDismiss();
   };

--- a/src/components/__tests__/AlarmOverlay.test.tsx
+++ b/src/components/__tests__/AlarmOverlay.test.tsx
@@ -14,13 +14,14 @@ jest.mock('../../utils/stationNotification', () => ({
 }));
 
 const mockDismiss = jest.fn();
-const mockEndTrip = jest.fn();
 
-function renderAlarm(type: AlarmEvent['type'], stationName: string) {
-  const event: AlarmEvent = { phaseId: 'early', type, stationName };
-  return render(
-    <AlarmOverlay event={event} onDismiss={mockDismiss} onEndTrip={mockEndTrip} />,
-  );
+function renderAlarm(
+  type: AlarmEvent['type'],
+  stationName: string,
+  phaseId: AlarmEvent['phaseId'] = 'early',
+) {
+  const event: AlarmEvent = { phaseId, type, stationName };
+  return render(<AlarmOverlay event={event} onDismiss={mockDismiss} />);
 }
 
 async function triggerModalClose(rendered: ReturnType<typeof renderAlarm>) {
@@ -46,23 +47,31 @@ describe('AlarmOverlay', () => {
     expect(getByText('시청에서\n환승하세요')).toBeTruthy();
   });
 
-  it('#633 환승 알람 dismiss → trip 유지. clearAlarmNotification만 호출, onEndTrip X', async () => {
+  it('환승 알람 dismiss → trip 유지. clearAlarmNotification만 호출 (#633)', async () => {
     const { getByTestId } = renderAlarm('transfer', '시청');
     fireEvent.press(getByTestId('alarm-dismiss-button'));
     await waitFor(() => {
       expect(mockClearAlarmNotification).toHaveBeenCalled();
       expect(mockKillAllAlarms).not.toHaveBeenCalled();
-      expect(mockEndTrip).not.toHaveBeenCalled();
       expect(mockDismiss).toHaveBeenCalled();
     });
   });
 
-  it('#633 도착 알람 dismiss → trip 종료. killAllAlarms + onEndTrip 호출', async () => {
-    const { getByTestId } = renderAlarm('destination', '강남');
+  it('#806 도착 알람(early) dismiss → trip 유지. killAllAlarms만 호출, release 트리거 없음', async () => {
+    const { getByTestId } = renderAlarm('destination', '강남', 'early');
     fireEvent.press(getByTestId('alarm-dismiss-button'));
     await waitFor(() => {
       expect(mockKillAllAlarms).toHaveBeenCalled();
-      expect(mockEndTrip).toHaveBeenCalled();
+      expect(mockClearAlarmNotification).not.toHaveBeenCalled();
+      expect(mockDismiss).toHaveBeenCalled();
+    });
+  });
+
+  it('#806 도착 알람(imminent) dismiss → trip 유지. killAllAlarms만 호출', async () => {
+    const { getByTestId } = renderAlarm('destination', '강남', 'imminent');
+    fireEvent.press(getByTestId('alarm-dismiss-button'));
+    await waitFor(() => {
+      expect(mockKillAllAlarms).toHaveBeenCalled();
       expect(mockClearAlarmNotification).not.toHaveBeenCalled();
       expect(mockDismiss).toHaveBeenCalled();
     });
@@ -85,12 +94,11 @@ describe('AlarmOverlay', () => {
       expect(renderAlarm('transfer', '시청').queryByTestId('alarm-keep-trip-button')).toBeNull();
     });
 
-    it('도착 알람 onRequestClose(Android 백 버튼/스와이프)도 trip 종료 동작 — handleDismiss로 통일', async () => {
-      const rendered = renderAlarm('destination', '강남');
+    it('#806 도착 알람 onRequestClose(Android 백 버튼/스와이프)도 trip 유지', async () => {
+      const rendered = renderAlarm('destination', '강남', 'early');
       await triggerModalClose(rendered);
       await waitFor(() => {
         expect(mockKillAllAlarms).toHaveBeenCalled();
-        expect(mockEndTrip).toHaveBeenCalled();
         expect(mockClearAlarmNotification).not.toHaveBeenCalled();
         expect(mockDismiss).toHaveBeenCalled();
       });
@@ -102,7 +110,6 @@ describe('AlarmOverlay', () => {
       await waitFor(() => {
         expect(mockClearAlarmNotification).toHaveBeenCalled();
         expect(mockKillAllAlarms).not.toHaveBeenCalled();
-        expect(mockEndTrip).not.toHaveBeenCalled();
         expect(mockDismiss).toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
Closes #806

## 변경
- `AlarmOverlay`에서 `onEndTrip` prop 제거. dismiss는 알람 UI/진동만 정리한다.
- destination 알람(early/imminent 모두) dismiss → trip(BoardingLock) 유지.
- transfer 알람은 기존대로 `clearAlarmNotification`만 호출.
- release는 도착역 station-passed 자동 감지(`useBoardingLockAutoRelease`, #759)에 위임.
- 호출자 `app/(tabs)/index.tsx`에서 dismiss 시점의 `releaseBoardingLock()`/`setDestination(null)` 호출 제거.

## 회귀 가드
- 한 정거장 전(early) destination 알람을 끄면 trip이 종료되던 회귀 fix.
- imminent destination 알람 dismiss도 trip 유지 (도착 자동 release만이 종료 트리거).

## 검증
- [x] dismiss → trip 유지 (AlarmOverlay 단위 테스트: early/imminent 양쪽 + onRequestClose)
- [x] release → trip 종료 (`useBoardingLockAutoRelease` 기존 테스트가 도착 grace 충족 시 releaseLock 호출 검증)
- [x] 커버리지 100% (`npm test`)
- [x] type-check 통과