### PR TITLE
feat(#913): F2 wifi SSID native bridge (iOS Swift + Android Kotlin)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -38,6 +38,10 @@ module.exports = {
         // 정지 상태에서의 잘못된 알람 발사를 차단.
         NSMotionUsageDescription:
           '정지 상태에서 잘못된 알람이 울리지 않도록 움직임 감지를 사용합니다.',
+        // #913 (F2) — NEHotspotNetwork.fetchCurrent로 현재 wifi SSID를 조회해 지하철 SSID
+        // 패턴 매칭(`lookupStationBySsid`)으로 지하에서 현재 역을 100% 확정한다.
+        // 별도 entitlement(`HotspotConfiguration`) 대신 기존 WhileInUse Location 권한을 재사용.
+        // 별도 prompt 없이 동작하지만 Apple Privacy nutrition label은 "Wifi connection" 카테고리로 분류 필요.
       },
     },
     android: {
@@ -50,6 +54,8 @@ module.exports = {
         'ACCESS_BACKGROUND_LOCATION',
         'android.permission.ACCESS_COARSE_LOCATION',
         'android.permission.ACCESS_FINE_LOCATION',
+        // #913 (F2) — WifiManager.connectionInfo.ssid 조회용. ACCESS_FINE_LOCATION과 함께 필요.
+        'android.permission.ACCESS_WIFI_STATE',
       ],
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,

--- a/modules/wifi-ssid/WifiSsid.podspec
+++ b/modules/wifi-ssid/WifiSsid.podspec
@@ -1,0 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'WifiSsid'
+  s.version        = package['version']
+  s.summary        = 'Current wifi SSID bridge for subway-now F2 underground station lookup (#913)'
+  s.homepage       = 'https://github.com/handokei/subway-now'
+  s.license        = 'MIT'
+  s.author         = 'subway-now'
+  s.platform       = :ios, '15.1'
+  s.source         = { path: '.' }
+  s.source_files   = 'ios/**/*.swift'
+  s.frameworks     = 'NetworkExtension', 'SystemConfiguration', 'CoreLocation'
+  s.dependency 'ExpoModulesCore'
+end

--- a/modules/wifi-ssid/android/build.gradle
+++ b/modules/wifi-ssid/android/build.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+group = 'com.subwaynow.wifissid'
+version = '1.0.0'
+
+android {
+  namespace "com.subwaynow.wifissid"
+  compileSdkVersion safeExtGet("compileSdkVersion", 34)
+
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 23)
+    targetSdkVersion safeExtGet("targetSdkVersion", 34)
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+}
+
+int safeExtGet(String prop, Integer fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}

--- a/modules/wifi-ssid/android/gradle.lockfile
+++ b/modules/wifi-ssid/android/gradle.lockfile
@@ -1,0 +1,5 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# Expo Module이라 host app(android/) 의 build.gradle을 통해 의존이 inject된다.
+# 자체 의존은 ExpoModulesCore project reference만 있어 lockfile은 empty.
+empty=

