### PR TITLE
feat(#918): OS-level 사전 예약 매역 일반화 — tripBoundScheduler infra (A3 첫 PR)

### DIFF
--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -1,0 +1,345 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import {
+  TRIP_BOUND_ALARM_PREFIX,
+  cancelTripBoundAlarms,
+  prescheduleStationAlerts,
+  tripBoundAlarmIdentifier,
+  type TripBoundStop,
+} from '../tripBoundScheduler';
+
+jest.mock('expo-notifications');
+
+const mockLoggerWarn = jest.fn();
+const mockLoggerInfo = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    error: jest.fn(),
+  }),
+}));
+
+jest.mock('../stationNotification', () => ({
+  buildAlarmContent: (event: { phaseId: string; stationName: string }) => ({
+    title: `T:${event.phaseId}`,
+    body: `B:${event.stationName}`,
+  }),
+}));
+
+const mockedSchedule = Notifications.scheduleNotificationAsync as jest.MockedFunction<
+  typeof Notifications.scheduleNotificationAsync
+>;
+const mockedGetAll = Notifications.getAllScheduledNotificationsAsync as jest.MockedFunction<
+  typeof Notifications.getAllScheduledNotificationsAsync
+>;
+const mockedCancel = Notifications.cancelScheduledNotificationAsync as jest.MockedFunction<
+  typeof Notifications.cancelScheduledNotificationAsync
+>;
+
+const NOW = new Date('2026-06-05T09:00:00Z').getTime();
+
+// 합리적인 trip — 3 stop, 첫 두 stop은 transfer, 마지막 stop이 destination.
+// 각 hop 2분(120_000ms). data-driven — 함수가 길이/타입에 분기하지 않음을 확인.
+const defaultStops: TripBoundStop[] = [
+  { stationName: '동대문', alarmType: 'transfer' },
+  { stationName: '서울역', alarmType: 'transfer' },
+  { stationName: '강남', alarmType: 'destination' },
+];
+const defaultHops = [120_000, 120_000, 120_000];
+
+describe('tripBoundAlarmIdentifier', () => {
+  it('prefix + phaseId + stationName 결합 identifier를 만든다', () => {
+    expect(tripBoundAlarmIdentifier({ phaseId: 'early', stationName: '강남' })).toBe(
+      'tba:early:강남',
+    );
+    expect(tripBoundAlarmIdentifier({ phaseId: 'imminent', stationName: '시청' })).toBe(
+      'tba:imminent:시청',
+    );
+  });
+  it('prefix 상수는 노출된 값과 일치한다', () => {
+    expect(TRIP_BOUND_ALARM_PREFIX).toBe('tba:');
+  });
+});
+
+describe('prescheduleStationAlerts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoggerWarn.mockClear();
+    mockLoggerInfo.mockClear();
+    mockedSchedule.mockResolvedValue('id');
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    // wall-clock 가드 (Date.now())가 NOW 기준 fixture를 통과시키도록 fake timer 시점을 NOW에 고정.
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stop별 early/imminent 두 phase를 예약한다 — stop 0 early는 정의상 fire=startTime이라 skip', async () => {
+    // 첫 stop의 early lead는 자기 자신의 hopMs라 fire = startTime + hopMs - hopMs = startTime.
+    // `fireMs <= startTime` 가드로 skip된다. 따라서 N stop trip은 (N*2 - 1)건 예약된다.
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+
+    expect(result).toHaveLength(defaultStops.length * 2 - 1);
+    expect(mockedSchedule).toHaveBeenCalledTimes(defaultStops.length * 2 - 1);
+  });
+
+  it('각 stop의 early는 (arrival - hopMs), imminent는 (arrival - 10s)에 fire한다', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+
+    // stop 0: arrival=NOW+120_000, early=NOW+0(=startTime → skip), imminent=NOW+110_000
+    // stop 1: arrival=NOW+240_000, early=NOW+120_000, imminent=NOW+230_000
+    // stop 2: arrival=NOW+360_000, early=NOW+240_000, imminent=NOW+350_000
+    // → stop 0 early는 fire<=startTime이라 skip → 총 5건
+    expect(result).toHaveLength(5);
+    expect(result.map((r) => r.identifier)).toEqual([
+      'tba:imminent:동대문',
+      'tba:early:서울역',
+      'tba:imminent:서울역',
+      'tba:early:강남',
+      'tba:imminent:강남',
+    ]);
+    expect(result[0].fireDate).toEqual(new Date(NOW + 110_000));
+    expect(result[1].fireDate).toEqual(new Date(NOW + 120_000));
+    expect(result[4].fireDate).toEqual(new Date(NOW + 350_000));
+  });
+
+  it('alarmType이 event.type으로 그대로 전달된다 (transfer/destination 데이터 주도)', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+    const types = result.map((r) => `${r.event.stationName}/${r.event.type}`);
+    expect(types).toContain('동대문/transfer');
+    expect(types).toContain('서울역/transfer');
+    expect(types).toContain('강남/destination');
+  });
+
+  it('routeStops가 비어 있으면 0건 반환, schedule을 호출하지 않는다', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: [],
+      estimatedHopTimesMs: [],
+      startTime: NOW,
+    });
+    expect(result).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    // 빈 입력은 정상 — warn 없음.
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('routeStops와 estimatedHopTimesMs 길이가 다르면 0건 + warn', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: [120_000, 120_000],
+      startTime: NOW,
+    });
+    expect(result).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('reason=length-mismatch stops=3 hops=2'),
+    );
+  });
+
+  it('모든 fireMs가 startTime 이하라면 0건 + reason=all-past warn', async () => {
+    // 단일 stop + hop=0ms → arrival=startTime, 모든 phase의 fireMs<=startTime → 전부 skip.
+    const result = await prescheduleStationAlerts({
+      routeStops: [{ stationName: '강남', alarmType: 'destination' }],
+      estimatedHopTimesMs: [0],
+      startTime: NOW,
+    });
+    expect(result).toEqual([]);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('reason=all-past'),
+    );
+  });
+
+  it('정상 예약 케이스에서는 warn을 발화하지 않고 info만 남긴다', async () => {
+    await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.stringContaining('prescheduled 5 alarms for 3 stops'),
+    );
+  });
+
+  it('iOS imminent phase는 interruptionLevel=timeSensitive', async () => {
+    await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+    // imminent phase 호출 — 적어도 한 번은 timeSensitive로 호출되어야 한다.
+    const calls = mockedSchedule.mock.calls.map((c) => c[0]);
+    const imminent = calls.find((c) => c.identifier?.startsWith('tba:imminent:'));
+    expect(imminent?.content).toMatchObject({ interruptionLevel: 'timeSensitive' });
+  });
+
+  it('iOS early phase는 interruptionLevel=active', async () => {
+    await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+    const calls = mockedSchedule.mock.calls.map((c) => c[0]);
+    const early = calls.find((c) => c.identifier?.startsWith('tba:early:'));
+    expect(early?.content).toMatchObject({ interruptionLevel: 'active' });
+  });
+
+  it('Android는 channelId + priority MAX를 포함, iOS interruptionLevel은 없음', async () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+    const call = mockedSchedule.mock.calls[0][0];
+    expect(call.content).toMatchObject({
+      channelId: 'station-alarm',
+      priority: Notifications.AndroidNotificationPriority.MAX,
+      sound: 'alarm.wav',
+    });
+    expect(call.content).not.toHaveProperty('interruptionLevel');
+  });
+
+  it('trigger.date에 fireDate가 전달된다', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+    });
+    const firstCall = mockedSchedule.mock.calls[0][0];
+    expect(firstCall.trigger).toEqual({
+      type: Notifications.SchedulableTriggerInputTypes.DATE,
+      date: result[0].fireDate,
+    });
+  });
+
+  it('scheduleNotificationAsync가 throw하면 caller로 전파한다 (try/catch 미흡수)', async () => {
+    mockedSchedule.mockRejectedValueOnce(new Error('permission denied'));
+    await expect(
+      prescheduleStationAlerts({
+        routeStops: defaultStops,
+        estimatedHopTimesMs: defaultHops,
+        startTime: NOW,
+      }),
+    ).rejects.toThrow('permission denied');
+  });
+
+  it('stop 1개짜리 trip(direct route)도 데이터 그대로 처리한다', async () => {
+    // startTime 30s 전부터 시작 → early fire=NOW-30s+600s-600s=NOW-30s? 아님: fire=arrival-hopMs.
+    // arrival=startTime+600_000, early lead=hopMs=600_000 → fire=startTime(=NOW-30_000) → skip.
+    // 그래서 30s 전 시작이라도 early는 항상 startTime에 떨어진다. 미래로 보내려면 hop을 분리해야.
+    // 단일 stop 시나리오에서 early는 정의상 fire=startTime이라 skip된다 — 의도된 정책.
+    // imminent만 1건 예약된다.
+    const result = await prescheduleStationAlerts({
+      routeStops: [{ stationName: '강남', alarmType: 'destination' }],
+      estimatedHopTimesMs: [600_000],
+      startTime: NOW,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].identifier).toBe('tba:imminent:강남');
+    expect(result[0].fireDate).toEqual(new Date(NOW + 590_000));
+  });
+
+  it('hopMs가 NaN/Infinity/음수면 해당 stop skip + warn', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: [
+        { stationName: '동대문', alarmType: 'transfer' },
+        { stationName: '서울역', alarmType: 'transfer' },
+        { stationName: '강남', alarmType: 'destination' },
+      ],
+      estimatedHopTimesMs: [120_000, Number.NaN, 120_000],
+      startTime: NOW,
+    });
+    // NaN stop은 cumulativeMs에 누적되지 않아 다음 stop fireMs가 startTime+120_000 그대로.
+    // result는 정상 hop stop만 포함.
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('invalid-hop stop=서울역'),
+    );
+    // 적어도 하나 이상 정상 stop의 알람이 예약되어야 한다 (NaN propagation 차단 확인).
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((r) => Number.isFinite(r.fireDate.getTime()))).toBe(true);
+  });
+
+  it('route에 같은 stationName이 중복 등장하면 두 번째부터 :n suffix로 unique', async () => {
+    // 순환 노선/route 다시 방문 케이스. iOS scheduleNotificationAsync는 동일 identifier 시
+    // silent overwrite하므로 phaseStationOccurrence map으로 idx suffix 추가.
+    const result = await prescheduleStationAlerts({
+      routeStops: [
+        { stationName: '시청', alarmType: 'transfer' },
+        { stationName: '강남', alarmType: 'transfer' },
+        { stationName: '시청', alarmType: 'destination' },
+      ],
+      estimatedHopTimesMs: [120_000, 120_000, 120_000],
+      startTime: NOW,
+    });
+    const ids = result.map((r) => r.identifier);
+    // 첫 시청 imminent → 기본 identifier, 두 번째 시청 imminent → :1 suffix.
+    expect(ids).toContain('tba:imminent:시청');
+    expect(ids).toContain('tba:imminent:시청:1');
+    // 모두 unique
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('cancelTripBoundAlarms', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoggerInfo.mockClear();
+  });
+
+  it('tba: prefix 알람만 취소하고 다른 prefix는 건드리지 않는다', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' },
+      { identifier: 'tba:imminent:강남' },
+      { identifier: 'alarm:early:강남' }, // 기존 alarmScheduler 예약
+      { identifier: 'bl:T1:0:early:강남' }, // boardingLockScheduler 예약
+      { identifier: 'current-station' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    await cancelTripBoundAlarms();
+
+    expect(mockedCancel).toHaveBeenCalledTimes(2);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:강남');
+    expect(mockedCancel).not.toHaveBeenCalledWith('alarm:early:강남');
+    expect(mockedCancel).not.toHaveBeenCalledWith('bl:T1:0:early:강남');
+    expect(mockedCancel).not.toHaveBeenCalledWith('current-station');
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.stringContaining('cancelled 2 trip-bound alarms'),
+    );
+  });
+
+  it('취소 대상이 없으면 cancel을 호출하지 않고 info 로그도 남기지 않는다', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'alarm:early:강남' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    await cancelTripBoundAlarms();
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockLoggerInfo).not.toHaveBeenCalled();
+  });
+
+  it('OS 큐가 비어 있으면 안전하게 통과한다', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    await expect(cancelTripBoundAlarms()).resolves.toBeUndefined();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -1,0 +1,192 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
+import { alarmKey, type AlarmEvent } from './stationAlarm';
+import { buildAlarmContent } from './stationNotification';
+import type { AlarmType } from '../../../shared/types/alarm';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('TripBoundScheduler');
+
+/**
+ * 새 identifier prefix — boarding-lock(#584)과 #335 reschedule 경로가 사용하는 `bl:` / `alarm:`
+ * 와 분리해서 lock 무관 trip-bound 사전 예약만 prefix로 식별/취소한다.
+ *
+ * #918 (A3): 자동 lock 후에도 네트워크 0 환경에서 silent push가 못 가는 경우를 대비해
+ * trip 등록 시점에 OS local notification을 사전 예약하는 일반화된 진입점.
+ */
+export const TRIP_BOUND_ALARM_PREFIX = 'tba:';
+
+/** iOS interruption level (lock scheduler와 동일 정책 — early=active, imminent=timeSensitive). */
+const PHASE_INTERRUPTION: Record<AlarmPhaseId, 'active' | 'timeSensitive'> = {
+  early: 'active',
+  imminent: 'timeSensitive',
+};
+
+/** Android channel id — stationNotification / alarmScheduler / boardingLockScheduler와 동일. */
+const ALARM_CHANNEL_ID = 'station-alarm';
+
+/** imminent phase 고정 lead(ms) — 도착 10초 전. early는 입력 `estimatedHopTimesMs[i]`를 그대로 사용. */
+const IMMINENT_LEAD_MS = 10_000;
+
+/**
+ * 사전 예약 대상 단일 stop. lock-free — boarding lock 메타에 의존하지 않고,
+ * 호출자가 route 어떤 형태(direct/transfer/multi-transfer)든 평탄화해 넘긴다.
+ */
+export interface TripBoundStop {
+  /** 알람 본문/identifier에 들어갈 canonical 역명. resolveAllTargets의 target.name과 동일 규약. */
+  stationName: string;
+  /** transfer 또는 destination — 본문 문구가 갈린다. */
+  alarmType: AlarmType;
+}
+
+export interface PrescheduleParams {
+  /** trip의 stop 시퀀스(0..N-1). 비어 있으면 schedule 없이 0건 반환. */
+  routeStops: ReadonlyArray<TripBoundStop>;
+  /**
+   * stop별 leg time(ms). `routeStops[i]`에 도달하기까지 직전 지점에서 걸리는 시간.
+   * 길이는 routeStops와 같아야 한다.
+   *
+   * 누적합 = `startTime` 기준 stop i의 예상 도착 시각.
+   * 또한 `estimatedHopTimesMs[i]` 자체가 stop i의 early phase lead(ms)로 사용된다 —
+   * boardingLockScheduler.computeHopTimings와 동일 의미(`legSeconds/legStops` 평균).
+   */
+  estimatedHopTimesMs: ReadonlyArray<number>;
+  /** 누적의 기준점. trip 등록 시각(ms epoch). */
+  startTime: number;
+}
+
+export interface ScheduledTripBoundAlarm {
+  identifier: string;
+  event: AlarmEvent;
+  fireDate: Date;
+}
+
+/**
+ * trip 등록(자동 lock 직후 포함) 시점에 destinationName 까지 모든 stop에 대해
+ * (early, imminent) OS local notification을 사전 예약한다. lock 유무와 무관.
+ *
+ * - 입력 검증: routeStops와 estimatedHopTimesMs의 길이가 다르면 0건. (호출자 contract 위반 — log warn)
+ * - 과거 시각(`fireMs <= startTime`) 알람은 skip — 이미 지난 stop은 자동으로 생략.
+ * - 어떤 phase도 예약되지 않으면 0건 반환 + warn (정상 trip은 ≥ 1건 나와야 함).
+ * - scheduleNotificationAsync throw 시 caller로 그대로 전파 — alarmScheduler.ts 정책과 일치.
+ *
+ * 반환: 예약된 alarm 메타 배열(identifier/event/fireDate). 호출자가 추적용 큐를 별도로
+ *       관리할 수 있다. cancelTripBoundAlarms()는 prefix 매칭만으로 일괄 취소한다.
+ */
+export async function prescheduleStationAlerts(
+  params: PrescheduleParams,
+): Promise<ScheduledTripBoundAlarm[]> {
+  const { routeStops, estimatedHopTimesMs, startTime } = params;
+
+  if (routeStops.length !== estimatedHopTimesMs.length) {
+    logger.warn(
+      `preschedule skip reason=length-mismatch stops=${routeStops.length} hops=${estimatedHopTimesMs.length}`,
+    );
+    return [];
+  }
+  if (routeStops.length === 0) {
+    return [];
+  }
+
+  const scheduled: ScheduledTripBoundAlarm[] = [];
+  let cumulativeMs = startTime;
+  // wall-clock 가드: caller가 stale startTime을 넘겨도 이미 지난 시각으로 OS 큐에 등록되지 않게.
+  // (iOS scheduleNotificationAsync는 과거 Date를 즉시 발사 — 잘못 입력 시 매역 알림 burst 회귀.)
+  const nowMs = Date.now();
+  // 같은 station이 route 안에 중복 등장(순환 노선 등) 시 identifier 충돌로 iOS가 silent overwrite한다.
+  // 발생한 identifier를 추적해 두 번째 등장은 phaseId만으로 식별이 부족하므로 phase별 occurrenceIdx
+  // suffix로 unique화한다 (cancelTripBoundAlarms는 prefix 매칭이라 영향 없음).
+  const phaseStationOccurrence = new Map<string, number>();
+
+  for (let i = 0; i < routeStops.length; i++) {
+    const hopMs = estimatedHopTimesMs[i];
+    // NaN/Infinity/음수 보호 — caller가 legSeconds/legStops를 legStops=0 가드 없이 계산한 케이스 등.
+    if (!Number.isFinite(hopMs) || hopMs < 0) {
+      logger.warn(
+        `preschedule skip reason=invalid-hop stop=${routeStops[i].stationName} hopMs=${hopMs}`,
+      );
+      continue;
+    }
+    cumulativeMs += hopMs;
+    const stop = routeStops[i];
+
+    for (const phase of ALARM_PHASES) {
+      const leadMs = phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS;
+      const fireMs = cumulativeMs - leadMs;
+      // startTime 기준 + 실제 wall-clock 기준 두 조건 모두 통과해야 등록.
+      if (fireMs <= startTime || fireMs <= nowMs) continue;
+
+      const event: AlarmEvent = {
+        phaseId: phase.id,
+        type: stop.alarmType,
+        stationName: stop.stationName,
+      };
+      const baseId = tripBoundAlarmIdentifier(event);
+      const occKey = `${phase.id}:${stop.stationName}`;
+      const occIdx = phaseStationOccurrence.get(occKey) ?? 0;
+      phaseStationOccurrence.set(occKey, occIdx + 1);
+      // 첫 등장은 base identifier 유지 (호환), 두 번째 이상은 :n suffix로 unique.
+      const identifier = occIdx === 0 ? baseId : `${baseId}:${occIdx}`;
+      const fireDate = new Date(fireMs);
+      const { title, body } = buildAlarmContent(event);
+
+      // scheduleNotificationAsync가 throw하면 caller로 전파 — alarmScheduler 정책 일치.
+      await Notifications.scheduleNotificationAsync({
+        identifier,
+        content: {
+          title,
+          body,
+          sound: 'alarm.wav',
+          ...(Platform.OS === 'android' && {
+            channelId: ALARM_CHANNEL_ID,
+            priority: Notifications.AndroidNotificationPriority.MAX,
+          }),
+          ...(Platform.OS === 'ios' && { interruptionLevel: PHASE_INTERRUPTION[phase.id] }),
+        },
+        trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: fireDate },
+      });
+
+      scheduled.push({ identifier, event, fireDate });
+    }
+  }
+
+  if (scheduled.length === 0) {
+    logger.warn(
+      `preschedule skip reason=all-past stops=${routeStops.length} startTime=${startTime}`,
+    );
+  } else {
+    logger.info(`prescheduled ${scheduled.length} alarms for ${routeStops.length} stops`);
+  }
+  return scheduled;
+}
+
+/**
+ * identifier 형식: `tba:${phaseId}:${stationName}`.
+ * alarmScheduler의 `alarm:` prefix와 분리해 trip-bound 사전 예약만 식별/취소한다.
+ */
+export function tripBoundAlarmIdentifier(
+  event: Pick<AlarmEvent, 'phaseId' | 'stationName'>,
+): string {
+  return `${TRIP_BOUND_ALARM_PREFIX}${alarmKey(event)}`;
+}
+
+/**
+ * trip 종료(release / 목적지 도착 / 사용자 취소) 시 호출 — `tba:` prefix를 가진 모든 사전
+ * 예약 알람을 OS 큐에서 제거한다. 다른 prefix(alarm:, bl:)는 건드리지 않는다.
+ *
+ * cancelScheduledNotificationAsync는 idempotent — 이미 발사된 알람도 안전하게 통과한다.
+ */
+export async function cancelTripBoundAlarms(): Promise<void> {
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let cancelled = 0;
+  for (const req of all) {
+    if (req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) {
+      await Notifications.cancelScheduledNotificationAsync(req.identifier);
+      cancelled++;
+    }
+  }
+  if (cancelled > 0) {
+    logger.info(`cancelled ${cancelled} trip-bound alarms`);
+  }
+}


