### PR TITLE
feat(#1034): 버그 신고 인프라 — Cloudflare KV FEEDBACK + POST /feedback

### DIFF
--- a/backend/alarm-worker/src/__tests__/feedback.test.ts
+++ b/backend/alarm-worker/src/__tests__/feedback.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { app } from '../index';
+import {
+  FEEDBACK_MAX_MESSAGE_LENGTH,
+  FEEDBACK_TTL_SECONDS,
+  feedbackKey,
+  generateFeedbackId,
+  storeFeedback,
+  validateFeedback,
+} from '../feedback';
+import type { Env } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    TRIPS: {} as Env['TRIPS'],
+    APNS_HOST: 'h',
+    APNS_HOST_SANDBOX: 'hs',
+    SEOUL_API_HOST: 'h',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: 'p',
+    APNS_BUNDLE_ID: 'b',
+    ...overrides,
+  };
+}
+
+async function post(path: string, body: unknown, env: Env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://example.com${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+describe('validateFeedback', () => {
+  it('accepts message-only payload', () => {
+    expect(validateFeedback({ message: 'hi' })).toEqual({ message: 'hi' });
+  });
+
+  it('trims message whitespace', () => {
+    expect(validateFeedback({ message: '  hello  ' })).toEqual({ message: 'hello' });
+  });
+
+  it('accepts full context', () => {
+    const result = validateFeedback({
+      message: 'bug!',
+      context: {
+        appVersion: '1.2.3',
+        platform: 'ios',
+        locale: 'ko-KR',
+        deviceModel: 'iPhone15,2',
+      },
+    });
+    expect(result).toEqual({
+      message: 'bug!',
+      context: {
+        appVersion: '1.2.3',
+        platform: 'ios',
+        locale: 'ko-KR',
+        deviceModel: 'iPhone15,2',
+      },
+    });
+  });
+
+  it('drops unknown context fields and rejects bad platform', () => {
+    const result = validateFeedback({
+      message: 'bug',
+      context: { platform: 'web', appVersion: '1.0.0', junk: 'x' },
+    });
+    expect(result).toEqual({
+      message: 'bug',
+      context: { appVersion: '1.0.0' },
+    });
+  });
+
+  it('truncates oversized context strings', () => {
+    const long = 'x'.repeat(200);
+    const result = validateFeedback({
+      message: 'm',
+      context: { appVersion: long, deviceModel: long, locale: long },
+    });
+    expect(result?.context?.appVersion?.length).toBe(64);
+    expect(result?.context?.deviceModel?.length).toBe(64);
+    expect(result?.context?.locale?.length).toBe(16);
+  });
+
+  it('returns context undefined when no known fields present', () => {
+    const result = validateFeedback({ message: 'm', context: { junk: 1 } });
+    expect(result).toEqual({ message: 'm' });
+  });
+
+  it('returns context undefined when context is not object', () => {
+    expect(validateFeedback({ message: 'm', context: 'nope' })).toEqual({ message: 'm' });
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateFeedback(null)).toBeNull();
+    expect(validateFeedback('string')).toBeNull();
+    expect(validateFeedback(42)).toBeNull();
+  });
+
+  it('rejects missing or non-string message', () => {
+    expect(validateFeedback({})).toBeNull();
+    expect(validateFeedback({ message: 123 })).toBeNull();
+  });
+
+  it('rejects empty / whitespace-only message', () => {
+    expect(validateFeedback({ message: '' })).toBeNull();
+    expect(validateFeedback({ message: '   ' })).toBeNull();
+  });
+
+  it('rejects oversized message', () => {
+    const tooLong = 'a'.repeat(FEEDBACK_MAX_MESSAGE_LENGTH + 1);
+    expect(validateFeedback({ message: tooLong })).toBeNull();
+  });
+
+  it('accepts exactly max-length message', () => {
+    const exact = 'a'.repeat(FEEDBACK_MAX_MESSAGE_LENGTH);
+    expect(validateFeedback({ message: exact })?.message.length).toBe(FEEDBACK_MAX_MESSAGE_LENGTH);
+  });
+});
+
+describe('generateFeedbackId', () => {
+  it('returns 8-char hex string', () => {
+    const id = generateFeedbackId();
+    expect(id).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('produces distinct ids across calls', () => {
+    const ids = new Set(Array.from({ length: 20 }, () => generateFeedbackId()));
+    expect(ids.size).toBeGreaterThan(1);
+  });
+});
+
+describe('feedbackKey', () => {
+  it('joins timestamp and id', () => {
+    expect(feedbackKey(123, 'abc')).toBe('feedback:123:abc');
+  });
+});
+
+describe('storeFeedback', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('writes record with TTL and returns key', async () => {
+    const putSpy = vi.spyOn(kv, 'put');
+    const key = await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'm', context: { platform: 'ios' } },
+      1000,
+      'idid',
+    );
+    expect(key).toBe('feedback:1000:idid');
+    expect(putSpy).toHaveBeenCalledWith(
+      'feedback:1000:idid',
+      JSON.stringify({ message: 'm', receivedAt: 1000, context: { platform: 'ios' } }),
+      { expirationTtl: FEEDBACK_TTL_SECONDS },
+    );
+  });
+
+  it('omits context when none provided', async () => {
+    await storeFeedback(kv as unknown as KVNamespace, { message: 'm' }, 5, 'aa');
+    const stored = await kv.get('feedback:5:aa');
+    expect(stored).toBe(JSON.stringify({ message: 'm', receivedAt: 5 }));
+  });
+});
+
+describe('POST /feedback', () => {
+  function envWithKv(): { env: Env; kv: InMemoryKV } {
+    const kv = new InMemoryKV();
+    const env = makeEnv({ FEEDBACK: kv as unknown as KVNamespace });
+    return { env, kv };
+  }
+
+  it('returns 503 when FEEDBACK binding is missing', async () => {
+    const res = await post('/feedback', { message: 'hi' }, makeEnv());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'feedback_unavailable' });
+  });
+
+  it('returns 400 on malformed JSON', async () => {
+    const { env } = envWithKv();
+    const res = await post('/feedback', '{not json', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 when message is missing', async () => {
+    const { env } = envWithKv();
+    const res = await post('/feedback', { context: { platform: 'ios' } }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('returns 400 when message exceeds limit', async () => {
+    const { env } = envWithKv();
+    const res = await post(
+      '/feedback',
+      { message: 'x'.repeat(FEEDBACK_MAX_MESSAGE_LENGTH + 1) },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('persists message with 201 on happy path', async () => {
+    const { env, kv } = envWithKv();
+    const res = await post(
+      '/feedback',
+      {
+        message: 'something is broken',
+        context: { platform: 'android', appVersion: '1.0.0' },
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { ok: boolean; key: string };
+    expect(json.ok).toBe(true);
+    expect(json.key).toMatch(/^feedback:\d+:[0-9a-f]{8}$/);
+    const stored = await kv.get(json.key);
+    expect(stored).not.toBeNull();
+    const record = JSON.parse(stored as string);
+    expect(record.message).toBe('something is broken');
+    expect(record.context).toEqual({ platform: 'android', appVersion: '1.0.0' });
+    expect(typeof record.receivedAt).toBe('number');
+  });
+});

--- a/backend/alarm-worker/src/feedback.ts
+++ b/backend/alarm-worker/src/feedback.ts
@@ -1,0 +1,97 @@
+/**
+ * 사용자 버그 신고 인프라 (#1034, docs/requirements/12-cross-cutting.md).
+ *
+ * 클라이언트가 SettingsScreen 진입점에서 자유 텍스트 + 디바이스 컨텍스트를 보낸다.
+ * 운영자가 `wrangler kv key list --binding FEEDBACK` / `wrangler kv get`으로 수거 후 분기 트리아지.
+ *
+ * 보관 정책:
+ *   - 키: `feedback:${epochMs}:${randomShortId}` — 시각 정렬 + 동시 충돌 회피
+ *   - TTL 30일 — 운영팀이 주기적으로 수거, 장기 보관 안 함 (개인정보 최소화)
+ *   - context는 옵션 — 미설정/잘못된 형식이면 무시하고 message만 저장
+ */
+
+export const FEEDBACK_TTL_SECONDS = 30 * 24 * 60 * 60;
+export const FEEDBACK_MAX_MESSAGE_LENGTH = 2000;
+
+export interface FeedbackContext {
+  appVersion?: string;
+  platform?: 'ios' | 'android';
+  locale?: string;
+  deviceModel?: string;
+}
+
+export interface FeedbackPayload {
+  message: string;
+  context?: FeedbackContext;
+}
+
+export interface FeedbackRecord {
+  message: string;
+  context?: FeedbackContext;
+  receivedAt: number;
+}
+
+/**
+ * 본문 검증. 한 필드라도 잘못되면 null → 호출부가 400 반환.
+ * context는 partial — 알려진 필드만 보존하고 나머지는 drop (forward compat).
+ */
+export function validateFeedback(input: unknown): FeedbackPayload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.message !== 'string') return null;
+  const message = obj.message.trim();
+  if (message.length === 0) return null;
+  if (message.length > FEEDBACK_MAX_MESSAGE_LENGTH) return null;
+
+  const context = parseContext(obj.context);
+  return context ? { message, context } : { message };
+}
+
+function parseContext(raw: unknown): FeedbackContext | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  const ctx: FeedbackContext = {};
+  if (typeof o.appVersion === 'string' && o.appVersion.length > 0) {
+    ctx.appVersion = o.appVersion.slice(0, 64);
+  }
+  if (o.platform === 'ios' || o.platform === 'android') {
+    ctx.platform = o.platform;
+  }
+  if (typeof o.locale === 'string' && o.locale.length > 0) {
+    ctx.locale = o.locale.slice(0, 16);
+  }
+  if (typeof o.deviceModel === 'string' && o.deviceModel.length > 0) {
+    ctx.deviceModel = o.deviceModel.slice(0, 64);
+  }
+  return Object.keys(ctx).length > 0 ? ctx : undefined;
+}
+
+/** 충돌 회피용 짧은 랜덤 ID. crypto.getRandomValues로 8자 hex. */
+export function generateFeedbackId(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function feedbackKey(receivedAt: number, id: string): string {
+  return `feedback:${receivedAt}:${id}`;
+}
+
+/**
+ * KV에 적재. JSON 직렬화 + TTL 30일.
+ */
+export async function storeFeedback(
+  kv: KVNamespace,
+  payload: FeedbackPayload,
+  receivedAt: number,
+  id: string,
+): Promise<string> {
+  const key = feedbackKey(receivedAt, id);
+  const record: FeedbackRecord = {
+    message: payload.message,
+    receivedAt,
+    ...(payload.context ? { context: payload.context } : {}),
+  };
+  await kv.put(key, JSON.stringify(record), { expirationTtl: FEEDBACK_TTL_SECONDS });
+  return key;
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -19,6 +19,11 @@ import {
   validateBoardingPromptOutcome,
 } from './boardingPromptOutcome';
 import { runFallbackPushes } from './fallback';
+import {
+  generateFeedbackId,
+  storeFeedback,
+  validateFeedback,
+} from './feedback';
 import { evaluateAndMaybeAlert } from './recallAlerts';
 import {
   cleanupTripWithLa,
@@ -81,6 +86,40 @@ function makeLaStats(): LiveActivityStats {
 export const app = new Hono<{ Bindings: Env }>();
 
 app.get('/health', (c) => c.json({ ok: true }));
+
+/**
+ * 사용자 버그 신고 (#1034, docs/requirements/12-cross-cutting.md).
+ *
+ * Body: `{ message: string, context?: { appVersion?, platform?, locale?, deviceModel? } }`
+ *   - message: 1~2000자 (validateFeedback이 trim 후 길이 검사)
+ *   - context: 옵션 — 알려진 필드만 보존, 나머지는 drop (forward compat)
+ *
+ * Responses:
+ *   201 { ok: true, key }       — 적재 성공
+ *   400 { error: 'invalid_json' | 'invalid_payload' }
+ *   503 { error: 'feedback_unavailable' } — FEEDBACK binding 미설정 (운영자 namespace 발급 전)
+ *
+ * 보관: TTL 30일. 운영자가 `wrangler kv` CLI로 수거.
+ */
+app.post('/feedback', async (c) => {
+  const kv = c.env.FEEDBACK;
+  if (!kv) return c.json({ error: 'feedback_unavailable' }, 503);
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateFeedback(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const receivedAt = Date.now();
+  const id = generateFeedbackId();
+  const key = await storeFeedback(kv, payload, receivedAt, id);
+  return c.json({ ok: true, key }, 201);
+});
 
 app.post('/trips', async (c) => {
   let body: unknown;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -427,6 +427,13 @@ export interface Env {
    * 생성: `wrangler kv:namespace create PENDING_PUSHES`
    */
   PENDING_PUSHES?: KVNamespace;
+  /**
+   * 사용자 버그 신고 KV (#1034, docs/requirements/12-cross-cutting.md).
+   * `POST /feedback`이 메시지 + 디바이스 컨텍스트를 30일 TTL로 적재.
+   * 미바인딩 시 endpoint는 503 graceful (운영자가 namespace 발급 전 환경 호환).
+   * 생성: `wrangler kv namespace create FEEDBACK`
+   */
+  FEEDBACK?: KVNamespace;
   /** Production APNs host (예: api.push.apple.com) */
   APNS_HOST: string;
   /** Sandbox APNs host (예: api.sandbox.push.apple.com) — dev/preview 빌드 토큰용 */

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -18,6 +18,17 @@ binding = "PENDING_PUSHES"
 id = "12e5eae8b5c94420b0efc1e89870c845"
 preview_id = "53a86628f78c48fa91fa954f84514df3"
 
+# KV: 사용자 버그 신고 (#1034, docs/requirements/12-cross-cutting.md)
+# `POST /feedback`이 메시지 + 디바이스 컨텍스트를 30일 TTL로 적재.
+# 운영자가 `wrangler kv key list --binding FEEDBACK`으로 수거 후 분기 트리아지.
+# TODO: 운영자가 `wrangler kv namespace create FEEDBACK` (+ `--preview`)로 실제 ID 발급 후
+#       아래 placeholder 두 줄을 교체. 코드는 `if (env.FEEDBACK)` 분기로 graceful —
+#       binding 미설정 환경(현재 placeholder 상태)에서는 endpoint가 503 응답.
+[[kv_namespaces]]
+binding = "FEEDBACK"
+id = "REPLACE_WITH_FEEDBACK_KV_ID"
+preview_id = "REPLACE_WITH_FEEDBACK_KV_PREVIEW_ID"
+
 # #498 — silent push 게이트 outcome 텔레메트리. 클라가 누적한 카운터를 일별 query 가능하게 적재.
 # Privacy: 카운트만, token은 8자 prefix만. 개별 push 내용/좌표 미저장.
 #

--- a/src/features/feedback/components/FeedbackModal.tsx
+++ b/src/features/feedback/components/FeedbackModal.tsx
@@ -1,0 +1,210 @@
+/**
+ * 버그 신고 모달 (#1034, docs/requirements/12-cross-cutting.md).
+ *
+ * SettingsScreen 진입점에서 열림. 사용자가 자유 텍스트로 메시지를 입력해 backend `POST /feedback`에
+ * 송신. 송신 결과(ok/실패)에 따라 toast 안내 후 자동 close.
+ *
+ * Scope 정책:
+ *   - 자유 텍스트 한 필드만 — 카테고리/이메일 등 추가 입력은 후속 PR.
+ *   - 디바이스 컨텍스트(앱 버전/플랫폼/로케일)는 `buildFeedbackContext`가 자동 첨부 — 사용자 입력 X.
+ *   - 송신 실패는 사용자 친화 toast로 안내하고 입력값은 보존 (재시도 가능).
+ */
+import { useState } from 'react';
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { submitFeedback } from '../../../shared/api/feedback';
+import { useTheme, spacing, radius } from '../../../shared/theme';
+
+/** message 최대 길이 — backend FEEDBACK_MAX_MESSAGE_LENGTH와 정합. */
+export const FEEDBACK_MAX_LENGTH = 2000;
+
+interface Props {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+}
+
+export function FeedbackModal({ visible, onClose }: Props) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [statusText, setStatusText] = useState<string | null>(null);
+
+  const trimmed = message.trim();
+  const canSubmit = trimmed.length > 0 && trimmed.length <= FEEDBACK_MAX_LENGTH && !submitting;
+
+  const handleClose = () => {
+    setMessage('');
+    setStatusText(null);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setStatusText(null);
+    const result = await submitFeedback(trimmed);
+    setSubmitting(false);
+    if (result.ok) {
+      setStatusText(t('feedback.successToast'));
+      setMessage('');
+      // 짧게 보여주고 자동 close — 즉시 닫으면 toast가 사라져 보이지 않음.
+      setTimeout(() => handleClose(), 1200);
+    } else {
+      setStatusText(t('feedback.errorToast'));
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={handleClose}
+      testID="feedback-modal"
+    >
+      <View style={[styles.backdrop, { backgroundColor: colors.overlay }]}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: colors.card,
+              paddingBottom: insets.bottom + spacing.lg,
+            },
+          ]}
+        >
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.ink }]}>
+              {t('feedback.title')}
+            </Text>
+            <Pressable
+              onPress={handleClose}
+              testID="feedback-close"
+              accessibilityRole="button"
+              accessibilityLabel={t('common.close')}
+            >
+              <Text style={[styles.close, { color: colors.muted }]}>✕</Text>
+            </Pressable>
+          </View>
+
+          <Text style={[styles.description, { color: colors.muted }]}>
+            {t('feedback.description')}
+          </Text>
+
+          <TextInput
+            style={[
+              styles.input,
+              { color: colors.ink, borderColor: colors.hair, backgroundColor: colors.bg },
+            ]}
+            value={message}
+            onChangeText={setMessage}
+            placeholder={t('feedback.placeholder')}
+            placeholderTextColor={colors.muted}
+            multiline
+            maxLength={FEEDBACK_MAX_LENGTH}
+            testID="feedback-input"
+            accessibilityLabel={t('feedback.title')}
+          />
+
+          <Text style={[styles.counter, { color: colors.muted }]}>
+            {trimmed.length}/{FEEDBACK_MAX_LENGTH}
+          </Text>
+
+          {statusText !== null && (
+            <Text
+              style={[styles.status, { color: colors.muted }]}
+              testID="feedback-status"
+            >
+              {statusText}
+            </Text>
+          )}
+
+          <Pressable
+            onPress={handleSubmit}
+            style={[
+              styles.submit,
+              {
+                backgroundColor: canSubmit ? colors.accent : colors.hair,
+              },
+            ]}
+            testID="feedback-submit"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !canSubmit }}
+          >
+            <Text style={[styles.submitText, { color: colors.onAccent }]}>
+              {submitting ? t('feedback.submitting') : t('feedback.submit')}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+    padding: spacing.lg,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  close: {
+    fontSize: 20,
+    padding: spacing.xs,
+  },
+  description: {
+    fontSize: 13,
+    lineHeight: 18,
+    marginBottom: spacing.md,
+  },
+  input: {
+    minHeight: 120,
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    fontSize: 15,
+    textAlignVertical: 'top',
+  },
+  counter: {
+    fontSize: 12,
+    textAlign: 'right',
+    marginTop: spacing.xs,
+  },
+  status: {
+    fontSize: 13,
+    marginTop: spacing.sm,
+    textAlign: 'center',
+  },
+  submit: {
+    marginTop: spacing.md,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    alignItems: 'center',
+  },
+  submitText: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/src/features/feedback/components/FeedbackModal.tsx
+++ b/src/features/feedback/components/FeedbackModal.tsx
@@ -11,8 +11,12 @@
  */
 import { useState } from 'react';
 import {
+  Keyboard,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -72,7 +76,16 @@ export function FeedbackModal({ visible, onClose }: Props) {
       onRequestClose={handleClose}
       testID="feedback-modal"
     >
-      <View style={[styles.backdrop, { backgroundColor: colors.overlay }]}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={[styles.backdrop, { backgroundColor: colors.overlay }]}
+      >
+        <Pressable
+          style={styles.backdropPressable}
+          onPress={Keyboard.dismiss}
+          testID="feedback-backdrop"
+          accessible={false}
+        />
         <View
           style={[
             styles.sheet,
@@ -82,70 +95,76 @@ export function FeedbackModal({ visible, onClose }: Props) {
             },
           ]}
         >
-          <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.ink }]}>
-              {t('feedback.title')}
-            </Text>
-            <Pressable
-              onPress={handleClose}
-              testID="feedback-close"
-              accessibilityRole="button"
-              accessibilityLabel={t('common.close')}
-            >
-              <Text style={[styles.close, { color: colors.muted }]}>✕</Text>
-            </Pressable>
-          </View>
-
-          <Text style={[styles.description, { color: colors.muted }]}>
-            {t('feedback.description')}
-          </Text>
-
-          <TextInput
-            style={[
-              styles.input,
-              { color: colors.ink, borderColor: colors.hair, backgroundColor: colors.bg },
-            ]}
-            value={message}
-            onChangeText={setMessage}
-            placeholder={t('feedback.placeholder')}
-            placeholderTextColor={colors.muted}
-            multiline
-            maxLength={FEEDBACK_MAX_LENGTH}
-            testID="feedback-input"
-            accessibilityLabel={t('feedback.title')}
-          />
-
-          <Text style={[styles.counter, { color: colors.muted }]}>
-            {trimmed.length}/{FEEDBACK_MAX_LENGTH}
-          </Text>
-
-          {statusText !== null && (
-            <Text
-              style={[styles.status, { color: colors.muted }]}
-              testID="feedback-status"
-            >
-              {statusText}
-            </Text>
-          )}
-
-          <Pressable
-            onPress={handleSubmit}
-            style={[
-              styles.submit,
-              {
-                backgroundColor: canSubmit ? colors.accent : colors.hair,
-              },
-            ]}
-            testID="feedback-submit"
-            accessibilityRole="button"
-            accessibilityState={{ disabled: !canSubmit }}
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={styles.scrollContent}
+            testID="feedback-scroll"
           >
-            <Text style={[styles.submitText, { color: colors.onAccent }]}>
-              {submitting ? t('feedback.submitting') : t('feedback.submit')}
+            <View style={styles.header}>
+              <Text style={[styles.title, { color: colors.ink }]}>
+                {t('feedback.title')}
+              </Text>
+              <Pressable
+                onPress={handleClose}
+                testID="feedback-close"
+                accessibilityRole="button"
+                accessibilityLabel={t('common.close')}
+              >
+                <Text style={[styles.close, { color: colors.muted }]}>✕</Text>
+              </Pressable>
+            </View>
+
+            <Text style={[styles.description, { color: colors.muted }]}>
+              {t('feedback.description')}
             </Text>
-          </Pressable>
+
+            <TextInput
+              style={[
+                styles.input,
+                { color: colors.ink, borderColor: colors.hair, backgroundColor: colors.bg },
+              ]}
+              value={message}
+              onChangeText={setMessage}
+              placeholder={t('feedback.placeholder')}
+              placeholderTextColor={colors.muted}
+              multiline
+              maxLength={FEEDBACK_MAX_LENGTH}
+              testID="feedback-input"
+              accessibilityLabel={t('feedback.title')}
+            />
+
+            <Text style={[styles.counter, { color: colors.muted }]}>
+              {trimmed.length}/{FEEDBACK_MAX_LENGTH}
+            </Text>
+
+            {statusText !== null && (
+              <Text
+                style={[styles.status, { color: colors.muted }]}
+                testID="feedback-status"
+              >
+                {statusText}
+              </Text>
+            )}
+
+            <Pressable
+              onPress={handleSubmit}
+              style={[
+                styles.submit,
+                {
+                  backgroundColor: canSubmit ? colors.accent : colors.hair,
+                },
+              ]}
+              testID="feedback-submit"
+              accessibilityRole="button"
+              accessibilityState={{ disabled: !canSubmit }}
+            >
+              <Text style={[styles.submitText, { color: colors.onAccent }]}>
+                {submitting ? t('feedback.submitting') : t('feedback.submit')}
+              </Text>
+            </Pressable>
+          </ScrollView>
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
@@ -155,10 +174,17 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'flex-end',
   },
+  backdropPressable: {
+    ...StyleSheet.absoluteFillObject,
+  },
   sheet: {
     borderTopLeftRadius: radius.lg,
     borderTopRightRadius: radius.lg,
     padding: spacing.lg,
+    maxHeight: '90%',
+  },
+  scrollContent: {
+    flexGrow: 1,
   },
   header: {
     flexDirection: 'row',

--- a/src/features/feedback/components/__tests__/FeedbackModal.test.tsx
+++ b/src/features/feedback/components/__tests__/FeedbackModal.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import { FeedbackModal, FEEDBACK_MAX_LENGTH } from '../FeedbackModal';
+import { submitFeedback } from '../../../../shared/api/feedback';
+
+jest.mock('../../../../shared/api/feedback', () => ({
+  submitFeedback: jest.fn(),
+}));
+
+const mockedSubmit = submitFeedback as jest.MockedFunction<typeof submitFeedback>;
+
+describe('FeedbackModal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedSubmit.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders title and submit disabled until non-empty input', () => {
+    const onClose = jest.fn();
+    const { getByTestId, getByText } = renderWithTheme(
+      <FeedbackModal visible onClose={onClose} />,
+    );
+    expect(getByText('버그 신고')).toBeTruthy();
+    const submit = getByTestId('feedback-submit');
+    expect(submit.props.accessibilityState).toEqual({ disabled: true });
+
+    fireEvent.changeText(getByTestId('feedback-input'), 'something broke');
+    expect(getByTestId('feedback-submit').props.accessibilityState).toEqual({
+      disabled: false,
+    });
+  });
+
+  it('disables submit when only whitespace is entered', () => {
+    const { getByTestId } = renderWithTheme(
+      <FeedbackModal visible onClose={jest.fn()} />,
+    );
+    fireEvent.changeText(getByTestId('feedback-input'), '   ');
+    expect(getByTestId('feedback-submit').props.accessibilityState).toEqual({
+      disabled: true,
+    });
+  });
+
+  it('submits trimmed message and shows success toast, then auto-closes', async () => {
+    mockedSubmit.mockResolvedValue({ ok: true, status: 201 });
+    const onClose = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <FeedbackModal visible onClose={onClose} />,
+    );
+    fireEvent.changeText(getByTestId('feedback-input'), '  hello  ');
+    await act(async () => {
+      fireEvent.press(getByTestId('feedback-submit'));
+    });
+    expect(mockedSubmit).toHaveBeenCalledWith('hello');
+    await waitFor(() => {
+      expect(getByTestId('feedback-status')).toBeTruthy();
+    });
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps input and shows error toast on submit failure', async () => {
+    mockedSubmit.mockResolvedValue({ ok: false, status: 500 });
+    const onClose = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <FeedbackModal visible onClose={onClose} />,
+    );
+    fireEvent.changeText(getByTestId('feedback-input'), 'broken');
+    await act(async () => {
+      fireEvent.press(getByTestId('feedback-submit'));
+    });
+    await waitFor(() => {
+      expect(getByTestId('feedback-status')).toBeTruthy();
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    // 입력 보존 — 사용자가 재시도할 수 있다.
+    expect(getByTestId('feedback-input').props.value).toBe('broken');
+  });
+
+  it('no-op when submit pressed while disabled', async () => {
+    mockedSubmit.mockResolvedValue({ ok: true, status: 201 });
+    const { getByTestId } = renderWithTheme(
+      <FeedbackModal visible onClose={jest.fn()} />,
+    );
+    await act(async () => {
+      fireEvent.press(getByTestId('feedback-submit'));
+    });
+    expect(mockedSubmit).not.toHaveBeenCalled();
+  });
+
+  it('shows submitting label while request is in flight', async () => {
+    let resolveFn: (v: { ok: boolean }) => void = () => {};
+    mockedSubmit.mockImplementation(
+      () => new Promise((resolve) => {
+        resolveFn = resolve;
+      }),
+    );
+    const { getByTestId, queryByText } = renderWithTheme(
+      <FeedbackModal visible onClose={jest.fn()} />,
+    );
+    fireEvent.changeText(getByTestId('feedback-input'), 'pending');
+    await act(async () => {
+      fireEvent.press(getByTestId('feedback-submit'));
+    });
+    expect(queryByText('보내는 중…')).toBeTruthy();
+    await act(async () => {
+      resolveFn({ ok: true });
+    });
+  });
+
+  it('close button resets state and calls onClose', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <FeedbackModal visible onClose={onClose} />,
+    );
+    fireEvent.changeText(getByTestId('feedback-input'), 'draft');
+    fireEvent.press(getByTestId('feedback-close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('FEEDBACK_MAX_LENGTH is 2000 (matches backend)', () => {
+    expect(FEEDBACK_MAX_LENGTH).toBe(2000);
+  });
+});

--- a/src/features/feedback/components/__tests__/FeedbackModal.test.tsx
+++ b/src/features/feedback/components/__tests__/FeedbackModal.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Keyboard } from 'react-native';
 import { act, fireEvent, waitFor } from '@testing-library/react-native';
 import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { FeedbackModal, FEEDBACK_MAX_LENGTH } from '../FeedbackModal';
@@ -126,5 +127,39 @@ describe('FeedbackModal', () => {
 
   it('FEEDBACK_MAX_LENGTH is 2000 (matches backend)', () => {
     expect(FEEDBACK_MAX_LENGTH).toBe(2000);
+  });
+
+  it('dismisses keyboard when backdrop is pressed', () => {
+    const dismissSpy = jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => {});
+    const { getByTestId } = renderWithTheme(
+      <FeedbackModal visible onClose={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('feedback-backdrop'));
+    expect(dismissSpy).toHaveBeenCalled();
+    dismissSpy.mockRestore();
+  });
+
+  it('uses height behavior on Android KeyboardAvoidingView', () => {
+    const original = require('react-native').Platform.OS;
+    require('react-native').Platform.OS = 'android';
+    try {
+      const { getByTestId } = renderWithTheme(
+        <FeedbackModal visible onClose={jest.fn()} />,
+      );
+      // 렌더만 성공하면 OK — Android 분기 커버.
+      expect(getByTestId('feedback-backdrop')).toBeTruthy();
+    } finally {
+      require('react-native').Platform.OS = original;
+    }
+  });
+
+  it('ScrollView allows taps to pass through to submit button while keyboard open', () => {
+    const { getByTestId } = renderWithTheme(
+      <FeedbackModal visible onClose={jest.fn()} />,
+    );
+    // keyboardShouldPersistTaps="handled" 보장 — 키보드가 열려 있어도 submit 버튼이 첫 탭에 반응한다.
+    expect(getByTestId('feedback-scroll').props.keyboardShouldPersistTaps).toBe(
+      'handled',
+    );
   });
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Alert, Pressable, ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +13,7 @@ import { ROUTE_CATEGORIES } from '../shared/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../shared/i18n/types';
 import { useTheme, spacing, radius } from '../shared/theme';
 import { useSleepModeGuide } from '../features/settings/hooks/useSleepModeGuide';
+import { FeedbackModal } from '../features/feedback/components/FeedbackModal';
 import {
   DEBUG_MODAL_TRIGGER_RESET_MS,
   DEBUG_MODAL_TRIGGER_TAP_COUNT,
@@ -49,6 +50,8 @@ export default function SettingsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const showSleepModeGuide = useSleepModeGuide();
+  // #1034 — 버그 신고 모달 (Cloudflare KV FEEDBACK + POST /feedback).
+  const [feedbackVisible, setFeedbackVisible] = useState(false);
 
   useEffect(() => {
     loadSleepMode();
@@ -186,8 +189,36 @@ export default function SettingsScreen() {
           </View>
         </View>
 
+        {/* #1034 — 버그 신고 진입점. Pressable 1줄로 모달 open. */}
+        <View style={[styles.card, { backgroundColor: colors.card }]}>
+          <Text style={[styles.sectionTitle, { color: colors.muted }]}>
+            {t('settings.feedbackSection')}
+          </Text>
+          <Pressable
+            style={styles.settingRow}
+            onPress={() => setFeedbackVisible(true)}
+            testID="feedback-entry"
+            accessibilityRole="button"
+            accessibilityLabel={t('settings.feedbackLabel')}
+          >
+            <View style={styles.settingInfo}>
+              <Text style={[styles.settingLabel, { color: colors.ink }]}>
+                {t('settings.feedbackLabel')}
+              </Text>
+              <Text style={[styles.settingDesc, { color: colors.muted }]}>
+                {t('settings.feedbackDescription')}
+              </Text>
+            </View>
+            <Text style={[styles.localeChevron, { color: colors.muted }]}>›</Text>
+          </Pressable>
+        </View>
+
         <VersionFooter />
       </ScrollView>
+      <FeedbackModal
+        visible={feedbackVisible}
+        onClose={() => setFeedbackVisible(false)}
+      />
     </SafeAreaView>
   );
 }

--- a/src/shared/api/__tests__/feedback.test.ts
+++ b/src/shared/api/__tests__/feedback.test.ts
@@ -1,0 +1,119 @@
+import { buildFeedbackContext, submitFeedback } from '../feedback';
+
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: { expoConfig: { version: '9.9.9' } },
+}));
+
+jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+
+jest.mock('i18next', () => ({
+  __esModule: true,
+  default: { language: 'ko-KR' },
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+describe('buildFeedbackContext', () => {
+  it('collects appVersion / platform / locale', () => {
+    expect(buildFeedbackContext()).toEqual({
+      appVersion: '9.9.9',
+      platform: 'ios',
+      locale: 'ko-KR',
+    });
+  });
+
+  it('omits fields when underlying sources are missing', () => {
+    const Constants = require('expo-constants').default as { expoConfig: { version?: string } };
+    const RN = require('react-native') as { Platform: { OS: string } };
+    const i18nMod = require('i18next').default as { language: string };
+    const origVersion = Constants.expoConfig.version;
+    const origOs = RN.Platform.OS;
+    const origLang = i18nMod.language;
+    try {
+      Constants.expoConfig.version = undefined;
+      RN.Platform.OS = 'web';
+      i18nMod.language = '';
+      expect(buildFeedbackContext()).toEqual({});
+    } finally {
+      Constants.expoConfig.version = origVersion;
+      RN.Platform.OS = origOs;
+      i18nMod.language = origLang;
+    }
+  });
+});
+
+describe('submitFeedback', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('URL 미설정이면 skipped=true', async () => {
+    const result = await submitFeedback('hi');
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('정상 응답 시 ok=true + body 직렬화 확인', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 201 });
+    const result = await submitFeedback('hello world');
+    expect(result).toEqual({ ok: true, status: 201 });
+    const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test/feedback');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.message).toBe('hello world');
+    expect(body.context).toEqual({
+      appVersion: '9.9.9',
+      platform: 'ios',
+      locale: 'ko-KR',
+    });
+  });
+
+  it('non-2xx 응답이면 ok=false + status', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 400 });
+    const result = await submitFeedback('m');
+    expect(result).toEqual({ ok: false, status: 400 });
+  });
+
+  it('fetch throw 시 ok=false', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    const result = await submitFeedback('m');
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('aborts on timeout', async () => {
+    jest.useFakeTimers();
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          (init.signal as AbortSignal).addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          );
+        }),
+    );
+    const promise = submitFeedback('m');
+    await jest.advanceTimersByTimeAsync(10_000);
+    const result = await promise;
+    expect(result).toEqual({ ok: false });
+    jest.useRealTimers();
+  });
+});

