### PR TITLE
feat(#924): route 미설정 환승 자동 detect 알고리즘 (D1 첫 PR)

### DIFF
--- a/src/features/route/utils/__tests__/transferDetect.test.ts
+++ b/src/features/route/utils/__tests__/transferDetect.test.ts
@@ -1,0 +1,129 @@
+import { detectTransfer, TRANSFER_DETECT_IMMINENT_SECONDS } from '../transferDetect';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type { NearestStationsResult } from '../../../../shared/types/station';
+
+const transferNearest: NearestStationsResult = {
+  primary: MOCK_STATIONS.chungmuro,
+  variants: [MOCK_STATIONS.chungmuro],
+  distanceKm: 0.05,
+  isTransfer: true,
+};
+
+const nonTransferNearest: NearestStationsResult = {
+  primary: MOCK_STATIONS.gangnam,
+  variants: [MOCK_STATIONS.gangnam],
+  distanceKm: 0.05,
+  isTransfer: false,
+};
+
+describe('detectTransfer', () => {
+  it('환승역 + walking + 임박 다른노선 → detected=true', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [{ line: '4', arrivalSeconds: 60 }],
+    });
+    expect(result).toEqual({ detected: true, candidateLines: ['4'] });
+  });
+
+  it('nearestStations=null → detect 불가', () => {
+    const result = detectTransfer({
+      nearestStations: null,
+      motionWalking: true,
+      otherLineArrivals: [{ line: '4', arrivalSeconds: 60 }],
+    });
+    expect(result.detected).toBe(false);
+    expect(result.candidateLines).toEqual([]);
+  });
+
+  it('환승역 아님 → detect 불가', () => {
+    const result = detectTransfer({
+      nearestStations: nonTransferNearest,
+      motionWalking: true,
+      otherLineArrivals: [{ line: '4', arrivalSeconds: 60 }],
+    });
+    expect(result.detected).toBe(false);
+  });
+
+  it('motionWalking=false (정지) → detect 불가', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: false,
+      otherLineArrivals: [{ line: '4', arrivalSeconds: 60 }],
+    });
+    expect(result.detected).toBe(false);
+  });
+
+  it('다른노선 도착 신호 없음 → detect 불가', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [],
+    });
+    expect(result.detected).toBe(false);
+  });
+
+  it('다른노선 도착이 임박 임계 초과 → detect 불가', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [{ line: '4', arrivalSeconds: TRANSFER_DETECT_IMMINENT_SECONDS + 1 }],
+    });
+    expect(result.detected).toBe(false);
+  });
+
+  it('임계 경계값(=180초) 포함', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [{ line: '4', arrivalSeconds: TRANSFER_DETECT_IMMINENT_SECONDS }],
+    });
+    expect(result.detected).toBe(true);
+    expect(result.candidateLines).toEqual(['4']);
+  });
+
+  it('음수 arrivalSeconds(누락/이상값)은 제외', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [{ line: '4', arrivalSeconds: -1 }],
+    });
+    expect(result.detected).toBe(false);
+  });
+
+  it('다중 노선 후보 모두 반환(입력 순서 보존)', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [
+        { line: '4', arrivalSeconds: 60 },
+        { line: '5', arrivalSeconds: 90 },
+      ],
+    });
+    expect(result.candidateLines).toEqual(['4', '5']);
+  });
+
+  it('같은 노선 중복 도착은 dedup, 임박한 것 우선', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [
+        { line: '4', arrivalSeconds: 60 },
+        { line: '4', arrivalSeconds: 180 },
+      ],
+    });
+    expect(result.candidateLines).toEqual(['4']);
+  });
+
+  it('임박/비임박 섞임 → 임박만 candidate', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [
+        { line: '4', arrivalSeconds: 60 },
+        { line: '5', arrivalSeconds: 600 },
+      ],
+    });
+    expect(result.candidateLines).toEqual(['4']);
+  });
+});

