### PR TITLE
feat(#919): trip-end recall 트리거 wire + idempotency (A4 후속 PR)

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -5,6 +5,8 @@ import {
   ROUTE_KEY,
   BOARDING_LOCK_KEY,
   ACTIVE_TRIP_KEY,
+  TRIP_STARTED_AT_KEY,
+  LAST_UPLOADED_RECALL_TRIP_START_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
@@ -32,6 +34,11 @@ describe('tripBoundCleanups', () => {
     expect(removedKeys).toContain(ROUTE_KEY);
     expect(removedKeys).toContain(BOARDING_LOCK_KEY);
     expect(removedKeys).toContain(ACTIVE_TRIP_KEY);
+    // #919 — trip start는 cleanup 대상이지만 LAST_UPLOADED_RECALL_TRIP_START_KEY는 보존
+    // (dedup 마커 — BG silent push upload 후 직후 FG setDestination(null) 재트리거 시
+    //  같은 tripStart 중복 upload 방지). 다른 tripStart로 시작되면 자연 무효화됨.
+    expect(removedKeys).toContain(TRIP_STARTED_AT_KEY);
+    expect(removedKeys).not.toContain(LAST_UPLOADED_RECALL_TRIP_START_KEY);
   });
 
   it('TRIP_BOUND_CLEANUPS의 모든 항목은 호출 가능하며 Promise를 반환하고 reject하지 않는다', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -16,6 +16,8 @@ import {
   ACTIVE_TRIP_KEY,
   TRIP_ORIGIN_KEY,
   ALARM_EVENT_KEY,
+  TRIP_STARTED_AT_KEY,
+  LAST_UPLOADED_RECALL_TRIP_START_KEY,
 } from '../../../shared/constants/storageKeys';
 import {
   clearFiredAlarms,
@@ -58,6 +60,11 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   () => AsyncStorage.removeItem(ALARM_EVENT_KEY),
   // #746 — 새 trip 시작 시 이전 trip의 dismiss silence는 무효 → 즉시 클리어.
   clearDismissSilenceStorage,
+  // #919 — trip 시작 시각만 제거. LAST_UPLOADED_RECALL_TRIP_START_KEY는 dedup 마커이므로
+  // 새 trip이 시작될 때 (tripStart 값이 달라질 때) 자연 무효화된다. 여기서 같이 지우면
+  // BG silent-push가 upload + 직후 FG setDestination(null)이 같은 tripStart로 재trigger되는
+  // 경계(self review)에서 idempotency가 깨져 중복 upload 가능 → 보존이 안전.
+  () => AsyncStorage.removeItem(TRIP_STARTED_AT_KEY),
 ];
 
 /**

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -47,6 +47,12 @@ jest.mock('../../utils/tripEndedSentinel', () => ({
   setTripEndedSentinel: (...args: unknown[]) => mockSetTripEndedSentinel(...args),
 }));
 
+// #919 — trip-ended 분기는 cleanup 직전에 recall trigger를 호출한다.
+const mockTriggerTripEndRecall = jest.fn().mockResolvedValue({ uploaded: false });
+jest.mock('../../utils/triggerTripEndRecall', () => ({
+  triggerTripEndRecall: (...args: unknown[]) => mockTriggerTripEndRecall(...args),
+}));
+
 const mockCheckGate = jest.fn();
 jest.mock('../../utils/silentPushLocationGate', () => ({
   checkSilentPushLocationGate: (...args: unknown[]) => mockCheckGate(...args),
@@ -215,6 +221,8 @@ describe('silentPushTask', () => {
     // #746 — 기본 silence 없음.
     mockGetDismissSilence.mockResolvedValue(null);
     mockClearDismissSilence.mockResolvedValue(undefined);
+    // #919 — recall trigger 기본 graceful skip.
+    mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
   });
 
   it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
@@ -1369,6 +1377,35 @@ describe('silentPushTask', () => {
         });
         await handleSilentPush(tripEndedPayload({ tripToken: 'OLD-TRIP-TOKEN' }));
         expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      });
+
+      // #919 — trip-end recall KPI 측정. cleanup *이전*에 trigger되어야 routeStops를 읽을 수 있다.
+      it('#919 — trip-ended 수신 시 triggerTripEndRecall 호출 + cleanup *이전* 순서 보장', async () => {
+        const callOrder: string[] = [];
+        mockTriggerTripEndRecall.mockImplementation(async () => {
+          callOrder.push('trigger');
+          return { uploaded: false };
+        });
+        mockRunTripBoundCleanups.mockImplementation(async () => {
+          callOrder.push('cleanup');
+        });
+
+        await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+
+        expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
+        expect(callOrder).toEqual(['trigger', 'cleanup']);
+      });
+
+      it('#919 — tripToken mismatch로 cleanup skip 시 recall trigger도 호출 안 함', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return 'NEW-TRIP-TOKEN';
+          return null;
+        });
+        await handleSilentPush(
+          tripEndedPayload({ pushId: 'te-uuid', tripToken: 'OLD-TRIP-TOKEN' }),
+        );
+        expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -47,6 +47,7 @@ import {
 } from '../utils/alarmLog';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { setTripEndedSentinel } from '../utils/tripEndedSentinel';
+import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
@@ -448,6 +449,10 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         sentAt: payload.sentAt,
         receivedAt,
       });
+      // #919 — trip-end recall KPI upload. *반드시* cleanup 전에 호출해야 한다 — trigger가
+      // ROUTE_KEY/DESTINATION_KEY/TRIP_STARTED_AT_KEY를 읽어 routeStops를 구성하기 때문.
+      // trigger는 throw하지 않으므로 후속 cleanup/sentinel 흐름 차단 없음.
+      await triggerTripEndRecall();
       await runTripBoundCleanups();
       // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
       // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -1,0 +1,205 @@
+/**
+ * triggerTripEndRecall — trip-end recall trigger 통합 테스트 (#919).
+ *
+ * AsyncStorage / computeAndUploadTripRecall / computeRouteArc / getTripStartedAt 을 mock하여
+ * trigger의 순서 + idempotency + graceful 분기를 검증한다.
+ */
+
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+const mockComputeAndUploadTripRecall = jest.fn();
+const mockComputeRouteArc = jest.fn();
+const mockGetTripStartedAt = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (...args: unknown[]) => mockGetItem(...args),
+    setItem: (...args: unknown[]) => mockSetItem(...args),
+  },
+}));
+
+jest.mock('../alarmLogTelemetry', () => ({
+  computeAndUploadTripRecall: (...args: unknown[]) => mockComputeAndUploadTripRecall(...args),
+}));
+
+jest.mock('../../../route/utils/routeProgress', () => ({
+  computeRouteArc: (...args: unknown[]) => mockComputeRouteArc(...args),
+}));
+
+jest.mock('../tripStartStorage', () => ({
+  getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { triggerTripEndRecall } from '../triggerTripEndRecall';
+import {
+  DESTINATION_KEY,
+  ROUTE_KEY,
+  TRIP_ORIGIN_KEY,
+  LAST_UPLOADED_RECALL_TRIP_START_KEY,
+} from '../../../../shared/constants/storageKeys';
+
+const ROUTE_JSON = JSON.stringify({ type: 'direct', line: '2', stops: 3, travelSeconds: 300 });
+const ORIGIN_JSON = JSON.stringify({ id: 'o', name: 'Origin', line: '2', lat: 0, lng: 0 });
+const DEST_JSON = JSON.stringify({ id: 'd', name: 'Dest', line: '2', lat: 0, lng: 0 });
+
+function setStorage(map: Record<string, string | null>): void {
+  mockGetItem.mockImplementation((key: string) =>
+    Promise.resolve(map[key] !== undefined ? map[key] : null),
+  );
+}
+
+const ROUTE_ARC_STATIONS = [
+  { id: 'o', name: 'Origin', line: '2', lat: 0, lng: 0 },
+  { id: 'm', name: 'Mid', line: '2', lat: 0, lng: 0 },
+  { id: 'd', name: 'Dest', line: '2', lat: 0, lng: 0 },
+];
+
+describe('triggerTripEndRecall', () => {
+  beforeEach(() => {
+    mockGetItem.mockReset();
+    mockSetItem.mockReset();
+    mockComputeAndUploadTripRecall.mockReset();
+    mockComputeRouteArc.mockReset();
+    mockGetTripStartedAt.mockReset();
+  });
+
+  it('tripStart 부재 시 즉시 skip (no-trip-start)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(null);
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'no-trip-start' });
+    expect(mockComputeAndUploadTripRecall).not.toHaveBeenCalled();
+  });
+
+  it('idempotency — 같은 tripStart 로 이미 upload 됐으면 skip (duplicate)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({ [LAST_UPLOADED_RECALL_TRIP_START_KEY]: '100' });
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'duplicate' });
+    expect(mockComputeAndUploadTripRecall).not.toHaveBeenCalled();
+  });
+
+  it('route/origin/destination 누락 시 skip (route-arc-failed)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: null, // 누락
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'route-arc-failed' });
+    expect(mockComputeAndUploadTripRecall).not.toHaveBeenCalled();
+  });
+
+  it('JSON parse 실패 시 skip (route-arc-failed)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: '{invalid json',
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'route-arc-failed' });
+  });
+
+  it('computeRouteArc null 반환 시 skip (route-arc-failed)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue(null);
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'route-arc-failed' });
+  });
+
+  it('정상 흐름 — routeStops 이름 배열을 computeAndUploadTripRecall 에 전달 + 성공 시 LAST_UPLOADED 기록', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue({ stations: ROUTE_ARC_STATIONS, arcM: [0, 1, 2], totalLengthM: 2 });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockSetItem.mockResolvedValue(undefined);
+
+    const result = await triggerTripEndRecall();
+
+    expect(mockComputeAndUploadTripRecall).toHaveBeenCalledWith({
+      routeStops: ['Origin', 'Mid', 'Dest'],
+      tripStart: 100,
+    });
+    expect(mockSetItem).toHaveBeenCalledWith(LAST_UPLOADED_RECALL_TRIP_START_KEY, '100');
+    expect(result).toEqual({ uploaded: true });
+  });
+
+  it('uploaded=false 면 LAST_UPLOADED 기록 안 함 (idempotency 차단 방지)', async () => {
+    // backend 실패 등으로 uploaded=false 면 다음 trigger에서 재시도 가능해야 함.
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue({ stations: ROUTE_ARC_STATIONS, arcM: [0, 1, 2], totalLengthM: 2 });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: false, skipped: 'empty' });
+
+    const result = await triggerTripEndRecall();
+
+    expect(mockSetItem).not.toHaveBeenCalled();
+    expect(result).toEqual({ uploaded: false });
+  });
+
+  it('예외 발생 시 graceful skip (error) — throw 안 함', async () => {
+    mockGetTripStartedAt.mockRejectedValue(new Error('boom'));
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'error' });
+  });
+
+  it('LAST_UPLOADED 값이 다른 tripStart면 정상 upload 진행', async () => {
+    mockGetTripStartedAt.mockResolvedValue(200);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: '100', // 이전 trip
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue({ stations: ROUTE_ARC_STATIONS, arcM: [0, 1, 2], totalLengthM: 2 });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockSetItem.mockResolvedValue(undefined);
+
+    const result = await triggerTripEndRecall();
+
+    expect(mockComputeAndUploadTripRecall).toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith(LAST_UPLOADED_RECALL_TRIP_START_KEY, '200');
+    expect(result).toEqual({ uploaded: true });
+  });
+});

