### PR TITLE
feat(#844): BffProgressProvider 인터페이스 + 기본 구현 (PR A)

### DIFF
--- a/src/providers/progress/MockBffProgressProvider.ts
+++ b/src/providers/progress/MockBffProgressProvider.ts
@@ -1,0 +1,23 @@
+import type { BffProgressProvider, BffProgressResponse } from './types';
+
+/**
+ * 개발/테스트용 mock progress provider.
+ *
+ * - 인자 없이 생성하면 `null` 반환 (서버 미수신 시나리오) — Stage 4 회귀 가드 점검에 사용.
+ * - 응답을 주입하면 호출자가 준 `nowMs`를 `receivedAtMs`로 채워 항상 신선한 high-confidence
+ *   응답을 흉내낸다. 테스트가 만료/low/실패 시나리오를 만들고 싶다면 직접 응답을 구성하거나
+ *   `respond(null)`을 호출한다.
+ *
+ * @see docs/decisions/ADR-008-boarding-progress-estimator.md Stage 4
+ */
+export class MockBffProgressProvider implements BffProgressProvider {
+  private next: BffProgressResponse | null = null;
+
+  respond(response: BffProgressResponse | null): void {
+    this.next = response;
+  }
+
+  async fetch(_tripToken: string, _nowMs: number): Promise<BffProgressResponse | null> {
+    return this.next;
+  }
+}

--- a/src/providers/progress/SeoulBffProgressProvider.ts
+++ b/src/providers/progress/SeoulBffProgressProvider.ts
@@ -1,0 +1,70 @@
+import type { BffProgressProvider, BffProgressResponse } from './types';
+
+/**
+ * ADR-008 Stage 4 — 기본 BFF progress 구현.
+ *
+ * - `baseUrl/api/progress/{tripToken}` GET. 인증/스키마 확정은 backend sub-issue.
+ * - TTL 캐시: 응답의 `ttlMs` 만큼 trip 단위로 메모리 캐시. 만료 시점에만 재호출.
+ * - 게이트 실패는 모두 `null` 반환 — estimator가 Stage 1-3 fallback으로 자연 진행 (회귀 가드).
+ *   - 네트워크 실패 / timeout / non-2xx 응답
+ *   - 만료 응답: `nowMs - receivedAtMs > ttlMs`
+ *   - `confidence === 'low'`
+ *
+ * @see docs/decisions/ADR-008-boarding-progress-estimator.md Stage 4
+ */
+export class SeoulBffProgressProvider implements BffProgressProvider {
+  private readonly cache = new Map<string, BffProgressResponse>();
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly timeoutMs: number = 5000,
+  ) {}
+
+  async fetch(tripToken: string, nowMs: number): Promise<BffProgressResponse | null> {
+    const cached = this.cache.get(tripToken);
+    if (cached && nowMs - cached.receivedAtMs <= cached.ttlMs) {
+      return this.gate(cached, nowMs);
+    }
+
+    const fresh = await this.fetchFromBff(tripToken);
+    if (!fresh) {
+      // 네트워크/timeout/non-2xx — stale 캐시는 폐기하지 않고 그대로 둔다.
+      // 다음 호출이 만료된 캐시를 다시 만나도 게이트가 null을 반환하므로 안전.
+      return null;
+    }
+
+    this.cache.set(tripToken, fresh);
+    return this.gate(fresh, nowMs);
+  }
+
+  /**
+   * 신선도/신뢰도 게이트. 회귀 가드: 게이트 실패 시 null 반환 — Stage 1-3 fallback으로 자연 진행.
+   */
+  private gate(response: BffProgressResponse, nowMs: number): BffProgressResponse | null {
+    if (response.confidence === 'low') {
+      return null;
+    }
+    if (nowMs - response.receivedAtMs > response.ttlMs) {
+      return null;
+    }
+    return response;
+  }
+
+  private async fetchFromBff(tripToken: string): Promise<BffProgressResponse | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const url = `${this.baseUrl}/api/progress/${encodeURIComponent(tripToken)}`;
+      const response = await fetch(url, { signal: controller.signal });
+      if (!response.ok) {
+        return null;
+      }
+      return (await response.json()) as BffProgressResponse;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/providers/progress/__tests__/MockBffProgressProvider.test.ts
+++ b/src/providers/progress/__tests__/MockBffProgressProvider.test.ts
@@ -1,0 +1,42 @@
+import { MockBffProgressProvider } from '../MockBffProgressProvider';
+import type { BffProgressResponse } from '../types';
+
+describe('MockBffProgressProvider', () => {
+  it('주입된 응답이 없으면 null을 반환한다 (기본값)', async () => {
+    const provider = new MockBffProgressProvider();
+    const result = await provider.fetch('any-token', 0);
+    expect(result).toBeNull();
+  });
+
+  it('respond로 주입한 응답을 그대로 반환한다', async () => {
+    const provider = new MockBffProgressProvider();
+    const response: BffProgressResponse = {
+      waypointIndex: 4,
+      remainingHopsMs: 15_000,
+      confidence: 'medium',
+      receivedAtMs: 1_000,
+      ttlMs: 60_000,
+    };
+    provider.respond(response);
+
+    const result = await provider.fetch('any-token', 9_999);
+
+    expect(result).toBe(response);
+  });
+
+  it('respond(null)로 응답을 비울 수 있다', async () => {
+    const provider = new MockBffProgressProvider();
+    provider.respond({
+      waypointIndex: 0,
+      remainingHopsMs: 0,
+      confidence: 'high',
+      receivedAtMs: 0,
+      ttlMs: 0,
+    });
+    provider.respond(null);
+
+    const result = await provider.fetch('any-token', 0);
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/providers/progress/__tests__/SeoulBffProgressProvider.test.ts
+++ b/src/providers/progress/__tests__/SeoulBffProgressProvider.test.ts
@@ -1,0 +1,176 @@
+import { SeoulBffProgressProvider } from '../SeoulBffProgressProvider';
+import type { BffProgressResponse } from '../types';
+
+describe('SeoulBffProgressProvider', () => {
+  const BASE_URL = 'https://bff.example.com';
+  const TRIP_TOKEN = 'trainCode-7301:line-2';
+  const NOW_MS = 1_700_000_000_000;
+
+  function mockFetchOk(data: BffProgressResponse) {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(data),
+    });
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('정상 응답 시 BffProgressResponse를 그대로 반환한다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    const response: BffProgressResponse = {
+      waypointIndex: 3,
+      remainingHopsMs: 45_000,
+      confidence: 'high',
+      receivedAtMs: NOW_MS,
+      ttlMs: 60_000,
+    };
+    mockFetchOk(response);
+
+    const result = await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+    expect(result).toEqual(response);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/api/progress/${encodeURIComponent(TRIP_TOKEN)}`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('응답이 만료되면 null을 반환한다 (nowMs - receivedAtMs > ttlMs)', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    const expired: BffProgressResponse = {
+      waypointIndex: 1,
+      remainingHopsMs: 30_000,
+      confidence: 'high',
+      receivedAtMs: NOW_MS - 120_000,
+      ttlMs: 60_000,
+    };
+    mockFetchOk(expired);
+
+    const result = await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+    expect(result).toBeNull();
+  });
+
+  it('confidence가 low면 신선해도 null을 반환한다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    const lowConfidence: BffProgressResponse = {
+      waypointIndex: 2,
+      remainingHopsMs: 40_000,
+      confidence: 'low',
+      receivedAtMs: NOW_MS,
+      ttlMs: 60_000,
+    };
+    mockFetchOk(lowConfidence);
+
+    const result = await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+    expect(result).toBeNull();
+  });
+
+  it('네트워크 실패 시 null을 반환한다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+    expect(result).toBeNull();
+  });
+
+  it('non-2xx 응답 시 null을 반환한다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 503 });
+
+    const result = await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+    expect(result).toBeNull();
+  });
+
+  it('TTL 만료 전까지 캐시에서 응답해 fetch를 중복 호출하지 않는다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    const fresh: BffProgressResponse = {
+      waypointIndex: 5,
+      remainingHopsMs: 25_000,
+      confidence: 'medium',
+      receivedAtMs: NOW_MS,
+      ttlMs: 60_000,
+    };
+    mockFetchOk(fresh);
+
+    const first = await provider.fetch(TRIP_TOKEN, NOW_MS);
+    const second = await provider.fetch(TRIP_TOKEN, NOW_MS + 10_000);
+
+    expect(first).toEqual(fresh);
+    expect(second).toEqual(fresh);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('캐시가 TTL을 넘기면 다시 fetch한다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    const first: BffProgressResponse = {
+      waypointIndex: 1,
+      remainingHopsMs: 50_000,
+      confidence: 'high',
+      receivedAtMs: NOW_MS,
+      ttlMs: 60_000,
+    };
+    const second: BffProgressResponse = {
+      waypointIndex: 2,
+      remainingHopsMs: 30_000,
+      confidence: 'high',
+      receivedAtMs: NOW_MS + 70_000,
+      ttlMs: 60_000,
+    };
+    mockFetchOk(first);
+    mockFetchOk(second);
+
+    const r1 = await provider.fetch(TRIP_TOKEN, NOW_MS);
+    const r2 = await provider.fetch(TRIP_TOKEN, NOW_MS + 70_000);
+
+    expect(r1).toEqual(first);
+    expect(r2).toEqual(second);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('타임아웃 abort 시 null을 반환한다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL, 100);
+    (global.fetch as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new DOMException('Aborted', 'AbortError')), 6000);
+        }),
+    );
+
+    const resultPromise = provider.fetch(TRIP_TOKEN, NOW_MS);
+    jest.runAllTimers();
+    const result = await resultPromise;
+
+    expect(result).toBeNull();
+  });
+
+  it('특수 문자가 포함된 tripToken을 URL 인코딩한다', async () => {
+    const provider = new SeoulBffProgressProvider(BASE_URL);
+    const response: BffProgressResponse = {
+      waypointIndex: 0,
+      remainingHopsMs: 60_000,
+      confidence: 'high',
+      receivedAtMs: NOW_MS,
+      ttlMs: 60_000,
+    };
+    mockFetchOk(response);
+
+    await provider.fetch('lock/with spaces', NOW_MS);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent('lock/with spaces')),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/providers/progress/__tests__/index.test.ts
+++ b/src/providers/progress/__tests__/index.test.ts
@@ -1,0 +1,40 @@
+import { createBffProgressProvider, SeoulBffProgressProvider, MockBffProgressProvider } from '..';
+
+describe('createBffProgressProvider', () => {
+  const ORIGINAL_USE_BFF = process.env.EXPO_PUBLIC_USE_BFF;
+  const ORIGINAL_BFF_URL = process.env.EXPO_PUBLIC_BFF_URL;
+
+  afterEach(() => {
+    if (ORIGINAL_USE_BFF === undefined) {
+      delete process.env.EXPO_PUBLIC_USE_BFF;
+    } else {
+      process.env.EXPO_PUBLIC_USE_BFF = ORIGINAL_USE_BFF;
+    }
+    if (ORIGINAL_BFF_URL === undefined) {
+      delete process.env.EXPO_PUBLIC_BFF_URL;
+    } else {
+      process.env.EXPO_PUBLIC_BFF_URL = ORIGINAL_BFF_URL;
+    }
+  });
+
+  it('EXPO_PUBLIC_USE_BFF=true이고 BFF_URL이 있으면 SeoulBffProgressProvider를 반환한다', () => {
+    process.env.EXPO_PUBLIC_USE_BFF = 'true';
+    process.env.EXPO_PUBLIC_BFF_URL = 'https://bff.example.com';
+
+    expect(createBffProgressProvider()).toBeInstanceOf(SeoulBffProgressProvider);
+  });
+
+  it('EXPO_PUBLIC_USE_BFF=false면 MockBffProgressProvider를 반환한다', () => {
+    process.env.EXPO_PUBLIC_USE_BFF = 'false';
+    process.env.EXPO_PUBLIC_BFF_URL = 'https://bff.example.com';
+
+    expect(createBffProgressProvider()).toBeInstanceOf(MockBffProgressProvider);
+  });
+
+  it('BFF_URL이 없으면 MockBffProgressProvider를 반환한다', () => {
+    process.env.EXPO_PUBLIC_USE_BFF = 'true';
+    delete process.env.EXPO_PUBLIC_BFF_URL;
+
+    expect(createBffProgressProvider()).toBeInstanceOf(MockBffProgressProvider);
+  });
+});

--- a/src/providers/progress/index.ts
+++ b/src/providers/progress/index.ts
@@ -1,0 +1,24 @@
+import type { BffProgressProvider } from './types';
+import { SeoulBffProgressProvider } from './SeoulBffProgressProvider';
+import { MockBffProgressProvider } from './MockBffProgressProvider';
+
+export type { BffProgressProvider, BffProgressResponse } from './types';
+export { SeoulBffProgressProvider } from './SeoulBffProgressProvider';
+export { MockBffProgressProvider } from './MockBffProgressProvider';
+
+/**
+ * ADR-008 Stage 4 progress provider factory.
+ *
+ * `EXPO_PUBLIC_USE_BFF=true` + `EXPO_PUBLIC_BFF_URL` 설정 시 BFF 호출. 그 외엔 항상 null을
+ * 반환하는 mock — Stage 1-3 fallback이 자연 진행되므로 BFF 미배포 환경에서도 안전.
+ */
+export function createBffProgressProvider(): BffProgressProvider {
+  const useBff = process.env.EXPO_PUBLIC_USE_BFF === 'true';
+  const bffUrl = process.env.EXPO_PUBLIC_BFF_URL;
+
+  if (useBff && bffUrl) {
+    return new SeoulBffProgressProvider(bffUrl);
+  }
+
+  return new MockBffProgressProvider();
+}

--- a/src/providers/progress/types.ts
+++ b/src/providers/progress/types.ts
@@ -1,0 +1,32 @@
+/**
+ * ADR-008 Stage 4 — BFF가 권위 있게 내려주는 boarding progress 응답.
+ *
+ * 서버는 1분 cron으로 trip의 `boardingLock`을 평가하고 현재 어디서 다음 어디까지
+ * 얼마 남았는지를 lock 단위로 산출한다. 클라는 medium 이상 신뢰도의 신선한 응답만
+ * 채택하고, 게이트 실패 시 Stage 1-3 fallback 경로로 자연 진행한다(회귀 가드).
+ */
+export interface BffProgressResponse {
+  /** route segment 내 현재 waypoint (0-indexed). */
+  waypointIndex: number;
+  /** 다음 waypoint까지 잔여 ms (서버 ETA 기준). */
+  remainingHopsMs: number;
+  /** 서버가 계산한 신뢰도 — 클라는 medium 이상만 채택. */
+  confidence: 'high' | 'medium' | 'low';
+  /** 서버 응답 시각 (epoch ms) — Stage 1-3 신선도 계약과 동일 명명. */
+  receivedAtMs: number;
+  /** 응답 유효 기간 — 만료 시 클라 fallback. */
+  ttlMs: number;
+}
+
+export interface BffProgressProvider {
+  /**
+   * trip 식별 토큰(lock과 1:1)으로 서버 progress 조회.
+   *
+   * - 신선/유효 응답이면 `BffProgressResponse`. 인증/캐싱은 구현체 책임.
+   * - 만료/네트워크 실패/timeout/`confidence === 'low'` → `null` 반환 (다음 전략으로 자연 진행).
+   *
+   * @param tripToken `lock.trainCode + boardingLine`으로 만든 trip 식별자
+   * @param nowMs 호출 시각 (epoch ms) — TTL 게이트와 캐시 만료 판단 기준
+   */
+  fetch(tripToken: string, nowMs: number): Promise<BffProgressResponse | null>;
+}


### PR DESCRIPTION
## 배경

ADR-008 Stage 4 — server-side progress 위임의 첫 단계. 클라 진입점만 본 PR에서 만든다.
estimator 전략 배열 swap, 측정 인프라, 회귀/통합 테스트는 후속 PR B/C/D에서 진행.

## 변경 사항

- `src/providers/progress/types.ts` — `BffProgressResponse` / `BffProgressProvider` 인터페이스 (ADR-008 Stage 4 본문 그대로)
- `src/providers/progress/SeoulBffProgressProvider.ts` — BFF 호출 + TTL 캐시 + timeout. 게이트 실패(만료/low/네트워크/non-2xx) 시 `null` 반환 → Stage 1-3 fallback 자연 진행 (회귀 가드)
- `src/providers/progress/MockBffProgressProvider.ts` — `respond()`로 응답 주입하는 테스트용
- `src/providers/progress/index.ts` — `createBffProgressProvider` factory (`EXPO_PUBLIC_USE_BFF=true` + `EXPO_PUBLIC_BFF_URL` 설정 시 Seoul, 아니면 Mock)
- `__tests__/` — 4 회귀 가드 케이스(정상/만료/low/네트워크 실패) + TTL 캐시 hit/miss + timeout abort + URL 인코딩 검증

## 스코프 노트

- backend endpoint(`/api/progress/{tripToken}`) 구현은 별도 sub-issue. 본 PR은 클라 인터페이스 + provider 구현만.
- 호출이 404/network error/non-2xx면 `null` 반환 → 호출자(추후 estimator)가 Stage 1-3 fallback으로 자연 진행하는 회귀 가드 보존.

## 회귀 가드 (ADR-008 Stage 4)

- 서버 응답 미수신/만료/`confidence === 'low'` → 100% `null` → Stage 1-3 fallback (변경 없음).
- 네트워크 timeout은 estimator 동기 경로를 막지 않도록 캐시 기반 비동기 refresh — stale 캐시는 폐기하지 않고 다음 게이트가 거른다.

## 테스트

- `npm test` 178 suites / 3402 tests PASS
- `npm run type-check` PASS
- 커버리지 100% 유지 (lines/branches/funcs/stmts)

Refs #844