### PR TITLE
fix(#1079): 위젯 갱신을 destination 게이트에서 분리

### DIFF
--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -858,15 +858,10 @@ describe('stationNotification', () => {
       mockClearWidgetStation.mockResolvedValue(undefined);
     });
 
-    it('updateStationNotification은 saveStationToWidget을 km 단위로 호출한다', async () => {
+    it('updateStationNotification은 saveStationToWidget을 호출하지 않는다 (#1079)', async () => {
+      // 위젯 갱신은 useWidgetMirror가 직접 담당. updateStationNotification은 LA/알림만 담당.
       await updateStationNotification(mockStation, 250);
-      expect(mockSaveStationToWidget).toHaveBeenCalledWith(mockStation, 0.25);
-    });
-
-    it('saveStationToWidget이 실패해도 updateLiveActivity는 호출된다', async () => {
-      mockSaveStationToWidget.mockRejectedValueOnce(new Error('group missing'));
-      await updateStationNotification(mockStation, 100);
-      expect(mockUpdateLiveActivity).toHaveBeenCalled();
+      expect(mockSaveStationToWidget).not.toHaveBeenCalled();
     });
 
     it('clearStationNotification은 위젯을 비우지 않는다 (#1094)', async () => {

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -19,7 +19,6 @@ import { vibrateAlarm, stopVibration } from './alarmSound';
 import { speakAlarm } from './tts';
 import { createLogger } from '../../../shared/utils/logger';
 import { getStationDisplayName, getStationDisplayNameByName } from '../../../shared/utils/stationDisplay';
-import { saveStationToWidget } from '../../widget/api/widgetStorage';
 import { hasFiredPushId } from './firedPushIds';
 import stationsData from '../../../data/stations.json';
 import type { ExitSide } from '../../../shared/types/exitSide';
@@ -382,10 +381,6 @@ export async function updateStationNotification(
   source?: NotificationSource,
 ): Promise<void> {
   notifLogger.info('updateStation:', currentStation.name, `${distanceM}m`, destination ? `→ ${destination.name}` : '');
-
-  await saveStationToWidget(currentStation, distanceM / 1000).catch((e) =>
-    notifLogger.error('위젯 저장 실패:', e),
-  );
 
   if (Platform.OS === 'ios') {
     const liveActivityEnabled = LiveActivity.isLiveActivityEnabled();


### PR DESCRIPTION
## Summary

- `updateStationNotification`에서 `saveStationToWidget` 호출 제거
- 위젯 갱신은 `useWidgetMirror` (#1094)가 GPS fusion 결과를 직접 처리하므로 중복 경로 제거
- `updateStationNotification`은 LA/알림만 담당하도록 단순화

## 원인

`saveStationToWidget`이 `updateStationNotification` 안에 묶여 있었고, 해당 함수는 `!effectiveOrigin || !destination` 게이트를 통과해야만 호출됐다. destination 미설정 또는 HomeScreen 미진입 시 위젯이 "감지 중"에서 갱신되지 않는 P0 버그 발생.

## 수정

PR #1095 (#1094)에서 `useWidgetMirror`가 이미 도입되어 destination/route와 무관하게 GPS 갱신 시마다 위젯을 갱신하고 있다. 이번 PR에서 `updateStationNotification` 내의 중복 호출 경로를 제거하여 책임을 단일화한다.

## Test plan

- [ ] `npm test` 커버리지 100% 통과 확인
- [ ] `npm run type-check` 통과 확인
- [ ] destination 미설정 상태에서 위젯에 현재 역 표시되는지 실기기 검증

Closes #1079