### PR TITLE
fix(#962): arvlcd-arrived pre-boarding weak signal

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedStationDetection.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedStationDetection.test.ts
@@ -47,44 +47,70 @@ describe('evaluateArvlcdArrivedSignal', () => {
     expect(evaluateArvlcdArrivedSignal(null, TRAIN_CODE)).toBeUndefined();
   });
 
-  it('lockedTrainCode null → undefined', () => {
-    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ARRIVED })]);
-    expect(evaluateArvlcdArrivedSignal(a, null)).toBeUndefined();
+  describe('post-boarding (lockedTrainCode 있음)', () => {
+    it('row 매칭 없음 → undefined', () => {
+      const a = arrival([arrivalRow({ trainCode: 'OTHER' })]);
+      expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBeUndefined();
+    });
+
+    it.each([
+      ['ARRIVED', ARRIVAL_CODE.ARRIVED],
+      ['ENTERING', ARRIVAL_CODE.ENTERING],
+    ])('arvlCd=%s → true', (_label, code) => {
+      const a = arrival([arrivalRow({ arrivalCode: code })]);
+      expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(true);
+    });
+
+    it.each([
+      ['DEPARTED', ARRIVAL_CODE.DEPARTED],
+      ['PREV_ARRIVED', ARRIVAL_CODE.PREV_ARRIVED],
+      ['RUNNING', ARRIVAL_CODE.RUNNING],
+    ])('arvlCd=%s → false (명시 미합의)', (_label, code) => {
+      const a = arrival([arrivalRow({ arrivalCode: code })]);
+      expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(false);
+    });
+
+    it('up과 down 모두 검색 — down에 매칭 row가 있어도 찾아냄', () => {
+      const a = arrival(
+        [arrivalRow({ trainCode: 'OTHER' })],
+        [arrivalRow({ trainCode: TRAIN_CODE, arrivalCode: ARRIVAL_CODE.ARRIVED })],
+      );
+      expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(true);
+    });
   });
 
-  it('lockedTrainCode undefined → undefined', () => {
-    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ARRIVED })]);
-    expect(evaluateArvlcdArrivedSignal(a, undefined)).toBeUndefined();
-  });
+  describe('pre-boarding (lockedTrainCode 없음, #962)', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+    ])('lockedTrainCode=%s + 어느 row든 ARRIVED → true (weak signal)', (_label, locked) => {
+      const a = arrival([
+        arrivalRow({ trainCode: 'OTHER1', arrivalCode: ARRIVAL_CODE.RUNNING }),
+        arrivalRow({ trainCode: 'OTHER2', arrivalCode: ARRIVAL_CODE.ARRIVED }),
+      ]);
+      expect(evaluateArvlcdArrivedSignal(a, locked)).toBe(true);
+    });
 
-  it('row 매칭 없음 → undefined', () => {
-    const a = arrival([arrivalRow({ trainCode: 'OTHER' })]);
-    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBeUndefined();
-  });
+    it('lockedTrainCode=null + down에 ENTERING row → true', () => {
+      const a = arrival(
+        [arrivalRow({ trainCode: 'OTHER1', arrivalCode: ARRIVAL_CODE.RUNNING })],
+        [arrivalRow({ trainCode: 'OTHER2', arrivalCode: ARRIVAL_CODE.ENTERING })],
+      );
+      expect(evaluateArvlcdArrivedSignal(a, null)).toBe(true);
+    });
 
-  it.each([
-    ['ARRIVED', ARRIVAL_CODE.ARRIVED],
-    ['ENTERING', ARRIVAL_CODE.ENTERING],
-  ])('arvlCd=%s → true', (_label, code) => {
-    const a = arrival([arrivalRow({ arrivalCode: code })]);
-    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(true);
-  });
+    it('lockedTrainCode=null + 모든 row 운행/출발 → false (명시 미합의)', () => {
+      const a = arrival([
+        arrivalRow({ arrivalCode: ARRIVAL_CODE.RUNNING }),
+        arrivalRow({ arrivalCode: ARRIVAL_CODE.DEPARTED }),
+      ]);
+      expect(evaluateArvlcdArrivedSignal(a, null)).toBe(false);
+    });
 
