### PR TITLE
fix(#868): backend trip auto-end → 클라 sync (trip-ended silent push + race 가드) (P1-D)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -210,10 +210,13 @@ describe('runScheduled', () => {
       makeTrip({ expiresAt: NOW + 5_000, alarmAtEpochMs: NOW - 1 }),
     );
     // expire 이전이지만 다음 시점은 expire 이후
+    // #868 — expired 경로는 trip-ended silent push도 발사 시도하므로 fetch mock 필요.
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
       seoul: makeSeoul([]),
       apnsConfig,
       apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
       now: () => NOW + 10_000,
     });
     expect(stats.polled).toBe(0);
@@ -1207,6 +1210,209 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     // shift 시 lastLaPushEpoch는 reset되어 다음 polling cycle의 첫 estimate가 임계 검사 없이 push되도록 보장.
     const stored = JSON.parse((await kv.get('trip:la-tok')) as string) as Trip;
     expect(stored.lastLaPushEpoch).toBeUndefined();
+  });
+});
+
+// #868 — server-side trip auto-end 경로에서 클라 state sync용 trip-ended silent push가 발사되는지.
+// LA dismissal과 별개 budget(분당 0~1건)이라 trip 종료 cleanup 1건당 1회 발사가 기대 동작.
+describe('runScheduled — trip-ended silent push (#868)', () => {
+  /** APNs silent push (trip-ended kind) 호출만 추출 — LA push와 분리해 단언. */
+  function getTripEndedCalls(
+    fetchImpl: ReturnType<typeof vi.fn>,
+  ): [string, RequestInit][] {
+    return (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) => {
+      const headers = (c[1]?.headers ?? {}) as Record<string, string>;
+      if (headers['apns-push-type'] !== 'background') return false;
+      try {
+        const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
+        return body?.data?.kind === 'trip-ended';
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  /** trip-ended push body의 data field 추출. */
+  function parseTripEndedData(call: [string, RequestInit]): {
+    kind: string;
+    reason: string;
+    pushId: string;
+    sentAt: number;
+  } {
+    const body = JSON.parse(call[1].body as string) as {
+      data: { kind: string; reason: string; pushId: string; sentAt: number };
+    };
+    return body.data;
+  }
+
+  it('fires trip-ended push (reason=eta-missing) when consecutiveEtaMissing exceeds threshold', async () => {
+    const kv = new InMemoryKV();
+    // makeLockTrip은 inner describe scope이므로 같은 fixture를 인라인 재구성.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'end-tok',
+        route: { type: 'direct', line: '7', stops: 2 },
+        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+        boardingLock: {
+          trainCode: '7246',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['용마산', '중곡', '군자'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+        consecutiveEtaMissing: 4, // 임계(5) -1
+      }),
+    );
+    const fetchImpl = makeOkFetch();
+    // arrivals 비어 있음 → estimate=null → miss 1 더 → 5 도달 → auto-end.
+    // top-level makeSeoul은 positions endpoint도 같은 fetchImpl을 사용 — realtimePositionList 키가
+    // 없어 빈 배열로 처리되므로 fallback도 estimate=null로 떨어진다.
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-eta-end',
+    });
+    const calls = getTripEndedCalls(fetchImpl);
+    expect(calls).toHaveLength(1);
+    const data = parseTripEndedData(calls[0]);
+    expect(data.kind).toBe('trip-ended');
+    expect(data.reason).toBe('eta-missing');
+    expect(data.sentAt).toBe(NOW);
+    expect(typeof data.pushId).toBe('string');
+    expect(data.pushId.length).toBeGreaterThan(0);
+    // #868 P1-2 race 가드 — payload에 tripToken 포함되어야 클라가 ACTIVE_TRIP_KEY와 매칭 가능.
+    expect(data.tripToken).toBe('end-tok');
+    // trip은 KV에서 삭제돼야 함 (#706 cleanup).
+    expect(await kv.get('trip:end-tok')).toBeNull();
+  });
+
+  it('fires trip-ended push (reason=destination-arrived) when destination waypoint ARRIVED', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip());
+    const fetchImpl = makeOkFetch();
+    // ARRIVED(arvlCd=1) → advanceBoardingLockWaypoint → destination → cleanup
+    await runLaScheduled(kv, { seoul: makeLockedSeoul(0, 1), fetchImpl });
+    const calls = getTripEndedCalls(fetchImpl);
+    expect(calls).toHaveLength(1);
+    const data = parseTripEndedData(calls[0]);
+    expect(data.reason).toBe('destination-arrived');
+    expect(await kv.get('trip:la-tok')).toBeNull();
+  });
+
+  it('fires trip-ended push (reason=expired) on trip.expiresAt elapsed', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(
+      'trip:la-tok',
+      JSON.stringify(
+        makeLockedLaTrip({ expiresAt: NOW + 5_000, alarmAtEpochMs: NOW - 1 }),
+      ),
+    );
+    const fetchImpl = makeOkFetch();
+    await runLaScheduled(kv, {
+      seoul: makeLockedSeoul(0),
+      fetchImpl,
+      now: () => NOW + 10_000,
+    });
+    const calls = getTripEndedCalls(fetchImpl);
+    expect(calls).toHaveLength(1);
+    expect(parseTripEndedData(calls[0]).reason).toBe('expired');
+  });
+
+  it('fires trip-ended push (reason=push-unrecoverable) on reschedule 410 Unregistered', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip());
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (isLaCall(url, init)) return new Response('', { status: 200 });
+      const body = init?.body as string | undefined;
+      // trip-ended push는 정상 응답 — reschedule push만 410 Unregistered로 폐기 트리거.
+      if (body && body.includes('"trip-ended"')) {
+        return new Response('', { status: 200 });
+      }
+      return new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 });
+    });
+    await runLaScheduled(kv, { seoul: makeLockedSeoul(120), fetchImpl });
+    const calls = getTripEndedCalls(fetchImpl);
+    expect(calls).toHaveLength(1);
+    expect(parseTripEndedData(calls[0]).reason).toBe('push-unrecoverable');
+    expect(await kv.get('trip:la-tok')).toBeNull();
+  });
+
+  it('#868 P2-1 — trip-ended push fetch throw해도 cleanup 흐름 계속 (trip 삭제됨)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'thr-tok',
+        route: { type: 'direct', line: '7', stops: 2 },
+        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+        boardingLock: {
+          trainCode: '7246',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['용마산', '중곡', '군자'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+        consecutiveEtaMissing: 4,
+      }),
+    );
+    // trip-ended push만 reject — reschedule/LA push는 정상.
+    const throwingFetch = vi.fn((url: unknown, init?: { body?: string }) => {
+      const body = typeof init?.body === 'string' ? init.body : '';
+      if (body.includes('"trip-ended"')) {
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: throwingFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-thr',
+    });
+    // throw 흡수 → cleanup 진행 → trip 삭제.
+    expect(await kv.get('trip:thr-tok')).toBeNull();
+  });
+
+  it('does not fire trip-ended push when miss counter increments below threshold', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'mid-tok',
+        route: { type: 'direct', line: '7', stops: 2 },
+        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+        boardingLock: {
+          trainCode: '7246',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['용마산', '중곡', '군자'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+        consecutiveEtaMissing: 1,
+      }),
+    );
+    const fetchImpl = makeOkFetch();
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-no-end',
+    });
+    expect(getTripEndedCalls(fetchImpl)).toHaveLength(0);
+    // trip은 살아 있어야 함 (counter만 증가)
+    const stored = JSON.parse((await kv.get('trip:mid-tok')) as string) as Trip;
+    expect(stored.consecutiveEtaMissing).toBe(2);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1245,26 +1245,27 @@ describe('runScheduled — trip-ended silent push (#868)', () => {
     return body.data;
   }
 
+  // 본 describe 안에서만 쓰이는 fixture — makeLockTrip은 outer scope에 있어 재사용 불가.
+  function makeEtaThresholdTrip(token: string, missCount: number) {
+    return makeTrip({
+      token,
+      route: { type: 'direct', line: '7', stops: 2 },
+      waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+      boardingLock: {
+        trainCode: '7246',
+        line: '7',
+        subwayId: '1007',
+        selectedDepartureTime: NOW,
+        segmentStations: ['용마산', '중곡', '군자'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+      consecutiveEtaMissing: missCount,
+    });
+  }
+
   it('fires trip-ended push (reason=eta-missing) when consecutiveEtaMissing exceeds threshold', async () => {
     const kv = new InMemoryKV();
-    // makeLockTrip은 inner describe scope이므로 같은 fixture를 인라인 재구성.
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        token: 'end-tok',
-        route: { type: 'direct', line: '7', stops: 2 },
-        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
-        boardingLock: {
-          trainCode: '7246',
-          line: '7',
-          subwayId: '1007',
-          selectedDepartureTime: NOW,
-          segmentStations: ['용마산', '중곡', '군자'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-        consecutiveEtaMissing: 4, // 임계(5) -1
-      }),
-    );
+    await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('end-tok', 4));
     const fetchImpl = makeOkFetch();
     // arrivals 비어 있음 → estimate=null → miss 1 더 → 5 도달 → auto-end.
     // top-level makeSeoul은 positions endpoint도 같은 fetchImpl을 사용 — realtimePositionList 키가
@@ -1344,23 +1345,7 @@ describe('runScheduled — trip-ended silent push (#868)', () => {
 
   it('#868 P2-1 — trip-ended push fetch throw해도 cleanup 흐름 계속 (trip 삭제됨)', async () => {
     const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        token: 'thr-tok',
-        route: { type: 'direct', line: '7', stops: 2 },
-        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
-        boardingLock: {
-          trainCode: '7246',
-          line: '7',
-          subwayId: '1007',
-          selectedDepartureTime: NOW,
-          segmentStations: ['용마산', '중곡', '군자'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-        consecutiveEtaMissing: 4,
-      }),
-    );
+    await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('thr-tok', 4));
     // trip-ended push만 reject — reschedule/LA push는 정상.
     const throwingFetch = vi.fn((url: unknown, init?: { body?: string }) => {
       const body = typeof init?.body === 'string' ? init.body : '';
@@ -1383,23 +1368,7 @@ describe('runScheduled — trip-ended silent push (#868)', () => {
 
   it('does not fire trip-ended push when miss counter increments below threshold', async () => {
     const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        token: 'mid-tok',
-        route: { type: 'direct', line: '7', stops: 2 },
-        waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
-        boardingLock: {
-          trainCode: '7246',
-          line: '7',
-          subwayId: '1007',
-          selectedDepartureTime: NOW,
-          segmentStations: ['용마산', '중곡', '군자'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-        consecutiveEtaMissing: 1,
-      }),
-    );
+    await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('mid-tok', 1));
     const fetchImpl = makeOkFetch();
     await runScheduled(makeEnv(kv), {
       seoul: makeSeoul([]),

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -7,7 +7,12 @@
 
 import { importPKCS8, SignJWT } from 'jose';
 import type { AlarmPhase } from './alarm';
-import type { BoardingPromptPushPayload, ReschedulePushPayload } from './types';
+import type {
+  BoardingPromptPushPayload,
+  ReschedulePushPayload,
+  TripEndedPushPayload,
+  TripEndedReason,
+} from './types';
 
 /**
  * iOS UNNotificationCategory 식별자 (#819 B 슬라이스). 클라이언트는 같은 식별자로
@@ -209,6 +214,59 @@ export async function sendReschedulePush(
     nextStation: options.nextStation,
     newArrivalTimeEpoch: options.newArrivalTimeEpoch,
     sentAt: options.sentAt,
+  };
+
+  const body = JSON.stringify({ aps: { 'content-available': 1 }, data: payload });
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${jwt}`,
+      'apns-topic': options.config.bundleId,
+      'apns-push-type': 'background',
+      'apns-priority': '5',
+      'content-type': 'application/json',
+    },
+    body,
+  });
+
+  if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
+/**
+ * Trip ended silent push (#868). server-side trip auto-end 시 클라이언트 state sync 신호.
+ *
+ * silent push와 동일 헤더(background, priority 5)지만 payload의 `kind: 'trip-ended'`로 구분.
+ * - alert fallback 대상이 아니다 — graceful loss 시 다음 FG 진입에서 trip 상태 재동기화 경로가 보강.
+ * - 발사 비용은 trip 종료 1건당 1회로 극소 (분당 0~1건 수준) — APNs budget 영향 무시 가능.
+ */
+export interface SendTripEndedPushOptions {
+  deviceToken: string;
+  pushId: string;
+  reason: TripEndedReason;
+  sentAt: number;
+  /** 종료된 trip의 token — 클라가 현재 ACTIVE_TRIP_KEY와 비교해 race 차단(#868 P1-2). */
+  tripToken: string;
+  config: ApnsConfig;
+  host: string;
+  fetchImpl?: typeof fetch;
+  now?: number;
+}
+
+export async function sendTripEndedPush(
+  options: SendTripEndedPushOptions,
+): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
+
+  const payload: TripEndedPushPayload = {
+    pushId: options.pushId,
+    kind: 'trip-ended',
+    reason: options.reason,
+    sentAt: options.sentAt,
+    tripToken: options.tripToken,
   };
 
   const body = JSON.stringify({ aps: { 'content-available': 1 }, data: payload });

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -13,12 +13,16 @@
  * 폴백 helper로 raw 필드(etaMinutes, distanceM, alarmType 등)에서 derive 한다.
  */
 
-import { sendLiveActivityUpdate, type LiveActivityContentState } from './apns';
+import {
+  sendLiveActivityUpdate,
+  sendTripEndedPush,
+  type LiveActivityContentState,
+} from './apns';
 import { pickApnsHost } from './apnsHost';
 import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
 import { deleteTrip } from './trips';
-import type { ApnsEnv, Env, Trip, Waypoint } from './types';
+import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
 
 /**
  * stale-date까지 클라이언트가 last content-state를 신뢰할 수 있는 시간(초).
@@ -171,6 +175,13 @@ export async function fireLiveActivityDismissal(
 /**
  * trip 정리 wrapper — LA dismissal(있을 때만) + deleteTrip을 단일 진입점으로.
  * scheduled.ts의 모든 deleteTrip 호출 + HTTP DELETE /trips/:token이 공유.
+ *
+ * #868 — reason 지정 시 trip-ended silent push 발사. server-side auto-end 경로(scheduled.ts의
+ * cron 호출자)는 reason을 명시 전달해 클라 route/destination/lock state를 동기화한다.
+ * HTTP DELETE 경로는 reason 미지정 — 이미 사용자가 destination을 clear한 시점이라 push 불필요.
+ *
+ * push는 LA dismissal과 별개의 budget(분당 0~1건 trip 종료 수준)이라 LA push와 직렬 발사로 충분.
+ * 실패 시 graceful — log만 남기고 cleanup 흐름은 계속 진행한다.
  */
 export async function cleanupTripWithLa(
   trip: Trip,
@@ -179,11 +190,61 @@ export async function cleanupTripWithLa(
   stats: LiveActivityStats,
   now: number,
   log: Logger,
+  reason?: TripEndedReason,
 ): Promise<void> {
   await fireLiveActivityDismissal(trip, deps, stats, now, log);
+  if (reason) {
+    await fireTripEndedPush(trip, reason, deps, now, log);
+  }
   await deleteTrip(env.TRIPS, trip.token);
   // #705 — trip을 폐기할 때 progress entry도 함께 제거. TTL이 자연 만료를 보장하지만
   // 즉시 cleanup해야 새 동일 token trip 등록 시 stale shiftedCount가 끼지 않는다.
   await deleteProgress(env.TRIPS, trip.token);
+}
+
+/**
+ * trip-ended silent push 발사 (#868). LA dismissal과 직렬로 1회 발사.
+ * 실패는 fire-and-forget 성격이지만 흐름 일관성을 위해 await — APNs latency는 cron 1 cycle 안에서 흡수.
+ * fireLiveActivityDismissal과 마찬가지로 trip 상태 변경 없이 best-effort.
+ */
+async function fireTripEndedPush(
+  trip: Trip,
+  reason: TripEndedReason,
+  deps: LiveActivityDeps,
+  now: number,
+  log: Logger,
+): Promise<void> {
+  const host = pickApnsHost(trip.apnsEnv, deps.apnsHosts);
+  const pushId = crypto.randomUUID();
+  // JWT 서명 / network reject 등의 throw가 cleanup 흐름을 차단하지 않도록 swallow.
+  // trip-ended push는 graceful fail-soft — graceful loss 시 클라는 다음 FG hydrate에서 회복.
+  try {
+    const result = await sendTripEndedPush({
+      deviceToken: trip.token,
+      pushId,
+      reason,
+      sentAt: now,
+      // race 가드(#868 P1-2) — push 도착 시점에 클라가 trip 갈아탔으면 ACTIVE_TRIP_KEY 불일치로 cleanup skip.
+      tripToken: trip.token,
+      config: deps.apnsConfig,
+      host,
+      fetchImpl: deps.fetchImpl,
+      now,
+    });
+    if (!result.ok) {
+      log('trip-ended push failed', {
+        token: trip.token.slice(0, 8),
+        reason,
+        status: result.status,
+        pushReason: result.reason,
+      });
+    }
+  } catch (e) {
+    log('trip-ended push threw', {
+      token: trip.token.slice(0, 8),
+      reason,
+      error: String(e),
+    });
+  }
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -237,7 +237,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
 
     if (trip.expiresAt <= now) {
       // #586 D — trip 만료 시 활성 LA가 남아 있으면 dismissal push로 정리하고 KV에서 제거.
-      await cleanupTripWithLa(trip, env, deps, stats, now, log);
+      // #868 — 클라 state sync용 trip-ended silent push도 함께 발사 (reason=expired).
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'expired');
       continue;
     }
 
@@ -502,13 +503,14 @@ export async function runTrainCodeTracking(
     });
     if (nextMissCount >= MAX_CONSECUTIVE_ETA_MISSING) {
       // #706 — 운행 시간대 외 무한 폴링 차단. cleanupTripWithLa가 LA dismissal + deleteTrip을 묶어 정리.
+      // #868 — 클라 state sync용 trip-ended silent push 발사 (reason=eta-missing).
       log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
         token: trip.token.slice(0, 8),
         trainCode: lock.trainCode,
         station: waypoint.stationName,
         threshold: MAX_CONSECUTIVE_ETA_MISSING,
       });
-      await cleanupTripWithLa(trip, env, deps, stats, now, log);
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'eta-missing');
       return;
     }
     trip.consecutiveEtaMissing = nextMissCount;
@@ -615,7 +617,8 @@ export async function advanceBoardingLockWaypoint(
   log: Logger,
 ): Promise<void> {
   if (waypoint.kind === 'destination') {
-    await cleanupTripWithLa(trip, env, deps, stats, now, log);
+    // #868 — destination 도착으로 trip 종료. 클라 state sync용 trip-ended silent push 발사.
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
     log('boarding-lock: destination arrived, trip cleared', {
       token: trip.token.slice(0, 8),
       station: waypoint.stationName,
@@ -632,7 +635,8 @@ export async function advanceBoardingLockWaypoint(
     remaining: trip.waypoints.length,
   });
   if (trip.waypoints.length === 0) {
-    await cleanupTripWithLa(trip, env, deps, stats, now, log);
+    // #868 — waypoints 소진(intermediate 마지막 통과)도 effective destination-arrived.
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
     return;
   }
   // stopsRemaining 변동 즉시 LA 발사 — 사용자에게 새 hop 정보를 즉시 노출.
@@ -767,7 +771,10 @@ export async function maybeReschedulePush(
     });
     if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
       // #586 D — trip이 unrecoverable로 폐기되는 경로에서도 LA가 살아있으면 dismissal로 정리.
-      await cleanupTripWithLa(trip, env, deps, stats, now, log);
+      // #868 — 클라 state sync용 trip-ended silent push도 발사 (reason=push-unrecoverable).
+      // 단, 토큰 자체가 unrecoverable이면 push도 같은 이유로 실패할 가능성이 높음 — fireTripEndedPush
+      // 내부에서 graceful log만 남기고 cleanup 흐름은 계속 진행한다.
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
       return { cleanedUp: true };
     }
   }
@@ -895,7 +902,8 @@ export async function runLocklessIntermediate(
       isUnrecoverableApnsError(heal.result.status, heal.result.reason) ||
       heal.envMismatchExhausted
     ) {
-      await cleanupTripWithLa(trip, env, deps, stats, now, log);
+      // #868 — lockless push unrecoverable로 trip 폐기 시에도 클라 state sync push 발사.
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
       return;
     }
     if (dirty) await putTrip(env.TRIPS, trip);
@@ -908,7 +916,8 @@ export async function runLocklessIntermediate(
   trip.waypoints.shift();
   if (trip.waypoints.length === 0) {
     // 마지막 intermediate까지 통과 — trip 종료. lockless는 destination을 직접 다루지 않는다.
-    await cleanupTripWithLa(trip, env, deps, stats, now, log);
+    // #868 — lockless trip의 effective destination-arrived도 동일 reason.
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
     return;
   }
   // 다음 waypoint를 위해 dedup stamp reset (위 shift 직후 첫 waypoint는 새 발사 대상).

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -214,6 +214,43 @@ export interface ReschedulePushPayload {
   sentAt: number;
 }
 
+/**
+ * Trip 자동 종료 reason (#868).
+ *   - 'eta-missing' — consecutiveEtaMissing 임계 초과 (운행 시간대 외 / trainCode 소실)
+ *   - 'destination-arrived' — 목적지 도착 또는 마지막 intermediate 통과로 trip 종료
+ *   - 'expired' — trip.expiresAt 시각 초과로 자동 만료
+ *   - 'push-unrecoverable' — APNs unrecoverable error로 trip 폐기
+ *
+ * 클라가 명시적으로 trip을 끝낸 경로(HTTP DELETE /trips/:token)는 발사 대상이 아님 —
+ * 사용자가 destination을 clear하면 이미 클라이언트 store가 정리된 상태이기 때문.
+ */
+export type TripEndedReason =
+  | 'eta-missing'
+  | 'destination-arrived'
+  | 'expired'
+  | 'push-unrecoverable';
+
+/**
+ * Trip ended silent push payload (#868).
+ * backend가 server-side로 trip을 자동 종료(eta-missing/destination-arrived/expired/push-unrecoverable)
+ * 했을 때 클라이언트의 route/destination/lock state를 동기화하기 위해 발사한다.
+ *
+ * client는 이 payload 수신 시 trip-bound storage(route, destination, boardingLock, activeTrip 등)를
+ * 일괄 cleanup한다. cleanup만 하므로 alert fallback 대상이 아니며 pushId echo 의무도 없다 (graceful loss
+ * 시에는 다음 FG 진입 시 useTripsBackendSync 등이 종국에는 hydrate로 복구).
+ *
+ * `tripToken`은 race 가드용 — backend가 trip A에 대해 push를 발사한 후 APNs latency 동안
+ * 사용자가 trip B를 새로 시작했다면, 클라는 tripToken과 현재 ACTIVE_TRIP_KEY를 비교해
+ * 불일치 시 cleanup을 skip (trip B의 storage를 잘못 파괴하는 것을 방지).
+ */
+export interface TripEndedPushPayload {
+  pushId: string;
+  kind: 'trip-ended';
+  reason: TripEndedReason;
+  sentAt: number;
+  tripToken: string;
+}
+
 /** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */
 export type ApnsEnv = 'sandbox' | 'production';
 

--- a/src/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/store/__tests__/tripBoundCleanups.test.ts
@@ -1,5 +1,11 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TRIP_BOUND_CLEANUPS, runTripBoundCleanups } from '../tripBoundCleanups';
+import {
+  DESTINATION_KEY,
+  ROUTE_KEY,
+  BOARDING_LOCK_KEY,
+  ACTIVE_TRIP_KEY,
+} from '../../constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
@@ -12,6 +18,20 @@ describe('tripBoundCleanups', () => {
 
   it('TRIP_BOUND_CLEANUPS는 비어있지 않다 (메타 배열 self-check)', () => {
     expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThan(0);
+  });
+
+  it('#868 — runTripBoundCleanups 실행 시 DESTINATION_KEY와 핵심 trip-bound 키들이 storage에서 제거된다', async () => {
+    // BG silent push 경로에서 zustand store에 접근 불가하므로 storage 직접 제거가 유일한 경로.
+    // DESTINATION_KEY 누락 회귀 차단 (#868 P1-1).
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+    await runTripBoundCleanups();
+    const removedKeys = (AsyncStorage.removeItem as jest.Mock).mock.calls.map(
+      (c) => c[0] as string,
+    );
+    expect(removedKeys).toContain(DESTINATION_KEY);
+    expect(removedKeys).toContain(ROUTE_KEY);
+    expect(removedKeys).toContain(BOARDING_LOCK_KEY);
+    expect(removedKeys).toContain(ACTIVE_TRIP_KEY);
   });
 
   it('TRIP_BOUND_CLEANUPS의 모든 항목은 호출 가능하며 Promise를 반환하고 reject하지 않는다', async () => {

--- a/src/store/tripBoundCleanups.ts
+++ b/src/store/tripBoundCleanups.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   ROUTE_KEY,
+  DESTINATION_KEY,
   CUSTOM_ORIGIN_KEY,
   BOARDING_LOCK_KEY,
   SCHEDULED_NOTIFICATIONS_KEY,
@@ -33,6 +34,10 @@ import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dism
 export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   clearFiredAlarms,
   () => AsyncStorage.removeItem(ROUTE_KEY),
+  // #868 — silent push trip-ended 경로에서는 zustand store에 접근 불가하므로 storage를 직접 제거.
+  // setDestination(null) 경로는 useAppStore가 이미 inline으로 removeItem을 수행하지만,
+  // 멱등 호출이라 중복 해도 무해. 이 배열은 BG cleanup의 single source.
+  () => AsyncStorage.removeItem(DESTINATION_KEY),
   () => AsyncStorage.removeItem(CUSTOM_ORIGIN_KEY),
   () => AsyncStorage.removeItem(BOARDING_LOCK_KEY),
   () => AsyncStorage.removeItem(SCHEDULED_NOTIFICATIONS_KEY),

--- a/src/tasks/__tests__/silentPushTask.test.ts
+++ b/src/tasks/__tests__/silentPushTask.test.ts
@@ -20,6 +20,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 const mockLogSilentPushReceived = jest.fn();
 const mockLogSilentPushRescheduleReceived = jest.fn();
+const mockLogSilentPushTripEndedReceived = jest.fn();
 const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
@@ -27,9 +28,17 @@ jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
   logSilentPushRescheduleReceived: (...args: unknown[]) =>
     mockLogSilentPushRescheduleReceived(...args),
+  logSilentPushTripEndedReceived: (...args: unknown[]) =>
+    mockLogSilentPushTripEndedReceived(...args),
   logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
+}));
+
+// #868 — trip-ended payload 수신 시 trip-bound storage cleanup.
+const mockRunTripBoundCleanups = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../store/tripBoundCleanups', () => ({
+  runTripBoundCleanups: () => mockRunTripBoundCleanups(),
 }));
 
 const mockCheckGate = jest.fn();
@@ -112,6 +121,7 @@ import {
 } from '../silentPushTask';
 import {
   APNS_TOKEN_KEY,
+  ACTIVE_TRIP_KEY,
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
 } from '../../constants/storageKeys';
@@ -417,6 +427,79 @@ describe('silentPushTask', () => {
             }),
           ),
         ).toMatchObject({ sentAt: undefined, pushId: undefined });
+      });
+    });
+
+    // #868 — server-side trip auto-end 신호. nextWaypoint 없이 reason만 의미 있는 payload.
+    describe('trip-ended kind (#868)', () => {
+      it('정상 trip-ended payload → TripEndedSilentPushPayload', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'trip-ended',
+              reason: 'eta-missing',
+              sentAt: 1_780_000_000_000,
+              pushId: 'uuid-te',
+            }),
+          ),
+        ).toEqual({
+          kind: 'trip-ended',
+          reason: 'eta-missing',
+          sentAt: 1_780_000_000_000,
+          pushId: 'uuid-te',
+        });
+      });
+
+      it.each([
+        ['eta-missing'],
+        ['destination-arrived'],
+        ['expired'],
+        ['push-unrecoverable'],
+      ])('known reason %s → 그대로 전달', (reason) => {
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended', reason })),
+        ).toMatchObject({ reason });
+      });
+
+      it('알 수 없는 reason → unknown으로 정규화 (구버전/신규 호환)', () => {
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended', reason: 'future-reason' })),
+        ).toMatchObject({ reason: 'unknown' });
+      });
+
+      it('reason 누락/비문자열 → unknown', () => {
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended' })),
+        ).toMatchObject({ reason: 'unknown' });
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended', reason: 42 })),
+        ).toMatchObject({ reason: 'unknown' });
+      });
+
+      it('sentAt/pushId 옵션 — 누락 시 undefined로 정리', () => {
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended', reason: 'expired' })),
+        ).toMatchObject({ sentAt: undefined, pushId: undefined });
+      });
+
+      it('tripToken 포함 시 그대로 전달 (race 가드용)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ kind: 'trip-ended', reason: 'eta-missing', tripToken: 'tok-abc' }),
+          ),
+        ).toMatchObject({ tripToken: 'tok-abc' });
+      });
+
+      it('tripToken 누락/비문자열/빈 문자열 → undefined로 정규화 (구버전 backend 호환)', () => {
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended', reason: 'expired' })),
+        ).toMatchObject({ tripToken: undefined });
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended', reason: 'expired', tripToken: 42 })),
+        ).toMatchObject({ tripToken: undefined });
+        expect(
+          extractPayload(bgTaskData({ kind: 'trip-ended', reason: 'expired', tripToken: '' })),
+        ).toMatchObject({ tripToken: undefined });
       });
     });
   });
