### PR TITLE
chore(#863): Cloudflare Worker observability logs persist 활성화

### DIFF
--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -34,6 +34,25 @@ preview_id = "53a86628f78c48fa91fa954f84514df3"
 [triggers]
 crons = ["*/1 * * * *"]
 
+# Observability — Workers Logs persist (#863)
+# `wrangler tail`은 실시간 1~2분 윈도우만 잡혀 retrospective 진단 불가.
+# logs만 활성화해 invocation logs를 Workers Logs에 영구 저장, dashboard에서 조회 가능.
+# traces는 비용/성능 영향 최소화 위해 일단 비활성. 필요 시 토글.
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1
+
 # 공개 환경변수 (시크릿은 `wrangler secret put` 사용)
 # - SEOUL_API_KEY          : 서울 열린데이터 API 키
 # - APNS_KEY_ID            : APNs 인증키 KeyID


### PR DESCRIPTION
## Summary

- backend/alarm-worker `wrangler.toml`에 `[observability]` / `[observability.logs]` / `[observability.traces]` 블록 추가
- logs만 enabled + persist + invocation_logs (Workers Logs dashboard retrospective 조회 가능)
- top-level `[observability]` 와 `[observability.traces]`는 enabled=false (비용/성능 영향 최소화, 필요 시 토글)

## 배경

`wrangler tail`은 실시간 1~2분 윈도우만 잡혀 1시간 전 cron 실행을 retrospective 조회 불가. #622 silent push 미발사 진단 같은 사후 분석 케이스에서 인프라가 부재했음. 본 PR로 다음 deploy부터 Workers Logs에 영구 저장된다.

## 비용 영향

Workers Logs는 Workers Free plan에서 일 200k logs 무료. 현재 cron 1분 × 1440회/일 + 클라 호출 수준이라 무료 한도 내. traces는 끈 상태라 추가 비용 없음.

## 검증

- [x] backend type-check: `cd backend/alarm-worker && npm run type-check` 통과 (wrangler.toml은 TS 영향 없음)
- [x] 명시적 `git add backend/alarm-worker/wrangler.toml`만 staged — 기존 modified `package.json` / `package-lock.json`은 본 PR 미포함 (별개 작업)
- [ ] 사용자 머지 후 직접 `npx wrangler deploy` (Claude 자동 deploy 금지)

## Deploy

**머지 후 사용자가 직접 실행**:
\`\`\`bash
cd backend/alarm-worker && npx wrangler deploy
\`\`\`

## Test plan

- [ ] CI Type Check & Test 통과 확인
- [ ] 머지 후 사용자가 `npx wrangler deploy`
- [ ] 다음 cron 실행 후 Cloudflare Dashboard → Workers Logs에서 invocation 로그가 영구 저장되는지 확인
- [ ] 1시간 후 dashboard에서 retrospective 조회 가능한지 확인

Closes #863