### PR TITLE
feat(#1063): alarmDirection에 inferLoopDirection fallback wiring

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmDirection.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmDirection.test.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../../testUtils/routeFixtures';
 
 jest.mock('../../../route/utils/travelDirection', () => ({
-  // 간단한 mock: from→to 쌍에 따라 미리 정한 결과를 반환. 시그니처는 { direction, fromStation, toStation }.
   resolveTravelDirection: (line: string, from: string, to: string) => {
     if (from === '없는역' || to === '없는역') return null;
     const directionByLine: Record<string, 'up' | 'down'> = { '1': 'down', '2': 'up' };
@@ -19,8 +18,6 @@ jest.mock('../../../route/utils/travelDirection', () => ({
 }));
 
 jest.mock('../../../route/utils/loopDirection', () => ({
-  // 루프 fallback mock (#1063): 노선 '5'(monotonic mock에서 null)일 때만 매칭.
-  // 실제 inferLoopDirection은 2호선만 처리하지만, 본 테스트는 chaining 동작 검증 목적.
   inferLoopDirection: (line: string, from: string, to: string) => {
     if (line !== '5') return null;
     if (from === '시청' && to === '왕십리') return 'down';
@@ -32,23 +29,26 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   isSameStationName: (a: string, b: string) => a === b,
 }));
 
-// 데이터 주도 테스트용 row 타입 (#1063 Sonar 중복 라인 게이트):
-// 모든 케이스가 (route, target, destinationName, sourceStationName) → expected 형태이므로
-// row 배열을 it.each로 돌려 호출 패턴 중복을 제거한다.
 type Target = { type: 'transfer' | 'destination'; stationName: string };
-type Row = {
-  label: string;
-  route: NonNullable<Route>;
-  target: Target;
-  destinationName: string;
-  sourceStationName: string;
-  expected: 'up' | 'down' | undefined;
-};
+type Expected = 'up' | 'down' | undefined;
+type Row = { label: string; route: NonNullable<Route>; target: Target; dest: string; src: string; expected: Expected };
 
-const runRow = ({ route, target, destinationName, sourceStationName, expected }: Row): void => {
-  expect(resolveAlarmDirection(target, { route, destinationName, sourceStationName })).toBe(
-    expected,
-  );
+// Row factory — 객체 리터럴 토큰 반복을 1줄로 압축해 Sonar 중복 감지를 차단한다 (#1063).
+// 대부분의 케이스가 dest='강남' / src='시청'을 공유하므로 default 값으로 둔다.
+const r = (
+  label: string,
+  route: NonNullable<Route>,
+  target: Target,
+  expected: Expected,
+  src = '시청',
+  dest = '강남',
+): Row => ({ label, route, target, dest, src, expected });
+
+const dest = (stationName: string): Target => ({ type: 'destination', stationName });
+const xfer = (stationName: string): Target => ({ type: 'transfer', stationName });
+
+const runRow = ({ route, target, dest: destinationName, src: sourceStationName, expected }: Row): void => {
+  expect(resolveAlarmDirection(target, { route, destinationName, sourceStationName })).toBe(expected);
 };
 
 describe('resolveAlarmDirection', () => {
@@ -57,38 +57,10 @@ describe('resolveAlarmDirection', () => {
     const loopDirect: NonNullable<Route> = makeDirectRoute(3, '5');
 
     const rows: Row[] = [
-      {
-        label: '대상역이 목적지이면 source→destination 방향을 반환한다',
-        route,
-        target: { type: 'destination', stationName: '강남' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: 'down',
-      },
-      {
-        label: '대상역이 목적지가 아니면 undefined',
-        route,
-        target: { type: 'destination', stationName: '다른역' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: undefined,
-      },
-      {
-        label: '방향 lookup이 null을 반환하면 undefined',
-        route,
-        target: { type: 'destination', stationName: '강남' },
-        destinationName: '강남',
-        sourceStationName: '없는역',
-        expected: undefined,
-      },
-      {
-        label: '루프 노선 fallback: direct route에서 monotonic이 null이면 loop 결과 사용 (#1063)',
-        route: loopDirect,
-        target: { type: 'destination', stationName: '왕십리' },
-        destinationName: '왕십리',
-        sourceStationName: '시청',
-        expected: 'down',
-      },
+      r('대상역이 목적지이면 source→destination 방향을 반환한다', route, dest('강남'), 'down'),
+      r('대상역이 목적지가 아니면 undefined', route, dest('다른역'), undefined),
+      r('방향 lookup이 null을 반환하면 undefined', route, dest('강남'), undefined, '없는역'),
+      r('루프 노선 fallback: direct route에서 monotonic이 null이면 loop 결과 사용 (#1063)', loopDirect, dest('왕십리'), 'down', '시청', '왕십리'),
     ];
 
     it.each(rows)('$label', runRow);
@@ -103,72 +75,17 @@ describe('resolveAlarmDirection', () => {
       stopsFromTransfer: 4,
     });
 
-    const makeLoopTransferRoute = (transferName: string, fromLine: LineNumber, toLine: LineNumber) =>
-      makeTransferRoute({
-        transferName,
-        fromLine,
-        toLine,
-        stopsToTransfer: 2,
-        stopsFromTransfer: 4,
-      });
+    const loopTransfer = (transferName: string, fromLine: LineNumber, toLine: LineNumber) =>
+      makeTransferRoute({ transferName, fromLine, toLine, stopsToTransfer: 2, stopsFromTransfer: 4 });
 
     const rows: Row[] = [
-      {
-        label: '대상역이 환승역이면 fromLine 기준 방향',
-        route,
-        target: { type: 'transfer', stationName: '동대문' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: 'down',
-      },
-      {
-        label: '대상역이 최종 목적지이면 toLine 기준 방향',
-        route,
-        target: { type: 'destination', stationName: '강남' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: 'up',
-      },
-      {
-        label: '대상역이 둘 다 아니면 undefined',
-        route,
-        target: { type: 'destination', stationName: '엉뚱역' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: undefined,
-      },
-      {
-        label: '방향 lookup이 null이면 undefined (환승역)',
-        route,
-        target: { type: 'transfer', stationName: '동대문' },
-        destinationName: '강남',
-        sourceStationName: '없는역',
-        expected: undefined,
-      },
-      {
-        label: '방향 lookup이 null이면 undefined (최종 목적지)',
-        route,
-        target: { type: 'destination', stationName: '없는역' },
-        destinationName: '없는역',
-        sourceStationName: '시청',
-        expected: undefined,
-      },
-      {
-        label: '루프 노선 fallback: transfer route 환승역 (#1063)',
-        route: makeLoopTransferRoute('왕십리', '5', '3'),
-        target: { type: 'transfer', stationName: '왕십리' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: 'down',
-      },
-      {
-        label: '루프 노선 fallback: transfer route 최종 목적지 (#1063)',
-        route: makeLoopTransferRoute('시청', '1', '5'),
-        target: { type: 'destination', stationName: '왕십리' },
-        destinationName: '왕십리',
-        sourceStationName: '동대문',
-        expected: 'down',
-      },
+      r('대상역이 환승역이면 fromLine 기준 방향', route, xfer('동대문'), 'down'),
+      r('대상역이 최종 목적지이면 toLine 기준 방향', route, dest('강남'), 'up'),
+      r('대상역이 둘 다 아니면 undefined', route, dest('엉뚱역'), undefined),
+      r('방향 lookup이 null이면 undefined (환승역)', route, xfer('동대문'), undefined, '없는역'),
+      r('방향 lookup이 null이면 undefined (최종 목적지)', route, dest('없는역'), undefined, '시청', '없는역'),
+      r('루프 노선 fallback: transfer route 환승역 (#1063)', loopTransfer('왕십리', '5', '3'), xfer('왕십리'), 'down'),
+      r('루프 노선 fallback: transfer route 최종 목적지 (#1063)', loopTransfer('시청', '1', '5'), dest('왕십리'), 'down', '동대문', '왕십리'),
     ];
 
     it.each(rows)('$label', runRow);
@@ -184,7 +101,7 @@ describe('resolveAlarmDirection', () => {
     });
 
     // 첫 환승 자리에 노선 '5'를 두고 sourceStationName→transferName 쌍만 다르게 검증 (#1063).
-    const makeLoopFirstHopRoute = (firstTransferName: string): NonNullable<Route> =>
+    const loopFirstHop = (firstTransferName: string): NonNullable<Route> =>
       makeMultiTransferRoute({
         transfers: [
           { transferName: firstTransferName, fromLine: '5', toLine: '3', stopsToTransfer: 3 },
@@ -193,7 +110,7 @@ describe('resolveAlarmDirection', () => {
         stopsAfterLastTransfer: 4,
       });
 
-    const routeWithNullableLine: NonNullable<Route> = makeMultiTransferRoute({
+    const nullableLine: NonNullable<Route> = makeMultiTransferRoute({
       transfers: [
         { transferName: '왕십리', fromLine: '3', toLine: '2', stopsToTransfer: 3 },
         { transferName: '교대', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
@@ -202,71 +119,18 @@ describe('resolveAlarmDirection', () => {
     });
 
     const rows: Row[] = [
-      {
-        label: '첫 번째 환승은 sourceStationName 기준',
-        route,
-        target: { type: 'transfer', stationName: '왕십리' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: 'down',
-      },
-      {
-        label: '두 번째 환승은 직전 환승역 기준 (해당 fromLine 사용)',
-        route,
-        target: { type: 'transfer', stationName: '교대' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: 'up',
-      },
-      {
-        label: '최종 목적지는 마지막 환승의 toLine 기준',
-        // toLine='3' → mock returns null → undefined
-        route,
-        target: { type: 'destination', stationName: '강남' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: undefined,
-      },
-      {
-        label: '대상역이 어디에도 매칭 안 되면 undefined',
-        route,
-        target: { type: 'transfer', stationName: '엉뚱역' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: undefined,
-      },
-      {
-        label: '루프 노선 fallback: monotonic이 null이면 inferLoopDirection 결과를 사용 (#1063)',
-        // 첫 환승의 fromLine='5' → monotonic null → loop fallback ('시청','왕십리') → 'down'.
-        route: makeLoopFirstHopRoute('왕십리'),
-        target: { type: 'transfer', stationName: '왕십리' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: 'down',
-      },
-      {
-        label: '루프 노선 fallback도 null이면 undefined',
-        // ('a','b') 쌍은 loop mock 매칭 안 됨 → 양쪽 모두 null → undefined.
-        route: makeLoopFirstHopRoute('b'),
-        target: { type: 'transfer', stationName: 'b' },
-        destinationName: '강남',
-        sourceStationName: 'a',
-        expected: undefined,
-      },
-      {
-        label: '환승 매칭은 됐지만 방향 lookup이 null이면 undefined',
-        route: routeWithNullableLine,
-        target: { type: 'transfer', stationName: '왕십리' },
-        destinationName: '강남',
-        sourceStationName: '시청',
-        expected: undefined,
-      },
+      r('첫 번째 환승은 sourceStationName 기준', route, xfer('왕십리'), 'down'),
+      r('두 번째 환승은 직전 환승역 기준 (해당 fromLine 사용)', route, xfer('교대'), 'up'),
+      r('최종 목적지는 마지막 환승의 toLine 기준', route, dest('강남'), undefined),
+      r('대상역이 어디에도 매칭 안 되면 undefined', route, xfer('엉뚱역'), undefined),
+      r('루프 노선 fallback: monotonic이 null이면 inferLoopDirection 결과를 사용 (#1063)', loopFirstHop('왕십리'), xfer('왕십리'), 'down'),
+      r('루프 노선 fallback도 null이면 undefined', loopFirstHop('b'), xfer('b'), undefined, 'a'),
+      r('환승 매칭은 됐지만 방향 lookup이 null이면 undefined', nullableLine, xfer('왕십리'), undefined),
     ];
 
     it.each(rows)('$label', runRow);
 
     it('추가 multi-transfer placeholder 한 건 (loop toLine 매칭 회귀 가드, #1063)', () => {
-      // last.toLine='5' placeholder 한 건 (mock 매칭 안 됨 → 환승 매칭 우선) 회귀 가드.
       const loopFallbackRoute: NonNullable<Route> = makeMultiTransferRoute({
         transfers: [{ transferName: '왕십리', fromLine: '1', toLine: '5', stopsToTransfer: 3 }],
         stopsAfterLastTransfer: 4,

--- a/src/features/alarm/utils/__tests__/alarmDirection.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmDirection.test.ts
@@ -1,5 +1,6 @@
 import { resolveAlarmDirection } from '../alarmDirection';
 import type { Route } from '../../../../shared/utils/stationRoute';
+import type { LineNumber } from '../../../../shared/types/station';
 import {
   makeDirectRoute,
   makeMultiTransferRoute,
@@ -62,13 +63,41 @@ describe('resolveAlarmDirection', () => {
     it('루프 노선 fallback: direct route에서 monotonic이 null이면 loop 결과 사용 (#1063)', () => {
       // line '5'는 monotonic mock에서 null. loop mock이 ('시청','왕십리') → 'down' 반환.
       const loopDirect: NonNullable<Route> = makeDirectRoute(3, '5');
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '왕십리' },
-        { route: loopDirect, destinationName: '왕십리', sourceStationName: '시청' },
-      );
-      expect(dir).toBe('down');
+      expect(
+        resolveAlarmDirection(
+          { type: 'destination', stationName: '왕십리' },
+          { route: loopDirect, destinationName: '왕십리', sourceStationName: '시청' },
+        ),
+      ).toBe('down');
     });
   });
+
+  // 루프 fallback 시나리오를 공통 헬퍼로 추출 (#1063 Sonar 중복 라인 게이트).
+  // 단순 transfer route + (target, source, destination) 조합만 다르므로 위임 형태로 줄인다.
+  const expectLoopTransferDir = (params: {
+    transferName: string;
+    fromLine: LineNumber;
+    toLine: LineNumber;
+    target: { type: 'transfer' | 'destination'; stationName: string };
+    destinationName: string;
+    sourceStationName: string;
+    expected: 'up' | 'down' | undefined;
+  }): void => {
+    const route: NonNullable<Route> = makeTransferRoute({
+      transferName: params.transferName,
+      fromLine: params.fromLine,
+      toLine: params.toLine,
+      stopsToTransfer: 2,
+      stopsFromTransfer: 4,
+    });
+    expect(
+      resolveAlarmDirection(params.target, {
+        route,
+        destinationName: params.destinationName,
+        sourceStationName: params.sourceStationName,
+      }),
+    ).toBe(params.expected);
+  };
 
   describe('transfer route', () => {
     const route: NonNullable<Route> = makeTransferRoute({
@@ -121,34 +150,28 @@ describe('resolveAlarmDirection', () => {
 
     it('루프 노선 fallback: transfer route 환승역 (#1063)', () => {
       // fromLine='5' → monotonic null → loop fallback. ('시청','왕십리') → 'down'.
-      const loopTransfer: NonNullable<Route> = makeTransferRoute({
+      expectLoopTransferDir({
         transferName: '왕십리',
         fromLine: '5',
         toLine: '3',
-        stopsToTransfer: 2,
-        stopsFromTransfer: 4,
+        target: { type: 'transfer', stationName: '왕십리' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: 'down',
       });
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '왕십리' },
-        { route: loopTransfer, destinationName: '강남', sourceStationName: '시청' },
-      );
-      expect(dir).toBe('down');
     });
 
     it('루프 노선 fallback: transfer route 최종 목적지 (#1063)', () => {
       // toLine='5' → monotonic null → loop fallback. transferName→destination 매칭.
-      const loopTransfer: NonNullable<Route> = makeTransferRoute({
+      expectLoopTransferDir({
         transferName: '시청',
         fromLine: '1',
         toLine: '5',
-        stopsToTransfer: 2,
-        stopsFromTransfer: 4,
+        target: { type: 'destination', stationName: '왕십리' },
+        destinationName: '왕십리',
+        sourceStationName: '동대문',
+        expected: 'down',
       });
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '왕십리' },
-        { route: loopTransfer, destinationName: '왕십리', sourceStationName: '동대문' },
-      );
-      expect(dir).toBe('down');
     });
   });
 
@@ -194,50 +217,41 @@ describe('resolveAlarmDirection', () => {
       expect(dir).toBeUndefined();
     });
 
-    it('루프 노선 fallback: monotonic이 null이면 inferLoopDirection 결과를 사용 (#1063)', () => {
-      // toLine='5'는 monotonic mock에서 null. loopDirection mock이 ('시청','왕십리')에 'down' 반환.
-      // route 전체 경로상 sourceStationName이 사용되지 않으므로 last.transferName → destination 방향만 평가.
-      const loopFallbackRoute: NonNullable<Route> = makeMultiTransferRoute({
+    // multi-transfer 루프 fallback 시나리오 공통 헬퍼 (#1063 Sonar 중복 라인 게이트).
+    // 첫 환승 자리에 노선 '5'를 두고 sourceStationName→transferName 쌍만 다르게 검증.
+    const makeLoopFirstHopRoute = (firstTransferName: string): NonNullable<Route> =>
+      makeMultiTransferRoute({
         transfers: [
-          { transferName: '왕십리', fromLine: '1', toLine: '5', stopsToTransfer: 3 },
-        ],
-        stopsAfterLastTransfer: 4,
-      });
-      // 최종 목적지 평가는 last.toLine='5', from=last.transferName='왕십리', to=destinationName.
-      // 위 시나리오는 from='왕십리'라 loop mock 매칭 안 됨 — 다른 케이스로 검증.
-      // 대신 transfer 매칭 케이스: fromLine='1'(monotonic)이므로 loop 호출 안 됨.
-      // 그래서 첫 환승 자리에 loop 노선을 두고 sourceStationName='시청'→transferName='왕십리'로 매칭.
-      const loopFirstHop: NonNullable<Route> = makeMultiTransferRoute({
-        transfers: [
-          { transferName: '왕십리', fromLine: '5', toLine: '3', stopsToTransfer: 3 },
+          { transferName: firstTransferName, fromLine: '5', toLine: '3', stopsToTransfer: 3 },
           { transferName: '교대', fromLine: '3', toLine: '1', stopsToTransfer: 5 },
         ],
         stopsAfterLastTransfer: 4,
       });
-      // monotonic mock: line '5' → null. loop mock: ('5','시청','왕십리') → 'down'.
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '왕십리' },
-        { route: loopFirstHop, destinationName: '강남', sourceStationName: '시청' },
-      );
-      expect(dir).toBe('down');
-      // loopFallbackRoute는 본 테스트의 라인 5 placeholder로만 사용 (eslint unused 회피용 ref).
+
+    it('루프 노선 fallback: monotonic이 null이면 inferLoopDirection 결과를 사용 (#1063)', () => {
+      // 첫 환승의 fromLine='5' → monotonic null → loop fallback ('시청','왕십리') → 'down'.
+      // 추가로 last.toLine='5' placeholder 한 건도 같이 검증 (mock 매칭 안 됨 → 환승 매칭 우선).
+      const loopFallbackRoute: NonNullable<Route> = makeMultiTransferRoute({
+        transfers: [{ transferName: '왕십리', fromLine: '1', toLine: '5', stopsToTransfer: 3 }],
+        stopsAfterLastTransfer: 4,
+      });
       expect(loopFallbackRoute.type).toBe('multi-transfer');
+      expect(
+        resolveAlarmDirection(
+          { type: 'transfer', stationName: '왕십리' },
+          { route: makeLoopFirstHopRoute('왕십리'), destinationName: '강남', sourceStationName: '시청' },
+        ),
+      ).toBe('down');
     });
 
     it('루프 노선 fallback도 null이면 undefined', () => {
-      // line='5'지만 loop mock이 매칭 안 되는 ('a','b') 쌍 — 양쪽 모두 null → undefined.
-      const loopRoute: NonNullable<Route> = makeMultiTransferRoute({
-        transfers: [
-          { transferName: 'b', fromLine: '5', toLine: '3', stopsToTransfer: 3 },
-          { transferName: '교대', fromLine: '3', toLine: '1', stopsToTransfer: 5 },
-        ],
-        stopsAfterLastTransfer: 4,
-      });
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: 'b' },
-        { route: loopRoute, destinationName: '강남', sourceStationName: 'a' },
-      );
-      expect(dir).toBeUndefined();
+      // ('a','b') 쌍은 loop mock 매칭 안 됨 → 양쪽 모두 null → undefined.
+      expect(
+        resolveAlarmDirection(
+          { type: 'transfer', stationName: 'b' },
+          { route: makeLoopFirstHopRoute('b'), destinationName: '강남', sourceStationName: 'a' },
+        ),
+      ).toBeUndefined();
     });
 
     it('환승 매칭은 됐지만 방향 lookup이 null이면 undefined', () => {

--- a/src/features/alarm/utils/__tests__/alarmDirection.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmDirection.test.ts
@@ -17,6 +17,16 @@ jest.mock('../../../route/utils/travelDirection', () => ({
   },
 }));
 
+jest.mock('../../../route/utils/loopDirection', () => ({
+  // 루프 fallback mock (#1063): 노선 '5'(monotonic mock에서 null)일 때만 매칭.
+  // 실제 inferLoopDirection은 2호선만 처리하지만, 본 테스트는 chaining 동작 검증 목적.
+  inferLoopDirection: (line: string, from: string, to: string) => {
+    if (line !== '5') return null;
+    if (from === '시청' && to === '왕십리') return 'down';
+    return null;
+  },
+}));
+
 jest.mock('../../../../shared/utils/stationRoute', () => ({
   isSameStationName: (a: string, b: string) => a === b,
 }));
@@ -47,6 +57,16 @@ describe('resolveAlarmDirection', () => {
         { route, destinationName: '강남', sourceStationName: '없는역' },
       );
       expect(dir).toBeUndefined();
+    });
+
+    it('루프 노선 fallback: direct route에서 monotonic이 null이면 loop 결과 사용 (#1063)', () => {
+      // line '5'는 monotonic mock에서 null. loop mock이 ('시청','왕십리') → 'down' 반환.
+      const loopDirect: NonNullable<Route> = makeDirectRoute(3, '5');
+      const dir = resolveAlarmDirection(
+        { type: 'destination', stationName: '왕십리' },
+        { route: loopDirect, destinationName: '왕십리', sourceStationName: '시청' },
+      );
+      expect(dir).toBe('down');
     });
   });
 
@@ -98,6 +118,38 @@ describe('resolveAlarmDirection', () => {
       );
       expect(dir).toBeUndefined();
     });
+
+    it('루프 노선 fallback: transfer route 환승역 (#1063)', () => {
+      // fromLine='5' → monotonic null → loop fallback. ('시청','왕십리') → 'down'.
+      const loopTransfer: NonNullable<Route> = makeTransferRoute({
+        transferName: '왕십리',
+        fromLine: '5',
+        toLine: '3',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 4,
+      });
+      const dir = resolveAlarmDirection(
+        { type: 'transfer', stationName: '왕십리' },
+        { route: loopTransfer, destinationName: '강남', sourceStationName: '시청' },
+      );
+      expect(dir).toBe('down');
+    });
+
+    it('루프 노선 fallback: transfer route 최종 목적지 (#1063)', () => {
+      // toLine='5' → monotonic null → loop fallback. transferName→destination 매칭.
+      const loopTransfer: NonNullable<Route> = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '1',
+        toLine: '5',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 4,
+      });
+      const dir = resolveAlarmDirection(
+        { type: 'destination', stationName: '왕십리' },
+        { route: loopTransfer, destinationName: '왕십리', sourceStationName: '동대문' },
+      );
+      expect(dir).toBe('down');
+    });
   });
 
   describe('multi-transfer route', () => {
@@ -138,6 +190,52 @@ describe('resolveAlarmDirection', () => {
       const dir = resolveAlarmDirection(
         { type: 'transfer', stationName: '엉뚱역' },
         { route, destinationName: '강남', sourceStationName: '시청' },
+      );
+      expect(dir).toBeUndefined();
+    });
+
+    it('루프 노선 fallback: monotonic이 null이면 inferLoopDirection 결과를 사용 (#1063)', () => {
+      // toLine='5'는 monotonic mock에서 null. loopDirection mock이 ('시청','왕십리')에 'down' 반환.
+      // route 전체 경로상 sourceStationName이 사용되지 않으므로 last.transferName → destination 방향만 평가.
+      const loopFallbackRoute: NonNullable<Route> = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '왕십리', fromLine: '1', toLine: '5', stopsToTransfer: 3 },
+        ],
+        stopsAfterLastTransfer: 4,
+      });
+      // 최종 목적지 평가는 last.toLine='5', from=last.transferName='왕십리', to=destinationName.
+      // 위 시나리오는 from='왕십리'라 loop mock 매칭 안 됨 — 다른 케이스로 검증.
+      // 대신 transfer 매칭 케이스: fromLine='1'(monotonic)이므로 loop 호출 안 됨.
+      // 그래서 첫 환승 자리에 loop 노선을 두고 sourceStationName='시청'→transferName='왕십리'로 매칭.
+      const loopFirstHop: NonNullable<Route> = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '왕십리', fromLine: '5', toLine: '3', stopsToTransfer: 3 },
+          { transferName: '교대', fromLine: '3', toLine: '1', stopsToTransfer: 5 },
+        ],
+        stopsAfterLastTransfer: 4,
+      });
+      // monotonic mock: line '5' → null. loop mock: ('5','시청','왕십리') → 'down'.
+      const dir = resolveAlarmDirection(
+        { type: 'transfer', stationName: '왕십리' },
+        { route: loopFirstHop, destinationName: '강남', sourceStationName: '시청' },
+      );
+      expect(dir).toBe('down');
+      // loopFallbackRoute는 본 테스트의 라인 5 placeholder로만 사용 (eslint unused 회피용 ref).
+      expect(loopFallbackRoute.type).toBe('multi-transfer');
+    });
+
+    it('루프 노선 fallback도 null이면 undefined', () => {
+      // line='5'지만 loop mock이 매칭 안 되는 ('a','b') 쌍 — 양쪽 모두 null → undefined.
+      const loopRoute: NonNullable<Route> = makeMultiTransferRoute({
+        transfers: [
+          { transferName: 'b', fromLine: '5', toLine: '3', stopsToTransfer: 3 },
+          { transferName: '교대', fromLine: '3', toLine: '1', stopsToTransfer: 5 },
+        ],
+        stopsAfterLastTransfer: 4,
+      });
+      const dir = resolveAlarmDirection(
+        { type: 'transfer', stationName: 'b' },
+        { route: loopRoute, destinationName: '강남', sourceStationName: 'a' },
       );
       expect(dir).toBeUndefined();
     });

--- a/src/features/alarm/utils/__tests__/alarmDirection.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmDirection.test.ts
@@ -32,42 +32,49 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   isSameStationName: (a: string, b: string) => a === b,
 }));
 
+// 공통 호출 헬퍼 (#1063 Sonar 중복 라인 게이트):
+// 모든 케이스가 (event, { route, destinationName, sourceStationName }) 형태로
+// resolveAlarmDirection을 호출하므로 위임 형태로 줄인다.
+type Target = { type: 'transfer' | 'destination'; stationName: string };
+const callResolve = (
+  route: NonNullable<Route>,
+  target: Target,
+  destinationName: string,
+  sourceStationName: string,
+) =>
+  resolveAlarmDirection(target, {
+    route,
+    destinationName,
+    sourceStationName,
+  });
+
 describe('resolveAlarmDirection', () => {
   describe('direct route', () => {
     const route: NonNullable<Route> = makeDirectRoute(3, '1');
 
     it('대상역이 목적지이면 source→destination 방향을 반환한다', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '강남' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
+      expect(callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '시청')).toBe(
+        'down',
       );
-      expect(dir).toBe('down');
     });
 
     it('대상역이 목적지가 아니면 undefined', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '다른역' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
-      );
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(route, { type: 'destination', stationName: '다른역' }, '강남', '시청'),
+      ).toBeUndefined();
     });
 
     it('방향 lookup이 null을 반환하면 undefined', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '강남' },
-        { route, destinationName: '강남', sourceStationName: '없는역' },
-      );
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '없는역'),
+      ).toBeUndefined();
     });
 
     it('루프 노선 fallback: direct route에서 monotonic이 null이면 loop 결과 사용 (#1063)', () => {
       // line '5'는 monotonic mock에서 null. loop mock이 ('시청','왕십리') → 'down' 반환.
       const loopDirect: NonNullable<Route> = makeDirectRoute(3, '5');
       expect(
-        resolveAlarmDirection(
-          { type: 'destination', stationName: '왕십리' },
-          { route: loopDirect, destinationName: '왕십리', sourceStationName: '시청' },
-        ),
+        callResolve(loopDirect, { type: 'destination', stationName: '왕십리' }, '왕십리', '시청'),
       ).toBe('down');
     });
   });
@@ -78,7 +85,7 @@ describe('resolveAlarmDirection', () => {
     transferName: string;
     fromLine: LineNumber;
     toLine: LineNumber;
-    target: { type: 'transfer' | 'destination'; stationName: string };
+    target: Target;
     destinationName: string;
     sourceStationName: string;
     expected: 'up' | 'down' | undefined;
@@ -91,11 +98,7 @@ describe('resolveAlarmDirection', () => {
       stopsFromTransfer: 4,
     });
     expect(
-      resolveAlarmDirection(params.target, {
-        route,
-        destinationName: params.destinationName,
-        sourceStationName: params.sourceStationName,
-      }),
+      callResolve(route, params.target, params.destinationName, params.sourceStationName),
     ).toBe(params.expected);
   };
 
@@ -109,43 +112,33 @@ describe('resolveAlarmDirection', () => {
     });
 
     it('대상역이 환승역이면 fromLine 기준 방향', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '동대문' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
+      expect(callResolve(route, { type: 'transfer', stationName: '동대문' }, '강남', '시청')).toBe(
+        'down',
       );
-      expect(dir).toBe('down');
     });
 
     it('대상역이 최종 목적지이면 toLine 기준 방향', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '강남' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
-      );
-      expect(dir).toBe('up');
+      expect(
+        callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '시청'),
+      ).toBe('up');
     });
 
     it('대상역이 둘 다 아니면 undefined', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '엉뚱역' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
-      );
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(route, { type: 'destination', stationName: '엉뚱역' }, '강남', '시청'),
+      ).toBeUndefined();
     });
 
     it('방향 lookup이 null이면 undefined (환승역)', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '동대문' },
-        { route, destinationName: '강남', sourceStationName: '없는역' },
-      );
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(route, { type: 'transfer', stationName: '동대문' }, '강남', '없는역'),
+      ).toBeUndefined();
     });
 
     it('방향 lookup이 null이면 undefined (최종 목적지)', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '없는역' },
-        { route, destinationName: '없는역', sourceStationName: '시청' },
-      );
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(route, { type: 'destination', stationName: '없는역' }, '없는역', '시청'),
+      ).toBeUndefined();
     });
 
     it('루프 노선 fallback: transfer route 환승역 (#1063)', () => {
@@ -185,36 +178,28 @@ describe('resolveAlarmDirection', () => {
     });
 
     it('첫 번째 환승은 sourceStationName 기준', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '왕십리' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
+      expect(callResolve(route, { type: 'transfer', stationName: '왕십리' }, '강남', '시청')).toBe(
+        'down',
       );
-      expect(dir).toBe('down');
     });
 
     it('두 번째 환승은 직전 환승역 기준 (해당 fromLine 사용)', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '교대' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
+      expect(callResolve(route, { type: 'transfer', stationName: '교대' }, '강남', '시청')).toBe(
+        'up',
       );
-      expect(dir).toBe('up');
     });
 
     it('최종 목적지는 마지막 환승의 toLine 기준', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'destination', stationName: '강남' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
-      );
       // toLine='3' → mock returns null → undefined
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '시청'),
+      ).toBeUndefined();
     });
 
     it('대상역이 어디에도 매칭 안 되면 undefined', () => {
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '엉뚱역' },
-        { route, destinationName: '강남', sourceStationName: '시청' },
-      );
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(route, { type: 'transfer', stationName: '엉뚱역' }, '강남', '시청'),
+      ).toBeUndefined();
     });
 
     // multi-transfer 루프 fallback 시나리오 공통 헬퍼 (#1063 Sonar 중복 라인 게이트).
