### PR TITLE
fix(#1056): dev boardingPromptContext lint — cross-feature import 옵트인

### DIFF
--- a/src/features/alarm/utils/boardingPromptContext.ts
+++ b/src/features/alarm/utils/boardingPromptContext.ts
@@ -1,3 +1,11 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: boarding-prompt 컨텍스트 빌더는 alarm 슬라이스에서 발사하는 push의
+ * 평가 입력을 route 슬라이스의 단조-노선 방향 유틸로부터 빌드한다. boarding-prompt 자체가 alarm + route를
+ * 가로지르는 본질적 cross-feature 게이트라 직접 import가 자연스러움. 후속 PR에서 resolveTravelDirection을
+ * src/shared/utils/로 추출하거나 orchestration 슬라이스로 이전 예정.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
 /**
  * "탔어요?" 푸시(#819) 평가 컨텍스트 빌더.
  *


### PR DESCRIPTION
## Summary

- \`dev\` HEAD에서 \`npm run lint\` 시 \`src/features/alarm/utils/boardingPromptContext.ts:31\` 에서 \`import/no-restricted-paths\` 에러 발생 (route 슬라이스의 \`travelDirection\` 직접 import).
- PR #1030 머지 시 cross-feature 옵트인 헤더 적용이 누락됨. 동시 작업 중인 BG agent들이 4회 이상 stumble해 클리어 필요.
- CLAUDE.md "본질적 cross-feature orchestrator는 파일 헤더의 eslint-disable 주석으로 명시 옵트인" 패턴(예: \`useApnsTripRegistration.ts\`)을 동일하게 적용.

## Scope

- 단일 파일(\`src/features/alarm/utils/boardingPromptContext.ts\`) 상단에 file-level \`eslint-disable import/no-restricted-paths\` 헤더 추가만.
- 동작 변경 없음.
- \`resolveTravelDirection\`을 \`src/shared/utils/\`로 추출하는 큰 리팩토링은 후속 PR(Phase 5 follow-up).

## Verification

- \`npm run lint\` clean
- \`npm run type-check\` clean
- \`npm test\` 4178 passed, coverage 100%

Closes #1056