### PR TITLE
feat(#917): client FG fast path — arvlCd=0/1 즉시 알람

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -624,26 +624,13 @@ describe('useStationAlarm', () => {
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
-    it('sleep OFF + 첫 hop transfer → 정상 발사', async () => {
-      useSettingsStore.setState({ sleepMode: false });
-      mockGetBoardingLock.mockResolvedValue(lock);
-      const route = makeTransferRoute({
-        transferName: '시청',
-        fromLine: '2',
-        toLine: '1',
-        stopsToTransfer: 2,
-        stopsFromTransfer: 3,
-      });
-      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
-      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
-      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
-    });
-
-    it('sleep ON + lock null → 게이트 비활성, 정상 발사', async () => {
-      useSettingsStore.setState({ sleepMode: true });
-      mockGetBoardingLock.mockResolvedValue(null);
+    // Sonar cpd 통합 — sleep OFF/lock 활성 vs sleep ON/lock null 모두 게이트 비활성 → 정상 발사.
+    it.each([
+      { name: 'sleep OFF + 첫 hop transfer → 정상 발사', sleepMode: false, lockValue: lock },
+      { name: 'sleep ON + lock null → 게이트 비활성, 정상 발사', sleepMode: true, lockValue: null },
+    ])('$name', async ({ sleepMode, lockValue }) => {
+      useSettingsStore.setState({ sleepMode });
+      mockGetBoardingLock.mockResolvedValue(lockValue);
       const route = makeTransferRoute({
         transferName: '시청',
         fromLine: '2',

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -2439,12 +2439,12 @@ describe('useStationAlarm', () => {
         dismissSilence: {
           sinceTs: Date.now(),
           sinceLat: 37.5,
-          sinceLng: 127.0,
+          sinceLng: 127,
         },
       });
 
       renderHook(() =>
-        useStationAlarm(fastPathInputs({ userLocation: { lat: 37.5, lng: 127.0 } })),
+        useStationAlarm(fastPathInputs({ userLocation: { lat: 37.5, lng: 127 } })),
       );
 
       await waitFor(() =>

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -100,6 +100,11 @@ jest.mock('../../../arrival/utils/imminentArrivalSignal', () => ({
   isImminentByArrivalCode: (...args: unknown[]) => mockIsImminentByArrivalCode(...args),
 }));
 
+const mockFindFgArvlCdFireSignal = jest.fn();
+jest.mock('../../utils/fgArvlCdFastPath', () => ({
+  findFgArvlCdFireSignal: (...args: unknown[]) => mockFindFgArvlCdFireSignal(...args),
+}));
+
 const mockGetStoredTripTrainCode = jest.fn();
 jest.mock('../../../route/utils/tripTrainCode', () => ({
   getStoredTripTrainCode: (...args: unknown[]) => mockGetStoredTripTrainCode(...args),
@@ -157,6 +162,7 @@ describe('useStationAlarm', () => {
     mockGetStoredTripTrainCode.mockResolvedValue(null);
     mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
     mockGetBoardingLock.mockResolvedValue(null);
+    mockFindFgArvlCdFireSignal.mockReturnValue(null);
   });
 
   it('does not evaluate when route is null', () => {
@@ -2219,6 +2225,379 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
       expect(clearSpy).toHaveBeenCalled();
       clearSpy.mockRestore();
+    });
+  });
+
+  // #917 A2 follow-up — FG fast path: lock.trainCode arvlCd∈{0,1} 매역 알림.
+  // GPS 기반 station-passed effect와 분리해 검증하기 위해 nearestStation을 off-route로 두고
+  // `findFgArvlCdFireSignal` mock으로 fast path만 isolate. fast path 자체는 isStationOnRoute을
+  // 보지만, 그 게이트는 effect 내부에서 직접 검사하지 않고 mock 반환값 + 경로 매칭으로 확인.
+  // GPS path는 isStationOnRoute=false로 사전 차단되므로 fast path 단독 검증이 가능.
+  describe('#917 FG fast path arvlCd∈{0,1} 매역 알림', () => {
+    const route = makeDirectRoute(3, '2');
+    // line '2' — direct route와 일치 → 양쪽 effect 모두 on-route. 그러나 GPS effect는
+    // 별도 mockGetLastNotifiedStationId 사전 set으로 dedup 처리(아래 helper).
+    const onRouteStation = makeStation('S-시청', '시청');
+    const activeLock = {
+      destinationId: 'D1',
+      trainCode: 'T-LOCK',
+      boardingStationId: 'S0',
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+    const dummyArrival = { up: [], down: [], isMock: false };
+
+    /**
+     * fastPathInputs:
+     *   - speedMps/accuracyMeters: movement gate 통과
+     *   - currentStationArrival: non-null (effect 게이트 통과). 내용은 mock으로 대체되므로 placeholder.
+     *   - nearestStation: on-route (line '2'). GPS path 발사를 막기 위해 default beforeEach에서
+     *     mockGetLastNotifiedStationId를 onRouteStation.id로 set → GPS path는 dedup 차단되고
+     *     fast path도 같은 dedup에 걸린다. fast path 통과 케이스 테스트는 별도 mockGetLastNotifiedStationId(null)
+     *     override + GPS path 차단을 위해 nearestStation 자체를 off-route로 둠.
+     */
+    function fastPathInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStationAlarmInputs {
+      return defaultInputs({
+        route,
+        destination,
+        nearestStation: onRouteStation,
+        speedMps: 5,
+        accuracyMeters: 50,
+        currentStationArrival: dummyArrival,
+        ...overrides,
+      });
+    }
+
+    // GPS station-passed effect를 완전히 우회하기 위해 off-route station으로 둠.
+    // fast path effect도 isStationOnRoute로 같은 station을 검사하지만, 핵심 게이트 검증은
+    // GPS path 발사가 0인 환경에서 fast path만의 fire/no-fire를 관찰하기 위함.
+    // off-route 테스트 외엔 onRouteStation을 쓰고, lastNotifiedStationId 사전 set으로 GPS dedup.
+    const OFF_ROUTE_LINE = '3' as const;
+    const offRouteStation: Station = { ...onRouteStation, id: 'OFF', line: OFF_ROUTE_LINE };
+
+    // fast path positive — GPS path는 nearestStation을 off-route로 두어 차단, fast path는
+    // isStationOnRoute=false 직격이라 발사 못 함. 다른 방법: GPS path가 dedup으로 차단되는 시나리오.
+    // → mockGetLastNotifiedStationId를 'GPS-FIRED'로 set하면 GPS path는 fire 후 dedup에 막힘…
+    //   아니, GPS path는 lastId === candidateStation.id면 dedup. candidateStation.id=onRouteStation.id.
+    //   다른 id를 fast path와 GPS가 봐도 둘 다 같은 candidate를 보기 때문에 분리 불가.
+    //
+    // 결론: positive 테스트는 GPS+fast 둘 다 fire 가능한 환경에서 진행 + 'fg-arvlcd' source 라벨로
+    // fast path 발사 여부만 가린다. GPS path는 sendStationPassedNotification을 'fg' source로 logFiredStationPassed
+    // 호출하므로 mock 호출 인자로 식별 가능.
+
+    it('lock 활성 + arvlCd 신호 → station-passed 알림 발사 + lastNotifiedStationId 갱신 + fg-arvlcd source 적재', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() => useStationAlarm(fastPathInputs()));
+
+      await waitFor(() =>
+        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', onRouteStation),
+      );
+      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(onRouteStation.id);
+    });
+
+    // #640 회귀 가드 — 본 PR의 핵심.
+    it('#640 회귀 가드 — lock 부재면 같은 신호여도 fast path 발사 X (fg-arvlcd 미적재)', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id); // GPS dedup
+      // findFgArvlCdFireSignal mock은 lock=null로 호출되어 null 반환 (helper 자체 가드 검증).
+      mockFindFgArvlCdFireSignal.mockImplementation((_arrival, lock) =>
+        lock ? { trainCode: 'T-LOCK', arvlCd: 0 } : null,
+      );
+
+      renderHook(() => useStationAlarm(fastPathInputs()));
+
+      // 충분히 대기 — fast path가 발사해선 안 됨.
+      await waitFor(() => expect(mockGetBoardingLock).toHaveBeenCalled());
+      await Promise.resolve();
+      await Promise.resolve();
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('#640 회귀 가드 — findFgArvlCdFireSignal이 null 반환(trainCode 불일치/arvlCd 불일치)면 발사 X', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      mockFindFgArvlCdFireSignal.mockReturnValue(null);
+
+      renderHook(() => useStationAlarm(fastPathInputs()));
+
+      await waitFor(() => expect(mockGetBoardingLock).toHaveBeenCalled());
+      await Promise.resolve();
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('lastNotifiedStationId가 같은 station.id면 fast path dedup → fg-arvlcd dedup 로그', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() => useStationAlarm(fastPathInputs()));
+
+      await waitFor(() =>
+        expect(mockLogSuppressedDedupStation).toHaveBeenCalledWith('fg-arvlcd', onRouteStation),
+      );
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('currentStationArrival 미전달(undefined)이면 fast path no-op (getBoardingLock 미호출)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+
+      renderHook(() => useStationAlarm(fastPathInputs({ currentStationArrival: undefined })));
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+      // mockEvaluateAlarmPhase=null & isImminentByArrivalCode=false → fireAndLog 미호출 →
+      // 본 hook에서 getBoardingLock 호출자는 fast path뿐. fast path가 early return하면 호출 0.
+      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('currentStationArrival null이면 fast path no-op', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+
+      renderHook(() => useStationAlarm(fastPathInputs({ currentStationArrival: null })));
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('nearestStation null이면 fast path no-op (fire 대상 station 결정 불가)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+
+      renderHook(() => useStationAlarm(fastPathInputs({ nearestStation: null })));
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('nearestStation이 route 밖이면(line 불일치) fast path no-op', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+
+      renderHook(() => useStationAlarm(fastPathInputs({ nearestStation: offRouteStation })));
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('route 또는 destination 미설정이면 fast path no-op', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+
+      renderHook(() => useStationAlarm(fastPathInputs({ route: null })));
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('destination 미설정이면 fast path no-op', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+
+      renderHook(() => useStationAlarm(fastPathInputs({ destination: null })));
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      await Promise.resolve();
+      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('movement gate 차단(speed=0) → fast path 발사 X + logSuppressedMovement(fg-arvlcd)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() => useStationAlarm(fastPathInputs({ speedMps: 0 })));
+
+      await waitFor(() =>
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg-arvlcd',
+            stationName: onRouteStation.name,
+            kind: 'station-passed',
+            reason: 'movement-static-speed',
+          }),
+        ),
+      );
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('dismiss silence 활성 시 fast path 발사 X + logSuppressedDismissSilence(fg-arvlcd)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+      useAlarmEventStore.setState({
+        dismissSilence: {
+          sinceTs: Date.now(),
+          sinceLat: 37.5,
+          sinceLng: 127.0,
+        },
+      });
+
+      renderHook(() =>
+        useStationAlarm(fastPathInputs({ userLocation: { lat: 37.5, lng: 127.0 } })),
+      );
+
+      await waitFor(() =>
+        expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg-arvlcd',
+            stationName: onRouteStation.name,
+            kind: 'station-passed',
+          }),
+        ),
+      );
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('hydration 미완료 시 fast path 보류 (firedHydrated=false)', async () => {
+      mockGetFiredAlarms.mockReturnValue(new Promise(() => {})); // 영원히 pending
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() => useStationAlarm(fastPathInputs()));
+
+      await Promise.resolve();
+      // hydration 보류 — fast path는 firedHydrated 가드로 early return.
+      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    });
+
+    it('내부 storage read/send 실패 시 catch로 swallow (logger.error 분기 커버)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      // getLastNotifiedStationId가 throw → fast path 내부 try/catch가 흡수.
+      // GPS path는 자체 try/catch가 있어 같은 에러로 둘 다 차단되지만 본 테스트는 fast path
+      // 분기 커버가 목적.
+      mockGetLastNotifiedStationId.mockRejectedValue(new Error('disk error'));
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() => useStationAlarm(fastPathInputs()));
+
+      // 에러 발생해도 unhandled rejection 없이 완료. fast path는 logFiredStationPassed 미호출.
+      await waitFor(() => expect(mockGetLastNotifiedStationId).toHaveBeenCalled());
+      await Promise.resolve();
+      await Promise.resolve();
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('effect cleanup (unmount) 후엔 후속 작업이 fast path 발사 안 함', async () => {
+      // getBoardingLock을 지연 resolve로 cleanup 시점을 끼워 넣음.
+      let resolveLock: (v: typeof activeLock) => void = () => {};
+      mockGetBoardingLock.mockReturnValueOnce(
+        new Promise<typeof activeLock>((r) => {
+          resolveLock = r;
+        }),
+      );
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      const { unmount } = renderHook(() => useStationAlarm(fastPathInputs()));
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      unmount();
+      resolveLock(activeLock);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // fast path의 logFiredStationPassed('fg-arvlcd', ...)이 호출되지 않아야 한다.
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('getLastNotifiedStationId 후 cleanup 되면 dedup/send 분기 진입 안 함 (cancelled gate line 720)', async () => {
+      // GPS effect와 fast path effect 둘 다 호출 가능 — mockImplementation으로 모든 호출 pending.
+      const resolvers: Array<(v: string | null) => void> = [];
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockImplementation(
+        () =>
+          new Promise<string | null>((r) => {
+            resolvers.push(r);
+          }),
+      );
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      const { unmount } = renderHook(() => useStationAlarm(fastPathInputs()));
+      // fast path는 getBoardingLock(resolved) → findSignal(sync) → gates(sync) → getLastNotifiedStationId(pending).
+      // 첫 mock 호출은 GPS effect일 수 있어 fast path가 자기 호출에 도달하도록 충분히 await.
+      await waitFor(() => expect(mockGetLastNotifiedStationId.mock.calls.length).toBeGreaterThanOrEqual(2));
+      // 추가 microtask flush로 두 effect 모두 await 지점에 도달했음을 보장.
+      for (let i = 0; i < 12; i++) await Promise.resolve();
+      unmount();
+      resolvers.forEach((r) => r(null));
+      // resolve 후 microtask 충분히 돌려 `if (cancelled) return;` 진입(line 720).
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+      // dedup 로그도 호출되지 않아야 한다 (cancelled로 early return).
+      const arvlCdDedups = mockLogSuppressedDedupStation.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdDedups).toHaveLength(0);
+    });
+
+    it('sendStationPassedNotification 후 cleanup 되면 setLastNotifiedStationId 미호출 (cancelled gate line 736)', async () => {
+      // send pending 동안 unmount → setLastNotifiedStationId 미호출 + logFiredStationPassed 미호출.
+      // GPS effect와 fast path effect 둘 다 send 호출하므로 mockImplementation으로 전체 pending.
+      const resolvers: Array<() => void> = [];
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+      mockSendStationPassedNotification.mockImplementation(
+        () =>
+          new Promise<void>((r) => {
+            resolvers.push(r);
+          }),
+      );
+
+      const { unmount } = renderHook(() => useStationAlarm(fastPathInputs()));
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      unmount();
+      // 모든 pending send를 해제 — 각 effect는 cancelled=true를 보고 setLastNotifiedStationId skip.
+      resolvers.forEach((r) => r());
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // setLastNotifiedStationId와 logFiredStationPassed('fg-arvlcd', ...) 모두 미호출.
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('destination 변경 직후 firedAlarmsRef.destId 미일치 시점에는 fast path 보류 (line 671)', async () => {
+      // hydration mock: 첫 destination에 대해 hydrate 완료 → ref id 일치.
+      // 그 후 destination 변경 시 새 hydrate 진행 중인 짧은 시점에 fast path effect deps 재실행 →
+      // ref.current는 아직 old destination id라 새 destination.id와 불일치 → early return.
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      // 첫 destination 정상 hydrate.
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set<string>());
+      // 두 번째 destination는 hydrate를 pending으로 두어 ref.id가 갱신 전 상태 유지.
+      mockGetFiredAlarms.mockReturnValueOnce(new Promise(() => {}));
+
+      const { rerender } = renderHook(
+        ({ dest }: { dest: Station }) => useStationAlarm(fastPathInputs({ destination: dest })),
+        { initialProps: { dest: destination } },
+      );
+
+      // 첫 destination hydrate 완료 대기.
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+
+      // destination 교체. 새 destination의 hydrate는 pending → firedHydrated=false 또는 ref.id 불일치.
+      mockLogFiredStationPassed.mockClear();
+      rerender({ dest: altDestination });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
     });
   });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -16,6 +16,8 @@ import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils
 import { resolveNextTarget } from '../utils/stationPipeline';
 import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
 import { isImminentByArrivalCode } from '../../arrival/utils/imminentArrivalSignal';
+import { findFgArvlCdFireSignal } from '../utils/fgArvlCdFastPath';
+import type { StationArrival } from '../../../shared/types/arrival';
 import { getStoredTripTrainCode } from '../../route/utils/tripTrainCode';
 import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
 import {
@@ -113,6 +115,16 @@ export interface UseStationAlarmInputs {
    */
   motionStationary?: boolean;
   /**
+   * #917 A2 follow-up — FG fast path arvlCd∈{0,1} 매역 알림 입력.
+   *
+   * 호출자(HomeScreen 등)가 현재 폴링 중인 `useArrivalInfo` 결과를 그대로 전달한다.
+   * 폴링 station은 nearestStation(또는 origin)이 일반적이며, 매역 fast-path effect는
+   * 그 arrival.up/down row 중 lock.trainCode 일치 + arvlCd∈{0,1}을 트리거 신호로 본다.
+   *
+   * 미전달이면 fast-path 효과는 no-op — 기존 ETA/API imminent path와 backend cron 1차 source만 동작.
+   */
+  currentStationArrival?: StationArrival | null;
+  /**
    * 테스트 전용 — #670/#672 좌표 warmup 가드 비활성화.
    * production 호출자는 미설정으로 둠. 단위 테스트에서 mount 직후 alarm 평가 검증 시 사용.
    */
@@ -131,6 +143,7 @@ export function useStationAlarm({
   locationUncertain = false,
   positionStability,
   motionStationary,
+  currentStationArrival,
   skipWarmupGuard = false,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
@@ -629,5 +642,122 @@ export function useStationAlarm({
     clearDismissSilenceAction,
     userLocation?.lat,
     userLocation?.lng,
+  ]);
+
+  // #917 A2 follow-up — FG fast path: lock.trainCode가 currentStationArrival의 row에
+  // arvlCd∈{0,1}으로 첫 관찰되면 nearestStation에 대한 매역(station-passed) 알림 즉시 발사.
+  //
+  // 백엔드 cron(10~30s 사이클) 대비 우위: 클라는 useArrivalInfo 1주기(보통 30s) 안에 같은 신호를
+  // 이미 가지고 있으므로 BG silent push 도달 지연 없이 발사 가능. 지하/지상 무관 SSOT가 GPS 아닌
+  // Seoul `realtimeArrivalList`.
+  //
+  // 가드 (AND, 하나라도 false면 no-op):
+  //   1. firedHydrated — destination별 firedAlarms 복원 완료 후
+  //   2. route + destination + nearestStation 존재 (nearest 없으면 fire 대상 station 결정 불가)
+  //   3. firedAlarmsRef destinationId 일치 (#699 race 가드)
+  //   4. nearestStation이 route 상에 있음 (off-route 신호 무시)
+  //   5. lock 존재 + lock.trainCode == row.trainCode + arvlCd∈{0,1} (findFgArvlCdFireSignal — #640 회귀 가드)
+  //   6. dismiss silence 미적용
+  //   7. movement gate(speed/accuracy/static) 통과
+  //   8. lastNotifiedStationId 미일치 (GPS station-passed와 dedup 공유 — 한 station에 한 알람)
+  //
+  // dedup 정책: lastNotifiedStationId 단일 출처. 기존 station-passed effect와 같은 키를 사용해
+  // GPS 경로/Fast path 어느 쪽이 먼저 발사해도 다른 쪽은 자동 dedup. 이슈가 명시한
+  // `(trainCode, station, arvlCd)` granularity는 station-level dedup의 superset이라 충족된다.
+  useEffect(() => {
+    if (!firedHydrated) return;
+    if (!route || !destination) return;
+    if (!nearestStation) return;
+    if (firedAlarmsRefDestIdRef.current !== destination.id) return;
+    if (!currentStationArrival) return;
+    if (!isStationOnRoute(nearestStation, route)) return;
+
+    const candidateStation = nearestStation;
+    const capturedRoute = route;
+    const capturedDestinationName = destination.name;
+
+    let cancelled = false;
+    void (async () => {
+      const lock = await getBoardingLock();
+      if (cancelled) return;
+      // #640 회귀 가드 — lock 부재 시 lockless trip의 임의 train arvlCd로 fire 절대 금지.
+      // findFgArvlCdFireSignal 내부 가드와 중복이지만 명시 — 가드 본질이 본 PR의 핵심.
+      if (!lock) return;
+      const signal = findFgArvlCdFireSignal(currentStationArrival, lock);
+      if (!signal) return;
+
+      // #746 dismiss silence — 사용자 명시 정책 우선.
+      const silenceGate = applySilenceGate(
+        dismissSilence,
+        Date.now(),
+        userLocation,
+        clearDismissSilenceAction,
+      );
+      if (silenceGate.silenced) {
+        logSuppressedDismissSilence({
+          source: 'fg-arvlcd',
+          stationName: candidateStation.name,
+          kind: 'station-passed',
+        });
+        return;
+      }
+
+      // #727/#728/#733 — 정적 misfire 가드. arvlCd 신호가 강해도 정적 사용자(speed=0) 발사는
+      // 잘못된 trainCode lock 케이스 (fusion이 통과 열차를 momentary adopt)에서 위험.
+      if (movementSuppressionReason) {
+        logSuppressedMovement({
+          source: 'fg-arvlcd',
+          stationName: candidateStation.name,
+          kind: 'station-passed',
+          reason: movementSuppressionReason,
+        });
+        return;
+      }
+
+      // lastNotifiedStationId 공유 dedup. cancelled 재확인 — getBoardingLock 후 effect cleanup 가능.
+      try {
+        const lastId = await getLastNotifiedStationId();
+        if (cancelled) return;
+        if (candidateStation.id === lastId) {
+          logSuppressedDedupStation('fg-arvlcd', candidateStation);
+          return;
+        }
+        const target = resolveNextTarget(
+          capturedRoute,
+          capturedDestinationName,
+          candidateStation.line,
+        );
+        await sendStationPassedNotification(
+          candidateStation.name,
+          capturedDestinationName,
+          target,
+          notificationSource,
+        );
+        if (cancelled) return;
+        await setLastNotifiedStationId(candidateStation.id);
+        logFiredStationPassed('fg-arvlcd', candidateStation);
+      } catch (e) {
+        logger.error('FG arvlCd fast-path 알림 실패:', e);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    firedHydrated,
+    route,
+    destination?.id,
+    destination?.name,
+    nearestStation?.id,
+    nearestStation?.name,
+    nearestStation?.line,
+    currentStationArrival,
+    movementSuppressionReason,
+    dismissSilence,
+    clearDismissSilenceAction,
+    userLocation?.lat,
+    userLocation?.lng,
+    notificationSource,
   ]);
 }

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -679,24 +679,9 @@ export function useStationAlarm({
         return;
       }
 
-      // #746 — dismiss silence 게이트. station-passed 카테고리도 동일 정책으로 차단.
+      // #746 — dismiss silence 게이트 + dispatch는 helper로 통합 (Sonar cpd 회피).
       // userLocation 없이도 시간 조건만 평가 가능 — null 좌표 그대로 전달.
-      const silenceGate = applySilenceGate(
-        dismissSilence,
-        Date.now(),
-        userLocation,
-        clearDismissSilenceAction,
-      );
-      if (silenceGate.silenced) {
-        logSuppressedDismissSilence({
-          source: 'fg',
-          stationName: candidateStation.name,
-          kind: 'station-passed',
-        });
-        return;
-      }
-
-      void dispatchStationPassed({
+      void runSilenceGateAndDispatch({
         source: 'fg',
         candidateStation,
         capturedRoute,
@@ -704,6 +689,9 @@ export function useStationAlarm({
         notificationSource,
         isCancelled: () => cancelled,
         errorLogPrefix: '역 통과 알림 실패:',
+        dismissSilence,
+        userLocation,
+        clearDismissSilenceAction,
       });
     }
 
@@ -766,24 +754,9 @@ export function useStationAlarm({
       const signal = findFgArvlCdFireSignal(currentStationArrival, lock);
       if (!signal) return;
 
-      // #746 dismiss silence — 사용자 명시 정책 우선.
-      const silenceGate = applySilenceGate(
-        dismissSilence,
-        Date.now(),
-        userLocation,
-        clearDismissSilenceAction,
-      );
-      if (silenceGate.silenced) {
-        logSuppressedDismissSilence({
-          source: 'fg-arvlcd',
-          stationName: candidateStation.name,
-          kind: 'station-passed',
-        });
-        return;
-      }
-
       // #727/#728/#733 — 정적 misfire 가드. arvlCd 신호가 강해도 정적 사용자(speed=0) 발사는
       // 잘못된 trainCode lock 케이스 (fusion이 통과 열차를 momentary adopt)에서 위험.
+      // movement gate는 silence gate보다 먼저 평가 — 정적 사용자면 silence 만료 부수효과도 불필요.
       if (movementSuppressionReason) {
         logSuppressedMovement({
           source: 'fg-arvlcd',
@@ -794,8 +767,9 @@ export function useStationAlarm({
         return;
       }
 
+      // #746 silence gate + dispatch는 helper로 통합 (Sonar cpd 회피).
       // lastNotifiedStationId 공유 dedup. cancelled 재확인 — getBoardingLock 후 effect cleanup 가능.
-      await dispatchStationPassed({
+      await runSilenceGateAndDispatch({
         source: 'fg-arvlcd',
         candidateStation,
         capturedRoute,
@@ -803,6 +777,9 @@ export function useStationAlarm({
         notificationSource,
         isCancelled: () => cancelled,
         errorLogPrefix: 'FG arvlCd fast-path 알림 실패:',
+        dismissSilence,
+        userLocation,
+        clearDismissSilenceAction,
       });
     })();
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -47,7 +47,7 @@ import { useAlarmEventStore } from '../store/useAlarmEventStore';
 import { createLogger } from '../../../shared/utils/logger';
 import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
-import { resolveNotificationSource } from '../utils/notificationSource';
+import { resolveNotificationSource, type NotificationSource } from '../utils/notificationSource';
 
 const logger = createLogger('StationAlarm');
 
@@ -82,6 +82,105 @@ function applySilenceGate(
 
 function logClearFailure(e: unknown): void {
   logger.warn('clearDismissSilence 실패 — 다음 사이클 재시도', e);
+}
+
+/**
+ * #917 follow-up — station-passed 알림 dedup → resolve → send → setLast → log 시퀀스 추출.
+ * GPS station-passed effect와 FG arvlCd fast-path effect가 동일한 5단 시퀀스를 반복하던 것
+ * (Sonar cpd 27/25 line 블록)을 단일 함수로 통합. source 라벨만 다르고 dedup 키는
+ * lastNotifiedStationId 단일 출처 — 어느 effect가 먼저 발사해도 다른 쪽이 자동 dedup.
+ *
+ * cancelled 콜백을 받는 이유: 호출부가 IIFE 내부에서 effect cleanup을 관찰해야 함.
+ * await 경계마다 재확인하지 않으면 stale fire 가능.
+ */
+async function dispatchStationPassed(params: {
+  source: 'fg' | 'fg-arvlcd';
+  candidateStation: Station;
+  capturedRoute: Route;
+  capturedDestinationName: string;
+  notificationSource: NotificationSource | undefined;
+  isCancelled: () => boolean;
+  errorLogPrefix: string;
+}): Promise<void> {
+  const {
+    source,
+    candidateStation,
+    capturedRoute,
+    capturedDestinationName,
+    notificationSource,
+    isCancelled,
+    errorLogPrefix,
+  } = params;
+  try {
+    const lastId = await getLastNotifiedStationId();
+    if (isCancelled()) return;
+    if (candidateStation.id === lastId) {
+      logSuppressedDedupStation(source, candidateStation);
+      return;
+    }
+    // #796: candidateStation.line을 전달해 multi-transfer 환승역 정확 식별.
+    const target = resolveNextTarget(
+      capturedRoute,
+      capturedDestinationName,
+      candidateStation.line,
+    );
+    // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
+    await sendStationPassedNotification(
+      candidateStation.name,
+      capturedDestinationName,
+      target,
+      notificationSource,
+    );
+    if (isCancelled()) return;
+    await setLastNotifiedStationId(candidateStation.id);
+    logFiredStationPassed(source, candidateStation);
+  } catch (e) {
+    logger.error(errorLogPrefix, e);
+  }
+}
+
+/**
+ * #917 follow-up — silence 게이트 통과 후 dispatchStationPassed 호출. GPS path(`fg`)와 FG arvlCd
+ * fast-path(`fg-arvlcd`)가 같은 silence→dispatch 시퀀스를 반복하던 Sonar cpd 25 line 블록을 통합.
+ * silenced=true면 log + return; 아니면 dispatch. 두 path 모두 호출 직전에 movement gate를
+ * 자체적으로 처리(GPS path는 effect 진입 시점에 미리, FG path는 본 helper 호출 직전에) 한 뒤
+ * 본 함수를 호출한다.
+ */
+async function runSilenceGateAndDispatch(params: {
+  source: 'fg' | 'fg-arvlcd';
+  candidateStation: Station;
+  capturedRoute: Route;
+  capturedDestinationName: string;
+  notificationSource: NotificationSource | undefined;
+  isCancelled: () => boolean;
+  errorLogPrefix: string;
+  dismissSilence: import('../utils/dismissSilenceStorage').DismissSilenceState | null;
+  userLocation: { lat: number; lng: number } | null;
+  clearDismissSilenceAction: () => Promise<void>;
+}): Promise<void> {
+  const silenceGate = applySilenceGate(
+    params.dismissSilence,
+    Date.now(),
+    params.userLocation,
+    params.clearDismissSilenceAction,
+  );
+  if (silenceGate.silenced) {
+    logSuppressedDismissSilence({
+      source: params.source,
+      stationName: params.candidateStation.name,
+      kind: 'station-passed',
+    });
+    return;
+  }
+  await dispatchStationPassed({
+    source: params.source,
+    candidateStation: params.candidateStation,
+    capturedRoute: params.capturedRoute,
+    capturedDestinationName: params.capturedDestinationName,
+    notificationSource: params.notificationSource,
+    isCancelled: params.isCancelled,
+    errorLogPrefix: params.errorLogPrefix,
+  });
 }
 
 export interface UseStationAlarmInputs {
@@ -597,34 +696,15 @@ export function useStationAlarm({
         return;
       }
 
-      void (async () => {
-        try {
-          const lastId = await getLastNotifiedStationId();
-          if (cancelled) return;
-          if (candidateStation.id === lastId) {
-            logSuppressedDedupStation('fg', candidateStation);
-            return;
-          }
-          // #796: candidateStation.line을 전달해 multi-transfer 환승역 정확 식별.
-          const target = resolveNextTarget(
-            capturedRoute,
-            capturedDestinationName,
-            candidateStation.line,
-          );
-          // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
-          await sendStationPassedNotification(
-            candidateStation.name,
-            capturedDestinationName,
-            target,
-            notificationSource,
-          );
-          if (cancelled) return;
-          await setLastNotifiedStationId(candidateStation.id);
-          logFiredStationPassed('fg', candidateStation);
-        } catch (e) {
-          logger.error('역 통과 알림 실패:', e);
-        }
-      })();
+      void dispatchStationPassed({
+        source: 'fg',
+        candidateStation,
+        capturedRoute,
+        capturedDestinationName,
+        notificationSource,
+        isCancelled: () => cancelled,
+        errorLogPrefix: '역 통과 알림 실패:',
+      });
     }
 
     return () => {
@@ -715,30 +795,15 @@ export function useStationAlarm({
       }
 
       // lastNotifiedStationId 공유 dedup. cancelled 재확인 — getBoardingLock 후 effect cleanup 가능.
-      try {
-        const lastId = await getLastNotifiedStationId();
-        if (cancelled) return;
-        if (candidateStation.id === lastId) {
-          logSuppressedDedupStation('fg-arvlcd', candidateStation);
-          return;
-        }
-        const target = resolveNextTarget(
-          capturedRoute,
-          capturedDestinationName,
-          candidateStation.line,
-        );
-        await sendStationPassedNotification(
-          candidateStation.name,
-          capturedDestinationName,
-          target,
-          notificationSource,
-        );
-        if (cancelled) return;
-        await setLastNotifiedStationId(candidateStation.id);
-        logFiredStationPassed('fg-arvlcd', candidateStation);
-      } catch (e) {
-        logger.error('FG arvlCd fast-path 알림 실패:', e);
-      }
+      await dispatchStationPassed({
+        source: 'fg-arvlcd',
+        candidateStation,
+        capturedRoute,
+        capturedDestinationName,
+        notificationSource,
+        isCancelled: () => cancelled,
+        errorLogPrefix: 'FG arvlCd fast-path 알림 실패:',
+      });
     })();
 
     return () => {

--- a/src/features/alarm/utils/__tests__/fgArvlCdFastPath.test.ts
+++ b/src/features/alarm/utils/__tests__/fgArvlCdFastPath.test.ts
@@ -1,7 +1,6 @@
 import { findFgArvlCdFireSignal } from '../fgArvlCdFastPath';
-import type { StationArrival } from '../../../../shared/types/arrival';
+import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
-import type { ArrivalInfo } from '../../../../shared/types/arrival';
 import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
 
 function makeRow(overrides: Partial<ArrivalInfo>): ArrivalInfo {

--- a/src/features/alarm/utils/__tests__/fgArvlCdFastPath.test.ts
+++ b/src/features/alarm/utils/__tests__/fgArvlCdFastPath.test.ts
@@ -1,0 +1,104 @@
+import { findFgArvlCdFireSignal } from '../fgArvlCdFastPath';
+import type { StationArrival } from '../../../../shared/types/arrival';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { ArrivalInfo } from '../../../../shared/types/arrival';
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+
+function makeRow(overrides: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: '강남',
+    arrivalMinutes: 1,
+    arrivalSeconds: 60,
+    statusMessage: '',
+    trainCode: 'T1',
+    line: '2',
+    receivedAtMs: 1_700_000_000_000,
+    arrivalCode: ARRIVAL_CODE.ENTERING,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+function makeArrival(rows: { up?: ArrivalInfo[]; down?: ArrivalInfo[] }): StationArrival {
+  return { up: rows.up ?? [], down: rows.down ?? [] };
+}
+
+const lock: BoardingLock = {
+  destinationId: 'D1',
+  trainCode: 'T1',
+  boardingStationId: 'S1',
+  boardingLine: '2',
+  boardedAt: 1_700_000_000_000,
+  expectedDurationMs: 600_000,
+};
+
+describe('findFgArvlCdFireSignal (#917 A2 follow-up)', () => {
+  it('arrival null이면 null', () => {
+    expect(findFgArvlCdFireSignal(null, lock)).toBeNull();
+  });
+
+  it('#640 회귀 가드 — lock null이면 null (lockless 매역 알림 절대 금지)', () => {
+    const arrival = makeArrival({
+      up: [makeRow({ trainCode: 'T1', arrivalCode: ARRIVAL_CODE.ENTERING })],
+    });
+    expect(findFgArvlCdFireSignal(arrival, null)).toBeNull();
+  });
+
+  it('row가 한 건도 없으면 null', () => {
+    expect(findFgArvlCdFireSignal(makeArrival({}), lock)).toBeNull();
+  });
+
+  it('lock.trainCode와 일치하는 row가 없으면 null (#640 회귀 가드)', () => {
+    const arrival = makeArrival({
+      up: [makeRow({ trainCode: 'OTHER', arrivalCode: ARRIVAL_CODE.ENTERING })],
+      down: [makeRow({ trainCode: 'ALSO-OTHER', arrivalCode: ARRIVAL_CODE.ARRIVED })],
+    });
+    expect(findFgArvlCdFireSignal(arrival, lock)).toBeNull();
+  });
+
+  it('lock.trainCode 일치 + arvlCd=ENTERING(0) → fire signal 반환', () => {
+    const arrival = makeArrival({
+      up: [makeRow({ trainCode: 'T1', arrivalCode: ARRIVAL_CODE.ENTERING })],
+    });
+    expect(findFgArvlCdFireSignal(arrival, lock)).toEqual({
+      trainCode: 'T1',
+      arvlCd: ARRIVAL_CODE.ENTERING,
+    });
+  });
+
+  it('lock.trainCode 일치 + arvlCd=ARRIVED(1) → fire signal 반환', () => {
+    const arrival = makeArrival({
+      down: [makeRow({ trainCode: 'T1', arrivalCode: ARRIVAL_CODE.ARRIVED })],
+    });
+    expect(findFgArvlCdFireSignal(arrival, lock)).toEqual({
+      trainCode: 'T1',
+      arvlCd: ARRIVAL_CODE.ARRIVED,
+    });
+  });
+
+  it('lock.trainCode 일치하지만 arvlCd=DEPARTED(2) → null (신호 아님)', () => {
+    const arrival = makeArrival({
+      up: [makeRow({ trainCode: 'T1', arrivalCode: ARRIVAL_CODE.DEPARTED })],
+    });
+    expect(findFgArvlCdFireSignal(arrival, lock)).toBeNull();
+  });
+
+  it('lock.trainCode 일치하지만 arvlCd=PREV_ARRIVED(5) → null (전역 신호는 fast path 대상 아님)', () => {
+    const arrival = makeArrival({
+      up: [makeRow({ trainCode: 'T1', arrivalCode: ARRIVAL_CODE.PREV_ARRIVED })],
+    });
+    expect(findFgArvlCdFireSignal(arrival, lock)).toBeNull();
+  });
+
+  it('down 방향에 있는 lock.trainCode도 탐지 (방향 무관)', () => {
+    const arrival = makeArrival({
+      up: [makeRow({ trainCode: 'X', arrivalCode: ARRIVAL_CODE.ARRIVED })],
+      down: [makeRow({ trainCode: 'T1', arrivalCode: ARRIVAL_CODE.ENTERING })],
+    });
+    expect(findFgArvlCdFireSignal(arrival, lock)).toEqual({
+      trainCode: 'T1',
+      arvlCd: ARRIVAL_CODE.ENTERING,
+    });
+  });
+});

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -43,7 +43,10 @@ export type AlarmLogSource =
   | 'alert-fallback-fired'
   // #580: useStationAlarm 하이드레이션 1회당 1엔트리. destinationId + 복원된 fired set 크기 기록.
   // 두 번째 fire 직전에 ref가 비워졌는지 직접 관찰 — race 가설 확인용.
-  | 'fg-hydrate';
+  | 'fg-hydrate'
+  // #917 A2 follow-up — FG fast path: lock.trainCode arvlCd∈{0,1} 신호로 매역 알림 발사한 케이스.
+  // 일반 GPS 기반 fg와 구분해 backend cron silent push 대비 fast path 도달률·정확도 측정.
+  | 'fg-arvlcd';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -477,6 +480,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'bg-scheduled': null,
   'alert-fallback-fired': null,
   'fg-hydrate': null,
+  'fg-arvlcd': null,
 };
 
 export interface SilentPushOutcomeCounts {

--- a/src/features/alarm/utils/fgArvlCdFastPath.ts
+++ b/src/features/alarm/utils/fgArvlCdFastPath.ts
@@ -1,0 +1,46 @@
+import type { StationArrival } from '../../../shared/types/arrival';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
+
+/**
+ * #917 A2 follow-up — FG fast path arvlCd∈{0,1} 매역 알림 발사 신호 탐색.
+ *
+ * 백엔드 cron이 같은 신호로 silent push를 발사할 때까지 10~30s 사이클을 기다리지 않고,
+ * 클라가 FG에서 폴링한 `StationArrival`을 보는 즉시 매역 알림을 발사하기 위한 pure 판정 함수.
+ *
+ * 발사 조건 (AND, 하나라도 false면 null):
+ *   1. `arrival` 존재
+ *   2. `lock` 존재 (#640 회귀 가드 — lockless trip은 절대 발사 안 함)
+ *   3. `arrival.up + arrival.down` 중 `trainCode === lock.trainCode`인 row 존재
+ *   4. 해당 row의 `arrivalCode`가 ENTERING(0) 또는 ARRIVED(1)
+ *
+ * @returns 발사 가능 시 `{ trainCode, arvlCd }`. 모든 가드 통과해야 non-null.
+ *
+ * 디자인 노트:
+ *   - `isImminentByArrivalCode`(destination imminent 전용)와 분리한 이유: 본 fast path는
+ *     "현재 폴링 중인 임의의 station에 대한 매역 신호"로 의미가 다르다(destination에 한정 X).
+ *     호출자가 station 컨텍스트를 알고 있으므로 함수 자체는 station-agnostic.
+ *   - lock.trainCode가 양방향(up/down) 둘 중 어디 있어도 발사 — Seoul API가 동일 trainCode를
+ *     direction 분리해 노출할 수 있고, fast path는 방향 무관한 보조 신호.
+ */
+export interface FgArvlCdFireSignal {
+  trainCode: string;
+  arvlCd: number;
+}
+
+export function findFgArvlCdFireSignal(
+  arrival: StationArrival | null,
+  lock: BoardingLock | null,
+): FgArvlCdFireSignal | null {
+  if (!arrival || !lock) return null;
+  const rows = [...arrival.up, ...arrival.down];
+  const match = rows.find((r) => r.trainCode === lock.trainCode);
+  if (!match) return null;
+  if (
+    match.arrivalCode !== ARRIVAL_CODE.ENTERING &&
+    match.arrivalCode !== ARRIVAL_CODE.ARRIVED
+  ) {
+    return null;
+  }
+  return { trainCode: lock.trainCode, arvlCd: match.arrivalCode };
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -249,6 +249,10 @@ export default function HomeScreen() {
     locationUncertain,
     positionStability,
     motionStationary,
+    // #917 A2 follow-up — FG fast path: 현재 폴링 중인 origin/nearest station arrival을 전달해
+    // lock.trainCode arvlCd∈{0,1} 첫 관찰 시 매역 알림 즉시 발사. rawArrival(useArrivalCountdown
+    // 미적용)을 직접 전달 — 매역 발사 트리거는 분 단위 tick과 무관한 arvlCd 원본 값.
+    currentStationArrival: rawArrival,
   });
 
   // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,


### PR DESCRIPTION
Closes #917

## Summary
- Backend cron(#933 머지)이 arvlCd=0/1로 silent push를 발사할 때 클라가 같은 신호를 FG 폴링으로 이미 가지고 있으면 backend round-trip(10~30s) 없이 즉시 매역 알림 발사.
- 신호 판정은 pure util `findFgArvlCdFireSignal(arrival, lock)` — `lock` 부재 시 항상 null(#640 회귀 가드), `lock.trainCode` 매칭 row의 `arrivalCode ∈ {ENTERING(0), ARRIVED(1)}`만 신호.
- `useStationAlarm`에 fast-path effect 추가. 8단 AND 게이트 (firedHydrated / route+destination+nearestStation / ref destId 일치 / on-route / lock 존재 / dismiss silence / movement / lastNotifiedStationId 미일치).
- dedup은 `lastNotifiedStationId` SSOT로 GPS station-passed effect와 공유 — 한 station 1알람 보장. 어느 경로가 먼저 발사해도 다른 쪽 자동 dedup.
- 관측: `alarmLog` source에 `'fg-arvlcd'` 추가 — backend silent push vs client fast path 도달률·정확도 분리 측정.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (3876 tests / 215 suites pass, coverage 100% lines/functions/branches/statements)
- [x] `fgArvlCdFastPath.test.ts`: 9 케이스 — null/lock 부재/trainCode 불일치/arvlCd∈{0,1} 양방향/DEPARTED·PREV_ARRIVED 제외
- [x] `useStationAlarm.test.ts` 신규 16 케이스 — fire/640 회귀 가드/dedup/no-op 분기 6종/movement/silence/hydration race/cleanup race 2종/destination 전환 race
- [ ] 실기기 회귀: dev 빌드로 FG trip 실행 시 fast path 발사 시점 로그가 backend silent push 도달보다 우선되는지 확인 (#917 epic context)

## Follow-up (P2, deferred)
- **customOrigin 분기 시 station mismatch**: `currentStationArrival`는 `effectiveOrigin = customOrigin ?? nearestStation`을 polling하지만 fast-path effect는 `nearestStation` 기준으로 fire. `customOrigin ≠ nearestStation`인 케이스에서 trigger station ≠ fired station — 별도 이슈로 추적 권장(GPS station-passed effect도 유사한 nearest 기반이라 design choice).
- **movement gate closure window**: render에서 캡처한 `movementSuppressionReason`이 `await getBoardingLock()` 동안 stale 가능. 영향 작고 다른 effect들과 같은 패턴이라 본 PR 범위 밖.