### PR TITLE
feat(#824): Phase 3 E2 — Kalman filter for fusedSpeed

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -244,6 +244,98 @@ describe('evaluateBoardingPromptGates — 9단 AND 게이트', () => {
   });
 });
 
+describe('evaluateBoardingPromptGates — #824 kalmanKmh 전달', () => {
+  const now = 1_000_000;
+  const ORIGIN = { lat: 0, lng: 0 };
+  const NEXT = { lat: 0, lng: 0.01 };
+
+  /**
+   * 아주 느린 series — GPS 속도가 too-low가 되도록 원점 부근에서 거의 이동 안 함.
+   * 단, origin(0,0) 방향(동쪽)으로 이동 + 마지막 sample이 origin 100m 이내여야
+   * 다른 gate(방향/origin-too-far)를 통과할 수 있다.
+   *
+   * 속도: lng -0.00004 → 0 → 0.00004
+   *   Δlng ≈ 4.44m/30s → ≈ 0.53 km/h (automotive mode이므로 floor 5 km/h 적용됨)
+   *   automotive floor=5 → fusedSpeed 5 → MIN_FUSED_SPEED_KMH=5 → 경계.
+   *   실제로 5 이상이므로 gate를 통과할 수 있다.
+   *
+   * 그래서 walking mode로 하면 floor가 없어 0.53 km/h < 5 km/h → speed-too-low.
+   */
+  function verySlowWalkingSeries(n: number) {
+    return [
+      { lat: 0, lng: -0.00004, accuracy: 10, ts: n - 60_000, motion: 'walking' as const },
+      { lat: 0, lng: 0, accuracy: 10, ts: n - 30_000, motion: 'walking' as const },
+      { lat: 0, lng: 0.00004, accuracy: 10, ts: n, motion: 'walking' as const },
+    ];
+  }
+
+  it('kalmanKmh 없으면 매우 저속 walking series는 speed-too-low', () => {
+    const r = evaluateBoardingPromptGates({
+      series: verySlowWalkingSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      kalmanKmh: undefined,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('speed-too-low');
+  });
+
+  it('kalmanKmh=50 주입 시 fusedSpeedKmh가 달라져 game outcome이 변한다', () => {
+    // GPS-only: speed-too-low
+    // kalmanKmh=50 주입 시: totalW = 0.7 + 0.6 = 1.3
+    // raw = (gpsAvg*0.7 + 50*0.6) / 1.3 >> 5 km/h
+    // walking clamp: Math.min(raw, 10) = 10 → 5 km/h 초과 → speed gate 통과
+    const withKalman = evaluateBoardingPromptGates({
+      series: verySlowWalkingSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      kalmanKmh: 50,
+    });
+    // kalmanKmh 주입 후 pass=true이거나, 다른 reason으로 fail (speed-too-low는 아님)
+    if (!withKalman.pass) {
+      expect(withKalman.reason).not.toBe('speed-too-low');
+    }
+    if (withKalman.pass) {
+      expect(withKalman.fusedSpeedKmh).toBeGreaterThan(5);
+    }
+  });
+
+  it('kalmanKmh 전달 시 fusedSpeedKmh가 GPS-only보다 크다 (happy path 기준)', () => {
+    // happy series: 동쪽으로 충분히 이동 (automotive)
+    function happySeries(n: number) {
+      return [
+        { lat: 0, lng: -0.0004, accuracy: 10, ts: n - 60_000, motion: 'automotive' as const },
+        { lat: 0, lng: 0.0002, accuracy: 10, ts: n - 30_000, motion: 'automotive' as const },
+        { lat: 0, lng: 0.0008, accuracy: 10, ts: n, motion: 'automotive' as const },
+      ];
+    }
+
+    const withoutKalman = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      kalmanKmh: null,
+    });
+    const withKalman = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      kalmanKmh: 60, // GPS-only 속도보다 훨씬 높은 Kalman 값
+    });
+
+    // 둘 다 통과해야 하며 Kalman 있을 때 fusedSpeedKmh가 더 크다
+    expect(withoutKalman.pass).toBe(true);
+    expect(withKalman.pass).toBe(true);
+    if (withoutKalman.pass && withKalman.pass) {
+      expect(withKalman.fusedSpeedKmh).toBeGreaterThan(withoutKalman.fusedSpeedKmh);
+    }
+  });
+});
+
 describe('markPromptFired / markPromptSilenced', () => {
   it('markPromptFired는 fired=true + lastFiredAt 설정', () => {
     expect(markPromptFired(1234)).toEqual({ fired: true, lastFiredAt: 1234 });

--- a/backend/alarm-worker/src/__tests__/fusedSpeed.test.ts
+++ b/backend/alarm-worker/src/__tests__/fusedSpeed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { fusedSpeed } from '../fusedSpeed';
+import { KALMAN_WEIGHT, fusedSpeed } from '../fusedSpeed';
 
 describe('fusedSpeed (#819)', () => {
   it('stationary motion → speed=0 confidence=high (다른 신호 무시)', () => {
@@ -103,5 +103,129 @@ describe('fusedSpeed (#819)', () => {
       mapMatchedKmh: null,
     });
     expect(low.confidence).toBe('low');
+  });
+});
+
+describe('fusedSpeed — Phase 3 Kalman 통합 (#824)', () => {
+  it('kalmanKmh=undefined (미지정) → 기존 결과와 동일 (Phase 1/2 회귀 없음)', () => {
+    // Phase 3 미적용 호출: kalmanKmh 미지정 → kalmanWeight=0 → 기존 가중치와 동일
+    const withoutKalman = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: null,
+    });
+    const withUndefined = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: null,
+      kalmanKmh: undefined,
+    });
+    expect(withUndefined).toEqual(withoutKalman);
+  });
+
+  it('kalmanKmh=null → kalmanWeight=0, 기존 결과와 동일', () => {
+    const withNull = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: null,
+      kalmanKmh: null,
+    });
+    const withoutKalman = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: null,
+    });
+    expect(withNull).toEqual(withoutKalman);
+  });
+
+  it('kalmanKmh 있을 때 가중치 합산 — GPS+Kalman → high confidence', () => {
+    // GPS accuracy=10m → gpsWeight=0.7, mapMatched=null → mapWeight=0
+    // kalmanKmh 있음 → kalmanWeight=KALMAN_WEIGHT=0.6
+    // totalW = 0.7 + 0 + 0.6 = 1.3 → high confidence
+    // raw = (30*0.7 + 0*0 + 35*0.6) / 1.3 = (21 + 0 + 21) / 1.3 ≈ 32.31
+    const r = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: null,
+      kalmanKmh: 35,
+    });
+    expect(r.confidence).toBe('high'); // totalW=1.3 ≥ 1.0
+    const expectedRaw = (30 * 0.7 + 35 * KALMAN_WEIGHT) / (0.7 + KALMAN_WEIGHT);
+    expect(r.speed).toBeCloseTo(expectedRaw, 4);
+  });
+
+  it('kalmanKmh 단독 (GPS accuracy≥100m + mapMatched null) → gpsWeight=0, kalmanWeight=0.6 → medium', () => {
+    // GPS accuracy=200m → gpsWeight=0, kalmanKmh 있음 → kalmanWeight=0.6
+    // totalW = 0 + 0 + 0.6 = 0.6 → medium (0.5 ≤ totalW < 1.0)
+    // raw = (gps*0 + 0*0 + kalman*0.6) / 0.6 = kalman
+    const r = fusedSpeed({
+      gpsAvgKmh: 5,
+      gpsAccuracyMeters: 200,
+      motion: 'unknown',
+      mapMatchedKmh: null,
+      kalmanKmh: 25,
+    });
+    expect(r.confidence).toBe('medium'); // 0.5 ≤ 0.6 < 1.0
+    expect(r.speed).toBeCloseTo(25, 4); // Kalman만 영향
+  });
+
+  it('motion=stationary이면 kalmanKmh 있어도 speed=0 (early return)', () => {
+    const r = fusedSpeed({
+      gpsAvgKmh: 40,
+      gpsAccuracyMeters: 10,
+      motion: 'stationary',
+      mapMatchedKmh: 50,
+      kalmanKmh: 45,
+    });
+    expect(r).toEqual({ speed: 0, confidence: 'high' });
+  });
+
+  it('kalmanKmh + walking motion clamp (상한 10 km/h)', () => {
+    // GPS 10m → 0.7, kalman → 0.6, totalW=1.3
+    // raw = (60*0.7 + 80*0.6) / 1.3 ≈ 69.23 → clamp at 10 (walking)
+    const r = fusedSpeed({
+      gpsAvgKmh: 60,
+      gpsAccuracyMeters: 10,
+      motion: 'walking',
+      mapMatchedKmh: null,
+      kalmanKmh: 80,
+    });
+    expect(r.speed).toBe(10); // walking clamp
+  });
+
+  it('kalmanKmh + automotive motion floor (하한 5 km/h)', () => {
+    // GPS=1 km/h, kalman=2 km/h → 매우 낮은 속도 → automotive clamp 5 km/h
+    const r = fusedSpeed({
+      gpsAvgKmh: 1,
+      gpsAccuracyMeters: 10,
+      motion: 'automotive',
+      mapMatchedKmh: null,
+      kalmanKmh: 2,
+    });
+    expect(r.speed).toBe(5); // automotive floor
+  });
+
+  it('GPS + mapMatched + kalman 3중 fusion → high confidence + 정확한 가중 평균', () => {
+    // GPS 10m → 0.7, map → 0.5, kalman → 0.6, totalW=1.8 → high
+    // raw = (30*0.7 + 40*0.5 + 35*0.6) / 1.8 = (21 + 20 + 21) / 1.8 = 62 / 1.8 ≈ 34.44
+    const r = fusedSpeed({
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      motion: 'unknown',
+      mapMatchedKmh: 40,
+      kalmanKmh: 35,
+    });
+    expect(r.confidence).toBe('high');
+    const expectedRaw = (30 * 0.7 + 40 * 0.5 + 35 * KALMAN_WEIGHT) / (0.7 + 0.5 + KALMAN_WEIGHT);
+    expect(r.speed).toBeCloseTo(expectedRaw, 4);
+  });
+
+  it('KALMAN_WEIGHT 상수값 검증 — 0.6', () => {
+    expect(KALMAN_WEIGHT).toBe(0.6);
   });
 });

