### PR TITLE
fix(#866): scheduleAlarmsForRoute 진단 로그 — OS 사전 예약 큐 0건 분류 (P1-C)

### DIFF
--- a/src/utils/__tests__/alarmScheduler.test.ts
+++ b/src/utils/__tests__/alarmScheduler.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../alarmScheduler';
 import { logScheduledAlarm } from '../alarmLog';
 import { getLastNotifiedStationId } from '../notificationState';
+import * as stationRoute from '../stationRoute';
 import {
   makeDirectRoute,
   makeMultiTransferRoute,
@@ -15,12 +16,16 @@ import {
 } from '../../testUtils/routeFixtures';
 
 jest.mock('expo-notifications');
+
+const mockLoggerWarn = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerError = jest.fn();
 jest.mock('../logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    error: (...args: unknown[]) => mockLoggerError(...args),
   }),
 }));
 
@@ -73,6 +78,9 @@ describe('parseScheduledAlarmIdentifier', () => {
 describe('scheduleAlarmsForRoute', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLoggerWarn.mockClear();
+    mockLoggerInfo.mockClear();
+    mockLoggerError.mockClear();
     (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('id');
     mockedGetLastNotified.mockResolvedValue(null);
     jest.replaceProperty(Platform, 'OS', 'ios');
@@ -386,6 +394,135 @@ describe('scheduleAlarmsForRoute', () => {
     expect(mockedLogScheduled.mock.calls.every(([event]) => event.stationName === '강남')).toBe(
       true,
     );
+  });
+
+  // ── #866 진단 로그 ──
+  // OS 사전 예약 큐가 0건일 때 분기(a/b+c/d) 중 어디서 멈췄는지 분류 가능해야 한다.
+  // 정상 경로(매 cycle reschedule)는 warn 발화 0건 — TestFlight USB Console noise 차단.
+  describe('#866 진단 로그', () => {
+    it('(a) totalStops=0이면 reason=total-stops-zero로 warn 후 빈 배열', async () => {
+      const route = makeDirectRoute(0, '1');
+      const result = await scheduleAlarmsForRoute({
+        route,
+        destinationName: '강남',
+        currentStationApproachEtaSeconds: 600,
+        now: NOW,
+      });
+      expect(result).toEqual([]);
+      const calls = mockLoggerWarn.mock.calls.map((c) => String(c[0]));
+      expect(
+        calls.some(
+          (msg) =>
+            msg.includes('reason=total-stops-zero') &&
+            msg.includes('targets=강남/0') &&
+            msg.includes('approachEta=600') &&
+            msg.includes('routeType=direct'),
+        ),
+      ).toBe(true);
+      // 정상 경로 noise 차단을 검증 — 이상 분기 1줄만.
+      expect(calls).toHaveLength(1);
+    });
+
+    it('(a) approachEta가 null이어도 total-stops-zero 로그에 approachEta=null로 표기된다', async () => {
+      const route = makeDirectRoute(0, '1');
+      await scheduleAlarmsForRoute({
+        route,
+        destinationName: '강남',
+        currentStationApproachEtaSeconds: null,
+        now: NOW,
+      });
+      const calls = mockLoggerWarn.mock.calls.map((c) => String(c[0]));
+      expect(
+        calls.some(
+          (msg) =>
+            msg.includes('reason=total-stops-zero') && msg.includes('approachEta=null'),
+        ),
+      ).toBe(true);
+    });
+
+    it('(b)/(c) scheduled=0인 분기는 reason=all-phases-skipped로 warn (전체 skip 분류 가능)', async () => {
+      // calculateStaticETA를 spy해 매우 작은 ETA(0.1분=6s)를 반환. finalEta=6s → 모든
+      // phase의 fireSeconds<=0이 되어 all-phases-skipped 경로 진입. 실 production에선
+      // approachEta=null + 비정상 staticETA(예: route 데이터 결손) 결합으로만 발생.
+      const spy = jest
+        .spyOn(stationRoute, 'calculateStaticETA')
+        .mockImplementation(() => 0.1);
+      try {
+        const route = makeDirectRoute(1, '1');
+        const result = await scheduleAlarmsForRoute({
+          route,
+          destinationName: '강남',
+          currentStationApproachEtaSeconds: null,
+          now: NOW,
+        });
+        expect(result).toEqual([]);
+        const calls = mockLoggerWarn.mock.calls.map((c) => String(c[0]));
+        expect(
+          calls.some(
+            (msg) =>
+              msg.includes('reason=all-phases-skipped') &&
+              msg.includes('totalStops=1') &&
+              msg.includes('finalEta=6.0') &&
+              msg.includes('approachEta=null') &&
+              msg.includes('skips=') &&
+              msg.includes('강남/early/') &&
+              msg.includes('강남/imminent/'),
+          ),
+        ).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('(d) scheduleNotificationAsync throw 시 caller로 그대로 전파 (try/catch 미흡수)', async () => {
+      const route = makeDirectRoute(10, '1');
+      const err = new Error('permission denied');
+      (Notifications.scheduleNotificationAsync as jest.Mock).mockRejectedValueOnce(err);
+
+      await expect(
+        scheduleAlarmsForRoute({
+          route,
+          destinationName: '강남',
+          currentStationApproachEtaSeconds: 600,
+          now: NOW,
+        }),
+      ).rejects.toThrow('permission denied');
+    });
+
+    it('정상 예약 케이스에서는 warn을 발화하지 않는다 (noise 0건)', async () => {
+      const route = makeDirectRoute(10, '1');
+      await scheduleAlarmsForRoute({
+        route,
+        destinationName: '강남',
+        currentStationApproachEtaSeconds: 600,
+        now: NOW,
+      });
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+      // 기존 success info 라인은 유지 — 콘솔 debug용.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining('scheduled 2 alarms for 1 waypoints'),
+      );
+    });
+
+    it('일부 phase만 skip된 부분 성공 케이스는 warn하지 않는다 (scheduled>0이라 정상으로 분류)', async () => {
+      // 환승역 stopsToTransfer=0 → 환승 waypoint는 두 phase 모두 fireSec<=0으로 skip.
+      // 도착역 stopsFromTransfer는 양수라 예약된다.
+      const route = makeTransferRoute({
+        transferName: '동대문',
+        fromLine: '1',
+        toLine: '4',
+        stopsToTransfer: 0,
+        stopsFromTransfer: 5,
+      });
+      const result = await scheduleAlarmsForRoute({
+        route,
+        destinationName: '강남',
+        currentStationApproachEtaSeconds: 60,
+        now: NOW,
+      });
+      expect(result.length).toBeGreaterThan(0);
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/utils/alarmScheduler.ts
+++ b/src/utils/alarmScheduler.ts
@@ -78,6 +78,12 @@ export interface ScheduleAlarmsParams {
  *
  * waypoint별 시각은 누적 정거장 수 비율로 finalEtaSeconds를 안분한다.
  * 과거 시각으로 산출된 알람은 건너뛴다.
+ *
+ * #866 진단 로그(`logger.warn`)는 OS 사전 예약 큐가 0건으로 보고되는 회귀를 분류한다:
+ *   (a) total-stops-zero     — totalStops=0 (route stops=0)
+ *   (b)/(c) all-phases-skipped — 모든 fireSeconds<=0 (finalEta가 너무 작거나 lead 부족)
+ *   (d) scheduleNotificationAsync throw — caller의 `.catch((e) => logger.error(...))` 경로로 전파
+ * 정상 경로(매 cycle 호출, trip 30분당 360회+)에서는 일체 warn하지 않는다. 이상 분기에서만 warn.
  */
 export async function scheduleAlarmsForRoute(
   params: ScheduleAlarmsParams,
@@ -92,7 +98,16 @@ export async function scheduleAlarmsForRoute(
 
   const targets = resolveAllTargets(route, destinationName);
   const totalStops = targets.reduce((sum, t) => sum + t.stops, 0);
-  if (totalStops === 0) return [];
+
+  if (totalStops === 0) {
+    // (a) 분기 — resolveAllTargets가 모든 waypoint stops=0(direct stops=0 등).
+    logger.warn(
+      `scheduleAlarms skip reason=total-stops-zero targets=${targets
+        .map((t) => `${t.name}/${t.stops}`)
+        .join(',')} approachEta=${currentStationApproachEtaSeconds ?? 'null'} routeType=${route.type}`,
+    );
+    return [];
+  }
 
   const finalEtaSeconds = resolveFinalEtaSeconds(currentStationApproachEtaSeconds, totalStops, route);
 
@@ -103,6 +118,7 @@ export async function scheduleAlarmsForRoute(
   const stampTrainCode = stamp?.usedTrainCode ?? null;
 
   const scheduled: ScheduledAlarm[] = [];
+  const skipped: string[] = [];
   let cumulativeStops = 0;
 
   for (const target of targets) {
@@ -111,7 +127,11 @@ export async function scheduleAlarmsForRoute(
 
     for (const phase of ALARM_PHASES) {
       const fireSeconds = waypointEtaSeconds - PHASE_LEAD_SECONDS[phase.id];
-      if (fireSeconds <= 0) continue;
+      if (fireSeconds <= 0) {
+        // (b)/(c) 분기 — fireSeconds<=0. ETA fallback이 작거나 lead 대비 ETA 부족.
+        skipped.push(`${target.name}/${phase.id}/${fireSeconds.toFixed(1)}`);
+        continue;
+      }
 
       const event: AlarmEvent = {
         phaseId: phase.id,
@@ -122,6 +142,9 @@ export async function scheduleAlarmsForRoute(
       const fireDate = new Date(now + fireSeconds * 1000);
       const { title, body } = buildAlarmContent(event);
 
+      // #866 (d) 분기 — scheduleNotificationAsync가 throw하면 caller(useScheduledAlarms)의
+      // `.catch((e) => logger.error('재예약 실패:', e))` 경로로 그대로 전파. try/catch를 두면
+      // error → warn 강등으로 운영 알람 신호가 사라지므로 명시적으로 전파한다.
       await Notifications.scheduleNotificationAsync({
         identifier,
         content: {
@@ -152,7 +175,17 @@ export async function scheduleAlarmsForRoute(
     }
   }
 
-  logger.info(`scheduled ${scheduled.length} alarms for ${targets.length} waypoints`);
+  // #866 — scheduled=0인 이상 분기(b/c)만 warn. 정상 경로(reschedule이 30분 trip당 360회 호출)
+  // 에서 enter/done warn을 모두 출력하면 USB Console에서 진단 신호가 noise에 묻힌다.
+  if (scheduled.length === 0) {
+    logger.warn(
+      `scheduleAlarms skip reason=all-phases-skipped totalStops=${totalStops} finalEta=${finalEtaSeconds.toFixed(
+        1,
+      )} approachEta=${currentStationApproachEtaSeconds ?? 'null'} skips=${skipped.join('|')}`,
+    );
+  } else {
+    logger.info(`scheduled ${scheduled.length} alarms for ${targets.length} waypoints`);
+  }
   return scheduled;
 }
 


### PR DESCRIPTION
## Summary

DebugModal "Scheduled queue" 섹션이 trip 활성 상태에서도 `(0)`으로 비어 있던 회귀(#866 P1-C)의 **분류 인프라**를 추가한다. 본 PR은 진단 로그만 — 실제 원인 수정은 후속.

### 분류 키 (각 키-값은 wrangler tail / USB Console.app에서 직접 grep 가능)

| 분기 | 트리거 조건 | 로그 reason |
|---|---|---|
| (a) | `totalStops === 0` (route stops=0) | `reason=total-stops-zero` |
| (b)/(c) | totalStops>0이지만 `scheduled.length===0` (모든 phase fireSec<=0) | `reason=all-phases-skipped` |
| (d) | `scheduleNotificationAsync` throw | caller `useScheduledAlarms`의 `logger.error('재예약 실패:', e)` 경로로 전파 |

### 설계 결정 (코드 리뷰 P1 반영)

- **정상 경로 warn 0건**: reschedule은 매 cycle 호출되어 30분 trip당 360+ 회. enter/done 라인을 매번 warn하면 진단 신호가 noise에 묻힘. 이상 분기에서만 warn 발화
- **try/catch 미도입**: (d) 분기에서 `scheduleNotificationAsync`를 try/catch로 감싸면 caller의 `logger.error` 신호가 warn으로 강등되어 운영 알람 누락. 그대로 throw 전파
- success 경로는 기존 `logger.info('scheduled N alarms ...')` 유지 — 디버그 시 USB Console에서 정상 동작 확인용

## 디바이스 evidence (이슈 본문)
Trip E (KST 20:44): POST /trips 17초 후 캡처에서 Scheduled queue (0). 다른 trip은 정상 → 클라 사전 예약 인프라 의심.

## Test plan
- [x] `npm run type-check` — 통과
- [x] `npm test` — 3357 passed, 커버리지 100%
- [x] 5건 신규 테스트 (a/b+c/d/정상 경로 noise 0/부분 skip noise 0)
- [x] code-review — P1 2건(noise wall / try/catch error 강등) 본 PR 반영
- [ ] 실기기 재현 — Scheduled queue (0) 발생 시 USB Console에서 reason=* 키 1건 확인 → 분기 식별

## Follow-up
- 분기 식별 후 실제 원인 수정 (별도 이슈)

Closes #866