### PR TITLE
feat(#986): 사전 예약 miss trip 자동 진단 컨텍스트 첨부

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1466,6 +1466,50 @@ describe('POST /telemetry/prescheduled (#918 A3)', () => {
     stationAccurateCount: 3,
     fireDeltaSamplesMs: [10, -5, 0, 100],
   });
+
+  // #986 — missContext optional 첨부.
+  it('accepts missContext and returns ok (Logpush로 보존)', async () => {
+    const env = makeEnv();
+    const res = await post(
+      '/telemetry/prescheduled',
+      {
+        token: 'aabbccdd11223344',
+        tripStart: 1_000,
+        tripEnd: 2_000,
+        scheduledCount: 5,
+        firedCount: 4,
+        stationAccurateCount: 3,
+        fireDeltaSamplesMs: [10, -5, 0, 100],
+        missContext: {
+          lockedTrainCode: '5050',
+          lockedAt: 999,
+          missedIdentifiers: ['tba:early:강남'],
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('rejects malformed missContext (400)', async () => {
+    const env = makeEnv();
+    const res = await post(
+      '/telemetry/prescheduled',
+      {
+        token: 'aabbccdd11223344',
+        tripStart: 1_000,
+        tripEnd: 2_000,
+        scheduledCount: 5,
+        firedCount: 4,
+        stationAccurateCount: 3,
+        fireDeltaSamplesMs: [10, -5, 0, 100],
+        missContext: { lockedAt: 'not-a-number' },
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
 });
 
 describe('GET /metrics/recall/summary (#919 후속)', () => {

--- a/backend/alarm-worker/src/__tests__/prescheduledTelemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/prescheduledTelemetry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   recordPrescheduledUpload,
+  validateMissContext,
   validatePrescheduledUpload,
   type PrescheduledUpload,
 } from '../prescheduledTelemetry';
@@ -222,5 +223,157 @@ describe('catalog SSOT', () => {
     expect(METRIC_KIND.PRESCHEDULED_FIRE_MISS_RATE).toBe('prescheduledFireMissRate');
     expect(METRIC_KIND.PRESCHEDULED_STATION_ACCURACY).toBe('prescheduledStationAccuracy');
     expect(METRIC_KIND.PRESCHEDULED_FIRE_DELTA_MS).toBe('prescheduledFireDeltaMs');
+  });
+});
+
+// #986 — missContext validation.
+describe('validateMissContext', () => {
+  it('undefined → undefined (skip 처리)', () => {
+    expect(validateMissContext(undefined)).toBeUndefined();
+  });
+
+  it.each([null, 'x', 123, []])('non-object %p → null', (v) => {
+    expect(validateMissContext(v)).toBeNull();
+  });
+
+  it('빈 객체 → 빈 MissContext', () => {
+    expect(validateMissContext({})).toEqual({});
+  });
+
+  it('정상 필드 전부 → 통과', () => {
+    const ctx = {
+      lockedTrainCode: '5050',
+      lockedAt: 1_000,
+      lastSilentPushReceived: { sentAt: 900, receivedAt: 1_000, stationName: '강남' },
+      lastScheduledStamp: {
+        selectedArrivalSeconds: 60,
+        expectedStationAtFire: '강남',
+        actualLastNotifiedStation: '역삼',
+      },
+      missedIdentifiers: ['tba:early:강남', 'tba:imminent:역삼'],
+    };
+    expect(validateMissContext(ctx)).toEqual(ctx);
+  });
+
+  it.each([
+    ['lockedTrainCode', 123],
+    ['lockedTrainCode', ''],
+    ['lockedAt', 'x'],
+    ['lockedAt', Number.NaN],
+  ])('reject invalid %s (%p)', (field, value) => {
+    expect(validateMissContext({ [field]: value })).toBeNull();
+  });
+
+  it('lockedTrainCode 길이 상한 초과 → reject', () => {
+    expect(validateMissContext({ lockedTrainCode: 'x'.repeat(201) })).toBeNull();
+  });
+
+  it('lastSilentPushReceived: receivedAt 누락 → reject', () => {
+    expect(validateMissContext({ lastSilentPushReceived: { sentAt: 1 } })).toBeNull();
+  });
+
+  it('lastSilentPushReceived: sentAt 비유한 → reject', () => {
+    expect(
+      validateMissContext({ lastSilentPushReceived: { receivedAt: 1, sentAt: Number.NaN } }),
+    ).toBeNull();
+  });
+
+  it('lastSilentPushReceived: stationName 빈문자 → reject', () => {
+    expect(
+      validateMissContext({ lastSilentPushReceived: { receivedAt: 1, stationName: '' } }),
+    ).toBeNull();
+  });
+
+  it('lastSilentPushReceived: receivedAt만 있으면 통과', () => {
+    expect(
+      validateMissContext({ lastSilentPushReceived: { receivedAt: 100 } }),
+    ).toEqual({ lastSilentPushReceived: { receivedAt: 100 } });
+  });
+
+  it.each([null, 'x', 123])('lastSilentPushReceived non-object %p → reject', (v) => {
+    expect(validateMissContext({ lastSilentPushReceived: v })).toBeNull();
+  });
+
+  it('lastScheduledStamp: 모든 필드 optional, 부분만 있어도 통과', () => {
+    expect(
+      validateMissContext({ lastScheduledStamp: { selectedArrivalSeconds: 45 } }),
+    ).toEqual({ lastScheduledStamp: { selectedArrivalSeconds: 45 } });
+  });
+
+  it.each([
+    ['selectedArrivalSeconds', Number.NaN],
+    ['selectedArrivalSeconds', 'x'],
+    ['expectedStationAtFire', 123],
+    ['expectedStationAtFire', ''],
+    ['actualLastNotifiedStation', 123],
+  ])('lastScheduledStamp invalid %s (%p) → reject', (field, value) => {
+    expect(
+      validateMissContext({ lastScheduledStamp: { [field]: value } }),
+    ).toBeNull();
+  });
+
+  it.each([null, 'x', 123])('lastScheduledStamp non-object %p → reject', (v) => {
+    expect(validateMissContext({ lastScheduledStamp: v })).toBeNull();
+  });
+
+  it('missedIdentifiers: 비배열 → reject', () => {
+    expect(validateMissContext({ missedIdentifiers: 'x' })).toBeNull();
+  });
+
+  it('missedIdentifiers: 상한(200) 초과 → reject', () => {
+    const ids = Array.from({ length: 201 }, (_, i) => `tba:early:S${i}`);
+    expect(validateMissContext({ missedIdentifiers: ids })).toBeNull();
+  });
+
+  it('missedIdentifiers: 비문자 entry → reject', () => {
+    expect(validateMissContext({ missedIdentifiers: ['tba:x:A', 1] })).toBeNull();
+  });
+
+  it('missedIdentifiers: 길이 상한 초과 entry → reject', () => {
+    expect(
+      validateMissContext({ missedIdentifiers: ['tba:x:A', 'y'.repeat(201)] }),
+    ).toBeNull();
+  });
+
+  it('missedIdentifiers: 빈 문자열 entry → reject', () => {
+    expect(validateMissContext({ missedIdentifiers: [''] })).toBeNull();
+  });
+
+  it('missedIdentifiers: 빈 배열 → 통과', () => {
+    expect(validateMissContext({ missedIdentifiers: [] })).toEqual({
+      missedIdentifiers: [],
+    });
+  });
+});
+
+// #986 — payload integration.
+describe('validatePrescheduledUpload with missContext', () => {
+  it('missContext 부재 시 payload에 missContext 키 없음', () => {
+    const out = validatePrescheduledUpload(base());
+    expect(out).not.toBeNull();
+    expect(out!.missContext).toBeUndefined();
+  });
+
+  it('정상 missContext 시 payload에 포함', () => {
+    const out = validatePrescheduledUpload({
+      ...base(),
+      missContext: {
+        lockedTrainCode: '5050',
+        lockedAt: 50,
+        missedIdentifiers: ['tba:early:강남'],
+      },
+    });
+    expect(out).not.toBeNull();
+    expect(out!.missContext).toEqual({
+      lockedTrainCode: '5050',
+      lockedAt: 50,
+      missedIdentifiers: ['tba:early:강남'],
+    });
+  });
+
+  it('깨진 missContext는 전체 payload reject', () => {
+    expect(
+      validatePrescheduledUpload({ ...base(), missContext: { lockedAt: 'x' } }),
+    ).toBeNull();
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -297,6 +297,9 @@ app.post('/telemetry/prescheduled', async (c) => {
       stationAccurateCount: payload.stationAccurateCount,
       deltaSamples: payload.fireDeltaSamplesMs.length,
       sink: writer ? 'ae' : 'none',
+      // #986 — miss trip 진단 컨텍스트. 없으면 omit (JSON.stringify가 undefined 자동 제거).
+      // Logpush로 사후 root cause 분석 (AE blob에는 미적재 — free-form/PII 회피).
+      missContext: payload.missContext,
     }),
   );
   return c.json({ ok: true });

--- a/backend/alarm-worker/src/prescheduledTelemetry.ts
+++ b/backend/alarm-worker/src/prescheduledTelemetry.ts
@@ -26,6 +26,26 @@ import {
 import type { AnalyticsEngineWriter } from './types';
 
 /**
+ * Trip-end 진단 컨텍스트 (#986). 모든 필드 optional — 신호 없으면 생략.
+ * client `prescheduledMissContext.PrescheduledMissContext` 와 동형. validation 동기 갱신.
+ */
+export interface MissContext {
+  lockedTrainCode?: string;
+  lockedAt?: number;
+  lastSilentPushReceived?: {
+    sentAt?: number;
+    receivedAt: number;
+    stationName?: string;
+  };
+  lastScheduledStamp?: {
+    selectedArrivalSeconds?: number;
+    expectedStationAtFire?: string;
+    actualLastNotifiedStation?: string;
+  };
+  missedIdentifiers?: readonly string[];
+}
+
+/**
  * client → backend upload payload.
  *   client `uploadPrescheduledTelemetry`(api/telemetryBackend.ts)와 동일 schema.
  */
@@ -44,6 +64,8 @@ export interface PrescheduledUpload {
   stationAccurateCount: number;
   /** actualFireMs - scheduledFireMs 차이 sample. fired entry당 1건. */
   fireDeltaSamplesMs: readonly number[];
+  /** miss 발생 trip 진단 컨텍스트 (#986). 없으면 생략. */
+  missContext?: MissContext;
 }
 
 function isNonNegativeInt(v: unknown): v is number {
@@ -68,6 +90,102 @@ function parseDeltaSamples(raw: unknown): number[] | null {
   return out;
 }
 
+/** missContext.missedIdentifiers 길이 상한. trip 1건의 사전 예약은 최대 ~80건이라 여유. */
+const MAX_MISSED_IDENTIFIERS = 200;
+/** identifier/stationName 문자열 길이 상한 — 비정상 입력 안전망. */
+const MAX_STRING_LEN = 200;
+
+function isShortString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0 && v.length <= MAX_STRING_LEN;
+}
+
+function parseLastSilentPushReceived(
+  raw: unknown,
+): NonNullable<MissContext['lastSilentPushReceived']> | null | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  if (!isFiniteNumber(obj.receivedAt)) return null;
+  const out: NonNullable<MissContext['lastSilentPushReceived']> = { receivedAt: obj.receivedAt };
+  if (obj.sentAt !== undefined) {
+    if (!isFiniteNumber(obj.sentAt)) return null;
+    out.sentAt = obj.sentAt;
+  }
+  if (obj.stationName !== undefined) {
+    if (!isShortString(obj.stationName)) return null;
+    out.stationName = obj.stationName;
+  }
+  return out;
+}
+
+function parseLastScheduledStamp(
+  raw: unknown,
+): NonNullable<MissContext['lastScheduledStamp']> | null | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const out: NonNullable<MissContext['lastScheduledStamp']> = {};
+  if (obj.selectedArrivalSeconds !== undefined) {
+    if (!isFiniteNumber(obj.selectedArrivalSeconds)) return null;
+    out.selectedArrivalSeconds = obj.selectedArrivalSeconds;
+  }
+  if (obj.expectedStationAtFire !== undefined) {
+    if (!isShortString(obj.expectedStationAtFire)) return null;
+    out.expectedStationAtFire = obj.expectedStationAtFire;
+  }
+  if (obj.actualLastNotifiedStation !== undefined) {
+    if (!isShortString(obj.actualLastNotifiedStation)) return null;
+    out.actualLastNotifiedStation = obj.actualLastNotifiedStation;
+  }
+  return out;
+}
+
+function parseMissedIdentifiers(raw: unknown): string[] | null | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) return null;
+  if (raw.length > MAX_MISSED_IDENTIFIERS) return null;
+  const out: string[] = [];
+  for (const v of raw) {
+    if (!isShortString(v)) return null;
+    out.push(v);
+  }
+  return out;
+}
+
+/**
+ * `missContext` 검증 (#986). 부재(undefined) 시 호출자 통과. 한 필드라도 깨졌으면 null —
+ * caller는 전체 payload 400으로 처리해 client bug를 빨리 노출.
+ */
+export function validateMissContext(raw: unknown): MissContext | null | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const out: MissContext = {};
+
+  if (obj.lockedTrainCode !== undefined) {
+    if (!isShortString(obj.lockedTrainCode)) return null;
+    out.lockedTrainCode = obj.lockedTrainCode;
+  }
+  if (obj.lockedAt !== undefined) {
+    if (!isFiniteNumber(obj.lockedAt)) return null;
+    out.lockedAt = obj.lockedAt;
+  }
+
+  const silent = parseLastSilentPushReceived(obj.lastSilentPushReceived);
+  if (silent === null) return null;
+  if (silent !== undefined) out.lastSilentPushReceived = silent;
+
+  const stamp = parseLastScheduledStamp(obj.lastScheduledStamp);
+  if (stamp === null) return null;
+  if (stamp !== undefined) out.lastScheduledStamp = stamp;
+
+  const missed = parseMissedIdentifiers(obj.missedIdentifiers);
+  if (missed === null) return null;
+  if (missed !== undefined) out.missedIdentifiers = missed;
+
+  return out;
+}
+
 /**
  * payload 검증. 한 필드라도 깨졌으면 null — caller는 400.
  *
@@ -77,6 +195,7 @@ function parseDeltaSamples(raw: unknown): number[] | null {
  *   - scheduledCount/firedCount/stationAccurateCount는 자연수
  *   - firedCount <= scheduledCount, stationAccurateCount <= firedCount
  *   - fireDeltaSamplesMs는 유한수 배열, 길이는 firedCount와 일치(불일치=client bug, reject)
+ *   - missContext (#986)는 optional — 존재 시 shape 강제, 깨졌으면 reject
  */
 export function validatePrescheduledUpload(input: unknown): PrescheduledUpload | null {
   if (!input || typeof input !== 'object') return null;
@@ -94,7 +213,10 @@ export function validatePrescheduledUpload(input: unknown): PrescheduledUpload |
   if (samples === null) return null;
   if (samples.length !== obj.firedCount) return null;
 
-  return {
+  const missContext = validateMissContext(obj.missContext);
+  if (missContext === null) return null;
+
+  const payload: PrescheduledUpload = {
     token: obj.token,
     tripStart: obj.tripStart,
     tripEnd: obj.tripEnd,
@@ -103,6 +225,8 @@ export function validatePrescheduledUpload(input: unknown): PrescheduledUpload |
     stationAccurateCount: obj.stationAccurateCount,
     fireDeltaSamplesMs: samples,
   };
+  if (missContext !== undefined) payload.missContext = missContext;
+  return payload;
 }
 
 /**

--- a/src/features/alarm/api/__tests__/telemetryBackend.test.ts
+++ b/src/features/alarm/api/__tests__/telemetryBackend.test.ts
@@ -219,4 +219,28 @@ describe('uploadPrescheduledTelemetry', () => {
     const result = await uploadPrescheduledTelemetry('tok', PRESCHEDULED_PAYLOAD);
     expect(result).toEqual({ ok: false });
   });
+
+  // #986 — missContext optional 인자.
+  it('missContext 미전달 시 body에 missContext 필드 미포함', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    await uploadPrescheduledTelemetry('tok', PRESCHEDULED_PAYLOAD);
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect('missContext' in body).toBe(false);
+  });
+
+  it('missContext 전달 시 body에 그대로 포함', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    const missContext = {
+      lockedTrainCode: '5050',
+      lockedAt: 50,
+      missedIdentifiers: ['tba:early:강남'],
+    };
+    await uploadPrescheduledTelemetry('tok', PRESCHEDULED_PAYLOAD, missContext);
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.missContext).toEqual(missContext);
+  });
 });

--- a/src/features/alarm/api/telemetryBackend.ts
+++ b/src/features/alarm/api/telemetryBackend.ts
@@ -8,6 +8,7 @@
 import type { SilentPushTelemetryPayload } from '../utils/telemetryAggregation';
 import type { TripRecallResult } from '../utils/recallMetrics';
 import type { PrescheduledMetricsResult } from '../utils/prescheduledMetrics';
+import type { PrescheduledMissContext } from '../utils/prescheduledMissContext';
 import { createLogger } from '../../../shared/utils/logger';
 
 const log = createLogger('telemetryBackend');
@@ -131,10 +132,14 @@ export async function uploadRecallTelemetry(
  * A3 사전 예약 효과 텔레메트리 1건을 backend `/telemetry/prescheduled`로 upload (#918, Epic #912 P1).
  *
  * recall과 같은 graceful 정책 — URL/token 부재 시 skipped, fetch 실패 시 ok=false. throw 안 함.
+ *
+ * #986 — caller가 miss 발생 trip에서 derive한 `missContext`를 선택적으로 첨부.
+ * undefined면 body에 포함하지 않아 기존 backend 호환 유지.
  */
 export async function uploadPrescheduledTelemetry(
   token: string,
   metrics: PrescheduledMetricsResult,
+  missContext?: PrescheduledMissContext,
 ): Promise<TelemetryUploadResult> {
   const base = getBackendUrl();
   if (!base) {
@@ -145,7 +150,7 @@ export async function uploadPrescheduledTelemetry(
     return { ok: false, skipped: true };
   }
 
-  const body = {
+  const body: Record<string, unknown> = {
     token,
     tripStart: metrics.tripStart,
     tripEnd: metrics.tripEnd,
@@ -154,6 +159,9 @@ export async function uploadPrescheduledTelemetry(
     stationAccurateCount: metrics.stationAccurateCount,
     fireDeltaSamplesMs: metrics.fireDeltaSamplesMs,
   };
+  if (missContext !== undefined) {
+    body.missContext = missContext;
+  }
 
   try {
     const res = await fetchWithTimeout(`${base}/telemetry/prescheduled`, {

--- a/src/features/alarm/utils/__tests__/alarmLogTelemetry.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLogTelemetry.test.ts
@@ -9,6 +9,9 @@ const mockUploadRecallTelemetry = jest.fn();
 const mockUploadPrescheduledTelemetry = jest.fn();
 const mockGetItem = jest.fn();
 const mockComputePrescheduledMetrics = jest.fn();
+const mockReadPrescheduledLedger = jest.fn();
+const mockGetBoardingLock = jest.fn();
+const mockCollectMissContext = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -30,6 +33,16 @@ jest.mock('../../api/telemetryBackend', () => ({
 jest.mock('../prescheduledMetrics', () => ({
   computePrescheduledMetrics: (...args: unknown[]) => mockComputePrescheduledMetrics(...args),
   isEmptyPrescheduledMetrics: (m: { scheduledCount: number }) => m.scheduledCount === 0,
+  readPrescheduledLedger: (...args: unknown[]) => mockReadPrescheduledLedger(...args),
+}));
+
+jest.mock('../boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+}));
+
+jest.mock('../prescheduledMissContext', () => ({
+  collectMissContext: (...args: unknown[]) => mockCollectMissContext(...args),
+  isEmptyMissContext: (ctx: Record<string, unknown>) => Object.keys(ctx).length === 0,
 }));
 
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -171,6 +184,9 @@ describe('computeAndUploadTripPrescheduled', () => {
     mockUploadPrescheduledTelemetry.mockReset();
     mockGetItem.mockReset();
     mockComputePrescheduledMetrics.mockReset();
+    mockReadPrescheduledLedger.mockReset().mockResolvedValue([]);
+    mockGetBoardingLock.mockReset().mockResolvedValue(null);
+    mockCollectMissContext.mockReset().mockReturnValue({});
   });
 
   it('APNs token 없으면 upload 호출 안 함 (graceful skip)', async () => {
@@ -345,5 +361,115 @@ describe('computeAndUploadTripPrescheduled', () => {
     const callArg = mockComputePrescheduledMetrics.mock.calls[0][0];
     expect(callArg.tripEnd).toBe(NOW);
     (Date.now as jest.Mock).mockRestore();
+  });
+
+  // #986 — missContext 첨부 분기.
+  it('miss 없음(scheduled=fired)이면 missContext 수집 안 함', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: 1000,
+      scheduledCount: 3,
+      firedCount: 3,
+      stationAccurateCount: 3,
+      fireDeltaSamplesMs: [1, 2, 3],
+    });
+    mockUploadPrescheduledTelemetry.mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0, tripEnd: 1000 });
+
+    expect(mockReadPrescheduledLedger).not.toHaveBeenCalled();
+    expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    expect(mockCollectMissContext).not.toHaveBeenCalled();
+    const [, , passedContext] = mockUploadPrescheduledTelemetry.mock.calls[0];
+    expect(passedContext).toBeUndefined();
+    expect(result.missContext).toBeUndefined();
+  });
+
+  it('miss 발생(scheduled>fired) + collectMissContext 결과 비어있으면 missContext 미첨부', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: 1000,
+      scheduledCount: 3,
+      firedCount: 1,
+      stationAccurateCount: 1,
+      fireDeltaSamplesMs: [10],
+    });
+    mockCollectMissContext.mockReturnValue({}); // 빈 context — 가드로 미첨부
+    mockUploadPrescheduledTelemetry.mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0, tripEnd: 1000 });
+
+    expect(mockReadPrescheduledLedger).toHaveBeenCalledTimes(1);
+    expect(mockGetBoardingLock).toHaveBeenCalledTimes(1);
+    expect(mockCollectMissContext).toHaveBeenCalledTimes(1);
+    const [, , passedContext] = mockUploadPrescheduledTelemetry.mock.calls[0];
+    expect(passedContext).toBeUndefined();
+    expect(result.missContext).toBeUndefined();
+  });
+
+  it('miss 발생 + collectMissContext 결과 비어있지 않으면 upload payload에 첨부', async () => {
+    mockGetItem.mockResolvedValue('apns-token');
+    mockGetAlarmLog.mockResolvedValue([
+      fixedEntry({
+        ts: 100,
+        source: 'silent-push-received',
+        outcome: 'received',
+        receivedAt: 100,
+        stationName: '강남',
+      }),
+    ]);
+    mockGetBoardingLock.mockResolvedValue({
+      destinationId: 'd',
+      trainCode: '5050',
+      boardingStationId: 'A',
+      boardingLine: '2',
+      boardedAt: 50,
+      expectedDurationMs: 600_000,
+    });
+    mockReadPrescheduledLedger.mockResolvedValue([
+      { identifier: 'tba:early:강남', scheduledFireMs: 500 },
+    ]);
+    mockComputePrescheduledMetrics.mockResolvedValue({
+      tripStart: 0,
+      tripEnd: 1000,
+      scheduledCount: 3,
+      firedCount: 1,
+      stationAccurateCount: 1,
+      fireDeltaSamplesMs: [10],
+    });
+    const expectedContext = {
+      lockedTrainCode: '5050',
+      lockedAt: 50,
+      missedIdentifiers: ['tba:early:강남'],
+    };
+    mockCollectMissContext.mockReturnValue(expectedContext);
+    mockUploadPrescheduledTelemetry.mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await computeAndUploadTripPrescheduled({ tripStart: 0, tripEnd: 1000 });
+
+    const [, , passedContext] = mockUploadPrescheduledTelemetry.mock.calls[0];
+    expect(passedContext).toEqual(expectedContext);
+    expect(result.missContext).toEqual(expectedContext);
+
+    // collectMissContext 호출 인자 검증 — alarmLog/lock/ledger 전달
+    const collectArg = mockCollectMissContext.mock.calls[0][0];
+    expect(collectArg.tripStart).toBe(0);
+    expect(collectArg.tripEnd).toBe(1000);
+    expect(collectArg.boardingLock).toEqual({
+      destinationId: 'd',
+      trainCode: '5050',
+      boardingStationId: 'A',
+      boardingLine: '2',
+      boardedAt: 50,
+      expectedDurationMs: 600_000,
+    });
+    expect(collectArg.ledger).toEqual([
+      { identifier: 'tba:early:강남', scheduledFireMs: 500 },
+    ]);
+    expect(collectArg.alarmLogEntries).toHaveLength(1);
   });
 });

--- a/src/features/alarm/utils/__tests__/prescheduledMissContext.test.ts
+++ b/src/features/alarm/utils/__tests__/prescheduledMissContext.test.ts
@@ -1,0 +1,390 @@
+/**
+ * 사전 예약 miss trip 자동 진단 컨텍스트 (#986).
+ *
+ * collectMissContext의 derive 로직 검증:
+ *   - BoardingLock → lockedTrainCode/lockedAt
+ *   - alarmLog silent-push-received → 마지막 entry 채택
+ *   - alarmLog bg-scheduled fired → 마지막 stamp entry 채택 (stamp 전부 비어있으면 skip)
+ *   - ledger → actualFireMs 미기록 identifier 목록
+ *   - 윈도우 범위 외 entry 제외
+ *   - isEmptyMissContext 가드
+ */
+
+import type { AlarmLogEntry } from '../alarmLog';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { PrescheduledLedgerEntry } from '../prescheduledMetrics';
+import { collectMissContext, isEmptyMissContext } from '../prescheduledMissContext';
+
+function lock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: 'dest',
+    trainCode: '5001',
+    boardingStationId: 'A',
+    boardingLine: '2',
+    boardedAt: 1_000,
+    expectedDurationMs: 600_000,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<AlarmLogEntry>): AlarmLogEntry {
+  return {
+    ts: 1_500,
+    source: 'fg',
+    outcome: 'fired',
+    ...overrides,
+  };
+}
+
+describe('collectMissContext', () => {
+  it('BoardingLock 존재 시 lockedTrainCode/lockedAt 채움', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [],
+      boardingLock: lock({ trainCode: '5050', boardedAt: 1_234 }),
+      ledger: [],
+    });
+    expect(out.lockedTrainCode).toBe('5050');
+    expect(out.lockedAt).toBe(1_234);
+  });
+
+  it('lock.trainCode 빈문자열이면 lockedTrainCode 미생성 (저장소 손상 가드)', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [],
+      boardingLock: lock({ trainCode: '', boardedAt: 1_000 }),
+      ledger: [],
+    });
+    expect(out.lockedTrainCode).toBeUndefined();
+    expect(out.lockedAt).toBe(1_000);
+  });
+
+  it('lock.boardedAt 비유한이면 lockedAt 미생성', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [],
+      boardingLock: lock({ trainCode: '5050', boardedAt: Number.NaN }),
+      ledger: [],
+    });
+    expect(out.lockedTrainCode).toBe('5050');
+    expect(out.lockedAt).toBeUndefined();
+  });
+
+  it('lock=null이면 train/lockedAt 미생성', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lockedTrainCode).toBeUndefined();
+    expect(out.lockedAt).toBeUndefined();
+  });
+
+  it('윈도우 안 가장 최근 silent-push-received entry 채택', () => {
+    const out = collectMissContext({
+      tripStart: 1_000,
+      tripEnd: 5_000,
+      alarmLogEntries: [
+        entry({
+          ts: 2_000,
+          source: 'silent-push-received',
+          outcome: 'received',
+          sentAt: 1_900,
+          receivedAt: 2_000,
+          stationName: '강남',
+        }),
+        entry({
+          ts: 4_000,
+          source: 'silent-push-received',
+          outcome: 'received',
+          sentAt: 3_900,
+          receivedAt: 4_000,
+          stationName: '역삼',
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastSilentPushReceived).toEqual({
+      sentAt: 3_900,
+      receivedAt: 4_000,
+      stationName: '역삼',
+    });
+  });
+
+  it('silent-push-received entry라도 receivedAt 없으면 skip', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({ ts: 2_000, source: 'silent-push-received', outcome: 'received' }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastSilentPushReceived).toBeUndefined();
+  });
+
+  it('silent push entry의 sentAt/stationName이 누락돼도 receivedAt만 있으면 적재', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 2_000,
+          source: 'silent-push-received',
+          outcome: 'received',
+          receivedAt: 2_000,
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastSilentPushReceived).toEqual({ receivedAt: 2_000 });
+  });
+
+  it('silent-push-received entry 다수 중 ts가 더 작은 후속 entry는 last를 갱신하지 않음', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 5_000,
+          source: 'silent-push-received',
+          outcome: 'received',
+          receivedAt: 5_000,
+          stationName: 'newer',
+        }),
+        entry({
+          ts: 1_000,
+          source: 'silent-push-received',
+          outcome: 'received',
+          receivedAt: 1_000,
+          stationName: 'older',
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastSilentPushReceived?.stationName).toBe('newer');
+  });
+
+  it('윈도우 밖 silent push entry는 무시', () => {
+    const out = collectMissContext({
+      tripStart: 1_000,
+      tripEnd: 5_000,
+      alarmLogEntries: [
+        entry({
+          ts: 500,
+          source: 'silent-push-received',
+          outcome: 'received',
+          receivedAt: 500,
+          stationName: 'before',
+        }),
+        entry({
+          ts: 6_000,
+          source: 'silent-push-received',
+          outcome: 'received',
+          receivedAt: 6_000,
+          stationName: 'after',
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastSilentPushReceived).toBeUndefined();
+  });
+
+  it('윈도우 안 가장 최근 bg-scheduled fired stamp 채택', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 2_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          selectedArrivalSeconds: 60,
+          expectedStationAtFire: '강남',
+          actualLastNotifiedStation: '역삼',
+        }),
+        entry({
+          ts: 4_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          selectedArrivalSeconds: 30,
+          expectedStationAtFire: '교대',
+          actualLastNotifiedStation: '강남',
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastScheduledStamp).toEqual({
+      selectedArrivalSeconds: 30,
+      expectedStationAtFire: '교대',
+      actualLastNotifiedStation: '강남',
+    });
+  });
+
+  it('stamp 모두 null/undefined인 bg-scheduled entry는 skip', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 2_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          selectedArrivalSeconds: null,
+          expectedStationAtFire: null,
+          actualLastNotifiedStation: null,
+        }),
+        entry({
+          ts: 1_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastScheduledStamp).toBeUndefined();
+  });
+
+  it('bg-scheduled 다수 중 ts가 더 작은 후속 entry는 last를 갱신하지 않음', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 5_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          expectedStationAtFire: 'newer',
+        }),
+        entry({
+          ts: 1_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          expectedStationAtFire: 'older',
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastScheduledStamp?.expectedStationAtFire).toBe('newer');
+  });
+
+  it('bg-scheduled stamp: 다른 필드만 있는 last entry → selectedArrivalSeconds 누락', () => {
+    // expectedStationAtFire만 있는 entry가 last가 되면, out.selectedArrivalSeconds는 채워지지 않는다.
+    // 이로써 lastScheduledStamp 구성 시 selectedArrivalSeconds 조건 false 분기를 커버한다.
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 2_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          expectedStationAtFire: '강남',
+          // selectedArrivalSeconds 미설정 + actualLastNotifiedStation 미설정
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastScheduledStamp).toEqual({ expectedStationAtFire: '강남' });
+  });
+
+  it('bg-scheduled 중 부분 stamp만 있는 entry도 채택 (있는 필드만 포함)', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 2_000,
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          selectedArrivalSeconds: 45,
+          expectedStationAtFire: null,
+          actualLastNotifiedStation: undefined,
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastScheduledStamp).toEqual({ selectedArrivalSeconds: 45 });
+  });
+
+  it('outcome이 fired가 아닌 bg-scheduled entry는 무시', () => {
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 10_000,
+      alarmLogEntries: [
+        entry({
+          ts: 2_000,
+          source: 'bg-scheduled',
+          outcome: 'suppressed',
+          selectedArrivalSeconds: 30,
+        }),
+      ],
+      boardingLock: null,
+      ledger: [],
+    });
+    expect(out.lastScheduledStamp).toBeUndefined();
+  });
+
+  it('ledger에서 actualFireMs 미기록 identifier 수집 (윈도우 필터)', () => {
+    const ledger: PrescheduledLedgerEntry[] = [
+      { identifier: 'tba:early:A', scheduledFireMs: 1_000 }, // miss, in window
+      { identifier: 'tba:early:B', scheduledFireMs: 2_000, actualFireMs: 2_010 }, // fired
+      { identifier: 'tba:imminent:A', scheduledFireMs: 3_000 }, // miss, in window
+      { identifier: 'tba:early:OUT', scheduledFireMs: 100 }, // out of window
+      { identifier: 'tba:early:OUT2', scheduledFireMs: 9_999 }, // out of window
+    ];
+    const out = collectMissContext({
+      tripStart: 1_000,
+      tripEnd: 5_000,
+      alarmLogEntries: [],
+      boardingLock: null,
+      ledger,
+    });
+    expect(out.missedIdentifiers).toEqual(['tba:early:A', 'tba:imminent:A']);
+  });
+
+  it('missed 0건이면 missedIdentifiers 자체를 생성하지 않음', () => {
+    const ledger: PrescheduledLedgerEntry[] = [
+      { identifier: 'tba:early:A', scheduledFireMs: 1_000, actualFireMs: 1_010 },
+    ];
+    const out = collectMissContext({
+      tripStart: 0,
+      tripEnd: 5_000,
+      alarmLogEntries: [],
+      boardingLock: null,
+      ledger,
+    });
+    expect(out.missedIdentifiers).toBeUndefined();
+  });
+});
+
+describe('isEmptyMissContext', () => {
+  it('모든 필드 부재 시 true', () => {
+    expect(isEmptyMissContext({})).toBe(true);
+  });
+
+  it.each([
+    ['lockedTrainCode', { lockedTrainCode: 'x' }],
+    ['lockedAt', { lockedAt: 1 }],
+    ['lastSilentPushReceived', { lastSilentPushReceived: { receivedAt: 1 } }],
+    ['lastScheduledStamp', { lastScheduledStamp: { selectedArrivalSeconds: 1 } }],
+    ['missedIdentifiers', { missedIdentifiers: ['tba:x:A'] }],
+  ])('필드 %s 있으면 false', (_label, ctx) => {
+    expect(isEmptyMissContext(ctx)).toBe(false);
+  });
+});

