### PR TITLE
feat(#875): 기압계(Barometer) spike — dP/dt 평가기 + 60s ring buffer

### DIFF
--- a/src/constants/barometer.ts
+++ b/src/constants/barometer.ts
@@ -1,0 +1,50 @@
+/**
+ * #875 — 기압계(Barometer) 보조 신호 상수.
+ *
+ * ADR-010 9단 게이트의 보조 신호로 사용 예정. 임계/윈도우는 spike 단계 제안값이며,
+ * 실측(다양한 노선·기기·계절) 후 후속 sub-issue에서 튜닝한다. 변경 시 단위 테스트가
+ * 깨지지 않도록 본 모듈 1곳에서만 수정한다 (CLAUDE.md 단일 출처 원칙).
+ */
+
+/**
+ * 지하 진입 감지 임계 — 30초 동안 압력이 이 값 이상 상승하면 "지하 진입"으로 본다.
+ *
+ * 단위: hPa (hectopascals, ≈ mbar).
+ *
+ * 근거 (실측 후 튜닝):
+ *   - 지상 → 깊이 10m 하강 시 약 1.2 hPa 상승 (대기 표준 모델, 9.81 m/s² × 1.225 kg/m³).
+ *   - 서울 지하철 평균 진입 깊이 5~25m, 진입 소요 15~40s.
+ *   - 0.3 hPa/30s = 약 2.5m/30s 하강 — 엘리베이터/계단 일반 보행은 임계 미달.
+ *   - 빠른 엘리베이터(고층 빌딩)는 임계 초과 가능 → 시간 윈도우로 false positive 제한
+ *     (탑승 prompt 시점 ±30s 안에서만 평가).
+ */
+export const BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA = 0.3;
+
+/**
+ * dP/dt 평가에 사용하는 시간 윈도우 — 최신 reading과 비교할 과거 reading의 최소 경과 시간.
+ *
+ * 단위: ms.
+ *
+ * 30s 이전 reading과 현재를 비교 → 일시적 spike (문 개폐, 터널 압력파)에 강건.
+ */
+export const BAROMETER_DPDT_WINDOW_MS = 30_000;
+
+/**
+ * Ring buffer 보관 기간 — 이 시간보다 오래된 reading은 자동 제거.
+ *
+ * 단위: ms.
+ *
+ * 60s는 dP/dt 평가 윈도우(30s)의 2배 — stale 검사 여유를 둔다. 동시에 메모리 부담도 작다
+ * (1Hz 폴링 기준 최대 60 entry).
+ */
+export const BAROMETER_RING_BUFFER_TTL_MS = 60_000;
+
+/**
+ * 센서 폴링 주기 — Barometer.setUpdateInterval에 전달.
+ *
+ * 단위: ms.
+ *
+ * 1Hz로 충분 (지하 진입은 초 단위 이벤트, ms 단위 정밀도 불필요).
+ * 더 높은 주기는 배터리 소모만 키운다.
+ */
+export const BAROMETER_SAMPLE_INTERVAL_MS = 1_000;

--- a/src/hooks/__tests__/useBarometer.test.ts
+++ b/src/hooks/__tests__/useBarometer.test.ts
@@ -1,0 +1,120 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+const mockIsAvailable = jest.fn();
+const mockRequestPermissions = jest.fn();
+const mockSetUpdateInterval = jest.fn();
+const mockAddListener = jest.fn();
+const mockRemove = jest.fn();
+
+jest.mock('expo-sensors', () => ({
+  Barometer: {
+    isAvailableAsync: (...args: unknown[]) => mockIsAvailable(...args),
+    requestPermissionsAsync: (...args: unknown[]) => mockRequestPermissions(...args),
+    setUpdateInterval: (...args: unknown[]) => mockSetUpdateInterval(...args),
+    addListener: (...args: unknown[]) => mockAddListener(...args),
+  },
+}));
+
+import { useBarometer } from '../useBarometer';
+import { BAROMETER_SAMPLE_INTERVAL_MS } from '../../constants/barometer';
+import {
+  getBarometerReadings,
+  resetBarometerState,
+} from '../../utils/barometerState';
+
+type Listener = (m: { pressure: number; timestamp: number }) => void;
+
+beforeEach(() => {
+  mockIsAvailable.mockReset();
+  mockRequestPermissions.mockReset();
+  mockSetUpdateInterval.mockReset();
+  mockAddListener.mockReset();
+  mockRemove.mockReset();
+  mockAddListener.mockReturnValue({ remove: mockRemove });
+  resetBarometerState();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useBarometer (#875)', () => {
+  it('isAvailable=false → permission 요청도 하지 않고 listener 등록 X', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+    renderHook(() => useBarometer());
+    await flush();
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  it('isAvailable throw → graceful, no-op', async () => {
+    mockIsAvailable.mockRejectedValue(new Error('boom'));
+    renderHook(() => useBarometer());
+    await flush();
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  it('권한 거절 → listener 등록 X', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: false });
+    renderHook(() => useBarometer());
+    await flush();
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  it('requestPermissions throw → graceful, no-op', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockRejectedValue(new Error('denied'));
+    renderHook(() => useBarometer());
+    await flush();
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  it('정상 케이스 → setUpdateInterval 호출, listener 등록, reading append', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+
+    const { unmount } = renderHook(() => useBarometer());
+    await flush();
+    expect(mockSetUpdateInterval).toHaveBeenCalledWith(BAROMETER_SAMPLE_INTERVAL_MS);
+    expect(mockAddListener).toHaveBeenCalledTimes(1);
+
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const epochBefore = Date.now();
+    listener({ pressure: 1013.25, timestamp: 12.34 });
+    listener({ pressure: 1013.3, timestamp: 13.34 });
+    const epochAfter = Date.now();
+
+    const readings = getBarometerReadings();
+    expect(readings).toHaveLength(2);
+    expect(readings[0].pressureHpa).toBeCloseTo(1013.25);
+    expect(readings[1].pressureHpa).toBeCloseTo(1013.3);
+    // boot-second(12.34) 대신 epoch wall-clock으로 stamp되는지 검증.
+    expect(readings[0].t).toBeGreaterThanOrEqual(epochBefore);
+    expect(readings[1].t).toBeLessThanOrEqual(epochAfter);
+
+    unmount();
+    expect(mockRemove).toHaveBeenCalled();
+    expect(getBarometerReadings()).toEqual([]);
+  });
+
+  it('unmount가 init 완료 전에 일어나도 listener 등록 X (cancelled 경로)', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockImplementation(() => new Promise(() => {}));
+    const { unmount } = renderHook(() => useBarometer());
+    unmount();
+    await flush();
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  it('unmount가 isAvailable 응답 전에 일어나도 permission 요청 X', async () => {
+    mockIsAvailable.mockImplementation(() => new Promise(() => {}));
+    const { unmount } = renderHook(() => useBarometer());
+    unmount();
+    await flush();
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useBarometer.ts
+++ b/src/hooks/useBarometer.ts
@@ -1,0 +1,82 @@
+/**
+ * #875 — 기압계(Barometer) 보조 신호 수집 훅 (Spike).
+ *
+ * 동작:
+ *   1. mount 시 `Barometer.isAvailableAsync()` → 권한 prompt → setUpdateInterval(BAROMETER_SAMPLE_INTERVAL_MS)
+ *   2. 1Hz callback이 들어오면 `appendBarometerReading`으로 ring buffer에 push
+ *      (60s TTL 자동 prune은 ring buffer 모듈이 처리)
+ *   3. unmount 시 subscription remove + ring buffer reset
+ *
+ * 권한:
+ *   - iOS: Apple은 motion 카테고리 통합 — `NSMotionUsageDescription` 1개 키로 충분.
+ *     이미 app.config.js에 `#728`(motion activity)로 등록되어 있어 재사용.
+ *   - Android: Barometer는 dangerous permission 아님. expo-sensors가 자동 처리.
+ *
+ * 미지원/권한 거절 (graceful — `feedback_whileinuse_must_work.md` 정책 준수):
+ *   - `isAvailableAsync` false → no-op (iPhone 6 이하, 일부 안드로이드 저가 기기)
+ *   - 권한 거절 → no-op + ambient state 비움
+ *   - ADR-010 게이트는 verdict null 시 그대로 기존 신호로 평가 (회귀 가드)
+ *
+ * 범위 (CLAUDE.md §2):
+ *   - 포그라운드 + WhileInUse 시나리오. iOS Barometer는 BG에서도 동작하지만 본 spike에서는
+ *     수집·평가 자체만. 송신/게이트 통합은 후속 sub-issue.
+ */
+
+import { useEffect } from 'react';
+import { Barometer, type BarometerMeasurement } from 'expo-sensors';
+import {
+  appendBarometerReading,
+  resetBarometerState,
+} from '../utils/barometerState';
+import { BAROMETER_SAMPLE_INTERVAL_MS } from '../constants/barometer';
+
+/**
+ * 기압계 수집을 활성화한다. 반환값 없음 — 외부에서는 `evaluateLatestSubsurface()`로 조회.
+ */
+export function useBarometer(): void {
+  useEffect(() => {
+    let cancelled = false;
+    let subscription: { remove(): void } | null = null;
+
+    const init = async (): Promise<void> => {
+      const available = await safeIsAvailable();
+      if (cancelled || !available) return;
+      const granted = await safeRequestPermission();
+      if (cancelled || !granted) return;
+
+      Barometer.setUpdateInterval(BAROMETER_SAMPLE_INTERVAL_MS);
+      subscription = Barometer.addListener((m: BarometerMeasurement) => {
+        // m.timestamp는 boot 이후 초 — wall-clock과 직접 비교 불가.
+        // ring buffer는 epoch ms 윈도우로 평가하므로 Date.now()로 직접 stamp.
+        appendBarometerReading({ t: Date.now(), pressureHpa: m.pressure });
+      });
+    };
+
+    void init();
+
+    return () => {
+      cancelled = true;
+      if (subscription !== null) subscription.remove();
+      resetBarometerState();
+    };
+  }, []);
+}
+
+/** isAvailableAsync 예외를 false로 폴백 — 일부 시뮬레이터에서 throw. */
+async function safeIsAvailable(): Promise<boolean> {
+  try {
+    return await Barometer.isAvailableAsync();
+  } catch {
+    return false;
+  }
+}
+
+/** requestPermissionsAsync 예외를 거절로 폴백 — graceful WhileInUse 보장. */
+async function safeRequestPermission(): Promise<boolean> {
+  try {
+    const { granted } = await Barometer.requestPermissionsAsync();
+    return granted;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/__tests__/barometerState.test.ts
+++ b/src/utils/__tests__/barometerState.test.ts
@@ -1,0 +1,62 @@
+import {
+  appendBarometerReading,
+  evaluateLatestSubsurface,
+  getBarometerReadings,
+  resetBarometerState,
+} from '../barometerState';
+import {
+  BAROMETER_DPDT_WINDOW_MS,
+  BAROMETER_RING_BUFFER_TTL_MS,
+  BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+} from '../../constants/barometer';
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  resetBarometerState();
+});
+
+describe('barometerState (#875)', () => {
+  it('초기 상태 → readings 비어있음, verdict null', () => {
+    expect(getBarometerReadings()).toEqual([]);
+    expect(evaluateLatestSubsurface(NOW)).toBeNull();
+  });
+
+  it('append 시 readings에 누적', () => {
+    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
+    appendBarometerReading({ t: NOW + 1_000, pressureHpa: 1013.05 });
+    expect(getBarometerReadings()).toHaveLength(2);
+  });
+
+  it('append 시 TTL 초과 reading 자동 제거', () => {
+    appendBarometerReading({
+      t: NOW - BAROMETER_RING_BUFFER_TTL_MS - 5_000,
+      pressureHpa: 1012.0,
+    });
+    // 새 reading의 t를 now로 사용하므로, 위 entry는 cutoff 밖으로 즉시 제거됨.
+    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
+    expect(getBarometerReadings()).toHaveLength(1);
+    expect(getBarometerReadings()[0].pressureHpa).toBeCloseTo(1013.0);
+  });
+
+  it('충분한 readings 누적 후 평가 → detected', () => {
+    appendBarometerReading({
+      t: NOW - BAROMETER_DPDT_WINDOW_MS,
+      pressureHpa: 1013.0,
+    });
+    appendBarometerReading({
+      t: NOW,
+      pressureHpa: 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+    });
+    const v = evaluateLatestSubsurface(NOW);
+    expect(v).not.toBeNull();
+    expect(v!.detected).toBe(true);
+  });
+
+  it('resetBarometerState → 비움', () => {
+    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
+    expect(getBarometerReadings()).toHaveLength(1);
+    resetBarometerState();
+    expect(getBarometerReadings()).toEqual([]);
+  });
+});

--- a/src/utils/__tests__/barometerSubsurface.test.ts
+++ b/src/utils/__tests__/barometerSubsurface.test.ts
@@ -1,0 +1,176 @@
+import {
+  evaluateSubsurfaceEnter,
+  pruneStaleReadings,
+  type BarometerReading,
+} from '../barometerSubsurface';
+import {
+  BAROMETER_DPDT_WINDOW_MS,
+  BAROMETER_RING_BUFFER_TTL_MS,
+  BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+} from '../../constants/barometer';
+
+const NOW = 1_700_000_000_000; // 고정 epoch (테스트 결정성 확보)
+
+function reading(offsetMs: number, pressureHpa: number): BarometerReading {
+  return { t: NOW + offsetMs, pressureHpa };
+}
+
+describe('barometerSubsurface (#875)', () => {
+  describe('evaluateSubsurfaceEnter', () => {
+    it('빈 readings → null (평가 불가)', () => {
+      const v = evaluateSubsurfaceEnter([], NOW);
+      expect(v).toBeNull();
+    });
+
+    it('window 미달 (30s 이내 데이터만) → null', () => {
+      const readings = [
+        reading(-10_000, 1013.0),
+        reading(-5_000, 1013.1),
+        reading(0, 1013.2),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).toBeNull();
+    });
+
+    it('정확히 dP=+0.3 hPa / 30s → detected', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(0, 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+      expect(v!.deltaHpa).toBeCloseTo(BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA);
+      expect(v!.elapsedMs).toBe(BAROMETER_DPDT_WINDOW_MS);
+    });
+
+    it('dP=+0.5 hPa / 30s (임계 초과) → detected', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(-15_000, 1013.2),
+        reading(0, 1013.5),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+      expect(v!.deltaHpa).toBeCloseTo(0.5);
+    });
+
+    it('dP=+0.1 hPa / 30s (임계 미달) → suppressed', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(0, 1013.1),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(false);
+      expect(v!.deltaHpa).toBeCloseTo(0.1);
+    });
+
+    it('dP 음수 (지상으로 상승) → suppressed', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.5),
+        reading(0, 1013.0),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(false);
+      expect(v!.deltaHpa).toBeCloseTo(-0.5);
+    });
+
+    it('30s 이전 reading이 여러 개면 가장 오래된 것(<= 30s 전 첫 매치) 사용', () => {
+      // 50s, 40s, 30s 전 + 현재. 평가 baseline은 30s 이전 readings 중
+      // 가장 최근(=가장 작은 elapsed) → 30s 전.
+      const readings = [
+        reading(-50_000, 1013.0),
+        reading(-40_000, 1013.1),
+        reading(-30_000, 1013.2),
+        reading(0, 1013.5),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+      // baseline pressure = 1013.2 (30s 전), delta = 0.3
+      expect(v!.deltaHpa).toBeCloseTo(0.3);
+      expect(v!.elapsedMs).toBe(30_000);
+    });
+
+    it('정렬되지 않은 readings도 시간순으로 평가', () => {
+      const readings = [
+        reading(0, 1013.5),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(-10_000, 1013.2),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+      expect(v!.deltaHpa).toBeCloseTo(0.5);
+    });
+
+    it('baseline 후보 중 정렬되지 않은 순서로 들어와도 30s 이전 중 가장 최근을 baseline으로', () => {
+      // -30s 후보가 먼저, -40s 후보가 나중 → 두 번째에서 r.t > baseline.t가 false인 분기.
+      const readings = [
+        reading(-30_000, 1013.2),
+        reading(-40_000, 1013.1),
+        reading(0, 1013.5),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      // baseline = -30s (1013.2) 유지, -40s는 더 오래되어 무시.
+      expect(v!.deltaHpa).toBeCloseTo(0.3);
+      expect(v!.elapsedMs).toBe(30_000);
+    });
+
+    it('readings의 가장 최신이 평가 시점(now)보다 미래면 그것을 latest로 사용', () => {
+      // 클라이언트 clock 미세 차이를 흡수 — 가장 큰 t를 latest로 본다.
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(+500, 1013.4),
+      ];
+      const v = evaluateSubsurfaceEnter(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+      expect(v!.deltaHpa).toBeCloseTo(0.4);
+    });
+  });
+
+  describe('pruneStaleReadings', () => {
+    it('빈 배열 → 빈 배열', () => {
+      expect(pruneStaleReadings([], NOW)).toEqual([]);
+    });
+
+    it('TTL 이내 readings 보존', () => {
+      const readings = [
+        reading(-30_000, 1013.0),
+        reading(-10_000, 1013.1),
+        reading(0, 1013.2),
+      ];
+      const out = pruneStaleReadings(readings, NOW);
+      expect(out).toHaveLength(3);
+    });
+
+    it('TTL 초과 reading 제거', () => {
+      const readings = [
+        reading(-(BAROMETER_RING_BUFFER_TTL_MS + 1_000), 1012.5),
+        reading(-30_000, 1013.0),
+        reading(0, 1013.2),
+      ];
+      const out = pruneStaleReadings(readings, NOW);
+      expect(out).toHaveLength(2);
+      expect(out[0].pressureHpa).toBeCloseTo(1013.0);
+    });
+
+    it('정확히 TTL 경계 reading은 보존 (inclusive)', () => {
+      const readings = [reading(-BAROMETER_RING_BUFFER_TTL_MS, 1012.0)];
+      const out = pruneStaleReadings(readings, NOW);
+      expect(out).toHaveLength(1);
+    });
+
+    it('readings 입력 mutate 안 함 (새 배열 반환)', () => {
+      const readings = [reading(-100_000, 1012.0), reading(0, 1013.0)];
+      const before = readings.length;
+      pruneStaleReadings(readings, NOW);
+      expect(readings).toHaveLength(before);
+    });
+  });
+});

--- a/src/utils/barometerState.ts
+++ b/src/utils/barometerState.ts
@@ -1,0 +1,50 @@
+/**
+ * #875 — 기압계 ring buffer ambient state.
+ *
+ * useBarometer hook이 sensor reading마다 push → 평가 시점에 readings 전체를 evaluate.
+ * BG task가 latest verdict를 snapshot으로 첨부할 수 있도록 ambient 모듈 패턴 사용
+ * (accelMotionState와 동형 — CLAUDE.md §3 재사용성).
+ *
+ * 정책:
+ *   - 메모리 ring buffer만 (60s ≤ 60 entry @ 1Hz, 매우 가벼움).
+ *   - hook unmount → reset. 영속화 필요 시 후속 sub-issue.
+ */
+
+import {
+  evaluateSubsurfaceEnter,
+  pruneStaleReadings,
+  type BarometerReading,
+  type SubsurfaceVerdict,
+} from './barometerSubsurface';
+
+let readings: BarometerReading[] = [];
+
+/**
+ * 새 reading을 추가하고, stale entry를 제거한다.
+ * 호출자(useBarometer)가 센서 콜백마다 호출.
+ */
+export function appendBarometerReading(reading: BarometerReading): void {
+  readings = pruneStaleReadings([...readings, reading], reading.t);
+}
+
+/**
+ * 현재 보관 중인 readings의 readonly 스냅샷. 디버그/테스트용.
+ */
+export function getBarometerReadings(): readonly BarometerReading[] {
+  return readings;
+}
+
+/**
+ * 현재 시점 기준 dP/dt 평가 결과를 반환. readings 부족이면 null.
+ * BG task가 position upload 직전에 호출.
+ */
+export function evaluateLatestSubsurface(now: number): SubsurfaceVerdict | null {
+  return evaluateSubsurfaceEnter(readings, now);
+}
+
+/**
+ * Ring buffer 초기화. hook unmount / 권한 거절 / 미지원 디바이스에서 호출.
+ */
+export function resetBarometerState(): void {
+  readings = [];
+}

--- a/src/utils/barometerSubsurface.ts
+++ b/src/utils/barometerSubsurface.ts
@@ -1,0 +1,102 @@
+/**
+ * #875 — 기압계 readings → 지하 진입 여부 평가 순수 함수.
+ *
+ * 정책 (ADR-010 보조 신호):
+ *   - 절대 기압값은 지역·날씨에 따라 변동 큼 → **상대 변화량(dP/dt)** 만 신호로 사용.
+ *   - 30s 윈도우 dP가 +0.3 hPa 이상이면 "지하 진입 진행 중" 후보로 본다.
+ *   - 일시적 노이즈(터널 압력파, 차문 개폐) 방지: 평가는 단일 reading이 아니라
+ *     윈도우 양 끝점 비교.
+ *
+ * 단순성 (CLAUDE.md §2):
+ *   - readings 컨테이너는 호출자(useBarometer)가 관리 — 본 모듈은 순수 평가기.
+ *   - 정렬·prune도 명시 함수로 분리. 호출자가 명시적으로 호출한다.
+ */
+
+import {
+  BAROMETER_DPDT_WINDOW_MS,
+  BAROMETER_RING_BUFFER_TTL_MS,
+  BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+} from '../constants/barometer';
+
+/**
+ * 단일 기압 reading. expo-sensors `BarometerMeasurement.pressure`는 hPa 단위.
+ */
+export interface BarometerReading {
+  /** epoch ms — 호출자가 wall-clock으로 stamp. */
+  t: number;
+  /** 압력값 (hPa, ≈ mbar). */
+  pressureHpa: number;
+}
+
+/**
+ * 평가 결과. 신호 자체는 boolean이지만 후속 게이트/메트릭이 raw delta도 참조하므로 함께 노출.
+ */
+export interface SubsurfaceVerdict {
+  /** dP가 임계 이상으로 상승했는가 (지하 진입 진행 중 후보). */
+  detected: boolean;
+  /** baseline 대비 latest 압력 변화 (hPa). 음수면 지상 상승. */
+  deltaHpa: number;
+  /** baseline과 latest 사이 경과 시간 (ms). */
+  elapsedMs: number;
+}
+
+/**
+ * 부동소수 오차 허용: 임계와 정확히 같은 dP에서 깜빡임 방지. hPa 단위에서 1e-9는
+ * 센서 정밀도(약 0.01 hPa) 대비 무시 가능.
+ */
+const FP_EPSILON = 1e-9;
+
+/**
+ * readings 중 `now - BAROMETER_RING_BUFFER_TTL_MS`보다 오래된 것을 제거.
+ * 원본 배열은 변경하지 않고 새 배열 반환.
+ */
+export function pruneStaleReadings(
+  readings: readonly BarometerReading[],
+  now: number,
+): BarometerReading[] {
+  const cutoff = now - BAROMETER_RING_BUFFER_TTL_MS;
+  return readings.filter((r) => r.t >= cutoff);
+}
+
+/**
+ * 30s 윈도우 dP를 평가해 지하 진입 후보 여부를 반환.
+ *
+ * baseline 결정 규칙:
+ *   - readings 중 `t <= now - BAROMETER_DPDT_WINDOW_MS`를 만족하는 가장 최근 reading.
+ *   - 즉 "30s 이전이지만 가장 가까운" reading. 메모리에 더 오래된 데이터가 있어도
+ *     윈도우 정의를 정확히 따르기 위해.
+ *
+ * latest 결정 규칙:
+ *   - readings 중 t가 가장 큰 것 (정렬되지 않아도 동작).
+ *
+ * 평가 불가:
+ *   - readings 비어있음 → null
+ *   - 윈도우 조건 만족하는 baseline 없음 → null
+ *
+ * 임계 초과 여부와 무관하게 raw delta는 항상 함께 반환 (메트릭/디버그 사용).
+ */
+export function evaluateSubsurfaceEnter(
+  readings: readonly BarometerReading[],
+  now: number,
+): SubsurfaceVerdict | null {
+  if (readings.length === 0) return null;
+
+  // readings.length >= 1이므로 latest는 반드시 존재. reduce로 동일 보장.
+  const latest = readings.reduce((acc, r) => (r.t > acc.t ? r : acc));
+
+  const baselineMaxT = now - BAROMETER_DPDT_WINDOW_MS;
+  let baseline: BarometerReading | null = null;
+  for (const r of readings) {
+    if (r.t > baselineMaxT) continue;
+    if (baseline === null || r.t > baseline.t) baseline = r;
+  }
+  if (baseline === null) return null;
+
+  const deltaHpa = latest.pressureHpa - baseline.pressureHpa;
+  const elapsedMs = latest.t - baseline.t;
+  return {
+    detected: deltaHpa >= BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA - FP_EPSILON,
+    deltaHpa,
+    elapsedMs,
+  };
+}


### PR DESCRIPTION
## Summary
Refs #875

ADR-010 9단 게이트의 보조 신호 후보인 **기압계(Barometer) dP/dt 신호**의 첫 PR.
센서 수집·평가 spike만 포함하며, 게이트 통합/backend 송신/metrics는 별도 sub-issue로 분리한다.

- `src/utils/barometerSubsurface.ts` — `evaluateSubsurfaceEnter` 순수 평가기 (baseline = 30s 이전 가장 최근 reading, latest = t 최대 reading). raw `deltaHpa` / `elapsedMs` 함께 노출 → 후속 metrics에서 그대로 사용.
- `src/utils/barometerState.ts` — 60s ring buffer ambient state (accelMotionState 동형 패턴).
- `src/hooks/useBarometer.ts` — expo-sensors Barometer 구독 hook. `isAvailableAsync` / 권한 / 예외 모든 경로 graceful fallback (WhileInUse 정책 준수).
- `src/constants/barometer.ts` — 임계/윈도우/TTL/폴링 상수 단일 출처.

## 결정 사항

### 권한 처리
- iOS: **`NSMotionUsageDescription` 재사용** — Apple은 motion 카테고리(가속도/자이로/CMAltimeter)를 한 키로 통합. `#728`에서 이미 등록 → 추가 권한 키 불필요.
- Android: Barometer는 dangerous permission 아님. `expo-sensors`가 자동 처리.

### 임계값 (제안값, 실측 후 튜닝)
| 상수 | 값 | 근거 |
|---|---|---|
| `BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA` | `+0.3 hPa` | 약 2.5m 하강분. 일반 보행/계단은 임계 미달. |
| `BAROMETER_DPDT_WINDOW_MS` | `30s` | 일시적 spike (터널 압력파, 문 개폐)에 강건. |
| `BAROMETER_RING_BUFFER_TTL_MS` | `60s` | 평가 윈도우의 2배, stale 검사 여유. |
| `BAROMETER_SAMPLE_INTERVAL_MS` | `1000ms` (1Hz) | 지하 진입은 초 단위 이벤트, 배터리 부담 최소. |

### 튜닝 plan (후속 sub-issue에서 진행)
1. **수집** — backend `processLocationUpdate` 페이로드에 `pressureHpa` 추가 (E1 가속도 동형). KV ring buffer 적재.
2. **로깅** — `barometerSubsurface.detected` / `.suppressed` 카운터, raw `deltaHpa` 히스토그램 (서울 주요 노선·기기·계절별).
3. **튜닝** — 1주일 실측 후 ROC 분석으로 임계값 확정. 빠른 엘리베이터 false positive ratio 모니터.
4. **게이트 통합** — ADR-010 9단 게이트의 `barometerSubsurfaceEnter` 신호 또는 게이트 #3 OR 분기로 보강.

## Known limitation
- **시스템 시계 뒤로 점프 corner case**: `appendBarometerReading`이 새 reading의 `t`를 prune cutoff로 사용. NTP correction / 사용자 수동 시계 변경으로 시계가 과거로 점프하면 stale entry가 일시적으로 보존되고 `evaluateSubsurfaceEnter`가 음수 `elapsedMs` / 음수 `deltaHpa`를 반환할 수 있음. `detected=false`라 알람 오발화는 없으나 ring buffer 정상화가 1 cycle 지연됨. **follow-up sub-issue로 별도 처리** (monotonic clock source 도입 또는 t < lastT 검사).

## 범위 외 (별도 sub-issue 예정)
- ADR-010 9단 게이트 통합
- Backend `processLocationUpdate` 페이로드 추가
- Metrics 등록 (`barometerSubsurface.detected/suppressed`, `alarm.gateBoostedByBarometer`)
- iPhone 6 이하·일부 안드로이드 저가 기기 미지원 디바이스 분포 측정

## Test plan
- [x] `npm test` — 178 suites, 3414 tests all pass, 글로벌 커버리지 100%.
- [x] `npm run type-check` — 0 errors.
- [ ] 실기기 (iPhone 12+) — 지하 진입 시 `evaluateLatestSubsurface` verdict 확인 (후속 sub-issue 측정 단계).
- [ ] 시뮬레이터 — `isAvailableAsync=false` 경로 검증 (Barometer 미지원).