### PR TITLE
feat(#1097): 혼잡도 데이터 PoC (provider + hook)

### DIFF
--- a/src/data/congestion-sample.json
+++ b/src/data/congestion-sample.json
@@ -1,0 +1,22 @@
+{
+  "_meta": {
+    "source": "서울교통공사 지하철혼잡도정보 (서울 열린데이터광장 OA-12928)",
+    "url": "https://data.seoul.go.kr/dataList/OA-12928/F/1/datasetView.do",
+    "note": "PoC용 발췌 샘플. 실제 API 키 발급 후 SeoulOdCongestionProvider로 대체. 값은 공개 명세에 따른 평균 혼잡도(%) 추정치이며 실시간이 아닌 30분 단위 평균.",
+    "issue": "#1097 P0-A"
+  },
+  "entries": [
+    { "line": "2", "stationName": "강남", "direction": "up", "dayType": "weekday", "timeSlot": "08:00", "raw": 155 },
+    { "line": "2", "stationName": "강남", "direction": "up", "dayType": "weekday", "timeSlot": "08:30", "raw": 168 },
+    { "line": "2", "stationName": "강남", "direction": "up", "dayType": "weekday", "timeSlot": "09:00", "raw": 142 },
+    { "line": "2", "stationName": "강남", "direction": "down", "dayType": "weekday", "timeSlot": "08:00", "raw": 95 },
+    { "line": "2", "stationName": "강남", "direction": "down", "dayType": "weekday", "timeSlot": "08:30", "raw": 110 },
+    { "line": "2", "stationName": "강남", "direction": "up", "dayType": "saturday", "timeSlot": "08:00", "raw": 60 },
+    { "line": "2", "stationName": "강남", "direction": "up", "dayType": "sunday", "timeSlot": "08:00", "raw": 48 },
+    { "line": "2", "stationName": "잠실", "direction": "up", "dayType": "weekday", "timeSlot": "08:30", "raw": 140 },
+    { "line": "2", "stationName": "잠실", "direction": "down", "dayType": "weekday", "timeSlot": "18:00", "raw": 152 },
+    { "line": "9", "stationName": "여의도", "direction": "up", "dayType": "weekday", "timeSlot": "08:00", "raw": 175 },
+    { "line": "9", "stationName": "여의도", "direction": "up", "dayType": "weekday", "timeSlot": "08:30", "raw": 188 },
+    { "line": "9", "stationName": "여의도", "direction": "down", "dayType": "weekday", "timeSlot": "18:30", "raw": 165 }
+  ]
+}

--- a/src/features/congestion/hooks/__tests__/useCongestion.test.ts
+++ b/src/features/congestion/hooks/__tests__/useCongestion.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react-native';
+import { useCongestion } from '../useCongestion';
+
+describe('useCongestion', () => {
+  it('역+노선+방향이 모두 주어지고 fixture에 매칭되면 entry 반환', () => {
+    const now = new Date(2026, 0, 5, 8, 0);
+    const { result } = renderHook(() =>
+      useCongestion({ stationName: '강남', line: '2', direction: 'up', now }),
+    );
+    expect(result.current).not.toBeNull();
+    expect(result.current?.raw).toBe(155);
+    expect(result.current?.level).toBe('veryHigh');
+  });
+
+  it('stationName이 null이면 null', () => {
+    const { result } = renderHook(() =>
+      useCongestion({ stationName: null, line: '2', direction: 'up', now: new Date(2026, 0, 5, 8, 0) }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('stationName이 undefined여도 null', () => {
+    const { result } = renderHook(() =>
+      useCongestion({ stationName: undefined, line: '2', direction: 'up', now: new Date(2026, 0, 5, 8, 0) }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('line이 null이면 null', () => {
+    const { result } = renderHook(() =>
+      useCongestion({ stationName: '강남', line: null, direction: 'up', now: new Date(2026, 0, 5, 8, 0) }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('direction이 null이면 null', () => {
+    const { result } = renderHook(() =>
+      useCongestion({ stationName: '강남', line: '2', direction: null, now: new Date(2026, 0, 5, 8, 0) }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('미커버 시간대는 null', () => {
+    const { result } = renderHook(() =>
+      useCongestion({ stationName: '강남', line: '2', direction: 'up', now: new Date(2026, 0, 5, 12, 0) }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('now 생략 시 호출 시점의 new Date()로 lookup (시스템 시간 fake로 검증)', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 0, 5, 8, 0));
+    const { result } = renderHook(() =>
+      useCongestion({ stationName: '강남', line: '2', direction: 'up' }),
+    );
+    expect(result.current?.raw).toBe(155);
+    jest.useRealTimers();
+  });
+
+  it('rerender 시 동일 입력은 메모이즈된 동일 참조 반환', () => {
+    const now = new Date(2026, 0, 5, 8, 0);
+    const { result, rerender } = renderHook(
+      ({ s }: { s: string }) =>
+        useCongestion({ stationName: s, line: '2', direction: 'up', now }),
+      { initialProps: { s: '강남' } },
+    );
+    const first = result.current;
+    rerender({ s: '강남' });
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/features/congestion/hooks/useCongestion.ts
+++ b/src/features/congestion/hooks/useCongestion.ts
@@ -1,0 +1,43 @@
+import { useMemo, useRef } from 'react';
+import type { LineNumber } from '../../../shared/types/station';
+import type {
+  CongestionDirection,
+  CongestionEntry,
+} from '../../../shared/types/congestion';
+import type { CongestionProvider } from '../providers/types';
+import { createCongestionProvider } from '../providers/factory';
+
+interface UseCongestionParams {
+  stationName: string | null | undefined;
+  line: LineNumber | null | undefined;
+  direction: CongestionDirection | null | undefined;
+  /** 명시 시각 — 기본값은 hook 호출 시점. 테스트/디버그에서 주입한다. */
+  now?: Date;
+}
+
+/**
+ * 현재 역+방향+시간대에 해당하는 시간대 평균 혼잡도를 반환한다.
+ *
+ * - 입력 필수값 중 하나라도 비어 있으면 `null` (UI는 미표시).
+ * - lookup 실패(미커버 노선/역/시간대)도 `null`.
+ * - 시간대 평균 데이터는 앱 lifetime 동안 정적이라 polling 없이 useMemo로 충분.
+ *
+ * #1097 P0-A PoC. UI 진입(Live Activity / HomeScreen)은 후속 PR.
+ */
+export function useCongestion({
+  stationName,
+  line,
+  direction,
+  now,
+}: UseCongestionParams): CongestionEntry | null {
+  const providerRef = useRef<CongestionProvider | null>(null);
+  if (!providerRef.current) {
+    providerRef.current = createCongestionProvider();
+  }
+
+  return useMemo(() => {
+    if (!stationName || !line || !direction) return null;
+    const at = now ?? new Date();
+    return providerRef.current!.getCongestion(stationName, line, direction, at);
+  }, [stationName, line, direction, now]);
+}

--- a/src/features/congestion/providers/MockCongestionProvider.ts
+++ b/src/features/congestion/providers/MockCongestionProvider.ts
@@ -1,0 +1,57 @@
+import type { CongestionProvider } from './types';
+import type { LineNumber } from '../../../shared/types/station';
+import type {
+  CongestionDirection,
+  CongestionEntry,
+} from '../../../shared/types/congestion';
+import { classifyCongestion } from '../utils/congestionLevel';
+import { toDayType, toTimeSlot } from '../utils/timeSlot';
+import sampleData from '../../../data/congestion-sample.json';
+
+interface RawEntry {
+  line: LineNumber;
+  stationName: string;
+  direction: CongestionDirection;
+  dayType: CongestionEntry['dayType'];
+  timeSlot: string;
+  raw: number;
+}
+
+const RAW_ENTRIES: readonly RawEntry[] = sampleData.entries as RawEntry[];
+
+/**
+ * `src/data/congestion-sample.json` fixture 기반 mock provider.
+ *
+ * PoC 단계: 실제 서울 OD API 키를 발급받기 전까지 lookup 인터페이스를 hook/UI에서
+ * 사용할 수 있게 하는 결정적 구현. 후속 PR에서 SeoulOdCongestionProvider가 실 API를
+ * 호출하면 factory로 교체한다.
+ */
+export class MockCongestionProvider implements CongestionProvider {
+  getCongestion(
+    stationName: string,
+    line: LineNumber,
+    direction: CongestionDirection,
+    now: Date,
+  ): CongestionEntry | null {
+    const timeSlot = toTimeSlot(now);
+    const dayType = toDayType(now);
+    const match = RAW_ENTRIES.find(
+      (entry) =>
+        entry.line === line &&
+        entry.stationName === stationName &&
+        entry.direction === direction &&
+        entry.dayType === dayType &&
+        entry.timeSlot === timeSlot,
+    );
+    if (!match) return null;
+    return {
+      line: match.line,
+      stationName: match.stationName,
+      direction: match.direction,
+      dayType: match.dayType,
+      timeSlot: match.timeSlot,
+      raw: match.raw,
+      level: classifyCongestion(match.raw),
+    };
+  }
+}

--- a/src/features/congestion/providers/SeoulOdCongestionProvider.ts
+++ b/src/features/congestion/providers/SeoulOdCongestionProvider.ts
@@ -1,0 +1,30 @@
+import type { CongestionProvider } from './types';
+import type { LineNumber } from '../../../shared/types/station';
+import type {
+  CongestionDirection,
+  CongestionEntry,
+} from '../../../shared/types/congestion';
+
+/**
+ * 서울 열린데이터 OA-12928 (지하철혼잡도정보) 연동 provider — **stub**.
+ *
+ * #1097 P0-A PoC: 실제 인증키 발급 + endpoint 명세 확정 후 구현 예정.
+ * 발급 키는 `EXPO_PUBLIC_SEOUL_DATA_API_KEY`를 재사용 가능.
+ *
+ * 구현 시 고려사항:
+ * - OA-12928는 실시간이 아닌 30분 단위 평균 데이터셋이므로 in-memory cache(앱 lifetime)로 충분.
+ * - 첫 호출 시 전체 fetch → in-memory index 구축, 이후 lookup은 O(1).
+ * - 응답 필드: `STATN_NM`, `LINE_NUM`, `WEEK_TAG`, `INNER_OUTER`, `HR_5_30`...`HR_24_00`.
+ */
+export class SeoulOdCongestionProvider implements CongestionProvider {
+  getCongestion(
+    _stationName: string,
+    _line: LineNumber,
+    _direction: CongestionDirection,
+    _now: Date,
+  ): CongestionEntry | null {
+    throw new Error(
+      'SeoulOdCongestionProvider not implemented — 키 발급 후 후속 PR에서 endpoint 채울 것 (#1097)',
+    );
+  }
+}

--- a/src/features/congestion/providers/__tests__/MockCongestionProvider.test.ts
+++ b/src/features/congestion/providers/__tests__/MockCongestionProvider.test.ts
@@ -1,0 +1,76 @@
+import { MockCongestionProvider } from '../MockCongestionProvider';
+
+describe('MockCongestionProvider', () => {
+  const provider = new MockCongestionProvider();
+
+  it('평일 출근 시간대 강남 상행: high 단계 매칭 (raw 155 → veryHigh)', () => {
+    // 2026-01-05 월요일 08:00 KST 기준 (로컬 시간으로 생성)
+    const result = provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 5, 8, 0));
+    expect(result).not.toBeNull();
+    expect(result!.raw).toBe(155);
+    expect(result!.level).toBe('veryHigh');
+    expect(result!.timeSlot).toBe('08:00');
+    expect(result!.dayType).toBe('weekday');
+  });
+
+  it('분이 30 미만이면 :00 슬롯으로 매칭', () => {
+    const result = provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 5, 8, 15));
+    expect(result?.timeSlot).toBe('08:00');
+    expect(result?.raw).toBe(155);
+  });
+
+  it('분이 30 이상이면 :30 슬롯으로 매칭 (raw 168 → veryHigh)', () => {
+    const result = provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 5, 8, 45));
+    expect(result?.timeSlot).toBe('08:30');
+    expect(result?.level).toBe('veryHigh');
+  });
+
+  it('방향이 다르면 별도 매칭 (down 95 → medium)', () => {
+    const result = provider.getCongestion('강남', '2', 'down', new Date(2026, 0, 5, 8, 0));
+    expect(result?.raw).toBe(95);
+    expect(result?.level).toBe('medium');
+  });
+
+  it('토요일은 saturday 데이터 매칭 (raw 60 → low)', () => {
+    // 2026-01-10 토요일
+    const result = provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 10, 8, 0));
+    expect(result?.dayType).toBe('saturday');
+    expect(result?.level).toBe('low');
+  });
+
+  it('일요일은 sunday 데이터 매칭 (raw 48 → low)', () => {
+    // 2026-01-11 일요일
+    const result = provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 11, 8, 0));
+    expect(result?.dayType).toBe('sunday');
+    expect(result?.raw).toBe(48);
+  });
+
+  it('high 경계 매칭 (raw 142 → high)', () => {
+    const result = provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 5, 9, 0));
+    expect(result?.raw).toBe(142);
+    expect(result?.level).toBe('high');
+  });
+
+  it('미커버 시간대는 null', () => {
+    // 강남 데이터는 평일 08:00/08:30/09:00만 존재
+    const result = provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 5, 10, 0));
+    expect(result).toBeNull();
+  });
+
+  it('미커버 역명은 null', () => {
+    const result = provider.getCongestion('존재하지않는역', '2', 'up', new Date(2026, 0, 5, 8, 0));
+    expect(result).toBeNull();
+  });
+
+  it('미커버 노선은 null', () => {
+    // 강남은 2호선만 fixture에 있음
+    const result = provider.getCongestion('강남', '3', 'up', new Date(2026, 0, 5, 8, 0));
+    expect(result).toBeNull();
+  });
+
+  it('9호선 여의도 상행: 188 → veryHigh', () => {
+    const result = provider.getCongestion('여의도', '9', 'up', new Date(2026, 0, 5, 8, 30));
+    expect(result?.raw).toBe(188);
+    expect(result?.level).toBe('veryHigh');
+  });
+});

--- a/src/features/congestion/providers/__tests__/SeoulOdCongestionProvider.test.ts
+++ b/src/features/congestion/providers/__tests__/SeoulOdCongestionProvider.test.ts
@@ -1,0 +1,10 @@
+import { SeoulOdCongestionProvider } from '../SeoulOdCongestionProvider';
+
+describe('SeoulOdCongestionProvider (stub)', () => {
+  it('PoC 단계에서는 호출 시 명시적으로 throw — 후속 PR에서 구현 예정', () => {
+    const provider = new SeoulOdCongestionProvider();
+    expect(() =>
+      provider.getCongestion('강남', '2', 'up', new Date(2026, 0, 5, 8, 0)),
+    ).toThrow(/not implemented/);
+  });
+});

--- a/src/features/congestion/providers/__tests__/factory.test.ts
+++ b/src/features/congestion/providers/__tests__/factory.test.ts
@@ -1,0 +1,17 @@
+import { createCongestionProvider } from '../factory';
+import { MockCongestionProvider } from '../MockCongestionProvider';
+
+describe('createCongestionProvider', () => {
+  it('PoC 단계에서는 항상 MockCongestionProvider 반환', () => {
+    expect(createCongestionProvider()).toBeInstanceOf(MockCongestionProvider);
+  });
+});
+
+describe('features/congestion/providers/index re-exports', () => {
+  it('MockCongestionProvider / SeoulOdCongestionProvider / createCongestionProvider 노출', () => {
+    const idx = require('../index');
+    expect(idx.MockCongestionProvider).toBeDefined();
+    expect(idx.SeoulOdCongestionProvider).toBeDefined();
+    expect(idx.createCongestionProvider).toBeDefined();
+  });
+});

--- a/src/features/congestion/providers/factory.ts
+++ b/src/features/congestion/providers/factory.ts
@@ -1,0 +1,12 @@
+import type { CongestionProvider } from './types';
+import { MockCongestionProvider } from './MockCongestionProvider';
+
+/**
+ * 혼잡도 provider factory.
+ *
+ * #1097 P0-A PoC: 현재는 항상 MockCongestionProvider 반환. 후속 PR에서
+ * `EXPO_PUBLIC_SEOUL_DATA_API_KEY` 존재 여부로 SeoulOdCongestionProvider로 분기 예정.
+ */
+export function createCongestionProvider(): CongestionProvider {
+  return new MockCongestionProvider();
+}

--- a/src/features/congestion/providers/index.ts
+++ b/src/features/congestion/providers/index.ts
@@ -1,0 +1,3 @@
+export { MockCongestionProvider } from './MockCongestionProvider';
+export { SeoulOdCongestionProvider } from './SeoulOdCongestionProvider';
+export { createCongestionProvider } from './factory';

--- a/src/features/congestion/providers/types.ts
+++ b/src/features/congestion/providers/types.ts
@@ -1,0 +1,20 @@
+import type { LineNumber } from '../../../shared/types/station';
+import type {
+  CongestionDirection,
+  CongestionEntry,
+} from '../../../shared/types/congestion';
+
+/**
+ * 시간대×역×방향 평균 혼잡도 lookup port.
+ *
+ * 입력 조건에 해당하는 entry가 없으면 `null` 반환 — caller가 fallback UI를 결정한다.
+ * (PoC 단계: 미커버 노선/역/시간대가 많아 null 허용. 후속 PR에서 nearest-slot fallback 검토.)
+ */
+export interface CongestionProvider {
+  getCongestion(
+    stationName: string,
+    line: LineNumber,
+    direction: CongestionDirection,
+    now: Date,
+  ): CongestionEntry | null;
+}

--- a/src/features/congestion/utils/__tests__/congestionLevel.test.ts
+++ b/src/features/congestion/utils/__tests__/congestionLevel.test.ts
@@ -1,0 +1,23 @@
+import { CONGESTION_THRESHOLDS, classifyCongestion } from '../congestionLevel';
+
+describe('classifyCongestion', () => {
+  it('80 미만은 low', () => {
+    expect(classifyCongestion(0)).toBe('low');
+    expect(classifyCongestion(79.9)).toBe('low');
+  });
+
+  it('80 ≤ x < 130 은 medium (경계 포함)', () => {
+    expect(classifyCongestion(CONGESTION_THRESHOLDS.medium)).toBe('medium');
+    expect(classifyCongestion(129)).toBe('medium');
+  });
+
+  it('130 ≤ x < 150 은 high (경계 포함)', () => {
+    expect(classifyCongestion(CONGESTION_THRESHOLDS.high)).toBe('high');
+    expect(classifyCongestion(149)).toBe('high');
+  });
+
+  it('150 이상은 veryHigh', () => {
+    expect(classifyCongestion(CONGESTION_THRESHOLDS.veryHigh)).toBe('veryHigh');
+    expect(classifyCongestion(200)).toBe('veryHigh');
+  });
+});

--- a/src/features/congestion/utils/__tests__/timeSlot.test.ts
+++ b/src/features/congestion/utils/__tests__/timeSlot.test.ts
@@ -1,0 +1,36 @@
+import { toDayType, toTimeSlot } from '../timeSlot';
+
+describe('toTimeSlot', () => {
+  it('분 < 30 은 :00 슬롯으로 floor', () => {
+    expect(toTimeSlot(new Date(2026, 0, 5, 8, 0))).toBe('08:00');
+    expect(toTimeSlot(new Date(2026, 0, 5, 8, 29))).toBe('08:00');
+  });
+
+  it('분 ≥ 30 은 :30 슬롯', () => {
+    expect(toTimeSlot(new Date(2026, 0, 5, 8, 30))).toBe('08:30');
+    expect(toTimeSlot(new Date(2026, 0, 5, 8, 59))).toBe('08:30');
+  });
+
+  it('한 자리 시간도 zero-pad', () => {
+    expect(toTimeSlot(new Date(2026, 0, 5, 5, 15))).toBe('05:00');
+  });
+});
+
+describe('toDayType', () => {
+  it('월~금은 weekday', () => {
+    // 2026-01-05는 월요일
+    expect(toDayType(new Date(2026, 0, 5))).toBe('weekday');
+    // 2026-01-09는 금요일
+    expect(toDayType(new Date(2026, 0, 9))).toBe('weekday');
+  });
+
+  it('토요일은 saturday', () => {
+    // 2026-01-10은 토요일
+    expect(toDayType(new Date(2026, 0, 10))).toBe('saturday');
+  });
+
+  it('일요일은 sunday', () => {
+    // 2026-01-11은 일요일
+    expect(toDayType(new Date(2026, 0, 11))).toBe('sunday');
+  });
+});

--- a/src/features/congestion/utils/congestionLevel.ts
+++ b/src/features/congestion/utils/congestionLevel.ts
@@ -1,0 +1,23 @@
+import type { CongestionLevel } from '../../../shared/types/congestion';
+
+/**
+ * 서울교통공사 공식 혼잡도 단계 임계값 (%).
+ * - low: < 80
+ * - medium: 80 ~ < 130
+ * - high: 130 ~ < 150
+ * - veryHigh: >= 150
+ *
+ * 출처: 서울교통공사 혼잡도 안내 (좌석 100%, 손잡이 130%, 밀착 150%).
+ */
+export const CONGESTION_THRESHOLDS = {
+  medium: 80,
+  high: 130,
+  veryHigh: 150,
+} as const;
+
+export function classifyCongestion(raw: number): CongestionLevel {
+  if (raw >= CONGESTION_THRESHOLDS.veryHigh) return 'veryHigh';
+  if (raw >= CONGESTION_THRESHOLDS.high) return 'high';
+  if (raw >= CONGESTION_THRESHOLDS.medium) return 'medium';
+  return 'low';
+}

--- a/src/features/congestion/utils/timeSlot.ts
+++ b/src/features/congestion/utils/timeSlot.ts
@@ -1,0 +1,20 @@
+import type { CongestionDayType, CongestionTimeSlot } from '../../../shared/types/congestion';
+
+/**
+ * Date → 30분 단위 슬롯(`HH:mm`).
+ * 분이 30 미만이면 `:00`, 그 이상이면 `:30`으로 절사 (floor).
+ * 서울 OD가 30분 평균치를 제공하므로 floor 가 자연스러운 매칭이다.
+ */
+export function toTimeSlot(date: Date): CongestionTimeSlot {
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = date.getMinutes() < 30 ? '00' : '30';
+  return `${hh}:${mm}`;
+}
+
+/** Date → 평일/토/일 분류. JS `getDay()`: 0=일, 6=토, 1~5=평일. */
+export function toDayType(date: Date): CongestionDayType {
+  const day = date.getDay();
+  if (day === 0) return 'sunday';
+  if (day === 6) return 'saturday';
+  return 'weekday';
+}

--- a/src/shared/types/congestion.ts
+++ b/src/shared/types/congestion.ts
@@ -1,0 +1,41 @@
+/**
+ * 시간대×역×방향 평균 혼잡도 타입.
+ *
+ * 데이터 출처: 서울교통공사 지하철혼잡도정보 (서울 열린데이터 OA-12928).
+ * 30분 단위 요일/시간대 평균 혼잡도(%). 100 ≈ 좌석 모두 사용 + 손잡이 채움.
+ *
+ * 이슈 #1097 P0-A PoC.
+ */
+
+import type { LineNumber } from './station';
+
+/** 진행 방향. 서울 OD `INNER_OUTER`/`UPDN_LINE` → 'up'(상행/외선) / 'down'(하행/내선). */
+export type CongestionDirection = 'up' | 'down';
+
+/**
+ * 혼잡도 단계 — 서울교통공사 공식 기준.
+ * - low: ~80% (여유, 좌석 여유 있음)
+ * - medium: 80~130% (보통, 손잡이까지 사용)
+ * - high: 130~150% (혼잡, 가까이 밀착)
+ * - veryHigh: 150% 이상 (매우 혼잡)
+ *
+ * 임계값은 `congestionLevel.ts`의 상수로 분리한다.
+ */
+export type CongestionLevel = 'low' | 'medium' | 'high' | 'veryHigh';
+
+/** 30분 단위 시간대 키. `HH:mm` 형식, mm은 `00` 또는 `30`. 예: '05:30', '08:00', '23:30'. */
+export type CongestionTimeSlot = string;
+
+/** 요일 구분 — 서울 OD `WEEK_TAG`: 1=평일, 2=토요일, 3=일/공휴일. */
+export type CongestionDayType = 'weekday' | 'saturday' | 'sunday';
+
+export interface CongestionEntry {
+  line: LineNumber;
+  stationName: string;
+  direction: CongestionDirection;
+  dayType: CongestionDayType;
+  timeSlot: CongestionTimeSlot;
+  level: CongestionLevel;
+  /** 원본 평균 혼잡도(%) — 0~200 추정. UI에서 단계 표시 외 미세 정렬용. */
+  raw: number;
+}


### PR DESCRIPTION
#1097 P0-A PoC.

## Summary
시간대×역×방향 평균 혼잡도 데이터를 앱에서 활용하기 위한 최소 슬라이스. UI 진입은 본 PoC 범위 밖이며, 후속 PR(Live Activity/HomeScreen)에서 `useCongestion` 훅을 소비한다.

## 변경
- **`src/shared/types/congestion.ts`** — `CongestionLevel` (low/medium/high/veryHigh), `CongestionDirection`, `CongestionDayType`, `CongestionEntry`.
- **`src/features/congestion/providers/`**
  - `CongestionProvider` port: `getCongestion(stationName, line, direction, now) → CongestionEntry | null`.
  - `MockCongestionProvider` — `src/data/congestion-sample.json` 기반 결정적 lookup.
  - `SeoulOdCongestionProvider` — **stub**. `EXPO_PUBLIC_SEOUL_DATA_API_KEY` 발급 후 후속 PR에서 endpoint 구현 예정.
  - `factory.createCongestionProvider()` — 현재는 항상 Mock 반환.
- **`src/features/congestion/hooks/useCongestion`** — 입력 누락/lookup 실패 모두 `null`. 30분 단위 정적 데이터라 polling 없이 `useMemo`로 충분.
- **`src/features/congestion/utils/`** — `classifyCongestion` (서울교통공사 공식 임계 80/130/150%) + `toTimeSlot`/`toDayType`.
- **`src/data/congestion-sample.json`** — 서울 OD `OA-12928` 발췌 샘플. `_meta`에 출처/URL/이슈 번호 명시.

## Sample 출처
서울교통공사 지하철혼잡도정보 (서울 열린데이터광장 `OA-12928`).
https://data.seoul.go.kr/dataList/OA-12928/F/1/datasetView.do
30분 단위 평균(실시간 아님). API 키 발급 전이라 fixture는 공개 명세 기반 발췌 샘플. 키 발급 후 `SeoulOdCongestionProvider`로 교체.

## 범위 외 (후속)
- UI 진입(Live Activity, HomeScreen) — 별도 follow-up 이슈에서 진행.
- `SeoulOdCongestionProvider` 실제 endpoint 구현 — 키 발급 후.
- nearest-slot fallback (미커버 시간대 보정).

## Test plan
- [x] `npx jest src/features/congestion` — 32 tests pass, 신규 슬라이스 100% 커버리지 (statements/branches/funcs/lines).
- [x] `npm run type-check` pass.
- [x] CI `Type Check & Test` 통과 확인.

Closes #1097 (P0-A scope).