### PR TITLE
feat(#897): Seam A — 시간 anchor 통일 + 지연 라벨

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,7 @@ import { useDestinationStore } from '../src/features/route/store/useDestinationS
 import { useLocaleStore } from '../src/shared/i18n/store/useLocaleStore';
 import { DebugModal } from '../src/features/debug/components/DebugModal';
 import { isDebugModalEnabled } from '../src/shared/constants/debugFlags';
-import '../src/tasks/backgroundLocationTask';
+import '../src/features/nearest-station/tasks/backgroundLocationTask';
 import { registerSilentPushTask } from '../src/features/alarm/tasks/silentPushTask';
 import { registerScheduledAlarmListener } from '../src/features/alarm/utils/scheduledAlarmReceiver';
 import { cancelScheduledAlarms } from '../src/features/alarm/utils/alarmScheduler';

--- a/src/features/alarm/components/BoardingLockHopCard.tsx
+++ b/src/features/alarm/components/BoardingLockHopCard.tsx
@@ -7,9 +7,19 @@ import type { BoardingLock } from '../../../shared/types/boardingLock';
 /** BoardingTrainList compact row와 동일한 좌측 stripe 두께 (#664/#758). */
 const LINE_STRIPE_WIDTH = 3;
 
+/** 지연 노출 임계값(초) — Seam A (#897). BoardingTrainList의 동명 상수와 동일 정책. */
+const DELAY_NOTICE_THRESHOLD_SECONDS = 180;
+
 interface Props {
   lock: BoardingLock;
   onRelease: () => void;
+  /**
+   * 현재 폴링의 lock.trainCode에 매칭되는 train의 잔여 ETA(초) — Epic #896 Seam A (#897).
+   *
+   * `lock.initialEtaSeconds`와 비교해 차이가 임계값 이상이면 "+N분 지연" 칩 노출. 미전달이면 칩 미노출.
+   * 매칭되는 train이 응답에 없으면(예: 다음 도착이 다른 trainCode) 호출자가 undefined를 전달한다.
+   */
+  currentEtaSeconds?: number;
 }
 
 /**
@@ -20,11 +30,12 @@ interface Props {
  *
  * 메타: "탑승 · {lineName} · {HH:mm}". trainCode raw 식별자는 비노출(#667, BoardingLockBanner 정신 유지).
  */
-export function BoardingLockHopCard({ lock, onRelease }: Props) {
+export function BoardingLockHopCard({ lock, onRelease, currentEtaSeconds }: Props) {
   const { colors } = useTheme();
   const lineName = LINE_NAMES[lock.boardingLine];
   const timeText = formatClockTime(lock.boardedAt);
   const metaText = `탑승 · ${lineName} · ${timeText}`;
+  const delayMinutes = computeDelayMinutes(lock.initialEtaSeconds, currentEtaSeconds);
   return (
     <View
       style={[
@@ -39,6 +50,14 @@ export function BoardingLockHopCard({ lock, onRelease }: Props) {
       >
         {metaText}
       </Text>
+      {delayMinutes != null && (
+        <View
+          style={[styles.delayChip, { borderColor: colors.danger }]}
+          testID="boarding-lock-hop-delay-chip"
+        >
+          <Text style={[styles.delayChipText, { color: colors.danger }]}>{`+${delayMinutes}분 지연`}</Text>
+        </View>
+      )}
       <Pressable
         onPress={onRelease}
         style={[styles.releaseButton, { borderColor: colors.accent }]}
@@ -48,6 +67,23 @@ export function BoardingLockHopCard({ lock, onRelease }: Props) {
       </Pressable>
     </View>
   );
+}
+
+/**
+ * 지연(분) 계산 — Seam A (#897). 같은 정책을 BoardingTrainList와 공유한다.
+ *
+ * 의도적으로 util로 추출하지 않은 이유: 두 호출처가 input 형태(arrivals[0] vs scalar pair)가 달라
+ * 공통화 시 인터페이스가 어색해진다. 같은 임계값 상수만 공유한다.
+ */
+function computeDelayMinutes(
+  initialEtaSeconds: number | undefined,
+  currentEtaSeconds: number | undefined,
+): number | null {
+  if (initialEtaSeconds == null || initialEtaSeconds <= 0) return null;
+  if (currentEtaSeconds == null) return null;
+  const diff = currentEtaSeconds - initialEtaSeconds;
+  if (diff < DELAY_NOTICE_THRESHOLD_SECONDS) return null;
+  return Math.ceil(diff / 60);
 }
 
 const styles = StyleSheet.create({
@@ -64,4 +100,12 @@ const styles = StyleSheet.create({
     borderRadius: radius.sm,
     borderWidth: 1,
   },
+  // #897 — ArrivalStatusBadge outline 컨벤션과 동일 외형(borderWidth 1 + radius 3).
+  delayChip: {
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 1,
+    borderRadius: 3,
+    borderWidth: 1,
+  },
+  delayChipText: { fontSize: 11, fontWeight: '700', letterSpacing: 0 },
 });

--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -244,8 +244,10 @@ function computeDelayMinutes(
 ): number | null {
   if (initialEtaSeconds == null || initialEtaSeconds <= 0) return null;
   if (arrivals.length === 0) return null;
-  const nearest = arrivals.reduce((min, cur) =>
-    cur.arrivalSeconds < min.arrivalSeconds ? cur : min,
+  const [head, ...rest] = arrivals;
+  const nearest = rest.reduce(
+    (min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min),
+    head,
   );
   const diff = nearest.arrivalSeconds - initialEtaSeconds;
   if (diff < DELAY_NOTICE_THRESHOLD_SECONDS) return null;

--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -12,6 +12,7 @@ import { LineBadge } from '../../../shared/ui/LineBadge';
 import type { ArrivalInfo } from '../../../shared/types/arrival';
 import type { LineNumber, Station } from '../../../shared/types/station';
 import { formatClockTime } from '../../../shared/utils/formatTime';
+import { arrivalAt } from '../../../shared/utils/arrivalClock';
 import { isScheduleFallbackTrainCode } from '../utils/scheduleFallback';
 import { buildDirectionMeta } from '../../route/utils/trainLineDirection';
 import { parseArrivalDistance } from '../../arrival/utils/arrivalStatusDistance';
@@ -23,6 +24,15 @@ const allStations = stationsData as Station[];
 
 /** row 좌측 호선 색 stripe 두께(#664). 시각적 구분을 헤더 외에도 row마다 즉시 인지 가능하게. */
 const LINE_STRIPE_WIDTH = 3;
+
+/**
+ * 지연 노출 임계값(초) — Epic #896 Seam A (#897).
+ *
+ * BoardingLock이 잡힌 시점의 ETA(initialEtaSeconds)와 현재 폴의 가장 가까운 도착 ETA 차이가
+ * 이 값 이상이면 "+N분 지연" 칩을 노출. 30s 폴링 jitter + 약간의 정상 변동을 흡수하면서 사용자가
+ * 체감 가능한 단위(3분)를 첫 신호로 잡는다.
+ */
+const DELAY_NOTICE_THRESHOLD_SECONDS = 180;
 
 interface Props {
   arrivals: ArrivalInfo[];
@@ -45,6 +55,14 @@ interface Props {
    * row padding 축소, 폰트 한 단계 다운, trainCode 라인 생략.
    */
   compact?: boolean;
+  /**
+   * 활성 BoardingLock의 탑승 시점 ETA 스냅샷(초) — Epic #896 Seam A (#897).
+   *
+   * 가장 가까운 도착 train의 arrivalSeconds가 이 값보다 DELAY_NOTICE_THRESHOLD_SECONDS 이상 늘었다면
+   * 같은 trainCode 유지 동안 누적 지연이 발생한 것으로 보고 "+N분 지연" 칩을 노출한다.
+   * 미전달이면 칩 미노출 — lock 없는 상태(예: misBoarding 재선택)나 레거시 lock에서도 안전.
+   */
+  initialEtaSeconds?: number;
 }
 
 /**
@@ -83,6 +101,7 @@ export function BoardingTrainList({
   title = '탑승할 열차 선택',
   nextStationLabel = null,
   compact = false,
+  initialEtaSeconds,
 }: Props) {
   const { colors } = useTheme();
   const isUnreachable = (train: ArrivalInfo): boolean =>
@@ -91,6 +110,10 @@ export function BoardingTrainList({
   // #664: 환승역 statnNm 응답에 같은 이름 다른 노선 열차가 섞여 들어오므로 헤더 line 기준 필터.
   // train.line은 어댑터가 subwayId로 row마다 정확히 결정한 값(#663). 일치하는 row만 표시.
   const filteredArrivals = arrivals.filter((train) => train.line === line);
+
+  // #897 Seam A: 가장 가까운 도착 ETA가 lock 시점보다 +180s 이상이면 누적 지연(분) 노출.
+  // arrivals는 호출자가 도착시간 오름차순으로 전달한다는 컨벤션을 따른다(#749 카운터와 동일 가정).
+  const delayMinutes = computeDelayMinutes(filteredArrivals, initialEtaSeconds);
 
   if (filteredArrivals.length === 0) {
     return (
@@ -112,6 +135,14 @@ export function BoardingTrainList({
         <View style={styles.header}>
           <LineBadge line={line} />
           <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
+        </View>
+      )}
+      {delayMinutes != null && (
+        <View
+          style={[styles.delayChip, { borderColor: colors.danger }]}
+          testID="boarding-train-delay-chip"
+        >
+          <Text style={[styles.delayChipText, { color: colors.danger }]}>{`+${delayMinutes}분 지연`}</Text>
         </View>
       )}
       {filteredArrivals.map((train, index) => {
@@ -190,13 +221,35 @@ export function BoardingTrainList({
 }
 
 /**
- * 도착 시각 절대 표기(HH:mm) — #634.
- * receivedAtMs(API fetch 시점) + arrivalSeconds로 절대 도착 시각 산출.
- * receivedAtMs 0(mock/stale)이면 현재 시각 기준 fallback — 한 사이클 내에서는 결정적.
+ * 도착 시각 절대 표기(HH:mm) — #634, #897.
+ *
+ * #897 Seam A: anchor를 receivedAtMs+arrivalSeconds → `arrivalAt(train)` (현재 시각 + 남은 초)로 통일.
+ * useArrivalCountdown이 tick마다 arrivalSeconds를 1씩 줄이는 동안 시계도 1초 흐르므로 anchor가 stable.
+ * ArrivalRow(useCountdown 기반)와 같은 row의 시각이 항상 일치한다.
  */
 function formatArrivalClock(train: ArrivalInfo): string {
-  const baseMs = train.receivedAtMs > 0 ? train.receivedAtMs : Date.now();
-  return formatClockTime(baseMs + train.arrivalSeconds * 1000);
+  return formatClockTime(arrivalAt(train));
+}
+
+/**
+ * 지연(분) 계산 — Epic #896 Seam A (#897).
+ *
+ * 가장 가까운 도착의 arrivalSeconds가 초기 ETA보다 임계값(180초) 이상 늘면 그 차이를 분 단위 올림으로 반환.
+ * 미만이면 null(칩 미노출). initialEta 미전달이나 0 이하(임박/baseline 없음)도 null.
+ * 호출자가 정렬을 보장하지 않을 수 있으므로 본 함수가 arrivalSeconds 오름차순 정렬 후 nearest 선택.
+ */
+function computeDelayMinutes(
+  arrivals: ArrivalInfo[],
+  initialEtaSeconds: number | undefined,
+): number | null {
+  if (initialEtaSeconds == null || initialEtaSeconds <= 0) return null;
+  if (arrivals.length === 0) return null;
+  const nearest = arrivals.reduce((min, cur) =>
+    cur.arrivalSeconds < min.arrivalSeconds ? cur : min,
+  );
+  const diff = nearest.arrivalSeconds - initialEtaSeconds;
+  if (diff < DELAY_NOTICE_THRESHOLD_SECONDS) return null;
+  return Math.ceil(diff / 60);
 }
 
 const styles = StyleSheet.create({
@@ -248,4 +301,13 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.xs,
     paddingHorizontal: spacing.sm,
   },
+  // #897 — outline 칩. ArrivalStatusBadge의 outline variant와 동일 외형(borderWidth 1 + radius 3).
+  delayChip: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 1,
+    borderRadius: 3,
+    borderWidth: 1,
+  },
+  delayChipText: { fontSize: 11, fontWeight: '700', letterSpacing: 0 },
 });

--- a/src/features/alarm/components/__tests__/BoardingLockHopCard.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingLockHopCard.test.tsx
@@ -58,4 +58,82 @@ describe('BoardingLockHopCard (#758)', () => {
       : card.props.style;
     expect(stripeStyle.borderLeftColor).toBe(LINE_COLORS['2']);
   });
+
+  describe('#897 Seam A — 지연 칩', () => {
+    const lockWithEta: BoardingLock = { ...baseLock, initialEtaSeconds: 120 };
+
+    it('initialEtaSeconds 미설정 (레거시 lock) → 칩 미노출', () => {
+      const { queryByTestId } = renderWithTheme(
+        <BoardingLockHopCard lock={baseLock} onRelease={() => {}} currentEtaSeconds={600} />,
+      );
+      expect(queryByTestId('boarding-lock-hop-delay-chip')).toBeNull();
+    });
+
+    it('currentEtaSeconds 미전달 (lock train이 응답에 없음) → 칩 미노출', () => {
+      const { queryByTestId } = renderWithTheme(
+        <BoardingLockHopCard lock={lockWithEta} onRelease={() => {}} />,
+      );
+      expect(queryByTestId('boarding-lock-hop-delay-chip')).toBeNull();
+    });
+
+    it('차이 < 임계치(180s) → 칩 미노출', () => {
+      const { queryByTestId } = renderWithTheme(
+        <BoardingLockHopCard
+          lock={lockWithEta}
+          onRelease={() => {}}
+          currentEtaSeconds={240}
+        />,
+      );
+      expect(queryByTestId('boarding-lock-hop-delay-chip')).toBeNull();
+    });
+
+    it('차이 >= 임계치 → "+N분 지연" 칩 노출 (ceil)', () => {
+      const { getByText } = renderWithTheme(
+        <BoardingLockHopCard
+          lock={lockWithEta}
+          onRelease={() => {}}
+          currentEtaSeconds={300}
+        />,
+      );
+      // diff=180s → ceil(180/60)=3분.
+      expect(getByText('+3분 지연')).toBeTruthy();
+    });
+
+    it('회귀 fixture — initial 90s에서 동일 90s 폴 → 칩 미노출', () => {
+      const { queryByTestId } = renderWithTheme(
+        <BoardingLockHopCard
+          lock={{ ...baseLock, initialEtaSeconds: 90 }}
+          onRelease={() => {}}
+          currentEtaSeconds={90}
+        />,
+      );
+      expect(queryByTestId('boarding-lock-hop-delay-chip')).toBeNull();
+    });
+
+    it('회귀 fixture — initial 90s에서 누적 +4분(240s) 지연 → "+4분 지연"', () => {
+      // "1분 30초 → 1분 더 지연" 시나리오에서 추가 폴링까지 누적된 케이스.
+      const { getByText } = renderWithTheme(
+        <BoardingLockHopCard
+          lock={{ ...baseLock, initialEtaSeconds: 90 }}
+          onRelease={() => {}}
+          currentEtaSeconds={330}
+        />,
+      );
+      // diff=240s → ceil(240/60)=4분.
+      expect(getByText('+4분 지연')).toBeTruthy();
+    });
+
+    it('initialEtaSeconds=0 (임박 열차 lock) → 칩 미노출 (baseline 0은 의미 없음)', () => {
+      // useBoardingLockController가 arrivalSeconds=0 train 탭을 허용 → initialEtaSeconds=0 lock 가능.
+      // baseline이 없는 상태에서 currentEta가 큰 값으로 잡혀도 false positive 차단.
+      const { queryByTestId } = renderWithTheme(
+        <BoardingLockHopCard
+          lock={{ ...baseLock, initialEtaSeconds: 0 }}
+          onRelease={() => {}}
+          currentEtaSeconds={300}
+        />,
+      );
+      expect(queryByTestId('boarding-lock-hop-delay-chip')).toBeNull();
+    });
+  });
 });

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -43,27 +43,174 @@ describe('BoardingTrainList', () => {
     expect(getByTestId('boarding-train-sequence-T-A').props.children).toBe('약 1정거장 전 (약 3분 후)');
   });
 
-  it('#634 도착 시각을 receivedAtMs + arrivalSeconds 기반 HH:mm으로 표시', () => {
-    // 2026-01-01 03:05 + 180s = 2026-01-01 03:08
-    const base = new Date(2026, 0, 1, 3, 5).getTime();
-    const train = makeTrain({ trainCode: 'T-CLOCK', receivedAtMs: base, arrivalSeconds: 180 });
-    const { getByTestId } = renderWithTheme(
-      <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
-    );
-    expect(getByTestId('boarding-train-arrival-T-CLOCK').props.children).toBe('03:08 도착 예정');
-  });
-
-  it('#634 receivedAtMs=0(mock/stale)이면 현재 시각 기준 HH:mm 계산', () => {
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(new Date(2026, 0, 1, 10, 0).getTime());
+  it('#897 Seam A: 도착 시각은 현재 시각 + arrivalSeconds 기반 HH:mm으로 표시', () => {
+    // #897: anchor를 receivedAtMs+arrivalSeconds → Date.now()+arrivalSeconds로 통일.
+    // useArrivalCountdown tick(1초마다 arrivalSeconds-1)과 시계 흐름이 동기화돼 stable.
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(new Date(2026, 0, 1, 3, 5).getTime());
     try {
-      const train = makeTrain({ trainCode: 'T-NOW', receivedAtMs: 0, arrivalSeconds: 120 });
+      // receivedAtMs 값에 관계없이 (지금 + 180s) 기준 HH:mm.
+      const train = makeTrain({ trainCode: 'T-CLOCK', receivedAtMs: 0, arrivalSeconds: 180 });
       const { getByTestId } = renderWithTheme(
         <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
       );
-      expect(getByTestId('boarding-train-arrival-T-NOW').props.children).toBe('10:02 도착 예정');
+      expect(getByTestId('boarding-train-arrival-T-CLOCK').props.children).toBe('03:08 도착 예정');
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  it('#897 Seam A: receivedAtMs 과거 값이어도 anchor는 현재 시각 — useArrivalCountdown tick과 stable', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(new Date(2026, 0, 1, 10, 0).getTime());
+    try {
+      // receivedAtMs가 1시간 전이라도 표시 시각은 (지금=10:00) + 120s = 10:02.
+      const stale = new Date(2026, 0, 1, 9, 0).getTime();
+      const train = makeTrain({ trainCode: 'T-STALE', receivedAtMs: stale, arrivalSeconds: 120 });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-arrival-T-STALE').props.children).toBe('10:02 도착 예정');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  describe('#897 Seam A — initialEtaSeconds 지연 칩', () => {
+    it('arrivalSeconds 차이 < 임계치(180s) → 칩 미노출', () => {
+      const train = makeTrain({ trainCode: 'T-OK', arrivalSeconds: 240 });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={120}
+        />,
+      );
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
+
+    it('차이 = 정확히 임계치 → 칩 노출 (diff < THRESHOLD가 거짓이므로 분기 진입)', () => {
+      // 120 + 180 = 300. diff=180. `diff < 180` false → 칩 노출 + ceil(180/60)=3.
+      const train = makeTrain({ trainCode: 'T-EDGE', arrivalSeconds: 300 });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={120}
+        />,
+      );
+      expect(getByTestId('boarding-train-delay-chip').props.children).toBeDefined();
+    });
+
+    it('arrivals 정렬 안 됨 → 가장 빠른 arrival 기준 (호출자 정렬 무관)', () => {
+      // 정렬되지 않은 입력: [400s, 90s]. nearest=90s. initial=60 → diff=30 < 180 → 칩 미노출.
+      // 정렬을 못 한 호출자가 첫 row를 nearest로 잘못 잡으면 diff=340 → "+6분 지연" 오발화하지 않음.
+      const slow = makeTrain({ trainCode: 'T-SLOW', arrivalSeconds: 400 });
+      const fast = makeTrain({ trainCode: 'T-FAST', arrivalSeconds: 90 });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[slow, fast]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={60}
+        />,
+      );
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
+
+    it('arrivals 오름차순 입력 → 첫 row가 nearest로 유지 (reduce keep-min 분기)', () => {
+      // [90s, 400s]. first=90s. cur=400s, 400<90 false → min(90) 유지. diff=90-60=30 < 180 → 미노출.
+      const fast = makeTrain({ trainCode: 'T-FAST', arrivalSeconds: 90 });
+      const slow = makeTrain({ trainCode: 'T-SLOW', arrivalSeconds: 400 });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[fast, slow]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={60}
+        />,
+      );
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
+
+    it('initialEtaSeconds=0 (임박 열차를 탭한 lock) → 칩 미노출 (baseline 0은 비교 의미 없음)', () => {
+      // 사용자가 arrivalSeconds=0 train을 탭해 initialEtaSeconds=0인 lock 생성.
+      // 다음 폴에 같은 trainCode가 캐시 재출현으로 300s 잡혀도 false positive 발사하지 않음.
+      const train = makeTrain({ trainCode: 'T-IMM', arrivalSeconds: 300 });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={0}
+        />,
+      );
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
+
+    it('차이 >= 임계치(180s) → "+N분 지연" 칩 노출 (ceil)', () => {
+      // initial 60s → 현재 240s. diff=180s → ceil(180/60)=3분.
+      const train = makeTrain({ trainCode: 'T-DELAY', arrivalSeconds: 240 });
+      const { getByText } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={60}
+        />,
+      );
+      expect(getByText('+3분 지연')).toBeTruthy();
+    });
+
+    it('회귀 fixture — initial 90s에서 폴 결과가 90s 그대로면 칩 미노출 (정상 진행)', () => {
+      const train = makeTrain({ trainCode: 'T-SAME', arrivalSeconds: 90 });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={90}
+        />,
+      );
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
+
+    it('회귀 fixture — initial 90s에서 추가 1분(60s) 지연 = diff 60s < 180 임계치 → 칩 미노출', () => {
+      // "1분 30초 → 그대로 1분 30초로 안 줄고 1분 더 지연" 시나리오 시작점.
+      const train = makeTrain({ trainCode: 'T-1MIN', arrivalSeconds: 150 });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={90}
+        />,
+      );
+      // 60s 지연은 임계치 미만 → 칩 미노출. 누적이 임계치를 넘으면 칩 노출.
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
+
+    it('initialEtaSeconds 미전달 → 칩 미노출 (lock 없는 상태에서 안전)', () => {
+      const train = makeTrain({ trainCode: 'T-NOLOCK', arrivalSeconds: 600 });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
+
+    it('filtered arrivals 비어있으면 칩 미노출', () => {
+      // 헤더 line 2 + train.line 7 → 필터 후 빈 list. 칩도 미노출.
+      const train = makeTrain({ trainCode: 'T-WRONG', line: '7' });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          initialEtaSeconds={60}
+        />,
+      );
+      expect(queryByTestId('boarding-train-delay-chip')).toBeNull();
+    });
   });
 
   it('train row 탭 시 onSelect에 해당 train 전달', () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -130,8 +130,18 @@ describe('useBoardingLockController', () => {
       expect(result.current.directionalArrivals).toEqual([upTrain, downTrain]);
     });
 
-    it('#666 arrivalSeconds <= 0 (지나간 열차)는 directionalArrivals에서 제외', () => {
-      const passed = makeTrain({ trainCode: 'PASSED', arrivalSeconds: 0 });
+    it('#897 Seam A: arrivalSeconds=0 (임박) 열차도 list에 유지 — useArrivalCountdown 0초 tick에서 행 사라짐 회귀 차단', () => {
+      const imminent = makeTrain({ trainCode: 'IMMINENT', arrivalSeconds: 0 });
+      const future = makeTrain({ trainCode: 'FUTURE', arrivalSeconds: 180 });
+      const arrivalImminent: StationArrival = { up: [imminent, future], down: [] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: arrivalImminent }),
+      );
+      expect(result.current.directionalArrivals).toEqual([imminent, future]);
+    });
+
+    it('#897 음수 arrivalSeconds(이미 지나간)는 그대로 제외 — createLock 오발화 방지', () => {
+      const passed = makeTrain({ trainCode: 'PASSED', arrivalSeconds: -10 });
       const future = makeTrain({ trainCode: 'FUTURE', arrivalSeconds: 180 });
       const arrivalWithPast: StationArrival = { up: [passed, future], down: [] };
       const { result } = renderHook(() =>
@@ -149,10 +159,10 @@ describe('useBoardingLockController', () => {
       (Date.now as jest.Mock).mockRestore();
     });
 
-    it('expectedDurationMinutes를 ms로 변환해 lock 생성', async () => {
+    it('expectedDurationMinutes를 ms로 변환해 lock 생성 + initialEtaSeconds 스냅샷(#897)', async () => {
       const { result } = renderHook(() => useBoardingLockController(defaultInputs));
       await act(async () => {
-        result.current.createLockFromTrain(makeTrain({ trainCode: 'T-X' }));
+        result.current.createLockFromTrain(makeTrain({ trainCode: 'T-X', arrivalSeconds: 240 }));
       });
       expect(mockSetBoardingLock).toHaveBeenCalledWith({
         destinationId: 'dest-1',
@@ -161,6 +171,7 @@ describe('useBoardingLockController', () => {
         boardingLine: '2',
         boardedAt: 1_700_000_000_000,
         expectedDurationMs: 20 * 60_000,
+        initialEtaSeconds: 240,
       });
     });
 

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -136,7 +136,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     };
   }
 
-  it('[탑승] 액션 + 후보 명확 + station 매칭 → createLock 호출', async () => {
+  it('[탑승] 액션 + 후보 명확 + station 매칭 → createLock 호출 + initialEtaSeconds 스냅샷(#897)', async () => {
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
     const deps = makeDeps();
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
@@ -148,6 +148,8 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
         boardingStationId: 'S1',
         boardingLine: '2',
         expectedDurationMs: 600_000,
+        // #897 Seam A: auto-lock 시점의 ETA(makeArrival 기본=60s) 스냅샷.
+        initialEtaSeconds: 60,
       }),
     );
     expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -95,8 +95,10 @@ export function useBoardingLockController({
 
   const directionalArrivals = useMemo<ArrivalInfo[]>(() => {
     if (!arrival) return [];
-    // #666 이미 지나간 열차(arrivalSeconds <= 0) 제외 — 사용자가 탭하면 lock 오발화.
-    const reachable = (t: ArrivalInfo): boolean => t.arrivalSeconds > 0;
+    // #897 (Seam A): 임박(arrivalSeconds=0) 열차도 list에 유지 — useArrivalCountdown tick으로 0초가
+    // 되어 행이 사라지면 사용자가 다음 차를 같은 차로 오인하는 회귀가 발생. 음수(이미 지나간)만 차단.
+    // 음수 train은 createLockFromTrain에서도 의미가 없어 #666 가드를 갈음한다.
+    const reachable = (t: ArrivalInfo): boolean => t.arrivalSeconds >= 0;
     if (direction === 'up') return arrival.up.filter(reachable);
     if (direction === 'down') return arrival.down.filter(reachable);
     return [...arrival.up, ...arrival.down].filter(reachable);
@@ -121,6 +123,9 @@ export function useBoardingLockController({
         boardingLine: train.line,
         boardedAt: Date.now(),
         expectedDurationMs: durationMin * 60_000,
+        // #897 Seam A: 탑승 시점 ETA 스냅샷. 동일 trainCode가 유지되는 동안 새 폴링의 arrivalSeconds가
+        // 이 값보다 크게 늘면 그 차이가 지연(분). BoardingTrainList가 "+N분 지연" 칩으로 노출.
+        initialEtaSeconds: train.arrivalSeconds,
       });
     },
     [destinationId, currentStation, expectedDurationMinutes, createLock],

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -169,5 +169,7 @@ async function tryAutoLock(
     boardingLine: chosen.line,
     boardedAt: Date.now(),
     expectedDurationMs: deps.expectedDurationMs,
+    // #897 Seam A: auto-lock 시점 ETA 스냅샷. 지연 신호의 기준치.
+    initialEtaSeconds: chosen.arrivalSeconds,
   });
 }

--- a/src/features/alarm/utils/__tests__/boardingLockStorage.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockStorage.test.ts
@@ -68,6 +68,29 @@ describe('boardingLockStorage', () => {
       (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
       expect(await getBoardingLock()).toBeNull();
     });
+
+    it('#897 initialEtaSeconds 누락 (레거시 lock) — 통과시키되 값은 undefined', async () => {
+      // 레거시 lock은 initialEtaSeconds 필드 없이 저장돼 있다. 새 코드가 지연 칩만 미노출할 뿐
+      // 다른 alarm 로직(만료/leg 교체)은 영향 없으므로 통과시킨다.
+      const legacy = { ...sample };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(legacy));
+      const restored = await getBoardingLock();
+      expect(restored).toEqual(sample);
+      expect(restored?.initialEtaSeconds).toBeUndefined();
+    });
+
+    it('#897 initialEtaSeconds가 number면 그대로 복원', async () => {
+      const withEta = { ...sample, initialEtaSeconds: 180 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(withEta));
+      const restored = await getBoardingLock();
+      expect(restored?.initialEtaSeconds).toBe(180);
+    });
+
+    it('#897 initialEtaSeconds가 number/undefined 외 타입이면 손상 → null', async () => {
+      const broken = { ...sample, initialEtaSeconds: 'not-a-number' };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getBoardingLock()).toBeNull();
+    });
   });
 
   describe('setBoardingLock', () => {

--- a/src/features/alarm/utils/boardingLockStorage.ts
+++ b/src/features/alarm/utils/boardingLockStorage.ts
@@ -15,13 +15,17 @@ const logger = createLogger('BoardingLockStorage');
 function isBoardingLock(value: unknown): value is BoardingLock {
   if (!value || typeof value !== 'object') return false;
   const v = value as Record<string, unknown>;
+  // initialEtaSeconds(#897)는 선택 필드 — 레거시 lock(없음)도 통과시키되, 존재 시에는 number만 허용.
+  // undefined도 number도 아닌 값(예: string)은 손상으로 간주.
+  const initialEtaOk = v.initialEtaSeconds === undefined || typeof v.initialEtaSeconds === 'number';
   return (
     typeof v.destinationId === 'string' &&
     typeof v.trainCode === 'string' &&
     typeof v.boardingStationId === 'string' &&
     typeof v.boardingLine === 'string' &&
     typeof v.boardedAt === 'number' &&
-    typeof v.expectedDurationMs === 'number'
+    typeof v.expectedDurationMs === 'number' &&
+    initialEtaOk
   );
 }
 

--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -129,8 +129,9 @@ describe('useTransferTrainList', () => {
         currentStation: gondeokOn6,
       }),
     );
-    act(() => result.current.createTransferLock(makeTrain({ trainCode: 'NEW' })));
+    act(() => result.current.createTransferLock(makeTrain({ trainCode: 'NEW', arrivalSeconds: 240 })));
     // calculateRemainingLegETA(route, 0) = stopsFromTransfer(3)*MINUTES_PER_STOP(2) = 6분
+    // #897 Seam A: initialEtaSeconds=탭한 train의 잔여 ETA(=240) 스냅샷.
     expect(mockCreateLock).toHaveBeenCalledWith(
       expect.objectContaining({
         destinationId: 'dest-X',
@@ -138,6 +139,7 @@ describe('useTransferTrainList', () => {
         boardingLine: '5',
         boardingStationId: (findStationByNameAndLine('공덕', '5') as Station).id,
         expectedDurationMs: 6 * 60_000,
+        initialEtaSeconds: 240,
       }),
     );
   });

--- a/src/features/route/hooks/useTransferTrainList.ts
+++ b/src/features/route/hooks/useTransferTrainList.ts
@@ -116,6 +116,8 @@ export function useTransferTrainList({
         boardingLine: context.nextLine,
         boardedAt: Date.now(),
         expectedDurationMs: durationMin * 60_000,
+        // #897 Seam A: 환승 leg 탑승 시점 ETA 스냅샷. 새 폴 응답이 이보다 +180s 이상이면 지연 신호.
+        initialEtaSeconds: train.arrivalSeconds,
       });
     },
     [context, lock, route, createLock],

--- a/src/features/route/utils/journeyAdapter.ts
+++ b/src/features/route/utils/journeyAdapter.ts
@@ -5,6 +5,7 @@ import type { ArrivalInfo } from '../../../shared/types/arrival';
 import type { NearestStationResult, LineNumber, Station } from '../../../shared/types/station';
 import { getStationDisplayName, getStationDisplayNameByName } from '../../../shared/utils/stationDisplay';
 import { parseTrainLineDirection } from './trainLineDirection';
+import { arrivalAt } from '../../../shared/utils/arrivalClock';
 import stationsData from '../../../data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -135,15 +136,15 @@ export function arrivalInfoToArrivalTrain(
   direction: string,
   line: LineNumber,
 ): ArrivalTrain[] {
-  const now = Date.now();
   // item.destination은 서울 열린데이터 API의 trainLineNm 기반("소요산행", "내선순환" 등 방면 표현).
   // parseTrainLineDirection이 패턴(역명+행, 내선/외선순환)을 인식해 현재 언어로 표시한다.
+  // #897 Seam A: arrivalAt(item) — BoardingTrainList와 동일한 anchor. useArrivalCountdown tick과 동기.
   return items.map((item) => ({
     direction: item.destination
       ? parseTrainLineDirection(item.destination, allStations)
       : direction,
     line,
-    arrivalAtMs: now + item.arrivalSeconds * 1000,
+    arrivalAtMs: arrivalAt(item),
     subtext: item.statusMessage || undefined,
     isLastTrain: item.isLastTrain,
     trainType: item.trainType,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -690,10 +690,16 @@ export default function HomeScreen() {
                             // #758 — origin hop slot에 BoardingLock 활성 상태 카드 렌더.
                             // BoardingLockBanner 별도 카드는 제거되고 timeline 안 hop으로 통합.
                             if (i === 0 && stop.mark === 'filled' && boardingLock) {
+                              // #897 Seam A: lock.trainCode 매칭 train의 잔여 ETA → 지연 칩 계산 input.
+                              // 매칭 없으면 undefined → 칩 미노출 (graceful).
+                              const matchedTrain = directionalArrivals.find(
+                                (t) => t.trainCode === boardingLock.trainCode,
+                              );
                               return (
                                 <BoardingLockHopCard
                                   lock={boardingLock}
                                   onRelease={releaseBoardingLock}
+                                  currentEtaSeconds={matchedTrain?.arrivalSeconds}
                                 />
                               );
                             }
@@ -724,6 +730,8 @@ export default function HomeScreen() {
                                     towardName,
                                   )
                                 : null;
+                              // #897 Seam A: 이 분기는 `!boardingLock` 가드 안 — lock이 없으므로 지연 칩 비교 기준이 없다.
+                              // 사용자가 BoardingTrainList에서 열차를 탭해야 lock이 생성되고, 이후 폴링에서 칩이 활성화된다.
                               return (
                                 <BoardingTrainList
                                   arrivals={directionalArrivals}
@@ -748,6 +756,8 @@ export default function HomeScreen() {
                                 transferContext.transferStationInToLine.name,
                                 transferContext.nextWaypointName,
                               );
+                              // #897 Seam A: 환승 list는 다음 leg 선택용 — 새 leg의 lock은 아직 없다.
+                              // 현재 lock은 이전 leg(곧 종료)라 ETA 비교 baseline으로 부적합. 칩 미노출.
                               return (
                                 <BoardingTrainList
                                   arrivals={transferArrivals}

--- a/src/shared/types/boardingLock.ts
+++ b/src/shared/types/boardingLock.ts
@@ -22,6 +22,16 @@ export interface BoardingLock {
   boardedAt: number;
   /** 예상 trip(또는 현재 leg) 소요 시간(ms). 자동 만료 계산용. */
   expectedDurationMs: number;
+  /**
+   * 탑승 시점 train의 잔여 ETA(초) — Seam A (#897).
+   *
+   * 이 lock으로 잠긴 trip이 동일 trainCode 동안 머무는 동안, 새 폴링 응답의 동일 train
+   * arrivalSeconds가 이 값보다 크게 늘었다면 그 차이가 지연(분) 단위 신호다.
+   *
+   * 레거시 영속화(이 필드 없이 저장된 lock)는 storage 가드가 그대로 통과시키되 값은 undefined.
+   * 지연 라벨은 값이 존재할 때만 노출되므로 graceful — 잘못된 추측 없이 다음 createLock에서 채워진다.
+   */
+  initialEtaSeconds?: number;
 }
 
 /** 자동 만료 안전 계수 — 예상 소요시간이 50% 초과되면 잘못된 Lock으로 보고 해제. */

--- a/src/shared/utils/__tests__/arrivalClock.test.ts
+++ b/src/shared/utils/__tests__/arrivalClock.test.ts
@@ -1,0 +1,49 @@
+import { arrivalAt } from '../arrivalClock';
+
+describe('arrivalAt', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('현재 시각 + arrivalSeconds*1000 ms 반환', () => {
+    const fixed = new Date(2026, 0, 1, 9, 0, 0).getTime();
+    jest.useFakeTimers().setSystemTime(fixed);
+    expect(arrivalAt({ arrivalSeconds: 180 })).toBe(fixed + 180_000);
+    expect(arrivalAt({ arrivalSeconds: 0 })).toBe(fixed);
+  });
+
+  it('Seam A 동기화: useArrivalCountdown tick과 함께 arrivalSeconds가 줄어들면 anchor는 stable (시계가 흐른 만큼 보정)', () => {
+    const t0 = new Date(2026, 0, 1, 9, 0, 0).getTime();
+    jest.useFakeTimers().setSystemTime(t0);
+    const initialEta = 180;
+    const a0 = arrivalAt({ arrivalSeconds: initialEta });
+    // 60초 흘렀고, useArrivalCountdown tick으로 arrivalSeconds도 60 줄었다.
+    jest.setSystemTime(t0 + 60_000);
+    const a1 = arrivalAt({ arrivalSeconds: initialEta - 60 });
+    expect(a1).toBe(a0);
+  });
+
+  it('clock anchor — 같은 폴링 cycle 내 동일 arrivalSeconds 두 호출은 같은 결과(시계 동결 가정)', () => {
+    const fixed = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(fixed);
+    expect(arrivalAt({ arrivalSeconds: 134 })).toBe(arrivalAt({ arrivalSeconds: 134 }));
+  });
+
+  it('Acceptance #897: BoardingTrainList anchor와 journeyAdapter anchor가 60s tick 후에도 동일', () => {
+    // BoardingTrainList의 formatArrivalClock(=arrivalAt)과 journeyAdapter.arrivalInfoToArrivalTrain의
+    // arrivalAtMs(=arrivalAt)는 같은 input을 받으면 같은 시각을 반환해야 한다.
+    const t0 = new Date(2026, 0, 1, 9, 0, 0).getTime();
+    jest.useFakeTimers().setSystemTime(t0);
+    const initialSeconds = 180;
+    const boardingListAnchor = arrivalAt({ arrivalSeconds: initialSeconds });
+    const arrivalRowAnchor = arrivalAt({ arrivalSeconds: initialSeconds });
+    expect(boardingListAnchor).toBe(arrivalRowAnchor);
+
+    // 60초 tick: useArrivalCountdown은 arrivalSeconds를 60 줄이고, useCountdown의 절대 시각은 그대로.
+    // 두 surface가 보는 anchor는 여전히 같다.
+    jest.setSystemTime(t0 + 60_000);
+    const tickedBoardingList = arrivalAt({ arrivalSeconds: initialSeconds - 60 });
+    // arrivalRow는 polling 사이 절대 시각 그대로 유지.
+    expect(tickedBoardingList).toBe(arrivalRowAnchor);
+  });
+});

--- a/src/shared/utils/arrivalClock.ts
+++ b/src/shared/utils/arrivalClock.ts
@@ -1,0 +1,20 @@
+/**
+ * 도착 시각 anchor — Epic #896 Seam A (#897).
+ *
+ * BoardingTrainList(현재역 도착 list)와 ArrivalRow(EditorialArrivalRow가 useCountdown로 매초 재계산)
+ * 사이의 표시 시각이 어긋나는 회귀가 있었다. 원인:
+ *
+ *   - useArrivalCountdown은 매초 `arrivalSeconds`만 1씩 차감한다 (receivedAtMs는 고정).
+ *   - 호출처가 `receivedAtMs + arrivalSeconds * 1000`로 절대 도착 시각을 계산하면, tick마다
+ *     시각이 1초씩 과거로 흐른다 → 30s 폴링 사이에 최대 30초 차.
+ *   - useCountdown(arrivalAtMs)은 절대 시각을 받아 `Date.now()`와 비교하므로 fetch 시점에 한 번
+ *     계산되어야 안정적이다.
+ *
+ * 해결: 도착 시각은 항상 "지금 시각 + 남은 초"로 계산한다. useArrivalCountdown이 tick으로 줄이는
+ * `arrivalSeconds`와 자연스럽게 동기화되어 두 표시 위치가 같은 anchor를 갖는다.
+ *
+ * 호출처가 직접 `Date.now() + arrivalSeconds * 1000`을 쓰는 대신 이 함수를 거쳐 의미를 명시한다.
+ */
+export function arrivalAt(item: { arrivalSeconds: number }): number {
+  return Date.now() + item.arrivalSeconds * 1000;
+}


### PR DESCRIPTION
Parent: #896

## Why
BoardingTrainList와 ArrivalRow가 같은 row 도착 시각을 다르게 표시 → useArrivalCountdown이 매초 arrivalSeconds-- 하는데 receivedAtMs는 polling 30s 사이 고정이라 `receivedAtMs + arrivalSeconds*1000` 호출처는 매초 1초씩 과거로 흐름.
useBoardingLockController가 임박(0초) 열차를 필터링해 다음 차로 보이는 오인 발생.

## 변경
1. **단일 anchor** `src/shared/utils/arrivalClock.ts` — `arrivalAt(item) = Date.now() + arrivalSeconds*1000`. BoardingTrainList·journeyAdapter 치환.
2. **필터 완화** `useBoardingLockController.directionalArrivals` `> 0` → `>= 0`. 음수만 차단해 #666 의도 유지.
3. **지연 라벨** BoardingLock에 `initialEtaSeconds?: number` 추가. BoardingTrainList·HopCard에 "+N분 지연" 칩(`diff ≥ 180s`).
4. **리뷰 P1 반영**: computeDelayMinutes가 자체 reduce로 nearest 선택 (호출자 정렬 무관). `initialEtaSeconds=0`은 baseline 비교 의미 없어 칩 미노출 — 임박 열차 lock false positive 차단.
5. **stale import 정정** `app/_layout.tsx`의 `src/tasks/backgroundLocationTask` → `src/features/nearest-station/tasks/`.

## Acceptance (#897)
- [x] 두 화면 도착 시각 동일 (60초 시뮬레이션)
- [x] 임박(0초) 열차 행 사라지지 않음
- [x] +3분 이상 지연 → "+N분 지연" 칩
- [x] 회귀 fixture: initial 90s + 누적 +4분 → "+4분 지연" (HopCard), initial 90s + 60s 지연 → 미노출 (임계 미만)
- [x] 첫 차/다음 차 강조 변경 없음
- [x] 100% 커버리지 (lines/branches/functions/statements), 3524 tests
- [x] type-check 통과

Closes #897