### PR TITLE
feat: ActionBanner a11y props + MisBoardingBanner 활용 (#1077 후속)

### DIFF
--- a/src/features/route/components/MisBoardingBanner.tsx
+++ b/src/features/route/components/MisBoardingBanner.tsx
@@ -1,4 +1,5 @@
 import { Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { useTheme, typography, spacing } from '../../../shared/theme';
 import { ActionBanner } from '../../../shared/ui/ActionBanner';
 
@@ -11,9 +12,12 @@ interface Props {
  *
  * 표시 조건/감지 로직은 useMisBoardingDetector가 담당 — 이 컴포넌트는 순수 표시 + 액션.
  * 공통 레이아웃은 ActionBanner 슬롯 패턴으로 위임.
+ *
+ * a11y(#1077 후속): ActionBanner의 a11y props로 alert role + 액션 라벨/힌트 주입.
  */
 export function MisBoardingBanner({ onReselect }: Props) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   return (
     <ActionBanner
       accent={colors.warn}
@@ -22,6 +26,9 @@ export function MisBoardingBanner({ onReselect }: Props) {
       onActionPress={onReselect}
       actionTestID="mis-boarding-reselect"
       marginBottom={spacing.md}
+      accessibilityLabel={t('a11y.route.misBoardingBannerLabel')}
+      actionAccessibilityLabel={t('a11y.route.misBoardingReselectLabel')}
+      actionAccessibilityHint={t('a11y.route.misBoardingReselectHint')}
     >
       <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 미확인</Text>
       <Text style={[typography.body, { color: colors.muted }]}>

--- a/src/features/route/components/__tests__/MisBoardingBanner.test.tsx
+++ b/src/features/route/components/__tests__/MisBoardingBanner.test.tsx
@@ -20,4 +20,19 @@ describe('MisBoardingBanner', () => {
     fireEvent.press(getByTestId('mis-boarding-reselect'));
     expect(onReselect).toHaveBeenCalledTimes(1);
   });
+
+  it('a11y: 배너에 alert role + liveRegion, 재선택 버튼에 라벨/힌트 부착(#1077 후속)', () => {
+    const { getByTestId } = renderWithTheme(<MisBoardingBanner onReselect={() => {}} />);
+    const banner = getByTestId('mis-boarding-banner');
+    expect(banner.props.accessibilityRole).toBe('alert');
+    expect(banner.props.accessibilityLiveRegion).toBe('polite');
+    expect(banner.props.accessibilityLabel).toBe(
+      '탑승 열차를 확인할 수 없습니다. 다시 선택하세요.',
+    );
+
+    const action = getByTestId('mis-boarding-reselect');
+    expect(action.props.accessibilityRole).toBe('button');
+    expect(action.props.accessibilityLabel).toBe('탑승 열차 재선택');
+    expect(action.props.accessibilityHint).toBe('탑승 열차 선택 화면을 다시 엽니다');
+  });
 });

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -294,7 +294,10 @@
       "assignSlotHint": "Saves the next selected station to this slot",
       "favoriteChipHint": "Tap to set this station as destination",
       "misBoardingCloseLabel": "Close",
-      "misBoardingCloseHint": "Cancels reselection"
+      "misBoardingCloseHint": "Cancels reselection",
+      "misBoardingBannerLabel": "Cannot identify your train. Please reselect.",
+      "misBoardingReselectLabel": "Reselect boarding train",
+      "misBoardingReselectHint": "Reopens the boarding train picker"
     }
   },
   "service": {

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -294,7 +294,10 @@
       "assignSlotHint": "次に選択する駅をこのスロットに保存します",
       "favoriteChipHint": "タップしてこの駅を目的地に設定",
       "misBoardingCloseLabel": "閉じる",
-      "misBoardingCloseHint": "再選択をキャンセルします"
+      "misBoardingCloseHint": "再選択をキャンセルします",
+      "misBoardingBannerLabel": "乗車中の列車を特定できません。再選択してください。",
+      "misBoardingReselectLabel": "乗車列車を再選択",
+      "misBoardingReselectHint": "乗車列車選択画面を再度開きます"
     }
   },
   "service": {

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -295,6 +295,9 @@
       "favoriteChipHint": "탭하여 이 역을 목적지로 선택",
       "misBoardingCloseLabel": "닫기",
       "misBoardingCloseHint": "재선택을 취소합니다",
+      "misBoardingBannerLabel": "탑승 열차를 확인할 수 없습니다. 다시 선택하세요.",
+      "misBoardingReselectLabel": "탑승 열차 재선택",
+      "misBoardingReselectHint": "탑승 열차 선택 화면을 다시 엽니다",
       "titleHeaderRole": "header"
     }
   },

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -294,7 +294,10 @@
       "assignSlotHint": "将下次选择的车站保存到此槽位",
       "favoriteChipHint": "点击将此站设为目的地",
       "misBoardingCloseLabel": "关闭",
