### PR TITLE
feat(#1028): "탔어요?" 푸시 와이어업 — boarding-prompt 컨텍스트 송신

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1009,4 +1009,60 @@ describe('useApnsTripRegistration', () => {
       expect(refreshed?.[0].subsurface).toBe(true);
     });
   });
+
+  describe('boarding-prompt 컨텍스트 (#1028)', () => {
+    it('currentStation이 destination과 다르면 promptGeoContext/promptDisplay 송신', async () => {
+      // 단조 line(3호선) 대화(3-001) → 정발산(3-003) — buildBoardingPromptContext가 non-null 반환.
+      const origin: Station = {
+        id: '3-001',
+        name: '대화',
+        line: '3',
+        lat: 37.676087,
+        lng: 126.747569,
+        lineColor: '#EF7C1C',
+      };
+      const dest: Station = {
+        id: '3-003',
+        name: '정발산',
+        line: '3',
+        lat: 37.659477,
+        lng: 126.773359,
+        lineColor: '#EF7C1C',
+      };
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: makeDirectRoute(2, '3'),
+          destination: dest,
+          nextStationEtaSeconds: 120,
+          currentStation: origin,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+      const args = mockRegister.mock.calls[0][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number }; direction: string | null };
+        promptDisplay?: { originStation: string; line: string };
+      };
+      expect(args.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+      expect(args.promptGeoContext?.direction).toBe('down');
+      expect(args.promptDisplay).toEqual({ originStation: '대화', line: '3' });
+    });
+
+    it('currentStation === destination이면 컨텍스트 누락 (backend 자동 skip)', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+      const args = mockRegister.mock.calls[0][0] as {
+        promptGeoContext?: unknown;
+        promptDisplay?: unknown;
+      };
+      expect(args.promptGeoContext).toBeUndefined();
+      expect(args.promptDisplay).toBeUndefined();
+    });
+  });
 });

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -25,6 +25,7 @@ import { routeSignature, getStationById } from '../../../shared/utils/stationRou
 import { registerActiveTrip, clearActiveTrip, type AlarmBoardingLock } from '../api/alarmBackend';
 import { routeToWaypoints } from '../../route/utils/routeWaypoints';
 import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
+import { buildBoardingPromptContext } from '../utils/boardingPromptContext';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
@@ -111,6 +112,14 @@ async function callRegister(input: RegisterCallInputs) {
     }
   }
 
