### PR TITLE
feat(#972): low-recall-trip-ratio webhook 알림 (PR #961 follow-up)

### DIFF
--- a/backend/alarm-worker/src/__tests__/recallAlerts.test.ts
+++ b/backend/alarm-worker/src/__tests__/recallAlerts.test.ts
@@ -1,0 +1,349 @@
+/**
+ * recallAlerts.ts — graceful no-op 가드, SQL API fetch, dedup, webhook 발사 회귀.
+ *
+ * fetchImpl/now를 deps로 주입해 외부 호출 없이 평가 흐름 전체를 결정적으로 검증한다.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ALERT_DEDUP_KEY,
+  ALERT_DEDUP_WINDOW_MS,
+  SQL_API_URL_TEMPLATE,
+  evaluateAndMaybeAlert,
+} from '../recallAlerts';
+import { MIN_RECALL_RATIO_THRESHOLD } from '../metrics';
+import { lowRecallTripRatioQuery } from '../recallQueries';
+import type { Env } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+const NOW = 1_700_000_000_000;
+
+/** Minimal AnalyticsEngineWriter stub — 본 테스트는 write 호출 안 함, 단지 binding 존재 신호. */
+const TELEMETRY = { writeDataPoint: () => undefined };
+
+interface BuildEnvOptions {
+  withTelemetry?: boolean;
+  webhookUrl?: string;
+  accountId?: string;
+  apiToken?: string;
+}
+
+function buildEnv(kv: InMemoryKV, overrides: BuildEnvOptions = {}): Env {
+  const {
+    withTelemetry = true,
+    webhookUrl = 'https://hooks.slack.test/xyz',
+    accountId = 'acct-123',
+    apiToken = 'token-abc',
+  } = overrides;
+  return {
+    TRIPS: kv as unknown as KVNamespace,
+    TELEMETRY: withTelemetry ? TELEMETRY : undefined,
+    APNS_HOST: 'p',
+    APNS_HOST_SANDBOX: 's',
+    SEOUL_API_HOST: 'h',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: 'p',
+    APNS_BUNDLE_ID: 'b',
+    RECALL_ALERT_WEBHOOK_URL: webhookUrl,
+    CF_ACCOUNT_ID: accountId,
+    CF_API_TOKEN: apiToken,
+  };
+}
+
+/** AE SQL API 응답 stub — `data[0]`에 row 1개 또는 빈 배열. */
+function sqlApiResponse(row: {
+  totalTokens?: number;
+  lowRecallTokens?: number;
+  lowRecallRatio?: number;
+} | null): Response {
+  const data =
+    row === null
+      ? []
+      : [
+          {
+            total_tokens: row.totalTokens,
+            low_recall_tokens: row.lowRecallTokens,
+            low_recall_ratio: row.lowRecallRatio,
+          },
+        ];
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function okResponse(): Response {
+  return new Response('ok', { status: 200 });
+}
+
+describe('evaluateAndMaybeAlert — graceful no-op', () => {
+  it('TELEMETRY binding 부재 시 fetch 호출 없이 no-op', async () => {
+    const kv = new InMemoryKV();
+    const env = buildEnv(kv, { withTelemetry: false });
+    const fetchImpl = vi.fn();
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'binding-missing' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('RECALL_ALERT_WEBHOOK_URL 미설정 시 no-op', async () => {
+    const env = buildEnv(new InMemoryKV(), { webhookUrl: '' });
+    const fetchImpl = vi.fn();
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'webhook-missing' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('CF_ACCOUNT_ID 미설정 시 no-op', async () => {
+    const env = buildEnv(new InMemoryKV(), { accountId: '' });
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'account-missing' });
+  });
+
+  it('CF_API_TOKEN 미설정 시 no-op', async () => {
+    const env = buildEnv(new InMemoryKV(), { apiToken: '' });
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'token-missing' });
+  });
+});
+
+describe('evaluateAndMaybeAlert — breach 발사', () => {
+  it('ratio > 0 → webhook POST + dedup stamp 갱신', async () => {
+    const kv = new InMemoryKV();
+    const env = buildEnv(kv);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sqlApiResponse({ totalTokens: 100, lowRecallTokens: 10, lowRecallRatio: 0.1 }),
+      )
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(result.kind).toBe('fired');
+    if (result.kind !== 'fired') throw new Error('unreachable');
+    expect(result.payload).toMatchObject({
+      kind: 'low-recall',
+      ratio: 0.1,
+      threshold: MIN_RECALL_RATIO_THRESHOLD,
+      sampleSize: 100,
+      observedAt: NOW,
+    });
+    expect(result.payload.text).toContain('10.0%');
+    expect(result.payload.text).toContain('sample=100');
+
+    // SQL API call shape 검증.
+    const [sqlUrl, sqlInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(sqlUrl).toBe(SQL_API_URL_TEMPLATE('acct-123'));
+    expect(sqlInit.method).toBe('POST');
+    expect(sqlInit.body).toBe(lowRecallTripRatioQuery);
+    expect((sqlInit.headers as Record<string, string>).Authorization).toBe('Bearer token-abc');
+
+    // Webhook call shape 검증.
+    const [webhookUrl, webhookInit] = fetchImpl.mock.calls[1] as [string, RequestInit];
+    expect(webhookUrl).toBe('https://hooks.slack.test/xyz');
+    expect(webhookInit.method).toBe('POST');
+    const sentPayload = JSON.parse(webhookInit.body as string);
+    expect(sentPayload.kind).toBe('low-recall');
+    expect(sentPayload.ratio).toBe(0.1);
+
+    // Dedup stamp 기록되어야 함.
+    expect(await kv.get(ALERT_DEDUP_KEY)).toBe(String(NOW));
+  });
+
+  it('ratio === 0 → no-breach no-op (webhook 미호출)', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sqlApiResponse({ totalTokens: 100, lowRecallTokens: 0, lowRecallRatio: 0 }),
+      );
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'no-breach' });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('sample=0 → no-breach no-op (분모 0 spurious 차단)', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sqlApiResponse({ totalTokens: 0, lowRecallTokens: 0, lowRecallRatio: 0.5 }),
+      );
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'no-breach' });
+  });
+
+  it('SQL API row 비어있음 → no-op (fetch-failed로 정규화)', async () => {
+    // AE SQL API가 빈 data array 반환 — 7d 윈도우에 trip 데이터 없을 때 발생 가능.
+    // 우리 SQL은 outer SELECT가 항상 1 row 보장 — 빈 결과는 비정상 신호로 다음 tick 재시도.
+    const env = buildEnv(new InMemoryKV());
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(sqlApiResponse(null));
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'fetch-failed' });
+  });
+});
+
+describe('evaluateAndMaybeAlert — dedup', () => {
+  it('dedup 윈도우 내면 SQL/webhook 호출 없이 noop', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(ALERT_DEDUP_KEY, String(NOW - 60_000)); // 1분 전 발사됨
+    const env = buildEnv(kv);
+    const fetchImpl = vi.fn();
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'dedup' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('dedup 윈도우 경과 후엔 평가 재개', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(ALERT_DEDUP_KEY, String(NOW - ALERT_DEDUP_WINDOW_MS - 1));
+    const env = buildEnv(kv);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sqlApiResponse({ totalTokens: 50, lowRecallTokens: 5, lowRecallRatio: 0.1 }),
+      )
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result.kind).toBe('fired');
+  });
+
+  it('corrupt dedup stamp(non-numeric)는 null로 정규화 — 평가 진행', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(ALERT_DEDUP_KEY, 'garbage');
+    const env = buildEnv(kv);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sqlApiResponse({ totalTokens: 10, lowRecallTokens: 1, lowRecallRatio: 0.1 }),
+      )
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result.kind).toBe('fired');
+  });
+});
+
+describe('evaluateAndMaybeAlert — fail-soft', () => {
+  it('SQL API non-ok → noop (cron 흐름 차단 안 함)', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const log = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('err', { status: 500 }));
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      log,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'fetch-failed' });
+    expect(log).toHaveBeenCalledWith('recall-alert: SQL API non-ok', { status: 500 });
+  });
+
+  it('SQL API throw → noop + log', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const log = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'));
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      log,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'fetch-failed' });
+    expect(log).toHaveBeenCalledWith('recall-alert: SQL API fetch threw', {
+      error: 'Error: network down',
+    });
+  });
+
+  it('webhook non-ok → noop + dedup stamp 미갱신 (다음 tick 재시도 가능)', async () => {
+    const kv = new InMemoryKV();
+    const env = buildEnv(kv);
+    const log = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sqlApiResponse({ totalTokens: 100, lowRecallTokens: 10, lowRecallRatio: 0.1 }),
+      )
+      .mockResolvedValueOnce(new Response('err', { status: 503 }));
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      log,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'webhook-failed' });
+    expect(await kv.get(ALERT_DEDUP_KEY)).toBeNull();
+    expect(log).toHaveBeenCalledWith('recall-alert: webhook non-ok', { status: 503 });
+  });
+
+  it('webhook throw → noop + log + dedup 미갱신', async () => {
+    const kv = new InMemoryKV();
+    const env = buildEnv(kv);
+    const log = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sqlApiResponse({ totalTokens: 100, lowRecallTokens: 10, lowRecallRatio: 0.1 }),
+      )
+      .mockRejectedValueOnce(new Error('connection refused'));
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      log,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'webhook-failed' });
+    expect(await kv.get(ALERT_DEDUP_KEY)).toBeNull();
+    expect(log).toHaveBeenCalledWith('recall-alert: webhook fetch threw', {
+      error: 'Error: connection refused',
+    });
+  });
+
+  it('log 미주입 시 silent fail (default noop logger)', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('x'));
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ kind: 'noop', reason: 'fetch-failed' });
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -19,6 +19,7 @@ import {
   validateBoardingPromptOutcome,
 } from './boardingPromptOutcome';
 import { runFallbackPushes } from './fallback';