-  it.each([
-    ['DEPARTED', ARRIVAL_CODE.DEPARTED],
-    ['PREV_ARRIVED', ARRIVAL_CODE.PREV_ARRIVED],
-    ['RUNNING', ARRIVAL_CODE.RUNNING],
-  ])('arvlCd=%s → false (명시 미합의)', (_label, code) => {
-    const a = arrival([arrivalRow({ arrivalCode: code })]);
-    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(false);
-  });
-
-  it('up과 down 모두 검색 — down에 매칭 row가 있어도 찾아냄', () => {
-    const a = arrival(
-      [arrivalRow({ trainCode: 'OTHER' })],
-      [arrivalRow({ trainCode: TRAIN_CODE, arrivalCode: ARRIVAL_CODE.ARRIVED })],
-    );
-    expect(evaluateArvlcdArrivedSignal(a, TRAIN_CODE)).toBe(true);
+    it('lockedTrainCode=null + arrival 비어있음 → false', () => {
+      const a = arrival([], []);
+      expect(evaluateArvlcdArrivedSignal(a, null)).toBe(false);
+    });
   });
 });
 
@@ -175,6 +201,36 @@ describe('useFusedStationDetection', () => {
     expect(result.current.detected).toBe(true);
     expect(result.current.confidence).toBe('medium');
     expect(result.current.signalsAgreed).toBe(2);
+  });
+
+  it('#962 pre-boarding: lockedTrainCode=null + any ARRIVED + motion-stationary=true → detected medium (weak signal이 합의에 기여)', () => {
+    const a = arrival([arrivalRow({ trainCode: 'OTHER', arrivalCode: ARRIVAL_CODE.ARRIVED })]);
+    const { result } = renderHook(() =>
+      useFusedStationDetection({
+        barometer: null,
+        motionStationary: true,
+        arrival: a,
+        lockedTrainCode: null,
+      }),
+    );
+    expect(result.current.detected).toBe(true);
+    expect(result.current.confidence).toBe('medium');
+    expect(result.current.signalsAgreed).toBe(2);
+  });
+
+  it('#962 pre-boarding: lockedTrainCode=null + any ARRIVED 단독 → detected=false (>=2 합의 필요)', () => {
+    const a = arrival([arrivalRow({ trainCode: 'OTHER', arrivalCode: ARRIVAL_CODE.ARRIVED })]);
+    const { result } = renderHook(() =>
+      useFusedStationDetection({
+        barometer: null,
+        motionStationary: undefined,
+        arrival: a,
+        lockedTrainCode: null,
+      }),
+    );
+    expect(result.current.detected).toBe(false);
+    expect(result.current.signalsAgreed).toBe(1);
+    expect(result.current.signalsAvailable).toBe(1);
   });
 
   it('3 신호 모두 합의 → detected high', () => {

--- a/src/features/nearest-station/hooks/useFusedStationDetection.ts
+++ b/src/features/nearest-station/hooks/useFusedStationDetection.ts
@@ -14,13 +14,19 @@
  * 신호 변환 규약:
  *   - 'barometer-stop'    ← BarometerSignal.stop (undefined → unavailable)
  *   - 'motion-stationary' ← useMotionActivity()의 stationary boolean
- *   - 'arvlcd-arrived'    ← lockedTrainCode 매칭 row의 arvlCd가 ARRIVED|ENTERING이면 true
+ *   - 'arvlcd-arrived'    ← arrival 응답의 arvlCd 평가 (pre/post-boarding 모드 분기, #962):
+ *       - lockedTrainCode != null (post-boarding): 매칭 row의 arvlCd가 ARRIVED|ENTERING이면 true.
+ *           정확한 trainCode 매칭으로 false positive 가능성 낮음 (strong path).
+ *       - lockedTrainCode == null (pre-boarding): up/down 어느 row든 arvlCd가 ARRIVED|ENTERING이면 true.
+ *           아직 어떤 열차를 탔는지 모르는 단계 — "이 역에 어떤 열차든 들어오고 있다"는 약신호로
+ *           사용. motion/barometer와 OR 결합되어야 합의(>=2) 도달 가능 — 단독으로는 detected 못 만듦.
  *
  * unavailable 정책:
  *   - barometer.stop=undefined → fusion 입력에서 키 자체 생략 (signalsAvailable 감소, 다른 신호로
  *     합의 가능).
  *   - motionStationary=undefined → 동일.
- *   - arrival=null 또는 lockedTrainCode=null → arvlcd-arrived 키 생략.
+ *   - arrival=null → arvlcd-arrived 키 생략.
+ *   - lockedTrainCode != null이면서 매칭 row 없음 → arvlcd-arrived 키 생략 (아직 응답에 row 미도착).
  *
  * 본 hook은 순수 변환 — 부수 효과 없음. render마다 동기 계산.
  */
@@ -52,26 +58,40 @@ export interface FusedStationDetectionInput {
   readonly lockedTrainCode: string | null | undefined;
 }
 
+function isArrivedCode(code: ArrivalInfo['arrivalCode']): boolean {
+  return code === ARRIVAL_CODE.ARRIVED || code === ARRIVAL_CODE.ENTERING;
+}
+
 /**
- * arvlcd-arrived 신호 평가.
+ * arvlcd-arrived 신호 평가. lockedTrainCode 존재 여부로 두 모드 분기 (#962).
  *
- * - arrival 또는 lockedTrainCode 부재 → undefined (unavailable).
- * - row 매칭 없음(아직 응답에 안 들어옴) → undefined (unavailable).
- * - row.arrivalCode가 ARRIVED|ENTERING → true.
- * - 그 외(출발/전역/운행중) → false (명시 미합의).
+ * post-boarding (lockedTrainCode != null):
+ *   - 매칭 row 없음 → undefined (unavailable, 아직 응답에 row 미도착).
+ *   - 매칭 row의 arrivalCode가 ARRIVED|ENTERING → true.
+ *   - 그 외 → false.
+ *
+ * pre-boarding (lockedTrainCode == null):
+ *   - up/down 어느 row든 ARRIVED|ENTERING이면 true (약신호).
+ *   - 그 외(rows 비어있음 포함) → false (명시 미합의).
+ *
+ * 공통: arrival === null → undefined (unavailable).
+ *
+ * pre-boarding 모드는 단독으로 detected 못 만듦 — fusion 알고리즘이 >=2 신호 합의를 요구하므로
+ * motion-stationary / barometer-stop과 OR 결합되어야만 합의에 기여한다. 이것이 false positive
+ * 방지 — pre-boarding 약신호가 다른 신호 없이 단독으로 detected를 만들지 않는다.
  */
 export function evaluateArvlcdArrivedSignal(
   arrival: StationArrival | null,
   lockedTrainCode: string | null | undefined,
 ): boolean | undefined {
-  if (arrival === null || lockedTrainCode == null) return undefined;
+  if (arrival === null) return undefined;
   const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
+  if (lockedTrainCode == null) {
+    return all.some((r) => isArrivedCode(r.arrivalCode));
+  }
   const row = all.find((r) => r.trainCode === lockedTrainCode);
   if (row === undefined) return undefined;
-  return (
-    row.arrivalCode === ARRIVAL_CODE.ARRIVED ||
-    row.arrivalCode === ARRIVAL_CODE.ENTERING
-  );
+  return isArrivedCode(row.arrivalCode);
 }
 
 /**


### PR DESCRIPTION
Closes #962

## Context

PR #944 (#921 fusion wire-up) merged with P1.3 follow-up. `evaluateArvlcdArrivedSignal`이 `lockedTrainCode`가 null이면 영구 `undefined`(unavailable) 반환 → BoardingLock 미잠금 사용자(pre-boarding, 다수)가 fusion 3 신호 중 arvlcd-arrived를 영구히 못 받아 합의(>=2) 어려움.

## Algorithm Change

`evaluateArvlcdArrivedSignal`를 두 모드로 분기:

- **post-boarding** (`lockedTrainCode != null`): 기존 동작 유지. 매칭 row의 arvlCd만 평가 → strong signal (정확한 trainCode 매칭).
- **pre-boarding** (`lockedTrainCode == null`): up/down 어느 row든 arvlCd ∈ {ARRIVED, ENTERING}이면 `true`. row 없거나 모두 운행/출발 상태면 `false` (명시 미합의). 약신호.

## Confidence 결정

fusion 알고리즘(`fuseStationDetectionSignals`)은 신호를 boolean으로만 받고 가중치 개념이 없다 — 합의 신호 수로만 verdict 결정. "weak signal"의 의미는 의미론적:

- pre-boarding 신호는 단독으로는 `signalsAgreed=1` → `detected=false` (>=2 임계 미달).
- motion-stationary 또는 barometer-stop과 OR 결합되어야만 합의에 기여.
- 이것이 자연스러운 false positive 방지 — pre-boarding 약신호 단독으로 detected를 만들지 않는다.

## Test plan

- [x] post-boarding 회귀: locked + arrived → true / not arrived → false / row 없음 → undefined
- [x] post-boarding up·down 모두 검색
- [x] pre-boarding 신규: lockedTrainCode=null/undefined + any row ARRIVED → true
- [x] pre-boarding 신규: down 쪽 ENTERING도 검출
- [x] pre-boarding 신규: 모든 row 운행/출발 → false
- [x] pre-boarding 신규: arrival 비어있음 → false
- [x] 회귀: arrival=null → undefined (모드 무관)
- [x] fusion 통합: pre-boarding + motion-stationary → detected medium
- [x] fusion 통합: pre-boarding 단독 → detected=false (단독 약신호 차단)
- [x] `npm test` 4008 pass, 100% coverage
- [x] `npm run type-check` clean