@@ -1112,6 +1195,147 @@ describe('silentPushTask', () => {
         await handleSilentPush(reschedulePayload({ pushId: 'rs-uuid' }));
         expect(mockSendPushAck).not.toHaveBeenCalled();
         expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    // #868 — server-side trip 자동 종료 신호 수신 → trip-bound storage cleanup.
+    describe('trip-ended kind (#868)', () => {
+      function tripEndedPayload(extra: Record<string, unknown> = {}) {
+        return {
+          data: {
+            data: {
+              data: { kind: 'trip-ended', reason: 'eta-missing', ...extra },
+              dataString: null,
+            },
+            notification: null,
+            aps: { 'content-available': 1 },
+          },
+        };
+      }
+
+      it('trip-ended 수신 → runTripBoundCleanups 호출 + 표준 발사 경로 미진입', async () => {
+        await handleSilentPush(tripEndedPayload({ sentAt: 1_780_000_000_000 }));
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+        // standard 발사 경로는 호출되지 않아야 함.
+        expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
+        expect(mockCheckGate).not.toHaveBeenCalled();
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
+      });
+
+      it('logSilentPushTripEndedReceived 1회 호출 + reason 보존', async () => {
+        await handleSilentPush(
+          tripEndedPayload({ reason: 'destination-arrived', sentAt: 1_780_000_000_000 }),
+        );
+        expect(mockLogSilentPushTripEndedReceived).toHaveBeenCalledTimes(1);
+        const arg = mockLogSilentPushTripEndedReceived.mock.calls[0][0];
+        expect(arg.reason).toBe('destination-arrived');
+        expect(arg.sentAt).toBe(1_780_000_000_000);
+        expect(typeof arg.receivedAt).toBe('number');
+      });
+
+      it.each([
+        ['eta-missing'],
+        ['destination-arrived'],
+        ['expired'],
+        ['push-unrecoverable'],
+      ])('known reason %s에서 cleanup 트리거', async (reason) => {
+        await handleSilentPush(tripEndedPayload({ reason }));
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+        expect(mockLogSilentPushTripEndedReceived).toHaveBeenCalledWith(
+          expect.objectContaining({ reason }),
+        );
+      });
+
+      it('알 수 없는 reason도 정규화(unknown)되어 cleanup 트리거', async () => {
+        await handleSilentPush(tripEndedPayload({ reason: 'future-reason' }));
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+        expect(mockLogSilentPushTripEndedReceived).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'unknown' }),
+        );
+      });
+
+      it('pushId 있으면 ack(fired, trip-ended:reason) 전송', async () => {
+        await handleSilentPush(tripEndedPayload({ pushId: 'te-uuid', reason: 'expired' }));
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'te-uuid',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'fired',
+          reason: 'trip-ended:expired',
+        });
+      });
+
+      it('pushId 없으면 ack 호출 안 함 — cleanup은 그대로', async () => {
+        await handleSilentPush(tripEndedPayload());
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      });
+
+      it('apnsToken null이면 pushId 있어도 ack skip — cleanup은 그대로', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return null;
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          return null;
+        });
+        await handleSilentPush(tripEndedPayload({ pushId: 'te-uuid' }));
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      });
+
+      it('#868 P1-2 — tripToken이 ACTIVE_TRIP_KEY와 불일치하면 cleanup skip + ack는 token-mismatch reason', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return 'NEW-TRIP-TOKEN';
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          return null;
+        });
+        await handleSilentPush(
+          tripEndedPayload({ pushId: 'te-uuid', tripToken: 'OLD-TRIP-TOKEN' }),
+        );
+        // cleanup은 호출되지 않아야 함 (다른 trip의 storage를 파괴하지 않음).
+        expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+        // ack는 그대로 전송(backend pendingPushes 정합).
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'te-uuid',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'fired',
+          reason: expect.stringContaining('token-mismatch') as unknown as string,
+        });
+      });
+
+      it('#868 P1-2 — tripToken이 ACTIVE_TRIP_KEY와 일치하면 cleanup 진행', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return 'SAME-TRIP-TOKEN';
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          return null;
+        });
+        await handleSilentPush(tripEndedPayload({ tripToken: 'SAME-TRIP-TOKEN' }));
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      });
+
+      it('#868 P1-2 — tripToken이 payload에 없으면(구버전 backend) cleanup 진행 (호환)', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return 'ANY-TOKEN';
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          return null;
+        });
+        // tripToken 누락 = 구버전 backend
+        await handleSilentPush(tripEndedPayload());
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      });
+
+      it('#868 P1-2 — ACTIVE_TRIP_KEY가 null(클라 이미 trip 종료)이면 cleanup 진행', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return null;
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          return null;
+        });
+        await handleSilentPush(tripEndedPayload({ tripToken: 'OLD-TRIP-TOKEN' }));
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/tasks/silentPushTask.ts
+++ b/src/tasks/silentPushTask.ts
@@ -22,6 +22,7 @@ import i18next from 'i18next';
 import type { Station } from '../types/station';
 import {
   APNS_TOKEN_KEY,
+  ACTIVE_TRIP_KEY,
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
 } from '../constants/storageKeys';