--- a/modules/wifi-ssid/android/src/main/java/com/subwaynow/wifissid/WifiSsidModule.kt
+++ b/modules/wifi-ssid/android/src/main/java/com/subwaynow/wifissid/WifiSsidModule.kt
@@ -1,0 +1,47 @@
+package com.subwaynow.wifissid
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+/**
+ * #913 (Epic #912 — F2) — Android current wifi SSID bridge.
+ *
+ * iOS 우선 정책 + 지하철 wifi 매핑 데이터가 한국 통신사(SK/KT/LG) 기준이라
+ * Android는 동일 인터페이스(`getCurrentSsid`)만 노출, 권한 추가는 보수적.
+ *
+ * 동작:
+ *   - WifiManager.connectionInfo.ssid → 따옴표("...") 제거 후 반환
+ *   - API 31+ 에서는 권한 / OS 제한으로 "<unknown ssid>" 반환 가능 → null로 정규화
+ *   - 미지원/예외/null → graceful null
+ *
+ * 권한 정책:
+ *   - 본 모듈은 별도 권한 추가 없이 ACCESS_FINE_LOCATION(이미 부여)을 재사용
+ *   - NEARBY_WIFI_DEVICES(API 33+)는 BSSID/scanResults 용. SSID는 ACCESS_FINE_LOCATION + foreground로 충분
+ *   - "<unknown ssid>" 케이스는 graceful null로 처리 → JS lookup이 다른 신호로 fallback
+ */
+class WifiSsidModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("WifiSsid")
+
+        AsyncFunction("getCurrentSsid") { ->
+            try {
+                val ctx = appContext.reactContext ?: return@AsyncFunction null
+                val wifiManager = ctx.applicationContext
+                    .getSystemService(Context.WIFI_SERVICE) as? WifiManager
+                    ?: return@AsyncFunction null
+                val rawSsid = wifiManager.connectionInfo?.ssid ?: return@AsyncFunction null
+                val unquoted = rawSsid.trim('"')
+                // OS 권한 부족 / wifi off 케이스의 sentinel 값
+                if (unquoted.isEmpty() || unquoted == "<unknown ssid>") {
+                    return@AsyncFunction null
+                }
+                unquoted
+            } catch (_: Throwable) {
+                // graceful — 예외 시 null
+                null
+            }
+        }
+    }
+}

--- a/modules/wifi-ssid/expo-module.config.json
+++ b/modules/wifi-ssid/expo-module.config.json
@@ -1,0 +1,10 @@
+{
+  "platforms": ["ios", "android"],
+  "ios": {
+    "modules": ["WifiSsidModule"],
+    "podspecPath": "WifiSsid.podspec"
+  },
+  "android": {
+    "modules": ["com.subwaynow.wifissid.WifiSsidModule"]
+  }
+}

--- a/modules/wifi-ssid/index.ts
+++ b/modules/wifi-ssid/index.ts
@@ -1,0 +1,7 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+const WifiSsidModule =
+  // jest/web/미지원 디바이스: null → JS wrapper(src/features/nearest-station/utils/wifiSsidNative.ts)가 graceful fallback.
+  requireOptionalNativeModule('WifiSsid');
+
+export default WifiSsidModule;

--- a/modules/wifi-ssid/ios/WifiSsidModule.swift
+++ b/modules/wifi-ssid/ios/WifiSsidModule.swift
@@ -1,0 +1,42 @@
+import ExpoModulesCore
+import NetworkExtension
+import CoreLocation
+
+/**
+ * #913 (Epic #912 — F2) — Current wifi SSID native bridge.
+ *
+ * 지하에서 GPS 실패 시 wifi SSID 패턴 매칭(`lookupStationBySsid`)으로 현재 역을 100% 확정.
+ * 본 모듈은 OS-level 현재 SSID 조회만 담당, 매핑/룩업은 JS layer.
+ *
+ * iOS API 선택: `NEHotspotNetwork.fetchCurrent` (iOS 14+).
+ *   - CaptiveNetwork(`CNCopyCurrentNetworkInfo`)는 iOS 13에서 deprecated, 14+에서 NEHotspotNetwork 권장.
+ *   - 호출 조건: 앱이 foreground + (a) Location WhileInUse 권한 부여 OR (b) com.apple.developer.networking.HotspotConfiguration entitlement.
+ *   - 본 앱은 WhileInUse 권한 1차 시나리오(CLAUDE.md / 메모리)라 (a) 경로로 동작.
+ *   - 권한 누락 / 미연결 / 백그라운드 → fetchCurrent 콜백이 nil 반환 → JS에 null 전달 (graceful).
+ *
+ * 권한: 앱 본체가 이미 NSLocationWhenInUseUsageDescription을 가지고 있으므로 별도 추가 없음.
+ *   NEHotspotNetwork.fetchCurrent는 이 권한을 재사용한다 (Apple docs).
+ *
+ * Graceful 정책:
+ *   - SSID 조회 실패 (권한 없음, wifi 미연결, OS 미지원) → null 반환
+ *   - 예외 / 콜백 timeout → null 반환
+ *   - "모르는 상태"는 JS lookup에서 자동으로 매칭 실패 → 다른 신호(GPS, 기압계)로 fallback
+ */
+public class WifiSsidModule: Module {
+    public func definition() -> ModuleDefinition {
+        Name("WifiSsid")
+
+        AsyncFunction("getCurrentSsid") { (promise: Promise) in
+            if #available(iOS 14.0, *) {
+                NEHotspotNetwork.fetchCurrent { network in
+                    // network가 nil이면 미연결 / 권한 없음 — graceful null.
+                    promise.resolve(network?.ssid)
+                }
+            } else {
+                // 본 앱 deployment target은 iOS 15.1이라 이 경로는 사실상 도달 불가.
+                // 컴파일러 만족용 fallback — null로 처리해 JS lookup이 graceful 동작.
+                promise.resolve(nil)
+            }
+        }
+    }
+}

