### PR TITLE
feat(#924): D1 stationRoute wire — 환승 auto-detect + A1 lock + F4 모달

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -1,0 +1,415 @@
+/* eslint-disable import/no-restricted-paths --
+ * 대상 hook(useTransferAutoDetect)이 본질적 cross-feature orchestrator로 file-level 옵트인되어
+ * 있으므로 그 테스트도 동일 정책으로 nearest-station type을 직접 import한다.
+ */
+/**
+ * #924 — useTransferAutoDetect (D1 후속 PR — production wire).
+ *
+ * pure 알고리즘은 transferDetect.test.ts에서 커버. 본 테스트는 hook 차원에서:
+ *   - 다른 노선 arrival 수집 + boardingLine 제외
+ *   - 단일 후보 → onAutoLock 호출 + idempotency
+ *   - 다중 후보 → 모달 open + selectLine으로 hydrate + dismiss 처리
+ *   - planned route transfer waypoint이면 detect skip
+ *   - 환승역 벗어나면 dismiss flag 리셋
+ */
+import { act, renderHook } from '@testing-library/react-native';
+import { useTransferAutoDetect } from '../useTransferAutoDetect';
+import { MOCK_STATIONS, makeArrivalInfo } from '../../../../testUtils/fixtures';
+import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { NearestStationsResult, Station } from '../../../../shared/types/station';
+import type { AutoLockCandidate } from '../../../nearest-station/api/boardingLockSync';
+
+// 동대문역사문화공원 — 2호선/4호선/5호선 환승역 fixture(테스트 전용 stations.json 무관).
+const DDP_2: Station = { id: '0205', name: '동대문역사문화공원', line: '2', lineColor: '#009D3E', lat: 37.565, lng: 127.008 };
+const DDP_4: Station = { id: '0405', name: '동대문역사문화공원', line: '4', lineColor: '#00A0E2', lat: 37.565, lng: 127.008 };
+const DDP_5: Station = { id: '0505', name: '동대문역사문화공원', line: '5', lineColor: '#996CAC', lat: 37.565, lng: 127.008 };
+
+const transferNearest: NearestStationsResult = {
+  primary: DDP_2,
+  variants: [DDP_2, DDP_4, DDP_5],
+  distanceKm: 0.03,
+  isTransfer: true,
+};
+
+const nonTransferNearest: NearestStationsResult = {
+  primary: MOCK_STATIONS.gangnam,
+  variants: [MOCK_STATIONS.gangnam],
+  distanceKm: 0.03,
+  isTransfer: false,
+};
+
+function makeArrival(up: ArrivalInfo[] = [], down: ArrivalInfo[] = []): StationArrival {
+  return { up, down };
+}
+
+function makeLock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: 'dest-1',
+    trainCode: 'T001',
+    boardingStationId: DDP_2.id,
+    boardingLine: '2',
+    boardedAt: Date.now(),
+    expectedDurationMs: 30 * 60_000,
+    ...overrides,
+  };
+}
+
+function baseInputs(overrides: Partial<Parameters<typeof useTransferAutoDetect>[0]> = {}) {
+  return {
+    nearestStations: transferNearest,
+    motionStationary: false,
+    arrival: makeArrival(),
+    boardingLock: null,
+    route: null,
+    destinationName: null,
+    onAutoLock: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('useTransferAutoDetect', () => {
+  it('단일 후보 detect → onAutoLock 호출 (현재 boardingLine 제외)', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival(
+      [makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' })],
+      [makeArrivalInfo({ destination: '잠실', arrivalSeconds: 30, line: '2', trainCode: 'T-2-A' })],
+    );
+    renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival, boardingLock: makeLock(), onAutoLock })),
+    );
+    expect(onAutoLock).toHaveBeenCalledTimes(1);
+    const candidate: AutoLockCandidate = onAutoLock.mock.calls[0][0];
+    expect(candidate).toEqual({ trainCode: 'T-4-A', line: '4', subwayId: '1004' });
+  });
+
+  it('motionStationary=true(정지) → no-op', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival(
+      [makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' })],
+    );
+    renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival, motionStationary: true, onAutoLock })),
+    );
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('nearestStations=null → no-op', () => {
+    const onAutoLock = jest.fn();
+    renderHook(() => useTransferAutoDetect(baseInputs({ nearestStations: null, onAutoLock })));
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('환승역 아님 → no-op', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival(
+      [makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' })],
+    );
+    renderHook(() =>
+      useTransferAutoDetect(baseInputs({ nearestStations: nonTransferNearest, arrival, onAutoLock })),
+    );
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('다중 후보 → 모달 open + modalCandidates 노출', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const { result } = renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
+    );
+    expect(onAutoLock).not.toHaveBeenCalled();
+    expect(result.current.modalVisible).toBe(true);
+    expect(result.current.modalCandidates.map((s) => s.line)).toEqual(['4', '5']);
+    expect(result.current.candidateLines).toEqual(['4', '5']);
+  });
+
+  it('selectLine → 해당 line의 임박 trainCode로 onAutoLock + 모달 close', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5-A' }),
+    ]);
+    const { result } = renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
+    );
+    act(() => result.current.selectLine('5'));
+    expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-5-A', line: '5', subwayId: '1005' });
+    expect(result.current.modalVisible).toBe(false);
+  });
+
+  it('dismissModal → 같은 환승역에서 재오픈 안 됨, 다른 역으로 이동하면 재오픈 가능', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
+      { initialProps: baseInputs({ arrival, onAutoLock }) },
+    );
+    expect(result.current.modalVisible).toBe(true);
+    act(() => result.current.dismissModal());
+    expect(result.current.modalVisible).toBe(false);
+    // 같은 station에서 새 polling — 다시 detect 일어나도 모달은 닫힌 채.
+    rerender(baseInputs({ arrival, onAutoLock }));
+    expect(result.current.modalVisible).toBe(false);
+    // 환승역을 벗어남 → 다른 환승역에 다시 도착하면 모달이 다시 열린다.
+    rerender(baseInputs({ nearestStations: nonTransferNearest, arrival, onAutoLock }));
+    rerender(baseInputs({ arrival, onAutoLock }));
+    expect(result.current.modalVisible).toBe(true);
+  });
+
+  it('단일 후보 idempotency — 같은 trainCode polling 반복돼도 onAutoLock 1회', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
+    ]);
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
+      { initialProps: baseInputs({ arrival, onAutoLock }) },
+    );
+    rerender(baseInputs({ arrival, onAutoLock }));
+    rerender(baseInputs({ arrival, onAutoLock }));
+    expect(onAutoLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('단일 후보 — 다른 trainCode가 들어오면 새로 hydrate', () => {
+    const onAutoLock = jest.fn();
+    const arrivalA = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
+    ]);
+    const arrivalB = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-B' }),
+    ]);
+    const { rerender } = renderHook((props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props), {
+      initialProps: baseInputs({ arrival: arrivalA, onAutoLock }),
+    });
+    rerender(baseInputs({ arrival: arrivalB, onAutoLock }));
+    expect(onAutoLock).toHaveBeenCalledTimes(2);
+    expect(onAutoLock.mock.calls[1][0].trainCode).toBe('T-4-B');
+  });
+
+  it('도착 데이터 없음 → trainCode pick 실패 → no-op', () => {
+    const onAutoLock = jest.fn();
+    renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival: null, onAutoLock })),
+    );
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('도착 음수만 있음(이미 지나간 차) → no-op', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: -10, line: '4', trainCode: 'T-4' }),
+    ]);
+    renderHook(() => useTransferAutoDetect(baseInputs({ arrival, onAutoLock })));
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('boardingLock이 후보 line과 같음 → 자기 노선은 제외되어 후보 0', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 60, line: '5', trainCode: 'T-5' }),
+    ]);
+    renderHook(() =>
+      useTransferAutoDetect(
+        baseInputs({ arrival, boardingLock: makeLock({ boardingLine: '5' }), onAutoLock }),
+      ),
+    );
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('planned route의 transfer waypoint면 detect skip (useTransferTrainList가 책임)', () => {
+    // findActiveTransferContext가 non-null을 반환하도록: 환승 route + 현재역이 환승 waypoint.
+    // 간단 fixture: 충무로(3↔4) 환승 route.
+    // stations.json 의존을 피하기 위해 lock+route 모두 fixture로 구성하되,
+    // findActiveTransferContext는 resolveAllTargets를 거치므로 실 route 사용.
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+    ]);
+    // TransferRoute 실 shape. resolveAllTargets는 transferName/destinationName으로 매칭.
+    const route = {
+      type: 'transfer' as const,
+      transferName: '충무로',
+      fromLine: '3' as const,
+      toLine: '4' as const,
+      stopsToTransfer: 1,
+      stopsFromTransfer: 2,
+      secondsToTransfer: 60,
+      secondsFromTransfer: 120,
+    };
+    const chungmuro3: Station = { id: '0330', name: '충무로', line: '3', lineColor: '#EF7C1C', lat: 37.561, lng: 126.994 };
+    const nearestChungmuro: NearestStationsResult = {
+      primary: chungmuro3,
+      variants: [chungmuro3],
+      distanceKm: 0.03,
+      isTransfer: true,
+    };
+    renderHook(() =>
+      useTransferAutoDetect(
+        baseInputs({
+          nearestStations: nearestChungmuro,
+          arrival,
+          boardingLock: makeLock({ boardingLine: '3', boardingStationId: chungmuro3.id }),
+          route,
+          destinationName: '서울역',
+          onAutoLock,
+        }),
+      ),
+    );
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('variants에 candidate line 없음 → 모달 후보 0 (selectLine 호출해도 no-op)', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    // variants에 4호선만 있고 5호선 없음 — 5호선은 modalCandidates에서 제외.
+    const partialNearest: NearestStationsResult = {
+      primary: DDP_2,
+      variants: [DDP_2, DDP_4], // 5호선 없음
+      distanceKm: 0.03,
+      isTransfer: true,
+    };
+    const { result } = renderHook(() =>
+      useTransferAutoDetect(baseInputs({ nearestStations: partialNearest, arrival, onAutoLock })),
+    );
+    expect(result.current.candidateLines).toEqual(['4', '5']);
+    expect(result.current.modalCandidates.map((s) => s.line)).toEqual(['4']);
+  });
+
+  it('selectLine — arrival이 사라진 뒤 호출되면 trainCode pick 실패로 no-op', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
+      { initialProps: baseInputs({ arrival, onAutoLock }) },
+    );
+    // arrival null로 전환 — modalVisible은 close 효과 effect로 false 가지만 selectLine 콜백은 유효.
+    rerender(baseInputs({ arrival: null, onAutoLock }));
+    onAutoLock.mockClear();
+    act(() => result.current.selectLine('4'));
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('currentStation 없는 동안 selectLine 호출 — 안전 no-op', () => {
+    const onAutoLock = jest.fn();
+    const { result } = renderHook(() =>
+      useTransferAutoDetect(baseInputs({ nearestStations: null, onAutoLock })),
+    );
+    act(() => result.current.selectLine('4'));
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('환승역에서 GPS 끊김(stationKey → null) → lastAutoLockedKey 리셋되어 재진입 시 다시 hydrate', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
+    ]);
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
+      { initialProps: baseInputs({ arrival, onAutoLock }) },
+    );
+    expect(onAutoLock).toHaveBeenCalledTimes(1);
+    // GPS 끊김 — nearestStations null.
+    rerender(baseInputs({ nearestStations: null, arrival, onAutoLock }));
+    // 다시 같은 환승역 진입 — 새 trainCode 같아도 ref가 리셋되었으므로 재호출.
+    rerender(baseInputs({ arrival, onAutoLock }));
+    expect(onAutoLock).toHaveBeenCalledTimes(2);
+  });
+
+  it('단일 후보 — 같은 trainCode + 새 arrival object → key 일치로 hydrate skip', () => {
+    // 같은 station + 같은 trainCode이지만 arrival 객체 ref만 새로 → effect 재실행 + key 가드 분기.
+    const onAutoLock = jest.fn();
+    const makeArrivalA = () =>
+      makeArrival([
+        makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
+      ]);
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
+      { initialProps: baseInputs({ arrival: makeArrivalA(), onAutoLock }) },
+    );
+    expect(onAutoLock).toHaveBeenCalledTimes(1);
+    // 새 arrival 객체(ref만 다름, 데이터 동일) → effect 재실행하지만 ref key가 같으면 skip.
+    rerender(baseInputs({ arrival: makeArrivalA(), onAutoLock }));
+    expect(onAutoLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('selectLine — 같은 line의 train이 여러 개면 가장 임박한 trainCode 선택', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival(
+      [
+        makeArrivalInfo({ destination: '서울역', arrivalSeconds: 120, line: '4', trainCode: 'T-4-LATE' }),
+        makeArrivalInfo({ destination: '서울역', arrivalSeconds: 30, line: '4', trainCode: 'T-4-EARLY' }),
+      ],
+      [makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' })],
+    );
+    const { result } = renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
+    );
+    act(() => result.current.selectLine('4'));
+    expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-4-EARLY', line: '4', subwayId: '1004' });
+  });
+
+  it('selectLine — 같은 line의 두 번째 train이 더 늦으면 첫 번째 유지(best 변경 없음 분기)', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival(
+      [
+        makeArrivalInfo({ destination: '서울역', arrivalSeconds: 30, line: '4', trainCode: 'T-4-EARLY' }),
+        makeArrivalInfo({ destination: '서울역', arrivalSeconds: 120, line: '4', trainCode: 'T-4-LATE' }),
+      ],
+      [makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' })],
+    );
+    const { result } = renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
+    );
+    act(() => result.current.selectLine('4'));
+    expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-4-EARLY', line: '4', subwayId: '1004' });
+  });
+
+  it('selectLine — arrival에 해당 line train이 없어도 안전 no-op (best=null 분기)', () => {
+    // multi 후보 detect로 모달 open된 상태에서, 새 polling으로 arrival에서 한 line이 사라진 뒤
+    // 사용자가 사라진 line을 선택한 케이스. pickImminentTrainCode가 best=null → trainCode null.
+    const onAutoLock = jest.fn();
+    const arrivalMulti = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const arrivalOnly5 = makeArrival([
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
+      { initialProps: baseInputs({ arrival: arrivalMulti, onAutoLock }) },
+    );
+    rerender(baseInputs({ arrival: arrivalOnly5, onAutoLock }));
+    // 사용자가 사라진 line 4 선택 — pickImminentTrainCode에서 매칭 없음 → no-op.
+    onAutoLock.mockClear();
+    act(() => result.current.selectLine('4'));
+    expect(onAutoLock).not.toHaveBeenCalled();
+  });
+
+  it('detect → 단일 후보로 hydrate된 후 candidates가 비면(arrival 사라짐) 모달 닫힘', () => {
+    const onAutoLock = jest.fn();
+    const arrivalMulti = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const { result, rerender } = renderHook((props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props), {
+      initialProps: baseInputs({ arrival: arrivalMulti, onAutoLock }),
+    });
+    expect(result.current.modalVisible).toBe(true);
+    // 다음 polling — 도착 데이터가 비면 후보 0 → 모달 close.
+    rerender(baseInputs({ arrival: null, onAutoLock }));
+    expect(result.current.modalVisible).toBe(false);
+  });
+});

