### PR TITLE
fix(#1117): E2E 5일 연속 FAIL — ios/.xcode.env.local 없음 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,9 @@ jobs:
       - name: Mock env를 Xcode build phase로 주입
         # xcodebuild → build phase → Metro 체인의 env 전파 누락에 대비.
         # Expo의 with-environment.sh가 .xcode.env.local을 소싱하므로 여기 export 추가.
+        # ios/.xcode.env.local은 .gitignore 대상이라 CI에 존재하지 않음 → touch로 먼저 생성.
         run: |
+          touch ios/.xcode.env.local
           echo 'export EXPO_PUBLIC_E2E_MOCK=true' >> ios/.xcode.env.local
           cat ios/.xcode.env.local
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -236,7 +236,9 @@ jobs:
         # Expo의 with-environment.sh가 .xcode.env.local을 소싱하므로 여기 export.
         # EXPO_PUBLIC_DEBUG_MODAL은 Seam D 시나리오 전용이지만 release 빌드는 시나리오와
         # 무관하게 1회 캐시되므로 모든 시나리오에 동일하게 주입(다른 시나리오는 7-tap을 안 함).
+        # ios/.xcode.env.local은 .gitignore 대상이라 CI에 존재하지 않음 → touch로 먼저 생성.
         run: |
+          touch ios/.xcode.env.local
           {
             echo 'export EXPO_PUBLIC_USE_BFF=true'
             echo 'export EXPO_PUBLIC_BFF_URL=http://localhost:8788'
@@ -402,7 +404,9 @@ jobs:
         run: node scripts/permission-matrix-runner.js --cell ${{ matrix.cell }} --dry-run
 
       - name: E2E mock 빌드-time env 주입
+        # ios/.xcode.env.local은 .gitignore 대상이라 CI에 존재하지 않음 → touch로 먼저 생성.
         run: |
+          touch ios/.xcode.env.local
           echo 'export EXPO_PUBLIC_E2E_MOCK=1' >> ios/.xcode.env.local
           cat ios/.xcode.env.local
 


### PR DESCRIPTION
## 원인 진단

`e2e.yml`과 `ci.yml`의 env 주입 스텝에서 `ios/.xcode.env.local` 파일이 없는 상태에서 `>>` append를 시도해 즉시 exit 1.

```
ios/.xcode.env.local: No such file or directory
Process completed with exit code 1.
```

**왜 파일이 없는가:**
- `ios/.xcode.env.local`은 `ios/.gitignore`에 등록된 로컬 파일
- CI 체크아웃 시 gitignore 대상 파일은 복원되지 않음
- `expo prebuild`도 `.xcode.env.local`(`.local` 접미사)은 생성하지 않음

**영향 범위:**
- `e2e.yml` `regression` job L239-246: prebuild 전 append 시도
- `e2e.yml` `permission-matrix` job L404-407: prebuild 전 append 시도
- `ci.yml` `e2e-smoke` job L194-199: prebuild 후지만 파일 미생성 상태

**재현 기간:** 2026-06-05 ~ 2026-06-09 (5일 연속 nightly FAIL)

## 수정 내용

세 위치 모두 `>> ios/.xcode.env.local` 전에 `touch ios/.xcode.env.local` 한 줄 추가.

- `ios/` 디렉토리는 git에 체크인되어 있으므로 `mkdir -p` 불필요
- `touch`는 파일이 이미 존재하면 mtime만 갱신 → 로컬 개발 환경에서도 안전

Closes #1117