### PR TITLE
feat(#816): lockless station-passed 토글(C 슬라이스) — lock 없는 trip에 station-passed 알림 opt-in

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -79,6 +79,9 @@ export default function HomeScreen() {
   const setSleepMode = useAppStore((s) => s.setSleepMode);
   const loadSleepMode = useAppStore((s) => s.loadSleepMode);
   const loadAllowSpeaker = useAppStore((s) => s.loadAllowSpeaker);
+  // #816 C — lockless station-passed 토글. useApnsTripRegistration이 backend register payload에 포함시킨다.
+  const locklessStationPassed = useAppStore((s) => s.locklessStationPassed);
+  const loadLocklessStationPassed = useAppStore((s) => s.loadLocklessStationPassed);
   const showSleepModeGuide = useSleepModeGuide();
   const alarmEvent = useAppStore((s) => s.alarmEvent);
   const clearAlarmEvent = useAppStore((s) => s.clearAlarmEvent);
@@ -319,6 +322,7 @@ export default function HomeScreen() {
       nextTrainMinutes != null && nextTrainMinutes !== Infinity ? nextTrainMinutes * 60 : null,
     currentStation: result?.station ?? null,
     boardingLock,
+    locklessStationPassed,
   });
 
   useEffect(() => {
@@ -334,6 +338,7 @@ export default function HomeScreen() {
     loadCustomOrigin();
     loadRoutePreference();
     loadAlarmEvent();
+    loadLocklessStationPassed();
     // iOS가 BG에서 앱을 메모리 압박으로 종료하면 Zustand 상태는 휘발되지만
     // DESTINATION_KEY는 디스크에 남는다. 콜드/웜 부팅 시 복원해 trip을 이어간다 (#541).
     // #700 — tripOrigin을 먼저 await으로 hydrate한 다음 destination을 set한다.

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -31,6 +31,10 @@ export default function SettingsScreen() {
   const accessibilityMode = useAppStore((s) => s.accessibilityMode);
   const setAccessibilityMode = useAppStore((s) => s.setAccessibilityMode);
   const loadAccessibilityMode = useAppStore((s) => s.loadAccessibilityMode);
+  // #816 C — lockless station-passed opt-in 토글.
+  const locklessStationPassed = useAppStore((s) => s.locklessStationPassed);
+  const setLocklessStationPassed = useAppStore((s) => s.setLocklessStationPassed);
+  const loadLocklessStationPassed = useAppStore((s) => s.loadLocklessStationPassed);
   const themeMode = useAppStore((s) => s.themeMode);
   const setThemeMode = useAppStore((s) => s.setThemeMode);
   const routePreference = useAppStore((s) => s.routePreference);
@@ -47,6 +51,7 @@ export default function SettingsScreen() {
     loadAllowSpeaker();
     loadAccessibilityMode();
     loadRoutePreference();
+    loadLocklessStationPassed();
   }, []);
 
   return (
@@ -135,6 +140,23 @@ export default function SettingsScreen() {
               trackColor={{ false: colors.hair, true: colors.accent }}
               thumbColor={allowSpeaker ? colors.onAccent : colors.subtle}
               testID="allow-speaker-switch"
+            />
+          </View>
+
+          {/* #816 C — lockless station-passed opt-in. 기본 OFF + 명시 동의 후에만 lock 없는 trip의 station-passed 발사. */}
+          <View style={[styles.settingRow, { borderTopWidth: 1, borderTopColor: colors.hair }]}>
+            <View style={styles.settingInfo}>
+              <Text style={[styles.settingLabel, { color: colors.ink }]}>{t('settings.locklessStationPassedLabel')}</Text>
+              <Text style={[styles.settingDesc, { color: colors.muted }]}>
+                {t('settings.locklessStationPassedDescription')}
+              </Text>
+            </View>
+            <Switch
+              value={locklessStationPassed}
+              onValueChange={setLocklessStationPassed}
+              trackColor={{ false: colors.hair, true: colors.accent }}
+              thumbColor={locklessStationPassed ? colors.onAccent : colors.subtle}
+              testID="lockless-station-passed-switch"
             />
           </View>
         </View>

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -147,6 +147,20 @@ describe('validateTrip', () => {
     // 필드 자체가 부재인 경우(구버전 trip): undefined로 보존, scheduled.ts가 ?? 0으로 fallback.
     expect(validateTrip(base())?.consecutiveEtaMissing).toBeUndefined();
   });
+
+  // #816 C — lockless station-passed opt-in 필드
+  it('preserves boolean locklessStationPassed (#816)', () => {
+    expect(validateTrip({ ...base(), locklessStationPassed: true })?.locklessStationPassed).toBe(true);
+    expect(validateTrip({ ...base(), locklessStationPassed: false })?.locklessStationPassed).toBe(false);
+  });
+
+  it('drops non-boolean locklessStationPassed and absent field stays undefined', () => {
+    expect(
+      validateTrip({ ...base(), locklessStationPassed: 'yes' })?.locklessStationPassed,
+    ).toBeUndefined();
+    expect(validateTrip({ ...base(), locklessStationPassed: 1 })?.locklessStationPassed).toBeUndefined();
+    expect(validateTrip(base())?.locklessStationPassed).toBeUndefined();
+  });
 });
 
 describe('validateTrip — boardingLock (#585)', () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -262,40 +262,32 @@ describe('runScheduled', () => {
       });
     }
 
-    it('lock 없음 + 토글 ON + intermediate + arvlCd=1 → push 발사 + locklessIntermediateFired 카운트 + waypoint shift', async () => {
+    /**
+     * Lockless scenario 셋업 통일 헬퍼. trip을 InMemoryKV에 넣고 seoul/apns mock 주입 후
+     * runScheduled를 한 cycle 돌려 stats + apnsFetch + kv를 반환한다. 어설션은 호출부에서.
+     *
+     * `arrivals`:
+     *   - undefined: Seoul fetch mock(`seoulFetch`)을 vi.fn()으로 두고 호출 여부만 추적
+     *     (lockMissing 게이트 등으로 Seoul 호출 자체가 일어나면 안 되는 시나리오용)
+     *   - 배열 (빈 배열 포함): makeSeoul로 실제 응답 — 빈 배열은 etaMissing 트리거
+     */
+    async function runLocklessCycle(input: {
+      trip: Trip;
+      arrivals?: ArrivalEntry[];
+      apnsOk?: boolean;
+    }) {
       const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, intermediateTrip());
-      const seoul = makeSeoul([
-        { destination: '강남행', arrivalSeconds: 30, trainCode: '7246', isUp: true, subwayNm: '지하철2호선', arvlCd: 1 },
-      ]);
-      const apnsFetch = makeApnsFetchOk();
-      const stats = await runScheduled(makeEnv(kv), {
-        seoul,
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-      });
-      expect(stats.pushed).toBe(1);
-      expect(stats.locklessIntermediateFired).toBe(1);
-      expect(stats.lockMissing).toBe(0);
-      expect(apnsFetch).toHaveBeenCalled();
-    });
-
-    it('lock 없음 + 토글 OFF + intermediate → lockMissing 카운트 (발사 0)', async () => {
-      const kv = new InMemoryKV();
-      await putTrip(
-        kv as unknown as KVNamespace,
-        intermediateTrip({ locklessStationPassed: false }),
-      );
+      await putTrip(kv as unknown as KVNamespace, input.trip);
       const seoulFetch = vi.fn();
-      const seoul = new SeoulArrivalClient({
-        apiKey: 'K',
-        host: 'h',
-        now: () => NOW,
-        fetchImpl: seoulFetch as unknown as typeof fetch,
-      });
-      const apnsFetch = vi.fn();
+      const seoul = input.arrivals
+        ? makeSeoul(input.arrivals)
+        : new SeoulArrivalClient({
+            apiKey: 'K',
+            host: 'h',
+            now: () => NOW,
+            fetchImpl: seoulFetch as unknown as typeof fetch,
+          });
+      const apnsFetch = input.apnsOk ? makeApnsFetchOk() : vi.fn();
       const stats = await runScheduled(makeEnv(kv), {
         seoul,
         apnsConfig,
@@ -303,82 +295,96 @@ describe('runScheduled', () => {
         fetchImpl: apnsFetch as unknown as typeof fetch,
         now: () => NOW,
       });
-      expect(stats.pushed).toBe(0);
-      expect(stats.locklessIntermediateFired).toBe(0);
-      expect(stats.lockMissing).toBe(1);
-      expect(seoulFetch).not.toHaveBeenCalled();
+      return { kv, stats, apnsFetch, seoulFetch };
+    }
+
+    const ARVL_ARRIVED: ArrivalEntry = {
+      destination: '강남행',
+      arrivalSeconds: 30,
+      trainCode: '7246',
+      isUp: true,
+      subwayNm: '지하철2호선',
+      arvlCd: 1,
+    };
+    const ARVL_NO_SIGNAL: ArrivalEntry = { ...ARVL_ARRIVED, arrivalSeconds: 60, arvlCd: null };
+
+    type LocklessCase = {
+      name: string;
+      trip: () => Trip;
+      arrivals?: ArrivalEntry[]; // undefined → Seoul fetch 미호출 보장 케이스
+      apnsOk: boolean;
+      expect: { pushed: number; locklessFired: number; lockMissing?: number; etaMissing?: number };
+      apnsCalled: boolean;
+      seoulCalled?: boolean; // arrivals undefined 케이스에서 seoulFetch 호출 여부 검증.
+    };
+
+    const cases: LocklessCase[] = [
+      {
+        name: '토글 ON + intermediate + arvlCd=1 → 발사 + locklessIntermediateFired 카운트',
+        trip: () => intermediateTrip(),
+        arrivals: [ARVL_ARRIVED],
+        apnsOk: true,
+        expect: { pushed: 1, locklessFired: 1, lockMissing: 0 },
+        apnsCalled: true,
+      },
+      {
+        name: '토글 OFF + intermediate → lockMissing 카운트 (발사 0, Seoul fetch 미호출)',
+        trip: () => intermediateTrip({ locklessStationPassed: false }),
+        apnsOk: false,
+        expect: { pushed: 0, locklessFired: 0, lockMissing: 1 },
+        apnsCalled: false,
+        seoulCalled: false,
+      },
+      {
+        name: '토글 ON + destination kind → lockMissing 카운트 (lockless는 intermediate만)',
+        trip: () =>
+          makeTrip({
+            waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+            locklessStationPassed: true,
+          }),
+        apnsOk: false,
+        expect: { pushed: 0, locklessFired: 0, lockMissing: 1 },
+        apnsCalled: false,
+      },
+      {
+        name: '토글 ON + intermediate + arvlCd 신호 없음 → 발사 0 (ARRIVED/ENTERING만 trigger)',
+        trip: () => intermediateTrip(),
+        arrivals: [ARVL_NO_SIGNAL],
+        apnsOk: false,
+        expect: { pushed: 0, locklessFired: 0 },
+        apnsCalled: false,
+      },
+      {
+        name: '토글 ON + intermediate + arrivals 비어있음 → etaMissing 증가, 발사 0',
+        trip: () => intermediateTrip(),
+        arrivals: [],
+        apnsOk: false,
+        expect: { pushed: 0, locklessFired: 0, etaMissing: 1 },
+        apnsCalled: false,
+      },
+    ];
+
+    it.each(cases)('lock 없음 + $name', async ({ trip, arrivals, apnsOk, expect: ex, apnsCalled, seoulCalled }) => {
+      const { stats, apnsFetch, seoulFetch } = await runLocklessCycle({
+        trip: trip(),
+        arrivals,
+        apnsOk,
+      });
+      expect(stats.pushed).toBe(ex.pushed);
+      expect(stats.locklessIntermediateFired).toBe(ex.locklessFired);
+      if (ex.lockMissing !== undefined) expect(stats.lockMissing).toBe(ex.lockMissing);
+      if (ex.etaMissing !== undefined) expect(stats.etaMissing).toBe(ex.etaMissing);
+      if (apnsCalled) {
+        expect(apnsFetch).toHaveBeenCalled();
+      } else {
+        expect(apnsFetch).not.toHaveBeenCalled();
+      }
+      if (seoulCalled === false) expect(seoulFetch).not.toHaveBeenCalled();
     });
 
-    it('lock 없음 + 토글 ON + destination kind → lockMissing 카운트 (lockless는 intermediate만 발사)', async () => {
-      const kv = new InMemoryKV();
-      await putTrip(
-        kv as unknown as KVNamespace,
-        makeTrip({
-          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
-          locklessStationPassed: true,
-        }),
-      );
-      const seoulFetch = vi.fn();
-      const seoul = new SeoulArrivalClient({
-        apiKey: 'K',
-        host: 'h',
-        now: () => NOW,
-        fetchImpl: seoulFetch as unknown as typeof fetch,
-      });
-      const apnsFetch = vi.fn();
-      const stats = await runScheduled(makeEnv(kv), {
-        seoul,
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-      });
-      expect(stats.pushed).toBe(0);
-      expect(stats.locklessIntermediateFired).toBe(0);
-      expect(stats.lockMissing).toBe(1);
-    });
-
-    it('lock 없음 + 토글 ON + intermediate + arvlCd 신호 없음(min ETA fallback) → 발사 0 (ARRIVED/ENTERING만 trigger)', async () => {
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, intermediateTrip());
-      const seoul = makeSeoul([
-        { destination: '강남행', arrivalSeconds: 60, trainCode: '7246', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
-      ]);
-      const apnsFetch = vi.fn();
-      const stats = await runScheduled(makeEnv(kv), {
-        seoul,
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-      });
-      expect(stats.pushed).toBe(0);
-      expect(stats.locklessIntermediateFired).toBe(0);
-      expect(apnsFetch).not.toHaveBeenCalled();
-    });
-
-    it('lock 없음 + 토글 ON + intermediate + arrivals 비어있음 → etaMissing 증가, 발사 0', async () => {
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, intermediateTrip());
-      const seoul = makeSeoul([]);
-      const apnsFetch = vi.fn();
-      const stats = await runScheduled(makeEnv(kv), {
-        seoul,
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-      });
-      expect(stats.pushed).toBe(0);
-      expect(stats.etaMissing).toBe(1);
-      expect(apnsFetch).not.toHaveBeenCalled();
-    });
-
-    it('lock 없음 + 토글 ON + intermediate(ARRIVED) → 발사 후 다음 intermediate가 남으면 waypoint advance', async () => {
-      const kv = new InMemoryKV();
-      await putTrip(
-        kv as unknown as KVNamespace,
-        makeTrip({
+    it('lock 없음 + intermediate(ARRIVED) → 발사 후 다음 intermediate 남으면 waypoint advance', async () => {
+      const { kv } = await runLocklessCycle({
+        trip: makeTrip({
           waypoints: [
             { stationName: '강남', line: '2', kind: 'intermediate' },
             { stationName: '역삼', line: '2', kind: 'intermediate' },
@@ -386,17 +392,8 @@ describe('runScheduled', () => {
           ],
           locklessStationPassed: true,
         }),
-      );
-      const seoul = makeSeoul([
-        { destination: '선릉행', arrivalSeconds: 0, trainCode: 'X', isUp: true, subwayNm: '지하철2호선', arvlCd: 1 },
-      ]);
-      const apnsFetch = makeApnsFetchOk();
-      await runScheduled(makeEnv(kv), {
-        seoul,
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
+        arrivals: [{ ...ARVL_ARRIVED, destination: '선릉행', arrivalSeconds: 0, trainCode: 'X' }],
+        apnsOk: true,
       });
       // 한 cycle 후 첫 waypoint(강남)는 shift되어야 한다.
       const stored = await (kv as unknown as KVNamespace).get('trip:tok');

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -244,6 +244,168 @@ describe('runScheduled', () => {
       expect(seoulFetch).not.toHaveBeenCalled();
     });
   });
+
+  // #816 C — lockless station-passed opt-in 분기. lock 없어도 토글 ON + intermediate면 발사 허용.
+  describe('#816 C — lockless intermediate', () => {
+    function makeApnsFetchOk(): ReturnType<typeof vi.fn> {
+      return vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+    }
+
+    function intermediateTrip(overrides: Partial<Trip> = {}): Trip {
+      return makeTrip({
+        waypoints: [
+          { stationName: '강남', line: '2', kind: 'intermediate' },
+          { stationName: '역삼', line: '2', kind: 'destination' },
+        ],
+        locklessStationPassed: true,
+        ...overrides,
+      });
+    }
+
+    it('lock 없음 + 토글 ON + intermediate + arvlCd=1 → push 발사 + locklessIntermediateFired 카운트 + waypoint shift', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, intermediateTrip());
+      const seoul = makeSeoul([
+        { destination: '강남행', arrivalSeconds: 30, trainCode: '7246', isUp: true, subwayNm: '지하철2호선', arvlCd: 1 },
+      ]);
+      const apnsFetch = makeApnsFetchOk();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.pushed).toBe(1);
+      expect(stats.locklessIntermediateFired).toBe(1);
+      expect(stats.lockMissing).toBe(0);
+      expect(apnsFetch).toHaveBeenCalled();
+    });
+
+    it('lock 없음 + 토글 OFF + intermediate → lockMissing 카운트 (발사 0)', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        intermediateTrip({ locklessStationPassed: false }),
+      );
+      const seoulFetch = vi.fn();
+      const seoul = new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: seoulFetch as unknown as typeof fetch,
+      });
+      const apnsFetch = vi.fn();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.pushed).toBe(0);
+      expect(stats.locklessIntermediateFired).toBe(0);
+      expect(stats.lockMissing).toBe(1);
+      expect(seoulFetch).not.toHaveBeenCalled();
+    });
+
+    it('lock 없음 + 토글 ON + destination kind → lockMissing 카운트 (lockless는 intermediate만 발사)', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeTrip({
+          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+          locklessStationPassed: true,
+        }),
+      );
+      const seoulFetch = vi.fn();
+      const seoul = new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: seoulFetch as unknown as typeof fetch,
+      });
+      const apnsFetch = vi.fn();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.pushed).toBe(0);
+      expect(stats.locklessIntermediateFired).toBe(0);
+      expect(stats.lockMissing).toBe(1);
+    });
+
+    it('lock 없음 + 토글 ON + intermediate + arvlCd 신호 없음(min ETA fallback) → 발사 0 (ARRIVED/ENTERING만 trigger)', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, intermediateTrip());
+      const seoul = makeSeoul([
+        { destination: '강남행', arrivalSeconds: 60, trainCode: '7246', isUp: true, subwayNm: '지하철2호선', arvlCd: null },
+      ]);
+      const apnsFetch = vi.fn();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.pushed).toBe(0);
+      expect(stats.locklessIntermediateFired).toBe(0);
+      expect(apnsFetch).not.toHaveBeenCalled();
+    });
+
+    it('lock 없음 + 토글 ON + intermediate + arrivals 비어있음 → etaMissing 증가, 발사 0', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, intermediateTrip());
+      const seoul = makeSeoul([]);
+      const apnsFetch = vi.fn();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.pushed).toBe(0);
+      expect(stats.etaMissing).toBe(1);
+      expect(apnsFetch).not.toHaveBeenCalled();
+    });
+
+    it('lock 없음 + 토글 ON + intermediate(ARRIVED) → 발사 후 다음 intermediate가 남으면 waypoint advance', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeTrip({
+          waypoints: [
+            { stationName: '강남', line: '2', kind: 'intermediate' },
+            { stationName: '역삼', line: '2', kind: 'intermediate' },
+            { stationName: '선릉', line: '2', kind: 'destination' },
+          ],
+          locklessStationPassed: true,
+        }),
+      );
+      const seoul = makeSeoul([
+        { destination: '선릉행', arrivalSeconds: 0, trainCode: 'X', isUp: true, subwayNm: '지하철2호선', arvlCd: 1 },
+      ]);
+      const apnsFetch = makeApnsFetchOk();
+      await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      // 한 cycle 후 첫 waypoint(강남)는 shift되어야 한다.
+      const stored = await (kv as unknown as KVNamespace).get('trip:tok');
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored as string);
+      expect(parsed.waypoints[0].stationName).toBe('역삼');
+      expect(parsed.lastFiredPhase).toBeUndefined();
+    });
+  });
 });
 
 describe('runScheduled — boardingLock trainCode tracking (#585)', () => {

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -402,6 +402,9 @@ export function validateTrip(input: unknown): Trip | null {
     // POST /trips merge 단계에서 existing 값을 보존한다 (consecutiveEtaMissing 누적이 유지되어야 자동 종료가 정상 동작).
     consecutiveEtaMissing:
       typeof obj.consecutiveEtaMissing === 'number' ? obj.consecutiveEtaMissing : undefined,
+    // #816 C: 사용자 명시 opt-in 토글값. 미송신 또는 boolean 아니면 undefined (default OFF).
+    locklessStationPassed:
+      typeof obj.locklessStationPassed === 'boolean' ? obj.locklessStationPassed : undefined,
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3,7 +3,12 @@
  */
 
 import { ARRIVAL_CODE, TRAIN_STATUS } from './alarm';
-import { sendReschedulePush, type ApnsConfig, type SendPushResult } from './apns';
+import {
+  sendReschedulePush,
+  sendSilentPush,
+  type ApnsConfig,
+  type SendPushResult,
+} from './apns';
 import { flipApnsEnv, pickApnsHost } from './apnsHost';
 import {
   buildLiveActivityContentState,
@@ -121,6 +126,12 @@ export interface ScheduledStats extends LiveActivityStats {
    * 사용자가 열차 미선택 상태에서 noise push가 발사되지 않도록 차단된 결과.
    */
   lockMissing: number;
+  /**
+   * #816 C — lockless opt-in 토글 ON trip에서 station-passed(intermediate) push가 발사된 횟수.
+   * false-positive 측정 인프라 — 사용자 dismiss/탭률은 client alarmLog로 별도 적재된다.
+   * (lockMissing은 토글 OFF로 게이트 차단된 trip만 카운트되도록 유지 — 두 stat은 disjoint.)
+   */
+  locklessIntermediateFired: number;
 }
 
 /**
@@ -159,6 +170,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     etaMissing: 0,
     envCorrected: 0,
     lockMissing: 0,
+    locklessIntermediateFired: 0,
     laPushSent: 0,
     laPushFailed: 0,
     laTokenCleared: 0,
@@ -194,10 +206,25 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     // Seoul polling/push 모두 skip. 디바이스는 lock 등록 후 train-code 단위로 정확히 추적하며,
     // lock 부재 상태에서의 phase-based push는 "탑승 전 노이즈"였다.
     if (!isBoardingLockActive(trip, now)) {
+      // #816 C — lockless opt-in trip은 게이트 우회. lock 없이도 intermediate waypoint 통과
+      // 시 station-passed push 발사. 사용자가 명시 동의(client 토글)한 trip에 한정한다.
+      // intermediate kind가 아니면(transfer/destination) 여전히 skip — trainCode 없이 발사하면
+      // 잘못된 leg/방향으로 갈 위험.
+      if (trip.locklessStationPassed && waypoint.kind === 'intermediate') {
+        try {
+          await runLocklessIntermediate(trip, waypoint, env, deps, stats, now, log, generatePushId);
+        } catch (e) {
+          stats.errors += 1;
+          log('lockless: poll error', { error: String(e), token: trip.token.slice(0, 8) });
+        }
+        continue;
+      }
       stats.lockMissing += 1;
       log('boarding-lock: skip cycle (lock missing or expired)', {
         token: trip.token.slice(0, 8),
         station: waypoint.stationName,
+        locklessOptIn: trip.locklessStationPassed === true,
+        waypointKind: waypoint.kind,
       });
       continue;
     }
@@ -556,6 +583,111 @@ export async function maybeReschedulePush(
     await putTrip(env.TRIPS, trip);
   }
   return { cleanedUp: false };
+}
+
+/**
+ * #816 C — lockless trip (사용자 opt-in)에서 intermediate waypoint 통과를 추적하고 station-passed
+ * push를 발사한다. BoardingLock 없으니 trainCode 추적은 불가 — Seoul arrivals 중 best signal로
+ * "그 역에 어느 열차가 진입/도착했다"만 판정한다.
+ *
+ * 발사 조건:
+ *   1. arrivals 중 best signal의 arvlCd가 ARRIVED(1) 또는 ENTERING(0)
+ *   2. dedup: 같은 waypoint에서 이미 한 번 발사한 경우 (lastFiredPhase='imminent') skip
+ *
+ * 발사 성공 시: waypoint shift + lastFiredPhase reset + trip 저장. waypoint 0이면 trip cleanup.
+ * 사양상 transfer/destination kind는 호출 전에 분기로 차단됨 — 이 함수는 intermediate에 한정.
+ */
+export async function runLocklessIntermediate(
+  trip: Trip,
+  waypoint: Waypoint,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+  generatePushId: () => string,
+): Promise<void> {
+  // 같은 waypoint에서 이미 발사했으면 dedup (lockless 흐름은 phase 개념이 없으니 imminent 단일 stamp 사용).
+  if (trip.lastFiredPhase === 'imminent') {
+    return;
+  }
+  const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
+  const signal = pickBestArrivalSignal(arrivals, waypoint);
+  if (signal === null || signal.arvlCd === null) {
+    stats.etaMissing += 1;
+    return;
+  }
+  // 발사 트리거: 해당 역에 진입(ENTERING) 또는 도착(ARRIVED). 그 외 phase는 통과 알림 부적합.
+  const fires =
+    signal.arvlCd === ARRIVAL_CODE.ENTERING || signal.arvlCd === ARRIVAL_CODE.ARRIVED;
+  if (!fires) {
+    return;
+  }
+  const pushId = generatePushId();
+  log('lockless: station-passed push', {
+    token: trip.token.slice(0, 8),
+    station: waypoint.stationName,
+    arvlCd: signal.arvlCd,
+    etaSeconds: signal.etaSeconds,
+  });
+  const heal = await sendWithEnvHeal(
+    (host) =>
+      sendSilentPush({
+        deviceToken: trip.token,
+        payload: {
+          nextWaypoint: waypoint.stationName,
+          etaSeconds: signal.etaSeconds,
+          phase: 'imminent',
+          kind: 'intermediate',
+          sentAt: now,
+          pushId,
+        },
+        config: deps.apnsConfig,
+        host,
+        fetchImpl: deps.fetchImpl,
+        now,
+      }),
+    trip.apnsEnv,
+    deps.apnsHosts,
+    log,
+    trip.token.slice(0, 8),
+  );
+  let dirty = false;
+  if (heal.correctedEnv) {
+    trip.apnsEnv = heal.correctedEnv;
+    dirty = true;
+    stats.envCorrected += 1;
+  }
+  if (!heal.result.ok) {
+    stats.errors += 1;
+    log('lockless: push failed', {
+      status: heal.result.status,
+      reason: heal.result.reason,
+      token: trip.token.slice(0, 8),
+    });
+    if (
+      isUnrecoverableApnsError(heal.result.status, heal.result.reason) ||
+      heal.envMismatchExhausted
+    ) {
+      await cleanupTripWithLa(trip, env, deps, stats, now, log);
+      return;
+    }
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
+  }
+  // 발사 성공 — waypoint 진행 + dedup stamp + 측정 카운터.
+  stats.pushed += 1;
+  stats.locklessIntermediateFired += 1;
+  trip.lastFiredPhase = 'imminent';
+  trip.waypoints.shift();
+  if (trip.waypoints.length === 0) {
+    // 마지막 intermediate까지 통과 — trip 종료. lockless는 destination을 직접 다루지 않는다.
+    await cleanupTripWithLa(trip, env, deps, stats, now, log);
+    return;
+  }
+  // 다음 waypoint를 위해 dedup stamp reset (위 shift 직후 첫 waypoint는 새 발사 대상).
+  trip.lastFiredPhase = undefined;
+  await putTrip(env.TRIPS, trip);
 }
 
 /**

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -108,6 +108,18 @@ export interface Trip {
    * 기존 trip(필드 부재)은 0으로 fallback (backward compat).
    */
   consecutiveEtaMissing?: number;
+  /**
+   * #816 C — 사용자 opt-in lockless station-passed.
+   * BoardingLock 없는 trip에서도 station-passed(intermediate) 알림을 발사할지 여부.
+   *
+   * 기본 (필드 부재 또는 false): #640 게이트 그대로 — lock 없으면 cycle skip.
+   * true: lock 없어도 intermediate waypoint 도착만 push 발사 허용.
+   *   - transfer/destination waypoint는 여전히 skip (trainCode 없이 정확도 보장 불가)
+   *   - 사용자가 명시 설정 토글로 ON했을 때만 trip 등록 시 송신
+   *
+   * 노이즈 차단 책임: 사용자에게 옵트인 권한 위임. #640 회귀는 OFF가 default로 보호.
+   */
+  locklessStationPassed?: boolean;
 }
 
 /** Device가 확정한 탑승 열차 정보 (#584). */

--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -203,6 +203,33 @@ describe('alarmBackend', () => {
         expect(body.boardingLock).toBeUndefined();
       });
 
+      // #816 C — lockless station-passed 토글
+      it('locklessStationPassed=true 송신 + 토글 변경 시 재등록', async () => {
+        const first = await registerActiveTrip({
+          ...SAMPLE_PAYLOAD,
+          locklessStationPassed: true,
+        });
+        expect(first.ok).toBe(true);
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.locklessStationPassed).toBe(true);
+
+        // 토글 OFF로 재호출 → hash 달라져서 재등록 (dedup 미적용)
+        const off = await registerActiveTrip({
+          ...SAMPLE_PAYLOAD,
+          locklessStationPassed: false,
+        });
+        expect(off).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        const offBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+        expect(offBody.locklessStationPassed).toBeUndefined();
+      });
+
+      it('locklessStationPassed=false/미설정이면 body에 미포함', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, locklessStationPassed: false });
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.locklessStationPassed).toBeUndefined();
+      });
+
       it('#701 in-flight dedup: 동일 페이로드 동시 호출 시 fetch는 1번만 발사된다', async () => {
         let resolveFetch: ((v: Response) => void) | null = null;
         (global.fetch as jest.Mock).mockImplementationOnce(

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -61,6 +61,15 @@ export interface RegisterTripPayload {
    * 기준으로 추적·reschedule 가능. 없으면 backend는 기존 anchor waypoint 폴링으로 fallback.
    */
   boardingLock?: AlarmBoardingLock;
+  /**
+   * #816 C — 사용자 명시 opt-in (lockless station-passed).
+   * true면 BoardingLock 없는 trip에서도 backend가 intermediate waypoint 통과 시
+   * station-passed(silent push)를 발사한다. 미송신/false면 기존 #640 게이트 그대로 (lock 부재 → skip).
+   *
+   * 토글 OFF 상태에선 false를 명시 송신할 필요 없음 — alarmBackend는 미송신 시 backend에서
+   * default OFF로 해석. dedup hash에는 반드시 포함해 토글 변경이 즉시 재등록되도록 한다.
+   */
+  locklessStationPassed?: boolean;
 }
 
 export interface AlarmBackendResult {
@@ -113,6 +122,7 @@ function buildRegisterHash(body: {
   alarmAtEpochMs: number;
   apnsEnv: ApnsEnv;
   boardingLock?: AlarmBoardingLock;
+  locklessStationPassed?: boolean;
 }): string {
   return JSON.stringify({
     token: body.token,
@@ -126,6 +136,9 @@ function buildRegisterHash(body: {
     boardingLockKey: body.boardingLock
       ? `${body.boardingLock.trainCode}|${body.boardingLock.line}|${body.boardingLock.subwayId}|${body.boardingLock.segmentStations.join(',')}`
       : null,
+    // #816 C — 토글 변경 즉시 backend로 전달되도록 dedup key에 포함.
+    // undefined와 false를 다르게 다루지 않는다 — 둘 다 OFF 동일 효과.
+    locklessStationPassed: body.locklessStationPassed === true,
   });
 }
 
@@ -169,6 +182,8 @@ async function performRegisterFetch(
     apnsEnv: payload.apnsEnv,
     // boardingLock은 있을 때만 송신 (없으면 backend는 기존 anchor 폴링).
     ...(payload.boardingLock ? { boardingLock: payload.boardingLock } : {}),
+    // #816 C — 토글 ON일 때만 송신. OFF/미설정은 필드 자체를 누락해 기존 trip schema 호환.
+    ...(payload.locklessStationPassed === true ? { locklessStationPassed: true } : {}),
   };
 
   try {
@@ -214,6 +229,7 @@ export function registerActiveTrip(
     alarmAtEpochMs: payload.alarmAtEpochMs,
     apnsEnv: payload.apnsEnv,
     boardingLock: payload.boardingLock,
+    locklessStationPassed: payload.locklessStationPassed,
   });
   if (hash === lastRegisteredHash) {
     return Promise.resolve({ ok: true, skipped: true });

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -52,3 +52,11 @@ export const BG_PERMISSION_DENIED_DISMISSED_KEY = 'subway-now:bg-permission-deni
 // 형식: {"station": Station, "distanceKm": number, "timestamp": number} JSON.
 // WhileInUse 권한 사용자에게는 BG task 자체가 동작하지 않으므로 graceful no-op (key 없음).
 export const BG_LAST_STATION_KEY = 'subway-now:bg-last-station';
+// #816 C — 사용자 opt-in 토글: lock 없는 trip route에서도 station-passed 알림 허용 여부.
+// 기본 OFF. #640 회귀(lock 없는 noise alarm) 차단을 위해 명시적 opt-in 필요.
+// 형식: 'true' 또는 키 부재. (sleep 모드 같은 패턴 — 단순 boolean)
+export const LOCKLESS_STATION_PASSED_KEY = 'subway-now:lockless-station-passed';
+// #816 B — boardingPrompt 발사 추적 (trip당 1회 발사 + dismiss 시 5분 silence).
+// 형식: {"tripKey": string, "promptedAt": number, "dismissedAt"?: number} JSON.
+// tripKey는 `${destinationId}|${createdAtBucketMs}` — destination 변경 시 자동 reset.
+export const BOARDING_PROMPT_STATE_KEY = 'subway-now:boarding-prompt-state';

--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -869,4 +869,80 @@ describe('useApnsTripRegistration', () => {
       expect(refreshed?.[0].boardingLock.trainCode).toBe('7246');
     });
   });
+
+  // #816 C — lockless station-passed opt-in
+  describe('lockless station-passed (#816)', () => {
+    it('locklessStationPassed=true 입력 시 register payload에 포함', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          locklessStationPassed: true,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].locklessStationPassed).toBe(true);
+    });
+
+    it('locklessStationPassed 미지정/false면 register payload에 미포함', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].locklessStationPassed).toBeUndefined();
+    });
+
+    it('토글 OFF→ON 전환 시 즉시 재등록 (deps 반영)', async () => {
+      const { rerender } = renderHook(
+        ({ lsp }: { lsp: boolean }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            locklessStationPassed: lsp,
+          }),
+        { initialProps: { lsp: false } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].locklessStationPassed).toBeUndefined();
+
+      rerender({ lsp: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].locklessStationPassed).toBe(true);
+    });
+
+    it('token refresh 경로도 최신 토글값을 송신 (latestInputsRef)', async () => {
+      const { rerender } = renderHook(
+        ({ lsp }: { lsp: boolean }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            locklessStationPassed: lsp,
+          }),
+        { initialProps: { lsp: false } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      // 토글 ON으로 변경
+      rerender({ lsp: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+
+      const listener = mockAddPushTokenListener.mock.calls[0][0];
+      await act(async () => {
+        listener({ data: 'token-NEW' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const refreshed = mockRegister.mock.calls.find(
+        (c) => (c[0] as { token: string }).token === 'token-NEW',
+      );
+      expect(refreshed?.[0].locklessStationPassed).toBe(true);
+    });
+  });
 });

--- a/src/hooks/useApnsTripRegistration.ts
+++ b/src/hooks/useApnsTripRegistration.ts
@@ -38,6 +38,12 @@ export interface UseApnsTripRegistrationInputs {
    * anchor waypoint 폴링으로 fallback.
    */
   boardingLock?: BoardingLock | null;
+  /**
+   * #816 C — 사용자 명시 opt-in. BoardingLock 없는 trip에서 station-passed 알림 발사 허용 여부.
+   * true면 backend가 lock 부재 trip에서도 intermediate waypoint 통과 시 silent push 발사한다.
+   * 미설정/false면 기존 #640 게이트 그대로 (lock 없으면 push 0건).
+   */
+  locklessStationPassed?: boolean;
 }
 
 /**
@@ -59,6 +65,7 @@ interface RegisterCallInputs {
   nextStationEtaSeconds: number | null;
   currentStation: Station | null;
   boardingLock: BoardingLock | null;
+  locklessStationPassed: boolean;
   /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
   createdAt: number;
 }
@@ -97,6 +104,8 @@ async function callRegister(input: RegisterCallInputs) {
     apnsEnv: resolveApnsEnv(),
     createdAt: input.createdAt,
     ...(boardingLockMeta ? { boardingLock: boardingLockMeta } : {}),
+    // #816 C — 토글 ON이면 backend에 lockless station-passed opt-in 명시. OFF면 필드 누락.
+    ...(input.locklessStationPassed ? { locklessStationPassed: true } : {}),
   });
 }
 
@@ -106,6 +115,7 @@ export function useApnsTripRegistration({
   nextStationEtaSeconds,
   currentStation = null,
   boardingLock = null,
+  locklessStationPassed = false,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
   // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
@@ -114,9 +124,9 @@ export function useApnsTripRegistration({
   // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
   const boardingLockSig = lockSig(boardingLock);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock });
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock };
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed };
   });
 
   // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
@@ -173,6 +183,7 @@ export function useApnsTripRegistration({
           nextStationEtaSeconds: eta,
           currentStation: cs,
           boardingLock: bl,
+          locklessStationPassed: lsp,
         } = latestInputsRef.current;
         if (!r || !d) return;
         const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
@@ -183,6 +194,7 @@ export function useApnsTripRegistration({
           nextStationEtaSeconds: eta,
           currentStation: cs,
           boardingLock: bl,
+          locklessStationPassed: lsp,
           createdAt: resolveTripCreatedAt(sessionKey),
         });
         // #767 — main effect와 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도
@@ -235,6 +247,7 @@ export function useApnsTripRegistration({
         nextStationEtaSeconds,
         currentStation,
         boardingLock,
+        locklessStationPassed,
         createdAt: resolveTripCreatedAt(sessionKey),
       });
       // POST 발사 직후(성공/실패 무관) 송신된 lock sig를 기록 — 다음 cycle이 "직전 송신 = lock,
@@ -278,6 +291,8 @@ export function useApnsTripRegistration({
     // deps에서 제외한다. 첫 register 후 backend cron(#704/#705)이 자체 progress KV로
     // station-by-station advance를 영속화하므로 client 재등록이 불필요하다. latestInputsRef로
     // token-refresh 경로는 여전히 최신값을 사용한다.
+    // #816 C: 토글 변경 시 즉시 backend에 반영해야 하므로 deps에 포함. 사용자가 ON/OFF 전환하면
+    // 한 cycle만에 register payload가 갱신된다.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeSig, destination?.id, boardingLockSig]);
+  }, [routeSig, destination?.id, boardingLockSig, locklessStationPassed]);
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -73,6 +73,8 @@
     "speakerOffTitle": "Turn off speaker output",
     "speakerOffMessage": "Disabling speaker output will play only vibration when earphones are not connected. Continue?",
     "speakerOffConfirm": "Turn off",
+    "locklessStationPassedLabel": "Station-passed alerts without train selection",
+    "locklessStationPassedDescription": "Receive station-passed notifications even when no train is selected. Estimates may be noisy.",
     "languageSection": "Language",
     "languageLabel": "App language",
     "languageDescription": "Auto follows your device setting",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -73,6 +73,8 @@
     "speakerOffTitle": "スピーカー出力をオフ",
     "speakerOffMessage": "スピーカー出力をオフにすると、イヤホン未接続時は振動のみになります。続けますか?",
     "speakerOffConfirm": "オフにする",
+    "locklessStationPassedLabel": "列車未選択時の通過駅通知",
+    "locklessStationPassedDescription": "乗車列車を選択していない経路でも通過駅通知を受け取ります。推定に依存するためノイズが出る可能性があります。",
     "languageSection": "言語",
     "languageLabel": "アプリの言語",
     "languageDescription": "自動はデバイスの設定に従います",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -73,6 +73,8 @@
     "speakerOffTitle": "스피커 출력 끄기",
     "speakerOffMessage": "스피커 출력을 끄면 이어폰이 연결되지 않은 상태에서 진동만 울립니다. 계속하시겠습니까?",
     "speakerOffConfirm": "끄기",
+    "locklessStationPassedLabel": "열차 미선택 시 역 통과 알림",
+    "locklessStationPassedDescription": "탑승 열차를 선택하지 않은 경로에서도 역 통과 알림을 받습니다. 추정에 의존하므로 노이즈가 있을 수 있습니다.",
     "languageSection": "언어",
     "languageLabel": "앱 언어",
     "languageDescription": "자동은 기기 설정을 따릅니다",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -73,6 +73,8 @@
     "speakerOffTitle": "关闭扬声器输出",
     "speakerOffMessage": "关闭扬声器输出后,未连接耳机时只会震动。是否继续?",
     "speakerOffConfirm": "关闭",
+    "locklessStationPassedLabel": "未选择列车时通过站点通知",
+    "locklessStationPassedDescription": "在未选择乘车列车的路线上也接收通过站点的通知。基于推测,可能会有噪音。",
     "languageSection": "语言",
     "languageLabel": "应用语言",
     "languageDescription": "自动会跟随设备设置",

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -27,7 +27,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, tripOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, tripOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false, locklessStationPassed: false });
     jest.clearAllMocks();
   });
 
@@ -624,6 +624,50 @@ describe('useAppStore', () => {
 
     const { sleepMode } = useAppStore.getState();
     expect(sleepMode).toBe(false);
+  });
+
+  // #816 C — lockless station-passed opt-in 토글 (기본 OFF).
+  it('초기 locklessStationPassed는 false이다', () => {
+    const { locklessStationPassed } = useAppStore.getState();
+    expect(locklessStationPassed).toBe(false);
+  });
+
+  it('setLocklessStationPassed: true를 설정하면 상태와 AsyncStorage가 갱신된다', async () => {
+    const { setLocklessStationPassed } = useAppStore.getState();
+    await setLocklessStationPassed(true);
+
+    expect(useAppStore.getState().locklessStationPassed).toBe(true);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:lockless-station-passed',
+      JSON.stringify(true),
+    );
+  });
+
+  it('loadLocklessStationPassed: 저장된 true를 복원한다', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(true));
+
+    const { loadLocklessStationPassed } = useAppStore.getState();
+    await loadLocklessStationPassed();
+
+    expect(useAppStore.getState().locklessStationPassed).toBe(true);
+  });
+
+  it('loadLocklessStationPassed: 저장된 값이 없으면 기본 false 유지', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { loadLocklessStationPassed } = useAppStore.getState();
+    await loadLocklessStationPassed();
+
+    expect(useAppStore.getState().locklessStationPassed).toBe(false);
+  });
+
+  it('loadLocklessStationPassed: AsyncStorage 오류 시 false 유지', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
+
+    const { loadLocklessStationPassed } = useAppStore.getState();
+    await loadLocklessStationPassed();
+
+    expect(useAppStore.getState().locklessStationPassed).toBe(false);
   });
 
   it('초기 customOrigin은 null이다', () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -7,7 +7,7 @@ function demoteSlotEntries(entries: FavoriteEntry[], role: FavoriteSlotRole): Fa
   return entries.map((f) => (f.role === role ? { ...f, role: 'general' as FavoriteRole } : f));
 }
 import type { AlarmEvent } from '../utils/stationAlarm';
-import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, BOARDING_LOCK_KEY, SCHEDULED_NOTIFICATIONS_KEY, ACTIVE_TRIP_KEY, TRIP_ORIGIN_KEY } from '../constants/storageKeys';
+import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, BOARDING_LOCK_KEY, SCHEDULED_NOTIFICATIONS_KEY, ACTIVE_TRIP_KEY, TRIP_ORIGIN_KEY, LOCKLESS_STATION_PASSED_KEY } from '../constants/storageKeys';
 import { clearFiredAlarms, clearLastNotifiedStationId, clearLastFiredAlarmStationName } from '../utils/notificationState';
 import { clearFiredPushIds } from '../utils/firedPushIds';
 import { clearTripTrainCode } from '../utils/tripTrainCode';
@@ -60,6 +60,14 @@ interface AppState {
   loadLocalePreference: () => Promise<void>;
   setSleepMode: (enabled: boolean) => Promise<void>;
   loadSleepMode: () => Promise<void>;
+  /**
+   * #816 C — BoardingLock 없는 trip에서도 station-passed(intermediate) 알림을 받을지 여부.
+   * 기본 OFF. ON 시 useApnsTripRegistration이 backend trip register payload에 포함시키고,
+   * backend가 lockless intermediate 발사를 허용한다.
+   */
+  locklessStationPassed: boolean;
+  setLocklessStationPassed: (enabled: boolean) => Promise<void>;
+  loadLocklessStationPassed: () => Promise<void>;
   setAllowSpeaker: (enabled: boolean) => Promise<void>;
   loadAllowSpeaker: () => Promise<void>;
   accessibilityMode: boolean;
@@ -84,6 +92,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   alarmEvent: null,
   debugVisible: false,
   accessibilityMode: false,
+  locklessStationPassed: false,
 
   setDebugVisible: (visible: boolean) => {
     set({ debugVisible: visible });
@@ -407,6 +416,22 @@ export const useAppStore = create<AppState>((set, get) => ({
       const raw = await AsyncStorage.getItem(SLEEP_MODE_KEY);
       if (raw) {
         set({ sleepMode: JSON.parse(raw) });
+      }
+    } catch {
+      // 저장된 데이터 없음 — false 유지
+    }
+  },
+
+  setLocklessStationPassed: async (enabled: boolean) => {
+    set({ locklessStationPassed: enabled });
+    await AsyncStorage.setItem(LOCKLESS_STATION_PASSED_KEY, JSON.stringify(enabled));
+  },
+
+  loadLocklessStationPassed: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(LOCKLESS_STATION_PASSED_KEY);
+      if (raw) {
+        set({ locklessStationPassed: JSON.parse(raw) === true });
       }
     } catch {
       // 저장된 데이터 없음 — false 유지

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -693,90 +693,95 @@ describe('silentPushTask', () => {
 
     // #816 C — lockless station-passed 분기
     describe('#816 C — lockless 분기 (lock 없음)', () => {
-      function setLockless(enabled: boolean) {
+      type LocklessStorage = 'on' | 'off' | 'absent' | 'throw';
+
+      function mockLocklessStorage(state: LocklessStorage) {
         (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
           if (key === DESTINATION_KEY) return JSON.stringify(destStation);
           if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(enabled);
+          if (key === LOCKLESS_STATION_PASSED_KEY) {
+            if (state === 'on') return JSON.stringify(true);
+            if (state === 'off') return JSON.stringify(false);
+            if (state === 'throw') throw new Error('boom');
+            return null; // absent
+          }
           return null;
         });
       }
 
-      it('lock 없음 + destination kind → skip(lockless-non-intermediate) + ack', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-dest' }),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-non-intermediate', kind: 'destination' }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
+      type SkipCase = {
+        name: string;
+        kind: 'destination' | 'transfer' | 'intermediate';
+        storage: LocklessStorage;
+        pushId?: string;
+        reason: 'lockless-non-intermediate' | 'lockless-opt-out';
+        logKind: 'destination' | 'transfer' | 'station-passed';
+      };
+
+      const skipCases: SkipCase[] = [
+        {
+          name: 'destination kind → lockless-non-intermediate + ack',
+          kind: 'destination',
+          storage: 'on',
           pushId: 'p-dest',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
           reason: 'lockless-non-intermediate',
-        });
-      });
-
-      it('lock 없음 + transfer kind → skip(lockless-non-intermediate)', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        await handleSilentPush(payload({ kind: 'transfer', phase: 'imminent' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-non-intermediate', kind: 'transfer' }),
-        );
-      });
-
-      it('lock 없음 + intermediate + 토글 OFF → skip(lockless-opt-out) + ack', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        setLockless(false);
-        await handleSilentPush(
-          payload({ kind: 'intermediate', phase: 'imminent', pushId: 'p-off' }),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-opt-out', kind: 'station-passed' }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
+          logKind: 'destination',
+        },
+        {
+          name: 'transfer kind → lockless-non-intermediate',
+          kind: 'transfer',
+          storage: 'on',
+          reason: 'lockless-non-intermediate',
+          logKind: 'transfer',
+        },
+        {
+          name: 'intermediate + 토글 OFF → lockless-opt-out + ack',
+          kind: 'intermediate',
+          storage: 'off',
           pushId: 'p-off',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
           reason: 'lockless-opt-out',
-        });
+          logKind: 'station-passed',
+        },
+        {
+          name: 'intermediate + 토글 키 자체 부재 → lockless-opt-out (기본 OFF)',
+          kind: 'intermediate',
+          storage: 'absent',
+          reason: 'lockless-opt-out',
+          logKind: 'station-passed',
+        },
+        {
+          name: 'intermediate + 토글 AsyncStorage read 오류 → lockless-opt-out (안전 fallback)',
+          kind: 'intermediate',
+          storage: 'throw',
+          reason: 'lockless-opt-out',
+          logKind: 'station-passed',
+        },
+      ];
+
+      it.each(skipCases)('lock 없음 + $name', async ({ kind, storage, pushId, reason, logKind }) => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        mockLocklessStorage(storage);
+        await handleSilentPush(payload({ kind, phase: 'imminent', ...(pushId ? { pushId } : {}) }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason, kind: logKind }),
+        );
+        if (pushId) {
+          expect(mockSendPushAck).toHaveBeenCalledWith({
+            pushId,
+            token: DEFAULT_APNS_TOKEN,
+            outcome: 'skipped',
+            reason,
+          });
+        }
       });
 
       it('lock 없음 + intermediate + 토글 ON → 일반 게이트로 진행 후 발사', async () => {
         mockGetBoardingLock.mockResolvedValue(null);
-        setLockless(true);
+        mockLocklessStorage('on');
         await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
         expect(mockScheduleNotificationAsync).toHaveBeenCalled();
         expect(mockLogSilentPushFired).toHaveBeenCalled();
-      });
-
-      it('lock 없음 + 토글 키 자체 부재 → opt-out (기본 OFF)', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        // 기본 mock: LOCKLESS_STATION_PASSED_KEY는 null 반환 (beforeEach 기본).
-        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-opt-out' }),
-        );
-      });
-
-      it('lock 없음 + 토글 AsyncStorage read 오류 → opt-out (안전 fallback)', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) throw new Error('boom');
-          return null;
-        });
-        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-opt-out' }),
-        );
       });
     });
 

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -103,7 +103,11 @@ import {
   registerSilentPushTask,
   SILENT_PUSH_TASK,
 } from '../silentPushTask';
