### PR TITLE
fix(#855): BoardingTrainList 거리 fallback — 약 N정거장 전 (약 M분 후) 표기

### DIFF
--- a/src/components/BoardingTrainList.tsx
+++ b/src/components/BoardingTrainList.tsx
@@ -8,6 +8,7 @@ import { isScheduleFallbackTrainCode } from '../utils/scheduleFallback';
 import { buildDirectionMeta } from '../utils/trainLineDirection';
 import { parseArrivalDistance } from '../utils/arrivalStatusDistance';
 import { LINE_COLORS } from '../constants/lineColors';
+import { buildFallbackSequenceLabel } from '../constants/labels';
 import stationsData from '../data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -55,7 +56,10 @@ interface Props {
  *       카운터는 호출자가 전달한 배열 순서를 1-indexed로 변환. 같은 trainCode가 유지되는 동안
  *       카운터 안정 → "같은 열차 지연" 신호.
  * #790: 거리 표기를 API `arvlMsg2`에서 정규식 파싱한 실거리로 변경 (`parseArrivalDistance`).
- *       비어있는 statusMessage(주로 mock/schedule fallback)는 기존 `${index+1}번째 전`로 fallback.
+ *       비어있는 statusMessage(주로 mock/schedule fallback)는 `${index+1}번째 전`로 fallback.
+ * #855: fallback 라벨을 "약 N정거장 전 (약 M분 후)"로 변경. 단위(정거장/분) 명시로 mock/schedule
+ *       fallback 시 사용자가 거리/시간을 인지할 수 있게 함. 라벨 텍스트는 `constants/labels.ts`
+ *       에 분리하여 JSX 하드코딩 금지(글로벌 룰 3).
  * #792: 종착 표기는 `parseTrainLineDirection`로 i18n 정규화한다 (기존 하드코딩 "행" 부착 제거).
  * #805: "곧 도착"/"전역 출발"/"당역 도착" 등 statusMessage가 sequence 슬롯을 차지하는 임박 상태에서
  *       도착 예정 HH:mm 시간 라벨이 같은 줄에서 가려지는 회귀가 있었다. 시간 라벨을 항상 별도 라인
@@ -106,11 +110,14 @@ export function BoardingTrainList({
         const unreachable = isUnreachable(train);
         // #792: 종착·방면 라벨을 i18n 정규화 + dedup. nextStationLabel 미전달이면 종착만.
         const metaText = buildDirectionMeta(train.destination, nextStationLabel, allStations);
-        // #790: API arvlMsg2 기반 진짜 거리 표시. 비어있으면 배열 인덱스 fallback(이전 동작 유지 —
-        // 주로 mock/schedule fallback 경로). 실 응답에서는 항상 [N]번째 전역 패턴이 들어와
-        // 사용자 의도(역 개수)와 일치한다.
+        // #790: API arvlMsg2 기반 진짜 거리 표시. 비어있으면 mock/schedule fallback 경로 —
+        // #855에서 fallback 라벨을 "약 N정거장 전 (약 M분 후)"로 단위 명시. arrivalSeconds가 0
+        // 이하면 분 라벨 생략.
         const parsedDistance = parseArrivalDistance(train.statusMessage);
-        const sequenceText = parsedDistance.length > 0 ? parsedDistance : `${index + 1}번째 전`;
+        const sequenceText =
+          parsedDistance.length > 0
+            ? parsedDistance
+            : buildFallbackSequenceLabel(index, train.arrivalSeconds);
         const arrivalText = `${formatArrivalClock(train)} 도착 예정`;
         return (
           <Pressable

--- a/src/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/components/__tests__/BoardingTrainList.test.tsx
@@ -39,7 +39,8 @@ describe('BoardingTrainList', () => {
     );
     expect(getByTestId('boarding-train-row-T-A')).toBeTruthy();
     expect(getByTestId('boarding-train-meta-T-A').props.children).toBe('강남행');
-    expect(getByTestId('boarding-train-sequence-T-A').props.children).toBe('1번째 전');
+    // #855: statusMessage 빈 경우 fallback 라벨 "약 N정거장 전 (약 M분 후)" — arrivalSeconds=180 → 3분.
+    expect(getByTestId('boarding-train-sequence-T-A').props.children).toBe('약 1정거장 전 (약 3분 후)');
   });
 
   it('#634 도착 시각을 receivedAtMs + arrivalSeconds 기반 HH:mm으로 표시', () => {
@@ -165,9 +166,10 @@ describe('BoardingTrainList', () => {
     const { getByTestId } = renderWithTheme(
       <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
     );
-    expect(getByTestId('boarding-train-sequence-T-1ST').props.children).toBe('1번째 전');
-    expect(getByTestId('boarding-train-sequence-T-2ND').props.children).toBe('2번째 전');
-    expect(getByTestId('boarding-train-sequence-T-3RD').props.children).toBe('3번째 전');
+    // #855: fallback 라벨에 분 라벨 포함. arrivalSeconds 60/180/300 → 1/3/5분.
+    expect(getByTestId('boarding-train-sequence-T-1ST').props.children).toBe('약 1정거장 전 (약 1분 후)');
+    expect(getByTestId('boarding-train-sequence-T-2ND').props.children).toBe('약 2정거장 전 (약 3분 후)');
+    expect(getByTestId('boarding-train-sequence-T-3RD').props.children).toBe('약 3정거장 전 (약 5분 후)');
   });
 
   it('#749 compact 모드: 헤더/trainCode 라인 생략, 단일 row "<next>방면" 라벨(#807)', () => {
@@ -197,7 +199,7 @@ describe('BoardingTrainList', () => {
         nextStationLabel="중곡"
       />,
     );
-    expect(getByTestId('boarding-train-sequence-T-CO-SEQ').props.children).toBe('1번째 전');
+    expect(getByTestId('boarding-train-sequence-T-CO-SEQ').props.children).toBe('약 1정거장 전 (약 3분 후)');
     expect(getByTestId('boarding-train-arrival-T-CO-SEQ')).toBeTruthy();
   });
 
@@ -251,7 +253,7 @@ describe('BoardingTrainList', () => {
       expect(getByTestId('boarding-train-sequence-T-DEPARTED').props.children).toBe('전역 출발');
     });
 
-    it('statusMessage 빈 문자열(mock/schedule)이면 index+1 fallback', () => {
+    it('#855 statusMessage 빈 문자열(mock/schedule)이면 "약 N정거장 전 (약 M분 후)" fallback', () => {
       const trains = [
         makeTrain({ trainCode: 'T-MOCK-1', statusMessage: '' }),
         makeTrain({ trainCode: 'T-MOCK-2', statusMessage: '' }),
@@ -259,8 +261,21 @@ describe('BoardingTrainList', () => {
       const { getByTestId } = renderWithTheme(
         <BoardingTrainList arrivals={trains} line="2" onSelect={() => {}} />,
       );
-      expect(getByTestId('boarding-train-sequence-T-MOCK-1').props.children).toBe('1번째 전');
-      expect(getByTestId('boarding-train-sequence-T-MOCK-2').props.children).toBe('2번째 전');
+      // arrivalSeconds=180 default → 3분.
+      expect(getByTestId('boarding-train-sequence-T-MOCK-1').props.children).toBe(
+        '약 1정거장 전 (약 3분 후)',
+      );
+      expect(getByTestId('boarding-train-sequence-T-MOCK-2').props.children).toBe(
+        '약 2정거장 전 (약 3분 후)',
+      );
+    });
+
+    it('#855 statusMessage 빈 + arrivalSeconds=0 이면 분 라벨 생략 ("약 N정거장 전"만)', () => {
+      const train = makeTrain({ trainCode: 'T-MOCK-0', statusMessage: '', arrivalSeconds: 0 });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-sequence-T-MOCK-0').props.children).toBe('약 1정거장 전');
     });
   });
 

--- a/src/constants/__tests__/labels.test.ts
+++ b/src/constants/__tests__/labels.test.ts
@@ -1,0 +1,38 @@
+import { buildFallbackSequenceLabel } from '../labels';
+
+describe('buildFallbackSequenceLabel (#855)', () => {
+  describe('arrivalSeconds > 0 — "(약 M분 후)" 결합', () => {
+    it.each<[number, number, string]>([
+      // [index, arrivalSeconds, expected]
+      [0, 60, '약 1정거장 전 (약 1분 후)'],
+      [0, 180, '약 1정거장 전 (약 3분 후)'],
+      [1, 180, '약 2정거장 전 (약 3분 후)'],
+      [2, 300, '약 3정거장 전 (약 5분 후)'],
+      [9, 600, '약 10정거장 전 (약 10분 후)'],
+    ])('index=%i arrivalSeconds=%i → %s', (index, seconds, expected) => {
+      expect(buildFallbackSequenceLabel(index, seconds)).toBe(expected);
+    });
+
+    it('60초 미만은 1분으로 라운드(0분 후 같은 무의미 라벨 방지)', () => {
+      // Math.round(29/60)=0 이지만 Math.max(1, …)로 1분 보장.
+      expect(buildFallbackSequenceLabel(0, 29)).toBe('약 1정거장 전 (약 1분 후)');
+      // 90초는 round(1.5)=2 분.
+      expect(buildFallbackSequenceLabel(0, 90)).toBe('약 1정거장 전 (약 2분 후)');
+    });
+  });
+
+  describe('arrivalSeconds 미전달/0/음수 — 분 라벨 생략', () => {
+    it('arrivalSeconds 미전달이면 "약 N정거장 전"만', () => {
+      expect(buildFallbackSequenceLabel(0)).toBe('약 1정거장 전');
+      expect(buildFallbackSequenceLabel(4)).toBe('약 5정거장 전');
+    });
+
+    it('arrivalSeconds=0이면 분 라벨 생략', () => {
+      expect(buildFallbackSequenceLabel(0, 0)).toBe('약 1정거장 전');
+    });
+
+    it('arrivalSeconds 음수면 분 라벨 생략 (이론상 발생 안하지만 가드)', () => {
+      expect(buildFallbackSequenceLabel(1, -10)).toBe('약 2정거장 전');
+    });
+  });
+});

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -1,0 +1,37 @@
+/**
+ * 사용자 노출 라벨 상수 모음.
+ *
+ * #855: BoardingTrainList가 statusMessage 빈 경우(mock/schedule fallback) 카운터를
+ * "${index+1}번째 전"으로만 노출해, 사용자가 단위(역/분/m)를 인지하지 못함. fallback 의미를
+ * 명확히 하기 위해 "약 N정거장 전" + 선택적 "(약 M분 후)" 결합 라벨을 사용한다.
+ *
+ * - 텍스트는 JSX 하드코딩 금지(글로벌 룰 3), 모든 사용자 노출 문구는 이 모듈을 거친다.
+ * - 라벨은 sequence-row 단일 라인에 들어가므로 길이를 짧게 유지.
+ * - BoardingTrainList 자체가 아직 i18n 미적용 컴포넌트라 일관성 위해 상수 분리만. i18n 전환은
+ *   컴포넌트 단위 별도 작업에서 일괄 진행한다(범위 비대화 방지 — 글로벌 룰 4 surgical change).
+ */
+
+/**
+ * BoardingTrainList sequence-row fallback 라벨.
+ *
+ * 입력:
+ * - `index`: arrivals 배열의 0-based 인덱스 (ordinal 표기용; 배열 항목 접근 인덱스 아님)
+ * - `arrivalSeconds`: 도착까지 남은 초. > 0이면 "약 M분 후" 보조 라벨을 결합.
+ *
+ * 출력 예:
+ *   buildFallbackSequenceLabel(0, 180)   → "약 1정거장 전 (약 3분 후)"
+ *   buildFallbackSequenceLabel(1, 600)   → "약 2정거장 전 (약 10분 후)"
+ *   buildFallbackSequenceLabel(0)        → "약 1정거장 전"
+ *   buildFallbackSequenceLabel(0, 0)     → "약 1정거장 전"           (≤ 0은 분 라벨 생략)
+ *   buildFallbackSequenceLabel(0, 30)    → "약 1정거장 전 (약 1분 후)" (60초 미만은 1분으로 라운드)
+ *
+ * "약" 접두어: mock/schedule fallback은 추정치라 정확도 보장 안 됨을 시각적으로 전달.
+ * Math.max(1, …)로 0분 표기를 막아 "0분 후" 같은 무의미 라벨 방지.
+ */
+export function buildFallbackSequenceLabel(index: number, arrivalSeconds?: number): string {
+  const ordinal = index + 1;
+  const base = `약 ${ordinal}정거장 전`;
+  if (arrivalSeconds == null || arrivalSeconds <= 0) return base;
+  const minutes = Math.max(1, Math.round(arrivalSeconds / 60));
+  return `${base} (약 ${minutes}분 후)`;
+}


### PR DESCRIPTION
## Summary
- `src/constants/labels.ts` 신규 — `buildFallbackSequenceLabel(index, arrivalSeconds?)` "약 N정거장 전 (약 M분 후)" 생성기
- `BoardingTrainList.tsx` fallback 분기 인라인 템플릿 → 함수 호출 1줄로 교체
- arrivalSeconds 가드: ≤0/미전달 → 분 라벨 생략 (임박 케이스 "약 0분 후" 회피), 60초 미만 → 1분 라운드

## i18n 미적용 정당화 (룰 4 surgical change)
BoardingTrainList 자체가 한국어 하드코딩 다수 ("탑승할 열차 선택", "도착 예정 열차가 없습니다"). 본 PR만 i18n 도입 시 4 locale 동기화 부담 + 일관성 깨짐. **`constants/labels.ts` 진입점 단일화**로 향후 i18n 일괄 전환 시 1곳만 수정하면 됨.

## Test plan
- [x] `npm test` 3255/3255 pass, 100% coverage 글로벌 강제 (labels.ts도 100%)
- [x] `npm run type-check` pass
- [x] code-review 에이전트 **PASS — no blockers** (P0/P1/P2 0건, P3 2건 비차단 참고)
- [x] 신규 9 테스트: arrivalSeconds 미전달/0/음수/29초(round=0 가드)/90초(round up)/9-index ordinal
- [x] BoardingTrainList.test 5건 갱신 + T-MOCK-0 신규 (0 가드 회귀 차단)

## 코딩 원칙 (CLAUDE.md 글로벌 3번)
- 라벨 텍스트 `constants/labels.ts` 분리 (JSX 한국어 하드코딩 추가 0)
- `arrivals.map` 순회 유지, 인덱스 하드코딩 금지
- `index + 1`은 ordinal 표기용으로 정당
- 깊은 체이닝 없음

## 후속 (별 PR, 비차단)
- P3-1: `parseArrivalDistance` 시그니처 변경 시 안전 위해 `statusMessage === ''` 직접 가드 검토
- P3-2: `MIN_DISPLAYED_MINUTES=1`, `SECONDS_PER_MINUTE=60` 모듈 상수 분리

Closes #855