### PR TITLE
feat(#967): modules/live-activity user-explicit dismiss event capture

### DIFF
--- a/modules/live-activity/__tests__/pushTokenListeners.test.ts
+++ b/modules/live-activity/__tests__/pushTokenListeners.test.ts
@@ -72,4 +72,41 @@ describe('live-activity push token / ended listeners', () => {
     expect(mockAddListener).not.toHaveBeenCalled();
     expect(() => sub.remove()).not.toThrow();
   });
+
+  it('iOS: addActivityDismissedListener wires native addListener("onActivityDismissed", cb)', () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'ios' });
+    const remove = jest.fn();
+    mockAddListener.mockReturnValue({ remove });
+    mockRequireOptionalNativeModule.mockReturnValue({ addListener: mockAddListener });
+
+    const mod = require('../index');
+    const cb = jest.fn();
+    const sub = mod.addActivityDismissedListener(cb);
+
+    expect(mockAddListener).toHaveBeenCalledWith('onActivityDismissed', cb);
+    sub.remove();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-iOS: addActivityDismissedListener returns noop subscription', () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'android' });
+    mockRequireOptionalNativeModule.mockReturnValue(null);
+
+    const mod = require('../index');
+    const sub = mod.addActivityDismissedListener(() => undefined);
+
+    expect(mockAddListener).not.toHaveBeenCalled();
+    expect(() => sub.remove()).not.toThrow();
+  });
+
+  it('iOS but native module missing: addActivityDismissedListener returns noop subscription', () => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'ios' });
+    mockRequireOptionalNativeModule.mockReturnValue(null);
+
+    const mod = require('../index');
+    const sub = mod.addActivityDismissedListener(() => undefined);
+
+    expect(mockAddListener).not.toHaveBeenCalled();
+    expect(() => sub.remove()).not.toThrow();
+  });
 });

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -97,3 +97,25 @@ export function addActivityEndedListener(
 ): EventSubscription {
   return LiveActivityModule?.addListener('onActivityEnded', listener) ?? NOOP_SUBSCRIPTION;
 }
+
+/**
+ * 사용자가 Live Activity를 직접 swipe-to-dismiss 한 시점 구독 (#967).
+ * 앱이 `endLiveActivity()` 호출로 종료된 경우는 emit되지 않는다 — dismiss sentinel은
+ * 사용자 의도만 반영해야 silent push의 LA refresh 차단 정책(#926)이 올바르게 동작한다.
+ *
+ * payload:
+ *  - dismissedAt: unix ms (native 시각)
+ *  - reason: 현재는 항상 `'user'` — native가 사용자 swipe 경로에서만 emit
+ */
+export interface ActivityDismissedEvent {
+  dismissedAt: number;
+  reason: 'user';
+}
+
+export function addActivityDismissedListener(
+  listener: (event: ActivityDismissedEvent) => void,
+): EventSubscription {
+  return (
+    LiveActivityModule?.addListener('onActivityDismissed', listener) ?? NOOP_SUBSCRIPTION
+  );
+}

