### PR TITLE
chore(#856): silent push UX 명확화 — received/fired/toggle 디버그 표기

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -21,10 +21,12 @@ import {
 } from '../hooks/useSilentPushDiagnostics';
 import {
   clearAlarmLog,
+  countSilentPushOutcomes,
   getAlarmLog,
   summarizeAlarmLogBySource,
   type AlarmLogEntry,
 } from '../utils/alarmLog';
+import { SILENT_PUSH_LABELS, buildSilentPushCountValue } from '../constants/labels';
 import {
   clearFusionDebugEntries,
   getFusionDebugEntries,
@@ -125,13 +127,23 @@ function formatAt(ts: number | null): string {
  * - uiLabel: KeyValue 좌측 (좁은 폭 — 약어)
  * - dumpKey: 텍스트 dump의 헤더 (전체 단어)
  * 새 필드는 여기와 hook 타입만 손대면 dump/UI가 동시에 갱신된다.
+ *
+ * #856 — `logs`/`locklessOn` 보강. lastRecv/lastFired 시간만 보고 "왜 안 울리지?" 묻는
+ * 사용자 의문을 한 라인으로 해소하기 위해 received/fired 카운트 + toggle 상태 row 추가.
+ * lastRecv/lastFired row는 카운트와 같은 값으로 흡수돼 단일 라인으로 줄어든다(중복 제거).
  */
 function silentPushDiagRows(
   d: SilentPushDiagnostics,
+  logs: readonly AlarmLogEntry[],
+  locklessOn: boolean,
 ): { uiLabel: string; dumpKey: string; value: string }[] {
   const task = d.taskRegistrationError
     ? `${d.taskRegistrationState} (${d.taskRegistrationError})`
     : d.taskRegistrationState;
+  const silentCounts = countSilentPushOutcomes(logs);
+  const receivedValue = buildSilentPushCountValue(silentCounts.received, formatAt(d.lastReceivedAt));
+  const firedValue = buildSilentPushCountValue(silentCounts.fired, formatAt(d.lastFiredAt));
+  const toggleValue = locklessOn ? SILENT_PUSH_LABELS.toggleOn : SILENT_PUSH_LABELS.toggleOff;
   return [
     { uiLabel: 'permission', dumpKey: 'permission', value: d.permissionStatus ?? '(unknown)' },
     { uiLabel: 'apnsToken', dumpKey: 'apnsToken', value: formatTokenTail(d.apnsToken) },
@@ -141,9 +153,22 @@ function silentPushDiagRows(
     { uiLabel: 'route', dumpKey: 'route', value: d.hasRoute ? 'set' : '(none)' },
     { uiLabel: 'dest', dumpKey: 'destination', value: d.destinationId ?? '(none)' },
     { uiLabel: 'currStn', dumpKey: 'currentStation', value: d.lastNotifiedStationId ?? '(none)' },
-    { uiLabel: 'lastRecv', dumpKey: 'lastReceived', value: formatAt(d.lastReceivedAt) },
-    { uiLabel: 'lastFired', dumpKey: 'lastFired', value: formatAt(d.lastFiredAt) },
+    {
+      uiLabel: SILENT_PUSH_LABELS.receivedKey,
+      dumpKey: SILENT_PUSH_LABELS.receivedKey,
+      value: receivedValue,
+    },
+    {
+      uiLabel: SILENT_PUSH_LABELS.firedKey,
+      dumpKey: SILENT_PUSH_LABELS.firedKey,
+      value: firedValue,
+    },
     { uiLabel: 'lastSkip', dumpKey: 'lastSkipped', value: formatAt(d.lastSkippedAt) },
+    {
+      uiLabel: SILENT_PUSH_LABELS.toggleKey,
+      dumpKey: SILENT_PUSH_LABELS.toggleKey,
+      value: toggleValue,
+    },
   ];
 }
 
@@ -179,6 +204,9 @@ function buildDumpText(args: {
   isMock: boolean;
   silentPush: SilentPushDiagnostics;
   logs: AlarmLogEntry[];
+  // #856: lockless station-passed toggle ON/OFF — Silent Push 섹션 row의 SSOT.
+  // optional — DebugModal 본체는 항상 전달, 단순 dump 단위 테스트는 생략 가능(기본 false).
+  locklessOn?: boolean;
   // #756: OS 큐 dump. 미전달/null = DebugModal에서 한 번도 Refresh 안 한 상태.
   scheduledDump?: ScheduledNotificationDumpEntry[] | null;
 }): string {
@@ -218,7 +246,7 @@ function buildDumpText(args: {
   if (args.isMock) lines.push('(MOCK)');
   lines.push('');
   lines.push('## Silent Push');
-  for (const { dumpKey, value } of silentPushDiagRows(args.silentPush)) {
+  for (const { dumpKey, value } of silentPushDiagRows(args.silentPush, args.logs, args.locklessOn ?? false)) {
     lines.push(`${dumpKey}=${value}`);
   }
   lines.push('');
@@ -293,6 +321,10 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
   const stationName = result?.station.name ?? null;
   const { arrival, isMock } = useArrivalInfo(stationName);
   const silentPush = useSilentPushDiagnostics();
+  // #856: lockless station-passed toggle. OFF면 backend가 받은 silent push도 client가
+  // intermediate 알림을 차단 → "received는 늘어도 fired는 안 늘어남"이 정상 동작.
+  // DebugModal에 한 줄로 노출해 사용자가 설정 위치를 즉시 알 수 있게 한다.
+  const locklessOn = useAppStore((s) => s.locklessStationPassed);
   const fusedLabel = formatStationLabel(result);
   const gpsLabel = formatStationLabel(gpsResult);
   const differs = fusedDiffersFromGps(result, gpsResult);
@@ -365,6 +397,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
       isMock,
       silentPush,
       logs,
+      locklessOn,
       scheduledDump,
     });
     void Share.share({ message });
@@ -385,6 +418,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
     isMock,
     silentPush,
     logs,
+    locklessOn,
     scheduledDump,
   ]);
 
@@ -483,7 +517,7 @@ function DebugModalInner({ onClose, candidateTrains }: DebugModalProps) {
           </Section>
 
           <Section title="Silent Push" colors={colors}>
-            {silentPushDiagRows(silentPush).map(({ uiLabel, value }) => (
+            {silentPushDiagRows(silentPush, logs, locklessOn).map(({ uiLabel, value }) => (
               <KeyValue key={uiLabel} label={uiLabel} value={value} colors={colors} />
             ))}
           </Section>

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -3,6 +3,7 @@ import { AppState, Share } from 'react-native';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import { DebugModal, __test__ } from '../DebugModal';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import { useAppStore } from '../../store/useAppStore';
 import type { AlarmLogEntry } from '../../utils/alarmLog';
 import type { Station, NearestStationResult } from '../../types/station';
 import type { StationArrival } from '../../api/arrivalApi';
@@ -1065,9 +1066,12 @@ describe('DebugModal — Silent Push 진단 섹션 (#506)', () => {
     expect(dump).toContain('activeTrip=…ef567890');
     expect(dump).toContain('apnsEnv=sandbox');
     expect(dump).toContain('taskRegistration=success');
-    expect(dump).toContain('lastReceived=');
-    expect(dump).toContain('lastFired=');
+    // #856 — lastReceived/lastFired는 received/fired 카운트 row로 흡수.
+    expect(dump).toContain('received=0 (last ');
+    expect(dump).toContain('fired=0 (last ');
     expect(dump).toContain('lastSkipped=');
+    // #856 — lockless toggle 기본 OFF(미전달 시 false).
+    expect(dump).toContain('toggle=off');
   });
 
   it('buildDumpText: token 없으면 (none), 시각 null이면 (never)', () => {
@@ -1108,8 +1112,9 @@ describe('DebugModal — Silent Push 진단 섹션 (#506)', () => {
     expect(dump).toContain('activeTrip=(none)');
     expect(dump).toContain('apnsEnv=production');
     expect(dump).toContain('taskRegistration=unknown');
-    expect(dump).toContain('lastReceived=(never)');
-    expect(dump).toContain('lastFired=(never)');
+    // #856 — received/fired 카운트 row가 lastReceived/lastFired 시각을 흡수.
+    expect(dump).toContain('received=0 (last (never))');
+    expect(dump).toContain('fired=0 (last (never))');
     expect(dump).toContain('lastSkipped=(never)');
   });
 
@@ -1314,5 +1319,103 @@ describe('DebugModal — Scheduled queue UI (#756)', () => {
     const sharedMessage = shareSpy.mock.calls[0][0].message;
     expect(sharedMessage).toContain('## Scheduled queue (1)');
     expect(sharedMessage).toContain('bl:T:0:imminent:장한평');
+  });
+});
+
+describe('DebugModal — Silent Push UX 카운트/토글 (#856)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupHookDefaults();
+    act(() => {
+      useAppStore.setState({ locklessStationPassed: false });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useAppStore.setState({ locklessStationPassed: false });
+    });
+  });
+
+  it('alarm log에 silent-push-received/fired/skipped가 있으면 received/fired 카운트 row가 노출된다', async () => {
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: 1, source: 'silent-push-received', outcome: 'received' },
+      { ts: 2, source: 'silent-push-received', outcome: 'received' },
+      { ts: 3, source: 'silent-push-fired', outcome: 'fired' },
+      { ts: 4, source: 'silent-push-skipped', outcome: 'suppressed' },
+    ]);
+    mockUseSilentPushDiagnostics.mockReturnValue({
+      apnsToken: null,
+      activeTripToken: null,
+      apnsEnv: 'sandbox',
+      permissionStatus: null,
+      taskRegistrationState: 'success',
+      taskRegistrationError: null,
+      lastReceivedAt: new Date('2026-06-04T01:23:45Z').getTime(),
+      lastFiredAt: new Date('2026-06-04T01:24:00Z').getTime(),
+      lastSkippedAt: null,
+      hasRoute: false,
+      destinationId: null,
+      lastNotifiedStationId: null,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    // logs 도착 후 row가 갱신될 때까지 대기. value에 카운트(2/1)와 시간이 함께 노출.
+    await waitFor(() => expect(screen.getByText(/^2 \(last \d{2}:\d{2}:\d{2}\)$/)).toBeTruthy());
+    expect(screen.getByText(/^1 \(last \d{2}:\d{2}:\d{2}\)$/)).toBeTruthy();
+  });
+
+  it('locklessStationPassed=false면 toggle row가 OFF 안내 문구로 노출된다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText(/lockless station-passed 비활성/)).toBeTruthy();
+  });
+
+  it('locklessStationPassed=true면 toggle row가 "on"으로 노출된다', async () => {
+    act(() => {
+      useAppStore.setState({ locklessStationPassed: true });
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('on')).toBeTruthy();
+  });
+
+  it('Share dump에 received/fired 카운트와 toggle 라벨이 포함된다', async () => {
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: 1, source: 'silent-push-received', outcome: 'received' },
+      { ts: 2, source: 'silent-push-fired', outcome: 'fired' },
+    ]);
+    act(() => {
+      useAppStore.setState({ locklessStationPassed: true });
+    });
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    // logs 반영(Alarm log 카운트로 검증) 후 share — useCallback closure가 신규 logs 캡처.
+    await waitFor(() => expect(screen.getByText('Alarm log (2)')).toBeTruthy());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    const msg = shareSpy.mock.calls[0][0].message;
+    expect(msg).toContain('received=1');
+    expect(msg).toContain('fired=1');
+    expect(msg).toContain('toggle=on');
+    shareSpy.mockRestore();
+  });
+
+  it('빈 log + lastReceived null이면 received=0 (last (never)) 노출', async () => {
+    mockUseSilentPushDiagnostics.mockReturnValue({
+      apnsToken: null,
+      activeTripToken: null,
+      apnsEnv: 'sandbox',
+      permissionStatus: null,
+      taskRegistrationState: 'unknown',
+      taskRegistrationError: null,
+      lastReceivedAt: null,
+      lastFiredAt: null,
+      lastSkippedAt: null,
+      hasRoute: false,
+      destinationId: null,
+      lastNotifiedStationId: null,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getAllByText('0 (last (never))').length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/constants/__tests__/labels.test.ts
+++ b/src/constants/__tests__/labels.test.ts
@@ -1,4 +1,8 @@
-import { buildFallbackSequenceLabel } from '../labels';
+import {
+  buildFallbackSequenceLabel,
+  buildSilentPushCountValue,
+  SILENT_PUSH_LABELS,
+} from '../labels';
 
 describe('buildFallbackSequenceLabel (#855)', () => {
   describe('arrivalSeconds > 0 — "(약 M분 후)" 결합', () => {
@@ -34,5 +38,34 @@ describe('buildFallbackSequenceLabel (#855)', () => {
     it('arrivalSeconds 음수면 분 라벨 생략 (이론상 발생 안하지만 가드)', () => {
       expect(buildFallbackSequenceLabel(1, -10)).toBe('약 2정거장 전');
     });
+  });
+});
+
+describe('buildSilentPushCountValue (#856)', () => {
+  it('lastFormatted가 있으면 "N (last X)"로 결합', () => {
+    expect(buildSilentPushCountValue(15, '01:23:45')).toBe('15 (last 01:23:45)');
+    expect(buildSilentPushCountValue(0, '(never)')).toBe('0 (last (never))');
+  });
+
+  it('lastFormatted가 null이면 카운트만', () => {
+    expect(buildSilentPushCountValue(3, null)).toBe('3');
+    expect(buildSilentPushCountValue(0, null)).toBe('0');
+  });
+});
+
+describe('SILENT_PUSH_LABELS (#856)', () => {
+  it('toggle off 라벨은 lockless 비활성 + 설정 안내 문구를 포함한다', () => {
+    expect(SILENT_PUSH_LABELS.toggleOff).toContain('lockless');
+    expect(SILENT_PUSH_LABELS.toggleOff).toContain('설정');
+  });
+
+  it('toggle on 라벨은 짧은 활성 표기다', () => {
+    expect(SILENT_PUSH_LABELS.toggleOn).toBe('on');
+  });
+
+  it('received/fired/toggle key는 dump 헤더용 안정 식별자', () => {
+    expect(SILENT_PUSH_LABELS.receivedKey).toBe('received');
+    expect(SILENT_PUSH_LABELS.firedKey).toBe('fired');
+    expect(SILENT_PUSH_LABELS.toggleKey).toBe('toggle');
   });
 });

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -35,3 +35,44 @@ export function buildFallbackSequenceLabel(index: number, arrivalSeconds?: numbe
   const minutes = Math.max(1, Math.round(arrivalSeconds / 60));
   return `${base} (약 ${minutes}분 후)`;
 }
+
+/**
+ * #856 — DebugModal Silent Push 섹션 라벨.
+ *
+ * `lastReceivedAt`만 보고 "왜 안 울리지?" 묻는 사용자 의문 해결을 위해 received/fired
+ * 카운트와 lockless toggle 상태를 한 라인씩 노출. 측정 인프라가 아니라 UX 표기 보조.
+ *
+ * 텍스트는 JSX 하드코딩 금지(글로벌 룰 3) 정책 + 추후 i18n 일괄 전환 대비 위치만 분리.
+ * (DebugModal은 dev/internal 영역이라 i18n 미적용은 의도된 stand-still — i18n 전환 시 일괄.)
+ */
+export const SILENT_PUSH_LABELS = {
+  /** received row 라벨. 카운트와 last time을 결합한다. */
+  receivedKey: 'received',
+  /** fired row 라벨. 카운트와 last time을 결합한다. */
+  firedKey: 'fired',
+  /** lockless station-passed toggle row 라벨. */
+  toggleKey: 'toggle',
+  /** toggle ON 표기 — 활성. */
+  toggleOn: 'on',
+  /** toggle OFF 표기 — lockless 비활성, 설정에서 켜기 안내. */
+  toggleOff: 'off — lockless station-passed 비활성 (설정에서 켜기)',
+} as const;
+
+/**
+ * received/fired row의 value 문자열을 만든다.
+ *
+ * 예:
+ *   buildSilentPushCountValue(15, '01:23:45')  → '15 (last 01:23:45)'
+ *   buildSilentPushCountValue(0, '(never)')    → '0 (last (never))'
+ *   buildSilentPushCountValue(3, null)         → '3'
+ *
+ * `lastFormatted`는 이미 포맷된 문자열(formatAt 결과 등). null이면 last 라벨 생략.
+ * 카운트와 시각을 한 줄로 합쳐 KeyValue row 1개로 표시.
+ */
+export function buildSilentPushCountValue(
+  count: number,
+  lastFormatted: string | null,
+): string {
+  if (lastFormatted == null) return String(count);
+  return `${count} (last ${lastFormatted})`;
+}

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -35,6 +35,7 @@ import {
   logSilentPushSkipped,
   logAlertFallbackFired,
   summarizeAlarmLogBySource,
+  countSilentPushOutcomes,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -940,6 +941,37 @@ describe('alarmLog', () => {
       const result = summarizeAlarmLogBySource(entries);
       expect(result).toEqual({ fg: 1 });
       expect(Object.keys(result)).not.toContain('bg');
+    });
+  });
+
+  describe('countSilentPushOutcomes (#856)', () => {
+    it('빈 배열이면 모두 0', () => {
+      expect(countSilentPushOutcomes([])).toEqual({ received: 0, fired: 0, skipped: 0 });
+    });
+
+    it('silent-push-received / silent-push-fired / silent-push-skipped만 집계한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received' }),
+        makeEntry({ source: 'silent-push-received' }),
+        makeEntry({ source: 'silent-push-received' }),
+        makeEntry({ source: 'silent-push-fired' }),
+        makeEntry({ source: 'silent-push-skipped' }),
+        makeEntry({ source: 'silent-push-skipped' }),
+      ];
+      expect(countSilentPushOutcomes(entries)).toEqual({ received: 3, fired: 1, skipped: 2 });
+    });
+
+    it('silent push 외 source(fg/bg/bg-scheduled/alert-fallback-fired/fg-hydrate/fg-evaluated)는 무시', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'fg' }),
+        makeEntry({ source: 'bg' }),
+        makeEntry({ source: 'bg-scheduled' }),
+        makeEntry({ source: 'alert-fallback-fired' }),
+        makeEntry({ source: 'fg-hydrate' }),
+        makeEntry({ source: 'fg-evaluated' }),
+        makeEntry({ source: 'silent-push-received' }),
+      ];
+      expect(countSilentPushOutcomes(entries)).toEqual({ received: 1, fired: 0, skipped: 0 });
     });
   });
 

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -432,6 +432,48 @@ export function summarizeAlarmLogBySource(
   return counts;
 }
 
