### PR TITLE
feat(#1044): Live Activity push token 복구 강건성 — 세션 유지 + dedup

### DIFF
--- a/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
@@ -20,6 +20,7 @@ jest.mock('../../api/alarmBackend', () => ({
 }));
 
 import {
+  __resetLiveActivityPushChannelForTests,
   endLiveActivityWithDeregister,
   startLiveActivityWithRegistration,
 } from '../liveActivityPushChannel';
@@ -62,10 +63,12 @@ describe('liveActivityPushChannel', () => {
     mockEndLiveActivity.mockResolvedValue(undefined);
     mockRegisterLiveActivityToken.mockResolvedValue({ ok: true });
     mockClearLiveActivityToken.mockResolvedValue({ ok: true });
+    __resetLiveActivityPushChannelForTests();
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    __resetLiveActivityPushChannelForTests();
   });
 
   describe('startLiveActivityWithRegistration', () => {
@@ -75,18 +78,38 @@ describe('liveActivityPushChannel', () => {
       expect(mockStartLiveActivity).toHaveBeenCalledWith(SAMPLE_DATA);
       handle.emit('aabbcc');
       expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-1', 'aabbcc');
-      expect(handle.remove).toHaveBeenCalledTimes(1);
     });
 
-    it('5s timeout 안에 token이 안 오면 subscription 정리 + register 미호출', async () => {
+    it('subscription은 첫 token 이후에도 유지 — 새 token 회전 시 재등록', async () => {
+      const handle = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok-a');
+      handle.emit('tok-b');
+      expect(mockRegisterLiveActivityToken).toHaveBeenNthCalledWith(1, 'trip-1', 'tok-a');
+      expect(mockRegisterLiveActivityToken).toHaveBeenNthCalledWith(2, 'trip-1', 'tok-b');
+      expect(handle.remove).not.toHaveBeenCalled();
+    });
+
+    it('동일 token 재emit은 dedup — backend 재호출 없음', async () => {
+      const handle = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok-a');
+      handle.emit('tok-a');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('5s timeout 안에 token이 안 와도 subscription은 유지 (로그만)', async () => {
       const handle = setupListener();
       await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
       jest.advanceTimersByTime(5000);
-      expect(handle.remove).toHaveBeenCalledTimes(1);
+      expect(handle.remove).not.toHaveBeenCalled();
       expect(mockRegisterLiveActivityToken).not.toHaveBeenCalled();
+      // 늦게라도 token이 오면 그제서야 register
+      handle.emit('late');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-1', 'late');
     });
 
-    it('token 도착 후 timer는 clearTimeout으로 cancel — 추가 register 없음', async () => {
+    it('token 도착 후 timer는 정리 — 이후 advanceTimers 영향 없음', async () => {
       const handle = setupListener();
       await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
       handle.emit('tok');
@@ -99,7 +122,6 @@ describe('liveActivityPushChannel', () => {
       mockRegisterLiveActivityToken.mockRejectedValue(new Error('net'));
       await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
       handle.emit('tok');
-      // promise rejection이 unhandled 되지 않도록 microtask 비움
       await Promise.resolve();
     });
 
@@ -111,13 +133,63 @@ describe('liveActivityPushChannel', () => {
       ).rejects.toThrow('LA disabled');
       expect(handle.remove).toHaveBeenCalledTimes(1);
     });
+
+    it('start가 await 중 다른 호출이 activeTeardown을 교체했고, 이후 throw 시 새 세션을 건드리지 않음', async () => {
+      // 첫 start가 await에 걸려 있는 동안 두 번째 start가 들어오는 시나리오.
+      let resolveFirst!: () => void;
+      let rejectFirst!: (e: Error) => void;
+      mockStartLiveActivity.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve, reject) => {
+            resolveFirst = resolve;
+            rejectFirst = reject;
+          }),
+      );
+      mockStartLiveActivity.mockResolvedValueOnce(undefined);
+
+      const first = setupListener();
+      const firstPromise = startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      // 두 번째 호출 — 기존 teardown을 교체
+      const second = setupListener();
+      await startLiveActivityWithRegistration('trip-2', SAMPLE_DATA);
+      expect(first.remove).toHaveBeenCalledTimes(1);
+
+      // 이제 첫 호출의 start가 throw — 두 번째 세션을 건드리지 않아야 한다
+      rejectFirst(new Error('first failed'));
+      void resolveFirst; // unused but captured for symmetry
+      await expect(firstPromise).rejects.toThrow('first failed');
+
+      // 두 번째 세션은 여전히 살아 있어야 함
+      second.emit('tok-2');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-2', 'tok-2');
+      expect(second.remove).not.toHaveBeenCalled();
+    });
+
+    it('이전 세션이 살아 있는 상태로 재호출하면 이전 subscription 정리', async () => {
+      const first = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      const second = setupListener();
+      await startLiveActivityWithRegistration('trip-2', SAMPLE_DATA);
+      expect(first.remove).toHaveBeenCalledTimes(1);
+      second.emit('tok');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-2', 'tok');
+    });
   });
 
   describe('endLiveActivityWithDeregister', () => {
-    it('end 호출 + backend DELETE', async () => {
+    it('end 호출 + backend DELETE + 활성 subscription 정리', async () => {
+      const handle = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
       await endLiveActivityWithDeregister('trip-1');
       expect(mockEndLiveActivity).toHaveBeenCalled();
       expect(mockClearLiveActivityToken).toHaveBeenCalledWith('trip-1');
+      expect(handle.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it('활성 세션이 없을 때도 end + clear 호출', async () => {
+      await endLiveActivityWithDeregister('trip-x');
+      expect(mockEndLiveActivity).toHaveBeenCalled();
+      expect(mockClearLiveActivityToken).toHaveBeenCalledWith('trip-x');
     });
 
     it('end가 throw해도 backend deregister는 시도', async () => {
@@ -132,6 +204,19 @@ describe('liveActivityPushChannel', () => {
       mockClearLiveActivityToken.mockRejectedValue(new Error('net'));
       await endLiveActivityWithDeregister('trip-1');
       expect(mockEndLiveActivity).toHaveBeenCalled();
+    });
+  });
+
+  describe('__resetLiveActivityPushChannelForTests', () => {
+    it('활성 세션 정리', async () => {
+      const handle = setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      __resetLiveActivityPushChannelForTests();
+      expect(handle.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it('활성 세션이 없을 때도 안전하게 no-op', () => {
+      expect(() => __resetLiveActivityPushChannelForTests()).not.toThrow();
     });
   });
 });

--- a/src/features/alarm/utils/liveActivityPushChannel.ts
+++ b/src/features/alarm/utils/liveActivityPushChannel.ts
@@ -1,14 +1,18 @@
 /**
- * Live Activity push channel (#586 B).
+ * Live Activity push channel (#586 B, #1044).
  *
  * native가 발급한 push token을 backend에 등록/해제하는 얇은 wrapper.
- * - `startLiveActivityWithRegistration`: Activity 시작 + 1회성 token 구독 → backend POST
- * - `endLiveActivityWithDeregister`: Activity 종료 + backend DELETE
+ * - `startLiveActivityWithRegistration`: Activity 시작 + token 구독 → backend POST
+ * - `endLiveActivityWithDeregister`: Activity 종료 + backend DELETE + subscription teardown
  *
  * 정책
- * - token emit이 비동기다. 5초 timeout 안에 안 오면 subscription 정리 후 silent skip.
- *   (LA 자체는 정상 동작한다 — backend가 못 push할 뿐.)
- * - 네트워크 실패는 silent log. 재시도하지 않는다 (다음 update 사이클이 자동 보정).
+ * - native는 `Activity.pushTokenUpdates` 시퀀스로 LA 세션 동안 여러 번 token을
+ *   emit할 수 있다 (APNs rotation 등). 따라서 subscription은 세션 동안 살려두고
+ *   매 emit마다 backend에 재등록한다 (#1044).
+ * - 동일 token 재emit은 dedup → 불필요한 POST 차단.
+ * - 첫 token이 5초 안에 안 오면 로그만 남기고 subscription은 그대로 둔다 — 늦게라도
+ *   token이 오면 backend에 반영해야 한다.
+ * - 네트워크 실패는 silent log. 재시도는 다음 token emit / 다음 LA 사이클에 의존.
  */
 
 import {
@@ -26,39 +30,69 @@ import { createLogger } from '../../../shared/utils/logger';
 
 const log = createLogger('liveActivityPushChannel');
 
-/** token이 안 오면 subscription을 정리할 안전 timeout. */
-const PUSH_TOKEN_TIMEOUT_MS = 5000;
+/** 첫 token이 안 올 때 로그만 남기는 안전 timeout. subscription은 끊지 않는다. */
+const PUSH_TOKEN_FIRST_EMIT_TIMEOUT_MS = 5000;
+
+/** 현재 LA 세션의 teardown 함수. 단일 LA만 동시 운영한다는 전제. */
+let activeTeardown: (() => void) | null = null;
 
 /**
- * Activity 시작과 동시에 token emit을 1회 기다려 backend에 register.
+ * Activity 시작과 동시에 token 구독을 LA 세션 동안 유지.
+ * 매 token emit마다 backend register. 동일 token은 dedup.
  * Activity 시작 자체가 실패하면 throw — 호출 측의 기존 fallback(예: 일반 알림) 흐름을 유지.
  */
 export async function startLiveActivityWithRegistration(
   tripToken: string,
   data: LiveActivityData,
 ): Promise<void> {
-  let subscription!: { remove: () => void };
-  let timer!: ReturnType<typeof setTimeout>;
-  const cleanup = (): void => {
-    subscription.remove();
-    clearTimeout(timer);
-  };
-  subscription = addPushTokenListener((event: PushTokenEvent) => {
-    cleanup();
+  // 이전 세션이 살아 있으면 정리 — LA는 동시에 하나만.
+  if (activeTeardown) {
+    activeTeardown();
+    activeTeardown = null;
+  }
+
+  let lastToken: string | null = null;
+  let firstEmitTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const subscription = addPushTokenListener((event: PushTokenEvent) => {
+    if (firstEmitTimer) {
+      clearTimeout(firstEmitTimer);
+      firstEmitTimer = null;
+    }
+    if (event.token === lastToken) {
+      // 같은 token 재emit — backend 상태 그대로 유지.
+      return;
+    }
+    lastToken = event.token;
     void registerLiveActivityToken(tripToken, event.token).catch((e) => {
       log.warn('LA register threw', e);
     });
   });
-  timer = setTimeout(() => {
-    cleanup();
-    log.info('push token timeout — backend register skipped');
-  }, PUSH_TOKEN_TIMEOUT_MS);
+
+  firstEmitTimer = setTimeout(() => {
+    // emit이 들어오면 위에서 firstEmitTimer를 clear하므로 이 콜백은 항상 lastToken === null.
+    firstEmitTimer = null;
+    log.info('push token first-emit timeout — subscription kept');
+  }, PUSH_TOKEN_FIRST_EMIT_TIMEOUT_MS);
+
+  const teardown = (): void => {
+    subscription.remove();
+    if (firstEmitTimer) {
+      clearTimeout(firstEmitTimer);
+      firstEmitTimer = null;
+    }
+  };
+  activeTeardown = teardown;
 
   try {
     await startLiveActivity(data);
   } catch (e) {
     // start가 실패하면 token은 발급될 일이 없다 — 정리 후 re-throw.
-    cleanup();
+    // 다른 호출이 await 사이에 activeTeardown을 교체했을 수 있으므로 우리 teardown만 정리한다.
+    teardown();
+    if (activeTeardown === teardown) {
+      activeTeardown = null;
+    }
     throw e;
   }
 }
@@ -66,15 +100,31 @@ export async function startLiveActivityWithRegistration(
 /**
  * Activity 종료 + backend deregister.
  * 종료 자체가 실패해도 backend deregister는 시도 — 양쪽 상태를 가능한 한 동기화.
+ * LA push subscription도 함께 정리.
  */
 export async function endLiveActivityWithDeregister(
   tripToken: string,
 ): Promise<void> {
+  if (activeTeardown) {
+    activeTeardown();
+    activeTeardown = null;
+  }
   try {
     await endLiveActivity();
   } finally {
     await clearLiveActivityToken(tripToken).catch((e) => {
       log.warn('LA deregister threw', e);
     });
+  }
+}
+
+/**
+ * 테스트 전용: 모듈 내 활성 세션을 초기화.
+ * 프로덕션 호출 금지.
+ */
+export function __resetLiveActivityPushChannelForTests(): void {
+  if (activeTeardown) {
+    activeTeardown();
+    activeTeardown = null;
   }
 }


### PR DESCRIPTION
## Summary
- `liveActivityPushChannel`이 첫 push token 1회만 받고 listener를 끊던 동작을 LA 세션 동안 유지하도록 변경.
- 동일 token 재emit은 dedup, 새 token(예: APNs rotation)은 backend에 재등록.
- 5초 first-emit timeout은 subscription을 끊지 않고 로그만 남김 — 늦게 오는 token도 반영.
- `endLiveActivityWithDeregister`가 활성 subscription도 함께 정리.

## Gap (왜)
native `LiveActivityManager.swift`는 이미 `Activity.pushTokenUpdates` 시퀀스로 세션 동안 여러 번 token을 emit한다. 그러나 JS 채널은 첫 token만 받고 unsubscribe → 회전된 token이 backend에 반영되지 않아 silent push가 무응답이 될 수 있는 비대칭.

## Test plan
- [x] `npx jest src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts` — 15/15 통과, 단일 파일 라인/브랜치/함수 100%
- [x] `npm run type-check` — clean
- [x] 전체 `npm test` — 4184/4185 통과 (1건은 `DebugModal.test.tsx` 무관한 기존 flake, 단독 실행 시 통과)
- [x] 실기기: LA 시작 후 token rotation 강제 (앱 재설치/iOS 재시동) 시 backend에 새 token 등록 확인

Closes #1044