### PR TITLE
feat(#919): recall KPI 집계 query + dashboard endpoint

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1456,6 +1456,46 @@ describe('POST /telemetry/recall (#919)', () => {
   });
 });
 
+describe('GET /metrics/recall/summary (#919 후속)', () => {
+  async function get(env: Env): Promise<Response> {
+    return app.fetch(
+      new Request('http://example.com/metrics/recall/summary', { method: 'GET' }),
+      env,
+    );
+  }
+
+  it('returns dataset + queries + threshold (binding 부재 시 available=false)', async () => {
+    const env = makeEnv();
+    const res = await get(env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      dataset: string;
+      available: boolean;
+      minRecallRatioThreshold: number;
+      queries: { id: string; description: string; sql: string }[];
+    };
+    expect(body.dataset).toBe('silent_push_telemetry');
+    expect(body.available).toBe(false);
+    expect(body.minRecallRatioThreshold).toBeGreaterThan(0);
+    expect(body.minRecallRatioThreshold).toBeLessThanOrEqual(1);
+    expect(body.queries.length).toBeGreaterThanOrEqual(3);
+    for (const q of body.queries) {
+      expect(typeof q.id).toBe('string');
+      expect(q.id.length).toBeGreaterThan(0);
+      expect(typeof q.description).toBe('string');
+      expect(q.sql).toContain('silent_push_telemetry');
+    }
+  });
+
+  it('reports available=true when TELEMETRY binding present', async () => {
+    const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
+    const env = makeEnv({ TELEMETRY: writer });
+    const res = await get(env);
+    const body = (await res.json()) as { available: boolean };
+    expect(body.available).toBe(true);
+  });
+});
+
 describe('validateTrip — #819 promptGeoContext / promptDisplay', () => {
   function withPrompt(overrides: Record<string, unknown>): Record<string, unknown> {
     return { ...base(), ...overrides };

--- a/backend/alarm-worker/src/__tests__/recallQueries.test.ts
+++ b/backend/alarm-worker/src/__tests__/recallQueries.test.ts
@@ -1,0 +1,104 @@
+/**
+ * recallQueries.ts SSOT 회귀 — query 문자열이 catalog/recallTelemetry schema와 동기를 유지하는지 검증.
+ *
+ * "동기"의 의미:
+ *   - blob label은 `recordRecallUpload`가 적재한 형식과 1:1 매칭
+ *   - threshold/dataset 식별자는 catalog SSOT에서 끌어옴 (hardcoded 식별자 금지)
+ *   - 새 query 추가 = `RECALL_QUERIES` 배열에만 등록
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  RECALL_DATASET,
+  RECALL_QUERIES,
+  dailyRecallRateQuery,
+  gateSuppressionDistributionQuery,
+  lowRecallTripRatioQuery,
+} from '../recallQueries';
+import { METRIC_KIND, MIN_RECALL_RATIO_THRESHOLD } from '../metrics';
+import { RECALL_DISTRIBUTION_LABEL_PREFIX } from '../recallTelemetry';
+
+describe('RECALL_DATASET', () => {
+  it('matches wrangler.toml dataset name', () => {
+    // wrangler.toml의 `dataset = "silent_push_telemetry"`와 동일 (#498 / #506 주석 참조).
+    expect(RECALL_DATASET).toBe('silent_push_telemetry');
+  });
+});
+
+describe('dailyRecallRateQuery', () => {
+  it('references both hit and total labels for the recall rate metric', () => {
+    const rateKind = METRIC_KIND.PER_STATION_ALARM_RECALL;
+    expect(dailyRecallRateQuery).toContain(`phase3:${rateKind}:hit`);
+    expect(dailyRecallRateQuery).toContain(`phase3:${rateKind}:total`);
+  });
+
+  it('queries the recall dataset', () => {
+    expect(dailyRecallRateQuery).toContain(RECALL_DATASET);
+  });
+
+  it('does not hardcode the metric key string literally', () => {
+    // catalog SSOT에서 끌어와야 함 — METRIC_KIND가 바뀌면 query도 자동 갱신.
+    // 본 테스트는 회귀 방지용 — 키가 바뀌었는데 query가 안 바뀌면 첫 assertion이 깨진다.
+    const rateKind = METRIC_KIND.PER_STATION_ALARM_RECALL;
+    expect(rateKind.length).toBeGreaterThan(0);
+  });
+});
+
+describe('gateSuppressionDistributionQuery', () => {
+  it('uses the recallTelemetry distribution label prefix', () => {
+    const gatePrefix = `phase3:${RECALL_DISTRIBUTION_LABEL_PREFIX}:`;
+    expect(gateSuppressionDistributionQuery).toContain(gatePrefix);
+  });
+
+  it('extracts reason via substring offset matching the prefix length', () => {
+    const gatePrefix = `phase3:${RECALL_DISTRIBUTION_LABEL_PREFIX}:`;
+    // SQL substring 인덱스는 1-based — prefix 길이 + 1 로 첫 reason 문자 시작.
+    expect(gateSuppressionDistributionQuery).toContain(
+      `substring(blob1, ${gatePrefix.length + 1})`,
+    );
+  });
+});
+
+describe('lowRecallTripRatioQuery', () => {
+  it('embeds the catalog SSOT threshold value', () => {
+    expect(lowRecallTripRatioQuery).toContain(String(MIN_RECALL_RATIO_THRESHOLD));
+  });
+
+  it('aggregates per token prefix (blob2)', () => {
+    expect(lowRecallTripRatioQuery).toContain('blob2');
+  });
+
+  it('guards division by zero (total_tokens=0 → ratio=0 instead of NaN)', () => {
+    // 빈 7일 윈도우에서 outer SELECT가 NaN/inf를 산출하면 alert webhook이 spurious 발사.
+    expect(lowRecallTripRatioQuery).toContain('if(total_tokens > 0');
+  });
+});
+
+describe('dailyRecallRateQuery', () => {
+  it('guards division by zero (expected_stops=0 → recall_rate=0 instead of NaN)', () => {
+    // 해당 일자에 total data point가 0인 경우 분모 0. NaN이면 dashboard 카드 깨짐.
+    expect(dailyRecallRateQuery).toContain('if(expected_stops > 0');
+  });
+});
+
+describe('RECALL_QUERIES', () => {
+  it('contains the three exported queries with unique ids', () => {
+    const ids = RECALL_QUERIES.map((q) => q.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain('daily-recall-rate');
+    expect(ids).toContain('gate-suppression-distribution');
+    expect(ids).toContain('low-recall-trip-ratio');
+  });
+
+  it('each entry exposes a non-empty SQL string referencing the dataset', () => {
+    for (const entry of RECALL_QUERIES) {
+      expect(entry.sql.length).toBeGreaterThan(0);
+      expect(entry.sql).toContain(RECALL_DATASET);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is frozen (catalog mutation guard)', () => {
+    expect(Object.isFrozen(RECALL_QUERIES)).toBe(true);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -34,6 +34,8 @@ import {
   recordRecallUpload,
   validateRecallUpload,
 } from './recallTelemetry';
+import { MIN_RECALL_RATIO_THRESHOLD } from './metrics';
+import { RECALL_DATASET, RECALL_QUERIES } from './recallQueries';
 import {
   tokenPrefix,
   validateTelemetryUpload,
@@ -254,6 +256,27 @@ app.post('/telemetry/recall', async (c) => {
     }),
   );
   return c.json({ ok: true });
+});
+
+/**
+ * Recall KPI 집계 query 노출 (#919, Epic #912 A4 후속).
+ *
+ * 운영 대시보드(Grafana / Notion KPI 카드)가 Cloudflare Analytics Engine SQL HTTP API로
+ * 그대로 호출할 수 있는 쿼리 문자열을 SSOT로 반환한다. Worker AE binding은 *write* 전용이라
+ * 워커 자체가 SQL을 실행하지 않는다 — 본 엔드포인트는 query catalog + dataset metadata만 노출.
+ *
+ * `TELEMETRY` binding이 활성화되지 않은 환경에서도 query는 그대로 반환된다(available=false).
+ * 대시보드는 available 플래그로 "데이터 미수집 중" 안내 배너를 노출할 수 있다.
+ *
+ * Privacy: query / dataset 메타만 노출 — 사용자 식별자/원문 미노출.
+ */
+app.get('/metrics/recall/summary', (c) => {
+  return c.json({
+    dataset: RECALL_DATASET,
+    available: c.env.TELEMETRY !== undefined,
+    minRecallRatioThreshold: MIN_RECALL_RATIO_THRESHOLD,
+    queries: RECALL_QUERIES,
+  });
 });
 
 /**

--- a/backend/alarm-worker/src/recallQueries.ts
+++ b/backend/alarm-worker/src/recallQueries.ts
@@ -1,0 +1,165 @@
+/**
+ * Recall KPI 집계 query (#919, Epic #912 A4 후속).
+ *
+ * `recordRecallUpload`가 Analytics Engine(dataset `silent_push_telemetry`)에 적재한
+ * data point들을 대시보드/운영 alert에서 조회하기 위한 **SQL 문자열 SSOT**.
+ *
+ * Why string SSOT (코드로 실행하지 않음)
+ *   현재 `wrangler.toml`은 Workers Paid 대기로 `[[analytics_engine_datasets]]` 블록이
+ *   주석 처리되어 있어 워커 런타임에는 AE binding이 없다. 또한 Workers AE binding은 *write* 전용
+ *   (`writeDataPoint`)이며, *read*는 Cloudflare SQL HTTP API
+ *   (`POST https://api.cloudflare.com/client/v4/accounts/<id>/analytics_engine/sql`)
+ *   로만 가능하다. 따라서 본 모듈은 query 문자열을 SSOT로 export하고,
+ *   `GET /metrics/recall/summary` 엔드포인트가 이를 그대로 노출 — 외부 대시보드
+ *   (Grafana / Notion 운영 페이지)가 동일 문자열로 SQL API를 호출한다.
+ *
+ * Schema 가정 (recallTelemetry.ts:recordRecallUpload와 동기)
+ *   blob1  = `phase3:<metricKey>:<field>` — perStationAlarmRecall의 경우 field='hit'|'total',
+ *             gateSuppressionDistribution의 경우 field='reason:<reasonKey>'
+ *   blob2  = token prefix(8자)
+ *   double1 = value (rate=정수 count, gate=정수 count)
+ *   index1  = token prefix
+ *
+ * 새 query 추가 = 본 파일에 `export const ...Query = ...` 추가 + `RECALL_QUERIES` 배열에 등록.
+ * 새 metric 추가 = `metrics.catalog.json` + `recallTelemetry.ts` 양쪽이 우선, 본 파일은 catalog SSOT
+ * 그대로 import해서 hardcoded key 없이 query를 조립한다.
+ *
+ * Privacy: query는 token prefix(8자)만 다룬다 — 개별 사용자 식별 불가.
+ */
+
+import { METRIC_KIND, MIN_RECALL_RATIO_THRESHOLD } from './metrics';
+import { RECALL_DISTRIBUTION_LABEL_PREFIX } from './recallTelemetry';
+
+/**
+ * AE dataset name. wrangler.toml의 `dataset = "silent_push_telemetry"`와 동일 (#498 / #506 주석 참조).
+ * binding이 활성화되어도 dataset name은 바뀌지 않는다 — read query에서 FROM 절에 그대로 사용.
+ */
+export const RECALL_DATASET = 'silent_push_telemetry';
+
+/**
+ * 본 모듈이 사용하는 metric 식별자 — catalog SSOT(`metrics.catalog.json`)에서 동적으로 끌어와
+ * hardcoded 식별자 없음. catalog에서 key가 바뀌면 query도 자동 갱신.
+ */
+const RECALL_RATE_KIND = METRIC_KIND.PER_STATION_ALARM_RECALL;
+
+/** rate metric의 field 분해 — `writeMetricDataPoints` 내부 schema와 일치. */
+const RATE_HIT_LABEL = `phase3:${RECALL_RATE_KIND}:hit`;
+const RATE_TOTAL_LABEL = `phase3:${RECALL_RATE_KIND}:total`;
+
+/** gate suppression distribution은 `phase3:gateSuppressionDistribution:reason:<reason>` prefix. */
+const GATE_LABEL_PREFIX = `phase3:${RECALL_DISTRIBUTION_LABEL_PREFIX}:`;
+
+/**
+ * **Q1. Daily recall rate.**
+ *
+ * 일자별 perStationAlarmRecall rate = SUM(hit) / SUM(total).
+ * 분자/분모 두 data point를 동시에 누적하고 비율 계산.
+ *
+ * 사용처
+ *   - Grafana time-series: 일별 매역 알림 도달률 추세.
+ *   - Notion 운영 대시보드 KPI 카드.
+ */
+export const dailyRecallRateQuery = `
+SELECT
+  day,
+  fired_stops,
+  expected_stops,
+  if(expected_stops > 0, fired_stops / expected_stops, 0) AS recall_rate
+FROM (
+  SELECT
+    toStartOfDay(timestamp) AS day,
+    SUM(CASE WHEN blob1 = '${RATE_HIT_LABEL}' THEN double1 ELSE 0 END) AS fired_stops,
+    SUM(CASE WHEN blob1 = '${RATE_TOTAL_LABEL}' THEN double1 ELSE 0 END) AS expected_stops
+  FROM ${RECALL_DATASET}
+  WHERE timestamp > NOW() - INTERVAL '14' DAY
+    AND blob1 IN ('${RATE_HIT_LABEL}', '${RATE_TOTAL_LABEL}')
+  GROUP BY day
+)
+ORDER BY day DESC
+`.trim();
+
+/**
+ * **Q2. Gate suppression breakdown.**
+ *
+ * 최근 14일 reason별 차단 count — `recordRecallUpload`가 `reason:<id>` 접미사로 분해
+ * 적재하므로 SQL `substring`으로 reason key 추출. reason 카탈로그가 늘어도 query 수정 불필요.
+ *
+ * 사용처
+ *   - Stacked bar / pie: 어느 게이트가 가장 많이 차단하는지.
+ *   - A1~A3(완화/임계/silence) 효과 측정의 기준 분포.
+ */
+export const gateSuppressionDistributionQuery = `
+SELECT
+  substring(blob1, ${GATE_LABEL_PREFIX.length + 1}) AS reason,
+  SUM(double1) AS suppressed_count
+FROM ${RECALL_DATASET}
+WHERE timestamp > NOW() - INTERVAL '14' DAY
+  AND blob1 LIKE '${GATE_LABEL_PREFIX}%'
+GROUP BY reason
+ORDER BY suppressed_count DESC
+`.trim();
+
+/**
+ * **Q3. Low-recall trip ratio (alert 임계).**
+ *
+ * token prefix 단위로 hit/total 합산 → 비율 < threshold인 prefix 비율 산출.
+ * 이 값이 운영 임계(예: 5%)를 넘으면 운영 알림 (Slack / 이메일) 발사 — 별도 PR에서 wiring.
+ *
+ * threshold는 `metrics.catalog.json:MIN_RECALL_RATIO_THRESHOLD` SSOT.
+ *
+ * 사용처
+ *   - "95% 미달 trip 비율" KPI 카드.
+ *   - 임계 초과 시 운영 alert webhook trigger 입력값.
+ */
+export const lowRecallTripRatioQuery = `
+SELECT
+  total_tokens,
+  low_recall_tokens,
+  if(total_tokens > 0, low_recall_tokens / total_tokens, 0) AS low_recall_ratio
+FROM (
+  SELECT
+    COUNT(*) AS total_tokens,
+    SUM(CASE WHEN total > 0 AND (hit / total) < ${MIN_RECALL_RATIO_THRESHOLD} THEN 1 ELSE 0 END) AS low_recall_tokens
+  FROM (
+    SELECT
+      blob2 AS token_prefix,
+      SUM(CASE WHEN blob1 = '${RATE_HIT_LABEL}' THEN double1 ELSE 0 END) AS hit,
+      SUM(CASE WHEN blob1 = '${RATE_TOTAL_LABEL}' THEN double1 ELSE 0 END) AS total
+    FROM ${RECALL_DATASET}
+    WHERE timestamp > NOW() - INTERVAL '7' DAY
+      AND blob1 IN ('${RATE_HIT_LABEL}', '${RATE_TOTAL_LABEL}')
+    GROUP BY token_prefix
+  )
+  WHERE total > 0
+)
+`.trim();
+
+/**
+ * Query 목록 — 카탈로그 형태로 노출해 endpoint가 순회. 새 query 추가 시 본 배열에 등록만.
+ */
+export interface RecallQueryEntry {
+  /** 안정 식별자. dashboard URL slug로 사용. */
+  id: string;
+  /** 사람이 읽는 한 줄 설명 — 운영 페이지 카드 제목으로 사용. */
+  description: string;
+  /** Cloudflare AE SQL. */
+  sql: string;
+}
+
+export const RECALL_QUERIES: readonly RecallQueryEntry[] = Object.freeze([
+  {
+    id: 'daily-recall-rate',
+    description: '일별 매역 알림 recall rate (분자=fired stops, 분모=expected stops, 14일 윈도우)',
+    sql: dailyRecallRateQuery,
+  },
+  {
+    id: 'gate-suppression-distribution',
+    description: '게이트별 차단 분포 — 14일 윈도우 reason별 count',
+    sql: gateSuppressionDistributionQuery,
+  },
+  {
+    id: 'low-recall-trip-ratio',
+    description: `recall < ${MIN_RECALL_RATIO_THRESHOLD} token 비율 (운영 alert 임계 입력, 7일 윈도우)`,
+    sql: lowRecallTripRatioQuery,
+  },
+]);


### PR DESCRIPTION
Closes #919 (운영 KPI dashboard wiring — A4 후속).

## 배경

PR #948에서 backend metrics catalog(`perStationAlarmRecall`, `gateSuppressionDistribution`) 등록 + `POST /telemetry/recall` 적재 endpoint를 정착시켰다. 본 PR은 **운영 대시보드/alert가 적재된 data point를 어떻게 조회하는지**를 SSOT로 노출한다.

## Deliverable rationale

**Option A + B** 채택.

- **Option A (SQL SSOT)**: `recallQueries.ts`에 Cloudflare AE SQL 3종을 export. `METRIC_KIND` / `MIN_RECALL_RATIO_THRESHOLD` / `RECALL_DISTRIBUTION_LABEL_PREFIX` 카탈로그 SSOT에서 label/threshold를 동적으로 조립 → catalog가 바뀌면 query가 자동 갱신, hardcoded 식별자 없음.
- **Option B (endpoint wrapper)**: `GET /metrics/recall/summary`가 query catalog + dataset name + threshold + `TELEMETRY` binding 가용성을 그대로 JSON으로 반환. Cloudflare AE binding은 *write* 전용 (`writeDataPoint`)이므로 워커가 SQL을 직접 실행할 수 없다 — 외부 대시보드(Grafana / Notion 운영 페이지)가 Cloudflare SQL HTTP API로 동일 문자열을 호출한다. 이렇게 두면 운영 페이지가 backend 코드를 SSOT로 참조하고, deploy만으로 dashboard 동기화가 보장된다.

**AE-pending note**: `wrangler.toml`의 `[[analytics_engine_datasets]]` 블록은 Workers Paid 대기로 주석 처리(#506) 상태. binding 부재 시 endpoint는 `available: false`로 응답해 dashboard가 "데이터 미수집 중" 안내 배너를 띄울 수 있다.

## Query 목록

| id | window | 용도 |
| --- | --- | --- |
| `daily-recall-rate` | 14d | 일별 매역 알림 도달률 추세 (Grafana time-series) |
| `gate-suppression-distribution` | 14d | 게이트별 차단 분포 (stacked bar / pie) — A1~A3 효과 측정의 기준 |
| `low-recall-trip-ratio` | 7d | `recall < MIN_RECALL_RATIO_THRESHOLD(0.95)` token 비율 — 운영 alert 임계 입력 |

세 query 모두 분모 0 가드 (`if(... > 0, ..., 0)`) 적용 — 빈 윈도우에서 NaN/inf alert 폭주 차단.

## Test plan

- [x] `npx vitest run` (backend) — 866 tests pass
- [x] `npx tsc --noEmit` (backend + root) — 신규 코드 에러 0건 (pre-existing `scheduled.test.ts` 2건은 unrelated)
- [x] SSOT 회귀 테스트: metric key / threshold / dataset / distribution prefix가 catalog와 동기인지
- [x] Endpoint 가용성: TELEMETRY 부재 시 `available=false` + queries 정상 노출, 존재 시 `available=true`
- [x] Divide-by-zero 가드 회귀 (daily / low-recall 양쪽)

## Out of scope (후속 PR 후보)

- Slack / 이메일 alert webhook wiring — `low-recall-trip-ratio` 결과를 임계와 비교해 발사
- Notion 운영 페이지에 query 등록 (배포 후 endpoint hit으로 가져옴)
- AE binding 활성화 후 sanity smoke (Workers Paid 전환 시점)