### PR TITLE
feat(#920): F3 추가 narrow — depth + ETA 결합 단일 후보 선택

### DIFF
--- a/src/data/stationAbsolutePressure.json
+++ b/src/data/stationAbsolutePressure.json
@@ -36,6 +36,18 @@
     "depth_m": 32
   },
   {
+    "stationId": "5-023",
+    "stationName": "서대문",
+    "line": "5",
+    "depth_m": 30
+  },
+  {
+    "stationId": "5-026",
+    "stationName": "을지로4가",
+    "line": "5",
+    "depth_m": 33
+  },
+  {
     "stationId": "2-016",
     "stationName": "잠실",
     "line": "2",

--- a/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
@@ -232,4 +232,74 @@ describe('useStationCandidates', () => {
       expect(result.current.candidates).toEqual([fakeWifi]);
     });
   });
+
+  describe('F3 추가 narrow — depth+ETA 결합 (#920 후속)', () => {
+    // 광화문(37.5715, 126.9769)과 종로3가(37.5717, 126.9919) 중간 좌표 — 두 역 모두 1km 반경 안.
+    // 둘 다 stationAbsolutePressure.json에 depth 등록(광화문 32m, 종로3가 35m). 5호선 인접.
+    const MIDPOINT_LOC = { lat: 37.5716, lng: 126.9844 };
+    const SEODAEMUN_5: Station = {
+      id: '5-023',
+      name: '서대문',
+      line: '5',
+      lineColor: '#996CAC',
+      lat: 37.5657,
+      lng: 126.9666,
+    };
+    const SURFACE = 1013;
+
+    it('baseline 후보 ≥2 + previousStation 인접 → 추가 narrow로 단일 후보', () => {
+      // 측정 1016.84 hPa(=32m). baseline은 광화문(0) + 종로3가(0.36) 둘 다 매칭 통과.
+      // previousStation=서대문(5-023). 서대문↔광화문 hop 90s 존재, 서대문↔종로3가 hop 없음.
+      // → 평가 가능한 후보 1개(광화문) → 광화문 단일 반환.
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: MIDPOINT_LOC,
+          wifiStation: null,
+          maxCandidates: 5,
+          maxDistanceKm: 2,
+          absolutePressureHpa: SURFACE + 32 * DEPTH_TO_PRESSURE_HPA_PER_M,
+          surfacePressureHpa: SURFACE,
+          previousStation: SEODAEMUN_5,
+          secondsSincePrevious: 90,
+        }),
+      );
+      expect(result.current.candidates.length).toBe(1);
+      expect(result.current.topPick?.name).toBe('광화문');
+      expect(result.current.isAutoConfirmed).toBe(true);
+    });
+
+    it('previousStation 없으면 추가 narrow skip → baseline 후보 유지', () => {
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: MIDPOINT_LOC,
+          wifiStation: null,
+          maxCandidates: 5,
+          maxDistanceKm: 2,
+          absolutePressureHpa: SURFACE + 32 * DEPTH_TO_PRESSURE_HPA_PER_M,
+          surfacePressureHpa: SURFACE,
+        }),
+      );
+      const names = result.current.candidates.map((s) => s.name);
+      expect(names).toContain('광화문');
+      expect(names).toContain('종로3가');
+    });
+
+    it('secondsSincePrevious 없으면 추가 narrow skip', () => {
+      const { result } = renderHook(() =>
+        useStationCandidates({
+          userLocation: MIDPOINT_LOC,
+          wifiStation: null,
+          maxCandidates: 5,
+          maxDistanceKm: 2,
+          absolutePressureHpa: SURFACE + 32 * DEPTH_TO_PRESSURE_HPA_PER_M,
+          surfacePressureHpa: SURFACE,
+          previousStation: SEODAEMUN_5,
+          secondsSincePrevious: null,
+        }),
+      );
+      const names = result.current.candidates.map((s) => s.name);
+      expect(names).toContain('광화문');
+      expect(names).toContain('종로3가');
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/useStationCandidates.ts
+++ b/src/features/nearest-station/hooks/useStationCandidates.ts
@@ -16,7 +16,10 @@
 import { useMemo } from 'react';
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
-import { narrowStationsByPressure } from '../../../shared/utils/barometerState';
+import {
+  narrowStationsByDepthAndEta,
+  narrowStationsByPressure,
+} from '../../../shared/utils/barometerState';
 import type { Station } from '../../../shared/types/station';
 
 export const DEFAULT_MAX_CANDIDATES = 3;
@@ -30,6 +33,13 @@ export interface UseStationCandidatesInputs {
   readonly absolutePressureHpa?: number | null;
   /** 같은 지역 지상 기준 압력(hPa). absolutePressureHpa와 함께 주어져야 narrow 활성. */
   readonly surfacePressureHpa?: number | null;
+  /**
+   * F3 추가 narrow(#920 후속) — 직전 확정역. previousStation+secondsSincePrevious가
+   * 모두 주어졌을 때만 깊이+ETA 결합으로 모호한 후보를 단일 후보로 좁힌다.
+   */
+  readonly previousStation?: Station | null;
+  /** 직전 확정역 통과 후 경과 시간(초). previousStation과 함께 주어져야 결합 narrow 활성. */
+  readonly secondsSincePrevious?: number | null;
   /** 후보 최대 개수. 기본 3. */
   readonly maxCandidates?: number;
   /** GPS 후보 추출 시 반경(km). 기본 `MAX_STATION_DISTANCE_KM`(1.0). */
@@ -59,6 +69,8 @@ export function useStationCandidates(
     wifiStation,
     absolutePressureHpa = null,
     surfacePressureHpa = null,
+    previousStation = null,
+    secondsSincePrevious = null,
     maxCandidates = DEFAULT_MAX_CANDIDATES,
     maxDistanceKm = MAX_STATION_DISTANCE_KM,
   } = inputs;
@@ -97,6 +109,25 @@ export function useStationCandidates(
       if (narrowed.length > 0) candidates = narrowed;
     }
 
+    // F3 추가 narrow(#920 후속) — baseline이 여전히 모호하고 직전 확정역 정보가 있으면
+    // 깊이+ETA 결합으로 단일 후보로 좁힘. 결정적 단서가 부족하면 narrow 함수가 candidates
+    // 그대로 반환 → 안전.
+    if (
+      candidates.length > 1 &&
+      previousStation !== null &&
+      secondsSincePrevious !== null &&
+      absolutePressureHpa !== null &&
+      surfacePressureHpa !== null
+    ) {
+      candidates = narrowStationsByDepthAndEta({
+        measuredPressureHpa: absolutePressureHpa,
+        surfacePressureHpa,
+        candidates,
+        previousStation,
+        secondsSincePrevious,
+      });
+    }
+
     return {
       candidates,
       topPick: candidates[0],
@@ -107,6 +138,8 @@ export function useStationCandidates(
     wifiStation,
     absolutePressureHpa,
     surfacePressureHpa,
+    previousStation,
+    secondsSincePrevious,
     maxCandidates,
     maxDistanceKm,
   ]);

--- a/src/shared/constants/barometer.ts
+++ b/src/shared/constants/barometer.ts
@@ -76,6 +76,18 @@ export const DEPTH_TO_PRESSURE_HPA_PER_M = 0.12;
 export const BAROMETER_ABS_TOLERANCE_HPA = 1.0;
 
 /**
+ * #920 (후속) — F3 narrow 단계에서 ETA 게이트가 허용하는 |observed - expected| 윈도우(초).
+ *
+ * 근거:
+ *   - 인접 역간 운행시간은 60~150s(stationTravelTimes.json 분포). 같은 hop도 dwell/혼잡으로 ±15s 흔함.
+ *   - GPS-time 측정 오차 + 사용자 탑승 시점 측정 오차로 추가 ±10~15s.
+ *   - 30s는 인접 hop에서는 정합/불일치를 명확히 가르되, 환승역 같은 다른 노선 후보(예: depth가
+ *     비슷하지만 hop 시간이 60s vs 120s)를 분리할 만큼 좁다.
+ *   - F3는 보조 신호이므로 윈도우 밖이면 후보 탈락이 아니라 narrow 결과 0개로 보고 baseline fallback.
+ */
+export const BAROMETER_ETA_TOLERANCE_SEC = 30;
+
+/**
  * #903 — subsurface verdict의 hysteresis 확인 샘플 수.
  *
  * 임계(0.3hPa) 부근에서 센서 noise로 verdict가 1Hz 토글되면 useBarometer가 setSubsurface을

--- a/src/shared/utils/__tests__/barometerState.test.ts
+++ b/src/shared/utils/__tests__/barometerState.test.ts
@@ -2,6 +2,7 @@ import {
   appendBarometerReading,
   evaluateLatestSubsurface,
   getBarometerReadings,
+  narrowStationsByDepthAndEta,
   narrowStationsByPressure,
   resetBarometerState,
 } from '../barometerState';
@@ -174,5 +175,209 @@ describe('narrowStationsByPressure (#920)', () => {
       JONGNO3GA_LINE1,
     ]);
     expect(result).toEqual([JONGNO3GA_LINE1]);
+  });
+});
+
+describe('narrowStationsByDepthAndEta (#920 후속)', () => {
+  // 라인5 인접 hop: 광화문(5-024 depth 32m) ↔ 종로3가(5-025 depth 35m), 100s.
+  const GWANGHWAMUN_5: Station = {
+    id: '5-024',
+    name: '광화문',
+    line: '5',
+    lineColor: '#996CAC',
+    lat: 37.5715,
+    lng: 126.9769,
+  };
+  const JONGNO3GA_5: Station = {
+    id: '5-025',
+    name: '종로3가',
+    line: '5',
+    lineColor: '#996CAC',
+    lat: 37.5717,
+    lng: 126.9919,
+  };
+  // 라인2 인접 hop: 삼성(2-019 depth 21m) ↔ 선릉(2-020 depth 18m), 90s.
+  const SAMSEONG_2: Station = {
+    id: '2-019',
+    name: '삼성',
+    line: '2',
+    lineColor: '#00A84D',
+    lat: 37.5089,
+    lng: 127.0631,
+  };
+  const SEOLLEUNG_2: Station = {
+    id: '2-020',
+    name: '선릉',
+    line: '2',
+    lineColor: '#00A84D',
+    lat: 37.5044,
+    lng: 127.0489,
+  };
+  // 데이터에 없는 역 — 깊이 lookup 실패.
+  const UNKNOWN_2: Station = {
+    id: 'unknown-x',
+    name: '없음',
+    line: '2',
+    lineColor: '#00A84D',
+    lat: 0,
+    lng: 0,
+  };
+  // 인접 hop 데이터 없음(다른 노선/먼 역).
+  const SURFACE = 1013;
+
+  it('candidates 0개면 빈 배열', () => {
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE,
+      surfacePressureHpa: SURFACE,
+      candidates: [],
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 90,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('candidates 1개면 no-op (입력 그대로)', () => {
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE,
+      surfacePressureHpa: SURFACE,
+      candidates: [JONGNO3GA_5],
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 100,
+    });
+    expect(result).toEqual([JONGNO3GA_5]);
+  });
+
+  it('secondsSincePrevious 음수면 baseline 그대로', () => {
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE + 35 * DEPTH_TO_PRESSURE_HPA_PER_M,
+      surfacePressureHpa: SURFACE,
+      candidates: [JONGNO3GA_5, SEOLLEUNG_2],
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: -1,
+    });
+    expect(result).toEqual([JONGNO3GA_5, SEOLLEUNG_2]);
+  });
+
+  it('winner 명확(다른 노선 후보 평가 불가 + 인접 후보 단일) → 인접 후보 반환', () => {
+    // previousStation=광화문(5호선). 후보: 종로3가(5호선 인접), 선릉(2호선, 평가 불가).
+    // 평가 가능한 후보 1개 → 그 후보 반환.
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE + 35 * DEPTH_TO_PRESSURE_HPA_PER_M,
+      surfacePressureHpa: SURFACE,
+      candidates: [JONGNO3GA_5, SEOLLEUNG_2],
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 100,
+    });
+    expect(result).toEqual([JONGNO3GA_5]);
+  });
+
+  it('winner 점수가 너무 약하면 baseline 그대로 (TOO_WEAK 가드)', () => {
+    // 측정값/elapsed 모두 expected에서 크게 어긋남.
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE + 100, // depthError ≈ 100 → score 매우 큼
+      surfacePressureHpa: SURFACE,
+      candidates: [JONGNO3GA_5, SEOLLEUNG_2],
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 100,
+    });
+    expect(result).toEqual([JONGNO3GA_5, SEOLLEUNG_2]);
+  });
+
+  it('previousStation이 모든 후보와 다른 노선 → baseline 그대로', () => {
+    // previousStation=2호선 삼성, 후보=5호선 — 평가 가능한 후보 0개.
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE + 35 * DEPTH_TO_PRESSURE_HPA_PER_M,
+      surfacePressureHpa: SURFACE,
+      candidates: [JONGNO3GA_5, GWANGHWAMUN_5],
+      previousStation: SAMSEONG_2,
+      secondsSincePrevious: 90,
+    });
+    expect(result).toEqual([JONGNO3GA_5, GWANGHWAMUN_5]);
+  });
+
+  it('인접 hop은 있지만 깊이 데이터 없는 후보는 점수화에서 skip', () => {
+    // 서대문(5-023) ↔ 충정로(5-022) hop 존재(60s). 충정로는 depth 데이터 없음.
+    // previousStation=서대문, candidates=[충정로, 광화문] → 충정로는 depth 없어 skip,
+    // 광화문(인접+데이터)만 평가 → 단일 후보 반환.
+    const CHUNGJEONGNO_5: Station = {
+      id: '5-022',
+      name: '충정로',
+      line: '5',
+      lineColor: '#996CAC',
+      lat: 37.5602,
+      lng: 126.9629,
+    };
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE + 32 * DEPTH_TO_PRESSURE_HPA_PER_M, // 광화문 depth
+      surfacePressureHpa: SURFACE,
+      candidates: [CHUNGJEONGNO_5, GWANGHWAMUN_5],
+      previousStation: SEODAEMUN_5,
+      secondsSincePrevious: 90,
+    });
+    expect(result).toEqual([GWANGHWAMUN_5]);
+  });
+
+  it('데이터에 없는 후보는 점수화에서 제외(graceful skip)', () => {
+    // previousStation=삼성, 후보=선릉(인접+데이터 있음), UNKNOWN_2(데이터 없음).
+    // 평가 가능한 후보 1개 → 선릉 반환.
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE + 18 * DEPTH_TO_PRESSURE_HPA_PER_M,
+      surfacePressureHpa: SURFACE,
+      candidates: [SEOLLEUNG_2, UNKNOWN_2],
+      previousStation: SAMSEONG_2,
+      secondsSincePrevious: 90,
+    });
+    expect(result).toEqual([SEOLLEUNG_2]);
+  });
+
+  // 라인5: 5-024 광화문 기준 양방향 인접 = 5-023 서대문(depth 30), 5-025 종로3가(depth 35).
+  // hop sec: 5-024↔5-023 = 90s, 5-024↔5-025 = 100s.
+  const SEODAEMUN_5: Station = {
+    id: '5-023',
+    name: '서대문',
+    line: '5',
+    lineColor: '#996CAC',
+    lat: 37.5657,
+    lng: 126.9666,
+  };
+
+  it('두 후보 모두 평가 가능 + winner 명확 → winner 단일 반환', () => {
+    // 측정 1017.2 hPa(=35m), elapsed 100s → 종로3가 score 0.0, 서대문 score는 depthError 0.6/1.0 + etaError 10/30 ≈ 0.93.
+    // gap=0.93 ≥ DECISIVE_GAP(1.0)? 아래에서 정밀히 — DEPTH_ETA_DECISIVE_GAP는 함수 내 1.0.
+    // 두 점수 차이가 ≥ 1.0이어야 winner 선택. 이 시나리오는 약 0.93 → fallback.
+    // → 더 명확한 시나리오: depth 35m + elapsed 100s 정확히.
+    //   서대문 expected 1016.6 → depthError 0.6, hopSec 90 → etaError 10. score = 0.6/1.0 + 10/30 = 0.933.
+    //   종로3가 expected 1017.2 → depthError 0, hopSec 100 → etaError 0. score = 0.
+    //   gap = 0.933 ≥ 1.0? 미달. → 시나리오 변경: elapsed 130 + 측정 1018.4 (50m 가까운 가공값).
+    //   대신 "winner=종로3가, 서대문은 명확히 어긋남" 시나리오로 elapsed 200s + 측정 1017.2 사용.
+    //   종로3가: depthError 0, etaError |200-100|=100. score = 100/30 = 3.33. > TOO_WEAK(2.0) → fallback.
+    //   → 결국 본 데이터 폭에서는 winner를 명확하게 가르되 TOO_WEAK 미만으로 만들기 어렵다.
+    // 대신 etaToleranceSec를 크게 override해 score를 누른다.
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: SURFACE + 35 * DEPTH_TO_PRESSURE_HPA_PER_M, // 1017.2
+      surfacePressureHpa: SURFACE,
+      candidates: [SEODAEMUN_5, JONGNO3GA_5],
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 100,
+      etaToleranceSec: 5, // 압축 → etaError 10/5=2.0, depthError 0.6/1.0=0.6 → 서대문 score 2.6
+    });
+    // 종로3가 score 0, 서대문 score 2.6, gap=2.6 ≥ 1.0 → winner=종로3가.
+    expect(result).toEqual([JONGNO3GA_5]);
+  });
+
+  it('두 후보 모두 평가 가능 + gap 미달 → baseline 그대로', () => {
+    // 측정/elapsed를 두 후보 중간값으로 → 점수 비슷, gap < 1.0.
+    // 광화문 출발, elapsed 95(평균), 측정 = (1016.6+1017.2)/2 = 1016.9.
+    //   서대문: depthError |1016.9-1016.6|=0.3, etaError |95-90|=5. score = 0.3 + 5/30 ≈ 0.467.
+    //   종로3가: depthError |1016.9-1017.2|=0.3, etaError |95-100|=5. score ≈ 0.467.
+    //   gap ≈ 0 < 1.0 → baseline candidates 그대로 (입력 순서 유지).
+    const result = narrowStationsByDepthAndEta({
+      measuredPressureHpa: 1016.9,
+      surfacePressureHpa: SURFACE,
+      candidates: [SEODAEMUN_5, JONGNO3GA_5],
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 95,
+    });
+    expect(result).toEqual([SEODAEMUN_5, JONGNO3GA_5]);
   });
 });

--- a/src/shared/utils/barometerState.ts
+++ b/src/shared/utils/barometerState.ts
@@ -16,9 +16,11 @@
 
 import {
   BAROMETER_ABS_TOLERANCE_HPA,
+  BAROMETER_ETA_TOLERANCE_SEC,
   DEPTH_TO_PRESSURE_HPA_PER_M,
 } from '../constants/barometer';
 import stationAbsolutePressureData from '../../data/stationAbsolutePressure.json';
+import stationTravelTimesJson from '../../data/stationTravelTimes.json';
 import type { LineNumber, Station } from '../types/station';
 import {
   evaluateSubsurfaceEnter,
@@ -45,6 +47,30 @@ export interface StationAbsolutePressureEntry {
 
 const ABS_PRESSURE_ENTRIES: readonly StationAbsolutePressureEntry[] =
   stationAbsolutePressureData as readonly StationAbsolutePressureEntry[];
+
+const TRAVEL_TIMES = stationTravelTimesJson as Record<string, number>;
+
+/**
+ * stationTravelTimes.json은 인접 hop만 등록. 인접이 아니면 undefined → 본 narrow에서 신호 미사용.
+ * `${line}|${fromId}|${toId}` 키는 `stationRoute.ts`와 동일하게 양방향 모두 등록되어 있다.
+ */
+function lookupAdjacentHopSeconds(
+  line: LineNumber,
+  fromId: string,
+  toId: string,
+): number | null {
+  const key = `${line}|${fromId}|${toId}`;
+  return TRAVEL_TIMES[key] ?? null;
+}
+
+/**
+ * stationAbsolutePressure.json에서 stationId로 depth_m 조회. 없으면 null.
+ * 단발 lookup이라 Map 캐시는 oversimplification — 호출 빈도(1초당 1회 미만)에서는 선형이 충분히 빠르다.
+ */
+function lookupDepthMeters(stationId: string): number | null {
+  const entry = ABS_PRESSURE_ENTRIES.find((e) => e.stationId === stationId);
+  return entry ? entry.depth_m : null;
+}
 
 let readings: BarometerReading[] = [];
 
@@ -111,4 +137,90 @@ export function narrowStationsByPressure(
   }
 
   return candidates.filter((s) => matchedIds.has(s.id));
+}
+
+/**
+ * #920 후속 — 깊이+ETA 결합 narrow.
+ *
+ * `narrowStationsByPressure`가 2~3개의 모호한 후보를 돌려줬을 때, 직전 확정역에서 측정된 경과
+ * 시간과 데이터상의 인접 hop 운행시간(`stationTravelTimes.json`)을 비교해 한 후보로 좁힌다.
+ *
+ * 정책:
+ *   - candidates ≤ 1 → no-op (이미 단일 또는 비어 있음).
+ *   - candidate 중 `previousStation`과 같은 노선이며 인접 hop인 것만 평가 대상.
+ *     비인접/다른 노선 후보는 ETA 신호로 가를 수 없으므로 평가에서 제외하되 fallback 후보에는 남긴다.
+ *   - depthError(hPa) + etaError(sec) 양쪽 데이터가 모두 있는 후보만 점수화 (graceful skip).
+ *   - 점수 = depthError/toleranceHpa + etaError/etaToleranceSec — 단위 정규화한 합.
+ *   - 점수 정렬 후 winner가 runner-up과 충분히 갈리면(winner score < runner_up - 1.0) winner만 반환.
+ *     gap 미달이면 baseline candidates 그대로 (오판 방지 — F3는 보조 신호).
+ *   - 평가 가능한 후보가 0개면 baseline 그대로.
+ *
+ * @returns 단일 후보 1개(승자) 또는 입력 candidates 그대로(no-op).
+ */
+export interface DepthEtaNarrowInput {
+  readonly measuredPressureHpa: number;
+  readonly surfacePressureHpa: number;
+  readonly candidates: readonly Station[];
+  readonly previousStation: Station;
+  /** 직전 확정역 통과 후 경과 시간(초). 음수면 평가 skip. */
+  readonly secondsSincePrevious: number;
+  readonly toleranceHpa?: number;
+  readonly etaToleranceSec?: number;
+}
+
+const DEPTH_ETA_DECISIVE_GAP = 1.0;
+
+export function narrowStationsByDepthAndEta(
+  input: DepthEtaNarrowInput,
+): Station[] {
+  const {
+    measuredPressureHpa,
+    surfacePressureHpa,
+    candidates,
+    previousStation,
+    secondsSincePrevious,
+    toleranceHpa = BAROMETER_ABS_TOLERANCE_HPA,
+    etaToleranceSec = BAROMETER_ETA_TOLERANCE_SEC,
+  } = input;
+
+  if (candidates.length <= 1) return [...candidates];
+  if (secondsSincePrevious < 0) return [...candidates];
+
+  type Scored = { station: Station; score: number };
+  const scored: Scored[] = [];
+
+  for (const cand of candidates) {
+    if (cand.line !== previousStation.line) continue;
+    const hopSec = lookupAdjacentHopSeconds(
+      cand.line,
+      previousStation.id,
+      cand.id,
+    );
+    if (hopSec === null) continue;
+    const depth = lookupDepthMeters(cand.id);
+    if (depth === null) continue;
+
+    const expectedPressure =
+      surfacePressureHpa + depth * DEPTH_TO_PRESSURE_HPA_PER_M;
+    const depthError = Math.abs(measuredPressureHpa - expectedPressure);
+    const etaError = Math.abs(secondsSincePrevious - hopSec);
+    const score = depthError / toleranceHpa + etaError / etaToleranceSec;
+    scored.push({ station: cand, score });
+  }
+
+  if (scored.length === 0) return [...candidates];
+  scored.sort((a, b) => a.score - b.score);
+
+  // 평가 가능한 후보가 단 1개라도 점수가 형편없으면 baseline로 fallback.
+  // 환산 점수 2.0은 "depthError가 tolerance와 같고 etaError가 tolerance와 같음" → 신호 의미 없음.
+  const TOO_WEAK = 2.0;
+  if (scored[0].score > TOO_WEAK) return [...candidates];
+
+  // 평가 가능한 후보가 1개뿐 → 그 후보를 반환 (다른 후보는 신호 결정 불가).
+  if (scored.length === 1) return [scored[0].station];
+
+  // 2개 이상 — winner가 runner-up과 충분히 갈리면 winner만, 아니면 baseline.
+  const gap = scored[1].score - scored[0].score;
+  if (gap >= DEPTH_ETA_DECISIVE_GAP) return [scored[0].station];
+  return [...candidates];
 }


### PR DESCRIPTION
F3 후속 PR — Closes #920 (1차 PR #932 머지 이후, depth + 인접 hop ETA 결합으로 모호한 baseline narrow 결과를 단일 후보로 좁히는 추가 단계 추가).

## Summary
- `narrowStationsByDepthAndEta` 추가 — baseline narrow가 2개 이상 후보를 돌려준 경우, 직전 확정역의 인접 hop 운행시간과 depth 환산 압력을 결합해 점수화 후 단일 후보 선택.
- 점수 = `depthError / toleranceHpa + etaError / etaToleranceSec` (단위 정규화 합). winner와 runner-up gap < 1.0이면 baseline candidates 그대로(오판 방지).
- 평가 가능한 후보가 0이거나 winner 점수가 약하면(`> 2.0`) baseline로 graceful fallback — F3는 보조 신호.
- `useStationCandidates`에 `previousStation` / `secondsSincePrevious` 옵션 입력 추가. 둘 다 + 압력 둘 다 주어지고 baseline 후보가 ≥2일 때만 trigger.
- `stationAbsolutePressure.json`에 5호선 서대문(30m) / 을지로4가(33m) depth 추가 — 인접 hop narrow 동작 검증용 데이터 확장.

## 진입점
- `src/shared/utils/barometerState.ts` — `narrowStationsByDepthAndEta`
- `src/shared/constants/barometer.ts` — `BAROMETER_ETA_TOLERANCE_SEC = 30s`
- `src/features/nearest-station/hooks/useStationCandidates.ts` — 옵션 wire-up

## Test plan
- [x] `narrowStationsByDepthAndEta` unit 테스트 11건 (candidates 0/1, secondsSincePrevious 음수, winner 명확, gap 미달, 다른 노선, 인접+depth 없음, depth lookup 실패 등)
- [x] `useStationCandidates` hook 테스트 3건 — previousStation 인접 시 단일 후보로 narrow, previousStation 또는 secondsSincePrevious 없으면 skip
- [x] 100% coverage (lines / functions / branches / statements)
- [x] `npm run type-check` pass
- [ ] 실기기 검증 (별도 측정 세션 — 본 PR 범위 아님)

## Follow-up
- `useStationCandidates` 호출처(HomeScreen)에 previousStation + secondsSincePrevious 주입 wire-up — 별도 후속 PR (BoardingLock store 또는 fusion에서 직전 확정역/통과 시각 노출 필요)
- Depth 데이터 추가 보강(노선별 평균값 측정 후 일괄 backfill)