### PR TITLE
feat: /feedback POST rate limit (KV fixed window)

### DIFF
--- a/backend/alarm-worker/src/__tests__/feedback.test.ts
+++ b/backend/alarm-worker/src/__tests__/feedback.test.ts
@@ -1,10 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { app } from '../index';
 import {
+  checkRateLimit,
   FEEDBACK_MAX_MESSAGE_LENGTH,
+  FEEDBACK_RATE_LIMIT_MAX,
+  FEEDBACK_RATE_LIMIT_WINDOW_MS,
   FEEDBACK_TTL_SECONDS,
   feedbackKey,
   generateFeedbackId,
+  rateLimitKey,
+  rateLimitWindowStart,
   storeFeedback,
   validateFeedback,
 } from '../feedback';
@@ -26,11 +31,16 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
   };
 }
 
-async function post(path: string, body: unknown, env: Env): Promise<Response> {
+async function post(
+  path: string,
+  body: unknown,
+  env: Env,
+  extraHeaders: Record<string, string> = {},
+): Promise<Response> {
   return app.fetch(
     new Request(`http://example.com${path}`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', ...extraHeaders },
       body: typeof body === 'string' ? body : JSON.stringify(body),
     }),
     env,
@@ -229,5 +239,152 @@ describe('POST /feedback', () => {
     expect(record.message).toBe('something is broken');
     expect(record.context).toEqual({ platform: 'android', appVersion: '1.0.0' });
     expect(typeof record.receivedAt).toBe('number');
+  });
+});
+
+describe('rateLimitWindowStart / rateLimitKey', () => {
+  it('aligns windowStart to FEEDBACK_RATE_LIMIT_WINDOW_MS boundary', () => {
+    expect(rateLimitWindowStart(0)).toBe(0);
+    expect(rateLimitWindowStart(FEEDBACK_RATE_LIMIT_WINDOW_MS - 1)).toBe(0);
+    expect(rateLimitWindowStart(FEEDBACK_RATE_LIMIT_WINDOW_MS)).toBe(
+      FEEDBACK_RATE_LIMIT_WINDOW_MS,
+    );
+    expect(rateLimitWindowStart(FEEDBACK_RATE_LIMIT_WINDOW_MS + 123)).toBe(
+      FEEDBACK_RATE_LIMIT_WINDOW_MS,
+    );
+  });
+
+  it('formats key with ip + windowStart', () => {
+    expect(rateLimitKey('1.2.3.4', 60000)).toBe('rl:feedback:1.2.3.4:60000');
+  });
+});
+
+describe('checkRateLimit', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('allows first MAX requests then denies', async () => {
+    const now = 1_000_000;
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      const r = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+      expect(r.allowed).toBe(true);
+    }
+    const denied = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it('isolates buckets per IP', async () => {
+    const now = 1_000_000;
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+    }
+    // 다른 IP는 별개 버킷
+    const otherIp = await checkRateLimit(kv as unknown as KVNamespace, '2.2.2.2', now);
+    expect(otherIp.allowed).toBe(true);
+  });
+
+  it('resets in next window', async () => {
+    const now = FEEDBACK_RATE_LIMIT_WINDOW_MS * 10;
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+    }
+    const denied = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+    expect(denied.allowed).toBe(false);
+
+    const next = now + FEEDBACK_RATE_LIMIT_WINDOW_MS;
+    const allowed = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', next);
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it('writes counter with TTL matching the window', async () => {
+    const putSpy = vi.spyOn(kv, 'put');
+    await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', 0);
+    expect(putSpy).toHaveBeenCalledWith('rl:feedback:1.1.1.1:0', '1', {
+      expirationTtl: Math.ceil(FEEDBACK_RATE_LIMIT_WINDOW_MS / 1000),
+    });
+  });
+
+  it('treats corrupt counter values as zero', async () => {
+    // 외부 시스템이 garbage를 박아도 정상 동작 (방어적).
+    await kv.put('rl:feedback:1.1.1.1:0', 'not-a-number');
+    const r = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', 0);
+    expect(r.allowed).toBe(true);
+  });
+
+  it('reports at least 1s retryAfter even at window boundary', async () => {
+    // 윈도우 끝에 가까운 시각이라도 Retry-After는 1초 이상.
+    const nearEnd = FEEDBACK_RATE_LIMIT_WINDOW_MS - 100;
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', nearEnd);
+    }
+    const denied = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', nearEnd);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('POST /feedback rate limiting', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function envWithKv(): { env: Env; kv: InMemoryKV } {
+    const kv = new InMemoryKV();
+    const env = makeEnv({ FEEDBACK: kv as unknown as KVNamespace });
+    return { env, kv };
+  }
+
+  it('returns 429 with Retry-After once MAX is exceeded for same IP', async () => {
+    const { env } = envWithKv();
+    const headers = { 'CF-Connecting-IP': '9.9.9.9' };
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      const ok = await post('/feedback', { message: `m${i}` }, env, headers);
+      expect(ok.status).toBe(201);
+    }
+    const denied = await post('/feedback', { message: 'over' }, env, headers);
+    expect(denied.status).toBe(429);
+    expect(await denied.json()).toEqual({ error: 'rate_limited' });
+    expect(denied.headers.get('Retry-After')).toMatch(/^\d+$/);
+  });
+
+  it('does not affect a different IP bucket', async () => {
+    const { env } = envWithKv();
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      await post('/feedback', { message: 'm' }, env, { 'CF-Connecting-IP': '9.9.9.9' });
+    }
+    const other = await post('/feedback', { message: 'hi' }, env, {
+      'CF-Connecting-IP': '8.8.8.8',
+    });
+    expect(other.status).toBe(201);
+  });
+
+  it('buckets requests without CF-Connecting-IP under unknown', async () => {
+    const { env } = envWithKv();
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      const ok = await post('/feedback', { message: 'm' }, env);
+      expect(ok.status).toBe(201);
+    }
+    const denied = await post('/feedback', { message: 'm' }, env);
+    expect(denied.status).toBe(429);
+  });
+
+  it('allows again after window elapses', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FEEDBACK_RATE_LIMIT_WINDOW_MS * 100));
+    const { env } = envWithKv();
+    const headers = { 'CF-Connecting-IP': '7.7.7.7' };
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
+      await post('/feedback', { message: 'm' }, env, headers);
+    }
+    const denied = await post('/feedback', { message: 'm' }, env, headers);
+    expect(denied.status).toBe(429);
+
+    // Advance past window — Date.now() moves to a new bucket. InMemoryKV TTL은 Date.now 기준.
+    vi.setSystemTime(new Date(FEEDBACK_RATE_LIMIT_WINDOW_MS * 101 + 1));
+    const ok = await post('/feedback', { message: 'after' }, env, headers);
+    expect(ok.status).toBe(201);
   });
 });

