### PR TITLE
feat(#903): Seam G — 기압계 통합 + Sticky wire-up + 알람 confidence 게이트

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,7 @@ import { useDestinationStore } from '../src/features/route/store/useDestinationS
 import { useLocaleStore } from '../src/shared/i18n/store/useLocaleStore';
 import { DebugModal } from '../src/features/debug/components/DebugModal';
 import { isDebugModalEnabled } from '../src/shared/constants/debugFlags';
-import '../src/tasks/backgroundLocationTask';
+import '../src/features/nearest-station/tasks/backgroundLocationTask';
 import { registerSilentPushTask } from '../src/features/alarm/tasks/silentPushTask';
 import { registerScheduledAlarmListener } from '../src/features/alarm/utils/scheduledAlarmReceiver';
 import { cancelScheduledAlarms } from '../src/features/alarm/utils/alarmScheduler';

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -381,32 +381,44 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     expect(finalTrip.consecutiveEtaMissing).toBe(4);
   });
 
-  // #903 (Seam G) — subsurface true→false 전환(지상 복귀)에서 누적 카운터 리셋.
-  // 지하 인내 임계(10)로 쌓은 값이 지상 임계(5)에 즉시 걸려 trip이 자동 종료되는 회귀 차단.
-  it('resets consecutiveEtaMissing when subsurface flips true→false (surface recovery)', async () => {
-    const env = makeKvEnv();
-    await post('/trips', { ...tripBody(), subsurface: true }, env);
-    const underground = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
-    underground.consecutiveEtaMissing = 7;
-    await env.TRIPS.put('trip:tok-578', JSON.stringify(underground));
-    // 지상 복귀
-    await post('/trips', { ...tripBody(), subsurface: false }, env);
-    const recovered = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
-    expect(recovered.consecutiveEtaMissing).toBe(0);
-    expect(recovered.subsurface).toBe(false);
-  });
+  // #903 (Seam G) — subsurface 전환에 따른 누적 카운터 정책.
+  // helper: existing trip을 (subsurface, count) 상태로 셋업.
+  async function seedExistingTrip(
+    env: ReturnType<typeof makeKvEnv>,
+    initialSubsurface: boolean | undefined,
+    missCount: number,
+  ): Promise<void> {
+    const body = initialSubsurface === undefined ? tripBody() : { ...tripBody(), subsurface: initialSubsurface };
+    await post('/trips', body, env);
+    const existing = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    existing.consecutiveEtaMissing = missCount;
+    await env.TRIPS.put('trip:tok-578', JSON.stringify(existing));
+  }
 
