### PR TITLE
feat(#919): backend metrics catalog + 집계 wiring

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -750,27 +750,24 @@ describe('POST /trips — #705 progress KV preserves advance across POST race', 
   });
 });
 
-describe('POST /telemetry/silent-push', () => {
-  const validBody = {
-    token: 'aabbccdd11223344',
-    since: 0,
-    until: 1000,
-    received: 3,
-    fired: 2,
-    skipped: 1,
-    skipReasons: { 'gate-out-of-range': 1 },
-  };
-
+/**
+ * 4 tests 공통 패턴 — TELEMETRY 적재형 POST endpoint(/telemetry/silent-push,
+ * /metrics/boarding-prompt, /telemetry/recall)는 모두 (1) invalid JSON 400,
+ * (2) invalid payload 400, (3) writer 있을 때 적재, (4) writer 없을 때 graceful
+ * 200을 보장해야 한다. Sonar `new_duplicated_lines_density` 임계(3%)에 걸리지 않도록
+ * helper로 통합 (#919 sonar fix).
+ */
+function runTelemetryEndpointSuite(path: string, validBody: Record<string, unknown>): void {
   it('returns 400 on invalid JSON', async () => {
     const env = makeEnv();
-    const res = await post('/telemetry/silent-push', 'not-json{', env);
+    const res = await post(path, 'not-json{', env);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_json' });
   });
 
   it('returns 400 on invalid payload', async () => {
     const env = makeEnv();
-    const res = await post('/telemetry/silent-push', { token: '' }, env);
+    const res = await post(path, { token: '' }, env);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_payload' });
   });
@@ -778,7 +775,7 @@ describe('POST /telemetry/silent-push', () => {
   it('writes to TELEMETRY binding when present', async () => {
     const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
     const env = makeEnv({ TELEMETRY: writer });
-    const res = await post('/telemetry/silent-push', validBody, env);
+    const res = await post(path, validBody, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
     expect(writer.writeDataPoint).toHaveBeenCalled();
@@ -786,9 +783,21 @@ describe('POST /telemetry/silent-push', () => {
 
   it('still returns ok when TELEMETRY binding absent (graceful)', async () => {
     const env = makeEnv();
-    const res = await post('/telemetry/silent-push', validBody, env);
+    const res = await post(path, validBody, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
+  });
+}
+
+describe('POST /telemetry/silent-push', () => {
+  runTelemetryEndpointSuite('/telemetry/silent-push', {
+    token: 'aabbccdd11223344',
+    since: 0,
+    until: 1000,
+    received: 3,
+    fired: 2,
+    skipped: 1,
+    skipReasons: { 'gate-out-of-range': 1 },
   });
 });
 
@@ -1367,41 +1376,14 @@ describe('POST /boarding-prompt/dismiss (#819)', () => {
 });
 
 describe('POST /metrics/boarding-prompt (#827)', () => {
-  const validBody = { token: 'aabbccdd11223344', outcome: 'dismissed' as const };
-
-  it('returns 400 on invalid JSON', async () => {
-    const env = makeEnv();
-    const res = await post('/metrics/boarding-prompt', 'not-json{', env);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_json' });
-  });
-
-  it('returns 400 on invalid payload', async () => {
-    const env = makeEnv();
-    const res = await post('/metrics/boarding-prompt', { token: '' }, env);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_payload' });
-  });
-
-  it('writes to TELEMETRY binding when present', async () => {
-    const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
-    const env = makeEnv({ TELEMETRY: writer });
-    const res = await post('/metrics/boarding-prompt', validBody, env);
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
-    expect(writer.writeDataPoint).toHaveBeenCalled();
-  });
-
-  it('still returns ok when TELEMETRY binding absent', async () => {
-    const env = makeEnv();
-    const res = await post('/metrics/boarding-prompt', validBody, env);
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
+  runTelemetryEndpointSuite('/metrics/boarding-prompt', {
+    token: 'aabbccdd11223344',
+    outcome: 'dismissed',
   });
 });
 
 describe('POST /telemetry/recall (#919)', () => {
-  const validBody = {
+  runTelemetryEndpointSuite('/telemetry/recall', {
     token: 'aabbccdd11223344',
     tripStart: 1_000,
     tripEnd: 2_000,
@@ -1409,36 +1391,6 @@ describe('POST /telemetry/recall (#919)', () => {
     firedStops: 4,
     recallPct: 80,
     gateSuppressionCounts: { 'gate-accuracy': 1 },
-  };
-
-  it('returns 400 on invalid JSON', async () => {
-    const env = makeEnv();
-    const res = await post('/telemetry/recall', 'not-json{', env);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_json' });
-  });
-
-  it('returns 400 on invalid payload', async () => {
-    const env = makeEnv();
-    const res = await post('/telemetry/recall', { token: '' }, env);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_payload' });
-  });
-
-  it('writes to TELEMETRY binding when present', async () => {
-    const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
-    const env = makeEnv({ TELEMETRY: writer });
-    const res = await post('/telemetry/recall', validBody, env);
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
-    expect(writer.writeDataPoint).toHaveBeenCalled();
-  });
-
-  it('still returns ok when TELEMETRY binding absent (graceful)', async () => {
-    const env = makeEnv();
-    const res = await post('/telemetry/recall', validBody, env);
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1400,6 +1400,48 @@ describe('POST /metrics/boarding-prompt (#827)', () => {
   });
 });
 
+describe('POST /telemetry/recall (#919)', () => {
+  const validBody = {
+    token: 'aabbccdd11223344',
+    tripStart: 1_000,
+    tripEnd: 2_000,
+    expectedStops: 5,
+    firedStops: 4,
+    recallPct: 80,
+    gateSuppressionCounts: { 'gate-accuracy': 1 },
+  };
+
+  it('returns 400 on invalid JSON', async () => {
+    const env = makeEnv();
+    const res = await post('/telemetry/recall', 'not-json{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const env = makeEnv();
+    const res = await post('/telemetry/recall', { token: '' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('writes to TELEMETRY binding when present', async () => {
+    const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
+    const env = makeEnv({ TELEMETRY: writer });
+    const res = await post('/telemetry/recall', validBody, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(writer.writeDataPoint).toHaveBeenCalled();
+  });
+
+  it('still returns ok when TELEMETRY binding absent (graceful)', async () => {
+    const env = makeEnv();
+    const res = await post('/telemetry/recall', validBody, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});
+
 describe('validateTrip — #819 promptGeoContext / promptDisplay', () => {
   function withPrompt(overrides: Record<string, unknown>): Record<string, unknown> {
     return { ...base(), ...overrides };

--- a/backend/alarm-worker/src/__tests__/recallTelemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/recallTelemetry.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  KNOWN_GATE_REASONS,
+  RECALL_DISTRIBUTION_LABEL_PREFIX,
+  recordRecallUpload,
+  validateRecallUpload,
+  type RecallUpload,
+} from '../recallTelemetry';
+import { METRIC_KIND, MIN_RECALL_RATIO_THRESHOLD } from '../metrics';
+
+function base(): Record<string, unknown> {
+  return {
+    token: 'aabbccdd11223344',
+    tripStart: 1_000,
+    tripEnd: 2_000,
+    expectedStops: 5,
+    firedStops: 4,
+    recallPct: 80,
+    gateSuppressionCounts: {
+      'gate-accuracy': 1,
+      'movement-static-position': 2,
+    },
+  };
+}
+
+describe('validateRecallUpload', () => {
+  it('accepts a valid payload', () => {
+    const result = validateRecallUpload(base());
+    expect(result).not.toBeNull();
+    expect(result?.expectedStops).toBe(5);
+    expect(result?.firedStops).toBe(4);
+    expect(result?.gateSuppressionCounts['gate-accuracy']).toBe(1);
+    expect(result?.gateSuppressionCounts['movement-static-position']).toBe(2);
+  });
+
+  it('rejects non-object', () => {
+    expect(validateRecallUpload(null)).toBeNull();
+    expect(validateRecallUpload('x')).toBeNull();
+  });
+
+  it('rejects missing/empty token', () => {
+    expect(validateRecallUpload({ ...base(), token: '' })).toBeNull();
+    const noToken = base();
+    delete noToken.token;
+    expect(validateRecallUpload(noToken)).toBeNull();
+  });
+
+  it.each([
+    ['tripStart', NaN],
+    ['tripStart', 'x'],
+    ['tripEnd', NaN],
+    ['tripEnd', 'x'],
+  ])('rejects non-finite %s (%p)', (field, value) => {
+    expect(validateRecallUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects tripEnd < tripStart', () => {
+    expect(
+      validateRecallUpload({ ...base(), tripStart: 2_000, tripEnd: 1_000 }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['expectedStops', -1],
+    ['expectedStops', 1.5],
+    ['expectedStops', NaN],
+    ['expectedStops', 'x'],
+    ['firedStops', -1],
+    ['firedStops', 1.5],
+  ])('rejects non-natural %s (%p)', (field, value) => {
+    expect(validateRecallUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects firedStops > expectedStops', () => {
+    expect(
+      validateRecallUpload({ ...base(), expectedStops: 2, firedStops: 3 }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['recallPct', -1],
+    ['recallPct', 101],
+    ['recallPct', 50.5],
+    ['recallPct', NaN],
+  ])('rejects out-of-range %s (%p)', (field, value) => {
+    expect(validateRecallUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects missing or non-object gateSuppressionCounts', () => {
+    const missing = base();
+    delete missing.gateSuppressionCounts;
+    expect(validateRecallUpload(missing)).toBeNull();
+    expect(validateRecallUpload({ ...base(), gateSuppressionCounts: 'x' })).toBeNull();
+    expect(validateRecallUpload({ ...base(), gateSuppressionCounts: null })).toBeNull();
+  });
+
+  it('rejects invalid gateSuppressionCounts value', () => {
+    expect(
+      validateRecallUpload({ ...base(), gateSuppressionCounts: { 'gate-accuracy': -1 } }),
+    ).toBeNull();
+    expect(
+      validateRecallUpload({ ...base(), gateSuppressionCounts: { 'gate-accuracy': 1.5 } }),
+    ).toBeNull();
+  });
+
+  it('drops unknown reason keys silently', () => {
+    const result = validateRecallUpload({
+      ...base(),
+      gateSuppressionCounts: { 'gate-accuracy': 1, 'unknown-reason': 99 },
+    });
+    expect(result?.gateSuppressionCounts['gate-accuracy']).toBe(1);
+    expect(
+      (result?.gateSuppressionCounts as Record<string, unknown>)['unknown-reason'],
+    ).toBeUndefined();
+  });
+
+  it('preserves empty gateSuppressionCounts', () => {
+    const result = validateRecallUpload({ ...base(), gateSuppressionCounts: {} });
+    expect(result?.gateSuppressionCounts).toEqual({});
+  });
+
+  it('accepts expectedStops=0 firedStops=0 (corner case — recall=100)', () => {
+    const result = validateRecallUpload({
+      ...base(),
+      expectedStops: 0,
+      firedStops: 0,
+      recallPct: 100,
+    });
+    expect(result?.expectedStops).toBe(0);
+    expect(result?.firedStops).toBe(0);
+  });
+});
+
+describe('recordRecallUpload', () => {
+  function makeWriter() {
+    return { writeDataPoint: vi.fn() };
+  }
+
+  const payload: RecallUpload = {
+    token: 'aabbccdd11223344',
+    tripStart: 0,
+    tripEnd: 1,
+    expectedStops: 10,
+    firedStops: 8,
+    recallPct: 80,
+    gateSuppressionCounts: {
+      'gate-accuracy': 1,
+      'movement-static-position': 1,
+    },
+  };
+
+  it('writes perStationAlarmRecall hit+total + one point per non-zero reason', () => {
+    const writer = makeWriter();
+    recordRecallUpload(writer, payload);
+    // rate metric: hit + total = 2 points (firedStops=8, expectedStops=10 — both >0)
+    // distribution: 2 reasons with count > 0 = 2 points
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(4);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain(`phase3:${METRIC_KIND.PER_STATION_ALARM_RECALL}:hit`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.PER_STATION_ALARM_RECALL}:total`);
+    expect(labels).toContain(`${RECALL_DISTRIBUTION_LABEL_PREFIX}:gate-accuracy`);
+    expect(labels).toContain(`${RECALL_DISTRIBUTION_LABEL_PREFIX}:movement-static-position`);
+  });
+
+  it('skips zero count reasons (only writes rate points)', () => {
+    const writer = makeWriter();
+    recordRecallUpload(writer, {
+      ...payload,
+      gateSuppressionCounts: {},
+    });
+    // only rate hit+total
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips zero firedStops in rate (still writes total)', () => {
+    const writer = makeWriter();
+    recordRecallUpload(writer, {
+      ...payload,
+      firedStops: 0,
+      gateSuppressionCounts: {},
+    });
+    // 0 hit skipped, total still written
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(1);
+    const first = writer.writeDataPoint.mock.calls[0][0];
+    expect(first.blobs[0]).toBe(`phase3:${METRIC_KIND.PER_STATION_ALARM_RECALL}:total`);
+  });
+
+  it('writes nothing when both rate and counts are zero', () => {
+    const writer = makeWriter();
+    recordRecallUpload(writer, {
+      ...payload,
+      expectedStops: 0,
+      firedStops: 0,
+      gateSuppressionCounts: {},
+    });
+    expect(writer.writeDataPoint).not.toHaveBeenCalled();
+  });
+
+  it('uses 8-char token prefix in blobs/indexes', () => {
+    const writer = makeWriter();
+    recordRecallUpload(writer, payload);
+    const distributionCall = writer.writeDataPoint.mock.calls.find((c) =>
+      (c[0].blobs[0] as string).startsWith(RECALL_DISTRIBUTION_LABEL_PREFIX),
+    );
+    expect(distributionCall).toBeDefined();
+    const point = distributionCall![0];
+    expect(point.blobs[1]).toBe('aabbccdd');
+    expect(point.indexes[0]).toBe('aabbccdd');
+    expect(point.doubles[0]).toBeGreaterThan(0);
+  });
+});
+
+describe('catalog + reason SSOT', () => {
+  it('exposes MIN_RECALL_RATIO_THRESHOLD via metrics module', () => {
+    expect(MIN_RECALL_RATIO_THRESHOLD).toBe(0.95);
+  });
+
+  it('exposes perStationAlarmRecall + gateSuppressionDistribution METRIC_KIND', () => {
+    expect(METRIC_KIND.PER_STATION_ALARM_RECALL).toBe('perStationAlarmRecall');
+    expect(METRIC_KIND.GATE_SUPPRESSION_DISTRIBUTION).toBe('gateSuppressionDistribution');
+  });
+
+  it('KNOWN_GATE_REASONS excludes dedup-station / dedup-alarm (정상 동작)', () => {
+    // dedup은 *이미 발화된* 알람의 재발화 차단이라 게이트 분포에 포함되면 신호 오염.
+    // client GATE_SUPPRESSION_REASONS와 양방향 SSOT — 같은 정책.
+    const reasons = new Set<string>(KNOWN_GATE_REASONS);
+    expect(reasons.has('dedup-station')).toBe(false);
+    expect(reasons.has('dedup-alarm')).toBe(false);
+  });
+
+  it('KNOWN_GATE_REASONS covers core gates (accuracy/movement/silence/lock)', () => {
+    const reasons = new Set<string>(KNOWN_GATE_REASONS);
+    expect(reasons.has('gate-accuracy')).toBe(true);
+    expect(reasons.has('movement-static-position')).toBe(true);
+    expect(reasons.has('dismiss-silence')).toBe(true);
+    expect(reasons.has('lock-line-mismatch')).toBe(true);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/recallTelemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/recallTelemetry.test.ts
@@ -46,9 +46,9 @@ describe('validateRecallUpload', () => {
   });
 
   it.each([
-    ['tripStart', NaN],
+    ['tripStart', Number.NaN],
     ['tripStart', 'x'],
-    ['tripEnd', NaN],
+    ['tripEnd', Number.NaN],
     ['tripEnd', 'x'],
   ])('rejects non-finite %s (%p)', (field, value) => {
     expect(validateRecallUpload({ ...base(), [field]: value })).toBeNull();
@@ -63,7 +63,7 @@ describe('validateRecallUpload', () => {
   it.each([
     ['expectedStops', -1],
     ['expectedStops', 1.5],
-    ['expectedStops', NaN],
+    ['expectedStops', Number.NaN],
     ['expectedStops', 'x'],
     ['firedStops', -1],
     ['firedStops', 1.5],
@@ -81,7 +81,7 @@ describe('validateRecallUpload', () => {
     ['recallPct', -1],
     ['recallPct', 101],
     ['recallPct', 50.5],
-    ['recallPct', NaN],
+    ['recallPct', Number.NaN],
   ])('rejects out-of-range %s (%p)', (field, value) => {
     expect(validateRecallUpload({ ...base(), [field]: value })).toBeNull();
   });
@@ -131,11 +131,11 @@ describe('validateRecallUpload', () => {
   });
 });
 
-describe('recordRecallUpload', () => {
-  function makeWriter() {
-    return { writeDataPoint: vi.fn() };
-  }
+function makeWriter() {
+  return { writeDataPoint: vi.fn() };
+}
 
+describe('recordRecallUpload', () => {
   const payload: RecallUpload = {
     token: 'aabbccdd11223344',
     tripStart: 0,

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -30,6 +30,10 @@ import { deleteProgress, getProgress, putProgress, type TripProgress } from './p
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
 import {
+  recordRecallUpload,
+  validateRecallUpload,
+} from './recallTelemetry';
+import {
   tokenPrefix,
   validateTelemetryUpload,
   writeTelemetryDataPoints,
@@ -190,6 +194,44 @@ app.post('/telemetry/silent-push', async (c) => {
       received: payload.received,
       fired: payload.fired,
       skipped: payload.skipped,
+      sink: writer ? 'ae' : 'none',
+    }),
+  );
+  return c.json({ ok: true });
+});
+
+/**
+ * 매역 알림 recall KPI upload (#919, Epic #912 A4).
+ *
+ * Trip 1건 종료 시 client(`alarmLogTelemetry.computeAndUploadTripRecall`)가 산출한 recall %와
+ * 게이트별 차단 분포를 Analytics Engine에 적재한다. 클라가 idempotency 가드를 가지므로 같은
+ * tripStart 재호출은 안 옴 — backend는 단순 적재.
+ *
+ * Trip 존재 여부 확인 안 함 — trip이 이미 만료된 경우에도 telemetry는 보존(데이터 완전성).
+ * TELEMETRY binding 미설정 시 graceful no-op (개발 환경 호환, `/telemetry/silent-push`와 동형).
+ */
+app.post('/telemetry/recall', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateRecallUpload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const writer = c.env.TELEMETRY;
+  if (writer) {
+    recordRecallUpload(writer, payload);
+  }
+  console.log(
+    JSON.stringify({
+      msg: 'recall uploaded',
+      tokenPrefix: tokenPrefix(payload.token),
+      expectedStops: payload.expectedStops,
+      firedStops: payload.firedStops,
+      recallPct: payload.recallPct,
       sink: writer ? 'ae' : 'none',
     }),
   );

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -6,7 +6,8 @@
     "FALSE_POSITIVE_RATIO_THRESHOLD": 0.05,
     "MIN_SAMPLE_FOR_DECISION": 30,
     "SLA_PERCENTILE": 0.95,
-    "METRIC_LABEL_PREFIX": "phase3"
+    "METRIC_LABEL_PREFIX": "phase3",
+    "MIN_RECALL_RATIO_THRESHOLD": 0.95
   },
   "metrics": [
     {
@@ -97,6 +98,20 @@
       "format": "rate",
       "display": "percentage",
       "description": "#917 A2 — prereq 게이트(lock 활성 + arvlCd∈{0,1}) 실패로 매역 push 미발사된 비율 — #640 회귀 방어 신호"
+    },
+    {
+      "key": "perStationAlarmRecall",
+      "constantName": "PER_STATION_ALARM_RECALL",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#919 A4 — trip 종료 시 route 정차역 대비 실제 발사된 매역 알림 비율. hit=firedStops, total=expectedStops. MIN_RECALL_RATIO_THRESHOLD(0.95) 미달 trip 비율로 운영 alert 발사 (Phase 4 결정 게이트 아님 — 운영 KPI)."
+    },
+    {
+      "key": "gateSuppressionDistribution",
+      "constantName": "GATE_SUPPRESSION_DISTRIBUTION",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#919 A4 — recall < 100% trip에서 매역 알림을 차단한 게이트(accuracy/motion/silence/lockMissing/...) 분포. 차단 reason은 별도 blob label로 적재(reason 카탈로그는 recallTelemetry.ts:KNOWN_GATE_REASONS와 client recallMetrics.ts:GATE_SUPPRESSION_REASONS의 양방향 SSOT)."
     }
   ]
 }

--- a/backend/alarm-worker/src/metrics.ts
+++ b/backend/alarm-worker/src/metrics.ts
@@ -83,6 +83,13 @@ export const MIN_SAMPLE_FOR_DECISION = readNumber('MIN_SAMPLE_FOR_DECISION');
 /** 히스토그램 메트릭의 SLA 평가용 백분위수. 0.95 = 95p. */
 export const SLA_PERCENTILE = readNumber('SLA_PERCENTILE');
 
+/**
+ * #919 A4 — 매역 알림 recall 운영 KPI 하한 비율. 본 비율 미만 trip이 alert 임계.
+ * Phase 4 결정 게이트(`decidePhaseFour`)와 분리된 운영 회귀 감시용 — 본 PR은 SSOT 노출만 하고
+ * 실제 alert 배선은 후속 PR (Slack webhook / cron summary)에서 처리.
+ */
+export const MIN_RECALL_RATIO_THRESHOLD = readNumber('MIN_RECALL_RATIO_THRESHOLD');
+
 /** AE 적재 label prefix — 기존 silent-push 텔레메트리와 namespace 분리. */
 const METRIC_LABEL_PREFIX = readString('METRIC_LABEL_PREFIX');
 

--- a/backend/alarm-worker/src/recallTelemetry.ts
+++ b/backend/alarm-worker/src/recallTelemetry.ts
@@ -89,6 +89,25 @@ function isFiniteNumber(v: unknown): v is number {
 }
 
 /**
+ * `gateSuppressionCounts` 객체에서 알려진 reason만 자연수로 보존한다.
+ *   - 객체 아니면 null
+ *   - 알려진 reason 값이 자연수 아니면 null (전체 payload reject)
+ *   - 미지 reason은 silently drop (구/신 클라이언트 호환)
+ */
+function parseGateCounts(raw: unknown): Partial<Record<KnownGateReason, number>> | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const counts: Partial<Record<KnownGateReason, number>> = {};
+  for (const reason of KNOWN_GATE_REASONS) {
+    const v = obj[reason];
+    if (v === undefined) continue;
+    if (!isNonNegativeInt(v)) return null;
+    counts[reason] = v;
+  }
+  return counts;
+}
+
+/**
  * payload 검증. 한 필드라도 깨졌으면 null — 호출자는 400 반환.
  *
  * 규칙:
@@ -109,18 +128,9 @@ export function validateRecallUpload(input: unknown): RecallUpload | null {
   if (!isNonNegativeInt(obj.expectedStops)) return null;
   if (!isNonNegativeInt(obj.firedStops)) return null;
   if (obj.firedStops > obj.expectedStops) return null;
-  if (!isNonNegativeInt(obj.recallPct)) return null;
-  if (obj.recallPct > 100) return null;
-  if (!obj.gateSuppressionCounts || typeof obj.gateSuppressionCounts !== 'object') return null;
-
-  const raw = obj.gateSuppressionCounts as Record<string, unknown>;
-  const counts: Partial<Record<KnownGateReason, number>> = {};
-  for (const reason of KNOWN_GATE_REASONS) {
-    const v = raw[reason];
-    if (v === undefined) continue;
-    if (!isNonNegativeInt(v)) return null;
-    counts[reason] = v;
-  }
+  if (!isNonNegativeInt(obj.recallPct) || obj.recallPct > 100) return null;
+  const counts = parseGateCounts(obj.gateSuppressionCounts);
+  if (counts === null) return null;
 
   return {
     token: obj.token,

--- a/backend/alarm-worker/src/recallTelemetry.ts
+++ b/backend/alarm-worker/src/recallTelemetry.ts
@@ -1,0 +1,170 @@
+/**
+ * 매역 알림 recall KPI telemetry (#919, Epic #912 A4).
+ *
+ * Trip 1건 종료 시 클라(`src/features/alarm/utils/recallMetrics.ts`)가 산출한 recall 결과를
+ * Cloudflare Analytics Engine에 적재한다.
+ *
+ *   perStationAlarmRecall            : RateMetric (hit=firedStops, total=expectedStops)
+ *                                       — 분자/분모 누적 → 일별/주별 recall % aggregate.
+ *   gateSuppressionDistribution      : reason별 count 분해 (recall<100% trip 원인 자동 분류)
+ *                                       — blob 라벨 `phase3:gateSuppressionDistribution:reason:<reason>`
+ *
+ * 운영 KPI: `MIN_RECALL_RATIO_THRESHOLD`(0.95) 미달 trip 비율이 대시보드에서 가시화된다.
+ * Phase 4 결정 게이트와 분리 — 본 메트릭은 운영 회귀 감시용이라 `decidePhaseFour`에 포함하지 않는다.
+ *
+ * Privacy: 좌표/시각/원문 미적재. 카운트만. token은 8자 prefix만 익명 aggregate에 사용.
+ *
+ * Reason vocabulary는 client `recallMetrics.ts:GATE_SUPPRESSION_REASONS`의 양방향 SSOT —
+ * client/backend 어느 쪽이 새 reason을 추가해도 반대편이 graceful drop(알 수 없는 reason은
+ * dashboard에 노출 안 됨)한다. 정합은 PR review 시점에 갱신 책임.
+ */
+
+import { METRIC_KIND, writeMetricDataPoints, type RateMetric } from './metrics';
+import { tokenPrefix } from './telemetry';
+import type { AnalyticsEngineWriter } from './types';
+
+/**
+ * client `recallMetrics.ts:GATE_SUPPRESSION_REASONS`와 양방향 SSOT.
+ * 본 배열에 없는 reason은 validate 단계에서 silently drop — 구버전 client / 신버전 client 호환.
+ *
+ * 새 reason 추가 절차:
+ *   1) client `alarmLog.ts:AlarmLogReason`에 union 추가
+ *   2) client `recallMetrics.ts:GATE_SUPPRESSION_REASONS`에 등록
+ *   3) backend 본 배열에 등록 (이 PR에서 동시에 처리하는 게 안전)
+ */
+export const KNOWN_GATE_REASONS = [
+  'gate-age',
+  'gate-accuracy',
+  'gate-jump',
+  'gate-unknown-station',
+  'gate-no-location',
+  'gate-stale-location',
+  'gate-out-of-range',
+  'lock-line-mismatch',
+  'payload-missing-kind',
+  'movement-no-location',
+  'movement-stale-timestamp',
+  'movement-low-accuracy',
+  'movement-static-speed',
+  'movement-static-position',
+  'movement-motion-stationary',
+  'sleep-first-transfer',
+  'lockless-non-intermediate',
+  'lockless-opt-out',
+  'dismiss-silence',
+] as const;
+
+export type KnownGateReason = (typeof KNOWN_GATE_REASONS)[number];
+
+/** 운영 KPI: 본 비율 미만 trip이 alert 임계. catalog SSOT에서 노출. */
+export const RECALL_DISTRIBUTION_LABEL_PREFIX = `${METRIC_KIND.GATE_SUPPRESSION_DISTRIBUTION}:reason`;
+
+/**
+ * client → backend upload payload.
+ *   client `uploadRecallTelemetry`(api/telemetryBackend.ts)와 동일 schema.
+ */
+export interface RecallUpload {
+  /** APNs device token (hex). 8자 prefix만 anonymous aggregate. */
+  token: string;
+  /** trip 시작 epoch ms. */
+  tripStart: number;
+  /** trip 종료 epoch ms. tripStart <= tripEnd 강제. */
+  tripEnd: number;
+  /** route 정차역 총 개수 (분모). */
+  expectedStops: number;
+  /** route 와 교집합인 fired 역 개수 (분자, 중복 제거). */
+  firedStops: number;
+  /** 0~100 정수. client에서 산출된 값 (서버 재계산 X — 표시용). */
+  recallPct: number;
+  /** 게이트별 차단 count. 알려진 reason만 보존. */
+  gateSuppressionCounts: Partial<Record<KnownGateReason, number>>;
+}
+
+function isNonNegativeInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v) && v >= 0;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+/**
+ * payload 검증. 한 필드라도 깨졌으면 null — 호출자는 400 반환.
+ *
+ * 규칙:
+ *   - token 비어있으면 reject
+ *   - tripStart/tripEnd는 유한수 + tripStart <= tripEnd
+ *   - expectedStops/firedStops는 자연수 (0 허용 — 동행 trip 가짜 신호는 isEmpty 가드가 client에 있음)
+ *   - firedStops <= expectedStops
+ *   - recallPct는 [0, 100] 정수
+ *   - gateSuppressionCounts는 객체, 알려진 reason은 자연수만 보존, 미지 reason은 silently drop
+ */
+export function validateRecallUpload(input: unknown): RecallUpload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (!isFiniteNumber(obj.tripStart)) return null;
+  if (!isFiniteNumber(obj.tripEnd)) return null;
+  if (obj.tripEnd < obj.tripStart) return null;
+  if (!isNonNegativeInt(obj.expectedStops)) return null;
+  if (!isNonNegativeInt(obj.firedStops)) return null;
+  if (obj.firedStops > obj.expectedStops) return null;
+  if (!isNonNegativeInt(obj.recallPct)) return null;
+  if (obj.recallPct > 100) return null;
+  if (!obj.gateSuppressionCounts || typeof obj.gateSuppressionCounts !== 'object') return null;
+
+  const raw = obj.gateSuppressionCounts as Record<string, unknown>;
+  const counts: Partial<Record<KnownGateReason, number>> = {};
+  for (const reason of KNOWN_GATE_REASONS) {
+    const v = raw[reason];
+    if (v === undefined) continue;
+    if (!isNonNegativeInt(v)) return null;
+    counts[reason] = v;
+  }
+
+  return {
+    token: obj.token,
+    tripStart: obj.tripStart,
+    tripEnd: obj.tripEnd,
+    expectedStops: obj.expectedStops,
+    firedStops: obj.firedStops,
+    recallPct: obj.recallPct,
+    gateSuppressionCounts: counts,
+  };
+}
+
+/**
+ * recall 1건을 AE에 적재.
+ *
+ *  1) `perStationAlarmRecall` rate metric — `writeMetricDataPoints` 통해
+ *     `phase3:perStationAlarmRecall:hit` / `:total` 두 data point.
+ *  2) `gateSuppressionDistribution` — 0보다 큰 reason 마다 data point 1건
+ *     (label = `phase3:gateSuppressionDistribution:reason:<reason>`).
+ *     Dashboard는 reason 별 sum으로 stacked bar 렌더.
+ *
+ * expectedStops=0 trip은 client가 `isEmptyRecall` 가드로 skip하므로 보통 도달하지 않지만,
+ * 다른 client 버전이 보낼 가능성을 고려해 rate point는 graceful — 0값은 `writeMetricDataPoints`
+ * 내부에서 skip된다.
+ */
+export function recordRecallUpload(
+  writer: AnalyticsEngineWriter,
+  payload: RecallUpload,
+): void {
+  const rate: RateMetric = {
+    kind: METRIC_KIND.PER_STATION_ALARM_RECALL,
+    hit: payload.firedStops,
+    total: payload.expectedStops,
+  };
+  writeMetricDataPoints(writer, payload.token, rate);
+
+  const prefix = tokenPrefix(payload.token);
+  for (const reason of KNOWN_GATE_REASONS) {
+    const count = payload.gateSuppressionCounts[reason] ?? 0;
+    if (count <= 0) continue;
+    writer.writeDataPoint({
+      blobs: [`${RECALL_DISTRIBUTION_LABEL_PREFIX}:${reason}`, prefix],
+      doubles: [count],
+      indexes: [prefix],
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Epic #912 P1 A4 후속 PR. #929(client recall 계산) + #940(trip-end trigger wire)에 이어 **backend metrics 카탈로그 + Cloudflare Analytics Engine 집계 wiring**.

### 신규 KPI (metrics.catalog.json)
- `perStationAlarmRecall` (rate, %) — `hit=firedStops`, `total=expectedStops`. 일별/주별 누적 → recall % aggregate.
- `gateSuppressionDistribution` (rate, %) — recall<100% trip의 차단 게이트 reason 분포 (accuracy/motion/silence/lockMissing/...). dashboard stacked bar용.

### 운영 KPI 임계
- `MIN_RECALL_RATIO_THRESHOLD = 0.95` (catalog constant + `metrics.ts` export). **Phase 4 결정 게이트와 분리** — 본 메트릭은 운영 회귀 감시용이라 `decidePhaseFour`에 포함하지 않음. 95% 미만 trip 비율 Slack alert 배선은 후속 PR.

### Storage 선택 (Cloudflare Analytics Engine)
기존 `/telemetry/silent-push` (#498) + `/metrics/boarding-prompt` (#827)가 이미 동일 패턴 사용. `writeMetricDataPoints` (metrics.ts)로 RateMetric 적재 + 분포는 reason별 data point. TELEMETRY binding 미설정 시 graceful no-op (개발 환경 호환).

### Schema
```
blob1 = phase3:perStationAlarmRecall:hit|total
blob1 = phase3:gateSuppressionDistribution:reason:<reason>
blob2 = token prefix (8자)
double1 = count
index1 = token prefix
```

### Reason vocabulary SSOT
`backend/recallTelemetry.ts:KNOWN_GATE_REASONS` ↔ `client/recallMetrics.ts:GATE_SUPPRESSION_REASONS` 양방향 SSOT. 어느 쪽이 새 reason 추가해도 반대편 graceful drop, PR review 시점에 갱신 책임.

## Test plan
- [x] `cd backend/alarm-worker && npm test` — vitest 843 passed (24 files), 신규 recallTelemetry.test.ts 33 케이스
- [x] `npm test` (frontend) — jest 3910 passed, 100% coverage
- [x] `npm run type-check` — frontend pass
- [x] catalog SSOT 회귀: `perf-report.js`/`metrics.ts`가 동적 로드라 신규 entry 자동 반영

## 슬라이싱 의도 (Refs #919 — 마지막 슬라이스)
완료: client recall 계산 (#929) → trip-end wire (#940) → **backend catalog + AE wiring (본 PR)**
후속 (별도 이슈 candidate): Slack alert 배선 (recall<95% trip cron summary), Cloudflare dashboard 쿼리 템플릿 publish

Closes #919
Refs #912