### PR TITLE
feat: Sentry breadcrumb logger wire

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -22,6 +22,16 @@ const { LANGUAGE_REGISTRY, FALLBACK_LANGUAGE } = require('./src/shared/i18n/type
 
 // react-native-safe-area-context 모킹: 컴포넌트 테스트가 SafeAreaProvider 없이도
 // useSafeAreaInsets / SafeAreaView를 호출할 수 있게. inset은 0(노치 없는 환경)으로 가정.
+// @sentry/react-native 글로벌 모킹: shared/utils/logger가 breadcrumb wire를 위해
+// shared/infra/monitoring/breadcrumb를 통해 Sentry SDK를 import한다. 네이티브 모듈이
+// Jest 환경에서 로드되지 않도록 no-op 모킹.
+// 참고: #1084(opt-in UI)에서 jest.setup.js와 충돌 가능성 있음.
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+}));
+
 jest.mock('react-native-safe-area-context', () => {
   const React = require('react');
   const { View } = require('react-native');

--- a/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
+++ b/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
@@ -1,0 +1,104 @@
+import * as Sentry from '@sentry/react-native';
+import { addLogBreadcrumb } from '../breadcrumb';
+import { setSentryEnabled } from '../sentryState';
+
+const addBreadcrumbMock = Sentry.addBreadcrumb as jest.Mock;
+const captureExceptionMock = Sentry.captureException as jest.Mock;
+
+beforeEach(() => {
+  addBreadcrumbMock.mockReset();
+  captureExceptionMock.mockReset();
+});
+
+afterEach(() => {
+  setSentryEnabled(false);
+});
+
+describe('addLogBreadcrumb', () => {
+  it('opt-in 비활성 시 no-op', () => {
+    addLogBreadcrumb('info', 'TEST', ['메시지']);
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('info → level "info" + category "log"', () => {
+    setSentryEnabled(true);
+    addLogBreadcrumb('info', 'TEST', ['hello']);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'log',
+      message: '[TEST] hello',
+    });
+  });
+
+  it('warn → level "warning"', () => {
+    setSentryEnabled(true);
+    addLogBreadcrumb('warn', 'TAG', ['주의']);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'warning',
+      category: 'log',
+      message: '[TAG] 주의',
+    });
+  });
+
+  it('debug → level "debug"', () => {
+    setSentryEnabled(true);
+    addLogBreadcrumb('debug', 'TAG', ['dbg']);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'debug',
+      category: 'log',
+      message: '[TAG] dbg',
+    });
+  });
+
+  it('error + 첫 인자가 Error → captureException 호출', () => {
+    setSentryEnabled(true);
+    const err = new Error('boom');
+    addLogBreadcrumb('error', 'TAG', [err, 'extra']);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'error',
+      category: 'log',
+      message: '[TAG] boom extra',
+    });
+    expect(captureExceptionMock).toHaveBeenCalledWith(err);
+  });
+
+  it('error지만 첫 인자가 Error가 아니면 captureException 안 함', () => {
+    setSentryEnabled(true);
+    addLogBreadcrumb('error', 'TAG', ['just a string error']);
+    expect(addBreadcrumbMock).toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('인자가 객체면 JSON 직렬화', () => {
+    setSentryEnabled(true);
+    addLogBreadcrumb('info', 'TAG', [{ foo: 1 }, 42]);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'log',
+      message: '[TAG] {"foo":1} 42',
+    });
+  });
+
+  it('순환참조 객체는 String() fallback', () => {
+    setSentryEnabled(true);
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    addLogBreadcrumb('info', 'TAG', [circular]);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'log',
+      message: '[TAG] [object Object]',
+    });
+  });
+
+  it('인자 없으면 태그만 메시지', () => {
+    setSentryEnabled(true);
+    addLogBreadcrumb('info', 'TAG', []);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'log',
+      message: '[TAG]',
+    });
+  });
+});