-  // 인내 모드(subsurface true)로 들어갈 때(undefined→true)는 카운터 그대로 — 보존이 #706 의도와 일치.
-  it('preserves consecutiveEtaMissing when subsurface goes undefined→true (no reset)', async () => {
+  it.each([
+    {
+      label: 'true→false 전환(지상 복귀) → counter 리셋',
+      initial: true,
+      seed: 7,
+      next: false,
+      expectedCount: 0,
+      expectedSubsurface: false,
+    },
+    {
+      label: 'undefined→true 전환(지하 진입) → counter 보존',
+      initial: undefined,
+      seed: 3,
+      next: true,
+      expectedCount: 3,
+      expectedSubsurface: true,
+    },
+  ])('subsurface $label', async ({ initial, seed, next, expectedCount, expectedSubsurface }) => {
     const env = makeKvEnv();
-    await post('/trips', tripBody(), env);
-    const advanced = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
-    advanced.consecutiveEtaMissing = 3;
-    await env.TRIPS.put('trip:tok-578', JSON.stringify(advanced));
-    await post('/trips', { ...tripBody(), subsurface: true }, env);
+    await seedExistingTrip(env, initial, seed);
+    await post('/trips', { ...tripBody(), subsurface: next }, env);
     const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
-    expect(finalTrip.consecutiveEtaMissing).toBe(3);
-    expect(finalTrip.subsurface).toBe(true);
+    expect(finalTrip.consecutiveEtaMissing).toBe(expectedCount);
+    expect(finalTrip.subsurface).toBe(expectedSubsurface);
   });
 
   it('returns 400 on invalid JSON', async () => {

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -161,6 +161,18 @@ describe('validateTrip', () => {
     expect(validateTrip({ ...base(), locklessStationPassed: 1 })?.locklessStationPassed).toBeUndefined();
     expect(validateTrip(base())?.locklessStationPassed).toBeUndefined();
   });
+
+  // #903 (Seam G) — subsurface 필드
+  it('preserves boolean subsurface (#903)', () => {
+    expect(validateTrip({ ...base(), subsurface: true })?.subsurface).toBe(true);
+    expect(validateTrip({ ...base(), subsurface: false })?.subsurface).toBe(false);
+  });
+
+  it('drops non-boolean subsurface and absent field stays undefined (#903)', () => {
+    expect(validateTrip({ ...base(), subsurface: 'yes' })?.subsurface).toBeUndefined();
+    expect(validateTrip({ ...base(), subsurface: 1 })?.subsurface).toBeUndefined();
+    expect(validateTrip(base())?.subsurface).toBeUndefined();
+  });
 });
 
 describe('validateTrip — boardingLock (#585)', () => {
@@ -367,6 +379,34 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     await post('/trips', tripBody(), env); // device sends payload w/o counter
     const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
     expect(finalTrip.consecutiveEtaMissing).toBe(4);
+  });
+
+  // #903 (Seam G) — subsurface true→false 전환(지상 복귀)에서 누적 카운터 리셋.
+  // 지하 인내 임계(10)로 쌓은 값이 지상 임계(5)에 즉시 걸려 trip이 자동 종료되는 회귀 차단.
+  it('resets consecutiveEtaMissing when subsurface flips true→false (surface recovery)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', { ...tripBody(), subsurface: true }, env);
+    const underground = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    underground.consecutiveEtaMissing = 7;
+    await env.TRIPS.put('trip:tok-578', JSON.stringify(underground));
+    // 지상 복귀
+    await post('/trips', { ...tripBody(), subsurface: false }, env);
+    const recovered = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(recovered.consecutiveEtaMissing).toBe(0);
+    expect(recovered.subsurface).toBe(false);
+  });
+
+  // 인내 모드(subsurface true)로 들어갈 때(undefined→true)는 카운터 그대로 — 보존이 #706 의도와 일치.
+  it('preserves consecutiveEtaMissing when subsurface goes undefined→true (no reset)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    const advanced = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    advanced.consecutiveEtaMissing = 3;
+    await env.TRIPS.put('trip:tok-578', JSON.stringify(advanced));
+    await post('/trips', { ...tripBody(), subsurface: true }, env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(finalTrip.consecutiveEtaMissing).toBe(3);
+    expect(finalTrip.subsurface).toBe(true);
   });
 
   it('returns 400 on invalid JSON', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -6,12 +6,14 @@ import type { WindowedMetrics } from '../positionSeries';
 import {
   MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
+  SUBSURFACE_ETA_MISSING_TOLERANCE,
   estimateArrivalFromPosition,
   flipApnsEnv,
   maybeCountDrift,
   pickActiveWaypoint,
   pickApnsHost,
   pickBestArrivalSignal,
+  resolveEtaMissingThreshold,
   runScheduled,
   type ScheduledDeps,
   type ScheduledStats,
@@ -690,6 +692,25 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
   describe('MAX_CONSECUTIVE_ETA_MISSING (#706)', () => {
     it('is 5', () => {
       expect(MAX_CONSECUTIVE_ETA_MISSING).toBe(5);
+    });
+  });
+
+  // #903 (Seam G) — 기압계 subsurface trip은 인내 threshold(10) 적용.
+  describe('#903 SUBSURFACE_ETA_MISSING_TOLERANCE', () => {
+    it('is 10 (기본의 2배)', () => {
+      expect(SUBSURFACE_ETA_MISSING_TOLERANCE).toBe(10);
+    });
+
+    it('resolveEtaMissingThreshold(subsurface=true) → 10', () => {
+      expect(resolveEtaMissingThreshold({ subsurface: true })).toBe(SUBSURFACE_ETA_MISSING_TOLERANCE);
+    });
+
+    it('resolveEtaMissingThreshold(subsurface=false) → 5 (기본)', () => {
+      expect(resolveEtaMissingThreshold({ subsurface: false })).toBe(MAX_CONSECUTIVE_ETA_MISSING);
+    });
+
+    it('resolveEtaMissingThreshold(subsurface=undefined) → 5 (graceful default)', () => {
+      expect(resolveEtaMissingThreshold({})).toBe(MAX_CONSECUTIVE_ETA_MISSING);
     });
   });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -121,7 +121,12 @@ app.post('/trips', async (c) => {
         activityState: existing.activityState,
         // #706: 연속 etaMissing 카운터는 backend-only state — 디바이스가 같은 세션으로 re-register해도
         // 누적치를 보존해야 자동 종료가 정상 동작 (re-register마다 0으로 초기화되면 무한 폴링 회귀).
-        consecutiveEtaMissing: existing.consecutiveEtaMissing,
+        // #903 (Seam G) — 지상 복귀(subsurface true→false) 시 누적 카운터 리셋. 지하 인내 임계(10)로
+        // 누적된 값이 지상 임계(5)에 곧장 걸려 trip이 즉시 자동 종료되는 회귀 방지. 신호 회복 = trust restored.
+        consecutiveEtaMissing:
+          existing.subsurface === true && incoming.subsurface !== true
+            ? 0
+            : existing.consecutiveEtaMissing,
         // #819: boarding-prompt 발사 카운터는 backend-only state — 디바이스가 같은 세션으로
         // re-register하더라도 trip당 1회 + 5분 silence 정책을 유지해야 한다 (re-register마다
         // reset되면 spam 회귀). promptGeoContext / promptDisplay는 incoming이 최신이라 그대로 받음.
@@ -552,6 +557,9 @@ export function validateTrip(input: unknown): Trip | null {
     // 자연 skip — 좌표 없는 평가는 게이트 #4/#5 정확도 0이라 의미 없음.
     promptGeoContext: parsePromptGeoContext(obj.promptGeoContext),
     promptDisplay: parsePromptDisplay(obj.promptDisplay),
+    // #903 (Seam G): 클라이언트 기압계가 보고한 지하 진입 신호. 미송신/비boolean이면 undefined(default OFF).
+    // scheduled.ts가 이 값으로 consecutiveEtaMissing threshold(5 vs 10)를 분기한다.
+    subsurface: typeof obj.subsurface === 'boolean' ? obj.subsurface : undefined,
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -83,6 +83,24 @@ export const LA_PUSH_THRESHOLD_MS = 30_000;
 export const MAX_CONSECUTIVE_ETA_MISSING = 5;
 
 /**
+ * #903 (Seam G) — 기압계 subsurface=true trip에 적용되는 인내 임계치 (10회 ≈ 10분).
+ * 지하 dead zone에서 GPS/trainCode 신호 누락이 더 자주, 더 길게 발생하므로 기본 임계의 2배로 인내.
+ * 너무 크면 자동 종료 효과를 잃어 무한 폴링 위험 — 2배가 절충점.
+ */
+export const SUBSURFACE_ETA_MISSING_TOLERANCE = 10;
+
+/**
+ * trip별 etaMissing 임계 결정. subsurface=true면 늘려 잡고, 그 외엔 기본값.
+ * 클라가 매 register POST에 기압계 신호를 동봉하므로 한 trip 내에서 지상→지하 전이 시
+ * threshold가 자연 갱신된다(stale 가능 윈도우는 다음 register 까지 ≤ ALARM_TIME_BUCKET_MS).
+ */
+export function resolveEtaMissingThreshold(trip: Pick<Trip, 'subsurface'>): number {
+  return trip.subsurface === true
+    ? SUBSURFACE_ETA_MISSING_TOLERANCE
+    : MAX_CONSECUTIVE_ETA_MISSING;
+}
+
+/**
  * cron이 progress KV를 read할 때의 cacheTtl (#766/#770).
  * POST `/trips`가 putProgress 직후 같은 cron 사이클에서 옛 값을 읽지 않도록 30s까지 단축.
  * trips.ts/pendingPushes.ts의 cron read와 동일 정책. Cloudflare KV는 cacheTtl<30s 시
@@ -501,14 +519,17 @@ export async function runTrainCodeTracking(
       station: waypoint.stationName,
       consecutiveEtaMissing: nextMissCount,
     });
-    if (nextMissCount >= MAX_CONSECUTIVE_ETA_MISSING) {
+    // #903 (Seam G) — subsurface=true trip은 인내 임계(10)로 분기. 지하 dead zone GPS/trainCode 일시 누락 인내.
+    const threshold = resolveEtaMissingThreshold(trip);
+    if (nextMissCount >= threshold) {
       // #706 — 운행 시간대 외 무한 폴링 차단. cleanupTripWithLa가 LA dismissal + deleteTrip을 묶어 정리.
       // #868 — 클라 state sync용 trip-ended silent push 발사 (reason=eta-missing).
       log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
         token: trip.token.slice(0, 8),
         trainCode: lock.trainCode,
         station: waypoint.stationName,
-        threshold: MAX_CONSECUTIVE_ETA_MISSING,
+        threshold,
+        subsurface: trip.subsurface === true,
       });
       await cleanupTripWithLa(trip, env, deps, stats, now, log, 'eta-missing');
       return;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -143,6 +143,15 @@ export interface Trip {
    * 부재(첫 평가 전) = phase 분류 신호 없음.
    */
   stationPhase?: StationPhaseState;
+  /**
+   * #903 (Seam G) — 클라이언트 기압계가 지하 진입을 시사하는가. true면 backend가
+   * consecutiveEtaMissing threshold를 5→10(SUBSURFACE_ETA_MISSING_TOLERANCE)으로 늘려 일시 GPS/arrival
+   * 누락을 더 인내한다. 부재/false면 기존 threshold(MAX_CONSECUTIVE_ETA_MISSING=5) 유지.
+   *
+   * 운영 정책: 기압계 신호는 client가 매 register POST에 동봉. 새 POST가 오면 갱신되며,
+   * 한 trip 내에서 지상→지하 전이로 false→true 변동 가능. cron 사이클 사이의 stale은 next register로 자연 정정.
+   */
+  subsurface?: boolean;
 }
 
 /**

--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -233,6 +233,27 @@ describe('alarmBackend', () => {
         expect(body.locklessStationPassed).toBeUndefined();
       });
 
+      // #903 (Seam G) — subsurface 동봉
+      it('subsurface=true 송신 + 토글 변경 시 재등록', async () => {
+        const first = await registerActiveTrip({ ...SAMPLE_PAYLOAD, subsurface: true });
+        expect(first.ok).toBe(true);
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.subsurface).toBe(true);
+
+        // subsurface OFF로 재호출 → hash 달라져서 재등록 (dedup 미적용)
+        const off = await registerActiveTrip({ ...SAMPLE_PAYLOAD, subsurface: false });
+        expect(off).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        const offBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+        expect(offBody.subsurface).toBeUndefined();
+      });
+
+      it('subsurface=false/미설정이면 body에 미포함 (graceful)', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, subsurface: false });
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.subsurface).toBeUndefined();
+      });
+
       it('#701 in-flight dedup: 동일 페이로드 동시 호출 시 fetch는 1번만 발사된다', async () => {
         let resolveFetch: ((v: Response) => void) | null = null;
         (global.fetch as jest.Mock).mockImplementationOnce(

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -107,6 +107,13 @@ export interface RegisterTripPayload {
     originStation: string;
     line: string;
   };
+  /**
+   * #903 (Seam G) — 등록 시점 기압계가 지하 진입을 시사하는가.
+   * true면 backend가 consecutiveEtaMissing threshold를 5→10으로 늘려 일시 GPS/arrival
+   * 누락에 더 인내한다(지하 dead zone일 때 trainCode 추적이 자주 끊김).
+   * false/미설정은 기존 동작 그대로 — 기압계 미지원/권한 거절 환경 graceful.
+   */
+  subsurface?: boolean;
 }
 
 export interface AlarmBackendResult {
@@ -161,6 +168,7 @@ function buildRegisterHash(body: {
   boardingLock?: AlarmBoardingLock;
   locklessStationPassed?: boolean;
   promptDisplay?: { originStation: string; line: string };
+  subsurface?: boolean;
 }): string {
   return JSON.stringify({
     token: body.token,
@@ -183,6 +191,9 @@ function buildRegisterHash(body: {
     promptDisplayKey: body.promptDisplay
       ? `${body.promptDisplay.originStation}|${body.promptDisplay.line}`
       : null,
+    // #903 (Seam G) — subsurface 토글이 바뀌면 backend threshold가 즉시 갱신되도록 dedup 키 포함.
+    // 빈번한 ON/OFF jitter는 useBarometer의 60s 윈도우 평가가 자체 흡수하므로 폭주 위험 낮음.
+    subsurface: body.subsurface === true,
   });
 }
 
@@ -231,6 +242,8 @@ async function performRegisterFetch(
     // #819 — boarding-prompt 평가 컨텍스트. 좌표/표시 둘 중 하나라도 없으면 backend는 자동 skip.
     ...(payload.promptGeoContext ? { promptGeoContext: payload.promptGeoContext } : {}),
     ...(payload.promptDisplay ? { promptDisplay: payload.promptDisplay } : {}),
+    // #903 (Seam G) — 지하 진입 신호. ON일 때만 송신. backend는 부재 시 false default로 기존 threshold(5) 적용.
+    ...(payload.subsurface === true ? { subsurface: true } : {}),
   };
 
   try {
@@ -278,6 +291,7 @@ export function registerActiveTrip(
     boardingLock: payload.boardingLock,
     locklessStationPassed: payload.locklessStationPassed,
     promptDisplay: payload.promptDisplay,
+    subsurface: payload.subsurface,
   });
   if (hash === lastRegisteredHash) {
     return Promise.resolve({ ok: true, skipped: true });

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -960,4 +960,79 @@ describe('useApnsTripRegistration', () => {
       expect(refreshed?.[0].locklessStationPassed).toBe(true);
     });
   });
+
+  // #903 (Seam G) — 기압계 subsurface 전달
+  describe('subsurface (#903)', () => {
+    it('subsurface=true 입력 시 register payload에 포함', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          subsurface: true,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].subsurface).toBe(true);
+    });
+
+    it('subsurface 미지정/false면 register payload에 미포함 (graceful)', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].subsurface).toBeUndefined();
+    });
+
+    it('OFF→ON 전환 시 즉시 재등록 (deps 반영 — backend threshold 빠른 갱신)', async () => {
+      const { rerender } = renderHook(
+        ({ sub }: { sub: boolean }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            subsurface: sub,
+          }),
+        { initialProps: { sub: false } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].subsurface).toBeUndefined();
+
+      rerender({ sub: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].subsurface).toBe(true);
+    });
+
+    it('token refresh 경로도 최신 subsurface 값을 송신', async () => {
+      const { rerender } = renderHook(
+        ({ sub }: { sub: boolean }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            subsurface: sub,
+          }),
+        { initialProps: { sub: false } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      rerender({ sub: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+
+      const listener = mockAddPushTokenListener.mock.calls[0][0];
+      await act(async () => {
+        listener({ data: 'token-NEW2' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const refreshed = mockRegister.mock.calls.find(
+        (c) => (c[0] as { token: string }).token === 'token-NEW2',
+      );
+      expect(refreshed?.[0].subsurface).toBe(true);
+    });
+  });
 });

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -963,72 +963,46 @@ describe('useApnsTripRegistration', () => {
 
   // #903 (Seam G) — 기압계 subsurface 전달
   describe('subsurface (#903)', () => {
-    it('subsurface=true 입력 시 register payload에 포함', async () => {
-      renderHook(() =>
-        useApnsTripRegistration({
-          route: directRoute,
-          destination: station,
-          nextStationEtaSeconds: 120,
-          subsurface: true,
-        }),
-      );
-      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-      expect(mockRegister.mock.calls[0][0].subsurface).toBe(true);
+    const baseInputs = (subsurface?: boolean) => ({
+      route: directRoute,
+      destination: station,
+      nextStationEtaSeconds: 120,
+      ...(subsurface === undefined ? {} : { subsurface }),
     });
+    const renderSub = (sub?: boolean) =>
+      renderHook(({ s }: { s?: boolean }) => useApnsTripRegistration(baseInputs(s)), {
+        initialProps: { s: sub },
+      });
 
-    it('subsurface 미지정/false면 register payload에 미포함 (graceful)', async () => {
-      renderHook(() =>
-        useApnsTripRegistration({
-          route: directRoute,
-          destination: station,
-          nextStationEtaSeconds: 120,
-        }),
-      );
+    it.each([
+      { label: 'subsurface=true → payload에 포함', sub: true, expected: true },
+      { label: 'subsurface 미지정 → payload에 미포함 (graceful)', sub: undefined, expected: undefined },
+    ])('$label', async ({ sub, expected }) => {
+      renderSub(sub);
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-      expect(mockRegister.mock.calls[0][0].subsurface).toBeUndefined();
+      expect(mockRegister.mock.calls[0][0].subsurface).toBe(expected);
     });
 
     it('OFF→ON 전환 시 즉시 재등록 (deps 반영 — backend threshold 빠른 갱신)', async () => {
-      const { rerender } = renderHook(
-        ({ sub }: { sub: boolean }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            subsurface: sub,
-          }),
-        { initialProps: { sub: false } },
-      );
+      const { rerender } = renderSub(false);
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
       expect(mockRegister.mock.calls[0][0].subsurface).toBeUndefined();
-
-      rerender({ sub: true });
+      rerender({ s: true });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
       expect(mockRegister.mock.calls[1][0].subsurface).toBe(true);
     });
 
     it('token refresh 경로도 최신 subsurface 값을 송신', async () => {
-      const { rerender } = renderHook(
-        ({ sub }: { sub: boolean }) =>
-          useApnsTripRegistration({
-            route: directRoute,
-            destination: station,
-            nextStationEtaSeconds: 120,
-            subsurface: sub,
-          }),
-        { initialProps: { sub: false } },
-      );
+      const { rerender } = renderSub(false);
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-      rerender({ sub: true });
+      rerender({ s: true });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
-
       const listener = mockAddPushTokenListener.mock.calls[0][0];
       await act(async () => {
         listener({ data: 'token-NEW2' });
         await Promise.resolve();
         await Promise.resolve();
       });
-
       const refreshed = mockRegister.mock.calls.find(
         (c) => (c[0] as { token: string }).token === 'token-NEW2',
       );

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -334,6 +334,59 @@ describe('useStationAlarm', () => {
     );
   });
 
+  // #903 (Seam G) — arrivalConfidence가 강등 라벨이면 evaluateAlarmPhase에 degradedConfidence=true 전달
+  describe('#903 degradedConfidence 전달', () => {
+    const route = makeDirectRoute(3, '2');
+    const baseInputs = () =>
+      defaultInputs({
+        route,
+        destination,
+        userLocation: { lat: 37.4, lng: 127.0 },
+        speedMps: 10,
+        accuracyMeters: 100,
+      });
+
+    it('arrivalConfidence="gps-only-underground" → degradedConfidence=true', async () => {
+      renderHook(() =>
+        useStationAlarm({ ...baseInputs(), arrivalConfidence: 'gps-only-underground' }),
+      );
+      await waitFor(() =>
+        expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+          expect.objectContaining({ degradedConfidence: true }),
+          expect.any(Set),
+          undefined,
+          expect.any(Array),
+        ),
+      );
+    });
+
+    it('arrivalConfidence="gps-only" → degradedConfidence=false', async () => {
+      renderHook(() =>
+        useStationAlarm({ ...baseInputs(), arrivalConfidence: 'gps-only' }),
+      );
+      await waitFor(() =>
+        expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+          expect.objectContaining({ degradedConfidence: false }),
+          expect.any(Set),
+          undefined,
+          expect.any(Array),
+        ),
+      );
+    });
+
+    it('arrivalConfidence 미전달 → degradedConfidence=false (graceful)', async () => {
+      renderHook(() => useStationAlarm(baseInputs()));
+      await waitFor(() =>
+        expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+          expect.objectContaining({ degradedConfidence: false }),
+          expect.any(Set),
+          undefined,
+          expect.any(Array),
+        ),
+      );
+    });
+  });
+
   it('passes null etaSeconds when speed is null', async () => {
     const route = makeDirectRoute(3, '2');
     renderHook(() =>

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -52,6 +52,12 @@ export interface UseApnsTripRegistrationInputs {
    * 미설정/false면 기존 #640 게이트 그대로 (lock 없으면 push 0건).
    */
   locklessStationPassed?: boolean;
+  /**
+   * #903 (Seam G) — 기압계 dP/dt가 지하 진입을 시사하는가. true면 backend로 함께 전달되어
+   * consecutiveEtaMissing threshold를 5→10으로 늘려 일시 GPS/arrival 누락에 더 인내한다.
+   * 미설정/false면 기존 threshold(5) 유지 — 기압계 미지원 환경 graceful.
+   */
+  subsurface?: boolean;
 }
 
 /**
@@ -74,6 +80,8 @@ interface RegisterCallInputs {
   currentStation: Station | null;
   boardingLock: BoardingLock | null;
   locklessStationPassed: boolean;
+  /** #903 (Seam G) — 기압계 subsurface 신호. true면 backend threshold 5→10. */
+  subsurface: boolean;
   /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
   createdAt: number;
 }
@@ -114,6 +122,8 @@ async function callRegister(input: RegisterCallInputs) {
     ...(boardingLockMeta ? { boardingLock: boardingLockMeta } : {}),
     // #816 C — 토글 ON이면 backend에 lockless station-passed opt-in 명시. OFF면 필드 누락.
     ...(input.locklessStationPassed ? { locklessStationPassed: true } : {}),
+    // #903 (Seam G) — 기압계 subsurface ON일 때만 송신. OFF/false는 필드 누락(graceful).
+    ...(input.subsurface ? { subsurface: true } : {}),
   });
 }
 
@@ -124,6 +134,7 @@ export function useApnsTripRegistration({
   currentStation = null,
   boardingLock = null,
   locklessStationPassed = false,
+  subsurface = false,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
   // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
@@ -132,9 +143,9 @@ export function useApnsTripRegistration({
   // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
   const boardingLockSig = lockSig(boardingLock);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed });
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed, subsurface });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed };
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed, subsurface };
   });
 
   // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
@@ -192,6 +203,7 @@ export function useApnsTripRegistration({
           currentStation: cs,
           boardingLock: bl,
           locklessStationPassed: lsp,
+          subsurface: sub,
         } = latestInputsRef.current;
         if (!r || !d) return;
         const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
@@ -203,6 +215,7 @@ export function useApnsTripRegistration({
           currentStation: cs,
           boardingLock: bl,
           locklessStationPassed: lsp,
+          subsurface: sub,
           createdAt: resolveTripCreatedAt(sessionKey),
         });
         // #767 — main effect와 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도
@@ -256,6 +269,7 @@ export function useApnsTripRegistration({
         currentStation,
         boardingLock,
         locklessStationPassed,
+        subsurface,
         createdAt: resolveTripCreatedAt(sessionKey),
       });
       // POST 발사 직후(성공/실패 무관) 송신된 lock sig를 기록 — 다음 cycle이 "직전 송신 = lock,
@@ -301,6 +315,9 @@ export function useApnsTripRegistration({
     // token-refresh 경로는 여전히 최신값을 사용한다.
     // #816 C: 토글 변경 시 즉시 backend에 반영해야 하므로 deps에 포함. 사용자가 ON/OFF 전환하면
     // 한 cycle만에 register payload가 갱신된다.
+    // #903 (Seam G): subsurface 변화 시 backend threshold(5→10)를 빨리 갱신해 지하 진입 직후
+    // 일시 GPS/arrival 누락에 인내. useBarometer의 60s 윈도우 평가가 토글 폭주를 자체 흡수하므로
+    // deps churn 위험 낮음. alarmBackend의 dedup hash가 subsurface 미변화 사이클은 POST를 skip.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeSig, destination?.id, boardingLockSig, locklessStationPassed]);
+  }, [routeSig, destination?.id, boardingLockSig, locklessStationPassed, subsurface]);
 }

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -338,12 +338,16 @@ export function useStationAlarm({
     }
 
     const suppressed: AlarmEvent[] = [];
+    // #903 (Seam G) — 기압계 강등 시 evaluateAlarmPhase가 early/transfer 알람을 보류.
+    // arrivalConfidence는 useFusedNearestStation이 'gps-only-underground'로 강등한 값을 그대로 흘려보냄.
+    const degraded = arrivalConfidence === 'gps-only-underground';
     const rawEvent = evaluateAlarmPhase(
       {
         route,
         destinationName: destination.name,
         etaSeconds,
         currentLine: nearestStation?.line ?? null,
+        degradedConfidence: degraded,
       },
       firedAlarmsRef.current,
       undefined,
@@ -415,6 +419,9 @@ export function useStationAlarm({
     skipWarmupGuard,
     dismissSilence,
     clearDismissSilenceAction,
+    // #903 — degraded 평가는 arrivalConfidence에서 파생. 지하 진입으로 'gps-only'→
+    // 'gps-only-underground' 단독 전환 시(다른 deps 정적) 본 effect 재실행되어 차단 정책 즉시 반영.
+    arrivalConfidence,
   ]);
 
   // #396: 도착정보 API 신호로 imminent 발사.
@@ -498,6 +505,8 @@ export function useStationAlarm({
     clearDismissSilenceAction,
     userLocation?.lat,
     userLocation?.lng,
+    // #903 — 위 ETA effect와 동일 사유. degraded 단독 전환에 본 API-신호 effect도 즉시 반응.
+    arrivalConfidence,
   ]);
 
   // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.

--- a/src/features/alarm/utils/__tests__/stationAlarm.test.ts
+++ b/src/features/alarm/utils/__tests__/stationAlarm.test.ts
@@ -409,4 +409,98 @@ describe('evaluateAlarmPhase', () => {
       ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
     });
   });
+
+  describe('#903 Seam G — degradedConfidence (gps-only-underground 강등 시 게이트)', () => {
+    it('degraded=true이고 phase=early이면 발사 보류 (destination/early)', () => {
+      // 강남까지 1정거장 — early 발사 조건. degraded 없으면 발사하지만 degraded=true면 보류.
+      const route = makeDirectRoute(1, '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName, degradedConfidence: true }),
+          new Set(),
+        ),
+      ).toBeNull();
+    });
+
+    it('degraded=false이면 early 정상 발사 (제어군)', () => {
+      const route = makeDirectRoute(1, '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName, degradedConfidence: false }),
+          new Set(),
+        ),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
+    });
+
+    it('degraded=true이고 transfer 카테고리면 모든 phase 보류', () => {
+      // TransferRoute: 환승역 시청 1정거장 (transfer early 발사 조건).
+      const route = makeTransferRoute(1, 5);
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName, degradedConfidence: true }),
+          new Set(),
+        ),
+      ).toBeNull();
+    });
+
+    it('degraded=true여도 destination imminent는 통과 (ETA 거리 게이트가 이중 가드)', () => {
+      const route = makeDirectRoute(1, '2');
+      // early phase가 보류되면 다음 phase(imminent)도 같은 leg 내에서 evaluate되어야 한다.
+      // imminent는 destination 카테고리 + remainingStops<=1 + etaSeconds<=10이면 발사.
+      const got = evaluateAlarmPhase(
+        source({
+          route,
+          destinationName,
+          etaSeconds: 5,
+          degradedConfidence: true,
+        }),
+        new Set(),
+      );
+      expect(got).toEqual({ phaseId: 'imminent', type: 'destination', stationName: '강남' });
+    });
+
+    it('degraded 미전달(undefined)이면 기존 동작 (graceful)', () => {
+      const route = makeDirectRoute(1, '2');
+      expect(
+        evaluateAlarmPhase(source({ route, destinationName }), new Set()),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
+    });
+
+    it('지하 7정거장 시뮬레이션 — degraded 상태에서 모든 cycle 알람 보류, 지상 복귀 후 정상 발사', () => {
+      // 시청 → 을지로3가 7정거장 시나리오. remainingStops 7→1 시뮬레이션 + transfer route 사용.
+      // 지하 동안 degraded=true → transfer/early phase 모두 발사 안 됨 → fired set 0개.
+      // 지상 복귀(degraded=false) 후 1정거장 남았을 때 정상 발사.
+      const fired = new Set<string>();
+      const route = makeTransferRoute(2, 5, '시청'); // 시청 환승 + 도착역 강남
+      // 7→3 정거장 동안 degraded=true (지하), early phase는 stops<=1만 발사이므로 어차피 발사 안 됨.
+      // transfer 카테고리는 stopsToTransfer=2일 때 도달.
+      const transferEarly = evaluateAlarmPhase(
+        source({
+          route: makeTransferRoute(1, 5, '시청'),
+          destinationName,
+          degradedConfidence: true,
+          currentLine: '1', // fromLine 매칭
+        }),
+        fired,
+      );
+      expect(transferEarly).toBeNull(); // transfer 카테고리는 degraded 시 차단
+      expect(fired.size).toBe(0);
+
+      // 지상 복귀 — 같은 stops/route, degraded=false → 정상 발사
+      const transferEarlySurface = evaluateAlarmPhase(
+        source({
+          route: makeTransferRoute(1, 5, '시청'),
+          destinationName,
+          degradedConfidence: false,
+          currentLine: '1',
+        }),
+        fired,
+      );
+      expect(transferEarlySurface).toEqual({
+        phaseId: 'early',
+        type: 'transfer',
+        stationName: '시청',
+      });
+    });
+  });
 });

