### PR TITLE
test(#985): Maestro 회귀 시나리오 wave 2 — Seam A + D

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -166,6 +166,8 @@ jobs:
           - seam-b-13-19
           - seam-e-13-39
           - seam-f-13-24
+          - seam-a-delay-chip
+          - seam-d-debug-entry
           # Seam C는 transfer-leg / FG-return 이벤트 mock 설계 결함으로 보류
           # ([[project-2026-06-05-epic-912-session-end]]).
     env:
@@ -173,6 +175,9 @@ jobs:
       EXPO_PUBLIC_USE_BFF: 'true'
       EXPO_PUBLIC_BFF_URL: 'http://localhost:8788'
       EXPO_PUBLIC_ALARM_BACKEND_URL: 'http://localhost:8788'
+      # Seam D 회귀 가드는 release 빌드에서 DebugModal 트리거가 살아 있는지 검증한다 — flag로 명시 활성.
+      # 다른 시나리오(B/E/F/A)는 영향 받지 않음(모달은 명시 7-tap 트리거에서만 노출).
+      EXPO_PUBLIC_DEBUG_MODAL: 'true'
 
     steps:
       - name: 코드 체크아웃
@@ -225,11 +230,14 @@ jobs:
 
       - name: mock 백엔드 빌드-time env 주입
         # Expo의 with-environment.sh가 .xcode.env.local을 소싱하므로 여기 export.
+        # EXPO_PUBLIC_DEBUG_MODAL은 Seam D 시나리오 전용이지만 release 빌드는 시나리오와
+        # 무관하게 1회 캐시되므로 모든 시나리오에 동일하게 주입(다른 시나리오는 7-tap을 안 함).
         run: |
           {
             echo 'export EXPO_PUBLIC_USE_BFF=true'
             echo 'export EXPO_PUBLIC_BFF_URL=http://localhost:8788'
             echo 'export EXPO_PUBLIC_ALARM_BACKEND_URL=http://localhost:8788'
+            echo 'export EXPO_PUBLIC_DEBUG_MODAL=true'
           } >> ios/.xcode.env.local
           cat ios/.xcode.env.local
 

--- a/.maestro/flows/regression/README.md
+++ b/.maestro/flows/regression/README.md
@@ -1,7 +1,8 @@
 # Maestro 회귀 fixture (#922)
 
-2026-06-05 실기기에서 발생한 4건의 알람 회귀(Seam B/C/E/F)를 단위 테스트 외에 실기기-동등
-환경에서 회귀 가드로 잡기 위한 Maestro flow 모음.
+2026-06-05 실기기에서 발생한 4건의 알람 회귀(Seam B/C/E/F)와 후속 Seam A(#897 lock 지연 칩),
+Seam D(#456 DebugModal 진입)를 단위 테스트 외에 실기기-동등 환경에서 회귀 가드로 잡기 위한
+Maestro flow 모음.
 
 ## 구성
 
@@ -20,6 +21,8 @@ SCENARIO=seam-b-13-19 PORT=8788 node scripts/maestro-mock-backend.js
 echo 'export EXPO_PUBLIC_USE_BFF=true' >> ios/.xcode.env.local
 echo 'export EXPO_PUBLIC_BFF_URL=http://localhost:8788' >> ios/.xcode.env.local
 echo 'export EXPO_PUBLIC_ALARM_BACKEND_URL=http://localhost:8788' >> ios/.xcode.env.local
+# Seam D (DebugModal 진입) 시나리오를 release 빌드로 실행할 때만 필요. dev 빌드(__DEV__=true)는 불필요.
+echo 'export EXPO_PUBLIC_DEBUG_MODAL=true' >> ios/.xcode.env.local
 npm run ios
 
 # 3) flow 실행
@@ -33,6 +36,8 @@ maestro test .maestro/flows/regression/seam-b-13-19.yaml
 | `seam-b-13-19.yaml` | B | 13:19 transfer/early/건대입구 fired @ 성수 | 성수 정지 + 건대입구 5분 후 ETA → false-positive 발사 없음 |
 | `seam-e-13-39.yaml` | E | 13:39~45 lockMissing | `/boarding-lock/sync` 응답이 advanced=true여도 ghost 알람 발사 0건, chip 안정 |
 | `seam-f-13-24.yaml` | F | 13:24~28 trainCode 7174 사라짐 | 25s 시점 trainCode drop 후에도 lockMissing/ghost 알람 발사 0건 |
+| `seam-a-delay-chip.yaml` | A | #897 lock 지연 칩 | 어린이대공원에서 7180 lock 후 phase 30s 전환 → `boarding-lock-hop-delay-chip` `+4분 지연` 노출 |
+| `seam-d-debug-entry.yaml` | D | #456 DebugModal 진입 | 설정 탭 → version footer 7-tap → `debug-modal` + `debug-arrival-summary` 노출, close 정상 |
 
 보류:
 - Seam C — 13:23 waypoint advanced + 14:02 stale chip. transfer-leg / FG-return /

--- a/.maestro/flows/regression/seam-a-delay-chip.yaml
+++ b/.maestro/flows/regression/seam-a-delay-chip.yaml
@@ -1,0 +1,102 @@
+appId: com.subwaynow.app
+name: "regression - Seam A (#922) — boarding lock 지연 칩 노출 (#897)"
+# Epic #896 Seam A(#897) 회귀 가드. 사용자가 BoardingTrainList의 열차 row를 탭해 lock하면
+# lock.initialEtaSeconds가 snapshot된다. 이후 폴링에서 동일 trainCode의 잔여 ETA가 임계값
+# (+180s) 이상 늘면 BoardingLockHopCard(testID=boarding-lock-hop-card)에 '+N분 지연' 칩
+# (testID=boarding-lock-hop-delay-chip)이 노출되어야 한다.
+#
+# 본 flow는 GPS를 어린이대공원에 두고 mock backend가 phase 0~30s 동안 trainCode 7180을
+# arrivalSeconds=120으로, phase 30s 이후로는 arrivalSeconds=360으로 응답하는 상황에서,
+# row 탭으로 lock 형성 후 약 60초 대기 → 지연 칩 노출을 검증한다.
+#
+# 전제: scripts/maestro-mock-backend.js가 SCENARIO=seam-a-delay-chip PORT=8788로 떠 있고
+# 앱은 EXPO_PUBLIC_BFF_URL/EXPO_PUBLIC_ALARM_BACKEND_URL로 mock을 가리키도록 빌드되어야 한다.
+---
+- setLocation:
+    latitude: 37.548014
+    longitude: 127.074658
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 어린이대공원 확인 (한/영 둘 다 매칭)
+- assertVisible:
+    text: "어린이대공원|Children"
+
+# 목적지: 군자 (7호선 단순 trip — Seam A의 핵심은 lock 후 지연 칩 노출)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "군자"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-7-017"
+- waitForAnimationToEnd
+
+# BoardingTrainList가 어린이대공원 row를 노출할 때까지 대기 (mock 응답 phase 0 활성).
+- extendedWaitUntil:
+    visible:
+      id: "boarding-train-row-7180"
+    timeout: 15000
+
+# 사용자가 7180 row 탭 → lock 형성 (lock.initialEtaSeconds=120 snapshot).
+- tapOn:
+    id: "boarding-train-row-7180"
+- waitForAnimationToEnd
+
+# Lock 카드가 떠야 한다 — BoardingTrainList는 사라지고 BoardingLockHopCard 노출.
+- extendedWaitUntil:
+    visible:
+      id: "boarding-lock-hop-card"
+    timeout: 10000
+
+# Phase 30s 전환 + 클라이언트 폴링 cycle을 위해 충분히 대기.
+# - mock fixture는 fromMs=30000부터 arrivalSeconds=360 응답.
+# - 클라이언트 arrival 폴링 30s 주기 + lock 카드 currentEtaSeconds 갱신.
+# 70초 대기로 phase 전환 + 최소 1회 폴링 cycle 확보.
+- repeat:
+    times: 70
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# Seam A 회귀 검증: 지연 칩이 노출되어야 한다.
+# 임계값 +180s 초과(+240s) → ceil(240/60)=4분.
+- assertVisible:
+    id: "boarding-lock-hop-delay-chip"
+- assertVisible:
+    text: "\\+4분 지연"
+
+# Lock은 유지되어야 하고 — false-positive 알람은 발사되지 않아야 한다.
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# 트립 진행 chip은 어린이대공원으로 안정 (지연이 waypoint advance 회귀를 유발하면 안 됨).
+- assertVisible:
+    text: "어린이대공원|Children"

--- a/.maestro/flows/regression/seam-d-debug-entry.yaml
+++ b/.maestro/flows/regression/seam-d-debug-entry.yaml
@@ -1,0 +1,80 @@
+appId: com.subwaynow.app
+name: "regression - Seam D (#922) — DebugModal 진입 경로 (#456)"
+# DebugModal(#456) 진입 경로 회귀 가드. 13:24 trainCode 사라짐 같은 야전 회귀에서 사용자가
+# DebugModal에 진입해 진단 dump를 공유할 수 있어야 root cause 식별 latency가 짧아진다.
+# 진입 경로 자체(설정 탭 → 버전 footer 7-tap → debug-modal)가 회귀하면 야전 진단이 막힌다.
+#
+# 검증:
+#   1. 홈 → 설정 탭 이동 후 settings-version-footer가 보인다.
+#   2. version footer를 DEBUG_MODAL_TRIGGER_TAP_COUNT(=7)회 빠르게 탭한다.
+#   3. debug-modal이 노출되고 debug-arrival-summary entry가 표시된다(빈 dump여도 텍스트 존재).
+#   4. debug-modal-close로 모달이 정상 닫힌다.
+#
+# 전제:
+#   - scripts/maestro-mock-backend.js가 SCENARIO=seam-d-debug-entry PORT=8788로 떠 있어야 한다
+#     (arrival 응답은 비어 있어도 됨 — 본 flow는 UI 진입 경로 검증이 목적).
+#   - 빌드 env에 EXPO_PUBLIC_DEBUG_MODAL=true가 주입되어 isDebugModalEnabled()=true여야 한다
+#     (release 빌드 기본은 false. e2e.yml regression job env에 추가).
+---
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 설정 탭 (87.5% — smoke/03_tab_navigation.yaml과 동일 좌표)
+- tapOn:
+    point: "87%,95%"
+- extendedWaitUntil:
+    visible:
+      id: "settings-version-footer"
+    timeout: 10000
+
+# Version footer 7회 빠르게 탭 (DEBUG_MODAL_TRIGGER_TAP_COUNT=7, RESET_MS=1500).
+# 각 탭 사이 간격이 1500ms를 넘으면 카운트가 리셋되므로 명시 wait 없이 연속 탭.
+- tapOn:
+    id: "settings-version-footer"
+- tapOn:
+    id: "settings-version-footer"
+- tapOn:
+    id: "settings-version-footer"
+- tapOn:
+    id: "settings-version-footer"
+- tapOn:
+    id: "settings-version-footer"
+- tapOn:
+    id: "settings-version-footer"
+- tapOn:
+    id: "settings-version-footer"
+
+# DebugModal 진입 검증.
+- extendedWaitUntil:
+    visible:
+      id: "debug-modal"
+    timeout: 10000
+
+# Arrival 섹션 entry 표시(#456 — debug dump의 핵심 패널 중 하나).
+# arrivals fixture가 비어 있어도 placeholder 텍스트가 렌더되어야 한다.
+- assertVisible:
+    id: "debug-arrival-summary"
+
+# 모달이 정상 닫힘 (back 버튼/iOS swipe 의존 X — 명시 close 버튼 검증).
+- tapOn:
+    id: "debug-modal-close"
+- extendedWaitUntil:
+    visible:
+      id: "settings-version-footer"
+    timeout: 5000

--- a/scripts/fixtures/regression/seam-a-delay-chip.json
+++ b/scripts/fixtures/regression/seam-a-delay-chip.json
@@ -1,0 +1,88 @@
+{
+  "name": "Seam A — boarding lock 지연 칩 노출 (#897)",
+  "seam": "A",
+  "_doc": [
+    "Epic #896 Seam A(#897) 회귀 가드. 사용자가 BoardingTrainList에서 열차를 lock한 시점의 ETA(initialEtaSeconds)",
+    "보다 이후 폴링의 동일 trainCode 잔여 ETA가 임계값(+180s) 이상 늘면 BoardingLockHopCard에",
+    "'+N분 지연' 칩(testID=boarding-lock-hop-delay-chip)이 노출되어야 한다.",
+    "",
+    "fixture 구성:",
+    "  - 어린이대공원(7-016) phase 0~30s: trainCode 7180 arrivalSeconds=120 → 사용자가 row 탭 → lock 형성",
+    "    (lock.initialEtaSeconds=120 snapshot).",
+    "  - phase 30s 이후: 동일 trainCode 7180 arrivalSeconds=360(=lock 시점 +240s, 임계값 +180s 초과)",
+    "    → BoardingLockHopCard의 currentEtaSeconds=360 → '+4분 지연' 칩 노출.",
+    "  - 목적지 군자(7-017)는 ETA 큰 값으로 응답해 false-positive 알람 발사 차단.",
+    "",
+    "기대 client-observable 동작: lock 생성 후 60초+ 시점에 boarding-lock-hop-delay-chip 노출,",
+    "ghost 알람 0건, 트립 chip은 어린이대공원으로 안정."
+  ],
+  "arrivals": {
+    "어린이대공원": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "장암",
+              "arrivalMinutes": 2,
+              "arrivalSeconds": 120,
+              "statusMessage": "2분 후 도착",
+              "trainCode": "7180",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      },
+      {
+        "fromMs": 30000,
+        "body": {
+          "up": [
+            {
+              "destination": "장암",
+              "arrivalMinutes": 6,
+              "arrivalSeconds": 360,
+              "statusMessage": "6분 후 도착",
+              "trainCode": "7180",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ],
+    "군자": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "군자",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "7180",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ]
+  }
+}

--- a/scripts/fixtures/regression/seam-d-debug-entry.json
+++ b/scripts/fixtures/regression/seam-d-debug-entry.json
@@ -1,0 +1,20 @@
+{
+  "name": "Seam D — DebugModal 진입 경로 (#456 / version footer 7-tap)",
+  "seam": "D",
+  "_doc": [
+    "DebugModal 진입 경로(설정 탭 → 버전 footer 7-탭) 자체의 회귀 가드.",
+    "13:24 trainCode 사라짐 같은 야전 회귀에서 사용자가 DebugModal에 진입해 진단 dump를 공유할 수 있어야",
+    "root cause 식별 latency가 짧아진다. 진입 경로가 회귀(testID 변경/7-tap 카운트 변경/release flag 미주입)하면",
+    "야전 진단 전부가 막힌다.",
+    "",
+    "fixture는 arrival 측면 검증이 아니므로 placeholder. flow의 핵심은 settings → version footer 7-tap →",
+    "debug-modal 노출 + debug-arrival-summary entry 표시 확인. 진입 자체에 arrival 데이터가 비어 있어도",
+    "modal은 렌더되어야 한다(빈 dump = 정상).",
+    "",
+    "전제: build env에 EXPO_PUBLIC_DEBUG_MODAL=true가 주입되어 있어야 한다(e2e.yml regression job에 추가).",
+    "release 빌드 기본은 false라 dev 빌드 동일 동작을 보장하려면 명시 주입 필요(#456 SSOT).",
+    "",
+    "기대 client-observable 동작: 7-탭 → debug-modal 노출, debug-modal-close로 정상 닫힘."
+  ],
+  "arrivals": {}
+}


### PR DESCRIPTION
Closes #985
Refs #922 #912

Parent epic #912 P2 E1 후속. PR #927 (infra + Seam B) → PR #953 (Seam F + Seam E) → 본 wave 2.

## Summary
- **Seam A (#897 — boarding lock 지연 칩)**: 어린이대공원에서 7180 lock 후 phase 30s 전환으로 동일 trainCode arrivalSeconds가 120→360 (+240s) 증가 → `boarding-lock-hop-delay-chip` 노출(+4분 지연) 검증.
- **Seam D (#456 — DebugModal 진입)**: 설정 탭 → `settings-version-footer` 7-탭 → `debug-modal` + `debug-arrival-summary` 노출 → `debug-modal-close` 정상 동작 검증.
- regression matrix 5 cells(B/E/F/A/D)로 확장. EXPO_PUBLIC_DEBUG_MODAL=true 빌드 env 주입(Seam D 전용, 타 시나리오 무영향).

## 설계 의도
- **Seam A**: lock 지연 칩은 사용자가 plan B(다음 열차)를 선택할지 결정하는 신호. 측정 인프라가 회귀하면 표면 UI에서만 보이고 사용자는 plan B 기회를 잃는다.
- **Seam D**: 13:24 trainCode 사라짐 같은 야전 회귀에서 사용자가 DebugModal에 진입해 진단 dump를 공유할 수 있어야 root cause 식별 latency가 짧아진다. 진입 경로(7-tap 카운트, testID, release flag 주입) 자체가 회귀하면 야전 진단 전체가 막힌다.
- **Seam C 보류 사유**: transfer-leg / FG-return / 명시적 event mock 설계가 현재 fixture-driven 구조에 맞지 않아 별도 인프라 PR 후로 미룸 (PR #953 README 인용).

## Files
- `scripts/fixtures/regression/seam-a-delay-chip.json` — 7-018 어린이대공원 phase 0 (arrivalSeconds=120) → phase 30s (arrivalSeconds=360)
- `scripts/fixtures/regression/seam-d-debug-entry.json` — placeholder (UI 진입 경로 검증)
- `.maestro/flows/regression/seam-a-delay-chip.yaml`
- `.maestro/flows/regression/seam-d-debug-entry.yaml`
- `.github/workflows/e2e.yml` — matrix 확장 + EXPO_PUBLIC_DEBUG_MODAL 주입
- `.maestro/flows/regression/README.md` — 시나리오 인덱스 + 로컬 실행 안내

## Test plan
- [x] `npm test` (4123/4123 passed, 100% coverage 유지)
- [x] `npm run type-check` pass
- [x] YAML/JSON 문법 검증 (`js-yaml.loadAll`, `JSON.parse`)
- [ ] nightly E2E Regression 5 cells 모두 green (cron 또는 workflow_dispatch)