### PR TITLE
chore(#987): pre-existing lint error 3건 정리

### DIFF
--- a/src/features/alarm/hooks/useBoardingLockAutoRelease.ts
+++ b/src/features/alarm/hooks/useBoardingLockAutoRelease.ts
@@ -7,7 +7,7 @@ import {
   AUTO_RELEASE_GRACE_MS,
 } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
-import { getTransferLegs } from '../../route/utils/transferLegs';
+import { getTransferLegs } from '../../../shared/utils/transferLegs';
 
 const logger = createLogger('useBoardingLockAutoRelease');
 

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -1,3 +1,10 @@
+/* eslint-disable import/no-restricted-paths --
+ * useStateRehydration은 cross-feature orchestrator로 본체에서 동일 disable 옵트인이
+ * 적용되어 있다 (src/shared/hooks/useStateRehydration.ts 헤더 주석 참조). 본 테스트는
+ * 해당 orchestrator를 검증하므로 동일 store에 대한 jest.spyOn이 필수. CLAUDE.md
+ * "본질적 cross-feature orchestrator는 파일 헤더의 eslint-disable import/no-restricted-paths
+ * 주석으로 명시 옵트인한다" 규칙에 따라 동일 옵트인 적용.
+ */
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { AppState, type AppStateStatus } from 'react-native';
 import { useStateRehydration } from '../useStateRehydration';

--- a/src/shared/utils/__tests__/transferLegs.test.ts
+++ b/src/shared/utils/__tests__/transferLegs.test.ts
@@ -3,7 +3,7 @@ import type {
   DirectRoute,
   MultiTransferRoute,
   TransferRoute,
-} from '../../../../shared/utils/stationRoute';
+} from '../stationRoute';
 
 describe('getTransferLegs', () => {
   it('null → []', () => {

--- a/src/shared/utils/transferLegs.ts
+++ b/src/shared/utils/transferLegs.ts
@@ -11,8 +11,8 @@
  *  - TransferRoute: 1개 leg.
  *  - MultiTransferRoute: transfers.length 개 leg.
  */
-import type { Route } from '../../../shared/utils/stationRoute';
-import type { LineNumber } from '../../../shared/types/station';
+import type { Route } from './stationRoute';
+import type { LineNumber } from '../types/station';
 
 export interface TransferLeg {
   /** 환승역 이름 (stations.json의 name과 일치). */


### PR DESCRIPTION
Closes #987

## 배경
최근 PR들에서 "Lint: 3 pre-existing errors (unchanged from origin/dev baseline)" 보고로 매번 스킵되어 dev baseline에 남아 있던 `import/no-restricted-paths` error 3건을 정리.

## 변경 사항

### 1) features/alarm → features/route 직접 import 해소
- `src/features/route/utils/transferLegs.ts` → `src/shared/utils/transferLegs.ts`로 이전.
- 본 유틸은 `Route`(shared) + `LineNumber`(shared) 타입만 의존하는 순수 함수 + 단순 `TransferLeg` 타입이라 shared 소속이 자연스럽다.
- `useBoardingLockAutoRelease`는 새 shared 경로로 import 변경.
- 기존 단위 테스트도 함께 이전 (`git mv` 100% rename).

### 2) shared/hooks 테스트의 features 역참조 옵트인
- `src/shared/hooks/__tests__/useStateRehydration.test.ts` 헤더에 file-level `eslint-disable import/no-restricted-paths` 주석 추가.
- 본체 `useStateRehydration.ts`는 cross-feature orchestrator로 동일 disable이 이미 적용되어 있음 (route + alarm 두 store hydrate). 단위 테스트가 동일 store를 spyOn 하는 것은 본질적이며, CLAUDE.md의 "본질적 cross-feature orchestrator는 파일 헤더의 `eslint-disable import/no-restricted-paths` 주석으로 명시 옵트인" 규칙 그대로 적용.

## 결과
- `npm run lint`: 0 error (3 → 0).
- `npm run type-check`: pass.
- `npm test`: 4123 passed, 100% coverage 유지 (`transferLegs.ts`도 100%).

## Test plan
- [x] `npm run lint` 0 error 확인
- [x] `npm run type-check` 통과
- [x] `npm test` 100% coverage 통과
- [ ] CI `Type Check & Test` green