### PR TITLE
chore(#854): boarding-prompt 9단 게이트 blocked reason 측정 자동화

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "data:fetch-quick-exit": "node scripts/fetch-quick-exit.js",
     "data:build-transfer-times": "node scripts/build-transfer-times.js",
     "tail:capture": "scripts/capture-tail.sh",
+    "measure:blocked-reasons": "scripts/capture-blocked-reasons.sh",
+    "measure:blocked-reasons:aggregate": "node scripts/aggregate-blocked-reasons.js",
     "perf:report": "node scripts/perf-report.js",
     "e2e": "maestro test .maestro/flows/",
     "e2e:home": "maestro test .maestro/flows/home/",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,59 @@
+# scripts/
+
+이 디렉토리에는 backend/data/측정 워크플로우 보조 스크립트가 있다.
+
+## measure:blocked-reasons — boarding-prompt 9단 게이트 분포 측정
+
+`#854`. 실기기 trip 중 backend `boarding-prompt: gate blocked` 로그를 30분 캡처해
+9단 AND 게이트 중 어느 단계에서 차단됐는지 분포를 집계한다.
+
+### 사용 (1줄)
+
+```bash
+# 다음 trip 출발 직전에 실행. 30분 자동 종료. Ctrl+C로도 정상 종료.
+npm run measure:blocked-reasons -- --token=35b3502c --duration=30m
+```
+
+- `--token=<8글자 prefix>`: 특정 trip 토큰만 필터 (생략 시 전체)
+- `--duration=30m | 15m | 600s | 1h`: 캡처 길이
+- `--output=path/file.jsonl`: 결과 jsonl 경로
+- `--no-aggregate`: capture만, 집계 생략
+
+결과:
+- `tasks/blocked-reasons-<ts>-<label>.jsonl` — 필터된 blocked 이벤트 raw
+- `tasks/blocked-reasons-<ts>-<label>.raw.jsonl` — wrangler tail 원본
+- `tasks/blocked-reasons-<ts>-<label>.summary.md` — reason별 카운트 표 + 임계값 stamp
+
+### 결과 해석
+
+reason 분포에서 비중 1위가 다음 작업의 후보:
+
+| reason | 의미 | 다음 작업 후보 |
+| --- | --- | --- |
+| `accuracy-too-poor` | 평균 accuracy ≥ 50m | 임계 완화 또는 위치 ingest 가중치 검토 |
+| `window-too-small` | 60s 윈도우 sample < 3 | foreground 위치 폴링 cadence 점검 |
+| `direction-mismatch` | cosine < 0.7 | 환승 leg 방향 데이터 정합 확인 |
+| `origin-too-far` | 출발역 > 100m | BoardingLock 동기화 / 출발역 좌표 정합 |
+| `speed-too-low` | fused speed < 5 km/h | fused speed weight 또는 Kalman 튜닝 |
+| `motion-not-moving` | motion 불일치 | Core Motion 권한/캘리브레이션 |
+| `silenced` / `already-fired` | 정상 운영 차단 | 행동 변경 불필요 |
+
+`__unknown:<reason>`이 보이면 backend가 새 reason을 추가했지만 본 스크립트가 미반영 —
+실제로는 `boardingPrompt.ts`에서 정규식으로 자동 추출하므로 backend 빌드 직후 재실행으로 해소.
+
+### 신뢰성 메모
+
+`wrangler tail`은 inactivity로 silent disconnect 될 수 있다 (lesson_wrangler_tail_wrapper_reliability).
+스크립트 종료 시 raw tail line 수가 0이면 인증/접속/disconnect를 즉시 의심하라는 경고가
+stderr에 출력된다. 0건이 정상이라고 결론짓기 전에 raw tail에 다른 이벤트가 있는지 확인.
+
+### SSOT 정합
+
+`scripts/aggregate-blocked-reasons.js`는 `backend/alarm-worker/src/boardingPrompt.ts`의
+`GateSkipReason` union literals와 임계값 export 상수를 정규식으로 직접 추출한다 —
+새 reason/임계값 추가 시 스크립트 수정 불필요 (CLAUDE.md 글로벌 룰 3).
+
+## tail:capture — 일반 wrangler tail (#622)
+
+`scripts/capture-tail.sh`. backend 전반 진단용 raw tail. boarding-prompt 특화 분석은
+위 `measure:blocked-reasons`를 사용.

--- a/scripts/aggregate-blocked-reasons.js
+++ b/scripts/aggregate-blocked-reasons.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * boarding-prompt 9단 게이트 blocked reason 분포 집계 — #854.
+ *
+ * 입력: capture-blocked-reasons.sh가 만든 jsonl (wrangler tail JSON line / 라인 당 1 이벤트).
+ *       각 라인은 보통 `{ "logs": [{ "message": ["<json-string>", ...] }], ... }` 형태이며,
+ *       message[0]에 `console.log(JSON.stringify({ msg, ...meta }))` 결과가 박혀 있다.
+ *
+ * SSOT 정합:
+ *   backend/alarm-worker/src/boardingPrompt.ts의 `GateSkipReason` union literals를
+ *   정규식으로 직접 추출해 reasons label 집합을 구성한다. 새 reason 추가/제거 시 본
+ *   스크립트 수정 없이 자동 반영 (CLAUDE.md 글로벌 룰 3 — 하드코딩 금지).
+ *
+ * 임계값 stamp:
+ *   ORIGIN_RADIUS_KM / DIRECTION_COSINE_THRESHOLD / MIN_WINDOW_SAMPLES /
+ *   MIN_FUSED_SPEED_KMH / DISMISS_SILENCE_MS 도 같은 파일에서 정규식으로 읽어
+ *   결과 summary에 함께 출력 — 측정 시점의 설정을 영속화.
+ *
+ * 출력:
+ *   - 표 형태(markdown): reason / count / share / 임계값 stamp
+ *   - 입력 파일 옆에 .summary.md 저장
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const BOARDING_PROMPT_PATH = path.join(
+  REPO_ROOT,
+  'backend/alarm-worker/src/boardingPrompt.ts',
+);
+const THRESHOLD_NAMES = [
+  'ORIGIN_RADIUS_KM',
+  'DIRECTION_COSINE_THRESHOLD',
+  'MIN_WINDOW_SAMPLES',
+  'MIN_FUSED_SPEED_KMH',
+  'DISMISS_SILENCE_MS',
+];
+
+function readArgs() {
+  const [input] = process.argv.slice(2);
+  if (!input) {
+    console.error('사용: node scripts/aggregate-blocked-reasons.js <input.jsonl>');
+    process.exit(2);
+  }
+  return { input };
+}
+
+/**
+ * backend의 GateSkipReason union에서 string literal들을 추출.
+ *   export type GateSkipReason =
+ *     | 'no-series'
+ *     | 'window-too-small'
+ *     | ...;
+ */
+function extractKnownReasons(source) {
+  const unionMatch = source.match(/export type GateSkipReason\s*=([\s\S]*?);/);
+  if (!unionMatch) {
+    throw new Error(
+      'GateSkipReason union을 ' +
+        BOARDING_PROMPT_PATH +
+        '에서 찾지 못했습니다. backend 변경 확인 필요.',
+    );
+  }
+  const literals = Array.from(unionMatch[1].matchAll(/'([^']+)'/g)).map((m) => m[1]);
+  if (literals.length === 0) {
+    throw new Error('GateSkipReason union literals 추출 실패.');
+  }
+  return literals;
+}
+
+/**
+ * 임계값 stamp — 정규식으로 export const 한 줄을 그대로 추출.
+ * 형태: `export const NAME = <expr>;` 같은 한 줄을 가정한다.
+ *       multi-line 값은 ($) 앵커로 차단해 부정확한 합성 결과를 막는다.
+ */
+function extractThresholdStamps(source) {
+  return THRESHOLD_NAMES.reduce((acc, name) => {
+    const re = new RegExp(
+      '^export const ' + name + '\\s*=\\s*([^;\\n]+);',
+      'm',
+    );
+    const m = source.match(re);
+    acc[name] = m ? m[1].trim() : '(미발견)';
+    return acc;
+  }, {});
+}
+
+function tryParseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * wrangler tail의 envelope에서 console.log 메시지를 끄집어 후보 문자열 배열로 반환.
+ * 두 형태 모두 허용: (a) 라인이 곧바로 JSON object (b) wrangler 래퍼 (logs[].message[]).
+ */
+function collectCandidateMessages(parsed) {
+  if (typeof parsed === 'string') return [parsed];
+  if (!parsed || typeof parsed !== 'object') return [];
+  if (!Array.isArray(parsed.logs)) return [JSON.stringify(parsed)];
+  const out = [];
+  for (const entry of parsed.logs) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (!Array.isArray(entry.message)) continue;
+    for (const part of entry.message) {
+      if (typeof part === 'string') out.push(part);
+    }
+  }
+  return out;
+}
+
+/**
+ * 한 줄에서 boarding-prompt blocked 이벤트를 1건 추출 (없으면 null).
+ * knownReasons에 없으면 `__unknown:<reason>`으로 표기해 추후 SSOT 드리프트 감지.
+ */
+function parseLine(line, knownReasons) {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const parsed = tryParseJson(trimmed);
+  if (!parsed) return null;
+
+  const candidates = collectCandidateMessages(parsed);
+  for (const candidate of candidates) {
+    const decoded = tryParseJson(candidate);
+    if (!decoded || typeof decoded !== 'object') continue;
+    if (decoded.msg !== 'boarding-prompt: gate blocked') continue;
+    const reason = decoded.reason;
+    if (typeof reason !== 'string') continue;
+    return {
+      reason: knownReasons.has(reason) ? reason : '__unknown:' + reason,
+      token: typeof decoded.token === 'string' ? decoded.token : null,
+      ts: typeof decoded.ts === 'number' ? decoded.ts : null,
+    };
+  }
+  return null;
+}
+
+function aggregate(input, knownReasons) {
+  const reasonSet = new Set(knownReasons);
+  const perReason = new Map(knownReasons.map((r) => [r, 0]));
+  const perToken = new Map();
+
+  const lines = fs.readFileSync(input, 'utf8').split('\n');
+  let blockedEvents = 0;
+  let unknownReasons = 0;
+
+  for (const line of lines) {
+    const evt = parseLine(line, reasonSet);
+    if (!evt) continue;
+    blockedEvents += 1;
+    perReason.set(evt.reason, (perReason.get(evt.reason) || 0) + 1);
+    if (evt.reason.startsWith('__unknown:')) unknownReasons += 1;
+    if (evt.token) perToken.set(evt.token, (perToken.get(evt.token) || 0) + 1);
+  }
+
+  return {
+    totalLines: lines.length,
+    blockedEvents,
+    unknownReasons,
+    perReason,
+    perToken,
+  };
+}
+
+function renderMarkdown(input, result, thresholds) {
+  const { blockedEvents, perReason, perToken, totalLines, unknownReasons } = result;
+  const denominator = blockedEvents || 1;
+
+  const reasonRows = Array.from(perReason.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, count]) => {
+      const share = ((count / denominator) * 100).toFixed(1);
+      return '| `' + reason + '` | ' + count + ' | ' + share + '% |';
+    });
+
+  const tokenEntries = Array.from(perToken.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  const tokenBlock =
+    tokenEntries.length === 0
+      ? '_token 정보 없음 (백엔드 log meta 누락 또는 token 필드 비포함)_'
+      : [
+          '| token | count |',
+          '| --- | ---: |',
+          ...tokenEntries.map(([t, c]) => '| `' + t + '` | ' + c + ' |'),
+        ].join('\n');
+
+  const thresholdRows = Object.entries(thresholds).map(
+    ([name, value]) => '| `' + name + '` | ' + value + ' |',
+  );
+
+  return [
+    '# boarding-prompt blocked reason 분포',
+    '',
+    '- 입력 파일: `' + path.relative(REPO_ROOT, input) + '`',
+    '- 캡처 라인 수: ' + totalLines,
+    '- blocked 이벤트: ' + blockedEvents,
+    '- 미식별 reason: ' + unknownReasons,
+    '',
+    '## reason 분포 (count desc)',
+    '',
+    '| reason | count | share |',
+    '| --- | ---: | ---: |',
+    ...reasonRows,
+    '',
+    '## token 상위 10',
+    '',
+    tokenBlock,
+    '',
+    '## 임계값 stamp (boardingPrompt.ts 자동 추출)',
+    '',
+    '| name | value |',
+    '| --- | --- |',
+    ...thresholdRows,
+    '',
+    '_자동 생성 — scripts/aggregate-blocked-reasons.js (#854)._',
+    '',
+  ].join('\n');
+}
+
+function main() {
+  const { input } = readArgs();
+  if (!fs.existsSync(input)) {
+    console.error('입력 파일 없음: ' + input);
+    process.exit(1);
+  }
+  const source = fs.readFileSync(BOARDING_PROMPT_PATH, 'utf8');
+  const knownReasons = extractKnownReasons(source);
+  const thresholds = extractThresholdStamps(source);
+
+  const result = aggregate(input, knownReasons);
+  const markdown = renderMarkdown(input, result, thresholds);
+
+  const summaryPath = input.replace(/\.jsonl?$/, '') + '.summary.md';
+  fs.writeFileSync(summaryPath, markdown, 'utf8');
+
+  process.stdout.write(markdown);
+  console.error('\n[aggregate] summary → ' + summaryPath);
+}
+
+main();

