### PR TITLE
chore(#1005): i18n 4 locale 균형 + dead key 5건 정리

### DIFF
--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -2,7 +2,6 @@
   "common": {
     "retry": "Retry",
     "close": "Close",
-    "confirm": "OK",
     "cancel": "Cancel",
     "remove": "Remove"
   },

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -274,13 +274,9 @@
       "locklessStationPassedHint": "Receive station-passed alerts even when no train is selected",
       "accessibilityModeHint": "Guides quick-exit positions based on elevators",
       "versionFooterLabel": "App version {{version}}",
-      "versionFooterHint": "Tap multiple times to open the debug menu",
-      "themeSegmentHint": "Change theme",
-      "routeSegmentHint": "Change route preference",
-      "localeRowHint": "Tap to select language"
+      "versionFooterHint": "Tap multiple times to open the debug menu"
     },
     "alarm": {
-      "dismissLabel": "Dismiss alarm",
       "dismissHint": "Stops the alarm sound and vibration",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "Tap to board this train",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -274,13 +274,9 @@
       "locklessStationPassedHint": "乗車列車を選択していなくても通過通知を受け取る",
       "accessibilityModeHint": "エレベーター基準で速やかな降車位置を案内",
       "versionFooterLabel": "アプリバージョン {{version}}",
-      "versionFooterHint": "複数回タップでデバッグメニューを開く",
-      "themeSegmentHint": "テーマを変更",
-      "routeSegmentHint": "経路設定を変更",
-      "localeRowHint": "タップして言語を選択"
+      "versionFooterHint": "複数回タップでデバッグメニューを開く"
     },
     "alarm": {
-      "dismissLabel": "アラームを停止",
       "dismissHint": "アラーム音と振動を停止します",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "タップしてこの列車に乗車",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -2,7 +2,6 @@
   "common": {
     "retry": "再試行",
     "close": "閉じる",
-    "confirm": "OK",
     "cancel": "キャンセル",
     "remove": "削除"
   },

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -2,7 +2,6 @@
   "common": {
     "retry": "다시 시도",
     "close": "닫기",
-    "confirm": "확인",
     "cancel": "취소",
     "remove": "삭제"
   },

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -274,13 +274,9 @@
       "locklessStationPassedHint": "탑승 열차 선택 없이도 역 통과 알림 수신",
       "accessibilityModeHint": "엘리베이터 기준으로 빠른 하차 위치 안내",
       "versionFooterLabel": "앱 버전 {{version}}",
-      "versionFooterHint": "여러 번 탭하면 디버그 메뉴 열기",
-      "themeSegmentHint": "테마 변경",
-      "routeSegmentHint": "경로 탐색 방식 변경",
-      "localeRowHint": "탭하여 언어 선택"
+      "versionFooterHint": "여러 번 탭하면 디버그 메뉴 열기"
     },
     "alarm": {
-      "dismissLabel": "알람 끄기",
       "dismissHint": "알람음과 진동을 중지합니다",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "탭하여 이 열차로 탑승 등록",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -274,13 +274,9 @@
       "locklessStationPassedHint": "未选择乘车列车也会收到经过站点通知",
       "accessibilityModeHint": "按电梯位置引导快速下车位置",
       "versionFooterLabel": "应用版本 {{version}}",
-      "versionFooterHint": "多次点击打开调试菜单",
-      "themeSegmentHint": "更改主题",
-      "routeSegmentHint": "更改路径偏好",
-      "localeRowHint": "点击选择语言"
+      "versionFooterHint": "多次点击打开调试菜单"
     },
     "alarm": {
-      "dismissLabel": "关闭闹钟",
       "dismissHint": "停止闹钟声和振动",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "点击乘坐该列车",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -2,7 +2,6 @@
   "common": {
     "retry": "重试",
     "close": "关闭",
-    "confirm": "确定",
     "cancel": "取消",
     "remove": "删除"
   },


### PR DESCRIPTION
## Summary
- 4 locale(ko/en/ja/zh)에서 사용되지 않는 i18n key 5건 일괄 제거
  - `common.confirm`
  - `a11y.alarm.dismissLabel`
  - `a11y.settings.localeRowHint`
  - `a11y.settings.routeSegmentHint`
  - `a11y.settings.themeSegmentHint`
- 4 locale 간 key 균형 확보 (각 파일 동일 키셋)

## Context
- #1093 (i18n audit 스크립트 PR) follow-up. audit에서 발견된 dead key를 실제로 제거.
- #1093은 키 추가(`share.trip.*`) + audit script 도입, 본 PR은 unused 키 제거. 영역 겹침이 적어 conflict 최소.

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` 통과 (4356 tests, coverage 100%)
- [x] 4개 locale JSON parse 성공
- [x] 5개 dead key가 4 locale 모두에서 0건으로 확인 (`grep -rn`)
- [x] 코드 사용처 grep — 5개 key 모두 미사용 확인

Closes #1005