-import { APNS_TOKEN_KEY, DESTINATION_KEY } from '../../constants/storageKeys';
+import {
+  APNS_TOKEN_KEY,
+  DESTINATION_KEY,
+  LOCKLESS_STATION_PASSED_KEY,
+} from '../../constants/storageKeys';
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 
@@ -150,6 +154,18 @@ const PASSING_GATE = {
 };
 
 describe('silentPushTask', () => {
+  // #816 C — 기본 lock을 부여해 기존 fire 테스트가 lockless 가드(lock null + non-intermediate 차단)에
+  // 막히지 않도록 한다. lockless 분기는 별도 describe에서 lock=null로 명시 override해 검증.
+  // line 가드는 lookup 반환값이 두 함수 모두 null이면 graceful pass (#707 — stations.json miss 케이스).
+  const defaultBoardingLock = {
+    destinationId: '0228',
+    trainCode: 'T-default',
+    boardingStationId: 'station-default',
+    boardingLine: '2' as const,
+    boardedAt: 1_700_000_000_000,
+    expectedDurationMs: 600_000,
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockScheduleNotificationAsync.mockResolvedValue('id');
@@ -162,9 +178,9 @@ describe('silentPushTask', () => {
       return null;
     });
     mockSendPushAck.mockResolvedValue({ ok: true });
-    // 기본: lock 없음 → line 가드 미적용 (기존 동작).
-    mockGetBoardingLock.mockResolvedValue(null);
-    // 기본: stationLookup miss는 가드에 영향 없음(lock 없을 때 호출되지 않음).
+    // 기본: lock 활성. lockless 가드를 우회하려면 lock 부여가 필요(stations.json 미존재 가정).
+    mockGetBoardingLock.mockResolvedValue(defaultBoardingLock);
+    // 기본 lookup 모두 null → line 가드는 graceful pass(stations.json 어디에도 없음 가정).
     mockFindStationByNameAndLine.mockReturnValue(null);
     mockFindStationByName.mockReturnValue(null);
   });
@@ -646,9 +662,15 @@ describe('silentPushTask', () => {
         );
       });
 
