### PR TITLE
feat(#1033): a11y label 1차 패스 — Settings + Alarm 영역

### DIFF
--- a/src/features/alarm/components/AlarmOverlay.tsx
+++ b/src/features/alarm/components/AlarmOverlay.tsx
@@ -54,6 +54,9 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
           onPress={handleDismiss}
           testID="alarm-dismiss-button"
           activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={t('alarmOverlay.dismiss')}
+          accessibilityHint={t('a11y.alarm.dismissHint')}
         >
           <Text style={[styles.buttonText, { color: colors.onAccent }]}>
             {t('alarmOverlay.dismiss')}

--- a/src/features/alarm/components/BoardingLockHopCard.tsx
+++ b/src/features/alarm/components/BoardingLockHopCard.tsx
@@ -1,4 +1,5 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 import { LINE_COLORS, LINE_NAMES } from '../../../shared/constants/lineColors';
 import { formatClockTime } from '../../../shared/utils/formatTime';
@@ -32,6 +33,7 @@ interface Props {
  */
 export function BoardingLockHopCard({ lock, onRelease, currentEtaSeconds }: Props) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   const lineName = LINE_NAMES[lock.boardingLine];
   const timeText = formatClockTime(lock.boardedAt);
   const metaText = `탑승 · ${lineName} · ${timeText}`;
@@ -62,8 +64,13 @@ export function BoardingLockHopCard({ lock, onRelease, currentEtaSeconds }: Prop
         onPress={onRelease}
         style={[styles.releaseButton, { borderColor: colors.accent }]}
         testID="boarding-lock-hop-release"
+        accessibilityRole="button"
+        accessibilityLabel={t('a11y.alarm.boardingLockReleaseLabel')}
+        accessibilityHint={t('a11y.alarm.boardingLockReleaseHint')}
       >
-        <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}>하차</Text>
+        <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}>
+          {t('a11y.alarm.boardingLockReleaseLabel')}
+        </Text>
       </Pressable>
     </View>
   );

--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -175,6 +175,14 @@ export function BoardingTrainList({
               { opacity: unreachable ? 0.4 : 1 },
             ]}
             testID={`boarding-train-row-${train.trainCode}`}