+  // #1028: boarding-prompt 평가 컨텍스트 (#819). 둘 다 있어야 backend가 9단 게이트를 돌리므로
+  // 항상 함께 송신. currentStation/route lookup 실패 시 null → 필드 누락 → backend 자동 skip.
+  const promptContext = buildBoardingPromptContext({
+    route: input.route,
+    currentStation: input.currentStation,
+    destination: input.destination,
+  });
+
   return registerActiveTrip({
     token: input.token,
     route: input.route,
@@ -122,6 +131,13 @@ async function callRegister(input: RegisterCallInputs) {
     ...(boardingLockMeta ? { boardingLock: boardingLockMeta } : {}),
     // #816 C — 토글 ON이면 backend에 lockless station-passed opt-in 명시. OFF면 필드 누락.
     ...(input.locklessStationPassed ? { locklessStationPassed: true } : {}),
+    // #819 / #1028 — boarding-prompt 평가/표시 컨텍스트. 짝으로만 송신.
+    ...(promptContext
+      ? {
+          promptGeoContext: promptContext.promptGeoContext,
+          promptDisplay: promptContext.promptDisplay,
+        }
+      : {}),
     // #903 (Seam G) — 기압계 subsurface ON일 때만 송신. OFF/false는 필드 누락(graceful).
     ...(input.subsurface ? { subsurface: true } : {}),
   });

--- a/src/features/alarm/utils/__tests__/boardingPromptContext.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingPromptContext.test.ts
@@ -1,0 +1,142 @@
+import { buildBoardingPromptContext } from '../boardingPromptContext';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../../../testUtils/routeFixtures';
+import { getStationById } from '../../../../shared/utils/stationRoute';
+import type { Station } from '../../../../shared/types/station';
+
+function st(id: string): Station {
+  const s = getStationById(id);
+  if (!s) throw new Error(`fixture station not found: ${id}`);
+  return s;
+}
+
+describe('buildBoardingPromptContext', () => {
+  it('route가 null이면 null', () => {
+    expect(
+      buildBoardingPromptContext({
+        route: null,
+        currentStation: st('3-001'),
+        destination: st('3-003'),
+      }),
+    ).toBeNull();
+  });
+
+  it('currentStation이 null이면 null', () => {
+    expect(
+      buildBoardingPromptContext({
+        route: makeDirectRoute(2, '3'),
+        currentStation: null,
+        destination: st('3-003'),
+      }),
+    ).toBeNull();
+  });
+
+  it('destination이 null이면 null', () => {
+    expect(
+      buildBoardingPromptContext({
+        route: makeDirectRoute(2, '3'),
+        currentStation: st('3-001'),
+        destination: null,
+      }),
+    ).toBeNull();
+  });
+
+  describe('DirectRoute', () => {
+    it('단조 line(3호선) — origin/next 좌표 + direction 채워짐', () => {
+      const current = st('3-001'); // 대화
+      const dest = st('3-003'); // 정발산
+      const next = st('3-002'); // 주엽
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(2, '3'),
+        currentStation: current,
+        destination: dest,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptGeoContext.origin).toEqual({ lat: current.lat, lng: current.lng });
+      expect(ctx?.promptGeoContext.nextStation).toEqual({ lat: next.lat, lng: next.lng });
+      // 대화는 low endpoint → 정발산 방향은 high(down)
+      expect(ctx?.promptGeoContext.direction).toBe('down');
+      expect(ctx?.promptDisplay.originStation).toBe('대화');
+      expect(ctx?.promptDisplay.line).toBe('3');
+    });
+
+    it('단조 line 역방향 — direction up', () => {
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(2, '3'),
+        currentStation: st('3-003'),
+        destination: st('3-001'),
+      });
+      expect(ctx?.promptGeoContext.direction).toBe('up');
+    });
+
+    it('비단조 line(2호선 순환) — direction null', () => {
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(2, '2'),
+        currentStation: st('2-001'),
+        destination: st('2-003'),
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptGeoContext.direction).toBeNull();
+      expect(ctx?.promptDisplay.line).toBe('2');
+    });
+
+    it('next station lookup 실패(current===destination) → null', () => {
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(0, '3'),
+        currentStation: st('3-001'),
+        destination: st('3-001'),
+      });
+      expect(ctx).toBeNull();
+    });
+  });
+
+  describe('TransferRoute', () => {
+    it('첫 leg = fromLine, next는 첫 leg 다음 역', () => {
+      // 3호선 대화(3-001) → 교대(3-032) 환승 → 2호선 강남(2-022)
+      const current = st('3-001'); // 대화
+      const dest = st('2-022'); // 강남
+      const ctx = buildBoardingPromptContext({
+        route: makeTransferRoute({
+          transferName: '교대',
+          fromLine: '3',
+          toLine: '2',
+          stopsToTransfer: 31,
+          stopsFromTransfer: 1,
+        }),
+        currentStation: current,
+        destination: dest,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptDisplay.line).toBe('3'); // fromLine
+      expect(ctx?.promptDisplay.originStation).toBe('대화');
+      // 대화 다음은 주엽
+      const next = st('3-002');
+      expect(ctx?.promptGeoContext.nextStation).toEqual({ lat: next.lat, lng: next.lng });
+    });
+  });
+
+  describe('MultiTransferRoute', () => {
+    it('첫 segment의 fromLine으로 평가', () => {
+      const current = st('3-001'); // 대화
+      const dest = st('2-022'); // 강남
+      const ctx = buildBoardingPromptContext({
+        route: makeMultiTransferRoute({
+          transfers: [
+            { transferName: '교대', fromLine: '3', toLine: '2', stopsToTransfer: 31 },
+            { transferName: '강남', fromLine: '2', toLine: 'sinbundang', stopsToTransfer: 1 },
+          ],
+          stopsAfterLastTransfer: 0,
+        }),
+        currentStation: current,
+        destination: dest,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptDisplay.line).toBe('3');
+      const next = st('3-002');
+      expect(ctx?.promptGeoContext.nextStation).toEqual({ lat: next.lat, lng: next.lng });
+    });
+  });
+});