+/**
+ * Silent push outcome별 집계 (#856).
+ *
+ * DebugModal Silent Push 섹션에서 "lastRecv 시간만 보고 왜 안 울리지?" 의문을 해소하기 위한
+ * UX 보조 카운트. `summarizeAlarmLogBySource`와 별개로 silent push 3개 source만 좁혀 집계.
+ *
+ * - `received`: backend가 보낸 silent push 도달 횟수 (`silent-push-received`)
+ * - `fired`: 위치 게이트 통과해 실제 알림이 노출된 횟수 (`silent-push-fired`)
+ * - `skipped`: 위치 게이트 실패로 발사 안 한 횟수 (`silent-push-skipped`)
+ *
+ * 새 silent push source가 추가되면 SILENT_PUSH_OUTCOME_SOURCES 맵에 한 줄만 더하면
+ * 자동 반영 (글로벌 룰 3 — 데이터 주도).
+ */
+const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcomeCounts | null> = {
+  'silent-push-received': 'received',
+  'silent-push-fired': 'fired',
+  'silent-push-skipped': 'skipped',
+  fg: null,
+  bg: null,
+  'fg-evaluated': null,
+  'bg-scheduled': null,
+  'alert-fallback-fired': null,
+  'fg-hydrate': null,
+};
+
+export interface SilentPushOutcomeCounts {
+  received: number;
+  fired: number;
+  skipped: number;
+}
+
+export function countSilentPushOutcomes(
+  entries: readonly AlarmLogEntry[],
+): SilentPushOutcomeCounts {
+  const counts: SilentPushOutcomeCounts = { received: 0, fired: 0, skipped: 0 };
+  for (const entry of entries) {
+    const bucket = SILENT_PUSH_OUTCOME_SOURCES[entry.source];
+    if (bucket !== null) counts[bucket] += 1;
+  }
+  return counts;
+}
+
 export function logSuppressedGate(
   reason: 'gate-age' | 'gate-accuracy' | 'gate-jump',
   location: AlarmLogLocation,


### PR DESCRIPTION
## Summary
- DebugModal Silent Push 섹션에 `received=N (last HH:mm:ss)` / `fired=N (last HH:mm:ss)` 카운트 행 추가
- `lockless` toggle 상태 row 추가 (`on` / `off — 설정에서 켜기` 액션 hint)
- `src/utils/alarmLog.ts`: `countSilentPushOutcomes` + `SILENT_PUSH_OUTCOME_SOURCES` Record (데이터 주도, 새 source 추가 시 type error로 누락 즉시 인지)
- `src/constants/labels.ts`: `SILENT_PUSH_LABELS` 상수 + `buildSilentPushCountValue` helper
- 기존 `lastReceived`/`lastFired` dump key를 카운트 row로 흡수 (외부 파서 부재 확인 — 회귀 0)

## 사용자 의도 (b) 확정
사용자가 본 "왜 안 울리지" 의문 즉시 해소 — "received 15 / fired 0 / toggle: off (설정에서 켜기)" 한 화면.

## Test plan
- [x] `npm test` 3320/3320 pass + 100% coverage 글로벌 강제
- [x] `npm run type-check` pass
- [x] code-review 에이전트 **PASS — no blockers** (데이터 주도/하드코딩 0/회귀 0)
- [x] 신규 케이스: 카운트 집계/lockless on·off 라벨/빈 log

## 코딩 원칙
- 라벨 텍스트 `constants/labels.ts` 분리 (JSX 한국어 하드코딩 없음)
- `SILENT_PUSH_OUTCOME_SOURCES` Record 데이터 주도 — 새 source 추가 시 type error
- alarm log 집계 `reduce` 순회, source/status 분기 if-else 없음
- 인덱스/매직넘버 하드코딩 없음
- 디버그 모달 전용 (__DEV__) — i18n 미적용 정당

Closes #856