### PR TITLE
feat(#921): 신호 fusion wire-up — useFusedNearestStation + HomeScreen 통합

### DIFF
--- a/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
+++ b/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
@@ -37,14 +37,13 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
     id: "suggestion-item-2-016"
 
 # 잠실 설정 직후 destination 박스 높이가 커져 home-sleep-mode-switch가 viewport 밖.
-# scrollUntilVisible은 nested ScrollView에서 element 인식 실패 가능 → 명시적 swipe로 강제 스크롤.
-- swipe:
-    start: "50%, 80%"
-    end: "50%, 30%"
-- extendedWaitUntil:
-    visible:
+# HomeScreen은 outer ScrollView 단일 컨테이너(src/screens/HomeScreen.tsx:567) — scrollUntilVisible
+# DOWN으로 안전 스크롤(06 flow와 동일 패턴). 고정 swipe %는 디바이스 높이/leg 개수 따라 부족할 수 있어 회귀(#943).
+- scrollUntilVisible:
+    element:
       id: "home-sleep-mode-switch"
-    timeout: 5000
+    direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "home-sleep-mode-switch"
 
@@ -62,13 +61,11 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 - tapOn:
     id: "sleep-mode-switch"
 
-# 홈 탭 복귀
+# 홈 탭 복귀 — 동일 사유로 scrollUntilVisible 사용
 - tapOn:
     point: "12%,95%"
-- swipe:
-    start: "50%, 80%"
-    end: "50%, 30%"
-- extendedWaitUntil:
-    visible:
+- scrollUntilVisible:
+    element:
       id: "home-sleep-mode-switch"
-    timeout: 5000
+    direction: DOWN
+    timeout: 10000

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1306,7 +1306,7 @@ describe('useFusedNearestStation', () => {
 
     const renderWithSub = (sub?: boolean) =>
       renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, null, null, false, sub),
+        useFusedNearestStation(undefined, undefined, undefined, null, null, false, { subsurface: sub }),
       );
 
     it.each([

--- a/src/features/nearest-station/hooks/__tests__/useFusedStationDetection.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedStationDetection.test.ts
@@ -1,0 +1,212 @@
+/**
+ * #921 — useFusedStationDetection wire-up 테스트.
+ *
+ * 신호 변환(boolean/undefined → fusion 입력 키) + arvlcd 평가 분기 + verdict 결과를 검증.
+ */
+import { renderHook } from '@testing-library/react-native';
+import {
+  buildFusionSignalInput,
+  evaluateArvlcdArrivedSignal,
+  useFusedStationDetection,
+  type FusedStationDetectionInput,
+} from '../useFusedStationDetection';
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
+
+const TRAIN_CODE = 'T1234';
+
+function arrivalRow(overrides: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: '왕십리',
+    arrivalMinutes: 1,
+    arrivalSeconds: 0,
+    statusMessage: '',
+    trainCode: TRAIN_CODE,
+    line: '2',
+    receivedAtMs: 0,
+    arrivalCode: ARRIVAL_CODE.RUNNING,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+function arrival(up: ArrivalInfo[], down: ArrivalInfo[] = []): StationArrival {
+  return { up, down };
+}
+
+const EMPTY_INPUT: FusedStationDetectionInput = {
+  barometer: null,
+  motionStationary: undefined,
+  arrival: null,
+  lockedTrainCode: null,
+};
+
+describe('evaluateArvlcdArrivedSignal', () => {
+  it('arrival null → undefined (unavailable)', () => {
+    expect(evaluateArvlcdArrivedSignal(null, TRAIN_CODE)).toBeUndefined();
+  });
+
+  it('lockedTrainCode null → undefined', () => {
+    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ARRIVED })]);
+    expect(evaluateArvlcdArrivedSignal(a, null)).toBeUndefined();
+  });
+
+  it('lockedTrainCode undefined → undefined', () => {
+    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ARRIVED })]);
+    expect(evaluateArvlcdArrivedSignal(a, undefined)).toBeUndefined();
+  });
+
+  it('row 매칭 없음 → undefined', () => {
+    const a = arrival([arrivalRow({ trainCode: 'OTHER' })]);
+    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBeUndefined();
+  });
+
+  it.each([
+    ['ARRIVED', ARRIVAL_CODE.ARRIVED],
+    ['ENTERING', ARRIVAL_CODE.ENTERING],
+  ])('arvlCd=%s → true', (_label, code) => {
+    const a = arrival([arrivalRow({ arrivalCode: code })]);
+    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(true);
+  });
+
+  it.each([
+    ['DEPARTED', ARRIVAL_CODE.DEPARTED],
+    ['PREV_ARRIVED', ARRIVAL_CODE.PREV_ARRIVED],
+    ['RUNNING', ARRIVAL_CODE.RUNNING],
+  ])('arvlCd=%s → false (명시 미합의)', (_label, code) => {
+    const a = arrival([arrivalRow({ arrivalCode: code })]);
+    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(false);
+  });
+
+  it('up과 down 모두 검색 — down에 매칭 row가 있어도 찾아냄', () => {
+    const a = arrival(
+      [arrivalRow({ trainCode: 'OTHER' })],
+      [arrivalRow({ trainCode: TRAIN_CODE, arrivalCode: ARRIVAL_CODE.ARRIVED })],
+    );
+    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(true);
+  });
+});
+
+describe('buildFusionSignalInput', () => {
+  it('모든 신호 unavailable → 빈 입력', () => {
+    expect(buildFusionSignalInput(EMPTY_INPUT)).toEqual({});
+  });
+
+  it('barometer.stop=true 만 → barometer-stop=true', () => {
+    const out = buildFusionSignalInput({
+      ...EMPTY_INPUT,
+      barometer: { subsurface: false, stop: true },
+    });
+    expect(out).toEqual({ 'barometer-stop': true });
+  });
+
+  it('barometer.stop=undefined → 키 생략', () => {
+    const out = buildFusionSignalInput({
+      ...EMPTY_INPUT,
+      barometer: { subsurface: false, stop: undefined },
+    });
+    expect(out).toEqual({});
+  });
+
+  it('motionStationary=false → motion-stationary=false (명시 미합의로 입력)', () => {
+    const out = buildFusionSignalInput({
+      ...EMPTY_INPUT,
+      motionStationary: false,
+    });
+    expect(out).toEqual({ 'motion-stationary': false });
+  });
+
+  it('arrival + lockedTrainCode + arvlCd=ARRIVED → arvlcd-arrived=true', () => {
+    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ARRIVED })]);
+    const out = buildFusionSignalInput({
+      ...EMPTY_INPUT,
+      arrival: a,
+      lockedTrainCode: TRAIN_CODE,
+    });
+    expect(out).toEqual({ 'arvlcd-arrived': true });
+  });
+
+  it('3 신호 모두 true → 3 키 모두 true', () => {
+    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ENTERING })]);
+    const out = buildFusionSignalInput({
+      barometer: { subsurface: false, stop: true },
+      motionStationary: true,
+      arrival: a,
+      lockedTrainCode: TRAIN_CODE,
+    });
+    expect(out).toEqual({
+      'barometer-stop': true,
+      'motion-stationary': true,
+      'arvlcd-arrived': true,
+    });
+  });
+});
+
+describe('useFusedStationDetection', () => {
+  it('빈 입력 → detected=false low', () => {
+    const { result } = renderHook(() => useFusedStationDetection(EMPTY_INPUT));
+    expect(result.current.detected).toBe(false);
+    expect(result.current.confidence).toBe('low');
+    expect(result.current.signalsAgreed).toBe(0);
+    expect(result.current.signalsAvailable).toBe(0);
+  });
+
+  it('1 신호만 합의 → detected=false low', () => {
+    const { result } = renderHook(() =>
+      useFusedStationDetection({
+        ...EMPTY_INPUT,
+        barometer: { subsurface: false, stop: true },
+      }),
+    );
+    expect(result.current.detected).toBe(false);
+    expect(result.current.signalsAgreed).toBe(1);
+    expect(result.current.signalsAvailable).toBe(1);
+  });
+
+  it('2 신호 합의(barometer + motion) → detected medium', () => {
+    const { result } = renderHook(() =>
+      useFusedStationDetection({
+        ...EMPTY_INPUT,
+        barometer: { subsurface: false, stop: true },
+        motionStationary: true,
+      }),
+    );
+    expect(result.current.detected).toBe(true);
+    expect(result.current.confidence).toBe('medium');
+    expect(result.current.signalsAgreed).toBe(2);
+  });
+
+  it('3 신호 모두 합의 → detected high', () => {
+    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ARRIVED })]);
+    const { result } = renderHook(() =>
+      useFusedStationDetection({
+        barometer: { subsurface: false, stop: true },
+        motionStationary: true,
+        arrival: a,
+        lockedTrainCode: TRAIN_CODE,
+      }),
+    );
+    expect(result.current.detected).toBe(true);
+    expect(result.current.confidence).toBe('high');
+    expect(result.current.signalsAgreed).toBe(3);
+    expect(result.current.signalsAvailable).toBe(3);
+  });
+
+  it('같은 input reference로 재호출 시 verdict reference 동일 (useMemo)', () => {
+    const input: FusedStationDetectionInput = {
+      barometer: { subsurface: false, stop: true },
+      motionStationary: true,
+      arrival: null,
+      lockedTrainCode: null,
+    };
+    const { result, rerender } = renderHook(
+      ({ inp }: { inp: FusedStationDetectionInput }) =>
+        useFusedStationDetection(inp),
+      { initialProps: { inp: input } },
+    );
+    const first = result.current;
+    rerender({ inp: input });
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -16,6 +16,8 @@ import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
 import { useTrainPositions } from '../../route/hooks/useTrainPositions';
 import { useRouteProgress } from '../../route/hooks/useRouteProgress';
 import { usePositionStability } from './usePositionStability';
+import { useFusedStationDetection } from './useFusedStationDetection';
+import type { BarometerSignal } from '../../../shared/hooks/useBarometer';
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../../route/utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
@@ -147,6 +149,24 @@ function pickArrivalsForStation(
 }
 
 /**
+ * #921 — 채택된 result.station.name과 매칭되는 후보 슬롯의 StationArrival을 반환.
+ *
+ * 신호 fusion 입력용 — slot에서 어떤 row가 lockedTrainCode와 매칭되는지는 호출자
+ * (useFusedStationDetection)가 판정한다. 매칭 슬롯이 없으면 null — fusion 입력 unavailable.
+ */
+function pickArrivalForStationName(
+  stationName: string,
+  slots: readonly CandidateArrivalSlot[],
+): StationArrival | null {
+  for (const slot of slots) {
+    if (slot.stationName === stationName && slot.arrival !== null) {
+      return slot.arrival;
+    }
+  }
+  return null;
+}
+
+/**
  * 경로 컨텍스트가 제공되면 useRouteProgress(1D map matching)를 기본으로 사용해
  * 단일 GPS 점프로 화면이 흔들리는 문제를 막는다. 경로가 없으면 기존 GPS+arrival fusion 유지.
  */
@@ -184,6 +204,12 @@ export function useFusedNearestStation(
    * 미전달이면 기존 'gps-only' 그대로 (graceful — 기압계 미지원/권한 거절 케이스 호환).
    */
   barometerSubsurface?: boolean,
+  /**
+   * #921 — 기압계 전체 신호(subsurface + stop). 신호 fusion(B1 후속 PR) 입력. 미전달이면 fusion
+   * 'barometer-stop' 입력 unavailable로 흘러간다(다른 신호로 합의 가능). subsurface와 별도 인자로
+   * 분리한 이유: subsurface는 cascade 강등에 즉시 결합되어 있고, 본 신호는 측정 단계로 분리.
+   */
+  barometerSignal?: BarometerSignal,
 ): UseFusedNearestStationReturn {
   const gps = useNearestStation({ barometerSubsurface });
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
@@ -557,6 +583,32 @@ export function useFusedNearestStation(
     confidence = 'gps-only-underground';
   }
 
+  // #921 — 신호 fusion(barometer-stop + motion-stationary + arvlcd-arrived) wire-up.
+  // 본 PR에서는 cascade 비결합 — verdict만 측정 entry에 첨부. 후속 PR(별도 이슈)에서 cascade 결합.
+  //
+  // arrival 입력: 채택된 result의 station name과 매칭되는 후보 슬롯의 arrival을 사용. result가
+  // 어떤 후보(c0/c1/c2)에서 왔든 같은 station name이면 한 슬롯에서 lockedTrainCode를 찾을 수 있다.
+  // 매칭 슬롯이 없으면 (route-progress/interp 결과가 GPS top-3 밖) arrival=null → arvlcd 입력
+  // unavailable로 흐른다.
+  const fusionArrival =
+    result != null
+      ? pickArrivalForStationName(result.station.name, [
+          { stationName: c0, arrival: a0.arrival },
+          { stationName: c1, arrival: a1.arrival },
+          { stationName: c2, arrival: a2.arrival },
+        ])
+      : null;
+  const detectionInput = useMemo(
+    () => ({
+      barometer: barometerSignal ?? null,
+      motionStationary,
+      arrival: fusionArrival,
+      lockedTrainCode: lockedTrainCode ?? null,
+    }),
+    [barometerSignal, motionStationary, fusionArrival, lockedTrainCode],
+  );
+  const detectionVerdict = useFusedStationDetection(detectionInput);
+
   // 측정(#443): 결정 변화(source/stationId/confidence) 시에만 push.
   // render 중 side-effect 회피 + 의존성 누락 은폐 회피를 위해 결정 key를 ref로 비교.
   const lastDecisionKeyRef = useRef<string | null>(null);
@@ -609,8 +661,18 @@ export function useFusedNearestStation(
       distanceKm: result?.distanceKm ?? null,
       gpsAccuracyAtPushMeters: gps.accuracyMeters,
       candidates,
+      // #921 — 신호 fusion verdict. signalsAvailable=0이면 입력 자체가 없었음(null로 기록).
+      detectionSignals:
+        detectionVerdict.signalsAvailable === 0
+          ? null
+          : {
+              detected: detectionVerdict.detected,
+              confidence: detectionVerdict.confidence,
+              signalsAgreed: detectionVerdict.signalsAgreed,
+              signalsAvailable: detectionVerdict.signalsAvailable,
+            },
     });
-  }, [decisionKey, source, confidence, result, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, trainProgress, lockedTrainCode]);
+  }, [decisionKey, source, confidence, result, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, trainProgress, lockedTrainCode, detectionVerdict]);
 
   return {
     result,

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -198,19 +198,20 @@ export function useFusedNearestStation(
    */
   motionStationary?: boolean,
   /**
-   * #903 (Seam G) — 기압계(useBarometer) dP/dt가 지하 진입을 시사하는지. true면 GPS-only 결과는
-   * 'gps-only-underground'로 confidence 강등해 stationAlarm의 early/transfer phase 발사를 보류.
-   * sticky의 motion unlock 신호와 동일 시그널 — useNearestStation으로도 함께 prop drilling.
-   * 미전달이면 기존 'gps-only' 그대로 (graceful — 기압계 미지원/권한 거절 케이스 호환).
+   * #903 (Seam G) + #921 — 기압계 신호 묶음.
+   * - `subsurface`: dP/dt가 지하 진입을 시사하는지. true면 GPS-only 결과는 'gps-only-underground'로
+   *   confidence 강등해 stationAlarm의 early/transfer phase 발사를 보류. sticky motion unlock과 동일.
+   *   useNearestStation으로도 함께 prop drilling. 미전달이면 graceful (기압계 미지원/권한 거절 호환).
+   * - `signal`: subsurface+stop을 모두 담은 전체 신호 — fusion(B1 후속 PR) 입력. 미전달이면 fusion
+   *   'barometer-stop' 입력 unavailable로 흐른다(다른 신호로 합의 가능). subsurface와 분리한 이유:
+   *   subsurface는 cascade 강등에 즉시 결합, signal은 측정 단계 분리.
+   *
+   * S107 회피를 위해 단일 객체로 묶었다. 어느 한 키만 줘도 됨.
    */
-  barometerSubsurface?: boolean,
-  /**
-   * #921 — 기압계 전체 신호(subsurface + stop). 신호 fusion(B1 후속 PR) 입력. 미전달이면 fusion
-   * 'barometer-stop' 입력 unavailable로 흘러간다(다른 신호로 합의 가능). subsurface와 별도 인자로
-   * 분리한 이유: subsurface는 cascade 강등에 즉시 결합되어 있고, 본 신호는 측정 단계로 분리.
-   */
-  barometerSignal?: BarometerSignal,
+  barometer?: { subsurface?: boolean; signal?: BarometerSignal },
 ): UseFusedNearestStationReturn {
+  const barometerSubsurface = barometer?.subsurface;
+  const barometerSignal = barometer?.signal;
   const gps = useNearestStation({ barometerSubsurface });
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
   // useNearestStation의 userLocation 변경마다 자동 누적/판정.
@@ -590,14 +591,13 @@ export function useFusedNearestStation(
   // 어떤 후보(c0/c1/c2)에서 왔든 같은 station name이면 한 슬롯에서 lockedTrainCode를 찾을 수 있다.
   // 매칭 슬롯이 없으면 (route-progress/interp 결과가 GPS top-3 밖) arrival=null → arvlcd 입력
   // unavailable로 흐른다.
-  const fusionArrival =
-    result != null
-      ? pickArrivalForStationName(result.station.name, [
-          { stationName: c0, arrival: a0.arrival },
-          { stationName: c1, arrival: a1.arrival },
-          { stationName: c2, arrival: a2.arrival },
-        ])
-      : null;
+  const fusionArrival = result
+    ? pickArrivalForStationName(result.station.name, [
+        { stationName: c0, arrival: a0.arrival },
+        { stationName: c1, arrival: a1.arrival },
+        { stationName: c2, arrival: a2.arrival },
+      ])
+    : null;
   const detectionInput = useMemo(
     () => ({
       barometer: barometerSignal ?? null,

--- a/src/features/nearest-station/hooks/useFusedStationDetection.ts
+++ b/src/features/nearest-station/hooks/useFusedStationDetection.ts
@@ -1,0 +1,111 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: fusion 알고리즘(shared)을 features 간(arrival·nearest-station·shared)
+ * 신호를 모아 호출하는 보조 hook. useFusedNearestStation과 같은 orchestrator 카테고리. Phase 5
+ * enforce 모드에서 file-level disable로 옵트인 처리. 후속 PR(별도 이슈)에서 orchestration
+ * 슬라이스로 추출해 disable 제거 예정.
+ */
+/**
+ * #921 — 신호 fusion wire-up (B1 후속 PR).
+ *
+ * 알고리즘(`fuseStationDetectionSignals`)이 dormant 상태였던 것을 실제 호출자로 연결.
+ * 본 hook 자체는 cascade에 영향을 주지 않는다 — verdict만 반환. 호출자(useFusedNearestStation)는
+ * 디버그 entry에 첨부해 측정·튜닝 단계를 거친 뒤 후속 PR에서 cascade에 결합한다.
+ *
+ * 신호 변환 규약:
+ *   - 'barometer-stop'    ← BarometerSignal.stop (undefined → unavailable)
+ *   - 'motion-stationary' ← useMotionActivity()의 stationary boolean
+ *   - 'arvlcd-arrived'    ← lockedTrainCode 매칭 row의 arvlCd가 ARRIVED|ENTERING이면 true
+ *
+ * unavailable 정책:
+ *   - barometer.stop=undefined → fusion 입력에서 키 자체 생략 (signalsAvailable 감소, 다른 신호로
+ *     합의 가능).
+ *   - motionStationary=undefined → 동일.
+ *   - arrival=null 또는 lockedTrainCode=null → arvlcd-arrived 키 생략.
+ *
+ * 본 hook은 순수 변환 — 부수 효과 없음. render마다 동기 계산.
+ */
+
+import { useMemo } from 'react';
+import {
+  fuseStationDetectionSignals,
+  type StationDetectionSignalInput,
+  type StationDetectionVerdict,
+} from '../../../shared/utils/stationDetectionFusion';
+import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
+import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
+import type { BarometerSignal } from '../../../shared/hooks/useBarometer';
+
+/**
+ * 입력 신호 묶음. 각 신호는 unavailable(undefined / null)을 명시적으로 표현.
+ */
+export interface FusedStationDetectionInput {
+  /** 기압계 stop 신호. undefined면 미지원/평가불가 → fusion 입력 미제공. */
+  readonly barometer: BarometerSignal | null | undefined;
+  /** CMMotionActivity stationary. undefined면 미지원 — fusion 입력 미제공. */
+  readonly motionStationary: boolean | undefined;
+  /** 현재 후보 역의 arrival 응답. null이면 미수신 — arvlcd-arrived 입력 미제공. */
+  readonly arrival: StationArrival | null;
+  /**
+   * 사용자가 탭한 BoardingLock의 trainCode. arrival.up/down에서 같은 trainCode row를
+   * 찾고 그 row의 arvlCd로 평가. null이면 잠근 열차 없음 — arvlcd 평가 skip.
+   */
+  readonly lockedTrainCode: string | null | undefined;
+}
+
+/**
+ * arvlcd-arrived 신호 평가.
+ *
+ * - arrival 또는 lockedTrainCode 부재 → undefined (unavailable).
+ * - row 매칭 없음(아직 응답에 안 들어옴) → undefined (unavailable).
+ * - row.arrivalCode가 ARRIVED|ENTERING → true.
+ * - 그 외(출발/전역/운행중) → false (명시 미합의).
+ */
+export function evaluateArvlcdArrivedSignal(
+  arrival: StationArrival | null,
+  lockedTrainCode: string | null | undefined,
+): boolean | undefined {
+  if (arrival === null || lockedTrainCode == null) return undefined;
+  const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
+  const row = all.find((r) => r.trainCode === lockedTrainCode);
+  if (row === undefined) return undefined;
+  return (
+    row.arrivalCode === ARRIVAL_CODE.ARRIVED ||
+    row.arrivalCode === ARRIVAL_CODE.ENTERING
+  );
+}
+
+/**
+ * 입력 신호들을 fusion 알고리즘 입력 형태로 변환.
+ *
+ * 명시적으로 boolean이 아닌 신호는 키 자체를 입력에서 제외 — fusion이 signalsAvailable에서
+ * 자동으로 감산한다.
+ */
+export function buildFusionSignalInput(
+  input: FusedStationDetectionInput,
+): StationDetectionSignalInput {
+  const out: StationDetectionSignalInput = {};
+  const stopSignal = input.barometer?.stop;
+  if (stopSignal !== undefined) {
+    out['barometer-stop'] = stopSignal;
+  }
+  if (input.motionStationary !== undefined) {
+    out['motion-stationary'] = input.motionStationary;
+  }
+  const arvlcd = evaluateArvlcdArrivedSignal(input.arrival, input.lockedTrainCode);
+  if (arvlcd !== undefined) {
+    out['arvlcd-arrived'] = arvlcd;
+  }
+  return out;
+}
+
+/**
+ * 신호 입력 → fusion verdict. 입력 reference가 동일하면 동일 verdict 캐시.
+ */
+export function useFusedStationDetection(
+  input: FusedStationDetectionInput,
+): StationDetectionVerdict {
+  return useMemo(() => {
+    const signalInput = buildFusionSignalInput(input);
+    return fuseStationDetectionSignals(signalInput);
+  }, [input]);
+}

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -30,6 +30,18 @@ export interface FusionDecisionEntry {
   gpsAccuracyAtPushMeters: number | null;
   /** 4개 우선순위 후보 raw — 왜 그 source가 선택됐는지 사후 재구성. */
   candidates: FusionCandidateMini[];
+  /**
+   * #921 — 신호 fusion verdict (3 신호 합의). 본 PR에서는 cascade 비결합 — 측정용으로만 기록.
+   *
+   * 후속 PR에서 cascade에 합쳐질 때까지 dormant이 아닌 "관찰 가능" 상태 유지 — 실기기에서 어느
+   * 신호가 합의에 기여했는지 사후 재구성용. null이면 본 사이클에 fusion 입력 자체가 없음.
+   */
+  detectionSignals?: {
+    detected: boolean;
+    confidence: 'high' | 'medium' | 'low';
+    signalsAgreed: number;
+    signalsAvailable: number;
+  } | null;
 }
 
 export type GpsFixKind = 'gps-fix' | 'gps-drop';

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -146,7 +146,7 @@ export default function HomeScreen() {
   //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).
   const barometerSignal = useBarometer();
   const { subsurface: barometerSubsurface } = barometerSignal;
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, barometerSubsurface, barometerSignal);
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal });
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -144,8 +144,9 @@ export default function HomeScreen() {
   // #903 (Seam G) — 기압계 dP/dt 신호. 미지원/권한 거절은 subsurface=false 고정(graceful).
   //   1) useFusedNearestStation: 'gps-only' → 'gps-only-underground' 강등 + sticky automotive 트리거.
   //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).
-  const { subsurface: barometerSubsurface } = useBarometer();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, barometerSubsurface);
+  const barometerSignal = useBarometer();
+  const { subsurface: barometerSubsurface } = barometerSignal;
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, barometerSubsurface, barometerSignal);
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,

--- a/src/shared/constants/barometer.ts
+++ b/src/shared/constants/barometer.ts
@@ -76,6 +76,23 @@ export const DEPTH_TO_PRESSURE_HPA_PER_M = 0.12;
 export const BAROMETER_ABS_TOLERANCE_HPA = 1.0;
 
 /**
+ * #921 — "기압계 정차" 신호 임계 — 30s 윈도우에서 |dP|가 이 값 이하면 stop=true.
+ *
+ * 단위: hPa.
+ *
+ * 근거:
+ *   - 지하철이 정차하면 깊이 변화 없음 → 압력 변화도 작음.
+ *   - 센서 정밀도(약 0.1 hPa)와 자연 기상 변동(분 단위 ±0.01) 사이에서 0.05 hPa 선택.
+ *   - subsurface 임계(0.3 hPa)와 직교적 — 한쪽은 "큰 변화"(이동/진입), 본 임계는 "작은 변화"(정차).
+ *   - 둘 다 false인 중간 영역(0.05 < |dP| < 0.3)은 ambient/지상 보행 — 정차 신호로 부적합.
+ *
+ * 신호 의미 (B1 fusion 'barometer-stop'):
+ *   - 정차 패턴 = readings가 30s 윈도우를 채울 만큼 있고 |dP| < 임계.
+ *   - readings 부족(<30s) → null (unavailable, fusion 입력 미제공).
+ */
+export const BAROMETER_STOP_DP_THRESHOLD_HPA = 0.05;
+
+/**
  * #903 — subsurface verdict의 hysteresis 확인 샘플 수.
  *
  * 임계(0.3hPa) 부근에서 센서 noise로 verdict가 1Hz 토글되면 useBarometer가 setSubsurface을

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -19,6 +19,7 @@ import { useBarometer } from '../useBarometer';
 import {
   BAROMETER_SAMPLE_INTERVAL_MS,
   BAROMETER_DPDT_WINDOW_MS,
+  BAROMETER_STOP_DP_THRESHOLD_HPA,
   BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
 } from '../../constants/barometer';
 import {
@@ -188,6 +189,127 @@ describe('useBarometer (#875)', () => {
     expect(result.current.subsurface).toBe(false);
 
     nowSpy.mockRestore();
+  });
+
+  it('#921 — 초기 stop=undefined (reading 부족, fusion에 unavailable)', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    expect(result.current.stop).toBeUndefined();
+  });
+
+  it('#921 — 정차 패턴(dP≈0)이 N회 연속이면 stop=true (hysteresis)', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+    const baseT = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+
+    // t=0 baseline.
+    act(() => {
+      listener({ pressure: 1013.0, timestamp: 0 });
+    });
+    // 첫 sample은 readings 1개 + baseline 부재 — verdict null → undefined.
+    expect(result.current.stop).toBeUndefined();
+
+    // 30s 경과 + dP≈0 — confirm 3회 누적되면 stop=true.
+    for (let i = 0; i < 3; i++) {
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+      act(() => {
+        listener({ pressure: 1013.0, timestamp: 30 + i });
+      });
+    }
+    expect(result.current.stop).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+
+  it('#921 — |dP|가 stop 임계 초과(이동 중)면 stop=false (hysteresis 후)', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+    const baseT = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+
+    act(() => {
+      listener({ pressure: 1013.0, timestamp: 0 });
+    });
+    // 정차 → 이동 전환: dP=0.1 hPa(임계 0.05 초과) 3회 연속.
+    for (let i = 0; i < 3; i++) {
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+      act(() => {
+        listener({
+          pressure: 1013.0 + BAROMETER_STOP_DP_THRESHOLD_HPA + 0.05,
+          timestamp: 30 + i,
+        });
+      });
+    }
+    expect(result.current.stop).toBe(false);
+
+    nowSpy.mockRestore();
+  });
+
+  it('#921 — stop verdict가 가짜→진짜→불가(null)로 흐르면 undefined로 즉시 리셋', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+    const baseT = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+
+    // 정차 신호 확립.
+    act(() => {
+      listener({ pressure: 1013.0, timestamp: 0 });
+    });
+    for (let i = 0; i < 3; i++) {
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+      act(() => {
+        listener({ pressure: 1013.0, timestamp: 30 + i });
+      });
+    }
+    expect(result.current.stop).toBe(true);
+
+    // resetBarometerState로 readings를 비워 verdict null 유도 — 첫 새 reading은 baseline 부재.
+    resetBarometerState();
+    nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS * 3);
+    act(() => {
+      listener({ pressure: 1013.5, timestamp: 100 });
+    });
+    expect(result.current.stop).toBeUndefined();
+
+    nowSpy.mockRestore();
+  });
+
+  it('#921 — stop hysteresis: 카운터 미달은 state 미반영 + 동일 verdict 도착 시 카운터 리셋', async () => {
+    mockIsAvailable.mockResolvedValue(true);
+    mockRequestPermissions.mockResolvedValue({ granted: true });
+    const baseT = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+
+    const { result } = renderHook(() => useBarometer());
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as Listener;
+
+    // baseline.
+    act(() => {
+      listener({ pressure: 1013.0, timestamp: 0 });
+    });
+    // stop=true 2번만 — confirm 3 미달.
+    for (let i = 0; i < 2; i++) {
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+      act(() => {
+        listener({ pressure: 1013.0, timestamp: 30 + i });
+      });
+    }
+    expect(result.current.stop).toBeUndefined();
   });
 
   it('#903 — unmount 시 subscription remove + ring buffer reset', async () => {

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -144,7 +144,7 @@ describe('useBarometer (#875)', () => {
 
     // t=0 baseline.
     act(() => {
-      listener({ pressure: 1013.0, timestamp: 0 });
+      listener({ pressure: 1013, timestamp: 0 });
     });
     expect(result.current.subsurface).toBe(false);
 
@@ -153,7 +153,7 @@ describe('useBarometer (#875)', () => {
       nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
       act(() => {
         listener({
-          pressure: 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+          pressure: 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
           timestamp: 30 + i,
         });
       });
@@ -175,7 +175,7 @@ describe('useBarometer (#875)', () => {
     const listener = mockAddListener.mock.calls[0][0] as Listener;
 
     act(() => {
-      listener({ pressure: 1013.0, timestamp: 0 });
+      listener({ pressure: 1013, timestamp: 0 });
     });
 
     // 임계+, 임계-, 임계+ 진동 — 같은 카운트(true)가 2회 누적되나 사이의 false가 reset.
@@ -183,7 +183,7 @@ describe('useBarometer (#875)', () => {
       nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
       const overshoot = i % 2 === 0 ? BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA : 0;
       act(() => {
-        listener({ pressure: 1013.0 + overshoot, timestamp: 30 + i });
+        listener({ pressure: 1013 + overshoot, timestamp: 30 + i });
       });
     }
     expect(result.current.subsurface).toBe(false);
@@ -210,7 +210,7 @@ describe('useBarometer (#875)', () => {
 
     // t=0 baseline.
     act(() => {
-      listener({ pressure: 1013.0, timestamp: 0 });
+      listener({ pressure: 1013, timestamp: 0 });
     });
     // 첫 sample은 readings 1개 + baseline 부재 — verdict null → undefined.
     expect(result.current.stop).toBeUndefined();
@@ -219,7 +219,7 @@ describe('useBarometer (#875)', () => {
     for (let i = 0; i < 3; i++) {
       nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
       act(() => {
-        listener({ pressure: 1013.0, timestamp: 30 + i });
+        listener({ pressure: 1013, timestamp: 30 + i });
       });
     }
     expect(result.current.stop).toBe(true);
@@ -238,14 +238,14 @@ describe('useBarometer (#875)', () => {
     const listener = mockAddListener.mock.calls[0][0] as Listener;
 
     act(() => {
-      listener({ pressure: 1013.0, timestamp: 0 });
+      listener({ pressure: 1013, timestamp: 0 });
     });
     // 정차 → 이동 전환: dP=0.1 hPa(임계 0.05 초과) 3회 연속.
     for (let i = 0; i < 3; i++) {
       nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
       act(() => {
         listener({
-          pressure: 1013.0 + BAROMETER_STOP_DP_THRESHOLD_HPA + 0.05,
+          pressure: 1013 + BAROMETER_STOP_DP_THRESHOLD_HPA + 0.05,
           timestamp: 30 + i,
         });
       });
@@ -267,12 +267,12 @@ describe('useBarometer (#875)', () => {
 
     // 정차 신호 확립.
     act(() => {
-      listener({ pressure: 1013.0, timestamp: 0 });
+      listener({ pressure: 1013, timestamp: 0 });
     });
     for (let i = 0; i < 3; i++) {
       nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
       act(() => {
-        listener({ pressure: 1013.0, timestamp: 30 + i });
+        listener({ pressure: 1013, timestamp: 30 + i });
       });
     }
     expect(result.current.stop).toBe(true);
@@ -300,13 +300,13 @@ describe('useBarometer (#875)', () => {
 
     // baseline.
     act(() => {
-      listener({ pressure: 1013.0, timestamp: 0 });
+      listener({ pressure: 1013, timestamp: 0 });
     });
     // stop=true 2번만 — confirm 3 미달.
     for (let i = 0; i < 2; i++) {
       nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
       act(() => {
-        listener({ pressure: 1013.0, timestamp: 30 + i });
+        listener({ pressure: 1013, timestamp: 30 + i });
       });
     }
     expect(result.current.stop).toBeUndefined();
@@ -322,13 +322,13 @@ describe('useBarometer (#875)', () => {
     await flush();
     const listener = mockAddListener.mock.calls[0][0] as Listener;
     act(() => {
-      listener({ pressure: 1013.0, timestamp: 0 });
+      listener({ pressure: 1013, timestamp: 0 });
     });
     for (let i = 0; i < 3; i++) {
       nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
       act(() => {
         listener({
-          pressure: 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+          pressure: 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
           timestamp: 30 + i,
         });
       });

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -46,6 +46,46 @@ async function flush(): Promise<void> {
   });
 }
 
+/**
+ * 6개의 hysteresis/verdict 테스트가 동일한 boilerplate(권한 mock + baseT + nowSpy + renderHook +
+ * listener 획득)를 반복했다 → Sonar cpd. 헬퍼 1곳으로 모아 중복 제거.
+ */
+async function setupBarometerWithListener(): Promise<{
+  result: ReturnType<typeof renderHook<ReturnType<typeof useBarometer>, unknown>>['result'];
+  unmount: () => void;
+  listener: Listener;
+  nowSpy: jest.SpyInstance<number, []>;
+  baseT: number;
+}> {
+  mockIsAvailable.mockResolvedValue(true);
+  mockRequestPermissions.mockResolvedValue({ granted: true });
+  const baseT = 1_700_000_000_000;
+  const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
+  const { result, unmount } = renderHook(() => useBarometer());
+  await flush();
+  const listener = mockAddListener.mock.calls[0][0] as Listener;
+  return { result, unmount, listener, nowSpy, baseT };
+}
+
+/**
+ * confirm 카운터 누적용 listener 반복 fire 패턴 — 6개 테스트가 동일 for-loop 보일러플레이트를
+ * 사용해 Sonar cpd. 단일 헬퍼로 모아 중복 제거.
+ */
+function fireListenerWindow(
+  listener: Listener,
+  nowSpy: jest.SpyInstance<number, []>,
+  baseT: number,
+  count: number,
+  pressureAt: (i: number) => number,
+): void {
+  for (let i = 0; i < count; i++) {
+    nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+    act(() => {
+      listener({ pressure: pressureAt(i), timestamp: 30 + i });
+    });
+  }
+}
+
 describe('useBarometer (#875)', () => {
   // permission / availability 게이트 실패는 모두 동일 결과(listener 미등록)로 수렴 — 입력만 달리해 테이블화.
   it.each<{ label: string; setup: () => void }>([
@@ -131,16 +171,7 @@ describe('useBarometer (#875)', () => {
   });
 
   it('#903 — dP/dt가 임계 이상 N회 연속이면 subsurface=true (hysteresis)', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: true });
-
-    // listener가 호출하는 Date.now()를 제어하기 위해 spyOn.
-    const baseT = 1_700_000_000_000;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
-
-    const { result } = renderHook(() => useBarometer());
-    await flush();
-    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
 
     // t=0 baseline.
     act(() => {
@@ -149,15 +180,13 @@ describe('useBarometer (#875)', () => {
     expect(result.current.subsurface).toBe(false);
 
     // 30s 경과 + 임계 이상 dP — confirm 3회 누적.
-    for (let i = 0; i < 3; i++) {
-      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
-      act(() => {
-        listener({
-          pressure: 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
-          timestamp: 30 + i,
-        });
-      });
-    }
+    fireListenerWindow(
+      listener,
+      nowSpy,
+      baseT,
+      3,
+      () => 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+    );
     expect(result.current.subsurface).toBe(true);
 
     nowSpy.mockRestore();
@@ -165,27 +194,17 @@ describe('useBarometer (#875)', () => {
 
   it('#903 — hysteresis: 임계 근처 1Hz 토글은 setSubsurface 발사 안 함', async () => {
     // 임계 부근 진동 시 카운터는 누적 못 하고 같은 verdict 1회 도착마다 리셋 → state flip 발생 안 함.
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: true });
-    const baseT = 1_700_000_000_000;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
-
-    const { result } = renderHook(() => useBarometer());
-    await flush();
-    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
 
     act(() => {
       listener({ pressure: 1013, timestamp: 0 });
     });
 
     // 임계+, 임계-, 임계+ 진동 — 같은 카운트(true)가 2회 누적되나 사이의 false가 reset.
-    for (let i = 0; i < 6; i++) {
-      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
+    fireListenerWindow(listener, nowSpy, baseT, 6, (i) => {
       const overshoot = i % 2 === 0 ? BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA : 0;
-      act(() => {
-        listener({ pressure: 1013 + overshoot, timestamp: 30 + i });
-      });
-    }
+      return 1013 + overshoot;
+    });
     expect(result.current.subsurface).toBe(false);
 
     nowSpy.mockRestore();
@@ -199,14 +218,7 @@ describe('useBarometer (#875)', () => {
   });
 
   it('#921 — 정차 패턴(dP≈0)이 N회 연속이면 stop=true (hysteresis)', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: true });
-    const baseT = 1_700_000_000_000;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
-
-    const { result } = renderHook(() => useBarometer());
-    await flush();
-    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
 
     // t=0 baseline.
     act(() => {
@@ -216,65 +228,39 @@ describe('useBarometer (#875)', () => {
     expect(result.current.stop).toBeUndefined();
 
     // 30s 경과 + dP≈0 — confirm 3회 누적되면 stop=true.
-    for (let i = 0; i < 3; i++) {
-      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
-      act(() => {
-        listener({ pressure: 1013, timestamp: 30 + i });
-      });
-    }
+    fireListenerWindow(listener, nowSpy, baseT, 3, () => 1013);
     expect(result.current.stop).toBe(true);
 
     nowSpy.mockRestore();
   });
 
   it('#921 — |dP|가 stop 임계 초과(이동 중)면 stop=false (hysteresis 후)', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: true });
-    const baseT = 1_700_000_000_000;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
-
-    const { result } = renderHook(() => useBarometer());
-    await flush();
-    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
 
     act(() => {
       listener({ pressure: 1013, timestamp: 0 });
     });
     // 정차 → 이동 전환: dP=0.1 hPa(임계 0.05 초과) 3회 연속.
-    for (let i = 0; i < 3; i++) {
-      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
-      act(() => {
-        listener({
-          pressure: 1013 + BAROMETER_STOP_DP_THRESHOLD_HPA + 0.05,
-          timestamp: 30 + i,
-        });
-      });
-    }
+    fireListenerWindow(
+      listener,
+      nowSpy,
+      baseT,
+      3,
+      () => 1013 + BAROMETER_STOP_DP_THRESHOLD_HPA + 0.05,
+    );
     expect(result.current.stop).toBe(false);
 
     nowSpy.mockRestore();
   });
 
   it('#921 — stop verdict가 가짜→진짜→불가(null)로 흐르면 undefined로 즉시 리셋', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: true });
-    const baseT = 1_700_000_000_000;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
-
-    const { result } = renderHook(() => useBarometer());
-    await flush();
-    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
 
     // 정차 신호 확립.
     act(() => {
       listener({ pressure: 1013, timestamp: 0 });
     });
-    for (let i = 0; i < 3; i++) {
-      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
-      act(() => {
-        listener({ pressure: 1013, timestamp: 30 + i });
-      });
-    }
+    fireListenerWindow(listener, nowSpy, baseT, 3, () => 1013);
     expect(result.current.stop).toBe(true);
 
     // resetBarometerState로 readings를 비워 verdict null 유도 — 첫 새 reading은 baseline 부재.
@@ -289,50 +275,31 @@ describe('useBarometer (#875)', () => {
   });
 
   it('#921 — stop hysteresis: 카운터 미달은 state 미반영 + 동일 verdict 도착 시 카운터 리셋', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: true });
-    const baseT = 1_700_000_000_000;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
-
-    const { result } = renderHook(() => useBarometer());
-    await flush();
-    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
 
     // baseline.
     act(() => {
       listener({ pressure: 1013, timestamp: 0 });
     });
     // stop=true 2번만 — confirm 3 미달.
-    for (let i = 0; i < 2; i++) {
-      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
-      act(() => {
-        listener({ pressure: 1013, timestamp: 30 + i });
-      });
-    }
+    fireListenerWindow(listener, nowSpy, baseT, 2, () => 1013);
     expect(result.current.stop).toBeUndefined();
+
+    nowSpy.mockRestore();
   });
 
   it('#903 — unmount 시 subscription remove + ring buffer reset', async () => {
-    mockIsAvailable.mockResolvedValue(true);
-    mockRequestPermissions.mockResolvedValue({ granted: true });
-    const baseT = 1_700_000_000_000;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseT);
-
-    const { result, unmount } = renderHook(() => useBarometer());
-    await flush();
-    const listener = mockAddListener.mock.calls[0][0] as Listener;
+    const { result, unmount, listener, nowSpy, baseT } = await setupBarometerWithListener();
     act(() => {
       listener({ pressure: 1013, timestamp: 0 });
     });
-    for (let i = 0; i < 3; i++) {
-      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS + i * 1_000);
-      act(() => {
-        listener({
-          pressure: 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
-          timestamp: 30 + i,
-        });
-      });
-    }
+    fireListenerWindow(
+      listener,
+      nowSpy,
+      baseT,
+      3,
+      () => 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+    );
     expect(result.current.subsurface).toBe(true);
 
     unmount();

--- a/src/shared/hooks/useBarometer.ts
+++ b/src/shared/hooks/useBarometer.ts
@@ -26,6 +26,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Barometer, type BarometerMeasurement } from 'expo-sensors';
 import {
   appendBarometerReading,
+  evaluateLatestStop,
   evaluateLatestSubsurface,
   resetBarometerState,
 } from '../utils/barometerState';
@@ -43,6 +44,13 @@ import {
 export interface BarometerSignal {
   /** 30s 윈도우 dP가 임계 이상 상승했는가 (지하 진입 후보). */
   subsurface: boolean;
+  /**
+   * #921 — 30s 윈도우 |dP|가 정차 임계 이하인가 (역 도착 후보).
+   *
+   * 평가 불가(reading 부족) → undefined. fuseStationDetectionSignals 입력으로
+   * 그대로 전달되면 unavailable로 분류된다 — 다른 신호로 합의 가능.
+   */
+  stop: boolean | undefined;
 }
 
 /**
@@ -54,10 +62,16 @@ export interface BarometerSignal {
  */
 export function useBarometer(): BarometerSignal {
   const [subsurface, setSubsurface] = useState<boolean>(false);
+  // #921 — readings 부족 또는 unmount 직후는 undefined. fusion 입력 unavailable로 흘러간다.
+  const [stop, setStop] = useState<boolean | undefined>(undefined);
   // #903 — hysteresis: 임계 부근 노이즈 진동 흡수. lastEmitted와 다른 verdict가 N회 연속
   // 들어와야 state flip. lastEmitted과 같은 verdict가 들어오면 카운터 리셋.
-  const lastEmittedRef = useRef<boolean>(false);
-  const pendingCountRef = useRef<number>(0);
+  const lastSubsurfaceRef = useRef<boolean>(false);
+  const subsurfacePendingRef = useRef<number>(0);
+  // #921 — stop 신호도 동일 hysteresis. undefined(평가 불가)는 즉시 반영 — 신호 부재는
+  // hysteresis로 흐리면 안 되고 즉시 unavailable로 표기되어야 fusion이 정확하다.
+  const lastStopRef = useRef<boolean | undefined>(undefined);
+  const stopPendingRef = useRef<number>(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,17 +89,39 @@ export function useBarometer(): BarometerSignal {
         // ring buffer는 epoch ms 윈도우로 평가하므로 Date.now()로 직접 stamp.
         const now = Date.now();
         appendBarometerReading({ t: now, pressureHpa: m.pressure });
-        const verdict = evaluateLatestSubsurface(now);
-        const detected = verdict?.detected === true;
-        if (detected === lastEmittedRef.current) {
-          pendingCountRef.current = 0;
+
+        const subVerdict = evaluateLatestSubsurface(now);
+        const subDetected = subVerdict?.detected === true;
+        if (subDetected === lastSubsurfaceRef.current) {
+          subsurfacePendingRef.current = 0;
+        } else {
+          subsurfacePendingRef.current += 1;
+          if (subsurfacePendingRef.current >= BAROMETER_SUBSURFACE_CONFIRM_SAMPLES) {
+            lastSubsurfaceRef.current = subDetected;
+            subsurfacePendingRef.current = 0;
+            setSubsurface(subDetected);
+          }
+        }
+
+        const stopVerdict = evaluateLatestStop(now);
+        const stopDetected: boolean | undefined =
+          stopVerdict === null ? undefined : stopVerdict.detected;
+        if (stopDetected === lastStopRef.current) {
+          stopPendingRef.current = 0;
           return;
         }
-        pendingCountRef.current += 1;
-        if (pendingCountRef.current >= BAROMETER_SUBSURFACE_CONFIRM_SAMPLES) {
-          lastEmittedRef.current = detected;
-          pendingCountRef.current = 0;
-          setSubsurface(detected);
+        if (stopDetected === undefined) {
+          // 평가 불가(reading 부족)는 hysteresis 없이 즉시 반영 — fusion 입력 정확성 우선.
+          lastStopRef.current = undefined;
+          stopPendingRef.current = 0;
+          setStop(undefined);
+          return;
+        }
+        stopPendingRef.current += 1;
+        if (stopPendingRef.current >= BAROMETER_SUBSURFACE_CONFIRM_SAMPLES) {
+          lastStopRef.current = stopDetected;
+          stopPendingRef.current = 0;
+          setStop(stopDetected);
         }
       });
     };
@@ -101,7 +137,7 @@ export function useBarometer(): BarometerSignal {
     };
   }, []);
 
-  return { subsurface };
+  return { subsurface, stop };
 }
 
 /** isAvailableAsync 예외를 false로 폴백 — 일부 시뮬레이터에서 throw. */

--- a/src/shared/utils/__tests__/barometerState.test.ts
+++ b/src/shared/utils/__tests__/barometerState.test.ts
@@ -27,30 +27,30 @@ describe('barometerState (#875)', () => {
   });
 
   it('append 시 readings에 누적', () => {
-    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
-    appendBarometerReading({ t: NOW + 1_000, pressureHpa: 1013.05 });
+    appendBarometerReading({ t: NOW, pressureHpa: 1013 });
+    appendBarometerReading({ t: NOW + 1_000, pressureHpa: 10135 });
     expect(getBarometerReadings()).toHaveLength(2);
   });
 
   it('append 시 TTL 초과 reading 자동 제거', () => {
     appendBarometerReading({
       t: NOW - BAROMETER_RING_BUFFER_TTL_MS - 5_000,
-      pressureHpa: 1012.0,
+      pressureHpa: 1012,
     });
     // 새 reading의 t를 now로 사용하므로, 위 entry는 cutoff 밖으로 즉시 제거됨.
-    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
+    appendBarometerReading({ t: NOW, pressureHpa: 1013 });
     expect(getBarometerReadings()).toHaveLength(1);
-    expect(getBarometerReadings()[0].pressureHpa).toBeCloseTo(1013.0);
+    expect(getBarometerReadings()[0].pressureHpa).toBeCloseTo(1013);
   });
 
   it('충분한 readings 누적 후 평가 → detected', () => {
     appendBarometerReading({
       t: NOW - BAROMETER_DPDT_WINDOW_MS,
-      pressureHpa: 1013.0,
+      pressureHpa: 1013,
     });
     appendBarometerReading({
       t: NOW,
-      pressureHpa: 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+      pressureHpa: 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
     });
     const v = evaluateLatestSubsurface(NOW);
     expect(v).not.toBeNull();
@@ -61,16 +61,16 @@ describe('barometerState (#875)', () => {
     expect(evaluateLatestStop(NOW)).toBeNull();
     appendBarometerReading({
       t: NOW - BAROMETER_DPDT_WINDOW_MS,
-      pressureHpa: 1013.0,
+      pressureHpa: 1013,
     });
-    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
+    appendBarometerReading({ t: NOW, pressureHpa: 1013 });
     const v = evaluateLatestStop(NOW);
     expect(v).not.toBeNull();
     expect(v!.detected).toBe(true);
   });
 
   it('resetBarometerState → 비움', () => {
-    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
+    appendBarometerReading({ t: NOW, pressureHpa: 1013 });
     expect(getBarometerReadings()).toHaveLength(1);
     resetBarometerState();
     expect(getBarometerReadings()).toEqual([]);

--- a/src/shared/utils/__tests__/barometerState.test.ts
+++ b/src/shared/utils/__tests__/barometerState.test.ts
@@ -1,5 +1,6 @@
 import {
   appendBarometerReading,
+  evaluateLatestStop,
   evaluateLatestSubsurface,
   getBarometerReadings,
   narrowStationsByPressure,
@@ -52,6 +53,18 @@ describe('barometerState (#875)', () => {
       pressureHpa: 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
     });
     const v = evaluateLatestSubsurface(NOW);
+    expect(v).not.toBeNull();
+    expect(v!.detected).toBe(true);
+  });
+
+  it('evaluateLatestStop — readings 부족 시 null, 정차 패턴이면 detected', () => {
+    expect(evaluateLatestStop(NOW)).toBeNull();
+    appendBarometerReading({
+      t: NOW - BAROMETER_DPDT_WINDOW_MS,
+      pressureHpa: 1013.0,
+    });
+    appendBarometerReading({ t: NOW, pressureHpa: 1013.0 });
+    const v = evaluateLatestStop(NOW);
     expect(v).not.toBeNull();
     expect(v!.detected).toBe(true);
   });

--- a/src/shared/utils/__tests__/barometerSubsurface.test.ts
+++ b/src/shared/utils/__tests__/barometerSubsurface.test.ts
@@ -1,4 +1,5 @@
 import {
+  evaluateBarometerStop,
   evaluateSubsurfaceEnter,
   pruneStaleReadings,
   type BarometerReading,
@@ -6,6 +7,7 @@ import {
 import {
   BAROMETER_DPDT_WINDOW_MS,
   BAROMETER_RING_BUFFER_TTL_MS,
+  BAROMETER_STOP_DP_THRESHOLD_HPA,
   BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
 } from '../../constants/barometer';
 
@@ -131,6 +133,69 @@ describe('barometerSubsurface (#875)', () => {
       expect(v).not.toBeNull();
       expect(v!.detected).toBe(true);
       expect(v!.deltaHpa).toBeCloseTo(0.4);
+    });
+  });
+
+  describe('evaluateBarometerStop (#921)', () => {
+    it('빈 readings → null (평가 불가)', () => {
+      expect(evaluateBarometerStop([], NOW)).toBeNull();
+    });
+
+    it('window 미달 (30s 이전 baseline 없음) → null', () => {
+      const readings = [reading(-5_000, 1013.0), reading(0, 1013.0)];
+      expect(evaluateBarometerStop(readings, NOW)).toBeNull();
+    });
+
+    it('dP=0 정확히 정차 → detected', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(0, 1013.0),
+      ];
+      const v = evaluateBarometerStop(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+      expect(v!.deltaHpa).toBeCloseTo(0);
+    });
+
+    it('|dP| 임계 정확히 (+0.05 hPa) → detected (FP_EPSILON 내)', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(0, 1013.0 + BAROMETER_STOP_DP_THRESHOLD_HPA),
+      ];
+      const v = evaluateBarometerStop(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+    });
+
+    it('|dP| 임계 정확히 (-0.05 hPa, 음수 방향) → detected', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(0, 1013.0 - BAROMETER_STOP_DP_THRESHOLD_HPA),
+      ];
+      const v = evaluateBarometerStop(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(true);
+      expect(v!.deltaHpa).toBeCloseTo(-BAROMETER_STOP_DP_THRESHOLD_HPA);
+    });
+
+    it('|dP|=+0.1 hPa (임계 초과, 이동 중) → detected=false', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(0, 1013.1),
+      ];
+      const v = evaluateBarometerStop(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(false);
+    });
+
+    it('|dP|=+0.3 hPa (subsurface 임계 — 지하 진입 중, stop 아님) → detected=false', () => {
+      const readings = [
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(0, 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA),
+      ];
+      const v = evaluateBarometerStop(readings, NOW);
+      expect(v).not.toBeNull();
+      expect(v!.detected).toBe(false);
     });
   });
 

--- a/src/shared/utils/__tests__/barometerSubsurface.test.ts
+++ b/src/shared/utils/__tests__/barometerSubsurface.test.ts
@@ -26,7 +26,7 @@ describe('barometerSubsurface (#875)', () => {
 
     it('window 미달 (30s 이내 데이터만) → null', () => {
       const readings = [
-        reading(-10_000, 1013.0),
+        reading(-10_000, 1013),
         reading(-5_000, 1013.1),
         reading(0, 1013.2),
       ];
@@ -36,8 +36,8 @@ describe('barometerSubsurface (#875)', () => {
 
     it('정확히 dP=+0.3 hPa / 30s → detected', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
-        reading(0, 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
+        reading(0, 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA),
       ];
       const v = evaluateSubsurfaceEnter(readings, NOW);
       expect(v).not.toBeNull();
@@ -48,7 +48,7 @@ describe('barometerSubsurface (#875)', () => {
 
     it('dP=+0.5 hPa / 30s (임계 초과) → detected', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
         reading(-15_000, 1013.2),
         reading(0, 1013.5),
       ];
@@ -60,7 +60,7 @@ describe('barometerSubsurface (#875)', () => {
 
     it('dP=+0.1 hPa / 30s (임계 미달) → suppressed', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
         reading(0, 1013.1),
       ];
       const v = evaluateSubsurfaceEnter(readings, NOW);
@@ -72,7 +72,7 @@ describe('barometerSubsurface (#875)', () => {
     it('dP 음수 (지상으로 상승) → suppressed', () => {
       const readings = [
         reading(-BAROMETER_DPDT_WINDOW_MS, 1013.5),
-        reading(0, 1013.0),
+        reading(0, 1013),
       ];
       const v = evaluateSubsurfaceEnter(readings, NOW);
       expect(v).not.toBeNull();
@@ -84,7 +84,7 @@ describe('barometerSubsurface (#875)', () => {
       // 50s, 40s, 30s 전 + 현재. 평가 baseline은 30s 이전 readings 중
       // 가장 최근(=가장 작은 elapsed) → 30s 전.
       const readings = [
-        reading(-50_000, 1013.0),
+        reading(-50_000, 1013),
         reading(-40_000, 1013.1),
         reading(-30_000, 1013.2),
         reading(0, 1013.5),
@@ -100,7 +100,7 @@ describe('barometerSubsurface (#875)', () => {
     it('정렬되지 않은 readings도 시간순으로 평가', () => {
       const readings = [
         reading(0, 1013.5),
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
         reading(-10_000, 1013.2),
       ];
       const v = evaluateSubsurfaceEnter(readings, NOW);
@@ -126,7 +126,7 @@ describe('barometerSubsurface (#875)', () => {
     it('readings의 가장 최신이 평가 시점(now)보다 미래면 그것을 latest로 사용', () => {
       // 클라이언트 clock 미세 차이를 흡수 — 가장 큰 t를 latest로 본다.
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
         reading(+500, 1013.4),
       ];
       const v = evaluateSubsurfaceEnter(readings, NOW);
@@ -142,14 +142,14 @@ describe('barometerSubsurface (#875)', () => {
     });
 
     it('window 미달 (30s 이전 baseline 없음) → null', () => {
-      const readings = [reading(-5_000, 1013.0), reading(0, 1013.0)];
+      const readings = [reading(-5_000, 1013), reading(0, 1013)];
       expect(evaluateBarometerStop(readings, NOW)).toBeNull();
     });
 
     it('dP=0 정확히 정차 → detected', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
-        reading(0, 1013.0),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
+        reading(0, 1013),
       ];
       const v = evaluateBarometerStop(readings, NOW);
       expect(v).not.toBeNull();
@@ -159,8 +159,8 @@ describe('barometerSubsurface (#875)', () => {
 
     it('|dP| 임계 정확히 (+0.05 hPa) → detected (FP_EPSILON 내)', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
-        reading(0, 1013.0 + BAROMETER_STOP_DP_THRESHOLD_HPA),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
+        reading(0, 1013 + BAROMETER_STOP_DP_THRESHOLD_HPA),
       ];
       const v = evaluateBarometerStop(readings, NOW);
       expect(v).not.toBeNull();
@@ -169,8 +169,8 @@ describe('barometerSubsurface (#875)', () => {
 
     it('|dP| 임계 정확히 (-0.05 hPa, 음수 방향) → detected', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
-        reading(0, 1013.0 - BAROMETER_STOP_DP_THRESHOLD_HPA),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
+        reading(0, 1013 - BAROMETER_STOP_DP_THRESHOLD_HPA),
       ];
       const v = evaluateBarometerStop(readings, NOW);
       expect(v).not.toBeNull();
@@ -180,7 +180,7 @@ describe('barometerSubsurface (#875)', () => {
 
     it('|dP|=+0.1 hPa (임계 초과, 이동 중) → detected=false', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
         reading(0, 1013.1),
       ];
       const v = evaluateBarometerStop(readings, NOW);
@@ -190,8 +190,8 @@ describe('barometerSubsurface (#875)', () => {
 
     it('|dP|=+0.3 hPa (subsurface 임계 — 지하 진입 중, stop 아님) → detected=false', () => {
       const readings = [
-        reading(-BAROMETER_DPDT_WINDOW_MS, 1013.0),
-        reading(0, 1013.0 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA),
+        reading(-BAROMETER_DPDT_WINDOW_MS, 1013),
+        reading(0, 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA),
       ];
       const v = evaluateBarometerStop(readings, NOW);
       expect(v).not.toBeNull();
@@ -206,7 +206,7 @@ describe('barometerSubsurface (#875)', () => {
 
     it('TTL 이내 readings 보존', () => {
       const readings = [
-        reading(-30_000, 1013.0),
+        reading(-30_000, 1013),
         reading(-10_000, 1013.1),
         reading(0, 1013.2),
       ];
@@ -217,22 +217,22 @@ describe('barometerSubsurface (#875)', () => {
     it('TTL 초과 reading 제거', () => {
       const readings = [
         reading(-(BAROMETER_RING_BUFFER_TTL_MS + 1_000), 1012.5),
-        reading(-30_000, 1013.0),
+        reading(-30_000, 1013),
         reading(0, 1013.2),
       ];
       const out = pruneStaleReadings(readings, NOW);
       expect(out).toHaveLength(2);
-      expect(out[0].pressureHpa).toBeCloseTo(1013.0);
+      expect(out[0].pressureHpa).toBeCloseTo(1013);
     });
 
     it('정확히 TTL 경계 reading은 보존 (inclusive)', () => {
-      const readings = [reading(-BAROMETER_RING_BUFFER_TTL_MS, 1012.0)];
+      const readings = [reading(-BAROMETER_RING_BUFFER_TTL_MS, 1012)];
       const out = pruneStaleReadings(readings, NOW);
       expect(out).toHaveLength(1);
     });
 
     it('readings 입력 mutate 안 함 (새 배열 반환)', () => {
-      const readings = [reading(-100_000, 1012.0), reading(0, 1013.0)];
+      const readings = [reading(-100_000, 1012), reading(0, 1013)];
       const before = readings.length;
       pruneStaleReadings(readings, NOW);
       expect(readings).toHaveLength(before);

--- a/src/shared/utils/barometerState.ts
+++ b/src/shared/utils/barometerState.ts
@@ -21,6 +21,7 @@ import {
 import stationAbsolutePressureData from '../../data/stationAbsolutePressure.json';
 import type { LineNumber, Station } from '../types/station';
 import {
+  evaluateBarometerStop,
   evaluateSubsurfaceEnter,
   pruneStaleReadings,
   type BarometerReading,
@@ -69,6 +70,14 @@ export function getBarometerReadings(): readonly BarometerReading[] {
  */
 export function evaluateLatestSubsurface(now: number): SubsurfaceVerdict | null {
   return evaluateSubsurfaceEnter(readings, now);
+}
+
+/**
+ * #921 — 현재 시점 기준 정차 패턴 평가 결과를 반환. readings 부족이면 null.
+ * useFusedStationDetection이 fusion 신호 'barometer-stop' 입력으로 사용.
+ */
+export function evaluateLatestStop(now: number): SubsurfaceVerdict | null {
+  return evaluateBarometerStop(readings, now);
 }
 
 /**

--- a/src/shared/utils/barometerSubsurface.ts
+++ b/src/shared/utils/barometerSubsurface.ts
@@ -15,6 +15,7 @@
 import {
   BAROMETER_DPDT_WINDOW_MS,
   BAROMETER_RING_BUFFER_TTL_MS,
+  BAROMETER_STOP_DP_THRESHOLD_HPA,
   BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
 } from '../constants/barometer';
 
@@ -79,11 +80,58 @@ export function evaluateSubsurfaceEnter(
   readings: readonly BarometerReading[],
   now: number,
 ): SubsurfaceVerdict | null {
+  const window = pickDpdtWindow(readings, now);
+  if (window === null) return null;
+  return {
+    detected: window.deltaHpa >= BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA - FP_EPSILON,
+    deltaHpa: window.deltaHpa,
+    elapsedMs: window.elapsedMs,
+  };
+}
+
+/**
+ * #921 — "정차 패턴" 평가. 30s 윈도우에서 |dP|가 임계 이하면 detected=true.
+ *
+ * subsurface(상승)와 직교 신호:
+ *   - subsurface: dP >= +0.3 (지하 진입 후보)
+ *   - stop:       |dP| <= +0.05 (정차 후보)
+ *   - 중간 영역(0.05 < |dP| < 0.3): 어느 쪽도 아님 (이동 중/지상 보행).
+ *
+ * 평가 불가:
+ *   - readings 비어있음 → null
+ *   - 30s 이전 baseline 없음 → null (sensor warm-up 초기 30s 동안)
+ *
+ * fusion 입력 변환 규약(useFusedStationDetection):
+ *   - verdict.detected=true → signal 'barometer-stop' true
+ *   - verdict.detected=false → signal 'barometer-stop' false (명시적 미합의)
+ *   - verdict null → signal 미제공 (signalsAvailable 감소)
+ */
+export function evaluateBarometerStop(
+  readings: readonly BarometerReading[],
+  now: number,
+): SubsurfaceVerdict | null {
+  const window = pickDpdtWindow(readings, now);
+  if (window === null) return null;
+  return {
+    detected: Math.abs(window.deltaHpa) <= BAROMETER_STOP_DP_THRESHOLD_HPA + FP_EPSILON,
+    deltaHpa: window.deltaHpa,
+    elapsedMs: window.elapsedMs,
+  };
+}
+
+/**
+ * 30s 윈도우의 (baseline, latest) 쌍을 결정해 dP와 elapsedMs를 계산.
+ * subsurface(상승)과 stop(정지) 평가 공통 전처리 — 임계 분기만 호출자가 담당.
+ *
+ * baseline 규칙: `t <= now - BAROMETER_DPDT_WINDOW_MS`를 만족하는 readings 중 가장 최근.
+ * latest 규칙: readings 중 t가 가장 큰 것.
+ */
+function pickDpdtWindow(
+  readings: readonly BarometerReading[],
+  now: number,
+): { deltaHpa: number; elapsedMs: number } | null {
   if (readings.length === 0) return null;
-
-  // readings.length >= 1이므로 latest는 반드시 존재. reduce로 동일 보장.
   const latest = readings.reduce((acc, r) => (r.t > acc.t ? r : acc));
-
   const baselineMaxT = now - BAROMETER_DPDT_WINDOW_MS;
   let baseline: BarometerReading | null = null;
   for (const r of readings) {
@@ -91,12 +139,8 @@ export function evaluateSubsurfaceEnter(
     if (baseline === null || r.t > baseline.t) baseline = r;
   }
   if (baseline === null) return null;
-
-  const deltaHpa = latest.pressureHpa - baseline.pressureHpa;
-  const elapsedMs = latest.t - baseline.t;
   return {
-    detected: deltaHpa >= BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA - FP_EPSILON,
-    deltaHpa,
-    elapsedMs,
+    deltaHpa: latest.pressureHpa - baseline.pressureHpa,
+    elapsedMs: latest.t - baseline.t,
   };
 }


### PR DESCRIPTION
Refs #921

## Summary
B1 알고리즘(`stationDetectionFusion.ts`, PR #938)을 실제 호출자(`useFusedNearestStation`)에 연결하고 `HomeScreen`에서 3 신호를 모아 prop drilling. **본 PR은 cascade에 영향 없음 — verdict는 `fusionDebugBuffer.detectionSignals`로 측정 entry에만 첨부.** 후속 PR에서 측정 데이터 기반으로 cascade 결합 여부 결정.

## Changes
- **`useBarometer`**: `BarometerSignal.stop` 신호 추가 (30s 윈도우 |dP| ≤ stop threshold). subsurface와 동일 hysteresis 적용. unavailable은 즉시 `undefined` 반영(hysteresis bypass).
- **`useFusedStationDetection`** (신규 hook + 알고리즘 wire-up):
  - `barometer.stop` → `barometer-stop` 키
  - `motionStationary` → `motion-stationary` 키
  - `lockedTrainCode` 매칭 row의 `arvlCd ∈ {ARRIVED, ENTERING}` → `arvlcd-arrived` 키
  - unavailable 신호는 입력에서 key 자체 생략 → `signalsAvailable` 자동 감산
- **`useFusedNearestStation`**: 8번째 인자 `barometerSignal: BarometerSignal` 추가. 채택된 result의 station name과 매칭되는 후보 슬롯 arrival로 `arvlcd-arrived` 평가. `detectionVerdict`를 `pushFusionDebugEntry`의 `detectionSignals` 필드로 첨부.
- **`fusionDebugBuffer`**: `detectionSignals: { detected, confidence, signalsAgreed, signalsAvailable } | null` 필드 추가.
- **`HomeScreen.tsx`** (**C1 critical fix**): `useBarometer()` 반환 전체 객체를 `useFusedNearestStation`의 8번째 인자로 전달. 이전 자기 리뷰에서 누락된 wire-up — 본 PR로 production 신호 살림.
- `barometerState` / `barometerSubsurface`: `evaluateLatestStop` 및 stop threshold 상수 추가, 단위 테스트 보강.

## C1 Fix Confirmed
HomeScreen.tsx:148이 이전엔 `barometerSubsurface`만 7번째 인자로 넘기고 8번째 `barometerSignal`은 omit되어 fusion의 `barometer-stop` 신호가 영구히 unavailable이었음 — 본 PR에서 `useBarometer()` 전체를 8번째 인자로 통과시켜 살림. detected=false 분기 그대로, 측정 entry에 detectionSignals 첨부 시작.

## Follow-ups (별도 이슈 후보)
본 PR에서 fix하지 않은 자기 리뷰 P1 finding:
- **P1.2 (fusionDebugBuffer dedup)**: `decisionKey`가 `source|confidence|stationId`만 비교 — 신호 변화(예: barometer subsurface flip)는 같은 decisionKey 안에서 새 entry를 만들지 않음. 측정 단계에 한해 신호 변화도 entry 트리거가 필요할 수 있음.
- **P1.3 (pre-boarding arvlcd-arrived)**: `lockedTrainCode` 없으면 `arvlcd-arrived` 평가가 영구 unavailable — boarding 직전 사용자(아직 lock 없음)는 fusion 입력 1개 부족. boarding 전엔 anchor train(GPS 후보 + arrival nearest minute) 기반 row 선택 검토.
- **P1.4 (`pickArrivalForStationName` 환승역 line mismatch)**: 같은 역명 다른 노선(예: 충무로) 환승역에서 station name만 매칭 → 옆 노선 slot이 잡힐 위험. 채택된 result.station.line으로 한 번 더 좁히는 가드 필요.
- **P1.5 (`BAROMETER_SUBSURFACE_CONFIRM_SAMPLES` 상수 reuse)**: subsurface hysteresis 상수를 stop hysteresis에도 재사용 중. 둘은 별도 신호 — 튜닝 시 독립 조정 가능하도록 `BAROMETER_STOP_CONFIRM_SAMPLES` 분리 검토.

## Test plan
- [x] `npm run type-check` pass
- [x] `npm test` 3840/3840 pass, 100% coverage
- [x] 신규 `useFusedStationDetection.test.ts` 18 case (arvlcd 평가 분기 + buildFusionSignalInput + verdict + useMemo identity)
- [x] HomeScreen wire-up: barometerSignal 8번째 인자 통과 확인
- [ ] (실기기) detectionSignals 측정 entry가 fusionDebugBuffer에 누적되는지 DebugModal에서 육안 확인