### PR TITLE
feat(#925): useArrivalAutoClear wire — destination 도착 + 도보 → LA 자동 end

### DIFF
--- a/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
@@ -1,0 +1,304 @@
+import { renderHook } from '@testing-library/react-native';
+import {
+  useDestinationAutoClear,
+  pickDestinationArvlCd,
+  type UseDestinationAutoClearInputs,
+} from '../useDestinationAutoClear';
+import type { Station } from '../../../../shared/types/station';
+import type { StationArrival, ArrivalInfo } from '../../../../shared/types/arrival';
+import {
+  NEAR_STATION_RADIUS_M,
+  STATIONARY_THRESHOLD_MS,
+} from '../../../../shared/constants/arrivalDetect';
+
+const mockUseArrivalInfo = jest.fn();
+jest.mock('../../../arrival/hooks/useArrivalInfo', () => ({
+  useArrivalInfo: (...args: unknown[]) => mockUseArrivalInfo(...args),
+}));
+
+const mockLoggerInfo = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const destination: Station = {
+  id: 'dest-1',
+  name: '강남',
+  line: '2',
+  lineColor: '#000',
+  lat: 37.498,
+  lng: 127.028,
+};
+const altDestination: Station = { ...destination, id: 'dest-2', name: '잠실' };
+
+const T0 = 1_700_000_000_000;
+
+function withDateNow<T>(value: number, fn: () => T): T {
+  const spy = jest.spyOn(Date, 'now').mockReturnValue(value);
+  try {
+    return fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+/** 단일 train ArrivalInfo factory. arvlCd 외 필드는 detect와 무관. */
+function makeTrain(arrivalCode: number): ArrivalInfo {
+  return {
+    destination: '왕십리행',
+    arrivalMinutes: 0,
+    arrivalSeconds: 0,
+    statusMessage: '도착',
+    trainCode: 'T-1',
+    line: '2',
+    receivedAtMs: T0,
+    arrivalCode,
+    isLastTrain: false,
+    trainType: 'normal',
+  };
+}
+
+function arrivalWithCodes(upCodes: number[], downCodes: number[] = []): StationArrival {
+  return {
+    up: upCodes.map(makeTrain),
+    down: downCodes.map(makeTrain),
+  };
+}
+
+function setArrival(arrival: StationArrival | null): void {
+  mockUseArrivalInfo.mockReturnValue({ arrival, isMock: false, loading: false });
+}
+
+function baseInputs(overrides: Partial<UseDestinationAutoClearInputs> = {}): UseDestinationAutoClearInputs {
+  return {
+    destination,
+    userLocation: { lat: destination.lat, lng: destination.lng },
+    motionStationary: false,
+    onAutoClear: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('pickDestinationArvlCd', () => {
+  it('arrival=null이면 null', () => {
+    expect(pickDestinationArvlCd(null)).toBeNull();
+  });
+
+  it('up/down 모두 비어 있으면 null', () => {
+    expect(pickDestinationArvlCd(arrivalWithCodes([], []))).toBeNull();
+  });
+
+  it('ARRIVED(1) 우선 선택 — ENTERING(0)과 섞여도 1 반환', () => {
+    expect(pickDestinationArvlCd(arrivalWithCodes([0, 1, 99]))).toBe(1);
+  });
+
+  it('ENTERING(0)만 있으면 0 반환', () => {
+    expect(pickDestinationArvlCd(arrivalWithCodes([99, 2, 0]))).toBe(0);
+  });
+
+  it('우선순위 0인 코드만 있으면 null — detect가 "이 역 아님"으로 분류', () => {
+    expect(pickDestinationArvlCd(arrivalWithCodes([2, 3, 99]))).toBeNull();
+  });
+
+  it('up/down 합쳐서 가장 강한 신호 반환', () => {
+    expect(pickDestinationArvlCd(arrivalWithCodes([99], [1]))).toBe(1);
+  });
+});
+
+describe('useDestinationAutoClear', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setArrival(null);
+  });
+
+  it('destination=null이면 onAutoClear 호출 안 함 + useArrivalInfo(null, null)로 폴링 정지', () => {
+    const onAutoClear = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useDestinationAutoClear(baseInputs({ destination: null, onAutoClear })));
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+    expect(mockUseArrivalInfo).toHaveBeenCalledWith(null, null);
+  });
+
+  it('arvlCd 약함(99) → 발사 안 함', () => {
+    setArrival(arrivalWithCodes([99]));
+    const onAutoClear = jest.fn();
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      renderHook(() => useDestinationAutoClear(baseInputs({ onAutoClear, motionStationary: true })));
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+  });
+
+  it('motionStationary=false면 발사 안 함 (정지 시간 카운트 안 함)', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useDestinationAutoClear(baseInputs({ onAutoClear, motionStationary: false })));
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+  });
+
+  it('첫 stationary 진입에서는 발사 안 함 (정지 시간 = 0)', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    withDateNow(T0, () => {
+      renderHook(() => useDestinationAutoClear(baseInputs({ onAutoClear, motionStationary: true })));
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+  });
+
+  it('motionStationary 진입 후 60s 지나면 onAutoClear 1회 호출 + log', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    const initial = baseInputs({ onAutoClear, motionStationary: true });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      // userLocation을 미세 변경해 effect 재실행 트리거 (좌표 가까운 jitter).
+      rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+    });
+    expect(onAutoClear).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'destination=강남 자동 해제 (confidence=high)',
+    );
+  });
+
+  it('userLocation이 50m 밖이면 발사 안 함', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    // 100m offset (1 deg lat ≈ 111km → 0.001 ≈ 111m → 안전하게 0.002)
+    const far = { lat: destination.lat + 0.002, lng: destination.lng };
+    const initial = baseInputs({ onAutoClear, motionStationary: true, userLocation: far });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      rerender({ ...initial, userLocation: { ...far, lat: far.lat + 0.00001 } });
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+  });
+
+  it('motionStationary가 중간에 끊기면 카운터 리셋 → 60s 새로 대기', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    const initial = baseInputs({ onAutoClear, motionStationary: true });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    // 30s 경과 후 잠깐 walking
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS / 2, () => {
+      rerender({ ...initial, motionStationary: false });
+    });
+    // 다시 stationary, 30s 더 흐름 — 총 경과는 STATIONARY_THRESHOLD_MS지만 카운트는 리셋되어 0부터 시작
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      rerender({ ...initial, motionStationary: true });
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+  });
+
+  it('한 trip에서 1회만 발사 — 같은 destination에서 후속 rerender는 no-op', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    const initial = baseInputs({ onAutoClear, motionStationary: true });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+    });
+    expect(onAutoClear).toHaveBeenCalledTimes(1);
+    // 같은 destination에서 추가 update — fired ref가 막아 재발사 안 함
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS + 30_000, () => {
+      rerender({ ...initial, userLocation: { lat: destination.lat + 0.00002, lng: destination.lng } });
+    });
+    expect(onAutoClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('destination 변경 시 fired ref 리셋 — 새 destination도 1회 발사 가능', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    const initial = baseInputs({ onAutoClear, motionStationary: true });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+    });
+    expect(onAutoClear).toHaveBeenCalledTimes(1);
+
+    // 새 destination — userLocation도 새 dest 부근으로 이동
+    const newInputs: UseDestinationAutoClearInputs = {
+      ...initial,
+      destination: altDestination,
+      userLocation: { lat: altDestination.lat, lng: altDestination.lng },
+    };
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS + 1_000, () => {
+      rerender(newInputs);
+    });
+    // 새 trip 첫 진입 — stationary ref가 새 timestamp만 기록
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS + 1_000 + STATIONARY_THRESHOLD_MS, () => {
+      rerender({
+        ...newInputs,
+        userLocation: { lat: altDestination.lat + 0.00001, lng: altDestination.lng },
+      });
+    });
+    expect(onAutoClear).toHaveBeenCalledTimes(2);
+  });
+
+  it('destination null로 전환 시 stationary ref 리셋 — 같은 destination 재설정 시 새 카운트', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    const initial = baseInputs({ onAutoClear, motionStationary: true });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    // stationary 30s 누적 후 destination null로 전환
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS / 2, () => {
+      rerender({ ...initial, destination: null });
+    });
+    // 같은 destination 재설정 — 카운터 0부터 다시 시작
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS / 2 + 1_000, () => {
+      rerender(initial);
+    });
+    // 60s 더 흘러야 발사 — 50s만 흐른 시점은 안 됨
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS / 2 + 1_000 + STATIONARY_THRESHOLD_MS - 10_000, () => {
+      rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+  });
+
+  it('userLocation=null이면 detect 입력 불충분 → 발사 안 함', () => {
+    setArrival(arrivalWithCodes([1]));
+    const onAutoClear = jest.fn();
+    const initial = baseInputs({ onAutoClear, motionStationary: true, userLocation: null });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      rerender({ ...initial });
+    });
+    expect(onAutoClear).not.toHaveBeenCalled();
+  });
+
+  it('확인용 — NEAR_STATION_RADIUS_M(50m) 경계 직전이면 발사', () => {
+    setArrival(arrivalWithCodes([0])); // ENTERING도 통과
+    const onAutoClear = jest.fn();
+    // ~40m 정도 — 100m 보수.  111000 m/deg lat → 40m ≈ 0.00036 deg
+    const near = { lat: destination.lat + 0.00036, lng: destination.lng };
+    expect(NEAR_STATION_RADIUS_M).toBe(50); // sanity — 변경 시 본 테스트 보정 필요
+    const initial = baseInputs({ onAutoClear, motionStationary: true, userLocation: near });
+    const { rerender } = withDateNow(T0, () =>
+      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
+    );
+    withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+      rerender({ ...initial, userLocation: { ...near, lat: near.lat + 0.00001 } });
+    });
+    expect(onAutoClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
@@ -84,6 +84,30 @@ function baseInputs(overrides: Partial<UseDestinationAutoClearInputs> = {}): Use
   };
 }
 
