### PR TITLE
fix(#1079): 위젯 갱신을 destination 게이트에서 분리

### DIFF
--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -851,33 +851,21 @@ describe('stationNotification', () => {
     });
   });
 
-  describe('widget storage 연동', () => {
+  describe('widget storage 분리 (#1079)', () => {
     beforeEach(() => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       mockSaveStationToWidget.mockResolvedValue(undefined);
       mockClearWidgetStation.mockResolvedValue(undefined);
     });
 
-    it('updateStationNotification은 saveStationToWidget을 km 단위로 호출한다', async () => {
+    it('updateStationNotification은 saveStationToWidget을 호출하지 않는다 (useWidgetSync로 분리)', async () => {
       await updateStationNotification(mockStation, 250);
-      expect(mockSaveStationToWidget).toHaveBeenCalledWith(mockStation, 0.25);
+      expect(mockSaveStationToWidget).not.toHaveBeenCalled();
     });
 
-    it('saveStationToWidget이 실패해도 updateLiveActivity는 호출된다', async () => {
-      mockSaveStationToWidget.mockRejectedValueOnce(new Error('group missing'));
-      await updateStationNotification(mockStation, 100);
-      expect(mockUpdateLiveActivity).toHaveBeenCalled();
-    });
-
-    it('clearStationNotification은 clearWidgetStation을 호출한다', async () => {
+    it('clearStationNotification은 clearWidgetStation을 호출하지 않는다 (위젯은 알림 lifecycle과 독립)', async () => {
       await clearStationNotification();
-      expect(mockClearWidgetStation).toHaveBeenCalled();
-    });
-
-    it('clearWidgetStation이 실패해도 endLiveActivity는 호출된다', async () => {
-      mockClearWidgetStation.mockRejectedValueOnce(new Error('group missing'));
-      await clearStationNotification();
-      expect(mockEndLiveActivity).toHaveBeenCalled();
+      expect(mockClearWidgetStation).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -19,7 +19,6 @@ import { vibrateAlarm, stopVibration } from './alarmSound';
 import { speakAlarm } from './tts';
 import { createLogger } from '../../../shared/utils/logger';
 import { getStationDisplayName, getStationDisplayNameByName } from '../../../shared/utils/stationDisplay';
-import { saveStationToWidget, clearWidgetStation } from '../../widget/api/widgetStorage';
 import { hasFiredPushId } from './firedPushIds';
 import stationsData from '../../../data/stations.json';
 import type { ExitSide } from '../../../shared/types/exitSide';
@@ -383,9 +382,9 @@ export async function updateStationNotification(
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
 
-  await saveStationToWidget(currentStation, distanceM / 1000).catch((e) =>
-    notifLogger.error('위젯 저장 실패:', e),
-  );
+  // 위젯 갱신은 destination 게이트와 독립적으로 useWidgetSync hook이 담당한다 (#1079).
+  // updateStationNotification은 destination이 있을 때만 호출되므로, 여기에서 saveStationToWidget을
+  // 호출하면 목적지 미설정/다른 탭/HomeScreen 미진입 케이스에서 위젯이 "감지 중"에 멈춘다.
 
   if (Platform.OS === 'ios') {
     const liveActivityEnabled = LiveActivity.isLiveActivityEnabled();
@@ -424,9 +423,8 @@ async function dismissStationPassedNotification(): Promise<void> {
 }
 
 export async function clearStationNotification(): Promise<void> {
-  await clearWidgetStation().catch((e) =>
-    notifLogger.error('위젯 해제 실패:', e),
-  );
+  // 위젯은 알림/Live Activity와 독립 lifecycle (#1079) — 여기서 clearWidgetStation을
+  // 호출하면 trip 종료/destination clear 시 위젯도 같이 꺼져 본 fix가 무력화된다.
   if (Platform.OS === 'ios') {
     if (!LiveActivity.isLiveActivityEnabled()) {
       notifLogger.info('알림 해제 (Live Activity 비활성)');

--- a/src/features/widget/hooks/__tests__/useWidgetSync.test.ts
+++ b/src/features/widget/hooks/__tests__/useWidgetSync.test.ts
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react-native';
+import type { Station } from '../../../../shared/types/station';
+
+const mockSave = jest.fn().mockResolvedValue(undefined);
+const mockClear = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../api/widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSave(...args),
+  clearWidgetStation: () => mockClear(),
+}));
+
+const mockLoggerError = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({ error: (...args: unknown[]) => mockLoggerError(...args), info: jest.fn() }),
+}));
+
+import { useWidgetSync } from '../useWidgetSync';
+
+const station: Station = {
+  id: '2-001',
+  name: '강남',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+const otherStation: Station = { ...station, id: '2-002', name: '역삼' };
+
+describe('useWidgetSync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('station + distance가 있으면 saveStationToWidget을 호출한다', () => {
+    renderHook(() => useWidgetSync(station, 0.25));
+    expect(mockSave).toHaveBeenCalledWith(station, 0.25);
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it('station이 null이면 clearWidgetStation을 호출한다', () => {
+    renderHook(() => useWidgetSync(null, null));
+    expect(mockClear).toHaveBeenCalled();
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it('distanceKm이 null이면 clearWidgetStation을 호출한다', () => {
+    renderHook(() => useWidgetSync(station, null));
+    expect(mockClear).toHaveBeenCalled();
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it('station이 바뀌면 다시 save를 호출한다', () => {
+    const { rerender } = renderHook(
+      ({ s, d }: { s: Station | null; d: number | null }) => useWidgetSync(s, d),
+      { initialProps: { s: station, d: 0.1 } },
+    );
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    rerender({ s: otherStation, d: 0.2 });
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(mockSave).toHaveBeenLastCalledWith(otherStation, 0.2);
+  });
+
+  it('station → null 전환 시 clear를 호출한다', () => {
+    const { rerender } = renderHook(
+      ({ s, d }: { s: Station | null; d: number | null }) => useWidgetSync(s, d),
+      { initialProps: { s: station as Station | null, d: 0.1 as number | null } },
+    );
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    rerender({ s: null, d: null });
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('save가 실패해도 throw하지 않고 logger.error로 기록한다', async () => {
+    mockSave.mockRejectedValueOnce(new Error('group missing'));
+    renderHook(() => useWidgetSync(station, 0.3));
+    // microtask flush
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockLoggerError).toHaveBeenCalled();
+  });
+
+  it('clear가 실패해도 throw하지 않고 logger.error로 기록한다', async () => {
+    mockClear.mockRejectedValueOnce(new Error('group missing'));
+    renderHook(() => useWidgetSync(null, null));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockLoggerError).toHaveBeenCalled();
+  });
+});

--- a/src/features/widget/hooks/useWidgetSync.ts
+++ b/src/features/widget/hooks/useWidgetSync.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { saveStationToWidget, clearWidgetStation } from '../api/widgetStorage';
+import type { Station } from '../../../shared/types/station';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('widgetSync');
+
+/**
+ * GPS 기반 fused 현재역을 destination/route와 무관하게 위젯에 동기화한다 (#1079).
+ *
+ * 위젯은 (stationName, lineColor, distanceM) 3개만 표시하므로 trip 진행 여부와
+ * 독립적으로 갱신되어야 한다. 기존에는 HomeScreen useEffect가
+ * `!destination`이면 early-return하면서 saveStationToWidget까지 함께 막혀,
+ * 목적지 미설정/다른 탭/HomeScreen 미진입 시 위젯이 "감지 중"에서 갱신되지 않았다.
+ *
+ * dedupe(station.id 기준)는 widgetStorage 내부 모듈 스코프에서 처리된다.
+ */
+export function useWidgetSync(station: Station | null, distanceKm: number | null): void {
+  useEffect(() => {
+    if (!station || distanceKm == null) {
+      clearWidgetStation().catch((e) => logger.error('위젯 해제 실패:', e));
+      return;
+    }
+    saveStationToWidget(station, distanceKm).catch((e) =>
+      logger.error('위젯 저장 실패:', e),
+    );
+  }, [station, distanceKm]);
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
 import { useFusedNearestStation } from '../features/nearest-station/hooks/useFusedNearestStation';
+import { useWidgetSync } from '../features/widget/hooks/useWidgetSync';
 import { useArrivalInfo } from '../features/arrival/hooks/useArrivalInfo';
 import type { ArrivalInfo } from '../features/arrival/api/arrivalApi';
 import { useArrivalCountdown } from '../features/arrival/hooks/useArrivalCountdown';
@@ -161,6 +162,10 @@ export default function HomeScreen() {
   const barometerSignal = useBarometer();
   const { subsurface: barometerSubsurface } = barometerSignal;
   const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal });
+
+  // #1079 — 위젯 갱신은 destination/route와 독립. fused 현재역이 갱신될 때마다 직접 sync.
+  // (기존엔 stationNotification → saveStationToWidget 체인이 destination 미설정 시 early-return.)
+  useWidgetSync(result?.station ?? null, result?.distanceKm ?? null);
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
   // 카드로 노출, 1탭 = customOrigin 적용.


### PR DESCRIPTION
## Summary

- HomeScreen useEffect의 `!destination` early-return이 saveStationToWidget까지 막아 위젯이 "감지 중"에 멈추는 P0 회귀를 수정한다.
- 위젯 갱신을 알림/Live Activity lifecycle에서 떼어내, GPS fused 결과 갱신 시 destination 유무와 무관하게 직접 동기화하도록 한다.

## Changes

- `src/features/widget/hooks/useWidgetSync.ts` 신설 — `(station, distanceKm)` 변화 시 `saveStationToWidget` / `clearWidgetStation` 호출.
- `src/screens/HomeScreen.tsx` — `useFusedNearestStation` 결과(`result?.station`, `result?.distanceKm`)를 `useWidgetSync`에 그대로 전달. destination 게이트 effect는 변경하지 않음.
- `src/features/alarm/utils/stationNotification.ts` — `updateStationNotification` / `clearStationNotification`에서 widget storage 호출 및 import 제거. 알림/LA 책임만 남김.
- 기존 widget storage dedupe(`station.id` 기준)는 `widgetStorage` 모듈 스코프에서 그대로 작동.

## 진입점 선택

옵션 1(useFusedNearestStation 결과를 HomeScreen에서 effect로 직접 호출)을 채택. `useFusedNearestStation` 자체는 이미 cross-feature orchestrator라 추가 의존을 늘리지 않고, HomeScreen은 controller layer라 features import가 허용됨. 별도 orchestrator hook을 두는 것은 현재 사용처가 1개라 과도한 추상화로 판단.

## Test plan

- [x] `useWidgetSync` 테스트 7건 (save/clear, station 변경, null 전환, 실패 시 graceful)
- [x] `stationNotification` widget 분리 검증 2건 (update/clear 양쪽이 widget 함수를 호출하지 않음)
- [x] `npm run type-check` 통과
- [ ] 실기기 회귀: 목적지 미설정 / 다른 탭 / HomeScreen 미진입 상태에서 위젯이 현재역으로 갱신되는지 확인

Closes #1079