### PR TITLE
chore(#1039): stations.json + lineTopology 정합성 검증 스크립트 + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,26 @@ jobs:
             echo "→ e2e-smoke 실행"
           fi
 
+  data-validation:
+    name: Data Validation
+    # stations.json + lineTopology.json 정합성을 5초 안에 검증 (#1039).
+    # 데이터 손상이 type check / test보다 먼저 fail-fast 되도록 분리한다.
+    runs-on: ubuntu-latest
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: stations.json + lineTopology 검증
+        run: node scripts/validate-stations.js
+
   test:
     name: Type Check & Test
+    needs: [data-validation]
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "data:fetch-exit-side": "node scripts/fetch-exit-side.js",
     "data:fetch-quick-exit": "node scripts/fetch-quick-exit.js",
     "data:build-transfer-times": "node scripts/build-transfer-times.js",
+    "validate:data": "node scripts/validate-stations.js",
     "tail:capture": "scripts/capture-tail.sh",
     "measure:blocked-reasons": "scripts/capture-blocked-reasons.sh",
     "measure:blocked-reasons:aggregate": "node scripts/aggregate-blocked-reasons.js",

--- a/scripts/__tests__/validate-stations.test.js
+++ b/scripts/__tests__/validate-stations.test.js
@@ -1,0 +1,319 @@
+/**
+ * validate-stations (#1039) — validate() 순수 함수 + main() CLI smoke 단위 테스트.
+ */
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  LAT_MIN,
+  LAT_MAX,
+  LNG_MIN,
+  LNG_MAX,
+  validate,
+  main,
+} = require('../validate-stations');
+
+const validStation = (overrides = {}) => ({
+  id: '1-001',
+  name: '소요산',
+  line: '1',
+  lineColor: '#0052A4',
+  lat: 37.9481,
+  lng: 127.061,
+  ...overrides,
+});
+
+const validTopology = (overrides = {}) => ({
+  monotonicLines: ['3'],
+  endpoints: { 3: { low: '대화', high: '오금' } },
+  ...overrides,
+});
+
+describe('validate()', () => {
+  it('passes for clean stations + topology', () => {
+    const stations = [
+      validStation({ id: '3-001', name: '대화', line: '3' }),
+      validStation({ id: '3-002', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+    ];
+    const res = validate({ stations, topology: validTopology() });
+    expect(res.errors).toEqual([]);
+    expect(res.warnings).toEqual([]);
+    expect(res.stationCount).toBe(2);
+    expect(res.monotonicLineCount).toBe(1);
+  });
+
+  it('flags non-array stations.json', () => {
+    const res = validate({ stations: null, topology: validTopology() });
+    expect(res.errors[0]).toMatch(/root가 배열이 아님/);
+    expect(res.stationCount).toBe(0);
+    expect(res.monotonicLineCount).toBe(0);
+  });
+
+  it('flags non-object topology', () => {
+    const res = validate({ stations: [validStation()], topology: null });
+    expect(res.errors[0]).toMatch(/root가 객체가 아님/);
+    expect(res.stationCount).toBe(1);
+  });
+
+  it('flags non-object station entry', () => {
+    const res = validate({ stations: [null], topology: validTopology({ monotonicLines: [] }) });
+    expect(res.errors.some((e) => /객체가 아님/.test(e))).toBe(true);
+  });
+
+  it('flags missing required string fields', () => {
+    const bad = {
+      id: '',
+      name: '',
+      line: '',
+      lineColor: '',
+      lat: 37,
+      lng: 127,
+    };
+    const res = validate({ stations: [bad], topology: validTopology({ monotonicLines: [] }) });
+    expect(res.errors.some((e) => /id가 비어있/.test(e))).toBe(true);
+    expect(res.errors.some((e) => /name이 비어있/.test(e))).toBe(true);
+    expect(res.errors.some((e) => /line이 비어있/.test(e))).toBe(true);
+    expect(res.errors.some((e) => /lineColor가 비어있/.test(e))).toBe(true);
+  });
+
+  it('flags lat out of bounds and NaN', () => {
+    const tooLow = validate({
+      stations: [validStation({ lat: LAT_MIN - 1 })],
+      topology: validTopology({ monotonicLines: [] }),
+    });
+    expect(tooLow.errors.some((e) => /lat이.*범위 밖/.test(e))).toBe(true);
+
+    const tooHigh = validate({
+      stations: [validStation({ lat: LAT_MAX + 1 })],
+      topology: validTopology({ monotonicLines: [] }),
+    });
+    expect(tooHigh.errors.some((e) => /lat이.*범위 밖/.test(e))).toBe(true);
+
+    const nan = validate({
+      stations: [validStation({ lat: Number.NaN })],
+      topology: validTopology({ monotonicLines: [] }),
+    });
+    expect(nan.errors.some((e) => /lat이.*finite/.test(e))).toBe(true);
+  });
+
+  it('flags lng out of bounds', () => {
+    const res = validate({
+      stations: [validStation({ lng: LNG_MIN - 1 })],
+      topology: validTopology({ monotonicLines: [] }),
+    });
+    expect(res.errors.some((e) => /lng가.*범위 밖/.test(e))).toBe(true);
+
+    const high = validate({
+      stations: [validStation({ lng: LNG_MAX + 1 })],
+      topology: validTopology({ monotonicLines: [] }),
+    });
+    expect(high.errors.some((e) => /lng가.*범위 밖/.test(e))).toBe(true);
+  });
+
+  it('flags duplicate id', () => {
+    const res = validate({
+      stations: [validStation({ id: 'dup' }), validStation({ id: 'dup' })],
+      topology: validTopology({ monotonicLines: [] }),
+    });
+    expect(res.errors.some((e) => /id "dup" 중복/.test(e))).toBe(true);
+  });
+
+  it('flags monotonic line missing endpoints entry', () => {
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '대화', line: '3' }),
+        validStation({ id: '3-002', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+      ],
+      topology: { monotonicLines: ['3'], endpoints: {} },
+    });
+    expect(res.errors.some((e) => /endpoints\["3"\] 누락/.test(e))).toBe(true);
+  });
+
+  it('flags empty endpoints low/high', () => {
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '대화', line: '3' }),
+        validStation({ id: '3-002', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+      ],
+      topology: { monotonicLines: ['3'], endpoints: { 3: { low: '', high: '' } } },
+    });
+    expect(res.errors.some((e) => /\.low가 비어있/.test(e))).toBe(true);
+    expect(res.errors.some((e) => /\.high가 비어있/.test(e))).toBe(true);
+  });
+
+  it('flags monotonic line with <2 stations', () => {
+    const res = validate({
+      stations: [validStation({ id: '3-001', name: '대화', line: '3' })],
+      topology: validTopology(),
+    });
+    expect(res.errors.some((e) => /1개만 존재/.test(e))).toBe(true);
+  });
+
+  it('flags non-array monotonicLines and non-object endpoints', () => {
+    const res = validate({
+      stations: [validStation()],
+      topology: { monotonicLines: 'nope', endpoints: 'nope' },
+    });
+    expect(res.errors.some((e) => /monotonicLines가 배열이 아님/.test(e))).toBe(true);
+    expect(res.errors.some((e) => /endpoints가 객체가 아님/.test(e))).toBe(true);
+  });
+
+  it('flags empty string in monotonicLines', () => {
+    const res = validate({
+      stations: [validStation()],
+      topology: { monotonicLines: [''], endpoints: {} },
+    });
+    expect(res.errors.some((e) => /monotonicLines에 비어있는 항목/.test(e))).toBe(true);
+  });
+
+  it('warns on id-sort first/last mismatch with endpoints', () => {
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '실제첫역', line: '3' }),
+        validStation({ id: '3-002', name: '실제마지막', line: '3', lat: 37.5, lng: 127.1 }),
+      ],
+      topology: validTopology(),
+    });
+    expect(res.errors).toEqual([]);
+    expect(res.warnings.some((w) => /첫 역 "실제첫역".*"대화"/.test(w))).toBe(true);
+    expect(res.warnings.some((w) => /마지막 역 "실제마지막".*"오금"/.test(w))).toBe(true);
+  });
+
+  it('warns on duplicate name within same line', () => {
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '대화', line: '3' }),
+        validStation({ id: '3-002', name: '대화', line: '3', lat: 37.5, lng: 127.1 }),
+        validStation({ id: '3-003', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+      ],
+      topology: validTopology(),
+    });
+    expect(res.warnings.some((w) => /name "대화"이 2회 중복/.test(w))).toBe(true);
+  });
+
+  it('skips name-dup count for stations without name string', () => {
+    // dup line name 카운트 분기에서 name이 string이 아닌 경우 continue 경로 — error로 잡히지만 warn은 안 띄움.
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '대화', line: '3' }),
+        validStation({ id: '3-002', name: '', line: '3', lat: 37.5, lng: 127.1 }),
+        validStation({ id: '3-003', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+      ],
+      topology: validTopology(),
+    });
+    // empty name → error, no name-dup warn
+    expect(res.errors.some((e) => /name이 비어있/.test(e))).toBe(true);
+    expect(res.warnings.every((w) => !/name ".*"이.*중복/.test(w))).toBe(true);
+  });
+});
+
+describe('main()', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-stations-'));
+  const writeJson = (name, data) => {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, JSON.stringify(data));
+    return p;
+  };
+
+  it('returns 0 and prints success summary for valid input', () => {
+    const outs = [];
+    const errs = [];
+    const stationsPath = writeJson('s-ok.json', [
+      validStation({ id: '3-001', name: '대화', line: '3' }),
+      validStation({ id: '3-002', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+    ]);
+    const topologyPath = writeJson('t-ok.json', validTopology());
+    const code = main([], {
+      writeOut: (s) => outs.push(s),
+      writeErr: (s) => errs.push(s),
+      stationsPath,
+      topologyPath,
+    });
+    expect(code).toBe(0);
+    expect(outs.some((s) => /✅ 2 stations OK, 1 monotonic lines OK$/.test(s))).toBe(true);
+    expect(errs).toEqual([]);
+  });
+
+  it('returns 0 with warning count in summary when warnings present', () => {
+    const outs = [];
+    const stationsPath = writeJson('s-warn.json', [
+      validStation({ id: '3-001', name: '실제첫역', line: '3' }),
+      validStation({ id: '3-002', name: '실제마지막', line: '3', lat: 37.5, lng: 127.1 }),
+    ]);
+    const topologyPath = writeJson('t-warn.json', validTopology());
+    const code = main([], {
+      writeOut: (s) => outs.push(s),
+      writeErr: () => {},
+      stationsPath,
+      topologyPath,
+    });
+    expect(code).toBe(0);
+    expect(outs.some((s) => /2 warnings/.test(s))).toBe(true);
+  });
+
+  it('returns 1 and prints errors for invalid input', () => {
+    const outs = [];
+    const errs = [];
+    const stationsPath = writeJson('s-bad.json', [validStation({ lat: 999 })]);
+    const topologyPath = writeJson('t-bad.json', validTopology({ monotonicLines: [] }));
+    const code = main([], {
+      writeOut: (s) => outs.push(s),
+      writeErr: (s) => errs.push(s),
+      stationsPath,
+      topologyPath,
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /lat이.*범위 밖/.test(s))).toBe(true);
+    expect(errs.some((s) => /^❌ \d+ errors$/.test(s))).toBe(true);
+  });
+
+  it('returns 1 when stations.json unreadable', () => {
+    const errs = [];
+    const code = main([], {
+      writeOut: () => {},
+      writeErr: (s) => errs.push(s),
+      stationsPath: path.join(tmpDir, 'does-not-exist.json'),
+      topologyPath: writeJson('t-rd.json', validTopology()),
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /stations\.json 읽기 실패/.test(s))).toBe(true);
+  });
+
+  it('returns 1 when lineTopology.json unreadable', () => {
+    const errs = [];
+    const stationsPath = writeJson('s-rd.json', [validStation()]);
+    const code = main([], {
+      writeOut: () => {},
+      writeErr: (s) => errs.push(s),
+      stationsPath,
+      topologyPath: path.join(tmpDir, 'does-not-exist-2.json'),
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /lineTopology\.json 읽기 실패/.test(s))).toBe(true);
+  });
+
+  it('uses default deps (real stdout/stderr + repo paths) when omitted', () => {
+    // SSOT data가 통과해야 한다는 것을 확인 (warnings는 허용).
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    const captured = { out: [], err: [] };
+    process.stdout.write = (s) => {
+      captured.out.push(String(s));
+      return true;
+    };
+    process.stderr.write = (s) => {
+      captured.err.push(String(s));
+      return true;
+    };
+    let code;
+    try {
+      code = main([]);
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    }
+    expect(code).toBe(0);
+    expect(captured.out.join('')).toMatch(/✅ \d+ stations OK/);
+  });
+});

