### PR TITLE
feat(#826): Phase 3 E4 — arvlCd ground truth Kalman reset + drift telemetry

### DIFF
--- a/backend/alarm-worker/src/__tests__/kalmanFilter.test.ts
+++ b/backend/alarm-worker/src/__tests__/kalmanFilter.test.ts
@@ -18,6 +18,7 @@ import {
   ACCURACY_R_MID_M,
   ACCEL_STD_Q_LOW,
   ACCEL_STD_Q_MID,
+  DRIFT_WARNING_THRESHOLD_KMH,
   Q_HIGH,
   Q_LOW,
   Q_MID,
@@ -29,8 +30,10 @@ import {
   clearKalmanState,
   computeNoiseQ,
   computeNoiseR,
+  detectKalmanDrift,
   predictKalman,
   readKalmanState,
+  resetKalmanForArrival,
   runKalmanStep,
   updateKalman,
   writeKalmanState,
@@ -405,6 +408,117 @@ describe('readKalmanState / writeKalmanState / clearKalmanState — KV 입출력
     await writeKalmanState(kv, 'bob', s2);
     expect(await readKalmanState(kv, 'alice')).toEqual(s1);
     expect(await readKalmanState(kv, 'bob')).toEqual(s2);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// DRIFT_WARNING_THRESHOLD_KMH 상수
+// ─────────────────────────────────────────────────────
+
+describe('DRIFT_WARNING_THRESHOLD_KMH 상수 (#826 E4)', () => {
+  it('DRIFT_WARNING_THRESHOLD_KMH === 15', () => {
+    expect(DRIFT_WARNING_THRESHOLD_KMH).toBe(15);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// resetKalmanForArrival
+// ─────────────────────────────────────────────────────
+
+describe('resetKalmanForArrival — 정거장 도착 ground truth hard reset (#826 E4)', () => {
+  it('now=1000 → { v: 0, P: R_LOW(=4), ts: 1000 }', () => {
+    const result = resetKalmanForArrival(1000);
+    expect(result).toEqual({ v: 0, P: R_LOW, ts: 1000 });
+  });
+
+  it('now=0 → ts=0, v=0, P=R_LOW', () => {
+    const result = resetKalmanForArrival(0);
+    expect(result.v).toBe(0);
+    expect(result.P).toBe(R_LOW);
+    expect(result.ts).toBe(0);
+  });
+
+  it('큰 ts 값도 그대로 반영', () => {
+    const ts = 1_700_000_000_000;
+    const result = resetKalmanForArrival(ts);
+    expect(result.ts).toBe(ts);
+    expect(result.v).toBe(0);
+    expect(result.P).toBe(R_LOW);
+  });
+
+  it('v는 항상 0 — 어떤 now에서도 불변', () => {
+    [100, 5_000, 9_999_999].forEach((now) => {
+      expect(resetKalmanForArrival(now).v).toBe(0);
+    });
+  });
+
+  it('P는 항상 R_LOW(=4) — 어떤 now에서도 불변', () => {
+    [1, 500, 1_000_000].forEach((now) => {
+      expect(resetKalmanForArrival(now).P).toBe(R_LOW);
+    });
+  });
+
+  it('매 호출마다 새 객체를 반환 (객체 동일성 아님)', () => {
+    const a = resetKalmanForArrival(1000);
+    const b = resetKalmanForArrival(1000);
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// detectKalmanDrift
+// ─────────────────────────────────────────────────────
+
+describe('detectKalmanDrift — drift 측정 (#826 E4)', () => {
+  const makeState = (v: number): KalmanState => ({ v, P: 10, ts: 1000 });
+
+  it('state.v=20, gpsAvg=5 → delta=15, warning=true (정확히 임계)', () => {
+    const result = detectKalmanDrift(makeState(20), 5);
+    expect(result.delta).toBe(15);
+    expect(result.warning).toBe(true);
+  });
+
+  it('state.v=10, gpsAvg=5 → delta=5, warning=false (임계 미달)', () => {
+    const result = detectKalmanDrift(makeState(10), 5);
+    expect(result.delta).toBe(5);
+    expect(result.warning).toBe(false);
+  });
+
+  it('state.v=5, gpsAvg=25 → delta=-20, warning=true (음수 delta, 절댓값 임계 초과)', () => {
+    const result = detectKalmanDrift(makeState(5), 25);
+    expect(result.delta).toBe(-20);
+    expect(result.warning).toBe(true);
+  });
+
+  it('state.v=gpsAvg → delta=0, warning=false', () => {
+    const result = detectKalmanDrift(makeState(30), 30);
+    expect(result.delta).toBe(0);
+    expect(result.warning).toBe(false);
+  });
+
+  it('경계값: |delta| = 14.99 → warning=false', () => {
+    // state.v=19.99, gpsAvg=5 → delta=14.99
+    const result = detectKalmanDrift(makeState(19.99), 5);
+    expect(Math.abs(result.delta)).toBeCloseTo(14.99, 5);
+    expect(result.warning).toBe(false);
+  });
+
+  it('경계값: |delta| = 15 → warning=true', () => {
+    const result = detectKalmanDrift(makeState(20), 5);
+    expect(Math.abs(result.delta)).toBe(15);
+    expect(result.warning).toBe(true);
+  });
+
+  it('경계값: |delta| = 15.01 → warning=true', () => {
+    const result = detectKalmanDrift(makeState(20.01), 5);
+    expect(result.warning).toBe(true);
+  });
+
+  it('delta는 signed: state.v - gpsAvgKmh (음수 포함)', () => {
+    // state.v=10, gpsAvg=30 → delta = -20
+    const result = detectKalmanDrift(makeState(10), 30);
+    expect(result.delta).toBe(-20);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -11,6 +11,7 @@ import {
   pickApnsHost,
   pickBestArrivalSignal,
   runScheduled,
+  type ScheduledDeps,
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
@@ -2081,6 +2082,24 @@ function makeArrivedSignal(arvlCd: number): ArrivalEntry {
   };
 }
 
+/**
+ * #826 Kalman reset 테스트용 deps 헬퍼 — 동일 boilerplate(apnsConfig/Hosts/fetchImpl/now)를
+ * 5곳에서 반복하지 않게 묶음. sonar new_duplicated_lines_density 임계 정합.
+ */
+function makeKalmanResetDeps(
+  seoul: SeoulArrivalClient,
+  pushId: string,
+): ScheduledDeps {
+  return {
+    seoul,
+    apnsConfig,
+    apnsHosts: APNS_HOSTS,
+    fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+    now: () => NOW,
+    generatePushId: () => pushId,
+  };
+}
+
 describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
   it('arvlCd=ARRIVED(1) → fires=true → kalman:<token>이 v=0/P=4로 reset + stats.kalmanReset=1', async () => {
     const kv = new InMemoryKV();
@@ -2089,14 +2108,10 @@ describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
     // 기존 kalman state 심기 (reset 이전 상태)
     await kv.put(`kalman:${token}`, JSON.stringify({ v: 40, P: 100, ts: NOW - 5_000 }));
 
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([makeArrivedSignal(1)]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'lk1',
-    });
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeKalmanResetDeps(makeSeoul([makeArrivedSignal(1)]), 'lk1'),
+    );
 
     expect(stats.kalmanReset).toBe(1);
     const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
@@ -2111,14 +2126,10 @@ describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
     await putTrip(kv as unknown as KVNamespace, makeLocklessKalmanTrip(token));
     await kv.put(`kalman:${token}`, JSON.stringify({ v: 35, P: 50, ts: NOW - 3_000 }));
 
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([makeArrivedSignal(0)]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'lk2',
-    });
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeKalmanResetDeps(makeSeoul([makeArrivedSignal(0)]), 'lk2'),
+    );
 
     expect(stats.kalmanReset).toBe(1);
     const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
@@ -2133,14 +2144,10 @@ describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
     await putTrip(kv as unknown as KVNamespace, makeLocklessKalmanTrip(token));
     await kv.put(`kalman:${token}`, JSON.stringify({ v: 30, P: 25, ts: NOW - 3_000 }));
 
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([makeArrivedSignal(2)]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'lk3',
-    });
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeKalmanResetDeps(makeSeoul([makeArrivedSignal(2)]), 'lk3'),
+    );
 
     // 핵심: fires=false로 reset 경로 자체 미진입 → kalmanReset=0
     expect(stats.kalmanReset).toBe(0);
@@ -2168,14 +2175,10 @@ describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
     ];
     await kv.put(`pos:${token}`, JSON.stringify(series));
 
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([makeArrivedSignal(1)]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'lk4',
-    });
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeKalmanResetDeps(makeSeoul([makeArrivedSignal(1)]), 'lk4'),
+    );
 
     // reset은 phase gate 이전에 발사
     expect(stats.kalmanReset).toBe(1);
@@ -2247,14 +2250,10 @@ describe('runScheduled — #826 runTrainCodeTracking Kalman reset', () => {
     // 기존 kalman state 심기
     await kv.put(`kalman:${token}`, JSON.stringify({ v: 40, P: 100, ts: NOW - 5_000 }));
 
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoulWithArvl('중곡', 0, 1), // arvlCd=1 ARRIVED
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'tc1',
-    });
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeKalmanResetDeps(makeSeoulWithArvl('중곡', 0, 1), 'tc1'), // arvlCd=1 ARRIVED
+    );
 
     expect(stats.kalmanReset).toBe(1);
     const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
@@ -2271,14 +2270,10 @@ describe('runScheduled — #826 runTrainCodeTracking Kalman reset', () => {
     const originalV = 35;
     await kv.put(`kalman:${token}`, JSON.stringify({ v: originalV, P: 25, ts: NOW - 5_000 }));
 
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoulWithArvl('중곡', 120, null), // arrived=false, 일반 예측
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'tc2',
-    });
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeKalmanResetDeps(makeSeoulWithArvl('중곡', 120, null), 'tc2'), // arrived=false
+    );
 
     expect(stats.kalmanReset).toBe(0);
     // kalman state는 reset되지 않음 (runFusionStep은 lockless/boardingPrompt 경로에서만 동작)

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1,7 +1,7 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
-import { readKalmanState } from '../kalmanFilter';
+import { R_LOW, readKalmanState } from '../kalmanFilter';
 import {
   MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
@@ -1929,5 +1929,363 @@ describe('runScheduled — #825 Phase 3 E3: phaseImminentBlocked + stationPhase 
     // stationPhase는 undefined 상태 유지
     const stored = JSON.parse((await kv.get('trip:phase-no-dist-tok'))!) as Trip;
     expect(stored.stationPhase).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #826 — ScheduledStats 초기값 검증
+// ---------------------------------------------------------------------------
+
+describe('ScheduledStats 초기값 (#826 E4)', () => {
+  it('kalmanReset, kalmanDriftWarning 초기값 0 — trip 없는 빈 실행', async () => {
+    const kv = new InMemoryKV();
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.kalmanReset).toBe(0);
+    expect(stats.kalmanDriftWarning).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #826 — drift telemetry
+// ---------------------------------------------------------------------------
+
+describe('runScheduled — #826 drift telemetry (kalmanDriftWarning)', () => {
+  /**
+   * series 헬퍼: 유효한 positionSeries를 KV에 심는다.
+   * gpsAvgKmh가 `targetKmh` 근방이 되도록 두 지점을 배치한다.
+   * 두 포인트의 haversine 거리 / Δt = gpsAvg.
+   */
+  async function seedSeriesWithGpsAvg(
+    kv: InMemoryKV,
+    token: string,
+    targetGpsKmh: number,
+  ): Promise<void> {
+    // Δt = 10s, 목표 거리 = targetGpsKmh * 10 / 3600 km
+    // lng 차이로 동서 이동 시뮬레이션. 위도 0 기준 1도 ≈ 111.32 km
+    const dtMs = 10_000;
+    const distKm = (targetGpsKmh * dtMs) / 3_600_000;
+    const lngDelta = distKm / 111.32;
+    const series = [
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW - dtMs, motion: 'automotive' },
+      { lat: 0, lng: lngDelta, accuracy: 10, ts: NOW, motion: 'automotive' },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+  }
+
+  function makeDriftTrip(token: string, overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token,
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+      ...overrides,
+    });
+  }
+
+  it('prior=null 첫 cycle → kalmanDriftWarning 0 (drift 검사 건너뜀)', async () => {
+    // prior가 없으면 detectKalmanDrift 호출 자체를 skip — delta=0이 아닌 호출 미발생
+    const kv = new InMemoryKV();
+    const trip = makeDriftTrip('drift-first');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // gpsAvg ≈ 30 km/h series 심기
+    await seedSeriesWithGpsAvg(kv, 'drift-first', 30);
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'd1',
+    });
+    // prior=null → detectKalmanDrift 미호출 → kalmanDriftWarning 미증가
+    expect(stats.kalmanDriftWarning).toBe(0);
+  });
+
+  it('prior 있음 + |gpsAvg - state.v| ≥ 15 → kalmanDriftWarning++', async () => {
+    // prior state.v=0 (정차), gpsAvg ≈ 30 km/h → delta=30 ≥ 15 → warning
+    const kv = new InMemoryKV();
+    const token = 'drift-warn';
+    const trip = makeDriftTrip(token);
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await seedSeriesWithGpsAvg(kv, token, 30);
+    // KV에 prior 심기 — state.v=0 (도착 직후 reset 상태)
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 0, P: R_LOW, ts: NOW - 15_000 }));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'd2',
+    });
+    expect(stats.kalmanDriftWarning).toBe(1);
+  });
+
+  it('prior 있음 + 작은 delta(< 15) → kalmanDriftWarning 0', async () => {
+    // prior state.v=30, gpsAvg ≈ 32 → delta=2 < 15 → warning 없음
+    const kv = new InMemoryKV();
+    const token = 'drift-small';
+    const trip = makeDriftTrip(token);
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await seedSeriesWithGpsAvg(kv, token, 32);
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 30, P: 25, ts: NOW - 15_000 }));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'd3',
+    });
+    expect(stats.kalmanDriftWarning).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #826 — lockless ARRIVED/ENTERING → Kalman reset
+// ---------------------------------------------------------------------------
+
+describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
+  function makeLocklessKalmanTrip(token: string, overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token,
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' },
+        { stationName: '역삼', line: '2', kind: 'destination' },
+      ],
+      locklessStationPassed: true,
+      ...overrides,
+    });
+  }
+
+  function makeArrivedSignal(arvlCd: number): ArrivalEntry {
+    return {
+      destination: '강남행',
+      arrivalSeconds: 10,
+      trainCode: '9999',
+      isUp: true,
+      subwayNm: '지하철2호선',
+      arvlCd,
+    };
+  }
+
+  it('arvlCd=ARRIVED(1) → fires=true → kalman:<token>이 v=0/P=4로 reset + stats.kalmanReset=1', async () => {
+    const kv = new InMemoryKV();
+    const token = 'lock-kalman-1';
+    await putTrip(kv as unknown as KVNamespace, makeLocklessKalmanTrip(token));
+    // 기존 kalman state 심기 (reset 이전 상태)
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 40, P: 100, ts: NOW - 5_000 }));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([makeArrivedSignal(1)]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'lk1',
+    });
+
+    expect(stats.kalmanReset).toBe(1);
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
+    expect(kalmanState?.v).toBe(0);
+    expect(kalmanState?.P).toBe(R_LOW);
+    expect(kalmanState?.ts).toBe(NOW);
+  });
+
+  it('arvlCd=ENTERING(0) → fires=true → Kalman reset 발사 + stats.kalmanReset=1', async () => {
+    const kv = new InMemoryKV();
+    const token = 'lock-kalman-2';
+    await putTrip(kv as unknown as KVNamespace, makeLocklessKalmanTrip(token));
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 35, P: 50, ts: NOW - 3_000 }));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([makeArrivedSignal(0)]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'lk2',
+    });
+
+    expect(stats.kalmanReset).toBe(1);
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
+    expect(kalmanState?.v).toBe(0);
+    expect(kalmanState?.P).toBe(R_LOW);
+  });
+
+  it('arvlCd=2(출발) → fires=false → Kalman reset 미발사 + stats.kalmanReset=0', async () => {
+    // arvlCd=2는 ENTERING(0)/ARRIVED(1) 아님 → fires=false → reset 경로 미진입
+    const kv = new InMemoryKV();
+    const token = 'lock-kalman-3';
+    await putTrip(kv as unknown as KVNamespace, makeLocklessKalmanTrip(token));
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 30, P: 25, ts: NOW - 3_000 }));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([makeArrivedSignal(2)]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'lk3',
+    });
+
+    // 핵심: fires=false로 reset 경로 자체 미진입 → kalmanReset=0
+    expect(stats.kalmanReset).toBe(0);
+  });
+
+  it('phase gate 차단 케이스 → reset은 phase gate와 무관하게 발사 (kalmanReset=1, phaseImminentBlocked=1)', async () => {
+    // ARRIVED + high-confidence CRUISING → phase gate 차단 → push 미발사
+    // 하지만 reset은 phase gate 평가 전에 이미 실행 → kalmanReset=1
+    const kv = new InMemoryKV();
+    const token = 'lock-kalman-4';
+    const tripWithCruising = makeLocklessKalmanTrip(token, {
+      stationPhase: {
+        current: 'CRUISING',
+        confidence: 0.9, // high-confidence CRUISING → gate 차단
+        lastEvaluatedAt: NOW - 1000,
+      },
+    });
+    await putTrip(kv as unknown as KVNamespace, tripWithCruising);
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 35, P: 25, ts: NOW - 3_000 }));
+    // nearestStationDistanceM 있는 series로 phase classification 활성화
+    const series = [
+      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive', nearestStationDistanceM: 500 },
+      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive', nearestStationDistanceM: 500 },
+      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive', nearestStationDistanceM: 500 },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([makeArrivedSignal(1)]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'lk4',
+    });
+
+    // reset은 phase gate 이전에 발사
+    expect(stats.kalmanReset).toBe(1);
+    // phase gate가 차단
+    expect(stats.phaseImminentBlocked).toBe(1);
+    // push 미발사
+    expect(stats.pushed).toBe(0);
+    // kalman state는 reset됨
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
+    expect(kalmanState?.v).toBe(0);
+    expect(kalmanState?.P).toBe(R_LOW);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #826 — runTrainCodeTracking → Kalman reset on arrived
+// ---------------------------------------------------------------------------
+
+describe('runScheduled — #826 runTrainCodeTracking Kalman reset', () => {
+  function makeLockWithKalmanTrip(token: string, overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token,
+      route: { type: 'direct', line: '7', stops: 2 },
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'destination' },
+      ],
+      boardingLock: {
+        trainCode: '7246',
+        line: '7',
+        subwayId: '1007',
+        selectedDepartureTime: NOW,
+        segmentStations: ['용마산', '중곡', '군자'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+      ...overrides,
+    });
+  }
+
+  function makeSeoulWithArvl(stationName: string, seconds: number, arvlCd: number | null): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: String(seconds),
+                recptnDt: '',
+                updnLine: '상행',
+                trainLineNm: stationName,
+                btrainNo: '7246',
+                subwayNm: '지하철7호선',
+                arvlCd,
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+  }
+
+  it('boardingLock 활성 + estimate.arrived=true(arvlCd=1) → reset + stats.kalmanReset=1', async () => {
+    const kv = new InMemoryKV();
+    const token = 'tc-kalman-1';
+    await putTrip(kv as unknown as KVNamespace, makeLockWithKalmanTrip(token));
+    // 기존 kalman state 심기
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 40, P: 100, ts: NOW - 5_000 }));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulWithArvl('중곡', 0, 1), // arvlCd=1 ARRIVED
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'tc1',
+    });
+
+    expect(stats.kalmanReset).toBe(1);
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
+    expect(kalmanState?.v).toBe(0);
+    expect(kalmanState?.P).toBe(R_LOW);
+    expect(kalmanState?.ts).toBe(NOW);
+  });
+
+  it('boardingLock 활성 + estimate.arrived=false → reset 미발사 + stats.kalmanReset=0', async () => {
+    const kv = new InMemoryKV();
+    const token = 'tc-kalman-2';
+    await putTrip(kv as unknown as KVNamespace, makeLockWithKalmanTrip(token));
+    // 일반 ETA 응답 (도착 아님)
+    const originalV = 35;
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: originalV, P: 25, ts: NOW - 5_000 }));
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulWithArvl('중곡', 120, null), // arrived=false, 일반 예측
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'tc2',
+    });
+
+    expect(stats.kalmanReset).toBe(0);
+    // kalman state는 reset되지 않음 (runFusionStep은 lockless/boardingPrompt 경로에서만 동작)
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
+    // reset이 없었으므로 v≠0 (원래 값 또는 update된 값)
+    if (kalmanState !== null) {
+      // arrived=false이면 kalman reset이 없어야 함 — v=0 아님을 확인
+      expect(kalmanState.v).not.toBe(0);
+    }
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1955,42 +1955,43 @@ describe('ScheduledStats 초기값 (#826 E4)', () => {
 // #826 — drift telemetry
 // ---------------------------------------------------------------------------
 
+/**
+ * series 헬퍼 (#826 drift telemetry): 유효한 positionSeries를 KV에 심는다.
+ * gpsAvgKmh가 `targetKmh` 근방이 되도록 두 지점을 배치한다.
+ * 두 포인트의 haversine 거리 / Δt = gpsAvg.
+ *
+ * sonar S7721 — 함수를 describe 외부 module scope에 두어 매 describe call 시 재정의 회피.
+ */
+async function seedSeriesWithGpsAvg(
+  kv: InMemoryKV,
+  token: string,
+  targetGpsKmh: number,
+): Promise<void> {
+  // Δt = 10s, lng 차이로 동서 이동 시뮬. 위도 0 기준 1도 ≈ 111.32 km.
+  const dtMs = 10_000;
+  const distKm = (targetGpsKmh * dtMs) / 3_600_000;
+  const lngDelta = distKm / 111.32;
+  const series = [
+    { lat: 0, lng: 0, accuracy: 10, ts: NOW - dtMs, motion: 'automotive' },
+    { lat: 0, lng: lngDelta, accuracy: 10, ts: NOW, motion: 'automotive' },
+  ];
+  await kv.put(`pos:${token}`, JSON.stringify(series));
+}
+
+function makeDriftTrip(token: string, overrides: Partial<Trip> = {}): Trip {
+  return makeTrip({
+    token,
+    promptGeoContext: {
+      origin: { lat: 0, lng: 0 },
+      nextStation: { lat: 0, lng: 0.01 },
+      direction: 'up',
+    },
+    promptDisplay: { originStation: '강남', line: '2' },
+    ...overrides,
+  });
+}
+
 describe('runScheduled — #826 drift telemetry (kalmanDriftWarning)', () => {
-  /**
-   * series 헬퍼: 유효한 positionSeries를 KV에 심는다.
-   * gpsAvgKmh가 `targetKmh` 근방이 되도록 두 지점을 배치한다.
-   * 두 포인트의 haversine 거리 / Δt = gpsAvg.
-   */
-  async function seedSeriesWithGpsAvg(
-    kv: InMemoryKV,
-    token: string,
-    targetGpsKmh: number,
-  ): Promise<void> {
-    // Δt = 10s, 목표 거리 = targetGpsKmh * 10 / 3600 km
-    // lng 차이로 동서 이동 시뮬레이션. 위도 0 기준 1도 ≈ 111.32 km
-    const dtMs = 10_000;
-    const distKm = (targetGpsKmh * dtMs) / 3_600_000;
-    const lngDelta = distKm / 111.32;
-    const series = [
-      { lat: 0, lng: 0, accuracy: 10, ts: NOW - dtMs, motion: 'automotive' },
-      { lat: 0, lng: lngDelta, accuracy: 10, ts: NOW, motion: 'automotive' },
-    ];
-    await kv.put(`pos:${token}`, JSON.stringify(series));
-  }
-
-  function makeDriftTrip(token: string, overrides: Partial<Trip> = {}): Trip {
-    return makeTrip({
-      token,
-      promptGeoContext: {
-        origin: { lat: 0, lng: 0 },
-        nextStation: { lat: 0, lng: 0.01 },
-        direction: 'up',
-      },
-      promptDisplay: { originStation: '강남', line: '2' },
-      ...overrides,
-    });
-  }
-
   it('prior=null 첫 cycle → kalmanDriftWarning 0 (drift 검사 건너뜀)', async () => {
     // prior가 없으면 detectKalmanDrift 호출 자체를 skip — delta=0이 아닌 호출 미발생
     const kv = new InMemoryKV();
@@ -2057,30 +2058,30 @@ describe('runScheduled — #826 drift telemetry (kalmanDriftWarning)', () => {
 // #826 — lockless ARRIVED/ENTERING → Kalman reset
 // ---------------------------------------------------------------------------
 
+function makeLocklessKalmanTrip(token: string, overrides: Partial<Trip> = {}): Trip {
+  return makeTrip({
+    token,
+    waypoints: [
+      { stationName: '강남', line: '2', kind: 'intermediate' },
+      { stationName: '역삼', line: '2', kind: 'destination' },
+    ],
+    locklessStationPassed: true,
+    ...overrides,
+  });
+}
+
+function makeArrivedSignal(arvlCd: number): ArrivalEntry {
+  return {
+    destination: '강남행',
+    arrivalSeconds: 10,
+    trainCode: '9999',
+    isUp: true,
+    subwayNm: '지하철2호선',
+    arvlCd,
+  };
+}
+
 describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
-  function makeLocklessKalmanTrip(token: string, overrides: Partial<Trip> = {}): Trip {
-    return makeTrip({
-      token,
-      waypoints: [
-        { stationName: '강남', line: '2', kind: 'intermediate' },
-        { stationName: '역삼', line: '2', kind: 'destination' },
-      ],
-      locklessStationPassed: true,
-      ...overrides,
-    });
-  }
-
-  function makeArrivedSignal(arvlCd: number): ArrivalEntry {
-    return {
-      destination: '강남행',
-      arrivalSeconds: 10,
-      trainCode: '9999',
-      isUp: true,
-      subwayNm: '지하철2호선',
-      arvlCd,
-    };
-  }
-
   it('arvlCd=ARRIVED(1) → fires=true → kalman:<token>이 v=0/P=4로 reset + stats.kalmanReset=1', async () => {
     const kv = new InMemoryKV();
     const token = 'lock-kalman-1';
@@ -2193,52 +2194,52 @@ describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
 // #826 — runTrainCodeTracking → Kalman reset on arrived
 // ---------------------------------------------------------------------------
 
+function makeLockWithKalmanTrip(token: string, overrides: Partial<Trip> = {}): Trip {
+  return makeTrip({
+    token,
+    route: { type: 'direct', line: '7', stops: 2 },
+    waypoints: [
+      { stationName: '중곡', line: '7', kind: 'intermediate' },
+      { stationName: '군자', line: '7', kind: 'destination' },
+    ],
+    boardingLock: {
+      trainCode: '7246',
+      line: '7',
+      subwayId: '1007',
+      selectedDepartureTime: NOW,
+      segmentStations: ['용마산', '중곡', '군자'],
+      expiresAt: NOW + 60 * 60_000,
+    },
+    ...overrides,
+  });
+}
+
+function makeSeoulWithArvl(stationName: string, seconds: number, arvlCd: number | null): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: [
+            {
+              barvlDt: String(seconds),
+              recptnDt: '',
+              updnLine: '상행',
+              trainLineNm: stationName,
+              btrainNo: '7246',
+              subwayNm: '지하철7호선',
+              arvlCd,
+            },
+          ],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
 describe('runScheduled — #826 runTrainCodeTracking Kalman reset', () => {
-  function makeLockWithKalmanTrip(token: string, overrides: Partial<Trip> = {}): Trip {
-    return makeTrip({
-      token,
-      route: { type: 'direct', line: '7', stops: 2 },
-      waypoints: [
-        { stationName: '중곡', line: '7', kind: 'intermediate' },
-        { stationName: '군자', line: '7', kind: 'destination' },
-      ],
-      boardingLock: {
-        trainCode: '7246',
-        line: '7',
-        subwayId: '1007',
-        selectedDepartureTime: NOW,
-        segmentStations: ['용마산', '중곡', '군자'],
-        expiresAt: NOW + 60 * 60_000,
-      },
-      ...overrides,
-    });
-  }
-
-  function makeSeoulWithArvl(stationName: string, seconds: number, arvlCd: number | null): SeoulArrivalClient {
-    return new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async () =>
-        new Response(
-          JSON.stringify({
-            realtimeArrivalList: [
-              {
-                barvlDt: String(seconds),
-                recptnDt: '',
-                updnLine: '상행',
-                trainLineNm: stationName,
-                btrainNo: '7246',
-                subwayNm: '지하철7호선',
-                arvlCd,
-              },
-            ],
-          }),
-          { status: 200 },
-        )) as unknown as typeof fetch,
-    });
-  }
-
   it('boardingLock 활성 + estimate.arrived=true(arvlCd=1) → reset + stats.kalmanReset=1', async () => {
     const kv = new InMemoryKV();
     const token = 'tc-kalman-1';

--- a/backend/alarm-worker/src/kalmanFilter.ts
+++ b/backend/alarm-worker/src/kalmanFilter.ts
@@ -197,6 +197,53 @@ export async function clearKalmanState(
   await kv.delete(stateKey(token));
 }
 
+/**
+ * Drift warning 임계 (km/h) — gpsAvgKmh와 Kalman state.v 차이가 이 이상이면 누적 drift 신호.
+ * 호출자가 cycle별로 측정해 ScheduledStats에 카운트한다 (E5 인프라와 cross-check).
+ *
+ * 15 km/h = 정거장 사이 평균속도(약 30~40 km/h)의 절반 — 의미있는 편차 임계.
+ * 노이즈는 R_HIGH/R_REJECT bands에서 자연 흡수되므로 보수적 임계로 시작.
+ * E5 측정 후 ↓ 조정 가능.
+ */
+export const DRIFT_WARNING_THRESHOLD_KMH = 15;
+
+/**
+ * Kalman state hard reset — 정거장 도착 (arvlCd=1) ground truth (#826 Phase 3 E4).
+ *
+ * 정거장에 도착하는 순간은 가장 강한 ground truth — 열차는 사실상 정차 상태.
+ * v=0(정지), P=R_LOW(낮은 분산 = 강한 신뢰), ts=now로 state를 직접 재초기화한다.
+ * 이후 cycle에서는 이 reset state를 prior로 받아 predict+update가 다시 시작.
+ *
+ * R_LOW를 P_0로 채택한 이유: arvlCd=1은 거의 0 노이즈 신호 — Kalman 신뢰 입력으로
+ * R 단계 함수의 가장 좋은 GPS(<20m)과 같은 신뢰도를 부여한다.
+ */
+export function resetKalmanForArrival(now: number): KalmanState {
+  return { v: 0, P: R_LOW, ts: now };
+}
+
+/**
+ * Drift 측정 — 현재 cycle |gpsAvgKmh - state.v| (km/h, 부호 없음, signed: state.v - gpsAvgKmh).
+ *
+ * 호출자가 임계(DRIFT_WARNING_THRESHOLD_KMH) 초과를 카운트해 ScheduledStats에 누적.
+ * 부호 정보는 drift 방향(over/underestimate) 진단용 — 절댓값 임계와 분리해 두 신호 모두 제공.
+ *
+ * 호출 시점: 정상 cycle (observationValid + prior 존재) — state.v가 의미 있는 prior일 때.
+ */
+export interface KalmanDriftSignal {
+  /** signed difference: state.v - gpsAvgKmh. */
+  delta: number;
+  /** |delta| ≥ DRIFT_WARNING_THRESHOLD_KMH 여부. */
+  warning: boolean;
+}
+
+export function detectKalmanDrift(
+  state: KalmanState,
+  gpsAvgKmh: number,
+): KalmanDriftSignal {
+  const delta = state.v - gpsAvgKmh;
+  return { delta, warning: Math.abs(delta) >= DRIFT_WARNING_THRESHOLD_KMH };
+}
+
 function stateKey(token: string): string {
   return `${KALMAN_STATE_PREFIX}${token}`;
 }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -18,7 +18,9 @@ import {
   type GateSkipReason,
 } from './boardingPrompt';
 import {
+  detectKalmanDrift,
   readKalmanState,
+  resetKalmanForArrival,
   runKalmanStep,
   writeKalmanState,
 } from './kalmanFilter';
@@ -169,6 +171,16 @@ export interface ScheduledStats extends LiveActivityStats {
    * 차단한 횟수. 측정 인프라 — gate가 실제로 발동된 빈도 + E5 RMSE/recall과 cross-check.
    */
   phaseImminentBlocked: number;
+  /**
+   * #826 — arvlCd=ARRIVED ground truth로 Kalman state hard reset된 횟수 (v=0/P=R_LOW).
+   * lockless ARRIVED 또는 boardingLock trainCode arrived 시점에 발사. drift 누적 차단.
+   */
+  kalmanReset: number;
+  /**
+   * #826 — 정상 cycle에서 |gpsAvgKmh - state.v| ≥ DRIFT_WARNING_THRESHOLD_KMH인 누적 횟수.
+   * 누적이 의미있게 커지면 Kalman 튜닝(R/Q) 재측정 또는 reset 정책 조정 신호.
+   */
+  kalmanDriftWarning: number;
 }
 
 /**
@@ -215,6 +227,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     boardingPromptFired: 0,
     boardingPromptBlocked: 0,
     phaseImminentBlocked: 0,
+    kalmanReset: 0,
+    kalmanDriftWarning: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -346,6 +360,7 @@ async function runFusionStep(
   trip: Trip,
   env: Env,
   now: number,
+  stats: ScheduledStats,
 ): Promise<FusionStepResult> {
   const [series, accelSeries, kalmanPrior] = await Promise.all([
     readSeries(env.TRIPS, trip.token),
@@ -359,6 +374,14 @@ async function runFusionStep(
 
   if (!observationValid) {
     return { series, posMetrics, kalmanKmh: null, phaseState: null };
+  }
+
+  // #826 — drift 측정은 prior 존재 정상 cycle만. 첫 cycle은 v=gpsAvg 초기화라 delta=0으로 의미 없음.
+  if (kalmanPrior !== null) {
+    const drift = detectKalmanDrift(kalmanPrior, posMetrics.gpsAvgKmh);
+    if (drift.warning) {
+      stats.kalmanDriftWarning += 1;
+    }
   }
 
   const kalmanState = runKalmanStep({
@@ -471,6 +494,10 @@ export async function runTrainCodeTracking(
   }
 
   if (estimate.arrived) {
+    // #826 — arvlCd=ARRIVED ground truth → Kalman state hard reset.
+    // 정거장 도착은 가장 강한 신호 (실제 정차) — v=0/P=R_LOW로 drift 누적 차단.
+    await writeKalmanState(env.TRIPS, trip.token, resetKalmanForArrival(now));
+    stats.kalmanReset += 1;
     await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
     return;
   }
@@ -748,7 +775,7 @@ export async function runLocklessIntermediate(
     return;
   }
   // #825 — Phase 3 E3 fusion step. 분류 결과를 trip에 stamp + imminent push 발사 가드에 사용.
-  const fusion = await runFusionStep(trip, env, now);
+  const fusion = await runFusionStep(trip, env, now, stats);
   let dirty = false;
   if (fusion.phaseState) {
     trip.stationPhase = fusion.phaseState;
@@ -768,6 +795,11 @@ export async function runLocklessIntermediate(
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
+  // #826 — fires=true(ARRIVED/ENTERING)는 ground truth 신호. push 발사 여부(phase 가드)와
+  // 무관하게 Kalman state를 reset해 drift 누적을 차단한다. arvlCd가 가장 강한 신호 — phase
+  // 분류는 휴리스틱이라 contradiction 시 arvlCd를 신뢰.
+  await writeKalmanState(env.TRIPS, trip.token, resetKalmanForArrival(now));
+  stats.kalmanReset += 1;
   // #825 — high-confidence non-APPROACHING phase면 차단 (false positive 1차).
   // 신호 부재/낮은 신뢰는 기존 동작 그대로 (회귀 없음, #834 wire 전까지 자연 skip).
   if (!phaseAllowsImminentFiring(fusion.phaseState)) {
@@ -976,7 +1008,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   stats.boardingPromptEvaluated += 1;
 
-  const fusion = await runFusionStep(trip, env, now);
+  const fusion = await runFusionStep(trip, env, now, stats);
   let dirty = false;
   // phase 분류 결과가 있으면 trip에 stamp — 다음 cycle hysteresis 입력 + lockless 가드용 상태.
   if (fusion.phaseState) {


### PR DESCRIPTION
## Summary

Phase 3 E4 (Epic #818 마지막 sub-issue). arvlCd=ARRIVED/ENTERING ground truth 시점에 Kalman state hard reset (v=0/P=R_LOW) + drift telemetry counter 추가.

- **kalmanFilter.ts**: \`resetKalmanForArrival(now)\`, \`detectKalmanDrift(state, gpsAvg)\`, \`DRIFT_WARNING_THRESHOLD_KMH=15\`
- **scheduled.ts**: \`runFusionStep\`에 drift 측정, \`runTrainCodeTracking\` arrived + \`runLocklessIntermediate\` fires=true 둘 다 reset wire
- **ScheduledStats**: \`kalmanReset\`, \`kalmanDriftWarning\` 카운터

## Scope 결정 — multi-measurement 보류

이슈 본문은 3종 ground truth (GPS recovery + polyline snap + arvlCd=1) multi-measurement Kalman update를 명시. 본 PR은 **scope 축소**:

| 신호 | 채택 | 이유 |
|---|---|---|
| **arvlCd=ARRIVED hard reset** | ✅ 본 PR | 가장 강한 ground truth (실제 정차). 근본 해결의 핵심 |
| GPS recovery (accuracy<20m) | 보류 | 이미 E2 R 단계 함수가 자연 처리 |
| Polyline snap measurement | 보류 | 이미 fusedSpeed에서 KALMAN_WEIGHT + #828 weighted average로 합류 |
| Polyline backend snap | 거부 | 기존 정책(stations.json 클라 책임, types.ts 주석) 위반 |
| Drift telemetry counter | ✅ 본 PR | E5 인프라와 cross-check |

판단 근거: multi-measurement Kalman update는 fusedSpeed 외부 weighted average와 이중. 측정 결과 보고 필요 시 follow-up 가능.

## 정책 — arvlCd > phase 휴리스틱

\`runLocklessIntermediate\`에서 reset 발사 위치는 **phase gate 앞**. 가설: arvlCd=ARRIVED는 가장 강한 신호 (Seoul API 직접 신호), phase 분류는 휴리스틱 (#825 score matrix). 두 신호 contradiction(예: arvlCd=ARRIVED + phase=CRUISING) 시 arvlCd를 신뢰해 reset 발사. phase gate는 push 발사만 차단.

## Drift telemetry 적용 범위

drift 측정은 **fusion이 도는 lockless/boarding-prompt 경로만**. \`runTrainCodeTracking\`(boardingLock 추적)에는 reset만 적용 — fusion step 미통과. boardingLock 경로 drift 측정은 측정 결과 보고 별도 follow-up 사안.

## 리뷰 P2 follow-up 사안

- **P2-1** dedup gate vs reset 위치 일관성
- **P2-2** reset 직후 cycle drift 측정 grace
- **P2-3** runFusionStep stats 인자 — 호출자로 끌어올리는 SRP 개선
- **P2-4** runTrainCodeTracking에도 fusion step 도입

→ 측정 결과 보고 결정 가능한 follow-up issue로 분리 예정.

## Test plan

- [x] backend \`npm test\` — **670 tests pass** (+25)
- [x] root \`npm test\` — **3233 tests pass, 100% coverage**
- [x] backend \`npm run type-check\` pass
- [x] root \`npm run type-check\` pass
- [x] resetKalmanForArrival pure 함수 검증 (v=0/P=R_LOW/ts=input)
- [x] detectKalmanDrift 경계값 (14.99/15/15.01), signed delta, 음수
- [x] scheduled wire — arvlCd=1/0/2/phase gate 차단 4 케이스 + boardingLock arrived/not arrived
- [x] code-review 에이전트 P1 0건, P2 4건 follow-up 분리

## Phase 3 epic #818 진행 상태

- E1 #823 ✅ (PR #831)
- E2 #824 ✅ (PR #832)
- E3 #825 ✅ (PR #835)
- **E4 #826 ✅ (본 PR 머지 시 epic close)**
- E5 #827 ✅ (PR #830)

후속: #834 (클라 nearestStationDistanceM 송신), #833 (E2 P2-2 refactor), 본 PR P2 follow-up.

Closes #826