### PR TITLE
feat: Sentry opt-in 토글 Settings 화면 추가

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -16,6 +16,13 @@ jest.mock('expo-localization', () => ({
   getLocales: () => [{ languageCode: 'ko' }],
 }));
 
+// @sentry/react-native: ESM 모듈로 jest transform 미지원 →
+// 전역 no-op mock. 개별 테스트가 필요시 jest.mock으로 덮어쓴다.
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  close: jest.fn(),
+}));
+
 const i18next = require('i18next');
 const { initReactI18next } = require('react-i18next');
 const { LANGUAGE_REGISTRY, FALLBACK_LANGUAGE } = require('./src/shared/i18n/types');

--- a/src/features/settings/store/__tests__/useSettingsStore.test.ts
+++ b/src/features/settings/store/__tests__/useSettingsStore.test.ts
@@ -1,9 +1,21 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSettingsStore } from '../useSettingsStore';
+import {
+  getSentryOptIn,
+  setSentryOptIn,
+} from '../../../../shared/infra/monitoring/sentryInit';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
+
+jest.mock('../../../../shared/infra/monitoring/sentryInit', () => ({
+  getSentryOptIn: jest.fn().mockResolvedValue(false),
+  setSentryOptIn: jest.fn().mockResolvedValue(undefined),
+}));
+
+const getSentryOptInMock = getSentryOptIn as jest.Mock;
+const setSentryOptInMock = setSentryOptIn as jest.Mock;
 
 describe('useSettingsStore', () => {
   beforeEach(() => {
@@ -13,8 +25,11 @@ describe('useSettingsStore', () => {
       accessibilityMode: false,
       // #915 — default ON. 각 테스트가 명시적으로 false로 덮어쓸 수 있다.
       locklessStationPassed: true,
+      sentryOptIn: false,
     });
     jest.clearAllMocks();
+    getSentryOptInMock.mockResolvedValue(false);
+    setSentryOptInMock.mockResolvedValue(undefined);
   });
 
   // ── sleepMode ──
@@ -171,5 +186,36 @@ describe('useSettingsStore', () => {
     (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
     await useSettingsStore.getState().loadLocklessStationPassed();
     expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
+  });
+
+  // ── #1038 — sentryOptIn (default OFF, opt-in only) ──
+
+  it('초기 sentryOptIn은 false다 (#1038 default OFF)', () => {
+    expect(useSettingsStore.getState().sentryOptIn).toBe(false);
+  });
+
+  it('setSentryOptIn: true → 상태 갱신 + sentryInit.setSentryOptIn(true) 호출', async () => {
+    await useSettingsStore.getState().setSentryOptIn(true);
+    expect(useSettingsStore.getState().sentryOptIn).toBe(true);
+    expect(setSentryOptInMock).toHaveBeenCalledWith(true);
+  });
+
+  it('setSentryOptIn: false → 상태 갱신 + sentryInit.setSentryOptIn(false) 호출', async () => {
+    useSettingsStore.setState({ sentryOptIn: true });
+    await useSettingsStore.getState().setSentryOptIn(false);
+    expect(useSettingsStore.getState().sentryOptIn).toBe(false);
+    expect(setSentryOptInMock).toHaveBeenCalledWith(false);
+  });
+
+  it('loadSentryOptIn: 저장된 true를 복원한다', async () => {
+    getSentryOptInMock.mockResolvedValueOnce(true);
+    await useSettingsStore.getState().loadSentryOptIn();
+    expect(useSettingsStore.getState().sentryOptIn).toBe(true);
+  });
+
+  it('loadSentryOptIn: 저장값 없으면 false 유지', async () => {
+    getSentryOptInMock.mockResolvedValueOnce(false);
+    await useSettingsStore.getState().loadSentryOptIn();
+    expect(useSettingsStore.getState().sentryOptIn).toBe(false);
   });
 });

--- a/src/features/settings/store/useSettingsStore.ts
+++ b/src/features/settings/store/useSettingsStore.ts
@@ -6,6 +6,7 @@ import {
   ACCESSIBILITY_MODE_KEY,
   LOCKLESS_STATION_PASSED_KEY,
 } from '../../../shared/constants/storageKeys';
+import { getSentryOptIn, setSentryOptIn } from '../../../shared/infra/monitoring/sentryInit';
 
 /**
  * Settings store — ADR 후속 Step 6 (#892).
@@ -37,6 +38,15 @@ export interface SettingsState {
   locklessStationPassed: boolean;
   setLocklessStationPassed: (enabled: boolean) => Promise<void>;
   loadLocklessStationPassed: () => Promise<void>;
+
+  /**
+   * #1038 follow-up — Sentry 오류 진단 정보 전송 opt-in. 기본 OFF.
+   * Storage 형식은 `sentryInit.ts`가 boot path에서 읽는 raw 'true'/'false' 문자열.
+   * 토글 시 `setSentryOptIn`이 Sentry SDK를 런타임에 enable/disable한다.
+   */
+  sentryOptIn: boolean;
+  setSentryOptIn: (enabled: boolean) => Promise<void>;
+  loadSentryOptIn: () => Promise<void>;
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
@@ -45,6 +55,8 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   accessibilityMode: false,
   // #915 — destination-only baseline UX. 매역 알림이 zero-config로 동작하도록 default ON.
   locklessStationPassed: true,
+  // #1038 — privacy stance. 사용자가 명시 동의해야 활성화.
+  sentryOptIn: false,
 
   setSleepMode: async (enabled: boolean) => {
     set({ sleepMode: enabled });
@@ -108,5 +120,15 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     } catch {
       // 저장된 데이터 없음 — false 유지
     }
+  },
+
+  setSentryOptIn: async (enabled: boolean) => {
+    set({ sentryOptIn: enabled });
+    await setSentryOptIn(enabled);
+  },
+
+  loadSentryOptIn: async () => {
+    const value = await getSentryOptIn();
+    set({ sentryOptIn: value });
   },
 }));

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -40,6 +40,10 @@ export default function SettingsScreen() {
   const locklessStationPassed = useSettingsStore((s) => s.locklessStationPassed);
   const setLocklessStationPassed = useSettingsStore((s) => s.setLocklessStationPassed);
   const loadLocklessStationPassed = useSettingsStore((s) => s.loadLocklessStationPassed);
+  // #1038 follow-up — Sentry 오류 진단 정보 opt-in.
+  const sentryOptIn = useSettingsStore((s) => s.sentryOptIn);
+  const setSentryOptIn = useSettingsStore((s) => s.setSentryOptIn);
+  const loadSentryOptIn = useSettingsStore((s) => s.loadSentryOptIn);
   const themeMode = useThemeStore((s) => s.themeMode);
   const setThemeMode = useThemeStore((s) => s.setThemeMode);
   const routePreference = useDestinationStore((s) => s.routePreference);
@@ -59,6 +63,7 @@ export default function SettingsScreen() {
     loadAccessibilityMode();
     loadRoutePreference();
     loadLocklessStationPassed();
+    loadSentryOptIn();
   }, []);
 
   return (
@@ -201,6 +206,34 @@ export default function SettingsScreen() {
               accessibilityLabel={t('settings.accessibilityModeLabel')}
               accessibilityHint={t('a11y.settings.accessibilityModeHint')}
               accessibilityState={{ checked: accessibilityMode }}
+            />
+          </View>
+        </View>
+
+        {/* #1038 follow-up — Sentry 오류 진단 정보 opt-in. 기본 OFF. */}
+        <View style={[styles.card, { backgroundColor: colors.card }]}>
+          <Text style={[styles.sectionTitle, { color: colors.muted }]}>
+            {t('settings.privacySection')}
+          </Text>
+          <View style={styles.settingRow}>
+            <View style={styles.settingInfo}>
+              <Text style={[styles.settingLabel, { color: colors.ink }]}>
+                {t('settings.sentryOptInLabel')}
+              </Text>
+              <Text style={[styles.settingDesc, { color: colors.muted }]}>
+                {t('settings.sentryOptInDescription')}
+              </Text>
+            </View>
+            <Switch
+              value={sentryOptIn}
+              onValueChange={setSentryOptIn}
+              trackColor={{ false: colors.hair, true: colors.accent }}
+              thumbColor={sentryOptIn ? colors.onAccent : colors.subtle}
+              testID="sentry-opt-in-switch"
+              accessibilityRole="switch"
+              accessibilityLabel={t('settings.sentryOptInLabel')}
+              accessibilityHint={t('a11y.settings.sentryOptInHint')}
+              accessibilityState={{ checked: sentryOptIn }}
             />
           </View>
         </View>

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -89,7 +89,10 @@
     "languageAuto": "Auto",
     "feedbackSection": "Support",
     "feedbackLabel": "Report a bug",
-    "feedbackDescription": "Tell us about issues you encountered"
+    "feedbackDescription": "Tell us about issues you encountered",
+    "privacySection": "Privacy",
+    "sentryOptInLabel": "Send diagnostic data",
+    "sentryOptInDescription": "Send anonymous error reports to the developer"
   },
   "feedback": {
     "title": "Report a bug",
@@ -273,6 +276,7 @@
       "sleepModeHint": "Plays a wake-up alarm sound when headphones are connected",
       "speakerOutputHint": "Plays alarm sound through the speaker when headphones are not connected",
       "locklessStationPassedHint": "Receive station-passed alerts even when no train is selected",
+      "sentryOptInHint": "Consent to send anonymous error reports",
       "accessibilityModeHint": "Guides quick-exit positions based on elevators",
       "versionFooterLabel": "App version {{version}}",
       "versionFooterHint": "Tap multiple times to open the debug menu",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -89,7 +89,10 @@
     "languageAuto": "自動",
     "feedbackSection": "サポート",
     "feedbackLabel": "バグを報告",
-    "feedbackDescription": "アプリで発生した問題をお知らせください"
+    "feedbackDescription": "アプリで発生した問題をお知らせください",
+    "privacySection": "プライバシー",
+    "sentryOptInLabel": "エラー診断情報の送信",
+    "sentryOptInDescription": "匿名のエラー情報を開発者に送信します"
   },
   "feedback": {
     "title": "バグを報告",
@@ -273,6 +276,7 @@
       "sleepModeHint": "イヤホン接続時に起床アラーム音で鳴ります",
       "speakerOutputHint": "イヤホン未接続時にスピーカーでアラーム音を再生",
       "locklessStationPassedHint": "乗車列車を選択していなくても通過通知を受け取る",
+      "sentryOptInHint": "匿名のエラー情報送信に同意",
       "accessibilityModeHint": "エレベーター基準で速やかな降車位置を案内",
       "versionFooterLabel": "アプリバージョン {{version}}",
       "versionFooterHint": "複数回タップでデバッグメニューを開く",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -89,7 +89,10 @@
     "languageAuto": "자동",
     "feedbackSection": "지원",
     "feedbackLabel": "버그 신고",
-    "feedbackDescription": "앱에서 겪은 문제를 알려 주세요"
+    "feedbackDescription": "앱에서 겪은 문제를 알려 주세요",
+    "privacySection": "개인정보",
+    "sentryOptInLabel": "오류 진단 정보 전송",
+    "sentryOptInDescription": "익명 오류 정보를 개발자에게 전송합니다"
   },
   "feedback": {
     "title": "버그 신고",
@@ -273,6 +276,7 @@
       "sleepModeHint": "이어폰 연결 시 기상 알람음으로 울립니다",
       "speakerOutputHint": "이어폰 미연결 시 스피커로 알람음 재생",
       "locklessStationPassedHint": "탑승 열차 선택 없이도 역 통과 알림 수신",
+      "sentryOptInHint": "익명 오류 정보 전송 동의",
       "accessibilityModeHint": "엘리베이터 기준으로 빠른 하차 위치 안내",
       "versionFooterLabel": "앱 버전 {{version}}",
       "versionFooterHint": "여러 번 탭하면 디버그 메뉴 열기",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -89,7 +89,10 @@
     "languageAuto": "自动",
     "feedbackSection": "支持",
     "feedbackLabel": "报告问题",
-    "feedbackDescription": "告诉我们您遇到的问题"
+    "feedbackDescription": "告诉我们您遇到的问题",
+    "privacySection": "隐私",
+    "sentryOptInLabel": "发送错误诊断信息",
+    "sentryOptInDescription": "向开发者发送匿名错误信息"
   },
   "feedback": {
     "title": "报告问题",
@@ -273,6 +276,7 @@
       "sleepModeHint": "连接耳机时以起床闹钟音播放",
       "speakerOutputHint": "未连接耳机时通过扬声器播放闹钟音",
       "locklessStationPassedHint": "未选择乘车列车也会收到经过站点通知",
+      "sentryOptInHint": "同意发送匿名错误信息",
       "accessibilityModeHint": "按电梯位置引导快速下车位置",
       "versionFooterLabel": "应用版本 {{version}}",
       "versionFooterHint": "多次点击打开调试菜单",

--- a/src/shared/infra/monitoring/__tests__/sentryInit.test.ts
+++ b/src/shared/infra/monitoring/__tests__/sentryInit.test.ts
@@ -1,22 +1,28 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
-import { initSentryIfOptedIn } from '../sentryInit';
+import { getSentryOptIn, initSentryIfOptedIn, setSentryOptIn } from '../sentryInit';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
+  setItem: jest.fn(),
 }));
 jest.mock('@sentry/react-native', () => ({
   init: jest.fn(),
+  close: jest.fn(),
 }));
 
 const getItemMock = AsyncStorage.getItem as jest.Mock;
