### PR TITLE
feat(#817): Phase 2 노선 polyline map matching — 좌표 snap + mapMatchedKmh 계산

### DIFF
--- a/src/utils/__tests__/linePolyline.test.ts
+++ b/src/utils/__tests__/linePolyline.test.ts
@@ -1,0 +1,255 @@
+import {
+  MAX_SNAP_DISTANCE_M,
+  __resetLinePolylineCacheForTests,
+  getLinePolyline,
+  mapMatchedSpeedKmh,
+  snapToLinePolyline,
+} from '../linePolyline';
+import { getStationsOnLine } from '../stationRoute';
+import type { LineNumber } from '../../types/station';
+
+describe('linePolyline', () => {
+  beforeEach(() => {
+    __resetLinePolylineCacheForTests();
+  });
+
+  describe('getLinePolyline', () => {
+    it('호선의 정거장 시퀀스와 누적 길이 테이블을 빌드한다', () => {
+      const polyline = getLinePolyline('2');
+      expect(polyline.line).toBe('2');
+      expect(polyline.stations.length).toBeGreaterThan(2);
+      expect(polyline.segmentLengthsM.length).toBe(polyline.stations.length - 1);
+      expect(polyline.cumulativeArcM.length).toBe(polyline.stations.length);
+      expect(polyline.cumulativeArcM[0]).toBe(0);
+      expect(polyline.cumulativeArcM[polyline.cumulativeArcM.length - 1]).toBeCloseTo(
+        polyline.totalLengthM,
+        5,
+      );
+    });
+
+    it('동일 호선 두 번 요청 시 캐시된 동일 객체를 반환한다', () => {
+      const first = getLinePolyline('3');
+      const second = getLinePolyline('3');
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('snapToLinePolyline — 단일 segment', () => {
+    // 1호선 신도림(37.508787, 126.891144) → 구로(서쪽). 둘 사이 중간점은 polyline 위.
+    it('두 정거장 사이 중간점은 progress≈0.5로 snap된다', () => {
+      const stations = getStationsOnLine('1');
+      const sindorim = stations.find((s) => s.id === '1-041');
+      const guro = stations.find((s) => s.id === '1-042');
+      if (!sindorim || !guro) throw new Error('fixture missing');
+      const midLat = (sindorim.lat + guro.lat) / 2;
+      const midLng = (sindorim.lng + guro.lng) / 2;
+
+      const result = snapToLinePolyline({ lat: midLat, lng: midLng }, '1');
+      expect(result.matched).toBe(true);
+      if (!result.matched) return;
+      expect(result.segmentStartId).toBe('1-041');
+      expect(result.segmentEndId).toBe('1-042');
+      expect(result.progress).toBeGreaterThan(0.4);
+      expect(result.progress).toBeLessThan(0.6);
+      expect(result.snapDistanceM).toBeLessThan(1);
+    });
+
+    it('정거장 좌표 정확히 일치 시 progress=0 또는 1로 snap된다', () => {
+      const result = snapToLinePolyline({ lat: 37.508787, lng: 126.891144 }, '1');
+      expect(result.matched).toBe(true);
+      if (!result.matched) return;
+      // 신도림은 1-041, 인접 segment 의 한 끝점.
+      expect([result.segmentStartId, result.segmentEndId]).toContain('1-041');
+      expect(result.snapDistanceM).toBeLessThan(0.1);
+    });
+  });
+
+  describe('snapToLinePolyline — 50m 경계', () => {
+    // 신도림(37.508787, 126.891144). 위도 1° ≒ 111320m.
+    // 약 40m 북쪽 = lat + 40 / 111320 ≈ 0.000359
+    it('수직거리 약 40m는 matched', () => {
+      const result = snapToLinePolyline(
+        { lat: 37.508787 + 40 / 111_320, lng: 126.891144 },
+        '1',
+      );
+      expect(result.matched).toBe(true);
+      if (!result.matched) return;
+      expect(result.snapDistanceM).toBeGreaterThan(35);
+      expect(result.snapDistanceM).toBeLessThan(45);
+    });
+
+    it('수직거리 약 60m는 unmatched (50m 상한 초과)', () => {
+      // 신도림(1호선)에서 정북 60m. 1호선은 신도림 양쪽이 영등포(NE)/구로(SW)라
+      // 정북 60m는 polyline 어느 segment 와도 60m 이상 떨어진다.
+      const result = snapToLinePolyline(
+        { lat: 37.508787 + 60 / 111_320, lng: 126.891144 },
+        '1',
+      );
+      expect(result.matched).toBe(false);
+    });
+
+    it('MAX_SNAP_DISTANCE_M 가 노출돼 호출자가 임계값을 알 수 있다', () => {
+      expect(MAX_SNAP_DISTANCE_M).toBe(50);
+    });
+  });
+
+  describe('snapToLinePolyline — 환승역 disambiguate', () => {
+    /**
+     * 같은 이름의 환승역도 노선마다 polyline 방향이 다르다.
+     * 좌표가 한 노선 polyline에 훨씬 가까우면 그 노선으로 snap이 이긴다.
+     * 본 테스트는 fusion이 어떤 line으로 잠글지 호출자가 결정할 수 있는 신호를 제공함을 검증.
+     */
+    it.each<{ name: string; coord: { lat: number; lng: number }; winner: LineNumber; loser: LineNumber }>([
+      {
+        // 신도림: 1호선은 영등포(NE)→신도림→구로(SW) 가로 방향, 2호선은 신도림→문래(N) 세로 방향.
+        // 신도림에서 정확히 문래 방향(약간 N+E) 좌표 → 2호선이 가까움.
+        name: '신도림 1 vs 2 — 문래 방향(2호선)',
+        coord: { lat: 37.5104, lng: 126.8915 },
+        winner: '2',
+        loser: '1',
+      },
+      {
+        // 군자: 5호선은 장한평(NW)→군자→아차산(SE), 7호선은 어린이대공원(SW)→군자→뚝섬유원지(SE).
+        // 어린이대공원(37.548014, 127.074658)~군자(37.556897, 127.079338) 사이 중간점은
+        // 7호선 polyline 위, 5호선 segment 어느 쪽과도 떨어진다.
+        name: '군자 5 vs 7 — 어린이대공원-군자 segment 중간점(7호선)',
+        coord: { lat: 37.5525, lng: 127.077 },
+        winner: '7',
+        loser: '5',
+      },
+      {
+        // 건대입구: 2호선은 건대입구→구의(E), 7호선은 어린이대공원(NW)→건대입구→뚝섬유원지(SW).
+        // 건대입구(37.540373, 127.069191)~구의(37.537077, 127.085916) 사이 중간점은
+        // 2호선 polyline 위, 7호선 segment 어느 쪽과도 떨어진다.
+        name: '건대입구 2 vs 7 — 건대입구-구의 segment 중간점(2호선)',
+        coord: { lat: 37.5387, lng: 127.0775 },
+        winner: '2',
+        loser: '7',
+      },
+    ])('$name', ({ coord, winner, loser }) => {
+      const winResult = snapToLinePolyline(coord, winner);
+      const loseResult = snapToLinePolyline(coord, loser);
+      expect(winResult.matched).toBe(true);
+      if (!winResult.matched) return;
+      if (loseResult.matched) {
+        expect(winResult.snapDistanceM).toBeLessThan(loseResult.snapDistanceM);
+      }
+      // 어느 경우든 winning line의 snap은 충분히 가까워야 함.
+      expect(winResult.snapDistanceM).toBeLessThan(MAX_SNAP_DISTANCE_M);
+    });
+  });
+
+  describe('snapToLinePolyline — 비매칭', () => {
+    it('서울 외 좌표(부산 해운대 등)는 unmatched', () => {
+      const result = snapToLinePolyline({ lat: 35.1631, lng: 129.1635 }, '2');
+      expect(result.matched).toBe(false);
+    });
+
+    it('지하철 노선에서 멀리 떨어진 도시 내 좌표는 unmatched', () => {
+      // 한강 한가운데 (37.520, 126.97 부근). 어떤 노선 polyline 과도 50m 안에 들지 않는 좌표.
+      const result = snapToLinePolyline({ lat: 37.521, lng: 126.965 }, '2');
+      expect(result.matched).toBe(false);
+    });
+  });
+
+  describe('snapToLinePolyline — 전 노선 fixture', () => {
+    // 데이터 주도: 어떤 노선을 추가해도 같은 동작을 보장한다.
+    const lines: LineNumber[] = [
+      '1', '2', '3', '4', '5', '6', '7', '8', '9',
+      'airport', 'bundang', 'gyeongui', 'sinbundang',
+    ];
+
+    it.each(lines)('노선 %s — 첫 segment 중간점이 matched + 첫 두 정거장으로 snap', (line) => {
+      const stations = getStationsOnLine(line);
+      expect(stations.length).toBeGreaterThanOrEqual(2);
+      const a = stations[0];
+      const b = stations[1];
+      const midLat = (a.lat + b.lat) / 2;
+      const midLng = (a.lng + b.lng) / 2;
+      const result = snapToLinePolyline({ lat: midLat, lng: midLng }, line);
+      expect(result.matched).toBe(true);
+      if (!result.matched) return;
+      expect(result.line).toBe(line);
+      expect(result.snapDistanceM).toBeLessThan(MAX_SNAP_DISTANCE_M);
+      // 첫 segment 의 중점이 첫/두 번째 정거장 segment 로 snap되거나,
+      // 인접 segment 가 더 가까운 경우 그 segment 로도 가능. 어느 쪽이든 첫 두 정거장 중 하나는 포함.
+      const ids = [result.segmentStartId, result.segmentEndId];
+      const hit = ids.includes(a.id) || ids.includes(b.id);
+      expect(hit).toBe(true);
+    });
+  });
+
+  describe('mapMatchedSpeedKmh', () => {
+    it('지하철 평균 속도(30~50km/h) 범위를 정확히 환산한다', () => {
+      // 1000m / 90s ≈ 11.1 m/s ≈ 40 km/h.
+      const kmh = mapMatchedSpeedKmh(
+        { line: '2', arcM: 1000 },
+        { line: '2', arcM: 2000 },
+        90,
+      );
+      expect(kmh).not.toBeNull();
+      if (kmh === null) return;
+      expect(kmh).toBeGreaterThan(35);
+      expect(kmh).toBeLessThan(45);
+    });
+
+    it('역방향 진행도 동일 속도로 계산된다', () => {
+      const forward = mapMatchedSpeedKmh(
+        { line: '2', arcM: 1000 },
+        { line: '2', arcM: 2000 },
+        90,
+      );
+      const backward = mapMatchedSpeedKmh(
+        { line: '2', arcM: 2000 },
+        { line: '2', arcM: 1000 },
+        90,
+      );
+      expect(forward).not.toBeNull();
+      expect(backward).not.toBeNull();
+      if (forward === null || backward === null) return;
+      expect(forward).toBeCloseTo(backward, 5);
+    });
+
+    it('다른 노선이면 null', () => {
+      const kmh = mapMatchedSpeedKmh(
+        { line: '2', arcM: 1000 },
+        { line: '7', arcM: 2000 },
+        90,
+      );
+      expect(kmh).toBeNull();
+    });
+
+    it('Δt가 0 이하면 null', () => {
+      expect(
+        mapMatchedSpeedKmh({ line: '2', arcM: 1000 }, { line: '2', arcM: 2000 }, 0),
+      ).toBeNull();
+      expect(
+        mapMatchedSpeedKmh({ line: '2', arcM: 1000 }, { line: '2', arcM: 2000 }, -10),
+      ).toBeNull();
+    });
+
+    it('Δarc=0(정지)이면 null', () => {
+      const kmh = mapMatchedSpeedKmh(
+        { line: '2', arcM: 1500 },
+        { line: '2', arcM: 1500 },
+        30,
+      );
+      expect(kmh).toBeNull();
+    });
+
+    it('segment 경계를 거쳐도 cumulativeArcM 차로 자연스럽게 누적된다', () => {
+      const polyline = getLinePolyline('2');
+      // 첫 두 segment 를 60초에 걸쳐 통과.
+      const startArc = 0;
+      const endArc = polyline.cumulativeArcM[2];
+      const kmh = mapMatchedSpeedKmh(
+        { line: '2', arcM: startArc },
+        { line: '2', arcM: endArc },
+        60,
+      );
+      expect(kmh).not.toBeNull();
+      if (kmh === null) return;
+      expect(kmh).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/utils/linePolyline.ts
+++ b/src/utils/linePolyline.ts
@@ -1,0 +1,205 @@
+import { getStationsOnLine } from './stationRoute';
+import type { LineNumber, Station } from '../types/station';
+
+/**
+ * Phase 2 — Map matching.
+ *
+ * GPS 좌표를 노선 polyline(인접 정거장 간 직선 segment 시퀀스)에 사영하여
+ *   - 어느 노선의 어느 segment 위인지
+ *   - 그 segment의 진행 비율(0~1)
+ *   - 사영점과 GPS 사이 수직 거리
+ * 를 산출한다. 환승역 disambiguate / silent push station 정확도 / 한 정거장 전 알람
+ * 시점 정확도 회귀(#662, #796, #798) 해소용 utility.
+ *
+ * 본 PR은 utility만 export. fusion(`fusedSpeed.mapMatchedKmh`)와의 통합은 #819에서.
+ */
+
+// 위도 1° ≒ 111.32km (적도 기준). 서울 위도(~37.5°)에서도 위도 방향 거리는 변하지 않음.
+// 경도 1°는 위도에 따라 cos(lat)배. 서울 시내 수십 km 범위에서 등각도 평면 근사는
+// 오차 1m 이하라 polyline snap에 충분히 정확하다. (routeProgress.ts와 동일 근사)
+const METERS_PER_DEG_LAT = 111_320;
+
+function metersPerDegLng(lat: number): number {
+  return 111_320 * Math.cos((lat * Math.PI) / 180);
+}
+
+/**
+ * snap을 matched 로 간주할 perpendicular 거리 상한(미터).
+ * 50m는 도시 도로 폭 + GPS accuracy 일반 수준을 감안한 값.
+ * 도로/실내(노선에서 멀리 떨어진 좌표)는 unmatched 로 거부한다.
+ */
+export const MAX_SNAP_DISTANCE_M = 50;
+
+/** 노선별 polyline (정거장 ordered + 누적 segment 길이 테이블). 캐시된다. */
+export interface LinePolyline {
+  line: LineNumber;
+  /** 노선 데이터 정렬 순(stationRoute.getStationsOnLine). 단조 노선은 종점→종점. */
+  stations: Station[];
+  /** segment[i] = stations[i] → stations[i+1] 길이(m). length === stations.length - 1. */
+  segmentLengthsM: number[];
+  /** stations[i] 까지의 polyline 시작점 기준 누적 거리(m). length === stations.length. */
+  cumulativeArcM: number[];
+  /** polyline 전체 길이(m). cumulativeArcM[last] === totalLengthM. */
+  totalLengthM: number;
+}
+
+/** snap 결과 — matched 인 경우 segment 정보 + arc 위치. unmatched 인 경우 reason. */
+export type SnapResult =
+  | {
+      matched: true;
+      line: LineNumber;
+      /** 사영이 일어난 segment의 시작 station id (stations.json의 id). */
+      segmentStartId: string;
+      /** 사영이 일어난 segment의 끝 station id. */
+      segmentEndId: string;
+      /** segment 시작점=0 ~ 끝점=1 사이 진행 비율. */
+      progress: number;
+      /** 사영점과 입력 좌표 사이 수직 거리(m). */
+      snapDistanceM: number;
+      /** polyline 시작점 기준 사영점의 누적 arc 거리(m). mapMatchedKmh 계산용. */
+      arcM: number;
+    }
+  | { matched: false };
+
+/** mapMatchedKmh 계산을 위한 두 snapped 좌표 표현. */
+export interface SnappedPosition {
+  line: LineNumber;
+  arcM: number;
+}
+
+// 노선별 polyline lazy-cache. 533역을 매 snap 호출마다 재빌드하지 않는다.
+const polylineCache = new Map<LineNumber, LinePolyline>();
+
+/**
+ * 두 좌표 사이 평면 근사 미터 거리. haversine 보다 빠르고
+ * 서울 시내 segment 길이(수 km) 범위에서 오차 1m 이하.
+ */
+function planarDistanceM(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const mPerLng = metersPerDegLng((lat1 + lat2) / 2);
+  const dx = (lng2 - lng1) * mPerLng;
+  const dy = (lat2 - lat1) * METERS_PER_DEG_LAT;
+  return Math.hypot(dx, dy);
+}
+
+/**
+ * 특정 노선의 polyline 빌드 또는 캐시 반환.
+ *
+ * LineNumber 타입과 stations.json 데이터 정합성상 모든 노선은 ≥ 13 정거장으로 보장된다.
+ * (1호선 63, sinbundang 16 등) 별도 short-circuit 가드 없이 빌드한다.
+ */
+export function getLinePolyline(line: LineNumber): LinePolyline {
+  const cached = polylineCache.get(line);
+  if (cached) return cached;
+
+  const stations = getStationsOnLine(line);
+
+  const segmentLengthsM: number[] = [];
+  const cumulativeArcM: number[] = [0];
+  let total = 0;
+  for (let i = 0; i < stations.length - 1; i++) {
+    const a = stations[i];
+    const b = stations[i + 1];
+    const segM = planarDistanceM(a.lat, a.lng, b.lat, b.lng);
+    segmentLengthsM.push(segM);
+    total += segM;
+    cumulativeArcM.push(total);
+  }
+
+  const polyline: LinePolyline = {
+    line,
+    stations,
+    segmentLengthsM,
+    cumulativeArcM,
+    totalLengthM: total,
+  };
+  polylineCache.set(line, polyline);
+  return polyline;
+}
+
+/**
+ * GPS 좌표를 특정 노선 polyline 에 사영한다.
+ *
+ * - 모든 segment에 대해 점-선분 사영을 수행하고 최소 perpendicular 거리를 채택.
+ * - perpendicular 거리 ≤ MAX_SNAP_DISTANCE_M 이면 matched, 아니면 unmatched.
+ * - 환승역 disambiguate: 호출자가 후보 노선 각각에 본 함수를 적용하면
+ *   가장 작은 snapDistanceM을 가진 노선이 실제 탑승 노선이다.
+ */
+export function snapToLinePolyline(
+  coord: { lat: number; lng: number },
+  line: LineNumber,
+): SnapResult {
+  const polyline = getLinePolyline(line);
+  const { stations, segmentLengthsM, cumulativeArcM } = polyline;
+
+  let bestPerpM = Infinity;
+  let bestSegIdx = 0;
+  let bestT = 0;
+
+  // stations.json 정합성으로 인접 정거장은 모두 서로 다른 좌표(segLenSq > 0)이므로
+  // 별도 0-length segment 가드는 두지 않는다 (방어적 코드 금지).
+  for (let i = 0; i < stations.length - 1; i++) {
+    const a = stations[i];
+    const b = stations[i + 1];
+    const mPerLng = metersPerDegLng(a.lat);
+    const bx = (b.lng - a.lng) * mPerLng;
+    const by = (b.lat - a.lat) * METERS_PER_DEG_LAT;
+    const px = (coord.lng - a.lng) * mPerLng;
+    const py = (coord.lat - a.lat) * METERS_PER_DEG_LAT;
+    const segLenSq = bx * bx + by * by;
+    let t = (px * bx + py * by) / segLenSq;
+    if (t < 0) t = 0;
+    else if (t > 1) t = 1;
+    const closestX = t * bx;
+    const closestY = t * by;
+    const perp = Math.hypot(px - closestX, py - closestY);
+    if (perp < bestPerpM) {
+      bestPerpM = perp;
+      bestSegIdx = i;
+      bestT = t;
+    }
+  }
+
+  if (bestPerpM > MAX_SNAP_DISTANCE_M) return { matched: false };
+
+  const segStart = stations[bestSegIdx];
+  const segEnd = stations[bestSegIdx + 1];
+  const arcM = cumulativeArcM[bestSegIdx] + bestT * segmentLengthsM[bestSegIdx];
+
+  return {
+    matched: true,
+    line,
+    segmentStartId: segStart.id,
+    segmentEndId: segEnd.id,
+    progress: bestT,
+    snapDistanceM: bestPerpM,
+    arcM,
+  };
+}
+
+/**
+ * 두 snapped 좌표 사이 진행거리 / 시간 = 평균 속도(km/h).
+ *
+ * - segment 경계를 거쳐도 cumulativeArcM 차로 자연스럽게 누적된다.
+ * - 다른 노선 / Δt ≤ 0 / 거리 0 등 의미 없는 경우 null.
+ * - 음의 진행(역방향)은 |Δarc|로 처리. 호출자가 방향을 알 필요 없다.
+ */
+export function mapMatchedSpeedKmh(
+  start: SnappedPosition,
+  end: SnappedPosition,
+  deltaSeconds: number,
+): number | null {
+  if (start.line !== end.line) return null;
+  if (deltaSeconds <= 0) return null;
+  const deltaM = Math.abs(end.arcM - start.arcM);
+  if (deltaM === 0) return null;
+  const mps = deltaM / deltaSeconds;
+  return mps * 3.6;
+}
+
+/**
+ * 테스트에서 cross-suite cache 영향을 제거하기 위한 escape hatch.
+ * 프로덕션 코드는 호출하지 않는다.
+ */
+export function __resetLinePolylineCacheForTests(): void {
+  polylineCache.clear();
+}


### PR DESCRIPTION
Closes #817

## 변경
- `src/utils/linePolyline.ts`: 노선별 polyline 빌드 + 점-선분 사영 snap 알고리즘
- snap 결과: `{ line, segmentStartId/End, progress(0~1), snapDistanceM, arcM } | unmatched`
- 50m perpendicular 가드 (`MAX_SNAP_DISTANCE_M`)로 도로/실내 GPS unmatched 거부
- 환승역 disambiguate: 같은 이름 환승역도 노선별 polyline 방향 차이로 가장 가까운 line이 이김
- `mapMatchedSpeedKmh`: 두 `SnappedPosition`의 `arcM` 차 / Δt → km/h (segment 경계 자연 누적)
- 노선별 polyline lazy-cache로 533역 재빌드 방지
- 데이터 주도(stations.json + `getStationsOnLine`) — 노선 분기 if-else 없음

## 해소 회귀
- #662/#796 환승역 잘못된 line 잠금
- #798 silent push 잘못된 station
- multi-transfer 첫 환승 누락
- 한 정거장 전 알람 시점 오차

## #819 fusion 통합
- 본 PR `linePolyline.ts` utility만 export
- #819에서 ADR Phase 1 `fusedSpeed`의 `mapMatchedKmh` 인자에 채움
- 호출자 통합/실제 알람·잠금 로직 변경은 #819 범위

## 검증
- [x] 단일 segment snap (정거장 사이 중간점 → progress≈0.5)
- [x] 정거장 좌표 정확히 일치 → snapDistance<0.1m
- [x] snap 50m 경계 (40m matched / 60m unmatched)
- [x] 환승역 disambiguate (신도림 1↔2, 군자 5↔7, 건대입구 2↔7) — 모두 정확한 line 채택
- [x] 비매칭 (부산 좌표, 한강 한가운데) → unmatched
- [x] mapMatchedKmh 정확도 (1000m/90s → ~40km/h, 지하철 평균 범위 내)
- [x] 전 13개 노선 fixture (1·2·3·4·5·6·7·8·9·airport·bundang·gyeongui·sinbundang)
- [x] 커버리지 100% (statements/branches/functions/lines)
- [x] type-check 통과
- [x] 전체 3060 테스트 통과

ADR: https://app.notion.com/p/37430c0194b6819c8323e37d4c31a777