-      it('lock 없음 → line 가드 skip (lookup 호출 안 됨, 기존 게이트 흐름)', async () => {
+      it('lock 없음 + intermediate + 토글 ON → line 가드 skip + 발사 (#816 C 정상 흐름)', async () => {
         mockGetBoardingLock.mockResolvedValue(null);
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(true);
+          return null;
+        });
+        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
         expect(mockFindStationByNameAndLine).not.toHaveBeenCalled();
         expect(mockScheduleNotificationAsync).toHaveBeenCalled();
       });
@@ -666,6 +688,95 @@ describe('silentPushTask', () => {
           expect.objectContaining({ kind: 'station-passed', reason: 'lock-line-mismatch' }),
         );
         expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      });
+    });
+
+    // #816 C — lockless station-passed 분기
+    describe('#816 C — lockless 분기 (lock 없음)', () => {
+      function setLockless(enabled: boolean) {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(enabled);
+          return null;
+        });
+      }
+
+      it('lock 없음 + destination kind → skip(lockless-non-intermediate) + ack', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-dest' }),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lockless-non-intermediate', kind: 'destination' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-dest',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'lockless-non-intermediate',
+        });
+      });
+
+      it('lock 없음 + transfer kind → skip(lockless-non-intermediate)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'imminent' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lockless-non-intermediate', kind: 'transfer' }),
+        );
+      });
+
+      it('lock 없음 + intermediate + 토글 OFF → skip(lockless-opt-out) + ack', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        setLockless(false);
+        await handleSilentPush(
+          payload({ kind: 'intermediate', phase: 'imminent', pushId: 'p-off' }),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lockless-opt-out', kind: 'station-passed' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-off',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'lockless-opt-out',
+        });
+      });
+
+      it('lock 없음 + intermediate + 토글 ON → 일반 게이트로 진행 후 발사', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        setLockless(true);
+        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('lock 없음 + 토글 키 자체 부재 → opt-out (기본 OFF)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        // 기본 mock: LOCKLESS_STATION_PASSED_KEY는 null 반환 (beforeEach 기본).
+        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lockless-opt-out' }),
+        );
+      });
+
+      it('lock 없음 + 토글 AsyncStorage read 오류 → opt-out (안전 fallback)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === LOCKLESS_STATION_PASSED_KEY) throw new Error('boom');
+          return null;
+        });
+        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lockless-opt-out' }),
+        );
       });
     });
 

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -20,7 +20,11 @@ import * as TaskManager from 'expo-task-manager';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
 import type { Station } from '../types/station';
