### PR TITLE
feat(#913): wifi SSID lookup util + 매핑 데이터 (F2 첫 PR)

### DIFF
--- a/src/data/subwayWifiSsidMap.json
+++ b/src/data/subwayWifiSsidMap.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "./subwayWifiSsidMap.schema",
+  "_meta": {
+    "description": "지하철 역사 wifi SSID → 역명 매핑 (#913, Epic #912). 지하에서 GPS가 실패해도 SSID 직접 매칭으로 현재 역을 100% 확정하기 위한 데이터.",
+    "patternSyntax": "정규식. 대소문자 무시(매칭 함수에서 'i' 플래그 부여). 한글/영문/한자/공백 변형을 흡수하도록 작성.",
+    "matchRule": "여러 항목의 patterns 중 하나라도 매치되면 stationName(canonical)으로 매핑. 정규화는 normalizeStationName + applyStationAlias를 거쳐 stations.json과 매칭한다.",
+    "lineHint": "환승역은 line이 여러 개이므로 lineHint는 단일값 강제 불가. 호출자(useNearestStation cascade)가 다른 신호(boarding-lock, 경로)와 교차로 호선을 결정한다.",
+    "dataCollection": "실제 SSID 패턴은 현장에서 수집해 점진적으로 보강한다. 본 PR은 통신사 공용 패턴(T_subway/Olleh_Subway/U+Subway) + 일부 역명 포함 패턴의 placeholder로 시작."
+  },
+  "entries": [
+    {
+      "stationName": "용마산",
+      "patterns": ["^T_subway_용마산", "^Olleh_Subway_용마산", "Yongmasan"]
+    },
+    {
+      "stationName": "중곡",
+      "patterns": ["^T_subway_중곡", "^Olleh_Subway_중곡", "Junggok"]
+    },
+    {
+      "stationName": "군자",
+      "patterns": ["^T_subway_군자", "^Olleh_Subway_군자", "Gunja"]
+    },
+    {
+      "stationName": "강남",
+      "patterns": ["^T_subway_강남", "^Olleh_Subway_강남", "Gangnam_Station"]
+    },
+    {
+      "stationName": "서울역",
+      "patterns": ["^T_subway_서울역", "^Olleh_Subway_서울역", "Seoul_Station_Subway"]
+    },
+    {
+      "stationName": "시청",
+      "patterns": ["^T_subway_시청", "^Olleh_Subway_시청", "CityHall_Subway"]
+    },
+    {
+      "stationName": "종로3가",
+      "patterns": ["^T_subway_종로3가", "^Olleh_Subway_종로3가", "Jongno3ga"]
+    },
+    {
+      "stationName": "왕십리",
+      "patterns": [
+        "^T_subway_왕십리",
+        "^Olleh_Subway_왕십리",
+        "U\\+Subway_왕십리",
+        "Wangsimni"
+      ]
+    },
+    {
+      "stationName": "건대입구",
+      "patterns": ["^T_subway_건대입구", "^Olleh_Subway_건대입구", "Konkuk_Univ"]
+    },
+    {
+      "stationName": "성수",
+      "patterns": ["^T_subway_성수", "^Olleh_Subway_성수", "Seongsu"]
+    },
+    {
+      "stationName": "잠실",
+      "patterns": ["^T_subway_잠실", "^Olleh_Subway_잠실", "Jamsil"]
+    },
+    {
+      "stationName": "사당",
+      "patterns": ["^T_subway_사당", "^Olleh_Subway_사당", "Sadang"]
+    },
+    {
+      "stationName": "이수",
+      "patterns": ["^T_subway_이수", "^Olleh_Subway_이수", "^T_subway_총신대입구", "Isu_Station"]
+    },
+    {
+      "stationName": "고속터미널",
+      "patterns": ["^T_subway_고속터미널", "^Olleh_Subway_고속터미널", "Express_Bus_Terminal"]
+    },
+    {
+      "stationName": "신도림",
+      "patterns": ["^T_subway_신도림", "^Olleh_Subway_신도림", "Sindorim"]
+    },
+    {
+      "stationName": "홍대입구",
+      "patterns": ["^T_subway_홍대입구", "^Olleh_Subway_홍대입구", "Hongik_Univ"]
+    },
+    {
+      "stationName": "교대",
+      "patterns": ["^T_subway_교대", "^Olleh_Subway_교대", "Seoul_Nat_Univ_of_Education"]
+    },
+    {
+      "stationName": "동대문역사문화공원",
+      "patterns": [
+        "^T_subway_동대문역사문화공원",
+        "^Olleh_Subway_동대문역사문화공원",
+        "DDP_Subway"
+      ]
+    },
+    {
+      "stationName": "공덕",
+      "patterns": ["^T_subway_공덕", "^Olleh_Subway_공덕", "Gongdeok"]
+    }
+  ]
+}

