### PR TITLE
fix(#808): cold start GPS 즉시 hydrate + speed=-1 fallback 강화

### DIFF
--- a/src/constants/locationTracking.ts
+++ b/src/constants/locationTracking.ts
@@ -12,6 +12,15 @@ const TRACKING_TIME_INTERVAL_MS = 30_000;
 // - `pausesUpdatesAutomatically: false`: iOS의 stationary 오판으로 인한 업데이트 중단 차단.
 // - `activityType: AutomotiveNavigation`: iOS가 GPS를 가장 공격적으로 유지하도록 차량 내비 프로필 사용.
 // - `deferredUpdatesInterval` 미설정: 백그라운드 batching 비활성화 (회귀 가드 #189).
+//
+// #808 — `accuracy: High` 유지 결정 (BestForNavigation 미채택):
+//   BestForNavigation은 GPS-only로 ~5m 정확도를 노리지만 fallback이 없다. 지하철 사용자는
+//   지하/터널 비중이 크고 GPS lock이 끊기는 환경 → BestForNavigation은 fix 자체를 못 얻는
+//   구간이 길어진다. High는 GPS lock 실패 시 WiFi BSSID / Cell tower triangulation으로
+//   fallback해 50~100m fix를 계속 흘려보낸다(useFusedNearestStation에서 realtimePosition fusion이
+//   GPS 부정확도를 보정 — 표시는 가능, 알람은 별도 엄격 게이트로 차단). 배터리 영향도 BestForNavigation
+//   대비 낮다. 본 앱은 차량 내비가 아니라 지하철 추적이므로 정확도 vs 배터리 vs 지하 가용성 균형이
+//   High가 최적.
 export const LOCATION_TRACKING_OPTIONS = {
   accuracy: Location.Accuracy.High,
   activityType: Location.LocationActivityType.AutomotiveNavigation,

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -540,10 +540,10 @@ describe('useNearestStation', () => {
     logSpy.mockRestore();
   });
 
-  it('저정확도 캐시 위치(MAX_ACCURACY_M 초과)는 무시하고 진단 로그를 남긴다', async () => {
+  it('표시 게이트 초과 캐시 위치(MAX_ACCURACY_M_DISPLAY 초과)는 무시하고 진단 로그를 남긴다', async () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     mockGranted();
-    mockLastKnownLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M + 1 });
+    mockLastKnownLocation(37.4980, 127.0277, { accuracy: MAX_ACCURACY_M_DISPLAY + 1 });
 
     const { result } = renderHook(() => useNearestStation());
 
@@ -554,11 +554,64 @@ describe('useNearestStation', () => {
       '[useNearestStation]',
       'lastKnown rejected: lowAccuracy',
       expect.objectContaining({
-        accuracyMeters: MAX_ACCURACY_M + 1,
+        accuracyMeters: MAX_ACCURACY_M_DISPLAY + 1,
         cumulativeLowAccuracy: 1,
       }),
     );
     logSpy.mockRestore();
+  });
+
+  it('#808 cold start hydrate: 알람 게이트 초과지만 표시 게이트 통과 fix는 uncertain=true로 hydrate한다', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockGranted();
+    // 220m: MAX_ACCURACY_M=200 초과 + MAX_ACCURACY_M_DISPLAY=250 이하
+    mockLastKnownLocation(37.4980, 127.0277, { accuracy: 220 });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // cold start 빈 화면 회피: result 채워짐
+    expect(result.current.result).not.toBeNull();
+    expect(result.current.result?.station.name).toBe('강남');
+    // "위치 확인 중" UX: uncertain=true
+    expect(result.current.locationUncertain).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[useNearestStation]',
+      'lastKnown coldStart hydrate: uncertain',
+      expect.objectContaining({ accuracyMeters: 220 }),
+    );
+    logSpy.mockRestore();
+  });
+
+  it('#808 cold start hydrate 후 fresh fix가 들어오면 uncertain이 false로 복귀한다', async () => {
+    mockGranted();
+    mockLastKnownLocation(37.4980, 127.0277, { accuracy: 220 });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.locationUncertain).toBe(true);
+
+    // fresh fix(strict 통과)가 들어오면 정정
+    simulateGps(37.4980, 127.0277, { accuracy: 30 });
+    await waitFor(() => expect(result.current.locationUncertain).toBe(false));
+    expect(result.current.result?.station.name).toBe('강남');
+  });
+
+  it('#808 cold start hydrate: speed=-1인 lastKnown은 speedMps를 null로 정규화한다', async () => {
+    mockGranted();
+    (Location.getLastKnownPositionAsync as jest.Mock).mockResolvedValue({
+      coords: { latitude: 37.4980, longitude: 127.0277, accuracy: 220, speed: -1 },
+      timestamp: Date.now() - 5_000,
+    });
+
+    const { result } = renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    // speed=-1 → null로 정규화. positionStability/motionStationary fallback 대상으로 전환.
+    expect(result.current.speedMps).toBeNull();
+    expect(result.current.result?.station.name).toBe('강남');
   });
 
   it('lastKnown 거부 카운터는 FG 재진입마다 누적된다', async () => {

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -12,6 +12,7 @@ import {
   isPlausibleJump,
   type FixSample,
 } from '../utils/locationGates';
+import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY } from '../constants/location';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../constants/e2e';
 import { createLogger } from '../utils/logger';
@@ -187,15 +188,34 @@ export function useNearestStation(): UseNearestStationReturn {
       }
       setPermissionDenied(false);
 
-      // 캐시된 위치는 신선하고 알람 엄격 게이트(200m)를 통과하는 경우만 즉시 표시.
-      // 콜드 스타트 시 부정확한 fix로 사용자에게 오정보를 주는 것을 방지.
+      // #808: 캐시 위치 hydrate 정책 — cold start 빈 화면 회피 + 잘못된 라우팅 방지.
+      //
+      // freshness 게이트(MAX_LOCATION_AGE_MS=15s)는 항상 유지 — stale 좌표로 hydrate하면
+      // 사용자가 이미 이동한 뒤일 수 있어 위험.
+      //
+      // accuracy 게이트는 **표시 게이트(MAX_ACCURACY_M_DISPLAY=250m)**까지 허용:
+      //   - 알람 엄격(200m) 통과 → applyLocation 정상 경로 (uncertain=false)
+      //   - 알람 엄격 초과 + 표시 통과 (200~250m) → result만 hydrate + uncertain=true
+      //     (cold start 빈 화면 회피 — UI는 "위치 확인 중" + 추정 역 표시)
+      //   - 표시 게이트 초과 → 진단 로그 + 무시 (오정보 방지)
+      // watch가 fresh fix를 보내면 uncertain이 false로 복귀하며 정정 가능.
+      // 사용자 정책 "실시간성 우선, 나쁜 좌표 거부"와 일치 — 250m도 거부, 그 이하만 hydrate.
       const lastKnown = await Location.getLastKnownPositionAsync();
       if (lastKnown) {
         const fresh = isLocationFresh(lastKnown.timestamp);
-        const acceptable = isAccuracyAcceptable(lastKnown.coords.accuracy);
-        if (fresh && acceptable) {
+        const strictlyAcceptable = isAccuracyAcceptable(lastKnown.coords.accuracy);
+        const displayAcceptable = isAccuracyAcceptableForDisplay(lastKnown.coords.accuracy);
+        if (fresh && strictlyAcceptable) {
           applyLocation(lastKnown.coords, lastKnown.timestamp);
           setLoading(false);
+        } else if (fresh && displayAcceptable) {
+          // cold start 완화 hydrate — result는 채우되 uncertain=true로 신뢰도 표시.
+          applyLocation(lastKnown.coords, lastKnown.timestamp);
+          setLocationUncertain(true);
+          setLoading(false);
+          logger.info('lastKnown coldStart hydrate: uncertain', {
+            accuracyMeters: lastKnown.coords.accuracy,
+          });
         } else if (!fresh) {
           lastKnownStaleCountRef.current += 1;
           logger.info('lastKnown rejected: stale', {


### PR DESCRIPTION
Closes #808

## 원인 분석과 트레이드오프

### 원인 1 — cold start 빈 화면
`useNearestStation.startWatch`가 lastKnown을 알람 엄격 게이트(MAX_ACCURACY_M=200m)로만 hydrate. lastKnown은 보통 100~400m accuracy → cold start 빈 화면 1~수십 초.

**선택**: 표시 게이트(MAX_ACCURACY_M_DISPLAY=250m)까지 완화 + `locationUncertain=true`로 표시. 250m 초과는 거부 ("실시간성 우선, 나쁜 좌표 거부" 정책).

### 원인 2 — LOCATION_TRACKING_OPTIONS accuracy
| 옵션 | 정확도 | 지하 fallback | 적합 |
| --- | --- | --- | --- |
| BestForNavigation | ~5m | GPS-only (지하 dead) | ✗ |
| **High (유지)** | ~10-50m | WiFi/Cell fallback | ✓ |

**결정**: High 유지. 지하 비중 큰 지하철 사용자에게 fallback이 핵심. 결정 근거 주석화.

### 원인 3 — iOS speed=-1
`applyLocation` 내부 `speed >= 0 ? speed : null` 정규화로 cold start hydrate에도 자동 적용. 후속 fusion downgrade는 #727/#728/#733의 positionStability/motionStationary fallback이 처리 (이미 구현됨).

## 변경
- useNearestStation: cold start 표시 게이트 완화 분기 + uncertain=true 마킹
- LOCATION_TRACKING_OPTIONS: High 유지 결정 근거 주석
- useFusedNearestStation / useBackgroundLocation: 변경 없음 (useNearestStation 위에 얹힌 구조로 자동 전파)

## 안전성
- 알람 발사 경로는 `isAccuracyAcceptable(200m)` 엄격 게이트 유지 → hydrate된 220m fix는 표시까지만 사용. 잘못된 라우팅 회귀 없음.
- WhileInUse 권한에서 정상 동작 — BG task 의존 없음.

## 검증
- [x] cold start 첫 화면 비어 있지 않음 (3개 단위 테스트 통과)
- [x] speed=-1 시 speedMps=null 정규화 (단위 테스트)
- [x] 커버리지 100% (2900/2900)
- [x] type-check 통과
- [ ] WhileInUse 권한 실기기 회귀 (다음 릴리스 검증)

연관: #791 BG persistent dismiss, #732 정적 misfire 가드