### PR TITLE
feat: 코레일 fallback ArrivalProvider PoC (#1096)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,11 @@ EXPO_PUBLIC_APNS_ENV=
 # Sentry DSN (#1038). 비워두면 사용자가 opt-in 켜도 graceful no-op.
 # 사용자 명시 동의(SENTRY_OPT_IN_KEY='true') + DSN 둘 다 있어야 외부 전송.
 EXPO_PUBLIC_SENTRY_DSN=
+
+# 코레일(한국철도공사) 열차운행정보 API 키 (#1096 PoC). 데이터포털 15125762.
+# 미설정 시 KorailArrivalProvider는 graceful skip — Composite는 서울 OD로 fallback.
+EXPO_PUBLIC_KORAIL_API_KEY=
+
+# 코레일 fallback routing 활성화 게이트 (#1096). "true"면 CompositeArrivalProvider로 wrap.
+# 미설정 시 기존 동작 그대로(SeoulOpenApi/BFF 직행).
+EXPO_PUBLIC_USE_KORAIL_FALLBACK=

--- a/src/features/arrival/providers/CompositeArrivalProvider.ts
+++ b/src/features/arrival/providers/CompositeArrivalProvider.ts
@@ -1,0 +1,53 @@
+import type { ArrivalProvider, ArrivalOptions } from './types';
+import type { StationArrival } from '../api/arrivalApi';
+import type { KorailArrivalProvider } from './KorailArrivalProvider';
+import { isKorailLine } from '../../../shared/constants/lineOperators';
+import { findLineByStationName } from '../../../shared/utils/stationLookup';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('CompositeArrivalProvider');
+
+/**
+ * 운영사 기반 routing arrival provider (#1096 PoC).
+ *
+ * 의사결정:
+ *   1. lineHint(또는 stationName lookup)로 노선 운영사 판정.
+ *   2. Korail 운영 노선이고 KorailArrivalProvider가 사용 가능하면 1차 시도.
+ *      - null 반환 또는 throw 시 서울 OD provider로 fallback (graceful).
+ *   3. 그 외 (Seoul, other, 운영사 미확정)는 기존 서울 OD provider 직행.
+ *
+ * 기존 SeoulOpenApiProvider 호출 경로는 변경하지 않는다 — Composite는 wrapper일 뿐
+ * 호출자가 명시적으로 선택할 때만 활성화된다 (factory에서 USE_KORAIL_FALLBACK env로 게이트).
+ */
+export class CompositeArrivalProvider implements ArrivalProvider {
+  constructor(
+    private readonly korail: KorailArrivalProvider,
+    private readonly fallback: ArrivalProvider,
+  ) {}
+
+  async getArrival(
+    stationName: string,
+    options?: ArrivalOptions,
+  ): Promise<StationArrival> {
+    const line = options?.lineHint ?? findLineByStationName(stationName);
+
+    if (line && isKorailLine(line) && this.korail.isAvailable) {
+      try {
+        const result = await this.korail.getArrival(stationName, options);
+        if (result) {
+          log.info('korail_primary_hit', { station: stationName, line });
+          return result;
+        }
+        log.info('korail_primary_null_fallback', { station: stationName, line });
+      } catch (error) {
+        log.warn('korail_primary_throw_fallback', {
+          station: stationName,
+          line,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return this.fallback.getArrival(stationName, options);
+  }
+}

--- a/src/features/arrival/providers/KorailArrivalProvider.ts
+++ b/src/features/arrival/providers/KorailArrivalProvider.ts
@@ -1,0 +1,50 @@
+import type { ArrivalProvider, ArrivalOptions } from './types';
+import type { StationArrival } from '../api/arrivalApi';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('KorailArrivalProvider');
+
+/**
+ * 한국철도공사 열차운행정보 API provider (#1096 PoC).
+ *
+ * 데이터포털 15125762 endpoint 기반. PoC 단계에서는 API 키 발급이 완료되지 않아
+ * 실제 endpoint 매핑/응답 정규화는 후속 PR로 미룬다. 본 클래스의 책임은:
+ *   1. 키가 없으면 즉시 `null`을 반환해 CompositeArrivalProvider가 서울 OD로 fallback하게 한다.
+ *   2. 키가 있으면 endpoint를 호출하고, 응답을 기존 StationArrival 스키마로 정규화한다.
+ *      (현재 stub — 후속 PR에서 실제 변환 로직 추가)
+ *
+ * graceful 계약: 호출자(Composite)는 `null`을 "데이터 없음 — 다음 provider로"로 해석한다.
+ * 예외 throw는 환경 오류로만 사용 — 빈 응답/스키마 불일치는 `null`로 흡수한다.
+ */
+export class KorailArrivalProvider {
+  constructor(private readonly apiKey: string | undefined) {}
+
+  /** 키 미설정/PoC stub 상태 판정. CompositeArrivalProvider가 호출 전 분기 가능. */
+  get isAvailable(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  async getArrival(
+    stationName: string,
+    _options?: ArrivalOptions,
+  ): Promise<StationArrival | null> {
+    if (!this.apiKey) {
+      log.info('korail_skip_no_api_key', { station: stationName });
+      return null;
+    }
+
+    // PoC stub: 실제 API endpoint/스키마 매핑은 키 발급 후 후속 PR에서 구현한다.
+    // 키가 설정된 환경에서도 정상 동작 보장을 위해 현 시점에서는 명시적으로 null을 반환.
+    log.info('korail_stub_not_implemented', { station: stationName });
+    return null;
+  }
+}
+
+/**
+ * ArrivalProvider 인터페이스에 호환되는 Provider를 만들기 위한 helper.
+ * Composite는 내부적으로 KorailArrivalProvider의 nullable 응답을 직접 다루기 때문에
+ * 단독으로 사용할 일은 거의 없지만, factory에서 inject할 때 일관된 생성자를 제공한다.
+ */
+export function createKorailArrivalProvider(): KorailArrivalProvider {
+  return new KorailArrivalProvider(process.env.EXPO_PUBLIC_KORAIL_API_KEY);
+}

--- a/src/features/arrival/providers/__tests__/CompositeArrivalProvider.test.ts
+++ b/src/features/arrival/providers/__tests__/CompositeArrivalProvider.test.ts
@@ -1,0 +1,155 @@
+import { CompositeArrivalProvider } from '../CompositeArrivalProvider';
+import { KorailArrivalProvider } from '../KorailArrivalProvider';
+import type { ArrivalProvider } from '../types';
+import type { StationArrival } from '../../api/arrivalApi';
+
+const KORAIL_RESULT: StationArrival = {
+  up: [
+    {
+      destination: '청량리',
+      arrivalMinutes: 2,
+      arrivalSeconds: 120,
+      statusMessage: '',
+      trainCode: 'KR-001',
+      line: 'bundang',
+      receivedAtMs: 0,
+      arrivalCode: -1,
+      isLastTrain: false,
+      trainType: 'normal',
+    },
+  ],
+  down: [],
+  source: 'realtime',
+};
+
+const FALLBACK_RESULT: StationArrival = {
+  up: [
+    {
+      destination: '서울역',
+      arrivalMinutes: 4,
+      arrivalSeconds: 240,
+      statusMessage: '',
+      trainCode: 'SO-001',
+      line: '2',
+      receivedAtMs: 0,
+      arrivalCode: -1,
+      isLastTrain: false,
+      trainType: 'normal',
+    },
+  ],
+  down: [],
+  source: 'realtime',
+};
+
+function makeFallback(): jest.Mocked<ArrivalProvider> {
+  return {
+    getArrival: jest.fn().mockResolvedValue(FALLBACK_RESULT),
+  };
+}
+
+describe('CompositeArrivalProvider', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Korail 노선이고 Korail provider 사용 가능 + 결과 반환 시 1차 hit', async () => {
+    const korail = new KorailArrivalProvider('test-key');
+    jest.spyOn(korail, 'getArrival').mockResolvedValueOnce(KORAIL_RESULT);
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
+
+    expect(result).toBe(KORAIL_RESULT);
+    expect(fallback.getArrival).not.toHaveBeenCalled();
+  });
+
+  it('Korail 노선이지만 Korail provider가 null 반환 시 fallback', async () => {
+    const korail = new KorailArrivalProvider('test-key');
+    jest.spyOn(korail, 'getArrival').mockResolvedValueOnce(null);
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
+
+    expect(result).toBe(FALLBACK_RESULT);
+    expect(fallback.getArrival).toHaveBeenCalledWith('왕십리', { lineHint: 'bundang' });
+  });
+
+  it('Korail provider가 throw해도 fallback으로 흡수', async () => {
+    const korail = new KorailArrivalProvider('test-key');
+    jest.spyOn(korail, 'getArrival').mockRejectedValueOnce(new Error('network'));
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
+
+    expect(result).toBe(FALLBACK_RESULT);
+    expect(fallback.getArrival).toHaveBeenCalled();
+  });
+
+  it('Korail provider가 throw하고 error가 non-Error 객체여도 fallback', async () => {
+    const korail = new KorailArrivalProvider('test-key');
+    jest.spyOn(korail, 'getArrival').mockRejectedValueOnce('string error');
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
+
+    expect(result).toBe(FALLBACK_RESULT);
+  });
+
+  it('Korail 노선이지만 API 키 미설정(isAvailable=false) 시 즉시 fallback', async () => {
+    const korail = new KorailArrivalProvider(undefined);
+    const korailSpy = jest.spyOn(korail, 'getArrival');
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('왕십리', { lineHint: 'gyeongui' });
+
+    expect(result).toBe(FALLBACK_RESULT);
+    expect(korailSpy).not.toHaveBeenCalled();
+  });
+
+  it('서울교통공사 노선(예: 2호선)은 Korail 거치지 않고 fallback 직행', async () => {
+    const korail = new KorailArrivalProvider('test-key');
+    const korailSpy = jest.spyOn(korail, 'getArrival');
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('강남', { lineHint: '2' });
+
+    expect(result).toBe(FALLBACK_RESULT);
+    expect(korailSpy).not.toHaveBeenCalled();
+  });
+
+  it('lineHint 없을 때 stationName으로 lookup 후 routing', async () => {
+    // '강남'은 2호선/신분당선 — Korail 아님. fallback 직행.
+    const korail = new KorailArrivalProvider('test-key');
+    const korailSpy = jest.spyOn(korail, 'getArrival');
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('강남');
+
+    expect(result).toBe(FALLBACK_RESULT);
+    expect(korailSpy).not.toHaveBeenCalled();
+  });
+
+  it('lineHint 없고 stationName lookup 실패해도 fallback 직행', async () => {
+    const korail = new KorailArrivalProvider('test-key');
+    const korailSpy = jest.spyOn(korail, 'getArrival');
+    const fallback = makeFallback();
+    const composite = new CompositeArrivalProvider(korail, fallback);
+
+    const result = await composite.getArrival('존재하지않는역');
+
+    expect(result).toBe(FALLBACK_RESULT);
+    expect(korailSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/arrival/providers/__tests__/CompositeArrivalProvider.test.ts
+++ b/src/features/arrival/providers/__tests__/CompositeArrivalProvider.test.ts
@@ -1,6 +1,6 @@
 import { CompositeArrivalProvider } from '../CompositeArrivalProvider';
 import { KorailArrivalProvider } from '../KorailArrivalProvider';
-import type { ArrivalProvider } from '../types';
+import type { ArrivalProvider, ArrivalOptions } from '../types';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const KORAIL_RESULT: StationArrival = {
@@ -41,10 +41,28 @@ const FALLBACK_RESULT: StationArrival = {
   source: 'realtime',
 };
 
-function makeFallback(): jest.Mocked<ArrivalProvider> {
-  return {
+type SetupOpts = { korailKeyless?: boolean };
+function setup(opts: SetupOpts = {}) {
+  const korail = new KorailArrivalProvider(opts.korailKeyless ? undefined : 'test-key');
+  const korailSpy = jest.spyOn(korail, 'getArrival');
+  const fallback: jest.Mocked<ArrivalProvider> = {
     getArrival: jest.fn().mockResolvedValue(FALLBACK_RESULT),
   };
+  const composite = new CompositeArrivalProvider(korail, fallback);
+  return { korail, korailSpy, fallback, composite };
+}
+
+async function expectFallbackDirect(
+  stationName: string,
+  options?: ArrivalOptions,
+  setupOpts: SetupOpts = {},
+) {
+  const { korailSpy, composite } = setup(setupOpts);
+
+  const result = await composite.getArrival(stationName, options);
+
+  expect(result).toBe(FALLBACK_RESULT);
+  expect(korailSpy).not.toHaveBeenCalled();
 }
 
 describe('CompositeArrivalProvider', () => {
@@ -58,10 +76,8 @@ describe('CompositeArrivalProvider', () => {
   });
 
   it('Korail 노선이고 Korail provider 사용 가능 + 결과 반환 시 1차 hit', async () => {
-    const korail = new KorailArrivalProvider('test-key');
+    const { korail, fallback, composite } = setup();
     jest.spyOn(korail, 'getArrival').mockResolvedValueOnce(KORAIL_RESULT);
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
 
     const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
 
@@ -70,10 +86,8 @@ describe('CompositeArrivalProvider', () => {
   });
 
   it('Korail 노선이지만 Korail provider가 null 반환 시 fallback', async () => {
-    const korail = new KorailArrivalProvider('test-key');
+    const { korail, fallback, composite } = setup();
     jest.spyOn(korail, 'getArrival').mockResolvedValueOnce(null);
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
 
     const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
 
@@ -82,10 +96,8 @@ describe('CompositeArrivalProvider', () => {
   });
 
   it('Korail provider가 throw해도 fallback으로 흡수', async () => {
-    const korail = new KorailArrivalProvider('test-key');
+    const { korail, fallback, composite } = setup();
     jest.spyOn(korail, 'getArrival').mockRejectedValueOnce(new Error('network'));
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
 
     const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
 
@@ -94,62 +106,41 @@ describe('CompositeArrivalProvider', () => {
   });
 
   it('Korail provider가 throw하고 error가 non-Error 객체여도 fallback', async () => {
-    const korail = new KorailArrivalProvider('test-key');
+    const { korail, composite } = setup();
     jest.spyOn(korail, 'getArrival').mockRejectedValueOnce('string error');
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
 
     const result = await composite.getArrival('왕십리', { lineHint: 'bundang' });
 
     expect(result).toBe(FALLBACK_RESULT);
   });
 
-  it('Korail 노선이지만 API 키 미설정(isAvailable=false) 시 즉시 fallback', async () => {
-    const korail = new KorailArrivalProvider(undefined);
-    const korailSpy = jest.spyOn(korail, 'getArrival');
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
-
-    const result = await composite.getArrival('왕십리', { lineHint: 'gyeongui' });
-
-    expect(result).toBe(FALLBACK_RESULT);
-    expect(korailSpy).not.toHaveBeenCalled();
-  });
-
-  it('서울교통공사 노선(예: 2호선)은 Korail 거치지 않고 fallback 직행', async () => {
-    const korail = new KorailArrivalProvider('test-key');
-    const korailSpy = jest.spyOn(korail, 'getArrival');
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
-
-    const result = await composite.getArrival('강남', { lineHint: '2' });
-
-    expect(result).toBe(FALLBACK_RESULT);
-    expect(korailSpy).not.toHaveBeenCalled();
-  });
-
-  it('lineHint 없을 때 stationName으로 lookup 후 routing', async () => {
-    // '강남'은 2호선/신분당선 — Korail 아님. fallback 직행.
-    const korail = new KorailArrivalProvider('test-key');
-    const korailSpy = jest.spyOn(korail, 'getArrival');
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
-
-    const result = await composite.getArrival('강남');
-
-    expect(result).toBe(FALLBACK_RESULT);
-    expect(korailSpy).not.toHaveBeenCalled();
-  });
-
-  it('lineHint 없고 stationName lookup 실패해도 fallback 직행', async () => {
-    const korail = new KorailArrivalProvider('test-key');
-    const korailSpy = jest.spyOn(korail, 'getArrival');
-    const fallback = makeFallback();
-    const composite = new CompositeArrivalProvider(korail, fallback);
-
-    const result = await composite.getArrival('존재하지않는역');
-
-    expect(result).toBe(FALLBACK_RESULT);
-    expect(korailSpy).not.toHaveBeenCalled();
+  // 데이터 주도: Korail을 거치지 않고 fallback 직행하는 케이스 묶음
+  it.each([
+    {
+      name: 'Korail 노선이지만 API 키 미설정(isAvailable=false) 시 즉시 fallback',
+      stationName: '왕십리',
+      options: { lineHint: 'gyeongui' } as ArrivalOptions | undefined,
+      setupOpts: { korailKeyless: true },
+    },
+    {
+      name: '서울교통공사 노선(예: 2호선)은 Korail 거치지 않고 fallback 직행',
+      stationName: '강남',
+      options: { lineHint: '2' } as ArrivalOptions | undefined,
+      setupOpts: {},
+    },
+    {
+      name: 'lineHint 없을 때 stationName으로 lookup 후 routing (강남=비Korail → fallback)',
+      stationName: '강남',
+      options: undefined as ArrivalOptions | undefined,
+      setupOpts: {},
+    },
+    {
+      name: 'lineHint 없고 stationName lookup 실패해도 fallback 직행',
+      stationName: '존재하지않는역',
+      options: undefined as ArrivalOptions | undefined,
+      setupOpts: {},
+    },
+  ])('$name', async ({ stationName, options, setupOpts }) => {
+    await expectFallbackDirect(stationName, options, setupOpts);
   });
 });

--- a/src/features/arrival/providers/__tests__/KorailArrivalProvider.test.ts
+++ b/src/features/arrival/providers/__tests__/KorailArrivalProvider.test.ts
@@ -1,0 +1,75 @@
+import {
+  KorailArrivalProvider,
+  createKorailArrivalProvider,
+} from '../KorailArrivalProvider';
+
+describe('KorailArrivalProvider', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('isAvailable', () => {
+    it('API 키가 undefined면 false', () => {
+      const provider = new KorailArrivalProvider(undefined);
+      expect(provider.isAvailable).toBe(false);
+    });
+
+    it('API 키가 빈 문자열이면 false', () => {
+      const provider = new KorailArrivalProvider('');
+      expect(provider.isAvailable).toBe(false);
+    });
+
+    it('API 키가 설정되면 true', () => {
+      const provider = new KorailArrivalProvider('test-key');
+      expect(provider.isAvailable).toBe(true);
+    });
+  });
+
+  describe('getArrival', () => {
+    it('API 키가 없으면 null 반환 (graceful)', async () => {
+      const provider = new KorailArrivalProvider(undefined);
+      const result = await provider.getArrival('왕십리');
+      expect(result).toBeNull();
+    });
+
+    it('API 키가 있어도 현 PoC stub 상태에서는 null 반환', async () => {
+      const provider = new KorailArrivalProvider('test-key');
+      const result = await provider.getArrival('왕십리', { lineHint: 'bundang' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createKorailArrivalProvider', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('환경변수 EXPO_PUBLIC_KORAIL_API_KEY를 사용해 인스턴스 생성', () => {
+      process.env.EXPO_PUBLIC_KORAIL_API_KEY = 'env-key';
+      // babel-preset-expo가 EXPO_PUBLIC_* 를 모듈 import 시점에 inline하므로
+      // jest.resetModules() 후 dynamic require로 env-aware하게 로드.
+      const { createKorailArrivalProvider: factory } = require('../KorailArrivalProvider');
+      const provider = factory();
+      expect(provider.isAvailable).toBe(true);
+    });
+
+    it('환경변수 미설정 시 isAvailable=false', () => {
+      delete process.env.EXPO_PUBLIC_KORAIL_API_KEY;
+      const { createKorailArrivalProvider: factory } = require('../KorailArrivalProvider');
+      const provider = factory();
+      expect(provider.isAvailable).toBe(false);
+    });
+  });
+});

--- a/src/features/arrival/providers/__tests__/factory.test.ts
+++ b/src/features/arrival/providers/__tests__/factory.test.ts
@@ -3,6 +3,8 @@
 
 const mockBffConstructor = jest.fn();
 const mockSeoulConstructor = jest.fn();
+const mockCompositeConstructor = jest.fn();
+const mockCreateKorail = jest.fn();
 
 jest.mock('../BffArrivalProvider', () => ({
   BffArrivalProvider: mockBffConstructor,
@@ -10,6 +12,15 @@ jest.mock('../BffArrivalProvider', () => ({
 
 jest.mock('../SeoulOpenApiProvider', () => ({
   SeoulOpenApiProvider: mockSeoulConstructor,
+}));
+
+jest.mock('../CompositeArrivalProvider', () => ({
+  CompositeArrivalProvider: mockCompositeConstructor,
+}));
+
+jest.mock('../KorailArrivalProvider', () => ({
+  createKorailArrivalProvider: mockCreateKorail,
+  KorailArrivalProvider: jest.fn(),
 }));
 
 // factory는 각 테스트마다 환경변수를 바꾼 뒤 동적으로 require해야 하므로
@@ -23,6 +34,8 @@ describe('createArrivalProvider', () => {
     process.env = { ...originalEnv };
     mockBffConstructor.mockClear();
     mockSeoulConstructor.mockClear();
+    mockCompositeConstructor.mockClear();
+    mockCreateKorail.mockClear();
   });
 
   afterEach(() => {
@@ -83,13 +96,54 @@ describe('createArrivalProvider', () => {
     expect(mockSeoulConstructor).toHaveBeenCalled();
     expect(mockBffConstructor).not.toHaveBeenCalled();
   });
+
+  it('EXPO_PUBLIC_USE_KORAIL_FALLBACK=true 시 Composite로 wrap (#1096)', () => {
+    process.env.EXPO_PUBLIC_USE_KORAIL_FALLBACK = 'true';
+    delete process.env.EXPO_PUBLIC_USE_BFF;
+    const fakeKorail = { isAvailable: false };
+    mockCreateKorail.mockReturnValue(fakeKorail);
+
+    const { createArrivalProvider } = require('../factory');
+    createArrivalProvider();
+
+    expect(mockCreateKorail).toHaveBeenCalled();
+    expect(mockCompositeConstructor).toHaveBeenCalledTimes(1);
+    expect(mockSeoulConstructor).toHaveBeenCalled();
+  });
+
+  it('EXPO_PUBLIC_USE_KORAIL_FALLBACK=true + BFF 활성 시 BFF를 fallback으로 wrap', () => {
+    process.env.EXPO_PUBLIC_USE_KORAIL_FALLBACK = 'true';
+    process.env.EXPO_PUBLIC_USE_BFF = 'true';
+    process.env.EXPO_PUBLIC_BFF_URL = 'https://bff.example.com';
+    mockCreateKorail.mockReturnValue({ isAvailable: false });
+
+    const { createArrivalProvider } = require('../factory');
+    createArrivalProvider();
+
+    expect(mockBffConstructor).toHaveBeenCalledWith('https://bff.example.com');
+    expect(mockCompositeConstructor).toHaveBeenCalledTimes(1);
+    expect(mockSeoulConstructor).not.toHaveBeenCalled();
+  });
+
+  it('EXPO_PUBLIC_USE_KORAIL_FALLBACK 미설정 시 Composite 미사용', () => {
+    delete process.env.EXPO_PUBLIC_USE_KORAIL_FALLBACK;
+
+    const { createArrivalProvider } = require('../factory');
+    createArrivalProvider();
+
+    expect(mockCompositeConstructor).not.toHaveBeenCalled();
+    expect(mockCreateKorail).not.toHaveBeenCalled();
+  });
 });
 
 describe('features/arrival/providers/index re-exports', () => {
-  it('should export SeoulOpenApiProvider, BffArrivalProvider, MockArrivalProvider', () => {
+  it('should export SeoulOpenApiProvider, BffArrivalProvider, MockArrivalProvider, KorailArrivalProvider, CompositeArrivalProvider', () => {
     const arrivalIndex = require('../index');
     expect(arrivalIndex.SeoulOpenApiProvider).toBeDefined();
     expect(arrivalIndex.BffArrivalProvider).toBeDefined();
     expect(arrivalIndex.MockArrivalProvider).toBeDefined();
+    expect(arrivalIndex.KorailArrivalProvider).toBeDefined();
+    expect(arrivalIndex.createKorailArrivalProvider).toBeDefined();
+    expect(arrivalIndex.CompositeArrivalProvider).toBeDefined();
   });
 });

--- a/src/features/arrival/providers/factory.ts
+++ b/src/features/arrival/providers/factory.ts
@@ -1,14 +1,22 @@
 import type { ArrivalProvider } from './types';
 import { SeoulOpenApiProvider } from './SeoulOpenApiProvider';
 import { BffArrivalProvider } from './BffArrivalProvider';
+import { CompositeArrivalProvider } from './CompositeArrivalProvider';
+import { createKorailArrivalProvider } from './KorailArrivalProvider';
 
 export function createArrivalProvider(): ArrivalProvider {
   const useBff = process.env.EXPO_PUBLIC_USE_BFF === 'true';
   const bffUrl = process.env.EXPO_PUBLIC_BFF_URL;
 
-  if (useBff && bffUrl) {
-    return new BffArrivalProvider(bffUrl);
+  const base: ArrivalProvider = useBff && bffUrl
+    ? new BffArrivalProvider(bffUrl)
+    : new SeoulOpenApiProvider();
+
+  // #1096: 코레일 fallback을 명시 게이트(EXPO_PUBLIC_USE_KORAIL_FALLBACK=true)로 활성화.
+  // 미설정 시 기존 동작 그대로 — Composite는 wrapper일 뿐 기본 경로에 영향 없음.
+  if (process.env.EXPO_PUBLIC_USE_KORAIL_FALLBACK === 'true') {
+    return new CompositeArrivalProvider(createKorailArrivalProvider(), base);
   }
 
-  return new SeoulOpenApiProvider();
+  return base;
 }

--- a/src/features/arrival/providers/index.ts
+++ b/src/features/arrival/providers/index.ts
@@ -1,3 +1,5 @@
 export { SeoulOpenApiProvider } from './SeoulOpenApiProvider';
 export { BffArrivalProvider } from './BffArrivalProvider';
 export { MockArrivalProvider } from './MockProvider';
+export { KorailArrivalProvider, createKorailArrivalProvider } from './KorailArrivalProvider';
+export { CompositeArrivalProvider } from './CompositeArrivalProvider';

--- a/src/shared/constants/__tests__/lineOperators.test.ts
+++ b/src/shared/constants/__tests__/lineOperators.test.ts
@@ -1,0 +1,54 @@
+import {
+  LINE_OPERATORS,
+  getLineOperator,
+  isKorailLine,
+} from '../lineOperators';
+import type { LineNumber } from '../../types/station';
+
+describe('lineOperators', () => {
+  it('LINE_OPERATORS는 모든 LineNumber에 대해 운영사를 매핑한다', () => {
+    const lines: LineNumber[] = [
+      '1', '2', '3', '4', '5', '6', '7', '8', '9',
+      'airport', 'gyeongui', 'bundang', 'sinbundang',
+    ];
+    for (const line of lines) {
+      expect(LINE_OPERATORS[line]).toBeDefined();
+    }
+  });
+
+  it('1~9호선은 seoul 운영사로 매핑된다', () => {
+    expect(getLineOperator('1')).toBe('seoul');
+    expect(getLineOperator('2')).toBe('seoul');
+    expect(getLineOperator('3')).toBe('seoul');
+    expect(getLineOperator('4')).toBe('seoul');
+    expect(getLineOperator('5')).toBe('seoul');
+    expect(getLineOperator('6')).toBe('seoul');
+    expect(getLineOperator('7')).toBe('seoul');
+    expect(getLineOperator('8')).toBe('seoul');
+    expect(getLineOperator('9')).toBe('seoul');
+  });
+
+  it('경의중앙선/수인분당선은 korail 운영사로 매핑된다', () => {
+    expect(getLineOperator('gyeongui')).toBe('korail');
+    expect(getLineOperator('bundang')).toBe('korail');
+  });
+
+  it('공항철도/신분당선은 other 운영사로 매핑된다', () => {
+    expect(getLineOperator('airport')).toBe('other');
+    expect(getLineOperator('sinbundang')).toBe('other');
+  });
+
+  describe('isKorailLine', () => {
+    it('Korail 운영 노선만 true', () => {
+      expect(isKorailLine('gyeongui')).toBe(true);
+      expect(isKorailLine('bundang')).toBe(true);
+    });
+
+    it('비-Korail 노선은 false', () => {
+      expect(isKorailLine('1')).toBe(false);
+      expect(isKorailLine('9')).toBe(false);
+      expect(isKorailLine('airport')).toBe(false);
+      expect(isKorailLine('sinbundang')).toBe(false);
+    });
+  });
+});

--- a/src/shared/constants/lineOperators.ts
+++ b/src/shared/constants/lineOperators.ts
@@ -1,0 +1,45 @@
+/**
+ * 노선 → 운영사 매핑 (#1096 PoC).
+ *
+ * 서울 열린데이터 API(서울교통공사)는 코레일 운영 구간(경의중앙, 수인분당 등)에서 데이터
+ * 품질 격차가 있어, 코레일 자체 API를 1차로 시도하고 실패 시 서울 OD로 fallback하는 routing의
+ * 기반 데이터다.
+ *
+ * 매핑 원칙: "해당 노선의 다수 구간을 누가 운영하는가" 기준.
+ * - 1~8호선: 서울교통공사 (Seoul Metro)
+ * - 9호선: 서울시메트로9호선㈜ — 서울 OD가 정식 데이터 제공자라 'seoul'로 묶는다
+ * - 경의중앙선, 수인분당선: 한국철도공사 (Korail)
+ * - 공항철도: 공항철도㈜ (서울/코레일 모두 아님) — 서울 OD 사용
+ * - 신분당선: 네오트랜스/새서울철도 — 서울 OD 사용
+ *
+ * 새 운영사 추가 시 LineOperator 유니온과 LINE_OPERATORS 매핑만 확장.
+ */
+
+import type { LineNumber } from '../types/station';
+
+export type LineOperator = 'seoul' | 'korail' | 'other';
+
+export const LINE_OPERATORS: Record<LineNumber, LineOperator> = {
+  '1': 'seoul',
+  '2': 'seoul',
+  '3': 'seoul',
+  '4': 'seoul',
+  '5': 'seoul',
+  '6': 'seoul',
+  '7': 'seoul',
+  '8': 'seoul',
+  '9': 'seoul',
+  airport: 'other',
+  gyeongui: 'korail',
+  bundang: 'korail',
+  sinbundang: 'other',
+};
+
+export function getLineOperator(line: LineNumber): LineOperator {
+  return LINE_OPERATORS[line];
+}
+
+/** Korail 자체 API로 1차 조회를 시도해야 하는 노선인지. */
+export function isKorailLine(line: LineNumber): boolean {
+  return LINE_OPERATORS[line] === 'korail';
+}


### PR DESCRIPTION
## Summary

#1096 P0 PoC. 서울 OD 실시간 도착 API의 코레일 구간(경의중앙·수인분당 등) 품질 격차를 완화하기 위한 routing 인프라.

- `lineOperators` 상수로 노선 → 운영사(`seoul`/`korail`/`other`) 매핑
- `KorailArrivalProvider`: 한국철도공사 열차운행정보 API stub
- `CompositeArrivalProvider`: Korail 노선만 1차 시도, null/throw 시 기존 provider로 graceful fallback
- `EXPO_PUBLIC_USE_KORAIL_FALLBACK=true` 게이트 — 미설정 시 기존 동작 100% 보존

## 제한 / 후속

API 키 미발급 상태 — `KorailArrivalProvider.getArrival`은 현재 명시적으로 `null` 반환(stub). Composite routing 자체는 작동(테스트로 검증), 실제 endpoint 호출 + 응답 → `StationArrival` 정규화는 키 발급 후 후속 PR에서 구현.

## 운영사 매핑

| 노선 | 운영사 |
|---|---|
| 1~9호선 | seoul |
| 경의중앙, 수인분당 | **korail** |
| 공항철도, 신분당선 | other |

## Test plan

- [x] `lineOperators` 매핑 검증 (총 13개 노선)
- [x] `KorailArrivalProvider` 키 유무에 따른 isAvailable/null 응답
- [x] `CompositeArrivalProvider` routing — Korail hit / null fallback / throw fallback / 비-Korail 직행 / lineHint 없을 때 lookup
- [x] `createArrivalProvider` env 게이트 (USE_KORAIL_FALLBACK + BFF 조합)
- [x] `npm run type-check` 통과
- [ ] 실 API 키 발급 후 endpoint 매핑 (후속 PR)

Closes #1096 (PoC 범위)