### PR TITLE
fix(#852): 디버그 모달 GPS state + lastFix 표기

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,12 @@ jobs:
         # 실패해도 후속 진단 step이 돌도록 continue-on-error.
         # 최종 job 결과는 마지막 step("Maestro 결과 판정")이 결정.
         continue-on-error: true
+        # #852 cifix: GitHub runner cold start 시 xcuitest installer가
+        # 기본 120s 안에 sim에 올라오지 못해 "iOS driver not ready in time"으로 즉시 실패하는
+        # 회귀가 관측됨. maestro가 직접 "MAESTRO_DRIVER_STARTUP_TIMEOUT 늘려라"고 안내함.
+        # ms 단위, 4분(240000ms)으로 여유 확보.
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '240000'
         run: |
           maestro --version || true
           maestro test --help 2>&1 | head -40 || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Maestro gps 실행
         id: gps
         continue-on-error: true
+        # #852 cifix: ci.yml smoke와 동일 — cold start 대비 driver startup timeout 확대.
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '240000'
         run: maestro test .maestro/flows/gps/ --format junit --output maestro-gps.xml --debug-output ./maestro-debug-gps
 
       - name: gps 시뮬레이터 화면 캡처
@@ -114,6 +117,9 @@ jobs:
       - name: Maestro scenario 실행
         id: scenario
         continue-on-error: true
+        # #852 cifix: ci.yml smoke와 동일 — cold start 대비 driver startup timeout 확대.
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '240000'
         run: maestro test .maestro/flows/scenario/ --format junit --output maestro-scenario.xml --debug-output ./maestro-debug-scenario
 
       - name: scenario 시뮬레이터 화면 캡처

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -189,22 +189,19 @@ function buildDumpText(args: {
   scheduledDump?: ScheduledNotificationDumpEntry[] | null;
 }): string {
   const lines: string[] = [];
-  lines.push(`[Subway debug] ${new Date().toISOString()}`);
-  lines.push('');
-  lines.push('## GPS');
-  lines.push(
-    args.userLocation
-      ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`
-      : '(no location)',
-  );
+  // SonarCloud S7778: 인접한 정적 push 호출은 다인자 단일 호출로 묶는다.
   // #852: watch 구독 상태 + 마지막 fix 시각. 'bg'면 watch가 정지된 상태(silent push wake 등).
   // 호출자 호환을 위해 optional — 미전달 시 'fg'/(never)로 표기.
   lines.push(
+    `[Subway debug] ${new Date().toISOString()}`,
+    '',
+    '## GPS',
+    args.userLocation
+      ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`
+      : '(no location)',
     `state=${args.gpsActive ?? 'fg'}, lastFix=${formatClockTimeWithSeconds(args.lastFixAtMs ?? null)}`,
     '',
-  );
-  lines.push('## Nearest');
-  lines.push(
+    '## Nearest',
     args.nearestName
       ? `${args.nearestName} · ${args.nearestDistanceM ?? '-'} m`
       : '(no nearest station)',
@@ -212,23 +209,22 @@ function buildDumpText(args: {
   if (args.variants.length > 0) {
     lines.push(`variants: ${args.variants.join(', ')}`);
   }
-  lines.push('');
-  lines.push('## Fusion');
-  lines.push(`confidence=${args.fusion.confidence}, source=${args.fusion.source}`);
-  lines.push(`fused: ${args.fusion.fusedLabel}`);
-  lines.push(`gps:   ${args.fusion.gpsLabel}`);
+  lines.push(
+    '',
+    '## Fusion',
+    `confidence=${args.fusion.confidence}, source=${args.fusion.source}`,
+    `fused: ${args.fusion.fusedLabel}`,
+    `gps:   ${args.fusion.gpsLabel}`,
+  );
   if (args.fusion.differs) lines.push('(fused != gps)');
   if (args.fusion.candidateTrains) {
     lines.push(
       `candidateTrains(${args.fusion.candidateTrains.length}): ${args.fusion.candidateTrains.join(', ') || '-'}`,
     );
   }
-  lines.push('');
-  lines.push('## Arrival');
-  lines.push(args.arrivalSummary);
+  lines.push('', '## Arrival', args.arrivalSummary);
   if (args.isMock) lines.push('(MOCK)');
-  lines.push('');
-  lines.push('## Silent Push');
+  lines.push('', '## Silent Push');
   for (const { dumpKey, value } of silentPushDiagRows(args.silentPush)) {
     lines.push(`${dumpKey}=${value}`);
   }

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -201,8 +201,8 @@ function buildDumpText(args: {
   // 호출자 호환을 위해 optional — 미전달 시 'fg'/(never)로 표기.
   lines.push(
     `state=${args.gpsActive ?? 'fg'}, lastFix=${formatClockTimeWithSeconds(args.lastFixAtMs ?? null)}`,
+    '',
   );
-  lines.push('');
   lines.push('## Nearest');
   lines.push(
     args.nearestName

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -13,6 +13,8 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAppStore } from '../store/useAppStore';
 import { isDebugModalEnabled } from '../constants/debugFlags';
+import type { GpsActiveState } from '../constants/gpsStatus';
+import { formatClockTimeWithSeconds } from '../utils/formatTime';
 import { useFusedNearestStation } from '../hooks/useFusedNearestStation';
 import { useArrivalInfo } from '../hooks/useArrivalInfo';
 import {
@@ -164,6 +166,10 @@ function buildDumpText(args: {
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
   accuracyMeters: number | null;
+  // #852: GPS watch 구독 상태(FG/BG) + 마지막 신뢰 fix 시각. silent push wake 시 stale window 진단용.
+  // 호환을 위해 optional — 미전달 시 'fg' / null로 fallback (한 번도 fix 없는 상태와 동일 표기).
+  gpsActive?: GpsActiveState;
+  lastFixAtMs?: number | null;
   nearestName: string | null;
   nearestDistanceM: number | null;
   variants: string[];
@@ -190,6 +196,11 @@ function buildDumpText(args: {
     args.userLocation
       ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`
       : '(no location)',
+  );
+  // #852: watch 구독 상태 + 마지막 fix 시각. 'bg'면 watch가 정지된 상태(silent push wake 등).
+  // 호출자 호환을 위해 optional — 미전달 시 'fg'/(never)로 표기.
+  lines.push(
+    `state=${args.gpsActive ?? 'fg'}, lastFix=${formatClockTimeWithSeconds(args.lastFixAtMs ?? null)}`,
   );
   lines.push('');
   lines.push('## Nearest');
@@ -289,6 +300,8 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
     userLocation,
     speedMps,
     accuracyMeters,
+    gpsActive,
+    lastFixAtMs,
   } = useFusedNearestStation();
   const stationName = result?.station.name ?? null;
   const { arrival, isMock } = useArrivalInfo(stationName);
@@ -350,6 +363,9 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
       userLocation,
       speedMps,
       accuracyMeters,
+      // #852: hook이 신규 필드를 미지원하던 시점 호환 — undefined면 'fg'/null로 fallback.
+      gpsActive: gpsActive ?? 'fg',
+      lastFixAtMs: lastFixAtMs ?? null,
       nearestName: result?.station.name ?? null,
       nearestDistanceM,
       variants: variantNames,
@@ -372,6 +388,8 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
     userLocation,
     speedMps,
     accuracyMeters,
+    gpsActive,
+    lastFixAtMs,
     result,
     nearestDistanceM,
     variantNames,
@@ -422,6 +440,14 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
             ) : (
               <Text style={[typography.mono, { color: colors.muted }]}>(no location)</Text>
             )}
+            {/* #852: GPS watch 구독 상태 — 사용자가 "왜 위치가 안 바뀌지" 확인 가능.
+                userLocation 유무와 무관하게 항상 노출(cold start 'fg lastFix=(never)' 식별). */}
+            <KeyValue label="state" value={gpsActive ?? 'fg'} colors={colors} />
+            <KeyValue
+              label="lastFix"
+              value={formatClockTimeWithSeconds(lastFixAtMs ?? null)}
+              colors={colors}
+            />
           </Section>
 
           <Section title="Fusion" colors={colors}>

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -59,6 +59,24 @@ const variantStation: Station = {
 };
 
 const baseResult: NearestStationResult = { station, distanceKm: 0.123 };
+const baseUserLocation = { lat: 37.5, lng: 127 };
+// #852: GPS section state/lastFix 테스트들이 동일 mock 골격을 반복 — duplication 감지 회피.
+// 호출부는 override만 넘기고, 나머지는 기본값으로 채운다.
+const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
+  result: baseResult,
+  gpsResult: baseResult,
+  confidence: 'gps-only' as const,
+  source: 'gps' as const,
+  variants: [],
+  userLocation: baseUserLocation,
+  speedMps: 1,
+  accuracyMeters: 12,
+  loading: false,
+  error: null,
+  permissionDenied: false,
+  refresh: jest.fn(),
+  ...overrides,
+});
 const arrivalDefaults = {
   line: '1' as const,
   receivedAtMs: 0,
@@ -79,7 +97,7 @@ const setupHookDefaults = () => {
     confidence: 'gps-only',
     source: 'gps',
     variants: [station, variantStation],
-    userLocation: { lat: 37.5, lng: 127.0 },
+    userLocation: { lat: 37.5, lng: 127 },
     speedMps: 1.5,
     accuracyMeters: 20,
     loading: false,
@@ -260,7 +278,7 @@ describe('DebugModal', () => {
       confidence: 'gps-only',
       source: 'gps',
       variants: [],
-      userLocation: { lat: 37.5, lng: 127.0 },
+      userLocation: { lat: 37.5, lng: 127 },
       speedMps: null,
       accuracyMeters: null,
       loading: false,
@@ -340,7 +358,7 @@ describe('DebugModal', () => {
       confidence: 'arrival-confirmed',
       source: 'arrival',
       variants: [],
-      userLocation: { lat: 37.5, lng: 127.0 },
+      userLocation: { lat: 37.5, lng: 127 },
       speedMps: 1,
       accuracyMeters: 12,
       loading: false,
@@ -365,7 +383,7 @@ describe('DebugModal', () => {
       confidence: 'arrival-arriving',
       source: 'arrival',
       variants: [],
-      userLocation: { lat: 37.5, lng: 127.0 },
+      userLocation: { lat: 37.5, lng: 127 },
       speedMps: 1,
       accuracyMeters: 10,
       loading: false,
@@ -389,22 +407,9 @@ describe('DebugModal', () => {
 
   it('#852: GPS 섹션에 state/lastFix를 항상 표시 (fix 있을 때)', () => {
     const fixTs = new Date(2026, 5, 4, 8, 42, 15).getTime();
-    mockUseFusedNearestStation.mockReturnValue({
-      result: baseResult,
-      gpsResult: baseResult,
-      confidence: 'gps-only',
-      source: 'gps',
-      variants: [],
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: 1,
-      accuracyMeters: 12,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      gpsActive: 'fg',
-      lastFixAtMs: fixTs,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({ gpsActive: 'fg', lastFixAtMs: fixTs }),
+    );
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByText('state')).toBeTruthy();
     expect(screen.getByText('fg')).toBeTruthy();
@@ -413,22 +418,17 @@ describe('DebugModal', () => {
   });
 
   it('#852: GPS 섹션 state/lastFix — userLocation 없어도 항상 노출 (cold start)', () => {
-    mockUseFusedNearestStation.mockReturnValue({
-      result: null,
-      gpsResult: null,
-      confidence: 'gps-only',
-      source: 'gps',
-      variants: [],
-      userLocation: null,
-      speedMps: null,
-      accuracyMeters: null,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      gpsActive: 'bg',
-      lastFixAtMs: null,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        result: null,
+        gpsResult: null,
+        userLocation: null,
+        speedMps: null,
+        accuracyMeters: null,
+        gpsActive: 'bg',
+        lastFixAtMs: null,
+      }),
+    );
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByText('(no location)')).toBeTruthy();
     // state/lastFix는 userLocation 유무와 무관하게 노출.
@@ -438,21 +438,8 @@ describe('DebugModal', () => {
   });
 
   it('#852: hook이 gpsActive/lastFixAtMs를 미제공해도 fg/(never)로 fallback', () => {
-    mockUseFusedNearestStation.mockReturnValue({
-      result: baseResult,
-      gpsResult: baseResult,
-      confidence: 'gps-only',
-      source: 'gps',
-      variants: [],
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: 1,
-      accuracyMeters: 10,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      refresh: jest.fn(),
-      // gpsActive / lastFixAtMs 의도적 미설정.
-    });
+    // gpsActive / lastFixAtMs 의도적 미설정.
+    mockUseFusedNearestStation.mockReturnValue(fusedReturnFixture({ accuracyMeters: 10 }));
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByText('fg')).toBeTruthy();
     expect(screen.getAllByText('(never)').length).toBeGreaterThanOrEqual(1);
@@ -486,7 +473,7 @@ describe('DebugModal helpers', () => {
       source: 'bg',
       outcome: 'suppressed',
       reason: 'gate-accuracy',
-      location: { lat: 37.5, lng: 127.0, accuracy: 80, ageMs: 1500 },
+      location: { lat: 37.5, lng: 127, accuracy: 80, ageMs: 1500 },
     };
     const line = __test__.formatLogLine(entry);
     expect(line).toContain('bg');
@@ -559,7 +546,7 @@ describe('DebugModal helpers', () => {
       source: 'bg',
       outcome: 'suppressed',
       reason: 'gate-age',
-      location: { lat: 37.5, lng: 127.0, accuracy: null, ageMs: 5000 },
+      location: { lat: 37.5, lng: 127, accuracy: null, ageMs: 5000 },
     };
     expect(__test__.formatLogLine(entry)).toContain('acc=-');
   });
@@ -590,7 +577,7 @@ describe('DebugModal helpers', () => {
 
   it('buildDumpText: 모든 섹션 포함', () => {
     const dump = __test__.buildDumpText({
-      userLocation: { lat: 37.5, lng: 127.0 },
+      userLocation: { lat: 37.5, lng: 127 },
       speedMps: 2,
       accuracyMeters: 30,
       nearestName: '강남',
@@ -616,7 +603,7 @@ describe('DebugModal helpers', () => {
 
   it('buildDumpText: fused != gps이면 diff 라인을 추가한다', () => {
     const dump = __test__.buildDumpText({
-      userLocation: { lat: 37.5, lng: 127.0 },
+      userLocation: { lat: 37.5, lng: 127 },
       speedMps: 2,
       accuracyMeters: 30,
       nearestName: '강남',
@@ -690,7 +677,7 @@ describe('DebugModal helpers', () => {
   it('#852 buildDumpText: gpsActive/lastFixAtMs를 받으면 state= / lastFix= 라인을 추가한다', () => {
     const fixTs = new Date(2026, 5, 4, 8, 42, 15).getTime();
     const dump = __test__.buildDumpText({
-      userLocation: { lat: 37.5, lng: 127.0 },
+      userLocation: { lat: 37.5, lng: 127 },
       speedMps: 2,
       accuracyMeters: 30,
       gpsActive: 'bg',
@@ -727,7 +714,7 @@ describe('DebugModal helpers', () => {
 
   it('buildDumpText: userLocation은 있고 speedMps/accuracy만 null이면 "-" 표기', () => {
     const dump = __test__.buildDumpText({
-      userLocation: { lat: 37.5, lng: 127.0 },
+      userLocation: { lat: 37.5, lng: 127 },
       speedMps: null,
       accuracyMeters: null,
       nearestName: '강남',
@@ -815,7 +802,7 @@ describe('DebugModal arrival edge cases', () => {
     confidence: 'gps-only' as const,
     source: 'gps' as const,
     variants: [],
-    userLocation: { lat: 37.5, lng: 127.0 },
+    userLocation: { lat: 37.5, lng: 127 },
     speedMps: 1,
     accuracyMeters: 15,
     loading: false,
@@ -922,7 +909,7 @@ describe('DebugModal fusion log section', () => {
       event: 'gps-fix',
       ts: Date.now(),
       lat: 37.5,
-      lng: 127.0,
+      lng: 127,
       accuracyMeters: 20,
       speedMps: 0,
       nearestStation: '용마산',
@@ -947,7 +934,7 @@ describe('formatFusionDebugLine', () => {
       event: 'gps-fix',
       ts: new Date('2026-05-20T14:30:00Z').getTime(),
       lat: 37.5,
-      lng: 127.0,
+      lng: 127,
       accuracyMeters: 25,
       speedMps: 0,
       nearestStation: '용마산',

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -387,6 +387,77 @@ describe('DebugModal', () => {
     expect(screen.getByText('0: -')).toBeTruthy();
   });
 
+  it('#852: GPS 섹션에 state/lastFix를 항상 표시 (fix 있을 때)', () => {
+    const fixTs = new Date(2026, 5, 4, 8, 42, 15).getTime();
+    mockUseFusedNearestStation.mockReturnValue({
+      result: baseResult,
+      gpsResult: baseResult,
+      confidence: 'gps-only',
+      source: 'gps',
+      variants: [],
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 1,
+      accuracyMeters: 12,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      gpsActive: 'fg',
+      lastFixAtMs: fixTs,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('state')).toBeTruthy();
+    expect(screen.getByText('fg')).toBeTruthy();
+    expect(screen.getByText('lastFix')).toBeTruthy();
+    expect(screen.getByText('08:42:15')).toBeTruthy();
+  });
+
+  it('#852: GPS 섹션 state/lastFix — userLocation 없어도 항상 노출 (cold start)', () => {
+    mockUseFusedNearestStation.mockReturnValue({
+      result: null,
+      gpsResult: null,
+      confidence: 'gps-only',
+      source: 'gps',
+      variants: [],
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      gpsActive: 'bg',
+      lastFixAtMs: null,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('(no location)')).toBeTruthy();
+    // state/lastFix는 userLocation 유무와 무관하게 노출.
+    expect(screen.getByText('bg')).toBeTruthy();
+    // (never)는 silentPush rows(lastReceived/lastFired/lastSkipped)에도 등장 → 최소 1개 이상.
+    expect(screen.getAllByText('(never)').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('#852: hook이 gpsActive/lastFixAtMs를 미제공해도 fg/(never)로 fallback', () => {
+    mockUseFusedNearestStation.mockReturnValue({
+      result: baseResult,
+      gpsResult: baseResult,
+      confidence: 'gps-only',
+      source: 'gps',
+      variants: [],
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 1,
+      accuracyMeters: 10,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+      // gpsActive / lastFixAtMs 의도적 미설정.
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('fg')).toBeTruthy();
+    expect(screen.getAllByText('(never)').length).toBeGreaterThanOrEqual(1);
+  });
+
   it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
@@ -614,6 +685,44 @@ describe('DebugModal helpers', () => {
     expect(dump).not.toContain('(MOCK)');
     expect(dump).not.toContain('candidateTrains');
     expect(dump).toContain('## Alarm log (0)');
+  });
+
+  it('#852 buildDumpText: gpsActive/lastFixAtMs를 받으면 state= / lastFix= 라인을 추가한다', () => {
+    const fixTs = new Date(2026, 5, 4, 8, 42, 15).getTime();
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 2,
+      accuracyMeters: 30,
+      gpsActive: 'bg',
+      lastFixAtMs: fixTs,
+      nearestName: '강남',
+      nearestDistanceM: 123,
+      variants: [],
+      fusion: baseFusion,
+      arrivalSummary: 'x',
+      isMock: false,
+      silentPush: baseSilentPush,
+      logs: [],
+    });
+    expect(dump).toContain('state=bg, lastFix=08:42:15');
+  });
+
+  it('#852 buildDumpText: gpsActive/lastFixAtMs 미전달 시 state=fg, lastFix=(never)로 fallback', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      // gpsActive / lastFixAtMs 의도적 미전달.
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: baseFusion,
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: baseSilentPush,
+      logs: [],
+    });
+    expect(dump).toContain('state=fg, lastFix=(never)');
   });
 
   it('buildDumpText: userLocation은 있고 speedMps/accuracy만 null이면 "-" 표기', () => {

--- a/src/constants/__tests__/gpsStatus.test.ts
+++ b/src/constants/__tests__/gpsStatus.test.ts
@@ -1,0 +1,27 @@
+import {
+  GPS_ACTIVE,
+  GPS_INACTIVE,
+  appStateToGpsActive,
+  currentGpsActive,
+} from '../gpsStatus';
+
+describe('gpsStatus (#852)', () => {
+  it('GPS_ACTIVE/INACTIVE 라벨 상수', () => {
+    expect(GPS_ACTIVE).toBe('fg');
+    expect(GPS_INACTIVE).toBe('bg');
+  });
+
+  it("appStateToGpsActive: 'active'만 fg, 그 외(background/inactive/unknown)는 bg", () => {
+    expect(appStateToGpsActive('active')).toBe('fg');
+    expect(appStateToGpsActive('background')).toBe('bg');
+    expect(appStateToGpsActive('inactive')).toBe('bg');
+    expect(appStateToGpsActive('unknown')).toBe('bg');
+  });
+
+  it('currentGpsActive: AppState.currentState 기준 매핑 결과를 반환', () => {
+    // 테스트 환경에서 AppState.currentState는 보통 'active' — fg.
+    // 값이 'active'/'background' 여부와 무관하게 함수 결과가 fg|bg 중 하나이면 ok.
+    const result = currentGpsActive();
+    expect(['fg', 'bg']).toContain(result);
+  });
+});

--- a/src/constants/gpsStatus.ts
+++ b/src/constants/gpsStatus.ts
@@ -1,0 +1,33 @@
+import { AppState, AppStateStatus } from 'react-native';
+
+/**
+ * #852 — useNearestStation의 GPS watch 구독 상태 라벨.
+ * AppState 'active' 동안만 watchPositionAsync 활성, 'background'/'inactive'에서는 stopWatch().
+ * silent push wake 시에도 watch는 미동작 — 사용자가 디버그 모달에서 "왜 안 바뀌지" 확인 가능하도록 노출.
+ *
+ * string union — UI 라벨/dump key 양쪽에서 그대로 사용한다.
+ */
+export type GpsActiveState = 'fg' | 'bg';
+
+export const GPS_ACTIVE: GpsActiveState = 'fg';
+export const GPS_INACTIVE: GpsActiveState = 'bg';
+
+/**
+ * AppState.currentState → GpsActiveState 매핑.
+ * 'active'만 fg, 그 외(background/inactive/unknown)는 bg로 간주 — watch가 정지된 상태와 일치.
+ * AppState 자체를 직접 비교하지 않고 함수로 래핑 — 테스트에서 mock 가능 + 다른 호출처에서 재사용.
+ */
+export function appStateToGpsActive(state: AppStateStatus): GpsActiveState {
+  return state === 'active' ? GPS_ACTIVE : GPS_INACTIVE;
+}
+
+/**
+ * 현재 AppState 기준 GPS watch 활성 여부. 초기 마운트 시 hook 초기값 계산용.
+ *
+ * UI hook은 화면이 살아있을 때만 마운트되므로 마운트 시점은 일반적으로 'active'다.
+ * 단 RN/Jest 환경에서 `AppState.currentState`가 `'unknown'`으로 시작할 수 있어,
+ * 명시적 'active'만 fg로 인정. 마운트 직후 AppState change listener가 실제 상태로 정정한다.
+ */
+export function currentGpsActive(): GpsActiveState {
+  return appStateToGpsActive(AppState.currentState);
+}

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -1020,3 +1020,100 @@ describe('useNearestStation — E2E mock mode', () => {
     expect(result.current.permissionDenied).toBe(false);
   });
 });
+
+describe('useNearestStation — #852 GPS state & lastFix', () => {
+  // RN의 AppState.currentState는 plain property — defineProperty로 직접 덮어쓴다.
+  const originalCurrentState = AppState.currentState;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+    mockGranted();
+    mockLocation(37.4979, 127.0276);
+    // jest 환경에서 AppState.currentState가 'unknown'일 수 있어 명시적으로 'active' 고정.
+    // 실제 UI hook은 마운트 시점이 FG라 'fg' 기본값과 일치.
+    (AppState as { currentState: string }).currentState = 'active';
+  });
+
+  afterEach(() => {
+    (AppState as { currentState: string }).currentState = originalCurrentState;
+  });
+
+  it('초기 마운트 시 gpsActive=fg, lastFixAtMs=null', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.gpsActive).toBe('fg');
+    expect(result.current.lastFixAtMs).toBeNull();
+  });
+
+  it('신뢰 fix 채택 시 lastFixAtMs가 fix timestamp로 갱신된다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(watchCallback).not.toBeNull());
+
+    const fixTs = new Date(2026, 5, 4, 8, 42, 15).getTime();
+    simulateGps(37.4979, 127.0276, { accuracy: 20, timestamp: fixTs });
+
+    await waitFor(() => expect(result.current.lastFixAtMs).toBe(fixTs));
+  });
+
+  it('AppState background 전환 시 gpsActive=bg, lastFixAtMs는 BG 진입 직전 값 유지', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(watchCallback).not.toBeNull());
+
+    const fixTs = new Date(2026, 5, 4, 8, 42, 15).getTime();
+    simulateGps(37.4979, 127.0276, { accuracy: 20, timestamp: fixTs });
+    await waitFor(() => expect(result.current.lastFixAtMs).toBe(fixTs));
+
+    act(() => { appStateCallback?.('background'); });
+
+    expect(result.current.gpsActive).toBe('bg');
+    // BG에서는 watch가 정지되어 lastFixAtMs가 갱신되지 않음 — stale window 시각화 핵심.
+    expect(result.current.lastFixAtMs).toBe(fixTs);
+  });
+
+  it('AppState inactive도 gpsActive=bg로 매핑 (watch 정지 상태와 일관)', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => { appStateCallback?.('inactive'); });
+
+    expect(result.current.gpsActive).toBe('bg');
+  });
+
+  it('AppState active 복귀 시 gpsActive=fg로 즉시 전환', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => { appStateCallback?.('background'); });
+    expect(result.current.gpsActive).toBe('bg');
+
+    await act(async () => { appStateCallback?.('active'); });
+    expect(result.current.gpsActive).toBe('fg');
+  });
+
+  it('jump gate drop된 fix는 lastFixAtMs를 갱신하지 않는다 (stale 시각 유지)', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(watchCallback).not.toBeNull());
+
+    const validTs = new Date(2026, 5, 4, 8, 42, 15).getTime();
+    simulateGps(37.4979, 127.0276, { accuracy: 20, timestamp: validTs });
+    await waitFor(() => expect(result.current.lastFixAtMs).toBe(validTs));
+
+    // 25km 점프 8s — isPlausibleJump fail → drop, lastFixAtMs 미갱신.
+    const jumpTs = validTs + 8_000;
+    simulateGps(37.7, 127.3, { accuracy: 20, timestamp: jumpTs });
+
+    // 약간 기다려도 stale 시각 유지(jump drop은 setLocationUncertain만 호출).
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.current.lastFixAtMs).toBe(validTs);
+  });
+});

--- a/src/hooks/useFusedNearestStation.ts
+++ b/src/hooks/useFusedNearestStation.ts
@@ -65,6 +65,10 @@ interface UseFusedNearestStationReturn {
   /** GPS 표시 게이트 drop으로 좌표가 정지된 상태. fusion에서 position/arrival 신호가 살아있어도
    *  GPS fallback 경로에 의존하는 호출자(예: 표시부)는 이 값으로 "위치 확인 중" UX를 띄울 수 있다. */
   locationUncertain: boolean;
+  /** #852 — GPS watch 구독 활성 여부(FG only). BG/silent push wake 시 'bg' — 디버그 표기용. */
+  gpsActive: import('../constants/gpsStatus').GpsActiveState;
+  /** #852 — 마지막 신뢰 fix epoch ms. null = 한 번도 fix 없음. 디버그 표기용. */
+  lastFixAtMs: number | null;
   /**
    * #733 — 위치 이력 기반 정적/이동/판정불가. iOS가 speed=-1(미측정)을 보고하는 정적 케이스에서
    * movementGate fallback 신호로 사용. 호출자(useStationAlarm 등)가 evaluateMovement에 전달해
@@ -573,6 +577,8 @@ export function useFusedNearestStation(
     error: gps.error,
     permissionDenied: gps.permissionDenied,
     locationUncertain: gps.locationUncertain,
+    gpsActive: gps.gpsActive,
+    lastFixAtMs: gps.lastFixAtMs,
     positionStability,
     refresh: gps.refresh,
   };

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -15,6 +15,11 @@ import {
 import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY } from '../constants/location';
 import { MAX_STATION_DISTANCE_KM } from '../constants/location';
 import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../constants/e2e';
+import {
+  appStateToGpsActive,
+  currentGpsActive,
+  type GpsActiveState,
+} from '../constants/gpsStatus';
 import { createLogger } from '../utils/logger';
 import { pushFusionDebugEntry } from '../utils/fusionDebugBuffer';
 
@@ -39,6 +44,12 @@ interface UseNearestStationReturn {
   // true: 직전 좌표가 표시 게이트(MAX_ACCURACY_M_DISPLAY)에 의해 drop되어 result가
   // 마지막 신뢰 fix로 정지된 상태. 호출자는 "위치 확인 중" 상태로 표시한다.
   locationUncertain: boolean;
+  // #852: GPS watch 구독 활성 여부. AppState 'active' 동안만 'fg', 그 외(BG/inactive)는 'bg'.
+  // silent push wake 시에도 'bg' — 사용자가 디버그 모달에서 "왜 안 바뀌지" 확인 가능.
+  gpsActive: GpsActiveState;
+  // #852: 마지막 신뢰 fix epoch ms. BG 진입 후 새 fix가 없으면 이 시각은 정지.
+  // null = 한 번도 fix 없음(cold start). 디버그 모달 표기용.
+  lastFixAtMs: number | null;
   refresh: () => Promise<void>;
 }
 
@@ -89,6 +100,10 @@ export function useNearestStation(): UseNearestStationReturn {
   const [error, setError] = useState<string | null>(null);
   const [permissionDenied, setPermissionDenied] = useState(false);
   const [locationUncertain, setLocationUncertain] = useState(false);
+  // #852: AppState 초기값 기준 — RN의 초기 currentState는 보통 'active'지만
+  // 모듈 마운트 타이밍에 따라 'unknown'/'background'일 수 있어 wrapper로 통일.
+  const [gpsActive, setGpsActive] = useState<GpsActiveState>(() => currentGpsActive());
+  const [lastFixAtMs, setLastFixAtMs] = useState<number | null>(null);
   const subscriptionRef = useRef<Location.LocationSubscription | null>(null);
   const lastStationIdRef = useRef<string | null>(null);
   const lastDistanceRef = useRef<number>(0);
@@ -113,6 +128,9 @@ export function useNearestStation(): UseNearestStationReturn {
     // (호출자 측 setLocationUncertain(false)에 의존하면 jump drop 직후 정상 fix가 들어와도
     //  복귀 호출 경로가 없어 uncertain이 고착되는 결함 발생 — P1 회피.)
     setLocationUncertain(false);
+    // #852: 신뢰 fix가 채택된 시점을 기록 — 디버그 모달 GPS 섹션에서 stale window 시각화.
+    // jump/accuracy drop된 fix는 채택 안 함(stale 시각이 그대로 유지) — 사용자가 stale 구간 식별 가능.
+    setLastFixAtMs(timestamp);
     const stationsResult = findNearestStations(latitude, longitude, MAX_STATION_DISTANCE_KM);
 
     const newId = stationsResult?.primary.id ?? null;
@@ -312,6 +330,9 @@ export function useNearestStation(): UseNearestStationReturn {
     startWatch();
 
     const appStateSub = AppState.addEventListener('change', (state) => {
+      // #852: AppState 전환 시점에 즉시 gpsActive 라벨 갱신. silent push wake로 BG에 있는 동안
+      // 'bg' 상태 유지 → 사용자가 디버그 모달에서 확인 가능.
+      setGpsActive(appStateToGpsActive(state));
       if (state === 'active') {
         // FG 복귀 시 result는 BG 진입 시점의 stale 위치 — 사용자가 그 사이 이동했을 수 있다 (#543).
         // 명시적으로 uncertain 상태로 전환해 UI가 "위치 확인 중"을 표시하게 하고,
@@ -340,5 +361,18 @@ export function useNearestStation(): UseNearestStationReturn {
     };
   }, [startWatch, stopWatch, refresh]);
 
-  return { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, refresh };
+  return {
+    result,
+    variants,
+    userLocation,
+    speedMps,
+    accuracyMeters,
+    loading,
+    error,
+    permissionDenied,
+    locationUncertain,
+    gpsActive,
+    lastFixAtMs,
+    refresh,
+  };
 }

--- a/src/utils/__tests__/formatTime.test.ts
+++ b/src/utils/__tests__/formatTime.test.ts
@@ -1,4 +1,4 @@
-import { formatArrivalTime, formatClockTime } from '../formatTime';
+import { formatArrivalTime, formatClockTime, formatClockTimeWithSeconds } from '../formatTime';
 
 describe('formatArrivalTime', () => {
   it('0초 이하이면 "곧 도착"을 반환한다', () => {
@@ -33,5 +33,21 @@ describe('formatClockTime (#625)', () => {
     // 2026-01-01T03:05:00 UTC 같은 시각을 timezone-agnostic하게 검증.
     const d = new Date(2026, 0, 1, 3, 5);
     expect(formatClockTime(d.getTime())).toBe('03:05');
+  });
+});
+
+describe('formatClockTimeWithSeconds (#852)', () => {
+  it('null이면 (never)', () => {
+    expect(formatClockTimeWithSeconds(null)).toBe('(never)');
+  });
+
+  it('HH:mm:ss 24h 포맷, 한 자리도 모두 두 자리로 패딩', () => {
+    const d = new Date(2026, 5, 3, 8, 7, 5);
+    expect(formatClockTimeWithSeconds(d.getTime())).toBe('08:07:05');
+  });
+
+  it('두 자리 시/분/초를 그대로 표기', () => {
+    const d = new Date(2026, 5, 3, 14, 30, 45);
+    expect(formatClockTimeWithSeconds(d.getTime())).toBe('14:30:45');
   });
 });

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -19,3 +19,16 @@ export function formatClockTime(epochMs: number): string {
   const mm = String(d.getMinutes()).padStart(2, '0');
   return `${hh}:${mm}`;
 }
+
+/**
+ * epoch ms → "HH:mm:ss" (24h, zero-padded). 디버그/진단 표시용 (#852).
+ * null → "(never)" — 한 번도 갱신된 적 없는 상태를 명시.
+ */
+export function formatClockTimeWithSeconds(epochMs: number | null): string {
+  if (epochMs == null) return '(never)';
+  const d = new Date(epochMs);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}


### PR DESCRIPTION
## Summary
- 디버그 모달 GPS 섹션에 `state`(fg/bg/inactive) + `lastFix`(HH:mm:ss / (never)) 표기
- `src/constants/gpsStatus.ts` 신규 — `GpsActiveState` 상수/타입 + `appStateToGpsActive` / `currentGpsActive` wrapper
- `formatClockTimeWithSeconds(epochMs|null)` 추가
- `useNearestStation`: `gpsActive`/`lastFixAtMs` state + AppState change 즉시 갱신 + applyLocation 시 timestamp 저장 (jump/accuracy drop은 미갱신)
- `useFusedNearestStation` pass-through

## BG silent push wake 한계
RN hook 미마운트 → `gpsActive` 실시간 못 바뀜. FG 복귀 시점에서만 갱신. `lastFixAtMs`로 stale window 길이 식별 가능 (예: "08:42:15에서 09:00:00 사이 정지"). 주석에 명시.

## Test plan
- [x] `npm test` 3262/3262 pass + 100% coverage
- [x] `npm run type-check` pass
- [x] code-review **PASS — no blockers** (P2 1건: 미사용 export `GPS_ACTIVE`/`GPS_INACTIVE` follow-up 가능)
- [x] 신규 케이스 11건 (gpsStatus wrapper 3 / formatTime / useNearestStation 6 / DebugModal 5)

## 코딩 원칙
- fg/bg/inactive 라벨 `src/constants/gpsStatus.ts` 분리
- `AppState.currentState` 비교 wrapper로 캡슐화
- 인덱스 하드코딩 없음, 깊은 체이닝 없음
- 디버그 모달 전용 텍스트 — i18n 미적용 정당

Closes #852