### PR TITLE
feat(#1064): 경로 시스템 텍스트 공유 util (Share A)

### DIFF
--- a/src/features/route/utils/__tests__/shareTrip.test.ts
+++ b/src/features/route/utils/__tests__/shareTrip.test.ts
@@ -1,0 +1,149 @@
+import { Share } from 'react-native';
+import { buildShareTripText, shareTripIntent } from '../shareTrip';
+import type { Station } from '../../../../shared/types/station';
+import type { DirectRoute, Route } from '../../../../shared/utils/stationRoute';
+
+function makeStation(overrides: Partial<Station> = {}): Station {
+  return {
+    id: '2-219',
+    name: '강남',
+    line: '2',
+    lineColor: '#00A84D',
+    lat: 37.4979,
+    lng: 127.0276,
+    ...overrides,
+  };
+}
+
+const directRoute: DirectRoute = {
+  type: 'direct',
+  stops: 5,
+  line: '2',
+  travelSeconds: 600,
+};
+
+const t = jest.fn((key: string, opts?: Record<string, unknown>) => {
+  if (key === 'share.trip.title') return 'TITLE';
+  if (key === 'share.trip.bodyTemplate' && opts) {
+    return `FROM ${opts.fromName} (${opts.fromLine}) TO ${opts.toName} (${opts.toLine}) ${opts.minutes}min ${opts.stops}stops`;
+  }
+  if (key === 'lines.2') return '2호선';
+  if (key === 'lines.8') return '8호선';
+  return key;
+});
+
+beforeEach(() => {
+  t.mockClear();
+});
+
+describe('buildShareTripText', () => {
+  it('빌드: 정상 입력이면 t로 본문 생성', () => {
+    const result = buildShareTripText({
+      route: directRoute,
+      currentStation: makeStation(),
+      destination: makeStation({ id: '2-216', name: '잠실', line: '2' }),
+      totalStops: 5,
+      travelMinutes: 10,
+      t,
+    });
+    expect(result).toBe('FROM 강남 (2호선) TO 잠실 (2호선) 10min 5stops');
+  });
+
+  it('환승: 출발/도착 노선이 다르면 각 노선 라벨이 들어간다', () => {
+    const result = buildShareTripText({
+      route: directRoute,
+      currentStation: makeStation({ line: '2' }),
+      destination: makeStation({ id: '8-008', name: '천호', line: '8' }),
+      totalStops: 12,
+      travelMinutes: 25,
+      t,
+    });
+    expect(result).toContain('(2호선)');
+    expect(result).toContain('(8호선)');
+  });
+
+  it('null route: null 반환', () => {
+    const result = buildShareTripText({
+      route: null as Route,
+      currentStation: makeStation(),
+      destination: makeStation({ id: '2-216', name: '잠실' }),
+      totalStops: 5,
+      travelMinutes: 10,
+      t,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('currentStation 없음: null 반환', () => {
+    const result = buildShareTripText({
+      route: directRoute,
+      currentStation: null,
+      destination: makeStation(),
+      totalStops: 5,
+      travelMinutes: 10,
+      t,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('destination 없음: null 반환', () => {
+    const result = buildShareTripText({
+      route: directRoute,
+      currentStation: makeStation(),
+      destination: null,
+      totalStops: 5,
+      travelMinutes: 10,
+      t,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('shareTripIntent', () => {
+  it('정상: Share.share를 message+title과 함께 호출하고 true', async () => {
+    const spy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    const ok = await shareTripIntent({
+      route: directRoute,
+      currentStation: makeStation(),
+      destination: makeStation({ id: '2-216', name: '잠실' }),
+      totalStops: 5,
+      travelMinutes: 10,
+      t,
+    });
+    expect(ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith({
+      title: 'TITLE',
+      message: 'FROM 강남 (2호선) TO 잠실 (2호선) 10min 5stops',
+    });
+    spy.mockRestore();
+  });
+
+  it('누락 입력: Share.share를 호출하지 않고 false', async () => {
+    const spy = jest.spyOn(Share, 'share');
+    const ok = await shareTripIntent({
+      route: null as Route,
+      currentStation: makeStation(),
+      destination: makeStation(),
+      totalStops: 0,
+      travelMinutes: 0,
+      t,
+    });
+    expect(ok).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('Share.share가 throw하면 false 반환', async () => {
+    const spy = jest.spyOn(Share, 'share').mockRejectedValue(new Error('user cancelled'));
+    const ok = await shareTripIntent({
+      route: directRoute,
+      currentStation: makeStation(),
+      destination: makeStation({ id: '2-216', name: '잠실' }),
+      totalStops: 5,
+      travelMinutes: 10,
+      t,
+    });
+    expect(ok).toBe(false);
+    spy.mockRestore();
+  });
+});

--- a/src/features/route/utils/shareTrip.ts
+++ b/src/features/route/utils/shareTrip.ts
@@ -1,0 +1,67 @@
+import { Share } from 'react-native';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+import type { LineNumber } from '../../../shared/types/station';
+
+/**
+ * Share A — 시스템 텍스트 공유.
+ *
+ * Trip 카드(출발/도착/소요시간/정거장 수)를 OS 공유 시트로 보낼 수 있도록
+ * 순수 텍스트를 만든다. UI 와이어는 후속 PR (#1062 등과 충돌 회피).
+ *
+ * - i18n은 호출자가 t를 주입한다 (테스트 시 결정적, 하드코딩 한국어 회피).
+ * - Route 종류(direct/transfer/multi-transfer)에 의존하지 않고
+ *   상위에서 미리 계산한 totalStops / travelMinutes 만 받는다.
+ */
+
+type TFunction = (key: string, options?: Record<string, unknown>) => string;
+
+export interface ShareTripInput {
+  route: Route;
+  currentStation: Station | null;
+  destination: Station | null;
+  totalStops: number;
+  travelMinutes: number;
+  t: TFunction;
+}
+
+function lineLabel(t: TFunction, line: LineNumber): string {
+  // ko/en/ja/zh 모두 lines.<number> 네임스페이스 보유.
+  return t(`lines.${line}`);
+}
+
+/**
+ * 공유 본문 문자열을 만든다. 누락 정보가 있으면 null을 반환해
+ * 호출자가 버튼을 비활성화할 수 있게 한다.
+ */
+export function buildShareTripText(input: ShareTripInput): string | null {
+  const { route, currentStation, destination, totalStops, travelMinutes, t } = input;
+  if (!route || !currentStation || !destination) return null;
+
+  return t('share.trip.bodyTemplate', {
+    fromName: currentStation.name,
+    fromLine: lineLabel(t, currentStation.line),
+    toName: destination.name,
+    toLine: lineLabel(t, destination.line),
+    minutes: travelMinutes,
+    stops: totalStops,
+  });
+}
+
+/**
+ * Share.share()로 OS 공유 시트를 띄운다. 누락된 정보면 false 반환.
+ * 예외 발생 시 false 반환 (호출자는 토스트 등으로 처리 가능).
+ */
+export async function shareTripIntent(input: ShareTripInput): Promise<boolean> {
+  const message = buildShareTripText(input);
+  if (!message) return false;
+  try {
+    await Share.share({
+      title: input.t('share.trip.title'),
+      message,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "Get off",
       "boardingLockReleaseHint": "Ends the current boarding session"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "Subway route",
+      "bodyTemplate": "🚇 Subway route\nFrom: {{fromName}} ({{fromLine}})\nTo: {{toName}} ({{toLine}})\nAbout {{minutes}} min ({{stops}} stops)"
+    }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "降車",
       "boardingLockReleaseHint": "現在の乗車を終了します"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "地下鉄ルート",
+      "bodyTemplate": "🚇 地下鉄ルート\n出発: {{fromName}} ({{fromLine}})\n到着: {{toName}} ({{toLine}})\n約 {{minutes}}分 ({{stops}}駅)"
+    }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "하차",
       "boardingLockReleaseHint": "현재 탑승 상태를 종료합니다"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "지하철 경로",
+      "bodyTemplate": "🚇 지하철 경로\n출발: {{fromName}} ({{fromLine}})\n도착: {{toName}} ({{toLine}})\n약 {{minutes}}분 소요 ({{stops}}정거장)"
+    }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "下车",
       "boardingLockReleaseHint": "结束当前乘车状态"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "地铁路线",
+      "bodyTemplate": "🚇 地铁路线\n出发: {{fromName}} ({{fromLine}})\n到达: {{toName}} ({{toLine}})\n约 {{minutes}}分钟 ({{stops}}站)"
+    }
   }
 }


### PR DESCRIPTION
Closes #1064

## Summary
- `src/features/route/utils/shareTrip.ts` 신규 — 순수 함수 `buildShareTripText` + `shareTripIntent` (react-native `Share.share()` wrapper)
- i18n `share.trip.title` / `share.trip.bodyTemplate` (ko/en/ja/zh)
- 단위 테스트 8건, 신규 util 100% 커버

## UI 와이어는 후속 PR
Trip 본체가 `src/screens/HomeScreen.tsx`에서만 렌더되고, 동일 파일을 #1062(자동 하차) 등 다른 작업이 동시에 수정 중이라 conflict 위험이 크다. 본 PR은 util + i18n + 테스트만 포함하고, 실제 공유 버튼 노출은 별도 PR로 분리한다.

## API 개요
```ts
buildShareTripText({
  route, currentStation, destination,
  totalStops, travelMinutes,    // RouteCandidate에서 그대로 전달
  t,                            // useTranslation의 t 주입
}) => string | null

shareTripIntent({...}) => Promise<boolean>   // Share.share 실패/취소 시 false
```

i18n 키는 호출 측에서 `t()`로 합성하므로 하드코딩 한국어 없음. `lines.<number>` 기존 네임스페이스 재사용.

## Test plan
- [x] `npm test` 통과 (235 suites / 4288 tests)
- [x] 신규 util 100% 커버 (stmts/branch/funcs/lines)
- [x] `npm run type-check` 통과
- [x] eslint 통과
- [ ] 후속 PR에서 UI 와이어 추가 후 실기기에서 시스템 공유 시트 동작 확인