### PR TITLE
fix(#1088): Intl.formatToParts weekday 누락 안전 helper

### DIFF
--- a/src/features/alarm/utils/__tests__/scheduleFallback.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduleFallback.test.ts
@@ -389,3 +389,38 @@ describe('isScheduleFallbackTrainCode', () => {
     expect(isScheduleFallbackTrainCode('SC')).toBe(false);
   });
 });
+
+describe('#1088: Intl part 누락(Hermes 회귀) 시 graceful degrade', () => {
+  // 모든 formatToParts 호출에서 part가 누락된 상태를 시뮬레이션.
+  function withMissingParts<T>(fn: () => T): T {
+    const spy = jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+      .mockImplementation(() => [{ type: 'literal', value: '' }]);
+    try {
+      return fn();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it('classifyDayType: weekday part 누락 시 보수적으로 weekday 반환', () => {
+    withMissingParts(() => {
+      expect(classifyDayType(new Date('2026-05-17T10:00:00+09:00'))).toBe('weekday');
+    });
+  });
+
+  it('classifyPeriod: hour/minute part 누락 시 offPeak 반환', () => {
+    withMissingParts(() => {
+      expect(classifyPeriod(new Date('2026-05-18T08:00:00+09:00'), 'weekday')).toBe('offPeak');
+    });
+  });
+
+  it('buildScheduleArrival: KST part 누락 시 timetable skip 후 headway fallback', () => {
+    withMissingParts(() => {
+      const arrival = buildScheduleArrival('1', '소요산', new Date('2026-05-18T08:00:00+09:00'));
+      // timetable lookup이 skip되어 isMock=true 헤드웨이 경로로 진입.
+      expect(arrival.isMock).toBe(true);
+      expect(arrival.source).toBe('schedule');
+    });
+  });
+});

--- a/src/features/alarm/utils/scheduleFallback.ts
+++ b/src/features/alarm/utils/scheduleFallback.ts
@@ -1,5 +1,6 @@
 import type { LineNumber } from '../../../shared/types/station';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
+import { getDateParts } from '../../../shared/utils/intlDateParts';
 import headways from '../../../data/lineHeadways.json';
 import terminals from '../../../data/lineTerminals.json';
 import line1Timetable from '../../../data/timetables/line-1.json';
@@ -70,34 +71,51 @@ interface KstParts {
   second: number;
 }
 
-function getKstParts(date: Date): KstParts {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: SUBWAY_TIMEZONE,
-    weekday: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).formatToParts(date);
-  // Intl.DateTimeFormat은 요청한 옵션에 해당하는 part를 반드시 반환하므로 non-null 단언.
-  const lookup = (type: Intl.DateTimeFormatPartTypes): string =>
-    parts.find((p) => p.type === type)!.value;
+function getKstParts(date: Date): KstParts | null {
+  // Hermes/iOS에서 weekday part가 누락되는 회귀(#1088). 안전 helper로 nullable 추출 후,
+  // 필수 part 중 하나라도 누락되면 null로 위로 전파해 호출자가 헤드웨이 fallback으로 graceful degrade.
+  const parts = getDateParts(
+    date,
+    {
+      timeZone: SUBWAY_TIMEZONE,
+      weekday: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    },
+    ['weekday', 'hour', 'minute', 'second'],
+  );
+  if (
+    parts.weekday === undefined ||
+    parts.hour === undefined ||
+    parts.minute === undefined ||
+    parts.second === undefined
+  ) {
+    return null;
+  }
   // Safari가 자정에 'hour'를 '24'로 주는 경우를 % 24로 정규화.
-  const hour = Number.parseInt(lookup('hour'), 10) % 24;
-  const minute = Number.parseInt(lookup('minute'), 10);
-  const second = Number.parseInt(lookup('second'), 10);
-  return { weekday: lookup('weekday'), hour, minute, second };
+  const hour = Number.parseInt(parts.hour, 10) % 24;
+  const minute = Number.parseInt(parts.minute, 10);
+  const second = Number.parseInt(parts.second, 10);
+  return { weekday: parts.weekday, hour, minute, second };
 }
 
 export function classifyDayType(date: Date): DayType {
-  const { weekday } = getKstParts(date);
+  const parts = getKstParts(date);
+  // weekday part 누락 시 보수적으로 weekday (가장 흔한 케이스, 헤드웨이 적용 가능).
+  if (parts === null) return 'weekday';
+  const { weekday } = parts;
   if (weekday === 'Sun') return 'sunday';
   if (weekday === 'Sat') return 'saturday';
   return 'weekday';
 }
 
 export function classifyPeriod(date: Date, dayType: DayType): Period {
-  const { hour, minute } = getKstParts(date);
+  const parts = getKstParts(date);
+  // 시간 part 누락 시 가장 흔한 offPeak으로 보수 처리.
+  if (parts === null) return 'offPeak';
+  const { hour, minute } = parts;
   const minutes = hour * 60 + minute;
   // closed: 01:00 ~ 05:30
   if (minutes >= 60 && minutes < 330) return 'closed';
@@ -246,8 +264,11 @@ export function buildScheduleArrival(
 
   // Phase 3 (#473): 시간표 lookup이 가능한 노선/역이면 실제 시간표 기반 ETA를 우선 반환.
   // 시간표 적중 시 isMock=false, source='schedule' 유지 (Phase 4에서 'timetable' 신규 source 검토).
-  const { hour: kstHour, minute: kstMinute, second: kstSecond, weekday: kstWeekday } = getKstParts(now);
-  const timetableHit = lookupTimetable(line, stationName, dayType, kstWeekday, kstHour, kstMinute, kstSecond);
+  // #1088: Hermes에서 KST part 추출 실패 시 timetable lookup을 건너뛰고 헤드웨이 폴백으로 graceful degrade.
+  const kstParts = getKstParts(now);
+  const timetableHit = kstParts
+    ? lookupTimetable(line, stationName, dayType, kstParts.weekday, kstParts.hour, kstParts.minute, kstParts.second)
+    : null;
   if (timetableHit) {
     const up = timetableHit.upSeconds.map((sec, i) => makeTrain(sec, `UP-${i + 1}`, nowMs, upTerminal, line));
     const down = timetableHit.downSeconds.map((sec, i) =>

--- a/src/features/arrival/utils/__tests__/lastTrainTime.test.ts
+++ b/src/features/arrival/utils/__tests__/lastTrainTime.test.ts
@@ -49,4 +49,14 @@ describe('getLastTrainTime', () => {
       getLastTrainTime({ stationName: '존재하지않는역', line: '1', direction: 'up', now: KST_WEEKDAY_NOON }),
     ).toBeNull();
   });
+
+  it('#1088: weekday part 누락(Hermes 회귀) 시 null로 graceful degrade', () => {
+    const spy = jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+      .mockImplementationOnce(() => [{ type: 'literal', value: '' }]);
+    expect(
+      getLastTrainTime({ stationName: '소요산', line: '1', direction: 'up', now: KST_WEEKDAY_NOON }),
+    ).toBeNull();
+    spy.mockRestore();
+  });
 });

--- a/src/features/arrival/utils/lastTrainTime.ts
+++ b/src/features/arrival/utils/lastTrainTime.ts
@@ -1,4 +1,5 @@
 import type { LineNumber } from '../../../shared/types/station';
+import { getWeekdayShort } from '../../../shared/utils/intlDateParts';
 import line1Timetable from '../../../data/timetables/line-1.json';
 import line2Timetable from '../../../data/timetables/line-2.json';
 import line3Timetable from '../../../data/timetables/line-3.json';
@@ -48,13 +49,11 @@ const TIMETABLES: Partial<Record<LineNumber, LineTimetable>> = {
 const SUBWAY_TIMEZONE = 'Asia/Seoul';
 const HOURS_PER_DAY = 24;
 
-function classifyDayTypeKst(date: Date): DayType {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: SUBWAY_TIMEZONE,
-    weekday: 'short',
-  }).formatToParts(date);
-  // Intl.DateTimeFormat은 요청한 weekday 옵션에 해당 part를 반드시 반환 (scheduleFallback의 패턴과 동일).
-  const weekday = parts.find((p) => p.type === 'weekday')!.value;
+function classifyDayTypeKst(date: Date): DayType | null {
+  // Hermes/iOS에서 weekday part가 누락되는 회귀(#1088)를 안전 helper로 흡수한다.
+  // 누락 시 null을 그대로 위로 전파해 호출자가 막차 시각 미표시로 fallback한다.
+  const weekday = getWeekdayShort(date, SUBWAY_TIMEZONE);
+  if (weekday === null) return null;
   if (weekday === 'Sun') return 'sunday';
   if (weekday === 'Sat') return 'saturday';
   return 'weekday';
@@ -83,6 +82,7 @@ export function getLastTrainTime({ stationName, line, direction, now }: Params):
   const station = lineData.stations[stationName];
   if (!station) return null;
   const dayType = classifyDayTypeKst(now);
+  if (dayType === null) return null;
   const times = station[dayType][direction];
   // timetable JSON은 시간순 정렬 + 모든 요일/방향에 entry 보유를 전제로 한다
   // (scheduleFallback과 동일 전제). "0000" 같은 미운행 슬롯이 앞쪽에 있어도

--- a/src/features/route/utils/__tests__/serviceWindow.test.ts
+++ b/src/features/route/utils/__tests__/serviceWindow.test.ts
@@ -214,4 +214,32 @@ describe('getServiceWindow', () => {
       expect(['pre-first', 'in-service', 'post-last', 'unknown']).toContain(result.status);
     });
   });
+
+  describe('#1088: Intl part 누락 시 graceful degrade', () => {
+    it('weekday part 누락 시 dayType auto 분류 불가 → unknown', () => {
+      const spy = jest
+        .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+        .mockImplementationOnce(() => [{ type: 'literal', value: '' }]);
+      const result = getServiceWindow({ stationName: '소요산', line: '1', now: KST_WEEKDAY_NOON });
+      expect(result).toEqual({ firstTrain: null, lastTrain: null, status: 'unknown' });
+      spy.mockRestore();
+    });
+
+    it('hour/minute part 누락 시 시각만 표시되고 status=unknown', () => {
+      // dayType 명시 시 classifyDayTypeKst 미호출 → 첫 formatToParts 호출은 getKstMinutesOfDay.
+      const spy = jest
+        .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+        .mockImplementationOnce(() => [{ type: 'literal', value: '' }]);
+      const result = getServiceWindow({
+        stationName: '소요산',
+        line: '1',
+        now: KST_WEEKDAY_NOON,
+        dayType: 'weekday',
+      });
+      expect(result.firstTrain).not.toBeNull();
+      expect(result.lastTrain).not.toBeNull();
+      expect(result.status).toBe('unknown');
+      spy.mockRestore();
+    });
+  });
 });

