### PR TITLE
refactor(#837): P2-1 — lockless dedup gate를 fusion+reset 이후로 이동

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2194,6 +2194,70 @@ describe('runScheduled — #826 lockless intermediate Kalman reset', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #837 P2-1 — lockless dedup gate / reset 순서 (arvlCd > phase 우선순위)
+// ---------------------------------------------------------------------------
+
+describe('runScheduled — #837 P2-1 lockless dedup vs Kalman reset 순서', () => {
+  it('이미 imminent 발사한 trip + arvlCd=ARRIVED → reset은 발사 (kalmanReset=1), push는 dedup으로 skip', async () => {
+    // 핵심: dedup된 trip이라도 ground truth(ARRIVED)면 Kalman state는 reset해야 함.
+    // 이전 동작: dedup gate가 fusion/reset 이전이라 reset 미진입 → drift 누적.
+    // 수정 후: fusion + arrivals fetch + reset 수행 → dedup gate가 push만 차단.
+    const kv = new InMemoryKV();
+    const token = 'lock-dedup-reset-1';
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLocklessKalmanTrip(token, { lastFiredPhase: 'imminent' }),
+    );
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 40, P: 100, ts: NOW - 5_000 }));
+
+    const fetchSpy = vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch;
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([makeArrivedSignal(1)]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchSpy,
+      now: () => NOW,
+      generatePushId: () => 'lk-dedup-1',
+    });
+
+    // reset은 수행 (drift 차단)
+    expect(stats.kalmanReset).toBe(1);
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
+    expect(kalmanState?.v).toBe(0);
+    expect(kalmanState?.P).toBe(R_LOW);
+    // push는 dedup으로 skip (APNs fetch 호출 0회)
+    expect(stats.pushed).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('이미 imminent 발사한 trip + signal null (etaMissing) → reset 미발사 (fires만이 진실)', async () => {
+    // dedup gate 이동했어도 reset 트리거는 fires=true만이어야 함.
+    // signal 부재/arvlCd null은 etaMissing 경로 — reset 미진입.
+    const kv = new InMemoryKV();
+    const token = 'lock-dedup-reset-2';
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLocklessKalmanTrip(token, { lastFiredPhase: 'imminent' }),
+    );
+    await kv.put(`kalman:${token}`, JSON.stringify({ v: 35, P: 50, ts: NOW - 3_000 }));
+
+    const stats = await runScheduled(
+      makeEnv(kv),
+      // arrivals 빈 배열 → signal=null → etaMissing 경로
+      makeKalmanResetDeps(makeSeoul([]), 'lk-dedup-2'),
+    );
+
+    expect(stats.kalmanReset).toBe(0);
+    expect(stats.etaMissing).toBe(1);
+    expect(stats.pushed).toBe(0);
+    // kalman state 보존 (reset 미진입)
+    const kalmanState = await readKalmanState(kv as unknown as KVNamespace, token);
+    expect(kalmanState?.v).toBe(35);
+    expect(kalmanState?.P).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #826 — runTrainCodeTracking → Kalman reset on arrived
 // ---------------------------------------------------------------------------
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -770,10 +770,9 @@ export async function runLocklessIntermediate(
   log: Logger,
   generatePushId: () => string,
 ): Promise<void> {
-  // 같은 waypoint에서 이미 발사했으면 dedup (lockless 흐름은 phase 개념이 없으니 imminent 단일 stamp 사용).
-  if (trip.lastFiredPhase === 'imminent') {
-    return;
-  }
+  // #837 P2-1 — dedup gate를 fusion + arrivals fetch + reset 이후로 이동.
+  // arvlCd=ARRIVED/ENTERING은 phase보다 강한 ground truth 신호이므로, 이미 imminent 발사한
+  // waypoint라도 reset은 수행해야 한다(state drift 누적 차단). push 발사만 dedup으로 차단.
   // #825 — Phase 3 E3 fusion step. 분류 결과를 trip에 stamp + imminent push 발사 가드에 사용.
   const fusion = await runFusionStep(trip, env, now, stats);
   let dirty = false;
@@ -795,11 +794,17 @@ export async function runLocklessIntermediate(
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
-  // #826 — fires=true(ARRIVED/ENTERING)는 ground truth 신호. push 발사 여부(phase 가드)와
+  // #826 — fires=true(ARRIVED/ENTERING)는 ground truth 신호. push 발사 여부(phase 가드/dedup)와
   // 무관하게 Kalman state를 reset해 drift 누적을 차단한다. arvlCd가 가장 강한 신호 — phase
-  // 분류는 휴리스틱이라 contradiction 시 arvlCd를 신뢰.
+  // 분류는 휴리스틱이라 contradiction 시 arvlCd를 신뢰. KV write는 idempotent(v=0/P=R_LOW).
   await writeKalmanState(env.TRIPS, trip.token, resetKalmanForArrival(now));
   stats.kalmanReset += 1;
+  // #837 P2-1 — dedup gate (reset 이후, push 발사 직전). 같은 waypoint에서 이미 발사했으면
+  // push만 skip하고 dirty 저장 후 return (lockless 흐름은 phase 개념이 없으니 imminent 단일 stamp 사용).
+  if (trip.lastFiredPhase === 'imminent') {
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
+  }
   // #825 — high-confidence non-APPROACHING phase면 차단 (false positive 1차).
   // 신호 부재/낮은 신뢰는 기존 동작 그대로 (회귀 없음, #834 wire 전까지 자연 skip).
   if (!phaseAllowsImminentFiring(fusion.phaseState)) {


### PR DESCRIPTION
## Summary
- `runLocklessIntermediate`의 imminent dedup gate를 `runFusionStep` + fires(`ARRIVED`/`ENTERING`) 판정 + `resetKalmanForArrival` 이후로 이동
- dedup된 trip도 fires=true면 reset 수행 → Kalman drift 누적 차단
- "arvlCd가 phase보다 강한 신호" 정책 일관성 — ground truth 신호는 phase 가드와 무관하게 state reset
- KV write가 dedup-return 경로에서 cycle당 +1 (idempotent `v=0/P=R_LOW`라 의미 정확 — 이슈 본문 명시)

## Test plan
- [x] backend/alarm-worker `npm test` 674/674 pass (base 672 → 신규 2)
- [x] worker + root `tsc --noEmit` pass
- [x] code-review 에이전트: 초기 P1(base 차이 false positive)은 rebase로 해소. 현재 diff는 P2-1만 (`scheduled.ts` +17/-6, test +64)
- [x] 신규 케이스 2건: imminent stamp + ARRIVED → reset only (push 미발사) / imminent + signal null → reset 없음

Refs #837 — P2-1만 처리. P2-2(drift grace) / P2-3(SRP refactor) / P2-4(runTrainCodeTracking fusion)는 측정 결과 또는 별도 PR로 분리.