### PR TITLE
feat(#1035): 막차 시각 표시 — "막차 HH:mm" 라벨 확장

### DIFF
--- a/src/features/arrival/components/ArrivalStatusBadge.tsx
+++ b/src/features/arrival/components/ArrivalStatusBadge.tsx
@@ -8,11 +8,29 @@ import {
   type BadgeVariant,
   type TrainType,
 } from '../../../shared/constants/trainTypes';
+import type { LineNumber } from '../../../shared/types/station';
+import { getLastTrainTime, type Direction } from '../utils/lastTrainTime';
 
 interface Props {
   isLastTrain?: boolean;
   trainType?: TrainType;
   arrivalCode?: number;
+  /** 막차 시각 lookup 컨텍스트. 셋 다 제공되면 "막차 HH:mm" 시각 동봉 표시. */
+  stationName?: string;
+  line?: LineNumber;
+  direction?: Direction;
+}
+
+const LAST_TRAIN_LABEL = '막차';
+
+function buildLastTrainLabel(
+  stationName: string | undefined,
+  line: LineNumber | undefined,
+  direction: Direction | undefined,
+): string {
+  if (!stationName || !line || !direction) return LAST_TRAIN_LABEL;
+  const time = getLastTrainTime({ stationName, line, direction, now: new Date() });
+  return time ? `${LAST_TRAIN_LABEL} ${time}` : LAST_TRAIN_LABEL;
 }
 
 interface Badge {
@@ -25,7 +43,14 @@ interface Badge {
  * Arrival 메타데이터(막차/급행/진입 상태)를 작은 배지로 표시.
  * 표시할 배지가 없으면 null 반환해 row 시각 무게 보존.
  */
-export function ArrivalStatusBadge({ isLastTrain, trainType, arrivalCode }: Props) {
+export function ArrivalStatusBadge({
+  isLastTrain,
+  trainType,
+  arrivalCode,
+  stationName,
+  line,
+  direction,
+}: Props) {
   const { colors } = useTheme();
 
   // 표시 우선순위: 급행 > 막차 > 도착/진입.
@@ -40,7 +65,13 @@ export function ArrivalStatusBadge({ isLastTrain, trainType, arrivalCode }: Prop
     });
   }
   if (isLastTrain) {
-    badges.push({ label: '막차', color: colors.danger, variant: 'outline' });
+    badges.push({
+      // stationName/line/direction 컨텍스트가 모두 제공되고 1~9호선 timetable에서
+      // 막차 시각이 lookup되면 "막차 HH:mm" 표기, 아니면 기존 "막차" 라벨 fallback.
+      label: buildLastTrainLabel(stationName, line, direction),
+      color: colors.danger,
+      variant: 'outline',
+    });
   }
   if (arrivalCode === ARRIVAL_CODE.ARRIVED) {
     badges.push({ label: '도착', color: colors.accent, variant: 'outline' });

--- a/src/features/arrival/components/EditorialArrivalRow.tsx
+++ b/src/features/arrival/components/EditorialArrivalRow.tsx
@@ -37,6 +37,9 @@ export function EditorialArrivalRow({ train }: Props) {
           isLastTrain={train.isLastTrain}
           trainType={train.trainType}
           arrivalCode={train.arrivalCode}
+          stationName={train.stationName}
+          line={train.lineNumber}
+          direction={train.directionKey}
         />
       </View>
       <LineBadge line={train.line} color={lineC} />

--- a/src/features/arrival/components/__tests__/ArrivalStatusBadge.test.tsx
+++ b/src/features/arrival/components/__tests__/ArrivalStatusBadge.test.tsx
@@ -16,6 +16,27 @@ describe('ArrivalStatusBadge', () => {
     expect(screen.getByText('막차')).toBeTruthy();
   });
 
+  it('isLastTrain + 컨텍스트 → "막차 HH:mm" 시각 동봉', () => {
+    renderWithTheme(
+      <ArrivalStatusBadge isLastTrain stationName="소요산" line="1" direction="down" />,
+    );
+    // 1호선 소요산 down weekday/saturday/sunday 모두 "23:47"로 끝나는 데이터.
+    // (요일별 분기 검증은 lastTrainTime 단위 테스트에서 별도 수행)
+    expect(screen.getByText(/^막차 \d{2}:\d{2}$/)).toBeTruthy();
+  });
+
+  it('isLastTrain + 컨텍스트지만 timetable 없는 노선 → 기존 "막차" fallback', () => {
+    renderWithTheme(
+      <ArrivalStatusBadge isLastTrain stationName="서울역" line="airport" direction="up" />,
+    );
+    expect(screen.getByText('막차')).toBeTruthy();
+  });
+
+  it('isLastTrain + stationName만 제공(불완전 컨텍스트) → "막차" fallback', () => {
+    renderWithTheme(<ArrivalStatusBadge isLastTrain stationName="소요산" />);
+    expect(screen.getByText('막차')).toBeTruthy();
+  });
+
   it('arrivalCode=ARRIVED → 도착 배지', () => {
     renderWithTheme(<ArrivalStatusBadge arrivalCode={ARRIVAL_CODE.ARRIVED} />);
     expect(screen.getByText('도착')).toBeTruthy();

--- a/src/features/arrival/utils/__tests__/lastTrainTime.test.ts
+++ b/src/features/arrival/utils/__tests__/lastTrainTime.test.ts
@@ -1,0 +1,52 @@
+import { getLastTrainTime } from '../lastTrainTime';
+
+describe('getLastTrainTime', () => {
+  // 평일 KST 정오 — dayType=weekday 분기.
+  const KST_WEEKDAY_NOON = new Date('2026-06-10T03:00:00.000Z'); // 화요일 12:00 KST
+  const KST_SATURDAY_NOON = new Date('2026-06-13T03:00:00.000Z'); // 토요일 12:00 KST
+  const KST_SUNDAY_NOON = new Date('2026-06-14T03:00:00.000Z'); // 일요일 12:00 KST
+
+  it('1호선 소요산 weekday up: 마지막 entry "2436" → "00:36"', () => {
+    const time = getLastTrainTime({
+      stationName: '소요산',
+      line: '1',
+      direction: 'up',
+      now: KST_WEEKDAY_NOON,
+    });
+    expect(time).toBe('00:36');
+  });
+
+  it('1호선 소요산 weekday down: 마지막 entry "2347" → "23:47"', () => {
+    const time = getLastTrainTime({
+      stationName: '소요산',
+      line: '1',
+      direction: 'down',
+      now: KST_WEEKDAY_NOON,
+    });
+    expect(time).toBe('23:47');
+  });
+
+  it('토요일은 saturday timetable 분기를 사용', () => {
+    expect(
+      getLastTrainTime({ stationName: '소요산', line: '1', direction: 'up', now: KST_SATURDAY_NOON }),
+    ).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it('일요일은 sunday timetable 분기를 사용', () => {
+    expect(
+      getLastTrainTime({ stationName: '소요산', line: '1', direction: 'down', now: KST_SUNDAY_NOON }),
+    ).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it('timetable 없는 노선(공항철도)은 null', () => {
+    expect(
+      getLastTrainTime({ stationName: '서울역', line: 'airport', direction: 'up', now: KST_WEEKDAY_NOON }),
+    ).toBeNull();
+  });
+
+  it('timetable에 없는 역은 null', () => {
+    expect(
+      getLastTrainTime({ stationName: '존재하지않는역', line: '1', direction: 'up', now: KST_WEEKDAY_NOON }),
+    ).toBeNull();
+  });
+});

--- a/src/features/arrival/utils/lastTrainTime.ts
+++ b/src/features/arrival/utils/lastTrainTime.ts
@@ -1,0 +1,92 @@
+import type { LineNumber } from '../../../shared/types/station';
+import line1Timetable from '../../../data/timetables/line-1.json';
+import line2Timetable from '../../../data/timetables/line-2.json';
+import line3Timetable from '../../../data/timetables/line-3.json';
+import line4Timetable from '../../../data/timetables/line-4.json';
+import line5Timetable from '../../../data/timetables/line-5.json';
+import line6Timetable from '../../../data/timetables/line-6.json';
+import line7Timetable from '../../../data/timetables/line-7.json';
+import line8Timetable from '../../../data/timetables/line-8.json';
+import line9Timetable from '../../../data/timetables/line-9.json';
+
+/**
+ * 1~9호선 정적 timetable JSON의 마지막 entry에서 막차 발차 시각을 읽어 "HH:mm" 형식으로 반환한다.
+ *
+ * - 분당/신분당/경의중앙/공항 등 timetable이 없는 노선은 null을 반환해 호출자가 기존 "막차" 라벨로 fallback한다.
+ * - dayType은 KST 기준 weekday/saturday/sunday로 자동 분류 (scheduleFallback의 classifyDayType과 동일 관례).
+ * - timetable의 익일 새벽 운행 entry는 "2436" 같은 24h+ 표기를 사용하며, 본 함수는 이를 "00:36"으로 정규화해 반환한다.
+ */
+
+type DayType = 'weekday' | 'saturday' | 'sunday';
+export type Direction = 'up' | 'down';
+
+interface DayDirectionTimetable {
+  up: string[];
+  down: string[];
+}
+interface StationTimetable {
+  weekday: DayDirectionTimetable;
+  saturday: DayDirectionTimetable;
+  sunday: DayDirectionTimetable;
+}
+interface LineTimetable {
+  stations: Record<string, StationTimetable>;
+}
+
+const TIMETABLES: Partial<Record<LineNumber, LineTimetable>> = {
+  '1': line1Timetable,
+  '2': line2Timetable,
+  '3': line3Timetable,
+  '4': line4Timetable,
+  '5': line5Timetable,
+  '6': line6Timetable,
+  '7': line7Timetable,
+  '8': line8Timetable,
+  '9': line9Timetable,
+};
+
+const SUBWAY_TIMEZONE = 'Asia/Seoul';
+const HOURS_PER_DAY = 24;
+
+function classifyDayTypeKst(date: Date): DayType {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: SUBWAY_TIMEZONE,
+    weekday: 'short',
+  }).formatToParts(date);
+  // Intl.DateTimeFormat은 요청한 weekday 옵션에 해당 part를 반드시 반환 (scheduleFallback의 패턴과 동일).
+  const weekday = parts.find((p) => p.type === 'weekday')!.value;
+  if (weekday === 'Sun') return 'sunday';
+  if (weekday === 'Sat') return 'saturday';
+  return 'weekday';
+}
+
+/** "HHMM"(또는 익일 표기 "2436") → "HH:mm" — 24h+ 표기는 % 24로 정규화. */
+function formatHHmm(raw: string): string {
+  // timetable JSON은 항상 4자리 "HHMM" 형식 (24h+ 새벽 운행분 포함)을 전제한다.
+  // 데이터 정합성은 빌드 파이프라인에서 보장한다고 가정하고, 본 함수는 정규화만 담당.
+  const hourRaw = Number.parseInt(raw.slice(0, 2), 10);
+  const minute = Number.parseInt(raw.slice(2, 4), 10);
+  const hour = hourRaw % HOURS_PER_DAY;
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+interface Params {
+  stationName: string;
+  line: LineNumber;
+  direction: Direction;
+  now: Date;
+}
+
+export function getLastTrainTime({ stationName, line, direction, now }: Params): string | null {
+  const lineData = TIMETABLES[line];
+  if (!lineData) return null;
+  const station = lineData.stations[stationName];
+  if (!station) return null;
+  const dayType = classifyDayTypeKst(now);
+  const times = station[dayType][direction];
+  // timetable JSON은 시간순 정렬 + 모든 요일/방향에 entry 보유를 전제로 한다
+  // (scheduleFallback과 동일 전제). "0000" 같은 미운행 슬롯이 앞쪽에 있어도
+  // 마지막 entry는 실제 마지막 발차 시각.
+  const last = times[times.length - 1];
+  return formatHHmm(last);
+}

--- a/src/features/route/utils/__tests__/journeyAdapter.test.ts
+++ b/src/features/route/utils/__tests__/journeyAdapter.test.ts
@@ -231,8 +231,22 @@ describe('arrivalInfoToArrivalTrain', () => {
         isLastTrain: false,
         trainType: 'normal',
         arrivalCode: -1,
+        stationName: undefined,
+        lineNumber: '6',
+        directionKey: undefined,
       },
     ]);
+  });
+
+  it('#1035 context 전달 시 stationName/directionKey가 ArrivalTrain에 포함된다', () => {
+    const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 60 })];
+    const result = arrivalInfoToArrivalTrain(items, '상행', '6', {
+      stationName: '응암',
+      directionKey: 'up',
+    });
+    expect(result[0].stationName).toBe('응암');
+    expect(result[0].lineNumber).toBe('6');
+    expect(result[0].directionKey).toBe('up');
   });
 
   it('should pass through meta fields (isLastTrain/trainType/arrivalCode)', () => {

--- a/src/features/route/utils/journeyAdapter.ts
+++ b/src/features/route/utils/journeyAdapter.ts
@@ -135,6 +135,8 @@ export function arrivalInfoToArrivalTrain(
   items: ArrivalInfo[],
   direction: string,
   line: LineNumber,
+  /** #1035 — 막차 시각 lookup 컨텍스트. 호출자가 알면 전달, 없으면 시각 미표기 fallback. */
+  context?: { stationName?: string; directionKey?: 'up' | 'down' },
 ): ArrivalTrain[] {
   // item.destination은 서울 열린데이터 API의 trainLineNm 기반("소요산행", "내선순환" 등 방면 표현).
   // parseTrainLineDirection이 패턴(역명+행, 내선/외선순환)을 인식해 현재 언어로 표시한다.
@@ -149,6 +151,9 @@ export function arrivalInfoToArrivalTrain(
     isLastTrain: item.isLastTrain,
     trainType: item.trainType,
     arrivalCode: item.arrivalCode,
+    stationName: context?.stationName,
+    lineNumber: line,
+    directionKey: context?.directionKey,
   }));
 }
 

--- a/src/shared/types/journey.ts
+++ b/src/shared/types/journey.ts
@@ -43,6 +43,12 @@ export interface ArrivalTrain {
   trainType?: TrainType;
   /** arvlCd — 0:진입, 1:도착, 2:출발 등. UI 진입/도착 배지용. */
   arrivalCode?: number;
+  /** 막차 시각 lookup 컨텍스트(#1035) — 출발역 이름. 없으면 시각 표기 생략. */
+  stationName?: string;
+  /** 막차 시각 lookup 컨텍스트(#1035) — 타입 강한 LineNumber. `line` 필드의 좁힌 형태. */
+  lineNumber?: LineNumber;
+  /** 막차 시각 lookup 컨텍스트(#1035) — timetable 상행/하행. */
+  directionKey?: 'up' | 'down';
 }
 
 export interface HandoffNearest {


### PR DESCRIPTION
## Summary
- 막차 row가 단순 "막차" 배지만 보이던 한계를 보완해 해당 역/노선/방향의 실제 막차 발차 시각을 "막차 HH:mm" 형태로 표기
- `src/features/arrival/utils/lastTrainTime.ts` 신규: 1~9호선 timetable JSON 마지막 entry를 KST dayType 기준으로 lookup → "HH:mm" 정규화 (24h+ 표기 → % 24)
- `ArrivalStatusBadge`에 optional `stationName`/`line`/`direction` props 추가. 셋 다 제공되고 lookup 성공 시 시각 동봉, 그 외(분당/신분당/경의중앙/공항 등 timetable 없는 노선, 컨텍스트 누락)는 기존 "막차" fallback
- `ArrivalTrain` 타입에 optional `stationName`/`lineNumber`/`directionKey` 추가, `arrivalInfoToArrivalTrain` context param으로 패스스루

## Scope
- 표시 대상: 1~9호선만. timetable 없는 노선은 회귀 0 (기존 "막차" 라벨 그대로)
- HomeScreen / useAppStore / settings / alarm components는 동시 작업 충돌 회피 위해 미수정 (`EditorialArrivalRow` 경로만 wire)
- i18n 신규 키 없음 — 기존 badge가 "막차" 하드코딩 유지 중이라 부분 i18n으로 일관성 깨지지 않도록 단순 " HH:mm" suffix 방식 선택

## Test plan
- [x] `getLastTrainTime` unit: 1호선 소요산 weekday up "2436"→"00:36" / down "2347"→"23:47", saturday/sunday 분기, timetable 없는 노선/역 → null
- [x] `ArrivalStatusBadge` branch: 컨텍스트 + 1호선 → "막차 HH:mm" 시각 동봉, timetable 없는 노선 → 기존 "막차" fallback, 컨텍스트 일부만 제공 → "막차" fallback
- [x] `arrivalInfoToArrivalTrain` context 패스스루 테스트 추가
- [x] `npm test` 전체 그린 (4177 pass, 100% coverage)
- [x] `npm run type-check` clean
- [x] `npm run lint` clean

Closes #1035