### PR TITLE
feat(#989): F3 narrow wave 2 — motion + barometer dP/dt 결합

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStationCandidates.test.ts
@@ -301,5 +301,60 @@ describe('useStationCandidates', () => {
       expect(names).toContain('광화문');
       expect(names).toContain('종로3가');
     });
+
+    describe('wave 2(#989) — motion + barometer 신호 wire-up', () => {
+      // 본 hook은 wave 2 신호를 narrowStationsByDepthAndEta로 그대로 전달한다.
+      // 결정 로직의 GAP/TOO_WEAK 완화는 barometerState 단위 테스트에서 검증.
+      // 여기서는 입력 옵션이 결과를 깨지 않는지(회귀)와 memoization이 깨지지 않는지만 확인.
+      const BASE_INPUT = {
+        userLocation: MIDPOINT_LOC,
+        wifiStation: null,
+        maxCandidates: 5,
+        maxDistanceKm: 2,
+        absolutePressureHpa: SURFACE + 32 * DEPTH_TO_PRESSURE_HPA_PER_M,
+        surfacePressureHpa: SURFACE,
+        previousStation: SEODAEMUN_5,
+        secondsSincePrevious: 90,
+      };
+
+      it('두 신호 모두 true → 결과는 narrow 함수 결정 (회귀 없음)', () => {
+        const { result } = renderHook(() =>
+          useStationCandidates({
+            ...BASE_INPUT,
+            motionStationary: true,
+            barometerStable: true,
+          }),
+        );
+        expect(result.current.topPick?.name).toBe('광화문');
+        expect(result.current.isAutoConfirmed).toBe(true);
+      });
+
+      it('두 신호 미제공 → 결과는 narrow 함수 결정 (회귀 없음)', () => {
+        const { result } = renderHook(() => useStationCandidates(BASE_INPUT));
+        expect(result.current.topPick?.name).toBe('광화문');
+      });
+
+      it('motion만 true → narrow 함수로 전달되고 결과 일관성 유지', () => {
+        const { result } = renderHook(() =>
+          useStationCandidates({ ...BASE_INPUT, motionStationary: true }),
+        );
+        expect(result.current.topPick?.name).toBe('광화문');
+      });
+
+      it('동일 입력 rerender 시 참조 안정성 (signals deps 포함)', () => {
+        const props = {
+          ...BASE_INPUT,
+          motionStationary: true,
+          barometerStable: true,
+        };
+        const { result, rerender } = renderHook(
+          (p: typeof props) => useStationCandidates(p),
+          { initialProps: props },
+        );
+        const first = result.current;
+        rerender(props);
+        expect(result.current).toBe(first);
+      });
+    });
   });
 });

--- a/src/features/nearest-station/hooks/useStationCandidates.ts
+++ b/src/features/nearest-station/hooks/useStationCandidates.ts
@@ -40,6 +40,16 @@ export interface UseStationCandidatesInputs {
   readonly previousStation?: Station | null;
   /** 직전 확정역 통과 후 경과 시간(초). previousStation과 함께 주어져야 결합 narrow 활성. */
   readonly secondsSincePrevious?: number | null;
+  /**
+   * F3 wave 2(#989) — CMMotionActivity stationary 신호. true면 사용자가 정지 상태 →
+   * 도착역에 멈춰 있을 가능성 ↑. `barometerStable`과 결합해 결정 gap 완화.
+   */
+  readonly motionStationary?: boolean | null;
+  /**
+   * F3 wave 2(#989) — `evaluateBarometerStop().detected` 결과. 압력 변화 없음 = 같은 깊이.
+   * 한쪽만 true여도 TOO_WEAK 임계만 완화(약한 가중치).
+   */
+  readonly barometerStable?: boolean | null;
   /** 후보 최대 개수. 기본 3. */
   readonly maxCandidates?: number;
   /** GPS 후보 추출 시 반경(km). 기본 `MAX_STATION_DISTANCE_KM`(1.0). */
@@ -71,6 +81,8 @@ export function useStationCandidates(
     surfacePressureHpa = null,
     previousStation = null,
     secondsSincePrevious = null,
+    motionStationary = null,
+    barometerStable = null,
     maxCandidates = DEFAULT_MAX_CANDIDATES,
     maxDistanceKm = MAX_STATION_DISTANCE_KM,
   } = inputs;
@@ -125,6 +137,8 @@ export function useStationCandidates(
         candidates,
         previousStation,
         secondsSincePrevious,
+        motionStationary: motionStationary ?? false,
+        barometerStable: barometerStable ?? false,
       });
     }
 