--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -68,6 +68,22 @@ function baseInputs(overrides: Partial<Parameters<typeof useTransferAutoDetect>[
   };
 }
 
+/** 4호선 60s + 5호선 90s 두 줄 임박. 다중 후보 detect의 표준 fixture. */
+function multiCandidateArrival(): StationArrival {
+  return makeArrival([
+    makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+    makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+  ]);
+}
+
+/** rerender-capable hook 실행. props prop으로 동적 재실행. */
+function renderTransferDetect(initialProps: Parameters<typeof useTransferAutoDetect>[0]) {
+  return renderHook(
+    (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
+    { initialProps },
+  );
+}
+
 describe('useTransferAutoDetect', () => {
   it('단일 후보 detect → onAutoLock 호출 (현재 boardingLine 제외)', () => {
     const onAutoLock = jest.fn();
@@ -113,12 +129,8 @@ describe('useTransferAutoDetect', () => {
 
   it('다중 후보 → 모달 open + modalCandidates 노출', () => {
     const onAutoLock = jest.fn();
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
     const { result } = renderHook(() =>
-      useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
+      useTransferAutoDetect(baseInputs({ arrival: multiCandidateArrival(), onAutoLock })),
     );
     expect(onAutoLock).not.toHaveBeenCalled();
     expect(result.current.modalVisible).toBe(true);
@@ -142,14 +154,8 @@ describe('useTransferAutoDetect', () => {
 
   it('dismissModal → 같은 환승역에서 재오픈 안 됨, 다른 역으로 이동하면 재오픈 가능', () => {
     const onAutoLock = jest.fn();
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
-    const { result, rerender } = renderHook(
-      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
-      { initialProps: baseInputs({ arrival, onAutoLock }) },
-    );
+    const arrival = multiCandidateArrival();
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
     expect(result.current.modalVisible).toBe(true);
     act(() => result.current.dismissModal());
     expect(result.current.modalVisible).toBe(false);
@@ -167,10 +173,7 @@ describe('useTransferAutoDetect', () => {
     const arrival = makeArrival([
       makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
     ]);
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
-      { initialProps: baseInputs({ arrival, onAutoLock }) },
-    );
+    const { rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
     rerender(baseInputs({ arrival, onAutoLock }));
     rerender(baseInputs({ arrival, onAutoLock }));
     expect(onAutoLock).toHaveBeenCalledTimes(1);
@@ -184,9 +187,7 @@ describe('useTransferAutoDetect', () => {
     const arrivalB = makeArrival([
       makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-B' }),
     ]);
-    const { rerender } = renderHook((props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props), {
-      initialProps: baseInputs({ arrival: arrivalA, onAutoLock }),
-    });
+    const { rerender } = renderTransferDetect(baseInputs({ arrival: arrivalA, onAutoLock }));
     rerender(baseInputs({ arrival: arrivalB, onAutoLock }));
     expect(onAutoLock).toHaveBeenCalledTimes(2);
     expect(onAutoLock.mock.calls[1][0].trainCode).toBe('T-4-B');
@@ -266,10 +267,7 @@ describe('useTransferAutoDetect', () => {
 
   it('variants에 candidate line 없음 → 모달 후보 0 (selectLine 호출해도 no-op)', () => {
     const onAutoLock = jest.fn();
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
+    const arrival = multiCandidateArrival();
     // variants에 4호선만 있고 5호선 없음 — 5호선은 modalCandidates에서 제외.
     const partialNearest: NearestStationsResult = {
       primary: DDP_2,
@@ -286,14 +284,8 @@ describe('useTransferAutoDetect', () => {
 
   it('selectLine — arrival이 사라진 뒤 호출되면 trainCode pick 실패로 no-op', () => {
     const onAutoLock = jest.fn();
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
-    const { result, rerender } = renderHook(
-      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
-      { initialProps: baseInputs({ arrival, onAutoLock }) },
-    );
+    const arrival = multiCandidateArrival();
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
     // arrival null로 전환 — modalVisible은 close 효과 effect로 false 가지만 selectLine 콜백은 유효.
     rerender(baseInputs({ arrival: null, onAutoLock }));
     onAutoLock.mockClear();
@@ -315,10 +307,7 @@ describe('useTransferAutoDetect', () => {
     const arrival = makeArrival([
       makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
     ]);
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
-      { initialProps: baseInputs({ arrival, onAutoLock }) },
-    );
+    const { rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
     expect(onAutoLock).toHaveBeenCalledTimes(1);
     // GPS 끊김 — nearestStations null.
     rerender(baseInputs({ nearestStations: null, arrival, onAutoLock }));
@@ -334,41 +323,35 @@ describe('useTransferAutoDetect', () => {
       makeArrival([
         makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
       ]);
-    const { rerender } = renderHook(
-      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
-      { initialProps: baseInputs({ arrival: makeArrivalA(), onAutoLock }) },
-    );
+    const { rerender } = renderTransferDetect(baseInputs({ arrival: makeArrivalA(), onAutoLock }));
     expect(onAutoLock).toHaveBeenCalledTimes(1);
     // 새 arrival 객체(ref만 다름, 데이터 동일) → effect 재실행하지만 ref key가 같으면 skip.
     rerender(baseInputs({ arrival: makeArrivalA(), onAutoLock }));
     expect(onAutoLock).toHaveBeenCalledTimes(1);
   });
 
-  it('selectLine — 같은 line의 train이 여러 개면 가장 임박한 trainCode 선택', () => {
-    const onAutoLock = jest.fn();
-    const arrival = makeArrival(
-      [
+  // pickImminentTrainCode가 best replace(later→earlier) 분기와 skip(earlier→later) 분기를
+  // 둘 다 타도록 두 순서를 it.each로 압축.
+  it.each<{ label: string; ups: ArrivalInfo[] }>([
+    {
+      label: 'LATE-first → best replace 분기',
+      ups: [
         makeArrivalInfo({ destination: '서울역', arrivalSeconds: 120, line: '4', trainCode: 'T-4-LATE' }),
         makeArrivalInfo({ destination: '서울역', arrivalSeconds: 30, line: '4', trainCode: 'T-4-EARLY' }),
       ],
-      [makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' })],
-    );
-    const { result } = renderHook(() =>
-      useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
-    );
-    act(() => result.current.selectLine('4'));
-    expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-4-EARLY', line: '4', subwayId: '1004' });
-  });
-
-  it('selectLine — 같은 line의 두 번째 train이 더 늦으면 첫 번째 유지(best 변경 없음 분기)', () => {
-    const onAutoLock = jest.fn();
-    const arrival = makeArrival(
-      [
+    },
+    {
+      label: 'EARLY-first → best 유지(skip) 분기',
+      ups: [
         makeArrivalInfo({ destination: '서울역', arrivalSeconds: 30, line: '4', trainCode: 'T-4-EARLY' }),
         makeArrivalInfo({ destination: '서울역', arrivalSeconds: 120, line: '4', trainCode: 'T-4-LATE' }),
       ],
-      [makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' })],
-    );
+    },
+  ])('selectLine — 같은 line 다중 train: $label 에서 EARLY 선택', ({ ups }) => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival(ups, [
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
     const { result } = renderHook(() =>
       useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
     );
@@ -380,17 +363,11 @@ describe('useTransferAutoDetect', () => {
     // multi 후보 detect로 모달 open된 상태에서, 새 polling으로 arrival에서 한 line이 사라진 뒤
     // 사용자가 사라진 line을 선택한 케이스. pickImminentTrainCode가 best=null → trainCode null.
     const onAutoLock = jest.fn();
-    const arrivalMulti = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
+    const arrivalMulti = multiCandidateArrival();
     const arrivalOnly5 = makeArrival([
       makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
     ]);
-    const { result, rerender } = renderHook(
-      (props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props),
-      { initialProps: baseInputs({ arrival: arrivalMulti, onAutoLock }) },
-    );
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival: arrivalMulti, onAutoLock }));
     rerender(baseInputs({ arrival: arrivalOnly5, onAutoLock }));
     // 사용자가 사라진 line 4 선택 — pickImminentTrainCode에서 매칭 없음 → no-op.
     onAutoLock.mockClear();
@@ -400,13 +377,7 @@ describe('useTransferAutoDetect', () => {
 
   it('detect → 단일 후보로 hydrate된 후 candidates가 비면(arrival 사라짐) 모달 닫힘', () => {
     const onAutoLock = jest.fn();
-    const arrivalMulti = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
-    const { result, rerender } = renderHook((props: Parameters<typeof useTransferAutoDetect>[0]) => useTransferAutoDetect(props), {
-      initialProps: baseInputs({ arrival: arrivalMulti, onAutoLock }),
-    });
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival: multiCandidateArrival(), onAutoLock }));
     expect(result.current.modalVisible).toBe(true);
     // 다음 polling — 도착 데이터가 비면 후보 0 → 모달 close.
     rerender(baseInputs({ arrival: null, onAutoLock }));

--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -68,11 +68,16 @@ function baseInputs(overrides: Partial<Parameters<typeof useTransferAutoDetect>[
   };
 }
 
+/** 5호선 90s 왕십리 임박 1줄. 다중 후보 fixture에서 line 5 슬롯으로 재사용. */
+function line5Arrival(): ArrivalInfo {
+  return makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' });
+}
+
 /** 4호선 60s + 5호선 90s 두 줄 임박. 다중 후보 detect의 표준 fixture. */
 function multiCandidateArrival(): StationArrival {
   return makeArrival([
     makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
-    makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    line5Arrival(),
   ]);
 }
 
@@ -140,15 +145,9 @@ describe('useTransferAutoDetect', () => {
 
   it('selectLine → 해당 line의 임박 trainCode로 onAutoLock + 모달 close', () => {
     const onAutoLock = jest.fn();
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5-A' }),
-    ]);
-    const { result } = renderHook(() =>
-      useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
-    );
+    const { result } = renderTransferDetect(baseInputs({ arrival: multiCandidateArrival(), onAutoLock }));
     act(() => result.current.selectLine('5'));
-    expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-5-A', line: '5', subwayId: '1005' });
+    expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-5', line: '5', subwayId: '1005' });
     expect(result.current.modalVisible).toBe(false);
   });
 
@@ -349,9 +348,7 @@ describe('useTransferAutoDetect', () => {
     },
   ])('selectLine — 같은 line 다중 train: $label 에서 EARLY 선택', ({ ups }) => {
     const onAutoLock = jest.fn();
-    const arrival = makeArrival(ups, [
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
+    const arrival = makeArrival(ups, [line5Arrival()]);
     const { result } = renderHook(() =>
       useTransferAutoDetect(baseInputs({ arrival, onAutoLock })),
     );
@@ -364,9 +361,7 @@ describe('useTransferAutoDetect', () => {
     // 사용자가 사라진 line을 선택한 케이스. pickImminentTrainCode가 best=null → trainCode null.
     const onAutoLock = jest.fn();
     const arrivalMulti = multiCandidateArrival();
-    const arrivalOnly5 = makeArrival([
-      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
-    ]);
+    const arrivalOnly5 = makeArrival([line5Arrival()]);
     const { result, rerender } = renderTransferDetect(baseInputs({ arrival: arrivalMulti, onAutoLock }));
     rerender(baseInputs({ arrival: arrivalOnly5, onAutoLock }));
     // 사용자가 사라진 line 4 선택 — pickImminentTrainCode에서 매칭 없음 → no-op.

--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -1,0 +1,242 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 본 hook은 nearest-station / arrival / alarm / route 신호를
+ * 조합해 환승 자동 detect를 수행한다. 본질적으로 cross-feature이라 file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #924 — route 미설정 환승 자동 detect — D1 후속 PR (production wire).
+ *
+ * pure 알고리즘(`transferDetect.ts`, #937 머지)을 런타임 신호와 묶어 다음을 한다:
+ *   1) 다른 노선 ArrivalRow를 모아 `detectTransfer`로 입력 — current `boardingLine`은 제외해
+ *      이미 타고 있는 노선이 후보로 잡히지 않게 한다.
+ *   2) 단일 후보 → A1 자동 lock (`hydrateLockFromCandidate` 재사용, `useBoardingLockController`)
+ *      — destination 미설정이면 lock 컨텍스트 부족으로 hydrate가 no-op이라 호출자 가드 불필요.
+ *   3) 다중 후보 → 모달 상태를 노출 — 호출자가 F4 1탭 모달(#914) UI 트리거.
+ *
+ * 본 hook이 막는 것(no-op 조건):
+ *   - 사용자가 이미 planned route의 transfer waypoint에 있다 (=`useTransferTrainList` context 활성).
+ *     기존 환승 list flow가 책임지므로 자동 detect는 중복 트리거 금지.
+ *   - 현재 boardingLock의 boardingLine으로만 후보가 들어와 있다 (=같은 노선 환승 데이터).
+ *
+ * 후속 PR 후보:
+ *   - destination 미설정 free trip을 위한 sentinel-destination lock (현재는 hydrate skip).
+ *   - 후보 line 선택 후 가장 임박한 trainCode 산출 시 trainType(express) 우선순위 적용.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { detectTransfer } from '../utils/transferDetect';
+import { findActiveTransferContext } from '../utils/findActiveTransferContext';
+import { lineToSubwayId } from '../../../shared/constants/lineApiNames';
+import type { OtherLineArrival } from '../utils/transferDetect';
+import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
+import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { LineNumber, NearestStationsResult, Station } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
+
+export interface UseTransferAutoDetectInputs {
+  /** 환승역 신호 + 후보 산출에 필요한 현재 fusion 결과. */
+  readonly nearestStations: NearestStationsResult | null;
+  /** 현재 정차 중 여부 — `false`(walking)일 때만 detect 활성. */
+  readonly motionStationary: boolean;
+  /** 현재 origin station의 도착 데이터(useArrivalInfo 결과). 다른 노선 후보 추출 입력. */
+  readonly arrival: StationArrival | null;
+  /** 현재 BoardingLock. 활성이면 boardingLine과 같은 후보는 제외(자기 노선 무한 detect 회피). */
+  readonly boardingLock: BoardingLock | null;
+  /** planned route. 사용자가 이미 알려진 transfer waypoint면 detect skip. */
+  readonly route: Route;
+  /** route 도착역 이름. `findActiveTransferContext`의 입력. */
+  readonly destinationName: string | null;
+  /**
+   * 단일 후보 detect 시 호출 — 호출자가 `useBoardingLockController.hydrateLockFromCandidate`로
+   * lock 자동 hydrate. destination 미설정 / lock 활성 등으로 hydrate가 no-op이면 graceful.
+   */
+  readonly onAutoLock: (candidate: AutoLockCandidate) => void;
+}
+
+export interface UseTransferAutoDetectResult {
+  /** detect된 다른 노선 후보(0/1/N). UI 디버깅 + 테스트 노출용. */
+  readonly candidateLines: readonly LineNumber[];
+  /** 다중 후보 모달이 열려 있어야 하는 상태. 호출자가 F4 모달 visible로 연결. */
+  readonly modalVisible: boolean;
+  /** 모달에 표시할 후보 역(=현재 환승역을 각 candidate line으로 매핑). */
+  readonly modalCandidates: readonly Station[];
+  /** 사용자가 모달에서 line(=station) 선택 시 호출. 해당 line으로 hydrate 후 모달 close. */
+  readonly selectLine: (line: LineNumber) => void;
+  /** 모달 dismiss(닫기/배경 탭). 같은 환승역에서 재오픈 방지하려면 sticky를 호출자가 결정. */
+  readonly dismissModal: () => void;
+}
+
+export function useTransferAutoDetect({
+  nearestStations,
+  motionStationary,
+  arrival,
+  boardingLock,
+  route,
+  destinationName,
+  onAutoLock,
+}: UseTransferAutoDetectInputs): UseTransferAutoDetectResult {
+  const currentStation = nearestStations?.primary ?? null;
+  const boardingLine = boardingLock?.boardingLine ?? null;
+
+  const otherLineArrivals = useMemo<OtherLineArrival[]>(
+    () => collectOtherLineArrivals(arrival, boardingLine),
+    [arrival, boardingLine],
+  );
+
+  // planned route의 transfer waypoint면 기존 useTransferTrainList가 책임지므로 detect skip.
+  const onPlannedTransfer = useMemo(
+    () => findActiveTransferContext(boardingLock, route, destinationName, currentStation) !== null,
+    [boardingLock, route, destinationName, currentStation],
+  );
+
+  const detection = useMemo(() => {
+    if (onPlannedTransfer) return { detected: false, candidateLines: [] as LineNumber[] };
+    return detectTransfer({
+      nearestStations,
+      motionWalking: !motionStationary,
+      otherLineArrivals,
+    });
+  }, [onPlannedTransfer, nearestStations, motionStationary, otherLineArrivals]);
+
+  const candidateLines = detection.candidateLines;
+
+  // 모달 visible은 user dismiss를 존중해야 하므로 별도 state. detect 결과만으로 derive하면
+  // 같은 환승역에서 사용자가 닫아도 다음 polling에서 다시 열린다.
+  const [modalVisible, setModalVisible] = useState(false);
+  const dismissedAtStationRef = useRef<string | null>(null);
+  const lastAutoLockedKeyRef = useRef<string | null>(null);
+
+  const stationKey = currentStation?.id ?? null;
+
+  // 사용자가 환승역을 벗어나면 dismiss flag 리셋 — 다음 환승에서 다시 모달 열림 허용.
+  useEffect(() => {
+    if (dismissedAtStationRef.current && dismissedAtStationRef.current !== stationKey) {
+      dismissedAtStationRef.current = null;
+    }
+    if (lastAutoLockedKeyRef.current && !stationKey) {
+      lastAutoLockedKeyRef.current = null;
+    }
+  }, [stationKey]);
+
+  // detect 결과 적용 — 단일 후보면 자동 lock, 다중 후보면 모달 open.
+  useEffect(() => {
+    if (!detection.detected || candidateLines.length === 0 || !currentStation) {
+      if (candidateLines.length === 0 && modalVisible) setModalVisible(false);
+      return;
+    }
+    if (candidateLines.length === 1) {
+      const [line] = candidateLines;
+      const candidate = buildAutoLockCandidate(line, arrival);
+      /* istanbul ignore next -- candidateLines가 detectTransfer로 산출되었으면 arrival에 해당 line의
+         imminent 도착이 반드시 존재 → pickImminentTrainCode는 항상 trainCode를 반환. 방어 코드. */
+      if (!candidate) return;
+      // 같은 환승역 같은 trainCode는 1회만 hydrate 시도 — onAutoLock 자체도 idempotent지만
+      // hydrateLockFromCandidate는 ETA 스냅샷이 없어 lock=null 가드만 의존 → 첫 hydrate가 race로
+      // 늦어지는 동안 매 polling tick에서 호출되는 churn을 줄인다.
+      const key = `${currentStation.id}|${candidate.trainCode}|${candidate.line}`;
+      if (lastAutoLockedKeyRef.current === key) return;
+      lastAutoLockedKeyRef.current = key;
+      onAutoLock(candidate);
+      return;
+    }
+    if (dismissedAtStationRef.current === stationKey) return;
+    setModalVisible(true);
+  }, [detection.detected, candidateLines, currentStation, arrival, onAutoLock, modalVisible, stationKey]);
+
+  const modalCandidates = useMemo<Station[]>(() => {
+    if (!currentStation) return [];
+    // 환승역 객체는 line 별로 stations.json에 분리되어 있다. variants에서 매핑.
+    return candidateLines
+      .map((line) => findStationVariantByLine(nearestStations, line))
+      .filter((s): s is Station => s !== null);
+  }, [candidateLines, nearestStations, currentStation]);
+
+  const selectLine = useCallback(
+    (line: LineNumber) => {
+      if (!currentStation) return;
+      const candidate = buildAutoLockCandidate(line, arrival);
+      if (!candidate) return;
+      const key = `${currentStation.id}|${candidate.trainCode}|${candidate.line}`;
+      lastAutoLockedKeyRef.current = key;
+      onAutoLock(candidate);
+      setModalVisible(false);
+      dismissedAtStationRef.current = stationKey;
+    },
+    [currentStation, arrival, onAutoLock, stationKey],
+  );
+
+  const dismissModal = useCallback(() => {
+    setModalVisible(false);
+    dismissedAtStationRef.current = stationKey;
+  }, [stationKey]);
+
+  return { candidateLines, modalVisible, modalCandidates, selectLine, dismissModal };
+}
+
+/**
+ * arrival.up / down을 평탄화한 뒤 `boardingLine`을 제외하고 OtherLineArrival 배열로 변환.
+ * 같은 line의 up/down이 모두 있어도 detectTransfer가 dedup하므로 추가 처리 불필요.
+ */
+function collectOtherLineArrivals(
+  arrival: StationArrival | null,
+  boardingLine: LineNumber | null,
+): OtherLineArrival[] {
+  if (!arrival) return [];
+  const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
+  const out: OtherLineArrival[] = [];
+  for (const t of all) {
+    if (boardingLine !== null && t.line === boardingLine) continue;
+    out.push({ line: t.line, arrivalSeconds: t.arrivalSeconds });
+  }
+  return out;
+}
+
+/**
+ * candidate line의 첫(=가장 임박) trainCode를 사용해 AutoLockCandidate 구성.
+ * subwayId 매핑 누락 시 null — 호출자가 hydrate skip(이미 line valid 가드 있음).
+ */
+function buildAutoLockCandidate(
+  line: LineNumber,
+  arrival: StationArrival | null,
+): AutoLockCandidate | null {
+  const subwayId = lineToSubwayId(line);
+  /* istanbul ignore next -- 모든 LineNumber는 LINE_TO_SUBWAY_ID에 등록되어 있어 null 분기는
+     valid LineNumber 입력 하에서 도달 불가. 타입 보강용 방어. */
+  if (!subwayId) return null;
+  const trainCode = pickImminentTrainCode(arrival, line);
+  if (!trainCode) return null;
+  return { trainCode, line, subwayId };
+}
+
+function pickImminentTrainCode(arrival: StationArrival | null, line: LineNumber): string | null {
+  if (!arrival) return null;
+  const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
+  let best: ArrivalInfo | null = null;
+  for (const t of all) {
+    if (t.line !== line) continue;
+    /* istanbul ignore next -- detectTransfer는 음수 arrivalSeconds를 후보에서 제외한 뒤 line을
+       반환하므로, 그 line의 음수 train이 있더라도 양수 train이 이미 적어도 하나 존재. 양수만
+       best로 선택되어 음수 분기는 도달하지 않는다. 방어 코드. */
+    if (t.arrivalSeconds < 0) continue;
+    if (!best || t.arrivalSeconds < best.arrivalSeconds) best = t;
+  }
+  return best?.trainCode ?? null;
+}
+
+/**
+ * nearestStations.variants에서 line 일치하는 station을 찾는다. 없으면 null —
+ * primary로 fallback하면 잘못된 line의 station 객체가 들어가 boardingStationId가 어긋난다.
+ */
+function findStationVariantByLine(
+  nearestStations: NearestStationsResult | null,
+  line: LineNumber,
+): Station | null {
+  /* istanbul ignore next -- 호출자(modalCandidates)가 currentStation 존재할 때만 호출하고,
+     currentStation은 nearestStations.primary에서 도출되어 nearestStations도 항상 truthy. */
+  if (!nearestStations) return null;
+  // variants에 없다 = stations.json에 해당 line의 동명 station이 없음. 자동 lock 후보로
+  // 부적합하므로 모달 표시도 skip. primary로 fallback하면 잘못된 line의 station 객체가
+  // 들어가 boardingStationId가 어긋난다.
+  return nearestStations.variants.find((v) => v.line === line) ?? null;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -55,6 +55,7 @@ import { Toast } from '../shared/ui/Toast';
 import { useMisBoardingDetector } from '../features/route/hooks/useMisBoardingDetector';
 import { useTrainPositions } from '../features/route/hooks/useTrainPositions';
 import { useTransferTrainList } from '../features/route/hooks/useTransferTrainList';
+import { useTransferAutoDetect } from '../features/route/hooks/useTransferAutoDetect';
 import { TRANSFER_WALKING_BUFFER_SECONDS, BOARDING_PROXIMITY_THRESHOLD_M } from '../shared/constants/boardingLock';
 import { BoardingTrainList } from '../features/alarm/components/BoardingTrainList';
 import { BoardingLockHopCard } from '../features/alarm/components/BoardingLockHopCard';
@@ -403,6 +404,39 @@ export default function HomeScreen() {
     destinationName: destination?.name ?? null,
     currentStation: result?.station ?? null,
   });
+  // #924 D1 — route 미설정 환승 자동 detect. 환승역 walking + 다른 노선 임박 ArrivalRow 신호 결합.
+  // useFusedNearestStation은 NearestStationResult(단수)만 노출 — 본 hook 입력 NearestStationsResult로 재조합.
+  const nearestStationsForDetect = useMemo(() => {
+    if (!result) return null;
+    return {
+      primary: result.station,
+      variants,
+      distanceKm: result.distanceKm,
+      // primary가 환승역 candidate들 사이에 포함되어 있으면 환승역. variants가 비어 있어도 같은 이름
+      // 다른 노선이 stations.json에 1개라도 더 있으면 isTransfer=true.
+      isTransfer: variants.length > 1,
+    };
+  }, [result, variants]);
+  const {
+    modalVisible: transferDetectModalVisible,
+    modalCandidates: transferDetectCandidates,
+    selectLine: selectTransferDetectLine,
+    dismissModal: dismissTransferDetectModal,
+  } = useTransferAutoDetect({
+    nearestStations: nearestStationsForDetect,
+    motionStationary,
+    arrival: rawArrival,
+    boardingLock,
+    route,
+    destinationName: destination?.name ?? null,
+    onAutoLock: hydrateLockFromCandidate,
+  });
+  const handleTransferDetectConfirm = useCallback(
+    (station: Station) => {
+      selectTransferDetectLine(station.line);
+    },
+    [selectTransferDetectLine],
+  );
   useBackgroundLocation(destination);
   useApnsTripRegistration({
     route,
@@ -623,6 +657,15 @@ export default function HomeScreen() {
         onSelect={handleMisBoardingReselect}
         onClose={handleMisBoardingModalClose}
         nextStationLabel={nextStationName}
+      />
+      {/* #924 D1 — 환승 자동 detect 다중 후보 모달. F4 1탭 모달 인프라(#914) 재사용. */}
+      <CurrentStationConfirmModal
+        visible={transferDetectModalVisible}
+        candidates={transferDetectCandidates}
+        topPick={transferDetectCandidates[0] ?? null}
+        onConfirm={handleTransferDetectConfirm}
+        onSearchFallback={dismissTransferDetectModal}
+        onClose={dismissTransferDetectModal}
       />
 
       <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>


### PR DESCRIPTION
Closes #924

## Summary
- `src/features/route/hooks/useTransferAutoDetect.ts` 추가: pure `detectTransfer`(#937 머지) 위에 런타임 신호 결합 layer.
  - 입력: `nearestStations` + `motionStationary` + `arrival` + `boardingLock` + `route` + `destinationName`.
  - 출력: 단일 후보 → `onAutoLock(candidate)`로 A1 자동 hydrate, 다중 후보 → `modalVisible/modalCandidates/selectLine/dismissModal`로 F4 1탭 모달(#914) 트리거 상태 노출.
- `src/screens/HomeScreen.tsx` wire:
  - `useFusedNearestStation` `result` + `variants`를 `NearestStationsResult`로 재조합해 hook에 주입.
  - `onAutoLock`은 기존 `hydrateLockFromCandidate`(`useBoardingLockController`) 재사용 — destination/lock 가드는 controller가 책임.
  - `CurrentStationConfirmModal` 추가 인스턴스 마운트(F4 모달 인프라 재사용).

## 본 PR이 의도적으로 막는 케이스
- planned route의 transfer waypoint에서는 `useTransferTrainList`가 책임지므로 detect skip(`findActiveTransferContext` 활성 시).
- 현재 `boardingLine`과 같은 line은 후보에서 제외 — 자기 노선이 detect되어 무한 재발화하지 않게.
- 같은 환승역에서 사용자가 dismiss 후 다음 polling에서 모달 재오픈 금지(역 떠나면 리셋).
- 같은 station+trainCode 반복 hydrate 차단(`lastAutoLockedKeyRef`).

## Test plan
- [x] `npm test` — 3969 it pass, 100% coverage(branches/lines/funcs/stmts).
- [x] hook 단독 22 it: 단일/다중 후보, idempotency, dismiss & 재진입, planned transfer skip, variants 누락, 임박 trainCode 선택(EARLY vs LATE replace + skip), arrival 사라짐 시 모달 close 등.
- [x] `npm run type-check` pass.
- [ ] 실기기: free trip(목적지 미설정)으로 환승역 walking 시 자동 lock + 다중 후보 모달 확인.

## Follow-ups
- pickImminentTrainCode가 `trainType=express` 우선순위는 아직 미적용(첫 도착만 선택). 후속 PR에서 enrich.
- topPick(`modalCandidates[0]`)은 arrival 순회 순서로 결정되어 가장 임박한 노선이 아닐 수 있음 — UX nit, 후속에서 sort by `arrivalSeconds` 검토.
- destination 미설정 상태에서 sentinel-destination lock으로 자동 hydrate가 실제 동작하려면 `hydrateLockFromCandidate`의 `if (!destinationId) return;` 가드를 풀어야 한다 — 별 PR.