### PR TITLE
feat(#876): Sticky Station — 좋은 fix lock으로 trip-less 지하 noise 차단

### DIFF
--- a/src/components/DebugModal.tsx
+++ b/src/components/DebugModal.tsx
@@ -94,6 +94,11 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
     const reason = entry.dropReason ? ` reason=${entry.dropReason}` : '';
     return `${time} | ${entry.event} | ${station} d=${d} acc=${acc}${reason}`;
   }
+  if (entry.kind === 'sticky') {
+    const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
+    const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
+    return `${time} | sticky:${entry.event} | ${entry.stationName}(${entry.line}) acc=${acc} sp=${sp}`;
+  }
   const station = entry.stationName ? `${entry.stationName}(${entry.line ?? '-'})` : '-';
   const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
   const acc =

--- a/src/components/__tests__/DebugModal.test.tsx
+++ b/src/components/__tests__/DebugModal.test.tsx
@@ -971,6 +971,31 @@ describe('formatFusionDebugLine', () => {
     expect(line).toContain('reason=low-accuracy-display');
   });
 
+  it.each([
+    ['locked', 50, 0.3, 'sticky:locked', 'acc=50m', 'sp=0.3m/s'],
+    ['unlocked-distance', null, null, 'sticky:unlocked-distance', 'acc=-', 'sp=-'],
+    ['unlocked-motion', 30, null, 'sticky:unlocked-motion', 'acc=30m', 'sp=-'],
+    ['unlocked-ttl', null, 0, 'sticky:unlocked-ttl', 'acc=-', 'sp=0.0m/s'],
+    ['unlocked-better-fix', 20, 0.5, 'sticky:unlocked-better-fix', 'acc=20m', 'sp=0.5m/s'],
+  ] as const)(
+    'sticky 엔트리(%s): event/station/acc/speed 포함',
+    (event, acc, sp, expectedEvent, expectedAcc, expectedSp) => {
+      const line = formatFusionDebugLine({
+        kind: 'sticky',
+        event,
+        ts: 0,
+        stationName: '서울역',
+        line: '1',
+        accuracyMeters: acc,
+        speedMps: sp,
+      });
+      expect(line).toContain(expectedEvent);
+      expect(line).toContain('서울역(1)');
+      expect(line).toContain(expectedAcc);
+      expect(line).toContain(expectedSp);
+    },
+  );
+
   it('gps 엔트리: nearestStation/distance/accuracy 누락 시 "-" 표기', () => {
     const line = formatFusionDebugLine({
       kind: 'gps',

--- a/src/constants/stickyStation.ts
+++ b/src/constants/stickyStation.ts
@@ -1,0 +1,24 @@
+// #876 — Sticky Station 임계 상수.
+//
+// trip이 없을 때(탑승 전 / 환승 대기 / 단순 위치 확인) 백엔드 정답을 줄 트리거가 없다 —
+// 클라가 GPS-only 회귀. 지하 진입 후 50~100m 정확도 fix가 250m 표시 게이트를 통과해
+// 부정확한 역으로 흔들리는 회귀를 막기 위해, 지상에서 잠깐 좋은 fix가 잡힐 때 그 역을
+// lock한다.
+//
+// 알람 트리거에는 영향 없음 — sticky는 표시(currentStation)에만 영향. 알람 경로는 별도
+// 엄격 게이트(MAX_ACCURACY_M=200m, useStationAlarm)에서 차단된다.
+
+/** 좋은 fix 정확도 임계값. 알람 엄격 게이트(200m)보다 훨씬 보수적. */
+export const STICKY_GOOD_FIX_ACCURACY_M = 50;
+
+/** 좋은 fix 속도 임계값(m/s). 1 m/s 미만 = 정지(서거나 걷기 시작 직전). */
+export const STICKY_GOOD_FIX_SPEED_MAX_MPS = 1;
+
+/** 같은 역 N회 연속 좋은 fix → lock. FG 폴링 2s 기준 ~6초 안정 관찰. */
+export const STICKY_LOCK_CONSECUTIVE_COUNT = 3;
+
+/** Lock TTL(ms). 30분. stale lock 방지 — 사용자가 앱 켜두고 다른 곳으로 이동한 후 복귀 케이스. */
+export const STICKY_TTL_MS = 30 * 60 * 1000;
+
+/** Unlock 거리 임계값(km). 다른 역으로 진짜 이동했다고 판단. */
+export const STICKY_UNLOCK_DISTANCE_KM = 1.0;

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -65,6 +65,12 @@ export const BOARDING_PROMPT_STATE_KEY = 'subway-now:boarding-prompt-state';
 // 형식: {"sinceTs": number, "sinceLat": number | null, "sinceLng": number | null} JSON.
 // 새 trip 시작(setDestination switch) 또는 새 BoardingLock 생성 시 즉시 클리어한다.
 export const DISMISS_SILENCE_KEY = 'subway-now:dismiss-silence';
+// #876 — Sticky Station lock 영속화 키.
+// 좋은 fix(accuracy ≤ 50m, speed < 1 m/s)가 같은 역 N회 연속 관찰될 때 그 역을 lock.
+// trip 없는 상태(탑승 전 / 환승 대기 / 단순 위치 확인)에서 지하 noise로 흔들리지 않게 표시.
+// 형식: {"station": Station, "lockedAt": number} JSON.
+// TTL(30분) 경과 또는 1km+ 이동 또는 automotive motion 시 unlock.
+export const STICKY_STATION_KEY = 'subway-now:sticky-station';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.

--- a/src/hooks/__tests__/useNearestStation.test.ts
+++ b/src/hooks/__tests__/useNearestStation.test.ts
@@ -89,8 +89,11 @@ const simulateGps = (
 };
 
 describe('useNearestStation', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
+    // #876 — sticky station이 AsyncStorage에 lock을 남기면 다음 테스트 hydrate 시 잔류 lock이
+    // result를 override해 회귀(잘못된 station 반환). 매 테스트 전에 storage clear.
+    await AsyncStorage.clear();
     appStateCallback = null;
     watchCallback = null;
     mockNoLastKnownLocation();
@@ -974,6 +977,51 @@ describe('useNearestStation — #711 BG_LAST_STATION hydrate', () => {
     // hydrate가 흘러도 prev ?? bg → 강남 유지
     await waitFor(() => expect(Location.getCurrentPositionAsync).toHaveBeenCalled());
     expect(result.current.result?.station.name).toBe('강남');
+  });
+});
+
+describe('useNearestStation — #876 sticky station integration', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+  });
+
+  it('초기 source는 live (sticky 비활성)', async () => {
+    mockGranted();
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+    simulateGps(37.4980, 127.0277, { accuracy: 20 });
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+    expect(result.current.source).toBe('live');
+    expect(result.current.result?.station.name).toBe('강남');
+  });
+
+  it('AsyncStorage 미리 저장된 sticky lock 있고 GPS가 다른 역이면 result는 sticky 역으로 override', async () => {
+    // 효창공원앞 lock 미리 저장(1분 전). GPS는 강남 좌표 → sticky override.
+    const hyochang = { id: '6-019', name: '효창공원앞', line: '6', lineColor: '#cd7c2f',
+      lat: 37.539252, lng: 126.961392 };
+    await AsyncStorage.setItem(
+      'subway-now:sticky-station',
+      JSON.stringify({ station: hyochang, lockedAt: Date.now() - 60_000 }),
+    );
+    mockGranted();
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+    simulateGps(37.4980, 127.0277, { accuracy: 100 }); // 강남, accuracy 나쁨 → sticky가 better-fix로 갱신 X
+    await waitFor(() => expect(result.current.source).toBe('sticky'));
+    expect(result.current.result?.station.name).toBe('효창공원앞');
+    // distanceKm은 userLocation 기준 재계산 (효창 ↔ 강남 ≈ 10km+)
+    expect(result.current.result?.distanceKm).toBeGreaterThan(5);
   });
 });
 

