### PR TITLE
fix(#957): pickArrivalForStationName 환승역 line slot 좁힘

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -7,7 +7,10 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { renderHook } from '@testing-library/react-native';
-import { useFusedNearestStation } from '../useFusedNearestStation';
+import {
+  useFusedNearestStation,
+  pickArrivalForStationName,
+} from '../useFusedNearestStation';
 import { useNearestStation } from '../useNearestStation';
 import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
 import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
@@ -1329,6 +1332,47 @@ describe('useFusedNearestStation', () => {
       mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
       const { result } = renderWithSub(true);
       expect(result.current.confidence).toBe('arrival-confirmed');
+    });
+  });
+
+  describe('#957 (P1.4) pickArrivalForStationName — 환승역 line 좁힘', () => {
+    // 같은 stationName('충무로') 다른 line('3'/'4')이 동시에 후보 슬롯에 들어온 환승역.
+    // useArrivalInfo는 (name, line)로 폴링하므로 슬롯의 line은 응답 라인과 1:1 동일.
+    const arrival3: StationArrival = { up: [info(ARRIVAL_CODE.RUNNING, { line: '3' })], down: [] };
+    const arrival4: StationArrival = { up: [info(ARRIVAL_CODE.ARRIVED, { line: '4' })], down: [] };
+    const slotsTransfer = [
+      { stationName: '충무로', line: '3', arrival: arrival3 },
+      { stationName: '충무로', line: '4', arrival: arrival4 },
+      { stationName: null, line: null, arrival: null },
+    ];
+
+    it('result.line=3호선 → 3호선 슬롯 픽 (4호선 옆 슬롯 무시)', () => {
+      expect(pickArrivalForStationName('충무로', '3', slotsTransfer)).toBe(arrival3);
+    });
+
+    it('result.line=4호선 → 4호선 슬롯 픽', () => {
+      expect(pickArrivalForStationName('충무로', '4', slotsTransfer)).toBe(arrival4);
+    });
+
+    it('line 미일치(다른 호선만 슬롯에 있음) → null 반환 → fusion 입력 unavailable', () => {
+      expect(pickArrivalForStationName('충무로', '5', slotsTransfer)).toBeNull();
+    });
+
+    it('단일 노선 일반역(매칭 슬롯 존재) → 기존 동작 동일', () => {
+      const slots = [{ stationName: '강남', line: '2', arrival: arrival3 }];
+      expect(pickArrivalForStationName('강남', '2', slots)).toBe(arrival3);
+    });
+
+    it('매칭 슬롯의 arrival이 null이면 skip하고 다음 슬롯 검사', () => {
+      const slots = [
+        { stationName: '충무로', line: '3', arrival: null },
+        { stationName: '충무로', line: '3', arrival: arrival3 },
+      ];
+      expect(pickArrivalForStationName('충무로', '3', slots)).toBe(arrival3);
+    });
+
+    it('빈 슬롯 배열 → null', () => {
+      expect(pickArrivalForStationName('충무로', '3', [])).toBeNull();
     });
   });
 });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -120,6 +120,11 @@ function matchPositionsForCandidate(
 interface CandidateArrivalSlot {
   /** 폴링 시 사용한 후보 역명 — `useArrivalInfo`의 첫 인자와 동일. */
   stationName: string | null;
+  /**
+   * 폴링 시 사용한 후보 노선 — `useArrivalInfo`의 두 번째 인자와 동일. 같은 역명 다른 노선
+   * 환승역(예: 충무로 3호선/4호선)에서 잘못된 슬롯이 픽되는 것을 차단하기 위해 사용. (#921 P1.4)
+   */
+  line: string | null;
   arrival: StationArrival | null;
 }
 
@@ -149,17 +154,26 @@ function pickArrivalsForStation(
 }
 
 /**
- * #921 — 채택된 result.station.name과 매칭되는 후보 슬롯의 StationArrival을 반환.
+ * #921 — 채택된 result.station(name+line)과 매칭되는 후보 슬롯의 StationArrival을 반환.
  *
  * 신호 fusion 입력용 — slot에서 어떤 row가 lockedTrainCode와 매칭되는지는 호출자
  * (useFusedStationDetection)가 판정한다. 매칭 슬롯이 없으면 null — fusion 입력 unavailable.
+ *
+ * #957 (P1.4 follow-up): 환승역(같은 stationName 다른 line)에서 옆 노선 슬롯이 픽되는 회귀
+ * 차단. `useArrivalInfo`는 `(stationName, line)`로 폴링하므로 슬롯의 line은 응답의 라인과
+ * 동일하다. 따라서 result.station.line과 슬롯 line을 같이 비교해야 한다.
  */
-function pickArrivalForStationName(
+export function pickArrivalForStationName(
   stationName: string,
+  line: string,
   slots: readonly CandidateArrivalSlot[],
 ): StationArrival | null {
   for (const slot of slots) {
-    if (slot.stationName === stationName && slot.arrival !== null) {
+    if (
+      slot.stationName === stationName &&
+      slot.line === line &&
+      slot.arrival !== null
+    ) {
       return slot.arrival;
     }
   }
@@ -478,9 +492,9 @@ export function useFusedNearestStation(
       ? arcStations[currentIdxHint + 1]
       : null;
   const nextStationArrivals = pickArrivalsForStation(nextStationOnArc, [
-    { stationName: c0, arrival: a0.arrival },
-    { stationName: c1, arrival: a1.arrival },
-    { stationName: c2, arrival: a2.arrival },
+    { stationName: c0, line: h0, arrival: a0.arrival },
+    { stationName: c1, line: h1, arrival: a1.arrival },
+    { stationName: c2, line: h2, arrival: a2.arrival },
   ]);
 
   // useMemo로 감싸면 deps가 시간을 포함하지 않아 부모 리렌더가 없는 동안 stale.
@@ -592,10 +606,10 @@ export function useFusedNearestStation(
   // 매칭 슬롯이 없으면 (route-progress/interp 결과가 GPS top-3 밖) arrival=null → arvlcd 입력
   // unavailable로 흐른다.
   const fusionArrival = result
-    ? pickArrivalForStationName(result.station.name, [
-        { stationName: c0, arrival: a0.arrival },
-        { stationName: c1, arrival: a1.arrival },
-        { stationName: c2, arrival: a2.arrival },
+    ? pickArrivalForStationName(result.station.name, result.station.line, [
+        { stationName: c0, line: h0, arrival: a0.arrival },
+        { stationName: c1, line: h1, arrival: a1.arrival },
+        { stationName: c2, line: h2, arrival: a2.arrival },
       ])
     : null;
   const detectionInput = useMemo(


### PR DESCRIPTION
Closes #957

PR #944 (#921 fusion wire-up) 본문에서 P1.4로 deferred된 follow-up.

## Root cause
`pickArrivalForStationName` (useFusedNearestStation.ts)이 station name으로만 후보 슬롯을 매칭. 환승역(예: 충무로 — 3호선·4호선)에서는 GPS 후보 슬롯에 같은 역명/다른 노선이 동시에 들어와 잘못된 노선의 `StationArrival`을 픽할 수 있다. 이 arrival이 `useFusedStationDetection`의 `arvlcd-arrived` 입력으로 흘러가면 옆 노선 열차의 arvlCd로 판정해 fusion verdict가 오염될 위험.

## Fix
- `CandidateArrivalSlot`에 `line: string | null` 필드 추가
- `pickArrivalForStationName` 시그니처에 `line` 인자 추가 → `(stationName + line)` 두 키로 매칭
- 두 호출자 모두 `h0/h1/h2`(슬롯 line) + `result.station.line` 전달
- 같은 보호 로직이 이미 적용되어 있는 `pickArrivalsForStation` 호출 슬롯에도 line 필드 채워 일관성 유지
- export로 surfacing해서 환승역 회귀 단위 테스트 추가

## Backwards compatibility
line이 일치하는 슬롯이 없으면 null 반환 — 기존 `arvlcd-arrived` unavailable 흐름과 동일. 단일 노선 일반역(슬롯 line == result.line)에서는 기존 동작 그대로.

## Test plan
- [x] `npm run type-check` pass
- [x] `npm test` 3987/3987 pass, 100% coverage
- [x] `pickArrivalForStationName` 단위 테스트 6건:
  - 환승역 result.line=3 → 3호선 슬롯 픽 (4호선 무시)
  - 환승역 result.line=4 → 4호선 슬롯 픽
  - line 미일치 → null
  - 단일 노선 일반역 → 기존 동작 동일
  - 매칭 슬롯 arrival=null → 다음 슬롯 검사
  - 빈 슬롯 배열 → null

## Refs
- PR #944 P1.4 follow-up
- Issue #957
