### PR TITLE
feat(#925): destination 자동 하차 감지 알고리즘 (C2 첫 PR)

### DIFF
--- a/src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts
+++ b/src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts
@@ -1,0 +1,163 @@
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+import {
+  NEAR_STATION_RADIUS_M,
+  STATIONARY_THRESHOLD_MS,
+} from '../../../../shared/constants/arrivalDetect';
+import type { Station } from '../../../../shared/types/station';
+import { detectDestinationArrival } from '../destinationArrivalDetect';
+
+const DESTINATION: Station = {
+  id: '0150',
+  name: '서울역',
+  line: '1',
+  lineColor: '#0052A4',
+  lat: 37.5547,
+  lng: 126.9707,
+};
+
+// 서울역 좌표에서 정확히 같은 점 = 0m. 살짝 다른 점은 수 m 단위.
+const AT_DESTINATION = { lat: DESTINATION.lat, lng: DESTINATION.lng };
+
+// 1km 가량 떨어진 좌표 (위도 0.01 ≈ 1.11km).
+const FAR_FROM_DESTINATION = { lat: DESTINATION.lat + 0.01, lng: DESTINATION.lng };
+
+describe('detectDestinationArrival', () => {
+  it('shouldAutoClear=true 일 때 confidence=high — 4개 조건 전부 만족', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result).toEqual({ shouldAutoClear: true, confidence: 'high' });
+  });
+
+  it('ENTERING(0) 도 "이 역" 신호로 인정', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ENTERING,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS + 5_000,
+    });
+    expect(result.shouldAutoClear).toBe(true);
+    expect(result.confidence).toBe('high');
+  });
+
+  it('destinationStation 없으면 즉시 low', () => {
+    const result = detectDestinationArrival({
+      destinationStation: null,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('destinationStation undefined 도 low', () => {
+    const result = detectDestinationArrival({
+      destinationStation: undefined,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result.shouldAutoClear).toBe(false);
+    expect(result.confidence).toBe('low');
+  });
+
+  it('userLocation 없으면 low', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: null,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('userLocation undefined 도 low', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: undefined,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result.shouldAutoClear).toBe(false);
+    expect(result.confidence).toBe('low');
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['DEPARTED(2)', ARRIVAL_CODE.DEPARTED],
+    ['PREV_ARRIVED(5)', ARRIVAL_CODE.PREV_ARRIVED],
+    ['PREV_ENTERING(4)', ARRIVAL_CODE.PREV_ENTERING],
+    ['PREV_DEPARTED(3)', ARRIVAL_CODE.PREV_DEPARTED],
+    ['RUNNING(99)', ARRIVAL_CODE.RUNNING],
+  ])('arvlCd 가 "이 역" 신호가 아니면 low — %s', (_label, code) => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: code,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('역에서 멀면 low (NEAR_STATION_RADIUS_M 초과)', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: FAR_FROM_DESTINATION,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('역 부근(<= NEAR_STATION_RADIUS_M) + arvlCd OK + 정지 시간 부족 → medium', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS - 1,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
+  });
+
+  it('stationaryDurationMs null 이면 정지 시간 부족 — medium', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ENTERING,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: null,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
+  });
+
+  it('stationaryDurationMs undefined 이면 medium', () => {
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ENTERING,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: undefined,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
+  });
+
+  it('정확히 NEAR_STATION_RADIUS_M 경계는 통과 — boundary inclusive', () => {
+    // 위도 1m ≈ 0.0000090 도. 50m ≈ 0.000450 도 (위도축).
+    // haversine 정확도 감안해 49m 정도 떨어진 좌표 사용.
+    const nearEdge = { lat: DESTINATION.lat + 0.00044, lng: DESTINATION.lng };
+    const result = detectDestinationArrival({
+      destinationStation: DESTINATION,
+      arvlCdAtDestination: ARRIVAL_CODE.ARRIVED,
+      userLocation: nearEdge,
+      stationaryDurationMs: STATIONARY_THRESHOLD_MS,
+    });
+    expect(result.shouldAutoClear).toBe(true);
+  });
+
+  it('상수 export 확인 — 회귀 게이트', () => {
+    expect(NEAR_STATION_RADIUS_M).toBe(50);
+    expect(STATIONARY_THRESHOLD_MS).toBe(60_000);
+  });
+});

--- a/src/features/alarm/utils/destinationArrivalDetect.ts
+++ b/src/features/alarm/utils/destinationArrivalDetect.ts
@@ -1,0 +1,86 @@
+/**
+ * #925 C2 — destination 자동 하차 감지 (pure 알고리즘).
+ *
+ * 사용자가 destination 역에 명시적으로 "하차" 액션을 안 눌러도, 다음 4개 신호가 동시에
+ * 만족되면 trip을 자동 종료할 수 있다는 판정만 한다(여기서는 부수효과 없음).
+ *
+ *   1) destinationStation 이 설정돼 있다
+ *   2) arvlCdAtDestination 이 "이 역" 신호 — ARRIVED(1) 또는 ENTERING(0)
+ *   3) userLocation 이 destinationStation 좌표로부터 NEAR_STATION_RADIUS_M 이내
+ *   4) stationaryDurationMs >= STATIONARY_THRESHOLD_MS
+ *
+ * 실제 wire(useArrivalAutoClear 확장, LA "도착" 명시 액션, destination 재설정 빠른 UI)는
+ * 후속 PR. 이 PR은 알고리즘 + 100% 커버리지만 다룬다.
+ *
+ * confidence:
+ *   - 'high'   → 4개 모두 만족 (shouldAutoClear=true)
+ *   - 'medium' → arvlCd "이 역" + 거리 게이트 통과, 정지 시간만 부족
+ *   - 'low'    → 그 외
+ */
+
+import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
+import {
+  NEAR_STATION_RADIUS_M,
+  STATIONARY_THRESHOLD_MS,
+} from '../../../shared/constants/arrivalDetect';
+import type { Station } from '../../../shared/types/station';
+import { haversine } from '../../../shared/utils/haversine';
+
+export type ArrivalDetectConfidence = 'high' | 'medium' | 'low';
+
+export interface DestinationArrivalDetectInput {
+  destinationStation: Station | null | undefined;
+  arvlCdAtDestination: number | null | undefined;
+  userLocation: { lat: number; lng: number } | null | undefined;
+  stationaryDurationMs: number | null | undefined;
+}
+
+export interface DestinationArrivalDetectResult {
+  shouldAutoClear: boolean;
+  confidence: ArrivalDetectConfidence;
+}
+
+const KM_TO_M = 1000;
+
+/**
+ * arvlCd 가 "사용자가 그 역에 있다"는 의미인지 — ARRIVED(1) / ENTERING(0) 만 통과.
+ * PREV_* (4/5) 는 "전역" 신호이므로 destination 도착 판정에 쓰면 안 됨.
+ */
+function isAtStationCode(code: number | null | undefined): boolean {
+  return code === ARRIVAL_CODE.ARRIVED || code === ARRIVAL_CODE.ENTERING;
+}
+
+export function detectDestinationArrival(
+  input: DestinationArrivalDetectInput,
+): DestinationArrivalDetectResult {
+  const { destinationStation, arvlCdAtDestination, userLocation, stationaryDurationMs } = input;
+
+  if (destinationStation == null || userLocation == null) {
+    return { shouldAutoClear: false, confidence: 'low' };
+  }
+
+  const atStation = isAtStationCode(arvlCdAtDestination);
+  if (!atStation) {
+    return { shouldAutoClear: false, confidence: 'low' };
+  }
+
+  const distanceM =
+    haversine(
+      userLocation.lat,
+      userLocation.lng,
+      destinationStation.lat,
+      destinationStation.lng,
+    ) * KM_TO_M;
+  const nearStation = distanceM <= NEAR_STATION_RADIUS_M;
+  if (!nearStation) {
+    return { shouldAutoClear: false, confidence: 'low' };
+  }
+
+  const stationaryEnough =
+    stationaryDurationMs != null && stationaryDurationMs >= STATIONARY_THRESHOLD_MS;
+  if (!stationaryEnough) {
+    return { shouldAutoClear: false, confidence: 'medium' };
+  }
+
+  return { shouldAutoClear: true, confidence: 'high' };
+}

--- a/src/shared/constants/arrivalDetect.ts
+++ b/src/shared/constants/arrivalDetect.ts
@@ -1,0 +1,17 @@
+/**
+ * #925 destination 자동 하차 감지 임계값.
+ *
+ * "사용자가 destination 역에 도착했고 N초 동안 정지해 있다 = 하차 완료"로 본다.
+ *
+ * - NEAR_STATION_RADIUS_M (50m):
+ *   역 좌표 vs 사용자 좌표의 허용 오차. 서울 지하철역 출구간 거리(통상 100~300m) 대비 보수.
+ *   GPS 노이즈가 큰 지하/실내에서는 어차피 GPS 매칭이 안 되므로, 이 게이트는
+ *   "지상 + 역 부근"이 명확한 케이스에서만 통과한다. 너무 넓히면 인접 역 통과 시 false positive.
+ *
+ * - STATIONARY_THRESHOLD_MS (60s):
+ *   "정지" 판정 시간. 일반 정차(20~30s)는 통과 못 하고, 하차 후 개찰구로 걷는 시간이
+ *   포함되도록 1분. 너무 짧으면 정차 중 자동 해제, 너무 길면 LA가 불필요하게 오래 떠 있다.
+ *   재측정 후 (B/C/D 슬라이스에서) 조정 가능.
+ */
+export const NEAR_STATION_RADIUS_M = 50;
+export const STATIONARY_THRESHOLD_MS = 60_000;


### PR DESCRIPTION
## Summary
- Epic #912 / sub #925 (C2) 첫 슬라이스 — destination 자동 하차 감지 **pure 알고리즘만** 추가.
- 4-신호 AND 게이트: destinationStation + arvlCd ∈ {ARRIVED(1), ENTERING(0)} + 역 부근(<=50m) + 정지(>=60s).
- 결과: `{ shouldAutoClear: boolean, confidence: 'high' | 'medium' | 'low' }`.
- 임계 상수는 `src/shared/constants/arrivalDetect.ts`로 분리 (재측정 후 조정 가능).

## Why
사용자가 destination 도착 후 "하차" 명시 액션을 안 누르고 그냥 내리는 케이스에서 LA/trip이 정리되지 않는 UX 결함(#925 본문 참고). "도착 = 자동 종료"가 자연스러우므로, 신호 4개가 동시 충족될 때만 종료를 트리거하는 게이트를 우선 알고리즘으로 만든다.

## Scope (이번 PR 한정)
- `src/features/alarm/utils/destinationArrivalDetect.ts` — pure 함수
- `src/shared/constants/arrivalDetect.ts` — `NEAR_STATION_RADIUS_M=50`, `STATIONARY_THRESHOLD_MS=60_000`
- 100% 커버리지 (19 cases)

## Out of scope (후속 PR)
- `useArrivalAutoClear` / `useStationAlarm` wire-up
- LA "도착" 명시 액션(취소 가능) UI
- 자동 해제 후 destination 빠른 재설정 UI
- `modules/live-activity` native 변경
- stationary 측정 인프라(motion-activity 또는 GPS 변화량 기반)

## Test plan
- [x] `npx jest src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts --coverage` → 19/19 pass, 100% lines/branches/funcs/statements
- [x] `npm test` 전체 → 3782/3782 pass
- [x] `npm run type-check` clean
- [ ] CI `Type Check & Test` 통과 확인 후 머지 (사용자 결정)

Refs #925
Refs #912