### PR TITLE
feat(#902): Seam F — backend 환승 자동 trainCode swap + 사라짐 후보 attach

### DIFF
--- a/backend/alarm-worker/src/__tests__/lineAlias.test.ts
+++ b/backend/alarm-worker/src/__tests__/lineAlias.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { LINE_ALIAS_MAP, canonicalLineName, matchLine } from '../lineAlias';
+import { LINE_ALIAS_MAP, canonicalLineName, matchLine, subwayIdForLine } from '../lineAlias';
 
 describe('canonicalLineName (#585)', () => {
   it.each([
@@ -73,5 +73,30 @@ describe('matchLine', () => {
       expect(LINE_ALIAS_MAP[code]).toBeDefined();
       expect(LINE_ALIAS_MAP[code].length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('subwayIdForLine (#902)', () => {
+  // 클라 LINE_TO_SUBWAY_ID(src/shared/constants/lineApiNames.ts)와 정합 확인.
+  it.each([
+    ['1', '1001'],
+    ['2', '1002'],
+    ['3', '1003'],
+    ['4', '1004'],
+    ['5', '1005'],
+    ['6', '1006'],
+    ['7', '1007'],
+    ['8', '1008'],
+    ['9', '1009'],
+    ['gyeongui', '1063'],
+    ['airport', '1065'],
+    ['bundang', '1075'],
+    ['sinbundang', '1077'],
+  ])('maps line="%s" → "%s"', (line, expected) => {
+    expect(subwayIdForLine(line)).toBe(expected);
+  });
+
+  it('returns null for unknown line', () => {
+    expect(subwayIdForLine('unknown')).toBeNull();
   });
 });

--- a/backend/alarm-worker/src/__tests__/lockSwap.test.ts
+++ b/backend/alarm-worker/src/__tests__/lockSwap.test.ts
@@ -1,0 +1,247 @@
+/**
+ * lockSwap.ts (#902 Seam F) — 환승/사라짐 자동 trainCode swap 단위 테스트.
+ *
+ * 통합 동작(advanceBoardingLockWaypoint / runTrainCodeTracking 진입점)은 scheduled.test.ts에서
+ * 별도 커버. 본 파일은 pure pipeline (KV/네트워크 의존 없음)에 한정.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
+import {
+  SWAP_LOCK_TTL_MS,
+  attachTrainCodeForLeg,
+  buildLegSegmentStations,
+} from '../lockSwap';
+import type { Trip, Waypoint } from '../types';
+
+const NOW = 1_700_000_000_000;
+
+function makeArrivalsFetch(arrivals: ArrivalEntry[]): typeof fetch {
+  return (async () =>
+    new Response(
+      JSON.stringify({
+        realtimeArrivalList: arrivals.map((a) => ({
+          barvlDt: String(a.arrivalSeconds),
+          recptnDt: '',
+          updnLine: a.isUp ? '상행' : '하행',
+          trainLineNm: a.destination,
+          btrainNo: a.trainCode,
+          subwayNm: a.subwayNm,
+          arvlCd: a.arvlCd,
+        })),
+      }),
+      { status: 200 },
+    )) as unknown as typeof fetch;
+}
+
+function makeSeoul(arrivals: ArrivalEntry[]): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: makeArrivalsFetch(arrivals),
+  });
+}
+
+function makeTrip(waypoints: Waypoint[]): Trip {
+  return {
+    token: 'tok',
+    route: { type: 'direct', line: '7', stops: 3 },
+    destination: 'dst',
+    waypoints,
+    expiresAt: NOW + 60 * 60_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 60_000,
+  };
+}
+
+function makeArrival(
+  trainCode: string,
+  arvlCd: number | null,
+  arrivalSeconds = 60,
+  subwayNm = '지하철7호선',
+): ArrivalEntry {
+  return {
+    destination: '도봉산',
+    arrivalSeconds,
+    trainCode,
+    isUp: true,
+    subwayNm,
+    arvlCd,
+  };
+}
+
+describe('buildLegSegmentStations', () => {
+  it('returns single station for a destination waypoint', () => {
+    const result = buildLegSegmentStations(
+      [{ stationName: '강남', line: '2', kind: 'destination' }],
+      '2',
+    );
+    expect(result).toEqual(['강남']);
+  });
+
+  it('collects consecutive same-line intermediate stations up to destination', () => {
+    const result = buildLegSegmentStations(
+      [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'intermediate' },
+        { stationName: '어린이대공원', line: '7', kind: 'destination' },
+      ],
+      '7',
+    );
+    expect(result).toEqual(['중곡', '군자', '어린이대공원']);
+  });
+
+  it('stops at the next transfer waypoint (inclusive) — leg ends there', () => {
+    // line=7 leg는 transfer waypoint(건대입구)까지 포함. 그 다음 line=2 segment는 별도 leg.
+    const result = buildLegSegmentStations(
+      [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '건대입구', line: '7', kind: 'transfer' },
+        { stationName: '성수', line: '2', kind: 'destination' },
+      ],
+      '7',
+    );
+    expect(result).toEqual(['중곡', '건대입구']);
+  });
+
+  it('stops on line change (no transfer kind) — defensive against malformed waypoint sequences', () => {
+    // 정상 sequence는 line 전환 시 transfer kind가 있어야 하지만, defensive하게 line만으로도 break.
+    const result = buildLegSegmentStations(
+      [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '성수', line: '2', kind: 'destination' },
+      ],
+      '7',
+    );
+    expect(result).toEqual(['중곡']);
+  });
+
+  it('returns empty array when first waypoint line does not match', () => {
+    const result = buildLegSegmentStations(
+      [{ stationName: '성수', line: '2', kind: 'destination' }],
+      '7',
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for empty waypoints', () => {
+    expect(buildLegSegmentStations([], '7')).toEqual([]);
+  });
+});
+
+describe('attachTrainCodeForLeg', () => {
+  const targetWaypoint: Waypoint = {
+    stationName: '어린이대공원',
+    line: '7',
+    kind: 'destination',
+  };
+
+  it('attaches single direction-matched candidate (arvlCd priority 1 ARRIVED)', async () => {
+    const seoul = makeSeoul([makeArrival('7246', 1, 60)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([targetWaypoint]),
+      targetWaypoint,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toEqual({
+      trainCode: '7246',
+      line: '7',
+      subwayId: '1007',
+      selectedDepartureTime: NOW,
+      segmentStations: ['어린이대공원'],
+      expiresAt: NOW + SWAP_LOCK_TTL_MS,
+    });
+  });
+
+  it('returns null when arrivals are empty (Seoul API returned nothing)', async () => {
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([targetWaypoint]),
+      targetWaypoint,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('returns null for unmapped line (subwayIdForLine miss)', async () => {
+    const unmapped: Waypoint = { stationName: '어디', line: 'unmapped', kind: 'destination' };
+    const seoul = makeSeoul([makeArrival('X', 1, 60)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([unmapped]),
+      targetWaypoint: unmapped,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('returns null on ambiguous candidates (multiple arvlCd=1) — boarding-prompt fallback expected', async () => {
+    // 두 train 모두 ARRIVED → pickAutoTrainCode가 ambiguity로 null
+    const seoul = makeSeoul([makeArrival('A', 1, 60), makeArrival('B', 1, 90)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([targetWaypoint]),
+      targetWaypoint,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('picks arvlCd=2 (DEPARTED) over arvlCd=1 (ARRIVED)', async () => {
+    const seoul = makeSeoul([makeArrival('ARR', 1, 60), makeArrival('DEP', 2, 30)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([targetWaypoint]),
+      targetWaypoint,
+      seoul,
+      now: NOW,
+    });
+    expect(lock?.trainCode).toBe('DEP');
+  });
+
+  it('returns null when no candidate matches the line (different subwayNm)', async () => {
+    // arrivals exist but all are for line 2, while target is line 7 → matchLine filters all out.
+    const seoul = makeSeoul([makeArrival('2HOST', 1, 60, '지하철2호선')]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([targetWaypoint]),
+      targetWaypoint,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('returns null when buildLegSegmentStations is empty (target line not first waypoint)', async () => {
+    // targetWaypoint.line=7이지만 trip.waypoints[0]는 line=2 → buildLegSegmentStations=[].
+    const seoul = makeSeoul([makeArrival('7246', 1, 60)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([{ stationName: '성수', line: '2', kind: 'destination' }]),
+      targetWaypoint,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('populates segmentStations from trip.waypoints same-line chain', async () => {
+    const seoul = makeSeoul([makeArrival('7246', 1, 60)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'intermediate' },
+        { stationName: '어린이대공원', line: '7', kind: 'destination' },
+      ]),
+      // targetWaypoint는 leg의 첫 waypoint와 동치여야 정상 (호출자 책임).
+      targetWaypoint: {
+        stationName: '중곡',
+        line: '7',
+        kind: 'intermediate',
+      },
+      seoul,
+      now: NOW,
+    });
+    expect(lock?.segmentStations).toEqual(['중곡', '군자', '어린이대공원']);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2662,3 +2662,217 @@ describe('runScheduled — #826 runTrainCodeTracking Kalman reset', () => {
     }
   });
 });
+
+/**
+ * #902 Seam F 공용 fixture 빌더.
+ *
+ * `realtimeArrivalList` raw row 1건의 shape는 `makeSeoul` 등 기존 helper와 동일하지만,
+ * 본 describe 묶음(환승 swap + 사라짐 re-attach)이 URL 분기, multi-row ambiguity 등을 별도로
+ * 조합하므로 row 빌더만 외부로 추출해 중복(barvlDt/recptnDt/updnLine ... arvlCd)을 제거한다.
+ */
+interface RawArrivalRowInput {
+  trainCode: string;
+  arrivalSeconds: number;
+  arvlCd: number;
+  subwayNm: string;
+  destination?: string;
+}
+function rawArrivalRow(row: RawArrivalRowInput): Record<string, unknown> {
+  return {
+    barvlDt: String(row.arrivalSeconds),
+    recptnDt: '',
+    updnLine: '상행',
+    trainLineNm: row.destination ?? '도봉산',
+    btrainNo: row.trainCode,
+    subwayNm: row.subwayNm,
+    arvlCd: row.arvlCd,
+  };
+}
+function arrivalListResponse(rows: RawArrivalRowInput[]): Response {
+  return new Response(
+    JSON.stringify({ realtimeArrivalList: rows.map(rawArrivalRow) }),
+    { status: 200 },
+  );
+}
+
+/**
+ * #902 Seam F — 환승 자동 trainCode swap 통합 테스트.
+ *
+ * 시나리오: 7호선 trainCode "7327"으로 건대입구(transfer) ARRIVED → lock 해제 + 다음 cycle
+ * 안에 같은 polling으로 2호선 성수 arrivals에서 후보 trainCode "2227"을 자동 attach.
+ * 옛 동작: lock 비어있는 다음 cycle이 boarding-prompt 경로로 떨어져 사용자가 manual 선택 필요.
+ */
+describe('runScheduled — Seam F 환승 자동 swap (#902)', () => {
+  /** transfer→destination waypoints + line 7 boardingLock(건대입구로 ARRIVED 예정)의 trip 빌더. */
+  function makeTransferTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'transfer-tok',
+      route: { type: 'direct', line: '7', stops: 3 },
+      waypoints: [
+        { stationName: '건대입구', line: '7', kind: 'transfer' },
+        { stationName: '성수', line: '2', kind: 'destination' },
+      ],
+      boardingLock: {
+        trainCode: '7327',
+        line: '7',
+        subwayId: '1007',
+        selectedDepartureTime: NOW,
+        segmentStations: ['어린이대공원', '군자', '건대입구'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+      ...overrides,
+    });
+  }
+
+  /**
+   * 라인별 응답 분기 fetch — 7호선 건대입구는 ARRIVED, 2호선 성수는 후보 1개(2227 arvlCd=1).
+   * Seoul API URL은 stationName query를 포함 — encode된 stationName으로 분기.
+   */
+  function makeTransferSeoul(): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes(encodeURIComponent('건대입구'))) {
+          // 7호선 trainCode 7327이 건대입구에 ARRIVED(arvlCd=1).
+          return arrivalListResponse([
+            { trainCode: '7327', arrivalSeconds: 0, arvlCd: 1, subwayNm: '지하철7호선' },
+          ]);
+        }
+        if (url.includes(encodeURIComponent('성수'))) {
+          // 2호선 성수: 후보 trainCode 2227 ARRIVED 1대만 → pickAutoTrainCode 1순위로 결정.
+          return arrivalListResponse([
+            { trainCode: '2227', arrivalSeconds: 60, arvlCd: 1, subwayNm: '지하철2호선', destination: '성수' },
+          ]);
+        }
+        return arrivalListResponse([]);
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  it('attaches new trainCode on transfer release within the same cycle', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTransferTrip());
+    const fetchImpl = makeOkFetch();
+    await runLaScheduled(kv, { seoul: makeTransferSeoul(), fetchImpl });
+
+    // trip은 KV에 남아 있어야 한다 (transfer는 trip 종료가 아님).
+    const raw = await kv.get('trip:transfer-tok');
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw as string) as Trip;
+    // waypoint shift: 건대입구 제거 → 첫 waypoint=성수
+    expect(stored.waypoints[0].stationName).toBe('성수');
+    expect(stored.waypoints[0].line).toBe('2');
+    // 자동 swap된 lock: trainCode 2227 + line 2 + segmentStations=[성수]
+    expect(stored.boardingLock).toBeDefined();
+    expect(stored.boardingLock?.trainCode).toBe('2227');
+    expect(stored.boardingLock?.line).toBe('2');
+    expect(stored.boardingLock?.subwayId).toBe('1002');
+    expect(stored.boardingLock?.segmentStations).toEqual(['성수']);
+  });
+
+  it('leaves lock undefined when no candidate matches (boarding-prompt fallback path)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTransferTrip());
+    // 7호선 건대입구는 ARRIVED 정상, 2호선 성수는 빈 응답 → swap 실패 → 기존 lockMissing 흐름.
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes(encodeURIComponent('건대입구'))) {
+          return arrivalListResponse([
+            { trainCode: '7327', arrivalSeconds: 0, arvlCd: 1, subwayNm: '지하철7호선' },
+          ]);
+        }
+        return arrivalListResponse([]);
+      }) as unknown as typeof fetch,
+    });
+    await runLaScheduled(kv, { seoul, fetchImpl: makeOkFetch() });
+    const stored = JSON.parse((await kv.get('trip:transfer-tok')) as string) as Trip;
+    expect(stored.waypoints[0].stationName).toBe('성수');
+    expect(stored.boardingLock).toBeUndefined();
+  });
+});
+
+/**
+ * #902 Seam F — trainCode 사라짐 후 재attach.
+ *
+ * 시나리오: 옛 trainCode가 Seoul API에서 사라지면 같은 station/line의 신규 trainCode를 같은
+ * cycle에 자동 swap. previousMissCount=1 + 이번 cycle 미스 = 2 도달이 트리거. 1로는 false swap
+ * 위험 — 일시적 API 누락과 진짜 사라짐 구분 불가.
+ */
+describe('runScheduled — Seam F 사라짐 후 재attach (#902)', () => {
+  function makeMissingTrainTrip(missCount: number): Trip {
+    // boardingLock.trainCode=7174는 사라짐(arrivals에 부재). same-line(7) 신규 후보로 swap 기대.
+    return makeTrip({
+      token: 'miss-tok',
+      route: { type: 'direct', line: '7', stops: 2 },
+      waypoints: [{ stationName: '군자', line: '7', kind: 'destination' }],
+      boardingLock: {
+        trainCode: '7174',
+        line: '7',
+        subwayId: '1007',
+        selectedDepartureTime: NOW,
+        segmentStations: ['어린이대공원', '군자'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+      consecutiveEtaMissing: missCount,
+    });
+  }
+
+  /** 7호선 군자 응답: trainCode 7174는 없음, 7246(arvlCd=2 DEPARTED) 1대만. */
+  function makeReAttachSeoul(): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        arrivalListResponse([
+          { trainCode: '7246', arrivalSeconds: 60, arvlCd: 2, subwayNm: '지하철7호선' },
+        ])) as unknown as typeof fetch,
+    });
+  }
+
+  it('swaps to new trainCode when threshold reached (prev miss=1 + this miss = 2)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeMissingTrainTrip(1));
+    const fetchImpl = makeOkFetch();
+    await runLaScheduled(kv, { seoul: makeReAttachSeoul(), fetchImpl });
+    const stored = JSON.parse((await kv.get('trip:miss-tok')) as string) as Trip;
+    // swap 성공 → trainCode 갱신 + 카운터 reset
+    expect(stored.boardingLock?.trainCode).toBe('7246');
+    expect(stored.consecutiveEtaMissing ?? 0).toBe(0);
+  });
+
+  it('does not swap on first miss (prev=0) — single transient API miss tolerated', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeMissingTrainTrip(0));
+    await runLaScheduled(kv, { seoul: makeReAttachSeoul(), fetchImpl: makeOkFetch() });
+    const stored = JSON.parse((await kv.get('trip:miss-tok')) as string) as Trip;
+    // swap 안 됨 — 기존 trainCode 유지 + 카운터 +1
+    expect(stored.boardingLock?.trainCode).toBe('7174');
+    expect(stored.consecutiveEtaMissing).toBe(1);
+  });
+
+  it('keeps incrementing miss counter when no candidate at threshold (ambiguous arrivals)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeMissingTrainTrip(1));
+    // 두 trainCode 모두 arvlCd=1 → pickAutoTrainCode가 ambiguity로 null → swap 실패
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        arrivalListResponse([
+          { trainCode: 'A', arrivalSeconds: 30, arvlCd: 1, subwayNm: '지하철7호선' },
+          { trainCode: 'B', arrivalSeconds: 60, arvlCd: 1, subwayNm: '지하철7호선' },
+        ])) as unknown as typeof fetch,
+    });
+    await runLaScheduled(kv, { seoul, fetchImpl: makeOkFetch() });
+    const stored = JSON.parse((await kv.get('trip:miss-tok')) as string) as Trip;
+    expect(stored.boardingLock?.trainCode).toBe('7174');
+    expect(stored.consecutiveEtaMissing).toBe(2);
+  });
+});

