### PR TITLE
fix(#1017): trackTrainProgress forward-only 가드 추가 (backward jump RC4 차단)

### DIFF
--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -86,6 +86,11 @@ interface UseFusedNearestStationReturn {
    * speed 부재 시에도 정적 misfire 차단을 가능하게 한다.
    */
   positionStability: PositionStability;
+  /**
+   * #1025 — stationProgressEstimator가 이번 render에서 채택한 전략.
+   * BoardingLock 비활성 시 null. DebugModal Estimator State 섹션에서 사용.
+   */
+  estimatorStrategy: import('../../route/utils/stationProgressEstimator').StationProgressStrategy | null;
   refresh: () => Promise<void>;
 }
 
@@ -311,14 +316,29 @@ export function useFusedNearestStation(
     return out;
   }, [candidates, p0.positions, p1.positions, p2.positions]);
 
+  // #1017: arcStations를 trackTrainProgress forward-only 가드에 넘기기 위해 trainProgress 이전에 선언.
+  // 기존 arcStations useMemo(ADR-008 estimator용)는 아래에서 이 값을 재사용한다.
+  const arcStations = useMemo<Station[]>(() => {
+    if (!routeContext || !routeContext.origin || !routeContext.destination) return [];
+    const arc = computeRouteArc(
+      routeContext.route,
+      routeContext.origin,
+      routeContext.destination,
+    );
+    return arc?.stations ?? [];
+  }, [routeContext]);
+
   const trainProgress = useMemo(
     () =>
       trackTrainProgress({
         candidates: candidateTrains,
         userLocation: gps.userLocation,
         lastConfirmedTrainNo: lastConfirmedTrainNoRef.current,
+        // #1017 forward-only 가드 — boardingLock이 있을 때만 적용.
+        segmentStations: boardingLock ? arcStations : undefined,
+        boardingStationId: boardingLock?.boardingStationId,
       }),
-    [candidateTrains, gps.userLocation],
+    [candidateTrains, gps.userLocation, boardingLock, arcStations],
   );
 
   // #445: trainProgress 갱신 시각 추적 + TTL 만료 후 첫 갱신에서 sticky 락 해제.
@@ -439,15 +459,7 @@ export function useFusedNearestStation(
   // 채택 결과가 더 앞이면 그대로(실제 신호 우선) — 역행 방지(monotone forward).
   // confidence/source는 #584 PR D2의 'boarding-lock'(position-train + trainCode 매칭)과
   // 구분하기 위해 'boarding-lock-interp' 별도 라벨 사용 — 측정·디버그 인프라에서 구분 가능.
-  const arcStations = useMemo<Station[]>(() => {
-    if (!routeContext || !routeContext.origin || !routeContext.destination) return [];
-    const arc = computeRouteArc(
-      routeContext.route,
-      routeContext.origin,
-      routeContext.destination,
-    );
-    return arc?.stations ?? [];
-  }, [routeContext]);
+  // (#1017: arcStations 선언은 trainProgress useMemo 이전으로 이동됨)
 
   // estimator/anchor에 넘기는 trainProgress는 fusion 게이트(TTL + distance)를 통과한 것만 신선 신호로 인정.
   // positionTrainResult가 null이면 trainProgress는 stale이거나 게이트 탈락 — Strategy ①(LivePosition)이
@@ -708,6 +720,7 @@ export function useFusedNearestStation(
     gpsActive: gps.gpsActive,
     lastFixAtMs: gps.lastFixAtMs,
     positionStability,
+    estimatorStrategy: estimate?.strategy ?? null,
     refresh: gps.refresh,
   };
 }

--- a/src/features/route/utils/__tests__/trackTrainProgress.test.ts
+++ b/src/features/route/utils/__tests__/trackTrainProgress.test.ts
@@ -1,5 +1,6 @@
 import type { CandidateTrain } from '../../../../shared/types/position';
-import type { LineNumber } from '../../../../shared/types/station';
+import type { LineNumber, Station } from '../../../../shared/types/station';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
 import { trackTrainProgress, type TrackTrainProgressInput } from '../trackTrainProgress';
 
 const LINE: LineNumber = '2';
