### PR TITLE
fix(#746): 알람 dismiss silence 5분/200m 차단

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -86,6 +86,11 @@ export default function HomeScreen() {
   const alarmEvent = useAppStore((s) => s.alarmEvent);
   const clearAlarmEvent = useAppStore((s) => s.clearAlarmEvent);
   const loadAlarmEvent = useAppStore((s) => s.loadAlarmEvent);
+  // #746: 알람 dismiss → silence 시작점 기록. 같은 컴포넌트의 userLocation을 같이 캡처.
+  const setDismissSilence = useAppStore((s) => s.setDismissSilence);
+  // #746 reviewer P1: cold-start hydration — storage에 살아있는 silence 상태를
+  // FG path가 무시하지 않도록 loadAlarmEvent와 같은 시퀀스로 hydrate.
+  const loadDismissSilence = useAppStore((s) => s.loadDismissSilence);
   const [pickerVisible, setPickerVisible] = useState(false);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
   const prevDestIdRef = useRef<string | null>(null);
@@ -339,6 +344,7 @@ export default function HomeScreen() {
     loadRoutePreference();
     loadAlarmEvent();
     loadLocklessStationPassed();
+    loadDismissSilence();
     // iOS가 BG에서 앱을 메모리 압박으로 종료하면 Zustand 상태는 휘발되지만
     // DESTINATION_KEY는 디스크에 남는다. 콜드/웜 부팅 시 복원해 trip을 이어간다 (#541).
     // #700 — tripOrigin을 먼저 await으로 hydrate한 다음 destination을 set한다.
@@ -892,7 +898,17 @@ export default function HomeScreen() {
         // #806: dismiss는 알람 UI/진동만 끄고 trip(BoardingLock)은 유지.
         // 한 정거장 전(early) destination 알람을 끄면 trip이 종료되던 회귀의 fix.
         // trip release는 도착 자동 release(useBoardingLockAutoRelease, #759)에 위임한다.
-        <AlarmOverlay event={alarmEvent} onDismiss={clearAlarmEvent} />
+        // #746: dismiss와 동시에 silence 시작점 기록. userLocation 미가용 시 시간 단독 silence.
+        <AlarmOverlay
+          event={alarmEvent}
+          onDismiss={() => {
+            void setDismissSilence(
+              Date.now(),
+              userLocation ? { lat: userLocation.lat, lng: userLocation.lng } : null,
+            );
+            clearAlarmEvent();
+          }}
+        />
       )}
 
       <DestinationPicker

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -902,10 +902,10 @@ export default function HomeScreen() {
         <AlarmOverlay
           event={alarmEvent}
           onDismiss={() => {
-            void setDismissSilence(
+            setDismissSilence(
               Date.now(),
               userLocation ? { lat: userLocation.lat, lng: userLocation.lng } : null,
-            );
+            ).catch(() => {});
             clearAlarmEvent();
           }}
         />

--- a/src/constants/alarmSilence.ts
+++ b/src/constants/alarmSilence.ts
@@ -1,0 +1,12 @@
+/**
+ * #746 — 사용자가 알람을 dismiss한 직후, 모든 카테고리(destination/transfer/station-passed)
+ * 알람을 한동안 차단하기 위한 정책 상수.
+ *
+ * 정책: dismiss 시점 이후 아래 두 조건 중 *먼저* 만족하는 쪽까지 모든 알람 silence.
+ *  - 시간 경과: DISMISS_SILENCE_MS 이상 경과
+ *  - 위치 이동: dismiss 당시 좌표로부터 DISMISS_SILENCE_RADIUS_M 이상 이동
+ *
+ * dismiss 시점 GPS가 없으면 거리 조건은 평가 불가 — 시간 조건만 사용한다.
+ */
+export const DISMISS_SILENCE_MS = 5 * 60_000;
+export const DISMISS_SILENCE_RADIUS_M = 200;

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -60,6 +60,11 @@ export const LOCKLESS_STATION_PASSED_KEY = 'subway-now:lockless-station-passed';
 // 형식: {"tripKey": string, "promptedAt": number, "dismissedAt"?: number} JSON.
 // tripKey는 `${destinationId}|${createdAtBucketMs}` — destination 변경 시 자동 reset.
 export const BOARDING_PROMPT_STATE_KEY = 'subway-now:boarding-prompt-state';
+// #746 — 사용자가 알람을 dismiss한 시점의 timestamp + 좌표(좌표는 null 가능).
+// dismiss 후 5분 또는 200m 이동까지 모든 카테고리 알람 silence하는 게이트의 SSOT.
+// 형식: {"sinceTs": number, "sinceLat": number | null, "sinceLng": number | null} JSON.
+// 새 trip 시작(setDestination switch) 또는 새 BoardingLock 생성 시 즉시 클리어한다.
+export const DISMISS_SILENCE_KEY = 'subway-now:dismiss-silence';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -2021,28 +2021,42 @@ describe('useStationAlarm', () => {
   describe('#746 dismiss silence 게이트 (FG)', () => {
     const route = makeDirectRoute(3, '2');
     const userLocation = { lat: 37.498, lng: 127.028 };
+    const ALARM_INPUTS = {
+      route,
+      destination,
+      userLocation,
+      speedMps: 10,
+      accuracyMeters: 50,
+      nearestStation: makeStation('S1', '시청', 37.498, 127.028),
+    };
+
+    // 중복 fixture 추출 — SonarCloud new_duplicated_lines_density 3% 임계 준수.
+    function seedSilence(state: { sinceTs: number; sinceLat: number | null; sinceLng: number | null }) {
+      useAppStore.setState({ dismissSilence: state });
+    }
+    function seedActiveSilence(loc: { lat: number; lng: number } | null = null) {
+      seedSilence({
+        sinceTs: Date.now(),
+        sinceLat: loc?.lat ?? null,
+        sinceLng: loc?.lng ?? null,
+      });
+    }
+    function seedExpiredSilence() {
+      seedSilence({ sinceTs: Date.now() - 10 * 60_000, sinceLat: null, sinceLng: null });
+    }
+    function setupApiImminent() {
+      mockGetStoredTripTrainCode.mockResolvedValue('T-1');
+      mockUseArrivalInfo.mockReturnValue({ arrival: { up: [], down: [] }, loading: false, isMock: false });
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+    }
+    function renderForSilence() {
+      renderHook(() => useStationAlarm(defaultInputs(ALARM_INPUTS)));
+    }
 
     it('ETA path: silence 활성이면 phase 알람 차단 + log + return (movement gate 전 단계)', async () => {
-      useAppStore.setState({
-        dismissSilence: {
-          sinceTs: Date.now(),
-          sinceLat: userLocation.lat,
-          sinceLng: userLocation.lng,
-        },
-      });
+      seedActiveSilence(userLocation);
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation,
-            speedMps: 10,
-            accuracyMeters: 50,
-            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
-          }),
-        ),
-      );
+      renderForSilence();
       await waitFor(() =>
         expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -2057,28 +2071,9 @@ describe('useStationAlarm', () => {
     });
 
     it('API imminent path: silence 활성이면 imminent도 차단', async () => {
-      useAppStore.setState({
-        dismissSilence: {
-          sinceTs: Date.now(),
-          sinceLat: null,
-          sinceLng: null,
-        },
-      });
-      mockGetStoredTripTrainCode.mockResolvedValue('T-1');
-      mockUseArrivalInfo.mockReturnValue({ arrival: { up: [], down: [] }, loading: false, isMock: false });
-      mockIsImminentByArrivalCode.mockReturnValue(true);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation,
-            speedMps: 10,
-            accuracyMeters: 50,
-            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
-          }),
-        ),
-      );
+      seedActiveSilence();
+      setupApiImminent();
+      renderForSilence();
       await waitFor(() =>
         expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -2092,32 +2087,14 @@ describe('useStationAlarm', () => {
     });
 
     it('station-passed path: silence 활성이면 알림 차단 + lastNotifiedStationId 갱신 보존', async () => {
-      useAppStore.setState({
-        dismissSilence: {
-          sinceTs: Date.now(),
-          sinceLat: userLocation.lat,
-          sinceLng: userLocation.lng,
-        },
-      });
+      seedActiveSilence(userLocation);
       mockGetLastNotifiedStationId.mockResolvedValue('other-id');
-      const nearestStation = makeStation('S1', '시청', 37.498, 127.028);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation,
-            speedMps: 10,
-            accuracyMeters: 50,
-            nearestStation,
-          }),
-        ),
-      );
+      renderForSilence();
       await waitFor(() =>
         expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
           expect.objectContaining({
             source: 'fg',
-            stationName: nearestStation.name,
+            stationName: ALARM_INPUTS.nearestStation.name,
             kind: 'station-passed',
           }),
         ),
@@ -2128,26 +2105,9 @@ describe('useStationAlarm', () => {
 
     it('silence 만료(시간 5분 초과) → 게이트 통과 + store clear action 호출 (정상 발사)', async () => {
       const setStateSpy = jest.spyOn(useAppStore.getState(), 'clearDismissSilence');
-      useAppStore.setState({
-        dismissSilence: {
-          sinceTs: Date.now() - 10 * 60_000,
-          sinceLat: null,
-          sinceLng: null,
-        },
-      });
+      seedExpiredSilence();
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation,
-            speedMps: 10,
-            accuracyMeters: 50,
-            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
-          }),
-        ),
-      );
+      renderForSilence();
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
       expect(setStateSpy).toHaveBeenCalled();
       setStateSpy.mockRestore();
@@ -2155,51 +2115,23 @@ describe('useStationAlarm', () => {
 
     it('API imminent path: silence 만료(시간) 시 clear 호출 + 정상 발사', async () => {
       const clearSpy = jest.spyOn(useAppStore.getState(), 'clearDismissSilence');
-      useAppStore.setState({
-        dismissSilence: {
-          sinceTs: Date.now() - 10 * 60_000,
-          sinceLat: null,
-          sinceLng: null,
-        },
-      });
-      mockGetStoredTripTrainCode.mockResolvedValue('T-1');
-      mockUseArrivalInfo.mockReturnValue({ arrival: { up: [], down: [] }, loading: false, isMock: false });
-      mockIsImminentByArrivalCode.mockReturnValue(true);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation,
-            speedMps: 10,
-            accuracyMeters: 50,
-            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
-          }),
-        ),
-      );
+      seedExpiredSilence();
+      setupApiImminent();
+      renderForSilence();
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
       expect(clearSpy).toHaveBeenCalled();
       clearSpy.mockRestore();
     });
 
     it('silence 만료(거리 200m 이상) → 게이트 통과', async () => {
-      useAppStore.setState({
-        dismissSilence: {
-          sinceTs: Date.now(),
-          sinceLat: 37.498,
-          sinceLng: 127.028,
-        },
-      });
+      // 0.003도 ≈ 333m. 시간은 fresh지만 좌표 거리로 만료.
+      seedSilence({ sinceTs: Date.now(), sinceLat: 37.498, sinceLng: 127.028 });
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderHook(() =>
         useStationAlarm(
           defaultInputs({
-            route,
-            destination,
-            // 0.003도 ≈ 333m 떨어진 좌표.
+            ...ALARM_INPUTS,
             userLocation: { lat: 37.501, lng: 127.028 },
-            speedMps: 10,
-            accuracyMeters: 50,
             nearestStation: makeStation('S1', '시청', 37.501, 127.028),
           }),
         ),
@@ -2210,18 +2142,7 @@ describe('useStationAlarm', () => {
     it('silence state 없음 → 게이트 통과 (정상 발사)', async () => {
       useAppStore.setState({ dismissSilence: null });
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation,
-            speedMps: 10,
-            accuracyMeters: 50,
-            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
-          }),
-        ),
-      );
+      renderForSilence();
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
       expect(mockLogSuppressedDismissSilence).not.toHaveBeenCalled();
     });
@@ -2231,26 +2152,9 @@ describe('useStationAlarm', () => {
       const clearSpy = jest
         .spyOn(useAppStore.getState(), 'clearDismissSilence')
         .mockRejectedValueOnce(new Error('storage write failed'));
-      useAppStore.setState({
-        dismissSilence: {
-          sinceTs: Date.now() - 10 * 60_000,
-          sinceLat: null,
-          sinceLng: null,
-        },
-      });
+      seedExpiredSilence();
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route,
-            destination,
-            userLocation,
-            speedMps: 10,
-            accuracyMeters: 50,
-            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
-          }),
-        ),
-      );
+      renderForSilence();
       // reject되어도 silence는 통과되어 알람 정상 발사.
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
       expect(clearSpy).toHaveBeenCalled();

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -67,6 +67,7 @@ const mockLogSuppressedDedupAlarm = jest.fn();
 const mockLogSuppressedDedupStation = jest.fn();
 const mockLogSuppressedMovement = jest.fn();
 const mockLogSuppressedSleepFirstTransfer = jest.fn();