--- a/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
+++ b/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
@@ -21,33 +21,17 @@ describe('addLogBreadcrumb', () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
-  it('info → level "info" + category "log"', () => {
+  it.each([
+    ['info' as const, 'info', 'TEST', ['hello'], '[TEST] hello'],
+    ['warn' as const, 'warning', 'TAG', ['주의'], '[TAG] 주의'],
+    ['debug' as const, 'debug', 'TAG', ['dbg'], '[TAG] dbg'],
+  ])('%s → level "%s"', (logLevel, sentryLevel, tag, args, message) => {
     setSentryEnabled(true);
-    addLogBreadcrumb('info', 'TEST', ['hello']);
+    addLogBreadcrumb(logLevel, tag, args);
     expect(addBreadcrumbMock).toHaveBeenCalledWith({
-      level: 'info',
+      level: sentryLevel,
       category: 'log',
-      message: '[TEST] hello',
-    });
-  });
-
-  it('warn → level "warning"', () => {
-    setSentryEnabled(true);
-    addLogBreadcrumb('warn', 'TAG', ['주의']);
-    expect(addBreadcrumbMock).toHaveBeenCalledWith({
-      level: 'warning',
-      category: 'log',
-      message: '[TAG] 주의',
-    });
-  });
-
-  it('debug → level "debug"', () => {
-    setSentryEnabled(true);
-    addLogBreadcrumb('debug', 'TAG', ['dbg']);
-    expect(addBreadcrumbMock).toHaveBeenCalledWith({
-      level: 'debug',
-      category: 'log',
-      message: '[TAG] dbg',
+      message,
     });
   });
 

--- a/src/shared/infra/monitoring/__tests__/sentryInit.test.ts
+++ b/src/shared/infra/monitoring/__tests__/sentryInit.test.ts
@@ -1,13 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
 import { initSentryIfOptedIn } from '../sentryInit';
+import { isSentryEnabled, setSentryEnabled } from '../sentryState';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
 }));
-jest.mock('@sentry/react-native', () => ({
-  init: jest.fn(),
-}));
+// @sentry/react-native는 jest.setup.js에서 글로벌 모킹됨.
 
 const getItemMock = AsyncStorage.getItem as jest.Mock;
 const initMock = Sentry.init as jest.Mock;
@@ -18,6 +17,7 @@ beforeEach(() => {
   getItemMock.mockReset();
   initMock.mockReset();
   delete process.env.EXPO_PUBLIC_SENTRY_DSN;
+  setSentryEnabled(false);
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
 });
@@ -51,11 +51,12 @@ describe('initSentryIfOptedIn', () => {
     expect(initMock).not.toHaveBeenCalled();
   });
 