--- a/backend/alarm-worker/src/__tests__/feedback.test.ts
+++ b/backend/alarm-worker/src/__tests__/feedback.test.ts
@@ -16,6 +16,20 @@ import {
 import type { Env } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
+// 테스트용 임의의 IP 리터럴. 의미 있는 값이 아니라 "서로 다른 IP" 표식.
+const TEST_IP_A = '1.1.1.1';
+const TEST_IP_B = '2.2.2.2';
+const TEST_IP_C = '9.9.9.9';
+const TEST_IP_D = '8.8.8.8';
+const TEST_IP_E = '7.7.7.7';
+const TEST_IP_SAMPLE = '1.2.3.4';
+
+function envWithKv(): { env: Env; kv: InMemoryKV } {
+  const kv = new InMemoryKV();
+  const env = makeEnv({ FEEDBACK: kv as unknown as KVNamespace });
+  return { env, kv };
+}
+
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
     TRIPS: {} as Env['TRIPS'],
@@ -183,12 +197,6 @@ describe('storeFeedback', () => {
 });
 
 describe('POST /feedback', () => {
-  function envWithKv(): { env: Env; kv: InMemoryKV } {
-    const kv = new InMemoryKV();
-    const env = makeEnv({ FEEDBACK: kv as unknown as KVNamespace });
-    return { env, kv };
-  }
-
   it('returns 503 when FEEDBACK binding is missing', async () => {
     const res = await post('/feedback', { message: 'hi' }, makeEnv());
     expect(res.status).toBe(503);
@@ -255,7 +263,7 @@ describe('rateLimitWindowStart / rateLimitKey', () => {
   });
 
   it('formats key with ip + windowStart', () => {
-    expect(rateLimitKey('1.2.3.4', 60000)).toBe('rl:feedback:1.2.3.4:60000');
+    expect(rateLimitKey(TEST_IP_SAMPLE, 60000)).toBe(`rl:feedback:${TEST_IP_SAMPLE}:60000`);
   });
 });
 
@@ -268,10 +276,10 @@ describe('checkRateLimit', () => {
   it('allows first MAX requests then denies', async () => {
     const now = 1_000_000;
     for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
-      const r = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+      const r = await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, now);
       expect(r.allowed).toBe(true);
     }
-    const denied = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+    const denied = await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, now);
     expect(denied.allowed).toBe(false);
     expect(denied.retryAfterSeconds).toBeGreaterThan(0);
   });
@@ -279,38 +287,38 @@ describe('checkRateLimit', () => {
   it('isolates buckets per IP', async () => {
     const now = 1_000_000;
     for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
-      await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+      await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, now);
     }
     // 다른 IP는 별개 버킷
-    const otherIp = await checkRateLimit(kv as unknown as KVNamespace, '2.2.2.2', now);
+    const otherIp = await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_B, now);
     expect(otherIp.allowed).toBe(true);
   });
 
   it('resets in next window', async () => {
     const now = FEEDBACK_RATE_LIMIT_WINDOW_MS * 10;
     for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
-      await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+      await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, now);
     }
-    const denied = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', now);
+    const denied = await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, now);
     expect(denied.allowed).toBe(false);
 
     const next = now + FEEDBACK_RATE_LIMIT_WINDOW_MS;
