### PR TITLE
fix(#916): fired+clear 분기 회복 — auto-prompt 재발사 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -417,6 +417,68 @@ describe('POST /trips — server-set auto-lock 보존 (#916 follow-up A)', () =>
   });
 });
 
+describe('POST /trips — lastAutoPromptedAt 보존 (#916 follow-up B)', () => {
+  // 30분 window (AUTO_PROMPT_DEDUP_WINDOW_MS) 안/밖, same/new session 4사분면 검증.
+  const CREATED = 1_700_000_000_000;
+  const TOKEN = 'tok-916-fub';
+  const WITHIN_WINDOW_MS = 5 * 60_000; // 5분 — 30분 window 안
+  const BEYOND_WINDOW_MS = 31 * 60_000; // 31분 — 30분 window 밖
+
+  function tripBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return { ...base(), token: TOKEN, createdAt: CREATED, ...overrides };
+  }
+
+  async function seedExisting(
+    env: ReturnType<typeof makeKvEnv>,
+    fields: Record<string, unknown>,
+  ): Promise<void> {
+    await env.TRIPS.put(
+      `trip:${TOKEN}`,
+      JSON.stringify({ ...tripBody(), ...fields }),
+    );
+  }
+
+  it('same session — existing.lastAutoPromptedAt 보존', async () => {
+    const env = makeKvEnv();
+    const stamp = CREATED - WITHIN_WINDOW_MS;
+    await seedExisting(env, { lastAutoPromptedAt: stamp });
+    await post('/trips', tripBody(), env);
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.lastAutoPromptedAt).toBe(stamp);
+  });
+
+  it('new session(createdAt drift > 5s) — window 안이면 보존', async () => {
+    const env = makeKvEnv();
+    const stamp = CREATED - WITHIN_WINDOW_MS;
+    await seedExisting(env, { lastAutoPromptedAt: stamp });
+    // boardingPromptState는 새 세션에서 리셋되지만 dedup 마커는 살아남아야 한다.
+    await post('/trips', tripBody({ createdAt: CREATED + 10_000 }), env);
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.lastAutoPromptedAt).toBe(stamp);
+  });
+
+  it('new session + window 밖 — 보존하지 않음(undefined)', async () => {
+    const env = makeKvEnv();
+    // existing의 createdAt도 같이 옛 시각으로 시뮬레이션 (둘 다 옛 시각이라야 incoming 새 시각과 drift)
+    const oldNow = CREATED - BEYOND_WINDOW_MS;
+    await env.TRIPS.put(
+      `trip:${TOKEN}`,
+      JSON.stringify({ ...tripBody({ createdAt: oldNow }), lastAutoPromptedAt: oldNow }),
+    );
+    await post('/trips', tripBody({ createdAt: CREATED }), env);
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.lastAutoPromptedAt).toBeUndefined();
+  });
+
+  it('existing 마커 부재 — incoming도 마커 없이 저장(undefined)', async () => {
+    const env = makeKvEnv();
+    await seedExisting(env, {}); // lastAutoPromptedAt 없음
+    await post('/trips', tripBody({ createdAt: CREATED + 10_000 }), env);
+    const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
+    expect(stored.lastAutoPromptedAt).toBeUndefined();
+  });
+});
+
 describe('POST /trips (#578 — preserve advance progress on re-register)', () => {
   const CREATED = 1_700_000_000_000;
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3260,6 +3260,111 @@ describe('runScheduled — #916 A1 auto-lock', () => {
   });
 });
 
