### PR TITLE
fix(#973): topPick imminence 정렬

### DIFF
--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -187,7 +187,7 @@ function collectOtherLineArrivals(
   const out: OtherLineArrival[] = [];
   for (const t of all) {
     if (boardingLine !== null && t.line === boardingLine) continue;
-    out.push({ line: t.line, arrivalSeconds: t.arrivalSeconds });
+    out.push({ line: t.line, arrivalSeconds: t.arrivalSeconds, arrivalCode: t.arrivalCode });
   }
   return out;
 }

--- a/src/features/route/utils/__tests__/transferDetect.test.ts
+++ b/src/features/route/utils/__tests__/transferDetect.test.ts
@@ -1,4 +1,5 @@
 import { detectTransfer, TRANSFER_DETECT_IMMINENT_SECONDS } from '../transferDetect';
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
 import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
 import type { NearestStationsResult } from '../../../../shared/types/station';
 
@@ -91,7 +92,7 @@ describe('detectTransfer', () => {
     expect(result.detected).toBe(false);
   });
 
-  it('다중 노선 후보 모두 반환(입력 순서 보존)', () => {
+  it('다중 노선 후보 모두 반환(arrivalSeconds 작은 순)', () => {
     const result = detectTransfer({
       nearestStations: transferNearest,
       motionWalking: true,
@@ -101,6 +102,44 @@ describe('detectTransfer', () => {
       ],
     });
     expect(result.candidateLines).toEqual(['4', '5']);
+  });
+
+  it('다중 노선: arvlCd priority 높은 line이 topPick (#973)', () => {
+    // line 5는 60초 남았지만 arvlCd=1(도착) 강한 신호, line 4는 30초+arvlCd=2(출발=priority 0).
+    // priority desc → ['5', '4'].
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [
+        { line: '4', arrivalSeconds: 30, arrivalCode: ARRIVAL_CODE.DEPARTED },
+        { line: '5', arrivalSeconds: 60, arrivalCode: ARRIVAL_CODE.ARRIVED },
+      ],
+    });
+    expect(result.candidateLines).toEqual(['5', '4']);
+  });
+
+  it('다중 노선: 같은 priority면 arrivalSeconds 작은 순 (#973)', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [
+        { line: '4', arrivalSeconds: 120, arrivalCode: ARRIVAL_CODE.ENTERING },
+        { line: '5', arrivalSeconds: 60, arrivalCode: ARRIVAL_CODE.ENTERING },
+      ],
+    });
+    expect(result.candidateLines).toEqual(['5', '4']);
+  });
+
+  it('arrivalCode 없는 항목은 priority 0, seconds로 tiebreak (#973)', () => {
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [
+        { line: '4', arrivalSeconds: 90 },
+        { line: '5', arrivalSeconds: 30 },
+      ],
+    });
+    expect(result.candidateLines).toEqual(['5', '4']);
   });
 
   it('같은 노선 중복 도착은 dedup, 임박한 것 우선', () => {
@@ -113,6 +152,22 @@ describe('detectTransfer', () => {
       ],
     });
     expect(result.candidateLines).toEqual(['4']);
+  });
+
+  it('같은 노선 dedup: 강한 arvlCd 신호가 정렬 키로 채택 (#973)', () => {
+    // line 4는 weak(seconds=30 priority=0), line 5는 strong(seconds=120 priority=100).
+    // 같은 line 4 안에서도 후순위로 들어온 priority=80(ENTERING)가 best로 채택되어야 한다.
+    const result = detectTransfer({
+      nearestStations: transferNearest,
+      motionWalking: true,
+      otherLineArrivals: [
+        { line: '4', arrivalSeconds: 30 },
+        { line: '4', arrivalSeconds: 60, arrivalCode: ARRIVAL_CODE.ENTERING },
+        { line: '5', arrivalSeconds: 120, arrivalCode: ARRIVAL_CODE.ARRIVED },
+      ],
+    });
+    // line 5: priority 100. line 4 best: priority 80 (ENTERING 채택). → ['5', '4'].
+    expect(result.candidateLines).toEqual(['5', '4']);
   });
 
   it('임박/비임박 섞임 → 임박만 candidate', () => {

--- a/src/features/route/utils/transferDetect.ts
+++ b/src/features/route/utils/transferDetect.ts
@@ -15,6 +15,7 @@
  *
  * candidateLines: 임박 도착이 잡힌 다른 노선들 — 다중 후보일 때 F4 모달(#914)에서 사용자에게 선택지 제공.
  */
+import { getArrivalPriority } from '../../../shared/constants/arrivalCodes';
 import type { LineNumber, NearestStationsResult } from '../../../shared/types/station';
 
 /** 다른 노선 도착이 "임박"으로 간주되는 최대 초. 이 이내 도착이면 환승 후보로 가산. */
@@ -23,6 +24,11 @@ export const TRANSFER_DETECT_IMMINENT_SECONDS = 180;
 export interface OtherLineArrival {
   line: LineNumber;
   arrivalSeconds: number;
+  /**
+   * arvlCd 응답값(0:진입, 1:도착, 5:전역도착 등). 누락은 -1.
+   * candidateLines 정렬에 사용 — `getArrivalPriority` 큰 값(도착>진입>...)이 더 임박.
+   */
+  arrivalCode?: number;
 }
 
 export interface DetectTransferInput {
@@ -39,7 +45,11 @@ export interface DetectTransferInput {
 
 export interface DetectTransferResult {
   detected: boolean;
-  /** 임박 도착이 감지된 다른 노선들(dedup, 입력 순서 보존). */
+  /**
+   * 임박 도착이 감지된 다른 노선들(dedup, imminence 정렬).
+   * 정렬 기준: arvlCd priority desc (1=도착>0=진입>5=전역도착>4=전역진입) → arrivalSeconds asc.
+   * 호출자는 `candidateLines[0]`을 가장 임박한 노선(=topPick)으로 사용 가능.
+   */
   candidateLines: LineNumber[];
 }
 
@@ -57,15 +67,34 @@ export function detectTransfer(input: DetectTransferInput): DetectTransferResult
   return { detected: true, candidateLines };
 }
 
+interface LineImminence {
+  line: LineNumber;
+  priority: number;
+  arrivalSeconds: number;
+}
+
 function collectImminentLines(arrivals: OtherLineArrival[]): LineNumber[] {
-  const seen = new Set<LineNumber>();
-  const out: LineNumber[] = [];
+  // line별 가장 임박한 신호로 sort key를 잡는다(같은 line의 여러 도착 중 best 선택).
+  const bestByLine = new Map<LineNumber, LineImminence>();
   for (const a of arrivals) {
     if (a.arrivalSeconds > TRANSFER_DETECT_IMMINENT_SECONDS) continue;
     if (a.arrivalSeconds < 0) continue;
-    if (seen.has(a.line)) continue;
-    seen.add(a.line);
-    out.push(a.line);
+    const priority = getArrivalPriority(a.arrivalCode);
+    const prev = bestByLine.get(a.line);
+    if (!prev || isMoreImminent(priority, a.arrivalSeconds, prev)) {
+      bestByLine.set(a.line, { line: a.line, priority, arrivalSeconds: a.arrivalSeconds });
+    }
   }
-  return out;
+  return [...bestByLine.values()]
+    .sort((x, y) => y.priority - x.priority || x.arrivalSeconds - y.arrivalSeconds)
+    .map((entry) => entry.line);
+}
+
+function isMoreImminent(
+  priority: number,
+  arrivalSeconds: number,
+  prev: LineImminence,
+): boolean {
+  if (priority !== prev.priority) return priority > prev.priority;
+  return arrivalSeconds < prev.arrivalSeconds;
 }


### PR DESCRIPTION
Closes #973

## Summary
PR #955 follow-up. 다중 환승 후보 노선의 `candidateLines` 정렬을 임박도 기준으로 변경하여 호출자가 `candidateLines[0]`을 topPick으로 안전하게 사용할 수 있도록 한다.

## Changes
- `transferDetect.ts`: `collectImminentLines`를 dedup-only(입력 순서 보존)에서 imminence 정렬로 변경
  - 정렬 기준: `arvlCd` priority desc (1=도착 > 0=진입 > 5=전역도착 > 4=전역진입) → `arrivalSeconds` asc
  - 같은 노선 dedup 시 가장 강한 arvlCd 신호를 정렬 키로 채택
- `OtherLineArrival`에 `arrivalCode?: number` 추가 (선택적, 누락은 priority 0)
- `useTransferAutoDetect.collectOtherLineArrivals`가 `arrivalCode`를 누락 없이 전달

## Test plan
- [x] `transferDetect.test.ts` 신규 케이스 4개 (arvlCd priority topPick / 같은 priority tiebreak / arrivalCode 누락 처리 / 같은 line dedup 시 강한 신호 채택)
- [x] 기존 케이스 명세 업데이트 (입력 순서 보존 → arrivalSeconds 작은 순)
- [x] `npm test` 100% coverage (4100 tests)
- [x] `npm run type-check`