-      "misBoardingCloseHint": "取消重新选择"
+      "misBoardingCloseHint": "取消重新选择",
+      "misBoardingBannerLabel": "无法识别乘坐的列车，请重新选择。",
+      "misBoardingReselectLabel": "重新选择乘坐列车",
+      "misBoardingReselectHint": "重新打开乘坐列车选择界面"
     }
   },
   "service": {

--- a/src/shared/ui/ActionBanner.tsx
+++ b/src/shared/ui/ActionBanner.tsx
@@ -14,6 +14,18 @@ interface Props {
   actionTestID: string;
   /** 다음 요소와 분리 margin. 미전달 시 0. */
   marginBottom?: number;
+  /**
+   * 컨테이너용 스크린리더 라벨(#1077 후속). 미전달 시 children의 텍스트를 그대로 읽도록 둔다.
+   * 배너 등장을 alert로 알리고 싶을 때 호출자가 의미 있는 요약문을 전달한다.
+   */
+  accessibilityLabel?: string;
+  /**
+   * 액션 버튼 스크린리더 라벨(#1077 후속). 미전달 시 `actionLabel`을 사용한다.
+   * 시각 라벨이 짧을 때(예: "하차") 더 풍부한 음성 라벨이 필요하면 override.
+   */
+  actionAccessibilityLabel?: string;
+  /** 액션 버튼 스크린리더 힌트(#1077 후속). 액션 결과를 한 줄로 설명. */
+  actionAccessibilityHint?: string;
 }
 
 /**
@@ -30,6 +42,9 @@ export function ActionBanner({
   testID,
   actionTestID,
   marginBottom,
+  accessibilityLabel,
+  actionAccessibilityLabel,
+  actionAccessibilityHint,
 }: Props) {
   const { colors } = useTheme();
   return (
@@ -39,12 +54,18 @@ export function ActionBanner({
         { backgroundColor: colors.card, borderColor: accent, marginBottom: marginBottom ?? 0 },
       ]}
       testID={testID}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={accessibilityLabel}
     >
       <View style={styles.info}>{children}</View>
       <Pressable
         onPress={onActionPress}
         style={[styles.actionButton, { borderColor: accent }]}
         testID={actionTestID}
+        accessibilityRole="button"
+        accessibilityLabel={actionAccessibilityLabel ?? actionLabel}
+        accessibilityHint={actionAccessibilityHint}
       >
         <Text style={[typography.body, { color: accent, fontWeight: '600' }]}>{actionLabel}</Text>
       </Pressable>

--- a/src/shared/ui/__tests__/ActionBanner.test.tsx
+++ b/src/shared/ui/__tests__/ActionBanner.test.tsx
@@ -63,4 +63,73 @@ describe('ActionBanner', () => {
       .find((m: number | undefined) => m !== undefined);
     expect(marginBottom).toBe(expected);
   });
+
+  it('컨테이너에 alert role + liveRegion + 전달된 accessibilityLabel 부착', () => {
+    const { getByTestId } = renderWithTheme(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={() => {}}
+        accessibilityLabel="긴급 안내"
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    const view = getByTestId('banner');
+    expect(view.props.accessibilityRole).toBe('alert');
+    expect(view.props.accessibilityLiveRegion).toBe('polite');
+    expect(view.props.accessibilityLabel).toBe('긴급 안내');
+  });
+
+  it('accessibilityLabel 미전달 시 컨테이너 라벨 undefined', () => {
+    const { getByTestId } = renderWithTheme(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={() => {}}
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    expect(getByTestId('banner').props.accessibilityLabel).toBeUndefined();
+  });
+
+  it('액션 버튼: actionAccessibilityLabel 우선, 미전달 시 actionLabel fallback + hint 전달', () => {
+    const { getByTestId, rerender } = renderWithTheme(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={() => {}}
+        actionAccessibilityLabel="자세한 실행"
+        actionAccessibilityHint="동작 시작"
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    const action = getByTestId('banner-action');
+    expect(action.props.accessibilityRole).toBe('button');
+    expect(action.props.accessibilityLabel).toBe('자세한 실행');
+    expect(action.props.accessibilityHint).toBe('동작 시작');
+
+    rerender(
+      <ActionBanner
+        accent="#000"
+        testID="banner"
+        actionLabel="실행"
+        actionTestID="banner-action"
+        onActionPress={() => {}}
+      >
+        <Text>info</Text>
+      </ActionBanner>,
+    );
+    const action2 = getByTestId('banner-action');
+    expect(action2.props.accessibilityLabel).toBe('실행');
+    expect(action2.props.accessibilityHint).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- `ActionBanner` 공용 컴포넌트에 a11y props 추가 — 컨테이너에 `accessibilityRole="alert"` + `accessibilityLiveRegion="polite"` 기본 부착으로 배너 등장 시 스크린리더가 즉시 읽도록 함. optional `accessibilityLabel` / `actionAccessibilityLabel` / `actionAccessibilityHint` 제공.
- 액션 `Pressable`: `accessibilityRole="button"` + `actionAccessibilityLabel ?? actionLabel` fallback + 선택적 힌트 전달.
- `MisBoardingBanner`: 새 props로 alert 요약문 + 재선택 버튼 라벨/힌트 주입. i18n key 신규 추가.
- i18n: `a11y.route.misBoardingBannerLabel` / `misBoardingReselectLabel` / `misBoardingReselectHint` 4개 locale에 추가 (en/ja/zh는 1차 번역 — 네이티브 리뷰 권장).

## #1077 follow-up
- PR #1077 에서 deferred 처리한 "ActionBanner 내부 Pressable에 a11y prop forward" 항목을 본 PR에서 해결.
- 현재 `ActionBanner` 사용처는 `MisBoardingBanner` 단 한 곳 — 과거 `BoardingLockBanner`는 #758 에서 `BoardingLockHopCard` (hop slot inline)로 통합되며 별도 배너가 사라졌다. 이 카드는 자체적으로 a11y props 부착 완료(릴리스 버튼).

## Out of scope
- `MisBoardingBanner` 내부 한국어 하드코딩(`탑승 열차 미확인`, 설명 문구) i18n 마이그레이션 — #1077 과 동일하게 별도 작업.
- en/ja/zh 번역 자연스러움 검토 — 네이티브 검수 별도 이슈 권장.

## Test plan
- [x] `npx jest src/shared/ui src/features/route src/shared/i18n` — 50 suites / 791 tests pass
- [x] ActionBanner / MisBoardingBanner targeted coverage 100% (lines/branches/functions/statements)
- [x] `npm run type-check` — clean
- [x] `npx eslint` 변경 파일 — clean
- [ ] VoiceOver/TalkBack 수동 검증 (실기기)

#1077 follow-up