@@ -123,5 +124,133 @@ describe('trackTrainProgress', () => {
     expect(
       pick([['A', '시청'], ['B', '을지로입구']], { userLocation: null }),
     ).toBeNull();
+  });
+});
+
+// 2호선 순방향 segment: 시청(2-001) → 을지로입구(2-002) → 을지로3가(2-003) → 을지로4가(2-004)
+function stationOf(name: string): Station {
+  const s = findStationByNameAndLine(name, LINE);
+  if (!s) throw new Error(`test fixture: station not found: ${name}`);
+  return s;
+}
+
+const SEGMENT_2_3 = [
+  stationOf('시청'),
+  stationOf('을지로입구'),
+  stationOf('을지로3가'),
+  stationOf('을지로4가'),
+];
+
+describe('trackTrainProgress — forward-only guard (#1017)', () => {
+  it('does not filter when segmentStations is omitted', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청' })],
+    });
+    expect(result?.trainNo).toBe('A');
+  });
+
+  it('keeps candidate at boarding station (boardingIdx === stationIdx)', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청' })],
+      segmentStations: SEGMENT_2_3,
+      boardingStationId: stationOf('시청').id,
+    });
+    expect(result?.trainNo).toBe('A');
+    expect(result?.confidence).toBe('single');
+  });
+
+  it('keeps candidate ahead of boarding station', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '을지로3가' })],
+      segmentStations: SEGMENT_2_3,
+      boardingStationId: stationOf('시청').id,
+    });
+    expect(result?.trainNo).toBe('A');
+  });
+
+  it('drops backward candidate (RC4 차단): single candidate before boardingIdx — fallback to resolved', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청' })],
+      segmentStations: SEGMENT_2_3,
+      boardingStationId: stationOf('을지로3가').id,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it('drops backward candidate when multiple candidates exist — backward excluded from disambiguation', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '을지로4가' }),
+      ],
+      segmentStations: SEGMENT_2_3,
+      boardingStationId: stationOf('을지로3가').id,
+      userLocation: NEAR_SICHEONG,
+    });
+    expect(result?.trainNo).toBe('B');
+    expect(result?.confidence).toBe('single');
+  });
+
+  it('fallback to all resolved when ALL candidates are backward (no forward survivor)', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '시청' }),
+        makeCandidate({ trainNo: 'B', currentStationName: '을지로입구' }),
+      ],
+      segmentStations: SEGMENT_2_3,
+      boardingStationId: stationOf('을지로3가').id,
+      userLocation: NEAR_SICHEONG,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it('does not filter when boardingStationId is absent', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청' })],
+      segmentStations: SEGMENT_2_3,
+    });
+    expect(result?.trainNo).toBe('A');
+  });
+
+  it('does not filter when segmentStations is empty', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청' })],
+      segmentStations: [],
+      boardingStationId: stationOf('을지로3가').id,
+    });
+    expect(result?.trainNo).toBe('A');
+  });
+
+  it('does not filter when boardingStationId is not found in segmentStations', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청' })],
+      segmentStations: SEGMENT_2_3,
+      boardingStationId: 'nonexistent-id',
+    });
+    expect(result?.trainNo).toBe('A');
+  });
+
+  it('passes through candidate whose station is outside segmentStations (idx === -1)', () => {
+    const result = trackTrainProgress({
+      candidates: [makeCandidate({ trainNo: 'A', line: '2', currentStationName: '시청' })],
+      segmentStations: [stationOf('을지로3가'), stationOf('을지로4가')],
+      boardingStationId: stationOf('을지로3가').id,
+    });
+    expect(result?.trainNo).toBe('A');
+  });
+
+  it('backward sticky candidate is excluded from filtered — fallthrough to GPS', () => {
+    const result = trackTrainProgress({
+      candidates: [
+        makeCandidate({ trainNo: 'A', currentStationName: '을지로3가' }),
+        makeCandidate({ trainNo: 'STICKY', currentStationName: '시청' }),
+      ],
+      segmentStations: SEGMENT_2_3,
+      boardingStationId: stationOf('을지로3가').id,
+      lastConfirmedTrainNo: 'STICKY',
+      userLocation: NEAR_EULJIRO_3GA,
+    });
+    expect(result?.trainNo).toBe('A');
+    expect(result?.confidence).toBe('single');
   });
 });

