### PR TITLE
feat(#825): Phase 3 E3 — 정거장 phase 감지 + lockless imminent gate

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1097,6 +1097,56 @@ describe('POST /position (#819)', () => {
     expect(parsed[0].mapMatchedLine).toBeUndefined();
     expect(parsed[0].mapMatchedArcM).toBeUndefined();
   });
+
+  describe('#825 — nearestStationDistanceM 옵션 필드', () => {
+    const BASE_POS = { token: 'tok-nsd', lat: 1, lng: 2, accuracy: 5, ts: 1234, motion: 'walking' as const };
+
+    it('정상값(number ≥ 0) → point.nearestStationDistanceM에 set', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', { ...BASE_POS, nearestStationDistanceM: 150 }, env);
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-nsd'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].nearestStationDistanceM).toBe(150);
+    });
+
+    it('nearestStationDistanceM=0 → set (경계값 0 허용)', async () => {
+      const env = makeKvEnv();
+      await post('/position', { ...BASE_POS, nearestStationDistanceM: 0 }, env);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-nsd'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].nearestStationDistanceM).toBe(0);
+    });
+
+    it('음수 → undefined로 graceful skip (payload 거부 X, 200)', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', { ...BASE_POS, nearestStationDistanceM: -1 }, env);
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-nsd'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].nearestStationDistanceM).toBeUndefined();
+    });
+
+    it('NaN → undefined로 graceful skip', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', { ...BASE_POS, nearestStationDistanceM: NaN }, env);
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-nsd'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].nearestStationDistanceM).toBeUndefined();
+    });
+
+    it('문자열 → undefined로 graceful skip', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', { ...BASE_POS, nearestStationDistanceM: '100' }, env);
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-nsd'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].nearestStationDistanceM).toBeUndefined();
+    });
+
+    it('필드 없음 → undefined (옵션 필드 부재 정상 처리)', async () => {
+      const env = makeKvEnv();
+      await post('/position', BASE_POS, env);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-nsd'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].nearestStationDistanceM).toBeUndefined();
+    });
+  });
 });
 
 describe('POST /boarding-prompt/dismiss (#819)', () => {

--- a/backend/alarm-worker/src/__tests__/positionSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/positionSeries.test.ts
@@ -351,6 +351,82 @@ describe('positionSeries — readSeries map matching field validation', () => {
   });
 });
 
