### PR TITLE
fix(#864): 환승역 trainCode 사라짐 — transfer waypoint 통과 시 backend lock release (P0-A)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -711,6 +711,73 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(stored.lastTrackedArrivalEpoch).toBeUndefined();
   });
 
+  // #864 — transfer waypoint 통과 시 lock release. 다음 cycle에서 새 leg의 trainCode를
+  // 찾지 못해 5분 만에 trip auto-end되던 회귀를 차단.
+  it('#864 — transfer waypoint advance 시 boardingLock release + progress 정리 (trip은 유지)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+        consecutiveEtaMissing: 2,
+      }),
+    );
+    // 옛 trainCode + shiftedCount가 진행 중 progress KV에 남아 있는 상태를 시뮬레이션.
+    await kv.put(
+      'progress:lock-tok',
+      JSON.stringify({ trainCode: '7246', shiftedCount: 2, lastTrackedArrivalEpoch: NOW + 5000 }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-transfer',
+    });
+    const raw = (await kv.get('trip:lock-tok')) as string;
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw);
+    expect(stored.boardingLock).toBeUndefined();
+    expect(stored.consecutiveEtaMissing).toBe(0);
+    expect(stored.waypoints).toHaveLength(1);
+    expect(stored.waypoints[0].stationName).toBe('아차산');
+    // P2-1: progress KV도 함께 정리 — token-refresh race에서 옛 trainCode가 progressApplies=true로
+    // 진입해 backend에 옛 lock이 부활하는 회귀를 차단.
+    expect(await kv.get('progress:lock-tok')).toBeNull();
+  });
+
+  it('#864 — intermediate waypoint advance 시 boardingLock은 유지 (같은 train 계속 추적)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '군자', line: '7', kind: 'destination' },
+        ],
+      }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-intermediate',
+    });
+    const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+    expect(stored.boardingLock).toBeDefined();
+    expect(stored.boardingLock.trainCode).toBe('7246');
+    expect(stored.waypoints).toHaveLength(1);
+    expect(stored.waypoints[0].stationName).toBe('군자');
+  });
+
   it.each([
     ['destination 도착 시 trip 삭제', '군자', 'destination'] as const,
     ['마지막 intermediate 통과 후 빈 리스트면 trip 삭제', '중곡', 'intermediate'] as const,

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -713,39 +713,46 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
 
   // #864 — transfer waypoint 통과 시 lock release. 다음 cycle에서 새 leg의 trainCode를
   // 찾지 못해 5분 만에 trip auto-end되던 회귀를 차단.
+  async function runArrivedScenario(
+    kv: InMemoryKV,
+    overrides: Partial<Trip>,
+    arrivalStation: string,
+    pushId: string,
+  ): Promise<void> {
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip(overrides));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock(arrivalStation, 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => pushId,
+    });
+  }
+
   it('#864 — transfer waypoint advance 시 boardingLock release + progress 정리 (trip은 유지)', async () => {
     const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockTrip({
-        waypoints: [
-          { stationName: '군자', line: '7', kind: 'transfer' },
-          { stationName: '아차산', line: '5', kind: 'destination' },
-        ],
-        consecutiveEtaMissing: 2,
-      }),
-    );
     // 옛 trainCode + shiftedCount가 진행 중 progress KV에 남아 있는 상태를 시뮬레이션.
     await kv.put(
       'progress:lock-tok',
       JSON.stringify({ trainCode: '7246', shiftedCount: 2, lastTrackedArrivalEpoch: NOW + 5000 }),
     );
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
-      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-transfer',
-    });
-    const raw = (await kv.get('trip:lock-tok')) as string;
-    expect(raw).not.toBeNull();
-    const stored = JSON.parse(raw);
+    await runArrivedScenario(
+      kv,
+      {
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+        consecutiveEtaMissing: 2,
+      },
+      '군자',
+      'p-transfer',
+    );
+    const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
     expect(stored.boardingLock).toBeUndefined();
     expect(stored.consecutiveEtaMissing).toBe(0);
