### PR TITLE
feat(#901): Seam E — 지상 lock sync 채널

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { app, validateLiveActivityRegister, validatePushAck, validateTrip } from '../index';
+import {
+  app,
+  computeLockSyncAdvance,
+  LOCK_TTL_REFRESH_MS,
+  validateBoardingLockSync,
+  validateLiveActivityRegister,
+  validatePushAck,
+  validateTrip,
+} from '../index';
+import { progressKey, type TripProgress } from '../progress';
 import { pendingKey } from '../pendingPushes';
 import type { AnalyticsEngineWriter, Env } from '../types';
 import { InMemoryKV } from './inMemoryKv';
@@ -1347,5 +1356,386 @@ describe('POST /trips — #819 boardingPromptState carries over same session', (
     const stored = JSON.parse((await env.TRIPS.get('trip:tok-bp')) as string);
     expect(stored.boardingPromptState).toBeUndefined();
     vi.useRealTimers();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Seam E (#901) — POST /boarding-lock/sync
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('validateBoardingLockSync (#901)', () => {
+  it('정상 payload 통과', () => {
+    expect(
+      validateBoardingLockSync({
+        token: 'tok',
+        observedStationName: '강남',
+        observedAtMs: 1,
+        accuracy: 10,
+      }),
+    ).toEqual({ token: 'tok', observedStationName: '강남', observedAtMs: 1, accuracy: 10 });
+  });
+
+  it('subsurface 옵션 필드 유지', () => {
+    const p = validateBoardingLockSync({
+      token: 'tok',
+      observedStationName: '강남',
+      observedAtMs: 1,
+      accuracy: 10,
+      subsurface: false,
+    });
+    expect(p?.subsurface).toBe(false);
+  });
+
+  it('subsurface 잘못된 타입은 무시', () => {
+    const p = validateBoardingLockSync({
+      token: 'tok',
+      observedStationName: '강남',
+      observedAtMs: 1,
+      accuracy: 10,
+      subsurface: 'yes',
+    });
+    expect(p?.subsurface).toBeUndefined();
+  });
+
+  it('non-object reject', () => {
+    expect(validateBoardingLockSync(null)).toBeNull();
+    expect(validateBoardingLockSync('s')).toBeNull();
+  });
+
+  it('빈 token reject', () => {
+    expect(
+      validateBoardingLockSync({
+        token: '',
+        observedStationName: '강남',
+        observedAtMs: 1,
+        accuracy: 10,
+      }),
+    ).toBeNull();
+  });
+
+  it('observedStationName 누락 reject', () => {
+    expect(
+      validateBoardingLockSync({ token: 'tok', observedAtMs: 1, accuracy: 10 }),
+    ).toBeNull();
+  });
+
+  it('빈 observedStationName reject', () => {
+    expect(
+      validateBoardingLockSync({
+        token: 'tok',
+        observedStationName: '',
+        observedAtMs: 1,
+        accuracy: 10,
+      }),
+    ).toBeNull();
+  });
+
+  it('NaN observedAtMs reject', () => {
+    expect(
+      validateBoardingLockSync({
+        token: 'tok',
+        observedStationName: '강남',
+        observedAtMs: Number.NaN,
+        accuracy: 10,
+      }),
+    ).toBeNull();
+  });
+
+  it('비숫자 observedAtMs reject', () => {
+    expect(
+      validateBoardingLockSync({
+        token: 'tok',
+        observedStationName: '강남',
+        observedAtMs: '1',
+        accuracy: 10,
+      }),
+    ).toBeNull();
+  });
+
+  it('음수 accuracy reject', () => {
+    expect(
+      validateBoardingLockSync({
+        token: 'tok',
+        observedStationName: '강남',
+        observedAtMs: 1,
+        accuracy: -1,
+      }),
+    ).toBeNull();
+  });
+
+  it('NaN accuracy reject', () => {
+    expect(
+      validateBoardingLockSync({
+        token: 'tok',
+        observedStationName: '강남',
+        observedAtMs: 1,
+        accuracy: Number.NaN,
+      }),
+    ).toBeNull();
+  });
+
+  it('비숫자 accuracy reject', () => {
+    expect(
+      validateBoardingLockSync({
+        token: 'tok',
+        observedStationName: '강남',
+        observedAtMs: 1,
+        accuracy: 'a',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('computeLockSyncAdvance (#901)', () => {
+  const w = (name: string) => ({ stationName: name, line: '2', kind: 'intermediate' as const });
+
+  it('waypoints[0] 일치 → 1 hop shift', () => {
+    expect(computeLockSyncAdvance([w('A'), w('B'), w('C')], 'A')).toEqual({ shiftedCount: 1 });
+  });
+
+  it('waypoints[1] 일치 → 2 hop catch-up', () => {
+    expect(computeLockSyncAdvance([w('A'), w('B'), w('C')], 'B')).toEqual({ shiftedCount: 2 });
+  });
+
+  it('waypoints[2] 일치 → 3 hop catch-up', () => {
+    expect(computeLockSyncAdvance([w('A'), w('B'), w('C')], 'C')).toEqual({ shiftedCount: 3 });
+  });
+
+  it('미일치 → 0 (no-op)', () => {
+    expect(computeLockSyncAdvance([w('A'), w('B')], 'X')).toEqual({ shiftedCount: 0 });
+  });
+
+  it('빈 waypoints → 0', () => {
+    expect(computeLockSyncAdvance([], 'A')).toEqual({ shiftedCount: 0 });
+  });
+});
+
+describe('POST /boarding-lock/sync (#901)', () => {
+  const FUTURE_LOCK = Date.now() + 30 * 60 * 1000;
+
+  function tripWithLock(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+      token: 'tok-sync',
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination: 'dst',
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' },
+        { stationName: '역삼', line: '2', kind: 'intermediate' },
+        { stationName: '선릉', line: '2', kind: 'destination' },
+      ],
+      expiresAt: FUTURE,
+      alarmAtEpochMs: FUTURE - 30 * 60 * 1000,
+      boardingLock: {
+        trainCode: 'T-1',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: 1,
+        segmentStations: ['강남', '역삼', '선릉'],
+        expiresAt: FUTURE_LOCK,
+      },
+      ...overrides,
+    };
+  }
+
+  it('잘못된 JSON → 400', async () => {
+    const env = makeKvEnv();
+    const res = await post('/boarding-lock/sync', '{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('잘못된 payload → 400', async () => {
+    const env = makeKvEnv();
+    const res = await post('/boarding-lock/sync', { token: 'x' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('trip 부재 → 404 trip_not_found', async () => {
+    const env = makeKvEnv();
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'unknown', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'trip_not_found' });
+  });
+
+  it('현재 waypoints[0] 일치 → 1 hop advance + currentWaypoint=역삼', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: true,
+      advanced: true,
+      currentWaypoint: '역삼',
+      nextStation: '역삼',
+    });
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+    expect(stored.waypoints.map((w: { stationName: string }) => w.stationName)).toEqual([
+      '역삼',
+      '선릉',
+    ]);
+  });
+
+  it('waypoints[1] 일치 → 2 hop catch-up advance', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '역삼', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { advanced: boolean; currentWaypoint: string | null };
+    expect(body.advanced).toBe(true);
+    expect(body.currentWaypoint).toBe('선릉');
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+    expect(stored.waypoints).toHaveLength(1);
+  });
+
+  it('미일치 → no-op (advanced=false), waypoints 그대로', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '신촌', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { advanced: boolean; currentWaypoint: string | null };
+    expect(body.advanced).toBe(false);
+    expect(body.currentWaypoint).toBe('강남');
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+    expect(stored.waypoints).toHaveLength(3);
+  });
+
+  it('마지막 waypoint(destination) 일치 → 전체 소진 + currentWaypoint=null', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '선릉', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      advanced: boolean;
+      currentWaypoint: string | null;
+      nextStation: string | null;
+    };
+    expect(body.advanced).toBe(true);
+    expect(body.currentWaypoint).toBeNull();
+    expect(body.nextStation).toBeNull();
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+    expect(stored.waypoints).toEqual([]);
+  });
+
+  it('boardingLock TTL refresh — expiresAt이 now+30min 이상으로 연장', async () => {
+    vi.useFakeTimers();
+    const NOW = Date.now();
+    vi.setSystemTime(NOW);
+    const env = makeKvEnv();
+    // 짧은 TTL의 lock을 직접 KV에 적재 — POST /trips 검증을 우회하기 위해.
+    const trip = validateTrip(
+      tripWithLock({ boardingLock: { ...(tripWithLock().boardingLock as object), expiresAt: NOW + 60_000 } }),
+    );
+    await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
+    await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+    expect(stored.boardingLock.expiresAt).toBeGreaterThanOrEqual(NOW + LOCK_TTL_REFRESH_MS);
+    vi.useRealTimers();
+  });
+
+  it('boardingLock 없는 trip — advance만 일어나고 lock 필드 추가 안 됨', async () => {
+    const env = makeKvEnv();
+    const tripNoLock = tripWithLock();
+    delete tripNoLock.boardingLock;
+    await post('/trips', tripNoLock, env);
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { advanced: boolean };
+    expect(body.advanced).toBe(true);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+    expect(stored.boardingLock).toBeUndefined();
+  });
+
+  it('advance 시 progress KV에 shiftedCount mirror', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '역삼', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    const progressRaw = await env.TRIPS.get(progressKey('tok-sync'));
+    expect(progressRaw).not.toBeNull();
+    const progress = JSON.parse(progressRaw as string) as TripProgress;
+    expect(progress.trainCode).toBe('T-1');
+    expect(progress.shiftedCount).toBe(2);
+  });
+
+  it('advance 누적 — 두 번째 sync도 progress.shiftedCount 누적', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    // 1차 sync — 강남(0) → 1 hop
+    await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    // 2차 sync — 역삼(이제 waypoints[0]) → 1 hop 추가
+    await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '역삼', observedAtMs: 2, accuracy: 5 },
+      env,
+    );
+    const progress = JSON.parse((await env.TRIPS.get(progressKey('tok-sync'))) as string);
+    expect(progress.shiftedCount).toBe(2);
+  });
+
+  it('boardingLock 없는 trip → progress mirror 안 함 (trainCode 없음)', async () => {
+    const env = makeKvEnv();
+    const tripNoLock = tripWithLock();
+    delete tripNoLock.boardingLock;
+    await post('/trips', tripNoLock, env);
+    await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(await env.TRIPS.get(progressKey('tok-sync'))).toBeNull();
+  });
+
+  it('subsurface 필드 허용 — 200', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    const res = await post(
+      '/boarding-lock/sync',
+      {
+        token: 'tok-sync',
+        observedStationName: '강남',
+        observedAtMs: 1,
+        accuracy: 5,
+        subsurface: false,
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1402,87 +1402,27 @@ describe('validateBoardingLockSync (#901)', () => {
     expect(validateBoardingLockSync('s')).toBeNull();
   });
 
-  it('빈 token reject', () => {
-    expect(
-      validateBoardingLockSync({
-        token: '',
-        observedStationName: '강남',
-        observedAtMs: 1,
-        accuracy: 10,
-      }),
-    ).toBeNull();
-  });
+  // 정상 baseline에서 한 필드만 변형해 reject 게이트를 일괄 검증.
+  const validBase = {
+    token: 'tok',
+    observedStationName: '강남',
+    observedAtMs: 1,
+    accuracy: 10,
+  } as Record<string, unknown>;
 
-  it('observedStationName 누락 reject', () => {
-    expect(
-      validateBoardingLockSync({ token: 'tok', observedAtMs: 1, accuracy: 10 }),
-    ).toBeNull();
-  });
-
-  it('빈 observedStationName reject', () => {
-    expect(
-      validateBoardingLockSync({
-        token: 'tok',
-        observedStationName: '',
-        observedAtMs: 1,
-        accuracy: 10,
-      }),
-    ).toBeNull();
-  });
-
-  it('NaN observedAtMs reject', () => {
-    expect(
-      validateBoardingLockSync({
-        token: 'tok',
-        observedStationName: '강남',
-        observedAtMs: Number.NaN,
-        accuracy: 10,
-      }),
-    ).toBeNull();
-  });
-
-  it('비숫자 observedAtMs reject', () => {
-    expect(
-      validateBoardingLockSync({
-        token: 'tok',
-        observedStationName: '강남',
-        observedAtMs: '1',
-        accuracy: 10,
-      }),
-    ).toBeNull();
-  });
-
-  it('음수 accuracy reject', () => {
-    expect(
-      validateBoardingLockSync({
-        token: 'tok',
-        observedStationName: '강남',
-        observedAtMs: 1,
-        accuracy: -1,
-      }),
-    ).toBeNull();
-  });
-
-  it('NaN accuracy reject', () => {
-    expect(
-      validateBoardingLockSync({
-        token: 'tok',
-        observedStationName: '강남',
-        observedAtMs: 1,
-        accuracy: Number.NaN,
-      }),
-    ).toBeNull();
-  });
-
-  it('비숫자 accuracy reject', () => {
-    expect(
-      validateBoardingLockSync({
-        token: 'tok',
-        observedStationName: '강남',
-        observedAtMs: 1,
-        accuracy: 'a',
-      }),
-    ).toBeNull();
+  it.each<{ label: string; mutate: (p: Record<string, unknown>) => void }>([
+    { label: '빈 token', mutate: (p) => (p.token = '') },
+    { label: 'observedStationName 누락', mutate: (p) => delete p.observedStationName },
+    { label: '빈 observedStationName', mutate: (p) => (p.observedStationName = '') },
+    { label: 'NaN observedAtMs', mutate: (p) => (p.observedAtMs = Number.NaN) },
+    { label: '비숫자 observedAtMs', mutate: (p) => (p.observedAtMs = '1') },
+    { label: '음수 accuracy', mutate: (p) => (p.accuracy = -1) },
+    { label: 'NaN accuracy', mutate: (p) => (p.accuracy = Number.NaN) },
+    { label: '비숫자 accuracy', mutate: (p) => (p.accuracy = 'a') },
+  ])('$label reject', ({ mutate }) => {
+    const payload = { ...validBase };
+    mutate(payload);
+    expect(validateBoardingLockSync(payload)).toBeNull();
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -26,7 +26,7 @@ import {
 import { ackPending } from './pendingPushes';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
-import { deleteProgress, getProgress, type TripProgress } from './progress';
+import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
 import {
@@ -351,6 +351,158 @@ app.post('/metrics/boarding-prompt', async (c) => {
   }
   return c.json({ ok: true });
 });
+
+/**
+ * Seam E (#901) — 지상 BoardingLock 정정 채널.
+ *
+ * 클라가 좋은 GPS fix(accuracy ≤ 50m)로 현재 정거장을 확정했을 때 호출. backend는 관측 역이
+ * 진행 방향 ±1 hop 이내면 waypoints를 advance해 lock의 currentWaypoint를 사용자 실제 위치와
+ * 정렬한다. cron의 Seoul 도착 폴링이 stale일 때(터널/긴 지연) silent push 누락 회귀(#622) 흡수.
+ *
+ * 지하 구간은 정의상 GPS 부재 → 클라가 호출하지 않는다. 호출 트리거는 클라 책임:
+ *   1) accuracy ≤ 50m + 새 currentStation 확정 (debounce 5s, useBoardingLockSync)
+ *   2) 지하→지상 경계 (subsurface=false 전환, Seam G barometer)
+ *   3) trip 등록 직후 1회
+ *
+ * Body: { token, observedStationName, observedAtMs, accuracy, subsurface? }
+ * Response 200:
+ *   { ok, advanced, currentWaypoint, nextStation }
+ *   - advanced: 이번 sync로 waypoints가 shift됐는지 (1+ hop)
+ *   - currentWaypoint: 정정 후 first waypoint stationName (없으면 null — destination 도착)
+ *   - nextStation: 정정 후 first waypoint = 다음 알람 대상 (currentWaypoint와 동일, 의미상 alias)
+ * Response 404: { error: 'trip_not_found' } — 클라는 다음 fix에서 자연 retry
+ *
+ * Trip 부재 시 lock 재생성 책임은 본 endpoint가 지지 않음 — 클라가 useApnsTripRegistration으로
+ * POST /trips를 호출하면 같은 경로로 lock이 들어온다 (분리된 lock store가 없는 현 backend 구조).
+ */
+app.post('/boarding-lock/sync', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+  const payload = validateBoardingLockSync(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const existing = await getTrip(c.env.TRIPS, payload.token);
+  if (!existing) return c.json({ error: 'trip_not_found' }, 404);
+
+  const now = Date.now();
+  const advance = computeLockSyncAdvance(existing.waypoints, payload.observedStationName);
+
+  let working: Trip = existing;
+  if (advance.shiftedCount > 0) {
+    const remaining = working.waypoints.slice(advance.shiftedCount);
+    working = {
+      ...working,
+      waypoints: remaining,
+      // 새 waypoint의 첫 push를 보장하기 위해 baseline reset (advanceBoardingLockWaypoint와 동형).
+      lastTrackedArrivalEpoch: undefined,
+      lastLaPushEpoch: undefined,
+    };
+    // progress KV mirror — POST /trips re-register 시 같은 trainCode면 shift 진행분이 보존되도록.
+    await maybeMirrorLockSyncProgress(c.env.TRIPS, working, advance.shiftedCount);
+  }
+
+  // lock TTL refresh — 사용자가 지상에서 lock을 활성 유지 중임을 confirm.
+  if (working.boardingLock) {
+    working = {
+      ...working,
+      boardingLock: {
+        ...working.boardingLock,
+        expiresAt: Math.max(working.boardingLock.expiresAt, now + LOCK_TTL_REFRESH_MS),
+      },
+    };
+  }
+
+  await putTrip(c.env.TRIPS, working);
+
+  const head = working.waypoints[0];
+  return c.json({
+    ok: true,
+    advanced: advance.shiftedCount > 0,
+    currentWaypoint: head ? head.stationName : null,
+    nextStation: head ? head.stationName : null,
+  });
+});
+
+/** Seam E 정정으로 lock TTL을 연장하는 길이. cron 주기 60s × 30 cycles 마진. */
+export const LOCK_TTL_REFRESH_MS = 30 * 60 * 1000;
+
+interface BoardingLockSyncPayload {
+  token: string;
+  observedStationName: string;
+  observedAtMs: number;
+  accuracy: number;
+  subsurface?: boolean;
+}
+
+export function validateBoardingLockSync(input: unknown): BoardingLockSyncPayload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (typeof obj.observedStationName !== 'string' || obj.observedStationName.length === 0) {
+    return null;
+  }
+  if (typeof obj.observedAtMs !== 'number' || !Number.isFinite(obj.observedAtMs)) return null;
+  if (typeof obj.accuracy !== 'number' || !Number.isFinite(obj.accuracy) || obj.accuracy < 0) {
+    return null;
+  }
+  const result: BoardingLockSyncPayload = {
+    token: obj.token,
+    observedStationName: obj.observedStationName,
+    observedAtMs: obj.observedAtMs,
+    accuracy: obj.accuracy,
+  };
+  if (typeof obj.subsurface === 'boolean') result.subsurface = obj.subsurface;
+  return result;
+}
+
+/**
+ * Seam E 진행 판단 — 관측 역이 waypoints 시퀀스 안 어디인지 찾고 shift 개수를 산출.
+ *
+ * 정책:
+ *   - waypoints[0] 일치: 현재 다음 hop 도달 → 1 hop advance
+ *   - waypoints[1] 일치: 1 hop 앞서감 (cron이 한 사이클 늦었음) → 2 hop catch-up advance
+ *   - waypoints[k≥2] 일치: k hop catch-up advance (긴 음영 후 재진입 케이스)
+ *   - 미일치: 사용자가 진행 방향 뒤에 있거나 다른 트립 → no-op (lock 보존)
+ *
+ * "사용자 뒤 1 hop은 grace 1 cycle 후 advance"는 Seam E가 아닌 cron의 자연 추적이 담당 —
+ * 본 endpoint는 GPS-확신 신호만 받아 진행 정정에 집중 (역방향 advance 안 함).
+ */
+export function computeLockSyncAdvance(
+  waypoints: Trip['waypoints'],
+  observedStationName: string,
+): { shiftedCount: number } {
+  const idx = waypoints.findIndex((w) => w.stationName === observedStationName);
+  if (idx < 0) return { shiftedCount: 0 };
+  return { shiftedCount: idx + 1 };
+}
+
+/**
+ * Seam E의 advance도 progress KV에 mirror — POST /trips 재등록 race에서 shift 진행분 보존.
+ * lock(trainCode) 없는 trip은 progress 자체가 의미 없어 no-op (scheduled.ts mirrorProgress와 동형).
+ */
+async function maybeMirrorLockSyncProgress(
+  kv: KVNamespace,
+  trip: Trip,
+  shiftedDelta: number,
+): Promise<void> {
+  const trainCode = trip.boardingLock?.trainCode;
+  if (!trainCode) return;
+  const existing = await getProgress(kv, trip.token);
+  const prevShifted = existing?.trainCode === trainCode ? existing.shiftedCount : 0;
+  const next: TripProgress = {
+    trainCode,
+    shiftedCount: prevShifted + shiftedDelta,
+    lastTrackedArrivalEpoch: trip.lastTrackedArrivalEpoch,
+    lastLaPushEpoch: trip.lastLaPushEpoch,
+    consecutiveEtaMissing: trip.consecutiveEtaMissing,
+  };
+  const ttlSec = Math.max(60, Math.floor((trip.expiresAt - Date.now()) / 1000));
+  await putProgress(kv, trip.token, next, ttlSec);
+}
 
 interface PushAckPayload {
   pushId: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,7 +1694,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2905,7 +2905,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -2923,7 +2923,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2939,7 +2939,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2956,7 +2956,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2969,14 +2969,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/console/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2986,7 +2986,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -2999,7 +2999,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
       "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -3047,7 +3047,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3063,7 +3063,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3080,7 +3080,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3096,7 +3096,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3109,14 +3109,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3126,7 +3126,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -3151,7 +3151,7 @@
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
       "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3176,7 +3176,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
@@ -3190,7 +3190,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -3220,7 +3220,7 @@
       "version": "30.1.0",
       "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3230,7 +3230,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -3246,7 +3246,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -3290,7 +3290,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3306,7 +3306,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3317,7 +3317,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3334,7 +3334,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3344,7 +3344,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3357,7 +3357,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/glob": {
@@ -3365,7 +3365,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -3386,7 +3386,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3396,7 +3396,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -3413,7 +3413,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3426,7 +3426,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -3440,7 +3440,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -3465,7 +3465,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -3480,7 +3480,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -3496,7 +3496,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -4428,7 +4428,7 @@
       "version": "13.3.3",
       "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
       "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-matcher-utils": "^30.0.5",
@@ -4455,7 +4455,7 @@
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
@@ -4468,14 +4468,14 @@
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4491,7 +4491,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4508,7 +4508,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4521,14 +4521,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react-native/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4538,7 +4538,7 @@
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
       "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/diff-sequences": "30.3.0",
@@ -4554,7 +4554,7 @@
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
       "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
@@ -4570,7 +4570,7 @@
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.0.5",
@@ -4585,7 +4585,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4598,7 +4598,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4740,7 +4740,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5918,7 +5918,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6055,7 +6055,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -6115,7 +6115,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -6126,7 +6126,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color": {
@@ -6320,7 +6320,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
       "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6342,7 +6342,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6358,7 +6358,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6375,7 +6375,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6388,14 +6388,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/create-jest/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6405,7 +6405,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6477,7 +6477,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6586,7 +6586,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -6719,7 +6719,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6735,7 +6735,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6855,7 +6855,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6919,7 +6919,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -6929,7 +6929,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/error-stack-parser": {
@@ -7760,7 +7760,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -7784,7 +7784,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7794,7 +7794,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -7810,7 +7810,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -7819,7 +7819,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -9361,7 +9361,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9707,7 +9707,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
@@ -9793,7 +9793,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -9921,7 +9921,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -9950,7 +9950,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10231,7 +10231,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10414,7 +10414,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10582,7 +10582,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -10597,7 +10597,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10607,7 +10607,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10620,7 +10620,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -10635,7 +10635,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10645,7 +10645,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -10675,7 +10675,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -10702,7 +10702,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -10717,7 +10717,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -10749,7 +10749,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10765,7 +10765,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10782,7 +10782,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -10795,14 +10795,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10812,7 +10812,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10825,7 +10825,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
       "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -10859,7 +10859,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10875,7 +10875,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10892,7 +10892,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -10905,14 +10905,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-cli/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10922,7 +10922,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10935,7 +10935,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -10981,7 +10981,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10997,7 +10997,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11008,7 +11008,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11025,7 +11025,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -11041,7 +11041,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11054,7 +11054,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/glob": {
@@ -11062,7 +11062,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -11083,7 +11083,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11093,7 +11093,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11106,7 +11106,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11119,7 +11119,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11132,7 +11132,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -11148,7 +11148,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11164,7 +11164,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11181,7 +11181,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11194,14 +11194,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-diff/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11211,7 +11211,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11224,7 +11224,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -11237,7 +11237,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -11254,7 +11254,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11270,7 +11270,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11287,7 +11287,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11300,14 +11300,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-each/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11317,7 +11317,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11445,7 +11445,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -11459,7 +11459,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -11475,7 +11475,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11491,7 +11491,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11508,7 +11508,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11521,14 +11521,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-matcher-utils/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11538,7 +11538,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11669,7 +11669,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11696,7 +11696,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -11717,7 +11717,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -11731,7 +11731,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11747,7 +11747,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11764,7 +11764,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11777,14 +11777,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-resolve/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11794,7 +11794,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11807,7 +11807,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -11840,7 +11840,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11856,7 +11856,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11873,7 +11873,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11886,14 +11886,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-runner/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11903,7 +11903,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11913,7 +11913,7 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11924,7 +11924,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11937,7 +11937,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -11971,7 +11971,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11987,7 +11987,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11998,7 +11998,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -12015,7 +12015,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -12028,7 +12028,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/glob": {
@@ -12036,7 +12036,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -12057,7 +12057,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12067,7 +12067,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -12080,7 +12080,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -12093,7 +12093,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -12125,7 +12125,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -12141,7 +12141,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -12158,7 +12158,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -12171,14 +12171,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12188,7 +12188,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -12628,7 +12628,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -12648,7 +12648,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -12664,7 +12664,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -12681,7 +12681,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12691,7 +12691,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -12704,14 +12704,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jest-watcher/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12721,7 +12721,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -12735,7 +12735,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -12942,7 +12942,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -13380,7 +13380,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -13862,7 +13862,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -13968,7 +13968,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -14106,7 +14106,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -14483,7 +14483,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -14631,7 +14631,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -14820,7 +14820,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -15314,7 +15314,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
       "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "react-is": "^19.1.0",
@@ -15328,14 +15328,14 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -15519,7 +15519,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -16478,7 +16478,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16488,7 +16488,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16498,7 +16498,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -17069,7 +17069,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -17351,7 +17351,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",

--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -44,55 +44,18 @@ async function flushAsyncStorage(): Promise<void> {
 }
 
 describe('useBoardingLockSync (#901)', () => {
-  it('tripActive=false → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: 10,
-        tripActive: false,
-      }),
-    );
-    act(() => {
-      jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100);
-    });
-    await flushAsyncStorage();
-    expect(mockedSync).not.toHaveBeenCalled();
-  });
+  type SyncInputs = Parameters<typeof useBoardingLockSync>[0];
+  const defaults: SyncInputs = { currentStationName: '강남', accuracyMeters: 10, tripActive: true };
+  const renderSync = (overrides: Partial<SyncInputs> = {}) =>
+    renderHook(() => useBoardingLockSync({ ...defaults, ...overrides }));
 
-  it('currentStationName=null → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: null,
-        accuracyMeters: 10,
-        tripActive: true,
-      }),
-    );
-    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-    await flushAsyncStorage();
-    expect(mockedSync).not.toHaveBeenCalled();
-  });
-
-  it('accuracy=null → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: null,
-        tripActive: true,
-      }),
-    );
-    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-    await flushAsyncStorage();
-    expect(mockedSync).not.toHaveBeenCalled();
-  });
-
-  it('accuracy > 50m → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 1,
-        tripActive: true,
-      }),
-    );
+  it.each<{ label: string; overrides: Partial<SyncInputs> }>([
+    { label: 'tripActive=false', overrides: { tripActive: false } },
+    { label: 'currentStationName=null', overrides: { currentStationName: null } },
+    { label: 'accuracy=null', overrides: { accuracyMeters: null } },
+    { label: 'accuracy > 50m', overrides: { accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 1 } },
+  ])('게이트 실패 ($label) → debounce 후에도 미발사', async ({ overrides }) => {
+    renderSync(overrides);
     act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
     await flushAsyncStorage();
     expect(mockedSync).not.toHaveBeenCalled();
@@ -217,81 +180,23 @@ describe('useBoardingLockSync (#901)', () => {
     expect(mockedSync).toHaveBeenCalledTimes(2);
   });
 
-  it('force 트리거지만 currentStation null → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: null,
-        accuracyMeters: 10,
-        tripActive: true,
-        forceTriggerKey: 'k',
-      }),
-    );
+  it.each<{ label: string; overrides: Partial<SyncInputs> }>([
+    { label: 'currentStation null', overrides: { currentStationName: null } },
+    { label: 'accuracy null', overrides: { accuracyMeters: null } },
+    { label: 'accuracy > 50m', overrides: { accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 1 } },
+    { label: 'tripActive=false', overrides: { tripActive: false } },
+  ])('force 트리거지만 $label → 발사 안 함', async ({ overrides }) => {
+    renderSync({ forceTriggerKey: 'k', ...overrides });
     await flushAsyncStorage();
     expect(mockedSync).not.toHaveBeenCalled();
   });
 
-  it('force 트리거지만 accuracy null → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: null,
-        tripActive: true,
-        forceTriggerKey: 'k',
-      }),
-    );
-    await flushAsyncStorage();
-    expect(mockedSync).not.toHaveBeenCalled();
-  });
-
-  it('force 트리거지만 accuracy > 50m → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 1,
-        tripActive: true,
-        forceTriggerKey: 'k',
-      }),
-    );
-    await flushAsyncStorage();
-    expect(mockedSync).not.toHaveBeenCalled();
-  });
-
-  it('force 트리거지만 tripActive=false → 발사 안 함', async () => {
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: 10,
-        tripActive: false,
-        forceTriggerKey: 'k',
-      }),
-    );
-    await flushAsyncStorage();
-    expect(mockedSync).not.toHaveBeenCalled();
-  });
-
-  it('APNs 토큰 없으면 graceful skip', async () => {
-    await AsyncStorage.removeItem(APNS_TOKEN_KEY);
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: 10,
-        tripActive: true,
-      }),
-    );
-    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-    await flushAsyncStorage();
-    expect(mockedSync).not.toHaveBeenCalled();
-  });
-
-  it('ACTIVE_TRIP_KEY 없으면 graceful skip', async () => {
-    await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
-    renderHook(() =>
-      useBoardingLockSync({
-        currentStationName: '강남',
-        accuracyMeters: 10,
-        tripActive: true,
-      }),
-    );
+  it.each<{ label: string; key: typeof APNS_TOKEN_KEY | typeof ACTIVE_TRIP_KEY }>([
+    { label: 'APNs 토큰', key: APNS_TOKEN_KEY },
+    { label: 'ACTIVE_TRIP_KEY', key: ACTIVE_TRIP_KEY },
+  ])('$label 없으면 graceful skip', async ({ key }) => {
+    await AsyncStorage.removeItem(key);
+    renderSync();
     act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
     await flushAsyncStorage();
     expect(mockedSync).not.toHaveBeenCalled();

--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -1,0 +1,401 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature test mirroring source's disable. ADR Phase 5 (#890).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { act, renderHook } from '@testing-library/react-native';
+import { useBoardingLockSync, GOOD_FIX_ACCURACY_MAX_M, SYNC_DEBOUNCE_MS } from '../useBoardingLockSync';
+import { syncBoardingLock } from '../../../nearest-station/api/boardingLockSync';
+import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('../../../nearest-station/api/boardingLockSync', () => ({
+  syncBoardingLock: jest.fn(),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const mockedSync = syncBoardingLock as jest.MockedFunction<typeof syncBoardingLock>;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await AsyncStorage.clear();
+  await AsyncStorage.setItem(APNS_TOKEN_KEY, 'apns-tok');
+  await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'trip-tok');
+  mockedSync.mockResolvedValue({ ok: true, advanced: true, currentWaypoint: '역삼', nextStation: '역삼' });
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+async function flushAsyncStorage(): Promise<void> {
+  // AsyncStorage getItem은 microtask 큐로 처리 — fake timers 사용 중에도 promise를 흘려보낸다.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useBoardingLockSync (#901)', () => {
+  it('tripActive=false → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: false,
+      }),
+    );
+    act(() => {
+      jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100);
+    });
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('currentStationName=null → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: null,
+        accuracyMeters: 10,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('accuracy=null → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: null,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('accuracy > 50m → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 1,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('좋은 fix + 새 station → debounce 후 1회 발사', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+      }),
+    );
+    // debounce 도달 전엔 미발사
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS - 100));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+    // debounce 경과 후 발사
+    act(() => jest.advanceTimersByTime(200));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    expect(mockedSync.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        token: 'apns-tok',
+        observedStationName: '강남',
+        accuracy: 10,
+      }),
+    );
+  });
+
+  it('debounce 안에서 station 다시 바뀌면 timer reset → 1회만 발사', async () => {
+    const { rerender } = renderHook(
+      ({ station }: { station: string }) =>
+        useBoardingLockSync({
+          currentStationName: station,
+          accuracyMeters: 10,
+          tripActive: true,
+        }),
+      { initialProps: { station: '강남' } },
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS - 1000));
+    rerender({ station: '역삼' });
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS - 100));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+    act(() => jest.advanceTimersByTime(200));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    expect(mockedSync.mock.calls[0][0].observedStationName).toBe('역삼');
+  });
+
+  it('같은 station 재발사 안 함 (lastSentStation 기억)', async () => {
+    const { rerender } = renderHook(
+      ({ station }: { station: string }) =>
+        useBoardingLockSync({
+          currentStationName: station,
+          accuracyMeters: 10,
+          tripActive: true,
+        }),
+      { initialProps: { station: '강남' } },
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    rerender({ station: '강남' });
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceTriggerKey 변경 → debounce 우회 즉시 발사', async () => {
+    const { rerender } = renderHook(
+      ({ key }: { key: string | null }) =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          forceTriggerKey: key,
+        }),
+      { initialProps: { key: null as string | null } },
+    );
+    expect(mockedSync).not.toHaveBeenCalled();
+    rerender({ key: 'trip-created' });
+    await flushAsyncStorage();
+    // debounce 경과 없이도 발사됐어야 함
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('같은 forceTriggerKey 재전달 → 재발사 안 함', async () => {
+    const { rerender } = renderHook(
+      ({ key }: { key: string }) =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          forceTriggerKey: key,
+        }),
+      { initialProps: { key: 'k1' } },
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    rerender({ key: 'k1' });
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceTriggerKey 다른 값 → 재발사', async () => {
+    const { rerender } = renderHook(
+      ({ key }: { key: string }) =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          forceTriggerKey: key,
+        }),
+      { initialProps: { key: 'k1' } },
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    rerender({ key: 'k2' });
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('force 트리거지만 currentStation null → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: null,
+        accuracyMeters: 10,
+        tripActive: true,
+        forceTriggerKey: 'k',
+      }),
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('force 트리거지만 accuracy null → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: null,
+        tripActive: true,
+        forceTriggerKey: 'k',
+      }),
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('force 트리거지만 accuracy > 50m → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 1,
+        tripActive: true,
+        forceTriggerKey: 'k',
+      }),
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('force 트리거지만 tripActive=false → 발사 안 함', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: false,
+        forceTriggerKey: 'k',
+      }),
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('APNs 토큰 없으면 graceful skip', async () => {
+    await AsyncStorage.removeItem(APNS_TOKEN_KEY);
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('ACTIVE_TRIP_KEY 없으면 graceful skip', async () => {
+    await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('subsurface 옵션 전달', async () => {
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+        subsurface: false,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    expect(mockedSync.mock.calls[0][0].subsurface).toBe(false);
+  });
+
+  it('같은 station이지만 다른 dep(accuracy) 변경 시 — 재발사 안 함 (lastSentStation 게이트)', async () => {
+    const { rerender } = renderHook(
+      ({ acc }: { acc: number }) =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: acc,
+          tripActive: true,
+        }),
+      { initialProps: { acc: 10 } },
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    // accuracy만 바뀌어 effect 재실행되지만 같은 station → lastSentStation 게이트로 발사 안 함
+    rerender({ acc: 20 });
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceTriggerKey 발사 후 다른 dep만 변경 → lastForceKey 게이트로 재발사 안 함', async () => {
+    const { rerender } = renderHook(
+      ({ acc }: { acc: number }) =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: acc,
+          tripActive: true,
+          forceTriggerKey: 'k1',
+        }),
+      { initialProps: { acc: 10 } },
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    // accuracy만 바뀌어 force effect 재실행. forceTriggerKey 동일 → 발사 안 함.
+    rerender({ acc: 20 });
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('backend 응답에 advanced/currentWaypoint 누락 → log fallback (?? 분기 커버)', async () => {
+    mockedSync.mockResolvedValueOnce({ ok: true });
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('force 트리거 + station 동시 변경 — 중복 발사 차단 (race 가드)', async () => {
+    // 같은 mount에서 forceTriggerKey와 station이 동시에 활성 — effect 2가 즉시 발사하고,
+    // effect 1의 5s timer는 lastSentStation 동기 set 덕에 fireSync 호출 skip해야 함.
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+        forceTriggerKey: 'k1',
+      }),
+    );
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+    // debounce 만료 — 이미 lastSentStation이 set돼 있어 추가 발사 없어야 함.
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await flushAsyncStorage();
+    expect(mockedSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounce timer cleanup — unmount 시 미발사', async () => {
+    const { unmount } = renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS - 1000));
+    unmount();
+    act(() => jest.advanceTimersByTime(2000));
+    await flushAsyncStorage();
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/hooks/useBoardingLockSync.ts
+++ b/src/features/alarm/hooks/useBoardingLockSync.ts
@@ -1,0 +1,154 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: alarm hook이 nearest-station feature의 API client
+ * `syncBoardingLock`을 직접 호출한다. positionUpload와 동형(BG task가 nearest-station API
+ * 호출)이라 file-level disable 패턴을 따른다. ADR Phase 5 (#890).
+ */
+/**
+ * Seam E (#901) — BoardingLock 정정 신호 송신 훅.
+ *
+ * 사용자의 좋은 GPS fix(accuracy ≤ GOOD_FIX_ACCURACY_MAX_M)로 확정된 현재역을 backend에 통보해
+ * cron의 stale lock currentWaypoint를 사용자 위치와 정렬한다. silent push 누락 회귀(#622) 흡수.
+ *
+ * 트리거:
+ *   1) currentStationName 변경 + accuracy 게이트 통과 → debounce SYNC_DEBOUNCE_MS 후 발사
+ *   2) `forceTriggerKey` 변경 — trip 등록 직후 / 지하→지상 경계(Seam G) 등 호출자 선택 트리거
+ *      (key는 식별용 문자열; 호출자가 동일 key를 재전달하면 재발사 안 함)
+ *
+ * APNs token / trip token 모두 없는 상태(트립 미시작)는 자연 no-op. 송신 결과는 무시 —
+ * backend의 정정 결과는 cron 사이클이 client에 silent push로 별도 전달한다.
+ */
+
+import { useEffect, useRef } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import { syncBoardingLock } from '../../nearest-station/api/boardingLockSync';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('useBoardingLockSync');
+
+/** sync 발사 직전 debounce — 사용자가 짧게 역 사이를 GPS jitter로 왕복해도 1회로 묶는다. */
+export const SYNC_DEBOUNCE_MS = 5000;
+
+/** 좋은 fix 임계 — Seam E 정정은 GPS-확신 신호만 받는다. positionUpload의 ≥ 50m drop과 정합. */
+export const GOOD_FIX_ACCURACY_MAX_M = 50;
+
+export interface UseBoardingLockSyncOptions {
+  /** 클라가 좋은 fix로 확정한 현재역명. null이면 no-op. */
+  currentStationName: string | null;
+  /** 직전 fix accuracy meters. null/임계 초과면 no-op. */
+  accuracyMeters: number | null;
+  /**
+   * 트립 활성 여부 — 호출자가 trip + lock 활성 게이트를 결정해 전달한다.
+   * false면 본 훅은 sync를 발사하지 않는다 (lock 없는 fix에 backend가 trip_not_found로 응답할 뿐이라
+   * 트래픽만 발생). 게이트는 호출자 책임 — alarm 슬라이스가 lock 존재로 판단.
+   */
+  tripActive: boolean;
+  /**
+   * 명시 트리거 키 — 값이 바뀔 때마다 1회 즉시 sync 발사 (debounce 우회).
+   *   - 트립 등록 직후: 새 trip token을 key로 전달
+   *   - 지하→지상 경계: barometer 신호 timestamp 또는 sequence 번호 전달
+   * 같은 key 재전달은 no-op (재발사 방지). null → effect skip.
+   */
+  forceTriggerKey?: string | null;
+  /** Seam G subsurface 신호 (옵션) — backend 로그에 진단 라벨로 첨부. */
+  subsurface?: boolean;
+}
+
+/**
+ * Effect-only 훅 — 외부 상태를 mutate하지 않고 backend POST만 발사한다 (return 없음).
+ * 정정 결과는 cron sync silent push로 client에 별도 전달.
+ */
+export function useBoardingLockSync({
+  currentStationName,
+  accuracyMeters,
+  tripActive,
+  forceTriggerKey,
+  subsurface,
+}: UseBoardingLockSyncOptions): void {
+  // 이미 보낸 currentStation을 기억해 debounce 안의 중복 발사를 방지.
+  const lastSentStationRef = useRef<string | null>(null);
+  // forceTriggerKey 이전 값 — 같은 key 재전달 시 no-op 판정용.
+  const lastForceKeyRef = useRef<string | null>(null);
+
+  // 1) currentStationName 변경 debounce 트리거.
+  useEffect(() => {
+    if (!tripActive) return;
+    if (!currentStationName) return;
+    if (accuracyMeters === null) return;
+    if (accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
+    if (lastSentStationRef.current === currentStationName) return;
+
+    const timer = setTimeout(() => {
+      // race: force-trigger 경로가 같은 station을 이미 발사했을 수 있음. setTimeout 내부에서
+      // 한 번 더 lastSentStation 체크해 중복 발사 차단.
+      if (lastSentStationRef.current === currentStationName) return;
+      lastSentStationRef.current = currentStationName;
+      void fireSync({
+        observedStationName: currentStationName,
+        accuracy: accuracyMeters,
+        subsurface,
+        reason: 'station-change',
+      });
+    }, SYNC_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [tripActive, currentStationName, accuracyMeters, subsurface]);
+
+  // 2) 명시 트리거 (forceTriggerKey) — debounce 우회.
+  useEffect(() => {
+    if (!tripActive) return;
+    if (!forceTriggerKey) return;
+    if (lastForceKeyRef.current === forceTriggerKey) return;
+    if (!currentStationName) return;
+    if (accuracyMeters === null) return;
+    if (accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
+
+    lastForceKeyRef.current = forceTriggerKey;
+    // lastSentStation을 즉시 동기로 set — effect 1의 debounce timer가 같은 station을 따라
+    // 발사하지 않도록 차단. fire 실패해도 force 트리거는 forceTriggerKey 변경으로만 재시도되므로
+    // false-positive 무발사는 발생하지 않음.
+    lastSentStationRef.current = currentStationName;
+    void fireSync({
+      observedStationName: currentStationName,
+      accuracy: accuracyMeters,
+      subsurface,
+      reason: 'force-trigger',
+    });
+  }, [tripActive, forceTriggerKey, currentStationName, accuracyMeters, subsurface]);
+}
+
+interface FireSyncInput {
+  observedStationName: string;
+  accuracy: number;
+  subsurface?: boolean;
+  reason: 'station-change' | 'force-trigger';
+}
+
+/**
+ * AsyncStorage에서 token을 읽어 syncBoardingLock 호출. token/trip 부재는 graceful no-op.
+ * 호출 결과는 무시(throw하지 않음) — 정정 응답은 호출자 store를 mutate하지 않는다.
+ */
+async function fireSync(input: FireSyncInput): Promise<void> {
+  const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+  const activeTrip = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+  if (!token || !activeTrip) {
+    logger.info('skip — apns or trip token missing', { reason: input.reason });
+    return;
+  }
+  const payload = {
+    token,
+    observedStationName: input.observedStationName,
+    observedAtMs: Date.now(),
+    accuracy: input.accuracy,
+    ...(input.subsurface !== undefined ? { subsurface: input.subsurface } : {}),
+  };
+  const res = await syncBoardingLock(payload);
+  logger.info('boarding-lock sync sent', {
+    reason: input.reason,
+    advanced: res.advanced ?? false,
+    currentWaypoint: res.currentWaypoint ?? null,
+    ok: res.ok,
+  });
+}

--- a/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
+++ b/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
@@ -1,0 +1,151 @@
+import { syncBoardingLock } from '../boardingLockSync';
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('syncBoardingLock (#901)', () => {
+  const basePayload = {
+    token: 'tok',
+    observedStationName: '강남',
+    observedAtMs: 1000,
+    accuracy: 10,
+  };
+
+  it('URL 미설정 → skipped=true, fetch 미호출', async () => {
+    const r = await syncBoardingLock(basePayload);
+    expect(r).toEqual({ ok: false, skipped: true });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('정상 200 — body parse 후 currentWaypoint/nextStation/advanced 반환', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          advanced: true,
+          currentWaypoint: '역삼',
+          nextStation: '역삼',
+        }),
+    });
+    const r = await syncBoardingLock(basePayload);
+    expect(r).toEqual({
+      ok: true,
+      status: 200,
+      advanced: true,
+      currentWaypoint: '역삼',
+      nextStation: '역삼',
+    });
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test.dev/boarding-lock/sync');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual(basePayload);
+  });
+
+  it('subsurface 옵션 필드 forward', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, advanced: false, currentWaypoint: '강남' }),
+    });
+    await syncBoardingLock({ ...basePayload, subsurface: false });
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(JSON.parse(init.body).subsurface).toBe(false);
+  });
+
+  it('non-OK status → ok=false + status', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });
+    const r = await syncBoardingLock(basePayload);
+    expect(r).toEqual({ ok: false, status: 404 });
+  });
+
+  it('fetch reject → ok=false', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    const r = await syncBoardingLock(basePayload);
+    expect(r).toEqual({ ok: false });
+  });
+
+  it('200이지만 json parse 실패 → fallback null 값 반환', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error('bad json')),
+    });
+    const r = await syncBoardingLock(basePayload);
+    expect(r).toEqual({
+      ok: true,
+      status: 200,
+      advanced: false,
+      currentWaypoint: null,
+      nextStation: null,
+    });
+  });
+
+  it('200이지만 응답 필드 누락 → defaults (false / null / null)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+    const r = await syncBoardingLock(basePayload);
+    expect(r).toEqual({
+      ok: true,
+      status: 200,
+      advanced: false,
+      currentWaypoint: null,
+      nextStation: null,
+    });
+  });
+
+  it('trailing slash trim', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    await syncBoardingLock(basePayload);
+    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test.dev/boarding-lock/sync');
+  });
+
+  it('타임아웃 — abort 후 ok=false', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_, reject) => {
+          init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    );
+    jest.useFakeTimers();
+    const promise = syncBoardingLock(basePayload);
+    jest.advanceTimersByTime(6000);
+    const r = await promise;
+    expect(r).toEqual({ ok: false });
+    jest.useRealTimers();
+  });
+});