+            accessibilityRole="button"
+            accessibilityLabel={t('a11y.alarm.boardingTrainSelectLabel', {
+              meta: metaText,
+              sequence: sequenceText,
+              arrival: arrivalText,
+            })}
+            accessibilityHint={t('a11y.alarm.boardingTrainSelectHint')}
+            accessibilityState={{ disabled: unreachable }}
           >
             <View style={styles.rowContent}>
               <View style={styles.rowMetaLine}>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -115,6 +115,10 @@ export default function SettingsScreen() {
               trackColor={{ false: colors.hair, true: colors.accent }}
               thumbColor={sleepMode ? colors.onAccent : colors.subtle}
               testID="sleep-mode-switch"
+              accessibilityRole="switch"
+              accessibilityLabel={t('settings.sleepModeLabel')}
+              accessibilityHint={t('a11y.settings.sleepModeHint')}
+              accessibilityState={{ checked: sleepMode }}
             />
           </View>
 
@@ -144,6 +148,10 @@ export default function SettingsScreen() {
               trackColor={{ false: colors.hair, true: colors.accent }}
               thumbColor={allowSpeaker ? colors.onAccent : colors.subtle}
               testID="allow-speaker-switch"
+              accessibilityRole="switch"
+              accessibilityLabel={t('settings.speakerOutputLabel')}
+              accessibilityHint={t('a11y.settings.speakerOutputHint')}
+              accessibilityState={{ checked: allowSpeaker }}
             />
           </View>
 
@@ -161,6 +169,10 @@ export default function SettingsScreen() {
               trackColor={{ false: colors.hair, true: colors.accent }}
               thumbColor={locklessStationPassed ? colors.onAccent : colors.subtle}
               testID="lockless-station-passed-switch"
+              accessibilityRole="switch"
+              accessibilityLabel={t('settings.locklessStationPassedLabel')}
+              accessibilityHint={t('a11y.settings.locklessStationPassedHint')}
+              accessibilityState={{ checked: locklessStationPassed }}
             />
           </View>
         </View>
@@ -182,6 +194,10 @@ export default function SettingsScreen() {
               trackColor={{ false: colors.hair, true: colors.accent }}
               thumbColor={accessibilityMode ? colors.onAccent : colors.subtle}
               testID="accessibility-mode-switch"
+              accessibilityRole="switch"
+              accessibilityLabel={t('settings.accessibilityModeLabel')}
+              accessibilityHint={t('a11y.settings.accessibilityModeHint')}
+              accessibilityState={{ checked: accessibilityMode }}
             />
           </View>
         </View>
@@ -194,6 +210,7 @@ export default function SettingsScreen() {
 
 function VersionFooter() {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   const tapCountRef = useRef(0);
   const lastTapAtRef = useRef(0);
   const setDebugVisible = useDebugStore((s) => s.setDebugVisible);
@@ -219,6 +236,9 @@ function VersionFooter() {
       onPress={handlePress}
       style={styles.versionFooter}
       testID="settings-version-footer"
+      accessibilityRole="button"
+      accessibilityLabel={t('a11y.settings.versionFooterLabel', { version })}
+      accessibilityHint={isDebugModalEnabled() ? t('a11y.settings.versionFooterHint') : undefined}
     >
       <Text style={[styles.versionText, { color: colors.muted }]}>v{version}</Text>
     </Pressable>
@@ -320,6 +340,9 @@ function SegmentSetting<T extends string>({
               style={[styles.segment, active && { backgroundColor: colors.accent }]}
               onPress={() => onChange(optionValue)}
               testID={`${testIDPrefix}-${optionValue}`}
+              accessibilityRole="radio"
+              accessibilityLabel={optionLabel}
+              accessibilityState={{ selected: active }}
             >
               <Text style={[styles.segmentText, { color: active ? colors.onAccent : colors.muted }]}>
                 {optionLabel}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -250,5 +250,26 @@
     "routeProgress": "Route est.",
     "gpsOnly": "GPS est.",
     "uncertain": "Locating…"
+  },
+  "a11y": {
+    "settings": {
+      "sleepModeHint": "Plays a wake-up alarm sound when headphones are connected",
+      "speakerOutputHint": "Plays alarm sound through the speaker when headphones are not connected",
+      "locklessStationPassedHint": "Receive station-passed alerts even when no train is selected",
+      "accessibilityModeHint": "Guides quick-exit positions based on elevators",
+      "versionFooterLabel": "App version {{version}}",
+      "versionFooterHint": "Tap multiple times to open the debug menu",
+      "themeSegmentHint": "Change theme",
+      "routeSegmentHint": "Change route preference",
+      "localeRowHint": "Tap to select language"
+    },
+    "alarm": {
+      "dismissLabel": "Dismiss alarm",
+      "dismissHint": "Stops the alarm sound and vibration",
+      "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
+      "boardingTrainSelectHint": "Tap to board this train",
+      "boardingLockReleaseLabel": "Get off",
+      "boardingLockReleaseHint": "Ends the current boarding session"
+    }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -250,5 +250,26 @@
     "routeProgress": "経路推定",
     "gpsOnly": "GPS推定",
     "uncertain": "位置確認中"
+  },
+  "a11y": {
+    "settings": {
+      "sleepModeHint": "イヤホン接続時に起床アラーム音で鳴ります",
+      "speakerOutputHint": "イヤホン未接続時にスピーカーでアラーム音を再生",
+      "locklessStationPassedHint": "乗車列車を選択していなくても通過通知を受け取る",
+      "accessibilityModeHint": "エレベーター基準で速やかな降車位置を案内",
+      "versionFooterLabel": "アプリバージョン {{version}}",
+      "versionFooterHint": "複数回タップでデバッグメニューを開く",
+      "themeSegmentHint": "テーマを変更",
+      "routeSegmentHint": "経路設定を変更",
+      "localeRowHint": "タップして言語を選択"
+    },
+    "alarm": {
+      "dismissLabel": "アラームを停止",
+      "dismissHint": "アラーム音と振動を停止します",
+      "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
+      "boardingTrainSelectHint": "タップしてこの列車に乗車",
+      "boardingLockReleaseLabel": "降車",
+      "boardingLockReleaseHint": "現在の乗車を終了します"
+    }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -250,5 +250,26 @@
     "routeProgress": "경로 추정",
     "gpsOnly": "GPS 추정",
     "uncertain": "위치 확인 중"
+  },
+  "a11y": {
+    "settings": {
+      "sleepModeHint": "이어폰 연결 시 기상 알람음으로 울립니다",
+      "speakerOutputHint": "이어폰 미연결 시 스피커로 알람음 재생",
+      "locklessStationPassedHint": "탑승 열차 선택 없이도 역 통과 알림 수신",
+      "accessibilityModeHint": "엘리베이터 기준으로 빠른 하차 위치 안내",
+      "versionFooterLabel": "앱 버전 {{version}}",
+      "versionFooterHint": "여러 번 탭하면 디버그 메뉴 열기",
+      "themeSegmentHint": "테마 변경",
+      "routeSegmentHint": "경로 탐색 방식 변경",
+      "localeRowHint": "탭하여 언어 선택"
+    },
+    "alarm": {
+      "dismissLabel": "알람 끄기",
+      "dismissHint": "알람음과 진동을 중지합니다",
+      "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
+      "boardingTrainSelectHint": "탭하여 이 열차로 탑승 등록",
+      "boardingLockReleaseLabel": "하차",
+      "boardingLockReleaseHint": "현재 탑승 상태를 종료합니다"
+    }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -250,5 +250,26 @@
     "routeProgress": "路径推算",
     "gpsOnly": "GPS推算",
     "uncertain": "定位中"
+  },
+  "a11y": {
+    "settings": {
+      "sleepModeHint": "连接耳机时以起床闹钟音播放",
+      "speakerOutputHint": "未连接耳机时通过扬声器播放闹钟音",
+      "locklessStationPassedHint": "未选择乘车列车也会收到经过站点通知",
+      "accessibilityModeHint": "按电梯位置引导快速下车位置",
+      "versionFooterLabel": "应用版本 {{version}}",
+      "versionFooterHint": "多次点击打开调试菜单",
+      "themeSegmentHint": "更改主题",
+      "routeSegmentHint": "更改路径偏好",
+      "localeRowHint": "点击选择语言"
+    },
+    "alarm": {
+      "dismissLabel": "关闭闹钟",
+      "dismissHint": "停止闹钟声和振动",
+      "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
+      "boardingTrainSelectHint": "点击乘坐该列车",
+      "boardingLockReleaseLabel": "下车",
+      "boardingLockReleaseHint": "结束当前乘车状态"
+    }
   }
 }


### PR DESCRIPTION
## Summary
docs/requirements/12-cross-cutting.md에 known gap으로 명시된 a11y(VoiceOver/TalkBack) 1차 패스. Settings + Alarm 영역의 모든 인터랙티브 요소에 `accessibilityLabel` / `accessibilityRole` / `accessibilityState` / `accessibilityHint`를 추가하여 스크린리더 사용자가 핵심 알람 흐름을 음성으로 인지/조작 가능.

## Scope (1차 패스)
**다룸:**
- `src/screens/SettingsScreen.tsx`
  - Switch 4종(취침/스피커/lockless/접근성) → `role="switch"` + `state.checked` + label/hint
  - SegmentSetting Pressable(테마/경로) → `role="radio"` + `state.selected`
  - VersionFooter Pressable → `role="button"` + 버전 포함 label
- `src/features/alarm/components/AlarmOverlay.tsx` → 알람 끄기 버튼 label/hint
- `src/features/alarm/components/BoardingLockHopCard.tsx` → 하차 버튼 label/hint (하드코딩 "하차" → i18n 키)
- `src/features/alarm/components/BoardingTrainList.tsx` → row Pressable 합성 label(메타+거리+도착시각) + `state.disabled`

**다음 PR:**
- Home 화면 (`src/screens/HomeScreen.tsx`)
- Route 화면 (`src/features/route/components/**`)
- Favorites / Map 화면

## i18n
- 신규 namespace `a11y.{settings,alarm}` — 14개 키, ko/en/ja/zh 4 locale 모두 추가
- LanguageScreen은 이미 `role="radio"` + `state.selected`가 있어 1차 패스에서 제외 (다음 PR에서 label 보강 검토)

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과 (max-warnings=0)
- [x] `npm test` — 226 suites / 4167 tests / 100% coverage 유지
- [ ] 실기기 VoiceOver(iOS) 수동 검증 — 별도 회귀 회차
- [ ] 실기기 TalkBack(Android) 수동 검증 — 별도 회귀 회차

## 노트
- 비-한국어 번역(en/ja/zh)은 reasonable fallback. 네이티브 검토는 후속 follow-up에서 — i18n 누락 자체는 차단되지 않음.
- BoardingLockHopCard의 "하차"를 i18n으로 분리하면서 화면 출력 텍스트도 같은 키 사용. 기존 한글 assertion은 jest setup의 ko 기본 로케일로 변함없이 통과.

Closes #1033
