### PR TITLE
feat(#819): "탑승했냐?" 푸시(B 슬라이스) + Phase 1 fusion 9단 게이트 + arvlCd 자동 lock

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,6 +20,10 @@ import { registerScheduledAlarmListener } from '../src/utils/scheduledAlarmRecei
 import { cancelScheduledAlarms } from '../src/utils/alarmScheduler';
 import { unregisterAlarmRefreshTask } from '../src/tasks/alarmRefreshTask';
 import { stopVibration } from '../src/utils/alarmSound';
+import { setupBoardingPromptCategory } from '../src/utils/notificationCategory';
+import { useBoardingPromptResponder } from '../src/hooks/useBoardingPromptResponder';
+import { fetchArrivalInfo } from '../src/api/arrivalApi';
+import { FALLBACK_BOARDING_DURATION_MINUTES } from '../src/constants/boardingLock';
 
 const layoutLogger = createLogger('RootLayout');
 
@@ -28,6 +32,10 @@ setupNotificationHandler();
 // iOS silent push BG task 등록 — APNs payload 수신용.
 // 권한/플랫폼 미지원 시 내부에서 graceful no-op.
 registerSilentPushTask().catch((e) => layoutLogger.warn('silent push task 등록 실패:', e));
+// #819 — "탑승했냐?" 푸시의 BOARDING_PROMPT category 등록. 액션 [탑승]/[미탑승]을 노출.
+setupBoardingPromptCategory().catch((e) =>
+  layoutLogger.warn('boarding-prompt category 등록 실패(#819):', e),
+);
 // 사전 예약 alarm receiver는 잔존 예약 발사 시 FIRED_ALARMS 갱신만 담당.
 registerScheduledAlarmListener();
 // 부팅 시 1회 마이그레이션 — #478 PR 1-2 사전예약 폐기 시점:
@@ -62,7 +70,17 @@ function RootContent() {
   const loadLocalePreference = useAppStore((s) => s.loadLocalePreference);
   const debugVisible = useAppStore((s) => s.debugVisible);
   const setDebugVisible = useAppStore((s) => s.setDebugVisible);
+  const destinationId = useAppStore((s) => s.destination?.id ?? null);
   const { i18n: i18nInstance } = useTranslation();
+
+  // #819 — "탑승했냐?" 응답 listener. boarding-prompt 카테고리 푸시의 [탑승]/[미탑승] 또는 탭을 받아
+  // arvlCd 우선순위로 trainCode 자동 lock 또는 5분 silence POST. 미bound trip(destinationId=null)에서도
+  // 마운트 — payload만 들어오면 silence POST는 동작.
+  useBoardingPromptResponder({
+    fetchArrivalsForStation: (stationName) => fetchArrivalInfo(stationName),
+    destinationId,
+    expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
+  });
 
   useEffect(() => {
     loadLocalePreference();

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -1,9 +1,11 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  BOARDING_PROMPT_CATEGORY,
   buildApnsJwt,
   resetApnsJwtCache,
   sendAlertPush,
+  sendBoardingPromptPush,
   sendLiveActivityUpdate,
   sendReschedulePush,
   sendSilentPush,
@@ -349,6 +351,66 @@ describe('sendLiveActivityUpdate (#586 C)', () => {
       activityToken: 't',
       contentState: {},
       event: 'update',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: false, status: 410, reason: 'BadDeviceToken' });
+  });
+});
+
+describe('sendBoardingPromptPush (#819)', () => {
+  beforeEach(() => resetApnsJwtCache());
+
+  it('alert push + category + data payload 송신', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const result = await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p1',
+      title: 'Are you on board?',
+      body: '2 · 강남',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok',
+      sentAt: 1234,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${TEST_HOST}/3/device/device-hex`);
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-push-type']).toBe('alert');
+    expect(headers['apns-priority']).toBe('10');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.alert).toEqual({ title: 'Are you on board?', body: '2 · 강남' });
+    expect(body.aps.category).toBe(BOARDING_PROMPT_CATEGORY);
+    expect(body.aps.sound).toBe('default');
+    expect(body.data).toEqual({
+      pushId: 'p1',
+      kind: 'boarding-prompt',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok',
+      sentAt: 1234,
+    });
+  });
+
+  it('non-OK 응답은 status/reason을 그대로 반환', async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 410 }),
+    );
+    const result = await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p1',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: 'L',
+      tripToken: 't',
+      sentAt: 0,
       config: makeConfig(),
       host: TEST_HOST,
       fetchImpl: fetchImpl as unknown as typeof fetch,

--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+import { ARRIVAL_CODE } from '../alarm';
+import {
+  DISMISS_SILENCE_MS,
+  evaluateBoardingPromptGates,
+  markPromptFired,
+  markPromptSilenced,
+  pickAutoTrainCode,
+} from '../boardingPrompt';
+import type { PositionPoint } from '../types';
+import type { ArrivalEntry } from '../seoul';
+
+/**
+ * 9단 게이트 평가는 series sample 3+, accuracy < 50m, 출발역 100m 이내, 방향 cosine ≥ 0.7,
+ * fused speed ≥ 5km/h, motion ∈ {walking, automotive}, silence/fired 미발동 7개 조건을 한꺼번에
+ * 만족해야 통과. 헬퍼로 'happy' series + origin/nextStation 좌표를 미리 만들고 각 테스트가
+ * 한 조건만 깨뜨려 reason을 검증.
+ */
+function happySeries(now: number): PositionPoint[] {
+  // 출발역(0,0)에서 다음역(0, 0.01) 방향(동쪽)으로 이동 중. 60s 동안 0.0008 deg ~ 88m
+  // (5.3 km/h → walking이지만 raw 그대로 5km/h 약간 초과) — accuracy 10m, motion 'automotive'.
+  // 마지막 sample이 origin 100m 이내에 있어야 게이트 #4 통과 (origin이 출발역, 사용자가
+  // 막 출발 직후 시점을 모델링).
+  return [
+    {
+      lat: 0,
+      lng: -0.0004,
+      accuracy: 10,
+      ts: now - 60_000,
+      motion: 'automotive',
+    },
+    {
+      lat: 0,
+      lng: 0.0002,
+      accuracy: 10,
+      ts: now - 30_000,
+      motion: 'automotive',
+    },
+    {
+      lat: 0,
+      lng: 0.0008,
+      accuracy: 10,
+      ts: now,
+      motion: 'automotive',
+    },
+  ];
+}
+
+const ORIGIN = { lat: 0, lng: 0 };
+const NEXT = { lat: 0, lng: 0.01 };
+
+describe('evaluateBoardingPromptGates — 9단 AND 게이트', () => {
+  const now = 1_000_000;
+
+  it('happy path: 모든 게이트 통과 → pass=true + fusedSpeedKmh 반환', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) {
+      expect(r.fusedSpeedKmh).toBeGreaterThan(5);
+      expect(r.metrics.motion).toBe('automotive');
+    }
+  });
+
+  it('#9: 이미 fired된 trip은 차단', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      promptState: { fired: true, lastFiredAt: now - 1000 },
+    });
+    expect(r).toEqual(expect.objectContaining({ pass: false, reason: 'already-fired' }));
+  });
+
+  it('#9: silencedUntil이 미래면 silenced 차단', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      promptState: { silencedUntil: now + 60_000 },
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('silenced');
+  });
+
+  it('#9: silencedUntil이 과거면 통과 (silence 만료)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      promptState: { silencedUntil: now - 60_000 },
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('#6: N<3 → window-too-small', () => {
+    const small = happySeries(now).slice(-2);
+    const r = evaluateBoardingPromptGates({
+      series: small,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('window-too-small');
+  });
+
+  it('#3: 평균 accuracy ≥ 50m → accuracy-too-poor', () => {
+    const blurry = happySeries(now).map((p) => ({ ...p, accuracy: 60 }));
+    const r = evaluateBoardingPromptGates({
+      series: blurry,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('accuracy-too-poor');
+  });
+
+  it('#4: 출발역에서 100m 초과 → origin-too-far', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      // 1km 떨어진 다른 origin
+      origin: { lat: 0.01, lng: 0.01 },
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('origin-too-far');
+  });
+
+  it('#5: 방향 cosine < 0.7 → direction-mismatch (다른 방향 진행)', () => {
+    // expected vector: 동쪽(NEXT). series는 북쪽으로 이동 (44m → 88m 모두 origin 100m 이내) — cos≈0
+    const northbound: PositionPoint[] = [
+      { lat: -0.0004, lng: 0, accuracy: 10, ts: now - 60_000, motion: 'automotive' },
+      { lat: 0.0002, lng: 0, accuracy: 10, ts: now - 30_000, motion: 'automotive' },
+      { lat: 0.0008, lng: 0, accuracy: 10, ts: now, motion: 'automotive' },
+    ];
+    const r = evaluateBoardingPromptGates({
+      series: northbound,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('direction-mismatch');
+  });
+
+  it('#8: motion=stationary → motion-not-moving', () => {
+    const stationary = happySeries(now).map((p) => ({ ...p, motion: 'stationary' as const }));
+    const r = evaluateBoardingPromptGates({
+      series: stationary,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('motion-not-moving');
+  });
+
+  it('#8: motion=unknown → motion-not-moving', () => {
+    const unknown = happySeries(now).map((p) => ({ ...p, motion: 'unknown' as const }));
+    const r = evaluateBoardingPromptGates({
+      series: unknown,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('motion-not-moving');
+  });
+
+  it('#7: fused speed < 5 km/h → speed-too-low (천천히 이동)', () => {
+    // walking 게이트 통과 + ~0.0001 deg / 30s = ~12m/30s = 1.44 km/h. clamp 후도 5 미만.
+    const slow: PositionPoint[] = [
+      { lat: 0, lng: 0, accuracy: 10, ts: now - 60_000, motion: 'walking' },
+      { lat: 0, lng: 0.00005, accuracy: 10, ts: now - 30_000, motion: 'walking' },
+      { lat: 0, lng: 0.0001, accuracy: 10, ts: now, motion: 'walking' },
+    ];
+    const r = evaluateBoardingPromptGates({
+      series: slow,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('speed-too-low');
+  });
+});
+
+describe('markPromptFired / markPromptSilenced', () => {
+  it('markPromptFired는 fired=true + lastFiredAt 설정', () => {
+    expect(markPromptFired(1234)).toEqual({ fired: true, lastFiredAt: 1234 });
+  });
+  it('markPromptSilenced는 silencedUntil = now + DISMISS_SILENCE_MS', () => {
+    const r = markPromptSilenced(undefined, 1000);
+    expect(r.silencedUntil).toBe(1000 + DISMISS_SILENCE_MS);
+  });
+  it('markPromptSilenced는 기존 fired 상태 보존', () => {
+    const r = markPromptSilenced({ fired: true, lastFiredAt: 500 }, 1000);
+    expect(r.fired).toBe(true);
+    expect(r.lastFiredAt).toBe(500);
+  });
+});
+
+describe('pickAutoTrainCode — arvlCd 우선순위', () => {
+  function entry(overrides: Partial<ArrivalEntry>): ArrivalEntry {
+    return {
+      destination: '',
+      arrivalSeconds: 0,
+      trainCode: 'T1',
+      isUp: true,
+      subwayNm: '2호선',
+      arvlCd: null,
+      ...overrides,
+    };
+  }
+
+  it('priority 1: arvlCd=2 (출발) 단독 → 채택', () => {
+    const arrivals = [
+      entry({ trainCode: 'T1', arvlCd: 0 }),
+      entry({ trainCode: 'T2', arvlCd: 2 }),
+      entry({ trainCode: 'T3', arvlCd: ARRIVAL_CODE.ARRIVED }),
+    ];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBe('T2');
+  });
+
+  it('priority 2: arvlCd=1 (도착) — arvlCd=2 없을 때', () => {
+    const arrivals = [
+      entry({ trainCode: 'T1', arvlCd: 0 }),
+      entry({ trainCode: 'T2', arvlCd: ARRIVAL_CODE.ARRIVED }),
+    ];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBe('T2');
+  });
+
+  it('priority 3: arvlCd=0 (진입) — 2/1 없을 때', () => {
+    const arrivals = [entry({ trainCode: 'T1', arvlCd: 0 })];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBe('T1');
+  });
+
+  it('priority 4: 그 외 코드 → 첫 후보 (receivedAt 순서 가정)', () => {
+    const arrivals = [
+      entry({ trainCode: 'T1', arvlCd: 99 }),
+      entry({ trainCode: 'T2', arvlCd: 3 }),
+    ];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBe('T1');
+  });
+
+  it('ambiguity: 같은 우선순위 후보 2+ → null (자동 lock 안 함)', () => {
+    const arrivals = [
+      entry({ trainCode: 'T1', arvlCd: 2 }),
+      entry({ trainCode: 'T2', arvlCd: 2 }),
+    ];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBeNull();
+  });
+
+  it('line 매칭 안 되면 null', () => {
+    const arrivals = [entry({ trainCode: 'T1', arvlCd: 2, subwayNm: '99호선' })];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBeNull();
+  });
+
+  it('direction null → 양방향 허용', () => {
+    const arrivals = [entry({ trainCode: 'T1', arvlCd: 2, isUp: false })];
+    expect(pickAutoTrainCode(arrivals, '2호선', null)).toBe('T1');
+  });
+
+  it('direction=down → 하행만 매칭', () => {
+    const arrivals = [
+      entry({ trainCode: 'TU', arvlCd: 2, isUp: true }),
+      entry({ trainCode: 'TD', arvlCd: 2, isUp: false }),
+    ];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'down')).toBe('TD');
+  });
+
+  it('방향 매칭 후 모두 제거되면 null', () => {
+    const arrivals = [entry({ trainCode: 'T1', arvlCd: 2, isUp: true })];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'down')).toBeNull();
+  });
+
+  it('trainCode 빈 문자열 후보 → null', () => {
+    const arrivals = [entry({ trainCode: '', arvlCd: 2 })];
+    expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/fusedSpeed.test.ts
+++ b/backend/alarm-worker/src/__tests__/fusedSpeed.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { fusedSpeed } from '../fusedSpeed';
+
+describe('fusedSpeed (#819)', () => {
+  it('stationary motion → speed=0 confidence=high (다른 신호 무시)', () => {
+    const r = fusedSpeed({
+      gpsAvgKmh: 50,
+      gpsAccuracyMeters: 10,
+      motion: 'stationary',
+      mapMatchedKmh: null,
+    });
+    expect(r).toEqual({ speed: 0, confidence: 'high' });
+  });
+
+  it.each([
+    // GPS only: 10m → weight 0.7 (medium), 25m → 0.5 (medium), 70m → 0.2 (low), 150m → 0 (low).
+    // Phase 1 단독에서는 'high'(totalW≥1.0)는 mapMatchedKmh 없이 도달 불가 — Phase 2 합류 케이스는
+    // 별도 mapMatchedKmh 테스트에서 검증.
+    [10, 'medium'],
+    [25, 'medium'],
+    [70, 'low'],
+    [150, 'low'],
+  ] as const)(
+    'GPS 정확도 %dm (GPS-only) → confidence=%s',
+    (acc, confidence) => {
+      const r = fusedSpeed({
+        gpsAvgKmh: 30,
+        gpsAccuracyMeters: acc,
+        motion: 'walking',
+        mapMatchedKmh: null,
+      });
+      expect(r.confidence).toBe(confidence);
+    },
+  );
+
+  it('GPS accuracy ≥ 100m + mapMatchedKmh null → totalW=0 speed=0 confidence=low', () => {
+    const r = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 200,
+      motion: 'walking',
+      mapMatchedKmh: null,
+    });
+    expect(r).toEqual({ speed: 0, confidence: 'low' });
+  });
+
+  it('walking motion → 최대 10 km/h로 clamp', () => {
+    const r = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'walking',
+      mapMatchedKmh: null,
+    });
+    expect(r.speed).toBe(10);
+  });
+
+  it('automotive motion → 최소 5 km/h로 floor (저속 GPS 보정)', () => {
+    const r = fusedSpeed({
+      gpsAvgKmh: 1,
+      gpsAccuracyMeters: 10,
+      motion: 'automotive',
+      mapMatchedKmh: null,
+    });
+    expect(r.speed).toBe(5);
+  });
+
+  it('unknown motion → clamp 없이 raw 값 그대로', () => {
+    const r = fusedSpeed({
+      gpsAvgKmh: 25,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: null,
+    });
+    expect(r.speed).toBeCloseTo(25, 5);
+  });
+
+  it('mapMatchedKmh 있을 때 가중 평균 fusion (Phase 2 합류 검증)', () => {
+    // gpsWeight 0.7 (10m) + mapWeight 0.5 = 1.2 → confidence high
+    // raw = (30*0.7 + 40*0.5)/1.2 = 41/1.2 ≈ 34.17
+    const r = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: 40,
+    });
+    expect(r.speed).toBeCloseTo(34.166, 2);
+    expect(r.confidence).toBe('high');
+  });
+
+  it('totalW ≥ 1 → high, ≥ 0.5 → medium, < 0.5 → low', () => {
+    // GPS only accuracy 25m → weight 0.5 → totalW=0.5 → medium
+    const med = fusedSpeed({
+      gpsAvgKmh: 20,
+      gpsAccuracyMeters: 25,
+      motion: 'walking',
+      mapMatchedKmh: null,
+    });
+    expect(med.confidence).toBe('medium');
+    // GPS 80m → weight 0.2 → totalW=0.2 → low
+    const low = fusedSpeed({
+      gpsAvgKmh: 20,
+      gpsAccuracyMeters: 80,
+      motion: 'walking',
+      mapMatchedKmh: null,
+    });
+    expect(low.confidence).toBe('low');
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -898,3 +898,207 @@ describe('Live Activity endpoints (#586 C)', () => {
     });
   });
 });
+
+describe('POST /position (#819)', () => {
+  it('valid payload → KV에 series append + 200', async () => {
+    const env = makeKvEnv();
+    const res = await post(
+      '/position',
+      { token: 'tok-pos', lat: 1, lng: 2, accuracy: 5, ts: 1234, motion: 'walking' },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const stored = (await env.TRIPS.get('pos:tok-pos'))!;
+    expect(JSON.parse(stored)).toEqual([
+      { lat: 1, lng: 2, accuracy: 5, ts: 1234, motion: 'walking' },
+    ]);
+  });
+
+  it('invalid JSON → 400', async () => {
+    const env = makeKvEnv();
+    const res = await post('/position', '{', env);
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    ['missing token', { lat: 1, lng: 2, accuracy: 5, ts: 0, motion: 'walking' }],
+    ['empty token', { token: '', lat: 1, lng: 2, accuracy: 5, ts: 0, motion: 'walking' }],
+    ['lat not number', { token: 't', lat: 'x', lng: 2, accuracy: 5, ts: 0, motion: 'walking' }],
+    ['lng infinity', { token: 't', lat: 1, lng: Infinity, accuracy: 5, ts: 0, motion: 'walking' }],
+    ['accuracy negative', { token: 't', lat: 1, lng: 2, accuracy: -1, ts: 0, motion: 'walking' }],
+    ['ts not number', { token: 't', lat: 1, lng: 2, accuracy: 5, ts: 'x', motion: 'walking' }],
+    ['motion invalid', { token: 't', lat: 1, lng: 2, accuracy: 5, ts: 0, motion: 'flying' }],
+    ['empty body', null],
+  ])('invalid_payload — %s', async (_label, body) => {
+    const env = makeKvEnv();
+    const res = await post('/position', body, env);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /boarding-prompt/dismiss (#819)', () => {
+  const CREATED = 1_710_000_000_000;
+  function tripBody(): Record<string, unknown> {
+    return {
+      token: 'tok-dis',
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination: 'dst',
+      waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+      expiresAt: CREATED + 60 * 60_000,
+      alarmAtEpochMs: CREATED + 30 * 60_000,
+      createdAt: CREATED,
+    };
+  }
+
+  it('trip 없으면 idempotent 200 applied:false', async () => {
+    const env = makeKvEnv();
+    const res = await post('/boarding-prompt/dismiss', { token: 'no-trip' }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, applied: false });
+  });
+
+  it('trip 있으면 silencedUntil 설정 (현재 시각 + 5분 이후)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(CREATED);
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    const res = await post('/boarding-prompt/dismiss', { token: 'tok-dis' }, env);
+    expect(res.status).toBe(200);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-dis')) as string);
+    expect(stored.boardingPromptState.silencedUntil).toBe(CREATED + 5 * 60 * 1000);
+    vi.useRealTimers();
+  });
+
+  it('invalid_json → 400', async () => {
+    const env = makeKvEnv();
+    const res = await post('/boarding-prompt/dismiss', '{', env);
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    ['missing token', {}],
+    ['empty token', { token: '' }],
+    ['token not string', { token: 123 }],
+    ['null body', null],
+  ])('invalid_payload — %s', async (_label, body) => {
+    const env = makeKvEnv();
+    const res = await post('/boarding-prompt/dismiss', body, env);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('validateTrip — #819 promptGeoContext / promptDisplay', () => {
+  function withPrompt(overrides: Record<string, unknown>): Record<string, unknown> {
+    return { ...base(), ...overrides };
+  }
+
+  it('valid geoContext + display 보존', () => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+          direction: 'up',
+        },
+        promptDisplay: { originStation: '강남', line: '2' },
+      }),
+    );
+    expect(trip?.promptGeoContext).toEqual({
+      origin: { lat: 1, lng: 2 },
+      nextStation: { lat: 3, lng: 4 },
+      direction: 'up',
+    });
+    expect(trip?.promptDisplay).toEqual({ originStation: '강남', line: '2' });
+  });
+
+  it('direction 부재 → null로 강등 (양방향 허용)', () => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+        },
+      }),
+    );
+    expect(trip?.promptGeoContext?.direction).toBeNull();
+  });
+
+  it.each([
+    ['origin coord 누락', { promptGeoContext: { nextStation: { lat: 1, lng: 2 } } }],
+    ['nextStation 누락', { promptGeoContext: { origin: { lat: 1, lng: 2 } } }],
+    ['lat NaN', { promptGeoContext: { origin: { lat: NaN, lng: 2 }, nextStation: { lat: 3, lng: 4 } } }],
+    ['lng infinity', { promptGeoContext: { origin: { lat: 1, lng: Infinity }, nextStation: { lat: 3, lng: 4 } } }],
+    ['nextStation lat string', { promptGeoContext: { origin: { lat: 1, lng: 2 }, nextStation: { lat: 'x', lng: 4 } } }],
+    ['nextStation lng string', { promptGeoContext: { origin: { lat: 1, lng: 2 }, nextStation: { lat: 3, lng: 'y' } } }],
+    ['non-object', { promptGeoContext: 'oops' }],
+  ])('promptGeoContext invalid — %s', (_label, override) => {
+    const trip = validateTrip(withPrompt(override));
+    expect(trip?.promptGeoContext).toBeUndefined();
+  });
+
+  it.each([
+    ['originStation 누락', { promptDisplay: { line: '2' } }],
+    ['line 누락', { promptDisplay: { originStation: '강남' } }],
+    ['originStation 빈 문자열', { promptDisplay: { originStation: '', line: '2' } }],
+    ['line 빈 문자열', { promptDisplay: { originStation: '강남', line: '' } }],
+    ['non-object', { promptDisplay: 'oops' }],
+  ])('promptDisplay invalid — %s', (_label, override) => {
+    const trip = validateTrip(withPrompt(override));
+    expect(trip?.promptDisplay).toBeUndefined();
+  });
+});
+
+describe('POST /trips — #819 boardingPromptState carries over same session', () => {
+  const CREATED = 1_700_000_000_000;
+  function tripBody(): Record<string, unknown> {
+    return {
+      token: 'tok-bp',
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination: 'dst',
+      waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+      expiresAt: CREATED + 60 * 60_000,
+      alarmAtEpochMs: CREATED + 30 * 60_000,
+      createdAt: CREATED,
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+    };
+  }
+
+  it('same session re-register → 이전 fired state 보존', async () => {
+    const env = makeKvEnv();
+    // 첫 등록 후 backend가 state.fired=true 적재했다고 가정
+    await env.TRIPS.put(
+      'trip:tok-bp',
+      JSON.stringify({
+        ...validateTrip(tripBody()),
+        boardingPromptState: { fired: true, lastFiredAt: CREATED - 10_000 },
+      }),
+    );
+    // re-register
+    await post('/trips', tripBody(), env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-bp')) as string);
+    expect(stored.boardingPromptState).toEqual({ fired: true, lastFiredAt: CREATED - 10_000 });
+  });
+
+  it('new session (createdAt drift > 5s) → state 초기화', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(CREATED);
+    const env = makeKvEnv();
+    // 기존 trip을 명시 trainCode 없이 저장 (#704 trainCode 미사용 시 createdAt drift만 본다)
+    await env.TRIPS.put(
+      'trip:tok-bp',
+      JSON.stringify({
+        ...validateTrip(tripBody()),
+        boardingPromptState: { fired: true, lastFiredAt: CREATED - 10_000 },
+      }),
+    );
+    await post('/trips', { ...tripBody(), createdAt: CREATED + 10_000 }, env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-bp')) as string);
+    expect(stored.boardingPromptState).toBeUndefined();
+    vi.useRealTimers();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/positionSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/positionSeries.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACCURACY_CUTOFF_M,
+  appendPositionPoint,
+  clearSeries,
+  cosineDirection,
+  evaluateWindow,
+  haversineKm,
+  pickMotionMode,
+  POSITION_WINDOW_MS,
+  readSeries,
+} from '../positionSeries';
+import type { PositionPoint } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+function point(overrides: Partial<PositionPoint>): PositionPoint {
+  return {
+    lat: 37.5,
+    lng: 127.0,
+    accuracy: 10,
+    ts: 0,
+    motion: 'unknown',
+    ...overrides,
+  };
+}
+
+describe('positionSeries — KV roundtrip', () => {
+  it('append → read 시 동일 series 복원', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const p = point({ ts: 1000 });
+    await appendPositionPoint(kv, 'tok', p);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toEqual([p]);
+  });
+
+  it('30개를 넘어가면 oldest sample이 ring으로 잘림', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    for (let i = 0; i < 40; i++) {
+      await appendPositionPoint(kv, 'tok', point({ ts: i }));
+    }
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(30);
+    expect(series[0].ts).toBe(10);
+    expect(series[29].ts).toBe(39);
+  });
+
+  it('clearSeries → readSeries 빈 배열', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await appendPositionPoint(kv, 'tok', point({ ts: 1 }));
+    await clearSeries(kv, 'tok');
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('읽은 JSON이 배열이 아니면 빈 배열로 폴백', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await kv.put('pos:tok', JSON.stringify({ notArray: true }));
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('JSON 파싱 실패 시 빈 배열', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await kv.put('pos:tok', 'not-json');
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('필드 누락 sample은 filter됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const invalid = JSON.stringify([
+      { lat: 1, lng: 2, accuracy: 3, ts: 4, motion: 'walking' },
+      { lat: 'bad', lng: 2, accuracy: 3, ts: 4, motion: 'walking' },
+      null,
+    ]);
+    await kv.put('pos:tok', invalid);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(1);
+  });
+});
+
+describe('haversineKm', () => {
+  it('서울시청 → 잠실역 ~ 9-12km 거리', () => {
+    const d = haversineKm(37.5663, 126.9779, 37.5133, 127.1006);
+    expect(d).toBeGreaterThan(8);
+    expect(d).toBeLessThan(15);
+  });
+  it('동일 좌표 → 0', () => {
+    expect(haversineKm(37.5, 127, 37.5, 127)).toBe(0);
+  });
+});
+
+describe('pickMotionMode', () => {
+  it('빈 입력 → unknown', () => {
+    expect(pickMotionMode([])).toBe('unknown');
+  });
+  it('단일 분류 dominant → 해당 분류', () => {
+    expect(
+      pickMotionMode([
+        point({ motion: 'walking' }),
+        point({ motion: 'walking' }),
+        point({ motion: 'automotive' }),
+      ]),
+    ).toBe('walking');
+  });
+  it('동률 → unknown으로 강등', () => {
+    expect(
+      pickMotionMode([
+        point({ motion: 'walking' }),
+        point({ motion: 'automotive' }),
+      ]),
+    ).toBe('unknown');
+  });
+});
+
+describe('evaluateWindow', () => {
+  it('윈도우 밖 sample은 제외 (POSITION_WINDOW_MS 기준)', () => {
+    const now = POSITION_WINDOW_MS + 10_000;
+    // 1000ms ts는 윈도우 밖 (now - 1000 > 60s)
+    const series = [
+      point({ ts: 1000, lat: 37.0, lng: 127.0, accuracy: 5, motion: 'walking' }),
+      // 윈도우 안 sample 3개 — 1km 정도 이동
+      point({ ts: now - 30_000, lat: 37.5, lng: 127.0, accuracy: 5, motion: 'walking' }),
+      point({ ts: now - 15_000, lat: 37.502, lng: 127.0, accuracy: 5, motion: 'walking' }),
+      point({ ts: now, lat: 37.504, lng: 127.0, accuracy: 5, motion: 'walking' }),
+    ];
+    const m = evaluateWindow(series, now);
+    expect(m.count).toBe(3);
+    expect(m.gpsAvgKmh).toBeGreaterThan(0);
+  });
+
+  it('accuracy ≥ 50m sample은 hop에서 제외 (게이트 #3 정책)', () => {
+    const now = 60_000;
+    const series = [
+      point({ ts: 0, lat: 37.5, lng: 127.0, accuracy: ACCURACY_CUTOFF_M + 1 }),
+      point({ ts: 30_000, lat: 37.51, lng: 127.0, accuracy: 5 }),
+      point({ ts: 60_000, lat: 37.52, lng: 127.0, accuracy: 5 }),
+    ];
+    const m = evaluateWindow(series, now);
+    // 첫 번째 hop은 accuracy 50+ 이라 제외, 두 번째 hop (30s, 37.51→37.52)만 카운트
+    expect(m.count).toBe(3);
+    expect(m.gpsAvgKmh).toBeGreaterThan(0);
+  });
+
+  it('윈도우 밖 sample만 있으면 빈 metrics — start/end null, gpsAvgKmh=0', () => {
+    const m = evaluateWindow([point({ ts: 0 })], 999_999);
+    expect(m.count).toBe(0);
+    expect(m.start).toBeNull();
+    expect(m.end).toBeNull();
+    expect(m.gpsAvgKmh).toBe(0);
+    expect(m.motion).toBe('unknown');
+  });
+
+  it('dtMs ≤ 0인 sample 쌍은 hop 제외 (시계 역행 보호)', () => {
+    const now = 60_000;
+    const series = [
+      point({ ts: 30_000, lat: 37.5, lng: 127.0, accuracy: 5 }),
+      // 두 번째가 ts 같음 → dtMs=0 → skip
+      point({ ts: 30_000, lat: 37.51, lng: 127.0, accuracy: 5 }),
+      point({ ts: 60_000, lat: 37.52, lng: 127.0, accuracy: 5 }),
+    ];
+    const m = evaluateWindow(series, now);
+    // 첫 hop dtMs=0 skip, 두 번째 hop만 카운트
+    expect(m.gpsAvgKmh).toBeGreaterThan(0);
+  });
+});
+
+describe('cosineDirection', () => {
+  it('같은 방향 → 1', () => {
+    // 동→서 두 vector 동일 방향
+    expect(cosineDirection(0, 0, 0, 1, 0, 0, 0, 2)).toBeCloseTo(1, 5);
+  });
+  it('정반대 방향 → -1', () => {
+    expect(cosineDirection(0, 0, 0, 1, 0, 0, 0, -2)).toBeCloseTo(-1, 5);
+  });
+  it('직각 → 0', () => {
+    expect(cosineDirection(0, 0, 0, 1, 0, 0, 1, 0)).toBeCloseTo(0, 5);
+  });
+  it('영벡터(velocity 0) → 0', () => {
+    expect(cosineDirection(0, 0, 0, 0, 0, 0, 1, 0)).toBe(0);
+  });
+  it('영벡터(expected 0) → 0', () => {
+    expect(cosineDirection(0, 0, 0, 1, 0, 0, 0, 0)).toBe(0);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1296,3 +1296,145 @@ describe('#705 scheduled.ts progress KV mirroring', () => {
     expect(await readProgress(kv)).toBeNull();
   });
 });
+
+describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
+  function makeUnlockedTrip(overrides: Partial<Trip> = {}): Trip {
+    // lockMissing 분기 진입 — boardingLock 없음.
+    return makeTrip({
+      token: 'bp-tok',
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+      ...overrides,
+    });
+  }
+
+  function makeBoardingPromptDeps(fetchImpl: typeof fetch) {
+    return {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'bp-push-1',
+    };
+  }
+
+  /** "happy path" series — 9단 모두 통과하는 60s window. helper에서 NOW 기준 timestamp 사용. */
+  async function seedHappySeries(kv: InMemoryKV, token = 'bp-tok'): Promise<void> {
+    const series = [
+      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+  }
+
+  it('promptGeoContext 없으면 skip — boardingPromptEvaluated 미증가', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'no-geo' }));
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    expect(stats.boardingPromptFired).toBe(0);
+  });
+
+  it('9단 통과 + APNs 200 → alert push 발사 + state.fired 영구화', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(
+      async () => new Response(null, { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(1);
+    expect(stats.boardingPromptBlocked).toBe(0);
+
+    // 1회 fetch (APNs) — 후속 cron에서 dedup.
+    const fetchMock = fetchImpl as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).headers).toMatchObject({
+      'apns-push-type': 'alert',
+      'apns-priority': '10',
+    });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.aps.category).toBe('BOARDING_PROMPT');
+    expect(body.data.kind).toBe('boarding-prompt');
+    expect(body.data.originStation).toBe('강남');
+    expect(body.data.line).toBe('2');
+
+    const persisted = JSON.parse((await kv.get('trip:bp-tok'))!);
+    expect(persisted.boardingPromptState).toEqual({ fired: true, lastFiredAt: NOW });
+  });
+
+  it('이미 fired된 trip은 미발사 + blocked 카운트', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({ boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 } }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('series 비어 있으면 window-too-small로 차단', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+  });
+
+  it('APNs 실패 시 errors 카운트 + state 유지', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    await seedHappySeries(kv);
+    // 410 외 일반 실패 — env mismatch 아님
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ reason: 'TopicDisallowed' }), { status: 403 }),
+    ) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.errors).toBeGreaterThan(0);
+  });
+
+  it('APNs env mismatch 시 self-heal → corrected env 저장', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({ apnsEnv: 'sandbox' }),
+    );
+    await seedHappySeries(kv);
+    let callIdx = 0;
+    const fetchImpl = vi.fn(async () => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
+      }
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptFired).toBe(1);
+    expect(stats.envCorrected).toBe(1);
+    const persisted = JSON.parse((await kv.get('trip:bp-tok'))!);
+    expect(persisted.apnsEnv).toBe('production');
+  });
+});

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -7,7 +7,14 @@
 
 import { importPKCS8, SignJWT } from 'jose';
 import type { AlarmPhase } from './alarm';
-import type { ReschedulePushPayload } from './types';
+import type { BoardingPromptPushPayload, ReschedulePushPayload } from './types';
+
+/**
+ * iOS UNNotificationCategory 식별자 (#819 B 슬라이스). 클라이언트는 같은 식별자로
+ * `Notifications.setNotificationCategoryAsync('BOARDING_PROMPT', ...)`로 [탑승]/[미탑승]
+ * 액션을 등록한다. 푸시 payload `aps.category`로 매칭.
+ */
+export const BOARDING_PROMPT_CATEGORY = 'BOARDING_PROMPT';
 
 /**
  * APNs JWT는 1시간 이내 재사용 가능. Worker 인스턴스 메모리에 캐시한다.
@@ -284,6 +291,73 @@ export async function sendLiveActivityUpdate(
       'apns-topic': `${options.config.bundleId}.push-type.liveactivity`,
       'apns-push-type': 'liveactivity',
       'apns-priority': String(priority),
+      'content-type': 'application/json',
+    },
+    body,
+  });
+
+  if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
+/**
+ * "탑승했냐?" 푸시 발사 (#819 B 슬라이스).
+ *
+ * iOS UNNotificationCategory "BOARDING_PROMPT" 액션 [탑승]/[미탑승]을 노출하려면 alert push
+ * (apns-push-type: alert, priority 10) + `aps.category` 필드가 필요하다. 일반 silent push와
+ * 달리 화면 표시가 핵심 UX. 클라이언트는 payload의 `originStation` / `line` / `tripToken`을
+ * 받아 [탑승] 응답 시 arvlCd 우선순위로 trainCode 자동 선택 후 BoardingLock을 생성한다.
+ */
+export interface SendBoardingPromptPushOptions {
+  deviceToken: string;
+  pushId: string;
+  /** 사용자 표시용 제목 (i18n는 클라가 한다 — 백엔드는 영문 raw 기본). */
+  title: string;
+  /** 사용자 표시용 본문 — `${line}호선 ${originStation}` 같은 컨텍스트 포함 권장. */
+  body: string;
+  /** trip 컨텍스트 — 클라이언트가 응답 처리 시 사용. */
+  originStation: string;
+  line: string;
+  tripToken: string;
+  sentAt: number;
+  config: ApnsConfig;
+  host: string;
+  fetchImpl?: typeof fetch;
+  now?: number;
+}
+
+export async function sendBoardingPromptPush(
+  options: SendBoardingPromptPushOptions,
+): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
+
+  const data: BoardingPromptPushPayload = {
+    pushId: options.pushId,
+    kind: 'boarding-prompt',
+    originStation: options.originStation,
+    line: options.line,
+    tripToken: options.tripToken,
+    sentAt: options.sentAt,
+  };
+
+  const body = JSON.stringify({
+    aps: {
+      alert: { title: options.title, body: options.body },
+      sound: 'default',
+      category: BOARDING_PROMPT_CATEGORY,
+    },
+    data,
+  });
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${jwt}`,
+      'apns-topic': options.config.bundleId,
+      'apns-push-type': 'alert',
+      'apns-priority': '10',
       'content-type': 'application/json',
     },
     body,

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -1,0 +1,217 @@
+/**
+ * "탑승했냐?" 푸시 (#819 B 슬라이스) — 9단 AND 게이트 + arvlCd 우선순위 trainCode 선택.
+ *
+ * 게이트 (ADR Section 2):
+ *   1. trip 활성 (caller가 listTrips로 보장)
+ *   2. BoardingLock 없음 (caller가 lockMissing trip 분기에서만 호출)
+ *   3. GPS accuracy < 50m (윈도우 평균 기준)
+ *   4. 출발역 100m 이내 (마지막 sample 기준 haversine)
+ *   5. 방향 cosine ≥ 0.7 (velocity vector vs 출발역→다음역)
+ *   6. 60s 윈도우 sample N≥3
+ *   7. fused speed ≥ 5 km/h AND confidence ≠ 'low'
+ *   8. motion ∈ {walking, automotive}
+ *   9. trip당 1회 + 5분 silence
+ *
+ * arvlCd 우선순위 (ADR Section 1.2):
+ *   2 (출발) > 1 (도착) > 0 (진입) > 그 외 receivedAt 가까운 + 방향 매칭
+ *   ambiguity → 자동 안 함 → 클라가 manual fallback.
+ */
+
+import { ARRIVAL_CODE } from './alarm';
+import { fusedSpeed } from './fusedSpeed';
+import { matchLine } from './lineAlias';
+import {
+  ACCURACY_CUTOFF_M,
+  cosineDirection,
+  evaluateWindow,
+  haversineKm,
+  type WindowedMetrics,
+} from './positionSeries';
+import type { ArrivalEntry } from './seoul';
+import type { BoardingPromptState, PositionPoint } from './types';
+
+/** 게이트 #4 — 출발역 거리 임계 (km 변환). */
+export const ORIGIN_RADIUS_KM = 0.1;
+/** 게이트 #5 — 방향 cosine 임계. */
+export const DIRECTION_COSINE_THRESHOLD = 0.7;
+/** 게이트 #6 — 60s 윈도우 최소 sample. */
+export const MIN_WINDOW_SAMPLES = 3;
+/** 게이트 #7 — fused speed 임계 (km/h). */
+export const MIN_FUSED_SPEED_KMH = 5;
+/** 게이트 #9 — dismiss 후 silence 길이. */
+export const DISMISS_SILENCE_MS = 5 * 60 * 1000;
+
+export type GateOutcome =
+  | { pass: true; metrics: WindowedMetrics; fusedSpeedKmh: number }
+  | { pass: false; reason: GateSkipReason; metrics?: WindowedMetrics };
+
+export type GateSkipReason =
+  | 'no-series'
+  | 'window-too-small'
+  | 'accuracy-too-poor'
+  | 'origin-too-far'
+  | 'direction-mismatch'
+  | 'speed-too-low'
+  | 'motion-not-moving'
+  | 'silenced'
+  | 'already-fired';
+
+export interface OriginCoord {
+  lat: number;
+  lng: number;
+}
+
+export interface NextStationCoord {
+  lat: number;
+  lng: number;
+}
+
+export interface EvaluateBoardingPromptInputs {
+  series: readonly PositionPoint[];
+  origin: OriginCoord;
+  /** trip 출발역 → 다음역의 좌표 — 방향 cosine 계산용. */
+  nextStation: NextStationCoord;
+  now: number;
+  /** trip의 boarding-prompt 상태 — 게이트 #9 평가. */
+  promptState?: BoardingPromptState;
+}
+
+/**
+ * 9단 AND 게이트 평가. 한 게이트라도 실패하면 즉시 reason과 함께 fail.
+ * 게이트 #1/#2는 caller가 미리 보장 (listTrips × lockMissing 분기) — 본 함수는 #3~#9만 평가.
+ */
+export function evaluateBoardingPromptGates(
+  inputs: EvaluateBoardingPromptInputs,
+): GateOutcome {
+  // #9 — silence / 1회 발사 dedup. promptState 부재 = 첫 시도, 통과.
+  if (inputs.promptState) {
+    if (inputs.promptState.fired) {
+      return { pass: false, reason: 'already-fired' };
+    }
+    if (
+      inputs.promptState.silencedUntil !== undefined &&
+      inputs.promptState.silencedUntil > inputs.now
+    ) {
+      return { pass: false, reason: 'silenced' };
+    }
+  }
+
+  // #6 — 60s 윈도우 N≥3 (cold start 보호). 0/1 sample은 metrics.start/end null로 자연 차단.
+  const metrics = evaluateWindow(inputs.series, inputs.now);
+  if (metrics.count < MIN_WINDOW_SAMPLES) {
+    return { pass: false, reason: 'window-too-small', metrics };
+  }
+  // window-too-small이 통과한 이후엔 start/end가 null이 될 수 없음(count ≥ 3).
+  // TypeScript narrowing을 위해 명시 assert로 진행.
+  if (!metrics.start || !metrics.end) {
+    return { pass: false, reason: 'window-too-small', metrics };
+  }
+
+  // #3 — accuracy. 평균 accuracy가 50m 이상이면 신뢰 불가.
+  if (metrics.avgAccuracyMeters >= ACCURACY_CUTOFF_M) {
+    return { pass: false, reason: 'accuracy-too-poor', metrics };
+  }
+
+  // #4 — 출발역 100m 이내. 마지막 sample 기준 (가장 최신 위치).
+  const originDistanceKm = haversineKm(
+    metrics.end.lat,
+    metrics.end.lng,
+    inputs.origin.lat,
+    inputs.origin.lng,
+  );
+  if (originDistanceKm > ORIGIN_RADIUS_KM) {
+    return { pass: false, reason: 'origin-too-far', metrics };
+  }
+
+  // #5 — 방향 cosine ≥ 0.7. expected vector는 출발역 → 다음역.
+  const cos = cosineDirection(
+    metrics.start.lat,
+    metrics.start.lng,
+    metrics.end.lat,
+    metrics.end.lng,
+    inputs.origin.lat,
+    inputs.origin.lng,
+    inputs.nextStation.lat,
+    inputs.nextStation.lng,
+  );
+  if (cos < DIRECTION_COSINE_THRESHOLD) {
+    return { pass: false, reason: 'direction-mismatch', metrics };
+  }
+
+  // #8 — motion ∈ {walking, automotive}. stationary/unknown은 차단.
+  if (metrics.motion !== 'walking' && metrics.motion !== 'automotive') {
+    return { pass: false, reason: 'motion-not-moving', metrics };
+  }
+
+  // #7 — fused speed. mapMatchedKmh는 Phase 2 (#817) 후속에서 채움 — 현재는 null.
+  const fused = fusedSpeed({
+    gpsAvgKmh: metrics.gpsAvgKmh,
+    gpsAccuracyMeters: metrics.avgAccuracyMeters,
+    motion: metrics.motion,
+    mapMatchedKmh: null,
+  });
+  if (fused.speed < MIN_FUSED_SPEED_KMH || fused.confidence === 'low') {
+    return { pass: false, reason: 'speed-too-low', metrics };
+  }
+
+  return { pass: true, metrics, fusedSpeedKmh: fused.speed };
+}
+
+/**
+ * trip의 boarding-prompt state를 발사 시점 또는 dismiss 시점에 갱신해 반환.
+ * caller는 결과를 trip에 set 후 KV 저장.
+ */
+export function markPromptFired(now: number): BoardingPromptState {
+  return { fired: true, lastFiredAt: now };
+}
+
+export function markPromptSilenced(
+  prev: BoardingPromptState | undefined,
+  now: number,
+): BoardingPromptState {
+  return {
+    ...prev,
+    silencedUntil: now + DISMISS_SILENCE_MS,
+  };
+}
+
+/**
+ * arvlCd 우선순위로 trainCode 자동 선택 (ADR Section 1.2).
+ *
+ * 같은 line + 진행 방향 매칭하는 후보 중:
+ *   1순위: arvlCd=2 (출발) — 사용자가 방금 그 차 타고 출발
+ *   2순위: arvlCd=1 (도착) — 막 탑승
+ *   3순위: arvlCd=0 (진입) — 다음 차 대기
+ *   4순위: 그 외 → 받은 순서 그대로 (Seoul API receivedAt 정렬)
+ *
+ * 같은 우선순위 후보가 여러 개면 (ambiguity) → null 반환. caller가 manual fallback.
+ *
+ * `line`은 boarding line (사용자 trip 출발 라인). lineAlias.matchLine으로 별칭(예: "1호선"
+ * vs "지하철1호선") 매칭.
+ */
+export function pickAutoTrainCode(
+  arrivals: readonly ArrivalEntry[],
+  line: string,
+  direction: 'up' | 'down' | null,
+): string | null {
+  const matching = arrivals.filter((a) => matchLine(a.subwayNm, line));
+  if (matching.length === 0) return null;
+  // 방향 일치 — direction이 null이면 양방향 허용.
+  const directional = direction
+    ? matching.filter((a) => (direction === 'up' ? a.isUp : !a.isUp))
+    : matching;
+  if (directional.length === 0) return null;
+
+  const priority: readonly number[] = [
+    /* 2: 출발 */ 2,
+    /* 1: 도착 */ ARRIVAL_CODE.ARRIVED,
+    /* 0: 진입 */ ARRIVAL_CODE.ENTERING,
+  ];
+  for (const code of priority) {
+    const tier = directional.filter((a) => a.arvlCd === code);
+    if (tier.length === 1) return tier[0].trainCode || null;
+    if (tier.length > 1) return null; // ambiguity → 자동 안 함
+  }
+  // 그 외 — 받은 순서 첫 후보.
+  return directional[0].trainCode || null;
+}

--- a/backend/alarm-worker/src/fusedSpeed.ts
+++ b/backend/alarm-worker/src/fusedSpeed.ts
@@ -1,0 +1,67 @@
+/**
+ * Phase 1 fused speed 계산 (#819 게이트 #7).
+ *
+ * GPS 좌표 series 평균속도 + Motion sanity + (Phase 2부터) map-matched speed의
+ * 가중 평균. iOS client.speed가 `-1`/빈 값으로 자주 떨어지는 회귀(#812 cold start) 때문에
+ * raw client.speed를 신뢰하지 않고 좌표 series로 직접 산출한다.
+ *
+ * ADR: https://app.notion.com/p/37430c0194b6819c8323e37d4c31a777 Section 5.
+ */
+
+export type Motion = 'stationary' | 'walking' | 'automotive' | 'unknown';
+
+export interface FusedSpeedInputs {
+  /** 좌표 series 60s 평균 km/h. */
+  gpsAvgKmh: number;
+  /** 평균 계산에 사용된 윈도우의 평균 accuracy meters — 가중치 단계 결정용. */
+  gpsAccuracyMeters: number;
+  /** CMMotionActivity 분류 결과 — 'stationary'는 즉시 0 km/h로 강등. */
+  motion: Motion;
+  /** Phase 2 map matching 결과. 미사용 단계는 null — 가중치 0으로 자연 무시. */
+  mapMatchedKmh: number | null;
+}
+
+export interface FusedSpeed {
+  /** km/h. motion clamp 적용 후 값. */
+  speed: number;
+  /** 가중치 합 기반 신뢰도. 'low'면 게이트 #7 차단 (보수). */
+  confidence: 'high' | 'medium' | 'low';
+}
+
+/**
+ * 좌표 series 60s 평균 + motion clamp + (Phase 2부터) map matching weighted fusion.
+ *
+ * - motion=stationary면 다른 신호 무시하고 0 km/h 강등 (false positive 1차 차단).
+ * - GPS 가중치는 accuracy 단계 함수 — < 20m: 0.7, < 50m: 0.5, < 100m: 0.2, 그 외: 0.
+ *   (50m 컷오프 자체는 호출자가 게이트 #3에서 series 필터로 처리. 여기서는 평균
+ *   accuracy 기반 신뢰도 조정만.)
+ * - mapMatchedKmh가 있으면 0.5 추가 — Phase 2까지는 null로 호출되므로 GPS only.
+ * - clamp: walking은 10 km/h 상한, automotive는 5 km/h 하한 — sensor 불일치를 완화.
+ */
+export function fusedSpeed(opts: FusedSpeedInputs): FusedSpeed {
+  if (opts.motion === 'stationary') return { speed: 0, confidence: 'high' };
+
+  const gpsWeight =
+    opts.gpsAccuracyMeters < 20
+      ? 0.7
+      : opts.gpsAccuracyMeters < 50
+        ? 0.5
+        : opts.gpsAccuracyMeters < 100
+          ? 0.2
+          : 0;
+  const mapWeight = opts.mapMatchedKmh != null ? 0.5 : 0;
+  const totalW = gpsWeight + mapWeight;
+  if (totalW === 0) return { speed: 0, confidence: 'low' };
+
+  const raw =
+    (opts.gpsAvgKmh * gpsWeight + (opts.mapMatchedKmh ?? 0) * mapWeight) / totalW;
+  const speed =
+    opts.motion === 'walking'
+      ? Math.min(raw, 10)
+      : opts.motion === 'automotive'
+        ? Math.max(raw, 5)
+        : raw;
+  const confidence: FusedSpeed['confidence'] =
+    totalW >= 1.0 ? 'high' : totalW >= 0.5 ? 'medium' : 'low';
+  return { speed, confidence };
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { Hono } from 'hono';
+import { markPromptSilenced } from './boardingPrompt';
 import { runFallbackPushes } from './fallback';
 import {
   cleanupTripWithLa,
@@ -19,6 +20,7 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { ackPending } from './pendingPushes';
+import { appendPositionPoint } from './positionSeries';
 import { deleteProgress, getProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
@@ -28,7 +30,14 @@ import {
   writeTelemetryDataPoints,
 } from './telemetry';
 import { getTrip, putTrip } from './trips';
-import type { BoardingLockMeta, Env, Trip } from './types';
+import type {
+  BoardingLockMeta,
+  Env,
+  PositionPoint,
+  PromptDisplay,
+  PromptGeoContext,
+  Trip,
+} from './types';
 
 /**
  * HTTP DELETE 같은 단일 trip 정리 진입점에서 LA dismissal 발사하기 위한 deps.
@@ -121,6 +130,10 @@ app.post('/trips', async (c) => {
         // #706: 연속 etaMissing 카운터는 backend-only state — 디바이스가 같은 세션으로 re-register해도
         // 누적치를 보존해야 자동 종료가 정상 동작 (re-register마다 0으로 초기화되면 무한 폴링 회귀).
         consecutiveEtaMissing: existing.consecutiveEtaMissing,
+        // #819: boarding-prompt 발사 카운터는 backend-only state — 디바이스가 같은 세션으로
+        // re-register하더라도 trip당 1회 + 5분 silence 정책을 유지해야 한다 (re-register마다
+        // reset되면 spam 회귀). promptGeoContext / promptDisplay는 incoming이 최신이라 그대로 받음.
+        boardingPromptState: existing.boardingPromptState,
       }
     : incoming;
 
@@ -208,6 +221,104 @@ app.post('/push/ack', async (c) => {
   const result = await ackPending(c.env.PENDING_PUSHES, ack.pushId, ack.token);
   return c.json({ ok: true, ...result });
 });
+
+/**
+ * 클라이언트 위치 sample 송신 (#819 Phase 1).
+ * BG/FG에서 backgroundLocationTask가 fix마다 호출. backend가 device token별 series를 KV에
+ * 누적해 cron 사이클마다 9단 boarding-prompt 게이트 평가에 사용한다.
+ *
+ * Body: { token, lat, lng, accuracy, ts, motion }
+ * Trip 존재 확인하지 않는다 — boarding-prompt가 켜지지 않은 디바이스라도 series는 보관해도 무해
+ * (TTL 1h로 자연 폐기).
+ */
+app.post('/position', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+  const payload = validatePositionPayload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  await appendPositionPoint(c.env.TRIPS, payload.token, payload.point);
+  return c.json({ ok: true });
+});
+
+interface PositionUploadPayload {
+  token: string;
+  point: PositionPoint;
+}
+
+export function validatePositionPayload(input: unknown): PositionUploadPayload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (typeof obj.lat !== 'number' || !Number.isFinite(obj.lat)) return null;
+  if (typeof obj.lng !== 'number' || !Number.isFinite(obj.lng)) return null;
+  if (typeof obj.accuracy !== 'number' || !Number.isFinite(obj.accuracy) || obj.accuracy < 0) {
+    return null;
+  }
+  if (typeof obj.ts !== 'number' || !Number.isFinite(obj.ts)) return null;
+  const motion = obj.motion;
+  if (
+    motion !== 'stationary' &&
+    motion !== 'walking' &&
+    motion !== 'automotive' &&
+    motion !== 'unknown'
+  ) {
+    return null;
+  }
+  return {
+    token: obj.token,
+    point: {
+      lat: obj.lat,
+      lng: obj.lng,
+      accuracy: obj.accuracy,
+      ts: obj.ts,
+      motion,
+    },
+  };
+}
+
+/**
+ * boarding-prompt 사용자 [미탑승]/dismiss 신호 (#819 게이트 #9).
+ * 클라이언트가 사용자 응답을 받아 호출한다. silencedUntil을 set해 5분간 재발사 차단.
+ *
+ * Body: { token }
+ * Trip 부재 시 idempotent — 200 deleted:false.
+ */
+app.post('/boarding-prompt/dismiss', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+  const payload = validateDismissPayload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const existing = await getTrip(c.env.TRIPS, payload.token);
+  if (!existing) return c.json({ ok: true, applied: false });
+
+  const updated: Trip = {
+    ...existing,
+    boardingPromptState: markPromptSilenced(existing.boardingPromptState, Date.now()),
+  };
+  await putTrip(c.env.TRIPS, updated);
+  return c.json({ ok: true, applied: true });
+});
+
+interface DismissPayload {
+  token: string;
+}
+
+export function validateDismissPayload(input: unknown): DismissPayload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  return { token: obj.token };
+}
 
 interface PushAckPayload {
   pushId: string;
@@ -405,7 +516,41 @@ export function validateTrip(input: unknown): Trip | null {
     // #816 C: 사용자 명시 opt-in 토글값. 미송신 또는 boolean 아니면 undefined (default OFF).
     locklessStationPassed:
       typeof obj.locklessStationPassed === 'boolean' ? obj.locklessStationPassed : undefined,
+    // #819: boarding-prompt 평가용 컨텍스트. 좌표/표시 명시 부재 시 백엔드는 lockMissing 분기에서
+    // 자연 skip — 좌표 없는 평가는 게이트 #4/#5 정확도 0이라 의미 없음.
+    promptGeoContext: parsePromptGeoContext(obj.promptGeoContext),
+    promptDisplay: parsePromptDisplay(obj.promptDisplay),
   };
+}
+
+function parsePromptGeoContext(raw: unknown): PromptGeoContext | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  const origin = o.origin;
+  const next = o.nextStation;
+  if (!origin || typeof origin !== 'object') return undefined;
+  if (!next || typeof next !== 'object') return undefined;
+  const oc = origin as Record<string, unknown>;
+  const nc = next as Record<string, unknown>;
+  if (typeof oc.lat !== 'number' || !Number.isFinite(oc.lat)) return undefined;
+  if (typeof oc.lng !== 'number' || !Number.isFinite(oc.lng)) return undefined;
+  if (typeof nc.lat !== 'number' || !Number.isFinite(nc.lat)) return undefined;
+  if (typeof nc.lng !== 'number' || !Number.isFinite(nc.lng)) return undefined;
+  const direction = o.direction;
+  const dir = direction === 'up' || direction === 'down' ? direction : null;
+  return {
+    origin: { lat: oc.lat, lng: oc.lng },
+    nextStation: { lat: nc.lat, lng: nc.lng },
+    direction: dir,
+  };
+}
+
+function parsePromptDisplay(raw: unknown): PromptDisplay | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.originStation !== 'string' || o.originStation.length === 0) return undefined;
+  if (typeof o.line !== 'string' || o.line.length === 0) return undefined;
+  return { originStation: o.originStation, line: o.line };
 }
 
 /**

--- a/backend/alarm-worker/src/positionSeries.ts
+++ b/backend/alarm-worker/src/positionSeries.ts
@@ -1,0 +1,228 @@
+/**
+ * 클라이언트 위치 series KV 저장 + 60s 평균속도/방향/motion 분류 (#819 Phase 1).
+ *
+ * 디바이스가 POST /position으로 보낸 단일 sample을 토큰별 ring buffer로 누적한다.
+ * 게이트 평가 시 60s 윈도우만 잘라 평균속도(accuracy ≥ 50m 제외)와 motion 최빈값을
+ * 산출한다. 노이즈가 큰 raw client.speed에 의존하지 않는 것이 핵심 정책 (#812 회귀).
+ */
+
+import type { PositionPoint } from './types';
+
+/** KV 키 prefix — device token 1개당 1 series. */
+const POSITION_SERIES_PREFIX = 'pos:';
+/** 평균속도 계산용 시간 윈도우 (ms). ADR Section 6 step 4-5: 60s. */
+export const POSITION_WINDOW_MS = 60_000;
+/** ring buffer 한 device에 저장하는 최대 좌표 수 — 60s window가 보통 6~12 sample. */
+const MAX_SERIES_POINTS = 30;
+/** KV TTL — 사용자가 1시간 미활동이면 series는 자연 폐기 (게이트 #6 reset 정책 정렬). */
+const SERIES_TTL_SEC = 60 * 60;
+/** motion 최빈값 계산용 윈도우 (최근 sample 개수). ADR Section 6 step 6. */
+const MOTION_RECENT_COUNT = 6;
+/** 게이트 #3 / 평균속도 산출에서 컷오프할 accuracy (meters). */
+export const ACCURACY_CUTOFF_M = 50;
+
+const EARTH_RADIUS_KM = 6371;
+
+function toRadians(deg: number): number {
+  return deg * (Math.PI / 180);
+}
+
+/** km 단위 거리 — haversine. backend는 client utils와 분리 빌드라 동일 식을 복제. */
+export function haversineKm(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+/**
+ * 디바이스 토큰의 위치 series를 KV에서 읽어 새 point를 append 후 저장.
+ * window를 벗어난 오래된 sample은 평가 시 잘리지만, KV에는 최대 MAX_SERIES_POINTS까지
+ * 보관해 cron 한 사이클 누락(>60s)에서도 직전 데이터를 활용할 수 있게 한다.
+ */
+export async function appendPositionPoint(
+  kv: KVNamespace,
+  token: string,
+  point: PositionPoint,
+): Promise<PositionPoint[]> {
+  const series = await readSeries(kv, token);
+  series.push(point);
+  // 오래된 쪽부터 제거 (push 후 잘림).
+  while (series.length > MAX_SERIES_POINTS) series.shift();
+  await kv.put(seriesKey(token), JSON.stringify(series), { expirationTtl: SERIES_TTL_SEC });
+  return series;
+}
+
+/** 디바이스의 현재 series를 읽는다 — 없으면 빈 배열. */
+export async function readSeries(
+  kv: KVNamespace,
+  token: string,
+): Promise<PositionPoint[]> {
+  const raw = await kv.get(seriesKey(token));
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isPositionPoint);
+  } catch {
+    return [];
+  }
+}
+
+/** 테스트/관리 — series 명시 삭제 (게이트 평가 후 1회 발사한 trip을 정리할 때 등). */
+export async function clearSeries(kv: KVNamespace, token: string): Promise<void> {
+  await kv.delete(seriesKey(token));
+}
+
+function seriesKey(token: string): string {
+  return `${POSITION_SERIES_PREFIX}${token}`;
+}
+
+function isPositionPoint(value: unknown): value is PositionPoint {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o.lat === 'number' &&
+    typeof o.lng === 'number' &&
+    typeof o.accuracy === 'number' &&
+    typeof o.ts === 'number' &&
+    (o.motion === 'stationary' ||
+      o.motion === 'walking' ||
+      o.motion === 'automotive' ||
+      o.motion === 'unknown')
+  );
+}
+
+export interface WindowedMetrics {
+  /** 시간 윈도우에 들어간 sample 개수 (raw, accuracy 컷오프 전). 게이트 #6 N≥3 평가용. */
+  count: number;
+  /** accuracy ≥ 50m 제외 후 hop 시간을 합산한 누적 거리 / 시간 평균속도 km/h. */
+  gpsAvgKmh: number;
+  /** 평균속도 산출에 사용된 sample들의 평균 accuracy meters. fusedSpeed 가중치 결정용. */
+  avgAccuracyMeters: number;
+  /** 최근 MOTION_RECENT_COUNT개 sample의 최빈 motion 분류. */
+  motion: PositionPoint['motion'];
+  /** 시작점/끝점 좌표 — 방향 cosine 계산 입력 (없으면 null, 0/1 sample 케이스). */
+  start: { lat: number; lng: number } | null;
+  /** 시작점/끝점 좌표 — 방향 cosine 계산 입력. */
+  end: { lat: number; lng: number } | null;
+}
+
+/**
+ * series에서 `[now - POSITION_WINDOW_MS, now]` 윈도우만 잘라 평균속도/방향/motion 산출.
+ *
+ * 평균속도는 인접 sample 쌍의 거리/시간 hop 평균 — accuracy ≥ 50m sample은 hop에서 빠진다.
+ * (ADR Section 6 step 5: `gpsAvgKmh = Σ haversine(points[i-1], points[i]) / Δt`)
+ *
+ * motion은 ADR Section 6 step 6 — 최근 MOTION_RECENT_COUNT(6)개 sample의 최빈값.
+ * 최빈이 동률이면 'unknown'으로 폴백해 게이트 #8을 보수적으로 차단.
+ */
+export function evaluateWindow(
+  series: readonly PositionPoint[],
+  now: number,
+): WindowedMetrics {
+  const windowed = series.filter((p) => now - p.ts <= POSITION_WINDOW_MS);
+  const start = windowed[0];
+  const end = windowed[windowed.length - 1];
+
+  let totalDistanceKm = 0;
+  let totalHopMs = 0;
+  let acceptedSampleCount = 0;
+  let totalAccuracy = 0;
+  for (let i = 1; i < windowed.length; i++) {
+    const prev = windowed[i - 1];
+    const cur = windowed[i];
+    // accuracy 50m 이상 sample은 hop에 포함하지 않음 (ADR Section 6 step 5).
+    if (prev.accuracy >= ACCURACY_CUTOFF_M || cur.accuracy >= ACCURACY_CUTOFF_M) continue;
+    const dtMs = cur.ts - prev.ts;
+    if (dtMs <= 0) continue;
+    totalDistanceKm += haversineKm(prev.lat, prev.lng, cur.lat, cur.lng);
+    totalHopMs += dtMs;
+    // 가중치 평균: 두 sample의 평균을 hop의 accuracy로 본다.
+    totalAccuracy += (prev.accuracy + cur.accuracy) / 2;
+    acceptedSampleCount += 1;
+  }
+  const gpsAvgKmh =
+    totalHopMs > 0 ? totalDistanceKm / (totalHopMs / 3_600_000) : 0;
+  const avgAccuracyMeters =
+    acceptedSampleCount > 0 ? totalAccuracy / acceptedSampleCount : Infinity;
+
+  const motion = pickMotionMode(windowed.slice(-MOTION_RECENT_COUNT));
+
+  return {
+    count: windowed.length,
+    gpsAvgKmh,
+    avgAccuracyMeters,
+    motion,
+    start: start ? { lat: start.lat, lng: start.lng } : null,
+    end: end ? { lat: end.lat, lng: end.lng } : null,
+  };
+}
+
+/**
+ * 최근 sample의 motion 최빈값. 동률 또는 빈 입력은 'unknown'으로 강등 — 게이트 #8을
+ * 보수 차단한다 (false positive 1차 정책).
+ */
+export function pickMotionMode(
+  recent: readonly PositionPoint[],
+): PositionPoint['motion'] {
+  if (recent.length === 0) return 'unknown';
+  const counts: Record<PositionPoint['motion'], number> = {
+    stationary: 0,
+    walking: 0,
+    automotive: 0,
+    unknown: 0,
+  };
+  for (const p of recent) counts[p.motion] += 1;
+  let best: PositionPoint['motion'] = 'unknown';
+  let bestCount = -1;
+  let tied = false;
+  for (const motion of ['stationary', 'walking', 'automotive', 'unknown'] as const) {
+    const c = counts[motion];
+    if (c > bestCount) {
+      best = motion;
+      bestCount = c;
+      tied = false;
+    } else if (c === bestCount && motion !== best) {
+      tied = true;
+    }
+  }
+  return tied ? 'unknown' : best;
+}
+
+/**
+ * 진행 방향 cosine — `velocity vector(start→end)` 대 `expected vector(origin→nextStation)` (게이트 #5).
+ *
+ * 길이 0(정지/동일점)은 0으로 강등해 게이트 ≥ 0.7 차단. atan2 vs degree 변환 노이즈를
+ * 피하려고 평면 근사 dot product를 직접 계산한다 — 도시 한 정거장 hop 거리에서는 충분히 정확.
+ */
+export function cosineDirection(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+  expectedFromLat: number,
+  expectedFromLng: number,
+  expectedToLat: number,
+  expectedToLng: number,
+): number {
+  const ax = toLng - fromLng;
+  const ay = toLat - fromLat;
+  const bx = expectedToLng - expectedFromLng;
+  const by = expectedToLat - expectedFromLat;
+  const magA = Math.hypot(ax, ay);
+  const magB = Math.hypot(bx, by);
+  if (magA === 0 || magB === 0) return 0;
+  return (ax * bx + ay * by) / (magA * magB);
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -4,6 +4,7 @@
 
 import { ARRIVAL_CODE, TRAIN_STATUS } from './alarm';
 import {
+  sendBoardingPromptPush,
   sendReschedulePush,
   sendSilentPush,
   type ApnsConfig,
@@ -11,12 +12,18 @@ import {
 } from './apns';
 import { flipApnsEnv, pickApnsHost } from './apnsHost';
 import {
+  evaluateBoardingPromptGates,
+  markPromptFired,
+  type GateSkipReason,
+} from './boardingPrompt';
+import {
   buildLiveActivityContentState,
   cleanupTripWithLa,
   fireLiveActivityUpdate,
   type LiveActivityStats,
 } from './liveActivity';
 import { matchLine } from './lineAlias';
+import { readSeries } from './positionSeries';
 import { getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { listTrips, putTrip } from './trips';
@@ -132,6 +139,12 @@ export interface ScheduledStats extends LiveActivityStats {
    * (lockMissing은 토글 OFF로 게이트 차단된 trip만 카운트되도록 유지 — 두 stat은 disjoint.)
    */
   locklessIntermediateFired: number;
+  /** #819 — boarding-prompt 게이트 평가가 한 번이라도 시도된 trip 수 (lockMissing 부분집합). */
+  boardingPromptEvaluated: number;
+  /** #819 — 9단 AND 게이트를 모두 통과해 alert push가 발사된 횟수 (측정 인프라). */
+  boardingPromptFired: number;
+  /** #819 — 게이트 차단으로 미발사한 횟수 — false positive 1차 방어 효과 측정. */
+  boardingPromptBlocked: number;
 }
 
 /**
@@ -174,6 +187,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     laPushSent: 0,
     laPushFailed: 0,
     laTokenCleared: 0,
+    boardingPromptEvaluated: 0,
+    boardingPromptFired: 0,
+    boardingPromptBlocked: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -226,6 +242,18 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
         locklessOptIn: trip.locklessStationPassed === true,
         waypointKind: waypoint.kind,
       });
+      // #819 — lock 미발생 trip에 boarding-prompt 9단 게이트 평가 분기. 게이트 통과 시 alert
+      // push로 "탑승 중이세요?"를 묻고, 클라이언트가 사용자 응답으로 lock을 자동 생성한다.
+      // 게이트 자체가 false positive 9중 차단 (ADR Section 2)이라 phase-based 노이즈와 분리.
+      try {
+        await evaluateAndMaybeFireBoardingPrompt(trip, env, deps, stats, now, log, generatePushId);
+      } catch (e) {
+        stats.errors += 1;
+        log('boarding-prompt: evaluation error', {
+          error: String(e),
+          token: trip.token.slice(0, 8),
+        });
+      }
       continue;
     }
 
@@ -785,4 +813,107 @@ function isUnrecoverableApnsError(status: number, _reason: string | undefined): 
  */
 function isApnsEnvMismatch(status: number, reason: string | undefined): boolean {
   return status === 400 && reason === 'BadDeviceToken';
+}
+
+/**
+ * "탑승했냐?" 푸시 평가 + 발사 (#819 B 슬라이스).
+ *
+ * lockMissing 분기에서만 호출. promptGeoContext가 없으면 skip — backend는 stations 좌표를
+ * 갖지 않으므로 평가 자체 불가. 9단 AND 게이트 평가는 evaluateBoardingPromptGates에 위임.
+ *
+ * 발사 성공:
+ *   - alert push (BOARDING_PROMPT category)로 [탑승]/[미탑승] 액션 노출
+ *   - trip.boardingPromptState = markPromptFired(now) → KV 저장 (게이트 #9 1회 정책)
+ *   - boardingPromptFired stat +1
+ *
+ * 차단:
+ *   - boardingPromptBlocked stat +1 (게이트 reason 로그)
+ *
+ * 좌표 컨텍스트 부재:
+ *   - no-op (silent skip, blocked 카운트 안 함 — 게이트 평가 안 한 것과 평가 후 차단 분리)
+ */
+export async function evaluateAndMaybeFireBoardingPrompt(
+  trip: Trip,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+  generatePushId: () => string,
+): Promise<void> {
+  const geo = trip.promptGeoContext;
+  const display = trip.promptDisplay;
+  if (!geo || !display) return;
+
+  stats.boardingPromptEvaluated += 1;
+
+  const series = await readSeries(env.TRIPS, trip.token);
+  const outcome = evaluateBoardingPromptGates({
+    series,
+    origin: geo.origin,
+    nextStation: geo.nextStation,
+    now,
+    promptState: trip.boardingPromptState,
+  });
+
+  if (!outcome.pass) {
+    stats.boardingPromptBlocked += 1;
+    log('boarding-prompt: gate blocked', {
+      token: trip.token.slice(0, 8),
+      reason: outcome.reason satisfies GateSkipReason,
+    });
+    return;
+  }
+
+  // 9단 통과 — alert push 발사.
+  const pushId = generatePushId();
+  const heal = await sendWithEnvHeal(
+    (host) =>
+      sendBoardingPromptPush({
+        deviceToken: trip.token,
+        pushId,
+        title: 'Are you on board?',
+        body: `${display.line} · ${display.originStation}`,
+        originStation: display.originStation,
+        line: display.line,
+        tripToken: trip.token,
+        sentAt: now,
+        config: deps.apnsConfig,
+        host,
+        fetchImpl: deps.fetchImpl,
+        now,
+      }),
+    trip.apnsEnv,
+    deps.apnsHosts,
+    log,
+    trip.token.slice(0, 8),
+  );
+
+  let dirty = false;
+  if (heal.correctedEnv) {
+    trip.apnsEnv = heal.correctedEnv;
+    dirty = true;
+    stats.envCorrected += 1;
+  }
+  if (heal.result.ok) {
+    stats.boardingPromptFired += 1;
+    trip.boardingPromptState = markPromptFired(now);
+    dirty = true;
+    log('boarding-prompt: fired', {
+      token: trip.token.slice(0, 8),
+      line: display.line,
+      originStation: display.originStation,
+      fusedSpeedKmh: Math.round(outcome.fusedSpeedKmh * 10) / 10,
+    });
+  } else {
+    stats.errors += 1;
+    log('boarding-prompt: push failed', {
+      token: trip.token.slice(0, 8),
+      status: heal.result.status,
+      reason: heal.result.reason,
+    });
+  }
+  if (dirty) {
+    await putTrip(env.TRIPS, trip);
+  }
 }

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -120,6 +120,37 @@ export interface Trip {
    * 노이즈 차단 책임: 사용자에게 옵트인 권한 위임. #640 회귀는 OFF가 default로 보호.
    */
   locklessStationPassed?: boolean;
+  /**
+   * boarding-prompt(#819) 발사 추적 — trip당 1회 + dismiss 5분 silence 게이트(#9).
+   * 부재 = 미발사 상태. 사용자 응답으로 lock이 생기면 자연스럽게 게이트 #2가 차단한다.
+   */
+  boardingPromptState?: BoardingPromptState;
+  /**
+   * boarding-prompt 평가용 출발역/다음역 좌표 (#819 게이트 #4/#5).
+   * backend는 stations.json을 갖지 않으므로 클라이언트가 trip 등록 시 함께 보낸다.
+   * 부재 시 boarding-prompt 평가 자체를 skip — 좌표 없는 lockMissing trip은 silent.
+   */
+  promptGeoContext?: PromptGeoContext;
+  /**
+   * boarding-prompt에 노출할 사용자 표시명 (#819).
+   * `originStation`: lock의 boardingStationId가 아닌 실제 역 이름 (Notification body 빌드).
+   * `line`: trip 출발 라인 (lock 생성 시 boardingLine으로 그대로 사용).
+   */
+  promptDisplay?: PromptDisplay;
+}
+
+/** boarding-prompt 게이트 평가용 출발역/다음역 좌표. */
+export interface PromptGeoContext {
+  origin: { lat: number; lng: number };
+  nextStation: { lat: number; lng: number };
+  /** 방향 게이트(#5)에서 어느 방향으로 가야 하는지 — Seoul API의 isUp과 정합. */
+  direction: 'up' | 'down' | null;
+}
+
+/** boarding-prompt 사용자 표시 컨텍스트. */
+export interface PromptDisplay {
+  originStation: string;
+  line: string;
 }
 
 /** Device가 확정한 탑승 열차 정보 (#584). */
@@ -154,6 +185,53 @@ export interface ReschedulePushPayload {
 
 /** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */
 export type ApnsEnv = 'sandbox' | 'production';
+
+/**
+ * 클라이언트가 송신한 단일 위치 샘플 (#819 Phase 1 fusion).
+ * KV 시리즈에 60s window로 누적되며 게이트 #3~#7 평가에 사용된다.
+ */
+export interface PositionPoint {
+  /** 위도 (degrees, WGS84) */
+  lat: number;
+  /** 경도 (degrees, WGS84) */
+  lng: number;
+  /** GPS accuracy meters — `>= 50m`는 평균속도 계산에서 제외 (게이트 #3 정책). */
+  accuracy: number;
+  /** epoch ms — 디바이스에서 측정한 시각 (시계 drift는 평균속도가 자가 보정). */
+  ts: number;
+  /** CMMotionActivity 분류 — graceful: 미지원/권한 거절 시 'unknown'. */
+  motion: 'stationary' | 'walking' | 'automotive' | 'unknown';
+}
+
+/**
+ * trip 단위 boarding-prompt 발사 상태 (#819 게이트 #9).
+ * 같은 trip에 1회 + 사용자 dismiss/미탑승 후 5분 silence 정책.
+ */
+export interface BoardingPromptState {
+  /** 마지막 발사 시각 (epoch ms). */
+  lastFiredAt?: number;
+  /** 사용자가 dismiss/미탑승으로 silence 요청한 시각 (epoch ms). */
+  silencedUntil?: number;
+  /** 이 trip에 이미 발사 후 사용자 응답을 받았는지 — 한 trip 1회 정책. */
+  fired?: boolean;
+}
+
+/**
+ * boarding-prompt push payload (#819 B 슬라이스).
+ * BOARDING_PROMPT iOS category 액션 [탑승]/[미탑승]을 함께 노출하기 위해
+ * alert + category로 발사한다 (silent 아님).
+ */
+export interface BoardingPromptPushPayload {
+  pushId: string;
+  kind: 'boarding-prompt';
+  /** 사용자 출발역 (lock 생성 시 boardingStation으로 사용). */
+  originStation: string;
+  /** 출발 노선 (lock 생성 시 boardingLine으로 사용). */
+  line: string;
+  /** trip 토큰 — 푸시 응답 시점에 trip 컨텍스트 복원용. */
+  tripToken: string;
+  sentAt: number;
+}
 
 /**
  * Cloudflare Analytics Engine writer. Minimal surface — Worker types에 의존하지 않게 별도 선언.

--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -496,4 +496,57 @@ describe('alarmBackend', () => {
       expect(result).toEqual({ ok: false });
     });
   });
+
+  describe('promptGeoContext / promptDisplay (#819)', () => {
+    const PROMPT_PAYLOAD: RegisterTripPayload = {
+      ...SAMPLE_PAYLOAD,
+      promptGeoContext: {
+        origin: { lat: 37.5, lng: 127 },
+        nextStation: { lat: 37.51, lng: 127.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+    };
+
+    beforeEach(() => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    });
+
+    it('promptGeoContext + promptDisplay body에 포함', async () => {
+      await registerActiveTrip(PROMPT_PAYLOAD);
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.promptGeoContext).toEqual({
+        origin: { lat: 37.5, lng: 127 },
+        nextStation: { lat: 37.51, lng: 127.01 },
+        direction: 'up',
+      });
+      expect(body.promptDisplay).toEqual({ originStation: '강남', line: '2' });
+    });
+
+    it('promptDisplay만 다르면 dedup 깨고 재등록', async () => {
+      await registerActiveTrip(PROMPT_PAYLOAD);
+      const changed = await registerActiveTrip({
+        ...PROMPT_PAYLOAD,
+        promptDisplay: { originStation: '강남', line: '신분당' },
+      });
+      expect(changed.ok).toBe(true);
+      expect(changed.skipped).toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('promptGeoContext 좌표 jitter는 dedup 유지 (hash에 미포함)', async () => {
+      await registerActiveTrip(PROMPT_PAYLOAD);
+      const jitter = await registerActiveTrip({
+        ...PROMPT_PAYLOAD,
+        promptGeoContext: {
+          origin: { lat: 37.5001, lng: 127.0001 },
+          nextStation: { lat: 37.5101, lng: 127.0101 },
+          direction: 'up',
+        },
+      });
+      expect(jitter.skipped).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/api/__tests__/positionUpload.test.ts
+++ b/src/api/__tests__/positionUpload.test.ts
@@ -1,0 +1,153 @@
+import { dismissBoardingPrompt, uploadPosition } from '../positionUpload';
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('uploadPosition (#819)', () => {
+  it('URL 미설정 시 skipped=true — fetch 미호출', async () => {
+    const r = await uploadPosition({
+      token: 't',
+      lat: 1,
+      lng: 2,
+      accuracy: 5,
+      ts: 0,
+      motion: 'walking',
+    });
+    expect(r).toEqual({ ok: false, skipped: true });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('정상 응답 → ok=true + payload 직렬화', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    const r = await uploadPosition({
+      token: 'tok',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 1234,
+      motion: 'automotive',
+    });
+    expect(r).toEqual({ ok: true, status: 200 });
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test.dev/position');
+    expect(JSON.parse(init.body)).toEqual({
+      token: 'tok',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 1234,
+      motion: 'automotive',
+    });
+  });
+
+  it('non-OK status → ok=false + status', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 } as Response);
+    const r = await uploadPosition({
+      token: 'tok',
+      lat: 0,
+      lng: 0,
+      accuracy: 0,
+      ts: 0,
+      motion: 'unknown',
+    });
+    expect(r).toEqual({ ok: false, status: 500 });
+  });
+
+  it('fetch throw → ok=false (graceful)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+    const r = await uploadPosition({
+      token: 'tok',
+      lat: 0,
+      lng: 0,
+      accuracy: 0,
+      ts: 0,
+      motion: 'unknown',
+    });
+    expect(r).toEqual({ ok: false });
+  });
+
+  it('5s 후 timeout abort — controller.abort 콜백 호출됨', async () => {
+    // fetch가 abort signal을 받기까지 timer를 advance. setTimeout 콜백이 실행돼야
+    // controller.abort()가 호출됨 (함수 커버리지 확보).
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    jest.useFakeTimers();
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          (init as RequestInit).signal?.addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          );
+        }),
+    );
+    const promise = uploadPosition({
+      token: 'tok',
+      lat: 0,
+      lng: 0,
+      accuracy: 0,
+      ts: 0,
+      motion: 'unknown',
+    });
+    jest.advanceTimersByTime(6000);
+    const r = await promise;
+    expect(r).toEqual({ ok: false });
+    jest.useRealTimers();
+  });
+});
+
+describe('dismissBoardingPrompt (#819)', () => {
+  it('URL 미설정 → skipped', async () => {
+    const r = await dismissBoardingPrompt('tok');
+    expect(r.skipped).toBe(true);
+  });
+
+  it('빈 token → ok:false 즉시 반환 (fetch 미호출)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    const r = await dismissBoardingPrompt('');
+    expect(r).toEqual({ ok: false });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('정상 응답 → ok=true', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    const r = await dismissBoardingPrompt('tok');
+    expect(r).toEqual({ ok: true, status: 200 });
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test.dev/boarding-prompt/dismiss');
+    expect(JSON.parse(init.body)).toEqual({ token: 'tok' });
+  });
+
+  it('non-OK status → ok=false + status', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 } as Response);
+    const r = await dismissBoardingPrompt('tok');
+    expect(r).toEqual({ ok: false, status: 404 });
+  });
+
+  it('fetch throw → ok=false', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+    const r = await dismissBoardingPrompt('tok');
+    expect(r).toEqual({ ok: false });
+  });
+});

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -70,6 +70,24 @@ export interface RegisterTripPayload {
    * default OFF로 해석. dedup hash에는 반드시 포함해 토글 변경이 즉시 재등록되도록 한다.
    */
   locklessStationPassed?: boolean;
+  /**
+   * #819 — boarding-prompt 9단 게이트 평가에 필요한 출발역/다음역 좌표.
+   * lockMissing trip에 대해 backend가 평가 — 좌표 부재 시 backend는 자동 skip.
+   */
+  promptGeoContext?: {
+    origin: { lat: number; lng: number };
+    nextStation: { lat: number; lng: number };
+    /** 출발역에서 trip 방향 (Seoul API의 isUp과 정합). 모르면 null — 양방향 허용. */
+    direction: 'up' | 'down' | null;
+  };
+  /**
+   * #819 — boarding-prompt push 본문에 노출할 출발역/노선 표시명.
+   * 좌표(promptGeoContext)와 짝으로 보내야 backend가 평가 결과 push를 빌드할 수 있다.
+   */
+  promptDisplay?: {
+    originStation: string;
+    line: string;
+  };
 }
 
 export interface AlarmBackendResult {
@@ -123,6 +141,7 @@ function buildRegisterHash(body: {
   apnsEnv: ApnsEnv;
   boardingLock?: AlarmBoardingLock;
   locklessStationPassed?: boolean;
+  promptDisplay?: { originStation: string; line: string };
 }): string {
   return JSON.stringify({
     token: body.token,
@@ -139,6 +158,12 @@ function buildRegisterHash(body: {
     // #816 C — 토글 변경 즉시 backend로 전달되도록 dedup key에 포함.
     // undefined와 false를 다르게 다루지 않는다 — 둘 다 OFF 동일 효과.
     locklessStationPassed: body.locklessStationPassed === true,
+    // #819 — promptDisplay(출발역/라인)가 바뀌면 backend가 보내는 push 본문이 달라지므로 dedup 키 일부.
+    // 좌표(promptGeoContext)는 GPS jitter로 매번 약간씩 흔들리므로 hash에 안 넣어 폭주 방지 — backend가
+    // 게이트 평가 시점에 KV series로 자체 계산하니 영향 없음.
+    promptDisplayKey: body.promptDisplay
+      ? `${body.promptDisplay.originStation}|${body.promptDisplay.line}`
+      : null,
   });
 }
 
@@ -184,6 +209,9 @@ async function performRegisterFetch(
     ...(payload.boardingLock ? { boardingLock: payload.boardingLock } : {}),
     // #816 C — 토글 ON일 때만 송신. OFF/미설정은 필드 자체를 누락해 기존 trip schema 호환.
     ...(payload.locklessStationPassed === true ? { locklessStationPassed: true } : {}),
+    // #819 — boarding-prompt 평가 컨텍스트. 좌표/표시 둘 중 하나라도 없으면 backend는 자동 skip.
+    ...(payload.promptGeoContext ? { promptGeoContext: payload.promptGeoContext } : {}),
+    ...(payload.promptDisplay ? { promptDisplay: payload.promptDisplay } : {}),
   };
 
   try {
@@ -230,6 +258,7 @@ export function registerActiveTrip(
     apnsEnv: payload.apnsEnv,
     boardingLock: payload.boardingLock,
     locklessStationPassed: payload.locklessStationPassed,
+    promptDisplay: payload.promptDisplay,
   });
   if (hash === lastRegisteredHash) {
     return Promise.resolve({ ok: true, skipped: true });

--- a/src/api/positionUpload.ts
+++ b/src/api/positionUpload.ts
@@ -1,0 +1,108 @@
+/**
+ * #819 — backend로 GPS 좌표 + Motion 송신.
+ *
+ * 디바이스가 BG/FG location task에서 fix마다 호출. backend가 device token별 series를 KV에
+ * 축적해 cron 사이클마다 9단 boarding-prompt 게이트(ADR Section 2)에 사용한다.
+ *
+ * iOS `client.speed`는 -1/빈 값으로 자주 떨어지는 것이 #812 회귀의 직접 원인 — backend가 좌표
+ * series로 평균 속도를 자체 계산하는 것이 정책 (ADR Section 6 step 5).
+ *
+ * 백엔드 URL 미설정/네트워크 실패는 throw 없이 graceful `{ ok:false, skipped:true }` — Phase 0
+ * baseline(사전 예약만)은 그대로 동작한다.
+ */
+
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('positionUpload');
+
+export type PositionMotion = 'stationary' | 'walking' | 'automotive' | 'unknown';
+
+export interface PositionUploadPayload {
+  /** APNs device token (hex) — backend가 같은 키로 series 적재. */
+  token: string;
+  lat: number;
+  lng: number;
+  /** GPS accuracy meters. backend가 ≥ 50m sample은 hop 계산에서 제외. */
+  accuracy: number;
+  /** epoch ms — 디바이스 측정 시각. backend 시계와의 drift는 평균속도가 자체 보정. */
+  ts: number;
+  motion: PositionMotion;
+}
+
+export interface PositionUploadResult {
+  ok: boolean;
+  skipped?: boolean;
+  status?: number;
+}
+
+/** fetch 타임아웃 — BG task는 OS suspend 임박이라 짧게 유지. */
+const REQUEST_TIMEOUT_MS = 5000;
+
+function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function uploadPosition(
+  payload: PositionUploadPayload,
+): Promise<PositionUploadResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip position upload');
+    return { ok: false, skipped: true };
+  }
+  try {
+    const res = await fetchWithTimeout(`${base}/position`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      log.warn(`position upload failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('position upload error', e);
+    return { ok: false };
+  }
+}
+
+/**
+ * boarding-prompt 사용자 [미탑승]/dismiss 통보 (#819 게이트 #9).
+ * backend가 trip.boardingPromptState.silencedUntil를 5분 후로 set해 재발사 차단.
+ */
+export async function dismissBoardingPrompt(token: string): Promise<PositionUploadResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip boarding-prompt dismiss');
+    return { ok: false, skipped: true };
+  }
+  if (!token) return { ok: false };
+  try {
+    const res = await fetchWithTimeout(`${base}/boarding-prompt/dismiss`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    if (!res.ok) {
+      log.warn(`dismiss failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('dismiss error', e);
+    return { ok: false };
+  }
+}

--- a/src/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -1,0 +1,347 @@
+import * as Notifications from 'expo-notifications';
+import {
+  extractBoardingPromptPayload,
+  handleResponse,
+  useBoardingPromptResponder,
+} from '../useBoardingPromptResponder';
+import {
+  BOARDING_PROMPT_ACTION_BOARDED,
+  BOARDING_PROMPT_ACTION_NOT_BOARDED,
+} from '../../utils/notificationCategory';
+import * as positionUpload from '../../api/positionUpload';
+import { renderHook } from '@testing-library/react-native';
+import type { StationArrival } from '../../api/arrivalApi';
+
+jest.mock('expo-notifications', () => ({
+  addNotificationResponseReceivedListener: jest.fn(),
+  DEFAULT_ACTION_IDENTIFIER: '$default',
+}));
+jest.mock('../../api/positionUpload', () => ({
+  dismissBoardingPrompt: jest.fn(),
+}));
+jest.mock('../../utils/stationLookup', () => ({
+  findStationByNameAndLine: jest.fn(),
+}));
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+// useBoardingLockStore mock — createLock 호출 검증용. jest.mock는 호이스팅되므로 모듈 내부 변수
+// 직접 참조 금지 — `mock` prefix 가진 변수만 허용. 외부 캡처 변수 대신 jest.fn()을 mock 내부에서
+// 만들고, 테스트는 requireMock으로 접근한다.
+jest.mock('../../store/useBoardingLockStore', () => {
+  const mockCreateLock = jest.fn();
+  return {
+    useBoardingLockStore: Object.assign(
+      (selector: (state: { createLock: jest.Mock }) => unknown) =>
+        selector({ createLock: mockCreateLock }),
+      {
+        getState: () => ({ createLock: mockCreateLock }),
+      },
+    ),
+    __mockCreateLock: mockCreateLock,
+  };
+});
+
+const { findStationByNameAndLine } = jest.requireMock('../../utils/stationLookup');
+const { __mockCreateLock: createLockMock } = jest.requireMock(
+  '../../store/useBoardingLockStore',
+);
+
+function makeArrival(overrides: Partial<StationArrival['up'][number]> = {}): StationArrival {
+  return {
+    up: [
+      {
+        destination: '',
+        arrivalMinutes: 1,
+        arrivalSeconds: 60,
+        statusMessage: '',
+        trainCode: 'T1',
+        line: '2',
+        receivedAtMs: 0,
+        arrivalCode: 2,
+        isLastTrain: false,
+        trainType: 'normal',
+        ...overrides,
+      },
+    ],
+    down: [],
+  };
+}
+
+describe('extractBoardingPromptPayload', () => {
+  it('valid payload → 보존', () => {
+    expect(
+      extractBoardingPromptPayload({
+        kind: 'boarding-prompt',
+        originStation: '강남',
+        line: '2',
+        tripToken: 'tok',
+      }),
+    ).toEqual({
+      kind: 'boarding-prompt',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok',
+    });
+  });
+
+  it.each([
+    ['null', null],
+    ['string', 'oops'],
+    ['kind 다른 값', { kind: 'reschedule', originStation: 'S', line: 'L', tripToken: 'T' }],
+    ['originStation 누락', { kind: 'boarding-prompt', line: 'L', tripToken: 'T' }],
+    ['originStation 빈 문자열', { kind: 'boarding-prompt', originStation: '', line: 'L', tripToken: 'T' }],
+    ['line 누락', { kind: 'boarding-prompt', originStation: 'S', tripToken: 'T' }],
+    ['line 빈 문자열', { kind: 'boarding-prompt', originStation: 'S', line: '', tripToken: 'T' }],
+    ['tripToken 누락', { kind: 'boarding-prompt', originStation: 'S', line: 'L' }],
+    ['tripToken 빈 문자열', { kind: 'boarding-prompt', originStation: 'S', line: 'L', tripToken: '' }],
+  ])('invalid payload — %s → null', (_label, input) => {
+    expect(extractBoardingPromptPayload(input)).toBeNull();
+  });
+});
+
+describe('handleResponse — boarding-prompt 분기 (#819)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const PAYLOAD = {
+    kind: 'boarding-prompt' as const,
+    originStation: '강남',
+    line: '2',
+    tripToken: 'tok',
+  };
+
+  function makeDeps(overrides: Partial<Parameters<typeof handleResponse>[2]> = {}) {
+    return {
+      fetchArrivalsForStation: jest.fn(async () => makeArrival()),
+      destinationId: 'dst',
+      expectedDurationMs: 600_000,
+      createLock: createLockMock,
+      ...overrides,
+    };
+  }
+
+  it('[탑승] 액션 + 후보 명확 + station 매칭 → createLock 호출', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    const deps = makeDeps();
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(deps.fetchArrivalsForStation).toHaveBeenCalledWith('강남');
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationId: 'dst',
+        trainCode: 'T1',
+        boardingStationId: 'S1',
+        boardingLine: '2',
+        expectedDurationMs: 600_000,
+      }),
+    );
+    expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
+  });
+
+  it('기본 탭 ($default) → boarded 분기와 동일 처리', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    const deps = makeDeps();
+    await handleResponse(Notifications.DEFAULT_ACTION_IDENTIFIER, PAYLOAD, deps);
+    expect(createLockMock).toHaveBeenCalled();
+  });
+
+  it('[미탑승] 액션 → dismissBoardingPrompt 호출 (lock 미생성)', async () => {
+    const deps = makeDeps();
+    await handleResponse(BOARDING_PROMPT_ACTION_NOT_BOARDED, PAYLOAD, deps);
+    expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok');
+    expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  it('dismiss(불명 액션) → dismissBoardingPrompt', async () => {
+    const deps = makeDeps();
+    await handleResponse('SOME_OTHER_ACTION', PAYLOAD, deps);
+    expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok');
+  });
+
+  it('destinationId null → dismiss POST만 발사 (lock 시도 안 함)', async () => {
+    const deps = makeDeps({ destinationId: null });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(deps.fetchArrivalsForStation).not.toHaveBeenCalled();
+    expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok');
+    expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  it('arrivals null → fallback to manual (createLock/dismiss 없음)', async () => {
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+    expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
+  });
+
+  it('ambiguity (같은 priority 후보 2+) → manual fallback, lock 안 함', async () => {
+    const arrival: StationArrival = {
+      up: [
+        {
+          destination: '',
+          arrivalMinutes: 1,
+          arrivalSeconds: 60,
+          statusMessage: '',
+          trainCode: 'T1',
+          line: '2',
+          receivedAtMs: 0,
+          arrivalCode: 2,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+        {
+          destination: '',
+          arrivalMinutes: 2,
+          arrivalSeconds: 120,
+          statusMessage: '',
+          trainCode: 'T2',
+          line: '2',
+          receivedAtMs: 0,
+          arrivalCode: 2,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+      ],
+      down: [],
+    };
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  it('station lookup 실패 → manual fallback (createLock 안 함)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue(null);
+    const deps = makeDeps();
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  it('arrivalSeconds <= 0인 후보는 필터됨 (지나간 열차 lock 차단)', async () => {
+    const arrival: StationArrival = {
+      up: [
+        {
+          destination: '',
+          arrivalMinutes: 0,
+          arrivalSeconds: 0,
+          statusMessage: '',
+          trainCode: 'T-old',
+          line: '2',
+          receivedAtMs: 0,
+          arrivalCode: 2,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+      ],
+      down: [],
+    };
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  it('line 불일치 후보는 필터됨', async () => {
+    const arrival: StationArrival = {
+      up: [
+        {
+          destination: '',
+          arrivalMinutes: 1,
+          arrivalSeconds: 60,
+          statusMessage: '',
+          trainCode: 'T1',
+          line: '9',
+          receivedAtMs: 0,
+          arrivalCode: 2,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+      ],
+      down: [],
+    };
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('useBoardingPromptResponder hook wiring', () => {
+  let registeredHandler: ((response: any) => void) | null = null;
+  const subscriptionRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registeredHandler = null;
+    (Notifications.addNotificationResponseReceivedListener as jest.Mock).mockImplementation(
+      (handler) => {
+        registeredHandler = handler;
+        return { remove: subscriptionRemove };
+      },
+    );
+  });
+
+  it('listener 등록 후 boarding-prompt payload 수신 시 handleResponse 분기 진입', () => {
+    const fetchArrivalsForStation = jest.fn(async () => makeArrival());
+    renderHook(() =>
+      useBoardingPromptResponder({
+        fetchArrivalsForStation,
+        destinationId: 'dst',
+        expectedDurationMs: 600_000,
+      }),
+    );
+    expect(Notifications.addNotificationResponseReceivedListener).toHaveBeenCalledTimes(1);
+    expect(registeredHandler).not.toBeNull();
+
+    // boarding-prompt 아닌 payload — 무시
+    registeredHandler!({
+      actionIdentifier: BOARDING_PROMPT_ACTION_BOARDED,
+      notification: { request: { content: { data: { kind: 'reschedule' } } } },
+    });
+    expect(fetchArrivalsForStation).not.toHaveBeenCalled();
+  });
+
+  it('unmount 시 subscription remove', () => {
+    const { unmount } = renderHook(() =>
+      useBoardingPromptResponder({
+        fetchArrivalsForStation: jest.fn(),
+        destinationId: 'dst',
+        expectedDurationMs: 600_000,
+      }),
+    );
+    unmount();
+    expect(subscriptionRemove).toHaveBeenCalled();
+  });
+
+  it('valid payload 수신 시 handleResponse 발화 (createLock 또는 dismiss)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    renderHook(() =>
+      useBoardingPromptResponder({
+        fetchArrivalsForStation: async () => makeArrival(),
+        destinationId: 'dst',
+        expectedDurationMs: 600_000,
+      }),
+    );
+    await registeredHandler!({
+      actionIdentifier: BOARDING_PROMPT_ACTION_BOARDED,
+      notification: {
+        request: {
+          content: {
+            data: {
+              kind: 'boarding-prompt',
+              originStation: '강남',
+              line: '2',
+              tripToken: 'tok',
+            },
+          },
+        },
+      },
+    });
+    // hook의 비동기 handleResponse 처리 후 검증
+    await new Promise((r) => setTimeout(r, 0));
+    expect(createLockMock).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useBoardingPromptResponder.ts
+++ b/src/hooks/useBoardingPromptResponder.ts
@@ -1,0 +1,165 @@
+/**
+ * #819 — "탑승했냐?" 푸시 응답 핸들러.
+ *
+ * iOS UNNotificationCategory "BOARDING_PROMPT"의 액션 [탑승]/[미탑승] 또는 기본 탭을 받아
+ * 분기 처리:
+ *
+ *   - [탑승] 액션: payload.originStation/line 컨텍스트로 Seoul API 도착 정보를 즉시 fetch →
+ *     line + 방향 매칭 후보 → arvlCd 우선순위로 trainCode 자동 선택 → `createLock`.
+ *     ambiguity → 자동 lock 안 함 (manual BoardingTrainList fallback).
+ *
+ *   - [미탑승] 액션 / dismiss: backend `POST /boarding-prompt/dismiss` → 5분 silence.
+ *
+ * `Notifications.addNotificationResponseReceivedListener`는 단일 listener라 app/_layout의
+ * 진동 정지 listener와 겹치지만, expo-notifications는 multi-listener를 허용한다 (FlatList 식).
+ */
+
+import { useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
+import type { ArrivalInfo, StationArrival } from '../api/arrivalApi';
+import { dismissBoardingPrompt } from '../api/positionUpload';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
+import {
+  BOARDING_PROMPT_ACTION_BOARDED,
+  BOARDING_PROMPT_ACTION_NOT_BOARDED,
+} from '../utils/notificationCategory';
+import { findStationByNameAndLine } from '../utils/stationLookup';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('boardingPromptResponder');
+
+/**
+ * 백엔드 payload는 backend `BoardingPromptPushPayload`와 동일 schema (kind/originStation/line/tripToken).
+ * Notification data 위치는 iOS에서 `notification.request.trigger.payload.data` 또는
+ * `notification.request.content.data` 양쪽에 등장 — both를 시도해 graceful fallback.
+ */
+export interface BoardingPromptPayload {
+  kind: 'boarding-prompt';
+  originStation: string;
+  line: string;
+  tripToken: string;
+}
+
+export function extractBoardingPromptPayload(
+  raw: unknown,
+): BoardingPromptPayload | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (o.kind !== 'boarding-prompt') return null;
+  if (typeof o.originStation !== 'string' || o.originStation.length === 0) return null;
+  if (typeof o.line !== 'string' || o.line.length === 0) return null;
+  if (typeof o.tripToken !== 'string' || o.tripToken.length === 0) return null;
+  return {
+    kind: 'boarding-prompt',
+    originStation: o.originStation,
+    line: o.line,
+    tripToken: o.tripToken,
+  };
+}
+
+export interface UseBoardingPromptResponderDeps {
+  /** Seoul API 도착 fetch — caller가 line + station으로 호출 가능한 함수 주입. */
+  fetchArrivalsForStation: (stationName: string) => Promise<StationArrival | null>;
+  /** trip의 destinationId — lock 생성 시 필요 (현재 사용자 trip 컨텍스트). */
+  destinationId: string | null;
+  /** 사용자 trip의 expectedDurationMs — lock expiry 계산. null이면 fallback 30분. */
+  expectedDurationMs: number;
+}
+
+/**
+ * 응답 listener wiring + 분기 처리.
+ *
+ * destinationId가 null이면 lock 생성 불가 — 사용자가 trip을 이미 종료한 후 푸시를 늦게 탭한 케이스.
+ * 그 경우 dismiss POST만 발사하고 lock 시도는 silent skip.
+ */
+export function useBoardingPromptResponder(deps: UseBoardingPromptResponderDeps): void {
+  const createLock = useBoardingLockStore((s) => s.createLock);
+
+  useEffect(() => {
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      const payload = extractBoardingPromptPayload(
+        response.notification.request.content.data,
+      );
+      if (!payload) return;
+      void handleResponse(response.actionIdentifier, payload, {
+        ...deps,
+        createLock,
+      });
+    });
+    return () => sub.remove();
+  }, [createLock, deps]);
+}
+
+interface HandleDeps extends UseBoardingPromptResponderDeps {
+  createLock: ReturnType<typeof useBoardingLockStore.getState>['createLock'];
+}
+
+/**
+ * actionIdentifier 분기 — pure 함수로 export해 테스트에서 직접 호출 가능.
+ *
+ *   - `BOARDING_PROMPT_ACTION_BOARDED`: 자동 lock 시도
+ *   - `BOARDING_PROMPT_ACTION_NOT_BOARDED`: silence POST
+ *   - `Notifications.DEFAULT_ACTION_IDENTIFIER` (= '$default'): 사용자가 알림 자체 탭 — 자동 lock 시도 (탭 = 긍정 의도)
+ *   - 그 외 (dismiss 등): silence POST
+ */
+export async function handleResponse(
+  actionIdentifier: string,
+  payload: BoardingPromptPayload,
+  deps: HandleDeps,
+): Promise<void> {
+  if (
+    actionIdentifier === BOARDING_PROMPT_ACTION_BOARDED ||
+    actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER
+  ) {
+    await tryAutoLock(payload, deps);
+    return;
+  }
+  // [미탑승] 또는 dismiss — 5분 silence.
+  await dismissBoardingPrompt(payload.tripToken);
+}
+
+async function tryAutoLock(
+  payload: BoardingPromptPayload,
+  deps: HandleDeps,
+): Promise<void> {
+  if (!deps.destinationId) {
+    // trip이 이미 끝남 — lock 시도 안 함, dismiss로 backend silence.
+    await dismissBoardingPrompt(payload.tripToken);
+    return;
+  }
+
+  const arrival = await deps.fetchArrivalsForStation(payload.originStation);
+  if (!arrival) {
+    log.info('arrivals fetch returned null — falling back to manual');
+    return;
+  }
+
+  // 같은 line 후보만 추림 (BoardingLockController.directionalArrivals 정책 — 방향은 푸시 시점
+  // 알 수 없으므로 양방향 허용, 노선 매칭은 client.line 일치로). arvlCd 우선순위는
+  // pickAutoTrainCodeFromArrivals에서 처리.
+  const sameLine = ([] as ArrivalInfo[])
+    .concat(arrival.up, arrival.down)
+    .filter((a) => a.line === payload.line && a.arrivalSeconds > 0);
+  const chosen = pickAutoTrainCodeFromArrivals(sameLine);
+  if (!chosen) {
+    log.info('ambiguity or empty — auto lock skipped');
+    return;
+  }
+
+  // boardingStationId — payload.originStation/line으로 정확 매칭. 매칭 실패는 manual fallback.
+  const station = findStationByNameAndLine(payload.originStation, chosen.line);
+  if (!station) {
+    log.info('station lookup failed — auto lock skipped');
+    return;
+  }
+
+  await deps.createLock({
+    destinationId: deps.destinationId,
+    trainCode: chosen.trainCode,
+    boardingStationId: station.id,
+    boardingLine: chosen.line,
+    boardedAt: Date.now(),
+    expectedDurationMs: deps.expectedDurationMs,
+  });
+}

--- a/src/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/tasks/__tests__/backgroundLocationTask.test.ts
@@ -46,6 +46,18 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedGate: (...args: unknown[]) => mockLogSuppressedGate(...args),
 }));
 
+// ── positionUpload 모킹 (#819) ──
+const mockUploadPosition = jest.fn();
+jest.mock('../../api/positionUpload', () => ({
+  uploadPosition: (...args: unknown[]) => mockUploadPosition(...args),
+}));
+
+// ── motionActivity 모킹 (#819 stationary 분류) ──
+const mockGetCurrentMotionStationary = jest.fn();
+jest.mock('../../utils/motionActivity', () => ({
+  getCurrentMotionStationary: () => mockGetCurrentMotionStationary(),
+}));
+
 // ── logger 모킹 ──
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
@@ -147,6 +159,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockGetFiredAlarms.mockResolvedValue(new Set());
     mockSetFiredAlarms.mockResolvedValue(undefined);
     mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockUploadPosition.mockResolvedValue({ ok: true, status: 200 });
+    mockGetCurrentMotionStationary.mockReturnValue(false);
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -719,5 +733,87 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
     const setItemCalls = (AsyncStorage.setItem as jest.Mock).mock.calls;
     expect(setItemCalls.every(([key]) => key !== 'subway-now:bg-last-station')).toBe(true);
+  });
+
+  describe('#819 — backend로 position + motion 송신', () => {
+    /**
+     * mockStorageValues 4번 chain 후 task code는 readBgLastFix(`getItem(BG_LAST_FIX_KEY)`)를 한 번,
+     * 그 다음 `getItem(APNS_TOKEN_KEY)`를 한 번 호출한다. 따라서 5번째에 null(=fresh fix, 점프 검사
+     * 통과), 6번째에 token을 chain한다. 안 그러면 APNS_TOKEN_KEY 자리에 BG_LAST_FIX 값이 들어가
+     * uploadPosition 호출 안 됨.
+     */
+    function stubApnsTokenAfterStorage(token: string | null): void {
+      (AsyncStorage.getItem as jest.Mock)
+        .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY — prevFix 없음
+        .mockResolvedValueOnce(token); // APNS_TOKEN_KEY
+    }
+
+    it('APNs token 있고 motion stationary=false → uploadPosition(unknown) 호출', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+      mockGetCurrentMotionStationary.mockReturnValue(false);
+
+      const fixTs = Date.now();
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      loc.timestamp = fixTs;
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockUploadPosition).toHaveBeenCalledWith({
+        token: 'apns-tok-1',
+        lat: 37.498,
+        lng: 127.028,
+        accuracy: 10,
+        ts: fixTs,
+        motion: 'unknown',
+      });
+    });
+
+    it('motion stationary=true → motion=stationary로 송신', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+      mockGetCurrentMotionStationary.mockReturnValue(true);
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      const call = mockUploadPosition.mock.calls[0]?.[0];
+      expect(call?.motion).toBe('stationary');
+    });
+
+    it('APNs token 부재 → uploadPosition 미호출 (graceful)', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage(null);
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockUploadPosition).not.toHaveBeenCalled();
+    });
+
+    it('AsyncStorage.getItem(APNS_TOKEN_KEY) throw → 무시하고 uploadPosition 미호출', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      // 5번째 call: BG_LAST_FIX_KEY null, 6번째 call: APNS_TOKEN_KEY에서 throw
+      (AsyncStorage.getItem as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockRejectedValueOnce(new Error('boom'));
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockUploadPosition).not.toHaveBeenCalled();
+    });
+
+    it('accuracy null fix는 isAccuracyAcceptable 통과 후 송신 시 0으로 강등', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+
+      // isAccuracyAcceptable(null)=true → gate 통과 → uploadPosition 분기 진입 → `accuracy ?? 0`로 0.
+      const loc = makeLocation(37.498, 127.028, { accuracy: null });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockUploadPosition).toHaveBeenCalledWith(
+        expect.objectContaining({ accuracy: 0 }),
+      );
+    });
   });
 });

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -4,11 +4,13 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from '../utils/stationPipeline';
 import { alarmKey } from '../utils/stationAlarm';
 import { createLogger } from '../utils/logger';