+const mockLogSuppressedDismissSilence = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -76,6 +77,7 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedMovement: (...args: unknown[]) => mockLogSuppressedMovement(...args),
   logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
     mockLogSuppressedSleepFirstTransfer(...args),
+  logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
 }));
 
 const mockGetBoardingLock = jest.fn();
@@ -136,7 +138,7 @@ function defaultInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStati
 describe('useStationAlarm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useAppStore.setState({ sleepMode: false, allowSpeaker: true, alarmEvent: null });
+    useAppStore.setState({ sleepMode: false, allowSpeaker: true, alarmEvent: null, dismissSilence: null });
     mockEvaluateAlarmPhase.mockReturnValue(null);
     mockResolveAlarmDirection.mockReturnValue(undefined);
     mockResolveNextTarget.mockReturnValue(null);
@@ -2013,6 +2015,215 @@ describe('useStationAlarm', () => {
       rerender({ lat: 37.50001 });
 
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+    });
+  });
+
+  describe('#746 dismiss silence 게이트 (FG)', () => {
+    const route = makeDirectRoute(3, '2');
+    const userLocation = { lat: 37.498, lng: 127.028 };
+
+    it('ETA path: silence 활성이면 phase 알람 차단 + log + return (movement gate 전 단계)', async () => {
+      useAppStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now(),
+          sinceLat: userLocation.lat,
+          sinceLng: userLocation.lng,
+        },
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation,
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
+          }),
+        ),
+      );
+      await waitFor(() =>
+        expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: earlyDest.stationName,
+            kind: earlyDest.type,
+            phaseId: earlyDest.phaseId,
+          }),
+        ),
+      );
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('API imminent path: silence 활성이면 imminent도 차단', async () => {
+      useAppStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now(),
+          sinceLat: null,
+          sinceLng: null,
+        },
+      });
+      mockGetStoredTripTrainCode.mockResolvedValue('T-1');
+      mockUseArrivalInfo.mockReturnValue({ arrival: { up: [], down: [] }, loading: false, isMock: false });
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation,
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
+          }),
+        ),
+      );
+      await waitFor(() =>
+        expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
+          expect.objectContaining({
+            stationName: imminentDest.stationName,
+            kind: 'destination',
+            phaseId: 'imminent',
+          }),
+        ),
+      );
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('station-passed path: silence 활성이면 알림 차단 + lastNotifiedStationId 갱신 보존', async () => {
+      useAppStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now(),
+          sinceLat: userLocation.lat,
+          sinceLng: userLocation.lng,
+        },
+      });
+      mockGetLastNotifiedStationId.mockResolvedValue('other-id');
+      const nearestStation = makeStation('S1', '시청', 37.498, 127.028);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation,
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation,
+          }),
+        ),
+      );
+      await waitFor(() =>
+        expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: nearestStation.name,
+            kind: 'station-passed',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+    });
+
+    it('silence 만료(시간 5분 초과) → 게이트 통과 + store clear action 호출 (정상 발사)', async () => {
+      const setStateSpy = jest.spyOn(useAppStore.getState(), 'clearDismissSilence');
+      useAppStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now() - 10 * 60_000,
+          sinceLat: null,
+          sinceLng: null,
+        },
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation,
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(setStateSpy).toHaveBeenCalled();
+      setStateSpy.mockRestore();
+    });
+
+    it('API imminent path: silence 만료(시간) 시 clear 호출 + 정상 발사', async () => {
+      const clearSpy = jest.spyOn(useAppStore.getState(), 'clearDismissSilence');
+      useAppStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now() - 10 * 60_000,
+          sinceLat: null,
+          sinceLng: null,
+        },
+      });
+      mockGetStoredTripTrainCode.mockResolvedValue('T-1');
+      mockUseArrivalInfo.mockReturnValue({ arrival: { up: [], down: [] }, loading: false, isMock: false });
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation,
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+
+    it('silence 만료(거리 200m 이상) → 게이트 통과', async () => {
+      useAppStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now(),
+          sinceLat: 37.498,
+          sinceLng: 127.028,
+        },
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            // 0.003도 ≈ 333m 떨어진 좌표.
+            userLocation: { lat: 37.501, lng: 127.028 },
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation: makeStation('S1', '시청', 37.501, 127.028),
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+    });
+
+    it('silence state 없음 → 게이트 통과 (정상 발사)', async () => {
+      useAppStore.setState({ dismissSilence: null });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation,
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedDismissSilence).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/hooks/__tests__/useStationAlarm.test.ts
@@ -2225,5 +2225,36 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
       expect(mockLogSuppressedDismissSilence).not.toHaveBeenCalled();
     });
+
+    it('silence 만료 시 clearAction이 reject되어도 정상 발사 + warn 로그', async () => {
+      // applySilenceGate의 logClearFailure 분기 커버.
+      const clearSpy = jest
+        .spyOn(useAppStore.getState(), 'clearDismissSilence')
+        .mockRejectedValueOnce(new Error('storage write failed'));
+      useAppStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now() - 10 * 60_000,
+          sinceLat: null,
+          sinceLng: null,
+        },
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation,
+            speedMps: 10,
+            accuracyMeters: 50,
+            nearestStation: makeStation('S1', '시청', 37.498, 127.028),
+          }),
+        ),
+      );
+      // reject되어도 silence는 통과되어 알람 정상 발사.
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
   });
 });

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -40,6 +40,39 @@ import { resolveNotificationSource } from '../utils/notificationSource';
 
 const logger = createLogger('StationAlarm');
 
