### PR TITLE
feat(#915): destination-only baseline UX (C1 첫 PR)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -363,6 +363,19 @@ describe('useBoardingLockController', () => {
       expect(mockSetBoardingLock).not.toHaveBeenCalled();
       expect(useBoardingLockStore.getState().lock?.trainCode).toBe('OLD-1');
     });
+
+    it('createLock storage 실패 시 graceful — .catch가 swallow', async () => {
+      // storage 일시 실패 시뮬레이션. createLock 내부의 setBoardingLock이 throw하면
+      // useBoardingLockController의 .catch 분기로 흡수돼 다음 sync에서 자연 재시도.
+      mockSetBoardingLock.mockRejectedValueOnce(new Error('storage'));
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      // throw가 RN 외부로 새지 않으면 OK — 다음 fix에서 createLock이 다시 호출되도록 lock은 null 유지.
+      await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      expect(useBoardingLockStore.getState().lock).toBeNull();
+    });
   });
 
   describe('releaseLock', () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -250,6 +250,129 @@ describe('useBoardingLockController', () => {
     });
   });
 
+  // #915/#916 — backend autoLockCandidate hydrate. lockController가 createLock으로 위임.
+  describe('hydrateLockFromCandidate (#915/#916)', () => {
+    it('valid candidate + 컨텍스트 있음 → createLock 호출', async () => {
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      const lock = mockSetBoardingLock.mock.calls[0][0];
+      expect(lock).toMatchObject({
+        destinationId: 'dest-1',
+        trainCode: 'AUTO-7',
+        boardingLine: '2',
+        expectedDurationMs: 20 * 60_000,
+      });
+      // initialEtaSeconds는 자동 hydrate에선 미포함 (Seam A 지연 칩은 명시 탭 lock 한정).
+      expect(lock.initialEtaSeconds).toBeUndefined();
+    });
+
+    it('역명+line 매칭 시 boardingStationId 정정', async () => {
+      mockFindStationByNameAndLine.mockReturnValueOnce({ id: 'stn-A-line2', name: '강남', line: '2' });
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      expect(mockSetBoardingLock.mock.calls[0][0].boardingStationId).toBe('stn-A-line2');
+    });
+
+    it('역명 매칭 실패 → currentStation.id 폴백', async () => {
+      mockFindStationByNameAndLine.mockReturnValueOnce(null);
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      expect(mockSetBoardingLock.mock.calls[0][0].boardingStationId).toBe('stn-A');
+    });
+
+    it('expectedDurationMinutes null → fallback 30분', async () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, expectedDurationMinutes: null }),
+      );
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      expect(mockSetBoardingLock.mock.calls[0][0].expectedDurationMs).toBe(30 * 60_000);
+    });
+
+    it('destinationId null → no-op', async () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, destinationId: null }),
+      );
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('currentStation null → no-op', async () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, currentStation: null }),
+      );
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('candidate.line 무효 값 → no-op (graceful)', async () => {
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '99', subwayId: '1099' });
+      });
+      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('idempotent — 동일 trainCode + line이 이미 활성이면 재생성 안 함', async () => {
+      const existing: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: 'AUTO-7',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+      };
+      // loadLock(mount effect)이 store를 덮어쓰지 않도록 storage mock도 동일 lock 반환.
+      mockGetBoardingLock.mockResolvedValue(existing);
+      useBoardingLockStore.setState({ lock: existing });
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await waitFor(() => expect(useBoardingLockStore.getState().lock?.trainCode).toBe('AUTO-7'));
+      mockSetBoardingLock.mockClear();
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('lock 이미 존재 → 다른 trainCode candidate 와도 no-op (사용자 명시 lock overwrite 차단)', async () => {
+      const existing: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: 'OLD-1',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+      };
+      mockGetBoardingLock.mockResolvedValue(existing);
+      useBoardingLockStore.setState({ lock: existing });
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await waitFor(() => expect(useBoardingLockStore.getState().lock?.trainCode).toBe('OLD-1'));
+      mockSetBoardingLock.mockClear();
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'NEW-2', line: '2', subwayId: '1002' });
+      });
+      // 정책: lock 존재 시 hydrate no-op. 사용자가 picker 탭한 lock을 backend cron candidate가
+      // silently overwrite하지 않게 보호. swap은 createLockFromTrain으로 명시 호출.
+      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      expect(useBoardingLockStore.getState().lock?.trainCode).toBe('OLD-1');
+    });
+  });
+
   describe('releaseLock', () => {
     it('store releaseLock으로 위임 — storage clear', async () => {
       useBoardingLockStore.setState({

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -328,44 +328,36 @@ describe('useBoardingLockController', () => {
       expect(mockSetBoardingLock).not.toHaveBeenCalled();
     });
 
-    it('idempotent — 동일 trainCode + line이 이미 활성이면 재생성 안 함', async () => {
+    // hydrate no-op 케이스 공통 시드 — existing lock과 candidate trainCode만 다른 두 분기.
+    async function seedExistingAndHydrate(opts: {
+      existingTrainCode: string;
+      candidateTrainCode: string;
+    }) {
       const existing: BoardingLock = {
         destinationId: 'dest-1',
-        trainCode: 'AUTO-7',
+        trainCode: opts.existingTrainCode,
         boardingStationId: 'stn-A',
         boardingLine: '2',
         boardedAt: Date.now(),
         expectedDurationMs: 600_000,
       };
-      // loadLock(mount effect)이 store를 덮어쓰지 않도록 storage mock도 동일 lock 반환.
       mockGetBoardingLock.mockResolvedValue(existing);
       useBoardingLockStore.setState({ lock: existing });
       const { result } = renderHook(() => useBoardingLockController(defaultInputs));
-      await waitFor(() => expect(useBoardingLockStore.getState().lock?.trainCode).toBe('AUTO-7'));
+      await waitFor(() => expect(useBoardingLockStore.getState().lock?.trainCode).toBe(opts.existingTrainCode));
       mockSetBoardingLock.mockClear();
       await act(async () => {
-        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        result.current.hydrateLockFromCandidate({ trainCode: opts.candidateTrainCode, line: '2', subwayId: '1002' });
       });
+    }
+
+    it('idempotent — 동일 trainCode + line이 이미 활성이면 재생성 안 함', async () => {
+      await seedExistingAndHydrate({ existingTrainCode: 'AUTO-7', candidateTrainCode: 'AUTO-7' });
       expect(mockSetBoardingLock).not.toHaveBeenCalled();
     });
 
     it('lock 이미 존재 → 다른 trainCode candidate 와도 no-op (사용자 명시 lock overwrite 차단)', async () => {
-      const existing: BoardingLock = {
-        destinationId: 'dest-1',
-        trainCode: 'OLD-1',
-        boardingStationId: 'stn-A',
-        boardingLine: '2',
-        boardedAt: Date.now(),
-        expectedDurationMs: 600_000,
-      };
-      mockGetBoardingLock.mockResolvedValue(existing);
-      useBoardingLockStore.setState({ lock: existing });
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
-      await waitFor(() => expect(useBoardingLockStore.getState().lock?.trainCode).toBe('OLD-1'));
-      mockSetBoardingLock.mockClear();
-      await act(async () => {
-        result.current.hydrateLockFromCandidate({ trainCode: 'NEW-2', line: '2', subwayId: '1002' });
-      });
+      await seedExistingAndHydrate({ existingTrainCode: 'OLD-1', candidateTrainCode: 'NEW-2' });
       // 정책: lock 존재 시 hydrate no-op. 사용자가 picker 탭한 lock을 backend cron candidate가
       // silently overwrite하지 않게 보호. swap은 createLockFromTrain으로 명시 호출.
       expect(mockSetBoardingLock).not.toHaveBeenCalled();

--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -289,6 +289,116 @@ describe('useBoardingLockSync (#901)', () => {
     expect(mockedSync).toHaveBeenCalledTimes(1);
   });
 
+  // #915/#916 — backend autoLockCandidate를 호출자 콜백으로 전달.
+  describe('onAutoLockCandidate (#915/#916)', () => {
+    it('응답에 autoLockCandidate 있음 → 콜백 호출', async () => {
+      mockedSync.mockResolvedValueOnce({
+        ok: true,
+        advanced: false,
+        currentWaypoint: '역삼',
+        nextStation: '역삼',
+        autoLockCandidate: { trainCode: 'AUTO-7', line: '2', subwayId: '1002' },
+      });
+      const onAutoLockCandidate = jest.fn();
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          onAutoLockCandidate,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(onAutoLockCandidate).toHaveBeenCalledWith({
+        trainCode: 'AUTO-7',
+        line: '2',
+        subwayId: '1002',
+      });
+    });
+
+    it('응답에 autoLockCandidate 없음(null) → 콜백 미호출', async () => {
+      mockedSync.mockResolvedValueOnce({
+        ok: true,
+        advanced: false,
+        currentWaypoint: '역삼',
+        nextStation: '역삼',
+        autoLockCandidate: null,
+      });
+      const onAutoLockCandidate = jest.fn();
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          onAutoLockCandidate,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(onAutoLockCandidate).not.toHaveBeenCalled();
+    });
+
+    it('ok=false 응답 → autoLockCandidate 있어도 콜백 미호출 (graceful)', async () => {
+      mockedSync.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        autoLockCandidate: { trainCode: 'AUTO-7', line: '2', subwayId: '1002' },
+      });
+      const onAutoLockCandidate = jest.fn();
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          onAutoLockCandidate,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(onAutoLockCandidate).not.toHaveBeenCalled();
+    });
+
+    it('force-trigger 경로도 콜백 호출', async () => {
+      mockedSync.mockResolvedValueOnce({
+        ok: true,
+        autoLockCandidate: { trainCode: 'AUTO-X', line: '2', subwayId: '1002' },
+      });
+      const onAutoLockCandidate = jest.fn();
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          forceTriggerKey: 'k1',
+          onAutoLockCandidate,
+        }),
+      );
+      await flushAsyncStorage();
+      expect(onAutoLockCandidate).toHaveBeenCalledWith({
+        trainCode: 'AUTO-X',
+        line: '2',
+        subwayId: '1002',
+      });
+    });
+
+    it('콜백 미제공 + autoLockCandidate 응답 → graceful (throw 없음)', async () => {
+      mockedSync.mockResolvedValueOnce({
+        ok: true,
+        autoLockCandidate: { trainCode: 'AUTO-7', line: '2', subwayId: '1002' },
+      });
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await expect(flushAsyncStorage()).resolves.toBeUndefined();
+    });
+  });
+
   it('debounce timer cleanup — unmount 시 미발사', async () => {
     const { unmount } = renderHook(() =>
       useBoardingLockSync({

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -13,9 +13,10 @@ import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { Route } from '../../../shared/utils/stationRoute';
-import type { Station } from '../../../shared/types/station';
+import type { LineNumber, Station } from '../../../shared/types/station';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../../../shared/constants/boardingLock';
+import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
 
 export interface UseBoardingLockControllerInputs {
   destinationId: string | null;
@@ -36,8 +37,28 @@ export interface UseBoardingLockControllerResult {
   directionalArrivals: ArrivalInfo[];
   /** 사용자가 도착 list에서 열차 탭 시 호출. lock 생성을 위한 컨텍스트가 부족하면 no-op. */
   createLockFromTrain: (train: ArrivalInfo) => void;
+  /**
+   * #915/#916 — backend `/boarding-lock/sync` 응답의 autoLockCandidate로 lock을 hydrate.
+   * destination-only baseline UX에서 사용자가 명시 탭하지 않아도 backend cron이 trainCode를
+   * 결정하면 client store에 반영해 lock UX 활성화한다.
+   *
+   * idempotent: 이미 같은 trainCode + boardingLine으로 활성 lock이 있으면 no-op.
+   * lock 생성을 위한 컨텍스트(destinationId / currentStation / line valid) 부족 시 no-op.
+   */
+  hydrateLockFromCandidate: (candidate: AutoLockCandidate) => void;
   /** 명시 하차. lock 없는 상태에서 호출돼도 안전. */
   releaseLock: () => void;
+}
+
+/**
+ * #915 — backend candidate.line(string)이 LineNumber valid 값인지 narrow.
+ * 미정합이면 hydrate skip — 호출자는 graceful로 lock 없는 상태 유지.
+ */
+const VALID_LINES: ReadonlyArray<LineNumber> = [
+  '1', '2', '3', '4', '5', '6', '7', '8', '9', 'airport', 'gyeongui', 'bundang', 'sinbundang',
+];
+function asLineNumber(raw: string): LineNumber | null {
+  return (VALID_LINES as ReadonlyArray<string>).includes(raw) ? (raw as LineNumber) : null;
 }
 
 /**
@@ -135,10 +156,42 @@ export function useBoardingLockController({
     void releaseLock();
   }, [releaseLock]);
 
+  // #915/#916 — backend autoLockCandidate를 받아 client BoardingLock store hydrate.
+  // hydrate 정책: lock이 이미 존재하면 항상 no-op.
+  //  - 사용자가 BoardingTrainList에서 명시 탭한 lock을 backend cron candidate(다른 trainCode 가능)가
+  //    silently overwrite하지 않게 보호 (#915 self code-review).
+  //  - destination 변경 시 controller의 stale-lock release effect가 lock=null로 만든 후에야 hydrate.
+  //  - 자동 lock도 한 번 잡히면 변경 X (Seam F swap은 backend cron이 trip.boardingLock을 갱신하고
+  //    silent push로 client store가 hydrate되는 별 경로).
+  const hydrateLockFromCandidate = useCallback(
+    (candidate: AutoLockCandidate) => {
+      if (!destinationId || !currentStation) return;
+      const boardingLine = asLineNumber(candidate.line);
+      if (!boardingLine) return;
+      if (lock) return;
+      const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
+      // boardingStationId는 createLockFromTrain과 동일하게 (역명, candidate.line) 매칭 정정.
+      const correctedStation = findStationByNameAndLine(currentStation.name, boardingLine);
+      const boardingStationId = correctedStation?.id ?? currentStation.id;
+      void createLock({
+        destinationId,
+        trainCode: candidate.trainCode,
+        boardingStationId,
+        boardingLine,
+        boardedAt: Date.now(),
+        expectedDurationMs: durationMin * 60_000,
+        // initialEtaSeconds는 candidate에 없음 — Seam A 지연 칩은 cron이 채워둔 lock 메타로 노출되지 않으며,
+        // 사용자가 명시 탭한 lock에서만 노출되는 게 의도(자동 lock은 정확도가 보장 안 됨).
+      });
+    },
+    [destinationId, currentStation, expectedDurationMinutes, lock, createLock],
+  );
+
   return {
     lock,
     directionalArrivals,
     createLockFromTrain,
+    hydrateLockFromCandidate,
     releaseLock: release,
   };
 }

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -173,7 +173,7 @@ export function useBoardingLockController({
       // boardingStationId는 createLockFromTrain과 동일하게 (역명, candidate.line) 매칭 정정.
       const correctedStation = findStationByNameAndLine(currentStation.name, boardingLine);
       const boardingStationId = correctedStation?.id ?? currentStation.id;
-      void createLock({
+      createLock({
         destinationId,
         trainCode: candidate.trainCode,
         boardingStationId,
@@ -182,6 +182,8 @@ export function useBoardingLockController({
         expectedDurationMs: durationMin * 60_000,
         // initialEtaSeconds는 candidate에 없음 — Seam A 지연 칩은 cron이 채워둔 lock 메타로 노출되지 않으며,
         // 사용자가 명시 탭한 lock에서만 노출되는 게 의도(자동 lock은 정확도가 보장 안 됨).
+      }).catch(() => {
+        // store action rejection은 graceful — loadLock race / storage 일시 실패는 다음 sync에서 자연 재시도.
       });
     },
     [destinationId, currentStation, expectedDurationMinutes, lock, createLock],

--- a/src/features/alarm/hooks/useBoardingLockSync.ts
+++ b/src/features/alarm/hooks/useBoardingLockSync.ts
@@ -21,7 +21,7 @@
 import { useEffect, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
-import { syncBoardingLock } from '../../nearest-station/api/boardingLockSync';
+import { syncBoardingLock, type AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useBoardingLockSync');
@@ -52,6 +52,14 @@ export interface UseBoardingLockSyncOptions {
   forceTriggerKey?: string | null;
   /** Seam G subsurface 신호 (옵션) — backend 로그에 진단 라벨로 첨부. */
   subsurface?: boolean;
+  /**
+   * #915/#916 A1 — backend 응답에서 autoLockCandidate를 받으면 호출. 호출자는 이 콜백에서
+   * useBoardingLockStore.createLock으로 hydrate해 사용자 명시 탭 없이 lock UX 활성화한다.
+   *
+   * candidate가 null인 응답은 콜백 호출 안 함(콜백은 candidate 존재 신호 전용).
+   * 같은 trainCode 중복 hydrate는 호출자가 store level에서 idempotent 판단.
+   */
+  onAutoLockCandidate?: (candidate: AutoLockCandidate) => void;
 }
 
 /**
@@ -64,11 +72,26 @@ export function useBoardingLockSync({
   tripActive,
   forceTriggerKey,
   subsurface,
+  onAutoLockCandidate,
 }: UseBoardingLockSyncOptions): void {
   // 이미 보낸 currentStation을 기억해 debounce 안의 중복 발사를 방지.
   const lastSentStationRef = useRef<string | null>(null);
   // forceTriggerKey 이전 값 — 같은 key 재전달 시 no-op 판정용.
   const lastForceKeyRef = useRef<string | null>(null);
+  // #915 — 매 렌더 새 함수일 가능성 → ref로 latest 보관해 effect deps churn 회피.
+  const onAutoLockCandidateRef = useRef(onAutoLockCandidate);
+  useEffect(() => {
+    onAutoLockCandidateRef.current = onAutoLockCandidate;
+  }, [onAutoLockCandidate]);
+
+  // tripActive false → true 전환 시 lastSent ref들을 리셋. 새 trip의 첫 currentStationName이
+  // 이전 trip의 마지막 station과 같아도 첫 sync가 발사되도록 보장 (#915 self code-review C4).
+  useEffect(() => {
+    if (!tripActive) {
+      lastSentStationRef.current = null;
+      lastForceKeyRef.current = null;
+    }
+  }, [tripActive]);
 
   // 1) currentStationName 변경 debounce 트리거.
   useEffect(() => {
@@ -88,6 +111,7 @@ export function useBoardingLockSync({
         accuracy: accuracyMeters,
         subsurface,
         reason: 'station-change',
+        onAutoLockCandidate: onAutoLockCandidateRef.current,
       });
     }, SYNC_DEBOUNCE_MS);
 
@@ -115,6 +139,7 @@ export function useBoardingLockSync({
       accuracy: accuracyMeters,
       subsurface,
       reason: 'force-trigger',
+      onAutoLockCandidate: onAutoLockCandidateRef.current,
     });
   }, [tripActive, forceTriggerKey, currentStationName, accuracyMeters, subsurface]);
 }
@@ -124,11 +149,13 @@ interface FireSyncInput {
   accuracy: number;
   subsurface?: boolean;
   reason: 'station-change' | 'force-trigger';
+  onAutoLockCandidate?: (candidate: AutoLockCandidate) => void;
 }
 
 /**
  * AsyncStorage에서 token을 읽어 syncBoardingLock 호출. token/trip 부재는 graceful no-op.
- * 호출 결과는 무시(throw하지 않음) — 정정 응답은 호출자 store를 mutate하지 않는다.
+ * 응답의 autoLockCandidate(#916)는 호출자 콜백으로 전달 — 정정 자체(currentWaypoint)는
+ * cron silent push 경로가 별도로 client store를 mutate한다.
  */
 async function fireSync(input: FireSyncInput): Promise<void> {
   const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
@@ -149,6 +176,11 @@ async function fireSync(input: FireSyncInput): Promise<void> {
     reason: input.reason,
     advanced: res.advanced ?? false,
     currentWaypoint: res.currentWaypoint ?? null,
+    autoLockCandidate: res.autoLockCandidate?.trainCode ?? null,
     ok: res.ok,
   });
+  // #915/#916 — backend가 자동/명시 lock 메타를 노출했으면 호출자에 전달. null이면 미호출.
+  if (res.ok && res.autoLockCandidate) {
+    input.onAutoLockCandidate?.(res.autoLockCandidate);
+  }
 }

--- a/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
+++ b/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
@@ -9,15 +9,15 @@ jest.mock('../../../../shared/utils/logger', () => ({
   }),
 }));
 
-const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
-  global.fetch = jest.fn();
+  globalThis.fetch = jest.fn();
 });
 
 afterEach(() => {
-  global.fetch = ORIGINAL_FETCH;
+  globalThis.fetch = ORIGINAL_FETCH;
 });
 
 describe('syncBoardingLock (#901)', () => {
@@ -31,12 +31,12 @@ describe('syncBoardingLock (#901)', () => {
   it('URL 미설정 → skipped=true, fetch 미호출', async () => {
     const r = await syncBoardingLock(basePayload);
     expect(r).toEqual({ ok: false, skipped: true });
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it('정상 200 — body parse 후 currentWaypoint/nextStation/advanced 반환', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: () =>
@@ -56,7 +56,7 @@ describe('syncBoardingLock (#901)', () => {
       nextStation: '역삼',
       autoLockCandidate: null,
     });
-    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
     expect(url).toBe('https://api.test.dev/boarding-lock/sync');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toEqual(basePayload);
@@ -64,7 +64,7 @@ describe('syncBoardingLock (#901)', () => {
 
   it('#915/#916 — autoLockCandidate 응답 forward', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: () =>
@@ -82,33 +82,33 @@ describe('syncBoardingLock (#901)', () => {
 
   it('subsurface 옵션 필드 forward', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: () => Promise.resolve({ ok: true, advanced: false, currentWaypoint: '강남' }),
     });
     await syncBoardingLock({ ...basePayload, subsurface: false });
-    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
     expect(JSON.parse(init.body).subsurface).toBe(false);
   });
 
   it('non-OK status → ok=false + status', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });
     const r = await syncBoardingLock(basePayload);
     expect(r).toEqual({ ok: false, status: 404 });
   });
 
   it('fetch reject → ok=false', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (global.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
     const r = await syncBoardingLock(basePayload);
     expect(r).toEqual({ ok: false });
   });
 
   it('200이지만 json parse 실패 → fallback null 값 반환', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: () => Promise.reject(new Error('bad json')),
@@ -126,7 +126,7 @@ describe('syncBoardingLock (#901)', () => {
 
   it('200이지만 응답 필드 누락 → defaults (false / null / null)', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: () => Promise.resolve({}),
@@ -144,19 +144,19 @@ describe('syncBoardingLock (#901)', () => {
 
   it('trailing slash trim', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: () => Promise.resolve({ ok: true }),
     });
     await syncBoardingLock(basePayload);
-    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    const [url] = (globalThis.fetch as jest.Mock).mock.calls[0];
     expect(url).toBe('https://api.test.dev/boarding-lock/sync');
   });
 
   it('타임아웃 — abort 후 ok=false', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (global.fetch as jest.Mock).mockImplementation(
+    (globalThis.fetch as jest.Mock).mockImplementation(
       (_url: string, init: { signal: AbortSignal }) =>
         new Promise((_, reject) => {
           init.signal.addEventListener('abort', () => reject(new Error('aborted')));

--- a/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
+++ b/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
@@ -54,11 +54,30 @@ describe('syncBoardingLock (#901)', () => {
       advanced: true,
       currentWaypoint: '역삼',
       nextStation: '역삼',
+      autoLockCandidate: null,
     });
     const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
     expect(url).toBe('https://api.test.dev/boarding-lock/sync');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toEqual(basePayload);
+  });
+
+  it('#915/#916 — autoLockCandidate 응답 forward', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          advanced: false,
+          currentWaypoint: '역삼',
+          nextStation: '역삼',
+          autoLockCandidate: { trainCode: '7246', line: '2', subwayId: '1002' },
+        }),
+    });
+    const r = await syncBoardingLock(basePayload);
+    expect(r.autoLockCandidate).toEqual({ trainCode: '7246', line: '2', subwayId: '1002' });
   });
 
   it('subsurface 옵션 필드 forward', async () => {
@@ -101,6 +120,7 @@ describe('syncBoardingLock (#901)', () => {
       advanced: false,
       currentWaypoint: null,
       nextStation: null,
+      autoLockCandidate: null,
     });
   });
 
@@ -118,6 +138,7 @@ describe('syncBoardingLock (#901)', () => {
       advanced: false,
       currentWaypoint: null,
       nextStation: null,
+      autoLockCandidate: null,
     });
   });
 

--- a/src/features/nearest-station/api/boardingLockSync.ts
+++ b/src/features/nearest-station/api/boardingLockSync.ts
@@ -35,6 +35,17 @@ export interface BoardingLockSyncPayload {
 }
 
 /**
+ * #916 A1 — backend cron이 자동 lock을 부착했을 때 노출하는 후보 메타.
+ * Client는 이 값으로 boardingLock store를 hydrate해 사용자가 직접 BoardingTrainList에서
+ * 열차를 탭하지 않아도 trainCode 추적이 활성화된다 (#915 destination-only baseline UX).
+ */
+export interface AutoLockCandidate {
+  trainCode: string;
+  line: string;
+  subwayId: string;
+}
+
+/**
  * Seam E response. 호출자는 `currentWaypoint`로 client store(useBoardingLockStore 등)에
  * 정정 결과를 반영할 수 있다. waypoints가 비면(`null`) destination 도착.
  */
@@ -46,6 +57,11 @@ export interface BoardingLockSyncResponse {
   currentWaypoint?: string | null;
   /** currentWaypoint와 동일 — 의미상 alias (다음 알람 대상). */
   nextStation?: string | null;
+  /**
+   * #916 A1 — backend가 trip에 부착한 자동/명시 lock 메타. 없으면 null.
+   * Client는 이 값을 useBoardingLockStore에 hydrate해 사용자 명시 탭 없이도 lock UX 활성화.
+   */
+  autoLockCandidate?: AutoLockCandidate | null;
   /** HTTP 실패/skip을 호출자가 진단할 수 있게 노출 — graceful (throw 아님). */
   skipped?: boolean;
   status?: number;
@@ -84,6 +100,7 @@ export async function syncBoardingLock(
       advanced: json?.advanced ?? false,
       currentWaypoint: json?.currentWaypoint ?? null,
       nextStation: json?.nextStation ?? null,
+      autoLockCandidate: json?.autoLockCandidate ?? null,
     };
   } catch (e) {
     log.warn('boarding-lock sync error', e);

--- a/src/features/settings/store/__tests__/useSettingsStore.test.ts
+++ b/src/features/settings/store/__tests__/useSettingsStore.test.ts
@@ -11,7 +11,8 @@ describe('useSettingsStore', () => {
       sleepMode: false,
       allowSpeaker: true,
       accessibilityMode: false,
-      locklessStationPassed: false,
+      // #915 — default ON. 각 테스트가 명시적으로 false로 덮어쓸 수 있다.
+      locklessStationPassed: true,
     });
     jest.clearAllMocks();
   });
@@ -129,13 +130,23 @@ describe('useSettingsStore', () => {
     expect(useSettingsStore.getState().accessibilityMode).toBe(false);
   });
 
-  // ── #816 C — locklessStationPassed opt-in 토글 (기본 OFF) ──
+  // ── #816 C / #915 — locklessStationPassed (기본 ON, destination-only baseline) ──
 
-  it('초기 locklessStationPassed는 false이다', () => {
+  it('초기 locklessStationPassed는 true이다 (#915 default ON)', () => {
+    expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
+  });
+
+  it('setLocklessStationPassed: false를 설정하면 상태와 AsyncStorage가 갱신된다', async () => {
+    await useSettingsStore.getState().setLocklessStationPassed(false);
     expect(useSettingsStore.getState().locklessStationPassed).toBe(false);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:lockless-station-passed',
+      JSON.stringify(false),
+    );
   });
 
   it('setLocklessStationPassed: true를 설정하면 상태와 AsyncStorage가 갱신된다', async () => {
+    useSettingsStore.setState({ locklessStationPassed: false });
     await useSettingsStore.getState().setLocklessStationPassed(true);
     expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
@@ -144,21 +155,21 @@ describe('useSettingsStore', () => {
     );
   });
 
-  it('loadLocklessStationPassed: 저장된 true를 복원한다', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(true));
+  it('loadLocklessStationPassed: 저장된 false를 복원한다 (기존 사용자 명시 OFF 보존)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(false));
+    await useSettingsStore.getState().loadLocklessStationPassed();
+    expect(useSettingsStore.getState().locklessStationPassed).toBe(false);
+  });
+
+  it('loadLocklessStationPassed: 저장된 값이 없으면 기본 true 유지 (#915)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
     await useSettingsStore.getState().loadLocklessStationPassed();
     expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
   });
 
-  it('loadLocklessStationPassed: 저장된 값이 없으면 기본 false 유지', async () => {
-    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
-    await useSettingsStore.getState().loadLocklessStationPassed();
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(false);
-  });
-
-  it('loadLocklessStationPassed: AsyncStorage 오류 시 false 유지', async () => {
+  it('loadLocklessStationPassed: AsyncStorage 오류 시 true 유지', async () => {
     (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
     await useSettingsStore.getState().loadLocklessStationPassed();
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(false);
+    expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
   });
 });

--- a/src/features/settings/store/useSettingsStore.ts
+++ b/src/features/settings/store/useSettingsStore.ts
@@ -30,8 +30,9 @@ export interface SettingsState {
 
   /**
    * #816 C — BoardingLock 없는 trip에서도 station-passed(intermediate) 알림을 받을지 여부.
-   * 기본 OFF. ON 시 useApnsTripRegistration이 backend trip register payload에 포함시키고,
-   * backend가 lockless intermediate 발사를 허용한다.
+   * 기본 ON (#915 — destination-only baseline). ON 시 useApnsTripRegistration이 backend trip register
+   * payload에 포함시키고, backend가 lockless intermediate 발사를 허용한다. 사용자가 명시적으로 OFF
+   * 하지 않는 한 zero-config baseline UX를 위해 매역 알림이 자동 동작한다.
    */
   locklessStationPassed: boolean;
   setLocklessStationPassed: (enabled: boolean) => Promise<void>;
@@ -42,7 +43,8 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   sleepMode: false,
   allowSpeaker: true,
   accessibilityMode: false,
-  locklessStationPassed: false,
+  // #915 — destination-only baseline UX. 매역 알림이 zero-config로 동작하도록 default ON.
+  locklessStationPassed: true,
 
   setSleepMode: async (enabled: boolean) => {
     set({ sleepMode: enabled });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -44,6 +44,7 @@ import { useBoardingLockController } from '../features/alarm/hooks/useBoardingLo
 import { useBoardingLockScheduler } from '../features/alarm/hooks/useBoardingLockScheduler';
 import { useBoardingLockAdvancer } from '../features/alarm/hooks/useBoardingLockAdvancer';
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
+import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
 import { Toast } from '../shared/ui/Toast';
@@ -256,6 +257,7 @@ export default function HomeScreen() {
     lock: boardingLock,
     directionalArrivals,
     createLockFromTrain,
+    hydrateLockFromCandidate,
     releaseLock: releaseBoardingLock,
   } = useBoardingLockController({
     destinationId: destination?.id ?? null,
@@ -264,6 +266,16 @@ export default function HomeScreen() {
     arrival,
     currentStation: result?.station ?? null,
     expectedDurationMinutes: staticEtaMinutes,
+  });
+  // #915 (C1 destination-only baseline UX) — destination 설정 직후 backend로 좋은 fix sync 발사.
+  // backend cron이 9단 게이트 통과 시 autoLockCandidate 응답에 부착(#916) → 사용자 명시 탭 없이
+  // boardingLock hydrate. lock 활성 여부와 무관하게 trip 활성 동안 폴링.
+  useBoardingLockSync({
+    currentStationName: result?.station.name ?? null,
+    accuracyMeters: accuracyMeters ?? null,
+    tripActive: Boolean(destination && route),
+    subsurface: barometerSubsurface,
+    onAutoLockCandidate: hydrateLockFromCandidate,
   });
   useBoardingLockScheduler({
     lock: boardingLock,


### PR DESCRIPTION
## Summary
Epic #912 P0 C1. "destination 설정 → 즉시 매역 알림" zero-config baseline.

- `HomeScreen.tsx`: `useBoardingLockSync(tripActive=true)` wire — destination 설정 즉시 backend `/boarding-lock/sync` POST, 응답의 `autoLockCandidate`(#916)로 client lock hydrate
- `useBoardingLockController.ts`:
  - `hydrateLockFromCandidate`: 사용자 명시 lock overwrite 차단 정책 (`if (lock) return`)
- `useBoardingLockSync.ts`:
  - `onAutoLockCandidate` ref useEffect deps 명시 (A6)
  - `tripActive` false → true 전환 시 `lastSentStationRef` / `lastForceKeyRef` 리셋 — 새 trip 첫 sync 보장
- `useSettingsStore.ts`: `locklessStationPassed` default `true` (기존 사용자 명시 OFF 값은 AsyncStorage에서 보존)
- `boardingLockSync.ts` 응답 타입에 `autoLockCandidate` 노출

## Self code-review 결과
- **C2 (manual lock overwrite)**: hydrate가 lock 존재 시 항상 no-op → fix
- **C4 (lastSent stale)**: tripActive false 전환에 ref 리셋 effect 추가 → fix
- **A6 (effect deps)**: 명시 deps 추가 → fix
- **A1 (destinationId 부재)**: C2 fix(any lock 존재 시 no-op)로 자동 해소

## 슬라이싱 의도 (Refs #915)
**본 PR 제외, 후속 PR 예정**:
- 자동 lock 실패 시 BoardingTrainList 작은 칩/배너 UI redesign
- `locklessStationPassed` 토글 SettingsScreen 제거
- 신규 사용자 onboarding flow 정렬

## Test plan
- [x] `npm test` 통과 (207 suites, 3727 tests, 100% coverage)
- [x] `npm run type-check` 통과

Refs #912
Refs #915