### PR TITLE
feat(#1029): HomeScreen pull-to-refresh — 위치/도착 정보 수동 갱신

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AppState, InteractionManager, Pressable, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { AppState, InteractionManager, Pressable, RefreshControl, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
@@ -226,12 +226,24 @@ export default function HomeScreen() {
   // #797: 환승역에서 nearest.station.line이 trip 방향과 어긋나는 회귀 차단.
   // BoardingLock(사용자 선택) > Route(구조적 SSOT) > station.line fallback.
   const approachLine = getApproachLine(route, fusionBoardingLock, effectiveOrigin);
-  const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading } = useArrivalInfo(
+  const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading, refetch: refetchArrival } = useArrivalInfo(
     effectiveOrigin?.name ?? null,
     approachLine,
   );
   const arrival = useArrivalCountdown(rawArrival);
   const isFav = effectiveOrigin ? favorites.some((f) => f.station.id === effectiveOrigin.id) : false;
+
+  // #1029 pull-to-refresh: 사용자 트리거에만 spinner 표시 (background polling과 분리).
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+  const handleRefresh = useCallback(async () => {
+    setIsManualRefreshing(true);
+    try {
+      await refresh();
+      refetchArrival();
+    } finally {
+      setIsManualRefreshing(false);
+    }
+  }, [refresh, refetchArrival]);
 
   // 환승역이면 모든 호선 변형에서 경로 계산 → 출발역 환승 없는 최적 경로 자동 선택
   const originVariants = !isCustomOrigin && variants.length > 1 ? variants : effectiveOrigin ? [effectiveOrigin] : [];
@@ -694,7 +706,10 @@ export default function HomeScreen() {
         onClose={dismissTransferDetectModal}
       />
 
-      <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: 80 }}
+        refreshControl={<RefreshControl refreshing={isManualRefreshing} onRefresh={handleRefresh} />}
+      >
         {effectiveOrigin ? (
           <>
             {/* Hero: origin station */}


### PR DESCRIPTION
## Summary
- HomeScreen 최상위 ScrollView에 `RefreshControl` 부착 — 사용자가 당기면 fused nearest-station + arrival info를 동시에 수동 갱신
- `useFusedNearestStation.refresh()` await 후 `useArrivalInfo.refetch()` 호출
- spinner는 사용자 트리거에만 표시되도록 별도 `useState`로 추적 (background 30s polling과 분리되어 idle 시 spinner 노출 없음)

## Test plan
- [ ] iOS 실기기에서 HomeScreen을 아래로 당겨 spinner가 표시되는지 확인
- [ ] 당김 직후 station chip / arrival ETA가 즉시 갱신되는지 확인
- [ ] 백그라운드 polling 중에는 spinner가 뜨지 않는지 확인 (idle 상태에서 무의미한 spinner 노출 없음)
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (4167 tests, coverage 100%)

Closes #1029