### PR TITLE
refactor: firstLeg util 추가 사용처 치환

### DIFF
--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -7,10 +7,10 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { isStationOnRoute, isSameStationName } from '../../../shared/utils/stationRoute';
+import { getFirstLeg, isStationOnRoute, isSameStationName } from '../../../shared/utils/stationRoute';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
-import { alarmKey, evaluateAlarmPhase, resolveAllTargets, type AlarmEvent } from '../utils/stationAlarm';
+import { alarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
 import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
@@ -360,9 +360,9 @@ export function useStationAlarm({
     // #750: 공통 sleep 룰 게이트. scheduler가 사전 예약을 skip한 transfer를 FG polling이
     // 우회 발사하던 회귀 차단. sleep으로 suppress된 키는 firedAlarmsRef에서 제거해 sleep OFF
     // 토글 시 다음 evaluation이 정상 발사 경로로 진입할 수 있게 한다.
-    // resolveAllTargets는 route가 활성이면 최소 1개 waypoint를 반환한다 — empty 분기 가드 불필요.
-    const firstHopName = resolveAllTargets(activeRoute, activeDestination.name)[0].name;
-    const isFirstHop = isSameStationName(firstHopName, rawEvent.stationName);
+    // getFirstLeg는 route 타입과 무관하게 첫 leg endName을 반환 — direct/transfer/multi-transfer
+    // 모두 첫 hop과 일치 (transferName 또는 collapsed destination).
+    const isFirstHop = isSameStationName(getFirstLeg(activeRoute, activeDestination.name).endName, rawEvent.stationName);
     const lock = await getBoardingLock();
     if (
       shouldSuppressBySleepRule({

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -17,12 +17,14 @@ const mockCalculateStaticETA = jest.fn();
 const mockUpdateRouteFromPosition = jest.fn();
 const mockIsStationOnRoute = jest.fn();
 const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
+const mockGetFirstLeg = jest.fn((..._args: unknown[]) => ({ line: '2', endName: '' }));
 jest.mock('../../../../shared/utils/stationRoute', () => ({
   findRoute: (...args: unknown[]) => mockFindRoute(...args),
   calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
   updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
   isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
   isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
+  getFirstLeg: (...args: unknown[]) => mockGetFirstLeg(...args),
 }));
 
 const mockEvaluateAlarmPhase = jest.fn();
@@ -142,6 +144,7 @@ describe('processLocationUpdate', () => {
     mockResolveAllTargets.mockReturnValue([
       { name: '시청', stops: 3, alarmType: 'destination', approachLine: '2' },
     ]);
+    mockGetFirstLeg.mockReturnValue({ line: '2', endName: '시청' });
     // #746: dismissSilence 기본은 null — silence 없음.
     mockGetDismissSilence.mockResolvedValue(null);
     mockClearDismissSilence.mockResolvedValue(undefined);
@@ -733,6 +736,7 @@ describe('processLocationUpdate', () => {
         { name: '교대', stops: 1, alarmType: 'transfer', approachLine: '2' },
         { name: '시청', stops: 3, alarmType: 'destination', approachLine: '1' },
       ]);
+      mockGetFirstLeg.mockReturnValue({ line: '2', endName: '교대' });
     });
 
     it('sleep ON + lock 활성 + 첫 hop transfer → sendAlarmNotification 호출 X, suppression 로그', async () => {

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -7,7 +7,7 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
-import { findRoute, calculateStaticETA, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
+import { findRoute, calculateStaticETA, getFirstLeg, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
 import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
@@ -288,9 +288,8 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   if (alarmEvent && route && !suppressedAlarmEvent) {
     // #750: 공통 sleep 룰 게이트. scheduler 사전 예약이 skip한 transfer를 BG 즉시 발사 path가
     // 우회 발사하던 회귀 차단. 첫 hop 판정은 route의 첫 waypoint와 stationName 일치로 — lock
-    // 활성 동안 leg가 갱신되면 lock도 갱신되므로 route.targets[0]이 곧 현재 leg의 첫 hop.
-    const firstHopName = resolveAllTargets(route, destination.name)[0].name;
-    const isFirstHop = isSameStationName(firstHopName, alarmEvent.stationName);
+    // 활성 동안 leg가 갱신되면 lock도 갱신되므로 route 첫 leg의 endName이 곧 현재 leg의 첫 hop.
+    const isFirstHop = isSameStationName(getFirstLeg(route, destination.name).endName, alarmEvent.stationName);
     const suppressBySleep = shouldSuppressBySleepRule({
       lock: lockForLineGuard,
       event: { type: alarmEvent.type, stationName: alarmEvent.stationName },

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -90,6 +90,8 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   // #750 — stationPipeline의 sleep 게이트가 isSameStationName으로 첫 hop을 매칭.
   // 결정적 fake: strict equality로 충분 (테스트는 동일 한국어 이름 사용).
   isSameStationName: (a: string, b: string) => a === b,
+  // direct route 테스트만 사용 — 첫 leg endName은 항상 destinationName.
+  getFirstLeg: (_route: unknown, destinationName: string) => ({ line: '2', endName: destinationName }),
 }));
 
 const mockSendAlarmNotification = jest.fn((..._args: unknown[]) => Promise.resolve());


### PR DESCRIPTION
## Summary
PR #1071 follow-up — 추가 사이트 2건 치환.

- `src/features/alarm/utils/stationPipeline.ts` — `resolveAllTargets(route, dest)[0].name` → `getFirstLeg(route, dest).endName`
- `src/features/alarm/hooks/useStationAlarm.ts` — 동일 치환 + 미사용된 `resolveAllTargets` import 제거

치환 정합성: 모든 route 타입(direct/transfer/multi-transfer)에서
`resolveAllTargets(route, dest)[0].name === getFirstLeg(route, dest).endName`임이
구조적으로 등가. 첫 hop만 필요한 사이트는 전체 targets 배열을 만들 필요 없이
util 호출 1회로 끝낸다.

### Not migrated (이유)
- `stationNotification.ts`, `stationAlarm.resolveAllTargets`, `routeWaypoints/routeToCoordinates/routeProgress`, `boardingLockScheduler/tripBoundScheduler`, `buildBoardingLockMeta.findSegmentEndStationName`, `approachLine.ts`, `alarmDirection.ts` — 모두 첫 leg가 아닌 `boardingLine`/`hopIndex`/`event.stationName` 등으로 keyed 되거나 전체 segment 순회가 필요해 `getFirstLeg` 시그니처(line+endName)에 맞지 않음.

## Test plan
- [x] `npm run type-check` 통과
- [x] 변경 영향 테스트 통과 (`stationPipeline.test.ts`, `useStationAlarm.test.ts`, `foregroundBackgroundTransition.test.ts`)
- [x] 기존 baseline 실패(stationNotification/widgetStorage/SharedGroupAdapter)는 본 PR과 무관 — origin/dev에 이미 존재

Closes: (no issue — PR #1071 cleanup follow-up)