### PR TITLE
fix(#1094): 위젯 lifecycle을 destination 게이트에서 분리

### DIFF
--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -869,15 +869,11 @@ describe('stationNotification', () => {
       expect(mockUpdateLiveActivity).toHaveBeenCalled();
     });
 
-    it('clearStationNotification은 clearWidgetStation을 호출한다', async () => {
+    it('clearStationNotification은 위젯을 비우지 않는다 (#1094)', async () => {
+      // 위젯 lifecycle은 HomeScreen mirror effect가 담당. destination이 사라져도
+      // 사용자가 역 근처에 있는 동안 위젯이 "감지 중"으로 깜빡이는 회귀를 막기 위함.
       await clearStationNotification();
-      expect(mockClearWidgetStation).toHaveBeenCalled();
-    });
-
-    it('clearWidgetStation이 실패해도 endLiveActivity는 호출된다', async () => {
-      mockClearWidgetStation.mockRejectedValueOnce(new Error('group missing'));
-      await clearStationNotification();
-      expect(mockEndLiveActivity).toHaveBeenCalled();
+      expect(mockClearWidgetStation).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -19,7 +19,7 @@ import { vibrateAlarm, stopVibration } from './alarmSound';
 import { speakAlarm } from './tts';
 import { createLogger } from '../../../shared/utils/logger';
 import { getStationDisplayName, getStationDisplayNameByName } from '../../../shared/utils/stationDisplay';
-import { saveStationToWidget, clearWidgetStation } from '../../widget/api/widgetStorage';
+import { saveStationToWidget } from '../../widget/api/widgetStorage';
 import { hasFiredPushId } from './firedPushIds';
 import stationsData from '../../../data/stations.json';
 import type { ExitSide } from '../../../shared/types/exitSide';
@@ -424,9 +424,9 @@ async function dismissStationPassedNotification(): Promise<void> {
 }
 
 export async function clearStationNotification(): Promise<void> {
-  await clearWidgetStation().catch((e) =>
-    notifLogger.error('위젯 해제 실패:', e),
-  );
+  // #1094: 위젯은 nearest station 결과를 따로 mirror 하므로 여기서 비우지 않는다.
+  // destination이 없거나 경로가 끝나도 사용자가 500m 내 역 근처에 있는 동안엔
+  // 위젯이 계속 현재 역을 보여줘야 한다. 위젯 lifecycle은 HomeScreen mirror effect가 담당.
   if (Platform.OS === 'ios') {
     if (!LiveActivity.isLiveActivityEnabled()) {
       notifLogger.info('알림 해제 (Live Activity 비활성)');

--- a/src/features/widget/hooks/__tests__/useWidgetMirror.test.ts
+++ b/src/features/widget/hooks/__tests__/useWidgetMirror.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from '@testing-library/react-native';
+import type { Station } from '../../../../shared/types/station';
+
+const mockSave = jest.fn().mockResolvedValue(undefined);
+const mockClear = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../api/widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSave(...args),
+  clearWidgetStation: () => mockClear(),
+}));
+
+const mockLoggerError = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    debug: jest.fn(),
+  };
+  return { createLogger: () => logger };
+});
+
+import { useWidgetMirror } from '../useWidgetMirror';
+
+const station: Station = {
+  id: '2-001',
+  name: '강남',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.497,
+  lng: 127.027,
+};
+
+beforeEach(() => {
+  mockSave.mockClear();
+  mockClear.mockClear();
+  mockLoggerError.mockClear();
+});
+
+describe('useWidgetMirror', () => {
+  it('station 감지 시 saveStationToWidget을 호출한다', () => {
+    renderHook(() => useWidgetMirror(station, 0.1));
+    expect(mockSave).toHaveBeenCalledWith(station, 0.1);
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it('station이 null이면 clearWidgetStation을 호출한다', () => {
+    renderHook(() => useWidgetMirror(null, null));
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it('distanceKm이 null이면 station이 있어도 clear', () => {
+    renderHook(() => useWidgetMirror(station, null));
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it('같은 50m bucket 내 미세 변경엔 effect가 재실행되지 않는다', () => {
+    // 100m → 120m → 149m 는 전부 bucket 2 (100~149m)
+    const { rerender } = renderHook(({ d }: { d: number }) => useWidgetMirror(station, d), {
+      initialProps: { d: 0.1 },
+    });
+    rerender({ d: 0.12 });
+    rerender({ d: 0.149 });
+    expect(mockSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('bucket이 바뀌면 다시 save', () => {
+    const { rerender } = renderHook(({ d }: { d: number }) => useWidgetMirror(station, d), {
+      initialProps: { d: 0.5 }, // bucket 10
+    });
+    rerender({ d: 0.45 }); // bucket 9
+    rerender({ d: 0.03 }); // bucket 0
+    expect(mockSave).toHaveBeenCalledTimes(3);
+  });
+
+  it('station이 바뀌면 다시 save', () => {
+    const other: Station = { ...station, id: '2-002', name: '역삼' };
+    const { rerender } = renderHook(
+      ({ s }: { s: Station }) => useWidgetMirror(s, 0.1),
+      { initialProps: { s: station } },
+    );
+    rerender({ s: other });
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(mockSave).toHaveBeenLastCalledWith(other, 0.1);
+  });
+
+  it('station → null 전환 시 clear', () => {
+    const { rerender } = renderHook(
+      ({ s, d }: { s: Station | null; d: number | null }) => useWidgetMirror(s, d),
+      { initialProps: { s: station as Station | null, d: 0.1 as number | null } },
+    );
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    rerender({ s: null, d: null });
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('save 실패 시 logger.error만 호출 (throw 안 함)', async () => {
+    mockSave.mockRejectedValueOnce(new Error('group missing'));
+    renderHook(() => useWidgetMirror(station, 0.1));
+    await new Promise((r) => setImmediate(r));
+    expect(mockLoggerError).toHaveBeenCalledWith('save 실패:', expect.any(Error));
+  });
+
+  it('clear 실패 시 logger.error만 호출 (throw 안 함)', async () => {
+    mockClear.mockRejectedValueOnce(new Error('group missing'));
+    renderHook(() => useWidgetMirror(null, null));
+    await new Promise((r) => setImmediate(r));
+    expect(mockLoggerError).toHaveBeenCalledWith('clear 실패:', expect.any(Error));
+  });
+});

--- a/src/features/widget/hooks/useWidgetMirror.ts
+++ b/src/features/widget/hooks/useWidgetMirror.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import type { Station } from '../../../shared/types/station';
+import { saveStationToWidget, clearWidgetStation } from '../api/widgetStorage';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('WidgetMirror');
+
+// 위젯이 사용자 체감 가능한 최소 거리 단위. widgetStorage.ts의 dedupe bucket과 동일하게 맞춰
+// useEffect deps가 같은 50m 안에서는 안정적으로 유지되도록 한다. 다른 bucket으로 재정의하면
+// effect 재실행이 dedupe 게이트와 어긋나 무용한 호출이 발생한다.
+const DISTANCE_BUCKET_M = 50;
+
+function distanceBucket(distanceKm: number | undefined | null): number | null {
+  if (distanceKm == null) return null;
+  const distanceM = Math.max(0, Math.round(distanceKm * 1000));
+  return Math.floor(distanceM / DISTANCE_BUCKET_M);
+}
+
+/**
+ * nearest station 결과를 iOS 홈 위젯에 단방향 mirror.
+ *
+ * - station 존재 (500m 반경 내 감지) → `saveStationToWidget`
+ * - station 없음 → `clearWidgetStation` 으로 위젯이 "감지 중" fallback 표시
+ *
+ * 위젯 lifecycle은 destination/route 상태와 분리되어 항상 nearest station을 반영한다(#1094).
+ * deps는 50m bucket으로 정규화해 GPS tick마다 불필요한 effect 재실행을 막는다.
+ */
+export function useWidgetMirror(
+  station: Station | null | undefined,
+  distanceKm: number | null | undefined,
+): void {
+  const bucket = distanceBucket(distanceKm);
+  const stationId = station?.id ?? null;
+
+  useEffect(() => {
+    if (!station || distanceKm == null) {
+      clearWidgetStation().catch((e) => logger.error('clear 실패:', e));
+      return;
+    }
+    saveStationToWidget(station, distanceKm).catch((e) =>
+      logger.error('save 실패:', e),
+    );
+    // station/distanceKm은 ref로만 사용. stationId/bucket이 effect 재실행 트리거.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stationId, bucket]);
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -22,6 +22,7 @@ import { journeyDisplayToStops, nearestResultToNearest } from '../features/route
 import { useRouter } from 'expo-router';
 import { getStationDisplayName } from '../shared/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../features/alarm/utils/stationNotification';
+import { useWidgetMirror } from '../features/widget/hooks/useWidgetMirror';
 import { useStationAlarm } from '../features/alarm/hooks/useStationAlarm';
 import { useMotionActivity } from '../features/nearest-station/hooks/useMotionActivity';
 import { useBarometer } from '../shared/hooks/useBarometer';
@@ -552,6 +553,10 @@ export default function HomeScreen() {
       }
     };
   }, []);
+
+  // #1094: 위젯은 destination/route 진행 여부와 무관하게 항상 nearest station을 미러링한다.
+  // 50m bucket 단위로 dedupe되어 GPS tick 폭주를 흡수. LA/푸시 알림 lifecycle과 의도적으로 분리.
+  useWidgetMirror(result?.station ?? null, result?.distanceKm ?? null);
 
   useEffect(() => {
     const prevDestId = prevDestIdRef.current;


### PR DESCRIPTION
## Summary

- destination이 없으면 위젯이 항상 "감지 중"으로 고정되던 회귀를 차단.
- `clearStationNotification`의 책임을 LA/푸시 알림 lifecycle로만 축소하고, 위젯 mirror는 nearest station 결과를 직접 따르는 별도 훅으로 분리.
- 위젯 mirror 로직을 `src/features/widget/hooks/useWidgetMirror`로 추출 — 50m bucket 단위 deps로 GPS tick 폭주 흡수.

## 변경 요약

| 파일 | 변경 |
| --- | --- |
| `src/features/widget/hooks/useWidgetMirror.ts` (new) | nearest station → 위젯 단방향 mirror 훅 |
| `src/features/widget/hooks/__tests__/useWidgetMirror.test.ts` (new) | 9 케이스, 100% coverage |
| `src/features/alarm/utils/stationNotification.ts` | `clearStationNotification`에서 `clearWidgetStation` 호출/import 제거 |
| `src/features/alarm/utils/__tests__/stationNotification.test.ts` | 회귀 가드(`위젯을 비우지 않는다`)로 교체 |
| `src/screens/HomeScreen.tsx` | `useWidgetMirror(result?.station, result?.distanceKm)` 추가 |

## 동작 변화

| 상태 | 기존 | 변경 후 |
| --- | --- | --- |
| 500m 내 역 + destination 없음 | "감지 중" | 현재 역명 + 거리 |
| 500m 내 역 + 경로 진행 중 | 현재 역명 | 동일 |
| 500m 밖 (역 미감지) | "감지 중" | "감지 중" (유지) |
| arrived → destination clear | "감지 중" | 현재 역 계속 표시 |

BG 경로(`updateStationNotification` → `saveStationToWidget`)는 그대로 유지 — BG 위젯 갱신 회귀 방지.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm test` 4314/4314 pass, coverage 100%
- [x] eslint clean
- [x] 코드 리뷰 1회 반영 (P1-1/P1-2 → 훅 추출 + bucket 안정화)
- [ ] (수동) 실기기 destination 없이 강남역 진입 → 위젯에 "강남" + 거리 표시
- [ ] (수동) 강남역에서 멀어지면(>500m) "감지 중"으로 전환
- [ ] (수동) 경로 도착 후 destination clear → 위젯에 현재 역 유지

Closes #1094