### PR TITLE
fix(#978): free-trip hydrate sentinel-destination lock 마커

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -300,14 +300,38 @@ describe('useBoardingLockController', () => {
       expect(mockSetBoardingLock.mock.calls[0][0].expectedDurationMs).toBe(30 * 60_000);
     });
 
-    it('destinationId null → no-op', async () => {
-      const { result } = renderHook(() =>
-        useBoardingLockController({ ...defaultInputs, destinationId: null }),
-      );
+    // #978 (PR #955 follow-up): destinationId null이면 free-trip sentinel으로 hydrate.
+    // 사용자가 나중에 실제 destination 설정 → destination 변경 effect가 sentinel mismatch로 자동 release.
+    it('destinationId null → sentinel destinationId + hydratedFromSentinel marker stamp (#978)', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_700_000_111_222);
+      try {
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, destinationId: null }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+        const created = mockSetBoardingLock.mock.calls[0][0];
+        expect(created.destinationId).toBe('__free-trip-sentinel__');
+        expect(created.hydratedFromSentinel).toEqual({
+          destinationId: '__free-trip-sentinel__',
+          sentinelAt: 1_700_000_111_222,
+        });
+      } finally {
+        (Date.now as jest.Mock).mockRestore();
+      }
+    });
+
+    it('destinationId 있음 → sentinel marker 없음 (기존 동작 유지)', async () => {
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
       });
