### PR TITLE
test(#982): 권한 매트릭스 회귀 추가 cell 2차 wave

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -332,7 +332,12 @@ jobs:
           - always-fg-aboveground-normal-ios18
           - whileInUse-fg-aboveground-sleep-ios18
           - always-fg-aboveground-sleep-ios18
-          # 후속 PR에서 추가: *-bg-*, *-underground-*, ios17, android
+          - always-bg-aboveground-normal-ios18
+          - whileInUse-fg-aboveground-normal-ios17
+          - always-fg-aboveground-normal-android
+          # 후속 PR에서 추가: *-underground-*, *-bg-sleep-*, 실측 recall 측정
+          # 주의: ios17/android cell은 현재 iPhone 16(iOS 18) 시뮬에서 권한 dispatch만 검증.
+          #       OS/플랫폼별 실제 시뮬레이터 부팅 분기는 후속 PR.
     env:
       SIM_NAME: 'iPhone 16'
       EXPO_PUBLIC_E2E_MOCK: '1'

--- a/.maestro/flows/permissions/README.md
+++ b/.maestro/flows/permissions/README.md
@@ -18,13 +18,17 @@ Android, FG/BG, 지상/지하, 일반/취침 등 권한·환경 조합별로 매
 | `always-fg-aboveground-normal-ios18` | Always | FG | 지상 | 일반 | iOS 18 | 권한 대조군 |
 | `whileInUse-fg-aboveground-sleep-ios18` | WhileInUse | FG | 지상 | 취침 | iOS 18 | 권한↓ + 취침 결합 |
 | `always-fg-aboveground-sleep-ios18` | Always | FG | 지상 | 취침 | iOS 18 | SLA 정본 조합 |
+| `always-bg-aboveground-normal-ios18` | Always | BG | 지상 | 일반 | iOS 18 | BG 차원 첫 진입 (2차 wave) |
+| `whileInUse-fg-aboveground-normal-ios17` | WhileInUse | FG | 지상 | 일반 | iOS 17 | iOS 17 차원 첫 진입 (2차 wave) |
+| `always-fg-aboveground-normal-android` | Always | FG | 지상 | 일반 | Android | Android 플랫폼 첫 진입 (2차 wave) |
 
 후속 PR에서 추가될 cell (`scripts/permission-matrix.json`의 `cells` 배열에
 entry만 추가하면 runner와 CI matrix가 자동으로 픽업):
 
-- `*-bg-*` 차원 (앱 BG 상태에서 매역 알람 SLA 검증)
 - `*-underground-*` 차원 (E2E mock fixture 확장 필요)
-- iOS 17 / Android 차원은 OS dimension 확장
+- `*-bg-sleep-*` 결합 차원
+- iOS 17 / Android cell의 실제 시뮬레이터/디바이스 부팅 분기 (현재는 iOS 18 시뮬에서 권한 dispatch만 검증)
+- 실측 recall 측정 (`expectedRecallPct` placeholder → 실측치)
 
 ## 로컬 실행
 

--- a/.maestro/flows/permissions/always-bg-aboveground-normal-ios18.yaml
+++ b/.maestro/flows/permissions/always-bg-aboveground-normal-ios18.yaml
@@ -1,0 +1,64 @@
+appId: com.subwaynow.app
+name: "permissions - Always × BG × 지상 × 일반 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=bg, environment=aboveground, mode=normal, os=ios18
+#
+# 검증 목표:
+#   - Always 권한 + 앱 백그라운드 상태(매역 알람 SLA의 본진 시나리오)에서
+#     홈 진입점이 유지되고 앱이 백그라운드/포그라운드 전이 후에도 정상 복귀함을 보장한다.
+#   - BG 차원의 매트릭스 첫 진입 — 후속 PR에서 BG 알람 발사 verify로 확장 예정.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, 강남역 fixture).
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# Expo dev-client(개발 빌드 한정) 안내 화면 — release 빌드에서는 없음
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 1차 포그라운드 진입 — destination-button 노출 확인 (baseline 동일)
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 백그라운드 전이 모사 — stopApp으로 프로세스를 내린 뒤 재기동.
+# 정확한 BG/FG 전이가 아닌 cold restart지만, Maestro의 cross-platform 안전 패턴이며
+# Always 권한이 재시작 후에도 보존되는지(권한 다이얼로그가 다시 뜨지 않는지) 검증 가능.
+# 실제 BG task / silent push 경로 검증은 후속 PR(시뮬레이터 백그라운드 hook 필요).
+- stopApp:
+    appId: com.subwaynow.app
+
+# 재기동 — clearState=false 로 권한 상태 유지 확인
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: false
+
+# 복귀 후에도 홈 진입점이 정상 노출되어야 한다 (BG → FG 회귀 가드)
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"

--- a/.maestro/flows/permissions/always-fg-aboveground-normal-android.yaml
+++ b/.maestro/flows/permissions/always-fg-aboveground-normal-android.yaml
@@ -1,0 +1,48 @@
+appId: com.subwaynow.app
+name: "permissions - Always × FG × 지상 × 일반 × Android (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=fg, environment=aboveground, mode=normal, os=android
+#
+# 검증 목표:
+#   - Android 권한 모델(ACCESS_BACKGROUND_LOCATION = "Always" 대응)에서도
+#     매역 알람 진입점이 정상 노출됨을 보장한다.
+#   - Maestro의 permission 매핑이 Android에서도 always → background grant로
+#     올바르게 dispatch 되는지 회귀 가드.
+#
+# 전제:
+#   - EXPO_PUBLIC_E2E_MOCK=1, 강남역 fixture (iOS와 동일 mock 데이터).
+#   - CI matrix runner는 Android 시뮬레이터/디바이스 부팅 로직을 후속 PR에서 분기 추가.
+#     (현재 단계는 권한 dispatch 차원 등록 — iOS 시뮬레이터에서도 dry-run/문법은 통과)
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+- assertVisible:
+    text: "목적지 설정|Set destination"

--- a/.maestro/flows/permissions/whileInUse-fg-aboveground-normal-ios17.yaml
+++ b/.maestro/flows/permissions/whileInUse-fg-aboveground-normal-ios17.yaml
@@ -1,0 +1,47 @@
+appId: com.subwaynow.app
+name: "permissions - WhileInUse × FG × 지상 × 일반 × iOS17 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=whileInUse, appState=fg, environment=aboveground, mode=normal, os=ios17
+#
+# 검증 목표:
+#   - iOS 17 시뮬레이터에서도 WhileInUse 권한 baseline 시나리오가 동일하게 동작함을 보장한다.
+#   - iOS 17/18 간 권한 다이얼로그 동작 차이(예: "Continue Once" vs "While Using")로 인한
+#     회귀를 OS 차원으로 검출하기 위한 첫 진입점.
+#
+# 전제:
+#   - EXPO_PUBLIC_E2E_MOCK=1, 강남역 fixture.
+#   - CI matrix runner는 SIM_NAME을 통해 iOS 17 시뮬레이터로 부팅하도록 후속 PR에서 분기 추가.
+#     (현재는 ios18과 동일 시뮬레이터에서 실행 — 권한 dispatch만 검증)
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: inuse
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+- assertVisible:
+    text: "목적지 설정|Set destination"

--- a/scripts/permission-matrix.json
+++ b/scripts/permission-matrix.json
@@ -58,6 +58,39 @@
       "expectedRecallPct": 95,
       "flow": "always-fg-aboveground-sleep-ios18.yaml",
       "_doc": "매역 알림 SLA의 정본 조합(권한=항상 + 취침). 후속 PR에서 실측 recall로 업데이트."
+    },
+    {
+      "id": "always-bg-aboveground-normal-ios18",
+      "permission": "always",
+      "appState": "bg",
+      "environment": "aboveground",
+      "mode": "normal",
+      "os": "ios18",
+      "expectedRecallPct": 95,
+      "flow": "always-bg-aboveground-normal-ios18.yaml",
+      "_doc": "BG 차원 첫 진입. 매역 알람 SLA 본진 시나리오(Always + 백그라운드)에서 BG→FG 복귀 후 홈 진입점 유지 회귀 가드. 후속 PR에서 BG 알람 발사 verify로 확장."
+    },
+    {
+      "id": "whileInUse-fg-aboveground-normal-ios17",
+      "permission": "whileInUse",
+      "appState": "fg",
+      "environment": "aboveground",
+      "mode": "normal",
+      "os": "ios17",
+      "expectedRecallPct": 95,
+      "flow": "whileInUse-fg-aboveground-normal-ios17.yaml",
+      "_doc": "iOS 17 OS 차원 첫 진입. baseline과 동일 시나리오를 iOS 17 시뮬레이터에서 회귀 가드. 후속 PR에서 SIM_NAME 분기."
+    },
+    {
+      "id": "always-fg-aboveground-normal-android",
+      "permission": "always",
+      "appState": "fg",
+      "environment": "aboveground",
+      "mode": "normal",
+      "os": "android",
+      "expectedRecallPct": 90,
+      "flow": "always-fg-aboveground-normal-android.yaml",
+      "_doc": "Android 플랫폼 차원 첫 진입. ACCESS_BACKGROUND_LOCATION 권한 dispatch가 Maestro permission 매핑에서 올바르게 처리되는지 회귀 가드. 후속 PR에서 Android 시뮬레이터 부팅 분기."
     }
   ]
 }


