### PR TITLE
chore: 위키백과 승강장 구조 자동 수집 PoC (#1092 follow-up)

### DIFF
--- a/data/wiki-platform-sample.json
+++ b/data/wiki-platform-sample.json
@@ -1,0 +1,247 @@
+{
+  "generatedAt": "2026-06-10T12:41:46.301Z",
+  "source": "ko.wikipedia.org",
+  "license": "CC BY-SA 4.0",
+  "results": [
+    {
+      "stationName": "소요산",
+      "line": "1",
+      "wikiTitle": null,
+      "rawField": null,
+      "layout": "unknown",
+      "confidence": "low"
+    },
+    {
+      "stationName": "시청",
+      "line": "2",
+      "wikiTitle": "시청역 (서울)",
+      "rawField": "[[수도권 전철 1호선]] : 2면 2선<br/>[[서울 지하철 2호선]] : 1면 2선",
+      "layout": "side",
+      "confidence": "medium"
+    },
+    {
+      "stationName": "대화",
+      "line": "3",
+      "wikiTitle": "대화역",
+      "rawField": "1면 2선",
+      "layout": "island",
+      "confidence": "medium"
+    },
+    {
+      "stationName": "당고개",
+      "line": "4",
+      "wikiTitle": null,
+      "rawField": null,
+      "layout": "unknown",
+      "confidence": "low"
+    },
+    {
+      "stationName": "방화",
+      "line": "5",
+      "wikiTitle": "방화역",
+      "rawField": "2면 3선",
+      "layout": "mixed",
+      "confidence": "low"
+    },
+    {
+      "stationName": "장암",
+      "line": "7",
+      "wikiTitle": "장암역",
+      "rawField": "1면 1선",
+      "layout": "mixed",
+      "confidence": "low"
+    },
+    {
+      "stationName": "개화",
+      "line": "9",
+      "wikiTitle": "개화역",
+      "rawField": "1면 2선([[섬식 승강장|섬식)]]",
+      "layout": "island",
+      "confidence": "high"
+    },
+    {
+      "stationName": "응암",
+      "line": "6",
+      "wikiTitle": "응암역",
+      "rawField": "1면 2선([[섬식 승강장|섬식]])",
+      "layout": "island",
+      "confidence": "high"
+    },
+    {
+      "stationName": "암사",
+      "line": "8",
+      "wikiTitle": "암사역",
+      "rawField": "2면 2선",
+      "layout": "side",
+      "confidence": "medium"
+    },
+    {
+      "stationName": "서울역",
+      "line": "airport",
+      "wikiTitle": "서울역",
+      "rawField": "경부선 : 8면 20선<br>경의선  : 1면 6선 || 각 1면 2선([[섬식 승강장|섬식]])",
+      "layout": "mixed",
+      "confidence": "medium"
+    },
+    {
+      "stationName": "운천",
+      "line": "gyeongui",
+      "wikiTitle": null,
+      "rawField": null,
+      "layout": "unknown",
+      "confidence": "low"
+    },
+    {
+      "stationName": "인천",
+      "line": "bundang",
+      "wikiTitle": "인천역",
+      "rawField": "[[수도권 전철 1호선|1호선]]: 2면 3선<br />[[수인·분당선]] : 1면 2선",
+      "layout": "mixed",
+      "confidence": "low"
+    },
+    {
+      "stationName": "광교(경기대)",
+      "line": "sinbundang",
+      "wikiTitle": null,
+      "rawField": null,
+      "layout": "unknown",
+      "confidence": "low"
+    },
+    {
+      "stationName": "동두천",
+      "line": "1",
+      "wikiTitle": "동두천역",
+      "rawField": "3면 14선",
+      "layout": "mixed",
+      "confidence": "low"
+    },
+    {
+      "stationName": "을지로입구",
+      "line": "2",
+      "wikiTitle": "을지로입구역",
+      "rawField": "2면 2선([[상대식 승강장|상대식]])",
+      "layout": "side",
+      "confidence": "high"
+    },
+    {
+      "stationName": "주엽",
+      "line": "3",
+      "wikiTitle": "주엽역",
+      "rawField": "2면 2선([[상대식 승강장|상대식]])",
+      "layout": "side",
+      "confidence": "high"
+    },
+    {
+      "stationName": "상계",
+      "line": "4",
+      "wikiTitle": "상계역",
+      "rawField": "2면 2선([[상대식 승강장|상대식]])",
+      "layout": "side",
+      "confidence": "high"
+    },
+    {
+      "stationName": "개화산",
+      "line": "5",
+      "wikiTitle": "개화산역",
+      "rawField": "2면 2선([[상대식 승강장|상대식]])",
+      "layout": "side",
+      "confidence": "high"
+    },
+    {
+      "stationName": "도봉산",
+      "line": "7",
+      "wikiTitle": "도봉산역",
+      "rawField": "2면 4선 || 2면 2선",
+      "layout": "mixed",
+      "confidence": "medium"
+    },
+    {
+      "stationName": "김포공항",
+      "line": "9",
+      "wikiTitle": "김포공항역",
+      "rawField": "2면 2선 ([[상대식 승강장|상대식]]) || 지하 3층: 2면 3선([[혼합식 승강장|혼합식]])<br />지하 4층: 1면 2선([[섬식 승강장|섬식]]) || 2면 2선([[상대식 승강장|상대식]]) || 2면 2선 ([[상대식 승강장|상대식]]) 지하 12층(지하 85m깊이에 건설)",
+      "layout": "mixed",
+      "confidence": "medium"
+    },
+    {
+      "stationName": "역촌",
+      "line": "6",
+      "wikiTitle": "역촌역",
+      "rawField": "1면 1선([[단선 승강장|단선]])",
+      "layout": "mixed",
+      "confidence": "low"
+    },
+    {
+      "stationName": "천호",
+      "line": "8",
+      "wikiTitle": "천호역",
+      "rawField": "각각 2면 2선([[상대식 승강장|상대식]])",
+      "layout": "side",
+      "confidence": "high"
+    },
+    {
+      "stationName": "공덕",
+      "line": "airport",
+      "wikiTitle": "공덕역",
+      "rawField": "서울 지하철 5호선 : 1면 2선([[섬식 승강장|섬식)]]<br />서울 지하철 6호선 : 2면 2선([[상대식 승강장|상대식)]]<br /> || 2면 2선([[상대식 승강장|상대식)]] || 2면 2선([[상대식 승강장|상대식)]]",
+      "layout": "mixed",
+      "confidence": "medium"
+    },
+    {
+      "stationName": "임진강",
+      "line": "gyeongui",
+      "wikiTitle": "임진강역",
+      "rawField": "1면 1선",
+      "layout": "mixed",
+      "confidence": "low"
+    },
+    {
+      "stationName": "신포",
+      "line": "bundang",
+      "wikiTitle": null,
+      "rawField": null,
+      "layout": "unknown",
+      "confidence": "low"
+    },
+    {
+      "stationName": "광교중앙(아주대)",
+      "line": "sinbundang",
+      "wikiTitle": null,
+      "rawField": null,
+      "layout": "unknown",
+      "confidence": "low"
+    },
+    {
+      "stationName": "보산",
+      "line": "1",
+      "wikiTitle": "보산역",
+      "rawField": "2면 2선 ([[상대식 승강장|상대식]])",
+      "layout": "side",
+      "confidence": "high"
+    },
+    {
+      "stationName": "을지로3가",
+      "line": "2",
+      "wikiTitle": "을지로3가역",
+      "rawField": "[[서울 지하철 2호선|2호선]]: 2면 2선([[상대식 승강장|상대식]])<br />[[서울 지하철 3호선|3호선]]: 1면 2선([[섬식 승강장|섬식]])",
+      "layout": "mixed",
+      "confidence": "high"
+    },
+    {
+      "stationName": "정발산",
+      "line": "3",
+      "wikiTitle": "정발산역",
+      "rawField": "2면 2선([[상대식 승강장|상대식]])",
+      "layout": "side",
+      "confidence": "high"
+    },
+    {
+      "stationName": "노원",
+      "line": "4",
+      "wikiTitle": "노원역",
+      "rawField": "서울 지하철 4호선: 2면 2선([[상대식 승강장|상대식]])<br />서울 지하철 7호선: 1면 2선(섬식)",
+      "layout": "mixed",
+      "confidence": "high"
+    }
+  ]
+}

--- a/scripts/__tests__/scrape-wiki-platform.test.js
+++ b/scripts/__tests__/scrape-wiki-platform.test.js
@@ -18,6 +18,14 @@ const {
 
 const TMP_OUT = path.join(os.tmpdir(), 'subway-now-wiki-platform-test.json');
 
+// 테스트 헬퍼: MediaWiki parse API 응답 mock 생성 (중복 제거)
+const wikiResponse = (wikitext) => ({
+  ok: true,
+  json: async () => ({ parse: { wikitext: { '*': wikitext } } }),
+});
+const notFoundResponse = () => ({ ok: false, json: async () => ({}) });
+const mockFetchOnce = (wikitext) => jest.fn().mockResolvedValue(wikiResponse(wikitext));
+
 describe('extractPlatformFields', () => {
   it('returns [] for empty / null input', () => {
     expect(extractPlatformFields('')).toEqual([]);
@@ -104,10 +112,7 @@ describe('aggregateLayout', () => {
 
 describe('fetchWikitext', () => {
   it('returns wikitext on 200', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선' } } }),
-    });
+    const fakeFetch = mockFetchOnce('|승강장 = 1면 2선');
     const wt = await fetchWikitext('잠실역', fakeFetch);
     expect(wt).toBe('|승강장 = 1면 2선');
     expect(fakeFetch).toHaveBeenCalledWith(
@@ -117,7 +122,7 @@ describe('fetchWikitext', () => {
   });
 
   it('returns null on non-ok response', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    const fakeFetch = jest.fn().mockResolvedValue(notFoundResponse());
     expect(await fetchWikitext('없는역', fakeFetch)).toBeNull();
   });
 
@@ -129,10 +134,7 @@ describe('fetchWikitext', () => {
 
 describe('resolveStation', () => {
   it('uses first matching candidate', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 2면 2선([[상대식]])' } } }),
-    });
+    const fakeFetch = mockFetchOnce('|승강장 = 2면 2선([[상대식]])');
     const r = await resolveStation({ name: '잠실', line: '2' }, fakeFetch);
     expect(r).toEqual({
       stationName: '잠실',
@@ -147,11 +149,8 @@ describe('resolveStation', () => {
 
   it('falls through to next candidate when first has no 승강장 field (disambiguation)', async () => {
     const fakeFetch = jest.fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ parse: { wikitext: { '*': '동음이의 페이지' } } }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선 섬식' } } }),
-      });
+      .mockResolvedValueOnce(wikiResponse('동음이의 페이지'))
+      .mockResolvedValueOnce(wikiResponse('|승강장 = 1면 2선 섬식'));
     const r = await resolveStation({ name: '시청', line: '2' }, fakeFetch);
     expect(r.wikiTitle).toBe('시청역 (서울)');
     expect(r.layout).toBe('island');
@@ -160,19 +159,16 @@ describe('resolveStation', () => {
 
   it('skips candidate when fetchWikitext returns null', async () => {
     const fakeFetch = jest.fn()
-      .mockResolvedValueOnce({ ok: false, json: async () => ({}) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선' } } }),
-      })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({}) });
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(wikiResponse('|승강장 = 1면 2선'))
+      .mockResolvedValueOnce(notFoundResponse());
     const r = await resolveStation({ name: '강남', line: '2' }, fakeFetch);
     expect(r.wikiTitle).toBe('강남역 (서울)');
     expect(r.layout).toBe('island');
   });
 
   it('returns unknown when all candidates fail', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    const fakeFetch = jest.fn().mockResolvedValue(notFoundResponse());
     const r = await resolveStation({ name: '없음', line: '99' }, fakeFetch);
     expect(r).toEqual({
       stationName: '없음',
@@ -243,10 +239,7 @@ describe('run (integration with deps injection)', () => {
   });
 
   it('scrapes --only stations and writes output', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선 ([[섬식]])' } } }),
-    });
+    const fakeFetch = mockFetchOnce('|승강장 = 1면 2선 ([[섬식]])');
     const sleepFn = jest.fn().mockResolvedValue(undefined);
     const writeFile = jest.fn();
     const log = jest.fn();
@@ -270,10 +263,7 @@ describe('run (integration with deps injection)', () => {
   });
 
   it('handles --sample argument', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 2면 2선 상대식' } } }),
-    });
+    const fakeFetch = mockFetchOnce('|승강장 = 2면 2선 상대식');
     const r = await run(['--sample', '1'], {
       fetch: fakeFetch,
       sleep: jest.fn(),

--- a/scripts/__tests__/scrape-wiki-platform.test.js
+++ b/scripts/__tests__/scrape-wiki-platform.test.js
@@ -1,0 +1,283 @@
+/**
+ * scrape-wiki-platform.js (#1092 follow-up PoC) — 인포박스 파서 + 분류 + 통합 동작 검증.
+ * 네트워크는 mock fetch로 격리한다.
+ */
+
+const {
+  extractPlatformFields,
+  classifyLayout,
+  aggregateLayout,
+  fetchWikitext,
+  resolveStation,
+  pickStations,
+  run,
+} = require('../scrape-wiki-platform');
+
+describe('extractPlatformFields', () => {
+  it('returns [] for empty / null input', () => {
+    expect(extractPlatformFields('')).toEqual([]);
+    expect(extractPlatformFields(null)).toEqual([]);
+    expect(extractPlatformFields(undefined)).toEqual([]);
+    expect(extractPlatformFields(123)).toEqual([]);
+  });
+
+  it('extracts single 승강장 field', () => {
+    const wt = '|역명 = 잠실\n|승강장 = 2면 2선([[상대식 승강장|상대식]])\n|코드 = 0216';
+    expect(extractPlatformFields(wt)).toEqual(['2면 2선([[상대식 승강장|상대식]])']);
+  });
+
+  it('extracts multiple 승강장 fields from multi-infobox page', () => {
+    const wt = '|승강장 = 2면 2선([[상대식]])\n... 다른 본문 ...\n|승강장 = 1면 2선([[섬식]])';
+    expect(extractPlatformFields(wt)).toEqual(['2면 2선([[상대식]])', '1면 2선([[섬식]])']);
+  });
+
+  it('ignores fields without value', () => {
+    const wt = '|승강장 =   \n|승강장 = 1면 2선';
+    expect(extractPlatformFields(wt)).toEqual(['1면 2선']);
+  });
+});
+
+describe('classifyLayout', () => {
+  it('returns unknown for empty', () => {
+    expect(classifyLayout('')).toEqual({ layout: 'unknown', confidence: 'low' });
+    expect(classifyLayout(null)).toEqual({ layout: 'unknown', confidence: 'low' });
+  });
+
+  it('detects 섬식 with high confidence', () => {
+    expect(classifyLayout('1면 2선 ([[섬식 승강장|섬식]])')).toEqual({ layout: 'island', confidence: 'high' });
+  });
+
+  it('detects 상대식 with high confidence', () => {
+    expect(classifyLayout('2면 2선([[상대식 승강장|상대식]])')).toEqual({ layout: 'side', confidence: 'high' });
+  });
+
+  it('detects mixed when both 섬식 and 상대식 present', () => {
+    expect(classifyLayout('상행 섬식 / 하행 상대식')).toEqual({ layout: 'mixed', confidence: 'high' });
+  });
+
+  it('heuristic: 1면 2선 → island (medium)', () => {
+    expect(classifyLayout('1면 2선')).toEqual({ layout: 'island', confidence: 'medium' });
+  });
+
+  it('heuristic: 2면 2선 → side (medium)', () => {
+    expect(classifyLayout('2면 2선')).toEqual({ layout: 'side', confidence: 'medium' });
+  });
+
+  it('heuristic: 2면 4선 → mixed (low)', () => {
+    expect(classifyLayout('2면 4선 혼합')).toEqual({ layout: 'mixed', confidence: 'low' });
+  });
+
+  it('returns unknown for free text without 면선 pattern', () => {
+    expect(classifyLayout('지상역')).toEqual({ layout: 'unknown', confidence: 'low' });
+  });
+});
+
+describe('aggregateLayout', () => {
+  it('returns unknown when no fields', () => {
+    expect(aggregateLayout([])).toEqual({ layout: 'unknown', confidence: 'low', rawField: null });
+  });
+
+  it('returns single classification when all fields agree', () => {
+    const r = aggregateLayout(['1면 2선 섬식', '1면 2선 섬식']);
+    expect(r.layout).toBe('island');
+    expect(r.confidence).toBe('high');
+    expect(r.rawField).toBe('1면 2선 섬식 || 1면 2선 섬식');
+  });
+
+  it('collapses to single layout if all non-unknown agree', () => {
+    const r = aggregateLayout(['1면 2선 섬식', '지상역']);
+    expect(r.layout).toBe('island');
+    expect(r.confidence).toBe('medium');
+  });
+
+  it('returns mixed when non-unknown layouts differ', () => {
+    const r = aggregateLayout(['2면 2선 상대식', '1면 2선 섬식']);
+    expect(r.layout).toBe('mixed');
+    expect(r.confidence).toBe('medium');
+  });
+});
+
+describe('fetchWikitext', () => {
+  it('returns wikitext on 200', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선' } } }),
+    });
+    const wt = await fetchWikitext('잠실역', fakeFetch);
+    expect(wt).toBe('|승강장 = 1면 2선');
+    expect(fakeFetch).toHaveBeenCalledWith(
+      expect.stringContaining('action=parse'),
+      expect.objectContaining({ headers: expect.objectContaining({ 'User-Agent': expect.any(String) }) }),
+    );
+  });
+
+  it('returns null on non-ok response', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    expect(await fetchWikitext('없는역', fakeFetch)).toBeNull();
+  });
+
+  it('returns null when parse field missing', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ error: 'missingtitle' }) });
+    expect(await fetchWikitext('없는역', fakeFetch)).toBeNull();
+  });
+});
+
+describe('resolveStation', () => {
+  it('uses first matching candidate', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 2면 2선([[상대식]])' } } }),
+    });
+    const r = await resolveStation({ name: '잠실', line: '2' }, fakeFetch);
+    expect(r).toEqual({
+      stationName: '잠실',
+      line: '2',
+      wikiTitle: '잠실역',
+      rawField: '2면 2선([[상대식]])',
+      layout: 'side',
+      confidence: 'high',
+    });
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to next candidate when first has no 승강장 field (disambiguation)', async () => {
+    const fakeFetch = jest.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ parse: { wikitext: { '*': '동음이의 페이지' } } }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선 섬식' } } }),
+      });
+    const r = await resolveStation({ name: '시청', line: '2' }, fakeFetch);
+    expect(r.wikiTitle).toBe('시청역 (서울)');
+    expect(r.layout).toBe('island');
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips candidate when fetchWikitext returns null', async () => {
+    const fakeFetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, json: async () => ({}) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선' } } }),
+      })
+      .mockResolvedValueOnce({ ok: false, json: async () => ({}) });
+    const r = await resolveStation({ name: '강남', line: '2' }, fakeFetch);
+    expect(r.wikiTitle).toBe('강남역 (서울)');
+    expect(r.layout).toBe('island');
+  });
+
+  it('returns unknown when all candidates fail', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    const r = await resolveStation({ name: '없음', line: '99' }, fakeFetch);
+    expect(r).toEqual({
+      stationName: '없음',
+      line: '99',
+      wikiTitle: null,
+      rawField: null,
+      layout: 'unknown',
+      confidence: 'low',
+    });
+  });
+});
+
+describe('pickStations', () => {
+  const stations = [
+    { name: 'A', line: '1' },
+    { name: 'B', line: '1' },
+    { name: 'A', line: '2' }, // 같은 이름이지만 다른 노선 (환승역)
+    { name: 'C', line: '2' },
+    { name: 'D', line: '3' },
+  ];
+
+  it('returns [] when no option', () => {
+    expect(pickStations(stations, {})).toEqual([]);
+  });
+
+  it('filters by --only and de-dupes names', () => {
+    const r = pickStations(stations, { only: ['A', 'C'] });
+    expect(r).toEqual([
+      { name: 'A', line: '1' },
+      { name: 'C', line: '2' },
+    ]);
+  });
+
+  it('--only ignores names not in the list', () => {
+    expect(pickStations(stations, { only: ['Z'] })).toEqual([]);
+  });
+
+  it('--sample picks across lines round-robin, dedupes', () => {
+    const r = pickStations(stations, { sample: 3 });
+    expect(r).toHaveLength(3);
+    const names = r.map((s) => s.name);
+    // Round 0: line 1 → A, line 2 → A (dup, skip), line 3 → D
+    // Round 1: line 1 → B
+    expect(names).toEqual(['A', 'D', 'B']);
+  });
+
+  it('--sample exits round loop after exhausting unique stations', () => {
+    // sample=99 but only 4 unique names → stop at 4
+    const r = pickStations(stations, { sample: 99 });
+    const names = r.map((s) => s.name);
+    expect(names).toEqual(['A', 'D', 'B', 'C']);
+  });
+});
+
+describe('run (integration with deps injection)', () => {
+  it('warns and returns empty when no targets', async () => {
+    const log = jest.fn();
+    const r = await run([], {
+      fetch: jest.fn(),
+      sleep: jest.fn(),
+      writeFile: jest.fn(),
+      log,
+      stations: [{ name: 'A', line: '1' }],
+    });
+    expect(r.results).toEqual([]);
+    expect(r.path).toBeNull();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('No target stations'));
+  });
+
+  it('scrapes --only stations and writes output', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 1면 2선 ([[섬식]])' } } }),
+    });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+    const writeFile = jest.fn();
+    const log = jest.fn();
+    const r = await run(['--only', 'A,B'], {
+      fetch: fakeFetch,
+      sleep: sleepFn,
+      writeFile,
+      log,
+      stations: [
+        { name: 'A', line: '1' },
+        { name: 'B', line: '2' },
+      ],
+      outFile: '/tmp/out.json',
+    });
+    expect(r.results).toHaveLength(2);
+    expect(r.results[0].layout).toBe('island');
+    expect(r.path).toBe('/tmp/out.json');
+    expect(writeFile).toHaveBeenCalledWith('/tmp/out.json', expect.stringContaining('"license": "CC BY-SA 4.0"'));
+    // sleep called once between 2 items (not after last)
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles --sample argument', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ parse: { wikitext: { '*': '|승강장 = 2면 2선 상대식' } } }),
+    });
+    const r = await run(['--sample', '1'], {
+      fetch: fakeFetch,
+      sleep: jest.fn(),
+      writeFile: jest.fn(),
+      log: jest.fn(),
+      stations: [{ name: 'X', line: '1' }],
+      outFile: '/tmp/out.json',
+    });
+    expect(r.results).toHaveLength(1);
+    expect(r.results[0].layout).toBe('side');
+  });
+});