+import { evaluateAndMaybeAlert } from './recallAlerts';
 import {
   cleanupTripWithLa,
   type LiveActivityDeps,
@@ -956,5 +957,8 @@ export default {
     await runScheduled(env, { seoul, apnsConfig, apnsHosts, log });
     // #572 P2c — silent push 30s 미ACK entry를 alert로 fallback. 같은 cron 사이클에서 실행.
     await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
+    // #972 — low-recall trip ratio 임계 위반 시 운영 webhook 발사. dedup KV(1h)로 spam 차단.
+    // binding/secret 미설정 환경에서는 graceful no-op이라 회귀 없음.
+    await evaluateAndMaybeAlert(env, { fetchImpl: fetch, now: () => Date.now(), log });
   },
 };

--- a/backend/alarm-worker/src/recallAlerts.ts
+++ b/backend/alarm-worker/src/recallAlerts.ts
@@ -1,0 +1,224 @@
+/**
+ * Low-recall trip ratio webhook 알림 (#972, PR #961 follow-up of Epic #912 A4).
+ *
+ * Cron tick마다 `lowRecallTripRatioQuery`를 Cloudflare Analytics Engine SQL HTTP API로
+ * 실행해 비율이 0보다 크면(즉, `MIN_RECALL_RATIO_THRESHOLD` 미달 trip이 존재) 운영
+ * webhook(Slack incoming webhook 또는 호환 receiver)에 POST한다.
+ *
+ * Why 별도 모듈:
+ *   - `recallQueries.ts`는 SQL 문자열 SSOT 전용 (read-side는 외부 dashboard 책임)
+ *   - 본 모듈은 worker가 직접 read+evaluate+notify 하는 유일한 경로 — query 보유와 alert
+ *     dispatch 책임을 분리해 dashboard와 alert가 동일 SSOT를 공유한다
+ *
+ * Graceful no-op 조건 (회귀 위험 차단):
+ *   - `TELEMETRY` binding 부재 — write가 안 되므로 read도 의미 없음 (현재 Free plan)
+ *   - `RECALL_ALERT_WEBHOOK_URL` secret 미설정 — 의도적 비활성
+ *   - `CF_ACCOUNT_ID` 또는 `CF_API_TOKEN` secret 미설정 — SQL HTTP API 호출 불가
+ *
+ * Dedup: 마지막 webhook 발사 시각을 `TRIPS` KV에 stamp(`recallAlert:lastFiredAt`)하고
+ * `ALERT_DEDUP_WINDOW_MS`(1시간) 내 재발사 차단. cron이 1분 주기라 dedup 없으면
+ * 임계 위반 상태가 지속될 때 60건/h spam 발생.
+ *
+ * Privacy: webhook payload는 비율/표본 수만 포함 — token prefix·user ID 미노출.
+ */
+
+import { MIN_RECALL_RATIO_THRESHOLD } from './metrics';
+import { lowRecallTripRatioQuery } from './recallQueries';
+import type { Env } from './types';
+
+/** 같은 임계 위반 alert이 연속 발사되지 않도록 차단하는 최소 윈도우 (1시간). */
+export const ALERT_DEDUP_WINDOW_MS = 60 * 60 * 1000;
+
+/** KV key — 마지막 webhook 발사 시각 epoch ms 저장. */
+export const ALERT_DEDUP_KEY = 'recallAlert:lastFiredAt';
+
+/**
+ * Cloudflare AE SQL HTTP API endpoint template.
+ * accountId는 secret(`CF_ACCOUNT_ID`)에서 주입 — 빌드 환경에 hardcode 금지.
+ */
+export const SQL_API_URL_TEMPLATE = (accountId: string): string =>
+  `https://api.cloudflare.com/client/v4/accounts/${accountId}/analytics_engine/sql`;
+
+/** webhook POST payload 모양 — Slack incoming webhook은 `text` field만 보면 무시한다(호환). */
+export interface RecallAlertPayload {
+  /** alert kind discriminator — 향후 다른 KPI alert가 같은 webhook 재사용할 수 있게 분리. */
+  kind: 'low-recall';
+  /** observed ratio (0~1). MIN_RECALL_RATIO_THRESHOLD 미달 trip / total trip. */
+  ratio: number;
+  /** SSOT threshold (currently 0.95). */
+  threshold: number;
+  /** 7d window 내 평가된 token prefix 수 — ratio의 신뢰도 입력. */
+  sampleSize: number;
+  /** epoch ms — alert 평가 시각. */
+  observedAt: number;
+  /** Slack incoming webhook이 그대로 표시할 텍스트(payload kind와 무관한 호환 필드). */
+  text: string;
+}
+
+/**
+ * AE SQL HTTP API 응답 — 우리는 첫 row만 사용. data 형식은 `data[].low_recall_ratio` 등.
+ * shape를 좁게 잡아 다른 query는 본 모듈에서 거부.
+ */
+interface SqlApiRow {
+  total_tokens?: number;
+  low_recall_tokens?: number;
+  low_recall_ratio?: number;
+}
+
+interface SqlApiResponse {
+  data?: SqlApiRow[];
+}
+
+/**
+ * Evaluator 진입점. cron 핸들러에서 매 tick 호출.
+ *
+ * 흐름:
+ *   1. 4가지 graceful no-op 조건 검사 (binding/url/account/token 부재)
+ *   2. dedup KV stamp 확인 — 1시간 윈도우 내면 즉시 종료
+ *   3. SQL API POST(`lowRecallTripRatioQuery`)
+ *   4. 결과 row 없음 또는 ratio === 0 → no breach, 종료
+ *   5. ratio > 0 → webhook POST + dedup stamp 갱신
+ *
+ * fetch 실패는 throw하지 않고 log로만 흘려 cron 본 흐름을 막지 않는다.
+ */
+export async function evaluateAndMaybeAlert(
+  env: Env,
+  deps: RecallAlertDeps,
+): Promise<RecallAlertOutcome> {
+  if (env.TELEMETRY === undefined) return { kind: 'noop', reason: 'binding-missing' };
+  if (!env.RECALL_ALERT_WEBHOOK_URL) return { kind: 'noop', reason: 'webhook-missing' };
+  if (!env.CF_ACCOUNT_ID) return { kind: 'noop', reason: 'account-missing' };
+  if (!env.CF_API_TOKEN) return { kind: 'noop', reason: 'token-missing' };
+
+  const now = deps.now();
+  const lastFiredAt = await readDedupStamp(env.TRIPS);
+  if (lastFiredAt !== null && now - lastFiredAt < ALERT_DEDUP_WINDOW_MS) {
+    return { kind: 'noop', reason: 'dedup' };
+  }
+
+  const row = await fetchLowRecallRow(env, deps);
+  if (row === null) return { kind: 'noop', reason: 'fetch-failed' };
+
+  const ratio = row.low_recall_ratio ?? 0;
+  const sampleSize = row.total_tokens ?? 0;
+  if (ratio <= 0 || sampleSize <= 0) {
+    return { kind: 'noop', reason: 'no-breach' };
+  }
+
+  const payload: RecallAlertPayload = {
+    kind: 'low-recall',
+    ratio,
+    threshold: MIN_RECALL_RATIO_THRESHOLD,
+    sampleSize,
+    observedAt: now,
+    text:
+      `subway-now recall alert — ${(ratio * 100).toFixed(1)}% of trips fell below ` +
+      `${MIN_RECALL_RATIO_THRESHOLD} recall (sample=${sampleSize})`,
+  };
+  const sent = await postWebhook(env.RECALL_ALERT_WEBHOOK_URL, payload, deps);
+  if (!sent) return { kind: 'noop', reason: 'webhook-failed' };
+
+  await writeDedupStamp(env.TRIPS, now);
+  return { kind: 'fired', payload };
+}
+
+/** 호출자(scheduled handler)가 주입 — fetch는 cf binding global이라 명시 주입으로 테스트 용이. */
+export interface RecallAlertDeps {
+  fetchImpl: typeof fetch;
+  now: () => number;
+  log?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+/** 평가 결과 — fired 또는 noop(이유). 호출자가 stat/log 분기에 사용 가능. */
+export type RecallAlertOutcome =
+  | { kind: 'fired'; payload: RecallAlertPayload }
+  | { kind: 'noop'; reason: RecallAlertNoopReason };
+
+export type RecallAlertNoopReason =
+  | 'binding-missing'
+  | 'webhook-missing'
+  | 'account-missing'
+  | 'token-missing'
+  | 'dedup'
+  | 'fetch-failed'
+  | 'no-breach'
+  | 'webhook-failed';
+
+/**
+ * Dedup stamp read — 파싱 실패/부재는 모두 null로 정규화.
+ * KV 값이 corrupt 되어도 alert 흐름 자체는 계속 동작해야 함 (corrupt = 1회 false positive 허용).
+ */
+async function readDedupStamp(kv: KVNamespace): Promise<number | null> {
+  const raw = await kv.get(ALERT_DEDUP_KEY);
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Dedup stamp write — TTL은 윈도우의 2배로 잡아 stale entry 자연 만료. */
+async function writeDedupStamp(kv: KVNamespace, now: number): Promise<void> {
+  const ttlSec = Math.ceil((ALERT_DEDUP_WINDOW_MS * 2) / 1000);
+  await kv.put(ALERT_DEDUP_KEY, String(now), { expirationTtl: ttlSec });
+}
+
+/**
+ * Cloudflare AE SQL HTTP API에 `lowRecallTripRatioQuery` POST.
+ * 실패(network/HTTP 오류/JSON 파싱 실패/data 비어있음)는 모두 null 반환.
+ * 본 모듈은 cron의 critical path가 아니므로 fail-soft가 정책.
+ */
+async function fetchLowRecallRow(
+  env: Env,
+  deps: RecallAlertDeps,
+): Promise<SqlApiRow | null> {
+  // graceful no-op 조건에서 이미 가드되어 doable. 타입 가드용 캐스팅.
+  const accountId = env.CF_ACCOUNT_ID as string;
+  const token = env.CF_API_TOKEN as string;
+  const log = deps.log ?? (() => undefined);
+  try {
+    const res = await deps.fetchImpl(SQL_API_URL_TEMPLATE(accountId), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'text/plain',
+      },
+      body: lowRecallTripRatioQuery,
+    });
+    if (!res.ok) {
+      log('recall-alert: SQL API non-ok', { status: res.status });
+      return null;
+    }
+    const body = (await res.json()) as SqlApiResponse;
+    const row = body.data?.[0];
+    return row ?? null;
+  } catch (e) {
+    log('recall-alert: SQL API fetch threw', { error: String(e) });
+    return null;
+  }
+}
+
+/**
+ * Webhook POST — 성공 시 true. 실패 시 false 반환하고 dedup stamp는 갱신하지 않음
+ * (다음 cron tick에서 재시도 가능하게).
+ */
+async function postWebhook(
+  url: string,
+  payload: RecallAlertPayload,
+  deps: RecallAlertDeps,
+): Promise<boolean> {
+  const log = deps.log ?? (() => undefined);
+  try {
+    const res = await deps.fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      log('recall-alert: webhook non-ok', { status: res.status });
+      return false;
+    }
+    return true;
+  } catch (e) {
+    log('recall-alert: webhook fetch threw', { error: String(e) });
+    return false;
+  }
+}

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -437,4 +437,17 @@ export interface Env {
   APNS_TEAM_ID: string;
   APNS_PRIVATE_KEY: string;
   APNS_BUNDLE_ID: string;
+  /**
+   * 운영 alert webhook URL (#972, PR #961 follow-up). Slack incoming webhook 또는 호환
+   * receiver. 미설정 시 `evaluateAndMaybeAlert`는 graceful no-op.
+   * 등록: `wrangler secret put RECALL_ALERT_WEBHOOK_URL`
+   */
+  RECALL_ALERT_WEBHOOK_URL?: string;
+  /**
+   * Cloudflare Analytics Engine SQL HTTP API 호출용 account ID (#972).
+   * `RECALL_ALERT_WEBHOOK_URL`과 함께 셋 다 있어야 alert 평가가 동작.
+   */
+  CF_ACCOUNT_ID?: string;
+  /** Cloudflare API token (Analytics Engine read 권한) (#972). secret으로 등록. */
+  CF_API_TOKEN?: string;
 }

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -59,6 +59,12 @@ head_sampling_rate = 1
 # - APNS_TEAM_ID           : Apple Developer Team ID
 # - APNS_PRIVATE_KEY       : .p8 PEM 본문 (BEGIN/END 라인 포함)
 # - APNS_BUNDLE_ID         : 앱 번들 ID (예: com.handokei.subwaynow)