--- a/src/features/alarm/utils/alarmLogTelemetry.ts
+++ b/src/features/alarm/utils/alarmLogTelemetry.ts
@@ -23,8 +23,15 @@ import {
 import {
   computePrescheduledMetrics,
   isEmptyPrescheduledMetrics,
+  readPrescheduledLedger,
   type PrescheduledMetricsResult,
 } from './prescheduledMetrics';
+import {
+  collectMissContext,
+  isEmptyMissContext,
+  type PrescheduledMissContext,
+} from './prescheduledMissContext';
+import { getBoardingLock } from './boardingLockStorage';
 import {
   uploadPrescheduledTelemetry,
   uploadRecallTelemetry,
@@ -93,6 +100,8 @@ export interface ComputeAndUploadTripPrescheduledResult {
   uploaded: boolean;
   skipped?: ComputeAndUploadSkipReason;
   metrics?: PrescheduledMetricsResult;
+  /** miss 발생(scheduled>fired) trip 에서만 채워지는 진단 컨텍스트. (#986) */
+  missContext?: PrescheduledMissContext;
 }
 
 /**
@@ -102,6 +111,9 @@ export interface ComputeAndUploadTripPrescheduledResult {
  * alarmLog는 한 번만 읽어 fired stationName 집합을 만들고 prescheduledMetrics에 전달
  * (recall + prescheduled 양쪽 모두 alarmLog 의존이지만 caller가 각각 호출하므로 두 번 읽힘 —
  * trip-end는 자주 일어나지 않아 비용 무시 가능).
+ *
+ * #986 — miss 발생(scheduled>fired) trip 에서만 BoardingLock + ledger 를 추가로 읽어
+ * `missContext` 를 derive해 upload payload에 첨부한다. fired-only(정상) trip은 추가 I/O 없음.
  */
 export async function computeAndUploadTripPrescheduled(
   input: ComputeAndUploadTripPrescheduledInput,
@@ -126,12 +138,45 @@ export async function computeAndUploadTripPrescheduled(
       return { uploaded: false, skipped: 'empty', metrics };
     }
 
-    const result = await uploadPrescheduledTelemetry(token, metrics);
-    return { uploaded: result.ok, metrics };
+    const missContext = await buildMissContextIfMissed({
+      metrics,
+      alarmLogEntries: entries,
+      tripStart: input.tripStart,
+      tripEnd,
+    });
+
+    const result = await uploadPrescheduledTelemetry(token, metrics, missContext);
+    return { uploaded: result.ok, metrics, missContext };
   } catch (e) {
     log.warn('prescheduled upload error', e);
     return { uploaded: false, skipped: 'error' };
   }
+}
+
+/**
+ * miss 발생 시에만 BoardingLock + ledger 추가 I/O. 빈 context면 undefined 반환 (caller가
+ * payload 에 첨부 안 함).
+ */
+async function buildMissContextIfMissed(input: {
+  metrics: PrescheduledMetricsResult;
+  alarmLogEntries: readonly AlarmLogEntry[];
+  tripStart: number;
+  tripEnd: number;
+}): Promise<PrescheduledMissContext | undefined> {
+  const { metrics, alarmLogEntries, tripStart, tripEnd } = input;
+  if (metrics.scheduledCount <= metrics.firedCount) return undefined;
+  const [boardingLock, ledger] = await Promise.all([
+    getBoardingLock(),
+    readPrescheduledLedger(),
+  ]);
+  const context = collectMissContext({
+    tripStart,
+    tripEnd,
+    alarmLogEntries,
+    boardingLock,
+    ledger,
+  });
+  return isEmptyMissContext(context) ? undefined : context;
 }
 
 /**

--- a/src/features/alarm/utils/prescheduledMissContext.ts
+++ b/src/features/alarm/utils/prescheduledMissContext.ts
@@ -1,0 +1,200 @@
+/**
+ * 사전 예약 miss trip 자동 진단 컨텍스트 (#986, #918/#956 follow-up).
+ *
+ * `prescheduledMetrics`가 trip 윈도우 안에서 scheduledCount > firedCount 인 trip 을 감지하면
+ * 본 모듈이 **이미 영속화된 신호들**을 모아 telemetry payload에 첨부한다. 새 write hook을
+ * 분산시키지 않고 trip-end 시점에 한 번만 derive — 사이드이펙트 0.
+ *
+ * 적재 신호:
+ *   - lockedTrainCode / lockedAt    : BoardingLock (탑승 시점 trainCode + boardedAt)
+ *   - lastSilentPushReceived         : alarmLog의 마지막 silent-push-received 엔트리 요약
+ *   - lastScheduledStamp             : alarmLog의 마지막 bg-scheduled fired 엔트리의 stamp
+ *   - missedIdentifiers              : ledger에서 actualFireMs 미기록 entry id 목록
+ *
+ * 모든 필드는 optional — 신호 없으면 그대로 제외. context 객체 자체가 비어있으면(모든
+ * 필드 부재) caller는 missContext를 첨부하지 않는다 (isEmptyMissContext 가드).
+ *
+ * Privacy: trainCode/stationName은 token prefix 기반 anonymous aggregate와 동일 정책으로
+ * 노출 — 좌표/원문 미적재. backend는 console.log + Logpush 로 보존 (AE blob에는 미적재).
+ */
+
+import type { AlarmLogEntry } from './alarmLog';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { PrescheduledLedgerEntry } from './prescheduledMetrics';
+
+/**
+ * Trip-end 시점 진단 컨텍스트 1건. 모든 필드 optional — 신호 없으면 생략.
+ *
+ * backend `prescheduledTelemetry.validatePrescheduledUpload`가 동형 schema로 검증한다.
+ * 추가 필드는 양쪽 동시 갱신 — 한쪽이 unknown이면 reject (조용히 drop 안 함).
+ */
+export interface PrescheduledMissContext {
+  /** BoardingLock.trainCode — 사용자가 탭한 열차. lock 없으면 생략. */
+  lockedTrainCode?: string;
+  /** BoardingLock.boardedAt — 탑승 시각(epoch ms). lock 없으면 생략. */
+  lockedAt?: number;
+  /** 마지막 silent push 수신 entry 요약. window 안에 1건도 없으면 생략. */
+  lastSilentPushReceived?: {
+    sentAt?: number;
+    receivedAt: number;
+    stationName?: string;
+  };
+  /** 마지막 bg-scheduled fired 엔트리의 stamp 요약. 없으면 생략. */
+  lastScheduledStamp?: {
+    selectedArrivalSeconds?: number;
+    expectedStationAtFire?: string;
+    actualLastNotifiedStation?: string;
+  };
+  /** ledger에서 actualFireMs가 미기록된 identifier 목록. 빈 배열이면 생략. */
+  missedIdentifiers?: readonly string[];
+}
+
+export interface CollectMissContextInput {
+  /** trip 윈도우 lower bound (inclusive). */
+  tripStart: number;
+  /** trip 윈도우 upper bound (inclusive). */
+  tripEnd: number;
+  /** trip-end 시점 alarmLog 전체. caller가 한 번 읽어 전달. */
+  alarmLogEntries: readonly AlarmLogEntry[];
+  /** trip-end 시점 BoardingLock (null = lock 없이 종료된 trip). */
+  boardingLock: BoardingLock | null;
+  /** trip-end 시점 prescheduled ledger 전체. */
+  ledger: readonly PrescheduledLedgerEntry[];
+}
+
+/**
+ * trip 윈도우 안 entry만 필터링. ts 가 [tripStart, tripEnd] 포함이면 통과.
+ * 정의: tripEnd 시점 발생한 entry 도 포함 (recallMetrics는 strict gt 시작이지만 본 함수는
+ * 진단 목적이라 윈도우 양 끝 포함이 더 안전 — 누락된 신호 더 잘 잡힘).
+ */
+function inWindow(entry: AlarmLogEntry, tripStart: number, tripEnd: number): boolean {
+  return entry.ts >= tripStart && entry.ts <= tripEnd;
+}
+
+/**
+ * 윈도우 안 가장 최근 silent-push-received entry 추출. 다수면 ts 가장 큰 것.
+ * 없으면 undefined.
+ */
+function pickLastSilentPushReceived(
+  entries: readonly AlarmLogEntry[],
+  tripStart: number,
+  tripEnd: number,
+): PrescheduledMissContext['lastSilentPushReceived'] {
+  let last: AlarmLogEntry | undefined;
+  for (const entry of entries) {
+    if (!inWindow(entry, tripStart, tripEnd)) continue;
+    if (entry.source !== 'silent-push-received') continue;
+    if (entry.receivedAt === undefined) continue;
+    if (last === undefined || entry.ts > last.ts) last = entry;
+  }
+  if (!last || last.receivedAt === undefined) return undefined;
+  const out: NonNullable<PrescheduledMissContext['lastSilentPushReceived']> = {
+    receivedAt: last.receivedAt,
+  };
+  if (last.sentAt !== undefined) out.sentAt = last.sentAt;
+  if (last.stationName !== undefined) out.stationName = last.stationName;
+  return out;
+}
+
+/**
+ * 윈도우 안 가장 최근 bg-scheduled fired entry 추출. stamp 필드 중 하나라도 값이
+ * 있으면 채택. 모두 null/undefined인 entry는 skip (정보 없음).
+ */
+function pickLastScheduledStamp(
+  entries: readonly AlarmLogEntry[],
+  tripStart: number,
+  tripEnd: number,
+): PrescheduledMissContext['lastScheduledStamp'] {
+  let last: AlarmLogEntry | undefined;
+  for (const entry of entries) {
+    if (!inWindow(entry, tripStart, tripEnd)) continue;
+    if (entry.source !== 'bg-scheduled') continue;
+    if (entry.outcome !== 'fired') continue;
+    // stamp 필드 셋 다 비어있으면 스킵 — 진단 가치 0.
+    const hasStamp =
+      (entry.selectedArrivalSeconds !== null && entry.selectedArrivalSeconds !== undefined) ||
+      (entry.expectedStationAtFire !== null && entry.expectedStationAtFire !== undefined) ||
+      (entry.actualLastNotifiedStation !== null &&
+        entry.actualLastNotifiedStation !== undefined);
+    if (!hasStamp) continue;
+    if (last === undefined || entry.ts > last.ts) last = entry;
+  }
+  if (!last) return undefined;
+  const out: NonNullable<PrescheduledMissContext['lastScheduledStamp']> = {};
+  if (last.selectedArrivalSeconds !== null && last.selectedArrivalSeconds !== undefined) {
+    out.selectedArrivalSeconds = last.selectedArrivalSeconds;
+  }
+  if (last.expectedStationAtFire !== null && last.expectedStationAtFire !== undefined) {
+    out.expectedStationAtFire = last.expectedStationAtFire;
+  }
+  if (last.actualLastNotifiedStation !== null && last.actualLastNotifiedStation !== undefined) {
+    out.actualLastNotifiedStation = last.actualLastNotifiedStation;
+  }
+  return out;
+}
+
+/**
+ * ledger에서 윈도우 안 scheduled entry 중 actualFireMs 가 비어있는 identifier 목록.
+ * 한 trip의 사전 예약 최대치는 ~80건이라 그대로 노출 — 노이즈 우려 없음.
+ */
+function collectMissedIdentifiers(
+  ledger: readonly PrescheduledLedgerEntry[],
+  tripStart: number,
+  tripEnd: number,
+): string[] {
+  const out: string[] = [];
+  for (const entry of ledger) {
+    if (entry.scheduledFireMs < tripStart || entry.scheduledFireMs > tripEnd) continue;
+    if (entry.actualFireMs !== undefined) continue;
+    out.push(entry.identifier);
+  }
+  return out;
+}
+
+/**
+ * Trip-end 시점 진단 컨텍스트 derive. 호출자는 prescheduledMetrics 결과의 scheduled>fired
+ * 조건이 성립할 때만 호출 — 본 함수 자체는 그 가드를 안 한다 (caller 책임).
+ *
+ * 모든 신호는 이미 영속화돼 있으므로 추가 I/O 0. caller가 alarmLog/lock/ledger를 한 번
+ * 읽어 전달한다.
+ */
+export function collectMissContext(input: CollectMissContextInput): PrescheduledMissContext {
+  const { tripStart, tripEnd, alarmLogEntries, boardingLock, ledger } = input;
+  const out: PrescheduledMissContext = {};
+
+  if (boardingLock) {
+    // empty trainCode(저장소 손상 케이스)는 skip — backend missContext schema가 빈 문자열 reject.
+    // 잘못된 신호가 trip 전체 upload를 깨지 않게 client에서 미리 차단.
+    if (boardingLock.trainCode.length > 0) {
+      out.lockedTrainCode = boardingLock.trainCode;
+    }
+    if (Number.isFinite(boardingLock.boardedAt)) {
+      out.lockedAt = boardingLock.boardedAt;
+    }
+  }
+
+  const lastSilent = pickLastSilentPushReceived(alarmLogEntries, tripStart, tripEnd);
+  if (lastSilent) out.lastSilentPushReceived = lastSilent;
+
+  const lastStamp = pickLastScheduledStamp(alarmLogEntries, tripStart, tripEnd);
+  if (lastStamp) out.lastScheduledStamp = lastStamp;
+
+  const missed = collectMissedIdentifiers(ledger, tripStart, tripEnd);
+  if (missed.length > 0) out.missedIdentifiers = missed;
+
+  return out;
+}
+
+/**
+ * 한 신호도 없는 경우 — caller는 missContext 자체를 upload payload에 첨부하지 않는다.
+ * (네트워크 절약 + backend validation 통과 보장.)
+ */
+export function isEmptyMissContext(context: PrescheduledMissContext): boolean {
+  return (
+    context.lockedTrainCode === undefined &&
+    context.lockedAt === undefined &&
+    context.lastSilentPushReceived === undefined &&
+    context.lastScheduledStamp === undefined &&
+    context.missedIdentifiers === undefined
+  );
+}


### PR DESCRIPTION
## 요약

PR #956(#918 A3) + #976(#919 recall webhook) 후속.

`prescheduledFireMissRate` 가 임계 위반 trip을 감지해도 그 trip의 root cause 단서가 없어 사후 분석이 어려웠다. 본 PR은 miss 발생(`scheduledCount > firedCount`) trip에서만 진단 컨텍스트를 telemetry payload에 첨부해 Logpush로 보존한다.

## missContext schema

```ts
interface PrescheduledMissContext {
  lockedTrainCode?: string;
  lockedAt?: number;
  lastSilentPushReceived?: { sentAt?: number; receivedAt: number; stationName?: string };
  lastScheduledStamp?: {
    selectedArrivalSeconds?: number;
    expectedStationAtFire?: string;
    actualLastNotifiedStation?: string;
  };
  missedIdentifiers?: string[]; // ledger의 actualFireMs 미기록 entry id
}
```

모든 필드 optional — 신호 없으면 생략, 전부 비어있으면 missContext 자체 미첨부.

## 설계 결정

- **신호 derive 시점**: trip-end 한 번. 새 write hook 분산 없이 alarmLog/BoardingLock/ledger 의 기존 영속 데이터에서 derive (사이드이펙트 0).
- **정상 trip은 추가 I/O 없음**: scheduled=fired 분기에서 BoardingLock/ledger 추가 read 스킵.
- **AE blob 미적재**: free-form/PII 회피. console.log + Logpush 로 보존 (검색은 Logpush export 기반).
- **backend validation**: 길이/타입/배열 상한(200) 강제. 깨진 missContext 는 전체 payload 400 reject로 client bug 빠르게 노출.

## Privacy

stationName/trainCode 는 기존 token prefix anonymous aggregate 정책과 동일. 좌표/원문 미포함.

## Test plan

- [x] `prescheduledMissContext.test.ts` — derive 로직 (lock/silent/stamp/missed) + 윈도우 필터 + isEmpty 가드 — 23 tests
- [x] `alarmLogTelemetry.test.ts` — miss 분기 통합 (no-miss skip / empty context skip / full context attach) — 3 신규
- [x] `telemetryBackend.test.ts` — uploadPrescheduledTelemetry missContext optional 인자 직렬화 — 2 신규
- [x] `prescheduledTelemetry.test.ts` (backend) — validateMissContext 22 케이스 + payload 통합 3
- [x] `index.test.ts` (backend) — `/telemetry/prescheduled` missContext accept/reject 라우트 — 2 신규
- [x] `npm test` 100% coverage (4151 passed)
- [x] `npm run type-check` pass
- [x] backend `npx vitest run` 951 passed

Closes #986