@@ -140,6 +154,8 @@ export function useStationCandidates(
     surfacePressureHpa,
     previousStation,
     secondsSincePrevious,
+    motionStationary,
+    barometerStable,
     maxCandidates,
     maxDistanceKm,
   ]);

--- a/src/shared/utils/__tests__/barometerState.test.ts
+++ b/src/shared/utils/__tests__/barometerState.test.ts
@@ -393,4 +393,94 @@ describe('narrowStationsByDepthAndEta (#920 후속)', () => {
     });
     expect(result).toEqual([SEODAEMUN_5, JONGNO3GA_5]);
   });
+
+  describe('wave 2(#989) — motion + barometer 신호 결합', () => {
+    // gap fail 시나리오: elapsed 85, measured=1016.6 (광화문 depth 32m).
+    //   서대문: depthError 0, etaError 5 → score 0.167
+    //   종로3가: depthError 0.6, etaError 15 → score 1.1
+    //   gap = 0.933 < 1.0 → 기본 동작은 baseline. 0.5(reinforced) ≤ 0.933 → winner 선택.
+    const GAP_FAIL_INPUT = {
+      measuredPressureHpa: 1016.6,
+      surfacePressureHpa: SURFACE,
+      candidates: [SEODAEMUN_5, JONGNO3GA_5] as const,
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 85,
+    };
+
+    it('두 신호 모두 true → gap 완화로 winner 선택', () => {
+      const result = narrowStationsByDepthAndEta({
+        ...GAP_FAIL_INPUT,
+        candidates: [...GAP_FAIL_INPUT.candidates],
+        motionStationary: true,
+        barometerStable: true,
+      });
+      expect(result).toEqual([SEODAEMUN_5]);
+    });
+
+    it('motion만 true → gap 임계는 기본 → baseline 그대로 (반쪽 신호)', () => {
+      const result = narrowStationsByDepthAndEta({
+        ...GAP_FAIL_INPUT,
+        candidates: [...GAP_FAIL_INPUT.candidates],
+        motionStationary: true,
+        barometerStable: false,
+      });
+      expect(result).toEqual([SEODAEMUN_5, JONGNO3GA_5]);
+    });
+
+    it('barometer만 true → gap 임계는 기본 → baseline 그대로 (반쪽 신호)', () => {
+      const result = narrowStationsByDepthAndEta({
+        ...GAP_FAIL_INPUT,
+        candidates: [...GAP_FAIL_INPUT.candidates],
+        motionStationary: false,
+        barometerStable: true,
+      });
+      expect(result).toEqual([SEODAEMUN_5, JONGNO3GA_5]);
+    });
+
+    it('두 신호 모두 false/미제공 → 기본 동작 (회귀 검사)', () => {
+      const result = narrowStationsByDepthAndEta({
+        ...GAP_FAIL_INPUT,
+        candidates: [...GAP_FAIL_INPUT.candidates],
+      });
+      expect(result).toEqual([SEODAEMUN_5, JONGNO3GA_5]);
+    });
+
+    // TOO_WEAK 시나리오: 평가 가능한 후보 1개(종로3가), depthError 2.3 → score 2.3.
+    //   기본 TOO_WEAK=2.0 → fallback. anyReinforced=3.0 → 2.3 < 3.0 → 종로3가 단일 반환.
+    const TOO_WEAK_INPUT = {
+      measuredPressureHpa: 1019.5, // 종로3가 expected 1017.2 → depthError 2.3
+      surfacePressureHpa: SURFACE,
+      candidates: [JONGNO3GA_5, SEOLLEUNG_2] as const,
+      previousStation: GWANGHWAMUN_5,
+      secondsSincePrevious: 100,
+    };
+
+    it('TOO_WEAK 경계 + motion만 true → TOO_WEAK 완화로 winner 선택', () => {
+      const result = narrowStationsByDepthAndEta({
+        ...TOO_WEAK_INPUT,
+        candidates: [...TOO_WEAK_INPUT.candidates],
+        motionStationary: true,
+      });
+      expect(result).toEqual([JONGNO3GA_5]);
+    });
+
+    it('TOO_WEAK 경계 + barometer만 true → TOO_WEAK 완화로 winner 선택', () => {
+      const result = narrowStationsByDepthAndEta({
+        ...TOO_WEAK_INPUT,
+        candidates: [...TOO_WEAK_INPUT.candidates],
+        barometerStable: true,
+      });
+      expect(result).toEqual([JONGNO3GA_5]);
+    });
+
+    it('TOO_WEAK 경계 + 둘 다 false → 기본 TOO_WEAK 적용 (회귀)', () => {
+      const result = narrowStationsByDepthAndEta({
+        ...TOO_WEAK_INPUT,
+        candidates: [...TOO_WEAK_INPUT.candidates],
+        motionStationary: false,
+        barometerStable: false,
+      });
+      expect(result).toEqual([JONGNO3GA_5, SEOLLEUNG_2]);
+    });
+  });
 });