+#
+# #972 — recall alert webhook (PR #961 follow-up). 셋 다 설정되어야 cron이 평가/발사한다.
+# 하나라도 비어 있으면 `evaluateAndMaybeAlert`가 graceful no-op (현재 Workers Paid 대기로 사실상 비활성).
+# - RECALL_ALERT_WEBHOOK_URL  : Slack incoming webhook URL 또는 호환 receiver
+# - CF_ACCOUNT_ID             : Cloudflare account ID (Analytics Engine SQL HTTP API endpoint 조립)
+# - CF_API_TOKEN              : Cloudflare API token (Analytics Engine read 권한)
 [vars]
 APNS_HOST = "api.push.apple.com"
 APNS_HOST_SANDBOX = "api.sandbox.push.apple.com"


### PR DESCRIPTION
Closes #972

## Summary

PR #961 (#919 recall KPI dashboard)에서 SSOT로 노출만 하고 wiring을 미룬 `lowRecallTripRatioQuery`를 실제 운영 alert로 연결.

Cron tick마다 Cloudflare Analytics Engine SQL HTTP API로 query 실행 → `low_recall_ratio > 0`이면 Slack 호환 webhook으로 POST. AE 바인딩이 commented out인 동안엔 graceful no-op이라 회귀 위험 없이 머지 가능.

