### PR TITLE
fix(#1050): 위젯 dedupe 정밀화 — 같은 역 내 거리 변화 반영

### DIFF
--- a/src/features/widget/api/__tests__/widgetStorage.test.ts
+++ b/src/features/widget/api/__tests__/widgetStorage.test.ts
@@ -45,24 +45,35 @@ describe('widgetStorage (native)', () => {
       expect(mockSave).not.toHaveBeenCalled();
     });
 
-    it('같은 역에 대해 연속 호출하면 한 번만 native에 전달된다', async () => {
+    it('같은 역 + 같은 50m 버킷이면 한 번만 native에 전달된다', async () => {
+      // 100m, 120m, 149m → 모두 bucket 2 (100~149m)
       await saveStationToWidget(station, 0.1);
-      await saveStationToWidget(station, 0.2);
-      await saveStationToWidget(station, 0.3);
+      await saveStationToWidget(station, 0.12);
+      await saveStationToWidget(station, 0.149);
       expect(mockSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('같은 역이라도 50m 버킷이 바뀌면 다시 전달된다', async () => {
+      await saveStationToWidget(station, 0.5); // bucket 10 (500m)
+      await saveStationToWidget(station, 0.45); // bucket 9 (450m)
+      await saveStationToWidget(station, 0.03); // bucket 0 (30m)
+      expect(mockSave).toHaveBeenCalledTimes(3);
+      expect(mockSave).toHaveBeenNthCalledWith(1, '강남', '#009933', 500);
+      expect(mockSave).toHaveBeenNthCalledWith(2, '강남', '#009933', 450);
+      expect(mockSave).toHaveBeenNthCalledWith(3, '강남', '#009933', 30);
     });
 
     it('역이 바뀌면 다시 native에 전달된다', async () => {
       const other: Station = { ...station, id: '2-002', name: '역삼' };
       await saveStationToWidget(station, 0.1);
-      await saveStationToWidget(other, 0.2);
+      await saveStationToWidget(other, 0.1);
       expect(mockSave).toHaveBeenCalledTimes(2);
     });
 
-    it('clearWidgetStation 이후엔 같은 역도 다시 전달된다', async () => {
+    it('clearWidgetStation 이후엔 같은 역/같은 버킷도 다시 전달된다', async () => {
       await saveStationToWidget(station, 0.1);
       await clearWidgetStation();
-      await saveStationToWidget(station, 0.2);
+      await saveStationToWidget(station, 0.1);
       expect(mockSave).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/features/widget/api/widgetStorage.ts
+++ b/src/features/widget/api/widgetStorage.ts
@@ -2,17 +2,26 @@ import { Platform } from 'react-native';
 import * as LiveActivity from 'live-activity';
 import { Station } from '../../../shared/types/station';
 
-// 동일 역 머무는 동안 매 GPS 폴링마다 WidgetCenter.reloadAllTimelines 가
-// 호출되는 낭비를 막기 위한 station.id 기준 dedupe.
-let lastStationId: string | null = null;
+// 위젯 거리 표시는 50m 단위로 의미가 있다고 보고, 같은 역 + 같은 50m 버킷일 때만
+// WidgetCenter.reloadAllTimelines 호출을 dedupe 한다. 같은 역이라도 버킷이
+// 바뀌면(예: 500m → 450m) 위젯이 stale 상태로 남지 않도록 재전달한다.
+const DISTANCE_BUCKET_M = 50;
+
+let lastDedupeKey: string | null = null;
+
+function distanceBucket(distanceKm: number): number {
+  const distanceM = Math.max(0, Math.round(distanceKm * 1000));
+  return Math.floor(distanceM / DISTANCE_BUCKET_M);
+}
 
 export async function saveStationToWidget(
   station: Station,
   distanceKm: number,
 ): Promise<void> {
   if (Platform.OS !== 'ios') return;
-  if (station.id === lastStationId) return;
-  lastStationId = station.id;
+  const key = `${station.id}:${distanceBucket(distanceKm)}`;
+  if (key === lastDedupeKey) return;
+  lastDedupeKey = key;
   await LiveActivity.saveWidgetStation(
     station.name,
     station.lineColor,
@@ -21,7 +30,7 @@ export async function saveStationToWidget(
 }
 
 export async function clearWidgetStation(): Promise<void> {
-  lastStationId = null;
+  lastDedupeKey = null;
   if (Platform.OS !== 'ios') return;
   await LiveActivity.clearWidgetStation();
 }

--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -79,6 +79,17 @@ struct SubwayWidgetView: View {
     }
 
     var body: some View {
+        // iOS 17+는 위젯이 containerBackground를 채택하지 않으면
+        // 시스템이 "Please adopt containerBackground API" placeholder를 대신 그린다.
+        // 배포 타겟 15.1이라 availability 분기 필요.
+        if #available(iOS 17.0, *) {
+            content.containerBackground(.background, for: .widget)
+        } else {
+            content
+        }
+    }
+
+    private var content: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 4) {
                 Circle()


### PR DESCRIPTION
## Summary

위젯 표시 회귀 두 건을 같은 PR에서 해소. 둘 다 같은 위젯 UI에 영향을 주고, B가 없으면 iOS 17+ 기기에서 A의 시각적 검증 자체가 불가능해 함께 묶음. 커밋은 원인별로 분리.

### A. JS gateway dedupe 정밀화 (commit 1)
- `src/features/widget/api/widgetStorage.ts`의 dedupe가 `station.id`만 비교하여, 같은 역에 머무는 동안 거리가 500m → 30m로 변해도 위젯에는 첫 호출 값이 그대로 남는 회귀.
- dedupe key를 `${station.id}:${50m bucket}`로 정밀화 — 같은 버킷 내 변화는 기존처럼 흡수해 `WidgetCenter.reloadAllTimelines` 낭비 호출은 막고, 버킷이 바뀌면 다시 위젯에 반영.
- 50m는 위젯 UI(`"\(distanceM)m"`)에서 사용자가 체감 가능한 최소 단위로 선택.

### B. iOS 17+ containerBackground API 채택 (commit 2)
- 실기기 iOS 17+ 검증 중 위젯 자리에 **"Please adopt containerBackground API"** placeholder가 표시되는 결함 확인.
- `targets/subway-widget/SubwayWidget.swift`의 `SubwayWidgetView.body`를 inner `content` + `containerBackground(for:.widget)` modifier로 분리.
- 배포 타겟 15.1이라 `#available(iOS 17.0, *)` 분기로 16.x 호환 유지.

## Scope

- A는 JS gateway만 수정
- B는 `SubwayWidget.swift` 한 곳만 수정 (홈 위젯 한정)
- `modules/live-activity/**`, `targets/subway-widget/SubwayLiveActivityWidget.swift`는 건드리지 않음

## Test plan

### A
- [x] `widgetStorage.ts` 100% line/branch/function/statement coverage
- [x] 같은 역 + 같은 50m 버킷 → 1회 호출 (regression 보장)
- [x] 같은 역 + 다른 50m 버킷 → 매번 호출 + 거리 값 검증
- [x] 다른 역 → 매번 호출
- [x] `clearWidgetStation` 이후 dedupe key 리셋

### B
- [x] `npm run type-check` clean (Swift는 type-check 대상 아님 — Xcode 빌드는 별도 검증)
- [ ] (수동) 실기기 iOS 17+ : 위젯 갤러리 / 홈 화면에서 placeholder 대신 실제 역명/거리 노출
- [ ] (수동) 실기기 iOS 16.x : 회귀 없음

### 공통
- [x] `npm run type-check` clean
- [x] `npm test` 4179/4179 pass
- [ ] (수동) 실기기 강남역 진입 → 멀어졌다 가까워지면 위젯 거리 갱신 확인

Closes #1050