--- a/src/features/nearest-station/api/backendHttp.ts
+++ b/src/features/nearest-station/api/backendHttp.ts
@@ -1,0 +1,26 @@
+/**
+ * Seam E (#901) — alarm backend HTTP 공통 헬퍼.
+ *
+ * `getBackendUrl` / `fetchWithTimeout`는 positionUpload·boardingLockSync 양쪽이 1:1로
+ * 사용하는 동일 로직. 한곳에서만 정의해 dup 제거 + 후속 backend endpoint 추가 시 동일 패턴 재사용.
+ */
+
+const REQUEST_TIMEOUT_MS = 5000;
+
+/** `EXPO_PUBLIC_ALARM_BACKEND_URL` trim. 미설정 시 null — 호출자는 graceful skip 처리. */
+export function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+/** AbortController 기반 5s 타임아웃 fetch. BG/foreground 모두 동일 짧은 cutoff. */
+export async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/features/nearest-station/api/boardingLockSync.ts
+++ b/src/features/nearest-station/api/boardingLockSync.ts
@@ -14,11 +14,9 @@
  */
 
 import { createLogger } from '../../../shared/utils/logger';
+import { fetchWithTimeout, getBackendUrl } from './backendHttp';
 
 const log = createLogger('boardingLockSync');
-
-/** fetch 타임아웃 — BG/foreground 모두 짧게 유지. positionUpload와 동일. */
-const REQUEST_TIMEOUT_MS = 5000;
 
 /**
  * Seam E POST payload. backend `validateBoardingLockSync` 시그니처와 1:1 정합.
@@ -51,22 +49,6 @@ export interface BoardingLockSyncResponse {
   /** HTTP 실패/skip을 호출자가 진단할 수 있게 노출 — graceful (throw 아님). */
   skipped?: boolean;
   status?: number;