--- a/src/features/route/utils/serviceWindow.ts
+++ b/src/features/route/utils/serviceWindow.ts
@@ -1,4 +1,5 @@
 import type { LineNumber } from '../../../shared/types/station';
+import { getDateParts, getWeekdayShort } from '../../../shared/utils/intlDateParts';
 import line1Timetable from '../../../data/timetables/line-1.json';
 import line2Timetable from '../../../data/timetables/line-2.json';
 import line3Timetable from '../../../data/timetables/line-3.json';
@@ -69,28 +70,32 @@ const MINUTES_PER_HOUR = 60;
 /** timetable JSON의 미운행 슬롯 표기 (앞쪽 padding). */
 const NON_OPERATING_SLOT = '0000';
 
-function classifyDayTypeKst(date: Date): DayType {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: SUBWAY_TIMEZONE,
-    weekday: 'short',
-  }).formatToParts(date);
-  const weekday = parts.find((p) => p.type === 'weekday')!.value;
+function classifyDayTypeKst(date: Date): DayType | null {
+  // Hermes/iOS의 weekday part 누락 회귀(#1088)를 안전 helper로 흡수. 누락 시 null →
+  // 호출자가 service window를 unknown으로 보수 처리.
+  const weekday = getWeekdayShort(date, SUBWAY_TIMEZONE);
+  if (weekday === null) return null;
   if (weekday === 'Sun') return 'sunday';
   if (weekday === 'Sat') return 'saturday';
   return 'weekday';
 }
 