--- a/src/shared/api/feedback.ts
+++ b/src/shared/api/feedback.ts
@@ -1,0 +1,88 @@
+/**
+ * 사용자 버그 신고 클라이언트 (#1034, docs/requirements/12-cross-cutting.md).
+ *
+ * SettingsScreen의 FeedbackModal이 사용. backend `POST /feedback`에 메시지 + 디바이스 컨텍스트를
+ * 송신한다. 실패는 graceful — UI가 "잠시 후 다시 시도" 안내.
+ *
+ * 환경변수:
+ *   `EXPO_PUBLIC_ALARM_BACKEND_URL` — 미설정 시 ok=false + skipped=true (개발 환경 호환).
+ */
+
+import { Platform } from 'react-native';
+import Constants from 'expo-constants';
+import i18n from 'i18next';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('feedbackApi');
+
+/** fetch 타임아웃 — UI 입력 흐름에 영향 주지 않게 짧게 끊는다. */
+export const FEEDBACK_REQUEST_TIMEOUT_MS = 5000;
+
+export interface SubmitFeedbackResult {
+  ok: boolean;
+  /** URL 미설정 등으로 호출이 건너뛰어진 경우 true. */
+  skipped?: boolean;
+  status?: number;
+}
+
+function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FEEDBACK_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** 클라이언트 디바이스 컨텍스트 — 운영자가 분기 트리아지 시 사용. */
+export function buildFeedbackContext(): {
+  appVersion?: string;
+  platform?: 'ios' | 'android';
+  locale?: string;
+} {
+  const ctx: { appVersion?: string; platform?: 'ios' | 'android'; locale?: string } = {};
+  const version = Constants.expoConfig?.version;
+  if (typeof version === 'string' && version.length > 0) ctx.appVersion = version;
+  if (Platform.OS === 'ios' || Platform.OS === 'android') ctx.platform = Platform.OS;
+  if (typeof i18n.language === 'string' && i18n.language.length > 0) ctx.locale = i18n.language;
+  return ctx;
+}
+
+/**
+ * 사용자 버그 신고 송신.
+ *
+ * @returns ok=true(201) / ok=false(network or non-2xx) / skipped=true(URL 미설정).
+ *   호출부(FeedbackModal)는 ok 기준으로 toast/dismiss 분기 — skipped도 ok=false로 동일 처리.
+ */
+export async function submitFeedback(message: string): Promise<SubmitFeedbackResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip feedback submit');
+    return { ok: false, skipped: true };
+  }
+
+  const body = { message, context: buildFeedbackContext() };
+
+  try {
+    const res = await fetchWithTimeout(`${base}/feedback`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      log.warn(`feedback submit failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('feedback submit error', e);
+    return { ok: false };
+  }
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -81,7 +81,19 @@
     "languageSection": "Language",
     "languageLabel": "App language",
     "languageDescription": "Auto follows your device setting",
-    "languageAuto": "Auto"
+    "languageAuto": "Auto",
+    "feedbackSection": "Support",
+    "feedbackLabel": "Report a bug",
+    "feedbackDescription": "Tell us about issues you encountered"
+  },
+  "feedback": {
+    "title": "Report a bug",
+    "description": "Describe the problem you experienced. App version and OS info will be sent along.",
+    "placeholder": "e.g. The arrival alarm for Gangnam didn't fire",
+    "submit": "Send",
+    "submitting": "Sending…",
+    "successToast": "Sent. Thank you!",
+    "errorToast": "Failed to send. Please try again later."
   },
   "map": {
     "originBadge": "Origin",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -81,7 +81,19 @@
     "languageSection": "言語",
     "languageLabel": "アプリの言語",
     "languageDescription": "自動はデバイスの設定に従います",
-    "languageAuto": "自動"
+    "languageAuto": "自動",
+    "feedbackSection": "サポート",
+    "feedbackLabel": "バグを報告",
+    "feedbackDescription": "アプリで発生した問題をお知らせください"
+  },
+  "feedback": {
+    "title": "バグを報告",
+    "description": "発生した問題を詳しく記入してください。アプリのバージョンとOS情報も一緒に送信されます。",
+    "placeholder": "例: 江南駅の到着アラームが鳴りませんでした",
+    "submit": "送信",
+    "submitting": "送信中…",
+    "successToast": "送信しました。ありがとうございます！",
+    "errorToast": "送信に失敗しました。しばらくしてからもう一度お試しください。"
   },
   "map": {
     "originBadge": "出発",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -81,7 +81,19 @@
     "languageSection": "언어",
     "languageLabel": "앱 언어",
     "languageDescription": "자동은 기기 설정을 따릅니다",
-    "languageAuto": "자동"
+    "languageAuto": "자동",
+    "feedbackSection": "지원",
+    "feedbackLabel": "버그 신고",
+    "feedbackDescription": "앱에서 겪은 문제를 알려 주세요"
+  },
+  "feedback": {
+    "title": "버그 신고",
+    "description": "겪으신 문제를 자세히 적어 주세요. 앱 버전과 OS 정보가 함께 전달됩니다.",
+    "placeholder": "예: 강남역 도착 알람이 울리지 않았어요",
+    "submit": "보내기",
+    "submitting": "보내는 중…",
+    "successToast": "전송했어요. 감사합니다!",
+    "errorToast": "전송에 실패했어요. 잠시 후 다시 시도해 주세요."
   },
   "map": {
     "originBadge": "출발",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -81,7 +81,19 @@
     "languageSection": "语言",
     "languageLabel": "应用语言",
     "languageDescription": "自动会跟随设备设置",
-    "languageAuto": "自动"
+    "languageAuto": "自动",
+    "feedbackSection": "支持",
+    "feedbackLabel": "报告问题",
+    "feedbackDescription": "告诉我们您遇到的问题"
+  },
+  "feedback": {
+    "title": "报告问题",
+    "description": "请详细描述您遇到的问题。应用版本和系统信息将一并发送。",
+    "placeholder": "例如：江南站的到达提醒未响起",
+    "submit": "发送",
+    "submitting": "正在发送…",
+    "successToast": "已发送，感谢您的反馈！",
+    "errorToast": "发送失败，请稍后再试。"
   },
   "map": {
     "originBadge": "出发",


### PR DESCRIPTION
## Summary
- alarm-worker `POST /feedback` 핸들러 신설: KV `FEEDBACK`에 메시지 + 디바이스 컨텍스트(app version / platform / locale)를 TTL 30일로 적재. binding 미설정 시 503 graceful
- 신규 feature slice `src/features/feedback/` — `FeedbackModal` (multiline TextInput + 제출/닫기) + `src/shared/api/feedback.ts` submit util (timeout 5s, URL 미설정 시 skipped)
- SettingsScreen 하단에 "지원 → 버그 신고" Pressable 1줄 추가, 모달 마운트
- i18n ko/en/ja/zh 4 locale 키 추가 (`settings.feedbackSection/Label/Description`, `feedback.*`)
- **FEEDBACK KV namespace 발급 + wrangler.toml ID 반영 완료** (별도 commit `chore(#1034): FEEDBACK KV namespace 실제 ID 반영`)

docs/requirements/12-cross-cutting.md "Cloudflare KV `FEEDBACK` namespace 신규 + `POST /feedback`" 항목 구현.

## Test plan
- [x] backend vitest: `feedback.test.ts` 22건 happy/empty/oversized/malformed/context truncation
- [x] backend `npm test`: 984 passed (28 suites)
- [x] client `npm test`: 4182 passed (228 suites) — 100% coverage 유지
- [x] client `npm run type-check`: clean
- [x] `npm run lint`: clean (feature slice 경계 OK)
- [ ] 실기기 수동 검증: Settings → 버그 신고 → 메시지 입력 → 성공 토스트 + 자동 close
- [ ] (머지 후) `wrangler deploy` → `POST /feedback` 201 응답 확인 → KV에 키 적재 확인

## 머지 후 액션

1. `cd backend/alarm-worker && npx wrangler deploy` (FEEDBACK binding 활성화 반영)
2. 실기기에서 Settings → 버그 신고 송신 → 토스트 성공
3. 수거: `npx wrangler kv key list --binding FEEDBACK --remote` → 키 확인

KV namespace IDs (참고, 평문 — secret 아님):
- production: `831193b9d97f44c5b65131f045c09804`
- preview: `d38f190e3f7f4fd3b6e7f6485dd1733d`

Closes #1034
