### PR TITLE
test(#999): Maestro 회귀 시나리오 wave 3 — Seam G + LA refresh

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -168,6 +168,8 @@ jobs:
           - seam-f-13-24
           - seam-a-delay-chip
           - seam-d-debug-entry
+          - seam-g-sticky-wireup
+          - seam-la-refresh-heartbeat
           # Seam C는 transfer-leg / FG-return 이벤트 mock 설계 결함으로 보류
           # ([[project-2026-06-05-epic-912-session-end]]).
     env:

--- a/.maestro/flows/regression/README.md
+++ b/.maestro/flows/regression/README.md
@@ -1,8 +1,8 @@
 # Maestro 회귀 fixture (#922)
 
 2026-06-05 실기기에서 발생한 4건의 알람 회귀(Seam B/C/E/F)와 후속 Seam A(#897 lock 지연 칩),
-Seam D(#456 DebugModal 진입)를 단위 테스트 외에 실기기-동등 환경에서 회귀 가드로 잡기 위한
-Maestro flow 모음.
+Seam D(#456 DebugModal 진입), Seam G(#903 barometer sticky wireup), LA refresh heartbeat
+(#900)을 단위 테스트 외에 실기기-동등 환경에서 회귀 가드로 잡기 위한 Maestro flow 모음.
 
 ## 구성
 
@@ -38,6 +38,8 @@ maestro test .maestro/flows/regression/seam-b-13-19.yaml
 | `seam-f-13-24.yaml` | F | 13:24~28 trainCode 7174 사라짐 | 25s 시점 trainCode drop 후에도 lockMissing/ghost 알람 발사 0건 |
 | `seam-a-delay-chip.yaml` | A | #897 lock 지연 칩 | 어린이대공원에서 7180 lock 후 phase 30s 전환 → `boarding-lock-hop-delay-chip` `+4분 지연` 노출 |
 | `seam-d-debug-entry.yaml` | D | #456 DebugModal 진입 | 설정 탭 → version footer 7-tap → `debug-modal` + `debug-arrival-summary` 노출, close 정상 |
+| `seam-g-sticky-wireup.yaml` | G | #903 barometer sticky wireup | 지하 좌표(보문) 단순 trip 90s 안정 — sticky 강등/알람 게이트 wire-up 회귀 시 ghost 알람 표면화 |
+| `seam-la-refresh-heartbeat.yaml` | LA-heartbeat | #900 LA refresh heartbeat | ETA 정체(arrivalSeconds=180 stable) 90s 동안 트립 chip + 알람 안정. heartbeat 게이트 회귀 시 ghost 표면화 |
 
 보류:
 - Seam C — 13:23 waypoint advanced + 14:02 stale chip. transfer-leg / FG-return /
@@ -51,7 +53,7 @@ maestro test .maestro/flows/regression/seam-b-13-19.yaml
 ```jsonc
 {
   "name": "사람이 읽을 시나리오 설명",
-  "seam": "B|C|E|F",
+  "seam": "A|B|C|D|E|F|G|LA-heartbeat",
   "arrivals": {
     "<역 이름>": [
       {

--- a/.maestro/flows/regression/seam-g-sticky-wireup.yaml
+++ b/.maestro/flows/regression/seam-g-sticky-wireup.yaml
@@ -1,0 +1,76 @@
+appId: com.subwaynow.app
+name: "regression - Seam G (#922) — barometer sticky wireup (#903)"
+# Epic #896 Seam G(#903) 회귀 가드. useBarometer.subsurface가 sticky/fusion/alarm 게이트로
+# 흐르는 wireup이 회귀하면 지하 구간에서 false-positive 알람이 폭발한다(GPS-only 좌표가
+# 인접 역으로 jump → ghost transfer/early 알람).
+#
+# Maestro 시뮬레이터는 expo-sensors Barometer를 토글할 수 없으므로 본 flow는 지하 구간 좌표
+# (보문, 6-029) + 안암(6-030) 단순 trip에서 client UI가 ghost 알람을 발사하지 않고 트립
+# chip이 보문에 안정됨을 검증한다 — Seam G wire-up이 깨지면 sticky 강등 + 알람 게이트 부재
+# 로 false-positive가 표면화한다.
+#
+# 전제: scripts/maestro-mock-backend.js가 SCENARIO=seam-g-sticky-wireup PORT=8788로 떠 있고
+# 앱은 EXPO_PUBLIC_BFF_URL/EXPO_PUBLIC_ALARM_BACKEND_URL로 mock을 가리키도록 빌드되어야 한다.
+---
+- setLocation:
+    latitude: 37.585274
+    longitude: 127.019351
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 보문 확인 (한/영 둘 다 매칭)
+- assertVisible:
+    text: "보문|Bomun"
+
+# 목적지: 안암 (6호선 단순 trip — Seam G의 핵심은 sticky/alarm wire-up 안정성)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "안암"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-6-030"
+- waitForAnimationToEnd
+
+# 트립 형성 후 90초 대기 — arrival 폴링 30s × 3 cycle 확보.
+# Seam G wire-up이 회귀하면 sticky 강등 + 알람 게이트 부재로 ghost 발사가 표면화한다.
+- repeat:
+    times: 90
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# Seam G 회귀 검증: false-positive 알람 발사 시 실패.
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# 트립 chip은 보문에 안정 — sticky 강등이 ghost jump를 만들면 안 됨.
+- assertVisible:
+    text: "보문|Bomun"

--- a/.maestro/flows/regression/seam-la-refresh-heartbeat.yaml
+++ b/.maestro/flows/regression/seam-la-refresh-heartbeat.yaml
@@ -1,0 +1,79 @@
+appId: com.subwaynow.app
+name: "regression - LA refresh heartbeat (#922) — ETA 정체 구간 트립 안정성 (#900)"
+# Epic #896 Seam D / #900 LA refresh heartbeat 회귀 가드. backend(alarm-worker scheduled)의
+# maybeFireLiveActivityUpdate가 ΔETA ≥ 30s 또는 (now − lastLaPushAt) ≥ 60s 시 LA push를
+# 발사해 ETA 정체 구간에서도 LA content-state stale을 방지한다.
+#
+# Maestro 시뮬레이터는 LA/APNs 발사 횟수를 직접 관찰할 수 없으므로 본 flow는 어린이대공원
+# (7-016) 좌표에서 ETA 90s 정체 시나리오(arrivalSeconds=180 stable) 동안 client UI가
+# stable 유지되고 false-positive 알람 발사 없음을 검증한다. heartbeat 발사 회수 자체는
+# alarm-worker 단위 테스트가 cron mock으로 검증한다.
+#
+# 전제: scripts/maestro-mock-backend.js가 SCENARIO=seam-la-refresh-heartbeat PORT=8788로
+# 떠 있고 앱은 EXPO_PUBLIC_BFF_URL/EXPO_PUBLIC_ALARM_BACKEND_URL로 mock을 가리키도록
+# 빌드되어야 한다.
+---
+- setLocation:
+    latitude: 37.548014
+    longitude: 127.074658
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 어린이대공원 확인 (한/영 둘 다 매칭)
+- assertVisible:
+    text: "어린이대공원|Children"
+
+# 목적지: 군자 (7호선 단순 trip — LA heartbeat의 핵심은 ETA 정체 구간 stability)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "군자"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-7-017"
+- waitForAnimationToEnd
+
+# 트립 형성 후 90초 대기 — heartbeat 윈도(60s) 초과 + 폴링 30s × 3 cycle.
+# ETA가 arrivalSeconds=180으로 stable이므로 ΔETA=0 → 정상 동작 시 heartbeat path만 발사.
+# 회귀(heartbeat 게이트 미적용) 시 LA stale로 트립 진행 chip이 ghost로 jump하거나
+# false-positive 알람이 발사된다.
+- repeat:
+    times: 90
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# heartbeat 회귀 검증: ETA 정체 구간에서 false-positive 알람 발사 시 실패.
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# 트립 chip은 어린이대공원에 안정 — ETA 정체로 ghost waypoint advance가 일어나면 안 됨.
+- assertVisible:
+    text: "어린이대공원|Children"

--- a/scripts/fixtures/regression/seam-g-sticky-wireup.json
+++ b/scripts/fixtures/regression/seam-g-sticky-wireup.json
@@ -1,0 +1,67 @@
+{
+  "name": "Seam G — barometer sticky wireup (#903)",
+  "seam": "G",
+  "_doc": [
+    "Epic #896 Seam G(#903) 회귀 가드. useBarometer.subsurface 신호가",
+    "useNearestStation / useFusedNearestStation → Sticky automotive 입력으로 흐르고",
+    "evaluateAlarmPhase가 degradedConfidence=true 시 early/transfer phase를 차단한다.",
+    "",
+    "Maestro fixture는 device-level 압력 시뮬레이션을 직접 토글할 수 없으므로(시뮬레이터에서",
+    "expo-sensors Barometer가 미지원), 본 시나리오는 sticky wireup의 **client-observable",
+    "표면 안정성**을 회귀 가드한다:",
+    "  - 지하 구간 좌표(보문, 6-029)에서 안암으로 단순 trip 형성",
+    "  - 안암 도착 ETA를 5분으로 stable 응답 → false-positive 알람 발사 없음",
+    "  - 트립 chip이 보문에 안정 (sticky 강등으로 인한 ghost chip jump 없음)",
+    "",
+    "Seam G 단위 테스트(barometerState/useBarometer/useStickyStation)가 압력→sticky→alarm",
+    "신호 경로를 검증하고, 본 fixture는 그 결과가 UI 표면에 ghost 알람을 만들지 않음을 가드한다."
+  ],
+  "arrivals": {
+    "보문": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "응암",
+              "arrivalMinutes": 3,
+              "arrivalSeconds": 180,
+              "statusMessage": "3분 후 도착",
+              "trainCode": "6029",
+              "line": "6",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ],
+    "안암": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "응암",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "6029",
+              "line": "6",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ]
+  }
+}

--- a/scripts/fixtures/regression/seam-la-refresh-heartbeat.json
+++ b/scripts/fixtures/regression/seam-la-refresh-heartbeat.json
@@ -1,0 +1,66 @@
+{
+  "name": "LA refresh heartbeat (#900) — ETA 정체 구간 트립 안정성",
+  "seam": "LA-heartbeat",
+  "_doc": [
+    "Epic #896 Seam D / #900 LA refresh heartbeat 회귀 가드. backend(alarm-worker scheduled)",
+    "의 maybeFireLiveActivityUpdate는 ΔETA ≥ 30s 또는 (now − lastLaPushAt) ≥ 60s일 때 LA push",
+    "를 발사해 ETA 정체 구간에서도 content-state stale을 방지한다.",
+    "",
+    "Maestro는 APNs/LA push 발사 수를 직접 관찰할 수 없으므로(LA는 iOS 시스템 영역), 본 fixture는",
+    "**클라이언트 표면 안정성**을 회귀 가드한다:",
+    "  - 어린이대공원(7-016) → 군자(7-017) 단순 trip 형성",
+    "  - 어린이대공원 ETA가 90s 동안 arrivalSeconds=180 (3분)으로 stable → ΔETA 0, heartbeat 윈도 진입",
+    "  - 그 동안 client UI(트립 chip, lock 카드, 알람)가 stable, ghost 발사 0건",
+    "",
+    "backend heartbeat 발사 회수 자체는 alarm-worker 단위 테스트가 cron mock으로 검증한다.",
+    "본 fixture는 정체된 ETA가 client에 false-positive 회귀를 유발하지 않음을 가드한다."
+  ],
+  "arrivals": {
+    "어린이대공원": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "장암",
+              "arrivalMinutes": 3,
+              "arrivalSeconds": 180,
+              "statusMessage": "3분 후 도착",
+              "trainCode": "7180",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ],
+    "군자": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "장암",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "7180",
+              "line": "7",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #999
Refs #922 #912 #903 #900

Parent epic #912 P2 E1 후속. PR #927(infra+Seam B) → #953(Seam F+E) → #988(Seam A+D wave 2) → 본 wave 3.

## Summary
- **Seam G (#903 barometer sticky wireup)**: 지하 좌표(보문, 6-029) → 안암(6-030) 단순 trip 90s. 시뮬레이터는 expo-sensors Barometer 토글 불가하므로 wire-up이 회귀하면 표면화되는 false-positive 알람/ghost chip jump를 클라이언트 표면에서 회귀 가드.
- **LA refresh heartbeat (#900)**: 어린이대공원(7-016) → 군자(7-017) 단순 trip. ETA arrivalSeconds=180 stable 90s 동안 heartbeat 윈도 진입 — 트립 chip + 알람이 stable, ghost 발사 0건 검증. heartbeat 발사 회수 자체는 alarm-worker 단위 테스트 영역.
- regression matrix 5 → 7 cells(B/E/F/A/D + **G/LA-heartbeat**).

## 설계 의도
- **Seam G**: useBarometer.subsurface → useNearestStation/useFusedNearestStation → Sticky automotive 입력 → evaluateAlarmPhase degradedConfidence 게이트로 흐르는 wireup이 단위 테스트 외 회귀하면 지하 false-positive가 폭발한다. UI 표면에서 false-positive 발사 0건을 가드.
- **LA refresh heartbeat**: backend maybeFireLiveActivityUpdate가 (now − lastLaPushAt) ≥ 60s 시 LA push를 발사해 정체 구간 stale 방지. LA push 발사 자체는 Maestro 관찰 불가지만 정체 구간에서 트립 chip이 ghost로 jump하지 않음을 가드.
- Seam C 보류 사유 동일 (transfer-leg / FG-return event mock 인프라 결함).

## Files
- `scripts/fixtures/regression/seam-g-sticky-wireup.json` — 보문/안암 stable ETA fixture
- `scripts/fixtures/regression/seam-la-refresh-heartbeat.json` — 어린이대공원/군자 ETA 정체(arrivalSeconds=180) fixture
- `.maestro/flows/regression/seam-g-sticky-wireup.yaml`
- `.maestro/flows/regression/seam-la-refresh-heartbeat.yaml`
- `.github/workflows/e2e.yml` — regression matrix 2 cell 추가
- `.maestro/flows/regression/README.md` — 인덱스 + seam schema enum 갱신

## Test plan
- [x] `npm test` (4167/4167 passed, 100% coverage 유지)
- [x] `npm run type-check` pass
- [x] YAML/JSON 문법 검증 (js-yaml.loadAll, JSON.parse)
- [x] mock backend 로컬 smoke (`/healthz`, `/api/arrival/<역>` 정상 — seam-g, seam-la 각각)
- [x] Maestro deprecated 명령어(`clearText`) 사용 0건
- [x] code-review (low) — (none)
- [ ] nightly E2E Regression 7 cells 모두 green (PR 머지 후 cron 또는 workflow_dispatch)