-import { DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
+import { APNS_TOKEN_KEY, DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../constants/storageKeys';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { isAccuracyAcceptable, isLocationFresh, isPlausibleJump, type FixSample } from '../utils/locationGates';
 import { logSuppressedGate } from '../utils/alarmLog';
 import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY } from '../constants/storageKeys';
+import { uploadPosition, type PositionMotion } from '../api/positionUpload';
+import { getCurrentMotionStationary } from '../utils/motionActivity';
 import type { Route } from '../utils/stationRoute';
 import type { Station } from '../types/station';
 
@@ -110,6 +112,25 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       return;
     }
     await AsyncStorage.setItem(BG_LAST_FIX_KEY, JSON.stringify(currFix));
+
+    // #819 — backend로 단일 좌표 + Motion sample 송신. backend가 KV에 60s ring buffer로 누적해
+    // boarding-prompt 9단 게이트(ADR Section 2)에 사용. APNs token 부재 시 skip (서버측 series는
+    // device token으로 키되므로 token 없으면 적재 불가). graceful fire-and-forget — 송신 실패는
+    // 본 BG task 흐름에 영향 없음 (#640: zero trip = zero push 정책은 그대로, 좌표 누락은 게이트
+    // 통과 못 하게 만들 뿐).
+    const apnsToken = await AsyncStorage.getItem(APNS_TOKEN_KEY).catch(() => null);
+    if (apnsToken) {
+      const motion: PositionMotion = getCurrentMotionStationary() ? 'stationary' : 'unknown';
+      void uploadPosition({
+        token: apnsToken,
+        lat,
+        lng,
+        accuracy: accuracy ?? 0,
+        ts: latest.timestamp,
+        motion,
+      });
+    }
+
     // destinationId scoped — 이전 trip의 stale entry는 빈 set으로 반환된다(#462).
     const firedAlarms = await getFiredAlarms(destination.id);
     const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;

