### PR TITLE
refactor(#899): Seam C — 상태 hydration seam 통합

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,6 +24,7 @@ import { unregisterAlarmRefreshTask } from '../src/features/alarm/tasks/alarmRef
 import { stopVibration } from '../src/features/alarm/utils/alarmSound';
 import { setupBoardingPromptCategory } from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
+import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
 import { fetchArrivalInfo } from '../src/features/arrival/api/arrivalApi';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../src/shared/constants/boardingLock';
 
@@ -83,6 +84,11 @@ function RootContent() {
     destinationId,
     expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
   });
+
+  // #899 (Seam C) — trip-bound 상태 단일 hydration seam. AppState 'active' 진입 시
+  // destination/customOrigin/tripOrigin/lock을 storage에서 재수화하고, BG silent push가
+  // trip-ended sentinel을 남겼다면 destination/lock store를 reset해 stale UI를 차단.
+  useStateRehydration();
 
   useEffect(() => {
     loadLocalePreference();

--- a/src/features/alarm/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
@@ -163,7 +163,7 @@ describe('useBoardingLockAutoRelease', () => {
       rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
     });
     expect(releaseLock).toHaveBeenCalledTimes(1);
-    expect(mockLoggerInfo).toHaveBeenCalledWith('도착 grace 충족 → lock 자동 release');
+    expect(mockLoggerInfo).toHaveBeenCalledWith('destination grace 충족 → lock 자동 release');
   });
 
   it('grace 만료 후 같은 조건 유지되어도 중복 release 안 함 (ref 리셋되어 새 카운트)', () => {
@@ -243,6 +243,126 @@ describe('useBoardingLockAutoRelease', () => {
     // 사용자가 막 탑승 — 도착 조건 충족하나 첫 진입
     withDateNow(T0 + 100, () => {
       rerender(baseInputs({ releaseLock }));
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  // ── #899 (Seam C) — 환승 waypoint 자동 release 분기 ──
+
+  const transferStation: Station = {
+    id: 'transfer-1',
+    name: '왕십리',
+    line: '2',
+    lineColor: '#000',
+    lat: 37.6,
+    lng: 127.0,
+  };
+  const transferRoute = {
+    type: 'transfer' as const,
+    transferName: '왕십리',
+    fromLine: '2' as const,
+    toLine: '5' as const,
+    stopsToTransfer: 3,
+    stopsFromTransfer: 4,
+    secondsToTransfer: 360,
+    secondsFromTransfer: 480,
+  };
+
+  it('환승 leg waypoint 도달 + proximity → grace 후 release', () => {
+    const releaseLock = jest.fn();
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: transferRoute,
+    });
+    const { rerender } = mountAtT0(inputs);
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenCalledWith('transfer grace 충족 → lock 자동 release');
+  });
+
+  it('route=null이면 환승 분기 불가 — 비목적지에서 release 안 함', () => {
+    const releaseLock = jest.fn();
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: null,
+    });
+    const { rerender } = mountAtT0(inputs);
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('환승 leg fromLine과 lock.boardingLine 불일치면 release 안 함 (동명이역 회피)', () => {
+    const releaseLock = jest.fn();
+    const wrongLine = { ...transferRoute, fromLine: '5' as const };
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: wrongLine,
+    });
+    const { rerender } = mountAtT0(inputs);
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('multi-transfer route — 첫 환승역 매칭 시에도 release', () => {
+    const releaseLock = jest.fn();
+    const multiRoute = {
+      type: 'multi-transfer' as const,
+      transfers: [
+        {
+          transferName: '왕십리',
+          fromLine: '2' as const,
+          toLine: '5' as const,
+          stopsToTransfer: 3,
+          secondsToTransfer: 360,
+        },
+        {
+          transferName: '광화문',
+          fromLine: '5' as const,
+          toLine: '3' as const,
+          stopsToTransfer: 2,
+          secondsToTransfer: 240,
+        },
+      ],
+      stopsAfterLastTransfer: 4,
+      secondsAfterLastTransfer: 480,
+    };
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: multiRoute,
+    });
+    const { rerender } = mountAtT0(inputs);
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('direct route는 transfer 분기 없음 — 비목적지에서 release 안 함', () => {
+    const releaseLock = jest.fn();
+    const directRoute = {
+      type: 'direct' as const,
+      stops: 5,
+      line: '2' as const,
+      travelSeconds: 600,
+    };
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: directRoute,
+    });
+    const { rerender } = mountAtT0(inputs);
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
     });
     expect(releaseLock).not.toHaveBeenCalled();
   });

