### PR TITLE
fix(#916): POST /trips server-set boardingLock 보존 (architectural follow-up A)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -40,6 +40,8 @@ describe('attemptAutoLock (#916 A1)', () => {
     expect(lock?.segmentStations).toEqual(['강남', '역삼', '선릉']);
     expect(lock?.expiresAt).toBe(NOW + AUTO_LOCK_TTL_MS);
     expect(lock?.selectedDepartureTime).toBe(NOW);
+    // #916 follow-up A — server-set 마커. POST /trips 재등록 시 보존 분기의 키.
+    expect(lock?.autoLockedAt).toBe(NOW);
   });
 
   it('AUTO_LOCK_TTL_MS는 SWAP_LOCK_TTL_MS와 동일 (단일 정책)', () => {

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -312,6 +312,111 @@ describe('POST /trips — boardingLock merge (#585)', () => {
   });
 });
 
+// #916 follow-up A — server-set auto-lock(autoLockedAt 마커) 보존.
+// client가 lock 필드 없이 same-session 재등록하면 사용자 명시 lock은 drop되고
+// server-set auto-lock은 보존되어야 한다 (cron 추적 연속성).
+describe('POST /trips — server-set auto-lock 보존 (#916 follow-up A)', () => {
+  const CREATED = 1_700_000_000_000;
+  const TOKEN = 'tok-916-fua';
+
+  function tripBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+      ...base(),
+      token: TOKEN,
+      createdAt: CREATED,
+      ...overrides,
+    };
+  }
+
+  /** existing trip을 KV에 직접 주입 — backend가 자동 합성한 server-set lock 시뮬레이션. */
+  async function seedExisting(
+    env: ReturnType<typeof makeKvEnv>,
+    lock: Record<string, unknown> | undefined,
+  ): Promise<void> {
+    const seeded: Record<string, unknown> = { ...tripBody() };
+    if (lock !== undefined) seeded.boardingLock = lock;
+    await env.TRIPS.put(`trip:${TOKEN}`, JSON.stringify(seeded));
+  }
+
+  function serverSetLock(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      trainCode: 'AUTO1',
+      line: '7',
+      subwayId: '1007',
+      selectedDepartureTime: CREATED,
+      segmentStations: ['용마산', '중곡', '군자'],
+      expiresAt: FUTURE,
+      autoLockedAt: CREATED + 1_000,
+      ...overrides,
+    };
+  }
+
+  function userSetLock(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    // autoLockedAt 부재 = 사용자 명시 lock
+    return {
+      trainCode: 'USER1',
+      line: '7',
+      subwayId: '1007',
+      selectedDepartureTime: CREATED,
+      segmentStations: ['용마산', '중곡', '군자'],
+      expiresAt: FUTURE,
+      ...overrides,
+    };
+  }
+
+  it('server-set lock + incoming.boardingLock 부재 → 보존', async () => {
+    const env = makeKvEnv();
+    await seedExisting(env, serverSetLock());
+    await post('/trips', tripBody(), env); // incoming.boardingLock 없음
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.boardingLock?.trainCode).toBe('AUTO1');
+    expect(stored.boardingLock?.autoLockedAt).toBe(CREATED + 1_000);
+  });
+
+  it('user-set lock + incoming.boardingLock 부재 → drop (기존 정책 유지)', async () => {
+    const env = makeKvEnv();
+    await seedExisting(env, userSetLock());
+    await post('/trips', tripBody(), env);
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.boardingLock).toBeUndefined();
+  });
+
+  it('server-set lock + incoming 새 trainCode → swap (새 lock 채택)', async () => {
+    const env = makeKvEnv();
+    await seedExisting(env, serverSetLock({ trainCode: 'AUTO1' }));
+    await post(
+      '/trips',
+      tripBody({
+        boardingLock: {
+          trainCode: 'NEW1',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: CREATED,
+          segmentStations: ['용마산', '중곡', '군자'],
+          expiresAt: FUTURE,
+        },
+      }),
+      env,
+    );
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.boardingLock?.trainCode).toBe('NEW1');
+    // 새 lock은 client가 보낸 그대로 — autoLockedAt 마커 없음
+    expect(stored.boardingLock?.autoLockedAt).toBeUndefined();
+  });
+
+  it('server-set lock 보존 시 lastTrackedArrivalEpoch도 유지 (cron 추적 연속성)', async () => {
+    const env = makeKvEnv();
+    await seedExisting(env, serverSetLock());
+    // backend cron이 baseline epoch을 stamp한 상태 시뮬레이션
+    const advanced = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    advanced.lastTrackedArrivalEpoch = 12_345;
+    await env.TRIPS.put(`trip:${TOKEN}`, JSON.stringify(advanced));
+    await post('/trips', tripBody(), env); // lock 필드 없이 재등록
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.lastTrackedArrivalEpoch).toBe(12_345);
+  });
+});
+
 describe('POST /trips (#578 — preserve advance progress on re-register)', () => {
   const CREATED = 1_700_000_000_000;
 

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -97,5 +97,8 @@ export async function attemptAutoLock(
     selectedDepartureTime: now,
     segmentStations,
     expiresAt: now + AUTO_LOCK_TTL_MS,
+    // #916 follow-up A — server-set 표시. POST /trips 재등록 시 incoming.boardingLock=undefined
+    // 케이스에서 existing lock을 보존할지 판단하는 마커 (사용자 명시 lock과 구분).
+    autoLockedAt: now,
   };
 }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -107,12 +107,30 @@ app.post('/trips', async (c) => {
         lastFiredPhase: existing.lastFiredPhase,
         lastEtaSeconds: existing.lastEtaSeconds,
         apnsEnv: existing.apnsEnv ?? incoming.apnsEnv,
+        // #916 follow-up A — server-set auto-lock 보존.
+        // 9단 게이트 통과로 backend가 합성한 lock(autoLockedAt 마커 보유)은 client가 lock 필드
+        // 없이 재등록해도 silent하게 drop되지 않아야 한다 (cron 추적이 끊기는 회귀 차단).
+        // 마커가 없는 사용자 명시 lock은 기존 정책대로 incoming.boardingLock===undefined일 때 drop —
+        // 사용자가 명시적으로 lock을 해제했다는 신호로 간주.
+        // incoming.boardingLock이 truthy면 (사용자가 다른 trainCode 선택 또는 client가 같은 lock
+        // 재송신) 그대로 채택돼 swap 경로가 동작.
+        boardingLock:
+          incoming.boardingLock ??
+          (existing.boardingLock?.autoLockedAt !== undefined
+            ? existing.boardingLock
+            : undefined),
         // boardingLock이 바뀌면(예: 환승 후 새 trainCode) 추적 baseline도 리셋.
         // 양쪽 모두 boardingLock이 있고 trainCode가 같을 때만 baseline 유지 — 둘 다 undefined인
         // 경우 비교가 true로 평가돼 stale epoch이 살아남는 회귀를 막는다.
+        //
+        // #916 follow-up A — incoming.boardingLock===undefined + existing auto-lock 보존 케이스도
+        // 같은 lock이 유지되므로 baseline 유지 (cron 추적 연속성). 사용자 명시 lock drop 케이스는
+        // 기존 정책대로 undefined로 리셋.
         lastTrackedArrivalEpoch:
-          incoming.boardingLock &&
-          existing.boardingLock?.trainCode === incoming.boardingLock.trainCode
+          (incoming.boardingLock &&
+            existing.boardingLock?.trainCode === incoming.boardingLock.trainCode) ||
+          (incoming.boardingLock === undefined &&
+            existing.boardingLock?.autoLockedAt !== undefined)
             ? existing.lastTrackedArrivalEpoch
             : undefined,
         // #586 C: Live Activity token/state는 별도 endpoint(`/live-activity/register`)로 관리.
@@ -786,6 +804,9 @@ function parseBoardingLock(raw: unknown): BoardingLockMeta | undefined {
     selectedDepartureTime: o.selectedDepartureTime,
     segmentStations: o.segmentStations as string[],
     expiresAt: o.expiresAt,
+    // #916 follow-up A: server-set 마커. client는 절대 송신하지 않지만 incoming 본문에 어떤 이유로
+    // 같이 echo돼도 보존한다 (drop하면 서버 set lock 표시가 사라져 보존 분기가 무력화됨).
+    ...(typeof o.autoLockedAt === 'number' ? { autoLockedAt: o.autoLockedAt } : {}),
   };
 }
 

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -214,6 +214,19 @@ export interface BoardingLockMeta {
   segmentStations: string[];
   /** Lock 자동 만료 시각 (epoch ms) */
   expiresAt: number;
+  /**
+   * #916 follow-up A — backend가 9단 게이트 통과 시점에 자동 합성한 lock의 stamp (epoch ms).
+   * 사용자가 명시적으로 [탑승] 버튼을 탭해 client가 POST한 lock에는 절대 부재한다.
+   *
+   * 용도: 같은 세션에서 client가 lock 필드 없이 `POST /trips`로 재등록할 때(예: GPS update,
+   * cold restart) baseTrip spread가 `existing.boardingLock`을 silent하게 drop하던 회귀를 차단한다.
+   * 이 마커가 있는 existing lock은 incoming.boardingLock===undefined일 때 보존되고,
+   * 마커가 없는 사용자 명시 lock은 기존 정책대로 drop된다 ("lock 해제" 의미 유지).
+   *
+   * 사용자가 다른 trainCode를 탭해 새 lock을 POST하면 incoming.boardingLock이 truthy라
+   * 기존 swap 경로(`lockSwap.ts`)가 그대로 동작 — 마커 유무와 무관히 새 lock 채택.
+   */
+  autoLockedAt?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
Epic #912 #916 첫 PR(#931 merged) self code-review에서 발견된 architectural follow-up A. server-set auto-lock이 client `POST /trips` 재등록 시 silent하게 drop되는 회귀 차단.

- `types.ts` `BoardingLockMeta`에 `autoLockedAt?: number` 옵셔널 필드 추가 (서버 set 시점 epoch ms)
- `autoLock.ts` `attemptAutoLock` 반환 시 `autoLockedAt: now` stamp
- `index.ts` `POST /trips` `baseTrip`: `incoming.boardingLock===undefined` + `existing.boardingLock.autoLockedAt`가 있으면 보존
- 사용자 명시 lock(`autoLockedAt` 없음)은 기존 동작 유지 — `incoming===undefined` 시 drop

## 슬라이싱 의도
**본 PR 제외, 후속 PR 예정 (follow-up B)**:
- `boardingPromptState.fired=true` 영구화 한계 — auto-lock이 틀려 사용자가 클리어해도 prompt 재발사 차단됨. fired 게이트에 "사용자 명시 클리어" 분기 추가 필요

## Test plan
- [x] backend `npm test` 통과 (23 files, 806 tests)
- [x] client `npm run type-check` 통과

Refs #912
Refs #916