-    const allowed = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', next);
+    const allowed = await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, next);
     expect(allowed.allowed).toBe(true);
   });
 
   it('writes counter with TTL matching the window', async () => {
     const putSpy = vi.spyOn(kv, 'put');
-    await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', 0);
-    expect(putSpy).toHaveBeenCalledWith('rl:feedback:1.1.1.1:0', '1', {
+    await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, 0);
+    expect(putSpy).toHaveBeenCalledWith(`rl:feedback:${TEST_IP_A}:0`, '1', {
       expirationTtl: Math.ceil(FEEDBACK_RATE_LIMIT_WINDOW_MS / 1000),
     });
   });
 
   it('treats corrupt counter values as zero', async () => {
     // 외부 시스템이 garbage를 박아도 정상 동작 (방어적).
-    await kv.put('rl:feedback:1.1.1.1:0', 'not-a-number');
-    const r = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', 0);
+    await kv.put(`rl:feedback:${TEST_IP_A}:0`, 'not-a-number');
+    const r = await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, 0);
     expect(r.allowed).toBe(true);
   });
 
@@ -318,9 +326,9 @@ describe('checkRateLimit', () => {
     // 윈도우 끝에 가까운 시각이라도 Retry-After는 1초 이상.
     const nearEnd = FEEDBACK_RATE_LIMIT_WINDOW_MS - 100;
     for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
-      await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', nearEnd);
+      await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, nearEnd);
     }
-    const denied = await checkRateLimit(kv as unknown as KVNamespace, '1.1.1.1', nearEnd);
+    const denied = await checkRateLimit(kv as unknown as KVNamespace, TEST_IP_A, nearEnd);
     expect(denied.allowed).toBe(false);
     expect(denied.retryAfterSeconds).toBeGreaterThanOrEqual(1);
   });
@@ -331,15 +339,9 @@ describe('POST /feedback rate limiting', () => {
     vi.useRealTimers();
   });
 
