### PR TITLE
feat(#1097): 출구별 시설 데이터 PoC (서울 OD OA-15993)

### DIFF
--- a/src/data/exit-info-sample.json
+++ b/src/data/exit-info-sample.json
@@ -1,0 +1,44 @@
+{
+  "_source": "서울특별시 공공데이터 OA-15993 '지하철역 출구별 주요 시설 정보' (https://data.seoul.go.kr/dataList/OA-15993/S/1/datasetView.do)",
+  "_note": "PoC sample fixture. 실 API 키 발급 + 전수 수집은 follow-up. 본 fixture는 공개 명세 기반으로 수기 작성한 대표 역 일부.",
+  "exits": [
+    {
+      "stationName": "강남",
+      "line": "2",
+      "exitNumber": "1",
+      "facilities": ["국기원", "강남구청"],
+      "nearby": "테헤란로 방면"
+    },
+    {
+      "stationName": "강남",
+      "line": "2",
+      "exitNumber": "6",
+      "facilities": ["강남역 지하상가", "교보타워"]
+    },
+    {
+      "stationName": "강남",
+      "line": "2",
+      "exitNumber": "10",
+      "facilities": ["뉴욕제과", "강남대로 버스환승센터"]
+    },
+    {
+      "stationName": "시청",
+      "line": "1",
+      "exitNumber": "5",
+      "facilities": ["서울시청", "서울도서관"]
+    },
+    {
+      "stationName": "시청",
+      "line": "1",
+      "exitNumber": "1",
+      "facilities": ["프레스센터", "조선일보"]
+    },
+    {
+      "stationName": "홍대입구",
+      "line": "2",
+      "exitNumber": "9",
+      "facilities": ["홍익대학교", "홍대 걷고싶은거리"],
+      "nearby": "주말 야간 혼잡"
+    }
+  ]
+}

--- a/src/features/exit-info/hooks/__tests__/useStationExits.test.ts
+++ b/src/features/exit-info/hooks/__tests__/useStationExits.test.ts
@@ -1,0 +1,159 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useStationExits } from '../useStationExits';
+import type { ExitInfoProvider } from '../../providers/types';
+import type { ExitInfo } from '../../../../shared/types/exitInfo';
+import type { LineNumber } from '../../../../shared/types/station';
+
+function makeProvider(exits: ExitInfo[]): ExitInfoProvider {
+  return {
+    getExits: jest.fn(async () => exits),
+  };
+}
+
+const gangnamExits: ExitInfo[] = [
+  { stationName: '강남', line: '2', exitNumber: '1', facilities: ['국기원'] },
+  { stationName: '강남', line: '2', exitNumber: '6', facilities: ['교보타워'] },
+  { stationName: '강남', line: '2', exitNumber: '10', facilities: ['뉴욕제과', '강남대로 버스환승센터'] },
+];
+
+describe('useStationExits', () => {
+  it('stationName 또는 line이 null이면 빈 결과', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { result } = renderHook(() =>
+      useStationExits({ stationName: null, line: '2', provider }),
+    );
+    expect(result.current.exits).toEqual([]);
+    expect(result.current.ranked).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(provider.getExits).not.toHaveBeenCalled();
+  });
+
+  it('line이 null이어도 호출하지 않는다', () => {
+    const provider = makeProvider(gangnamExits);
+    renderHook(() =>
+      useStationExits({ stationName: '강남', line: null, provider }),
+    );
+    expect(provider.getExits).not.toHaveBeenCalled();
+  });
+
+  it('역+노선이 주어지면 provider를 호출하고 결과를 반환한다', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { result } = renderHook(() =>
+      useStationExits({ stationName: '강남', line: '2', provider }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.exits).toEqual(gangnamExits);
+    expect(provider.getExits).toHaveBeenCalledWith('강남', '2');
+  });
+
+  it('destination 없으면 ranked는 원본 순서 + matchesDestination=false', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { result } = renderHook(() =>
+      useStationExits({ stationName: '강남', line: '2', provider }),
+    );
+    await waitFor(() => expect(result.current.ranked.length).toBe(3));
+    expect(result.current.ranked.map((r) => r.exit.exitNumber)).toEqual(['1', '6', '10']);
+    expect(result.current.ranked.every((r) => !r.matchesDestination)).toBe(true);
+  });
+
+  it('destination이 facilities에 포함된 출구를 앞으로 정렬', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { result } = renderHook(() =>
+      useStationExits({
+        stationName: '강남',
+        line: '2',
+        destination: '교보타워',
+        provider,
+      }),
+    );
+    await waitFor(() => expect(result.current.ranked.length).toBe(3));
+    expect(result.current.ranked[0]?.exit.exitNumber).toBe('6');
+    expect(result.current.ranked[0]?.matchesDestination).toBe(true);
+    expect(result.current.ranked.slice(1).every((r) => !r.matchesDestination)).toBe(true);
+  });
+
+  it('destination이 빈 문자열/공백이면 매칭하지 않는다', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { result } = renderHook(() =>
+      useStationExits({
+        stationName: '강남',
+        line: '2',
+        destination: '   ',
+        provider,
+      }),
+    );
+    await waitFor(() => expect(result.current.ranked.length).toBe(3));
+    expect(result.current.ranked.every((r) => !r.matchesDestination)).toBe(true);
+  });
+
+  it('provider 실패 시 빈 결과로 fallback', async () => {
+    const provider: ExitInfoProvider = {
+      getExits: jest.fn(async () => {
+        throw new Error('boom');
+      }),
+    };
+    const { result } = renderHook(() =>
+      useStationExits({ stationName: '강남', line: '2', provider }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.exits).toEqual([]);
+  });
+
+  it('stationName이 바뀌면 재조회', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { result, rerender } = renderHook(
+      ({ stationName, line }: { stationName: string | null; line: LineNumber | null }) =>
+        useStationExits({ stationName, line, provider }),
+      { initialProps: { stationName: '강남', line: '2' as LineNumber | null } },
+    );
+    await waitFor(() => expect(result.current.exits.length).toBe(3));
+    rerender({ stationName: '시청', line: '1' });
+    await waitFor(() => expect(provider.getExits).toHaveBeenCalledWith('시청', '1'));
+  });
+
+  it('unmount 후 resolve된 promise는 상태를 갱신하지 않는다', async () => {
+    let resolveFn: (v: ExitInfo[]) => void = () => undefined;
+    const provider: ExitInfoProvider = {
+      getExits: jest.fn(
+        () =>
+          new Promise<ExitInfo[]>((resolve) => {
+            resolveFn = resolve;
+          }),
+      ),
+    };
+    const { unmount } = renderHook(() =>
+      useStationExits({ stationName: '강남', line: '2', provider }),
+    );
+    unmount();
+    // resolve 후에도 throw 없이 통과해야 한다.
+    resolveFn(gangnamExits);
+    await Promise.resolve();
+  });
+
+  it('unmount 후 reject된 promise도 silent fail', async () => {
+    let rejectFn: (e: Error) => void = () => undefined;
+    const provider: ExitInfoProvider = {
+      getExits: jest.fn(
+        () =>
+          new Promise<ExitInfo[]>((_, reject) => {
+            rejectFn = reject;
+          }),
+      ),
+    };
+    const { unmount } = renderHook(() =>
+      useStationExits({ stationName: '강남', line: '2', provider }),
+    );
+    unmount();
+    rejectFn(new Error('late'));
+    await Promise.resolve();
+  });
+
+  it('기본 provider(MockExitInfoProvider)로도 동작', async () => {
+    const { result } = renderHook(() =>
+      useStationExits({ stationName: '강남', line: '2' }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // sample fixture에 강남 2호선 출구가 들어있다.
+    expect(result.current.exits.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/exit-info/hooks/useStationExits.ts
+++ b/src/features/exit-info/hooks/useStationExits.ts
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import type { LineNumber } from '../../../shared/types/station';
+import type { ExitInfo } from '../../../shared/types/exitInfo';
+import type { ExitInfoProvider } from '../providers/types';
+import { MockExitInfoProvider } from '../providers/MockExitInfoProvider';
+
+const defaultProvider: ExitInfoProvider = new MockExitInfoProvider();
+
+export interface RankedExit {
+  exit: ExitInfo;
+  /** destination 텍스트가 facilities 항목 중 하나에 substring으로 포함되면 true. */
+  matchesDestination: boolean;
+}
+
+export interface UseStationExitsResult {
+  exits: ExitInfo[];
+  /**
+   * destination이 주어졌을 때: 매칭 출구를 앞으로, 나머지는 기존 순서를 보존해 뒤로.
+   * destination이 없으면 입력 순서 그대로.
+   */
+  ranked: RankedExit[];
+  loading: boolean;
+}
+
+export interface UseStationExitsOptions {
+  stationName: string | null;
+  line: LineNumber | null;
+  /** 사용자가 입력/선택한 도착 시설 텍스트. 없으면 ranking 없이 원본 순서. */
+  destination?: string | null;
+  /** 테스트/DI용. 미지정 시 MockExitInfoProvider 사용. */
+  provider?: ExitInfoProvider;
+}
+
+function matches(facilities: string[], destination: string): boolean {
+  const needle = destination.trim();
+  if (needle.length === 0) return false;
+  return facilities.some((facility) => facility.includes(needle));
+}
+
+/**
+ * 현재 역의 출구 목록을 로드하고, destination 텍스트가 facilities에 포함되는 출구를
+ * 앞쪽으로 정렬한 ranked 리스트를 함께 반환한다 (#1097 PoC).
+ *
+ * UI 진입(컴포넌트 wiring)은 follow-up. 본 hook은 데이터 계약 + ranking 정책의 단일 진입점.
+ */
+export function useStationExits({
+  stationName,
+  line,
+  destination,
+  provider = defaultProvider,
+}: UseStationExitsOptions): UseStationExitsResult {
+  const [exits, setExits] = useState<ExitInfo[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!stationName || !line) {
+      setExits([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    provider
+      .getExits(stationName, line)
+      .then((result) => {
+        if (cancelled) return;
+        setExits(result);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setExits([]);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [stationName, line, provider]);
+
+  const ranked: RankedExit[] = (() => {
+    const annotated = exits.map((exit) => ({
+      exit,
+      matchesDestination: destination
+        ? matches(exit.facilities, destination)
+        : false,
+    }));
+    if (!destination) return annotated;
+    // stable partition: matches first, preserving original order in each group.
+    return [
+      ...annotated.filter((r) => r.matchesDestination),
+      ...annotated.filter((r) => !r.matchesDestination),
+    ];
+  })();
+
+  return { exits, ranked, loading };
+}

--- a/src/features/exit-info/providers/MockExitInfoProvider.ts
+++ b/src/features/exit-info/providers/MockExitInfoProvider.ts
@@ -1,0 +1,41 @@
+import type { LineNumber } from '../../../shared/types/station';
+import type { ExitInfo } from '../../../shared/types/exitInfo';
+import type { ExitInfoProvider } from './types';
+import sampleData from '../../../data/exit-info-sample.json';
+
+interface SampleEntry {
+  stationName: string;
+  line: string;
+  exitNumber: string;
+  facilities: string[];
+  nearby?: string;
+}
+
+interface SampleFile {
+  exits: SampleEntry[];
+}
+
+/**
+ * 개발/테스트용 mock provider. `src/data/exit-info-sample.json`을 in-memory 인덱싱.
+ *
+ * 실 API(SeoulOdExitInfoProvider) 키 발급 전에도 hook/UI 개발이 가능하도록 한다.
+ */
+export class MockExitInfoProvider implements ExitInfoProvider {
+  private readonly entries: ExitInfo[];
+
+  constructor(data: SampleFile = sampleData as SampleFile) {
+    this.entries = data.exits.map((entry) => ({
+      stationName: entry.stationName,
+      line: entry.line as LineNumber,
+      exitNumber: entry.exitNumber,
+      facilities: entry.facilities,
+      nearby: entry.nearby,
+    }));
+  }
+
+  async getExits(stationName: string, line: LineNumber): Promise<ExitInfo[]> {
+    return this.entries.filter(
+      (entry) => entry.stationName === stationName && entry.line === line,
+    );
+  }
+}

--- a/src/features/exit-info/providers/SeoulOdExitInfoProvider.ts
+++ b/src/features/exit-info/providers/SeoulOdExitInfoProvider.ts
@@ -1,0 +1,23 @@
+import type { LineNumber } from '../../../shared/types/station';
+import type { ExitInfo } from '../../../shared/types/exitInfo';
+import type { ExitInfoProvider } from './types';
+
+/**
+ * 서울 OD OA-15993 ('지하철역 출구별 주요 시설 정보') 실 API 구현 stub.
+ *
+ * 키 발급 + 응답 스키마 확정 후 follow-up PR에서 fetch 로직 채움. 본 PoC 단계에서는
+ * `EXPO_PUBLIC_SEOUL_DATA_API_KEY`를 받아 보관만 한다. 호출 시 빈 배열을 돌려주면
+ * UI는 graceful하게 "출구 정보 없음"으로 표시한다 (interface 계약).
+ *
+ * 명세 참고: http://openapi.seoul.go.kr:8088/{KEY}/json/SearchInfoBySubwayNameService/...
+ */
+export class SeoulOdExitInfoProvider implements ExitInfoProvider {
+  constructor(private readonly apiKey: string) {}
+
+  async getExits(_stationName: string, _line: LineNumber): Promise<ExitInfo[]> {
+    // PoC stub — API 키 발급 후 fetch + parse 채울 예정.
+    // apiKey가 의도적으로 보관됨을 표시 (lint/TS unused 회피).
+    void this.apiKey;
+    return [];
+  }
+}

--- a/src/features/exit-info/providers/__tests__/MockExitInfoProvider.test.ts
+++ b/src/features/exit-info/providers/__tests__/MockExitInfoProvider.test.ts
@@ -1,0 +1,46 @@
+import { MockExitInfoProvider } from '../MockExitInfoProvider';
+
+describe('MockExitInfoProvider', () => {
+  it('샘플 fixture에서 강남 2호선 출구를 반환한다', async () => {
+    const provider = new MockExitInfoProvider();
+    const exits = await provider.getExits('강남', '2');
+    expect(exits.length).toBeGreaterThan(0);
+    expect(exits.every((e) => e.stationName === '강남' && e.line === '2')).toBe(true);
+  });
+
+  it('없는 역은 빈 배열', async () => {
+    const provider = new MockExitInfoProvider();
+    const exits = await provider.getExits('없는역', '2');
+    expect(exits).toEqual([]);
+  });
+
+  it('다른 노선은 분리된다', async () => {
+    const provider = new MockExitInfoProvider();
+    const line2 = await provider.getExits('강남', '2');
+    const line1 = await provider.getExits('강남', '1');
+    expect(line2.length).toBeGreaterThan(0);
+    expect(line1).toEqual([]);
+  });
+
+  it('주입된 데이터를 사용한다', async () => {
+    const provider = new MockExitInfoProvider({
+      exits: [
+        { stationName: '테스트', line: '3', exitNumber: '2', facilities: ['카페'], nearby: '메모' },
+      ],
+    });
+    const exits = await provider.getExits('테스트', '3');
+    expect(exits).toEqual([
+      { stationName: '테스트', line: '3', exitNumber: '2', facilities: ['카페'], nearby: '메모' },
+    ]);
+  });
+
+  it('nearby가 없는 엔트리도 그대로 보존된다 (undefined)', async () => {
+    const provider = new MockExitInfoProvider({
+      exits: [
+        { stationName: '테스트', line: '3', exitNumber: '1', facilities: ['역사'] },
+      ],
+    });
+    const exits = await provider.getExits('테스트', '3');
+    expect(exits[0]?.nearby).toBeUndefined();
+  });
+});

--- a/src/features/exit-info/providers/__tests__/SeoulOdExitInfoProvider.test.ts
+++ b/src/features/exit-info/providers/__tests__/SeoulOdExitInfoProvider.test.ts
@@ -1,0 +1,9 @@
+import { SeoulOdExitInfoProvider } from '../SeoulOdExitInfoProvider';
+
+describe('SeoulOdExitInfoProvider (PoC stub)', () => {
+  it('현재는 빈 배열만 반환한다 (API 키 연동은 follow-up)', async () => {
+    const provider = new SeoulOdExitInfoProvider('test-key');
+    const exits = await provider.getExits('강남', '2');
+    expect(exits).toEqual([]);
+  });
+});

--- a/src/features/exit-info/providers/index.ts
+++ b/src/features/exit-info/providers/index.ts
@@ -1,0 +1,3 @@
+export { MockExitInfoProvider } from './MockExitInfoProvider';
+export { SeoulOdExitInfoProvider } from './SeoulOdExitInfoProvider';
+export type { ExitInfoProvider } from './types';

--- a/src/features/exit-info/providers/types.ts
+++ b/src/features/exit-info/providers/types.ts
@@ -1,0 +1,18 @@
+/**
+ * ExitInfoProvider — 역 + 노선을 받아 출구별 시설 정보를 반환하는 추상 인터페이스.
+ *
+ * 구현체:
+ *  - `MockExitInfoProvider`: `src/data/exit-info-sample.json` 기반 (개발/테스트)
+ *  - `SeoulOdExitInfoProvider`: 서울 OD OA-15993 실 API (키 발급 후 활성)
+ */
+
+import type { LineNumber } from '../../../shared/types/station';
+import type { ExitInfo } from '../../../shared/types/exitInfo';
+
+export interface ExitInfoProvider {
+  /**
+   * 주어진 역+노선에 대한 모든 출구 정보를 반환한다.
+   * 데이터가 없으면 빈 배열을 반환한다 (throw 금지 — UI는 "출구 정보 없음"으로 표시).
+   */
+  getExits(stationName: string, line: LineNumber): Promise<ExitInfo[]>;
+}

--- a/src/shared/types/exitInfo.ts
+++ b/src/shared/types/exitInfo.ts
@@ -1,0 +1,26 @@
+/**
+ * 출구별 시설 데이터 타입 (#1097 P0).
+ *
+ * 데이터 출처: 서울특별시 공공데이터 "지하철역 출구별 주요 시설 정보" (OA-15993).
+ * https://data.seoul.go.kr/dataList/OA-15993/S/1/datasetView.do
+ *
+ * exitSide(좌/우 하차 방향)와는 별개 차원이다. 본 타입은 "N번 출구가 무엇과 가까운가"를
+ * 표현하며, 도착 안내 시 사용자가 사전에 출구를 결정할 수 있게 돕는다.
+ */
+
+import type { LineNumber } from './station';
+
+/**
+ * 단일 출구의 부가 정보.
+ *
+ * - `exitNumber`는 문자열 ("1", "1-1" 형태 포함). 일부 역은 한 글자 suffix를 쓰므로 number 사용 금지.
+ * - `facilities`는 출구 인근 주요 시설 목록 (학교/관공서/대형 상가 등).
+ * - `nearby`는 자유 텍스트 보조 설명(있는 경우만).
+ */
+export interface ExitInfo {
+  stationName: string;
+  line: LineNumber;
+  exitNumber: string;
+  facilities: string[];
+  nearby?: string;
+}


### PR DESCRIPTION
## Summary
- 서울특별시 공공데이터 `OA-15993` ("지하철역 출구별 주요 시설 정보") 기반 PoC.
- `ExitInfoProvider` 인터페이스 + Mock/SeoulOD 두 구현체 (실 API는 키 발급 후 follow-up).
- `useStationExits` hook: destination 텍스트가 facilities에 포함된 출구를 ranking 앞쪽으로 정렬.

## 시그니처
```ts
interface ExitInfoProvider {
  getExits(stationName: string, line: LineNumber): Promise<ExitInfo[]>;
}

useStationExits({ stationName, line, destination?, provider? })
  -> { exits, ranked, loading }
```

## 데이터 출처
- 서울 OD `OA-15993` https://data.seoul.go.kr/dataList/OA-15993/S/1/datasetView.do (무료, 키 필요)
- `src/data/exit-info-sample.json`은 PoC sample. 키 발급 후 전수 수집 follow-up.

## 범위 밖 (follow-up)
- UI 진입 (도착 안내에 추천 출구 표시)
- 실 API fetch/parse 구현 (`SeoulOdExitInfoProvider`는 현재 stub)
- 전체 서울 528개 역 데이터 수집

## Test plan
- [x] `npm test` — exit-info 슬라이스 100% 커버리지 (lines/branches/funcs/stmts)
- [x] `npm run type-check`
- [ ] follow-up PR에서 실 API 키 발급 후 SeoulOd 구현 + UI wiring

Closes #1097