### PR TITLE
refactor(#1065): firstLeg shared util 추출

### DIFF
--- a/src/features/alarm/utils/boardingPromptContext.ts
+++ b/src/features/alarm/utils/boardingPromptContext.ts
@@ -26,14 +26,13 @@
  *   - line: 첫 leg 라인 (boarding 단계 노선)
  *
  * `currentStation === null`이거나 next/lookup 실패 시 null 반환 — backend는 자동 skip.
- *
- * TODO(#1028 follow-up): firstLeg 추출은 tripDirection.ts에도 중복 존재. shared util로 분리 예정.
  */
 
-import type { Station, LineNumber } from '../../../shared/types/station';
+import type { Station } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
 import {
   findStationByNameAndLine,
+  getFirstLeg,
   getNextStationName,
 } from '../../../shared/utils/stationRoute';
 import { resolveTravelDirection } from '../../route/utils/travelDirection';
@@ -56,22 +55,6 @@ interface BuildInputs {
   destination: Station | null;
 }
 
-interface FirstLeg {
-  line: LineNumber;
-  endName: string;
-}
-
-function firstLeg(route: NonNullable<Route>, destinationName: string): FirstLeg {
-  if (route.type === 'direct') {
-    return { line: route.line, endName: destinationName };
-  }
-  if (route.type === 'transfer') {
-    return { line: route.fromLine, endName: route.transferName };
-  }
-  const first = route.transfers[0];
-  return { line: first.fromLine, endName: first.transferName };
-}
-
 export function buildBoardingPromptContext({
   route,
   currentStation,
@@ -79,7 +62,7 @@ export function buildBoardingPromptContext({
 }: BuildInputs): BoardingPromptContext | null {
   if (!route || !currentStation || !destination) return null;
 
-  const leg = firstLeg(route, destination.name);
+  const leg = getFirstLeg(route, destination.name);
   const nextName = getNextStationName(currentStation.id, destination.id, route);
   if (!nextName) return null;
 

--- a/src/features/route/utils/tripDirection.ts
+++ b/src/features/route/utils/tripDirection.ts
@@ -1,6 +1,5 @@
-import type { LineNumber } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
-import { getStationsOnLine } from '../../../shared/utils/stationRoute';
+import { getFirstLeg, getStationsOnLine } from '../../../shared/utils/stationRoute';
 
 export type TripDirection = 'up' | 'down';
 
@@ -20,24 +19,10 @@ export function resolveTripDirection(
   destinationName: string,
   currentStationId: string,
 ): TripDirection | null {
-  const { line, nextWaypointName } = firstLeg(route, destinationName);
+  const { line, endName } = getFirstLeg(route, destinationName);
   const lineStations = getStationsOnLine(line);
   const currIdx = lineStations.findIndex((s) => s.id === currentStationId);
-  const nextIdx = lineStations.findIndex((s) => s.name === nextWaypointName);
+  const nextIdx = lineStations.findIndex((s) => s.name === endName);
   if (currIdx < 0 || nextIdx < 0 || currIdx === nextIdx) return null;
   return nextIdx > currIdx ? 'down' : 'up';
-}
-
-function firstLeg(
-  route: NonNullable<Route>,
-  destinationName: string,
-): { line: LineNumber; nextWaypointName: string } {
-  if (route.type === 'direct') {
-    return { line: route.line, nextWaypointName: destinationName };
-  }
-  if (route.type === 'transfer') {
-    return { line: route.fromLine, nextWaypointName: route.transferName };
-  }
-  const first = route.transfers[0];
-  return { line: first.fromLine, nextWaypointName: first.transferName };
 }

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, getFirstLeg, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 import {
@@ -1522,6 +1522,35 @@ describe('updateRouteFromPosition', () => {
       const result = updateRouteFromPosition(storedMultiRoute, jangam7, '1-001');
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('getFirstLeg', () => {
+  it('direct route → { line, endName: destinationName }', () => {
+    const route = makeDirectRoute(3, '2');
+    expect(getFirstLeg(route, '강남')).toEqual({ line: '2', endName: '강남' });
+  });
+
+  it('transfer route → { line: fromLine, endName: transferName }', () => {
+    const route = makeTransferRoute({
+      transferName: '서울역',
+      fromLine: '1',
+      toLine: '4',
+      stopsToTransfer: 5,
+      stopsFromTransfer: 3,
+    });
+    expect(getFirstLeg(route, '강남')).toEqual({ line: '1', endName: '서울역' });
+  });
+
+  it('multi-transfer route → { line: transfers[0].fromLine, endName: transfers[0].transferName }', () => {
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 5 },
+        { transferName: '명동', fromLine: '4', toLine: '2', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 2,
+    });
+    expect(getFirstLeg(route, '강남')).toEqual({ line: '1', endName: '서울역' });
   });
 });
 

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -347,6 +347,30 @@ export function updateRouteFromPosition(
   return null;
 }
 
+/**
+ * 경로의 첫 leg(=탑승 단계)의 노선과 종점 역 이름을 반환한다.
+ *
+ *   - direct       → { line, endName: destinationName }
+ *   - transfer     → { line: fromLine, endName: transferName }
+ *   - multiTransfer→ { line: transfers[0].fromLine, endName: transfers[0].transferName }
+ *
+ * "endName"은 첫 leg에서 사용자가 향하는 노선상 종점(다음 환승 지점 또는 최종 목적지) 이름.
+ * tripDirection / boardingPromptContext가 공통으로 사용 — #1028 follow-up (#1065).
+ */
+export function getFirstLeg(
+  route: NonNullable<Route>,
+  destinationName: string,
+): { line: LineNumber; endName: string } {
+  if (route.type === 'direct') {
+    return { line: route.line, endName: destinationName };
+  }
+  if (route.type === 'transfer') {
+    return { line: route.fromLine, endName: route.transferName };
+  }
+  const first = route.transfers[0];
+  return { line: first.fromLine, endName: first.transferName };
+}
+
 export function isStationOnRoute(station: Station, route: NonNullable<Route>): boolean {
   if (route.type === 'direct') {
     return station.line === route.line;


### PR DESCRIPTION
Closes #1065

## 배경

ADR-011 (#1054) 및 PR #1030의 `boardingPromptContext.ts` TODO에서 명시된 firstLeg 중복.

- `src/features/alarm/utils/boardingPromptContext.ts` — private `firstLeg` (#1030 머지)
- `src/features/route/utils/tripDirection.ts` — private `firstLeg`

두 구현은 의미상 동일:
- `direct` → `{ line, destinationName }`
- `transfer` → `{ fromLine, transferName }`
- `multi-transfer` → `{ transfers[0].fromLine, transfers[0].transferName }`

차이는 반환 키 이름뿐 (`endName` vs `nextWaypointName`).

## 변경

- `src/shared/utils/stationRoute.ts`에 `getFirstLeg(route, destinationName) → { line, endName }` 추가
- 두 consumer가 새 util 사용 (private 사본 제거)
- `boardingPromptContext.ts`의 `#1028 follow-up` TODO 주석 정리

## 검증

- `npm run type-check` pass
- `npm run lint` pass
- `npm test` — 234 suites, 4283 tests pass (100% coverage)
- 새 `getFirstLeg` 단위 테스트 3건 (direct/transfer/multi-transfer)