### PR TITLE
feat(backend): feedback 일일 통계 cron + admin list 페이지네이션

### DIFF
--- a/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
+++ b/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
@@ -46,6 +46,14 @@ async function get(
   );
 }
 
+function authedEnv(kv: InMemoryKV): Env {
+  return makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace });
+}
+
+async function authedGet(path: string, kv: InMemoryKV): Promise<Response> {
+  return get(path, authedEnv(kv), { authorization: 'Bearer secret' });
+}
+
 async function seed(kv: InMemoryKV, count: number, baseTs = 10_000): Promise<void> {
   for (let i = 0; i < count; i++) {
     await storeFeedback(
@@ -262,11 +270,7 @@ describe('GET /admin/feedback', () => {
   it('returns entries with default limit and nextBefore=null on small dataset', async () => {
     const kv = new InMemoryKV();
     await seed(kv, 2, 100);
-    const res = await get(
-      '/admin/feedback',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback', kv);
     expect(res.status).toBe(200);
     const json = (await res.json()) as { entries: { receivedAt: number }[]; nextBefore: number | null };
     expect(json.entries.map((e) => e.receivedAt)).toEqual([101, 100]);
@@ -276,11 +280,7 @@ describe('GET /admin/feedback', () => {
   it('honors limit and before query params', async () => {
     const kv = new InMemoryKV();
     await seed(kv, 5, 200);
-    const res = await get(
-      '/admin/feedback?limit=2&before=204',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback?limit=2&before=204', kv);
     expect(res.status).toBe(200);
     const json = (await res.json()) as { entries: { receivedAt: number }[]; nextBefore: number | null };
     expect(json.entries.map((e) => e.receivedAt)).toEqual([203, 202]);
@@ -290,11 +290,7 @@ describe('GET /admin/feedback', () => {
   it('ignores non-numeric query params (falls back to defaults)', async () => {
     const kv = new InMemoryKV();
     await seed(kv, 2, 300);
-    const res = await get(
-      '/admin/feedback?limit=abc&before=xyz',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback?limit=abc&before=xyz', kv);
     expect(res.status).toBe(200);
     const json = (await res.json()) as { entries: unknown[] };
     expect(json.entries).toHaveLength(2);
@@ -326,11 +322,7 @@ describe('GET /admin/feedback/export.csv', () => {
 
   it('returns header-only CSV when no entries', async () => {
     const kv = new InMemoryKV();
-    const res = await get(
-      '/admin/feedback/export.csv',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback/export.csv', kv);
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toBe('text/csv; charset=utf-8');
     expect(res.headers.get('content-disposition')).toContain('feedback.csv');
@@ -342,11 +334,7 @@ describe('GET /admin/feedback/export.csv', () => {
   it('serializes entries with header + rows', async () => {
     const kv = new InMemoryKV();
     await seed(kv, 2, 500);
-    const res = await get(
-      '/admin/feedback/export.csv?limit=10',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback/export.csv?limit=10', kv);
     expect(res.status).toBe(200);
     const body = await res.text();
     const lines = body.trim().split('\n');
@@ -572,22 +560,14 @@ describe('GET /admin/feedback/stats', () => {
 
   it('returns 400 for malformed date', async () => {
     const kv = new InMemoryKV();
-    const res = await get(
-      '/admin/feedback/stats?date=not-a-date',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback/stats?date=not-a-date', kv);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_date' });
   });
 
   it('returns 404 when stats for that date not yet stored', async () => {
     const kv = new InMemoryKV();
-    const res = await get(
-      '/admin/feedback/stats?date=2026-06-09',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback/stats?date=2026-06-09', kv);
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: 'stats_not_found' });
   });
@@ -601,11 +581,7 @@ describe('GET /admin/feedback/stats', () => {
       byAppVersion: { '1.0.0': 7 },
       byLocale: { ko: 7 },
     });
-    const res = await get(
-      '/admin/feedback/stats?date=2026-06-09',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback/stats?date=2026-06-09', kv);
     expect(res.status).toBe(200);
     const json = (await res.json()) as { total: number };
     expect(json.total).toBe(7);
@@ -621,11 +597,7 @@ describe('GET /admin/feedback/stats', () => {
       byAppVersion: {},
       byLocale: {},
     });
-    const res = await get(
-      '/admin/feedback/stats',
-      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
-      { authorization: 'Bearer secret' },
-    );
+    const res = await authedGet('/admin/feedback/stats', kv);
     expect(res.status).toBe(200);
     const json = (await res.json()) as { date: string; total: number };
     expect(json.date).toBe(yesterday);

--- a/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
+++ b/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
@@ -54,6 +54,34 @@ async function authedGet(path: string, kv: InMemoryKV): Promise<Response> {
   return get(path, authedEnv(kv), { authorization: 'Bearer secret' });
 }
 
+/**
+ * Shared auth/binding gate tests for any /admin/feedback* route.
+ * Covers: missing ADMIN_TOKEN (503), mismatched token (401), missing FEEDBACK binding (503).
+ * Extracted to avoid duplicated test blocks across describe groups (SonarCloud).
+ */
+function describeAdminAuthGate(path: string): void {
+  it(`${path} returns 503 when ADMIN_TOKEN missing`, async () => {
+    const res = await get(path, makeEnv());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'admin_unavailable' });
+  });
+
+  it(`${path} returns 401 when token mismatches`, async () => {
+    const res = await get(path, makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Bearer nope',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it(`${path} returns 503 when FEEDBACK binding missing`, async () => {
+    const res = await get(path, makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Bearer secret',
+    });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'feedback_unavailable' });
+  });
+}
+
 async function seed(kv: InMemoryKV, count: number, baseTs = 10_000): Promise<void> {
   for (let i = 0; i < count; i++) {
     await storeFeedback(
@@ -233,11 +261,7 @@ describe('toCsv', () => {
 });
 
 describe('GET /admin/feedback', () => {
-  it('returns 503 when ADMIN_TOKEN secret missing', async () => {
-    const res = await get('/admin/feedback', makeEnv());
-    expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: 'admin_unavailable' });
-  });
+  describeAdminAuthGate('/admin/feedback');
 
   it('returns 401 when Authorization header absent', async () => {
     const res = await get('/admin/feedback', makeEnv({ ADMIN_TOKEN: 'secret' }));
@@ -250,21 +274,6 @@ describe('GET /admin/feedback', () => {
       authorization: 'Basic secret',
     });
     expect(res.status).toBe(401);
-  });
-
-  it('returns 401 when token mismatches', async () => {
-    const res = await get('/admin/feedback', makeEnv({ ADMIN_TOKEN: 'secret' }), {
-      authorization: 'Bearer nope',
-    });
-    expect(res.status).toBe(401);
-  });
-
-  it('returns 503 when FEEDBACK binding missing despite valid auth', async () => {
-    const res = await get('/admin/feedback', makeEnv({ ADMIN_TOKEN: 'secret' }), {
-      authorization: 'Bearer secret',
-    });
-    expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: 'feedback_unavailable' });
   });
 
   it('returns entries with default limit and nextBefore=null on small dataset', async () => {
@@ -537,26 +546,7 @@ describe('maybeRunDailyFeedbackStats', () => {
 });
 
 describe('GET /admin/feedback/stats', () => {
-  it('returns 503 when ADMIN_TOKEN missing', async () => {
-    const res = await get('/admin/feedback/stats', makeEnv());
-    expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: 'admin_unavailable' });
-  });
-
-  it('returns 401 when token mismatches', async () => {
-    const res = await get('/admin/feedback/stats', makeEnv({ ADMIN_TOKEN: 'secret' }), {
-      authorization: 'Bearer nope',
-    });
-    expect(res.status).toBe(401);
-  });
-
-  it('returns 503 when FEEDBACK binding missing', async () => {
-    const res = await get('/admin/feedback/stats', makeEnv({ ADMIN_TOKEN: 'secret' }), {
-      authorization: 'Bearer secret',
-    });
-    expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: 'feedback_unavailable' });
-  });
+  describeAdminAuthGate('/admin/feedback/stats');
 
   it('returns 400 for malformed date', async () => {
     const kv = new InMemoryKV();

--- a/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
+++ b/backend/alarm-worker/src/__tests__/feedbackAdmin.test.ts
@@ -1,11 +1,19 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { app } from '../index';
 import {
+  aggregateFeedbackStats,
+  dayStartFromIsoDate,
   FEEDBACK_LIST_DEFAULT_LIMIT,
   FEEDBACK_LIST_MAX_LIMIT,
+  feedbackStatsKey,
+  getFeedbackStats,
+  isoDateUtc,
+  listAllFeedbackKeys,
   listFeedback,
+  maybeRunDailyFeedbackStats,
   normalizeLimit,
   parseReceivedAtFromKey,
+  storeFeedbackStats,
   toCsv,
 } from '../feedbackAdmin';
 import { storeFeedback } from '../feedback';
@@ -345,5 +353,282 @@ describe('GET /admin/feedback/export.csv', () => {
     expect(lines).toHaveLength(3); // header + 2 entries
     expect(lines[1]).toContain('"msg-1"'); // newest first
     expect(lines[2]).toContain('"msg-0"');
+  });
+});
+
+describe('listAllFeedbackKeys', () => {
+  it('joins paginated KV list pages via cursor (#1080 follow-up)', async () => {
+    const kv = new InMemoryKV();
+    kv.pageSize = 2;
+    await seed(kv, 5, 1_000);
+    const keys = await listAllFeedbackKeys(kv as unknown as KVNamespace);
+    expect(keys).toHaveLength(5);
+  });
+
+  it('listFeedback now returns newest entries even past first KV page', async () => {
+    const kv = new InMemoryKV();
+    kv.pageSize = 2;
+    // 5 entries — pre-fix would only see the lex-asc first 2 keys (oldest), losing newest 3.
+    await seed(kv, 5, 1_000);
+    const result = await listFeedback(kv as unknown as KVNamespace, { limit: 3 });
+    expect(result.entries.map((e) => e.receivedAt)).toEqual([1_004, 1_003, 1_002]);
+  });
+});
+
+describe('isoDateUtc / dayStartFromIsoDate', () => {
+  it('round-trips a UTC midnight epoch', () => {
+    const epoch = Date.UTC(2026, 5, 9);
+    expect(isoDateUtc(epoch)).toBe('2026-06-09');
+    expect(dayStartFromIsoDate('2026-06-09')).toBe(epoch);
+  });
+
+  it('rejects malformed dates with NaN', () => {
+    expect(Number.isNaN(dayStartFromIsoDate('nope'))).toBe(true);
+    expect(Number.isNaN(dayStartFromIsoDate('2026-13-40'))).toBe(true);
+    expect(Number.isNaN(dayStartFromIsoDate('2026-6-9'))).toBe(true);
+  });
+});
+
+describe('aggregateFeedbackStats', () => {
+  it('counts entries in [dayStart, dayEnd) by platform/appVersion/locale buckets', async () => {
+    const kv = new InMemoryKV();
+    const dayStart = Date.UTC(2026, 5, 9);
+    // 3 in-range
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'a', context: { platform: 'ios', appVersion: '1.0.0', locale: 'ko-KR' } },
+      dayStart + 1_000,
+      'a1',
+    );
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'b', context: { platform: 'android', appVersion: '1.0.0', locale: 'en-US' } },
+      dayStart + 2_000,
+      'a2',
+    );
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'c' },
+      dayStart + 3_000,
+      'a3',
+    );
+    // out-of-range (next day)
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'd', context: { platform: 'ios' } },
+      dayStart + 24 * 60 * 60 * 1000,
+      'a4',
+    );
+    // out-of-range (previous day)
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'e', context: { platform: 'ios' } },
+      dayStart - 1,
+      'a5',
+    );
+
+    const stats = await aggregateFeedbackStats(kv as unknown as KVNamespace, dayStart);
+    expect(stats.date).toBe('2026-06-09');
+    expect(stats.total).toBe(3);
+    expect(stats.byPlatform).toEqual({ ios: 1, android: 1, unknown: 1 });
+    expect(stats.byAppVersion).toEqual({ '1.0.0': 2, unknown: 1 });
+    expect(stats.byLocale).toEqual({ ko: 1, en: 1, unknown: 1 });
+  });
+
+  it('skips entries whose stored value disappeared mid-aggregate', async () => {
+    const kv = new InMemoryKV();
+    const dayStart = Date.UTC(2026, 5, 9);
+    await storeFeedback(kv as unknown as KVNamespace, { message: 'keep' }, dayStart + 1, 'k1');
+    await storeFeedback(kv as unknown as KVNamespace, { message: 'gone' }, dayStart + 2, 'k2');
+    kv.store.delete('feedback:' + (dayStart + 2) + ':k2');
+    const stats = await aggregateFeedbackStats(kv as unknown as KVNamespace, dayStart);
+    expect(stats.total).toBe(1); // count is from key enumeration
+    expect(stats.byPlatform).toEqual({ unknown: 1 });
+  });
+
+  it('skips entries with malformed JSON', async () => {
+    const kv = new InMemoryKV();
+    const dayStart = Date.UTC(2026, 5, 9);
+    await kv.put(`feedback:${dayStart + 1}:bad`, '{not json');
+    const stats = await aggregateFeedbackStats(kv as unknown as KVNamespace, dayStart);
+    expect(stats.total).toBe(1); // counted by key
+    expect(stats.byPlatform).toEqual({}); // but no bucket bumped
+  });
+
+  it('treats bare locale without dash as its own bucket', async () => {
+    const kv = new InMemoryKV();
+    const dayStart = Date.UTC(2026, 5, 9);
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'x', context: { locale: 'ja' } },
+      dayStart + 1,
+      'j1',
+    );
+    const stats = await aggregateFeedbackStats(kv as unknown as KVNamespace, dayStart);
+    expect(stats.byLocale).toEqual({ ja: 1 });
+  });
+});
+
+describe('storeFeedbackStats / getFeedbackStats', () => {
+  it('round-trips stats via stats:YYYY-MM-DD key', async () => {
+    const kv = new InMemoryKV();
+    const stats = {
+      date: '2026-06-09',
+      total: 2,
+      byPlatform: { ios: 2 },
+      byAppVersion: { '1.0.0': 2 },
+      byLocale: { ko: 2 },
+    };
+    await storeFeedbackStats(kv as unknown as KVNamespace, stats);
+    expect(await getFeedbackStats(kv as unknown as KVNamespace, '2026-06-09')).toEqual(stats);
+  });
+
+  it('returns null when stats key missing', async () => {
+    const kv = new InMemoryKV();
+    expect(await getFeedbackStats(kv as unknown as KVNamespace, '2026-06-09')).toBeNull();
+  });
+
+  it('returns null when stored value is malformed JSON', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(feedbackStatsKey('2026-06-09'), '{broken');
+    expect(await getFeedbackStats(kv as unknown as KVNamespace, '2026-06-09')).toBeNull();
+  });
+});
+
+describe('maybeRunDailyFeedbackStats', () => {
+  const targetDay = Date.UTC(2026, 5, 9);
+  const cronTime = Date.UTC(2026, 5, 10, 0, 5); // 00:05 UTC the next day
+
+  it('skips when current UTC hour is not 0', async () => {
+    const kv = new InMemoryKV();
+    const result = await maybeRunDailyFeedbackStats(
+      kv as unknown as KVNamespace,
+      Date.UTC(2026, 5, 10, 1, 5),
+    );
+    expect(result.ran).toBe(false);
+  });
+
+  it('skips when current UTC minute is not 5', async () => {
+    const kv = new InMemoryKV();
+    const result = await maybeRunDailyFeedbackStats(
+      kv as unknown as KVNamespace,
+      Date.UTC(2026, 5, 10, 0, 6),
+    );
+    expect(result.ran).toBe(false);
+  });
+
+  it('runs at 00:05 UTC and aggregates the previous day', async () => {
+    const kv = new InMemoryKV();
+    await storeFeedback(
+      kv as unknown as KVNamespace,
+      { message: 'x', context: { platform: 'ios' } },
+      targetDay + 1_000,
+      'r1',
+    );
+    const result = await maybeRunDailyFeedbackStats(kv as unknown as KVNamespace, cronTime);
+    expect(result).toEqual({ ran: true, date: '2026-06-09' });
+    const stored = await getFeedbackStats(kv as unknown as KVNamespace, '2026-06-09');
+    expect(stored?.total).toBe(1);
+    expect(stored?.byPlatform).toEqual({ ios: 1 });
+  });
+
+  it('is idempotent — second run at same window does not re-aggregate', async () => {
+    const kv = new InMemoryKV();
+    await storeFeedbackStats(kv as unknown as KVNamespace, {
+      date: '2026-06-09',
+      total: 99,
+      byPlatform: { ios: 99 },
+      byAppVersion: {},
+      byLocale: {},
+    });
+    const result = await maybeRunDailyFeedbackStats(kv as unknown as KVNamespace, cronTime);
+    expect(result).toEqual({ ran: false, date: '2026-06-09' });
+    const stored = await getFeedbackStats(kv as unknown as KVNamespace, '2026-06-09');
+    expect(stored?.total).toBe(99); // preserved
+  });
+});
+
+describe('GET /admin/feedback/stats', () => {
+  it('returns 503 when ADMIN_TOKEN missing', async () => {
+    const res = await get('/admin/feedback/stats', makeEnv());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'admin_unavailable' });
+  });
+
+  it('returns 401 when token mismatches', async () => {
+    const res = await get('/admin/feedback/stats', makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Bearer nope',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when FEEDBACK binding missing', async () => {
+    const res = await get('/admin/feedback/stats', makeEnv({ ADMIN_TOKEN: 'secret' }), {
+      authorization: 'Bearer secret',
+    });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'feedback_unavailable' });
+  });
+
+  it('returns 400 for malformed date', async () => {
+    const kv = new InMemoryKV();
+    const res = await get(
+      '/admin/feedback/stats?date=not-a-date',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_date' });
+  });
+
+  it('returns 404 when stats for that date not yet stored', async () => {
+    const kv = new InMemoryKV();
+    const res = await get(
+      '/admin/feedback/stats?date=2026-06-09',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'stats_not_found' });
+  });
+
+  it('returns stored stats for the requested date', async () => {
+    const kv = new InMemoryKV();
+    await storeFeedbackStats(kv as unknown as KVNamespace, {
+      date: '2026-06-09',
+      total: 7,
+      byPlatform: { ios: 5, android: 2 },
+      byAppVersion: { '1.0.0': 7 },
+      byLocale: { ko: 7 },
+    });
+    const res = await get(
+      '/admin/feedback/stats?date=2026-06-09',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { total: number };
+    expect(json.total).toBe(7);
+  });
+
+  it('defaults date= to yesterday UTC when query omitted', async () => {
+    const kv = new InMemoryKV();
+    const yesterday = isoDateUtc(Date.now() - 24 * 60 * 60 * 1000);
+    await storeFeedbackStats(kv as unknown as KVNamespace, {
+      date: yesterday,
+      total: 3,
+      byPlatform: {},
+      byAppVersion: {},
+      byLocale: {},
+    });
+    const res = await get(
+      '/admin/feedback/stats',
+      makeEnv({ ADMIN_TOKEN: 'secret', FEEDBACK: kv as unknown as KVNamespace }),
+      { authorization: 'Bearer secret' },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { date: string; total: number };
+    expect(json.date).toBe(yesterday);
+    expect(json.total).toBe(3);
   });
 });

--- a/backend/alarm-worker/src/__tests__/inMemoryKv.ts
+++ b/backend/alarm-worker/src/__tests__/inMemoryKv.ts
@@ -51,7 +51,9 @@ export class InMemoryKV {
     cursor: string;
   }> {
     const prefix = options?.prefix ?? '';
-    const allMatching = [...this.store.keys()].filter((k) => k.startsWith(prefix)).sort();
+    const allMatching = [...this.store.keys()]
+      .filter((k) => k.startsWith(prefix))
+      .sort((a, b) => a.localeCompare(b));
     const startIdx = options?.cursor ? Number.parseInt(options.cursor, 10) : 0;
     const safeStart = Number.isFinite(startIdx) && startIdx >= 0 ? startIdx : 0;
     const endIdx = Number.isFinite(this.pageSize)

--- a/backend/alarm-worker/src/__tests__/inMemoryKv.ts
+++ b/backend/alarm-worker/src/__tests__/inMemoryKv.ts
@@ -38,15 +38,31 @@ export class InMemoryKV {
     this.store.delete(key);
   }
 
+  /**
+   * `pageSize`를 인스턴스 필드로 두고 cursor로 잇는 KV 의사 동작.
+   * 기본은 `Infinity` → 단일 페이지(기존 호환). 테스트에서 페이지네이션 회귀를 확인할 때만
+   * `kv.pageSize = N`으로 작게 설정한다.
+   */
+  pageSize = Number.POSITIVE_INFINITY;
+
   async list(options?: { prefix?: string; cursor?: string }): Promise<{
     keys: { name: string }[];
     list_complete: boolean;
     cursor: string;
   }> {
     const prefix = options?.prefix ?? '';
-    const keys = [...this.store.keys()]
-      .filter((k) => k.startsWith(prefix))
-      .map((name) => ({ name }));
-    return { keys, list_complete: true, cursor: '' };
+    const allMatching = [...this.store.keys()].filter((k) => k.startsWith(prefix)).sort();
+    const startIdx = options?.cursor ? Number.parseInt(options.cursor, 10) : 0;
+    const safeStart = Number.isFinite(startIdx) && startIdx >= 0 ? startIdx : 0;
+    const endIdx = Number.isFinite(this.pageSize)
+      ? Math.min(allMatching.length, safeStart + this.pageSize)
+      : allMatching.length;
+    const page = allMatching.slice(safeStart, endIdx).map((name) => ({ name }));
+    const complete = endIdx >= allMatching.length;
+    return {
+      keys: page,
+      list_complete: complete,
+      cursor: complete ? '' : String(endIdx),
+    };
   }
 }

--- a/backend/alarm-worker/src/feedbackAdmin.ts
+++ b/backend/alarm-worker/src/feedbackAdmin.ts
@@ -1,5 +1,5 @@
 /**
- * 운영자용 feedback 조회 / CSV export (#1034 follow-up, PR #1042 후속).
+ * 운영자용 feedback 조회 / CSV export / 일일 통계 (#1034 follow-up, PR #1042/#1080 후속).
  *
  * `POST /feedback`이 KV `FEEDBACK`에 적재한 사용자 신고를 운영자가 wrangler CLI 없이
  * HTTP로 직접 수거할 수 있게 하는 admin endpoint들의 비-HTTP 계층 (pure / KV).
@@ -10,12 +10,37 @@
  * 정렬: 최신 → 오래된 순(receivedAt desc). 운영자가 "최근 N건"을 보는 사용 패턴에 맞춤.
  * KV native cursor는 lex ascending(=오래된 순)이라 후속 페이지 호출에서 의미가 어긋나
  * 의도적으로 사용하지 않는다 — 대신 `before` cursor(epoch ms)로 "그 시각보다 더 오래된 N건".
+ *
+ * 보존 정책 (#1080 follow-up):
+ *   - feedback entry: TTL 30일 (feedback.ts). 운영자는 30일 윈도우 안에 admin endpoint로 수거.
+ *   - 일일 통계: 매일 00:00 UTC 직후 cron이 어제 entry를 집계해 `stats:YYYY-MM-DD` KV 키로
+ *     365일 보관. 원문 30일 만료 후에도 카운트/분포는 1년 유지 → KPI 추세 추적.
+ *   - 원문 archive(R2/D1) 미도입 — 1년 카운트 통계로 충분하고, 원문 보존은 PII 표면을 늘림.
  */
 
 import type { FeedbackContext, FeedbackRecord } from './feedback';
 
 export const FEEDBACK_LIST_DEFAULT_LIMIT = 50;
 export const FEEDBACK_LIST_MAX_LIMIT = 500;
+
+/**
+ * KV list cursor 페이지네이션 안전 상한 (#1080 follow-up).
+ *
+ * KV `list`는 첫 페이지가 최대 1000개 — 그 이상이면 cursor로 잇는다. 운영팀이 30일 안에
+ * 수거하는 정상 가정에서 키가 수천 단위로 폭주할 일은 거의 없지만, 30일 TTL + 트래픽 폭증으로
+ * 1만+가 될 수도 있다. listFeedback은 desc 정렬을 위해 전체 키를 메모리에 모으므로 cap이 필요.
+ *
+ * 50_000 키 = 페이지 50회 — Worker CPU 한도(50ms free / 30s paid)를 보수적으로 지키는 값.
+ * cap 도달 시 가장 최근 50_000 키 정도가 잡히고 그 이전은 잘림 (desc 첫 페이지는 정확).
+ */
+export const FEEDBACK_LIST_MAX_KEYS_SCAN = 50_000;
+
+/**
+ * 일일 통계 키 prefix + TTL (#1080 follow-up).
+ * 운영 KPI 추세를 1년 보관. 원문 30일 만료 후에도 카운트는 365일까지 유지.
+ */
+export const FEEDBACK_STATS_KEY_PREFIX = 'stats:';
+export const FEEDBACK_STATS_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 export interface FeedbackListEntry {
   key: string;
@@ -63,14 +88,12 @@ export function parseReceivedAtFromKey(key: string): number {
  * FEEDBACK KV에서 entry를 desc(최신순) 정렬해 반환.
  *
  * 구현:
- *   1) `list({ prefix: 'feedback:' })`로 모든 키 조회 (KV는 lex asc=오래된순으로 줌)
- *   2) before 필터 + receivedAt desc 정렬
+ *   1) `list({ prefix: 'feedback:' })`를 cursor로 반복 호출해 모든 키 enumerate (#1080 follow-up)
+ *      - KV first page는 1000개 cap이라 cursor를 잇지 않으면 1000+ 환경에서 최신이 누락된다.
+ *      - 안전상한 FEEDBACK_LIST_MAX_KEYS_SCAN(=50_000)에서 중단.
+ *   2) before 필터 + receivedAt desc 정렬 (전체 키 대상)
  *   3) limit + 1개를 fetch해 nextBefore 산출(다음 페이지 존재 여부)
  *   4) 각 키의 value를 get → JSON parse. parse 실패는 skip(상한 보호).
- *
- * 30일 TTL + 운영팀이 주기적으로 수거하는 패턴이라 키 수가 수만 단위로 폭발하지 않는다는 가정.
- * 폭발 시 KV list가 1000개 단위 페이지를 cursor로 잇는데, 본 함수는 first page만 사용 —
- * 운영자가 정말 그 이상을 한 번에 보고 싶다면 별도 pagination 설계 필요(현재 요구 범위 밖).
  */
 export async function listFeedback(
   kv: KVNamespace,
@@ -79,9 +102,9 @@ export async function listFeedback(
   const limit = normalizeLimit(options.limit);
   const before = options.before;
 
-  const { keys } = await kv.list({ prefix: 'feedback:' });
-  const filtered = keys
-    .map((k) => ({ key: k.name, receivedAt: parseReceivedAtFromKey(k.name) }))
+  const allKeys = await listAllFeedbackKeys(kv);
+  const filtered = allKeys
+    .map((name) => ({ key: name, receivedAt: parseReceivedAtFromKey(name) }))
     .filter((k) => Number.isFinite(k.receivedAt))
     .filter((k) => (before === undefined ? true : k.receivedAt < before))
     .sort((a, b) => b.receivedAt - a.receivedAt);
@@ -171,4 +194,193 @@ export function toCsv(entries: FeedbackListEntry[]): string {
 
 function csvCell(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
+}
+
+/**
+ * KV `list` cursor를 잇는 단순 enumerate (#1080 follow-up).
+ *
+ * 모든 key 이름을 메모리에 모은다 — value는 안 읽음(따로 listFeedback이 entries만 get).
+ * KV first page는 1000개 cap이라 cursor를 잇지 않으면 1000+ 환경에서 desc 정렬 시 최신이
+ * 잘리는 회귀가 발생한다(#1080 admin endpoint 한계).
+ *
+ * Safety cap: FEEDBACK_LIST_MAX_KEYS_SCAN(=50_000) 도달 시 중단. 첫 페이지부터 lex asc로
+ * 받아 모은 키들에서 마지막에 desc 정렬하므로, cap 도달은 "가장 오래된 키 일부 누락" —
+ * 운영 KPI 관점에서는 최신만 보면 되므로 무해. cap 자체는 Worker CPU 한도 보호용.
+ */
+export async function listAllFeedbackKeys(kv: KVNamespace): Promise<string[]> {
+  const all: string[] = [];
+  let cursor: string | undefined;
+  // 무한 루프 방지: Worker 단일 invocation에서 50회면 50_000 키. 이론적 KV list 페이지 = 1000.
+  for (let page = 0; page < 100; page++) {
+    const result = await kv.list({ prefix: 'feedback:', cursor });
+    for (const k of result.keys) {
+      all.push(k.name);
+      if (all.length >= FEEDBACK_LIST_MAX_KEYS_SCAN) return all;
+    }
+    if (result.list_complete) return all;
+    if (!result.cursor) return all;
+    cursor = result.cursor;
+  }
+  return all;
+}
+
+/**
+ * 일일 통계 집계 결과 (#1080 follow-up).
+ *
+ * - date: ISO date `YYYY-MM-DD` (UTC). 집계 대상 일.
+ * - total: 해당 날의 feedback entry 수.
+ * - byPlatform: ios/android/unknown 카운트. context 미설정은 'unknown' 버킷.
+ * - byAppVersion: appVersion → 카운트. 미설정은 'unknown' 버킷.
+ * - byLocale: locale prefix(`ko`, `en`, `ja`, `zh`) → 카운트. 미설정은 'unknown'.
+ *
+ * Privacy: 카운트만 노출 — message 원문/deviceModel은 집계에 포함하지 않는다.
+ *   deviceModel은 카디널리티가 높아 통계로서 가치가 낮고 fingerprint 위험.
+ */
+export interface FeedbackDailyStats {
+  date: string;
+  total: number;
+  byPlatform: Record<string, number>;
+  byAppVersion: Record<string, number>;
+  byLocale: Record<string, number>;
+}
+
+/**
+ * dayStartMs (UTC 00:00) 기준 24시간 윈도우의 feedback entry를 집계.
+ *
+ * 입력 (dayStartMs)은 cron이 직접 산출 — UTC 자정 정렬. 24h 윈도우 [dayStart, dayEnd)에
+ * receivedAt이 속하는 entry만 카운트. 키 enumerate는 `listAllFeedbackKeys`로 cursor 페이지네이션.
+ *
+ * 정상 케이스: 어제 자정~오늘 자정. cron은 매일 00:00 UTC 직후 1회 실행.
+ * Worker 호환: enumerate cap이 50_000이라 단일 invocation에서 처리 가능. 그 이상이면
+ * 오래된 일부가 잘리지만, 같은 날 통계는 "최신부터 cap 안에 들어가는 한" 정확.
+ */
+export async function aggregateFeedbackStats(
+  kv: KVNamespace,
+  dayStartMs: number,
+): Promise<FeedbackDailyStats> {
+  const dayEndMs = dayStartMs + 24 * 60 * 60 * 1000;
+  const date = isoDateUtc(dayStartMs);
+
+  const keys = await listAllFeedbackKeys(kv);
+  const inRange = keys.filter((name) => {
+    const ts = parseReceivedAtFromKey(name);
+    return Number.isFinite(ts) && ts >= dayStartMs && ts < dayEndMs;
+  });
+
+  const byPlatform: Record<string, number> = {};
+  const byAppVersion: Record<string, number> = {};
+  const byLocale: Record<string, number> = {};
+
+  for (const key of inRange) {
+    const raw = await kv.get(key);
+    if (raw === null) continue;
+    const record = safeParseRecord(raw);
+    if (!record) continue;
+    bump(byPlatform, record.context?.platform ?? 'unknown');
+    bump(byAppVersion, record.context?.appVersion ?? 'unknown');
+    bump(byLocale, localeBucket(record.context?.locale));
+  }
+
+  return {
+    date,
+    total: inRange.length,
+    byPlatform,
+    byAppVersion,
+    byLocale,
+  };
+}
+
+function bump(map: Record<string, number>, key: string): void {
+  map[key] = (map[key] ?? 0) + 1;
+}
+
+/**
+ * locale prefix bucket — `ko-KR` → `ko`, 빈/누락은 `unknown`.
+ * 카디널리티 폭주 차단 (en-US/en-GB/en-CA … 분리되면 day stats가 비대해짐).
+ */
+function localeBucket(locale: string | undefined): string {
+  if (!locale) return 'unknown';
+  const dash = locale.indexOf('-');
+  return dash > 0 ? locale.slice(0, dash) : locale;
+}
+
+/**
+ * epoch ms → `YYYY-MM-DD` (UTC). Date.toISOString() prefix slice.
+ */
+export function isoDateUtc(epochMs: number): string {
+  return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+/**
+ * `YYYY-MM-DD` (UTC) → 그 날의 UTC 00:00 epoch ms.
+ * 형식이 어긋나면 NaN 반환 — caller가 invalid date로 처리.
+ */
+export function dayStartFromIsoDate(date: string): number {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return Number.NaN;
+  const ts = Date.parse(`${date}T00:00:00.000Z`);
+  return Number.isFinite(ts) ? ts : Number.NaN;
+}
+
+export function feedbackStatsKey(date: string): string {
+  return `${FEEDBACK_STATS_KEY_PREFIX}${date}`;
+}
+
+/**
+ * 집계 결과를 KV에 저장. TTL 365일 — 원문 30일 만료 후에도 카운트 추세는 1년 유지.
+ */
+export async function storeFeedbackStats(
+  kv: KVNamespace,
+  stats: FeedbackDailyStats,
+): Promise<void> {
+  await kv.put(feedbackStatsKey(stats.date), JSON.stringify(stats), {
+    expirationTtl: FEEDBACK_STATS_TTL_SECONDS,
+  });
+}
+
+/**
+ * 저장된 일일 통계 조회. 없으면 null — caller가 404 처리.
+ */
+export async function getFeedbackStats(
+  kv: KVNamespace,
+  date: string,
+): Promise<FeedbackDailyStats | null> {
+  const raw = await kv.get(feedbackStatsKey(date));
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as FeedbackDailyStats;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cron 매분 호출에서 "오늘 00:05 UTC 윈도우" 1회만 어제 집계를 트리거한다 (#1080 follow-up).
+ *
+ * 매분 cron의 모든 invocation에서 풀집계를 돌리면 Worker CPU 낭비 + KV write 폭주.
+ * - hourUtc===0 + minuteUtc===5 윈도우: 정확히 1분간 1회 — 자정 직후 race를 피해 5분 grace.
+ * - 이미 KV `stats:YYYY-MM-DD` 키가 있으면 skip (idempotent — cron 중복 실행 / replay 안전).
+ *
+ * `now`는 Date.now()를 caller가 주입 — 테스트 시 결정적 시점 제어.
+ */
+export const FEEDBACK_STATS_CRON_HOUR_UTC = 0;
+export const FEEDBACK_STATS_CRON_MINUTE_UTC = 5;
+
+export async function maybeRunDailyFeedbackStats(
+  kv: KVNamespace,
+  now: number,
+): Promise<{ ran: boolean; date?: string }> {
+  const d = new Date(now);
+  if (d.getUTCHours() !== FEEDBACK_STATS_CRON_HOUR_UTC) return { ran: false };
+  if (d.getUTCMinutes() !== FEEDBACK_STATS_CRON_MINUTE_UTC) return { ran: false };
+
+  // 어제(=오늘 자정 - 24h) 윈도우 집계.
+  const yesterdayStart = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) - 24 * 60 * 60 * 1000;
+  const date = isoDateUtc(yesterdayStart);
+  // Idempotent guard — 같은 날짜 키가 이미 있으면 재집계 안 함.
+  const existing = await kv.get(feedbackStatsKey(date));
+  if (existing !== null) return { ran: false, date };
+
+  const stats = await aggregateFeedbackStats(kv, yesterdayStart);
+  await storeFeedbackStats(kv, stats);
+  return { ran: true, date };
 }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -25,7 +25,14 @@ import {
   storeFeedback,
   validateFeedback,
 } from './feedback';
-import { listFeedback, toCsv } from './feedbackAdmin';
+import {
+  dayStartFromIsoDate,
+  getFeedbackStats,
+  isoDateUtc,
+  listFeedback,
+  maybeRunDailyFeedbackStats,
+  toCsv,
+} from './feedbackAdmin';
 import { evaluateAndMaybeAlert } from './recallAlerts';
 import {
   cleanupTripWithLa,
@@ -184,6 +191,37 @@ app.get('/admin/feedback/export.csv', async (c) => {
       'content-disposition': 'attachment; filename="feedback.csv"',
     },
   });
+});
+
+/**
+ * 운영자용 feedback 일일 통계 조회 (#1080 follow-up).
+ *
+ * 매일 00:05 UTC cron이 어제 entry를 집계해 `stats:YYYY-MM-DD` KV에 365일 TTL로 적재.
+ * 본 endpoint는 그 결과를 그대로 반환 — Worker가 즉석에서 집계하지 않는다 (CPU 비용 보호).
+ *
+ * Auth: `/admin/feedback`과 동일 정책 (Bearer + ADMIN_TOKEN secret).
+ * Query: `?date=YYYY-MM-DD` (UTC). 미지정 시 어제 UTC 날짜 default.
+ *
+ * Response 200: { date, total, byPlatform, byAppVersion, byLocale }
+ * Response 400: { error: 'invalid_date' } — date 형식 불일치
+ * Response 404: { error: 'stats_not_found' } — 해당 날 집계가 아직 없음 (오늘 또는 미수집)
+ * Response 401/503: 인증/binding 정책 동일
+ */
+app.get('/admin/feedback/stats', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const kv = c.env.FEEDBACK;
+  if (!kv) return c.json({ error: 'feedback_unavailable' }, 503);
+
+  const requested = c.req.query('date');
+  const date = requested ?? isoDateUtc(Date.now() - 24 * 60 * 60 * 1000);
+  if (!Number.isFinite(dayStartFromIsoDate(date))) {
+    return c.json({ error: 'invalid_date' }, 400);
+  }
+
+  const stats = await getFeedbackStats(kv, date);
+  if (!stats) return c.json({ error: 'stats_not_found' }, 404);
+  return c.json(stats);
 });
 
 interface AdminAuthError {
@@ -1101,5 +1139,14 @@ export default {
     // #972 — low-recall trip ratio 임계 위반 시 운영 webhook 발사. dedup KV(1h)로 spam 차단.
     // binding/secret 미설정 환경에서는 graceful no-op이라 회귀 없음.
     await evaluateAndMaybeAlert(env, { fetchImpl: fetch, now: () => Date.now(), log });
+    // #1080 follow-up — feedback 일일 통계 집계. 매분 cron이지만 함수가 자체적으로
+    // 00:05 UTC 1분 윈도우만 동작 + 같은 날짜 키 존재 시 skip(idempotent). FEEDBACK binding
+    // 부재 시 graceful no-op.
+    if (env.FEEDBACK) {
+      const result = await maybeRunDailyFeedbackStats(env.FEEDBACK, Date.now());
+      if (result.ran) {
+        log('feedback daily stats aggregated', { date: result.date });
+      }
+    }
   },
 };

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -21,6 +21,12 @@ preview_id = "53a86628f78c48fa91fa954f84514df3"
 # KV: 사용자 버그 신고 (#1034, docs/requirements/12-cross-cutting.md)
 # `POST /feedback`이 메시지 + 디바이스 컨텍스트를 30일 TTL로 적재.
 # 운영자가 `wrangler kv key list --binding FEEDBACK`으로 수거 후 분기 트리아지.
+# 키 prefix:
+#   - `feedback:<epochMs>:<id>` — 원문 entry, TTL 30일
+#   - `rl:feedback:<ip>:<windowStartMs>` — rate limit 카운터, TTL 60s
+#   - `stats:YYYY-MM-DD` — 일일 집계 (#1080 follow-up). cron이 매일 00:05 UTC에 어제 entry를
+#     집계(platform/appVersion/locale 카운트)해 적재. TTL 365일.
+#     `GET /admin/feedback/stats?date=YYYY-MM-DD`로 조회.
 [[kv_namespaces]]
 binding = "FEEDBACK"
 id = "831193b9d97f44c5b65131f045c09804"


### PR DESCRIPTION
PR #1080 follow-up — `listFeedback` KV 한계 fix + 일일 통계 cron/endpoint 추가.

## 정책 결정 (a: TTL 30일 유지 + 일일 통계 집계)

원문 archive(R2/D1) 미도입 — 1년 카운트 통계로 KPI 추세 추적이 가능하고, 원문 장기 보존은 PII 표면을 늘려 비채택.

| 항목 | 보관 |
| --- | --- |
| feedback entry 원문 | KV TTL 30일 (기존 유지) |
| 일일 카운트 집계 | KV `stats:YYYY-MM-DD` 키, TTL 365일 |

## 변경

- **`listFeedback` 페이지네이션 fix** — KV `list` cursor를 잇는 enumerate로 교체. 1000+ 키 환경에서 first page만 봐서 최신이 누락되던 #1080 한계 해소. safety cap `FEEDBACK_LIST_MAX_KEYS_SCAN`(50_000)으로 Worker CPU 보호.
- **일일 통계 집계** — `aggregateFeedbackStats`가 `[dayStart, dayEnd)` 윈도우의 platform/appVersion/locale 카운트를 계산. PII 회피 위해 message/deviceModel은 집계에 포함 안 함.
- **cron 훅** — 기존 1분 cron의 00:05 UTC 윈도우에서 `maybeRunDailyFeedbackStats`가 어제 entry 1회 집계. 같은 날짜 키가 있으면 idempotent skip → cron 중복/replay 안전. 별도 cron schedule 미추가 (기존 1분 cron 재사용).
- **`GET /admin/feedback/stats?date=YYYY-MM-DD`** endpoint — 기존 admin auth 정책 재사용. date 미지정 시 어제 UTC default. 미수집 시 404 `stats_not_found`, malformed date 400.
- **`inMemoryKv`** — `pageSize` 필드로 KV list 페이지네이션 의사 동작 추가 (회귀 테스트용).

## Test plan

- [x] `cd backend/alarm-worker && npm test` — 1048개 통과
- [x] `npm run type-check` (backend + root) — 통과
- [ ] 배포 후 실 cron 1회 도달 시 `wrangler tail`로 `feedback daily stats aggregated` 로그 확인
- [ ] `GET /admin/feedback/stats` 응답 검증

Closes #1080 follow-up (no issue — direct follow-up to merged PR).