### PR TITLE
test(#922): Maestro 회귀 시나리오 — Seam F + Seam E 추가

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -164,7 +164,10 @@ jobs:
       matrix:
         scenario:
           - seam-b-13-19
-          # 후속 PR에서 추가: seam-c-14-02, seam-e-13-39, seam-f-13-24
+          - seam-e-13-39
+          - seam-f-13-24
+          # Seam C는 transfer-leg / FG-return 이벤트 mock 설계 결함으로 보류
+          # ([[project-2026-06-05-epic-912-session-end]]).
     env:
       SIM_NAME: 'iPhone 16'
       EXPO_PUBLIC_USE_BFF: 'true'

--- a/.maestro/flows/regression/README.md
+++ b/.maestro/flows/regression/README.md
@@ -31,11 +31,13 @@ maestro test .maestro/flows/regression/seam-b-13-19.yaml
 | 파일 | Seam | 회귀 시점 | 검증 내용 |
 | --- | --- | --- | --- |
 | `seam-b-13-19.yaml` | B | 13:19 transfer/early/건대입구 fired @ 성수 | 성수 정지 + 건대입구 5분 후 ETA → false-positive 발사 없음 |
+| `seam-e-13-39.yaml` | E | 13:39~45 lockMissing | `/boarding-lock/sync` 응답이 advanced=true여도 ghost 알람 발사 0건, chip 안정 |
+| `seam-f-13-24.yaml` | F | 13:24~28 trainCode 7174 사라짐 | 25s 시점 trainCode drop 후에도 lockMissing/ghost 알람 발사 0건 |
 
-후속 PR에서 추가 예정:
-- Seam C — 13:23 waypoint advanced + 14:02 stale chip
-- Seam E — 13:39~45 lockMissing
-- Seam F — 13:24~28 trainCode 사라짐
+보류:
+- Seam C — 13:23 waypoint advanced + 14:02 stale chip. transfer-leg / FG-return /
+  명시적 event mock 설계가 fixture-driven 구조에 맞지 않아 별도 인프라 PR 후로 미룸
+  ([[project-2026-06-05-epic-912-session-end]]).
 
 ## fixture 작성 가이드
 
@@ -57,7 +59,16 @@ maestro test .maestro/flows/regression/seam-b-13-19.yaml
       }
     ]
   },