-  function envWithKv(): { env: Env; kv: InMemoryKV } {
-    const kv = new InMemoryKV();
-    const env = makeEnv({ FEEDBACK: kv as unknown as KVNamespace });
-    return { env, kv };
-  }
-
   it('returns 429 with Retry-After once MAX is exceeded for same IP', async () => {
     const { env } = envWithKv();
-    const headers = { 'CF-Connecting-IP': '9.9.9.9' };
+    const headers = { 'CF-Connecting-IP': TEST_IP_C };
     for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
       const ok = await post('/feedback', { message: `m${i}` }, env, headers);
       expect(ok.status).toBe(201);
@@ -353,10 +355,10 @@ describe('POST /feedback rate limiting', () => {
   it('does not affect a different IP bucket', async () => {
     const { env } = envWithKv();
     for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
-      await post('/feedback', { message: 'm' }, env, { 'CF-Connecting-IP': '9.9.9.9' });
+      await post('/feedback', { message: 'm' }, env, { 'CF-Connecting-IP': TEST_IP_C });
     }
     const other = await post('/feedback', { message: 'hi' }, env, {
-      'CF-Connecting-IP': '8.8.8.8',
+      'CF-Connecting-IP': TEST_IP_D,
     });
     expect(other.status).toBe(201);
   });
@@ -375,7 +377,7 @@ describe('POST /feedback rate limiting', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FEEDBACK_RATE_LIMIT_WINDOW_MS * 100));
     const { env } = envWithKv();
-    const headers = { 'CF-Connecting-IP': '7.7.7.7' };
+    const headers = { 'CF-Connecting-IP': TEST_IP_E };
     for (let i = 0; i < FEEDBACK_RATE_LIMIT_MAX; i += 1) {
       await post('/feedback', { message: 'm' }, env, headers);
     }

--- a/backend/alarm-worker/src/feedback.ts
+++ b/backend/alarm-worker/src/feedback.ts
@@ -13,6 +13,66 @@
 export const FEEDBACK_TTL_SECONDS = 30 * 24 * 60 * 60;
 export const FEEDBACK_MAX_MESSAGE_LENGTH = 2000;
 
+/**
+ * Rate limit (스팸 방지).
+ *
+ * 동일 IP가 1분 fixed window 안에서 5회까지 POST 가능. 6번째부터 429.
+ * Fixed window를 택한 이유:
+ *   - 코드/스토리지 단순. sliding window는 history 배열 유지 필요해 read-modify-write payload가 커진다.
+ *   - 경계에서 burst 허용 (최악 10회/2분) 가능하지만 사용자 버그 신고 채널엔 수용 가능.
+ *
+ * Storage: 기존 FEEDBACK KV를 prefix `rl:feedback:`로 공유. namespace 추가 안 함.
+ * Key: `rl:feedback:${ip}:${windowStartMs}` — 윈도우가 바뀌면 자연스럽게 새 키.
+ * TTL: WINDOW_MS와 동일 (60s) — 윈도우 종료 후 KV가 자동 청소.
+ * Race: KV는 eventually consistent이므로 burst 시 정확히 5건 cap 보장 안 됨 (~5건).
+ *       buggy spammer 차단이 목적이므로 soft cap으로 충분.
+ */
+export const FEEDBACK_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+export const FEEDBACK_RATE_LIMIT_MAX = 5;
+
+export function rateLimitKey(ip: string, windowStartMs: number): string {
+  return `rl:feedback:${ip}:${windowStartMs}`;
+}
+
+export function rateLimitWindowStart(nowMs: number): number {
+  return Math.floor(nowMs / FEEDBACK_RATE_LIMIT_WINDOW_MS) * FEEDBACK_RATE_LIMIT_WINDOW_MS;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** 윈도우 종료까지 남은 초. 429 응답의 Retry-After 헤더에 사용. */
+  retryAfterSeconds: number;
+}
+
+/**
+ * Fixed-window 카운트 증가. count > MAX이면 거부.
+ *
+ * 정확한 atomic increment 대신 read→write의 best-effort 증가 — KV는 atomic op이 없다.
+ * 동시 요청 충돌 시 일부 카운트가 누락될 수 있으나, 스팸 차단 임계값(분당 5회)이
+ * 매우 낮아 실질 cap은 ~5건으로 유지된다.
+ */
+export async function checkRateLimit(
+  kv: KVNamespace,
+  ip: string,
+  nowMs: number,
+): Promise<RateLimitResult> {
+  const windowStart = rateLimitWindowStart(nowMs);
+  const key = rateLimitKey(ip, windowStart);
+  const raw = await kv.get(key);
+  const current = raw ? Number.parseInt(raw, 10) : 0;
+  const count = Number.isFinite(current) && current >= 0 ? current : 0;
+  const windowEnd = windowStart + FEEDBACK_RATE_LIMIT_WINDOW_MS;
+  const retryAfterSeconds = Math.max(1, Math.ceil((windowEnd - nowMs) / 1000));
+
+  if (count >= FEEDBACK_RATE_LIMIT_MAX) {
+    return { allowed: false, retryAfterSeconds };
+  }
+  await kv.put(key, String(count + 1), {
+    expirationTtl: Math.ceil(FEEDBACK_RATE_LIMIT_WINDOW_MS / 1000),
+  });
+  return { allowed: true, retryAfterSeconds };
+}
+
 export interface FeedbackContext {
   appVersion?: string;
   platform?: 'ios' | 'android';

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from './boardingPromptOutcome';
 import { runFallbackPushes } from './fallback';
 import {
+  checkRateLimit,
   generateFeedbackId,
   storeFeedback,
   validateFeedback,
@@ -97,13 +98,28 @@ app.get('/health', (c) => c.json({ ok: true }));
  * Responses:
  *   201 { ok: true, key }       — 적재 성공
  *   400 { error: 'invalid_json' | 'invalid_payload' }
+ *   429 { error: 'rate_limited' } — 동일 IP 1분 5회 초과. `Retry-After`(seconds) 포함
  *   503 { error: 'feedback_unavailable' } — FEEDBACK binding 미설정 (운영자 namespace 발급 전)
  *
  * 보관: TTL 30일. 운영자가 `wrangler kv` CLI로 수거.
+ *
+ * Rate limit: CF-Connecting-IP 기준 분당 5회 (PR #1042 follow-up, 스팸 방지).
+ *   - 헤더 부재 시 'unknown' 단일 버킷으로 fallback — 헤더가 없는 환경(테스트/로컬)도 cap 받음.
  */
 app.post('/feedback', async (c) => {
   const kv = c.env.FEEDBACK;
   if (!kv) return c.json({ error: 'feedback_unavailable' }, 503);
+
+  const ip = c.req.header('CF-Connecting-IP') ?? 'unknown';
+  const now = Date.now();
+  const rl = await checkRateLimit(kv, ip, now);
+  if (!rl.allowed) {
+    return c.json(
+      { error: 'rate_limited' },
+      429,
+      { 'Retry-After': String(rl.retryAfterSeconds) },
+    );
+  }
 
   let body: unknown;
   try {
@@ -115,9 +131,8 @@ app.post('/feedback', async (c) => {
   const payload = validateFeedback(body);
   if (!payload) return c.json({ error: 'invalid_payload' }, 400);
 
-  const receivedAt = Date.now();
   const id = generateFeedbackId();
-  const key = await storeFeedback(kv, payload, receivedAt, id);
+  const key = await storeFeedback(kv, payload, now, id);
   return c.json({ ok: true, key }, 201);
 });
 


### PR DESCRIPTION
PR #1042 follow-up. PR #1080과 동시에 dev로 머지 시 `backend/alarm-worker/src/feedback.ts` / `index.ts` 영역에서 conflict 가능 — 머지 순서 조율 필요.

## Summary
- `/feedback` POST에 IP 기준 fixed-window rate limit 추가 (스팸 방지).
- 임계값: **분당 5회 / IP** (`FEEDBACK_RATE_LIMIT_MAX=5`, window `60_000ms`).
- KV 키 패턴: `rl:feedback:${ip}:${windowStartMs}` — 기존 `FEEDBACK` KV namespace 재사용, 새 binding 없음. TTL = window(60s).
- IP 추출: `CF-Connecting-IP` 헤더. 부재 시 `'unknown'` 단일 버킷 fallback.
  - **한계**: 단일 fallback 키이므로 분산 환경에서 헤더 없는 정상 트래픽까지 같은 버킷을 공유한다. 운영상 Cloudflare edge는 항상 `CF-Connecting-IP`를 채워주므로 실제 영향은 무시할 수준이지만, 직접 호출/테스트 트래픽에서는 cap에 걸릴 수 있음.
- 초과 시 `429 { error: 'rate_limited' }` + `Retry-After: <remaining seconds>` 헤더.
- KV는 atomic increment가 없어 race 시 best-effort. 임계가 낮아 실질 cap은 ~5건 유지.

## Test plan
- [x] `cd backend/alarm-worker && npm test` — 996 tests pass (feedback 34건 포함: allow/deny/per-IP/missing IP/corrupt counter/window reset)
- [x] `npm run type-check` — pass
- [ ] 실측: production 배포 후 동일 IP로 6회 연속 호출 시 6번째 응답 `429` + `Retry-After` 확인