@@ -237,9 +222,11 @@ describe('resolveAlarmDirection', () => {
       });
       expect(loopFallbackRoute.type).toBe('multi-transfer');
       expect(
-        resolveAlarmDirection(
+        callResolve(
+          makeLoopFirstHopRoute('왕십리'),
           { type: 'transfer', stationName: '왕십리' },
-          { route: makeLoopFirstHopRoute('왕십리'), destinationName: '강남', sourceStationName: '시청' },
+          '강남',
+          '시청',
         ),
       ).toBe('down');
     });
@@ -247,9 +234,11 @@ describe('resolveAlarmDirection', () => {
     it('루프 노선 fallback도 null이면 undefined', () => {
       // ('a','b') 쌍은 loop mock 매칭 안 됨 → 양쪽 모두 null → undefined.
       expect(
-        resolveAlarmDirection(
+        callResolve(
+          makeLoopFirstHopRoute('b'),
           { type: 'transfer', stationName: 'b' },
-          { route: makeLoopFirstHopRoute('b'), destinationName: '강남', sourceStationName: 'a' },
+          '강남',
+          'a',
         ),
       ).toBeUndefined();
     });
@@ -262,11 +251,14 @@ describe('resolveAlarmDirection', () => {
         ],
         stopsAfterLastTransfer: 4,
       });
-      const dir = resolveAlarmDirection(
-        { type: 'transfer', stationName: '왕십리' },
-        { route: routeWithNullableLine, destinationName: '강남', sourceStationName: '시청' },
-      );
-      expect(dir).toBeUndefined();
+      expect(
+        callResolve(
+          routeWithNullableLine,
+          { type: 'transfer', stationName: '왕십리' },
+          '강남',
+          '시청',
+        ),
+      ).toBeUndefined();
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/alarmDirection.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmDirection.test.ts
@@ -32,75 +32,67 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   isSameStationName: (a: string, b: string) => a === b,
 }));
 
