### PR TITLE
fix(#853): 디버그 모달 fusedSpeed fallback + GPS speed helper 통일

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -192,12 +192,12 @@ function buildGpsRows(args: {
     { label: 'lng', value: String(args.userLocation.lng) },
     {
       label: 'speed',
-      value: args.speedMps != null ? `${args.speedMps.toFixed(2)} m/s` : '-',
+      value: args.speedMps == null ? '-' : `${args.speedMps.toFixed(2)} m/s`,
     },
     { label: 'fused', value: fusedValue },
     {
       label: 'accuracy',
-      value: args.accuracyMeters != null ? `${args.accuracyMeters.toFixed(0)} m` : '-',
+      value: args.accuracyMeters == null ? '-' : `${args.accuracyMeters.toFixed(0)} m`,
     },
   ];
 }
@@ -236,8 +236,8 @@ function buildDumpText(args: {
       : NO_FUSED_SIGNAL_LABEL;
     lines.push(
       `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`,
+      `fused=${fusedDump}`,
     );
-    lines.push(`fused=${fusedDump}`);
   } else {
     lines.push('(no location)');
   }
@@ -331,7 +331,7 @@ export function DebugModal(props: DebugModalProps) {
   return <DebugModalInner {...props} />;
 }
 
-function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: DebugModalProps) {
+function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<DebugModalProps>) {
   const { colors } = useTheme();
   // #458: RN Modal 안에서는 SafeAreaView가 안 먹는다(portal로 inset 컨텍스트 분리).
   // 루트 SafeAreaProvider의 insets를 hook으로 직접 받아 헤더에 manual padding.

--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -160,10 +160,54 @@ function fusedDiffersFromGps(
   return fused.station.id !== gps.station.id;
 }
 
+/**
+ * fusedSpeed signal — backend Phase 3 fusion(ADR-009) 산출치를 디버그 모달에 전달하기 위한 prop 형태.
+ * 클라 자체에는 산출 함수가 아직 없으므로(#819 후속) 호출부가 명시적으로 주입한다.
+ * 미전달이면 UI/dump 모두 `(no fused signal)`로 노출 — GPS speed=null과 구분 가능.
+ */
+export interface FusedSpeedSignal {
+  kmh: number;
+  source: FusionSource;
+}
+
+const NO_FUSED_SIGNAL_LABEL = '(no fused signal)';
+
+/**
+ * GPS 섹션에 노출할 row 목록. fused 라인은 fused signal 유무와 무관하게 항상 1줄 — 사용자가
+ * "현재 속도 신호가 클라에 도달했는가"를 즉시 인지할 수 있게 한다. 줄별 렌더링은 호출부에서
+ * `Array.map`으로 순회.
+ */
+function buildGpsRows(args: {
+  userLocation: { lat: number; lng: number } | null;
+  speedMps: number | null;
+  accuracyMeters: number | null;
+  fusedSpeed: FusedSpeedSignal | null;
+}): { label: string; value: string }[] {
+  if (!args.userLocation) return [];
+  const fusedValue = args.fusedSpeed
+    ? `${args.fusedSpeed.kmh.toFixed(1)} km/h (${args.fusedSpeed.source})`
+    : NO_FUSED_SIGNAL_LABEL;
+  return [
+    { label: 'lat', value: String(args.userLocation.lat) },
+    { label: 'lng', value: String(args.userLocation.lng) },
+    {
+      label: 'speed',
+      value: args.speedMps != null ? `${args.speedMps.toFixed(2)} m/s` : '-',
+    },
+    { label: 'fused', value: fusedValue },
+    {
+      label: 'accuracy',
+      value: args.accuracyMeters != null ? `${args.accuracyMeters.toFixed(0)} m` : '-',
+    },
+  ];
+}
+
 function buildDumpText(args: {
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
   accuracyMeters: number | null;
+  /** #853 — Phase 3 fused speed. 미전달이면 dump의 fused 라인이 (no fused signal). */
+  fusedSpeed?: FusedSpeedSignal | null;
   nearestName: string | null;
   nearestDistanceM: number | null;
   variants: string[];
@@ -186,11 +230,17 @@ function buildDumpText(args: {
   lines.push(`[Subway debug] ${new Date().toISOString()}`);
   lines.push('');
   lines.push('## GPS');
-  lines.push(
-    args.userLocation
-      ? `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`
-      : '(no location)',
-  );
+  if (args.userLocation) {
+    const fusedDump = args.fusedSpeed
+      ? `${args.fusedSpeed.kmh.toFixed(1)} km/h (${args.fusedSpeed.source})`
+      : NO_FUSED_SIGNAL_LABEL;
+    lines.push(
+      `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`,
+    );
+    lines.push(`fused=${fusedDump}`);
+  } else {
+    lines.push('(no location)');
+  }
   lines.push('');
   lines.push('## Nearest');
   lines.push(
@@ -263,6 +313,12 @@ interface DebugModalProps {
    * 미전달이면 섹션에서 "(n/a)"로 표기.
    */
   candidateTrains?: string[];
+  /**
+   * #853 — backend fused speed(ADR-009 Phase 3). 미전달이면 GPS 섹션 fused 라인이
+   * `(no fused signal)`로 표기돼 사용자가 클라 GPS 미측정과 구분 가능.
+   * 클라 자체 산출 함수는 #819 후속.
+   */
+  fusedSpeed?: FusedSpeedSignal;
 }
 
 // 디버그 모달은 측정 인프라 — 관찰자 효과를 피하려고 모달이 열린 동안에만 마운트한다.
@@ -275,7 +331,7 @@ export function DebugModal(props: DebugModalProps) {
   return <DebugModalInner {...props} />;
 }
 
-function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
+function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: DebugModalProps) {
   const { colors } = useTheme();
   // #458: RN Modal 안에서는 SafeAreaView가 안 먹는다(portal로 inset 컨텍스트 분리).
   // 루트 SafeAreaProvider의 insets를 hook으로 직접 받아 헤더에 manual padding.
@@ -345,11 +401,15 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
   const nearestDistanceM = result ? Math.round(result.distanceKm * 1000) : null;
   const variantNames = variants.map((v) => `${v.name}(${v.line})`);
 
+  // fusedSpeed prop을 null로 정규화해 buildGpsRows/buildDumpText 양쪽에서 동일 분기 사용.
+  const fusedSpeedSignal: FusedSpeedSignal | null = fusedSpeed ?? null;
+
   const handleShare = useCallback(() => {
     const message = buildDumpText({
       userLocation,
       speedMps,
       accuracyMeters,
+      fusedSpeed: fusedSpeedSignal,
       nearestName: result?.station.name ?? null,
       nearestDistanceM,
       variants: variantNames,
@@ -372,6 +432,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
     userLocation,
     speedMps,
     accuracyMeters,
+    fusedSpeedSignal,
     result,
     nearestDistanceM,
     variantNames,
@@ -405,20 +466,14 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
         <ScrollView contentContainerStyle={{ padding: spacing.xl }}>
           <Section title="GPS" colors={colors}>
             {userLocation ? (
-              <>
-                <KeyValue label="lat" value={String(userLocation.lat)} colors={colors} />
-                <KeyValue label="lng" value={String(userLocation.lng)} colors={colors} />
-                <KeyValue
-                  label="speed"
-                  value={speedMps != null ? `${speedMps.toFixed(2)} m/s` : '-'}
-                  colors={colors}
-                />
-                <KeyValue
-                  label="accuracy"
-                  value={accuracyMeters != null ? `${accuracyMeters.toFixed(0)} m` : '-'}
-                  colors={colors}
-                />
-              </>
+              buildGpsRows({
+                userLocation,
+                speedMps,
+                accuracyMeters,
+                fusedSpeed: fusedSpeedSignal,
+              }).map(({ label, value }) => (
+                <KeyValue key={label} label={label} value={value} colors={colors} />
+              ))
             ) : (
               <Text style={[typography.mono, { color: colors.muted }]}>(no location)</Text>
             )}
@@ -665,10 +720,12 @@ function KeyValue({
 export const __test__ = {
   formatLogLine,
   buildDumpText,
+  buildGpsRows,
   formatFusionDebugLine,
   formatTokenTail,
   formatAt,
   formatSourceCountsLine,
+  NO_FUSED_SIGNAL_LABEL,
 };
 
 const styles = StyleSheet.create({

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -1316,3 +1316,208 @@ describe('DebugModal — Scheduled queue UI (#756)', () => {
     expect(sharedMessage).toContain('bl:T:0:imminent:장한평');
   });
 });
+
+describe('DebugModal — fusedSpeed fallback (#853)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupHookDefaults();
+  });
+
+  const fusedRowFor = (
+    label: string,
+    rows: ReturnType<typeof __test__.buildGpsRows>,
+  ): string => rows.find((r) => r.label === label)?.value ?? '';
+
+  it('buildGpsRows: userLocation 없으면 빈 배열', () => {
+    const rows = __test__.buildGpsRows({
+      userLocation: null,
+      speedMps: 1,
+      accuracyMeters: 10,
+      fusedSpeed: null,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('buildGpsRows: GPS speed 정상 + fused 미전달이면 fused 라벨이 (no fused signal)', () => {
+    const rows = __test__.buildGpsRows({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 1.13,
+      accuracyMeters: 12,
+      fusedSpeed: null,
+    });
+    expect(fusedRowFor('speed', rows)).toBe('1.13 m/s');
+    expect(fusedRowFor('fused', rows)).toBe(__test__.NO_FUSED_SIGNAL_LABEL);
+    expect(fusedRowFor('accuracy', rows)).toBe('12 m');
+  });
+
+  it('buildGpsRows: GPS speed=null이어도 fused signal 전달되면 km/h + source 노출', () => {
+    const rows = __test__.buildGpsRows({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      accuracyMeters: null,
+      fusedSpeed: { kmh: 18.4, source: 'position-train' },
+    });
+    expect(fusedRowFor('speed', rows)).toBe('-');
+    expect(fusedRowFor('fused', rows)).toBe('18.4 km/h (position-train)');
+    expect(fusedRowFor('accuracy', rows)).toBe('-');
+  });
+
+  it('buildGpsRows: fused signal source는 FusionSource enum 그대로 노출(kalman/mapMatched 등 후속 확장 시 라벨 변경 불필요)', () => {
+    const rows = __test__.buildGpsRows({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      accuracyMeters: null,
+      fusedSpeed: { kmh: 0, source: 'gps' },
+    });
+    expect(fusedRowFor('fused', rows)).toBe('0.0 km/h (gps)');
+  });
+
+  it('buildDumpText: fused signal 미전달이면 fused=(no fused signal) 라인', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      accuracyMeters: null,
+      nearestName: '강남',
+      nearestDistanceM: 100,
+      variants: [],
+      fusion: {
+        confidence: 'gps-only',
+        source: 'gps',
+        fusedLabel: '-',
+        gpsLabel: '-',
+        differs: false,
+        candidateTrains: null,
+      },
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: {
+        apnsToken: null,
+        activeTripToken: null,
+        apnsEnv: 'sandbox',
+        permissionStatus: null,
+        taskRegistrationState: 'unknown',
+        taskRegistrationError: null,
+        lastReceivedAt: null,
+        lastFiredAt: null,
+        lastSkippedAt: null,
+        hasRoute: false,
+        destinationId: null,
+        lastNotifiedStationId: null,
+      },
+      logs: [],
+    });
+    expect(dump).toContain(`fused=${__test__.NO_FUSED_SIGNAL_LABEL}`);
+  });
+
+  it('buildDumpText: fused signal 전달 시 km/h + source 라인', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: 1.5,
+      accuracyMeters: 10,
+      fusedSpeed: { kmh: 22.7, source: 'position' },
+      nearestName: '강남',
+      nearestDistanceM: 100,
+      variants: [],
+      fusion: {
+        confidence: 'gps-only',
+        source: 'gps',
+        fusedLabel: '-',
+        gpsLabel: '-',
+        differs: false,
+        candidateTrains: null,
+      },
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: {
+        apnsToken: null,
+        activeTripToken: null,
+        apnsEnv: 'sandbox',
+        permissionStatus: null,
+        taskRegistrationState: 'unknown',
+        taskRegistrationError: null,
+        lastReceivedAt: null,
+        lastFiredAt: null,
+        lastSkippedAt: null,
+        hasRoute: false,
+        destinationId: null,
+        lastNotifiedStationId: null,
+      },
+      logs: [],
+    });
+    expect(dump).toContain('fused=22.7 km/h (position)');
+  });
+
+  it('buildDumpText: userLocation=null이면 fused 라인 자체 미노출 ("(no location)"만)', () => {
+    const dump = __test__.buildDumpText({
+      userLocation: null,
+      speedMps: null,
+      accuracyMeters: null,
+      fusedSpeed: { kmh: 5, source: 'gps' },
+      nearestName: null,
+      nearestDistanceM: null,
+      variants: [],
+      fusion: {
+        confidence: 'gps-only',
+        source: 'gps',
+        fusedLabel: '-',
+        gpsLabel: '-',
+        differs: false,
+        candidateTrains: null,
+      },
+      arrivalSummary: '-',
+      isMock: false,
+      silentPush: {
+        apnsToken: null,
+        activeTripToken: null,
+        apnsEnv: 'sandbox',
+        permissionStatus: null,
+        taskRegistrationState: 'unknown',
+        taskRegistrationError: null,
+        lastReceivedAt: null,
+        lastFiredAt: null,
+        lastSkippedAt: null,
+        hasRoute: false,
+        destinationId: null,
+        lastNotifiedStationId: null,
+      },
+      logs: [],
+    });
+    expect(dump).toContain('(no location)');
+    expect(dump).not.toContain('fused=');
+  });
+
+  it('GPS 섹션 렌더링: fusedSpeed prop 미전달이면 "(no fused signal)" 노출', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    // 기본 mock: speedMps=1.5, userLocation 존재.
+    expect(await screen.findByText(__test__.NO_FUSED_SIGNAL_LABEL)).toBeTruthy();
+  });
+
+  it('GPS 섹션 렌더링: fusedSpeed prop 전달 시 "km/h (source)" 라벨 노출', async () => {
+    renderWithTheme(
+      <DebugModal onClose={jest.fn()} fusedSpeed={{ kmh: 35.2, source: 'arrival' }} />,
+    );
+    expect(await screen.findByText('35.2 km/h (arrival)')).toBeTruthy();
+  });
+
+  it('GPS 섹션 렌더링: GPS speed=null + fusedSpeed 전달 시 두 줄 분리 노출', async () => {
+    mockUseFusedNearestStation.mockReturnValue({
+      result: baseResult,
+      gpsResult: baseResult,
+      confidence: 'gps-only',
+      source: 'gps',
+      variants: [],
+      userLocation: { lat: 37.5, lng: 127.0 },
+      speedMps: null,
+      accuracyMeters: 12,
+      loading: false,
+      error: null,
+      permissionDenied: false,
+      refresh: jest.fn(),
+    });
+    renderWithTheme(
+      <DebugModal onClose={jest.fn()} fusedSpeed={{ kmh: 18, source: 'position-train' }} />,
+    );
+    // GPS speed가 "-"로 노출되더라도 fused 라인이 별도로 사용자 인지 가능해야 함.
+    expect(await screen.findByText('18.0 km/h (position-train)')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -1328,160 +1328,111 @@ describe('DebugModal — fusedSpeed fallback (#853)', () => {
     rows: ReturnType<typeof __test__.buildGpsRows>,
   ): string => rows.find((r) => r.label === label)?.value ?? '';
 
+  // SonarCloud CPD 회피: 4개 buildGpsRows 테스트가 동일 baseline. helper로 공통 args 묶음.
+  type GpsArgs = Parameters<typeof __test__.buildGpsRows>[0];
+  const gpsRowsArgs = (overrides: Partial<GpsArgs> = {}): GpsArgs => ({
+    userLocation: { lat: 37.5, lng: 127 },
+    speedMps: null,
+    accuracyMeters: null,
+    fusedSpeed: null,
+    ...overrides,
+  });
+
+  // SonarCloud CPD 회피: 3개 buildDumpText 테스트가 동일 baseline. silentPush/fusion 블록 helper로 묶음.
+  const baselineSilentPush = {
+    apnsToken: null,
+    activeTripToken: null,
+    apnsEnv: 'sandbox' as const,
+    permissionStatus: null,
+    taskRegistrationState: 'unknown' as const,
+    taskRegistrationError: null,
+    lastReceivedAt: null,
+    lastFiredAt: null,
+    lastSkippedAt: null,
+    hasRoute: false,
+    destinationId: null,
+    lastNotifiedStationId: null,
+  };
+  type DumpArgs = Parameters<typeof __test__.buildDumpText>[0];
+  const fusedDumpArgs = (overrides: Partial<DumpArgs> = {}): DumpArgs => ({
+    userLocation: { lat: 37.5, lng: 127 },
+    speedMps: null,
+    accuracyMeters: null,
+    nearestName: '강남',
+    nearestDistanceM: 100,
+    variants: [],
+    fusion: {
+      confidence: 'gps-only',
+      source: 'gps',
+      fusedLabel: '-',
+      gpsLabel: '-',
+      differs: false,
+      candidateTrains: null,
+    },
+    arrivalSummary: '-',
+    isMock: false,
+    silentPush: baselineSilentPush,
+    logs: [],
+    ...overrides,
+  });
+
   it('buildGpsRows: userLocation 없으면 빈 배열', () => {
-    const rows = __test__.buildGpsRows({
-      userLocation: null,
-      speedMps: 1,
-      accuracyMeters: 10,
-      fusedSpeed: null,
-    });
+    const rows = __test__.buildGpsRows(
+      gpsRowsArgs({ userLocation: null, speedMps: 1, accuracyMeters: 10 }),
+    );
     expect(rows).toEqual([]);
   });
 
   it('buildGpsRows: GPS speed 정상 + fused 미전달이면 fused 라벨이 (no fused signal)', () => {
-    const rows = __test__.buildGpsRows({
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: 1.13,
-      accuracyMeters: 12,
-      fusedSpeed: null,
-    });
+    const rows = __test__.buildGpsRows(
+      gpsRowsArgs({ speedMps: 1.13, accuracyMeters: 12 }),
+    );
     expect(fusedRowFor('speed', rows)).toBe('1.13 m/s');
     expect(fusedRowFor('fused', rows)).toBe(__test__.NO_FUSED_SIGNAL_LABEL);
     expect(fusedRowFor('accuracy', rows)).toBe('12 m');
   });
 
   it('buildGpsRows: GPS speed=null이어도 fused signal 전달되면 km/h + source 노출', () => {
-    const rows = __test__.buildGpsRows({
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: null,
-      accuracyMeters: null,
-      fusedSpeed: { kmh: 18.4, source: 'position-train' },
-    });
+    const rows = __test__.buildGpsRows(
+      gpsRowsArgs({ fusedSpeed: { kmh: 18.4, source: 'position-train' } }),
+    );
     expect(fusedRowFor('speed', rows)).toBe('-');
     expect(fusedRowFor('fused', rows)).toBe('18.4 km/h (position-train)');
     expect(fusedRowFor('accuracy', rows)).toBe('-');
   });
 
   it('buildGpsRows: fused signal source는 FusionSource enum 그대로 노출(kalman/mapMatched 등 후속 확장 시 라벨 변경 불필요)', () => {
-    const rows = __test__.buildGpsRows({
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: null,
-      accuracyMeters: null,
-      fusedSpeed: { kmh: 0, source: 'gps' },
-    });
+    const rows = __test__.buildGpsRows(
+      gpsRowsArgs({ fusedSpeed: { kmh: 0, source: 'gps' } }),
+    );
     expect(fusedRowFor('fused', rows)).toBe('0.0 km/h (gps)');
   });
 
   it('buildDumpText: fused signal 미전달이면 fused=(no fused signal) 라인', () => {
-    const dump = __test__.buildDumpText({
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: null,
-      accuracyMeters: null,
-      nearestName: '강남',
-      nearestDistanceM: 100,
-      variants: [],
-      fusion: {
-        confidence: 'gps-only',
-        source: 'gps',
-        fusedLabel: '-',
-        gpsLabel: '-',
-        differs: false,
-        candidateTrains: null,
-      },
-      arrivalSummary: '-',
-      isMock: false,
-      silentPush: {
-        apnsToken: null,
-        activeTripToken: null,
-        apnsEnv: 'sandbox',
-        permissionStatus: null,
-        taskRegistrationState: 'unknown',
-        taskRegistrationError: null,
-        lastReceivedAt: null,
-        lastFiredAt: null,
-        lastSkippedAt: null,
-        hasRoute: false,
-        destinationId: null,
-        lastNotifiedStationId: null,
-      },
-      logs: [],
-    });
+    const dump = __test__.buildDumpText(fusedDumpArgs());
     expect(dump).toContain(`fused=${__test__.NO_FUSED_SIGNAL_LABEL}`);
   });
 
   it('buildDumpText: fused signal 전달 시 km/h + source 라인', () => {
-    const dump = __test__.buildDumpText({
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: 1.5,
-      accuracyMeters: 10,
-      fusedSpeed: { kmh: 22.7, source: 'position' },
-      nearestName: '강남',
-      nearestDistanceM: 100,
-      variants: [],
-      fusion: {
-        confidence: 'gps-only',
-        source: 'gps',
-        fusedLabel: '-',
-        gpsLabel: '-',
-        differs: false,
-        candidateTrains: null,
-      },
-      arrivalSummary: '-',
-      isMock: false,
-      silentPush: {
-        apnsToken: null,
-        activeTripToken: null,
-        apnsEnv: 'sandbox',
-        permissionStatus: null,
-        taskRegistrationState: 'unknown',
-        taskRegistrationError: null,
-        lastReceivedAt: null,
-        lastFiredAt: null,
-        lastSkippedAt: null,
-        hasRoute: false,
-        destinationId: null,
-        lastNotifiedStationId: null,
-      },
-      logs: [],
-    });
+    const dump = __test__.buildDumpText(
+      fusedDumpArgs({
+        speedMps: 1.5,
+        accuracyMeters: 10,
+        fusedSpeed: { kmh: 22.7, source: 'position' },
+      }),
+    );
     expect(dump).toContain('fused=22.7 km/h (position)');
   });
 
   it('buildDumpText: userLocation=null이면 fused 라인 자체 미노출 ("(no location)"만)', () => {
-    const dump = __test__.buildDumpText({
-      userLocation: null,
-      speedMps: null,
-      accuracyMeters: null,
-      fusedSpeed: { kmh: 5, source: 'gps' },
-      nearestName: null,
-      nearestDistanceM: null,
-      variants: [],
-      fusion: {
-        confidence: 'gps-only',
-        source: 'gps',
-        fusedLabel: '-',
-        gpsLabel: '-',
-        differs: false,
-        candidateTrains: null,
-      },
-      arrivalSummary: '-',
-      isMock: false,
-      silentPush: {
-        apnsToken: null,
-        activeTripToken: null,
-        apnsEnv: 'sandbox',
-        permissionStatus: null,
-        taskRegistrationState: 'unknown',
-        taskRegistrationError: null,
-        lastReceivedAt: null,
-        lastFiredAt: null,
-        lastSkippedAt: null,
-        hasRoute: false,
-        destinationId: null,
-        lastNotifiedStationId: null,
-      },
-      logs: [],
-    });
+    const dump = __test__.buildDumpText(
+      fusedDumpArgs({
+        userLocation: null,
+        nearestName: null,
+        nearestDistanceM: null,
+        fusedSpeed: { kmh: 5, source: 'gps' },
+      }),
+    );
     expect(dump).toContain('(no location)');
     expect(dump).not.toContain('fused=');
   });

--- a/src/constants/__tests__/location.test.ts
+++ b/src/constants/__tests__/location.test.ts
@@ -1,0 +1,25 @@
+import { GPS_SPEED_INVALID, isValidGpsSpeedMps } from '../location';
+
+describe('GPS_SPEED_INVALID', () => {
+  it('iOS CoreLocation 무효값(-1)을 그대로 export한다', () => {
+    expect(GPS_SPEED_INVALID).toBe(-1);
+  });
+});
+
+describe('isValidGpsSpeedMps', () => {
+  it('null/undefined는 invalid', () => {
+    expect(isValidGpsSpeedMps(null)).toBe(false);
+    expect(isValidGpsSpeedMps(undefined)).toBe(false);
+  });
+
+  it('GPS_SPEED_INVALID(-1) 등 음수는 invalid', () => {
+    expect(isValidGpsSpeedMps(GPS_SPEED_INVALID)).toBe(false);
+    expect(isValidGpsSpeedMps(-0.001)).toBe(false);
+  });
+
+  it('0(정지)과 양수(이동)는 valid', () => {
+    expect(isValidGpsSpeedMps(0)).toBe(true);
+    expect(isValidGpsSpeedMps(1.5)).toBe(true);
+    expect(isValidGpsSpeedMps(20)).toBe(true);
+  });
+});

--- a/src/constants/location.ts
+++ b/src/constants/location.ts
@@ -20,3 +20,18 @@ export const MAX_PLAUSIBLE_SPEED_MPS = 50;
 // 짧은 간격(< 1s) 두 fix가 거의 같은 위치일 때 d/dt가 비정상적으로 부풀어 false-positive
 // 차단이 발생하는 것을 막는다. 21:29 사고(25km)는 이 임계값보다 한참 위라 영향 없음.
 export const MIN_JUMP_DISTANCE_M = 100;
+
+// iOS CoreLocation은 속도를 측정할 수 없을 때 음수(보통 -1)를 반환한다.
+// stationary/indoor/cold-start 등에서 자주 발생 — null로 정규화해 다운스트림이
+// "측정 불가"와 "정지(0 m/s)"를 명확히 구분하도록 한다.
+// 참고: Apple docs — CLLocation.speed: "A negative value indicates an invalid speed."
+export const GPS_SPEED_INVALID = -1;
+
+/**
+ * GPS speed가 의미 있는 값인지(>= 0) 판정. null/undefined/음수는 모두 invalid.
+ * GPS_SPEED_INVALID 게이트 적용 지점이 여럿(`useNearestStation`의 fix/drop 분기 등)이라
+ * helper로 분리해 의미를 한 곳에 모은다.
+ */
+export function isValidGpsSpeedMps(value: number | null | undefined): value is number {
+  return value != null && value >= 0;
+}

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -12,8 +12,12 @@ import {
   isPlausibleJump,
   type FixSample,
 } from '../utils/locationGates';
-import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY } from '../constants/location';
-import { MAX_STATION_DISTANCE_KM } from '../constants/location';
+import {
+  MAX_ACCURACY_M,
+  MAX_ACCURACY_M_DISPLAY,
+  MAX_STATION_DISTANCE_KM,
+  isValidGpsSpeedMps,
+} from '../constants/location';
 import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../constants/e2e';
 import { createLogger } from '../utils/logger';
 import { pushFusionDebugEntry } from '../utils/fusionDebugBuffer';
@@ -123,7 +127,7 @@ export function useNearestStation(): UseNearestStationReturn {
 
     // raw 신호는 매 fix 즉시 갱신. useFusedNearestStation의 candidates 메모가
     // userLocation 변화에 의존하므로 throttle 안에 두면 천천히 이동할 때 후보가 잠긴다.
-    setSpeedMps(speed != null && speed >= 0 ? speed : null);
+    setSpeedMps(isValidGpsSpeedMps(speed) ? speed : null);
     setAccuracyMeters(accuracy ?? null);
     setUserLocation({ lat: latitude, lng: longitude });
 
@@ -143,7 +147,7 @@ export function useNearestStation(): UseNearestStationReturn {
         lat: latitude,
         lng: longitude,
         accuracyMeters: accuracy ?? null,
-        speedMps: speed != null && speed >= 0 ? speed : null,
+        speedMps: isValidGpsSpeedMps(speed) ? speed : null,
         nearestStation: stationsResult?.primary.name ?? null,
         nearestLine: stationsResult?.primary.line ?? null,
         nearestDistanceKm: stationsResult?.distanceKm ?? null,
@@ -258,7 +262,7 @@ export function useNearestStation(): UseNearestStationReturn {
               lat: location.coords.latitude,
               lng: location.coords.longitude,
               accuracyMeters: location.coords.accuracy,
-              speedMps: dropSpeed != null && dropSpeed >= 0 ? dropSpeed : null,
+              speedMps: isValidGpsSpeedMps(dropSpeed) ? dropSpeed : null,
               nearestStation: null,
               nearestLine: null,
               nearestDistanceKm: null,

--- a/src/tasks/backgroundLocationTask.ts
+++ b/src/tasks/backgroundLocationTask.ts
@@ -13,6 +13,7 @@ import { uploadPosition, type PositionMotion } from '../api/positionUpload';
 import { getCurrentMotionStationary } from '../utils/motionActivity';
 import { getLatestAccelSummary } from '../utils/accelMotionState';
 import type { Route } from '../utils/stationRoute';
+import { isValidGpsSpeedMps } from '../constants/location';
 import type { Station } from '../types/station';
 
 const logger = createLogger('BackgroundLocation');
@@ -73,7 +74,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   }
 
   const { speed } = latest.coords;
-  const speedMps = speed != null && speed >= 0 ? speed : null;
+  const speedMps = isValidGpsSpeedMps(speed) ? speed : null;
 
   try {
     const [destJson, sleepJson, routeJson, allowSpeakerJson] = await Promise.all([

--- a/src/utils/silentPushLocationGate.ts
+++ b/src/utils/silentPushLocationGate.ts
@@ -2,6 +2,7 @@ import * as Location from 'expo-location';
 import { haversine } from './haversine';
 import { findStationByName } from './stationLookup';
 import { createLogger } from './logger';
+import { isValidGpsSpeedMps } from '../constants/location';
 
 const logger = createLogger('SilentPushLocationGate');
 
@@ -84,7 +85,7 @@ function extractMotionFields(
 ): { speedMps?: number; accuracyM?: number } {
   const out: { speedMps?: number; accuracyM?: number } = {};
   // expo-location speed/accuracy는 측정 불가 시 -1 또는 null. 음수/null은 미적용으로 정리.
-  if (typeof coords.speed === 'number' && coords.speed >= 0) out.speedMps = coords.speed;
+  if (isValidGpsSpeedMps(coords.speed)) out.speedMps = coords.speed;
   if (typeof coords.accuracy === 'number' && coords.accuracy >= 0) out.accuracyM = coords.accuracy;
   return out;
 }


### PR DESCRIPTION
## Summary
- `src/constants/location.ts`: `GPS_SPEED_INVALID = -1` 상수 + `isValidGpsSpeedMps` helper type guard
- `useNearestStation` 게이트 3건 helper migration
- **reviewer P1 해소**: `silentPushLocationGate.ts:87` + `backgroundLocationTask.ts:76` 동일 패턴 helper migration → 의미 single-source-of-truth
- `DebugModal` GPS 섹션에 `fused` 라인 추가 (`FusedSpeedSignal` optional prop)
- `buildGpsRows` data-driven `.map` 렌더 / `NO_FUSED_SIGNAL_LABEL` 상수 분리

## 한계 (PR scope 명시 — reviewer P2)
클라에 fused/kalman 산출 함수 없어 본 PR은 **prop 채널만 추가**. `_layout.tsx` 호출부는 `fusedSpeed` 미전달 → 현재 모든 사용자에게 `(no fused signal)` 노출. 실제 backend ADR-009 fused 값 주입은 후속 PR(#819 등)에서. 이번 PR로 "GPS speed 미측정"과 "fused 미연동"을 사용자가 구분 가능.

## Test plan
- [x] `npm test` 3259/3259 pass + 100% coverage (location.ts/DebugModal/useNearestStation 100%)
- [x] `npm run type-check` pass
- [x] code-review P1 해소 / P2(prop 채널 한계) PR description 명시 / P3 follow-up 가능

## 코딩 원칙
- `GPS_SPEED_INVALID` 상수 분리, 매직넘버 없음
- helper single-source-of-truth (4곳 통일)
- `buildGpsRows` 데이터 주도 — 행 추가 시 한 곳만
- `FusedSpeedSignal.source: FusionSource` 기존 enum 재사용
- 디버그 모달 전용 — i18n 미적용 정당

## 후속
- P3-1: `formatFusedSpeed` helper로 포맷 중복 제거
- P3-2: 테스트 fixture factory 추출
- `_layout.tsx`에서 `fusedSpeed` prop 주입 wire — 별도 PR (#819 후속)

Closes #853