### PR TITLE
fix(#949): E2E 취침 모드 토글 flake — home-sleep-mode-switch visible 안정화

### DIFF
--- a/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
+++ b/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
@@ -31,20 +31,26 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 - tapOn:
     id: "search-input"
 - inputText: "잠실"
-- assertVisible:
-    id: "suggestions-list"
+# iOS 시뮬레이터 IME가 한글 입력 후 setQuery → suggestions useMemo → SectionList 렌더까지
+# 종종 ~1s를 넘긴다. flow 02와 동일하게 extendedWaitUntil(5s)로 흡수.
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
 - tapOn:
     id: "suggestion-item-2-016"
 
-# 잠실 설정 직후 destination 박스 높이가 커져 home-sleep-mode-switch가 viewport 밖.
-# scrollUntilVisible은 nested ScrollView에서 element 인식 실패 가능 → 명시적 swipe로 강제 스크롤.
-- swipe:
-    start: "50%, 80%"
-    end: "50%, 30%"
-- extendedWaitUntil:
-    visible:
+# 잠실 설정 직후 destination/route 박스가 늘어나 home-sleep-mode-switch가 viewport 밖.
+# #644는 단발 swipe(50%→30%)로 보정했지만 이후 destination 블록에 컨텐츠가 추가되며
+# (#749/#758/#797/#816) 한 번의 swipe로는 도달 못 하는 회귀 발생(#949). scrollUntilVisible로
+# 가변 컨텐츠 길이에 자동 적응하도록 전환. centerElement로 nested ScrollView 인식 안정화.
+- scrollUntilVisible:
+    element:
       id: "home-sleep-mode-switch"
-    timeout: 5000
+    direction: DOWN
+    timeout: 10000
+    centerElement: true
+    visibilityPercentage: 100
 - tapOn:
     id: "home-sleep-mode-switch"
 
@@ -65,10 +71,10 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 # 홈 탭 복귀
 - tapOn:
     point: "12%,95%"
-- swipe:
-    start: "50%, 80%"
-    end: "50%, 30%"
-- extendedWaitUntil:
-    visible:
+- scrollUntilVisible:
+    element:
       id: "home-sleep-mode-switch"
-    timeout: 5000
+    direction: DOWN
+    timeout: 10000
+    centerElement: true
+    visibilityPercentage: 100


### PR DESCRIPTION
Closes #949

## Root cause

PR #644 (`f8cc01c`)에서 `scrollUntilVisible` → 단발 `swipe(50%,80% → 50%,30%)` + `extendedWaitUntil 5s`로 교체. 당시엔 통과.

이후 destination/route 블록에 컨텐츠가 추가됨:
- #749 BoardingTrainList 시퀀스 카운터 + 방면 노출
- #758 BoardingLockHopCard hop slot 통합
- #797 환승역 호선 분기
- #816 lockless station-passed toggle

→ route 박스 세로 길이가 늘어나 **50%→30% 단발 swipe로는 sleep-mode-row가 viewport에 들어오지 않음**. `extendedWaitUntil`은 추가 스크롤 없이 대기만 하므로 5s 후 timeout.

## Fix

- 단발 `swipe` + `extendedWaitUntil` → `scrollUntilVisible(direction: DOWN, timeout: 10000, centerElement: true, visibilityPercentage: 100)`로 전환. 가변 컨텐츠 길이에 자동 적응.
- `centerElement: true`로 nested ScrollView element 인식 안정화 (#644 회피 사유 해소).
- 동일 패턴을 잠실 설정 직후 + 홈 탭 복귀 양쪽에 적용.
- 부수: `assertVisible: suggestions-list` → `extendedWaitUntil 5s`로 flow 02와 정렬 (한글 IME 1s+ 지연 latent flake 차단).

## Evidence (dev-wide 100% 재현 실패)

dev 직접 실행 (PR diff 무관):
- run [27021246958](https://github.com/handokei/subway-now/actions/runs/27021246958)
- run [27020330357](https://github.com/handokei/subway-now/actions/runs/27020330357)
- run [27019218391](https://github.com/handokei/subway-now/actions/runs/27019218391)

최근 PR (동일 단계 실패):
- PR #943, #944, #945

모두: `[Failed] smoke - 취침 모드 토글 (홈 ↔ 설정 동기화) (Assertion is false: id: home-sleep-mode-switch is visible)`

## Test plan

- [ ] CI `E2E Smoke (mock mode)` green
- [ ] 나머지 5 smoke flow 회귀 없음 (`0/6 Flow Failed`)
- [ ] `Type Check & Test` green
- [ ] `Maestro flow 문법 검증` step 통과 (deprecated 명령어 없음)