--- a/backend/alarm-worker/src/__tests__/kalmanFilter.test.ts
+++ b/backend/alarm-worker/src/__tests__/kalmanFilter.test.ts
@@ -1,0 +1,531 @@
+/**
+ * kalmanFilter.ts 단위 테스트 (#824 Phase 3 E2).
+ *
+ * 검증 범위:
+ *   - computeNoiseR: 4 bands (경계값 포함)
+ *   - computeNoiseQ: 3 bands (경계값 포함)
+ *   - predictKalman: Δt>0 / Δt=0 / Δt<0 (시계 역행)
+ *   - updateKalman: K 산출 + v/P 갱신
+ *   - runKalmanStep: prior=null / stale / 정상 / 경계값 (Δt === threshold)
+ *   - KV roundtrip: read/write/clear + JSON 오류 + 필드 누락 + NaN/Infinity
+ *   - 수치 회귀 (RMSE): Kalman vs 단순 평균
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ACCURACY_R_HIGH_M,
+  ACCURACY_R_LOW_M,
+  ACCURACY_R_MID_M,
+  ACCEL_STD_Q_LOW,
+  ACCEL_STD_Q_MID,
+  Q_HIGH,
+  Q_LOW,
+  Q_MID,
+  R_HIGH,
+  R_LOW,
+  R_MID,
+  R_REJECT,
+  STATE_STALE_THRESHOLD_MS,
+  clearKalmanState,
+  computeNoiseQ,
+  computeNoiseR,
+  predictKalman,
+  readKalmanState,
+  runKalmanStep,
+  updateKalman,
+  writeKalmanState,
+  type KalmanState,
+} from '../kalmanFilter';
+import { InMemoryKV } from './inMemoryKv';
+
+// ─────────────────────────────────────────────────────
+// computeNoiseR
+// ─────────────────────────────────────────────────────
+
+describe('computeNoiseR — accuracy → 관측 분산 단계 함수', () => {
+  it('10m (< 20m) → R_LOW=4', () => {
+    expect(computeNoiseR(10)).toBe(R_LOW);
+  });
+
+  it('0m (경계 최소) → R_LOW=4', () => {
+    expect(computeNoiseR(0)).toBe(R_LOW);
+  });
+
+  it('경계값 19.9m (<20m) → R_LOW=4', () => {
+    expect(computeNoiseR(19.9)).toBe(R_LOW);
+  });
+
+  it(`경계값 ${ACCURACY_R_LOW_M}m (정확히 20m) → R_MID=25`, () => {
+    // 20m는 < 20m 조건 불만족 → 다음 band
+    expect(computeNoiseR(ACCURACY_R_LOW_M)).toBe(R_MID);
+  });
+
+  it('30m (20m ≤ x < 50m) → R_MID=25', () => {
+    expect(computeNoiseR(30)).toBe(R_MID);
+  });
+
+  it(`경계값 ${ACCURACY_R_MID_M}m (정확히 50m) → R_HIGH=100`, () => {
+    expect(computeNoiseR(ACCURACY_R_MID_M)).toBe(R_HIGH);
+  });
+
+  it('70m (50m ≤ x < 100m) → R_HIGH=100', () => {
+    expect(computeNoiseR(70)).toBe(R_HIGH);
+  });
+
+  it(`경계값 ${ACCURACY_R_HIGH_M}m (정확히 100m) → R_REJECT=400`, () => {
+    expect(computeNoiseR(ACCURACY_R_HIGH_M)).toBe(R_REJECT);
+  });
+
+  it('150m (≥ 100m) → R_REJECT=400', () => {
+    expect(computeNoiseR(150)).toBe(R_REJECT);
+  });
+
+  it('매우 큰 값 → R_REJECT=400', () => {
+    expect(computeNoiseR(9999)).toBe(R_REJECT);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// computeNoiseQ
+// ─────────────────────────────────────────────────────
+
+describe('computeNoiseQ — accel stddev → 프로세스 분산 단계 함수', () => {
+  it('0.1 m/s² (< 0.5) → Q_LOW=1', () => {
+    expect(computeNoiseQ(0.1)).toBe(Q_LOW);
+  });
+
+  it('0.0 (경계 최소) → Q_LOW=1', () => {
+    expect(computeNoiseQ(0.0)).toBe(Q_LOW);
+  });
+
+  it('경계값 0.49 (< 0.5) → Q_LOW=1', () => {
+    expect(computeNoiseQ(0.49)).toBe(Q_LOW);
+  });
+
+  it(`경계값 ${ACCEL_STD_Q_LOW} (정확히 0.5) → Q_MID=9`, () => {
+    expect(computeNoiseQ(ACCEL_STD_Q_LOW)).toBe(Q_MID);
+  });
+
+  it('1.0 m/s² (0.5 ≤ x < 2.0) → Q_MID=9', () => {
+    expect(computeNoiseQ(1.0)).toBe(Q_MID);
+  });
+
+  it('경계값 1.99 (< 2.0) → Q_MID=9', () => {
+    expect(computeNoiseQ(1.99)).toBe(Q_MID);
+  });
+
+  it(`경계값 ${ACCEL_STD_Q_MID} (정확히 2.0) → Q_HIGH=36`, () => {
+    expect(computeNoiseQ(ACCEL_STD_Q_MID)).toBe(Q_HIGH);
+  });
+
+  it('3.0 m/s² (≥ 2.0) → Q_HIGH=36', () => {
+    expect(computeNoiseQ(3.0)).toBe(Q_HIGH);
+  });
+
+  it('매우 큰 값 → Q_HIGH=36', () => {
+    expect(computeNoiseQ(100)).toBe(Q_HIGH);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// predictKalman
+// ─────────────────────────────────────────────────────
+
+describe('predictKalman — constant-velocity predict step', () => {
+  const prior: KalmanState = { v: 30, P: 100, ts: 1000 };
+
+  it('Δt > 0: P_pred = P + Q * dtSec, v 유지, ts=now', () => {
+    // Δt = 10_000ms = 10s, accelStd=0.1 → Q_LOW=1 → P_pred = 100 + 1*10 = 110
+    const result = predictKalman(prior, 0.1, 11_000);
+    expect(result.v).toBe(30);
+    expect(result.P).toBeCloseTo(110, 5);
+    expect(result.ts).toBe(11_000);
+  });
+
+  it('Δt > 0: 다른 Q 밴드 (accelStd=1.0 → Q_MID=9)', () => {
+    // Δt = 5_000ms = 5s, Q=9 → P_pred = 100 + 9*5 = 145
+    const result = predictKalman(prior, 1.0, 6_000);
+    expect(result.P).toBeCloseTo(145, 5);
+  });
+
+  it('Δt > 0: Q_HIGH 밴드 (accelStd=3.0 → Q_HIGH=36)', () => {
+    // Δt = 2_000ms = 2s, Q=36 → P_pred = 100 + 36*2 = 172
+    const result = predictKalman(prior, 3.0, 3_000);
+    expect(result.P).toBeCloseTo(172, 5);
+  });
+
+  it('Δt = 0 → prior 그대로 반환 (시계 동일)', () => {
+    const result = predictKalman(prior, 0.1, 1000);
+    expect(result).toBe(prior); // 동일 객체 참조
+  });
+
+  it('Δt < 0 → prior 그대로 반환 (시계 역행)', () => {
+    const result = predictKalman(prior, 0.1, 500);
+    expect(result).toBe(prior); // 동일 객체 참조
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// updateKalman
+// ─────────────────────────────────────────────────────
+
+describe('updateKalman — Bayesian update step', () => {
+  it('P=100, R=100 (accuracy=70m → R_HIGH=100) → K=0.5; z=50, v_pred=30 → v_new=40', () => {
+    // accuracy=70m → R=R_HIGH=100
+    // K = 100 / (100 + 100) = 0.5
+    // v_new = 30 + 0.5 * (50 - 30) = 30 + 10 = 40
+    // P_new = (1 - 0.5) * 100 = 50
+    const predicted: KalmanState = { v: 30, P: 100, ts: 5000 };
+    const result = updateKalman(predicted, 50, 70);
+    expect(result.v).toBeCloseTo(40, 5);
+    expect(result.P).toBeCloseTo(50, 5);
+    expect(result.ts).toBe(5000); // ts는 predicted에서 유지
+  });
+
+  it('accuracy < 20m (R=4) → K가 높아 GPS에 강하게 수렴', () => {
+    // P=100, R=4 → K = 100/104 ≈ 0.9615
+    // v_new ≈ 20 + 0.9615*(60-20) ≈ 20 + 38.46 ≈ 58.46
+    const predicted: KalmanState = { v: 20, P: 100, ts: 0 };
+    const result = updateKalman(predicted, 60, 10);
+    const expectedK = 100 / (100 + R_LOW);
+    const expectedV = 20 + expectedK * (60 - 20);
+    expect(result.v).toBeCloseTo(expectedV, 4);
+    expect(result.P).toBeCloseTo((1 - expectedK) * 100, 4);
+  });
+
+  it('accuracy > 100m (R=400) → K가 낮아 prediction 유지', () => {
+    // P=100, R=400 → K = 100/500 = 0.2
+    // v_new = 30 + 0.2*(80-30) = 30 + 10 = 40
+    const predicted: KalmanState = { v: 30, P: 100, ts: 0 };
+    const result = updateKalman(predicted, 80, 150);
+    const expectedK = 100 / (100 + R_REJECT);
+    const expectedV = 30 + expectedK * (80 - 30);
+    expect(result.v).toBeCloseTo(expectedV, 4);
+  });
+
+  it('P=0 → K=0, v_new = v_pred (완전 신뢰 prediction)', () => {
+    // K = 0 / (0 + R) = 0
+    const predicted: KalmanState = { v: 25, P: 0, ts: 0 };
+    const result = updateKalman(predicted, 60, 30);
+    expect(result.v).toBeCloseTo(25, 5);
+    expect(result.P).toBeCloseTo(0, 5);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// runKalmanStep
+// ─────────────────────────────────────────────────────
+
+describe('runKalmanStep — predict + update 통합', () => {
+  const now = 1_000_000;
+
+  it('prior=null → observation 직접 초기화 (v=gpsAvgKmh, P=R(accuracy), ts=now)', () => {
+    const result = runKalmanStep({
+      prior: null,
+      gpsAvgKmh: 35,
+      gpsAccuracyMeters: 10,
+      accelMagnitudeStd: 0.1,
+      now,
+    });
+    expect(result.v).toBe(35);
+    expect(result.P).toBe(R_LOW); // accuracy=10 → R_LOW=4
+    expect(result.ts).toBe(now);
+  });
+
+  it('prior=null + accuracy=50m → P=R_HIGH=100', () => {
+    const result = runKalmanStep({
+      prior: null,
+      gpsAvgKmh: 20,
+      gpsAccuracyMeters: 50,
+      accelMagnitudeStd: 0.5,
+      now,
+    });
+    expect(result.P).toBe(R_HIGH); // accuracy=50 → R_HIGH=100
+  });
+
+  it('stale prior (Δt > STATE_STALE_THRESHOLD_MS) → observation 직접 초기화', () => {
+    const stale: KalmanState = {
+      v: 10,
+      P: 50,
+      ts: now - STATE_STALE_THRESHOLD_MS - 1, // 1ms 초과
+    };
+    const result = runKalmanStep({
+      prior: stale,
+      gpsAvgKmh: 40,
+      gpsAccuracyMeters: 10,
+      accelMagnitudeStd: 0.1,
+      now,
+    });
+    expect(result.v).toBe(40);
+    expect(result.P).toBe(R_LOW);
+    expect(result.ts).toBe(now);
+  });
+
+  it('경계값: Δt === STATE_STALE_THRESHOLD_MS → predict+update 실행 (stale 아님)', () => {
+    // Δt = STATE_STALE_THRESHOLD_MS이면 now - prior.ts = threshold 이므로
+    // > threshold 조건 불만족 → 정상 predict + update
+    const prior: KalmanState = {
+      v: 20,
+      P: 50,
+      ts: now - STATE_STALE_THRESHOLD_MS,
+    };
+    const result = runKalmanStep({
+      prior,
+      gpsAvgKmh: 30,
+      gpsAccuracyMeters: 10,
+      accelMagnitudeStd: 0.1,
+      now,
+    });
+    // predict: P_pred = 50 + Q_LOW * dtSec
+    const dtSec = STATE_STALE_THRESHOLD_MS / 1000;
+    const pPred = 50 + Q_LOW * dtSec;
+    // update: K = P_pred / (P_pred + R_LOW)
+    const k = pPred / (pPred + R_LOW);
+    const vExpected = 20 + k * (30 - 20);
+    expect(result.v).toBeCloseTo(vExpected, 4);
+    // observation 직접 초기화가 아님 (v ≠ gpsAvgKmh=30 이여야 함, 블렌딩 값)
+    expect(result.v).not.toBe(30);
+  });
+
+  it('정상 prior → predict → update 결합 결과', () => {
+    // prior: v=20, P=100, ts=now-10_000
+    // accelStd=0.1 → Q=1, Δt=10s → P_pred=100+10=110
+    // gpsAccuracy=30 → R=25, K=110/135, v_new = 20 + K*(40-20)
+    const prior: KalmanState = { v: 20, P: 100, ts: now - 10_000 };
+    const result = runKalmanStep({
+      prior,
+      gpsAvgKmh: 40,
+      gpsAccuracyMeters: 30,
+      accelMagnitudeStd: 0.1,
+      now,
+    });
+    const dtSec = 10;
+    const pPred = 100 + Q_LOW * dtSec;
+    const k = pPred / (pPred + R_MID);
+    const vExpected = 20 + k * (40 - 20);
+    expect(result.v).toBeCloseTo(vExpected, 4);
+    expect(result.ts).toBe(now);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// KV roundtrip
+// ─────────────────────────────────────────────────────
+
+describe('readKalmanState / writeKalmanState / clearKalmanState — KV 입출력', () => {
+  it('write → read 시 동일 state 복원', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const state: KalmanState = { v: 35.5, P: 42.0, ts: 1_700_000_000_000 };
+    await writeKalmanState(kv, 'tok1', state);
+    const loaded = await readKalmanState(kv, 'tok1');
+    expect(loaded).toEqual(state);
+  });
+
+  it('clear → read 시 null 반환', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const state: KalmanState = { v: 10, P: 5, ts: 1000 };
+    await writeKalmanState(kv, 'tok2', state);
+    await clearKalmanState(kv, 'tok2');
+    expect(await readKalmanState(kv, 'tok2')).toBeNull();
+  });
+
+  it('KV에 데이터 없으면 null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    expect(await readKalmanState(kv, 'nonexistent')).toBeNull();
+  });
+
+  it('JSON parse 실패 → null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await (kv as unknown as InMemoryKV).put('kalman:tok3', 'not-valid-json');
+    expect(await readKalmanState(kv, 'tok3')).toBeNull();
+  });
+
+  it('배열 저장 → null (객체가 아님)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await (kv as unknown as InMemoryKV).put('kalman:tok4', JSON.stringify([1, 2, 3]));
+    expect(await readKalmanState(kv, 'tok4')).toBeNull();
+  });
+
+  it('null 저장 → null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await (kv as unknown as InMemoryKV).put('kalman:tok5', JSON.stringify(null));
+    expect(await readKalmanState(kv, 'tok5')).toBeNull();
+  });
+
+  it('v 필드 누락 → null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await (kv as unknown as InMemoryKV).put('kalman:tok6', JSON.stringify({ P: 10, ts: 1000 }));
+    expect(await readKalmanState(kv, 'tok6')).toBeNull();
+  });
+
+  it('P 필드 누락 → null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await (kv as unknown as InMemoryKV).put('kalman:tok7', JSON.stringify({ v: 30, ts: 1000 }));
+    expect(await readKalmanState(kv, 'tok7')).toBeNull();
+  });
+
+  it('ts 필드 누락 → null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await (kv as unknown as InMemoryKV).put('kalman:tok8', JSON.stringify({ v: 30, P: 10 }));
+    expect(await readKalmanState(kv, 'tok8')).toBeNull();
+  });
+
+  it('v=NaN → null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    // JSON.stringify(NaN)은 'null'이므로 직접 문자열로 삽입
+    await (kv as unknown as InMemoryKV).put('kalman:tok9', '{"v":null,"P":10,"ts":1000}');
+    expect(await readKalmanState(kv, 'tok9')).toBeNull();
+  });
+
+  it('P=Infinity → null (isFiniteNumber 실패)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    // JSON에서 Infinity는 직접 표현 불가 → 문자열로 삽입
+    await (kv as unknown as InMemoryKV).put(
+      'kalman:tok10',
+      '{"v":30,"P":1e+9999,"ts":1000}',
+    );
+    // 1e+9999는 Infinity로 파싱되므로 isFiniteNumber 실패 → null
+    expect(await readKalmanState(kv, 'tok10')).toBeNull();
+  });
+
+  it('ts=NaN (문자열) → null', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await (kv as unknown as InMemoryKV).put(
+      'kalman:tok11',
+      '{"v":30,"P":10,"ts":"not-a-number"}',
+    );
+    expect(await readKalmanState(kv, 'tok11')).toBeNull();
+  });
+
+  it('서로 다른 token은 독립적으로 저장/조회됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const s1: KalmanState = { v: 10, P: 5, ts: 100 };
+    const s2: KalmanState = { v: 50, P: 20, ts: 200 };
+    await writeKalmanState(kv, 'alice', s1);
+    await writeKalmanState(kv, 'bob', s2);
+    expect(await readKalmanState(kv, 'alice')).toEqual(s1);
+    expect(await readKalmanState(kv, 'bob')).toEqual(s2);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// 수치 회귀 (RMSE) 골든 케이스
+// ─────────────────────────────────────────────────────
+
+describe('수치 회귀 — Kalman RMSE vs 단순 평균', () => {
+  /**
+   * 결정론적 "노이즈 추가" GPS 시뮬레이션.
+   * trueSpeed에 sin 기반 deterministic noise를 추가한다 (Math.random 대신).
+   * noise amplitude는 σ에 해당하는 피크 진폭으로 설정.
+   */
+  function simulateGpsSeries(opts: {
+    trueSpeedKmh: number;
+    noiseAmplitude: number;
+    count: number;
+    startTs: number;
+    dtMs: number;
+  }): Array<{ ts: number; v: number }> {
+    const { trueSpeedKmh, noiseAmplitude, count, startTs, dtMs } = opts;
+    return Array.from({ length: count }, (_, i) => ({
+      ts: startTs + i * dtMs,
+      // sin 기반 결정론적 노이즈 (i에 따라 변화하는 패턴)
+      v: trueSpeedKmh + noiseAmplitude * Math.sin(i * 0.7),
+    }));
+  }
+
+  function rmse(predictions: number[], truth: number): number {
+    const mse = predictions.reduce((sum, p) => sum + (p - truth) ** 2, 0) / predictions.length;
+    return Math.sqrt(mse);
+  }
+
+  it('정속 시나리오: Kalman RMSE ≤ 단순 평균 RMSE (노이즈 평활화 효과)', () => {
+    const TRUE_SPEED = 30; // km/h
+    const NOISE_AMP = 5;   // 피크 amplitude ≈ σ
+    const COUNT = 60;
+    const START_TS = 1_700_000_000_000;
+    const DT_MS = 1000; // 1s 간격
+
+    const samples = simulateGpsSeries({
+      trueSpeedKmh: TRUE_SPEED,
+      noiseAmplitude: NOISE_AMP,
+      count: COUNT,
+      startTs: START_TS,
+      dtMs: DT_MS,
+    });
+
+    // Kalman filter 순차 처리
+    let state: KalmanState | null = null;
+    const kalmanResults: number[] = [];
+    const rawResults: number[] = [];
+
+    for (const s of samples) {
+      state = runKalmanStep({
+        prior: state,
+        gpsAvgKmh: s.v,
+        gpsAccuracyMeters: 15, // 15m → R_LOW=4 (좋은 GPS)
+        accelMagnitudeStd: 0.1, // 정속 → Q_LOW=1
+        now: s.ts,
+      });
+      kalmanResults.push(state.v);
+      rawResults.push(s.v);
+    }
+
+    const kalmanRmse = rmse(kalmanResults, TRUE_SPEED);
+    const rawRmse = rmse(rawResults, TRUE_SPEED);
+
+    // Kalman이 단순 raw보다 RMSE가 작거나 같아야 함
+    expect(kalmanRmse).toBeLessThanOrEqual(rawRmse + 0.01); // 수치 오차 허용
+  });
+
+  it('정차 → 정속 시나리오: 감속 구간에서 Kalman이 안정적으로 수렴', () => {
+    // 처음 30s: 30 km/h 정속 → 다음 30s: 0 km/h (정차)
+    const START_TS = 2_000_000_000_000;
+    const PHASE1_TRUE = 30;
+    const PHASE2_TRUE = 0;
+
+    const phase1Samples = simulateGpsSeries({
+      trueSpeedKmh: PHASE1_TRUE,
+      noiseAmplitude: 3,
+      count: 30,
+      startTs: START_TS,
+      dtMs: 1000,
+    });
+    const phase2Samples = simulateGpsSeries({
+      trueSpeedKmh: PHASE2_TRUE,
+      noiseAmplitude: 1,
+      count: 30,
+      startTs: START_TS + 30_000,
+      dtMs: 1000,
+    });
+
+    const allSamples = [...phase1Samples, ...phase2Samples];
+
+    let state: KalmanState | null = null;
+    const kalmanResults: number[] = [];
+    const rawResults: number[] = [];
+
+    for (const s of allSamples) {
+      state = runKalmanStep({
+        prior: state,
+        gpsAvgKmh: s.v,
+        gpsAccuracyMeters: 15,
+        accelMagnitudeStd: 0.3,
+        now: s.ts,
+      });
+      kalmanResults.push(state.v);
+      rawResults.push(s.v);
+    }
+
+    // phase2(정차)의 마지막 10 sample 기준 RMSE
+    const kalmanPhase2 = kalmanResults.slice(50);
+    const rawPhase2 = rawResults.slice(50);
+    const kalmanRmse = rmse(kalmanPhase2, PHASE2_TRUE);
+    const rawRmse = rmse(rawPhase2, PHASE2_TRUE);
+
+    // 정차 구간에서 Kalman은 raw보다 크지 않거나 비슷해야 한다 (smoothing 효과)
+    // Kalman은 prior를 유지하므로 약간 더 클 수 있지만, raw의 2배를 넘지 않아야 함
+    expect(kalmanRmse).toBeLessThan(rawRmse * 2 + 1);
+    // phase2의 마지막 시점에서 state.v는 유한수여야 함
+    expect(Number.isFinite(state!.v)).toBe(true);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import { readKalmanState } from '../kalmanFilter';
 import {
   MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
@@ -1436,5 +1437,247 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     expect(stats.envCorrected).toBe(1);
     const persisted = JSON.parse((await kv.get('trip:bp-tok'))!);
     expect(persisted.apnsEnv).toBe('production');
+  });
+});
+
+describe('runScheduled — evaluateAndMaybeFireBoardingPrompt Kalman KV 통합 (#824)', () => {
+  /**
+   * boarding-prompt 경로에서 Kalman state가 KV에 persist/read되는지 검증.
+   *
+   * evaluateAndMaybeFireBoardingPrompt는:
+   *   1. accelSeries + kalmanState 병렬 로드 (readAccelSeries + readKalmanState)
+   *   2. runKalmanStep 실행
+   *   3. writeKalmanState → KV에 `kalman:<token>` 저장
+   *   4. kalmanState.v를 evaluateBoardingPromptGates에 전달
+   */
+
+  function makeKalmanTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'kalman-tok',
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+      ...overrides,
+    });
+  }
+
+  async function seedHappySeries(kv: InMemoryKV, token = 'kalman-tok'): Promise<void> {
+    const series = [
+      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+  }
+
+  function makeKalmanPromptDeps(fetchImpl: typeof fetch) {
+    return {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'kalman-push-1',
+    };
+  }
+
+  it('evaluateAndMaybeFireBoardingPrompt: writeKalmanState → KV에 kalman:<token> 저장됨', async () => {
+    // promptGeoContext 있는 trip + happy series → evaluateAndMaybeFireBoardingPrompt 진입
+    // kalman KV key = 'kalman:kalman-tok' 생성 확인
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeKalmanTrip());
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    await runScheduled(makeEnv(kv), makeKalmanPromptDeps(fetchImpl));
+
+    // KV에 kalman state가 저장되어야 함
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, 'kalman-tok');
+    expect(kalmanState).not.toBeNull();
+    expect(typeof kalmanState?.v).toBe('number');
+    expect(typeof kalmanState?.P).toBe('number');
+    expect(typeof kalmanState?.ts).toBe('number');
+    expect(Number.isFinite(kalmanState!.v)).toBe(true);
+    expect(Number.isFinite(kalmanState!.P)).toBe(true);
+  });
+
+  it('prior Kalman state가 KV에 있으면 다음 cycle에서 predict+update 연속 실행', async () => {
+    // 1st cycle: prior=null → observation 초기화 → state 저장
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeKalmanTrip());
+    await seedHappySeries(kv);
+    const fetchImpl1 = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    await runScheduled(makeEnv(kv), makeKalmanPromptDeps(fetchImpl1));
+    const stateAfterCycle1 = await readKalmanState(kv as unknown as KVNamespace, 'kalman-tok');
+    expect(stateAfterCycle1).not.toBeNull();
+
+    // 2nd cycle: boardingPromptState.fired=true이므로 게이트 차단되지만
+    // Kalman step은 게이트와 무관하게 실행되어 state가 갱신되어야 함.
+    // fired=true로 게이트 차단 → 따라서 boardingPromptFired=0이어야 함.
+    // Kalman writeKalmanState는 게이트 평가 전에 실행되므로 state가 갱신됨.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeKalmanTrip({ boardingPromptState: { fired: true, lastFiredAt: NOW - 1000 } }),
+    );
+    const fetchImpl2 = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeKalmanPromptDeps(fetchImpl2));
+    expect(stats.boardingPromptFired).toBe(0); // 게이트 차단
+    expect(stats.boardingPromptBlocked).toBe(1);
+
+    // 2nd cycle 후 state가 업데이트되었는지 확인 (ts가 now=NOW로 갱신)
+    const stateAfterCycle2 = await readKalmanState(kv as unknown as KVNamespace, 'kalman-tok');
+    expect(stateAfterCycle2).not.toBeNull();
+    expect(stateAfterCycle2?.ts).toBe(NOW);
+  });
+
+  it('kalmanKmh가 evaluateBoardingPromptGates에 전달되어 fusedSpeedKmh에 영향을 줌 (간접 검증)', async () => {
+    // kalman state를 KV에 미리 넣어 두면 (prior 있음 + 최근 ts),
+    // runKalmanStep이 predict+update를 실행해 kalmanKmh가 GPS avg와 다를 수 있다.
+    // outcome.fusedSpeedKmh가 GPS-only보다 달라지는지를 비교한다.
+
+    // Case A: KV에 kalman state 없음 (prior=null → 초기화 → kalmanKmh ≈ gpsAvg)
+    const kvA = new InMemoryKV();
+    await seedHappySeries(kvA, 'kalman-tok');
+    await putTrip(kvA as unknown as KVNamespace, makeKalmanTrip());
+    const fetchA = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const statsA = await runScheduled(makeEnv(kvA), makeKalmanPromptDeps(fetchA));
+    // 게이트 통과 여부와 kalman state 저장 확인
+    expect(statsA.boardingPromptEvaluated).toBe(1);
+    const stateA = await readKalmanState(kvA as unknown as KVNamespace, 'kalman-tok');
+    expect(stateA).not.toBeNull();
+
+    // Case B: KV에 kalman state가 있음 (prior 있음 → predict+update로 다른 v 값)
+    const kvB = new InMemoryKV();
+    // prior state: v=100 km/h (비현실적으로 높은 값) → kalmanKmh가 GPS avg와 달라짐
+    const priorState = { v: 100, P: 400, ts: NOW - 5_000 };
+    await kvB.put('kalman:kalman-tok', JSON.stringify(priorState));
+    await putTrip(kvB as unknown as KVNamespace, makeKalmanTrip());
+    await seedHappySeries(kvB, 'kalman-tok');
+    const fetchB = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const statsB = await runScheduled(makeEnv(kvB), makeKalmanPromptDeps(fetchB));
+    expect(statsB.boardingPromptEvaluated).toBe(1);
+
+    // KV의 kalman state가 갱신되어 있어야 함 (ts=NOW로)
+    const stateB = await readKalmanState(kvB as unknown as KVNamespace, 'kalman-tok');
+    expect(stateB?.ts).toBe(NOW);
+    // v는 prior(100)과 GPS avg 블렌딩 → 100과 gpsAvg 사이의 값이어야 함
+    expect(stateB!.v).toBeGreaterThan(0);
+  });
+
+  // 기존 lockMissing/lock-active 회귀 보존
+  it('기존 lockMissing 회귀: lock 부재 + promptGeoContext 없음 → lockMissing+1, kalman 미호출', async () => {
+    const kv = new InMemoryKV();
+    // promptGeoContext 없는 trip → evaluateAndMaybeFireBoardingPrompt에서 early return
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'no-geo-kalman' }));
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      generatePushId: () => 'k1',
+    });
+    expect(stats.lockMissing).toBe(1);
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    // kalman KV key가 생성되지 않아야 함
+    expect(await kv.get('kalman:no-geo-kalman')).toBeNull();
+  });
+
+  it('기존 lock-active trip은 kalman path 진입 안 함 (lockMissing=0)', async () => {
+    const kv = new InMemoryKV();
+    const lockTrip = makeTrip({
+      token: 'active-lock-kalman',
+      boardingLock: {
+        trainCode: 'X',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW,
+        segmentStations: ['강남', '역삼'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+      waypoints: [{ stationName: '역삼', line: '2', kind: 'destination' }],
+    });
+    await putTrip(kv as unknown as KVNamespace, lockTrip);
+    // Seoul API: arrivals 비어 있음 → etaMissing
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      generatePushId: () => 'k2',
+    });
+    expect(stats.lockMissing).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    // kalman key 미생성 (lock-active 분기는 kalman path 미통과)
+    expect(await kv.get('kalman:active-lock-kalman')).toBeNull();
+  });
+
+  // 리뷰 P2-1 — 무관측 cycle은 Kalman state I/O를 skip해 거짓 0 km/h observation 누적 방지.
+  it('series 비어 있으면 kalman state 미작성 (관측 무효 → skip)', async () => {
+    const kv = new InMemoryKV();
+    // positionSeries 자체가 없는 trip — count=0, avgAccuracy=Infinity
+    await putTrip(kv as unknown as KVNamespace, makeKalmanTrip({ token: 'empty-series' }));
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'empty-1',
+    });
+    // boarding-prompt 평가는 진입했지만 게이트에서 차단됨 (window-too-small)
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    // kalman state는 만들어지지 않아야 함 — 거짓 0 km/h observation으로 prior 오염 방지
+    expect(await kv.get('kalman:empty-series')).toBeNull();
+  });
+
+  it('모든 sample이 accuracy로 reject되면 kalman state 미작성 (관측 무효 → skip)', async () => {
+    const kv = new InMemoryKV();
+    // accuracy ≥ 50m sample만 있어 totalHopMs=0 → avgAccuracy=Infinity, gpsAvg=0
+    const series = [
+      { lat: 0, lng: -0.0004, accuracy: 80, ts: NOW - 60_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0002, accuracy: 80, ts: NOW - 30_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0008, accuracy: 80, ts: NOW, motion: 'automotive' },
+    ];
+    await kv.put('pos:bad-acc', JSON.stringify(series));
+    await putTrip(kv as unknown as KVNamespace, makeKalmanTrip({ token: 'bad-acc' }));
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'bad-acc-1',
+    });
+    // accuracy-too-poor 게이트에서 차단되고 Kalman은 skip
+    expect(await kv.get('kalman:bad-acc')).toBeNull();
+  });
+
+  // 리뷰 P2-3 — prior 부재 첫 cycle은 state.v=gpsAvg로 초기화되어 fusion에 합류 시
+  // 같은 GPS가 2회 가중 → confidence 가짜 상승. state는 persist 하되 kalmanKmh는 null로
+  // 게이트에 전달해야 한다. 검증: prior 없는 cycle은 GPS-only fusedSpeed와 동일 confidence.
+  it('prior=null 첫 cycle은 state는 persist하되 kalmanKmh를 게이트에 전달하지 않음', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeKalmanTrip({ token: 'first-cycle' }));
+    await seedHappySeries(kv, 'first-cycle');
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const stats = await runScheduled(makeEnv(kv), makeKalmanPromptDeps(fetchImpl));
+
+    // state는 다음 cycle prior로 쓸 수 있게 persist
+    const state = await readKalmanState(kv as unknown as KVNamespace, 'first-cycle');
+    expect(state).not.toBeNull();
+    expect(state?.ts).toBe(NOW);
+    // boarding-prompt 게이트는 통과 — kalmanKmh=null이라 fusedSpeed는 GPS+map only 합산
+    expect(stats.boardingPromptEvaluated).toBe(1);
   });
 });

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -74,6 +74,12 @@ export interface EvaluateBoardingPromptInputs {
   now: number;
   /** trip의 boarding-prompt 상태 — 게이트 #9 평가. */
   promptState?: BoardingPromptState;
+  /**
+   * Phase 3 Kalman smoothed velocity (#824). 호출자가 kalmanFilter.runKalmanStep으로
+   * 산출해 전달. 미적용 단계는 null/undefined — fusedSpeed가 가중치 0으로 자연 무시
+   * (Phase 1/2 회귀 없음).
+   */
+  kalmanKmh?: number | null;
 }
 
 /**
@@ -143,13 +149,15 @@ export function evaluateBoardingPromptGates(
     return { pass: false, reason: 'motion-not-moving', metrics };
   }
 
-  // #7 — fused speed. mapMatchedKmh는 #828에서 wire — 양 끝 sample이 같은 line + arcM을 가질
-  // 때만 evaluateWindow가 산출하고, 그 외에는 null로 강등 (GPS-only fallback).
+  // #7 — fused speed. mapMatchedKmh는 #828, kalmanKmh는 #824에서 wire — 양 끝 sample이 같은
+  // line + arcM을 가질 때만 evaluateWindow가 mapMatchedKmh 산출, 그 외에는 null로 강등
+  // (GPS-only fallback). kalmanKmh는 호출자(scheduled.ts)가 runKalmanStep으로 산출 후 주입.
   const fused = fusedSpeed({
     gpsAvgKmh: metrics.gpsAvgKmh,
     gpsAccuracyMeters: metrics.avgAccuracyMeters,
     motion: metrics.motion,
     mapMatchedKmh: metrics.mapMatchedKmh,
+    kalmanKmh: inputs.kalmanKmh ?? null,
   });
   if (fused.speed < MIN_FUSED_SPEED_KMH || fused.confidence === 'low') {
     return { pass: false, reason: 'speed-too-low', metrics };

--- a/backend/alarm-worker/src/fusedSpeed.ts
+++ b/backend/alarm-worker/src/fusedSpeed.ts
@@ -1,7 +1,7 @@
 /**
- * Phase 1 fused speed 계산 (#819 게이트 #7).
+ * Phase 1 fused speed 계산 (#819 게이트 #7) + Phase 2 map matching (#828) + Phase 3 Kalman (#824).
  *
- * GPS 좌표 series 평균속도 + Motion sanity + (Phase 2부터) map-matched speed의
+ * GPS 좌표 series 평균속도 + Motion sanity + map-matched speed + Kalman smoothed velocity의
  * 가중 평균. iOS client.speed가 `-1`/빈 값으로 자주 떨어지는 회귀(#812 cold start) 때문에
  * raw client.speed를 신뢰하지 않고 좌표 series로 직접 산출한다.
  *
@@ -9,6 +9,11 @@
  */
 
 export type Motion = 'stationary' | 'walking' | 'automotive' | 'unknown';