## 변경

- `backend/alarm-worker/src/recallAlerts.ts` (신규)
  - `evaluateAndMaybeAlert(env, deps)` — 4단 graceful no-op 가드 → dedup 검사 → SQL fetch → ratio/sample 가드 → webhook POST → dedup stamp
  - `ALERT_DEDUP_WINDOW_MS = 1h`, KV key `recallAlert:lastFiredAt` (TRIPS KV 재사용)
  - fail-soft: SQL/webhook 실패는 throw 없이 log + noop. webhook 실패는 dedup stamp 미갱신 → 다음 tick 재시도
- `backend/alarm-worker/src/types.ts` — `Env`에 `RECALL_ALERT_WEBHOOK_URL` / `CF_ACCOUNT_ID` / `CF_API_TOKEN` optional 추가
- `backend/alarm-worker/src/index.ts` — `scheduled` 핸들러에서 `runFallbackPushes` 뒤에 `evaluateAndMaybeAlert` 호출
- `backend/alarm-worker/wrangler.toml` — 3 secret 가이드 주석 추가
- `__tests__/recallAlerts.test.ts` — 16 케이스 (16/16 pass)

## Alert design

- **임계**: `metrics.catalog.json:MIN_RECALL_RATIO_THRESHOLD = 0.95`. query가 SQL 안에서 비교하므로 본 모듈은 결과 ratio가 0보다 크면 발사 (즉, 미달 trip이 1건이라도 존재)
- **Dedup**: 1시간 윈도우. cron 1분 주기에서 spam 차단 (60건/h → 1건/h)
- **Payload**: `{ kind:'low-recall', ratio, threshold, sampleSize, observedAt, text }` — Slack incoming webhook은 `text`만 표시하므로 호환
- **Privacy**: token prefix·user ID 미노출. 비율/표본 수만

## AE-pending no-op

현재 `wrangler.toml`의 `[[analytics_engine_datasets]]`는 Workers Paid 대기로 commented out. 본 PR 머지 후에도:
- `TELEMETRY` binding 없음 → `evaluateAndMaybeAlert`는 `noop:binding-missing` 즉시 반환
- secret 3종 중 하나라도 없으면 동일하게 즉시 noop

Paid 전환 + secret 등록 시 cron이 자동으로 동작 시작. 별도 코드 변경 없음.

## Test plan

- [x] `npm run type-check` (root) pass
- [x] `npx vitest run` (backend, 27 files / 911 tests) pass
- [x] `npm test` (root jest, 223 files / 4096 tests, coverage 100%) pass
- [x] 신규 테스트 16/16 pass
  - graceful no-op 4종 (binding/webhook/account/token 부재)
  - breach 발사 payload shape + KV stamp 갱신
  - dedup 윈도우 내/외 + corrupt stamp 정규화
  - SQL non-ok/throw + webhook non-ok/throw fail-soft
  - default logger silent fail