### PR TITLE
feat(#920): 기압계 절대값 기반 역 narrow + useStationCandidates 통합 (F3 첫 PR)

### DIFF
--- a/src/data/stationAbsolutePressure.json
+++ b/src/data/stationAbsolutePressure.json
@@ -1,0 +1,122 @@
+[
+  {
+    "stationId": "1-031",
+    "stationName": "종로3가",
+    "line": "1",
+    "depth_m": 14
+  },
+  {
+    "stationId": "3-021",
+    "stationName": "종로3가",
+    "line": "3",
+    "depth_m": 22
+  },
+  {
+    "stationId": "5-025",
+    "stationName": "종로3가",
+    "line": "5",
+    "depth_m": 35
+  },
+  {
+    "stationId": "1-033",
+    "stationName": "시청",
+    "line": "1",
+    "depth_m": 12
+  },
+  {
+    "stationId": "2-001",
+    "stationName": "시청",
+    "line": "2",
+    "depth_m": 18
+  },
+  {
+    "stationId": "5-024",
+    "stationName": "광화문",
+    "line": "5",
+    "depth_m": 32
+  },
+  {
+    "stationId": "2-016",
+    "stationName": "잠실",
+    "line": "2",
+    "depth_m": 16
+  },
+  {
+    "stationId": "8-005",
+    "stationName": "잠실",
+    "line": "8",
+    "depth_m": 28
+  },
+  {
+    "stationId": "2-022",
+    "stationName": "강남",
+    "line": "2",
+    "depth_m": 20
+  },
+  {
+    "stationId": "sinbundang-013",
+    "stationName": "강남",
+    "line": "sinbundang",
+    "depth_m": 45
+  },
+  {
+    "stationId": "5-031",
+    "stationName": "왕십리",
+    "line": "5",
+    "depth_m": 27
+  },
+  {
+    "stationId": "2-008",
+    "stationName": "왕십리",
+    "line": "2",
+    "depth_m": 8
+  },
+  {
+    "stationId": "6-021",
+    "stationName": "이태원",
+    "line": "6",
+    "depth_m": 26
+  },
+  {
+    "stationId": "5-017",
+    "stationName": "여의도",
+    "line": "5",
+    "depth_m": 22
+  },
+  {
+    "stationId": "9-015",
+    "stationName": "여의도",
+    "line": "9",
+    "depth_m": 17
+  },
+  {
+    "stationId": "3-041",
+    "stationName": "수서",
+    "line": "3",
+    "depth_m": 14
+  },
+  {
+    "stationId": "2-020",
+    "stationName": "선릉",
+    "line": "2",
+    "depth_m": 18
+  },
+  {
+    "stationId": "2-019",
+    "stationName": "삼성",
+    "line": "2",
+    "depth_m": 21
+  },
+  {
+    "stationId": "1-042",
+    "stationName": "구로",
+    "line": "1",
+    "depth_m": 0
+  },
+  {
+    "stationId": "4-003",
+    "stationName": "노원",
+    "line": "4",
+    "depth_m": 0
+  }
+]

--- a/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-native';
 import { useStationCandidates } from '../useStationCandidates';
 import type { Station } from '../../../../shared/types/station';
+import { DEPTH_TO_PRESSURE_HPA_PER_M } from '../../../../shared/constants/barometer';
 
 const YONGMASAN: Station = {
   id: '7-015',
@@ -134,5 +135,101 @@ describe('useStationCandidates', () => {
     const first = result.current;
     rerender(props);
     expect(result.current).toBe(first);
+  });
+
+  describe('F3 기압계 절대값 narrow (#920)', () => {
+    // 잠실: GPS top-N(이름 dedup) → [잠실, 잠실나루] 같은 deduped 후보 목록.
+    // 잠실 line 2 depth_m=16. 잠실나루는 압력 데이터 없음(narrow 시 자동 탈락).
+    const JAMSIL_LOC = { lat: 37.513262, lng: 127.100159 };
+    const SURFACE = 1013;
+    const PRESSURE_AT_16M = SURFACE + 16 * DEPTH_TO_PRESSURE_HPA_PER_M;
+    const PRESSURE_FAR_OFF = 950; // 어떤 entry도 매칭 안 됨.
+
+    it('absolutePressure 없으면 GPS 후보 그대로 (narrow skip)', () => {
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: JAMSIL_LOC,
+          wifiStation: null,
+          absolutePressureHpa: null,
+          surfacePressureHpa: SURFACE,
+        }),
+      );
+      const names = result.current.candidates.map((s) => s.name);
+      expect(names).toContain('잠실');
+      expect(names).toContain('잠실나루');
+    });
+
+    it('surfacePressure 없으면 narrow skip → GPS 후보 그대로', () => {
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: JAMSIL_LOC,
+          wifiStation: null,
+          absolutePressureHpa: PRESSURE_AT_16M,
+          surfacePressureHpa: null,
+        }),
+      );
+      const names = result.current.candidates.map((s) => s.name);
+      expect(names).toContain('잠실');
+      expect(names).toContain('잠실나루');
+    });
+
+    it('압력값 모두 주면 narrow 적용 → 데이터 있는 역만 살아남음', () => {
+      // 잠실(line2 depth 16m)은 매칭, 잠실나루(데이터 없음)는 탈락.
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: JAMSIL_LOC,
+          wifiStation: null,
+          absolutePressureHpa: PRESSURE_AT_16M,
+          surfacePressureHpa: SURFACE,
+        }),
+      );
+      const names = result.current.candidates.map((s) => s.name);
+      expect(names).toContain('잠실');
+      expect(names).not.toContain('잠실나루');
+    });
+
+    it('narrow 결과 0개면 GPS 후보로 fallback (안전망)', () => {
+      // 950 hPa는 어떤 entry도 매칭 안 됨 → GPS 후보 그대로 유지.
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: JAMSIL_LOC,
+          wifiStation: null,
+          absolutePressureHpa: PRESSURE_FAR_OFF,
+          surfacePressureHpa: SURFACE,
+        }),
+      );
+      const names = result.current.candidates.map((s) => s.name);
+      expect(names).toContain('잠실');
+    });
+
+    it('narrow 후 단일 후보 → isAutoConfirmed=true', () => {
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: JAMSIL_LOC,
+          wifiStation: null,
+          absolutePressureHpa: PRESSURE_AT_16M,
+          surfacePressureHpa: SURFACE,
+        }),
+      );
+      // narrow 후보가 1개로 좁혀지면 자동 확정 신호.
+      if (result.current.candidates.length === 1) {
+        expect(result.current.isAutoConfirmed).toBe(true);
+      }
+      expect(result.current.topPick?.name).toBe('잠실');
+    });
+
+    it('wifi가 있으면 F3 입력이 와도 wifi 우선', () => {
+      const fakeWifi: Station = { ...YONGMASAN, id: 'wifi-pick', name: 'WifiPick' };
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: JAMSIL_LOC,
+          wifiStation: fakeWifi,
+          absolutePressureHpa: PRESSURE_AT_16M,
+          surfacePressureHpa: SURFACE,
+        }),
+      );
+      expect(result.current.topPick).toBe(fakeWifi);
+      expect(result.current.candidates).toEqual([fakeWifi]);
+    });
   });
 });