--- a/src/shared/utils/barometerState.ts
+++ b/src/shared/utils/barometerState.ts
@@ -175,9 +175,33 @@ export interface DepthEtaNarrowInput {
   readonly secondsSincePrevious: number;
   readonly toleranceHpa?: number;
   readonly etaToleranceSec?: number;
+  /**
+   * #920 wave 2 — 사용자 정지 신호(CMMotionActivity). true면 도착역에 멈춰 있을 가능성 ↑.
+   * `barometerStable`과 함께 true일 때 결정 gap을 완화해 winner 선택을 허용한다.
+   * 미제공/false이면 기존 동작.
+   */
+  readonly motionStationary?: boolean;
+  /**
+   * #920 wave 2 — 기압 변화 없음 신호(`evaluateBarometerStop` detected).
+   * true면 압력이 안정 → 같은 깊이에 머무름(정차 후보). motion과 결합 시 결정 gap 완화.
+   * 한쪽만 true면 TOO_WEAK만 완화(약한 가중치), 둘 다 true면 GAP+TOO_WEAK 모두 완화.
+   */
+  readonly barometerStable?: boolean;
 }
 
 const DEPTH_ETA_DECISIVE_GAP = 1.0;
+/**
+ * #920 wave 2 — motion+barometer 두 신호 모두 true일 때 적용하는 완화 gap.
+ * 1.0 → 0.5. winner와 runner-up이 가깝게 붙어 baseline fallback되던 케이스에서 winner 선택 허용.
+ * 0.5는 점수 단위계(depthError/tolerance + etaError/tolerance) 절반 — 한 차원이 명확히 갈리면 충분.
+ */
+const DEPTH_ETA_DECISIVE_GAP_REINFORCED = 0.5;
+const DEPTH_ETA_TOO_WEAK = 2.0;
+/**
+ * #920 wave 2 — motion 또는 barometer 한 신호라도 true일 때 적용하는 완화 TOO_WEAK.
+ * 2.0 → 3.0. 측정 잡음으로 점수가 약간 높아져도 winner 선택 허용. 둘 다 false/미제공이면 기본값.
+ */
+const DEPTH_ETA_TOO_WEAK_REINFORCED = 3.0;
 
 export function narrowStationsByDepthAndEta(
   input: DepthEtaNarrowInput,
@@ -190,6 +214,8 @@ export function narrowStationsByDepthAndEta(
     secondsSincePrevious,
     toleranceHpa = BAROMETER_ABS_TOLERANCE_HPA,
     etaToleranceSec = BAROMETER_ETA_TOLERANCE_SEC,
+    motionStationary = false,
+    barometerStable = false,
   } = input;
 
   if (candidates.length <= 1) return [...candidates];
@@ -220,16 +246,25 @@ export function narrowStationsByDepthAndEta(
   if (scored.length === 0) return [...candidates];
   scored.sort((a, b) => a.score - b.score);
 
+  // #920 wave 2 — 신호 강도에 따라 임계 완화:
+  //   - 둘 다 true(정지+압력 안정) = 도착역 근거 강함 → GAP + TOO_WEAK 모두 완화
+  //   - 한쪽만 true = 부분 신호 → TOO_WEAK만 완화 (약한 가중치)
+  //   - 둘 다 false/미제공 = 기존 동작 (회귀 X)
+  const bothReinforced = motionStationary && barometerStable;
+  const anyReinforced = motionStationary || barometerStable;
+  const tooWeak = anyReinforced ? DEPTH_ETA_TOO_WEAK_REINFORCED : DEPTH_ETA_TOO_WEAK;
+  const decisiveGap = bothReinforced
+    ? DEPTH_ETA_DECISIVE_GAP_REINFORCED
+    : DEPTH_ETA_DECISIVE_GAP;
+
   // 평가 가능한 후보가 단 1개라도 점수가 형편없으면 baseline로 fallback.
-  // 환산 점수 2.0은 "depthError가 tolerance와 같고 etaError가 tolerance와 같음" → 신호 의미 없음.
-  const TOO_WEAK = 2.0;
-  if (scored[0].score > TOO_WEAK) return [...candidates];
+  if (scored[0].score > tooWeak) return [...candidates];
 
   // 평가 가능한 후보가 1개뿐 → 그 후보를 반환 (다른 후보는 신호 결정 불가).
   if (scored.length === 1) return [scored[0].station];
 
   // 2개 이상 — winner가 runner-up과 충분히 갈리면 winner만, 아니면 baseline.
   const gap = scored[1].score - scored[0].score;
-  if (gap >= DEPTH_ETA_DECISIVE_GAP) return [scored[0].station];
+  if (gap >= decisiveGap) return [scored[0].station];
   return [...candidates];
 }


### PR DESCRIPTION
Closes #989 (Epic #912 P2 F3 wave 2). PR #932(depth baseline) + PR #959(depth+ETA) 위에 motion + barometer 변화율 신호를 결합해 narrow 정확도를 추가로 끌어올린다.

## Summary
- `narrowStationsByDepthAndEta`에 옵셔널 `motionStationary` / `barometerStable` 입력 추가.
- **scoring 공식**: `score = depthError / toleranceHpa + etaError / etaToleranceSec` (기존 동일).
- **임계 완화 규칙**:
  - 둘 다 true → `DEPTH_ETA_DECISIVE_GAP` 1.0 → 0.5 (정지 + 압력 안정 = 도착역 후보 강함)
  - 한쪽만 true → `DEPTH_ETA_TOO_WEAK` 2.0 → 3.0 (반쪽 신호 = 측정 잡음만 흡수)
  - 둘 다 false/미제공 → 기존 동작 (회귀 X)
- 인라인 `const TOO_WEAK = 2.0` 매직 넘버를 모듈 상수로 분리(`DEPTH_ETA_TOO_WEAK`).
- `useStationCandidates`에 두 입력 옵셔널 추가 → narrow 함수에 forward + memo deps 갱신.

## 진입점
- `src/shared/utils/barometerState.ts` — narrow 함수 + 상수
- `src/features/nearest-station/hooks/useStationCandidates.ts` — wire-up

## Test plan
- [x] `narrowStationsByDepthAndEta` 추가 7건 — gap 완화(둘 다 true → winner / 한쪽만 → baseline / 둘 다 false → baseline), TOO_WEAK 완화(motion / barometer 단독 → winner / 둘 다 false → baseline)
- [x] `useStationCandidates` 추가 4건 — wire-up 회귀 / motion-only forward / memo 참조 안정성
- [x] 기존 50+ 테스트 모두 PASS (회귀 X)
- [x] 100% coverage (lines / functions / branches / statements)
- [x] `npm run type-check` pass
- [ ] 실기기 검증 (별도 측정 세션)

## Follow-up
- HomeScreen + `useCurrentStationConfirmModal`에 motion/barometer 신호 주입 wire-up — 별도 PR (현재는 caller가 주입하지 않음 → 기존 동작 유지)

Refs #920 #912