### PR TITLE
feat(#981): recall dashboard Notion ops page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ coverage-temp/
 docs/*
 !docs/ci/
 !docs/decisions/
+!docs/ops/
 handoff/
 img/
 subway/

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1484,12 +1484,14 @@ describe('GET /metrics/recall/summary (#919 후속)', () => {
       dataset: string;
       available: boolean;
       minRecallRatioThreshold: number;
+      opsPageUrl: string;
       queries: { id: string; description: string; sql: string }[];
     };
     expect(body.dataset).toBe('silent_push_telemetry');
     expect(body.available).toBe(false);
     expect(body.minRecallRatioThreshold).toBeGreaterThan(0);
     expect(body.minRecallRatioThreshold).toBeLessThanOrEqual(1);
+    expect(body.opsPageUrl).toMatch(/^https:\/\//);
     expect(body.queries.length).toBeGreaterThanOrEqual(3);
     for (const q of body.queries) {
       expect(typeof q.id).toBe('string');

--- a/backend/alarm-worker/src/__tests__/recallQueries.test.ts
+++ b/backend/alarm-worker/src/__tests__/recallQueries.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   RECALL_DATASET,
+  RECALL_OPS_PAGE_URL,
   RECALL_QUERIES,
   dailyRecallRateQuery,
   gateSuppressionDistributionQuery,
@@ -22,6 +23,12 @@ describe('RECALL_DATASET', () => {
   it('matches wrangler.toml dataset name', () => {
     // wrangler.toml의 `dataset = "silent_push_telemetry"`와 동일 (#498 / #506 주석 참조).
     expect(RECALL_DATASET).toBe('silent_push_telemetry');
+  });
+});
+
+describe('RECALL_OPS_PAGE_URL (#981)', () => {
+  it('is a Notion URL (운영 페이지 SSOT)', () => {
+    expect(RECALL_OPS_PAGE_URL).toMatch(/^https:\/\/(app\.notion\.com|.*\.notion\.site)\//);
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -36,7 +36,7 @@ import {
   validateRecallUpload,
 } from './recallTelemetry';
 import { MIN_RECALL_RATIO_THRESHOLD } from './metrics';
-import { RECALL_DATASET, RECALL_QUERIES } from './recallQueries';
+import { RECALL_DATASET, RECALL_OPS_PAGE_URL, RECALL_QUERIES } from './recallQueries';
 import {
   recordPrescheduledUpload,
   validatePrescheduledUpload,
@@ -319,6 +319,7 @@ app.get('/metrics/recall/summary', (c) => {
     dataset: RECALL_DATASET,
     available: c.env.TELEMETRY !== undefined,
     minRecallRatioThreshold: MIN_RECALL_RATIO_THRESHOLD,
+    opsPageUrl: RECALL_OPS_PAGE_URL,
     queries: RECALL_QUERIES,
   });
 });

--- a/backend/alarm-worker/src/recallQueries.ts
+++ b/backend/alarm-worker/src/recallQueries.ts
@@ -37,6 +37,18 @@ import { RECALL_DISTRIBUTION_LABEL_PREFIX } from './recallTelemetry';
 export const RECALL_DATASET = 'silent_push_telemetry';
 
 /**
+ * 운영 대시보드 Notion 페이지 URL (#981 / PR #961 후속).
+ *
+ * Notion 페이지가 endpoint 응답에 포함된 SQL 카탈로그를 그대로 사용한다.
+ * `GET /metrics/recall/summary` 응답에 함께 노출 — 외부에서 endpoint만 보고도
+ * 운영 페이지 위치를 알 수 있게 SSOT 일원화.
+ *
+ * 페이지 컨텐츠 source: `docs/ops/recall-dashboard.md`.
+ */
+export const RECALL_OPS_PAGE_URL =
+  'https://app.notion.com/p/37730c0194b6817e8953dacb9e533039';
+
+/**
  * 본 모듈이 사용하는 metric 식별자 — catalog SSOT(`metrics.catalog.json`)에서 동적으로 끌어와
  * hardcoded 식별자 없음. catalog에서 key가 바뀌면 query도 자동 갱신.
  */

--- a/docs/ops/recall-dashboard.md
+++ b/docs/ops/recall-dashboard.md
@@ -1,0 +1,51 @@
+# Recall KPI 운영 대시보드 (#919 / PR #961 후속)
+
+본 문서는 Notion 운영 페이지와 backend `GET /metrics/recall/summary` endpoint의 컨텐츠 source.
+
+- **Notion 페이지**: https://app.notion.com/p/37730c0194b6817e8953dacb9e533039
+- **Endpoint SSOT**: `backend/alarm-worker/src/recallQueries.ts`
+- **Endpoint URL 상수**: `RECALL_OPS_PAGE_URL` (위 Notion URL을 노출, endpoint 응답에 포함)
+
+## 목적
+
+Phase 3 매역 알림(`perStationAlarmRecall`)의 도달률과 게이트 차단 분포를 추적해 운영 임계 alert 발사 입력값을 SSOT로 모은다.
+
+## Query 목록
+
+| id | window | 용도 |
+| --- | --- | --- |
+| `daily-recall-rate` | 14d | 일별 매역 알림 recall rate 추세 |
+| `gate-suppression-distribution` | 14d | 게이트별 차단 분포 |
+| `low-recall-trip-ratio` | 7d | `recall < MIN_RECALL_RATIO_THRESHOLD` token 비율 (alert 임계 입력) |
+
+세 query 모두 분모 0 가드(`if(... > 0, ..., 0)`)로 NaN/inf alert 폭주 차단.
+
+## 임계값
+
+- **`MIN_RECALL_RATIO_THRESHOLD = 0.95`** — `metrics.catalog.json` SSOT. token prefix 단위 recall이 95% 미만이면 low-recall token으로 분류.
+
+## Webhook 연계 (PR #976 / #972)
+
+`low-recall-trip-ratio` 결과가 임계 초과 시 운영 alert webhook 발사. 자세한 wiring은 PR #976 (#972) 참조.
+
+## AE binding 활성 상태
+
+- `wrangler.toml`의 `[[analytics_engine_datasets]]` 블록은 Workers Paid 대기로 주석 처리 상태(#506).
+- **`available: false`** → AE binding 미활성. Notion 페이지에 "데이터 미수집 중" placeholder 표시.
+- **`available: true`** → AE 활성. SQL HTTP API로 endpoint 응답의 `queries[].sql`을 그대로 호출해 데이터 fetch.
+
+## 외부 호출 예시
+
+```bash
+# 1. endpoint에서 query 카탈로그 fetch
+curl https://alarm-worker.<workers-dev>/metrics/recall/summary
+
+# 2. AE 활성 후, fetch한 SQL로 Cloudflare SQL HTTP API 호출
+curl -X POST https://api.cloudflare.com/client/v4/accounts/<account>/analytics_engine/sql \
+  -H "Authorization: Bearer <token>" \
+  --data-binary "<sql 문자열>"
+```
+
+## Privacy
+
+token prefix 8자만 — 개별 사용자 식별 불가.


### PR DESCRIPTION
Closes #981 (PR #961 follow-up — Notion 운영 페이지 wire-up).

## 배경

PR #961에서 `recallQueries.ts` SQL SSOT + `GET /metrics/recall/summary` endpoint가 dev에 머지됨. 본 후속 PR은 운영 Notion 페이지를 그 endpoint를 SSOT로 사용하도록 wire-up.

## Deliverable

- **Notion 운영 페이지** 생성 — `subway-now/기술적의사결정` 하위
  - URL: https://app.notion.com/p/37730c0194b6817e8953dacb9e533039
  - 섹션: 목적 / Endpoint SSOT / Query 목록 / 임계값 / Webhook 연계 (#976) / AE binding 활성 상태 / 외부 호출 예시 / Privacy
- **`docs/ops/recall-dashboard.md`** — Notion 페이지 컨텐츠 source. `.gitignore`에 `!docs/ops/` 추가해 추적.
- **`RECALL_OPS_PAGE_URL`** 상수 — `recallQueries.ts`에 export. Notion URL SSOT.
- **`GET /metrics/recall/summary`** 응답에 **`opsPageUrl`** 필드 추가 — 외부에서 endpoint만 보고도 운영 페이지 위치를 알 수 있음.

## AE-pending behavior

`wrangler.toml`의 `[[analytics_engine_datasets]]`이 Workers Paid 대기 주석(#506). binding 부재 시 endpoint는 `available: false` 반환, Notion 페이지는 "데이터 미수집 중" placeholder. AE 활성 후 즉시 dashboard로 사용 가능.

## Test plan

- [x] `npx vitest run` (backend) — 912 tests pass
- [x] `npm test` (root) — 4123 tests, 100% coverage
- [x] `npm run type-check` — pass (backend의 scheduled.test.ts 2건은 PR #961에서 이미 보고된 pre-existing)
- [x] 회귀: `RECALL_OPS_PAGE_URL` Notion URL 형식, endpoint 응답 shape에 `opsPageUrl` 포함

## Dependencies

- PR #961 (머지 완료) — `recallQueries.ts` + endpoint
- PR #976 / #972 (머지 완료) — low-recall webhook (Notion 페이지에서 참조)