### PR TITLE
chore: daily test cron 워크플로우 추가

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -1,0 +1,46 @@
+name: Daily Test
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # UTC 00:00 = KST 09:00
+  workflow_dispatch:
+
+jobs:
+  data-validation:
+    name: Data Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: stations.json + lineTopology 검증
+        run: node scripts/validate-stations.js
+
+  test:
+    name: Type Check & Test
+    needs: [data-validation]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 의존성 설치
+        run: npm ci --legacy-peer-deps
+
+      - name: TypeScript 타입 체크
+        run: npm run type-check
+
+      - name: 단위 테스트 실행 (커버리지 100% 검증)
+        run: npm test -- --ci --forceExit


### PR DESCRIPTION
## Summary

- 매일 UTC 00:00 (KST 09:00)에 자동으로 테스트를 실행하는 cron 워크플로우 추가
- `workflow_dispatch`로 수동 트리거도 지원
- 기존 `ci.yml`과 동일한 구조: data-validation → type-check → test

## Test plan

- [x] GitHub Actions 탭에서 워크플로우 수동 트리거(`workflow_dispatch`) 실행 확인
- [x] `npm test` 정상 통과 확인

Closes #1115