### PR TITLE
feat(#1047): 운행 시간 외 안내 util — getServiceWindow

### DIFF
--- a/src/features/route/utils/__tests__/serviceWindow.test.ts
+++ b/src/features/route/utils/__tests__/serviceWindow.test.ts
@@ -1,0 +1,230 @@
+import { getServiceWindow } from '../serviceWindow';
+
+describe('getServiceWindow', () => {
+  // KST 시간대 명시. UTC+9 — KST 정오는 UTC 03:00.
+  const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z'); // 화요일 12:00 KST
+  const KST_SATURDAY_NOON = new Date('2026-06-13T03:00:00.000Z'); // 토요일 12:00 KST
+  const KST_SUNDAY_NOON = new Date('2026-06-14T03:00:00.000Z'); // 일요일 12:00 KST
+
+  describe('status="in-service" 분기', () => {
+    it('평일 정오는 운행 중', () => {
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: KST_WEEKDAY_NOON,
+      });
+      expect(result.status).toBe('in-service');
+      expect(result.firstTrain).toMatch(/^\d{2}:\d{2}$/);
+      expect(result.lastTrain).toMatch(/^\d{2}:\d{2}$/);
+    });
+
+    it('토요일은 saturday timetable 사용', () => {
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: KST_SATURDAY_NOON,
+      });
+      expect(result.status).toBe('in-service');
+    });
+
+    it('일요일은 sunday timetable 사용', () => {
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: KST_SUNDAY_NOON,
+      });
+      expect(result.status).toBe('in-service');
+    });
+
+    it('dayType 명시 시 KST 자동 분류를 override', () => {
+      // 토요일 정오인데 dayType='weekday' 강제
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        dayType: 'weekday',
+        now: KST_SATURDAY_NOON,
+      });
+      expect(result.status).toBe('in-service');
+    });
+  });
+
+  describe('status="pre-first" 분기', () => {
+    it('overnight 없는 timetable에서 첫차 전은 pre-first (mock으로 검증)', () => {
+      // 모든 실제 1~9호선 역은 24h+ 운행을 가지므로 non-overnight 분기는 mock으로 검증.
+      jest.isolateModules(() => {
+        jest.doMock('../../../../data/timetables/line-1.json', () => ({
+          stations: {
+            테스트역: {
+              weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
+              saturday: { up: ['0600'], down: ['0610'] },
+              sunday: { up: ['0600'], down: ['0610'] },
+            },
+          },
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { getServiceWindow: build } = require('../serviceWindow');
+        // KST 04:00 = UTC 19:00 전날.
+        const earlyMorning = new Date('2026-06-08T19:00:00.000Z');
+        const result = build({ stationName: '테스트역', line: '1', now: earlyMorning });
+        expect(result.status).toBe('pre-first');
+        expect(result.firstTrain).toBe('06:00');
+        expect(result.lastTrain).toBe('23:00');
+      });
+      jest.resetModules();
+    });
+
+    it('overnight timetable에서 첫차 전(overnight tail 종료 후 ~ 다음 첫차 전)은 post-last로 분류', () => {
+      // 소요산: lastRaw=1476(00:36 익일), firstRaw=346(05:46).
+      // KST 03:00은 overnight tail(00:36) 이후, 첫차(05:46) 전 → post-last (어제 막차 종료).
+      const between = new Date('2026-06-08T18:00:00.000Z'); // 2026-06-09 03:00 KST
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: between,
+      });
+      expect(result.status).toBe('post-last');
+    });
+  });
+
+  describe('non-overnight timetable post-last 분기', () => {
+    it('lastRaw < 1440 timetable에서 막차 후는 post-last (mock으로 검증)', () => {
+      jest.isolateModules(() => {
+        jest.doMock('../../../../data/timetables/line-1.json', () => ({
+          stations: {
+            테스트역: {
+              weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
+              saturday: { up: ['0600'], down: ['0610'] },
+              sunday: { up: ['0600'], down: ['0610'] },
+            },
+          },
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { getServiceWindow: build } = require('../serviceWindow');
+        // KST 23:30 = UTC 14:30 → 23:00(last) 후.
+        const afterLast = new Date('2026-06-09T14:30:00.000Z');
+        const result = build({ stationName: '테스트역', line: '1', now: afterLast });
+        expect(result.status).toBe('post-last');
+      });
+      jest.resetModules();
+    });
+
+    it('lastRaw < 1440 timetable에서 윈도우 내는 in-service (mock으로 검증)', () => {
+      jest.isolateModules(() => {
+        jest.doMock('../../../../data/timetables/line-1.json', () => ({
+          stations: {
+            테스트역: {
+              weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
+              saturday: { up: ['0600'], down: ['0610'] },
+              sunday: { up: ['0600'], down: ['0610'] },
+            },
+          },
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { getServiceWindow: build } = require('../serviceWindow');
+        const noon = new Date('2026-06-09T03:00:00.000Z');
+        const result = build({ stationName: '테스트역', line: '1', now: noon });
+        expect(result.status).toBe('in-service');
+      });
+      jest.resetModules();
+    });
+  });
+
+  describe('status="post-last" 분기', () => {
+    it('막차 후(소요산 weekday up 마지막은 24:36, KST 02:00은 그 후)', () => {
+      // 소요산 weekday lastTrain은 down "2347" / up "2436" → 합치면 raw 1476 (다음날 00:36).
+      // KST 03:00은 (1476-1440)=36분보다 늦으므로 post-last (overnight tail 이후).
+      const afterLast = new Date('2026-06-09T18:00:00.000Z'); // KST 03:00 화요일 새벽
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: afterLast,
+      });
+      expect(result.status).toBe('post-last');
+    });
+  });
+
+  describe('status="unknown" 분기', () => {
+    it('timetable 없는 노선(공항철도)은 unknown', () => {
+      const result = getServiceWindow({
+        stationName: '서울역',
+        line: 'airport',
+        now: KST_WEEKDAY_NOON,
+      });
+      expect(result).toEqual({ firstTrain: null, lastTrain: null, status: 'unknown' });
+    });
+
+    it('timetable에 없는 역은 unknown', () => {
+      const result = getServiceWindow({
+        stationName: '존재하지않는역',
+        line: '1',
+        now: KST_WEEKDAY_NOON,
+      });
+      expect(result).toEqual({ firstTrain: null, lastTrain: null, status: 'unknown' });
+    });
+
+    it('모든 슬롯이 "0000"(NON_OPERATING)인 비정상 timetable은 unknown', () => {
+      // jest.isolateModules + doMock 으로 line-1.json을 일시 치환.
+      jest.isolateModules(() => {
+        jest.doMock('../../../../data/timetables/line-1.json', () => ({
+          stations: {
+            전부미운행: {
+              weekday: { up: ['0000', '0000'], down: ['0000'] },
+              saturday: { up: ['0000'], down: ['0000'] },
+              sunday: { up: ['0000'], down: ['0000'] },
+            },
+          },
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { getServiceWindow: build } = require('../serviceWindow');
+        const result = build({
+          stationName: '전부미운행',
+          line: '1',
+          now: KST_WEEKDAY_NOON,
+        });
+        expect(result).toEqual({ firstTrain: null, lastTrain: null, status: 'unknown' });
+      });
+      jest.resetModules();
+    });
+  });
+
+  describe('overnight overflow 처리', () => {
+    it('막차가 다음날 새벽(24h+)인 역의 overnight tail은 in-service', () => {
+      // 소요산 weekday up "2436" → 다음날 00:36 KST.
+      // KST 00:20 (2026-06-10 화요일 00:20 = 2026-06-09 15:20 UTC)은 아직 운행 중.
+      const overnightTail = new Date('2026-06-09T15:20:00.000Z');
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: overnightTail,
+      });
+      expect(result.status).toBe('in-service');
+    });
+
+    it('lastTrain 표시는 24h+ 표기를 "HH:mm"으로 정규화 (소요산 up 2436 → 00:36)', () => {
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: KST_WEEKDAY_NOON,
+      });
+      // 소요산 up 마지막 "2436"이 down 마지막 "2347"보다 늦으므로 lastTrain은 "00:36".
+      expect(result.lastTrain).toBe('00:36');
+    });
+
+    it('firstTrain은 up/down 합쳐 가장 빠른 실제 운행 entry (소요산 down 0546 vs up 0553 → 05:46)', () => {
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: KST_WEEKDAY_NOON,
+      });
+      expect(result.firstTrain).toBe('05:46');
+    });
+  });
+
+  describe('now 인자 미지정 시 현재 시각 사용', () => {
+    it('now 생략하면 new Date()로 fallback', () => {
+      const result = getServiceWindow({ stationName: '소요산', line: '1' });
+      // 결정성 없는 분기지만, 호출 자체가 throw하지 않고 4개 status 중 하나 반환하면 OK.
+      expect(['pre-first', 'in-service', 'post-last', 'unknown']).toContain(result.status);
+    });
+  });
+});