--- a/src/features/nearest-station/hooks/useStationCandidates.ts
+++ b/src/features/nearest-station/hooks/useStationCandidates.ts
@@ -3,17 +3,20 @@
  *
  * 자동 추정으로 현재역을 단정할 수 없을 때 1탭 모달에 뿌릴 후보 목록을 메모이즈한다.
  * - wifi SSID(F2) 매칭 결과가 있으면 그 역을 topPick으로 두고 후보 1개 + 자동 확정 신호.
+ * - F2 실패 시 F3 기압계 절대값(#920)으로 GPS 후보를 narrow.
  * - 그 외엔 GPS 기반 `findTopNearestStations`로 거리순 상위 N개를 반환.
  *
  * 본 hook은 부수 효과 없는 순수 계산 layer. 모달 표시/검색 fallback 트리거는 호출자가 결정한다.
  *
  * 후속 PR:
  *  - HomeScreen wire(cold start + locationUncertain 길어질 때 표시)
- *  - F3 기압계(#920) 신호를 입력에 추가해 지하 진입 시 후보 가중치 보정
+ *  - F3 surfacePressure baseline 수집 (현재는 호출자가 주입)
+ *  - 환승역 노선/방향 결합 narrow
  */
 import { useMemo } from 'react';
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
+import { narrowStationsByPressure } from '../../../shared/utils/barometerState';
 import type { Station } from '../../../shared/types/station';
 
 export const DEFAULT_MAX_CANDIDATES = 3;
@@ -23,6 +26,10 @@ export interface UseStationCandidatesInputs {
   readonly userLocation: { readonly lat: number; readonly lng: number } | null;
   /** F2 wifi SSID 매칭 결과 (`lookupStationBySsid`). 있으면 최우선. */
   readonly wifiStation: Station | null;
+  /** F3 기압계 절대 측정값(hPa). null이면 narrow skip. */
+  readonly absolutePressureHpa?: number | null;
+  /** 같은 지역 지상 기준 압력(hPa). absolutePressureHpa와 함께 주어져야 narrow 활성. */
+  readonly surfacePressureHpa?: number | null;
   /** 후보 최대 개수. 기본 3. */
   readonly maxCandidates?: number;
   /** GPS 후보 추출 시 반경(km). 기본 `MAX_STATION_DISTANCE_KM`(1.0). */
@@ -50,6 +57,8 @@ export function useStationCandidates(
   const {
     userLocation,
     wifiStation,
+    absolutePressureHpa = null,
+    surfacePressureHpa = null,
     maxCandidates = DEFAULT_MAX_CANDIDATES,
     maxDistanceKm = MAX_STATION_DISTANCE_KM,
   } = inputs;
@@ -74,11 +83,31 @@ export function useStationCandidates(
     );
     if (ranked.length === 0) return EMPTY;
 
-    const candidates = ranked.map((r) => r.station);
+    const gpsCandidates = ranked.map((r) => r.station);
+
+    // F3 — 기압계 절대값으로 GPS 후보를 narrow. 압력값 모두 주어지고 narrow 결과가
+    // 비지 않을 때만 적용. 0개로 좁아지면 F3 신호를 무시(GPS 후보 그대로 사용).
+    let candidates = gpsCandidates;
+    if (absolutePressureHpa !== null && surfacePressureHpa !== null) {
+      const narrowed = narrowStationsByPressure(
+        absolutePressureHpa,
+        surfacePressureHpa,
+        gpsCandidates,
+      );
+      if (narrowed.length > 0) candidates = narrowed;
+    }
+
     return {
       candidates,
       topPick: candidates[0],
       isAutoConfirmed: candidates.length === 1,
     };
-  }, [userLocation, wifiStation, maxCandidates, maxDistanceKm]);
+  }, [
+    userLocation,
+    wifiStation,
+    absolutePressureHpa,
+    surfacePressureHpa,
+    maxCandidates,
+    maxDistanceKm,
+  ]);
 }