@@ -31,10 +32,12 @@ import {
   flushAlarmLog,
   logSilentPushReceived,
   logSilentPushRescheduleReceived,
+  logSilentPushTripEndedReceived,
   logSilentPushFired,
   logSilentPushSkipped,
   type AlarmLogReason,
 } from '../utils/alarmLog';
+import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../utils/movementGate';
@@ -91,8 +94,43 @@ export interface RescheduleSilentPushPayload {
   pushId?: string;
 }
 
-/** extractPayload 결과 — standard silent push 또는 reschedule push. */
-export type ExtractedPayload = SilentPushPayload | RescheduleSilentPushPayload;
+/**
+ * Trip ended silent push payload (#868). 백엔드가 server-side로 trip을 자동 종료했을 때
+ * 클라이언트의 route/destination/lock state를 동기화하라는 신호. backend `apns.ts`의
+ * `TripEndedPushPayload`와 1:1.
+ *
+ * reason 타입은 backend types.ts의 `TripEndedReason`과 동일 enum literal을 사용하지만,
+ * 클라는 unknown reason도 graceful하게 처리하기 위해 string으로 받아 후처리한다.
+ * (구버전 backend 호환 + 신규 reason 추가 시 회귀 없음.)
+ */
+export interface TripEndedSilentPushPayload {
+  kind: 'trip-ended';
+  reason: TripEndedReason;
+  sentAt?: number;
+  pushId?: string;
+  /**
+   * race 가드용 trip 식별자(#868 P1-2). backend가 보낸 trip의 token — 클라가 현재
+   * ACTIVE_TRIP_KEY와 비교해 불일치 시 cleanup skip. 구버전 backend 호환을 위해 optional.
+   */
+  tripToken?: string;
+}
+
+/**
+ * Trip 자동 종료 reason — backend `types.ts`의 TripEndedReason과 정렬.
+ * 알 수 없는 reason은 'unknown'으로 정규화해 처리 (구버전 backend 호환 + cleanup은 동일).
+ */
+export type TripEndedReason =
+  | 'eta-missing'
+  | 'destination-arrived'
+  | 'expired'
+  | 'push-unrecoverable'
+  | 'unknown';
+
+/** extractPayload 결과 — standard silent push / reschedule push / trip-ended push. */
+export type ExtractedPayload =
+  | SilentPushPayload
+  | RescheduleSilentPushPayload
+  | TripEndedSilentPushPayload;
 
 /**
  * expo-notifications iOS의 `BackgroundEventTransformer.swift`가 APNs payload를
@@ -132,6 +170,10 @@ function isRescheduleCandidate(rec: Record<string, unknown>): boolean {
   return rec.kind === 'reschedule';
 }
 
+function isTripEndedCandidate(rec: Record<string, unknown>): boolean {
+  return rec.kind === 'trip-ended';
+}
+
 function findFieldsLayer(
   taskData: NotificationBackgroundTaskData['data'],
 ): Record<string, unknown> | null {
@@ -147,7 +189,13 @@ function findFieldsLayer(
     candidates.push(root);
   }
   for (const rec of candidates) {
-    if (isStandardCandidate(rec) || isRescheduleCandidate(rec)) return rec;
+    if (
+      isStandardCandidate(rec) ||
+      isRescheduleCandidate(rec) ||
+      isTripEndedCandidate(rec)
+    ) {
+      return rec;
+    }
   }
   return null;
 }
@@ -166,6 +214,8 @@ export function extractPayload(
   if (!obj) return null;
   // reschedule 분기 (#725) — schema가 standard와 다름. discriminator는 kind === 'reschedule'.
   if (obj.kind === 'reschedule') return extractReschedulePayload(obj);
+  // trip-ended 분기 (#868) — schema는 단순 (reason만). discriminator는 kind === 'trip-ended'.
+  if (obj.kind === 'trip-ended') return extractTripEndedPayload(obj);
   return extractStandardPayload(obj);
 }
 
@@ -206,6 +256,37 @@ function extractReschedulePayload(
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
   };
+}
+
+/**
+ * trip-ended payload 추출 (#868). schema 최소 — discriminator(kind)와 reason만.
+ * reason이 known set에 없으면 'unknown'으로 정규화 (구버전 backend / 신규 reason 호환).
+ */
+function extractTripEndedPayload(
+  obj: Record<string, unknown>,
+): TripEndedSilentPushPayload | null {
+  const { reason, sentAt, pushId, tripToken } = obj;
+  return {
+    kind: 'trip-ended',
+    reason: normalizeTripEndedReason(reason),
+    sentAt: validSentAt(sentAt),
+    pushId: validPushId(pushId),
+    tripToken: typeof tripToken === 'string' && tripToken.length > 0 ? tripToken : undefined,
+  };
+}
+
+const KNOWN_TRIP_ENDED_REASONS: ReadonlyArray<TripEndedReason> = [
+  'eta-missing',
+  'destination-arrived',
+  'expired',
+  'push-unrecoverable',
+];
+
+function normalizeTripEndedReason(reason: unknown): TripEndedReason {
+  if (typeof reason !== 'string') return 'unknown';
+  return KNOWN_TRIP_ENDED_REASONS.includes(reason as TripEndedReason)
+    ? (reason as TripEndedReason)
+    : 'unknown';
 }
 
 function validSentAt(sentAt: unknown): number | undefined {
@@ -327,6 +408,38 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         receivedAt,
       });
       ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
