### PR TITLE
fix(#1075): backend scheduled.test.ts TS 에러 2건 정리

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1550,9 +1550,16 @@ describe('runScheduled — trip-ended silent push (#868)', () => {
     reason: string;
     pushId: string;
     sentAt: number;
+    tripToken: string;
   } {
     const body = JSON.parse(call[1].body as string) as {
-      data: { kind: string; reason: string; pushId: string; sentAt: number };
+      data: {
+        kind: string;
+        reason: string;
+        pushId: string;
+        sentAt: number;
+        tripToken: string;
+      };
     };
     return body.data;
   }
@@ -1659,7 +1666,7 @@ describe('runScheduled — trip-ended silent push (#868)', () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('thr-tok', 4));
     // trip-ended push만 reject — reschedule/LA push는 정상.
-    const throwingFetch = vi.fn((url: unknown, init?: { body?: string }) => {
+    const throwingFetch = vi.fn((_url: unknown, init?: { body?: string }) => {
       const body = typeof init?.body === 'string' ? init.body : '';
       if (body.includes('"trip-ended"')) {
         return Promise.reject(new Error('network down'));


### PR DESCRIPTION
## Summary
dev HEAD에서 발생하던 backend type-check 실패 2건 수정.

bug-feedback PR agent(#1042)가 보고:
> Pre-existing unrelated issue: `backend/alarm-worker/src/__tests__/scheduled.test.ts` has 2 TypeScript errors on `dev` HEAD (TripEndedPushPayload.tripToken / unused `url`).

재현:
```
src/__tests__/scheduled.test.ts(1602,17): error TS2339: Property 'tripToken' does not exist on type '{ kind: string; reason: string; pushId: string; sentAt: number; }'.
src/__tests__/scheduled.test.ts(1662,34): error TS6133: 'url' is declared but its value is never read.
```

## Fix
- `parseTripEndedData` 반환 타입에 `tripToken: string` 추가 → `TripEndedPushPayload`(types.ts:292)와 정합.  
  - 라인 1602의 `expect(data.tripToken).toBe('end-tok')` 어서션은 의도된 검증(#868 P1-2 race 가드)이므로 타입 쪽을 맞추는 것이 옳음.
- 라인 1662의 `throwingFetch` mock에서 사용하지 않는 `url` 파라미터를 `_url`로 prefix → `noUnusedParameters` 충족.

## Test plan
- [x] `cd backend/alarm-worker && npx tsc --noEmit` — clean
- [x] `cd backend/alarm-worker && npm test` — 28 files / 984 tests passed
- [x] 변경 범위 test-only (production code 무수정)

Closes #1075