--- a/src/shared/constants/barometer.ts
+++ b/src/shared/constants/barometer.ts
@@ -50,6 +50,32 @@ export const BAROMETER_RING_BUFFER_TTL_MS = 60_000;
 export const BAROMETER_SAMPLE_INTERVAL_MS = 1_000;
 
 /**
+ * #920 — 깊이(m) → 압력 변화(hPa) 환산 상수.
+ *
+ * 단위: hPa / m.
+ *
+ * 표준 대기 모델(ISA, 해수면 부근)에서 고도 1m 하강 시 약 0.12 hPa 상승한다.
+ * `avgPressure_hPa = surfacePressure + (depth_m × DEPTH_TO_PRESSURE_HPA_PER_M)`.
+ *
+ * 데이터 파일에 absolute pressure가 명시되지 않은 역은 이 상수로 추정한다
+ * (CLAUDE.md §3 데이터 주도 — 새 역 추가 시 코드 수정 없이 깊이만 채우면 됨).
+ */
+export const DEPTH_TO_PRESSURE_HPA_PER_M = 0.12;
+
+/**
+ * #920 — F3 절대값 narrow에 사용하는 압력 일치 tolerance.
+ *
+ * 단위: hPa.
+ *
+ * 근거:
+ *   - 일별 기압 변동(고/저기압) ±5 hPa 수준 → 단일 기준치로는 매칭 불가.
+ *     본 PR에서는 surfacePressure를 외부에서 주입받는 형태로 일반화하여 변동을 흡수.
+ *   - 센서 정밀도 ≈ 0.1 hPa, 깊이 ±5m(약 0.6 hPa) 오차 고려해 1.0 hPa 허용.
+ *   - 깊이 차이 약 8m 이내 역은 후보로 같이 잡힘 → ±2역 narrow 목표에 부합.
+ */
+export const BAROMETER_ABS_TOLERANCE_HPA = 1.0;
+
+/**
  * #903 — subsurface verdict의 hysteresis 확인 샘플 수.
  *
  * 임계(0.3hPa) 부근에서 센서 noise로 verdict가 1Hz 토글되면 useBarometer가 setSubsurface을

--- a/src/shared/utils/__tests__/barometerState.test.ts
+++ b/src/shared/utils/__tests__/barometerState.test.ts
@@ -2,13 +2,16 @@ import {
   appendBarometerReading,
   evaluateLatestSubsurface,
   getBarometerReadings,
+  narrowStationsByPressure,
   resetBarometerState,
 } from '../barometerState';
 import {
   BAROMETER_DPDT_WINDOW_MS,
   BAROMETER_RING_BUFFER_TTL_MS,
   BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+  DEPTH_TO_PRESSURE_HPA_PER_M,
 } from '../../constants/barometer';
+import type { Station } from '../../types/station';
 
 const NOW = 1_700_000_000_000;
 
@@ -58,5 +61,118 @@ describe('barometerState (#875)', () => {
     expect(getBarometerReadings()).toHaveLength(1);
     resetBarometerState();
     expect(getBarometerReadings()).toEqual([]);
+  });
+});
+
+describe('narrowStationsByPressure (#920)', () => {
+  // stationAbsolutePressure.json 실재 entry — 종로3가 1호선 depth_m=14.
+  const JONGNO3GA_LINE1: Station = {
+    id: '1-031',
+    name: '종로3가',
+    line: '1',
+    lineColor: '#0052A4',
+    lat: 37.571607,
+    lng: 126.991806,
+  };
+  const JONGNO3GA_LINE5: Station = {
+    id: '5-025',
+    name: '종로3가',
+    line: '5',
+    lineColor: '#996CAC',
+    lat: 37.571607,
+    lng: 126.991806,
+  };
+  const GURO_SURFACE: Station = {
+    id: '1-042',
+    name: '구로',
+    line: '1',
+    lineColor: '#0052A4',
+    lat: 37.5,
+    lng: 126.88,
+  };
+  const NOT_IN_DATA: Station = {
+    id: 'unknown-999',
+    name: '없는역',
+    line: '1',
+    lineColor: '#0052A4',
+    lat: 0,
+    lng: 0,
+  };
+
+  const SURFACE = 1013;
+  const PRESSURE_AT_14M = SURFACE + 14 * DEPTH_TO_PRESSURE_HPA_PER_M; // 1014.68
+  const PRESSURE_AT_35M = SURFACE + 35 * DEPTH_TO_PRESSURE_HPA_PER_M; // 1017.2
+
+  it('candidates 비어있으면 빈 배열 반환', () => {
+    expect(narrowStationsByPressure(PRESSURE_AT_14M, SURFACE, [])).toEqual([]);
+  });
+
+  it('candidates 인자 생략 시 default [] → 빈 결과', () => {
+    expect(narrowStationsByPressure(PRESSURE_AT_14M, SURFACE)).toEqual([]);
+  });
+
+  it('얕은 깊이(14m) 압력이 14m 역만 매칭', () => {
+    const result = narrowStationsByPressure(PRESSURE_AT_14M, SURFACE, [
+      JONGNO3GA_LINE1,
+      JONGNO3GA_LINE5,
+    ]);
+    expect(result).toEqual([JONGNO3GA_LINE1]);
+  });
+
+  it('깊은 깊이(35m) 압력이 35m 역만 매칭', () => {
+    const result = narrowStationsByPressure(PRESSURE_AT_35M, SURFACE, [
+      JONGNO3GA_LINE1,
+      JONGNO3GA_LINE5,
+    ]);
+    expect(result).toEqual([JONGNO3GA_LINE5]);
+  });
+
+  it('지상 압력은 depth_m=0 역(구로) 매칭', () => {
+    const result = narrowStationsByPressure(SURFACE, SURFACE, [
+      GURO_SURFACE,
+      JONGNO3GA_LINE5,
+    ]);
+    expect(result).toEqual([GURO_SURFACE]);
+  });
+
+  it('데이터에 없는 stationId는 후보로 포함돼도 제외', () => {
+    const result = narrowStationsByPressure(PRESSURE_AT_14M, SURFACE, [
+      NOT_IN_DATA,
+      JONGNO3GA_LINE1,
+    ]);
+    expect(result).toEqual([JONGNO3GA_LINE1]);
+  });
+
+  it('tolerance 내(±1 hPa default)면 매칭', () => {
+    const result = narrowStationsByPressure(PRESSURE_AT_14M + 0.5, SURFACE, [
+      JONGNO3GA_LINE1,
+    ]);
+    expect(result).toEqual([JONGNO3GA_LINE1]);
+  });
+
+  it('tolerance 밖이면 매칭 없음', () => {
+    const result = narrowStationsByPressure(PRESSURE_AT_14M + 5, SURFACE, [
+      JONGNO3GA_LINE1,
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it('tolerance 명시 override 가능', () => {
+    const result = narrowStationsByPressure(
+      PRESSURE_AT_14M + 2,
+      SURFACE,
+      [JONGNO3GA_LINE1],
+      3,
+    );
+    expect(result).toEqual([JONGNO3GA_LINE1]);
+  });
+
+  it('surfacePressure 변동(저기압)에도 동일 depth 매칭 가능', () => {
+    const lowSurface = 1005;
+    const measured = lowSurface + 14 * DEPTH_TO_PRESSURE_HPA_PER_M;
+    const result = narrowStationsByPressure(measured, lowSurface, [
+      JONGNO3GA_LINE1,
+    ]);
+    expect(result).toEqual([JONGNO3GA_LINE1]);
   });
 });

--- a/src/shared/utils/barometerState.ts
+++ b/src/shared/utils/barometerState.ts
@@ -8,14 +8,43 @@
  * 정책:
  *   - 메모리 ring buffer만 (60s ≤ 60 entry @ 1Hz, 매우 가벼움).
  *   - hook unmount → reset. 영속화 필요 시 후속 sub-issue.
+ *
+ * #920 — 절대값 narrow 함수 추가.
+ *   - dP/dt(상대 변화)와 별개로, 깊이별 평균 절대 압력을 비교해 후보 역을 ±2역 narrow.
+ *   - F2(wifi) 매칭이 실패한 지하에서 fallback.
  */
 
