### PR TITLE
feat(#917): backend cron arvlCd 0/1 매역 알림 1차 source (A2)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -173,6 +173,28 @@ function parseArvlCdStationPassedData(call: [string, RequestInit]): {
   return body.data;
 }
 
+// arrivals 빈 응답 + positions에 lock.trainCode 매칭(중곡 ARRIVED) — positions-fallback 경로 테스트 공용.
+function makePositionsFallbackSeoul(): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async (url: string) => {
+      if (url.includes('/realtimePosition/')) {
+        return new Response(
+          JSON.stringify({
+            realtimePositionList: [
+              { trainNo: '7246', statnNm: '중곡', trainSttus: 1, updnLine: '상행', lastRecptnDt: '' },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
+    }) as unknown as typeof fetch,
+  });
+}
+
 // 7호선 용마산→중곡→군자 leg lockTrip 공용 (lock 추적/arvlCd fire 테스트 공통).
 // token만 describe별로 다르므로 token은 호출 시 명시.
 function makeLockTripFixture(token: string, overrides: Partial<Trip> = {}): Trip {
@@ -3360,25 +3382,12 @@ describe('estimateBoardingLockArrival arvlCd exposure (#917 A2)', () => {
 
   it('positions-fallback → arvlCd=null (sttus 신호는 매역 SSOT 아님)', async () => {
     // arrivals 빈 응답 + positions에 lock.trainCode 매칭 → fallback 경로 진입.
-    const seoul = new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async (url: string) => {
-        if (url.includes('/realtimePosition/')) {
-          return new Response(
-            JSON.stringify({
-              realtimePositionList: [
-                { trainNo: '7246', statnNm: '중곡', trainSttus: 1, updnLine: '상행', lastRecptnDt: '' },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
-      }) as unknown as typeof fetch,
-    });
-    const result = await estimateBoardingLockArrival(makeArrivalDeps(seoul), lock, waypoint, NOW);
+    const result = await estimateBoardingLockArrival(
+      makeArrivalDeps(makePositionsFallbackSeoul()),
+      lock,
+      waypoint,
+      NOW,
+    );
     // arrived=true (sttus=ARRIVED + station match)지만 arvlCd=null (positions 경로 명시)
     expect(result?.arvlCd).toBeNull();
     expect(result?.arrived).toBe(true);
@@ -3470,24 +3479,7 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     // 호출 흐름: estimate.arrived=true (positions 경로), estimate.arvlCd=null → fire 게이트 차단.
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeLockTrip());
-    const seoul = new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async (url: string) => {
-        if (url.includes('/realtimePosition/')) {
-          return new Response(
-            JSON.stringify({
-              realtimePositionList: [
-                { trainNo: '7246', statnNm: '중곡', trainSttus: 1, updnLine: '상행', lastRecptnDt: '' },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
-      }) as unknown as typeof fetch,
-    });
+    const seoul = makePositionsFallbackSeoul();
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
       seoul,

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4,10 +4,15 @@ import { resetApnsJwtCache, type ApnsConfig } from '../apns';
 import { DRIFT_WARNING_THRESHOLD_KMH, R_LOW, readKalmanState, type KalmanState } from '../kalmanFilter';
 import type { WindowedMetrics } from '../positionSeries';
 import {
+  ARVLCD_FIRE_DEDUP_TTL_SEC,
+  ARVLCD_FIRE_KEY_PREFIX,
   MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
   SUBSURFACE_ETA_MISSING_TOLERANCE,
+  arvlCdFireKey,
   estimateArrivalFromPosition,
+  estimateBoardingLockArrival,
+  evaluateArvlCdFireGate,
   flipApnsEnv,
   maybeCountDrift,
   pickActiveWaypoint,
@@ -20,7 +25,7 @@ import {
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
-import type { BoardingLockMeta, Env, Trip } from '../types';
+import type { BoardingLockMeta, Env, Trip, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
 let apnsConfig: ApnsConfig;
@@ -3116,5 +3121,536 @@ describe('runScheduled — #916 A1 auto-lock', () => {
 
     const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
     expect(stored.boardingLock?.trainCode).toBe('USER-Y');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #917 A2 — arvlCd∈{0,1} 매역 알림 1차 source. backend cron이 lock된 trainCode를
+// realtimeArrivalList에서 추적해 next waypoint에서 ARRIVED/ENTERING 첫 관찰 시
+// station-passed silent push를 발사. dedup KV로 같은 신호 중복 차단.
+// ---------------------------------------------------------------------------
+
+describe('arvlCdFireKey / ARVLCD_FIRE_KEY_PREFIX (#917 A2)', () => {
+  it('prefix는 arvlcd-fire:', () => {
+    expect(ARVLCD_FIRE_KEY_PREFIX).toBe('arvlcd-fire:');
+  });
+
+  it('key는 token|trainCode|station|arvlCd 조합 — arvlCd 0과 1을 별 entry로 분리', () => {
+    expect(arvlCdFireKey('tok1', '7246', '중곡', 0)).toBe('arvlcd-fire:tok1|7246|중곡|0');
+    expect(arvlCdFireKey('tok1', '7246', '중곡', 1)).toBe('arvlcd-fire:tok1|7246|중곡|1');
+    expect(arvlCdFireKey('tok1', '7246', '중곡', 0)).not.toBe(arvlCdFireKey('tok1', '7246', '중곡', 1));
+  });
+
+  it('token이 다르면 다른 key — 같은 train 다른 trip이 서로 silence하지 않음 (cross-trip leak 차단)', () => {
+    // 두 사용자가 같은 train(5025) 탄 채 같은 역(강남) 도착 시 각 trip별 dedup entry.
+    expect(arvlCdFireKey('tokA', '5025', '강남', 1)).not.toBe(arvlCdFireKey('tokB', '5025', '강남', 1));
+  });
+
+  it('dedup TTL은 1시간 (60s × 60)', () => {
+    expect(ARVLCD_FIRE_DEDUP_TTL_SEC).toBe(60 * 60);
+  });
+});
+
+describe('evaluateArvlCdFireGate (#917 A2 prereq guard)', () => {
+  const activeLock: BoardingLockMeta = {
+    trainCode: '7246',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: NOW,
+    segmentStations: ['용마산', '중곡'],
+    expiresAt: NOW + 60 * 60_000,
+  };
+
+  it('lock 활성 + arvlCd=1(ARRIVED) → fire', () => {
+    expect(evaluateArvlCdFireGate(activeLock, 1, NOW)).toBe('fire');
+  });
+
+  it('lock 활성 + arvlCd=0(ENTERING) → fire', () => {
+    expect(evaluateArvlCdFireGate(activeLock, 0, NOW)).toBe('fire');
+  });
+
+  it('#640 회귀 — lock undefined → mismatch (push X)', () => {
+    expect(evaluateArvlCdFireGate(undefined, 1, NOW)).toBe('mismatch');
+  });
+
+  it('#640 회귀 — lock 만료 → mismatch (push X)', () => {
+    const expired = { ...activeLock, expiresAt: NOW - 1 };
+    expect(evaluateArvlCdFireGate(expired, 1, NOW)).toBe('mismatch');
+  });
+
+  it('positions-fallback (arvlCd=null) → mismatch (push X)', () => {
+    expect(evaluateArvlCdFireGate(activeLock, null, NOW)).toBe('mismatch');
+  });
+
+  it('arvlCd=2(DEPARTED) 등 비-매역 신호 → mismatch', () => {
+    expect(evaluateArvlCdFireGate(activeLock, 2, NOW)).toBe('mismatch');
+    expect(evaluateArvlCdFireGate(activeLock, 4, NOW)).toBe('mismatch');
+    expect(evaluateArvlCdFireGate(activeLock, 5, NOW)).toBe('mismatch');
+    expect(evaluateArvlCdFireGate(activeLock, 99, NOW)).toBe('mismatch');
+  });
+});
+
+describe('estimateBoardingLockArrival arvlCd exposure (#917 A2)', () => {
+  const lock: BoardingLockMeta = {
+    trainCode: '7246',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: NOW,
+    segmentStations: ['용마산', '중곡', '군자'],
+    expiresAt: NOW + 60 * 60_000,
+  };
+  const waypoint: Waypoint = { stationName: '중곡', line: '7', kind: 'intermediate' };
+
+  function makeArrivalSeoul(arvlCd: number | null): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: '0',
+                recptnDt: '',
+                updnLine: '상행',
+                trainLineNm: '중곡',
+                btrainNo: '7246',
+                subwayNm: '지하철7호선',
+                arvlCd,
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+  }
+
+  function makeArrivalDeps(seoul: SeoulArrivalClient): ScheduledDeps {
+    return {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+    };
+  }
+
+  it('arrivals 매칭 시 arvlCd=1 노출 (arrived=true)', async () => {
+    const result = await estimateBoardingLockArrival(
+      makeArrivalDeps(makeArrivalSeoul(1)),
+      lock,
+      waypoint,
+      NOW,
+    );
+    expect(result).toEqual({ epoch: NOW, arrived: true, arvlCd: 1 });
+  });
+
+  it('arrivals 매칭 시 arvlCd=0 노출 (arrived=true)', async () => {
+    const result = await estimateBoardingLockArrival(
+      makeArrivalDeps(makeArrivalSeoul(0)),
+      lock,
+      waypoint,
+      NOW,
+    );
+    expect(result).toEqual({ epoch: NOW, arrived: true, arvlCd: 0 });
+  });
+
+  it('arrivals 매칭 + arvlCd=2(DEPARTED) → arrived=false + arvlCd=2 그대로 노출', async () => {
+    const result = await estimateBoardingLockArrival(
+      makeArrivalDeps(makeArrivalSeoul(2)),
+      lock,
+      waypoint,
+      NOW,
+    );
+    expect(result).toEqual({ epoch: NOW, arrived: false, arvlCd: 2 });
+  });
+
+  it('arrivals 매칭 + arvlCd=null → arrived=false + arvlCd=null', async () => {
+    const result = await estimateBoardingLockArrival(
+      makeArrivalDeps(makeArrivalSeoul(null)),
+      lock,
+      waypoint,
+      NOW,
+    );
+    expect(result).toEqual({ epoch: NOW, arrived: false, arvlCd: null });
+  });
+
+  it('positions-fallback → arvlCd=null (sttus 신호는 매역 SSOT 아님)', async () => {
+    // arrivals 빈 응답 + positions에 lock.trainCode 매칭 → fallback 경로 진입.
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes('/realtimePosition/')) {
+          return new Response(
+            JSON.stringify({
+              realtimePositionList: [
+                { trainNo: '7246', statnNm: '중곡', trainSttus: 1, updnLine: '상행', lastRecptnDt: '' },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    const result = await estimateBoardingLockArrival(makeArrivalDeps(seoul), lock, waypoint, NOW);
+    // arrived=true (sttus=ARRIVED + station match)지만 arvlCd=null (positions 경로 명시)
+    expect(result?.arvlCd).toBeNull();
+    expect(result?.arrived).toBe(true);
+  });
+});
+
+describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
+  function makeLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
+    return {
+      trainCode: '7246',
+      line: '7',
+      subwayId: '1007',
+      selectedDepartureTime: NOW,
+      segmentStations: ['용마산', '중곡', '군자'],
+      expiresAt: NOW + 60 * 60_000,
+      ...overrides,
+    };
+  }
+
+  function makeLockTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'arvl-tok',
+      route: { type: 'direct', line: '7', stops: 2 },
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '군자', line: '7', kind: 'destination' },
+      ],
+      boardingLock: makeLock(),
+      ...overrides,
+    });
+  }
+
+  /** arrivals + positions URL 분기 + lock.trainCode 매칭 응답 builder. */
+  function makeArrivalSeoul(
+    stationName: string,
+    seconds: number,
+    arvlCd: number | null,
+    trainCode = '7246',
+  ): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: String(seconds),
+                recptnDt: '',
+                updnLine: '상행',
+                trainLineNm: stationName,
+                btrainNo: trainCode,
+                subwayNm: '지하철7호선',
+                arvlCd,
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+  }
+
+  /** silent push (background, kind=intermediate/destination) 호출만 추출. */
+  function getStationPassedCalls(
+    fetchImpl: ReturnType<typeof vi.fn>,
+  ): [string, RequestInit][] {
+    return (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) => {
+      const headers = (c[1]?.headers ?? {}) as Record<string, string>;
+      if (headers['apns-push-type'] !== 'background') return false;
+      try {
+        const body = JSON.parse(c[1]?.body as string) as {
+          data?: { phase?: string; kind?: string };
+        };
+        // arvlCd fire는 phase=imminent + kind∈{intermediate, destination}.
+        // reschedule push(kind='reschedule')와 trip-ended push(kind='trip-ended')와 구분.
+        return (
+          body?.data?.phase === 'imminent' &&
+          (body?.data?.kind === 'intermediate' || body?.data?.kind === 'destination')
+        );
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  function parseStationPassedData(call: [string, RequestInit]): {
+    nextWaypoint: string;
+    etaSeconds: number;
+    phase: string;
+    kind: string;
+    pushId: string;
+    sentAt: number;
+  } {
+    const body = JSON.parse(call[1].body as string) as {
+      data: {
+        nextWaypoint: string;
+        etaSeconds: number;
+        phase: string;
+        kind: string;
+        pushId: string;
+        sentAt: number;
+      };
+    };
+    return body.data;
+  }
+
+  it('arvlCd=1(ARRIVED) → 매역 push 발사 + stats.arvlCdFireSuccess=1 + dedup KV stamp', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-1',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(stats.arvlCdFireDedup).toBe(0);
+    expect(stats.arvlCdFireMismatch).toBe(0);
+    expect(stats.pushed).toBe(1);
+    const calls = getStationPassedCalls(apnsFetch);
+    expect(calls).toHaveLength(1);
+    const data = parseStationPassedData(calls[0]);
+    expect(data.nextWaypoint).toBe('중곡');
+    expect(data.kind).toBe('intermediate');
+    expect(data.phase).toBe('imminent');
+    expect(data.etaSeconds).toBe(0);
+    expect(data.pushId).toBe('p-arvl-1');
+    expect(data.sentAt).toBe(NOW);
+    // dedup KV stamp 확인 (TTL은 InMemoryKV가 그대로 보관 — expiration 무시)
+    expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 1))).toBe('1');
+  });
+
+  it('arvlCd=0(ENTERING) → 매역 push 발사 (arvlCd=0 dedup key)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 0),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-0',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 0))).toBe('1');
+    // arvlCd=1 entry는 아직 stamp 없음 — 0과 1은 분리.
+    expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 1))).toBeNull();
+  });
+
+  it('dedup — 같은 (trainCode, station, arvlCd) 이미 stamp되어 있으면 push 미발사', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    // 이전 cycle에서 같은 신호로 이미 stamp된 상태
+    await kv.put(arvlCdFireKey('arvl-tok', '7246', '중곡', 1), '1');
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-dup',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(stats.arvlCdFireDedup).toBe(1);
+    // 매역 push 발사 없음 (waypoint advance LA push 등 다른 경로 push는 별개)
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
+  });
+
+  it('#640 회귀 가드 — positions-fallback arrived(arvlCd=null)은 매역 push 미발사 (mismatch++)', async () => {
+    // arrivals 빈 응답 + positions에 lock.trainCode가 target 역에 ARRIVED.
+    // 호출 흐름: estimate.arrived=true (positions 경로), estimate.arvlCd=null → fire 게이트 차단.
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes('/realtimePosition/')) {
+          return new Response(
+            JSON.stringify({
+              realtimePositionList: [
+                { trainNo: '7246', statnNm: '중곡', trainSttus: 1, updnLine: '상행', lastRecptnDt: '' },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-pos',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(stats.arvlCdFireMismatch).toBe(1);
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
+  });
+
+  it('#640 회귀 가드 — lock 부재 trip은 lockMissing 게이트에 막혀 매역 fire 경로 진입 자체 X', async () => {
+    // lock 없는 trip + arrivals에 임의 trainCode arvlCd=1 → 외부에서 보면 "매역 신호"지만
+    // lockMissing 게이트가 차단해야 한다.
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip()); // boardingLock undefined
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('강남', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-nolock',
+    });
+    expect(stats.lockMissing).toBe(1);
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    // mismatch도 0 — 게이트가 더 위에서 차단해 fire 경로 진입 자체가 없음.
+    expect(stats.arvlCdFireMismatch).toBe(0);
+    expect(apnsFetch).not.toHaveBeenCalled();
+  });
+
+  it('waypoint advance는 매역 push 발사 후에도 정상 수행 (push와 progress는 독립)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-adv',
+    });
+    // 중곡(intermediate) advance 후 다음 waypoint=군자
+    const stored = JSON.parse((await kv.get('trip:arvl-tok')) as string) as Trip;
+    expect(stored.waypoints).toHaveLength(1);
+    expect(stored.waypoints[0].stationName).toBe('군자');
+  });
+
+  it('APNs env mismatch self-heal — sandbox 1차 거부 → production 정정 + arvlCdFireSuccess=1', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ apnsEnv: 'sandbox' }));
+    const apnsFetch = vi.fn();
+    apnsFetch
+      .mockImplementationOnce(async () =>
+        new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+      )
+      .mockImplementationOnce(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-heal',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(stats.envCorrected).toBe(1);
+    const stored = JSON.parse((await kv.get('trip:arvl-tok')) as string) as Trip;
+    expect(stored.apnsEnv).toBe('production');
+  });
+
+  it('push 실패 시 stats.errors++ + dedup KV 미stamp (다음 cycle 재시도 허용)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadFoo' }), { status: 400 }),
+    );
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-fail',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(stats.errors).toBeGreaterThanOrEqual(1);
+    // 실패는 dedup stamp X — 다음 cycle 재시도 가능.
+    expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 1))).toBeNull();
+  });
+
+  it('destination waypoint도 arvlCd=1이면 매역 push 발사 (kind=destination)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [{ stationName: '군자', line: '7', kind: 'destination' }],
+      }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('군자', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-dest',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    const calls = getStationPassedCalls(apnsFetch);
+    expect(calls).toHaveLength(1);
+    expect(parseStationPassedData(calls[0]).kind).toBe('destination');
+  });
+
+  it('cross-trip 격리 — 같은 trainCode 같은 역에 두 trip 동시 도착 시 둘 다 발사 (token이 dedup key)', async () => {
+    // 두 사용자가 같은 train(7246)을 탄 채 같은 cycle 안 같은 역(중곡)에 도착하는 시나리오.
+    // 옛 동작(token 미포함 dedup key)은 두 번째 trip을 silence했음.
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ token: 'user-a' }));
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ token: 'user-b' }));
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-cross',
+    });
+    // 두 trip 모두 push 발사.
+    expect(stats.arvlCdFireSuccess).toBe(2);
+    expect(stats.arvlCdFireDedup).toBe(0);
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(2);
+  });
+
+  it('arvlCd=1이지만 lock 만료된 trip은 lockMissing 게이트로 차단 (fire 경로 미진입)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ boardingLock: makeLock({ expiresAt: NOW - 1 }) }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-exp',
+    });
+    expect(stats.lockMissing).toBe(1);
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(stats.arvlCdFireMismatch).toBe(0); // 게이트 위 차단이라 fire 경로 미진입
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3403,14 +3403,17 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   const parseStationPassedData = parseArvlCdStationPassedData;
 
   // arvlCd fire 테스트 공통 setup — kv 시드 + runScheduled 실행. apnsFetch는 옵션으로 사전 stub 가능.