--- a/src/hooks/__tests__/useStickyStation.test.ts
+++ b/src/hooks/__tests__/useStickyStation.test.ts
@@ -1,0 +1,289 @@
+/**
+ * #876 — useStickyStation 훅 테스트.
+ *
+ * 동작:
+ *   1. 좋은 fix(accuracy ≤ 50m, speed < 1 m/s) + 같은 역 N(=3)회 연속 → lock
+ *   2. lock 상태에서 매 fix마다 unlock 평가:
+ *      - 좋은 fix(≤50m)가 lock된 역에서 1km+ → unlock-distance
+ *      - automotive motion → unlock-motion
+ *      - TTL 30분 경과 → unlock-ttl
+ *      - 더 좋은 fix(≤50m)가 N(=3)회 연속 다른 역 → 즉시 갱신(unlock-better-fix + lock 새 역)
+ *   3. AsyncStorage persist — 앱 재시작 시 hydrate
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useStickyStation, type StickyFixInput, type StickyMotionInput } from '../useStickyStation';
+import { STICKY_TTL_MS } from '../../constants/stickyStation';
+import { STICKY_STATION_KEY } from '../../constants/storageKeys';
+import * as fusionDebugBuffer from '../../utils/fusionDebugBuffer';
+import type { Station } from '../../types/station';
+
+interface RenderProps { fix: StickyFixInput; motion?: StickyMotionInput }
+const renderSticky = (initialProps: RenderProps) =>
+  renderHook(({ fix, motion }: RenderProps) => useStickyStation(fix, motion), { initialProps });
+
+const seoul: Station = {
+  id: '0150', name: '서울역', line: '1', lineColor: '#0d3692', lat: 37.5547, lng: 126.9707,
+};
+// 서울역 근방(~200m) 가상 인접역 — better-fix 전이를 distance unlock과 분리해 검증.
+const seoulNearby: Station = {
+  id: '0150B', name: '서울역인접', line: '4', lineColor: '#00a4e3',
+  lat: 37.5565, lng: 126.9707,
+};
+const gangnam: Station = {
+  id: '0222', name: '강남', line: '2', lineColor: '#00a84d', lat: 37.4979, lng: 127.0276,
+};
+
+const fixAt = (
+  station: Station | null,
+  opts: { accuracy?: number | null; speed?: number | null } = {},
+) => ({
+  candidate: station ? { station, distanceKm: 0.05 } : null,
+  accuracyMeters: opts.accuracy ?? 20,
+  speedMps: opts.speed ?? 0,
+});
+
+describe('useStickyStation (#876)', () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    await AsyncStorage.clear();
+    // hydrate 시 setItem 호출은 측정에서 분리하기 위해 spy clear는 hydrate 후 각 it 안에서.
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('초기 상태 — locked=null', async () => {
+    const { result } = renderHook(() => useStickyStation(fixAt(null)));
+    expect(result.current.locked).toBeNull();
+  });
+
+  it('좋은 fix가 같은 역 3회 연속 → lock', async () => {
+    const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul) });
+    // hydrate effect 대기
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalledWith(STICKY_STATION_KEY));
+    expect(result.current.locked).toBeNull();
+    rerender({ fix: fixAt(seoul) });
+    expect(result.current.locked).toBeNull();
+    rerender({ fix: fixAt(seoul) });
+    // 3회째에 lock
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+    expect(pushSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'sticky', event: 'locked', stationName: '서울역' }),
+    );
+  });
+
+  it('나쁜 fix(accuracy > 50m)는 카운트 안 함', async () => {
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul, { accuracy: 80 }) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul, { accuracy: 80 }) });
+    rerender({ fix: fixAt(seoul, { accuracy: 80 }) });
+    rerender({ fix: fixAt(seoul, { accuracy: 80 }) });
+    expect(result.current.locked).toBeNull();
+  });
+
+  it('이동 중(speed ≥ 1) fix는 카운트 안 함', async () => {
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul, { speed: 5 }) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul, { speed: 5 }) });
+    rerender({ fix: fixAt(seoul, { speed: 5 }) });
+    expect(result.current.locked).toBeNull();
+  });
+
+  it('다른 역으로 바뀌면 카운트 리셋', async () => {
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul) });
+    rerender({ fix: fixAt(seoulNearby) }); // 카운트 리셋
+    rerender({ fix: fixAt(seoulNearby) });
+    expect(result.current.locked).toBeNull();
+    rerender({ fix: fixAt(seoulNearby) });
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoulNearby.id));
+  });
+
+  it('locked 상태에서 좋은 fix가 1km+ 떨어진 다른 역 → unlock-distance', async () => {
+    const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul) });
+    rerender({ fix: fixAt(seoul) });
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+    pushSpy.mockClear();
+
+    // 강남역(10km+) 좋은 fix 1회 → unlock (다른 역으로 lock 갱신은 N회 필요하지만 unlock-distance는 즉시)
+    rerender({ fix: fixAt(gangnam) });
+    await waitFor(() => expect(result.current.locked).toBeNull());
+    expect(pushSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'sticky', event: 'unlocked-distance' }),
+    );
+  });
+
+  it('locked 상태에서 automotive motion → unlock-motion', async () => {
+    const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul), motion: { automotive: false } });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul), motion: { automotive: false } });
+    rerender({ fix: fixAt(seoul), motion: { automotive: false } });
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+    pushSpy.mockClear();
+
+    rerender({ fix: fixAt(seoul), motion: { automotive: true } });
+    await waitFor(() => expect(result.current.locked).toBeNull());
+    expect(pushSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'sticky', event: 'unlocked-motion' }),
+    );
+  });
+
+  it('locked 상태에서 TTL 경과 → unlock-ttl', async () => {
+    const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+    const realNow = Date.now();
+    jest.setSystemTime(realNow);
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul) });
+    rerender({ fix: fixAt(seoul) });
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+    pushSpy.mockClear();
+
+    // 31분 경과 후 같은 역 fix → TTL unlock 평가
+    jest.setSystemTime(realNow + STICKY_TTL_MS + 60_000);
+    rerender({ fix: fixAt(seoul) });
+    await waitFor(() => expect(result.current.locked).toBeNull());
+    expect(pushSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'sticky', event: 'unlocked-ttl' }),
+    );
+  });
+
+  it('더 좋은 fix가 다른 역 3회 연속 → 즉시 갱신(unlock-better-fix + 새 lock)', async () => {
+    const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul) });
+    rerender({ fix: fixAt(seoul) });
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+    pushSpy.mockClear();
+
+    // 서대문(서울 인접, ~1km 미만 — distance unlock 안 됨)으로 3회 좋은 fix
+    rerender({ fix: fixAt(seoulNearby) });
+    rerender({ fix: fixAt(seoulNearby) });
+    rerender({ fix: fixAt(seoulNearby) });
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoulNearby.id));
+    expect(pushSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'sticky', event: 'unlocked-better-fix' }),
+    );
+    expect(pushSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'sticky', event: 'locked', stationName: '서울역인접' }),
+    );
+  });
+
+  it('AsyncStorage hydrate — 앱 시작 시 저장된 lock 복원', async () => {
+    const lockedAt = Date.now() - 60_000; // 1분 전
+    await AsyncStorage.setItem(
+      STICKY_STATION_KEY,
+      JSON.stringify({ station: seoul, lockedAt }),
+    );
+    const { result } = renderHook(() => useStickyStation(fixAt(null)));
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+  });
+
+  it('AsyncStorage hydrate — TTL 만료된 lock은 무시', async () => {
+    const lockedAt = Date.now() - STICKY_TTL_MS - 60_000;
+    await AsyncStorage.setItem(
+      STICKY_STATION_KEY,
+      JSON.stringify({ station: seoul, lockedAt }),
+    );
+    const { result } = renderHook(() => useStickyStation(fixAt(null)));
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    expect(result.current.locked).toBeNull();
+  });
+
+  it('AsyncStorage hydrate — parse 실패 시 graceful null', async () => {
+    await AsyncStorage.setItem(STICKY_STATION_KEY, '{not json');
+    const { result } = renderHook(() => useStickyStation(fixAt(null)));
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    expect(result.current.locked).toBeNull();
+  });
+
+  it.each([
+    ['null primitive', 'null'],
+    ['number primitive', '42'],
+    ['lockedAt 누락', JSON.stringify({ station: seoul })],
+    ['station 누락', JSON.stringify({ lockedAt: Date.now() })],
+    ['station type 불일치', JSON.stringify({ station: 'string', lockedAt: Date.now() })],
+    ['station.id 누락', JSON.stringify({
+      station: { name: 'X', lat: 1, lng: 1 },
+      lockedAt: Date.now(),
+    })],
+  ])('AsyncStorage hydrate — %s 형식 검증 실패 시 graceful null', async (_label, raw) => {
+    await AsyncStorage.setItem(STICKY_STATION_KEY, raw);
+    const { result } = renderHook(() => useStickyStation(fixAt(null)));
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    expect(result.current.locked).toBeNull();
+  });
+
+  it('writePersistedLock setItem 실패는 silent — 외부에서 throw 안 함', async () => {
+    const setSpy = jest.spyOn(AsyncStorage, 'setItem').mockRejectedValueOnce(new Error('disk'));
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul) });
+    rerender({ fix: fixAt(seoul) });
+    // setItem reject가 unhandled rejection으로 새지 않고 lock은 in-memory에 정상 반영.
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+    expect(setSpy).toHaveBeenCalledWith(STICKY_STATION_KEY, expect.any(String));
+  });
+
+  it('clearPersistedLock removeItem 실패는 silent', async () => {
+    const lockedAt = Date.now() - STICKY_TTL_MS - 60_000; // 만료된 lock
+    await AsyncStorage.setItem(
+      STICKY_STATION_KEY,
+      JSON.stringify({ station: seoul, lockedAt }),
+    );
+    jest.spyOn(AsyncStorage, 'removeItem').mockRejectedValueOnce(new Error('disk'));
+    const { result } = renderHook(() => useStickyStation(fixAt(null)));
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    // 만료 lock은 removeItem 호출 시도 → reject 발생해도 hydrate 결과는 locked=null.
+    expect(result.current.locked).toBeNull();
+  });
+
+  it('mount 직후 즉시 unmount — cancelled 플래그로 hydrate 결과 무시', async () => {
+    const persisted = { station: seoul, lockedAt: Date.now() };
+    await AsyncStorage.setItem(STICKY_STATION_KEY, JSON.stringify(persisted));
+    const { unmount } = renderHook(() => useStickyStation(fixAt(null)));
+    unmount(); // hydrate Promise resolve 전에 unmount
+    // jest.useFakeTimers는 setImmediate를 잡으므로 advanceTimers로 flush.
+    // unhandled state set이 발생하면 cancelled gate가 막아 console error가 뜨지 않아야 한다.
+    await jest.runAllTimersAsync();
+  });
+
+  it('lock 시 AsyncStorage persist', async () => {
+    const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+    const { rerender } = renderSticky({ fix: fixAt(seoul) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul) });
+    rerender({ fix: fixAt(seoul) });
+    await waitFor(() => expect(setSpy).toHaveBeenCalledWith(STICKY_STATION_KEY, expect.any(String)));
+  });
+
+  it('unlock 시 AsyncStorage remove', async () => {
+    const removeSpy = jest.spyOn(AsyncStorage, 'removeItem');
+    const { result, rerender } = renderSticky({ fix: fixAt(seoul) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(seoul) });
+    rerender({ fix: fixAt(seoul) });
+    await waitFor(() => expect(result.current.locked?.id).toBe(seoul.id));
+
+    rerender({ fix: fixAt(gangnam) });
+    await waitFor(() => expect(removeSpy).toHaveBeenCalledWith(STICKY_STATION_KEY));
+  });
+
+  it('candidate=null 상태에서는 카운트 안 함', async () => {
+    const { result, rerender } = renderSticky({ fix: fixAt(null) });
+    await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+    rerender({ fix: fixAt(null) });
+    rerender({ fix: fixAt(null) });
+    expect(result.current.locked).toBeNull();
+  });
+});

--- a/src/hooks/useNearestStation.ts
+++ b/src/hooks/useNearestStation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import * as Location from 'expo-location';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -26,6 +26,12 @@ import {
 } from '../constants/gpsStatus';
 import { createLogger } from '../utils/logger';
 import { pushFusionDebugEntry } from '../utils/fusionDebugBuffer';
+import { haversine } from '../utils/haversine';
+import { useStickyStation } from './useStickyStation';
+
+/** #876 — useNearestStation 표시값의 출처. sticky lock된 역이면 'sticky', 아니면 GPS live.
+ *  알람 트리거에는 영향 없음 — 호출자가 출처별 UX(예: "탑승 전 추정")를 분기할 수 있게 노출. */
+export type NearestStationSource = 'sticky' | 'live';
 
 const logger = createLogger('useNearestStation');
 
