### PR TITLE
refactor(#837): P2-3 — runFusionStep SRP 분리 + maybeCountDrift 헬퍼

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1,17 +1,20 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
-import { R_LOW, readKalmanState } from '../kalmanFilter';
+import { DRIFT_WARNING_THRESHOLD_KMH, R_LOW, readKalmanState, type KalmanState } from '../kalmanFilter';
+import type { WindowedMetrics } from '../positionSeries';
 import {
   MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
   estimateArrivalFromPosition,
   flipApnsEnv,
+  maybeCountDrift,
   pickActiveWaypoint,
   pickApnsHost,
   pickBestArrivalSignal,
   runScheduled,
   type ScheduledDeps,
+  type ScheduledStats,
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
@@ -2051,6 +2054,55 @@ describe('runScheduled — #826 drift telemetry (kalmanDriftWarning)', () => {
       now: () => NOW,
       generatePushId: () => 'd3',
     });
+    expect(stats.kalmanDriftWarning).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #837 P2-3 — maybeCountDrift 단위 (fusion에서 분리한 헬퍼, SRP)
+// ---------------------------------------------------------------------------
+
+function makePosMetricsFixture(gpsAvgKmh: number): WindowedMetrics {
+  return {
+    count: 6,
+    gpsAvgKmh,
+    avgAccuracyMeters: 12,
+    motion: 'walking',
+    start: null,
+    end: null,
+    mapMatchedKmh: null,
+  };
+}
+
+function makeEmptyStats(): ScheduledStats {
+  // maybeCountDrift는 stats.kalmanDriftWarning만 참조. 다른 필드는 영향 없어 0으로 채운다.
+  // ScheduledStats 전체 필드를 일일이 적는 대신 runScheduled 본문과 동일하게 단일 필드만 검증한다.
+  return { kalmanDriftWarning: 0 } as unknown as ScheduledStats;
+}
+
+describe('maybeCountDrift (#837 P2-3)', () => {
+  it('prior=null이면 drift 카운트 skip (첫 cycle)', () => {
+    const stats = makeEmptyStats();
+    const posMetrics = makePosMetricsFixture(30); // delta=30 ≥ 15지만 prior 없음
+    maybeCountDrift(null, posMetrics, stats);
+    expect(stats.kalmanDriftWarning).toBe(0);
+  });
+
+  it('prior 존재 + |state.v - gpsAvg| ≥ DRIFT_WARNING_THRESHOLD_KMH → +1', () => {
+    const stats = makeEmptyStats();
+    const prior: KalmanState = { v: 0, P: R_LOW, ts: 0 };
+    // state.v=0, gpsAvg=DRIFT_WARNING_THRESHOLD_KMH → |delta|=15 (경계 포함)
+    const posMetrics = makePosMetricsFixture(DRIFT_WARNING_THRESHOLD_KMH);
+    maybeCountDrift(prior, posMetrics, stats);
+    expect(stats.kalmanDriftWarning).toBe(1);
+  });
+
+  it('prior 존재 + |delta| < 임계 → 카운트 변화 없음', () => {
+    const stats = makeEmptyStats();
+    const prior: KalmanState = { v: 30, P: 25, ts: 0 };
+    // |30 - 32| = 2 < 15
+    const posMetrics = makePosMetricsFixture(32);
+    maybeCountDrift(prior, posMetrics, stats);
     expect(stats.kalmanDriftWarning).toBe(0);
   });
 });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -19,6 +19,7 @@ import {
 } from './boardingPrompt';
 import {
   detectKalmanDrift,
+  type KalmanState,
   readKalmanState,
   resetKalmanForArrival,
   runKalmanStep,
@@ -330,6 +331,13 @@ interface FusionStepResult {
   kalmanKmh: number | null;
   /** 운행 phase 분류 결과. null인 경우: observation 무효 또는 nearestStationDistanceM 미수신. */
   phaseState: StationPhaseState | null;
+  /**
+   * 정상 cycle(observationValid)의 직전 cycle Kalman state — drift 측정 입력 (#837 P2-3).
+   * observation 무효 cycle 또는 KV 미존재면 null → 호출자 maybeCountDrift가 skip.
+   */
+  kalmanPrior: KalmanState | null;
+  /** 이번 cycle predict+update 직후 state. observation 무효면 null (KV write 자체가 skip). */
+  kalmanState: KalmanState | null;
 }
 
 /**
@@ -346,12 +354,13 @@ interface FusionStepResult {
  *   - phaseState non-null이면 trip.stationPhase에 stamp + putTrip 시 persist
  *   - kalmanKmh를 게이트/fusion 입력으로 전달
  *   - series는 본 함수가 fetched한 raw KV 값 — 추가 read 불필요
+ *   - #837 P2-3 — drift 카운트(stats.kalmanDriftWarning)는 호출자가 maybeCountDrift(prior, posMetrics, stats)
+ *     로 수행. fusion 자체는 stats를 받지 않아 SRP 유지(HTTP path 등에서 stats 없이 재사용 가능).
  */
 async function runFusionStep(
   trip: Trip,
   env: Env,
   now: number,
-  stats: ScheduledStats,
 ): Promise<FusionStepResult> {
   const [series, accelSeries, kalmanPrior] = await Promise.all([
     readSeries(env.TRIPS, trip.token),
@@ -364,15 +373,15 @@ async function runFusionStep(
     posMetrics.count > 0 && Number.isFinite(posMetrics.avgAccuracyMeters);
 
   if (!observationValid) {
-    return { series, posMetrics, kalmanKmh: null, phaseState: null };
-  }
-
-  // #826 — drift 측정은 prior 존재 정상 cycle만. 첫 cycle은 v=gpsAvg 초기화라 delta=0으로 의미 없음.
-  if (kalmanPrior !== null) {
-    const drift = detectKalmanDrift(kalmanPrior, posMetrics.gpsAvgKmh);
-    if (drift.warning) {
-      stats.kalmanDriftWarning += 1;
-    }
+    // observation 무효 cycle은 drift도 의미 없음 — kalmanPrior=null로 반환해 호출자가 skip.
+    return {
+      series,
+      posMetrics,
+      kalmanKmh: null,
+      phaseState: null,
+      kalmanPrior: null,
+      kalmanState: null,
+    };
   }
 
   const kalmanState = runKalmanStep({
@@ -405,7 +414,37 @@ async function runFusionStep(
     trip.stationPhase,
   );
 
-  return { series, posMetrics, kalmanKmh, phaseState };
+  return {
+    series,
+    posMetrics,
+    kalmanKmh,
+    phaseState,
+    kalmanPrior,
+    kalmanState,
+  };
+}
+
+/**
+ * #837 P2-3 — Kalman drift 카운트 헬퍼.
+ *
+ * runFusionStep에서 분리한 책임 (SRP):
+ *  - fusion은 순수 pipeline (KV I/O + 계산만), stats 의존 제거 → HTTP path 등에서 dummy stats 없이 재사용.
+ *  - drift 카운트는 호출자 직후에 수행 — 발생 시점/조건 동치(정상 cycle + prior 존재).
+ *
+ * skip 조건:
+ *  - prior=null (첫 cycle, v=gpsAvg 초기화라 delta=0 의미 없음)
+ *  - posMetrics가 fusion observation 무효 cycle의 것이면 호출자가 prior=null로 받음 (#826 정합)
+ */
+export function maybeCountDrift(
+  prior: KalmanState | null,
+  posMetrics: WindowedMetrics,
+  stats: ScheduledStats,
+): void {
+  if (prior === null) return;
+  const drift = detectKalmanDrift(prior, posMetrics.gpsAvgKmh);
+  if (drift.warning) {
+    stats.kalmanDriftWarning += 1;
+  }
 }
 
 /**
@@ -765,7 +804,9 @@ export async function runLocklessIntermediate(
   // arvlCd=ARRIVED/ENTERING은 phase보다 강한 ground truth 신호이므로, 이미 imminent 발사한
   // waypoint라도 reset은 수행해야 한다(state drift 누적 차단). push 발사만 dedup으로 차단.
   // #825 — Phase 3 E3 fusion step. 분류 결과를 trip에 stamp + imminent push 발사 가드에 사용.
-  const fusion = await runFusionStep(trip, env, now, stats);
+  const fusion = await runFusionStep(trip, env, now);
+  // #837 P2-3 — drift 카운트는 fusion 외부 (SRP). fusion 결과 직후 동일 시점/조건으로 평가.
+  maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats);
   let dirty = false;
   if (fusion.phaseState) {
     trip.stationPhase = fusion.phaseState;
@@ -1004,7 +1045,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   stats.boardingPromptEvaluated += 1;
 
-  const fusion = await runFusionStep(trip, env, now, stats);
+  const fusion = await runFusionStep(trip, env, now);
+  // #837 P2-3 — drift 카운트는 fusion 외부 (SRP). fusion 결과 직후 동일 시점/조건으로 평가.
+  maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats);
   let dirty = false;
   // phase 분류 결과가 있으면 trip에 stamp — 다음 cycle hysteresis 입력 + lockless 가드용 상태.
   if (fusion.phaseState) {


### PR DESCRIPTION
## Summary
- `runFusionStep` 시그니처에서 `stats: ScheduledStats` 인자 완전 제거 — fusion 함수는 순수 pipeline + KV I/O만 담당
- `FusionStepResult`에 `kalmanPrior: KalmanState | null` + `kalmanState: KalmanState | null` 추가 (HTTP path 등 fusion 재사용 시 dummy stats 불필요)
- `maybeCountDrift(prior, posMetrics, stats)` 헬퍼 신규 — `stats.kalmanDriftWarning` 카운트 단일 사이트
- 두 호출자(`runLocklessIntermediate`, `evaluateBoardingPromptIfNeeded`) 모두 `const fusion = await runFusionStep(...); maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats);` 패턴 적용 — 동일 시점/조건

## 동작 동치 보장
- Before: fusion 내부 `if (kalmanPrior !== null) detectKalmanDrift(...)`
- After: 동일 prior를 result에 노출, 호출자가 `maybeCountDrift`로 동일 분기. observation 무효 cycle은 `kalmanPrior: null` → 헬퍼가 즉시 skip (기존 early-return과 동치)
- 두 호출자 패턴 동일, `dirty` flag 평가 전 — 기존 위치와 동치

## Test plan
- [x] backend/alarm-worker `npm test` 677/677 pass (base 674 + 신규 3: prior null skip / 임계 경계 +1 / 임계 이하 0)
- [x] worker + root `tsc --noEmit` pass
- [x] code-review 에이전트 **PASS — no blockers** (SRP 깨끗/회귀 안전/임계 경계 정확/임시방편 X)
- [x] `runFusionStep` 호출 사이트 grep 결과 2곳만, 둘 다 패치

Refs #837 — P2-3만 처리. P2-1은 #840 머지됨, P2-2(drift grace)/P2-4(runTrainCodeTracking fusion)는 E5 측정 데이터 누적 후 별도 PR.