### PR TITLE
feat: 위젯 savedAt timestamp로 freshness 표시

### DIFF
--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -61,10 +61,15 @@ export function saveWidgetStation(
   stationName: string,
   lineColor: string,
   distanceM: number,
+  savedAt: number = Date.now(),
 ): Promise<void> {
   return (
-    LiveActivityModule?.saveWidgetStation(stationName, lineColor, distanceM) ??
-    Promise.resolve()
+    LiveActivityModule?.saveWidgetStation(
+      stationName,
+      lineColor,
+      distanceM,
+      savedAt,
+    ) ?? Promise.resolve()
   );
 }
 

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -6,6 +6,8 @@ private let APP_GROUP = "group.com.subwaynow.app"
 private let WIDGET_KEY_STATION_NAME = "stationName"
 private let WIDGET_KEY_LINE_COLOR = "lineColor"
 private let WIDGET_KEY_DISTANCE_M = "distanceM"
+// 위젯 freshness 표시용. JS에서 epoch ms로 전달, UserDefaults에는 Double(초)로 저장.
+private let WIDGET_KEY_SAVED_AT = "savedAt"
 
 public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
@@ -62,11 +64,13 @@ public class LiveActivityModule: Module {
             return false
         }
 
-        AsyncFunction("saveWidgetStation") { (stationName: String, lineColor: String, distanceM: Int) in
+        AsyncFunction("saveWidgetStation") { (stationName: String, lineColor: String, distanceM: Int, savedAtMs: Double) in
             guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
             defaults.set(stationName, forKey: WIDGET_KEY_STATION_NAME)
             defaults.set(lineColor, forKey: WIDGET_KEY_LINE_COLOR)
             defaults.set(String(distanceM), forKey: WIDGET_KEY_DISTANCE_M)
+            // epoch ms → 초 단위 Double로 저장. 위젯이 Date(timeIntervalSince1970:)로 복원.
+            defaults.set(savedAtMs / 1000.0, forKey: WIDGET_KEY_SAVED_AT)
             if #available(iOS 14.0, *) {
                 WidgetCenter.shared.reloadAllTimelines()
             }
@@ -77,6 +81,7 @@ public class LiveActivityModule: Module {
             defaults.removeObject(forKey: WIDGET_KEY_STATION_NAME)
             defaults.removeObject(forKey: WIDGET_KEY_LINE_COLOR)
             defaults.removeObject(forKey: WIDGET_KEY_DISTANCE_M)
+            defaults.removeObject(forKey: WIDGET_KEY_SAVED_AT)
             if #available(iOS 14.0, *) {
                 WidgetCenter.shared.reloadAllTimelines()
             }

--- a/src/features/widget/api/__tests__/widgetStorage.test.ts
+++ b/src/features/widget/api/__tests__/widgetStorage.test.ts
@@ -29,14 +29,27 @@ describe('widgetStorage (native)', () => {
   });
 
   describe('saveStationToWidget', () => {
-    it('iOS에서 station 정보와 m 단위 거리로 native 함수를 호출한다', async () => {
-      await saveStationToWidget(station, 0.123);
-      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 123);
+    it('iOS에서 station 정보와 m 단위 거리, savedAt을 native 함수에 전달한다', async () => {
+      const t = 1_700_000_000_000;
+      await saveStationToWidget(station, 0.123, t);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 123, t);
+    });
+
+    it('savedAt 인자를 생략하면 Date.now()로 호출한다', async () => {
+      const before = Date.now();
+      await saveStationToWidget(station, 0.1);
+      const after = Date.now();
+      const args = mockSave.mock.calls[0];
+      expect(args[0]).toBe('강남');
+      expect(args[1]).toBe('#009933');
+      expect(args[2]).toBe(100);
+      expect(args[3]).toBeGreaterThanOrEqual(before);
+      expect(args[3]).toBeLessThanOrEqual(after);
     });
 
     it('음수 거리는 0으로 보정된다', async () => {
-      await saveStationToWidget(station, -0.5);
-      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 0);
+      await saveStationToWidget(station, -0.5, 1);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 0, 1);
     });
 
     it('iOS가 아니면 native 호출 없이 종료된다', async () => {
@@ -45,35 +58,46 @@ describe('widgetStorage (native)', () => {
       expect(mockSave).not.toHaveBeenCalled();
     });
 
-    it('같은 역 + 같은 50m 버킷이면 한 번만 native에 전달된다', async () => {
+    it('같은 역 + 같은 50m 버킷 + freshness 윈도우 내면 한 번만 native에 전달된다', async () => {
       // 100m, 120m, 149m → 모두 bucket 2 (100~149m)
-      await saveStationToWidget(station, 0.1);
-      await saveStationToWidget(station, 0.12);
-      await saveStationToWidget(station, 0.149);
+      const t = 1_700_000_000_000;
+      await saveStationToWidget(station, 0.1, t);
+      await saveStationToWidget(station, 0.12, t + 1_000);
+      await saveStationToWidget(station, 0.149, t + 2_000);
       expect(mockSave).toHaveBeenCalledTimes(1);
     });
 
+    it('같은 역/버킷이라도 5분이 지나면 savedAt 갱신을 위해 다시 전달된다', async () => {
+      const t = 1_700_000_000_000;
+      await saveStationToWidget(station, 0.1, t);
+      // 5분 + 1ms 이후
+      await saveStationToWidget(station, 0.1, t + 5 * 60 * 1000 + 1);
+      expect(mockSave).toHaveBeenCalledTimes(2);
+      expect(mockSave).toHaveBeenNthCalledWith(2, '강남', '#009933', 100, t + 5 * 60 * 1000 + 1);
+    });
+
     it('같은 역이라도 50m 버킷이 바뀌면 다시 전달된다', async () => {
-      await saveStationToWidget(station, 0.5); // bucket 10 (500m)
-      await saveStationToWidget(station, 0.45); // bucket 9 (450m)
-      await saveStationToWidget(station, 0.03); // bucket 0 (30m)
+      const t = 1_700_000_000_000;
+      await saveStationToWidget(station, 0.5, t); // bucket 10 (500m)
+      await saveStationToWidget(station, 0.45, t); // bucket 9 (450m)
+      await saveStationToWidget(station, 0.03, t); // bucket 0 (30m)
       expect(mockSave).toHaveBeenCalledTimes(3);
-      expect(mockSave).toHaveBeenNthCalledWith(1, '강남', '#009933', 500);
-      expect(mockSave).toHaveBeenNthCalledWith(2, '강남', '#009933', 450);
-      expect(mockSave).toHaveBeenNthCalledWith(3, '강남', '#009933', 30);
+      expect(mockSave).toHaveBeenNthCalledWith(1, '강남', '#009933', 500, t);
+      expect(mockSave).toHaveBeenNthCalledWith(2, '강남', '#009933', 450, t);
+      expect(mockSave).toHaveBeenNthCalledWith(3, '강남', '#009933', 30, t);
     });
 
     it('역이 바뀌면 다시 native에 전달된다', async () => {
       const other: Station = { ...station, id: '2-002', name: '역삼' };
-      await saveStationToWidget(station, 0.1);
-      await saveStationToWidget(other, 0.1);
+      await saveStationToWidget(station, 0.1, 1);
+      await saveStationToWidget(other, 0.1, 1);
       expect(mockSave).toHaveBeenCalledTimes(2);
     });
 
     it('clearWidgetStation 이후엔 같은 역/같은 버킷도 다시 전달된다', async () => {
-      await saveStationToWidget(station, 0.1);
+      await saveStationToWidget(station, 0.1, 1);
       await clearWidgetStation();
-      await saveStationToWidget(station, 0.1);
+      await saveStationToWidget(station, 0.1, 1);
       expect(mockSave).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/features/widget/api/widgetStorage.ts
+++ b/src/features/widget/api/widgetStorage.ts
@@ -7,7 +7,12 @@ import { Station } from '../../../shared/types/station';
 // 바뀌면(예: 500m → 450m) 위젯이 stale 상태로 남지 않도록 재전달한다.
 const DISTANCE_BUCKET_M = 50;
 
+// 같은 역+버킷에 머물러도 위젯의 savedAt이 stale로 표시되지 않도록 강제로 재전달하는
+// 최소 간격. 위젯 측 stale 임계(10분)보다 작아야 의미가 있다.
+const FRESHNESS_REFRESH_MS = 5 * 60 * 1000;
+
 let lastDedupeKey: string | null = null;
+let lastSavedAt: number | null = null;
 
 function distanceBucket(distanceKm: number): number {
   const distanceM = Math.max(0, Math.round(distanceKm * 1000));
@@ -17,20 +22,27 @@ function distanceBucket(distanceKm: number): number {
 export async function saveStationToWidget(
   station: Station,
   distanceKm: number,
+  savedAt: number = Date.now(),
 ): Promise<void> {
   if (Platform.OS !== 'ios') return;
   const key = `${station.id}:${distanceBucket(distanceKm)}`;
-  if (key === lastDedupeKey) return;
+  const isSameKey = key === lastDedupeKey;
+  const isFresh =
+    lastSavedAt !== null && savedAt - lastSavedAt < FRESHNESS_REFRESH_MS;
+  if (isSameKey && isFresh) return;
   lastDedupeKey = key;
+  lastSavedAt = savedAt;
   await LiveActivity.saveWidgetStation(
     station.name,
     station.lineColor,
     Math.max(0, Math.round(distanceKm * 1000)),
+    savedAt,
   );
 }
 
 export async function clearWidgetStation(): Promise<void> {
   lastDedupeKey = null;
+  lastSavedAt = null;
   if (Platform.OS !== 'ios') return;
   await LiveActivity.clearWidgetStation();
 }

--- a/src/features/widget/api/widgetStorage.web.ts
+++ b/src/features/widget/api/widgetStorage.web.ts
@@ -3,7 +3,8 @@ import { Station } from '../../../shared/types/station';
 // 웹 플랫폼에서는 iOS App Groups를 사용할 수 없으므로 no-op으로 처리
 export async function saveStationToWidget(
   _station: Station,
-  _distanceKm: number
+  _distanceKm: number,
+  _savedAt?: number,
 ): Promise<void> {
   return;
 }

--- a/src/shared/infra/storage/SharedGroupAdapter.ts
+++ b/src/shared/infra/storage/SharedGroupAdapter.ts
@@ -10,12 +10,18 @@ import type { WidgetStoragePort } from '../../ports/WidgetStoragePort';
  * `clearWidgetStation`이 SharedGroupPreferences에 기록 후 WidgetCenter.reloadAllTimelines를 호출한다.
  */
 export class SharedGroupAdapter implements WidgetStoragePort {
-  async saveStation(stationName: string, lineColor: string, distanceKm: number): Promise<void> {
+  async saveStation(
+    stationName: string,
+    lineColor: string,
+    distanceKm: number,
+    savedAt: number = Date.now(),
+  ): Promise<void> {
     if (Platform.OS !== 'ios') return;
     await LiveActivity.saveWidgetStation(
       stationName,
       lineColor,
       Math.max(0, Math.round(distanceKm * 1000)),
+      savedAt,
     );
   }
 

--- a/src/shared/infra/storage/__tests__/SharedGroupAdapter.test.ts
+++ b/src/shared/infra/storage/__tests__/SharedGroupAdapter.test.ts
@@ -19,14 +19,23 @@ describe('SharedGroupAdapter', () => {
   });
 
   describe('saveStation', () => {
-    it('iOS에서 station 정보와 m 단위 거리로 native 함수를 호출한다', async () => {
-      await adapter.saveStation('강남', '#009933', 0.123);
-      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 123);
+    it('iOS에서 station 정보와 m 단위 거리, savedAt을 native 함수에 전달한다', async () => {
+      await adapter.saveStation('강남', '#009933', 0.123, 1_700_000_000_000);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 123, 1_700_000_000_000);
+    });
+
+    it('savedAt 인자를 생략하면 Date.now()로 호출한다', async () => {
+      const before = Date.now();
+      await adapter.saveStation('강남', '#009933', 0.1);
+      const after = Date.now();
+      const args = mockSave.mock.calls[0];
+      expect(args[3]).toBeGreaterThanOrEqual(before);
+      expect(args[3]).toBeLessThanOrEqual(after);
     });
 
     it('음수 거리는 0으로 보정된다', async () => {
-      await adapter.saveStation('강남', '#009933', -0.5);
-      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 0);
+      await adapter.saveStation('강남', '#009933', -0.5, 1);
+      expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 0, 1);
     });
 
     it('iOS가 아니면 native 호출 없이 종료된다', async () => {

--- a/src/shared/ports/WidgetStoragePort.ts
+++ b/src/shared/ports/WidgetStoragePort.ts
@@ -8,8 +8,16 @@
  * `widgetStorage.ts` 함수를 직접 호출한다. Phase 5에서 어댑터 주입으로 전환.
  */
 export interface WidgetStoragePort {
-  /** 현재 역과 거리(km)를 위젯 저장소에 쓰고 WidgetCenter를 리로드한다. */
-  saveStation(stationName: string, lineColor: string, distanceKm: number): Promise<void>;
+  /**
+   * 현재 역과 거리(km)를 위젯 저장소에 쓰고 WidgetCenter를 리로드한다.
+   * `savedAt`은 위젯 측 freshness 표시에 사용된다 (default: 호출 시각).
+   */
+  saveStation(
+    stationName: string,
+    lineColor: string,
+    distanceKm: number,
+    savedAt?: number,
+  ): Promise<void>;
   /** 위젯에 저장된 역 정보를 초기화한다. */
   clearStation(): Promise<void>;
 }

--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -9,7 +9,13 @@ struct SubwayEntry: TimelineEntry {
     let lineColor: String
     let distanceM: Int
     let isAvailable: Bool
+    // 앱이 마지막으로 위젯 데이터를 기록한 시각. nil이면 freshness 표시 생략 (legacy 데이터).
+    let savedAt: Date?
 }
+
+// 저장 시각으로부터 이 시간이 지나면 위젯에 "정보 오래됨"을 표시한다.
+// 백그라운드 위치 갱신이 끊겼거나 앱이 종료된 상태를 사용자에게 알리는 용도.
+private let STALE_THRESHOLD_SECONDS: TimeInterval = 10 * 60
 
 // MARK: - Timeline Provider
 
@@ -22,7 +28,8 @@ struct SubwayProvider: TimelineProvider {
             stationName: "강남",
             lineColor: "#009933",
             distanceM: 120,
-            isAvailable: true
+            isAvailable: true,
+            savedAt: Date()
         )
     }
 
@@ -32,7 +39,9 @@ struct SubwayProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<SubwayEntry>) -> Void) {
         let entry = makeEntry()
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
+        // 앱이 종료된 상태에서도 freshness 표시(10분 임계)가 비교적 빨리 반영되도록
+        // 5분 간격으로 재평가한다. 앱이 살아있으면 saveWidgetStation이 호출되며 즉시 reload.
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: Date()) ?? Date()
         let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
         completion(timeline)
     }
@@ -44,13 +53,17 @@ struct SubwayProvider: TimelineProvider {
         let distanceStr = defaults?.string(forKey: "distanceM") ?? "0"
         let distance = Int(distanceStr) ?? 0
         let isAvailable = !name.isEmpty
+        // savedAt이 없는 레거시 설치 환경에서는 nil로 두어 freshness 표시를 생략한다.
+        let savedAtSec = defaults?.object(forKey: "savedAt") as? Double
+        let savedAt = savedAtSec.map { Date(timeIntervalSince1970: $0) }
 
         return SubwayEntry(
             date: Date(),
             stationName: isAvailable ? name : "감지 중",
             lineColor: color,
             distanceM: distance,
-            isAvailable: isAvailable
+            isAvailable: isAvailable,
+            savedAt: savedAt
         )
     }
 }
@@ -76,6 +89,12 @@ struct SubwayWidgetView: View {
 
     var lineColor: Color {
         Color(hex: entry.lineColor) ?? .gray
+    }
+
+    // savedAt이 임계치 이전이면 stale로 간주. nil(legacy)이면 stale 표시 생략.
+    var isStale: Bool {
+        guard let savedAt = entry.savedAt else { return false }
+        return entry.date.timeIntervalSince(savedAt) > STALE_THRESHOLD_SECONDS
     }
 
     var body: some View {
@@ -111,6 +130,12 @@ struct SubwayWidgetView: View {
                 Text("\(entry.distanceM)m")
                     .font(.subheadline)
                     .foregroundColor(lineColor)
+            }
+
+            if isStale {
+                Text("정보 오래됨")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
 
             Spacer()


### PR DESCRIPTION
## Summary
PR #1095 (위젯 lifecycle decouple) follow-up. 위젯이 앱 종료 후 한참 지난 위치를 stale 상태로 계속 표시하는 회귀를 사용자에게 명시적으로 알리기 위해 `savedAt` epoch timestamp를 데이터 페이로드에 추가한다.

- TS: `saveStationToWidget` / `saveWidgetStation` / `SharedGroupAdapter.saveStation`에 `savedAt: number` (default `Date.now()`) 추가
- iOS native: `LiveActivityModule.swift`가 App Group UserDefaults에 `savedAt`(초 단위 Double) 기록, 위젯이 동일 키를 읽어 `Date(timeIntervalSince1970:)`로 복원
- Swift Widget: `SubwayEntry`에 `savedAt: Date?` 추가, `Date().timeIntervalSince(savedAt) > 10분`이면 `"정보 오래됨"` 캡션 노출
- 위젯 timeline 재평가 간격을 15분 → 5분으로 단축 → 앱이 죽은 상태에서도 stale 임계가 비교적 빨리 반영됨
- widgetStorage dedupe에 freshness 5분 refresh 윈도우 추가 → 같은 역/버킷에 오래 머물러도 위젯 savedAt이 stale 임계 전에 갱신됨
- legacy 설치 (savedAt 키 없음) → stale 표시 생략 (호환 안전)

## 임계
- **10분** stale 임계 (`STALE_THRESHOLD_SECONDS`)
- **5분** dedupe freshness refresh 윈도우 (`FRESHNESS_REFRESH_MS`)
- **5분** 위젯 timeline 재평가 간격

## Test plan
- [x] `npx jest src/features/widget/api/__tests__/widgetStorage.test.ts` — savedAt 인자 전달 / 5분 refresh / default Date.now() / dedupe + clear 시나리오
- [x] `npx jest src/shared/infra/storage/__tests__/SharedGroupAdapter.test.ts` — savedAt 인자 전달
- [x] `npm run type-check`
- [ ] **iOS native는 manual smoke 필요** — 실기기에서 (1) 정상 갱신 시 "정보 오래됨" 미표시 (2) 앱 종료 후 10분 경과 시 "정보 오래됨" 노출 확인

Closes #1095 follow-up.