+      return;
+    }
+
+    // trip-ended 분기 (#868) — backend가 server-side trip 자동 종료를 알리는 신호.
+    // route/destination/lock 등 trip-bound storage를 일괄 cleanup해 다음 FG 진입 시
+    // store hydrate가 stale state를 그대로 재현하지 않도록 한다.
+    //
+    // ack outcome='fired'는 backend pendingPushes 입장에서는 "처리 완료, alert fallback 발사 마라"
+    // 신호. trip-ended는 alert fallback 대상이 아니지만 호환을 위해 일반 silent push와 같은 의미로 ack.
+    if (payload.kind === 'trip-ended') {
+      logger.info(
+        `trip-ended received: reason=${payload.reason} tripToken=${payload.tripToken?.slice(0, 8) ?? 'unknown'} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+      );
+      // race 가드(#868 P1-2). 신규 backend는 tripToken을 항상 보냄. 구버전(undefined)은
+      // 호환 위해 cleanup 진행 — race 가능성은 있지만 backend 배포 후 사라짐.
+      if (payload.tripToken !== undefined) {
+        const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+        if (activeTripToken !== null && activeTripToken !== payload.tripToken) {
+          logger.warn(
+            `trip-ended skip: tripToken mismatch payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken.slice(0, 8)}`,
+          );
+          ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}:token-mismatch`);
+          return;
+        }
+      }
+      logSilentPushTripEndedReceived({
+        reason: payload.reason,
+        sentAt: payload.sentAt,
+        receivedAt,
+      });
+      await runTripBoundCleanups();
+      ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}`);
       return;
     }
 

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -31,6 +31,7 @@ import {
   logSuppressedMovement,
   logSilentPushReceived,
   logSilentPushRescheduleReceived,
+  logSilentPushTripEndedReceived,
   logSilentPushFired,
   logSilentPushSkipped,
   logAlertFallbackFired,
@@ -819,6 +820,44 @@ describe('alarmLog', () => {
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
       expect(saved[0].sentAt).toBeUndefined();
+    });
+
+    // #868 — trip-ended 수신 적재. station name 자리에 `trip-ended:${reason}`을 인코딩해
+    // DebugModal에서 reason을 가시화. kind/phaseId는 trip 종료라 의미 없음.
+    it('logSilentPushTripEndedReceived: stationName=trip-ended:${reason}, sentAt/receivedAt 적재 (#868)', async () => {
+      logSilentPushTripEndedReceived({
+        reason: 'eta-missing',
+        sentAt: 1_780_000_000_000,
+        receivedAt: 1_780_000_001_500,
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        ts: 1_780_000_001_500,
+        source: 'silent-push-received',
+        outcome: 'received',
+        stationName: 'trip-ended:eta-missing',
+        sentAt: 1_780_000_000_000,
+        receivedAt: 1_780_000_001_500,
+      });
+      expect(saved[0].kind).toBeUndefined();
+      expect(saved[0].phaseId).toBeUndefined();
+    });
+
+    it('logSilentPushTripEndedReceived: sentAt 누락이면 undefined로 적재 (#868)', async () => {
+      logSilentPushTripEndedReceived({
+        reason: 'destination-arrived',
+        sentAt: undefined,
+        receivedAt: 1_780_000_001_500,
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].sentAt).toBeUndefined();
+      expect(saved[0].stationName).toBe('trip-ended:destination-arrived');
     });
 
     it('logSilentPushFired: 게이트 통과 후 발사 1건 적재 (#478 PR 1-2)', async () => {

--- a/src/utils/__tests__/alarmLog.test.ts
+++ b/src/utils/__tests__/alarmLog.test.ts
@@ -824,41 +824,29 @@ describe('alarmLog', () => {
 
     // #868 — trip-ended 수신 적재. station name 자리에 `trip-ended:${reason}`을 인코딩해
     // DebugModal에서 reason을 가시화. kind/phaseId는 trip 종료라 의미 없음.
-    it('logSilentPushTripEndedReceived: stationName=trip-ended:${reason}, sentAt/receivedAt 적재 (#868)', async () => {
-      logSilentPushTripEndedReceived({
-        reason: 'eta-missing',
-        sentAt: 1_780_000_000_000,
-        receivedAt: 1_780_000_001_500,
-      });
-      await flushAlarmLog();
-
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved[0]).toMatchObject({
-        ts: 1_780_000_001_500,
-        source: 'silent-push-received',
-        outcome: 'received',
-        stationName: 'trip-ended:eta-missing',
-        sentAt: 1_780_000_000_000,
-        receivedAt: 1_780_000_001_500,
-      });
-      expect(saved[0].kind).toBeUndefined();
-      expect(saved[0].phaseId).toBeUndefined();
-    });
-
-    it('logSilentPushTripEndedReceived: sentAt 누락이면 undefined로 적재 (#868)', async () => {
-      logSilentPushTripEndedReceived({
-        reason: 'destination-arrived',
-        sentAt: undefined,
-        receivedAt: 1_780_000_001_500,
-      });
-      await flushAlarmLog();
-
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved[0].sentAt).toBeUndefined();
-      expect(saved[0].stationName).toBe('trip-ended:destination-arrived');
-    });
+    it.each<['eta-missing' | 'destination-arrived', number | undefined]>([
+      ['eta-missing', 1_780_000_000_000],
+      ['destination-arrived', undefined],
+    ])(
+      'logSilentPushTripEndedReceived reason=%s sentAt=%s 적재 (#868)',
+      async (reason, sentAt) => {
+        const receivedAt = 1_780_000_001_500;
+        logSilentPushTripEndedReceived({ reason, sentAt, receivedAt });
+        await flushAlarmLog();
+        const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+        const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+        expect(saved[0]).toMatchObject({
+          ts: receivedAt,
+          source: 'silent-push-received',
+          outcome: 'received',
+          stationName: `trip-ended:${reason}`,
+          receivedAt,
+        });
+        expect(saved[0].sentAt).toBe(sentAt);
+        expect(saved[0].kind).toBeUndefined();
+        expect(saved[0].phaseId).toBeUndefined();
+      },
+    );
 
     it('logSilentPushFired: 게이트 통과 후 발사 1건 적재 (#478 PR 1-2)', async () => {
       logSilentPushFired({

--- a/src/utils/alarmLog.ts
+++ b/src/utils/alarmLog.ts
@@ -341,6 +341,28 @@ export function logSilentPushRescheduleReceived(input: {
 }
 
 /**
+ * Trip-ended silent push 수신 1건 적재 (#868).
+ *
+ * server-side trip auto-end 신호. 일반 silent push와 source는 같지만 station/kind/phaseId 모두 무의미
+ * (trip 자체가 종료되므로 다음 역 컨텍스트 없음). reason은 stationName 자리에 인코딩해 DebugModal에서
+ * 가시화 — alarmLog schema에 새 reason 필드를 더하지 않고 기존 슬롯을 재사용한다.
+ */
+export function logSilentPushTripEndedReceived(input: {
+  reason: string;
+  sentAt: number | undefined;
+  receivedAt: number;
+}): void {
+  appendAlarmLog({
+    ts: input.receivedAt,
+    source: 'silent-push-received',
+    outcome: 'received',
+    stationName: `trip-ended:${input.reason}`,
+    sentAt: input.sentAt,
+    receivedAt: input.receivedAt,
+  });
+}
+
+/**
  * silent push가 위치 게이트 통과 → 즉시 발사한 1건 (#478 PR 1-2).
  */
 export function logSilentPushFired(input: {


### PR DESCRIPTION
## Summary

backend boarding-lock cron이 trip을 server-side 자동 종료(eta-missing/destination-arrived/expired/push-unrecoverable)한 후에도 클라가 trip 상태(route/destination/activeTrip)를 유지해 FG 진입 시 alarm log burst가 발생하던 P1-D 회귀를 silent push 신호로 해소한다.

### 흐름
```
backend cleanupTripWithLa(trip, reason)
  → fireLiveActivityDismissal
  → fireTripEndedPush  (NEW)  — silent push (kind='trip-ended', tripToken, reason)
  → deleteTrip / deleteProgress
