### PR TITLE
fix(#1018): attemptAutoLock confidence gate 추가 (RC1 차단)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { AUTO_LOCK_TTL_MS, attemptAutoLock } from '../autoLock';
+import {
+  AUTO_LOCK_CONFIDENCE_THRESHOLD,
+  AUTO_LOCK_TTL_MS,
+  attemptAutoLock,
+} from '../autoLock';
 import { SWAP_LOCK_TTL_MS } from '../lockSwap';
 import { type ArrivalEntry } from '../seoul';
 import type { Waypoint } from '../types';
 import {
   FIXTURE_NOW as NOW,
   makeSeoulFixture as makeSeoul,
+  makeSeoulFixtureByStation,
   makeTripFixture as makeTrip,
 } from './helpers/testFixtures';
 
@@ -18,7 +23,9 @@ function arrival(overrides: Partial<ArrivalEntry>): ArrivalEntry {
     trainCode: 'T1',
     isUp: true,
     subwayNm: '2호선',
-    arvlCd: 2,
+    // 기본값 arvlCd=1(도착) — confidence gate(#1018)를 의도치 않게 트리거하지 않도록.
+    // arvlCd=2(출발)를 테스트하려면 명시 지정한다.
+    arvlCd: 1,
     ...overrides,
   };
 }
@@ -30,7 +37,7 @@ describe('attemptAutoLock (#916 A1)', () => {
       targetWaypoint: target,
       originStation: '강남',
       direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
       now: NOW,
     });
     expect(lock).not.toBeNull();
@@ -81,7 +88,7 @@ describe('attemptAutoLock (#916 A1)', () => {
       targetWaypoint: { stationName: '역삼', line: 'XX', kind: 'intermediate' },
       originStation: '강남',
       direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
       now: NOW,
     });
     expect(lock).toBeNull();
@@ -95,7 +102,7 @@ describe('attemptAutoLock (#916 A1)', () => {
       targetWaypoint: target, // target.line='2'와 waypoints line='3' 불일치
       originStation: '강남',
       direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
       now: NOW,
     });
     expect(lock).toBeNull();
@@ -108,8 +115,8 @@ describe('attemptAutoLock (#916 A1)', () => {
       originStation: '강남',
       direction: 'down',
       seoul: makeSeoul([
-        arrival({ trainCode: 'TU', arvlCd: 2, isUp: true }),
-        arrival({ trainCode: 'TD', arvlCd: 2, isUp: false }),
+        arrival({ trainCode: 'TU', arvlCd: 1, isUp: true }),
+        arrival({ trainCode: 'TD', arvlCd: 1, isUp: false }),
       ]),
       now: NOW,
     });
@@ -122,7 +129,7 @@ describe('attemptAutoLock (#916 A1)', () => {
       targetWaypoint: target,
       originStation: '강남',
       direction: null,
-      seoul: makeSeoul([arrival({ trainCode: 'TD', arvlCd: 2, isUp: false })]),
+      seoul: makeSeoul([arrival({ trainCode: 'TD', arvlCd: 1, isUp: false })]),
       now: NOW,
     });
     expect(lock?.trainCode).toBe('TD');
@@ -141,9 +148,168 @@ describe('attemptAutoLock (#916 A1)', () => {
       targetWaypoint: { stationName: '강남', line: '2', kind: 'intermediate' },
       originStation: '강남',
       direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
       now: NOW,
     });
     expect(lock?.segmentStations).toEqual(['강남', '역삼']);
