### PR TITLE
test(#998): 권한 매트릭스 회귀 추가 cell 4차 wave

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -335,9 +335,15 @@ jobs:
           - always-bg-aboveground-normal-ios18
           - whileInUse-fg-aboveground-normal-ios17
           - always-fg-aboveground-normal-android
-          # 후속 PR에서 추가: *-underground-*, *-bg-sleep-*, 실측 recall 측정
+          - always-fg-underground-normal-ios18
+          - always-bg-aboveground-sleep-ios18
+          - always-bg-underground-normal-ios18
+          # 후속 PR에서 추가: E2E mock fixture 확장(underground 분기), 최난도 조합
+          # (always-bg-underground-sleep-ios18), WhileInUse × 가혹 환경, 실측 recall 측정.
           # 주의: ios17/android cell은 현재 iPhone 16(iOS 18) 시뮬에서 권한 dispatch만 검증.
           #       OS/플랫폼별 실제 시뮬레이터 부팅 분기는 후속 PR.
+          #       underground cell도 fixture 확장 전까지 GPS dispatch만 검증
+          #       (mock fixture는 강남 고정 반환 — README 참고).
     env:
       SIM_NAME: 'iPhone 16'
       EXPO_PUBLIC_E2E_MOCK: '1'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -338,8 +338,12 @@ jobs:
           - always-fg-underground-normal-ios18
           - always-bg-aboveground-sleep-ios18
           - always-bg-underground-normal-ios18
-          # 후속 PR에서 추가: E2E mock fixture 확장(underground 분기), 최난도 조합
-          # (always-bg-underground-sleep-ios18), WhileInUse × 가혹 환경, 실측 recall 측정.
+          - always-bg-underground-sleep-ios18
+          - whileInUse-bg-aboveground-normal-ios18
+          - whileInUse-fg-underground-normal-ios18
+          # 후속 PR에서 추가: E2E mock fixture 확장(underground 분기),
+          # WhileInUse × BG × sleep / WhileInUse × underground × sleep 등 권한↓ 최난도 결합,
+          # 실측 recall 측정.
           # 주의: ios17/android cell은 현재 iPhone 16(iOS 18) 시뮬에서 권한 dispatch만 검증.
           #       OS/플랫폼별 실제 시뮬레이터 부팅 분기는 후속 PR.
           #       underground cell도 fixture 확장 전까지 GPS dispatch만 검증

--- a/.maestro/flows/permissions/README.md
+++ b/.maestro/flows/permissions/README.md
@@ -21,12 +21,18 @@ Android, FG/BG, 지상/지하, 일반/취침 등 권한·환경 조합별로 매
 | `always-bg-aboveground-normal-ios18` | Always | BG | 지상 | 일반 | iOS 18 | BG 차원 첫 진입 (2차 wave) |
 | `whileInUse-fg-aboveground-normal-ios17` | WhileInUse | FG | 지상 | 일반 | iOS 17 | iOS 17 차원 첫 진입 (2차 wave) |
 | `always-fg-aboveground-normal-android` | Always | FG | 지상 | 일반 | Android | Android 플랫폼 첫 진입 (2차 wave) |
+| `always-fg-underground-normal-ios18` | Always | FG | 지하 | 일반 | iOS 18 | underground 차원 첫 진입 (3차 wave) |
+| `always-bg-aboveground-sleep-ios18` | Always | BG | 지상 | 취침 | iOS 18 | BG × sleep 결합 첫 진입 (3차 wave) |
+| `always-bg-underground-normal-ios18` | Always | BG | 지하 | 일반 | iOS 18 | BG × underground 결합 첫 진입 (3차 wave) |
 
 후속 PR에서 추가될 cell (`scripts/permission-matrix.json`의 `cells` 배열에
 entry만 추가하면 runner와 CI matrix가 자동으로 픽업):
 
-- `*-underground-*` 차원 (E2E mock fixture 확장 필요)
-- `*-bg-sleep-*` 결합 차원
+- E2E mock fixture 확장 — `*-underground-*` cell이 강남(지상) 대신 지하역(예: 신도림)을
+  반환하도록 분기. 현재 underground cell은 GPS dispatch만 검증(dispatch-only).
+- `always-bg-underground-sleep-ios18` 최난도 SLA 정본 조합 (3차 wave의 BG × underground와
+  BG × sleep을 결합)
+- WhileInUse × BG / underground × sleep 등 권한↓ × 가혹 환경 결합
 - iOS 17 / Android cell의 실제 시뮬레이터/디바이스 부팅 분기 (현재는 iOS 18 시뮬에서 권한 dispatch만 검증)
 - 실측 recall 측정 (`expectedRecallPct` placeholder → 실측치)
 

--- a/.maestro/flows/permissions/README.md
+++ b/.maestro/flows/permissions/README.md
@@ -24,15 +24,17 @@ Android, FG/BG, 지상/지하, 일반/취침 등 권한·환경 조합별로 매
 | `always-fg-underground-normal-ios18` | Always | FG | 지하 | 일반 | iOS 18 | underground 차원 첫 진입 (3차 wave) |
 | `always-bg-aboveground-sleep-ios18` | Always | BG | 지상 | 취침 | iOS 18 | BG × sleep 결합 첫 진입 (3차 wave) |
 | `always-bg-underground-normal-ios18` | Always | BG | 지하 | 일반 | iOS 18 | BG × underground 결합 첫 진입 (3차 wave) |
+| `always-bg-underground-sleep-ios18` | Always | BG | 지하 | 취침 | iOS 18 | SLA 최난도 결합(Always+BG+지하+취침) 첫 진입 (4차 wave) |
+| `whileInUse-bg-aboveground-normal-ios18` | WhileInUse | BG | 지상 | 일반 | iOS 18 | WhileInUse × BG 결합 첫 진입 (4차 wave) |
+| `whileInUse-fg-underground-normal-ios18` | WhileInUse | FG | 지하 | 일반 | iOS 18 | WhileInUse × underground 결합 첫 진입 (4차 wave) |
 
 후속 PR에서 추가될 cell (`scripts/permission-matrix.json`의 `cells` 배열에
 entry만 추가하면 runner와 CI matrix가 자동으로 픽업):
 
 - E2E mock fixture 확장 — `*-underground-*` cell이 강남(지상) 대신 지하역(예: 신도림)을
   반환하도록 분기. 현재 underground cell은 GPS dispatch만 검증(dispatch-only).
-- `always-bg-underground-sleep-ios18` 최난도 SLA 정본 조합 (3차 wave의 BG × underground와
-  BG × sleep을 결합)
-- WhileInUse × BG / underground × sleep 등 권한↓ × 가혹 환경 결합
+- WhileInUse × BG × sleep / WhileInUse × underground × sleep / WhileInUse × BG × underground
+  등 권한↓ × 가혹 환경 추가 결합
 - iOS 17 / Android cell의 실제 시뮬레이터/디바이스 부팅 분기 (현재는 iOS 18 시뮬에서 권한 dispatch만 검증)
 - 실측 recall 측정 (`expectedRecallPct` placeholder → 실측치)
 

--- a/.maestro/flows/permissions/always-bg-aboveground-sleep-ios18.yaml
+++ b/.maestro/flows/permissions/always-bg-aboveground-sleep-ios18.yaml
@@ -1,0 +1,78 @@
+appId: com.subwaynow.app
+name: "permissions - Always × BG × 지상 × 취침 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=bg, environment=aboveground, mode=sleep, os=ios18
+#
+# 검증 목표:
+#   - 매역 알람 SLA의 정본 운영 조합(권한=Always + BG + 취침 모드 ON).
+#     BG → FG 복귀 후에도 취침 모드 토글이 유지되고 홈 진입점이 reachable 함을 보장한다.
+#   - bg × sleep 결합 차원 첫 진입 — 후속 PR에서 BG silent push 발사 verify로 확장 예정.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, 강남역 fixture).
+# BG 전이 모사는 always-bg-aboveground-normal-ios18 cell과 동일한 stopApp + relaunch 패턴.
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 1차 포그라운드 진입 — 홈 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 취침 모드 ON
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+
+- tapOn:
+    id: "home-sleep-mode-switch"
+
+# BG 전이 모사 — stopApp 후 relaunch (clearState=false로 권한/취침 상태 보존)
+- stopApp:
+    appId: com.subwaynow.app
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: false
+
+# 복귀 후에도 홈 진입점이 유지되어야 한다 (BG × sleep 결합 회귀 가드)
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 취침 모드 토글이 복귀 후에도 reachable 해야 한다
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+
+- assertVisible:
+    id: "home-sleep-mode-switch"

--- a/.maestro/flows/permissions/always-bg-underground-normal-ios18.yaml
+++ b/.maestro/flows/permissions/always-bg-underground-normal-ios18.yaml
@@ -1,0 +1,64 @@
+appId: com.subwaynow.app
+name: "permissions - Always × BG × 지하 × 일반 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=bg, environment=underground, mode=normal, os=ios18
+#
+# 검증 목표:
+#   - BG × underground 결합 첫 진입. 매역 알람 SLA가 가장 까다로워지는 조합
+#     (앱 BG + 지하 GPS 약화) 직전 단계의 회귀 가드.
+#   - 지하 GPS 좌표에서 cold-restart(stopApp + relaunch) 후에도 Always 권한이
+#     보존되고 홈 진입점이 유지됨을 보장한다.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, mock fixture는 강남 고정 반환).
+# underground 차원 등록은 dispatch-only — fixture 확장 후속 PR에서
+# "GPS 약화" 배너 / 기압계 fallback 같은 underground UX assert를 추가한다.
+---
+# 신도림 1호선(지하) 좌표 — stations.json id "1-041"
+- setLocation:
+    latitude: 37.508787
+    longitude: 126.891144
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 1차 포그라운드 — 지하 GPS 좌표에서도 홈 진입점 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# mock fixture가 강남 고정 반환. fixture 확장 후 "신도림|Sindorim"으로 교체.
+- assertVisible:
+    text: "강남|Gangnam"
+
+# BG 전이 모사 — stopApp + relaunch (clearState=false로 권한 보존 확인)
+- stopApp:
+    appId: com.subwaynow.app
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: false
+
+# 복귀 후에도 홈 진입점이 유지되어야 한다 (BG × underground 결합 회귀 가드)
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"

--- a/.maestro/flows/permissions/always-bg-underground-sleep-ios18.yaml
+++ b/.maestro/flows/permissions/always-bg-underground-sleep-ios18.yaml
@@ -1,0 +1,83 @@
+appId: com.subwaynow.app
+name: "permissions - Always × BG × 지하 × 취침 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=bg, environment=underground, mode=sleep, os=ios18
+#
+# 검증 목표:
+#   - 매역 알람 SLA 최난도 조합(권한=Always + BG + 지하 + 취침). 3차 wave에서
+#     BG×sleep / BG×underground 결합을 각각 첫 진입한 뒤 남은 BG×sleep×underground
+#     최종 결합 차원 첫 진입.
+#   - 지하 GPS 좌표 + 취침 모드 ON 상태에서 stopApp + relaunch 후에도 Always 권한,
+#     취침 토글, 홈 진입점이 모두 보존됨을 보장한다.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, 강남 고정 fixture).
+# underground는 dispatch-only (3차 wave의 always-bg-underground-normal-ios18 과 동일 패턴).
+# BG 전이는 stopApp + relaunch(clearState=false).
+---
+# 신도림 1호선(지하) 좌표 — stations.json id "1-041"
+- setLocation:
+    latitude: 37.508787
+    longitude: 126.891144
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 1차 포그라운드 — 지하 GPS 좌표에서도 홈 진입점 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# mock fixture가 강남 고정 반환. fixture 확장 후 "신도림|Sindorim"으로 교체.
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 취침 모드 ON
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+
+- tapOn:
+    id: "home-sleep-mode-switch"
+
+# BG 전이 모사 — stopApp + relaunch (clearState=false로 권한/취침 상태 보존)
+- stopApp:
+    appId: com.subwaynow.app
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: false
+
+# 복귀 후에도 홈 진입점이 유지되어야 한다 (BG × underground × sleep 최난도 결합 회귀 가드)
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 취침 모드 토글이 복귀 후에도 reachable 해야 한다
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+
+- assertVisible:
+    id: "home-sleep-mode-switch"

--- a/.maestro/flows/permissions/always-fg-underground-normal-ios18.yaml
+++ b/.maestro/flows/permissions/always-fg-underground-normal-ios18.yaml
@@ -1,0 +1,53 @@
+appId: com.subwaynow.app
+name: "permissions - Always × FG × 지하 × 일반 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=always, appState=fg, environment=underground, mode=normal, os=ios18
+#
+# 검증 목표:
+#   - underground 환경 첫 진입 — Always 권한 + FG 상태에서 지하역 GPS 좌표가
+#     dispatch 됐을 때 홈 진입점이 유지됨을 보장한다.
+#   - underground 차원 등록(dispatch-only). 현재 E2E mock fixture는 강남(지상)을
+#     고정 반환하므로 본 cell은 GPS 좌표만 지하역으로 차원 등록하고,
+#     실제 underground UX 검증(예: "GPS 약화" 배너, 기압계 fallback)은
+#     fixture 확장 후속 PR에서 별도 assert로 강화한다.
+#     (iOS 17 / Android cell의 dispatch-only 등록 패턴과 동일.)
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, fixture는 강남역 고정 반환).
+---
+# 신도림 1호선(지하) 좌표 — stations.json id "1-041"
+- setLocation:
+    latitude: 37.508787
+    longitude: 126.891144
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 홈 진입점 노출 — 지하 GPS 좌표에서도 destination-button이 렌더되어야 함
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 — mock fixture가 강남 고정 반환하므로 강남으로 assert.
+# fixture가 underground 분기를 지원하게 되면 "신도림|Sindorim"으로 교체할 것.
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 매역 알람 경로의 진입점이 유지되어야 한다 (underground 차원 회귀 가드)
+- assertVisible:
+    text: "목적지 설정|Set destination"