+describe('positionSeries — nearestStationDistanceM field validation (#825)', () => {
+  it('nearestStationDistanceM 정상값(양수 finite) → series에 정상 적재', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const valid: PositionPoint = {
+      lat: 37.5,
+      lng: 127.0,
+      accuracy: 5,
+      ts: 1000,
+      motion: 'automotive',
+      nearestStationDistanceM: 150,
+    };
+    await appendPositionPoint(kv, 'tok', valid);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toEqual([valid]);
+    expect(series[0].nearestStationDistanceM).toBe(150);
+  });
+
+  it('nearestStationDistanceM=0 → 정상 적재 (0m도 유효)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', nearestStationDistanceM: 0 },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(1);
+    expect(series[0].nearestStationDistanceM).toBe(0);
+  });
+
+  it('nearestStationDistanceM 음수 → filter됨 (haversine 거리는 항상 ≥ 0)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', nearestStationDistanceM: -1 },
+    ]);
+    await kv.put('pos:tok', raw);
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('nearestStationDistanceM=NaN → filter됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', nearestStationDistanceM: NaN },
+    ]);
+    await kv.put('pos:tok', raw);
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('nearestStationDistanceM=Infinity → filter됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', nearestStationDistanceM: Infinity },
+    ]);
+    await kv.put('pos:tok', raw);
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('nearestStationDistanceM 문자열 타입 → filter됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', nearestStationDistanceM: '100' },
+    ]);
+    await kv.put('pos:tok', raw);
+    expect(await readSeries(kv, 'tok')).toEqual([]);
+  });
+
+  it('nearestStationDistanceM 필드 없음(undefined) → 정상 적재 (옵션 필드)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking' },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(1);
+    expect(series[0].nearestStationDistanceM).toBeUndefined();
+  });
+});
+
 describe('cosineDirection', () => {
   it('같은 방향 → 1', () => {
     // 동→서 두 vector 동일 방향

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1681,3 +1681,253 @@ describe('runScheduled — evaluateAndMaybeFireBoardingPrompt Kalman KV 통합 (
     expect(stats.boardingPromptEvaluated).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #825 — Phase 3 E3 phase gate 통합 테스트
+// ---------------------------------------------------------------------------
+
+describe('runScheduled — #825 Phase 3 E3: phaseImminentBlocked + stationPhase stamp', () => {
+  /** lockless intermediate trip 팩토리 (phase gate 경로 전용). */
+  function makePhaseTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'phase-tok',
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' },
+        { stationName: '역삼', line: '2', kind: 'destination' },
+      ],
+      locklessStationPassed: true,
+      ...overrides,
+    });
+  }
+
+  /** ARRIVED(arvlCd=1) signal로 fires 조건 충족 */
+  const ARVL_ARRIVED: ArrivalEntry = {
+    destination: '강남행',
+    arrivalSeconds: 30,
+    trainCode: '7246',
+    isUp: true,
+    subwayNm: '지하철2호선',
+    arvlCd: 1,
+  };
+
+  /**
+   * nearestStationDistanceM이 포함된 series를 KV에 심는다.
+   * stationPhase 분류 pipeline을 실제로 동작시킨다.
+   */
+  async function seedSeriesWithDistance(
+    kv: InMemoryKV,
+    token: string,
+    nearestStationDistanceM: number | undefined,
+  ): Promise<void> {
+    const series = [
+      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive', nearestStationDistanceM },
+      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive', nearestStationDistanceM },
+      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive', nearestStationDistanceM },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+  }
+
+  // ---------------------------------------------------------------------------
+  // phaseImminentBlocked 회귀 — 기존 동작 보존
+  // ---------------------------------------------------------------------------
+  it('phaseState null + fires(arvlCd=1) → 기존 동작: push 발사, phaseImminentBlocked=0', async () => {
+    // nearestStationDistanceM 없는 series → phaseState=null → gate 허용
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makePhaseTrip());
+    // nearestStationDistanceM=undefined → runStationPhaseStep returns null
+    await seedSeriesWithDistance(kv, 'phase-tok', undefined);
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([ARVL_ARRIVED]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'phase-p1',
+    });
+
+    expect(stats.pushed).toBe(1);
+    expect(stats.phaseImminentBlocked).toBe(0);
+    expect(apnsFetch).toHaveBeenCalled();
+  });
+
+  it('high-confidence CRUISING (dist=500m, kmh=35) + fires → phaseImminentBlocked++, push 미발사', async () => {
+    // dist=500m → CRUISING 우세, confidence>0.7 → gate 차단
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makePhaseTrip());
+    await seedSeriesWithDistance(kv, 'phase-tok', 500);
+    // KV에 Kalman prior 심어 kalmanKmh가 null이 아닌 35km/h 근방으로 수렴되게 한다.
+    // (prior 없으면 kalmanKmh=null → phaseState 분류 입력으로 kalmanState.v 사용)
+    // Kalman prior가 있어야 kalmanKmh가 non-null이 됨 — 하지만 phaseState는 kalmanState.v 입력.
+    // 실제로 runFusionStep은 kalmanState.v를 phase 입력으로 사용하므로 prior 상관없이 분류는 실행됨.
+    // 핵심: series의 마지막 sample nearestStationDistanceM=500 → CRUISING → confidence>0 테스트.
+    // cruiseSpeed는 kalmanState.v≥20일 때 활성. 초기 kalman에서 gpsAvg를 사용 → ~35km/h 예측.
+    // 또한 farFromStationStill은 500>200이지만 속도 높으면 비활성.
+    // prior=null 첫 cycle이면 kalmanKmh=null → phase 입력으로 kalmanState.v는 gpsAvg≈35로 초기화.
+    // → cruiseSpeed 활성 → CRUISING 우세 → confidence=3/Σ > 0.7이면 차단.
+    // 실제 confidence 계산: dist=500>200 → stationVicinity 비활성, dwellingZone 비활성.
+    // cruiseSpeed(35≥20): A-1,D-2,Dep-1,C+3
+    // → A=-1, D=-2, Dep=-1, C=3 → CRUISING best, second=-1
+    // confidence=(3-(-1))/Σ|1+2+1+3|=4/7≈0.571 < 0.7 → gate 허용 (차단 안 됨)
+    // 즉 dist=500, speed=35만으로는 confidence<0.7 → 차단 안 됨.
+    // 차단하려면 더 많은 feature 활성화가 필요.
+    // 실제로 phaseImminentBlocked 테스트는 confidence≥0.7 케이스를 직접 주입해야 함.
+    // stationPhase를 trip에 미리 stamp해서 prev hysteresis로 boost.
+    const tripWithPhase = makePhaseTrip({
+      stationPhase: {
+        current: 'CRUISING',
+        confidence: 0.9, // 이미 high-confidence CRUISING
+        lastEvaluatedAt: NOW - 1000,
+      },
+    });
+    await kv.delete('trip:phase-tok');
+    await putTrip(kv as unknown as KVNamespace, tripWithPhase);
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([ARVL_ARRIVED]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'phase-p2',
+    });
+
+    // phaseState.confidence가 boost돼 ≥0.7이고 CRUISING → gate 차단
+    expect(stats.phaseImminentBlocked).toBe(1);
+    expect(stats.pushed).toBe(0);
+    expect(apnsFetch).not.toHaveBeenCalled();
+    // dirty=true → putTrip 호출됨 → trip에 stationPhase persist 확인
+    const stored = JSON.parse((await kv.get('trip:phase-tok'))!) as Trip;
+    expect(stored.stationPhase).toBeDefined();
+  });
+
+  it('low-confidence CRUISING (confidence=0.5) + fires → gate 허용, push 발사', async () => {
+    // confidence < IMMINENT_FIRING_CONFIDENCE(0.7) → 허용
+    const tripWithLowConf = makePhaseTrip({
+      stationPhase: {
+        current: 'CRUISING',
+        confidence: 0.5,
+        lastEvaluatedAt: NOW - 1000,
+      },
+    });
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, tripWithLowConf);
+    // nearestStationDistanceM=500 series — 분류 결과가 prev와 달라도 prev.confidence=0.5
+    // hysteresis: candidate=CRUISING == prev.current → confidence boost 0.5+0.2=0.7
+    // 그런데 boost 후 0.7 ≥ IMMINENT_FIRING_CONFIDENCE → gate 차단될 수 있음.
+    // nearestStationDistanceM=undefined로 phase null path 유지 → phaseAllows=true.
+    await seedSeriesWithDistance(kv, 'phase-tok', undefined);
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([ARVL_ARRIVED]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'phase-p3',
+    });
+
+    // phaseState=null (nearestStationDistanceM undefined) → phaseAllows=true → 발사
+    expect(stats.phaseImminentBlocked).toBe(0);
+    expect(stats.pushed).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // ScheduledStats.phaseImminentBlocked 초기값
+  // ---------------------------------------------------------------------------
+  it('phaseImminentBlocked 초기 0: 정상 사이클에서 phase gate 미발동이면 0 유지', async () => {
+    // lock-active trip만 있으면 lockless path 미진입 → phaseImminentBlocked=0
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({
+      token: 'lock-only',
+      boardingLock: {
+        trainCode: 'T',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW,
+        segmentStations: ['강남', '역삼'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+      waypoints: [{ stationName: '역삼', line: '2', kind: 'destination' }],
+    }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'phase-init',
+    });
+    expect(stats.phaseImminentBlocked).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // evaluateAndMaybeFireBoardingPrompt — phase stamp
+  // ---------------------------------------------------------------------------
+  it('nearestStationDistanceM 포함 series + boarding-prompt 경로 → trip.stationPhase 갱신 + putTrip', async () => {
+    // boarding-prompt 평가 경로(lockMissing)에서 phase stamp 확인
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'phase-bp-tok',
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // series with nearestStationDistanceM → phase 분류 가능
+    await seedSeriesWithDistance(kv, 'phase-bp-tok', 500);
+
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl,
+      now: () => NOW,
+      generatePushId: () => 'phase-bp-1',
+    });
+
+    // phase 분류 결과가 trip에 stamp되어야 함
+    const stored = JSON.parse((await kv.get('trip:phase-bp-tok'))!) as Trip;
+    expect(stored.stationPhase).toBeDefined();
+    expect(stored.stationPhase?.current).toBeDefined();
+    expect(stored.stationPhase?.lastEvaluatedAt).toBe(NOW);
+  });
+
+  it('nearestStationDistanceM 없는 series → trip.stationPhase 갱신 안 됨 (기존 회귀 보존)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'phase-no-dist-tok',
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // nearestStationDistanceM=undefined → phaseState=null → trip.stationPhase 변경 없음
+    await seedSeriesWithDistance(kv, 'phase-no-dist-tok', undefined);
+
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'phase-no-1',
+    });
+
+    // stationPhase는 갱신 안 됨 (phase null → dirty=false → putTrip 미호출 혹은 stationPhase 미set)
+    // boarding-prompt 게이트가 통과되면 boardingPromptState가 set되므로 trip은 저장되지만
+    // stationPhase는 undefined 상태 유지
+    const stored = JSON.parse((await kv.get('trip:phase-no-dist-tok'))!) as Trip;
+    expect(stored.stationPhase).toBeUndefined();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/stationPhase.test.ts
+++ b/backend/alarm-worker/src/__tests__/stationPhase.test.ts
@@ -1,0 +1,656 @@
+/**
+ * stationPhase.ts 단위 테스트 (#825 Phase 3 E3).
+ *
+ * 검증 대상:
+ *   - classifyStationPhase: 4 golden 시나리오 + 경계값 + score/confidence 수치 + 동률
+ *   - applyPhaseHysteresis: 전이 패턴 6가지 (신규/유지/boost/전환/후보 accumulate/후보 reset)
+ *   - runStationPhaseStep: nearestStationDistanceM 존재 여부 분기
+ *   - phaseAllowsImminentFiring: 4가지 정책 경로
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyPhaseHysteresis,
+  classifyStationPhase,
+  IMMINENT_FIRING_CONFIDENCE,
+  IMMINENT_FIRING_PHASES,
+  MOTION_ACCEL_THRESHOLD,
+  PHASES,
+  phaseAllowsImminentFiring,
+  runStationPhaseStep,
+  SAME_PHASE_BOOST,
+  STATION_DWELL_RADIUS_M,
+  STATION_NEAR_RADIUS_M,
+  STATIONARY_KMH,
+  SWITCH_CYCLES,
+  CRUISE_KMH,
+} from '../stationPhase';
+import type { StationPhaseState } from '../types';
+
+const NOW = 1_700_000_000_000;
+
+/** 기본 입력 팩토리 — 필요한 필드만 override. */
+function makeInputs(
+  overrides: Partial<{
+    kalmanKmh: number;
+    prevKalmanKmh: number | undefined;
+    accelMagnitudeMean: number;
+    accelMagnitudeStd: number;
+    nearestStationDistanceM: number | undefined;
+    motion: 'stationary' | 'walking' | 'automotive' | 'unknown';
+    now: number;
+  }> = {},
+) {
+  return {
+    kalmanKmh: 15,
+    prevKalmanKmh: undefined as number | undefined,
+    accelMagnitudeMean: 0.3,
+    accelMagnitudeStd: 0.2,
+    nearestStationDistanceM: undefined as number | undefined,
+    motion: 'unknown' as const,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// classifyStationPhase — 4 golden 시나리오
+// ---------------------------------------------------------------------------
+describe('classifyStationPhase — golden scenarios', () => {
+  it('APPROACHING: 정거장 100m + kalmanV 4km/h(감속) + accel 0.8 + automotive', () => {
+    // dist=100(≤200) → stationVicinity+highAccelNearStation 활성
+    // kmh=4(≤5)  → slowOrStop 활성 → APPROACHING+1 추가 기여로 DEPARTING과 분리
+    // scores: APPROACHING=4, DWELLING=2, DEPARTING=2, CRUISING=-4 → 명확한 단독 1위
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: 100,
+        kalmanKmh: 4,
+        accelMagnitudeMean: 0.8,
+        motion: 'automotive',
+      }),
+    );
+    expect(result.phase).toBe('APPROACHING');
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+    // APPROACHING이 최대 점수
+    expect(result.scores.APPROACHING).toBeGreaterThan(result.scores.DWELLING);
+    expect(result.scores.APPROACHING).toBeGreaterThan(result.scores.DEPARTING);
+    expect(result.scores.APPROACHING).toBeGreaterThan(result.scores.CRUISING);
+  });
+
+  it('DWELLING: 정거장 20m + kalmanV 2km/h + accel 0.1 + stationary', () => {
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: 20,
+        kalmanKmh: 2,
+        accelMagnitudeMean: 0.1,
+        motion: 'stationary',
+      }),
+    );
+    expect(result.phase).toBe('DWELLING');
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+    expect(result.scores.DWELLING).toBeGreaterThan(result.scores.APPROACHING);
+    expect(result.scores.DWELLING).toBeGreaterThan(result.scores.CRUISING);
+  });
+
+  it('DEPARTING: 정거장 150m + kalmanV 12km/h + 직전 4km/h(가속 추세) + accel 0.6 + automotive', () => {
+    // 정거장 근처(≤200) + velocityIncreasing(Δv≥+3) → DEPARTING이 단독 우세.
+    // velocityIncreasing 기여: APPROACHING-2, DWELLING-1, DEPARTING+3, CRUISING+1
+    // stationVicinity: 모두 +1, CRUISING -1
+    // highAccelNearStation: A+1, D-1, Dep+1, C-2
+    // → APPROACHING=0, DWELLING=-1, DEPARTING=5, CRUISING=-2
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: 150,
+        kalmanKmh: 12,
+        prevKalmanKmh: 4, // Δv=+8 ≥ VELOCITY_DELTA_KMH(3) → 가속 추세
+        accelMagnitudeMean: 0.6,
+        motion: 'automotive',
+      }),
+    );
+    expect(result.phase).toBe('DEPARTING');
+    expect(result.scores.DEPARTING).toBeGreaterThan(result.scores.APPROACHING);
+    expect(result.scores.DEPARTING).toBeGreaterThan(result.scores.DWELLING);
+    expect(result.scores.DEPARTING).toBeGreaterThan(result.scores.CRUISING);
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it('APPROACHING 추세 보강: 정거장 150m + kalmanV 8km/h + 직전 18km/h(감속 추세)', () => {
+    // velocityDecreasing(Δv≤-3) → APPROACHING 단독 우세.
+    // velocityDecreasing 기여: APPROACHING+3, DWELLING+1, DEPARTING-2, CRUISING-1
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: 150,
+        kalmanKmh: 8,
+        prevKalmanKmh: 18, // Δv=-10 ≤ -VELOCITY_DELTA_KMH → 감속 추세
+        accelMagnitudeMean: 0.6,
+        motion: 'automotive',
+      }),
+    );
+    expect(result.phase).toBe('APPROACHING');
+    expect(result.scores.APPROACHING).toBeGreaterThan(result.scores.DEPARTING);
+  });
+
+  it('CRUISING: 정거장 500m + kalmanV 35km/h + accel 0.2 + automotive', () => {
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: 500,
+        kalmanKmh: 35,
+        accelMagnitudeMean: 0.2,
+        motion: 'automotive',
+      }),
+    );
+    expect(result.phase).toBe('CRUISING');
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+    expect(result.scores.CRUISING).toBeGreaterThan(result.scores.APPROACHING);
+    expect(result.scores.CRUISING).toBeGreaterThan(result.scores.DWELLING);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyStationPhase — confidence 수치 검증
+// ---------------------------------------------------------------------------
+describe('classifyStationPhase — confidence 수치 검증', () => {
+  it('confidence는 항상 0 이상 1 이하', () => {
+    // APPROACHING 시나리오
+    const r1 = classifyStationPhase(
+      makeInputs({ nearestStationDistanceM: 100, kalmanKmh: 10, accelMagnitudeMean: 0.8, motion: 'automotive' }),
+    );
+    expect(r1.confidence).toBeGreaterThanOrEqual(0);
+    expect(r1.confidence).toBeLessThanOrEqual(1);
+
+    // CRUISING 시나리오
+    const r2 = classifyStationPhase(
+      makeInputs({ nearestStationDistanceM: 500, kalmanKmh: 35, accelMagnitudeMean: 0.2 }),
+    );
+    expect(r2.confidence).toBeGreaterThanOrEqual(0);
+    expect(r2.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it('모든 feature 비활성(신호 전무) → Σ|score|=0 → confidence=0', () => {
+    // nearestStationDistanceM=undefined 이면 거리 기반 feature 모두 비활성.
+    // kalmanKmh는 STATIONARY_KMH 초과 + CRUISE_KMH 미만 → slowOrStop/cruiseSpeed 모두 비활성.
+    // motion='unknown' → motionStationary 비활성.
+    // accelMagnitudeMean < 0.5 → highAccelNearStation 비활성.
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: undefined,
+        kalmanKmh: 10, // 5 초과 + 20 미만 → slowOrStop/cruiseSpeed 둘 다 비활성
+        accelMagnitudeMean: 0.1,
+        motion: 'unknown',
+      }),
+    );
+    // 모든 feature가 비활성이면 score는 전부 0 → Σ|score|=0 → confidence=0
+    expect(Object.values(result.scores).every((s) => s === 0)).toBe(true);
+    expect(result.confidence).toBe(0);
+  });
+
+  it('두 phase 동률 → confidence 공식에서 gap=0이면 0', () => {
+    // APPROACHING과 DEPARTING이 동점이 되는 입력:
+    // stationVicinity(1+1+1+1=각 1) + highAccelNearStation(2+2) → APPROACHING=3, DEPARTING=3
+    // slowOrStop 비활성, cruiseSpeed 비활성, motionStationary 비활성
+    // nearestStationDistanceM = 100(≤200 ≤200) — stationVicinity 활성화, highAccelNearStation 활성화
+    // kalmanKmh = 10 (5 초과, 20 미만)
+    // accelMagnitudeMean = 0.6 (≥0.5 → highAccelNearStation 활성)
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: 100,
+        kalmanKmh: 10,
+        accelMagnitudeMean: 0.6,
+        motion: 'unknown',
+      }),
+    );
+    // stationVicinity: APPROACHING+1, DWELLING+1, DEPARTING+1, CRUISING-1
+    // highAccelNearStation: APPROACHING+2, DWELLING-1, DEPARTING+2, CRUISING-1
+    // → APPROACHING=3, DWELLING=0, DEPARTING=3, CRUISING=-2
+    // 동률이면 argmax는 첫 번째(APPROACHING) 선택
+    expect(result.phase).toBe('APPROACHING');
+    // confidence = (3-3)/Σ|score| = 0
+    expect(result.confidence).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyStationPhase — 경계값 테스트
+// ---------------------------------------------------------------------------
+describe('classifyStationPhase — feature 활성 경계값', () => {
+  describe('STATION_NEAR_RADIUS_M (=200m) 경계', () => {
+    it('nearestStationDistanceM=199 → stationVicinity 활성', () => {
+      const inside = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 199, kalmanKmh: 25 }),
+      );
+      // stationVicinity 활성 → CRUISING에 -1 기여 → cruiseSpeed(+3)를 상쇄해 confidence 감소
+      const outside = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 201, kalmanKmh: 25 }),
+      );
+      // 거리만 다른 두 경우: 199m일 때 stationVicinity가 CRUISING score에 -1 추가
+      expect(inside.scores.CRUISING).toBeLessThan(outside.scores.CRUISING);
+    });
+
+    it('nearestStationDistanceM=200 → stationVicinity 활성 (≤ 포함)', () => {
+      // kmh=12: slowOrStop/cruiseSpeed 모두 비활성 → stationVicinity 기여만 반영
+      const at = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: STATION_NEAR_RADIUS_M, kalmanKmh: 12, accelMagnitudeMean: 0.3 }),
+      );
+      expect(at.scores.APPROACHING).toBeGreaterThan(0); // stationVicinity 기여 (+1)
+    });
+
+    it('nearestStationDistanceM=201 → stationVicinity 비활성', () => {
+      const outside = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 201, kalmanKmh: 25 }),
+      );
+      // stationVicinity 비활성 → APPROACHING에 +1 기여 없음
+      const inside = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 199, kalmanKmh: 25 }),
+      );
+      expect(outside.scores.APPROACHING).toBeLessThan(inside.scores.APPROACHING);
+    });
+  });
+
+  describe('STATIONARY_KMH (=5km/h) 경계', () => {
+    it('kalmanKmh=5 → slowOrStop 활성 (≤ 포함)', () => {
+      const at = classifyStationPhase(makeInputs({ kalmanKmh: STATIONARY_KMH }));
+      const above = classifyStationPhase(makeInputs({ kalmanKmh: STATIONARY_KMH + 0.1 }));
+      // slowOrStop 활성 시 DWELLING+2 기여 → at의 DWELLING이 above보다 높아야 함
+      expect(at.scores.DWELLING).toBeGreaterThan(above.scores.DWELLING);
+    });
+
+    it('kalmanKmh=5.1 → slowOrStop 비활성', () => {
+      const result = classifyStationPhase(makeInputs({ kalmanKmh: 5.1 }));
+      const below = classifyStationPhase(makeInputs({ kalmanKmh: 4.9 }));
+      expect(result.scores.DWELLING).toBeLessThan(below.scores.DWELLING);
+    });
+  });
+
+  describe('CRUISE_KMH (=20km/h) 경계', () => {
+    it('kalmanKmh=20 → cruiseSpeed 활성 (≥ 포함)', () => {
+      const at = classifyStationPhase(makeInputs({ kalmanKmh: CRUISE_KMH }));
+      const below = classifyStationPhase(makeInputs({ kalmanKmh: CRUISE_KMH - 0.1 }));
+      // cruiseSpeed 활성 시 CRUISING+3 기여
+      expect(at.scores.CRUISING).toBeGreaterThan(below.scores.CRUISING);
+    });
+
+    it('kalmanKmh=19.9 → cruiseSpeed 비활성', () => {
+      const result = classifyStationPhase(makeInputs({ kalmanKmh: 19.9 }));
+      const above = classifyStationPhase(makeInputs({ kalmanKmh: 20.1 }));
+      expect(result.scores.CRUISING).toBeLessThan(above.scores.CRUISING);
+    });
+  });
+
+  describe('MOTION_ACCEL_THRESHOLD (=0.5) + 근처 역 경계', () => {
+    it('accelMagnitudeMean=0.5 + 근처(100m) → highAccelNearStation 활성', () => {
+      const at = classifyStationPhase(
+        makeInputs({
+          nearestStationDistanceM: 100,
+          accelMagnitudeMean: MOTION_ACCEL_THRESHOLD,
+          kalmanKmh: 10,
+        }),
+      );
+      const below = classifyStationPhase(
+        makeInputs({
+          nearestStationDistanceM: 100,
+          accelMagnitudeMean: MOTION_ACCEL_THRESHOLD - 0.01,
+          kalmanKmh: 10,
+        }),
+      );
+      // highAccelNearStation 활성 → APPROACHING+2
+      expect(at.scores.APPROACHING).toBeGreaterThan(below.scores.APPROACHING);
+    });
+
+    it('accelMagnitudeMean=0.49 → highAccelNearStation 비활성 (feature contribution 없음)', () => {
+      const result = classifyStationPhase(
+        makeInputs({
+          nearestStationDistanceM: 100,
+          accelMagnitudeMean: 0.49,
+          kalmanKmh: 10,
+        }),
+      );
+      const above = classifyStationPhase(
+        makeInputs({
+          nearestStationDistanceM: 100,
+          accelMagnitudeMean: 0.51,
+          kalmanKmh: 10,
+        }),
+      );
+      // 0.49는 feature 비활성이므로 APPROACHING 점수가 더 낮음
+      expect(result.scores.APPROACHING).toBeLessThan(above.scores.APPROACHING);
+    });
+  });
+
+  describe('STATION_DWELL_RADIUS_M (=50m) 경계', () => {
+    it('nearestStationDistanceM=50 → dwellingZone 활성 (≤ 포함)', () => {
+      const at = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: STATION_DWELL_RADIUS_M, kalmanKmh: 2, motion: 'stationary' }),
+      );
+      expect(at.scores.DWELLING).toBeGreaterThan(0); // dwellingZone +2 + stationVicinity +1 + slowOrStop +2 + motionStationary +2
+    });
+
+    it('nearestStationDistanceM=51 → dwellingZone 비활성', () => {
+      const outside = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 51, kalmanKmh: 2, motion: 'stationary' }),
+      );
+      const inside = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 49, kalmanKmh: 2, motion: 'stationary' }),
+      );
+      // dwellingZone 활성/비활성 차이: DWELLING+2
+      expect(inside.scores.DWELLING).toBeGreaterThan(outside.scores.DWELLING);
+    });
+  });
+
+  describe('farFromStationStill feature', () => {
+    it('정거장 먼 거리(>200m) + 저속 → farFromStationStill 활성 → CRUISING-2', () => {
+      const far = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 300, kalmanKmh: 2 }),
+      );
+      const near = classifyStationPhase(
+        makeInputs({ nearestStationDistanceM: 100, kalmanKmh: 2 }),
+      );
+      // farFromStationStill 활성 시 CRUISING에 -2 추가 → far의 CRUISING이 낮아야 함
+      expect(far.scores.CRUISING).toBeLessThan(near.scores.CRUISING);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyStationPhase — argmax 동률
+// ---------------------------------------------------------------------------
+describe('classifyStationPhase — argmax 동률', () => {
+  it('최고 점수 phase가 여럿일 때 PHASES 배열 첫 번째가 선택됨', () => {
+    // 앞 테스트에서 이미 확인: APPROACHING=3, DEPARTING=3 동률 → APPROACHING 선택
+    const result = classifyStationPhase(
+      makeInputs({
+        nearestStationDistanceM: 100,
+        kalmanKmh: 10,
+        accelMagnitudeMean: 0.6,
+        motion: 'unknown',
+      }),
+    );
+    expect(result.phase).toBe(PHASES[0]); // 'APPROACHING'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyPhaseHysteresis
+// ---------------------------------------------------------------------------
+describe('applyPhaseHysteresis', () => {
+  it('prev=undefined → candidate가 current로 즉시 채택, candidateCount 미설정', () => {
+    const result = applyPhaseHysteresis(
+      { phase: 'CRUISING', confidence: 0.8 },
+      undefined,
+      NOW,
+    );
+    expect(result.current).toBe('CRUISING');
+    expect(result.confidence).toBe(0.8);
+    expect(result.candidate).toBeUndefined();
+    expect(result.candidateCount).toBeUndefined();
+    expect(result.lastEvaluatedAt).toBe(NOW);
+  });
+
+  it('candidate == prev.current → current 유지, confidence += SAME_PHASE_BOOST', () => {
+    const prev: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 0.5,
+      lastEvaluatedAt: NOW - 1000,
+    };
+    const result = applyPhaseHysteresis(
+      { phase: 'CRUISING', confidence: 0.6 },
+      prev,
+      NOW,
+    );
+    expect(result.current).toBe('CRUISING');
+    expect(result.confidence).toBeCloseTo(0.6 + SAME_PHASE_BOOST);
+    expect(result.lastEvaluatedAt).toBe(NOW);
+  });
+
+  it('confidence boost가 1.0을 초과하면 1.0으로 clamp', () => {
+    const prev: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 0.9,
+      lastEvaluatedAt: NOW - 1000,
+    };
+    const result = applyPhaseHysteresis(
+      { phase: 'CRUISING', confidence: 0.9 },
+      prev,
+      NOW,
+    );
+    expect(result.confidence).toBe(1.0);
+  });
+
+  it('candidate != prev.current + prev.candidate undefined → candidate 저장, count=1, current 유지', () => {
+    const prev: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 0.8,
+      lastEvaluatedAt: NOW - 1000,
+    };
+    const result = applyPhaseHysteresis(
+      { phase: 'APPROACHING', confidence: 0.5 },
+      prev,
+      NOW,
+    );
+    expect(result.current).toBe('CRUISING'); // 아직 전환 안 됨
+    expect(result.candidate).toBe('APPROACHING');
+    expect(result.candidateCount).toBe(1);
+    expect(result.confidence).toBe(prev.confidence); // boost 없음 → prev 값 유지
+  });
+
+  it('candidate == prev.candidate + count+1 < SWITCH_CYCLES → count 증가, current 유지', () => {
+    // SWITCH_CYCLES=2 이므로 count=1 → nextCount=2 → 전환 발생
+    // count=0 케이스 테스트 (count 1 미만 시)
+    // SWITCH_CYCLES=2라면 1번 반복 후 count=1이 되어 아직 미달 (nextCount=1 < 2)
+    const prev: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 0.8,
+      candidate: 'APPROACHING',
+      candidateCount: 0,
+      lastEvaluatedAt: NOW - 1000,
+    };
+    // candidateCount=0 + 1 = 1, SWITCH_CYCLES=2 → 미달
+    const result = applyPhaseHysteresis(
+      { phase: 'APPROACHING', confidence: 0.5 },
+      prev,
+      NOW,
+    );
+    // SWITCH_CYCLES=2, nextCount=1 < 2 → 전환 안 됨
+    expect(result.current).toBe('CRUISING');
+    expect(result.candidate).toBe('APPROACHING');
+    expect(result.candidateCount).toBe(1);
+  });
+
+  it('candidate == prev.candidate + count+1 >= SWITCH_CYCLES → 전환 (current=candidate)', () => {
+    const prev: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 0.8,
+      candidate: 'APPROACHING',
+      candidateCount: SWITCH_CYCLES - 1, // 한 번 더 오면 전환
+      lastEvaluatedAt: NOW - 1000,
+    };
+    const result = applyPhaseHysteresis(
+      { phase: 'APPROACHING', confidence: 0.6 },
+      prev,
+      NOW,
+    );
+    expect(result.current).toBe('APPROACHING');
+    expect(result.confidence).toBe(0.6);
+    expect(result.candidate).toBeUndefined(); // 전환 후 candidate 초기화
+    expect(result.lastEvaluatedAt).toBe(NOW);
+  });
+
+  it('candidate != prev.candidate → candidate reset, count=1', () => {
+    const prev: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 0.8,
+      candidate: 'APPROACHING',
+      candidateCount: 1,
+      lastEvaluatedAt: NOW - 1000,
+    };
+    // 이번엔 다른 phase로 바뀜
+    const result = applyPhaseHysteresis(
+      { phase: 'DWELLING', confidence: 0.4 },
+      prev,
+      NOW,
+    );
+    expect(result.current).toBe('CRUISING'); // 여전히 전환 안 됨
+    expect(result.candidate).toBe('DWELLING');
+    expect(result.candidateCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStationPhaseStep
+// ---------------------------------------------------------------------------
+describe('runStationPhaseStep', () => {
+  it('nearestStationDistanceM=undefined → null 반환 (phase 분류 skip)', () => {
+    const result = runStationPhaseStep(
+      makeInputs({ nearestStationDistanceM: undefined }),
+      undefined,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('nearestStationDistanceM 있으면 classify + hysteresis → StationPhaseState 반환', () => {
+    const result = runStationPhaseStep(
+      makeInputs({
+        nearestStationDistanceM: 500,
+        kalmanKmh: 35,
+        accelMagnitudeMean: 0.2,
+        motion: 'automotive',
+      }),
+      undefined,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.current).toBe('CRUISING');
+    expect(result?.lastEvaluatedAt).toBe(NOW);
+  });
+
+  it('prev state가 있으면 hysteresis 적용됨 (같은 phase → boost)', () => {
+    const prev: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 0.5,
+      lastEvaluatedAt: NOW - 1000,
+    };
+    const result = runStationPhaseStep(
+      makeInputs({
+        nearestStationDistanceM: 500,
+        kalmanKmh: 35,
+        accelMagnitudeMean: 0.2,
+        motion: 'automotive',
+      }),
+      prev,
+    );
+    expect(result?.current).toBe('CRUISING');
+    // 같은 phase → confidence boost
+    expect(result!.confidence).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// phaseAllowsImminentFiring
+// ---------------------------------------------------------------------------
+describe('phaseAllowsImminentFiring', () => {
+  it('state=null → true (신호 부재 허용, 기존 동작 유지)', () => {
+    expect(phaseAllowsImminentFiring(null)).toBe(true);
+  });
+
+  it('confidence < IMMINENT_FIRING_CONFIDENCE → true (낮은 신뢰 허용)', () => {
+    const state: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: IMMINENT_FIRING_CONFIDENCE - 0.01,
+      lastEvaluatedAt: NOW,
+    };
+    expect(phaseAllowsImminentFiring(state)).toBe(true);
+  });
+
+  it('confidence=0 → true (낮은 신뢰 허용)', () => {
+    const state: StationPhaseState = {
+      current: 'DWELLING',
+      confidence: 0,
+      lastEvaluatedAt: NOW,
+    };
+    expect(phaseAllowsImminentFiring(state)).toBe(true);
+  });
+
+  it('confidence >= 임계 + phase=APPROACHING → true (허용 phase)', () => {
+    const state: StationPhaseState = {
+      current: 'APPROACHING',
+      confidence: IMMINENT_FIRING_CONFIDENCE,
+      lastEvaluatedAt: NOW,
+    };
+    expect(phaseAllowsImminentFiring(state)).toBe(true);
+  });
+
+  it.each([
+    ['DWELLING', 'DWELLING'],
+    ['DEPARTING', 'DEPARTING'],
+    ['CRUISING', 'CRUISING'],
+  ] as const)(
+    'confidence >= 임계 + phase=%s → false (non-APPROACHING high-confidence 차단)',
+    (_label, phase) => {
+      const state: StationPhaseState = {
+        current: phase,
+        confidence: IMMINENT_FIRING_CONFIDENCE + 0.01,
+        lastEvaluatedAt: NOW,
+      };
+      expect(phaseAllowsImminentFiring(state)).toBe(false);
+    },
+  );
+
+  it('confidence=1.0 + CRUISING → false (완전 신뢰 차단)', () => {
+    const state: StationPhaseState = {
+      current: 'CRUISING',
+      confidence: 1.0,
+      lastEvaluatedAt: NOW,
+    };
+    expect(phaseAllowsImminentFiring(state)).toBe(false);
+  });
+
+  it('상수 export 검증 — IMMINENT_FIRING_PHASES에는 APPROACHING만 포함', () => {
+    expect(IMMINENT_FIRING_PHASES).toContain('APPROACHING');
+    expect(IMMINENT_FIRING_PHASES).not.toContain('DWELLING');
+    expect(IMMINENT_FIRING_PHASES).not.toContain('DEPARTING');
+    expect(IMMINENT_FIRING_PHASES).not.toContain('CRUISING');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 상수 export 검증
+// ---------------------------------------------------------------------------
+describe('상수 export', () => {
+  it('PHASES는 4개 phase를 정해진 순서로 포함', () => {
+    expect(PHASES).toEqual(['APPROACHING', 'DWELLING', 'DEPARTING', 'CRUISING']);
+  });
+
+  it('STATION_NEAR_RADIUS_M=200', () => {
+    expect(STATION_NEAR_RADIUS_M).toBe(200);
+  });
+
+  it('STATION_DWELL_RADIUS_M=50', () => {
+    expect(STATION_DWELL_RADIUS_M).toBe(50);
+  });
+
+  it('STATIONARY_KMH=5', () => {
+    expect(STATIONARY_KMH).toBe(5);
+  });
+
+  it('CRUISE_KMH=20', () => {
+    expect(CRUISE_KMH).toBe(20);
+  });
+
+  it('MOTION_ACCEL_THRESHOLD=0.5', () => {
+    expect(MOTION_ACCEL_THRESHOLD).toBe(0.5);
+  });
+
+  it('SAME_PHASE_BOOST=0.2', () => {
+    expect(SAME_PHASE_BOOST).toBe(0.2);
+  });
+
+  it('SWITCH_CYCLES=2', () => {
+    expect(SWITCH_CYCLES).toBe(2);
+  });
+
+  it('IMMINENT_FIRING_CONFIDENCE=0.7', () => {
+    expect(IMMINENT_FIRING_CONFIDENCE).toBe(0.7);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -294,6 +294,14 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
       ? obj.mapMatchedArcM
       : undefined;
   const hasPair = mapMatchedLine !== undefined && mapMatchedArcM !== undefined;
+  // #825 — Phase 3 E3 입력. 클라가 stations.json haversine 산출해 stamp (#834에서 wire).
+  // 음수/NaN/Infinity는 graceful skip (전체 payload 거부 X — 기존 mapMatched 정책과 정합).
+  const nearestStationDistanceM =
+    typeof obj.nearestStationDistanceM === 'number' &&
+    Number.isFinite(obj.nearestStationDistanceM) &&
+    obj.nearestStationDistanceM >= 0
+      ? obj.nearestStationDistanceM
+      : undefined;
   return {
     token: obj.token,
     point: {
@@ -303,6 +311,7 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
       ts: obj.ts,
       motion,
       ...(hasPair ? { mapMatchedLine, mapMatchedArcM } : {}),
+      ...(nearestStationDistanceM !== undefined ? { nearestStationDistanceM } : {}),
     },
     accelSummary,
   };

--- a/backend/alarm-worker/src/positionSeries.ts
+++ b/backend/alarm-worker/src/positionSeries.ts
@@ -115,6 +115,13 @@ function isPositionPoint(value: unknown): value is PositionPoint {
   const hasLine = typeof o.mapMatchedLine === 'string';
   const hasArc = typeof o.mapMatchedArcM === 'number';
   if (hasLine !== hasArc) return false;
+  // #825 — nearestStationDistanceM은 옵션. 값이 있다면 finite number 필수. 음수도 거부
+  //   (haversine 거리는 항상 ≥ 0).
+  if (o.nearestStationDistanceM !== undefined) {
+    if (typeof o.nearestStationDistanceM !== 'number') return false;
+    if (!Number.isFinite(o.nearestStationDistanceM)) return false;
+    if (o.nearestStationDistanceM < 0) return false;
+  }
   return true;
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -29,11 +29,24 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { matchLine } from './lineAlias';
-import { evaluateWindow, readSeries } from './positionSeries';
+import {
+  evaluateWindow,
+  readSeries,
+  type WindowedMetrics,
+} from './positionSeries';
 import { getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
+import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
-import type { ApnsEnv, BoardingLockMeta, Env, Trip, Waypoint } from './types';
+import type {
+  ApnsEnv,
+  BoardingLockMeta,
+  Env,
+  PositionPoint,
+  StationPhaseState,
+  Trip,
+  Waypoint,
+} from './types';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -151,6 +164,11 @@ export interface ScheduledStats extends LiveActivityStats {
   boardingPromptFired: number;
   /** #819 — 게이트 차단으로 미발사한 횟수 — false positive 1차 방어 효과 측정. */
   boardingPromptBlocked: number;
+  /**
+   * #825 — phase 분류가 'high-confidence non-APPROACHING'으로 lockless imminent 발사를
+   * 차단한 횟수. 측정 인프라 — gate가 실제로 발동된 빈도 + E5 RMSE/recall과 cross-check.
+   */
+  phaseImminentBlocked: number;
 }
 
 /**
@@ -196,6 +214,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     boardingPromptEvaluated: 0,
     boardingPromptFired: 0,
     boardingPromptBlocked: 0,
+    phaseImminentBlocked: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -290,6 +309,89 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     seoulCalls: deps.seoul.stats.callCount,
   });
   return stats;
+}
+
+/** runFusionStep 반환값 — boarding-prompt / lockless-intermediate 분기에서 공통 사용. */
+interface FusionStepResult {
+  /** 원본 positionSeries (호출자가 evaluateBoardingPromptGates 등에 그대로 전달). */
+  series: PositionPoint[];
+  /** evaluateWindow 결과 — observation 유효성/window 카운트 평가용. */
+  posMetrics: WindowedMetrics;
+  /**
+   * smoothed velocity를 fusedSpeed에 합류시킬 값 (km/h). null인 경우:
+   *  - observation 무효 (Kalman skip)
+   *  - prior=null 첫 cycle (state는 persist하지만 fusion 합류 제외 — #832 P2-3 정합)
+   */
+  kalmanKmh: number | null;
+  /** 운행 phase 분류 결과. null인 경우: observation 무효 또는 nearestStationDistanceM 미수신. */
+  phaseState: StationPhaseState | null;
+}
+
+/**
+ * Phase 3 fusion 한 cycle pipeline (#824 E2 + #825 E3).
+ *
+ *   1. positionSeries + accelSeries + Kalman prior state 병렬 KV read
+ *   2. evaluateWindow + evaluateAccelWindow
+ *   3. observationValid 가드 — 무효면 state I/O skip (P2-1)
+ *   4. runKalmanStep → writeKalmanState
+ *   5. prior 부재 첫 cycle은 fusion 합류 제외 (P2-3)
+ *   6. runStationPhaseStep — nearestStationDistanceM 없으면 phase null로 graceful skip (#834 wire 전)
+ *
+ * 호출자 책임:
+ *   - phaseState non-null이면 trip.stationPhase에 stamp + putTrip 시 persist
+ *   - kalmanKmh를 게이트/fusion 입력으로 전달
+ *   - series는 본 함수가 fetched한 raw KV 값 — 추가 read 불필요
+ */
+async function runFusionStep(
+  trip: Trip,
+  env: Env,
+  now: number,
+): Promise<FusionStepResult> {
+  const [series, accelSeries, kalmanPrior] = await Promise.all([
+    readSeries(env.TRIPS, trip.token),
+    readAccelSeries(env.TRIPS, trip.token),
+    readKalmanState(env.TRIPS, trip.token),
+  ]);
+  const posMetrics = evaluateWindow(series, now);
+  const accelMetrics = evaluateAccelWindow(accelSeries, now);
+  const observationValid =
+    posMetrics.count > 0 && Number.isFinite(posMetrics.avgAccuracyMeters);
+
+  if (!observationValid) {
+    return { series, posMetrics, kalmanKmh: null, phaseState: null };
+  }
+
+  const kalmanState = runKalmanStep({
+    prior: kalmanPrior,
+    gpsAvgKmh: posMetrics.gpsAvgKmh,
+    gpsAccuracyMeters: posMetrics.avgAccuracyMeters,
+    accelMagnitudeStd: accelMetrics.avgMagnitudeStd,
+    now,
+  });
+  await writeKalmanState(env.TRIPS, trip.token, kalmanState);
+
+  // P2-3 정합 — 첫 cycle은 v=gpsAvg라 fusion에 합류 시 같은 GPS 2회 가중 → confidence 가짜
+  // 상승. state는 persist 하되 fusion 입력에서는 제외.
+  const kalmanKmh = kalmanPrior !== null ? kalmanState.v : null;
+
+  // phase 분류 — 가장 최신 sample의 distance 입력. #834 wire 전까지 undefined → null 반환.
+  // 직전 cycle의 kalmanPrior.v를 prevKalmanKmh로 전달해 APPROACHING(감속)/DEPARTING(가속)
+  // 방향 구분 — accel magnitude만으로는 부호 부재라 분리 불가.
+  const lastSample = series[series.length - 1];
+  const phaseState = runStationPhaseStep(
+    {
+      kalmanKmh: kalmanState.v,
+      prevKalmanKmh: kalmanPrior?.v,
+      accelMagnitudeMean: accelMetrics.avgMagnitudeMean,
+      accelMagnitudeStd: accelMetrics.avgMagnitudeStd,
+      nearestStationDistanceM: lastSample?.nearestStationDistanceM,
+      motion: posMetrics.motion,
+      now,
+    },
+    trip.stationPhase,
+  );
+
+  return { series, posMetrics, kalmanKmh, phaseState };
 }
 
 /**
@@ -645,16 +747,38 @@ export async function runLocklessIntermediate(
   if (trip.lastFiredPhase === 'imminent') {
     return;
   }
+  // #825 — Phase 3 E3 fusion step. 분류 결과를 trip에 stamp + imminent push 발사 가드에 사용.
+  const fusion = await runFusionStep(trip, env, now);
+  let dirty = false;
+  if (fusion.phaseState) {
+    trip.stationPhase = fusion.phaseState;
+    dirty = true;
+  }
   const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
   const signal = pickBestArrivalSignal(arrivals, waypoint);
   if (signal === null || signal.arvlCd === null) {
     stats.etaMissing += 1;
+    if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
   // 발사 트리거: 해당 역에 진입(ENTERING) 또는 도착(ARRIVED). 그 외 phase는 통과 알림 부적합.
   const fires =
     signal.arvlCd === ARRIVAL_CODE.ENTERING || signal.arvlCd === ARRIVAL_CODE.ARRIVED;
   if (!fires) {
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
+  }
+  // #825 — high-confidence non-APPROACHING phase면 차단 (false positive 1차).
+  // 신호 부재/낮은 신뢰는 기존 동작 그대로 (회귀 없음, #834 wire 전까지 자연 skip).
+  if (!phaseAllowsImminentFiring(fusion.phaseState)) {
+    stats.phaseImminentBlocked += 1;
+    log('lockless: phase gate blocked', {
+      token: trip.token.slice(0, 8),
+      station: waypoint.stationName,
+      phase: fusion.phaseState?.current,
+      confidence: fusion.phaseState?.confidence,
+    });
+    if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
   const pushId = generatePushId();
@@ -686,7 +810,6 @@ export async function runLocklessIntermediate(
     log,
     trip.token.slice(0, 8),
   );
-  let dirty = false;
   if (heal.correctedEnv) {
     trip.apnsEnv = heal.correctedEnv;
     dirty = true;
@@ -853,48 +976,21 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   stats.boardingPromptEvaluated += 1;
 
-  // Phase 3 E2 (#824) — positionSeries + accelSeries + 직전 Kalman state를 병렬 로드.
-  // 정상 cycle은 predict+update로 smoothed velocity를 산출해 fusedSpeed의 가중평균에 합류.
-  //
-  // 두 가지 가드:
-  //   (1) 관측 무효 (count=0 or 모든 hop이 accuracy로 reject되어 avgAccuracy=Infinity)
-  //       → state I/O 자체를 skip. 거짓 0 km/h observation을 누적하지 않는다 (리뷰 P2-1).
-  //   (2) prior 부재 첫 cycle은 state.v === gpsAvgKmh (관측 직접 초기화)이므로
-  //       fusedSpeed에 합류시키면 같은 GPS가 가중치 2회 합산 → confidence 가짜 상승.
-  //       state는 다음 cycle prior로 쓸 수 있게 persist 하되 kalmanKmh는 null로 전달
-  //       해 fusion에는 합류하지 않는다 (리뷰 P2-3). 다음 cycle부터 진짜 smoothing 효과.
-  const [series, accelSeries, kalmanPrior] = await Promise.all([
-    readSeries(env.TRIPS, trip.token),
-    readAccelSeries(env.TRIPS, trip.token),
-    readKalmanState(env.TRIPS, trip.token),
-  ]);
-  const posMetrics = evaluateWindow(series, now);
-  const accelMetrics = evaluateAccelWindow(accelSeries, now);
-  const observationValid =
-    posMetrics.count > 0 && Number.isFinite(posMetrics.avgAccuracyMeters);
-
-  let kalmanKmh: number | null = null;
-  if (observationValid) {
-    const kalmanState = runKalmanStep({
-      prior: kalmanPrior,
-      gpsAvgKmh: posMetrics.gpsAvgKmh,
-      gpsAccuracyMeters: posMetrics.avgAccuracyMeters,
-      accelMagnitudeStd: accelMetrics.avgMagnitudeStd,
-      now,
-    });
-    await writeKalmanState(env.TRIPS, trip.token, kalmanState);
-    if (kalmanPrior !== null) {
-      kalmanKmh = kalmanState.v;
-    }
+  const fusion = await runFusionStep(trip, env, now);
+  let dirty = false;
+  // phase 분류 결과가 있으면 trip에 stamp — 다음 cycle hysteresis 입력 + lockless 가드용 상태.
+  if (fusion.phaseState) {
+    trip.stationPhase = fusion.phaseState;
+    dirty = true;
   }
 
   const outcome = evaluateBoardingPromptGates({
-    series,
+    series: fusion.series,
     origin: geo.origin,
     nextStation: geo.nextStation,
     now,
     promptState: trip.boardingPromptState,
-    kalmanKmh,
+    kalmanKmh: fusion.kalmanKmh,
   });
 
   if (!outcome.pass) {
@@ -903,6 +999,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       token: trip.token.slice(0, 8),
       reason: outcome.reason satisfies GateSkipReason,
     });
+    if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
 
@@ -930,7 +1027,6 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     trip.token.slice(0, 8),
   );
 
-  let dirty = false;
   if (heal.correctedEnv) {
     trip.apnsEnv = heal.correctedEnv;
     dirty = true;

--- a/backend/alarm-worker/src/stationPhase.ts
+++ b/backend/alarm-worker/src/stationPhase.ts
@@ -1,0 +1,298 @@
+/**
+ * 운행 phase 분류기 — APPROACHING / DWELLING / DEPARTING / CRUISING (#825 Phase 3 E3).
+ *
+ * 입력: Kalman smoothed velocity (E2) + accel summary (E1) + 가장 가까운 정거장 거리 (#834).
+ * 출력: phase + confidence(0~1) + 2-cycle hysteresis state.
+ *
+ * 알고리즘 (rule-based + score matrix):
+ *   1. 각 phase에 대해 feature score를 합산
+ *   2. argmax phase 선택 + confidence = (max - second) / Σ|score|
+ *   3. hysteresis: 직전 cycle phase와 같으면 confidence boost. 다르면 같은 candidate가
+ *      2 cycle 연속이어야 전환 (flicker 방지)
+ *
+ * ML 모델은 보류 — score matrix가 데이터 주도라 임계값만 E5 측정으로 조정하면 됨.
+ *
+ * ADR: https://app.notion.com/p/37430c0194b6819c8323e37d4c31a777 Section 5 (Phase 3).
+ */
+
+import type { StationPhaseState, StationPhaseType } from './types';
+
+/** 정거장 근접 임계 (m) — APPROACHING/DWELLING/DEPARTING 모두 정거장 근처에서 의미. */
+export const STATION_NEAR_RADIUS_M = 200;
+/** 정차 인접 임계 (m) — DWELLING은 더 가까운 거리. */
+export const STATION_DWELL_RADIUS_M = 50;
+/** 정지 속도 임계 (km/h) — DWELLING 후보. */
+export const STATIONARY_KMH = 5;
+/** 순항 속도 임계 (km/h) — CRUISING 후보. */
+export const CRUISE_KMH = 20;
+/** 감속/가속 magnitude 임계 (m/s²) — 출발/감속 phase 신호. */
+export const MOTION_ACCEL_THRESHOLD = 0.5;
+/**
+ * 속도 변화 임계 (km/h) — cycle간 |Δv|가 이 이상이면 가/감속 추세로 인정.
+ * cron 60s 주기 × 지하철 가속 ~1 m/s²(약 3.6 km/h/s)면 cycle 차이가 수 km/h 이상.
+ * 노이즈는 줄이고 실제 가/감속만 잡도록 보수적인 임계.
+ */
+export const VELOCITY_DELTA_KMH = 3;
+/** hysteresis confidence boost — 같은 phase 유지 시. */
+export const SAME_PHASE_BOOST = 0.2;
+/** 같은 candidate가 N cycle 연속이어야 전환. */
+export const SWITCH_CYCLES = 2;
+
+/** 모든 phase 목록 — argmax / 점수 매트릭스 iteration 데이터 주도. */
+export const PHASES: readonly StationPhaseType[] = [
+  'APPROACHING',
+  'DWELLING',
+  'DEPARTING',
+  'CRUISING',
+] as const;
+
+export interface ClassifyInputs {
+  /** Kalman smoothed velocity km/h. E2 결과 (state.v). */
+  kalmanKmh: number;
+  /**
+   * 직전 cycle의 Kalman v (km/h). cycle간 추세로 APPROACHING(감속) vs DEPARTING(가속)을
+   * 구분 — accel magnitude만으로는 부호가 없어 불가능. undefined = 첫 cycle (추세 신호 없음).
+   */
+  prevKalmanKmh: number | undefined;
+  /** accel magnitude 평균 m/s². E1 evaluateAccelWindow.avgMagnitudeMean. */
+  accelMagnitudeMean: number;
+  /** accel magnitude std m/s². E1 evaluateAccelWindow.avgMagnitudeStd. */
+  accelMagnitudeStd: number;
+  /** 가장 가까운 정거장 거리 m (#834에서 클라가 stamp). undefined = phase 분류 skip. */
+  nearestStationDistanceM: number | undefined;
+  /** CMMotionActivity 분류 — DWELLING 보강 신호. */
+  motion: 'stationary' | 'walking' | 'automotive' | 'unknown';
+  /** 현 시각 epoch ms. */
+  now: number;
+}
+
+/** phase별 score 벡터. argmax/normalize 용이하게 별도 타입으로 노출 (테스트 검증용). */
+export type PhaseScores = Record<StationPhaseType, number>;
+
+/**
+ * Feature → phase 점수 기여 매트릭스. 각 feature가 어떤 phase에 +/-로 기여하는지 데이터로 표현.
+ * 확장 시 새 phase/feature는 이 매트릭스에 행/열 추가만으로 처리 (Open/Closed).
+ */
+type FeatureContribution = Record<StationPhaseType, number>;
+interface PhaseFeature {
+  name: string;
+  /** feature가 활성인지 판단. */
+  active: (i: ClassifyInputs) => boolean;
+  /** 활성 시 phase별 가중치 기여. */
+  contribution: FeatureContribution;
+}
+
+const PHASE_FEATURES: readonly PhaseFeature[] = [
+  {
+    name: 'dwellingZone',
+    active: (i) =>
+      i.nearestStationDistanceM !== undefined &&
+      i.nearestStationDistanceM <= STATION_DWELL_RADIUS_M,
+    contribution: { APPROACHING: 0, DWELLING: 2, DEPARTING: 0, CRUISING: -1 },
+  },
+  {
+    name: 'stationVicinity',
+    active: (i) =>
+      i.nearestStationDistanceM !== undefined &&
+      i.nearestStationDistanceM <= STATION_NEAR_RADIUS_M,
+    contribution: { APPROACHING: 1, DWELLING: 1, DEPARTING: 1, CRUISING: -1 },
+  },
+  {
+    name: 'slowOrStop',
+    active: (i) => i.kalmanKmh <= STATIONARY_KMH,
+    contribution: { APPROACHING: 1, DWELLING: 2, DEPARTING: -1, CRUISING: -2 },
+  },
+  {
+    name: 'cruiseSpeed',
+    active: (i) => i.kalmanKmh >= CRUISE_KMH,
+    contribution: { APPROACHING: -1, DWELLING: -2, DEPARTING: -1, CRUISING: 3 },
+  },
+  {
+    name: 'motionStationary',
+    active: (i) => i.motion === 'stationary',
+    contribution: { APPROACHING: 0, DWELLING: 2, DEPARTING: -1, CRUISING: -2 },
+  },
+  {
+    // 정거장 근처에서 큰 magnitude — 감속/가속 phase 신호 (방향은 velocity trend가 결정).
+    // 첫 cycle처럼 prev 없을 때도 "near station에서 뭔가 일어나는 중"을 잡아 CRUISING 차단.
+    name: 'highAccelNearStation',
+    active: (i) =>
+      i.nearestStationDistanceM !== undefined &&
+      i.nearestStationDistanceM <= STATION_NEAR_RADIUS_M &&
+      i.accelMagnitudeMean >= MOTION_ACCEL_THRESHOLD,
+    contribution: { APPROACHING: 1, DWELLING: -1, DEPARTING: 1, CRUISING: -2 },
+  },
+  {
+    // velocity 추세 — Δv ≤ -VELOCITY_DELTA_KMH (현재 < 이전): 감속 → APPROACHING.
+    // prevKalmanKmh 없으면 비활성 (첫 cycle은 추세 신호 없음).
+    name: 'velocityDecreasing',
+    active: (i) =>
+      i.prevKalmanKmh !== undefined &&
+      i.prevKalmanKmh - i.kalmanKmh >= VELOCITY_DELTA_KMH,
+    contribution: { APPROACHING: 3, DWELLING: 1, DEPARTING: -2, CRUISING: -1 },
+  },
+  {
+    // velocity 추세 — Δv ≥ +VELOCITY_DELTA_KMH (현재 > 이전): 가속 → DEPARTING.
+    name: 'velocityIncreasing',
+    active: (i) =>
+      i.prevKalmanKmh !== undefined &&
+      i.kalmanKmh - i.prevKalmanKmh >= VELOCITY_DELTA_KMH,
+    contribution: { APPROACHING: -2, DWELLING: -1, DEPARTING: 3, CRUISING: 1 },
+  },
+  {
+    // 정거장 멀리 + 거의 정지 — 데이터 무효 (지하 dead zone 등) → CRUISING 안 가게 살짝 막음.
+    name: 'farFromStationStill',
+    active: (i) =>
+      i.nearestStationDistanceM !== undefined &&
+      i.nearestStationDistanceM > STATION_NEAR_RADIUS_M &&
+      i.kalmanKmh <= STATIONARY_KMH,
+    contribution: { APPROACHING: 0, DWELLING: 0, DEPARTING: 0, CRUISING: -2 },
+  },
+];
+
+/**
+ * score matrix 계산 + argmax + confidence 산출.
+ *
+ * confidence = (max - second_max) / Σ|score|
+ *   - 두 phase가 점수 동률이면 0 (불확실)
+ *   - 한 phase만 크게 압도하면 → 1에 근접
+ *
+ * Σ|score|이 0이면 confidence 0 (signal 부재). 호출자가 hysteresis 적용 시 신중하게 처리.
+ */
+export function classifyStationPhase(inputs: ClassifyInputs): {
+  phase: StationPhaseType;
+  confidence: number;
+  scores: PhaseScores;
+} {
+  const scores: PhaseScores = {
+    APPROACHING: 0,
+    DWELLING: 0,
+    DEPARTING: 0,
+    CRUISING: 0,
+  };
+  for (const feature of PHASE_FEATURES) {
+    if (!feature.active(inputs)) continue;
+    for (const phase of PHASES) {
+      scores[phase] += feature.contribution[phase];
+    }
+  }
+
+  // argmax
+  let best: StationPhaseType = PHASES[0];
+  let bestScore = scores[best];
+  for (const phase of PHASES) {
+    if (scores[phase] > bestScore) {
+      best = phase;
+      bestScore = scores[phase];
+    }
+  }
+  // second max — best 제외 최댓값
+  let secondScore = -Infinity;
+  for (const phase of PHASES) {
+    if (phase === best) continue;
+    if (scores[phase] > secondScore) secondScore = scores[phase];
+  }
+
+  // normalize confidence — Σ|score|이 0이면 confidence 0.
+  let totalAbs = 0;
+  for (const phase of PHASES) {
+    totalAbs += Math.abs(scores[phase]);
+  }
+  const confidence =
+    totalAbs === 0 ? 0 : Math.max(0, Math.min(1, (bestScore - secondScore) / totalAbs));
+
+  return { phase: best, confidence, scores };
+}
+
+/**
+ * 2 cycle hysteresis 적용 + state transition.
+ *
+ *   - prev 없음: candidate가 곧 current (첫 평가는 곧바로 채택, 그러나 confidence는 boost 없음)
+ *   - candidate == prev.current: state 유지, confidence boost (max 1.0)
+ *   - candidate != prev.current:
+ *      · candidate == prev.candidate → count++. count >= SWITCH_CYCLES면 전환.
+ *      · 아니면 prev.candidate := candidate, count := 1
+ *      · 전환 안 됨 → current는 prev.current 유지, confidence는 boost 없음 (원본 그대로)
+ *
+ * hysteresis는 flicker 방지 — 한 cycle 흔들림이 phase 토글로 이어지지 않게 한다.
+ */
+export function applyPhaseHysteresis(
+  classification: { phase: StationPhaseType; confidence: number },
+  prev: StationPhaseState | undefined,
+  now: number,
+): StationPhaseState {
+  const candidate = classification.phase;
+  const baseConfidence = classification.confidence;
+
+  if (!prev) {
+    return {
+      current: candidate,
+      confidence: baseConfidence,
+      lastEvaluatedAt: now,
+    };
+  }
+
+  if (candidate === prev.current) {
+    return {
+      current: prev.current,
+      confidence: Math.min(1, baseConfidence + SAME_PHASE_BOOST),
+      lastEvaluatedAt: now,
+    };
+  }
+
+  // candidate가 prev.candidate와 동일하면 count++. 임계 도달 시 전환.
+  const nextCount =
+    prev.candidate === candidate ? (prev.candidateCount ?? 0) + 1 : 1;
+  if (nextCount >= SWITCH_CYCLES) {
+    return {
+      current: candidate,
+      confidence: baseConfidence,
+      lastEvaluatedAt: now,
+    };
+  }
+  return {
+    current: prev.current,
+    confidence: prev.confidence,
+    candidate,
+    candidateCount: nextCount,
+    lastEvaluatedAt: now,
+  };
+}
+
+/**
+ * 한 cycle의 phase 분류 + hysteresis 적용 — scheduled.ts에서 호출하는 진입점.
+ *
+ *   - nearestStationDistanceM 없으면 분류 skip — `null` 반환. 기존 state는 호출자가 그대로 유지.
+ *     (klient #834에서 wire되기 전까지 자연 회귀 없음.)
+ *   - 있으면 classify + hysteresis → 새 state 반환.
+ */
+export function runStationPhaseStep(
+  inputs: ClassifyInputs,
+  prev: StationPhaseState | undefined,
+): StationPhaseState | null {
+  if (inputs.nearestStationDistanceM === undefined) return null;
+  const classification = classifyStationPhase(inputs);
+  return applyPhaseHysteresis(classification, prev, inputs.now);
+}
+
+/** imminent push 발사 허용 phase (SSOT — E5 측정 후 조정 가능). */
+export const IMMINENT_FIRING_PHASES: readonly StationPhaseType[] = ['APPROACHING'];
+/** imminent gate confidence 임계. 낮은 신뢰는 기존 신호에 위임 (false positive 방지보다 회귀 회피). */
+export const IMMINENT_FIRING_CONFIDENCE = 0.7;
+
+/**
+ * imminent silent push 발사 허용 여부 (#825 게이트 wire).
+ *
+ *   - phaseState null (분류 신호 부재) → 허용 (기존 동작 유지, #834 wire 전까지 회귀 없음)
+ *   - confidence < IMMINENT_FIRING_CONFIDENCE → 허용 (낮은 신뢰는 기존 arvlCd/ETA 신호에 위임)
+ *   - confidence ≥ 임계 + phase ∈ IMMINENT_FIRING_PHASES → 허용
+ *   - 그 외 (high-confidence non-APPROACHING, 예: CRUISING with conf 0.9) → 차단
+ *
+ * 정책: "phase 신호가 강하게 '지금 임박 아니다'"라고 말할 때만 발사를 막는다.
+ * 낮은 신뢰 또는 신호 부재면 기존 동작 그대로 — gate는 **false positive 1차 차단**용.
+ */
+export function phaseAllowsImminentFiring(state: StationPhaseState | null): boolean {
+  if (!state) return true;
+  if (state.confidence < IMMINENT_FIRING_CONFIDENCE) return true;
+  return IMMINENT_FIRING_PHASES.includes(state.current);
+}

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -137,6 +137,37 @@ export interface Trip {
    * `line`: trip 출발 라인 (lock 생성 시 boardingLine으로 그대로 사용).
    */
   promptDisplay?: PromptDisplay;
+  /**
+   * Phase 3 E3 (#825) — 운행 phase 분류 + 2 cycle hysteresis 상태. cron 사이클마다
+   * stationPhase.ts가 분류 결과로 갱신한다. 사용자가 명시 보내는 필드 아님 — backend 자체 stamp.
+   * 부재(첫 평가 전) = phase 분류 신호 없음.
+   */
+  stationPhase?: StationPhaseState;
+}
+
+/**
+ * 운행 phase 분류 (#825 Phase 3 E3).
+ *   APPROACHING — 진입/감속
+ *   DWELLING   — 정차
+ *   DEPARTING  — 출발/가속
+ *   CRUISING   — 순항
+ */
+export type StationPhaseType = 'APPROACHING' | 'DWELLING' | 'DEPARTING' | 'CRUISING';
+
+/**
+ * trip별 phase 분류 + 2 cycle hysteresis 상태.
+ *   - current: 마지막으로 확정된 phase
+ *   - candidate / candidateCount: 직전 candidate (current와 다른 신호)와 연속 횟수.
+ *     2 cycle 연속 같은 candidate면 current로 승격 (flicker 방지).
+ *   - confidence: 마지막 분류의 confidence 0~1 (hysteresis boost 후 값)
+ *   - lastEvaluatedAt: 마지막 분류 epoch ms — 진단/디버그 로그용.
+ */
+export interface StationPhaseState {
+  current: StationPhaseType;
+  confidence: number;
+  candidate?: StationPhaseType;
+  candidateCount?: number;
+  lastEvaluatedAt: number;
 }
 
 /** boarding-prompt 게이트 평가용 출발역/다음역 좌표. */
@@ -213,6 +244,17 @@ export interface PositionPoint {
    */
   mapMatchedLine?: string;
   mapMatchedArcM?: number;
+  /**
+   * Phase 3 E3 (#825) — 가장 가까운 정거장까지의 거리 (meters). 클라이언트가 매 sample
+   * 송신 시 `stations.json` 좌표 사전으로 haversine 산출해 stamp한다 (#834).
+   *
+   * 사용: backend `stationPhase.ts`가 운행 phase(APPROACHING/DWELLING/DEPARTING/CRUISING)
+   * 분류 입력 중 하나로 사용. 미적용 단계는 undefined — phase 산출 skip (회귀 없음).
+   *
+   * 정책: backend는 stations.json을 갖지 않으므로 거리는 반드시 클라 책임
+   * (mapMatchedLine/ArcM과 동일 패턴).
+   */
+  nearestStationDistanceM?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 3 E3 (Epic #818). 운행 phase(APPROACHING/DWELLING/DEPARTING/CRUISING) 4-class 분류기 + 2-cycle hysteresis + lockless \`imminent\` push 발사 직전 phase 가드.

- **신규**: \`backend/alarm-worker/src/stationPhase.ts\` — 데이터 주도 score matrix (8 features × 4 phases), confidence 산출, hysteresis, \`phaseAllowsImminentFiring\` 정책
- **확장**: \`types.ts\` (\`PositionPoint.nearestStationDistanceM?\`, \`StationPhaseType\`, \`StationPhaseState\`, \`Trip.stationPhase?\`)
- **wire**: \`scheduled.ts\`에 \`runFusionStep\` 헬퍼 추출 — boarding-prompt + lockless 두 호출 사이트가 동일 파이프라인 (positionSeries+accelSeries+Kalman 병렬 + phase 분류). lockless 발사 직전 high-confidence non-APPROACHING 차단.

## 설계 결정

### Phase 분류 — Score matrix (rule-based, 데이터 주도)
8 features × 4 phases contribution matrix → argmax → confidence \`(max - second) / Σ|score|\`.
| Feature | 활성 조건 | A | DW | DEP | CR |
|---|---|---|---|---|---|
| dwellingZone | dist ≤ 50m | 0 | +2 | 0 | -1 |
| stationVicinity | dist ≤ 200m | +1 | +1 | +1 | -1 |
| slowOrStop | kalmanV ≤ 5 km/h | +1 | +2 | -1 | -2 |
| cruiseSpeed | kalmanV ≥ 20 km/h | -1 | -2 | -1 | +3 |
| motionStationary | motion='stationary' | 0 | +2 | -1 | -2 |
| highAccelNearStation | dist ≤ 200 + accel ≥ 0.5 m/s² | +1 | -1 | +1 | -2 |
| **velocityDecreasing** | prev - curr ≥ 3 km/h | +3 | +1 | -2 | -1 |
| **velocityIncreasing** | curr - prev ≥ 3 km/h | -2 | -1 | +3 | +1 |
| farFromStationStill | dist > 200 + 거의 정지 | 0 | 0 | 0 | -2 |

**중요 fix**: 초기 설계는 highAccelNearStation이 APPROACHING/DEPARTING에 동등 기여라 두 phase 구분 불가. \`prevKalmanKmh\` 추세 입력 + velocityDecreasing/Increasing feature 추가로 fix (test-writer 발견 → 본 PR에서 surgical 수정).

### Hysteresis (flicker 방지)
- candidate == prev.current → confidence +SAME_PHASE_BOOST(0.2), max 1.0
- candidate != prev.current AND prev.candidate != candidate → candidate stamp, count=1
- candidate == prev.candidate → count++. count ≥ SWITCH_CYCLES(2)면 전환

### \`phaseAllowsImminentFiring\` 정책 (permissive)
\`\`\`
null              → true (신호 부재 시 기존 동작 유지)
confidence < 0.7  → true (낮은 신뢰는 기존 arvlCd/ETA에 위임)
phase=APPROACHING → true
그 외 (high-confidence non-APPROACHING) → false (false positive 차단)
\`\`\`
False positive 1차 차단 의도라 strict AND 대신 permissive. 신호가 강하게 \"임박 아니다\"라고 말할 때만 차단.

### \`runFusionStep\` 헬퍼
boarding-prompt + lockless 두 호출 사이트에서 같은 KV read + Kalman + phase 파이프라인. P2-1/P2-3 가드 유지 (observation valid 가드 + 첫 cycle kalmanKmh null).

## 정책 정합 — \`stations.json\` 클라 책임

\`nearestStationDistanceM\`은 클라이언트가 stations.json 사전으로 산출해 송신.
backend는 stations.json 미보유 (\`types.ts\` 정책 주석). \`mapMatchedLine/ArcM\` (#828)과 동일 패턴.

이번 PR은 backend만 — 클라 송신은 별도 sub-issue **#834**로 분리. #834 머지 전까지 phase 분류는 자연 skip → **회귀 없음**.

## 측정 인프라

- \`ScheduledStats.phaseImminentBlocked\` — gate 발동 횟수 카운트. E5 인프라(#827)와 cross-check 가능 (precision/recall + 알람 시점 오차)

## Test plan

- [x] backend \`npm test\` — **645 tests pass** (+50 신규 stationPhase + 확장)
- [x] root \`npm test\` — **3233 tests pass, 100% coverage**
- [x] backend \`npm run type-check\` pass
- [x] root \`npm run type-check\` pass
- [x] 4 phase golden 시나리오 (DEPARTING은 추세 입력으로 진짜 검증)
- [x] hysteresis 6 전이 패턴 + boundary
- [x] phaseAllowsImminentFiring 4 정책 경로
- [x] scheduled.ts wire 회귀 (kalman P2-1/P2-3 가드 유지)

## 영향 범위

- lockless intermediate push: phase 가드 ON (default permissive)
- boarding-prompt: phase 산출 + stamp만 (게이트 미적용 — 9단은 별개 정책)
- 기타 path: 무영향

Closes #825