### PR TITLE
refactor: evaluateBoardingPromptGates metrics 옵션 인자 — evaluateWindow 중복 호출 제거

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ARRIVAL_CODE } from '../alarm';
 import {
   DISMISS_SILENCE_MS,
@@ -7,6 +7,7 @@ import {
   markPromptSilenced,
   pickAutoTrainCode,
 } from '../boardingPrompt';
+import * as positionSeries from '../positionSeries';
 import type { PositionPoint } from '../types';
 import type { ArrivalEntry } from '../seoul';
 
@@ -332,6 +333,58 @@ describe('evaluateBoardingPromptGates — #824 kalmanKmh 전달', () => {
     expect(withKalman.pass).toBe(true);
     if (withoutKalman.pass && withKalman.pass) {
       expect(withKalman.fusedSpeedKmh).toBeGreaterThan(withoutKalman.fusedSpeedKmh);
+    }
+  });
+});
+
+describe('evaluateBoardingPromptGates — #833 pre-computed metrics 재사용', () => {
+  const now = 1_000_000;
+
+  it('metrics 미지정 시 내부 evaluateWindow를 호출한다', () => {
+    const spy = vi.spyOn(positionSeries, 'evaluateWindow');
+    try {
+      const r = evaluateBoardingPromptGates({
+        series: happySeries(now),
+        origin: ORIGIN,
+        nextStation: NEXT,
+        now,
+      });
+      expect(r.pass).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('metrics 지정 시 evaluateWindow를 호출하지 않고 주입값을 그대로 사용한다', () => {
+    // 내부 호출이 일어났다면 happy series 결과를 재계산해 stationary 차단을 우회했을 것.
+    // motion=stationary로 주입한 metrics를 그대로 쓴다면 motion-not-moving으로 차단되어야 한다.
+    const injected: positionSeries.WindowedMetrics = {
+      count: 5,
+      gpsAvgKmh: 20,
+      avgAccuracyMeters: 10,
+      motion: 'stationary',
+      start: { lat: 0, lng: -0.0004 },
+      end: { lat: 0, lng: 0.0008 },
+      mapMatchedKmh: null,
+    };
+    const spy = vi.spyOn(positionSeries, 'evaluateWindow');
+    try {
+      const r = evaluateBoardingPromptGates({
+        series: happySeries(now),
+        origin: ORIGIN,
+        nextStation: NEXT,
+        now,
+        metrics: injected,
+      });
+      expect(r.pass).toBe(false);
+      if (!r.pass) {
+        expect(r.reason).toBe('motion-not-moving');
+        expect(r.metrics).toBe(injected); // 동일 참조 — 재계산 안 함
+      }
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
     }
   });
 });

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -80,6 +80,12 @@ export interface EvaluateBoardingPromptInputs {
    * (Phase 1/2 회귀 없음).
    */
   kalmanKmh?: number | null;
+  /**
+   * Pre-computed window metrics (#833). 호출자가 이미 동일 series/now로
+   * `evaluateWindow`를 계산했다면(예: Kalman observation 산출용) 결과를 그대로 전달해
+   * hot path redundancy를 제거한다. 미지정 시 내부에서 1회 계산 — 회귀 없음.
+   */
+  metrics?: WindowedMetrics;
 }
 
 /**
@@ -103,7 +109,9 @@ export function evaluateBoardingPromptGates(
   }
 
   // #6 — 60s 윈도우 N≥3 (cold start 보호). 0/1 sample은 metrics.start/end null로 자연 차단.
-  const metrics = evaluateWindow(inputs.series, inputs.now);
+  // #833 — 호출자가 동일 series/now로 이미 evaluateWindow를 돌렸다면(예: scheduled.ts의
+  // Kalman observation) 결과를 재사용해 hot path 중복 계산을 제거한다.
+  const metrics = inputs.metrics ?? evaluateWindow(inputs.series, inputs.now);
   if (metrics.count < MIN_WINDOW_SAMPLES) {
     return { pass: false, reason: 'window-too-small', metrics };
   }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1023,6 +1023,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     now,
     promptState: trip.boardingPromptState,
     kalmanKmh: fusion.kalmanKmh,
+    // #833 — runFusionStep이 Kalman observation을 위해 이미 evaluateWindow를 1회 돌렸다.
+    // 그 결과를 그대로 재사용해 trip당 redundant window 평가를 제거 (동작 동치).
+    metrics: fusion.posMetrics,
   });
 
   if (!outcome.pass) {


### PR DESCRIPTION
## Summary
- `EvaluateBoardingPromptInputs.metrics?: WindowedMetrics` 옵션 신설 — 미지정 시 기존처럼 내부 evaluateWindow 호출(회귀 없음)
- `scheduled.ts:evaluateAndMaybeFireBoardingPrompt`가 `fusion.posMetrics` 재사용 → cron hot path 중복 평가 제거 (trip당 2회 → 1회)
- 동일 series/now로 산출된 metrics만 주입한다는 호출자 책임을 JSDoc/inline에 명문화

## Test plan
- [x] backend/alarm-worker `npm test` 672/672 pass
- [x] worker `tsc --noEmit` + root `tsc --noEmit` 모두 pass
- [x] code-review 에이전트 PASS — no blockers (단순성/확장성/동작 동치 모두 충족)
- [x] 신규 spy 케이스: (a) metrics 미지정 → spy 1회 (b) metrics 지정 → spy 0회 + `r.metrics === injected` 참조 동등성

Closes #833