--- a/scripts/__tests__/scrape-wiki-platform.test.js
+++ b/scripts/__tests__/scrape-wiki-platform.test.js
@@ -26,6 +26,27 @@ const wikiResponse = (wikitext) => ({
 const notFoundResponse = () => ({ ok: false, json: async () => ({}) });
 const mockFetchOnce = (wikitext) => jest.fn().mockResolvedValue(wikiResponse(wikitext));
 
+// resolveStation 결과 shape 헬퍼 (필드 9줄 중복 제거)
+const stationResult = (overrides) => ({
+  stationName: '',
+  line: '',
+  wikiTitle: null,
+  rawField: null,
+  layout: 'unknown',
+  confidence: 'low',
+  ...overrides,
+});
+
+// run() deps 헬퍼 (kwargs 중복 제거)
+const runDeps = (overrides = {}) => ({
+  fetch: jest.fn(),
+  sleep: jest.fn(),
+  writeFile: jest.fn(),
+  log: jest.fn(),
+  stations: [],
+  ...overrides,
+});
+
 describe('extractPlatformFields', () => {
   it('returns [] for empty / null input', () => {
     expect(extractPlatformFields('')).toEqual([]);
@@ -136,14 +157,14 @@ describe('resolveStation', () => {
   it('uses first matching candidate', async () => {
     const fakeFetch = mockFetchOnce('|승강장 = 2면 2선([[상대식]])');
     const r = await resolveStation({ name: '잠실', line: '2' }, fakeFetch);
-    expect(r).toEqual({
+    expect(r).toEqual(stationResult({
       stationName: '잠실',
       line: '2',
       wikiTitle: '잠실역',
       rawField: '2면 2선([[상대식]])',
       layout: 'side',
       confidence: 'high',
-    });
+    }));
     expect(fakeFetch).toHaveBeenCalledTimes(1);
   });
 
@@ -170,14 +191,7 @@ describe('resolveStation', () => {
   it('returns unknown when all candidates fail', async () => {
     const fakeFetch = jest.fn().mockResolvedValue(notFoundResponse());
     const r = await resolveStation({ name: '없음', line: '99' }, fakeFetch);
-    expect(r).toEqual({
-      stationName: '없음',
-      line: '99',
-      wikiTitle: null,
-      rawField: null,
-      layout: 'unknown',
-      confidence: 'low',
-    });
+    expect(r).toEqual(stationResult({ stationName: '없음', line: '99' }));
   });
 });
 
@@ -226,13 +240,7 @@ describe('pickStations', () => {
 describe('run (integration with deps injection)', () => {
   it('warns and returns empty when no targets', async () => {
     const log = jest.fn();
-    const r = await run([], {
-      fetch: jest.fn(),
-      sleep: jest.fn(),
-      writeFile: jest.fn(),
-      log,
-      stations: [{ name: 'A', line: '1' }],
-    });
+    const r = await run([], runDeps({ log, stations: [{ name: 'A', line: '1' }] }));
     expect(r.results).toEqual([]);
     expect(r.path).toBeNull();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('No target stations'));
@@ -242,18 +250,16 @@ describe('run (integration with deps injection)', () => {
     const fakeFetch = mockFetchOnce('|승강장 = 1면 2선 ([[섬식]])');
     const sleepFn = jest.fn().mockResolvedValue(undefined);
     const writeFile = jest.fn();
-    const log = jest.fn();
-    const r = await run(['--only', 'A,B'], {
+    const r = await run(['--only', 'A,B'], runDeps({
       fetch: fakeFetch,
       sleep: sleepFn,
       writeFile,
-      log,
       stations: [
         { name: 'A', line: '1' },
         { name: 'B', line: '2' },
       ],
       outFile: TMP_OUT,
-    });
+    }));
     expect(r.results).toHaveLength(2);
     expect(r.results[0].layout).toBe('island');
     expect(r.path).toBe(TMP_OUT);
@@ -264,14 +270,11 @@ describe('run (integration with deps injection)', () => {
 
   it('handles --sample argument', async () => {
     const fakeFetch = mockFetchOnce('|승강장 = 2면 2선 상대식');
-    const r = await run(['--sample', '1'], {
+    const r = await run(['--sample', '1'], runDeps({
       fetch: fakeFetch,
-      sleep: jest.fn(),
-      writeFile: jest.fn(),
-      log: jest.fn(),
       stations: [{ name: 'X', line: '1' }],
       outFile: TMP_OUT,
-    });
+    }));
     expect(r.results).toHaveLength(1);
     expect(r.results[0].layout).toBe('side');
   });

--- a/scripts/__tests__/scrape-wiki-platform.test.js
+++ b/scripts/__tests__/scrape-wiki-platform.test.js
@@ -72,37 +72,18 @@ describe('extractPlatformFields', () => {
 });
 
 describe('classifyLayout', () => {
-  it('returns unknown for empty', () => {
-    expect(classifyLayout('')).toEqual({ layout: 'unknown', confidence: 'low' });
-    expect(classifyLayout(null)).toEqual({ layout: 'unknown', confidence: 'low' });
-  });
-
-  it('detects 섬식 with high confidence', () => {
-    expect(classifyLayout('1면 2선 ([[섬식 승강장|섬식]])')).toEqual({ layout: 'island', confidence: 'high' });
-  });
-
-  it('detects 상대식 with high confidence', () => {
-    expect(classifyLayout('2면 2선([[상대식 승강장|상대식]])')).toEqual({ layout: 'side', confidence: 'high' });
-  });
-
-  it('detects mixed when both 섬식 and 상대식 present', () => {
-    expect(classifyLayout('상행 섬식 / 하행 상대식')).toEqual({ layout: 'mixed', confidence: 'high' });
-  });
-
-  it('heuristic: 1면 2선 → island (medium)', () => {
-    expect(classifyLayout('1면 2선')).toEqual({ layout: 'island', confidence: 'medium' });
-  });
-
-  it('heuristic: 2면 2선 → side (medium)', () => {
-    expect(classifyLayout('2면 2선')).toEqual({ layout: 'side', confidence: 'medium' });
-  });
-
-  it('heuristic: 2면 4선 → mixed (low)', () => {
-    expect(classifyLayout('2면 4선 혼합')).toEqual({ layout: 'mixed', confidence: 'low' });
-  });
-
-  it('returns unknown for free text without 면선 pattern', () => {
-    expect(classifyLayout('지상역')).toEqual({ layout: 'unknown', confidence: 'low' });
+  it.each([
+    ['empty string', '', 'unknown', 'low'],
+    ['null', null, 'unknown', 'low'],
+    ['섬식 (high)', '1면 2선 ([[섬식 승강장|섬식]])', 'island', 'high'],
+    ['상대식 (high)', '2면 2선([[상대식 승강장|상대식]])', 'side', 'high'],
+    ['both 섬식+상대식 → mixed (high)', '상행 섬식 / 하행 상대식', 'mixed', 'high'],
+    ['1면 2선 heuristic → island (medium)', '1면 2선', 'island', 'medium'],
+    ['2면 2선 heuristic → side (medium)', '2면 2선', 'side', 'medium'],
+    ['2면 4선 heuristic → mixed (low)', '2면 4선 혼합', 'mixed', 'low'],
+    ['free text without 면선 → unknown', '지상역', 'unknown', 'low'],
+  ])('%s', (_label, input, layout, confidence) => {
+    expect(classifyLayout(input)).toEqual({ layout, confidence });
   });
 });
 

--- a/scripts/__tests__/scrape-wiki-platform.test.js
+++ b/scripts/__tests__/scrape-wiki-platform.test.js
@@ -3,6 +3,9 @@
  * 네트워크는 mock fetch로 격리한다.
  */
 
+const os = require('node:os');
+const path = require('node:path');
+
 const {
   extractPlatformFields,
   classifyLayout,
@@ -12,6 +15,8 @@ const {
   pickStations,
   run,
 } = require('../scrape-wiki-platform');
+
+const TMP_OUT = path.join(os.tmpdir(), 'subway-now-wiki-platform-test.json');
 
 describe('extractPlatformFields', () => {
   it('returns [] for empty / null input', () => {
@@ -254,12 +259,12 @@ describe('run (integration with deps injection)', () => {
         { name: 'A', line: '1' },
         { name: 'B', line: '2' },
       ],
-      outFile: '/tmp/out.json',
+      outFile: TMP_OUT,
     });
     expect(r.results).toHaveLength(2);
     expect(r.results[0].layout).toBe('island');
-    expect(r.path).toBe('/tmp/out.json');
-    expect(writeFile).toHaveBeenCalledWith('/tmp/out.json', expect.stringContaining('"license": "CC BY-SA 4.0"'));
+    expect(r.path).toBe(TMP_OUT);
+    expect(writeFile).toHaveBeenCalledWith(TMP_OUT, expect.stringContaining('"license": "CC BY-SA 4.0"'));
     // sleep called once between 2 items (not after last)
     expect(sleepFn).toHaveBeenCalledTimes(1);
   });
@@ -275,7 +280,7 @@ describe('run (integration with deps injection)', () => {
       writeFile: jest.fn(),
       log: jest.fn(),
       stations: [{ name: 'X', line: '1' }],
-      outFile: '/tmp/out.json',
+      outFile: TMP_OUT,
     });
     expect(r.results).toHaveLength(1);
     expect(r.results[0].layout).toBe('side');

--- a/scripts/scrape-wiki-platform.js
+++ b/scripts/scrape-wiki-platform.js
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * scrape-wiki-platform.js — #1092 follow-up PoC
+ *
+ * 위키백과(ko.wikipedia.org)의 한국 지하철역 인포박스에서 "승강장" 필드를 추출해
+ * 승강장 구조(섬식/상대식/혼합)를 추정한다. exitSide cross-check 보조 자료 후보.
+ *
+ * 데이터 출처: 위키백과 한국어판 — CC BY-SA 4.0
+ *   https://ko.wikipedia.org/wiki/위키백과:저작권
+ *
+ * 사용:
+ *   node scripts/scrape-wiki-platform.js --sample 30
+ *     # stations.json에서 무작위/대표 30개 역만 시도 → data/wiki-platform-sample.json
+ *   node scripts/scrape-wiki-platform.js --only 강남,잠실,사당
+ *     # 특정 역만 시도
+ *
+ * 한계:
+ *   - section=0(인포박스)만 파싱. 동음이의 페이지(예: "시청역")는 매칭 실패 → 'unknown'.
+ *   - "1면 2선" → 섬식, "2면 2선" → 상대식 휴리스틱은 지상/지하 혼합역에서 오류 가능
+ *     (예: 신도림, 노원, 서울역 등 다중 인포박스 보유 역).
+ *   - rate limit 보호용 1.1s sleep. 전체 528개 실행 금지(약 10분, 위키 정책 권장 범위 밖 작업
+ *     아니지만 본 PoC는 sample만 검증).
+ *
+ * 출력 스키마:
+ *   { generatedAt: ISO8601, source: 'ko.wikipedia.org', license: 'CC BY-SA 4.0',
+ *     results: Array<{ stationName, line, rawField, layout, confidence }> }
+ *   - layout: 'island' | 'side' | 'mixed' | 'unknown'
+ *   - confidence: 'high' (명시적 섬식/상대식 키워드) | 'medium' (N면N선 휴리스틱) | 'low' (추정 실패)
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const STATIONS = require(path.join(ROOT, 'src', 'data', 'stations.json'));
+const OUT_DIR = path.join(ROOT, 'data');
+const OUT_FILE = path.join(OUT_DIR, 'wiki-platform-sample.json');
+
+const SLEEP_MS = 1100;
+const USER_AGENT = 'subway-now-poc/1.0 (https://github.com/handokei/subway-now; CC BY-SA cross-check)';
+
+function readOption(args, flag) {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * 인포박스 wikitext에서 `|승강장 = ...` 필드 값을 모두 추출한다.
+ * 여러 노선이 한 페이지에 있으면(예: 강남역 = 2호선 + 신분당선) 여러 매칭이 나온다.
+ * @param {string} wikitext
+ * @returns {string[]}
+ */
+function extractPlatformFields(wikitext) {
+  if (!wikitext || typeof wikitext !== 'string') return [];
+  // `[ \t]*` (not `\s*`) prevents the value capture from crossing newlines into the next field.
+  const matches = [...wikitext.matchAll(/\|[ \t]*승강장[ \t]*=[ \t]*([^\n]*)/g)];
+  return matches.map((m) => m[1].trim()).filter((v) => v.length > 0);
+}
+
+/**
+ * 추출한 raw 필드 문자열로부터 승강장 구조를 판정한다.
+ * @param {string} raw
+ * @returns {{ layout: 'island'|'side'|'mixed'|'unknown', confidence: 'high'|'medium'|'low' }}
+ */
+function classifyLayout(raw) {
+  if (!raw) return { layout: 'unknown', confidence: 'low' };
+  const hasIsland = /섬식/.test(raw);
+  const hasSide = /상대식/.test(raw);
+  if (hasIsland && hasSide) return { layout: 'mixed', confidence: 'high' };
+  if (hasIsland) return { layout: 'island', confidence: 'high' };
+  if (hasSide) return { layout: 'side', confidence: 'high' };
+
+  // 휴리스틱: N면 M선 패턴
+  // 1면 2선 → 섬식 (1 platform between 2 tracks)
+  // 2면 2선 → 상대식 (2 side platforms, 2 tracks)
+  // 그 외(2면 4선 등) → mixed/unknown
+  const dim = raw.match(/(\d+)\s*면\s*(\d+)\s*선/);
+  if (dim) {
+    const platforms = Number(dim[1]);
+    const tracks = Number(dim[2]);
+    if (platforms === 1 && tracks === 2) return { layout: 'island', confidence: 'medium' };
+    if (platforms === 2 && tracks === 2) return { layout: 'side', confidence: 'medium' };
+    return { layout: 'mixed', confidence: 'low' };
+  }
+  return { layout: 'unknown', confidence: 'low' };
+}
+
+/**
+ * 한 페이지의 모든 라인 인포박스를 합쳐서 대표 layout을 정한다.
+ * 여러 노선이 같은 layout이면 그대로, 다르면 'mixed'.
+ * @param {string[]} fields
+ */
+function aggregateLayout(fields) {
+  if (fields.length === 0) return { layout: 'unknown', confidence: 'low', rawField: null };
+  const classified = fields.map((f) => ({ raw: f, ...classifyLayout(f) }));
+  const layouts = new Set(classified.map((c) => c.layout));
+  const rawField = fields.join(' || ');
+  if (layouts.size === 1) {
+    return { layout: classified[0].layout, confidence: classified[0].confidence, rawField };
+  }
+  // 노선별로 다른 layout이면 mixed
+  layouts.delete('unknown');
+  if (layouts.size === 1) {
+    return { layout: [...layouts][0], confidence: 'medium', rawField };
+  }
+  return { layout: 'mixed', confidence: 'medium', rawField };
+}
+
+/**
+ * 위키백과 페이지 wikitext를 가져온다. 동음이의 페이지면 null 반환.
+ * @param {string} title
+ * @param {typeof fetch} fetchFn
+ */
+async function fetchWikitext(title, fetchFn) {
+  const url = `https://ko.wikipedia.org/w/api.php?action=parse&page=${encodeURIComponent(title)}&format=json&prop=wikitext&section=0`;
+  const res = await fetchFn(url, { headers: { 'User-Agent': USER_AGENT, 'Accept-Language': 'ko-KR,ko' } });
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json?.parse?.wikitext?.['*'] ?? null;
+}
+
+/**
+ * 한 역에 대해 위키백과 lookup 시도. 1차: "{name}역", 2차: "{name}역 (서울)" 형태.
+ * @param {{ name: string, line: string }} station
+ * @param {typeof fetch} fetchFn
+ */
+async function resolveStation(station, fetchFn) {
+  const candidates = [`${station.name}역`, `${station.name}역 (서울)`, station.name];
+  for (const title of candidates) {
+    const wt = await fetchWikitext(title, fetchFn);
+    if (!wt) continue;
+    const fields = extractPlatformFields(wt);
+    if (fields.length === 0) continue;
+    const { layout, confidence, rawField } = aggregateLayout(fields);
+    return {
+      stationName: station.name,
+      line: station.line,
+      wikiTitle: title,
+      rawField,
+      layout,
+      confidence,
+    };
+  }
+  return {
+    stationName: station.name,
+    line: station.line,
+    wikiTitle: null,
+    rawField: null,
+    layout: 'unknown',
+    confidence: 'low',
+  };
+}
+
+/**
+ * 샘플 대상 역 리스트를 결정한다.
+ *   --only A,B,C → 정확히 그 역들
+ *   --sample N → 노선별 균등 샘플
+ */
+function pickStations(stations, { only, sample }) {
+  if (only && only.length > 0) {
+    const wanted = new Set(only);
+    // 중복 노선 제거: 같은 이름 첫 등장만
+    const seen = new Set();
+    return stations.filter((s) => {
+      if (!wanted.has(s.name) || seen.has(s.name)) return false;
+      seen.add(s.name);
+      return true;
+    });
+  }
+  if (sample && sample > 0) {
+    // 노선별로 1~2개씩 골라 N개에 도달
+    const byLine = new Map();
+    for (const s of stations) {
+      if (!byLine.has(s.line)) byLine.set(s.line, []);
+      byLine.get(s.line).push(s);
+    }
+    const picked = [];
+    const seen = new Set();
+    let round = 0;
+    while (picked.length < sample && round < 50) {
+      for (const list of byLine.values()) {
+        if (picked.length >= sample) break;
+        const candidate = list[round];
+        if (!candidate) continue;
+        if (seen.has(candidate.name)) continue;
+        seen.add(candidate.name);
+        picked.push(candidate);
+      }
+      round += 1;
+    }
+    return picked;
+  }
+  return [];
+}
+
+async function run(argv, deps = {}) {
+  const fetchFn = deps.fetch ?? fetch;
+  const sleepFn = deps.sleep ?? sleep;
+  const writeFile = deps.writeFile ?? ((p, c) => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, c);
+  });
+  const log = deps.log ?? console.log;
+
+  const only = readOption(argv, '--only')?.split(',').map((s) => s.trim()).filter(Boolean);
+  const sample = Number(readOption(argv, '--sample') ?? '0') || 0;
+  const stations = deps.stations ?? STATIONS;
+  const targets = pickStations(stations, { only, sample });
+
+  if (targets.length === 0) {
+    log('No target stations. Use --sample N or --only A,B,C.');
+    return { results: [], path: null };
+  }
+
+  log(`Scraping ${targets.length} stations (sleep ${SLEEP_MS}ms)...`);
+  const results = [];
+  for (let i = 0; i < targets.length; i += 1) {
+    const station = targets[i];
+    const result = await resolveStation(station, fetchFn);
+    results.push(result);
+    log(`[${i + 1}/${targets.length}] ${result.stationName} (line ${result.line}) → ${result.layout} (${result.confidence})`);
+    if (i < targets.length - 1) await sleepFn(SLEEP_MS);
+  }
+
+  const out = {
+    generatedAt: new Date().toISOString(),
+    source: 'ko.wikipedia.org',
+    license: 'CC BY-SA 4.0',
+    results,
+  };
+  const outPath = deps.outFile ?? OUT_FILE;
+  writeFile(outPath, JSON.stringify(out, null, 2) + '\n');
+  log(`Wrote ${results.length} results → ${outPath}`);
+  return { results, path: outPath };
+}
+
+module.exports = {
+  extractPlatformFields,
+  classifyLayout,
+  aggregateLayout,
+  fetchWikitext,
+  resolveStation,
+  pickStations,
+  run,
+};
+
+if (require.main === module) {
+  run(process.argv.slice(2)).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/scrape-wiki-platform.js
+++ b/scripts/scrape-wiki-platform.js
@@ -78,7 +78,8 @@ function classifyLayout(raw) {
   // 1면 2선 → 섬식 (1 platform between 2 tracks)
   // 2면 2선 → 상대식 (2 side platforms, 2 tracks)
   // 그 외(2면 4선 등) → mixed/unknown
-  const dim = raw.match(/(\d+)\s*면\s*(\d+)\s*선/);
+  // 숫자 자리수를 2자리로 bound (현실 데이터 상한) — ReDoS 방지.
+  const dim = /(\d{1,2})[ \t]{0,3}면[ \t]{0,3}(\d{1,2})[ \t]{0,3}선/.exec(raw);
   if (dim) {
     const platforms = Number(dim[1]);
     const tracks = Number(dim[2]);
@@ -155,45 +156,53 @@ async function resolveStation(station, fetchFn) {
   };
 }
 
+function pickOnlyStations(stations, only) {
+  const wanted = new Set(only);
+  const seen = new Set();
+  return stations.filter((s) => {
+    if (!wanted.has(s.name) || seen.has(s.name)) return false;
+    seen.add(s.name);
+    return true;
+  });
+}
+
+function groupByLine(stations) {
+  const byLine = new Map();
+  for (const s of stations) {
+    if (!byLine.has(s.line)) byLine.set(s.line, []);
+    byLine.get(s.line).push(s);
+  }
+  return byLine;
+}
+
+function pickSampleRound(byLine, round, sample, picked, seen) {
+  for (const list of byLine.values()) {
+    if (picked.length >= sample) return;
+    const candidate = list[round];
+    if (!candidate || seen.has(candidate.name)) continue;
+    seen.add(candidate.name);
+    picked.push(candidate);
+  }
+}
+
+function pickSampleStations(stations, sample) {
+  const byLine = groupByLine(stations);
+  const picked = [];
+  const seen = new Set();
+  for (let round = 0; picked.length < sample && round < 50; round += 1) {
+    pickSampleRound(byLine, round, sample, picked, seen);
+  }
+  return picked;
+}
+
 /**
  * 샘플 대상 역 리스트를 결정한다.
  *   --only A,B,C → 정확히 그 역들
  *   --sample N → 노선별 균등 샘플
  */
 function pickStations(stations, { only, sample }) {
-  if (only && only.length > 0) {
-    const wanted = new Set(only);
-    // 중복 노선 제거: 같은 이름 첫 등장만
-    const seen = new Set();
-    return stations.filter((s) => {
-      if (!wanted.has(s.name) || seen.has(s.name)) return false;
-      seen.add(s.name);
-      return true;
-    });
-  }
-  if (sample && sample > 0) {
-    // 노선별로 1~2개씩 골라 N개에 도달
-    const byLine = new Map();
-    for (const s of stations) {
-      if (!byLine.has(s.line)) byLine.set(s.line, []);
-      byLine.get(s.line).push(s);
-    }
-    const picked = [];
-    const seen = new Set();
-    let round = 0;
-    while (picked.length < sample && round < 50) {
-      for (const list of byLine.values()) {
-        if (picked.length >= sample) break;
-        const candidate = list[round];
-        if (!candidate) continue;
-        if (seen.has(candidate.name)) continue;
-        seen.add(candidate.name);
-        picked.push(candidate);
-      }
-      round += 1;
-    }
-    return picked;
-  }
+  if (only && only.length > 0) return pickOnlyStations(stations, only);
+  if (sample && sample > 0) return pickSampleStations(stations, sample);
   return [];
 }
 


### PR DESCRIPTION
## Summary
- #1092 심화조사에서 발견된 위키백과 "한국 지하철역 승강장 구조" 자료(CC BY-SA 4.0)의 자동 수집 가능성 PoC
- exitSide cross-check 보조 자료 후보로 평가하기 위한 사전 단계 — 코드에서 사용하지 않고 별도 산출물(`data/wiki-platform-sample.json`)로만 검증
- 전체 528역 적용은 본 PR 범위 밖

## 구현
- `scripts/scrape-wiki-platform.js`: ko.wikipedia.org MediaWiki API(`action=parse&prop=wikitext&section=0`)로 인포박스 `|승강장 = ...` 필드를 추출. `섬식`/`상대식` 명시 키워드 우선, 없으면 `N면 M선` 휴리스틱(1면 2선 → 섬식, 2면 2선 → 상대식)으로 보강
- `scripts/__tests__/scrape-wiki-platform.test.js`: 31 케이스 — 파서, 분류, 다중 인포박스 통합, 동음이의 페이지 fallback, `--only`/`--sample` CLI 옵션 검증 (네트워크는 mock fetch로 격리)
- `data/wiki-platform-sample.json`: 노선별 sample 30역 실측 결과

## PoC 결과 (sample 30역)
- **24/30 (80%)** 유효 layout 추출 — high confidence 11, medium 7, mixed-low 6
- **6/30 (20%)** 'unknown' — 주로 외곽 종착역(소요산, 당고개, 운천, 광교 등)으로 위키백과 인포박스 미작성/동음이의
- 인포박스 필드명: `|승강장 = N면 M선([[상대식 승강장|상대식]])` 형식이 표준. 환승역(강남, 노원 등)은 노선별 다중 인포박스 → `||`로 합쳐 mixed 판정

## 한계
- 동음이의 페이지(예: "시청역")는 fallback으로 `"시청역 (서울)"` 시도 후 그래도 실패하면 unknown
- 다중 인포박스 환승역에서 노선별 layout이 다르면 mixed로 표시되어 노선 단위 정밀도가 떨어짐 — 향후 노선별 분리 필요
- rate limit 보호 1.1s sleep, 전체 528역 적용 시 약 10분 소요 (별도 PR에서 결정)

## Test plan
- [x] `npx jest scripts/__tests__/scrape-wiki-platform.test.js --coverage=false` — 31/31 통과
- [x] `npm run type-check` 통과
- [x] `node scripts/scrape-wiki-platform.js --sample 30` 실제 실행 검증
- [ ] (후속) 정확도 분석 — 위키백과 표기와 namu.wiki/서울교통공사 도면 cross-check
- [ ] (후속) 정확도 90%+ 확인 시 전체 528역 적용 검토

#1092 follow-up — exitSide cross-check 데이터 PoC