### PR TITLE
feat: HomeScreen ArrivalRow → EditorialArrivalRow 전환 (#1043 활성화)

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -7,7 +7,6 @@ import { useFusedNearestStation } from '../features/nearest-station/hooks/useFus
 import { useArrivalInfo } from '../features/arrival/hooks/useArrivalInfo';
 import type { ArrivalInfo } from '../features/arrival/api/arrivalApi';
 import { useArrivalCountdown } from '../features/arrival/hooks/useArrivalCountdown';
-import { formatArrivalTime } from '../shared/utils/formatTime';
 import { LINE_NAMES } from '../shared/constants/lineColors';
 import { useFavoritesStore } from '../features/favorites/store/useFavoritesStore';
 import { useSettingsStore } from '../features/settings/store/useSettingsStore';
@@ -18,7 +17,8 @@ import { DestinationPicker } from '../features/route/components/DestinationPicke
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
 import { EditorialTimeline } from '../features/arrival/components/EditorialTimeline';
-import { journeyDisplayToStops, nearestResultToNearest } from '../features/route/utils/journeyAdapter';
+import { arrivalInfoToArrivalTrain, journeyDisplayToStops, nearestResultToNearest } from '../features/route/utils/journeyAdapter';
+import { EditorialArrivalRow } from '../features/arrival/components/EditorialArrivalRow';
 import { useRouter } from 'expo-router';
 import { getStationDisplayName } from '../shared/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../features/alarm/utils/stationNotification';
@@ -64,7 +64,7 @@ import { BoardingLockHopCard } from '../features/alarm/components/BoardingLockHo
 import { resolveNextAdjacentStationName } from '../features/route/utils/nextAdjacentStation';
 import { getApproachLine } from '../features/route/utils/approachLine';
 import type { Stop } from '../shared/types/journey';
-import type { Station } from '../shared/types/station';
+import type { LineNumber, Station } from '../shared/types/station';
 
 const logger = createLogger('HomeScreen');
 
@@ -1094,8 +1094,20 @@ export default function HomeScreen() {
                 <ArrivalSourceNotice arrival={arrival} />
                 {arrival && arrival.source !== 'closed' && (
                   <>
-                    <ArrivalRow label={t('arrival.upbound')} items={arrival.up} />
-                    <ArrivalRow label={t('arrival.downbound')} items={arrival.down} />
+                    <ArrivalDirectionGroup
+                      label={t('arrival.upbound')}
+                      items={arrival.up}
+                      stationName={effectiveOrigin.name}
+                      line={effectiveOrigin.line}
+                      directionKey="up"
+                    />
+                    <ArrivalDirectionGroup
+                      label={t('arrival.downbound')}
+                      items={arrival.down}
+                      stationName={effectiveOrigin.name}
+                      line={effectiveOrigin.line}
+                      directionKey="down"
+                    />
                   </>
                 )}
               </View>
@@ -1201,35 +1213,40 @@ function findNextWaypointName(stops: Stop[], fromIdx: number): string | null {
   return null;
 }
 
-function ArrivalRow({
+/**
+ * #1074 — 도착 섹션 한 방향(상행/하행) 그룹.
+ * arrival.up/down(ArrivalInfo[]) → arrivalInfoToArrivalTrain으로 변환해 EditorialArrivalRow로 렌더.
+ * stationName/line/directionKey 컨텍스트를 패스스루해 ArrivalStatusBadge가 막차 HH:mm을 lookup한다(#1035/#1043).
+ */
+function ArrivalDirectionGroup({
   label,
   items,
+  stationName,
+  line,
+  directionKey,
 }: {
   label: string;
-  items: { destination: string; arrivalSeconds: number; statusMessage: string }[];
+  items: ArrivalInfo[];
+  stationName: string;
+  line: LineNumber;
+  directionKey: 'up' | 'down';
 }) {
   const { colors } = useTheme();
   const { t } = useTranslation();
+  const trains = useMemo(
+    () => arrivalInfoToArrivalTrain(items, label, line, { stationName, directionKey }),
+    [items, label, line, stationName, directionKey],
+  );
   return (
-    <View style={[styles.arrivalRow, { borderTopColor: colors.hair }]}>
+    <View style={[styles.arrivalGroup, { borderTopColor: colors.hair }]}>
       <Text style={[styles.arrivalLabel, { color: colors.muted }]}>{label}</Text>
-      <View>
-        {items.length === 0 ? (
-          <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.noArrivalInfo')}</Text>
-        ) : (
-          items.map((item, idx) => (
-            <View key={idx} style={styles.arrivalItemContainer}>
-              <Text style={[styles.arrivalItem, { color: colors.ink }]}>
-                {item.destination ? `${item.destination} · ` : ''}
-                {formatArrivalTime(item.arrivalSeconds)}
-              </Text>
-              {item.statusMessage !== '' && (
-                <Text style={[styles.statusMessage, { color: colors.accent }]}>{item.statusMessage}</Text>
-              )}
-            </View>
-          ))
-        )}
-      </View>
+      {trains.length === 0 ? (
+        <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.noArrivalInfo')}</Text>
+      ) : (
+        trains.map((train, idx) => (
+          <EditorialArrivalRow key={`${train.line}-${idx}`} train={train} />
+        ))
+      )}
     </View>
   );
 }
@@ -1395,28 +1412,18 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     textTransform: 'uppercase',
   },
-  arrivalRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    paddingVertical: 10,
+  arrivalGroup: {
+    paddingTop: 10,
     borderTopWidth: 1,
+    marginTop: spacing.sm,
   },
   arrivalLabel: {
     fontSize: 15,
     fontWeight: '600',
-  },
-  arrivalItemContainer: {
-    marginBottom: 4,
+    marginBottom: spacing.xs,
   },
   arrivalItem: {
     fontSize: 15,
-    textAlign: 'right',
-  },
-  statusMessage: {
-    fontSize: 12,
-    textAlign: 'right',
-    marginTop: 2,
   },
   icon: {
     fontSize: 48,


### PR DESCRIPTION
## Summary
- PR #1043에서 추가된 막차 시각 표기("막차 HH:mm")가 어떤 화면에도 렌더되지 않던 dead path 해소
- HomeScreen 도착 섹션에서 local `ArrivalRow` → `EditorialArrivalRow`로 전환하고 `stationName/line/directionKey` 컨텍스트를 패스스루
- `arrivalInfoToArrivalTrain` 첫 production 호출자 — `lastTrainTime` lookup 활성화

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` (234 suites / 4284 tests, 100% coverage)
- [ ] 실기기: 막차 시간대(예: 23:30 이후)에 1~9호선 역에서 도착 섹션에 "막차 HH:mm" 노출 확인
- [ ] 실기기: 일반 시간대에 기존 도착 표기(분/초 카운트다운 + direction + line badge) 정상 노출 확인

Closes #1074