+  // seedKv는 trip put 직후 추가 KV 시드 (이전 cycle stamp 등) 수행하는 콜백.
   async function runArvlScheduled(opts: {
     seoul: SeoulArrivalClient;
     trip?: Trip;
     apnsFetch?: ReturnType<typeof vi.fn>;
     pushId?: string;
+    seedKv?: (kv: InMemoryKV) => Promise<void>;
   }): Promise<{ stats: ScheduledStats; kv: InMemoryKV; apnsFetch: ReturnType<typeof vi.fn> }> {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, opts.trip ?? makeLockTrip());
+    if (opts.seedKv) await opts.seedKv(kv);
     const apnsFetch = opts.apnsFetch ?? vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
       seoul: opts.seoul,
@@ -3446,16 +3449,9 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   });
 
   it('arvlCd=0(ENTERING) → 매역 push 발사 (arvlCd=0 dedup key)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
+    const { stats, kv } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 0),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-0',
+      pushId: 'p-arvl-0',
     });
     expect(stats.arvlCdFireSuccess).toBe(1);
     expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 0))).toBe('1');
@@ -3464,18 +3460,13 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   });
 
   it('dedup — 같은 (trainCode, station, arvlCd) 이미 stamp되어 있으면 push 미발사', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
-    // 이전 cycle에서 같은 신호로 이미 stamp된 상태
-    await kv.put(arvlCdFireKey('arvl-tok', '7246', '중곡', 1), '1');
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
+    const { stats, apnsFetch } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-dup',
+      pushId: 'p-arvl-dup',
+      seedKv: async (kv) => {
+        // 이전 cycle에서 같은 신호로 이미 stamp된 상태
+        await kv.put(arvlCdFireKey('arvl-tok', '7246', '중곡', 1), '1');
+      },
     });
     expect(stats.arvlCdFireSuccess).toBe(0);
     expect(stats.arvlCdFireDedup).toBe(1);

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -65,6 +65,114 @@ function makeEnv(kv: InMemoryKV, pending?: InMemoryKV): Env {
   };
 }
 