-// 공통 호출 헬퍼 (#1063 Sonar 중복 라인 게이트):
-// 모든 케이스가 (event, { route, destinationName, sourceStationName }) 형태로
-// resolveAlarmDirection을 호출하므로 위임 형태로 줄인다.
+// 데이터 주도 테스트용 row 타입 (#1063 Sonar 중복 라인 게이트):
+// 모든 케이스가 (route, target, destinationName, sourceStationName) → expected 형태이므로
+// row 배열을 it.each로 돌려 호출 패턴 중복을 제거한다.
 type Target = { type: 'transfer' | 'destination'; stationName: string };
-const callResolve = (
-  route: NonNullable<Route>,
-  target: Target,
-  destinationName: string,
-  sourceStationName: string,
-) =>
-  resolveAlarmDirection(target, {
-    route,
-    destinationName,
-    sourceStationName,
-  });
+type Row = {
+  label: string;
+  route: NonNullable<Route>;
+  target: Target;
+  destinationName: string;
+  sourceStationName: string;
+  expected: 'up' | 'down' | undefined;
+};
+
+const runRow = ({ route, target, destinationName, sourceStationName, expected }: Row): void => {
+  expect(resolveAlarmDirection(target, { route, destinationName, sourceStationName })).toBe(
+    expected,
+  );
+};
 
 describe('resolveAlarmDirection', () => {
   describe('direct route', () => {
     const route: NonNullable<Route> = makeDirectRoute(3, '1');
+    const loopDirect: NonNullable<Route> = makeDirectRoute(3, '5');
 
-    it('대상역이 목적지이면 source→destination 방향을 반환한다', () => {
-      expect(callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '시청')).toBe(
-        'down',
-      );
-    });
+    const rows: Row[] = [
+      {
+        label: '대상역이 목적지이면 source→destination 방향을 반환한다',
+        route,
+        target: { type: 'destination', stationName: '강남' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: 'down',
+      },
+      {
+        label: '대상역이 목적지가 아니면 undefined',
+        route,
+        target: { type: 'destination', stationName: '다른역' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: undefined,
+      },
+      {
+        label: '방향 lookup이 null을 반환하면 undefined',
+        route,
+        target: { type: 'destination', stationName: '강남' },
+        destinationName: '강남',
+        sourceStationName: '없는역',
+        expected: undefined,
+      },
+      {
+        label: '루프 노선 fallback: direct route에서 monotonic이 null이면 loop 결과 사용 (#1063)',
+        route: loopDirect,
+        target: { type: 'destination', stationName: '왕십리' },
+        destinationName: '왕십리',
+        sourceStationName: '시청',
+        expected: 'down',
+      },
+    ];
 
-    it('대상역이 목적지가 아니면 undefined', () => {
-      expect(
-        callResolve(route, { type: 'destination', stationName: '다른역' }, '강남', '시청'),
-      ).toBeUndefined();
-    });
-
-    it('방향 lookup이 null을 반환하면 undefined', () => {
-      expect(
-        callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '없는역'),
-      ).toBeUndefined();
-    });
-
-    it('루프 노선 fallback: direct route에서 monotonic이 null이면 loop 결과 사용 (#1063)', () => {
-      // line '5'는 monotonic mock에서 null. loop mock이 ('시청','왕십리') → 'down' 반환.
-      const loopDirect: NonNullable<Route> = makeDirectRoute(3, '5');
-      expect(
-        callResolve(loopDirect, { type: 'destination', stationName: '왕십리' }, '왕십리', '시청'),
-      ).toBe('down');
-    });
+    it.each(rows)('$label', runRow);
   });
-
-  // 루프 fallback 시나리오를 공통 헬퍼로 추출 (#1063 Sonar 중복 라인 게이트).
-  // 단순 transfer route + (target, source, destination) 조합만 다르므로 위임 형태로 줄인다.
-  const expectLoopTransferDir = (params: {
-    transferName: string;
-    fromLine: LineNumber;
-    toLine: LineNumber;
-    target: Target;
-    destinationName: string;
-    sourceStationName: string;
-    expected: 'up' | 'down' | undefined;
-  }): void => {
-    const route: NonNullable<Route> = makeTransferRoute({
-      transferName: params.transferName,
-      fromLine: params.fromLine,
-      toLine: params.toLine,
-      stopsToTransfer: 2,
-      stopsFromTransfer: 4,
-    });
-    expect(
-      callResolve(route, params.target, params.destinationName, params.sourceStationName),
-    ).toBe(params.expected);
-  };
 
   describe('transfer route', () => {
     const route: NonNullable<Route> = makeTransferRoute({
@@ -111,61 +103,75 @@ describe('resolveAlarmDirection', () => {
       stopsFromTransfer: 4,
     });
 
-    it('대상역이 환승역이면 fromLine 기준 방향', () => {
-      expect(callResolve(route, { type: 'transfer', stationName: '동대문' }, '강남', '시청')).toBe(
-        'down',
-      );
-    });
+    const makeLoopTransferRoute = (transferName: string, fromLine: LineNumber, toLine: LineNumber) =>
+      makeTransferRoute({
+        transferName,
+        fromLine,
+        toLine,
+        stopsToTransfer: 2,
+        stopsFromTransfer: 4,
+      });
 
-    it('대상역이 최종 목적지이면 toLine 기준 방향', () => {
-      expect(
-        callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '시청'),
-      ).toBe('up');
-    });
-
-    it('대상역이 둘 다 아니면 undefined', () => {
-      expect(
-        callResolve(route, { type: 'destination', stationName: '엉뚱역' }, '강남', '시청'),
-      ).toBeUndefined();
-    });
-
-    it('방향 lookup이 null이면 undefined (환승역)', () => {
-      expect(
-        callResolve(route, { type: 'transfer', stationName: '동대문' }, '강남', '없는역'),
-      ).toBeUndefined();
-    });
-
-    it('방향 lookup이 null이면 undefined (최종 목적지)', () => {
-      expect(
-        callResolve(route, { type: 'destination', stationName: '없는역' }, '없는역', '시청'),
-      ).toBeUndefined();
-    });
-
-    it('루프 노선 fallback: transfer route 환승역 (#1063)', () => {
-      // fromLine='5' → monotonic null → loop fallback. ('시청','왕십리') → 'down'.
-      expectLoopTransferDir({
-        transferName: '왕십리',
-        fromLine: '5',
-        toLine: '3',
+    const rows: Row[] = [
+      {
+        label: '대상역이 환승역이면 fromLine 기준 방향',
+        route,
+        target: { type: 'transfer', stationName: '동대문' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: 'down',
+      },
+      {
+        label: '대상역이 최종 목적지이면 toLine 기준 방향',
+        route,
+        target: { type: 'destination', stationName: '강남' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: 'up',
+      },
+      {
+        label: '대상역이 둘 다 아니면 undefined',
+        route,
+        target: { type: 'destination', stationName: '엉뚱역' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: undefined,
+      },
+      {
+        label: '방향 lookup이 null이면 undefined (환승역)',
+        route,
+        target: { type: 'transfer', stationName: '동대문' },
+        destinationName: '강남',
+        sourceStationName: '없는역',
+        expected: undefined,
+      },
+      {
+        label: '방향 lookup이 null이면 undefined (최종 목적지)',
+        route,
+        target: { type: 'destination', stationName: '없는역' },
+        destinationName: '없는역',
+        sourceStationName: '시청',
+        expected: undefined,
+      },
+      {
+        label: '루프 노선 fallback: transfer route 환승역 (#1063)',
+        route: makeLoopTransferRoute('왕십리', '5', '3'),
         target: { type: 'transfer', stationName: '왕십리' },
         destinationName: '강남',
         sourceStationName: '시청',
         expected: 'down',
-      });
-    });
-
-    it('루프 노선 fallback: transfer route 최종 목적지 (#1063)', () => {
-      // toLine='5' → monotonic null → loop fallback. transferName→destination 매칭.
-      expectLoopTransferDir({
-        transferName: '시청',
-        fromLine: '1',
-        toLine: '5',
+      },
+      {
+        label: '루프 노선 fallback: transfer route 최종 목적지 (#1063)',
+        route: makeLoopTransferRoute('시청', '1', '5'),
         target: { type: 'destination', stationName: '왕십리' },
         destinationName: '왕십리',
         sourceStationName: '동대문',
         expected: 'down',
-      });
-    });
+      },
+    ];
+
+    it.each(rows)('$label', runRow);
   });
 
   describe('multi-transfer route', () => {
@@ -177,33 +183,7 @@ describe('resolveAlarmDirection', () => {
       stopsAfterLastTransfer: 4,
     });
 
-    it('첫 번째 환승은 sourceStationName 기준', () => {
-      expect(callResolve(route, { type: 'transfer', stationName: '왕십리' }, '강남', '시청')).toBe(
-        'down',
-      );
-    });
-
-    it('두 번째 환승은 직전 환승역 기준 (해당 fromLine 사용)', () => {
-      expect(callResolve(route, { type: 'transfer', stationName: '교대' }, '강남', '시청')).toBe(
-        'up',
-      );
-    });
-
-    it('최종 목적지는 마지막 환승의 toLine 기준', () => {
-      // toLine='3' → mock returns null → undefined
-      expect(
-        callResolve(route, { type: 'destination', stationName: '강남' }, '강남', '시청'),
-      ).toBeUndefined();
-    });
-
-    it('대상역이 어디에도 매칭 안 되면 undefined', () => {
-      expect(
-        callResolve(route, { type: 'transfer', stationName: '엉뚱역' }, '강남', '시청'),
-      ).toBeUndefined();
-    });
-
-    // multi-transfer 루프 fallback 시나리오 공통 헬퍼 (#1063 Sonar 중복 라인 게이트).
-    // 첫 환승 자리에 노선 '5'를 두고 sourceStationName→transferName 쌍만 다르게 검증.
+    // 첫 환승 자리에 노선 '5'를 두고 sourceStationName→transferName 쌍만 다르게 검증 (#1063).
     const makeLoopFirstHopRoute = (firstTransferName: string): NonNullable<Route> =>
       makeMultiTransferRoute({
         transfers: [
@@ -213,52 +193,85 @@ describe('resolveAlarmDirection', () => {
         stopsAfterLastTransfer: 4,
       });
 
-    it('루프 노선 fallback: monotonic이 null이면 inferLoopDirection 결과를 사용 (#1063)', () => {
-      // 첫 환승의 fromLine='5' → monotonic null → loop fallback ('시청','왕십리') → 'down'.
-      // 추가로 last.toLine='5' placeholder 한 건도 같이 검증 (mock 매칭 안 됨 → 환승 매칭 우선).
+    const routeWithNullableLine: NonNullable<Route> = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '왕십리', fromLine: '3', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '교대', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    });
+
+    const rows: Row[] = [
+      {
+        label: '첫 번째 환승은 sourceStationName 기준',
+        route,
+        target: { type: 'transfer', stationName: '왕십리' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: 'down',
+      },
+      {
+        label: '두 번째 환승은 직전 환승역 기준 (해당 fromLine 사용)',
+        route,
+        target: { type: 'transfer', stationName: '교대' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: 'up',
+      },
+      {
+        label: '최종 목적지는 마지막 환승의 toLine 기준',
+        // toLine='3' → mock returns null → undefined
+        route,
+        target: { type: 'destination', stationName: '강남' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: undefined,
+      },
+      {
+        label: '대상역이 어디에도 매칭 안 되면 undefined',
+        route,
+        target: { type: 'transfer', stationName: '엉뚱역' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: undefined,
+      },
+      {
+        label: '루프 노선 fallback: monotonic이 null이면 inferLoopDirection 결과를 사용 (#1063)',
+        // 첫 환승의 fromLine='5' → monotonic null → loop fallback ('시청','왕십리') → 'down'.
+        route: makeLoopFirstHopRoute('왕십리'),
+        target: { type: 'transfer', stationName: '왕십리' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: 'down',
+      },
+      {
+        label: '루프 노선 fallback도 null이면 undefined',
+        // ('a','b') 쌍은 loop mock 매칭 안 됨 → 양쪽 모두 null → undefined.
+        route: makeLoopFirstHopRoute('b'),
+        target: { type: 'transfer', stationName: 'b' },
+        destinationName: '강남',
+        sourceStationName: 'a',
+        expected: undefined,
+      },
+      {
+        label: '환승 매칭은 됐지만 방향 lookup이 null이면 undefined',
+        route: routeWithNullableLine,
+        target: { type: 'transfer', stationName: '왕십리' },
+        destinationName: '강남',
+        sourceStationName: '시청',
+        expected: undefined,
+      },
+    ];
+
+    it.each(rows)('$label', runRow);
+
+    it('추가 multi-transfer placeholder 한 건 (loop toLine 매칭 회귀 가드, #1063)', () => {
+      // last.toLine='5' placeholder 한 건 (mock 매칭 안 됨 → 환승 매칭 우선) 회귀 가드.
       const loopFallbackRoute: NonNullable<Route> = makeMultiTransferRoute({
         transfers: [{ transferName: '왕십리', fromLine: '1', toLine: '5', stopsToTransfer: 3 }],
         stopsAfterLastTransfer: 4,
       });
       expect(loopFallbackRoute.type).toBe('multi-transfer');
-      expect(
-        callResolve(
-          makeLoopFirstHopRoute('왕십리'),
-          { type: 'transfer', stationName: '왕십리' },
-          '강남',
-          '시청',
-        ),
-      ).toBe('down');
-    });
-
-    it('루프 노선 fallback도 null이면 undefined', () => {
-      // ('a','b') 쌍은 loop mock 매칭 안 됨 → 양쪽 모두 null → undefined.
-      expect(
-        callResolve(
-          makeLoopFirstHopRoute('b'),
-          { type: 'transfer', stationName: 'b' },
-          '강남',
-          'a',
-        ),
-      ).toBeUndefined();
-    });
-
-    it('환승 매칭은 됐지만 방향 lookup이 null이면 undefined', () => {
-      const routeWithNullableLine: NonNullable<Route> = makeMultiTransferRoute({
-        transfers: [
-          { transferName: '왕십리', fromLine: '3', toLine: '2', stopsToTransfer: 3 },
-          { transferName: '교대', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
-        ],
-        stopsAfterLastTransfer: 4,
-      });
-      expect(
-        callResolve(
-          routeWithNullableLine,
-          { type: 'transfer', stationName: '왕십리' },
-          '강남',
-          '시청',
-        ),
-      ).toBeUndefined();
     });
   });
 });

--- a/src/features/alarm/utils/alarmDirection.ts
+++ b/src/features/alarm/utils/alarmDirection.ts
@@ -10,13 +10,23 @@ import type { AlarmEvent } from './stationAlarm';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { isSameStationName } from '../../../shared/utils/stationRoute';
 import type { TravelDirection } from '../../../shared/types/exitSide';
+import type { LineNumber } from '../../../shared/types/station';
 import { resolveTravelDirection } from '../../route/utils/travelDirection';
+import { inferLoopDirection } from '../../route/utils/loopDirection';
 
 interface ResolveAlarmDirectionInput {
   route: NonNullable<Route>;
   destinationName: string;
   // 사용자가 현재 탑승해 있는 출발역. DirectRoute나 첫 환승 전 구간의 방향을 결정한다.
   sourceStationName: string;
+}
+
+// 단조 노선은 resolveTravelDirection이, 순환선(2호선)은 inferLoopDirection이 처리(#1063).
+// 양쪽 모두 매칭 실패면 undefined — 알람 본문에서 방향 표시를 생략한다.
+function directionFor(line: LineNumber, from: string, to: string): TravelDirection | undefined {
+  const monotonic = resolveTravelDirection(line, from, to)?.direction;
+  if (monotonic) return monotonic;
+  return inferLoopDirection(line, from, to) ?? undefined;
 }
 
 // 알람 이벤트의 대상역까지 가는 마지막 구간을 찾아, 그 구간의 노선/출발/도착으로
@@ -28,15 +38,15 @@ export function resolveAlarmDirection(
 ): TravelDirection | undefined {
   if (route.type === 'direct') {
     if (!isSameStationName(event.stationName, destinationName)) return undefined;
-    return resolveTravelDirection(route.line, sourceStationName, destinationName)?.direction;
+    return directionFor(route.line, sourceStationName, destinationName);
   }
 
   if (route.type === 'transfer') {
     if (isSameStationName(event.stationName, route.transferName)) {
-      return resolveTravelDirection(route.fromLine, sourceStationName, route.transferName)?.direction;
+      return directionFor(route.fromLine, sourceStationName, route.transferName);
     }
     if (isSameStationName(event.stationName, destinationName)) {
-      return resolveTravelDirection(route.toLine, route.transferName, destinationName)?.direction;
+      return directionFor(route.toLine, route.transferName, destinationName);
     }
     return undefined;
   }
@@ -47,11 +57,11 @@ export function resolveAlarmDirection(
     const segment = transfers[i];
     if (!isSameStationName(event.stationName, segment.transferName)) continue;
     const prevAnchor = i === 0 ? sourceStationName : transfers[i - 1].transferName;
-    return resolveTravelDirection(segment.fromLine, prevAnchor, segment.transferName)?.direction;
+    return directionFor(segment.fromLine, prevAnchor, segment.transferName);
   }
   if (isSameStationName(event.stationName, destinationName)) {
     const last = transfers.at(-1)!;
-    return resolveTravelDirection(last.toLine, last.transferName, destinationName)?.direction;
+    return directionFor(last.toLine, last.transferName, destinationName);
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- PR #1048에서 도입된 `inferLoopDirection`을 `resolveAlarmDirection`의 4개 call site에 wiring
- `resolveTravelDirection`(monotonic) null 시 `inferLoopDirection`으로 fallback하는 `directionFor` 헬퍼로 통합
- 2호선(순환선) 알람 본문에 상행/하행 표기가 누락되던 회귀 해소

## 범위
- 수정: `src/features/alarm/utils/alarmDirection.ts` — 4개 call site → `directionFor` 헬퍼
- 테스트: `src/features/alarm/utils/__tests__/alarmDirection.test.ts` — loop fallback case 4종(direct / transfer 환승역 / transfer 최종 목적지 / multi-transfer 첫 환승) + null fallback 1종
- util 본체(`loopDirection.ts`) 미변경

## 범위 외 (별도 후속)
- `nextAdjacentStation.ts` — 인접역 계산은 loop-aware adjacent 별도 설계 필요
- `EditorialTimeline.tsx` — `toStation.id` 의존 → loop fallback은 별도 설계
- `parseTrainLineDirection` wiring (Seoul API arrival parser) — 별도 이슈

## Test plan
- [x] `npm test` 4285/4285 pass, 전역 커버리지 100% 유지
- [x] `alarmDirection.ts` 100% statement/branch/function/line
- [x] `npx tsc --noEmit` clean
- [x] `eslint` clean
- [ ] 실기기: 2호선 트립에서 알람 본문에 상/하행 표시 확인

Closes #1063