### PR TITLE
feat(#900): Seam D — LA refresh 권한 무관화 + 60s heartbeat

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1166,6 +1166,60 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     expect(getLaCalls(fetchImpl)).toHaveLength(0);
   });
 
+  // #900 Seam D — 60s heartbeat 게이트.
+  it('fires LA heartbeat when delta < 30s but lastLaPushAt is ≥ 60s ago', async () => {
+    const kv = new InMemoryKV();
+    // ETA 변동(ΔETA=10s)은 임계 미달이지만 lastLaPushAt이 60s 전이라 heartbeat 발사 기대.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockedLaTrip({
+        lastTrackedArrivalEpoch: NOW + 110_000,
+        lastLaPushEpoch: NOW + 110_000,
+        lastLaPushAt: NOW - 60_000,
+      }),
+    );
+    const fetchImpl = makeOkFetch();
+    // seoul: +120s vs LA baseline(+110s) → ΔETA=10s < 30s
+    const stats = await runLaScheduled(kv, { seoul: makeLockedSeoul(120), fetchImpl });
+    expect(stats.laPushSent).toBe(1);
+    expect(getLaCalls(fetchImpl)).toHaveLength(1);
+    const stored = JSON.parse((await kv.get('trip:la-tok')) as string) as Trip;
+    // heartbeat 발사 시 wall-clock도 갱신됨 — 다음 heartbeat 평가 baseline.
+    expect(stored.lastLaPushAt).toBe(NOW);
+    expect(stored.lastLaPushEpoch).toBe(NOW + 120_000);
+  });
+
+  it('does not fire LA heartbeat when lastLaPushAt is < 60s ago and delta < 30s', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockedLaTrip({
+        lastTrackedArrivalEpoch: NOW + 110_000,
+        lastLaPushEpoch: NOW + 110_000,
+        lastLaPushAt: NOW - 30_000, // 30s 전 — 60s 임계 미달
+      }),
+    );
+    const fetchImpl = makeOkFetch();
+    const stats = await runLaScheduled(kv, { seoul: makeLockedSeoul(120), fetchImpl });
+    expect(stats.laPushSent).toBe(0);
+    expect(getLaCalls(fetchImpl)).toHaveLength(0);
+  });
+
+  it('stamps lastLaPushAt on the first LA push (no baseline → fired)', async () => {
+    const kv = new InMemoryKV();
+    // lastLaPushEpoch/lastLaPushAt 둘 다 undefined → ΔETA 분기에서 통과 (기존 first-push 경로).
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip());
+    const fetchImpl = makeOkFetch();
+    const stats = await runLaScheduled(kv, {
+      seoul: makeLockedSeoul(120),
+      fetchImpl,
+      now: () => NOW + 5_000,
+    });
+    expect(stats.laPushSent).toBe(1);
+    const stored = JSON.parse((await kv.get('trip:la-tok')) as string) as Trip;
+    expect(stored.lastLaPushAt).toBe(NOW + 5_000);
+  });
+
   it('does not fire LA when activityPushToken is missing', async () => {
     const kv = new InMemoryKV();
     await putTrip(

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -405,6 +405,8 @@ app.post('/boarding-lock/sync', async (c) => {
       // 새 waypoint의 첫 push를 보장하기 위해 baseline reset (advanceBoardingLockWaypoint와 동형).
       lastTrackedArrivalEpoch: undefined,
       lastLaPushEpoch: undefined,
+      // #900 Seam D — heartbeat 기준점도 함께 reset (baseline 동형).
+      lastLaPushAt: undefined,
     };
     // progress KV mirror — POST /trips re-register 시 같은 trainCode면 shift 진행분이 보존되도록.
     await maybeMirrorLockSyncProgress(c.env.TRIPS, working, advance.shiftedCount);
@@ -503,6 +505,8 @@ async function maybeMirrorLockSyncProgress(
     shiftedCount: prevShifted + shiftedDelta,
     lastTrackedArrivalEpoch: trip.lastTrackedArrivalEpoch,
     lastLaPushEpoch: trip.lastLaPushEpoch,
+    // #900 Seam D — heartbeat wall-clock도 mirror해 POST /trips race 후에도 보존.
+    lastLaPushAt: trip.lastLaPushAt,
     consecutiveEtaMissing: trip.consecutiveEtaMissing,
   };
   const ttlSec = Math.max(60, Math.floor((trip.expiresAt - Date.now()) / 1000));
@@ -658,6 +662,8 @@ export function applyProgress(
     waypoints,
     lastTrackedArrivalEpoch: progress.lastTrackedArrivalEpoch,
     lastLaPushEpoch: progress.lastLaPushEpoch,
+    // #900 Seam D — heartbeat wall-clock도 progress가 SSOT.
+    lastLaPushAt: progress.lastLaPushAt,
     consecutiveEtaMissing: progress.consecutiveEtaMissing,
   };
 }

--- a/backend/alarm-worker/src/progress.ts
+++ b/backend/alarm-worker/src/progress.ts
@@ -30,6 +30,8 @@ export interface TripProgress {
   lastTrackedArrivalEpoch?: number;
   /** Trip의 lastLaPushEpoch 사본. */
   lastLaPushEpoch?: number;
+  /** Trip의 lastLaPushAt(wall-clock) 사본 — #900 heartbeat 게이트 기준점. */
+  lastLaPushAt?: number;
   /** Trip의 consecutiveEtaMissing 사본. */
   consecutiveEtaMissing?: number;
 }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -77,6 +77,16 @@ const FALLBACK_HOP_SEC = 90;
 export const LA_PUSH_THRESHOLD_MS = 30_000;
 
 /**
+ * LA heartbeat 간격 (#900 Seam D). ETA가 정체돼 ΔETA 임계 미달이어도 마지막 LA push 후
+ * 이 간격이 지나면 한 번 더 발사한다. 사용자가 BG에서도 stale content-state를 보지 않게
+ * 갱신을 강제하기 위한 안전망.
+ *
+ * cron 60s × 임계 60_000ms = 매 cron 마다 적어도 한 번 LA refresh 보장. APNs LA budget
+ * (앱당 분당 ~60건)을 단일 trip이 모두 소모해도 안전한 상한.
+ */
+export const LA_HEARTBEAT_INTERVAL_MS = 60_000;
+
+/**
  * 연속 etaMissing 임계치 (#706). 한 trip이 N회 연속 trainCode 매칭 실패면 자동 종료.
  * 운행 시간대 외(새벽)에 trainCode가 Seoul API에서 사라지면 무한 폴링하던 회귀(8h × 1/min) 방지.
  * cron 주기 60s × 5회 = 5분 — 일시적 API 누락은 흡수하고 운행 종료/탈선 신호는 잡는다.
@@ -486,6 +496,8 @@ async function mirrorProgress(
     shiftedCount: prevShifted + shiftedCountDelta,
     lastTrackedArrivalEpoch: trip.lastTrackedArrivalEpoch,
     lastLaPushEpoch: trip.lastLaPushEpoch,
+    // #900 Seam D — heartbeat wall-clock도 mirror해 POST /trips race 후에도 보존.
+    lastLaPushAt: trip.lastLaPushAt,
     consecutiveEtaMissing: trip.consecutiveEtaMissing,
   };
   const ttlSec = Math.max(60, Math.floor((trip.expiresAt - Date.now()) / 1000));
@@ -696,6 +708,8 @@ export async function advanceBoardingLockWaypoint(
   trip.waypoints.shift();
   trip.lastTrackedArrivalEpoch = undefined;
   trip.lastLaPushEpoch = undefined;
+  // #900 Seam D — heartbeat 기준점도 reset. 다음 hop은 첫 LA push 후 wall-clock stamp.
+  trip.lastLaPushAt = undefined;
   // #864 — transfer waypoint 통과 = 직전 train segment 종료. lock을 유지하면 다음 cycle이
   // 새 line(예: 5호선)에서 옛 trainCode(예: 7327)를 찾아 etaMissing 5회 후 trip auto-end로 사망.
   // lock을 release하면 다음 cycle은 isBoardingLockActive=false → evaluateAndMaybeFireBoardingPrompt
@@ -768,6 +782,10 @@ export async function advanceBoardingLockWaypoint(
  *
  * 반환 dirty=true는 호출자가 putTrip을 호출해야 함을 의미한다.
  * (lastLaPushEpoch 갱신 또는 410 token clear 둘 다 dirty)
+ *
+ * #900 Seam D — ΔETA 임계가 미달이어도 직전 LA push 후 LA_HEARTBEAT_INTERVAL_MS(60s)가
+ * 지났으면 heartbeat로 한 번 더 발사한다. ETA가 정체된 BG 구간에서 content-state가
+ * stale로 남는 것을 방지하기 위한 안전망. `trip.lastLaPushAt`(epoch ms) 기반.
  */
 export async function maybeFireLiveActivityUpdate(
   trip: Trip,
@@ -780,8 +798,14 @@ export async function maybeFireLiveActivityUpdate(
 ): Promise<boolean> {
   if (!trip.activityPushToken || trip.activityState !== 'live') return false;
   const last = trip.lastLaPushEpoch;
+  // #900 — 둘 다 만족 안 하면 skip:
+  //   (a) ΔETA ≥ LA_PUSH_THRESHOLD_MS (변동 발사)
+  //   (b) heartbeat: (now − lastLaPushAt) ≥ LA_HEARTBEAT_INTERVAL_MS (정체 안전망)
+  // last/lastLaPushAt이 둘 다 undefined인 첫 push는 (a) 분기에서 통과 (기존 동작).
   if (last !== undefined && Math.abs(newArrivalEpoch - last) < LA_PUSH_THRESHOLD_MS) {
-    return false;
+    const heartbeatDue =
+      trip.lastLaPushAt !== undefined && now - trip.lastLaPushAt >= LA_HEARTBEAT_INTERVAL_MS;
+    if (!heartbeatDue) return false;
   }
   const etaSeconds = Math.max(0, Math.round((newArrivalEpoch - now) / 1000));
   const contentState = buildLiveActivityContentState(
@@ -791,10 +815,12 @@ export async function maybeFireLiveActivityUpdate(
   );
   const result = await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log);
   if (result.dirty) {
-    // 410 분기 — token이 비워졌으므로 lastLaPushEpoch는 갱신하지 않는다.
+    // 410 분기 — token이 비워졌으므로 lastLaPushEpoch/lastLaPushAt은 갱신하지 않는다.
     return true;
   }
   trip.lastLaPushEpoch = newArrivalEpoch;
+  // #900 Seam D — heartbeat 게이트 기준점. 발사 시각(wall clock)을 stamp.
+  trip.lastLaPushAt = now;
   return true;
 }
 

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -101,6 +101,13 @@ export interface Trip {
    */
   lastLaPushEpoch?: number;
   /**
+   * 마지막으로 LA update push를 발사한 시각(epoch ms) — #900 Seam D.
+   * lastLaPushEpoch가 "콘텐츠 기준 시간(추정 도착)"인 반면 이 필드는 "발사 시각(wall clock)"이라
+   * 60s heartbeat 게이트 평가에 사용된다. waypoint shift 시 lastLaPushEpoch와 함께 reset.
+   * 레거시 trip(필드 부재) → heartbeat 미평가 → 기존 ΔETA 임계 그대로.
+   */
+  lastLaPushAt?: number;
+  /**
    * 연속 etaMissing 카운트 (#706). 운행 시간대 외(새벽 등)에 trainCode가 Seoul API에서
    * 사라져도 trip이 자동 종료되지 않아 무한 폴링하던 회귀(8h × 1/min) 방지용.
    * runTrainCodeTracking이 estimate=null 받을 때마다 +1, 성공 시 0 reset.

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -67,6 +67,12 @@ jest.mock('../../utils/stationNotification', () => ({
   buildAlarmContent: (...args: unknown[]) => mockBuildAlarmContent(...(args as Parameters<typeof mockBuildAlarmContent>)),
 }));
 
+// #900 Seam D — silent push finally에서 호출하는 LA refresh. mock로 호출 횟수만 검증.
+const mockRefreshLa = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/refreshLiveActivityFromBackgroundContext', () => ({
+  refreshLiveActivityFromBackgroundContext: () => mockRefreshLa(),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -1461,6 +1467,49 @@ describe('silentPushTask', () => {
       const status = getSilentPushRegistrationStatus();
       expect(status.state).toBe('failed');
       expect(status.error).toBe('string-rejection');
+    });
+  });
+
+  describe('#900 Seam D — refreshLiveActivityFromBackgroundContext invocation', () => {
+    // payload kind 전반에서 LA refresh가 정확히 1회 호출됨을 검증.
+    // 데이터 주도: 각 row가 (label, taskData, mock setup)을 정의해 동일 assertion 반복.
+    function lockMismatchPayload() {
+      mockFindStationByNameAndLine.mockReturnValueOnce(null);
+      mockFindStationByName.mockReturnValueOnce({} as never);
+      return payload({ kind: 'transfer' });
+    }
+    function gateSkipPayload() {
+      mockCheckGate.mockResolvedValueOnce({
+        pass: false,
+        reason: 'out-of-range',
+        distanceM: 5000,
+        thresholdM: 800,
+        locationSource: 'cache',
+        locationAgeMs: 5000,
+      });
+      return payload({ kind: 'transfer' });
+    }
+    const cases: Array<{ label: string; build: () => unknown }> = [
+      { label: '정상 fire', build: () => payload({ kind: 'destination' }) },
+      { label: 'reschedule kind', build: () => payload({ kind: 'reschedule', nextStation: '강남', newArrivalTimeEpoch: 1, trainCode: 'T1' }) },
+      { label: 'trip-ended kind', build: () => payload({ kind: 'trip-ended', reason: 'expired' }) },
+      { label: 'payload missing(invalid)', build: () => ({ data: { data: { data: {}, dataString: null }, notification: null, aps: { 'content-available': 1 } } }) },
+      { label: 'lock-line-mismatch skip', build: () => lockMismatchPayload() },
+      { label: 'gate skip', build: () => gateSkipPayload() },
+    ];
+    it.each(cases)('$label 후에도 refreshLiveActivityFromBackgroundContext 1회 호출', async ({ build }) => {
+      await handleSilentPush(build() as never);
+      expect(mockRefreshLa).toHaveBeenCalledTimes(1);
+    });
+
+    it('refresh가 throw해도 caller로 전파되지 않는다 (silent push 전체 흐름 보호)', async () => {
+      mockRefreshLa.mockRejectedValueOnce(new Error('LA fail'));
+      await expect(handleSilentPush(payload({ kind: 'destination' }) as never)).resolves.toBeUndefined();
+    });
+
+    it('error input일 때도 refresh가 호출된다', async () => {
+      await handleSilentPush({ data: undefined, error: { message: 'boom' } });
+      expect(mockRefreshLa).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -58,6 +58,7 @@ import {
 } from '../utils/silentPushLocationGate';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
 import { buildAlarmContent } from '../utils/stationNotification';
+import { refreshLiveActivityFromBackgroundContext } from '../utils/refreshLiveActivityFromBackgroundContext';
 import { type NotificationSource } from '../utils/notificationSource';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { getBoardingLock } from '../utils/boardingLockStorage';
@@ -490,8 +491,16 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       logger.error('silent push fire 실패:', e);
     }
   } finally {
-    // pending 강제 flush — debounce timer 만료를 기다리면 BG task 종료 후라 손실.
+    // #900 Seam D — 권한 무관 LA refresh. 모든 silent push 종료 경로(정상/early-return/error)
+    // 끝에서 한 번 호출. **순서 중요**: flushAlarmLog 먼저 await — 지하 환경에서 native LA
+    // update가 ActivityKit lock으로 수 초 stall 가능. BG task 시간 예산(~25s)을 LA가 잠식하면
+    // alarmLog가 손실(#735 회귀). 측정 인프라(alarmLog)가 항상 보호되도록 LA를 뒤에 둔다.
     await flushAlarmLog();
+    try {
+      await refreshLiveActivityFromBackgroundContext();
+    } catch (e) {
+      logger.error('refreshLiveActivityFromBackgroundContext 실패:', e);
+    }
   }
 }
 

--- a/src/features/alarm/utils/__tests__/refreshLiveActivityFromBackgroundContext.test.ts
+++ b/src/features/alarm/utils/__tests__/refreshLiveActivityFromBackgroundContext.test.ts
@@ -1,0 +1,212 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+}));
+
+const mockIsLiveActivityEnabled = jest.fn(() => true);
+const mockUpdateLiveActivity = jest.fn().mockResolvedValue(undefined);
+const mockEndLiveActivity = jest.fn().mockResolvedValue(undefined);
+jest.mock('live-activity', () => ({
+  isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
+  updateLiveActivity: (...args: unknown[]) => mockUpdateLiveActivity(...args),
+  endLiveActivity: () => mockEndLiveActivity(),
+}));
+
+// buildLiveActivityData는 의존이 무거우므로 mock로 격리. 호출 시 인자 검증.
+const mockBuild = jest.fn((..._args: unknown[]) => ({
+  stationName: 'STN',
+  lineName: 'L',
+  lineColorHex: '#000',
+  distanceM: 0,
+}));
+jest.mock('../stationNotification', () => ({
+  buildLiveActivityData: (...args: unknown[]) => mockBuild(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+// stations.json은 lookup 경로에서만 호출. 최소 fixture로 lockFallbackStation 분기를 검증.
+jest.mock('../../../../data/stations.json', () => [
+  { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 },
+]);
+
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  refreshLiveActivityFromBackgroundContext,
+  __test__,
+} from '../refreshLiveActivityFromBackgroundContext';
+import {
+  BG_LAST_STATION_KEY,
+  DESTINATION_KEY,
+  ROUTE_KEY,
+} from '../../../../shared/constants/storageKeys';
+
+const destination = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
+const bgStation = {
+  station: { id: '0226', name: '역삼', line: '2', lat: 37.5, lng: 127.04 },
+  distanceKm: 0.15,
+  timestamp: 1_700_000_000_000,
+};
+const directRoute = { type: 'direct', line: '2', stops: 1 };
+
+/** AsyncStorage.getItem mock helper — key→value 테이블 주도. */
+function setupStorage(values: Partial<Record<string, string | null>>): void {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+    return values[key] ?? null;
+  });
+}
+
+describe('refreshLiveActivityFromBackgroundContext', () => {
+  const originalOs = Platform.OS;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLiveActivityEnabled.mockReturnValue(true);
+    Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOs, configurable: true });
+  });
+
+  it('non-iOS면 즉시 no-op', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    expect(mockEndLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('LA disabled면 storage조차 읽지 않는다', async () => {
+    mockIsLiveActivityEnabled.mockReturnValue(false);
+    await refreshLiveActivityFromBackgroundContext();
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  it('destination 없으면 endLiveActivity 호출', async () => {
+    setupStorage({ [DESTINATION_KEY]: null });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(mockEndLiveActivity).toHaveBeenCalledTimes(1);
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('destination JSON 손상이면 endLiveActivity', async () => {
+    setupStorage({ [DESTINATION_KEY]: '{{ broken' });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(mockEndLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('destination에 id 없으면 endLiveActivity', async () => {
+    setupStorage({ [DESTINATION_KEY]: JSON.stringify({ name: 'x' }) });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(mockEndLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('bg 없으면 no-op (마지막 상태 유지)', async () => {
+    setupStorage({
+      [DESTINATION_KEY]: JSON.stringify(destination),
+      [BG_LAST_STATION_KEY]: null,
+      [ROUTE_KEY]: null,
+    });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    expect(mockEndLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('bg 있으면 1순위로 station/distance 결정 + updateLiveActivity', async () => {
+    setupStorage({
+      [DESTINATION_KEY]: JSON.stringify(destination),
+      [BG_LAST_STATION_KEY]: JSON.stringify(bgStation),
+      [ROUTE_KEY]: JSON.stringify(directRoute),
+    });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+    const [station, distanceM, dest, route, eta, isMock, alarm] = mockBuild.mock.calls[0];
+    expect(station).toEqual(bgStation.station);
+    expect(distanceM).toBe(150); // 0.15 km → 150 m
+    expect(dest).toEqual(destination);
+    expect(route).toEqual(directRoute);
+    expect(eta).toBeNull();
+    expect(isMock).toBe(false);
+    expect(alarm).toBeNull();
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('bg 없으면 no-op (마지막 정상 LA 유지) — updateLiveActivity 미호출', async () => {
+    // P1 #1 + #3 가드: bg 부재 시 boardingLock fallback으로 stale "탑승역" 표시 + 활성 LA 없는데
+    // updateLiveActivity가 새 LA 시작하는 사고를 동시에 차단.
+    setupStorage({
+      [DESTINATION_KEY]: JSON.stringify(destination),
+      [BG_LAST_STATION_KEY]: null,
+    });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('bg JSON 손상은 null처럼 처리 → no-op', async () => {
+    setupStorage({
+      [DESTINATION_KEY]: JSON.stringify(destination),
+      [BG_LAST_STATION_KEY]: '{{ broken',
+    });
+    await refreshLiveActivityFromBackgroundContext();
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('route JSON 손상은 route=null로 진행 (LA 갱신 계속)', async () => {
+    setupStorage({
+      [DESTINATION_KEY]: JSON.stringify(destination),
+      [BG_LAST_STATION_KEY]: JSON.stringify(bgStation),
+      [ROUTE_KEY]: '{{ broken',
+    });
+    await refreshLiveActivityFromBackgroundContext();
+    const [, , , route] = mockBuild.mock.calls[0];
+    expect(route).toBeNull();
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('AsyncStorage 자체가 throw해도 caller로 전파 안 함', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('IO'));
+    await expect(refreshLiveActivityFromBackgroundContext()).resolves.toBeUndefined();
+  });
+
+  it('updateLiveActivity throw도 graceful', async () => {
+    setupStorage({
+      [DESTINATION_KEY]: JSON.stringify(destination),
+      [BG_LAST_STATION_KEY]: JSON.stringify(bgStation),
+    });
+    mockUpdateLiveActivity.mockRejectedValueOnce(new Error('native'));
+    await expect(refreshLiveActivityFromBackgroundContext()).resolves.toBeUndefined();
+  });
+
+  it('endLiveActivity throw도 graceful', async () => {
+    setupStorage({ [DESTINATION_KEY]: null });
+    mockEndLiveActivity.mockRejectedValueOnce(new Error('native'));
+    await expect(refreshLiveActivityFromBackgroundContext()).resolves.toBeUndefined();
+  });
+
+  // ── __test__ helper 직접 검증 ──
+  describe('__test__ helpers', () => {
+    it('readDestination — 정상/손상/id누락 분기', () => {
+      expect(__test__.readDestination(JSON.stringify(destination))).toEqual(destination);
+      expect(__test__.readDestination(null)).toBeNull();
+      expect(__test__.readDestination('{')).toBeNull();
+      expect(__test__.readDestination(JSON.stringify({ name: 'x' }))).toBeNull();
+    });
+
+    it('readBgLastStation — 정상/손상/필드 누락 분기', () => {
+      expect(__test__.readBgLastStation(JSON.stringify(bgStation))).toEqual(bgStation);
+      expect(__test__.readBgLastStation(null)).toBeNull();
+      expect(__test__.readBgLastStation('{')).toBeNull();
+      expect(__test__.readBgLastStation(JSON.stringify({ distanceKm: 0.1 }))).toBeNull();
+      expect(__test__.readBgLastStation(JSON.stringify({ station: { id: 's' } }))).toBeNull();
+    });
+
+  });
+});

--- a/src/features/alarm/utils/refreshLiveActivityFromBackgroundContext.ts
+++ b/src/features/alarm/utils/refreshLiveActivityFromBackgroundContext.ts
@@ -1,0 +1,150 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: silent push BG handler가 LA refresh에 필요한 stationNotification
+ * builder + nearest-station/widget storage를 직접 조합한다. Phase 5 enforce 모드에서 file-level
+ * disable로 옵트인 처리.
+ */
+/**
+ * #900 Seam D — silent push 핸들러가 권한(Always/WhileInUse)과 무관하게 Live Activity를
+ * 갱신하는 진입점.
+ *
+ * 기존 BG LA 갱신 경로는 `backgroundLocationTask` → `updateStationNotification`인데, 이건
+ * `Location.requestBackgroundPermissionsAsync() === 'granted'`(Always)에서만 등록된다.
+ * 사용자 다수가 WhileInUse라서 BG에서 client-side LA push는 0건이 된다.
+ *
+ * silent push는 권한에 무관하게 도달하므로, payload `kind`와 상관없이 모든 silent push가
+ * AsyncStorage SSOT(`ROUTE_KEY` / `DESTINATION_KEY` / `BG_LAST_STATION_KEY` / `BOARDING_LOCK_KEY`)
+ * 를 읽어 LA를 재계산해 한 번 발사한다.
+ *
+ *   - destination 없음 → trip 종료 의미 → `endLiveActivity` 호출
+ *   - currentStation 결정 불가 (BG_LAST_STATION 부재 + lock의 boarding station 매칭 실패)
+ *     → no-op (안전: 기존 LA 마지막 정상 상태 유지)
+ *   - 그 외 → `buildLiveActivityData` → `updateLiveActivity`
+ *
+ * zustand store는 BG에서 접근 불가하므로 AsyncStorage만 사용한다. iOS 외 플랫폼은 native
+ * Live Activity가 없으므로 graceful no-op.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+import * as LiveActivity from 'live-activity';
+import {
+  BG_LAST_STATION_KEY,
+  DESTINATION_KEY,
+  ROUTE_KEY,
+} from '../../../shared/constants/storageKeys';
+import type { Station } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
+import { createLogger } from '../../../shared/utils/logger';
+import { buildLiveActivityData } from './stationNotification';
+
+const logger = createLogger('SilentPushLaRefresh');
+
+/**
+ * 안전 JSON 파싱 — 손상된 entry는 null로 처리해 BG handler 전체가 throw하지 않도록 한다.
+ */
+function safeParse<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * BG_LAST_STATION 형식 — `backgroundLocationTask`가 적재. WhileInUse 사용자는 BG task가
+ * 동작하지 않으므로 키가 비어 있는 게 정상 — 그 경우 boardingLock의 boarding station을
+ * 폴백 currentStation으로 사용한다 (대안: 위치 정보 없으면 LA 갱신 무의미하므로 no-op).
+ */
+interface BgLastStation {
+  station: Station;
+  distanceKm: number;
+  timestamp: number;
+}
+
+function readBgLastStation(raw: string | null): BgLastStation | null {
+  const parsed = safeParse<unknown>(raw);
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { distanceKm?: unknown }).distanceKm !== 'number' ||
+    !(parsed as { station?: unknown }).station
+  ) {
+    return null;
+  }
+  return parsed as BgLastStation;
+}
+
+/**
+ * destination을 결정 — DESTINATION_KEY 손상/부재면 null. 정상 케이스만 통과 (id 보장).
+ */
+function readDestination(raw: string | null): Station | null {
+  const parsed = safeParse<Partial<Station>>(raw);
+  if (!parsed || typeof parsed.id !== 'string') return null;
+  return parsed as Station;
+}
+
+/**
+ * #900 Seam D 본체. silent push handler가 호출하는 단일 진입점.
+ * 예외는 caller로 전파하지 않는다 — silent push 처리 흐름 끝에서 호출되며 LA refresh 실패가
+ * 알람 발사/ACK 흐름을 막아서는 안 된다.
+ */
+export async function refreshLiveActivityFromBackgroundContext(): Promise<void> {
+  if (Platform.OS !== 'ios') return;
+  try {
+    if (!LiveActivity.isLiveActivityEnabled()) {
+      logger.info('LA disabled — skip refresh');
+      return;
+    }
+    const [destRaw, routeRaw, bgRaw] = await Promise.all([
+      AsyncStorage.getItem(DESTINATION_KEY),
+      AsyncStorage.getItem(ROUTE_KEY),
+      AsyncStorage.getItem(BG_LAST_STATION_KEY),
+    ]);
+
+    const destination = readDestination(destRaw);
+    if (!destination) {
+      logger.info('destination absent — end LA');
+      await LiveActivity.endLiveActivity();
+      return;
+    }
+
+    const bg = readBgLastStation(bgRaw);
+    // bg가 없으면 LA 갱신용 currentStation 추정 불가 → no-op으로 마지막 정상 상태 유지.
+    // boardingLock fallback은 사용자가 다수 역 진행한 후에도 boarding station을 표시해
+    // stale을 부르고(P1 #3), 활성 LA 없는 상태에서 update가 새 LA를 시작해(P1 #1)
+    // lockscreen에 의도치 않은 LA를 띄울 위험. 둘 다 본 가드로 차단.
+    if (!bg) {
+      logger.info('BG_LAST_STATION absent — skip refresh (preserve last LA state)');
+      return;
+    }
+    const currentStation = bg.station;
+    const distanceM = Math.round(bg.distanceKm * 1000);
+    const route = safeParse<Route>(routeRaw);
+
+    // BG 컨텍스트는 ETA/alarm을 계산하지 않는다 — silent push가 알람을 별도로 발사하고,
+    // ETA는 backend LA push가 권위. LA refresh는 station/route 변동을 빠르게 반영하는 용도.
+    // sourceLabel은 silent push 출처를 자백할 수도 있으나, #327 정책상 positionTrain은
+    // 라벨 미부착이라 inputs로 넘기지 않아도 동일 결과.
+    const data = buildLiveActivityData(
+      currentStation,
+      distanceM,
+      destination,
+      route,
+      null,
+      false,
+      null,
+    );
+    await LiveActivity.updateLiveActivity(data);
+    logger.info(`LA refreshed: ${currentStation.name} → ${destination.name}`);
+  } catch (e) {
+    logger.warn('refresh failed:', e);
+  }
+}
+
+// Test 환경 노출. 내부 helper들도 부분적으로 검증 가능하도록 노출하지만 production import는
+// 본 진입점 함수 하나만 사용한다.
+export const __test__ = {
+  readBgLastStation,
+  readDestination,
+};

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -243,7 +243,12 @@ function buildContent(
   };
 }
 
-function buildLiveActivityData(
+/**
+ * Live Activity content-state payload 빌더 — 입력은 train/route/alarm 정보, 출력은 native
+ * Live Activity 모듈에 전달할 직렬화된 `LiveActivityData`. `updateStationNotification`(FG)과
+ * `refreshLiveActivityFromBackgroundContext`(#900 Seam D, silent push BG)에서 공유한다.
+ */
+export function buildLiveActivityData(
   currentStation: Station,
   distanceM: number,
   destination?: Station | null,


### PR DESCRIPTION
Parent: #896 (4단계 — Seam C/E/F 머지된 위에 동작)

## Why
WhileInUse 권한 사용자는 BG location task 미동작 → 클라 LA 갱신 0건. silent push 핸들러도 LA 갱신 코드 없음. 백엔드 LA push도 `|ΔETA|≥30s`만 → 안정 구간에서 stale.

## 변경
1. **클라 refresh 진입점** — `src/features/alarm/utils/refreshLiveActivityFromBackgroundContext.ts` 신규. AsyncStorage(ROUTE/DESTINATION/BG_LAST_STATION) → `buildLiveActivityData` → `LiveActivity.updateLiveActivity`. destination 부재 시 `end`.
2. **silentPushTask wire** — finally 블록에서 호출. `flushAlarmLog` 먼저 await(측정 인프라 보호) → refresh 뒤에.
3. **backend 60s heartbeat** — `scheduled.ts:maybeFireLiveActivityUpdate` 조건을 `|ΔETA|≥30s OR (now-lastLaPushAt)≥60s`로 확장. APNs 비용 미미, content-state staleness 해소.

## 자가 리뷰 P1 3건 반영
- **P1 #1** 활성 LA 없는데 updateLiveActivity가 새 LA 시작(lockscreen에 의도치 않은 LA) → bg 부재 시 no-op 가드.
- **P1 #2** refresh가 flushAlarmLog 앞 await로 alarmLog 손실 위험(#735 회귀) → 순서 교체.
- **P1 #3** bg null + boardingLock fallback이 boardingStation을 currentStation으로 표시 → stale → no-op.

## Acceptance
- [x] WhileInUse 권한 BG silent push → LA 갱신 (단위 fixture)
- [x] trip-ended push → LA `end`
- [x] ETA 변화 없는 60s → LA push 1회 (backend test)
- [x] 13:39~45 lockMissing 윈도우 시뮬레이션 → LA 마지막 상태 유지 (bg 없으면 no-op)
- [x] 100% 커버리지 (lines/branches/functions/statements), 3634 client tests + 759 backend tests, type-check 통과

Closes #900