--- a/src/features/alarm/utils/boardingPromptContext.ts
+++ b/src/features/alarm/utils/boardingPromptContext.ts
@@ -1,0 +1,96 @@
+/**
+ * "탔어요?" 푸시(#819) 평가 컨텍스트 빌더.
+ *
+ * backend `evaluateAndMaybeFireBoardingPrompt`는 `trip.promptGeoContext` +
+ * `trip.promptDisplay`가 모두 있어야 9단 게이트 평가를 진행한다. 둘 중 하나라도
+ * 없으면 skip이므로, register payload에 컨텍스트를 동봉해야 발사 0건 상태를 해소한다.
+ *
+ * 전제: boarding-prompt는 **leg 0 미시작(=탑승 전)** 상황에서만 의미 있다. backend의
+ * 9단 게이트가 `origin` 근접 + `nextStation` 방향 이동을 검사하므로, 사용자가 첫 leg를
+ * 이미 진행 중이면 게이트가 자연 차단된다(또는 다른 분기로 위임). 따라서 mid-trip
+ * transfer 등에서 first-leg와 active-leg가 어긋나도 잘못된 발사로 이어지지 않는다.
+ *
+ * 컨텍스트:
+ *   - origin: 호출 시점의 GPS-nearest 역(= 탑승 후보) 좌표
+ *   - nextStation: 첫 leg에서 origin 다음 역 좌표
+ *   - direction: 첫 leg의 진행 방향(단조 라인만), 비단조면 null (양방향 허용)
+ *   - originStation: 사용자 표시용 역 이름
+ *   - line: 첫 leg 라인 (boarding 단계 노선)
+ *
+ * `currentStation === null`이거나 next/lookup 실패 시 null 반환 — backend는 자동 skip.
+ *
+ * TODO(#1028 follow-up): firstLeg 추출은 tripDirection.ts에도 중복 존재. shared util로 분리 예정.
+ */
+
+import type { Station, LineNumber } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
+import {
+  findStationByNameAndLine,
+  getNextStationName,
+} from '../../../shared/utils/stationRoute';
+import { resolveTravelDirection } from '../../route/utils/travelDirection';
+
+export interface BoardingPromptContext {
+  promptGeoContext: {
+    origin: { lat: number; lng: number };
+    nextStation: { lat: number; lng: number };
+    direction: 'up' | 'down' | null;
+  };
+  promptDisplay: {
+    originStation: string;
+    line: string;
+  };
+}
+
+interface BuildInputs {
+  route: Route;
+  currentStation: Station | null;
+  destination: Station | null;
+}
+
+interface FirstLeg {
+  line: LineNumber;
+  endName: string;
+}
+
+function firstLeg(route: NonNullable<Route>, destinationName: string): FirstLeg {
+  if (route.type === 'direct') {
+    return { line: route.line, endName: destinationName };
+  }
+  if (route.type === 'transfer') {
+    return { line: route.fromLine, endName: route.transferName };
+  }
+  const first = route.transfers[0];
+  return { line: first.fromLine, endName: first.transferName };
+}
+
+export function buildBoardingPromptContext({
+  route,
+  currentStation,
+  destination,
+}: BuildInputs): BoardingPromptContext | null {
+  if (!route || !currentStation || !destination) return null;
+
+  const leg = firstLeg(route, destination.name);
+  const nextName = getNextStationName(currentStation.id, destination.id, route);
+  if (!nextName) return null;
+
+  const nextStation = findStationByNameAndLine(nextName, leg.line);
+  /* istanbul ignore next -- getNextStationName이 같은 line에서 lookup한 name이므로 재조회 실패 불가 */
+  if (!nextStation) return null;
+
+  const resolved = resolveTravelDirection(leg.line, currentStation.name, leg.endName);
+  const direction = resolved ? resolved.direction : null;
+
+  return {
+    promptGeoContext: {
+      origin: { lat: currentStation.lat, lng: currentStation.lng },
+      nextStation: { lat: nextStation.lat, lng: nextStation.lng },
+      direction,
+    },
+    promptDisplay: {
+      originStation: currentStation.name,
+      line: leg.line,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- `buildBoardingPromptContext` util 신규 — route + currentStation + destination 에서 `promptGeoContext`(origin/nextStation/direction) + `promptDisplay`(originStation/line) 를 도출
- `useApnsTripRegistration`의 `callRegister` payload 에 컨텍스트를 spread 해 #819 backend 가 boarding-prompt 평가를 진행할 수 있도록 와이어업
- 단조 line 은 direction up/down, 비단조 line 은 null(양방향 허용). currentStation 없거나 lookup 실패 시 필드 누락 → backend 자동 skip

Closes #1028

## Follow-up
- `firstLeg` 도출 로직이 `tripDirection.ts` 와 중복 — 후속 이슈에서 dedup 예정

## Test plan
- [x] `npm test` (커버리지 100% 게이트 통과)
- [x] `npm run type-check`
- [x] `buildBoardingPromptContext` 단위 테스트: 단조/비단조 line direction, 미존재 station, lookup miss
- [x] `useApnsTripRegistration` 통합 테스트: payload spread, 컨텍스트 누락 시 필드 미송신
- [ ] 실기기: 백엔드 로그에서 `promptGeoContext` / `promptDisplay` 수신 확인