### PR TITLE
feat: 경로 시스템 텍스트 공유 버튼 wire

### DIFF
--- a/src/features/route/components/ShareTripButton.tsx
+++ b/src/features/route/components/ShareTripButton.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { Pressable, Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
+import { shareTripIntent } from '../utils/shareTrip';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+
+interface Props {
+  route: Route;
+  currentStation: Station | null;
+  destination: Station | null;
+  totalStops: number;
+  travelMinutes: number;
+  testID?: string;
+}
+
+/**
+ * PR #1069 follow-up — 경로 시스템 텍스트 공유 진입점.
+ *
+ * 트립 카드 영역(HomeScreen Route 섹션) 헤더에 노출된다. 필수 데이터(route/
+ * currentStation/destination)가 빠진 상태면 자기 자신을 숨겨 잘못된 빈
+ * 공유 시트가 뜨지 않게 한다.
+ */
+export function ShareTripButton({
+  route,
+  currentStation,
+  destination,
+  totalStops,
+  travelMinutes,
+  testID,
+}: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+
+  const onPress = useCallback(() => {
+    void shareTripIntent({
+      route,
+      currentStation,
+      destination,
+      totalStops,
+      travelMinutes,
+      // shareTrip util은 (key, options) → string 시그니처만 사용 — react-i18next의
+      // 광범위한 오버로드와 좁은 호환만 필요해 cast로 좁힌다.
+      t: t as unknown as (key: string, options?: Record<string, unknown>) => string,
+    });
+  }, [route, currentStation, destination, totalStops, travelMinutes, t]);
+
+  if (!route || !currentStation || !destination) return null;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      testID={testID ?? 'route-share-button'}
+      accessibilityRole="button"
+      accessibilityLabel={t('share.trip.buttonLabel')}
+      style={{
+        paddingHorizontal: spacing.md,
+        paddingVertical: spacing.sm,
+        borderRadius: radius.sm,
+        borderWidth: 1,
+        borderColor: colors.hair,
+      }}
+    >
+      <Text style={[typography.label, { color: colors.muted, fontWeight: '600' }]}>
+        {t('share.trip.buttonLabel')}
+      </Text>
+    </Pressable>
+  );
+}

