### PR TITLE
fix(#1090): 워크트리 생성 시 node_modules 자동 npm install (symlink 금지)

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: worktree
+description: "git worktree로 이슈별 격리 작업 환경 생성/관리. '워크트리 만들어줘', 'wt new', '새 작업 격리', '이슈 격리', '워크트리 정리', '워크트리 목록' 요청 시 트리거."
+allowed-tools: Bash
+argument-hint: "[new <이슈번호> <타입> <기능명> | list | clean <이슈번호>]"
+---
+
+## 목적
+
+이슈별로 완전히 격리된 git worktree를 생성해 병렬 작업 시 파일 충돌을 방지한다.
+각 이슈는 독립된 디렉토리에서 작업하므로 테스트/파일 수정이 서로 영향을 주지 않는다.
+
+## 트리거 조건
+
+- "워크트리 만들어줘", "wt new", "새 작업 격리", "이슈 격리"
+- "워크트리 목록", "wt list"
+- "워크트리 정리", "wt clean"
+
+## 핵심 룰 (필수)
+
+### node_modules는 반드시 실제 `npm install` (symlink 금지)
+
+워크트리 생성 시 시간 절약을 이유로 `ln -s ../subway-now/node_modules node_modules` 패턴을
+**절대 사용하지 않는다.** 본 프로젝트는 로컬 expo modules(`modules/live-activity`,
+`modules/audio-route`, `modules/motion-activity`, `modules/wifi-ssid`)를 다음과 같이 상대
+심링크로 등록한다:
+
+```
+node_modules/live-activity → ../modules/live-activity
+```
+
+워크트리에서 `node_modules`를 메인 repo로 심링크하면 위 상대 경로가 **메인 repo의 modules/**로
+해석되고, 워크트리 소스의 `jest.mock('../../../../../modules/live-activity', ...)`은 워크트리
+경로로 resolve된다. Jest는 mock을 absolute path 키로 보관하므로 두 경로가 달라지면 mock이
+적용되지 않아 **광역 테스트 false positive**(이슈 #1090: 35건 실패)가 발생한다.
+
+따라서 워크트리 생성 시 **항상** 다음을 자동 실행한다:
+
+```bash
+npm install --prefer-offline --no-audit --no-fund
+```
+
+(`npm ci`는 `package-lock.json` 외 로컬 expo modules 링크를 새로 만들지 않을 수 있어 사용하지 않는다.)
+
+### 검증
+
+생성 후 다음 명령으로 실제 install 여부와 mock-resolve 안전성을 확인한다:
+
+```bash
+# 1. node_modules가 심링크가 아닌 실제 디렉토리인지
+test -L node_modules && echo "FAIL: symlink" || echo "OK: real dir"
+
+# 2. live-activity가 워크트리 내부 경로로 resolve 되는지
+node -e "console.log(require.resolve('live-activity'))"
+# 결과가 워크트리 디렉토리 안 경로여야 함 (메인 repo 경로면 FAIL)
+```
+
+위 둘 중 하나라도 실패하면 `rm -rf node_modules && npm install --prefer-offline --no-audit --no-fund`로 복구한다.
+
+## 절차
+
+### 요청 유형 판단
+
+사용자 요청에서 의도를 파악:
+- 생성 요청 → **[생성]** 절차
+- 목록 확인 → **[목록]** 절차
+- 정리 요청 → **[정리]** 절차
+
+---
+
+### [생성] 새 워크트리 만들기
+
+**1단계: 인자 확인**
+
+이슈번호, 타입, 기능명이 제공되지 않은 경우 질문:
+- 이슈번호: GitHub 이슈 번호 (예: 68)
+- 타입: `feat` | `fix` | `chore` | `refactor`
+- 기능명: 브랜치 이름에 쓸 영문 kebab-case (예: widget-destination)
+
+**2단계: 워크트리 생성 + 자동 install**
+
+```bash
+bash .claude/skills/worktree/scripts/wt-new.sh <이슈번호> <타입> <기능명>
+```
+
+이 스크립트는 다음을 순차 실행한다:
+1. `git fetch origin`
+2. `git worktree add ... -b <branch> origin/dev`
+3. **새 워크트리에서 `npm install --prefer-offline --no-audit --no-fund`** (symlink 금지 룰 강제)
+4. 검증: `node_modules`가 심링크가 아닌지, `live-activity`가 워크트리 내부로 resolve 되는지
+
+install 실패 시 워크트리 자체는 유지하되 명확히 보고한다(사용자가 재시도 가능).
+
+**3단계: 결과 안내**
+
+```
+✅ 워크트리 생성 완료
+브랜치: <타입>/#<이슈번호>-<기능명>
+경로:   ../subway-now-issue<이슈번호>
+node_modules: real install (npm install 완료)
+
+새 터미널에서:
+  cd ../subway-now-issue<이슈번호> && claude
+```
+
+---
+
+### [목록] 워크트리 확인
+
+```bash
+bash .claude/skills/worktree/scripts/wt-list.sh
+```
+
+현재 활성 워크트리 목록과 각 브랜치를 출력한다.
+
+---
+
+### [정리] 워크트리 제거
+
+**1단계: 이슈번호 확인**
+
+제공되지 않은 경우 현재 목록을 보여주고 질문.
+
+**2단계: 워크트리 제거**
+
+```bash
+bash .claude/skills/worktree/scripts/wt-clean.sh <이슈번호>
+```
+
+## 자체 검증
+
+- [ ] 이슈번호/타입/기능명이 모두 확인되었는가
+- [ ] 브랜치명이 `<타입>/#<이슈번호>-<기능명>` 형식인가
+- [ ] origin/dev 기준으로 생성되었는가
+- [ ] **`npm install` 자동 실행되어 `node_modules`가 실제 디렉토리인가 (symlink 아님)**
+- [ ] **`require.resolve('live-activity')`가 워크트리 내부 경로를 반환하는가**
+- [ ] 생성 경로가 올바르게 안내되었는가
+
+## 관련 이슈/메모
+
+- 이슈 #1090 — 워크트리 symlink로 jest 35건 false positive
+- 메모: `feedback_worktree_for_isolation.md` — "node_modules는 symlink 말고 실제 install"

--- a/.claude/skills/worktree/scripts/wt-clean.sh
+++ b/.claude/skills/worktree/scripts/wt-clean.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# 완료된 워크트리 정리
+# 사용법: wt-clean.sh <이슈번호>
+# 예시:   wt-clean.sh 68
+
+set -e
+
+ISSUE=$1
+
+if [ -z "$ISSUE" ]; then
+  echo "사용법: wt-clean.sh <이슈번호>"
+  echo "예시:   wt-clean.sh 68"
+  echo ""
+  echo "현재 워크트리 목록:"
+  git worktree list
+  exit 1
+fi
+
+PROJECT_DIR=$(git -C "$(pwd)" rev-parse --show-toplevel)
+PROJECT_NAME=$(basename "$PROJECT_DIR")
+WORKTREE_DIR="${PROJECT_DIR}/../${PROJECT_NAME}-issue${ISSUE}"
+
+if [ ! -d "$WORKTREE_DIR" ]; then
+  echo "❌ 워크트리를 찾을 수 없음: $WORKTREE_DIR"
+  exit 1
+fi
+
+echo "🗑️  워크트리 제거: $WORKTREE_DIR"
+git worktree remove "$WORKTREE_DIR" --force
+echo "✅ 완료"

--- a/.claude/skills/worktree/scripts/wt-list.sh
+++ b/.claude/skills/worktree/scripts/wt-list.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# 현재 워크트리 목록 확인
+git worktree list

--- a/.claude/skills/worktree/scripts/wt-new.sh
+++ b/.claude/skills/worktree/scripts/wt-new.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# 새 격리된 워크트리 생성 + node_modules 실제 install (symlink 금지)
+# 사용법: wt-new.sh <이슈번호> <타입> <기능명>
+# 예시:   wt-new.sh 68 feat widget-destination
+#         wt-new.sh 69 fix arrival-crash
+#
+# 본 스크립트는 이슈 #1090(워크트리 symlink 시 jest 35건 false positive)을 막기 위해
+# `npm install`을 항상 자동 실행한다. node_modules symlink는 절대 사용하지 않는다.
+
+set -e
+
+ISSUE=$1
+TYPE=$2
+NAME=$3
+
+if [ -z "$ISSUE" ] || [ -z "$TYPE" ] || [ -z "$NAME" ]; then
+  echo "사용법: wt-new.sh <이슈번호> <타입> <기능명>"
+  echo "예시:   wt-new.sh 68 feat widget-destination"
+  exit 1
+fi
+
+BRANCH="${TYPE}/#${ISSUE}-${NAME}"
+PROJECT_DIR=$(git -C "$(pwd)" rev-parse --show-toplevel)
+PROJECT_NAME=$(basename "$PROJECT_DIR")
+WORKTREE_DIR="${PROJECT_DIR}/../${PROJECT_NAME}-issue${ISSUE}"
+
+echo "📁 워크트리 생성 중..."
+echo "  브랜치: $BRANCH"
+echo "  경로:   $WORKTREE_DIR"
+
+# dev 최신화 후 워크트리 생성
+cd "$PROJECT_DIR"
+git fetch origin
+git worktree add "$WORKTREE_DIR" -b "$BRANCH" origin/dev
+
+# ─────────────────────────────────────────────────────────────
+# node_modules 실제 install (symlink 금지 — 이슈 #1090)
+# ─────────────────────────────────────────────────────────────
+echo ""
+echo "📦 npm install 실행 중 (symlink 금지, 실제 install)..."
+echo "   사유: node_modules symlink 시 로컬 expo modules 상대 심링크가"
+echo "         메인 repo로 해석되어 jest mock이 매칭되지 않음 (#1090)."
+
+cd "$WORKTREE_DIR"
+
+# 혹시라도 워크트리에 symlink가 미리 만들어진 경우 제거
+if [ -L node_modules ]; then
+  echo "⚠️  기존 node_modules symlink 감지 — 제거 후 실제 install"
+  rm node_modules
+fi
+
+if npm install --prefer-offline --no-audit --no-fund; then
+  echo "✅ npm install 완료"
+else
+  echo "❌ npm install 실패 — 워크트리는 유지되었으니 수동으로 재시도하세요:"
+  echo "   cd $WORKTREE_DIR && npm install --prefer-offline --no-audit --no-fund"
+  exit 1
+fi
+
+# ─────────────────────────────────────────────────────────────
+# 검증
+# ─────────────────────────────────────────────────────────────
+echo ""
+echo "🔍 검증 중..."
+
+if [ -L node_modules ]; then
+  echo "❌ FAIL: node_modules가 여전히 symlink 입니다. 수동 점검 필요."
+  exit 1
+fi
+echo "  ✓ node_modules는 실제 디렉토리"
+
+RESOLVED=$(node -e "console.log(require.resolve('live-activity'))" 2>/dev/null || echo "")
+if [ -z "$RESOLVED" ]; then
+  echo "  ⚠️  live-activity resolve 실패 (선택적 모듈일 수 있음 — 무시)"
+elif [[ "$RESOLVED" != "$WORKTREE_DIR"* ]]; then
+  echo "❌ FAIL: live-activity가 워크트리 외부로 resolve 됨"
+  echo "   resolved: $RESOLVED"
+  echo "   expected prefix: $WORKTREE_DIR"
+  exit 1
+else
+  echo "  ✓ live-activity resolve OK ($RESOLVED)"
+fi
+
+echo ""
+echo "✅ 완료! 아래 명령으로 이동하세요:"
+echo ""
+echo "  cd $WORKTREE_DIR && claude"
+echo ""

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,11 @@ coverage/
 .idea/
 
 # Claude Code
-.claude/
+.claude/*
+# 워크트리 스킬은 팀 공통 (#1090: node_modules symlink 금지 자동화)
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/worktree/
 
 # Maestro E2E 산출물
 .maestro/screenshots/


### PR DESCRIPTION
Closes #1090

## 배경

이번 세션에 워크트리(`subway-now-issue*`)에서 시간 절약을 위해 `node_modules`를 메인 repo로 symlink하는 패턴 때문에 **jest 35건 false positive**가 발생. PR #1083/#1084/#1085/#1086에서 "origin/dev에서도 동일 재현"이라 보고된 실패가 모두 동일 원인이었다.

근본: 로컬 expo modules(`live-activity` 등)는 `node_modules/live-activity → ../modules/live-activity` 상대 심링크. 워크트리에서 `node_modules`를 symlink하면 위 상대 경로가 메인 repo로 해석되고, 워크트리 소스의 `jest.mock('../../../../../modules/live-activity', ...)`은 워크트리 경로로 resolve → 두 absolute path가 달라 mock 미적용 → 35건 fail.

## 변경 내역

- `.claude/skills/worktree/SKILL.md`: 글로벌 worktree 스킬을 프로젝트 레벨로 override. "node_modules symlink 금지" 룰 + 원인 + 검증 명령(`node -e "require.resolve('live-activity')"`) 명시
- `.claude/skills/worktree/scripts/wt-new.sh`: `git worktree add` 직후 자동으로 `npm install --prefer-offline --no-audit --no-fund` 실행. 기존 symlink 감지 시 제거. install 후 `node_modules`가 실제 디렉토리인지 + `live-activity`가 워크트리 내부로 resolve 되는지 자동 검증
- `.claude/skills/worktree/scripts/wt-{list,clean}.sh`: 글로벌과 동일 (그대로 복사)
- `.gitignore`: `.claude/skills/worktree/`만 추적(나머지 `.claude/` 산출물은 계속 ignore)

## 자동화 방식

skill text 가이드 + helper script(`wt-new.sh`) 양쪽. 사용자가 skill을 호출하면 항상 `npm install`이 강제 실행되어 symlink 우회 불가.

## 일관성

- 메모리 `feedback_worktree_for_isolation.md`의 "node_modules는 symlink 말고 실제 install" 룰을 자동화로 강제
- src/ 코드 변경 없음 (`.claude/` + `.gitignore` 메타 변경만)

## 검증 계획

- [ ] 새 워크트리 생성 → `wt-new.sh` 실행 → `node_modules`가 symlink 아닌 실제 디렉토리
- [ ] 워크트리에서 `npx jest src/features/widget/api/__tests__/widgetStorage.test.ts` → 0 fail
- [ ] `node -e "console.log(require.resolve('live-activity'))"` 결과가 워크트리 내부 경로