### PR TITLE
feat(#1032): 최근 경로 3개 확장 + 개별 삭제 UI

### DIFF
--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -46,7 +46,7 @@ describe('useDestinationStore', () => {
   beforeEach(() => {
     useDestinationStore.setState({
       destination: null,
-      recentDestination: null,
+      recentDestinations: [],
       customOrigin: null,
       tripOrigin: null,
       routePreference: 'optimal',
@@ -323,28 +323,116 @@ describe('useDestinationStore', () => {
     expect(useDestinationStore.getState().destination).toBeNull();
   });
 
-  // ── recentDestination ──
+  // ── recentDestinations (#1032) ──
 
-  it('초기 recentDestination은 null이다', () => {
-    const { recentDestination } = useDestinationStore.getState();
-    expect(recentDestination).toBeNull();
+  it('초기 recentDestinations는 빈 배열이다', () => {
+    const { recentDestinations } = useDestinationStore.getState();
+    expect(recentDestinations).toEqual([]);
   });
 
-  it('setRecentDestination: 역을 설정하면 상태가 업데이트된다', () => {
-    const { setRecentDestination } = useDestinationStore.getState();
-    setRecentDestination(mockStation);
+  it('addRecentDestination: 최근 선택이 맨 앞으로 추가된다', () => {
+    const { addRecentDestination } = useDestinationStore.getState();
+    addRecentDestination(mockStation);
+    addRecentDestination(mockStation2);
 
-    const { recentDestination } = useDestinationStore.getState();
-    expect(recentDestination?.id).toBe('2-022');
+    const { recentDestinations } = useDestinationStore.getState();
+    expect(recentDestinations.map((s) => s.id)).toEqual(['2-021', '2-022']);
   });
 
-  it('setRecentDestination: null을 설정하면 초기화된다', () => {
-    const { setRecentDestination } = useDestinationStore.getState();
-    setRecentDestination(mockStation);
-    setRecentDestination(null);
+  it('addRecentDestination: 동일 station id는 dedup되고 최신이 맨 앞으로 이동', () => {
+    const { addRecentDestination } = useDestinationStore.getState();
+    addRecentDestination(mockStation);
+    addRecentDestination(mockStation2);
+    addRecentDestination(mockStation); // 재선택
 
-    const { recentDestination } = useDestinationStore.getState();
-    expect(recentDestination).toBeNull();
+    const { recentDestinations } = useDestinationStore.getState();
+    expect(recentDestinations.map((s) => s.id)).toEqual(['2-022', '2-021']);
+  });
+
+  it('addRecentDestination: 최대 3개로 제한된다 (LRU 잘림)', () => {
+    const { addRecentDestination } = useDestinationStore.getState();
+    const s3: Station = { ...mockStation, id: '2-020', name: '선릉' };
+    const s4: Station = { ...mockStation, id: '2-019', name: '삼성' };
+    addRecentDestination(mockStation);
+    addRecentDestination(mockStation2);
+    addRecentDestination(s3);
+    addRecentDestination(s4);
+
+    const { recentDestinations } = useDestinationStore.getState();
+    expect(recentDestinations.map((s) => s.id)).toEqual(['2-019', '2-020', '2-021']);
+  });
+
+  it('addRecentDestination: AsyncStorage에 영속화한다', () => {
+    const { addRecentDestination } = useDestinationStore.getState();
+    addRecentDestination(mockStation);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'subway-now:recent-destinations',
+      JSON.stringify([mockStation]),
+    );
+  });
+
+  it('removeRecentDestination: 지정 id만 제거한다', () => {
+    const { addRecentDestination, removeRecentDestination } = useDestinationStore.getState();
+    addRecentDestination(mockStation);
+    addRecentDestination(mockStation2);
+    removeRecentDestination('2-022');
+
+    const { recentDestinations } = useDestinationStore.getState();
+    expect(recentDestinations.map((s) => s.id)).toEqual(['2-021']);
+    expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
+      'subway-now:recent-destinations',
+      JSON.stringify([mockStation2]),
+    );
+  });
+
+  it('removeRecentDestination: 마지막 항목 제거 시 AsyncStorage 키도 삭제', () => {
+    const { addRecentDestination, removeRecentDestination } = useDestinationStore.getState();
+    addRecentDestination(mockStation);
+    removeRecentDestination('2-022');
+
+    const { recentDestinations } = useDestinationStore.getState();
+    expect(recentDestinations).toEqual([]);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:recent-destinations');
+  });
+
+  it('loadRecentDestinations: storage에서 hydrate되며 최대 3개로 자른다', async () => {
+    const s3: Station = { ...mockStation, id: '2-020' };
+    const s4: Station = { ...mockStation, id: '2-019' };
+    await AsyncStorage.setItem(
+      'subway-now:recent-destinations',
+      JSON.stringify([mockStation, mockStation2, s3, s4]),
+    );
+
+    const { loadRecentDestinations } = useDestinationStore.getState();
+    await loadRecentDestinations();
+
+    const { recentDestinations } = useDestinationStore.getState();
+    expect(recentDestinations.map((s) => s.id)).toEqual(['2-022', '2-021', '2-020']);
+  });
+
+  it('loadRecentDestinations: 키 부재 시 빈 배열을 유지한다', async () => {
+    await AsyncStorage.removeItem('subway-now:recent-destinations');
+    const { loadRecentDestinations } = useDestinationStore.getState();
+    await loadRecentDestinations();
+
+    expect(useDestinationStore.getState().recentDestinations).toEqual([]);
+  });
+
+  it('loadRecentDestinations: 비배열 JSON은 무시한다', async () => {
+    await AsyncStorage.setItem('subway-now:recent-destinations', JSON.stringify({ bogus: true }));
+    const { loadRecentDestinations } = useDestinationStore.getState();
+    await loadRecentDestinations();
+
+    expect(useDestinationStore.getState().recentDestinations).toEqual([]);
+  });
+
+  it('loadRecentDestinations: 손상된 JSON에서 graceful하게 빈 배열 유지', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('{not-json');
+    const { loadRecentDestinations } = useDestinationStore.getState();
+    await loadRecentDestinations();
+
+    expect(useDestinationStore.getState().recentDestinations).toEqual([]);
   });
 
   // ── customOrigin ──

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -14,7 +14,9 @@ import {
   CUSTOM_ORIGIN_KEY,
   TRIP_ORIGIN_KEY,
   ROUTE_PREFERENCE_KEY,
+  RECENT_DESTINATIONS_KEY,
 } from '../../../shared/constants/storageKeys';
+import { RECENT_ROUTES_LIMIT } from '../../../shared/constants/recentDestinations';
 import { runTripBoundCleanups } from '../../alarm/store/tripBoundCleanups';
 import { setTripStartedAt } from '../../alarm/utils/tripStartStorage';
 import { triggerTripEndRecall } from '../../alarm/utils/triggerTripEndRecall';
@@ -28,7 +30,8 @@ const noop = (): void => {};
  * Destination/route 상태 store — ADR 후속 Step 6 (#892).
  *
  * 책임:
- *  - destination / recentDestination: 사용자 목적지 (영속 + 메모리).
+ *  - destination / recentDestinations: 사용자 목적지 (영속 + 메모리). recentDestinations는
+ *    LRU 리스트(#1032) — 최대 RECENT_ROUTES_LIMIT개.
  *  - customOrigin: 사용자가 명시 지정한 출발역 (GPS와 별개).
  *  - tripOrigin (#700): trip 시작 시 캡처한 출발역. cold restart 후 첫 GPS fix가
  *    실제 출발역과 다른 회귀 방지용 영속화.
@@ -41,7 +44,12 @@ const noop = (): void => {};
  */
 export interface DestinationState {
   destination: Station | null;
-  recentDestination: Station | null;
+  /**
+   * #1032 — 최근 선택한 목적지 리스트. 가장 최근 우선(index 0).
+   * 동일 station id는 dedup되며 최신 선택이 맨 앞으로 이동.
+   * 최대 RECENT_ROUTES_LIMIT개까지 보관. AsyncStorage(RECENT_DESTINATIONS_KEY)로 영속.
+   */
+  recentDestinations: Station[];
   customOrigin: Station | null;
   // #700 — useTripOrigin이 destination set 시점에 캡처한 origin. cold restart 시
   // 첫 GPS fix가 진짜 출발역과 다른 회귀를 막기 위해 영속화한다 (TRIP_ORIGIN_KEY).
@@ -50,7 +58,9 @@ export interface DestinationState {
 
   setDestination: (station: Station | null) => void;
   loadDestination: () => Promise<void>;
-  setRecentDestination: (station: Station | null) => void;
+  addRecentDestination: (station: Station) => void;
+  removeRecentDestination: (stationId: string) => void;
+  loadRecentDestinations: () => Promise<void>;
   setCustomOrigin: (station: Station | null) => void;
   loadCustomOrigin: () => Promise<void>;
   setTripOrigin: (station: Station | null) => void;
@@ -61,7 +71,7 @@ export interface DestinationState {
 
 export const useDestinationStore = create<DestinationState>((set, get) => ({
   destination: null,
-  recentDestination: null,
+  recentDestinations: [],
   customOrigin: null,
   tripOrigin: null,
   routePreference: 'optimal' as RoutePreference,
@@ -129,8 +139,38 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
     }
   },
 
-  setRecentDestination: (station: Station | null) => {
-    set({ recentDestination: station });
+  // #1032 — 가장 최근 목적지를 리스트 맨 앞에 추가. 같은 id가 이미 있으면 제거 후 prepend(dedup).
+  // 결과 길이는 RECENT_ROUTES_LIMIT으로 자른다.
+  addRecentDestination: (station: Station) => {
+    const prev = get().recentDestinations;
+    const deduped = prev.filter((s) => s.id !== station.id);
+    const next = [station, ...deduped].slice(0, RECENT_ROUTES_LIMIT);
+    set({ recentDestinations: next });
+    AsyncStorage.setItem(RECENT_DESTINATIONS_KEY, JSON.stringify(next)).catch(noop);
+  },
+
+  removeRecentDestination: (stationId: string) => {
+    const next = get().recentDestinations.filter((s) => s.id !== stationId);
+    set({ recentDestinations: next });
+    if (next.length === 0) {
+      AsyncStorage.removeItem(RECENT_DESTINATIONS_KEY).catch(noop);
+    } else {
+      AsyncStorage.setItem(RECENT_DESTINATIONS_KEY, JSON.stringify(next)).catch(noop);
+    }
+  },
+
+  loadRecentDestinations: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(RECENT_DESTINATIONS_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          set({ recentDestinations: parsed.slice(0, RECENT_ROUTES_LIMIT) });
+        }
+      }
+    } catch {
+      // 저장된 데이터 없음 — 빈 배열 유지
+    }
   },
 
   setCustomOrigin: (station: Station | null) => {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -87,8 +87,10 @@ export default function HomeScreen() {
   const destination = useDestinationStore((s) => s.destination);
   const setDestination = useDestinationStore((s) => s.setDestination);
   const loadDestination = useDestinationStore((s) => s.loadDestination);
-  const recentDestination = useDestinationStore((s) => s.recentDestination);
-  const setRecentDestination = useDestinationStore((s) => s.setRecentDestination);
+  const recentDestinations = useDestinationStore((s) => s.recentDestinations);
+  const addRecentDestination = useDestinationStore((s) => s.addRecentDestination);
+  const removeRecentDestination = useDestinationStore((s) => s.removeRecentDestination);
+  const loadRecentDestinations = useDestinationStore((s) => s.loadRecentDestinations);
   const sleepMode = useSettingsStore((s) => s.sleepMode);
   const setSleepMode = useSettingsStore((s) => s.setSleepMode);
   const loadSleepMode = useSettingsStore((s) => s.loadSleepMode);
@@ -487,6 +489,7 @@ export default function HomeScreen() {
     loadAllowSpeaker();
     loadCustomOrigin();
     loadRoutePreference();
+    loadRecentDestinations();
     loadAlarmEvent();
     loadLocklessStationPassed();
     loadDismissSilence();
@@ -995,20 +998,39 @@ export default function HomeScreen() {
             {/* No destination: picker + recent */}
             {!destination && (
               <View style={{ paddingHorizontal: spacing.xxl, paddingVertical: spacing.xxl }}>
-                {recentDestination && (
-                  <TouchableOpacity
-                    style={[styles.recentDestinationButton, { borderColor: colors.accent }]}
-                    onPress={() => setDestination(recentDestination)}
-                    testID="recent-destination-button"
-                  >
-                    <Text style={[styles.recentDestinationLabel, { color: colors.accent }]}>{t('home.previousDestination')}</Text>
-                    <View style={styles.recentDestinationRow}>
-                      <Text style={[styles.recentDestinationName, { color: colors.ink }]}>{getStationDisplayName(recentDestination)}</Text>
-                      <View style={[styles.recentLineBadge, { backgroundColor: recentDestination.lineColor }]}>
-                        <Text style={styles.recentLineText}>{LINE_NAMES[recentDestination.line]}</Text>
+                {recentDestinations.length > 0 && (
+                  <View testID="recent-destinations-list">
+                    <Text style={[styles.recentDestinationLabel, { color: colors.accent, paddingHorizontal: spacing.lg }]}>
+                      {t('home.previousDestination')}
+                    </Text>
+                    {recentDestinations.map((recent) => (
+                      <View
+                        key={recent.id}
+                        style={[styles.recentDestinationButton, styles.recentDestinationItemRow, { borderColor: colors.accent }]}
+                      >
+                        <TouchableOpacity
+                          style={styles.recentDestinationTapArea}
+                          onPress={() => setDestination(recent)}
+                          testID={`recent-destination-button-${recent.id}`}
+                        >
+                          <View style={styles.recentDestinationRow}>
+                            <Text style={[styles.recentDestinationName, { color: colors.ink }]}>{getStationDisplayName(recent)}</Text>
+                            <View style={[styles.recentLineBadge, { backgroundColor: recent.lineColor }]}>
+                              <Text style={styles.recentLineText}>{LINE_NAMES[recent.line]}</Text>
+                            </View>
+                          </View>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                          style={styles.recentDestinationDelete}
+                          onPress={() => removeRecentDestination(recent.id)}
+                          accessibilityLabel={t('common.remove')}
+                          testID={`recent-destination-delete-${recent.id}`}
+                        >
+                          <Text style={[styles.recentDestinationDeleteText, { color: colors.muted }]}>✕</Text>
+                        </TouchableOpacity>
                       </View>
-                    </View>
-                  </TouchableOpacity>
+                    ))}
+                  </View>
                 )}
                 <TouchableOpacity
                   style={[styles.destinationButton, { backgroundColor: colors.accent }]}
@@ -1109,7 +1131,7 @@ export default function HomeScreen() {
       <DestinationPicker
         visible={pickerVisible}
         onSelect={(station) => {
-          setRecentDestination(station);
+          addRecentDestination(station);
           setDestination(station);
           setPickerVisible(false);
         }}
@@ -1267,6 +1289,22 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
     marginBottom: spacing.sm,
+  },
+  recentDestinationItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  recentDestinationTapArea: {
+    flex: 1,
+  },
+  recentDestinationDelete: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    marginLeft: spacing.sm,
+  },
+  recentDestinationDeleteText: {
+    fontSize: 16,
+    fontWeight: '700',
   },
   recentDestinationLabel: {
     fontSize: 11,

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -34,7 +34,7 @@ export default function MapScreen() {
   const setCustomOrigin = useDestinationStore((s) => s.setCustomOrigin);
   const destination = useDestinationStore((s) => s.destination);
   const setDestination = useDestinationStore((s) => s.setDestination);
-  const setRecentDestination = useDestinationStore((s) => s.setRecentDestination);
+  const addRecentDestination = useDestinationStore((s) => s.addRecentDestination);
   const favorites = useFavoritesStore((s) => s.favorites);
   const setSlotFavorite = useFavoritesStore((s) => s.setSlotFavorite);
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
@@ -178,7 +178,7 @@ export default function MapScreen() {
             <TouchableOpacity
               style={[styles.selectionButton, { borderWidth: 1, borderColor: colors.accent }]}
               onPress={() => {
-                setRecentDestination(selectedStation);
+                addRecentDestination(selectedStation);
                 setDestination(selectedStation);
                 setSelectedStation(null);
                 router.navigate('/(tabs)');

--- a/src/shared/constants/recentDestinations.ts
+++ b/src/shared/constants/recentDestinations.ts
@@ -1,0 +1,4 @@
+// #1032 — 최근 선택한 목적지 보관 개수 상한.
+// useDestinationStore의 `recentDestinations` 리스트가 이 값을 넘으면
+// 가장 오래된 항목부터 잘려나간다. UI는 이 리스트를 그대로 매핑해 렌더한다.
+export const RECENT_ROUTES_LIMIT = 3;

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -113,3 +113,7 @@ export const LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY =
 // registerActiveTrip이 promptDisplay.line으로 set하고 clearActiveTrip이 삭제.
 // 형식: LineNumber 문자열 ('1'..'9' | 'airport' | ...). 키 부재 = snap skip(graceful).
 export const ACTIVE_BOARDING_LINE_KEY = 'subway-now:active-boarding-line';
+// #1032 — 최근 선택한 목적지 리스트. 가장 최근 우선(LRU), 동일 station id는 dedup.
+// 최대 RECENT_ROUTES_LIMIT개(`src/shared/constants/recentDestinations.ts`)까지 보관.
+// 형식: Station[] JSON.
+export const RECENT_DESTINATIONS_KEY = 'subway-now:recent-destinations';

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -3,7 +3,8 @@
     "retry": "Retry",
     "close": "Close",
     "confirm": "OK",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "remove": "Remove"
   },
   "tabs": {
     "current": "Current",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3,7 +3,8 @@
     "retry": "再試行",
     "close": "閉じる",
     "confirm": "OK",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "remove": "削除"
   },
   "tabs": {
     "current": "現在",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3,7 +3,8 @@
     "retry": "다시 시도",
     "close": "닫기",
     "confirm": "확인",
-    "cancel": "취소"
+    "cancel": "취소",
+    "remove": "삭제"
   },
   "tabs": {
     "current": "현재 역",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -3,7 +3,8 @@
     "retry": "重试",
     "close": "关闭",
     "confirm": "确定",
-    "cancel": "取消"
+    "cancel": "取消",
+    "remove": "删除"
   },
   "tabs": {
     "current": "当前",


### PR DESCRIPTION
## Summary
- `useDestinationStore`의 단일 `recentDestination`을 LRU 리스트 `recentDestinations`(최대 `RECENT_ROUTES_LIMIT=3`)로 교체. 동일 station id는 dedup, 최신 선택이 맨 앞으로 이동.
- AsyncStorage(`RECENT_DESTINATIONS_KEY`) 영속화 + cold restart 시 hydrate.
- HomeScreen의 "이전 목적지" 단일 카드 → 최근 3개 리스트 + 항목별 ✕ 삭제 버튼. 탭 시 기존과 동일하게 destination 복원.
- MapScreen의 destination set 경로도 동일 add 액션으로 연결.
- `common.remove` i18n 키 4개 locale 추가.

## Design notes
- "3"은 `src/shared/constants/recentDestinations.ts`의 `RECENT_ROUTES_LIMIT` 상수로 분리 (글로벌 3번 룰).
- 호환 레이어 없이 단일 → 리스트로 교체 — 기존 `setRecentDestination` 호출자는 HomeScreen/MapScreen 2곳뿐이라 surface가 작다.
- 삭제 확인 다이얼로그는 일단 생략 (요구 명세).

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [x] `npm test` 전체 4175 tests / 100% coverage 통과
- [x] store 신규 테스트 11건 (add/dedup/limit/persist/remove/load 변형)
- [ ] 실기기: 목적지 3번 다른 역으로 선택 → 모두 노출, 4번째 시 가장 오래된 항목 잘림, ✕ 탭 시 즉시 제거 + 앱 재시작 후 유지 확인

Refs: docs/requirements/03-destination-route.md
Closes #1032