### PR TITLE
feat(#977): F4 모달 검색 fallback wire

### DIFF
--- a/src/features/route/components/DestinationPicker.tsx
+++ b/src/features/route/components/DestinationPicker.tsx
@@ -46,6 +46,13 @@ interface Props {
   readonly userLng?: number | null;
   readonly onRecenter?: () => void;
   readonly onAssignSlot?: (role: FavoriteSlotRole, station: Station) => void;
+  /**
+   * 모달 헤더 타이틀 모드 (#977, PR #954 follow-up).
+   * - 'destination'(기본): destinationPicker.title
+   * - 'origin': destinationPicker.originTitle — F4 confirm 모달 검색 fallback에서 사용.
+   * UI/검색/맵 인프라는 동일 — i18n title만 스위치.
+   */
+  readonly mode?: 'destination' | 'origin';
 }
 
 export function DestinationPicker({
@@ -57,6 +64,7 @@ export function DestinationPicker({
   favorites,
   onRecenter,
   onAssignSlot,
+  mode = 'destination',
 }: Props) {
   const [query, setQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
@@ -148,7 +156,9 @@ export function DestinationPicker({
 
         <View style={styles.overlay} pointerEvents="box-none">
           <View style={[styles.header, { backgroundColor: colors.bgTranslucent }]}>
-            <Text style={[styles.title, { color: colors.ink }]}>{t('destinationPicker.title')}</Text>
+            <Text style={[styles.title, { color: colors.ink }]}>
+              {t(mode === 'origin' ? 'destinationPicker.originTitle' : 'destinationPicker.title')}
+            </Text>
             <TouchableOpacity onPress={handleClose} testID="close-button">
               <Text style={[styles.closeText, { color: colors.accent }]}>{t('common.close')}</Text>
             </TouchableOpacity>

--- a/src/features/route/components/__tests__/DestinationPicker.test.tsx
+++ b/src/features/route/components/__tests__/DestinationPicker.test.tsx
@@ -384,4 +384,35 @@ describe('DestinationPicker', () => {
     fireEvent(getByTestId('search-input'), 'focus');
     expect(getByTestId('suggestions-list')).toBeTruthy();
   });
+
+  // #977 — F4 모달 검색 fallback. mode prop으로 i18n title만 스위치(UI/검색/맵 인프라 동일).
+  describe('mode prop (#977)', () => {
+    it('mode 미지정 시 기본 destination 타이틀을 노출한다', () => {
+      const { getByText } = render(<DestinationPicker {...defaultProps} />);
+      expect(getByText('목적지 설정')).toBeTruthy();
+    });
+
+    it("mode='destination' 명시 시 destination 타이틀을 노출한다", () => {
+      const { getByText } = render(<DestinationPicker {...defaultProps} mode="destination" />);
+      expect(getByText('목적지 설정')).toBeTruthy();
+    });
+
+    it("mode='origin' 시 origin 타이틀(현재 역 선택)을 노출한다", () => {
+      const { getByText, queryByText } = render(
+        <DestinationPicker {...defaultProps} mode="origin" />,
+      );
+      expect(getByText('현재 역 선택')).toBeTruthy();
+      expect(queryByText('목적지 설정')).toBeNull();
+    });
+
+    it("mode='origin'에서도 onSelect는 동일하게 station을 인자로 호출된다", () => {
+      const onSelect = jest.fn();
+      const { getByTestId } = render(
+        <DestinationPicker {...defaultProps} mode="origin" onSelect={onSelect} />,
+      );
+      fireEvent.changeText(getByTestId('search-input'), '강남');
+      fireEvent.press(getByTestId(`suggestion-item-${mockStation.id}`));
+      expect(onSelect).toHaveBeenCalledWith(mockStation);
+    });
+  });
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -105,6 +105,9 @@ export default function HomeScreen() {
   // FG path가 무시하지 않도록 loadAlarmEvent와 같은 시퀀스로 hydrate.
   const loadDismissSilence = useAlarmEventStore((s) => s.loadDismissSilence);
   const [pickerVisible, setPickerVisible] = useState(false);
+  // #977 — F4 confirm 모달 검색 fallback. 후보 0개 또는 사용자 명시 "검색으로 선택" 시 origin 전용
+  // DestinationPicker(mode='origin')를 띄워 직접 station 검색 → setCustomOrigin.
+  const [originPickerVisible, setOriginPickerVisible] = useState(false);
   const prevNotifKeyRef = useRef<string | undefined>(undefined);
   const prevDestIdRef = useRef<string | null>(null);
   // #534: route 비동기 계산이 끝나기 전 첫 LA 송출이 일어나면 ETA-less 카드가 잠금화면에
@@ -183,8 +186,23 @@ export default function HomeScreen() {
     }
   }, [confirmModal.autoConfirmedStation, confirmModal.consumeAutoConfirmed, t]);
   const handleConfirmAutoToastDismiss = useCallback(() => setConfirmAutoToast(null), []);
-  // 검색 fallback 실제 wire는 후속 PR — 현재는 onClose와 동일 동작(모달만 닫음).
-  // (origin 검색용 picker는 별도 component 필요. DestinationPicker는 목적지 전용.)
+  // #977 — F4 검색 fallback wire. confirm 모달 dismiss(setDismissed=true) + origin picker 오픈.
+  // 사용자가 picker에서 station 선택 시 setCustomOrigin → confirm 모달은 hasEffectiveOrigin
+  // 으로 자동 차단되어 재오픈하지 않는다.
+  // onClose는 hook 내부 useCallback(deps=[])로 stable — 객체 자체가 아닌 method를 deps에 둔다.
+  const confirmModalClose = confirmModal.onClose;
+  const handleSearchFallback = useCallback(() => {
+    confirmModalClose();
+    setOriginPickerVisible(true);
+  }, [confirmModalClose]);
+  const handleOriginPickerSelect = useCallback(
+    (station: Station) => {
+      setCustomOrigin(station);
+      setOriginPickerVisible(false);
+    },
+    [setCustomOrigin],
+  );
+  const handleOriginPickerClose = useCallback(() => setOriginPickerVisible(false), []);
 
 
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
@@ -1054,14 +1072,28 @@ export default function HomeScreen() {
       )}
 
       {/* #914 (F4) — 1탭 현재역 확정. wifi 단일 매칭은 자동 확정 + toast 노출,
-           GPS 다중 후보는 모달 1탭 확정, 후보 0개는 검색 fallback 안내. */}
+           GPS 다중 후보는 모달 1탭 확정, 후보 0개는 검색 fallback 안내(#977 wire). */}
       <CurrentStationConfirmModal
         visible={confirmModal.visible}
         candidates={confirmModal.candidates}
         topPick={confirmModal.topPick}
         onConfirm={confirmModal.onCardTap}
-        onSearchFallback={confirmModal.onClose}
+        onSearchFallback={handleSearchFallback}
         onClose={confirmModal.onClose}
+      />
+      {/* #977 — F4 검색 fallback origin picker. DestinationPicker mode='origin' 재사용.
+           onAssignSlot 미전달 → 즐겨찾기 슬롯 placeholder는 자동 숨김(origin 컨텍스트 무관). */}
+      <DestinationPicker
+        visible={originPickerVisible}
+        mode="origin"
+        onSelect={handleOriginPickerSelect}
+        onClose={handleOriginPickerClose}
+        favorites={favorites}
+        userLat={userLocation?.lat ?? null}
+        userLng={userLocation?.lng ?? null}
+        onRecenter={() => {
+          void refreshRef.current();
+        }}
       />
       <Toast
         visible={confirmAutoToast !== null}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -123,6 +123,7 @@
   "destinationPicker": {
     "noLocation": "Location info unavailable.",
     "title": "Set destination",
+    "originTitle": "Choose current station",
     "searchPlaceholder": "Search station name",
     "assignSlot": "Add {{label}}",
     "pendingSlot": "The next station you pick will be saved as {{label}}"

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -123,6 +123,7 @@
   "destinationPicker": {
     "noLocation": "位置情報がありません。",
     "title": "目的地を設定",
+    "originTitle": "現在の駅を選択",
     "searchPlaceholder": "駅名を検索",
     "assignSlot": "{{label}}を追加",
     "pendingSlot": "次に選ぶ駅を{{label}}として保存します"

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -123,6 +123,7 @@
   "destinationPicker": {
     "noLocation": "위치 정보가 없습니다.",
     "title": "목적지 설정",
+    "originTitle": "현재 역 선택",
     "searchPlaceholder": "역 이름 검색",
     "assignSlot": "{{label}} 추가",
     "pendingSlot": "다음에 선택하는 역을 {{label}}로 저장합니다"

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -123,6 +123,7 @@
   "destinationPicker": {
     "noLocation": "无位置信息。",
     "title": "设置目的地",
+    "originTitle": "选择当前车站",
     "searchPlaceholder": "搜索车站名称",
     "assignSlot": "添加{{label}}",
     "pendingSlot": "下次选择的车站将保存为{{label}}"


### PR DESCRIPTION
## Summary
PR #954 (F4 1탭 현재역 확정 모달 wire) 후속. 모달의 "검색으로 선택" fallback 버튼이 stub(`onClose`)이던 것을 실제 origin 전용 search modal로 wire.

## 동작
- F4 confirm 모달의 "검색으로 선택" 탭 → confirm 모달 dismiss + `DestinationPicker` (mode='origin') 오픈.
- Search/맵에서 station 선택 → `setCustomOrigin(station)` → confirm 모달은 `hasEffectiveOrigin`으로 자동 차단되어 재오픈하지 않음.
- Picker 취소 → no-op.
- 후보 0개(empty state) 케이스와 사용자 명시 "검색으로 선택" 둘 다 동일 경로.

## 결정 — 신규 OriginPicker 컴포넌트 대신 DestinationPicker 재사용
DestinationPicker는 모든 528개 역 검색·맵·즐겨찾기 UI 인프라를 보유. 별도 OriginPicker 컴포넌트는 중복.
변경 최소화: optional `mode?: 'destination' | 'origin'` prop 1개 추가 — i18n title만 스위치(기본 동작 불변, 기존 호출자 영향 0).
`onAssignSlot`을 origin 모드에서 미전달 → 즐겨찾기 슬롯 placeholder는 hook 가드(`!onAssignSlot → return []`)로 자동 숨김.

## 변경 파일
- `src/features/route/components/DestinationPicker.tsx` — `mode` prop + title 분기.
- `src/screens/HomeScreen.tsx` — `originPickerVisible` state + `handleSearchFallback` + 새 DestinationPicker(mode='origin') mount.
- `src/shared/i18n/locales/{ko,en,ja,zh}.json` — `destinationPicker.originTitle` 키 추가.
- `src/features/route/components/__tests__/DestinationPicker.test.tsx` — mode prop 테스트 4건.

## Test plan
- [x] `npm test` — 223 suites, 4100 tests pass, 100% coverage
- [x] `npm run type-check` — pass
- [x] `npx eslint` — pass
- [x] DestinationPicker.test.tsx — 신규 4건(default/explicit-destination/origin/select via origin mode)

Closes #977
Refs #914
Refs #954