### PR TITLE
chore(#1110): 환승소요 데이터 사전조사 결과 + build script 경로 fix

### DIFF
--- a/scripts/build-transfer-times.js
+++ b/scripts/build-transfer-times.js
@@ -16,7 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 // 정규화 SSOT — stationRoute.ts와 동일 로직 보장.
-const { normalizeStationName } = require('../src/utils/normalizeStationName');
+const { normalizeStationName } = require('../src/shared/utils/normalizeStationName');
 
 const CSV_PATH = path.join(
   __dirname,


### PR DESCRIPTION
Closes #1110

## 요약

#1097 P0-B (환승역거리/소요시간 데이터) **사전조사 결과: 이미 구현 완료**. 잔여 잡일로 깨진 build script만 surgical 수정.

## 사전조사 결론

| 항목 | 위치 | 상태 |
|---|---|---|
| 원본 CSV (서울교통공사_환승역거리_20250331) | `scripts/서울교통공사_환승역거리 소요시간 정보_20250331.csv` | 145 row |
| Build script | `scripts/build-transfer-times.js` | **import 경로 stale** → 본 PR fix |
| 가공 데이터 | `src/data/transferTimes.json` | 175 entries (양방향) |
| Lookup | `src/shared/utils/stationRoute.ts:660` `getTransferSeconds()` | direct/transfer/multi-transfer ETA에 합산 |
| Fallback | `FALLBACK_TRANSFER_SECONDS = 180` (3분) | 미등록 환승역 |

이 데이터는 이슈 #654 시리즈에서 production 반영됨:
- `60b7402 feat(#654): 환승역 실제 시간 데이터 도입 (Phase 1a)`
- `329d59b fix(#654): build-transfer-times.js sort에 localeCompare 적용`
- `96828ec chore(#654): transferTimes.json 재생성 (dev 동기화)`

따라서 **PoC 별도 구현 불요**. 새 데이터 fetch 스크립트도 의미 없음(이미 import 완료).

## 데이터 소스 / 라이선스

- 출처: [공공데이터포털 15044419 — 서울교통공사 환승역거리 소요시간 정보](https://www.data.go.kr/data/15044419/fileData.do)
- 측정 기준: 보행속도 1.2 m/s
- 라이선스: 공공누리 제1유형 (출처표시), 무료
- 정적 데이터 (스냅샷 20250331) — 갱신 불요, 향후 새 스냅샷 공지 시 CSV 교체 후 `node scripts/build-transfer-times.js` 재실행

## 발견 잔여 작업 (본 PR 해결)

ADR Phase 5 (#894 등) 디렉토리 재정비로 `normalizeStationName` 모듈이 `src/utils/` → `src/shared/utils/`로 이전됐는데 build script가 미동기화되어 **현재 재실행 시 즉시 MODULE_NOT_FOUND**.

```diff
- const { normalizeStationName } = require('../src/utils/normalizeStationName');
+ const { normalizeStationName } = require('../src/shared/utils/normalizeStationName');
```

검증:
- `node scripts/build-transfer-times.js` 성공: 매칭 125건, 양방향 173 키
- 재생성 결과 `src/data/transferTimes.json`은 dev와 byte-identical (`git diff` empty) → idempotent
- 매칭 실패 샘플 2건 (`4↔7|총신대입구`, `7↔4|이수`): 4호선 총신대입구 ↔ 7호선 이수 환승 — stations.json에는 line별로 다른 이름(`총신대입구(이수)` vs `이수`)으로 등록되어 정규화 후에도 mismatch. 별도 이슈 후보지만 본 PR 범위 외.

## 변경

- `scripts/build-transfer-times.js`: import 경로 1줄

## 테스트

- `npm run type-check` 통과
- `npm test -- --testPathPattern="stationRoute"` 172 passed (기존 환승 시간 로직 회귀 없음)
- coverage: scripts/는 `collectCoverageFrom` 대상 외라 영향 없음

## 다음 단계 제안 (#1097 후속)

별도 이슈로 분리 권장:
1. **P0-A 혼잡도 평균(시간대별)** — 정적 import 가능, KV 캐싱 backend 패턴 재활용
2. **P0-C 첫차/막차 시간표** — 취침 모드 알람 정확도 직결
3. **P0-D 출구별 주요시설** — exitSide 보조
4. 4↔7 총신대입구↔이수 환승 매칭 실패 — `stations.json`의 별칭 컬럼 또는 환승 alias map으로 fix

## 머지

- 머지 금지 (사용자 전담)