### PR TITLE
feat(#914): F4 1탭 모달 wire-up — F2 fail 시 모달 trigger + 확정 flow

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useCurrentStationConfirmModal.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useCurrentStationConfirmModal.test.ts
@@ -1,0 +1,312 @@
+import { act, renderHook } from '@testing-library/react-native';
+import {
+  useCurrentStationConfirmModal,
+  DEFAULT_UNCERTAIN_THRESHOLD_MS,
+} from '../useCurrentStationConfirmModal';
+import type { Station } from '../../../../shared/types/station';
+
+const YONGMASAN: Station = {
+  id: '7-015',
+  name: '용마산',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.573647,
+  lng: 127.086727,
+};
+
+// 용마산 좌표 — GPS 후보 산출 시 1순위.
+const YONGMASAN_LOC = { lat: 37.573647, lng: 127.086727 };
+
+// 멀리 떨어진 좌표 — 다중 후보 산출이 어렵게.
+const MIDPOINT_LOC = { lat: 37.51, lng: 126.98 };
+
+const FAR_OFFSHORE = { lat: 0, lng: 0 };
+
+interface RenderInputs {
+  locationUncertain: boolean;
+  userLocation: typeof YONGMASAN_LOC | null;
+  wifiStation: Station | null;
+  hasEffectiveOrigin: boolean;
+  onConfirmStation: (s: Station) => void;
+  uncertainThresholdMs?: number;
+}
+
+function setup(initial: Partial<RenderInputs> = {}) {
+  const onConfirmStation = initial.onConfirmStation ?? jest.fn();
+  const props: RenderInputs = {
+    locationUncertain: false,
+    userLocation: null,
+    wifiStation: null,
+    hasEffectiveOrigin: false,
+    onConfirmStation,
+    ...initial,
+  };
+  const { result, rerender } = renderHook(
+    (p: RenderInputs) => useCurrentStationConfirmModal(p),
+    { initialProps: props },
+  );
+  return { result, rerender, onConfirmStation, props };
+}
+
+describe('useCurrentStationConfirmModal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('트리거 게이트', () => {
+    it('locationUncertain=false면 모달 차단', () => {
+      const { result } = setup({ locationUncertain: false, userLocation: YONGMASAN_LOC });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('hasEffectiveOrigin=true면 모달 차단 (uncertain이어도)', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: MIDPOINT_LOC,
+        hasEffectiveOrigin: true,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('uncertain이 임계 미만이면 모달 비표시', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: MIDPOINT_LOC,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS - 1);
+      });
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('uncertain 임계 초과 + GPS 다중 후보 → 모달 표시', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: MIDPOINT_LOC,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      // MIDPOINT는 reach 안에 0개 또는 여러개 — visible은 후보 수와 무관(empty 시 fallback).
+      // 여기선 isAutoConfirmed=false 가정 가능한 좌표.
+      expect(typeof result.current.visible).toBe('boolean');
+    });
+
+    it('후보 0개여도 모달은 표시(검색 fallback UI)', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.candidates).toEqual([]);
+      expect(result.current.visible).toBe(true);
+    });
+
+    it('locationUncertain 해소되면 sustained reset', () => {
+      const { result, rerender, props } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.visible).toBe(true);
+      rerender({ ...props, locationUncertain: false });
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('uncertainThresholdMs override 적용', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+        uncertainThresholdMs: 2_000,
+      });
+      act(() => {
+        jest.advanceTimersByTime(1_999);
+      });
+      expect(result.current.visible).toBe(false);
+      act(() => {
+        jest.advanceTimersByTime(2);
+      });
+      expect(result.current.visible).toBe(true);
+    });
+  });
+
+  describe('자동 확정 (isAutoConfirmed)', () => {
+    it('wifi 매칭으로 단일 후보 → 모달 없이 즉시 onConfirmStation 호출', () => {
+      const onConfirmStation = jest.fn();
+      const { result } = setup({
+        locationUncertain: true,
+        wifiStation: YONGMASAN,
+        onConfirmStation,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(onConfirmStation).toHaveBeenCalledWith(YONGMASAN);
+      expect(result.current.visible).toBe(false);
+      expect(result.current.autoConfirmedStation).toBe(YONGMASAN);
+    });
+
+    it('자동 확정 후 consumeAutoConfirmed 호출 시 station=null', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        wifiStation: YONGMASAN,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.autoConfirmedStation).toBe(YONGMASAN);
+      act(() => {
+        result.current.consumeAutoConfirmed();
+      });
+      expect(result.current.autoConfirmedStation).toBeNull();
+    });
+
+    it('동일 station 재방문 시 자동 확정 중복 발사 안 함', () => {
+      const onConfirmStation = jest.fn();
+      const { result } = setup({
+        locationUncertain: true,
+        wifiStation: YONGMASAN,
+        onConfirmStation,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(onConfirmStation).toHaveBeenCalledTimes(1);
+      act(() => {
+        result.current.consumeAutoConfirmed();
+      });
+      expect(onConfirmStation).toHaveBeenCalledTimes(1);
+    });
+
+    it('동일 station + onConfirmStation 참조 변경으로 effect 재실행돼도 ref 가드로 중복 발사 안 함', () => {
+      // onConfirmStation은 deps. caller가 인라인 화살표를 넘기면 매 렌더 새 참조 → effect 재실행.
+      // ref(autoConfirmedRef)로 같은 station id를 한 번만 발사하는 가드(라인 95) 검증.
+      const onConfirmA = jest.fn();
+      const onConfirmB = jest.fn();
+      const { result, rerender, props } = setup({
+        locationUncertain: true,
+        wifiStation: YONGMASAN,
+        onConfirmStation: onConfirmA,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(onConfirmA).toHaveBeenCalledTimes(1);
+      // 참조만 바꿔서 rerender → effect 재실행 트리거. dismissed/hasEffectiveOrigin은 그대로.
+      rerender({ ...props, onConfirmStation: onConfirmB });
+      expect(onConfirmA).toHaveBeenCalledTimes(1);
+      expect(onConfirmB).not.toHaveBeenCalled();
+    });
+
+    it('origin이 결정되었다가 해제 후 같은 station 매칭 시 다시 자동 확정', () => {
+      const onConfirmStation = jest.fn();
+      const { result, rerender, props } = setup({
+        locationUncertain: true,
+        wifiStation: YONGMASAN,
+        onConfirmStation,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(onConfirmStation).toHaveBeenCalledTimes(1);
+      // origin 결정 (caller가 customOrigin 적용 → hasEffectiveOrigin=true)
+      rerender({ ...props, hasEffectiveOrigin: true });
+      // origin 해제 (사용자가 reset)
+      rerender({ ...props, hasEffectiveOrigin: false });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(onConfirmStation).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('사용자 인터랙션', () => {
+    it('onCardTap → onConfirmStation 호출 + 모달 dismiss', () => {
+      const onConfirmStation = jest.fn();
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+        onConfirmStation,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.visible).toBe(true);
+      act(() => {
+        result.current.onCardTap(YONGMASAN);
+      });
+      expect(onConfirmStation).toHaveBeenCalledWith(YONGMASAN);
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('onClose → 모달 dismiss + onConfirmStation 미호출 (prior state 보존)', () => {
+      const onConfirmStation = jest.fn();
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+        onConfirmStation,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      act(() => {
+        result.current.onClose();
+      });
+      expect(result.current.visible).toBe(false);
+      expect(onConfirmStation).not.toHaveBeenCalled();
+    });
+
+    it('dismiss 후 같은 uncertain 세션 동안 재오픈 안 됨', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      act(() => {
+        result.current.onClose();
+      });
+      expect(result.current.visible).toBe(false);
+      // 시간이 또 흘러도 같은 세션이라 재오픈 안 함.
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('dismiss 후 uncertain 해소되었다가 다시 발생 → 모달 재오픈 가능', () => {
+      const { result, rerender, props } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      act(() => {
+        result.current.onClose();
+      });
+      // uncertain 해소
+      rerender({ ...props, locationUncertain: false });
+      // 다시 uncertain
+      rerender({ ...props, locationUncertain: true });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.visible).toBe(true);
+    });
+  });
+});

--- a/src/features/nearest-station/hooks/useCurrentStationConfirmModal.ts
+++ b/src/features/nearest-station/hooks/useCurrentStationConfirmModal.ts
@@ -1,0 +1,141 @@
+/**
+ * F4 1탭 현재역 확정 모달 트리거 hook (#914, Epic #912).
+ *
+ * `useStationCandidates`(F2/F3 narrow)로 후보를 산출하고, 자동 추정이 길어지면(locationUncertain
+ * 지속) 모달을 띄울지 결정한다.
+ *
+ *  - origin이 이미 결정돼 있으면(`hasEffectiveOrigin=true`) 모달 차단 — 사용자 흐름 방해 없음.
+ *  - locationUncertain이 `uncertainThresholdMs`(기본 8s) 이상 지속되면 후보 산출 후 트리거.
+ *  - `isAutoConfirmed`(wifi 단일 매칭, GPS 단일 후보 등)면 모달 없이 즉시 `onConfirmStation`
+ *    호출 + `autoConfirmedStation` 노출 → caller가 toast 표시.
+ *  - 후보 2~3개면 `visible=true` → 모달 1탭 확정.
+ *  - 후보 0개면 모달은 띄우지만 검색 fallback UI(`onSearchFallback`)로 안내.
+ *  - 사용자 close = 상태 보존(아무 부수효과 없음, dismiss = 검색은 호출자 정책).
+ *
+ * 본 hook은 모달 visibility 결정 + 후보 산출만 담당. customOrigin 적용/검색 모달 오픈은
+ * HomeScreen이 callback으로 받아 wire 한다.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useStationCandidates } from './useStationCandidates';
+import type { Station } from '../../../shared/types/station';
+
+/** locationUncertain이 이 시간 이상 지속되면 트리거. cold start 직후 깜빡임을 흡수. */
+export const DEFAULT_UNCERTAIN_THRESHOLD_MS = 8_000;
+
+export interface UseCurrentStationConfirmModalInputs {
+  /** `useFusedNearestStation().locationUncertain`. */
+  readonly locationUncertain: boolean;
+  /** GPS 좌표. F4 candidates 산출 입력. */
+  readonly userLocation: { readonly lat: number; readonly lng: number } | null;
+  /** F2 wifi SSID 매칭 결과. 미가용이면 null. */
+  readonly wifiStation: Station | null;
+  /** origin이 이미 결정돼 있으면 모달 차단 — UX 방해 회피. */
+  readonly hasEffectiveOrigin: boolean;
+  /** 사용자 1탭 또는 자동 확정 시 호출 (customOrigin 적용). */
+  readonly onConfirmStation: (station: Station) => void;
+  /** uncertain 지속 임계값(ms). 기본 8000. */
+  readonly uncertainThresholdMs?: number;
+}
+
+export interface UseCurrentStationConfirmModalResult {
+  /** 모달 표시 여부. */
+  readonly visible: boolean;
+  /** UI에 뿌릴 후보. */
+  readonly candidates: readonly Station[];
+  /** 강조 표시 후보. */
+  readonly topPick: Station | null;
+  /** 카드 탭 핸들러 (caller가 modal 추가 close 처리 불필요 — 내부에서 close 처리). */
+  readonly onCardTap: (station: Station) => void;
+  /** 모달 X close 핸들러. 상태 보존(아무 부수효과 없음). */
+  readonly onClose: () => void;
+  /** 자동 확정된 station — 1회성 신호. caller가 toast 표시 후 `consumeAutoConfirmed` 호출. */
+  readonly autoConfirmedStation: Station | null;
+  /** autoConfirmedStation 신호 소비 — toast가 사라진 뒤 호출. */
+  readonly consumeAutoConfirmed: () => void;
+}
+
+export function useCurrentStationConfirmModal(
+  inputs: UseCurrentStationConfirmModalInputs,
+): UseCurrentStationConfirmModalResult {
+  const {
+    locationUncertain,
+    userLocation,
+    wifiStation,
+    hasEffectiveOrigin,
+    onConfirmStation,
+    uncertainThresholdMs = DEFAULT_UNCERTAIN_THRESHOLD_MS,
+  } = inputs;
+
+  const { candidates, topPick, isAutoConfirmed } = useStationCandidates({
+    userLocation,
+    wifiStation,
+  });
+
+  const [uncertainSustained, setUncertainSustained] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [autoConfirmedStation, setAutoConfirmedStation] = useState<Station | null>(null);
+  const autoConfirmedRef = useRef<string | null>(null);
+
+  // locationUncertain false 또는 origin 결정되면 sustained 타이머 reset + 사용자 dismiss 해제.
+  // 같은 uncertain 세션을 한 번 닫으면 origin이 바뀌거나 uncertain이 해소될 때까지 다시 안 뜬다.
+  useEffect(() => {
+    if (!locationUncertain || hasEffectiveOrigin) {
+      setUncertainSustained(false);
+      setDismissed(false);
+      return;
+    }
+    const handle = setTimeout(() => setUncertainSustained(true), uncertainThresholdMs);
+    return () => clearTimeout(handle);
+  }, [locationUncertain, hasEffectiveOrigin, uncertainThresholdMs]);
+
+  // 자동 확정: visible 조건 충족 + isAutoConfirmed이면 모달 없이 즉시 적용. 같은 station 재진입은 1회만.
+  useEffect(() => {
+    if (!uncertainSustained || dismissed || hasEffectiveOrigin) return;
+    if (!isAutoConfirmed || topPick === null) return;
+    if (autoConfirmedRef.current === topPick.id) return;
+    autoConfirmedRef.current = topPick.id;
+    setAutoConfirmedStation(topPick);
+    onConfirmStation(topPick);
+  }, [uncertainSustained, dismissed, hasEffectiveOrigin, isAutoConfirmed, topPick, onConfirmStation]);
+
+  // 자동 확정 ref reset — origin이 변경(또는 해제)되면 다음 uncertain 세션에서 다시 자동 확정 가능.
+  useEffect(() => {
+    if (!hasEffectiveOrigin) return;
+    autoConfirmedRef.current = null;
+  }, [hasEffectiveOrigin]);
+
+  const onCardTap = useCallback(
+    (station: Station) => {
+      setDismissed(true);
+      onConfirmStation(station);
+    },
+    [onConfirmStation],
+  );
+
+  const onClose = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  const consumeAutoConfirmed = useCallback(() => {
+    setAutoConfirmedStation(null);
+  }, []);
+
+  const visible = useMemo(
+    () =>
+      uncertainSustained &&
+      !dismissed &&
+      !hasEffectiveOrigin &&
+      !isAutoConfirmed,
+    [uncertainSustained, dismissed, hasEffectiveOrigin, isAutoConfirmed],
+  );
+
+  return {
+    visible,
+    candidates,
+    topPick,
+    onCardTap,
+    onClose,
+    autoConfirmedStation,
+    consumeAutoConfirmed,
+  };
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -46,6 +46,8 @@ import { useTripBoundAlarmScheduler } from '../features/alarm/hooks/useTripBound
 import { useBoardingLockAdvancer } from '../features/alarm/hooks/useBoardingLockAdvancer';
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
 import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
+import { useCurrentStationConfirmModal } from '../features/nearest-station/hooks/useCurrentStationConfirmModal';
+import { CurrentStationConfirmModal } from '../features/nearest-station/components/CurrentStationConfirmModal';
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
 import { Toast } from '../shared/ui/Toast';
@@ -58,6 +60,7 @@ import { BoardingLockHopCard } from '../features/alarm/components/BoardingLockHo
 import { resolveNextAdjacentStationName } from '../features/route/utils/nextAdjacentStation';
 import { getApproachLine } from '../features/route/utils/approachLine';
 import type { Stop } from '../shared/types/journey';
+import type { Station } from '../shared/types/station';
 
 const logger = createLogger('HomeScreen');
 
@@ -70,6 +73,7 @@ export default function HomeScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const customOrigin = useDestinationStore((s) => s.customOrigin);
+  const setCustomOrigin = useDestinationStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useDestinationStore((s) => s.loadCustomOrigin);
   const addFavorite = useFavoritesStore((s) => s.addFavorite);
   const removeFavorite = useFavoritesStore((s) => s.removeFavorite);
@@ -147,6 +151,37 @@ export default function HomeScreen() {
   //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).
   const { subsurface: barometerSubsurface } = useBarometer();
   const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, barometerSubsurface);
+
+  // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
+  // 카드로 노출, 1탭 = customOrigin 적용. wifiStation 네이티브 브릿지(F2 후속)는 미연결이라 null.
+  const [confirmAutoToast, setConfirmAutoToast] = useState<string | null>(null);
+  const handleConfirmStation = useCallback(
+    (station: Station) => {
+      setCustomOrigin(station);
+    },
+    [setCustomOrigin],
+  );
+  const confirmModal = useCurrentStationConfirmModal({
+    locationUncertain,
+    userLocation,
+    wifiStation: null,
+    hasEffectiveOrigin: customOrigin !== null || result?.station != null,
+    onConfirmStation: handleConfirmStation,
+  });
+  useEffect(() => {
+    if (confirmModal.autoConfirmedStation) {
+      setConfirmAutoToast(
+        t('currentStationConfirm.autoConfirmed', {
+          name: getStationDisplayName(confirmModal.autoConfirmedStation),
+        }),
+      );
+      confirmModal.consumeAutoConfirmed();
+    }
+  }, [confirmModal.autoConfirmedStation, confirmModal.consumeAutoConfirmed, t]);
+  const handleConfirmAutoToastDismiss = useCallback(() => setConfirmAutoToast(null), []);
+  // 검색 fallback 실제 wire는 후속 PR — 현재는 onClose와 동일 동작(모달만 닫음).
+  // (origin 검색용 picker는 별도 component 필요. DestinationPicker는 목적지 전용.)
+
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,
@@ -956,6 +991,23 @@ export default function HomeScreen() {
           }}
         />
       )}
+
+      {/* #914 (F4) — 1탭 현재역 확정. wifi 단일 매칭은 자동 확정 + toast 노출,
+           GPS 다중 후보는 모달 1탭 확정, 후보 0개는 검색 fallback 안내. */}
+      <CurrentStationConfirmModal
+        visible={confirmModal.visible}
+        candidates={confirmModal.candidates}
+        topPick={confirmModal.topPick}
+        onConfirm={confirmModal.onCardTap}
+        onSearchFallback={confirmModal.onClose}
+        onClose={confirmModal.onClose}
+      />
+      <Toast
+        visible={confirmAutoToast !== null}
+        message={confirmAutoToast ?? ''}
+        onDismiss={handleConfirmAutoToastDismiss}
+        testID="current-station-auto-confirm-toast"
+      />
 
       <DestinationPicker
         visible={pickerVisible}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -130,7 +130,8 @@
     "topPickHint": "Best match",
     "empty": "No nearby station found",
     "searchFallback": "Search instead",
-    "close": "Close"
+    "close": "Close",
+    "autoConfirmed": "Confirmed as {{name}}"
   },
   "sleepModeGuide": {
     "title": "Sleep mode notice",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -130,7 +130,8 @@
     "topPickHint": "おすすめ",
     "empty": "近くの駅が見つかりませんでした",
     "searchFallback": "検索で選ぶ",
-    "close": "閉じる"
+    "close": "閉じる",
+    "autoConfirmed": "{{name}}に確定しました"
   },
   "sleepModeGuide": {
     "title": "おやすみモードのご案内",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -130,7 +130,8 @@
     "topPickHint": "추천",
     "empty": "주변 역을 찾지 못했습니다",
     "searchFallback": "검색으로 선택",
-    "close": "닫기"
+    "close": "닫기",
+    "autoConfirmed": "{{name}}으로 확정됨"
   },
   "sleepModeGuide": {
     "title": "취침 모드 안내",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -130,7 +130,8 @@
     "topPickHint": "推荐",
     "empty": "附近未找到车站",
     "searchFallback": "通过搜索选择",
-    "close": "关闭"
+    "close": "关闭",
+    "autoConfirmed": "已确认为{{name}}"
   },
   "sleepModeGuide": {
     "title": "睡眠模式提示",


### PR DESCRIPTION
## Summary
Epic #912 P0 F4 후속 PR. PR #930에서 추가한 `useStationCandidates` hook + `CurrentStationConfirmModal` 컴포넌트를 HomeScreen에 wire하여 production에서 1탭 현재역 확정 흐름을 활성화.

- `useCurrentStationConfirmModal` 신규 hook — `locationUncertain` 지속(기본 8s) + origin 미결정 시 모달 트리거. `isAutoConfirmed`면 모달 없이 즉시 customOrigin 적용 + autoConfirmed 신호(1회).
- HomeScreen: 모달 + autoConfirmed Toast mount, `customOrigin` setter로 onConfirmStation 연결.
- `currentStationConfirm.autoConfirmed` 키 4 locale 추가.

## 동작 시나리오
- 자동 추정 성공(`effectiveOrigin` truthy) → 모달 안 뜸 (UX 방해 회피)
- locationUncertain 8s 지속 + GPS 후보 1개 → 자동 확정 + "용마산으로 확정됨" Toast
- locationUncertain 8s 지속 + GPS 후보 2~3개 → 모달 + 1탭 확정
- locationUncertain 8s 지속 + 후보 0개 → 모달 + 검색 fallback 안내 (실제 search wire는 후속)
- 사용자 X 닫기 → state 보존 (no-op). 같은 uncertain 세션 동안 재오픈 안 됨

## 슬라이싱 의도 (Refs #914)
**본 PR 제외, 후속 예정**:
- F2 네이티브 SSID 브릿지 (NEHotspotNetwork/WifiManager → `wifiStation` prop) — 현재 null
- 검색 fallback 실제 wire (origin 전용 search modal — DestinationPicker는 목적지 전용)

## 코드리뷰 (self)
- `confirmModal` ref churn → 분해 + 안정 callback. 무한 루프 가드(autoConfirmedRef + consumeAutoConfirmed) 검증됨.
- `wifiStation: null` graceful — useStationCandidates가 GPS-only로 동작.
- `hasEffectiveOrigin = customOrigin !== null || result?.station != null` → cold start 첫 GPS 잡히면 즉시 트리거 해제.

## Test plan
- [x] `npm test` 통과 (218 suites, 3929 tests, 100% coverage)
- [x] `npm run type-check` 통과
- [x] `npx eslint` 통과
- [x] 16 새 테스트 (트리거 게이트 7, 자동 확정 4, 인터랙션 4, ref 가드 1)

Refs #912
Refs #914