[클라]
  → silentPushTask handleSilentPush
  → payload.tripToken === ACTIVE_TRIP_KEY 인 경우만 runTripBoundCleanups
  → ack(fired, trip-ended:reason)
```

### 변경
**backend** (`backend/alarm-worker/src/`):
- `types.ts` — TripEndedReason union + TripEndedPushPayload (tripToken 포함)
- `apns.ts` — sendTripEndedPush helper
- `liveActivity.ts` — cleanupTripWithLa에 reason optional 추가, fireTripEndedPush try/catch graceful
- `scheduled.ts` — cleanup 경로 4곳에서 reason 명시 전달

**client** (`src/`):
- `tasks/silentPushTask.ts` — trip-ended 분기 + tripToken race 가드(ACTIVE_TRIP_KEY 비교)
- `store/tripBoundCleanups.ts` — DESTINATION_KEY 추가 (BG에서 zustand 접근 불가)
- `utils/alarmLog.ts` — logSilentPushTripEndedReceived 진단 entry

### 코드 리뷰 P1 반영
- **P1-1 (`DESTINATION_KEY` 누락)**: TRIP_BOUND_CLEANUPS에 명시 추가 + 회귀 가드 테스트. PR의 핵심 의도(destination cleanup)가 누락된 회귀 차단
- **P1-2 (tripToken race)**: backend payload에 tripToken 추가, client에서 ACTIVE_TRIP_KEY와 비교해 다른 trip의 storage 파괴 방지. 구버전 backend(tripToken 누락) 호환 유지
- **P2-1 (push throw)**: `fireTripEndedPush` try/catch graceful — JWT/network throw가 cleanup 흐름 차단하지 않음

### APNs budget
trip 종료는 분당 0~1건 — budget 영향 무시 가능.

## 디바이스 evidence (이슈 본문)
Trip D (KST 18:45~18:57): backend auto-end(18:57) 이후에도 클라는 19:43~20:44 사이 `route=set, destination=2-011, activeTrip=…35b3502c` 유지. BG 24분+33분 alarm log 공백 + FG 진입 직후 `dedup-station × 3 + fg-hydrate 1` 발사.

## Test plan
- [x] backend `npm test` — 683 passed (trip-ended push 4 reason / tripToken 검증 / throw graceful 5건 신규)
- [x] client `npm test` — 3378 passed, 커버리지 100% (extractPayload tripToken 3건 / race 가드 4건 / DESTINATION_KEY 회귀 1건)
- [x] backend `npm run type-check` 통과
- [x] client `npm run type-check` 통과
- [x] code-review — P1 2건(DESTINATION_KEY 누락 / tripToken race) 본 PR 반영, P2 fireTripEndedPush try/catch도 반영
- [ ] 실기기: 환승 또는 destination-arrived trip에서 backend auto-end 발생 시 클라 storage 자동 정리 확인

## Follow-up (별도 이슈 권장)
- (P2-2) alarmLog.stationName에 reason 인코딩 → 정식 reason 필드 (schema 정합)
- (P2-3) extractTripEndedPayload 반환 타입 정리 (`| null` 제거 또는 명시 검증)
- (P2-4) pushId 발급되지만 backend pending KV 미등록 — ack 정합/pushId 제거 결정
- (P2-5) `'push-unrecoverable'` reason 발사 정책 재검토 — 도달 가능성 0 가까운 경우 skip
- (P3-1) TripEndedReason 클라/backend 중복 타입 정의

Closes #868