### PR TITLE
feat(#1058): 자동 하차 감지 시 toast + undo

### DIFF
--- a/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
@@ -176,13 +176,15 @@ describe('useDestinationAutoClear', () => {
     expect(onAutoClear).not.toHaveBeenCalled();
   });
 
-  it('motionStationary 진입 후 60s 지나면 onAutoClear 1회 호출 + log', () => {
+  it('motionStationary 진입 후 60s 지나면 onAutoClear 1회 호출 + log + cleared station 전달', () => {
     const { onAutoClear, initial, rerender } = mountStationaryDetect({ arvlCodes: [1] });
     withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
       // userLocation을 미세 변경해 effect 재실행 트리거 (좌표 가까운 jitter).
       rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
     });
     expect(onAutoClear).toHaveBeenCalledTimes(1);
+    // #1058: cleared station snapshot이 인자로 전달돼야 함 (undo 복원용).
+    expect(onAutoClear).toHaveBeenCalledWith(destination);
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       'destination=강남 자동 해제 (confidence=high)',
     );

--- a/src/features/alarm/hooks/useDestinationAutoClear.ts
+++ b/src/features/alarm/hooks/useDestinationAutoClear.ts
@@ -56,8 +56,12 @@ export interface UseDestinationAutoClearInputs {
   userLocation: { lat: number; lng: number } | null;
   /** CMMotionActivity stationary 신호. 미지원/거절 케이스는 false로 전달되어 detect=false. */
   motionStationary: boolean;
-  /** `setDestination(null)`을 호출하는 콜백. HomeScreen이 useCallback으로 메모이즈해 전달. */
-  onAutoClear: () => void;
+  /**
+   * 자동 해제 시 호출. `setDestination(null)` 등 cleanup은 caller 책임이다.
+   * #1058: cleared station을 인자로 받아 caller가 undo toast에 노출하거나 복원할 수 있다.
+   * HomeScreen이 useCallback으로 메모이즈해 전달.
+   */
+  onAutoClear: (cleared: Station) => void;
 }
 
 /**
@@ -141,7 +145,7 @@ export function useDestinationAutoClear({
       logger.info(
         `destination=${destination.name} 자동 해제 (confidence=${result.confidence})`,
       );
-      onAutoClear();
+      onAutoClear(destination);
     }
   }, [
     destination,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -395,11 +395,29 @@ export default function HomeScreen() {
   // 기존 arrival/useArrivalAutoClear(500m/2s, GPS 역명 매칭)와도 책임 분리:
   //   - arrival/useArrivalAutoClear: 도착 banner UX + 빠른 2초 후 자동 클리어 (낙관적 단순 정책).
   //   - 본 hook: motion=stationary + arvlCd 보강 → 사용자가 명시 "하차" 안 누른 케이스의 안전망.
+  // #1058: 자동 하차 직후 6초간 toast + undo 액션. cleared 인자는 useDestinationAutoClear가
+  // fire 시점 destination snapshot을 전달 — recentDestination이 아니라 "방금 해제된" station을
+  // 그대로 복원할 수 있다 (사용자가 trip 도중 다른 picker 작업으로 recent를 덮어쓰는 회귀 차단).
+  const [autoDisembarkToast, setAutoDisembarkToast] = useState<Station | null>(null);
+  const handleAutoDisembark = useCallback(
+    (cleared: Station) => {
+      setDestination(null);
+      setAutoDisembarkToast(cleared);
+    },
+    [setDestination],
+  );
+  const handleAutoDisembarkUndo = useCallback(() => {
+    if (autoDisembarkToast) {
+      setDestination(autoDisembarkToast);
+    }
+    setAutoDisembarkToast(null);
+  }, [autoDisembarkToast, setDestination]);
+  const handleAutoDisembarkDismiss = useCallback(() => setAutoDisembarkToast(null), []);
   useDestinationAutoClear({
     destination,
     userLocation,
     motionStationary,
-    onAutoClear: handleArrivalClear,
+    onAutoClear: handleAutoDisembark,
   });
   // #584 PR D3: lock.boardingLine 위치 데이터를 별도 구독 — fusion 캐시와 dedup되어 추가 비용 없음.
   // lock 없으면 line=null로 호출되어 polling이 자동 정지된다.
@@ -689,6 +707,15 @@ export default function HomeScreen() {
         onDismiss={handleMisBoardingToastDismiss}
         accent={colors.warn}
         testID="mis-boarding-toast"
+      />
+      <Toast
+        visible={autoDisembarkToast !== null}
+        message={t('home.autoDisembarkToast.message', { name: autoDisembarkToast?.name ?? '' })}
+        actionLabel={t('home.autoDisembarkToast.undo')}
+        onAction={handleAutoDisembarkUndo}
+        onDismiss={handleAutoDisembarkDismiss}
+        durationMs={6000}
+        testID="auto-disembark-toast"
       />
       {/* line이 정해져야 list를 렌더 가능 — line null이면 모달 자체를 띄우지 않음 (빈 sheet 회피). */}
       <MisBoardingReselectModal

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -53,7 +53,11 @@
     "boardingProximityHint": "Move closer to the boarding station to pick a train",
     "boardingTrainListTitle": "Pick your train",
     "boardingTrainListEmpty": "No upcoming trains.",
-    "misBoardingToast": "Can't find your train. Please reselect."
+    "misBoardingToast": "Can't find your train. Please reselect.",
+    "autoDisembarkToast": {
+      "message": "Arrived at {{name}} — destination cleared",
+      "undo": "Undo"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -53,7 +53,11 @@
     "boardingProximityHint": "乗車駅の近くで列車を選択できます",
     "boardingTrainListTitle": "乗車する列車を選択",
     "boardingTrainListEmpty": "到着予定の列車がありません。",
-    "misBoardingToast": "乗車中の列車が見つかりません。もう一度選択してください。"
+    "misBoardingToast": "乗車中の列車が見つかりません。もう一度選択してください。",
+    "autoDisembarkToast": {
+      "message": "{{name}}に到着し、目的地を解除しました",
+      "undo": "元に戻す"
+    }
   },
   "settings": {
     "title": "設定",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -53,7 +53,11 @@
     "boardingProximityHint": "탑승역 근처에서 열차를 선택할 수 있어요",
     "boardingTrainListTitle": "탑승할 열차 선택",
     "boardingTrainListEmpty": "도착 예정 열차가 없습니다.",
-    "misBoardingToast": "탑승 열차를 찾을 수 없어요. 다시 선택해주세요."
+    "misBoardingToast": "탑승 열차를 찾을 수 없어요. 다시 선택해주세요.",
+    "autoDisembarkToast": {
+      "message": "{{name}}에 도착해 목적지를 해제했어요",
+      "undo": "되돌리기"
+    }
   },
   "settings": {
     "title": "설정",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -53,7 +53,11 @@
     "boardingProximityHint": "靠近乘车站后可以选择列车",
     "boardingTrainListTitle": "选择乘坐列车",
     "boardingTrainListEmpty": "暂无即将到达的列车。",
-    "misBoardingToast": "找不到乘坐的列车,请重新选择。"
+    "misBoardingToast": "找不到乘坐的列车,请重新选择。",
+    "autoDisembarkToast": {
+      "message": "已到达{{name}},已清除目的地",
+      "undo": "撤销"
+    }
   },
   "settings": {
     "title": "设置",

--- a/src/shared/ui/Toast.tsx
+++ b/src/shared/ui/Toast.tsx
@@ -12,6 +12,14 @@ interface Props {
   onDismiss: () => void;
   /** accent color. warn/danger/accent 등 의도 색. 기본 accent. */
   accent?: string;
+  /**
+   * 우측 액션 버튼 라벨 (#1058 — 자동 하차 undo). actionLabel과 onAction이 모두
+   * 전달돼야 액션 버튼이 렌더된다. 액션 탭은 onDismiss를 호출하지 않는다 — caller가
+   * onAction 내에서 dismiss 상태를 직접 정리한다.
+   */
+  actionLabel?: string;
+  /** 액션 버튼 탭 핸들러. actionLabel과 짝으로 전달. */
+  onAction?: () => void;
   testID?: string;
 }
 
@@ -21,6 +29,9 @@ interface Props {
  * controlled component — caller가 visible state를 관리. durationMs 후 자동 onDismiss 호출.
  * Pressable 전체가 dismiss 버튼이라 사용자가 어디든 탭하면 닫힘.
  * 외부 토스트 라이브러리 회피 — 의존성 최소 + 테마 토큰 직접 사용.
+ *
+ * #1058: optional 액션 버튼(actionLabel + onAction). 액션 영역은 별도 Pressable이라
+ * 액션 탭이 컨테이너 onPress(dismiss)로 버블링되지 않는다.
  */
 export function Toast({
   visible,
@@ -28,10 +39,13 @@ export function Toast({
   durationMs = 5000,
   onDismiss,
   accent,
+  actionLabel,
+  onAction,
   testID,
 }: Props) {
   const { colors } = useTheme();
   const tone = accent ?? colors.accent;
+  const hasAction = actionLabel !== undefined && onAction !== undefined;
 
   useEffect(() => {
     if (!visible || durationMs <= 0) return;
@@ -49,6 +63,15 @@ export function Toast({
     >
       <View style={[styles.accentStripe, { backgroundColor: tone }]} />
       <Text style={[typography.body, styles.message, { color: colors.ink }]}>{message}</Text>
+      {hasAction && (
+        <Pressable
+          onPress={onAction}
+          style={styles.action}
+          testID={testID ? `${testID}-action` : undefined}
+        >
+          <Text style={[typography.body, styles.actionLabel, { color: tone }]}>{actionLabel}</Text>
+        </Pressable>
+      )}
     </Pressable>
   );
 }
@@ -74,5 +97,12 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.lg,
+  },
+  action: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+  },
+  actionLabel: {
+    fontWeight: '600',
   },
 });

--- a/src/shared/ui/__tests__/Toast.test.tsx
+++ b/src/shared/ui/__tests__/Toast.test.tsx
@@ -82,4 +82,47 @@ describe('Toast', () => {
     );
     expect(getByTestId('t')).toBeTruthy();
   });
+
+  // #1058 — 액션 버튼(actionLabel + onAction) 지원.
+  it('actionLabel + onAction 둘 다 전달 시 액션 버튼 렌더 + 탭 시 onAction만 호출', () => {
+    const onAction = jest.fn();
+    const onDismiss = jest.fn();
+    const { getByTestId, getByText } = renderWithTheme(
+      <Toast
+        visible
+        message="msg"
+        onDismiss={onDismiss}
+        actionLabel="Undo"
+        onAction={onAction}
+        testID="t"
+      />,
+    );
+    expect(getByText('Undo')).toBeTruthy();
+    fireEvent.press(getByTestId('t-action'));
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('actionLabel만 있고 onAction 없으면 액션 버튼 렌더 안 함', () => {
+    const { queryByTestId } = renderWithTheme(
+      <Toast visible message="msg" onDismiss={() => {}} actionLabel="Undo" testID="t" />,
+    );
+    expect(queryByTestId('t-action')).toBeNull();
+  });
+
+  it('actionLabel/onAction 모두 없으면 액션 버튼 미렌더', () => {
+    const { queryByTestId } = renderWithTheme(
+      <Toast visible message="msg" onDismiss={() => {}} testID="t" />,
+    );
+    expect(queryByTestId('t-action')).toBeNull();
+  });
+
+  it('testID 미전달 시 액션 버튼 testID도 undefined (탭은 동작)', () => {
+    const onAction = jest.fn();
+    const { getByText } = renderWithTheme(
+      <Toast visible message="msg" onDismiss={() => {}} actionLabel="Undo" onAction={onAction} />,
+    );
+    fireEvent.press(getByText('Undo'));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- `useDestinationAutoClear` 콜백 시그니처가 `(cleared: Station) => void`로 변경 — fire 시점의 destination snapshot을 caller에 전달
- HomeScreen에서 자동 하차 감지 시 Toast (6초) 노출: "{역명}에 도착해 목적지를 해제했어요" + "되돌리기" 액션 버튼
- Undo 탭 시 `recentDestination`이 아닌 cleared station을 그대로 `setDestination`으로 복원해, 사용자가 trip 도중 다른 picker 작업으로 recent를 덮어쓴 케이스에서도 의도한 station이 복원됨
- `Toast` 공용 컴포넌트에 optional `actionLabel` / `onAction` prop 추가 (backward compatible — 기존 호출부 영향 없음)
- i18n ko/en/ja/zh 4 locale에 `home.autoDisembarkToast.message` (`{{name}}` interpolation) + `home.autoDisembarkToast.undo` 추가

docs/requirements/08-disembark.md의 ⚠️ unimplemented 항목 해소.

## Test plan
- [x] `npm test` — 229 suites / 4229 tests pass, 100% coverage
- [x] `npm run type-check` clean
- [x] Toast / useDestinationAutoClear 변경분 100% coverage 유지
- [ ] 실기기 — destination 설정 후 도착역 50m 이내 + 60s motion stationary → Toast 노출 확인
- [ ] 실기기 — Undo 탭 시 destination 복원 확인
- [ ] 실기기 — 6초 후 자동 dismiss + Toast 영역 탭 시 즉시 dismiss

Closes #1058