### PR TITLE
feat(#1066): ServiceWindowBanner 공용 컴포넌트 (운행 시간 외 안내)

### DIFF
--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "Get off",
       "boardingLockReleaseHint": "Ends the current boarding session"
     }
+  },
+  "service": {
+    "window": {
+      "preFirst": "Before first train · first train at {{time}}",
+      "postLast": "After last train · first train tomorrow at {{time}}"
+    }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "降車",
       "boardingLockReleaseHint": "現在の乗車を終了します"
     }
+  },
+  "service": {
+    "window": {
+      "preFirst": "始発前 · 始発 {{time}} 予定",
+      "postLast": "終電後 · 明日の始発 {{time}}"
+    }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "하차",
       "boardingLockReleaseHint": "현재 탑승 상태를 종료합니다"
     }
+  },
+  "service": {
+    "window": {
+      "preFirst": "첫차 전 · 첫차 {{time}} 예정",
+      "postLast": "막차 후 · 내일 첫차 {{time}}"
+    }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -284,5 +284,11 @@
       "boardingLockReleaseLabel": "下车",
       "boardingLockReleaseHint": "结束当前乘车状态"
     }
+  },
+  "service": {
+    "window": {
+      "preFirst": "首班车前 · 首班车 {{time}}",
+      "postLast": "末班车后 · 明日首班车 {{time}}"
+    }
   }
 }

--- a/src/shared/ui/ServiceWindowBanner.tsx
+++ b/src/shared/ui/ServiceWindowBanner.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable import/no-restricted-paths --
+ * `getServiceWindow`는 1~9호선 timetable JSON과 강하게 결합되어 있어 도메인 슬라이스
+ * `src/features/route/utils/`에 위치한다. 본 배너는 여러 feature 화면(HomeScreen 등)에서
+ * 공통으로 노출될 운행시간 외 안내 UI이므로 shared/ui에 두고, util 참조만 file-level로
+ * 옵트인 처리한다 (#1066).
+ */
+import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import type { LineNumber } from '../types/station';
+import { getServiceWindow } from '../../features/route/utils/serviceWindow';
+import { useTheme, typography, spacing, radius } from '../theme';
+
+interface Props {
+  stationName: string;
+  line: LineNumber;
+  /** 미지정 시 `new Date()`. 테스트/스토리북 등에서 주입 가능. */
+  now?: Date;
+}
+
+/**
+ * 운행 시간 외(첫차 전 / 막차 후) 안내 배너 (#1066).
+ *
+ * - `getServiceWindow`(#1052)가 산출한 status 기반.
+ * - `in-service` / `unknown`이면 렌더하지 않는다(`null`).
+ * - 색은 `useTheme().colors.warn`을 사용해 라이트/다크 공통 톤 유지.
+ *
+ * NOTE: HomeScreen 등 화면 wiring은 후속 PR.
+ */
+export function ServiceWindowBanner({ stationName, line, now }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { status, firstTrain } = getServiceWindow({ stationName, line, now });
+
+  // 운행 중이거나 timetable unknown이면 안내 불필요.
+  // firstTrain은 pre-first/post-last 분기일 때 getServiceWindow가 보장하는 non-null.
+  if (status !== 'pre-first' && status !== 'post-last') {
+    return null;
+  }
+
+  const message =
+    status === 'pre-first'
+      ? t('service.window.preFirst', { time: firstTrain })
+      : t('service.window.postLast', { time: firstTrain });
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.card, borderColor: colors.warn }]}
+      testID="service-window-banner"
+      accessibilityRole="alert"
+    >
+      <Text
+        style={[typography.body, { color: colors.warn, fontWeight: '600' }]}
+        testID="service-window-banner-text"
+      >
+        {message}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+  },
+});

