### PR TITLE
feat(#918): useStationAlarm wire — tripBoundScheduler 자동 호출 (A3 후속 PR)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
@@ -184,6 +184,38 @@ describe('useTripBoundAlarmScheduler', () => {
     await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(2));
   });
 
+  // cancel await 중 새 effect가 token을 bump하면 stale run은 cancel 직후 early return해야 한다.
+  it('stale completion 가드: cancel await 중 새 effect fire 시 stale run이 preschedule을 호출하지 않음', async () => {
+    let resolveCancelB: (() => void) | null = null;
+    // 첫 run(A): cancel 없음(prev 없음) + 정상 preschedule.
+    mockedPreschedule.mockResolvedValueOnce([]);
+    // 두 번째 run(B): cancel을 지연 → 그 사이 lockC로 token bump.
+    mockedCancel.mockImplementationOnce(
+      () => new Promise<void>((res) => { resolveCancelB = () => res(); }),
+    );
+    // 세 번째 run(C): 정상 cancel + preschedule.
+    mockedCancel.mockResolvedValueOnce(undefined);
+    mockedPreschedule.mockResolvedValueOnce([]);
+
+    const lockC: BoardingLock = { ...lockA, trainCode: 'C', boardedAt: 3_000 };
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(1));
+
+    // run B 시작 → cancel pending.
+    rerender({ lock: lockB, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledTimes(1));
+
+    // token bump → run C 시작 (이전 token=B는 이제 stale).
+    rerender({ lock: lockC, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(2));
+
+    // 이제 run B의 cancel을 늦게 resolve — stale 가드(line 77)가 발동해 추가 preschedule 호출 없어야 함.
+    if (resolveCancelB) (resolveCancelB as () => void)();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedPreschedule).toHaveBeenCalledTimes(2);
+  });
+
   // async race 가드: 이전 run이 await에서 멈춰있는 동안 새 lock으로 effect가 다시 fire되면
   // stale run은 ref를 업데이트하지 말아야 한다 (self code-review #3).
   it('stale completion 가드: 빠른 lock swap 시 stale run의 ref update 차단', async () => {

--- a/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
@@ -1,0 +1,209 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature test: useTripBoundAlarmScheduler 본체가 orchestrator(file-level disable).
+ * 동일 패턴으로 routeFixtures import. ADR Phase 5 (#890).
+ */
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useTripBoundAlarmScheduler } from '../useTripBoundAlarmScheduler';
+import type { ScheduledTripBoundAlarm } from '../../utils/tripBoundScheduler';
+import {
+  cancelTripBoundAlarms,
+  prescheduleStationAlerts,
+} from '../../utils/tripBoundScheduler';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import { makeDirectRoute, makeTransferRoute } from '../../../../testUtils/routeFixtures';
+
+jest.mock('../../utils/tripBoundScheduler', () => {
+  const actual = jest.requireActual('../../utils/tripBoundScheduler');
+  return {
+    ...actual,
+    prescheduleStationAlerts: jest.fn(),
+    cancelTripBoundAlarms: jest.fn(),
+  };
+});
+
+const mockLoggerError = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  }),
+}));
+
+const mockedPreschedule = prescheduleStationAlerts as jest.MockedFunction<
+  typeof prescheduleStationAlerts
+>;
+const mockedCancel = cancelTripBoundAlarms as jest.MockedFunction<typeof cancelTripBoundAlarms>;
+
+type Props = Parameters<typeof useTripBoundAlarmScheduler>[0];
+function renderScheduler(initialProps: Props) {
+  return renderHook((props: Props) => useTripBoundAlarmScheduler(props), { initialProps });
+}
+async function awaitFirstSchedule() {
+  await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(1));
+}
+
+const route = makeDirectRoute(2, '2');
+const lockA: BoardingLock = {
+  destinationId: 'd',
+  trainCode: 'A',
+  boardingStationId: 's',
+  boardingLine: '2',
+  boardedAt: 1_000,
+  expectedDurationMs: 60_000,
+};
+const lockB: BoardingLock = { ...lockA, trainCode: 'B', boardedAt: 2_000 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedPreschedule.mockResolvedValue([]);
+  mockedCancel.mockResolvedValue(undefined);
+});
+
+describe('useTripBoundAlarmScheduler', () => {
+  it('lock=null + route 있어도 cancel/preschedule 둘 다 호출 안 함 (초기 마운트)', async () => {
+    renderHook(() =>
+      useTripBoundAlarmScheduler({ lock: null, route, destinationName: '강남' }),
+    );
+    // 한 tick 후에도 호출 없음 — prev/next 모두 null로 early return.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedPreschedule).not.toHaveBeenCalled();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('lock + route + destination 모두 활성 → preschedule 1회 호출', async () => {
+    renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    const call = mockedPreschedule.mock.calls[0][0];
+    expect(call.startTime).toBe(lockA.boardedAt);
+    // direct route 2 stops → 단일 destination waypoint.
+    expect(call.routeStops).toEqual([{ stationName: '강남', alarmType: 'destination' }]);
+    expect(call.estimatedHopTimesMs.length).toBe(1);
+    // 초기 마운트는 prev=null → cancel skip.
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('null → lock 진입 시 preschedule 호출 (cancel 없음)', async () => {
+    const { rerender } = renderScheduler({ lock: null, route, destinationName: '강남' });
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('lock 교체(A → B) 시 cancel → 재예약', async () => {
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    rerender({ lock: lockB, route, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedCancel).toHaveBeenCalledTimes(1);
+      expect(mockedPreschedule).toHaveBeenCalledTimes(2);
+    });
+    const lastCall = mockedPreschedule.mock.calls[1][0];
+    expect(lastCall.startTime).toBe(lockB.boardedAt);
+  });
+
+  it('destination=null 전환 시 cancel 호출 (preschedule 추가 없음)', async () => {
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    rerender({ lock: lockA, route, destinationName: null });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledTimes(1));
+    expect(mockedPreschedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('lock=null 전환 시 cancel 호출', async () => {
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    rerender({ lock: null, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledTimes(1));
+    expect(mockedPreschedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('같은 trainCode + 같은 route signature 재렌더는 no-op', async () => {
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    rerender({ lock: { ...lockA }, route, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedPreschedule).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('route signature 변경(같은 trainCode) → cancel 후 재예약', async () => {
+    const altRoute = makeTransferRoute({
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    });
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    rerender({ lock: lockA, route: altRoute, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockedCancel).toHaveBeenCalledTimes(1);
+      expect(mockedPreschedule).toHaveBeenCalledTimes(2);
+    });
+    const lastCall = mockedPreschedule.mock.calls[1][0];
+    // transfer route → 2 stops (transfer + destination).
+    expect(lastCall.routeStops.map((s) => s.stationName)).toEqual(['교대', '강남']);
+  });
+
+  it('lock 있어도 route=null이면 preschedule skip (초기 마운트)', async () => {
+    renderScheduler({ lock: lockA, route: null, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedPreschedule).not.toHaveBeenCalled();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('preschedule 실패는 logger.error로 기록 (throw 안 함)', async () => {
+    mockedPreschedule.mockRejectedValueOnce(new Error('boom'));
+    renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'tripBoundScheduler 전환 실패:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  it('cold restart: lock 먼저 들어오고 route 늦게 로드돼도 1회 preschedule 보장', async () => {
+    const { rerender } = renderScheduler({ lock: lockA, route: null, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedPreschedule).not.toHaveBeenCalled();
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('lock release 후 같은 trainCode 재진입 시 다시 preschedule', async () => {
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    rerender({ lock: null, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(2));
+  });
+
+  // async race 가드: 이전 run이 await에서 멈춰있는 동안 새 lock으로 effect가 다시 fire되면
+  // stale run은 ref를 업데이트하지 말아야 한다 (self code-review #3).
+  it('stale completion 가드: 빠른 lock swap 시 stale run의 ref update 차단', async () => {
+    let resolveA: ((v: ScheduledTripBoundAlarm[]) => void) | null = null;
+    mockedPreschedule.mockImplementationOnce(
+      () => new Promise<ScheduledTripBoundAlarm[]>((res) => { resolveA = res; }),
+    );
+    mockedPreschedule.mockResolvedValueOnce([]);
+    mockedPreschedule.mockResolvedValueOnce([]);
+
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(1));
+    rerender({ lock: lockB, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(2));
+    // run-A의 preschedule을 늦게 resolve — stale token이라 ref 업데이트 차단.
+    if (resolveA) (resolveA as (v: ScheduledTripBoundAlarm[]) => void)([]);
+    await new Promise((r) => setTimeout(r, 0));
+    // lockA 재진입 시 새 preschedule trigger (ref가 stale에 의해 lockA로 잘못 set되지 않았음 확인).
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(3));
+  });
+});
+

--- a/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
+++ b/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
@@ -1,0 +1,98 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 hook은 destination(route feature) + boarding lock(alarm feature) +
+ * route stops(shared utils)를 묶어 OS local notification 사전 예약(tripBoundScheduler)을 트리거하는
+ * orchestrator. useBoardingLockScheduler와 동일한 옵트인 패턴(file-level disable). ADR Phase 5 (#890).
+ */
+import { useEffect, useRef } from 'react';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { Route } from '../../../shared/utils/stationRoute';
+import { routeSignature } from '../utils/boardingLockScheduler';
+import {
+  cancelTripBoundAlarms,
+  deriveTripBoundStops,
+  prescheduleStationAlerts,
+} from '../utils/tripBoundScheduler';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('useTripBoundAlarmScheduler');
+
+export interface UseTripBoundAlarmSchedulerInputs {
+  /** 현재 trip의 boarding lock. `boardedAt`을 startTime의 SSOT로 사용. null이면 cancel만. */
+  lock: BoardingLock | null;
+  /** 트립 route. null이면 cancel만. */
+  route: Route;
+  /** 목적지명. null이면 cancel만. */
+  destinationName: string | null;
+}
+
+/**
+ * #918 (A3 후속 wire) — `tripBoundScheduler.prescheduleStationAlerts`의 단일 호출자.
+ *
+ * - lock + route + destinationName이 모두 갖춰진 첫 시점에 1회 사전 예약.
+ * - lock.trainCode 변경 또는 route signature 변경 시 기존 `tba:` 알람 일괄 cancel 후 재예약.
+ * - lock=null 전환(release / trip 종료) 시 모든 `tba:` 알람 cancel.
+ * - 같은 trainCode + 같은 route signature 재렌더는 no-op (ref 비교).
+ *
+ * useBoardingLockScheduler와 prefix만 다르고 동일 lifecycle 패턴 — `bl:` 사전 예약은 lock 사용자 명시
+ * 시작 시점에만 동작하지만 `tba:`는 destination+route+lock 활성 시점부터 OS 큐에 사전 예약된 일반화
+ * fallback이다 (네트워크 0 환경 silent push 누락 보완).
+ *
+ * 호출 측은 단일 owner 원칙(useBoardingLockScheduler와 동일) — HomeScreen에서 1회 마운트.
+ */
+export function useTripBoundAlarmScheduler({
+  lock,
+  route,
+  destinationName,
+}: UseTripBoundAlarmSchedulerInputs): void {
+  // 마지막 성공한 schedule의 trainCode/sig. null이면 "현재 큐에 tba 알람 없음".
+  const scheduledTrainCodeRef = useRef<string | null>(null);
+  const scheduledRouteSigRef = useRef<string | null>(null);
+
+  // async race 가드: 같은 effect의 이전 호출이 아직 진행 중일 수 있으므로 in-flight token으로
+  // stale completion이 ref를 잘못 update하지 않게 차단 (self code-review #3).
+  const inFlightTokenRef = useRef(0);
+
+  useEffect(() => {
+    const nextTrain = lock?.trainCode ?? null;
+    const nextSig = routeSignature(route, destinationName);
+    const canSchedule = lock !== null && route !== null && destinationName !== null;
+
+    const prevTrain = scheduledTrainCodeRef.current;
+    const prevSig = scheduledRouteSigRef.current;
+    const hasPrevSchedule = prevTrain !== null;
+
+    // 이전 예약이 없고 이번에도 schedule 못 함 → 호출 자체 skip (lock=null인 상태에서 route만 바뀜 등).
+    if (!hasPrevSchedule && !canSchedule) return;
+    // 이전과 동일 (trainCode + sig 일치) → no-op.
+    if (hasPrevSchedule && prevTrain === nextTrain && prevSig === nextSig) return;
+
+    const myToken = ++inFlightTokenRef.current;
+
+    const run = async (): Promise<void> => {
+      // 이전 예약이 있으면 항상 먼저 cancel (trainCode change / route change / release 모두 대상).
+      if (hasPrevSchedule) {
+        await cancelTripBoundAlarms();
+      }
+      // stale completion: token이 현재 in-flight와 다르면 이번 run 결과로 ref 업데이트하지 않는다.
+      if (myToken !== inFlightTokenRef.current) return;
+      if (!canSchedule) {
+        scheduledTrainCodeRef.current = null;
+        scheduledRouteSigRef.current = null;
+        return;
+      }
+      const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, destinationName);
+      await prescheduleStationAlerts({
+        routeStops,
+        estimatedHopTimesMs,
+        startTime: lock.boardedAt,
+      });
+      if (myToken !== inFlightTokenRef.current) return;
+      scheduledTrainCodeRef.current = nextTrain;
+      scheduledRouteSigRef.current = nextSig;
+    };
+
+    run().catch((e: unknown) => {
+      logger.error('tripBoundScheduler 전환 실패:', e);
+    });
+  }, [lock, route, destinationName]);
+}

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -3,10 +3,16 @@ import { Platform } from 'react-native';
 import {
   TRIP_BOUND_ALARM_PREFIX,
   cancelTripBoundAlarms,
+  deriveTripBoundStops,
   prescheduleStationAlerts,
   tripBoundAlarmIdentifier,
   type TripBoundStop,
 } from '../tripBoundScheduler';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../../../testUtils/routeFixtures';
 
 jest.mock('expo-notifications');
 
@@ -341,5 +347,69 @@ describe('cancelTripBoundAlarms', () => {
     mockedGetAll.mockResolvedValue([]);
     await expect(cancelTripBoundAlarms()).resolves.toBeUndefined();
     expect(mockedCancel).not.toHaveBeenCalled();
+  });
+});
+
+// #918 (A3 후속) — useTripBoundAlarmScheduler가 호출하는 caller-side helper.
+// route 종류별 hop 매핑 + legStops=0 fallback을 검증.
+describe('deriveTripBoundStops', () => {
+  it('route=null이면 빈 배열', () => {
+    const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(null, '강남');
+    expect(routeStops).toEqual([]);
+    expect(estimatedHopTimesMs).toEqual([]);
+  });
+
+  it('destinationName=null이면 빈 배열', () => {
+    const { routeStops } = deriveTripBoundStops(makeDirectRoute(2, '2'), null);
+    expect(routeStops).toEqual([]);
+  });
+
+  it('direct route → destination 1개 waypoint, hopMs=full leg time', () => {
+    const route = makeDirectRoute(3, '2');
+    const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, '강남');
+    expect(routeStops).toEqual([{ stationName: '강남', alarmType: 'destination' }]);
+    expect(estimatedHopTimesMs.length).toBe(1);
+    // waypoint-level: hopMs = travelSeconds * 1000 (평균 X). 360 * 1000 = 360_000.
+    expect(estimatedHopTimesMs[0]).toBe(360_000);
+  });
+
+  it('transfer route → 환승역 + 도착역 2개 waypoint, 각 leg full seconds', () => {
+    const route = makeTransferRoute({
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    });
+    const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, '강남');
+    expect(routeStops).toEqual([
+      { stationName: '교대', alarmType: 'transfer' },
+      { stationName: '강남', alarmType: 'destination' },
+    ]);
+    // hopMs는 각 leg full seconds. 양수 검증 (정확 값은 makeTransferRoute fixture 의존).
+    expect(estimatedHopTimesMs.length).toBe(2);
+    expect(estimatedHopTimesMs[0]).toBeGreaterThan(0);
+    expect(estimatedHopTimesMs[1]).toBeGreaterThan(0);
+  });
+
+  it('multi-transfer route → 환승역 N개 + 마지막 leg 도착역, hopIndex 매핑 정확', () => {
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 2 },
+        { transferName: '종로3가', fromLine: '1', toLine: '3', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 4,
+    });
+    const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, '약수');
+    expect(routeStops.map((s) => s.stationName)).toEqual(['시청', '종로3가', '약수']);
+    expect(routeStops.map((s) => s.alarmType)).toEqual(['transfer', 'transfer', 'destination']);
+    expect(estimatedHopTimesMs.length).toBe(3);
+    expect(estimatedHopTimesMs.every((ms) => ms > 0)).toBe(true);
+  });
+
+  it('legSeconds=0/음수/NaN/Infinity면 HOP_TIME_MS fallback', () => {
+    const route = { type: 'direct' as const, stops: 1, line: '2' as const, travelSeconds: 0 };
+    const { estimatedHopTimesMs } = deriveTripBoundStops(route, '강남');
+    expect(estimatedHopTimesMs).toEqual([90_000]);
   });
 });

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -1,9 +1,11 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
-import { alarmKey, type AlarmEvent } from './stationAlarm';
+import { alarmKey, resolveAllTargets, type AlarmEvent } from './stationAlarm';
 import { buildAlarmContent } from './stationNotification';
 import type { AlarmType } from '../../../shared/types/alarm';
+import { isSameStationName, type Route } from '../../../shared/utils/stationRoute';
+import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('TripBoundScheduler');
@@ -169,6 +171,60 @@ export function tripBoundAlarmIdentifier(
   event: Pick<AlarmEvent, 'phaseId' | 'stationName'>,
 ): string {
   return `${TRIP_BOUND_ALARM_PREFIX}${alarmKey(event)}`;
+}
+
+/**
+ * #918 (caller-side helper): `route` + `destinationName`에서 prescheduleStationAlerts에 넘길
+ * `routeStops` + `estimatedHopTimesMs`를 만든다.
+ *
+ * **계약**: routeStops는 *waypoint 단위*(transfer + destination만). 각 hop의 hopMs는 직전
+ * waypoint→현 waypoint 전체 leg 시간(`legSeconds * 1000`). preschedule은 cumulative hop으로
+ * fire 시각을 계산하므로 destination 알람은 boardedAt + 전체 trip 시간 - 10s에 발사된다.
+ * (legSeconds/legStops 평균 X — 그 값은 station-level 시퀀스용이고 본 helper는 waypoint-level.
+ *  self code-review에서 평균치 누적 시 imminent가 leg 1/legStops 위치에서 발사되는 회귀 식별.)
+ *
+ * - legSeconds≤0/NaN/Infinity 가드: HOP_TIME_MS fallback. 사용자에게 노출되는 알람 시각이
+ *   NaN으로 OS 큐에 들어가는 회귀를 caller-side에서 차단(scheduler 본체의 `Number.isFinite`
+ *   가드와 이중 안전).
+ * - route=null 또는 destinationName=null이면 빈 배열 — 호출자(hook)는 cancel만 수행하고 schedule skip.
+ */
+export function deriveTripBoundStops(
+  route: Route,
+  destinationName: string | null,
+): { routeStops: TripBoundStop[]; estimatedHopTimesMs: number[] } {
+  if (!route || !destinationName) {
+    return { routeStops: [], estimatedHopTimesMs: [] };
+  }
+  const targets = resolveAllTargets(route, destinationName);
+  const routeStops: TripBoundStop[] = targets.map((t) => ({
+    stationName: t.name,
+    alarmType: t.alarmType,
+  }));
+  const estimatedHopTimesMs: number[] = targets.map((t, i) => {
+    const legSeconds = legSecondsForHop(route, i, t.name);
+    const legMs = legSeconds * 1000;
+    if (!Number.isFinite(legMs) || legMs <= 0) return HOP_TIME_MS;
+    return legMs;
+  });
+  return { routeStops, estimatedHopTimesMs };
+}
+
+/**
+ * hopIndex / target name으로 route의 leg seconds 필드를 선택. boardingLockScheduler.legSecondsAt
+ * 와 동일한 매핑(resolveAllTargets와 1:1 정렬). 두 곳을 합치는 SSOT 통합은 별도 PR.
+ */
+function legSecondsForHop(
+  route: NonNullable<Route>,
+  hopIndex: number,
+  targetName: string,
+): number {
+  if (route.type === 'direct') return route.travelSeconds;
+  if (route.type === 'transfer') {
+    if (isSameStationName(route.transferName, targetName)) return route.secondsToTransfer;
+    return route.secondsFromTransfer;
+  }
+  if (hopIndex < route.transfers.length) return route.transfers[hopIndex].secondsToTransfer;
+  return route.secondsAfterLastTransfer;
 }
 
 /**

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -42,6 +42,7 @@ import { useSleepModeGuide } from '../features/settings/hooks/useSleepModeGuide'
 import { useArrivalAutoClear } from '../features/arrival/hooks/useArrivalAutoClear';
 import { useBoardingLockController } from '../features/alarm/hooks/useBoardingLockController';
 import { useBoardingLockScheduler } from '../features/alarm/hooks/useBoardingLockScheduler';
+import { useTripBoundAlarmScheduler } from '../features/alarm/hooks/useTripBoundAlarmScheduler';
 import { useBoardingLockAdvancer } from '../features/alarm/hooks/useBoardingLockAdvancer';
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
 import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
@@ -278,6 +279,14 @@ export default function HomeScreen() {
     onAutoLockCandidate: hydrateLockFromCandidate,
   });
   useBoardingLockScheduler({
+    lock: boardingLock,
+    route,
+    destinationName: destination?.name ?? null,
+  });
+  // #918 (A3 후속 wire) — boarding lock + route + destination이 모두 갖춰지면 OS local notification에
+  // 사전 예약. 네트워크 0 환경에서 silent push가 못 가는 trip의 fallback alarm 경로. `bl:` prefix와
+  // 분리된 `tba:` prefix를 사용해 lock-scheduler 큐와 충돌 없이 공존한다.
+  useTripBoundAlarmScheduler({
     lock: boardingLock,
     route,
     destinationName: destination?.name ?? null,


### PR DESCRIPTION
## Summary
Epic #912 #918 첫 PR(#936 merged)의 `tripBoundScheduler` infra를 실제 caller에 wire.

- `useTripBoundAlarmScheduler` hook: lock + route + destinationName 활성 시 `prescheduleStationAlerts` 호출, lock null로 전환 시 `cancelTripBoundAlarms`
- `HomeScreen`에 1회 마운트 (단일 owner)
- `deriveTripBoundStops` helper: route + destinationName → routeStops + estimatedHopTimesMs

## Self code-review P1 3건 반영
1. **`deriveTripBoundStops` hopMs full leg time**: waypoint-level인데 `legSeconds/legStops` 평균으로 나눠 imminent가 leg 1/legStops에서 발사되는 회귀 식별 → full `legSeconds*1000` 사용
2. **JSDoc orphan 복원**: `cancelTripBoundAlarms` 위 doc 누락 회복
3. **async race**: `inFlightTokenRef`로 stale completion이 `scheduledTrainCodeRef` 잘못 update 차단

## Test plan
- [x] `npm test` 통과 (212 suites, 3825 tests, 100% coverage)
- [x] `npm run type-check` 통과

Refs #912
Refs #918