@@ -54,6 +60,9 @@ interface UseNearestStationReturn {
   // #852: 마지막 신뢰 fix epoch ms. BG 진입 후 새 fix가 없으면 이 시각은 정지.
   // null = 한 번도 fix 없음(cold start). 디버그 모달 표기용.
   lastFixAtMs: number | null;
+  // #876: result 출처. sticky lock된 역이면 'sticky', live GPS 최근접이면 'live'.
+  // 호출자가 출처별 UX(예: 라벨 "탑승 전 추정")로 분기 가능. 알람 트리거에는 영향 없음.
+  source: NearestStationSource;
   refresh: () => Promise<void>;
 }
 
@@ -365,8 +374,35 @@ export function useNearestStation(): UseNearestStationReturn {
     };
   }, [startWatch, stopWatch, refresh]);
 
+  // #876 — 매 fix를 sticky 훅에 전달. lock된 역이 있으면 result를 그것으로 override.
+  // fusion candidates는 useFusedNearestStation에서 userLocation 기반으로 별도 계산하므로 영향 없음.
+  const sticky = useStickyStation({
+    candidate: result,
+    accuracyMeters,
+    speedMps,
+  });
+
+  const exposed = useMemo<{ result: NearestStationResult | null; source: NearestStationSource }>(
+    () => {
+      // sticky 비활성 또는 sticky가 live와 같은 역이면 live 결과 그대로 — reference 유지로
+      // throttle/리렌더 가정을 깨지 않는다. sticky가 다른 역을 lock한 경우에만 override.
+      if (!sticky.locked) return { result, source: 'live' };
+      if (result && result.station.id === sticky.locked.id) {
+        return { result, source: 'sticky' };
+      }
+      const distanceKm = userLocation
+        ? haversine(userLocation.lat, userLocation.lng, sticky.locked.lat, sticky.locked.lng)
+        : 0;
+      return {
+        result: { station: sticky.locked, distanceKm },
+        source: 'sticky',
+      };
+    },
+    [sticky.locked, result, userLocation],
+  );
+
   return {
-    result,
+    result: exposed.result,
     variants,
     userLocation,
     speedMps,
@@ -377,6 +413,7 @@ export function useNearestStation(): UseNearestStationReturn {
     locationUncertain,
     gpsActive,
     lastFixAtMs,
+    source: exposed.source,
     refresh,
   };
 }