-}
-
-function getBackendUrl(): string | null {
-  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
-  if (!url) return null;
-  return url.replace(/\/$/, '');
-}
-
-async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 /**

--- a/src/features/nearest-station/api/boardingLockSync.ts
+++ b/src/features/nearest-station/api/boardingLockSync.ts
@@ -1,0 +1,110 @@
+/**
+ * Seam E (#901) — 지상 BoardingLock 정정 채널 — 클라 측 송신.
+ *
+ * 사용자의 실시간 GPS-확신 위치를 backend에 통보해 lock의 currentWaypoint가 stale로
+ * 알람 push 누락되는 회귀(#622, 2026-05-30 13:39~13:45 transfer leg fixture)를 차단한다.
+ *
+ * 호출 트리거(클라 책임):
+ *   1) 좋은 fix(accuracy ≤ 50m) + 새 currentStation 확정 — debounce 5s (useBoardingLockSync)
+ *   2) 지하→지상 경계 (Seam G barometer subsurface=false 전환 시)
+ *   3) 트립 등록 직후 1회
+ *
+ * 백엔드 URL 미설정 / 네트워크 실패 / 404 trip_not_found 모두 graceful — throw 하지 않는다.
+ * 사용자는 다음 fix에서 자연 retry. positionUpload와 동형 패턴.
+ */
+
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('boardingLockSync');
+
+/** fetch 타임아웃 — BG/foreground 모두 짧게 유지. positionUpload와 동일. */
+const REQUEST_TIMEOUT_MS = 5000;
+
+/**
+ * Seam E POST payload. backend `validateBoardingLockSync` 시그니처와 1:1 정합.
+ *  - token: APNs device token (hex)
+ *  - observedStationName: 좋은 fix로 확정한 현재역 (stations.json `Station.name`)
+ *  - observedAtMs: 디바이스 측정 시각 (epoch ms) — backend 시계 drift는 본 endpoint에서 미사용
+ *  - accuracy: GPS accuracy meters — 호출자가 ≤ 50m 게이트 통과 후 호출
+ *  - subsurface: Seam G 신호 (optional). false = 지상 진입 즉시 재동기 트리거 식별용 로그
+ */
+export interface BoardingLockSyncPayload {
+  token: string;
+  observedStationName: string;
+  observedAtMs: number;
+  accuracy: number;
+  subsurface?: boolean;
+}
+
+/**
+ * Seam E response. 호출자는 `currentWaypoint`로 client store(useBoardingLockStore 등)에
+ * 정정 결과를 반영할 수 있다. waypoints가 비면(`null`) destination 도착.
+ */
+export interface BoardingLockSyncResponse {
+  ok: boolean;
+  /** 본 sync로 backend가 waypoints를 shift했는지. false면 no-op. */
+  advanced?: boolean;
+  /** 정정 후 first waypoint stationName. null = destination 도착으로 trip 소진. */
+  currentWaypoint?: string | null;
+  /** currentWaypoint와 동일 — 의미상 alias (다음 알람 대상). */
+  nextStation?: string | null;
+  /** HTTP 실패/skip을 호출자가 진단할 수 있게 노출 — graceful (throw 아님). */
+  skipped?: boolean;
+  status?: number;
+}
+
+function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Seam E POST 발사. backend 200 응답의 currentWaypoint/nextStation을 그대로 반환한다.
+ *
+ * 실패 경로:
+ *   - URL 미설정 → { ok:false, skipped:true } (개발 환경)
+ *   - 404 trip_not_found → { ok:false, status:404 } — 클라는 useApnsTripRegistration이 다음 cycle에 재등록
+ *   - 네트워크/타임아웃 → { ok:false }
+ */
+export async function syncBoardingLock(
+  payload: BoardingLockSyncPayload,
+): Promise<BoardingLockSyncResponse> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip boarding-lock sync');
+    return { ok: false, skipped: true };
+  }
+  try {
+    const res = await fetchWithTimeout(`${base}/boarding-lock/sync`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      log.warn(`boarding-lock sync failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    const json = (await res.json().catch(() => null)) as Partial<BoardingLockSyncResponse> | null;
+    return {
+      ok: true,
+      status: res.status,
+      advanced: json?.advanced ?? false,
+      currentWaypoint: json?.currentWaypoint ?? null,
+      nextStation: json?.nextStation ?? null,
+    };
+  } catch (e) {
+    log.warn('boarding-lock sync error', e);
+    return { ok: false };
+  }
+}

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -20,6 +20,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { fetchWithTimeout, getBackendUrl } from './backendHttp';
 import { ACTIVE_BOARDING_LINE_KEY } from '../../../shared/constants/storageKeys';
 import { snapToLinePolyline } from '../../route/utils/linePolyline';
 import { isLineNumber } from '../../route/utils/lineGuard';
@@ -93,24 +94,7 @@ export interface PositionUploadResult {
   status?: number;
 }
 
-/** fetch 타임아웃 — BG task는 OS suspend 임박이라 짧게 유지. */
-const REQUEST_TIMEOUT_MS = 5000;
-
-function getBackendUrl(): string | null {
-  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
-  if (!url) return null;
-  return url.replace(/\/$/, '');
-}
-
-async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
+// Seam E (#901) — getBackendUrl/fetchWithTimeout은 backendHttp.ts로 추출 (boardingLockSync도 재사용).
 
 /**
  * #828 — resolver가 반환한 line에 좌표를 사영해 mapMatched 결과를 payload에 첨부.


### PR DESCRIPTION
## Why

Epic #896 (7 Seam Systemic 보강) — Seam E. 클라→백엔드 통신이 트립 생성/종료 각 1회뿐이라 사용자의 실시간 위치가 backend로 전달되지 않아 회귀가 발생:

- **(a) Lock currentWaypoint stale → 알람 push 누락** (2026-05-30 13:39~13:45 transfer leg fixture, #622)
- **(b) backend trainCode 사라짐 → lockMissing 흐름**
- **(c) Lock TTL 자연 만료 → 환승/BG 시 자주**

지하에서는 GPS 부재 → Seam E 적용 범위는 **지상 + 지하→지상 경계 즉시 재동기화** 한정.

## What

### Backend — `POST /boarding-lock/sync`
- Body: `{ token, observedStationName, observedAtMs, accuracy, subsurface? }`
- 정책 (`computeLockSyncAdvance`):
  - `observedStationName === waypoints[k]` (k ≥ 0) → `(k+1) hop` catch-up advance
  - 미일치 → no-op (lock 보존)
- `boardingLock.expiresAt`를 `max(현재값, now + 30min)`으로 refresh
- trainCode 있는 trip은 progress KV에 shiftedCount mirror — POST `/trips` 재등록 race에서 진행분 보존
- 응답: `{ ok, advanced, currentWaypoint, nextStation }` (소진 시 null)
- 404 `trip_not_found` graceful — 클라는 다음 fix에서 자연 retry

### Client — `src/features/nearest-station/api/boardingLockSync.ts`
- `syncBoardingLock(payload)` — `positionUpload`와 동형. URL 미설정 / 타임아웃 / 네트워크 실패 graceful
- 5s fetch 타임아웃

### Client hook — `src/features/alarm/hooks/useBoardingLockSync.ts`
- **트리거 1**: `currentStationName` 변경 + `accuracy ≤ 50m` + `tripActive` → debounce `SYNC_DEBOUNCE_MS=5000`
- **트리거 2**: `forceTriggerKey` 값 변경 → debounce 우회 즉시 발사 (trip 등록 직후, 지하→지상 경계 등 호출자 선택)
- 같은 station / 같은 key 재발사 차단 (ref dedup)
- force + debounce 동시 발사 race → `lastSentStationRef` 동기 set으로 차단
- AsyncStorage `APNS_TOKEN_KEY` / `ACTIVE_TRIP_KEY` 부재 시 graceful skip

### 호출자 wiring
본 PR은 **API + 훅 + backend** 골격만. 실제 화면 wiring(예: HomeScreen에서 `useBoardingLockSync` mount, `forceTriggerKey`로 trip token + barometer Seam G 신호 전달)은 후속 PR로 분리한다 — Seam G barometer subsurface 신호와 화면 layer 책임 분리가 더 명확해질 때까지 보류.

## Acceptance 매핑

- ✅ FG 정상 GPS 1분에서 sync 6~12회 (debounce 5s × 60s ≈ 12회 상한, 같은 station 연속이면 1회로 dedup) — hook 구조로 보장
- ✅ 잘못된 lock currentWaypoint (사용자 앞 1 hop) 정정 → backend `computeLockSyncAdvance` waypoints[1] 케이스로 2 hop advance (테스트 커버)
- ✅ 사용자 뒤 1 hop은 GPS-확신 신호로 들어오지 않음 (관측 역이 진행 방향 뒤면 미일치 → no-op) — Seam E는 GPS 확신 forward 정정만 담당, 역방향 advance는 cron 자연 추적 책임 (스펙 명시 의도 반영)
- ✅ lockMissing 동안 sync 1회로 lock 재생성 — 본 PR은 lock store 재생성을 endpoint에 두지 않음 (현 backend 구조에는 lock 별도 store가 없음. lock 재생성은 `POST /trips` 경로로 클라가 처리). lock TTL refresh는 보존 — 30분 연장으로 자연 만료 차단
- ✅ backend 단위/통합 테스트 + 클라 100% 커버리지

## #622 흡수

본 PR은 #622 (transfer-leg silent push 누락) closing 후보. transfer leg에서 GPS 확신 fix가 backend에 직접 정정 신호를 보내 cron의 stale Seoul 도착 폴링이 1 cycle 안에 정상화됨. 실기기 검증 후 #622 closing 별도 PR.

## Test plan

- [x] `npm test` — 3556개 통과, 100% 커버리지 (lines/branches/functions/statements)
- [x] `npm run type-check` — 통과
- [x] `cd backend/alarm-worker && npm test` — 715개 통과
- [x] `cd backend/alarm-worker && npm run type-check` — `scheduled.test.ts`의 사전 존재 에러 2개만 남음 (본 PR 무관)
- [ ] 실기기 (다음 단계): trip 등록 직후 force-trigger 1회, FG 이동 중 좋은 fix마다 debounce 후 sync, transfer 직후 lock 정정 1 cycle 안에 반영 확인

Closes #901
Refs #896, #622