--- a/src/features/alarm/utils/__tests__/tripStartStorage.test.ts
+++ b/src/features/alarm/utils/__tests__/tripStartStorage.test.ts
@@ -1,0 +1,85 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  setTripStartedAt,
+  getTripStartedAt,
+  clearTripStartedAt,
+} from '../tripStartStorage';
+import { TRIP_STARTED_AT_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockRemoveItem = AsyncStorage.removeItem as jest.Mock;
+
+describe('tripStartStorage', () => {
+  beforeEach(() => {
+    mockSetItem.mockReset();
+    mockGetItem.mockReset();
+    mockRemoveItem.mockReset();
+  });
+
+  describe('setTripStartedAt', () => {
+    it('주어진 시각을 TRIP_STARTED_AT_KEY 에 기록한다', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await setTripStartedAt(123456);
+      expect(mockSetItem).toHaveBeenCalledWith(TRIP_STARTED_AT_KEY, '123456');
+    });
+
+    it('인자 미지정 시 Date.now() 사용', async () => {
+      const NOW = 999_999;
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      mockSetItem.mockResolvedValue(undefined);
+      await setTripStartedAt();
+      expect(mockSetItem).toHaveBeenCalledWith(TRIP_STARTED_AT_KEY, String(NOW));
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('AsyncStorage 실패 시 graceful (throw 안 함)', async () => {
+      mockSetItem.mockRejectedValue(new Error('fail'));
+      await expect(setTripStartedAt(1)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getTripStartedAt', () => {
+    it('숫자 문자열을 number로 파싱해서 반환', async () => {
+      mockGetItem.mockResolvedValue('42');
+      await expect(getTripStartedAt()).resolves.toBe(42);
+    });
+
+    it('키 부재 시 null', async () => {
+      mockGetItem.mockResolvedValue(null);
+      await expect(getTripStartedAt()).resolves.toBeNull();
+    });
+
+    it('NaN/비숫자 raw 는 null', async () => {
+      mockGetItem.mockResolvedValue('not-a-number');
+      await expect(getTripStartedAt()).resolves.toBeNull();
+    });
+
+    it('AsyncStorage 실패 시 graceful null', async () => {
+      mockGetItem.mockRejectedValue(new Error('fail'));
+      await expect(getTripStartedAt()).resolves.toBeNull();
+    });
+  });
+
+  describe('clearTripStartedAt', () => {
+    it('TRIP_STARTED_AT_KEY 를 제거한다', async () => {
+      mockRemoveItem.mockResolvedValue(undefined);
+      await clearTripStartedAt();
+      expect(mockRemoveItem).toHaveBeenCalledWith(TRIP_STARTED_AT_KEY);
+    });
+
+    it('AsyncStorage 실패 시 graceful (throw 안 함)', async () => {
+      mockRemoveItem.mockRejectedValue(new Error('fail'));
+      await expect(clearTripStartedAt()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/features/alarm/utils/recallMetrics.ts
+++ b/src/features/alarm/utils/recallMetrics.ts
@@ -20,9 +20,22 @@ export interface TripRecallInput {
   routeStops: readonly string[];
   /** alarmLog ring buffer 의 모든 entries (필터링은 내부에서). */
   entries: readonly AlarmLogEntry[];
-  /** trip 시작 epoch ms (exclusive) — 이전 trip 의 잔여 entries 차단. */
+  /**
+   * trip 시작 epoch ms — alarmLog 윈도우의 **exclusive lower bound** (`entry.ts > tripStart`).
+   *
+   * 의미: "이 시각보다 *뒤에* 적재된 alarmLog entries만 카운트한다."
+   *
+   * 경계 정책 (#919 P2-1):
+   *  - 권장: `setDestination(non-null)`로 새 trip을 만든 직후의 `Date.now()` 시각을 사용한다
+   *    (`tripStartStorage.setTripStartedAt`이 자동 기록). 이렇게 하면 직전 trip의 종료 직후에
+   *    적재된 entries(예: 같은 ms에 fire된 마지막 station-passed)가 새 trip에 leak되지 않는다.
+   *  - exclusive 인 이유: 동일 ms에 두 trip 경계가 겹치는 코너 케이스에서 직전 trip 의 entry 가
+   *    새 trip 의 분자에 포함되지 않도록 한다 (혼합 회귀 차단).
+   *  - 만약 caller가 *직전 trip의 마지막 entry ts* 같은 보수적 값을 쓰고 싶다면 그 ts 그대로
+   *    넘기면 된다 — exclusive 비교라 그 entry 자체는 제외되고 그 다음(>)부터만 포함된다.
+   */
   tripStart: number;
-  /** trip 종료 epoch ms (inclusive). */
+  /** trip 종료 epoch ms — alarmLog 윈도우의 **inclusive upper bound** (`entry.ts <= tripEnd`). */
   tripEnd: number;
 }
 

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -1,0 +1,131 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: trip-end 시점에 route(stations 시퀀스 재구성) + alarm(log 윈도우)
+ * + telemetry(backend upload)를 한 곳에서 묶어 호출하는 trigger. route 슬라이스의
+ * `computeRouteArc`를 직접 참조하는 것이 본질이므로 file-level disable로 옵트인 처리.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * Trip 종료 시 매역 알림 recall KPI 1건을 backend `/telemetry/recall`로 upload하는 trigger (#919).
+ *
+ * 호출자 (두 경로):
+ *  1. silent push `trip-ended` BG handler — backend가 trip을 자동 종료할 때.
+ *  2. FG `useDestinationStore.setDestination(null)` — 사용자가 destination 직접 클리어할 때.
+ *
+ * 두 경로 모두 `runTripBoundCleanups` *이전* 에 호출되어야 한다. cleanup이 `ROUTE_KEY` /
+ * `DESTINATION_KEY` / `TRIP_ORIGIN_KEY` / `TRIP_STARTED_AT_KEY`를 제거하므로 trigger가
+ * 그 뒤에 돌면 recall 입력이 비어 자동 skip ('empty')된다.
+ *
+ * Idempotency (P2-2):
+ *  - 같은 `tripStart`로 두 번 호출되면 두 번째는 `LAST_UPLOADED_RECALL_TRIP_START_KEY`
+ *    비교로 skip한다. silent push trip-ended 직후 FG 복귀 시 useStateRehydration이
+ *    `setDestination(null)`을 다시 호출하는 race 경로(#899 sentinel)에서 중복 upload 차단.
+ *
+ * 동작 변경 없음 — 순수 측정. routeStops 미구성 / tripStart 부재 / backend 실패 모두
+ * 호출자 흐름 차단 없이 graceful skip.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  DESTINATION_KEY,
+  ROUTE_KEY,
+  TRIP_ORIGIN_KEY,
+  LAST_UPLOADED_RECALL_TRIP_START_KEY,
+} from '../../../shared/constants/storageKeys';
+import type { Station } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
+import { computeRouteArc } from '../../route/utils/routeProgress';
+import { computeAndUploadTripRecall } from './alarmLogTelemetry';
+import { getTripStartedAt } from './tripStartStorage';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('triggerTripEndRecall');
+
+export type TriggerTripEndRecallSkipReason =
+  | 'no-trip-start'
+  | 'no-route'
+  | 'no-destination'
+  | 'no-origin'
+  | 'route-arc-failed'
+  | 'duplicate'
+  | 'error';
+
+export interface TriggerTripEndRecallResult {
+  uploaded: boolean;
+  skipped?: TriggerTripEndRecallSkipReason;
+}
+
+/**
+ * Trip-end recall trigger. 호출자(`trip-ended` silent push handler / FG setDestination(null))는
+ * 이 함수를 fire-and-forget으로 호출한 뒤 `runTripBoundCleanups`로 storage를 정리한다.
+ *
+ * 절대 throw 하지 않는다 — 호출자 흐름(cleanup, route reset)의 critical path를
+ * 측정 인프라가 차단하면 안 된다.
+ */
+export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult> {
+  try {
+    const tripStart = await getTripStartedAt();
+    if (tripStart === null) {
+      return { uploaded: false, skipped: 'no-trip-start' };
+    }
+
+    // Idempotency 가드 (P2-2). silent push trip-ended → FG 복귀 → useStateRehydration의
+    // setDestination(null) 재호출 같은 race에서도 중복 upload 차단.
+    const lastUploadedRaw = await AsyncStorage.getItem(LAST_UPLOADED_RECALL_TRIP_START_KEY);
+    if (lastUploadedRaw !== null && Number(lastUploadedRaw) === tripStart) {
+      log.info(`duplicate trip-end recall skip: tripStart=${tripStart}`);
+      return { uploaded: false, skipped: 'duplicate' };
+    }
+
+    const routeStops = await loadRouteStops();
+    if (routeStops === null) {
+      return { uploaded: false, skipped: 'route-arc-failed' };
+    }
+
+    const result = await computeAndUploadTripRecall({
+      routeStops,
+      tripStart,
+    });
+
+    if (result.uploaded) {
+      // tripStart를 idempotency 키로 기록. 다음 trip 시작 시 tripBoundCleanups에서 제거되므로
+      // 새 trip은 다시 upload 가능.
+      await AsyncStorage.setItem(LAST_UPLOADED_RECALL_TRIP_START_KEY, String(tripStart));
+    }
+
+    return { uploaded: result.uploaded };
+  } catch (e) {
+    log.warn('trigger error', e);
+    return { uploaded: false, skipped: 'error' };
+  }
+}
+
+/**
+ * AsyncStorage의 route/origin/destination를 읽어 ordered station name 시퀀스를 만든다.
+ * 하나라도 누락 / parse 실패 / arc 계산 실패 시 null — caller가 graceful skip.
+ *
+ * origin은 TRIP_ORIGIN_KEY(#700 — destination set 시점에 캡처된 진짜 출발역)를 사용한다.
+ * customOrigin은 GPS와 별개라 trip 시작 시점의 진짜 출발 지점을 보장하지 못한다.
+ */
+async function loadRouteStops(): Promise<string[] | null> {
+  const [routeRaw, originRaw, destinationRaw] = await Promise.all([
+    AsyncStorage.getItem(ROUTE_KEY),
+    AsyncStorage.getItem(TRIP_ORIGIN_KEY),
+    AsyncStorage.getItem(DESTINATION_KEY),
+  ]);
+  if (!routeRaw || !originRaw || !destinationRaw) return null;
+
+  let route: Route;
+  let origin: Station;
+  let destination: Station;
+  try {
+    route = JSON.parse(routeRaw) as Route;
+    origin = JSON.parse(originRaw) as Station;
+    destination = JSON.parse(destinationRaw) as Station;
+  } catch {
+    return null;
+  }
+
+  const arc = computeRouteArc(route, origin, destination);
+  if (!arc) return null;
+  return arc.stations.map((s) => s.name);
+}

--- a/src/features/alarm/utils/tripStartStorage.ts
+++ b/src/features/alarm/utils/tripStartStorage.ts
@@ -1,0 +1,46 @@
+/**
+ * Trip 시작 시각 storage (#919, Epic #912 A4).
+ *
+ * trip-end recall KPI 계산을 위해 trip이 시작한 순간을 epoch ms로 기록한다.
+ * `tripStart`는 recall 계산에서 alarmLog 윈도우의 exclusive lower bound로 사용된다
+ * (이전 trip 의 잔여 entries가 새 trip 의 recall에 섞이지 않도록).
+ *
+ * Writers: `useDestinationStore.setDestination(non-null)` (FG, isSwitch 분기).
+ * Reader: trip-end recall trigger (silent push trip-ended / FG setDestination(null)).
+ * Cleanup: `tripBoundCleanups` — 새 trip 시작 또는 trip 종료 시 함께 제거.
+ *
+ * 모든 함수는 AsyncStorage 실패를 graceful 흡수 — 기록 실패는 recall 측정 가능 여부만
+ * 영향, 알람 발사 흐름에는 무영향.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TRIP_STARTED_AT_KEY } from '../../../shared/constants/storageKeys';
+
+/** Trip 시작 시각 기록. setDestination switch 분기에서 호출. */
+export async function setTripStartedAt(at: number = Date.now()): Promise<void> {
+  try {
+    await AsyncStorage.setItem(TRIP_STARTED_AT_KEY, String(at));
+  } catch {
+    // graceful — recall 측정만 영향, trip 흐름 무관.
+  }
+}
+
+/** Trip 시작 epoch ms 또는 null. 키 부재/NaN 모두 null. */
+export async function getTripStartedAt(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(TRIP_STARTED_AT_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Trip 시작 시각 제거. tripBoundCleanups에서 호출. */
+export async function clearTripStartedAt(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(TRIP_STARTED_AT_KEY);
+  } catch {
+    // graceful — 다음 cleanup에서 재시도.
+  }
+}

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -8,10 +8,21 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useDestinationStore } from '../useDestinationStore';
 import { useAlarmEventStore } from '../../../alarm/store/useAlarmEventStore';
 import { Station } from '../../../../shared/types/station';
+import { setTripStartedAt } from '../../../alarm/utils/tripStartStorage';
+import { triggerTripEndRecall } from '../../../alarm/utils/triggerTripEndRecall';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
+
+// #919 — recall trigger / tripStart setter는 wiring 본 자체가 단위 검증 대상이라
+// store 테스트에서는 호출 여부만 확인하면 충분. 실제 동작은 각 파일의 전용 테스트에서.
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  setTripStartedAt: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../../alarm/utils/triggerTripEndRecall', () => ({
+  triggerTripEndRecall: jest.fn().mockResolvedValue({ uploaded: false }),
+}));
 
 const mockStation: Station = {
   id: '2-022',
@@ -42,6 +53,10 @@ describe('useDestinationStore', () => {
     });
     useAlarmEventStore.setState({ alarmEvent: null, dismissSilence: null });
     jest.clearAllMocks();
+    // jest.clearAllMocks가 mock implementations도 리셋 — #919 trigger/setTripStartedAt이
+    // Promise를 반환하지 않으면 setDestination의 .then chain이 깨진다. 기본 impl 복구.
+    (triggerTripEndRecall as jest.Mock).mockResolvedValue({ uploaded: false });
+    (setTripStartedAt as jest.Mock).mockResolvedValue(undefined);
   });
 
   // ── destination ──
@@ -68,7 +83,7 @@ describe('useDestinationStore', () => {
     expect(destination).toBeNull();
   });
 
-  it('setDestination: 역 설정 시 AsyncStorage에 저장하고 null 시 삭제한다', () => {
+  it('setDestination: 역 설정 시 AsyncStorage에 저장하고 null 시 삭제한다', async () => {
     const { setDestination } = useDestinationStore.getState();
     setDestination(mockStation);
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
@@ -77,7 +92,11 @@ describe('useDestinationStore', () => {
     );
 
     jest.clearAllMocks();
+    (triggerTripEndRecall as jest.Mock).mockResolvedValue({ uploaded: false });
+    (setTripStartedAt as jest.Mock).mockResolvedValue(undefined);
     setDestination(null);
+    // #919 — trigger → cleanup이 then-chain이라 microtask flush 후 검증.
+    await flushMicrotasks();
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:destination');
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:fired-alarms');
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:route');
@@ -85,13 +104,17 @@ describe('useDestinationStore', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:trip-origin');
   });
 
-  it('setDestination(#702): 목적지 switch 시 부수 storage(customOrigin/lock/scheduled/active-trip) 자동 클리어', () => {
+  it('setDestination(#702): 목적지 switch 시 부수 storage(customOrigin/lock/scheduled/active-trip) 자동 클리어', async () => {
     const { setDestination } = useDestinationStore.getState();
     setDestination(mockStation);
     jest.clearAllMocks();
+    (triggerTripEndRecall as jest.Mock).mockResolvedValue({ uploaded: false });
+    (setTripStartedAt as jest.Mock).mockResolvedValue(undefined);
 
     // 다른 역으로 switch
     setDestination(mockStation2);
+    // #919 — trigger → cleanup이 then-chain이라 microtask flush 후 검증.
+    await flushMicrotasks();
 
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:custom-origin');
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:boarding-lock');
@@ -101,12 +124,16 @@ describe('useDestinationStore', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:route');
   });
 
-  it('setDestination(#702): null로 클리어 시에도 부수 storage 자동 클리어', () => {
+  it('setDestination(#702): null로 클리어 시에도 부수 storage 자동 클리어', async () => {
     const { setDestination } = useDestinationStore.getState();
     setDestination(mockStation);
     jest.clearAllMocks();
+    (triggerTripEndRecall as jest.Mock).mockResolvedValue({ uploaded: false });
+    (setTripStartedAt as jest.Mock).mockResolvedValue(undefined);
 
     setDestination(null);
+    // #919 — trigger → cleanup이 then-chain이라 microtask flush 후 검증.
+    await flushMicrotasks();
 
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:custom-origin');
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:boarding-lock');
@@ -116,9 +143,12 @@ describe('useDestinationStore', () => {
 
   // clearFiredPushIds는 firedPushIds 모듈의 write queue를 통과 — microtask flush 후 검증.
   async function flushMicrotasks(): Promise<void> {
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // #919 — setDestination이 triggerTripEndRecall → runTripBoundCleanups → setTripStartedAt
+    // 세 단계 then-chain을 돌리는데 cleanup 안에서 Promise.allSettled가 추가 microtask를 만든다.
+    // 충분히 넉넉하게 flush.
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
   }
 
   // #799: switch와 null 두 경로가 동일한 trip-bound cleanup을 트리거하므로 it.each로 통합.
@@ -501,5 +531,68 @@ describe('useDestinationStore', () => {
       sinceLat: 0,
       sinceLng: 0,
     });
+  });
+
+  // ── #919 trip-end recall wiring ──
+
+  it('setDestination(#919): switch 시 triggerTripEndRecall이 cleanup *이전*에 호출된다', async () => {
+    // 호출 순서를 추적 — trigger가 cleanup *이전*이어야 ROUTE_KEY 등을 읽을 수 있다.
+    const callOrder: string[] = [];
+    (triggerTripEndRecall as jest.Mock).mockImplementation(async () => {
+      callOrder.push('trigger');
+      return { uploaded: false };
+    });
+    (setTripStartedAt as jest.Mock).mockImplementation(async () => {
+      callOrder.push('setTripStartedAt');
+    });
+    // runTripBoundCleanups 자체를 spy 못 하므로 그 안에서 호출되는 removeItem 첫 트리거를 마커로 사용.
+    (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (!callOrder.includes('cleanup')) callOrder.push('cleanup');
+      return undefined;
+    });
+
+    // 첫 destination — switch (prev=null → next=mockStation).
+    useDestinationStore.getState().setDestination(mockStation);
+    await flushMicrotasks();
+
+    expect(callOrder).toEqual(['trigger', 'cleanup', 'setTripStartedAt']);
+  });
+
+  it('setDestination(#919): null로 종료 시 triggerTripEndRecall 호출, 단 새 tripStart 기록 안 함', async () => {
+    useDestinationStore.setState({ destination: mockStation });
+    const triggerMock = triggerTripEndRecall as jest.Mock;
+    const setTripStartedAtMock = setTripStartedAt as jest.Mock;
+    triggerMock.mockClear();
+    setTripStartedAtMock.mockClear();
+
+    useDestinationStore.getState().setDestination(null);
+    await flushMicrotasks();
+
+    expect(triggerMock).toHaveBeenCalledTimes(1);
+    expect(setTripStartedAtMock).not.toHaveBeenCalled(); // trip 종료 — 새 tripStart 기록 없음
+  });
+
+  it('setDestination(#919): 같은 destination 재설정(isSwitch=false)이면 trigger/set 둘 다 호출 안 됨', async () => {
+    useDestinationStore.setState({ destination: mockStation });
+    const triggerMock = triggerTripEndRecall as jest.Mock;
+    const setTripStartedAtMock = setTripStartedAt as jest.Mock;
+    triggerMock.mockClear();
+    setTripStartedAtMock.mockClear();
+
+    useDestinationStore.getState().setDestination(mockStation);
+    await flushMicrotasks();
+
+    expect(triggerMock).not.toHaveBeenCalled();
+    expect(setTripStartedAtMock).not.toHaveBeenCalled();
+  });
+
+  it('setDestination(#919): trigger가 reject해도 setDestination 흐름은 영향 없음 (graceful)', async () => {
+    const triggerMock = triggerTripEndRecall as jest.Mock;
+    triggerMock.mockRejectedValueOnce(new Error('trigger fail'));
+
+    // throw가 노출되면 unhandled rejection으로 잡힐 것 — 노출 안 되어야 함.
+    useDestinationStore.getState().setDestination(mockStation);
+    await flushMicrotasks();
+    expect(useDestinationStore.getState().destination?.id).toBe('2-022');
   });
 });

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -16,6 +16,8 @@ import {
   ROUTE_PREFERENCE_KEY,
 } from '../../../shared/constants/storageKeys';
 import { runTripBoundCleanups } from '../../alarm/store/tripBoundCleanups';
+import { setTripStartedAt } from '../../alarm/utils/tripStartStorage';
+import { triggerTripEndRecall } from '../../alarm/utils/triggerTripEndRecall';
 import { useAlarmEventStore } from '../../alarm/store/useAlarmEventStore';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../../../shared/utils/stationRoute';
 
@@ -81,11 +83,22 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
     // 주의: 여기서는 storage만 정리한다. BoardingLock 메모리 release 및 예약 알림 cancel은
     // useBoardingLockController가 destinationId 변경 감지로 처리한다 (store 분리 유지).
     if (isSwitch) {
-      // trip-bound storage 키 cleanup은 단일 메타 배열에서 일괄 실행한다.
-      // 새 trip-bound 키 추가 시 src/features/alarm/store/tripBoundCleanups.ts에 한 줄만
-      // 추가하면 setDestination에서 누락 회귀가 차단된다. (#702 → #799 사이
-      // LAST_FIRED_ALARM_STATION_NAME_KEY, #746 dismissSilence 등 누락 사례 재발 방지.)
-      runTripBoundCleanups().catch(noop);
+      // #919 + cleanup + 새 trip 기록을 순서대로 chain. 각 단계는 자체 catch를 가져
+      // 한 단계 실패가 다음 단계를 막지 않도록 한다 — 측정 인프라가 cleanup의 critical
+      // path를 차단하면 안 된다.
+      // 1) recall trigger: ROUTE_KEY/DESTINATION_KEY/TRIP_STARTED_AT_KEY를 cleanup 전에 읽어야 함
+      // 2) trip-bound storage 키 cleanup
+      //    새 trip-bound 키 추가 시 src/features/alarm/store/tripBoundCleanups.ts에 한 줄만
+      //    추가하면 setDestination에서 누락 회귀가 차단된다. (#702 → #799 사이
+      //    LAST_FIRED_ALARM_STATION_NAME_KEY, #746 dismissSilence 등 누락 사례 재발 방지.)
+      // 3) 새 trip(station != null)이면 새 tripStart를 기록 — cleanup이 직전에 이전 키를 제거했으니
+      //    여기서 set하면 다음 trip 측정 가능. station === null(trip 종료) 경로에서는 set 안 함.
+      triggerTripEndRecall()
+        .catch(noop)
+        .then(() => runTripBoundCleanups())
+        .catch(noop)
+        .then(() => (station ? setTripStartedAt() : undefined))
+        .catch(noop);
       // customOrigin 메모리 상태도 동기화. (loadCustomOrigin은 hydration용이므로 영향 없음)
       if (get().customOrigin !== null) {
         set({ customOrigin: null });

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -80,6 +80,17 @@ export const STICKY_STATION_KEY = 'subway-now:sticky-station';
 // 또 다른 trip-ended를 의미.
 // 형식: 숫자 (epoch ms) 문자열.
 export const TRIP_ENDED_BY_BACKEND_AT_KEY = 'subway-now:trip-ended-by-backend-at';
+// #919 — Trip 시작 epoch ms. setDestination(non-null)의 switch 분기에서 set,
+// trip-end 시점에 recall KPI 계산용 alarmLog 윈도우 lower bound로 사용.
+// tripBoundCleanups에서 새 trip 시작 또는 trip 종료 시 함께 제거된다.
+// 형식: 숫자(epoch ms) 문자열.
+export const TRIP_STARTED_AT_KEY = 'subway-now:trip-started-at';
+// #919 — 마지막으로 recall telemetry upload된 tripStart 값. idempotency 가드:
+// 같은 trip을 두 번 trigger해도(silent push trip-ended → FG 진입 후 setDestination(null) race 등)
+// 중복 upload 되지 않도록 비교한다. 새 trip이 시작되면 tripBoundCleanups에서 제거되어
+// 다음 trip에 대해 다시 upload가 가능해진다.
+// 형식: 숫자(epoch ms) 문자열.
+export const LAST_UPLOADED_RECALL_TRIP_START_KEY = 'subway-now:last-uploaded-recall-trip-start';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.


### PR DESCRIPTION
## Summary
Epic #912 P1 A4 follow-up. 첫 PR(#929 merged)의 client-side recall infra(`recallMetrics.ts` + `alarmLogTelemetry.ts`)를 실제 두 trip-end 경로에서 호출하도록 wire.

- 신규 `triggerTripEndRecall.ts`: TRIP_STARTED_AT/ROUTE/DESTINATION 읽어 `computeAndUploadTripRecall` 호출 + idempotency 가드
- 신규 `tripStartStorage.ts`: 새 trip 시작 시 `TRIP_STARTED_AT_KEY` 기록 helper
- `silentPushTask.ts`: backend `trip-ended` silent push 수신 시 trigger
- `useDestinationStore.ts`: FG에서 `setDestination(null)` 시 cleanup 직전에 trigger
- `recallMetrics.ts:isInWindow` JSDoc: `tripStart`는 exclusive boundary 명시

## Self code-review 결과 — P1 1건 반영
- **`LAST_UPLOADED_RECALL_TRIP_START_KEY` cleanup 보존**: BG silent push가 upload + idempotency marker 기록 직후 FG `setDestination(null)`이 같은 tripStart로 재트리거되는 race에서 중복 upload 방지. dedup 마커는 다른 tripStart에서 자연 무효화되므로 cleanup 대상 제외

## 슬라이싱 의도 (Refs #919)
**본 PR 제외, 후속 PR 예정**:
- backend `metrics.catalog.json`에 `perStationAlarmRecall` / `gateSuppressionDistribution` 등록
- Cloudflare Analytics dashboard + 95% 미만 trip Slack alert

## Test plan
- [x] `npm test` 통과 (210 suites, 3787 tests, 100% coverage)
- [x] `npm run type-check` 통과

Refs #912
Refs #919