### PR TITLE
feat(#926): HomeScreen sentinel clear 트리거 wire

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -7,6 +7,7 @@ import {
   ACTIVE_TRIP_KEY,
   TRIP_STARTED_AT_KEY,
   LAST_UPLOADED_RECALL_TRIP_START_KEY,
+  LA_DISMISSED_AT_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
@@ -38,6 +39,9 @@ describe('tripBoundCleanups', () => {
     // (dedup 마커 — BG silent push upload 후 직후 FG setDestination(null) 재트리거 시
     //  같은 tripStart 중복 upload 방지). 다른 tripStart로 시작되면 자연 무효화됨.
     expect(removedKeys).toContain(TRIP_STARTED_AT_KEY);
+    // #926 — LA dismiss sentinel도 destination switch 시 함께 클리어. 다음 silent push에서
+    // LA 재상승 허용. 누락 회귀가 발생하면 dismiss 후 새 trip 시작해도 LA가 살아나지 않음.
+    expect(removedKeys).toContain(LA_DISMISSED_AT_KEY);
     expect(removedKeys).not.toContain(LAST_UPLOADED_RECALL_TRIP_START_KEY);
   });
 

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -27,6 +27,7 @@ import {
 import { clearFiredPushIds } from '../utils/firedPushIds';
 import { clearTripTrainCode } from '../../route/utils/tripTrainCode';
 import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dismissSilenceStorage';
+import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
 
 // trip-bound storage cleanup 단일 출처.
 // useDestinationStore.setDestination이 isSwitch(목적지 변경 또는 null 클리어) 분기에서 호출한다.
@@ -60,6 +61,9 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   () => AsyncStorage.removeItem(ALARM_EVENT_KEY),
   // #746 — 새 trip 시작 시 이전 trip의 dismiss silence는 무효 → 즉시 클리어.
   clearDismissSilenceStorage,
+  // #926 — destination 재설정(switch/null) 시 LA dismiss sentinel도 해제 → 다음 silent push에서
+  // LA 재상승 허용. TTL 30분은 보조 게이트, 사용자 명시 재설정이 더 강한 의도 신호이므로 즉시 reset.
+  clearLaDismissSentinel,
   // #919 — trip 시작 시각만 제거. LAST_UPLOADED_RECALL_TRIP_START_KEY는 dedup 마커이므로
   // 새 trip이 시작될 때 (tripStart 값이 달라질 때) 자연 무효화된다. 여기서 같이 지우면
   // BG silent-push가 upload + 직후 FG setDestination(null)이 같은 tripStart로 재trigger되는

--- a/src/features/alarm/utils/laDismissSentinel.ts
+++ b/src/features/alarm/utils/laDismissSentinel.ts
@@ -7,7 +7,9 @@
  *
  * 정책:
  *  - sentinel TTL = `LA_DISMISS_SENTINEL_TTL_MS` (30분). TTL 경과 후 자동 만료 → LA 재상승 OK.
- *  - 명시적 reset(destination 재설정 / 앱 진입)은 `clearLaDismissSentinel()`로 즉시 해제(후속 PR).
+ *  - 명시적 reset(destination 재설정)은 `clearLaDismissSentinel()`로 즉시 해제 — #926 후속 PR에서
+ *    `TRIP_BOUND_CLEANUPS`(alarm/store/tripBoundCleanups.ts)에 wire되어
+ *    `setDestination` switch 분기에서 자동 호출된다.
  *
  * SSOT key: `storageKeys.LA_DISMISSED_AT_KEY`.
  *
@@ -48,7 +50,10 @@ export async function isLaDismissed(now: number = Date.now()): Promise<boolean> 
   }
 }
 
-/** sentinel 명시적 reset. destination 재설정 / 앱 진입 트리거에서 호출(후속 PR). */
+/**
+ * sentinel 명시적 reset. `TRIP_BOUND_CLEANUPS`에 wire되어 `setDestination` switch 시 자동 호출(#926).
+ * 사용자가 새 목적지를 설정하는 것은 dismiss 의도보다 강한 재engagement 신호이므로 TTL을 기다리지 않고 즉시 해제.
+ */
 export async function clearLaDismissSentinel(): Promise<void> {
   try {
     await AsyncStorage.removeItem(LA_DISMISSED_AT_KEY);

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -212,6 +212,35 @@ describe('useDestinationStore', () => {
     }
   });
 
+  // #926 — destination 재설정 시 LA dismiss sentinel도 함께 reset되어 다음 silent push에서
+  // LA가 다시 살아나야 한다. switch와 null 두 경로 모두 동일 cleanup을 트리거.
+  it.each<[string, 'switch' | 'null']>([
+    ['switch', 'switch'],
+    ['null clear', 'null'],
+  ])('setDestination(#926): %s 시 LA dismiss sentinel도 함께 클리어', async (_, transition) => {
+    const { setDestination } = useDestinationStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+    (triggerTripEndRecall as jest.Mock).mockResolvedValue({ uploaded: false });
+    (setTripStartedAt as jest.Mock).mockResolvedValue(undefined);
+
+    setDestination(transition === 'switch' ? mockStation2 : null);
+    await flushMicrotasks();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:la-dismissed-at');
+  });
+
+  it('setDestination(#926): 같은 목적지 재설정에서는 sentinel을 건드리지 않는다 — dismiss 의도 보존', () => {
+    const { setDestination } = useDestinationStore.getState();
+    setDestination(mockStation);
+    jest.clearAllMocks();
+
+    // 같은 station 재설정 — switch 아님 → sentinel 보존(사용자 dismiss 의도가 더 강함).
+    setDestination(mockStation);
+
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:la-dismissed-at');
+  });
+
   it('setDestination(#702): switch 시 customOrigin 메모리 state도 null로 동기화', () => {
     const { setDestination, setCustomOrigin } = useDestinationStore.getState();
     setDestination(mockStation);


### PR DESCRIPTION
Closes #926

## Summary
- `TRIP_BOUND_CLEANUPS`에 `clearLaDismissSentinel` 추가 → `setDestination` switch 분기에서 자동 호출
- destination 재설정(A→B / A→null)이 LA dismiss sentinel을 즉시 reset해 다음 silent push에서 LA 재상승 허용
- 같은 destination 재설정은 switch 아님 → sentinel 보존 (사용자 dismiss 의도 더 강함)
- 30분 TTL은 sentinel util 안에 이미 존재 → 재구현 없음
- 앱 cold-start hydration은 sentinel 건드리지 않음 — dismiss 정책 보존(명시 재설정만 신호로 인정)

## 설계 결정
- E3 #941 PR의 sentinel infra(`markLaDismissed` / `isLaDismissed` / `clearLaDismissSentinel`)를 그대로 활용. SSOT인 `TRIP_BOUND_CLEANUPS`에 한 줄 추가하는 wire-up만 수행
- HomeScreen 직접 호출 대신 cleanup 배열 사용: 단일 진입점이라 BG silent-push trip-end 경로(#868)도 자동 커버 + 미래 wire 누락 회귀 차단 (장점 #702/#799 사례)

## Test plan
- [x] `npm test` — 3913 tests pass, 100% coverage (lines/functions/branches/statements)
- [x] `npm run type-check` clean
- [x] `tripBoundCleanups.test.ts`: `LA_DISMISSED_AT_KEY`가 cleanup으로 제거되는지 invariant 추가
- [x] `useDestinationStore.test.ts`: switch/null 경로 it.each + same-destination 보존 케이스
- [x] sentinel util 자체 테스트(#941에서 추가) 기존 통과 — TTL 경계/clock-skew/AsyncStorage 실패 graceful

## Follow-up
- modules/live-activity 사용자 명시 dismiss 이벤트 capture는 별도 PR(이슈 #926 본문 진입점 외 영역)