### PR TITLE
feat(#926): LA dismiss sentinel + TTL 30분 정책 (E3 첫 PR)

### DIFF
--- a/src/features/alarm/utils/__tests__/laDismissSentinel.test.ts
+++ b/src/features/alarm/utils/__tests__/laDismissSentinel.test.ts
@@ -9,16 +9,13 @@ import { LA_DISMISS_SENTINEL_TTL_MS } from '../../../../shared/constants/laDismi
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
-  default: {
-    setItem: jest.fn(),
-    getItem: jest.fn(),
-    removeItem: jest.fn(),
-  },
+  default: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
 }));
 
-const setItemMock = AsyncStorage.setItem as jest.Mock;
-const getItemMock = AsyncStorage.getItem as jest.Mock;
-const removeItemMock = AsyncStorage.removeItem as jest.Mock;
+const storage = jest.mocked(AsyncStorage);
+const setItemMock = storage.setItem;
+const getItemMock = storage.getItem;
+const removeItemMock = storage.removeItem;
 
 describe('laDismissSentinel', () => {
   beforeEach(() => {

--- a/src/features/alarm/utils/__tests__/laDismissSentinel.test.ts
+++ b/src/features/alarm/utils/__tests__/laDismissSentinel.test.ts
@@ -1,0 +1,121 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  clearLaDismissSentinel,
+  isLaDismissed,
+  markLaDismissed,
+} from '../laDismissSentinel';
+import { LA_DISMISSED_AT_KEY } from '../../../../shared/constants/storageKeys';
+import { LA_DISMISS_SENTINEL_TTL_MS } from '../../../../shared/constants/laDismiss';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const setItemMock = AsyncStorage.setItem as jest.Mock;
+const getItemMock = AsyncStorage.getItem as jest.Mock;
+const removeItemMock = AsyncStorage.removeItem as jest.Mock;
+
+describe('laDismissSentinel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setItemMock.mockResolvedValue(undefined);
+    removeItemMock.mockResolvedValue(undefined);
+  });
+
+  describe('markLaDismissed', () => {
+    it('at 인자를 문자열로 직렬화해 sentinel 키에 저장', async () => {
+      await markLaDismissed(1_700_000_000_000);
+      expect(setItemMock).toHaveBeenCalledWith(LA_DISMISSED_AT_KEY, '1700000000000');
+    });
+
+    it('기본값은 Date.now()', async () => {
+      const now = 1_710_000_000_000;
+      const spy = jest.spyOn(Date, 'now').mockReturnValue(now);
+      try {
+        await markLaDismissed();
+      } finally {
+        spy.mockRestore();
+      }
+      expect(setItemMock).toHaveBeenCalledWith(LA_DISMISSED_AT_KEY, String(now));
+    });
+
+    it('AsyncStorage 실패는 graceful', async () => {
+      setItemMock.mockRejectedValueOnce(new Error('disk full'));
+      await expect(markLaDismissed(1)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isLaDismissed', () => {
+    const dismissedAt = 1_700_000_000_000;
+
+    it('키 부재 → false', async () => {
+      getItemMock.mockResolvedValueOnce(null);
+      await expect(isLaDismissed(dismissedAt + 1000)).resolves.toBe(false);
+    });
+
+    it('TTL 안(+15분) → true', async () => {
+      getItemMock.mockResolvedValueOnce(String(dismissedAt));
+      await expect(isLaDismissed(dismissedAt + 15 * 60_000)).resolves.toBe(true);
+    });
+
+    it('TTL 경계(+30분 정각)는 만료(>=) → false', async () => {
+      // TTL은 미만(<) 비교. 정확히 30분 경과 시 만료로 처리.
+      getItemMock.mockResolvedValueOnce(String(dismissedAt));
+      await expect(
+        isLaDismissed(dismissedAt + LA_DISMISS_SENTINEL_TTL_MS),
+      ).resolves.toBe(false);
+    });
+
+    it('TTL 만료(+31분) → false', async () => {
+      getItemMock.mockResolvedValueOnce(String(dismissedAt));
+      await expect(isLaDismissed(dismissedAt + 31 * 60_000)).resolves.toBe(false);
+    });
+
+    it('NaN 문자열 → false (graceful)', async () => {
+      getItemMock.mockResolvedValueOnce('abc');
+      await expect(isLaDismissed(dismissedAt)).resolves.toBe(false);
+    });
+
+    it('clock-skew (at이 미래) → false — NTP 보정으로 시각 점프 시 무기한 차단 방지', async () => {
+      // 디바이스 clock이 forward 점프했다가 NTP가 backward로 정정한 케이스.
+      // 저장된 at이 now보다 큼 (elapsed < 0) → 정상 elapsed로 환산 불가하므로 무효 처리.
+      getItemMock.mockResolvedValueOnce(String(dismissedAt + 10 * 60_000));
+      await expect(isLaDismissed(dismissedAt)).resolves.toBe(false);
+    });
+
+    it('AsyncStorage 실패 → false (게이트 fail-open)', async () => {
+      // sentinel 못 읽으면 LA refresh를 허용하는 쪽으로 fail-open. 보조 채널의
+      // 실패가 silent push 핵심 흐름(알람/LA refresh)을 막아서는 안 된다.
+      getItemMock.mockRejectedValueOnce(new Error('boom'));
+      await expect(isLaDismissed(dismissedAt)).resolves.toBe(false);
+    });
+
+    it('기본 now는 Date.now()', async () => {
+      const now = dismissedAt + 5 * 60_000;
+      const spy = jest.spyOn(Date, 'now').mockReturnValue(now);
+      try {
+        getItemMock.mockResolvedValueOnce(String(dismissedAt));
+        await expect(isLaDismissed()).resolves.toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe('clearLaDismissSentinel', () => {
+    it('removeItem 호출', async () => {
+      await clearLaDismissSentinel();
+      expect(removeItemMock).toHaveBeenCalledWith(LA_DISMISSED_AT_KEY);
+    });
+
+    it('실패는 흡수', async () => {
+      removeItemMock.mockRejectedValueOnce(new Error('boom'));
+      await expect(clearLaDismissSentinel()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/features/alarm/utils/__tests__/refreshLiveActivityFromBackgroundContext.test.ts
+++ b/src/features/alarm/utils/__tests__/refreshLiveActivityFromBackgroundContext.test.ts
@@ -22,6 +22,13 @@ jest.mock('../stationNotification', () => ({
   buildLiveActivityData: (...args: unknown[]) => mockBuild(...args),
 }));
 
+// #926 — LA dismiss sentinel은 본 모듈의 독립 유닛 테스트(`laDismissSentinel.test.ts`)에서
+// 검증한다. 여기서는 wire-up만 격리 검증 — sentinel 활성 시 LA refresh가 skip되는지.
+const mockIsLaDismissed = jest.fn(async () => false);
+jest.mock('../laDismissSentinel', () => ({
+  isLaDismissed: () => mockIsLaDismissed(),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -69,6 +76,7 @@ describe('refreshLiveActivityFromBackgroundContext', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsLiveActivityEnabled.mockReturnValue(true);
+    mockIsLaDismissed.mockResolvedValue(false);
     Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
   });
 
@@ -88,6 +96,14 @@ describe('refreshLiveActivityFromBackgroundContext', () => {
     mockIsLiveActivityEnabled.mockReturnValue(false);
     await refreshLiveActivityFromBackgroundContext();
     expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  it('#926 — dismiss sentinel 활성이면 storage 읽기 전에 skip (LA 안 살림)', async () => {
+    mockIsLaDismissed.mockResolvedValueOnce(true);
+    await refreshLiveActivityFromBackgroundContext();
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    expect(mockEndLiveActivity).not.toHaveBeenCalled();
   });
 
   it('destination 없으면 endLiveActivity 호출', async () => {

--- a/src/features/alarm/utils/laDismissSentinel.ts
+++ b/src/features/alarm/utils/laDismissSentinel.ts
@@ -1,0 +1,58 @@
+/**
+ * #926 (Seam E3) — LA dismiss sentinel storage + 정책.
+ *
+ * 사용자가 Live Activity를 dismiss하면 `markLaDismissed()`를 호출해 sentinel을 기록한다.
+ * silent push 핸들러(`refreshLiveActivityFromBackgroundContext`)는 호출 직전에
+ * `isLaDismissed(now)`로 확인하고, 활성이면 LA refresh를 skip한다.
+ *
+ * 정책:
+ *  - sentinel TTL = `LA_DISMISS_SENTINEL_TTL_MS` (30분). TTL 경과 후 자동 만료 → LA 재상승 OK.
+ *  - 명시적 reset(destination 재설정 / 앱 진입)은 `clearLaDismissSentinel()`로 즉시 해제(후속 PR).
+ *
+ * SSOT key: `storageKeys.LA_DISMISSED_AT_KEY`.
+ *
+ * 모든 함수는 AsyncStorage 실패를 graceful하게 흡수 — sentinel은 보조 채널이라
+ * 실패해도 silent push의 핵심 흐름(알람 발사/ACK)은 영향받지 않아야 한다.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LA_DISMISSED_AT_KEY } from '../../../shared/constants/storageKeys';
+import { LA_DISMISS_SENTINEL_TTL_MS } from '../../../shared/constants/laDismiss';
+
+/** sentinel 작성. LA dismiss 이벤트 수신 시점에 호출. 기본값은 Date.now(). */
+export async function markLaDismissed(at: number = Date.now()): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LA_DISMISSED_AT_KEY, String(at));
+  } catch {
+    // sentinel 실패는 graceful — 다음 dismiss 이벤트에서 재시도된다.
+  }
+}
+
+/**
+ * sentinel 활성 여부. now 기준으로 TTL 안의 sentinel이 있으면 true.
+ *  - 키 부재 / NaN / TTL 만료 → false (LA refresh 허용)
+ *  - 키 존재 + TTL 안 → true (LA refresh 차단)
+ */
+export async function isLaDismissed(now: number = Date.now()): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(LA_DISMISSED_AT_KEY);
+    if (raw === null) return false;
+    const at = Number(raw);
+    if (!Number.isFinite(at)) return false;
+    const elapsed = now - at;
+    // clock-skew 방어: at이 미래(elapsed < 0)면 sentinel 무효 — NTP 보정으로 시각이 뒤로 점프해도
+    // LA refresh가 무기한 차단되는 회귀 방지. 양의 elapsed + TTL 안일 때만 활성.
+    if (elapsed < 0) return false;
+    return elapsed < LA_DISMISS_SENTINEL_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/** sentinel 명시적 reset. destination 재설정 / 앱 진입 트리거에서 호출(후속 PR). */
+export async function clearLaDismissSentinel(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(LA_DISMISSED_AT_KEY);
+  } catch {
+    // graceful — 다음 clear 호출 또는 TTL 만료로 자연 정리된다.
+  }
+}

--- a/src/features/alarm/utils/refreshLiveActivityFromBackgroundContext.ts
+++ b/src/features/alarm/utils/refreshLiveActivityFromBackgroundContext.ts
@@ -36,6 +36,7 @@ import type { Station } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { createLogger } from '../../../shared/utils/logger';
 import { buildLiveActivityData } from './stationNotification';
+import { isLaDismissed } from './laDismissSentinel';
 
 const logger = createLogger('SilentPushLaRefresh');
 
@@ -94,6 +95,13 @@ export async function refreshLiveActivityFromBackgroundContext(): Promise<void> 
   try {
     if (!LiveActivity.isLiveActivityEnabled()) {
       logger.info('LA disabled — skip refresh');
+      return;
+    }
+    // #926 (Seam E3) — 사용자가 LA를 dismiss한 직후에는 silent push가 도착해도 LA를 다시
+    // 살리지 않는다. TTL(LA_DISMISS_SENTINEL_TTL_MS, 30분) 안의 sentinel이 있으면 skip.
+    // TTL 경과 또는 명시적 clear 후에는 정상 refresh.
+    if (await isLaDismissed()) {
+      logger.info('LA dismiss sentinel active — skip refresh');
       return;
     }
     const [destRaw, routeRaw, bgRaw] = await Promise.all([

--- a/src/shared/constants/laDismiss.ts
+++ b/src/shared/constants/laDismiss.ts
@@ -1,0 +1,10 @@
+/**
+ * #926 (Seam E3) — LA dismiss sentinel TTL.
+ *
+ * 사용자가 Live Activity를 dismiss하면 `markLaDismissed()`로 sentinel을 기록하고,
+ * silent push 핸들러는 이 TTL 안의 sentinel이 있으면 LA refresh를 skip한다.
+ *
+ * 30분: 일반적인 트립 길이(서울 평균 30~40분) 안에서 dismiss 의사를 존중하기에 충분하면서,
+ * 그 이상 silence가 지속되면 trip이 살아있어도 LA가 영영 안 뜨는 사고를 방지할 만큼 짧다.
+ */
+export const LA_DISMISS_SENTINEL_TTL_MS = 30 * 60_000;

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -80,6 +80,13 @@ export const STICKY_STATION_KEY = 'subway-now:sticky-station';
 // 또 다른 trip-ended를 의미.
 // 형식: 숫자 (epoch ms) 문자열.
 export const TRIP_ENDED_BY_BACKEND_AT_KEY = 'subway-now:trip-ended-by-backend-at';
+// #926 (Seam E3) — 사용자가 Live Activity를 dismiss한 시점(epoch ms).
+// silent push 핸들러가 sentinel 활성 동안 LA를 다시 살리지 않도록 차단하는 게이트.
+// 사용자의 명시적 dismiss 의사를 존중하되, TTL(LA_DISMISS_SENTINEL_TTL_MS) 경과 후
+// 자동 reset해 trip이 살아있는 상태에서 LA가 영영 안 뜨는 사고를 방지.
+// HomeScreen 진입/destination 재설정 같은 명시적 의사도 sentinel clear 트리거가 될 수 있다(후속 PR).
+// 형식: 숫자(epoch ms) 문자열. 키 부재 = sentinel 없음.
+export const LA_DISMISSED_AT_KEY = 'subway-now:la-dismissed-at';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.


### PR DESCRIPTION
## Summary
Epic #912 P3 E3 첫 슬라이스. dismiss 후 LA 재상승 경계 정책.

- `laDismissSentinel.ts` 신규: `markLaDismissed` / `isLaDismissed` / `clearLaDismissSentinel`
- `src/shared/constants/laDismiss.ts`: `LA_DISMISS_SENTINEL_TTL_MS = 30 * 60_000`
- `storageKeys.ts`: `LA_DISMISSED_AT_KEY` 추가
- `refreshLiveActivityFromBackgroundContext`: silent push 시 sentinel 활성이면 LA 살리지 않음

## Self code-review P1 반영
**clock-skew 방어**: `at`이 미래(elapsed<0)면 sentinel 무효 처리. NTP 보정으로 시각 점프 시 LA refresh가 무기한 차단되는 회귀 방지.

## 슬라이싱 의도 (Refs #926)
**본 PR 제외, 후속 PR 예정**:
- `HomeScreen.tsx` sentinel clear 트리거 (destination 재설정 시)
- `modules/live-activity/` 사용자 명시 dismiss 이벤트 capture native 변경

## Test plan
- [x] `npm test` 통과 (3777 tests, 100% coverage)
- [x] `npm run type-check` 통과

Refs #912
Refs #926