--- a/src/features/route/utils/transferDetect.ts
+++ b/src/features/route/utils/transferDetect.ts
@@ -1,0 +1,71 @@
+/**
+ * #924 — route 미설정 환승 자동 detect (D1, 첫 PR: pure 알고리즘).
+ *
+ * 목적: 사용자가 route(목적지)를 설정하지 않은 free trip에서도 환승을 자동으로 잡는다.
+ * Seam F의 사전 정의 route 위 swap만으로는 free trip 환승 미해결 — destination 안 정한 사용자도 진짜 free하려면 필요.
+ *
+ * 첫 PR 범위: pure JS detect 알고리즘만. 호출 wire(stationRoute 확장, A1 자동 lock, F4 모달)는 후속 PR.
+ *
+ * 신호 결합(모두 충족 시 detect):
+ *   1) 현재 가장 가까운 역이 환승역(`isTransfer === true`) — 환승역 코너에 있어야 환승 가능
+ *   2) motion walking(이동 중) — 가만히 있으면 환승이 아니라 단순 정차/대기
+ *   3) 다른 노선의 강한 도착 신호 — 임박 도착 ArrivalRow 1개 이상
+ *
+ * #921(signal fusion) 머지 후에는 fusion 패턴으로 가중치 결합으로 강화 예정. 첫 PR은 단순 AND.
+ *
+ * candidateLines: 임박 도착이 잡힌 다른 노선들 — 다중 후보일 때 F4 모달(#914)에서 사용자에게 선택지 제공.
+ */
+import type { LineNumber, NearestStationsResult } from '../../../shared/types/station';
+
+/** 다른 노선 도착이 "임박"으로 간주되는 최대 초. 이 이내 도착이면 환승 후보로 가산. */
+export const TRANSFER_DETECT_IMMINENT_SECONDS = 180;
+
+export interface OtherLineArrival {
+  line: LineNumber;
+  arrivalSeconds: number;
+}
+
+export interface DetectTransferInput {
+  /** 현재 fusion된 최근접 역(환승역 후보 포함). null이면 GPS 미가용 → detect 불가. */
+  nearestStations: NearestStationsResult | null;
+  /** motion=walking 패턴(이동 중). `getCurrentMotionStationary()`의 negation을 호출자가 전달. */
+  motionWalking: boolean;
+  /**
+   * 다른 노선의 도착 신호. 호출자는 현재 boarding line을 제외한 다른 노선만 추려서 전달.
+   * 같은 노선이 여러 번 와도 OK — 임박 1개라도 있으면 그 노선이 candidate.
+   */
+  otherLineArrivals: OtherLineArrival[];
+}
+
+export interface DetectTransferResult {
+  detected: boolean;
+  /** 임박 도착이 감지된 다른 노선들(dedup, 입력 순서 보존). */
+  candidateLines: LineNumber[];
+}
+
+const EMPTY_RESULT: DetectTransferResult = { detected: false, candidateLines: [] };
+
+export function detectTransfer(input: DetectTransferInput): DetectTransferResult {
+  const { nearestStations, motionWalking, otherLineArrivals } = input;
+
+  if (!nearestStations || !nearestStations.isTransfer) return EMPTY_RESULT;
+  if (!motionWalking) return EMPTY_RESULT;
+
+  const candidateLines = collectImminentLines(otherLineArrivals);
+  if (candidateLines.length === 0) return EMPTY_RESULT;
+
+  return { detected: true, candidateLines };
+}
+
+function collectImminentLines(arrivals: OtherLineArrival[]): LineNumber[] {
+  const seen = new Set<LineNumber>();
+  const out: LineNumber[] = [];
+  for (const a of arrivals) {
+    if (a.arrivalSeconds > TRANSFER_DETECT_IMMINENT_SECONDS) continue;
+    if (a.arrivalSeconds < 0) continue;
+    if (seen.has(a.line)) continue;
+    seen.add(a.line);
+    out.push(a.line);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- `src/features/route/utils/transferDetect.ts` — pure JS `detectTransfer({ nearestStations, motionWalking, otherLineArrivals })` 알고리즘
- 신호 AND 결합: (1) 환승역(`isTransfer`) (2) motion walking (3) 다른 노선 임박 도착(`arrivalSeconds <= 180s`) 1개 이상
- `candidateLines`: 임박 도착이 잡힌 다른 노선들 — dedup, 입력 순서 보존 (다중 후보 시 F4 모달용)
- `TRANSFER_DETECT_IMMINENT_SECONDS=180` 상수로 매직넘버 분리, 음수/임계 경계 가드

## Why
Seam F는 사전 정의된 route 위 swap만 처리 → 사용자가 route(목적지) 설정 안 하고 환승하는 free trip은 미해결. destination 안 정한 사용자도 진짜 free하려면 환승 자동 detect 필요.

## Scope (첫 PR 한정)
- **포함**: pure detect 알고리즘 + 11 단위 테스트 (100% coverage)
- **제외 (후속 PR)**:
  - stationRoute.ts 확장 wire
  - A1(#916) 다음 leg trainCode 자동 lock 호출
  - F4(#914) 다중 노선 모달 wire
  - #921(signal fusion) 머지 후 가중치 결합으로 강화

## Test
- `npx jest src/features/route/utils/__tests__/transferDetect.test.ts` — 11 passed
- `npm test` — 3774 passed, 글로벌 coverage 100%
- `npm run type-check` — pass
- `transferDetect.ts`: Stmts/Branch/Funcs/Lines 100/100/100/100

## Follow-ups
- [ ] stationRoute.ts 확장 wire + 호출 통합
- [ ] A1 자동 lock 연동
- [ ] F4 다중 후보 모달 연동
- [ ] #921 fusion 가중치 결합으로 신호 강화

Refs #924