--- a/scripts/validate-stations.js
+++ b/scripts/validate-stations.js
@@ -1,0 +1,238 @@
+/**
+ * stations.json + lineTopology.json 정합성 검증 (#1039).
+ *
+ * Errors (exit 1):
+ *   - station 필수 필드 누락/형식 오류 (id/name/line/lineColor 비어있음)
+ *   - lat/lng가 finite 아님 또는 한반도 bounding box 밖
+ *   - id 중복
+ *   - monotonicLines의 노선이 stations.json에 2개 미만으로 존재
+ *   - endpoints[line].low / .high 가 비어있는 문자열
+ *
+ * Warnings (exit 0):
+ *   - 같은 line 내 name 중복 (데이터 오류 의심)
+ *   - 단조 노선의 id-sort 첫/마지막이 endpoints와 다름 — lineTopology.json의
+ *     `_endpoints_comment`에 명시된 의도된 divergence (4/7/8/9/sinbundang 연장)
+ *
+ * 본 스크립트는 SSOT(stations.json, lineTopology.json)을 절대 수정하지 않는다.
+ * 문제를 보고만 한다.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// 한반도 widest reasonable bounding box.
+// Seoul subway는 위도 37.x, 경도 126.x 부근이지만, 미래 노선 확장(인천공항 등) 여유 포함.
+const LAT_MIN = 33;
+const LAT_MAX = 39;
+const LNG_MIN = 124;
+const LNG_MAX = 132;
+
+const STATIONS_PATH = path.resolve(__dirname, '..', 'src', 'data', 'stations.json');
+const TOPOLOGY_PATH = path.resolve(__dirname, '..', 'src', 'data', 'lineTopology.json');
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.length > 0;
+}
+
+function isInRange(v, min, max) {
+  return typeof v === 'number' && Number.isFinite(v) && v >= min && v <= max;
+}
+
+/**
+ * @param {{ stations: unknown, topology: unknown }} input
+ * @returns {{ errors: string[], warnings: string[], stationCount: number, monotonicLineCount: number }}
+ */
+function validate(input) {
+  const errors = [];
+  const warnings = [];
+
+  const { stations, topology } = input;
+
+  if (!Array.isArray(stations)) {
+    errors.push('stations.json: root가 배열이 아님');
+    return { errors, warnings, stationCount: 0, monotonicLineCount: 0 };
+  }
+  if (!topology || typeof topology !== 'object') {
+    errors.push('lineTopology.json: root가 객체가 아님');
+    return { errors, warnings, stationCount: stations.length, monotonicLineCount: 0 };
+  }
+
+  const idSeen = new Map(); // id -> first index
+  stations.forEach((stn, idx) => {
+    const where = `stations.json[${idx}]`;
+    if (!stn || typeof stn !== 'object') {
+      errors.push(`${where}: 객체가 아님`);
+      return;
+    }
+    if (!isNonEmptyString(stn.id)) {
+      errors.push(`${where}: id가 비어있거나 문자열이 아님`);
+    }
+    if (!isNonEmptyString(stn.name)) {
+      errors.push(`${where} (id=${stn.id ?? '?'}): name이 비어있거나 문자열이 아님`);
+    }
+    if (!isNonEmptyString(stn.line)) {
+      errors.push(`${where} (id=${stn.id ?? '?'}): line이 비어있거나 문자열이 아님`);
+    }
+    if (!isNonEmptyString(stn.lineColor)) {
+      errors.push(`${where} (id=${stn.id ?? '?'}): lineColor가 비어있거나 문자열이 아님`);
+    }
+    if (!isInRange(stn.lat, LAT_MIN, LAT_MAX)) {
+      errors.push(
+        `${where} (id=${stn.id ?? '?'}): lat이 finite number가 아니거나 [${LAT_MIN}, ${LAT_MAX}] 범위 밖 (got ${stn.lat})`,
+      );
+    }
+    if (!isInRange(stn.lng, LNG_MIN, LNG_MAX)) {
+      errors.push(
+        `${where} (id=${stn.id ?? '?'}): lng가 finite number가 아니거나 [${LNG_MIN}, ${LNG_MAX}] 범위 밖 (got ${stn.lng})`,
+      );
+    }
+
+    if (isNonEmptyString(stn.id)) {
+      if (idSeen.has(stn.id)) {
+        errors.push(`${where}: id "${stn.id}" 중복 (이전 index=${idSeen.get(stn.id)})`);
+      } else {
+        idSeen.set(stn.id, idx);
+      }
+    }
+  });
+
+  const monotonicLines = Array.isArray(topology.monotonicLines) ? topology.monotonicLines : null;
+  const endpoints =
+    topology.endpoints && typeof topology.endpoints === 'object' ? topology.endpoints : null;
+
+  if (!monotonicLines) {
+    errors.push('lineTopology.json: monotonicLines가 배열이 아님');
+  }
+  if (!endpoints) {
+    errors.push('lineTopology.json: endpoints가 객체가 아님');
+  }
+
+  let monotonicLineCount = 0;
+  if (monotonicLines && endpoints) {
+    for (const line of monotonicLines) {
+      if (!isNonEmptyString(line)) {
+        errors.push(`lineTopology.json: monotonicLines에 비어있는 항목`);
+        continue;
+      }
+      const ep = endpoints[line];
+      if (!ep || typeof ep !== 'object') {
+        errors.push(`lineTopology.json: endpoints["${line}"] 누락`);
+        continue;
+      }
+      if (!isNonEmptyString(ep.low)) {
+        errors.push(`lineTopology.json: endpoints["${line}"].low가 비어있음`);
+      }
+      if (!isNonEmptyString(ep.high)) {
+        errors.push(`lineTopology.json: endpoints["${line}"].high가 비어있음`);
+      }
+
+      const stns = stations.filter((s) => s && s.line === line);
+      if (stns.length < 2) {
+        errors.push(
+          `lineTopology.json: 단조 노선 "${line}"이 stations.json에 ${stns.length}개만 존재 (≥2 필요)`,
+        );
+        continue;
+      }
+
+      monotonicLineCount += 1;
+
+      // Warning: id-sort 첫/마지막이 endpoints와 일치하지 않을 때.
+      // 의도된 divergence (lineTopology.json _endpoints_comment 참조)이지만
+      // 새로 도입된 divergence를 가시화하기 위해 알림만 띄운다.
+      const sorted = stns.slice().sort((a, b) => a.id.localeCompare(b.id));
+      const first = sorted[0].name;
+      const last = sorted[sorted.length - 1].name;
+      if (isNonEmptyString(ep.low) && first !== ep.low) {
+        warnings.push(
+          `line "${line}": id-sort 첫 역 "${first}" ≠ endpoints.low "${ep.low}" (의도된 divergence면 무시)`,
+        );
+      }
+      if (isNonEmptyString(ep.high) && last !== ep.high) {
+        warnings.push(
+          `line "${line}": id-sort 마지막 역 "${last}" ≠ endpoints.high "${ep.high}" (의도된 divergence면 무시)`,
+        );
+      }
+
+      // Warning: 같은 line 내 name 중복.
+      const nameCount = new Map();
+      for (const s of stns) {
+        if (!isNonEmptyString(s.name)) continue;
+        nameCount.set(s.name, (nameCount.get(s.name) ?? 0) + 1);
+      }
+      for (const [name, count] of nameCount) {
+        if (count > 1) {
+          warnings.push(`line "${line}": name "${name}"이 ${count}회 중복`);
+        }
+      }
+    }
+  }
+
+  return {
+    errors,
+    warnings,
+    stationCount: stations.length,
+    monotonicLineCount,
+  };
+}
+
+function readJson(p) {
+  const raw = fs.readFileSync(p, 'utf8');
+  return JSON.parse(raw);
+}
+
+function main(_argv, deps = {}) {
+  const writeOut = deps.writeOut ?? ((s) => process.stdout.write(s + '\n'));
+  const writeErr = deps.writeErr ?? ((s) => process.stderr.write(s + '\n'));
+  const stationsPath = deps.stationsPath ?? STATIONS_PATH;
+  const topologyPath = deps.topologyPath ?? TOPOLOGY_PATH;
+
+  let stations;
+  let topology;
+  try {
+    stations = readJson(stationsPath);
+  } catch (e) {
+    writeErr(`validate-stations: stations.json 읽기 실패 — ${e.message}`);
+    return 1;
+  }
+  try {
+    topology = readJson(topologyPath);
+  } catch (e) {
+    writeErr(`validate-stations: lineTopology.json 읽기 실패 — ${e.message}`);
+    return 1;
+  }
+
+  const result = validate({ stations, topology });
+
+  for (const w of result.warnings) {
+    writeOut(`⚠️  ${w}`);
+  }
+  for (const e of result.errors) {
+    writeErr(`❌ ${e}`);
+  }
+
+  if (result.errors.length > 0) {
+    writeErr(`❌ ${result.errors.length} errors`);
+    return 1;
+  }
+  writeOut(
+    `✅ ${result.stationCount} stations OK, ${result.monotonicLineCount} monotonic lines OK` +
+      (result.warnings.length > 0 ? ` (${result.warnings.length} warnings)` : ''),
+  );
+  return 0;
+}
+
+module.exports = {
+  LAT_MIN,
+  LAT_MAX,
+  LNG_MIN,
+  LNG_MAX,
+  validate,
+  main,
+};
+
+/* istanbul ignore if -- CLI 진입은 require.main 분기, 단위 테스트는 main()을 직접 호출 */
+if (require.main === module) {
+  process.exit(main(process.argv));
+}


