### PR TITLE
feat(#918): A3 사전 예약 효과 측정 텔레메트리

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1456,6 +1456,18 @@ describe('POST /telemetry/recall (#919)', () => {
   });
 });
 
+describe('POST /telemetry/prescheduled (#918 A3)', () => {
+  runTelemetryEndpointSuite('/telemetry/prescheduled', {
+    token: 'aabbccdd11223344',
+    tripStart: 1_000,
+    tripEnd: 2_000,
+    scheduledCount: 5,
+    firedCount: 4,
+    stationAccurateCount: 3,
+    fireDeltaSamplesMs: [10, -5, 0, 100],
+  });
+});
+
 describe('validateTrip — #819 promptGeoContext / promptDisplay', () => {
   function withPrompt(overrides: Record<string, unknown>): Record<string, unknown> {
     return { ...base(), ...overrides };

--- a/backend/alarm-worker/src/__tests__/prescheduledTelemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/prescheduledTelemetry.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  recordPrescheduledUpload,
+  validatePrescheduledUpload,
+  type PrescheduledUpload,
+} from '../prescheduledTelemetry';
+import { METRIC_KIND } from '../metrics';
+
+function base(): Record<string, unknown> {
+  return {
+    token: 'aabbccdd11223344',
+    tripStart: 1_000,
+    tripEnd: 2_000,
+    scheduledCount: 5,
+    firedCount: 4,
+    stationAccurateCount: 3,
+    fireDeltaSamplesMs: [10, -5, 0, 100],
+  };
+}
+
+describe('validatePrescheduledUpload', () => {
+  it('accepts valid payload', () => {
+    const result = validatePrescheduledUpload(base());
+    expect(result).not.toBeNull();
+    expect(result?.scheduledCount).toBe(5);
+    expect(result?.firedCount).toBe(4);
+    expect(result?.stationAccurateCount).toBe(3);
+    expect(result?.fireDeltaSamplesMs).toEqual([10, -5, 0, 100]);
+  });
+
+  it('rejects non-object', () => {
+    expect(validatePrescheduledUpload(null)).toBeNull();
+    expect(validatePrescheduledUpload('x')).toBeNull();
+  });
+
+  it('rejects missing/empty token', () => {
+    expect(validatePrescheduledUpload({ ...base(), token: '' })).toBeNull();
+    const noToken = base();
+    delete noToken.token;
+    expect(validatePrescheduledUpload(noToken)).toBeNull();
+  });
+
+  it.each([
+    ['tripStart', Number.NaN],
+    ['tripStart', 'x'],
+    ['tripEnd', Number.NaN],
+    ['tripEnd', 'x'],
+  ])('rejects non-finite %s (%p)', (field, value) => {
+    expect(validatePrescheduledUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects tripEnd < tripStart', () => {
+    expect(
+      validatePrescheduledUpload({ ...base(), tripStart: 2_000, tripEnd: 1_000 }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['scheduledCount', -1],
+    ['scheduledCount', 1.5],
+    ['firedCount', -1],
+    ['stationAccurateCount', -1],
+  ])('rejects non-natural %s (%p)', (field, value) => {
+    expect(validatePrescheduledUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects firedCount > scheduledCount', () => {
+    expect(
+      validatePrescheduledUpload({
+        ...base(),
+        scheduledCount: 2,
+        firedCount: 3,
+        stationAccurateCount: 2,
+        fireDeltaSamplesMs: [1, 2, 3],
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects stationAccurateCount > firedCount', () => {
+    expect(
+      validatePrescheduledUpload({
+        ...base(),
+        scheduledCount: 5,
+        firedCount: 2,
+        stationAccurateCount: 3,
+        fireDeltaSamplesMs: [1, 2],
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects non-array fireDeltaSamplesMs', () => {
+    expect(
+      validatePrescheduledUpload({ ...base(), fireDeltaSamplesMs: 'x' }),
+    ).toBeNull();
+  });
+
+  it('rejects non-finite sample in array', () => {
+    expect(
+      validatePrescheduledUpload({ ...base(), fireDeltaSamplesMs: [1, Number.NaN, 2] }),
+    ).toBeNull();
+    expect(
+      validatePrescheduledUpload({ ...base(), fireDeltaSamplesMs: [1, 'x', 2] }),
+    ).toBeNull();
+  });
+
+  it('rejects sample length != firedCount', () => {
+    expect(
+      validatePrescheduledUpload({
+        ...base(),
+        firedCount: 4,
+        fireDeltaSamplesMs: [1, 2, 3], // length=3, firedCount=4
+      }),
+    ).toBeNull();
+  });
+
+  it('accepts empty samples when firedCount=0', () => {
+    const result = validatePrescheduledUpload({
+      ...base(),
+      scheduledCount: 5,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    expect(result).not.toBeNull();
+    expect(result?.firedCount).toBe(0);
+  });
+
+  it('accepts scheduledCount=0 corner case', () => {
+    const result = validatePrescheduledUpload({
+      ...base(),
+      scheduledCount: 0,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    expect(result?.scheduledCount).toBe(0);
+  });
+});
+
+function makeWriter() {
+  return { writeDataPoint: vi.fn() };
+}
+
+describe('recordPrescheduledUpload', () => {
+  const payload: PrescheduledUpload = {
+    token: 'aabbccdd11223344',
+    tripStart: 0,
+    tripEnd: 1_000,
+    scheduledCount: 10,
+    firedCount: 8,
+    stationAccurateCount: 7,
+    fireDeltaSamplesMs: [5, 10, 15, 20, 25, 30, 35, 40],
+  };
+
+  it('writes miss rate + accuracy rate + histogram metrics', () => {
+    const writer = makeWriter();
+    recordPrescheduledUpload(writer, payload);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0] as string);
+    // miss rate: hit=2, total=10
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_FIRE_MISS_RATE}:hit`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_FIRE_MISS_RATE}:total`);
+    // accuracy rate: hit=7, total=8
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_STATION_ACCURACY}:hit`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_STATION_ACCURACY}:total`);
+    // histogram: count, mean, p95
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_FIRE_DELTA_MS}:count`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_FIRE_DELTA_MS}:mean`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_FIRE_DELTA_MS}:p95`);
+  });
+
+  it('skips accuracy rate when firedCount=0', () => {
+    const writer = makeWriter();
+    recordPrescheduledUpload(writer, {
+      ...payload,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0] as string);
+    expect(labels).not.toContain(`phase3:${METRIC_KIND.PRESCHEDULED_STATION_ACCURACY}:hit`);
+    expect(labels).not.toContain(`phase3:${METRIC_KIND.PRESCHEDULED_STATION_ACCURACY}:total`);
+    // miss rate (scheduledCount=10-0=10 missed) 그대로
+    expect(labels).toContain(`phase3:${METRIC_KIND.PRESCHEDULED_FIRE_MISS_RATE}:hit`);
+  });
+
+  it('skips histogram when samples empty', () => {
+    const writer = makeWriter();
+    recordPrescheduledUpload(writer, {
+      ...payload,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0] as string);
+    expect(labels).not.toContain(`phase3:${METRIC_KIND.PRESCHEDULED_FIRE_DELTA_MS}:count`);
+  });
+
+  it('uses 8-char token prefix in blob2/indexes', () => {
+    const writer = makeWriter();
+    recordPrescheduledUpload(writer, payload);
+    const anyCall = writer.writeDataPoint.mock.calls[0][0];
+    expect(anyCall.blobs[1]).toBe('aabbccdd');
+    expect(anyCall.indexes[0]).toBe('aabbccdd');
+  });
+
+  it('skips writes entirely when scheduledCount=0 + firedCount=0', () => {
+    const writer = makeWriter();
+    recordPrescheduledUpload(writer, {
+      ...payload,
+      scheduledCount: 0,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    // 0 hit + 0 total miss rate → writeMetricDataPoints가 0값을 skip → 적재 0건
+    expect(writer.writeDataPoint).not.toHaveBeenCalled();
+  });
+});
+
+describe('catalog SSOT', () => {
+  it('exposes prescheduled metric kinds', () => {
+    expect(METRIC_KIND.PRESCHEDULED_FIRE_MISS_RATE).toBe('prescheduledFireMissRate');
+    expect(METRIC_KIND.PRESCHEDULED_STATION_ACCURACY).toBe('prescheduledStationAccuracy');
+    expect(METRIC_KIND.PRESCHEDULED_FIRE_DELTA_MS).toBe('prescheduledFireDeltaMs');
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -35,6 +35,10 @@ import {
   validateRecallUpload,
 } from './recallTelemetry';
 import {
+  recordPrescheduledUpload,
+  validatePrescheduledUpload,
+} from './prescheduledTelemetry';
+import {
   tokenPrefix,
   validateTelemetryUpload,
   writeTelemetryDataPoints,
@@ -250,6 +254,45 @@ app.post('/telemetry/recall', async (c) => {
       expectedStops: payload.expectedStops,
       firedStops: payload.firedStops,
       recallPct: payload.recallPct,
+      sink: writer ? 'ae' : 'none',
+    }),
+  );
+  return c.json({ ok: true });
+});
+
+/**
+ * A3 사전 예약 효과 텔레메트리 upload (#918, Epic #912 P1).
+ *
+ * Trip 1건 종료 시 client(`prescheduledLogTelemetry.computeAndUploadTripPrescheduled`)가 산출한
+ * miss rate / station 정확도 / fire delta sample을 Analytics Engine에 적재한다.
+ * recall과 동형 — client에 idempotency 가드 (LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY).
+ *
+ * Trip 존재 여부 확인 안 함 — trip 만료 케이스에도 telemetry 보존.
+ * TELEMETRY binding 미설정 시 graceful no-op.
+ */
+app.post('/telemetry/prescheduled', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validatePrescheduledUpload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const writer = c.env.TELEMETRY;
+  if (writer) {
+    recordPrescheduledUpload(writer, payload);
+  }
+  console.log(
+    JSON.stringify({
+      msg: 'prescheduled uploaded',
+      tokenPrefix: tokenPrefix(payload.token),
+      scheduledCount: payload.scheduledCount,
+      firedCount: payload.firedCount,
+      stationAccurateCount: payload.stationAccurateCount,
+      deltaSamples: payload.fireDeltaSamplesMs.length,
       sink: writer ? 'ae' : 'none',
     }),
   );

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -112,6 +112,27 @@
       "format": "rate",
       "display": "percentage",
       "description": "#919 A4 — recall < 100% trip에서 매역 알림을 차단한 게이트(accuracy/motion/silence/lockMissing/...) 분포. 차단 reason은 별도 blob label로 적재(reason 카탈로그는 recallTelemetry.ts:KNOWN_GATE_REASONS와 client recallMetrics.ts:GATE_SUPPRESSION_REASONS의 양방향 SSOT)."
+    },
+    {
+      "key": "prescheduledFireMissRate",
+      "constantName": "PRESCHEDULED_FIRE_MISS_RATE",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#918 A3 — trip 종료까지 fire ledger에 actualFireMs가 기록되지 않은 비율. hit=scheduledCount-firedCount, total=scheduledCount. OS local notification 누락/cancel/일정 변경의 합산 신호 — A4 recall과 보완. 운영 KPI(Phase 4 결정 게이트 아님)."
+    },
+    {
+      "key": "prescheduledStationAccuracy",
+      "constantName": "PRESCHEDULED_STATION_ACCURACY",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#918 A3 — fired 사전 예약 알람의 station 정확도. hit=fired entry 중 alarmLog가 같은 station에서 fired outcome을 남긴 수, total=firedCount. 사전 예약 시점 prediction과 실제 trip 진행 일치도."
+    },
+    {
+      "key": "prescheduledFireDeltaMs",
+      "constantName": "PRESCHEDULED_FIRE_DELTA_MS",
+      "format": "histogram",
+      "display": "numeric",
+      "description": "#918 A3 — actualFireMs - scheduledFireMs (양수=OS 늦게 발사). p95로 OS 타이밍 SLA 추적. 시계 보정/timer drift 진단 신호."
     }
   ]
 }

--- a/backend/alarm-worker/src/prescheduledTelemetry.ts
+++ b/backend/alarm-worker/src/prescheduledTelemetry.ts
@@ -1,0 +1,145 @@
+/**
+ * A3 사전 예약 효과 텔레메트리 (#918, Epic #912 P1).
+ *
+ * Trip 1건 종료 시 client `prescheduledMetrics.computePrescheduledMetrics`가 산출한 결과를
+ * Cloudflare Analytics Engine에 적재한다. metrics.catalog.json SSOT의 세 항목:
+ *
+ *   prescheduledFireMissRate      : RateMetric (hit=missed, total=scheduled)
+ *                                   → missed = scheduled - fired (OS drop/cancel/일정 변경)
+ *   prescheduledStationAccuracy   : RateMetric (hit=accurate, total=fired)
+ *                                   → fired alarm이 알람 로그상 같은 station에서 fired로 확인된 비율
+ *   prescheduledFireDeltaMs       : HistogramMetric (samples = actualFire-scheduledFire ms)
+ *                                   → OS local notification 타이밍 정확도. p95로 SLA 추적.
+ *
+ * Privacy: 좌표/원문 미적재. token 8자 prefix만 anonymous aggregate에 사용 — recallTelemetry 동형.
+ *
+ * 본 메트릭은 Phase 4 결정 게이트와 분리된 운영 KPI — `decidePhaseFour`에 포함하지 않는다.
+ * (catalog entry에 `gate` 필드 없음.)
+ */
+
+import {
+  METRIC_KIND,
+  writeMetricDataPoints,
+  type HistogramMetric,
+  type RateMetric,
+} from './metrics';
+import type { AnalyticsEngineWriter } from './types';
+
+/**
+ * client → backend upload payload.
+ *   client `uploadPrescheduledTelemetry`(api/telemetryBackend.ts)와 동일 schema.
+ */
+export interface PrescheduledUpload {
+  /** APNs device token (hex). 8자 prefix만 anonymous aggregate. */
+  token: string;
+  /** trip 시작 epoch ms. */
+  tripStart: number;
+  /** trip 종료 epoch ms. tripStart <= tripEnd 강제. */
+  tripEnd: number;
+  /** ledger 내 trip 윈도우의 사전 예약 entry 총 수 (분모 — miss/fired). */
+  scheduledCount: number;
+  /** 그 중 fire가 기록된 entry 수 (분자 — accuracy / 누락 분모). */
+  firedCount: number;
+  /** fired entry 중 station이 alarmLog fired와 일치한 entry 수 (분자 — accuracy). */
+  stationAccurateCount: number;
+  /** actualFireMs - scheduledFireMs 차이 sample. fired entry당 1건. */
+  fireDeltaSamplesMs: readonly number[];
+}
+
+function isNonNegativeInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v) && v >= 0;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+/**
+ * fireDeltaSamplesMs 배열 검증 — 유한수만 보존. 한 entry라도 비유한이면 전체 reject
+ * (조용히 drop하지 않음 — 비정상 sample이 mean/p95를 오염시키지 않게).
+ */
+function parseDeltaSamples(raw: unknown): number[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out: number[] = [];
+  for (const v of raw) {
+    if (!isFiniteNumber(v)) return null;
+    out.push(v);
+  }
+  return out;
+}
+
+/**
+ * payload 검증. 한 필드라도 깨졌으면 null — caller는 400.
+ *
+ * 규칙:
+ *   - token 비어있으면 reject
+ *   - tripStart/tripEnd는 유한수 + tripStart <= tripEnd
+ *   - scheduledCount/firedCount/stationAccurateCount는 자연수
+ *   - firedCount <= scheduledCount, stationAccurateCount <= firedCount
+ *   - fireDeltaSamplesMs는 유한수 배열, 길이는 firedCount와 일치(불일치=client bug, reject)
+ */
+export function validatePrescheduledUpload(input: unknown): PrescheduledUpload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (!isFiniteNumber(obj.tripStart)) return null;
+  if (!isFiniteNumber(obj.tripEnd)) return null;
+  if (obj.tripEnd < obj.tripStart) return null;
+  if (!isNonNegativeInt(obj.scheduledCount)) return null;
+  if (!isNonNegativeInt(obj.firedCount)) return null;
+  if (!isNonNegativeInt(obj.stationAccurateCount)) return null;
+  if (obj.firedCount > obj.scheduledCount) return null;
+  if (obj.stationAccurateCount > obj.firedCount) return null;
+  const samples = parseDeltaSamples(obj.fireDeltaSamplesMs);
+  if (samples === null) return null;
+  if (samples.length !== obj.firedCount) return null;
+
+  return {
+    token: obj.token,
+    tripStart: obj.tripStart,
+    tripEnd: obj.tripEnd,
+    scheduledCount: obj.scheduledCount,
+    firedCount: obj.firedCount,
+    stationAccurateCount: obj.stationAccurateCount,
+    fireDeltaSamplesMs: samples,
+  };
+}
+
+/**
+ * 사전 예약 텔레메트리 1건을 AE에 적재.
+ *
+ *  1) prescheduledFireMissRate     — RateMetric (missed/scheduled)
+ *  2) prescheduledStationAccuracy  — RateMetric (accurate/fired)  — fired=0이면 skip (의미 없음)
+ *  3) prescheduledFireDeltaMs      — HistogramMetric — samples=0이면 skip
+ *
+ * writeMetricDataPoints가 0값을 skip하므로 fully empty trip은 자동 no-op이지만
+ * 호출자는 isEmptyPrescheduledMetrics 가드로 0건 upload 자체를 막는다 (네트워크 절약).
+ */
+export function recordPrescheduledUpload(
+  writer: AnalyticsEngineWriter,
+  payload: PrescheduledUpload,
+): void {
+  const missRate: RateMetric = {
+    kind: METRIC_KIND.PRESCHEDULED_FIRE_MISS_RATE,
+    hit: payload.scheduledCount - payload.firedCount,
+    total: payload.scheduledCount,
+  };
+  writeMetricDataPoints(writer, payload.token, missRate);
+
+  if (payload.firedCount > 0) {
+    const accuracy: RateMetric = {
+      kind: METRIC_KIND.PRESCHEDULED_STATION_ACCURACY,
+      hit: payload.stationAccurateCount,
+      total: payload.firedCount,
+    };
+    writeMetricDataPoints(writer, payload.token, accuracy);
+  }
+
+  if (payload.fireDeltaSamplesMs.length > 0) {
+    const histogram: HistogramMetric = {
+      kind: METRIC_KIND.PRESCHEDULED_FIRE_DELTA_MS,
+      samples: payload.fireDeltaSamplesMs,
+    };
+    writeMetricDataPoints(writer, payload.token, histogram);
+  }
+}

--- a/src/features/alarm/api/__tests__/telemetryBackend.test.ts
+++ b/src/features/alarm/api/__tests__/telemetryBackend.test.ts
@@ -1,6 +1,11 @@
-import { uploadSilentPushTelemetry, uploadRecallTelemetry } from '../telemetryBackend';
+import {
+  uploadPrescheduledTelemetry,
+  uploadRecallTelemetry,
+  uploadSilentPushTelemetry,
+} from '../telemetryBackend';
 import type { SilentPushTelemetryPayload } from '../../utils/telemetryAggregation';
 import type { TripRecallResult } from '../../utils/recallMetrics';
+import type { PrescheduledMetricsResult } from '../../utils/prescheduledMetrics';
 
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -149,6 +154,69 @@ describe('uploadRecallTelemetry', () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
     (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
     const result = await uploadRecallTelemetry('tok', RECALL_PAYLOAD);
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+const PRESCHEDULED_PAYLOAD: PrescheduledMetricsResult = {
+  tripStart: 0,
+  tripEnd: 1_000,
+  scheduledCount: 5,
+  firedCount: 4,
+  stationAccurateCount: 3,
+  fireDeltaSamplesMs: [10, -5, 0, 100],
+};
+
+describe('uploadPrescheduledTelemetry', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('URL 미설정이면 skipped=true', async () => {
+    const result = await uploadPrescheduledTelemetry('token', PRESCHEDULED_PAYLOAD);
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('빈 token도 skipped=true', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    const result = await uploadPrescheduledTelemetry('', PRESCHEDULED_PAYLOAD);
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('정상 응답 시 ok=true, body 직렬화 확인', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    const result = await uploadPrescheduledTelemetry('tok', PRESCHEDULED_PAYLOAD);
+    expect(result).toEqual({ ok: true, status: 200 });
+    const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test/telemetry/prescheduled');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.token).toBe('tok');
+    expect(body.scheduledCount).toBe(5);
+    expect(body.firedCount).toBe(4);
+    expect(body.stationAccurateCount).toBe(3);
+    expect(body.fireDeltaSamplesMs).toEqual([10, -5, 0, 100]);
+  });
+
+  it('!res.ok 응답 시 ok=false + status', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+    const result = await uploadPrescheduledTelemetry('tok', PRESCHEDULED_PAYLOAD);
+    expect(result).toEqual({ ok: false, status: 500 });
+  });
+
+  it('fetch throw 시 ok=false', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    const result = await uploadPrescheduledTelemetry('tok', PRESCHEDULED_PAYLOAD);
     expect(result).toEqual({ ok: false });
   });
 });

--- a/src/features/alarm/api/telemetryBackend.ts
+++ b/src/features/alarm/api/telemetryBackend.ts
@@ -7,6 +7,7 @@
 
 import type { SilentPushTelemetryPayload } from '../utils/telemetryAggregation';
 import type { TripRecallResult } from '../utils/recallMetrics';
+import type { PrescheduledMetricsResult } from '../utils/prescheduledMetrics';
 import { createLogger } from '../../../shared/utils/logger';
 
 const log = createLogger('telemetryBackend');
@@ -122,6 +123,51 @@ export async function uploadRecallTelemetry(
     return { ok: true, status: res.status };
   } catch (e) {
     log.warn('recall upload error', e);
+    return { ok: false };
+  }
+}
+
+/**
+ * A3 사전 예약 효과 텔레메트리 1건을 backend `/telemetry/prescheduled`로 upload (#918, Epic #912 P1).
+ *
+ * recall과 같은 graceful 정책 — URL/token 부재 시 skipped, fetch 실패 시 ok=false. throw 안 함.
+ */
+export async function uploadPrescheduledTelemetry(
+  token: string,
+  metrics: PrescheduledMetricsResult,
+): Promise<TelemetryUploadResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip prescheduled upload');
+    return { ok: false, skipped: true };
+  }
+  if (!token) {
+    return { ok: false, skipped: true };
+  }
+
+  const body = {
+    token,
+    tripStart: metrics.tripStart,
+    tripEnd: metrics.tripEnd,
+    scheduledCount: metrics.scheduledCount,
+    firedCount: metrics.firedCount,
+    stationAccurateCount: metrics.stationAccurateCount,
+    fireDeltaSamplesMs: metrics.fireDeltaSamplesMs,
+  };
+
+  try {
+    const res = await fetchWithTimeout(`${base}/telemetry/prescheduled`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      log.warn(`prescheduled upload failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('prescheduled upload error', e);
     return { ok: false };
   }
 }

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -28,6 +28,7 @@ import { clearFiredPushIds } from '../utils/firedPushIds';
 import { clearTripTrainCode } from '../../route/utils/tripTrainCode';
 import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dismissSilenceStorage';
 import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
+import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
 
 // trip-bound storage cleanup 단일 출처.
 // useDestinationStore.setDestination이 isSwitch(목적지 변경 또는 null 클리어) 분기에서 호출한다.
@@ -69,6 +70,10 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // BG silent-push가 upload + 직후 FG setDestination(null)이 같은 tripStart로 재trigger되는
   // 경계(self review)에서 idempotency가 깨져 중복 upload 가능 → 보존이 안전.
   () => AsyncStorage.removeItem(TRIP_STARTED_AT_KEY),
+  // #918 — A3 사전 예약 측정 ledger. 새 trip마다 클리어 — 직전 trip의 잔여 fire/scheduled가
+  // 새 trip 분모에 섞이는 회귀 차단. LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY는 recall과
+  // 같은 이유로 보존 (tripStart값으로 자연 무효화).
+  clearPrescheduledLedger,
 ];
 
 /**

--- a/src/features/alarm/utils/__tests__/alarmLogTelemetry.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLogTelemetry.test.ts
@@ -6,7 +6,9 @@
 
 const mockGetAlarmLog = jest.fn();
 const mockUploadRecallTelemetry = jest.fn();
+const mockUploadPrescheduledTelemetry = jest.fn();
 const mockGetItem = jest.fn();
+const mockComputePrescheduledMetrics = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -21,6 +23,13 @@ jest.mock('../alarmLog', () => ({
 
 jest.mock('../../api/telemetryBackend', () => ({
   uploadRecallTelemetry: (...args: unknown[]) => mockUploadRecallTelemetry(...args),
+  uploadPrescheduledTelemetry: (...args: unknown[]) =>
+    mockUploadPrescheduledTelemetry(...args),
+}));
+
+jest.mock('../prescheduledMetrics', () => ({
+  computePrescheduledMetrics: (...args: unknown[]) => mockComputePrescheduledMetrics(...args),
+  isEmptyPrescheduledMetrics: (m: { scheduledCount: number }) => m.scheduledCount === 0,
 }));
 
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -33,7 +42,10 @@ jest.mock('../../../../shared/utils/logger', () => ({
 }));
 
 // import은 mock 등록 후.
-import { computeAndUploadTripRecall } from '../alarmLogTelemetry';
+import {
+  computeAndUploadTripPrescheduled,
+  computeAndUploadTripRecall,
+} from '../alarmLogTelemetry';
 import type { AlarmLogEntry } from '../alarmLog';
 
 const fixedEntry = (
@@ -150,5 +162,188 @@ describe('computeAndUploadTripRecall', () => {
     expect(mockUploadRecallTelemetry).not.toHaveBeenCalled();
     expect(result.uploaded).toBe(false);
     expect(result.skipped).toBe('error');
+  });
+});
+
+describe('computeAndUploadTripPrescheduled', () => {
+  beforeEach(() => {
+    mockGetAlarmLog.mockReset();
+    mockUploadPrescheduledTelemetry.mockReset();
+    mockGetItem.mockReset();
+    mockComputePrescheduledMetrics.mockReset();
+  });
+
+  it('APNs token 없으면 upload 호출 안 함 (graceful skip)', async () => {
+    mockGetItem.mockResolvedValue(null);
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0 });
+
+    expect(mockUploadPrescheduledTelemetry).not.toHaveBeenCalled();
+    expect(result.uploaded).toBe(false);
+    expect(result.skipped).toBe('no-token');
+  });
+
+  it('ledger 비어있어 scheduledCount=0이면 upload 호출 안 함 (empty)', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: 1000,
+      scheduledCount: 0,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0 });
+
+    expect(mockUploadPrescheduledTelemetry).not.toHaveBeenCalled();
+    expect(result.skipped).toBe('empty');
+  });
+
+  it('정상 흐름 — alarmLog fired stationName 집합 + ledger 계산 → upload', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([
+      fixedEntry({
+        ts: 100,
+        source: 'fg-evaluated',
+        outcome: 'fired',
+        kind: 'station-passed',
+        stationName: 'A',
+      }),
+      fixedEntry({
+        ts: 200,
+        source: 'bg-scheduled',
+        outcome: 'fired',
+        kind: 'station-passed',
+        stationName: 'B',
+      }),
+    ]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: 1000,
+      scheduledCount: 3,
+      firedCount: 2,
+      stationAccurateCount: 2,
+      fireDeltaSamplesMs: [5, 10],
+    });
+    mockUploadPrescheduledTelemetry.mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0 });
+
+    expect(mockUploadPrescheduledTelemetry).toHaveBeenCalledTimes(1);
+    const [, metrics] = mockUploadPrescheduledTelemetry.mock.calls[0];
+    expect(metrics.scheduledCount).toBe(3);
+    expect(result.uploaded).toBe(true);
+
+    // computePrescheduledMetrics이 firedStationNames Set으로 호출됐는지 확인
+    const callArg = mockComputePrescheduledMetrics.mock.calls[0][0];
+    expect(callArg.firedStationNames.has('A')).toBe(true);
+    expect(callArg.firedStationNames.has('B')).toBe(true);
+  });
+
+  it('윈도우 밖 fired/suppressed entry는 firedStationNames에 포함 안 함', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([
+      // tripStart=0 이하 (exclusive) → 제외
+      fixedEntry({
+        ts: 0,
+        source: 'fg-evaluated',
+        outcome: 'fired',
+        kind: 'station-passed',
+        stationName: 'OutBefore',
+      }),
+      // tripEnd 이후 → 제외
+      fixedEntry({
+        ts: 5000,
+        source: 'fg-evaluated',
+        outcome: 'fired',
+        kind: 'station-passed',
+        stationName: 'OutAfter',
+      }),
+      // outcome=suppressed → 제외
+      fixedEntry({
+        ts: 100,
+        source: 'fg-evaluated',
+        outcome: 'suppressed',
+        kind: 'station-passed',
+        stationName: 'Suppressed',
+      }),
+      // stationName 없음 → 제외
+      fixedEntry({ ts: 200, source: 'fg-evaluated', outcome: 'fired' }),
+      // 정상
+      fixedEntry({
+        ts: 300,
+        source: 'fg-evaluated',
+        outcome: 'fired',
+        kind: 'station-passed',
+        stationName: 'In',
+      }),
+    ]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: 1000,
+      scheduledCount: 1,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    mockUploadPrescheduledTelemetry.mockResolvedValue({ ok: true, status: 200 });
+
+    await computeAndUploadTripPrescheduled({ tripStart: 0, tripEnd: 1000 });
+
+    const callArg = mockComputePrescheduledMetrics.mock.calls[0][0];
+    expect(Array.from(callArg.firedStationNames).sort()).toEqual(['In']);
+  });
+
+  it('upload 실패해도 throw 안 함', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: 1000,
+      scheduledCount: 1,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    mockUploadPrescheduledTelemetry.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0 });
+
+    expect(result.uploaded).toBe(false);
+    expect(result.skipped).toBeUndefined();
+  });
+
+  it('alarmLog read 실패 시 graceful error', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockRejectedValue(new Error('fail'));
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0 });
+
+    expect(mockUploadPrescheduledTelemetry).not.toHaveBeenCalled();
+    expect(result.skipped).toBe('error');
+  });
+
+  it('tripEnd 미지정 시 Date.now() 사용', async () => {
+    const NOW = 999_999;
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: NOW,
+      scheduledCount: 1,
+      firedCount: 0,
+      stationAccurateCount: 0,
+      fireDeltaSamplesMs: [],
+    });
+    mockUploadPrescheduledTelemetry.mockResolvedValue({ ok: true, status: 200 });
+
+    await computeAndUploadTripPrescheduled({ tripStart: 0 });
+
+    const callArg = mockComputePrescheduledMetrics.mock.calls[0][0];
+    expect(callArg.tripEnd).toBe(NOW);
+    (Date.now as jest.Mock).mockRestore();
   });
 });

--- a/src/features/alarm/utils/__tests__/alarmLogTelemetry.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLogTelemetry.test.ts
@@ -293,7 +293,7 @@ describe('computeAndUploadTripPrescheduled', () => {
     await computeAndUploadTripPrescheduled({ tripStart: 0, tripEnd: 1000 });
 
     const callArg = mockComputePrescheduledMetrics.mock.calls[0][0];
-    expect(Array.from(callArg.firedStationNames).sort()).toEqual(['In']);
+    expect([...callArg.firedStationNames]).toEqual(['In']);
   });
 
   it('upload 실패해도 throw 안 함', async () => {

--- a/src/features/alarm/utils/__tests__/prescheduledMetrics.test.ts
+++ b/src/features/alarm/utils/__tests__/prescheduledMetrics.test.ts
@@ -1,0 +1,314 @@
+/**
+ * A3 사전 예약 효과 측정 ledger + compute 테스트 (#918).
+ *
+ * - ledger record/clear/read 동작 검증 (AsyncStorage RMW)
+ * - computePrescheduledMetrics: 윈도우 필터, miss/accuracy/delta 산출
+ * - graceful skip: malformed JSON, non-tba identifier, NaN scheduledFireMs
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  LEDGER_MAX_ENTRIES,
+  clearPrescheduledLedger,
+  computePrescheduledMetrics,
+  isEmptyPrescheduledMetrics,
+  readPrescheduledLedger,
+  recordFiredAlarm,
+  recordScheduledAlarm,
+  stationNameFromIdentifier,
+} from '../prescheduledMetrics';
+import { PRESCHEDULED_LEDGER_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const mem = new Map<string, string>();
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((k: string) => Promise.resolve(mem.has(k) ? (mem.get(k) ?? null) : null)),
+      setItem: jest.fn((k: string, v: string) => {
+        mem.set(k, v);
+        return Promise.resolve();
+      }),
+      removeItem: jest.fn((k: string) => {
+        mem.delete(k);
+        return Promise.resolve();
+      }),
+      __mem: mem,
+    },
+  };
+});
+
+const mem: Map<string, string> = (AsyncStorage as unknown as { __mem: Map<string, string> }).__mem;
+
+beforeEach(() => {
+  mem.clear();
+  jest.clearAllMocks();
+});
+
+describe('recordScheduledAlarm', () => {
+  it('non-tba prefix는 ledger에 적재하지 않는다', async () => {
+    await recordScheduledAlarm({ identifier: 'alarm:early:강남', scheduledFireMs: 100 });
+    expect(mem.get(PRESCHEDULED_LEDGER_KEY)).toBeUndefined();
+  });
+
+  it('NaN/Infinity scheduledFireMs는 skip', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:강남', scheduledFireMs: Number.NaN });
+    await recordScheduledAlarm({
+      identifier: 'tba:early:강남',
+      scheduledFireMs: Number.POSITIVE_INFINITY,
+    });
+    expect(mem.get(PRESCHEDULED_LEDGER_KEY)).toBeUndefined();
+  });
+
+  it('새 identifier는 append', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    await recordScheduledAlarm({ identifier: 'tba:imminent:A', scheduledFireMs: 200 });
+    const ledger = await readPrescheduledLedger();
+    expect(ledger).toEqual([
+      { identifier: 'tba:early:A', scheduledFireMs: 100 },
+      { identifier: 'tba:imminent:A', scheduledFireMs: 200 },
+    ]);
+  });
+
+  it('같은 identifier 재호출은 entry 갱신 + actualFireMs reset (새 trip 재예약)', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    await recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: 150 });
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 500 });
+    const ledger = await readPrescheduledLedger();
+    expect(ledger).toEqual([{ identifier: 'tba:early:A', scheduledFireMs: 500 }]);
+  });
+
+  it('ledger 상한 초과 시 oldest 절단', async () => {
+    for (let i = 0; i < LEDGER_MAX_ENTRIES + 3; i++) {
+      await recordScheduledAlarm({ identifier: `tba:early:S${i}`, scheduledFireMs: i });
+    }
+    const ledger = await readPrescheduledLedger();
+    expect(ledger.length).toBe(LEDGER_MAX_ENTRIES);
+    // oldest 3건이 잘려나가야 함
+    expect(ledger[0].identifier).toBe('tba:early:S3');
+    expect(ledger[ledger.length - 1].identifier).toBe(`tba:early:S${LEDGER_MAX_ENTRIES + 2}`);
+  });
+
+  it('AsyncStorage setItem 실패 시 graceful (throw 안 함)', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    await expect(
+      recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('recordFiredAlarm', () => {
+  it('ledger에 없는 identifier는 no-op', async () => {
+    await recordFiredAlarm({ identifier: 'tba:early:Unknown', actualFireMs: 500 });
+    expect(mem.get(PRESCHEDULED_LEDGER_KEY)).toBeUndefined();
+  });
+
+  it('non-tba prefix는 무시', async () => {
+    await recordFiredAlarm({ identifier: 'alarm:early:A', actualFireMs: 500 });
+    expect(mem.get(PRESCHEDULED_LEDGER_KEY)).toBeUndefined();
+  });
+
+  it('NaN actualFireMs는 skip', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    await recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: Number.NaN });
+    const ledger = await readPrescheduledLedger();
+    expect(ledger[0].actualFireMs).toBeUndefined();
+  });
+
+  it('정상 케이스 — actualFireMs 기록', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    await recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: 150 });
+    const ledger = await readPrescheduledLedger();
+    expect(ledger[0].actualFireMs).toBe(150);
+  });
+
+  it('AsyncStorage read 실패는 graceful', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    await expect(
+      recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: 100 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('AsyncStorage write 실패도 graceful (recordFiredAlarm catch)', async () => {
+    // ledger entry는 있어서 writeLedger까지 도달해야 함
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('write fail'));
+    await expect(
+      recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: 150 }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('readPrescheduledLedger', () => {
+  it('JSON 깨졌으면 빈 배열 반환 (graceful)', async () => {
+    mem.set(PRESCHEDULED_LEDGER_KEY, 'not-json');
+    expect(await readPrescheduledLedger()).toEqual([]);
+  });
+
+  it('JSON이 배열 아니면 빈 배열 반환', async () => {
+    mem.set(PRESCHEDULED_LEDGER_KEY, '{"foo": "bar"}');
+    expect(await readPrescheduledLedger()).toEqual([]);
+  });
+
+  it('entry 일부가 shape 위반이면 정상 entry만 보존', async () => {
+    mem.set(
+      PRESCHEDULED_LEDGER_KEY,
+      JSON.stringify([
+        { identifier: 'tba:early:A', scheduledFireMs: 100 },
+        null, // null entry
+        'string-entry', // primitive
+        { identifier: 'alarm:early:B', scheduledFireMs: 200 }, // wrong prefix
+        { identifier: 'tba:early:C', scheduledFireMs: 'x' }, // wrong type
+        { identifier: 'tba:early:D', scheduledFireMs: 400, actualFireMs: 'x' }, // bad actual
+      ]),
+    );
+    const ledger = await readPrescheduledLedger();
+    expect(ledger).toEqual([{ identifier: 'tba:early:A', scheduledFireMs: 100 }]);
+  });
+
+  it('AsyncStorage getItem 실패 시 빈 배열', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    expect(await readPrescheduledLedger()).toEqual([]);
+  });
+
+  it('빈 키는 빈 배열', async () => {
+    expect(await readPrescheduledLedger()).toEqual([]);
+  });
+});
+
+describe('clearPrescheduledLedger', () => {
+  it('키 제거 — 다음 read는 빈 배열', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    await clearPrescheduledLedger();
+    expect(await readPrescheduledLedger()).toEqual([]);
+  });
+
+  it('removeItem 실패는 graceful', async () => {
+    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    await expect(clearPrescheduledLedger()).resolves.toBeUndefined();
+  });
+});
+
+describe('stationNameFromIdentifier', () => {
+  it('정상 identifier에서 station name 추출', () => {
+    expect(stationNameFromIdentifier('tba:early:강남')).toBe('강남');
+    expect(stationNameFromIdentifier('tba:imminent:서울역')).toBe('서울역');
+  });
+
+  it('station이 콜론 포함하는 경우 첫 콜론 뒤 전체', () => {
+    expect(stationNameFromIdentifier('tba:early:A:B')).toBe('A:B');
+  });
+
+  it('non-tba prefix는 null', () => {
+    expect(stationNameFromIdentifier('alarm:early:A')).toBeNull();
+    expect(stationNameFromIdentifier('A')).toBeNull();
+  });
+
+  it('phaseId만 있고 station 없으면 null', () => {
+    expect(stationNameFromIdentifier('tba:early')).toBeNull();
+    expect(stationNameFromIdentifier('tba:early:')).toBeNull();
+  });
+
+  it('phase 부분이 비어 있어도 station 추출은 시도 안 함 (콜론 시작 위반)', () => {
+    // 'tba::A' → rest=':A', colon=0 (콜론이 0번째) → colon<=0 → null
+    expect(stationNameFromIdentifier('tba::A')).toBeNull();
+  });
+});
+
+describe('computePrescheduledMetrics', () => {
+  it('ledger 비어있으면 모든 카운트 0', async () => {
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(),
+    });
+    expect(result.scheduledCount).toBe(0);
+    expect(result.firedCount).toBe(0);
+    expect(result.stationAccurateCount).toBe(0);
+    expect(result.fireDeltaSamplesMs).toEqual([]);
+    expect(isEmptyPrescheduledMetrics(result)).toBe(true);
+  });
+
+  it('윈도우 밖 entry는 제외 (scheduledFireMs < tripStart)', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:Out', scheduledFireMs: -100 });
+    await recordScheduledAlarm({ identifier: 'tba:early:In', scheduledFireMs: 500 });
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(),
+    });
+    expect(result.scheduledCount).toBe(1);
+  });
+
+  it('윈도우 밖 entry는 제외 (scheduledFireMs > tripEnd)', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:Out', scheduledFireMs: 2000 });
+    await recordScheduledAlarm({ identifier: 'tba:early:In', scheduledFireMs: 500 });
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(),
+    });
+    expect(result.scheduledCount).toBe(1);
+  });
+
+  it('윈도우 경계 (=)는 포함', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:Start', scheduledFireMs: 0 });
+    await recordScheduledAlarm({ identifier: 'tba:early:End', scheduledFireMs: 1000 });
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(),
+    });
+    expect(result.scheduledCount).toBe(2);
+  });
+
+  it('actualFireMs 있는 entry만 firedCount + delta 카운트', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    await recordScheduledAlarm({ identifier: 'tba:early:B', scheduledFireMs: 200 });
+    await recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: 110 });
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(),
+    });
+    expect(result.scheduledCount).toBe(2);
+    expect(result.firedCount).toBe(1);
+    expect(result.fireDeltaSamplesMs).toEqual([10]);
+  });
+
+  it('fired entry의 station이 firedStationNames에 있으면 정확도 카운트', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    await recordScheduledAlarm({ identifier: 'tba:imminent:B', scheduledFireMs: 200 });
+    await recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: 110 });
+    await recordFiredAlarm({ identifier: 'tba:imminent:B', actualFireMs: 210 });
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(['A']),
+    });
+    expect(result.firedCount).toBe(2);
+    expect(result.stationAccurateCount).toBe(1);
+  });
+
+  it('음수 delta (시계 보정으로 더 일찍 발사) 그대로 보존', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 200 });
+    await recordFiredAlarm({ identifier: 'tba:early:A', actualFireMs: 150 });
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(),
+    });
+    expect(result.fireDeltaSamplesMs).toEqual([-50]);
+  });
+
+  it('scheduled=1만 있고 fire 없으면 isEmpty=false (miss 신호 의미 있음)', async () => {
+    await recordScheduledAlarm({ identifier: 'tba:early:A', scheduledFireMs: 100 });
+    const result = await computePrescheduledMetrics({
+      tripStart: 0,
+      tripEnd: 1000,
+      firedStationNames: new Set(),
+    });
+    expect(isEmptyPrescheduledMetrics(result)).toBe(false);
+  });
+});

--- a/src/features/alarm/utils/__tests__/prescheduledMetrics.test.ts
+++ b/src/features/alarm/utils/__tests__/prescheduledMetrics.test.ts
@@ -87,7 +87,7 @@ describe('recordScheduledAlarm', () => {
     expect(ledger.length).toBe(LEDGER_MAX_ENTRIES);
     // oldest 3건이 잘려나가야 함
     expect(ledger[0].identifier).toBe('tba:early:S3');
-    expect(ledger[ledger.length - 1].identifier).toBe(`tba:early:S${LEDGER_MAX_ENTRIES + 2}`);
+    expect(ledger.at(-1)?.identifier).toBe(`tba:early:S${LEDGER_MAX_ENTRIES + 2}`);
   });
 
   it('AsyncStorage setItem 실패 시 graceful (throw 안 함)', async () => {

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -17,6 +17,11 @@ jest.mock('../notificationState', () => ({
   setLastFiredAlarmStationName: jest.fn(),
 }));
 
+const mockRecordFiredAlarm = jest.fn();
+jest.mock('../prescheduledMetrics', () => ({
+  recordFiredAlarm: (...args: unknown[]) => mockRecordFiredAlarm(...args),
+}));
+
 const mockErrorSpy = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -56,6 +61,8 @@ let appStateSpy: jest.SpyInstance;
 beforeEach(async () => {
   jest.clearAllMocks();
   mockErrorSpy.mockClear();
+  mockRecordFiredAlarm.mockReset();
+  mockRecordFiredAlarm.mockResolvedValue(undefined);
   mockGetFiredAlarms.mockResolvedValue(new Set());
   mockSetFiredAlarms.mockResolvedValue(undefined);
   mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
@@ -284,5 +291,74 @@ describe('registerScheduledAlarmListener', () => {
 describe('awaitInitialScheduledAlarmDrain', () => {
   it('리스너가 등록되지 않았으면 즉시 resolve한다', async () => {
     await expect(awaitInitialScheduledAlarmDrain()).resolves.toBeUndefined();
+  });
+});
+
+describe('#918 A3 prescheduled fire ledger 기록', () => {
+  it('drain 시 Notification.date를 actualFireMs로 전달 (BG 발사 시점 보존)', async () => {
+    mockGetPresented.mockResolvedValueOnce([
+      { date: 1234567890, request: { identifier: 'tba:early:강남' } },
+    ]);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockRecordFiredAlarm).toHaveBeenCalledWith({
+      identifier: 'tba:early:강남',
+      actualFireMs: 1234567890,
+    });
+    handle.remove();
+  });
+
+  it('drain 시 date가 number 아니면 Date.now() 폴백', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(999_999);
+    mockGetPresented.mockResolvedValueOnce([
+      { date: undefined, request: { identifier: 'tba:early:A' } },
+    ]);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockRecordFiredAlarm).toHaveBeenCalledWith({
+      identifier: 'tba:early:A',
+      actualFireMs: 999_999,
+    });
+    handle.remove();
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('FG 수신 시 notification.date를 그대로 전달', async () => {
+    mockAddListener.mockImplementationOnce((cb) => {
+      void cb({ date: 7777, request: { identifier: 'tba:early:Foo' } });
+      return { remove: jest.fn() };
+    });
+
+    const handle = registerScheduledAlarmListener();
+    await flushAsync();
+
+    expect(mockRecordFiredAlarm).toHaveBeenCalledWith({
+      identifier: 'tba:early:Foo',
+      actualFireMs: 7777,
+    });
+    handle.remove();
+  });
+
+  it('FG 수신 시 date가 number 아니면 Date.now() 폴백', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(555);
+    mockAddListener.mockImplementationOnce((cb) => {
+      // date 누락
+      void cb({ request: { identifier: 'tba:early:Bar' } });
+      return { remove: jest.fn() };
+    });
+
+    const handle = registerScheduledAlarmListener();
+    await flushAsync();
+
+    expect(mockRecordFiredAlarm).toHaveBeenCalledWith({
+      identifier: 'tba:early:Bar',
+      actualFireMs: 555,
+    });
+    handle.remove();
+    (Date.now as jest.Mock).mockRestore();
   });
 });

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -329,7 +329,7 @@ describe('#918 A3 prescheduled fire ledger 기록', () => {
 
   it('FG 수신 시 notification.date를 그대로 전달', async () => {
     mockAddListener.mockImplementationOnce((cb) => {
-      void cb({ date: 7777, request: { identifier: 'tba:early:Foo' } });
+      cb({ date: 7777, request: { identifier: 'tba:early:Foo' } });
       return { remove: jest.fn() };
     });
 
@@ -347,7 +347,7 @@ describe('#918 A3 prescheduled fire ledger 기록', () => {
     jest.spyOn(Date, 'now').mockReturnValue(555);
     mockAddListener.mockImplementationOnce((cb) => {
       // date 누락
-      void cb({ request: { identifier: 'tba:early:Bar' } });
+      cb({ request: { identifier: 'tba:early:Bar' } });
       return { remove: jest.fn() };
     });
 

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -8,6 +8,7 @@
 const mockGetItem = jest.fn();
 const mockSetItem = jest.fn();
 const mockComputeAndUploadTripRecall = jest.fn();
+const mockComputeAndUploadTripPrescheduled = jest.fn();
 const mockComputeRouteArc = jest.fn();
 const mockGetTripStartedAt = jest.fn();
 
@@ -21,6 +22,8 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 jest.mock('../alarmLogTelemetry', () => ({
   computeAndUploadTripRecall: (...args: unknown[]) => mockComputeAndUploadTripRecall(...args),
+  computeAndUploadTripPrescheduled: (...args: unknown[]) =>
+    mockComputeAndUploadTripPrescheduled(...args),
 }));
 
 jest.mock('../../../route/utils/routeProgress', () => ({
@@ -46,6 +49,7 @@ import {
   ROUTE_KEY,
   TRIP_ORIGIN_KEY,
   LAST_UPLOADED_RECALL_TRIP_START_KEY,
+  LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 const ROUTE_JSON = JSON.stringify({ type: 'direct', line: '2', stops: 3, travelSeconds: 300 });
@@ -69,6 +73,8 @@ describe('triggerTripEndRecall', () => {
     mockGetItem.mockReset();
     mockSetItem.mockReset();
     mockComputeAndUploadTripRecall.mockReset();
+    mockComputeAndUploadTripPrescheduled.mockReset();
+    mockComputeAndUploadTripPrescheduled.mockResolvedValue({ uploaded: false });
     mockComputeRouteArc.mockReset();
     mockGetTripStartedAt.mockReset();
   });
@@ -182,6 +188,98 @@ describe('triggerTripEndRecall', () => {
     const result = await triggerTripEndRecall();
 
     expect(result).toEqual({ uploaded: false, skipped: 'error' });
+  });
+
+  it('#918 — prescheduled 트리거 호출: uploaded=true 시 LAST_UPLOADED_PRESCHEDULED 기록', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue({
+      stations: ROUTE_ARC_STATIONS,
+      arcM: [0, 1, 2],
+      totalLengthM: 2,
+    });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockComputeAndUploadTripPrescheduled.mockResolvedValue({ uploaded: true });
+    mockSetItem.mockResolvedValue(undefined);
+
+    await triggerTripEndRecall();
+
+    expect(mockComputeAndUploadTripPrescheduled).toHaveBeenCalledWith({ tripStart: 100 });
+    expect(mockSetItem).toHaveBeenCalledWith(LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY, '100');
+  });
+
+  it('#918 — prescheduled uploaded=false면 LAST_UPLOADED_PRESCHEDULED 기록 안 함', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue({
+      stations: ROUTE_ARC_STATIONS,
+      arcM: [0, 1, 2],
+      totalLengthM: 2,
+    });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockComputeAndUploadTripPrescheduled.mockResolvedValue({ uploaded: false, skipped: 'empty' });
+    mockSetItem.mockResolvedValue(undefined);
+
+    await triggerTripEndRecall();
+
+    const presetCalls = mockSetItem.mock.calls.filter(
+      (c) => c[0] === LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY,
+    );
+    expect(presetCalls).toHaveLength(0);
+  });
+
+  it('#918 — prescheduled 마커가 같은 tripStart면 trigger skip (중복 차단)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY]: '100',
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue({
+      stations: ROUTE_ARC_STATIONS,
+      arcM: [0, 1, 2],
+      totalLengthM: 2,
+    });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+
+    await triggerTripEndRecall();
+
+    expect(mockComputeAndUploadTripPrescheduled).not.toHaveBeenCalled();
+  });
+
+  it('#918 — prescheduled trigger 예외도 흡수 (recall 결과는 영향 없음)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+    });
+    mockComputeRouteArc.mockReturnValue({
+      stations: ROUTE_ARC_STATIONS,
+      arcM: [0, 1, 2],
+      totalLengthM: 2,
+    });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockComputeAndUploadTripPrescheduled.mockRejectedValue(new Error('boom'));
+
+    const result = await triggerTripEndRecall();
+    expect(result.uploaded).toBe(true); // recall 성공 영향 없음
   });
 
   it('LAST_UPLOADED 값이 다른 tripStart면 정상 upload 진행', async () => {

--- a/src/features/alarm/utils/alarmLogTelemetry.ts
+++ b/src/features/alarm/utils/alarmLogTelemetry.ts
@@ -14,13 +14,21 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { APNS_TOKEN_KEY } from '../../../shared/constants/storageKeys';
-import { getAlarmLog } from './alarmLog';
+import { getAlarmLog, type AlarmLogEntry } from './alarmLog';
 import {
   computeTripRecall,
   isEmptyRecall,
   type TripRecallResult,
 } from './recallMetrics';
-import { uploadRecallTelemetry } from '../api/telemetryBackend';
+import {
+  computePrescheduledMetrics,
+  isEmptyPrescheduledMetrics,
+  type PrescheduledMetricsResult,
+} from './prescheduledMetrics';
+import {
+  uploadPrescheduledTelemetry,
+  uploadRecallTelemetry,
+} from '../api/telemetryBackend';
 import { createLogger } from '../../../shared/utils/logger';
 
 const log = createLogger('alarmLogTelemetry');
@@ -72,4 +80,75 @@ export async function computeAndUploadTripRecall(
     log.warn('recall upload error', e);
     return { uploaded: false, skipped: 'error' };
   }
+}
+
+export interface ComputeAndUploadTripPrescheduledInput {
+  /** trip 시작 epoch ms — ledger 필터 lower bound. */
+  tripStart: number;
+  /** trip 종료 epoch ms — ledger 필터 upper bound (default now). */
+  tripEnd?: number;
+}
+
+export interface ComputeAndUploadTripPrescheduledResult {
+  uploaded: boolean;
+  skipped?: ComputeAndUploadSkipReason;
+  metrics?: PrescheduledMetricsResult;
+}
+
+/**
+ * A3 사전 예약 효과 텔레메트리 trip-end trigger (#918, Epic #912 P1).
+ *
+ * `computeAndUploadTripRecall`과 동형 — APNs token이 없거나 ledger가 비어있으면 graceful skip.
+ * alarmLog는 한 번만 읽어 fired stationName 집합을 만들고 prescheduledMetrics에 전달
+ * (recall + prescheduled 양쪽 모두 alarmLog 의존이지만 caller가 각각 호출하므로 두 번 읽힘 —
+ * trip-end는 자주 일어나지 않아 비용 무시 가능).
+ */
+export async function computeAndUploadTripPrescheduled(
+  input: ComputeAndUploadTripPrescheduledInput,
+): Promise<ComputeAndUploadTripPrescheduledResult> {
+  try {
+    const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+    if (!token) {
+      log.info('no APNs token — skip prescheduled upload');
+      return { uploaded: false, skipped: 'no-token' };
+    }
+
+    const entries = await getAlarmLog();
+    const tripEnd = input.tripEnd ?? Date.now();
+    const firedStationNames = collectFiredStationNames(entries, input.tripStart, tripEnd);
+    const metrics = await computePrescheduledMetrics({
+      tripStart: input.tripStart,
+      tripEnd,
+      firedStationNames,
+    });
+
+    if (isEmptyPrescheduledMetrics(metrics)) {
+      return { uploaded: false, skipped: 'empty', metrics };
+    }
+
+    const result = await uploadPrescheduledTelemetry(token, metrics);
+    return { uploaded: result.ok, metrics };
+  } catch (e) {
+    log.warn('prescheduled upload error', e);
+    return { uploaded: false, skipped: 'error' };
+  }
+}
+
+/**
+ * 윈도우 안 fired outcome entry에서 stationName 집합을 추출. prescheduledMetrics의 정확도 분자
+ * 산출에 사용. recallMetrics는 routeStops ∩ fired를 보는 반면 prescheduled는 ledger identifier에서
+ * 파싱한 station을 cross-key로 한다.
+ */
+function collectFiredStationNames(
+  entries: readonly AlarmLogEntry[],
+  tripStart: number,
+  tripEnd: number,
+): Set<string> {
+  const out = new Set<string>();
+  for (const entry of entries) {
+    if (entry.ts <= tripStart || entry.ts > tripEnd) continue;
+    if (entry.outcome !== 'fired') continue;
+    if (entry.stationName) out.add(entry.stationName);
+  }
+  return out;
 }

--- a/src/features/alarm/utils/prescheduledMetrics.ts
+++ b/src/features/alarm/utils/prescheduledMetrics.ts
@@ -1,0 +1,232 @@
+/**
+ * A3 사전 예약 효과 측정 인프라 (#918, Epic #912 P1).
+ *
+ * `tripBoundScheduler.prescheduleStationAlerts`가 OS local notification으로 사전 예약한
+ * 매역 알람이 실제로 발사됐는지/예측 시각 대비 얼마나 어긋났는지를 ledger 기반으로 측정한다.
+ *
+ * 산출 지표 (Phase 4 결정 게이트 아님 — 운영 KPI / A4 metrics catalog로 노출):
+ *  - prescheduledFireDeltaMs   : histogram (actualFireMs - scheduledFireMs)
+ *      → OS local notification 타이밍 정확도. 큰 양수면 OS가 늦게 발사,
+ *        음수면 timer drift / 시계 보정으로 더 일찍 발사된 케이스.
+ *  - prescheduledFireMissRate  : rate (hit=missed, total=scheduled)
+ *      → trip 종료 시점까지 fire ledger에 actualFireMs가 기록되지 않은 비율.
+ *        cancel/취소/OS drop을 모두 포함 — A4 recall과 보완 신호 (사전 예약 단독).
+ *  - prescheduledStationAccuracy : rate (hit=correctStation, total=fired)
+ *      → fired entry 중 alarmLog가 같은 station에서 fired outcome을 남긴 비율.
+ *        identifier에서 phaseId/stationName을 파싱하므로 별도 cross-key 불필요.
+ *
+ * 동작 변경 없음 — 순수 측정 모듈. ledger는 trip마다 시작 시 cleared, fire ledger entry는
+ * 최대 LEDGER_MAX_ENTRIES(200)건만 보관 (스마트폰 1 trip 최대 ~40역 × 2 phase = 80건이라
+ * 여유). 보관 초과 시 oldest 절단.
+ *
+ * Privacy: 좌표/원문 미적재. identifier(`tba:phaseId:stationName`)는 사용자 stations.json에서
+ * 식별 가능한 정보지만 backend는 token prefix(8자) anonymous aggregate만 사용 — recallTelemetry
+ * 정책 동일.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createLogger } from '../../../shared/utils/logger';
+import { PRESCHEDULED_LEDGER_KEY } from '../../../shared/constants/storageKeys';
+// NOTE: `tripBoundScheduler.ts`의 `TRIP_BOUND_ALARM_PREFIX`와 동일 값 — 모듈 간 순환 import
+// 방지를 위해 로컬 상수로 보관. tripBoundScheduler에서 prefix가 바뀌면 본 파일도 동시 업데이트.
+const TRIP_BOUND_ALARM_PREFIX = 'tba:';
+
+const log = createLogger('prescheduledMetrics');
+
+/** Ledger 크기 상한 — 1 trip 최대 ~40역 × 2 phase 여유. 초과분은 oldest 절단. */
+export const LEDGER_MAX_ENTRIES = 200;
+
+/**
+ * Ledger entry 1건. identifier는 `tba:phaseId:stationName` (tripBoundAlarmIdentifier 산출물).
+ * 같은 identifier가 한 trip 안에 두 번 등장하지 않는다 — tripBoundScheduler가 occurrence suffix로
+ * 충돌 방지.
+ */
+export interface PrescheduledLedgerEntry {
+  identifier: string;
+  /** 사전 예약 시점에 호출자가 예측한 발사 시각 (epoch ms). */
+  scheduledFireMs: number;
+  /** 발사 ledger 기록 시각 (epoch ms). 미발사면 undefined. */
+  actualFireMs?: number;
+}
+
+export type PrescheduledLedger = PrescheduledLedgerEntry[];
+
+async function readLedger(): Promise<PrescheduledLedger> {
+  try {
+    const raw = await AsyncStorage.getItem(PRESCHEDULED_LEDGER_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // shape 가드 — entry 일부가 깨져도 전체 ledger 폐기보다 정상 entry만 보존.
+    return parsed.filter(isLedgerEntry);
+  } catch (e) {
+    log.warn('ledger read failed — start fresh', e);
+    return [];
+  }
+}
+
+function isLedgerEntry(v: unknown): v is PrescheduledLedgerEntry {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.identifier !== 'string' || !o.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) {
+    return false;
+  }
+  if (typeof o.scheduledFireMs !== 'number' || !Number.isFinite(o.scheduledFireMs)) return false;
+  if (o.actualFireMs !== undefined) {
+    if (typeof o.actualFireMs !== 'number' || !Number.isFinite(o.actualFireMs)) return false;
+  }
+  return true;
+}
+
+async function writeLedger(ledger: PrescheduledLedger): Promise<void> {
+  // 상한 절단 — oldest(앞쪽) 제거.
+  const trimmed =
+    ledger.length > LEDGER_MAX_ENTRIES
+      ? ledger.slice(ledger.length - LEDGER_MAX_ENTRIES)
+      : ledger;
+  await AsyncStorage.setItem(PRESCHEDULED_LEDGER_KEY, JSON.stringify(trimmed));
+}
+
+/**
+ * tripBoundScheduler가 사전 예약 1건 등록 직후 호출. 같은 identifier가 ledger에 이미 있으면
+ * scheduledFireMs를 갱신하고 actualFireMs는 reset (재예약 케이스 — 새 trip).
+ */
+export async function recordScheduledAlarm(input: {
+  identifier: string;
+  scheduledFireMs: number;
+}): Promise<void> {
+  if (!input.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) return;
+  if (!Number.isFinite(input.scheduledFireMs)) return;
+  try {
+    const ledger = await readLedger();
+    const idx = ledger.findIndex((e) => e.identifier === input.identifier);
+    const entry: PrescheduledLedgerEntry = {
+      identifier: input.identifier,
+      scheduledFireMs: input.scheduledFireMs,
+    };
+    if (idx >= 0) {
+      ledger[idx] = entry;
+    } else {
+      ledger.push(entry);
+    }
+    await writeLedger(ledger);
+  } catch (e) {
+    log.warn('recordScheduledAlarm failed', e);
+  }
+}
+
+/**
+ * `tba:` 알람 발사 수신 시 호출 (scheduledAlarmReceiver). ledger에 entry가 없으면 no-op —
+ * 다른 trip의 잔여 발화이거나 ledger reset 후 발사된 케이스. fire ledger entry는 actualFireMs만 set.
+ */
+export async function recordFiredAlarm(input: {
+  identifier: string;
+  actualFireMs: number;
+}): Promise<void> {
+  if (!input.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) return;
+  if (!Number.isFinite(input.actualFireMs)) return;
+  try {
+    const ledger = await readLedger();
+    const idx = ledger.findIndex((e) => e.identifier === input.identifier);
+    if (idx < 0) return;
+    ledger[idx] = { ...ledger[idx], actualFireMs: input.actualFireMs };
+    await writeLedger(ledger);
+  } catch (e) {
+    log.warn('recordFiredAlarm failed', e);
+  }
+}
+
+/** trip 종료/새 trip 시작 시 호출. 다음 trip은 깨끗한 ledger에서 시작. */
+export async function clearPrescheduledLedger(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(PRESCHEDULED_LEDGER_KEY);
+  } catch (e) {
+    log.warn('clearPrescheduledLedger failed', e);
+  }
+}
+
+/** test/debug 용 — ledger 현 상태 노출. 외부 호출자는 일반적으로 compute*만 호출. */
+export async function readPrescheduledLedger(): Promise<PrescheduledLedger> {
+  return readLedger();
+}
+
+/**
+ * identifier `tba:phaseId:stationName`에서 station name 추출. 형식 위반은 null.
+ * recallMetrics의 cross-check(같은 stationName이 alarmLog fired에 있는지)에 사용.
+ */
+export function stationNameFromIdentifier(identifier: string): string | null {
+  if (!identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) return null;
+  const rest = identifier.slice(TRIP_BOUND_ALARM_PREFIX.length);
+  const colon = rest.indexOf(':');
+  if (colon <= 0) return null;
+  const name = rest.slice(colon + 1);
+  return name.length > 0 ? name : null;
+}
+
+export interface PrescheduledMetricsResult {
+  /** trip 윈도우 lower bound (inclusive, scheduledFireMs ≥ tripStart). */
+  tripStart: number;
+  /** trip 윈도우 upper bound. */
+  tripEnd: number;
+  /** scheduledFireMs가 윈도우에 포함되는 ledger entry 수. */
+  scheduledCount: number;
+  /** 그 중 actualFireMs가 기록된 entry 수. */
+  firedCount: number;
+  /** 그 중 alarmLog fired와 station이 일치한 entry 수 (정확도 분자). */
+  stationAccurateCount: number;
+  /** scheduledFireMs - actualFireMs 차이 (양수 = OS 늦게 발사). fired entry만. */
+  fireDeltaSamplesMs: readonly number[];
+}
+
+export interface ComputeMetricsInput {
+  /** trip 시작 epoch ms — entry.scheduledFireMs ≥ tripStart인 ledger entry만 포함. */
+  tripStart: number;
+  /** trip 종료 epoch ms — entry.scheduledFireMs ≤ tripEnd인 ledger entry만 포함. */
+  tripEnd: number;
+  /**
+   * alarmLog의 fired entries에서 추출된 station name 집합. recallMetrics가 동일 입력으로
+   * 산출하므로 호출자가 한 번만 alarmLog를 읽어 양쪽에 전달한다.
+   */
+  firedStationNames: ReadonlySet<string>;
+}
+
+export async function computePrescheduledMetrics(
+  input: ComputeMetricsInput,
+): Promise<PrescheduledMetricsResult> {
+  const { tripStart, tripEnd, firedStationNames } = input;
+  const ledger = await readLedger();
+
+  const fireDeltaSamplesMs: number[] = [];
+  let scheduledCount = 0;
+  let firedCount = 0;
+  let stationAccurateCount = 0;
+
+  for (const entry of ledger) {
+    if (entry.scheduledFireMs < tripStart || entry.scheduledFireMs > tripEnd) continue;
+    scheduledCount++;
+    if (entry.actualFireMs === undefined) continue;
+    firedCount++;
+    fireDeltaSamplesMs.push(entry.actualFireMs - entry.scheduledFireMs);
+    const stationName = stationNameFromIdentifier(entry.identifier);
+    if (stationName !== null && firedStationNames.has(stationName)) {
+      stationAccurateCount++;
+    }
+  }
+
+  return {
+    tripStart,
+    tripEnd,
+    scheduledCount,
+    firedCount,
+    stationAccurateCount,
+    fireDeltaSamplesMs,
+  };
+}
+
+/**
+ * upload 의미가 있는지 — scheduled=0이면 사전 예약 자체가 없었던 trip(lock 없이 시작 등).
+ * 빈 신호 전송으로 backend 노이즈 증가 막기 위한 가드.
+ */
+export function isEmptyPrescheduledMetrics(result: PrescheduledMetricsResult): boolean {
+  return result.scheduledCount === 0;
+}

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -9,6 +9,7 @@ import {
 } from './notificationState';
 import { DESTINATION_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
+import { recordFiredAlarm } from './prescheduledMetrics';
 
 const logger = createLogger('ScheduledAlarmReceiver');
 
@@ -37,7 +38,14 @@ async function getCurrentDestinationId(): Promise<string | null> {
  * - LAST_FIRED_ALARM_STATION_NAME_KEY를 해당 역 이름으로 갱신 → BGAppRefreshTask가
  *   다음 사이클에서 Arrival API를 올바른 기준역으로 호출.
  */
-export async function reconcileScheduledAlarmDelivery(identifier: string): Promise<void> {
+export async function reconcileScheduledAlarmDelivery(
+  identifier: string,
+  actualFireMs: number = Date.now(),
+): Promise<void> {
+  // #918 A3 measurement — `tba:` prefix 사전 예약 알람 발사 시각 ledger 기록.
+  // `alarm:` prefix와 무관 — graceful no-op for non-tba identifier.
+  await recordFiredAlarm({ identifier, actualFireMs });
+
   const parsed = parseScheduledAlarmIdentifier(identifier);
   if (!parsed) return;
 
@@ -63,6 +71,13 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
   } catch (e) {
     logger.error('delivered 알람 조회 실패:', e);
     return;
+  }
+
+  // #918 A3 — `tba:` prefix BG-fired 알람도 ledger에 fire ts 기록. Notification.date(epoch ms)
+  // 가 OS의 실제 발사 시각 — drain 시점(=FG resume)이 아닌 발사 시점을 정확히 측정.
+  for (const n of presented) {
+    const fireMs = typeof n.date === 'number' ? n.date : Date.now();
+    await recordFiredAlarm({ identifier: n.request.identifier, actualFireMs: fireMs });
   }
 
   const destinationId = await getCurrentDestinationId();
@@ -123,7 +138,11 @@ export function registerScheduledAlarmListener(): ScheduledAlarmListenerHandle {
   initialDrainPromise = drainDeliveredScheduledAlarms();
 
   const notifSub = Notifications.addNotificationReceivedListener((notification) => {
-    void reconcileScheduledAlarmDelivery(notification.request.identifier);
+    // #918 A3 — Notification.date는 OS가 기록한 실제 발사 시각(epoch ms). Date.now() 폴백.
+    void reconcileScheduledAlarmDelivery(
+      notification.request.identifier,
+      typeof notification.date === 'number' ? notification.date : Date.now(),
+    );
   });
 
   const onAppStateChange = (state: AppStateStatus): void => {

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -30,11 +30,15 @@ import {
   ROUTE_KEY,
   TRIP_ORIGIN_KEY,
   LAST_UPLOADED_RECALL_TRIP_START_KEY,
+  LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY,
 } from '../../../shared/constants/storageKeys';
 import type { Station } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { computeRouteArc } from '../../route/utils/routeProgress';
-import { computeAndUploadTripRecall } from './alarmLogTelemetry';
+import {
+  computeAndUploadTripPrescheduled,
+  computeAndUploadTripRecall,
+} from './alarmLogTelemetry';
 import { getTripStartedAt } from './tripStartStorage';
 import { createLogger } from '../../../shared/utils/logger';
 
@@ -92,10 +96,40 @@ export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult
       await AsyncStorage.setItem(LAST_UPLOADED_RECALL_TRIP_START_KEY, String(tripStart));
     }
 
+    // #918 A3 — recall과 같은 trip 종료 시점에 사전 예약 텔레메트리도 upload. recall과 별도
+    // idempotency 키를 사용 — recall 실패/skip이 prescheduled upload를 막지 않게.
+    await triggerPrescheduledUpload(tripStart);
+
     return { uploaded: result.uploaded };
   } catch (e) {
     log.warn('trigger error', e);
     return { uploaded: false, skipped: 'error' };
+  }
+}
+
+/**
+ * 사전 예약 텔레메트리 1건 upload + idempotency 키 기록.
+ * recall과 분리한 이유: recall은 route arc 계산이 실패하면 skip하지만 prescheduled는 ledger만
+ * 보면 되므로 routeStops 부재 케이스(custom origin 사용 등)에서도 발사 가능해야 한다.
+ *
+ * 에러는 흡수 — trip-end 흐름을 측정 인프라가 차단하지 않는다.
+ */
+async function triggerPrescheduledUpload(tripStart: number): Promise<void> {
+  try {
+    const lastRaw = await AsyncStorage.getItem(LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY);
+    if (lastRaw !== null && Number(lastRaw) === tripStart) {
+      log.info(`duplicate prescheduled upload skip: tripStart=${tripStart}`);
+      return;
+    }
+    const result = await computeAndUploadTripPrescheduled({ tripStart });
+    if (result.uploaded) {
+      await AsyncStorage.setItem(
+        LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY,
+        String(tripStart),
+      );
+    }
+  } catch (e) {
+    log.warn('prescheduled trigger error', e);
   }
 }
 

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -7,6 +7,7 @@ import type { AlarmType } from '../../../shared/types/alarm';
 import { isSameStationName, type Route } from '../../../shared/utils/stationRoute';
 import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
+import { recordScheduledAlarm } from './prescheduledMetrics';
 
 const logger = createLogger('TripBoundScheduler');
 
@@ -150,6 +151,11 @@ export async function prescheduleStationAlerts(
       });
 
       scheduled.push({ identifier, event, fireDate });
+      // #918 A3 measurement — ledger에 적재해 trip 종료 시 fire delta / miss rate / station 정확도 산출.
+      // 실패는 graceful (prescheduledMetrics 내부에서 try/catch — schedule 흐름 차단 안 함).
+      // 순차 await — 동시 RMW가 서로 덮어쓰는 race 차단. 30+ 역 trip 1회 약 ~100-300ms 추가지만
+      // 사전 예약은 trip 시작 시 1회만 발생하는 oneshot이라 허용.
+      await recordScheduledAlarm({ identifier, scheduledFireMs: fireMs });
     }
   }
 

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -98,6 +98,15 @@ export const TRIP_STARTED_AT_KEY = 'subway-now:trip-started-at';
 // 다음 trip에 대해 다시 upload가 가능해진다.
 // 형식: 숫자(epoch ms) 문자열.
 export const LAST_UPLOADED_RECALL_TRIP_START_KEY = 'subway-now:last-uploaded-recall-trip-start';
+// #918 — A3 사전 예약 효과 측정 ledger.
+// `tripBoundScheduler.prescheduleStationAlerts` 1건 등록 시 entry 추가,
+// `tba:` 알람 발사 수신 시 actualFireMs 기록. trip 종료 시 compute → backend upload.
+// 형식: PrescheduledLedgerEntry[] JSON (prescheduledMetrics.ts).
+export const PRESCHEDULED_LEDGER_KEY = 'subway-now:prescheduled-ledger';
+// #918 — 마지막으로 prescheduled telemetry upload된 tripStart 값. recall과 동형 idempotency.
+// 형식: 숫자(epoch ms) 문자열.
+export const LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY =
+  'subway-now:last-uploaded-prescheduled-trip-start';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.


### PR DESCRIPTION
Ref #918 (A3 후속 PR — recall A4와 분리)

## Summary
PR #936 (OS 사전 예약 매역 일반화) + #943 (useStationAlarm wire) 머지 후 측정 인프라.
A3가 실제로 작동하는지 trip 단위로 산출해 backend AE에 적재한다. A4 recall(#919)과 보완 신호.

## KPI (catalog SSOT — 운영 KPI, Phase 4 결정 게이트 아님)
- **prescheduledFireMissRate** — RateMetric (hit=scheduled-fired, total=scheduled). OS 누락/cancel/일정변경 합산.
- **prescheduledStationAccuracy** — RateMetric (hit=accurate, total=fired). fired entry 중 alarmLog가 같은 station에서 fired outcome을 남긴 비율.
- **prescheduledFireDeltaMs** — HistogramMetric. actualFire-scheduledFire (양수=OS 늦게 발사). p95로 SLA 추적.

## Instrumentation
**Client**
- `prescheduledMetrics.ts` — AsyncStorage ledger (entry: identifier/scheduledFireMs/actualFireMs, 200건 상한). pure compute + graceful guards.
- `tripBoundScheduler.ts` — scheduleNotificationAsync 직후 `recordScheduledAlarm` (await로 race 차단; trip 시작 1회 oneshot).
- `scheduledAlarmReceiver.ts` — `tba:` prefix 발사 시 `Notification.date`(OS 발사 시각)로 `recordFiredAlarm`. FG/BG drain 양쪽 wire.
- `alarmLogTelemetry.ts` — `computeAndUploadTripPrescheduled` (recall과 동형). alarmLog fired stationName 집합을 cross-key로 전달.
- `triggerTripEndRecall.ts` — recall과 같은 trip-end 시점에 prescheduled trigger도 호출. 독립 idempotency 키(LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY).
- `tripBoundCleanups.ts` — 새 trip 시작 시 ledger clear (이전 trip 잔여 entry 분모 오염 차단).
- `telemetryBackend.ts` — `uploadPrescheduledTelemetry` (graceful skip on URL/token 부재).
- `storageKeys.ts` — 2 신규 키 (ledger + idempotency).

**Backend**
- `prescheduledTelemetry.ts` — `validatePrescheduledUpload` + `recordPrescheduledUpload` (recall과 동형).
- `index.ts` — `POST /telemetry/prescheduled` endpoint (graceful no-op when TELEMETRY binding 부재).
- `metrics.catalog.json` — 3 메트릭 catalog 등록 (gate 필드 없음 → `decidePhaseFour` 비포함).

## Test plan
- [x] `npm test` — 3999 pass, 커버리지 100% (lines/branches/funcs/statements)
- [x] backend `vitest` — 880 pass (25 신규 prescheduled + 1 신규 endpoint test 포함)
- [x] `npm run type-check` — pass
- [x] CI E2E smoke / lint / type-check 통과 모니터링
- [ ] 실기기 검증: 사전 예약 trip 시작 → 임의 알람 발사 → trip 종료 → backend AE에 metrics 적재 확인 (별도 next session)

## Privacy
좌표/시각/원문 미적재. token 8자 prefix anonymous aggregate만. recallTelemetry 정책 동일.