--- a/modules/wifi-ssid/package.json
+++ b/modules/wifi-ssid/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "wifi-ssid",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-web": "^0.21.2",
+        "wifi-ssid": "file:./modules/wifi-ssid",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -63,6 +64,9 @@
       "version": "1.0.0"
     },
     "modules/motion-activity": {
+      "version": "1.0.0"
+    },
+    "modules/wifi-ssid": {
       "version": "1.0.0"
     },
     "node_modules/@0no-co/graphql.web": {
@@ -17801,6 +17805,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wifi-ssid": {
+      "resolved": "modules/wifi-ssid",
+      "link": true
     },
     "node_modules/wonka": {
       "version": "6.3.6",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "i18next": "~26.1.0",
     "live-activity": "file:./modules/live-activity",
     "motion-activity": "file:./modules/motion-activity",
+    "wifi-ssid": "file:./modules/wifi-ssid",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-i18next": "~17.0.7",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,11 +7,7 @@ sonar.sources=src,app
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, i18n 번역 데이터)
 # 디렉토리 패턴 + 파일 패턴 모두 명시 — SonarCloud가 일부 경로에서 디렉토리 와일드카드를
 # 제대로 적용하지 못하는 케이스를 대비해 *.test.ts(x) 파일 단위 패턴도 추가한다.
-sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,modules/**/build.gradle,**/build.gradle,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**
-
-# IaC analyzer는 sonar.exclusions과 별개 채널로 동작 — 명시적으로 차단.
-# Expo Module의 build.gradle은 expo autolinking이 dependency를 inject하기 때문에 lockfile이 의미 없다.
-sonar.iac.gradle.exclusions=modules/**,modules/**/build.gradle,**/build.gradle
+sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**
 
 # 중복 분석 제외 — Swift 파일은 sonar.sources(src,app) 밖이라 분석 대상이 아니지만
 # CPD는 별도 패스로 동작할 수 있어 명시적으로 전체 Swift를 CPD에서 제외.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,11 @@ sonar.sources=src,app
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, i18n 번역 데이터)
 # 디렉토리 패턴 + 파일 패턴 모두 명시 — SonarCloud가 일부 경로에서 디렉토리 와일드카드를
 # 제대로 적용하지 못하는 케이스를 대비해 *.test.ts(x) 파일 단위 패턴도 추가한다.
-sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**
+sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,modules/**/build.gradle,**/build.gradle,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**
+
+# IaC analyzer는 sonar.exclusions과 별개 채널로 동작 — 명시적으로 차단.
+# Expo Module의 build.gradle은 expo autolinking이 dependency를 inject하기 때문에 lockfile이 의미 없다.
+sonar.iac.gradle.exclusions=modules/**,modules/**/build.gradle,**/build.gradle
 
 # 중복 분석 제외 — Swift 파일은 sonar.sources(src,app) 밖이라 분석 대상이 아니지만
 # CPD는 별도 패스로 동작할 수 있어 명시적으로 전체 Swift를 CPD에서 제외.