+  });
+});
+
+describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
+  it('AUTO_LOCK_CONFIDENCE_THRESHOLD는 2', () => {
+    expect(AUTO_LOCK_CONFIDENCE_THRESHOLD).toBe(2);
+  });
+
+  it('arvlCd=2 + origin에 동일 trainCode 있음 → confidence=2 → 통과', async () => {
+    // next-waypoint: T1이 arvlCd=2 (출발), origin: T1도 보임 → score=2, threshold=2 → pass
+    const seoul = makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: [arrival({ trainCode: 'T1', arvlCd: 1 })],
+    });
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+    });
+    expect(lock).not.toBeNull();
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('arvlCd=2 + origin에 없음 + 신호 없음 → confidence=0 → null', async () => {
+    // next-waypoint: T1이 arvlCd=2, origin: 빈 배열 → score=0 < threshold=2 → null
+    const seoul = makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: [],
+    });
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arvlCd=2 + origin 없음 + boardingPromptState.fired + 최근 motion → confidence=2 → 통과', async () => {
+    // origin 미확인(0) + fired(+1) + lastMotionAt within 3min(+1) = 2 → pass
+    const seoul = makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: [],
+    });
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+      boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
+      lastMotionAt: NOW - 60_000, // 1분 전 — 3분 이내
+    });
+    expect(lock).not.toBeNull();
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('arvlCd=2 + origin 없음 + fired만 있음 → confidence=1 → null', async () => {
+    // origin(0) + fired(+1) = 1 < threshold=2 → null
+    const seoul = makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: [],
+    });
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+      boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
+      // lastMotionAt 미전달
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arvlCd=2 + origin 없음 + 최근 motion만 있음 → confidence=1 → null', async () => {
+    // origin(0) + lastMotionAt(+1) = 1 < threshold=2 → null
+    const seoul = makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: [],
+    });
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+      lastMotionAt: NOW - 60_000,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arvlCd=2 + origin 없음 + motion이 너무 오래됨(>3min) → confidence=0 → null', async () => {
+    const seoul = makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: [],
+    });
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+      boardingPromptState: { fired: false },
+      lastMotionAt: NOW - 4 * 60_000, // 4분 전 — 3분 초과
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arvlCd=1(도착) — confidence gate 미적용, origin fetch 없이 정상 통과', async () => {
+    // arvlCd=2가 아니므로 confidence 체크 자체를 하지 않음 → 기존 경로 유지
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+    });
+    expect(lock).not.toBeNull();
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('arvlCd=0(진입) — confidence gate 미적용, 정상 통과', async () => {
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 0 })]),
+      now: NOW,
+    });
+    expect(lock).not.toBeNull();
+  });
+
+  it('arvlCd=2 + origin에 다른 trainCode만 있음 → confidence=0 → null', async () => {
+    // origin arrivals에는 T2만 있고 T1은 없음 → origin 미확인(0) + 소프트 신호 없음 → null
+    const seoul = makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: [arrival({ trainCode: 'T2', arvlCd: 1 })],
+    });
+    const lock = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
   });
 });

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -156,58 +156,50 @@ describe('attemptAutoLock (#916 A1)', () => {
 });
 
 describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