+// estimateBoardingLockArrival 테스트 공용 — 단일 arvlCd 노출만 검증.
+function makeEstimateArrivalSeoul(arvlCd: number | null): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: [
+            {
+              barvlDt: '0',
+              recptnDt: '',
+              updnLine: '상행',
+              trainLineNm: '중곡',
+              btrainNo: '7246',
+              subwayNm: '지하철7호선',
+              arvlCd,
+            },
+          ],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
+function makeEstimateArrivalDeps(seoul: SeoulArrivalClient): ScheduledDeps {
+  return {
+    seoul,
+    apnsConfig,
+    apnsHosts: APNS_HOSTS,
+    fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+  };
+}
+
+// #917 arvlCd fire 테스트용 — stationName/seconds/arvlCd/trainCode 명시.
+function makeArvlCdFireSeoul(
+  stationName: string,
+  seconds: number,
+  arvlCd: number | null,
+  trainCode = '7246',
+): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: [
+            {
+              barvlDt: String(seconds),
+              recptnDt: '',
+              updnLine: '상행',
+              trainLineNm: stationName,
+              btrainNo: trainCode,
+              subwayNm: '지하철7호선',
+              arvlCd,
+            },
+          ],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
+/** arvlCd fire silent push (background, kind=intermediate/destination, phase=imminent) 호출만 추출. */
+function getArvlCdStationPassedCalls(
+  fetchImpl: ReturnType<typeof vi.fn>,
+): [string, RequestInit][] {
+  return (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) => {
+    const headers = (c[1]?.headers ?? {}) as Record<string, string>;
+    if (headers['apns-push-type'] !== 'background') return false;
+    try {
+      const body = JSON.parse(c[1]?.body as string) as {
+        data?: { phase?: string; kind?: string };
+      };
+      return (
+        body?.data?.phase === 'imminent' &&
+        (body?.data?.kind === 'intermediate' || body?.data?.kind === 'destination')
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+function parseArvlCdStationPassedData(call: [string, RequestInit]): {
+  nextWaypoint: string;
+  etaSeconds: number;
+  phase: string;
+  kind: string;
+  pushId: string;
+  sentAt: number;
+} {
+  const body = JSON.parse(call[1].body as string) as {
+    data: {
+      nextWaypoint: string;
+      etaSeconds: number;
+      phase: string;
+      kind: string;
+      pushId: string;
+      sentAt: number;
+    };
+  };
+  return body.data;
+}
+
 // boardingLock fixture — 7호선 용마산→중곡→군자 leg 공용 (lock 추적/arvlCd fire 테스트 공통).
 function makeBoardingLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
   return {
@@ -3204,39 +3312,8 @@ describe('estimateBoardingLockArrival arvlCd exposure (#917 A2)', () => {
   };
   const waypoint: Waypoint = { stationName: '중곡', line: '7', kind: 'intermediate' };
 
-  function makeArrivalSeoul(arvlCd: number | null): SeoulArrivalClient {
-    return new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async () =>
-        new Response(
-          JSON.stringify({
-            realtimeArrivalList: [
-              {
-                barvlDt: '0',
-                recptnDt: '',
-                updnLine: '상행',
-                trainLineNm: '중곡',
-                btrainNo: '7246',
-                subwayNm: '지하철7호선',
-                arvlCd,
-              },
-            ],
-          }),
-          { status: 200 },
-        )) as unknown as typeof fetch,
-    });
-  }
-
-  function makeArrivalDeps(seoul: SeoulArrivalClient): ScheduledDeps {
-    return {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
-    };
-  }
+  const makeArrivalSeoul = makeEstimateArrivalSeoul;
+  const makeArrivalDeps = makeEstimateArrivalDeps;
 
   it('arrivals 매칭 시 arvlCd=1 노출 (arrived=true)', async () => {
     const result = await estimateBoardingLockArrival(
@@ -3321,80 +3398,9 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     });
   }
 
-  /** arrivals + positions URL 분기 + lock.trainCode 매칭 응답 builder. */
-  function makeArrivalSeoul(
-    stationName: string,
-    seconds: number,
-    arvlCd: number | null,
-    trainCode = '7246',
-  ): SeoulArrivalClient {
-    return new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async () =>
-        new Response(
-          JSON.stringify({
-            realtimeArrivalList: [
-              {
-                barvlDt: String(seconds),
-                recptnDt: '',
-                updnLine: '상행',
-                trainLineNm: stationName,
-                btrainNo: trainCode,
-                subwayNm: '지하철7호선',
-                arvlCd,
-              },
-            ],
-          }),
-          { status: 200 },
-        )) as unknown as typeof fetch,
-    });
-  }
-
-  /** silent push (background, kind=intermediate/destination) 호출만 추출. */
-  function getStationPassedCalls(
-    fetchImpl: ReturnType<typeof vi.fn>,
-  ): [string, RequestInit][] {
-    return (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) => {
-      const headers = (c[1]?.headers ?? {}) as Record<string, string>;
-      if (headers['apns-push-type'] !== 'background') return false;
-      try {
-        const body = JSON.parse(c[1]?.body as string) as {
-          data?: { phase?: string; kind?: string };
-        };
-        // arvlCd fire는 phase=imminent + kind∈{intermediate, destination}.
-        // reschedule push(kind='reschedule')와 trip-ended push(kind='trip-ended')와 구분.
-        return (
-          body?.data?.phase === 'imminent' &&
-          (body?.data?.kind === 'intermediate' || body?.data?.kind === 'destination')
-        );
-      } catch {
-        return false;
-      }
-    });
-  }
-
-  function parseStationPassedData(call: [string, RequestInit]): {
-    nextWaypoint: string;
-    etaSeconds: number;
-    phase: string;
-    kind: string;
-    pushId: string;
-    sentAt: number;
-  } {
-    const body = JSON.parse(call[1].body as string) as {
-      data: {
-        nextWaypoint: string;
-        etaSeconds: number;
-        phase: string;
-        kind: string;
-        pushId: string;
-        sentAt: number;
-      };
-    };
-    return body.data;
-  }
+  const makeArrivalSeoul = makeArvlCdFireSeoul;
+  const getStationPassedCalls = getArvlCdStationPassedCalls;
+  const parseStationPassedData = parseArvlCdStationPassedData;
 
   it('arvlCd=1(ARRIVED) → 매역 push 발사 + stats.arvlCdFireSuccess=1 + dedup KV stamp', async () => {
     const kv = new InMemoryKV();

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3402,17 +3402,31 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   const getStationPassedCalls = getArvlCdStationPassedCalls;
   const parseStationPassedData = parseArvlCdStationPassedData;
 
-  it('arvlCd=1(ARRIVED) → 매역 push 발사 + stats.arvlCdFireSuccess=1 + dedup KV stamp', async () => {
+  // arvlCd fire 테스트 공통 setup — kv 시드 + runScheduled 실행. apnsFetch는 옵션으로 사전 stub 가능.
+  async function runArvlScheduled(opts: {
+    seoul: SeoulArrivalClient;
+    trip?: Trip;
+    apnsFetch?: ReturnType<typeof vi.fn>;
+    pushId?: string;
+  }): Promise<{ stats: ScheduledStats; kv: InMemoryKV; apnsFetch: ReturnType<typeof vi.fn> }> {
     const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await putTrip(kv as unknown as KVNamespace, opts.trip ?? makeLockTrip());
+    const apnsFetch = opts.apnsFetch ?? vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeArrivalSeoul('중곡', 0, 1),
+      seoul: opts.seoul,
       apnsConfig,
       apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
-      generatePushId: () => 'p-arvl-1',
+      generatePushId: () => opts.pushId ?? 'p-arvl-1',
+    });
+    return { stats, kv, apnsFetch };
+  }
+
+  it('arvlCd=1(ARRIVED) → 매역 push 발사 + stats.arvlCdFireSuccess=1 + dedup KV stamp', async () => {
+    const { stats, kv, apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      pushId: 'p-arvl-1',
     });
     expect(stats.arvlCdFireSuccess).toBe(1);
     expect(stats.arvlCdFireDedup).toBe(0);
@@ -3509,16 +3523,10 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   it('#640 회귀 가드 — lock 부재 trip은 lockMissing 게이트에 막혀 매역 fire 경로 진입 자체 X', async () => {
     // lock 없는 trip + arrivals에 임의 trainCode arvlCd=1 → 외부에서 보면 "매역 신호"지만
     // lockMissing 게이트가 차단해야 한다.
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeTrip()); // boardingLock undefined
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
+    const { stats, apnsFetch } = await runArvlScheduled({
       seoul: makeArrivalSeoul('강남', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-nolock',
+      trip: makeTrip(), // boardingLock undefined
+      pushId: 'p-arvl-nolock',
     });
     expect(stats.lockMissing).toBe(1);
     expect(stats.arvlCdFireSuccess).toBe(0);
@@ -3528,16 +3536,9 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   });
 
   it('waypoint advance는 매역 push 발사 후에도 정상 수행 (push와 progress는 독립)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
+    const { kv } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-adv',
+      pushId: 'p-arvl-adv',
     });
     // 중곡(intermediate) advance 후 다음 waypoint=군자
     const stored = JSON.parse((await kv.get('trip:arvl-tok')) as string) as Trip;

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -173,6 +173,21 @@ function parseArvlCdStationPassedData(call: [string, RequestInit]): {
   return body.data;
 }
 
+// 7호선 용마산→중곡→군자 leg lockTrip 공용 (lock 추적/arvlCd fire 테스트 공통).
+// token만 describe별로 다르므로 token은 호출 시 명시.
+function makeLockTripFixture(token: string, overrides: Partial<Trip> = {}): Trip {
+  return makeTrip({
+    token,
+    route: { type: 'direct', line: '7', stops: 2 },
+    waypoints: [
+      { stationName: '중곡', line: '7', kind: 'intermediate' },
+      { stationName: '군자', line: '7', kind: 'destination' },
+    ],
+    boardingLock: makeBoardingLock(),
+    ...overrides,
+  });
+}
+
 // boardingLock fixture — 7호선 용마산→중곡→군자 leg 공용 (lock 추적/arvlCd fire 테스트 공통).
 function makeBoardingLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
   return {
@@ -574,19 +589,7 @@ describe('runScheduled', () => {
 
 describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
   const makeLock = makeBoardingLock;
-
-  function makeLockTrip(overrides: Partial<Trip> = {}): Trip {
-    return makeTrip({
-      token: 'lock-tok',
-      route: { type: 'direct', line: '7', stops: 2 },
-      waypoints: [
-        { stationName: '중곡', line: '7', kind: 'intermediate' },
-        { stationName: '군자', line: '7', kind: 'destination' },
-      ],
-      boardingLock: makeLock(),
-      ...overrides,
-    });
-  }
+  const makeLockTrip = (overrides: Partial<Trip> = {}) => makeLockTripFixture('lock-tok', overrides);
 
   /** Seoul API 응답 — arrivals와 positions를 URL 경로로 분기. */
   function makeSeoulCombo(
@@ -3384,19 +3387,7 @@ describe('estimateBoardingLockArrival arvlCd exposure (#917 A2)', () => {
 
 describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   const makeLock = makeBoardingLock;
-
-  function makeLockTrip(overrides: Partial<Trip> = {}): Trip {
-    return makeTrip({
-      token: 'arvl-tok',
-      route: { type: 'direct', line: '7', stops: 2 },
-      waypoints: [
-        { stationName: '중곡', line: '7', kind: 'intermediate' },
-        { stationName: '군자', line: '7', kind: 'destination' },
-      ],
-      boardingLock: makeLock(),
-      ...overrides,
-    });
-  }
+  const makeLockTrip = (overrides: Partial<Trip> = {}) => makeLockTripFixture('arvl-tok', overrides);
 
   const makeArrivalSeoul = makeArvlCdFireSeoul;
   const getStationPassedCalls = getArvlCdStationPassedCalls;

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3538,21 +3538,17 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   });
 
   it('APNs env mismatch self-heal — sandbox 1차 거부 → production 정정 + arvlCdFireSuccess=1', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ apnsEnv: 'sandbox' }));
     const apnsFetch = vi.fn();
     apnsFetch
       .mockImplementationOnce(async () =>
         new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
       )
       .mockImplementationOnce(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
+    const { stats, kv } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-heal',
+      trip: makeLockTrip({ apnsEnv: 'sandbox' }),
+      apnsFetch,
+      pushId: 'p-arvl-heal',
     });
     expect(stats.arvlCdFireSuccess).toBe(1);
     expect(stats.envCorrected).toBe(1);
@@ -3561,18 +3557,13 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   });
 
   it('push 실패 시 stats.errors++ + dedup KV 미stamp (다음 cycle 재시도 허용)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
     const apnsFetch = vi.fn(async () =>
       new Response(JSON.stringify({ reason: 'BadFoo' }), { status: 400 }),
     );
-    const stats = await runScheduled(makeEnv(kv), {
+    const { stats, kv } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-fail',
+      apnsFetch,
+      pushId: 'p-arvl-fail',
     });
     expect(stats.arvlCdFireSuccess).toBe(0);
     expect(stats.errors).toBeGreaterThanOrEqual(1);
@@ -3581,21 +3572,12 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   });
 
   it('destination waypoint도 arvlCd=1이면 매역 push 발사 (kind=destination)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockTrip({
+    const { stats, apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('군자', 0, 1),
+      trip: makeLockTrip({
         waypoints: [{ stationName: '군자', line: '7', kind: 'destination' }],
       }),
-    );
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeArrivalSeoul('군자', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-dest',
+      pushId: 'p-arvl-dest',
     });
     expect(stats.arvlCdFireSuccess).toBe(1);
     const calls = getStationPassedCalls(apnsFetch);