--- a/src/features/route/utils/__tests__/serviceWindow.test.ts
+++ b/src/features/route/utils/__tests__/serviceWindow.test.ts
@@ -1,5 +1,35 @@
 import { getServiceWindow } from '../serviceWindow';
 
+type ServiceWindowResult = ReturnType<typeof getServiceWindow>;
+
+// 테스트용 line-1.json mock + getServiceWindow 재로드를 한 헬퍼로 통합.
+// 동일한 isolateModules + doMock + require 시퀀스가 여러 it()에서 반복돼 Sonar 중복으로 검출됨.
+function withMockedLine1(
+  stations: Record<string, unknown>,
+  call: (
+    fn: (input: {
+      stationName: string;
+      line: string;
+      now?: Date;
+      dayType?: 'weekday' | 'saturday' | 'sunday';
+    }) => ServiceWindowResult,
+  ) => void,
+): void {
+  jest.isolateModules(() => {
+    jest.doMock('../../../../data/timetables/line-1.json', () => ({ stations }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getServiceWindow: build } = require('../serviceWindow');
+    call(build);
+  });
+  jest.resetModules();
+}
+
+const SIMPLE_TIMETABLE = {
+  weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
+  saturday: { up: ['0600'], down: ['0610'] },
+  sunday: { up: ['0600'], down: ['0610'] },
+};
+
 describe('getServiceWindow', () => {
   // KST 시간대 명시. UTC+9 — KST 정오는 UTC 03:00.
   const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z'); // 화요일 12:00 KST
@@ -51,18 +81,7 @@ describe('getServiceWindow', () => {
   describe('status="pre-first" 분기', () => {
     it('overnight 없는 timetable에서 첫차 전은 pre-first (mock으로 검증)', () => {
       // 모든 실제 1~9호선 역은 24h+ 운행을 가지므로 non-overnight 분기는 mock으로 검증.
-      jest.isolateModules(() => {
-        jest.doMock('../../../../data/timetables/line-1.json', () => ({
-          stations: {
-            테스트역: {
-              weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
-              saturday: { up: ['0600'], down: ['0610'] },
-              sunday: { up: ['0600'], down: ['0610'] },
-            },
-          },
-        }));
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const { getServiceWindow: build } = require('../serviceWindow');
+      withMockedLine1({ 테스트역: SIMPLE_TIMETABLE }, (build) => {
         // KST 04:00 = UTC 19:00 전날.
         const earlyMorning = new Date('2026-06-08T19:00:00.000Z');
         const result = build({ stationName: '테스트역', line: '1', now: earlyMorning });
@@ -70,7 +89,6 @@ describe('getServiceWindow', () => {
         expect(result.firstTrain).toBe('06:00');
         expect(result.lastTrain).toBe('23:00');
       });
-      jest.resetModules();
     });
 
     it('overnight timetable에서 첫차 전(overnight tail 종료 후 ~ 다음 첫차 전)은 post-last로 분류', () => {
@@ -88,44 +106,20 @@ describe('getServiceWindow', () => {
 
   describe('non-overnight timetable post-last 분기', () => {
     it('lastRaw < 1440 timetable에서 막차 후는 post-last (mock으로 검증)', () => {
-      jest.isolateModules(() => {
-        jest.doMock('../../../../data/timetables/line-1.json', () => ({
-          stations: {
-            테스트역: {
-              weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
-              saturday: { up: ['0600'], down: ['0610'] },
-              sunday: { up: ['0600'], down: ['0610'] },
-            },
-          },
-        }));
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const { getServiceWindow: build } = require('../serviceWindow');
+      withMockedLine1({ 테스트역: SIMPLE_TIMETABLE }, (build) => {
         // KST 23:30 = UTC 14:30 → 23:00(last) 후.
         const afterLast = new Date('2026-06-09T14:30:00.000Z');
         const result = build({ stationName: '테스트역', line: '1', now: afterLast });
         expect(result.status).toBe('post-last');
       });
-      jest.resetModules();
     });
 
     it('lastRaw < 1440 timetable에서 윈도우 내는 in-service (mock으로 검증)', () => {
-      jest.isolateModules(() => {
-        jest.doMock('../../../../data/timetables/line-1.json', () => ({
-          stations: {
-            테스트역: {
-              weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
-              saturday: { up: ['0600'], down: ['0610'] },
-              sunday: { up: ['0600'], down: ['0610'] },
-            },
-          },
-        }));
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const { getServiceWindow: build } = require('../serviceWindow');
+      withMockedLine1({ 테스트역: SIMPLE_TIMETABLE }, (build) => {
         const noon = new Date('2026-06-09T03:00:00.000Z');
         const result = build({ stationName: '테스트역', line: '1', now: noon });
         expect(result.status).toBe('in-service');
       });
-      jest.resetModules();
     });
   });
 
@@ -164,18 +158,12 @@ describe('getServiceWindow', () => {
 
     it('모든 슬롯이 "0000"(NON_OPERATING)인 비정상 timetable은 unknown', () => {
       // jest.isolateModules + doMock 으로 line-1.json을 일시 치환.
-      jest.isolateModules(() => {
-        jest.doMock('../../../../data/timetables/line-1.json', () => ({
-          stations: {
-            전부미운행: {
-              weekday: { up: ['0000', '0000'], down: ['0000'] },
-              saturday: { up: ['0000'], down: ['0000'] },
-              sunday: { up: ['0000'], down: ['0000'] },
-            },
-          },
-        }));
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const { getServiceWindow: build } = require('../serviceWindow');
+      const allZero = {
+        weekday: { up: ['0000', '0000'], down: ['0000'] },
+        saturday: { up: ['0000'], down: ['0000'] },
+        sunday: { up: ['0000'], down: ['0000'] },
+      };
+      withMockedLine1({ 전부미운행: allZero }, (build) => {
         const result = build({
           stationName: '전부미운행',
           line: '1',
@@ -183,7 +171,6 @@ describe('getServiceWindow', () => {
         });
         expect(result).toEqual({ firstTrain: null, lastTrain: null, status: 'unknown' });
       });
-      jest.resetModules();
     });
   });
 

--- a/src/features/route/utils/serviceWindow.ts
+++ b/src/features/route/utils/serviceWindow.ts
@@ -1,0 +1,192 @@
+import type { LineNumber } from '../../../shared/types/station';
+import line1Timetable from '../../../data/timetables/line-1.json';
+import line2Timetable from '../../../data/timetables/line-2.json';
+import line3Timetable from '../../../data/timetables/line-3.json';
+import line4Timetable from '../../../data/timetables/line-4.json';
+import line5Timetable from '../../../data/timetables/line-5.json';
+import line6Timetable from '../../../data/timetables/line-6.json';
+import line7Timetable from '../../../data/timetables/line-7.json';
+import line8Timetable from '../../../data/timetables/line-8.json';
+import line9Timetable from '../../../data/timetables/line-9.json';
+
+/**
+ * 운행 시간 외(첫차 전 / 막차 후) 안내용 util.
+ *
+ * - 1~9호선 정적 timetable JSON에서 (역, 요일)별 첫차/막차 시각을 읽어,
+ *   현재 시각이 운행 시간 내인지 판정한다.
+ * - timetable이 없는 노선(분당/신분당/경의중앙/공항)은 status='unknown'.
+ * - dayType은 KST 기준 weekday/saturday/sunday로 자동 분류
+ *   (#1043 lastTrainTime / scheduleFallback의 classifyDayType과 동일 관례).
+ * - timetable의 익일 새벽 운행 entry는 "2436" 같은 24h+ 표기를 사용하며,
+ *   본 util은 이를 firstTrain/lastTrain 표시 시 "00:36"으로 정규화하고,
+ *   상태 판정 시에는 raw 분(>=1440)을 그대로 사용해 overnight tail을 in-service로 본다.
+ *
+ * UI 미연결 — banner 등 consumer는 별도 PR에서 wiring한다.
+ *
+ * NOTE(follow-up): lastTrainTime.ts(#1043)와 timetable 로딩/HHMM 정규화/dayType 분류 로직이
+ * 겹친다. #1043 머지 후 공통 helper(예: src/features/.../utils/timetableShared.ts)로
+ * 추출 검토.
+ */
+
+export type DayType = 'weekday' | 'saturday' | 'sunday';
+export type ServiceStatus = 'pre-first' | 'in-service' | 'post-last' | 'unknown';
+
+export interface ServiceWindow {
+  firstTrain: string | null;
+  lastTrain: string | null;
+  status: ServiceStatus;
+}
+
+interface DayDirectionTimetable {
+  up: string[];
+  down: string[];
+}
+interface StationTimetable {
+  weekday: DayDirectionTimetable;
+  saturday: DayDirectionTimetable;
+  sunday: DayDirectionTimetable;
+}
+interface LineTimetable {
+  stations: Record<string, StationTimetable>;
+}
+
+const TIMETABLES: Partial<Record<LineNumber, LineTimetable>> = {
+  '1': line1Timetable,
+  '2': line2Timetable,
+  '3': line3Timetable,
+  '4': line4Timetable,
+  '5': line5Timetable,
+  '6': line6Timetable,
+  '7': line7Timetable,
+  '8': line8Timetable,
+  '9': line9Timetable,
+};
+
+const SUBWAY_TIMEZONE = 'Asia/Seoul';
+const HOURS_PER_DAY = 24;
+const MINUTES_PER_DAY = 1440;
+const MINUTES_PER_HOUR = 60;
+/** timetable JSON의 미운행 슬롯 표기 (앞쪽 padding). */
+const NON_OPERATING_SLOT = '0000';
+
+function classifyDayTypeKst(date: Date): DayType {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: SUBWAY_TIMEZONE,
+    weekday: 'short',
+  }).formatToParts(date);
+  const weekday = parts.find((p) => p.type === 'weekday')!.value;
+  if (weekday === 'Sun') return 'sunday';
+  if (weekday === 'Sat') return 'saturday';
+  return 'weekday';
+}
+
+/** Date → KST 기준 minutes-of-day (0~1439). */
+function getKstMinutesOfDay(date: Date): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: SUBWAY_TIMEZONE,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+  // hour12:false에서 자정은 '24'로 나올 수 있어 % 24로 정규화.
+  const hour = Number.parseInt(parts.find((p) => p.type === 'hour')!.value, 10) % HOURS_PER_DAY;
+  const minute = Number.parseInt(parts.find((p) => p.type === 'minute')!.value, 10);
+  return hour * MINUTES_PER_HOUR + minute;
+}
+
+/** "HHMM"(또는 익일 표기 "2436") → raw minutes (>=1440이면 overnight). */
+function rawToMinutes(raw: string): number {
+  const hour = Number.parseInt(raw.slice(0, 2), 10);
+  const minute = Number.parseInt(raw.slice(2, 4), 10);
+  return hour * MINUTES_PER_HOUR + minute;
+}
+
+/** raw minutes → "HH:mm" — 24h+ 표기는 % 1440으로 정규화. */
+function formatMinutes(minutes: number): string {
+  const normalized = minutes % MINUTES_PER_DAY;
+  const hour = Math.floor(normalized / MINUTES_PER_HOUR);
+  const minute = normalized % MINUTES_PER_HOUR;
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+interface Params {
+  stationName: string;
+  line: LineNumber;
+  /** 미지정 시 now 기준 KST로 자동 분류. */
+  dayType?: DayType;
+  /** 미지정 시 new Date(). */
+  now?: Date;
+}
+
+/**
+ * 역 단위 service window 계산:
+ * - firstTrain: up/down 합쳐 가장 빠른 실제 운행 entry(NON_OPERATING_SLOT 제외)
+ * - lastTrain: up/down 합쳐 가장 늦은 entry (overnight raw 분 우선)
+ */
+function pickStationWindow(timetable: DayDirectionTimetable): {
+  firstRaw: number | null;
+  lastRaw: number | null;
+} {
+  const directions = [timetable.up, timetable.down];
+  let firstRaw: number | null = null;
+  let lastRaw: number | null = null;
+  for (const entries of directions) {
+    for (const entry of entries) {
+      if (entry === NON_OPERATING_SLOT) continue;
+      const minutes = rawToMinutes(entry);
+      if (firstRaw === null || minutes < firstRaw) firstRaw = minutes;
+      if (lastRaw === null || minutes > lastRaw) lastRaw = minutes;
+    }
+  }
+  return { firstRaw, lastRaw };
+}
+
+export function getServiceWindow({
+  stationName,
+  line,
+  dayType,
+  now,
+}: Params): ServiceWindow {
+  const reference = now ?? new Date();
+  const lineData = TIMETABLES[line];
+  if (!lineData) {
+    return { firstTrain: null, lastTrain: null, status: 'unknown' };
+  }
+  const station = lineData.stations[stationName];
+  if (!station) {
+    return { firstTrain: null, lastTrain: null, status: 'unknown' };
+  }
+  const resolvedDayType = dayType ?? classifyDayTypeKst(reference);
+  const { firstRaw, lastRaw } = pickStationWindow(station[resolvedDayType]);
+  if (firstRaw === null || lastRaw === null) {
+    // 모든 슬롯이 NON_OPERATING_SLOT인 비정상 케이스 — 호출자가 fallback할 수 있게 unknown.
+    return { firstTrain: null, lastTrain: null, status: 'unknown' };
+  }
+
+  const firstTrain = formatMinutes(firstRaw);
+  const lastTrain = formatMinutes(lastRaw);
+  const nowMinutes = getKstMinutesOfDay(reference);
+
+  // 24h+ overnight 처리:
+  // - lastRaw가 1440 이상이고 nowMinutes <= (lastRaw - 1440)이면 아직 어제 운행분의 끝자락(in-service).
+  // - 그 윈도우를 지났는데 아직 nowMinutes < firstRaw이면 어제 막차는 끝났고 오늘 첫차 전 = post-last.
+  if (lastRaw >= MINUTES_PER_DAY) {
+    const overnightTailEnd = lastRaw - MINUTES_PER_DAY;
+    if (nowMinutes <= overnightTailEnd) {
+      return { firstTrain, lastTrain, status: 'in-service' };
+    }
+    if (nowMinutes < firstRaw) {
+      return { firstTrain, lastTrain, status: 'post-last' };
+    }
+    return { firstTrain, lastTrain, status: 'in-service' };
+  }
+
+  // lastRaw < 1440 (당일 내 종료): 단순 [first, last] 윈도우.
+  if (nowMinutes < firstRaw) {
+    return { firstTrain, lastTrain, status: 'pre-first' };
+  }
+  if (nowMinutes > lastRaw) {
+    return { firstTrain, lastTrain, status: 'post-last' };
+  }
+  return { firstTrain, lastTrain, status: 'in-service' };
+}


### PR DESCRIPTION
## Summary
- 신규 util \`src/features/route/utils/serviceWindow.ts\` — 1~9호선 timetable JSON에서 \`firstTrain\`/\`lastTrain\`/\`status\`를 계산
- status: \`'pre-first' | 'in-service' | 'post-last' | 'unknown'\`
- KST tz 자동 분류 + 24h+ overnight overflow 처리 (#1043 lastTrainTime와 동일 정책)
- UI 미연결 — banner consumer는 별도 PR follow-up (다른 PR 동시 진행 중이라 wiring 회피)

## Notes
- #1043(lastTrainTime)과 timetable 로딩 / HHMM 정규화 / dayType 분류 로직이 겹친다. **#1043 머지 후** 공통 helper로 추출 검토 (follow-up).
- overnight 윈도우 의미: lastRaw가 24h+(>=1440)인 역에서 overnight tail 종료 후 ~ 다음날 첫차 전 구간은 \`post-last\`(어제 막차 종료)로 분류한다.
- 모든 실 timetable 역이 overnight 운행을 가져, non-overnight 분기는 \`jest.isolateModules + doMock\` 패턴으로 검증.

## Test plan
- [x] \`npx jest src/features/route/utils/__tests__/serviceWindow.test.ts --coverage\` — 16 pass, 100% line/branch/func/stmt
- [x] \`npm run type-check\` 통과
- [x] ESLint clean
- [ ] follow-up: banner UI consumer + i18n 키 추가 (별도 PR)

Closes #1047