+  // 공통 헬퍼: 역삼에 T1(arvlCd=2), 강남에 지정된 arrivals를 반환하는 seoul fixture.
+  function makeDepartedSeoul(originArrivals: ArrivalEntry[] = []) {
+    return makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: originArrivals,
+    });
+  }
+
+  // 공통 헬퍼: 기본 confidence gate 테스트 입력 + 선택적 override.
+  function callGate(
+    seoul: ReturnType<typeof makeSeoulFixtureByStation>,
+    extra: Partial<Parameters<typeof attemptAutoLock>[0]> = {},
+  ) {
+    return attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul,
+      now: NOW,
+      ...extra,
+    });
+  }
+
   it('AUTO_LOCK_CONFIDENCE_THRESHOLD는 2', () => {
     expect(AUTO_LOCK_CONFIDENCE_THRESHOLD).toBe(2);
   });
 
   it('arvlCd=2 + origin에 동일 trainCode 있음 → confidence=2 → 통과', async () => {
     // next-waypoint: T1이 arvlCd=2 (출발), origin: T1도 보임 → score=2, threshold=2 → pass
-    const seoul = makeSeoulFixtureByStation({
-      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
-      강남: [arrival({ trainCode: 'T1', arvlCd: 1 })],
-    });
-    const lock = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul,
-      now: NOW,
-    });
+    const lock = await callGate(makeDepartedSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]));
     expect(lock).not.toBeNull();
     expect(lock?.trainCode).toBe('T1');
   });
 
   it('arvlCd=2 + origin에 없음 + 신호 없음 → confidence=0 → null', async () => {
     // next-waypoint: T1이 arvlCd=2, origin: 빈 배열 → score=0 < threshold=2 → null
-    const seoul = makeSeoulFixtureByStation({
-      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
-      강남: [],
-    });
-    const lock = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul,
-      now: NOW,
-    });
+    const lock = await callGate(makeDepartedSeoul());
     expect(lock).toBeNull();
   });
 
   it('arvlCd=2 + origin 없음 + boardingPromptState.fired + 최근 motion → confidence=2 → 통과', async () => {
     // origin 미확인(0) + fired(+1) + lastMotionAt within 3min(+1) = 2 → pass
-    const seoul = makeSeoulFixtureByStation({
-      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
-      강남: [],
-    });
-    const lock = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul,
-      now: NOW,
+    const lock = await callGate(makeDepartedSeoul(), {
       boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
       lastMotionAt: NOW - 60_000, // 1분 전 — 3분 이내
     });
@@ -217,17 +209,7 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=2 + origin 없음 + fired만 있음 → confidence=1 → null', async () => {
     // origin(0) + fired(+1) = 1 < threshold=2 → null
-    const seoul = makeSeoulFixtureByStation({
-      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
-      강남: [],
-    });
-    const lock = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul,
-      now: NOW,
+    const lock = await callGate(makeDepartedSeoul(), {
       boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
       // lastMotionAt 미전달
     });
@@ -236,34 +218,12 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=2 + origin 없음 + 최근 motion만 있음 → confidence=1 → null', async () => {
     // origin(0) + lastMotionAt(+1) = 1 < threshold=2 → null
-    const seoul = makeSeoulFixtureByStation({
-      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
-      강남: [],
-    });
-    const lock = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul,
-      now: NOW,
-      lastMotionAt: NOW - 60_000,
-    });
+    const lock = await callGate(makeDepartedSeoul(), { lastMotionAt: NOW - 60_000 });
     expect(lock).toBeNull();
   });
 
   it('arvlCd=2 + origin 없음 + motion이 너무 오래됨(>3min) → confidence=0 → null', async () => {
-    const seoul = makeSeoulFixtureByStation({
-      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
-      강남: [],
-    });
-    const lock = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul,
-      now: NOW,
+    const lock = await callGate(makeDepartedSeoul(), {
       boardingPromptState: { fired: false },
       lastMotionAt: NOW - 4 * 60_000, // 4분 전 — 3분 초과
     });
@@ -298,18 +258,9 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=2 + origin에 다른 trainCode만 있음 → confidence=0 → null', async () => {
     // origin arrivals에는 T2만 있고 T1은 없음 → origin 미확인(0) + 소프트 신호 없음 → null
-    const seoul = makeSeoulFixtureByStation({
-      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
-      강남: [arrival({ trainCode: 'T2', arvlCd: 1 })],
-    });
-    const lock = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul,
-      now: NOW,
-    });
+    const lock = await callGate(
+      makeDepartedSeoul([arrival({ trainCode: 'T2', arvlCd: 1 })]),
+    );
     expect(lock).toBeNull();
   });
 });

--- a/backend/alarm-worker/src/__tests__/helpers/testFixtures.ts
+++ b/backend/alarm-worker/src/__tests__/helpers/testFixtures.ts
@@ -4,26 +4,54 @@ import type { Trip } from '../../types';
 
 export const FIXTURE_NOW = 1_700_000_000_000;
 
