### PR TITLE
feat(#915): C1 baseline UX 다듬기 — BoardingTrainList title 기본값 i18n + HomeScreen polish

### DIFF
--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -7,6 +7,7 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 import { LineBadge } from '../../../shared/ui/LineBadge';
 import type { ArrivalInfo } from '../../../shared/types/arrival';
@@ -43,7 +44,7 @@ interface Props {
    * 환승 list에서 도보 buffer 표현용. 미전달 시 모든 열차 활성.
    */
   walkingBufferSeconds?: number;
-  /** 헤더 라벨 커스텀 (환승 list 등). 미전달 시 기본 "탑승할 열차 선택". compact=true면 무시. */
+  /** 헤더 라벨 커스텀 (환승 list 등). 미전달 시 home.boardingTrainListTitle i18n 키. compact=true면 무시. */
   title?: string;
   /**
    * 다음 인접역 라벨(#649, #749, #807). 있으면 "<label>방면"만 노출(종착 제거).
@@ -98,12 +99,16 @@ export function BoardingTrainList({
   line,
   onSelect,
   walkingBufferSeconds,
-  title = '탑승할 열차 선택',
+  title,
   nextStationLabel = null,
   compact = false,
   initialEtaSeconds,
 }: Props) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
+  // #915 후속: 헤더 라벨/empty placeholder를 i18n으로 분리.
+  // 4 locales(ko/en/ja/zh) 비-한국어 사용자가 핵심 baseline UX("탑승할 열차 선택")를 모국어로 본다.
+  const headerTitle = title ?? t('home.boardingTrainListTitle');
   const isUnreachable = (train: ArrivalInfo): boolean =>
     walkingBufferSeconds != null && train.arrivalSeconds < walkingBufferSeconds;
 
@@ -121,7 +126,7 @@ export function BoardingTrainList({
         style={compact ? styles.emptyCompact : styles.empty}
         testID="boarding-train-list-empty"
       >
-        <Text style={[typography.bodySm, { color: colors.muted }]}>도착 예정 열차가 없습니다.</Text>
+        <Text style={[typography.bodySm, { color: colors.muted }]}>{t('home.boardingTrainListEmpty')}</Text>
       </View>
     );
   }
@@ -134,7 +139,7 @@ export function BoardingTrainList({
       {!compact && (
         <View style={styles.header}>
           <LineBadge line={line} />
-          <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
+          <Text style={[typography.label, { color: colors.muted }]}>{headerTitle}</Text>
         </View>
       )}
       {delayMinutes != null && (

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -22,11 +22,12 @@ function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
 }
 
 describe('BoardingTrainList', () => {
-  it('arrivals 비어있을 때 placeholder 렌더', () => {
+  it('arrivals 비어있을 때 placeholder 렌더 (#915 후속: i18n 키 사용)', () => {
     const { getByTestId, getByText } = renderWithTheme(
       <BoardingTrainList arrivals={[]} line="2" onSelect={() => {}} />,
     );
     expect(getByTestId('boarding-train-list-empty')).toBeTruthy();
+    // jest.setup.js의 i18n 기본 lng='ko' → ko.json home.boardingTrainListEmpty 값.
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
   });
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -610,7 +610,7 @@ export default function HomeScreen() {
       )}
       <Toast
         visible={misBoardingToastVisible}
-        message="탑승 열차를 찾을 수 없어요. 다시 선택해주세요."
+        message={t('home.misBoardingToast')}
         onDismiss={handleMisBoardingToastDismiss}
         accent={colors.warn}
         testID="mis-boarding-toast"

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -49,7 +49,10 @@
     "locationUncertainTitle": "Locating",
     "locationUncertainDescription": "GPS accuracy is low,\nso we can't pinpoint your location.\nWe'll retry automatically.",
     "refresh": "Refresh",
-    "boardingProximityHint": "Move closer to the boarding station to pick a train"
+    "boardingProximityHint": "Move closer to the boarding station to pick a train",
+    "boardingTrainListTitle": "Pick your train",
+    "boardingTrainListEmpty": "No upcoming trains.",
+    "misBoardingToast": "Can't find your train. Please reselect."
   },
   "settings": {
     "title": "Settings",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -49,7 +49,10 @@
     "locationUncertainTitle": "位置確認中",
     "locationUncertainDescription": "GPSの精度が低いため、\n現在地を特定できません。\nしばらくしてから自動で再試行します。",
     "refresh": "更新",
-    "boardingProximityHint": "乗車駅の近くで列車を選択できます"
+    "boardingProximityHint": "乗車駅の近くで列車を選択できます",
+    "boardingTrainListTitle": "乗車する列車を選択",
+    "boardingTrainListEmpty": "到着予定の列車がありません。",
+    "misBoardingToast": "乗車中の列車が見つかりません。もう一度選択してください。"
   },
   "settings": {
     "title": "設定",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -49,7 +49,10 @@
     "locationUncertainTitle": "위치 확인 중",
     "locationUncertainDescription": "현재 GPS 정확도가 낮아\n위치를 단정할 수 없습니다.\n잠시 후 자동으로 다시 확인합니다.",
     "refresh": "새로고침",
-    "boardingProximityHint": "탑승역 근처에서 열차를 선택할 수 있어요"
+    "boardingProximityHint": "탑승역 근처에서 열차를 선택할 수 있어요",
+    "boardingTrainListTitle": "탑승할 열차 선택",
+    "boardingTrainListEmpty": "도착 예정 열차가 없습니다.",
+    "misBoardingToast": "탑승 열차를 찾을 수 없어요. 다시 선택해주세요."
   },
   "settings": {
     "title": "설정",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -49,7 +49,10 @@
     "locationUncertainTitle": "正在定位",
     "locationUncertainDescription": "GPS精度较低,\n暂时无法确定您的位置。\n稍后将自动重试。",
     "refresh": "刷新",
-    "boardingProximityHint": "靠近乘车站后可以选择列车"
+    "boardingProximityHint": "靠近乘车站后可以选择列车",
+    "boardingTrainListTitle": "选择乘坐列车",
+    "boardingTrainListEmpty": "暂无即将到达的列车。",
+    "misBoardingToast": "找不到乘坐的列车,请重新选择。"
   },
   "settings": {
     "title": "设置",


### PR DESCRIPTION
Closes #915 (C1 후속 PR)

## Summary
- BoardingTrainList 헤더 라벨(`title` prop 기본값)과 empty placeholder를 i18n 키로 분리
- HomeScreen `misBoardingToast` 메시지를 i18n 키로 분리
- 4 locales(ko/en/ja/zh) 모두 동일 키 추가 — 비-한국어 사용자가 핵심 baseline UX를 모국어로 본다

## Changes
- `src/features/alarm/components/BoardingTrainList.tsx`
  - `title` prop 기본값 `'탑승할 열차 선택'` → `t('home.boardingTrainListTitle')` (i18n fallback)
  - empty 텍스트 `'도착 예정 열차가 없습니다.'` → `t('home.boardingTrainListEmpty')`
  - 기존 `title` prop 호출자(MisBoardingReselectModal 등)는 변경 없음
- `src/screens/HomeScreen.tsx`
  - Toast `message` 하드코딩 → `t('home.misBoardingToast')`
- `src/shared/i18n/locales/{ko,en,ja,zh}.json`
  - 신규 키: `home.boardingTrainListTitle`, `home.boardingTrainListEmpty`, `home.misBoardingToast`

## Test plan
- [x] `npm test` 3947 passed, coverage 100%
- [x] `npm run type-check` clean
- [x] 기본 lng=ko 시 기존 텍스트와 동일 (regression 없음)