### PR TITLE
feat(#807): 열차 표시 통일 — 종착 제거 · 다음역방면만 노출 + 전 노선 fixture 가드

### DIFF
--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -27,8 +27,8 @@ interface Props {
   /** 헤더 라벨 커스텀 (환승 list 등). 미전달 시 기본 "탑승할 열차 선택". compact=true면 무시. */
   title?: string;
   /**
-   * 다음 인접역 라벨(#649, #749). 종착과 같이 "{destination}행 · {label}방면" 형태로 노출.
-   * 호출자가 resolveNextAdjacentStationName으로 계산해 전달. null/미전달이면 종착만 표기.
+   * 다음 인접역 라벨(#649, #749, #807). 있으면 "<label>방면"만 노출(종착 제거).
+   * 호출자가 resolveNextAdjacentStationName으로 계산해 전달. null/미전달이면 종착 fallback.
    */
   nextStationLabel?: string | null;
   /**
@@ -57,8 +57,8 @@ interface Props {
  * #790: 거리 표기를 API `arvlMsg2`에서 정규식 파싱한 실거리로 변경 (`parseArrivalDistance`).
  *       비어있는 statusMessage(주로 mock/schedule fallback)는 기존 `${index+1}번째 전`로 fallback.
  * #792: 종착 표기는 `parseTrainLineDirection`로 i18n 정규화한다 (기존 하드코딩 "행" 부착 제거).
- *       종착에 이미 다음역 명이 포함된 경우(예: "어린이대공원(세종대)방면"+"어린이대공원") "방면"
- *       접미사를 생략해 라벨 중복("…방면행 · …방면")을 차단한다.
+ * #807: 첫째 줄은 종착(마천행/방화행 등)이 아니라 **다음 인접역 방면**만 표시(`buildDirectionMeta`).
+ *       nextStationLabel 미전달 시에만 종착 fallback. 종착 분기 누락 회귀(5호선 등) 완전 차단.
  */
 export function BoardingTrainList({
   arrivals,

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -127,7 +127,8 @@ describe('BoardingTrainList', () => {
     expect(onSelect).toHaveBeenCalled();
   });
 
-  it('#749 nextStationLabel 전달 시 종착 + 방면 동시 표시 ("○○행 · ○○방면")', () => {
+  it('#807 nextStationLabel 전달 시 종착 제거하고 "<next>방면"만 표시', () => {
+    // 5호선 마천행 등 종착 분기 누락 회귀의 회귀 차단. 종착 표기는 UI에서 빠진다.
     const train = makeTrain({ trainCode: 'T-NEXT', destination: '석남행', line: '7' });
     const { getByTestId } = renderWithTheme(
       <BoardingTrainList
@@ -137,7 +138,7 @@ describe('BoardingTrainList', () => {
         nextStationLabel="중곡"
       />,
     );
-    expect(getByTestId('boarding-train-meta-T-NEXT').props.children).toBe('석남행 · 중곡방면');
+    expect(getByTestId('boarding-train-meta-T-NEXT').props.children).toBe('중곡방면');
   });
 
   it('#749 nextStationLabel null이면 종착만 표시 (방면 생략)', () => {
@@ -169,7 +170,7 @@ describe('BoardingTrainList', () => {
     expect(getByTestId('boarding-train-sequence-T-3RD').props.children).toBe('3번째 전');
   });
 
-  it('#749 compact 모드: 헤더/trainCode 라인 생략, 단일 row 종착·방면 라벨', () => {
+  it('#749 compact 모드: 헤더/trainCode 라인 생략, 단일 row "<next>방면" 라벨(#807)', () => {
     const train = makeTrain({ trainCode: 'T-COMPACT', destination: '석남행', line: '7' });
     const { getByTestId, queryByText } = renderWithTheme(
       <BoardingTrainList
@@ -180,7 +181,7 @@ describe('BoardingTrainList', () => {
         nextStationLabel="중곡"
       />,
     );
-    expect(getByTestId('boarding-train-meta-T-COMPACT').props.children).toBe('석남행 · 중곡방면');
+    expect(getByTestId('boarding-train-meta-T-COMPACT').props.children).toBe('중곡방면');
     expect(queryByText('탑승할 열차 선택')).toBeNull();
     expect(queryByText('T-COMPACT')).toBeNull();
   });
@@ -208,17 +209,19 @@ describe('BoardingTrainList', () => {
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
   });
 
-  // #792 라벨 dedup 회귀 가드 — 동일 BoardingTrainList 렌더 + assertion 패턴이라 it.each로 통합
-  // (SonarCloud CPD duplication 차단; 직전 PR #788과 동일한 접근).
-  describe('#792 종착/방면 라벨 중복 제거', () => {
+  // #807 라벨 통일 — 종착(마천행/방화행 등) 제거하고 "<next>방면"만 노출.
+  // nextStationLabel 미전달 시에만 종착 fallback. 노선/종착 표기에 무관 동일 결과.
+  describe('#807 종착 제거 · "<next>방면" 통일', () => {
     it.each<[string, string, LineNumber, string | null, string]>([
-      ['방면 패턴 + 동일 역 dedup', '어린이대공원(세종대)방면', '7', '어린이대공원', '어린이대공원(세종대)방면'],
-      ['순환선 + nextStationLabel 없음 → 행 미부착', '내선순환', '2', null, '내선순환'],
-      ['일반 종착 + 다른 인접역 → 정상 부착', '도봉산행', '7', '중곡', '도봉산행 · 중곡방면'],
-      // 1호선 망월사 시뮬레이션 — 이전 includes() 기반 dedup이 false-positive로 "도봉산행"만 표시했음.
-      ['substring false-positive 방지 (도봉산행 + 도봉)', '도봉산행', '1', '도봉', '도봉산행 · 도봉방면'],
+      ['방면 패턴 종착 + next → next만', '어린이대공원(세종대)방면', '7', '구의', '구의방면'],
+      ['순환선 + nextStationLabel 없음 → 종착 fallback', '내선순환', '2', null, '내선순환'],
+      ['일반 종착 + 다른 인접역 → next방면', '도봉산행', '7', '중곡', '중곡방면'],
+      ['terminal=next 케이스도 dedup 없이 next방면', '도봉산행', '1', '도봉산', '도봉산방면'],
+      // 5호선 회귀 가드 — 종착 분기 누락 차단의 회귀 자체 제거.
+      ['5호선 마천행 → next방면', '마천행', '5', '중곡', '중곡방면'],
+      ['5호선 방화행 → next방면', '방화행', '5', '광화문', '광화문방면'],
     ])('%s', (_, destination, line, nextStationLabel, expected) => {
-      const train = makeTrain({ trainCode: 'T-792', destination, line });
+      const train = makeTrain({ trainCode: 'T-807', destination, line });
       const { getByTestId } = renderWithTheme(
         <BoardingTrainList
           arrivals={[train]}
@@ -227,7 +230,7 @@ describe('BoardingTrainList', () => {
           nextStationLabel={nextStationLabel}
         />,
       );
-      expect(getByTestId('boarding-train-meta-T-792').props.children).toBe(expected);
+      expect(getByTestId('boarding-train-meta-T-807').props.children).toBe(expected);
     });
   });
 

--- a/src/components/__tests__/MisBoardingReselectModal.test.tsx
+++ b/src/components/__tests__/MisBoardingReselectModal.test.tsx
@@ -79,8 +79,9 @@ describe('MisBoardingReselectModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('#749 nextStationLabel을 BoardingTrainList로 forward — "○○행 · ○○방면" 표기', () => {
-    // destination은 Seoul API trainLineNm 원본 포맷("도봉산행"). #792 parseTrainLineDirection 정규화.
+  it('#807 nextStationLabel을 BoardingTrainList로 forward — "<next>방면"만 표기 (종착 제거)', () => {
+    // destination은 Seoul API trainLineNm 원본 포맷("도봉산행"). #807 사양으로 종착은 UI에서 빠지고
+    // 다음 인접역 방면만 노출된다. 5호선 마천/방화 누락 회귀의 회귀 차단.
     const train = makeTrain({ trainCode: 'C', destination: '도봉산행', line: '7' });
     const { getByTestId } = renderWithTheme(
       <MisBoardingReselectModal
@@ -92,6 +93,6 @@ describe('MisBoardingReselectModal', () => {
         nextStationLabel="사가정"
       />,
     );
-    expect(getByTestId('boarding-train-meta-C').props.children).toBe('도봉산행 · 사가정방면');
+    expect(getByTestId('boarding-train-meta-C').props.children).toBe('사가정방면');
   });
 });

--- a/src/utils/__tests__/lineDirectionFixtures.test.ts
+++ b/src/utils/__tests__/lineDirectionFixtures.test.ts
@@ -8,6 +8,9 @@
  *
  * 노선별 종착역(첫/마지막 역)을 stations.json에서 데이터 주도로 추출해 라인 전체를 한 곳에 모아
  * 검증한다. 새 노선이 stations.json에 추가되면 해당 노선 fixture가 자동 포함된다.
+ *
+ * 중복 차단: 동일 패턴(라인별 정/역/전구간, ko/en fallback)은 it.each(scenario × line) 단일 루프로
+ * 통합해 SonarCloud CPD를 회피한다.
  */
 
 import i18next from 'i18next';
@@ -29,19 +32,13 @@ interface LineTerminals {
   line: LineNumber;
   first: Station;
   last: Station;
-  count: number;
 }
 
 // 라인별 첫/마지막 역(종착 fixture) 계산. getStationsOnLine은 id 기준 정렬을 보장한다
-// (stationRoute.test.ts의 별도 describe에서 검증됨).
+// (stationRoute.test.ts 별도 describe에서 검증됨).
 const lineTerminals: LineTerminals[] = LINES.map((line) => {
   const stations = getStationsOnLine(line);
-  return {
-    line,
-    first: stations[0],
-    last: stations[stations.length - 1],
-    count: stations.length,
-  };
+  return { line, first: stations[0], last: stations[stations.length - 1] };
 });
 
 describe('#807 — buildDirectionMeta 전 노선 종착 라벨 → "<next>방면" 통일', () => {
@@ -56,7 +53,7 @@ describe('#807 — buildDirectionMeta 전 노선 종착 라벨 → "<next>방면
       '$line 노선: 마지막 종착 라벨로 진입해도 다음역방면만',
       async ({ first, last }) => {
         await i18next.changeLanguage('ko');
-        // 양 방향 종착 라벨로 가정해도 nextStationLabel="중곡"이면 항상 "중곡방면"
+        // 양 종착 라벨 모두 nextStationLabel="중곡"이면 일관된 "중곡방면"
         expect(buildDirectionMeta(`${first.name}행`, '중곡', allStations)).toBe('중곡방면');
         expect(buildDirectionMeta(`${last.name}행`, '중곡', allStations)).toBe('중곡방면');
       },
@@ -78,24 +75,19 @@ describe('#807 — buildDirectionMeta 전 노선 종착 라벨 → "<next>방면
 
   describe('데이터에 없는 종착 표기(상일동/하남검단산 등)도 next만 살아남음', () => {
     // 운영상 들어오지만 stations.json에 미반영된 종착도 다음역방면만 표시되므로 영향 없음.
-    const operationalTerminalsNotInData = [
-      '상일동행',
-      '하남검단산행',
-      '신창행',
-      '연천행',
-      '석남행',
-      '진접행',
-      '별내행',
-      '서동탄행',
-      '병점행',
-    ];
-
-    it.each(operationalTerminalsNotInData)(
-      '"%s" + next="중곡" → "중곡방면"',
-      (destination) => {
-        expect(buildDirectionMeta(destination, '중곡', allStations)).toBe('중곡방면');
-      },
-    );
+    it.each([
+      ['상일동행'],
+      ['하남검단산행'],
+      ['신창행'],
+      ['연천행'],
+      ['석남행'],
+      ['진접행'],
+      ['별내행'],
+      ['서동탄행'],
+      ['병점행'],
+    ])('"%s" + next="중곡" → "중곡방면"', (destination) => {
+      expect(buildDirectionMeta(destination, '중곡', allStations)).toBe('중곡방면');
+    });
   });
 
   describe('순환선: 종착 정보 없어도 다음역방면 OK', () => {
@@ -108,20 +100,14 @@ describe('#807 — buildDirectionMeta 전 노선 종착 라벨 → "<next>방면
   });
 
   describe('다국어 통일 — next 표기만 i18n 변환', () => {
-    it.each<[LineNumber, string]>([
-      ['1', 'en'],
-      ['5', 'en'],
-      ['7', 'ja'],
-      ['9', 'zh'],
-    ])('$line 노선 / lang=$1: terminal과 무관하게 next만 i18n 표기', async (line, lang) => {
+    it.each<[LineNumber, 'en' | 'ja' | 'zh', string]>([
+      ['1', 'en', 'via 다음역'],
+      ['5', 'en', 'via 다음역'],
+      ['7', 'ja', '다음역方面'],
+      ['9', 'zh', '다음역方向'],
+    ])('$line 노선 / lang=$1: terminal과 무관하게 next만 i18n 표기', async (line, lang, expected) => {
       await i18next.changeLanguage(lang);
       const { first, last } = lineTerminals.find((t) => t.line === line)!;
-      const expectedTemplate: Record<string, string> = {
-        en: 'via 다음역',
-        ja: '다음역方面',
-        zh: '다음역方向',
-      };
-      const expected = expectedTemplate[lang];
       expect(buildDirectionMeta(`${first.name}행`, '다음역', allStations)).toBe(expected);
       expect(buildDirectionMeta(`${last.name}행`, '다음역', allStations)).toBe(expected);
     });
@@ -131,84 +117,77 @@ describe('#807 — buildDirectionMeta 전 노선 종착 라벨 → "<next>방면
 describe('#807 — parseTrainLineDirection (종착 fallback 경로) 전 노선 검증', () => {
   // buildDirectionMeta가 nextStationLabel 미전달 시 fallback으로 호출하는 경로 — 환승 list 등에서
   // 진행 방향 미정일 때 종착 텍스트는 노출되므로 i18n 정규화가 정상 동작해야 함.
+  // ko/en을 (lang × line) 단일 it.each로 통합해 동일 어셈블리/어설션 블록 중복을 차단(CPD).
   afterEach(async () => {
     await i18next.changeLanguage('ko');
   });
 
-  describe('ko: 종착역 라벨은 한글 원본 그대로', () => {
-    it.each(lineTerminals)('$line', async ({ first, last }) => {
-      await i18next.changeLanguage('ko');
-      const firstLabel = `${first.name}행`;
-      const lastLabel = `${last.name}행`;
-      expect(parseTrainLineDirection(firstLabel, allStations)).toBe(firstLabel);
-      expect(parseTrainLineDirection(lastLabel, allStations)).toBe(lastLabel);
-    });
-  });
+  // expected 계산은 lang별 한 줄 분기. lang 추가 시 표만 확장하면 됨.
+  function expectedTerminal(label: string, station: Station, lang: 'ko' | 'en'): string {
+    if (lang === 'ko') return `${label}행`;
+    const en = station.nameEn ?? station.name;
+    return `Bound for ${en}`;
+  }
 
-  describe('en: 종착역 라벨은 nameEn으로 i18n 정규화', () => {
-    it.each(lineTerminals)('$line', async ({ first, last }) => {
-      await i18next.changeLanguage('en');
-      // stations.json의 모든 운영 역은 nameEn을 갖는다. 비어있으면 한글 fallback이 stationDisplay에서 동작.
-      const firstEn = first.nameEn ?? first.name;
-      const lastEn = last.nameEn ?? last.name;
+  const langs = ['ko', 'en'] as const;
+  const langLineCases = langs.flatMap((lang) =>
+    lineTerminals.map((t) => ({ lang, ...t })),
+  );
+
+  it.each(langLineCases)(
+    'lang=$lang / line=$line 첫·마지막 종착 라벨 i18n 정규화',
+    async ({ lang, first, last }) => {
+      await i18next.changeLanguage(lang);
       expect(parseTrainLineDirection(`${first.name}행`, allStations)).toBe(
-        `Bound for ${firstEn}`,
+        expectedTerminal(first.name, first, lang),
       );
       expect(parseTrainLineDirection(`${last.name}행`, allStations)).toBe(
-        `Bound for ${lastEn}`,
+        expectedTerminal(last.name, last, lang),
       );
-    });
-  });
+    },
+  );
 
   describe('신분당선 광교(경기대)행 — 괄호 별칭 종착', () => {
-    it('ko: 원본 그대로', async () => {
-      await i18next.changeLanguage('ko');
-      expect(parseTrainLineDirection('광교(경기대)행', allStations)).toBe('광교(경기대)행');
-    });
-
-    it('en: 정확 매칭으로 nameEn="Gwanggyo" 변환', async () => {
-      await i18next.changeLanguage('en');
-      expect(parseTrainLineDirection('광교(경기대)행', allStations)).toBe(
-        'Bound for Gwanggyo',
-      );
+    it.each<['ko' | 'en', string]>([
+      ['ko', '광교(경기대)행'],
+      ['en', 'Bound for Gwanggyo'],
+    ])('lang=%s → "%s"', async (lang, expected) => {
+      await i18next.changeLanguage(lang);
+      expect(parseTrainLineDirection('광교(경기대)행', allStations)).toBe(expected);
     });
   });
 });
 
 describe('#807 — getNextStationName 전 노선 DirectRoute fixture', () => {
-  // 라인별 첫 역→두 번째 역(정방향), 마지막 역→끝에서 두 번째(역방향), 첫→마지막 종착 트립을
-  // 검증. 5호선 방화→마천 같은 전 구간 트립에서 첫 hop이 두 번째 역을 정확히 짚는지 가드.
+  // 정방향(첫→두 번째), 역방향(마지막→끝에서 두 번째), 전 구간 트립(첫→마지막)을 한 it.each로
+  // 통합. caseBuilder는 라인 stations에서 시나리오별 (from, to, expected)를 추출 — 중복 블록 제거.
+  type Scenario = '정방향' | '역방향' | '전구간트립';
+  const scenarios: Scenario[] = ['정방향', '역방향', '전구간트립'];
 
-  describe('정방향: 첫 역 → 두 번째 역 (라인별)', () => {
-    it.each(lineTerminals)('$line', ({ line }) => {
-      const stations = getStationsOnLine(line);
-      const first = stations[0];
-      const second = stations[1];
-      const route = findRoute(first.id, second.id);
-      expect(route).not.toBeNull();
-      expect(getNextStationName(first.id, second.id, route)).toBe(second.name);
-    });
-  });
+  function buildCase(line: LineNumber, scenario: Scenario): {
+    from: Station;
+    to: Station;
+    expected: string;
+  } {
+    const stations = getStationsOnLine(line);
+    const first = stations[0];
+    const second = stations[1];
+    const last = stations[stations.length - 1];
+    const beforeLast = stations[stations.length - 2];
+    if (scenario === '정방향') return { from: first, to: second, expected: second.name };
+    if (scenario === '역방향') return { from: last, to: beforeLast, expected: beforeLast.name };
+    // 전구간트립: 첫→마지막 트립의 첫 hop은 두 번째 역.
+    return { from: first, to: last, expected: second.name };
+  }
 
-  describe('역방향: 마지막 역 → 끝에서 두 번째 역 (라인별)', () => {
-    it.each(lineTerminals)('$line', ({ line }) => {
-      const stations = getStationsOnLine(line);
-      const last = stations[stations.length - 1];
-      const beforeLast = stations[stations.length - 2];
-      const route = findRoute(last.id, beforeLast.id);
-      expect(route).not.toBeNull();
-      expect(getNextStationName(last.id, beforeLast.id, route)).toBe(beforeLast.name);
-    });
-  });
+  const cases = scenarios.flatMap((scenario) =>
+    lineTerminals.map((t) => ({ scenario, line: t.line })),
+  );
 
-  describe('전 구간 종착 트립: 첫 역 → 마지막 역 (라인별)', () => {
-    it.each(lineTerminals)('$line: 첫 hop은 두 번째 역', ({ line }) => {
-      const stations = getStationsOnLine(line);
-      const first = stations[0];
-      const last = stations[stations.length - 1];
-      const route = findRoute(first.id, last.id);
-      expect(route).not.toBeNull();
-      expect(getNextStationName(first.id, last.id, route)).toBe(stations[1].name);
-    });
+  it.each(cases)('scenario=$scenario / line=$line', ({ scenario, line }) => {
+    const { from, to, expected } = buildCase(line, scenario);
+    const route = findRoute(from.id, to.id);
+    expect(route).not.toBeNull();
+    expect(getNextStationName(from.id, to.id, route)).toBe(expected);
   });
 });

--- a/src/utils/__tests__/lineDirectionFixtures.test.ts
+++ b/src/utils/__tests__/lineDirectionFixtures.test.ts
@@ -1,0 +1,214 @@
+/**
+ * #807 — parseTrainLineDirection / buildDirectionMeta / getNextStationName 전 노선 fixture 회귀 가드.
+ *
+ * 실기기 트립에서 5호선(마천행/방화행) 방면 표기 누락이 보고됐고, 다른 노선도 전수 검증 안 됨.
+ * 새 사양(#807):
+ *   - UI에는 종착 대신 **다음 인접역 방면**만 노출 (`buildDirectionMeta(dest, next, ...) → "<next>방면"`)
+ *   - `parseTrainLineDirection`은 nextStationLabel 미전달 경로의 종착 fallback에만 사용됨
+ *
+ * 노선별 종착역(첫/마지막 역)을 stations.json에서 데이터 주도로 추출해 라인 전체를 한 곳에 모아
+ * 검증한다. 새 노선이 stations.json에 추가되면 해당 노선 fixture가 자동 포함된다.
+ */
+
+import i18next from 'i18next';
+
+import stationsData from '../../data/stations.json';
+import type { LineNumber, Station } from '../../types/station';
+import { buildDirectionMeta, parseTrainLineDirection } from '../trainLineDirection';
+import { findRoute, getNextStationName, getStationsOnLine } from '../stationRoute';
+
+const allStations = stationsData as Station[];
+
+// stations.json에 실제 존재하는 라인을 데이터에서 추출 — 하드코딩 금지.
+// 새 라인이 추가되면 fixture/검증이 자동 포함된다.
+const LINES: readonly LineNumber[] = Array.from(
+  new Set(allStations.map((s) => s.line)),
+) as LineNumber[];
+
+interface LineTerminals {
+  line: LineNumber;
+  first: Station;
+  last: Station;
+  count: number;
+}
+
+// 라인별 첫/마지막 역(종착 fixture) 계산. getStationsOnLine은 id 기준 정렬을 보장한다
+// (stationRoute.test.ts의 별도 describe에서 검증됨).
+const lineTerminals: LineTerminals[] = LINES.map((line) => {
+  const stations = getStationsOnLine(line);
+  return {
+    line,
+    first: stations[0],
+    last: stations[stations.length - 1],
+    count: stations.length,
+  };
+});
+
+describe('#807 — buildDirectionMeta 전 노선 종착 라벨 → "<next>방면" 통일', () => {
+  // 핵심 사양: 종착이 어떤 노선/표기든 nextStationLabel만 주어지면 "<next>방면"으로 통일.
+  // 5호선 마천행/방화행 회귀의 정확한 가드.
+  afterEach(async () => {
+    await i18next.changeLanguage('ko');
+  });
+
+  describe('ko: 각 노선 종착 라벨 + 다음역 → "<next>방면"만', () => {
+    it.each(lineTerminals)(
+      '$line 노선: 마지막 종착 라벨로 진입해도 다음역방면만',
+      async ({ first, last }) => {
+        await i18next.changeLanguage('ko');
+        // 양 방향 종착 라벨로 가정해도 nextStationLabel="중곡"이면 항상 "중곡방면"
+        expect(buildDirectionMeta(`${first.name}행`, '중곡', allStations)).toBe('중곡방면');
+        expect(buildDirectionMeta(`${last.name}행`, '중곡', allStations)).toBe('중곡방면');
+      },
+    );
+  });
+
+  describe('5호선 회귀 가드 — 마천/방화 누락 차단', () => {
+    // 실기기 보고 회귀의 핵심: 5호선 종착 표기에서 방면이 누락됐던 사례. 이제는 종착 표기 자체가
+    // UI에 안 보이고 "<next>방면"만 노출 — 회귀 가능성 자체 제거.
+    it.each([
+      ['마천행', '중곡', '중곡방면'],
+      ['방화행', '광화문', '광화문방면'],
+      ['마천행', '광화문', '광화문방면'],
+      ['방화행', '중곡', '중곡방면'],
+    ])('destination="%s", next="%s" → "%s"', (destination, next, expected) => {
+      expect(buildDirectionMeta(destination, next, allStations)).toBe(expected);
+    });
+  });
+
+  describe('데이터에 없는 종착 표기(상일동/하남검단산 등)도 next만 살아남음', () => {
+    // 운영상 들어오지만 stations.json에 미반영된 종착도 다음역방면만 표시되므로 영향 없음.
+    const operationalTerminalsNotInData = [
+      '상일동행',
+      '하남검단산행',
+      '신창행',
+      '연천행',
+      '석남행',
+      '진접행',
+      '별내행',
+      '서동탄행',
+      '병점행',
+    ];
+
+    it.each(operationalTerminalsNotInData)(
+      '"%s" + next="중곡" → "중곡방면"',
+      (destination) => {
+        expect(buildDirectionMeta(destination, '중곡', allStations)).toBe('중곡방면');
+      },
+    );
+  });
+
+  describe('순환선: 종착 정보 없어도 다음역방면 OK', () => {
+    it.each([
+      ['내선순환', '신도림', '신도림방면'],
+      ['외선순환', '신도림', '신도림방면'],
+    ])('"%s" + next="%s" → "%s"', (destination, next, expected) => {
+      expect(buildDirectionMeta(destination, next, allStations)).toBe(expected);
+    });
+  });
+
+  describe('다국어 통일 — next 표기만 i18n 변환', () => {
+    it.each<[LineNumber, string]>([
+      ['1', 'en'],
+      ['5', 'en'],
+      ['7', 'ja'],
+      ['9', 'zh'],
+    ])('$line 노선 / lang=$1: terminal과 무관하게 next만 i18n 표기', async (line, lang) => {
+      await i18next.changeLanguage(lang);
+      const { first, last } = lineTerminals.find((t) => t.line === line)!;
+      const expectedTemplate: Record<string, string> = {
+        en: 'via 다음역',
+        ja: '다음역方面',
+        zh: '다음역方向',
+      };
+      const expected = expectedTemplate[lang];
+      expect(buildDirectionMeta(`${first.name}행`, '다음역', allStations)).toBe(expected);
+      expect(buildDirectionMeta(`${last.name}행`, '다음역', allStations)).toBe(expected);
+    });
+  });
+});
+
+describe('#807 — parseTrainLineDirection (종착 fallback 경로) 전 노선 검증', () => {
+  // buildDirectionMeta가 nextStationLabel 미전달 시 fallback으로 호출하는 경로 — 환승 list 등에서
+  // 진행 방향 미정일 때 종착 텍스트는 노출되므로 i18n 정규화가 정상 동작해야 함.
+  afterEach(async () => {
+    await i18next.changeLanguage('ko');
+  });
+
+  describe('ko: 종착역 라벨은 한글 원본 그대로', () => {
+    it.each(lineTerminals)('$line', async ({ first, last }) => {
+      await i18next.changeLanguage('ko');
+      const firstLabel = `${first.name}행`;
+      const lastLabel = `${last.name}행`;
+      expect(parseTrainLineDirection(firstLabel, allStations)).toBe(firstLabel);
+      expect(parseTrainLineDirection(lastLabel, allStations)).toBe(lastLabel);
+    });
+  });
+
+  describe('en: 종착역 라벨은 nameEn으로 i18n 정규화', () => {
+    it.each(lineTerminals)('$line', async ({ first, last }) => {
+      await i18next.changeLanguage('en');
+      // stations.json의 모든 운영 역은 nameEn을 갖는다. 비어있으면 한글 fallback이 stationDisplay에서 동작.
+      const firstEn = first.nameEn ?? first.name;
+      const lastEn = last.nameEn ?? last.name;
+      expect(parseTrainLineDirection(`${first.name}행`, allStations)).toBe(
+        `Bound for ${firstEn}`,
+      );
+      expect(parseTrainLineDirection(`${last.name}행`, allStations)).toBe(
+        `Bound for ${lastEn}`,
+      );
+    });
+  });
+
+  describe('신분당선 광교(경기대)행 — 괄호 별칭 종착', () => {
+    it('ko: 원본 그대로', async () => {
+      await i18next.changeLanguage('ko');
+      expect(parseTrainLineDirection('광교(경기대)행', allStations)).toBe('광교(경기대)행');
+    });
+
+    it('en: 정확 매칭으로 nameEn="Gwanggyo" 변환', async () => {
+      await i18next.changeLanguage('en');
+      expect(parseTrainLineDirection('광교(경기대)행', allStations)).toBe(
+        'Bound for Gwanggyo',
+      );
+    });
+  });
+});
+
+describe('#807 — getNextStationName 전 노선 DirectRoute fixture', () => {
+  // 라인별 첫 역→두 번째 역(정방향), 마지막 역→끝에서 두 번째(역방향), 첫→마지막 종착 트립을
+  // 검증. 5호선 방화→마천 같은 전 구간 트립에서 첫 hop이 두 번째 역을 정확히 짚는지 가드.
+
+  describe('정방향: 첫 역 → 두 번째 역 (라인별)', () => {
+    it.each(lineTerminals)('$line', ({ line }) => {
+      const stations = getStationsOnLine(line);
+      const first = stations[0];
+      const second = stations[1];
+      const route = findRoute(first.id, second.id);
+      expect(route).not.toBeNull();
+      expect(getNextStationName(first.id, second.id, route)).toBe(second.name);
+    });
+  });
+
+  describe('역방향: 마지막 역 → 끝에서 두 번째 역 (라인별)', () => {
+    it.each(lineTerminals)('$line', ({ line }) => {
+      const stations = getStationsOnLine(line);
+      const last = stations[stations.length - 1];
+      const beforeLast = stations[stations.length - 2];
+      const route = findRoute(last.id, beforeLast.id);
+      expect(route).not.toBeNull();
+      expect(getNextStationName(last.id, beforeLast.id, route)).toBe(beforeLast.name);
+    });
+  });
+
+  describe('전 구간 종착 트립: 첫 역 → 마지막 역 (라인별)', () => {
+    it.each(lineTerminals)('$line: 첫 hop은 두 번째 역', ({ line }) => {
+      const stations = getStationsOnLine(line);
+      const first = stations[0];
+      const last = stations[stations.length - 1];
+      const route = findRoute(first.id, last.id);
+      expect(route).not.toBeNull();
+      expect(getNextStationName(first.id, last.id, route)).toBe(stations[1].name);
+    });
+  });
+});

--- a/src/utils/__tests__/trainLineDirection.test.ts
+++ b/src/utils/__tests__/trainLineDirection.test.ts
@@ -37,71 +37,37 @@ describe('parseTrainLineDirection', () => {
 describe('buildDirectionMeta (#807)', () => {
   // #807: 종착(마천행/방화행 등) 제거, **다음 인접역 방면**만 노출. nextStationLabel 미전달 시에만
   // 종착 fallback. terminal/destination 비교 없이 일관 통일.
+  // 동일 어설션 블록 중복(SonarCloud CPD)을 피하기 위해 시나리오를 데이터 테이블로 통합.
   afterEach(async () => {
     await i18next.changeLanguage('ko');
   });
 
-  describe('nextStationLabel 있음 — 항상 "<name>방면"만', () => {
-    it('일반 종착 + 다음역 → 다음역방면만 (종착 제거)', () => {
-      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('구로방면');
-    });
-
-    it('5호선 마천행 — 종착 제거, 다음역방면만 (#807 회귀 원본)', () => {
-      // 5호선 군자→중곡 진행 시 사용자가 보고 싶은 표시는 "중곡방면"뿐.
-      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('중곡방면');
-    });
-
-    it('5호선 방화행 — 반대 방향도 동일하게 다음역방면만', () => {
-      expect(buildDirectionMeta('방화행', '광화문', stations)).toBe('광화문방면');
-    });
-
-    it('순환선 + 다음역 → 다음역방면 (종착 정보 없으니 항상 방면)', () => {
-      expect(buildDirectionMeta('내선순환', '신도림', stations)).toBe('신도림방면');
-    });
-
-    it('terminal 일치 케이스도 더 이상 dedup 없이 "<name>방면"', () => {
-      // 종착이 사라졌으므로 dedup 개념 자체가 없음. terminal=nextStation도 단순 방면 표기.
-      expect(buildDirectionMeta('도봉산행', '도봉산', stations)).toBe('도봉산방면');
-    });
-
-    it('괄호 별칭 종착 — 다음역명만 보이므로 별칭 영향 없음', () => {
-      expect(buildDirectionMeta('어린이대공원(세종대)방면', '구의', stations)).toBe('구의방면');
-    });
+  // nextStationLabel 있음 — 항상 "<name>방면"만. (label, lang, destination, next, expected)
+  it.each<[string, string, string, string, string]>([
+    ['ko / 일반 종착', 'ko', '소요산행', '구로', '구로방면'],
+    // 5호선 회귀 원본: 마천행/방화행 → 다음역방면만
+    ['ko / 5호선 마천행', 'ko', '마천행', '중곡', '중곡방면'],
+    ['ko / 5호선 방화행', 'ko', '방화행', '광화문', '광화문방면'],
+    ['ko / 순환선', 'ko', '내선순환', '신도림', '신도림방면'],
+    ['ko / terminal=next dedup 없이 next방면', 'ko', '도봉산행', '도봉산', '도봉산방면'],
+    ['ko / 괄호 별칭 종착도 next방면만', 'ko', '어린이대공원(세종대)방면', '구의', '구의방면'],
+    // 다국어 통일 — terminal과 무관하게 next만 i18n 변환
+    ['en / via', 'en', '마천행', '중곡', 'via 중곡'],
+    ['ja / 方面', 'ja', '마천행', '중곡', '중곡方面'],
+    ['zh / 方向', 'zh', '마천행', '중곡', '중곡方向'],
+  ])('%s', async (_, lang, destination, next, expected) => {
+    await i18next.changeLanguage(lang);
+    expect(buildDirectionMeta(destination, next, stations)).toBe(expected);
   });
 
-  describe('nextStationLabel 없음(null) — 종착 fallback', () => {
-    it('일반 종착', () => {
-      expect(buildDirectionMeta('소요산행', null, stations)).toBe('소요산행');
-    });
-
-    it('순환선', () => {
-      expect(buildDirectionMeta('내선순환', null, stations)).toBe('내선순환');
-    });
-
-    it('비정형 텍스트도 그대로 fallback', () => {
-      expect(buildDirectionMeta('급행임시', null, stations)).toBe('급행임시');
-    });
-  });
-
-  describe('다국어 — 다음역방면 표기 통일', () => {
-    it('en locale: "via <name>" 포맷', async () => {
-      await i18next.changeLanguage('en');
-      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('via 중곡');
-    });
-
-    it('ja locale: "<name>方面" 포맷', async () => {
-      await i18next.changeLanguage('ja');
-      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('중곡方面');
-    });
-
-    it('zh locale: "<name>方向" 포맷', async () => {
-      await i18next.changeLanguage('zh');
-      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('중곡方向');
-    });
-
-    it('en locale + null nextStation → 종착 fallback (Bound for ...)', async () => {
-      await i18next.changeLanguage('en');
-      expect(buildDirectionMeta('소요산행', null, stations)).toBe('Bound for Soyosan');
-    });
+  // nextStationLabel 없음(null) — 종착 fallback. (label, lang, destination, expected)
+  it.each<[string, string, string, string]>([
+    ['ko / 일반 종착', 'ko', '소요산행', '소요산행'],
+    ['ko / 순환선', 'ko', '내선순환', '내선순환'],
+    ['ko / 비정형 텍스트', 'ko', '급행임시', '급행임시'],
+    ['en / 종착 fallback (Bound for ...)', 'en', '소요산행', 'Bound for Soyosan'],
+  ])('null nextStation — %s', async (_, lang, destination, expected) => {
+    await i18next.changeLanguage(lang);
+    expect(buildDirectionMeta(destination, null, stations)).toBe(expected);
   });
 });

--- a/src/utils/__tests__/trainLineDirection.test.ts
+++ b/src/utils/__tests__/trainLineDirection.test.ts
@@ -1,9 +1,5 @@
 import i18next from 'i18next';
-import {
-  parseTrainLineDirection,
-  getTerminalStationName,
-  buildDirectionMeta,
-} from '../trainLineDirection';
+import { parseTrainLineDirection, buildDirectionMeta } from '../trainLineDirection';
 import type { Station } from '../../types/station';
 
 const stations: Station[] = [
@@ -20,7 +16,7 @@ describe('parseTrainLineDirection', () => {
   });
 
   it.each([
-    // [lang, input, expected, 설명]
+    // [lang, input, expected]
     ['ko', '내선순환', '내선순환'],
     ['en', '내선순환', 'Inner Loop'],
     ['ko', '외선순환', '외선순환'],
@@ -38,99 +34,74 @@ describe('parseTrainLineDirection', () => {
   });
 });
 
-describe('getTerminalStationName (#792)', () => {
-  // i18n에 독립적인 순수 추출 함수 — locale 전환 불필요.
-  it.each([
-    // 일반 종착
-    ['도봉산행', '도봉산'],
-    ['소요산행', '소요산'],
-    ['구로행', '구로'],
-    // 방면 패턴 (지선/분기)
-    ['어린이대공원방면', '어린이대공원'],
-    // 방면 + 괄호 별칭 (#792 회귀 원본)
-    ['어린이대공원(세종대)방면', '어린이대공원'],
-    ['응암(은평구청)방면', '응암'],
-  ])('terminal 추출: "%s" → "%s"', (input, expected) => {
-    expect(getTerminalStationName(input)).toBe(expected);
-  });
-
-  it.each([
-    // 순환선은 종착 없음
-    ['내선순환'],
-    ['외선순환'],
-    // 빈 문자열
-    [''],
-    // 접미사 단독 입력 — 역명 0길이라 null fallback
-    ['방면'],
-    ['(별칭)방면'],
-    ['행'],
-  ])('null 반환: "%s"', (input) => {
-    expect(getTerminalStationName(input)).toBeNull();
-  });
-
-  it('비정형 텍스트는 null (안전한 fallback — caller가 dedup 못 함)', () => {
-    expect(getTerminalStationName('급행임시')).toBeNull();
-    expect(getTerminalStationName('운행중')).toBeNull();
-  });
-});
-
-describe('buildDirectionMeta (#792)', () => {
+describe('buildDirectionMeta (#807)', () => {
+  // #807: 종착(마천행/방화행 등) 제거, **다음 인접역 방면**만 노출. nextStationLabel 미전달 시에만
+  // 종착 fallback. terminal/destination 비교 없이 일관 통일.
   afterEach(async () => {
     await i18next.changeLanguage('ko');
   });
 
-  describe('회귀 가드 — substring false-positive 방지', () => {
-    it('destination="도봉산행" + nextStationLabel="도봉" → 정상 부착 (terminal "도봉산" ≠ "도봉")', () => {
-      // 1호선 망월사 시뮬레이션. 이전 includes() 기반 dedup은 false-positive로 방면 정보를 누락했음.
-      expect(buildDirectionMeta('도봉산행', '도봉', stations)).toBe('도봉산행 · 도봉방면');
+  describe('nextStationLabel 있음 — 항상 "<name>방면"만', () => {
+    it('일반 종착 + 다음역 → 다음역방면만 (종착 제거)', () => {
+      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('구로방면');
     });
 
-    it('destination="도봉산행" + nextStationLabel="도봉산" → dedup (terminal 정확 일치)', () => {
-      expect(buildDirectionMeta('도봉산행', '도봉산', stations)).toBe('도봉산행');
+    it('5호선 마천행 — 종착 제거, 다음역방면만 (#807 회귀 원본)', () => {
+      // 5호선 군자→중곡 진행 시 사용자가 보고 싶은 표시는 "중곡방면"뿐.
+      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('중곡방면');
     });
 
-    it('destination="어린이대공원(세종대)방면" + nextStationLabel="어린이대공원" → dedup (#792 원본 회귀)', () => {
-      expect(buildDirectionMeta('어린이대공원(세종대)방면', '어린이대공원', stations)).toBe(
-        '어린이대공원(세종대)방면',
-      );
+    it('5호선 방화행 — 반대 방향도 동일하게 다음역방면만', () => {
+      expect(buildDirectionMeta('방화행', '광화문', stations)).toBe('광화문방면');
+    });
+
+    it('순환선 + 다음역 → 다음역방면 (종착 정보 없으니 항상 방면)', () => {
+      expect(buildDirectionMeta('내선순환', '신도림', stations)).toBe('신도림방면');
+    });
+
+    it('terminal 일치 케이스도 더 이상 dedup 없이 "<name>방면"', () => {
+      // 종착이 사라졌으므로 dedup 개념 자체가 없음. terminal=nextStation도 단순 방면 표기.
+      expect(buildDirectionMeta('도봉산행', '도봉산', stations)).toBe('도봉산방면');
+    });
+
+    it('괄호 별칭 종착 — 다음역명만 보이므로 별칭 영향 없음', () => {
+      expect(buildDirectionMeta('어린이대공원(세종대)방면', '구의', stations)).toBe('구의방면');
     });
   });
 
-  describe('순환선/nextStationLabel 미전달', () => {
-    it('nextStationLabel=null이면 종착만 표기', () => {
+  describe('nextStationLabel 없음(null) — 종착 fallback', () => {
+    it('일반 종착', () => {
       expect(buildDirectionMeta('소요산행', null, stations)).toBe('소요산행');
     });
 
-    it('순환선은 terminal null이라 항상 부속 라벨 부착 (nextStationLabel 있을 때)', () => {
-      expect(buildDirectionMeta('내선순환', '신도림', stations)).toBe('내선순환 · 신도림방면');
+    it('순환선', () => {
+      expect(buildDirectionMeta('내선순환', null, stations)).toBe('내선순환');
     });
 
-    it('순환선 + nextStationLabel=null → 순환선만', () => {
-      expect(buildDirectionMeta('내선순환', null, stations)).toBe('내선순환');
+    it('비정형 텍스트도 그대로 fallback', () => {
+      expect(buildDirectionMeta('급행임시', null, stations)).toBe('급행임시');
     });
   });
 
-  describe('다국어 (#792 P1-2)', () => {
-    it('en locale에서도 dedup 정상 동작 (terminal 비교는 i18n 독립)', async () => {
+  describe('다국어 — 다음역방면 표기 통일', () => {
+    it('en locale: "via <name>" 포맷', async () => {
       await i18next.changeLanguage('en');
-      expect(buildDirectionMeta('어린이대공원(세종대)방면', '어린이대공원', stations)).toBe(
-        '어린이대공원(세종대)방면',
-      );
+      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('via 중곡');
     });
 
-    it('en locale 부속 라벨은 "via {{name}}" 포맷', async () => {
-      await i18next.changeLanguage('en');
-      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('Bound for Soyosan · via 구로');
-    });
-
-    it('ja locale 부속 라벨은 "{{name}}方面" 포맷 (역명은 nameJa 없으면 nameEn fallback)', async () => {
+    it('ja locale: "<name>方面" 포맷', async () => {
       await i18next.changeLanguage('ja');
-      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('Soyosan行き · 구로方面');
+      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('중곡方面');
     });
 
-    it('zh locale 부속 라벨은 "{{name}}方向" 포맷 (역명은 nameHanja 없으면 nameEn fallback)', async () => {
+    it('zh locale: "<name>方向" 포맷', async () => {
       await i18next.changeLanguage('zh');
-      expect(buildDirectionMeta('소요산행', '구로', stations)).toBe('开往Soyosan · 구로方向');
+      expect(buildDirectionMeta('마천행', '중곡', stations)).toBe('중곡方向');
+    });
+
+    it('en locale + null nextStation → 종착 fallback (Bound for ...)', async () => {
+      await i18next.changeLanguage('en');
+      expect(buildDirectionMeta('소요산행', null, stations)).toBe('Bound for Soyosan');
     });
   });
 });

--- a/src/utils/trainLineDirection.ts
+++ b/src/utils/trainLineDirection.ts
@@ -27,61 +27,33 @@ export function parseTrainLineDirection(
 }
 
 /**
- * #792: 종착역의 "기준 역명"만 추출한다. dedup용 정확 비교 키.
+ * #807: 종착(마천행/방화행 등)이 아니라 **다음으로 지날 인접역 방면**만 노출한다.
  *
- * 패턴별 추출:
- *   "도봉산행"               → "도봉산"
- *   "어린이대공원(세종대)방면" → "어린이대공원"   (괄호 안 별칭/노선 표기 제거)
- *   "어린이대공원방면"         → "어린이대공원"
- *   "내선순환" / "외선순환"    → null            (순환선은 종착이 없음)
- *   ""                       → null
- *   "비정형 텍스트"            → null            (외부 호출자는 비교 못 함 → 안전한 fallback)
+ * 사용자 요구(#807): "내가 타야하는 다음 역" 정보만 한 줄로. 종착 표기는 정보 과부하 + 노선별
+ * 분기(상일동/하남검단산 등) 누락 회귀의 원인이라 제거. nextStationLabel이 있으면 항상
+ * `<name>방면`만 반환한다 — terminal/destination 비교 없이 일관 통일.
  *
- * 호출자(`buildDirectionMeta`)는 추출된 terminal이 nextStationLabel과 **정확히 같을 때만** dedup해
- * substring false-positive(예: "도봉산행".includes("도봉")=true → 잘못된 dedup)를 방지한다.
+ * nextStationLabel 미전달(null/빈문자) 시에만 종착(`parseTrainLineDirection`)으로 fallback —
+ * 환승 list 등에서 진행 방향 미정인 경우 종착 텍스트라도 보여주기 위함.
  *
- * 구현 노트: `.+?` 같은 lazy quantifier + optional group 조합은 ReDoS(super-linear backtracking)
- * 위험이라 sonar:typescript:S5852가 잡는다. suffix 매칭 + 단순 char-class 정규식으로 회피한다.
- */
-const TRAILING_PAREN_ALIAS_RE = /\([^()]*\)$/;
-const TERMINAL_SUFFIX_BOUND_FOR = '행';
-const TERMINAL_SUFFIX_VIA_NAME = '방면';
-
-export function getTerminalStationName(trainLineNm: string): string | null {
-  if (!trainLineNm) return null;
-  if (trainLineNm === '내선순환' || trainLineNm === '외선순환') return null;
-
-  if (trainLineNm.endsWith(TERMINAL_SUFFIX_VIA_NAME)) {
-    const withoutSuffix = trainLineNm.slice(0, -TERMINAL_SUFFIX_VIA_NAME.length);
-    const withoutAlias = withoutSuffix.replace(TRAILING_PAREN_ALIAS_RE, '');
-    return withoutAlias.length > 0 ? withoutAlias : null;
-  }
-  if (trainLineNm.endsWith(TERMINAL_SUFFIX_BOUND_FOR)) {
-    const withoutSuffix = trainLineNm.slice(0, -TERMINAL_SUFFIX_BOUND_FOR.length);
-    return withoutSuffix.length > 0 ? withoutSuffix : null;
-  }
-  return null;
-}
-
-/**
- * #792: 종착·방면 라벨 빌더. parseTrainLineDirection으로 종착 표기 i18n 정규화 후, nextStationLabel과
- * 종착 역명이 같으면 "방면" 접미사 생략(중복 차단). 다국어 부속 라벨은 `direction.viaName` 키 사용.
+ * 다국어:
+ *   - ko: "<name>방면"
+ *   - en: "via <name>"
+ *   - ja: "<name>方面"
+ *   - zh: "<name>方向"
  *
- * 회귀 가드:
- *   - destination="어린이대공원(세종대)방면", nextStationLabel="어린이대공원" → terminal 일치 → dedup ✓
- *   - destination="도봉산행", nextStationLabel="도봉" → terminal "도봉산" ≠ "도봉" → 정상 부착 ✓
- *     (이전 substring 기반은 false-positive로 dedup해 사용자에게 방면 정보 누락)
- *   - destination="도봉산행", nextStationLabel="도봉산" → terminal 일치 → dedup ✓
- *   - destination="내선순환" → terminal null → 항상 부속 라벨 부착 (단 nextStationLabel 있을 때)
+ * 회귀 가드(#807):
+ *   - destination="마천행", nextStationLabel="중곡" → "중곡방면" (5호선 마천/방화 누락 차단)
+ *   - destination="어린이대공원(세종대)방면", nextStationLabel="어린이대공원" → "어린이대공원방면"
+ *   - destination="내선순환", nextStationLabel="신도림" → "신도림방면"
+ *
+ * stations 인자는 fallback 경로(`parseTrainLineDirection`)에서만 사용. 일반 경로는 i18n 키만 사용.
  */
 export function buildDirectionMeta(
   destination: string,
   nextStationLabel: string | null,
   stations: readonly Station[],
 ): string {
-  const direction = parseTrainLineDirection(destination, stations);
-  if (!nextStationLabel) return direction;
-  const terminal = getTerminalStationName(destination);
-  if (terminal !== null && terminal === nextStationLabel) return direction;
-  return `${direction} · ${i18next.t('direction.viaName', { name: nextStationLabel })}`;
+  if (!nextStationLabel) return parseTrainLineDirection(destination, stations);
+  return i18next.t('direction.viaName', { name: nextStationLabel });
 }


### PR DESCRIPTION
Closes #807

## 변경
- **사양 변경**: BoardingTrainList 첫째 줄에서 종착(마천행/방화행 등)을 제거하고 **다음 인접역 방면**만 노출. 5호선 마천/방화 회귀처럼 종착 분기 누락 가능성 자체를 차단.
- `buildDirectionMeta`: `nextStationLabel` 있으면 `<name>방면`만 반환. 미전달 시에만 `parseTrainLineDirection`으로 종착 fallback (환승 list 등 진행 방향 미정 케이스).
- 본 변경이 orphan으로 만든 `getTerminalStationName` + #792 dedup 로직 제거 (글로벌 룰 "본인 변경이 만든 dead code 제거").
- `lineDirectionFixtures.test.ts` 추가: stations.json `LineNumber` set을 데이터에서 추출해 전 노선 종착역 fixture를 자동 구성.
  - `buildDirectionMeta`가 노선/종착에 무관하게 `<next>방면`으로 통일됨을 라인별로 검증
  - `parseTrainLineDirection` 종착 fallback 경로(ko 원본, en `nameEn` 변환, 신분당 광교(경기대) 등) 검증
  - `getNextStationName` DirectRoute 정/역방향 + 전 구간 트립 라인별 검증

## 검증
- [ ] 5호선 마천행/방화행이 BoardingTrainList에서 빠지고 다음역방면만 표시
- [ ] 다른 노선 종착도 동일하게 통일됨
- [ ] 전 노선 fixture 테스트 (stations.json 기반 13 라인) 통과
- [ ] 커버리지 100% (`npm test`)
- [ ] `npm run type-check` 통과