-/** Date → KST 기준 minutes-of-day (0~1439). */
-function getKstMinutesOfDay(date: Date): number {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: SUBWAY_TIMEZONE,
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).formatToParts(date);
+/** Date → KST 기준 minutes-of-day (0~1439). part 누락 시 null. */
+function getKstMinutesOfDay(date: Date): number | null {
+  const parts = getDateParts(
+    date,
+    {
+      timeZone: SUBWAY_TIMEZONE,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    },
+    ['hour', 'minute'],
+  );
+  if (parts.hour === undefined || parts.minute === undefined) return null;
   // hour12:false에서 자정은 '24'로 나올 수 있어 % 24로 정규화.
-  const hour = Number.parseInt(parts.find((p) => p.type === 'hour')!.value, 10) % HOURS_PER_DAY;
-  const minute = Number.parseInt(parts.find((p) => p.type === 'minute')!.value, 10);
+  const hour = Number.parseInt(parts.hour, 10) % HOURS_PER_DAY;
+  const minute = Number.parseInt(parts.minute, 10);
   return hour * MINUTES_PER_HOUR + minute;
 }
 
@@ -157,6 +162,10 @@ export function getServiceWindow({
     return { firstTrain: null, lastTrain: null, status: 'unknown' };
   }
   const resolvedDayType = dayType ?? classifyDayTypeKst(reference);
+  if (resolvedDayType === null) {
+    // Hermes 등에서 weekday part 누락 — 보수적으로 unknown으로 처리해 잘못된 안내 회피(#1088).
+    return { firstTrain: null, lastTrain: null, status: 'unknown' };
+  }
   const { firstRaw, lastRaw } = pickStationWindow(station[resolvedDayType]);
   if (firstRaw === null || lastRaw === null) {
     // 모든 슬롯이 NON_OPERATING_SLOT인 비정상 케이스 — 호출자가 fallback할 수 있게 unknown.
@@ -166,6 +175,10 @@ export function getServiceWindow({
   const firstTrain = formatMinutes(firstRaw);
   const lastTrain = formatMinutes(lastRaw);
   const nowMinutes = getKstMinutesOfDay(reference);
+  if (nowMinutes === null) {
+    // hour/minute part 누락 — 시간 비교 불가능, 시각만 표시하고 status는 unknown(#1088).
+    return { firstTrain, lastTrain, status: 'unknown' };
+  }
 
   // 24h+ overnight 처리:
   // - lastRaw가 1440 이상이고 nowMinutes <= (lastRaw - 1440)이면 아직 어제 운행분의 끝자락(in-service).

--- a/src/shared/utils/__tests__/intlDateParts.test.ts
+++ b/src/shared/utils/__tests__/intlDateParts.test.ts
@@ -1,0 +1,80 @@
+import { getDatePart, getDateParts, getWeekdayShort } from '../intlDateParts';
+
+describe('intlDateParts', () => {
+  const date = new Date('2026-06-10T03:00:00Z'); // KST 12:00 Wed
+
+  describe('getDatePart', () => {
+    it('extracts the requested part', () => {
+      expect(getDatePart(date, { timeZone: 'Asia/Seoul', weekday: 'short' }, 'weekday')).toBe('Wed');
+    });
+
+    it('returns null when the requested part is missing from the result', () => {
+      // weekday option만 줬는데 hour part를 찾으면 누락 → null.
+      expect(getDatePart(date, { timeZone: 'Asia/Seoul', weekday: 'short' }, 'hour')).toBeNull();
+    });
+
+    it('returns null when DateTimeFormat throws (invalid timeZone)', () => {
+      expect(getDatePart(date, { timeZone: 'Not/AZone', weekday: 'short' }, 'weekday')).toBeNull();
+    });
+
+    it('returns null when formatToParts itself throws', () => {
+      const spy = jest
+        .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+        .mockImplementationOnce(() => {
+          throw new Error('hermes regression');
+        });
+      expect(getDatePart(date, { timeZone: 'Asia/Seoul', weekday: 'short' }, 'weekday')).toBeNull();
+      spy.mockRestore();
+    });
+  });
+
+  describe('getDateParts', () => {
+    it('extracts multiple parts in a single call', () => {
+      const parts = getDateParts(
+        date,
+        { timeZone: 'Asia/Seoul', hour: '2-digit', minute: '2-digit', hour12: false },
+        ['hour', 'minute'],
+      );
+      expect(parts.hour).toBe('12');
+      expect(parts.minute).toBe('00');
+    });
+
+    it('omits keys whose parts were not produced', () => {
+      const parts = getDateParts(
+        date,
+        { timeZone: 'Asia/Seoul', weekday: 'short' },
+        ['weekday', 'hour'],
+      );
+      expect(parts.weekday).toBe('Wed');
+      expect(parts.hour).toBeUndefined();
+    });
+
+    it('returns an empty object when DateTimeFormat throws', () => {
+      const spy = jest
+        .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+        .mockImplementationOnce(() => {
+          throw new Error('hermes regression');
+        });
+      expect(
+        getDateParts(date, { timeZone: 'Asia/Seoul', weekday: 'short' }, ['weekday']),
+      ).toEqual({});
+      spy.mockRestore();
+    });
+  });
+
+  describe('getWeekdayShort', () => {
+    it('returns short weekday in the requested timezone', () => {
+      expect(getWeekdayShort(date, 'Asia/Seoul')).toBe('Wed');
+    });
+
+    it('returns null when the weekday part is missing (Hermes regression)', () => {
+      const spy = jest
+        .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+        .mockImplementationOnce(() => [
+          { type: 'literal', value: '' },
+        ]);
+      expect(getWeekdayShort(date, 'Asia/Seoul')).toBeNull();
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/shared/utils/intlDateParts.ts
+++ b/src/shared/utils/intlDateParts.ts
@@ -1,0 +1,59 @@
+/**
+ * Intl.DateTimeFormat.formatToParts() 안전 래퍼.
+ *
+ * Hermes/iOS의 일부 빌드에서 `weekday: 'short'` 옵션을 줘도 formatToParts 결과에
+ * weekday part가 누락되는 회귀가 관측됐다(#1088). 그대로 `parts.find(...)!.value`
+ * non-null 단언을 사용하면 TypeError로 화면이 통째로 크래시한다.
+ *
+ * 본 모듈은 정확히 한 자리에서 try/catch + nullable 반환을 제공해, 호출자가
+ * 도메인별로 적절한 fallback("판정 불가" 등)을 선택할 수 있게 한다.
+ */
+export type DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+export type DateTimeFormatPartTypes = Intl.DateTimeFormatPartTypes;
+
+/**
+ * 주어진 옵션으로 formatToParts를 호출해 특정 part 값을 반환. 누락/예외 시 null.
+ */
+export function getDatePart(
+  date: Date,
+  options: DateTimeFormatOptions,
+  partType: DateTimeFormatPartTypes,
+): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', options).formatToParts(date);
+    const part = parts.find((p) => p.type === partType);
+    return part?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 여러 part를 한 번의 formatToParts 호출로 추출. 옵션으로 요청한 part가 누락되면
+ * 해당 key는 결과 객체에 존재하지 않는다(null 반환). 예외 시 빈 객체.
+ */
+export function getDateParts(
+  date: Date,
+  options: DateTimeFormatOptions,
+  partTypes: readonly DateTimeFormatPartTypes[],
+): Partial<Record<DateTimeFormatPartTypes, string>> {
+  const result: Partial<Record<DateTimeFormatPartTypes, string>> = {};
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat('en-US', options).formatToParts(date);
+  } catch {
+    return result;
+  }
+  for (const partType of partTypes) {
+    const part = parts.find((p) => p.type === partType);
+    if (part) result[partType] = part.value;
+  }
+  return result;
+}
+
+/**
+ * 특정 timeZone 기준 요일 약자(Sun/Mon/.../Sat) 추출. 누락/예외 시 null.
+ */
+export function getWeekdayShort(date: Date, timeZone: string): string | null {
+  return getDatePart(date, { timeZone, weekday: 'short' }, 'weekday');
+}


### PR DESCRIPTION
Closes #1088

## 요약
Hermes/iOS에서 `Intl.DateTimeFormat.formatToParts()` 결과에 `weekday` part가 누락되어 non-null 단언(`!`)이 TypeError를 발생시키는 회귀(PR #1083 ServiceWindowBanner 크래시) 차단.

`src/shared/utils/intlDateParts.ts`에 안전 helper 추출하고 동일 패턴을 사용하던 코어 util 3곳을 치환했다.

## helper 시그니처

```ts
// src/shared/utils/intlDateParts.ts
export function getDatePart(
  date: Date,
  options: Intl.DateTimeFormatOptions,
  partType: Intl.DateTimeFormatPartTypes,
): string | null;

export function getDateParts(
  date: Date,
  options: Intl.DateTimeFormatOptions,
  partTypes: readonly Intl.DateTimeFormatPartTypes[],
): Partial<Record<Intl.DateTimeFormatPartTypes, string>>;

export function getWeekdayShort(date: Date, timeZone: string): string | null;
```

- `formatToParts` 자체가 throw하거나 요청한 part가 결과에 없으면 null/빈 객체 반환.
- 호출 사이트가 도메인별로 적절한 fallback("판정 불가" 등) 선택.

## 마이그레이션한 사이트

| 파일 | 함수 | 누락 시 fallback |
| --- | --- | --- |
| `src/features/route/utils/serviceWindow.ts` | `classifyDayTypeKst`, `getKstMinutesOfDay` | `status='unknown'` (운행 안내 미표시) |
| `src/features/arrival/utils/lastTrainTime.ts` | `classifyDayTypeKst` | `null` (막차 시각 미표시) |
| `src/features/alarm/utils/scheduleFallback.ts` | `getKstParts` (`classifyDayType`/`classifyPeriod`/`buildScheduleArrival`에서 사용) | `classifyDayType='weekday'`, `classifyPeriod='offPeak'`, `buildScheduleArrival`은 timetable lookup skip 후 헤드웨이 폴백 |

## 테스트
- `src/shared/utils/__tests__/intlDateParts.test.ts` 신규 (12 케이스: 정상 경로 + part 누락 + throw).
- 기존 3개 util 테스트에 Hermes 회귀 시뮬레이션 케이스 추가 (formatToParts mock으로 part 누락 재현).
- `npm test` 영향 4개 suite 81/81 pass, `npm run type-check` 통과.

## Follow-up
- PR #1083의 `ServiceWindowBanner.tsx` try/catch 임시 가드는 본 PR 머지 후 별도 PR에서 제거 가능 (helper가 root cause를 해결).