+import {
+  BAROMETER_ABS_TOLERANCE_HPA,
+  DEPTH_TO_PRESSURE_HPA_PER_M,
+} from '../constants/barometer';
+import stationAbsolutePressureData from '../../data/stationAbsolutePressure.json';
+import type { LineNumber, Station } from '../types/station';
 import {
   evaluateSubsurfaceEnter,
   pruneStaleReadings,
   type BarometerReading,
   type SubsurfaceVerdict,
 } from './barometerSubsurface';
+
+/**
+ * 역별 절대 압력 entry. 지하 깊이(m) 기반 — 표준 대기 모델로 압력 환산.
+ *
+ * 실측 압력값을 직접 보관하지 않는 이유: 지역 기준 압력은 일별 ±5 hPa 변동.
+ * surfacePressure를 외부에서 주입받고 깊이만 비교하는 방식이 단순하고 안정적이다
+ * (CLAUDE.md §2 단순성). 후속 PR에서 실측 보정이 필요하면 그 때 필드 추가.
+ *
+ * CLAUDE.md §3 데이터 주도: 새 역 추가 시 코드 수정 없이 JSON 항목만 추가.
+ */
+export interface StationAbsolutePressureEntry {
+  readonly stationId: string;
+  readonly stationName: string;
+  readonly line: LineNumber;
+  readonly depth_m: number;
+}
+
+const ABS_PRESSURE_ENTRIES: readonly StationAbsolutePressureEntry[] =
+  stationAbsolutePressureData as readonly StationAbsolutePressureEntry[];
 
 let readings: BarometerReading[] = [];
 