--- a/src/features/alarm/hooks/useBoardingLockAutoRelease.ts
+++ b/src/features/alarm/hooks/useBoardingLockAutoRelease.ts
@@ -1,11 +1,13 @@
 import { useEffect, useRef } from 'react';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { Station } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
 import {
   ARRIVAL_PROXIMITY_THRESHOLD_M,
   AUTO_RELEASE_GRACE_MS,
 } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
+import { getTransferLegs } from '../../route/utils/transferLegs';
 
 const logger = createLogger('useBoardingLockAutoRelease');
 
@@ -20,6 +22,11 @@ export interface UseBoardingLockAutoReleaseInputs {
   distanceKm: number | null;
   /** Lock 해제 액션. useBoardingLockController.releaseLock 또는 store releaseLock 위임. */
   releaseLock: () => void;
+  /**
+   * 활성 trip route. null이면 환승 leg 분기는 동작하지 않고 도착 분기만 평가.
+   * #899 (Seam C) — 환승 leg 도달 시 lock 자동 release을 위해 추가.
+   */
+  route?: Route;
 }
 
 /**
@@ -27,9 +34,15 @@ export interface UseBoardingLockAutoReleaseInputs {
  *
  * 활성 BoardingLock + 도착 신호 지속 시 lock을 자동 해제한다.
  *
+ * 매칭 분기 (#899 Seam C — 환승 분기 추가):
+ *  1) 목적지 도달: currentStation.id == destinationId.
+ *  2) 환승 leg 도달: route의 어떤 transfer leg의 transferName/fromLine이
+ *     lock.boardingLine과 일치하고 그 leg의 transferName이 currentStation.name과 일치.
+ *     → 사용자가 새 leg에 탑승하는 사이 stale lock이 남는 회귀(#899) 차단.
+ *
  * 트리거 조건:
  *  - lock active
- *  - fusion currentStation.id == destination
+ *  - 위 매칭 분기 중 하나 true
  *  - distance < ARRIVAL_PROXIMITY_THRESHOLD_M
  *  - 위 셋이 AUTO_RELEASE_GRACE_MS 이상 지속
  *
@@ -39,8 +52,8 @@ export interface UseBoardingLockAutoReleaseInputs {
  *    (b) 조건 미충족 → ref 리셋 (다음 진입에서 새로 카운트 시작).
  *  - lock.trainCode 변경(새 trip/leg) 시 ref 리셋 — 이전 trip의 진입 ts가 새 trip에 흘러가지 않음.
  *
- * 환승 trip의 마지막 hop도 동일 처리 — destinationId 기준으로 매칭하므로 환승 시점 leg의 도착이
- * 아닌 trip 최종 도착에서만 발화한다.
+ * 환승 trip의 마지막 hop도 동일 처리 — 마지막 hop은 destinationId 매칭, 그 외 hop은
+ * transfer leg 매칭으로 발화한다.
  *
  * sleep mode와 무관: release는 알람 발화가 아니라 lock 라이프사이클 정리.
  *
@@ -56,6 +69,7 @@ export function useBoardingLockAutoRelease({
   currentStation,
   distanceKm,
   releaseLock,
+  route = null,
 }: UseBoardingLockAutoReleaseInputs): void {
   const firstArrivedAtRef = useRef<number | null>(null);
   const lastTrainCodeRef = useRef<string | null>(null);
@@ -72,9 +86,14 @@ export function useBoardingLockAutoRelease({
       return;
     }
 
-    const stationMatched = currentStation.id === destinationId;
+    const matchKind = matchReleaseTarget(
+      currentStation,
+      destinationId,
+      route,
+      lock.boardingLine,
+    );
     const proximityOk = distanceKm * 1000 < ARRIVAL_PROXIMITY_THRESHOLD_M;
-    if (!stationMatched || !proximityOk) {
+    if (matchKind === null || !proximityOk) {
       firstArrivedAtRef.current = null;
       return;
     }
@@ -87,8 +106,31 @@ export function useBoardingLockAutoRelease({
 
     if (now - firstArrivedAtRef.current >= AUTO_RELEASE_GRACE_MS) {
       firstArrivedAtRef.current = null;
-      logger.info('도착 grace 충족 → lock 자동 release');
+      logger.info(`${matchKind} grace 충족 → lock 자동 release`);
       releaseLock();
     }
-  }, [lock, destinationId, currentStation, distanceKm, releaseLock]);
+  }, [lock, destinationId, currentStation, distanceKm, releaseLock, route]);
+}
+
+/**
+ * 현재역이 release 대상인지 판정한다.
+ * - 'destination': trip 최종 도착역 매칭.
+ * - 'transfer': route의 transfer leg 중 boardingLine과 일치하는 leg의 환승역 매칭.
+ * - null: 매칭 없음.
+ *
+ * 동명이역 회피: transfer 매칭은 leg.fromLine과 lock.boardingLine이 같아야 한다.
+ * 같은 leg에서 destination/transfer가 동시에 매칭될 수는 없다 (destination은 id 매칭).
+ */
+function matchReleaseTarget(
+  currentStation: Station,
+  destinationId: string,
+  route: Route,
+  boardingLine: string,
+): 'destination' | 'transfer' | null {
+  if (currentStation.id === destinationId) return 'destination';
+  const legs = getTransferLegs(route);
+  const matched = legs.some(
+    (leg) => leg.fromLine === boardingLine && leg.transferName === currentStation.name,
+  );
+  return matched ? 'transfer' : null;
 }

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -41,6 +41,12 @@ jest.mock('../../store/tripBoundCleanups', () => ({
   runTripBoundCleanups: () => mockRunTripBoundCleanups(),
 }));
 