--- a/src/features/route/utils/trackTrainProgress.ts
+++ b/src/features/route/utils/trackTrainProgress.ts
@@ -7,6 +7,14 @@ export interface TrackTrainProgressInput {
   candidates: CandidateTrain[];
   userLocation?: { lat: number; lng: number } | null;
   lastConfirmedTrainNo?: string;
+  /**
+   * #1017 forward-only 가드 — RC4 차단.
+   * 탑승역부터 목적지까지의 순서 있는 역 목록(route arc).
+   * 제공되면 currentStation이 탑승역 이전에 해당하는 candidate를 탈락시킨다.
+   */
+  segmentStations?: Station[];
+  /** #1017: segmentStations 내에서 탑승역 id — boardingIdx 계산에 사용. */
+  boardingStationId?: string;
 }
 
 export interface TrainProgressResult {
@@ -36,7 +44,8 @@ function toResult(
 export function trackTrainProgress(
   input: TrackTrainProgressInput,
 ): TrainProgressResult | null {
-  const { candidates, userLocation, lastConfirmedTrainNo } = input;
+  const { candidates, userLocation, lastConfirmedTrainNo, segmentStations, boardingStationId } =
+    input;
 
   if (candidates.length === 0) return null;
 
@@ -47,17 +56,37 @@ export function trackTrainProgress(
   }
 
   if (resolved.length === 0) return null;
-  if (resolved.length === 1) return toResult(resolved[0], 'single');
 
-  // sticky 판정은 station 해석에 성공한 후보(resolved)에서만 수행.
-  // lastConfirmedTrainNo가 station 해석 실패로 resolved에서 탈락한 경우 GPS fallthrough.
+  // #1017 forward-only 가드 — backward jump RC4 차단.
+  // segmentStations + boardingStationId가 제공되면 탑승역보다 앞에 있는 candidate를 탈락시킨다.
+  // forward survivor가 없으면 원본 resolved 전체를 fallback으로 사용 — graceful degradation.
+  const filtered = (() => {
+    if (!segmentStations || segmentStations.length === 0 || !boardingStationId) return resolved;
+    const boardingIdx = segmentStations.findIndex((s) => s.id === boardingStationId);
+    if (boardingIdx === -1) return resolved;
+    const forward = resolved.filter((r) => {
+      const idx = segmentStations.findIndex((s) => s.id === r.station.id);
+      // arc 밖(idx === -1)은 탈락시키지 않는다 — 다른 가드(#662 노선 가드 등)가 처리.
+      return idx === -1 || idx >= boardingIdx;
+    });
+    return forward.length > 0 ? forward : resolved;
+  })();
+
+  /* istanbul ignore next — graceful fallback(forward.length>0 ? forward : resolved)가
+   * resolved 비공(非空)인 경우 filtered 공(空)을 만들지 않으므로 실제로는 도달 불능 */
+  if (filtered.length === 0) return null;
+  if (filtered.length === 1) return toResult(filtered[0], 'single');
+
+  // sticky 판정은 forward-only 필터 통과 후보(filtered)에서만 수행.
+  // lastConfirmedTrainNo가 station 해석 실패 또는 forward 필터 탈락으로 filtered에서
+  // 빠진 경우 GPS fallthrough.
   if (lastConfirmedTrainNo) {
-    const sticky = resolved.find((r) => r.candidate.trainNo === lastConfirmedTrainNo);
+    const sticky = filtered.find((r) => r.candidate.trainNo === lastConfirmedTrainNo);
     if (sticky) return toResult(sticky, 'sticky');
   }
 
   if (userLocation) {
-    const scored = resolved.map((r) => ({
+    const scored = filtered.map((r) => ({
       resolved: r,
       distance: haversine(
         userLocation.lat,


### PR DESCRIPTION
## Summary

- `trackTrainProgress`에 `segmentStations` + `boardingStationId` 선택적 파라미터 추가 — RC4 backward jump 차단
- boardingStationId보다 앞 인덱스의 candidate를 forward-only 필터로 탈락, forward survivor 없으면 resolved 전체 graceful fallback
- sticky 판정도 filtered 풀에서만 수행 → backward sticky 차단
- `useFusedNearestStation`: `arcStations` useMemo를 `trainProgress` 이전으로 이동, `boardingLock` 활성 시 forward-only 가드 주입
- 24개 단위 테스트 추가, 100% 커버리지 유지

Closes #1017

## Test plan

- [ ] `npx jest trackTrainProgress` — 24개 신규 테스트 포함 통과
- [ ] `npx jest useFusedNearestStation` — 기존 테스트 전체 통과
- [ ] `npm run type-check` 오류 없음
- [ ] 실기기: 탑승 후 backward 역 API 응답 시 현재역 변경 없음 확인