+function buildArrivalList(arrivals: ArrivalEntry[]): unknown {
+  return {
+    realtimeArrivalList: arrivals.map((a) => ({
+      barvlDt: String(a.arrivalSeconds),
+      recptnDt: '',
+      updnLine: a.isUp ? '상행' : '하행',
+      trainLineNm: a.destination,
+      btrainNo: a.trainCode,
+      subwayNm: a.subwayNm,
+      arvlCd: a.arvlCd,
+    })),
+  };
+}
+
 export function makeSeoulFixture(arrivals: ArrivalEntry[]): SeoulArrivalClient {
   return new SeoulArrivalClient({
     apiKey: 'K',
     host: 'h',
     now: () => FIXTURE_NOW,
     fetchImpl: (async () =>
-      new Response(
-        JSON.stringify({
-          realtimeArrivalList: arrivals.map((a) => ({
-            barvlDt: String(a.arrivalSeconds),
-            recptnDt: '',
-            updnLine: a.isUp ? '상행' : '하행',
-            trainLineNm: a.destination,
-            btrainNo: a.trainCode,
-            subwayNm: a.subwayNm,
-            arvlCd: a.arvlCd,
-          })),
-        }),
-        { status: 200 },
-      )) as unknown as typeof fetch,
+      new Response(JSON.stringify(buildArrivalList(arrivals)), {
+        status: 200,
+      })) as unknown as typeof fetch,
+  });
+}
+
+/**
+ * 역 이름별로 다른 arrivals를 반환하는 SeoulArrivalClient fixture.
+ * RC1 confidence gate 테스트처럼 next-waypoint / origin 역 각각 다른 결과가 필요할 때 사용.
+ * 맵에 없는 역명은 빈 배열을 반환한다.
+ */
+export function makeSeoulFixtureByStation(
+  stationMap: Record<string, ArrivalEntry[]>,
+): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => FIXTURE_NOW,
+    fetchImpl: ((url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      // URL 형식: http://host/api/subway/key/json/realtimeStationArrival/0/10/{stationName}
+      const match = urlStr.match(/realtimeStationArrival\/\d+\/\d+\/([^/?]+)/);
+      const stationName = match ? decodeURIComponent(match[1]) : '';
+      const arrivals = stationMap[stationName] ?? [];
+      return Promise.resolve(
+        new Response(JSON.stringify(buildArrivalList(arrivals)), { status: 200 }),
+      );
+    }) as unknown as typeof fetch,
   });
 }
 

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -11,6 +11,9 @@
  *    (정확도, 방향 cosine, fused speed, motion 등 모두 통과 시점에만 호출된다)
  *  - arvlCd 우선순위 (#819 ADR Section 1.2)의 ambiguity 해소 — 같은 우선순위 후보 2개 이상이면
  *    `pickAutoTrainCode`가 null을 반환해 자동 lock을 자연 차단한다 → 다음 cycle에 narrow.
+ *  - RC1 차단 (#1018) — arvlCd=2(출발) at next-waypoint는 origin-pass 후보이므로 origin
+ *    arrival 보조 검증 + boardingPromptState + lastMotionAt으로 confidence를 합산한다.
+ *    confidence < AUTO_LOCK_CONFIDENCE_THRESHOLD면 null 반환 → prompt push fallback.
  *
  * 두 임계가 곱(AND)이라 단일 magic number 대신 "통과한 게이트의 곱"이 threshold다.
  * 본 모듈은 두 신호 양쪽이 모두 만족할 때만 lock 합성을 시도한다.
@@ -20,10 +23,10 @@
  */
 
 import { pickAutoTrainCode } from './boardingPrompt';
-import { subwayIdForLine } from './lineAlias';
+import { matchLine, subwayIdForLine } from './lineAlias';
 import { buildLegSegmentStations, SWAP_LOCK_TTL_MS } from './lockSwap';
 import type { SeoulArrivalClient } from './seoul';
-import type { BoardingLockMeta, Trip, Waypoint } from './types';
+import type { BoardingLockMeta, BoardingPromptState, Trip, Waypoint } from './types';
 
 /**
  * 자동 lock의 TTL. lockSwap의 `SWAP_LOCK_TTL_MS`와 동일 30분 — 두 흐름 모두 "사용자 명시
@@ -47,6 +50,26 @@ export const AUTO_LOCK_TTL_MS = SWAP_LOCK_TTL_MS;
  */
 export const AUTO_PROMPT_DEDUP_WINDOW_MS = AUTO_LOCK_TTL_MS;
 
+/**
+ * #1018 RC1 차단 — arvlCd=2(출발) at next-waypoint 검출 시 confidence gate 임계.
+ *
+ * 0~4점 척도:
+ *   +2: origin arrivals에서 같은 trainCode 확인 (열차가 아직 출발역 권역에 있음 — 강한 증거)
+ *   +1: boardingPromptState.fired=true (사용자가 이 세션에 이미 1회 탑승 확인 응답)
+ *   +1: lastMotionAt이 3분 이내 (사용자가 최근까지 이동 중 — 탑승 직후 신호)
+ *
+ * threshold=2: origin 확인이 없더라도 두 소프트 신호가 모두 있으면 통과.
+ * origin 확인만 있어도 통과 (2점). 단일 소프트 신호만 있으면 차단 (1점 < 2).
+ * arvlCd=2가 아닌 경우 confidence check 자체를 skip → 기존 동작 유지.
+ */
+export const AUTO_LOCK_CONFIDENCE_THRESHOLD = 2;
+
+/** RC1 confidence 체크 트리거 arvlCd 값 (출발). */
+const ARVL_CD_DEPARTED = 2;
+
+/** lastMotionAt이 이 시간(ms) 이내이면 "최근 이동" 신호로 간주. */
+const RECENT_MOTION_WINDOW_MS = 3 * 60 * 1000;
+
 export interface AttemptAutoLockInputs {
   trip: Trip;
   /** 다음 추적 대상 waypoint — arrivals 폴링 대상 (현재 leg 첫 waypoint). */
@@ -64,6 +87,18 @@ export interface AttemptAutoLockInputs {
   direction: 'up' | 'down' | null;
   seoul: SeoulArrivalClient;
   now: number;
+  /**
+   * #1018 RC1 confidence gate 입력 (a): trip의 boarding-prompt 발사 상태.
+   * fired=true면 사용자가 이미 탑승 확인 응답을 한 것 → confidence +1.
+   * 미전달 시 0점으로 간주.
+   */
+  boardingPromptState?: BoardingPromptState;
+  /**
+   * #1018 RC1 confidence gate 입력 (b): GPS 시리즈 마지막 motion 샘플 시각(epoch ms).
+   * 호출자가 `fusion.series[fusion.series.length - 1]?.ts`를 전달한다.
+   * RECENT_MOTION_WINDOW_MS 이내이면 confidence +1. 미전달 시 0점으로 간주.
+   */
+  lastMotionAt?: number;
 }
 
 /**
@@ -74,6 +109,7 @@ export interface AttemptAutoLockInputs {
  *  - segmentStations 비어있지 않음 (origin + 같은 line 유지 구간)
  *  - arrivals 비어있지 않음
  *  - `pickAutoTrainCode`가 단일 후보로 수렴 (ambiguity 없음)
+ *  - RC1 confidence gate 통과 (선택 trainCode의 arvlCd=2인 경우만 평가)
  *
  * 실패 (return null):
  *  - 위 중 하나라도 실패 → caller가 기존 boarding-prompt push fallback 진행
@@ -83,7 +119,16 @@ export interface AttemptAutoLockInputs {
 export async function attemptAutoLock(
   inputs: AttemptAutoLockInputs,
 ): Promise<BoardingLockMeta | null> {
-  const { trip, targetWaypoint, originStation, direction, seoul, now } = inputs;
+  const {
+    trip,
+    targetWaypoint,
+    originStation,
+    direction,
+    seoul,
+    now,
+    boardingPromptState,
+    lastMotionAt,
+  } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
   if (!subwayId) return null;
@@ -93,15 +138,31 @@ export async function attemptAutoLock(
   // origin은 leg의 시작점 — positions fallback이 train.stationName === origin인 케이스를
   // segmentStations.indexOf로 찾을 수 있도록 prepend. legStations 첫 원소(=waypoints[0])와
   // 중복되지 않게 dedup 한다 (이론상 origin과 waypoints[0]는 서로 다른 역이어야 하지만 방어).
-  const segmentStations = legStations[0] === originStation
-    ? legStations
-    : [originStation, ...legStations];
+  const segmentStations =
+    legStations[0] === originStation ? legStations : [originStation, ...legStations];
 
   const arrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
   if (arrivals.length === 0) return null;
 
   const trainCode = pickAutoTrainCode(arrivals, line, direction);
   if (!trainCode) return null;
+
+  // #1018 RC1 confidence gate — arvlCd=2(출발) at next-waypoint는 사용자가 이미 그 열차를
+  // 타고 origin을 떠났거나, 반대로 그 열차가 사용자보다 먼저 출발했을 수 있다 (origin-pass 후보).
+  // 추가 신호로 confidence를 합산해 임계 미달 시 null 반환 → prompt push fallback.
+  const chosenEntry = arrivals.find((a) => a.trainCode === trainCode);
+  if (chosenEntry?.arvlCd === ARVL_CD_DEPARTED) {
+    const confidence = await computeConfidence({
+      trainCode,
+      line,
+      originStation,
+      seoul,
+      boardingPromptState,
+      lastMotionAt,
+      now,
+    });
+    if (confidence < AUTO_LOCK_CONFIDENCE_THRESHOLD) return null;
+  }
 
   return {
     trainCode,
@@ -114,4 +175,42 @@ export async function attemptAutoLock(
     // 케이스에서 existing lock을 보존할지 판단하는 마커 (사용자 명시 lock과 구분).
     autoLockedAt: now,
   };
+}
+
+interface ComputeConfidenceInputs {
+  trainCode: string;
+  line: string;
+  originStation: string;
+  seoul: SeoulArrivalClient;
+  boardingPromptState: BoardingPromptState | undefined;
+  lastMotionAt: number | undefined;
+  now: number;
+}
+
+/**
+ * RC1 confidence 점수 합산 (#1018).
+ *
+ * (a) origin arrivals에서 같은 trainCode가 보이면 +2 (열차가 아직 origin 권역에 있음).
+ * (b) boardingPromptState.fired=true 이면 +1 (사용자 탑승 확인 응답 이력).
+ * (b) lastMotionAt이 RECENT_MOTION_WINDOW_MS 이내이면 +1 (최근 이동 신호).
+ */
+async function computeConfidence(inputs: ComputeConfidenceInputs): Promise<number> {
+  const { trainCode, line, originStation, seoul, boardingPromptState, lastMotionAt, now } = inputs;
+
+  let score = 0;
+
+  // (a) origin arrivals 보조 검증 — same-line 열차 중 trainCode 일치 확인.
+  const originArrivals = await seoul.fetchArrivals(originStation);
+  const originHasTrain = originArrivals.some(
+    (a) => a.trainCode === trainCode && matchLine(a.subwayNm, line),
+  );
+  if (originHasTrain) score += 2;
+
+  // (b) boardingPromptState — 사용자가 이 세션에 이미 탑승 확인 응답한 경우.
+  if (boardingPromptState?.fired) score += 1;
+
+  // (b) lastMotionAt — 최근 이동 신호.
+  if (lastMotionAt !== undefined && now - lastMotionAt <= RECENT_MOTION_WINDOW_MS) score += 1;
+
+  return score;
 }

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -226,6 +226,8 @@ export function pickAutoTrainCode(
   ];
   for (const code of priority) {
     const tier = directional.filter((a) => a.arvlCd === code);
+    // ambiguity 임계: 같은 우선순위 후보가 2개 이상이면 자동 판단 불가 → null.
+    // 단일 후보(tier.length === 1)만 자동 lock을 허용한다.
     if (tier.length === 1) return tier[0].trainCode || null;
     if (tier.length > 1) return null; // ambiguity → 자동 안 함
   }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1511,6 +1511,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       direction: geo.direction,
       seoul: deps.seoul,
       now,
+      // #1018 RC1 confidence gate 입력 — arvlCd=2 at next-waypoint 검출 시 사용.
+      boardingPromptState: trip.boardingPromptState,
+      lastMotionAt: fusion.series[fusion.series.length - 1]?.ts,
     });
     if (autoLock) {
       trip.boardingLock = autoLock;

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -333,11 +333,6 @@ describe('useFusedNearestStation', () => {
 
     it('lock.boardingLine과 positionTrain.line이 같으면 positionTrain 유지', () => {
       setupPositionTrainTransferStation('T-3');
-      // #1016 hole-b: lock 활성 시 accuracy>MAX_ACCURACY_M bypass 금지 → 충무로 실 좌표로 override해
-      // 거리 게이트 통과 보장. 테스트 목적은 line check(#662)이며 거리 gate는 별도 describe에서 검증.
-      mockUseNearest.mockReturnValue(
-        gpsBase({ accuracyMeters: 50, userLocation: { lat: 37.5614, lng: 126.994 } }),
-      );
       const { result } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, undefined, null, lockOnLine('3')),
       );
@@ -460,8 +455,7 @@ describe('useFusedNearestStation', () => {
     const { result, rerender } = renderHook(() => useFusedNearestStation());
     expect(result.current.confidence).toBe('position-train');
 
-    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS가 사라지면 position-train도 강등됨.
-    // #1016 hole-a: userLocation=null → positionTrainResult=null. sticky는 gps fallback으로 대체.
+    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS 없이도 sticky로 T-1 유지.
     mockUsePositions.mockReturnValue(
       positionRet({
         line: '2',
@@ -473,8 +467,8 @@ describe('useFusedNearestStation', () => {
     );
     mockUseNearest.mockReturnValue(gpsBase({ userLocation: null }));
     rerender(undefined);
-    // hole-a: userLocation=null이면 positionTrainResult=null → gps fallback
-    expect(result.current.source).toBe('gps');
+    expect(result.current.source).toBe('position-train');
+    expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
   });
 
   it('GPS pass-through 필드들(loading/error/permissionDenied/locationUncertain/refresh 등)이 보존된다', () => {
@@ -969,13 +963,6 @@ describe('useFusedNearestStation', () => {
         // GPS는 용마산(arc 첫 역). 7093이 군자(arc idx 2)에서 도착 — trainProgress → 군자.
         jest.setSystemTime(T0 + 2 * 90_000);
         setupGpsAtWithLoosAccuracy(yongmasan);
-        // #1016 hole-b: lock 활성 시 accuracy>MAX_ACCURACY_M bypass 금지.
-        // 용마산-군자 실 좌표 거리(~2km)가 MAX_FUSION_DISTANCE_KM(0.6km) 초과 → userLocation을
-        // 군자 실 좌표로 override해 positionTrainResult가 거리 게이트를 통과하도록 함.
-        mockUseNearest.mockReturnValue(
-          gpsBase({ userLocation: { lat: gunja.lat, lng: gunja.lng }, accuracyMeters: 50 }),
-        );
-        mockFindTop.mockReturnValue([{ station: gunja, distanceKm: 0 }]);
         const t7093 = train('군자', TRAIN_STATUS.ARRIVED, { trainNo: '7093' });
         mockUsePositions.mockReturnValue(positionRet({ line: '7', trains: [t7093] }));
 

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -333,6 +333,11 @@ describe('useFusedNearestStation', () => {
 
     it('lock.boardingLine과 positionTrain.line이 같으면 positionTrain 유지', () => {
       setupPositionTrainTransferStation('T-3');
+      // #1016 hole-b: lock 활성 시 accuracy>MAX_ACCURACY_M bypass 금지 → 충무로 실 좌표로 override해
+      // 거리 게이트 통과 보장. 테스트 목적은 line check(#662)이며 거리 gate는 별도 describe에서 검증.
+      mockUseNearest.mockReturnValue(
+        gpsBase({ accuracyMeters: 50, userLocation: { lat: 37.5614, lng: 126.994 } }),
+      );
       const { result } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, undefined, null, lockOnLine('3')),
       );
@@ -455,7 +460,8 @@ describe('useFusedNearestStation', () => {
     const { result, rerender } = renderHook(() => useFusedNearestStation());
     expect(result.current.confidence).toBe('position-train');
 
-    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS 없이도 sticky로 T-1 유지.
+    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS가 사라지면 position-train도 강등됨.
+    // #1016 hole-a: userLocation=null → positionTrainResult=null. sticky는 gps fallback으로 대체.
     mockUsePositions.mockReturnValue(
       positionRet({
         line: '2',
@@ -467,8 +473,8 @@ describe('useFusedNearestStation', () => {
     );
     mockUseNearest.mockReturnValue(gpsBase({ userLocation: null }));
     rerender(undefined);
-    expect(result.current.source).toBe('position-train');
-    expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
+    // hole-a: userLocation=null이면 positionTrainResult=null → gps fallback
+    expect(result.current.source).toBe('gps');
   });
 
   it('GPS pass-through 필드들(loading/error/permissionDenied/locationUncertain/refresh 등)이 보존된다', () => {
@@ -963,6 +969,13 @@ describe('useFusedNearestStation', () => {
         // GPS는 용마산(arc 첫 역). 7093이 군자(arc idx 2)에서 도착 — trainProgress → 군자.
         jest.setSystemTime(T0 + 2 * 90_000);
         setupGpsAtWithLoosAccuracy(yongmasan);
+        // #1016 hole-b: lock 활성 시 accuracy>MAX_ACCURACY_M bypass 금지.
+        // 용마산-군자 실 좌표 거리(~2km)가 MAX_FUSION_DISTANCE_KM(0.6km) 초과 → userLocation을
+        // 군자 실 좌표로 override해 positionTrainResult가 거리 게이트를 통과하도록 함.
+        mockUseNearest.mockReturnValue(
+          gpsBase({ userLocation: { lat: gunja.lat, lng: gunja.lng }, accuracyMeters: 50 }),
+        );
+        mockFindTop.mockReturnValue([{ station: gunja, distanceKm: 0 }]);
         const t7093 = train('군자', TRAIN_STATUS.ARRIVED, { trainNo: '7093' });
         mockUsePositions.mockReturnValue(positionRet({ line: '7', trains: [t7093] }));
 


### PR DESCRIPTION
## Summary

- `attemptAutoLock`에 RC1 false-positive 차단을 위한 confidence gate 추가
- `pickAutoTrainCode`의 ambiguity 임계 주석 명시
- `makeSeoulFixtureByStation` 헬퍼 추가 및 RC1 gate 10개 테스트

## 변경 내용

### `autoLock.ts`
- `AUTO_LOCK_CONFIDENCE_THRESHOLD = 2` 상수 도입
- `AttemptAutoLockInputs`에 `boardingPromptState?`, `lastMotionAt?` 추가
- arvlCd=2(출발) at next-waypoint 검출 시 `computeConfidence()` 호출
  - (a) origin arrivals에서 동일 trainCode 확인: +2점
  - (b) `boardingPromptState.fired=true`: +1점
  - (b) `lastMotionAt` 3분 이내: +1점
  - 합계 < 2 → `null` 반환 → prompt push fallback 진입

### `boardingPrompt.ts`
- `pickAutoTrainCode` ambiguity 임계(tier.length === 1만 허용) 주석 명시

### `scheduled.ts`
- `attemptAutoLock` 호출 시 `boardingPromptState`, `lastMotionAt` 전달

### 테스트
- `makeSeoulFixtureByStation`: 역 이름별 다른 arrivals 반환 fixture
- RC1 gate 시나리오 10개 테스트 추가
- 기존 #916 A1 테스트: arvlCd=2를 의도치 않게 사용하던 기본값을 arvlCd=1로 정정

## Test plan

- [ ] `cd backend/alarm-worker && npx vitest run` → 1058 tests pass
- [ ] `npx tsc --noEmit` → 타입 에러 없음
- [ ] CI `Type Check & Test` pass 확인

Closes #1018