### PR TITLE
feat(#971): trainType priority candidate ranking

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -382,13 +382,10 @@ describe('useTransferAutoDetect', () => {
   /**
    * #971 (#955 follow-up) — trainType priority.
    *
-   * 환승 후보 line(1호선)에 일반·급행 두 trainType이 동시에 임박해 있을 때,
-   * destinationName이 일반정차역 only(예: '대방')이면 급행(서울역 등만 정차)을 통과
-   * 사고로 lock해서는 안 되므로 일반을 선택해야 한다. 반대로 destination이 급행 정차역
-   * (예: '용산')이면 일반보다 조금 늦더라도 급행을 우선 선택해야 한다.
-   *
-   * 1호선 환승역 fixture(서울역-1·4호선) 재사용. variants는 4호선 boardingLine 제외 후
-   * 1호선이 후보로 잡히도록 구성.
+   * destinationName이 일반정차역 only(예: '대방')이면 express(서울역 등만 정차)를 통과
+   * 사고로 lock하지 않고 normal을 선택해야 한다. 급행 정차역(예: '용산')이면 더 임박한
+   * type을 정상 선택. destination=null은 기존 동작(전체 imminent) 유지. preferred 비면
+   * fallback으로 hydrate. Matrix는 it.each로 압축(Sonar dup 회피).
    */
   describe('#971 trainType priority', () => {
     const SEOUL_1: Station = { id: '0101', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.554, lng: 126.972 };
@@ -399,129 +396,53 @@ describe('useTransferAutoDetect', () => {
       distanceKm: 0.03,
       isTransfer: true,
     };
-
-    /** 1호선 같은 line에 normal(빠름)·express(느림) 두 줄 임박. */
-    function mixedTrainTypeArrival(): StationArrival {
-      return makeArrival([
-        makeArrivalInfo({ destination: '인천', arrivalSeconds: 30, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' }),
-        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 120, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
-      ]);
+    /** 1호선만 후보로 잡히도록 boardingLine=4호선으로 고정한 baseInputs 변형. */
+    function inputs1Line(arrival: StationArrival, destinationName: string | null, onAutoLock: jest.Mock) {
+      return baseInputs({
+        nearestStations: transferNearest1_4,
+        arrival,
+        destinationName,
+        boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
+        onAutoLock,
+      });
     }
+    const NORMAL_30 = makeArrivalInfo({ destination: '인천', arrivalSeconds: 30, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' });
+    const NORMAL_180 = makeArrivalInfo({ destination: '인천', arrivalSeconds: 180, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' });
+    const EXPRESS_60 = makeArrivalInfo({ destination: '동인천', arrivalSeconds: 60, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' });
+    const EXPRESS_120 = makeArrivalInfo({ destination: '동인천', arrivalSeconds: 120, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' });
 
-    it('destination이 일반정차역 only(대방) → 일반 우선 (express 통과 회피)', () => {
-      // 대방은 1호선 normal 정차역. EXPRESS_STOPS['1'].express에 없음 → express 통과.
+    it.each<{
+      label: string;
+      ups: ArrivalInfo[];
+      destinationName: string | null;
+      expectedTrainCode: string;
+    }>([
+      // destination=대방(일반정차역 only): express 통과 → normal 선택.
+      { label: '일반정차역 only(대방) + 혼합 → normal', ups: [NORMAL_30, EXPRESS_120], destinationName: '대방', expectedTrainCode: 'T-1-NORMAL' },
+      // destination=용산(급행 정차): normal·express 모두 preferred → imminent normal(30s).
+      { label: '급행 정차역(용산) + normal-faster → normal', ups: [NORMAL_30, EXPRESS_120], destinationName: '용산', expectedTrainCode: 'T-1-NORMAL' },
+      // destination=용산 + express가 더 임박 → express 선택.
+      { label: '급행 정차역(용산) + express-faster → express', ups: [NORMAL_180, EXPRESS_60], destinationName: '용산', expectedTrainCode: 'T-1-EXPRESS' },
+      // destination=null(legacy): 모든 후보 동등 → imminent normal(30s).
+      { label: 'destination=null → 기존 동작', ups: [NORMAL_30, EXPRESS_120], destinationName: null, expectedTrainCode: 'T-1-NORMAL' },
+      // 일반정차역 only(대방) + express만 → preferred 비어 fallback으로 express(60s).
+      { label: '일반정차역 only(대방) + express only → fallback', ups: [EXPRESS_60], destinationName: '대방', expectedTrainCode: 'T-1-EXPRESS' },
+    ])('$label', ({ ups, destinationName, expectedTrainCode }) => {
       const onAutoLock = jest.fn();
-      const { result } = renderHook(() =>
-        useTransferAutoDetect(
-          baseInputs({
-            nearestStations: transferNearest1_4,
-            arrival: mixedTrainTypeArrival(),
-            destinationName: '대방',
-            // 다중 후보 회피: boardingLine을 4호선으로 두면 1호선만 후보.
-            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
-            onAutoLock,
-          }),
-        ),
-      );
-      expect(onAutoLock).toHaveBeenCalledTimes(1);
-      // express가 더 빠르더라도 normal(통과 안 함) 우선.
-      expect(result.current.candidateLines).toEqual(['1']);
-      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
-    });
-
-    it('destination이 급행 정차역(용산) → 일반·급행 모두 후보, 가장 임박한 normal 선택', () => {
-      // 용산은 EXPRESS_STOPS['1'].express에 있음. normal도 모든 역 정차 → 둘 다 preferred.
-      // 가장 임박한 normal(30s) 선택.
-      const onAutoLock = jest.fn();
-      renderHook(() =>
-        useTransferAutoDetect(
-          baseInputs({
-            nearestStations: transferNearest1_4,
-            arrival: mixedTrainTypeArrival(),
-            destinationName: '용산',
-            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
-            onAutoLock,
-          }),
-        ),
-      );
-      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
-    });
-
-    it('destination이 급행 정차역(용산) + 급행이 더 임박 → 급행 선택', () => {
-      const onAutoLock = jest.fn();
-      const arrival = makeArrival([
-        makeArrivalInfo({ destination: '인천', arrivalSeconds: 180, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' }),
-        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 60, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
-      ]);
-      renderHook(() =>
-        useTransferAutoDetect(
-          baseInputs({
-            nearestStations: transferNearest1_4,
-            arrival,
-            destinationName: '용산',
-            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
-            onAutoLock,
-          }),
-        ),
-      );
-      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-EXPRESS', line: '1', subwayId: '1001' });
-    });
-
-    it('destination=null → 기존 동작 유지 (가장 임박한 후보 선택, trainType 무시)', () => {
-      // destinationName null이면 express가 더 빨라도 normal(법적 type 무관) 모두 동등 후보.
-      // mixedTrainTypeArrival은 normal이 빠름 → normal 선택.
-      const onAutoLock = jest.fn();
-      renderHook(() =>
-        useTransferAutoDetect(
-          baseInputs({
-            nearestStations: transferNearest1_4,
-            arrival: mixedTrainTypeArrival(),
-            destinationName: null,
-            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
-            onAutoLock,
-          }),
-        ),
-      );
-      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
-    });
-
-    it('destination 일반정차역 only + 후보가 express만 → fallback으로 express 선택 (no-op 회피)', () => {
-      // express만 남아 있고 통과 위험이 있어도, hydrate 자체를 막으면 lock 기회를 영구 잃는다.
-      // preferred 비면 fallback으로 가장 임박한 후보 선택 — 사용자 안전성 표시는 별도 UI 책임.
-      const onAutoLock = jest.fn();
-      const arrival = makeArrival([
-        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 60, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
-      ]);
-      renderHook(() =>
-        useTransferAutoDetect(
-          baseInputs({
-            nearestStations: transferNearest1_4,
-            arrival,
-            destinationName: '대방',
-            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
-            onAutoLock,
-          }),
-        ),
-      );
-      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-EXPRESS', line: '1', subwayId: '1001' });
+      renderHook(() => useTransferAutoDetect(inputs1Line(makeArrival(ups), destinationName, onAutoLock)));
+      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: expectedTrainCode, line: '1', subwayId: '1001' });
     });
 
     it('selectLine 경로도 동일한 trainType 우선순위 적용 (다중 후보 모달에서 선택)', () => {
-      // 1호선·5호선 다중 후보 fixture. 1호선에 normal/express 혼합 → 사용자가 1호선 선택 시
-      // destination(대방)에 맞춰 normal 선택.
+      // 1호선·5호선 다중 후보 — 사용자가 1호선 선택 시 destination(대방)에 맞춰 normal 선택.
       const onAutoLock = jest.fn();
       const DDP_1: Station = { id: '0145', name: '동대문', line: '1', lineColor: '#0052A4', lat: 37.571, lng: 127.009 };
       const DDP_2: Station = { id: '0205-2', name: '동대문', line: '2', lineColor: '#009D3E', lat: 37.571, lng: 127.009 };
       const DDP_5_X: Station = { id: '0505-X', name: '동대문', line: '5', lineColor: '#996CAC', lat: 37.571, lng: 127.009 };
-      const nearest: NearestStationsResult = {
-        primary: DDP_2,
-        variants: [DDP_2, DDP_1, DDP_5_X],
-        distanceKm: 0.03,
-        isTransfer: true,
-      };
+      const nearest: NearestStationsResult = { primary: DDP_2, variants: [DDP_2, DDP_1, DDP_5_X], distanceKm: 0.03, isTransfer: true };
       const arrival = makeArrival([
-        makeArrivalInfo({ destination: '인천', arrivalSeconds: 30, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' }),
-        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 60, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
+        NORMAL_30,
+        EXPRESS_60,
         makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5', trainType: 'normal' }),
       ]);
       const { result } = renderTransferDetect(
@@ -529,14 +450,12 @@ describe('useTransferAutoDetect', () => {
           nearestStations: nearest,
           arrival,
           destinationName: '대방',
-          // boardingLine 2호선 — 1·5호선이 후보로.
           boardingLock: makeLock({ boardingLine: '2', boardingStationId: DDP_2.id }),
           onAutoLock,
         }),
       );
       expect(result.current.candidateLines).toEqual(['1', '5']);
       act(() => result.current.selectLine('1'));
-      // destination=대방 → 1호선 normal(30s) > express(60s) preferred 선택.
       expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
     });
   });

--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -378,4 +378,166 @@ describe('useTransferAutoDetect', () => {
     rerender(baseInputs({ arrival: null, onAutoLock }));
     expect(result.current.modalVisible).toBe(false);
   });
+
+  /**
+   * #971 (#955 follow-up) — trainType priority.
+   *
+   * 환승 후보 line(1호선)에 일반·급행 두 trainType이 동시에 임박해 있을 때,
+   * destinationName이 일반정차역 only(예: '대방')이면 급행(서울역 등만 정차)을 통과
+   * 사고로 lock해서는 안 되므로 일반을 선택해야 한다. 반대로 destination이 급행 정차역
+   * (예: '용산')이면 일반보다 조금 늦더라도 급행을 우선 선택해야 한다.
+   *
+   * 1호선 환승역 fixture(서울역-1·4호선) 재사용. variants는 4호선 boardingLine 제외 후
+   * 1호선이 후보로 잡히도록 구성.
+   */
+  describe('#971 trainType priority', () => {
+    const SEOUL_1: Station = { id: '0101', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.554, lng: 126.972 };
+    const SEOUL_4: Station = { id: '0426', name: '서울역', line: '4', lineColor: '#00A0E2', lat: 37.554, lng: 126.972 };
+    const transferNearest1_4: NearestStationsResult = {
+      primary: SEOUL_4,
+      variants: [SEOUL_4, SEOUL_1],
+      distanceKm: 0.03,
+      isTransfer: true,
+    };
+
+    /** 1호선 같은 line에 normal(빠름)·express(느림) 두 줄 임박. */
+    function mixedTrainTypeArrival(): StationArrival {
+      return makeArrival([
+        makeArrivalInfo({ destination: '인천', arrivalSeconds: 30, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' }),
+        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 120, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
+      ]);
+    }
+
+    it('destination이 일반정차역 only(대방) → 일반 우선 (express 통과 회피)', () => {
+      // 대방은 1호선 normal 정차역. EXPRESS_STOPS['1'].express에 없음 → express 통과.
+      const onAutoLock = jest.fn();
+      const { result } = renderHook(() =>
+        useTransferAutoDetect(
+          baseInputs({
+            nearestStations: transferNearest1_4,
+            arrival: mixedTrainTypeArrival(),
+            destinationName: '대방',
+            // 다중 후보 회피: boardingLine을 4호선으로 두면 1호선만 후보.
+            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
+            onAutoLock,
+          }),
+        ),
+      );
+      expect(onAutoLock).toHaveBeenCalledTimes(1);
+      // express가 더 빠르더라도 normal(통과 안 함) 우선.
+      expect(result.current.candidateLines).toEqual(['1']);
+      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
+    });
+
+    it('destination이 급행 정차역(용산) → 일반·급행 모두 후보, 가장 임박한 normal 선택', () => {
+      // 용산은 EXPRESS_STOPS['1'].express에 있음. normal도 모든 역 정차 → 둘 다 preferred.
+      // 가장 임박한 normal(30s) 선택.
+      const onAutoLock = jest.fn();
+      renderHook(() =>
+        useTransferAutoDetect(
+          baseInputs({
+            nearestStations: transferNearest1_4,
+            arrival: mixedTrainTypeArrival(),
+            destinationName: '용산',
+            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
+            onAutoLock,
+          }),
+        ),
+      );
+      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
+    });
+
+    it('destination이 급행 정차역(용산) + 급행이 더 임박 → 급행 선택', () => {
+      const onAutoLock = jest.fn();
+      const arrival = makeArrival([
+        makeArrivalInfo({ destination: '인천', arrivalSeconds: 180, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' }),
+        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 60, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
+      ]);
+      renderHook(() =>
+        useTransferAutoDetect(
+          baseInputs({
+            nearestStations: transferNearest1_4,
+            arrival,
+            destinationName: '용산',
+            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
+            onAutoLock,
+          }),
+        ),
+      );
+      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-EXPRESS', line: '1', subwayId: '1001' });
+    });
+
+    it('destination=null → 기존 동작 유지 (가장 임박한 후보 선택, trainType 무시)', () => {
+      // destinationName null이면 express가 더 빨라도 normal(법적 type 무관) 모두 동등 후보.
+      // mixedTrainTypeArrival은 normal이 빠름 → normal 선택.
+      const onAutoLock = jest.fn();
+      renderHook(() =>
+        useTransferAutoDetect(
+          baseInputs({
+            nearestStations: transferNearest1_4,
+            arrival: mixedTrainTypeArrival(),
+            destinationName: null,
+            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
+            onAutoLock,
+          }),
+        ),
+      );
+      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
+    });
+
+    it('destination 일반정차역 only + 후보가 express만 → fallback으로 express 선택 (no-op 회피)', () => {
+      // express만 남아 있고 통과 위험이 있어도, hydrate 자체를 막으면 lock 기회를 영구 잃는다.
+      // preferred 비면 fallback으로 가장 임박한 후보 선택 — 사용자 안전성 표시는 별도 UI 책임.
+      const onAutoLock = jest.fn();
+      const arrival = makeArrival([
+        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 60, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
+      ]);
+      renderHook(() =>
+        useTransferAutoDetect(
+          baseInputs({
+            nearestStations: transferNearest1_4,
+            arrival,
+            destinationName: '대방',
+            boardingLock: makeLock({ boardingLine: '4', boardingStationId: SEOUL_4.id }),
+            onAutoLock,
+          }),
+        ),
+      );
+      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-EXPRESS', line: '1', subwayId: '1001' });
+    });
+
+    it('selectLine 경로도 동일한 trainType 우선순위 적용 (다중 후보 모달에서 선택)', () => {
+      // 1호선·5호선 다중 후보 fixture. 1호선에 normal/express 혼합 → 사용자가 1호선 선택 시
+      // destination(대방)에 맞춰 normal 선택.
+      const onAutoLock = jest.fn();
+      const DDP_1: Station = { id: '0145', name: '동대문', line: '1', lineColor: '#0052A4', lat: 37.571, lng: 127.009 };
+      const DDP_2: Station = { id: '0205-2', name: '동대문', line: '2', lineColor: '#009D3E', lat: 37.571, lng: 127.009 };
+      const DDP_5_X: Station = { id: '0505-X', name: '동대문', line: '5', lineColor: '#996CAC', lat: 37.571, lng: 127.009 };
+      const nearest: NearestStationsResult = {
+        primary: DDP_2,
+        variants: [DDP_2, DDP_1, DDP_5_X],
+        distanceKm: 0.03,
+        isTransfer: true,
+      };
+      const arrival = makeArrival([
+        makeArrivalInfo({ destination: '인천', arrivalSeconds: 30, line: '1', trainCode: 'T-1-NORMAL', trainType: 'normal' }),
+        makeArrivalInfo({ destination: '동인천', arrivalSeconds: 60, line: '1', trainCode: 'T-1-EXPRESS', trainType: 'express' }),
+        makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5', trainType: 'normal' }),
+      ]);
+      const { result } = renderTransferDetect(
+        baseInputs({
+          nearestStations: nearest,
+          arrival,
+          destinationName: '대방',
+          // boardingLine 2호선 — 1·5호선이 후보로.
+          boardingLock: makeLock({ boardingLine: '2', boardingStationId: DDP_2.id }),
+          onAutoLock,
+        }),
+      );
+      expect(result.current.candidateLines).toEqual(['1', '5']);
+      act(() => result.current.selectLine('1'));
+      // destination=대방 → 1호선 normal(30s) > express(60s) preferred 선택.
+      expect(onAutoLock).toHaveBeenCalledWith({ trainCode: 'T-1-NORMAL', line: '1', subwayId: '1001' });
+    });
+  });
 });

--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -19,13 +19,14 @@
  *     기존 환승 list flow가 책임지므로 자동 detect는 중복 트리거 금지.
  *   - 현재 boardingLock의 boardingLine으로만 후보가 들어와 있다 (=같은 노선 환승 데이터).
  *
- * 후속 PR 후보:
- *   - destination 미설정 free trip을 위한 sentinel-destination lock (현재는 hydrate skip).
- *   - 후보 line 선택 후 가장 임박한 trainCode 산출 시 trainType(express) 우선순위 적용.
+ * #971 (#955 follow-up) — 후보 line의 trainCode 산출 시 destination 정차 여부로 우선순위.
+ *   destination이 일반정차만 가능 → 급행/특급 통과로 lock 사고 회피. destination 미설정 시
+ *   기존 동작(가장 임박) 유지.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { detectTransfer } from '../utils/transferDetect';
 import { findActiveTransferContext } from '../utils/findActiveTransferContext';
+import { isExpressStop } from '../utils/expressLookup';
 import { lineToSubwayId } from '../../../shared/constants/lineApiNames';
 import type { OtherLineArrival } from '../utils/transferDetect';
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
@@ -127,7 +128,7 @@ export function useTransferAutoDetect({
     }
     if (candidateLines.length === 1) {
       const [line] = candidateLines;
-      const candidate = buildAutoLockCandidate(line, arrival);
+      const candidate = buildAutoLockCandidate(line, arrival, destinationName);
       /* istanbul ignore next -- candidateLines가 detectTransfer로 산출되었으면 arrival에 해당 line의
          imminent 도착이 반드시 존재 → pickImminentTrainCode는 항상 trainCode를 반환. 방어 코드. */
       if (!candidate) return;
@@ -142,7 +143,7 @@ export function useTransferAutoDetect({
     }
     if (dismissedAtStationRef.current === stationKey) return;
     setModalVisible(true);
-  }, [detection.detected, candidateLines, currentStation, arrival, onAutoLock, modalVisible, stationKey]);
+  }, [detection.detected, candidateLines, currentStation, arrival, destinationName, onAutoLock, modalVisible, stationKey]);
 
   const modalCandidates = useMemo<Station[]>(() => {
     if (!currentStation) return [];
@@ -155,7 +156,7 @@ export function useTransferAutoDetect({
   const selectLine = useCallback(
     (line: LineNumber) => {
       if (!currentStation) return;
-      const candidate = buildAutoLockCandidate(line, arrival);
+      const candidate = buildAutoLockCandidate(line, arrival, destinationName);
       if (!candidate) return;
       const key = `${currentStation.id}|${candidate.trainCode}|${candidate.line}`;
       lastAutoLockedKeyRef.current = key;
@@ -163,7 +164,7 @@ export function useTransferAutoDetect({
       setModalVisible(false);
       dismissedAtStationRef.current = stationKey;
     },
-    [currentStation, arrival, onAutoLock, stationKey],
+    [currentStation, arrival, destinationName, onAutoLock, stationKey],
   );
 
   const dismissModal = useCallback(() => {
@@ -195,33 +196,56 @@ function collectOtherLineArrivals(
 /**
  * candidate line의 첫(=가장 임박) trainCode를 사용해 AutoLockCandidate 구성.
  * subwayId 매핑 누락 시 null — 호출자가 hydrate skip(이미 line valid 가드 있음).
+ *
+ * #971: destinationName이 주어지면 trainType이 destination에 정차하는 후보를 우선 선택.
+ * 일반정차역만 가능한 destination에서 급행/특급이 통과하는 lock 사고를 회피한다.
  */
 function buildAutoLockCandidate(
   line: LineNumber,
   arrival: StationArrival | null,
+  destinationName: string | null,
 ): AutoLockCandidate | null {
   const subwayId = lineToSubwayId(line);
   /* istanbul ignore next -- 모든 LineNumber는 LINE_TO_SUBWAY_ID에 등록되어 있어 null 분기는
      valid LineNumber 입력 하에서 도달 불가. 타입 보강용 방어. */
   if (!subwayId) return null;
-  const trainCode = pickImminentTrainCode(arrival, line);
+  const trainCode = pickImminentTrainCode(arrival, line, destinationName);
   if (!trainCode) return null;
   return { trainCode, line, subwayId };
 }
 
-function pickImminentTrainCode(arrival: StationArrival | null, line: LineNumber): string | null {
+/**
+ * 같은 line의 후보 중 가장 임박한 trainCode 반환.
+ *
+ * #971: destinationName이 있으면 destination 정차 가능한 trainType을 1차 후보군으로,
+ * 그 군이 비면 전체에서 fallback. destinationName=null은 기존 동작(전체에서 imminent).
+ *
+ * `isExpressStop`은 normal에 대해 항상 true, 데이터 미보유 line/type에 대해 보수적으로 true →
+ * 미지의 노선/타입을 사용자에게 무리하게 막지 않는다. 일반정차역 only인 destination에서
+ * 정확한 express 정차역 데이터가 있는 경우(예: 1·9호선 급행)에만 express 후보를 제외한다.
+ */
+function pickImminentTrainCode(
+  arrival: StationArrival | null,
+  line: LineNumber,
+  destinationName: string | null,
+): string | null {
   if (!arrival) return null;
   const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
-  let best: ArrivalInfo | null = null;
+  let preferred: ArrivalInfo | null = null;
+  let fallback: ArrivalInfo | null = null;
   for (const t of all) {
     if (t.line !== line) continue;
     /* istanbul ignore next -- detectTransfer는 음수 arrivalSeconds를 후보에서 제외한 뒤 line을
        반환하므로, 그 line의 음수 train이 있더라도 양수 train이 이미 적어도 하나 존재. 양수만
        best로 선택되어 음수 분기는 도달하지 않는다. 방어 코드. */
     if (t.arrivalSeconds < 0) continue;
-    if (!best || t.arrivalSeconds < best.arrivalSeconds) best = t;
+    if (!fallback || t.arrivalSeconds < fallback.arrivalSeconds) fallback = t;
+    // destination 미설정 → 모든 후보가 preferred와 동등 → fallback만으로 판정.
+    if (destinationName === null) continue;
+    if (!isExpressStop(destinationName, line, t.trainType)) continue;
+    if (!preferred || t.arrivalSeconds < preferred.arrivalSeconds) preferred = t;
   }
-  return best?.trainCode ?? null;
+  return (preferred ?? fallback)?.trainCode ?? null;
 }
 
 /**


### PR DESCRIPTION
Closes #971
Follow-up of PR #955 (#924 D1 wire).

## 배경
PR #955 본문 follow-up 후보:
> 후보 line 선택 후 가장 임박한 trainCode 산출 시 trainType(express) 우선순위 적용.

기존 `pickImminentTrainCode`는 같은 line의 후보 중 `arrivalSeconds` 최소만 선택했다. 사용자의 destination이 일반정차역 only(예: 1호선 '대방')인데 급행/특급이 더 빨리 도착하면 통과 사고로 lock이 의미 없어진다.

## 변경
`pickImminentTrainCode(arrival, line, destinationName)`로 destination 인자를 추가하고, `expressLookup.isExpressStop(destinationName, line, trainType)`을 재사용해 다음 우선순위로 trainCode 선택:

| destination | trainType 처리 |
| --- | --- |
| 일반정차 only (예: 대방) | express/rapid 통과 후보 제외 → normal 중 imminent |
| 급행 정차역 (예: 용산) | normal·express 모두 preferred → 그 중 imminent |
| 특급 정차역 | normal·express·rapid 모두 preferred → imminent |
| null (legacy) | 전체 후보 중 imminent (기존 동작 그대로) |
| preferred 비면 | fallback으로 전체 중 imminent (lock 기회 보전) |

데이터 미보유 line/type은 `isExpressStop`이 보수적으로 true 반환 → 미지 노선에서 hydrate 기회를 막지 않는다.

호출 경로:
- 단일 후보 자동 lock effect의 `buildAutoLockCandidate`
- 다중 후보 모달에서 `selectLine(line)` 콜백

## Test plan
- [x] 일반정차역 only(대방) + 같은 line normal(30s)·express(120s) → normal 선택
- [x] 급행 정차역(용산) + normal-faster → normal 선택
- [x] 급행 정차역(용산) + express-faster → express 선택
- [x] destination=null → 기존 동작 (전체에서 imminent)
- [x] 일반정차역 + 후보가 express only → fallback으로 express (no-op 회피)
- [x] selectLine 다중 후보 경로도 동일 우선순위 적용
- [x] 4085 it / 222 suites · 100% coverage(lines/funcs/branches/stmts)
- [x] `npm run type-check` pass