### PR TITLE
fix(#805): BoardingTrainList 도착 임박 상태에도 시간 라벨 유지 + mock 시간표 기반

### DIFF
--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -59,6 +59,9 @@ interface Props {
  * #792: 종착 표기는 `parseTrainLineDirection`로 i18n 정규화한다 (기존 하드코딩 "행" 부착 제거).
  *       종착에 이미 다음역 명이 포함된 경우(예: "어린이대공원(세종대)방면"+"어린이대공원") "방면"
  *       접미사를 생략해 라벨 중복("…방면행 · …방면")을 차단한다.
+ * #805: "곧 도착"/"전역 출발"/"당역 도착" 등 statusMessage가 sequence 슬롯을 차지하는 임박 상태에서
+ *       도착 예정 HH:mm 시간 라벨이 같은 줄에서 가려지는 회귀가 있었다. 시간 라벨을 항상 별도 라인
+ *       으로 분리해 "상태 텍스트(또는 거리) → 시간"이 위아래로 명확히 보이도록 한다.
  */
 export function BoardingTrainList({
   arrivals,
@@ -141,14 +144,21 @@ export function BoardingTrainList({
                     <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
                   ))}
               </View>
-              <View style={styles.rowDetailLine}>
-                <Text
-                  style={[typography.bodySm, { color: colors.muted }]}
-                  testID={`boarding-train-sequence-${train.trainCode}`}
-                >
-                  {sequenceText}
-                </Text>
-                <Text style={[typography.bodySm, { color: colors.subtle }]}>·</Text>
+              {/* #805: sequence(거리/상태)와 시간 라벨은 별도 라인으로 분리.
+                  sequenceText가 "전역 출발"/"당역 도착"/"4번째 전" 등 어떤 길이여도 시간 라벨이
+                  같은 줄에서 가려지지 않는다. sequenceText가 비어 있으면 그 라인은 미렌더하지만
+                  시간 라벨 라인은 항상 표시한다. */}
+              {sequenceText.length > 0 && (
+                <View style={styles.rowSequenceLine}>
+                  <Text
+                    style={[typography.bodySm, { color: colors.muted }]}
+                    testID={`boarding-train-sequence-${train.trainCode}`}
+                  >
+                    {sequenceText}
+                  </Text>
+                </View>
+              )}
+              <View style={styles.rowArrivalLine}>
                 <Text
                   style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}
                   testID={`boarding-train-arrival-${train.trainCode}`}
@@ -207,10 +217,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.sm,
   },
-  rowDetailLine: {
+  rowSequenceLine: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.xs,
+  },
+  rowArrivalLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   empty: {
     padding: spacing.lg,

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -261,6 +261,37 @@ describe('BoardingTrainList', () => {
     });
   });
 