--- a/src/utils/__tests__/boardingPromptAutoLock.test.ts
+++ b/src/utils/__tests__/boardingPromptAutoLock.test.ts
@@ -1,0 +1,73 @@
+import { ARRIVAL_CODE } from '../../constants/arrivalCodes';
+import type { ArrivalInfo } from '../../api/arrivalApi';
+import { pickAutoTrainCodeFromArrivals } from '../boardingPromptAutoLock';
+
+function arr(overrides: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: '',
+    arrivalMinutes: 0,
+    arrivalSeconds: 60,
+    statusMessage: '',
+    trainCode: 'T1',
+    line: '2',
+    receivedAtMs: 0,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+describe('pickAutoTrainCodeFromArrivals (#819 arvlCd 우선순위)', () => {
+  it('빈 배열 → null', () => {
+    expect(pickAutoTrainCodeFromArrivals([])).toBeNull();
+  });
+
+  it('priority 1: arvlCd=2 (출발) 단독 → 채택', () => {
+    const list = [
+      arr({ trainCode: 'A', arrivalCode: 0 }),
+      arr({ trainCode: 'B', arrivalCode: 2 }),
+      arr({ trainCode: 'C', arrivalCode: ARRIVAL_CODE.ARRIVED }),
+    ];
+    expect(pickAutoTrainCodeFromArrivals(list)?.trainCode).toBe('B');
+  });
+
+  it('priority 2: arvlCd=1 (도착) — arvlCd=2 없을 때', () => {
+    const list = [
+      arr({ trainCode: 'A', arrivalCode: 0 }),
+      arr({ trainCode: 'B', arrivalCode: ARRIVAL_CODE.ARRIVED }),
+    ];
+    expect(pickAutoTrainCodeFromArrivals(list)?.trainCode).toBe('B');
+  });
+
+  it('priority 3: arvlCd=0 (진입) — 2/1 없을 때', () => {
+    const list = [arr({ trainCode: 'A', arrivalCode: 0 })];
+    expect(pickAutoTrainCodeFromArrivals(list)?.trainCode).toBe('A');
+  });
+
+  it('priority 4 fallback: 그 외 코드 → 첫 후보', () => {
+    const list = [
+      arr({ trainCode: 'A', arrivalCode: 99 }),
+      arr({ trainCode: 'B', arrivalCode: ARRIVAL_CODE.PREV_ARRIVED }),
+    ];
+    expect(pickAutoTrainCodeFromArrivals(list)?.trainCode).toBe('A');
+  });
+
+  it('ambiguity: 같은 우선순위 후보 2+ → null', () => {
+    const list = [
+      arr({ trainCode: 'A', arrivalCode: 2 }),
+      arr({ trainCode: 'B', arrivalCode: 2 }),
+    ];
+    expect(pickAutoTrainCodeFromArrivals(list)).toBeNull();
+  });
+
+  it('trainCode 빈 문자열 단독 → null', () => {
+    const list = [arr({ trainCode: '', arrivalCode: 2 })];
+    expect(pickAutoTrainCodeFromArrivals(list)).toBeNull();
+  });
+
+  it('fallback 후보의 trainCode가 빈 문자열이면 null', () => {
+    const list = [arr({ trainCode: '', arrivalCode: 99 })];
+    expect(pickAutoTrainCodeFromArrivals(list)).toBeNull();
+  });
+});

--- a/src/utils/__tests__/notificationCategory.test.ts
+++ b/src/utils/__tests__/notificationCategory.test.ts
@@ -1,0 +1,41 @@
+import * as Notifications from 'expo-notifications';
+import {
+  BOARDING_PROMPT_ACTION_BOARDED,
+  BOARDING_PROMPT_ACTION_NOT_BOARDED,
+  BOARDING_PROMPT_CATEGORY,
+  setupBoardingPromptCategory,
+} from '../notificationCategory';
+
+jest.mock('expo-notifications', () => ({
+  setNotificationCategoryAsync: jest.fn(),
+}));
+
+describe('setupBoardingPromptCategory (#819)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('BOARDING_PROMPT 식별자로 [탑승]/[미탑승] 액션 등록', async () => {
+    await setupBoardingPromptCategory();
+    expect(Notifications.setNotificationCategoryAsync).toHaveBeenCalledWith(
+      BOARDING_PROMPT_CATEGORY,
+      expect.arrayContaining([
+        expect.objectContaining({
+          identifier: BOARDING_PROMPT_ACTION_BOARDED,
+          options: expect.objectContaining({ opensAppToForeground: true }),
+        }),
+        expect.objectContaining({
+          identifier: BOARDING_PROMPT_ACTION_NOT_BOARDED,
+          options: expect.objectContaining({ opensAppToForeground: false, isDestructive: true }),
+        }),
+      ]),
+    );
+  });
+
+  it('Notifications가 throw해도 graceful (no throw)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await expect(setupBoardingPromptCategory()).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/boardingPromptAutoLock.ts
+++ b/src/utils/boardingPromptAutoLock.ts
@@ -1,0 +1,51 @@
+/**
+ * #819 B 슬라이스 — "탑승" 응답 시 arvlCd 우선순위로 trainCode 자동 lock.
+ *
+ * ADR Section 1.2 그대로 client-side에서 재현:
+ *   1순위: arvlCd=2 (출발) — 사용자가 그 차 타고 출발
+ *   2순위: arvlCd=1 (도착)
+ *   3순위: arvlCd=0 (진입)
+ *   4순위: 그 외 → 첫 후보 (Seoul API receivedAt 정렬)
+ *
+ * 같은 우선순위 후보가 여러 개면 (ambiguity) → null 반환 — 클라가 자동 lock 안 하고 manual
+ * fallback (사용자가 BoardingTrainList에서 직접 선택).
+ *
+ * line/방향 매칭은 caller가 ArrivalInfo[]를 사전 필터해서 넣는 게 자연스럽다 (useBoardingLockController의
+ * directionalArrivals와 동일 정책 — 거기서 이미 진행 방향 + 노선 매칭 + arrivalSeconds>0이 필터됨).
+ */
+
+import { ARRIVAL_CODE } from '../constants/arrivalCodes';
+import type { ArrivalInfo } from '../api/arrivalApi';
+
+/**
+ * 후보 리스트(이미 line/방향 필터 후)에서 arvlCd 우선순위로 1대를 고른다.
+ *
+ * 빈 입력 또는 ambiguity → null.
+ * 결과 trainCode가 빈 문자열이면 null로 강등(빈 trainCode로 lock 만들면 backend tracking이 무용).
+ */
+export function pickAutoTrainCodeFromArrivals(
+  arrivals: readonly ArrivalInfo[],
+): ArrivalInfo | null {
+  if (arrivals.length === 0) return null;
+  const priority: readonly number[] = [
+    /* 2: 출발 — 사용자 그 차 타고 출발 */
+    2,
+    /* 1: 도착 */
+    ARRIVAL_CODE.ARRIVED,
+    /* 0: 진입 */
+    ARRIVAL_CODE.ENTERING,
+  ];
+  for (const code of priority) {
+    const tier = arrivals.filter((a) => a.arrivalCode === code);
+    if (tier.length === 1) {
+      return tier[0].trainCode.length > 0 ? tier[0] : null;
+    }
+    if (tier.length > 1) {
+      // ambiguity — 자동 lock 안 함, manual fallback.
+      return null;
+    }
+  }
+  // 그 외 코드 fallback — 첫 후보. backend와 client의 receivedAt 정렬은 동일하다고 가정.
+  const fallback = arrivals[0];
+  return fallback.trainCode.length > 0 ? fallback : null;
+}

--- a/src/utils/notificationCategory.ts
+++ b/src/utils/notificationCategory.ts
@@ -1,0 +1,49 @@
+/**
+ * iOS UNNotificationCategory 등록 (#819 B 슬라이스).
+ *
+ * APNs alert payload의 `aps.category`가 식별자와 매칭되면 푸시 알림에 우리가 등록한
+ * 액션 버튼이 노출된다. 사용자가 액션을 탭하면 `Notifications.addNotificationResponseReceivedListener`가
+ * `actionIdentifier`를 받아 분기 처리.
+ *
+ * Android는 expo-notifications가 category를 무시 — graceful no-op.
+ */
+
+import * as Notifications from 'expo-notifications';
+
+/** APNs payload `aps.category`와 1:1 매칭. backend `BOARDING_PROMPT_CATEGORY`와 동기. */
+export const BOARDING_PROMPT_CATEGORY = 'BOARDING_PROMPT';
+
+/** [탑승] 액션 식별자 — 응답 listener가 분기 키로 사용. */
+export const BOARDING_PROMPT_ACTION_BOARDED = 'BOARDING_PROMPT_BOARDED';
+/** [미탑승] 액션 식별자. */
+export const BOARDING_PROMPT_ACTION_NOT_BOARDED = 'BOARDING_PROMPT_NOT_BOARDED';
+
+/**
+ * BOARDING_PROMPT category 등록. 앱 부팅 시 1회 호출.
+ * 실패는 graceful — category 미등록 시 알림이 평범한 alert로 표시되지만 사용자가 탭하면
+ * 같은 listener가 default action으로 호출되니 trainCode 자동 lock은 계속 동작.
+ */
+export async function setupBoardingPromptCategory(): Promise<void> {
+  try {
+    await Notifications.setNotificationCategoryAsync(BOARDING_PROMPT_CATEGORY, [
+      {
+        identifier: BOARDING_PROMPT_ACTION_BOARDED,
+        buttonTitle: 'Boarded',
+        options: {
+          opensAppToForeground: true,
+        },
+      },
+      {
+        identifier: BOARDING_PROMPT_ACTION_NOT_BOARDED,
+        buttonTitle: 'Not boarded',
+        options: {
+          // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
+          opensAppToForeground: false,
+          isDestructive: true,
+        },
+      },
+    ]);
+  } catch {
+    // graceful — Android/예외 시 기본 동작으로 폴백.
+  }
+}


### PR DESCRIPTION
Closes #819

## 변경
- iOS UNNotificationCategory "BOARDING_PROMPT" + 액션 [탑승]/[미탑승]
- backend cron 좌표 series + motion 평균속도 (Phase 1 fusion)
- 9단 AND 게이트
- arvlCd 우선순위 (2 > 1 > 0 > 그 외)로 trainCode 자동
- BoardingLock 자동 생성 → #584 SLA
- 측정 카운터 (KV)

## 의존성
- **stacked on #816** (C 슬라이스). #816 머지 후 본 PR rebase
- #817 (Map matching) 머지 후 fusedSpeed의 mapMatchedKmh 채움 (이번 PR은 null)

## #640 회귀 차단
- 9단 AND 게이트로 false positive 차단
- ambiguity 자동 안 함
- trip당 1회 + dismiss 5분

## 검증
- [ ] 9단 게이트 각 통과/차단
- [ ] arvlCd 우선순위
- [ ] backend cron 평균속도
- [ ] 커버리지 100%

ADR: https://app.notion.com/p/37430c0194b6819c8323e37d4c31a777