+
+/** Phase 3 Kalman smoothed velocity의 fusion 가중치 (#824). 0.6~0.8 범위에서 0.6 채택 —
+ *  Kalman은 부분적으로 GPS observation에 의존하므로 독립 신호 대비 보수적으로 시작.
+ *  E5 측정 인프라로 실측 후 ↑ 조정 가능. PR 본문 R/Q 표와 함께 SSOT. */
+export const KALMAN_WEIGHT = 0.6;
 
 export interface FusedSpeedInputs {
   /** 좌표 series 60s 평균 km/h. */
@@ -19,6 +24,11 @@ export interface FusedSpeedInputs {
   motion: Motion;
   /** Phase 2 map matching 결과. 미사용 단계는 null — 가중치 0으로 자연 무시. */
   mapMatchedKmh: number | null;
+  /**
+   * Phase 3 Kalman smoothed velocity (#824). 미적용 단계는 null/undefined — 가중치 0으로
+   * 자연 무시 (Phase 1/2 회귀 없음). 평가 사이트에서 runKalmanStep 결과 `state.v`를 전달.
+   */
+  kalmanKmh?: number | null;
 }
 
 export interface FusedSpeed {
@@ -29,13 +39,15 @@ export interface FusedSpeed {
 }
 
 /**
- * 좌표 series 60s 평균 + motion clamp + (Phase 2부터) map matching weighted fusion.
+ * 좌표 series 60s 평균 + motion clamp + map matching + Kalman smoothed velocity weighted fusion.
  *
  * - motion=stationary면 다른 신호 무시하고 0 km/h 강등 (false positive 1차 차단).
  * - GPS 가중치는 accuracy 단계 함수 — < 20m: 0.7, < 50m: 0.5, < 100m: 0.2, 그 외: 0.
  *   (50m 컷오프 자체는 호출자가 게이트 #3에서 series 필터로 처리. 여기서는 평균
  *   accuracy 기반 신뢰도 조정만.)
- * - mapMatchedKmh가 있으면 0.5 추가 — Phase 2까지는 null로 호출되므로 GPS only.
+ * - mapMatchedKmh가 있으면 0.5 추가 (#828).
+ * - kalmanKmh가 있으면 KALMAN_WEIGHT(0.6) 추가 (#824). Phase 3 미적용 호출은 null/undefined로
+ *   들어와 가중치 0 — 회귀 없음.
  * - clamp: walking은 10 km/h 상한, automotive는 5 km/h 하한 — sensor 불일치를 완화.
  */
 export function fusedSpeed(opts: FusedSpeedInputs): FusedSpeed {
@@ -50,11 +62,15 @@ export function fusedSpeed(opts: FusedSpeedInputs): FusedSpeed {
           ? 0.2
           : 0;
   const mapWeight = opts.mapMatchedKmh != null ? 0.5 : 0;
-  const totalW = gpsWeight + mapWeight;
+  const kalmanWeight = opts.kalmanKmh != null ? KALMAN_WEIGHT : 0;
+  const totalW = gpsWeight + mapWeight + kalmanWeight;
   if (totalW === 0) return { speed: 0, confidence: 'low' };
 
   const raw =
-    (opts.gpsAvgKmh * gpsWeight + (opts.mapMatchedKmh ?? 0) * mapWeight) / totalW;
+    (opts.gpsAvgKmh * gpsWeight +
+      (opts.mapMatchedKmh ?? 0) * mapWeight +
+      (opts.kalmanKmh ?? 0) * kalmanWeight) /
+    totalW;
   const speed =
     opts.motion === 'walking'
       ? Math.min(raw, 10)

--- a/backend/alarm-worker/src/kalmanFilter.ts
+++ b/backend/alarm-worker/src/kalmanFilter.ts
@@ -1,0 +1,214 @@
+/**
+ * 1D Kalman filter — smoothed velocity 추정 (#824 Phase 3 E2).
+ *
+ * positionSeries.evaluateWindow의 `gpsAvgKmh` (관측)와 accelSeries.evaluateAccelWindow의
+ * magnitude 통계(프로세스 노이즈 driver)를 fuse해 transient noise — 터널 진입/정거장
+ * 정차/짧은 GPS dropout — 에 robust한 속도를 산출한다. 결과는 `fusedSpeed.kalmanKmh`에
+ * weighted average로 합류한다.
+ *
+ * ADR: https://app.notion.com/p/37430c0194b6819c8323e37d4c31a777 Section 5 (Phase 3).
+ *
+ * # State
+ *  - `v`  scalar velocity (km/h)
+ *  - `P`  uncertainty covariance (km/h)²
+ *  - `ts` 마지막 update 시각 (epoch ms) — Δt 산출
+ *
+ * # Predict (random walk + uncertainty inflation)
+ *   v_pred = v_prev
+ *   P_pred = P_prev + Q(accelStd) · Δt
+ *
+ * 의도적 단순화: E1 `magnitudeMean`은 unsigned positive라 가/감속을 구분 못한다.
+ * 직접 driver로 `v_prev + a·Δt`를 쓰면 정거장 정차 phase에서도 위로 drift한다.
+ * 대신 stddev를 process noise Q로 인코딩 — 가속도 흔들림이 크면 predict 분산이
+ * 커져 GPS update가 더 강하게 보정. E3/E4에서 signed direction 또는 phase 추정으로
+ * 정밀화 가능.
+ *
+ * # Update (Bayesian fusion)
+ *   K = P_pred / (P_pred + R(accuracy))
+ *   v_new = v_pred + K · (z - v_pred)   // z = gpsAvgKmh
+ *   P_new = (1 - K) · P_pred
+ *
+ * # Noise tables (PR 본문 표와 SSOT)
+ *  관측 R — accuracy 단계 함수 (km/h)²
+ *    < 20m  →  4   (~±2  km/h, urban canyon 정상)
+ *    < 50m  →  25  (~±5  km/h, 일반 도시 GPS)
+ *    < 100m →  100 (~±10 km/h, 신뢰 낮음)
+ *    ≥ 100m →  400 (~±20 km/h, observation 거의 무시)
+ *
+ *  프로세스 Q — accel stddev 단계 함수 (km/h)²/s
+ *    < 0.5 m/s² →  1  (정거장 정차/정속 cruise)
+ *    < 2.0 m/s² →  9  (도보/일반 가속)
+ *    ≥ 2.0 m/s² →  36 (열차 출발·감속 phase)
+ *
+ *  초기 P₀ = R(accuracy) — 첫 관측의 분산이 prior 부재 시 가장 정확한 사전.
+ *
+ * # State 만료
+ *  - prior 부재 또는 Δt > STATE_STALE_THRESHOLD_MS → observation 직접 초기화.
+ *  - Δt ≤ 0 → predict skip (시계 역행 보호; prior 그대로 update만).
+ */
+
+/** KV 키 prefix — device token 1개당 1 state. */
+const KALMAN_STATE_PREFIX = 'kalman:';
+/** KV TTL — positionSeries/accelSeries와 정합 (1h 미활동 시 자연 폐기). */
+const STATE_TTL_SEC = 60 * 60;
+/** 상태 만료 임계 — Δt 이 값 초과면 stale로 간주해 observation으로 초기화. */
+export const STATE_STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/** R 단계 함수 임계 (m). */
+export const ACCURACY_R_LOW_M = 20;
+export const ACCURACY_R_MID_M = 50;
+export const ACCURACY_R_HIGH_M = 100;
+/** R 단계 함수 분산 (km/h)². */
+export const R_LOW = 4;
+export const R_MID = 25;
+export const R_HIGH = 100;
+export const R_REJECT = 400;
+
+/** Q 단계 함수 임계 (m/s²). */
+export const ACCEL_STD_Q_LOW = 0.5;
+export const ACCEL_STD_Q_MID = 2;
+/** Q 단계 함수 분산 (km/h)²/s — Δt 곱해서 사용. */
+export const Q_LOW = 1;
+export const Q_MID = 9;
+export const Q_HIGH = 36;
+
+export interface KalmanState {
+  /** 추정 속도 km/h. */
+  v: number;
+  /** 추정 분산 (km/h)². */
+  P: number;
+  /** 마지막 update 시각 (epoch ms). */
+  ts: number;
+}
+
+export interface KalmanStepInputs {
+  /** 직전 cycle의 state. 미존재(null)거나 stale이면 observation으로 초기화. */
+  prior: KalmanState | null;
+  /** GPS 관측 km/h — positionSeries.evaluateWindow.gpsAvgKmh. */
+  gpsAvgKmh: number;
+  /** 윈도우 평균 accuracy meters — R 단계 함수 입력. */
+  gpsAccuracyMeters: number;
+  /** accel 윈도우 stddev (m/s²) — Q 단계 함수 입력. 0이면 Q_LOW. */
+  accelMagnitudeStd: number;
+  /** 현 시각 epoch ms — Δt 산출. */
+  now: number;
+}
+
+/** R 단계 함수 — accuracy → 관측 분산. */
+export function computeNoiseR(accuracyMeters: number): number {
+  if (accuracyMeters < ACCURACY_R_LOW_M) return R_LOW;
+  if (accuracyMeters < ACCURACY_R_MID_M) return R_MID;
+  if (accuracyMeters < ACCURACY_R_HIGH_M) return R_HIGH;
+  return R_REJECT;
+}
+
+/** Q 단계 함수 — accel stddev → 프로세스 분산 per second. */
+export function computeNoiseQ(accelStd: number): number {
+  if (accelStd < ACCEL_STD_Q_LOW) return Q_LOW;
+  if (accelStd < ACCEL_STD_Q_MID) return Q_MID;
+  return Q_HIGH;
+}
+
+/**
+ * Predict step — constant velocity, uncertainty grows by Q · Δt.
+ * Δt ≤ 0은 시계 역행 보호로 prior 그대로 반환 (다음 update가 이어받음).
+ */
+export function predictKalman(
+  prior: KalmanState,
+  accelMagnitudeStd: number,
+  now: number,
+): KalmanState {
+  const dtMs = now - prior.ts;
+  if (dtMs <= 0) return prior;
+  const dtSec = dtMs / 1000;
+  const Q = computeNoiseQ(accelMagnitudeStd);
+  return {
+    v: prior.v,
+    P: prior.P + Q * dtSec,
+    ts: now,
+  };
+}
+
+/** Update step — Kalman gain으로 prediction과 GPS 관측을 가중평균. */
+export function updateKalman(
+  predicted: KalmanState,
+  gpsAvgKmh: number,
+  gpsAccuracyMeters: number,
+): KalmanState {
+  const R = computeNoiseR(gpsAccuracyMeters);
+  const K = predicted.P / (predicted.P + R);
+  return {
+    v: predicted.v + K * (gpsAvgKmh - predicted.v),
+    P: (1 - K) * predicted.P,
+    ts: predicted.ts,
+  };
+}
+
+/**
+ * 한 cycle의 Kalman step (predict + update).
+ *
+ *   1. prior 부재 또는 Δt > STATE_STALE_THRESHOLD_MS → observation 직접 초기화
+ *      (v=gpsAvgKmh, P=R(accuracy), ts=now). 첫 관측의 분산이 prior 부재 시 가장
+ *      정확한 사전.
+ *   2. 정상 prior → predict → update.
+ *
+ * 반환된 state는 호출자가 fusedSpeed에 `kalmanKmh = state.v`로 전달하고 KV에 persist.
+ */
+export function runKalmanStep(inputs: KalmanStepInputs): KalmanState {
+  const { prior, gpsAvgKmh, gpsAccuracyMeters, accelMagnitudeStd, now } = inputs;
+  if (!prior || now - prior.ts > STATE_STALE_THRESHOLD_MS) {
+    return { v: gpsAvgKmh, P: computeNoiseR(gpsAccuracyMeters), ts: now };
+  }
+  const predicted = predictKalman(prior, accelMagnitudeStd, now);
+  return updateKalman(predicted, gpsAvgKmh, gpsAccuracyMeters);
+}
+
+/** KV state load — 없거나 invalid JSON이면 null. */
+export async function readKalmanState(
+  kv: KVNamespace,
+  token: string,
+): Promise<KalmanState | null> {
+  const raw = await kv.get(stateKey(token));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isKalmanState(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** KV state 저장 — TTL 1h. */
+export async function writeKalmanState(
+  kv: KVNamespace,
+  token: string,
+  state: KalmanState,
+): Promise<void> {
+  await kv.put(stateKey(token), JSON.stringify(state), {
+    expirationTtl: STATE_TTL_SEC,
+  });
+}
+
+/** 명시 삭제 — trip 종료/cleanup 시 사용. */
+export async function clearKalmanState(
+  kv: KVNamespace,
+  token: string,
+): Promise<void> {
+  await kv.delete(stateKey(token));
+}
+
+function stateKey(token: string): string {
+  return `${KALMAN_STATE_PREFIX}${token}`;
+}
+
+function isKalmanState(value: unknown): value is KalmanState {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  return (
+    isFiniteNumber(o.v) && isFiniteNumber(o.P) && isFiniteNumber(o.ts)
+  );
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3,6 +3,7 @@
  */
 
 import { ARRIVAL_CODE, TRAIN_STATUS } from './alarm';
+import { evaluateAccelWindow, readAccelSeries } from './accelSeries';
 import {
   sendBoardingPromptPush,
   sendReschedulePush,
@@ -17,13 +18,18 @@ import {
   type GateSkipReason,
 } from './boardingPrompt';
 import {
+  readKalmanState,
+  runKalmanStep,
+  writeKalmanState,
+} from './kalmanFilter';
+import {
   buildLiveActivityContentState,
   cleanupTripWithLa,
   fireLiveActivityUpdate,
   type LiveActivityStats,
 } from './liveActivity';
 import { matchLine } from './lineAlias';
-import { readSeries } from './positionSeries';
+import { evaluateWindow, readSeries } from './positionSeries';
 import { getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { listTrips, putTrip } from './trips';
@@ -847,13 +853,48 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   stats.boardingPromptEvaluated += 1;
 
-  const series = await readSeries(env.TRIPS, trip.token);
+  // Phase 3 E2 (#824) — positionSeries + accelSeries + 직전 Kalman state를 병렬 로드.
+  // 정상 cycle은 predict+update로 smoothed velocity를 산출해 fusedSpeed의 가중평균에 합류.
+  //
+  // 두 가지 가드:
+  //   (1) 관측 무효 (count=0 or 모든 hop이 accuracy로 reject되어 avgAccuracy=Infinity)
+  //       → state I/O 자체를 skip. 거짓 0 km/h observation을 누적하지 않는다 (리뷰 P2-1).
+  //   (2) prior 부재 첫 cycle은 state.v === gpsAvgKmh (관측 직접 초기화)이므로
+  //       fusedSpeed에 합류시키면 같은 GPS가 가중치 2회 합산 → confidence 가짜 상승.
+  //       state는 다음 cycle prior로 쓸 수 있게 persist 하되 kalmanKmh는 null로 전달
+  //       해 fusion에는 합류하지 않는다 (리뷰 P2-3). 다음 cycle부터 진짜 smoothing 효과.
+  const [series, accelSeries, kalmanPrior] = await Promise.all([
+    readSeries(env.TRIPS, trip.token),
+    readAccelSeries(env.TRIPS, trip.token),
+    readKalmanState(env.TRIPS, trip.token),
+  ]);
+  const posMetrics = evaluateWindow(series, now);
+  const accelMetrics = evaluateAccelWindow(accelSeries, now);
+  const observationValid =
+    posMetrics.count > 0 && Number.isFinite(posMetrics.avgAccuracyMeters);
+
+  let kalmanKmh: number | null = null;
+  if (observationValid) {
+    const kalmanState = runKalmanStep({
+      prior: kalmanPrior,
+      gpsAvgKmh: posMetrics.gpsAvgKmh,
+      gpsAccuracyMeters: posMetrics.avgAccuracyMeters,
+      accelMagnitudeStd: accelMetrics.avgMagnitudeStd,
+      now,
+    });
+    await writeKalmanState(env.TRIPS, trip.token, kalmanState);
+    if (kalmanPrior !== null) {
+      kalmanKmh = kalmanState.v;
+    }
+  }
+
   const outcome = evaluateBoardingPromptGates({
     series,
     origin: geo.origin,
     nextStation: geo.nextStation,
     now,
     promptState: trip.boardingPromptState,
+    kalmanKmh,
   });
 
   if (!outcome.pass) {


### PR DESCRIPTION
## Summary

Phase 3 E2 (Epic #818). GPS series 평균속도 + accel summary를 1D Kalman으로 fuse해 smoothed velocity를 산출, `fusedSpeed`의 가중평균에 합류시켜 게이트 #7 정확도를 끌어올린다.

- **신규**: `backend/alarm-worker/src/kalmanFilter.ts` — predict/update/runStep + KV state I/O
- **확장**: `fusedSpeed.ts` `kalmanKmh?: number | null` 입력 + `KALMAN_WEIGHT=0.6` 합류 (Phase 1/2 호출자 회귀 0건 — null 시 weight 0으로 자연 무시)
- **wire**: `boardingPrompt.ts`가 옵션으로 받아 `fusedSpeed`에 forward, `scheduled.ts:evaluateAndMaybeFireBoardingPrompt`가 KV 병렬 read + runKalmanStep + persist

## 설계 결정

### Predict — random walk + Q-driven uncertainty
이슈 본문은 `v_pred = v_prev + a · Δt`로 명시했으나, E1 `magnitudeMean`은 **unsigned positive**라 가/감속 phase 모두 양수로 들어가 predict가 위로 drift. 직접 driver로 쓰면 정거장 정차 phase에서도 v가 증가하는 회귀.

**채택**: `v_pred = v_prev` (constant velocity), `P_pred = P_prev + Q(accelStd) · Δt`. 가속도 변동성을 process noise로 인코딩 → GPS update가 자연 보정. E3/E4에서 signed phase 추정으로 정밀화할 자연스러운 확장 경로 확보.

### R / Q 튜닝 표 (SSOT — `kalmanFilter.ts` export 상수)

**관측 R (km/h)²** — accuracy 단계 함수
| accuracy | R | 근거 |
| --- | --- | --- |
| < 20m | 4 | ~±2 km/h. urban canyon 정상 |
| < 50m | 25 | ~±5 km/h. 일반 도시 GPS |
| < 100m | 100 | ~±10 km/h. 신뢰 낮음 |
| ≥ 100m | 400 | ~±20 km/h. observation 거의 무시 |

**프로세스 Q (km/h)²/s** — accel stddev 단계 함수
| accel std | Q | 근거 |
| --- | --- | --- |
| < 0.5 m/s² | 1 | 정거장 정차/정속 cruise |
| < 2.0 m/s² | 9 | 도보/일반 가속 |
| ≥ 2.0 m/s² | 36 | 열차 출발·감속 phase |

**초기 P₀** = `R(accuracy)` — 첫 관측 분산이 prior 부재 시 가장 정확한 사전.

### KV 라이프사이클
- key `kalman:<token>`, TTL 1h (positionSeries/accelSeries와 정합)
- `STATE_STALE_THRESHOLD_MS=5분` 초과 시 observation으로 직접 초기화

### Kalman weight 0.6
이슈 spec의 0.6~0.8 범위에서 하단 채택 — Kalman은 부분적으로 GPS observation에 의존하므로 독립 신호 대비 보수적으로 시작. **E5 측정 인프라로 실측 RMSE 비교 후 ↑ 조정 가능.**

## 리뷰 P2 반영

- **P2-1 (무관측 → 거짓 0 km/h update 누적)**: `scheduled.ts`에서 `observationValid` 가드 (count=0 또는 avgAccuracy=Infinity면 Kalman state I/O skip)
- **P2-3 (prior=null 첫 cycle double-count)**: state는 persist 하되 `kalmanKmh=null`로 게이트 전달. 다음 cycle부터 실제 smoothing fusion
- **P2-2 (evaluateWindow 중복 호출)**: hot path 비용 작아 별도 follow-up 이슈로 분리 예정

## Test plan

- [x] backend `npm test` — **577 tests pass** (kalmanFilter 48 신규 + fusedSpeed/boardingPrompt/scheduled 확장)
- [x] root `npm test` — **3233 tests pass, 100% coverage**
- [x] backend `npm run type-check` pass
- [x] root `npm run type-check` pass
- [x] code-review 에이전트 P1 0건, P2 3건 중 P2-1/P2-3 본 PR 반영

## 영향 범위

- boarding-prompt 9단 게이트 평가만 영향 (`evaluateAndMaybeFireBoardingPrompt` 분기)
- lock-active trip / lockless intermediate / 기타 path는 무영향 (kalman 미통과)
- Phase 1/2 호출자는 `kalmanKmh` 미지정 → 가중치 0으로 자연 회귀 없음

Closes #824