### PR TITLE
feat(#1073): a11y label 2차 패스 — Route 영역

### DIFF
--- a/src/features/route/components/DestinationPicker.tsx
+++ b/src/features/route/components/DestinationPicker.tsx
@@ -156,10 +156,19 @@ export function DestinationPicker({
 
         <View style={styles.overlay} pointerEvents="box-none">
           <View style={[styles.header, { backgroundColor: colors.bgTranslucent }]}>
-            <Text style={[styles.title, { color: colors.ink }]}>
+            <Text
+              style={[styles.title, { color: colors.ink }]}
+              accessibilityRole="header"
+            >
               {t(mode === 'origin' ? 'destinationPicker.originTitle' : 'destinationPicker.title')}
             </Text>
-            <TouchableOpacity onPress={handleClose} testID="close-button">
+            <TouchableOpacity
+              onPress={handleClose}
+              testID="close-button"
+              accessibilityRole="button"
+              accessibilityLabel={t('common.close')}
+              accessibilityHint={t('a11y.route.destinationCloseHint')}
+            >
               <Text style={[styles.closeText, { color: colors.accent }]}>{t('common.close')}</Text>
             </TouchableOpacity>
           </View>
@@ -168,7 +177,12 @@ export function DestinationPicker({
               <Text style={[styles.pendingText, { color: colors.onAccent }]}>
                 {t('destinationPicker.pendingSlot', { label: t(`favorites.${pendingSlot}`) })}
               </Text>
-              <TouchableOpacity onPress={() => setPendingSlot(null)} testID="pending-slot-cancel">
+              <TouchableOpacity
+                onPress={() => setPendingSlot(null)}
+                testID="pending-slot-cancel"
+                accessibilityRole="button"
+                accessibilityLabel={t('common.cancel')}
+              >
                 <Text style={[styles.pendingCancel, { color: colors.onAccent }]}>{t('common.cancel')}</Text>
               </TouchableOpacity>
             </View>
@@ -206,6 +220,10 @@ export function DestinationPicker({
                   ]}
                   onPress={() => setPendingSlot(pendingSlot === role ? null : role)}
                   testID={`slot-placeholder-chip-${role}`}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('a11y.route.assignSlotLabel', { label: t(`favorites.${role}`) })}
+                  accessibilityHint={t('a11y.route.assignSlotHint')}
+                  accessibilityState={{ selected: pendingSlot === role }}
                 >
                   <Text style={styles.chipIcon}>{FAVORITE_SLOT_ICONS[role]}</Text>
                   <Text style={[styles.chipText, { color: colors.ink }]}>
@@ -224,6 +242,9 @@ export function DestinationPicker({
                     style={[styles.chip, { backgroundColor: colors.card, borderColor: colors.hair }]}
                     onPress={() => handleSelect(station)}
                     testID={`favorite-chip-${station.id}`}
+                    accessibilityRole="button"
+                    accessibilityLabel={chipText}
+                    accessibilityHint={t('a11y.route.favoriteChipHint')}
                   >
                     {isSlot && <Text style={styles.chipIcon}>{FAVORITE_SLOT_ICONS[role]}</Text>}
                     <Text style={[styles.chipText, { color: colors.ink }]}>{chipText}</Text>
@@ -255,6 +276,7 @@ export function DestinationPicker({
               setRecenterNonce((n) => n + 1);
             }}
             accessibilityLabel={t('map.recenter')}
+            accessibilityRole="button"
             testID="recenter-button"
           >
             <Text style={[styles.recenterIcon, { color: colors.ink }]}>◎</Text>

--- a/src/features/route/components/MisBoardingReselectModal.tsx
+++ b/src/features/route/components/MisBoardingReselectModal.tsx
@@ -65,7 +65,13 @@ export function MisBoardingReselectModal({
         >
           <View style={[styles.header, { borderBottomColor: colors.hair }]}>
             <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 재선택</Text>
-            <Pressable onPress={onClose} testID="mis-boarding-reselect-close">
+            <Pressable
+              onPress={onClose}
+              testID="mis-boarding-reselect-close"
+              accessibilityRole="button"
+              accessibilityLabel="닫기"
+              accessibilityHint="재선택을 취소합니다"
+            >
               <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>닫기</Text>
             </Pressable>
           </View>

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -287,6 +287,14 @@
       "boardingTrainSelectHint": "Tap to board this train",
       "boardingLockReleaseLabel": "Get off",
       "boardingLockReleaseHint": "Ends the current boarding session"
+    },
+    "route": {
+      "destinationCloseHint": "Cancels destination selection and closes the modal",
+      "assignSlotLabel": "Assign {{label}} slot",
+      "assignSlotHint": "Saves the next selected station to this slot",
+      "favoriteChipHint": "Tap to set this station as destination",
+      "misBoardingCloseLabel": "Close",
+      "misBoardingCloseHint": "Cancels reselection"
     }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -287,6 +287,14 @@
       "boardingTrainSelectHint": "タップしてこの列車に乗車",
       "boardingLockReleaseLabel": "降車",
       "boardingLockReleaseHint": "現在の乗車を終了します"
+    },
+    "route": {
+      "destinationCloseHint": "目的地選択をキャンセルしモーダルを閉じます",
+      "assignSlotLabel": "{{label}} スロットを指定",
+      "assignSlotHint": "次に選択する駅をこのスロットに保存します",
+      "favoriteChipHint": "タップしてこの駅を目的地に設定",
+      "misBoardingCloseLabel": "閉じる",
+      "misBoardingCloseHint": "再選択をキャンセルします"
     }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -287,6 +287,15 @@
       "boardingTrainSelectHint": "탭하여 이 열차로 탑승 등록",
       "boardingLockReleaseLabel": "하차",
       "boardingLockReleaseHint": "현재 탑승 상태를 종료합니다"
+    },
+    "route": {
+      "destinationCloseHint": "목적지 선택을 취소하고 모달을 닫습니다",
+      "assignSlotLabel": "{{label}} 슬롯 지정",
+      "assignSlotHint": "다음에 선택할 역을 이 슬롯에 저장합니다",
+      "favoriteChipHint": "탭하여 이 역을 목적지로 선택",
+      "misBoardingCloseLabel": "닫기",
+      "misBoardingCloseHint": "재선택을 취소합니다",
+      "titleHeaderRole": "header"
     }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -287,6 +287,14 @@
       "boardingTrainSelectHint": "点击乘坐该列车",
       "boardingLockReleaseLabel": "下车",
       "boardingLockReleaseHint": "结束当前乘车状态"
+    },
+    "route": {
+      "destinationCloseHint": "取消目的地选择并关闭弹窗",
+      "assignSlotLabel": "指定 {{label}} 槽位",
+      "assignSlotHint": "将下次选择的车站保存到此槽位",
+      "favoriteChipHint": "点击将此站设为目的地",
+      "misBoardingCloseLabel": "关闭",
+      "misBoardingCloseHint": "取消重新选择"
     }
   }
 }


### PR DESCRIPTION
## Summary
- `src/features/route/components/**` 인터랙티브 요소에 `accessibilityLabel/Role/Hint` 추가 (PR #1037 후속)
- `a11y.route.*` i18n 키 신규 (ko/en/ja/zh) — 5개 신규 key, en/ja/zh는 합리적 fallback (네이티브 리뷰 권장)
- DestinationPicker 헤더 title `role=header`, close/cancel/recenter 버튼 a11y, favorite/slot chip a11y(슬롯은 `selected` state)
- MisBoardingReselectModal 닫기 Pressable a11y

## Out of scope (deferred)
- **MisBoardingBanner**: `ActionBanner` 공용 컴포넌트(`src/shared/ui/ActionBanner.tsx`)의 내부 Pressable에 a11y prop을 forward해야 하나, 본 PR scope를 Route 컴포넌트로 한정해 shared/ui 변경을 회피. 후속 PR에서 ActionBanner에 `accessibilityRole/Hint` props 추가하면 BoardingLockBanner/MisBoardingBanner 동시 해결 가능.
- MisBoardingReselectModal/MisBoardingBanner의 하드코딩 한국어 문자열 → i18n 마이그레이션(기존부터 존재, scope 외)

## Test plan
- [x] `npm test` — 4284 tests pass, 100% coverage
- [x] `npm run type-check` — clean
- [x] `npx eslint src/features/route/components/**` — clean
- [ ] VoiceOver/TalkBack 수동 검증 (실기기)

Closes #1073