--- a/modules/live-activity/ios/LiveActivityManager.swift
+++ b/modules/live-activity/ios/LiveActivityManager.swift
@@ -17,6 +17,13 @@ actor LiveActivityManager {
     /// LiveActivityModule이 주입하는 이벤트 emitter. 메인 액터/스레드 안전성은 호출자가 보장한다.
     var onPushTokenHex: ((String) -> Void)?
     var onActivityEnded: (() -> Void)?
+    /// 사용자가 LA를 직접 swipe-to-dismiss 한 경우만 emit (#967).
+    /// 앱이 `end()`를 호출해 종료된 경우는 emit 되지 않는다 — dismiss sentinel은 사용자 의도만 반영.
+    var onActivityDismissed: ((_ dismissedAtMs: Double) -> Void)?
+
+    /// `end()` 호출 직전 set 되는 플래그. observer가 `.ended`/`.dismissed`로 전이된 시점에
+    /// 이 값이 true면 system end로 분류 → dismiss emit skip. false면 사용자 swipe로 분류.
+    private var expectingSystemEnd: Bool = false
 
     private init() {}
 
@@ -26,10 +33,12 @@ actor LiveActivityManager {
 
     func setEventHandlers(
         onPushTokenHex: @escaping (String) -> Void,
-        onActivityEnded: @escaping () -> Void
+        onActivityEnded: @escaping () -> Void,
+        onActivityDismissed: @escaping (_ dismissedAtMs: Double) -> Void
     ) {
         self.onPushTokenHex = onPushTokenHex
         self.onActivityEnded = onActivityEnded
+        self.onActivityDismissed = onActivityDismissed
     }
 
     /// 현재 추적 중인 Activity + 이전 세션에서 남은 고아 Activity 일괄 종료.
@@ -81,11 +90,23 @@ actor LiveActivityManager {
             for await state in activity.activityStateUpdates {
                 if Task.isCancelled { return }
                 if state == .ended || state == .dismissed {
-                    await self?.emitActivityEnded()
+                    await self?.handleObservedEnd()
                     return
                 }
             }
         }
+    }
+
+    /// observer에서 `.ended`/`.dismissed`를 받은 시점에 호출.
+    /// `expectingSystemEnd` 플래그가 false면 사용자 swipe로 분류 → dismiss emit.
+    /// 어느 경우든 기존 `onActivityEnded`는 호출 (backend deregister 호환).
+    private func handleObservedEnd() {
+        let wasUserDismiss = !expectingSystemEnd
+        expectingSystemEnd = false
+        if wasUserDismiss {
+            emitActivityDismissed()
+        }
+        emitActivityEnded()
     }
 
     private func emitPushToken(_ hex: String) {
@@ -99,6 +120,14 @@ actor LiveActivityManager {
         onActivityEnded?()
         #if DEBUG
         print("[LiveActivity] ended")
+        #endif
+    }
+
+    private func emitActivityDismissed() {
+        let dismissedAtMs = Date().timeIntervalSince1970 * 1000
+        onActivityDismissed?(dismissedAtMs)
+        #if DEBUG
+        print("[LiveActivity] dismissed by user at \(dismissedAtMs)")
         #endif
     }
 
@@ -173,6 +202,8 @@ actor LiveActivityManager {
         // 명시적 종료 경로: backend가 token deregister 트리거를 받을 수 있도록
         // observer cancel 이전에 직접 emit. JS / backend는 idempotent 처리 전제.
         // (start() 내부 cleanup 경로는 다음 토큰이 backend를 upsert하므로 emit 불필요)
+        // #967: observer가 뒤따라 발사될 때 system end로 분류하도록 플래그 set.
+        expectingSystemEnd = true
         let hadActivity = currentActivity != nil
             || !Activity<SubwayActivityAttributes>.activities.isEmpty
         if hadActivity {

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -11,7 +11,7 @@ public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
         Name("LiveActivity")
 
-        Events("onPushToken", "onActivityEnded")
+        Events("onPushToken", "onActivityEnded", "onActivityDismissed")
 
         OnCreate {
             if #available(iOS 16.2, *) {
@@ -22,6 +22,12 @@ public class LiveActivityModule: Module {
                         },
                         onActivityEnded: { [weak self] in
                             self?.sendEvent("onActivityEnded", [:])
+                        },
+                        onActivityDismissed: { [weak self] dismissedAtMs in
+                            self?.sendEvent("onActivityDismissed", [
+                                "dismissedAt": dismissedAtMs,
+                                "reason": "user",
+                            ])
                         }
                     )
                 }

--- a/src/features/alarm/hooks/__tests__/useLiveActivityDismissBridge.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLiveActivityDismissBridge.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react-native';
+
+type DismissListener = (event: { dismissedAt: number; reason: string }) => void;
+
+const mockAddActivityDismissedListener = jest.fn();
+const mockMarkLaDismissed = jest.fn();
+const mockWarn = jest.fn();
+
+jest.mock('../../../../../modules/live-activity', () => ({
+  addActivityDismissedListener: (...args: unknown[]) =>
+    mockAddActivityDismissedListener(...args),
+}));
+
+jest.mock('../../utils/laDismissSentinel', () => ({
+  markLaDismissed: (...args: unknown[]) => mockMarkLaDismissed(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: (...args: unknown[]) => mockWarn(...args),
+    error: jest.fn(),
+  }),
+}));
+
+import { useLiveActivityDismissBridge } from '../useLiveActivityDismissBridge';
+
+describe('useLiveActivityDismissBridge', () => {
+  let listenerRemove: jest.Mock;
+  let capturedListener: DismissListener | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listenerRemove = jest.fn();
+    capturedListener = null;
+    mockAddActivityDismissedListener.mockImplementation((cb: DismissListener) => {
+      capturedListener = cb;
+      return { remove: listenerRemove };
+    });
+    mockMarkLaDismissed.mockResolvedValue(undefined);
+  });
+
+  it('마운트 시 addActivityDismissedListener 구독', () => {
+    renderHook(() => useLiveActivityDismissBridge());
+    expect(mockAddActivityDismissedListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("reason='user' 이벤트 → markLaDismissed(dismissedAt) 호출", () => {
+    renderHook(() => useLiveActivityDismissBridge());
+    expect(capturedListener).not.toBeNull();
+    capturedListener!({ dismissedAt: 1234567890, reason: 'user' });
+    expect(mockMarkLaDismissed).toHaveBeenCalledWith(1234567890);
+  });
+
+  it("reason이 'user'가 아니면 markLaDismissed 호출 안 함", () => {
+    renderHook(() => useLiveActivityDismissBridge());
+    capturedListener!({ dismissedAt: 1, reason: 'system' });
+    expect(mockMarkLaDismissed).not.toHaveBeenCalled();
+  });
+
+  it('unmount 시 subscription.remove 호출', () => {
+    const { unmount } = renderHook(() => useLiveActivityDismissBridge());
+    unmount();
+    expect(listenerRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('markLaDismissed가 throw하면 logger.warn으로 흡수', async () => {
+    mockMarkLaDismissed.mockRejectedValueOnce(new Error('storage down'));
+    renderHook(() => useLiveActivityDismissBridge());
+    capturedListener!({ dismissedAt: 1, reason: 'user' });
+    // microtask flush
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockWarn).toHaveBeenCalledWith('markLaDismissed threw', expect.any(Error));
+  });
+});

--- a/src/features/alarm/hooks/useLiveActivityDismissBridge.ts
+++ b/src/features/alarm/hooks/useLiveActivityDismissBridge.ts
@@ -1,0 +1,34 @@
+/**
+ * Live Activity 사용자 dismiss → sentinel write 브리지 (#967, #926 follow-up).
+ *
+ * native(`modules/live-activity`)는 사용자가 LA를 swipe-to-dismiss 한 시점에
+ * `onActivityDismissed` 이벤트를 emit한다(reason: 'user'). 이 hook은 해당 이벤트를
+ * 구독해 `markLaDismissed(dismissedAt)`를 호출한다.
+ *
+ * 결과: silent push 핸들러(`refreshLiveActivityFromBackgroundContext`)가 sentinel을
+ * 보고 LA refresh를 30분간 skip → 사용자 dismiss 의도 존중. destination 재설정 시
+ * `TRIP_BOUND_CLEANUPS` 경로(`clearLaDismissSentinel`)가 즉시 reset 한다.
+ *
+ * 마운트 위치: HomeScreen — 앱 활성 전체 lifecycle 동안 구독 유지.
+ */
+import { useEffect } from 'react';
+import { addActivityDismissedListener } from '../../../../modules/live-activity';
+import { markLaDismissed } from '../utils/laDismissSentinel';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('useLiveActivityDismissBridge');
+
+export function useLiveActivityDismissBridge(): void {
+  useEffect(() => {
+    const subscription = addActivityDismissedListener((event) => {
+      // reason은 현재 항상 'user'지만 향후 분기 추가 시 안전망을 둔다.
+      if (event.reason !== 'user') return;
+      void markLaDismissed(event.dismissedAt).catch((e) => {
+        log.warn('markLaDismissed threw', e);
+      });
+    });
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -28,6 +28,7 @@ import { useBarometer } from '../shared/hooks/useBarometer';
 import { useTripOrigin } from '../features/route/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../features/nearest-station/hooks/useBackgroundLocation';
 import { useApnsTripRegistration } from '../features/alarm/hooks/useApnsTripRegistration';
+import { useLiveActivityDismissBridge } from '../features/alarm/hooks/useLiveActivityDismissBridge';
 import { registerSilentPushTask } from '../features/alarm/tasks/silentPushTask';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ROUTE_KEY } from '../shared/constants/storageKeys';
@@ -440,6 +441,7 @@ export default function HomeScreen() {
     [selectTransferDetectLine],
   );
   useBackgroundLocation(destination);
+  useLiveActivityDismissBridge();
   useApnsTripRegistration({
     route,
     destination,


### PR DESCRIPTION
Closes #967
Follow-up of PR #941 / PR #946 (#926 Seam E3)

## Why
PR #941 introduced `markLaDismissed()` + TTL 30분 sentinel 정책. PR #946은 destination 재설정 시 clear 트리거 wire. 그러나 **`markLaDismissed()` callsite 부재** — sentinel write 자체가 dormant 상태였다. 이 PR이 첫 실제 callsite: iOS Live Activity 사용자 swipe-to-dismiss를 native bridge로 잡아 sentinel에 반영.

## Changes

### iOS Native (`modules/live-activity/ios/`)
- `LiveActivityManager.swift`
  - `expectingSystemEnd: Bool` flag로 `end()` 호출(system) vs observer 자발 전이(user) 구분
  - observer가 `.ended` / `.dismissed`를 받으면 `handleObservedEnd()` → 사용자 dismiss면 `onActivityDismissed` emit, 어느 경우든 기존 `onActivityEnded`는 호출(backend deregister 호환)
  - `setEventHandlers(...)` signature에 `onActivityDismissed` 추가
  - `emitActivityDismissed()`는 native epoch ms를 payload로 전달
- `LiveActivityModule.swift`
  - `Events("onPushToken", "onActivityEnded", "onActivityDismissed")`
  - `OnCreate`에서 `onActivityDismissed` handler 주입 — `{ dismissedAt, reason: 'user' }` payload

### JS Bridge (`modules/live-activity/index.ts`)
- `ActivityDismissedEvent` interface + `addActivityDismissedListener(handler)` export
- iOS / non-iOS / 모듈 부재 시 noop subscription (기존 `addActivityEndedListener` 패턴 따름)

### Client Wire
- `src/features/alarm/hooks/useLiveActivityDismissBridge.ts` 신규
  - `addActivityDismissedListener` 구독 → `reason === 'user'`일 때 `markLaDismissed(event.dismissedAt)` 호출
  - 마운트/언마운트 lifecycle 정상 처리
- `HomeScreen.tsx`에 hook wire 1줄 추가

### Tests
- `modules/live-activity/__tests__/pushTokenListeners.test.ts` 확장 (4 cases)
- `src/features/alarm/hooks/__tests__/useLiveActivityDismissBridge.test.ts` 신규 (5 cases)
  - 마운트 시 구독 / `reason='user'` → markLaDismissed / 비-user 무시 / unmount cleanup / markLaDismissed throw 흡수

## Test plan
- [x] `npm test` — 4035 passed, 100% coverage
- [x] `npm run type-check` — pass
- [ ] **실기기 검증** (CI 범위 밖) — LA swipe → AsyncStorage `LA_DISMISSED_AT` 기록 → 30분 silent push LA refresh skip 확인. 결과는 후속 follow-up issue로 보고

## Out of scope
- Android 등가물 — Live Activity 미지원
- ActivityKit `dismissalDate` 기반 자동 만료 분기 (현재는 사용자 swipe만 user dismiss로 분류, 시스템 시각 만료는 system end로 흡수)