--- a/backend/alarm-worker/src/lineAlias.ts
+++ b/backend/alarm-worker/src/lineAlias.ts
@@ -16,31 +16,56 @@ export interface LineMeta {
   canonical: string;
   aliases: readonly string[];
   color: string;
+  /**
+   * Seoul Open API subwayId (예: "1007" = 7호선). #902 Seam F — 환승 자동 swap이
+   * 새 노선 lock을 합성할 때 클라가 송신하던 subwayId의 backend-side 대체.
+   * 클라의 `src/shared/constants/lineApiNames.ts`의 LINE_TO_SUBWAY_ID와 정합 유지.
+   */
+  subwayId: string;
 }
 
 export const LINE_META: Record<string, LineMeta> = {
-  '1': { canonical: '1호선', aliases: ['지하철1호선'], color: '#0052A4' },
-  '2': { canonical: '2호선', aliases: ['지하철2호선'], color: '#009D3E' },
-  '3': { canonical: '3호선', aliases: ['지하철3호선'], color: '#EF7C1C' },
-  '4': { canonical: '4호선', aliases: ['지하철4호선'], color: '#00A2D1' },
-  '5': { canonical: '5호선', aliases: ['지하철5호선'], color: '#996CAC' },
-  '6': { canonical: '6호선', aliases: ['지하철6호선'], color: '#CD7C2F' },
-  '7': { canonical: '7호선', aliases: ['지하철7호선'], color: '#747F00' },
-  '8': { canonical: '8호선', aliases: ['지하철8호선'], color: '#E6186C' },
-  '9': { canonical: '9호선', aliases: ['지하철9호선'], color: '#BDB092' },
-  gyeongui: { canonical: '경의중앙선', aliases: ['지하철경의중앙선', '경의중앙'], color: '#77C4A3' },
+  '1': { canonical: '1호선', aliases: ['지하철1호선'], color: '#0052A4', subwayId: '1001' },
+  '2': { canonical: '2호선', aliases: ['지하철2호선'], color: '#009D3E', subwayId: '1002' },
+  '3': { canonical: '3호선', aliases: ['지하철3호선'], color: '#EF7C1C', subwayId: '1003' },
+  '4': { canonical: '4호선', aliases: ['지하철4호선'], color: '#00A2D1', subwayId: '1004' },
+  '5': { canonical: '5호선', aliases: ['지하철5호선'], color: '#996CAC', subwayId: '1005' },
+  '6': { canonical: '6호선', aliases: ['지하철6호선'], color: '#CD7C2F', subwayId: '1006' },
+  '7': { canonical: '7호선', aliases: ['지하철7호선'], color: '#747F00', subwayId: '1007' },
+  '8': { canonical: '8호선', aliases: ['지하철8호선'], color: '#E6186C', subwayId: '1008' },
+  '9': { canonical: '9호선', aliases: ['지하철9호선'], color: '#BDB092', subwayId: '1009' },
+  gyeongui: {
+    canonical: '경의중앙선',
+    aliases: ['지하철경의중앙선', '경의중앙'],
+    color: '#77C4A3',
+    subwayId: '1063',
+  },
   bundang: {
     canonical: '수인분당선',
     aliases: ['지하철수인분당선', '분당선', '수인분당'],
     color: '#F5A200',
+    subwayId: '1075',
   },
-  sinbundang: { canonical: '신분당선', aliases: ['지하철신분당선'], color: '#D4003B' },
-  airport: { canonical: '공항철도', aliases: ['인천국제공항철도'], color: '#4B81BF' },
+  sinbundang: {
+    canonical: '신분당선',
+    aliases: ['지하철신분당선'],
+    color: '#D4003B',
+    subwayId: '1077',
+  },
+  airport: { canonical: '공항철도', aliases: ['인천국제공항철도'], color: '#4B81BF', subwayId: '1065' },
 };
 
 /** realtimePosition URL 파라미터용 정식 노선명. 매핑 없으면 null. */
 export function canonicalLineName(line: string): string | null {
   return LINE_META[line]?.canonical ?? null;
+}
+
+/**
+ * #902 Seam F — line code → Seoul API subwayId. 환승 자동 swap이 새 lock을 합성할 때 사용.
+ * 매핑 없는 line이면 null — caller가 swap 자체를 abort한다.
+ */
+export function subwayIdForLine(line: string): string | null {
+  return LINE_META[line]?.subwayId ?? null;
 }
 
 /**

--- a/backend/alarm-worker/src/lockSwap.ts
+++ b/backend/alarm-worker/src/lockSwap.ts
@@ -1,0 +1,96 @@
+/**
+ * #902 Seam F — boardingLock의 trainCode 자동 swap 로직.
+ *
+ * 두 회귀에 대응:
+ *  1) 환승 직후 lock release → 다음 cycle이 새 line의 첫 waypoint에서 옛 trainCode를 찾아
+ *     etaMissing 5회 후 trip auto-end (`backend/alarm-worker/src/scheduled.ts` advanceBoardingLockWaypoint).
+ *  2) 운행 중 trainCode가 Seoul OpenAPI에서 사라지면 다음 후보 모름 → 같은 line/방향의 신규
+ *     trainCode가 같은 시점에 나타나면 자동 swap (`runTrainCodeTracking` 연속 etaMissing 누적 시).
+ *
+ * 본 모듈은 순수 pipeline (KV I/O 없음). 호출자가 결과 BoardingLockMeta를 trip에 stamp + putTrip.
+ *
+ * 방향 매칭은 stationName 필터로 implicit 해소:
+ *  - 다음 waypoint stationName + 같은 line의 arrivals만 평가 → 잘못된 방향은 station 응답 자체가 없음.
+ *  - 추가로 `pickAutoTrainCode`(boardingPrompt.ts)의 arvlCd 우선순위(2>1>0)로 ambiguity 회피.
+ */
+
+import { pickAutoTrainCode } from './boardingPrompt';
+import { subwayIdForLine } from './lineAlias';
+import type { SeoulArrivalClient } from './seoul';
+import type { BoardingLockMeta, Trip, Waypoint } from './types';
+
+/**
+ * 자동 swap 후 새 lock의 TTL. 환승 직후엔 사용자가 즉시 새 lock을 client에서 보낼 가능성이
+ * 낮으므로(같은 화면 갱신 race) cron 사이클 30분 마진을 둔다. Seam E sync가 가장 먼저 정정해도
+ * lock 자체는 계속 활성 유지.
+ */
+export const SWAP_LOCK_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * 새 lock의 segmentStations 산출.
+ *
+ * `trip.waypoints[0]`(=새 line의 첫 waypoint)부터 시작해 같은 line이 유지되는 동안 stationName을 모은다.
+ * line이 바뀌는 waypoint(다음 환승)는 포함하지 않는다 — 이번 leg 범위 한정 (positions fallback 정확도용).
+ * destination에 도달하면 destination까지 포함.
+ *
+ * 빈 배열은 호출자에서 swap 자체를 abort (segmentStations는 BoardingLockMeta 필수 필드).
+ */
+export function buildLegSegmentStations(
+  waypoints: readonly Waypoint[],
+  line: string,
+): string[] {
+  const stations: string[] = [];
+  for (const wp of waypoints) {
+    if (wp.line !== line) break;
+    stations.push(wp.stationName);
+    if (wp.kind === 'transfer' || wp.kind === 'destination') break;
+  }
+  return stations;
+}
+
+export interface AttachLockInputs {
+  trip: Trip;
+  /** 다음 추적 대상 waypoint — arrivals 폴링 대상 (현재 leg 첫 waypoint). */
+  targetWaypoint: Waypoint;
+  seoul: SeoulArrivalClient;
+  now: number;
+}
+
+/**
+ * 자동 swap의 핵심 — `targetWaypoint`의 stationName + line에서 후보 trainCode를 1개 골라
+ * 새 BoardingLockMeta를 합성한다.
+ *
+ * 후보 선택 정책:
+ *  - 노선 매칭(matchLine) + arvlCd 우선순위(2 출발 > 1 도착 > 0 진입 > 그 외)
+ *  - 같은 우선순위 후보 다수 = ambiguity → null (silent skip, caller가 boarding-prompt fallback)
+ *  - direction=null: stationName 필터가 이미 진행 방향을 implicit으로 결정 (그 역에 보이지 않는
+ *    방향 train은 응답 자체가 없음).
+ *
+ * subwayId 매핑 누락 line이면 null — backend는 stations.json 없이 line code만 신뢰.
+ */
+export async function attachTrainCodeForLeg(
+  inputs: AttachLockInputs,
+): Promise<BoardingLockMeta | null> {
+  const { targetWaypoint, seoul, now, trip } = inputs;
+  const line = targetWaypoint.line;
+  const subwayId = subwayIdForLine(line);
+  if (!subwayId) return null;
+
+  const segmentStations = buildLegSegmentStations(trip.waypoints, line);
+  if (segmentStations.length === 0) return null;
+
+  const arrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
+  if (arrivals.length === 0) return null;
+
+  const trainCode = pickAutoTrainCode(arrivals, line, null);
+  if (!trainCode) return null;
+
+  return {
+    trainCode,
+    line,
+    subwayId,
+    selectedDepartureTime: now,
+    segmentStations,
+    expiresAt: now + SWAP_LOCK_TTL_MS,
+  };
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -32,6 +32,7 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { matchLine } from './lineAlias';
+import { attachTrainCodeForLeg } from './lockSwap';
 import {
   evaluateWindow,
   readSeries,
@@ -496,7 +497,19 @@ async function mirrorProgress(
  *
  * 3단계로 분리: estimate → arrival 시 waypoint 진행(early return) → 아니면 reschedule push.
  * push가 trip 도착 시점에 의미 없으므로 도착 케이스를 먼저 처리해 dirty write를 단일화.
+ *
+ * #902 Seam F — estimate=null이고 누적 miss가 임계(VANISH_RE_ATTACH_THRESHOLD) 도달 직전이면
+ * 같은 station/line의 신규 trainCode를 자동 swap 후 같은 cycle에 재estimate한다.
  */
+
+/**
+ * #902 Seam F — trainCode 사라짐 후 재attach 시도 임계.
+ * `consecutiveEtaMissing`이 이 값에 도달한 미스 cycle에서 한 번 swap을 시도한다.
+ * 1회로는 일시적 API 누락과 진짜 사라짐을 구분하지 못해 false swap 위험이 크므로 2로 둔다.
+ * (그 미만 미스는 단순 누락으로 간주 + 카운터 증가만).
+ */
+export const VANISH_RE_ATTACH_THRESHOLD = 2;
+
 export async function runTrainCodeTracking(
   trip: Trip,
   waypoint: Waypoint,
@@ -508,14 +521,48 @@ export async function runTrainCodeTracking(
   log: Logger,
   generatePushId: () => string,
 ): Promise<void> {
-  const estimate = await estimateBoardingLockArrival(deps, lock, waypoint, now);
+  let activeLock = lock;
+  let estimate = await estimateBoardingLockArrival(deps, activeLock, waypoint, now);
+  if (estimate === null) {
+    const previousMissCount = trip.consecutiveEtaMissing ?? 0;
+    // #902 Seam F — 사라짐 후 재attach. previous=1 + 이번 미스 = 2 도달 시 1회 swap 시도.
+    // 같은 station에 같은 line 신규 trainCode가 보이면 lock을 교체하고 이번 cycle에 재estimate.
+    // 성공 시 그 아래의 정상 경로(arrived/reschedule)로 자연 진입.
+    const reachedVanishThreshold = previousMissCount + 1 >= VANISH_RE_ATTACH_THRESHOLD;
+    if (reachedVanishThreshold) {
+      const swapped = await attachTrainCodeForLeg({
+        trip,
+        targetWaypoint: waypoint,
+        seoul: deps.seoul,
+        now,
+      });
+      if (swapped && swapped.trainCode !== activeLock.trainCode) {
+        log('boarding-lock: trainCode vanished, swapped', {
+          token: trip.token.slice(0, 8),
+          previousTrainCode: activeLock.trainCode,
+          newTrainCode: swapped.trainCode,
+          station: waypoint.stationName,
+          consecutiveEtaMissing: previousMissCount + 1,
+        });
+        // segmentStations는 기존 lock 것을 유지 (이미 진행 중인 leg) — 새 trainCode/expiresAt만 채택.
+        activeLock = {
+          ...activeLock,
+          trainCode: swapped.trainCode,
+          expiresAt: Math.max(activeLock.expiresAt, swapped.expiresAt),
+        };
+        trip.boardingLock = activeLock;
+        trip.consecutiveEtaMissing = 0;
+        estimate = await estimateBoardingLockArrival(deps, activeLock, waypoint, now);
+      }
+    }
+  }
   if (estimate === null) {
     stats.etaMissing += 1;
     const previousMissCount = trip.consecutiveEtaMissing ?? 0;
     const nextMissCount = previousMissCount + 1;
     log('boarding-lock: trainCode not found in arrivals or positions', {
       token: trip.token.slice(0, 8),
-      trainCode: lock.trainCode,
+      trainCode: activeLock.trainCode,
       station: waypoint.stationName,
       consecutiveEtaMissing: nextMissCount,
     });
@@ -526,7 +573,7 @@ export async function runTrainCodeTracking(
       // #868 — 클라 state sync용 trip-ended silent push 발사 (reason=eta-missing).
       log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
         token: trip.token.slice(0, 8),
-        trainCode: lock.trainCode,
+        trainCode: activeLock.trainCode,
         station: waypoint.stationName,
         threshold,
         subsurface: trip.subsurface === true,
@@ -558,7 +605,7 @@ export async function runTrainCodeTracking(
   const { cleanedUp } = await maybeReschedulePush(
     trip,
     waypoint,
-    lock,
+    activeLock,
     estimate.epoch,
     env,
     deps,
@@ -664,6 +711,24 @@ export async function advanceBoardingLockWaypoint(
     trip.consecutiveEtaMissing = 0;
     await deleteProgress(env.TRIPS, trip.token);
   }
+  // #902 Seam F — 환승 직후 자동 trainCode swap. release한 lock 자리에 새 노선의 후보를
+  // 동일 cycle 안에 부착해 다음 cycle의 lockMissing/boarding-prompt 우회 + 즉시 trainCode 추적.
+  // 후보 ambiguity / arrivals 비어있음 / subwayId 매핑 누락이면 attempted=true + 결과 null →
+  // 기존 lockMissing → evaluateAndMaybeFireBoardingPrompt fallback 흐름이 그대로 살아있다.
+  let transferSwapAttached = false;
+  if (lockReleasedOnTransfer && trip.waypoints.length > 0) {
+    const next = trip.waypoints[0];
+    const swapped = await attachTrainCodeForLeg({
+      trip,
+      targetWaypoint: next,
+      seoul: deps.seoul,
+      now,
+    });
+    if (swapped) {
+      trip.boardingLock = swapped;
+      transferSwapAttached = true;
+    }
+  }
   log('boarding-lock: waypoint advanced', {
     token: trip.token.slice(0, 8),
     completed: waypoint.stationName,
@@ -671,6 +736,7 @@ export async function advanceBoardingLockWaypoint(
     remaining: trip.waypoints.length,
     // P2-2: true일 때만 log key 포함 — false noise로 운영 로그 가시성 저하 방지.
     ...(lockReleasedOnTransfer ? { lockReleasedOnTransfer: true } : {}),
+    ...(transferSwapAttached ? { transferSwapAttached: true } : {}),
   });
   if (trip.waypoints.length === 0) {
     // #868 — waypoints 소진(intermediate 마지막 통과)도 effective destination-arrived.


### PR DESCRIPTION
Closes #902
Parent epic: #896
의존: Seam E(#901) — sync 채널 위에 동작.

## Why

2026-06-05 실기기 로그 결함 2건:

1. **환승 직후 trainCode 자동 교체 없음** (13:24~28, 5분 손실). `boarding-lock: waypoint advanced (transfer)` 직후에도 옛 노선의 trainCode 2227(2호선)을 7호선 어린이대공원에서 찾아 5 etaMissing 후 trip auto-end.
2. **trainCode가 OpenAPI에서 사라지면 다음 후보 모름** (13:39~45, 6분 손실). 7174 7호선 어린이대공원 떠난 후 군자/중곡으로 누가 다음 trainCode인지 모름.

## What

### `backend/alarm-worker/src/lockSwap.ts` (신규)
순수 pipeline 모듈 — KV/네트워크 직접 의존 없음.
- `buildLegSegmentStations(waypoints, line)` — `trip.waypoints[0]`부터 같은 line이 유지되는 동안 stationName 수집. transfer/destination kind에 도달하면 포함하고 종료.
- `attachTrainCodeForLeg({trip, targetWaypoint, seoul, now})` — target station/line의 arrivals를 폴해 `pickAutoTrainCode`(arvlCd 우선순위 2>1>0)로 후보 1개 결정 → 새 `BoardingLockMeta` 합성. `subwayId`는 `LINE_META` 데이터 주도 매핑.
- `SWAP_LOCK_TTL_MS = 30분` — Seam E sync가 곧 TTL을 정정해도 lock 활성 유지 마진.

### `backend/alarm-worker/src/lineAlias.ts`
- `LineMeta`에 `subwayId` 필드 추가 (1호선~9호선/경의중앙/공항철도/수인분당/신분당). 클라 `LINE_TO_SUBWAY_ID`와 정합.
- `subwayIdForLine(line)` 데이터 주도 헬퍼.

### `backend/alarm-worker/src/scheduled.ts`
- `advanceBoardingLockWaypoint`: transfer release 직후 같은 cycle 안에서 `attachTrainCodeForLeg` 호출. 성공 시 `trip.boardingLock` 합성 + `transferSwapAttached: true` 로그. 실패하면 기존 lockMissing → boarding-prompt fallback 흐름 그대로.
- `runTrainCodeTracking`: estimate=null이고 누적 miss + 이번 미스 ≥ `VANISH_RE_ATTACH_THRESHOLD(=2)`이면 같은 station/line의 신규 trainCode 1회 swap 시도. 성공 시 `boarding-lock: trainCode vanished, swapped` 로그 + 카운터 reset + 같은 cycle 재estimate로 정상 경로(arrived/reschedule) 진입.
- 임계 2로 설정 — 1회 미스로 swap하면 일시적 API 누락에서 false swap 위험.

### 사용자 입력 0
UI 변경 없음. backend 자율 처리.

## Acceptance

- 환승 transfer waypoint ARRIVED → 같은 cycle 안에 새 노선 후보 trainCode 1개 attach 검증 (`runScheduled — Seam F 환승 자동 swap (#902)`).
- 후보 ambiguity/빈 arrivals → 기존 boarding-prompt 흐름 유지 검증.
- 누적 miss=1 + 이번 miss → swap 성공 시 trainCode 갱신 + 카운터 reset 검증.
- 누적 miss=0 첫 cycle은 swap 안 함 (일시적 누락 인내) 검증.
- 누적 miss=1 + 이번 miss + ambiguity → swap 실패 + 카운터 누적 검증.
- 단위 14건(`lockSwap.test.ts`) + 통합 6건(`scheduled.test.ts`) + lineAlias 13건 = 33건 신규.

## Tests

- backend: 756 passed (33 new), type-check pass*
- client: 3583 passed, 100% coverage
- root type-check: pass

*pre-existing TS errors in scheduled.test.ts:1376/1436 (verified with `git stash`, exist on `dev`). 본 PR 미관련.

## Sonar new_duplicated_lines_density

- 신규 테스트 fixture 빌더(`rawArrivalRow` + `arrivalListResponse`)로 `realtimeArrivalList` raw row 중복 제거.
- 신규 backend 헬퍼는 `pickAutoTrainCode`(boardingPrompt.ts) + `LINE_META`(lineAlias.ts) 재사용으로 validation/매핑 dup 회피.