--- a/scripts/capture-blocked-reasons.sh
+++ b/scripts/capture-blocked-reasons.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# boarding-prompt 9단 게이트 blocked reason 분포 측정 — #854.
+#
+# 사용:
+#   scripts/capture-blocked-reasons.sh                       # 30분, 전체 trip
+#   scripts/capture-blocked-reasons.sh --duration=15m
+#   scripts/capture-blocked-reasons.sh --token=35b3502c       # 특정 trip 8글자 prefix
+#   scripts/capture-blocked-reasons.sh --output=blocked.jsonl
+#   scripts/capture-blocked-reasons.sh --no-aggregate         # capture만, 집계 생략
+#
+# npm 경유:
+#   npm run measure:blocked-reasons -- --token=35b3502c --duration=15m
+#
+# 동작:
+#   - wrangler tail JSON을 jsonl로 캡처 → boarding-prompt 이벤트만 필터해 OUT 파일에 저장
+#   - duration 초과 또는 Ctrl+C 시 정상 종료 → aggregate 스크립트 자동 호출
+#   - timeout 도구 미존재 환경(macOS) 대비 background sleep + kill로 자체 구현
+#
+# 신뢰성 메모 (lesson_wrangler_tail_wrapper_reliability):
+#   wrangler tail은 inactivity로 silent disconnect 될 수 있다. 이 스크립트는
+#   "수신된 데이터의 시각 stamp"와 "마지막 line 수신 후 inactivity 경고"를 stderr로 찍어,
+#   30분 후 결과 라인이 비정상적으로 적으면 즉시 인지할 수 있게 한다.
+set -euo pipefail
+
+DURATION="30m"
+TOKEN_FILTER=""
+OUTPUT=""
+DO_AGGREGATE=1
+
+for arg in "$@"; do
+  case "$arg" in
+    --duration=*) DURATION="${arg#--duration=}" ;;
+    --token=*) TOKEN_FILTER="${arg#--token=}" ;;
+    --output=*) OUTPUT="${arg#--output=}" ;;
+    --no-aggregate) DO_AGGREGATE=0 ;;
+    -h|--help)
+      grep -E '^# ' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "[capture-blocked-reasons] 알 수 없는 옵션: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# duration → seconds 변환 (예: 30m, 15m, 600s, 1h).
+case "$DURATION" in
+  *h) DURATION_SEC=$(( ${DURATION%h} * 3600 )) ;;
+  *m) DURATION_SEC=$(( ${DURATION%m} * 60 )) ;;
+  *s) DURATION_SEC=${DURATION%s} ;;
+  *) DURATION_SEC="$DURATION" ;;
+esac
+
+if [[ -n "$TOKEN_FILTER" && ! "$TOKEN_FILTER" =~ ^[A-Za-z0-9]{4,}$ ]]; then
+  echo "[capture-blocked-reasons] --token은 영숫자 4글자 이상이어야 합니다: $TOKEN_FILTER" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TS=$(date +%Y%m%d-%H%M%S)
+LABEL="${TOKEN_FILTER:-all}"
+if [[ -z "$OUTPUT" ]]; then
+  OUTPUT="$REPO_ROOT/tasks/blocked-reasons-$TS-$LABEL.jsonl"
+fi
+RAW_TAIL="$REPO_ROOT/tasks/blocked-reasons-$TS-$LABEL.raw.jsonl"
+
+WORKER_NAME=$(awk -F'"' '/^name *=/ {print $2; exit}' "$REPO_ROOT/backend/alarm-worker/wrangler.toml")
+if [[ -z "$WORKER_NAME" ]]; then
+  echo "[capture-blocked-reasons] backend/alarm-worker/wrangler.toml에서 worker name 추출 실패" >&2
+  exit 1
+fi
+
+mkdir -p "$REPO_ROOT/tasks"
+
+echo "[capture-blocked-reasons] worker:     $WORKER_NAME"
+echo "[capture-blocked-reasons] duration:   ${DURATION_SEC}s"
+echo "[capture-blocked-reasons] token:      ${TOKEN_FILTER:-(전체)}"
+echo "[capture-blocked-reasons] 캡처 경로:  $OUTPUT"
+echo "[capture-blocked-reasons] raw tail:   $RAW_TAIL"
+echo "[capture-blocked-reasons] Ctrl+C 종료 시에도 aggregate가 실행됩니다."
+echo
+
+TAIL_PID=""
+TIMER_PID=""
+EXIT_REASON="unknown"
+
+cleanup() {
+  set +e
+  if [[ -n "$TIMER_PID" ]] && kill -0 "$TIMER_PID" 2>/dev/null; then
+    kill "$TIMER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$TAIL_PID" ]] && kill -0 "$TAIL_PID" 2>/dev/null; then
+    kill "$TAIL_PID" 2>/dev/null || true
+    wait "$TAIL_PID" 2>/dev/null || true
+  fi
+  echo
+  echo "[capture-blocked-reasons] 종료 사유: $EXIT_REASON"
+
+  local raw_lines=0
+  local filtered_lines=0
+  [[ -f "$RAW_TAIL" ]] && raw_lines=$(wc -l < "$RAW_TAIL" | tr -d ' ')
+  [[ -f "$OUTPUT" ]] && filtered_lines=$(wc -l < "$OUTPUT" | tr -d ' ')
+  echo "[capture-blocked-reasons] raw tail lines:    $raw_lines"
+  echo "[capture-blocked-reasons] blocked events:    $filtered_lines"
+
+  if [[ "$raw_lines" -eq 0 ]]; then
+    echo "[capture-blocked-reasons] 경고: tail 라인 0건. wrangler 인증/접속 또는 inactivity disconnect 가능." >&2
+  fi
+
+  if [[ "$DO_AGGREGATE" -eq 1 && "$filtered_lines" -gt 0 ]]; then
+    echo "[capture-blocked-reasons] aggregate 실행 → $OUTPUT"
+    (cd "$REPO_ROOT" && node scripts/aggregate-blocked-reasons.js "$OUTPUT") || true
+  elif [[ "$DO_AGGREGATE" -eq 1 ]]; then
+    echo "[capture-blocked-reasons] blocked 이벤트 0건 → aggregate 생략"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# duration 만료를 별 프로세스로 관리 (macOS는 timeout 미내장).
+(
+  sleep "$DURATION_SEC"
+  echo "[capture-blocked-reasons] duration ${DURATION_SEC}s 도달 → 종료" >&2
+  kill -TERM $$ 2>/dev/null || true
+) &
+TIMER_PID=$!
+
+# wrangler tail을 jsonl로 받아 raw에 tee + boarding-prompt 이벤트만 OUTPUT으로 필터.
+# 필터는 awk로 jq 의존 없이 처리 — token 옵션과 reason 추출은 aggregate 단계에서.
+cd "$REPO_ROOT/backend/alarm-worker"
+
+set +e
+npx wrangler tail "$WORKER_NAME" --format=json 2>>"$RAW_TAIL.stderr" \
+  | tee -a "$RAW_TAIL" \
+  | awk -v token="$TOKEN_FILTER" '
+      /"boarding-prompt: gate blocked"/ {
+        if (token == "" || index($0, token) > 0) {
+          print
+          fflush()
+        }
+      }
+    ' >> "$OUTPUT" &
+TAIL_PID=$!
+
+wait "$TAIL_PID"
+TAIL_EXIT=$?
+set -e
+
+if [[ $TAIL_EXIT -eq 0 ]]; then
+  EXIT_REASON="wrangler tail이 자체 종료 (inactivity disconnect 의심)"
+else
+  EXIT_REASON="wrangler tail PID=$TAIL_PID exit=$TAIL_EXIT"
+fi