-  "strictStations": false      // optional, 없는 역 요청 시 200 빈 응답(false) vs 404(true)
+  "strictStations": false,     // optional, 없는 역 요청 시 200 빈 응답(false) vs 404(true)
+  "boardingLockSync": {        // optional (Seam E). POST /boarding-lock/sync 응답.
+    "response": {              // 없으면 기본 { ok:true, advanced:false } 반환.
+      "ok": true,
+      "advanced": true,
+      "currentWaypoint": "군자",
+      "nextStation": "중곡",
+      "autoLockCandidate": { "trainCode": "7180", "line": "7", "subwayId": "1077" }
+    }
+  }
 }
 ```
 

--- a/.maestro/flows/regression/seam-e-13-39.yaml
+++ b/.maestro/flows/regression/seam-e-13-39.yaml
@@ -1,0 +1,78 @@
+appId: com.subwaynow.app
+name: "regression - Seam E (#922) — boardingLock sync 정정 (lockMissing 차단)"
+# 2026-06-05 13:39~45 실기기 회귀 재현. 사용자가 7호선 군자역까지 진행했는데 backend
+# lock의 currentWaypoint는 어린이대공원에 stale로 머물러 군자 알람 push 0건이었다.
+# Seam E(#901)는 client → backend POST /boarding-lock/sync로 좋은 GPS fix를 통보해
+# lock을 advance한다.
+#
+# 본 flow는 사용자 GPS를 군자역에 두고 mock backend가 sync 응답으로 advanced=true +
+# currentWaypoint=군자를 돌려주는 상황에서, client UI가 ghost '곧 도착' 알람을 발사하지
+# 않고 trip chip이 정상적으로 군자(또는 다음 hop)로 안정됨을 검증한다.
+#
+# 전제: scripts/maestro-mock-backend.js가 SCENARIO=seam-e-13-39 PORT=8788로 떠 있고
+# 앱은 EXPO_PUBLIC_BFF_URL/EXPO_PUBLIC_ALARM_BACKEND_URL로 mock을 가리키도록 빌드되어야 한다.
+---
+- setLocation:
+    latitude: 37.556897
+    longitude: 127.079338
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 군자 확인 (한/영 둘 다 매칭)
+- assertVisible:
+    text: "군자|Gunja"
+
+# 목적지: 중곡 (7호선 단순 trip — Seam E의 핵심은 lock sync 정정)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "중곡"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-7-016"
+- waitForAnimationToEnd
+
+# 트립 형성 후 90초 대기 — sync debounce(5s) × 다회 + arrival 폴링 cycle 확보.
+# 13:39~45 회귀는 lockMissing 6분 윈도였으므로 90s 안에 false-positive를 재현할 수 있다.
+- repeat:
+    times: 90
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# Seam E 회귀 검증: ghost 알람 발사 시 실패.
+# 본 시나리오의 핵심은 sync POST가 발사되고 그 응답이 ghost 알람을 유발하지 않는다는 것.
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# 트립 chip은 군자로 안정 — sync 응답이 advanced=true여도 client는 chip을 ghost로
+# 점프시키지 않아야 한다(GPS 기반 currentStation이 SSOT).
+- assertVisible:
+    text: "군자|Gunja"

--- a/.maestro/flows/regression/seam-f-13-24.yaml
+++ b/.maestro/flows/regression/seam-f-13-24.yaml
@@ -1,0 +1,73 @@
+appId: com.subwaynow.app
+name: "regression - Seam F (#922) — trainCode 사라짐 후 false-positive 차단"
+# 2026-06-05 13:24~28 실기기 회귀 재현. 7호선 어린이대공원에서 추적 중이던 trainCode 7174가
+# OpenAPI 응답에서 사라졌을 때, 다음 후보(7176)로 부드럽게 transition하면서 client UI는
+# 'lockMissing' 또는 ghost '곧 도착' 알람을 발사하지 않아야 한다.
+#
+# 전제: scripts/maestro-mock-backend.js가 SCENARIO=seam-f-13-24 PORT=8788로 떠 있고
+# 앱은 EXPO_PUBLIC_BFF_URL/EXPO_PUBLIC_ALARM_BACKEND_URL로 mock을 가리키도록 빌드되어야 한다.
+# fixture는 25s 시점에 7174를 응답에서 제거 → flow는 그 이후로 충분히 대기해 검증.
+---
+- setLocation:
+    latitude: 37.548014
+    longitude: 127.074658
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 어린이대공원 확인 (한/영 둘 다 매칭)
+- assertVisible:
+    text: "어린이대공원|Children"
+
+# 목적지: 군자 (7호선 단순 trip — Seam F의 핵심은 환승이 아닌 trainCode 사라짐 자체)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "군자"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-7-017"
+- waitForAnimationToEnd
+
+# 트립 형성 후 90초 대기 — fixture 25s 시점 trainCode 사라짐 + 그 이후 65s 회복 관찰.
+# 회귀(false-positive 발사)는 보통 사라짐 직후 1~2 cycle(30~60s) 안에 발생했다.
+- repeat:
+    times: 90
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# Seam F 회귀 검증: lockMissing/곧 도착/하차 알림 UI 노출 시 실패.
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# 트립 진행 chip은 어린이대공원으로 안정 — trainCode 7174 사라져도 다음 후보(7176)로
+# silent transition. ghost waypoint advance가 일어났다면 chip이 군자로 잘못 advance.
+- assertVisible:
+    text: "어린이대공원|Children"

--- a/scripts/fixtures/regression/seam-e-13-39.json
+++ b/scripts/fixtures/regression/seam-e-13-39.json
@@ -1,0 +1,79 @@
+{
+  "name": "Seam E — 13:39~45 lockMissing (어린이대공원→군자 sync 정정)",
+  "seam": "E",
+  "_doc": [
+    "2026-06-05 13:39~45 실기기 회귀: 사용자가 군자를 지났는데 backend lock의",
+    "currentWaypoint는 여전히 어린이대공원에 있어 군자 알람 push 0건 (lockMissing).",
+    "Seam E(#901)는 client → backend POST /boarding-lock/sync로 사용자 GPS-확신",
+    "위치를 통보해 lock의 currentWaypoint를 즉시 advance한다.",
+    "",
+    "fixture 구성:",
+    "  - 도착정보: 군자 응답은 다음 열차 5분 후 → client 측에서는 false-positive 발사 없음",
+    "  - /boarding-lock/sync POST 수신 시 backend가 advanced=true + currentWaypoint=군자",
+    "    + nextStation=중곡 응답 (lock 정정 시뮬레이션)",
+    "",
+    "기대 client-observable 동작: 'lockMissing' 또는 ghost '곧 도착' UI 노출 없음,",
+    "트립 chip은 군자(또는 다음 hop)로 안정 — 환승 advance UI 표시 가능."
+  ],
+  "arrivals": {
+    "군자": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "군자",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "7180",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ],
+    "중곡": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "중곡",
+              "arrivalMinutes": 7,
+              "arrivalSeconds": 420,
+              "statusMessage": "7분 후 도착",
+              "trainCode": "7180",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ]
+  },
+  "boardingLockSync": {
+    "response": {
+      "ok": true,
+      "advanced": true,
+      "currentWaypoint": "군자",
+      "nextStation": "중곡",
+      "autoLockCandidate": {
+        "trainCode": "7180",
+        "line": "7",
+        "subwayId": "1077"
+      }
+    }
+  }
+}

--- a/scripts/fixtures/regression/seam-f-13-24.json
+++ b/scripts/fixtures/regression/seam-f-13-24.json
@@ -1,0 +1,99 @@
+{
+  "name": "Seam F — 13:24~28 trainCode 7174가 OpenAPI에서 사라짐 (어린이대공원)",
+  "seam": "F",
+  "_doc": [
+    "2026-06-05 13:24~28 실기기 회귀: 7호선 어린이대공원에서 trainCode 7174가",
+    "OpenAPI 응답에서 사라짐 → 다음 후보 trainCode 모름 → lockMissing 흐름 진입,",
+    "BG LA 6분 손실. backend Seam F(#902)는 같은 노선/방향 신규 trainCode를 자동",
+    "swap하지만 client 측면에서는 stale trainCode가 사라져도 false-positive 알람을",
+    "발사하지 않아야 한다(Seam F 회귀의 client-observable 표면).",
+    "",
+    "fixture 구성:",
+    "  - 0~25s: 어린이대공원 up 응답에 7174 + 신규 7176 두 후보 노출 (정상 추적)",
+    "  - 25s~ : 7174 사라짐, 7176만 남음 → client는 lockMissing UI나 ghost 알람을",
+    "           띄우지 않고 trip chip은 어린이대공원으로 안정 유지해야 한다.",
+    "",
+    "기대 동작: '곧 도착'/'하차 알림'/'알람 끄기' 발사 0건, 트립 chip = 어린이대공원."
+  ],
+  "arrivals": {
+    "어린이대공원": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "어린이대공원",
+              "arrivalMinutes": 0,
+              "arrivalSeconds": 0,
+              "statusMessage": "도착",
+              "trainCode": "7174",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 1,
+              "isLastTrain": false,
+              "trainType": "normal"
+            },
+            {
+              "destination": "어린이대공원",
+              "arrivalMinutes": 6,
+              "arrivalSeconds": 360,
+              "statusMessage": "6분 후 도착",
+              "trainCode": "7176",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      },
+      {
+        "fromMs": 25000,
+        "body": {
+          "up": [
+            {
+              "destination": "어린이대공원",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "7176",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ],
+    "군자": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "군자",
+              "arrivalMinutes": 4,
+              "arrivalSeconds": 240,
+              "statusMessage": "4분 후 도착",
+              "trainCode": "7176",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ]
+  }
+}

--- a/scripts/maestro-mock-backend.js
+++ b/scripts/maestro-mock-backend.js
@@ -110,6 +110,19 @@ function handle(req, res) {
     return;
   }
 
+  // POST /boarding-lock/sync — Seam E (#901). fixture.boardingLockSync.response가
+  // 있으면 그대로 반환(advance/currentWaypoint/autoLockCandidate). 없으면 ACK no-op.
+  // body 파싱 실패는 graceful — sync 호출자도 fail-soft.
+  if (method === 'POST' && url === '/boarding-lock/sync') {
+    const cfg = fixture.boardingLockSync;
+    if (cfg && cfg.response) {
+      sendJson(res, 200, cfg.response);
+    } else {
+      sendJson(res, 200, { ok: true, advanced: false });
+    }
+    return;
+  }
+
   // POST /trips/*, /live-activity/* — alarm-worker.
   // 회귀 시나리오는 silent push 없이 client-side 알람만 검증하므로 ACK만 돌려준다.
   if (method === 'POST' && (url.startsWith('/trips') || url.startsWith('/live-activity'))) {


### PR DESCRIPTION
## Summary

Epic #912 P2 E1 follow-up. PR #927 (merged)가 Maestro 회귀 fixture 인프라 + Seam B 1개 시나리오를 추가했고, 본 PR은 남은 시나리오 중 Seam F + Seam E 2개를 추가한다.

## Scenarios

| 파일 | Seam | 회귀 시점 | 검증 내용 |
| --- | --- | --- | --- |
| `seam-f-13-24.yaml` | F | 13:24~28 trainCode 7174 사라짐 | fixture 25s 시점에 응답에서 7174 drop → client lockMissing/ghost 알람 발사 0건, chip = 어린이대공원 안정 |
| `seam-e-13-39.yaml` | E | 13:39~45 lockMissing | `POST /boarding-lock/sync` 응답이 advanced=true / currentWaypoint=군자여도 ghost 알람 발사 0건, chip = 군자 안정 |

## Design notes

- 두 시나리오 모두 **client-observable 표면**(false-positive 알람 비발사 + chip 안정)을 검증. backend 자율 처리(Seam F의 trainCode swap, Seam E의 currentWaypoint advance) 자체는 단위 테스트가 잡고, 본 fixture는 그 결과가 실기기 UI에 ghost를 만들지 않음을 가드.
- Seam B 템플릿(launchApp clearState → destination 검색 → 90s 대기 → assertNotVisible 3종 → chip 안정 확인)을 그대로 따라 fixture-driven 구조 유지.
- mock backend는 `/boarding-lock/sync` 핸들러 1개만 추가 (`fixture.boardingLockSync.response`가 있으면 그대로 반환, 없으면 ACK no-op). 추가 의존성 없음.

## Seam C 보류

Seam C(13:23 waypoint advanced + 14:02 stale chip)는 transfer-leg / FG-return / 명시적 event mock 설계가 현 fixture-driven 구조로는 표현할 수 없어 별도 인프라 PR 후로 미룬다. [[project-2026-06-05-epic-912-session-end]]에 abandonment 기록 있음.

## Test plan

- [x] `npm test` (3913 passed, coverage 100%)
- [x] `npm run type-check` 통과
- [x] mock backend 로컬 smoke: `SCENARIO=seam-e-13-39 node scripts/maestro-mock-backend.js` → `/healthz`, `/boarding-lock/sync`, `/api/arrival/군자` 모두 정상
- [x] fixture JSON parse + seam 식별 OK
- [x] Maestro YAML deprecated 명령어(`clearText`) 없음
- [x] code-review (low) — none
- [ ] nightly e2e regression matrix 3개 시나리오 모두 green (PR 머지 후 nightly 또는 workflow_dispatch로 확인)

Refs #922