+// #899 (Seam C) — trip-ended 분기는 FG 복귀를 위한 sentinel을 작성한다.
+const mockSetTripEndedSentinel = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/tripEndedSentinel', () => ({
+  setTripEndedSentinel: (...args: unknown[]) => mockSetTripEndedSentinel(...args),
+}));
+
 const mockCheckGate = jest.fn();
 jest.mock('../../utils/silentPushLocationGate', () => ({
   checkSilentPushLocationGate: (...args: unknown[]) => mockCheckGate(...args),
@@ -1325,6 +1331,27 @@ describe('silentPushTask', () => {
         // tripToken 누락 = 구버전 backend
         await handleSilentPush(tripEndedPayload());
         expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      });
+
+      // #899 (Seam C) — BG에서는 zustand에 접근 불가 → sentinel을 작성해 FG 복귀 시 store reset 트리거.
+      it('#899 (Seam C) — cleanup 완료 후 setTripEndedSentinel 호출', async () => {
+        await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+        expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+        expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
+        expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(expect.any(Number));
+      });
+
+      it('#899 (Seam C) — tripToken mismatch로 cleanup skip 시 sentinel도 작성 안 함', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return 'NEW-TRIP-TOKEN';
+          return null;
+        });
+        await handleSilentPush(
+          tripEndedPayload({ pushId: 'te-uuid', tripToken: 'OLD-TRIP-TOKEN' }),
+        );
+        expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+        expect(mockSetTripEndedSentinel).not.toHaveBeenCalled();
       });
 
       it('#868 P1-2 — ACTIVE_TRIP_KEY가 null(클라 이미 trip 종료)이면 cleanup 진행', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -46,6 +46,7 @@ import {
   type AlarmLogReason,
 } from '../utils/alarmLog';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
+import { setTripEndedSentinel } from '../utils/tripEndedSentinel';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
@@ -447,6 +448,9 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         receivedAt,
       });
       await runTripBoundCleanups();