@@ -3606,38 +3588,25 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   it('cross-trip 격리 — 같은 trainCode 같은 역에 두 trip 동시 도착 시 둘 다 발사 (token이 dedup key)', async () => {
     // 두 사용자가 같은 train(7246)을 탄 채 같은 cycle 안 같은 역(중곡)에 도착하는 시나리오.
     // 옛 동작(token 미포함 dedup key)은 두 번째 trip을 silence했음.
-    const kv = new InMemoryKV();
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ token: 'user-a' }));
-    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ token: 'user-b' }));
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
+    const { stats, apnsFetch } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-cross',
+      trip: makeLockTrip({ token: 'user-a' }),
+      pushId: 'p-arvl-cross',
+      seedKv: async (kv) => {
+        // 두 번째 trip을 같은 KV에 추가 시드.
+        await putTrip(kv as unknown as KVNamespace, makeLockTrip({ token: 'user-b' }));
+      },
     });
-    // 두 trip 모두 push 발사.
     expect(stats.arvlCdFireSuccess).toBe(2);
     expect(stats.arvlCdFireDedup).toBe(0);
     expect(getStationPassedCalls(apnsFetch)).toHaveLength(2);
   });
 
   it('arvlCd=1이지만 lock 만료된 trip은 lockMissing 게이트로 차단 (fire 경로 미진입)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockTrip({ boardingLock: makeLock({ expiresAt: NOW - 1 }) }),
-    );
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
+    const { stats, apnsFetch } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p-arvl-exp',
+      trip: makeLockTrip({ boardingLock: makeLock({ expiresAt: NOW - 1 }) }),
+      pushId: 'p-arvl-exp',
     });
     expect(stats.lockMissing).toBe(1);
     expect(stats.arvlCdFireSuccess).toBe(0);

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -65,6 +65,19 @@ function makeEnv(kv: InMemoryKV, pending?: InMemoryKV): Env {
   };
 }
 