### PR DESCRIPTION
Closes #982
Parent: #923 (Epic #912 P2 E2)

## Why
PR #935 (infra + 1 baseline cell) + PR #952 (3 cell 추가) 머지 후 매트릭스에는 4 cell만 등록된 상태. `*-bg-*`, iOS 17, Android 등 핵심 차원이 비어 회귀 가드 범위가 좁다. 다음 임팩트 큰 cell 3건을 데이터 주도 방식으로 추가해 매트릭스 완성도를 한 단계 올린다.

## What
| cell id | permission | appState | environment | mode | os | rationale |
| --- | --- | --- | --- | --- | --- | --- |
| `always-bg-aboveground-normal-ios18` | Always | BG | 지상 | 일반 | iOS 18 | BG 차원 첫 진입. 매역 알람 SLA 본진 시나리오(Always + 백그라운드)에서 stopApp/relaunch 후에도 권한 보존 + 홈 진입점 복귀 |
| `whileInUse-fg-aboveground-normal-ios17` | WhileInUse | FG | 지상 | 일반 | iOS 17 | iOS 17/18 권한 다이얼로그 차이로 인한 회귀 검출. OS 차원 첫 진입 |
| `always-fg-aboveground-normal-android` | Always | FG | 지상 | 일반 | Android | Android 권한 모델(ACCESS_BACKGROUND_LOCATION) Maestro dispatch 가드. 플랫폼 차원 첫 진입 |