+/**
+ * #746 — dismiss silence 게이트 판정 + 만료 시 store clear 호출.
+ * 3개 effect(phase / imminent / station-passed)에서 evaluate→expired 분기를 반복하던 것을 추출.
+ * 호출부는 반환값의 silenced만 보고 log + return을 직접 처리한다(콜백 미사용 → 익명 함수
+ * 추가 카운팅 방지).
+ *
+ * - silenced=true: 호출부가 logSuppressedDismissSilence 후 즉시 return.
+ * - expired=true:  헬퍼가 clear action을 fire-and-forget으로 호출(실패 무시, 다음 사이클 재시도).
+ *
+ * SonarCloud S3776(cognitive complexity) 해소 — phase effect의 silence 분기 4개를
+ * 단일 호출로 압축. 동시에 S3735(void 연산자)도 Promise chain으로 대체.
+ */
+function applySilenceGate(
+  silence: import('../utils/dismissSilenceStorage').DismissSilenceState | null,
+  now: number,
+  userLocation: { lat: number; lng: number } | null,
+  clearAction: () => Promise<void>,
+): { silenced: boolean } {
+  const decision = evaluateDismissSilence(silence, now, userLocation);
+  if (decision.silenced) return { silenced: true };
+  if (decision.expired) {
+    // expired → store/storage cleanup. test spy 환경에서 undefined 반환 가능성을
+    // Promise.resolve로 정규화하고, 실패는 logger.warn으로 흡수해 익명 catch 핸들러를
+    // 만들지 않는다(커버리지 안정).
+    Promise.resolve(clearAction()).then(undefined, logClearFailure);
+  }
+  return { silenced: false };
+}
+
+function logClearFailure(e: unknown): void {
+  logger.warn('clearDismissSilence 실패 — 다음 사이클 재시도', e);
+}
+
 export interface UseStationAlarmInputs {
   route: Route;
   destination: Station | null;
@@ -314,12 +347,13 @@ export function useStationAlarm({
     if (rawEvent) {
       // #746 — dismiss silence 게이트. 사용자 dismiss 후 5분/200m 이내라면 모든 카테고리 차단.
       // movement/dedup보다 위 — 사용자 명시 정책이 데이터 정확성보다 우선.
-      const silenceDecision = evaluateDismissSilence(
+      const silenceGate = applySilenceGate(
         dismissSilence,
         Date.now(),
         userLocation,
+        clearDismissSilenceAction,
       );
-      if (silenceDecision.silenced) {
+      if (silenceGate.silenced) {
         logSuppressedDismissSilence({
           source: 'fg',
           stationName: rawEvent.stationName,
@@ -327,9 +361,6 @@ export function useStationAlarm({
           phaseId: rawEvent.phaseId,
         });
         return;
-      }
-      if (silenceDecision.expired) {
-        void clearDismissSilenceAction();
       }
       // #733 — Phase ETA path movement gate. early phase는 etaSeconds 무관, remainingStops<=1만
       // 검사하므로 fusion이 인접역으로 jitter하면 즉시 발사. snapshot 1/2에서 관측된 20:07:48 등
@@ -398,12 +429,13 @@ export function useStationAlarm({
     if (firedAlarmsRef.current.has(imminentKey)) return;
 
     // #746 — dismiss silence 게이트. dismiss 후 5분/200m 이내라면 imminent도 차단.
-    const silenceDecision = evaluateDismissSilence(
+    const silenceGate = applySilenceGate(
       dismissSilence,
       Date.now(),
       userLocation,
+      clearDismissSilenceAction,
     );
-    if (silenceDecision.silenced) {
+    if (silenceGate.silenced) {
       logSuppressedDismissSilence({
         source: 'fg',
         stationName: destination.name,
@@ -411,9 +443,6 @@ export function useStationAlarm({
         phaseId: 'imminent',
       });
       return;
-    }
-    if (silenceDecision.expired) {
-      void clearDismissSilenceAction();
     }
 
     // #727 정적 misfire 가드 — useStationAlarm은 timestamp 입력이 없으므로 speed/accuracy만 평가.
@@ -522,21 +551,19 @@ export function useStationAlarm({
 
       // #746 — dismiss silence 게이트. station-passed 카테고리도 동일 정책으로 차단.
       // userLocation 없이도 시간 조건만 평가 가능 — null 좌표 그대로 전달.
-      const silenceDecision = evaluateDismissSilence(
+      const silenceGate = applySilenceGate(
         dismissSilence,
         Date.now(),
         userLocation,
+        clearDismissSilenceAction,
       );
-      if (silenceDecision.silenced) {
+      if (silenceGate.silenced) {
         logSuppressedDismissSilence({
           source: 'fg',
           stationName: candidateStation.name,
           kind: 'station-passed',
         });
         return;
-      }
-      if (silenceDecision.expired) {
-        void clearDismissSilenceAction();
       }
 
       void (async () => {

--- a/src/hooks/useStationAlarm.ts
+++ b/src/hooks/useStationAlarm.ts
@@ -23,9 +23,11 @@ import {
   logFiredStationPassed,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
+  logSuppressedDismissSilence,
   logSuppressedMovement,
   logSuppressedSleepFirstTransfer,
 } from '../utils/alarmLog';
+import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { getBoardingLock } from '../utils/boardingLockStorage';
 import { shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../utils/movementGate';
@@ -123,6 +125,10 @@ export function useStationAlarm({
   const sleepMode = useAppStore((s) => s.sleepMode);
   const allowSpeaker = useAppStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAppStore((s) => s.setAlarmEvent);
+  // #746 — dismiss silence 게이트 평가용 in-memory state. clear는 만료 시점에
+  // store action을 통해 호출(storage도 함께 정리). 게이트 자체는 pure 함수.
+  const dismissSilence = useAppStore((s) => s.dismissSilence);
+  const clearDismissSilenceAction = useAppStore((s) => s.clearDismissSilence);
   const sleepModeRef = useRef(sleepMode);
   const allowSpeakerRef = useRef(allowSpeaker);
 
@@ -306,6 +312,25 @@ export function useStationAlarm({
     // #754: in-flight dedup은 fireAndLog 진입부의 sync firedAlarmsRef.current.add(key) 가
     // 보장한다 (await getBoardingLock 전에 set에 들어가므로 같은 키의 동시 호출은 즉시 return).
     if (rawEvent) {
+      // #746 — dismiss silence 게이트. 사용자 dismiss 후 5분/200m 이내라면 모든 카테고리 차단.
+      // movement/dedup보다 위 — 사용자 명시 정책이 데이터 정확성보다 우선.
+      const silenceDecision = evaluateDismissSilence(
+        dismissSilence,
+        Date.now(),
+        userLocation,
+      );
+      if (silenceDecision.silenced) {
+        logSuppressedDismissSilence({
+          source: 'fg',
+          stationName: rawEvent.stationName,
+          kind: rawEvent.type,
+          phaseId: rawEvent.phaseId,
+        });
+        return;
+      }
+      if (silenceDecision.expired) {
+        void clearDismissSilenceAction();
+      }
       // #733 — Phase ETA path movement gate. early phase는 etaSeconds 무관, remainingStops<=1만
       // 검사하므로 fusion이 인접역으로 jitter하면 즉시 발사. snapshot 1/2에서 관측된 20:07:48 등
       // 정적 transfer-early 회귀 차단.
@@ -348,6 +373,8 @@ export function useStationAlarm({
     positionStability,
     motionStationary,
     skipWarmupGuard,
+    dismissSilence,
+    clearDismissSilenceAction,
   ]);
 
   // #396: 도착정보 API 신호로 imminent 발사.
@@ -369,6 +396,25 @@ export function useStationAlarm({
 
     const imminentKey = `imminent:${destination.name}`;
     if (firedAlarmsRef.current.has(imminentKey)) return;
+
+    // #746 — dismiss silence 게이트. dismiss 후 5분/200m 이내라면 imminent도 차단.
+    const silenceDecision = evaluateDismissSilence(
+      dismissSilence,
+      Date.now(),
+      userLocation,
+    );
+    if (silenceDecision.silenced) {
+      logSuppressedDismissSilence({
+        source: 'fg',
+        stationName: destination.name,
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+      return;
+    }
+    if (silenceDecision.expired) {
+      void clearDismissSilenceAction();
+    }
 
     // #727 정적 misfire 가드 — useStationAlarm은 timestamp 입력이 없으므로 speed/accuracy만 평가.
     // #733 — speed=null 시 positionStability fallback 사용.
@@ -410,6 +456,10 @@ export function useStationAlarm({
     accuracyMeters,
     positionStability,
     motionStationary,
+    dismissSilence,
+    clearDismissSilenceAction,
+    userLocation?.lat,
+    userLocation?.lng,
   ]);
 
   // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.
@@ -470,6 +520,25 @@ export function useStationAlarm({
         return;
       }
 
+      // #746 — dismiss silence 게이트. station-passed 카테고리도 동일 정책으로 차단.
+      // userLocation 없이도 시간 조건만 평가 가능 — null 좌표 그대로 전달.
+      const silenceDecision = evaluateDismissSilence(
+        dismissSilence,
+        Date.now(),
+        userLocation,
+      );
+      if (silenceDecision.silenced) {
+        logSuppressedDismissSilence({
+          source: 'fg',
+          stationName: candidateStation.name,
+          kind: 'station-passed',
+        });
+        return;
+      }
+      if (silenceDecision.expired) {
+        void clearDismissSilenceAction();
+      }
+
       void (async () => {
         try {
           const lastId = await getLastNotifiedStationId();
@@ -511,5 +580,9 @@ export function useStationAlarm({
     accuracyOk,
     arrivalConfirmed,
     movementSuppressionReason,
+    dismissSilence,
+    clearDismissSilenceAction,
+    userLocation?.lat,
+    userLocation?.lng,
   ]);
 }

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -13,7 +13,7 @@ const mockStation: Station = {
   line: '2',
   lineColor: '#009D3E',
   lat: 37.4979,
-  lng: 127.0276,
+  lng: 127276,
 };
 
 const mockStation2: Station = {
@@ -22,7 +22,7 @@ const mockStation2: Station = {
   line: '2',
   lineColor: '#009D3E',
   lat: 37.5006,
-  lng: 127.0365,
+  lng: 127365,
 };
 
 describe('useAppStore', () => {
@@ -1123,18 +1123,18 @@ describe('useAppStore', () => {
   });
 
   it('setDismissSilence: timestamp + 좌표 함께 메모리와 storage에 기록', async () => {
-    await useAppStore.getState().setDismissSilence(1_700_000_000_000, { lat: 37.5, lng: 127.0 });
+    await useAppStore.getState().setDismissSilence(1_700_000_000_000, { lat: 37.5, lng: 127 });
     expect(useAppStore.getState().dismissSilence).toEqual({
       sinceTs: 1_700_000_000_000,
       sinceLat: 37.5,
-      sinceLng: 127.0,
+      sinceLng: 127,
     });
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:dismiss-silence',
       JSON.stringify({
         sinceTs: 1_700_000_000_000,
         sinceLat: 37.5,
-        sinceLng: 127.0,
+        sinceLng: 127,
       }),
     );
   });

--- a/src/store/__tests__/useAppStore.test.ts
+++ b/src/store/__tests__/useAppStore.test.ts
@@ -27,7 +27,7 @@ const mockStation2: Station = {
 
 describe('useAppStore', () => {
   beforeEach(() => {
-    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, tripOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false, locklessStationPassed: false });
+    useAppStore.setState({ favorites: [], destination: null, recentDestination: null, sleepMode: false, allowSpeaker: true, customOrigin: null, tripOrigin: null, themeMode: 'auto', routePreference: 'optimal', localePreference: 'auto', alarmEvent: null, debugVisible: false, accessibilityMode: false, locklessStationPassed: false, dismissSilence: null });
     jest.clearAllMocks();
   });
 
@@ -1114,5 +1114,82 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().debugVisible).toBe(true);
     useAppStore.getState().setDebugVisible(false);
     expect(useAppStore.getState().debugVisible).toBe(false);
+  });
+
+  // ── #746 dismissSilence ──
+
+  it('초기 dismissSilence는 null', () => {
+    expect(useAppStore.getState().dismissSilence).toBeNull();
+  });
+
+  it('setDismissSilence: timestamp + 좌표 함께 메모리와 storage에 기록', async () => {
+    await useAppStore.getState().setDismissSilence(1_700_000_000_000, { lat: 37.5, lng: 127.0 });
+    expect(useAppStore.getState().dismissSilence).toEqual({
+      sinceTs: 1_700_000_000_000,
+      sinceLat: 37.5,
+      sinceLng: 127.0,
+    });
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:dismiss-silence',
+      JSON.stringify({
+        sinceTs: 1_700_000_000_000,
+        sinceLat: 37.5,
+        sinceLng: 127.0,
+      }),
+    );
+  });
+
+  it('setDismissSilence: 좌표 null이면 sinceLat/sinceLng 모두 null로 저장', async () => {
+    await useAppStore.getState().setDismissSilence(42, null);
+    expect(useAppStore.getState().dismissSilence).toEqual({
+      sinceTs: 42,
+      sinceLat: null,
+      sinceLng: null,
+    });
+  });
+
+  it('clearDismissSilence: 메모리와 storage 모두 비운다', async () => {
+    await useAppStore.getState().setDismissSilence(42, { lat: 0, lng: 0 });
+    await useAppStore.getState().clearDismissSilence();
+    expect(useAppStore.getState().dismissSilence).toBeNull();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:dismiss-silence');
+  });
+
+  it('clearDismissSilence: 이미 null이어도 storage clear는 호출(재진입 안전)', async () => {
+    await useAppStore.getState().clearDismissSilence();
+    expect(useAppStore.getState().dismissSilence).toBeNull();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:dismiss-silence');
+  });
+
+  it('loadDismissSilence: storage에서 hydrate', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify({ sinceTs: 99, sinceLat: 1, sinceLng: 2 }),
+    );
+    await useAppStore.getState().loadDismissSilence();
+    expect(useAppStore.getState().dismissSilence).toEqual({
+      sinceTs: 99,
+      sinceLat: 1,
+      sinceLng: 2,
+    });
+  });
+
+  it('setDestination 으로 새 destination 설정 시 dismissSilence는 즉시 클리어', async () => {
+    await useAppStore.getState().setDismissSilence(1, { lat: 0, lng: 0 });
+    expect(useAppStore.getState().dismissSilence).not.toBeNull();
+    // 새 destination 진입 (switch).
+    useAppStore.getState().setDestination(mockStation);
+    expect(useAppStore.getState().dismissSilence).toBeNull();
+  });
+
+  it('setDestination: 같은 destination 재설정(isSwitch=false)이면 dismissSilence 유지', async () => {
+    useAppStore.setState({ destination: mockStation });
+    await useAppStore.getState().setDismissSilence(1, { lat: 0, lng: 0 });
+    // 같은 destination 재설정 — storage clear 분기는 미실행.
+    useAppStore.getState().setDestination(mockStation);
+    expect(useAppStore.getState().dismissSilence).toEqual({
+      sinceTs: 1,
+      sinceLat: 0,
+      sinceLng: 0,
+    });
   });
 });

--- a/src/store/__tests__/useBoardingLockStore.test.ts
+++ b/src/store/__tests__/useBoardingLockStore.test.ts
@@ -5,11 +5,16 @@ import type { BoardingLock } from '../../types/boardingLock';
 const mockGetBoardingLock = jest.fn();
 const mockSetBoardingLock = jest.fn();
 const mockClearBoardingLock = jest.fn();
+const mockClearDismissSilence = jest.fn();
 
 jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
   setBoardingLock: (...args: unknown[]) => mockSetBoardingLock(...args),
   clearBoardingLock: (...args: unknown[]) => mockClearBoardingLock(...args),
+}));
+
+jest.mock('../../utils/dismissSilenceStorage', () => ({
+  clearDismissSilence: (...args: unknown[]) => mockClearDismissSilence(...args),
 }));
 
 const sample: BoardingLock = {
@@ -26,6 +31,7 @@ describe('useBoardingLockStore', () => {
     jest.clearAllMocks();
     mockSetBoardingLock.mockResolvedValue(undefined);
     mockClearBoardingLock.mockResolvedValue(undefined);
+    mockClearDismissSilence.mockResolvedValue(undefined);
     useBoardingLockStore.setState({ lock: null });
   });
 
@@ -52,6 +58,13 @@ describe('useBoardingLockStore', () => {
       });
       expect(useBoardingLockStore.getState().lock).toEqual(next);
       expect(mockSetBoardingLock).toHaveBeenLastCalledWith(next);
+    });
+
+    it('#746 — createLock은 dismissSilence storage를 즉시 클리어', async () => {
+      await act(async () => {
+        await useBoardingLockStore.getState().createLock(sample);
+      });
+      expect(mockClearDismissSilence).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/store/tripBoundCleanups.ts
+++ b/src/store/tripBoundCleanups.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/notificationState';
 import { clearFiredPushIds } from '../utils/firedPushIds';
 import { clearTripTrainCode } from '../utils/tripTrainCode';
+import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dismissSilenceStorage';
 
 // trip-bound storage cleanup 단일 출처.
 // useAppStore.setDestination이 isSwitch(목적지 변경 또는 null 클리어) 분기에서 호출한다.
@@ -42,6 +43,8 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   clearFiredPushIds,
   clearTripTrainCode,
   () => AsyncStorage.removeItem(ALARM_EVENT_KEY),
+  // #746 — 새 trip 시작 시 이전 trip의 dismiss silence는 무효 → 즉시 클리어.
+  clearDismissSilenceStorage,
 ];
 
 /**

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -9,6 +9,11 @@ function demoteSlotEntries(entries: FavoriteEntry[], role: FavoriteSlotRole): Fa
 import type { AlarmEvent } from '../utils/stationAlarm';
 import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, TRIP_ORIGIN_KEY, LOCKLESS_STATION_PASSED_KEY } from '../constants/storageKeys';
 import { runTripBoundCleanups } from './tripBoundCleanups';
+import {
+  setDismissSilence as setDismissSilenceStorage,
+  getDismissSilence as getDismissSilenceStorage,
+  type DismissSilenceState,
+} from '../utils/dismissSilenceStorage';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../utils/stationRoute';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n/types';
 
@@ -74,6 +79,15 @@ interface AppState {
   setAlarmEvent: (event: AlarmEvent) => void;
   clearAlarmEvent: () => void;
   loadAlarmEvent: () => Promise<void>;
+  /**
+   * #746 — 사용자가 알람을 dismiss한 시점 기록. 5분 또는 200m 이내까지 모든 카테고리
+   * 알람을 차단한다. AsyncStorage SSOT(DISMISS_SILENCE_KEY)와 in-memory mirror 동기 유지.
+   * BG path는 storage helper(getDismissSilence)를 직접 read.
+   */
+  dismissSilence: DismissSilenceState | null;
+  setDismissSilence: (now: number, position: { lat: number; lng: number } | null) => Promise<void>;
+  clearDismissSilence: () => Promise<void>;
+  loadDismissSilence: () => Promise<void>;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -91,6 +105,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   debugVisible: false,
   accessibilityMode: false,
   locklessStationPassed: false,
+  dismissSilence: null,
 
   setDebugVisible: (visible: boolean) => {
     set({ debugVisible: visible });
@@ -211,8 +226,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (isSwitch) {
       // trip-bound storage 키 cleanup은 단일 메타 배열에서 일괄 실행한다.
       // 새 trip-bound 키 추가 시 src/store/tripBoundCleanups.ts에 한 줄만 추가하면
-      // setDestination에서 누락 회귀가 차단된다. (#702 → #799 사이 LAST_FIRED_ALARM_STATION_NAME_KEY 등
-      // 호출부에서 빠졌던 사례 재발 방지.)
+      // setDestination에서 누락 회귀가 차단된다. (#702 → #799 사이 LAST_FIRED_ALARM_STATION_NAME_KEY,
+      // #746 dismissSilence 등 누락 사례 재발 방지.)
       runTripBoundCleanups().catch(noop);
       // customOrigin 메모리 상태도 동기화. (loadCustomOrigin은 hydration용이므로 영향 없음)
       if (get().customOrigin !== null) {
@@ -221,6 +236,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       // alarmEvent 메모리 상태도 동기화 — clearAlarmEvent와 같은 set, 재진입 안전.
       if (get().alarmEvent !== null) {
         set({ alarmEvent: null });
+      }
+      // #746: dismissSilence 메모리 상태도 동기화 — storage clear와 같은 set, 재진입 안전.
+      if (get().dismissSilence !== null) {
+        set({ dismissSilence: null });
       }
     }
   },
@@ -424,6 +443,31 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch {
       // 저장된 데이터 없음 — false 유지
     }
+  },
+
+  // #746 — 사용자가 알람을 dismiss하면 silence 시작점을 기록. 좌표는 호출자가 마지막 알려진
+  // 사용자 위치를 전달 — GPS 미가용 시 null을 넘기면 거리 조건은 미평가되고 시간 조건만 활성.
+  // 메모리/storage 양쪽 동기 — BG 게이트가 storage helper로 직접 read해도 일관.
+  setDismissSilence: async (now, position) => {
+    const next: DismissSilenceState = {
+      sinceTs: now,
+      sinceLat: position?.lat ?? null,
+      sinceLng: position?.lng ?? null,
+    };
+    set({ dismissSilence: next });
+    await setDismissSilenceStorage(next);
+  },
+
+  clearDismissSilence: async () => {
+    if (get().dismissSilence !== null) {
+      set({ dismissSilence: null });
+    }
+    await clearDismissSilenceStorage();
+  },
+
+  loadDismissSilence: async () => {
+    const stored = await getDismissSilenceStorage();
+    set({ dismissSilence: stored });
   },
 
 }));

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -10,6 +10,7 @@ import type { AlarmEvent } from '../utils/stationAlarm';
 import { FAVORITES_KEY, SLEEP_MODE_KEY, DESTINATION_KEY, ALARM_EVENT_KEY, CUSTOM_ORIGIN_KEY, THEME_MODE_KEY, ROUTE_PREFERENCE_KEY, ALLOW_SPEAKER_KEY, LOCALE_PREFERENCE_KEY, ACCESSIBILITY_MODE_KEY, TRIP_ORIGIN_KEY, LOCKLESS_STATION_PASSED_KEY } from '../constants/storageKeys';
 import { runTripBoundCleanups } from './tripBoundCleanups';
 import {
+  clearDismissSilence as clearDismissSilenceStorage,
   setDismissSilence as setDismissSilenceStorage,
   getDismissSilence as getDismissSilenceStorage,
   type DismissSilenceState,

--- a/src/store/useBoardingLockStore.ts
+++ b/src/store/useBoardingLockStore.ts
@@ -6,6 +6,7 @@ import {
   getBoardingLock,
   setBoardingLock,
 } from '../utils/boardingLockStorage';
+import { clearDismissSilence } from '../utils/dismissSilenceStorage';
 
 /**
  * BoardingLock 전역 store (#584 PR A).
@@ -35,6 +36,9 @@ export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
   createLock: async (lock: BoardingLock) => {
     set({ lock });
     await setBoardingLock(lock);
+    // #746: 새 lock 생성 = 사용자가 새 leg에 탑승 의사 명시 → 이전 dismiss silence는 무효.
+    // 동일 trip 내 환승으로 lock이 교체되는 경우에도 같은 의미 — 즉시 클리어.
+    await clearDismissSilence();
   },
 
   releaseLock: async () => {

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -77,6 +77,13 @@ jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
 }));
 
+const mockGetDismissSilence = jest.fn();
+const mockClearDismissSilence = jest.fn();
+jest.mock('../../utils/dismissSilenceStorage', () => ({
+  getDismissSilence: (...args: unknown[]) => mockGetDismissSilence(...args),
+  clearDismissSilence: (...args: unknown[]) => mockClearDismissSilence(...args),
+}));
+
 const mockFindStationByNameAndLine = jest.fn();
 const mockFindStationByName = jest.fn();
 jest.mock('../../utils/stationLookup', () => ({
@@ -183,6 +190,9 @@ describe('silentPushTask', () => {
     // 기본 lookup 모두 null → line 가드는 graceful pass(stations.json 어디에도 없음 가정).
     mockFindStationByNameAndLine.mockReturnValue(null);
     mockFindStationByName.mockReturnValue(null);
+    // #746 — 기본 silence 없음.
+    mockGetDismissSilence.mockResolvedValue(null);
+    mockClearDismissSilence.mockResolvedValue(undefined);
   });
 
   it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
@@ -1102,6 +1112,62 @@ describe('silentPushTask', () => {
         await handleSilentPush(reschedulePayload({ pushId: 'rs-uuid' }));
         expect(mockSendPushAck).not.toHaveBeenCalled();
         expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('#746 dismiss silence 게이트 (BG silent push)', () => {
+      it('silence 활성이면 발사 차단 + logSilentPushSkipped(reason=dismiss-silence) + ACK skip', async () => {
+        mockGetDismissSilence.mockResolvedValue({
+          sinceTs: Date.now(),
+          sinceLat: null,
+          sinceLng: null,
+        });
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent', pushId: 'p1' }));
+        expect(mockCheckGate).not.toHaveBeenCalled();
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: 'dismiss-silence',
+            stationName: '강남',
+            kind: 'destination',
+            phaseId: 'imminent',
+          }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          expect.objectContaining({ outcome: 'skipped', reason: 'dismiss-silence' }),
+        );
+      });
+
+      it('silence 만료 시 clear 호출 + 정상 발사 path로 진입(checkGate 호출)', async () => {
+        mockGetDismissSilence.mockResolvedValue({
+          sinceTs: Date.now() - 10 * 60_000,
+          sinceLat: null,
+          sinceLng: null,
+        });
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockClearDismissSilence).toHaveBeenCalledTimes(1);
+        expect(mockCheckGate).toHaveBeenCalled();
+      });
+
+      it('intermediate 카테고리도 silence가 차단(kind=station-passed로 log)', async () => {
+        mockGetDismissSilence.mockResolvedValue({
+          sinceTs: Date.now(),
+          sinceLat: null,
+          sinceLng: null,
+        });
+        await handleSilentPush(payload({ kind: 'intermediate', phase: 'early', pushId: 'p2' }));
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: 'dismiss-silence',
+            kind: 'station-passed',
+          }),
+        );
+      });
+
+      it('silence state null이면 정상 path로 진입', async () => {
+        mockGetDismissSilence.mockResolvedValue(null);
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockCheckGate).toHaveBeenCalled();
       });
     });
   });

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -35,6 +35,8 @@ import {
   logSilentPushSkipped,
   type AlarmLogReason,
 } from '../utils/alarmLog';
+import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
+import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../utils/movementGate';
 import { getCurrentMotionStationary } from '../utils/motionActivity';
 import { addFiredPushId } from '../utils/firedPushIds';
@@ -430,6 +432,27 @@ async function fireWithGate(
       logger.info(`lockless skip opt-out: station=${payload.nextWaypoint}`);
       return;
     }
+  }
+
+  // #746 — dismiss silence 게이트. BG path는 좌표 신뢰성이 낮아 시간 조건만 평가
+  //   (currentPosition=null). lock/lockless 분기 통과 후 위치 게이트보다 위에 위치해
+  //   사용자 정책이 데이터 정확성보다 우선되도록 한다.
+  const dismissSilenceState = await getDismissSilence();
+  const silenceDecision = evaluateDismissSilence(dismissSilenceState, Date.now(), null);
+  if (!silenceDecision.silenced && silenceDecision.expired) {
+    await clearDismissSilence();
+  }
+  if (silenceDecision.silenced) {
+    const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
+    logSilentPushSkipped({
+      stationName: payload.nextWaypoint,
+      kind: logKind,
+      phaseId: payload.phase,
+      reason: 'dismiss-silence',
+    });
+    ackOutcome(payload.pushId, apnsToken, 'skipped', 'dismiss-silence');
+    logger.info(`dismiss-silence skip: station=${payload.nextWaypoint}`);
+    return;
   }
 
   const gate = await checkSilentPushLocationGate({

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -26,6 +26,7 @@ import {
   FLUSH_DEBOUNCE_MS,
   FLUSH_MAX_DELAY_MS,
   logSuppressedDedupStation,
+  logSuppressedDismissSilence,
   logSuppressedGate,
   logSuppressedMovement,
   logSilentPushReceived,
@@ -481,6 +482,44 @@ describe('alarmLog', () => {
         kind: 'destination',
         phaseId: 'early',
       });
+    });
+
+    it('logSuppressedDismissSilence: reason=dismiss-silence + source/kind/phaseId 보존 (#746)', async () => {
+      logSuppressedDismissSilence({
+        source: 'fg',
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'early',
+      });
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dismiss-silence',
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'early',
+      });
+    });
+
+    it('logSuppressedDismissSilence: phaseId 미전달 시에도 적재 (station-passed kind)', async () => {
+      logSuppressedDismissSilence({
+        source: 'bg',
+        stationName: '시청',
+        kind: 'station-passed',
+      });
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'dismiss-silence',
+        kind: 'station-passed',
+      });
+      expect(saved[0].phaseId).toBeUndefined();
     });
 
     it('#626 같은 키 윈도우 내 재호출은 drop (FG polling 매초 평가 스팸 차단)', async () => {

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -423,6 +423,18 @@ describe('alarmLog', () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     });
 
+    // 마지막 setItem 호출에 저장된 첫 엔트리가 matchers와 일치하는지 검증.
+    // log helper 테스트들의 flush + JSON.parse + toMatchObject 반복 패턴 추출
+    // (SonarCloud new_duplicated_lines_density 임계 준수).
+    async function expectLastSavedEntryMatches(matchers: Partial<AlarmLogEntry>): Promise<AlarmLogEntry> {
+      await flushAlarmLog();
+      const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+      const [, savedJson] = calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject(matchers);
+      return saved[0];
+    }
+
     it('logFiredAlarm: source + event를 outcome=fired로 적재한다', async () => {
       logFiredAlarm('fg', event);
       await flushAlarmLog();
@@ -470,11 +482,7 @@ describe('alarmLog', () => {
 
     it('logSuppressedDedupAlarm: reason=dedup-alarm, phase+type+stationName 적재 (#580)', async () => {
       logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '강남' });
-      await flushAlarmLog();
-
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved[0]).toMatchObject({
+      await expectLastSavedEntryMatches({
         source: 'fg',
         outcome: 'suppressed',
         reason: 'dedup-alarm',
@@ -491,10 +499,7 @@ describe('alarmLog', () => {
         kind: 'destination',
         phaseId: 'early',
       });
-      await flushAlarmLog();
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved[0]).toMatchObject({
+      await expectLastSavedEntryMatches({
         source: 'fg',
         outcome: 'suppressed',
         reason: 'dismiss-silence',
@@ -510,16 +515,13 @@ describe('alarmLog', () => {
         stationName: '시청',
         kind: 'station-passed',
       });
-      await flushAlarmLog();
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved[0]).toMatchObject({
+      const entry = await expectLastSavedEntryMatches({
         source: 'bg',
         outcome: 'suppressed',
         reason: 'dismiss-silence',
         kind: 'station-passed',
       });
-      expect(saved[0].phaseId).toBeUndefined();
+      expect(entry.phaseId).toBeUndefined();
     });
 
     it('#626 같은 키 윈도우 내 재호출은 drop (FG polling 매초 평가 스팸 차단)', async () => {

--- a/src/utils/__tests__/dismissSilenceGate.test.ts
+++ b/src/utils/__tests__/dismissSilenceGate.test.ts
@@ -1,0 +1,70 @@
+import { evaluateDismissSilence } from '../dismissSilenceGate';
+import {
+  DISMISS_SILENCE_MS,
+  DISMISS_SILENCE_RADIUS_M,
+} from '../../constants/alarmSilence';
+
+const SEOUL = { lat: 37.5665, lng: 126.978 };
+
+describe('evaluateDismissSilence', () => {
+  it('state가 null이면 silence 없음, expired=false', () => {
+    const decision = evaluateDismissSilence(null, 1_000, SEOUL);
+    expect(decision).toEqual({ silenced: false, expired: false });
+  });
+
+  it('5분 미만 + 좌표 미공급(state null lat/lng)이면 시간만 평가해 silenced=true', () => {
+    const state = { sinceTs: 0, sinceLat: null, sinceLng: null };
+    const decision = evaluateDismissSilence(state, DISMISS_SILENCE_MS - 1, null);
+    expect(decision).toEqual({ silenced: true });
+  });
+
+  it('5분 미만 + state 좌표 + 현재 좌표 동일이면 silenced=true', () => {
+    const state = { sinceTs: 0, sinceLat: SEOUL.lat, sinceLng: SEOUL.lng };
+    const decision = evaluateDismissSilence(state, 60_000, SEOUL);
+    expect(decision).toEqual({ silenced: true });
+  });
+
+  it('정확히 5분 경과면 시간 만료 — silenced=false, expired=true', () => {
+    const state = { sinceTs: 0, sinceLat: null, sinceLng: null };
+    const decision = evaluateDismissSilence(state, DISMISS_SILENCE_MS, null);
+    expect(decision).toEqual({ silenced: false, expired: true });
+  });
+
+  it('5분 초과면 시간 만료', () => {
+    const state = { sinceTs: 0, sinceLat: SEOUL.lat, sinceLng: SEOUL.lng };
+    const decision = evaluateDismissSilence(state, DISMISS_SILENCE_MS + 1, SEOUL);
+    expect(decision).toEqual({ silenced: false, expired: true });
+  });
+
+  it('200m 이상 이동하면 거리 만료', () => {
+    // 위도 1도 ≈ 111km → 0.003도 ≈ 333m
+    const state = { sinceTs: 0, sinceLat: SEOUL.lat, sinceLng: SEOUL.lng };
+    const farther = { lat: SEOUL.lat + 0.003, lng: SEOUL.lng };
+    const decision = evaluateDismissSilence(state, 60_000, farther);
+    expect(decision).toEqual({ silenced: false, expired: true });
+  });
+
+  it('200m 미만 이동 + 시간 미경과면 여전히 silenced', () => {
+    // 0.001도 ≈ 111m
+    const state = { sinceTs: 0, sinceLat: SEOUL.lat, sinceLng: SEOUL.lng };
+    const closer = { lat: SEOUL.lat + 0.001, lng: SEOUL.lng };
+    const decision = evaluateDismissSilence(state, 60_000, closer);
+    expect(decision).toEqual({ silenced: true });
+  });
+
+  it('state에 좌표 있지만 현재 좌표 null이면 거리 평가 skip — 시간만 본다', () => {
+    const state = { sinceTs: 0, sinceLat: SEOUL.lat, sinceLng: SEOUL.lng };
+    const decision = evaluateDismissSilence(state, 60_000, null);
+    expect(decision).toEqual({ silenced: true });
+  });
+
+  it('200m + 1cm 거리 = 거리 만료(>= 임계)', () => {
+    // 위도 1도 ≈ 111.19km/도. 임계 + 0.01m 만큼만 띄워 부동소수 부정확성에 안전한 경계 케이스.
+    const metersPerDegree = 111_194.93;
+    const deltaLat = (DISMISS_SILENCE_RADIUS_M + 0.01) / metersPerDegree;
+    const state = { sinceTs: 0, sinceLat: SEOUL.lat, sinceLng: SEOUL.lng };
+    const justOver = { lat: SEOUL.lat + deltaLat, lng: SEOUL.lng };
+    const decision = evaluateDismissSilence(state, 60_000, justOver);
+    expect(decision).toEqual({ silenced: false, expired: true });
+  });
+});

--- a/src/utils/__tests__/dismissSilenceStorage.test.ts
+++ b/src/utils/__tests__/dismissSilenceStorage.test.ts
@@ -1,0 +1,100 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  clearDismissSilence,
+  getDismissSilence,
+  setDismissSilence,
+} from '../dismissSilenceStorage';
+import { DISMISS_SILENCE_KEY } from '../../constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const sample = { sinceTs: 1_700_000_000_000, sinceLat: 37.5, sinceLng: 127.0 };
+
+describe('dismissSilenceStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getDismissSilence', () => {
+    it('AsyncStorage가 null이면 null 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      expect(await getDismissSilence()).toBeNull();
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(DISMISS_SILENCE_KEY);
+    });
+
+    it('유효한 JSON을 그대로 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(sample));
+      expect(await getDismissSilence()).toEqual(sample);
+    });
+
+    it('좌표 null인 유효한 entry도 그대로 반환 (시간 단독 silence)', async () => {
+      const noPos = { sinceTs: 1, sinceLat: null, sinceLng: null };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(noPos));
+      expect(await getDismissSilence()).toEqual(noPos);
+    });
+
+    it('파싱 실패 시 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+      expect(await getDismissSilence()).toBeNull();
+    });
+
+    it('sinceTs 누락 시 null', async () => {
+      const broken = { sinceLat: 0, sinceLng: 0 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getDismissSilence()).toBeNull();
+    });
+
+    it('sinceLat 타입 오염 시 null', async () => {
+      const broken = { sinceTs: 1, sinceLat: 'x', sinceLng: 0 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getDismissSilence()).toBeNull();
+    });
+
+    it('sinceLng 타입 오염 시 null', async () => {
+      const broken = { sinceTs: 1, sinceLat: 0, sinceLng: 'x' };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getDismissSilence()).toBeNull();
+    });
+
+    it('루트가 객체가 아니면 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify('a string'));
+      expect(await getDismissSilence()).toBeNull();
+    });
+
+    it('AsyncStorage 오류 시 null (graceful)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      expect(await getDismissSilence()).toBeNull();
+    });
+  });
+
+  describe('setDismissSilence', () => {
+    it('state를 JSON 직렬화해 저장', async () => {
+      await setDismissSilence(sample);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        DISMISS_SILENCE_KEY,
+        JSON.stringify(sample),
+      );
+    });
+
+    it('AsyncStorage 오류 시 throw 없이 swallow', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      await expect(setDismissSilence(sample)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearDismissSilence', () => {
+    it('DISMISS_SILENCE_KEY 제거', async () => {
+      await clearDismissSilence();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(DISMISS_SILENCE_KEY);
+    });
+
+    it('AsyncStorage 오류 시 swallow', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      await expect(clearDismissSilence()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/__tests__/dismissSilenceStorage.test.ts
+++ b/src/utils/__tests__/dismissSilenceStorage.test.ts
@@ -12,7 +12,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(),
 }));
 
-const sample = { sinceTs: 1_700_000_000_000, sinceLat: 37.5, sinceLng: 127.0 };
+const sample = { sinceTs: 1_700_000_000_000, sinceLat: 37.5, sinceLng: 127 };
 
 describe('dismissSilenceStorage', () => {
   beforeEach(() => {

--- a/src/utils/__tests__/stationPipeline.test.ts
+++ b/src/utils/__tests__/stationPipeline.test.ts
@@ -39,6 +39,13 @@ jest.mock('../boardingLockStorage', () => ({
   getBoardingLock: () => mockGetBoardingLock(),
 }));
 
+const mockGetDismissSilence = jest.fn();
+const mockClearDismissSilence = jest.fn();
+jest.mock('../dismissSilenceStorage', () => ({
+  getDismissSilence: (...args: unknown[]) => mockGetDismissSilence(...args),
+  clearDismissSilence: (...args: unknown[]) => mockClearDismissSilence(...args),
+}));
+
 const mockAdvanceHopWindow = jest.fn().mockResolvedValue(undefined);
 jest.mock('../boardingLockScheduler', () => ({
   advanceHopWindow: (...args: unknown[]) => mockAdvanceHopWindow(...args),
@@ -65,6 +72,7 @@ const mockLogFiredStationPassed = jest.fn();
 const mockLogSuppressedDedupStation = jest.fn();
 const mockLogSuppressedDedupAlarm = jest.fn();
 const mockLogSuppressedSleepFirstTransfer = jest.fn();
+const mockLogSuppressedDismissSilence = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -72,6 +80,7 @@ jest.mock('../alarmLog', () => ({
   logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
   logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
     mockLogSuppressedSleepFirstTransfer(...args),
+  logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
 }));
 
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
@@ -133,6 +142,9 @@ describe('processLocationUpdate', () => {
     mockResolveAllTargets.mockReturnValue([
       { name: '시청', stops: 3, alarmType: 'destination', approachLine: '2' },
     ]);
+    // #746: dismissSilence 기본은 null — silence 없음.
+    mockGetDismissSilence.mockResolvedValue(null);
+    mockClearDismissSilence.mockResolvedValue(undefined);
   });
 
   it('returns null nearest and null alarm when findNearestStation returns null', async () => {
@@ -794,6 +806,98 @@ describe('processLocationUpdate', () => {
       await call({ sleepMode: true });
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#746 dismiss silence 게이트 (BG path)', () => {
+    beforeEach(() => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockIsStationOnRoute.mockReturnValue(true);
+    });
+
+    it('silence 활성이면 phase 알람 발사 차단 + suppress reason 로그', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+      // 시간/거리 모두 silence 범위.
+      mockGetDismissSilence.mockResolvedValue({
+        sinceTs: Date.now(),
+        sinceLat: 37.498,
+        sinceLng: 127.028,
+      });
+      const result = await call({ source: 'bg' });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'bg',
+          stationName: mockAlarmEvent.stationName,
+          kind: mockAlarmEvent.type,
+          phaseId: mockAlarmEvent.phaseId,
+        }),
+      );
+      // 반환 alarmEvent는 null로 정정 (caller가 sleep overlay 등에 표시하지 않도록).
+      expect(result.alarmEvent).toBeNull();
+    });
+
+    it('silence 활성이면 station-passed 알림도 차단 + lastNotifiedStationId 갱신 보존', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue('other-id');
+      mockGetDismissSilence.mockResolvedValue({
+        sinceTs: Date.now(),
+        sinceLat: 37.498,
+        sinceLng: 127.028,
+      });
+      await call({ source: 'bg' });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+      expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'bg',
+          stationName: mockStation.name,
+          kind: 'station-passed',
+        }),
+      );
+    });
+
+    it('silence 만료(시간) 시 게이트 통과 + storage clear 호출', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+      mockGetDismissSilence.mockResolvedValue({
+        sinceTs: Date.now() - 10 * 60_000,
+        sinceLat: null,
+        sinceLng: null,
+      });
+      await call({ source: 'bg' });
+      expect(mockClearDismissSilence).toHaveBeenCalledTimes(1);
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+    });
+
+    it('silence state 좌표 null(=GPS-less dismiss)이면 거리 평가 skip — 시간 조건만 활성', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+      mockGetDismissSilence.mockResolvedValue({
+        sinceTs: Date.now(),
+        sinceLat: null,
+        sinceLng: null,
+      });
+      // 사용자가 1km 떨어진 좌표여도 시간 조건이 silence이므로 차단.
+      await call({ source: 'bg', lat: 37.6, lng: 127.1 });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('silence state 없음(null) → 정상 발사', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+      mockGetDismissSilence.mockResolvedValue(null);
+      await call({ source: 'bg' });
+      expect(mockLogSuppressedDismissSilence).not.toHaveBeenCalled();
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+    });
+
+    it('silence 활성이어도 updateStationNotification(UI)은 계속 호출 — silence는 알람만 차단', async () => {
+      mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+      mockGetDismissSilence.mockResolvedValue({
+        sinceTs: Date.now(),
+        sinceLat: null,
+        sinceLng: null,
+      });
+      await call({ source: 'bg' });
+      expect(mockUpdateStationNotification).toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -80,7 +80,9 @@ export type AlarmLogReason =
   //   'lockless-non-intermediate': lock 없는 trip에 transfer/destination push 도달 (backend race).
   //   'lockless-opt-out': 사용자 토글 OFF 상태에서 lockless intermediate push 도달.
   | 'lockless-non-intermediate'
-  | 'lockless-opt-out';
+  | 'lockless-opt-out'
+  // #746 — 사용자가 알람을 dismiss한 직후 5분 또는 200m 이내 동안 모든 카테고리 차단.
+  | 'dismiss-silence';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -460,6 +462,28 @@ export function logSuppressedMovement(input: {
     source: input.source,
     outcome: 'suppressed',
     reason: input.reason,
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #746 — dismiss silence 게이트가 차단한 알람 1건 적재.
+ * source는 호출 path를 식별: FG polling은 'fg', BG location task는 'bg',
+ * silent push BG handler는 'silent-push-skipped'.
+ */
+export function logSuppressedDismissSilence(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'dismiss-silence',
     stationName: input.stationName,
     kind: input.kind,
     phaseId: input.phaseId,

--- a/src/utils/dismissSilenceGate.ts
+++ b/src/utils/dismissSilenceGate.ts
@@ -1,0 +1,45 @@
+import { haversine } from './haversine';
+import { DISMISS_SILENCE_MS, DISMISS_SILENCE_RADIUS_M } from '../constants/alarmSilence';
+import type { DismissSilenceState } from './dismissSilenceStorage';
+
+export type DismissSilenceDecision =
+  | { silenced: true }
+  | { silenced: false; expired: boolean };
+
+/**
+ * #746 — 사용자가 알람을 dismiss한 후의 silence 게이트.
+ *
+ * 활성 조건:
+ *  - state가 null이면 즉시 통과(silenced=false, expired=false).
+ *  - `now - state.sinceTs >= DISMISS_SILENCE_MS` 이면 시간 만료 → silenced=false, expired=true.
+ *  - state에 좌표가 있고 currentPosition이 주어졌으며 두 점 사이 거리 >= DISMISS_SILENCE_RADIUS_M
+ *    이면 거리 만료 → silenced=false, expired=true.
+ *  - 그 외엔 silenced=true.
+ *
+ * 좌표 한쪽이라도 누락(state가 dismiss 시 GPS 없음, 또는 현재 GPS 없음)이면 거리 평가는
+ * 건너뛰고 시간 조건만 사용한다 — 누락 자체로 silence를 해제하지 않는다.
+ *
+ * 호출자는 expired=true를 받으면 dismissSilenceStorage.clearDismissSilence()를 호출해 stale
+ * 항목을 정리한다 — 게이트 자체는 순수 함수로 IO 없음.
+ */
+export function evaluateDismissSilence(
+  state: DismissSilenceState | null,
+  now: number,
+  currentPosition: { lat: number; lng: number } | null,
+): DismissSilenceDecision {
+  if (!state) return { silenced: false, expired: false };
+
+  if (now - state.sinceTs >= DISMISS_SILENCE_MS) {
+    return { silenced: false, expired: true };
+  }
+
+  if (state.sinceLat != null && state.sinceLng != null && currentPosition) {
+    const distanceM =
+      haversine(state.sinceLat, state.sinceLng, currentPosition.lat, currentPosition.lng) * 1000;
+    if (distanceM >= DISMISS_SILENCE_RADIUS_M) {
+      return { silenced: false, expired: true };
+    }
+  }
+
+  return { silenced: true };
+}

--- a/src/utils/dismissSilenceStorage.ts
+++ b/src/utils/dismissSilenceStorage.ts
@@ -1,0 +1,57 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { DISMISS_SILENCE_KEY } from '../constants/storageKeys';
+
+/**
+ * #746 — dismiss silence 상태. dismiss 시점의 timestamp와 좌표.
+ * 좌표는 GPS 미가용 시 null — 이 경우 거리 조건은 평가 불가하고 시간 조건만 평가된다.
+ */
+export interface DismissSilenceState {
+  sinceTs: number;
+  sinceLat: number | null;
+  sinceLng: number | null;
+}
+
+/**
+ * FG/BG 어디서든 동일하게 read 가능한 storage SSOT. 호출자는 await 후
+ * dismissSilenceGate(state, now, currentPosition)로 활성 여부를 판정한다.
+ *
+ * parse 실패/키 부재 시 null — 이전 dismiss 기록 없음(또는 만료/clear됨)을 의미.
+ */
+export async function getDismissSilence(): Promise<DismissSilenceState | null> {
+  try {
+    const raw = await AsyncStorage.getItem(DISMISS_SILENCE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<DismissSilenceState> | null;
+    if (
+      parsed &&
+      typeof parsed.sinceTs === 'number' &&
+      (parsed.sinceLat === null || typeof parsed.sinceLat === 'number') &&
+      (parsed.sinceLng === null || typeof parsed.sinceLng === 'number')
+    ) {
+      return {
+        sinceTs: parsed.sinceTs,
+        sinceLat: parsed.sinceLat,
+        sinceLng: parsed.sinceLng,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setDismissSilence(state: DismissSilenceState): Promise<void> {
+  try {
+    await AsyncStorage.setItem(DISMISS_SILENCE_KEY, JSON.stringify(state));
+  } catch {
+    // storage 실패는 silent — silence 미지속이 더 작은 회귀 (다음 cycle에서 게이트 자연 통과).
+  }
+}
+
+export async function clearDismissSilence(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(DISMISS_SILENCE_KEY);
+  } catch {
+    // storage 실패는 silent — stale entry는 다음 만료/clear 사이클에서 자연 정리.
+  }
+}

--- a/src/utils/stationPipeline.ts
+++ b/src/utils/stationPipeline.ts
@@ -11,10 +11,13 @@ import {
   logFiredStationPassed,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
+  logSuppressedDismissSilence,
   logSuppressedSleepFirstTransfer,
   type AlarmLogSource,
 } from './alarmLog';
 import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
+import { evaluateDismissSilence } from './dismissSilenceGate';
+import { clearDismissSilence, getDismissSilence } from './dismissSilenceStorage';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import type { LineNumber, NearestStationResult, Station } from '../types/station';
 import type { Route } from './stationRoute';
@@ -247,10 +250,34 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
 
   for (const event of suppressed) logSuppressedDedupAlarm(source, event);
 
+  // #746 — dismiss silence 게이트. BG path는 storage helper를 직접 read해 store와 동일 결과.
+  // 한 cycle 안에서 phase + station-passed 분기가 모두 사용하므로 1회 read.
+  const dismissSilenceState = await getDismissSilence();
+  const silenceDecision = evaluateDismissSilence(
+    dismissSilenceState,
+    Date.now(),
+    { lat, lng },
+  );
+  if (!silenceDecision.silenced && silenceDecision.expired) {
+    await clearDismissSilence();
+  }
+
   // alarmEvent && route 두 조건이 동시에 참일 때만 발사 분기 진입.
   // evaluateAlarmPhase는 route=null이면 항상 null이라 사실상 alarmEvent != null이면 route != null.
   // 명시 가드로 type narrowing 후 resolveAllTargets 호출 — non-null assertion 회피.
-  if (alarmEvent && route) {
+  // #746 — silence가 활성이면 phase 알람 발사는 skip하지만 UI 갱신(updateStationNotification)은
+  //   계속 — silence는 "알람"만 차단, "현재 역 표시" 같은 정보 표시는 보존.
+  let suppressedAlarmEvent = false;
+  if (alarmEvent && route && silenceDecision.silenced) {
+    logSuppressedDismissSilence({
+      source,
+      stationName: alarmEvent.stationName,
+      kind: alarmEvent.type,
+      phaseId: alarmEvent.phaseId,
+    });
+    suppressedAlarmEvent = true;
+  }
+  if (alarmEvent && route && !suppressedAlarmEvent) {
     // #750: 공통 sleep 룰 게이트. scheduler 사전 예약이 skip한 transfer를 BG 즉시 발사 path가
     // 우회 발사하던 회귀 차단. 첫 hop 판정은 route의 첫 waypoint와 stationName 일치로 — lock
     // 활성 동안 leg가 갱신되면 lock도 갱신되므로 route.targets[0]이 곧 현재 leg의 첫 hop.
@@ -277,7 +304,15 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   // 역 변경 감지 → per-station 알림. 단, 경로상 노선의 역만 (false alarm 방지)
   // 알림 상태는 notificationState 모듈(AsyncStorage)을 단일 출처로 사용해
   // Foreground/Background 양쪽에서 동일한 dedup이 적용된다.
-  if (route && isStationOnRoute(nearest.station, route)) {
+  // #746 — station-passed도 dismiss silence 게이트. dedup(lastNotifiedStationId)보다 위에 두어
+  //   silence 중에는 lastNotifiedStationId 갱신을 막아 silence 만료 직후 정상 발사를 보존한다.
+  if (route && isStationOnRoute(nearest.station, route) && silenceDecision.silenced) {
+    logSuppressedDismissSilence({
+      source,
+      stationName: nearest.station.name,
+      kind: 'station-passed',
+    });
+  } else if (route && isStationOnRoute(nearest.station, route)) {
     const lastNotifiedStationId = await getLastNotifiedStationId();
     if (nearest.station.id !== lastNotifiedStationId) {
       // #796: 환승역 도착 timing의 segment 정확 식별. evaluateAlarmPhase(:233)와 동일한
@@ -336,6 +371,8 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     arrivalAtOrigin,
     arrivalsAtTransfers,
   });
+  // #746 — silence로 차단된 phase 알람은 sleep overlay에 노출하지 않음 (alarmEvent → null).
+  const effectiveAlarmEvent = suppressedAlarmEvent ? null : alarmEvent;
   await updateStationNotification(
     nearest.station,
     Math.round(nearest.distanceKm * 1000),
@@ -343,9 +380,9 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     route,
     eta,
     undefined,
-    sleepMode ? alarmEvent : null,
+    sleepMode ? effectiveAlarmEvent : null,
     notificationSource,
   );
 
-  return { alarmEvent, nearest };
+  return { alarmEvent: effectiveAlarmEvent, nearest };
 }


### PR DESCRIPTION
## Summary
- 알람 dismiss 후 **5분 또는 200m 이동(빠른 쪽)까지 모든 카테고리 silence** — 사용자 멘탈 모델("한동안 진동 X")과 정합
- `src/constants/alarmSilence.ts` (DISMISS_SILENCE_MS=5분, DISMISS_SILENCE_RADIUS_M=200m)
- `src/utils/dismissSilenceGate.ts` (pure 만료 판정), `src/utils/dismissSilenceStorage.ts` (AsyncStorage SSOT)
- `useAppStore`에 dismissSilence state/액션 (`set/clear/load`)
- FG(`useStationAlarm` ETA/API/station-passed 3 effect), BG(`stationPipeline` phase + station-passed), silent push(`silentPushTask`) 모두 silence 게이트 — dedup 상위에 일관 배치
- 새 trip(`setDestination` switch) / lock 생성 시 즉시 clear, GPS-less dismiss → 시간 단독 fallback
- `suppress reason: 'dismiss-silence'` 알람 로깅

## #803 메타화와 정합
- `clearDismissSilenceStorage`를 `TRIP_BOUND_CLEANUPS` 메타 배열에 한 줄 등록 → #803(`PR #843`) 후속 신규 등록 첫 사례
- `useAppStore.setDestination` switch는 `runTripBoundCleanups()` 1줄로 단일화 동일 유지

## reviewer P1 해소
- `loadDismissSilence()` hydration을 `app/(tabs)/index.tsx`의 `useEffect`에 추가 — cold-start 후 FG path가 storage에 살아있는 silence를 무시하지 않게

## Test plan
- [x] `npm test` 3295/3295 pass + 100% coverage 강제 통과
- [x] `npm run type-check` pass
- [x] code-review 에이전트 결과: P0 없음 / P1 1건(hydration) **해소됨** / #843 conflict 가이드대로 **메타 배열에 등록** / P2/P3는 후속 가능
- [x] 신규 TDD 4단계 + 회귀 7건 모두 결정적

## UX 트레이드오프 (명시 결정)
잠금화면 swipe-to-dismiss는 silence 활성 안 함 — `_layout.tsx`의 `addNotificationResponseReceivedListener`는 의도적 제외(swipe는 "이 알람만" 의도로 해석, AlarmOverlay 버튼 누름이 명시적 "그만"). swipe도 silence 활성 정책으로 가려면 알람 카테고리 식별 도입 별도 PR.

Closes #746