### PR TITLE
chore(#1119): ci.yml SKIP_RE에 .claude/ 디렉토리 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           # - src/data/       : 정적 데이터. mock smoke는 stations.json을 우회 (강남 fixture 단락)
           # - src/features/<slice>/tasks/ : expo-task-manager backed BG task. mock smoke와 무관(FG only).
           # - src/__tests__/, src/**/__tests__/ : 테스트 코드는 앱 번들 미포함, jest로 별도 검증
-          SKIP_RE='^(src/shared/i18n/|src/shared/types/|src/testUtils/|src/data/|src/features/[^/]+/types/|src/features/[^/]+/tasks/|src/(.+/)?__tests__/|backend/|docs/|scripts/|tasks/|img/|subway/|locales/|__mocks__/|\.maestro/manual/|\.maestro/flows/(gps|scenario)/|\.github/workflows/(e2e|ci)\.yml$|eas\.json$|jest\.setup\.js$|sonar-project\.properties$|\.env\.example$|\.gitignore$|\.prettierrc.*$|\.eslintrc.*$|\.editorconfig$|.*\.md$|.*\.txt$)'
+          SKIP_RE='^(src/shared/i18n/|src/shared/types/|src/testUtils/|src/data/|src/features/[^/]+/types/|src/features/[^/]+/tasks/|src/(.+/)?__tests__/|backend/|docs/|scripts/|tasks/|img/|subway/|locales/|__mocks__/|\.claude/|\.maestro/manual/|\.maestro/flows/(gps|scenario)/|\.github/workflows/(e2e|ci)\.yml$|eas\.json$|jest\.setup\.js$|sonar-project\.properties$|\.env\.example$|\.gitignore$|\.prettierrc.*$|\.eslintrc.*$|\.editorconfig$|.*\.md$|.*\.txt$)'
           relevant=$(echo "$files" | grep -v '^$' | grep -vE "$SKIP_RE" || true)
           if [ -z "$relevant" ] && [ -n "$files" ]; then
             echo "ui_affected=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 요약

- `.claude/` 파일만 변경된 PR도 E2E smoke가 트리거되어 불필요한 macOS runner(~25분) 소모 발생
- `changes` job의 `SKIP_RE` 패턴에 `\.claude/` 추가로 해결
- PR #1108 (fix/#1090-worktree-npm-install)이 `.claude/CLAUDE.md` 등 내부 파일만 수정했는데 E2E가 트리거된 것이 발단 사례

## 변경 내용

`.github/workflows/ci.yml` SKIP_RE에 `\.claude/` 패턴 추가

## 테스트 플랜

- [x] CI `Type Check & Test` 통과 확인
- [x] E2E smoke가 `.claude/` 파일만 변경된 PR에서 스킵되는지 확인 (`ui_affected=false`)

Closes #1119