--- a/src/features/alarm/utils/__tests__/stationAlarm.test.ts
+++ b/src/features/alarm/utils/__tests__/stationAlarm.test.ts
@@ -411,92 +411,53 @@ describe('evaluateAlarmPhase', () => {
   });
 
   describe('#903 Seam G — degradedConfidence (gps-only-underground 강등 시 게이트)', () => {
-    it('degraded=true이고 phase=early이면 발사 보류 (destination/early)', () => {
-      // 강남까지 1정거장 — early 발사 조건. degraded 없으면 발사하지만 degraded=true면 보류.
-      const route = makeDirectRoute(1, '2');
-      expect(
-        evaluateAlarmPhase(
-          source({ route, destinationName, degradedConfidence: true }),
-          new Set(),
-        ),
-      ).toBeNull();
+    const directRoute1 = makeDirectRoute(1, '2');
+    const transferRoute1 = makeTransferRoute(1, 5);
+    const evalDegraded = (
+      overrides: Partial<Parameters<typeof source>[0]>,
+      fired: Set<string> = new Set(),
+    ) => evaluateAlarmPhase(source({ route: directRoute1, destinationName, ...overrides }), fired);
+
+    it.each([
+      { label: 'degraded=true + destination/early → 보류', overrides: { degradedConfidence: true }, expected: null },
+      {
+        label: 'degraded=false → early 정상 발사 (제어군)',
+        overrides: { degradedConfidence: false },
+        expected: { phaseId: 'early', type: 'destination', stationName: '강남' },
+      },
+      {
+        label: 'degraded=true + transfer 카테고리 → 보류',
+        overrides: { route: transferRoute1, degradedConfidence: true },
+        expected: null,
+      },
+      {
+        label: 'degraded=true + imminent(ETA 5s) → destination imminent 통과',
+        overrides: { etaSeconds: 5, degradedConfidence: true },
+        expected: { phaseId: 'imminent', type: 'destination', stationName: '강남' },
+      },
+      {
+        label: 'degraded 미전달(undefined) → 기존 동작 (graceful)',
+        overrides: {},
+        expected: { phaseId: 'early', type: 'destination', stationName: '강남' },
+      },
+    ])('$label', ({ overrides, expected }) => {
+      expect(evalDegraded(overrides)).toEqual(expected);
     });
 
-    it('degraded=false이면 early 정상 발사 (제어군)', () => {
-      const route = makeDirectRoute(1, '2');
-      expect(
-        evaluateAlarmPhase(
-          source({ route, destinationName, degradedConfidence: false }),
-          new Set(),
-        ),
-      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
-    });
-
-    it('degraded=true이고 transfer 카테고리면 모든 phase 보류', () => {
-      // TransferRoute: 환승역 시청 1정거장 (transfer early 발사 조건).
-      const route = makeTransferRoute(1, 5);
-      expect(
-        evaluateAlarmPhase(
-          source({ route, destinationName, degradedConfidence: true }),
-          new Set(),
-        ),
-      ).toBeNull();
-    });
-
-    it('degraded=true여도 destination imminent는 통과 (ETA 거리 게이트가 이중 가드)', () => {
-      const route = makeDirectRoute(1, '2');
-      // early phase가 보류되면 다음 phase(imminent)도 같은 leg 내에서 evaluate되어야 한다.
-      // imminent는 destination 카테고리 + remainingStops<=1 + etaSeconds<=10이면 발사.
-      const got = evaluateAlarmPhase(
-        source({
-          route,
-          destinationName,
-          etaSeconds: 5,
-          degradedConfidence: true,
-        }),
-        new Set(),
-      );
-      expect(got).toEqual({ phaseId: 'imminent', type: 'destination', stationName: '강남' });
-    });
-
-    it('degraded 미전달(undefined)이면 기존 동작 (graceful)', () => {
-      const route = makeDirectRoute(1, '2');
-      expect(
-        evaluateAlarmPhase(source({ route, destinationName }), new Set()),
-      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
-    });
-
-    it('지하 7정거장 시뮬레이션 — degraded 상태에서 모든 cycle 알람 보류, 지상 복귀 후 정상 발사', () => {
-      // 시청 → 을지로3가 7정거장 시나리오. remainingStops 7→1 시뮬레이션 + transfer route 사용.
-      // 지하 동안 degraded=true → transfer/early phase 모두 발사 안 됨 → fired set 0개.
-      // 지상 복귀(degraded=false) 후 1정거장 남았을 때 정상 발사.
+    it('지하→지상 복귀 회귀 (시청 환승 fixture) — degraded 동안 보류, 복귀 후 정상 발사', () => {
+      // 환승역 시청 1정거장 남음. degraded=true → transfer/early 보류 → fired 0건.
+      // degraded=false → 정상 transfer early 발사.
       const fired = new Set<string>();
-      const route = makeTransferRoute(2, 5, '시청'); // 시청 환승 + 도착역 강남
-      // 7→3 정거장 동안 degraded=true (지하), early phase는 stops<=1만 발사이므로 어차피 발사 안 됨.
-      // transfer 카테고리는 stopsToTransfer=2일 때 도달.
-      const transferEarly = evaluateAlarmPhase(
+      const transferContext = (degraded: boolean) =>
         source({
           route: makeTransferRoute(1, 5, '시청'),
           destinationName,
-          degradedConfidence: true,
-          currentLine: '1', // fromLine 매칭
-        }),
-        fired,
-      );
-      expect(transferEarly).toBeNull(); // transfer 카테고리는 degraded 시 차단
-      expect(fired.size).toBe(0);
-
-      // 지상 복귀 — 같은 stops/route, degraded=false → 정상 발사
-      const transferEarlySurface = evaluateAlarmPhase(
-        source({
-          route: makeTransferRoute(1, 5, '시청'),
-          destinationName,
-          degradedConfidence: false,
+          degradedConfidence: degraded,
           currentLine: '1',
-        }),
-        fired,
-      );
-      expect(transferEarlySurface).toEqual({
+        });
+      expect(evaluateAlarmPhase(transferContext(true), fired)).toBeNull();
+      expect(fired.size).toBe(0);
+      expect(evaluateAlarmPhase(transferContext(false), fired)).toEqual({
         phaseId: 'early',
         type: 'transfer',
         stationName: '시청',

--- a/src/features/alarm/utils/stationAlarm.ts
+++ b/src/features/alarm/utils/stationAlarm.ts
@@ -77,6 +77,14 @@ export interface AlarmSource {
   // approachLine이 일치하는 웨이포인트만 phase 평가 대상이 된다.
   // GPS 미확정 등으로 노선을 알 수 없을 때만 명시적으로 null을 전달 — 모든 leg 평가가 skip된다.
   currentLine: LineNumber | null;
+  /**
+   * #903 (Seam G) — fusion confidence가 'gps-only-underground'로 강등됐는가.
+   * true면 transfer 알람과 early phase 알람을 차단한다(지하 GPS는 wifi/cell 삼각측량 fallback일
+   * 가능성이 높아 정거장 단위 추정이 부정확). imminent phase는 destination 카테고리에 한해 통과 —
+   * 거리 게이트(useStationAlarm.isAccuracyAcceptable)와 ETA 임계(10s)가 이중 가드.
+   * 미전달/false면 기존 동작 유지(graceful — 기압계 미지원 환경 호환).
+   */
+  degradedConfidence?: boolean;
 }
 
 /**
@@ -126,6 +134,13 @@ export function evaluateAlarmPhase(
         continue;
       }
       if (!phase.evaluate(context)) continue;
+      // #903 (Seam G) — confidence 'gps-only-underground' 강등 시 early phase / transfer 카테고리 보류.
+      // 지하 진입 진행 중엔 정거장 단위 추정이 부정확해 환승역 미리 알림이나 다음 hop 도달 알람이
+      // 잘못 발사될 위험. imminent + destination만 통과 — useStationAlarm의 accuracy 200m 게이트와
+      // ETA 10s 임계가 이중 가드. dedup으로는 적재하지 않음(silenced — 다음 tick에서 신호 복귀 시 재평가).
+      if (source.degradedConfidence === true) {
+        if (phase.id === 'early' || target.alarmType === 'transfer') continue;
+      }
       return { phaseId: phase.id, type: target.alarmType, stationName: target.name };
     }
     // 매칭된 leg는 현재 사용자가 탑승 중인 구간 — 발사 조건 미달이면 다음 leg를 평가하지 않는다.

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1304,36 +1304,30 @@ describe('useFusedNearestStation', () => {
       mockUsePositions.mockReturnValue(positionRet(null));
     });
 
-    it('subsurface=true + gps-only이면 confidence가 gps-only-underground로 강등', () => {
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, null, null, false, true),
+    const renderWithSub = (sub?: boolean) =>
+      renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, false, sub),
       );
-      expect(result.current.confidence).toBe('gps-only-underground');
-      // source는 그대로 gps — 신호원은 변화 없음. 라벨만 게이트 분기 위해 강등.
+
+    it.each([
+      { label: 'subsurface=true + gps-only → gps-only-underground 강등', sub: true, expected: 'gps-only-underground' },
+      { label: 'subsurface=false → 강등 없음', sub: false, expected: 'gps-only' },
+      { label: 'subsurface 미전달 → 강등 없음 (graceful)', sub: undefined, expected: 'gps-only' },
+    ])('$label', ({ sub, expected }) => {
+      const { result } = renderWithSub(sub);
+      expect(result.current.confidence).toBe(expected);
+    });
+
+    it('subsurface=true + 강등 케이스: source=gps + result=GPS 최근접 유지', () => {
+      const { result } = renderWithSub(true);
       expect(result.current.source).toBe('gps');
-      // result 객체는 GPS 최근접 그대로 유지.
       expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
     });
 
-    it('subsurface=false면 강등 없음', () => {
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, null, null, false, false),
-      );
-      expect(result.current.confidence).toBe('gps-only');
-    });
-
-    it('subsurface 미전달(undefined)이면 강등 없음 (graceful)', () => {
-      const { result } = renderHook(() => useFusedNearestStation());
-      expect(result.current.confidence).toBe('gps-only');
-    });
-
     it('subsurface=true이지만 confidence가 arrival-confirmed면 강등하지 않음', () => {
-      // arrival-confirmed는 자체 검증 신호 — 기압계로 강등하지 않는다 (정책: GPS-only만 강등).
-      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+      // arrival-confirmed는 자체 검증 신호 — 기압계로 강등하지 않는다.
       mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, null, null, false, true),
-      );
+      const { result } = renderWithSub(true);
       expect(result.current.confidence).toBe('arrival-confirmed');
     });
   });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1272,4 +1272,46 @@ describe('useFusedNearestStation', () => {
       }
     });
   });
+
+  describe('#903 Seam G: barometer subsurface confidence 강등', () => {
+    beforeEach(() => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      mockUsePositions.mockReturnValue(positionRet(null));
+    });
+
+    it('subsurface=true + gps-only이면 confidence가 gps-only-underground로 강등', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, false, true),
+      );
+      expect(result.current.confidence).toBe('gps-only-underground');
+      // source는 그대로 gps — 신호원은 변화 없음. 라벨만 게이트 분기 위해 강등.
+      expect(result.current.source).toBe('gps');
+      // result 객체는 GPS 최근접 그대로 유지.
+      expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
+
+    it('subsurface=false면 강등 없음', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, false, false),
+      );
+      expect(result.current.confidence).toBe('gps-only');
+    });
+
+    it('subsurface 미전달(undefined)이면 강등 없음 (graceful)', () => {
+      const { result } = renderHook(() => useFusedNearestStation());
+      expect(result.current.confidence).toBe('gps-only');
+    });
+
+    it('subsurface=true이지만 confidence가 arrival-confirmed면 강등하지 않음', () => {
+      // arrival-confirmed는 자체 검증 신호 — 기압계로 강등하지 않는다 (정책: GPS-only만 강등).
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+      mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, false, true),
+      );
+      expect(result.current.confidence).toBe('arrival-confirmed');
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -3,6 +3,7 @@ import * as Location from 'expo-location';
 import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNearestStation } from '../useNearestStation';
+import * as useStickyStationModule from '../useStickyStation';
 import * as findNearestStationModule from '../../utils/findNearestStation';
 import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../../../shared/constants/location';
 import { BG_LAST_STATION_KEY } from '../../../../shared/constants/storageKeys';
@@ -1163,5 +1164,51 @@ describe('useNearestStation — #852 GPS state & lastFix', () => {
     // 약간 기다려도 stale 시각 유지(jump drop은 setLocationUncertain만 호출).
     await new Promise((r) => setTimeout(r, 10));
     expect(result.current.lastFixAtMs).toBe(validTs);
+  });
+});
+
+describe('useNearestStation — #903 Seam G barometer→sticky', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+    mockGranted();
+  });
+
+  it('기본(미전달) 시 sticky motion.automotive=false', async () => {
+    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
+    renderHook(() => useNearestStation());
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    // 호출 인자 검증: 마지막 호출의 2번째 인자.
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(lastCall[1]).toEqual({ automotive: false });
+    spy.mockRestore();
+  });
+
+  it('barometerSubsurface=true → sticky motion.automotive=true 매핑', async () => {
+    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
+    renderHook(() => useNearestStation({ barometerSubsurface: true }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(lastCall[1]).toEqual({ automotive: true });
+    spy.mockRestore();
+  });
+
+  it('barometerSubsurface=false → sticky motion.automotive=false (graceful)', async () => {
+    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
+    renderHook(() => useNearestStation({ barometerSubsurface: false }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(lastCall[1]).toEqual({ automotive: false });
+    spy.mockRestore();
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1184,31 +1184,16 @@ describe('useNearestStation — #903 Seam G barometer→sticky', () => {
     mockGranted();
   });
 
-  it('기본(미전달) 시 sticky motion.automotive=false', async () => {
+  it.each([
+    { label: '기본(미전달) → automotive=false', input: undefined, expected: false },
+    { label: 'barometerSubsurface=true → automotive=true', input: true, expected: true },
+    { label: 'barometerSubsurface=false → automotive=false (graceful)', input: false, expected: false },
+  ])('$label', async ({ input, expected }) => {
     const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
-    renderHook(() => useNearestStation());
-    await waitFor(() => expect(spy).toHaveBeenCalled());
-    // 호출 인자 검증: 마지막 호출의 2번째 인자.
-    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
-    expect(lastCall[1]).toEqual({ automotive: false });
-    spy.mockRestore();
-  });
-
-  it('barometerSubsurface=true → sticky motion.automotive=true 매핑', async () => {
-    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
-    renderHook(() => useNearestStation({ barometerSubsurface: true }));
+    renderHook(() => useNearestStation(input === undefined ? {} : { barometerSubsurface: input }));
     await waitFor(() => expect(spy).toHaveBeenCalled());
     const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
-    expect(lastCall[1]).toEqual({ automotive: true });
-    spy.mockRestore();
-  });
-
-  it('barometerSubsurface=false → sticky motion.automotive=false (graceful)', async () => {
-    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
-    renderHook(() => useNearestStation({ barometerSubsurface: false }));
-    await waitFor(() => expect(spy).toHaveBeenCalled());
-    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
-    expect(lastCall[1]).toEqual({ automotive: false });
+    expect(lastCall[1]).toEqual({ automotive: expected });
     spy.mockRestore();
   });
 });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -177,8 +177,15 @@ export function useFusedNearestStation(
    * 정적 사용자 케이스에서 positionStability보다 우선 적용. 미전달이면 기존 동작 유지.
    */
   motionStationary?: boolean,
+  /**
+   * #903 (Seam G) — 기압계(useBarometer) dP/dt가 지하 진입을 시사하는지. true면 GPS-only 결과는
+   * 'gps-only-underground'로 confidence 강등해 stationAlarm의 early/transfer phase 발사를 보류.
+   * sticky의 motion unlock 신호와 동일 시그널 — useNearestStation으로도 함께 prop drilling.
+   * 미전달이면 기존 'gps-only' 그대로 (graceful — 기압계 미지원/권한 거절 케이스 호환).
+   */
+  barometerSubsurface?: boolean,
 ): UseFusedNearestStationReturn {
-  const gps = useNearestStation();
+  const gps = useNearestStation({ barometerSubsurface });
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
   // useNearestStation의 userLocation 변경마다 자동 누적/판정.
   const positionStability = usePositionStability(gps.userLocation);
@@ -516,6 +523,14 @@ export function useFusedNearestStation(
     confidence = 'gps-only';
     source = 'gps';
     result = gps.result;
+  }
+
+  // #903 (Seam G) — GPS-only 결과인데 기압계 dP/dt가 지하 진입을 시사하면 'gps-only-underground'로 강등.
+  // 지하 GPS fix는 wifi/cell 삼각측량 fallback이 보고된 좌표일 가능성이 높아 stationAlarm 게이트에서
+  // early/transfer 알람 발사를 별도 정책으로 보류. source는 그대로 'gps' — 신호원 자체는 동일.
+  // 다른 confidence(position-train / boarding-lock / arrival-*)는 강등하지 않음 — 본인의 검증 신호로 우선.
+  if (confidence === 'gps-only' && barometerSubsurface === true) {
+    confidence = 'gps-only-underground';
   }
 
   // 측정(#443): 결정 변화(source/stationId/confidence) 시에만 push.

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -103,7 +103,21 @@ function applyNearestResult(
   }
 }
 
-export function useNearestStation(): UseNearestStationReturn {
+/**
+ * #903 (Seam G) — 외부 신호 입력. 옵셔널이라 기존 호출자(테스트, 다른 화면)는 영향 없음.
+ */
+export interface UseNearestStationInputs {
+  /**
+   * 기압계(useBarometer) dP/dt가 지하 진입을 시사하는지. true면 useStickyStation의 automotive
+   * 입력으로 전달되어 차/지하철 이동 확정 unlock 트리거. subsurface 신호는 OS 가속도계/GPS와
+   * 무관하게 지상→지하 전이를 가장 일찍 감지하므로 sticky의 motion unlock 트리거로 사용한다.
+   */
+  barometerSubsurface?: boolean;
+}
+
+export function useNearestStation(
+  inputs: UseNearestStationInputs = {},
+): UseNearestStationReturn {
   const [result, setResult] = useState<NearestStationResult | null>(null);
   const [variants, setVariants] = useState<Station[]>([]);
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
@@ -376,11 +390,19 @@ export function useNearestStation(): UseNearestStationReturn {
 
   // #876 — 매 fix를 sticky 훅에 전달. lock된 역이 있으면 result를 그것으로 override.
   // fusion candidates는 useFusedNearestStation에서 userLocation 기반으로 별도 계산하므로 영향 없음.
-  const sticky = useStickyStation({
-    candidate: result,
-    accuracyMeters,
-    speedMps,
-  });
+  //
+  // #903 (Seam G) — 기압계 subsurface 신호를 sticky의 automotive 입력으로 매핑.
+  // 지하 진입은 차/지하철 이동 확정과 동등한 unlock 트리거(사용자가 이미 지상 sticky를 떠나 이동 중).
+  // CMMotionActivity native bridge가 자동차 신호를 노출하지 않아 sticky가 motion unlock 미작동
+  // 상태였던 회귀 해소.
+  const sticky = useStickyStation(
+    {
+      candidate: result,
+      accuracyMeters,
+      speedMps,
+    },
+    { automotive: inputs.barometerSubsurface === true },
+  );
 
   const exposed = useMemo<{ result: NearestStationResult | null; source: NearestStationSource }>(
     () => {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -24,6 +24,7 @@ import { getStationDisplayName } from '../shared/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../features/alarm/utils/stationNotification';
 import { useStationAlarm } from '../features/alarm/hooks/useStationAlarm';
 import { useMotionActivity } from '../features/nearest-station/hooks/useMotionActivity';
+import { useBarometer } from '../shared/hooks/useBarometer';
 import { useTripOrigin } from '../features/route/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../features/nearest-station/hooks/useBackgroundLocation';
 import { useApnsTripRegistration } from '../features/alarm/hooks/useApnsTripRegistration';
@@ -139,7 +140,11 @@ export default function HomeScreen() {
   // #728 — CMMotionActivity 신호. 권한 요청/폴링은 hook 내부에서 lifecycle 관리.
   // 미지원/거절 시 false로 고정되어 기존 가드만 동작 (graceful fallback).
   const motionStationary = useMotionActivity();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary);
+  // #903 (Seam G) — 기압계 dP/dt 신호. 미지원/권한 거절은 subsurface=false 고정(graceful).
+  //   1) useFusedNearestStation: 'gps-only' → 'gps-only-underground' 강등 + sticky automotive 트리거.
+  //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).
+  const { subsurface: barometerSubsurface } = useBarometer();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, barometerSubsurface);
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,
@@ -331,6 +336,7 @@ export default function HomeScreen() {
     currentStation: result?.station ?? null,
     boardingLock,
     locklessStationPassed,
+    subsurface: barometerSubsurface,
   });
 
   useEffect(() => {

--- a/src/shared/constants/barometer.ts
+++ b/src/shared/constants/barometer.ts
@@ -48,3 +48,13 @@ export const BAROMETER_RING_BUFFER_TTL_MS = 60_000;
  * 더 높은 주기는 배터리 소모만 키운다.
  */
 export const BAROMETER_SAMPLE_INTERVAL_MS = 1_000;
+
+/**
+ * #903 — subsurface verdict의 hysteresis 확인 샘플 수.
+ *
+ * 임계(0.3hPa) 부근에서 센서 noise로 verdict가 1Hz 토글되면 useBarometer가 setSubsurface을
+ * 매초 반전해 상위 hook re-render 폭주(useApnsTripRegistration register effect, alarmBackend
+ * dedup hash churn)를 일으킨다. N회 연속 동일 verdict를 확인한 후에만 state를 flip해 진동을
+ * 흡수. 3회 × 1초 = 3초 grace는 지하 진입 응답성과 false toggle 차단의 균형.
+ */
+export const BAROMETER_SUBSURFACE_CONFIRM_SAMPLES = 3;

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -16,7 +16,11 @@ jest.mock('expo-sensors', () => ({
 }));
 
 import { useBarometer } from '../useBarometer';
-import { BAROMETER_SAMPLE_INTERVAL_MS } from '../../constants/barometer';
+import {
+  BAROMETER_SAMPLE_INTERVAL_MS,
+  BAROMETER_DPDT_WINDOW_MS,
+  BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+} from '../../constants/barometer';
 import {
   getBarometerReadings,
   resetBarometerState,
@@ -116,5 +120,102 @@ describe('useBarometer (#875)', () => {
     unmount();
     await flush();
     expect(mockRequestPermissions).not.toHaveBeenCalled();
+  });
+
+  it('#903 — 초기 subsurface=false', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    expect(result.current.subsurface).toBe(false);
+  });
+
+  it('#903 — dP/dt가 임계 이상 N회 연속이면 subsurface=true (hysteresis)', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+
+    // listener가 호출하는 Date.now()를 제어하기 위해 spyOn.
+    const baseT = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+
+    // t=0 baseline.
+    act(() => {
+      listener({ pressure: 1013.0, timestamp: 0 });
+    });
+    expect(result.current.subsurface).toBe(false);
+
+    // 30s 경과 + 임계 이상 dP — confirm 3회 누적.
+    for (let i = 0; i < 3; i++) {
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+      act(() => {
+        listener({
+          pressure: 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+          timestamp: 30 + i,
+        });
+      });
+    }
+    expect(result.current.subsurface).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+
+  it('#903 — hysteresis: 임계 근처 1Hz 토글은 setSubsurface 발사 안 함', async () => {
+    // 임계 부근 진동 시 카운터는 누적 못 하고 같은 verdict 1회 도착마다 리셋 → state flip 발생 안 함.
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+    const baseT = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+
+    act(() => {
+      listener({ pressure: 1013.0, timestamp: 0 });
+    });
+
+    // 임계+, 임계-, 임계+ 진동 — 같은 카운트(true)가 2회 누적되나 사이의 false가 reset.
+    for (let i = 0; i < 6; i++) {
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+      const overshoot = i % 2 === 0 ? BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA : 0;
+      act(() => {
+        listener({ pressure: 1013.0 + overshoot, timestamp: 30 + i });
+      });
+    }
+    expect(result.current.subsurface).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  it('#903 — unmount 시 subscription remove + ring buffer reset', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+    const baseT = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+
+    const { result, unmount } = renderHook(() => useBarometer());
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    act(() => {
+      listener({ pressure: 1013.0, timestamp: 0 });
+    });
+    for (let i = 0; i < 3; i++) {
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+      act(() => {
+        listener({
+          pressure: 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+          timestamp: 30 + i,
+        });
+      });
+    }
+    expect(result.current.subsurface).toBe(true);
+
+    unmount();
+    expect(mockRemove).toHaveBeenCalled();
+    expect(getBarometerReadings()).toEqual([]);
+    nowSpy.mockRestore();
   });
 });

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -46,32 +46,32 @@ async function flush(): Promise<void> {
 }
 
 describe('useBarometer (#875)', () => {
-  it('isAvailable=false → permission 요청도 하지 않고 listener 등록 X', async () => {
-    mockIsAvailable.mockResolvedValue(false);
-    renderHook(() => useBarometer());
-    await flush();
-    expect(mockRequestPermissions).not.toHaveBeenCalled();
-    expect(mockAddListener).not.toHaveBeenCalled();
-  });
-
-  it('isAvailable throw → graceful, no-op', async () => {
-    mockIsAvailable.mockRejectedValue(new Error('boom'));
-    renderHook(() => useBarometer());
-    await flush();
-    expect(mockAddListener).not.toHaveBeenCalled();
-  });
-
-  it('권한 거절 → listener 등록 X', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: false });
-    renderHook(() => useBarometer());
-    await flush();
-    expect(mockAddListener).not.toHaveBeenCalled();
-  });
-
-  it('requestPermissions throw → graceful, no-op', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockRejectedValue(new Error('denied'));
+  // permission / availability 게이트 실패는 모두 동일 결과(listener 미등록)로 수렴 — 입력만 달리해 테이블화.
+  it.each<{ label: string; setup: () => void }>([
+    {
+      label: 'isAvailable=false',
+      setup: () => mockIsAvailable.mockResolvedValue(false),
+    },
+    {
+      label: 'isAvailable throw',
+      setup: () => mockIsAvailable.mockRejectedValue(new Error('boom')),
+    },
+    {
+      label: '권한 거절',
+      setup: () => {
+        mockIsAvailable.mockResolvedValue(true);
+        mockRequestPermissions.mockResolvedValue({ granted: false });
+      },
+    },
+    {
+      label: 'requestPermissions throw',
+      setup: () => {
+        mockIsAvailable.mockResolvedValue(true);
+        mockRequestPermissions.mockRejectedValue(new Error('denied'));
+      },
+    },
+  ])('게이트 실패 ($label) → listener 등록 X', async ({ setup }) => {
+    setup();
     renderHook(() => useBarometer());
     await flush();
     expect(mockAddListener).not.toHaveBeenCalled();

--- a/src/shared/hooks/useBarometer.ts
+++ b/src/shared/hooks/useBarometer.ts
@@ -22,18 +22,43 @@
  *     수집·평가 자체만. 송신/게이트 통합은 후속 sub-issue.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Barometer, type BarometerMeasurement } from 'expo-sensors';
 import {
   appendBarometerReading,
+  evaluateLatestSubsurface,
   resetBarometerState,
 } from '../utils/barometerState';
-import { BAROMETER_SAMPLE_INTERVAL_MS } from '../constants/barometer';
+import {
+  BAROMETER_SAMPLE_INTERVAL_MS,
+  BAROMETER_SUBSURFACE_CONFIRM_SAMPLES,
+} from '../constants/barometer';
 
 /**
- * 기압계 수집을 활성화한다. 반환값 없음 — 외부에서는 `evaluateLatestSubsurface()`로 조회.
+ * #903 — 외부 소비자에 노출되는 보조 신호 스냅샷.
+ *
+ * `subsurface`만 노출 — UI/sticky/alarm은 boolean 한 값으로 충분. 디버그용 raw delta는
+ * `getBarometerReadings()` / `evaluateLatestSubsurface()`로 직접 조회.
  */
-export function useBarometer(): void {
+export interface BarometerSignal {
+  /** 30s 윈도우 dP가 임계 이상 상승했는가 (지하 진입 후보). */
+  subsurface: boolean;
+}
+
+/**
+ * 기압계 수집을 활성화하고 최신 dP/dt 평가 결과를 반환한다.
+ *
+ * 미지원/권한 거절/reading 부족: subsurface=false (보수적 fallback).
+ * Seam G(#903) — 호출자(useNearestStation / useFusedNearestStation)는 반환값의 subsurface로
+ * sticky automotive · fusion confidence · backend payload를 한 신호로 일관되게 분기한다.
+ */
+export function useBarometer(): BarometerSignal {
+  const [subsurface, setSubsurface] = useState<boolean>(false);
+  // #903 — hysteresis: 임계 부근 노이즈 진동 흡수. lastEmitted와 다른 verdict가 N회 연속
+  // 들어와야 state flip. lastEmitted과 같은 verdict가 들어오면 카운터 리셋.
+  const lastEmittedRef = useRef<boolean>(false);
+  const pendingCountRef = useRef<number>(0);
+
   useEffect(() => {
     let cancelled = false;
     let subscription: { remove(): void } | null = null;
@@ -48,7 +73,20 @@ export function useBarometer(): void {
       subscription = Barometer.addListener((m: BarometerMeasurement) => {
         // m.timestamp는 boot 이후 초 — wall-clock과 직접 비교 불가.
         // ring buffer는 epoch ms 윈도우로 평가하므로 Date.now()로 직접 stamp.
-        appendBarometerReading({ t: Date.now(), pressureHpa: m.pressure });
+        const now = Date.now();
+        appendBarometerReading({ t: now, pressureHpa: m.pressure });
+        const verdict = evaluateLatestSubsurface(now);
+        const detected = verdict?.detected === true;
+        if (detected === lastEmittedRef.current) {
+          pendingCountRef.current = 0;
+          return;
+        }
+        pendingCountRef.current += 1;
+        if (pendingCountRef.current >= BAROMETER_SUBSURFACE_CONFIRM_SAMPLES) {
+          lastEmittedRef.current = detected;
+          pendingCountRef.current = 0;
+          setSubsurface(detected);
+        }
       });
     };
 
@@ -58,8 +96,12 @@ export function useBarometer(): void {
       cancelled = true;
       if (subscription !== null) subscription.remove();
       resetBarometerState();
+      // 주의: unmount 후 setSubsurface 호출은 React가 무시(unmounted state warning). state는
+      // remount 시 useState 초기값으로 자연 리셋되므로 명시적 reset 불필요.
     };
   }, []);
+
+  return { subsurface };
 }
 
 /** isAvailableAsync 예외를 false로 폴백 — 일부 시뮬레이터에서 throw. */

--- a/src/shared/types/fusion.ts
+++ b/src/shared/types/fusion.ts
@@ -9,6 +9,11 @@
  * 신호원(arrival/position/route-progress)은 source 필드로 분리 식별.
  * 'route-progress'는 1D map matching 진행도 기반(Phase A) — GPS 점프에 면역이지만
  * 도착/위치 API와 달리 자체 검증 신호가 아니라 별도 confidence로 둔다.
+ *
+ * #903 (Seam G) — 'gps-only-underground' 추가. GPS-only 결과인데 기압계 dP/dt가 지하 진입을
+ * 시사하면 강등 라벨을 붙여 early/transfer 알람 발사를 보류한다(stationAlarm 게이트).
+ * gps-only와 동급 신뢰지만 지하 fix는 wifi/cell 삼각측량 fallback이 보고된 좌표일 가능성이 높아
+ * 알람 정확도 측면에서 별도 분기가 필요하다.
  */
 export type FusionConfidence =
   | 'boarding-lock'
@@ -17,7 +22,8 @@ export type FusionConfidence =
   | 'arrival-confirmed'
   | 'arrival-arriving'
   | 'route-progress'
-  | 'gps-only';
+  | 'gps-only'
+  | 'gps-only-underground';
 
 /**
  * fusion 신호 출처. position-train이 가장 정확(특정 trainNo 추적 → 현재역),


### PR DESCRIPTION
Parent: #896

## Why
2026-06-05 점검: Sticky Station(#876)은 머지됐지만 `automotive` 입력 미연결 → motion unlock 미작동. 지하 정확도는 GPS만으론 한계 — #875 기압계 dP/dt 적극 활용 필요.

## 변경
1. **Sticky wire-up** — useNearestStation/useFusedNearestStation이 `useBarometer().subsurface`를 Sticky의 automotive 입력에 전달.
2. **Confidence 강등** — `'gps-only-underground'` 신규. fusion confidence가 'gps-only'이고 subsurface=true면 강등.
3. **알람 게이트** — `evaluateAlarmPhase`가 degradedConfidence=true 시 early phase + transfer 카테고리 차단. destination/imminent는 통과.
4. **Hysteresis** — `BAROMETER_SUBSURFACE_CONFIRM_SAMPLES=3`. 임계 부근 1Hz 진동 흡수.
5. **Backend** — `consecutiveEtaMissing` threshold subsurface=true → 10, else 5. true→false 전환 시 카운터 리셋(지상 복귀 시 trip 즉시 종료 회귀 차단).
6. **deps 보강** — useStationAlarm의 ETA·API effect 둘 다에 arrivalConfidence 추가.
7. **stale import 정정** — `app/_layout.tsx`의 backgroundLocationTask 경로.

## 자가 리뷰 P1 4건 반영
- #1 useStationAlarm deps arrivalConfidence 누락 → 추가
- #2 useBarometer 임계 진동 → 3-sample hysteresis
- #3 subsurface true→false 시 누적 카운터 미리셋 → 리셋 로직 + 회귀 테스트 2건
- #4 destination/early 차단 — spec 의도와 일치(보수적 보류) → 코드 유지, 본문에 문서화

## Acceptance
- [x] automotive=true 입력 시 Sticky unlock-motion (Hysteresis 3샘플 후)
- [x] subsurface=true + GPS-only → confidence 강등 + early/transfer 차단
- [x] backend threshold 5→10 인내, 복귀 시 카운터 리셋
- [x] 100% 커버리지, 3525 tests
- [x] type-check 통과

Closes #903