### PR TITLE
test(#923): 권한 매트릭스 회귀 — 추가 cell 3건

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -326,7 +326,10 @@ jobs:
       matrix:
         cell:
           - whileInUse-fg-aboveground-normal-ios18
-          # 후속 PR에서 추가: always-*, *-bg-*, *-underground-*, *-sleep-*, ios17, android
+          - always-fg-aboveground-normal-ios18
+          - whileInUse-fg-aboveground-sleep-ios18
+          - always-fg-aboveground-sleep-ios18
+          # 후속 PR에서 추가: *-bg-*, *-underground-*, ios17, android
     env:
       SIM_NAME: 'iPhone 16'
       EXPO_PUBLIC_E2E_MOCK: '1'

--- a/.maestro/flows/permissions/README.md
+++ b/.maestro/flows/permissions/README.md
@@ -10,19 +10,20 @@ Android, FG/BG, 지상/지하, 일반/취침 등 권한·환경 조합별로 매
 - `scripts/permission-matrix-runner.js` — JSON을 읽어 cell 단위로 maestro 실행.
 - `.maestro/flows/permissions/<cell-id>.yaml` — cell별 Maestro flow.
 
-## 첫 PR 범위 (E2)
+## 현재 PR 범위 (E2 첫 PR + 후속)
 
-baseline 1셀만 포함:
+| cell id | permission | appState | environment | mode | os | 비고 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `whileInUse-fg-aboveground-normal-ios18` | WhileInUse | FG | 지상 | 일반 | iOS 18 | baseline (첫 PR) |
+| `always-fg-aboveground-normal-ios18` | Always | FG | 지상 | 일반 | iOS 18 | 권한 대조군 |
+| `whileInUse-fg-aboveground-sleep-ios18` | WhileInUse | FG | 지상 | 취침 | iOS 18 | 권한↓ + 취침 결합 |
+| `always-fg-aboveground-sleep-ios18` | Always | FG | 지상 | 취침 | iOS 18 | SLA 정본 조합 |
 
-| cell id | permission | appState | environment | mode | os |
-| --- | --- | --- | --- | --- | --- |
-| `whileInUse-fg-aboveground-normal-ios18` | WhileInUse | FG | 지상 | 일반 | iOS 18 |
-
-후속 PR에서 추가될 15+ cell (`scripts/permission-matrix.json`의 `cells` 배열에
+후속 PR에서 추가될 cell (`scripts/permission-matrix.json`의 `cells` 배열에
 entry만 추가하면 runner와 CI matrix가 자동으로 픽업):
 
-- Always × FG/BG × 지상/지하 × 일반/취침 = 8 cell
-- WhileInUse × FG/BG × 지상/지하 × 일반/취침 = 8 cell (baseline 1셀 제외 7)
+- `*-bg-*` 차원 (앱 BG 상태에서 매역 알람 SLA 검증)
+- `*-underground-*` 차원 (E2E mock fixture 확장 필요)
 - iOS 17 / Android 차원은 OS dimension 확장
 
 ## 로컬 실행

--- a/.maestro/flows/permissions/always-fg-aboveground-normal-ios18.yaml
+++ b/.maestro/flows/permissions/always-fg-aboveground-normal-ios18.yaml
@@ -1,0 +1,49 @@
+appId: com.subwaynow.app
+name: "permissions - Always × FG × 지상 × 일반 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=fg, environment=aboveground, mode=normal, os=ios18
+#
+# 검증 목표:
+#   - 위치 권한 "항상"이 부여된 상태(매역 알림 SLA의 정본 권한)에서
+#     앱이 정상 부팅되고 매역 알람 진입점 UI가 정상 노출됨을 보장한다.
+#   - whileInUse baseline과 비교해 다른 권한 경로에서도 동일 UX가 동작해야 한다.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, useNearestStation이 강남역 고정 fixture).
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# Expo dev-client(개발 빌드 한정) 안내 화면 — release 빌드에서는 없음
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+# Dev menu가 떴을 경우를 위한 swipe-down (smoke와 동일 패턴)
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 홈 화면 노출 — Always 권한에서도 destination-button이 렌더되어야 함
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 강남(지상) — useNearestStation이 fixture를 반환해야 한다
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 매역 알람 경로의 진입점인 "목적지 설정" CTA가 보여야 한다
+- assertVisible:
+    text: "목적지 설정|Set destination"

--- a/.maestro/flows/permissions/always-fg-aboveground-sleep-ios18.yaml
+++ b/.maestro/flows/permissions/always-fg-aboveground-sleep-ios18.yaml
@@ -1,0 +1,52 @@
+appId: com.subwaynow.app
+name: "permissions - Always × FG × 지상 × 취침 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=fg, environment=aboveground, mode=sleep, os=ios18
+#
+# 검증 목표:
+#   - 매역 알림 SLA의 정본 조합(권한=항상 + 취침 모드 ON)에서 홈 화면이 정상
+#     렌더되고 취침 모드 토글이 reachable 함을 보장한다.
+#   - 다음 PR(실측 recall)에서 본 cell의 expectedRecallPct를 채울 예정.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, 강남역 fixture).
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+
+- tapOn:
+    id: "home-sleep-mode-switch"
+
+- assertVisible:
+    id: "home-sleep-mode-switch"

--- a/.maestro/flows/permissions/whileInUse-fg-aboveground-sleep-ios18.yaml
+++ b/.maestro/flows/permissions/whileInUse-fg-aboveground-sleep-ios18.yaml
@@ -1,0 +1,54 @@
+appId: com.subwaynow.app
+name: "permissions - WhileInUse × FG × 지상 × 취침 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=whileInUse, appState=fg, environment=aboveground, mode=sleep, os=ios18
+#
+# 검증 목표:
+#   - 권한이 "사용하는 동안"으로 다운그레이드된 상태에서 취침 모드를 켜도
+#     홈 화면이 정상 렌더되고 매역 알람 진입점이 유지됨을 보장한다.
+#   - 취침 모드 토글이 권한 약화와 무관하게 reachable 해야 한다 (회귀 가드).
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, 강남역 fixture).
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: inuse
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 취침 모드 토글 영역까지 스크롤 후 ON 전환
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+
+- tapOn:
+    id: "home-sleep-mode-switch"
+
+# 토글 후에도 매역 알람 진입점이 유지되어야 한다 (권한 약화 + 취침 조합 회귀 가드)
+- assertVisible:
+    id: "home-sleep-mode-switch"

--- a/scripts/permission-matrix.json
+++ b/scripts/permission-matrix.json
@@ -25,6 +25,39 @@
       "flow": "whileInUse-fg-aboveground-normal.yaml",
       "baseline": true,
       "_doc": "E2 baseline. 가장 흔한 사용자 시나리오(권한=사용중 + 앱 열림 + 지상 + 일반모드). 매역 알람 정상 발사를 보장한다."
+    },
+    {
+      "id": "always-fg-aboveground-normal-ios18",
+      "permission": "always",
+      "appState": "fg",
+      "environment": "aboveground",
+      "mode": "normal",
+      "os": "ios18",
+      "expectedRecallPct": 95,
+      "flow": "always-fg-aboveground-normal-ios18.yaml",
+      "_doc": "권한 다른 쪽 baseline 대조군. Always 권한 경로(매역 알림 SLA 정본 권한)에서도 홈 진입점이 동작함을 보장한다."
+    },
+    {
+      "id": "whileInUse-fg-aboveground-sleep-ios18",
+      "permission": "whileInUse",
+      "appState": "fg",
+      "environment": "aboveground",
+      "mode": "sleep",
+      "os": "ios18",
+      "expectedRecallPct": 90,
+      "flow": "whileInUse-fg-aboveground-sleep-ios18.yaml",
+      "_doc": "권한 다운그레이드 + 취침 모드 조합 회귀 가드. 두 차원이 결합해도 토글이 reachable 해야 한다."
+    },
+    {
+      "id": "always-fg-aboveground-sleep-ios18",
+      "permission": "always",
+      "appState": "fg",
+      "environment": "aboveground",
+      "mode": "sleep",
+      "os": "ios18",
+      "expectedRecallPct": 95,
+      "flow": "always-fg-aboveground-sleep-ios18.yaml",
+      "_doc": "매역 알림 SLA의 정본 조합(권한=항상 + 취침). 후속 PR에서 실측 recall로 업데이트."
     }
   ]
 }