--- a/.maestro/flows/permissions/whileInUse-bg-aboveground-normal-ios18.yaml
+++ b/.maestro/flows/permissions/whileInUse-bg-aboveground-normal-ios18.yaml
@@ -1,0 +1,61 @@
+appId: com.subwaynow.app
+name: "permissions - WhileInUse × BG × 지상 × 일반 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=whileInUse, appState=bg, environment=aboveground, mode=normal, os=ios18
+#
+# 검증 목표:
+#   - WhileInUse × BG 결합 첫 진입. 가장 흔한 권한 다운그레이드 사용자 시나리오
+#     (앱이 BG에 진입해도 권한 강등으로 GPS가 잠시 끊겼다 복귀하는 경로) 회귀 가드.
+#   - stopApp + relaunch(clearState=false) 후 WhileInUse 권한이 보존되고
+#     홈 진입점이 유지되는지 확인한다.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, 강남역 fixture).
+# BG 전이는 always-bg-aboveground-normal-ios18 cell과 동일 패턴.
+---
+- setLocation:
+    latitude: 37.497942
+    longitude: 127.027621
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: inuse
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 1차 포그라운드 — 홈 진입점 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"
+
+# BG 전이 모사 — stopApp + relaunch (clearState=false로 권한 보존 확인)
+- stopApp:
+    appId: com.subwaynow.app
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: false
+
+# 복귀 후에도 홈 진입점이 유지되어야 한다 (WhileInUse × BG 결합 회귀 가드)
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+- assertVisible:
+    text: "강남|Gangnam"