-import { APNS_TOKEN_KEY, DESTINATION_KEY } from '../constants/storageKeys';
+import {
+  APNS_TOKEN_KEY,
+  DESTINATION_KEY,
+  LOCKLESS_STATION_PASSED_KEY,
+} from '../constants/storageKeys';
 import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../utils/logger';
 import {
@@ -266,6 +270,21 @@ async function loadApnsToken(): Promise<string | null> {
 }
 
 /**
+ * #816 C — 사용자 토글 (lockless station-passed opt-in) 현재값을 AsyncStorage에서 읽는다.
+ * BG task에서는 zustand store에 접근 불가하므로 useAppStore.setLocklessStationPassed가
+ * 기록한 키를 직접 read. 값이 없거나 파싱 실패면 OFF(false) — default 보수적.
+ */
+async function loadLocklessOptIn(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(LOCKLESS_STATION_PASSED_KEY);
+    if (!raw) return false;
+    return JSON.parse(raw) === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Task 콜백 본체 — 단위 테스트가 직접 호출할 수 있도록 export.
  */
 export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
@@ -377,6 +396,38 @@ async function fireWithGate(
       logger.info(
         `lock line mismatch skip: nextWaypoint=${payload.nextWaypoint} boardingLine=${lock.boardingLine}`,
       );
+      return;
+    }
+  } else {
+    // #816 C — lock 없는 trip의 lockless 분기.
+    // backend가 lockless trip의 station-passed(intermediate)만 발사하지만, race로 transfer/destination이
+    // 도착하거나 토글 OFF로 변경된 직후의 push가 도달할 수 있어 client에서 추가 가드.
+    //   1) intermediate가 아니면 skip (trainCode 없이 알람 위치 보장 불가)
+    //   2) 토글 OFF면 skip (사용자 명시 동의 부재 → #640 회귀 차단)
+    // 둘 다 통과하면 line 가드 우회하고 일반 위치/movement 게이트로 진행.
+    if (payload.kind !== 'intermediate') {
+      logSilentPushSkipped({
+        stationName: payload.nextWaypoint,
+        kind: payload.kind,
+        phaseId: payload.phase,
+        reason: 'lockless-non-intermediate',
+      });
+      ackOutcome(payload.pushId, apnsToken, 'skipped', 'lockless-non-intermediate');
+      logger.info(
+        `lockless skip non-intermediate: kind=${payload.kind} station=${payload.nextWaypoint}`,
+      );
+      return;
+    }
+    const optedIn = await loadLocklessOptIn();
+    if (!optedIn) {
+      logSilentPushSkipped({
+        stationName: payload.nextWaypoint,
+        kind: 'station-passed',
+        phaseId: payload.phase,
+        reason: 'lockless-opt-out',
+      });
+      ackOutcome(payload.pushId, apnsToken, 'skipped', 'lockless-opt-out');
+      logger.info(`lockless skip opt-out: station=${payload.nextWaypoint}`);
       return;
     }
   }

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -75,7 +75,12 @@ export type AlarmLogReason =
   | 'movement-motion-stationary'
   // #750 — 공통 sleep 룰 게이트(shouldSuppressBySleepRule)가 차단한 발사.
   // scheduler/FG/BG 3개 path 어디서든 같은 reason으로 적재 — 정책 단일 출처.
-  | 'sleep-first-transfer';
+  | 'sleep-first-transfer'
+  // #816 C — lockless 분기에서 client 추가 가드가 차단한 발사.
+  //   'lockless-non-intermediate': lock 없는 trip에 transfer/destination push 도달 (backend race).
+  //   'lockless-opt-out': 사용자 토글 OFF 상태에서 lockless intermediate push 도달.
+  | 'lockless-non-intermediate'
+  | 'lockless-opt-out';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.


### PR DESCRIPTION
Closes #816 (C 슬라이스 부분 — B는 후속 PR로 분리)

## 변경 (C 슬라이스)
- backend types.ts: Trip.locklessStationPassed? 필드
- backend index.ts: validateTrip 파싱
- backend scheduled.ts: lockless trip 발사 분기 + stats 카운터
- client useAppStore: 토글 state/setter/loader
- client storageKeys: 키
- client alarmBackend: payload + dedup hash + body
- client useApnsTripRegistration: 입력/ref/token-refresh/main effect/deps
- client silentPushTask: lock null + 토글 ON 분기
- client app/(tabs)/index.tsx: 토글 전달
- client app/(tabs)/settings.tsx: Switch UI
- client i18n 4 locale

## #640 회귀 차단
- 기본 OFF + 명시 opt-in (사용자 동의 영역)
- trip route 없으면 zero (zero trip = zero push)

## 검증
- [x] 토글 OFF: 기존 동작 그대로
- [x] 토글 ON + trip route + lock 없음: station-passed 발사
- [x] trip 없음: 발사 0건
- [x] 커버리지 100%

ADR: https://app.notion.com/p/37430c0194b6819c8323e37d4c31a777
B 슬라이스는 후속 PR에서 Phase 1 fusion + boarding-prompt + arvlCd 자동 lock 묶어 진행