### PR TITLE
chore(#1067): FEEDBACK KV namespace 실제 ID 반영

### DIFF
--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -21,13 +21,10 @@ preview_id = "53a86628f78c48fa91fa954f84514df3"
 # KV: 사용자 버그 신고 (#1034, docs/requirements/12-cross-cutting.md)
 # `POST /feedback`이 메시지 + 디바이스 컨텍스트를 30일 TTL로 적재.
 # 운영자가 `wrangler kv key list --binding FEEDBACK`으로 수거 후 분기 트리아지.
-# TODO: 운영자가 `wrangler kv namespace create FEEDBACK` (+ `--preview`)로 실제 ID 발급 후
-#       아래 placeholder 두 줄을 교체. 코드는 `if (env.FEEDBACK)` 분기로 graceful —
-#       binding 미설정 환경(현재 placeholder 상태)에서는 endpoint가 503 응답.
 [[kv_namespaces]]
 binding = "FEEDBACK"
-id = "REPLACE_WITH_FEEDBACK_KV_ID"
-preview_id = "REPLACE_WITH_FEEDBACK_KV_PREVIEW_ID"
+id = "831193b9d97f44c5b65131f045c09804"
+preview_id = "d38f190e3f7f4fd3b6e7f6485dd1733d"
 
 # #498 — silent push 게이트 outcome 텔레메트리. 클라가 누적한 카운터를 일별 query 가능하게 적재.
 # Privacy: 카운트만, token은 8자 prefix만. 개별 push 내용/좌표 미저장.


### PR DESCRIPTION
## Summary

PR #1042(`feat/#1034-bug-feedback`)가 머지되면서 `backend/alarm-worker/wrangler.toml`의 `FEEDBACK` KV namespace ID가 placeholder 상태로 dev에 들어왔다. 머지 직전 ID 반영 commit이 race로 누락된 결과.

이 PR이 실제 발급된 namespace ID로 교체.

## 변경

`backend/alarm-worker/wrangler.toml`:
- `id`: `REPLACE_WITH_FEEDBACK_KV_ID` → `831193b9d97f44c5b65131f045c09804`
- `preview_id`: `REPLACE_WITH_FEEDBACK_KV_PREVIEW_ID` → `d38f190e3f7f4fd3b6e7f6485dd1733d`
- placeholder 안내 TODO 주석 제거

KV namespace ID는 secret이 아닌 식별자 — 기존 TRIPS/PENDING_PUSHES IDs도 동일하게 평문 커밋되어 있음. 데이터 접근은 별도 Cloudflare API token으로 제어.

## Test plan

- [x] `npm run type-check` (영향 없음 — toml만 변경)
- [x] 머지 후 `cd backend/alarm-worker && npx wrangler deploy` 성공
- [x] 실기기 앱에서 Settings → 버그 신고 송신 → 토스트 성공
- [x] `npx wrangler kv key list --binding FEEDBACK --remote`로 키 적재 확인

Closes #1067
