### PR TITLE
feat: ServiceWindowBanner HomeScreen 진입

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -36,6 +36,7 @@ import { AlarmOverlay } from '../features/alarm/components/AlarmOverlay';
 import { createLogger } from '../shared/utils/logger';
 import { useTheme, typography, spacing, radius } from '../shared/theme';
 import { LineBadge } from '../shared/ui/LineBadge';
+import { ServiceWindowBanner } from '../shared/ui/ServiceWindowBanner';
 import { SourceBadge } from '../features/arrival/components/SourceBadge';
 import { resolveNotificationSource } from '../features/alarm/utils/notificationSource';
 import { ArrivalSourceNotice } from '../features/arrival/components/ArrivalSourceNotice';
@@ -742,6 +743,11 @@ export default function HomeScreen() {
       >
         {effectiveOrigin ? (
           <>
+            {/* #1066 follow-up — 운행 시간 외 안내 배너. 배너 자체가 in-service/unknown 분기에서
+                 null을 반환해 운행 중엔 자동 숨김. effectiveOrigin.line 기준으로 timetable 조회. */}
+            <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxl }}>
+              <ServiceWindowBanner stationName={effectiveOrigin.name} line={effectiveOrigin.line} />
+            </View>
             {/* Hero: origin station */}
             <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxxl - 4 }}>
               <Text style={[typography.label, { color: colors.muted, marginBottom: 10 }]}>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -749,10 +749,10 @@ export default function HomeScreen() {
         {effectiveOrigin ? (
           <>
             {/* #1066 follow-up — 운행 시간 외 안내 배너. 배너 자체가 in-service/unknown 분기에서
-                 null을 반환해 운행 중엔 자동 숨김. effectiveOrigin.line 기준으로 timetable 조회. */}
-            <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxl }}>
-              <ServiceWindowBanner stationName={effectiveOrigin.name} line={effectiveOrigin.line} />
-            </View>
+                 null을 반환해 운행 중엔 자동 숨김. 외곽 padding은 배너가 직접 소유한다 — 여기에
+                 wrapper로 padding을 두면 운행 중에도 phantom 여백이 남아 하단 레이아웃을
+                 밀어내고 E2E scrollUntilVisible 회귀를 일으킨다(#1083). */}
+            <ServiceWindowBanner stationName={effectiveOrigin.name} line={effectiveOrigin.line} />
             {/* Hero: origin station */}
             <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxxl - 4 }}>
               <Text style={[typography.label, { color: colors.muted, marginBottom: 10 }]}>