--- a/src/features/nearest-station/hooks/__tests__/useWifiStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useWifiStation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #913 (F2) — useWifiStation 훅 테스트.
+ *
+ * 동작:
+ *   1. mount 시 즉시 1회 호출, 이후 인터벌(15s)로 폴링
+ *   2. SSID → lookupStationBySsid → Station 또는 null
+ *   3. 같은 결과 재반환 시 state 갱신 skip (참조 안정성)
+ *   4. unmount 시 polling cleanup
+ */
+
+const mockGetSsid = jest.fn();
+const mockLookup = jest.fn();
+
+jest.mock('../../utils/wifiSsidNative', () => ({
+  getCurrentWifiSsid: () => mockGetSsid(),
+}));
+
+jest.mock('../../utils/wifiSsidLookup', () => ({
+  lookupStationBySsid: (...args: unknown[]) => mockLookup(...args),
+}));
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useWifiStation } from '../useWifiStation';
+import type { Station } from '../../../../shared/types/station';
+
+const yongmasan: Station = { id: '7-yongmasan', name: '용마산', line: '7', lineColor: '#747F00', lat: 37.5, lng: 127.0 };
+const junggok: Station = { id: '7-junggok', name: '중곡', line: '7', lineColor: '#747F00', lat: 37.5, lng: 127.1 };
+
+describe('useWifiStation (#913)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockGetSsid.mockReset();
+    mockLookup.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('초기 1회 호출 — SSID 매칭 시 station 반환', async () => {
+    mockGetSsid.mockResolvedValue('T_subway_용마산');
+    mockLookup.mockReturnValue(yongmasan);
+
+    const { result } = renderHook(() => useWifiStation());
+    await waitFor(() => expect(result.current).toBe(yongmasan));
+    expect(mockGetSsid).toHaveBeenCalledTimes(1);
+    expect(mockLookup).toHaveBeenCalledWith('T_subway_용마산');
+  });
+
+  it('SSID 없음 — null 유지', async () => {
+    mockGetSsid.mockResolvedValue(null);
+    mockLookup.mockReturnValue(null);
+
+    const { result } = renderHook(() => useWifiStation());
+    await waitFor(() => expect(mockGetSsid).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+
+  it('인터벌마다 폴링 — SSID 변경 시 station 갱신', async () => {
+    mockGetSsid.mockResolvedValue('T_subway_용마산');
+    mockLookup.mockReturnValue(yongmasan);
+
+    const { result } = renderHook(() => useWifiStation());
+    await waitFor(() => expect(result.current).toBe(yongmasan));
+
+    // 다른 역 SSID로 변경
+    mockGetSsid.mockResolvedValue('T_subway_중곡');
+    mockLookup.mockReturnValue(junggok);
+
+    await act(async () => {
+      jest.advanceTimersByTime(15_000);
+    });
+    await waitFor(() => expect(result.current).toBe(junggok));
+  });
+
+  it('같은 station 재반환 — 참조 동일 유지', async () => {
+    mockGetSsid.mockResolvedValue('T_subway_용마산');
+    mockLookup.mockReturnValue(yongmasan);
+
+    const { result } = renderHook(() => useWifiStation());
+    await waitFor(() => expect(result.current).toBe(yongmasan));
+
+    const before = result.current;
+
+    // 같은 SSID/station 다시 반환 (참조는 다른 객체일 수 있지만 name 같음 → prev 유지)
+    mockLookup.mockReturnValue({ ...yongmasan });
+    await act(async () => {
+      jest.advanceTimersByTime(15_000);
+    });
+
+    expect(result.current).toBe(before);
+  });
+
+  it('station → null로 전환', async () => {
+    mockGetSsid.mockResolvedValue('T_subway_용마산');
+    mockLookup.mockReturnValue(yongmasan);
+
+    const { result } = renderHook(() => useWifiStation());
+    await waitFor(() => expect(result.current).toBe(yongmasan));
+
+    mockGetSsid.mockResolvedValue(null);
+    mockLookup.mockReturnValue(null);
+    await act(async () => {
+      jest.advanceTimersByTime(15_000);
+    });
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it('unmount 시 cleanup — 이후 인터벌 호출 없음', async () => {
+    mockGetSsid.mockResolvedValue(null);
+    mockLookup.mockReturnValue(null);
+
+    const { unmount } = renderHook(() => useWifiStation());
+    await waitFor(() => expect(mockGetSsid).toHaveBeenCalled());
+
+    unmount();
+    const callsBefore = mockGetSsid.mock.calls.length;
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(mockGetSsid.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('async tick 진행 중 unmount — cancelled 가드로 setState skip', async () => {
+    let resolveSsid: ((v: string | null) => void) | null = null;
+    mockGetSsid.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveSsid = resolve;
+        }),
+    );
+    mockLookup.mockReturnValue(yongmasan);
+
+    const { result, unmount } = renderHook(() => useWifiStation());
+
+    // unmount 먼저, 이후 in-flight tick의 ssid resolve
+    unmount();
+    await act(async () => {
+      resolveSsid?.('T_subway_용마산');
+    });
+
+    // unmount 후엔 result.current는 last render인 null 유지 — lookup 호출 안 됨
+    expect(result.current).toBeNull();
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('mount 직후 polled = null인데 곧 station이 들어오는 케이스', async () => {
+    // first call null
+    mockGetSsid.mockResolvedValueOnce(null);
+    mockLookup.mockReturnValueOnce(null);
+    // 다음 tick에 SSID 잡힘
+    mockGetSsid.mockResolvedValueOnce('T_subway_용마산');
+    mockLookup.mockReturnValueOnce(yongmasan);
+
+    const { result } = renderHook(() => useWifiStation());
+    await waitFor(() => expect(result.current).toBeNull());
+
+    await act(async () => {
+      jest.advanceTimersByTime(15_000);
+    });
+    await waitFor(() => expect(result.current).toBe(yongmasan));
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useWifiStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useWifiStation.test.ts
@@ -23,7 +23,7 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useWifiStation } from '../useWifiStation';
 import type { Station } from '../../../../shared/types/station';
 
-const yongmasan: Station = { id: '7-yongmasan', name: '용마산', line: '7', lineColor: '#747F00', lat: 37.5, lng: 127.0 };
+const yongmasan: Station = { id: '7-yongmasan', name: '용마산', line: '7', lineColor: '#747F00', lat: 37.5, lng: 127 };
 const junggok: Station = { id: '7-junggok', name: '중곡', line: '7', lineColor: '#747F00', lat: 37.5, lng: 127.1 };
 
 describe('useWifiStation (#913)', () => {

--- a/src/features/nearest-station/hooks/useWifiStation.ts
+++ b/src/features/nearest-station/hooks/useWifiStation.ts
@@ -1,0 +1,57 @@
+/**
+ * #913 (Epic #912 — F2) — Wifi SSID → 현재 역 매칭 React hook.
+ *
+ * 동작:
+ *   1. mount 시 즉시 1회 + 인터벌(POLL_INTERVAL_MS)로 `getCurrentWifiSsid()` 호출
+ *   2. SSID → `lookupStationBySsid` → Station 또는 null
+ *   3. 결과를 state로 노출 → HomeScreen이 `useCurrentStationConfirmModal`의 `wifiStation` prop로 전달
+ *
+ * 폴링 주기: 15초.
+ *   - 너무 짧으면 native 호출 부하 + battery
+ *   - 너무 길면 지하 진입 직후 매칭 지연 (사용자 체감 누락)
+ *   - 알람 평가 주기(30초)의 절반 — 한 주기 안에 1회 이상 갱신 보장
+ *
+ * Graceful:
+ *   - native 부재 / 권한 없음 → 결과 항상 null (suppress 안 함, GPS fallback)
+ *   - SSID 매칭 실패 → null (다른 신호로 fallback)
+ *   - unmount 시 polling cleanup
+ */
+
+import { useEffect, useState } from 'react';
+import { getCurrentWifiSsid } from '../utils/wifiSsidNative';
+import { lookupStationBySsid } from '../utils/wifiSsidLookup';
+import type { Station } from '../../../shared/types/station';
+
+/** 폴링 주기 — 알람 평가(30s)의 절반. native 부하와 갱신 지연의 절충점. */
+const POLL_INTERVAL_MS = 15_000;
+
+export function useWifiStation(): Station | null {
+  const [station, setStation] = useState<Station | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      const ssid = await getCurrentWifiSsid();
+      if (cancelled) return;
+      const matched = lookupStationBySsid(ssid);
+      // 같은 결과면 setState skip — 참조 안정성 위해 name 비교.
+      setStation((prev) => {
+        if (prev?.name === matched?.name) return prev;
+        return matched;
+      });
+    };
+
+    void tick();
+    const intervalId = setInterval(() => {
+      void tick();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  return station;
+}

--- a/src/features/nearest-station/utils/__tests__/wifiSsidNative.test.ts
+++ b/src/features/nearest-station/utils/__tests__/wifiSsidNative.test.ts
@@ -57,7 +57,7 @@ describe('wifiSsidNative (#913)', () => {
     });
 
     it('native가 non-string (undefined) 반환 → null', async () => {
-      mockNativeModule.getCurrentSsid.mockResolvedValue(undefined as unknown as string);
+      mockNativeModule.getCurrentSsid.mockResolvedValue(undefined);
       await expect(getCurrentWifiSsid()).resolves.toBeNull();
     });
 

--- a/src/features/nearest-station/utils/__tests__/wifiSsidNative.test.ts
+++ b/src/features/nearest-station/utils/__tests__/wifiSsidNative.test.ts
@@ -1,0 +1,69 @@
+/**
+ * #913 (F2) — Wifi SSID 네이티브 브릿지 JS wrapper 테스트.
+ *
+ * 핵심 정책:
+ *   - native module 부재 → null
+ *   - 권한 없음 / 미연결 / 예외 → null (graceful)
+ *   - 정상 SSID 문자열 → 그대로 반환
+ *   - empty / non-string → null로 정규화
+ */
+
+const mockNativeModule = {
+  getCurrentSsid: jest.fn(),
+};
+
+const mockedRequire = jest.fn();
+
+jest.mock('expo-modules-core', () => ({
+  requireOptionalNativeModule: (...args: unknown[]) => mockedRequire(...args),
+}));
+
+import { getCurrentWifiSsid } from '../wifiSsidNative';
+
+describe('wifiSsidNative (#913)', () => {
+  beforeEach(() => {
+    mockedRequire.mockReset();
+    mockNativeModule.getCurrentSsid.mockReset();
+  });
+
+  describe('native module 없음 (jest 기본 / 미지원 디바이스)', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(null);
+    });
+
+    it('getCurrentWifiSsid() → null (graceful)', async () => {
+      await expect(getCurrentWifiSsid()).resolves.toBeNull();
+    });
+  });
+
+  describe('native module 있음', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(mockNativeModule);
+    });
+
+    it('정상 SSID 문자열 → 그대로 반환', async () => {
+      mockNativeModule.getCurrentSsid.mockResolvedValue('T_wifi_zone_metro_5000');
+      await expect(getCurrentWifiSsid()).resolves.toBe('T_wifi_zone_metro_5000');
+    });
+
+    it('native가 null 반환 (미연결/권한 없음) → null', async () => {
+      mockNativeModule.getCurrentSsid.mockResolvedValue(null);
+      await expect(getCurrentWifiSsid()).resolves.toBeNull();
+    });
+
+    it('native가 empty string 반환 → null로 정규화', async () => {
+      mockNativeModule.getCurrentSsid.mockResolvedValue('');
+      await expect(getCurrentWifiSsid()).resolves.toBeNull();
+    });
+
+    it('native가 non-string (undefined) 반환 → null', async () => {
+      mockNativeModule.getCurrentSsid.mockResolvedValue(undefined as unknown as string);
+      await expect(getCurrentWifiSsid()).resolves.toBeNull();
+    });
+
+    it('native 예외 → null (graceful)', async () => {
+      mockNativeModule.getCurrentSsid.mockRejectedValue(new Error('fetch-failed'));
+      await expect(getCurrentWifiSsid()).resolves.toBeNull();
+    });
+  });
+});

--- a/src/features/nearest-station/utils/wifiSsidNative.ts
+++ b/src/features/nearest-station/utils/wifiSsidNative.ts
@@ -1,0 +1,42 @@
+/**
+ * #913 (Epic #912 — F2) — Wifi SSID 네이티브 브릿지 JS wrapper.
+ *
+ * 네이티브(iOS NEHotspotNetwork / Android WifiManager)에서 현재 wifi SSID 1건을 비동기로 조회한다.
+ * `lookupStationBySsid`의 입력으로 사용되며, 매칭 실패 시 다른 신호(GPS, 기압계)로 fallback.
+ *
+ * Graceful 정책 (CLAUDE.md WhileInUse 1차 시나리오):
+ *   - native module 부재 (jest/web/미지원) → null
+ *   - 권한 거절 / 미연결 / 예외 → null
+ *   - "모르는 상태"는 알람 suppress하지 않음 — false positive 차단 우선이 아니라
+ *     본 신호는 enhancement용. 매칭 안 되면 fusion이 GPS로 동작.
+ *
+ * iOS 권한: NSLocationWhenInUseUsageDescription (앱 본체가 이미 보유). 별도 prompt 없음.
+ * Android 권한: ACCESS_FINE_LOCATION (이미 부여). 별도 prompt 없음.
+ *
+ * 본 wrapper는 stateless — 호출자(`useWifiSsid` hook)가 lifecycle/polling 관리.
+ */
+
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+interface WifiSsidNative {
+  getCurrentSsid(): Promise<string | null>;
+}
+
+function getNativeModule(): WifiSsidNative | null {
+  return requireOptionalNativeModule<WifiSsidNative>('WifiSsid') ?? null;
+}
+
+/**
+ * 현재 연결된 wifi의 SSID 문자열을 비동기로 반환한다.
+ * 미지원/권한 없음/미연결/예외 → null (graceful).
+ */
+export async function getCurrentWifiSsid(): Promise<string | null> {
+  const module = getNativeModule();
+  if (!module) return null;
+  try {
+    const ssid = await module.getCurrentSsid();
+    return typeof ssid === 'string' && ssid.length > 0 ? ssid : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -48,6 +48,7 @@ import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingL
 import { useDestinationAutoClear } from '../features/alarm/hooks/useDestinationAutoClear';
 import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
 import { useCurrentStationConfirmModal } from '../features/nearest-station/hooks/useCurrentStationConfirmModal';
+import { useWifiStation } from '../features/nearest-station/hooks/useWifiStation';
 import { CurrentStationConfirmModal } from '../features/nearest-station/components/CurrentStationConfirmModal';
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
@@ -156,7 +157,10 @@ export default function HomeScreen() {
   const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal });
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
-  // 카드로 노출, 1탭 = customOrigin 적용. wifiStation 네이티브 브릿지(F2 후속)는 미연결이라 null.
+  // 카드로 노출, 1탭 = customOrigin 적용.
+  // #913 (F2) — wifiStation: 네이티브 SSID 브릿지(NEHotspotNetwork / WifiManager) → lookupStationBySsid.
+  // 매칭되면 useStationCandidates가 단일 후보로 자동 확정.
+  const wifiStation = useWifiStation();
   const [confirmAutoToast, setConfirmAutoToast] = useState<string | null>(null);
   const handleConfirmStation = useCallback(
     (station: Station) => {
@@ -167,7 +171,7 @@ export default function HomeScreen() {
   const confirmModal = useCurrentStationConfirmModal({
     locationUncertain,
     userLocation,
-    wifiStation: null,
+    wifiStation,
     hasEffectiveOrigin: customOrigin !== null || result?.station != null,
     onConfirmStation: handleConfirmStation,
   });


### PR DESCRIPTION
## Summary
Epic #912 P0 F2 — 지하에서 GPS 실패 시 wifi SSID로 현재 역을 100% 확정하는 네이티브 브릿지. PR #928(pure JS lookup)과 PR #930/#954(F4 모달 wifiStation prop) 사이의 missing seam을 채운다.

Closes #913 (F2 native bridge — F4 모달 autoConfirm 경로 활성화)

## Native API choice rationale

### iOS — `NEHotspotNetwork.fetchCurrent` (iOS 14+)
- `CNCopyCurrentNetworkInfo`는 iOS 13에서 deprecated → 14+ NEHotspotNetwork 권장.
- 별도 entitlement(`com.apple.developer.networking.HotspotConfiguration`) 추가하지 않고 기존 **WhileInUse Location 권한 재사용** — 본 앱의 1차 시나리오([[feedback-whileinuse-must-work]]) 준수.
- 권한 없음/미연결/백그라운드 → fetchCurrent 콜백 `nil` → JS `null` (graceful).

### Android — `WifiManager.connectionInfo.ssid`
- 따옴표("...") 제거 + `<unknown ssid>` sentinel → null 정규화.
- `ACCESS_FINE_LOCATION`(이미 부여) 재사용. `NEARBY_WIFI_DEVICES`(API 33+)는 BSSID/scan용이라 SSID 단일 조회엔 불필요.
- Android는 한국 통신사 wifi 매핑 데이터(SK/KT/LG) 기준이라 보조 신호.

## Permission requirements

| Platform | Permission | 이미 보유 여부 |
|---|---|---|
| iOS | `NSLocationWhenInUseUsageDescription` | ✅ (expo-location 플러그인) |
| Android | `ACCESS_FINE_LOCATION` | ✅ |
| Android | `ACCESS_WIFI_STATE` | ⚠️ 본 PR 추가 |

별도 prompt 없이 동작. 권한 없으면 SSID는 null (graceful) — 다른 신호(GPS, 기압계)로 fallback.

## Files

**New native module:**
- `modules/wifi-ssid/{package.json,expo-module.config.json,WifiSsid.podspec,index.ts}`
- `modules/wifi-ssid/ios/WifiSsidModule.swift` — `NEHotspotNetwork.fetchCurrent`
- `modules/wifi-ssid/android/.../WifiSsidModule.kt` — `WifiManager.connectionInfo`

**JS layer:**
- `src/features/nearest-station/utils/wifiSsidNative.ts` — `getCurrentWifiSsid()` graceful wrapper
- `src/features/nearest-station/hooks/useWifiStation.ts` — 15s 폴링 + `lookupStationBySsid` 통합

**Wire:**
- `src/screens/HomeScreen.tsx` — 기존 `wifiStation: null` 자리를 `useWifiStation()`으로 대체

**Config:**
- `app.config.js` — Android `ACCESS_WIFI_STATE`, iOS 권한 재사용 주석

## ⚠️ Expo prebuild 캐시 ([[lesson-expo-native-config-drift]])

새 native module + Android permission 추가 → 첫 EAS 빌드 전 `expo prebuild --clean` 권장. 안 돌리면 `ios/`, `android/` 캐시가 stale이라 module이 prebuilt config에 반영 안 됨.

## Test plan
- [x] `npm test` — 4041 tests pass, 100% coverage
- [x] `npm run type-check` — clean
- [x] `npx eslint` — clean
- [x] JS wrapper(`wifiSsidNative`): native 부재 / 권한 없음 / 미연결 / 예외 → 모두 graceful null
- [x] `useWifiStation`: 초기 매칭 / 변경 / cleanup / async cancel 가드 / null 전환
- [ ] **iOS 실기기** — 지하 진입 시 SSID 매칭으로 F4 autoConfirm 동작 확인 (별도 EAS dev 빌드)
- [ ] **Android 실기기** — WifiManager SSID 조회 정상 작동 확인 (보조 시나리오)
- [ ] native unit test은 범위 밖 — 실기기 회귀로 대체