--- a/src/features/route/components/__tests__/ShareTripButton.test.tsx
+++ b/src/features/route/components/__tests__/ShareTripButton.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent } from '@testing-library/react-native';
+import { Share } from 'react-native';
+import { ShareTripButton } from '../ShareTripButton';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import type { DirectRoute, Route } from '../../../../shared/utils/stationRoute';
+import type { Station } from '../../../../shared/types/station';
+
+const directRoute: DirectRoute = {
+  type: 'direct',
+  stops: 5,
+  line: '2',
+  travelSeconds: 600,
+};
+
+function makeStation(overrides: Partial<Station> = {}): Station {
+  return {
+    id: '2-219',
+    name: '강남',
+    line: '2',
+    lineColor: '#00A84D',
+    lat: 37.4979,
+    lng: 127.0276,
+    ...overrides,
+  };
+}
+
+describe('ShareTripButton', () => {
+  beforeEach(() => {
+    jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' } as never);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('필수 정보가 모두 있으면 버튼 렌더 + tap 시 Share.share 호출', () => {
+    const { getByTestId } = renderWithTheme(
+      <ShareTripButton
+        route={directRoute}
+        currentStation={makeStation()}
+        destination={makeStation({ name: '잠실' })}
+        totalStops={5}
+        travelMinutes={10}
+      />,
+    );
+    fireEvent.press(getByTestId('route-share-button'));
+    expect(Share.share).toHaveBeenCalledTimes(1);
+    const arg = (Share.share as jest.Mock).mock.calls[0][0];
+    expect(typeof arg.message).toBe('string');
+    expect(arg.message.length).toBeGreaterThan(0);
+  });
+
+  it('route가 없으면 null 렌더 + Share 미호출', () => {
+    const { queryByTestId } = renderWithTheme(
+      <ShareTripButton
+        route={null as unknown as Route}
+        currentStation={makeStation()}
+        destination={makeStation({ name: '잠실' })}
+        totalStops={5}
+        travelMinutes={10}
+      />,
+    );
+    expect(queryByTestId('route-share-button')).toBeNull();
+    expect(Share.share).not.toHaveBeenCalled();
+  });
+
+  it('currentStation이 null이면 null 렌더', () => {
+    const { queryByTestId } = renderWithTheme(
+      <ShareTripButton
+        route={directRoute}
+        currentStation={null}
+        destination={makeStation({ name: '잠실' })}
+        totalStops={5}
+        travelMinutes={10}
+      />,
+    );
+    expect(queryByTestId('route-share-button')).toBeNull();
+  });
+
+  it('destination이 null이면 null 렌더', () => {
+    const { queryByTestId } = renderWithTheme(
+      <ShareTripButton
+        route={directRoute}
+        currentStation={makeStation()}
+        destination={null}
+        totalStops={5}
+        travelMinutes={10}
+      />,
+    );
+    expect(queryByTestId('route-share-button')).toBeNull();
+  });
+
+  it('커스텀 testID 적용', () => {
+    const { getByTestId } = renderWithTheme(
+      <ShareTripButton
+        route={directRoute}
+        currentStation={makeStation()}
+        destination={makeStation({ name: '잠실' })}
+        totalStops={5}
+        travelMinutes={10}
+        testID="custom-share"
+      />,
+    );
+    expect(getByTestId('custom-share')).toBeTruthy();
+  });
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -53,6 +53,7 @@ import { useWifiStation } from '../features/nearest-station/hooks/useWifiStation
 import { CurrentStationConfirmModal } from '../features/nearest-station/components/CurrentStationConfirmModal';
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
+import { ShareTripButton } from '../features/route/components/ShareTripButton';
 import { Toast } from '../shared/ui/Toast';
 import { useMisBoardingDetector } from '../features/route/hooks/useMisBoardingDetector';
 import { useTrainPositions } from '../features/route/hooks/useTrainPositions';
@@ -867,19 +868,30 @@ export default function HomeScreen() {
                   )}
                   {journey && (() => {
                     const stops = journeyDisplayToStops(journey, { expanded: routeExpanded });
+                    const selectedCandidate = categorized.find((r) => r.category.key === selectedKey)?.candidate;
                     return (
                       <>
-                        <Pressable
-                          accessibilityRole="button"
-                          accessibilityLabel={routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
-                          onPress={() => setRouteExpanded((v) => !v)}
-                          style={styles.expandToggle}
-                          testID="route-expand-toggle"
-                        >
-                          <Text style={[typography.label, { color: colors.accent, fontWeight: '600' }]}>
-                            {routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
-                          </Text>
-                        </Pressable>
+                        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel={routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
+                            onPress={() => setRouteExpanded((v) => !v)}
+                            style={styles.expandToggle}
+                            testID="route-expand-toggle"
+                          >
+                            <Text style={[typography.label, { color: colors.accent, fontWeight: '600' }]}>
+                              {routeExpanded ? t('home.routeCollapse') : t('home.routeExpand')}
+                            </Text>
+                          </Pressable>
+                          {/* PR #1069 follow-up — 경로 시스템 텍스트 공유. route/currentStation/destination 누락 시 자동 숨김. */}
+                          <ShareTripButton
+                            route={route}
+                            currentStation={result?.station ?? null}
+                            destination={destination}
+                            totalStops={journey.totalStops}
+                            travelMinutes={selectedCandidate?.travelMinutes ?? 0}
+                          />
+                        </View>
                         <EditorialTimeline
                           stops={stops}
                           renderHopSlot={(stop, i) => {

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -294,5 +294,12 @@
       "preFirst": "Before first train · first train at {{time}}",
       "postLast": "After last train · first train tomorrow at {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "Subway Route",
+      "buttonLabel": "Share route",
+      "bodyTemplate": "🚇 Subway Route\nFrom: {{fromName}} ({{fromLine}})\nTo: {{toName}} ({{toLine}})\nAbout {{minutes}} min ({{stops}} stops)"
+    }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -294,5 +294,12 @@
       "preFirst": "始発前 · 始発 {{time}} 予定",
       "postLast": "終電後 · 明日の始発 {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "地下鉄ルート",
+      "buttonLabel": "ルートを共有",
+      "bodyTemplate": "🚇 地下鉄ルート\n出発: {{fromName}} ({{fromLine}})\n到着: {{toName}} ({{toLine}})\n約 {{minutes}} 分 ({{stops}} 駅)"
+    }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -294,5 +294,12 @@
       "preFirst": "첫차 전 · 첫차 {{time}} 예정",
       "postLast": "막차 후 · 내일 첫차 {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "지하철 경로",
+      "buttonLabel": "경로 공유",
+      "bodyTemplate": "🚇 지하철 경로\n출발: {{fromName}} ({{fromLine}})\n도착: {{toName}} ({{toLine}})\n약 {{minutes}}분 소요 ({{stops}}정거장)"
+    }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -294,5 +294,12 @@
       "preFirst": "首班车前 · 首班车 {{time}}",
       "postLast": "末班车后 · 明日首班车 {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "地铁路线",
+      "buttonLabel": "分享路线",
+      "bodyTemplate": "🚇 地铁路线\n起点: {{fromName}} ({{fromLine}})\n终点: {{toName}} ({{toLine}})\n约 {{minutes}} 分钟 ({{stops}} 站)"
+    }
   }
 }


### PR DESCRIPTION
## Summary
PR #1069 follow-up. `shareTripIntent` util은 머지됐지만 UI 진입점이 없어 사용자가 사용 불가 상태였다.

- `ShareTripButton` 컴포넌트 추가 (`src/features/route/components/`) — `shareTripIntent`를 호출하는 진입점. route/currentStation/destination 누락 시 `null` 리턴해 자동 숨김.
- HomeScreen 트립 카드의 "전체 보기/접기" 토글 행 우측에 배치. flexDirection row + space-between으로 기존 토글과 한 줄에 표시.
- `share` i18n 키 복구 — PR #1069 ↔ PR #1072(`ServiceWindowBanner`) merge 충돌에서 누락된 `share.trip.title` / `share.trip.bodyTemplate`을 다시 추가하고 `share.trip.buttonLabel` 신규 키 도입 (ko/en/ja/zh).

## Test plan
- [x] `npm run type-check` 통과
- [x] `ShareTripButton.test.tsx` 5케이스 (Share.share mock, null prop 가드 × 3, custom testID)
- [x] 사전 존재 실패(widget/SharedGroup/stationNotification 3 suites · 35 tests)는 dev baseline과 동일 — 본 PR 영향 없음
- [ ] 실기기 — 트립 카드에서 공유 버튼 → OS 공유 시트 노출 + 본문 텍스트 확인