### PR TITLE
feat: Phase 3 E3-B — 클라이언트 nearestStationDistanceM 송신 (stationPhase 입력)

### DIFF
--- a/src/api/__tests__/positionUpload.test.ts
+++ b/src/api/__tests__/positionUpload.test.ts
@@ -1,9 +1,11 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
+  defaultNearestStationResolver,
   dismissBoardingPrompt,
   readActiveBoardingLine,
   uploadPosition,
   withMapMatched,
+  withNearestStationDistance,
 } from '../positionUpload';
 import { ACTIVE_BOARDING_LINE_KEY } from '../../constants/storageKeys';
 
@@ -56,14 +58,18 @@ describe('uploadPosition (#819)', () => {
     expect(r).toEqual({ ok: true, status: 200 });
     const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
     expect(url).toBe('https://api.test.dev/position');
-    expect(JSON.parse(init.body)).toEqual({
-      token: 'tok',
-      lat: 37.5,
-      lng: 127,
-      accuracy: 10,
-      ts: 1234,
-      motion: 'automotive',
-    });
+    // #834: 한국 좌표는 defaultNearestStationResolver가 자동으로 nearestStationDistanceM을
+    // 첨부하므로 exact toEqual 대신 핵심 필드만 비교한다.
+    expect(JSON.parse(init.body)).toEqual(
+      expect.objectContaining({
+        token: 'tok',
+        lat: 37.5,
+        lng: 127,
+        accuracy: 10,
+        ts: 1234,
+        motion: 'automotive',
+      }),
+    );
   });
 
   it('non-OK status → ok=false + status', async () => {
@@ -197,6 +203,43 @@ describe('uploadPosition (#819)', () => {
     expect(body.mapMatchedArcM).toBe(999);
   });
 
+  it('#834: 한국 좌표(강남역) → body에 nearestStationDistanceM이 finite 양수', async () => {
+    // ACTIVE_BOARDING_LINE_KEY 미설정 — mapMatched는 omit, nearestStationDistance만 첨부 확인.
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    await uploadPosition({
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 10,
+      ts: 0,
+      motion: 'automotive',
+    });
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(typeof body.nearestStationDistanceM).toBe('number');
+    expect(Number.isFinite(body.nearestStationDistanceM)).toBe(true);
+    expect(body.nearestStationDistanceM).toBeGreaterThanOrEqual(0);
+  });
+
+  it('#834: 호출자가 명시 전달한 nearestStationDistanceM은 override (resolver 미호출)', async () => {
+    // payload에 0 명시 → resolver를 호출하지 않고 그대로 직렬화 (스파이로 미호출 확인).
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+    await uploadPosition({
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 10,
+      ts: 0,
+      motion: 'automotive',
+      nearestStationDistanceM: 0,
+    });
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.nearestStationDistanceM).toBe(0);
+  });
+
   it('5s 후 timeout abort — controller.abort 콜백 호출됨', async () => {
     // fetch가 abort signal을 받기까지 timer를 advance. setTimeout 콜백이 실행돼야
     // controller.abort()가 호출됨 (함수 커버리지 확보).
@@ -289,6 +332,77 @@ describe('withMapMatched (#828)', () => {
     };
     const out = await withMapMatched(payload, async () => null);
     expect(out).toEqual(payload);
+  });
+});
+
+describe('withNearestStationDistance (#834)', () => {
+  it('명시 nearestStationDistanceM이 이미 있으면 그대로 반환 (resolver 미호출)', async () => {
+    const resolver = jest.fn();
+    const out = withNearestStationDistance(
+      {
+        token: 'tok',
+        lat: 37.4979,
+        lng: 127.0276,
+        accuracy: 0,
+        ts: 0,
+        motion: 'walking',
+        nearestStationDistanceM: 0,
+      },
+      resolver,
+    );
+    expect(out.nearestStationDistanceM).toBe(0);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('resolver 주입 — 호출자가 지정한 값으로 첨부 (확장성)', () => {
+    // 측정 fixture / spatial index 등 호출자 단 확장 시나리오.
+    const out = withNearestStationDistance(
+      {
+        token: 'tok',
+        lat: 37.4979,
+        lng: 127.0276,
+        accuracy: 0,
+        ts: 0,
+        motion: 'walking',
+      },
+      () => 42,
+    );
+    expect(out.nearestStationDistanceM).toBe(42);
+  });
+
+  it('resolver가 undefined 반환 → 필드 omit (graceful)', () => {
+    const payload = {
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 0,
+      ts: 0,
+      motion: 'walking' as const,
+    };
+    const out = withNearestStationDistance(payload, () => undefined);
+    expect(out).toEqual(payload);
+    expect(out.nearestStationDistanceM).toBeUndefined();
+  });
+
+  it('defaultNearestStationResolver — 한국 좌표 → finite 양수 m', () => {
+    // findNearestStation은 maxDistanceKm 없이 호출되므로 지구 어디든 매칭은 되지만
+    // 한국 좌표(강남역)에서는 실제 거리가 작은 값이어야 한다.
+    const m = defaultNearestStationResolver(37.4979, 127.0276);
+    expect(typeof m).toBe('number');
+    expect(Number.isFinite(m)).toBe(true);
+    expect(m).toBeGreaterThanOrEqual(0);
+  });
+
+  it('defaultNearestStationResolver — findNearestStation null → undefined (graceful 분기)', () => {
+    // 실제 stations.json은 528개라 null이 나올 수 없지만, 안전 가드 분기를 커버하기 위해
+    // 모듈을 mock해 null을 강제한다.
+    jest.isolateModules(() => {
+      jest.doMock('../../utils/findNearestStation', () => ({
+        findNearestStation: () => null,
+      }));
+      const mod = require('../positionUpload');
+      expect(mod.defaultNearestStationResolver(0, 0)).toBeUndefined();
+    });
   });
 });
 

--- a/src/api/__tests__/positionUpload.test.ts
+++ b/src/api/__tests__/positionUpload.test.ts
@@ -30,6 +30,26 @@ afterEach(() => {
   global.fetch = ORIGINAL_FETCH;
 });
 
+// #834 — 강남역 좌표(37.4979/127.0276) 기반 uploadPosition body 캡처 헬퍼.
+// 두 신규 테스트가 공유하는 fetch mock setup + body 추출을 중복 없이 표현한다.
+async function captureGangnamUploadBody(
+  overrides: Partial<Parameters<typeof uploadPosition>[0]> = {},
+): Promise<Record<string, unknown>> {
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+  (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+  await uploadPosition({
+    token: 'tok',
+    lat: 37.4979,
+    lng: 127.0276,
+    accuracy: 10,
+    ts: 0,
+    motion: 'automotive',
+    ...overrides,
+  });
+  const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+  return JSON.parse(init.body);
+}
+
 describe('uploadPosition (#819)', () => {
   it('URL 미설정 시 skipped=true — fetch 미호출', async () => {
     const r = await uploadPosition({
@@ -205,18 +225,7 @@ describe('uploadPosition (#819)', () => {
 
   it('#834: 한국 좌표(강남역) → body에 nearestStationDistanceM이 finite 양수', async () => {
     // ACTIVE_BOARDING_LINE_KEY 미설정 — mapMatched는 omit, nearestStationDistance만 첨부 확인.
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
-    await uploadPosition({
-      token: 'tok',
-      lat: 37.4979,
-      lng: 127.0276,
-      accuracy: 10,
-      ts: 0,
-      motion: 'automotive',
-    });
-    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
-    const body = JSON.parse(init.body);
+    const body = await captureGangnamUploadBody();
     expect(typeof body.nearestStationDistanceM).toBe('number');
     expect(Number.isFinite(body.nearestStationDistanceM)).toBe(true);
     expect(body.nearestStationDistanceM).toBeGreaterThanOrEqual(0);
@@ -224,19 +233,7 @@ describe('uploadPosition (#819)', () => {
 
   it('#834: 호출자가 명시 전달한 nearestStationDistanceM은 override (resolver 미호출)', async () => {
     // payload에 0 명시 → resolver를 호출하지 않고 그대로 직렬화 (스파이로 미호출 확인).
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
-    await uploadPosition({
-      token: 'tok',
-      lat: 37.4979,
-      lng: 127.0276,
-      accuracy: 10,
-      ts: 0,
-      motion: 'automotive',
-      nearestStationDistanceM: 0,
-    });
-    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
-    const body = JSON.parse(init.body);
+    const body = await captureGangnamUploadBody({ nearestStationDistanceM: 0 });
     expect(body.nearestStationDistanceM).toBe(0);
   });
 

--- a/src/api/positionUpload.ts
+++ b/src/api/positionUpload.ts
@@ -15,6 +15,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ACTIVE_BOARDING_LINE_KEY } from '../constants/storageKeys';
 import { snapToLinePolyline } from '../utils/linePolyline';
 import { isLineNumber } from '../utils/lineGuard';
+import { findNearestStation } from '../utils/findNearestStation';
 import type { LineNumber } from '../types/station';
 import { createLogger } from '../utils/logger';
 import type { AccelSummary } from '../utils/accelMotion';
@@ -68,6 +69,14 @@ export interface PositionUploadPayload {
    */
   mapMatchedLine?: string;
   mapMatchedArcM?: number;
+  /**
+   * #834 Phase 3 E3-B — 클라가 stations.json 전수 스캔으로 산출한 최근접 역까지의 거리 (m).
+   * backend는 stations.json을 갖지 않으므로 거리는 반드시 클라 책임 (`mapMatched*`와 동형).
+   * backend `stationPhase.ts`가 APPROACHING/DWELLING/DEPARTING/CRUISING 분류 입력 중
+   * 하나로 사용. undefined → phase 산출 skip (회귀 없음, GPS-only fallback).
+   * 음수/NaN/Infinity는 backend가 series 단계에서 거부.
+   */
+  nearestStationDistanceM?: number;
 }
 
 export interface PositionUploadResult {
@@ -122,6 +131,52 @@ export async function withMapMatched(
   };
 }
 
+/**
+ * #834 — 좌표를 받아 최근접 역까지의 거리(m)를 반환하는 전략 함수.
+ *
+ * 기본 구현은 `findNearestStation` (stations.json 528개 전수 스캔, BG sample 당 1회).
+ * 호출자는 측정 fixture / spatial index / active-line scoping 등 미래 확장을 위해
+ * 자기만의 resolver를 주입할 수 있다. undefined 반환 시 필드 omit (graceful).
+ */
+export type NearestStationResolver = (lat: number, lng: number) => number | undefined;
+
+/** 1km → 1000m 변환 상수. 매직넘버 분리. */
+const METERS_PER_KM = 1000;
+
+/**
+ * 기본 resolver — `findNearestStation`이 반환한 km 거리를 m로 변환.
+ * null(매칭 실패) → undefined (snap skip, graceful).
+ */
+export const defaultNearestStationResolver: NearestStationResolver = (lat, lng) => {
+  const result = findNearestStation(lat, lng);
+  if (!result) return undefined;
+  return result.distanceKm * METERS_PER_KM;
+};
+
+/**
+ * #834 — resolver가 산출한 최근접 역 거리를 payload에 첨부.
+ *
+ * - 호출자가 `nearestStationDistanceM`을 명시 전달했으면 그대로 사용 (override, resolver 미호출).
+ * - resolver undefined → 필드 omit (graceful, GPS-only fallback).
+ *
+ * `withMapMatched`와 동형 패턴 — resolver를 함수로 주입받아 미래의 spatial index /
+ * 측정 fixture / active-line scoping 같은 확장이 호출자 단에서 자유롭게 결정된다.
+ */
+export function withNearestStationDistance(
+  payload: PositionUploadPayload,
+  resolve: NearestStationResolver = defaultNearestStationResolver,
+): PositionUploadPayload {
+  if (payload.nearestStationDistanceM !== undefined) {
+    return payload;
+  }
+  const distanceM = resolve(payload.lat, payload.lng);
+  if (distanceM === undefined) return payload;
+  return {
+    ...payload,
+    nearestStationDistanceM: distanceM,
+  };
+}
+
 export async function uploadPosition(
   payload: PositionUploadPayload,
 ): Promise<PositionUploadResult> {
@@ -130,7 +185,8 @@ export async function uploadPosition(
     log.info('ALARM_BACKEND_URL not set — skip position upload');
     return { ok: false, skipped: true };
   }
-  const enriched = await withMapMatched(payload);
+  const mapMatched = await withMapMatched(payload);
+  const enriched = withNearestStationDistance(mapMatched);
   try {
     const res = await fetchWithTimeout(`${base}/position`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- `PositionUploadPayload.nearestStationDistanceM` 옵션 필드 추가 — backend `stationPhase` 분류기(#825) 입력 wire 완료
- `NearestStationResolver` 타입 + `defaultNearestStationResolver` export (findNearestStation, km→m 변환)
- `withMapMatched`와 동형인 `withNearestStationDistance` enrichment — 호출자 명시 override → resolver → omit 우선순위
- `METERS_PER_KM` 상수 분리
- `uploadPosition` 내부에서 `withMapMatched` → `withNearestStationDistance` 순차 적용

## Test plan
- [x] `npm test` 3240/3240 pass
- [x] `positionUpload.ts` 100% lines/functions/branches/statements
- [x] `npm run type-check` pass
- [x] code-review 에이전트 PASS — no blockers (P0/P1 0건, P2 3건 후속 관찰: resolver 시그니처 비대칭/unreachable 가드 강제 커버/backend 거부 telemetry 부재)
- [x] #828 회귀 안정화 — 기존 `toEqual` → `expect.objectContaining`으로 자동 첨부된 nearestStationDistanceM 받아들임

Closes #834