### PR TITLE
fix(#865): SCHED-* 시간표 fallback trainCode가 backend boarding-lock에 누설되던 회귀 차단

### DIFF
--- a/src/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -647,6 +647,21 @@ describe('useApnsTripRegistration', () => {
       const args = mockRegister.mock.calls[0][0];
       expect(args.boardingLock).toBeUndefined();
     });
+
+    it('#865 — SCHED-* 시간표 fallback trainCode면 payload.boardingLock 누락 (backend 누설 차단)', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: { ...lockFor7, trainCode: 'SCHED-UP-1' },
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+      const args = mockRegister.mock.calls[0][0];
+      expect(args.boardingLock).toBeUndefined();
+    });
   });
 
   describe('#767 boardingLock 해제 race 차단 (debounce)', () => {

--- a/src/utils/__tests__/buildBoardingLockMeta.test.ts
+++ b/src/utils/__tests__/buildBoardingLockMeta.test.ts
@@ -80,6 +80,28 @@ describe('buildBoardingLockMeta', () => {
     expect(result).toBeNull();
   });
 
+  it('#865 — 시간표 fallback trainCode(SCHED-*)면 null (backend 누설 차단)', () => {
+    const route = makeDirectRoute(1, '7');
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, trainCode: 'SCHED-UP-1', boardingLine: '7' },
+      route,
+      destinationName: '용마산',
+      boardingStationName: '면목',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('#865 — SCHED-DN-* 같은 다른 suffix도 동일하게 null', () => {
+    const route = makeDirectRoute(1, '7');
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, trainCode: 'SCHED-DN-2', boardingLine: '7' },
+      route,
+      destinationName: '용마산',
+      boardingStationName: '면목',
+    });
+    expect(result).toBeNull();
+  });
+
   it('segmentStations 추론 불가하면 (boardingLine ≠ route segment) null', () => {
     const route = makeTransferRoute({
       transferName: '교대',

--- a/src/utils/buildBoardingLockMeta.ts
+++ b/src/utils/buildBoardingLockMeta.ts
@@ -6,6 +6,10 @@ import { lineToSubwayId } from '../constants/lineApiNames';
 import type { Station } from '../types/station';
 import type { LineNumber } from '../types/station';
 import type { AlarmBoardingLock } from '../api/alarmBackend';
+import { isScheduleFallbackTrainCode } from './scheduleFallback';
+import { createLogger } from './logger';
+
+const logger = createLogger('buildBoardingLockMeta');
 
 /**
  * 현재 BoardingLock leg의 끝 역(다음 환승역 또는 최종 도착역) 이름을 결정한다.
@@ -91,6 +95,17 @@ export function buildBoardingLockMeta({
   destinationName: string;
   boardingStationName: string;
 }): AlarmBoardingLock | null {
+  // #865 — 시간표 fallback이 만든 가상 trainCode(SCHED-*)는 backend 실시간 API에서
+  // 절대 찾을 수 없어 `consecutiveEtaMissing exceeded`로 4분 만에 trip auto-end된다.
+  // 등록 자체를 보류해 backend가 anchor waypoint 폴링으로 fallback하게 한다 — 실시간
+  // trainCode가 잡히면 다음 effect cycle에서 정상 등록된다. (UI 측 필터는 #648.)
+  if (isScheduleFallbackTrainCode(lock.trainCode)) {
+    logger.warn(
+      `skip backend register — schedule fallback trainCode=${lock.trainCode} (line=${lock.boardingLine})`,
+    );
+    return null;
+  }
+
   const subwayId = lineToSubwayId(lock.boardingLine);
   if (!subwayId) return null;
 


### PR DESCRIPTION
## Summary

실시간 도착 API가 빈약한 시간대에 클라이언트가 생성한 가상 trainCode(`SCHED-UP-1`, `SCHED-DN-2`)가 backend boarding-lock에 그대로 등록되어, backend가 실시간 API에서 절대 찾지 못해 4번 연속 `etaMissing` 후 `consecutiveEtaMissing exceeded`로 trip을 4분 만에 auto-end시키는 P0 회귀를 차단한다.

### 변경
- `src/utils/buildBoardingLockMeta.ts` — 함수 진입점에서 `isScheduleFallbackTrainCode(lock.trainCode)` 가드. 매칭되면 `null` 반환 + `logger.warn`
- 호출자 `useApnsTripRegistration.callRegister`는 이미 `null`인 경우 `boardingLock` 필드를 payload에서 자동 omit — backend는 기존 anchor waypoint 폴링으로 graceful fallback
- 로컬 boarding-lock 자체는 그대로 유지 (UI/scheduler 영향 없음). 실시간 trainCode가 잡히면 다음 effect cycle에서 정상 등록

### 설계 결정
- 단일 chokepoint 선택 — 진입점 3곳(`createLockFromTrain`, `createTransferLock`, `tryAutoLock`) 각각에 가드를 박지 않고 backend POST 변환 함수에 단일 게이트
- `isScheduleFallbackTrainCode` predicate 재사용 — UI 측 #648 필터와 동일 SSOT (`SCHEDULE_FALLBACK_TRAIN_CODE_PREFIX`)

## 백엔드 evidence (2026-06-04 Trip B, KST 14:12~14:41)
```
05:36 POST /trips
05:37~05:41 boarding-lock: trainCode not found (군자, SCHED-UP-1) × 5
05:41 boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)
```

## Test plan
- [x] 단위: `buildBoardingLockMeta.test.ts` — SCHED-UP-1, SCHED-DN-2 두 케이스 모두 null
- [x] 통합: `useApnsTripRegistration.test.ts` — SCHED-* lock 전달 시 `args.boardingLock` undefined 확인
- [x] `npm test` — 3354 passed, 100% coverage
- [x] `npm run type-check` — 통과
- [ ] 실기기 빈약 시간대(심야 등) 회귀 검증

## Follow-up (별도 이슈 권장)
- `useApnsTripRegistration:255` `lastSentLockSigRef`의 의미가 "송신 의도" vs "실제 송신"으로 모호 — SCHED-* 가드 후 ref가 SCHED sig를 기록하면 다음 release transition 판정 시 1.5s debounce가 불필요하게 발사. 기능 회귀는 없지만 정합성 후속 분리 권장 (P2-1)

Closes #865