### PR TITLE
chore: i18n 누락 키 audit 스크립트 + share.trip 회귀 보완

### DIFF
--- a/scripts/__tests__/audit-i18n.test.js
+++ b/scripts/__tests__/audit-i18n.test.js
@@ -1,0 +1,70 @@
+/**
+ * audit-i18n script — pure helper coverage + integration: ensure the
+ * repository's locale files have no cross-locale or used-but-missing keys.
+ */
+
+const path = require('node:path');
+const { flatten, loadLocales, diff, extractUsedKeys } = require('../audit-i18n');
+
+describe('flatten', () => {
+  it('flattens nested objects with dot-joined keys', () => {
+    expect(flatten({ a: { b: { c: 1 }, d: 2 }, e: 3 })).toEqual({
+      'a.b.c': 1,
+      'a.d': 2,
+      e: 3,
+    });
+  });
+
+  it('treats arrays as leaves', () => {
+    expect(flatten({ a: [1, 2, 3] })).toEqual({ a: [1, 2, 3] });
+  });
+});
+
+describe('diff', () => {
+  it('reports per-locale missing keys', () => {
+    const locales = {
+      ko: { 'common.ok': '확인' },
+      en: { 'common.ok': 'OK', 'common.cancel': 'Cancel' },
+      ja: { 'common.ok': 'OK' },
+      zh: { 'common.ok': '确定' },
+    };
+    const { missingByLocale, allKeys } = diff(locales);
+    expect(allKeys.size).toBe(2);
+    expect(missingByLocale.ko).toEqual(['common.cancel']);
+    expect(missingByLocale.en).toEqual([]);
+    expect(missingByLocale.ja).toEqual(['common.cancel']);
+    expect(missingByLocale.zh).toEqual(['common.cancel']);
+  });
+});
+
+describe('repository i18n locales (integration)', () => {
+  it('has no cross-locale missing keys', () => {
+    const locales = loadLocales();
+    const { missingByLocale } = diff(locales);
+    expect(missingByLocale).toEqual({ ko: [], en: [], ja: [], zh: [] });
+  });
+
+  it('has no used-but-missing keys (accounting for i18next plural suffixes and template-literal prefixes)', () => {
+    const locales = loadLocales();
+    const { used, dynamicPrefixes } = extractUsedKeys();
+    const PLURAL_SUFFIXES = ['_zero', '_one', '_two', '_few', '_many', '_other'];
+    const LOCALES = ['ko', 'en', 'ja', 'zh'];
+    const hasKey = (locale, key) => {
+      if (key in locale) return true;
+      for (const suf of PLURAL_SUFFIXES) if ((key + suf) in locale) return true;
+      return false;
+    };
+    const missing = [];
+    for (const key of used) {
+      // Skip keys covered by a dynamic prefix (e.g. t(`lines.${n}`)).
+      let underDynamic = false;
+      for (const p of dynamicPrefixes) {
+        if (key === p || key.startsWith(p + '.')) { underDynamic = true; break; }
+      }
+      if (underDynamic) continue;
+      const missingIn = LOCALES.filter((loc) => !hasKey(locales[loc], key));
+      if (missingIn.length > 0) missing.push({ key, missingIn });
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/scripts/audit-i18n.js
+++ b/scripts/audit-i18n.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * i18n key audit
+ *
+ * - Flattens all locale JSON files under src/shared/i18n/locales/
+ * - Reports keys that exist in some locales but not others (regression risk:
+ *   raw key string is shown to user when their locale is the missing one)
+ * - Scans source files for t('...') / i18n.t('...') usage and reports:
+ *   - used keys missing from any locale (regression)
+ *   - dead keys defined in all locales but never used (cleanup candidates)
+ *
+ * Exit codes:
+ *   0 - no missing-across-locales keys and no used-but-missing keys
+ *   1 - regressions detected
+ *
+ * Dead keys do not fail the script (cleanup is a separate concern).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const LOCALES_DIR = path.join(REPO_ROOT, 'src/shared/i18n/locales');
+const LOCALES = ['ko', 'en', 'ja', 'zh'];
+
+const SCAN_ROOTS = [
+  path.join(REPO_ROOT, 'src'),
+  path.join(REPO_ROOT, 'app'),
+  path.join(REPO_ROOT, 'modules'),
+];
+const SCAN_EXT = new Set(['.ts', '.tsx', '.js', '.jsx']);
+const SKIP_DIR = new Set(['__tests__', '__mocks__', 'node_modules', '.expo']);
+
+function flatten(obj, prefix = '', out = {}) {
+  for (const [k, v] of Object.entries(obj)) {
+    const next = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      flatten(v, next, out);
+    } else {
+      out[next] = v;
+    }
+  }
+  return out;
+}
+
+function loadLocales() {
+  const result = {};
+  for (const locale of LOCALES) {
+    const file = path.join(LOCALES_DIR, `${locale}.json`);
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+    result[locale] = flatten(raw);
+  }
+  return result;
+}
+
+function walk(dir, files = []) {
+  if (!fs.existsSync(dir)) return files;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIR.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, files);
+    } else if (SCAN_EXT.has(path.extname(entry.name))) {
+      // skip test files
+      if (/\.test\.[tj]sx?$/.test(entry.name)) continue;
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+// Match t(...) / i18n.t(...) / i18next.t(...) calls and extract all quoted
+// dotted keys within the first argument (which may be a ternary).
+// We scan for the call prefix, then read forward up to the first balanced
+// ')' or a comma at depth-0 — extracting any quoted dotted strings on the way.
+const T_CALL_RE = /\b(?:i18n(?:ext)?\.)?t\(/g;
+const QUOTED_KEY_INNER_RE = /(['"])([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_-]+)+)\1/g;
+
+// Also pick up table-driven keys: labelKey: 'settings.themeAuto', key: 'foo.bar'
+const LABEL_KEY_RE = /\b(?:labelKey|titleKey|i18nKey|translationKey)\s*:\s*(['"])([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_-]+)+)\1/g;
+
+// Template-literal prefixes like `lines.${...}` — any key under that prefix is live.
+const TEMPLATE_PREFIX_RE = /`([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_-]+)*)\.\$\{/g;
+
+function extractTCallArg(text, start) {
+  // start is the index right after '('. Read until matching ')'.
+  let depth = 1;
+  let i = start;
+  // Stop at depth-0 comma to limit scope to the first argument.
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return text.slice(start, i);
+    } else if (ch === ',' && depth === 1) {
+      return text.slice(start, i);
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      // skip string
+      const quote = ch;
+      i++;
+      while (i < text.length && text[i] !== quote) {
+        if (text[i] === '\\') i++;
+        i++;
+      }
+    }
+    i++;
+  }
+  return text.slice(start, i);
+}
+
+function extractUsedKeys() {
+  const used = new Set();
+  const dynamicPrefixes = new Set();
+  const byKey = new Map();
+  for (const root of SCAN_ROOTS) {
+    for (const file of walk(root)) {
+      const text = fs.readFileSync(file, 'utf8');
+      const rel = path.relative(REPO_ROOT, file);
+      T_CALL_RE.lastIndex = 0;
+      let m;
+      while ((m = T_CALL_RE.exec(text)) !== null) {
+        const arg = extractTCallArg(text, m.index + m[0].length);
+        QUOTED_KEY_INNER_RE.lastIndex = 0;
+        let km;
+        while ((km = QUOTED_KEY_INNER_RE.exec(arg)) !== null) {
+          const key = km[2];
+          used.add(key);
+          if (!byKey.has(key)) byKey.set(key, []);
+          byKey.get(key).push(rel);
+        }
+      }
+      LABEL_KEY_RE.lastIndex = 0;
+      while ((m = LABEL_KEY_RE.exec(text)) !== null) {
+        const key = m[2];
+        used.add(key);
+        if (!byKey.has(key)) byKey.set(key, []);
+        byKey.get(key).push(rel);
+      }
+      TEMPLATE_PREFIX_RE.lastIndex = 0;
+      while ((m = TEMPLATE_PREFIX_RE.exec(text)) !== null) {
+        dynamicPrefixes.add(m[1]);
+      }
+    }
+  }
+  return { used, dynamicPrefixes, byKey };
+}
+
+function diff(locales) {
+  const allKeys = new Set();
+  for (const loc of LOCALES) {
+    for (const k of Object.keys(locales[loc])) allKeys.add(k);
+  }
+  const missingByLocale = {};
+  for (const loc of LOCALES) missingByLocale[loc] = [];
+  for (const key of allKeys) {
+    for (const loc of LOCALES) {
+      if (!(key in locales[loc])) missingByLocale[loc].push(key);
+    }
+  }
+  for (const loc of LOCALES) missingByLocale[loc].sort();
+  return { allKeys, missingByLocale };
+}
+
+function main() {
+  const locales = loadLocales();
+  const { allKeys, missingByLocale } = diff(locales);
+  const { used, dynamicPrefixes } = extractUsedKeys();
+
+  console.log('=== i18n audit ===\n');
+  console.log(`Locales: ${LOCALES.join(', ')}`);
+  for (const loc of LOCALES) {
+    console.log(`  ${loc}: ${Object.keys(locales[loc]).length} keys`);
+  }
+  console.log(`Total unique keys (union): ${allKeys.size}`);
+  console.log(`Used keys in source: ${used.size}\n`);
+
+  let hasRegression = false;
+
+  console.log('--- Cross-locale missing keys ---');
+  for (const loc of LOCALES) {
+    const miss = missingByLocale[loc];
+    if (miss.length === 0) {
+      console.log(`  ${loc}: OK`);
+    } else {
+      hasRegression = true;
+      console.log(`  ${loc}: missing ${miss.length}`);
+      for (const k of miss) console.log(`    - ${k}`);
+    }
+  }
+  console.log();
+
+  console.log('--- Used keys missing from any locale ---');
+  // i18next v4 plural suffixes: t('foo') with { count } resolves to foo_one / foo_other / foo_zero / foo_two / foo_few / foo_many.
+  // Treat a used key as present in a locale if either the exact key or ANY plural-suffixed variant exists.
+  const PLURAL_SUFFIXES = ['_zero', '_one', '_two', '_few', '_many', '_other'];
+  const hasKey = (locale, key) => {
+    if (key in locale) return true;
+    for (const suf of PLURAL_SUFFIXES) {
+      if ((key + suf) in locale) return true;
+    }
+    return false;
+  };
+  const usedMissing = [];
+  for (const key of used) {
+    const missingIn = LOCALES.filter((loc) => !hasKey(locales[loc], key));
+    if (missingIn.length > 0) {
+      usedMissing.push({ key, missingIn });
+    }
+  }
+  if (usedMissing.length === 0) {
+    console.log('  OK');
+  } else {
+    hasRegression = true;
+    for (const { key, missingIn } of usedMissing) {
+      console.log(`  - ${key}  (missing: ${missingIn.join(', ')})`);
+    }
+  }
+  console.log();
+
+  console.log('--- Dead keys (defined but never referenced statically) ---');
+  // Only report keys present in ALL locales but never used.
+  // (Keys missing in some locales are already reported above.)
+  const dead = [];
+  for (const key of allKeys) {
+    const inAll = LOCALES.every((loc) => key in locales[loc]);
+    if (!inAll) continue;
+    if (used.has(key)) continue;
+    // Template-literal dynamic prefix: t(`lines.${x}`) → any key under "lines" is live.
+    let underDynamicPrefix = false;
+    for (const p of dynamicPrefixes) {
+      if (key === p || key.startsWith(p + '.')) { underDynamicPrefix = true; break; }
+    }
+    if (underDynamicPrefix) continue;
+    // Heuristic: dynamic keys often share a prefix. If any used key startsWith
+    // this key + '.', or this key startsWith any used key + '.', treat as live.
+    let dynamic = false;
+    // Strip plural suffix to compare against used base keys.
+    let base = key;
+    for (const suf of PLURAL_SUFFIXES) {
+      if (key.endsWith(suf)) { base = key.slice(0, -suf.length); break; }
+    }
+    for (const u of used) {
+      if (u === key || u === base) { dynamic = true; break; }
+      if (u.startsWith(key + '.') || key.startsWith(u + '.')) {
+        dynamic = true;
+        break;
+      }
+      if (u.startsWith(base + '.') || base.startsWith(u + '.')) {
+        dynamic = true;
+        break;
+      }
+    }
+    if (!dynamic) dead.push(key);
+  }
+  dead.sort();
+  if (dead.length === 0) {
+    console.log('  OK');
+  } else {
+    console.log(`  ${dead.length} candidates (cleanup is a separate concern, not failing):`);
+    for (const k of dead) console.log(`    - ${k}`);
+  }
+
+  console.log();
+  if (hasRegression) {
+    console.log('FAIL: regressions detected.');
+    process.exit(1);
+  }
+  console.log('OK');
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { flatten, loadLocales, diff, extractUsedKeys };

--- a/scripts/audit-i18n.js
+++ b/scripts/audit-i18n.js
@@ -18,8 +18,8 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const LOCALES_DIR = path.join(REPO_ROOT, 'src/shared/i18n/locales');
@@ -76,76 +76,83 @@ function walk(dir, files = []) {
 // We scan for the call prefix, then read forward up to the first balanced
 // ')' or a comma at depth-0 — extracting any quoted dotted strings on the way.
 const T_CALL_RE = /\b(?:i18n(?:ext)?\.)?t\(/g;
-const QUOTED_KEY_INNER_RE = /(['"])([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_-]+)+)\1/g;
+const QUOTED_KEY_INNER_RE = /(['"])([a-zA-Z]\w*(?:\.[\w-]+)+)\1/g;
 
 // Also pick up table-driven keys: labelKey: 'settings.themeAuto', key: 'foo.bar'
-const LABEL_KEY_RE = /\b(?:labelKey|titleKey|i18nKey|translationKey)\s*:\s*(['"])([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_-]+)+)\1/g;
+const LABEL_KEY_RE = /\b(?:labelKey|titleKey|i18nKey|translationKey)\s*:\s*(['"])([a-zA-Z]\w*(?:\.[\w-]+)+)\1/g;
 
 // Template-literal prefixes like `lines.${...}` — any key under that prefix is live.
-const TEMPLATE_PREFIX_RE = /`([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_-]+)*)\.\$\{/g;
+const TEMPLATE_PREFIX_RE = /`([a-zA-Z]\w*(?:\.[\w-]+)*)\.\$\{/g;
+
+function skipString(text, start, quote) {
+  // Return index of the closing quote (or text.length if unterminated).
+  let i = start;
+  while (i < text.length && text[i] !== quote) {
+    if (text[i] === '\\') i++;
+    i++;
+  }
+  return i;
+}
 
 function extractTCallArg(text, start) {
-  // start is the index right after '('. Read until matching ')'.
+  // start is the index right after '('. Read until matching ')' or depth-0 ','.
   let depth = 1;
   let i = start;
-  // Stop at depth-0 comma to limit scope to the first argument.
   while (i < text.length) {
     const ch = text[i];
-    if (ch === '(') depth++;
-    else if (ch === ')') {
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipString(text, i + 1, ch);
+    } else if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
       depth--;
       if (depth === 0) return text.slice(start, i);
     } else if (ch === ',' && depth === 1) {
       return text.slice(start, i);
-    } else if (ch === '"' || ch === "'" || ch === '`') {
-      // skip string
-      const quote = ch;
-      i++;
-      while (i < text.length && text[i] !== quote) {
-        if (text[i] === '\\') i++;
-        i++;
-      }
     }
     i++;
   }
   return text.slice(start, i);
 }
 
+function recordKey(used, byKey, rel, key) {
+  used.add(key);
+  if (!byKey.has(key)) byKey.set(key, []);
+  byKey.get(key).push(rel);
+}
+
+function scanFile(text, rel, ctx) {
+  const { used, dynamicPrefixes, byKey } = ctx;
+  T_CALL_RE.lastIndex = 0;
+  let m;
+  while ((m = T_CALL_RE.exec(text)) !== null) {
+    const arg = extractTCallArg(text, m.index + m[0].length);
+    QUOTED_KEY_INNER_RE.lastIndex = 0;
+    let km;
+    while ((km = QUOTED_KEY_INNER_RE.exec(arg)) !== null) {
+      recordKey(used, byKey, rel, km[2]);
+    }
+  }
+  LABEL_KEY_RE.lastIndex = 0;
+  while ((m = LABEL_KEY_RE.exec(text)) !== null) {
+    recordKey(used, byKey, rel, m[2]);
+  }
+  TEMPLATE_PREFIX_RE.lastIndex = 0;
+  while ((m = TEMPLATE_PREFIX_RE.exec(text)) !== null) {
+    dynamicPrefixes.add(m[1]);
+  }
+}
+
 function extractUsedKeys() {
-  const used = new Set();
-  const dynamicPrefixes = new Set();
-  const byKey = new Map();
+  const ctx = { used: new Set(), dynamicPrefixes: new Set(), byKey: new Map() };
   for (const root of SCAN_ROOTS) {
     for (const file of walk(root)) {
       const text = fs.readFileSync(file, 'utf8');
       const rel = path.relative(REPO_ROOT, file);
-      T_CALL_RE.lastIndex = 0;
-      let m;
-      while ((m = T_CALL_RE.exec(text)) !== null) {
-        const arg = extractTCallArg(text, m.index + m[0].length);
-        QUOTED_KEY_INNER_RE.lastIndex = 0;
-        let km;
-        while ((km = QUOTED_KEY_INNER_RE.exec(arg)) !== null) {
-          const key = km[2];
-          used.add(key);
-          if (!byKey.has(key)) byKey.set(key, []);
-          byKey.get(key).push(rel);
-        }
-      }
-      LABEL_KEY_RE.lastIndex = 0;
-      while ((m = LABEL_KEY_RE.exec(text)) !== null) {
-        const key = m[2];
-        used.add(key);
-        if (!byKey.has(key)) byKey.set(key, []);
-        byKey.get(key).push(rel);
-      }
-      TEMPLATE_PREFIX_RE.lastIndex = 0;
-      while ((m = TEMPLATE_PREFIX_RE.exec(text)) !== null) {
-        dynamicPrefixes.add(m[1]);
-      }
+      scanFile(text, rel, ctx);
     }
   }
-  return { used, dynamicPrefixes, byKey };
+  return ctx;
 }
 
 function diff(locales) {
@@ -160,15 +167,106 @@ function diff(locales) {
       if (!(key in locales[loc])) missingByLocale[loc].push(key);
     }
   }
-  for (const loc of LOCALES) missingByLocale[loc].sort();
+  for (const loc of LOCALES) missingByLocale[loc].sort((a, b) => a.localeCompare(b));
   return { allKeys, missingByLocale };
 }
 
-function main() {
-  const locales = loadLocales();
-  const { allKeys, missingByLocale } = diff(locales);
-  const { used, dynamicPrefixes } = extractUsedKeys();
+// i18next v4 plural suffixes: t('foo') with { count } resolves to foo_one / foo_other / foo_zero / foo_two / foo_few / foo_many.
+const PLURAL_SUFFIXES = ['_zero', '_one', '_two', '_few', '_many', '_other'];
 
+function hasKeyWithPlural(locale, key) {
+  if (key in locale) return true;
+  for (const suf of PLURAL_SUFFIXES) {
+    if ((key + suf) in locale) return true;
+  }
+  return false;
+}
+
+function stripPluralSuffix(key) {
+  for (const suf of PLURAL_SUFFIXES) {
+    if (key.endsWith(suf)) return key.slice(0, -suf.length);
+  }
+  return key;
+}
+
+function isUnderDynamicPrefix(key, dynamicPrefixes) {
+  for (const p of dynamicPrefixes) {
+    if (key === p || key.startsWith(p + '.')) return true;
+  }
+  return false;
+}
+
+function isDynamicallyReferenced(key, used) {
+  const base = stripPluralSuffix(key);
+  for (const u of used) {
+    if (u === key || u === base) return true;
+    if (u.startsWith(key + '.') || key.startsWith(u + '.')) return true;
+    if (u.startsWith(base + '.') || base.startsWith(u + '.')) return true;
+  }
+  return false;
+}
+
+function reportCrossLocaleMissing(missingByLocale) {
+  console.log('--- Cross-locale missing keys ---');
+  let regression = false;
+  for (const loc of LOCALES) {
+    const miss = missingByLocale[loc];
+    if (miss.length === 0) {
+      console.log(`  ${loc}: OK`);
+      continue;
+    }
+    regression = true;
+    console.log(`  ${loc}: missing ${miss.length}`);
+    for (const k of miss) console.log(`    - ${k}`);
+  }
+  console.log();
+  return regression;
+}
+
+function reportUsedMissing(locales, used) {
+  console.log('--- Used keys missing from any locale ---');
+  const usedMissing = [];
+  for (const key of used) {
+    const missingIn = LOCALES.filter((loc) => !hasKeyWithPlural(locales[loc], key));
+    if (missingIn.length > 0) usedMissing.push({ key, missingIn });
+  }
+  if (usedMissing.length === 0) {
+    console.log('  OK');
+    console.log();
+    return false;
+  }
+  for (const { key, missingIn } of usedMissing) {
+    console.log(`  - ${key}  (missing: ${missingIn.join(', ')})`);
+  }
+  console.log();
+  return true;
+}
+
+function findDeadKeys(allKeys, locales, used, dynamicPrefixes) {
+  const dead = [];
+  for (const key of allKeys) {
+    const inAll = LOCALES.every((loc) => key in locales[loc]);
+    if (!inAll) continue;
+    if (used.has(key)) continue;
+    if (isUnderDynamicPrefix(key, dynamicPrefixes)) continue;
+    if (isDynamicallyReferenced(key, used)) continue;
+    dead.push(key);
+  }
+  dead.sort((a, b) => a.localeCompare(b));
+  return dead;
+}
+
+function reportDeadKeys(dead) {
+  console.log('--- Dead keys (defined but never referenced statically) ---');
+  if (dead.length === 0) {
+    console.log('  OK');
+    return;
+  }
+  console.log(`  ${dead.length} candidates (cleanup is a separate concern, not failing):`);
+  for (const k of dead) console.log(`    - ${k}`);
+}
+
+function printSummary(locales, allKeys, used) {
   console.log('=== i18n audit ===\n');
   console.log(`Locales: ${LOCALES.join(', ')}`);
   for (const loc of LOCALES) {
@@ -176,95 +274,22 @@ function main() {
   }
   console.log(`Total unique keys (union): ${allKeys.size}`);
   console.log(`Used keys in source: ${used.size}\n`);
+}
 
-  let hasRegression = false;
+function main() {
+  const locales = loadLocales();
+  const { allKeys, missingByLocale } = diff(locales);
+  const { used, dynamicPrefixes } = extractUsedKeys();
 
-  console.log('--- Cross-locale missing keys ---');
-  for (const loc of LOCALES) {
-    const miss = missingByLocale[loc];
-    if (miss.length === 0) {
-      console.log(`  ${loc}: OK`);
-    } else {
-      hasRegression = true;
-      console.log(`  ${loc}: missing ${miss.length}`);
-      for (const k of miss) console.log(`    - ${k}`);
-    }
-  }
-  console.log();
+  printSummary(locales, allKeys, used);
 
-  console.log('--- Used keys missing from any locale ---');
-  // i18next v4 plural suffixes: t('foo') with { count } resolves to foo_one / foo_other / foo_zero / foo_two / foo_few / foo_many.
-  // Treat a used key as present in a locale if either the exact key or ANY plural-suffixed variant exists.
-  const PLURAL_SUFFIXES = ['_zero', '_one', '_two', '_few', '_many', '_other'];
-  const hasKey = (locale, key) => {
-    if (key in locale) return true;
-    for (const suf of PLURAL_SUFFIXES) {
-      if ((key + suf) in locale) return true;
-    }
-    return false;
-  };
-  const usedMissing = [];
-  for (const key of used) {
-    const missingIn = LOCALES.filter((loc) => !hasKey(locales[loc], key));
-    if (missingIn.length > 0) {
-      usedMissing.push({ key, missingIn });
-    }
-  }
-  if (usedMissing.length === 0) {
-    console.log('  OK');
-  } else {
-    hasRegression = true;
-    for (const { key, missingIn } of usedMissing) {
-      console.log(`  - ${key}  (missing: ${missingIn.join(', ')})`);
-    }
-  }
-  console.log();
-
-  console.log('--- Dead keys (defined but never referenced statically) ---');
-  // Only report keys present in ALL locales but never used.
-  // (Keys missing in some locales are already reported above.)
-  const dead = [];
-  for (const key of allKeys) {
-    const inAll = LOCALES.every((loc) => key in locales[loc]);
-    if (!inAll) continue;
-    if (used.has(key)) continue;
-    // Template-literal dynamic prefix: t(`lines.${x}`) → any key under "lines" is live.
-    let underDynamicPrefix = false;
-    for (const p of dynamicPrefixes) {
-      if (key === p || key.startsWith(p + '.')) { underDynamicPrefix = true; break; }
-    }
-    if (underDynamicPrefix) continue;
-    // Heuristic: dynamic keys often share a prefix. If any used key startsWith
-    // this key + '.', or this key startsWith any used key + '.', treat as live.
-    let dynamic = false;
-    // Strip plural suffix to compare against used base keys.
-    let base = key;
-    for (const suf of PLURAL_SUFFIXES) {
-      if (key.endsWith(suf)) { base = key.slice(0, -suf.length); break; }
-    }
-    for (const u of used) {
-      if (u === key || u === base) { dynamic = true; break; }
-      if (u.startsWith(key + '.') || key.startsWith(u + '.')) {
-        dynamic = true;
-        break;
-      }
-      if (u.startsWith(base + '.') || base.startsWith(u + '.')) {
-        dynamic = true;
-        break;
-      }
-    }
-    if (!dynamic) dead.push(key);
-  }
-  dead.sort();
-  if (dead.length === 0) {
-    console.log('  OK');
-  } else {
-    console.log(`  ${dead.length} candidates (cleanup is a separate concern, not failing):`);
-    for (const k of dead) console.log(`    - ${k}`);
-  }
+  const crossLocaleRegression = reportCrossLocaleMissing(missingByLocale);
+  const usedMissingRegression = reportUsedMissing(locales, used);
+  const dead = findDeadKeys(allKeys, locales, used, dynamicPrefixes);
+  reportDeadKeys(dead);
 
   console.log();
-  if (hasRegression) {
+  if (crossLocaleRegression || usedMissingRegression) {
     console.log('FAIL: regressions detected.');
     process.exit(1);
   }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -294,5 +294,11 @@
       "preFirst": "Before first train · first train at {{time}}",
       "postLast": "After last train · first train tomorrow at {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "Share subway route",
+      "bodyTemplate": "{{fromName}} ({{fromLine}}) → {{toName}} ({{toLine}})\n~{{minutes}} min · {{stops}} stops"
+    }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -294,5 +294,11 @@
       "preFirst": "始発前 · 始発 {{time}} 予定",
       "postLast": "終電後 · 明日の始発 {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "地下鉄ルートを共有",
+      "bodyTemplate": "{{fromName}}（{{fromLine}}）→ {{toName}}（{{toLine}}）\n約{{minutes}}分・{{stops}}駅"
+    }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -294,5 +294,11 @@
       "preFirst": "첫차 전 · 첫차 {{time}} 예정",
       "postLast": "막차 후 · 내일 첫차 {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "지하철 경로 공유",
+      "bodyTemplate": "{{fromName}}({{fromLine}}) → {{toName}}({{toLine}})\n약 {{minutes}}분 · {{stops}}개 역"
+    }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -294,5 +294,11 @@
       "preFirst": "首班车前 · 首班车 {{time}}",
       "postLast": "末班车后 · 明日首班车 {{time}}"
     }
+  },
+  "share": {
+    "trip": {
+      "title": "分享地铁路线",
+      "bodyTemplate": "{{fromName}}（{{fromLine}}）→ {{toName}}（{{toLine}}）\n约{{minutes}}分钟 · {{stops}}站"
+    }
   }
 }


### PR DESCRIPTION
## 배경

PR #1085 작업 중 \`share.trip.title\` / \`share.trip.bodyTemplate\`이 #1069 ↔ #1072 머지 conflict 과정에서 누락된 채 dev에 들어간 회귀 발견. 동일한 누락이 더 있는지 audit.

## 변경

### 1. \`scripts/audit-i18n.js\` 추가
- ko/en/ja/zh 4개 locale을 평탄화해 차집합 계산
- 소스(\`src/\`, \`app/\`, \`modules/\`)에서 \`t(...)\` / \`i18n.t(...)\` / \`i18next.t(...)\` 호출의 첫 인자(삼항 포함) 안의 quoted dotted key를 추출
- \`labelKey: '...'\` 같은 table-driven 키도 인식
- i18next v4 plural suffix(\`_zero\`/\`_one\`/\`_two\`/\`_few\`/\`_many\`/\`_other\`) 인식 → \`t('foo', { count })\`는 \`foo_one\`/\`foo_other\`만 있어도 정상
- \`t(\`prefix.\${x}\`)\` 형태 dynamic prefix 인식 → \`lines.*\`, \`favorites.*\`, \`routes.*\` 등 데이터 주도 키를 dead로 오탐하지 않음
- 누락 발견 시 exit 1 (CI 게이트 가능)
- dead key는 보고만 (별도 PR에서 정리)

### 2. \`scripts/__tests__/audit-i18n.test.js\` 추가
\`flatten\` / \`diff\` 단위 테스트 + repo 통합 테스트(누락 0건 보장).

### 3. \`share.trip\` 4개 locale 보완

| locale | title | bodyTemplate |
| --- | --- | --- |
| ko | 지하철 경로 공유 | \`{{fromName}}({{fromLine}}) → {{toName}}({{toLine}})\\n약 {{minutes}}분 · {{stops}}개 역\` |
| en | Share subway route | \`{{fromName}} ({{fromLine}}) → {{toName}} ({{toLine}})\\n~{{minutes}} min · {{stops}} stops\` |
| ja | 地下鉄ルートを共有 | \`{{fromName}}（{{fromLine}}）→ {{toName}}（{{toLine}}）\\n約{{minutes}}分・{{stops}}駅\` |
| zh | 分享地铁路线 | \`{{fromName}}（{{fromLine}}）→ {{toName}}（{{toLine}}）\\n约{{minutes}}分钟 · {{stops}}站\` |

> ja/zh는 best-effort. 네이티브 검토는 후속 PR에서.

## audit 결과

- **Cross-locale 누락**: 0건 (보완 후)
- **Used-but-missing**: 0건 (보완 후, plural/dynamic prefix 반영)
- **Dead key 후보 5건** (별도 PR에서 정리):
  - \`a11y.alarm.dismissLabel\`
  - \`a11y.settings.localeRowHint\`
  - \`a11y.settings.routeSegmentHint\`
  - \`a11y.settings.themeSegmentHint\`
  - \`common.confirm\`

## 확인

- \`node scripts/audit-i18n.js\` → OK
- \`npx jest scripts/__tests__/audit-i18n.test.js src/shared/i18n\` → 22 passed
- \`npm run type-check\` → 통과

> \`npm test\` 전체 실행 시 \`LiveActivityModule\` 네이티브 mock 관련 테스트 35건 실패 — origin/dev HEAD에서도 동일하게 재현되는 **사전 회귀**로, 본 PR(JSON + scripts/만 수정)과 무관. 별도 처리 필요.

## 후속

- audit script를 CI에 붙여 회귀 게이트화 (별도 chore 이슈)
- dead key 5건 정리 (별도 chore PR)
- ja/zh 네이티브 검토