### PR TITLE
feat(#914): 1탭 현재역 확정 모달 + useStationCandidates hook (F4 첫 PR)

### DIFF
--- a/src/features/nearest-station/components/CurrentStationConfirmModal.tsx
+++ b/src/features/nearest-station/components/CurrentStationConfirmModal.tsx
@@ -1,0 +1,202 @@
+/**
+ * 1탭 현재역 확정 모달 (#914, Epic #912 — F4 100% 현재역).
+ *
+ * 자동 추정으로 현재역을 단정할 수 없는 경우(wifi dead zone, 환승 통로 등)에
+ * 후보 1~3개를 카드로 노출하고 사용자가 한 번만 탭해 확정한다.
+ *
+ * - 후보 0개: "주변 역 없음" + 검색 fallback 버튼
+ * - 후보 N개: 거리순 카드 리스트, topPick은 시각적으로 강조
+ * - 1탭 = onConfirm(station) — caller가 toast + 현재역 적용
+ *
+ * 후속 PR:
+ *  - HomeScreen wire (cold start + locationUncertain 길어질 때)
+ *  - F3 기압계(#920) 신호 통합 — useStationCandidates 입력에 추가
+ *  - 검색 fallback 실제 wire (현재는 onSearchFallback prop으로 노출만)
+ */
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { LINE_NAMES } from '../../../shared/constants/lineColors';
+import { getStationDisplayName } from '../../../shared/utils/stationDisplay';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
+import type { Station } from '../../../shared/types/station';
+
+interface Props {
+  readonly visible: boolean;
+  /** 후보 역 목록(거리순). 빈 배열이면 fallback UI. */
+  readonly candidates: readonly Station[];
+  /** 강조 표시할 후보. candidates에 포함된 것이어야 한다. null이면 강조 없음. */
+  readonly topPick: Station | null;
+  /** 카드 탭 시 호출. caller가 현재역 적용 + 모달 close + toast 처리. */
+  readonly onConfirm: (station: Station) => void;
+  /** 후보가 없을 때 표시되는 fallback 버튼 — caller가 검색 모달 오픈. */
+  readonly onSearchFallback: () => void;
+  /** 모달 자체 dismiss (헤더 [닫기]). */
+  readonly onClose: () => void;
+}
+
+export function CurrentStationConfirmModal({
+  visible,
+  candidates,
+  topPick,
+  onConfirm,
+  onSearchFallback,
+  onClose,
+}: Props) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+
+  const hasCandidates = candidates.length > 0;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      testID="current-station-confirm-modal"
+    >
+      <View style={[styles.backdrop, { backgroundColor: colors.overlay }]}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: colors.bg,
+              paddingTop: spacing.lg,
+              paddingBottom: insets.bottom + spacing.lg,
+            },
+          ]}
+        >
+          <View style={[styles.header, { borderBottomColor: colors.hair }]}>
+            <Text style={[typography.label, { color: colors.muted }]}>
+              {t('currentStationConfirm.title')}
+            </Text>
+            <Pressable onPress={onClose} testID="current-station-confirm-close">
+              <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
+                {t('currentStationConfirm.close')}
+              </Text>
+            </Pressable>
+          </View>
+
+          {hasCandidates && (
+            <Text style={[typography.bodySm, { color: colors.muted }]}>
+              {t('currentStationConfirm.subtitle')}
+            </Text>
+          )}
+
+          {hasCandidates ? (
+            <View style={styles.list} testID="current-station-confirm-list">
+              {candidates.map((station) => {
+                const isTopPick = topPick !== null && station.id === topPick.id;
+                return (
+                  <Pressable
+                    key={station.id}
+                    onPress={() => onConfirm(station)}
+                    style={[
+                      styles.card,
+                      {
+                        backgroundColor: colors.card,
+                        borderColor: isTopPick ? colors.accent : colors.hair,
+                        borderWidth: isTopPick ? 2 : 1,
+                      },
+                    ]}
+                    testID={`current-station-confirm-item-${station.id}`}
+                  >
+                    <View style={styles.cardInfo}>
+                      <Text style={[typography.body, { color: colors.ink, fontWeight: '600' }]}>
+                        {getStationDisplayName(station)}
+                      </Text>
+                      {isTopPick && (
+                        <Text
+                          style={[typography.label, { color: colors.accent }]}
+                          testID={`current-station-confirm-top-pick-${station.id}`}
+                        >
+                          {t('currentStationConfirm.topPickHint')}
+                        </Text>
+                      )}
+                    </View>
+                    <View style={[styles.lineBadge, { backgroundColor: station.lineColor }]}>
+                      <Text style={styles.lineText}>{LINE_NAMES[station.line]}</Text>
+                    </View>
+                  </Pressable>
+                );
+              })}
+            </View>
+          ) : (
+            <View style={styles.empty} testID="current-station-confirm-empty">
+              <Text style={[typography.body, { color: colors.muted }]}>
+                {t('currentStationConfirm.empty')}
+              </Text>
+              <Pressable
+                onPress={onSearchFallback}
+                style={[styles.searchButton, { borderColor: colors.accent }]}
+                testID="current-station-confirm-search-fallback"
+              >
+                <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
+                  {t('currentStationConfirm.searchFallback')}
+                </Text>
+              </Pressable>
+            </View>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+    paddingHorizontal: spacing.lg,
+    gap: spacing.md,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBottom: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  list: {
+    gap: spacing.sm,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.lg,
+    borderRadius: radius.md,
+    gap: spacing.md,
+  },
+  cardInfo: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  lineBadge: {
+    borderRadius: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+  },
+  lineText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  empty: {
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.xl,
+  },
+  searchButton: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+});