--- a/src/features/alarm/utils/__tests__/notificationSource.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationSource.test.ts
@@ -9,9 +9,11 @@ import type { FusionSource } from '../../../../shared/types/fusion';
 describe('resolveNotificationSource', () => {
   it.each<[FusionSource, NotificationSource]>([
     ['boarding-lock', 'positionTrain'],
+    ['boarding-lock-interp', 'positionTrain'],
     ['position-train', 'positionTrain'],
     ['position', 'positionTrain'],
     ['arrival', 'positionTrain'],
+    ['wifi-ssid', 'positionTrain'],
     ['route-progress', 'routeProgress'],
     ['gps', 'gpsOnly'],
   ])('%s → %s', (source, expected) => {

--- a/src/features/alarm/utils/notificationSource.ts
+++ b/src/features/alarm/utils/notificationSource.ts
@@ -30,6 +30,7 @@ export function resolveNotificationSource(
     case 'position-train':
     case 'position':
     case 'arrival':
+    case 'wifi-ssid':
       return 'positionTrain';
     case 'route-progress':
       return 'routeProgress';

--- a/src/features/nearest-station/utils/__tests__/wifiSsidLookup.test.ts
+++ b/src/features/nearest-station/utils/__tests__/wifiSsidLookup.test.ts
@@ -1,0 +1,105 @@
+import {
+  lookupStationBySsid,
+  __resetWifiSsidLookupCacheForTest,
+} from '../wifiSsidLookup';
+
+describe('lookupStationBySsid', () => {
+  beforeEach(() => {
+    __resetWifiSsidLookupCacheForTest();
+  });
+
+  describe('정상 매칭', () => {
+    it.each([
+      ['T_subway_용마산', '용마산'],
+      ['T_subway_중곡', '중곡'],
+      ['Olleh_Subway_강남', '강남'],
+      ['U+Subway_왕십리', '왕십리'],
+      ['Gangnam_Station', '강남'],
+      ['Seoul_Station_Subway', '서울역'],
+      ['Konkuk_Univ_AP_03', '건대입구'],
+      ['CityHall_Subway_2F', '시청'],
+      ['Express_Bus_Terminal_Wifi', '고속터미널'],
+    ])('SSID "%s" → station "%s"', (ssid, expectedName) => {
+      const result = lookupStationBySsid(ssid);
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe(expectedName);
+    });
+
+    it('Station 객체에는 stations.json의 lat/lng가 포함된다', () => {
+      const result = lookupStationBySsid('T_subway_용마산');
+      expect(result).not.toBeNull();
+      expect(typeof result?.lat).toBe('number');
+      expect(typeof result?.lng).toBe('number');
+      expect(result?.line).toBe('7');
+    });
+
+    it('대소문자 무시 매칭 — "t_SUBWAY_강남" 도 매칭된다', () => {
+      const result = lookupStationBySsid('t_SUBWAY_강남');
+      expect(result?.name).toBe('강남');
+    });
+
+    it('SSID 앞뒤 공백은 trim 처리한다', () => {
+      const result = lookupStationBySsid('   T_subway_용마산   ');
+      expect(result?.name).toBe('용마산');
+    });
+
+    it('한 entry의 첫 패턴이 안 맞아도 두 번째 패턴이 맞으면 매칭', () => {
+      const result = lookupStationBySsid('Yongmasan_Free_Wifi');
+      expect(result?.name).toBe('용마산');
+    });
+
+    it('이수 별칭 — "T_subway_총신대입구" SSID도 이수 entry로 매칭되며 canonical(총신대입구)로 정규화', () => {
+      // STATION_ALIASES: 이수 → 총신대입구. JSON entry는 "이수"로 적혀 있지만
+      // stations.json 매칭은 canonical 표기를 따른다.
+      const result = lookupStationBySsid('T_subway_총신대입구');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('총신대입구');
+    });
+  });
+
+  describe('매칭 실패 / fallback', () => {
+    it.each([
+      ['', 'empty string'],
+      ['   ', 'whitespace only'],
+      ['random_home_wifi', 'unrelated SSID'],
+      ['T_subway_없는역', 'pattern 자체는 맞지만 매핑 stationName이 없는 경우 — 실제로는 entries 없음'],
+      ['iptime_5G_home', '가정용 공유기'],
+      ['KT_GIGA_2G', '통신사 일반 SSID'],
+    ])('SSID "%s" (%s) → null 반환', (ssid) => {
+      expect(lookupStationBySsid(ssid)).toBeNull();
+    });
+
+    it('null/undefined 입력은 null 반환 (방어적)', () => {
+      expect(lookupStationBySsid(null as unknown as string)).toBeNull();
+      expect(lookupStationBySsid(undefined as unknown as string)).toBeNull();
+    });
+
+    it('JSON entry stationName이 stations.json에 없으면 null (정합성 보호)', () => {
+      // findStationByName이 null을 반환하는 분기를 mock으로 강제 — 데이터 정합성 가드 검증.
+      jest.isolateModules(() => {
+        jest.doMock('../../../../shared/utils/stationLookup', () => ({
+          findStationByName: () => null,
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const mod = require('../wifiSsidLookup');
+        expect(mod.lookupStationBySsid('T_subway_용마산')).toBeNull();
+      });
+    });
+  });
+
+  describe('캐시 동작', () => {
+    it('두 번째 호출도 같은 결과 — 캐시된 컴파일 정규식이 재사용된다', () => {
+      const first = lookupStationBySsid('T_subway_용마산');
+      const second = lookupStationBySsid('T_subway_용마산');
+      expect(first?.name).toBe('용마산');
+      expect(second?.name).toBe('용마산');
+    });
+
+    it('__resetWifiSsidLookupCacheForTest 호출 후에도 정상 동작', () => {
+      lookupStationBySsid('T_subway_용마산'); // warm
+      __resetWifiSsidLookupCacheForTest();
+      const result = lookupStationBySsid('T_subway_용마산');
+      expect(result?.name).toBe('용마산');
+    });
+  });
+});

--- a/src/features/nearest-station/utils/wifiSsidLookup.ts
+++ b/src/features/nearest-station/utils/wifiSsidLookup.ts
@@ -1,0 +1,69 @@
+/**
+ * Wifi SSID 직접 매칭으로 역을 확정한다 (#913, Epic #912 — F2 100% 현재역).
+ *
+ * 지하에서 GPS가 실패해도 wifi가 잡히면 SSID 패턴 매칭으로 현재 역을 결정한다.
+ * - 매핑 데이터: `src/data/subwayWifiSsidMap.json` (역명 → 정규식 패턴 배열)
+ * - 정규화: 매칭된 역명은 `applyStationAlias` → `stations.json` 매칭 후 첫 호선의 Station 반환.
+ *   환승역의 line 결정은 호출자가 다른 신호(boarding-lock·경로)와 교차해 처리한다.
+ *
+ * 본 유틸은 pure JS layer. 네이티브 SSID 조회 브릿지(NEHotspotNetwork / WifiManager)와
+ * useNearestStation cascade wire는 후속 PR에서 추가한다.
+ */
+import wifiSsidMapRaw from '../../../data/subwayWifiSsidMap.json';
+import { applyStationAlias } from '../../../data/stationAliases';
+import { findStationByName } from '../../../shared/utils/stationLookup';
+import type { Station } from '../../../shared/types/station';
+
+interface WifiSsidEntry {
+  stationName: string;
+  patterns: string[];
+}
+
+interface WifiSsidMap {
+  entries: WifiSsidEntry[];
+}
+
+interface CompiledEntry {
+  canonicalName: string;
+  regexes: RegExp[];
+}
+
+const wifiSsidMap = wifiSsidMapRaw as unknown as WifiSsidMap;
+
+let compiledCache: CompiledEntry[] | null = null;
+
+function getCompiledEntries(): CompiledEntry[] {
+  if (compiledCache !== null) return compiledCache;
+  compiledCache = wifiSsidMap.entries.map((entry) => ({
+    canonicalName: applyStationAlias(entry.stationName),
+    regexes: entry.patterns.map((p) => new RegExp(p, 'i')),
+  }));
+  return compiledCache;
+}
+
+/**
+ * 현재 wifi SSID 문자열을 받아 매칭되는 Station을 반환한다.
+ * @param ssid - 네이티브에서 조회한 현재 연결된 wifi SSID. null/empty/매칭 실패 시 null.
+ */
+export function lookupStationBySsid(ssid: string | null | undefined): Station | null {
+  if (typeof ssid !== 'string') return null;
+  const trimmed = ssid.trim();
+  if (trimmed.length === 0) return null;
+
+  const entries = getCompiledEntries();
+  for (const entry of entries) {
+    const matched = entry.regexes.some((re) => re.test(trimmed));
+    if (!matched) continue;
+    const station = findStationByName(entry.canonicalName);
+    if (station !== null) return station;
+  }
+  return null;
+}
+
+/**
+ * 테스트 전용 — 컴파일된 정규식 캐시를 비운다.
+ * 프로덕션 런타임에서는 호출되지 않는다(데이터가 JSON 정적 import이므로 cache 무효화 불필요).
+ */
+export function __resetWifiSsidLookupCacheForTest(): void {
+  compiledCache = null;
+}

--- a/src/shared/types/fusion.ts
+++ b/src/shared/types/fusion.ts
@@ -14,6 +14,10 @@
  * 시사하면 강등 라벨을 붙여 early/transfer 알람 발사를 보류한다(stationAlarm 게이트).
  * gps-only와 동급 신뢰지만 지하 fix는 wifi/cell 삼각측량 fallback이 보고된 좌표일 가능성이 높아
  * 알람 정확도 측면에서 별도 분기가 필요하다.
+ *
+ * #913 (Epic #912) — 'wifi-ssid' 추가. 지하에서 wifi가 잡힐 때 SSID 패턴 직접 매칭으로
+ * 역을 확정한다(예: `T_subway_용마산`). GPS 무관 100% 확정 신호이므로 cascade의
+ * 첫 단계로 사용되며 boarding-lock과 동급 신뢰로 취급(별도 source 필드로 식별).
  */
 export type FusionConfidence =
   | 'boarding-lock'
@@ -23,13 +27,17 @@ export type FusionConfidence =
   | 'arrival-arriving'
   | 'route-progress'
   | 'gps-only'
-  | 'gps-only-underground';
+  | 'gps-only-underground'
+  | 'wifi-ssid';
 
 /**
  * fusion 신호 출처. position-train이 가장 정확(특정 trainNo 추적 → 현재역),
  * position은 station 단위 trainSttus 직접 매칭, arrival은 추정(곧 도착),
  * route-progress는 트랙 1D 진행도, gps는 거리 기반.
  * 알람 dedup·로깅에서 source별 정책 분기에 사용.
+ *
+ * #913 (Epic #912) — 'wifi-ssid'는 지하 SSID 매칭 결과. cascade의 가장 앞 단계로
+ * 사용되며 GPS/arrival 호출 없이 역을 확정한다.
  */
 export type FusionSource =
   | 'boarding-lock'
@@ -38,4 +46,5 @@ export type FusionSource =
   | 'position'
   | 'arrival'
   | 'route-progress'
-  | 'gps';
+  | 'gps'
+  | 'wifi-ssid';


### PR DESCRIPTION
## Summary
Epic #912 P0 F2 첫 슬라이스. 지하 wifi SSID → 현재역 100% 확정의 pure JS layer만 먼저 분리.

- `src/data/subwayWifiSsidMap.json`: 서울 지하철 19개 역 SSID 패턴 (T_subway_, Olleh_Subway_, U+Subway_ 등 통신사 prefix 정규식 + 영문/한자 변형)
- `src/features/nearest-station/utils/wifiSsidLookup.ts`: 현재 SSID 문자열 → 매칭된 역 객체 (또는 null). 정규식 컴파일 캐시 + `applyStationAlias` 별칭 흡수
- `src/shared/types/fusion.ts`: `FusionConfidence` / `FusionSource`에 `'wifi-ssid'` 추가
- `src/features/alarm/utils/notificationSource.ts`: 새 source case 추가 (exhaustive switch 가드)

## 슬라이싱 의도 (Refs #913)
**본 PR 제외, 후속 PR 예정**:
- `modules/wifi-ssid/` iOS `NEHotspotNetwork.fetchCurrent` + Android `WifiManager.getConnectionInfo` native bridge
- `useNearestStation` cascade 첫 단계로 wire (GPS보다 우선)
- 실제 SSID 데이터 수집 (필드 작업 + 크라우드소싱)

본 PR에는 sample 19개 역 placeholder 패턴만 포함. 프로덕션 코드에서 import 0건 (격리).

## 코드리뷰 결과
code-review agent low effort: P1 0건. P2 3건은 후속 cascade wire PR에서 처리 권고:
- P2-1: 통신사 prefix를 `WIFI_SSID_CARRIER_PREFIXES` 상수로 분리
- P2-2: `'wifi-ssid'`를 confidence/source 양쪽 추가한 의미 결정 docs화
- P2-3: 정규식 anchor 컨벤션화 (`^` vs `\b`)

## Test plan
- [x] `npm test` 통과 (203 suites, 3660 tests, 100% coverage)
- [x] `npm run type-check` 통과
- [x] code-review agent 호출 → P1 0건

Refs #912
Refs #913