### PR TITLE
feat: backend feedback admin/export endpoint

### DIFF
--- a/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
+++ b/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
@@ -1,0 +1,349 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { app } from '../index';
+import {
+  FEEDBACK_LIST_DEFAULT_LIMIT,
+  FEEDBACK_LIST_MAX_LIMIT,
+  listFeedback,
+  normalizeLimit,
+  parseReceivedAtFromKey,
+  toCsv,
+} from '../feedbackAdmin';
+import { storeFeedback } from '../feedback';
+import type { Env } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    TRIPS: {} as Env['TRIPS'],
+    APNS_HOST: 'h',
+    APNS_HOST_SANDBOX: 'hs',
+    SEOUL_API_HOST: 'h',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: 'p',
+    APNS_BUNDLE_ID: 'b',
+    ...overrides,
+  };
+}
+
+async function get(
+  path: string,
+  env: Env,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return app.fetch(
+    new Request(`http://example.com${path}`, { method: 'GET', headers }),
+    env,
+  );
+}
+
+async function seed(kv: InMemoryKV, count: number, baseTs = 10_000): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      {
+        message: `msg-${i}`,
+        context: { platform: i % 2 === 0 ? 'ios' : 'android', appVersion: `1.0.${i}` },
+      },
+      baseTs + i,
+      `id${i.toString().padStart(4, '0')}`,
+    );
+  }
+}
+
+describe('normalizeLimit', () => {
+  it('falls back to default for non-positive / non-finite', () => {
+    expect(normalizeLimit(0)).toBe(FEEDBACK_LIST_DEFAULT_LIMIT);
+    expect(normalizeLimit(-5)).toBe(FEEDBACK_LIST_DEFAULT_LIMIT);
+    expect(normalizeLimit(Number.NaN)).toBe(FEEDBACK_LIST_DEFAULT_LIMIT);
+    expect(normalizeLimit('hi')).toBe(FEEDBACK_LIST_DEFAULT_LIMIT);
+    expect(normalizeLimit(undefined)).toBe(FEEDBACK_LIST_DEFAULT_LIMIT);
+  });
+
+  it('clamps to max and floors', () => {
+    expect(normalizeLimit(10_000)).toBe(FEEDBACK_LIST_MAX_LIMIT);
+    expect(normalizeLimit(3.9)).toBe(3);
+  });
+
+  it('returns value within range as-is (floored)', () => {
+    expect(normalizeLimit(25)).toBe(25);
+  });
+});
+
+describe('parseReceivedAtFromKey', () => {
+  it('extracts epoch from canonical key', () => {
+    expect(parseReceivedAtFromKey('feedback:1234:abcd')).toBe(1234);
+  });
+
+  it('returns NaN for malformed key', () => {
+    expect(Number.isNaN(parseReceivedAtFromKey('no-colons'))).toBe(true);
+    expect(Number.isNaN(parseReceivedAtFromKey('feedback:nope:id'))).toBe(true);
+  });
+});
+
+describe('listFeedback', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('returns empty result on empty KV', async () => {
+    expect(await listFeedback(kv as unknown as KVNamespace)).toEqual({
+      entries: [],
+      nextBefore: null,
+    });
+  });
+
+  it('returns entries sorted by receivedAt desc', async () => {
+    await seed(kv, 3);
+    const result = await listFeedback(kv as unknown as KVNamespace);
+    expect(result.entries.map((e) => e.receivedAt)).toEqual([10_002, 10_001, 10_000]);
+    expect(result.nextBefore).toBeNull();
+  });
+
+  it('applies limit and exposes nextBefore', async () => {
+    await seed(kv, 5);
+    const result = await listFeedback(kv as unknown as KVNamespace, { limit: 2 });
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0].receivedAt).toBe(10_004);
+    expect(result.entries[1].receivedAt).toBe(10_003);
+    expect(result.nextBefore).toBe(10_003);
+  });
+
+  it('paginates with before cursor', async () => {
+    await seed(kv, 5);
+    const result = await listFeedback(kv as unknown as KVNamespace, {
+      limit: 2,
+      before: 10_003,
+    });
+    expect(result.entries.map((e) => e.receivedAt)).toEqual([10_002, 10_001]);
+    expect(result.nextBefore).toBe(10_001);
+  });
+
+  it('nextBefore null when fewer than limit remain', async () => {
+    await seed(kv, 3);
+    const result = await listFeedback(kv as unknown as KVNamespace, { limit: 10 });
+    expect(result.entries).toHaveLength(3);
+    expect(result.nextBefore).toBeNull();
+  });
+
+  it('skips malformed keys and unparseable values', async () => {
+    await seed(kv, 1, 5_000);
+    // 손상된 JSON
+    await kv.put('feedback:6000:bad1', '{not json');
+    // 키 포맷 어긋남(receivedAt 미파싱)
+    await kv.put('feedback:bad', JSON.stringify({ message: 'm', receivedAt: 7000 }));
+    // record schema 어긋남 — message 누락
+    await kv.put('feedback:6001:bad2', JSON.stringify({ receivedAt: 6001 }));
+    // record schema 어긋남 — receivedAt 누락
+    await kv.put('feedback:6002:bad3', JSON.stringify({ message: 'm' }));
+    // record가 객체 아님
+    await kv.put('feedback:6003:bad4', JSON.stringify('string'));
+
+    const result = await listFeedback(kv as unknown as KVNamespace);
+    expect(result.entries.map((e) => e.message)).toEqual(['msg-0']);
+  });
+
+  it('skips keys whose value disappeared mid-list', async () => {
+    await seed(kv, 2, 5_000);
+    // list에는 잡히지만 get에서 사라진 케이스 모사 — 직접 store에서 삭제
+    kv.store.delete('feedback:5001:id0001');
+    const result = await listFeedback(kv as unknown as KVNamespace);
+    expect(result.entries.map((e) => e.receivedAt)).toEqual([5_000]);
+  });
+
+  it('omits context field when record has none', async () => {
+    await storeFeedback(kv as unknown as KVNamespace, { message: 'noctx' }, 9_000, 'idx');
+    const result = await listFeedback(kv as unknown as KVNamespace);
+    expect(result.entries[0]).toEqual({
+      key: 'feedback:9000:idx',
+      receivedAt: 9_000,
+      message: 'noctx',
+    });
+  });
+});
+
+describe('toCsv', () => {
+  it('returns header-only row for empty entries', () => {
+    expect(toCsv([])).toBe(
+      '"key","receivedAt","message","appVersion","platform","locale","deviceModel"\n',
+    );
+  });
+
+  it('serializes entries with ISO timestamp and context fields', () => {
+    const csv = toCsv([
+      {
+        key: 'feedback:0:aa',
+        receivedAt: 0,
+        message: 'hello',
+        context: {
+          appVersion: '1.0.0',
+          platform: 'ios',
+          locale: 'ko-KR',
+          deviceModel: 'iPhone15,2',
+        },
+      },
+    ]);
+    const lines = csv.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe(
+      '"feedback:0:aa","1970-01-01T00:00:00.000Z","hello","1.0.0","ios","ko-KR","iPhone15,2"',
+    );
+  });
+
+  it('escapes quotes, commas, and newlines per RFC 4180', () => {
+    const csv = toCsv([
+      {
+        key: 'feedback:1:bb',
+        receivedAt: 1,
+        message: 'has "quotes", commas,\nand newlines',
+      },
+    ]);
+    expect(csv).toContain('"has ""quotes"", commas,\nand newlines"');
+  });
+
+  it('emits empty cells for missing context fields', () => {
+    const csv = toCsv([
+      {
+        key: 'feedback:2:cc',
+        receivedAt: 2,
+        message: 'partial',
+        context: { platform: 'android' },
+      },
+    ]);
+    expect(csv).toContain('"partial","","android","",""');
+  });
+});
+
+describe('GET /admin/feedback', () => {
+  it('returns 503 when ADMIN_TOKEN secret missing', async () => {
+    const res = await get('/admin/feedback', makeEnv());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'admin_unavailable' });
+  });
+
+  it('returns 401 when Authorization header absent', async () => {
+    const res = await get('/admin/feedback', makeEnv({ ADMIN_TOKEN: 'secret' }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('returns 401 when scheme is not Bearer', async () => {
+    const res = await get('/admin/feedback', makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Basic secret',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when token mismatches', async () => {
+    const res = await get('/admin/feedback', makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Bearer nope',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when FEEDBACK binding missing despite valid auth', async () => {
+    const res = await get('/admin/feedback', makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Bearer secret',
+    });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'feedback_unavailable' });
+  });
+
+  it('returns entries with default limit and nextBefore=null on small dataset', async () => {
+    const kv = new InMemoryKV();
+    await seed(kv, 2, 100);
+    const res = await get(
+      '/admin/feedback',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { entries: { receivedAt: number }[]; nextBefore: number | null };
+    expect(json.entries.map((e) => e.receivedAt)).toEqual([101, 100]);
+    expect(json.nextBefore).toBeNull();
+  });
+
+  it('honors limit and before query params', async () => {
+    const kv = new InMemoryKV();
+    await seed(kv, 5, 200);
+    const res = await get(
+      '/admin/feedback?limit=2&before=204',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { entries: { receivedAt: number }[]; nextBefore: number | null };
+    expect(json.entries.map((e) => e.receivedAt)).toEqual([203, 202]);
+    expect(json.nextBefore).toBe(202);
+  });
+
+  it('ignores non-numeric query params (falls back to defaults)', async () => {
+    const kv = new InMemoryKV();
+    await seed(kv, 2, 300);
+    const res = await get(
+      '/admin/feedback?limit=abc&before=xyz',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { entries: unknown[] };
+    expect(json.entries).toHaveLength(2);
+  });
+});
+
+describe('GET /admin/feedback/export.csv', () => {
+  it('returns 401 when token mismatches', async () => {
+    const res = await get('/admin/feedback/export.csv', makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Bearer nope',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when FEEDBACK binding missing', async () => {
+    const res = await get(
+      '/admin/feedback/export.csv',
+      makeEnv({ ADMIN_TOKEN: 'secret' }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 when ADMIN_TOKEN missing', async () => {
+    const res = await get('/admin/feedback/export.csv', makeEnv());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'admin_unavailable' });
+  });
+
+  it('returns header-only CSV when no entries', async () => {
+    const kv = new InMemoryKV();
+    const res = await get(
+      '/admin/feedback/export.csv',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/csv; charset=utf-8');
+    expect(res.headers.get('content-disposition')).toContain('feedback.csv');
+    const body = await res.text();
+    expect(body.split('\n')[0]).toContain('"message"');
+    expect(body.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('serializes entries with header + rows', async () => {
+    const kv = new InMemoryKV();
+    await seed(kv, 2, 500);
+    const res = await get(
+      '/admin/feedback/export.csv?limit=10',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    const lines = body.trim().split('\n');
+    expect(lines).toHaveLength(3); // header + 2 entries
+    expect(lines[1]).toContain('"msg-1"'); // newest first
+    expect(lines[2]).toContain('"msg-0"');
+  });
+});

--- a/backend/alarm-worker/src/feedbackAdmin.ts
+++ b/backend/alarm-worker/src/feedbackAdmin.ts
@@ -1,0 +1,174 @@
+/**
+ * 운영자용 feedback 조회 / CSV export (#1034 follow-up, PR #1042 후속).
+ *
+ * `POST /feedback`이 KV `FEEDBACK`에 적재한 사용자 신고를 운영자가 wrangler CLI 없이
+ * HTTP로 직접 수거할 수 있게 하는 admin endpoint들의 비-HTTP 계층 (pure / KV).
+ *
+ * 인증: caller(`index.ts`)가 `Authorization: Bearer <ADMIN_TOKEN>` 검증 후 호출 — 본 모듈은
+ * 인증 미통과 케이스를 다루지 않는다.
+ *
+ * 정렬: 최신 → 오래된 순(receivedAt desc). 운영자가 "최근 N건"을 보는 사용 패턴에 맞춤.
+ * KV native cursor는 lex ascending(=오래된 순)이라 후속 페이지 호출에서 의미가 어긋나
+ * 의도적으로 사용하지 않는다 — 대신 `before` cursor(epoch ms)로 "그 시각보다 더 오래된 N건".
+ */
+
+import type { FeedbackContext, FeedbackRecord } from './feedback';
+
+export const FEEDBACK_LIST_DEFAULT_LIMIT = 50;
+export const FEEDBACK_LIST_MAX_LIMIT = 500;
+
+export interface FeedbackListEntry {
+  key: string;
+  receivedAt: number;
+  message: string;
+  context?: FeedbackContext;
+}
+
+export interface FeedbackListResult {
+  entries: FeedbackListEntry[];
+  /** 다음 페이지 호출 시 `?before=<nextBefore>`로 전달. 더 없으면 null. */
+  nextBefore: number | null;
+}
+
+export interface ListOptions {
+  limit?: number;
+  /** epoch ms — 이 시각 미만(strict)인 entry만 반환. desc 페이지네이션 cursor. */
+  before?: number;
+}
+
+/**
+ * limit 정규화 — 1..MAX 범위로 clamp. 비-number/NaN/0/음수는 default로 fallback.
+ */
+export function normalizeLimit(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) {
+    return FEEDBACK_LIST_DEFAULT_LIMIT;
+  }
+  const floored = Math.floor(raw);
+  if (floored > FEEDBACK_LIST_MAX_LIMIT) return FEEDBACK_LIST_MAX_LIMIT;
+  return floored;
+}
+
+/**
+ * KV 키에서 receivedAt 추출 — `feedback:${epochMs}:${id}` 포맷.
+ * 포맷이 어긋난 키는 NaN을 반환해 호출부가 skip하게 만든다 (graceful).
+ */
+export function parseReceivedAtFromKey(key: string): number {
+  const parts = key.split(':');
+  if (parts.length < 3) return Number.NaN;
+  const ts = Number(parts[1]);
+  return Number.isFinite(ts) ? ts : Number.NaN;
+}
+
+/**
+ * FEEDBACK KV에서 entry를 desc(최신순) 정렬해 반환.
+ *
+ * 구현:
+ *   1) `list({ prefix: 'feedback:' })`로 모든 키 조회 (KV는 lex asc=오래된순으로 줌)
+ *   2) before 필터 + receivedAt desc 정렬
+ *   3) limit + 1개를 fetch해 nextBefore 산출(다음 페이지 존재 여부)
+ *   4) 각 키의 value를 get → JSON parse. parse 실패는 skip(상한 보호).
+ *
+ * 30일 TTL + 운영팀이 주기적으로 수거하는 패턴이라 키 수가 수만 단위로 폭발하지 않는다는 가정.
+ * 폭발 시 KV list가 1000개 단위 페이지를 cursor로 잇는데, 본 함수는 first page만 사용 —
+ * 운영자가 정말 그 이상을 한 번에 보고 싶다면 별도 pagination 설계 필요(현재 요구 범위 밖).
+ */
+export async function listFeedback(
+  kv: KVNamespace,
+  options: ListOptions = {},
+): Promise<FeedbackListResult> {
+  const limit = normalizeLimit(options.limit);
+  const before = options.before;
+
+  const { keys } = await kv.list({ prefix: 'feedback:' });
+  const filtered = keys
+    .map((k) => ({ key: k.name, receivedAt: parseReceivedAtFromKey(k.name) }))
+    .filter((k) => Number.isFinite(k.receivedAt))
+    .filter((k) => (before === undefined ? true : k.receivedAt < before))
+    .sort((a, b) => b.receivedAt - a.receivedAt);
+
+  // limit + 1을 시도 — nextBefore 산출용. 실제 entries는 limit개로 자른다.
+  const sliced = filtered.slice(0, limit + 1);
+  const hasMore = sliced.length > limit;
+  const pageKeys = hasMore ? sliced.slice(0, limit) : sliced;
+
+  const entries: FeedbackListEntry[] = [];
+  for (const { key, receivedAt } of pageKeys) {
+    const raw = await kv.get(key);
+    if (raw === null) continue;
+    const parsed = safeParseRecord(raw);
+    if (!parsed) continue;
+    entries.push({
+      key,
+      receivedAt: parsed.receivedAt ?? receivedAt,
+      message: parsed.message,
+      ...(parsed.context ? { context: parsed.context } : {}),
+    });
+  }
+
+  const nextBefore = hasMore && entries.length > 0
+    ? entries[entries.length - 1].receivedAt
+    : null;
+
+  return { entries, nextBefore };
+}
+
+function safeParseRecord(raw: string): FeedbackRecord | null {
+  try {
+    const obj = JSON.parse(raw) as unknown;
+    if (!obj || typeof obj !== 'object') return null;
+    const r = obj as Record<string, unknown>;
+    if (typeof r.message !== 'string') return null;
+    if (typeof r.receivedAt !== 'number') return null;
+    const record: FeedbackRecord = {
+      message: r.message,
+      receivedAt: r.receivedAt,
+    };
+    if (r.context && typeof r.context === 'object') {
+      record.context = r.context as FeedbackContext;
+    }
+    return record;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * entries → CSV 직렬화. 운영자가 스프레드시트로 분기 트리아지하기 위한 형식.
+ *
+ * 컬럼: key, receivedAt(ISO8601 UTC), message, appVersion, platform, locale, deviceModel
+ * - 모든 셀은 RFC 4180 규칙으로 quote (필드 안 `"` → `""`, 줄바꿈/콤마 안전).
+ * - empty entry 배열도 header line은 항상 반환 — 다운스트림 파서 단순화.
+ */
+export function toCsv(entries: FeedbackListEntry[]): string {
+  const header = [
+    'key',
+    'receivedAt',
+    'message',
+    'appVersion',
+    'platform',
+    'locale',
+    'deviceModel',
+  ];
+  const lines: string[] = [header.map(csvCell).join(',')];
+  for (const entry of entries) {
+    lines.push(
+      [
+        entry.key,
+        new Date(entry.receivedAt).toISOString(),
+        entry.message,
+        entry.context?.appVersion ?? '',
+        entry.context?.platform ?? '',
+        entry.context?.locale ?? '',
+        entry.context?.deviceModel ?? '',
+      ]
+        .map(csvCell)
+        .join(','),
+    );
+  }
+  // 마지막 줄에도 줄바꿈을 둬 Excel/Numbers 호환.
+  return `${lines.join('\n')}\n`;
+}
+
+function csvCell(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -186,9 +186,13 @@ function checkAdminAuth(
 ): AdminAuthError | null {
   if (!configured) return { code: 'admin_unavailable', status: 503 };
   if (!authHeader) return { code: 'unauthorized', status: 401 };
-  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
-  if (!match) return { code: 'unauthorized', status: 401 };
-  if (match[1] !== configured) return { code: 'unauthorized', status: 401 };
+  const prefix = 'bearer ';
+  if (authHeader.length <= prefix.length) return { code: 'unauthorized', status: 401 };
+  if (authHeader.slice(0, prefix.length).toLowerCase() !== prefix) {
+    return { code: 'unauthorized', status: 401 };
+  }
+  const token = authHeader.slice(prefix.length).trimStart();
+  if (!token || token !== configured) return { code: 'unauthorized', status: 401 };
   return null;
 }
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -24,6 +24,7 @@ import {
   storeFeedback,
   validateFeedback,
 } from './feedback';
+import { listFeedback, toCsv } from './feedbackAdmin';
 import { evaluateAndMaybeAlert } from './recallAlerts';
 import {
   cleanupTripWithLa,
@@ -120,6 +121,82 @@ app.post('/feedback', async (c) => {
   const key = await storeFeedback(kv, payload, receivedAt, id);
   return c.json({ ok: true, key }, 201);
 });
+
+/**
+ * 운영자용 feedback 조회 (#1042 follow-up).
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` 필수. ADMIN_TOKEN secret 미설정 시 503.
+ * Query: `?limit=N` (default 50, max 500) / `?before=<epochMs>` (desc 페이지네이션 cursor).
+ *
+ * Response 200:
+ *   { entries: [{ key, receivedAt, message, context? }, ...], nextBefore: number | null }
+ *   - entries: 최신 → 오래된 순 정렬.
+ *   - nextBefore: 다음 페이지 호출 시 그대로 `?before=`로 전달. 더 없으면 null.
+ * Response 401: { error: 'unauthorized' } — 토큰 누락/불일치.
+ * Response 503: { error: 'admin_unavailable' | 'feedback_unavailable' } — secret/binding 미설정.
+ */
+app.get('/admin/feedback', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const kv = c.env.FEEDBACK;
+  if (!kv) return c.json({ error: 'feedback_unavailable' }, 503);
+
+  const limit = parseQueryNumber(c.req.query('limit'));
+  const before = parseQueryNumber(c.req.query('before'));
+  const result = await listFeedback(kv, { limit, before });
+  return c.json(result);
+});
+
+/**
+ * 운영자용 feedback CSV export (#1042 follow-up).
+ * 인증/binding 정책은 `/admin/feedback`과 동일. limit/before 동일하게 적용.
+ * 성공 시 `text/csv` + Content-Disposition으로 다운로드 트리거.
+ */
+app.get('/admin/feedback/export.csv', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const kv = c.env.FEEDBACK;
+  if (!kv) return c.json({ error: 'feedback_unavailable' }, 503);
+
+  const limit = parseQueryNumber(c.req.query('limit'));
+  const before = parseQueryNumber(c.req.query('before'));
+  const { entries } = await listFeedback(kv, { limit, before });
+  const csv = toCsv(entries);
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      'content-type': 'text/csv; charset=utf-8',
+      'content-disposition': 'attachment; filename="feedback.csv"',
+    },
+  });
+});
+
+interface AdminAuthError {
+  code: 'admin_unavailable' | 'unauthorized';
+  status: 503 | 401;
+}
+
+/**
+ * Bearer 토큰 검증. configured token이 없으면 503(설정 누락) — 401과 구분해 운영자가
+ * secret put을 잊은 케이스를 즉시 진단할 수 있게 한다.
+ */
+function checkAdminAuth(
+  authHeader: string | undefined,
+  configured: string | undefined,
+): AdminAuthError | null {
+  if (!configured) return { code: 'admin_unavailable', status: 503 };
+  if (!authHeader) return { code: 'unauthorized', status: 401 };
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+  if (!match) return { code: 'unauthorized', status: 401 };
+  if (match[1] !== configured) return { code: 'unauthorized', status: 401 };
+  return null;
+}
+
+function parseQueryNumber(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
 
 app.post('/trips', async (c) => {
   let body: unknown;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -457,4 +457,11 @@ export interface Env {
   CF_ACCOUNT_ID?: string;
   /** Cloudflare API token (Analytics Engine read 권한) (#972). secret으로 등록. */
   CF_API_TOKEN?: string;
+  /**
+   * 운영자용 admin endpoint Bearer token (#1042 follow-up).
+   * `/admin/feedback`, `/admin/feedback/export.csv`가 본 토큰으로 인증한다.
+   * 미설정 시 admin endpoint들은 503 (운영자가 secret 등록 전 환경 호환).
+   * 등록: `wrangler secret put ADMIN_TOKEN`
+   */
+  ADMIN_TOKEN?: string;
 }

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -73,6 +73,10 @@ head_sampling_rate = 1
 # - RECALL_ALERT_WEBHOOK_URL  : Slack incoming webhook URL 또는 호환 receiver
 # - CF_ACCOUNT_ID             : Cloudflare account ID (Analytics Engine SQL HTTP API endpoint 조립)
 # - CF_API_TOKEN              : Cloudflare API token (Analytics Engine read 권한)
+#
+# - ADMIN_TOKEN               : 운영자용 admin endpoint Bearer token (#1042 follow-up).
+#     `/admin/feedback`, `/admin/feedback/export.csv` 접근에 필요. 미설정 시 503.
+#     등록: `wrangler secret put ADMIN_TOKEN`
 [vars]
 APNS_HOST = "api.push.apple.com"
 APNS_HOST_SANDBOX = "api.sandbox.push.apple.com"


### PR DESCRIPTION
## Summary

PR #1042 (`POST /feedback`) follow-up. 운영자가 `wrangler kv key list` / `kv get` CLI에 의존하지 않고 HTTP로 직접 사용자 신고를 조회/CSV export 할 수 있게 admin endpoint 2개 추가.

- `GET /admin/feedback?limit=N&before=<epochMs>` — 최신순(receivedAt desc) 리스트 + `nextBefore` cursor pagination (default 50, max 500).
- `GET /admin/feedback/export.csv?limit=N&before=...` — RFC 4180 quoting, `text/csv; charset=utf-8` + `Content-Disposition: attachment`.
- 인증: `Authorization: Bearer <ADMIN_TOKEN>` 필수. 토큰 누락/불일치 → 401. `ADMIN_TOKEN` secret 미설정 → 503 (`admin_unavailable`)로 운영자가 secret put 누락을 즉시 진단.
- `FEEDBACK` KV binding 부재 시 동일하게 503 (`feedback_unavailable`) — `POST /feedback`과 정합.

비-HTTP 계층(`feedbackAdmin.ts`)은 pure / KV로 분리 — listFeedback / toCsv / normalizeLimit / parseReceivedAtFromKey 각각 단위 테스트.

## 운영 절차

```bash
# 1) secret 등록 (1회)
cd backend/alarm-worker
wrangler secret put ADMIN_TOKEN
# (랜덤한 충분히 긴 문자열 입력)

# 2) deploy
wrangler deploy

# 3) 조회
curl -H "Authorization: Bearer <ADMIN_TOKEN>" \
  https://<worker>.workers.dev/admin/feedback?limit=20

# 4) CSV export
curl -H "Authorization: Bearer <ADMIN_TOKEN>" \
  -o feedback.csv \
  https://<worker>.workers.dev/admin/feedback/export.csv
```

## 알려진 한계 (follow-up 후보)

`listFeedback`은 KV `list({ prefix })`의 first page만 사용. 30일 TTL + 운영팀 주기 수거 패턴이라 1000개 이내 가정이 안전하지만, 폭증 시 cursor 잇기 + lex asc→desc 재정렬 페이지네이션이 필요. 현재 요구 범위 밖.

## Test plan

- [x] `cd backend/alarm-worker && npm test` — 1014 tests pass (new feedbackAdmin: 30 tests)
- [x] `cd backend/alarm-worker && npm run type-check` — clean
- [ ] 배포 후 `curl` 1회 smoke (운영자 수동)