@@ -47,4 +76,39 @@ export function evaluateLatestSubsurface(now: number): SubsurfaceVerdict | null 
  */
 export function resetBarometerState(): void {
   readings = [];
+}
+
+/**
+ * #920 — 절대 압력 측정값으로 후보 역을 narrow.
+ *
+ * @param measuredPressureHpa 단말 기압계 절대값 (hPa).
+ * @param surfacePressureHpa 같은 지역 지상 기준 압력 (hPa). 일별 기상 변동을 흡수하기 위해
+ *   호출자가 GPS + 날씨/지상 baseline에서 주입한다 (본 PR 외부 — 임시 1013 default 가능).
+ * @param candidates 사전 후보 역(예: GPS top-N). 빈 배열이면 빈 결과.
+ * @param toleranceHpa 일치 허용 폭. 기본 `BAROMETER_ABS_TOLERANCE_HPA`.
+ * @returns 추정 압력이 측정값과 tolerance 안인 후보 역의 부분집합.
+ *
+ * 정책:
+ *   - 후보 안에서만 필터 — F2 실패 시 GPS top-N narrow 용도.
+ *   - 환승역(같은 이름 다중 노선)도 깊이가 다르면 다른 entry → 자연스럽게 분리됨.
+ *   - 데이터에 없는 stationId는 자동 제외 (점진적 데이터 보강).
+ */
+export function narrowStationsByPressure(
+  measuredPressureHpa: number,
+  surfacePressureHpa: number,
+  candidates: readonly Station[] = [],
+  toleranceHpa: number = BAROMETER_ABS_TOLERANCE_HPA,
+): Station[] {
+  if (candidates.length === 0) return [];
+
+  const matchedIds = new Set<string>();
+  for (const entry of ABS_PRESSURE_ENTRIES) {
+    const expected =
+      surfacePressureHpa + entry.depth_m * DEPTH_TO_PRESSURE_HPA_PER_M;
+    if (Math.abs(measuredPressureHpa - expected) <= toleranceHpa) {
+      matchedIds.add(entry.stationId);
+    }
+  }
+
+  return candidates.filter((s) => matchedIds.has(s.id));
 }