## 1차 wave (#935, #952)과의 비교
- 1차(infra + 4 cell): permission(2) × mode(2) 차원만 채움. 모두 FG × 지상 × iOS 18.
- 본 PR: 매트릭스의 다른 3개 축 모두 첫 진입(BG / iOS17 / Android). 매트릭스 가로축 확장.

## 무변경
- `scripts/permission-matrix-runner.js` (데이터 주도 — entry만 추가)
- `scripts/__tests__/permission-matrix-runner.test.js` (4123 tests pass, 100% coverage 유지)
- 기존 cell flow / baseline 정의

## 후속 PR 큐 (본 PR 범위 외 — README에 명시)
- `*-underground-*` 차원 (E2E mock fixture 확장 필요)
- `*-bg-sleep-*` 결합 차원
- iOS 17 / Android cell의 실제 시뮬레이터 부팅 분기 (현재는 iOS 18 시뮬에서 권한 dispatch만 검증)
- 실측 recall 측정 (`expectedRecallPct` placeholder → 실측치)

## Verification
- `npm test`: 225 suites, 4123 tests pass, 100% coverage
- `npm run type-check`: pass
- `node scripts/permission-matrix-runner.js --list`: 7 cell 노출 확인
- `--dry-run`: 3 신규 cell 모두 maestro 명령 dispatch 정상

CI는 nightly만 trigger (PR gate 아님 — `permission-matrix` job은 cron/workflow_dispatch only).