--- a/.maestro/flows/permissions/whileInUse-fg-underground-normal-ios18.yaml
+++ b/.maestro/flows/permissions/whileInUse-fg-underground-normal-ios18.yaml
@@ -1,0 +1,51 @@
+appId: com.subwaynow.app
+name: "permissions - WhileInUse × FG × 지하 × 일반 (#923 cell)"
+# 권한 매트릭스 cell.
+# 차원: permission=whileInUse, appState=fg, environment=underground, mode=normal, os=ios18
+#
+# 검증 목표:
+#   - WhileInUse × underground 결합 첫 진입. 권한 다운그레이드 + 가혹 환경
+#     (지하 GPS 약화) 결합 회귀 가드.
+#   - underground 차원은 dispatch-only (3차 wave의 always-fg-underground-normal-ios18 과
+#     동일 패턴). fixture 확장 후 "신도림|Sindorim" + underground UX(예: GPS 약화 배너)로
+#     강화 예정.
+#
+# 전제: baseline cell과 동일 (EXPO_PUBLIC_E2E_MOCK=1, 강남 고정 fixture).
+---
+# 신도림 1호선(지하) 좌표 — stations.json id "1-041"
+- setLocation:
+    latitude: 37.508787
+    longitude: 126.891144
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: inuse
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+
+- swipe:
+    start: 50%, 50%
+    end: 50%, 95%
+
+# 홈 진입점 노출 — 지하 GPS 좌표 + WhileInUse에서도 destination-button이 렌더되어야 함
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 — mock fixture가 강남 고정 반환하므로 강남으로 assert.
+# fixture가 underground 분기를 지원하게 되면 "신도림|Sindorim"으로 교체할 것.
+- assertVisible:
+    text: "강남|Gangnam"
+
+# 매역 알람 경로의 진입점이 유지되어야 한다 (WhileInUse × underground 결합 회귀 가드)
+- assertVisible:
+    text: "목적지 설정|Set destination"