--- a/src/features/nearest-station/components/__tests__/CurrentStationConfirmModal.test.tsx
+++ b/src/features/nearest-station/components/__tests__/CurrentStationConfirmModal.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent } from '@testing-library/react-native';
+import { CurrentStationConfirmModal } from '../CurrentStationConfirmModal';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import type { Station } from '../../../../shared/types/station';
+
+const YONGMASAN: Station = {
+  id: '7-015',
+  name: '용마산',
+  nameEn: 'Yongmasan',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.573647,
+  lng: 127.086727,
+};
+
+const JUNGGOK: Station = {
+  id: '7-016',
+  name: '중곡',
+  nameEn: 'Junggok',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.565923,
+  lng: 127.08432,
+};
+
+const SAGAJEONG: Station = {
+  id: '7-014',
+  name: '사가정',
+  nameEn: 'Sagajeong',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.5814,
+  lng: 127.0884,
+};
+
+function renderModal(overrides: {
+  visible?: boolean;
+  candidates?: readonly Station[];
+  topPick?: Station | null;
+  onConfirm?: (s: Station) => void;
+  onSearchFallback?: () => void;
+  onClose?: () => void;
+} = {}) {
+  // topPick은 null도 의미 있는 값이라 ?? 대신 hasOwnProperty 체크로 디폴트 적용.
+  const topPick = 'topPick' in overrides ? (overrides.topPick ?? null) : YONGMASAN;
+  return renderWithTheme(
+    <CurrentStationConfirmModal
+      visible={overrides.visible ?? true}
+      candidates={overrides.candidates ?? [YONGMASAN, JUNGGOK, SAGAJEONG]}
+      topPick={topPick}
+      onConfirm={overrides.onConfirm ?? jest.fn()}
+      onSearchFallback={overrides.onSearchFallback ?? jest.fn()}
+      onClose={overrides.onClose ?? jest.fn()}
+    />,
+  );
+}
+
+describe('CurrentStationConfirmModal', () => {
+  it('visible=true이면 모달과 후보 list를 렌더한다', () => {
+    const { getByTestId } = renderModal();
+    expect(getByTestId('current-station-confirm-modal')).toBeTruthy();
+    expect(getByTestId('current-station-confirm-list')).toBeTruthy();
+  });
+
+  it('각 후보마다 prefix 적용된 testID로 카드 렌더', () => {
+    const { getByTestId } = renderModal();
+    expect(getByTestId('current-station-confirm-item-7-015')).toBeTruthy();
+    expect(getByTestId('current-station-confirm-item-7-016')).toBeTruthy();
+    expect(getByTestId('current-station-confirm-item-7-014')).toBeTruthy();
+  });
+
+  it('topPick과 일치하는 후보만 강조 라벨 노출', () => {
+    const { getByTestId, queryByTestId } = renderModal({ topPick: JUNGGOK });
+    expect(getByTestId('current-station-confirm-top-pick-7-016')).toBeTruthy();
+    expect(queryByTestId('current-station-confirm-top-pick-7-015')).toBeNull();
+    expect(queryByTestId('current-station-confirm-top-pick-7-014')).toBeNull();
+  });
+
+  it('topPick=null이면 강조 라벨이 어디에도 표시되지 않음', () => {
+    const { queryByTestId } = renderModal({ topPick: null });
+    expect(queryByTestId('current-station-confirm-top-pick-7-015')).toBeNull();
+    expect(queryByTestId('current-station-confirm-top-pick-7-016')).toBeNull();
+  });
+
+  it('카드 탭 시 해당 station을 onConfirm으로 전달', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = renderModal({ onConfirm });
+    fireEvent.press(getByTestId('current-station-confirm-item-7-016'));
+    expect(onConfirm).toHaveBeenCalledWith(JUNGGOK);
+  });
+
+  it('닫기 버튼 탭 시 onClose 호출', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = renderModal({ onClose });
+    fireEvent.press(getByTestId('current-station-confirm-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('후보가 비어 있으면 empty 영역 + 검색 fallback 버튼 노출', () => {
+    const { getByTestId, queryByTestId } = renderModal({ candidates: [], topPick: null });
+    expect(getByTestId('current-station-confirm-empty')).toBeTruthy();
+    expect(getByTestId('current-station-confirm-search-fallback')).toBeTruthy();
+    expect(queryByTestId('current-station-confirm-list')).toBeNull();
+  });
+
+  it('검색 fallback 버튼 탭 시 onSearchFallback 호출', () => {
+    const onSearchFallback = jest.fn();
+    const { getByTestId } = renderModal({
+      candidates: [],
+      topPick: null,
+      onSearchFallback,
+    });
+    fireEvent.press(getByTestId('current-station-confirm-search-fallback'));
+    expect(onSearchFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('후보가 1개면 그 한 카드만 렌더', () => {
+    const { getByTestId, queryByTestId } = renderModal({
+      candidates: [YONGMASAN],
+      topPick: YONGMASAN,
+    });
+    expect(getByTestId('current-station-confirm-item-7-015')).toBeTruthy();
+    expect(queryByTestId('current-station-confirm-item-7-016')).toBeNull();
+  });
+
+  it('visible=false이면 list testID가 검색되지 않는다 (RN Modal hidden semantics)', () => {
+    // RN의 Modal은 visible=false 시 자식을 hide. queryBy는 visible과 무관하게 트리를 보지만
+    // 호출자에겐 Modal의 visible prop 전달만 검증하면 충분 — 추가 검증으로 prop 시그니처 확인.
+    const { UNSAFE_getByType } = renderModal({ visible: false });
+    // react-native Modal element를 직접 lookup해 visible prop 전달 확인.
+    const ModalRN: typeof import('react-native').Modal = require('react-native').Modal;
+    expect(UNSAFE_getByType(ModalRN).props.visible).toBe(false);
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
@@ -1,0 +1,138 @@
+import { renderHook } from '@testing-library/react-native';
+import { useStationCandidates } from '../useStationCandidates';
+import type { Station } from '../../../../shared/types/station';
+
+const YONGMASAN: Station = {
+  id: '7-015',
+  name: '용마산',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.573647,
+  lng: 127.086727,
+};
+
+// 용마산 좌표 — stations.json에 실재. findTopNearestStations가 거리 1순위로 반환.
+const YONGMASAN_LOC = { lat: 37.573647, lng: 127.086727 };
+
+// 한반도 밖 — 1km 반경에 어떤 역도 없음.
+const FAR_OFFSHORE = { lat: 0, lng: 0 };
+
+describe('useStationCandidates', () => {
+  it('userLocation/wifiStation 모두 없으면 빈 결과', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({ userLocation: null, wifiStation: null }),
+    );
+    expect(result.current.candidates).toEqual([]);
+    expect(result.current.topPick).toBeNull();
+    expect(result.current.isAutoConfirmed).toBe(false);
+  });
+
+  it('wifi 매칭만 있으면 그 역 단일 후보 + 자동 확정', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({ userLocation: null, wifiStation: YONGMASAN }),
+    );
+    expect(result.current.candidates).toEqual([YONGMASAN]);
+    expect(result.current.topPick).toBe(YONGMASAN);
+    expect(result.current.isAutoConfirmed).toBe(true);
+  });
+
+  it('wifi 매칭이 있으면 GPS보다 우선한다', () => {
+    // GPS는 용마산이지만 wifi는 임의의 다른 역(목업)을 가리킨다.
+    const fakeWifi: Station = { ...YONGMASAN, id: 'fake', name: '가상역' };
+    const { result } = renderHook(() =>
+      useStationCandidates({ userLocation: YONGMASAN_LOC, wifiStation: fakeWifi }),
+    );
+    expect(result.current.candidates).toEqual([fakeWifi]);
+    expect(result.current.topPick).toBe(fakeWifi);
+    expect(result.current.isAutoConfirmed).toBe(true);
+  });
+
+  it('GPS 좌표가 역에 가까우면 거리순 후보를 반환하고 1순위가 topPick', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({ userLocation: YONGMASAN_LOC, wifiStation: null }),
+    );
+    expect(result.current.candidates.length).toBeGreaterThan(0);
+    expect(result.current.topPick).not.toBeNull();
+    expect(result.current.topPick?.name).toBe('용마산');
+    // 환승역이 아니므로 후보가 단일이거나 인근 역이 함께. 다음 분기는 후보 수에 의존 안 함.
+  });
+
+  it('maxCandidates를 기본 3으로 제한한다', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({ userLocation: YONGMASAN_LOC, wifiStation: null }),
+    );
+    expect(result.current.candidates.length).toBeLessThanOrEqual(3);
+  });
+
+  it('maxCandidates 명시 시 그 값으로 제한된다', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({
+        userLocation: YONGMASAN_LOC,
+        wifiStation: null,
+        maxCandidates: 2,
+      }),
+    );
+    expect(result.current.candidates.length).toBeLessThanOrEqual(2);
+  });
+
+  it('maxCandidates가 0이면 빈 결과 (정의 가드)', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({
+        userLocation: YONGMASAN_LOC,
+        wifiStation: null,
+        maxCandidates: 0,
+      }),
+    );
+    expect(result.current.candidates).toEqual([]);
+    expect(result.current.topPick).toBeNull();
+    expect(result.current.isAutoConfirmed).toBe(false);
+  });
+
+  it('maxDistanceKm 반경 밖이면 빈 결과', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({
+        userLocation: FAR_OFFSHORE,
+        wifiStation: null,
+      }),
+    );
+    expect(result.current.candidates).toEqual([]);
+    expect(result.current.topPick).toBeNull();
+    expect(result.current.isAutoConfirmed).toBe(false);
+  });
+
+  it('maxDistanceKm를 매우 작게 주면 좌표가 정확해도 빈 결과', () => {
+    const { result } = renderHook(() =>
+      useStationCandidates({
+        userLocation: { lat: 37.573647 + 0.01, lng: 127.086727 + 0.01 },
+        wifiStation: null,
+        maxDistanceKm: 0.05,
+      }),
+    );
+    expect(result.current.candidates).toEqual([]);
+  });
+
+  it('후보가 정확히 1개면 isAutoConfirmed=true (GPS 경로)', () => {
+    // 매우 좁은 반경 → 단일 역만 들어오게.
+    const { result } = renderHook(() =>
+      useStationCandidates({
+        userLocation: YONGMASAN_LOC,
+        wifiStation: null,
+        maxDistanceKm: 0.05,
+      }),
+    );
+    expect(result.current.candidates.length).toBe(1);
+    expect(result.current.isAutoConfirmed).toBe(true);
+  });
+
+  it('같은 입력으로 rerender 시 참조 안정성 (useMemo)', () => {
+    const props = { userLocation: YONGMASAN_LOC, wifiStation: null };
+    const { result, rerender } = renderHook(
+      (p: { userLocation: typeof YONGMASAN_LOC; wifiStation: Station | null }) =>
+        useStationCandidates(p),
+      { initialProps: props },
+    );
+    const first = result.current;
+    rerender(props);
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/features/nearest-station/hooks/useStationCandidates.ts
+++ b/src/features/nearest-station/hooks/useStationCandidates.ts
@@ -1,0 +1,84 @@
+/**
+ * 현재 위치 + wifi 매칭 결과를 결합해 "현재 역" 후보를 산출하는 hook (#914, Epic #912 — F4).
+ *
+ * 자동 추정으로 현재역을 단정할 수 없을 때 1탭 모달에 뿌릴 후보 목록을 메모이즈한다.
+ * - wifi SSID(F2) 매칭 결과가 있으면 그 역을 topPick으로 두고 후보 1개 + 자동 확정 신호.
+ * - 그 외엔 GPS 기반 `findTopNearestStations`로 거리순 상위 N개를 반환.
+ *
+ * 본 hook은 부수 효과 없는 순수 계산 layer. 모달 표시/검색 fallback 트리거는 호출자가 결정한다.
+ *
+ * 후속 PR:
+ *  - HomeScreen wire(cold start + locationUncertain 길어질 때 표시)
+ *  - F3 기압계(#920) 신호를 입력에 추가해 지하 진입 시 후보 가중치 보정
+ */
+import { useMemo } from 'react';
+import { findTopNearestStations } from '../utils/findNearestStation';
+import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
+import type { Station } from '../../../shared/types/station';
+
+export const DEFAULT_MAX_CANDIDATES = 3;
+
+export interface UseStationCandidatesInputs {
+  /** 현재 GPS 좌표. null이면 GPS 기반 후보 추출 skip. */
+  readonly userLocation: { readonly lat: number; readonly lng: number } | null;
+  /** F2 wifi SSID 매칭 결과 (`lookupStationBySsid`). 있으면 최우선. */
+  readonly wifiStation: Station | null;
+  /** 후보 최대 개수. 기본 3. */
+  readonly maxCandidates?: number;
+  /** GPS 후보 추출 시 반경(km). 기본 `MAX_STATION_DISTANCE_KM`(1.0). */
+  readonly maxDistanceKm?: number;
+}
+
+export interface UseStationCandidatesResult {
+  /** UI에 표시할 후보 역 목록 (거리순 또는 wifi 단일). 최대 `maxCandidates`개. */
+  readonly candidates: readonly Station[];
+  /** 가장 유력한 후보 (강조 표시용). 후보 없으면 null. */
+  readonly topPick: Station | null;
+  /** 후보가 단 하나 → 모달 없이 자동 확정 가능. */
+  readonly isAutoConfirmed: boolean;
+}
+
+const EMPTY: UseStationCandidatesResult = {
+  candidates: [],
+  topPick: null,
+  isAutoConfirmed: false,
+};
+
+export function useStationCandidates(
+  inputs: UseStationCandidatesInputs,
+): UseStationCandidatesResult {
+  const {
+    userLocation,
+    wifiStation,
+    maxCandidates = DEFAULT_MAX_CANDIDATES,
+    maxDistanceKm = MAX_STATION_DISTANCE_KM,
+  } = inputs;
+
+  return useMemo<UseStationCandidatesResult>(() => {
+    // wifi 매칭(F2)이 있으면 그 역을 단일 후보로 — 지하 SSID는 GPS보다 신뢰도가 높다.
+    if (wifiStation) {
+      return {
+        candidates: [wifiStation],
+        topPick: wifiStation,
+        isAutoConfirmed: true,
+      };
+    }
+
+    if (!userLocation || maxCandidates <= 0) return EMPTY;
+
+    const ranked = findTopNearestStations(
+      userLocation.lat,
+      userLocation.lng,
+      maxCandidates,
+      maxDistanceKm,
+    );
+    if (ranked.length === 0) return EMPTY;
+
+    const candidates = ranked.map((r) => r.station);
+    return {
+      candidates,
+      topPick: candidates[0],
+      isAutoConfirmed: candidates.length === 1,
+    };
+  }, [userLocation, wifiStation, maxCandidates, maxDistanceKm]);
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -124,6 +124,14 @@
     "assignSlot": "Add {{label}}",
     "pendingSlot": "The next station you pick will be saved as {{label}}"
   },
+  "currentStationConfirm": {
+    "title": "Confirm your current station",
+    "subtitle": "Tap to set as current station",
+    "topPickHint": "Best match",
+    "empty": "No nearby station found",
+    "searchFallback": "Search instead",
+    "close": "Close"
+  },
   "sleepModeGuide": {
     "title": "Sleep mode notice",
     "message": "If earphones are not connected, the alarm may play through the speaker.\n\nIf you do not want speaker output, turn off 'Allow speaker output' under Settings > Alarm.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -124,6 +124,14 @@
     "assignSlot": "{{label}}を追加",
     "pendingSlot": "次に選ぶ駅を{{label}}として保存します"
   },
+  "currentStationConfirm": {
+    "title": "現在の駅を確認してください",
+    "subtitle": "タップすると現在の駅に設定されます",
+    "topPickHint": "おすすめ",
+    "empty": "近くの駅が見つかりませんでした",
+    "searchFallback": "検索で選ぶ",
+    "close": "閉じる"
+  },
   "sleepModeGuide": {
     "title": "おやすみモードのご案内",
     "message": "イヤホンが接続されていない場合、アラームがスピーカーで再生されることがあります。\n\nスピーカー出力を希望しない場合は、設定 > アラームで「スピーカー出力を許可」をオフにしてください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -124,6 +124,14 @@
     "assignSlot": "{{label}} 추가",
     "pendingSlot": "다음에 선택하는 역을 {{label}}로 저장합니다"
   },
+  "currentStationConfirm": {
+    "title": "현재 역을 확인해 주세요",
+    "subtitle": "탭하면 현재 역으로 설정됩니다",
+    "topPickHint": "추천",
+    "empty": "주변 역을 찾지 못했습니다",
+    "searchFallback": "검색으로 선택",
+    "close": "닫기"
+  },
   "sleepModeGuide": {
     "title": "취침 모드 안내",
     "message": "이어폰이 연결되지 않은 경우 알람이 스피커로 재생될 수 있습니다.\n\n스피커 출력을 원하지 않으시면 설정 > 알람에서 '스피커 출력 허용'을 꺼주세요.",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -124,6 +124,14 @@
     "assignSlot": "添加{{label}}",
     "pendingSlot": "下次选择的车站将保存为{{label}}"
   },
+  "currentStationConfirm": {
+    "title": "请确认当前车站",
+    "subtitle": "点按即设为当前车站",
+    "topPickHint": "推荐",
+    "empty": "附近未找到车站",
+    "searchFallback": "通过搜索选择",
+    "close": "关闭"
+  },
   "sleepModeGuide": {
     "title": "睡眠模式提示",
     "message": "如果未连接耳机,提醒可能通过扬声器播放。\n\n如不希望扬声器输出,请在 设置 > 提醒 中关闭'允许扬声器输出'。",


### PR DESCRIPTION
## Summary
Epic #912 P0 F4 첫 슬라이스. 자동 추정(F2 wifi 등)으로 현재역 100% 확정 못 하는 케이스의 1탭 fallback.

- `src/features/nearest-station/hooks/useStationCandidates.ts`: wifi SSID 매칭 우선 + 거리 기반 후보 1~3개 narrow. `{ candidates, topPick }` 반환
- `src/features/nearest-station/components/CurrentStationConfirmModal.tsx`: topPick 강조 카드 + 후보 카드 + 1탭 확정 + 검색 fallback (dismiss)
- 4 locale 키 추가 (ko/en/ja/zh)

## 슬라이싱 의도 (Refs #914)
**본 PR 제외, 후속 PR 예정**:
- `HomeScreen.tsx` 모달 wire (cold start + locationUncertain 길어질 때 트리거)
- F3 기압계 통합 (#920에서 useStationCandidates 확장)
- ArrivalRow narrow 추가

## 코드리뷰 결과
code-review agent: **P1 0건**. wifi 우선 분기, `userLocation`/`maxCandidates` 가드, `topPick !== null` 체크 후 id 비교, Modal prop forwarding 모두 정상.

## Test plan
- [x] `npm test` 통과 (205 suites, 3681 tests, 100% coverage)
- [x] `npm run type-check` 통과
- [x] code-review agent → P1 0건

Refs #912
Refs #914