### PR TITLE
feat(#1045): openAppSettings util + LocationStateView 설정 열기 버튼

### DIFF
--- a/src/shared/ui/LocationStateView.tsx
+++ b/src/shared/ui/LocationStateView.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../theme';
+import { openAppSettings } from '../utils/openAppSettings';
 
 interface LocationStateViewProps {
   permissionDenied: boolean;
@@ -22,6 +23,13 @@ export function LocationStateView({ permissionDenied, loading, error, onRetry }:
           <Text style={[styles.message, { color: colors.muted }]}>{t('permissions.locationRequiredShort')}</Text>
           <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={onRetry} testID="location-retry-button">
             <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('permissions.request')}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.secondaryButton, { borderColor: colors.accent }]}
+            onPress={openAppSettings}
+            testID="location-open-settings-button"
+          >
+            <Text style={[styles.buttonText, { color: colors.accent }]}>{t('permissions.openSettings')}</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -73,6 +81,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingVertical: 12,
     borderRadius: 8,
+  },
+  secondaryButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    marginTop: 12,
   },
   buttonText: {
     fontSize: 16,

--- a/src/shared/ui/__tests__/LocationStateView.test.tsx
+++ b/src/shared/ui/__tests__/LocationStateView.test.tsx
@@ -32,39 +32,30 @@ describe('LocationStateView', () => {
   });
 
   describe('permissionDenied 상태', () => {
-    it('권한 거부 메시지를 표시한다', () => {
+    beforeEach(() => {
       renderWithTheme(
         <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={onRetry} />,
       );
+    });
+
+    it('권한 거부 메시지를 표시한다', () => {
       expect(screen.getByText('위치 권한이 필요합니다.')).toBeTruthy();
     });
 
     it('권한 요청 버튼을 표시한다', () => {
-      renderWithTheme(
-        <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={onRetry} />,
-      );
       expect(screen.getByText('권한 요청')).toBeTruthy();
     });
 
     it('권한 요청 버튼 클릭 시 onRetry를 호출한다', () => {
-      renderWithTheme(
-        <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={onRetry} />,
-      );
       fireEvent.press(screen.getByTestId('location-retry-button'));
       expect(onRetry).toHaveBeenCalledTimes(1);
     });
 
     it('"설정 열기" 버튼을 표시한다', () => {
-      renderWithTheme(
-        <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={onRetry} />,
-      );
       expect(screen.getByText('설정 열기')).toBeTruthy();
     });
 
     it('"설정 열기" 버튼 클릭 시 openAppSettings를 호출한다', () => {
-      renderWithTheme(
-        <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={onRetry} />,
-      );
       fireEvent.press(screen.getByTestId('location-open-settings-button'));
       expect(openAppSettings).toHaveBeenCalledTimes(1);
     });

--- a/src/shared/ui/__tests__/LocationStateView.test.tsx
+++ b/src/shared/ui/__tests__/LocationStateView.test.tsx
@@ -3,6 +3,11 @@ import { screen, fireEvent } from '@testing-library/react-native';
 import * as RN from 'react-native';
 import { LocationStateView } from '../LocationStateView';
 import { renderWithTheme } from '../../../testUtils/renderWithTheme';
+import { openAppSettings } from '../../utils/openAppSettings';
+
+jest.mock('../../utils/openAppSettings', () => ({
+  openAppSettings: jest.fn(),
+}));
 
 const mockUseColorScheme = jest.spyOn(RN, 'useColorScheme');
 
@@ -12,6 +17,7 @@ describe('LocationStateView', () => {
   beforeEach(() => {
     mockUseColorScheme.mockReturnValue('light');
     onRetry.mockReset();
+    (openAppSettings as jest.Mock).mockReset();
   });
 
   afterEach(() => {
@@ -46,6 +52,21 @@ describe('LocationStateView', () => {
       );
       fireEvent.press(screen.getByTestId('location-retry-button'));
       expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('"설정 열기" 버튼을 표시한다', () => {
+      renderWithTheme(
+        <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={onRetry} />,
+      );
+      expect(screen.getByText('설정 열기')).toBeTruthy();
+    });
+
+    it('"설정 열기" 버튼 클릭 시 openAppSettings를 호출한다', () => {
+      renderWithTheme(
+        <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={onRetry} />,
+      );
+      fireEvent.press(screen.getByTestId('location-open-settings-button'));
+      expect(openAppSettings).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/shared/utils/__tests__/openAppSettings.test.ts
+++ b/src/shared/utils/__tests__/openAppSettings.test.ts
@@ -1,0 +1,30 @@
+import { Linking } from 'react-native';
+import { openAppSettings } from '../openAppSettings';
+
+describe('openAppSettings', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Linking.openSettings를 호출한다', async () => {
+    const spy = jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined);
+
+    await openAppSettings();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Linking.openSettings가 reject되어도 throw하지 않고 warn 로그를 남긴다', async () => {
+    const failure = new Error('settings unavailable');
+    jest.spyOn(Linking, 'openSettings').mockRejectedValue(failure);
+
+    await expect(openAppSettings()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith('[OpenAppSettings]', 'openSettings failed', failure);
+  });
+});

--- a/src/shared/utils/openAppSettings.ts
+++ b/src/shared/utils/openAppSettings.ts
@@ -1,0 +1,16 @@
+import { Linking } from 'react-native';
+import { createLogger } from './logger';
+
+const logger = createLogger('OpenAppSettings');
+
+/**
+ * OS 설정 앱을 연다. 권한 거부 후 사용자가 다시 권한을 켤 수 있도록 안내하는 진입점.
+ * Linking.openSettings()가 실패해도 호출자에게 throw하지 않고 로그만 남긴다.
+ */
+export async function openAppSettings(): Promise<void> {
+  try {
+    await Linking.openSettings();
+  } catch (error) {
+    logger.warn('openSettings failed', error);
+  }
+}


### PR DESCRIPTION
## Summary
- `src/shared/utils/openAppSettings.ts` 신규: `Linking.openSettings()` 래퍼 + 실패 시 createLogger.warn (호출자에 throw 안 함)
- `LocationStateView` permissionDenied 분기에 "설정 열기" 보조 버튼 추가 (기존 "권한 요청" 버튼 유지). 거부 후 OS 다이얼로그가 다시 뜨지 않는 막다른 길 해소
- 기존 i18n 키 `permissions.openSettings` (4개 로케일 모두 존재) 재사용 — 신규 키 추가 없음

## Background
`docs/requirements/01-onboarding.md`에서 ⚠️ 미구현으로 표시된 "권한 거부 시 설정 앱 열기 버튼 일관 노출" 항목.

## Test plan
- [x] `npm test` 4182 passed, 100% coverage (openAppSettings.ts 100%, LocationStateView.tsx 100%)
- [x] `npm run type-check` clean
- [x] 실기기: 위치 권한 거부 → 홈 화면에서 LocationStateView 두 버튼 노출 확인 → "설정 열기" 탭 시 iOS/Android 설정 앱 진입 확인

## Non-goals (follow-up)
- `useBackgroundLocation.ts` Alert 내 인라인 `Linking.openSettings()`를 신규 util로 일원화 (별도 PR)
- HomeScreen/MapScreen/SettingsScreen 등 다른 permission-blocked 진입점 통일 (별도 PR)

Closes #1045