+// ──────────────────────────────────────────────────────────────────────────
+// #916 follow-up B — fired+clear 분기 회복. auto-lock 후 lock이 클리어돼 lockMissing으로
+// 돌아온 trip의 auto-prompt 재발사를 `lastAutoPromptedAt` 윈도우로 차단.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('runScheduled — #916 follow-up B lastAutoPromptedAt dedup', () => {
+  const seedHappySeries = (kv: InMemoryKV, token: string) => seedHappyGateSeries(kv, token);
+  // AUTO_PROMPT_DEDUP_WINDOW_MS = 30분 — 매직 넘버 안 쓰고 의도 그대로 표현.
+  const WINDOW_MS = 30 * 60_000;
+
+  async function runOneCycle(
+    kv: InMemoryKV,
+    arrivals: ArrivalEntry[],
+    pushId = 'fub-1',
+  ): Promise<ScheduledStats> {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    return runScheduled(makeEnv(kv), {
+      seoul: makeSeoul(arrivals),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => pushId,
+    });
+  }
+
+  it('auto-lock 성공 시 lastAutoPromptedAt이 stamp된다', async () => {
+    const kv = new InMemoryKV();
+    const token = 'fub-stamp';
+    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
+    await seedHappySeries(kv, token);
+    const stats = await runOneCycle(kv, [
+      { destination: '선릉', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+    ]);
+    expect(stats.autoLockSuccess).toBe(1);
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(stored.lastAutoPromptedAt).toBe(NOW);
+  });
+
+  it('prompt push 발사 시에도 lastAutoPromptedAt stamp (auto-lock 실패 fallback)', async () => {
+    const kv = new InMemoryKV();
+    const token = 'fub-stamp-push';
+    await putTrip(kv as unknown as KVNamespace, makePromptTrip({ token }));
+    await seedHappySeries(kv, token);
+    // ambiguity → auto-lock 실패 → push 발사 path
+    const stats = await runOneCycle(kv, [
+      { destination: 'A', arrivalSeconds: 60, trainCode: 'X1', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+      { destination: 'B', arrivalSeconds: 90, trainCode: 'X2', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+    ]);
+    expect(stats.boardingPromptFired).toBe(1);
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(stored.lastAutoPromptedAt).toBe(NOW);
+  });
+
+  it('lastAutoPromptedAt 윈도우 안(=lock 클리어된 직후) → 재평가 자체 차단 (dedup)', async () => {
+    const kv = new InMemoryKV();
+    const token = 'fub-dedup';
+    // 시뮬레이션: 직전 cycle에서 auto-prompt가 발사된 trip이 lock 클리어 + boardingPromptState도
+    // 외부 분기(isSameSession=false)로 리셋된 상태로 lockMissing으로 돌아왔다.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makePromptTrip({
+        token,
+        lastAutoPromptedAt: NOW - 5 * 60_000, // 5분 전 — window(30분) 안
+        boardingPromptState: undefined,
+      }),
+    );
+    await seedHappySeries(kv, token);
+    const stats = await runOneCycle(kv, [
+      { destination: '선릉', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+    ]);
+    // 평가 자체에 안 들어감 — 측정 인프라가 별도 dedup 카운터로 잡는다.
+    expect(stats.boardingPromptAutoDeduped).toBe(1);
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    expect(stats.autoLockSuccess).toBe(0);
+    expect(stats.boardingPromptFired).toBe(0);
+    // trip은 그대로 — auto-prompt 마커는 유지된다.
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(stored.lastAutoPromptedAt).toBe(NOW - 5 * 60_000);
+    expect(stored.boardingLock).toBeUndefined();
+  });
+
+  it('lastAutoPromptedAt 윈도우 밖 → 정상 평가 (새 trip 효과)', async () => {
+    const kv = new InMemoryKV();
+    const token = 'fub-window-expired';
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makePromptTrip({
+        token,
+        lastAutoPromptedAt: NOW - WINDOW_MS - 1_000, // window 만료
+        boardingPromptState: undefined,
+      }),
+    );
+    await seedHappySeries(kv, token);
+    const stats = await runOneCycle(kv, [
+      { destination: '선릉', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+    ]);
+    expect(stats.boardingPromptAutoDeduped).toBe(0);
+    expect(stats.autoLockSuccess).toBe(1);
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    // 새 발사로 마커 갱신.
+    expect(stored.lastAutoPromptedAt).toBe(NOW);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // #917 A2 — arvlCd∈{0,1} 매역 알림 1차 source. backend cron이 lock된 trainCode를
 // realtimeArrivalList에서 추적해 next waypoint에서 ARRIVED/ENTERING 첫 관찰 시

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -34,6 +34,19 @@ import type { BoardingLockMeta, Trip, Waypoint } from './types';
  */
 export const AUTO_LOCK_TTL_MS = SWAP_LOCK_TTL_MS;
 
+/**
+ * #916 follow-up B — auto-prompt 발사 dedup 윈도우.
+ *
+ * `evaluateAndMaybeFireBoardingPrompt`가 9단 게이트 통과 직후 `attemptAutoLock`을 시도/성공한
+ * trip은 이 윈도우 내에서 다시 prompt를 평가하지 않는다. lock이 사라져도(transfer release,
+ * 사용자 swap, isSameSession=false로 boardingPromptState 리셋) 같은 trip token에 대한 자동
+ * prompt 재발사를 차단해 시도 - 클리어 - 재시도 ping-pong 회귀를 방지한다.
+ *
+ * 길이는 `AUTO_LOCK_TTL_MS`(=30분)와 동일 — 자동 lock TTL이 끝나면 prompt dedup도 자연 만료.
+ * 두 정책이 한 번에 바뀌도록 같은 상수를 재사용한다.
+ */
+export const AUTO_PROMPT_DEDUP_WINDOW_MS = AUTO_LOCK_TTL_MS;
+
 export interface AttemptAutoLockInputs {
   trip: Trip;
   /** 다음 추적 대상 waypoint — arrivals 폴링 대상 (현재 leg 첫 waypoint). */

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { Hono } from 'hono';
+import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
 import { markPromptSilenced } from './boardingPrompt';
 import {
   recordBoardingPromptOutcome,
@@ -90,6 +91,15 @@ app.post('/trips', async (c) => {
   //   3) 그 외 (다른 trainCode 또는 큰 drift) → 새 세션, 전면 교체
   const existing = await getTrip(c.env.TRIPS, incoming.token);
   const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
+  // #916 follow-up B — auto-prompt dedup 마커 보존. boardingPromptState와 달리 isSameSession=false
+  // 분기에서도 같은 token + AUTO_PROMPT_DEDUP_WINDOW_MS 안이면 보존한다. 사용자가 lock 클리어 후
+  // 목적지를 살짝 바꿔 새 createdAt으로 재등록하는 케이스에서 prompt 재발사를 차단 (fired+clear
+  // 분기 회복). 윈도우 만료/필드 부재면 undefined로 자연 리셋 — 새 trip은 fresh prompt 평가.
+  const preservedLastAutoPromptedAt =
+    existing?.lastAutoPromptedAt !== undefined &&
+    incoming.createdAt - existing.lastAutoPromptedAt < AUTO_PROMPT_DEDUP_WINDOW_MS
+      ? existing.lastAutoPromptedAt
+      : undefined;
   // #705: progress KV 우선 참조. 같은 trainCode면 shift된 waypoints를 incoming에 적용.
   // 다른 trainCode/none이면 progress 폐기.
   const progress = existing !== null ? await getProgress(c.env.TRIPS, incoming.token) : null;
@@ -149,8 +159,16 @@ app.post('/trips', async (c) => {
         // re-register하더라도 trip당 1회 + 5분 silence 정책을 유지해야 한다 (re-register마다
         // reset되면 spam 회귀). promptGeoContext / promptDisplay는 incoming이 최신이라 그대로 받음.
         boardingPromptState: existing.boardingPromptState,
+        // #916 follow-up B — same session에선 같은 trip이므로 그대로 보존.
+        lastAutoPromptedAt: existing.lastAutoPromptedAt,
       }
-    : incoming;
+    : {
+        ...incoming,
+        // #916 follow-up B — 새 세션(createdAt drift > 5s)으로 판정돼 incoming으로 전면 교체되더라도
+        // 같은 token + window 안이면 auto-prompt dedup 마커는 보존. backend가 직전에 auto-lock 시도/
+        // 발사한 trip 컨텍스트의 재발사 ping-pong을 차단한다.
+        lastAutoPromptedAt: preservedLastAutoPromptedAt,
+      };
 
   // #705 — progress KV가 우선. 같은 trainCode면 incoming.waypoints에서 shift된 만큼 잘라낸다.
   // existing trip이 사라졌더라도(KV TTL 만료 등) progress가 살아 있으면 진행분을 그대로 복원.

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -12,7 +12,7 @@ import {
   type SendPushResult,
 } from './apns';
 import { flipApnsEnv, pickApnsHost } from './apnsHost';
-import { attemptAutoLock } from './autoLock';
+import { attemptAutoLock, AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
 import {
   evaluateBoardingPromptGates,
   markPromptFired,
@@ -225,6 +225,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   autoLockFalsePositive: number;
   /**
+   * #916 follow-up B — 직전 auto-prompt 발사 윈도우(AUTO_PROMPT_DEDUP_WINDOW_MS) 안에 다시
+   * `evaluateAndMaybeFireBoardingPrompt`에 진입한 trip을 `lastAutoPromptedAt` 마커로 차단한
+   * 누적 횟수. lock이 클리어/swap돼 lockMissing으로 돌아오거나 `isSameSession=false`로
+   * boardingPromptState가 리셋된 케이스가 여기에 잡힌다. 0이면 회귀 방어가 발동되지 않은 상태.
+   */
+  boardingPromptAutoDeduped: number;
+  /**
    * #917 A2 — boardingLock 활성 trip에서 Seoul arrivals의 arvlCd∈{0(ENTERING), 1(ARRIVED)}
    * 신호로 매역 station-passed silent push가 성공 발사된 누적 횟수. 매역 알림 1차 source는
    * GPS가 아니라 이 신호 — 다운로드 가치 직결(지하/지상 무관).
@@ -292,6 +299,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     kalmanDriftWarning: 0,
     autoLockSuccess: 0,
     autoLockFalsePositive: 0,
+    boardingPromptAutoDeduped: 0,
     arvlCdFireSuccess: 0,
     arvlCdFireDedup: 0,
     arvlCdFireMismatch: 0,
@@ -1439,6 +1447,22 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   const display = trip.promptDisplay;
   if (!geo || !display) return;
 
+  // #916 follow-up B — fired+clear 분기 회복. 직전 auto-prompt 발사 윈도우 안에 다시 들어왔다면
+  // 평가 자체를 skip — boardingPromptState가 isSameSession=false로 리셋됐거나 lock이 클리어된
+  // 직후 같은 trip token이 lockMissing으로 돌아온 케이스. 같은 trip 컨텍스트의 중복 auto-prompt
+  // 시도/푸시를 차단한다 (윈도우 만료 후엔 자연 재평가 — 새 leg/새 trip은 fresh).
+  if (
+    trip.lastAutoPromptedAt !== undefined &&
+    now - trip.lastAutoPromptedAt < AUTO_PROMPT_DEDUP_WINDOW_MS
+  ) {
+    stats.boardingPromptAutoDeduped += 1;
+    log('boarding-prompt: auto-deduped (within window)', {
+      token: trip.token.slice(0, 8),
+      ageMs: now - trip.lastAutoPromptedAt,
+    });
+    return;
+  }
+
   stats.boardingPromptEvaluated += 1;
 
   const fusion = await runFusionStep(trip, env, now);
@@ -1491,6 +1515,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     if (autoLock) {
       trip.boardingLock = autoLock;
       trip.boardingPromptState = markPromptFired(now);
+      // #916 follow-up B — auto-prompt dedup 마커. lock이 나중에 클리어돼도 window 안에서
+      // 재발사를 차단한다. boardingPromptState와 별개라 isSameSession=false 리셋에도 살아남는다.
+      trip.lastAutoPromptedAt = now;
       trip.consecutiveEtaMissing = 0;
       stats.autoLockSuccess += 1;
       log('boarding-prompt: auto-lock attached', {
@@ -1537,6 +1564,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   if (heal.result.ok) {
     stats.boardingPromptFired += 1;
     trip.boardingPromptState = markPromptFired(now);
+    // #916 follow-up B — prompt push도 같은 dedup 마커를 stamp한다. dismiss + 클리어 후
+    // isSameSession=false 분기로 boardingPromptState가 사라져도 window 안에서 재발사 차단.
+    trip.lastAutoPromptedAt = now;
     dirty = true;
     log('boarding-prompt: fired', {
       token: trip.token.slice(0, 8),

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -133,6 +133,23 @@ export interface Trip {
    */
   boardingPromptState?: BoardingPromptState;
   /**
+   * #916 follow-up B — backend auto-lock 또는 boarding-prompt가 발사된 마지막 시각(epoch ms).
+   * `boardingPromptState`와 별개로 유지되는 dedup 마커.
+   *
+   * 필요한 이유: `boardingPromptState`는 `isSameSession=false` 분기에서 `baseTrip=incoming`로
+   * 갈아치워져 사라진다. auto-lock 성공 직후 사용자가 lock을 클리어/swap하거나 목적지를
+   * 살짝 바꿔 새 createdAt으로 재등록하면 새 trip 세션처럼 인식돼 prompt가 재발사된다 —
+   * 같은 trip token + 같은 출발 컨텍스트에 대해 backend가 방금 자동 lock을 시도/성공한 직후라.
+   *
+   * 본 필드는 같은 token + window 내 새 세션에도 보존되어 `evaluateAndMaybeFireBoardingPrompt`
+   * 초입에서 prompt 재평가 자체를 차단한다 (AUTO_PROMPT_DEDUP_WINDOW_MS = 30분, lockSwap의
+   * SWAP_LOCK_TTL_MS와 정합). 윈도우 만료 또는 명백히 다른 trip(createdAt이 window 이상 차이)은
+   * 보존하지 않아 새 prompt가 자연 발사된다.
+   *
+   * 클라이언트는 절대 송신하지 않는다 — backend가 stamp + 자체 보존.
+   */
+  lastAutoPromptedAt?: number;
+  /**
    * boarding-prompt 평가용 출발역/다음역 좌표 (#819 게이트 #4/#5).
    * backend는 stations.json을 갖지 않으므로 클라이언트가 trip 등록 시 함께 보낸다.
    * 부재 시 boarding-prompt 평가 자체를 skip — 좌표 없는 lockMissing trip은 silent.


### PR DESCRIPTION
## Summary
Epic #912 #916 follow-up B. PR #931 (first PR) + PR #942 (follow-up A — `autoLockedAt` 보존)에 이어 self code-review 한계 #2 해소: auto-lock 후 lock이 클리어되고 `boardingPromptState`가 `isSameSession=false` 분기로 리셋되면 다음 cycle이 lockMissing 으로 돌아와 auto-prompt를 다시 발사하던 ping-pong 회귀를 차단한다.

- `Trip.lastAutoPromptedAt?: number` — backend가 auto-lock 또는 prompt push를 stamp한 시각.
- `evaluateAndMaybeFireBoardingPrompt` — window(=`AUTO_LOCK_TTL_MS` 30분) 안에 다시 진입하면 9단 게이트 평가 자체 skip → `boardingPromptAutoDeduped` 카운트.
- `POST /trips` — same-session에서 그대로 보존, new-session에서도 같은 token + window 안이면 보존(목적지 미세 변경으로 createdAt drift > 5s 케이스).
- stamp 위치: `attemptAutoLock` 성공 분기 + prompt push `heal.result.ok` 분기 양쪽.

## 설계 근거
`boardingPromptState`는 같은 trip session 안에서만 fired/silence 정책을 표현한다. backend가 자동 합성한 prompt는 session 재구성(`isSameSession=false`)으로 사라지면 안 되므로 별도 dedup 마커가 필요하다. window는 `AUTO_LOCK_TTL_MS`와 정합 — 자동 lock TTL이 끝나면 prompt dedup도 자연 만료(같은 상수 재사용으로 두 정책 동시 변경 보장).

## Test plan
- [x] `npm run type-check` (root) 통과
- [x] backend `npm test` 통과 (23 files, 814 tests)
- [x] client `npm test` 통과 (217 files, 3910 tests, 100% coverage)
- [x] 추가 tests:
  - `runScheduled — #916 follow-up B lastAutoPromptedAt dedup` 4 cases (stamp on auto-lock / stamp on push / dedup within window / pass after window)
  - `POST /trips — lastAutoPromptedAt 보존 (#916 follow-up B)` 4 cases (same session preserve / new session within window preserve / new session beyond window drop / no marker absent)
- [x] code-review (medium effort) — confirmed/plausible 0건

Closes #916
Refs #912