### PR TITLE
feat(#997): recall alert payload schema 확장 (#976 follow-up)

### DIFF
--- a/backend/alarm-worker/src/__tests__/recallAlerts.test.ts
+++ b/backend/alarm-worker/src/__tests__/recallAlerts.test.ts
@@ -8,11 +8,16 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   ALERT_DEDUP_KEY,
   ALERT_DEDUP_WINDOW_MS,
+  ALERT_GATE_BREAKDOWN_TOP_N,
+  ALERT_WINDOW_MS,
   SQL_API_URL_TEMPLATE,
   evaluateAndMaybeAlert,
 } from '../recallAlerts';
 import { MIN_RECALL_RATIO_THRESHOLD } from '../metrics';
-import { lowRecallTripRatioQuery } from '../recallQueries';
+import {
+  gateSuppressionDistribution7dQuery,
+  lowRecallTripRatioQuery,
+} from '../recallQueries';
 import type { Env } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -78,6 +83,15 @@ function okResponse(): Response {
   return new Response('ok', { status: 200 });
 }
 
+/** Gate breakdown SQL 응답 stub. row=[]면 빈 data 반환(graceful empty). */
+function gateApiResponse(rows: Array<{ reason: string; count: number }>): Response {
+  const data = rows.map((r) => ({ reason: r.reason, suppressed_count: r.count }));
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 describe('evaluateAndMaybeAlert — graceful no-op', () => {
   it('TELEMETRY binding 부재 시 fetch 호출 없이 no-op', async () => {
     const kv = new InMemoryKV();
@@ -122,13 +136,19 @@ describe('evaluateAndMaybeAlert — graceful no-op', () => {
 });
 
 describe('evaluateAndMaybeAlert — breach 발사', () => {
-  it('ratio > 0 → webhook POST + dedup stamp 갱신', async () => {
+  it('ratio > 0 → webhook POST + dedup stamp 갱신 + timeWindow/gateBreakdown 포함', async () => {
     const kv = new InMemoryKV();
     const env = buildEnv(kv);
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(
         sqlApiResponse({ totalTokens: 100, lowRecallTokens: 10, lowRecallRatio: 0.1 }),
+      )
+      .mockResolvedValueOnce(
+        gateApiResponse([
+          { reason: 'gate-accuracy', count: 12 },
+          { reason: 'gate-jump', count: 7 },
+        ]),
       )
       .mockResolvedValueOnce(okResponse());
     const result = await evaluateAndMaybeAlert(env, {
@@ -144,24 +164,38 @@ describe('evaluateAndMaybeAlert — breach 발사', () => {
       threshold: MIN_RECALL_RATIO_THRESHOLD,
       sampleSize: 100,
       observedAt: NOW,
+      timeWindow: { from: NOW - ALERT_WINDOW_MS, to: NOW },
+      gateBreakdown: [
+        { reason: 'gate-accuracy', count: 12 },
+        { reason: 'gate-jump', count: 7 },
+      ],
     });
     expect(result.payload.text).toContain('10.0%');
     expect(result.payload.text).toContain('sample=100');
+    expect(result.payload.text).toContain('gate-accuracy=12');
+    expect(result.payload.text).toContain('gate-jump=7');
 
-    // SQL API call shape 검증.
+    // 1차 SQL: ratio query.
     const [sqlUrl, sqlInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
     expect(sqlUrl).toBe(SQL_API_URL_TEMPLATE('acct-123'));
     expect(sqlInit.method).toBe('POST');
     expect(sqlInit.body).toBe(lowRecallTripRatioQuery);
     expect((sqlInit.headers as Record<string, string>).Authorization).toBe('Bearer token-abc');
 
-    // Webhook call shape 검증.
-    const [webhookUrl, webhookInit] = fetchImpl.mock.calls[1] as [string, RequestInit];
+    // 2차 SQL: gate breakdown query.
+    const [gateUrl, gateInit] = fetchImpl.mock.calls[1] as [string, RequestInit];
+    expect(gateUrl).toBe(SQL_API_URL_TEMPLATE('acct-123'));
+    expect(gateInit.body).toBe(gateSuppressionDistribution7dQuery);
+
+    // 3차: Webhook POST.
+    const [webhookUrl, webhookInit] = fetchImpl.mock.calls[2] as [string, RequestInit];
     expect(webhookUrl).toBe('https://hooks.slack.test/xyz');
     expect(webhookInit.method).toBe('POST');
     const sentPayload = JSON.parse(webhookInit.body as string);
     expect(sentPayload.kind).toBe('low-recall');
     expect(sentPayload.ratio).toBe(0.1);
+    expect(sentPayload.timeWindow).toEqual({ from: NOW - ALERT_WINDOW_MS, to: NOW });
+    expect(sentPayload.gateBreakdown).toHaveLength(2);
 
     // Dedup stamp 기록되어야 함.
     expect(await kv.get(ALERT_DEDUP_KEY)).toBe(String(NOW));
@@ -234,6 +268,7 @@ describe('evaluateAndMaybeAlert — dedup', () => {
       .mockResolvedValueOnce(
         sqlApiResponse({ totalTokens: 50, lowRecallTokens: 5, lowRecallRatio: 0.1 }),
       )
+      .mockResolvedValueOnce(gateApiResponse([]))
       .mockResolvedValueOnce(okResponse());
     const result = await evaluateAndMaybeAlert(env, {
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -251,6 +286,7 @@ describe('evaluateAndMaybeAlert — dedup', () => {
       .mockResolvedValueOnce(
         sqlApiResponse({ totalTokens: 10, lowRecallTokens: 1, lowRecallRatio: 0.1 }),
       )
+      .mockResolvedValueOnce(gateApiResponse([]))
       .mockResolvedValueOnce(okResponse());
     const result = await evaluateAndMaybeAlert(env, {
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -302,6 +338,7 @@ describe('evaluateAndMaybeAlert — fail-soft', () => {
       .mockResolvedValueOnce(
         sqlApiResponse({ totalTokens: 100, lowRecallTokens: 10, lowRecallRatio: 0.1 }),
       )
+      .mockResolvedValueOnce(gateApiResponse([]))
       .mockResolvedValueOnce(new Response('err', { status: 503 }));
     const result = await evaluateAndMaybeAlert(env, {
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -322,6 +359,7 @@ describe('evaluateAndMaybeAlert — fail-soft', () => {
       .mockResolvedValueOnce(
         sqlApiResponse({ totalTokens: 100, lowRecallTokens: 10, lowRecallRatio: 0.1 }),
       )
+      .mockResolvedValueOnce(gateApiResponse([]))
       .mockRejectedValueOnce(new Error('connection refused'));
     const result = await evaluateAndMaybeAlert(env, {
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -345,5 +383,121 @@ describe('evaluateAndMaybeAlert — fail-soft', () => {
       now: () => NOW,
     });
     expect(result).toEqual({ kind: 'noop', reason: 'fetch-failed' });
+  });
+});
+
+describe('evaluateAndMaybeAlert — gate breakdown', () => {
+  function firedBreachRatioStub() {
+    return sqlApiResponse({ totalTokens: 100, lowRecallTokens: 10, lowRecallRatio: 0.1 });
+  }
+
+  it('top N(5) 초과 시 count desc 정렬 후 상위 N개만 보존', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const tooMany = Array.from({ length: ALERT_GATE_BREAKDOWN_TOP_N + 3 }, (_, i) => ({
+      reason: `gate-${i}`,
+      count: (i + 1) * 10, // 10, 20, 30, ... (asc 입력)
+    }));
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(firedBreachRatioStub())
+      .mockResolvedValueOnce(gateApiResponse(tooMany))
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result.kind).toBe('fired');
+    if (result.kind !== 'fired') throw new Error('unreachable');
+    expect(result.payload.gateBreakdown).toHaveLength(ALERT_GATE_BREAKDOWN_TOP_N);
+    // desc 정렬 보장: 첫 항목이 가장 큰 count.
+    const counts = result.payload.gateBreakdown.map((e) => e.count);
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+    expect(counts[0]).toBe((ALERT_GATE_BREAKDOWN_TOP_N + 3) * 10);
+  });
+
+  it('count=0 또는 음수, 비정상 row는 drop', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(firedBreachRatioStub())
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              { reason: 'gate-jump', suppressed_count: 5 },
+              { reason: 'gate-noop', suppressed_count: 0 },
+              { reason: '', suppressed_count: 3 },
+              { reason: 'gate-neg', suppressed_count: -1 },
+              { reason: 'gate-nan', suppressed_count: 'oops' },
+              { reason: 'gate-missing' },
+            ],
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result.kind).toBe('fired');
+    if (result.kind !== 'fired') throw new Error('unreachable');
+    expect(result.payload.gateBreakdown).toEqual([{ reason: 'gate-jump', count: 5 }]);
+  });
+
+  it('gate SQL non-ok → 빈 배열, alert는 정상 발사', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const log = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(firedBreachRatioStub())
+      .mockResolvedValueOnce(new Response('err', { status: 500 }))
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      log,
+    });
+    expect(result.kind).toBe('fired');
+    if (result.kind !== 'fired') throw new Error('unreachable');
+    expect(result.payload.gateBreakdown).toEqual([]);
+    // baseText만 — gate top 줄 미포함
+    expect(result.payload.text).not.toContain('Top gates:');
+    expect(log).toHaveBeenCalledWith('recall-alert: gate SQL non-ok', { status: 500 });
+  });
+
+  it('gate SQL throw → 빈 배열, alert는 정상 발사 + log', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const log = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(firedBreachRatioStub())
+      .mockRejectedValueOnce(new Error('gate net down'))
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      log,
+    });
+    expect(result.kind).toBe('fired');
+    if (result.kind !== 'fired') throw new Error('unreachable');
+    expect(result.payload.gateBreakdown).toEqual([]);
+    expect(log).toHaveBeenCalledWith('recall-alert: gate SQL fetch threw', {
+      error: 'Error: gate net down',
+    });
+  });
+
+  it('gate SQL throw + log 미주입 시 silent (default noop logger)', async () => {
+    const env = buildEnv(new InMemoryKV());
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(firedBreachRatioStub())
+      .mockRejectedValueOnce(new Error('x'))
+      .mockResolvedValueOnce(okResponse());
+    const result = await evaluateAndMaybeAlert(env, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(result.kind).toBe('fired');
   });
 });

--- a/backend/alarm-worker/src/recallAlerts.ts
+++ b/backend/alarm-worker/src/recallAlerts.ts
@@ -23,11 +23,24 @@
  */
 
 import { MIN_RECALL_RATIO_THRESHOLD } from './metrics';
-import { lowRecallTripRatioQuery } from './recallQueries';
+import {
+  gateSuppressionDistribution7dQuery,
+  lowRecallTripRatioQuery,
+} from './recallQueries';
 import type { Env } from './types';
 
 /** 같은 임계 위반 alert이 연속 발사되지 않도록 차단하는 최소 윈도우 (1시간). */
 export const ALERT_DEDUP_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Alert payload `timeWindow`/`gateBreakdown`이 참조하는 집계 윈도우.
+ * `lowRecallTripRatioQuery` SQL 본문의 `INTERVAL '7' DAY`와 동일 — 한 쪽이 바뀌면 같이 갱신.
+ * alert의 의미적 시간 범위는 **임계를 결정하는 ratio query**의 7d를 기준으로 통일.
+ */
+export const ALERT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Alert payload에 임베드할 gate breakdown 항목 수 상한 (root cause 단서, 본문 폭주 차단). */
+export const ALERT_GATE_BREAKDOWN_TOP_N = 5;
 
 /** KV key — 마지막 webhook 발사 시각 epoch ms 저장. */
 export const ALERT_DEDUP_KEY = 'recallAlert:lastFiredAt';
@@ -38,6 +51,15 @@ export const ALERT_DEDUP_KEY = 'recallAlert:lastFiredAt';
  */
 export const SQL_API_URL_TEMPLATE = (accountId: string): string =>
   `https://api.cloudflare.com/client/v4/accounts/${accountId}/analytics_engine/sql`;
+
+/**
+ * Gate suppression breakdown 1 항목. root cause 단서로 alert 본문에 임베드.
+ * `KNOWN_GATE_REASONS` SSOT의 reason key.
+ */
+export interface RecallAlertGateEntry {
+  reason: string;
+  count: number;
+}
 
 /** webhook POST payload 모양 — Slack incoming webhook은 `text` field만 보면 무시한다(호환). */
 export interface RecallAlertPayload {
@@ -51,6 +73,16 @@ export interface RecallAlertPayload {
   sampleSize: number;
   /** epoch ms — alert 평가 시각. */
   observedAt: number;
+  /**
+   * 집계 윈도우 epoch ms — `lowRecallTripRatioQuery`의 7d 윈도우 반영.
+   * receiver가 `from`/`to` 범위로 dashboard deep-link를 만들 수 있게 explicit 노출.
+   */
+  timeWindow: { from: number; to: number };
+  /**
+   * 미달 trip의 주요 차단 사유 top N (count desc). gate breakdown query 실패 시 빈 배열.
+   * Alert 받는 운영자가 어떤 gate를 먼저 봐야 할지 즉시 단서 제공.
+   */
+  gateBreakdown: RecallAlertGateEntry[];
   /** Slack incoming webhook이 그대로 표시할 텍스트(payload kind와 무관한 호환 필드). */
   text: string;
 }
@@ -67,6 +99,16 @@ interface SqlApiRow {
 
 interface SqlApiResponse {
   data?: SqlApiRow[];
+}
+
+/** Gate suppression query 응답 row — `gateSuppressionDistributionQuery` 출력 shape와 1:1. */
+interface GateSqlRow {
+  reason?: string;
+  suppressed_count?: number;
+}
+
+interface GateSqlResponse {
+  data?: GateSqlRow[];
 }
 
 /**
@@ -105,15 +147,23 @@ export async function evaluateAndMaybeAlert(
     return { kind: 'noop', reason: 'no-breach' };
   }
 
+  // Gate breakdown은 root cause 단서로만 사용 — fetch 실패해도 alert 본 흐름은 진행.
+  const gateBreakdown = await fetchGateBreakdown(env, deps);
+  const baseText =
+    `subway-now recall alert — ${(ratio * 100).toFixed(1)}% of trips fell below ` +
+    `${MIN_RECALL_RATIO_THRESHOLD} recall (sample=${sampleSize})`;
+  const text = gateBreakdown.length > 0
+    ? `${baseText}\nTop gates: ${formatGateSummary(gateBreakdown)}`
+    : baseText;
   const payload: RecallAlertPayload = {
     kind: 'low-recall',
     ratio,
     threshold: MIN_RECALL_RATIO_THRESHOLD,
     sampleSize,
     observedAt: now,
-    text:
-      `subway-now recall alert — ${(ratio * 100).toFixed(1)}% of trips fell below ` +
-      `${MIN_RECALL_RATIO_THRESHOLD} recall (sample=${sampleSize})`,
+    timeWindow: { from: now - ALERT_WINDOW_MS, to: now },
+    gateBreakdown,
+    text,
   };
   const sent = await postWebhook(env.RECALL_ALERT_WEBHOOK_URL, payload, deps);
   if (!sent) return { kind: 'noop', reason: 'webhook-failed' };
@@ -194,6 +244,55 @@ async function fetchLowRecallRow(
     log('recall-alert: SQL API fetch threw', { error: String(e) });
     return null;
   }
+}
+
+/**
+ * Gate suppression breakdown fetch. payload root cause 단서 전용 — 실패는 빈 배열 반환,
+ * alert 본 흐름(ratio breach 발사)은 차단하지 않는다. 그래서 별도 fail-soft 경로.
+ *
+ * 정렬: count desc로 SQL이 이미 정렬해 보내지만, 본 함수가 truncate 책임을 가지므로
+ * 다시 정렬해 race-safe하게 top N만 보존한다.
+ */
+async function fetchGateBreakdown(
+  env: Env,
+  deps: RecallAlertDeps,
+): Promise<RecallAlertGateEntry[]> {
+  const accountId = env.CF_ACCOUNT_ID as string;
+  const token = env.CF_API_TOKEN as string;
+  const log = deps.log ?? (() => undefined);
+  try {
+    const res = await deps.fetchImpl(SQL_API_URL_TEMPLATE(accountId), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'text/plain',
+      },
+      body: gateSuppressionDistribution7dQuery,
+    });
+    if (!res.ok) {
+      log('recall-alert: gate SQL non-ok', { status: res.status });
+      return [];
+    }
+    const body = (await res.json()) as GateSqlResponse;
+    const rows = body.data ?? [];
+    const entries: RecallAlertGateEntry[] = [];
+    for (const r of rows) {
+      if (typeof r.reason !== 'string' || r.reason.length === 0) continue;
+      if (typeof r.suppressed_count !== 'number' || !Number.isFinite(r.suppressed_count)) continue;
+      if (r.suppressed_count <= 0) continue;
+      entries.push({ reason: r.reason, count: r.suppressed_count });
+    }
+    entries.sort((a, b) => b.count - a.count);
+    return entries.slice(0, ALERT_GATE_BREAKDOWN_TOP_N);
+  } catch (e) {
+    log('recall-alert: gate SQL fetch threw', { error: String(e) });
+    return [];
+  }
+}
+
+/** "reason1=12, reason2=7" 형태 단일 줄 — Slack `text` 가독성 위해 top N만. */
+function formatGateSummary(entries: RecallAlertGateEntry[]): string {
+  return entries.map((e) => `${e.reason}=${e.count}`).join(', ');
 }
 
 /**

--- a/backend/alarm-worker/src/recallQueries.ts
+++ b/backend/alarm-worker/src/recallQueries.ts
@@ -147,6 +147,28 @@ FROM (
 `.trim();
 
 /**
+ * **Q4. Gate suppression breakdown — 7d window (alert payload 전용).**
+ *
+ * `gateSuppressionDistributionQuery`는 dashboard의 14d 안정 윈도우 SSOT라 변경 부담이 크다.
+ * Alert payload는 `lowRecallTripRatioQuery`의 7d 임계 윈도우와 의미가 일치해야 receiver가
+ * `timeWindow.from`/`to`를 그대로 dashboard deep-link에 쓸 수 있다. 따라서 동일 분포 query를
+ * 7d 윈도우로 별도 노출 — SQL 본문 외엔 동일.
+ *
+ * 사용처
+ *   - `recallAlerts.ts:fetchGateBreakdown` — alert payload `gateBreakdown` 임베드.
+ */
+export const gateSuppressionDistribution7dQuery = `
+SELECT
+  substring(blob1, ${GATE_LABEL_PREFIX.length + 1}) AS reason,
+  SUM(double1) AS suppressed_count
+FROM ${RECALL_DATASET}
+WHERE timestamp > NOW() - INTERVAL '7' DAY
+  AND blob1 LIKE '${GATE_LABEL_PREFIX}%'
+GROUP BY reason
+ORDER BY suppressed_count DESC
+`.trim();
+
+/**
  * Query 목록 — 카탈로그 형태로 노출해 endpoint가 순회. 새 query 추가 시 본 배열에 등록만.
  */
 export interface RecallQueryEntry {


### PR DESCRIPTION
Closes #997

## Summary

PR #976 (#972 low-recall webhook) 후속. Alert receiver에게 root cause 단서를 즉시 노출하기 위해 payload schema 확장.

## Schema diff

```ts
// 추가 필드
timeWindow: { from: number; to: number };      // 7d 윈도우 epoch ms
gateBreakdown: Array<{ reason: string; count: number }>;  // top 5, count desc
// `text`는 기존 형태 유지 + `\nTop gates: reason=count` 1줄 append
```

기존 `kind` / `ratio` / `threshold` / `sampleSize` / `observedAt` / `text`는 동일 — Slack incoming webhook 호환 유지.

## 주요 결정

- **Window 일치성**: `lowRecallTripRatioQuery`는 7d, 기존 `gateSuppressionDistributionQuery`는 14d. payload `timeWindow=7d`와 `gateBreakdown=14d`가 어긋나 receiver가 deep-link 만들 때 잘못 인식. 새 `gateSuppressionDistribution7dQuery` 추가로 정확히 동일 윈도우 보장. dashboard용 14d 쿼리는 SSOT로 그대로 보존.
- **Fail-soft 격리**: gate breakdown fetch 실패는 빈 배열로 degrade — alert 본 흐름(ratio breach 발사)은 차단하지 않음. 기존 4단 graceful no-op + dedup + webhook fail-soft 회귀 없음.
- **Top N(5) truncation + 재정렬**: SQL이 desc 정렬 보장하지만 본 함수가 truncate 책임을 가지므로 race-safe하게 재정렬.
- **`platformBreakdown` / `topFailingStations`는 별도 이슈**: 현 `recordRecallUpload`가 platform·stationId를 AE blob에 적재하지 않음. write path 변경이 필요해 본 PR scope 분리.

## AE-pending no-op

`TELEMETRY` binding / 3 secret 부재 시 즉시 noop. Workers Paid + secret 등록 시 자동 동작.

## Test plan

- [x] `npx vitest run` (backend, 27 files / 956 tests) pass
- [x] `npm test` (root jest, 226 files / 4167 tests, coverage 100%) pass
- [x] `npm run type-check` pass
- [x] `recallAlerts.test.ts` 21 case (기존 16 + 신규 5)
  - top N(5) truncate + count desc 재정렬
  - malformed row drop (빈 reason, 음수 count, 비숫자 count, 누락 필드)
  - gate SQL non-ok / throw → 빈 gateBreakdown, alert는 정상 발사
  - default noop logger silent fail