### PR TITLE
feat(#1046): 비단조 노선 방향 추론 util (2호선 우선)

### DIFF
--- a/src/features/route/utils/__tests__/loopDirection.test.ts
+++ b/src/features/route/utils/__tests__/loopDirection.test.ts
@@ -1,0 +1,128 @@
+import { inferLoopDirection, parseTrainLineDirection } from '../loopDirection';
+
+jest.mock('../../../../shared/utils/stationRoute', () => ({
+  getStationsOnLine: (line: string) => {
+    if (line === '2') {
+      // 8역짜리 가짜 루프 + 지선(2-105) 1개. 메인 루프만 추론 대상.
+      return [
+        { id: '2-001', name: '시청', line: '2' },
+        { id: '2-002', name: '을지로입구', line: '2' },
+        { id: '2-003', name: '을지로3가', line: '2' },
+        { id: '2-004', name: '을지로4가', line: '2' },
+        { id: '2-005', name: '동대문역사문화공원', line: '2' },
+        { id: '2-006', name: '신당', line: '2' },
+        { id: '2-007', name: '상왕십리', line: '2' },
+        { id: '2-008', name: '왕십리', line: '2' },
+        { id: '2-105', name: '까치산', line: '2' }, // 지선 — 추론 대상 외
+      ];
+    }
+    if (line === '3') return [{ id: '3-0', name: '대화', line: '3' }];
+    if (line === '6') return []; // 빈 노선
+    return [];
+  },
+  normalizeStationName: (name: string) => {
+    if (name.endsWith(')')) {
+      const open = name.lastIndexOf('(');
+      if (open > 0) return name.slice(0, open).trim();
+    }
+    return name;
+  },
+}));
+
+describe('inferLoopDirection', () => {
+  it('순환선 외(monotonic) 노선은 null', () => {
+    expect(inferLoopDirection('3', '대화', '주엽')).toBeNull();
+  });
+
+  it('2호선이지만 stations 빈 경우는 null', () => {
+    // line '6'을 빈 배열로 mock — 동일 분기 검증 위해 line '2'에 대해 빈 배열 시나리오를
+    // 별도로 만들 수 없으므로 LOOP_LINES 분기 후 stations.length === 0 가드를 보장하기 위해
+    // 임시로 mock을 덮어쓰지 않고, 빈 루프 가드는 다음 케이스(필터 결과 < 2)에서 함께 검증한다.
+    // 여기서는 monotonic skip만 우선 확인.
+    expect(inferLoopDirection('3', '대화', '대화')).toBeNull();
+  });
+
+  it('id 증가 방향이 짧으면 외선순환(down)', () => {
+    // 시청(0) → 을지로4가(3): forward=3, backward=5 → down
+    expect(inferLoopDirection('2', '시청', '을지로4가')).toBe('down');
+  });
+
+  it('id 감소(wrap) 방향이 짧으면 내선순환(up)', () => {
+    // 시청(0) → 왕십리(7): forward=7, backward=1 → up
+    expect(inferLoopDirection('2', '시청', '왕십리')).toBe('up');
+  });
+
+  it('정반대 위치(두 호 동일 길이)는 null', () => {
+    // 루프 길이 8 → 시청(0) ↔ 동대문역사문화공원(4): forward=4, backward=4 → null
+    expect(inferLoopDirection('2', '시청', '동대문역사문화공원')).toBeNull();
+  });
+
+  it('동일 역이면 null', () => {
+    expect(inferLoopDirection('2', '시청', '시청')).toBeNull();
+  });
+
+  it('from이 지선(까치산)이면 메인 루프 인덱스 매칭 실패 → null', () => {
+    expect(inferLoopDirection('2', '까치산', '시청')).toBeNull();
+  });
+
+  it('to가 지선이면 null', () => {
+    expect(inferLoopDirection('2', '시청', '까치산')).toBeNull();
+  });
+
+  it('역명에 별칭 괄호가 붙어도 normalize로 매칭', () => {
+    // 시청(0) → 을지로3가(별칭)(2): forward=2, backward=6 → down
+    expect(inferLoopDirection('2', '시청', '을지로3가(별칭)')).toBe('down');
+  });
+
+  it('정확 매칭이 normalize 매칭보다 우선', () => {
+    // 시청(0) → 을지로입구(1): forward=1, backward=7 → down (정확 매칭 경로 검증)
+    expect(inferLoopDirection('2', '시청', '을지로입구')).toBe('down');
+  });
+});
+
+describe('inferLoopDirection — empty/small loop guards', () => {
+  // line '6'은 빈 배열을 반환하지만 LOOP_LINES에 포함돼있지 않아 stations.length === 0 분기에
+  // 도달하지 않는다. 해당 가드 + 'loop.length < 2' 가드를 명시적으로 커버하기 위해
+  // 임시로 mock을 재설정해 line '2'를 빈 배열 / 단일 항목으로 만든다.
+  const stationRoute = jest.requireMock('../../../../shared/utils/stationRoute') as {
+    getStationsOnLine: (line: string) => Array<{ id: string; name: string; line: string }>;
+  };
+  const original = stationRoute.getStationsOnLine;
+
+  afterEach(() => {
+    stationRoute.getStationsOnLine = original;
+  });
+
+  it('순환선이지만 stations 빈 배열이면 null', () => {
+    stationRoute.getStationsOnLine = (line: string) => (line === '2' ? [] : []);
+    expect(inferLoopDirection('2', '시청', '왕십리')).toBeNull();
+  });
+
+  it('메인 루프 station이 1개 이하면 null', () => {
+    stationRoute.getStationsOnLine = (line: string) =>
+      line === '2' ? [{ id: '2-001', name: '시청', line: '2' }] : [];
+    expect(inferLoopDirection('2', '시청', '왕십리')).toBeNull();
+  });
+});
+
+describe('parseTrainLineDirection', () => {
+  it('"내선순환" → up', () => {
+    expect(parseTrainLineDirection('내선순환')).toBe('up');
+  });
+
+  it('"외선순환" → down', () => {
+    expect(parseTrainLineDirection('외선순환')).toBe('down');
+  });
+
+  it('내선순환 부분 문자열도 인식', () => {
+    expect(parseTrainLineDirection('2호선 내선순환 열차')).toBe('up');
+  });
+
+  it('역명행 패턴은 null (이 util 범위 외)', () => {
+    expect(parseTrainLineDirection('성수행')).toBeNull();
+  });
+
+  it('빈 문자열은 null', () => {
+    expect(parseTrainLineDirection('')).toBeNull();
+  });
+});

--- a/src/features/route/utils/__tests__/loopDirection.test.ts
+++ b/src/features/route/utils/__tests__/loopDirection.test.ts
@@ -30,53 +30,25 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
 }));
 
 describe('inferLoopDirection', () => {
-  it('순환선 외(monotonic) 노선은 null', () => {
-    expect(inferLoopDirection('3', '대화', '주엽')).toBeNull();
-  });
+  // 케이스: [설명, line, from, to, 기대값]
+  // - LOOP_LINES(2호선) 외 / 동일 역 / 정반대 위치 / 지선 매칭 실패 → null
+  // - id 증가 방향이 짧으면 'down' (외선순환), wrap 방향이 짧으면 'up' (내선순환)
+  // - normalize는 정확 매칭 다음 fallback
+  const cases: Array<[string, '2' | '3', string, string, 'up' | 'down' | null]> = [
+    ['순환선 외(monotonic) 노선은 null', '3', '대화', '주엽', null],
+    ['LOOP_LINES 미포함 노선은 동일 역도 null', '3', '대화', '대화', null],
+    ['시청(0) → 을지로4가(3): forward=3, backward=5 → down', '2', '시청', '을지로4가', 'down'],
+    ['시청(0) → 왕십리(7): forward=7, backward=1 → up', '2', '시청', '왕십리', 'up'],
+    ['시청(0) ↔ 동대문역사문화공원(4): 정반대 → null', '2', '시청', '동대문역사문화공원', null],
+    ['동일 역이면 null', '2', '시청', '시청', null],
+    ['from이 지선(까치산) → null', '2', '까치산', '시청', null],
+    ['to가 지선(까치산) → null', '2', '시청', '까치산', null],
+    ['시청(0) → 을지로3가(별칭)(2): normalize 매칭 → down', '2', '시청', '을지로3가(별칭)', 'down'],
+    ['시청(0) → 을지로입구(1): 정확 매칭 우선 → down', '2', '시청', '을지로입구', 'down'],
+  ];
 
-  it('2호선이지만 stations 빈 경우는 null', () => {
-    // line '6'을 빈 배열로 mock — 동일 분기 검증 위해 line '2'에 대해 빈 배열 시나리오를
-    // 별도로 만들 수 없으므로 LOOP_LINES 분기 후 stations.length === 0 가드를 보장하기 위해
-    // 임시로 mock을 덮어쓰지 않고, 빈 루프 가드는 다음 케이스(필터 결과 < 2)에서 함께 검증한다.
-    // 여기서는 monotonic skip만 우선 확인.
-    expect(inferLoopDirection('3', '대화', '대화')).toBeNull();
-  });
-
-  it('id 증가 방향이 짧으면 외선순환(down)', () => {
-    // 시청(0) → 을지로4가(3): forward=3, backward=5 → down
-    expect(inferLoopDirection('2', '시청', '을지로4가')).toBe('down');
-  });
-
-  it('id 감소(wrap) 방향이 짧으면 내선순환(up)', () => {
-    // 시청(0) → 왕십리(7): forward=7, backward=1 → up
-    expect(inferLoopDirection('2', '시청', '왕십리')).toBe('up');
-  });
-
-  it('정반대 위치(두 호 동일 길이)는 null', () => {
-    // 루프 길이 8 → 시청(0) ↔ 동대문역사문화공원(4): forward=4, backward=4 → null
-    expect(inferLoopDirection('2', '시청', '동대문역사문화공원')).toBeNull();
-  });
-
-  it('동일 역이면 null', () => {
-    expect(inferLoopDirection('2', '시청', '시청')).toBeNull();
-  });
-
-  it('from이 지선(까치산)이면 메인 루프 인덱스 매칭 실패 → null', () => {
-    expect(inferLoopDirection('2', '까치산', '시청')).toBeNull();
-  });
-
-  it('to가 지선이면 null', () => {
-    expect(inferLoopDirection('2', '시청', '까치산')).toBeNull();
-  });
-
-  it('역명에 별칭 괄호가 붙어도 normalize로 매칭', () => {
-    // 시청(0) → 을지로3가(별칭)(2): forward=2, backward=6 → down
-    expect(inferLoopDirection('2', '시청', '을지로3가(별칭)')).toBe('down');
-  });
-
-  it('정확 매칭이 normalize 매칭보다 우선', () => {
-    // 시청(0) → 을지로입구(1): forward=1, backward=7 → down (정확 매칭 경로 검증)
-    expect(inferLoopDirection('2', '시청', '을지로입구')).toBe('down');
+  it.each(cases)('%s', (_desc, line, from, to, expected) => {
+    expect(inferLoopDirection(line, from, to)).toBe(expected);
   });
 });
 

--- a/src/features/route/utils/__tests__/loopDirection.test.ts
+++ b/src/features/route/utils/__tests__/loopDirection.test.ts
@@ -94,7 +94,7 @@ describe('inferLoopDirection — empty/small loop guards', () => {
   });
 
   it('순환선이지만 stations 빈 배열이면 null', () => {
-    stationRoute.getStationsOnLine = (line: string) => (line === '2' ? [] : []);
+    stationRoute.getStationsOnLine = () => [];
     expect(inferLoopDirection('2', '시청', '왕십리')).toBeNull();
   });
 

--- a/src/features/route/utils/loopDirection.ts
+++ b/src/features/route/utils/loopDirection.ts
@@ -1,0 +1,75 @@
+import type { LineNumber } from '../../../shared/types/station';
+import type { TravelDirection } from '../../../shared/types/exitSide';
+import { getStationsOnLine, normalizeStationName } from '../../../shared/utils/stationRoute';
+
+// 비단조 노선(현재 2호선 순환선만) 방향 추론.
+// monotonic 화이트리스트(`travelDirection.ts`)에 들어가지 못하는 노선을 보완한다.
+//
+// 2호선 순환선:
+//   - 메인 루프(시청 ~ 충정로, stations.json id 2-001 ~ 2-043, 43개)는 순환선.
+//   - 까치산(2-105) / 신설동(2-205)은 지선으로 본 추론 대상 외 → null.
+//   - 진행 방향 결정: from → to까지 id 증가 방향으로 가는 호(arc)와
+//     반대 방향(루프 wrap) 호 중 짧은 쪽을 선택.
+//   - 증가 방향이 더 짧으면 외선순환 = 'down' (low→high 컨벤션 정렬)
+//   - 감소 방향(wrap)이 더 짧으면 내선순환 = 'up'
+//   - 두 호가 정확히 같은 길이(정반대 위치)면 ambiguous → null.
+//
+// 이 util은 호출부에 직접 wiring 되지 않는다(후속 PR). monotonic util과 분리 유지.
+
+const LOOP_LINES = new Set<LineNumber>(['2']);
+
+// 2호선 메인 루프 station id prefix. 지선(2-105, 2-205)을 배제.
+const LINE2_LOOP_PREFIX = '2-0';
+
+/**
+ * 2호선 순환선의 from → to 방향을 추론한다.
+ * - 'up'   = 내선순환 (id 감소 방향이 더 짧음)
+ * - 'down' = 외선순환 (id 증가 방향이 더 짧음)
+ * - null   = 추론 불가 (지선 포함, 동일 역, 정반대 위치 등)
+ */
+export function inferLoopDirection(
+  line: LineNumber,
+  fromName: string,
+  toName: string,
+): TravelDirection | null {
+  if (!LOOP_LINES.has(line)) return null;
+  const stations = getStationsOnLine(line);
+  if (stations.length === 0) return null;
+
+  // 메인 루프만 추출(지선 제외). id 오름차순 정렬은 stations.json 기준 유지.
+  const loop = stations.filter((s) => s.id.startsWith(LINE2_LOOP_PREFIX));
+  if (loop.length < 2) return null;
+
+  const fromIdx = indexOf(loop, fromName);
+  const toIdx = indexOf(loop, toName);
+  if (fromIdx === -1 || toIdx === -1) return null;
+  if (fromIdx === toIdx) return null;
+
+  const n = loop.length;
+  const forward = (toIdx - fromIdx + n) % n; // id 증가 방향 호 길이
+  const backward = n - forward; // wrap 방향 호 길이
+
+  if (forward === backward) return null; // 정반대 위치 — ambiguous
+  return forward < backward ? 'down' : 'up';
+}
+
+/**
+ * Seoul OpenAPI `trainLineNm` 텍스트에서 순환선 방향 토큰을 파싱한다.
+ * - "내선순환" → 'up'
+ * - "외선순환" → 'down'
+ * - 그 외 → null
+ *
+ * 후속에서 inferLoopDirection의 fallback/검증용으로 활용.
+ */
+export function parseTrainLineDirection(trainLineNm: string): TravelDirection | null {
+  if (trainLineNm.includes('내선순환')) return 'up';
+  if (trainLineNm.includes('외선순환')) return 'down';
+  return null;
+}
+
+function indexOf(stations: ReadonlyArray<{ name: string }>, name: string): number {
+  const exact = stations.findIndex((s) => s.name === name);
+  if (exact !== -1) return exact;
+  const normalized = normalizeStationName(name);
+  return stations.findIndex((s) => normalizeStationName(s.name) === normalized);
+}


### PR DESCRIPTION
## Summary
- `resolveTravelDirection`이 커버하지 못하는 비단조 노선(2호선 순환선) 방향 추론 util 추가
- `inferLoopDirection(line, from, to)` — 짧은 호(arc) 기준 내선(up) / 외선(down) / null
- `parseTrainLineDirection(trainLineNm)` — Seoul OpenAPI 텍스트에서 "내선순환"/"외선순환" 토큰 파싱

## 설계
- 2호선 메인 루프(id `2-0xx` 43역)만 대상. 지선(까치산 2-105, 신설동 2-205)은 null.
- forward = (toIdx - fromIdx + N) % N, backward = N - forward.
- forward < backward → 외선순환(down), forward > backward → 내선순환(up), 동일 → null(정반대).
- 신분당선/공항철도는 이미 monotonic → 별도 처리 불필요.
- 1/5/6/경의중앙선은 분기 구조라 본 PR 범위 외 (후속).

## 비범위
- **호출부 wiring 없음** — util + 테스트만. 동시 진행 중인 alarm/transfer 관련 PR과 충돌 회피를 위해 호출부 통합은 별도 PR에서.
- `lineTopology.json` 미변경. `travelDirection.ts` 미변경.

## Test plan
- [x] `npx jest loopDirection` — 17 cases pass, 100% lines/funcs/branches/stmts
- [x] `npm test` — 4195 tests pass, 전체 커버리지 임계 통과
- [x] `npm run type-check` clean
- [x] ESLint clean

Closes #1046