### PR TITLE
test(#912): P2 — Maestro 회귀 fixture infra + Seam B (E1 첫 PR)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,3 +148,166 @@ jobs:
             maestro-debug-scenario/
             diag-gps/
             diag-scenario/
+
+  regression:
+    name: E2E Regression (#922 fixture mock)
+    # 2026-06-05에 발견된 4건의 알람 회귀(Seam B/C/E/F)에 대한 실기기-동등 가드.
+    # `scripts/maestro-mock-backend.ts`가 BFF/alarm-worker 응답을 회귀 시점 상태로 고정 →
+    # GPS 좌표 + UI 검증만으로 회귀 재현. nightly only, PR 게이트 아님.
+    #
+    # 시나리오 추가는 아래 matrix에 fixture 이름(scripts/fixtures/regression/*.json)만 추가.
+    runs-on: macos-14
+    timeout-minutes: 45
+    strategy:
+      # 한 시나리오가 깨져도 나머지 신호는 보존.
+      fail-fast: false
+      matrix:
+        scenario:
+          - seam-b-13-19
+          # 후속 PR에서 추가: seam-c-14-02, seam-e-13-39, seam-f-13-24
+    env:
+      SIM_NAME: 'iPhone 16'
+      EXPO_PUBLIC_USE_BFF: 'true'
+      EXPO_PUBLIC_BFF_URL: 'http://localhost:8788'
+      EXPO_PUBLIC_ALARM_BACKEND_URL: 'http://localhost:8788'
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Xcode 버전 고정
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 의존성 설치
+        run: npm ci --legacy-peer-deps
+
+      - name: Maestro CLI 설치
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Maestro flow 문법 검증 (regression)
+        run: |
+          set -e
+          if "$HOME/.maestro/bin/maestro" test --help 2>&1 | grep -q -- '--dry-run'; then
+            "$HOME/.maestro/bin/maestro" test .maestro/flows/regression --dry-run || exit 1
+          fi
+
+      - name: mock backend 기동 (백그라운드)
+        run: |
+          node scripts/maestro-mock-backend.js \
+            > mock-backend.log 2>&1 &
+          echo "MOCK_PID=$!" >> $GITHUB_ENV
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8788/healthz > /dev/null; then
+              echo "mock backend ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::mock backend가 30초 안에 기동되지 않음"
+          cat mock-backend.log
+          exit 1
+        env:
+          SCENARIO: ${{ matrix.scenario }}
+          PORT: '8788'
+
+      - name: mock 백엔드 빌드-time env 주입
+        # Expo의 with-environment.sh가 .xcode.env.local을 소싱하므로 여기 export.
+        run: |
+          {
+            echo 'export EXPO_PUBLIC_USE_BFF=true'
+            echo 'export EXPO_PUBLIC_BFF_URL=http://localhost:8788'
+            echo 'export EXPO_PUBLIC_ALARM_BACKEND_URL=http://localhost:8788'
+          } >> ios/.xcode.env.local
+          cat ios/.xcode.env.local
+
+      - name: iOS Prebuild
+        run: npx expo prebuild --platform ios --no-install
+
+      - name: CocoaPods 캐시
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
+
+      - name: CocoaPods 설치
+        run: cd ios && pod install
+
+      - name: iOS 빌드 (Release, mock backend)
+        run: |
+          cd ios
+          xcodebuild -workspace subwaynow.xcworkspace \
+            -scheme subwaynow \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination "platform=iOS Simulator,name=${SIM_NAME}" \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            ONLY_ACTIVE_ARCH=YES \
+            build
+
+      - name: 시뮬레이터 부팅
+        run: |
+          xcrun simctl boot "${SIM_NAME}" || true
+          xcrun simctl bootstatus "${SIM_NAME}" -b
+
+      - name: 앱 설치
+        run: |
+          APP_PATH=$(find ios/build -name "*.app" -type d | head -1)
+          if [ -z "$APP_PATH" ]; then echo "ERROR: .app not found"; exit 1; fi
+          xcrun simctl install booted "$APP_PATH"
+
+      - name: Maestro regression 실행
+        id: regression
+        continue-on-error: true
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '240000'
+        run: |
+          maestro test .maestro/flows/regression/${{ matrix.scenario }}.yaml \
+            --format junit \
+            --output maestro-regression-${{ matrix.scenario }}.xml \
+            --debug-output ./maestro-debug-regression-${{ matrix.scenario }}
+
+      - name: 진단 자료 수집
+        if: always()
+        run: |
+          mkdir -p ./diag-regression-${{ matrix.scenario }}
+          xcrun simctl io booted screenshot ./diag-regression-${{ matrix.scenario }}/last-screen.png || true
+          xcrun simctl spawn booted log show --last 2m --predicate 'process == "subwaynow"' --style compact \
+            > ./diag-regression-${{ matrix.scenario }}/app.log 2>&1 || true
+          cp mock-backend.log ./diag-regression-${{ matrix.scenario }}/ || true
+
+      - name: mock backend 종료
+        if: always()
+        run: |
+          if [ -n "${MOCK_PID:-}" ]; then
+            kill "${MOCK_PID}" 2>/dev/null || true
+          fi
+
+      - name: 결과 업로드
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-regression-${{ matrix.scenario }}-results
+          path: |
+            maestro-regression-*.xml
+            maestro-debug-regression-*/
+            diag-regression-*/
+
+      - name: 결과 판정
+        if: always()
+        run: |
+          if [ "${{ steps.regression.outcome }}" != "success" ]; then
+            echo "::error::regression(${{ matrix.scenario }}) 실패. artifact를 확인하세요."
+            exit 1
+          fi

--- a/.maestro/flows/regression/README.md
+++ b/.maestro/flows/regression/README.md
@@ -1,0 +1,69 @@
+# Maestro 회귀 fixture (#922)
+
+2026-06-05 실기기에서 발생한 4건의 알람 회귀(Seam B/C/E/F)를 단위 테스트 외에 실기기-동등
+환경에서 회귀 가드로 잡기 위한 Maestro flow 모음.
+
+## 구성
+
+- `scripts/maestro-mock-backend.ts` — BFF arrival + alarm-worker endpoint를 mock하는
+  단일 파일 HTTP 서버. fixture(JSON) driven 으로 시나리오 추가는 파일 1개만 더하면 된다.
+- `scripts/fixtures/regression/<scenario>.json` — 시나리오별 station 응답 phase.
+- `.maestro/flows/regression/<scenario>.yaml` — GPS 좌표 + UI 검증 step.
+
+## 로컬 실행
+
+```bash
+# 1) mock backend 기동 (별도 터미널, plain Node — 추가 의존성 없음)
+SCENARIO=seam-b-13-19 PORT=8788 node scripts/maestro-mock-backend.js
+
+# 2) 시뮬레이터에 mock-wired 빌드 설치 (env 주입은 ios/.xcode.env.local로)
+echo 'export EXPO_PUBLIC_USE_BFF=true' >> ios/.xcode.env.local
+echo 'export EXPO_PUBLIC_BFF_URL=http://localhost:8788' >> ios/.xcode.env.local
+echo 'export EXPO_PUBLIC_ALARM_BACKEND_URL=http://localhost:8788' >> ios/.xcode.env.local
+npm run ios
+
+# 3) flow 실행
+maestro test .maestro/flows/regression/seam-b-13-19.yaml
+```
+
+## 시나리오 인덱스
+
+| 파일 | Seam | 회귀 시점 | 검증 내용 |
+| --- | --- | --- | --- |
+| `seam-b-13-19.yaml` | B | 13:19 transfer/early/건대입구 fired @ 성수 | 성수 정지 + 건대입구 5분 후 ETA → false-positive 발사 없음 |
+
+후속 PR에서 추가 예정:
+- Seam C — 13:23 waypoint advanced + 14:02 stale chip
+- Seam E — 13:39~45 lockMissing
+- Seam F — 13:24~28 trainCode 사라짐
+
+## fixture 작성 가이드
+
+`scripts/fixtures/regression/<name>.json` 스키마:
+
+```jsonc
+{
+  "name": "사람이 읽을 시나리오 설명",
+  "seam": "B|C|E|F",
+  "arrivals": {
+    "<역 이름>": [
+      {
+        "fromMs": 0,           // 서버 기동 시점 기준 활성화 오프셋(ms)
+        "body": {
+          "up":   [/* ArrivalInfo[] */],
+          "down": [/* ArrivalInfo[] */],
+          "source": "realtime" // optional, 기본 "realtime"
+        }
+      }
+    ]
+  },
+  "strictStations": false      // optional, 없는 역 요청 시 200 빈 응답(false) vs 404(true)
+}
+```
+
+`receivedAtMs`는 서버가 phase activation 시각으로 자동 주입하므로 fixture에는 0으로 둔다.
+
+## CI
+
+`.github/workflows/e2e.yml`의 `regression` job이 nightly로 실행. 시나리오 추가 시
+job의 `scenarios` matrix에 fixture 이름만 추가하면 된다.

--- a/.maestro/flows/regression/seam-b-13-19.yaml
+++ b/.maestro/flows/regression/seam-b-13-19.yaml
@@ -1,0 +1,73 @@
+appId: com.subwaynow.app
+name: "regression - Seam B (#922) — 성수 정지 중 건대입구 false-positive 차단"
+# 2026-06-05 13:19 실기기 회귀 재현. 사용자가 성수역에서 정지 중일 때
+# 환승 목적지 건대입구에 대한 "곧 도착" 알람이 잘못 발사되었음(Seam B).
+# 본 flow는 GPS를 성수에 고정하고 mock backend가 건대입구 ETA를 5분 후로 응답한 뒤,
+# 일정 시간 동안 client-side 알람 UI가 발사되지 않음을 검증한다.
+#
+# 전제: scripts/maestro-mock-backend.ts가 SCENARIO=seam-b-13-19 PORT=8788로 떠 있고
+# 앱은 EXPO_PUBLIC_BFF_URL/EXPO_PUBLIC_ALARM_BACKEND_URL로 mock을 가리키도록 빌드되어야 한다.
+---
+- setLocation:
+    latitude: 37.544581
+    longitude: 127.055961
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 성수 확인 (한/영 둘 다 매칭)
+- assertVisible:
+    text: "성수|Seongsu"
+
+# 목적지: 건대입구 (환승 목적지로 transfer leg 형성)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "건대입구"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-2-012"
+- waitForAnimationToEnd
+
+# 트립이 형성된 뒤 BG 폴링 + ArrivalRow refetch가 충분히 돌도록 90초 대기.
+# 13:19 회귀는 트립 형성 후 약 30~60초 사이에 발사되었으므로 90초로 여유 확보.
+- repeat:
+    times: 90
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# Seam B 회귀 검증: "곧 도착", "하차 알림", "건대입구 도착" 등 발사 UI가 노출되면 실패.
+# 회귀가 없으면 위 텍스트는 보이지 않는다.
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# 트립 진행 chip은 여전히 성수로 안정되어 있어야 한다(waypoint advance 회귀 동시 차단).
+- assertVisible:
+    text: "성수|Seongsu"

--- a/scripts/fixtures/regression/seam-b-13-19.json
+++ b/scripts/fixtures/regression/seam-b-13-19.json
@@ -1,0 +1,60 @@
+{
+  "name": "Seam B — 13:19 transfer/early/건대입구 fired @ 성수",
+  "seam": "B",
+  "_doc": [
+    "2026-06-05 13:19 실기기 회귀: 사용자가 성수역에서 정지 중인데 환승 목적지 건대입구에 대해",
+    "early(곧 도착) 알람이 발사됨. transfer leg가 backend boardingLock과 sync되지 않아",
+    "client가 stale ETA를 기반으로 잘못 발사했다(Seam B).",
+    "본 fixture는 성수역 좌표 + 성수 도착정보(현재 정차 중)를 응답하면서, 건대입구 ETA는",
+    "이미 큰 값(곧 도착 아님)으로 내려와 client가 발사 조건을 충족하지 않아야 함을 검증한다.",
+    "기대 동작: 매역 통과 알람 0건, 트립 진행 chip은 '성수'로 안정."
+  ],
+  "arrivals": {
+    "성수": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "성수",
+              "arrivalMinutes": 0,
+              "arrivalSeconds": 0,
+              "statusMessage": "도착",
+              "trainCode": "2211",
+              "line": "2",
+              "receivedAtMs": 0,
+              "arrivalCode": 1,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ],
+    "건대입구": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "건대입구",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "2213",
+              "line": "2",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ]
+  }
+}