-    expect(stored.waypoints).toHaveLength(1);
-    expect(stored.waypoints[0].stationName).toBe('아차산');
+    expect(stored.waypoints).toEqual([{ stationName: '아차산', line: '5', kind: 'destination' }]);
     // P2-1: progress KV도 함께 정리 — token-refresh race에서 옛 trainCode가 progressApplies=true로
     // 진입해 backend에 옛 lock이 부활하는 회귀를 차단.
     expect(await kv.get('progress:lock-tok')).toBeNull();
@@ -753,29 +760,20 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
 
   it('#864 — intermediate waypoint advance 시 boardingLock은 유지 (같은 train 계속 추적)', async () => {
     const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockTrip({
+    await runArrivedScenario(
+      kv,
+      {
         waypoints: [
           { stationName: '중곡', line: '7', kind: 'intermediate' },
           { stationName: '군자', line: '7', kind: 'destination' },
         ],
-      }),
+      },
+      '중곡',
+      'p-intermediate',
     );
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
-      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-intermediate',
-    });
     const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
-    expect(stored.boardingLock).toBeDefined();
-    expect(stored.boardingLock.trainCode).toBe('7246');
-    expect(stored.waypoints).toHaveLength(1);
-    expect(stored.waypoints[0].stationName).toBe('군자');
+    expect(stored.boardingLock?.trainCode).toBe('7246');
+    expect(stored.waypoints).toEqual([{ stationName: '군자', line: '7', kind: 'destination' }]);
   });
 
   it.each([

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -37,7 +37,7 @@ import {
   readSeries,
   type WindowedMetrics,
 } from './positionSeries';
-import { getProgress, putProgress, type TripProgress } from './progress';
+import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
@@ -625,11 +625,28 @@ export async function advanceBoardingLockWaypoint(
   trip.waypoints.shift();
   trip.lastTrackedArrivalEpoch = undefined;
   trip.lastLaPushEpoch = undefined;
+  // #864 — transfer waypoint 통과 = 직전 train segment 종료. lock을 유지하면 다음 cycle이
+  // 새 line(예: 5호선)에서 옛 trainCode(예: 7327)를 찾아 etaMissing 5회 후 trip auto-end로 사망.
+  // lock을 release하면 다음 cycle은 isBoardingLockActive=false → evaluateAndMaybeFireBoardingPrompt
+  // 가 사용자에게 환승 train 선택을 prompt하고, 클라이언트의 createTransferLock이 새 lock을 등록.
+  // segmentStations도 직전 leg 기준이라 위치 fallback 폴링도 더는 의미 없음.
+  //
+  // progress KV도 같이 정리 — 옛 trainCode + shiftedCount가 stale로 남으면 token-refresh race
+  // (`useApnsTripRegistration` `latestInputsRef` 옛 lock 보유) 윈도우에서 client 옛 lock POST 시
+  // `progressApplies=true` 분기로 진입해 옛 lock이 backend에 다시 active로 복원되는 회귀가 가능.
+  const lockReleasedOnTransfer = waypoint.kind === 'transfer' && trip.boardingLock !== undefined;
+  if (lockReleasedOnTransfer) {
+    trip.boardingLock = undefined;
+    trip.consecutiveEtaMissing = 0;
+    await deleteProgress(env.TRIPS, trip.token);
+  }
   log('boarding-lock: waypoint advanced', {
     token: trip.token.slice(0, 8),
     completed: waypoint.stationName,
     kind: waypoint.kind,
     remaining: trip.waypoints.length,
+    // P2-2: true일 때만 log key 포함 — false noise로 운영 로그 가시성 저하 방지.
+    ...(lockReleasedOnTransfer ? { lockReleasedOnTransfer: true } : {}),
   });
   if (trip.waypoints.length === 0) {
     await cleanupTripWithLa(trip, env, deps, stats, now, log);


### PR DESCRIPTION
## Summary

환승 경로 trip이 환승역 진입 후 4~5분 만에 backend boarding-lock cron이 `consecutiveEtaMissing exceeded`로 trip을 auto-end시키는 P0 회귀를 차단한다. backend가 직전 leg의 `lock.line`과 `lock.trainCode`로 새 leg에서 추적을 시도해 실패하던 문제. transfer waypoint 통과 시점에 backend가 자율로 lock을 release하면, 다음 cycle은 `evaluateAndMaybeFireBoardingPrompt` 분기로 진입해 사용자에게 다음 train 선택을 자연스럽게 prompt한다.

### 변경 — `backend/alarm-worker/src/scheduled.ts:608`

`advanceBoardingLockWaypoint`에 transfer 분기:
- `waypoint.kind === 'transfer' && trip.boardingLock !== undefined` → lock release + `consecutiveEtaMissing = 0` reset
- `progress:<token>` KV도 `deleteProgress`로 동시 정리 — token-refresh race(`useApnsTripRegistration` `latestInputsRef` 옛 lock) 시 `progressApplies=true`로 옛 lock이 backend에 부활하는 회귀 차단
- log payload는 `lockReleasedOnTransfer:true`일 때만 키 포함 (운영 로그 noise 최소화)

### 백엔드 evidence (2026-06-04 Trip D, KST 18:45~18:57)
```
09:45 POST /trips (destination=2-011 을지로입구, 7→5→2 multi-transfer)
09:52 boarding-lock: waypoint advanced (중곡 통과 → 군자 환승역 진입)
09:54~09:57 boarding-lock: trainCode not found (군자, 7327) — 4회 연속
09:57 boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)
```

### Root cause
- `lock.line='7'`, `lock.trainCode='7327'`, `lock.segmentStations`은 boarding leg(중곡→군자) 기준
- 사용자가 군자(7↔5 환승) 도달 = waypoint advance → 다음 waypoint는 5호선 역
- `estimateBoardingLockArrival`은 `lock.line='7'`로 positions 조회 → 5호선 진행 중인 user의 train을 못 찾음
- `segmentStations`는 7호선 leg만 포함 → positions fallback의 `indexOf` 매칭도 실패
- 5분간 etaMissing 5회 → cleanup

### 설계 결정 (대안 비교)

| 옵션 | 장단점 |
|---|---|
| ✅ Lock release on transfer | 옛 trainCode 무의미 폴링 즉시 차단. 다음 cycle에서 `boarding-prompt`(#819) 또는 `createTransferLock`이 새 lock 등록 — 자연 복구. |
| ❌ Lock.line 갱신 | 다음 leg trainCode를 모르므로 stale lock으로 똑같이 실패 |
| ❌ Grace period (etaMissing 임계값 늘림) | MAX_CONSECUTIVE_ETA_MISSING(#706) 정책 우회. trip 사망 무한 지연 위험 |
| ❌ Transfer-specific etaMissing 무시 | 위와 동일. 신호와 노이즈 구분 불가 |

## Follow-up (별도 이슈 권장)
- **P2-3 client sync**: backend가 lock auto-release하는 동안 client `useBoardingLockStore`는 여전히 옛 lock 보유 → `useFusedNearestStation` 등 옛 line 기준 동작. 환승역 통과 감지 → `releaseLock()` 트리거 후속 이슈
- **P2-4 WaypointKind SSOT**: `'transfer'` 문자열 리터럴 → `WAYPOINT_KIND.TRANSFER` 상수화 (확장성)
- **P3 추가 테스트**: transfer release 직후 cycle의 `lockMissing` 분기 검증 (다음 cycle 회귀 가드)

## Test plan
- [x] backend 단위: `scheduled.test.ts` — transfer release (progress KV 정리 포함) + intermediate 유지 2건 추가
- [x] `npm test` (backend) — 679 passed
- [x] `npm run type-check` (backend) — 통과
- [x] code-review (시니어 레벨) — P1 0건, P2-1/P2-2 본 PR 반영, P2-3/P2-4/P3는 별도 이슈 권장
- [ ] 실기기: 환승 trip 1건 진행 → 군자 통과 후 wrangler tail로 `lockReleasedOnTransfer:true` 확인 + 5분 이상 trip alive 확인

Closes #864