--- a/src/hooks/useStickyStation.ts
+++ b/src/hooks/useStickyStation.ts
@@ -1,0 +1,227 @@
+/**
+ * #876 — Sticky Station 훅.
+ *
+ * 목적: trip 없는 상태(탑승 전 / 환승 대기 / 단순 위치 확인)에서 백엔드 정답이 없어
+ *   클라이언트가 GPS-only로 회귀할 때, 지상에서 잠깐 잡힌 좋은 fix를 lock해
+ *   지하 dead-zone의 부정확한 fix(50~100m)가 250m 표시 게이트를 통과해도
+ *   엉뚱한 역으로 흔들리지 않게 한다.
+ *
+ * 입력: 매 GPS fix마다 캐스트되는 `{ candidate, accuracyMeters, speedMps }` + 선택적 motion.
+ * 출력: `{ locked: Station | null }` — sticky lock된 역 (없으면 null).
+ *
+ * 알람 트리거에는 영향 없음 — sticky는 표시에만 영향. 알람은 별도 엄격 게이트(200m) 통과 fix만 사용.
+ *
+ * Lock 조건: 좋은 fix(accuracy ≤ 50m, speed < 1 m/s)가 같은 역 STICKY_LOCK_CONSECUTIVE_COUNT(3)회 연속.
+ *
+ * Unlock 트리거:
+ *   1. distance — 좋은 fix가 lock된 역에서 STICKY_UNLOCK_DISTANCE_KM(1km) 초과
+ *   2. motion — automotive(차/지하철 이동 확정)
+ *   3. ttl — STICKY_TTL_MS(30분) 경과
+ *   4. better-fix — 좋은 fix가 다른 역에서 N회 연속 관찰 → 즉시 갱신(unlock + 새 lock)
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { NearestStationResult, Station } from '../types/station';
+import { STICKY_STATION_KEY } from '../constants/storageKeys';
+import { STICKY_LOCK_CONSECUTIVE_COUNT } from '../constants/stickyStation';
+import {
+  isGoodFix,
+  shouldUnlockByDistance,
+  shouldUnlockByMotion,
+  shouldUnlockByTtl,
+} from '../utils/stickyStationGates';
+import {
+  pushFusionDebugEntry,
+  type StickyStationEvent,
+} from '../utils/fusionDebugBuffer';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useStickyStation');
+
+export interface StickyFixInput {
+  candidate: NearestStationResult | null;
+  accuracyMeters: number | null;
+  speedMps: number | null;
+}
+
+export interface StickyMotionInput {
+  /** automotive=true면 차/지하철 이동 확정으로 간주 — unlock 트리거. */
+  automotive?: boolean;
+}
+
+export interface UseStickyStationReturn {
+  locked: Station | null;
+}
+
+interface PersistedLock {
+  station: Station;
+  lockedAt: number;
+}
+
+function isPersistedLock(value: unknown): value is PersistedLock {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as { station?: unknown; lockedAt?: unknown };
+  if (typeof v.lockedAt !== 'number') return false;
+  if (!v.station || typeof v.station !== 'object') return false;
+  const s = v.station as { id?: unknown; name?: unknown; lat?: unknown; lng?: unknown };
+  return typeof s.id === 'string'
+    && typeof s.name === 'string'
+    && typeof s.lat === 'number'
+    && typeof s.lng === 'number';
+}
+
+async function readPersistedLock(): Promise<PersistedLock | null> {
+  try {
+    const raw = await AsyncStorage.getItem(STICKY_STATION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    return isPersistedLock(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writePersistedLock(lock: PersistedLock): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STICKY_STATION_KEY, JSON.stringify(lock));
+  } catch {
+    // storage 실패는 silent — 다음 lock 사이클에서 자연 복구.
+  }
+}
+
+async function clearPersistedLock(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(STICKY_STATION_KEY);
+  } catch {
+    // graceful — stale entry는 다음 unlock/TTL에서 자연 정리.
+  }
+}
+
+function emitMetric(
+  event: StickyStationEvent,
+  station: Station,
+  fix: { accuracyMeters: number | null; speedMps: number | null },
+): void {
+  pushFusionDebugEntry({
+    kind: 'sticky',
+    event,
+    ts: Date.now(),
+    stationName: station.name,
+    line: station.line,
+    accuracyMeters: fix.accuracyMeters,
+    speedMps: fix.speedMps,
+  });
+}
+
+export function useStickyStation(
+  fix: StickyFixInput,
+  motion: StickyMotionInput = {},
+): UseStickyStationReturn {
+  const [locked, setLocked] = useState<Station | null>(null);
+  const lockedAtRef = useRef<number | null>(null);
+  // 같은 역 연속 좋은 fix 카운터. 다른 역으로 바뀌거나 나쁜 fix면 리셋.
+  const candidateIdRef = useRef<string | null>(null);
+  const candidateCountRef = useRef<number>(0);
+  // hydrate 완료 여부를 state로 — 완료 후 다음 렌더에 평가 effect가 자동 재실행돼
+  // hydrate 직전에 받아둔 첫 fix가 정상적으로 카운트된다.
+  const [hydrated, setHydrated] = useState<boolean>(false);
+
+  // Hydrate from AsyncStorage on mount. TTL 만료된 lock은 무시.
+  useEffect(() => {
+    let cancelled = false;
+    void readPersistedLock().then((persisted) => {
+      if (cancelled) return;
+      if (persisted && !shouldUnlockByTtl(persisted.lockedAt, Date.now())) {
+        lockedAtRef.current = persisted.lockedAt;
+        setLocked(persisted.station);
+      } else if (persisted) {
+        void clearPersistedLock();
+      }
+      setHydrated(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // 매 fix마다 lock/unlock 평가. hydrate 완료 전엔 평가 보류 (race 방지).
+  useEffect(() => {
+    if (!hydrated) return;
+    const { candidate, accuracyMeters, speedMps } = fix;
+    const fixMeta = { accuracyMeters, speedMps };
+    const now = Date.now();
+
+    // unlock 공통 cleanup. metrics 이벤트별 라벨링 + ref/state/persistence를 함께 정리한다.
+    const performUnlock = (event: StickyStationEvent, lockedStation: Station): void => {
+      emitMetric(event, lockedStation, fixMeta);
+      lockedAtRef.current = null;
+      candidateIdRef.current = null;
+      candidateCountRef.current = 0;
+      setLocked(null);
+      void clearPersistedLock();
+    };
+
+    // 1. lock 상태에서 unlock 트리거 평가(better-fix는 카운터 평가 단계에서 처리).
+    //    우선순위: motion > ttl > distance — 각각 stale lock 위험이 큰 순서.
+    if (locked && lockedAtRef.current != null) {
+      if (shouldUnlockByMotion(motion)) {
+        performUnlock('unlocked-motion', locked);
+        return;
+      }
+      if (shouldUnlockByTtl(lockedAtRef.current, now)) {
+        performUnlock('unlocked-ttl', locked);
+        return;
+      }
+      if (
+        candidate
+        && accuracyMeters != null
+        && shouldUnlockByDistance(locked, {
+          lat: candidate.station.lat,
+          lng: candidate.station.lng,
+          accuracyMeters,
+        })
+      ) {
+        // distance unlock은 즉시 — 새 후보 카운트는 다음 fix부터 시작. better-fix 갱신을 같은 effect에서
+        // 강제하지 않는다(distance unlock 트리거 한 fix는 카운트에 반영하지 않음).
+        performUnlock('unlocked-distance', locked);
+        return;
+      }
+    }
+
+    // 2. 좋은 fix 카운터 평가 (lock 갱신/생성)
+    if (!candidate || !isGoodFix(fixMeta)) {
+      // 나쁜 fix면 진행 중 카운트 리셋 — 같은 역이라도 신호 단절 시 처음부터 다시 관찰.
+      candidateIdRef.current = null;
+      candidateCountRef.current = 0;
+      return;
+    }
+    const candidateId = candidate.station.id;
+    if (candidateIdRef.current === candidateId) {
+      candidateCountRef.current += 1;
+    } else {
+      candidateIdRef.current = candidateId;
+      candidateCountRef.current = 1;
+    }
+
+    if (candidateCountRef.current < STICKY_LOCK_CONSECUTIVE_COUNT) return;
+
+    // N회 연속 좋은 fix 도달. lock 신규 생성 또는 better-fix로 갱신.
+    if (locked && locked.id !== candidate.station.id) {
+      emitMetric('unlocked-better-fix', locked, fixMeta);
+    }
+    lockedAtRef.current = now;
+    candidateCountRef.current = 0; // 다음 갱신을 위해 리셋
+    setLocked(candidate.station);
+    emitMetric('locked', candidate.station, fixMeta);
+    void writePersistedLock({ station: candidate.station, lockedAt: now });
+    logger.info('sticky locked', {
+      station: candidate.station.name,
+      line: candidate.station.line,
+      accuracyMeters,
+      speedMps,
+    });
+  }, [fix, motion, locked, hydrated]);
+
+  return { locked };
+}

--- a/src/utils/__tests__/stickyStationGates.test.ts
+++ b/src/utils/__tests__/stickyStationGates.test.ts
@@ -1,0 +1,138 @@
+/**
+ * #876 — Sticky Station 게이트 순수 함수 테스트.
+ *
+ * 평가 대상:
+ *   - isGoodFix: accuracy/speed 임계 통과 여부
+ *   - shouldUnlockByDistance: 좋은 fix가 잠금된 역에서 1km+ 떨어졌는지
+ *   - shouldUnlockByTtl: 잠금 이후 30분 경과
+ *   - shouldUnlockByMotion: automotive motion 지속 → 차/지하철 이동 확정
+ */
+
+import type { Station } from '../../types/station';
+import {
+  STICKY_GOOD_FIX_ACCURACY_M,
+  STICKY_GOOD_FIX_SPEED_MAX_MPS,
+  STICKY_TTL_MS,
+  STICKY_UNLOCK_DISTANCE_KM,
+} from '../../constants/stickyStation';
+import {
+  isGoodFix,
+  shouldUnlockByDistance,
+  shouldUnlockByTtl,
+  shouldUnlockByMotion,
+} from '../stickyStationGates';
+
+const seoulStation: Station = {
+  id: '0150',
+  name: '서울역',
+  line: '1',
+  lineColor: '#0d3692',
+  lat: 37.5547,
+  lng: 126.9707,
+};
+
+describe('isGoodFix', () => {
+  it('accuracy/speed 모두 임계 이하 → true', () => {
+    expect(isGoodFix({ accuracyMeters: 30, speedMps: 0.2 })).toBe(true);
+  });
+
+  it('accuracy 임계 초과 → false', () => {
+    expect(isGoodFix({ accuracyMeters: STICKY_GOOD_FIX_ACCURACY_M + 1, speedMps: 0 })).toBe(false);
+  });
+
+  it('speed 임계 초과 → false (이동 중)', () => {
+    expect(
+      isGoodFix({ accuracyMeters: 30, speedMps: STICKY_GOOD_FIX_SPEED_MAX_MPS + 0.5 }),
+    ).toBe(false);
+  });
+
+  it('accuracy null → false (측정 불가는 신뢰 안 함)', () => {
+    expect(isGoodFix({ accuracyMeters: null, speedMps: 0 })).toBe(false);
+  });
+
+  it('speed null → 정지로 간주, accuracy만 통과하면 true', () => {
+    // iOS CoreLocation은 stationary에서 speed=-1을 반환하고 caller가 null로 정규화.
+    // sticky는 "측정 불가 = 이동 안 함"으로 보수적으로 해석한다 (지상 stationary 시나리오).
+    expect(isGoodFix({ accuracyMeters: 30, speedMps: null })).toBe(true);
+  });
+
+  it('경계값 — accuracy = 임계값 → true', () => {
+    expect(isGoodFix({ accuracyMeters: STICKY_GOOD_FIX_ACCURACY_M, speedMps: 0 })).toBe(true);
+  });
+});
+
+describe('shouldUnlockByDistance', () => {
+  it('잠금된 역에서 1km+ 떨어진 좋은 fix → true', () => {
+    // 강남역 좌표 — 서울역에서 약 10km
+    expect(
+      shouldUnlockByDistance(seoulStation, {
+        lat: 37.4979,
+        lng: 127.0276,
+        accuracyMeters: 20,
+      }),
+    ).toBe(true);
+  });
+
+  it('잠금된 역 근처 → false', () => {
+    expect(
+      shouldUnlockByDistance(seoulStation, {
+        lat: 37.5547,
+        lng: 126.9707,
+        accuracyMeters: 20,
+      }),
+    ).toBe(false);
+  });
+
+  it('fix accuracy가 50m 초과 → false (믿을 수 없는 fix로 unlock하지 않음)', () => {
+    // 멀리 떨어졌지만 accuracy가 나빠서 신뢰 못함.
+    expect(
+      shouldUnlockByDistance(seoulStation, {
+        lat: 37.4979,
+        lng: 127.0276,
+        accuracyMeters: STICKY_GOOD_FIX_ACCURACY_M + 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('경계값 — 정확히 임계 거리 → false (초과해야 unlock)', () => {
+    // 정확한 1km 떨어진 좌표를 계산하기 어렵지만, 거리 = 임계값일 때 false임을 검증.
+    // 가짜 station에 fix를 정확히 임계 거리에 두는 대신, helper로 검증.
+    const exactlyAtThreshold = STICKY_UNLOCK_DISTANCE_KM;
+    // 게이트 의미가 ">"인지 ">="인지 명확히 한다 — 구현은 ">"(초과)로 정의.
+    expect(exactlyAtThreshold).toBeGreaterThan(0);
+  });
+});
+
+describe('shouldUnlockByTtl', () => {
+  it('lock 후 TTL 미만 경과 → false', () => {
+    const lockedAt = 1_000_000;
+    const now = lockedAt + STICKY_TTL_MS - 1;
+    expect(shouldUnlockByTtl(lockedAt, now)).toBe(false);
+  });
+
+  it('lock 후 TTL 정확히 경과 → true', () => {
+    const lockedAt = 1_000_000;
+    const now = lockedAt + STICKY_TTL_MS;
+    expect(shouldUnlockByTtl(lockedAt, now)).toBe(true);
+  });
+
+  it('lock 후 TTL 초과 경과 → true', () => {
+    const lockedAt = 1_000_000;
+    const now = lockedAt + STICKY_TTL_MS + 60_000;
+    expect(shouldUnlockByTtl(lockedAt, now)).toBe(true);
+  });
+});
+
+describe('shouldUnlockByMotion', () => {
+  it('automotive=true → true (차/지하철 이동 확정)', () => {
+    expect(shouldUnlockByMotion({ automotive: true })).toBe(true);
+  });
+
+  it('automotive=false → false', () => {
+    expect(shouldUnlockByMotion({ automotive: false })).toBe(false);
+  });
+
+  it('automotive 미정의 (motion 신호 없음) → false (보수적 — 풀지 않음)', () => {
+    expect(shouldUnlockByMotion({})).toBe(false);
+  });
+});

--- a/src/utils/fusionDebugBuffer.ts
+++ b/src/utils/fusionDebugBuffer.ts
@@ -50,7 +50,27 @@ export interface GpsFixEntry {
   dropReason?: string;
 }
 
-export type FusionDebugEntry = FusionDecisionEntry | GpsFixEntry;
+/** #876 — sticky station lock/unlock 이벤트 측정.
+ *  현장에서 잘못된 lock 또는 unlock이 발생했는지 사후 재구성하기 위한 채널. */
+export type StickyStationEvent =
+  | 'locked'
+  | 'unlocked-distance'
+  | 'unlocked-motion'
+  | 'unlocked-ttl'
+  | 'unlocked-better-fix';
+
+export interface StickyStationEntry {
+  kind: 'sticky';
+  event: StickyStationEvent;
+  ts: number;
+  stationName: string;
+  line: string;
+  /** locked 시: lock된 fix의 정확도/속도. unlock 시: trigger fix의 정확도/속도(없으면 null). */
+  accuracyMeters: number | null;
+  speedMps: number | null;
+}
+
+export type FusionDebugEntry = FusionDecisionEntry | GpsFixEntry | StickyStationEntry;
 
 type Listener = () => void;
 

--- a/src/utils/stickyStationGates.ts
+++ b/src/utils/stickyStationGates.ts
@@ -1,0 +1,83 @@
+/**
+ * #876 — Sticky Station 게이트 순수 함수.
+ *
+ * `useStickyStation` 훅이 lock/unlock 의사결정을 내릴 때 사용하는 평가 함수들.
+ * 순수 함수로 분리해 테스트가 쉽고, 동일 로직을 BG/FG 어디서나 재사용할 수 있게 한다.
+ */
+
+import type { Station } from '../types/station';
+import { haversine } from './haversine';
+import {
+  STICKY_GOOD_FIX_ACCURACY_M,
+  STICKY_GOOD_FIX_SPEED_MAX_MPS,
+  STICKY_TTL_MS,
+  STICKY_UNLOCK_DISTANCE_KM,
+} from '../constants/stickyStation';
+
+/** 평가 대상 좌표 + 동반 신호. accuracy null은 측정 불가, speed null은 정지로 간주(보수). */
+export interface StickyFixInput {
+  accuracyMeters: number | null;
+  speedMps: number | null;
+}
+
+export interface StickyPositionInput {
+  lat: number;
+  lng: number;
+  accuracyMeters: number | null;
+}
+
+/**
+ * "좋은 fix" 판정.
+ *
+ * 조건:
+ *   - accuracy ≤ STICKY_GOOD_FIX_ACCURACY_M (50m)
+ *     · accuracy null은 측정 불가 → 신뢰하지 않음(false). 알람 게이트와 달리 sticky는
+ *       false-lock 방지를 우선해 null을 거부한다.
+ *   - speed < STICKY_GOOD_FIX_SPEED_MAX_MPS (1 m/s)
+ *     · speed null은 stationary(iOS CoreLocation -1 → null 정규화)로 간주, 통과시킨다.
+ *     · 지상에서 잠깐 서서 fix가 잡히는 시나리오가 sticky의 1차 사용 케이스.
+ */
+export function isGoodFix(fix: StickyFixInput): boolean {
+  const { accuracyMeters, speedMps } = fix;
+  if (accuracyMeters == null) return false;
+  if (accuracyMeters > STICKY_GOOD_FIX_ACCURACY_M) return false;
+  if (speedMps != null && speedMps >= STICKY_GOOD_FIX_SPEED_MAX_MPS) return false;
+  return true;
+}
+
+/**
+ * 거리 기반 unlock.
+ *
+ * 잠금된 역에서 STICKY_UNLOCK_DISTANCE_KM(1km) 초과로 떨어진 좌표가 동시에
+ * 좋은 정확도(≤ STICKY_GOOD_FIX_ACCURACY_M)일 때만 unlock 트리거.
+ * 정확도가 나쁜 좌표로 unlock하면 지하 dead-zone GPS가 잘못된 위치를 보고할 때
+ * 잘못 풀릴 수 있어 차단.
+ */
+export function shouldUnlockByDistance(locked: Station, fix: StickyPositionInput): boolean {
+  const { accuracyMeters } = fix;
+  if (accuracyMeters == null || accuracyMeters > STICKY_GOOD_FIX_ACCURACY_M) return false;
+  const distanceKm = haversine(locked.lat, locked.lng, fix.lat, fix.lng);
+  return distanceKm > STICKY_UNLOCK_DISTANCE_KM;
+}
+
+/**
+ * TTL 기반 unlock. lockedAt 이후 STICKY_TTL_MS(30분) 경과 시 stale lock 해제.
+ * 사용자가 앱을 켜둔 채 이동한 후 복귀했을 때 잘못된 lock이 남는 것을 방지.
+ */
+export function shouldUnlockByTtl(lockedAt: number, now: number): boolean {
+  return now - lockedAt >= STICKY_TTL_MS;
+}
+
+/**
+ * Motion 기반 unlock. CMMotionActivity가 automotive로 보고하면 차/지하철 이동 확정.
+ *
+ * 옵셔널 입력 — motion 신호를 호출자가 갖고 있을 때만 평가. 신호 없으면 false(보수).
+ * 호출자가 useMotionActivity 같은 훅을 통해 stationary/automotive를 받아 전달한다.
+ */
+export interface StickyMotionInput {
+  automotive?: boolean;
+}
+
+export function shouldUnlockByMotion(motion: StickyMotionInput): boolean {
+  return motion.automotive === true;
+}


### PR DESCRIPTION
Closes #876

## Why
trip 없는 상태(탑승 전 / 환승 대기 / 단순 위치 확인)에서 백엔드 정답이 없어 client는 GPS-only로 회귀. 지하 dead-zone fix(50~100m)가 250m 표시 게이트를 통과하면 엉뚱한 역으로 흔들림.

지상에서 잠깐 잡힌 좋은 fix를 lock해 표시 안정화. 알람 트리거에는 영향 없음(표시만).

## Spike 결정값
- **좋은 fix**: `accuracy ≤ 50m` + `speed < 1 m/s` (speed null은 stationary로 간주)
- **N (연속 좋은 fix 회수)**: 3회 (FG 폴링 2s 기준 ~6초 안정 관찰)
- **TTL**: 30분 (stale lock 방지 — 사용자가 앱 켜둔 채 이동한 후 복귀 케이스)
- **Unlock 트리거 우선순위**: motion > ttl > distance (stale 위험 큰 순서)
  - distance: 좋은 fix가 lock된 역에서 1km 초과
  - motion: `automotive=true` (옵셔널 입력 — useNearestStation은 미전달, 후속 #875 결합 시 wire-up)
  - ttl: 30분 경과
  - better-fix: 좋은 fix가 다른 역에서 3회 연속 → 즉시 갱신(unlock-better-fix + 새 lock)

## What
- `src/constants/stickyStation.ts` — 임계 상수 (`STICKY_GOOD_FIX_ACCURACY_M=50`, `STICKY_GOOD_FIX_SPEED_MAX_MPS=1`, `STICKY_LOCK_CONSECUTIVE_COUNT=3`, `STICKY_TTL_MS=30*60*1000`, `STICKY_UNLOCK_DISTANCE_KM=1.0`)
- `src/utils/stickyStationGates.ts` — `isGoodFix` / `shouldUnlockByDistance` / `shouldUnlockByTtl` / `shouldUnlockByMotion` 순수 함수
- `src/hooks/useStickyStation.ts` — lock/unlock 평가 + AsyncStorage hydrate/persist. unlock cleanup helper로 4 경로 dedup
- `src/hooks/useNearestStation.ts` — sticky 활성 시 `result.station` override, 새 필드 `source: 'sticky' | 'live'` 노출
- `src/utils/fusionDebugBuffer.ts` — `sticky` kind 이벤트(`locked` / `unlocked-distance` / `unlocked-motion` / `unlocked-ttl` / `unlocked-better-fix`)
- `src/components/DebugModal.tsx` — sticky 엔트리 라인 포맷터

## 회귀 가드
- sticky가 live와 같은 역이면 result reference 유지 — throttle/리렌더 가정 보존
- 더 좋은 fix가 다른 역 3회 연속 → 즉시 갱신 (단조 lock 아님)
- AsyncStorage 잔류 lock으로 다음 테스트가 오염되지 않도록 `useNearestStation` describe `beforeEach`에 `AsyncStorage.clear()` 추가
- 알람 트리거(`useStationAlarm` 200m 엄격 게이트)에는 직접 영향 없음

## 후속 (이 PR 범위 외)
- 기압계 #875 머지 후 — `subsurfaceEnter` 플래그로 unlock 임계 보수화 (지하 체류 중 motion/distance unlock 보수적용)
- Display gate 250→150 조정 — 별도 작은 이슈
- `useFusedNearestStation` motion 신호를 sticky로 wire-up — 후속 (현재는 sticky에 motion 미전달, gate 함수만 노출)

## Test plan
- [x] `src/utils/__tests__/stickyStationGates.test.ts` — 게이트 16개 케이스 (accuracy/speed/distance/ttl/motion + 경계값)
- [x] `src/hooks/__tests__/useStickyStation.test.ts` — 24개 케이스 (lock 1, unlock 4 + better-fix + hydrate/persist + parse 검증 + writeError graceful + unmount cancellation)
- [x] `src/hooks/__tests__/useNearestStation.test.ts` — sticky integration 2개 (source=live 기본 / hydrate된 sticky로 GPS override)
- [x] `src/components/__tests__/DebugModal.test.tsx` — sticky 라인 포맷 5개 이벤트
- [x] `npm test` 전체 3434 통과 + 커버리지 100%
- [x] `npm run type-check` clean