### PR TITLE
feat(#828): Phase 1+2 fusion wire — mapMatchedKmh null → 실제 값

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -193,6 +193,55 @@ describe('evaluateBoardingPromptGates — 9단 AND 게이트', () => {
     expect(r.pass).toBe(false);
     if (!r.pass) expect(r.reason).toBe('speed-too-low');
   });
+
+  it('#828: mapMatched arcM이 양 끝 sample에 있으면 fusedSpeed에 흘러간다 (GPS+map weighted)', () => {
+    // 좌표는 happy GPS와 동일하지만 양 끝 sample에 arcM 0 → 1000 (1km, 60s) → mapMatched=60 km/h.
+    // GPS-only 평균은 ~5.3 km/h였으나 mapMatched 가중치가 합산되어 metrics.mapMatchedKmh 산출.
+    const wired: PositionPoint[] = [
+      {
+        lat: 0,
+        lng: -0.0004,
+        accuracy: 10,
+        ts: now - 60_000,
+        motion: 'automotive',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 0,
+      },
+      { lat: 0, lng: 0.0002, accuracy: 10, ts: now - 30_000, motion: 'automotive' },
+      {
+        lat: 0,
+        lng: 0.0008,
+        accuracy: 10,
+        ts: now,
+        motion: 'automotive',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 1000,
+      },
+    ];
+    const r = evaluateBoardingPromptGates({
+      series: wired,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) {
+      expect(r.metrics.mapMatchedKmh).toBeCloseTo(60, 0);
+      // happy(GPS-only)의 fusedSpeedKmh보다 큰 값이어야 — mapMatched 60km/h가 weighted average에 합류.
+      expect(r.fusedSpeedKmh).toBeGreaterThan(10);
+    }
+  });
+
+  it('#828: mapMatched 부재면 mapMatchedKmh=null로 GPS-only 동작 (Phase 1 회귀 없음)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) expect(r.metrics.mapMatchedKmh).toBeNull();
+  });
 });
 
 describe('markPromptFired / markPromptSilenced', () => {

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -934,6 +934,99 @@ describe('POST /position (#819)', () => {
     const res = await post('/position', body, env);
     expect(res.status).toBe(400);
   });
+
+  it('#828: mapMatchedLine + mapMatchedArcM 둘 다 있으면 series에 적재', async () => {
+    const env = makeKvEnv();
+    const res = await post(
+      '/position',
+      {
+        token: 'tok-mm',
+        lat: 1,
+        lng: 2,
+        accuracy: 5,
+        ts: 1234,
+        motion: 'walking',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 678.9,
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const stored = (await env.TRIPS.get('pos:tok-mm'))!;
+    expect(JSON.parse(stored)).toEqual([
+      {
+        lat: 1,
+        lng: 2,
+        accuracy: 5,
+        ts: 1234,
+        motion: 'walking',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 678.9,
+      },
+    ]);
+  });
+
+  it.each([
+    [
+      'mapMatchedLine only — 둘 다 omit 처리',
+      {
+        token: 'tok-mm-half',
+        lat: 1,
+        lng: 2,
+        accuracy: 5,
+        ts: 0,
+        motion: 'walking',
+        mapMatchedLine: '2',
+      },
+    ],
+    [
+      'mapMatchedArcM only — 둘 다 omit 처리',
+      {
+        token: 'tok-mm-half',
+        lat: 1,
+        lng: 2,
+        accuracy: 5,
+        ts: 0,
+        motion: 'walking',
+        mapMatchedArcM: 100,
+      },
+    ],
+    [
+      'mapMatchedLine 빈 문자열 — 둘 다 omit 처리',
+      {
+        token: 'tok-mm-half',
+        lat: 1,
+        lng: 2,
+        accuracy: 5,
+        ts: 0,
+        motion: 'walking',
+        mapMatchedLine: '',
+        mapMatchedArcM: 100,
+      },
+    ],
+    [
+      'mapMatchedArcM NaN/inf — 둘 다 omit 처리',
+      {
+        token: 'tok-mm-half',
+        lat: 1,
+        lng: 2,
+        accuracy: 5,
+        ts: 0,
+        motion: 'walking',
+        mapMatchedLine: '2',
+        mapMatchedArcM: Infinity,
+      },
+    ],
+  ])('#828: %s', async (_label, body) => {
+    const env = makeKvEnv();
+    const res = await post('/position', body, env);
+    expect(res.status).toBe(200);
+    const stored = (await env.TRIPS.get(`pos:${body.token}`))!;
+    const parsed = JSON.parse(stored) as Array<Record<string, unknown>>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].mapMatchedLine).toBeUndefined();
+    expect(parsed[0].mapMatchedArcM).toBeUndefined();
+  });
 });
 
 describe('POST /boarding-prompt/dismiss (#819)', () => {

--- a/backend/alarm-worker/src/__tests__/positionSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/positionSeries.test.ts
@@ -162,6 +162,195 @@ describe('evaluateWindow', () => {
   });
 });
 