### PR DESCRIPTION
## Summary
- `scripts/capture-blocked-reasons.sh` (153줄, +x) — wrangler tail 30분 캡처 + trap 정상 종료 + inactivity 감지 2단계
- `scripts/aggregate-blocked-reasons.js` (247줄, +x) — backend `boardingPrompt.ts`에서 `GateSkipReason` union + 임계값 5종 **정규식 추출 (SSOT)**. drift 시 `__unknown:<reason>` 마커로 즉시 가시화
- `scripts/README.md` (59줄) — 사용 가이드 + reason별 후속 작업 매트릭스
- `package.json` — `measure:blocked-reasons` / `measure:blocked-reasons:aggregate` 2 npm script (**의존성 변경 0**)

## 사용 (1줄)
```bash
npm run measure:blocked-reasons -- --token=35b3502c --duration=30m
```
다음 trip 출발 직전 실행 → 30분 후 자동 종료 → `tasks/blocked-reasons-*.summary.md`에 reason별 카운트 + 임계값 stamp.

## SSOT 정합 (CLAUDE.md 글로벌 룰 3)
reason 라벨 / 임계값 모두 `boardingPrompt.ts`에서 정규식 추출 — 새 reason 추가/제거 시 스크립트 무수정. drift 시 `__unknown` 마커로 즉시 인지.

## Test plan
- [x] `npm run type-check` pass
- [x] `bash -n` / `node --check` syntax pass
- [x] fixture jsonl 7라인 dry-run → reason 분포/token 상위/임계값 stamp 정확 출력
- [x] empty input / bad option / 미인증 wrangler 환경 graceful
- [x] code-review **PASS — no blockers** (P0/P1 0건, P2 3건 후속 권고)

## 코딩 원칙
- reason union backend 직접 추출 (하드코딩 0)
- 임계값 5종 stamp (SSOT 정합)
- 집계 `reduce` 순회 (분기 if-else 없음)
- backend/클라 무수정 (scripts만)

## 후속 (별 PR, P2)
- P2-1: cleanup 재진입 방지(`trap - EXIT INT TERM`) + timer `wait` 호출
- P2-2: 정규식 multi-line `export const` warning
- P2-3: `parseFailed` 카운터 summary 노출 (lesson 정합)

Closes #854