### PR TITLE
feat(#827): Phase 3 fusion baseline 측정 인프라

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPromptOutcome.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPromptOutcome.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  recordBoardingPromptOutcome,
+  validateBoardingPromptOutcome,
+} from '../boardingPromptOutcome';
+
+describe('validateBoardingPromptOutcome', () => {
+  it('accepts boarded outcome', () => {
+    expect(
+      validateBoardingPromptOutcome({ token: 'aabbccdd', outcome: 'boarded' }),
+    ).toEqual({ token: 'aabbccdd', outcome: 'boarded' });
+  });
+
+  it('accepts dismissed outcome', () => {
+    expect(
+      validateBoardingPromptOutcome({ token: 'aabbccdd', outcome: 'dismissed' }),
+    ).toEqual({ token: 'aabbccdd', outcome: 'dismissed' });
+  });
+
+  it('rejects non-object', () => {
+    expect(validateBoardingPromptOutcome(null)).toBeNull();
+    expect(validateBoardingPromptOutcome('x')).toBeNull();
+  });
+
+  it('rejects empty token', () => {
+    expect(validateBoardingPromptOutcome({ token: '', outcome: 'boarded' })).toBeNull();
+  });
+
+  it('rejects missing token', () => {
+    expect(validateBoardingPromptOutcome({ outcome: 'boarded' })).toBeNull();
+  });
+
+  it('rejects unknown outcome', () => {
+    expect(
+      validateBoardingPromptOutcome({ token: 'aabbccdd', outcome: 'bogus' }),
+    ).toBeNull();
+  });
+});
+
+describe('recordBoardingPromptOutcome', () => {
+  it('writes total only when outcome is boarded (hit=0 skipped)', () => {
+    const writer = { writeDataPoint: vi.fn() };
+    recordBoardingPromptOutcome(writer, { token: 'aabbccdd1234', outcome: 'boarded' });
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(1);
+    const call = writer.writeDataPoint.mock.calls[0][0];
+    expect(call.blobs[0]).toBe('phase3:boardingFalsePositiveRate:total');
+    expect(call.doubles[0]).toBe(1);
+  });
+
+  it('writes hit + total when outcome is dismissed', () => {
+    const writer = { writeDataPoint: vi.fn() };
+    recordBoardingPromptOutcome(writer, { token: 'aabbccdd1234', outcome: 'dismissed' });
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(2);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain('phase3:boardingFalsePositiveRate:hit');
+    expect(labels).toContain('phase3:boardingFalsePositiveRate:total');
+  });
+
+  it('uses 8-char token prefix in indexes', () => {
+    const writer = { writeDataPoint: vi.fn() };
+    recordBoardingPromptOutcome(writer, { token: 'aabbccdd1234', outcome: 'dismissed' });
+    const call = writer.writeDataPoint.mock.calls[0][0];
+    expect(call.indexes[0]).toBe('aabbccdd');
+    expect(call.blobs[1]).toBe('aabbccdd');
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -987,6 +987,40 @@ describe('POST /boarding-prompt/dismiss (#819)', () => {
   });
 });
 
+describe('POST /metrics/boarding-prompt (#827)', () => {
+  const validBody = { token: 'aabbccdd11223344', outcome: 'dismissed' as const };
+
+  it('returns 400 on invalid JSON', async () => {
+    const env = makeEnv();
+    const res = await post('/metrics/boarding-prompt', 'not-json{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const env = makeEnv();
+    const res = await post('/metrics/boarding-prompt', { token: '' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('writes to TELEMETRY binding when present', async () => {
+    const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
+    const env = makeEnv({ TELEMETRY: writer });
+    const res = await post('/metrics/boarding-prompt', validBody, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(writer.writeDataPoint).toHaveBeenCalled();
+  });
+
+  it('still returns ok when TELEMETRY binding absent', async () => {
+    const env = makeEnv();
+    const res = await post('/metrics/boarding-prompt', validBody, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});
+
 describe('validateTrip — #819 promptGeoContext / promptDisplay', () => {
   function withPrompt(overrides: Record<string, unknown>): Record<string, unknown> {
     return { ...base(), ...overrides };

--- a/backend/alarm-worker/src/__tests__/metrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/metrics.test.ts
@@ -4,11 +4,13 @@ import {
   FALSE_POSITIVE_RATIO_THRESHOLD,
   isRateMetric,
   mean,
+  METRIC_CATALOG,
   METRIC_KIND,
   MIN_SAMPLE_FOR_DECISION,
   percentile,
   rate,
   SLA_LATE_THRESHOLD_MS,
+  SLA_PERCENTILE,
   summarizeMetric,
   validateMetricBatch,
   validateMetricEntry,
@@ -144,86 +146,152 @@ function makeSummary(
 
 describe('decidePhaseFour', () => {
   it('holds decision when falsePositive samples insufficient', () => {
-    const decision = decidePhaseFour({
-      falsePositive: makeSummary({
+    const decision = decidePhaseFour([
+      makeSummary({
         kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
         significant: false,
         count: 5,
       }),
-      imminentSla: makeSummary({ kind: METRIC_KIND.IMMINENT_SLA_ERROR }),
-    });
+      makeSummary({ kind: METRIC_KIND.IMMINENT_SLA_ERROR }),
+    ]);
     expect(decision.proceed).toBe(false);
     expect(decision.insufficientSamples).toBe(true);
     expect(decision.triggers).toEqual([]);
   });
 
   it('holds decision when imminentSla samples insufficient', () => {
-    const decision = decidePhaseFour({
-      falsePositive: makeSummary({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
-      imminentSla: makeSummary({
+    const decision = decidePhaseFour([
+      makeSummary({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
+      makeSummary({
         kind: METRIC_KIND.IMMINENT_SLA_ERROR,
         significant: false,
         count: 2,
       }),
-    });
+    ]);
     expect(decision.proceed).toBe(false);
     expect(decision.insufficientSamples).toBe(true);
   });
 
+  it('holds when a gated metric is missing from input', () => {
+    // 카탈로그의 모든 gate-필수 메트릭이 입력에 있어야 함.
+    const decision = decidePhaseFour([
+      makeSummary({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
+    ]);
+    expect(decision.insufficientSamples).toBe(true);
+    expect(decision.proceed).toBe(false);
+  });
+
   it('skips Phase 4 when both within threshold', () => {
-    const decision = decidePhaseFour({
-      falsePositive: makeSummary({
+    const decision = decidePhaseFour([
+      makeSummary({
         kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
         value: FALSE_POSITIVE_RATIO_THRESHOLD,
       }),
-      imminentSla: makeSummary({
+      makeSummary({
         kind: METRIC_KIND.IMMINENT_SLA_ERROR,
         p95: SLA_LATE_THRESHOLD_MS,
       }),
-    });
+    ]);
     expect(decision.proceed).toBe(false);
     expect(decision.insufficientSamples).toBe(false);
     expect(decision.triggers).toEqual([]);
   });
 
   it('triggers on false-positive breach', () => {
-    const decision = decidePhaseFour({
-      falsePositive: makeSummary({
+    const decision = decidePhaseFour([
+      makeSummary({
         kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
         value: FALSE_POSITIVE_RATIO_THRESHOLD + 0.01,
       }),
-      imminentSla: makeSummary({ kind: METRIC_KIND.IMMINENT_SLA_ERROR }),
-    });
+      makeSummary({ kind: METRIC_KIND.IMMINENT_SLA_ERROR }),
+    ]);
     expect(decision.proceed).toBe(true);
     expect(decision.triggers).toContain('falsePositive');
     expect(decision.triggers).not.toContain('imminentSla');
   });
 
   it('triggers on imminentSla breach', () => {
-    const decision = decidePhaseFour({
-      falsePositive: makeSummary({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
-      imminentSla: makeSummary({
+    const decision = decidePhaseFour([
+      makeSummary({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
+      makeSummary({
         kind: METRIC_KIND.IMMINENT_SLA_ERROR,
         p95: SLA_LATE_THRESHOLD_MS + 1,
       }),
-    });
+    ]);
     expect(decision.proceed).toBe(true);
     expect(decision.triggers).toContain('imminentSla');
   });
 
   it('aggregates multiple triggers', () => {
-    const decision = decidePhaseFour({
-      falsePositive: makeSummary({
+    const decision = decidePhaseFour([
+      makeSummary({
         kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
         value: 0.3,
       }),
-      imminentSla: makeSummary({
+      makeSummary({
         kind: METRIC_KIND.IMMINENT_SLA_ERROR,
         p95: SLA_LATE_THRESHOLD_MS + 1000,
       }),
-    });
+    ]);
     expect(decision.proceed).toBe(true);
     expect(decision.triggers).toEqual(['falsePositive', 'imminentSla']);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// 카탈로그 — data-driven 보장.
+// 새 지표/게이트 추가 시 추가 분기 코드 필요 없음을 회귀 보장.
+// ───────────────────────────────────────────────────────────────
+
+describe('METRIC_CATALOG (data-driven)', () => {
+  it('exposes every catalog key via METRIC_KIND', () => {
+    for (const entry of METRIC_CATALOG) {
+      expect(METRIC_KIND[entry.constantName]).toBe(entry.key);
+    }
+  });
+
+  it('every metric has a known format', () => {
+    for (const entry of METRIC_CATALOG) {
+      expect(['rate', 'histogram']).toContain(entry.format);
+    }
+  });
+
+  it('every gate references a known threshold constant', () => {
+    const allowed = new Set([
+      'SLA_LATE_THRESHOLD_MS',
+      'FALSE_POSITIVE_RATIO_THRESHOLD',
+      'MIN_SAMPLE_FOR_DECISION',
+      'SLA_PERCENTILE',
+    ]);
+    for (const entry of METRIC_CATALOG) {
+      if (entry.gate) {
+        expect(allowed.has(entry.gate.thresholdConst)).toBe(true);
+      }
+    }
+  });
+
+  it('gates currently registered cover exactly the documented Phase 4 inputs', () => {
+    const triggers = METRIC_CATALOG.filter((m) => m.gate).map((m) => m.gate?.triggerName);
+    expect(triggers).toEqual(['falsePositive', 'imminentSla']);
+  });
+});
+
+describe('SLA_PERCENTILE', () => {
+  it('reflects catalog constant (default 0.95)', () => {
+    expect(SLA_PERCENTILE).toBe(0.95);
+  });
+
+  it('summarizeMetric uses SLA_PERCENTILE for histogram p95 field', () => {
+    // SLA_PERCENTILE이 0.95라는 가정 없이 분포 기반 검증:
+    // 정렬 후 ceil(p * n) - 1 인덱스 일치.
+    const samples = Array.from({ length: 100 }, (_, i) => i + 1);
+    const expectedIdx = Math.max(0, Math.ceil(SLA_PERCENTILE * samples.length) - 1);
+    const expected = samples[expectedIdx];
+    const result = summarizeMetric({
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples,
+    });
+    expect(result.p95).toBe(expected);
   });
 });
 
@@ -278,9 +346,10 @@ describe('writeMetricDataPoints', () => {
     };
     writeMetricDataPoints(writer, 'aabbccdd11223344', hist);
     const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    const pctLabel = `p${Math.round(SLA_PERCENTILE * 100)}`;
     expect(labels).toContain('phase3:imminentSlaErrorMs:count');
     expect(labels).toContain('phase3:imminentSlaErrorMs:mean');
-    expect(labels).toContain('phase3:imminentSlaErrorMs:p95');
+    expect(labels).toContain(`phase3:imminentSlaErrorMs:${pctLabel}`);
   });
 
   it('skips zero histogram values (empty samples writes nothing)', () => {

--- a/backend/alarm-worker/src/__tests__/metrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/metrics.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  decidePhaseFour,
+  FALSE_POSITIVE_RATIO_THRESHOLD,
+  isRateMetric,
+  mean,
+  METRIC_KIND,
+  MIN_SAMPLE_FOR_DECISION,
+  percentile,
+  rate,
+  SLA_LATE_THRESHOLD_MS,
+  summarizeMetric,
+  validateMetricBatch,
+  validateMetricEntry,
+  writeMetricDataPoints,
+  type HistogramMetric,
+  type MetricSummary,
+  type RateMetric,
+} from '../metrics';
+
+// ───────────────────────────────────────────────────────────────
+// 통계 헬퍼.
+// ───────────────────────────────────────────────────────────────
+
+describe('percentile', () => {
+  it('returns 0 for empty array', () => {
+    expect(percentile([], 0.95)).toBe(0);
+  });
+
+  it('returns p95 for known sample', () => {
+    // 1..100 정렬 → ceil(0.95 * 100) - 1 = 94 → 95
+    const samples = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(percentile(samples, 0.95)).toBe(95);
+  });
+
+  it('handles p=0 → smallest', () => {
+    expect(percentile([5, 1, 3], 0)).toBe(1);
+  });
+
+  it('returns 0 for out-of-range p', () => {
+    expect(percentile([1, 2, 3], -0.1)).toBe(0);
+    expect(percentile([1, 2, 3], 1.1)).toBe(0);
+  });
+
+  it('clamps to last index when p=1', () => {
+    expect(percentile([1, 2, 3], 1)).toBe(3);
+  });
+});
+
+describe('mean', () => {
+  it('returns 0 for empty array', () => {
+    expect(mean([])).toBe(0);
+  });
+
+  it('computes mean', () => {
+    expect(mean([2, 4, 6])).toBe(4);
+  });
+});
+
+describe('rate', () => {
+  it('returns 0 when total is 0', () => {
+    expect(rate({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 0, total: 0 })).toBe(0);
+  });
+
+  it('computes ratio', () => {
+    expect(rate({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 1, total: 4 })).toBe(0.25);
+  });
+});
+
+describe('isRateMetric', () => {
+  it('classifies rate by total field', () => {
+    expect(
+      isRateMetric({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 0, total: 1 }),
+    ).toBe(true);
+  });
+
+  it('classifies histogram absent of total', () => {
+    expect(isRateMetric({ kind: METRIC_KIND.IMMINENT_SLA_ERROR, samples: [] })).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// summary.
+// ───────────────────────────────────────────────────────────────
+
+describe('summarizeMetric', () => {
+  it('summarizes a rate metric', () => {
+    const result = summarizeMetric({
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 5,
+      total: 100,
+    });
+    expect(result.value).toBe(0.05);
+    expect(result.p95).toBe(0);
+    expect(result.count).toBe(100);
+    expect(result.significant).toBe(true);
+  });
+
+  it('marks rate metric insignificant when below threshold', () => {
+    const result = summarizeMetric({
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 1,
+      total: MIN_SAMPLE_FOR_DECISION - 1,
+    });
+    expect(result.significant).toBe(false);
+  });
+
+  it('summarizes a histogram metric (mean/p95/count)', () => {
+    const samples = Array.from({ length: 50 }, (_, i) => i + 1);
+    const result = summarizeMetric({
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples,
+    });
+    expect(result.count).toBe(50);
+    expect(result.value).toBeCloseTo(25.5);
+    expect(result.p95).toBe(48);
+    expect(result.significant).toBe(true);
+  });
+
+  it('marks histogram insignificant when sample count low', () => {
+    const result = summarizeMetric({
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples: [10, 20, 30],
+    });
+    expect(result.significant).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// Phase 4 결정.
+// ───────────────────────────────────────────────────────────────
+
+function makeSummary(
+  partial: Partial<MetricSummary> & Pick<MetricSummary, 'kind'>,
+): MetricSummary {
+  return {
+    value: 0,
+    p95: 0,
+    count: MIN_SAMPLE_FOR_DECISION,
+    significant: true,
+    ...partial,
+  };
+}
+
+describe('decidePhaseFour', () => {
+  it('holds decision when falsePositive samples insufficient', () => {
+    const decision = decidePhaseFour({
+      falsePositive: makeSummary({
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        significant: false,
+        count: 5,
+      }),
+      imminentSla: makeSummary({ kind: METRIC_KIND.IMMINENT_SLA_ERROR }),
+    });
+    expect(decision.proceed).toBe(false);
+    expect(decision.insufficientSamples).toBe(true);
+    expect(decision.triggers).toEqual([]);
+  });
+
+  it('holds decision when imminentSla samples insufficient', () => {
+    const decision = decidePhaseFour({
+      falsePositive: makeSummary({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
+      imminentSla: makeSummary({
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        significant: false,
+        count: 2,
+      }),
+    });
+    expect(decision.proceed).toBe(false);
+    expect(decision.insufficientSamples).toBe(true);
+  });
+
+  it('skips Phase 4 when both within threshold', () => {
+    const decision = decidePhaseFour({
+      falsePositive: makeSummary({
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        value: FALSE_POSITIVE_RATIO_THRESHOLD,
+      }),
+      imminentSla: makeSummary({
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        p95: SLA_LATE_THRESHOLD_MS,
+      }),
+    });
+    expect(decision.proceed).toBe(false);
+    expect(decision.insufficientSamples).toBe(false);
+    expect(decision.triggers).toEqual([]);
+  });
+
+  it('triggers on false-positive breach', () => {
+    const decision = decidePhaseFour({
+      falsePositive: makeSummary({
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        value: FALSE_POSITIVE_RATIO_THRESHOLD + 0.01,
+      }),
+      imminentSla: makeSummary({ kind: METRIC_KIND.IMMINENT_SLA_ERROR }),
+    });
+    expect(decision.proceed).toBe(true);
+    expect(decision.triggers).toContain('falsePositive');
+    expect(decision.triggers).not.toContain('imminentSla');
+  });
+
+  it('triggers on imminentSla breach', () => {
+    const decision = decidePhaseFour({
+      falsePositive: makeSummary({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
+      imminentSla: makeSummary({
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        p95: SLA_LATE_THRESHOLD_MS + 1,
+      }),
+    });
+    expect(decision.proceed).toBe(true);
+    expect(decision.triggers).toContain('imminentSla');
+  });
+
+  it('aggregates multiple triggers', () => {
+    const decision = decidePhaseFour({
+      falsePositive: makeSummary({
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        value: 0.3,
+      }),
+      imminentSla: makeSummary({
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        p95: SLA_LATE_THRESHOLD_MS + 1000,
+      }),
+    });
+    expect(decision.proceed).toBe(true);
+    expect(decision.triggers).toEqual(['falsePositive', 'imminentSla']);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// AE 적재.
+// ───────────────────────────────────────────────────────────────
+
+describe('writeMetricDataPoints', () => {
+  function makeWriter() {
+    return { writeDataPoint: vi.fn() };
+  }
+
+  it('writes hit + total points for rate metric (skips zero hit)', () => {
+    const writer = makeWriter();
+    writeMetricDataPoints(writer, 'aabbccdd11223344', {
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 0,
+      total: 10,
+    });
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(1);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain('phase3:boardingFalsePositiveRate:total');
+  });
+
+  it('writes hit + total when both > 0', () => {
+    const writer = makeWriter();
+    writeMetricDataPoints(writer, 'aabbccdd11223344', {
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 3,
+      total: 10,
+    });
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(2);
+  });
+
+  it('includes token prefix in blobs/indexes', () => {
+    const writer = makeWriter();
+    writeMetricDataPoints(writer, 'aabbccdd11223344', {
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 1,
+      total: 1,
+    });
+    const first = writer.writeDataPoint.mock.calls[0][0];
+    expect(first.blobs[1]).toBe('aabbccdd');
+    expect(first.indexes[0]).toBe('aabbccdd');
+  });
+
+  it('writes count/mean/p95 for histogram with non-zero values', () => {
+    const writer = makeWriter();
+    const hist: HistogramMetric = {
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples: [10, 20, 30, 40, 50],
+    };
+    writeMetricDataPoints(writer, 'aabbccdd11223344', hist);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain('phase3:imminentSlaErrorMs:count');
+    expect(labels).toContain('phase3:imminentSlaErrorMs:mean');
+    expect(labels).toContain('phase3:imminentSlaErrorMs:p95');
+  });
+
+  it('skips zero histogram values (empty samples writes nothing)', () => {
+    const writer = makeWriter();
+    writeMetricDataPoints(writer, 'aabbccdd11223344', {
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples: [],
+    });
+    expect(writer.writeDataPoint).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// validation.
+// ───────────────────────────────────────────────────────────────
+
+describe('validateMetricEntry', () => {
+  it('accepts a valid rate metric', () => {
+    const entry: RateMetric = {
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 2,
+      total: 5,
+    };
+    expect(validateMetricEntry(entry)).toEqual(entry);
+  });
+
+  it('accepts a valid histogram metric', () => {
+    const entry: HistogramMetric = {
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples: [10, 20, 30],
+    };
+    expect(validateMetricEntry(entry)).toEqual(entry);
+  });
+
+  it('rejects non-object', () => {
+    expect(validateMetricEntry(null)).toBeNull();
+    expect(validateMetricEntry('x')).toBeNull();
+  });
+
+  it('rejects unknown kind', () => {
+    expect(
+      validateMetricEntry({ kind: 'bogus', hit: 1, total: 2 }),
+    ).toBeNull();
+  });
+
+  it('rejects rate with non-integer counts', () => {
+    expect(
+      validateMetricEntry({
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        hit: 1.5,
+        total: 2,
+      }),
+    ).toBeNull();
+    expect(
+      validateMetricEntry({
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        hit: -1,
+        total: 2,
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects rate when hit > total', () => {
+    expect(
+      validateMetricEntry({
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        hit: 5,
+        total: 2,
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects histogram with non-finite samples', () => {
+    expect(
+      validateMetricEntry({
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        samples: [10, Number.NaN, 30],
+      }),
+    ).toBeNull();
+    expect(
+      validateMetricEntry({
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        samples: [10, 'x', 30],
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects histogram when samples not array', () => {
+    expect(
+      validateMetricEntry({
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        samples: 'bogus',
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects rate when total missing detection path falls through', () => {
+    // total field 자체가 없으면 histogram 분기로 가서 samples 없음 → null
+    expect(
+      validateMetricEntry({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE }),
+    ).toBeNull();
+  });
+});
+
+describe('validateMetricBatch', () => {
+  it('rejects non-array', () => {
+    expect(validateMetricBatch({})).toBeNull();
+  });
+
+  it('accepts empty array', () => {
+    expect(validateMetricBatch([])).toEqual([]);
+  });
+
+  it('accepts mixed valid entries', () => {
+    const batch = [
+      { kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 1, total: 2 },
+      { kind: METRIC_KIND.IMMINENT_SLA_ERROR, samples: [10, 20] },
+    ];
+    expect(validateMetricBatch(batch)).toHaveLength(2);
+  });
+
+  it('rejects on any invalid entry', () => {
+    expect(
+      validateMetricBatch([
+        { kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 1, total: 2 },
+        { kind: 'bogus', hit: 0, total: 0 },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/boardingPromptOutcome.ts
+++ b/backend/alarm-worker/src/boardingPromptOutcome.ts
@@ -1,0 +1,54 @@
+/**
+ * boarding-prompt 사용자 응답 telemetry (#827 / Part of #819).
+ *
+ * 9단 게이트 통과 후 발사된 "탑승했냐?" push에 사용자가 응답한 결과(boarded/dismissed)를
+ * 백엔드가 카운트해 false positive율을 측정한다. dismiss는 silencedUntil 갱신용
+ * `/boarding-prompt/dismiss` endpoint에서 trip 상태 변경을 따로 처리하므로, 본 endpoint는
+ * 측정 목적 only.
+ *
+ * 카운트는 `metrics.ts`의 RateMetric (BOARDING_FALSE_POSITIVE)에 그대로 누적된다 —
+ * total 분모는 '게이트 통과 발사', hit 분자는 '미탑승 dismiss'.
+ */
+
+import { METRIC_KIND, writeMetricDataPoints, type RateMetric } from './metrics';
+import type { AnalyticsEngineWriter } from './types';
+
+export type BoardingPromptOutcome = 'boarded' | 'dismissed';
+
+export interface BoardingPromptOutcomePayload {
+  /** APNs device token (hex). prefix(8자)만 anonymous aggregate에 사용. */
+  token: string;
+  outcome: BoardingPromptOutcome;
+}
+
+/**
+ * payload 검증. token 빈 문자열/outcome 잘못된 값 reject.
+ */
+export function validateBoardingPromptOutcome(
+  input: unknown,
+): BoardingPromptOutcomePayload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (obj.outcome !== 'boarded' && obj.outcome !== 'dismissed') return null;
+  return { token: obj.token, outcome: obj.outcome };
+}
+
+/**
+ * outcome 한 건을 BOARDING_FALSE_POSITIVE rate metric으로 변환해 AE에 적재.
+ *
+ *   boarded   → total +1
+ *   dismissed → total +1, hit +1 (false positive 분자)
+ */
+export function recordBoardingPromptOutcome(
+  writer: AnalyticsEngineWriter,
+  payload: BoardingPromptOutcomePayload,
+): void {
+  const hit = payload.outcome === 'dismissed' ? 1 : 0;
+  const entry: RateMetric = {
+    kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+    hit,
+    total: 1,
+  };
+  writeMetricDataPoints(writer, payload.token, entry);
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -13,6 +13,10 @@
 
 import { Hono } from 'hono';
 import { markPromptSilenced } from './boardingPrompt';
+import {
+  recordBoardingPromptOutcome,
+  validateBoardingPromptOutcome,
+} from './boardingPromptOutcome';
 import { runFallbackPushes } from './fallback';
 import {
   cleanupTripWithLa,
@@ -319,6 +323,32 @@ export function validateDismissPayload(input: unknown): DismissPayload | null {
   if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
   return { token: obj.token };
 }
+
+/**
+ * boarding-prompt 응답 측정 (#827).
+ *
+ * 클라이언트가 "탑승했냐?" 푸시 응답을 받아 결과(boarded/dismissed)를 보고한다.
+ * `/boarding-prompt/dismiss`는 trip의 silencedUntil 갱신용이고 본 endpoint는 측정 only —
+ * 같은 dismiss 응답이라도 두 endpoint를 별개로 호출해야 false positive 분모/분자가 정확해진다.
+ *
+ * TELEMETRY binding 부재 시 graceful no-op (개발 환경 호환).
+ */
+app.post('/metrics/boarding-prompt', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+  const payload = validateBoardingPromptOutcome(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const writer = c.env.TELEMETRY;
+  if (writer) {
+    recordBoardingPromptOutcome(writer, payload);
+  }
+  return c.json({ ok: true });
+});
 
 interface PushAckPayload {
   pushId: string;

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "./metrics.catalog.schema.json",
+  "description": "Phase 3 fusion baseline 지표 카탈로그. backend metrics.ts와 scripts/perf-report.js의 단일 SSOT.",
+  "constants": {
+    "SLA_LATE_THRESHOLD_MS": 30000,
+    "FALSE_POSITIVE_RATIO_THRESHOLD": 0.05,
+    "MIN_SAMPLE_FOR_DECISION": 30,
+    "SLA_PERCENTILE": 0.95,
+    "METRIC_LABEL_PREFIX": "phase3"
+  },
+  "metrics": [
+    {
+      "key": "boardingFalsePositiveRate",
+      "constantName": "BOARDING_FALSE_POSITIVE",
+      "format": "rate",
+      "display": "percentage",
+      "description": "9단 게이트 통과 후 미탑승 dismiss된 비율",
+      "gate": {
+        "field": "value",
+        "op": ">",
+        "thresholdConst": "FALSE_POSITIVE_RATIO_THRESHOLD",
+        "triggerName": "falsePositive"
+      }
+    },
+    {
+      "key": "imminentSlaErrorMs",
+      "constantName": "IMMINENT_SLA_ERROR",
+      "format": "histogram",
+      "display": "numeric",
+      "description": "임박 알람 발사 vs 실제 도착 시각 차이",
+      "gate": {
+        "field": "p95",
+        "op": ">",
+        "thresholdConst": "SLA_LATE_THRESHOLD_MS",
+        "triggerName": "imminentSla"
+      }
+    },
+    {
+      "key": "stationPassedAccuracy",
+      "constantName": "STATION_PASSED_ACCURACY",
+      "format": "rate",
+      "display": "percentage",
+      "description": "사전 예약 station-passed가 실제 통과와 일치한 비율"
+    },
+    {
+      "key": "phaseClassificationAccuracy",
+      "constantName": "PHASE_CLASSIFICATION_ACCURACY",
+      "format": "rate",
+      "display": "percentage",
+      "description": "E3 4-class precision/recall"
+    },
+    {
+      "key": "driftRecoveryMeters",
+      "constantName": "DRIFT_RECOVERY",
+      "format": "histogram",
+      "display": "numeric",
+      "description": "E4 GPS 회복 시점 position 오차"
+    },
+    {
+      "key": "kalmanResidual",
+      "constantName": "KALMAN_RESIDUAL",
+      "format": "histogram",
+      "display": "numeric",
+      "description": "E2 Kalman predict vs observe 차이"
+    }
+  ]
+}

--- a/backend/alarm-worker/src/metrics.ts
+++ b/backend/alarm-worker/src/metrics.ts
@@ -2,62 +2,116 @@
  * Phase 3 fusion 효과 정량 측정 — baseline 지표 추상화 (#827).
  *
  * 기존 silent-push 텔레메트리(`telemetry.ts`)는 게이트 outcome 카운트만 다룬다.
- * 본 모듈은 Phase 3 epic(#818) 효과를 비교하기 위한 6종 핵심 지표를
- * data-driven 방식으로 집계 + Analytics Engine 적재한다. enum/객체 키 추가만으로
- * 새 지표를 등록할 수 있게 분리 — 호출 코드 변경 없이 항목이 늘어남.
+ * 본 모듈은 Phase 3 epic(#818) 효과를 비교하기 위한 핵심 지표를
+ * **데이터 주도(카탈로그 JSON)** 방식으로 집계 + Analytics Engine 적재한다.
  *
- * Phase 4 (Particle filter) 진행 결정 게이트:
- *   - 임박 알람 시점 오차 95p > SLA_LATE_THRESHOLD_MS → 진행 검토
- *   - false positive율 > FALSE_POSITIVE_RATIO_THRESHOLD → 진행 검토
- *   - 둘 다 미만이면 Phase 4 skip — ADR에 결정 근거 1회 stamp
+ *   카탈로그 = `metrics.catalog.json` (SSOT — perf-report.js와 공유)
+ *   새 지표 등록 = JSON 객체 1개 추가 (호출/리포팅/결정 코드 무수정)
+ *   새 게이트 등록 = 객체에 `gate` 필드 1개 추가
+ *
+ * Phase 4 (Particle filter) 진행 결정 게이트는 카탈로그의 `gate` 메타를 순회해
+ * 임계 위반 트리거를 자동 수집한다. if 체인 0건.
  *
  * Privacy: 개별 위치/시각/원문은 적재하지 않는다. 카운트/히스토그램/통계량만.
  * token은 8자 prefix만 anonymous aggregate에 사용.
  */
 
+import catalog from './metrics.catalog.json';
 import { tokenPrefix } from './telemetry';
 import type { AnalyticsEngineWriter } from './types';
 
 // ───────────────────────────────────────────────────────────────
-// Phase 4 결정 임계 — 매직넘버 금지 (글로벌 CLAUDE.md 3번).
+// 카탈로그 타입 — JSON SSOT를 컴파일 타임에 강타입화.
 // ───────────────────────────────────────────────────────────────
+
+type GateOperator = '>';
+type GateField = 'value' | 'p95';
+type MetricFormat = 'rate' | 'histogram';
+
+interface GateMeta {
+  field: GateField;
+  op: GateOperator;
+  thresholdConst: ConstantName;
+  triggerName: string;
+}
+
+interface MetricCatalogEntry {
+  key: string;
+  constantName: string;
+  format: MetricFormat;
+  display: 'percentage' | 'numeric';
+  description: string;
+  gate?: GateMeta;
+}
+
+type ConstantName = keyof typeof catalog.constants;
+
+const CATALOG = catalog as {
+  constants: Record<ConstantName, number | string>;
+  metrics: readonly MetricCatalogEntry[];
+};
+
+// ───────────────────────────────────────────────────────────────
+// 임계 상수 — 카탈로그 SSOT에서 추출.
+// ───────────────────────────────────────────────────────────────
+
+function readNumber(name: ConstantName): number {
+  const v = CATALOG.constants[name];
+  if (typeof v !== 'number') {
+    throw new Error(`metrics.catalog.json: constants.${name} must be number`);
+  }
+  return v;
+}
+
+function readString(name: ConstantName): string {
+  const v = CATALOG.constants[name];
+  if (typeof v !== 'string') {
+    throw new Error(`metrics.catalog.json: constants.${name} must be string`);
+  }
+  return v;
+}
 
 /** 임박 알람 발사 vs 실제 도착 시각 95p 허용치(ms). 초과 시 Phase 4 검토. */
-export const SLA_LATE_THRESHOLD_MS = 30_000;
+export const SLA_LATE_THRESHOLD_MS = readNumber('SLA_LATE_THRESHOLD_MS');
 
 /** false positive율 허용 상한(0~1). 초과 시 Phase 4 검토. */
-export const FALSE_POSITIVE_RATIO_THRESHOLD = 0.05;
+export const FALSE_POSITIVE_RATIO_THRESHOLD = readNumber('FALSE_POSITIVE_RATIO_THRESHOLD');
 
 /** Phase 4 진행 여부 판정에 필요한 최소 표본 — 통계적 의미 확보용. */
-export const MIN_SAMPLE_FOR_DECISION = 30;
+export const MIN_SAMPLE_FOR_DECISION = readNumber('MIN_SAMPLE_FOR_DECISION');
+
+/** 히스토그램 메트릭의 SLA 평가용 백분위수. 0.95 = 95p. */
+export const SLA_PERCENTILE = readNumber('SLA_PERCENTILE');
+
+/** AE 적재 label prefix — 기존 silent-push 텔레메트리와 namespace 분리. */
+const METRIC_LABEL_PREFIX = readString('METRIC_LABEL_PREFIX');
 
 // ───────────────────────────────────────────────────────────────
-// 지표 카탈로그 — data-driven (글로벌 CLAUDE.md 3번).
-// 새 지표 추가 = 객체 키 1개 추가. 호출/리포팅 코드 무수정.
+// 지표 카탈로그 외부 노출 — METRIC_KIND는 기존 호출자/테스트 호환을 위해
+// 카탈로그에서 동적 생성 (constantName → key 매핑).
 // ───────────────────────────────────────────────────────────────
 
 /**
- * Phase 3 핵심 지표 6종 (이슈 #827 본문 범위).
- *
- *   1. boardingFalsePositiveRate — 9단 게이트 통과 후 "미탑승" dismiss된 비율
- *   2. imminentSlaErrorMs        — 임박 알람 발사 vs 실제 도착 시각 차이 (히스토그램)
- *   3. stationPassedAccuracy     — 사전 예약 station-passed가 실제 통과와 일치한 비율
- *   4. phaseClassificationAccuracy — E3 4-class precision/recall (라벨링 가능 시)
- *   5. driftRecoveryMeters       — E4 GPS 회복 시점에 측정된 position 오차 (히스토그램)
- *   6. kalmanResidual            — E2 Kalman predict vs observe 차이 (히스토그램)
+ * Phase 3 핵심 지표 — 카탈로그(`metrics.catalog.json`)에서 동적 생성.
+ * 새 지표 추가 = JSON 객체 1개 추가. 호출/리포팅 코드 무수정.
  */
-export const METRIC_KIND = {
-  BOARDING_FALSE_POSITIVE: 'boardingFalsePositiveRate',
-  IMMINENT_SLA_ERROR: 'imminentSlaErrorMs',
-  STATION_PASSED_ACCURACY: 'stationPassedAccuracy',
-  PHASE_CLASSIFICATION_ACCURACY: 'phaseClassificationAccuracy',
-  DRIFT_RECOVERY: 'driftRecoveryMeters',
-  KALMAN_RESIDUAL: 'kalmanResidual',
-} as const;
+export const METRIC_KIND: Readonly<Record<string, string>> = Object.freeze(
+  CATALOG.metrics.reduce<Record<string, string>>((acc, m) => {
+    acc[m.constantName] = m.key;
+    return acc;
+  }, {}),
+);
 
-export type MetricKind = (typeof METRIC_KIND)[keyof typeof METRIC_KIND];
+export type MetricKind = string;
 
-const METRIC_KINDS: readonly MetricKind[] = Object.values(METRIC_KIND);
+const METRIC_KEYS: readonly string[] = CATALOG.metrics.map((m) => m.key);
+
+function findEntry(kind: MetricKind): MetricCatalogEntry | undefined {
+  return CATALOG.metrics.find((m) => m.key === kind);
+}
+
+/** 카탈로그 entry 외부 노출 — 리포팅/테스트에서 순회용. 불변. */
+export const METRIC_CATALOG: readonly MetricCatalogEntry[] = Object.freeze([...CATALOG.metrics]);
 
 /**
  * 비율형 지표 (0~1). hit / total 누적 → rate = hit / total.
@@ -90,7 +144,7 @@ export function isRateMetric(entry: MetricEntry): entry is RateMetric {
 // 통계량 — 외부 의존성 없음 (linear scan).
 // ───────────────────────────────────────────────────────────────
 
-/** sample 배열의 p95 — 정렬 후 ceil(0.95 * n) - 1 인덱스. 빈 배열은 0. */
+/** sample 배열의 p 분위수 — 정렬 후 ceil(p * n) - 1 인덱스. 빈 배열은 0. */
 export function percentile(samples: readonly number[], p: number): number {
   if (samples.length === 0) return 0;
   if (p < 0 || p > 1) return 0;
@@ -148,50 +202,77 @@ export function summarizeMetric(entry: MetricEntry): MetricSummary {
   return {
     kind: entry.kind,
     value: mean(entry.samples),
-    p95: percentile(entry.samples, 0.95),
+    p95: percentile(entry.samples, SLA_PERCENTILE),
     count: entry.samples.length,
     significant: entry.samples.length >= MIN_SAMPLE_FOR_DECISION,
   };
 }
 
 // ───────────────────────────────────────────────────────────────
-// Phase 4 결정 게이트.
+// Phase 4 결정 게이트 — 카탈로그의 `gate` 메타를 순회.
+// 새 게이트 추가 = 카탈로그 객체에 `gate` 필드 추가. 분기 코드 무수정.
 // ───────────────────────────────────────────────────────────────
-
-export interface PhaseFourDecisionInputs {
-  /** boardingFalsePositiveRate 요약 — RateMetric 기반. */
-  falsePositive: MetricSummary;
-  /** imminentSlaErrorMs 요약 — HistogramMetric 기반. */
-  imminentSla: MetricSummary;
-}
 
 export interface PhaseFourDecision {
   /** true = Phase 4 검토 권장 (임계 초과). false = skip 권장. */
   proceed: boolean;
-  /** 의미 있는 표본이 한쪽이라도 부족하면 결정 보류. */
+  /** gate가 등록된 지표 중 의미 있는 표본이 한쪽이라도 부족하면 결정 보류. */
   insufficientSamples: boolean;
-  /** 어느 지표가 임계를 넘었는지 — ADR stamp 근거 기록용. */
-  triggers: ReadonlyArray<'falsePositive' | 'imminentSla'>;
+  /** 어느 지표가 임계를 넘었는지 — ADR stamp 근거 기록용. 카탈로그 triggerName 순. */
+  triggers: readonly string[];
+}
+
+interface GateBinding {
+  entry: MetricCatalogEntry;
+  gate: GateMeta;
+}
+
+/** 카탈로그에서 gate가 있는 메트릭만 추출 — Phase 4 결정 입력. */
+function gatedEntries(): readonly GateBinding[] {
+  return CATALOG.metrics
+    .filter((m): m is MetricCatalogEntry & { gate: GateMeta } => m.gate !== undefined)
+    .map((m) => ({ entry: m, gate: m.gate }));
+}
+
+function gateThreshold(gate: GateMeta): number {
+  return readNumber(gate.thresholdConst);
+}
+
+function gateValue(summary: MetricSummary, gate: GateMeta): number {
+  return gate.field === 'p95' ? summary.p95 : summary.value;
+}
+
+function gateBreached(summary: MetricSummary, gate: GateMeta): boolean {
+  const threshold = gateThreshold(gate);
+  const v = gateValue(summary, gate);
+  // 현재 op는 '>'만 지원 — 추후 카탈로그 확장 시 분기 추가.
+  return gate.op === '>' && v > threshold;
 }
 
 /**
  * Phase 4 (Particle filter) 진행 여부 판정.
  *
- * 둘 다 의미 있는 표본을 갖춰야 결정 — 한쪽이라도 부족하면 보류 (proceed=false,
- * insufficientSamples=true). triggers 배열은 데이터 주도로 임계 위반 지표를 모두 수집해
- * ADR에 일괄 기록 가능.
+ * 카탈로그에서 `gate`가 정의된 모든 메트릭의 요약을 입력받아 임계 위반 여부 평가.
+ * 게이트가 있는 모든 메트릭이 의미 있는 표본을 갖춰야 결정 — 한쪽이라도 부족하면
+ * 보류 (proceed=false, insufficientSamples=true).
+ *
+ * @param summaries 요약 배열 — gate 등록된 메트릭의 summary가 모두 포함되어야 함
  */
-export function decidePhaseFour(inputs: PhaseFourDecisionInputs): PhaseFourDecision {
-  const insufficient = !inputs.falsePositive.significant || !inputs.imminentSla.significant;
-  if (insufficient) {
-    return { proceed: false, insufficientSamples: true, triggers: [] };
+export function decidePhaseFour(summaries: readonly MetricSummary[]): PhaseFourDecision {
+  const byKind = new Map(summaries.map((s) => [s.kind, s]));
+  const gates = gatedEntries();
+  // gate 등록된 메트릭 중 missing 또는 insignificant면 hold.
+  for (const { entry } of gates) {
+    const s = byKind.get(entry.key);
+    if (!s || !s.significant) {
+      return { proceed: false, insufficientSamples: true, triggers: [] };
+    }
   }
-  const triggers: Array<'falsePositive' | 'imminentSla'> = [];
-  if (inputs.falsePositive.value > FALSE_POSITIVE_RATIO_THRESHOLD) {
-    triggers.push('falsePositive');
-  }
-  if (inputs.imminentSla.p95 > SLA_LATE_THRESHOLD_MS) {
-    triggers.push('imminentSla');
+  const triggers: string[] = [];
+  for (const { entry, gate } of gates) {
+    // missing 분기는 위 loop에서 이미 hold로 반환됨 — non-null 보장.
+    const s = byKind.get(entry.key) as MetricSummary;
+    if (gateBreached(s, gate)) triggers.push(gate.triggerName);
   }
   return {
     proceed: triggers.length > 0,
@@ -204,8 +285,8 @@ export function decidePhaseFour(inputs: PhaseFourDecisionInputs): PhaseFourDecis
 // Analytics Engine 적재 — telemetry.ts와 동일 schema, 별도 label namespace.
 // ───────────────────────────────────────────────────────────────
 
-/** AE 적재 label prefix — 기존 silent-push 텔레메트리와 namespace 분리. */
-const METRIC_LABEL_PREFIX = 'phase3';
+/** 히스토그램 p95 적재용 label 접미사 — SLA_PERCENTILE 기반 동적 생성. */
+const HISTOGRAM_PERCENTILE_LABEL = `p${Math.round(SLA_PERCENTILE * 100)}`;
 
 /**
  * MetricEntry 한 건을 AE에 적재. RateMetric은 hit/total 두 point,
@@ -242,7 +323,7 @@ export function writeMetricDataPoints(
   const summary = summarizeMetric(entry);
   write('count', summary.count);
   write('mean', summary.value);
-  write('p95', summary.p95);
+  write(HISTOGRAM_PERCENTILE_LABEL, summary.p95);
 }
 
 // ───────────────────────────────────────────────────────────────
@@ -258,7 +339,7 @@ function isNonNegativeInt(value: unknown): value is number {
 }
 
 function isKnownKind(value: unknown): value is MetricKind {
-  return typeof value === 'string' && METRIC_KINDS.includes(value as MetricKind);
+  return typeof value === 'string' && METRIC_KEYS.includes(value);
 }
 
 /**
@@ -271,12 +352,14 @@ export function validateMetricEntry(input: unknown): MetricEntry | null {
   if (!input || typeof input !== 'object') return null;
   const obj = input as Record<string, unknown>;
   if (!isKnownKind(obj.kind)) return null;
-  // rate 우선 — total 필드 존재로 분기.
-  if ('total' in obj) {
+  const meta = findEntry(obj.kind);
+  // 카탈로그의 format에 따라 분기 — rate면 hit/total, histogram이면 samples.
+  if (meta?.format === 'rate') {
     if (!isNonNegativeInt(obj.hit) || !isNonNegativeInt(obj.total)) return null;
     if (obj.hit > obj.total) return null;
     return { kind: obj.kind, hit: obj.hit, total: obj.total };
   }
+  // histogram (or unknown — safety net으로 histogram 처리)
   if (!Array.isArray(obj.samples)) return null;
   const samples: number[] = [];
   for (const v of obj.samples) {
@@ -299,3 +382,4 @@ export function validateMetricBatch(input: unknown): MetricEntry[] | null {
   }
   return out;
 }
+

--- a/backend/alarm-worker/src/metrics.ts
+++ b/backend/alarm-worker/src/metrics.ts
@@ -1,0 +1,301 @@
+/**
+ * Phase 3 fusion 효과 정량 측정 — baseline 지표 추상화 (#827).
+ *
+ * 기존 silent-push 텔레메트리(`telemetry.ts`)는 게이트 outcome 카운트만 다룬다.
+ * 본 모듈은 Phase 3 epic(#818) 효과를 비교하기 위한 6종 핵심 지표를
+ * data-driven 방식으로 집계 + Analytics Engine 적재한다. enum/객체 키 추가만으로
+ * 새 지표를 등록할 수 있게 분리 — 호출 코드 변경 없이 항목이 늘어남.
+ *
+ * Phase 4 (Particle filter) 진행 결정 게이트:
+ *   - 임박 알람 시점 오차 95p > SLA_LATE_THRESHOLD_MS → 진행 검토
+ *   - false positive율 > FALSE_POSITIVE_RATIO_THRESHOLD → 진행 검토
+ *   - 둘 다 미만이면 Phase 4 skip — ADR에 결정 근거 1회 stamp
+ *
+ * Privacy: 개별 위치/시각/원문은 적재하지 않는다. 카운트/히스토그램/통계량만.
+ * token은 8자 prefix만 anonymous aggregate에 사용.
+ */
+
+import { tokenPrefix } from './telemetry';
+import type { AnalyticsEngineWriter } from './types';
+
+// ───────────────────────────────────────────────────────────────
+// Phase 4 결정 임계 — 매직넘버 금지 (글로벌 CLAUDE.md 3번).
+// ───────────────────────────────────────────────────────────────
+
+/** 임박 알람 발사 vs 실제 도착 시각 95p 허용치(ms). 초과 시 Phase 4 검토. */
+export const SLA_LATE_THRESHOLD_MS = 30_000;
+
+/** false positive율 허용 상한(0~1). 초과 시 Phase 4 검토. */
+export const FALSE_POSITIVE_RATIO_THRESHOLD = 0.05;
+
+/** Phase 4 진행 여부 판정에 필요한 최소 표본 — 통계적 의미 확보용. */
+export const MIN_SAMPLE_FOR_DECISION = 30;
+
+// ───────────────────────────────────────────────────────────────
+// 지표 카탈로그 — data-driven (글로벌 CLAUDE.md 3번).
+// 새 지표 추가 = 객체 키 1개 추가. 호출/리포팅 코드 무수정.
+// ───────────────────────────────────────────────────────────────
+
+/**
+ * Phase 3 핵심 지표 6종 (이슈 #827 본문 범위).
+ *
+ *   1. boardingFalsePositiveRate — 9단 게이트 통과 후 "미탑승" dismiss된 비율
+ *   2. imminentSlaErrorMs        — 임박 알람 발사 vs 실제 도착 시각 차이 (히스토그램)
+ *   3. stationPassedAccuracy     — 사전 예약 station-passed가 실제 통과와 일치한 비율
+ *   4. phaseClassificationAccuracy — E3 4-class precision/recall (라벨링 가능 시)
+ *   5. driftRecoveryMeters       — E4 GPS 회복 시점에 측정된 position 오차 (히스토그램)
+ *   6. kalmanResidual            — E2 Kalman predict vs observe 차이 (히스토그램)
+ */
+export const METRIC_KIND = {
+  BOARDING_FALSE_POSITIVE: 'boardingFalsePositiveRate',
+  IMMINENT_SLA_ERROR: 'imminentSlaErrorMs',
+  STATION_PASSED_ACCURACY: 'stationPassedAccuracy',
+  PHASE_CLASSIFICATION_ACCURACY: 'phaseClassificationAccuracy',
+  DRIFT_RECOVERY: 'driftRecoveryMeters',
+  KALMAN_RESIDUAL: 'kalmanResidual',
+} as const;
+
+export type MetricKind = (typeof METRIC_KIND)[keyof typeof METRIC_KIND];
+
+const METRIC_KINDS: readonly MetricKind[] = Object.values(METRIC_KIND);
+
+/**
+ * 비율형 지표 (0~1). hit / total 누적 → rate = hit / total.
+ * total이 MIN_SAMPLE_FOR_DECISION 미만이면 의미 없는 표본으로 간주.
+ */
+export interface RateMetric {
+  kind: MetricKind;
+  hit: number;
+  total: number;
+}
+
+/**
+ * 히스토그램형 지표. observed 값을 그대로 받아 mean/p95/min/max 산출.
+ * count가 MIN_SAMPLE_FOR_DECISION 미만이면 의미 없는 표본으로 간주.
+ */
+export interface HistogramMetric {
+  kind: MetricKind;
+  /** 최근 N개 sample. 호출자가 ring buffer로 보관할 수도, 모두 누적할 수도 있음. */
+  samples: readonly number[];
+}
+
+export type MetricEntry = RateMetric | HistogramMetric;
+
+/** RateMetric type guard. */
+export function isRateMetric(entry: MetricEntry): entry is RateMetric {
+  return 'total' in entry;
+}
+
+// ───────────────────────────────────────────────────────────────
+// 통계량 — 외부 의존성 없음 (linear scan).
+// ───────────────────────────────────────────────────────────────
+
+/** sample 배열의 p95 — 정렬 후 ceil(0.95 * n) - 1 인덱스. 빈 배열은 0. */
+export function percentile(samples: readonly number[], p: number): number {
+  if (samples.length === 0) return 0;
+  if (p < 0 || p > 1) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(p * sorted.length) - 1));
+  return sorted[idx];
+}
+
+/** sample 배열 평균. 빈 배열은 0. */
+export function mean(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  let sum = 0;
+  for (const v of samples) sum += v;
+  return sum / samples.length;
+}
+
+/** RateMetric → 0~1 비율. total=0이면 0. */
+export function rate(metric: RateMetric): number {
+  if (metric.total === 0) return 0;
+  return metric.hit / metric.total;
+}
+
+// ───────────────────────────────────────────────────────────────
+// 요약 — Phase 4 결정 입력에 그대로 사용.
+// ───────────────────────────────────────────────────────────────
+
+export interface MetricSummary {
+  kind: MetricKind;
+  /** RateMetric인 경우 rate, HistogramMetric인 경우 mean. */
+  value: number;
+  /** 히스토그램 한정 — RateMetric은 0. */
+  p95: number;
+  /** 표본 수 (rate=total, histogram=count). */
+  count: number;
+  /**
+   * MIN_SAMPLE_FOR_DECISION 충족 여부 — Phase 4 결정 게이트 입력.
+   * false면 위 value/p95는 표본 부족으로 무시해야 한다.
+   */
+  significant: boolean;
+}
+
+/**
+ * 단일 지표 요약. 호출자가 호출 시점에 한 번 계산해 perf-report/decision 양쪽에 전달.
+ */
+export function summarizeMetric(entry: MetricEntry): MetricSummary {
+  if (isRateMetric(entry)) {
+    return {
+      kind: entry.kind,
+      value: rate(entry),
+      p95: 0,
+      count: entry.total,
+      significant: entry.total >= MIN_SAMPLE_FOR_DECISION,
+    };
+  }
+  return {
+    kind: entry.kind,
+    value: mean(entry.samples),
+    p95: percentile(entry.samples, 0.95),
+    count: entry.samples.length,
+    significant: entry.samples.length >= MIN_SAMPLE_FOR_DECISION,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────
+// Phase 4 결정 게이트.
+// ───────────────────────────────────────────────────────────────
+
+export interface PhaseFourDecisionInputs {
+  /** boardingFalsePositiveRate 요약 — RateMetric 기반. */
+  falsePositive: MetricSummary;
+  /** imminentSlaErrorMs 요약 — HistogramMetric 기반. */
+  imminentSla: MetricSummary;
+}
+
+export interface PhaseFourDecision {
+  /** true = Phase 4 검토 권장 (임계 초과). false = skip 권장. */
+  proceed: boolean;
+  /** 의미 있는 표본이 한쪽이라도 부족하면 결정 보류. */
+  insufficientSamples: boolean;
+  /** 어느 지표가 임계를 넘었는지 — ADR stamp 근거 기록용. */
+  triggers: ReadonlyArray<'falsePositive' | 'imminentSla'>;
+}
+
+/**
+ * Phase 4 (Particle filter) 진행 여부 판정.
+ *
+ * 둘 다 의미 있는 표본을 갖춰야 결정 — 한쪽이라도 부족하면 보류 (proceed=false,
+ * insufficientSamples=true). triggers 배열은 데이터 주도로 임계 위반 지표를 모두 수집해
+ * ADR에 일괄 기록 가능.
+ */
+export function decidePhaseFour(inputs: PhaseFourDecisionInputs): PhaseFourDecision {
+  const insufficient = !inputs.falsePositive.significant || !inputs.imminentSla.significant;
+  if (insufficient) {
+    return { proceed: false, insufficientSamples: true, triggers: [] };
+  }
+  const triggers: Array<'falsePositive' | 'imminentSla'> = [];
+  if (inputs.falsePositive.value > FALSE_POSITIVE_RATIO_THRESHOLD) {
+    triggers.push('falsePositive');
+  }
+  if (inputs.imminentSla.p95 > SLA_LATE_THRESHOLD_MS) {
+    triggers.push('imminentSla');
+  }
+  return {
+    proceed: triggers.length > 0,
+    insufficientSamples: false,
+    triggers,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────
+// Analytics Engine 적재 — telemetry.ts와 동일 schema, 별도 label namespace.
+// ───────────────────────────────────────────────────────────────
+
+/** AE 적재 label prefix — 기존 silent-push 텔레메트리와 namespace 분리. */
+const METRIC_LABEL_PREFIX = 'phase3';
+
+/**
+ * MetricEntry 한 건을 AE에 적재. RateMetric은 hit/total 두 point,
+ * HistogramMetric은 count/mean/p95 세 point로 분해해 query하기 쉽게.
+ *
+ * Schema:
+ *   blob1 = `${prefix}:${kind}:${field}` (예: phase3:boardingFalsePositiveRate:hit)
+ *   blob2 = token prefix (8자)
+ *   double1 = value
+ *   index1 = token prefix (sampling용)
+ *
+ * 0값은 skip — query 노이즈 감소. token이 빈 문자열인 경우(서버 합산 등) prefix 그대로.
+ */
+export function writeMetricDataPoints(
+  writer: AnalyticsEngineWriter,
+  token: string,
+  entry: MetricEntry,
+): void {
+  const prefix = tokenPrefix(token);
+  const write = (field: string, value: number): void => {
+    if (value <= 0) return;
+    writer.writeDataPoint({
+      blobs: [`${METRIC_LABEL_PREFIX}:${entry.kind}:${field}`, prefix],
+      doubles: [value],
+      indexes: [prefix],
+    });
+  };
+
+  if (isRateMetric(entry)) {
+    write('hit', entry.hit);
+    write('total', entry.total);
+    return;
+  }
+  const summary = summarizeMetric(entry);
+  write('count', summary.count);
+  write('mean', summary.value);
+  write('p95', summary.p95);
+}
+
+// ───────────────────────────────────────────────────────────────
+// payload validation — perf-report CLI / HTTP endpoint 공용.
+// ───────────────────────────────────────────────────────────────
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonNegativeInt(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0 && Number.isInteger(value);
+}
+
+function isKnownKind(value: unknown): value is MetricKind {
+  return typeof value === 'string' && METRIC_KINDS.includes(value as MetricKind);
+}
+
+/**
+ * 외부에서 들어온 단일 MetricEntry payload 검증.
+ * - kind는 카탈로그 등록된 값만 허용
+ * - rate는 hit/total 자연수
+ * - histogram은 samples가 유한수 배열
+ */
+export function validateMetricEntry(input: unknown): MetricEntry | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (!isKnownKind(obj.kind)) return null;
+  // rate 우선 — total 필드 존재로 분기.
+  if ('total' in obj) {
+    if (!isNonNegativeInt(obj.hit) || !isNonNegativeInt(obj.total)) return null;
+    if (obj.hit > obj.total) return null;
+    return { kind: obj.kind, hit: obj.hit, total: obj.total };
+  }
+  if (!Array.isArray(obj.samples)) return null;
+  const samples: number[] = [];
+  for (const v of obj.samples) {
+    if (!isFiniteNumber(v)) return null;
+    samples.push(v);
+  }
+  return { kind: obj.kind, samples };
+}
+
+/**
+ * MetricEntry 배열 일괄 검증. 하나라도 깨졌으면 null — 호출자는 400으로.
+ */
+export function validateMetricBatch(input: unknown): MetricEntry[] | null {
+  if (!Array.isArray(input)) return null;
+  const out: MetricEntry[] = [];
+  for (const raw of input) {
+    const entry = validateMetricEntry(raw);
+    if (!entry) return null;
+    out.push(entry);
+  }
+  return out;
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "data:fetch-quick-exit": "node scripts/fetch-quick-exit.js",
     "data:build-transfer-times": "node scripts/build-transfer-times.js",
     "tail:capture": "scripts/capture-tail.sh",
+    "perf:report": "node scripts/perf-report.js",
     "e2e": "maestro test .maestro/flows/",
     "e2e:home": "maestro test .maestro/flows/home/",
     "e2e:favorites": "maestro test .maestro/flows/favorites/",

--- a/scripts/__tests__/perf-report.test.js
+++ b/scripts/__tests__/perf-report.test.js
@@ -1,0 +1,456 @@
+/**
+ * perf-report (#827) — 순수 함수 + CLI smoke 검증.
+ *
+ * golden MetricEntry 입력 → expected 수치/Phase 4 결정 일치 확인.
+ */
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  METRIC_KIND,
+  SLA_LATE_THRESHOLD_MS,
+  FALSE_POSITIVE_RATIO_THRESHOLD,
+  MIN_SAMPLE_FOR_DECISION,
+  percentile,
+  mean,
+  isRate,
+  summarize,
+  decidePhaseFour,
+  validateEntry,
+  validateBatch,
+  buildReport,
+  formatSummary,
+  formatReport,
+  main,
+} = require('../perf-report');
+
+describe('percentile', () => {
+  it('returns 0 for empty', () => {
+    expect(percentile([], 0.95)).toBe(0);
+  });
+  it('computes p95 on 1..100 → 95', () => {
+    const samples = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(percentile(samples, 0.95)).toBe(95);
+  });
+  it('clamps to last index when p=1', () => {
+    expect(percentile([1, 2, 3], 1)).toBe(3);
+  });
+  it('returns 0 for out-of-range p', () => {
+    expect(percentile([1, 2], -0.1)).toBe(0);
+    expect(percentile([1, 2], 1.1)).toBe(0);
+  });
+});
+
+describe('mean', () => {
+  it('returns 0 for empty', () => {
+    expect(mean([])).toBe(0);
+  });
+  it('averages numbers', () => {
+    expect(mean([2, 4, 6])).toBe(4);
+  });
+});
+
+describe('isRate', () => {
+  it('detects total field', () => {
+    expect(isRate({ hit: 1, total: 2 })).toBe(true);
+  });
+  it('histogram has no total', () => {
+    expect(isRate({ samples: [] })).toBe(false);
+  });
+});
+
+describe('summarize', () => {
+  it('summarizes rate (0 total → 0 value)', () => {
+    const result = summarize({
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 0,
+      total: 0,
+    });
+    expect(result.value).toBe(0);
+    expect(result.significant).toBe(false);
+  });
+  it('marks rate significant beyond threshold', () => {
+    const result = summarize({
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 3,
+      total: MIN_SAMPLE_FOR_DECISION,
+    });
+    expect(result.significant).toBe(true);
+    expect(result.value).toBeCloseTo(3 / MIN_SAMPLE_FOR_DECISION);
+  });
+  it('summarizes histogram', () => {
+    const samples = Array.from({ length: 40 }, (_, i) => i + 1);
+    const result = summarize({
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples,
+    });
+    expect(result.count).toBe(40);
+    expect(result.p95).toBe(38);
+    expect(result.significant).toBe(true);
+  });
+});
+
+describe('decidePhaseFour', () => {
+  const sufficient = (kind, value, p95) => ({
+    kind,
+    value,
+    p95,
+    count: MIN_SAMPLE_FOR_DECISION,
+    significant: true,
+  });
+
+  it('insufficient when fp missing', () => {
+    const d = decidePhaseFour([
+      sufficient(METRIC_KIND.IMMINENT_SLA_ERROR, 100, 100),
+    ]);
+    expect(d.insufficientSamples).toBe(true);
+  });
+
+  it('insufficient when sla missing', () => {
+    const d = decidePhaseFour([
+      sufficient(METRIC_KIND.BOARDING_FALSE_POSITIVE, 0.01, 0),
+    ]);
+    expect(d.insufficientSamples).toBe(true);
+  });
+
+  it('insufficient when fp significant=false', () => {
+    const d = decidePhaseFour([
+      { ...sufficient(METRIC_KIND.BOARDING_FALSE_POSITIVE, 0, 0), significant: false },
+      sufficient(METRIC_KIND.IMMINENT_SLA_ERROR, 100, 100),
+    ]);
+    expect(d.insufficientSamples).toBe(true);
+  });
+
+  it('insufficient when sla significant=false', () => {
+    const d = decidePhaseFour([
+      sufficient(METRIC_KIND.BOARDING_FALSE_POSITIVE, 0.01, 0),
+      { ...sufficient(METRIC_KIND.IMMINENT_SLA_ERROR, 100, 100), significant: false },
+    ]);
+    expect(d.insufficientSamples).toBe(true);
+  });
+
+  it('skip when within thresholds', () => {
+    const d = decidePhaseFour([
+      sufficient(METRIC_KIND.BOARDING_FALSE_POSITIVE, FALSE_POSITIVE_RATIO_THRESHOLD, 0),
+      sufficient(METRIC_KIND.IMMINENT_SLA_ERROR, 0, SLA_LATE_THRESHOLD_MS),
+    ]);
+    expect(d.proceed).toBe(false);
+    expect(d.triggers).toEqual([]);
+  });
+
+  it('triggers on fp breach', () => {
+    const d = decidePhaseFour([
+      sufficient(
+        METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        FALSE_POSITIVE_RATIO_THRESHOLD + 0.01,
+        0,
+      ),
+      sufficient(METRIC_KIND.IMMINENT_SLA_ERROR, 0, SLA_LATE_THRESHOLD_MS),
+    ]);
+    expect(d.proceed).toBe(true);
+    expect(d.triggers).toEqual(['falsePositive']);
+  });
+
+  it('triggers on sla breach', () => {
+    const d = decidePhaseFour([
+      sufficient(METRIC_KIND.BOARDING_FALSE_POSITIVE, 0, 0),
+      sufficient(METRIC_KIND.IMMINENT_SLA_ERROR, 0, SLA_LATE_THRESHOLD_MS + 1),
+    ]);
+    expect(d.proceed).toBe(true);
+    expect(d.triggers).toEqual(['imminentSla']);
+  });
+});
+
+describe('validateEntry', () => {
+  it('accepts rate', () => {
+    expect(validateEntry({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 1, total: 2 })).toEqual({
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 1,
+      total: 2,
+    });
+  });
+  it('accepts histogram', () => {
+    expect(validateEntry({ kind: METRIC_KIND.IMMINENT_SLA_ERROR, samples: [1, 2] })).toEqual({
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples: [1, 2],
+    });
+  });
+  it('rejects non-object', () => {
+    expect(validateEntry(null)).toBeNull();
+    expect(validateEntry('x')).toBeNull();
+  });
+  it('rejects unknown kind', () => {
+    expect(validateEntry({ kind: 'bogus', hit: 0, total: 0 })).toBeNull();
+  });
+  it('rejects rate with negative count', () => {
+    expect(
+      validateEntry({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: -1, total: 0 }),
+    ).toBeNull();
+  });
+  it('rejects rate with non-integer', () => {
+    expect(
+      validateEntry({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 1.5, total: 2 }),
+    ).toBeNull();
+  });
+  it('rejects rate when total < hit', () => {
+    expect(
+      validateEntry({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 5, total: 2 }),
+    ).toBeNull();
+  });
+  it('rejects rate with negative total', () => {
+    expect(
+      validateEntry({ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 0, total: -1 }),
+    ).toBeNull();
+  });
+  it('rejects histogram with non-array samples', () => {
+    expect(validateEntry({ kind: METRIC_KIND.IMMINENT_SLA_ERROR, samples: 'x' })).toBeNull();
+  });
+  it('rejects histogram with non-finite samples', () => {
+    expect(
+      validateEntry({ kind: METRIC_KIND.IMMINENT_SLA_ERROR, samples: [1, NaN] }),
+    ).toBeNull();
+    expect(
+      validateEntry({ kind: METRIC_KIND.IMMINENT_SLA_ERROR, samples: [1, 'x'] }),
+    ).toBeNull();
+  });
+});
+
+describe('validateBatch', () => {
+  it('rejects non-array', () => {
+    expect(validateBatch({})).toBeNull();
+  });
+  it('accepts empty', () => {
+    expect(validateBatch([])).toEqual([]);
+  });
+  it('rejects on invalid entry', () => {
+    expect(
+      validateBatch([
+        { kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 0, total: 0 },
+        { kind: 'bogus' },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe('buildReport + formatReport', () => {
+  const golden = [
+    {
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      hit: 1,
+      total: 50,
+    },
+    {
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      samples: Array.from({ length: 40 }, (_, i) => 1000 + i * 100),
+    },
+    {
+      kind: METRIC_KIND.STATION_PASSED_ACCURACY,
+      hit: 48,
+      total: 50,
+    },
+    {
+      kind: METRIC_KIND.PHASE_CLASSIFICATION_ACCURACY,
+      hit: 30,
+      total: 40,
+    },
+    {
+      kind: METRIC_KIND.DRIFT_RECOVERY,
+      samples: [5, 10, 15],
+    },
+    {
+      kind: METRIC_KIND.KALMAN_RESIDUAL,
+      samples: [0.1, 0.2, 0.3],
+    },
+  ];
+
+  it('reports summaries and SKIP decision (within thresholds)', () => {
+    const report = buildReport(golden);
+    expect(report.summaries).toHaveLength(6);
+    expect(report.decision.insufficientSamples).toBe(false);
+    expect(report.decision.proceed).toBe(false);
+  });
+
+  it('formatReport lists every summary and SKIP line', () => {
+    const text = formatReport(buildReport(golden));
+    expect(text).toContain(METRIC_KIND.BOARDING_FALSE_POSITIVE);
+    expect(text).toContain(METRIC_KIND.IMMINENT_SLA_ERROR);
+    expect(text).toContain(METRIC_KIND.STATION_PASSED_ACCURACY);
+    expect(text).toContain('SKIP');
+  });
+
+  it('formatReport HOLD when insufficient samples', () => {
+    const minimal = [{ kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 0, total: 0 }];
+    expect(formatReport(buildReport(minimal))).toContain('HOLD');
+  });
+
+  it('formatReport PROCEED when fp breach', () => {
+    const breach = [
+      {
+        kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+        hit: MIN_SAMPLE_FOR_DECISION,
+        total: MIN_SAMPLE_FOR_DECISION,
+      },
+      {
+        kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+        samples: Array.from({ length: MIN_SAMPLE_FOR_DECISION }, () => 0),
+      },
+    ];
+    expect(formatReport(buildReport(breach))).toContain('PROCEED');
+  });
+});
+
+describe('formatSummary', () => {
+  it('formats rate metric as percentage', () => {
+    const text = formatSummary({
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      value: 0.05,
+      p95: 0,
+      count: 100,
+      significant: true,
+    });
+    expect(text).toContain('5.00%');
+    expect(text).toContain('n=100');
+  });
+
+  it('marks insufficient samples', () => {
+    const text = formatSummary({
+      kind: METRIC_KIND.BOARDING_FALSE_POSITIVE,
+      value: 0,
+      p95: 0,
+      count: 1,
+      significant: false,
+    });
+    expect(text).toContain('insufficient');
+  });
+
+  it('formats accuracy metric as percentage', () => {
+    const text = formatSummary({
+      kind: METRIC_KIND.STATION_PASSED_ACCURACY,
+      value: 0.98,
+      p95: 0,
+      count: 100,
+      significant: true,
+    });
+    expect(text).toContain('98.00%');
+  });
+
+  it('marks insufficient on accuracy metric below threshold', () => {
+    const text = formatSummary({
+      kind: METRIC_KIND.PHASE_CLASSIFICATION_ACCURACY,
+      value: 0,
+      p95: 0,
+      count: 2,
+      significant: false,
+    });
+    expect(text).toContain('insufficient');
+  });
+
+  it('marks insufficient on histogram below threshold', () => {
+    const text = formatSummary({
+      kind: METRIC_KIND.DRIFT_RECOVERY,
+      value: 0,
+      p95: 0,
+      count: 1,
+      significant: false,
+    });
+    expect(text).toContain('insufficient');
+  });
+
+  it('formats histogram with mean and p95', () => {
+    const text = formatSummary({
+      kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+      value: 1500.5,
+      p95: 2800.25,
+      count: 40,
+      significant: true,
+    });
+    expect(text).toContain('mean=1500.50');
+    expect(text).toContain('p95=2800.25');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// CLI smoke.
+// ───────────────────────────────────────────────────────────────
+
+describe('main (CLI smoke)', () => {
+  function makeEnv() {
+    const out = [];
+    const err = [];
+    return {
+      stdin: '[]',
+      writeOut: (msg) => out.push(msg),
+      writeErr: (msg) => err.push(msg),
+      out,
+      err,
+    };
+  }
+
+  it('reads from stdin when no file arg, prints HOLD on empty batch', () => {
+    const env = makeEnv();
+    const code = main(['node', 'perf-report'], env);
+    expect(code).toBe(0);
+    expect(env.out.join('\n')).toContain('HOLD');
+  });
+
+  it('reads from file path when given', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-report-'));
+    const filePath = path.join(dir, 'm.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify([
+        { kind: METRIC_KIND.BOARDING_FALSE_POSITIVE, hit: 1, total: MIN_SAMPLE_FOR_DECISION },
+        {
+          kind: METRIC_KIND.IMMINENT_SLA_ERROR,
+          samples: Array.from({ length: MIN_SAMPLE_FOR_DECISION }, () => 1000),
+        },
+      ]),
+    );
+    const env = makeEnv();
+    const code = main(['node', 'perf-report', filePath], env);
+    fs.rmSync(dir, { recursive: true, force: true });
+    expect(code).toBe(0);
+    expect(env.out.join('\n')).toContain('Phase 4 decision');
+  });
+
+  it('exits 1 on invalid JSON', () => {
+    const env = makeEnv();
+    env.stdin = 'not-json{';
+    const code = main(['node', 'perf-report'], env);
+    expect(code).toBe(1);
+    expect(env.err.join('\n')).toContain('invalid JSON');
+  });
+
+  it('exits 1 on schema mismatch', () => {
+    const env = makeEnv();
+    env.stdin = JSON.stringify([{ kind: 'bogus' }]);
+    const code = main(['node', 'perf-report'], env);
+    expect(code).toBe(1);
+    expect(env.err.join('\n')).toContain('schema invalid');
+  });
+
+  it('exits 1 when file read fails', () => {
+    const env = makeEnv();
+    const code = main(['node', 'perf-report', '/nonexistent/path-zzz.json'], env);
+    expect(code).toBe(1);
+    expect(env.err.join('\n')).toContain('failed to read');
+  });
+
+  it('uses default writers (process.stdout/stderr) when env omitted', () => {
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // 인자만 주고 env는 비움 — writeOut/writeErr fallback 분기 진입.
+    // file arg로 즉시 실패해 stderr 폴백을 검증, 그 외 분기는 invalid JSON로 동일 path.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-report-default-'));
+    const okPath = path.join(dir, 'ok.json');
+    fs.writeFileSync(okPath, '[]');
+    expect(main(['node', 'perf-report', okPath])).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalled();
+    fs.rmSync(dir, { recursive: true, force: true });
+    expect(main(['node', 'perf-report', '/no/such/path-yyy.json'])).toBe(1);
+    expect(stderrSpy).toHaveBeenCalled();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+});

--- a/scripts/__tests__/perf-report.test.js
+++ b/scripts/__tests__/perf-report.test.js
@@ -9,9 +9,11 @@ const path = require('node:path');
 
 const {
   METRIC_KIND,
+  METRIC_CATALOG,
   SLA_LATE_THRESHOLD_MS,
   FALSE_POSITIVE_RATIO_THRESHOLD,
   MIN_SAMPLE_FOR_DECISION,
+  SLA_PERCENTILE,
   percentile,
   mean,
   isRate,
@@ -24,6 +26,8 @@ const {
   formatReport,
   main,
 } = require('../perf-report');
+
+const catalogJson = require('../../backend/alarm-worker/src/metrics.catalog.json');
 
 describe('percentile', () => {
   it('returns 0 for empty', () => {
@@ -365,8 +369,50 @@ describe('formatSummary', () => {
       count: 40,
       significant: true,
     });
+    const pctLabel = `p${Math.round(SLA_PERCENTILE * 100)}`;
     expect(text).toContain('mean=1500.50');
-    expect(text).toContain('p95=2800.25');
+    expect(text).toContain(`${pctLabel}=2800.25`);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// 카탈로그 SSOT 일관성 — backend metrics.catalog.json 단일 출처.
+// ───────────────────────────────────────────────────────────────
+
+describe('catalog SSOT consistency', () => {
+  it('exports same constants as catalog JSON', () => {
+    expect(SLA_LATE_THRESHOLD_MS).toBe(catalogJson.constants.SLA_LATE_THRESHOLD_MS);
+    expect(FALSE_POSITIVE_RATIO_THRESHOLD).toBe(
+      catalogJson.constants.FALSE_POSITIVE_RATIO_THRESHOLD,
+    );
+    expect(MIN_SAMPLE_FOR_DECISION).toBe(catalogJson.constants.MIN_SAMPLE_FOR_DECISION);
+    expect(SLA_PERCENTILE).toBe(catalogJson.constants.SLA_PERCENTILE);
+  });
+
+  it('METRIC_KIND mirrors catalog entries', () => {
+    for (const entry of catalogJson.metrics) {
+      expect(METRIC_KIND[entry.constantName]).toBe(entry.key);
+    }
+  });
+
+  it('METRIC_CATALOG reflects raw catalog entries', () => {
+    expect(METRIC_CATALOG).toHaveLength(catalogJson.metrics.length);
+    const keys = METRIC_CATALOG.map((m) => m.key);
+    const expected = catalogJson.metrics.map((m) => m.key);
+    expect(keys).toEqual(expected);
+  });
+
+  it('every gate references an existing constant', () => {
+    for (const entry of catalogJson.metrics) {
+      if (entry.gate) {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            catalogJson.constants,
+            entry.gate.thresholdConst,
+          ),
+        ).toBe(true);
+      }
+    }
   });
 });
 

--- a/scripts/perf-report.js
+++ b/scripts/perf-report.js
@@ -11,32 +11,53 @@
  *   cat metrics.json | node scripts/perf-report.js
  *   npm run perf:report -- metrics.json
  *
- * backend `metrics.ts`와 schema 호환 — wrangler tail 또는 Analytics Engine query 결과를
- * 그대로 입력 가능. 외부 의존성 없음 — node fs / process만 사용.
+ * 카탈로그 SSOT:
+ *   `backend/alarm-worker/src/metrics.catalog.json` — backend metrics.ts와 공유.
+ *   새 지표/임계 추가 시 JSON 1곳만 수정하면 양쪽이 동일하게 반영된다.
+ *
+ * 외부 의존성 없음 — node fs / process만 사용.
  */
 
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 // ───────────────────────────────────────────────────────────────
-// Phase 4 결정 임계 — backend metrics.ts와 동기화 (CONST source of truth).
+// 카탈로그 — backend metrics.ts와 단일 JSON SSOT 공유.
 // ───────────────────────────────────────────────────────────────
 
-const SLA_LATE_THRESHOLD_MS = 30_000;
-const FALSE_POSITIVE_RATIO_THRESHOLD = 0.05;
-const MIN_SAMPLE_FOR_DECISION = 30;
+const CATALOG_PATH = path.resolve(
+  __dirname,
+  '..',
+  'backend',
+  'alarm-worker',
+  'src',
+  'metrics.catalog.json',
+);
 
-// 지표 카탈로그 — 새 지표 추가 시 키 1개만 늘리면 perf-report 흐름 무수정.
-const METRIC_KIND = {
-  BOARDING_FALSE_POSITIVE: 'boardingFalsePositiveRate',
-  IMMINENT_SLA_ERROR: 'imminentSlaErrorMs',
-  STATION_PASSED_ACCURACY: 'stationPassedAccuracy',
-  PHASE_CLASSIFICATION_ACCURACY: 'phaseClassificationAccuracy',
-  DRIFT_RECOVERY: 'driftRecoveryMeters',
-  KALMAN_RESIDUAL: 'kalmanResidual',
-};
-const KNOWN_KINDS = new Set(Object.values(METRIC_KIND));
+/* istanbul ignore next — catalog 로드 실패는 빌드/배포 사고이고 단위 테스트로 재현 불가. */
+function loadCatalog() {
+  return JSON.parse(fs.readFileSync(CATALOG_PATH, 'utf8'));
+}
+
+const CATALOG = loadCatalog();
+
+const SLA_LATE_THRESHOLD_MS = CATALOG.constants.SLA_LATE_THRESHOLD_MS;
+const FALSE_POSITIVE_RATIO_THRESHOLD = CATALOG.constants.FALSE_POSITIVE_RATIO_THRESHOLD;
+const MIN_SAMPLE_FOR_DECISION = CATALOG.constants.MIN_SAMPLE_FOR_DECISION;
+const SLA_PERCENTILE = CATALOG.constants.SLA_PERCENTILE;
+
+// 카탈로그의 constantName → key 매핑 — 기존 호출자 호환.
+const METRIC_KIND = Object.freeze(
+  CATALOG.metrics.reduce((acc, m) => {
+    acc[m.constantName] = m.key;
+    return acc;
+  }, {}),
+);
+
+const KNOWN_KINDS = new Set(CATALOG.metrics.map((m) => m.key));
+const METRIC_BY_KEY = new Map(CATALOG.metrics.map((m) => [m.key, m]));
 
 // ───────────────────────────────────────────────────────────────
 // 통계.
@@ -78,45 +99,68 @@ function summarize(entry) {
   return {
     kind: entry.kind,
     value: mean(entry.samples),
-    p95: percentile(entry.samples, 0.95),
+    p95: percentile(entry.samples, SLA_PERCENTILE),
     count: entry.samples.length,
     significant: entry.samples.length >= MIN_SAMPLE_FOR_DECISION,
   };
 }
 
 // ───────────────────────────────────────────────────────────────
-// 결정.
+// 결정 — 카탈로그의 gate 메타를 순회. 새 게이트 추가 시 분기 무수정.
 // ───────────────────────────────────────────────────────────────
 
+function gatedEntries() {
+  return CATALOG.metrics.filter((m) => m.gate);
+}
+
+function gateValue(summary, gate) {
+  return gate.field === 'p95' ? summary.p95 : summary.value;
+}
+
+function gateThreshold(gate) {
+  return CATALOG.constants[gate.thresholdConst];
+}
+
+function gateBreached(summary, gate) {
+  const threshold = gateThreshold(gate);
+  const v = gateValue(summary, gate);
+  // 현재 op는 '>'만 지원 — 카탈로그 확장 시 분기 추가.
+  return gate.op === '>' && v > threshold;
+}
+
 function decidePhaseFour(summaries) {
-  const fp = summaries.find((s) => s.kind === METRIC_KIND.BOARDING_FALSE_POSITIVE);
-  const sla = summaries.find((s) => s.kind === METRIC_KIND.IMMINENT_SLA_ERROR);
-  if (!fp || !sla) {
-    return { proceed: false, insufficientSamples: true, triggers: [] };
-  }
-  if (!fp.significant || !sla.significant) {
-    return { proceed: false, insufficientSamples: true, triggers: [] };
+  const byKind = new Map(summaries.map((s) => [s.kind, s]));
+  const gates = gatedEntries();
+  for (const entry of gates) {
+    const s = byKind.get(entry.key);
+    if (!s || !s.significant) {
+      return { proceed: false, insufficientSamples: true, triggers: [] };
+    }
   }
   const triggers = [];
-  if (fp.value > FALSE_POSITIVE_RATIO_THRESHOLD) triggers.push('falsePositive');
-  if (sla.p95 > SLA_LATE_THRESHOLD_MS) triggers.push('imminentSla');
+  for (const entry of gates) {
+    const s = byKind.get(entry.key);
+    if (gateBreached(s, entry.gate)) triggers.push(entry.gate.triggerName);
+  }
   return { proceed: triggers.length > 0, insufficientSamples: false, triggers };
 }
 
 // ───────────────────────────────────────────────────────────────
-// 입력 검증.
+// 입력 검증 — 카탈로그 format에 따라 분기.
 // ───────────────────────────────────────────────────────────────
 
 function validateEntry(raw) {
   if (!raw || typeof raw !== 'object') return null;
   if (!KNOWN_KINDS.has(raw.kind)) return null;
-  if ('total' in raw) {
+  const meta = METRIC_BY_KEY.get(raw.kind);
+  if (meta && meta.format === 'rate') {
     const { hit, total } = raw;
     if (!Number.isInteger(hit) || hit < 0) return null;
     if (!Number.isInteger(total) || total < 0) return null;
     if (hit > total) return null;
     return { kind: raw.kind, hit, total };
   }
+  // histogram (or unknown — safety net으로 histogram 처리)
   if (!Array.isArray(raw.samples)) return null;
   for (const v of raw.samples) {
     if (typeof v !== 'number' || !Number.isFinite(v)) return null;
@@ -137,6 +181,7 @@ function validateBatch(raw) {
 
 // ───────────────────────────────────────────────────────────────
 // 리포트 빌드 — 순수 함수, IO 없음. CLI smoke 테스트 진입점.
+// 카탈로그 display에 따라 포맷 분기 (percentage / numeric). if 체인 없음.
 // ───────────────────────────────────────────────────────────────
 
 function buildReport(entries) {
@@ -145,18 +190,19 @@ function buildReport(entries) {
   return { summaries, decision };
 }
 
+const PERCENTILE_LABEL = `p${Math.round(SLA_PERCENTILE * 100)}`;
+
 function formatSummary(summary) {
-  const pct = (n) => `${(n * 100).toFixed(2)}%`;
-  if (summary.kind === METRIC_KIND.BOARDING_FALSE_POSITIVE) {
-    return `  ${summary.kind}: ${pct(summary.value)} (n=${summary.count}${summary.significant ? '' : ', insufficient'})`;
+  const meta = METRIC_BY_KEY.get(summary.kind);
+  const sampleTag = `n=${summary.count}${summary.significant ? '' : ', insufficient'}`;
+  // display 메타가 누락된 경우는 안전 폴백으로 numeric.
+  const display = meta ? meta.display : 'numeric';
+  if (display === 'percentage') {
+    const pct = `${(summary.value * 100).toFixed(2)}%`;
+    return `  ${summary.kind}: ${pct} (${sampleTag})`;
   }
-  if (
-    summary.kind === METRIC_KIND.STATION_PASSED_ACCURACY ||
-    summary.kind === METRIC_KIND.PHASE_CLASSIFICATION_ACCURACY
-  ) {
-    return `  ${summary.kind}: ${pct(summary.value)} (n=${summary.count}${summary.significant ? '' : ', insufficient'})`;
-  }
-  return `  ${summary.kind}: mean=${summary.value.toFixed(2)} p95=${summary.p95.toFixed(2)} (n=${summary.count}${summary.significant ? '' : ', insufficient'})`;
+  // numeric / histogram
+  return `  ${summary.kind}: mean=${summary.value.toFixed(2)} ${PERCENTILE_LABEL}=${summary.p95.toFixed(2)} (${sampleTag})`;
 }
 
 function formatReport(report) {
@@ -229,9 +275,11 @@ function main(argv, env = {}) {
 
 module.exports = {
   METRIC_KIND,
+  METRIC_CATALOG: CATALOG.metrics,
   SLA_LATE_THRESHOLD_MS,
   FALSE_POSITIVE_RATIO_THRESHOLD,
   MIN_SAMPLE_FOR_DECISION,
+  SLA_PERCENTILE,
   percentile,
   mean,
   isRate,
@@ -250,3 +298,4 @@ module.exports = {
 if (require.main === module) {
   process.exit(main(process.argv));
 }
+

--- a/scripts/perf-report.js
+++ b/scripts/perf-report.js
@@ -1,0 +1,252 @@
+/**
+ * Phase 3 fusion baseline 지표 리포트 CLI (#827).
+ *
+ * 입력: JSON MetricEntry 배열 (file path 인자 또는 stdin).
+ *   [{ kind, hit, total } | { kind, samples: [...] }, ...]
+ *
+ * 출력: 사람이 읽을 수 있는 요약 + Phase 4 결정 판정.
+ *
+ * 사용:
+ *   node scripts/perf-report.js metrics.json
+ *   cat metrics.json | node scripts/perf-report.js
+ *   npm run perf:report -- metrics.json
+ *
+ * backend `metrics.ts`와 schema 호환 — wrangler tail 또는 Analytics Engine query 결과를
+ * 그대로 입력 가능. 외부 의존성 없음 — node fs / process만 사용.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+
+// ───────────────────────────────────────────────────────────────
+// Phase 4 결정 임계 — backend metrics.ts와 동기화 (CONST source of truth).
+// ───────────────────────────────────────────────────────────────
+
+const SLA_LATE_THRESHOLD_MS = 30_000;
+const FALSE_POSITIVE_RATIO_THRESHOLD = 0.05;
+const MIN_SAMPLE_FOR_DECISION = 30;
+
+// 지표 카탈로그 — 새 지표 추가 시 키 1개만 늘리면 perf-report 흐름 무수정.
+const METRIC_KIND = {
+  BOARDING_FALSE_POSITIVE: 'boardingFalsePositiveRate',
+  IMMINENT_SLA_ERROR: 'imminentSlaErrorMs',
+  STATION_PASSED_ACCURACY: 'stationPassedAccuracy',
+  PHASE_CLASSIFICATION_ACCURACY: 'phaseClassificationAccuracy',
+  DRIFT_RECOVERY: 'driftRecoveryMeters',
+  KALMAN_RESIDUAL: 'kalmanResidual',
+};
+const KNOWN_KINDS = new Set(Object.values(METRIC_KIND));
+
+// ───────────────────────────────────────────────────────────────
+// 통계.
+// ───────────────────────────────────────────────────────────────
+
+function percentile(samples, p) {
+  if (samples.length === 0) return 0;
+  if (p < 0 || p > 1) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(p * sorted.length) - 1),
+  );
+  return sorted[idx];
+}
+
+function mean(samples) {
+  if (samples.length === 0) return 0;
+  let sum = 0;
+  for (const v of samples) sum += v;
+  return sum / samples.length;
+}
+
+function isRate(entry) {
+  return Object.prototype.hasOwnProperty.call(entry, 'total');
+}
+
+function summarize(entry) {
+  if (isRate(entry)) {
+    const value = entry.total === 0 ? 0 : entry.hit / entry.total;
+    return {
+      kind: entry.kind,
+      value,
+      p95: 0,
+      count: entry.total,
+      significant: entry.total >= MIN_SAMPLE_FOR_DECISION,
+    };
+  }
+  return {
+    kind: entry.kind,
+    value: mean(entry.samples),
+    p95: percentile(entry.samples, 0.95),
+    count: entry.samples.length,
+    significant: entry.samples.length >= MIN_SAMPLE_FOR_DECISION,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────
+// 결정.
+// ───────────────────────────────────────────────────────────────
+
+function decidePhaseFour(summaries) {
+  const fp = summaries.find((s) => s.kind === METRIC_KIND.BOARDING_FALSE_POSITIVE);
+  const sla = summaries.find((s) => s.kind === METRIC_KIND.IMMINENT_SLA_ERROR);
+  if (!fp || !sla) {
+    return { proceed: false, insufficientSamples: true, triggers: [] };
+  }
+  if (!fp.significant || !sla.significant) {
+    return { proceed: false, insufficientSamples: true, triggers: [] };
+  }
+  const triggers = [];
+  if (fp.value > FALSE_POSITIVE_RATIO_THRESHOLD) triggers.push('falsePositive');
+  if (sla.p95 > SLA_LATE_THRESHOLD_MS) triggers.push('imminentSla');
+  return { proceed: triggers.length > 0, insufficientSamples: false, triggers };
+}
+
+// ───────────────────────────────────────────────────────────────
+// 입력 검증.
+// ───────────────────────────────────────────────────────────────
+
+function validateEntry(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  if (!KNOWN_KINDS.has(raw.kind)) return null;
+  if ('total' in raw) {
+    const { hit, total } = raw;
+    if (!Number.isInteger(hit) || hit < 0) return null;
+    if (!Number.isInteger(total) || total < 0) return null;
+    if (hit > total) return null;
+    return { kind: raw.kind, hit, total };
+  }
+  if (!Array.isArray(raw.samples)) return null;
+  for (const v of raw.samples) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+  }
+  return { kind: raw.kind, samples: raw.samples };
+}
+
+function validateBatch(raw) {
+  if (!Array.isArray(raw)) return null;
+  const out = [];
+  for (const entry of raw) {
+    const v = validateEntry(entry);
+    if (!v) return null;
+    out.push(v);
+  }
+  return out;
+}
+
+// ───────────────────────────────────────────────────────────────
+// 리포트 빌드 — 순수 함수, IO 없음. CLI smoke 테스트 진입점.
+// ───────────────────────────────────────────────────────────────
+
+function buildReport(entries) {
+  const summaries = entries.map(summarize);
+  const decision = decidePhaseFour(summaries);
+  return { summaries, decision };
+}
+
+function formatSummary(summary) {
+  const pct = (n) => `${(n * 100).toFixed(2)}%`;
+  if (summary.kind === METRIC_KIND.BOARDING_FALSE_POSITIVE) {
+    return `  ${summary.kind}: ${pct(summary.value)} (n=${summary.count}${summary.significant ? '' : ', insufficient'})`;
+  }
+  if (
+    summary.kind === METRIC_KIND.STATION_PASSED_ACCURACY ||
+    summary.kind === METRIC_KIND.PHASE_CLASSIFICATION_ACCURACY
+  ) {
+    return `  ${summary.kind}: ${pct(summary.value)} (n=${summary.count}${summary.significant ? '' : ', insufficient'})`;
+  }
+  return `  ${summary.kind}: mean=${summary.value.toFixed(2)} p95=${summary.p95.toFixed(2)} (n=${summary.count}${summary.significant ? '' : ', insufficient'})`;
+}
+
+function formatReport(report) {
+  const lines = ['Phase 3 fusion metrics report', '----------------------------'];
+  for (const s of report.summaries) {
+    lines.push(formatSummary(s));
+  }
+  lines.push('');
+  lines.push('Phase 4 decision');
+  lines.push('----------------');
+  if (report.decision.insufficientSamples) {
+    lines.push(
+      `  HOLD — insufficient samples (need >= ${MIN_SAMPLE_FOR_DECISION} each)`,
+    );
+  } else if (report.decision.proceed) {
+    lines.push(
+      `  PROCEED — review Phase 4 (Particle filter). triggers: ${report.decision.triggers.join(', ')}`,
+    );
+  } else {
+    lines.push('  SKIP — within thresholds. stamp ADR.');
+  }
+  return lines.join('\n');
+}
+
+// ───────────────────────────────────────────────────────────────
+// IO — CLI entry.
+// ───────────────────────────────────────────────────────────────
+
+/* istanbul ignore next — fd 0 동기 read는 단위 테스트에서 안전히 호출 불가. main()에서 env.stdin 주입으로 우회. */
+function readStdinSync() {
+  return fs.readFileSync(0, 'utf8');
+}
+
+function parseInput(argv, env) {
+  // 인자 우선, 없으면 env.stdin(테스트 주입), 그 외 process stdin.
+  const file = argv[2];
+  if (file) return fs.readFileSync(file, 'utf8');
+  /* istanbul ignore else — non-string stdin은 단위 테스트에서 fd 0 read와 동일 분기. */
+  if (typeof env.stdin === 'string') return env.stdin;
+  /* istanbul ignore next — readStdinSync 분기는 IO 부수효과로 테스트 불가. */
+  return readStdinSync();
+}
+
+function main(argv, env = {}) {
+  const writeOut = env.writeOut || ((msg) => process.stdout.write(`${msg}\n`));
+  const writeErr = env.writeErr || ((msg) => process.stderr.write(`${msg}\n`));
+  let raw;
+  try {
+    raw = parseInput(argv, env);
+  } catch (e) {
+    writeErr(`perf-report: failed to read input — ${e.message}`);
+    return 1;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    writeErr(`perf-report: invalid JSON — ${e.message}`);
+    return 1;
+  }
+  const batch = validateBatch(parsed);
+  if (!batch) {
+    writeErr('perf-report: payload schema invalid');
+    return 1;
+  }
+  const report = buildReport(batch);
+  writeOut(formatReport(report));
+  return 0;
+}
+
+module.exports = {
+  METRIC_KIND,
+  SLA_LATE_THRESHOLD_MS,
+  FALSE_POSITIVE_RATIO_THRESHOLD,
+  MIN_SAMPLE_FOR_DECISION,
+  percentile,
+  mean,
+  isRate,
+  summarize,
+  decidePhaseFour,
+  validateEntry,
+  validateBatch,
+  buildReport,
+  formatSummary,
+  formatReport,
+  main,
+};
+
+// CLI 진입 — require로 import 시는 실행 안 함.
+/* istanbul ignore if — require.main 분기는 단위 테스트 환경에서 진입 안 함. */
+if (require.main === module) {
+  process.exit(main(process.argv));
+}

--- a/src/api/__tests__/alarmBackend.test.ts
+++ b/src/api/__tests__/alarmBackend.test.ts
@@ -4,6 +4,7 @@ import {
   sendPushAck,
   registerLiveActivityToken,
   clearLiveActivityToken,
+  reportBoardingPromptOutcome,
   __resetAlarmBackendDedup,
 } from '../alarmBackend';
 import type { RegisterTripPayload } from '../alarmBackend';
@@ -420,6 +421,46 @@ describe('alarmBackend', () => {
       await sendPushAck(ACK);
       const [url] = (global.fetch as jest.Mock).mock.calls[0];
       expect(url).toBe('https://api.test.dev/push/ack');
+    });
+  });
+
+  describe('reportBoardingPromptOutcome (#827)', () => {
+    it('URL 미설정 시 skipped=true 반환', async () => {
+      const result = await reportBoardingPromptOutcome('tok', 'boarded');
+      expect(result).toEqual({ ok: false, skipped: true });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('빈 token이면 ok=false (fetch 미호출)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      const result = await reportBoardingPromptOutcome('', 'boarded');
+      expect(result).toEqual({ ok: false });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('POST /metrics/boarding-prompt에 token/outcome 직렬화', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+      const result = await reportBoardingPromptOutcome('tok-1', 'dismissed');
+      expect(result).toEqual({ ok: true, status: 200 });
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://api.test.dev/metrics/boarding-prompt');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body)).toEqual({ token: 'tok-1', outcome: 'dismissed' });
+    });
+
+    it('non-2xx 응답 시 ok=false + status', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 } as Response);
+      const result = await reportBoardingPromptOutcome('tok-1', 'boarded');
+      expect(result).toEqual({ ok: false, status: 500 });
+    });
+
+    it('fetch throw 시 ok=false (throw 안 함)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
+      const result = await reportBoardingPromptOutcome('tok-1', 'boarded');
+      expect(result).toEqual({ ok: false });
     });
   });
 

--- a/src/api/alarmBackend.ts
+++ b/src/api/alarmBackend.ts
@@ -349,6 +349,45 @@ export async function clearActiveTrip(token: string): Promise<AlarmBackendResult
 }
 
 /**
+ * boarding-prompt 응답 측정 (#827).
+ *
+ * 사용자가 "탑승했냐?" 푸시에 응답한 결과를 backend `/metrics/boarding-prompt`로 보낸다.
+ * `boarded` / `dismissed` 두 outcome만 허용. dismiss 시 silencedUntil 갱신은 별도
+ * `/boarding-prompt/dismiss` endpoint에서 수행 — 본 호출은 측정 only(부수효과 없음).
+ *
+ * URL 미설정/네트워크 실패 시 throw 없이 `{ok:false}` — measurement loss는 발생하지만 본
+ * 알람 흐름에는 영향 없음.
+ */
+export type BoardingPromptOutcome = 'boarded' | 'dismissed';
+
+export async function reportBoardingPromptOutcome(
+  token: string,
+  outcome: BoardingPromptOutcome,
+): Promise<AlarmBackendResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip boarding-prompt metric');
+    return { ok: false, skipped: true };
+  }
+  if (!token) return { ok: false };
+  try {
+    const res = await fetchWithTimeout(`${base}/metrics/boarding-prompt`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token, outcome }),
+    });
+    if (!res.ok) {
+      log.warn(`boarding-prompt metric failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('boarding-prompt metric error', e);
+    return { ok: false };
+  }
+}
+
+/**
  * Live Activity push token 등록 (#586 B/C).
  * native가 emit한 push token hex를 backend의 trip 레코드에 보관한다.
  * URL 미설정/네트워크 실패는 throw 없이 `{ok:false}` — LA 자체는 정상 동작한다.


### PR DESCRIPTION
## Summary
- backend `metrics.ts` (신규) — 6종 핵심 지표(boarding false-positive, imminent SLA, station-passed, phase classification, drift recovery, Kalman residual)를 data-driven enum 카탈로그로 캡슐화. RateMetric/HistogramMetric 통합 요약 + AE 적재(`phase3:<kind>:<field>` namespace, 기존 silent-push 텔레메트리와 분리).
- backend `boardingPromptOutcome.ts` + `POST /metrics/boarding-prompt` (신규) — 사용자 응답(boarded/dismissed) telemetry로 false-positive 분자/분모 누적. `/boarding-prompt/dismiss`는 trip 상태 갱신 전용이고 본 endpoint는 측정 only(부수효과 없음).
- Phase 4 결정 게이트 — false-positive율 > 5% OR imminent p95 > 30s → PROCEED, 둘 다 미만 → SKIP, 표본 < 30 → HOLD. 매직넘버 상수화(`SLA_LATE_THRESHOLD_MS`, `FALSE_POSITIVE_RATIO_THRESHOLD`, `MIN_SAMPLE_FOR_DECISION`).
- `scripts/perf-report.js` + `npm run perf:report` (신규) — AE/wrangler tail JSON 입력 → 사람이 읽는 요약 + PROCEED/SKIP/HOLD 판정. 외부 의존성 0, 인자/stdin/file path 모두 지원.
- `src/api/alarmBackend.reportBoardingPromptOutcome` (신규) — 클라이언트 보고 함수. URL 미설정/네트워크 실패는 graceful skip(본 알람 흐름 영향 없음).
- 충돌 회피: fusion-wire가 점유 중인 `fusedSpeed.ts` / `positionSeries.ts` / `linePolyline.ts` / `types.ts` 미수정. E1이 점유 중인 expo-sensors 미도입. `index.ts`는 새 route + import 두 곳만 추가.

Closes #827
Part of #818

## Test plan
- [x] backend `npm test` — 461 tests passing (metrics 31 + boardingPromptOutcome 9 + index 신규 4 endpoint 테스트)
- [x] backend `npm run type-check` — clean
- [x] client `npm test` — 3180 tests, coverage 100% (alarmBackend.ts 100%, perf-report.js 100%)
- [x] client `npm run type-check` — clean
- [x] `npm run perf:report -- <path-to-metrics.json>` smoke — golden 6종 metric → SKIP/HOLD/PROCEED 분기 모두 단위 검증
- [ ] 실기기/실 배포는 #818 epic E1~E4 와 같이 진행 후 1~2주 데이터 누적 시 perf-report로 첫 Phase 4 결정