### PR DESCRIPTION
## 요약 (Epic #912 F3 — 첫 슬라이스)

F2(wifi) 매칭이 실패하는 지하 환경에서, 기압계 절대값(역별 깊이 차이)으로 GPS 후보 역을 narrow하는 pure JS layer 추가. F4(#914) 모달에 더 좁아진 후보를 전달한다.

## 변경 사항

- `src/data/stationAbsolutePressure.json` — sample 20개 역 (종로3가 1/3/5호선, 잠실 2/8, 강남 2/sinbundang 등 환승역 포함). 깊이 m만 보관, 압력은 환산식으로.
- `src/shared/constants/barometer.ts` — `DEPTH_TO_PRESSURE_HPA_PER_M` (0.12 hPa/m, ISA), `BAROMETER_ABS_TOLERANCE_HPA` (1.0 hPa)
- `src/shared/utils/barometerState.ts` — `narrowStationsByPressure(measured, surface, candidates, tolerance)` 추가. `surfacePressure`를 외부 주입받아 일별 기상 변동(±5 hPa)을 흡수
- `src/features/nearest-station/hooks/useStationCandidates.ts` — F3 cascade 통합. **wifi 우선 → GPS top-N → 압력 narrow**. narrow 결과 0개면 GPS 후보 그대로 (안전망)
- 100% coverage / type-check / lint (변경 파일 한정) pass

## 정책 결정

- **실측 압력값 대신 깊이만 보관**: 지역 기준 압력은 일별 ±5 hPa 변동 → 실측치는 stale 가능. surfacePressure를 호출자가 주입하는 형태로 일반화 (CLAUDE.md §2 단순성)
- **환승역(같은 이름 다중 노선) 다중 반환**: F3 단일 신호만으로 노선/방향 결합은 후속 PR. 깊이가 명확히 다른 환승역(예: 종로3가 1호선 14m vs 5호선 35m)은 자연 분리됨
- **narrow 0개 → GPS fallback**: 압력 데이터 없는 지역(현재 528개 중 20개만 sample)에서 사용자가 길을 잃지 않도록 안전망 유지

## 후속 PR (Refs #920)

- F3 surfacePressure baseline 수집 (기상청 API or `useBarometer` 지상 reading 추적)
- 환승역 노선/방향 narrow 결합
- stationAbsolutePressure.json 실측 데이터 수집 자동화 (Maestro flow 또는 사용자 contribute)
- `useBarometer` 와의 wire (절대값 push → useStationCandidates 입력)

Refs #920