### PR TITLE
fix(#966): BAROMETER_STOP_CONFIRM_SAMPLES 상수 분리 (P1.5)

### DIFF
--- a/src/shared/constants/barometer.ts
+++ b/src/shared/constants/barometer.ts
@@ -113,3 +113,14 @@ export const BAROMETER_ETA_TOLERANCE_SEC = 30;
  * 흡수. 3회 × 1초 = 3초 grace는 지하 진입 응답성과 false toggle 차단의 균형.
  */
 export const BAROMETER_SUBSURFACE_CONFIRM_SAMPLES = 3;
+
+/**
+ * #966 — stop verdict의 hysteresis 확인 샘플 수 (#921 P1.5 follow-up).
+ *
+ * subsurface와 동일 사유로 hysteresis 적용 — 단, 임계(0.05hPa)와 false-positive 비용이
+ * 다르다(stop=true는 사용자에게 "도착" 신호로 노출 가능성, subsurface=true는 내부 게이트만).
+ * 튜닝을 독립 조정할 수 있도록 별도 상수로 분리. 초기값은 회귀 방지를 위해 3 (subsurface와
+ * 동일). 실측 후 stop은 false-positive 비용이 더 크면 4~5로 늘리고, subsurface는 응답성을
+ * 위해 2로 줄이는 식으로 각각 따로 조정 가능.
+ */
+export const BAROMETER_STOP_CONFIRM_SAMPLES = 3;

--- a/src/shared/hooks/useBarometer.ts
+++ b/src/shared/hooks/useBarometer.ts
@@ -32,6 +32,7 @@ import {
 } from '../utils/barometerState';
 import {
   BAROMETER_SAMPLE_INTERVAL_MS,
+  BAROMETER_STOP_CONFIRM_SAMPLES,
   BAROMETER_SUBSURFACE_CONFIRM_SAMPLES,
 } from '../constants/barometer';
 
@@ -68,8 +69,9 @@ export function useBarometer(): BarometerSignal {
   // 들어와야 state flip. lastEmitted과 같은 verdict가 들어오면 카운터 리셋.
   const lastSubsurfaceRef = useRef<boolean>(false);
   const subsurfacePendingRef = useRef<number>(0);
-  // #921 — stop 신호도 동일 hysteresis. undefined(평가 불가)는 즉시 반영 — 신호 부재는
-  // hysteresis로 흐리면 안 되고 즉시 unavailable로 표기되어야 fusion이 정확하다.
+  // #921 — stop 신호도 hysteresis 적용(독립 상수 BAROMETER_STOP_CONFIRM_SAMPLES, #966).
+  // undefined(평가 불가)는 즉시 반영 — 신호 부재는 hysteresis로 흐리면 안 되고 즉시
+  // unavailable로 표기되어야 fusion이 정확하다.
   const lastStopRef = useRef<boolean | undefined>(undefined);
   const stopPendingRef = useRef<number>(0);
 
@@ -118,7 +120,7 @@ export function useBarometer(): BarometerSignal {
           return;
         }
         stopPendingRef.current += 1;
-        if (stopPendingRef.current >= BAROMETER_SUBSURFACE_CONFIRM_SAMPLES) {
+        if (stopPendingRef.current >= BAROMETER_STOP_CONFIRM_SAMPLES) {
           lastStopRef.current = stopDetected;
           stopPendingRef.current = 0;
           setStop(stopDetected);


### PR DESCRIPTION
Closes #966
Refs PR #944 (P1.5 finding)

## Context
PR #944 (#921 fusion wire-up) merged with P1.5 deferred. `BAROMETER_SUBSURFACE_CONFIRM_SAMPLES` 가 두 신호 hysteresis confirm 카운트로 동시에 사용되어 결합:
- **subsurface verdict** (#903, 임계 0.3hPa, 지하 진입 감지)
- **stop verdict** (#921, 임계 0.05hPa, 정차 감지) ← 이 경로가 reuse

두 신호는 임계도 다르고 false-positive 비용도 다른데(subsurface는 내부 게이트 전용, stop은 추후 사용자 노출 가능) 한 상수로 묶여 있어 한쪽을 튜닝하면 다른 쪽까지 변경됨.

## Changes
- `src/shared/constants/barometer.ts`: `BAROMETER_STOP_CONFIRM_SAMPLES = 3` 신규 추가 (JSDoc 포함, #966 marker)
- `src/shared/hooks/useBarometer.ts`: stop 경로 hysteresis만 새 상수 사용. subsurface 경로는 `BAROMETER_SUBSURFACE_CONFIRM_SAMPLES` 그대로
- stop 신호 hysteresis 주석에 독립 상수 사용 명시

## 이름 결정 이유
`MOTION_STOP_CONFIRM_SAMPLES` 대신 `BAROMETER_STOP_CONFIRM_SAMPLES` 선택:
- 신호 출처가 motion activity가 아니라 barometer 압력 평가(`evaluateLatestStop`)
- 기존 짝 상수 `BAROMETER_STOP_DP_THRESHOLD_HPA` 와 prefix/도메인 정합
- 추후 motion activity 기반 stop 신호가 별도 추가되어도 충돌 없이 공존 가능

## 회귀 방지
초기값 둘 다 3 — useBarometer 동작 변경 없음. 후속 실측에서 stop은 4~5, subsurface는 2로 따로 조정하면 됨.

## Test plan
- [x] `npm run type-check` pass
- [x] `npm test` 4022/4022 pass, 100% coverage
- [x] 기존 useBarometer.test.ts 12개 case 그대로 통과 (정상 케이스 + 게이트 실패 + hysteresis + stop verdict + unmount)