+// boardingLock fixture — 7호선 용마산→중곡→군자 leg 공용 (lock 추적/arvlCd fire 테스트 공통).
+function makeBoardingLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
+  return {
+    trainCode: '7246',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: NOW,
+    segmentStations: ['용마산', '중곡', '군자'],
+    expiresAt: NOW + 60 * 60_000,
+    ...overrides,
+  };
+}
+
 // 9단 게이트 happy path 공용 GPS series — boarding-prompt / kalman / auto-lock 테스트 공통 사용.
 // 게이트 #4(origin 100m 이내) / #5(direction cosine ≥ 0.7) / #7(speed ≥ 5 km/h) 모두 통과 설계.
 async function seedHappyGateSeries(kv: InMemoryKV, token: string): Promise<void> {
@@ -452,17 +465,7 @@ describe('runScheduled', () => {
 });
 
 describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
-  function makeLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
-    return {
-      trainCode: '7246',
-      line: '7',
-      subwayId: '1007',
-      selectedDepartureTime: NOW,
-      segmentStations: ['용마산', '중곡', '군자'],
-      expiresAt: NOW + 60 * 60_000,
-      ...overrides,
-    };
-  }
+  const makeLock = makeBoardingLock;
 
   function makeLockTrip(overrides: Partial<Trip> = {}): Trip {
     return makeTrip({
@@ -3303,17 +3306,7 @@ describe('estimateBoardingLockArrival arvlCd exposure (#917 A2)', () => {
 });
 
 describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
-  function makeLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
-    return {
-      trainCode: '7246',
-      line: '7',
-      subwayId: '1007',
-      selectedDepartureTime: NOW,
-      segmentStations: ['용마산', '중곡', '군자'],
-      expiresAt: NOW + 60 * 60_000,
-      ...overrides,
-    };
-  }
+  const makeLock = makeBoardingLock;
 
   function makeLockTrip(overrides: Partial<Trip> = {}): Trip {
     return makeTrip({

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -76,6 +76,27 @@
       "format": "rate",
       "display": "percentage",
       "description": "#916 A1 — 자동 lock 후 사용자가 다른 trainCode로 swap한 비율 (catalog placeholder, 후속 PR에서 client swap 신호 wire)"
+    },
+    {
+      "key": "arvlCdFireSuccess",
+      "constantName": "ARVLCD_FIRE_SUCCESS",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#917 A2 — boardingLock 활성 trip에서 Seoul arvlCd∈{0,1} 신호로 매역 station-passed push 발사 성공 비율"
+    },
+    {
+      "key": "arvlCdFireDedup",
+      "constantName": "ARVLCD_FIRE_DEDUP",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#917 A2 — 같은 (trainCode, station, arvlCd) 조합 dedup KV로 차단된 비율 — Seoul API 갱신 지연으로 중복 신호 차단 효과 측정"
+    },
+    {
+      "key": "arvlCdFireMismatch",
+      "constantName": "ARVLCD_FIRE_MISMATCH",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#917 A2 — prereq 게이트(lock 활성 + arvlCd∈{0,1}) 실패로 매역 push 미발사된 비율 — #640 회귀 방어 신호"
     }
   ]
 }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -631,18 +631,23 @@ export function evaluateArvlCdFireGate(
  * @returns cleanedUp=true는 token unrecoverable로 trip 폐기 신호 (호출자가 advance 스킵).
  *          현재 정책상 cleanup 분기는 없고 항상 false 반환.
  */
+export interface FireArvlCdStationPushInputs {
+  trip: Trip;
+  waypoint: Waypoint;
+  lock: BoardingLockMeta;
+  arvlCd: number;
+  env: Env;
+  deps: ScheduledDeps;
+  stats: ScheduledStats;
+  now: number;
+  log: Logger;
+  generatePushId: () => string;
+}
+
 export async function fireArvlCdStationPush(
-  trip: Trip,
-  waypoint: Waypoint,
-  lock: BoardingLockMeta,
-  arvlCd: number,
-  env: Env,
-  deps: ScheduledDeps,
-  stats: ScheduledStats,
-  now: number,
-  log: Logger,
-  generatePushId: () => string,
+  inputs: FireArvlCdStationPushInputs,
 ): Promise<{ dirty: boolean }> {
+  const { trip, waypoint, lock, arvlCd, env, deps, stats, now, log, generatePushId } = inputs;
   const key = arvlCdFireKey(trip.token, lock.trainCode, waypoint.stationName, arvlCd);
   const existing = await env.TRIPS.get(key);
   if (existing !== null) {
@@ -709,6 +714,46 @@ export async function fireArvlCdStationPush(
   return { dirty };
 }
 
+/**
+ * #902 Seam F — trainCode 사라짐 후 swap. previous+이번 미스 = VANISH_RE_ATTACH_THRESHOLD 도달 시 시도.
+ * 같은 station에 같은 line 신규 trainCode가 보이면 activeLock 교체. 호출자는 swap 결과를 사용해 재estimate.
+ * `runTrainCodeTracking`의 cognitive complexity 분담용 추출 (Sonar S3776).
+ */
+async function attemptVanishSwap(
+  trip: Trip,
+  waypoint: Waypoint,
+  activeLock: BoardingLockMeta,
+  deps: ScheduledDeps,
+  now: number,
+  log: Logger,
+): Promise<BoardingLockMeta | null> {
+  const previousMissCount = trip.consecutiveEtaMissing ?? 0;
+  if (previousMissCount + 1 < VANISH_RE_ATTACH_THRESHOLD) return null;
+  const swapped = await attachTrainCodeForLeg({
+    trip,
+    targetWaypoint: waypoint,
+    seoul: deps.seoul,
+    now,
+  });
+  if (!swapped || swapped.trainCode === activeLock.trainCode) return null;
+  log('boarding-lock: trainCode vanished, swapped', {
+    token: trip.token.slice(0, 8),
+    previousTrainCode: activeLock.trainCode,
+    newTrainCode: swapped.trainCode,
+    station: waypoint.stationName,
+    consecutiveEtaMissing: previousMissCount + 1,
+  });
+  // segmentStations는 기존 lock 것을 유지 (이미 진행 중인 leg) — 새 trainCode/expiresAt만 채택.
+  const newLock: BoardingLockMeta = {
+    ...activeLock,
+    trainCode: swapped.trainCode,
+    expiresAt: Math.max(activeLock.expiresAt, swapped.expiresAt),
+  };
+  trip.boardingLock = newLock;
+  trip.consecutiveEtaMissing = 0;
+  return newLock;
+}
+
 export async function runTrainCodeTracking(
   trip: Trip,
   waypoint: Waypoint,
@@ -723,36 +768,10 @@ export async function runTrainCodeTracking(
   let activeLock = lock;
   let estimate = await estimateBoardingLockArrival(deps, activeLock, waypoint, now);
   if (estimate === null) {
-    const previousMissCount = trip.consecutiveEtaMissing ?? 0;
-    // #902 Seam F — 사라짐 후 재attach. previous=1 + 이번 미스 = 2 도달 시 1회 swap 시도.
-    // 같은 station에 같은 line 신규 trainCode가 보이면 lock을 교체하고 이번 cycle에 재estimate.
-    // 성공 시 그 아래의 정상 경로(arrived/reschedule)로 자연 진입.
-    const reachedVanishThreshold = previousMissCount + 1 >= VANISH_RE_ATTACH_THRESHOLD;
-    if (reachedVanishThreshold) {
-      const swapped = await attachTrainCodeForLeg({
-        trip,
-        targetWaypoint: waypoint,
-        seoul: deps.seoul,
-        now,
-      });
-      if (swapped && swapped.trainCode !== activeLock.trainCode) {
-        log('boarding-lock: trainCode vanished, swapped', {
-          token: trip.token.slice(0, 8),
-          previousTrainCode: activeLock.trainCode,
-          newTrainCode: swapped.trainCode,
-          station: waypoint.stationName,
-          consecutiveEtaMissing: previousMissCount + 1,
-        });
-        // segmentStations는 기존 lock 것을 유지 (이미 진행 중인 leg) — 새 trainCode/expiresAt만 채택.
-        activeLock = {
-          ...activeLock,
-          trainCode: swapped.trainCode,
-          expiresAt: Math.max(activeLock.expiresAt, swapped.expiresAt),
-        };
-        trip.boardingLock = activeLock;
-        trip.consecutiveEtaMissing = 0;
-        estimate = await estimateBoardingLockArrival(deps, activeLock, waypoint, now);
-      }
+    const swappedLock = await attemptVanishSwap(trip, waypoint, activeLock, deps, now, log);
+    if (swappedLock) {
+      activeLock = swappedLock;
+      estimate = await estimateBoardingLockArrival(deps, activeLock, waypoint, now);
     }
   }
   if (estimate === null) {
@@ -802,18 +821,18 @@ export async function runTrainCodeTracking(
     // prereq 게이트: lock 활성 + arvlCd∈{0,1}. #640 회귀(lock 없는 trip 발사) defensive recheck.
     const gate = evaluateArvlCdFireGate(activeLock, estimate.arvlCd, now);
     if (gate === 'fire' && estimate.arvlCd !== null) {
-      const fire = await fireArvlCdStationPush(
+      const fire = await fireArvlCdStationPush({
         trip,
         waypoint,
-        activeLock,
-        estimate.arvlCd,
+        lock: activeLock,
+        arvlCd: estimate.arvlCd,
         env,
         deps,
         stats,
         now,
         log,
         generatePushId,
-      );
+      });
       if (fire.dirty) await putTrip(env.TRIPS, trip);
     } else {
       stats.arvlCdFireMismatch += 1;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -754,6 +754,49 @@ async function attemptVanishSwap(
   return newLock;
 }
 
+/**
+ * estimate가 null로 끝난 cycle 처리 — etaMissing 카운터 누적 + 임계 초과 시 trip 자동 종료.
+ * runTrainCodeTracking의 cognitive complexity 분담용 추출 (Sonar S3776).
+ */
+async function handleEtaMissing(
+  trip: Trip,
+  waypoint: Waypoint,
+  activeLock: BoardingLockMeta,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+): Promise<void> {
+  stats.etaMissing += 1;
+  const previousMissCount = trip.consecutiveEtaMissing ?? 0;
+  const nextMissCount = previousMissCount + 1;
+  log('boarding-lock: trainCode not found in arrivals or positions', {
+    token: trip.token.slice(0, 8),
+    trainCode: activeLock.trainCode,
+    station: waypoint.stationName,
+    consecutiveEtaMissing: nextMissCount,
+  });
+  // #903 (Seam G) — subsurface=true trip은 인내 임계(10)로 분기. 지하 dead zone GPS/trainCode 일시 누락 인내.
+  const threshold = resolveEtaMissingThreshold(trip);
+  if (nextMissCount >= threshold) {
+    // #706 — 운행 시간대 외 무한 폴링 차단. cleanupTripWithLa가 LA dismissal + deleteTrip을 묶어 정리.
+    // #868 — 클라 state sync용 trip-ended silent push 발사 (reason=eta-missing).
+    log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
+      token: trip.token.slice(0, 8),
+      trainCode: activeLock.trainCode,
+      station: waypoint.stationName,
+      threshold,
+      subsurface: trip.subsurface === true,
+    });
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'eta-missing');
+    return;
+  }
+  trip.consecutiveEtaMissing = nextMissCount;
+  await putTrip(env.TRIPS, trip);
+  await mirrorProgress(env.TRIPS, trip, 0);
+}
+
 export async function runTrainCodeTracking(
   trip: Trip,
   waypoint: Waypoint,
@@ -775,33 +818,7 @@ export async function runTrainCodeTracking(
     }
   }
   if (estimate === null) {
-    stats.etaMissing += 1;
-    const previousMissCount = trip.consecutiveEtaMissing ?? 0;
-    const nextMissCount = previousMissCount + 1;
-    log('boarding-lock: trainCode not found in arrivals or positions', {
-      token: trip.token.slice(0, 8),
-      trainCode: activeLock.trainCode,
-      station: waypoint.stationName,
-      consecutiveEtaMissing: nextMissCount,
-    });
-    // #903 (Seam G) — subsurface=true trip은 인내 임계(10)로 분기. 지하 dead zone GPS/trainCode 일시 누락 인내.
-    const threshold = resolveEtaMissingThreshold(trip);
-    if (nextMissCount >= threshold) {
-      // #706 — 운행 시간대 외 무한 폴링 차단. cleanupTripWithLa가 LA dismissal + deleteTrip을 묶어 정리.
-      // #868 — 클라 state sync용 trip-ended silent push 발사 (reason=eta-missing).
-      log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
-        token: trip.token.slice(0, 8),
-        trainCode: activeLock.trainCode,
-        station: waypoint.stationName,
-        threshold,
-        subsurface: trip.subsurface === true,
-      });
-      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'eta-missing');
-      return;
-    }
-    trip.consecutiveEtaMissing = nextMissCount;
-    await putTrip(env.TRIPS, trip);
-    await mirrorProgress(env.TRIPS, trip, 0);
+    await handleEtaMissing(trip, waypoint, activeLock, env, deps, stats, now, log);
     return;
   }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -758,16 +758,18 @@ async function attemptVanishSwap(
  * estimate가 null로 끝난 cycle 처리 — etaMissing 카운터 누적 + 임계 초과 시 trip 자동 종료.
  * runTrainCodeTracking의 cognitive complexity 분담용 추출 (Sonar S3776).
  */
-async function handleEtaMissing(
-  trip: Trip,
-  waypoint: Waypoint,
-  activeLock: BoardingLockMeta,
-  env: Env,
-  deps: ScheduledDeps,
-  stats: ScheduledStats,
-  now: number,
-  log: Logger,
-): Promise<void> {
+interface HandleEtaMissingInputs {
+  trip: Trip;
+  waypoint: Waypoint;
+  activeLock: BoardingLockMeta;
+  env: Env;
+  deps: ScheduledDeps;
+  stats: ScheduledStats;
+  now: number;
+  log: Logger;
+}
+async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
+  const { trip, waypoint, activeLock, env, deps, stats, now, log } = inputs;
   stats.etaMissing += 1;
   const previousMissCount = trip.consecutiveEtaMissing ?? 0;
   const nextMissCount = previousMissCount + 1;
@@ -818,7 +820,7 @@ export async function runTrainCodeTracking(
     }
   }
   if (estimate === null) {
-    await handleEtaMissing(trip, waypoint, activeLock, env, deps, stats, now, log);
+    await handleEtaMissing({ trip, waypoint, activeLock, env, deps, stats, now, log });
     return;
   }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -224,6 +224,24 @@ export interface ScheduledStats extends LiveActivityStats {
    * client swap 신호 처리는 후속 PR (#916 A2)에서 wire한다. 현재는 항상 0.
    */
   autoLockFalsePositive: number;
+  /**
+   * #917 A2 — boardingLock 활성 trip에서 Seoul arrivals의 arvlCd∈{0(ENTERING), 1(ARRIVED)}
+   * 신호로 매역 station-passed silent push가 성공 발사된 누적 횟수. 매역 알림 1차 source는
+   * GPS가 아니라 이 신호 — 다운로드 가치 직결(지하/지상 무관).
+   */
+  arvlCdFireSuccess: number;
+  /**
+   * #917 A2 — 같은 (trainCode, station, arvlCd) 조합에 대해 이미 발사한 dedup KV가 있어
+   * 매역 push가 차단된 횟수. cron 60s × Seoul API 갱신 지연으로 같은 신호가 2~3 cycle 반복
+   * 노출되는데, 클라가 같은 알림을 중복 수신하는 회귀를 차단한다.
+   */
+  arvlCdFireDedup: number;
+  /**
+   * #917 A2 — 매역 fire path 진입했지만 prereq 게이트(lock 활성 + arvlCd∈{0,1}) 실패로
+   * push 미발사된 횟수. positions-fallback arrived(arvlCd=null) 등 SSOT가 arvlCd가 아닌
+   * 경로를 측정한다. #640 회귀(lock 없는 trip 발사) 방어 신호 — 정상 운영에서는 0이어야 한다.
+   */
+  arvlCdFireMismatch: number;
 }
 
 /**
@@ -274,6 +292,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     kalmanDriftWarning: 0,
     autoLockSuccess: 0,
     autoLockFalsePositive: 0,
+    arvlCdFireSuccess: 0,
+    arvlCdFireDedup: 0,
+    arvlCdFireMismatch: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -537,6 +558,157 @@ async function mirrorProgress(
  */
 export const VANISH_RE_ATTACH_THRESHOLD = 2;
 
+/**
+ * #917 A2 — 매역 알림 dedup KV TTL(초).
+ * 같은 trainCode가 같은 역의 arvlCd∈{0,1} 신호를 cron 60s × Seoul API 갱신 지연으로 2~3 cycle
+ * 반복 노출하는데, 그 윈도우 동안 push가 중복 발사되지 않도록 차단한다.
+ * 한 trip 진행 중 같은 역으로 다시 돌아올 일은 없으므로 보수적으로 1시간 — KV TTL 최소(60s) 위.
+ */
+export const ARVLCD_FIRE_DEDUP_TTL_SEC = 60 * 60;
+
+/**
+ * #917 A2 — 매역 알림 dedup KV key prefix.
+ * Key 형식: `${prefix}${token}|${trainCode}|${stationName}|${arvlCd}`
+ *
+ * 주의: trip token이 key에 포함된다 — 같은 train(trainCode)을 탄 여러 사용자가 같은 역에
+ * 도착할 때 한 명만 push 받고 나머지가 dedup으로 silence되는 cross-trip leak을 차단한다.
+ */
+export const ARVLCD_FIRE_KEY_PREFIX = 'arvlcd-fire:';
+
+/**
+ * dedup KV key 빌더. arvlCd 0(ENTERING) vs 1(ARRIVED)은 별 entry로 분리(둘 다 신호).
+ * token은 trip 단위 격리 — 같은 train 다른 trip이 서로 silence하지 않도록.
+ */
+export function arvlCdFireKey(
+  token: string,
+  trainCode: string,
+  stationName: string,
+  arvlCd: number,
+): string {
+  return `${ARVLCD_FIRE_KEY_PREFIX}${token}|${trainCode}|${stationName}|${arvlCd}`;
+}
+
+/**
+ * arvlCd∈{0(ENTERING), 1(ARRIVED)} 신호로 매역 알림 발사 가능한지 prereq 평가 (#917 A2 가드).
+ *
+ * Returns:
+ *   - 'fire'      — push 발사 진행
+ *   - 'mismatch'  — prereq 실패. push X. arvlCdFireMismatch++로 카운트해 회귀 측정.
+ *
+ * 가드:
+ *   1. lock 활성 (호출 전 isBoardingLockActive로 이미 검증되지만 defensive recheck)
+ *   2. estimate.arvlCd가 ARRIVED(1) 또는 ENTERING(0)
+ *
+ * #640 회귀 차단: lock 없는 trip은 애초에 runTrainCodeTracking에 도달하지 못한다.
+ * positions-fallback arrived(arvlCd=null)는 매역 알림 SSOT(arvlCd)와 다른 신호 →
+ * mismatch로 분류해 push 미발사 + 운영 가시성 카운트.
+ */
+export function evaluateArvlCdFireGate(
+  lock: BoardingLockMeta | undefined,
+  estimateArvlCd: number | null,
+  now: number,
+): 'fire' | 'mismatch' {
+  if (lock === undefined || lock.expiresAt <= now) return 'mismatch';
+  if (estimateArvlCd !== ARRIVAL_CODE.ARRIVED && estimateArvlCd !== ARRIVAL_CODE.ENTERING) {
+    return 'mismatch';
+  }
+  return 'fire';
+}
+
+/**
+ * #917 A2 — boardingLock trip에서 arvlCd∈{0,1} 신호 관측 시 매역 station-passed silent push 발사.
+ *
+ * 호출 시점: runTrainCodeTracking이 estimate.arrived=true를 얻은 직후 advanceBoardingLockWaypoint
+ * 진입 전. prereq 게이트(lock 활성 + arvlCd∈{0,1}) 통과 + dedup KV 미존재 시 발사.
+ *
+ * push 실패 분기 정책:
+ *   - APNs env mismatch self-heal은 reschedule push와 동일 (sendWithEnvHeal 재사용)
+ *   - 410 Unregistered / env exhausted 등 unrecoverable은 trip 자체 cleanup이 reschedule 경로의
+ *     maybeReschedulePush에서 처리되므로 본 함수는 그 분기를 만들지 않는다 — arvlCd fire는 trip
+ *     상태에 영향을 주지 않는 보조 신호로 한정 (waypoint advance / cleanup은 호출자 책임).
+ *   - 일반 실패는 stats.errors++ + log만 — dedup KV는 성공 시에만 stamp해 다음 cycle 재시도 허용.
+ *
+ * @returns cleanedUp=true는 token unrecoverable로 trip 폐기 신호 (호출자가 advance 스킵).
+ *          현재 정책상 cleanup 분기는 없고 항상 false 반환.
+ */
+export async function fireArvlCdStationPush(
+  trip: Trip,
+  waypoint: Waypoint,
+  lock: BoardingLockMeta,
+  arvlCd: number,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+  generatePushId: () => string,
+): Promise<{ dirty: boolean }> {
+  const key = arvlCdFireKey(trip.token, lock.trainCode, waypoint.stationName, arvlCd);
+  const existing = await env.TRIPS.get(key);
+  if (existing !== null) {
+    stats.arvlCdFireDedup += 1;
+    log('arvlcd-fire: dedup skip', {
+      token: trip.token.slice(0, 8),
+      trainCode: lock.trainCode,
+      station: waypoint.stationName,
+      arvlCd,
+    });
+    return { dirty: false };
+  }
+  const pushId = generatePushId();
+  log('arvlcd-fire: station-passed push', {
+    token: trip.token.slice(0, 8),
+    trainCode: lock.trainCode,
+    station: waypoint.stationName,
+    arvlCd,
+    kind: waypoint.kind,
+  });
+  const heal = await sendWithEnvHeal(
+    (host) =>
+      sendSilentPush({
+        deviceToken: trip.token,
+        payload: {
+          nextWaypoint: waypoint.stationName,
+          // arvlCd∈{0,1}은 "지금 진입/도착" 신호 — eta는 사실상 0.
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: waypoint.kind,
+          sentAt: now,
+          pushId,
+        },
+        config: deps.apnsConfig,
+        host,
+        fetchImpl: deps.fetchImpl,
+        now,
+      }),
+    trip.apnsEnv,
+    deps.apnsHosts,
+    log,
+    trip.token.slice(0, 8),
+  );
+  let dirty = false;
+  if (heal.correctedEnv) {
+    trip.apnsEnv = heal.correctedEnv;
+    dirty = true;
+    stats.envCorrected += 1;
+  }
+  if (!heal.result.ok) {
+    stats.errors += 1;
+    log('arvlcd-fire: push failed', {
+      status: heal.result.status,
+      reason: heal.result.reason,
+      token: trip.token.slice(0, 8),
+    });
+    // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
+    return { dirty };
+  }
+  stats.arvlCdFireSuccess += 1;
+  stats.pushed += 1;
+  // dedup stamp — 같은 cycle에서 Seoul API 갱신 지연으로 같은 신호가 재노출돼도 차단.
+  await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
+  return { dirty };
+}
+
 export async function runTrainCodeTracking(
   trip: Trip,
   waypoint: Waypoint,
@@ -625,6 +797,33 @@ export async function runTrainCodeTracking(
     // 정거장 도착은 가장 강한 신호 (실제 정차) — v=0/P=R_LOW로 drift 누적 차단.
     await writeKalmanState(env.TRIPS, trip.token, resetKalmanForArrival(now));
     stats.kalmanReset += 1;
+    // #917 A2 — 매역 알림 1차 source는 arvlCd∈{0(ENTERING), 1(ARRIVED)}.
+    // positions-fallback arrived(arvlCd=null)는 SSOT 다름 — mismatch로 분류해 push X.
+    // prereq 게이트: lock 활성 + arvlCd∈{0,1}. #640 회귀(lock 없는 trip 발사) defensive recheck.
+    const gate = evaluateArvlCdFireGate(activeLock, estimate.arvlCd, now);
+    if (gate === 'fire' && estimate.arvlCd !== null) {
+      const fire = await fireArvlCdStationPush(
+        trip,
+        waypoint,
+        activeLock,
+        estimate.arvlCd,
+        env,
+        deps,
+        stats,
+        now,
+        log,
+        generatePushId,
+      );
+      if (fire.dirty) await putTrip(env.TRIPS, trip);
+    } else {
+      stats.arvlCdFireMismatch += 1;
+      log('arvlcd-fire: mismatch (prereq failed)', {
+        token: trip.token.slice(0, 8),
+        trainCode: activeLock.trainCode,
+        station: waypoint.stationName,
+        arvlCd: estimate.arvlCd,
+      });
+    }
     await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
     return;
   }
@@ -675,7 +874,7 @@ export async function estimateBoardingLockArrival(
   lock: BoardingLockMeta,
   waypoint: Waypoint,
   now: number,
-): Promise<{ epoch: number; arrived: boolean } | null> {
+): Promise<{ epoch: number; arrived: boolean; arvlCd: number | null } | null> {
   const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
   const matched = arrivals.find((a) => a.trainCode === lock.trainCode);
   if (matched) {
@@ -683,6 +882,9 @@ export async function estimateBoardingLockArrival(
       epoch: now + matched.arrivalSeconds * 1000,
       arrived:
         matched.arvlCd === ARRIVAL_CODE.ARRIVED || matched.arvlCd === ARRIVAL_CODE.ENTERING,
+      // #917 A2 — 매역 알림 1차 source. arrivals 경로의 arvlCd를 호출자에게 노출해
+      // dedup key 구성 + position-fallback arrived와 구분(positions 경로는 arvlCd=null).
+      arvlCd: matched.arvlCd,
     };
   }
   const positions = await deps.seoul.fetchPositions(lock.line);
@@ -690,7 +892,9 @@ export async function estimateBoardingLockArrival(
   if (!train) return null;
   const fallback = estimateArrivalFromPosition(train, waypoint.stationName, lock, now);
   if (fallback.epoch === null) return null;
-  return { epoch: fallback.epoch, arrived: fallback.arrived };
+  // positions 경로의 arrived는 arvlCd가 아닌 sttus 신호 — 호출자가 arvlCd 매역 fire 분기를
+  // skip하도록 null 명시 (#917 A2 prereq guard).
+  return { epoch: fallback.epoch, arrived: fallback.arrived, arvlCd: null };
 }
 
 /**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx
+sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx,backend/**,backend/**/*


### PR DESCRIPTION
## 요약

Epic #912 (매역 알림 100% + 지하 100% 현재역) Phase A2 의 첫 PR. backend-only 슬라이스.

매역 알림의 1차 source 는 GPS 가 아니라 Seoul OpenAPI `realtimeArrivalList` 의 `arvlCd` (0=ENTERING / 1=ARRIVED) 라는 결정에 따라, backend cron 이 lock 된 trainCode 를 추적하다가 next waypoint 에서 그 trainCode 의 arvlCd∈{0,1} 첫 관찰 시 station-passed silent push 를 즉시 발사한다. 지하/지상 무관.

## 변경 사항

- `runTrainCodeTracking` arvlCd fire 분기 추가 (estimate.arrived=true + arvlCd∈{0,1} 시)
- `estimateBoardingLockArrival` 반환에 `arvlCd` 노출 (positions-fallback 은 null 명시)
- dedup KV: `arvlcd-fire:{token}|{trainCode}|{station}|{arvlCd}`, TTL 1h
  - token 포함으로 cross-trip silence leak 차단 (같은 train 다른 trip 시나리오)
- prereq 게이트 `evaluateArvlCdFireGate`: lock 활성 + arvlCd∈{0,1}
- 새 stats: `arvlCdFireSuccess` / `arvlCdFireDedup` / `arvlCdFireMismatch`
- `metrics.catalog.json` 3 entry 등록

## #640 회귀 가드 (review 포커스)

- **lock 없는 trip**: outer `isBoardingLockActive` 게이트가 `runTrainCodeTracking` 진입 자체 차단 → fire 경로 미진입. test 로 명시 확인.
- **lock 만료**: outer 게이트에서 lockMissing 으로 차단 + `evaluateArvlCdFireGate` defensive recheck (lock.expiresAt <= now → mismatch).
- **positions-fallback arrived(arvlCd=null)**: `estimate.arvlCd === null` → gate=mismatch → push X + `arvlCdFireMismatch++`. 매역 SSOT 가 arvlCd 가 아닌 sttus 신호이므로 fire 차단.
- **lock.trainCode vs arvlCd row trainCode mismatch**: `estimateBoardingLockArrival` 내부에서 `arrivals.find((a) => a.trainCode === lock.trainCode)` 로 이미 매칭 보장 — fire 경로에 도달하는 arvlCd 는 반드시 lock.trainCode 의 것.

## 테스트

- backend Vitest 802 통과 (24 신규)
- `arvlCdFireKey` / `evaluateArvlCdFireGate` 순수 함수 분리 + 단위 테스트
- runScheduled 통합 시나리오 (성공, dedup, mismatch, env self-heal, push 실패, destination kind, lock 만료, cross-trip 격리)
- type-check 회귀 없음

## 본 PR 제외 (후속)

- client `useStationAlarm` FG fast path effect — 별도 PR
- 실기기 측정: production 배포 후 `arvlCdFireSuccess` / `arvlCdFireDedup` ratio 관측 → false positive 0 confirm

Refs #917