+      // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
+      // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
+      await setTripEndedSentinel(receivedAt);
       ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}`);
       return;
     }

--- a/src/features/alarm/utils/__tests__/tripEndedSentinel.test.ts
+++ b/src/features/alarm/utils/__tests__/tripEndedSentinel.test.ts
@@ -1,0 +1,74 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  clearTripEndedSentinel,
+  getTripEndedSentinel,
+  setTripEndedSentinel,
+} from '../tripEndedSentinel';
+import { TRIP_ENDED_BY_BACKEND_AT_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const setItemMock = AsyncStorage.setItem as jest.Mock;
+const getItemMock = AsyncStorage.getItem as jest.Mock;
+const removeItemMock = AsyncStorage.removeItem as jest.Mock;
+
+describe('tripEndedSentinel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setItemMock.mockResolvedValue(undefined);
+    removeItemMock.mockResolvedValue(undefined);
+  });
+
+  it('setTripEndedSentinel — at 인자를 문자열로 직렬화해 sentinel 키에 저장', async () => {
+    await setTripEndedSentinel(1_700_000_000_000);
+    expect(setItemMock).toHaveBeenCalledWith(TRIP_ENDED_BY_BACKEND_AT_KEY, '1700000000000');
+  });
+
+  it('setTripEndedSentinel — 기본값은 Date.now()', async () => {
+    const now = 1_710_000_000_000;
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      await setTripEndedSentinel();
+    } finally {
+      spy.mockRestore();
+    }
+    expect(setItemMock).toHaveBeenCalledWith(TRIP_ENDED_BY_BACKEND_AT_KEY, String(now));
+  });
+
+  it('setTripEndedSentinel — AsyncStorage 실패는 흡수 (graceful)', async () => {
+    setItemMock.mockRejectedValueOnce(new Error('disk full'));
+    await expect(setTripEndedSentinel(1)).resolves.toBeUndefined();
+  });
+
+  it.each<[string, unknown, number | null]>([
+    ['숫자 문자열', '1700000000000', 1_700_000_000_000],
+    ['키 부재(null)', null, null],
+    ['NaN 문자열', 'abc', null],
+    ['빈 문자열은 Number("")=0이라 0 반환', '', 0],
+  ])('getTripEndedSentinel — %s → %s', async (_label, raw, expected) => {
+    getItemMock.mockResolvedValueOnce(raw);
+    await expect(getTripEndedSentinel()).resolves.toBe(expected);
+  });
+
+  it('getTripEndedSentinel — AsyncStorage 실패 시 null', async () => {
+    getItemMock.mockRejectedValueOnce(new Error('boom'));
+    await expect(getTripEndedSentinel()).resolves.toBeNull();
+  });
+
+  it('clearTripEndedSentinel — removeItem 호출', async () => {
+    await clearTripEndedSentinel();
+    expect(removeItemMock).toHaveBeenCalledWith(TRIP_ENDED_BY_BACKEND_AT_KEY);
+  });
+
+  it('clearTripEndedSentinel — 실패는 흡수', async () => {
+    removeItemMock.mockRejectedValueOnce(new Error('boom'));
+    await expect(clearTripEndedSentinel()).resolves.toBeUndefined();
+  });
+});

--- a/src/features/alarm/utils/tripEndedSentinel.ts
+++ b/src/features/alarm/utils/tripEndedSentinel.ts
@@ -1,0 +1,44 @@
+/**
+ * Trip-ended sentinel storage (#899 Seam C).
+ *
+ * BG silent push trip-ended 핸들러가 작성하는 키. zustand store에 BG에서 접근할 수
+ * 없어 storage cleanup만 수행하는데, FG 복귀 시 useStateRehydration이 이 키를 보고
+ * destination/lock store를 reset해 stale UI를 차단한다.
+ *
+ * SSOT key: storageKeys.TRIP_ENDED_BY_BACKEND_AT_KEY.
+ *
+ * 모든 함수는 AsyncStorage 실패를 graceful하게 흡수 — sentinel은 보조 채널이므로
+ * 실패해도 storage cleanup 자체의 효력은 유지된다.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TRIP_ENDED_BY_BACKEND_AT_KEY } from '../../../shared/constants/storageKeys';
+
+/** sentinel 작성. trip-ended silent push 수신 시점에 호출. */
+export async function setTripEndedSentinel(at: number = Date.now()): Promise<void> {
+  try {
+    await AsyncStorage.setItem(TRIP_ENDED_BY_BACKEND_AT_KEY, String(at));
+  } catch {
+    // sentinel 실패는 graceful — storage cleanup은 이미 수행됨.
+  }
+}
+
+/** sentinel epoch ms 또는 null. 값이 NaN/누락이면 null. */
+export async function getTripEndedSentinel(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(TRIP_ENDED_BY_BACKEND_AT_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** sentinel 처리 완료 시 호출. 다음 trip-ended를 다시 감지할 수 있도록 키 삭제. */
+export async function clearTripEndedSentinel(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(TRIP_ENDED_BY_BACKEND_AT_KEY);
+  } catch {
+    // graceful — 다음 reset 호출에서 재시도된다.
+  }
+}

--- a/src/features/route/utils/__tests__/transferLegs.test.ts
+++ b/src/features/route/utils/__tests__/transferLegs.test.ts
@@ -1,0 +1,64 @@
+import { getTransferLegs } from '../transferLegs';
+import type {
+  DirectRoute,
+  MultiTransferRoute,
+  TransferRoute,
+} from '../../../../shared/utils/stationRoute';
+
+describe('getTransferLegs', () => {
+  it('null → []', () => {
+    expect(getTransferLegs(null)).toEqual([]);
+  });
+
+  it('direct → [] (환승 없음)', () => {
+    const route: DirectRoute = {
+      type: 'direct',
+      stops: 5,
+      line: '2',
+      travelSeconds: 600,
+    };
+    expect(getTransferLegs(route)).toEqual([]);
+  });
+
+  it('transfer → 1 leg (fromLine 보존)', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '왕십리',
+      fromLine: '2',
+      toLine: '5',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 4,
+      secondsToTransfer: 360,
+      secondsFromTransfer: 480,
+    };
+    expect(getTransferLegs(route)).toEqual([{ transferName: '왕십리', fromLine: '2' }]);
+  });
+
+  it('multi-transfer → transfers 순서 보존 (fromLine만 추출)', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        {
+          transferName: '왕십리',
+          fromLine: '2',
+          toLine: '5',
+          stopsToTransfer: 3,
+          secondsToTransfer: 360,
+        },
+        {
+          transferName: '광화문',
+          fromLine: '5',
+          toLine: '3',
+          stopsToTransfer: 2,
+          secondsToTransfer: 240,
+        },
+      ],
+      stopsAfterLastTransfer: 4,
+      secondsAfterLastTransfer: 480,
+    };
+    expect(getTransferLegs(route)).toEqual([
+      { transferName: '왕십리', fromLine: '2' },
+      { transferName: '광화문', fromLine: '5' },
+    ]);
+  });
+});

--- a/src/features/route/utils/transferLegs.ts
+++ b/src/features/route/utils/transferLegs.ts
@@ -1,0 +1,39 @@
+/**
+ * Route → transfer leg 평탄화 (#899 Seam C).
+ *
+ * `useBoardingLockAutoRelease`가 환승 waypoint 자동 release 분기에서 사용한다.
+ * Route 타입(direct/transfer/multi-transfer) 분기 대신 호출처는 단일 배열 순회로
+ * lock.boardingLine과 매칭되는 leg를 찾는다 — Route 분기가 transferLegs 한 곳에만
+ * 존재하도록 격리한다.
+ *
+ * leg는 "어느 노선을 타고 어느 역까지 가서 갈아탄다"의 단위:
+ *  - DirectRoute: leg 없음 (환승이 없으므로 도착 release만 발화).
+ *  - TransferRoute: 1개 leg.
+ *  - MultiTransferRoute: transfers.length 개 leg.
+ */
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { LineNumber } from '../../../shared/types/station';
+
+export interface TransferLeg {
+  /** 환승역 이름 (stations.json의 name과 일치). */
+  transferName: string;
+  /** 현재 leg에서 타고 있는 노선. lock.boardingLine과 비교해 매칭한다. */
+  fromLine: LineNumber;
+}
+
+/**
+ * Route → TransferLeg[]. null/direct는 [] 반환 — 호출처는 빈 배열을 자연스럽게 처리.
+ *
+ * 정렬 보장: trip 진행 순서(첫 환승부터). 다음 leg는 array[i+1].
+ */
+export function getTransferLegs(route: Route): TransferLeg[] {
+  if (!route) return [];
+  if (route.type === 'direct') return [];
+  if (route.type === 'transfer') {
+    return [{ transferName: route.transferName, fromLine: route.fromLine }];
+  }
+  return route.transfers.map((t) => ({
+    transferName: t.transferName,
+    fromLine: t.fromLine,
+  }));
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -278,12 +278,14 @@ export default function HomeScreen() {
   });
   // #759 — 목적지역 도착 grace 후 lock 자동 release. 명시 "하차" 버튼은 그대로 유지하며,
   // 사용자가 누르지 않은 정상 도착 케이스만 처리. sleep mode와 무관.
+  // #899 (Seam C) — route를 전달해 환승 leg waypoint 도달 시에도 자동 release.
   useBoardingLockAutoRelease({
     lock: boardingLock,
     destinationId: destination?.id ?? null,
     currentStation: result?.station ?? null,
     distanceKm: result?.distanceKm ?? null,
     releaseLock: releaseBoardingLock,
+    route,
   });
   // #584 PR D3: lock.boardingLine 위치 데이터를 별도 구독 — fusion 캐시와 dedup되어 추가 비용 없음.
   // lock 없으면 line=null로 호출되어 polling이 자동 정지된다.

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -71,6 +71,15 @@ export const DISMISS_SILENCE_KEY = 'subway-now:dismiss-silence';
 // 형식: {"station": Station, "lockedAt": number} JSON.
 // TTL(30분) 경과 또는 1km+ 이동 또는 automotive motion 시 unlock.
 export const STICKY_STATION_KEY = 'subway-now:sticky-station';
+// #899 (Seam C) — silent push trip-ended 핸들러가 BG에서 작성하는 sentinel.
+// BG에서는 zustand store에 접근할 수 없어 storage cleanup만 수행하는데, 그러면
+// FG 복귀 시 hydrated 직전의 in-memory store 상태(destination/lock 등)가 stale로
+// 잠시 노출된다. trip-ended 시 이 키에 epoch ms를 쓰면 useStateRehydration이
+// AppState 'active' 진입 시 키를 읽고 sentinel 이후 destination/lock store를
+// reset해 stale UI를 차단한다. 처리 후 키를 즉시 삭제 — 키가 다시 나타나면
+// 또 다른 trip-ended를 의미.
+// 형식: 숫자 (epoch ms) 문자열.
+export const TRIP_ENDED_BY_BACKEND_AT_KEY = 'subway-now:trip-ended-by-backend-at';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -1,0 +1,134 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { AppState, type AppStateStatus } from 'react-native';
+import { useStateRehydration } from '../useStateRehydration';
+import { useDestinationStore } from '../../../features/route/store/useDestinationStore';
+import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingLockStore';
+
+const mockGetSentinel = jest.fn();
+const mockClearSentinel = jest.fn();
+jest.mock('../../../features/alarm/utils/tripEndedSentinel', () => ({
+  getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
+  clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
+  setTripEndedSentinel: jest.fn(),
+}));
+
+// destination store cross-feature import는 storage helper 안에서 일어나므로 spy로 충분.
+// useDestinationStore.getState()를 그대로 사용한다 (실제 store)
+
+const mockSetDestination = jest.fn();
+const mockLoadDestination = jest.fn();
+const mockLoadCustomOrigin = jest.fn();
+const mockLoadTripOrigin = jest.fn();
+
+const mockReleaseLock = jest.fn();
+const mockLoadLock = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSentinel.mockResolvedValue(null);
+  mockClearSentinel.mockResolvedValue(undefined);
+  mockSetDestination.mockReturnValue(undefined);
+  mockLoadDestination.mockResolvedValue(undefined);
+  mockLoadCustomOrigin.mockResolvedValue(undefined);
+  mockLoadTripOrigin.mockResolvedValue(undefined);
+  mockReleaseLock.mockResolvedValue(undefined);
+  mockLoadLock.mockResolvedValue(undefined);
+  jest.spyOn(useDestinationStore, 'getState').mockReturnValue({
+    setDestination: mockSetDestination,
+    loadDestination: mockLoadDestination,
+    loadCustomOrigin: mockLoadCustomOrigin,
+    loadTripOrigin: mockLoadTripOrigin,
+  } as unknown as ReturnType<typeof useDestinationStore.getState>);
+  jest.spyOn(useBoardingLockStore, 'getState').mockReturnValue({
+    releaseLock: mockReleaseLock,
+    loadLock: mockLoadLock,
+  } as unknown as ReturnType<typeof useBoardingLockStore.getState>);
+});
+
+function mockAppState(): {
+  emit: (state: AppStateStatus) => void;
+  remove: jest.Mock;
+} {
+  const remove = jest.fn();
+  let handler: ((state: AppStateStatus) => void) | null = null;
+  jest.spyOn(AppState, 'addEventListener').mockImplementation((event, h) => {
+    if (event === 'change') handler = h as typeof handler;
+    return { remove } as ReturnType<typeof AppState.addEventListener>;
+  });
+  return {
+    emit: (state) => handler?.(state),
+    remove,
+  };
+}
+
+describe('useStateRehydration', () => {
+  it('마운트 시 destination/customOrigin/tripOrigin/lock load 모두 호출', async () => {
+    mockAppState();
+    renderHook(() => useStateRehydration());
+    await waitFor(() => {
+      expect(mockLoadDestination).toHaveBeenCalled();
+      expect(mockLoadCustomOrigin).toHaveBeenCalled();
+      expect(mockLoadTripOrigin).toHaveBeenCalled();
+      expect(mockLoadLock).toHaveBeenCalled();
+    });
+  });
+
+  it('sentinel 없음 — store reset 호출 안 함', async () => {
+    mockGetSentinel.mockResolvedValue(null);
+    mockAppState();
+    renderHook(() => useStateRehydration());
+    await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+    expect(mockSetDestination).not.toHaveBeenCalled();
+    expect(mockReleaseLock).not.toHaveBeenCalled();
+    expect(mockClearSentinel).not.toHaveBeenCalled();
+  });
+
+  it('sentinel 있음 — setDestination(null) + releaseLock + sentinel clear', async () => {
+    mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+    mockAppState();
+    renderHook(() => useStateRehydration());
+    await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
+    expect(mockSetDestination).toHaveBeenCalledWith(null);
+    expect(mockReleaseLock).toHaveBeenCalled();
+  });
+
+  it("AppState 'active' 진입 시 재실행", async () => {
+    const app = mockAppState();
+    renderHook(() => useStateRehydration());
+    await waitFor(() => expect(mockLoadDestination).toHaveBeenCalledTimes(1));
+
+    app.emit('active');
+    await waitFor(() => expect(mockLoadDestination).toHaveBeenCalledTimes(2));
+  });
+
+  it("AppState 비'active'는 무시", async () => {
+    const app = mockAppState();
+    renderHook(() => useStateRehydration());
+    await waitFor(() => expect(mockLoadDestination).toHaveBeenCalledTimes(1));
+
+    app.emit('background');
+    app.emit('inactive');
+    // 마운트 1회 외 추가 호출 없음
+    expect(mockLoadDestination).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmount 시 AppState listener remove', () => {
+    const app = mockAppState();
+    const { unmount } = renderHook(() => useStateRehydration());
+    unmount();
+    expect(app.remove).toHaveBeenCalled();
+  });
+
+  it('active 진입에서도 sentinel 있으면 reset 호출', async () => {
+    const app = mockAppState();
+    mockGetSentinel.mockResolvedValueOnce(null);
+    renderHook(() => useStateRehydration());
+    await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+    expect(mockSetDestination).not.toHaveBeenCalled();
+
+    mockGetSentinel.mockResolvedValueOnce(1_700_000_000_001);
+    app.emit('active');
+    await waitFor(() => expect(mockSetDestination).toHaveBeenCalledWith(null));
+    expect(mockReleaseLock).toHaveBeenCalled();
+  });
+});

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -1,0 +1,69 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 본 hook은 trip 상태가 살고 있는 모든 zustand store를
+ * 한 곳에서 재수화·동기화하는 orchestrator. 여러 feature(route/alarm)의 store를 직접
+ * 참조하는 것이 본질이므로 file-level disable로 옵트인 처리.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import { useEffect } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { useDestinationStore } from '../../features/route/store/useDestinationStore';
+import { useBoardingLockStore } from '../../features/alarm/store/useBoardingLockStore';
+import {
+  clearTripEndedSentinel,
+  getTripEndedSentinel,
+} from '../../features/alarm/utils/tripEndedSentinel';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useStateRehydration');
+
+/**
+ * FG 복귀 시 상태 hydration seam (#899 Seam C).
+ *
+ * 책임:
+ *  1) 마운트 + AppState 'active' 진입마다 trip-bound store(destination/customOrigin/
+ *     tripOrigin/lock)를 storage에서 재수화 — BG 동안 다른 채널(silent push 등)이 storage를
+ *     갱신했을 수 있으므로 zustand snapshot을 항상 최신화.
+ *  2) trip-ended sentinel(`TRIP_ENDED_BY_BACKEND_AT_KEY`)이 있으면 destination/lock store를
+ *     명시적으로 reset — BG에서 storage cleanup만 수행한 trip-ended가 in-memory zustand에
+ *     stale state로 잠시 노출되는 회귀(#899)를 차단. 처리 후 sentinel 즉시 삭제.
+ *
+ * 호출 시점: app/_layout.tsx에서 1회 마운트. 마운트 자체가 첫 hydrate를 트리거.
+ *
+ * runAt 인자: 테스트에서 시각 주입용. 기본 Date.now.
+ *
+ * 멱등성: 동일 active 진입에서 여러 번 호출되어도 storage 키 부재 시 graceful no-op.
+ */
+export function useStateRehydration(): void {
+  useEffect(() => {
+    void runRehydration('mount');
+    const handler = (state: AppStateStatus): void => {
+      if (state === 'active') void runRehydration('active');
+    };
+    const sub = AppState.addEventListener('change', handler);
+    return () => sub.remove();
+  }, []);
+}
+
+/** 한 번의 재수화 사이클. mount/active 모두 동일 로직. */
+async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
+  // sentinel 우선 — store reset이 hydrate된 stale state를 덮지 않도록 순서 보장.
+  const sentinel = await getTripEndedSentinel();
+  if (sentinel !== null) {
+    logger.info(`trigger=${trigger} trip-ended sentinel=${sentinel} → store reset`);
+    // setDestination(null)이 customOrigin/tripOrigin 메모리 동기화 + tripBoundCleanups
+    // 호출까지 atomic하게 처리한다 — storage는 이미 BG에서 cleanup됐지만 멱등.
+    useDestinationStore.getState().setDestination(null);
+    await useBoardingLockStore.getState().releaseLock();
+    await clearTripEndedSentinel();
+  }
+
+  // 항상 storage → memory hydrate (sentinel 분기에서 reset된 store는 빈 storage 그대로 유지).
+  const destStore = useDestinationStore.getState();
+  await Promise.allSettled([
+    destStore.loadDestination(),
+    destStore.loadCustomOrigin(),
+    destStore.loadTripOrigin(),
+    useBoardingLockStore.getState().loadLock(),
+  ]);
+}


### PR DESCRIPTION
## Summary

trip 종료 6경로 중 일부가 **storage cleanup만 수행되고 zustand store는 stale로 남는** 회귀, 그리고 **환승 waypoint에서 사용자가 새 열차를 누르지 않으면 stale boarding chip이 남는** 회귀를 단일 hydration seam으로 통합.

Seam C는 epic #896의 3단계 — 1단계 (Seam A/B/G), 2단계 (Seam E #901) 이후 hydration 정리를 담당.

## 변경 사항

### Sentinel + FG 복귀 재수화 (BG 회귀 차단)

- `TRIP_ENDED_BY_BACKEND_AT_KEY` 신규 storage 키 + `tripEndedSentinel.ts` util.
- `silentPushTask.ts` trip-ended 분기에서 `runTripBoundCleanups()` 직후 `setTripEndedSentinel(receivedAt)` 호출. (BG에서 zustand 접근 불가 회피)
- `src/shared/hooks/useStateRehydration.ts` 신규: 마운트 + AppState 'active' 진입마다
  1. sentinel 확인 → 있으면 destination/lock store 명시 reset → sentinel clear
  2. `loadDestination + loadCustomOrigin + loadTripOrigin + loadLock` 일괄 hydrate
- `app/_layout.tsx`에 마운트.

### 환승 waypoint 자동 release

- `src/features/route/utils/transferLegs.ts` 신규: Route → TransferLeg[] 평탄화. direct/transfer/multi-transfer 분기를 한 곳에 격리.
- `useBoardingLockAutoRelease`에 `route` 인자 + `matchReleaseTarget`:
  - 목적지 도달 매칭(id) → release
  - **환승 leg waypoint 도달 매칭** (`leg.fromLine === lock.boardingLine && leg.transferName === currentStation.name`) → release
- HomeScreen에서 route 전달.
- 동명이역 회피: `fromLine === boardingLine` AND-조건으로 안전.

### 데이터 주도 일반화 (글로벌 규칙 #3)

- `getTransferLegs`는 Route 타입 분기를 한 곳에서만 처리. 호출처는 `legs.some(...)` 한 줄.
- `route.transfers[0]` 같은 인덱스 하드코딩 없음.
- 새 transfer route 타입이 추가돼도 helper 한 곳만 갱신.

### Sonar duplication 회피

- 5+ block 동일 setup 패턴은 처음부터 `mountAtT0` 헬퍼 + `it.each`로 작성.
- transferLegs / sentinel 테스트도 동일 구조 회피.

## Test Plan

- [x] `npm test` — 201 suites / 3611 tests PASS, 커버리지 100%
- [x] `npm run type-check` PASS
- [x] 자체 code-review (recall-biased, P0/P1 0건)
- [ ] CI `Type Check & Test` PASS
- [ ] SonarCloud `new_duplicated_lines_density` ≤ 3%

## 회귀 evidence

이슈 본문 13:23 backend waypoint advanced + 13:28 trip auto-ended 이후 14:02 시점 잠금화면에 "탑승 · 2호선 · 13:20" stale chip + LA 살아있던 케이스. 본 PR로 sentinel + FG 재수화가 stale UI를 차단.

Closes #899