+describe('evaluateWindow — mapMatchedKmh (#828 Phase 1+2 wire)', () => {
+  // arc 시작점/끝점 1km 차이를 30초에 → 120 km/h. 평균속도 산식이 맞는지 확인용.
+  const lineCode = '2';
+
+  it('양 끝 sample이 같은 line + arcM → mapMatchedKmh 산출', () => {
+    const now = 60_000;
+    const series = [
+      point({
+        ts: 30_000,
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: lineCode,
+        mapMatchedArcM: 0,
+      }),
+      point({
+        ts: 60_000,
+        lat: 37.502,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: lineCode,
+        mapMatchedArcM: 1000,
+      }),
+    ];
+    const m = evaluateWindow(series, now);
+    // |1000 - 0| / 30s = 33.33 m/s → 120 km/h
+    expect(m.mapMatchedKmh).toBeCloseTo(120, 0);
+  });
+
+  it('한쪽 sample에 mapMatchedLine 없으면 mapMatchedKmh=null (Phase 1 회귀 없음)', () => {
+    const now = 60_000;
+    const series = [
+      point({ ts: 30_000, lat: 37.5, lng: 127.0, accuracy: 5 }),
+      point({
+        ts: 60_000,
+        lat: 37.502,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: lineCode,
+        mapMatchedArcM: 1000,
+      }),
+    ];
+    expect(evaluateWindow(series, now).mapMatchedKmh).toBeNull();
+  });
+
+  it('환승역 disambiguate — 두 sample line이 다르면 null (다른 노선 점프 차단)', () => {
+    const now = 60_000;
+    const series = [
+      point({
+        ts: 30_000,
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: '2',
+        mapMatchedArcM: 100,
+      }),
+      point({
+        ts: 60_000,
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: '3',
+        mapMatchedArcM: 200,
+      }),
+    ];
+    expect(evaluateWindow(series, now).mapMatchedKmh).toBeNull();
+  });
+
+  it('역방향 진행(end.arcM < start.arcM)도 |Δarc|로 산출', () => {
+    const now = 60_000;
+    const series = [
+      point({
+        ts: 30_000,
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: lineCode,
+        mapMatchedArcM: 1000,
+      }),
+      point({
+        ts: 60_000,
+        lat: 37.498,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: lineCode,
+        mapMatchedArcM: 0,
+      }),
+    ];
+    const m = evaluateWindow(series, now);
+    expect(m.mapMatchedKmh).toBeCloseTo(120, 0);
+  });
+
+  it('Δarc=0 → null (정지 sample은 mapMatched 신호 없음)', () => {
+    const now = 60_000;
+    const series = [
+      point({
+        ts: 30_000,
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: lineCode,
+        mapMatchedArcM: 500,
+      }),
+      point({
+        ts: 60_000,
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        mapMatchedLine: lineCode,
+        mapMatchedArcM: 500,
+      }),
+    ];
+    expect(evaluateWindow(series, now).mapMatchedKmh).toBeNull();
+  });
+
+  it('빈 윈도우 → mapMatchedKmh=null', () => {
+    expect(evaluateWindow([], 0).mapMatchedKmh).toBeNull();
+  });
+});
+
+describe('positionSeries — readSeries map matching field validation', () => {
+  it('mapMatchedLine + arcM 짝이 있는 sample은 정상 복원', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const valid: PositionPoint = {
+      lat: 37.5,
+      lng: 127.0,
+      accuracy: 5,
+      ts: 1000,
+      motion: 'automotive',
+      mapMatchedLine: '2',
+      mapMatchedArcM: 1234,
+    };
+    await appendPositionPoint(kv, 'tok', valid);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toEqual([valid]);
+  });
+
+  it('mapMatchedLine만 있고 arcM 누락된 sample은 filter됨 (짝 정책)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const bad = JSON.stringify([
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        ts: 1000,
+        motion: 'walking',
+        mapMatchedLine: '2',
+        // arcM 누락
+      },
+    ]);
+    await kv.put('pos:tok', bad);
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('mapMatchedArcM 타입 잘못된 sample은 filter됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const bad = JSON.stringify([
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        ts: 1000,
+        motion: 'walking',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 'nope',
+      },
+    ]);
+    await kv.put('pos:tok', bad);
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('mapMatchedLine 타입 잘못된 sample은 filter됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const bad = JSON.stringify([
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        ts: 1000,
+        motion: 'walking',
+        mapMatchedLine: 99,
+        mapMatchedArcM: 100,
+      },
+    ]);
+    await kv.put('pos:tok', bad);
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+});
+
 describe('cosineDirection', () => {
   it('같은 방향 → 1', () => {
     // 동→서 두 vector 동일 방향

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -143,12 +143,13 @@ export function evaluateBoardingPromptGates(
     return { pass: false, reason: 'motion-not-moving', metrics };
   }
 
-  // #7 — fused speed. mapMatchedKmh는 Phase 2 (#817) 후속에서 채움 — 현재는 null.
+  // #7 — fused speed. mapMatchedKmh는 #828에서 wire — 양 끝 sample이 같은 line + arcM을 가질
+  // 때만 evaluateWindow가 산출하고, 그 외에는 null로 강등 (GPS-only fallback).
   const fused = fusedSpeed({
     gpsAvgKmh: metrics.gpsAvgKmh,
     gpsAccuracyMeters: metrics.avgAccuracyMeters,
     motion: metrics.motion,
-    mapMatchedKmh: null,
+    mapMatchedKmh: metrics.mapMatchedKmh,
   });
   if (fused.speed < MIN_FUSED_SPEED_KMH || fused.confidence === 'low') {
     return { pass: false, reason: 'speed-too-low', metrics };

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -269,6 +269,17 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
   ) {
     return null;
   }
+  // #828 — map matching 필드는 옵션. 짝(line+arcM)이 함께 와야 series에 적재.
+  // 한쪽만 보낸 페이로드는 구버전/잘못된 클라로 간주해 두 필드를 모두 무시 (graceful).
+  const mapMatchedLine =
+    typeof obj.mapMatchedLine === 'string' && obj.mapMatchedLine.length > 0
+      ? obj.mapMatchedLine
+      : undefined;
+  const mapMatchedArcM =
+    typeof obj.mapMatchedArcM === 'number' && Number.isFinite(obj.mapMatchedArcM)
+      ? obj.mapMatchedArcM
+      : undefined;
+  const hasPair = mapMatchedLine !== undefined && mapMatchedArcM !== undefined;
   return {
     token: obj.token,
     point: {
@@ -277,6 +288,7 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
       accuracy: obj.accuracy,
       ts: obj.ts,
       motion,
+      ...(hasPair ? { mapMatchedLine, mapMatchedArcM } : {}),
     },
   };
 }

--- a/backend/alarm-worker/src/positionSeries.ts
+++ b/backend/alarm-worker/src/positionSeries.ts
@@ -92,16 +92,30 @@ function seriesKey(token: string): string {
 function isPositionPoint(value: unknown): value is PositionPoint {
   if (!value || typeof value !== 'object') return false;
   const o = value as Record<string, unknown>;
-  return (
-    typeof o.lat === 'number' &&
-    typeof o.lng === 'number' &&
-    typeof o.accuracy === 'number' &&
-    typeof o.ts === 'number' &&
-    (o.motion === 'stationary' ||
-      o.motion === 'walking' ||
-      o.motion === 'automotive' ||
-      o.motion === 'unknown')
-  );
+  if (
+    typeof o.lat !== 'number' ||
+    typeof o.lng !== 'number' ||
+    typeof o.accuracy !== 'number' ||
+    typeof o.ts !== 'number'
+  ) {
+    return false;
+  }
+  if (
+    o.motion !== 'stationary' &&
+    o.motion !== 'walking' &&
+    o.motion !== 'automotive' &&
+    o.motion !== 'unknown'
+  ) {
+    return false;
+  }
+  // #828 — optional map matching 필드는 짝(line+arcM)이 함께 있을 때만 유효. 한쪽만 있는
+  // payload는 stale write로 간주해 series에서 거부 (false positive 1차 차단 정책 정렬).
+  if (o.mapMatchedLine !== undefined && typeof o.mapMatchedLine !== 'string') return false;
+  if (o.mapMatchedArcM !== undefined && typeof o.mapMatchedArcM !== 'number') return false;
+  const hasLine = typeof o.mapMatchedLine === 'string';
+  const hasArc = typeof o.mapMatchedArcM === 'number';
+  if (hasLine !== hasArc) return false;
+  return true;
 }
 
 export interface WindowedMetrics {
@@ -117,6 +131,15 @@ export interface WindowedMetrics {
   start: { lat: number; lng: number } | null;
   /** 시작점/끝점 좌표 — 방향 cosine 계산 입력. */
   end: { lat: number; lng: number } | null;
+  /**
+   * Phase 2 map matching 결과 (#828). 윈도우 양 끝 sample이 모두 같은 line + arcM을 가질 때만
+   * `|Δarc| / Δt`로 산출 — fusedSpeed의 mapMatchedKmh 인자로 그대로 전달된다.
+   *
+   * - null: 클라이언트가 한쪽이라도 snap 못한 경우 (boarding line 미설정/멀리 떨어진 좌표).
+   *   fusedSpeed는 GPS-only로 자연 동작 (Phase 1 회귀 없음).
+   * - 환승역 disambiguate: start/end line이 다르면 null로 강등.
+   */
+  mapMatchedKmh: number | null;
 }
 
 /**
@@ -167,7 +190,33 @@ export function evaluateWindow(
     motion,
     start: start ? { lat: start.lat, lng: start.lng } : null,
     end: end ? { lat: end.lat, lng: end.lng } : null,
+    mapMatchedKmh: computeMapMatchedKmh(start, end),
   };
+}
+
+/**
+ * 윈도우 양 끝 sample이 모두 같은 line + arcM을 갖는 경우 `|Δarc| / Δt`로 평균속도(km/h) 산출.
+ *
+ * - 한쪽이라도 snap 안 됨 / line 다름 / Δt ≤ 0 / Δarc = 0 → null (fusedSpeed가 GPS-only로 강등).
+ * - 역방향 진행(음의 Δarc)은 `|·|`로 처리해 호출자가 방향을 알 필요 없게 한다 — 이는
+ *   client `mapMatchedSpeedKmh`(#817) 정책과 정렬.
+ */
+function computeMapMatchedKmh(
+  start: PositionPoint | undefined,
+  end: PositionPoint | undefined,
+): number | null {
+  if (!start || !end) return null;
+  const { mapMatchedLine: startLine, mapMatchedArcM: startArc } = start;
+  const { mapMatchedLine: endLine, mapMatchedArcM: endArc } = end;
+  if (startLine === undefined || startArc === undefined) return null;
+  if (endLine === undefined || endArc === undefined) return null;
+  if (startLine !== endLine) return null;
+  const dtMs = end.ts - start.ts;
+  if (dtMs <= 0) return null;
+  const deltaM = Math.abs(endArc - startArc);
+  if (deltaM === 0) return null;
+  const mps = deltaM / (dtMs / 1000);
+  return mps * 3.6;
 }
 
 /**

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -201,6 +201,18 @@ export interface PositionPoint {
   ts: number;
   /** CMMotionActivity 분류 — graceful: 미지원/권한 거절 시 'unknown'. */
   motion: 'stationary' | 'walking' | 'automotive' | 'unknown';
+  /**
+   * Phase 2 map matching (#828) — 클라이언트가 활성 boarding line polyline에 좌표를 사영해
+   * 산출한 누적 arc 거리(m) + 노선 코드. (`src/utils/linePolyline.ts`)
+   *
+   * - 양 끝 sample이 모두 같은 line + arcM을 갖는 경우에만 evaluateWindow가 mapMatchedKmh
+   *   산출 → fusedSpeed가 GPS+map matching 가중평균으로 동작.
+   * - 부재 시 mapMatchedKmh=null로 강등 → fusedSpeed가 GPS-only로 동작 (Phase 1 회귀 없음).
+   * - 환승역 disambiguate: 클라이언트가 active line으로만 snap하므로 다른 line snap은 자연 차단.
+   * - backend는 stations.json을 갖지 않으므로 snap은 반드시 클라이언트 책임이다 (types 주석 참조).
+   */
+  mapMatchedLine?: string;
+  mapMatchedArcM?: number;
 }
 
 /**

--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   registerActiveTrip,
   clearActiveTrip,
@@ -8,6 +9,7 @@ import {
 } from '../alarmBackend';
 import type { RegisterTripPayload } from '../alarmBackend';
 import { makeDirectRoute } from '../../testUtils/routeFixtures';
+import { ACTIVE_BOARDING_LINE_KEY } from '../../constants/storageKeys';
 
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
@@ -547,6 +549,45 @@ describe('alarmBackend', () => {
       });
       expect(jitter.skipped).toBe(true);
       expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#828 — ACTIVE_BOARDING_LINE_KEY mirror', () => {
+    beforeEach(async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      await AsyncStorage.removeItem(ACTIVE_BOARDING_LINE_KEY);
+    });
+
+    it('register 시 promptDisplay.line이 AsyncStorage에 mirror', async () => {
+      await registerActiveTrip({
+        ...SAMPLE_PAYLOAD,
+        promptDisplay: { originStation: '강남', line: '2' },
+      });
+      expect(await AsyncStorage.getItem(ACTIVE_BOARDING_LINE_KEY)).toBe('2');
+    });
+
+    it('register 시 promptDisplay 부재면 mirror 제거', async () => {
+      await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, 'stale');
+      await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(await AsyncStorage.getItem(ACTIVE_BOARDING_LINE_KEY)).toBeNull();
+    });
+
+    it('clearActiveTrip 호출 시 mirror 제거', async () => {
+      await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, '2');
+      await clearActiveTrip('token-hex');
+      expect(await AsyncStorage.getItem(ACTIVE_BOARDING_LINE_KEY)).toBeNull();
+    });
+
+    it('AsyncStorage throw → register는 계속 진행 (graceful)', async () => {
+      const originalSetItem = AsyncStorage.setItem;
+      (AsyncStorage.setItem as jest.Mock) = jest.fn().mockRejectedValue(new Error('storage down'));
+      const result = await registerActiveTrip({
+        ...SAMPLE_PAYLOAD,
+        promptDisplay: { originStation: '강남', line: '2' },
+      });
+      expect(result.ok).toBe(true);
+      AsyncStorage.setItem = originalSetItem;
     });
   });
 });

--- a/src/api/__tests__/positionUpload.test.ts
+++ b/src/api/__tests__/positionUpload.test.ts
@@ -1,4 +1,6 @@
-import { dismissBoardingPrompt, uploadPosition } from '../positionUpload';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { dismissBoardingPrompt, uploadPosition, withMapMatched } from '../positionUpload';
+import { ACTIVE_BOARDING_LINE_KEY } from '../../constants/storageKeys';
 
 jest.mock('../../utils/logger', () => ({
   createLogger: () => ({
@@ -11,9 +13,10 @@ jest.mock('../../utils/logger', () => ({
 
 const ORIGINAL_FETCH = global.fetch;
 
-beforeEach(() => {
+beforeEach(async () => {
   delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
   global.fetch = jest.fn();
+  await AsyncStorage.clear();
 });
 
 afterEach(() => {
@@ -86,9 +89,87 @@ describe('uploadPosition (#819)', () => {
     expect(r).toEqual({ ok: false });
   });
 
+  it('#828: ACTIVE_BOARDING_LINE_KEY set → snap 결과가 body에 첨부', async () => {
+    // 2호선 강남역(37.4979, 127.0276) 좌표 정확히 사용 → snap matched + arcM 출력.
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, '2');
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    await uploadPosition({
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 10,
+      ts: 0,
+      motion: 'automotive',
+    });
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.mapMatchedLine).toBe('2');
+    expect(typeof body.mapMatchedArcM).toBe('number');
+    expect(body.mapMatchedArcM).toBeGreaterThanOrEqual(0);
+  });
+
+  it('#828: ACTIVE_BOARDING_LINE_KEY set but unmatched (멀리 떨어진 좌표) → 필드 omit', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, '2');
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    // 노선에서 매우 먼 좌표 (남극 인근).
+    await uploadPosition({
+      token: 'tok',
+      lat: -89,
+      lng: 0,
+      accuracy: 10,
+      ts: 0,
+      motion: 'automotive',
+    });
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.mapMatchedLine).toBeUndefined();
+    expect(body.mapMatchedArcM).toBeUndefined();
+  });
+
+  it('#828: mirror 부재 → snap skip, body 그대로', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    await uploadPosition({
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 10,
+      ts: 0,
+      motion: 'automotive',
+    });
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.mapMatchedLine).toBeUndefined();
+    expect(body.mapMatchedArcM).toBeUndefined();
+  });
+
+  it('#828: 호출자가 명시 전달한 mapMatched 필드는 override (mirror snap 안 함)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, '2');
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    await uploadPosition({
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 10,
+      ts: 0,
+      motion: 'automotive',
+      mapMatchedLine: '3',
+      mapMatchedArcM: 999,
+    });
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.mapMatchedLine).toBe('3');
+    expect(body.mapMatchedArcM).toBe(999);
+  });
+
   it('5s 후 timeout abort — controller.abort 콜백 호출됨', async () => {
     // fetch가 abort signal을 받기까지 timer를 advance. setTimeout 콜백이 실행돼야
     // controller.abort()가 호출됨 (함수 커버리지 확보).
+    // #828 — uploadPosition은 fetch 직전에 withMapMatched(AsyncStorage await)를 거치므로
+    // advanceTimersByTimeAsync로 microtask까지 함께 흘려야 한다 (Async 버전이 promise도 진행).
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
     jest.useFakeTimers();
     (global.fetch as jest.Mock).mockImplementation(
@@ -107,10 +188,44 @@ describe('uploadPosition (#819)', () => {
       ts: 0,
       motion: 'unknown',
     });
-    jest.advanceTimersByTime(6000);
+    await jest.advanceTimersByTimeAsync(6000);
     const r = await promise;
     expect(r).toEqual({ ok: false });
     jest.useRealTimers();
+  });
+});
+
+describe('withMapMatched (#828)', () => {
+  it('명시 mapMatched 필드가 이미 있으면 그대로 반환 (snap 안 함)', async () => {
+    await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, '2');
+    const out = await withMapMatched({
+      token: 'tok',
+      lat: 1,
+      lng: 2,
+      accuracy: 0,
+      ts: 0,
+      motion: 'walking',
+      mapMatchedLine: 'x',
+      mapMatchedArcM: 42,
+    });
+    expect(out.mapMatchedLine).toBe('x');
+    expect(out.mapMatchedArcM).toBe(42);
+  });
+
+  it('AsyncStorage throw → 원본 payload 반환 (graceful)', async () => {
+    const originalGetItem = AsyncStorage.getItem;
+    (AsyncStorage.getItem as jest.Mock) = jest.fn().mockRejectedValue(new Error('storage down'));
+    const payload = {
+      token: 'tok',
+      lat: 1,
+      lng: 2,
+      accuracy: 0,
+      ts: 0,
+      motion: 'walking' as const,
+    };
+    const out = await withMapMatched(payload);
+    expect(out).toEqual(payload);
+    AsyncStorage.getItem = originalGetItem;
   });
 });
 

--- a/src/api/__tests__/positionUpload.test.ts
+++ b/src/api/__tests__/positionUpload.test.ts
@@ -1,5 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { dismissBoardingPrompt, uploadPosition, withMapMatched } from '../positionUpload';
+import {
+  dismissBoardingPrompt,
+  readActiveBoardingLine,
+  uploadPosition,
+  withMapMatched,
+} from '../positionUpload';
 import { ACTIVE_BOARDING_LINE_KEY } from '../../constants/storageKeys';
 
 jest.mock('../../utils/logger', () => ({
@@ -225,6 +230,64 @@ describe('withMapMatched (#828)', () => {
     };
     const out = await withMapMatched(payload);
     expect(out).toEqual(payload);
+    AsyncStorage.getItem = originalGetItem;
+  });
+
+  it('resolver 주입 — 호출자가 지정한 line으로 snap 수행 (확장성)', async () => {
+    // AsyncStorage 키에 의존하지 않고 명시 resolver만으로 snap 가능 — multi-trip/fallback 시나리오 확장점.
+    // 2호선 강남역 좌표(matched) + resolver가 '2' 반환 → 결과에 mapMatched 필드가 채워짐.
+    const out = await withMapMatched(
+      {
+        token: 'tok',
+        lat: 37.4979,
+        lng: 127.0276,
+        accuracy: 0,
+        ts: 0,
+        motion: 'walking',
+      },
+      async () => '2',
+    );
+    expect(out.mapMatchedLine).toBe('2');
+    expect(typeof out.mapMatchedArcM).toBe('number');
+  });
+
+  it('resolver가 null 반환 → snap skip (필드 omit)', async () => {
+    const payload = {
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 0,
+      ts: 0,
+      motion: 'walking' as const,
+    };
+    const out = await withMapMatched(payload, async () => null);
+    expect(out).toEqual(payload);
+  });
+});
+
+describe('readActiveBoardingLine (#828)', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('AsyncStorage 값이 stations.json line 코드면 LineNumber로 좁힘', async () => {
+    await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, '2');
+    expect(await readActiveBoardingLine()).toBe('2');
+  });
+
+  it('유효하지 않은 line 코드(가짜 호선)는 null — isLineNumber 가드', async () => {
+    await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, 'fake-line-99');
+    expect(await readActiveBoardingLine()).toBeNull();
+  });
+
+  it('키 부재 → null', async () => {
+    expect(await readActiveBoardingLine()).toBeNull();
+  });
+
+  it('AsyncStorage throw → null (graceful)', async () => {
+    const originalGetItem = AsyncStorage.getItem;
+    (AsyncStorage.getItem as jest.Mock) = jest.fn().mockRejectedValue(new Error('boom'));
+    expect(await readActiveBoardingLine()).toBeNull();
     AsyncStorage.getItem = originalGetItem;
   });
 });

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -8,11 +8,31 @@
  * graceful skip(`{ok:false, skipped:true}`) — Phase 1 baseline(사전 예약만)으로 동작한다.
  */
 
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Route } from '../utils/stationRoute';
 import type { ApnsEnv } from '../utils/apnsEnv';
 import { createLogger } from '../utils/logger';
+import { ACTIVE_BOARDING_LINE_KEY } from '../constants/storageKeys';
 
 const log = createLogger('alarmBackend');
+
+/**
+ * #828 — BG/FG location task가 좌표 upload 시 linePolyline snap을 수행할 active boarding line.
+ * register/clear 시점에 mirror하여 backgroundLocationTask가 trip 컨텍스트 없이도 snap 가능.
+ *
+ * AsyncStorage 실패는 graceful — snap이 skip될 뿐 fusion 자체는 Phase 1로 자연 동작.
+ */
+async function mirrorBoardingLine(line: string | undefined): Promise<void> {
+  try {
+    if (line && line.length > 0) {
+      await AsyncStorage.setItem(ACTIVE_BOARDING_LINE_KEY, line);
+    } else {
+      await AsyncStorage.removeItem(ACTIVE_BOARDING_LINE_KEY);
+    }
+  } catch (e) {
+    log.warn('mirror boarding line failed', e);
+  }
+}
 
 /** 백엔드 Trip.Waypoint와 동일 구조. backend/alarm-worker/src/types.ts와 동기화. */
 export interface AlarmWaypoint {
@@ -271,6 +291,10 @@ export function registerActiveTrip(
     return pending;
   }
 
+  // #828 — BG/FG location task가 snap에 사용할 boarding line을 mirror. fetch와 병렬로 발사해
+  // register와 무관하게 (URL 미설정 graceful 경로에서도) 다음 좌표 upload부터 효과.
+  void mirrorBoardingLine(payload.promptDisplay?.line);
+
   const promise = performRegisterFetch(base, payload, hash).finally(() => {
     inFlightRegisters.delete(hash);
   });
@@ -325,6 +349,8 @@ export async function clearActiveTrip(token: string): Promise<AlarmBackendResult
   // 이전 Promise를 재사용하지 않는다.
   lastRegisteredHash = null;
   inFlightRegisters.clear();
+  // #828 — trip 종료 시 mirror도 제거. 다음 좌표 upload부터 snap skip(graceful).
+  void mirrorBoardingLine(undefined);
 
   const base = getBackendUrl();
   if (!base) {

--- a/src/api/positionUpload.ts
+++ b/src/api/positionUpload.ts
@@ -11,6 +11,10 @@
  * baseline(사전 예약만)은 그대로 동작한다.
  */
 
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ACTIVE_BOARDING_LINE_KEY } from '../constants/storageKeys';
+import { snapToLinePolyline } from '../utils/linePolyline';
+import type { LineNumber } from '../types/station';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger('positionUpload');
@@ -27,6 +31,13 @@ export interface PositionUploadPayload {
   /** epoch ms — 디바이스 측정 시각. backend 시계와의 drift는 평균속도가 자체 보정. */
   ts: number;
   motion: PositionMotion;
+  /**
+   * #828 Phase 2 fusion — 클라이언트가 active boarding line polyline에 좌표를 사영한 결과.
+   * 짝(line+arcM)으로만 의미가 있고 한쪽만 보내면 backend가 둘 다 무시한다.
+   * unmatched / boarding line 미설정 시 두 필드 모두 omit (graceful — backend는 GPS-only로 동작).
+   */
+  mapMatchedLine?: string;
+  mapMatchedArcM?: number;
 }
 
 export interface PositionUploadResult {
@@ -54,6 +65,39 @@ async function fetchWithTimeout(input: string, init: RequestInit): Promise<Respo
   }
 }
 
+/**
+ * #828 — active boarding line이 mirror돼 있으면 그 라인으로 좌표를 snap해 mapMatched 결과를 채운다.
+ *
+ * - 호출자가 `mapMatchedLine` + `mapMatchedArcM`을 명시 전달했으면 그대로 사용 (override).
+ * - mirror 부재 / unmatched / AsyncStorage 실패 → 두 필드 모두 omit (graceful, GPS-only fallback).
+ *
+ * 결과 객체는 backend로 보낼 JSON. 호출자가 직접 쓸 수 있게 export.
+ */
+export async function withMapMatched(
+  payload: PositionUploadPayload,
+): Promise<PositionUploadPayload> {
+  if (payload.mapMatchedLine !== undefined && payload.mapMatchedArcM !== undefined) {
+    return payload;
+  }
+  let line: string | null;
+  try {
+    line = await AsyncStorage.getItem(ACTIVE_BOARDING_LINE_KEY);
+  } catch {
+    return payload;
+  }
+  if (!line) return payload;
+  const snap = snapToLinePolyline(
+    { lat: payload.lat, lng: payload.lng },
+    line as LineNumber,
+  );
+  if (!snap.matched) return payload;
+  return {
+    ...payload,
+    mapMatchedLine: snap.line,
+    mapMatchedArcM: snap.arcM,
+  };
+}
+
 export async function uploadPosition(
   payload: PositionUploadPayload,
 ): Promise<PositionUploadResult> {
@@ -62,11 +106,12 @@ export async function uploadPosition(
     log.info('ALARM_BACKEND_URL not set — skip position upload');
     return { ok: false, skipped: true };
   }
+  const enriched = await withMapMatched(payload);
   try {
     const res = await fetchWithTimeout(`${base}/position`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(enriched),
     });
     if (!res.ok) {
       log.warn(`position upload failed status=${res.status}`);

--- a/src/api/positionUpload.ts
+++ b/src/api/positionUpload.ts
@@ -14,10 +14,33 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ACTIVE_BOARDING_LINE_KEY } from '../constants/storageKeys';
 import { snapToLinePolyline } from '../utils/linePolyline';
+import { isLineNumber } from '../utils/lineGuard';
 import type { LineNumber } from '../types/station';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger('positionUpload');
+
+/**
+ * #828 — 좌표 snap 대상 line을 산출하는 전략 함수.
+ *
+ * 기본 구현은 `ACTIVE_BOARDING_LINE_KEY`를 읽는 AsyncStorage 백엔드(`readActiveBoardingLine`).
+ * 호출자는 multi-trip / multi-line / fallback line 시나리오에 맞춰 자기만의 resolver를
+ * 주입할 수 있다. resolver가 null을 반환하면 snap을 skip한다.
+ */
+export type ActiveLineResolver = () => Promise<LineNumber | null>;
+
+/**
+ * 기본 resolver — `ACTIVE_BOARDING_LINE_KEY`를 AsyncStorage에서 읽고 `LineNumber`로 좁힌다.
+ * 키 부재 / 잘못된 코드 / AsyncStorage 실패 → null (snap skip, graceful).
+ */
+export const readActiveBoardingLine: ActiveLineResolver = async () => {
+  try {
+    const raw = await AsyncStorage.getItem(ACTIVE_BOARDING_LINE_KEY);
+    return isLineNumber(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+};
 
 export type PositionMotion = 'stationary' | 'walking' | 'automotive' | 'unknown';
 
@@ -66,30 +89,24 @@ async function fetchWithTimeout(input: string, init: RequestInit): Promise<Respo
 }
 
 /**
- * #828 — active boarding line이 mirror돼 있으면 그 라인으로 좌표를 snap해 mapMatched 결과를 채운다.
+ * #828 — resolver가 반환한 line에 좌표를 사영해 mapMatched 결과를 payload에 첨부.
  *
  * - 호출자가 `mapMatchedLine` + `mapMatchedArcM`을 명시 전달했으면 그대로 사용 (override).
- * - mirror 부재 / unmatched / AsyncStorage 실패 → 두 필드 모두 omit (graceful, GPS-only fallback).
+ * - resolver null / unmatched → 두 필드 모두 omit (graceful, GPS-only fallback).
  *
- * 결과 객체는 backend로 보낼 JSON. 호출자가 직접 쓸 수 있게 export.
+ * resolver를 함수로 주입받아 multi-trip / fallback line / 측정 fixture 같은 미래 확장이
+ * 호출자 단에서 자유롭게 결정된다 (CLAUDE.md 글로벌 규칙 3번 — 확장성/재사용성 우선).
  */
 export async function withMapMatched(
   payload: PositionUploadPayload,
+  resolveLine: ActiveLineResolver = readActiveBoardingLine,
 ): Promise<PositionUploadPayload> {
   if (payload.mapMatchedLine !== undefined && payload.mapMatchedArcM !== undefined) {
     return payload;
   }
-  let line: string | null;
-  try {
-    line = await AsyncStorage.getItem(ACTIVE_BOARDING_LINE_KEY);
-  } catch {
-    return payload;
-  }
+  const line = await resolveLine();
   if (!line) return payload;
-  const snap = snapToLinePolyline(
-    { lat: payload.lat, lng: payload.lng },
-    line as LineNumber,
-  );
+  const snap = snapToLinePolyline({ lat: payload.lat, lng: payload.lng }, line);
   if (!snap.matched) return payload;
   return {
     ...payload,

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -60,3 +60,9 @@ export const LOCKLESS_STATION_PASSED_KEY = 'subway-now:lockless-station-passed';
 // 형식: {"tripKey": string, "promptedAt": number, "dismissedAt"?: number} JSON.
 // tripKey는 `${destinationId}|${createdAtBucketMs}` — destination 변경 시 자동 reset.
 export const BOARDING_PROMPT_STATE_KEY = 'subway-now:boarding-prompt-state';
+// #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
+// BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
+// `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.
+// registerActiveTrip이 promptDisplay.line으로 set하고 clearActiveTrip이 삭제.
+// 형식: LineNumber 문자열 ('1'..'9' | 'airport' | ...). 키 부재 = snap skip(graceful).
+export const ACTIVE_BOARDING_LINE_KEY = 'subway-now:active-boarding-line';

--- a/src/utils/__tests__/lineGuard.test.ts
+++ b/src/utils/__tests__/lineGuard.test.ts
@@ -1,0 +1,27 @@
+import stations from '../../data/stations.json';
+import type { Station } from '../../types/station';
+import { isLineNumber } from '../lineGuard';
+
+describe('isLineNumber', () => {
+  it('stations.json에 존재하는 모든 line 코드를 통과시킨다 (데이터 주도)', () => {
+    const codes = Array.from(new Set((stations as Station[]).map((s) => s.line)));
+    // 가드가 stations.json의 union을 그대로 추종하는지 — 하드코딩한 list가 아닌
+    // 실제 데이터에서 도출됨을 보장.
+    for (const code of codes) {
+      expect(isLineNumber(code)).toBe(true);
+    }
+    // 최소한 우리가 지원하는 13 노선 이상은 stations.json에 들어있어야 한다.
+    expect(codes.length).toBeGreaterThanOrEqual(13);
+  });
+
+  it.each([
+    ['빈 문자열', ''],
+    ['stations.json에 없는 가짜 코드', 'fake-line-99'],
+    ['number type', 2],
+    ['null', null],
+    ['undefined', undefined],
+    ['object', { line: '2' }],
+  ])('잘못된 입력 %s → false', (_label, input) => {
+    expect(isLineNumber(input)).toBe(false);
+  });
+});

--- a/src/utils/lineGuard.ts
+++ b/src/utils/lineGuard.ts
@@ -1,0 +1,23 @@
+/**
+ * `LineNumber` runtime 가드 (#828).
+ *
+ * 외부 source(AsyncStorage, network payload, telemetry round-trip 등)에서 들어온 string을
+ * `LineNumber`로 안전하게 좁힌다. 새 노선 추가 시 `stations.json`만 갱신하면 자동으로
+ * 인식되므로 type 단언이나 if-else 체인이 필요없다 (데이터 주도 — CLAUDE.md 글로벌 규칙 3번).
+ */
+
+import stations from '../data/stations.json';
+import type { LineNumber, Station } from '../types/station';
+
+/**
+ * `stations.json`의 line 필드 union set. 모듈 로드 시 1회 계산되어 캐시된다.
+ * 새 노선이 stations.json에 추가되면 별도 list 갱신 없이 자동 인식.
+ */
+const KNOWN_LINE_CODES: ReadonlySet<string> = new Set(
+  (stations as Station[]).map((s) => s.line),
+);
+
+/** 문자열이 stations.json에 존재하는 line 코드인지 좁힌다. */
+export function isLineNumber(value: unknown): value is LineNumber {
+  return typeof value === 'string' && KNOWN_LINE_CODES.has(value);
+}


### PR DESCRIPTION
## Summary

ADR fusion 로드맵의 Phase 1 (#819, PR #822 머지)과 Phase 2 (#817, PR #821 머지) 결과물을 연결한다. 기존 `boardingPrompt.ts:147`이 `mapMatchedKmh: null`로 하드코딩되어 있어 `src/utils/linePolyline.ts`의 polyline snap 결과가 fusion에 흘러가지 않던 갭을 닫는다.

## 변경 사항

**backend (`backend/alarm-worker/src/`)**
- `types.ts` — `PositionPoint`에 `mapMatchedLine?: string`, `mapMatchedArcM?: number` optional 필드 추가
- `positionSeries.ts`
  - `isPositionPoint` 가드가 짝(line+arcM) 정합성을 검증 (한쪽만 있으면 reject)
  - `WindowedMetrics`에 `mapMatchedKmh: number | null` 추가
  - `computeMapMatchedKmh` 헬퍼 — 양 끝 sample이 같은 line + arcM 가질 때만 `|Δarc| / Δt`로 산출
- `boardingPrompt.ts` — `fusedSpeed` 호출 시 `metrics.mapMatchedKmh` 전달 (기존 null 하드코딩 제거)
- `index.ts` — `validatePositionPayload`가 옵션 두 필드 검증 + 짝 누락 시 graceful omit

**client (`src/`)**
- `constants/storageKeys.ts` — `ACTIVE_BOARDING_LINE_KEY` 추가
- `api/alarmBackend.ts` — `registerActiveTrip`이 `promptDisplay.line`을 mirror, `clearActiveTrip`이 제거
- `api/positionUpload.ts`
  - `PositionUploadPayload`에 동일한 두 옵션 필드 추가
  - `withMapMatched` helper — mirror된 line으로 `snapToLinePolyline` 호출 후 결과를 payload에 첨부 (graceful: 미설정/unmatched/AsyncStorage 실패는 자동 skip)
  - `uploadPosition`이 fetch 전에 자동 enrich

## 설계 결정

`backend/`는 `stations.json`을 갖지 않는 정책 (types.ts:130)을 그대로 유지. snap은 **클라이언트(BG/FG location task)**에서 수행하고 backend로는 arcM + line만 전달한다. backend는 윈도우 양 끝 sample의 arcM 차로 mapMatchedKmh를 계산해 `fusedSpeed`의 `mapMatchedKmh` 인자로 그대로 흘려보낸다.

```
[client] uploadPosition → withMapMatched → snapToLinePolyline(coord, activeLine)
  → POST /position { ..., mapMatchedLine, mapMatchedArcM }

[backend] evaluateWindow(series) → mapMatchedKmh (|Δarc|/Δt or null)
  → fusedSpeed({ ..., mapMatchedKmh })
```

## 보호 정책

- **Phase 1 회귀 없음**: 한쪽 sample이라도 mapMatched 필드 부재 / 다른 line / Δarc=0 → `mapMatchedKmh=null` → `fusedSpeed`가 GPS-only로 동작 (기존 #819 동작).
- **환승역 disambiguate**: 클라이언트가 active line으로만 snap → 다른 line snap은 자연 차단. start/end line이 다르면 backend가 null로 강등.
- **하드코딩/매직 라인 코드 금지**: 라인 코드는 stations.json line 그대로 string으로 전달.
- **backend의 stations.json 비의존**: 유지.

## Test plan

- [x] `backend npm test` — 426 passed (positionSeries 5종 매칭 케이스, validatePositionPayload optional 필드 4종, boardingPrompt mapMatched-wired/non-wired 2종 추가)
- [x] `npm test` — 3138 passed, 100% coverage 유지
- [x] `npm run type-check` (root + backend) — 양쪽 통과
- [ ] 실기기 회귀: lockMissing trip에서 fusedSpeed 로그에 `mapMatchedKmh`가 nonzero 값으로 보이는지 wrangler tail로 확인 (PR 머지 후 EAS 빌드 단계)

Closes #828