-  it('opt-in true + DSN 있음 → Sentry.init 호출', async () => {
+  it('opt-in true + DSN 있음 → Sentry.init 호출 + isSentryEnabled true', async () => {
     getItemMock.mockResolvedValueOnce('true');
     process.env.EXPO_PUBLIC_SENTRY_DSN = 'https://test@sentry.io/123';
     await initSentryIfOptedIn();
     expect(initMock).toHaveBeenCalledWith({ dsn: 'https://test@sentry.io/123' });
+    expect(isSentryEnabled()).toBe(true);
   });
 
   it('AsyncStorage throw → throw 전파하지 않음 (boot path 비차단)', async () => {

--- a/src/shared/infra/monitoring/__tests__/sentryState.test.ts
+++ b/src/shared/infra/monitoring/__tests__/sentryState.test.ts
@@ -1,0 +1,22 @@
+import { isSentryEnabled, setSentryEnabled } from '../sentryState';
+
+afterEach(() => {
+  setSentryEnabled(false);
+});
+
+describe('sentryState', () => {
+  it('기본값은 false', () => {
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('setSentryEnabled(true) 후 isSentryEnabled가 true 반환', () => {
+    setSentryEnabled(true);
+    expect(isSentryEnabled()).toBe(true);
+  });
+
+  it('setSentryEnabled(false)로 비활성화 가능', () => {
+    setSentryEnabled(true);
+    setSentryEnabled(false);
+    expect(isSentryEnabled()).toBe(false);
+  });
+});

--- a/src/shared/infra/monitoring/breadcrumb.ts
+++ b/src/shared/infra/monitoring/breadcrumb.ts
@@ -1,0 +1,54 @@
+import * as Sentry from '@sentry/react-native';
+import { isSentryEnabled } from './sentryState';
+
+/**
+ * #1040 follow-up — logger / 도메인 이벤트를 Sentry breadcrumb로 전달.
+ *
+ * Privacy:
+ *   - opt-in 비활성(`isSentryEnabled() === false`) 시 no-op.
+ *   - Sentry SDK 자체도 init 안 됐으면 무시하지만, 명시 가드로 이중 안전.
+ *
+ * PII 주의: logger 메시지에 사용자 위치/역 이름 등이 포함될 수 있다.
+ * opt-in 토글로 사용자가 명시 동의 후만 전송된다. 마스킹은 별도 PR 후보.
+ */
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVEL_TO_SENTRY: Record<LogLevel, Sentry.SeverityLevel> = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warning',
+  error: 'error',
+};
+
+function serializeArg(arg: unknown): string {
+  if (arg instanceof Error) return arg.message;
+  if (typeof arg === 'string') return arg;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+/**
+ * logger 호출 시 Sentry breadcrumb 추가.
+ * `level === 'error'` + 첫 인자가 Error 인스턴스면 `Sentry.captureException`도 호출.
+ */
+export function addLogBreadcrumb(level: LogLevel, tag: string, args: unknown[]): void {
+  if (!isSentryEnabled()) return;
+
+  const message = `[${tag}] ${args.map(serializeArg).join(' ')}`.trim();
+  Sentry.addBreadcrumb({
+    level: LEVEL_TO_SENTRY[level],
+    category: 'log',
+    message,
+  });
+
+  if (level === 'error') {
+    const first = args[0];
+    if (first instanceof Error) {
+      Sentry.captureException(first);
+    }
+  }
+}

--- a/src/shared/infra/monitoring/sentryInit.ts
+++ b/src/shared/infra/monitoring/sentryInit.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
 import { SENTRY_OPT_IN_KEY } from '../../constants/storageKeys';
 import { createLogger } from '../../utils/logger';
+import { setSentryEnabled } from './sentryState';
 
 const logger = createLogger('SentryInit');
 
@@ -28,6 +29,7 @@ export async function initSentryIfOptedIn(): Promise<void> {
       return;
     }
     Sentry.init({ dsn });
+    setSentryEnabled(true);
     logger.info('Sentry 초기화 완료');
   } catch (e) {
     logger.warn('Sentry 초기화 실패:', e);

--- a/src/shared/infra/monitoring/sentryState.ts
+++ b/src/shared/infra/monitoring/sentryState.ts
@@ -1,0 +1,18 @@
+/**
+ * #1040 follow-up — Sentry 활성 상태 in-memory 플래그.
+ *
+ * sentryInit.ts에서 init 성공 시 `setSentryEnabled(true)` 호출.
+ * breadcrumb wiring은 매 로그마다 AsyncStorage를 읽지 않고 이 플래그로 가드한다.
+ *
+ * 별도 모듈로 분리한 이유: logger.ts → breadcrumb.ts → (state) 경로에서
+ * sentryInit.ts(logger를 import)와 순환 의존을 피하기 위함.
+ */
+let sentryEnabled = false;
+
+export function setSentryEnabled(value: boolean): void {
+  sentryEnabled = value;
+}
+
+export function isSentryEnabled(): boolean {
+  return sentryEnabled;
+}

--- a/src/shared/utils/__tests__/logger.test.ts
+++ b/src/shared/utils/__tests__/logger.test.ts
@@ -1,4 +1,8 @@
+import * as Sentry from '@sentry/react-native';
+import { setSentryEnabled } from '../../infra/monitoring/sentryState';
 import { createLogger, setMinLevel } from '../logger';
+
+const addBreadcrumbMock = Sentry.addBreadcrumb as jest.Mock;
 
 describe('createLogger', () => {
   let logSpy: jest.SpyInstance;
@@ -9,10 +13,13 @@ describe('createLogger', () => {
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    addBreadcrumbMock.mockReset();
+    setSentryEnabled(false);
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    setSentryEnabled(false);
   });
 
   it('debug 레벨은 console.log를 호출한다', () => {
@@ -49,6 +56,35 @@ describe('createLogger', () => {
     const logger = createLogger('TEST');
     logger.info('상태:', 'granted', 42);
     expect(logSpy).toHaveBeenCalledWith('[TEST]', '상태:', 'granted', 42);
+  });
+
+  describe('Sentry breadcrumb wire', () => {
+    it('opt-in 비활성 시 breadcrumb 호출 안 함', () => {
+      const logger = createLogger('TAG');
+      logger.info('메시지');
+      expect(addBreadcrumbMock).not.toHaveBeenCalled();
+    });
+
+    it('opt-in 활성 + info → breadcrumb 호출', () => {
+      setSentryEnabled(true);
+      const logger = createLogger('TAG');
+      logger.info('hi');
+      expect(addBreadcrumbMock).toHaveBeenCalledWith({
+        level: 'info',
+        category: 'log',
+        message: '[TAG] hi',
+      });
+    });
+
+    it('minLevel 가드로 막힌 로그는 breadcrumb도 호출 안 함', () => {
+      setSentryEnabled(true);
+      setMinLevel('warn');
+      const logger = createLogger('TAG');
+      logger.debug('skip');
+      logger.info('skip');
+      expect(addBreadcrumbMock).not.toHaveBeenCalled();
+      setMinLevel('debug');
+    });
   });
 
   describe('setMinLevel', () => {

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -1,3 +1,5 @@
+import { addLogBreadcrumb } from '../infra/monitoring/breadcrumb';
+
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 const LEVELS: Record<LogLevel, number> = {
@@ -16,6 +18,9 @@ export function setMinLevel(level: LogLevel): void {
 
 function log(level: LogLevel, tag: string, ...args: unknown[]): void {
   if (LEVELS[level] < LEVELS[minLevel]) return;
+
+  // Sentry breadcrumb forward — opt-in 비활성 시 내부에서 no-op.
+  addLogBreadcrumb(level, tag, args);
 
   const message = `[${tag}]`;
   switch (level) {


### PR DESCRIPTION
## Summary

PR #1040(Sentry init) follow-up. 앱 logger (`shared/utils/logger`)의 모든 `log()` 호출을 **Sentry breadcrumb**로 자동 전달한다.

- `shared/infra/monitoring/breadcrumb.ts` — `addLogBreadcrumb(level, tag, args)` 신규. level 매핑(`info→info`, `warn→warning`, `error→error`, `debug→debug`), category `'log'`, 메시지는 `[tag] arg1 arg2 ...` 직렬화.
- `shared/infra/monitoring/sentryState.ts` — in-memory 활성 플래그. `sentryInit.ts`에서 `Sentry.init` 성공 직후 `setSentryEnabled(true)` 호출. logger → breadcrumb → state 경로로 분리해 `sentryInit ↔ logger` 순환 의존 회피.
- `shared/utils/logger.ts` — `log()` 진입부에서 `addLogBreadcrumb` 호출. minLevel 차단된 로그는 breadcrumb도 호출되지 않음.
- `error` 레벨 + 첫 인자가 `Error` 인스턴스면 `Sentry.captureException(err)` 동반 호출.
- `jest.setup.js` — `@sentry/react-native` 글로벌 mock 추가 (logger가 전역에서 import되므로 모든 테스트가 네이티브 모듈 격리 필요).

## Privacy

- **default OFF** — `sentryEnabled` 플래그가 false면 `addBreadcrumb` 호출 자체를 건너뜀. 토글이 활성된 사용자만 전송됨.
- `Sentry.init`이 안 됐어도 SDK는 no-op이지만, 명시 가드로 이중 안전 + 불필요한 함수 호출 비용 절감.
- **PII 주의** — logger 메시지에 사용자 위치/역 이름 등이 포함될 수 있다. opt-in 토글 동의 후만 전송된다는 전제. 메시지 마스킹은 별도 PR 후보.

## 범위 한정

이번 PR은 **logger wire만** 포함. alarm fire / trip start·end / boarding lock 같은 도메인 이벤트 breadcrumb(`category: 'alarm'|'trip'|'boarding'`)은 별도 follow-up.

## 충돌 가능성

- #1084 (opt-in UI 토글, OPEN) 가 `jest.setup.js`에 같은 Sentry mock을 추가할 수 있음 → 한쪽 머지 시 다른 쪽 conflict 가능. 먼저 머지되는 쪽으로 정렬.

## Test plan

- [x] `npx jest src/shared/utils/__tests__/logger.test.ts src/shared/infra/monitoring/` — 4 suites / 29 tests pass, 100% coverage on touched files
- [x] `npm run type-check` 통과
- [x] `npx eslint src/shared/infra/monitoring/**/*.ts src/shared/utils/logger.ts` 통과
- [ ] CI `Type Check & Test` 통과 확인
- [ ] 실기기: opt-in OFF 상태에서 로그 발생 시 Sentry 이벤트 0건
- [ ] 실기기: opt-in ON + DSN 설정 후 logger.error(new Error(...)) 호출 → Sentry issue + 직전 breadcrumbs 표시

Closes (follow-up of #1040)