### PR TITLE
feat(#916): backend trip-bound trainCode auto-lock (A1 첫 PR)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { AUTO_LOCK_TTL_MS, attemptAutoLock } from '../autoLock';
+import { SWAP_LOCK_TTL_MS } from '../lockSwap';
+import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
+import type { Trip, Waypoint } from '../types';
+
+const NOW = 1_700_000_000_000;
+
+function makeSeoul(arrivals: ArrivalEntry[]): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: arrivals.map((a) => ({
+            barvlDt: String(a.arrivalSeconds),
+            recptnDt: '',
+            updnLine: a.isUp ? '상행' : '하행',
+            trainLineNm: a.destination,
+            btrainNo: a.trainCode,
+            subwayNm: a.subwayNm,
+            arvlCd: a.arvlCd,
+          })),
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
+function makeTrip(overrides: Partial<Trip> = {}): Trip {
+  return {
+    token: 'tok-auto',
+    route: { type: 'direct', line: '2', stops: 5 },
+    destination: 'dst',
+    waypoints: [
+      { stationName: '역삼', line: '2', kind: 'intermediate' },
+      { stationName: '선릉', line: '2', kind: 'destination' },
+    ],
+    expiresAt: NOW + 60 * 60_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 60_000,
+    ...overrides,
+  };
+}
+
+const target: Waypoint = { stationName: '역삼', line: '2', kind: 'intermediate' };
+
+function arrival(overrides: Partial<ArrivalEntry>): ArrivalEntry {
+  return {
+    destination: 'X',
+    arrivalSeconds: 0,
+    trainCode: 'T1',
+    isUp: true,
+    subwayNm: '2호선',
+    arvlCd: 2,
+    ...overrides,
+  };
+}
+
+describe('attemptAutoLock (#916 A1)', () => {
+  it('단일 후보 → lock 합성 성공, origin이 segmentStations 첫 원소', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      now: NOW,
+    });
+    expect(lock).not.toBeNull();
+    expect(lock?.trainCode).toBe('T1');
+    expect(lock?.line).toBe('2');
+    expect(lock?.subwayId).toBe('1002');
+    expect(lock?.segmentStations).toEqual(['강남', '역삼', '선릉']);
+    expect(lock?.expiresAt).toBe(NOW + AUTO_LOCK_TTL_MS);
+    expect(lock?.selectedDepartureTime).toBe(NOW);
+  });
+
+  it('AUTO_LOCK_TTL_MS는 SWAP_LOCK_TTL_MS와 동일 (단일 정책)', () => {
+    expect(AUTO_LOCK_TTL_MS).toBe(SWAP_LOCK_TTL_MS);
+  });
+
+  it('ambiguity(같은 arvlCd 우선순위 후보 2+) → null', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([
+        arrival({ trainCode: 'T1', arvlCd: 2 }),
+        arrival({ trainCode: 'T2', arvlCd: 2 }),
+      ]),
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arrivals 비어있음 → null', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([]),
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('subwayId 매핑 불가 line → null', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: { stationName: '역삼', line: 'XX', kind: 'intermediate' },
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('legStations 비어있음(waypoints 모두 다른 line) → null', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip({
+        waypoints: [{ stationName: '역삼', line: '3', kind: 'destination' }],
+      }),
+      targetWaypoint: target, // target.line='2'와 waypoints line='3' 불일치
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('direction=down → 하행 trainCode만 매칭', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'down',
+      seoul: makeSeoul([
+        arrival({ trainCode: 'TU', arvlCd: 2, isUp: true }),
+        arrival({ trainCode: 'TD', arvlCd: 2, isUp: false }),
+      ]),
+      now: NOW,
+    });
+    expect(lock?.trainCode).toBe('TD');
+  });
+
+  it('direction=null → 양방향 허용 (단일 후보)', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: null,
+      seoul: makeSeoul([arrival({ trainCode: 'TD', arvlCd: 2, isUp: false })]),
+      now: NOW,
+    });
+    expect(lock?.trainCode).toBe('TD');
+  });
+
+  it('origin이 legStations 첫 원소와 같으면 dedup (중복 prepend 방지)', async () => {
+    // waypoints[0].stationName === originStation인 (방어적) 케이스. 정상 운영에서는 발생하지 않지만
+    // 클라가 origin name과 waypoints를 어긋나게 보낸 회귀에 대해 segmentStations에 중복이 없어야 한다.
+    const lock = await attemptAutoLock({
+      trip: makeTrip({
+        waypoints: [
+          { stationName: '강남', line: '2', kind: 'intermediate' },
+          { stationName: '역삼', line: '2', kind: 'destination' },
+        ],
+      }),
+      targetWaypoint: { stationName: '강남', line: '2', kind: 'intermediate' },
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      now: NOW,
+    });
+    expect(lock?.segmentStations).toEqual(['강남', '역삼']);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -1,49 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { AUTO_LOCK_TTL_MS, attemptAutoLock } from '../autoLock';
 import { SWAP_LOCK_TTL_MS } from '../lockSwap';
-import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
-import type { Trip, Waypoint } from '../types';
-
-const NOW = 1_700_000_000_000;
-
-function makeSeoul(arrivals: ArrivalEntry[]): SeoulArrivalClient {
-  return new SeoulArrivalClient({
-    apiKey: 'K',
-    host: 'h',
-    now: () => NOW,
-    fetchImpl: (async () =>
-      new Response(
-        JSON.stringify({
-          realtimeArrivalList: arrivals.map((a) => ({
-            barvlDt: String(a.arrivalSeconds),
-            recptnDt: '',
-            updnLine: a.isUp ? '상행' : '하행',
-            trainLineNm: a.destination,
-            btrainNo: a.trainCode,
-            subwayNm: a.subwayNm,
-            arvlCd: a.arvlCd,
-          })),
-        }),
-        { status: 200 },
-      )) as unknown as typeof fetch,
-  });
-}
-
-function makeTrip(overrides: Partial<Trip> = {}): Trip {
-  return {
-    token: 'tok-auto',
-    route: { type: 'direct', line: '2', stops: 5 },
-    destination: 'dst',
-    waypoints: [
-      { stationName: '역삼', line: '2', kind: 'intermediate' },
-      { stationName: '선릉', line: '2', kind: 'destination' },
-    ],
-    expiresAt: NOW + 60 * 60_000,
-    createdAt: NOW,
-    alarmAtEpochMs: NOW + 60_000,
-    ...overrides,
-  };
-}
+import { type ArrivalEntry } from '../seoul';
+import type { Waypoint } from '../types';
+import {
+  FIXTURE_NOW as NOW,
+  makeSeoulFixture as makeSeoul,
+  makeTripFixture as makeTrip,
+} from './helpers/testFixtures';
 
 const target: Waypoint = { stationName: '역삼', line: '2', kind: 'intermediate' };
 

--- a/backend/alarm-worker/src/__tests__/helpers/testFixtures.ts
+++ b/backend/alarm-worker/src/__tests__/helpers/testFixtures.ts
@@ -1,0 +1,44 @@
+// 공용 테스트 fixture — scheduled.test.ts / autoLock.test.ts 등이 공유한다.
+import { SeoulArrivalClient, type ArrivalEntry } from '../../seoul';
+import type { Trip } from '../../types';
+
+export const FIXTURE_NOW = 1_700_000_000_000;
+
+export function makeSeoulFixture(arrivals: ArrivalEntry[]): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => FIXTURE_NOW,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: arrivals.map((a) => ({
+            barvlDt: String(a.arrivalSeconds),
+            recptnDt: '',
+            updnLine: a.isUp ? '상행' : '하행',
+            trainLineNm: a.destination,
+            btrainNo: a.trainCode,
+            subwayNm: a.subwayNm,
+            arvlCd: a.arvlCd,
+          })),
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
+export function makeTripFixture(overrides: Partial<Trip> = {}): Trip {
+  return {
+    token: 'tok-auto',
+    route: { type: 'direct', line: '2', stops: 5 },
+    destination: 'dst',
+    waypoints: [
+      { stationName: '역삼', line: '2', kind: 'intermediate' },
+      { stationName: '선릉', line: '2', kind: 'destination' },
+    ],
+    expiresAt: FIXTURE_NOW + 60 * 60_000,
+    createdAt: FIXTURE_NOW,
+    alarmAtEpochMs: FIXTURE_NOW + 60_000,
+    ...overrides,
+  };
+}

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1569,6 +1569,8 @@ describe('POST /boarding-lock/sync (#901)', () => {
       advanced: true,
       currentWaypoint: '역삼',
       nextStation: '역삼',
+      // #916 — tripWithLock fixture에 boardingLock이 미리 설정돼 있으므로 candidate로 노출.
+      autoLockCandidate: { trainCode: 'T-1', line: '2', subwayId: '1002' },
     });
     const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
     expect(stored.waypoints.map((w: { stationName: string }) => w.stationName)).toEqual([
@@ -1729,5 +1731,39 @@ describe('POST /boarding-lock/sync (#901)', () => {
       env,
     );
     expect(res.status).toBe(200);
+  });
+
+  // #916 A1 — boardingLock이 있으면 autoLockCandidate로 노출, 없으면 null.
+  // client는 이 필드를 보고 자동 lock이 부착됐는지 알 수 있다.
+  it('boardingLock 있는 trip → autoLockCandidate에 trainCode/line/subwayId 노출', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripWithLock(), env);
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '신촌', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      autoLockCandidate: { trainCode: string; line: string; subwayId: string } | null;
+    };
+    expect(body.autoLockCandidate).toEqual({ trainCode: 'T-1', line: '2', subwayId: '1002' });
+  });
+
+  it('boardingLock 없는 trip → autoLockCandidate=null', async () => {
+    const env = makeKvEnv();
+    const tripNoLock = tripWithLock();
+    delete tripNoLock.boardingLock;
+    await post('/trips', tripNoLock, env);
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-sync', observedStationName: '신촌', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      autoLockCandidate: unknown;
+    };
+    expect(body.autoLockCandidate).toBeNull();
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2956,36 +2956,46 @@ describe('runScheduled — #916 A1 auto-lock', () => {
   // 모듈 레벨 makePromptTrip / seedHappyGateSeries 재사용 (boarding-prompt / kalman 테스트와 공통).
   const seedHappySeries = (kv: InMemoryKV, token: string) => seedHappyGateSeries(kv, token);
 
+  // 4 tests 공통 setup. 9단 게이트 통과 trip 시드 + GPS series + runScheduled 실행.
+  async function runAutoLockCron(opts: {
+    kv: InMemoryKV;
+    token: string;
+    arrivals: ArrivalEntry[];
+    seedSeries?: boolean;
+    pushId?: string;
+  }): Promise<{
+    stats: ScheduledStats;
+    fetchImpl: ReturnType<typeof vi.fn>;
+  }> {
+    await putTrip(opts.kv as unknown as KVNamespace, makePromptTrip({ token: opts.token }));
+    if (opts.seedSeries !== false) await seedHappySeries(opts.kv, opts.token);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const stats = await runScheduled(makeEnv(opts.kv), {
+      seoul: makeSeoul(opts.arrivals),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      generatePushId: () => opts.pushId ?? 'auto-1',
+    });
+    return { stats, fetchImpl };
+  }
+
   // 9단 게이트 통과 시점에 backend가 arvlCd=2 단일 후보로 trainCode를 결정 → 자동 lock 부착.
   it('9단 통과 + arrivals 단일 후보 → auto-lock 성공, boardingPrompt push 미발사', async () => {
     const kv = new InMemoryKV();
     const token = 'auto-lock-tok';
-    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
-    await seedHappySeries(kv, token);
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
-
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([
-        {
-          destination: '선릉',
-          arrivalSeconds: 60,
-          trainCode: 'AUTO-T1',
-          isUp: true,
-          subwayNm: '지하철2호선',
-          arvlCd: 2,
-        },
-      ]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      now: () => NOW,
-      fetchImpl,
-      generatePushId: () => 'auto-1',
+    const { stats, fetchImpl } = await runAutoLockCron({
+      kv,
+      token,
+      arrivals: [
+        { destination: '선릉', arrivalSeconds: 60, trainCode: 'AUTO-T1', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+      ],
     });
 
     expect(stats.autoLockSuccess).toBe(1);
     expect(stats.boardingPromptFired).toBe(0);
     expect(stats.boardingPromptEvaluated).toBe(1);
-    // boardingPromptPush 미발사 → fetchImpl 호출 0 (APNs 호출 자체가 없어야 함)
     expect(fetchImpl).not.toHaveBeenCalled();
 
     const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
@@ -2999,20 +3009,14 @@ describe('runScheduled — #916 A1 auto-lock', () => {
   it('arvlCd 우선순위 ambiguity → auto-lock 실패 → boarding-prompt push 발사', async () => {
     const kv = new InMemoryKV();
     const token = 'auto-amb-tok';
-    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
-    await seedHappySeries(kv, token);
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
-
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([
+    const { stats } = await runAutoLockCron({
+      kv,
+      token,
+      pushId: 'amb-1',
+      arrivals: [
         { destination: 'A', arrivalSeconds: 60, trainCode: 'X1', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
         { destination: 'B', arrivalSeconds: 90, trainCode: 'X2', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
-      ]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      now: () => NOW,
-      fetchImpl,
-      generatePushId: () => 'amb-1',
+      ],
     });
 
     expect(stats.autoLockSuccess).toBe(0);
@@ -3026,20 +3030,7 @@ describe('runScheduled — #916 A1 auto-lock', () => {
   // arrivals 비어있어도 9단 통과(arrivals API와 promptGeoContext는 독립) → auto-lock skip → fallback.
   it('arrivals 비어있음 → auto-lock 실패 → boarding-prompt push 발사', async () => {
     const kv = new InMemoryKV();
-    const token = 'auto-empty-tok';
-    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
-    await seedHappySeries(kv, token);
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
-
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      now: () => NOW,
-      fetchImpl,
-      generatePushId: () => 'empty-1',
-    });
-
+    const { stats } = await runAutoLockCron({ kv, token: 'auto-empty-tok', arrivals: [], pushId: 'empty-1' });
     expect(stats.autoLockSuccess).toBe(0);
     expect(stats.boardingPromptFired).toBe(1);
   });
@@ -3047,22 +3038,15 @@ describe('runScheduled — #916 A1 auto-lock', () => {
   // 9단 게이트 차단 → auto-lock 자체에 진입하지 않음.
   it('게이트 차단(window-too-small) → auto-lock 미시도', async () => {
     const kv = new InMemoryKV();
-    const token = 'auto-gate-block';
-    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
-    // series 미시드 → window-too-small로 게이트 차단
-    const fetchImpl = vi.fn() as unknown as typeof fetch;
-
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([
+    const { stats } = await runAutoLockCron({
+      kv,
+      token: 'auto-gate-block',
+      seedSeries: false, // series 미시드 → window-too-small 게이트 차단
+      pushId: 'gate-1',
+      arrivals: [
         { destination: 'A', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
-      ]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      now: () => NOW,
-      fetchImpl,
-      generatePushId: () => 'gate-1',
+      ],
     });
-
     expect(stats.autoLockSuccess).toBe(0);
     expect(stats.boardingPromptBlocked).toBe(1);
     expect(stats.boardingPromptFired).toBe(0);

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -60,6 +60,37 @@ function makeEnv(kv: InMemoryKV, pending?: InMemoryKV): Env {
   };
 }
 
+// 9단 게이트 happy path 공용 GPS series — boarding-prompt / kalman / auto-lock 테스트 공통 사용.
+// 게이트 #4(origin 100m 이내) / #5(direction cosine ≥ 0.7) / #7(speed ≥ 5 km/h) 모두 통과 설계.
+async function seedHappyGateSeries(kv: InMemoryKV, token: string): Promise<void> {
+  const series = [
+    { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive' },
+    { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive' },
+    { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
+  ];
+  await kv.put(`pos:${token}`, JSON.stringify(series));
+}
+
+// #916 auto-lock 테스트용 trip 시드. promptGeoContext + promptDisplay + waypoints 9단 게이트 통과 형태.
+function makePromptTrip(overrides: Partial<Trip> = {}): Trip {
+  return makeTrip({
+    token: 'auto-lock-tok',
+    route: { type: 'direct', line: '2', stops: 3 },
+    destination: '선릉',
+    waypoints: [
+      { stationName: '역삼', line: '2', kind: 'intermediate' },
+      { stationName: '선릉', line: '2', kind: 'destination' },
+    ],
+    promptGeoContext: {
+      origin: { lat: 0, lng: 0 },
+      nextStation: { lat: 0, lng: 0.01 },
+      direction: 'up',
+    },
+    promptDisplay: { originStation: '강남', line: '2' },
+    ...overrides,
+  });
+}
+
 function makeTrip(overrides: Partial<Trip> = {}): Trip {
   return {
     token: 'tok',
@@ -1643,15 +1674,8 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     };
   }
 
-  /** "happy path" series — 9단 모두 통과하는 60s window. helper에서 NOW 기준 timestamp 사용. */
-  async function seedHappySeries(kv: InMemoryKV, token = 'bp-tok'): Promise<void> {
-    const series = [
-      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive' },
-      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive' },
-      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
-    ];
-    await kv.put(`pos:${token}`, JSON.stringify(series));
-  }
+  /** "happy path" series — 모듈 레벨 seedHappyGateSeries 재사용 (bp-tok 기본). */
+  const seedHappySeries = (kv: InMemoryKV, token = 'bp-tok') => seedHappyGateSeries(kv, token);
 
   it('promptGeoContext 없으면 skip — boardingPromptEvaluated 미증가', async () => {
     const kv = new InMemoryKV();
@@ -1783,14 +1807,7 @@ describe('runScheduled — evaluateAndMaybeFireBoardingPrompt Kalman KV 통합 (
     });
   }
 
-  async function seedHappySeries(kv: InMemoryKV, token = 'kalman-tok'): Promise<void> {
-    const series = [
-      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive' },
-      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive' },
-      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
-    ];
-    await kv.put(`pos:${token}`, JSON.stringify(series));
-  }
+  const seedHappySeries = (kv: InMemoryKV, token = 'kalman-tok') => seedHappyGateSeries(kv, token);
 
   function makeKalmanPromptDeps(fetchImpl: typeof fetch) {
     return {
@@ -2936,35 +2953,8 @@ describe('runScheduled — Seam F 사라짐 후 재attach (#902)', () => {
 // ──────────────────────────────────────────────────────────────────────────
 
 describe('runScheduled — #916 A1 auto-lock', () => {
-  // 9단 게이트를 통과시키는 happy GPS series + 동일한 prompt geo/display.
-  // 게이트 #4(origin 100m 이내) / #5(direction cosine ≥ 0.7) / #7(speed ≥ 5 km/h) 모두 통과하도록 설계.
-  function makePromptTrip(overrides: Partial<Trip> = {}): Trip {
-    return makeTrip({
-      token: 'auto-lock-tok',
-      route: { type: 'direct', line: '2', stops: 3 },
-      destination: '선릉',
-      waypoints: [
-        { stationName: '역삼', line: '2', kind: 'intermediate' },
-        { stationName: '선릉', line: '2', kind: 'destination' },
-      ],
-      promptGeoContext: {
-        origin: { lat: 0, lng: 0 },
-        nextStation: { lat: 0, lng: 0.01 },
-        direction: 'up',
-      },
-      promptDisplay: { originStation: '강남', line: '2' },
-      ...overrides,
-    });
-  }
-
-  async function seedHappySeries(kv: InMemoryKV, token: string): Promise<void> {
-    const series = [
-      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive' },
-      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive' },
-      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
-    ];
-    await kv.put(`pos:${token}`, JSON.stringify(series));
-  }
+  // 모듈 레벨 makePromptTrip / seedHappyGateSeries 재사용 (boarding-prompt / kalman 테스트와 공통).
+  const seedHappySeries = (kv: InMemoryKV, token: string) => seedHappyGateSeries(kv, token);
 
   // 9단 게이트 통과 시점에 backend가 arvlCd=2 단일 후보로 trainCode를 결정 → 자동 lock 부착.
   it('9단 통과 + arrivals 단일 후보 → auto-lock 성공, boardingPrompt push 미발사', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2930,3 +2930,217 @@ describe('runScheduled — Seam F 사라짐 후 재attach (#902)', () => {
     expect(stored.consecutiveEtaMissing).toBe(2);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// #916 A1 — auto-lock 통합 (evaluateAndMaybeFireBoardingPrompt 분기)
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('runScheduled — #916 A1 auto-lock', () => {
+  // 9단 게이트를 통과시키는 happy GPS series + 동일한 prompt geo/display.
+  // 게이트 #4(origin 100m 이내) / #5(direction cosine ≥ 0.7) / #7(speed ≥ 5 km/h) 모두 통과하도록 설계.
+  function makePromptTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'auto-lock-tok',
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination: '선릉',
+      waypoints: [
+        { stationName: '역삼', line: '2', kind: 'intermediate' },
+        { stationName: '선릉', line: '2', kind: 'destination' },
+      ],
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+      ...overrides,
+    });
+  }
+
+  async function seedHappySeries(kv: InMemoryKV, token: string): Promise<void> {
+    const series = [
+      { lat: 0, lng: -0.0004, accuracy: 10, ts: NOW - 60_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0002, accuracy: 10, ts: NOW - 30_000, motion: 'automotive' },
+      { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+  }
+
+  // 9단 게이트 통과 시점에 backend가 arvlCd=2 단일 후보로 trainCode를 결정 → 자동 lock 부착.
+  it('9단 통과 + arrivals 단일 후보 → auto-lock 성공, boardingPrompt push 미발사', async () => {
+    const kv = new InMemoryKV();
+    const token = 'auto-lock-tok';
+    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
+    await seedHappySeries(kv, token);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([
+        {
+          destination: '선릉',
+          arrivalSeconds: 60,
+          trainCode: 'AUTO-T1',
+          isUp: true,
+          subwayNm: '지하철2호선',
+          arvlCd: 2,
+        },
+      ]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'auto-1',
+    });
+
+    expect(stats.autoLockSuccess).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    // boardingPromptPush 미발사 → fetchImpl 호출 0 (APNs 호출 자체가 없어야 함)
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(stored.boardingLock?.trainCode).toBe('AUTO-T1');
+    expect(stored.boardingLock?.segmentStations).toEqual(['강남', '역삼', '선릉']);
+    expect(stored.boardingPromptState?.fired).toBe(true);
+    expect(stored.consecutiveEtaMissing).toBe(0);
+  });
+
+  // ambiguity면 자동 lock 안 함 → 기존 boarding-prompt push fallback.
+  it('arvlCd 우선순위 ambiguity → auto-lock 실패 → boarding-prompt push 발사', async () => {
+    const kv = new InMemoryKV();
+    const token = 'auto-amb-tok';
+    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
+    await seedHappySeries(kv, token);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([
+        { destination: 'A', arrivalSeconds: 60, trainCode: 'X1', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+        { destination: 'B', arrivalSeconds: 90, trainCode: 'X2', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+      ]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'amb-1',
+    });
+
+    expect(stats.autoLockSuccess).toBe(0);
+    expect(stats.boardingPromptFired).toBe(1);
+
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(stored.boardingLock).toBeUndefined();
+    expect(stored.boardingPromptState?.fired).toBe(true);
+  });
+
+  // arrivals 비어있어도 9단 통과(arrivals API와 promptGeoContext는 독립) → auto-lock skip → fallback.
+  it('arrivals 비어있음 → auto-lock 실패 → boarding-prompt push 발사', async () => {
+    const kv = new InMemoryKV();
+    const token = 'auto-empty-tok';
+    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
+    await seedHappySeries(kv, token);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'empty-1',
+    });
+
+    expect(stats.autoLockSuccess).toBe(0);
+    expect(stats.boardingPromptFired).toBe(1);
+  });
+
+  // 9단 게이트 차단 → auto-lock 자체에 진입하지 않음.
+  it('게이트 차단(window-too-small) → auto-lock 미시도', async () => {
+    const kv = new InMemoryKV();
+    const token = 'auto-gate-block';
+    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
+    // series 미시드 → window-too-small로 게이트 차단
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([
+        { destination: 'A', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+      ]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'gate-1',
+    });
+
+    expect(stats.autoLockSuccess).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+  });
+
+  // 이미 fired 상태(같은 trip 재호출)면 게이트 #9가 차단하므로 auto-lock 미시도.
+  it('boardingPromptState.fired=true → 게이트 #9 차단으로 auto-lock 미시도', async () => {
+    const kv = new InMemoryKV();
+    const token = 'auto-fired';
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makePromptTrip({
+        token,
+        boardingPromptState: { fired: true, lastFiredAt: NOW - 1000 },
+      }),
+    );
+    await seedHappySeries(kv, token);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([
+        { destination: 'A', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+      ]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'fired-1',
+    });
+
+    expect(stats.autoLockSuccess).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+  });
+
+  // 다음 cycle에서 client가 다른 lock을 등록하면 #864/#704 분기로 자연 교체된다.
+  // (본 PR에서는 그 분기 자체는 변경하지 않으므로 회귀 보존만 확인)
+  it('auto-lock 성공한 trip에 client가 다른 trainCode lock POST → 새 lock으로 교체', async () => {
+    const kv = new InMemoryKV();
+    const token = 'auto-swap';
+    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
+    await seedHappySeries(kv, token);
+    const fetchImpl1 = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    // 1st cycle: auto-lock 부착
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([
+        { destination: '선릉', arrivalSeconds: 60, trainCode: 'AUTO-X', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+      ]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl: fetchImpl1,
+      generatePushId: () => 'auto-x',
+    });
+    const afterAuto = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(afterAuto.boardingLock?.trainCode).toBe('AUTO-X');
+
+    // client가 다른 trainCode로 새 lock 등록 — putTrip으로 직접 시뮬레이션.
+    const userChosen = {
+      ...afterAuto,
+      boardingLock: {
+        ...afterAuto.boardingLock!,
+        trainCode: 'USER-Y',
+      },
+    };
+    await putTrip(kv as unknown as KVNamespace, userChosen);
+
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(stored.boardingLock?.trainCode).toBe('USER-Y');
+  });
+});

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -1,0 +1,101 @@
+/**
+ * #916 — trip-bound trainCode auto-lock (A1).
+ *
+ * lockMissing trip에서 9단 게이트(`boardingPrompt.ts`)가 통과한 시점에 backend가
+ * Seoul arrivals의 `pickAutoTrainCode`(arvlCd 우선순위)로 trainCode를 자동 결정해
+ * `BoardingLock`을 합성한다. 사용자가 "탑승" 액션을 직접 탭하지 않아도 cron이 매역 추적을
+ * 시작할 수 있게 한다.
+ *
+ * Confidence threshold:
+ *  - 9단 AND 게이트 (#819 ADR Section 2) — 9개의 독립 조건 곱으로 발사 임계 자체가 매우 높다.
+ *    (정확도, 방향 cosine, fused speed, motion 등 모두 통과 시점에만 호출된다)
+ *  - arvlCd 우선순위 (#819 ADR Section 1.2)의 ambiguity 해소 — 같은 우선순위 후보 2개 이상이면
+ *    `pickAutoTrainCode`가 null을 반환해 자동 lock을 자연 차단한다 → 다음 cycle에 narrow.
+ *
+ * 두 임계가 곱(AND)이라 단일 magic number 대신 "통과한 게이트의 곱"이 threshold다.
+ * 본 모듈은 두 신호 양쪽이 모두 만족할 때만 lock 합성을 시도한다.
+ *
+ * 거짓 양성 차단: 사용자가 자동 lock 직후 다른 trainCode를 탭하면 client가 새 lock POST →
+ * 기존 #864/#704 same-session 분기가 새 lock으로 자연 교체 (Seam F swap과 동일 경로).
+ */
+
+import { pickAutoTrainCode } from './boardingPrompt';
+import { subwayIdForLine } from './lineAlias';
+import { buildLegSegmentStations, SWAP_LOCK_TTL_MS } from './lockSwap';
+import type { SeoulArrivalClient } from './seoul';
+import type { BoardingLockMeta, Trip, Waypoint } from './types';
+
+/**
+ * 자동 lock의 TTL. lockSwap의 `SWAP_LOCK_TTL_MS`와 동일 30분 — 두 흐름 모두 "사용자 명시
+ * 입력 없이 backend가 lock을 합성"한 케이스라 같은 마진이 적절.
+ *
+ * 본 모듈에서 별도 상수를 두지 않고 `lockSwap.SWAP_LOCK_TTL_MS`를 그대로 재사용한다 — 한쪽 정책
+ * 변경 시 두 흐름이 동시에 따라가야 한다.
+ */
+export const AUTO_LOCK_TTL_MS = SWAP_LOCK_TTL_MS;
+
+export interface AttemptAutoLockInputs {
+  trip: Trip;
+  /** 다음 추적 대상 waypoint — arrivals 폴링 대상 (현재 leg 첫 waypoint). */
+  targetWaypoint: Waypoint;
+  /**
+   * 사용자 boarding 출발역 표시명. `BoardingLockMeta.segmentStations` 첫 원소로 prepend된다
+   * (#902 swap path와 달리 사용자가 origin에 머무는 시점이라 origin도 segment에 포함되어야
+   * positions-fallback이 origin 인덱스를 찾을 수 있다).
+   */
+  originStation: string;
+  /**
+   * 진행 방향. `promptGeoContext.direction` 그대로 — null이면 양방향 허용
+   * (`pickAutoTrainCode` 내부에서 stationName 필터가 implicit 방향 해소).
+   */
+  direction: 'up' | 'down' | null;
+  seoul: SeoulArrivalClient;
+  now: number;
+}
+
+/**
+ * lockMissing trip에 대해 trainCode 자동 결정 시도.
+ *
+ * 성공 (return non-null):
+ *  - subwayId 매핑 성공
+ *  - segmentStations 비어있지 않음 (origin + 같은 line 유지 구간)
+ *  - arrivals 비어있지 않음
+ *  - `pickAutoTrainCode`가 단일 후보로 수렴 (ambiguity 없음)
+ *
+ * 실패 (return null):
+ *  - 위 중 하나라도 실패 → caller가 기존 boarding-prompt push fallback 진행
+ *
+ * 본 함수는 KV I/O를 하지 않는다 (순수 pipeline). caller가 결과를 trip에 stamp + putTrip.
+ */
+export async function attemptAutoLock(
+  inputs: AttemptAutoLockInputs,
+): Promise<BoardingLockMeta | null> {
+  const { trip, targetWaypoint, originStation, direction, seoul, now } = inputs;
+  const line = targetWaypoint.line;
+  const subwayId = subwayIdForLine(line);
+  if (!subwayId) return null;
+
+  const legStations = buildLegSegmentStations(trip.waypoints, line);
+  if (legStations.length === 0) return null;
+  // origin은 leg의 시작점 — positions fallback이 train.stationName === origin인 케이스를
+  // segmentStations.indexOf로 찾을 수 있도록 prepend. legStations 첫 원소(=waypoints[0])와
+  // 중복되지 않게 dedup 한다 (이론상 origin과 waypoints[0]는 서로 다른 역이어야 하지만 방어).
+  const segmentStations = legStations[0] === originStation
+    ? legStations
+    : [originStation, ...legStations];
+
+  const arrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
+  if (arrivals.length === 0) return null;
+
+  const trainCode = pickAutoTrainCode(arrivals, line, direction);
+  if (!trainCode) return null;
+
+  return {
+    trainCode,
+    line,
+    subwayId,
+    selectedDepartureTime: now,
+    segmentStations,
+    expiresAt: now + AUTO_LOCK_TTL_MS,
+  };
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -371,10 +371,13 @@ app.post('/metrics/boarding-prompt', async (c) => {
  *
  * Body: { token, observedStationName, observedAtMs, accuracy, subsurface? }
  * Response 200:
- *   { ok, advanced, currentWaypoint, nextStation }
+ *   { ok, advanced, currentWaypoint, nextStation, autoLockCandidate }
  *   - advanced: 이번 sync로 waypoints가 shift됐는지 (1+ hop)
  *   - currentWaypoint: 정정 후 first waypoint stationName (없으면 null — destination 도착)
  *   - nextStation: 정정 후 first waypoint = 다음 알람 대상 (currentWaypoint와 동일, 의미상 alias)
+ *   - autoLockCandidate (#916 A1): cron이 자동 lock을 부착했을 때 그 lock 메타.
+ *     클라는 이 값을 보고 사용자가 직접 탭하지 않아도 boardingLock state를 hydrate 가능.
+ *     없으면 null. 후속 PR에서 클라이언트가 이 필드를 처리한다.
  * Response 404: { error: 'trip_not_found' } — 클라는 다음 fix에서 자연 retry
  *
  * Trip 부재 시 lock 재생성 책임은 본 endpoint가 지지 않음 — 클라가 useApnsTripRegistration으로
@@ -431,6 +434,16 @@ app.post('/boarding-lock/sync', async (c) => {
     advanced: advance.shiftedCount > 0,
     currentWaypoint: head ? head.stationName : null,
     nextStation: head ? head.stationName : null,
+    // #916 A1 — cron auto-lock(또는 사용자 명시 lock)이 trip에 부착돼 있으면 그 메타를
+    // candidate로 노출. client가 이 값으로 boardingLock UI/state를 hydrate한다.
+    // segmentStations/expiresAt 등 내부 필드는 client가 트래킹할 필요가 없어 공개 표면 최소화.
+    autoLockCandidate: working.boardingLock
+      ? {
+          trainCode: working.boardingLock.trainCode,
+          line: working.boardingLock.line,
+          subwayId: working.boardingLock.subwayId,
+        }
+      : null,
   });
 });
 

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -62,6 +62,20 @@
       "format": "histogram",
       "display": "numeric",
       "description": "E2 Kalman predict vs observe 차이"
+    },
+    {
+      "key": "autoLockSuccess",
+      "constantName": "AUTO_LOCK_SUCCESS",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#916 A1 — 9단 게이트 통과 후 backend가 trainCode를 자동 결정해 lock 부착에 성공한 비율"
+    },
+    {
+      "key": "autoLockFalsePositive",
+      "constantName": "AUTO_LOCK_FALSE_POSITIVE",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#916 A1 — 자동 lock 후 사용자가 다른 trainCode로 swap한 비율 (catalog placeholder, 후속 PR에서 client swap 신호 wire)"
     }
   ]
 }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -12,6 +12,7 @@ import {
   type SendPushResult,
 } from './apns';
 import { flipApnsEnv, pickApnsHost } from './apnsHost';
+import { attemptAutoLock } from './autoLock';
 import {
   evaluateBoardingPromptGates,
   markPromptFired,
@@ -211,6 +212,18 @@ export interface ScheduledStats extends LiveActivityStats {
    * 누적이 의미있게 커지면 Kalman 튜닝(R/Q) 재측정 또는 reset 정책 조정 신호.
    */
   kalmanDriftWarning: number;
+  /**
+   * #916 A1 — 9단 게이트 통과 후 backend가 `attemptAutoLock`으로 trainCode를 자동 합성해
+   * `trip.boardingLock`을 부착한 누적 횟수. 사용자가 "탑승" 액션을 직접 탭하지 않아도 cron이
+   * 매역 추적을 시작한 케이스 수 = 다운로드 가치 직결 신호.
+   */
+  autoLockSuccess: number;
+  /**
+   * #916 A1 — 자동 lock 후 사용자가 다른 trainCode로 swap한 케이스의 placeholder
+   * (false positive 측정 인프라). 본 PR에서는 catalog 등록 + stat 필드 placeholder만 — 실제
+   * client swap 신호 처리는 후속 PR (#916 A2)에서 wire한다. 현재는 항상 0.
+   */
+  autoLockFalsePositive: number;
 }
 
 /**
@@ -259,6 +272,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     phaseImminentBlocked: 0,
     kalmanReset: 0,
     kalmanDriftWarning: 0,
+    autoLockSuccess: 0,
+    autoLockFalsePositive: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -1214,6 +1229,38 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     });
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
+  }
+
+  // #916 A1 — 9단 게이트 통과 시점에 backend가 직접 trainCode를 결정 가능한지 시도.
+  // 성공하면 사용자에게 "탑승했냐?" 푸시 없이 lock을 자동 부착하고 cron이 매역 추적을 시작.
+  // 실패(arrivals 없음/ambiguity/subwayId 매핑 누락 등) → 기존 boarding-prompt push fallback.
+  // 거짓 양성 방어: 사용자가 다른 trainCode를 탭하면 client가 새 lock POST → #864/#704 분기로
+  // 자연 교체. boardingPromptState도 함께 fired stamp해 같은 cycle에서 prompt 발사를 차단.
+  const targetWaypoint = pickActiveWaypoint(trip);
+  if (targetWaypoint) {
+    const autoLock = await attemptAutoLock({
+      trip,
+      targetWaypoint,
+      originStation: display.originStation,
+      direction: geo.direction,
+      seoul: deps.seoul,
+      now,
+    });
+    if (autoLock) {
+      trip.boardingLock = autoLock;
+      trip.boardingPromptState = markPromptFired(now);
+      trip.consecutiveEtaMissing = 0;
+      stats.autoLockSuccess += 1;
+      log('boarding-prompt: auto-lock attached', {
+        token: trip.token.slice(0, 8),
+        trainCode: autoLock.trainCode,
+        line: autoLock.line,
+        originStation: display.originStation,
+        fusedSpeedKmh: Math.round(outcome.fusedSpeedKmh * 10) / 10,
+      });
+      await putTrip(env.TRIPS, trip);
+      return;
+    }
   }
 
   // 9단 통과 — alert push 발사.


### PR DESCRIPTION
## Summary
Epic #912 P1 A1 첫 슬라이스. lockMissing trip에서 9단 게이트(#819) 통과 시점에 backend가 `pickAutoTrainCode`(arvlCd 우선순위)로 trainCode를 자동 결정해 `boardingLock`을 합성한다. 사용자가 "탑승" 액션을 직접 탭하지 않아도 cron이 매역 추적 시작.

- `backend/alarm-worker/src/autoLock.ts`: `attemptAutoLock` 순수 pipeline — subwayId/segmentStations/arrivals/pickAutoTrainCode 모두 통과 시만 성공
- `backend/alarm-worker/src/scheduled.ts`: `evaluateAndMaybeFireBoardingPrompt`가 boarding-prompt push 발사 전 auto-lock 시도, 성공 시 prompt 차단
- `backend/alarm-worker/src/index.ts`: `/boarding-lock/sync` 응답에 `autoLockCandidate` 필드 (client hydrate용)
- `backend/alarm-worker/src/metrics.catalog.json`: `autoLockSuccess` / `autoLockFalsePositive` 메트릭 등록
- `AUTO_LOCK_TTL_MS = SWAP_LOCK_TTL_MS` (30분) 재사용 — 두 server-set lock 정책 동시 변경 보장

## Confidence threshold
별도 magic number 없음. 두 신호의 곱(AND)이 threshold:
1. **9단 AND 게이트** (`boardingPrompt.ts`) — 9개 독립 조건 (정확도/방향 cosine/fused speed/motion 등)
2. **arvlCd 우선순위 ambiguity 해소** — 같은 우선순위 후보 2개 이상이면 `pickAutoTrainCode` null → 자동 lock 차단, 다음 cycle narrow

## 슬라이싱 의도 (Refs #916)
**본 PR 제외, 후속 PR / 후속 이슈 예정**:
- 클라이언트 `boardingLockSync.ts`에서 `autoLockCandidate` 응답 처리 + UI hydrate
- `autoLockFalsePositive` 실측 (현재는 placeholder, 항상 0) — client swap signal 처리

## ⚠️ 알려진 한계 (follow-up 이슈 분리 권장)
self code-review에서 발견된 architectural follow-up:

1. **POST /trips 재등록 시 server-set lock 드롭 가능** (`index.ts:103-134`): 사용자 destination 변경/FG 재등록 시 incoming.boardingLock 없으면 baseTrip이 existing.boardingLock을 보존하지 않음. auto-lock 직후 클라가 응답 받기 전 같은 세션 재등록하면 lock이 사라짐. 사전부터 있던 semantics이지만 auto-lock에서 더 잘 노출됨. → `autoLockedAt` 마커 필드 + baseTrip 보존 로직 별도 PR
2. **auto-lock + boardingPromptState.fired=true** (`scheduled.ts:1246-1247`): auto-lock이 틀려 사용자가 클리어해도 prompt 재발사 차단됨. → fired 게이트에 "사용자 명시 클리어" 분기 별도 PR

본 PR은 attempt 코어가 작동하는 경우(같은 cycle 내) recall을 측정할 수 있는 인프라 추가. 위 한계는 다음 세션에서 별도 PR로 처리.

## Test plan
- [x] `npm run type-check` 통과
- [x] backend `npm test` 통과 (23 files, 776 tests)
- [x] client `npm test` 통과 (203 files, 3660 tests, 100% coverage)
- [x] code-review agent → P1급 한계 2건은 architectural follow-up으로 분리 명시

Refs #912
Refs #916