--- a/scripts/permission-matrix.json
+++ b/scripts/permission-matrix.json
@@ -91,6 +91,39 @@
       "expectedRecallPct": 90,
       "flow": "always-fg-aboveground-normal-android.yaml",
       "_doc": "Android 플랫폼 차원 첫 진입. ACCESS_BACKGROUND_LOCATION 권한 dispatch가 Maestro permission 매핑에서 올바르게 처리되는지 회귀 가드. 후속 PR에서 Android 시뮬레이터 부팅 분기."
+    },
+    {
+      "id": "always-fg-underground-normal-ios18",
+      "permission": "always",
+      "appState": "fg",
+      "environment": "underground",
+      "mode": "normal",
+      "os": "ios18",
+      "expectedRecallPct": 90,
+      "flow": "always-fg-underground-normal-ios18.yaml",
+      "_doc": "underground 환경 차원 첫 진입. 지하역 GPS 좌표(신도림 1호선) dispatch 후 홈 진입점 유지 회귀 가드. mock fixture 확장 전까지는 dispatch-only(ios17/android 패턴과 동일)."
+    },
+    {
+      "id": "always-bg-aboveground-sleep-ios18",
+      "permission": "always",
+      "appState": "bg",
+      "environment": "aboveground",
+      "mode": "sleep",
+      "os": "ios18",
+      "expectedRecallPct": 90,
+      "flow": "always-bg-aboveground-sleep-ios18.yaml",
+      "_doc": "BG × sleep 결합 차원 첫 진입. 매역 알람 SLA 정본 운영 조합(Always + BG + 취침). 후속 PR에서 BG silent push 발사 verify로 확장."
+    },
+    {
+      "id": "always-bg-underground-normal-ios18",
+      "permission": "always",
+      "appState": "bg",
+      "environment": "underground",
+      "mode": "normal",
+      "os": "ios18",
+      "expectedRecallPct": 85,
+      "flow": "always-bg-underground-normal-ios18.yaml",
+      "_doc": "BG × underground 결합 차원 첫 진입. cold-restart 후 Always 권한 보존 회귀 가드. 매역 알람 SLA 최난도 조합(Always + BG + 지하)의 직전 단계."
     }
   ]
 }