-      expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      const created = mockSetBoardingLock.mock.calls[0][0];
+      expect(created.destinationId).toBe('dest-1');
+      expect(created.hydratedFromSentinel).toBeUndefined();
     });
 
     it('currentStation null → no-op', async () => {
@@ -426,6 +450,49 @@ describe('useBoardingLockController', () => {
       renderHook(() => useBoardingLockController(defaultInputs));
       await waitFor(() => expect(useBoardingLockStore.getState().lock).toEqual(matching));
       expect(mockClearBoardingLock).not.toHaveBeenCalled();
+    });
+
+    // #978 — free-trip sentinel lock 상태 + destinationId=null이면 같은 free trip으로 간주, 유지.
+    it('sentinel lock + destinationId null이면 release 안 함 (같은 free trip 유지) (#978)', async () => {
+      const sentinelLock: BoardingLock = {
+        destinationId: '__free-trip-sentinel__',
+        trainCode: 'AUTO-7',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+        hydratedFromSentinel: {
+          destinationId: '__free-trip-sentinel__',
+          sentinelAt: Date.now(),
+        },
+      };
+      mockGetBoardingLock.mockResolvedValueOnce(sentinelLock);
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, destinationId: null }),
+      );
+      await waitFor(() => expect(useBoardingLockStore.getState().lock).toEqual(sentinelLock));
+      expect(mockClearBoardingLock).not.toHaveBeenCalled();
+    });
+
+    // #978 — sentinel lock 활성 중 사용자가 실제 destination 설정 → sentinel mismatch로 invalidate.
+    it('sentinel lock + 실 destinationId 설정 → 자동 release (cross-talk 차단) (#978)', async () => {
+      const sentinelLock: BoardingLock = {
+        destinationId: '__free-trip-sentinel__',
+        trainCode: 'AUTO-7',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+        hydratedFromSentinel: {
+          destinationId: '__free-trip-sentinel__',
+          sentinelAt: Date.now(),
+        },
+      };
+      mockGetBoardingLock.mockResolvedValueOnce(sentinelLock);
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, destinationId: 'dest-real' }),
+      );
+      await waitFor(() => expect(mockClearBoardingLock).toHaveBeenCalled());
     });
   });
 

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -15,7 +15,10 @@ import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival'
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { LineNumber, Station } from '../../../shared/types/station';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
-import { FALLBACK_BOARDING_DURATION_MINUTES } from '../../../shared/constants/boardingLock';
+import {
+  FALLBACK_BOARDING_DURATION_MINUTES,
+  FREE_TRIP_DESTINATION_SENTINEL,
+} from '../../../shared/constants/boardingLock';
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
 
 export interface UseBoardingLockControllerInputs {
@@ -93,10 +96,14 @@ export function useBoardingLockController({
   }, [loadLock]);
 
   // destination 변경 → stale lock release. 같은 destination이면 그대로 유지(앱 재시작 등).
+  // #978: free-trip sentinel lock은 destinationId=null인 동안 그대로 유지하고, 사용자가 실제
+  // destination을 설정하는 순간(sentinel !== realId) invalidate. destinationId=null + sentinel lock
+  // 조합은 "여전히 free trip 진행 중"으로 본다.
   useEffect(() => {
-    if (lock && lock.destinationId !== destinationId) {
-      void releaseLock();
-    }
+    if (!lock) return;
+    if (lock.destinationId === destinationId) return;
+    if (destinationId === null && lock.destinationId === FREE_TRIP_DESTINATION_SENTINEL) return;
+    void releaseLock();
   }, [lock, destinationId, releaseLock]);
 
   // AppState active 진입 시 만료 검사 + 마운트 직후 1회.
@@ -165,23 +172,37 @@ export function useBoardingLockController({
   //    silent push로 client store가 hydrate되는 별 경로).
   const hydrateLockFromCandidate = useCallback(
     (candidate: AutoLockCandidate) => {
-      if (!destinationId || !currentStation) return;
+      if (!currentStation) return;
       const boardingLine = asLineNumber(candidate.line);
       if (!boardingLine) return;
       if (lock) return;
+      // #978 (PR #955 follow-up): destinationId 없으면 free-trip sentinel으로 hydrate.
+      // 사용자가 나중에 실제 destination을 설정하면 위의 destination 변경 effect가
+      // (sentinel !== realId) → 자동 release하므로 cross-talk 차단.
+      const isSentinel = !destinationId;
+      const effectiveDestinationId = destinationId ?? FREE_TRIP_DESTINATION_SENTINEL;
       const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
       // boardingStationId는 createLockFromTrain과 동일하게 (역명, candidate.line) 매칭 정정.
       const correctedStation = findStationByNameAndLine(currentStation.name, boardingLine);
       const boardingStationId = correctedStation?.id ?? currentStation.id;
+      const now = Date.now();
       createLock({
-        destinationId,
+        destinationId: effectiveDestinationId,
         trainCode: candidate.trainCode,
         boardingStationId,
         boardingLine,
-        boardedAt: Date.now(),
+        boardedAt: now,
         expectedDurationMs: durationMin * 60_000,
         // initialEtaSeconds는 candidate에 없음 — Seam A 지연 칩은 cron이 채워둔 lock 메타로 노출되지 않으며,
         // 사용자가 명시 탭한 lock에서만 노출되는 게 의도(자동 lock은 정확도가 보장 안 됨).
+        ...(isSentinel
+          ? {
+              hydratedFromSentinel: {
+                destinationId: FREE_TRIP_DESTINATION_SENTINEL,
+                sentinelAt: now,
+              },
+            }
+          : {}),
       }).catch(() => {
         // store action rejection은 graceful — loadLock race / storage 일시 실패는 다음 sync에서 자연 재시도.
       });

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -77,3 +77,20 @@ export const AUTO_RELEASE_GRACE_MS = 45_000;
  *    지연돼 BG cron이 옛 lock으로 한 사이클 더 폴링 가능.
  */
 export const BOARDING_LOCK_RELEASE_DEBOUNCE_MS = 1500;
+
+/**
+ * Free-trip sentinel destinationId (#978, PR #955 follow-up).
+ *
+ * 사용자가 명시 destination을 설정하지 않은 free trip 상태에서도 transfer auto-detect로
+ * boardingLock을 자동 hydrate하려면 lock storage 스키마상 destinationId가 비어 있을 수 없다
+ * (#915 정책: 모든 lock은 trip 단위 id로 trip과 1:1 매핑되며, destination 변경 시 자동 release).
+ *
+ * 이 sentinel을 destinationId로 사용해 lock을 생성하면:
+ *   1) 사용자가 나중에 실제 destination을 설정하는 순간, controller의 destination 변경 effect
+ *      (lock.destinationId !== input.destinationId)가 발동해 sentinel lock을 자동 invalidate.
+ *      → 다른 trip의 stale lock cross-talk 차단.
+ *   2) sentinel이 유지되는 동안은 같은 free trip으로 간주, lock 그대로 유지.
+ *
+ * 값은 일반 destination id(`stn-*`, UUID 등)와 충돌하지 않도록 `__` prefix.
+ */
+export const FREE_TRIP_DESTINATION_SENTINEL = '__free-trip-sentinel__';

--- a/src/shared/types/boardingLock.ts
+++ b/src/shared/types/boardingLock.ts
@@ -32,6 +32,25 @@ export interface BoardingLock {
    * 지연 라벨은 값이 존재할 때만 노출되므로 graceful — 잘못된 추측 없이 다음 createLock에서 채워진다.
    */
   initialEtaSeconds?: number;
+  /**
+   * Free-trip sentinel marker (#978, PR #955 follow-up).
+   *
+   * 사용자가 destination을 설정하지 않은 free trip에서 transfer auto-detect로 hydrate된
+   * lock에만 stamp된다. 명시 destination이 있는 일반 lock에는 undefined.
+   *
+   * 용도:
+   *   - 진단/텔레메트리: 이 lock이 sentinel-destination 기반인지 명시.
+   *   - controller가 hydrate 시점을 sentinelAt에 기록 → 후속 free-trip 만료 정책에서 사용 가능.
+   *
+   * destination 변경 시 invalidate는 BoardingLock.destinationId가 sentinel 값 자체로 채워져
+   * 있기 때문에 기존 destinationId mismatch effect로 자동 처리된다 (별도 분기 불필요).
+   */
+  hydratedFromSentinel?: {
+    /** sentinel 상수 값 — 디버그/로그용. lock.destinationId와 동일해야 한다. */
+    destinationId: string;
+    /** sentinel-hydrate 시각(ms epoch). */
+    sentinelAt: number;
+  };
 }
 
 /** 자동 만료 안전 계수 — 예상 소요시간이 50% 초과되면 잘못된 Lock으로 보고 해제. */


### PR DESCRIPTION
Closes #978.
PR #955 (D1 stationRoute wire) follow-up — 3가지 중 sentinel-destination lock 분리 PR.
(이전: #974 trainType priority, #975 topPick imminence)

## 배경

\`useTransferAutoDetect\` 가 단일 후보 환승을 감지하면 \`onAutoLock(candidate)\` → \`useBoardingLockController.hydrateLockFromCandidate\` 를 호출한다. 그러나 기존 controller는 \`destinationId\` 가 null(=route 미설정 free trip)이면 즉시 early-return — 자동 lock이 free trip에선 무력화되었다.

destination 미설정 사용자도 free trip에서 환승 자동 lock 혜택을 받게 하되, 나중에 사용자가 실제 목적지를 설정하면 sentinel으로 잡힌 stale lock이 cross-talk를 일으키면 안 된다.

## 변경

1. \`FREE_TRIP_DESTINATION_SENTINEL = '__free-trip-sentinel__'\` (src/shared/constants/boardingLock.ts).
2. \`BoardingLock.hydratedFromSentinel?: { destinationId, sentinelAt }\` marker 필드 (src/shared/types/boardingLock.ts).
3. \`hydrateLockFromCandidate\`: destinationId null이면 sentinel을 destinationId로 사용 + marker stamp. destinationId 있으면 기존 동작 그대로(marker 없음).
4. destination-change release effect: \`destinationId=null + lock.destinationId=sentinel\` 조합은 같은 free trip으로 간주, 유지. 그 외 mismatch는 release.
5. \`createLockFromTrain\` 미변경 — 명시 탭은 destination 필요 UX 유지.

## Invalidate flow

- free trip 자동 lock: \`destinationId=null\` → hydrate 시 sentinel + marker stamp
- 같은 free trip 유지: \`destinationId=null + sentinel lock\` → 유지 (no release)
- 실 destination 설정: \`destinationId='dest-X' + sentinel lock\` → mismatch → \`releaseLock\`
- 명시 destination → 다른 destination 변경: 기존 동작 그대로

## Marker shape

\`\`\`ts
hydratedFromSentinel?: {
  destinationId: string;   // sentinel 상수 (디버그/로그용)
  sentinelAt: number;      // hydrate 시각(ms epoch)
}
\`\`\`

## Test plan

- [x] \`destinationId null → sentinel destinationId + marker stamp\` (4099 it 포함)
- [x] \`destinationId 있음 → sentinel marker 없음\` (기존 동작 회귀 X)
- [x] \`sentinel lock + destinationId null이면 release 안 함\` (free trip 유지)
- [x] \`sentinel lock + 실 destinationId 설정 → 자동 release\` (cross-talk 차단)
- [x] 기존 idempotent / lock 존재 시 no-op / candidate.line invalid 등 보조 분기 회귀 없음
- [x] \`npm test\` 4099 it · 100% coverage (branches/lines/funcs/stmts)
- [x] \`npm run type-check\` 통과
- [ ] 실기기: free trip 상태에서 환승역 감지 → 자동 lock UX 노출 (별 PR에서 실제 UI 트리거 시 검증)

Refs PR #955.