### PR TITLE
fix(#814): 환승 dismiss 후 BoardingTrainList warmup 단축 — imminent prefetch + release 즉시 refetch

### DIFF
--- a/src/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/hooks/__tests__/useArrivalInfo.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { AppState } from 'react-native';
-import { useArrivalInfo, __resetArrivalCacheForTests } from '../useArrivalInfo';
+import { prefetchArrival, useArrivalInfo, __resetArrivalCacheForTests } from '../useArrivalInfo';
 import * as arrivalApiModule from '../../api/arrivalApi';
 
 jest.mock('../../api/arrivalApi');
@@ -392,6 +392,76 @@ describe('useArrivalInfo', () => {
 
     // 에러 무시 — 기존 데이터 유지
     expect(result.current.arrival).toEqual(mockArrival);
+  });
+
+  describe('prefetchArrival (#814)', () => {
+    it('stationName이 null이면 fetch하지 않는다', async () => {
+      await prefetchArrival(null, '5');
+      expect(arrivalApiModule.fetchArrivalInfo).not.toHaveBeenCalled();
+    });
+
+    it('cache miss 시 fetch + cache에 저장 — 다음 useArrivalInfo 마운트에서 cache hit', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+      await prefetchArrival('공덕', '5');
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('공덕', { lineHint: '5' });
+
+      // 후속 useArrivalInfo 마운트는 cache hit으로 loading=false 즉시 표시.
+      const { result } = renderHook(() => useArrivalInfo('공덕', '5'));
+      expect(result.current.arrival).toEqual(mockArrival);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('cache가 valid면 no-op — 중복 네트워크 호출 방지', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+
+      await prefetchArrival('공덕', '5');
+      const firstCalls = (arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length;
+      await prefetchArrival('공덕', '5');
+      expect((arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length).toBe(firstCalls);
+    });
+
+    it('lineHint=null이면 undefined로 provider에 전달', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+      await prefetchArrival('공덕', null);
+      expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('공덕', { lineHint: undefined });
+    });
+
+    it('mock 데이터는 cache에 저장하지 않는다', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrivalWithMock);
+      await prefetchArrival('공덕', '5');
+      // 같은 station에 한 번 더 prefetch — cache가 비어 있으므로 다시 fetch 발생
+      await prefetchArrival('공덕', '5');
+      expect((arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length).toBe(2);
+    });
+
+    it('fetch 실패는 silent하게 무시한다 — 다음 폴링이 재시도', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockRejectedValue(new Error('network'));
+      await expect(prefetchArrival('공덕', '5')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('refetch (#814)', () => {
+    it('refetch 호출 시 polling 주기를 기다리지 않고 즉시 fetch한다', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+      const { result } = renderHook(() => useArrivalInfo('강남'));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const initialCalls = (arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length;
+      act(() => result.current.refetch());
+      await waitFor(() =>
+        expect((arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length).toBeGreaterThan(
+          initialCalls,
+        ),
+      );
+    });
+
+    it('stationName이 null이면 refetch는 no-op', async () => {
+      const { result } = renderHook(() => useArrivalInfo(null));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      act(() => result.current.refetch());
+      expect(arrivalApiModule.fetchArrivalInfo).not.toHaveBeenCalled();
+    });
   });
 
   it('포그라운드 복귀 시 캐시를 클리어하고 fresh fetch한다', async () => {

--- a/src/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/hooks/__tests__/useTransferTrainList.test.tsx
@@ -1,15 +1,17 @@
 import { act, renderHook } from '@testing-library/react-native';
 import { useTransferTrainList, filterArrivalsByDirection } from '../useTransferTrainList';
-import { useArrivalInfo } from '../useArrivalInfo';
+import { prefetchArrival, useArrivalInfo } from '../useArrivalInfo';
 import { useBoardingLockStore } from '../../store/useBoardingLockStore';
 import { findStationByNameAndLine } from '../../utils/stationRoute';
 import type { ArrivalInfo, StationArrival } from '../../api/arrivalApi';
 import type { BoardingLock } from '../../types/boardingLock';
 import type { Station } from '../../types/station';
-import { makeTransferRoute } from '../../testUtils/routeFixtures';
+import { makeDirectRoute, makeTransferRoute } from '../../testUtils/routeFixtures';
 
 jest.mock('../useArrivalInfo');
 const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockPrefetchArrival = prefetchArrival as jest.Mock;
+const mockRefetch = jest.fn();
 
 const mockCreateLock = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../store/useBoardingLockStore', () => {
@@ -39,7 +41,7 @@ const route = makeTransferRoute({
 const gondeokOn6 = findStationByNameAndLine('공덕', '6') as Station;
 
 function arrivalRet(arrival: StationArrival | null) {
-  return { arrival, loading: false, isMock: false };
+  return { arrival, loading: false, isMock: false, refetch: mockRefetch };
 }
 
 function makeTrain(overrides: Partial<ArrivalInfo>): ArrivalInfo {
@@ -62,6 +64,7 @@ describe('useTransferTrainList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockPrefetchArrival.mockResolvedValue(undefined);
   });
 
   it('context 미확정(currentStation=null) → context=null + arrivals=[]', () => {
@@ -144,6 +147,131 @@ describe('useTransferTrainList', () => {
     expect(mockCreateLock).not.toHaveBeenCalled();
   });
 
+  // #814 — 환승 imminent prefetch + transferContext 활성화 시 refetch
+  describe('#814 imminent prefetch & release refetch', () => {
+    it('환승 1정거장 전(imminent) → 다음 호선 arrival prefetch 트리거', () => {
+      const hyochangOn6 = findStationByNameAndLine('효창공원앞', '6') as Station;
+      const routeImminent = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 3,
+      });
+      renderHook(() =>
+        useTransferTrainList({
+          lock,
+          route: routeImminent,
+          destinationName: '여의나루',
+          currentStation: hyochangOn6,
+        }),
+      );
+      expect(mockPrefetchArrival).toHaveBeenCalledWith('공덕', '5');
+    });
+
+    it('환승역 도달 시(잔여=0)도 prefetch — context 활성화와 동시 prefetch+refetch', () => {
+      renderHook(() =>
+        useTransferTrainList({
+          lock,
+          route,
+          destinationName: '여의나루',
+          currentStation: gondeokOn6,
+        }),
+      );
+      expect(mockPrefetchArrival).toHaveBeenCalledWith('공덕', '5');
+    });
+
+    it('환승 2정거장 이상 전 → prefetch 미발생', () => {
+      const samgakji = findStationByNameAndLine('삼각지', '6') as Station;
+      renderHook(() =>
+        useTransferTrainList({
+          lock,
+          route,
+          destinationName: '여의나루',
+          currentStation: samgakji,
+        }),
+      );
+      expect(mockPrefetchArrival).not.toHaveBeenCalled();
+    });
+
+    it('비환승 trip(direct route) → prefetch 미발생 (불필요 폴링 없음)', () => {
+      const directRoute = makeDirectRoute(5, '6');
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      renderHook(() =>
+        useTransferTrainList({
+          lock: lockOn6,
+          route: directRoute,
+          destinationName: '여의나루',
+          currentStation: gondeokOn6,
+        }),
+      );
+      expect(mockPrefetchArrival).not.toHaveBeenCalled();
+    });
+
+    it('lock=null → prefetch 미발생', () => {
+      renderHook(() =>
+        useTransferTrainList({
+          lock: null,
+          route,
+          destinationName: '여의나루',
+          currentStation: gondeokOn6,
+        }),
+      );
+      expect(mockPrefetchArrival).not.toHaveBeenCalled();
+    });
+
+    it('transferContext 활성화 즉시 refetch 호출 — 첫 응답 앞당김', () => {
+      // 초기 마운트: currentStation=null → context null → refetch 미호출
+      const { rerender } = renderHook(
+        (props: {
+          lock: BoardingLock | null;
+          currentStation: Station | null;
+        }) =>
+          useTransferTrainList({
+            lock: props.lock,
+            route,
+            destinationName: '여의나루',
+            currentStation: props.currentStation,
+          }),
+        { initialProps: { lock, currentStation: null } },
+      );
+      expect(mockRefetch).not.toHaveBeenCalled();
+
+      // 환승역 도달 → context 활성화 → refetch 1회
+      rerender({ lock, currentStation: gondeokOn6 });
+      expect(mockRefetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('transferContext 유지 중에는 추가 refetch 미발생 (re-render에 면역)', () => {
+      const { rerender } = renderHook(
+        (props: { currentStation: Station }) =>
+          useTransferTrainList({
+            lock,
+            route,
+            destinationName: '여의나루',
+            currentStation: props.currentStation,
+          }),
+        { initialProps: { currentStation: gondeokOn6 } },
+      );
+      expect(mockRefetch).toHaveBeenCalledTimes(1);
+      // 같은 currentStation으로 rerender — context 동일 → refetch 추가 호출 없음
+      rerender({ currentStation: gondeokOn6 });
+      expect(mockRefetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('비환승 trip은 refetch도 미호출', () => {
+      const directRoute = makeDirectRoute(5, '6');
+      renderHook(() =>
+        useTransferTrainList({
+          lock,
+          route: directRoute,
+          destinationName: '강남',
+          currentStation: gondeokOn6,
+        }),
+      );
+      expect(mockRefetch).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('filterArrivalsByDirection', () => {

--- a/src/hooks/useArrivalInfo.ts
+++ b/src/hooks/useArrivalInfo.ts
@@ -18,6 +18,43 @@ const arrivalCache = new TtlCache<string, StationArrival>(CACHE_TTL_MS);
 /** 테스트 격리용 — useArrivalInfo 사용처 외에는 호출하지 말 것. */
 export function __resetArrivalCacheForTests(): void {
   arrivalCache.clear();
+  prefetchProvider = null;
+}
+
+/**
+ * #814 prefetch 전용 모듈 싱글톤 provider. useArrivalInfo가 mount 전 또는 다른 station을
+ * 폴링 중인 시점에 호출돼도 같은 캐시를 공유할 수 있도록 lazy 초기화.
+ * (providerRef는 hook 인스턴스 단위라 prefetch caller가 직접 쓸 수 없음.)
+ */
+let prefetchProvider: ArrivalProvider | null = null;
+function getPrefetchProvider(): ArrivalProvider {
+  if (!prefetchProvider) prefetchProvider = createArrivalProvider();
+  return prefetchProvider;
+}
+
+/**
+ * 환승 등 임박 시점에 다음 노선 도착 정보를 사전 폴링해 warmup을 단축한다 (#814).
+ * - cache TTL(30s) 내에 valid 엔트리가 있으면 no-op — 중복 네트워크 호출 방지.
+ * - 결과는 useArrivalInfo와 같은 모듈 스코프 cache에 저장되어, 호출자(useTransferTrainList)가
+ *   transferContext 활성화로 useArrivalInfo를 마운트할 때 첫 effect가 cache hit으로 즉시 표시.
+ * - 호출자는 결과를 await할 필요 없음 — fire-and-forget. 실패 시 silent (다음 폴링이 재시도).
+ */
+export async function prefetchArrival(
+  stationName: string | null,
+  lineHint?: LineNumber | null,
+): Promise<void> {
+  if (!stationName) return;
+  if (arrivalCache.get(stationName)) return;
+  try {
+    const data = await getPrefetchProvider().getArrival(stationName, {
+      lineHint: lineHint ?? undefined,
+    });
+    if (!data.isMock) {
+      arrivalCache.set(stationName, data);
+    }
+  } catch {
+    // prefetch 실패는 무시 — 실제 useArrivalInfo 폴링이 재시도한다.
+  }
 }
 
 function arrivalEqual(a: StationArrival | null, b: StationArrival): boolean {
@@ -28,6 +65,12 @@ interface UseArrivalInfoReturn {
   arrival: StationArrival | null;
   loading: boolean;
   isMock: boolean;
+  /**
+   * 호출 즉시 한 번 강제 폴링을 트리거한다 (#814). 캐시 TTL과 무관하게 fetch — 환승 알람
+   * dismiss 직후 다음 노선 list가 자연 polling 주기(5초)를 기다리지 않고 최신 데이터로
+   * 갱신되도록 한다. stationName이 null이면 no-op.
+   */
+  refetch: () => void;
 }
 
 export function useArrivalInfo(
@@ -102,24 +145,22 @@ export function useArrivalInfo(
     // lineHint가 바뀌면 즉시 refetch — stale hint로 5초간 잘못된 호선 schedule이 보이는 것 방지.
   }, [stationName, lineHint]);
 
-  usePolling(
-    () => {
-      const name = stationNameRef.current;
-      if (!name) return;
-      providerRef.current.getArrival(name, {
-        lineHint: lineHintRef.current ?? undefined,
-      }).then((data) => {
-        if (name !== stationNameRef.current) return;
-        if (!data.isMock) {
-          arrivalCache.set(name, data);
-        }
-        updateArrival(data);
-        setLoading(false);
-      }).catch(() => {});
-    },
-    POLL_INTERVAL_MS,
-    { onResume: () => arrivalCache.clear() },
-  );
+  const doPoll = useCallback(() => {
+    const name = stationNameRef.current;
+    if (!name) return;
+    providerRef.current.getArrival(name, {
+      lineHint: lineHintRef.current ?? undefined,
+    }).then((data) => {
+      if (name !== stationNameRef.current) return;
+      if (!data.isMock) {
+        arrivalCache.set(name, data);
+      }
+      updateArrival(data);
+      setLoading(false);
+    }).catch(() => {});
+  }, [updateArrival]);
 
-  return { arrival, loading, isMock: arrival?.isMock ?? false };
+  usePolling(doPoll, POLL_INTERVAL_MS, { onResume: () => arrivalCache.clear() });
+
+  return { arrival, loading, isMock: arrival?.isMock ?? false, refetch: doPoll };
 }

--- a/src/hooks/useTransferTrainList.ts
+++ b/src/hooks/useTransferTrainList.ts
@@ -1,7 +1,10 @@
-import { useCallback, useMemo } from 'react';
-import { useArrivalInfo } from './useArrivalInfo';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { prefetchArrival, useArrivalInfo } from './useArrivalInfo';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
-import { findActiveTransferContext } from '../utils/findActiveTransferContext';
+import {
+  findActiveTransferContext,
+  findUpcomingTransferPrefetch,
+} from '../utils/findActiveTransferContext';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../constants/boardingLock';
 import { calculateRemainingLegETA } from '../utils/stationRoute';
 import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
@@ -50,7 +53,36 @@ export function useTransferTrainList({
 
   const transferStationName = context?.transferStationInToLine.name ?? null;
   const transferLine = context?.nextLine ?? null;
-  const { arrival } = useArrivalInfo(transferStationName, transferLine, arrivalProvider);
+  const { arrival, refetch } = useArrivalInfo(transferStationName, transferLine, arrivalProvider);
+
+  // #814 — 환승 알람 imminent 시점부터 다음 노선 arrival을 사전 폴링한다.
+  // findUpcomingTransferPrefetch는 lock 활성 + transfer 라우트 + 다음 환승까지 잔여 stops ≤ 1
+  // (또는 이미 환승역 위)일 때만 target을 반환한다. 비환승 trip(direct route)이면 항상 null —
+  // prefetch가 자연스럽게 skip되어 불필요 폴링이 발생하지 않는다.
+  // prefetchArrival 자체가 cache TTL(30s) 내 valid 엔트리가 있으면 no-op이라 같은 trigger가
+  // 여러 번 호출돼도 중복 네트워크 호출이 없다.
+  const upcomingTransfer = useMemo(
+    () => findUpcomingTransferPrefetch(lock, route, destinationName, currentStation),
+    [lock, route, destinationName, currentStation],
+  );
+  const upcomingStation = upcomingTransfer?.transferStationName ?? null;
+  const upcomingLine = upcomingTransfer?.nextLine ?? null;
+  useEffect(() => {
+    if (!upcomingStation || !upcomingLine) return;
+    void prefetchArrival(upcomingStation, upcomingLine);
+  }, [upcomingStation, upcomingLine]);
+
+  // #814 — context가 막 활성화된 순간(release: 사용자가 환승역에 도달해 다음 leg로 전환)
+  // useArrivalInfo의 자연 polling 주기를 기다리지 않고 즉시 한 번 강제 fetch. cache가 비어
+  // 있으면 첫 응답을 앞당기고, cache가 있어도 latest로 갱신해 stale 데이터 노출 시간을 줄인다.
+  const prevContextActiveRef = useRef(false);
+  useEffect(() => {
+    const active = context !== null;
+    if (active && !prevContextActiveRef.current) {
+      refetch();
+    }
+    prevContextActiveRef.current = active;
+  }, [context, refetch]);
 
   const arrivals = useMemo<ArrivalInfo[]>(
     () => filterByDirection(arrival, context?.direction ?? null),

--- a/src/utils/__tests__/findActiveTransferContext.test.ts
+++ b/src/utils/__tests__/findActiveTransferContext.test.ts
@@ -1,4 +1,8 @@
-import { findActiveTransferContext, resolveDirectionInLine } from '../findActiveTransferContext';
+import {
+  findActiveTransferContext,
+  findUpcomingTransferPrefetch,
+  resolveDirectionInLine,
+} from '../findActiveTransferContext';
 import { findStationByNameAndLine, getStationsOnLine } from '../stationRoute';
 import type { BoardingLock } from '../../types/boardingLock';
 import type { Station } from '../../types/station';
@@ -178,6 +182,171 @@ describe('findActiveTransferContext', () => {
     expect(
       findActiveTransferContext(transferredLock, route, '여의나루', gondeokOnLine6),
     ).toBeNull();
+  });
+
+  describe('findUpcomingTransferPrefetch (#814)', () => {
+    it('lock=null이면 null', () => {
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      expect(findUpcomingTransferPrefetch(null, route, '여의나루', gondeokOnLine6)).toBeNull();
+    });
+
+    it('route=null이면 null', () => {
+      expect(findUpcomingTransferPrefetch(lock, null, '여의나루', gondeokOnLine6)).toBeNull();
+    });
+
+    it('destinationName=null이면 null', () => {
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      expect(findUpcomingTransferPrefetch(lock, route, null, gondeokOnLine6)).toBeNull();
+    });
+
+    it('currentStation=null이면 null', () => {
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      expect(findUpcomingTransferPrefetch(lock, route, '여의나루', null)).toBeNull();
+    });
+
+    it('direct route(비환승 trip)은 항상 null — prefetch 미발생', () => {
+      const route = makeDirectRoute(5, '6');
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      expect(findUpcomingTransferPrefetch(lockOn6, route, '공덕', gondeokOnLine6)).toBeNull();
+    });
+
+    it('환승 1정거장 전 (imminent) → next line + 환승역 반환', () => {
+      // 6호선 효창공원앞은 공덕 바로 다음(잔여 stops=1) — imminent threshold 충족
+      const hyochangOn6 = findStationByNameAndLine('효창공원앞', '6') as Station;
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 3,
+      });
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      const result = findUpcomingTransferPrefetch(lockOn6, route, '여의나루', hyochangOn6);
+      expect(result).not.toBeNull();
+      expect(result!.nextLine).toBe('5');
+      expect(result!.transferStationName).toBe('공덕');
+    });
+
+    it('환승 2정거장 이상 전 → null (잔여 stops > 1)', () => {
+      // 6호선 삼각지는 공덕에서 2 stop 떨어짐 — threshold 초과
+      const samgakji = findStationByNameAndLine('삼각지', '6') as Station;
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      expect(findUpcomingTransferPrefetch(lockOn6, route, '여의나루', samgakji)).toBeNull();
+    });
+
+    it('이미 환승역 도달(잔여=0)도 prefetch target 반환 — context 활성화와 동시 호출 케이스', () => {
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      const result = findUpcomingTransferPrefetch(lockOn6, route, '여의나루', gondeokOnLine6);
+      expect(result).not.toBeNull();
+      expect(result!.transferStationName).toBe('공덕');
+    });
+
+    it('lock이 이미 nextLine으로 교체됨(환승 완료) → null', () => {
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 3,
+      });
+      const transferredLock = { ...lock, boardingLine: '5' as const };
+      const hyochangOn6 = findStationByNameAndLine('효창공원앞', '6') as Station;
+      expect(
+        findUpcomingTransferPrefetch(transferredLock, route, '여의나루', hyochangOn6),
+      ).toBeNull();
+    });
+
+    it('currentStation이 환승역명과 같지만 다른 line variant — fromLine variant lookup으로 잔여=0', () => {
+      // 사용자가 환승역에 도달해 fusion이 nextLine 변형(공덕 5호선)으로 stitch된 직후.
+      // currentStation.line='5'이지만 currentStation.name='공덕'이고 fromLine(6)에도 공덕이 존재 →
+      // findStationByNameAndLine('공덕', '6') 성공 → getRemainingStops(6공덕, 6공덕) = 0 → prefetch.
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      const result = findUpcomingTransferPrefetch(lockOn6, route, '여의나루', gondeokOnLine5);
+      expect(result).not.toBeNull();
+      expect(result!.transferStationName).toBe('공덕');
+    });
+
+    it('currentStation이 fromLine variant도 없는 다른 역(여의나루) → null', () => {
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 3,
+      });
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      // 5호선 여의나루: 6호선 variant 없음 + 환승역명과도 다름 → fromLineStation undefined → null
+      expect(findUpcomingTransferPrefetch(lockOn6, route, '여의나루', yeouinaru)).toBeNull();
+    });
+
+    it('lock.boardingLine이 어떤 transfer waypoint의 fromLine도 아니면 null', () => {
+      // 사용자가 1호선 lock인데 route는 6→5 환승 — fromLine 매칭 없음
+      const route = makeTransferRoute({
+        transferName: '공덕',
+        fromLine: '6',
+        toLine: '5',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 3,
+      });
+      const lockOn1 = { ...lock, boardingLine: '1' as const };
+      const hyochangOn6 = findStationByNameAndLine('효창공원앞', '6') as Station;
+      expect(findUpcomingTransferPrefetch(lockOn1, route, '여의나루', hyochangOn6)).toBeNull();
+    });
+
+    it('multi-transfer route — 첫 leg의 다음 환승만 prefetch 대상', () => {
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '공덕', fromLine: '6', toLine: '5', stopsToTransfer: 1 },
+          { transferName: '여의도', fromLine: '5', toLine: '9', stopsToTransfer: 3 },
+        ],
+        stopsAfterLastTransfer: 1,
+      });
+      const lockOn6 = { ...lock, boardingLine: '6' as const };
+      const hyochangOn6 = findStationByNameAndLine('효창공원앞', '6') as Station;
+      const result = findUpcomingTransferPrefetch(lockOn6, route, '아무목적지', hyochangOn6);
+      expect(result).not.toBeNull();
+      expect(result!.transferStationName).toBe('공덕');
+      expect(result!.nextLine).toBe('5');
+    });
   });
 
   describe('resolveDirectionInLine (직접 호출)', () => {

--- a/src/utils/findActiveTransferContext.ts
+++ b/src/utils/findActiveTransferContext.ts
@@ -1,7 +1,12 @@
 import type { BoardingLock } from '../types/boardingLock';
 import type { LineNumber, Station } from '../types/station';
 import type { Route } from './stationRoute';
-import { findStationByNameAndLine, getStationsOnLine, isSameStationName } from './stationRoute';
+import {
+  findStationByNameAndLine,
+  getRemainingStops,
+  getStationsOnLine,
+  isSameStationName,
+} from './stationRoute';
 import { resolveAllTargets } from './stationAlarm';
 import type { TripDirection } from './tripDirection';
 
@@ -75,6 +80,79 @@ export function findActiveTransferContext(
     direction,
     completedTransferIdx: matchedIdx,
   };
+}
+
+/** prefetch 트리거에 사용 — 환승 imminent로 판정하는 잔여 stops 임계값 (#814). */
+const PREFETCH_IMMINENT_STOPS = 1;
+
+export interface UpcomingTransferTarget {
+  /** 환승 후 탑승할 노선 — useArrivalInfo lineHint로 사용. */
+  nextLine: LineNumber;
+  /** toLine 기준 환승역 이름 — prefetch 캐시 키(useArrivalInfo의 stationName과 동일 스코프). */
+  transferStationName: string;
+}
+
+/**
+ * 현재 leg에서 다음 환승이 imminent(잔여 stops ≤ 1)인지 판정하고, prefetch 대상(next line + 환승역)
+ * 을 반환한다 (#814). 이미 환승역 도달해 findActiveTransferContext가 활성 컨텍스트를 반환하는
+ * 순간은 포함된다(잔여 stops = 0).
+ *
+ * - lock/route/currentStation 중 하나라도 없으면 null
+ * - lock.boardingLine을 fromLine으로 가지는 transfer waypoint(=다음 환승)를 찾아
+ *   currentStation으로부터의 잔여 stops를 계산. PREFETCH_IMMINENT_STOPS 이하만 반환
+ * - direct route는 transfer waypoint가 없어 null
+ * - currentStation이 fromLine 변형이 아닌 경우(=환승 도중 nextLine으로 이미 stitch된 상태)는
+ *   nextLine 변형으로 currentStation을 재조회해 잔여=0(=환승역 위)로 평가
+ *
+ * 호출자(useTransferTrainList)는 결과를 받으면 prefetchArrival을 호출해 BoardingTrainList
+ * warmup을 줄인다. 비환승 trip은 null 반환 → prefetch 미발생.
+ */
+export function findUpcomingTransferPrefetch(
+  lock: BoardingLock | null,
+  route: Route,
+  destinationName: string | null,
+  currentStation: Station | null,
+): UpcomingTransferTarget | null {
+  if (!lock || !route || !destinationName || !currentStation) return null;
+  if (route.type === 'direct') return null;
+
+  const targets = resolveAllTargets(route, destinationName);
+  // 다음 환승 = lock.boardingLine을 fromLine으로 사용하는 transfer 타겟 (= approachLine === boardingLine).
+  // multi-transfer에서도 사용자가 현재 leg의 boardingLine을 기준으로 다음 환승만 찾는다.
+  const upcoming = targets.find(
+    (t) => t.alarmType === 'transfer' && t.approachLine === lock.boardingLine,
+  );
+  if (!upcoming) return null;
+
+  const upcomingIdx = targets.indexOf(upcoming);
+  const next = targets[upcomingIdx + 1];
+  // resolveAllTargets는 transfer 타겟 뒤에 destination/다음 transfer를 보장 — 방어 코드만.
+  /* istanbul ignore next */
+  if (!next) return null;
+
+  const nextLine = next.approachLine;
+  // 위 upcoming 매칭이 t.approachLine === lock.boardingLine 조건으로 이미 filter 했으므로
+  // lock.boardingLine === nextLine 시나리오는 매칭 자체가 안 된다 (다음 leg는 다른 노선).
+  // 같은 노선 안에서 leg가 분리되는 케이스(e.g. 분기선)는 stations.json 라우트에 없음.
+
+  // 잔여 stops: currentStation이 fromLine 변형이면 직접 계산.
+  const fromLineStation = findStationByNameAndLine(currentStation.name, upcoming.approachLine);
+  const transferOnFromLine = findStationByNameAndLine(upcoming.name, upcoming.approachLine);
+  /* istanbul ignore next -- targets는 stations.json에서 도출되므로 lookup 실패는 데이터 정합성 가상 케이스. */
+  if (!transferOnFromLine) return null;
+
+  // currentStation.name이 fromLine 변형으로 존재하지 않으면 잔여 stops를 계산할 수 없다.
+  // 일반 시나리오에선 사용자가 fromLine 위에 있어 lookup이 항상 성공한다. lookup 실패는 fusion이
+  // 다른 노선으로 stitch됐거나 데이터 정합성 깨진 케이스 — 보수적으로 prefetch 건너뜀.
+  if (!fromLineStation) return null;
+
+  const remainingStops = getRemainingStops(fromLineStation.id, transferOnFromLine.id);
+  /* istanbul ignore next -- fromLineStation과 transferOnFromLine은 같은 line(upcoming.approachLine)
+     으로 lookup된 결과라 getRemainingStops가 null을 반환할 일이 없다. 방어 코드. */
+  if (remainingStops === null) return null;
+  if (remainingStops > PREFETCH_IMMINENT_STOPS) return null;
+
+  return { nextLine, transferStationName: upcoming.name };
 }
 
 /**


### PR DESCRIPTION
Closes #814

## 변경
- 환승 알람 imminent 시점부터 다음 line arrival prefetch
- BoardingLock release 즉시 transfer line refetch
- 비환승 trip은 prefetch 건너뜀 (불필요 폴링 없음)

## 검증
- [ ] imminent → prefetch 트리거 (단위 테스트)
- [ ] release → 즉시 refetch (단위 테스트)
- [ ] 비환승 trip → prefetch 없음 (단위 테스트)
- [ ] 커버리지 100%