+/**
+ * 4단 setup (setArrival → onAutoClear → initial inputs → mountAtT0) 통합 helper.
+ * SonarCloud가 잡는 rerender 기반 테스트들의 중복 boilerplate 제거(arrival 코드/onAutoClear/initial inputs를
+ * 인자로 받아 같은 mount 시퀀스를 반환).
+ */
+function mountStationaryDetect(params: {
+  arvlCodes: number[];
+  inputOverrides?: Partial<UseDestinationAutoClearInputs>;
+}) {
+  setArrival(arrivalWithCodes(params.arvlCodes));
+  const onAutoClear = jest.fn();
+  const initial = baseInputs({
+    onAutoClear,
+    motionStationary: true,
+    ...params.inputOverrides,
+  });
+  const { rerender } = withDateNow(T0, () =>
+    renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
+      initialProps: initial,
+    }),
+  );
+  return { onAutoClear, initial, rerender };
+}
+
 describe('pickDestinationArvlCd', () => {
   it('arrival=null이면 null', () => {
     expect(pickDestinationArvlCd(null)).toBeNull();
@@ -153,12 +177,7 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('motionStationary 진입 후 60s 지나면 onAutoClear 1회 호출 + log', () => {
-    setArrival(arrivalWithCodes([1]));
-    const onAutoClear = jest.fn();
-    const initial = baseInputs({ onAutoClear, motionStationary: true });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({ arvlCodes: [1] });
     withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
       // userLocation을 미세 변경해 effect 재실행 트리거 (좌표 가까운 jitter).
       rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
@@ -170,14 +189,12 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('userLocation이 50m 밖이면 발사 안 함', () => {
-    setArrival(arrivalWithCodes([1]));
-    const onAutoClear = jest.fn();
     // 100m offset (1 deg lat ≈ 111km → 0.001 ≈ 111m → 안전하게 0.002)
     const far = { lat: destination.lat + 0.002, lng: destination.lng };
-    const initial = baseInputs({ onAutoClear, motionStationary: true, userLocation: far });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({
+      arvlCodes: [1],
+      inputOverrides: { userLocation: far },
+    });
     withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
       rerender({ ...initial, userLocation: { ...far, lat: far.lat + 0.00001 } });
     });
@@ -185,12 +202,7 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('motionStationary가 중간에 끊기면 카운터 리셋 → 60s 새로 대기', () => {
-    setArrival(arrivalWithCodes([1]));
-    const onAutoClear = jest.fn();
-    const initial = baseInputs({ onAutoClear, motionStationary: true });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({ arvlCodes: [1] });
     // 30s 경과 후 잠깐 walking
     withDateNow(T0 + STATIONARY_THRESHOLD_MS / 2, () => {
       rerender({ ...initial, motionStationary: false });
@@ -203,12 +215,7 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('한 trip에서 1회만 발사 — 같은 destination에서 후속 rerender는 no-op', () => {
-    setArrival(arrivalWithCodes([1]));
-    const onAutoClear = jest.fn();
-    const initial = baseInputs({ onAutoClear, motionStationary: true });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({ arvlCodes: [1] });
     withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
       rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
     });
@@ -221,12 +228,7 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('destination 변경 시 fired ref 리셋 — 새 destination도 1회 발사 가능', () => {
-    setArrival(arrivalWithCodes([1]));
-    const onAutoClear = jest.fn();
-    const initial = baseInputs({ onAutoClear, motionStationary: true });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({ arvlCodes: [1] });
     withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
       rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
     });
@@ -252,12 +254,7 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('destination null로 전환 시 stationary ref 리셋 — 같은 destination 재설정 시 새 카운트', () => {
-    setArrival(arrivalWithCodes([1]));
-    const onAutoClear = jest.fn();
-    const initial = baseInputs({ onAutoClear, motionStationary: true });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({ arvlCodes: [1] });
     // stationary 30s 누적 후 destination null로 전환
     withDateNow(T0 + STATIONARY_THRESHOLD_MS / 2, () => {
       rerender({ ...initial, destination: null });
@@ -274,12 +271,10 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('userLocation=null이면 detect 입력 불충분 → 발사 안 함', () => {
-    setArrival(arrivalWithCodes([1]));
-    const onAutoClear = jest.fn();
-    const initial = baseInputs({ onAutoClear, motionStationary: true, userLocation: null });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({
+      arvlCodes: [1],
+      inputOverrides: { userLocation: null },
+    });
     withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
       rerender({ ...initial });
     });
@@ -287,15 +282,13 @@ describe('useDestinationAutoClear', () => {
   });
 
   it('확인용 — NEAR_STATION_RADIUS_M(50m) 경계 직전이면 발사', () => {
-    setArrival(arrivalWithCodes([0])); // ENTERING도 통과
-    const onAutoClear = jest.fn();
     // ~40m 정도 — 100m 보수.  111000 m/deg lat → 40m ≈ 0.00036 deg
     const near = { lat: destination.lat + 0.00036, lng: destination.lng };
     expect(NEAR_STATION_RADIUS_M).toBe(50); // sanity — 변경 시 본 테스트 보정 필요
-    const initial = baseInputs({ onAutoClear, motionStationary: true, userLocation: near });
-    const { rerender } = withDateNow(T0, () =>
-      renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), { initialProps: initial }),
-    );
+    const { onAutoClear, initial, rerender } = mountStationaryDetect({
+      arvlCodes: [0], // ENTERING도 통과
+      inputOverrides: { userLocation: near },
+    });
     withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
       rerender({ ...initial, userLocation: { ...near, lat: near.lat + 0.00001 } });
     });

--- a/src/features/alarm/hooks/useDestinationAutoClear.ts
+++ b/src/features/alarm/hooks/useDestinationAutoClear.ts
@@ -1,0 +1,153 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 본 hook은 alarm 슬라이스의 detect 알고리즘에 arrival/nearest-station
+ * 슬라이스의 실시간 입력(arvlCd, userLocation, motionStationary)을 결합해 destination 자동 해제
+ * 액션(useDestinationStore)을 호출한다. orchestration이 본질이라 file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #925 C2 — destination 자동 하차 wire-up.
+ *
+ * PR #939에서 추가된 pure 알고리즘 `detectDestinationArrival`에 production 입력 신호를 묶어
+ * destination 자동 해제(`setDestination(null)`)를 호출하는 hook.
+ *
+ * 입력 (HomeScreen에서 그대로 전달):
+ *   - `destination`: useDestinationStore.destination
+ *   - `userLocation`: useFusedNearestStation.userLocation
+ *   - `motionStationary`: useMotionActivity() — CMMotionActivity stationary 신호
+ *   - `onAutoClear`: setDestination(null) wrapper (HomeScreen이 메모이즈)
+ *
+ * 내부:
+ *   - `useArrivalInfo(destination.name, destination.line)`로 destination 역 폴링 (useStationAlarm과
+ *     동일 호출 — 모듈 스코프 TtlCache가 dedup하므로 추가 비용 없음).
+ *   - up/down rows 중 가장 강한 arvlCd("ARRIVED" > "ENTERING")를 선택해 detect 입력으로 전달.
+ *   - motionStationary 전환 시점을 ref로 기록 → `stationaryDurationMs = now - stationaryStartedAt`.
+ *     motionStationary=false면 ref 리셋(다음 stationary 진입에서 새로 카운트).
+ *
+ * 트리거 idempotency:
+ *   - destinationId별 firedRef로 trip 1회 자동 해제 보장. destinationId 변경 시 ref 리셋 →
+ *     사용자가 다시 동일 destination을 설정하면 새 trip으로 간주.
+ *   - onAutoClear는 fire-and-forget — setDestination(null)이 storage cleanup까지 처리한다.
+ *
+ * useBoardingLockAutoRelease와의 책임 분리:
+ *   - useBoardingLockAutoRelease — lock 라이프사이클 정리(300m/45s, fusion distance 기반).
+ *   - 본 hook — destination 자체를 해제하는 UX 레벨 액션(50m/60s, GPS+motion 기반).
+ *   - 두 hook은 독립 (서로의 ref/storage 공유 없음). 자동 release가 lock만 풀고 destination이
+ *     남는 케이스(사용자가 명시 "하차" 안 누름 → lock release는 됐어도 LA가 destination에 묶여 있음)를
+ *     이 hook이 cover.
+ */
+import { useEffect, useRef } from 'react';
+import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
+import type { Station } from '../../../shared/types/station';
+import {
+  detectDestinationArrival,
+  type DestinationArrivalDetectInput,
+} from '../utils/destinationArrivalDetect';
+import { getArrivalPriority } from '../../../shared/constants/arrivalCodes';
+import { createLogger } from '../../../shared/utils/logger';
+import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
+
+const logger = createLogger('useDestinationAutoClear');
+
+export interface UseDestinationAutoClearInputs {
+  /** 현재 trip의 destination. null이면 hook은 no-op. */
+  destination: Station | null;
+  /** Fusion에서 결정된 사용자 좌표. null이면 거리 게이트 통과 불가 → detect=false. */
+  userLocation: { lat: number; lng: number } | null;
+  /** CMMotionActivity stationary 신호. 미지원/거절 케이스는 false로 전달되어 detect=false. */
+  motionStationary: boolean;
+  /** `setDestination(null)`을 호출하는 콜백. HomeScreen이 useCallback으로 메모이즈해 전달. */
+  onAutoClear: () => void;
+}
+
+/**
+ * up/down rows를 합쳐 destination 역에서의 가장 강한 arvlCd를 반환.
+ * ARRIVED(1) > ENTERING(0) > 그 외(우선순위 0) — 우선순위가 0이면 null 반환 (detect가 "이 역 신호 아님"으로 분류).
+ *
+ * 알고리즘이 ENTERING(0)을 통과시키지만 row가 없거나 모든 row가 DEPARTED/PREV_*면 null이 되어
+ * detect가 자동으로 'low' confidence 반환. 호출자는 단순히 함수 결과만 전달하면 됨.
+ */
+export function pickDestinationArvlCd(arrival: StationArrival | null): number | null {
+  if (!arrival) return null;
+  const trains: ArrivalInfo[] = [...arrival.up, ...arrival.down];
+  let bestCode: number | null = null;
+  let bestPriority = 0;
+  for (const t of trains) {
+    const p = getArrivalPriority(t.arrivalCode);
+    if (p > bestPriority) {
+      bestPriority = p;
+      bestCode = t.arrivalCode;
+    }
+  }
+  return bestCode;
+}
+
+export function useDestinationAutoClear({
+  destination,
+  userLocation,
+  motionStationary,
+  onAutoClear,
+}: UseDestinationAutoClearInputs): void {
+  // destination 폴링 — useStationAlarm의 동일 호출과 TtlCache dedup.
+  const { arrival: destinationArrival } = useArrivalInfo(
+    destination?.name ?? null,
+    destination?.line ?? null,
+  );
+
+  // motionStationary 진입 시점 — false면 null. detect 입력 stationaryDurationMs 계산용.
+  const stationaryStartedAtRef = useRef<number | null>(null);
+  // destinationId별 1회 발사 — 같은 trip에서 중복 호출 차단.
+  // destination 변경 시 리셋되어 사용자가 새 trip 시작 시 다시 동작 가능.
+  const firedForDestIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // destination 변경 시 fired ref 리셋. 동일 destination 재설정 trip은 새 1회.
+    const destId = destination?.id ?? null;
+    if (firedForDestIdRef.current !== null && firedForDestIdRef.current !== destId) {
+      firedForDestIdRef.current = null;
+    }
+
+    if (!destination) {
+      // destination 없으면 stationary ref도 의미 없음 — clean up.
+      stationaryStartedAtRef.current = null;
+      return;
+    }
+
+    const now = Date.now();
+    if (motionStationary) {
+      if (stationaryStartedAtRef.current === null) {
+        stationaryStartedAtRef.current = now;
+      }
+    } else {
+      stationaryStartedAtRef.current = null;
+    }
+
+    // 이미 발사한 trip이면 추가 평가 불필요 — onAutoClear 후속 setDestination(null)가
+    // 다음 cycle에서 deps를 클리어하지만, 같은 cycle 내 race 가드.
+    if (firedForDestIdRef.current === destId) return;
+
+    const stationaryDurationMs =
+      stationaryStartedAtRef.current === null ? null : now - stationaryStartedAtRef.current;
+
+    const input: DestinationArrivalDetectInput = {
+      destinationStation: destination,
+      arvlCdAtDestination: pickDestinationArvlCd(destinationArrival),
+      userLocation,
+      stationaryDurationMs,
+    };
+    const result = detectDestinationArrival(input);
+    if (result.shouldAutoClear) {
+      firedForDestIdRef.current = destId;
+      logger.info(
+        `destination=${destination.name} 자동 해제 (confidence=${result.confidence})`,
+      );
+      onAutoClear();
+    }
+  }, [
+    destination,
+    destinationArrival,
+    userLocation,
+    motionStationary,
+    onAutoClear,
+  ]);
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -45,6 +45,7 @@ import { useBoardingLockScheduler } from '../features/alarm/hooks/useBoardingLoc
 import { useTripBoundAlarmScheduler } from '../features/alarm/hooks/useTripBoundAlarmScheduler';
 import { useBoardingLockAdvancer } from '../features/alarm/hooks/useBoardingLockAdvancer';
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
+import { useDestinationAutoClear } from '../features/alarm/hooks/useDestinationAutoClear';
 import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
@@ -311,6 +312,19 @@ export default function HomeScreen() {
     distanceKm: result?.distanceKm ?? null,
     releaseLock: releaseBoardingLock,
     route,
+  });
+  // #925 (C2 wire) — destination 자동 하차 감지. arvlCd=0/1 + 역 50m 이내 + 60s motion stationary
+  // 4-신호 AND 게이트 통과 시 setDestination(null) 호출 → 후속 LA end / trip-end recall은
+  // useDestinationStore.setDestination(null)의 기존 cleanup 경로(triggerTripEndRecall, runTripBoundCleanups)에서 처리.
+  // useBoardingLockAutoRelease(lock 라이프사이클, 300m/45s)와는 임계값/책임이 달라 독립적으로 동작.
+  // 기존 arrival/useArrivalAutoClear(500m/2s, GPS 역명 매칭)와도 책임 분리:
+  //   - arrival/useArrivalAutoClear: 도착 banner UX + 빠른 2초 후 자동 클리어 (낙관적 단순 정책).
+  //   - 본 hook: motion=stationary + arvlCd 보강 → 사용자가 명시 "하차" 안 누른 케이스의 안전망.
+  useDestinationAutoClear({
+    destination,
+    userLocation,
+    motionStationary,
+    onAutoClear: handleArrivalClear,
   });
   // #584 PR D3: lock.boardingLine 위치 데이터를 별도 구독 — fusion 캐시와 dedup되어 추가 비용 없음.
   // lock 없으면 line=null로 호출되어 polling이 자동 정지된다.


### PR DESCRIPTION
Closes #925
Refs #912 (Epic), #939 (PR — pure 알고리즘)

## Summary
- Epic #912 / sub #925 (C2) **wire-up PR**. PR #939에서 추가한 pure 알고리즘 `detectDestinationArrival`에 production 입력 신호를 묶어 destination 자동 해제(`setDestination(null)`)를 호출하는 hook을 추가하고 HomeScreen에 wire.
- 새 hook 이름: `useDestinationAutoClear` (alarm 슬라이스). 기존 `arrival/useArrivalAutoClear`(GPS 역명 매칭 + 2초 배너 UX)와 책임/이름 분리.

## What changes
- `src/features/alarm/hooks/useDestinationAutoClear.ts` (신규):
  - 입력: `destination`, `userLocation`, `motionStationary`, `onAutoClear`
  - 내부: `useArrivalInfo(destination.name, destination.line)` 폴링 (TtlCache dedup), motion 진입 ts ref, destinationId별 fired ref
  - detect 통과 시 1회 `onAutoClear()` 호출 → `setDestination(null)`의 기존 cleanup 경로(`triggerTripEndRecall`, `runTripBoundCleanups`, LA end)가 후속 처리
- `src/screens/HomeScreen.tsx`:
  - `useDestinationAutoClear` import + `useBoardingLockAutoRelease` 직후 wiring (`handleArrivalClear` 콜백 재사용)

## Why
사용자가 destination 도착 후 명시 "하차" 액션을 안 누른 케이스에서 LA가 destination에 묶여 잔존하던 회귀(#925 본문). 4-신호 AND 게이트(arvlCd 0/1 + 역 50m 이내 + motion stationary 60s)로 conservative 자동 해제.

## Responsibility split (기존 hook과)
- `arrival/useArrivalAutoClear` (기존): 도착 banner UX + 2초 후 GPS 역명 매칭 자동 클리어 (낙관적, 빠름).
- `alarm/useBoardingLockAutoRelease`: lock 라이프사이클 정리 (300m/45s, fusion distance).
- **본 hook** (`alarm/useDestinationAutoClear`): 위 두 경로가 못 잡은 케이스의 안전망 (50m/60s, GPS+motion sensor fusion).

## Out of scope (issue 본문의 후속 항목)
- LA "도착" 명시 액션(취소 가능) UI — `modules/live-activity/` 네이티브 변경 필요
- 자동 해제 후 destination 빠른 재설정 UI

## Test plan
- [x] `npx jest src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts --coverage` → 18/18 pass, 100% lines/branches/funcs/statements
- [x] `npm test` 전체 → 218 suites / 3928 tests pass, 100% 커버리지 유지
- [x] `npm run type-check` clean
- [x] `npx eslint` 본 PR 변경 파일 clean (기존 dev 3건 lint error는 본 PR 무관)
- [ ] CI `Type Check & Test` 통과 확인 후 머지 (사용자 결정)
- [ ] 실기기 회귀 검증: destination 설정 후 도착 + 도보 시 1분 내 LA 자동 end