+  describe('#805 도착 임박 상태에서도 시간 라벨 유지', () => {
+    // arvlCd=0(진입)/1(도착)/2(출발)/3(전역 출발) 등 임박 상태에서 statusMessage가 시간 텍스트를
+    // 대체하더라도 BoardingTrainList의 도착 예정 HH:mm 라벨은 별도 라인으로 항상 노출되어야 한다.
+    it.each<[string, Partial<ArrivalInfo>]>([
+      ['arrivalSeconds=0 + statusMessage 비어있음', { arrivalSeconds: 0, statusMessage: '' }],
+      ['arrivalSeconds=0 + "곧 도착"', { arrivalSeconds: 0, statusMessage: '곧 도착' }],
+      ['arrivalSeconds=1 + "전역 출발"', { arrivalSeconds: 1, statusMessage: '전역 출발' }],
+      ['arrivalSeconds=30 + "당역 도착"', { arrivalSeconds: 30, statusMessage: '당역 도착' }],
+    ])('%s — arrival 시간 라벨이 보임', (_, overrides) => {
+      const base = new Date(2026, 0, 1, 9, 0).getTime();
+      const train = makeTrain({ trainCode: 'T-805', receivedAtMs: base, ...overrides });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      const arrival = getByTestId('boarding-train-arrival-T-805');
+      // 도착 예정 텍스트는 항상 "HH:mm 도착 예정" 형태로 렌더.
+      expect(arrival.props.children).toMatch(/\d{2}:\d{2} 도착 예정$/);
+    });
+
+    it('sequence 라인과 arrival 라인은 별도 View — 시간 라벨이 같은 줄에서 가려지지 않음', () => {
+      const train = makeTrain({ trainCode: 'T-LINES', statusMessage: '전역 출발' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      const sequence = getByTestId('boarding-train-sequence-T-LINES');
+      const arrival = getByTestId('boarding-train-arrival-T-LINES');
+      // 두 element가 동일 parent(같은 row) 안에 있되 서로 다른 View 안에 있어야 한다.
+      expect(sequence.parent).not.toBe(arrival.parent);
+    });
+  });
+
   describe('#664 환승역 line 필터 + 호선 색 stripe', () => {
     function flattenStyle(style: unknown): Record<string, unknown> {
       if (Array.isArray(style)) return Object.assign({}, ...style.map(flattenStyle));

--- a/src/providers/arrival/MockProvider.ts
+++ b/src/providers/arrival/MockProvider.ts
@@ -1,12 +1,30 @@
 import type { ArrivalProvider, ArrivalOptions } from '../types';
-import type { StationArrival } from '../../api/arrivalApi';
-import { MOCK_ARRIVALS } from '../../api/arrivalApi';
+import { MOCK_ARRIVALS, type StationArrival } from '../../api/arrivalApi';
+import { findLineByStationName } from '../../utils/stationLookup';
+import { buildScheduleArrival, hasHeadwayData } from '../../utils/scheduleFallback';
 
+/**
+ * 개발/테스트용 mock arrival provider.
+ *
+ * #805: 기존 구현은 하드코딩 정적 `MOCK_ARRIVALS`만 반환해 BoardingTrainList의 "곧 도착"/"전역 출발"
+ * 같은 상태 회귀를 mock에서 재현할 수 없었다. 이제는 stationName + lineHint로 실제 시간표 데이터를
+ * 조회해 결정적 schedule fallback을 만든다 — 실 서비스의 `getFallbackArrival`과 동일한 정책이라
+ * UI 회귀 가드가 mock 경로에서도 동작한다.
+ *
+ * - stationName이 시간표 데이터에 매핑되면 `buildScheduleArrival`이 SCHED-* trainCode + 결정적
+ *   arrivalSeconds를 갖는 StationArrival을 반환.
+ * - station/line lookup 실패 또는 headway 데이터 누락 시 하드코딩 `MOCK_ARRIVALS` 최후 fallback —
+ *   기존 호출자(스토리북, 테스트)가 station 미지정으로 호출할 때의 동작을 보존한다.
+ */
 export class MockArrivalProvider implements ArrivalProvider {
   async getArrival(
-    _stationName: string,
-    _options?: ArrivalOptions,
+    stationName: string,
+    options?: ArrivalOptions,
   ): Promise<StationArrival> {
-    return MOCK_ARRIVALS;
+    const line = options?.lineHint ?? findLineByStationName(stationName);
+    if (!line || !hasHeadwayData(line)) {
+      return MOCK_ARRIVALS;
+    }
+    return buildScheduleArrival(line, stationName, new Date());
   }
 }

--- a/src/providers/arrival/__tests__/MockProvider.test.ts
+++ b/src/providers/arrival/__tests__/MockProvider.test.ts
@@ -1,41 +1,71 @@
 import { MockArrivalProvider } from '../MockProvider';
 import { MOCK_ARRIVALS } from '../../../api/arrivalApi';
+import { SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX } from '../../../utils/scheduleFallback';
 
 describe('MockArrivalProvider', () => {
   let provider: MockArrivalProvider;
 
+  // 시간표 lookup이 결정적으로 hit하도록 평일 출근 시간대(KST 09:00)로 시간 고정.
+  const FIXED_KST_DATETIME = '2026-01-05T09:00:00+09:00';
+
   beforeEach(() => {
     provider = new MockArrivalProvider();
+    jest.useFakeTimers().setSystemTime(new Date(FIXED_KST_DATETIME));
   });
 
-  it('should return MOCK_ARRIVALS regardless of station name', async () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('lineHint와 알려진 역명을 받으면 schedule-based StationArrival 반환 (#805)', async () => {
+    const result = await provider.getArrival('강남', { lineHint: '2' });
+    // schedule-based 결과는 SCHED-* trainCode + isMock=false + source='schedule'.
+    expect(result.isMock).toBe(false);
+    expect(result.source).toBe('schedule');
+    const allTrains = [...result.up, ...result.down];
+    // 시간표 hit 시 최소 한 방향에는 train이 존재한다 (양방향 합산).
+    expect(allTrains.length).toBeGreaterThan(0);
+    for (const train of allTrains) {
+      expect(train.trainCode.startsWith(SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX)).toBe(true);
+    }
+  });
+
+  it('lineHint 없이도 역명만으로 호선을 찾아 schedule-based 응답 (#805)', async () => {
     const result = await provider.getArrival('강남');
+    // 강남은 stations.json에 2호선으로 등록되어 lookup 성공.
+    expect(result.source).toBe('schedule');
+  });
+
+  it('알 수 없는 역명은 하드코딩 MOCK_ARRIVALS fallback (기존 동작 보존)', async () => {
+    const result = await provider.getArrival('존재하지않는역');
     expect(result).toBe(MOCK_ARRIVALS);
   });
 
-  it('should return MOCK_ARRIVALS when station name is empty string', async () => {
+  it('빈 문자열 역명도 MOCK_ARRIVALS fallback', async () => {
     const result = await provider.getArrival('');
     expect(result).toBe(MOCK_ARRIVALS);
   });
 
-  it('should return MOCK_ARRIVALS when options are provided', async () => {
-    const result = await provider.getArrival('홍대입구', { timeoutMs: 3000, maxPerDirection: 5 });
-    expect(result).toBe(MOCK_ARRIVALS);
-  });
-
-  it('should return MOCK_ARRIVALS when options is undefined', async () => {
-    const result = await provider.getArrival('서울역', undefined);
-    expect(result).toBe(MOCK_ARRIVALS);
-  });
-
-  it('should return object with isMock true', async () => {
-    const result = await provider.getArrival('신촌');
-    expect(result.isMock).toBe(true);
-  });
-
-  it('should return object with up and down arrays', async () => {
-    const result = await provider.getArrival('종각');
+  it('options.timeoutMs 같은 무관 옵션은 결과에 영향 없음', async () => {
+    const result = await provider.getArrival('강남', { lineHint: '2', timeoutMs: 3000, maxPerDirection: 5 });
+    expect(result.source).toBe('schedule');
     expect(Array.isArray(result.up)).toBe(true);
     expect(Array.isArray(result.down)).toBe(true);
+  });
+
+  it('options=undefined도 처리', async () => {
+    const result = await provider.getArrival('강남', undefined);
+    expect(result.source).toBe('schedule');
+  });
+
+  it('schedule 적중 결과는 arrivalSeconds가 양수인 결정적 trainCode 시퀀스', async () => {
+    const result = await provider.getArrival('강남', { lineHint: '2' });
+    const allTrains = [...result.up, ...result.down];
+    for (const train of allTrains) {
+      // 시간표 hit가 0초 트레인을 필터링하므로 arrivalSeconds > 0.
+      expect(train.arrivalSeconds).toBeGreaterThan(0);
+      // schedule fallback이 정해진 prefix + 방향+인덱스 suffix를 부여.
+      expect(train.trainCode).toMatch(/^SCHED-(UP|DN)-\d+$/);
+    }
   });
 });


### PR DESCRIPTION
Closes #805

## 변경
- arrivalSeconds=0 또는 statusMessage 대체 시에도 시간 라벨 라인 유지
- mock arrival provider: 무작위 → schedule-based (scheduleFallback 등)

## 검증
- [ ] '곧 도착' 케이스에서 시간 라벨 보임 (단위 테스트)
- [ ] mock 시간표 기반 (단위 테스트)
- [ ] 커버리지 100%