### PR DESCRIPTION
## 요약
`src/data/stations.json`(533역)과 `src/data/lineTopology.json`이 손상되어도 잡아낼 자동 검증이 없었다. NaN 좌표/ID 중복/단조 노선 endpoints 누락이 런타임에서야 발견되는 위험을 CI 단계에서 차단한다.

## 변경 사항
- `scripts/validate-stations.js` — 순수 함수 `validate({stations, topology})` + CLI `main()` 분리
- `scripts/__tests__/validate-stations.test.js` — 22 케이스, validate/main 분기 전부 커버
- `package.json` — `npm run validate:data`
- `.github/workflows/ci.yml` — 새 `Data Validation` job. `Type Check & Test`의 `needs:`에 추가하여 fail-fast.

## 검사 항목

### Error (exit 1)
- 각 station: `id`/`name`/`line`/`lineColor` 비어있지 않음, `lat ∈ [33, 39]`, `lng ∈ [124, 132]` finite
- `id` 전체 unique
- `monotonicLines` 각 노선: stations.json에 ≥2개 존재, `endpoints[line].low/high` 비어있지 않음

### Warning (exit 0)
- 같은 line 내 `name` 중복
- 단조 노선의 id-sort 첫/마지막 ≠ endpoints.low/high — `lineTopology.json`의 `_endpoints_comment`에 명시된 의도된 divergence (4/7/8/9/sinbundang 연장 미반영)

## 로컬 결과
```
✅ 533 stations OK, 8 monotonic lines OK (5 warnings)
```
5건 warning은 모두 문서화된 의도된 divergence (당고개/부평구청/암사/올림픽공원/광교(경기대)).

## 비범위
- `stations.json`/`lineTopology.json` 데이터는 **수정하지 않음**. 본 PR은 검증만 추가.

## 테스트
- [x] `npm run validate:data` 로컬 통과
- [x] `npm run type-check` clean
- [x] `npm test` 전체 228 suites / 4200 tests green, 100% coverage 유지
- [ ] CI `Data Validation` job green

Closes #1039