--- a/scripts/maestro-mock-backend.js
+++ b/scripts/maestro-mock-backend.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Maestro 회귀 테스트용 mock backend HTTP 서버 (#922).
+ *
+ * 2026-06-05에 발견된 4건의 실기기 알람 회귀(Seam B/C/E/F)는 단위 테스트로 잡았으나
+ * 실기기 재현 경로가 없어 다시 깨지기 쉽다. 본 서버가 BFF arrival + alarm-worker
+ * register/clear endpoint를 mock하면 Maestro flow가 시뮬레이터 GPS만으로 회귀 시나리오를
+ * 재생해 검증할 수 있다.
+ *
+ * 첫 PR은 Seam B 1개 시나리오만 지원하지만, scenario fixture(JSON)를 추가하기만 하면
+ * 나머지 3개(C/E/F) 시나리오도 동일 인터페이스로 수용 가능하도록 fixture-driven 구조를
+ * 유지한다.
+ *
+ * 사용:
+ *   SCENARIO=seam-b-13-19 PORT=8788 node scripts/maestro-mock-backend.js
+ *
+ * 환경 변수:
+ *   - SCENARIO  : scripts/fixtures/regression/<name>.json 의 파일명(확장자 제외)
+ *   - PORT      : HTTP 포트 (기본 8788)
+ *
+ * 앱은
+ *   EXPO_PUBLIC_USE_BFF=true
+ *   EXPO_PUBLIC_BFF_URL=http://localhost:8788
+ *   EXPO_PUBLIC_ALARM_BACKEND_URL=http://localhost:8788
+ * 로 빌드한다.
+ *
+ * fixture 스키마는 .maestro/flows/regression/README.md 참고.
+ */
+const { createServer } = require('http');
+const { readFileSync, existsSync } = require('fs');
+const { join } = require('path');
+
+const PORT = Number(process.env.PORT || 8788);
+const SCENARIO = process.env.SCENARIO;
+
+if (!SCENARIO) {
+  console.error('SCENARIO env required (e.g. SCENARIO=seam-b-13-19)');
+  process.exit(1);
+}
+
+const fixturePath = join(__dirname, 'fixtures', 'regression', `${SCENARIO}.json`);
+if (!existsSync(fixturePath)) {
+  console.error(`Fixture not found: ${fixturePath}`);
+  process.exit(1);
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+const startedAt = Date.now();
+
+console.log(`[mock-backend] scenario=${SCENARIO} seam=${fixture.seam} port=${PORT}`);
+console.log(`[mock-backend] stations: ${Object.keys(fixture.arrivals).join(', ')}`);
+
+/**
+ * 현재 시점에 활성화된 phase를 골라 응답 생성 (receivedAtMs 자동 주입).
+ * @param {string} stationName
+ * @returns {object | null}
+ */
+function resolveArrival(stationName) {
+  const phases = fixture.arrivals[stationName];
+  if (!phases || phases.length === 0) {
+    return null;
+  }
+  const elapsed = Date.now() - startedAt;
+  const active = phases
+    .filter((p) => p.fromMs <= elapsed)
+    .sort((a, b) => b.fromMs - a.fromMs)[0];
+  if (!active) {
+    return null;
+  }
+  const receivedAtMs = startedAt + active.fromMs;
+  return {
+    ...active.body,
+    up: active.body.up.map((r) => ({ ...r, receivedAtMs })),
+    down: active.body.down.map((r) => ({ ...r, receivedAtMs })),
+    source: active.body.source || 'realtime',
+  };
+}
+
+function sendJson(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+const ARRIVAL_PATH = /^\/api\/arrival\/([^/?]+)/;
+
+function handle(req, res) {
+  const url = req.url || '/';
+  const method = req.method || 'GET';
+
+  console.log(`[mock-backend] ${method} ${url}`);
+
+  // GET /api/arrival/:stationName — BFF arrival
+  const arrivalMatch = url.match(ARRIVAL_PATH);
+  if (method === 'GET' && arrivalMatch) {
+    const stationName = decodeURIComponent(arrivalMatch[1]);
+    const body = resolveArrival(stationName);
+    if (!body) {
+      if (fixture.strictStations) {
+        sendJson(res, 404, { error: 'station_not_in_fixture', stationName });
+      } else {
+        sendJson(res, 200, { up: [], down: [], source: 'realtime' });
+      }
+      return;
+    }
+    sendJson(res, 200, body);
+    return;
+  }
+
+  // POST /trips/*, /live-activity/* — alarm-worker.
+  // 회귀 시나리오는 silent push 없이 client-side 알람만 검증하므로 ACK만 돌려준다.
+  if (method === 'POST' && (url.startsWith('/trips') || url.startsWith('/live-activity'))) {
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  // GET /healthz — CI가 mock 기동을 대기할 수 있도록.
+  if (url === '/healthz') {
+    sendJson(res, 200, { ok: true, scenario: SCENARIO });
+    return;
+  }
+
+  sendJson(res, 404, { error: 'not_found', url });
+}
+
+const server = createServer(handle);
+server.listen(PORT, () => {
+  console.log(`[mock-backend] listening on http://localhost:${PORT}`);
+});
+
+const shutdown = () => {
+  console.log('[mock-backend] shutting down');
+  server.close(() => process.exit(0));
+};
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/scripts/maestro-mock-backend.js
+++ b/scripts/maestro-mock-backend.js
@@ -26,9 +26,9 @@
  *
  * fixture 스키마는 .maestro/flows/regression/README.md 참고.
  */
-const { createServer } = require('http');
-const { readFileSync, existsSync } = require('fs');
-const { join } = require('path');
+const { createServer } = require('node:http');
+const { readFileSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
 
 const PORT = Number(process.env.PORT || 8788);
 const SCENARIO = process.env.SCENARIO;
@@ -88,7 +88,7 @@ function handle(req, res) {
   const url = req.url || '/';
   const method = req.method || 'GET';
 
-  console.log(`[mock-backend] ${method} ${url}`);
+  console.log('[mock-backend] %s %s', encodeURIComponent(method), encodeURIComponent(url));
 
   // GET /api/arrival/:stationName — BFF arrival
   const arrivalMatch = url.match(ARRIVAL_PATH);

--- a/scripts/maestro-mock-backend.js
+++ b/scripts/maestro-mock-backend.js
@@ -88,7 +88,10 @@ function handle(req, res) {
   const url = req.url || '/';
   const method = req.method || 'GET';
 
-  console.log('[mock-backend] %s %s', encodeURIComponent(method), encodeURIComponent(url));
+  // 화이트리스트 외 문자는 '_' 로 치환 (SonarCloud S5145: log injection 차단)
+  const safeMethod = /^[A-Z]+$/.test(method) ? method : 'INVALID';
+  const safeUrl = url.replace(/[^a-zA-Z0-9/_\-?=&%.:]/g, '_').slice(0, 200);
+  console.log('[mock-backend] %s %s', safeMethod, safeUrl);
 
   // GET /api/arrival/:stationName — BFF arrival
   const arrivalMatch = url.match(ARRIVAL_PATH);


### PR DESCRIPTION
## Summary
- `scripts/maestro-mock-backend.js`: BFF arrival + alarm-worker endpoint를 mock하는 단일 파일 HTTP 서버. fixture(JSON) driven으로 시나리오 추가는 파일 1개만 더하면 동일 인터페이스로 수용. 추가 dep 없음 (plain Node).
- `scripts/fixtures/regression/seam-b-13-19.json`: 2026-06-05 13:19 Seam B 회귀(성수 정차 중 건대입구 false-positive 발사) 재현 fixture.
- `.maestro/flows/regression/seam-b-13-19.yaml`: GPS 고정 + UI 검증 flow. 알람 발사 UI 미출현 + 트립 chip 안정성 검증.
- `.github/workflows/e2e.yml`: nightly regression job 추가 (matrix 구조, fail-fast=false). PR 게이트 아님.
- `.maestro/flows/regression/README.md`: 로컬 실행 + fixture 작성 가이드.

후속 PR에서 추가 예정:
- Seam C — 13:23 waypoint advanced + 14:02 stale chip
- Seam E — 13:39~45 lockMissing
- Seam F — 13:24~28 trainCode 사라짐
- 회귀 시 Slack 알림

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 전체 통과 (3634 tests, coverage 100%)
- [x] mock backend 로컬 smoke (healthz / arrival / POST trips/* / unknown station fallback) 정상
- [ ] CI: changes job이 `.github/workflows/e2e.yml`만 변경된 PR이라 e2e-smoke는 자동 스킵, nightly regression job은 다음 cron(KST 04:00) 또는 workflow_dispatch에서 첫 실행
- [ ] 실기기/시뮬레이터에서 첫 nightly green 확인 후 후속 시나리오(Seam C/E/F) PR 진행

Refs #922