--- a/scripts/permission-matrix.json
+++ b/scripts/permission-matrix.json
@@ -124,6 +124,39 @@
       "expectedRecallPct": 85,
       "flow": "always-bg-underground-normal-ios18.yaml",
       "_doc": "BG × underground 결합 차원 첫 진입. cold-restart 후 Always 권한 보존 회귀 가드. 매역 알람 SLA 최난도 조합(Always + BG + 지하)의 직전 단계."
+    },
+    {
+      "id": "always-bg-underground-sleep-ios18",
+      "permission": "always",
+      "appState": "bg",
+      "environment": "underground",
+      "mode": "sleep",
+      "os": "ios18",
+      "expectedRecallPct": 80,
+      "flow": "always-bg-underground-sleep-ios18.yaml",
+      "_doc": "매역 알람 SLA 최난도 조합(Always + BG + 지하 + 취침) 첫 진입. 3차 wave의 BG×sleep / BG×underground 결합 직후 단계. underground는 dispatch-only(fixture 확장 전)."
+    },
+    {
+      "id": "whileInUse-bg-aboveground-normal-ios18",
+      "permission": "whileInUse",
+      "appState": "bg",
+      "environment": "aboveground",
+      "mode": "normal",
+      "os": "ios18",
+      "expectedRecallPct": 80,
+      "flow": "whileInUse-bg-aboveground-normal-ios18.yaml",
+      "_doc": "WhileInUse × BG 결합 첫 진입. 가장 흔한 권한 다운그레이드 사용자 시나리오(앱 BG 진입 시 권한 격하) 회귀 가드. cold-restart 후 WhileInUse 권한 보존 + 홈 진입점 유지."
+    },
+    {
+      "id": "whileInUse-fg-underground-normal-ios18",
+      "permission": "whileInUse",
+      "appState": "fg",
+      "environment": "underground",
+      "mode": "normal",
+      "os": "ios18",
+      "expectedRecallPct": 85,
+      "flow": "whileInUse-fg-underground-normal-ios18.yaml",
+      "_doc": "WhileInUse × underground 결합 첫 진입. 권한↓ + 가혹 환경 결합 회귀 가드. underground는 dispatch-only(fixture 확장 전)."
     }
   ]
 }