### PR DESCRIPTION
Refs #923 (E2 후속 PR — baseline 1셀에 cell 3건 추가, 매트릭스 총 4셀)

## Summary
- `scripts/permission-matrix.json`에 3개 cell entry 추가 (데이터 주도 — runner 무수정)
- `.maestro/flows/permissions/`에 cell별 yaml 3개 신규 작성 (baseline 템플릿 복제)
- `.github/workflows/e2e.yml`의 `permission-matrix` job matrix.cell에 3개 id 추가

## 추가 Cell + 선택 근거

| cell id | permission | mode | 선택 근거 |
| --- | --- | --- | --- |
| `always-fg-aboveground-normal-ios18` | Always | 일반 | **권한 대조군**. WhileInUse baseline 대비 Always 경로(매역 알림 SLA의 정본 권한)에서도 홈 진입점이 동작함을 보장 |
| `whileInUse-fg-aboveground-sleep-ios18` | WhileInUse | 취침 | **결합 회귀 가드**. 권한 다운그레이드 + 취침 모드 두 차원이 결합해도 토글이 reachable 해야 함 |
| `always-fg-aboveground-sleep-ios18` | Always | 취침 | **매역 알림 SLA 정본 조합**. 후속 PR에서 실측 recall로 expectedRecallPct 채울 예정 |

## 제외 (후속 PR)
- `*-bg-*` — appState=BG는 시뮬레이터 BG 진입 시나리오 필요 (별도 infra)
- `*-underground-*` — IS_E2E_MOCK이 강남(지상) 고정 fixture 반환 → mock 확장 선행 필요
- iOS 17 / Android — OS dimension 확장 (별도 runner)
- 실측 recall / Slack 알림

## Test plan
- [x] `npm test` — 3913 passed, 100% coverage 유지 (테스트 추가/변경 없음 — yaml/json/yml만 추가)
- [x] `npm run type-check` — pass
- [x] `node scripts/permission-matrix-runner.js --list` — 4 cells 발견 확인
- [x] `node scripts/permission-matrix-runner.js --dry-run` — 4 maestro 명령 정상 생성 확인
- [ ] nightly에서 permission-matrix job 4 cell 모두 통과 확인 (머지 후 cron)