### PR DESCRIPTION
## Summary
Epic #912 P1 A3 첫 슬라이스. lock 무관한 trip-bound OS local notification 사전 예약 인프라.

- `src/features/alarm/utils/tripBoundScheduler.ts` 신규:
  - `prescheduleStationAlerts({ routeStops, estimatedHopTimesMs, startTime })`: 각 stop에 early/imminent 두 phase OS 알람 등록
  - `tripBoundAlarmIdentifier(event)`: `tba:` prefix로 #584 boarding-lock(`bl:`) / `alarmScheduler`(`alarm:`)와 격리
  - `cancelTripBoundAlarms()`: prefix 매칭으로 일괄 cancel (trip 종료 시)
- 100% 커버리지

## Self code-review 결과 — P1 3건 반영
1. **wall-clock 가드** (`fireMs <= Date.now()`): caller가 stale startTime 넘겨도 iOS 과거 Date 즉시 발사 burst 차단
2. **invalid-hop 가드** (`!Number.isFinite(hopMs) || hopMs < 0`): legSeconds/legStops legStops=0 가드 빠진 caller로부터 NaN propagation 차단
3. **중복 stationName identifier `:n` suffix**: 순환 노선/route 다시 방문 시 iOS `scheduleNotificationAsync` silent overwrite 차단

## 슬라이싱 의도 (Refs #918)
**본 PR 제외, 후속 PR 예정**:
- `useStationAlarm` / `HomeScreen` wire (자동 lock 시 → preschedule 호출)
- `backend/alarm-worker/src/scheduled.ts` 정정/취소 push 트리거 확장
- 실기기 비행기 모드 검증

## Test plan
- [x] `npm test` 통과 (3731 tests, 100% coverage)
- [x] `npm run type-check` 통과

Refs #912
Refs #918