### PR DESCRIPTION
Closes #998
Parent: #923 (Epic #912 P2 E2)
선행 PR: #935 (infra+baseline) → #952 (3 cell 1차) → #983 (3 cell 2차) → #996 (3 cell 3차)
Stacked on: PR #996 (`test/#991-matrix-cell-3w`)

## Summary

권한 매트릭스 cell 3건 추가 — SLA 최난도 결합 + WhileInUse 권한↓ × 가혹 환경. PR #996 README 후속 큐 중 가장 큰 미커버 차원을 데이터 주도로 채운다.

| cell id | permission | appState | environment | mode | os | rationale |
| --- | --- | --- | --- | --- | --- | --- |
| `always-bg-underground-sleep-ios18` | Always | BG | 지하 | 취침 | iOS 18 | 매역 알람 SLA 최난도 결합 첫 진입. 3차 wave의 BG×sleep + BG×underground 결합 직후 단계 |
| `whileInUse-bg-aboveground-normal-ios18` | WhileInUse | BG | 지상 | 일반 | iOS 18 | WhileInUse × BG 결합 첫 진입. 가장 흔한 권한 다운그레이드 사용자 시나리오 |
| `whileInUse-fg-underground-normal-ios18` | WhileInUse | FG | 지하 | 일반 | iOS 18 | WhileInUse × underground 결합 첫 진입. 권한↓ + 가혹 환경 결합 |

## 1/2/3/4차 wave 비교

- 1차 (#935): infra + WhileInUse FG 지상 baseline 1셀.
- 2차 (#952): FG × {Always 대조군, WhileInUse 취침, Always 취침} = +3셀. 권한·모드 cross.
- 2차 후속 (#983): BG / iOS 17 / Android 가로축 차원 첫 진입 = +3셀.
- 3차 (#996): underground 차원 + BG×sleep + BG×underground 결합 = +3셀.
- **4차 (본 PR): SLA 최난도(BG×underground×sleep) + WhileInUse×BG + WhileInUse×underground = +3셀.**

머지 후 매트릭스 13 cell 등록.

## 데이터 주도 — runner / CI infra 무수정

- `scripts/permission-matrix.json`의 `cells` 배열에 entry 3건 추가
- `.maestro/flows/permissions/<cell-id>.yaml` 3건 추가
- `.github/workflows/e2e.yml`의 `matrix.cell`에 id 3건 추가
- `.maestro/flows/permissions/README.md` 표 + 후속 큐 cleanup

runner(`scripts/permission-matrix-runner.js`)와 기존 flow는 손대지 않았다. `node scripts/permission-matrix-runner.js --list`로 13셀 자동 픽업 확인.

## 알려진 제한 (의도적)

- underground cell은 GPS 좌표만 신도림(1호선 지하)으로 dispatch. 현재 E2E mock fixture(`E2E_MOCK_LOCATION`)는 강남 고정 반환이라 `assertVisible`은 여전히 "강남|Gangnam"이다. 3차 wave underground cell과 동일한 dispatch-only 등록 패턴. fixture가 underground 분기를 지원하게 되면 후속 PR에서 강화한다.
- BG 전이 모사는 `always-bg-aboveground-normal-ios18`/`always-bg-aboveground-sleep-ios18`와 동일한 `stopApp + relaunch(clearState=false)` 패턴. 진짜 BG task / silent push 검증은 별도 시뮬레이터 hook 필요.

## Test plan

- [x] `npm test` 100% coverage 유지 (225 suites, 4127 tests pass)
- [x] `npm run type-check` 통과
- [x] `node scripts/permission-matrix-runner.js --list` — 13셀 모두 등록 확인
- [x] code-review (self) — runtime 영향 없는 data/config diff
- [ ] CI `permission-matrix` nightly job에서 새 3셀 통과 (nightly only, PR 게이트 아님)
- [ ] PR 게이트 CI(`Type Check & Test`) 통과

## Out of scope

- E2E mock fixture의 underground 분기 (별도 follow-up)
- WhileInUse × BG × sleep, WhileInUse × underground × sleep 등 권한↓ 최난도 추가 결합
- iOS 17 / Android cell의 실제 시뮬레이터 부팅 분기
- 실측 recall 측정