+const setItemMock = AsyncStorage.setItem as jest.Mock;
 const initMock = Sentry.init as jest.Mock;
+const closeMock = Sentry.close as jest.Mock;
 
 const originalDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
 
 beforeEach(() => {
   getItemMock.mockReset();
+  setItemMock.mockReset();
   initMock.mockReset();
+  closeMock.mockReset();
   delete process.env.EXPO_PUBLIC_SENTRY_DSN;
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -71,5 +77,67 @@ describe('initSentryIfOptedIn', () => {
       throw new Error('sentry boom');
     });
     await expect(initSentryIfOptedIn()).resolves.toBeUndefined();
+  });
+});
+
+describe('setSentryOptIn', () => {
+  it('enabled=true: storage에 "true" 저장 + DSN 있으면 Sentry.init', async () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = 'https://test@sentry.io/123';
+    setItemMock.mockResolvedValueOnce(undefined);
+    await setSentryOptIn(true);
+    expect(setItemMock).toHaveBeenCalledWith('subway-now:sentry-opt-in', 'true');
+    expect(initMock).toHaveBeenCalledWith({ dsn: 'https://test@sentry.io/123' });
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  it('enabled=true + DSN 미설정: storage 저장만 하고 init은 skip (graceful)', async () => {
+    setItemMock.mockResolvedValueOnce(undefined);
+    await setSentryOptIn(true);
+    expect(setItemMock).toHaveBeenCalledWith('subway-now:sentry-opt-in', 'true');
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false: storage에 "false" 저장 + Sentry.close', async () => {
+    setItemMock.mockResolvedValueOnce(undefined);
+    await setSentryOptIn(false);
+    expect(setItemMock).toHaveBeenCalledWith('subway-now:sentry-opt-in', 'false');
+    expect(closeMock).toHaveBeenCalled();
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  it('AsyncStorage 실패해도 SDK 토글은 계속 진행 (graceful)', async () => {
+    setItemMock.mockRejectedValueOnce(new Error('storage boom'));
+    await expect(setSentryOptIn(false)).resolves.toBeUndefined();
+    expect(closeMock).toHaveBeenCalled();
+  });
+
+  it('Sentry SDK 토글 실패해도 throw하지 않음', async () => {
+    setItemMock.mockResolvedValueOnce(undefined);
+    closeMock.mockImplementationOnce(() => {
+      throw new Error('close boom');
+    });
+    await expect(setSentryOptIn(false)).resolves.toBeUndefined();
+  });
+});
+
+describe('getSentryOptIn', () => {
+  it('"true" 저장값 → true', async () => {
+    getItemMock.mockResolvedValueOnce('true');
+    await expect(getSentryOptIn()).resolves.toBe(true);
+  });
+
+  it('null 저장값 → false (default OFF)', async () => {
+    getItemMock.mockResolvedValueOnce(null);
+    await expect(getSentryOptIn()).resolves.toBe(false);
+  });
+
+  it('"false" 저장값 → false', async () => {
+    getItemMock.mockResolvedValueOnce('false');
+    await expect(getSentryOptIn()).resolves.toBe(false);
+  });
+
+  it('AsyncStorage 실패 → false (default OFF)', async () => {
+    getItemMock.mockRejectedValueOnce(new Error('storage boom'));
+    await expect(getSentryOptIn()).resolves.toBe(false);
   });
 });

--- a/src/shared/infra/monitoring/sentryInit.ts
+++ b/src/shared/infra/monitoring/sentryInit.ts
@@ -5,6 +5,8 @@ import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('SentryInit');
 
+const OPT_IN_VALUE = 'true';
+
 /**
  * #1038 — Sentry 에러 모니터링 init.
  *
@@ -14,22 +16,64 @@ const logger = createLogger('SentryInit');
  *   - 어떤 실패도 boot path를 막지 않는다 (catch → log)
  *
  * 호출 시점: 앱 boot 직후 (`app/_layout.tsx`) — fire-and-forget.
- * UI 토글은 follow-up PR (concurrent SettingsScreen 작업 머지 후).
+ * 런타임 토글(#1038 follow-up): {@link setSentryOptIn}.
  */
 export async function initSentryIfOptedIn(): Promise<void> {
   try {
     const optIn = await AsyncStorage.getItem(SENTRY_OPT_IN_KEY);
-    if (optIn !== 'true') {
+    if (optIn !== OPT_IN_VALUE) {
       return;
     }
-    const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
-    if (!dsn) {
-      logger.info('opt-in 상태이지만 DSN 미설정 — Sentry 비활성화');
-      return;
-    }
-    Sentry.init({ dsn });
-    logger.info('Sentry 초기화 완료');
+    enableSentry();
   } catch (e) {
     logger.warn('Sentry 초기화 실패:', e);
   }
+}
+
+/**
+ * #1038 follow-up — opt-in 상태 영속 + Sentry SDK 런타임 활성/비활성.
+ *
+ * - enabled === true: AsyncStorage에 'true' 저장 + (DSN 있으면) `Sentry.init`
+ * - enabled === false: AsyncStorage에 'false' 저장 + `Sentry.close()`
+ * 두 경로 모두 실패해도 throw하지 않는다 (UI 토글이 boot path와 동일하게 graceful).
+ */
+export async function setSentryOptIn(enabled: boolean): Promise<void> {
+  try {
+    await AsyncStorage.setItem(SENTRY_OPT_IN_KEY, enabled ? OPT_IN_VALUE : 'false');
+  } catch (e) {
+    logger.warn('Sentry opt-in 저장 실패:', e);
+  }
+  try {
+    if (enabled) {
+      enableSentry();
+    } else {
+      Sentry.close();
+      logger.info('Sentry 비활성화');
+    }
+  } catch (e) {
+    logger.warn('Sentry SDK 토글 실패:', e);
+  }
+}
+
+/**
+ * 저장된 opt-in 상태를 반환한다 (boot 후 store 복원용).
+ * 실패 시 false (default OFF).
+ */
+export async function getSentryOptIn(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(SENTRY_OPT_IN_KEY);
+    return raw === OPT_IN_VALUE;
+  } catch {
+    return false;
+  }
+}
+
+function enableSentry(): void {
+  const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+  if (!dsn) {
+    logger.info('opt-in 상태이지만 DSN 미설정 — Sentry 비활성화');
+    return;
+  }
+  Sentry.init({ dsn });
+  logger.info('Sentry 초기화 완료');
 }


### PR DESCRIPTION
## Summary
PR #1040 follow-up — Sentry opt-in UI.

- Settings 화면에 "개인정보 > 오류 진단 정보 전송" Switch 추가 (기본 OFF, 사용자가 토글해야 활성화)
- 토글 ON ↔ OFF 시 AsyncStorage(`subway-now:sentry-opt-in`)에 'true'/'false' 저장 + Sentry SDK 런타임 init/close
- `sentryInit.ts`에 `setSentryOptIn` / `getSentryOptIn` 추가, 기존 boot path `initSentryIfOptedIn`은 동일 키로 그대로 동작
- `useSettingsStore`에 `sentryOptIn` slice 추가 (default OFF)
- ko/en/ja/zh 4개 로케일 라벨/설명/a11y hint
- jest.setup.js에 `@sentry/react-native` 전역 no-op mock (ESM transform 회피)

## Test plan
- [x] `npm test` — 새 store/SDK 토글 테스트 13건 통과 (sentryInit 11건 + store 5건)
- [x] `npm run type-check` 통과
- [ ] 실기기: 토글 ON → DSN 설정 후 강제 에러 발생 → Sentry dashboard 수신 확인
- [ ] 실기기: 토글 OFF → 같은 에러 발생 시 Sentry 미수신 확인
- [ ] 다국어 (ko/en/ja/zh) 라벨/설명 표시 확인