### PR TITLE
fix(#963): fusionDebugBuffer decisionKey signal mask 추가

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1331,4 +1331,54 @@ describe('useFusedNearestStation', () => {
       expect(result.current.confidence).toBe('arrival-confirmed');
     });
   });
+
+  describe('#963 fusionDebugBuffer decisionKey signal mask', () => {
+    beforeEach(() => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      mockUsePositions.mockReturnValue(positionRet(null));
+    });
+
+    const renderWithMotion = (motionStationary: boolean | undefined) =>
+      renderHook(
+        ({ ms }: { ms: boolean | undefined }) =>
+          useFusedNearestStation(undefined, undefined, undefined, null, null, ms),
+        { initialProps: { ms: motionStationary } },
+      );
+
+    it('같은 source/confidence/stationId + 다른 signal 조합 → 별도 entry로 보존', () => {
+      const {
+        clearFusionDebugEntries,
+        getFusionDebugEntries,
+      } = jest.requireActual('../../utils/fusionDebugBuffer') as typeof import('../../utils/fusionDebugBuffer');
+      clearFusionDebugEntries();
+
+      // motionStationary=false → mask "UFU"
+      const { rerender } = renderWithMotion(false);
+      // motionStationary=true → 같은 source/confidence/stationId, mask "UTU"
+      rerender({ ms: true });
+      // motionStationary=undefined → mask "UUU"
+      rerender({ ms: undefined });
+
+      const entries = getFusionDebugEntries().filter((e) => e.kind === 'fusion');
+      // 동일 source/confidence/stationId여도 mask가 다르므로 3개 보존
+      expect(entries.length).toBe(3);
+    });
+
+    it('완전 동일 signal 조합 재렌더 → dedup 유지 (entry 1개)', () => {
+      const {
+        clearFusionDebugEntries,
+        getFusionDebugEntries,
+      } = jest.requireActual('../../utils/fusionDebugBuffer') as typeof import('../../utils/fusionDebugBuffer');
+      clearFusionDebugEntries();
+
+      const { rerender } = renderWithMotion(true);
+      rerender({ ms: true });
+      rerender({ ms: true });
+
+      const entries = getFusionDebugEntries().filter((e) => e.kind === 'fusion');
+      expect(entries.length).toBe(1);
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedStationDetection.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedStationDetection.test.ts
@@ -6,6 +6,7 @@
 import { renderHook } from '@testing-library/react-native';
 import {
   buildFusionSignalInput,
+  buildFusionSignalMask,
   evaluateArvlcdArrivedSignal,
   useFusedStationDetection,
   type FusedStationDetectionInput,
@@ -143,6 +144,48 @@ describe('buildFusionSignalInput', () => {
   });
 });
 
+describe('buildFusionSignalMask (#963)', () => {
+  it('빈 입력 → "UUU" (모든 신호 unavailable)', () => {
+    expect(buildFusionSignalMask({})).toBe('UUU');
+  });
+
+  it('모든 신호 true → "TTT"', () => {
+    expect(
+      buildFusionSignalMask({
+        'barometer-stop': true,
+        'motion-stationary': true,
+        'arvlcd-arrived': true,
+      }),
+    ).toBe('TTT');
+  });
+
+  it('모든 신호 false → "FFF"', () => {
+    expect(
+      buildFusionSignalMask({
+        'barometer-stop': false,
+        'motion-stationary': false,
+        'arvlcd-arrived': false,
+      }),
+    ).toBe('FFF');
+  });
+
+  it('일부 unavailable 혼합 — STATION_DETECTION_SIGNALS 순서 유지', () => {
+    expect(
+      buildFusionSignalMask({
+        'arvlcd-arrived': true,
+        'barometer-stop': false,
+      }),
+    ).toBe('FUT');
+  });
+
+  it('신호 조합이 다르면 mask가 다르다 (dedup key로 사용 가능)', () => {
+    const a = buildFusionSignalMask({ 'motion-stationary': true });
+    const b = buildFusionSignalMask({ 'motion-stationary': false });
+    const c = buildFusionSignalMask({});
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+});
+
 describe('useFusedStationDetection', () => {
   it('빈 입력 → detected=false low', () => {
     const { result } = renderHook(() => useFusedStationDetection(EMPTY_INPUT));
@@ -191,6 +234,25 @@ describe('useFusedStationDetection', () => {
     expect(result.current.confidence).toBe('high');
     expect(result.current.signalsAgreed).toBe(3);
     expect(result.current.signalsAvailable).toBe(3);
+  });
+
+  it('#963 verdict에 signalMask가 포함된다 — 모든 unavailable이면 "UUU"', () => {
+    const { result } = renderHook(() => useFusedStationDetection(EMPTY_INPUT));
+    expect(result.current.signalMask).toBe('UUU');
+  });
+
+  it('#963 신호 조합별 signalMask — 순서 STATION_DETECTION_SIGNALS 따름', () => {
+    const a = arrival([arrivalRow({ arrivalCode: ARRIVAL_CODE.ARRIVED })]);
+    const { result } = renderHook(() =>
+      useFusedStationDetection({
+        barometer: { subsurface: false, stop: true },
+        motionStationary: false,
+        arrival: a,
+        lockedTrainCode: TRAIN_CODE,
+      }),
+    );
+    // STATION_DETECTION_SIGNALS: ['barometer-stop','motion-stationary','arvlcd-arrived']
+    expect(result.current.signalMask).toBe('TFT');
   });
 
   it('같은 input reference로 재호출 시 verdict reference 동일 (useMemo)', () => {

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -611,9 +611,13 @@ export function useFusedNearestStation(
 
   // 측정(#443): 결정 변화(source/stationId/confidence) 시에만 push.
   // render 중 side-effect 회피 + 의존성 누락 은폐 회피를 위해 결정 key를 ref로 비교.
+  //
+  // #963 — signalMask까지 포함해 신호 조합 변화(motion/barometer/arvlcd flip)도 별도 entry로
+  // 보존. 이전엔 source/confidence/stationId만 비교해 같은 결정 안에서 신호 변화가 측정 데이터에서
+  // 누락됐다 (PR #944 P1.2 follow-up).
   const lastDecisionKeyRef = useRef<string | null>(null);
   const resultStationId = result?.station.id ?? null;
-  const decisionKey = `${source}|${confidence}|${resultStationId}`;
+  const decisionKey = `${source}|${confidence}|${resultStationId}|${detectionVerdict.signalMask}`;
   useEffect(() => {
     if (lastDecisionKeyRef.current === decisionKey) return;
     lastDecisionKeyRef.current = decisionKey;

--- a/src/features/nearest-station/hooks/useFusedStationDetection.ts
+++ b/src/features/nearest-station/hooks/useFusedStationDetection.ts
@@ -27,6 +27,7 @@
 
 import { useMemo } from 'react';
 import {
+  STATION_DETECTION_SIGNALS,
   fuseStationDetectionSignals,
   type StationDetectionSignalInput,
   type StationDetectionVerdict,
@@ -99,13 +100,44 @@ export function buildFusionSignalInput(
 }
 
 /**
- * 신호 입력 → fusion verdict. 입력 reference가 동일하면 동일 verdict 캐시.
+ * #963 — fusion 신호 조합의 안정 식별자. unavailable까지 구분해서 인코딩한다.
+ *
+ * 인코딩: STATION_DETECTION_SIGNALS 순서대로 각 신호를 `T`(true) / `F`(false) / `U`(unavailable)
+ * 문자 하나로 합친 고정 길이 문자열. 신호 추가 시 STATION_DETECTION_SIGNALS 갱신만으로 길이가
+ * 자연스럽게 늘어난다.
+ *
+ * 용도: `useFusedNearestStation`의 fusionDebugBuffer dedup key에 포함시켜 같은 station에서
+ * 신호 조합 변화(예: motion stationary flip, barometer subsurface flip)도 별도 entry로 보존.
+ * P1.2 follow-up (PR #944 본문 참고) — decisionKey가 source/confidence/stationId만 비교해
+ * 신호 변화가 측정 데이터에서 누락되던 버그 수정.
+ */
+export function buildFusionSignalMask(input: StationDetectionSignalInput): string {
+  let mask = '';
+  for (const name of STATION_DETECTION_SIGNALS) {
+    const value = input[name];
+    if (value === undefined) {
+      mask += 'U';
+    } else if (value) {
+      mask += 'T';
+    } else {
+      mask += 'F';
+    }
+  }
+  return mask;
+}
+
+/**
+ * 신호 입력 → fusion verdict + signal mask. 입력 reference가 동일하면 동일 결과 캐시.
+ *
+ * signalMask는 호출자(useFusedNearestStation)의 측정 dedup key에 포함되어 신호 조합 변화도
+ * entry로 보존한다 (#963).
  */
 export function useFusedStationDetection(
   input: FusedStationDetectionInput,
-): StationDetectionVerdict {
+): StationDetectionVerdict & { readonly signalMask: string } {
   return useMemo(() => {
     const signalInput = buildFusionSignalInput(input);
-    return fuseStationDetectionSignals(signalInput);
+    const verdict = fuseStationDetectionSignals(signalInput);
+    return { ...verdict, signalMask: buildFusionSignalMask(signalInput) };
   }, [input]);
 }


### PR DESCRIPTION
Closes #963

PR #944 (#921 fusion wire-up) 본문 Follow-ups의 **P1.2** 수정.

## Root cause

`useFusedNearestStation`의 측정 entry dedup이 `source|confidence|stationId`만 비교 → 같은 station에서 신호 조합(motion-stationary / barometer-stop / arvlcd-arrived) 변화가 발생해도 fusionDebugBuffer에서 1 entry로 합쳐져 측정 데이터에서 누락되던 버그.

PR #944로 entry에 `detectionSignals` 필드가 추가되었지만 dedup key가 signal 변화를 반영하지 않아 변화 시점이 잘리고 사후 재구성 불가.

## Fix

`useFusedStationDetection`에 `buildFusionSignalMask` 추가 — `STATION_DETECTION_SIGNALS` 순서대로 각 신호를 `T`(true) / `F`(false) / `U`(unavailable) 1글자씩 합친 안정 식별자(예: `"TFT"`, `"UUU"`). 신호 개수 하드코딩 없이 STATION_DETECTION_SIGNALS만 갱신하면 자동 확장.

`useFusedNearestStation`의 `decisionKey`에 `signalMask` 포함:
```ts
const decisionKey = `${source}|${confidence}|${resultStationId}|${detectionVerdict.signalMask}`;
```

## Test plan

- [x] `buildFusionSignalMask` 단위 테스트 — UUU / TTT / FFF / 일부 unavailable 혼합 / 조합별 unique
- [x] `useFusedNearestStation` dedup 테스트 — 같은 source/confidence/stationId + 다른 motionStationary 3종 → entry 3개 보존
- [x] 완전 동일 signal 조합 재렌더 → entry 1개 dedup 회귀
- [x] `useFusedStationDetection` verdict에 signalMask 포함 확인 (모든 unavailable → "UUU", 혼합 → "TFT")
- [x] `npm run type-check` pass
- [x] `npm test` 4012/4012 pass, 100% coverage