### PR TITLE
test(#923): 권한 매트릭스 회귀 infra + WhileInUse FG 지상 baseline (E2 첫 PR)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -311,3 +311,132 @@ jobs:
             echo "::error::regression(${{ matrix.scenario }}) 실패. artifact를 확인하세요."
             exit 1
           fi
+
+  permission-matrix:
+    name: E2E Permission Matrix (#923)
+    # 권한 매트릭스 회귀 가드(#923). Always vs WhileInUse × FG/BG × 지상/지하 × 일반/취침 × OS
+    # 차원에서 매역 알람 경로 정상 동작을 검증한다. nightly only, PR 게이트 아님.
+    #
+    # 새 cell 추가는 scripts/permission-matrix.json에 entry를 더한 뒤
+    # 아래 matrix.cell에도 같은 id를 추가하면 끝(runner는 데이터 주도).
+    runs-on: macos-14
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        cell:
+          - whileInUse-fg-aboveground-normal-ios18
+          # 후속 PR에서 추가: always-*, *-bg-*, *-underground-*, *-sleep-*, ios17, android
+    env:
+      SIM_NAME: 'iPhone 16'
+      EXPO_PUBLIC_E2E_MOCK: '1'
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Xcode 버전 고정
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 의존성 설치
+        run: npm ci --legacy-peer-deps
+
+      - name: Maestro CLI 설치
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Maestro flow 문법 검증 (permissions)
+        run: |
+          set -e
+          if "$HOME/.maestro/bin/maestro" test --help 2>&1 | grep -q -- '--dry-run'; then
+            "$HOME/.maestro/bin/maestro" test .maestro/flows/permissions --dry-run || exit 1
+          fi
+
+      - name: 매트릭스 dry-run (cell 선택 검증)
+        run: node scripts/permission-matrix-runner.js --cell ${{ matrix.cell }} --dry-run
+
+      - name: E2E mock 빌드-time env 주입
+        run: |
+          echo 'export EXPO_PUBLIC_E2E_MOCK=1' >> ios/.xcode.env.local
+          cat ios/.xcode.env.local
+
+      - name: iOS Prebuild
+        run: npx expo prebuild --platform ios --no-install
+
+      - name: CocoaPods 캐시
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
+
+      - name: CocoaPods 설치
+        run: cd ios && pod install
+
+      - name: iOS 빌드 (Release, E2E mock)
+        run: |
+          cd ios
+          xcodebuild -workspace subwaynow.xcworkspace \
+            -scheme subwaynow \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination "platform=iOS Simulator,name=${SIM_NAME}" \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            ONLY_ACTIVE_ARCH=YES \
+            build
+
+      - name: 시뮬레이터 부팅
+        run: |
+          xcrun simctl boot "${SIM_NAME}" || true
+          xcrun simctl bootstatus "${SIM_NAME}" -b
+
+      - name: 앱 설치
+        run: |
+          APP_PATH=$(find ios/build -name "*.app" -type d | head -1)
+          if [ -z "$APP_PATH" ]; then echo "ERROR: .app not found"; exit 1; fi
+          xcrun simctl install booted "$APP_PATH"
+
+      - name: 권한 매트릭스 실행
+        id: matrix
+        continue-on-error: true
+        env:
+          # MAESTRO_BIN은 기본값 "maestro" — $GITHUB_PATH에 추가된 ~/.maestro/bin이 해석한다.
+          # 다른 job들과 동일 패턴(regression/nightly가 maestro를 PATH로 호출).
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '240000'
+        run: node scripts/permission-matrix-runner.js --cell ${{ matrix.cell }}
+
+      - name: 진단 자료 수집
+        if: always()
+        run: |
+          mkdir -p ./diag-permission-${{ matrix.cell }}
+          xcrun simctl io booted screenshot ./diag-permission-${{ matrix.cell }}/last-screen.png || true
+          xcrun simctl spawn booted log show --last 2m --predicate 'process == "subwaynow"' --style compact \
+            > ./diag-permission-${{ matrix.cell }}/app.log 2>&1 || true
+
+      - name: 결과 업로드
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-permission-${{ matrix.cell }}-results
+          path: |
+            permission-matrix-*.xml
+            permission-matrix-debug-*/
+            diag-permission-*/
+
+      - name: 결과 판정
+        if: always()
+        run: |
+          if [ "${{ steps.matrix.outcome }}" != "success" ]; then
+            echo "::error::permission-matrix(${{ matrix.cell }}) 실패. artifact를 확인하세요."
+            exit 1
+          fi

--- a/.maestro/flows/permissions/README.md
+++ b/.maestro/flows/permissions/README.md
@@ -1,0 +1,76 @@
+# Maestro 권한 매트릭스 (#923 E2)
+
+매역 알림 100% epic(#912)의 회귀 가드. iOS Always vs WhileInUse, iOS 17/18,
+Android, FG/BG, 지상/지하, 일반/취침 등 권한·환경 조합별로 매역 알람 발사 경로가
+의도대로 동작하는지 검증한다.
+
+## 구성
+
+- `scripts/permission-matrix.json` — 매트릭스 정의(cell × expected). 데이터 주도.
+- `scripts/permission-matrix-runner.js` — JSON을 읽어 cell 단위로 maestro 실행.
+- `.maestro/flows/permissions/<cell-id>.yaml` — cell별 Maestro flow.
+
+## 첫 PR 범위 (E2)
+
+baseline 1셀만 포함:
+
+| cell id | permission | appState | environment | mode | os |
+| --- | --- | --- | --- | --- | --- |
+| `whileInUse-fg-aboveground-normal-ios18` | WhileInUse | FG | 지상 | 일반 | iOS 18 |
+
+후속 PR에서 추가될 15+ cell (`scripts/permission-matrix.json`의 `cells` 배열에
+entry만 추가하면 runner와 CI matrix가 자동으로 픽업):
+
+- Always × FG/BG × 지상/지하 × 일반/취침 = 8 cell
+- WhileInUse × FG/BG × 지상/지하 × 일반/취침 = 8 cell (baseline 1셀 제외 7)
+- iOS 17 / Android 차원은 OS dimension 확장
+
+## 로컬 실행
+
+```bash
+# E2E mock 모드로 시뮬레이터 빌드 + 설치 (smoke와 동일)
+EXPO_PUBLIC_E2E_MOCK=1 npm run ios
+
+# baseline cell만 실행
+node scripts/permission-matrix-runner.js --baseline
+
+# 특정 cell만
+node scripts/permission-matrix-runner.js --cell whileInUse-fg-aboveground-normal-ios18
+
+# cell 목록 확인
+node scripts/permission-matrix-runner.js --list
+
+# 명령만 출력(시뮬레이션)
+node scripts/permission-matrix-runner.js --dry-run
+```
+
+## 새 cell 추가 절차
+
+1. `.maestro/flows/permissions/<cell-id>.yaml` 작성 (본 README의 baseline flow 템플릿 사용).
+2. `scripts/permission-matrix.json`의 `cells` 배열에 entry 추가:
+   ```jsonc
+   {
+     "id": "always-bg-underground-sleep-ios18",
+     "permission": "always",
+     "appState": "bg",
+     "environment": "underground",
+     "mode": "sleep",
+     "os": "ios18",
+     "expectedRecallPct": 90,
+     "flow": "always-bg-underground-sleep-ios18.yaml"
+   }
+   ```
+3. CI(`.github/workflows/e2e.yml`)의 `permission-matrix` job matrix에 cell id 추가.
+4. runner와 flow는 추가 수정 불필요 (데이터 주도).
+
+## CI
+
+`.github/workflows/e2e.yml`의 `permission-matrix` job이 nightly로 실행한다.
+첫 PR에서는 baseline 1셀만 matrix에 등록. PR 게이트 아님(nightly only).
+
+## 이번 PR 제외
+
+- 나머지 15+ cell flow (후속 PR에서 추가)
+- Slack 알림
+- 실측 recall 측정(`expectedRecallPct`는 baseline placeholder)
+- Always BG / 지하 / 취침 모드 차원 변동

--- a/.maestro/flows/permissions/whileInUse-fg-aboveground-normal.yaml
+++ b/.maestro/flows/permissions/whileInUse-fg-aboveground-normal.yaml
@@ -1,0 +1,53 @@
+appId: com.subwaynow.app
+name: "permissions - WhileInUse × FG × 지상 × 일반 (#923 E2 baseline)"
+# 권한 매트릭스 baseline cell.
+# 차원: permission=whileInUse, appState=fg, environment=aboveground, mode=normal, os=ios18
+#
+# 검증 목표:
+#   - 위치 권한 "사용하는 동안"만 부여된 상태에서 앱이 정상 부팅되고
+#     매역 알람 경로(홈 화면 + 현재역 노출)가 동작함을 보장한다.
+#   - 권한이 always가 아니어도 FG 상태에서는 핵심 UX가 깨지지 않아야 한다.
+#
+# 전제:
+#   - EXPO_PUBLIC_E2E_MOCK=1 빌드. useNearestStation이 강남역(지상) 고정 fixture 반환.
+#   - GPS 좌표는 강남역(2호선 지상)으로 set → environment=aboveground 충족.
+#
+# 후속 PR에서 추가될 15+ cell flow는 본 파일을 템플릿으로 사용한다.
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: inuse
+      notifications: allow
+
+# Expo dev-client(개발 빌드 한정) 안내 화면 — release 빌드에서는 없음
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+# Dev menu가 떴을 경우를 위한 swipe-down (smoke와 동일 패턴)
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 홈 화면 노출 — 권한이 always가 아니어도 destination-button이 렌더되어야 함
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 강남(지상) — useNearestStation이 fixture를 반환해야 한다
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 매역 알람 경로의 진입점인 "목적지 설정" CTA가 보여야 한다
+- assertVisible:
+    text: "목적지 설정|Set destination"

--- a/scripts/__tests__/permission-matrix-runner.test.js
+++ b/scripts/__tests__/permission-matrix-runner.test.js
@@ -1,0 +1,163 @@
+/**
+ * #923 permission-matrix-runner 단위 테스트.
+ * 외부 영향(maestro 실행, FS)을 격리하기 위해 dep injection으로 spawnSync/stdout을 mock한다.
+ */
+const path = require('node:path');
+const {
+  parseArgs,
+  selectCells,
+  buildMaestroCommand,
+  main,
+} = require('../permission-matrix-runner');
+
+function createStream() {
+  return {
+    chunks: [],
+    write(s) {
+      this.chunks.push(s);
+    },
+    get text() {
+      return this.chunks.join('');
+    },
+  };
+}
+
+const MATRIX_PATH = path.join(__dirname, '..', 'permission-matrix.json');
+
+describe('parseArgs', () => {
+  it.each([
+    [[], { cell: null, baselineOnly: false, list: false, dryRun: false }],
+    [['--cell', 'foo'], { cell: 'foo', baselineOnly: false, list: false, dryRun: false }],
+    [['--baseline'], { cell: null, baselineOnly: true, list: false, dryRun: false }],
+    [['--list'], { cell: null, baselineOnly: false, list: true, dryRun: false }],
+    [['--dry-run'], { cell: null, baselineOnly: false, list: false, dryRun: true }],
+  ])('parses %j', (argv, expected) => {
+    expect(parseArgs(argv)).toEqual(expected);
+  });
+
+  it('flags help', () => {
+    expect(parseArgs(['-h']).help).toBe(true);
+    expect(parseArgs(['--help']).help).toBe(true);
+  });
+
+  it('records unknown argument as error', () => {
+    expect(parseArgs(['--bogus']).error).toMatch(/Unknown/);
+  });
+});
+
+describe('selectCells', () => {
+  const matrix = {
+    cells: [
+      { id: 'a', baseline: true, flow: 'a.yaml' },
+      { id: 'b', flow: 'b.yaml' },
+      { id: 'c', baseline: false, flow: 'c.yaml' },
+    ],
+  };
+
+  it('returns all when no filter', () => {
+    expect(selectCells(matrix, parseArgs([])).map((c) => c.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('filters by cell id', () => {
+    expect(selectCells(matrix, parseArgs(['--cell', 'b'])).map((c) => c.id)).toEqual(['b']);
+  });
+
+  it('throws when cell id not found', () => {
+    expect(() => selectCells(matrix, parseArgs(['--cell', 'zzz']))).toThrow(/not found/);
+  });
+
+  it('filters by baseline', () => {
+    expect(selectCells(matrix, parseArgs(['--baseline'])).map((c) => c.id)).toEqual(['a']);
+  });
+});
+
+describe('buildMaestroCommand', () => {
+  it('produces flow path and junit/debug outputs anchored on cell id', () => {
+    const cmd = buildMaestroCommand(
+      { id: 'x', flow: 'x.yaml' },
+      { flowsDir: '/flows', outputDir: '/out', maestroBin: 'maestro' },
+    );
+    expect(cmd.bin).toBe('maestro');
+    expect(cmd.args).toEqual([
+      'test',
+      '/flows/x.yaml',
+      '--format',
+      'junit',
+      '--output',
+      '/out/permission-matrix-x.xml',
+      '--debug-output',
+      '/out/permission-matrix-debug-x',
+    ]);
+  });
+});
+
+describe('main', () => {
+  const originalEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns 0 and prints help on --help', () => {
+    const stdout = createStream();
+    const stderr = createStream();
+    const code = main(['--help'], { exec: jest.fn(), stdout, stderr });
+    expect(code).toBe(0);
+    expect(stdout.text).toMatch(/permission-matrix-runner/);
+  });
+
+  it('returns 2 on unknown argument', () => {
+    const stderr = createStream();
+    const code = main(['--bogus'], { exec: jest.fn(), stdout: createStream(), stderr });
+    expect(code).toBe(2);
+    expect(stderr.text).toMatch(/Unknown/);
+  });
+
+  it('returns 2 when matrix file missing', () => {
+    process.env.MATRIX_JSON = '/nonexistent/matrix.json';
+    const stderr = createStream();
+    const code = main([], { exec: jest.fn(), stdout: createStream(), stderr });
+    expect(code).toBe(2);
+    expect(stderr.text).toMatch(/not found/);
+  });
+
+  it('lists cells without executing maestro', () => {
+    process.env.MATRIX_JSON = MATRIX_PATH;
+    const stdout = createStream();
+    const exec = jest.fn();
+    const code = main(['--list'], { exec, stdout, stderr: createStream() });
+    expect(code).toBe(0);
+    expect(exec).not.toHaveBeenCalled();
+    expect(stdout.text).toContain('whileInUse-fg-aboveground-normal-ios18');
+    expect(stdout.text).toContain('baseline=true');
+  });
+
+  it('dry-run prints commands without invoking exec', () => {
+    process.env.MATRIX_JSON = MATRIX_PATH;
+    const stdout = createStream();
+    const exec = jest.fn();
+    const code = main(['--baseline', '--dry-run'], { exec, stdout, stderr: createStream() });
+    expect(code).toBe(0);
+    expect(exec).not.toHaveBeenCalled();
+    expect(stdout.text).toContain('maestro test');
+    expect(stdout.text).toContain('1 cell(s) passed');
+  });
+
+  it('returns 0 when exec succeeds for all cells', () => {
+    process.env.MATRIX_JSON = MATRIX_PATH;
+    const stdout = createStream();
+    const exec = jest.fn().mockReturnValue({ status: 0 });
+    const code = main(['--baseline'], { exec, stdout, stderr: createStream() });
+    expect(code).toBe(0);
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(stdout.text).toContain('passed');
+  });
+
+  it('returns 1 when any cell fails', () => {
+    process.env.MATRIX_JSON = MATRIX_PATH;
+    const stderr = createStream();
+    const exec = jest.fn().mockReturnValue({ status: 1 });
+    const code = main(['--baseline'], { exec, stdout: createStream(), stderr });
+    expect(code).toBe(1);
+    expect(stderr.text).toContain('FAIL');
+  });
+});

--- a/scripts/permission-matrix-runner.js
+++ b/scripts/permission-matrix-runner.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * 권한 매트릭스 회귀 테스트 dispatcher (#923 E2).
+ *
+ * scripts/permission-matrix.json을 읽어 cell 단위로 Maestro flow를 실행한다.
+ * 데이터 주도: 새 셀 추가는 JSON entry 1개로 끝난다. 본 파일은 수정하지 않는다.
+ *
+ * 사용:
+ *   node scripts/permission-matrix-runner.js                  # 모든 cell 순차 실행
+ *   node scripts/permission-matrix-runner.js --cell <id>      # 특정 cell만
+ *   node scripts/permission-matrix-runner.js --baseline       # baseline=true인 cell만
+ *   node scripts/permission-matrix-runner.js --list           # cell 목록만 출력 후 종료
+ *   node scripts/permission-matrix-runner.js --dry-run        # 실행 없이 명령만 출력
+ *
+ * 환경 변수:
+ *   MAESTRO_BIN     : maestro 실행 경로 (기본 "maestro")
+ *   FLOWS_DIR       : flow 디렉토리 (기본 ".maestro/flows/permissions")
+ *   MATRIX_JSON     : 매트릭스 JSON 경로 (기본 "scripts/permission-matrix.json")
+ *   OUTPUT_DIR      : junit/디버그 출력 디렉토리 (기본 ".")
+ *
+ * 종료 코드:
+ *   0 — 선택된 모든 cell 통과
+ *   1 — 하나 이상 cell 실패
+ *   2 — 사용법/입력 오류
+ */
+const { readFileSync, existsSync } = require('node:fs');
+const { join, isAbsolute } = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = join(__dirname, '..');
+
+function resolveFromRoot(p) {
+  return isAbsolute(p) ? p : join(REPO_ROOT, p);
+}
+
+function parseArgs(argv) {
+  const args = { cell: null, baselineOnly: false, list: false, dryRun: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--cell') {
+      args.cell = argv[i + 1];
+      i += 1;
+    } else if (token === '--baseline') {
+      args.baselineOnly = true;
+    } else if (token === '--list') {
+      args.list = true;
+    } else if (token === '--dry-run') {
+      args.dryRun = true;
+    } else if (token === '--help' || token === '-h') {
+      args.help = true;
+    } else {
+      args.error = `Unknown argument: ${token}`;
+    }
+  }
+  return args;
+}
+
+function loadMatrix(path) {
+  if (!existsSync(path)) {
+    throw new Error(`Matrix file not found: ${path}`);
+  }
+  const raw = readFileSync(path, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed.cells) || parsed.cells.length === 0) {
+    throw new Error('Matrix must contain non-empty cells array');
+  }
+  return parsed;
+}
+
+function selectCells(matrix, args) {
+  const all = matrix.cells;
+  if (args.cell) {
+    const found = all.filter((c) => c.id === args.cell);
+    if (found.length === 0) {
+      throw new Error(`Cell not found: ${args.cell}`);
+    }
+    return found;
+  }
+  if (args.baselineOnly) {
+    return all.filter((c) => c.baseline === true);
+  }
+  return all;
+}
+
+function buildMaestroCommand(cell, options) {
+  const flowPath = join(options.flowsDir, cell.flow);
+  const junit = join(options.outputDir, `permission-matrix-${cell.id}.xml`);
+  const debug = join(options.outputDir, `permission-matrix-debug-${cell.id}`);
+  return {
+    bin: options.maestroBin,
+    args: ['test', flowPath, '--format', 'junit', '--output', junit, '--debug-output', debug],
+  };
+}
+
+function printHelp(stdout) {
+  // help 메시지는 파일 상단 주석에서 단일 출처로 유지.
+  // 호출자가 grep할 수 있도록 핵심 사용법만 stderr가 아닌 stdout으로 출력.
+  stdout.write(
+    [
+      'permission-matrix-runner — #923 권한 매트릭스 dispatcher',
+      'usage: node scripts/permission-matrix-runner.js [--cell <id>|--baseline|--list|--dry-run]',
+      '자세한 옵션은 파일 상단 주석 참고.',
+      '',
+    ].join('\n'),
+  );
+}
+
+function main(argv, deps = {}) {
+  const exec = deps.exec || spawnSync;
+  const stdout = deps.stdout || process.stdout;
+  const stderr = deps.stderr || process.stderr;
+
+  const args = parseArgs(argv);
+  if (args.help) {
+    printHelp(stdout);
+    return 0;
+  }
+  if (args.error) {
+    stderr.write(`${args.error}\n`);
+    return 2;
+  }
+
+  const matrixPath = resolveFromRoot(process.env.MATRIX_JSON || 'scripts/permission-matrix.json');
+  const flowsDir = resolveFromRoot(process.env.FLOWS_DIR || '.maestro/flows/permissions');
+  const outputDir = resolveFromRoot(process.env.OUTPUT_DIR || '.');
+  const maestroBin = process.env.MAESTRO_BIN || 'maestro';
+
+  let matrix;
+  try {
+    matrix = loadMatrix(matrixPath);
+  } catch (err) {
+    stderr.write(`${err.message}\n`);
+    return 2;
+  }
+
+  let cells;
+  try {
+    cells = selectCells(matrix, args);
+  } catch (err) {
+    stderr.write(`${err.message}\n`);
+    return 2;
+  }
+
+  if (args.list) {
+    for (const cell of cells) {
+      stdout.write(`${cell.id}\t${cell.flow}\tbaseline=${Boolean(cell.baseline)}\n`);
+    }
+    return 0;
+  }
+
+  const options = { flowsDir, outputDir, maestroBin };
+  let failed = 0;
+  for (const cell of cells) {
+    const command = buildMaestroCommand(cell, options);
+    const display = `${command.bin} ${command.args.join(' ')}`;
+    stdout.write(`[matrix] cell=${cell.id} → ${display}\n`);
+    if (args.dryRun) {
+      continue;
+    }
+    const result = exec(command.bin, command.args, { stdio: 'inherit', cwd: REPO_ROOT });
+    if (result.status !== 0) {
+      stderr.write(`[matrix] FAIL cell=${cell.id} status=${result.status}\n`);
+      failed += 1;
+    }
+  }
+
+  if (failed > 0) {
+    stderr.write(`[matrix] ${failed}/${cells.length} cell(s) failed\n`);
+    return 1;
+  }
+  stdout.write(`[matrix] ${cells.length} cell(s) passed\n`);
+  return 0;
+}
+
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+module.exports = {
+  parseArgs,
+  loadMatrix,
+  selectCells,
+  buildMaestroCommand,
+  main,
+};

--- a/scripts/permission-matrix.json
+++ b/scripts/permission-matrix.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "./permission-matrix.schema.json",
+  "_doc": [
+    "권한 매트릭스 회귀 테스트 정의 (#923 E2).",
+    "각 cell은 권한 × 앱상태 × 환경 × 모드 × OS 차원의 한 점이며, Maestro flow와 expected를 매핑한다.",
+    "새 셀 추가는 cells 배열에 entry 하나만 추가하면 된다 (runner는 데이터 주도).",
+    "expectedRecallPct는 후속 PR에서 실측 기반으로 채워질 예정(현재는 baseline 1셀만 정의)."
+  ],
+  "dimensions": {
+    "permission": ["always", "whileInUse"],
+    "appState": ["fg", "bg"],
+    "environment": ["aboveground", "underground"],
+    "mode": ["normal", "sleep"],
+    "os": ["ios17", "ios18", "android"]
+  },
+  "cells": [
+    {
+      "id": "whileInUse-fg-aboveground-normal-ios18",
+      "permission": "whileInUse",
+      "appState": "fg",
+      "environment": "aboveground",
+      "mode": "normal",
+      "os": "ios18",
+      "expectedRecallPct": 95,
+      "flow": "whileInUse-fg-aboveground-normal.yaml",
+      "baseline": true,
+      "_doc": "E2 baseline. 가장 흔한 사용자 시나리오(권한=사용중 + 앱 열림 + 지상 + 일반모드). 매역 알람 정상 발사를 보장한다."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

#923 (Epic #912 P2 회귀 가드, E2 시리즈 첫 PR). 권한 매트릭스 회귀 테스트의 **infra + baseline 1셀**만 도입한다. 데이터 주도 구조로, 후속 PR에서 셀을 추가할 때 본 PR의 runner/CI 구조를 다시 건드릴 필요가 없게 했다.

### 포함된 것

- `scripts/permission-matrix.json` — 매트릭스 정의(dimensions × cells). 새 셀 추가는 `cells` 배열에 entry 1개만 더하면 끝.
- `scripts/permission-matrix-runner.js` — JSON을 읽어 cell 단위로 maestro 실행. `--cell` / `--baseline` / `--list` / `--dry-run` 옵션 지원. `MAESTRO_BIN` / `FLOWS_DIR` / `MATRIX_JSON` / `OUTPUT_DIR` 환경변수로 위치 오버라이드.
- `scripts/__tests__/permission-matrix-runner.test.js` — dep-injection 기반 단위 테스트 19개(parseArgs · selectCells · buildMaestroCommand · main의 모든 분기).
- `.maestro/flows/permissions/whileInUse-fg-aboveground-normal.yaml` — baseline cell flow. `EXPO_PUBLIC_E2E_MOCK=1` 빌드에서 강남(지상) 고정 fixture를 사용해 WhileInUse 권한으로 홈 화면 + destination CTA 렌더 검증.
- `.maestro/flows/permissions/README.md` — 운영 + 새 셀 추가 절차.
- `.github/workflows/e2e.yml` — `permission-matrix` job 추가. `strategy.matrix.cell`에 셀 id 추가하기만 하면 신규 셀이 nightly에 합류.

### 이번 PR 제외 (후속)

- 나머지 15+ 셀 Maestro flow (Always × …, BG, 지하, 취침, iOS17, Android)
- Slack 알림
- 실측 recall 측정 — 현재 `expectedRecallPct`는 baseline placeholder
- Maestro `location: inuse` 권한 분기가 실제 location gate를 통과하는지 검증 (mock fixture가 short-circuit하므로 후속 PR에서 mock 비활성 셀 추가 시 본격 검증)

### 검증

- `npm test` — 3730 tests pass, coverage 100% 유지
- `npm run type-check` — clean
- `node scripts/permission-matrix-runner.js --baseline --dry-run` — 1 cell passed (실제 maestro 미호출)
- code-review (medium): P1 1건 (CI env `MAESTRO_BIN: ${{ env.HOME }}/...` 잘못된 context 사용 → empty 평가) → 수정 완료. `MAESTRO_BIN`은 기본 `maestro`로 두고 `$GITHUB_PATH`가 해석하도록 함 (regression/nightly job과 동일 패턴).

## Test plan

- [ ] CI nightly가 정상 트리거되는지 다음 cron(KST 04:00) 후 확인
- [ ] baseline cell이 macOS-14 + iPhone 16 시뮬레이터에서 통과
- [ ] 후속 PR에서 cell entry 1개 추가만으로 새 셀이 동작 (구조 검증)

Refs #923

### 후속 PR 목록

1. WhileInUse × FG × 지하 × 일반
2. WhileInUse × FG × 지상 × 취침
3. WhileInUse × BG × 지상 × 일반 (background-fetch alarm 경로)
4. Always × FG × 지상 × 일반
5. Always × BG × 지하 × 일반
6. Always × BG × 지하 × 취침 (가장 까다로운 셀)
7. iOS 17 디멘션 (시뮬레이터 분기)
8. Android 디멘션 (별도 runner)
9. 실측 recall 측정 + `expectedRecallPct` 채움
10. Slack 알림 (실패 셀 핀포인트)