--- a/src/shared/ui/__tests__/ServiceWindowBanner.test.tsx
+++ b/src/shared/ui/__tests__/ServiceWindowBanner.test.tsx
@@ -1,0 +1,55 @@
+import { ServiceWindowBanner } from '../ServiceWindowBanner';
+import { renderWithTheme } from '../../../testUtils/renderWithTheme';
+
+/**
+ * #1066 — getServiceWindow 4개 분기(pre-first / in-service / post-last / unknown)별
+ * 렌더링 동작을 검증한다. now 주입으로 시각을 통제하고, 소요산(1호선) timetable을
+ * fixture로 사용한다(weekday first ~05:53, last 익일 00:36).
+ */
+describe('ServiceWindowBanner', () => {
+  // 토요일(2026-06-06) 시청(2호선): first=05:31, last=23:58 (overnight 없음 → pre-first 분기 도달 가능)
+  const PRE_FIRST_SAT_KST_04_00 = new Date('2026-06-06T04:00:00+09:00');
+  // 월요일(2026-06-08) 평일 KST 10:00 — 어느 역이든 운행 중
+  const IN_SERVICE_KST_10_00 = new Date('2026-06-08T10:00:00+09:00');
+
+  it('pre-first 상태에서 배너와 첫차 시각을 노출한다', () => {
+    const { getByTestId } = renderWithTheme(
+      <ServiceWindowBanner stationName="시청" line="2" now={PRE_FIRST_SAT_KST_04_00} />,
+    );
+    const text = getByTestId('service-window-banner-text').props.children as string;
+    expect(text).toContain('첫차 전');
+    expect(text).toContain('05:31');
+  });
+
+  it('post-last 상태에서 배너와 첫차 시각을 노출한다', () => {
+    // 소요산(1호선) weekday: last 24:36 → KST 02:00 = post-last (>00:36 그리고 <첫차 05:46)
+    const POST_LAST_MON_KST_02_00 = new Date('2026-06-08T02:00:00+09:00');
+    const { getByTestId } = renderWithTheme(
+      <ServiceWindowBanner stationName="소요산" line="1" now={POST_LAST_MON_KST_02_00} />,
+    );
+    const text = getByTestId('service-window-banner-text').props.children as string;
+    expect(text).toContain('막차 후');
+    expect(text).toContain('05:46');
+  });
+
+  it('in-service 상태에서는 아무것도 렌더하지 않는다(null)', () => {
+    const { queryByTestId } = renderWithTheme(
+      <ServiceWindowBanner stationName="소요산" line="1" now={IN_SERVICE_KST_10_00} />,
+    );
+    expect(queryByTestId('service-window-banner')).toBeNull();
+  });
+
+  it('unknown 상태(timetable 없는 노선)에서는 null', () => {
+    const { queryByTestId } = renderWithTheme(
+      <ServiceWindowBanner stationName="청량리" line="bundang" now={IN_SERVICE_KST_10_00} />,
+    );
+    expect(queryByTestId('service-window-banner')).toBeNull();
+  });
+
+  it('now 미지정 시 현재 시각으로 fallback (smoke)', () => {
+    // 분기 결과는 시각 의존이라 단정하지 않고, 호출이 throw 없이 끝나는지만 확인.
+    expect(() =>
+      renderWithTheme(<ServiceWindowBanner stationName="소요산" line="1" />),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `src/shared/ui/ServiceWindowBanner.tsx` 추가 — `getServiceWindow`(#1052) 결과를 기반으로 첫차 전 / 막차 후 안내 배너 렌더.
- `in-service` / `unknown`이면 `null`. 색은 `useTheme().colors.warn` 사용.
- i18n: `service.window.preFirst` / `service.window.postLast` 4개 로케일(ko/en/ja/zh) 추가.

## 비범위 (follow-up)
- HomeScreen 등 화면 wiring (#1062 등 다른 PR이 active).

## 설계 메모
- `src/shared/`는 `src/features/` 직접 import가 ESLint로 차단되어 있으나, `getServiceWindow`는 timetable JSON과의 결합으로 `features/route/utils/`에 위치한 도메인 util. 본 배너는 여러 feature 화면에서 공유될 UI이므로 `shared/ui`에 두고, util 참조만 file-level `eslint-disable import/no-restricted-paths`로 옵트인 처리(기존 `src/shared/hooks/useStateRehydration.ts` 패턴과 동일).

## Test plan
- [x] `npm test` — 4285 tests pass, 100% coverage 유지
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] 4개 status 분기(`pre-first` / `in-service` / `post-last` / `unknown`) + `now` 미지정 fallback smoke 테스트

Closes #1066