--- a/src/shared/ui/ServiceWindowBanner.tsx
+++ b/src/shared/ui/ServiceWindowBanner.tsx
@@ -30,16 +30,9 @@ interface Props {
 export function ServiceWindowBanner({ stationName, line, now }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  // Hermes/iOS Intl 구현이 timeZone+formatToParts(weekday) 조합에서 일부 part를
-  // 누락해 throw하는 사례가 관측됐다(#1083 E2E 회귀). 배너는 보조 UI이므로 어떤 이유로든
-  // window 산출이 실패하면 조용히 null을 반환해 화면 전체 크래시를 막는다.
-  let window: ReturnType<typeof getServiceWindow>;
-  try {
-    window = getServiceWindow({ stationName, line, now });
-  } catch {
-    return null;
-  }
-  const { status, firstTrain } = window;
+  // #1088(safe Intl helper) 머지 이후 getServiceWindow는 throw 대신 status='unknown' 반환 →
+  // 별도 try/catch 불필요. unknown 분기에서 null을 반환하는 아래 가드가 안전망 역할.
+  const { status, firstTrain } = getServiceWindow({ stationName, line, now });
 
   // 운행 중이거나 timetable unknown이면 안내 불필요.
   // firstTrain은 pre-first/post-last 분기일 때 getServiceWindow가 보장하는 non-null.

--- a/src/shared/ui/ServiceWindowBanner.tsx
+++ b/src/shared/ui/ServiceWindowBanner.tsx
@@ -46,22 +46,31 @@ export function ServiceWindowBanner({ stationName, line, now }: Props) {
       : t('service.window.postLast', { time: firstTrain });
 
   return (
-    <View
-      style={[styles.container, { backgroundColor: colors.card, borderColor: colors.warn }]}
-      testID="service-window-banner"
-      accessibilityRole="alert"
-    >
-      <Text
-        style={[typography.body, { color: colors.warn, fontWeight: '600' }]}
-        testID="service-window-banner-text"
+    <View style={styles.outer}>
+      <View
+        style={[styles.container, { backgroundColor: colors.card, borderColor: colors.warn }]}
+        testID="service-window-banner"
+        accessibilityRole="alert"
       >
-        {message}
-      </Text>
+        <Text
+          style={[typography.body, { color: colors.warn, fontWeight: '600' }]}
+          testID="service-window-banner-text"
+        >
+          {message}
+        </Text>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  // 외곽 spacing을 배너가 직접 소유한다. HomeScreen 등 consumer가 wrapper에
+  // padding을 두면 운행 중(=배너 null)에도 phantom 여백이 남아 viewport-tight
+  // layout(E2E scrollUntilVisible 등)에서 회귀를 일으킨다(#1083).
+  outer: {
+    paddingHorizontal: spacing.xxl,
+    paddingTop: spacing.xxl,
+  },
   container: {
     padding: spacing.lg,
     borderRadius: radius.lg,

--- a/src/shared/ui/ServiceWindowBanner.tsx
+++ b/src/shared/ui/ServiceWindowBanner.tsx
@@ -30,7 +30,16 @@ interface Props {
 export function ServiceWindowBanner({ stationName, line, now }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const { status, firstTrain } = getServiceWindow({ stationName, line, now });
+  // Hermes/iOS Intl 구현이 timeZone+formatToParts(weekday) 조합에서 일부 part를
+  // 누락해 throw하는 사례가 관측됐다(#1083 E2E 회귀). 배너는 보조 UI이므로 어떤 이유로든
+  // window 산출이 실패하면 조용히 null을 반환해 화면 전체 크래시를 막는다.
+  let window: ReturnType<typeof getServiceWindow>;
+  try {
+    window = getServiceWindow({ stationName, line, now });
+  } catch {
+    return null;
+  }
+  const { status, firstTrain } = window;
 
   // 운행 중이거나 timetable unknown이면 안내 불필요.
   // firstTrain은 pre-first/post-last 분기일 때 getServiceWindow가 보장하는 non-null.

--- a/src/shared/ui/__tests__/ServiceWindowBanner.test.tsx
+++ b/src/shared/ui/__tests__/ServiceWindowBanner.test.tsx
@@ -1,6 +1,5 @@
 import { ServiceWindowBanner } from '../ServiceWindowBanner';
 import { renderWithTheme } from '../../../testUtils/renderWithTheme';
-import * as serviceWindowModule from '../../../features/route/utils/serviceWindow';
 
 /**
  * #1066 — getServiceWindow 4개 분기(pre-first / in-service / post-last / unknown)별
@@ -54,19 +53,4 @@ describe('ServiceWindowBanner', () => {
     ).not.toThrow();
   });
 
-  it('getServiceWindow가 throw해도 화면을 크래시시키지 않고 null을 반환한다 (#1083)', () => {
-    // Hermes/iOS Intl 구현에서 timeZone+formatToParts(weekday)가 part를 누락해
-    // TypeError를 던지는 회귀가 관측됐다. 배너는 보조 UI이므로 안전망이 필요하다.
-    const spy = jest.spyOn(serviceWindowModule, 'getServiceWindow').mockImplementation(() => {
-      throw new TypeError("Cannot read property 'value' of undefined");
-    });
-    try {
-      const { queryByTestId } = renderWithTheme(
-        <ServiceWindowBanner stationName="강남" line="2" now={IN_SERVICE_KST_10_00} />,
-      );
-      expect(queryByTestId('service-window-banner')).toBeNull();
-    } finally {
-      spy.mockRestore();
-    }
-  });
 });

--- a/src/shared/ui/__tests__/ServiceWindowBanner.test.tsx
+++ b/src/shared/ui/__tests__/ServiceWindowBanner.test.tsx
@@ -1,5 +1,6 @@
 import { ServiceWindowBanner } from '../ServiceWindowBanner';
 import { renderWithTheme } from '../../../testUtils/renderWithTheme';
+import * as serviceWindowModule from '../../../features/route/utils/serviceWindow';
 
 /**
  * #1066 — getServiceWindow 4개 분기(pre-first / in-service / post-last / unknown)별
@@ -51,5 +52,21 @@ describe('ServiceWindowBanner', () => {
     expect(() =>
       renderWithTheme(<ServiceWindowBanner stationName="소요산" line="1" />),
     ).not.toThrow();
+  });
+
+  it('getServiceWindow가 throw해도 화면을 크래시시키지 않고 null을 반환한다 (#1083)', () => {
+    // Hermes/iOS Intl 구현에서 timeZone+formatToParts(weekday)가 part를 누락해
+    // TypeError를 던지는 회귀가 관측됐다. 배너는 보조 UI이므로 안전망이 필요하다.
+    const spy = jest.spyOn(serviceWindowModule, 'getServiceWindow').mockImplementation(() => {
+      throw new TypeError("Cannot read property 'value' of undefined");
+    });
+    try {
+      const { queryByTestId } = renderWithTheme(
+        <ServiceWindowBanner stationName="강남" line="2" now={IN_SERVICE_KST_10_00} />,
+      );
+      expect(queryByTestId('service-window-banner')).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- PR #1072 (#1066) follow-up — 공용 `ServiceWindowBanner`를 HomeScreen에 첫 진입.
- `effectiveOrigin`이 결정된 뒤 hero(현재역) 카드 위에 렌더. 배너 컴포넌트 내부에서 `getServiceWindow` 분기로 `pre-first` / `post-last`일 때만 노출, `in-service` / `unknown`은 null.
- 운행 시간 외엔 ETA가 부정확하므로 사용자에게 첫차/막차 시각을 명확히 안내.

## 배치
- `<ScrollView>` 안 `effectiveOrigin ?` 분기 첫 노드, hero 카드 바로 위 (`paddingHorizontal: spacing.xxl, paddingTop: spacing.xxl`).
- 운행시간 판정 source: `effectiveOrigin.name` + `effectiveOrigin.line` → 배너 내부 `getServiceWindow({ stationName, line, now=new Date() })`.

## Test plan
- [x] `npm run type-check` 통과
- [x] `npx jest src/shared/ui/__tests__/ServiceWindowBanner.test.tsx` 5/5 pass (pre-first / post-last / in-service / unknown / now 미지정 fallback).
- [ ] 실기기: KST 02:00 / 04:00 등 운행 시간 외 진입 시 hero 위 배너 노출 확인.
- [ ] 실기기: 운행 시간 내(10:00) 배너 미노출 확인.

NOTE: 본 PR diff에는 영향 없는 pre-existing 테스트 실패(`SharedGroupAdapter`, `widgetStorage`, `stationNotification`)가 `origin/dev`에서 동일하게 재현됨 — 별개 이슈.