### PR TITLE
feat(#1022): Worker daily request quota 추적 및 admin dashboard

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2030,3 +2030,78 @@ describe('POST /boarding-lock/sync (#901)', () => {
     expect(body.autoLockCandidate).toBeNull();
   });
 });
+
+// ─── GET /admin/quota (#1022) ─────────────────────────────────────────────────
+
+async function getAdminQuota(
+  env: Env,
+  authHeader?: string,
+): Promise<Response> {
+  return app.fetch(
+    new Request('http://example.com/admin/quota', {
+      method: 'GET',
+      headers: authHeader ? { authorization: authHeader } : {},
+    }),
+    env,
+  );
+}
+
+describe('GET /admin/quota (#1022)', () => {
+  it('returns 503 when ADMIN_TOKEN is not configured', async () => {
+    const env = makeKvEnv();
+    const res = await getAdminQuota(env, 'Bearer some-token');
+    expect(res.status).toBe(503);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('admin_unavailable');
+  });
+
+  it('returns 401 when no Authorization header', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    const res = await getAdminQuota(env);
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('unauthorized');
+  });
+
+  it('returns 401 when token does not match', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    const res = await getAdminQuota(env, 'Bearer wrong-token');
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('unauthorized');
+  });
+
+  it('returns 200 with quota status fields', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    const res = await getAdminQuota(env, 'Bearer secret');
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      date: string;
+      count: number;
+      limit: number;
+      ratio: number;
+      warning: boolean;
+    };
+    // middleware increments count on every request, so count >= 1
+    expect(body.count).toBeGreaterThanOrEqual(1);
+    expect(body.limit).toBe(100_000);
+    expect(body.ratio).toBeGreaterThanOrEqual(0);
+    expect(body.warning).toBe(false);
+    expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('reflects request count incremented by middleware', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    // Fire one request to increment the counter via middleware
+    await app.fetch(new Request('http://example.com/health'), env);
+    const res = await getAdminQuota(env, 'Bearer secret');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { count: number };
+    // At least 1 from /health + 1 from /admin/quota (middleware runs on all requests)
+    expect(body.count).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/quotaTracker.test.ts
+++ b/backend/alarm-worker/src/__tests__/quotaTracker.test.ts
@@ -1,0 +1,204 @@
+/**
+ * quotaTracker.ts 테스트 (#1022).
+ *
+ * KV를 InMemoryKV로 대체해 외부 의존 없이 결정적으로 검증.
+ * - isoDateUtc / quotaKey 순수 함수
+ * - readDailyCount: 키 없음 / 숫자 / 손상값
+ * - incrementDailyRequestCount: 단순 증가 / 80% 임계 crossing / webhook 발사 / 연속 crossing 방지
+ * - getQuotaStatus: 비율 계산 / warning 플래그
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DAILY_REQUEST_LIMIT,
+  QUOTA_WARN_THRESHOLD,
+  getQuotaStatus,
+  incrementDailyRequestCount,
+  isoDateUtc,
+  quotaKey,
+  readDailyCount,
+} from '../quotaTracker';
+import { InMemoryKV } from './inMemoryKv';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeKv(): KVNamespace {
+  return new InMemoryKV() as unknown as KVNamespace;
+}
+
+/** 임계 직전 카운트로 KV를 초기화한다 */
+async function seedCount(kv: KVNamespace, dateStr: string, count: number): Promise<void> {
+  const kv_ = kv as unknown as InMemoryKV;
+  kv_.store.set(quotaKey(dateStr), { value: String(count) });
+}
+
+// ─── isoDateUtc ────────────────────────────────────────────────────────────
+
+describe('isoDateUtc', () => {
+  it('returns YYYY-MM-DD for a known UTC epoch', () => {
+    // 2024-01-15T00:00:00Z = 1705276800000
+    expect(isoDateUtc(1_705_276_800_000)).toBe('2024-01-15');
+  });
+
+  it('returns current UTC date shape', () => {
+    const result = isoDateUtc(Date.now());
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+// ─── quotaKey ────────────────────────────────────────────────────────────────
+
+describe('quotaKey', () => {
+  it('formats as quota:<date>', () => {
+    expect(quotaKey('2024-01-15')).toBe('quota:2024-01-15');
+  });
+});
+
+// ─── readDailyCount ──────────────────────────────────────────────────────────
+
+describe('readDailyCount', () => {
+  it('returns 0 when key is absent', async () => {
+    const kv = makeKv();
+    expect(await readDailyCount(kv, '2024-01-15')).toBe(0);
+  });
+
+  it('returns stored number', async () => {
+    const kv = makeKv();
+    await seedCount(kv, '2024-01-15', 42);
+    expect(await readDailyCount(kv, '2024-01-15')).toBe(42);
+  });
+
+  it('returns 0 for corrupt (NaN) value', async () => {
+    const kv = makeKv();
+    const kv_ = kv as unknown as InMemoryKV;
+    kv_.store.set(quotaKey('2024-01-15'), { value: 'not-a-number' });
+    expect(await readDailyCount(kv, '2024-01-15')).toBe(0);
+  });
+});
+
+// ─── incrementDailyRequestCount ──────────────────────────────────────────────
+
+describe('incrementDailyRequestCount', () => {
+  const DATE_STR = '2024-01-15';
+  // epoch that maps to 2024-01-15 UTC
+  const NOW = 1_705_276_800_000;
+
+  it('increments from 0 to 1', async () => {
+    const kv = makeKv();
+    const result = await incrementDailyRequestCount(kv, NOW);
+    expect(result).toBe(1);
+    expect(await readDailyCount(kv, DATE_STR)).toBe(1);
+  });
+
+  it('increments existing count', async () => {
+    const kv = makeKv();
+    await seedCount(kv, DATE_STR, 10);
+    const result = await incrementDailyRequestCount(kv, NOW);
+    expect(result).toBe(11);
+  });
+
+  it('does not fire warning below threshold', async () => {
+    const kv = makeKv();
+    const warnAt = Math.floor(DAILY_REQUEST_LIMIT * QUOTA_WARN_THRESHOLD) - 1;
+    await seedCount(kv, DATE_STR, warnAt - 1);
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await incrementDailyRequestCount(kv, NOW);
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('fires console.warn exactly when crossing 80% threshold', async () => {
+    const kv = makeKv();
+    const warnAt = Math.floor(DAILY_REQUEST_LIMIT * QUOTA_WARN_THRESHOLD);
+    await seedCount(kv, DATE_STR, warnAt - 1);
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await incrementDailyRequestCount(kv, NOW);
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    expect(consoleSpy.mock.calls[0][0]).toContain('80%');
+    consoleSpy.mockRestore();
+  });
+
+  it('fires webhook when crossing threshold and webhookUrl is given', async () => {
+    const kv = makeKv();
+    const warnAt = Math.floor(DAILY_REQUEST_LIMIT * QUOTA_WARN_THRESHOLD);
+    await seedCount(kv, DATE_STR, warnAt - 1);
+    const fetched: { url: string; body: string }[] = [];
+    const fakeFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      fetched.push({ url: url.toString(), body: (init?.body as string) ?? '' });
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await incrementDailyRequestCount(kv, NOW, 'https://hooks.test/webhook', fakeFetch);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].url).toBe('https://hooks.test/webhook');
+    const payload = JSON.parse(fetched[0].body) as { text: string };
+    expect(payload.text).toContain('80%');
+    vi.restoreAllMocks();
+  });
+
+  it('does not fire webhook on subsequent requests above threshold (already crossed)', async () => {
+    const kv = makeKv();
+    const warnAt = Math.floor(DAILY_REQUEST_LIMIT * QUOTA_WARN_THRESHOLD);
+    // Already above 80%
+    await seedCount(kv, DATE_STR, warnAt + 5);
+    const fakeFetch = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await incrementDailyRequestCount(kv, NOW, 'https://hooks.test/webhook', fakeFetch);
+    expect(fakeFetch).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('swallows webhook fetch errors without throwing', async () => {
+    const kv = makeKv();
+    const warnAt = Math.floor(DAILY_REQUEST_LIMIT * QUOTA_WARN_THRESHOLD);
+    await seedCount(kv, DATE_STR, warnAt - 1);
+    const fakeFetch = vi.fn(async () => { throw new Error('network error'); }) as unknown as typeof fetch;
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await expect(
+      incrementDailyRequestCount(kv, NOW, 'https://hooks.test/webhook', fakeFetch),
+    ).resolves.not.toThrow();
+    vi.restoreAllMocks();
+  });
+});
+
+// ─── getQuotaStatus ──────────────────────────────────────────────────────────
+
+describe('getQuotaStatus', () => {
+  const DATE_STR = '2024-01-15';
+  const NOW = 1_705_276_800_000;
+
+  it('returns zero count when no requests yet', async () => {
+    const kv = makeKv();
+    const status = await getQuotaStatus(kv, NOW);
+    expect(status.date).toBe(DATE_STR);
+    expect(status.count).toBe(0);
+    expect(status.limit).toBe(DAILY_REQUEST_LIMIT);
+    expect(status.ratio).toBe(0);
+    expect(status.warning).toBe(false);
+  });
+
+  it('computes ratio correctly', async () => {
+    const kv = makeKv();
+    await seedCount(kv, DATE_STR, 25_000);
+    const status = await getQuotaStatus(kv, NOW);
+    expect(status.count).toBe(25_000);
+    expect(status.ratio).toBeCloseTo(0.25, 5);
+    expect(status.warning).toBe(false);
+  });
+
+  it('sets warning=true at exactly 80%', async () => {
+    const kv = makeKv();
+    const warnAt = Math.floor(DAILY_REQUEST_LIMIT * QUOTA_WARN_THRESHOLD);
+    await seedCount(kv, DATE_STR, warnAt);
+    const status = await getQuotaStatus(kv, NOW);
+    expect(status.warning).toBe(true);
+  });
+
+  it('sets warning=true above 80%', async () => {
+    const kv = makeKv();
+    await seedCount(kv, DATE_STR, DAILY_REQUEST_LIMIT);
+    const status = await getQuotaStatus(kv, NOW);
+    expect(status.ratio).toBeCloseTo(1, 5);
+    expect(status.warning).toBe(true);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -61,6 +61,7 @@ import {
   writeTelemetryDataPoints,
 } from './telemetry';
 import { getTrip, putTrip } from './trips';
+import { getQuotaStatus, incrementDailyRequestCount } from './quotaTracker';
 import type {
   AccelSummary,
   BoardingLockMeta,
@@ -93,6 +94,20 @@ function makeLaStats(): LiveActivityStats {
 }
 
 export const app = new Hono<{ Bindings: Env }>();
+
+/**
+ * 일일 요청 카운트 미들웨어 (#1022).
+ * 모든 요청에 대해 quota KV 카운터를 +1한다. 80% 도달 시 콘솔 경고 + 선택적 webhook.
+ * KV 미바인딩(개발 환경) 시 graceful no-op.
+ */
+app.use('*', async (c, next) => {
+  if (c.env.TRIPS) {
+    await incrementDailyRequestCount(c.env.TRIPS, Date.now(), c.env.QUOTA_ALERT_WEBHOOK_URL).catch(
+      () => { /* quota tracking failure는 트래픽에 영향 없이 swallow */ },
+    );
+  }
+  return next();
+});
 
 app.get('/health', (c) => c.json({ ok: true }));
 
@@ -222,6 +237,25 @@ app.get('/admin/feedback/stats', async (c) => {
   const stats = await getFeedbackStats(kv, date);
   if (!stats) return c.json({ error: 'stats_not_found' }, 404);
   return c.json(stats);
+});
+
+/**
+ * 운영자용 daily request quota 현황 (#1022).
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` 필수.
+ * Response 200: { date, count, limit, ratio, warning }
+ *   - date: UTC YYYY-MM-DD
+ *   - count: 오늘 요청 카운트
+ *   - limit: 일일 한도 (100000)
+ *   - ratio: 0~1 사용 비율
+ *   - warning: ratio >= 0.8 여부
+ * Response 401/503: 인증/binding 정책은 /admin/feedback과 동일.
+ */
+app.get('/admin/quota', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const status = await getQuotaStatus(c.env.TRIPS, Date.now());
+  return c.json(status);
 });
 
 interface AdminAuthError {

--- a/backend/alarm-worker/src/quotaTracker.ts
+++ b/backend/alarm-worker/src/quotaTracker.ts
@@ -1,0 +1,122 @@
+/**
+ * Cloudflare Worker daily request quota tracker (#1022).
+ *
+ * 무료 플랜 한도 100K req/day 대비 현재 사용량을 KV에 적재하고,
+ * 80% 도달 시 경고 hook(콘솔 + 선택적 webhook)을 발사한다.
+ *
+ * - KV key: `quota:YYYY-MM-DD` (UTC 날짜 단위, TTL 48h)
+ * - GET /admin/quota — 오늘 사용량/한도/비율/경고 여부 반환
+ * - incrementDailyRequestCount() — Worker fetch 핸들러 초입에서 1회 호출
+ *
+ * Privacy: IP/path/token 등 개인정보는 절대 저장하지 않는다. 단순 카운터만.
+ */
+
+/** 무료 플랜 일일 요청 한도 */
+export const DAILY_REQUEST_LIMIT = 100_000;
+
+/** 경고 hook 발사 임계 비율 (0~1). 0.8 = 80% */
+export const QUOTA_WARN_THRESHOLD = 0.8;
+
+/** KV TTL: 48시간 (일 단위 키가 만료되어도 당일+익일 유지) */
+const KV_TTL_SECONDS = 48 * 60 * 60;
+
+/** UTC 날짜 문자열 (YYYY-MM-DD) */
+export function isoDateUtc(epochMs: number): string {
+  return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+/** 오늘 날짜 기반 KV 키 */
+export function quotaKey(dateStr: string): string {
+  return `quota:${dateStr}`;
+}
+
+/**
+ * KV에서 오늘 요청 카운트를 읽는다. 키가 없으면 0.
+ */
+export async function readDailyCount(kv: KVNamespace, dateStr: string): Promise<number> {
+  const raw = await kv.get(quotaKey(dateStr));
+  if (!raw) return 0;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * 오늘 요청 카운트를 +1 증가시켜 KV에 적재한다.
+ * 80% 임계 최초 도달 시 콘솔 경고 + 선택적 webhook 발사.
+ *
+ * @returns 증가 후 카운트
+ */
+export async function incrementDailyRequestCount(
+  kv: KVNamespace,
+  now: number,
+  webhookUrl?: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number> {
+  const dateStr = isoDateUtc(now);
+  const prev = await readDailyCount(kv, dateStr);
+  const next = prev + 1;
+  await kv.put(quotaKey(dateStr), String(next), { expirationTtl: KV_TTL_SECONDS });
+
+  const prevRatio = prev / DAILY_REQUEST_LIMIT;
+  const nextRatio = next / DAILY_REQUEST_LIMIT;
+  const crossedWarn =
+    nextRatio >= QUOTA_WARN_THRESHOLD && prevRatio < QUOTA_WARN_THRESHOLD;
+
+  if (crossedWarn) {
+    const pct = Math.round(nextRatio * 100);
+    console.warn(`[quota] daily request count reached ${pct}% of limit (${next}/${DAILY_REQUEST_LIMIT})`);
+    if (webhookUrl) {
+      await fireQuotaWebhook(webhookUrl, next, pct, dateStr, fetchImpl).catch(() => {
+        // webhook 실패는 트래픽에 영향을 주지 않아야 하므로 swallow
+      });
+    }
+  }
+
+  return next;
+}
+
+/** Slack incoming webhook 호환 payload 발사 */
+async function fireQuotaWebhook(
+  webhookUrl: string,
+  count: number,
+  pct: number,
+  dateStr: string,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  await fetchImpl(webhookUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      text: `⚠️ [subway-now] Worker quota ${pct}% on ${dateStr}: ${count}/${DAILY_REQUEST_LIMIT} req/day`,
+    }),
+  });
+}
+
+/**
+ * 오늘 quota 상태 요약.
+ */
+export interface QuotaStatus {
+  date: string;
+  count: number;
+  limit: number;
+  /** 0~1 사용 비율 */
+  ratio: number;
+  /** ratio >= QUOTA_WARN_THRESHOLD */
+  warning: boolean;
+}
+
+/**
+ * 오늘 quota 상태를 반환한다.
+ */
+export async function getQuotaStatus(kv: KVNamespace, now: number): Promise<QuotaStatus> {
+  const dateStr = isoDateUtc(now);
+  const count = await readDailyCount(kv, dateStr);
+  const ratio = count / DAILY_REQUEST_LIMIT;
+  return {
+    date: dateStr,
+    count,
+    limit: DAILY_REQUEST_LIMIT,
+    ratio,
+    warning: ratio >= QUOTA_WARN_THRESHOLD,
+  };
+}

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -464,4 +464,10 @@ export interface Env {
    * 등록: `wrangler secret put ADMIN_TOKEN`
    */
   ADMIN_TOKEN?: string;
+  /**
+   * 일일 요청 quota 80% 도달 시 경고 webhook URL (#1022).
+   * Slack incoming webhook 또는 호환 receiver. 미설정 시 콘솔 경고만 발사(graceful no-op).
+   * 등록: `wrangler secret put QUOTA_ALERT_WEBHOOK_URL`
+   */
+  QUOTA_ALERT_WEBHOOK_URL?: string;
 }

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -689,6 +689,21 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
             )}
           </Section>
 
+          {/* #1022: Worker Quota admin view */}
+          <Section title="Worker Quota" colors={colors}>
+            <KeyValue
+              label="endpoint"
+              value={`${process.env.EXPO_PUBLIC_ALARM_BACKEND_URL ?? '(unset)'}/admin/quota`}
+              colors={colors}
+            />
+            <Text
+              style={[typography.mono, { color: colors.muted, marginTop: spacing.xs }]}
+              testID="debug-quota-note"
+            >
+              GET with Bearer ADMIN_TOKEN
+            </Text>
+          </Section>
+
           <View style={styles.actions}>
             <TouchableOpacity
               style={[styles.actionButton, { borderColor: colors.accent }]}


### PR DESCRIPTION
## Summary

- `quotaTracker.ts` 신규 모듈: KV 기반 일일 요청 카운터 + 80% 임계 도달 시 콘솔 경고 + 선택적 Slack webhook 발사
- Hono 전역 미들웨어로 매 요청마다 카운트 +1 (KV 미바인딩 시 graceful no-op)
- `GET /admin/quota`: Bearer ADMIN_TOKEN 인증 후 `{ date, count, limit, ratio, warning }` 반환
- `Env` 타입에 `QUOTA_ALERT_WEBHOOK_URL` optional env 추가
- DebugModal에 "Worker Quota" admin 섹션 추가 — `/admin/quota` endpoint URL 노출
- 단위 테스트 22개 추가 (quotaTracker 17개 + /admin/quota endpoint 5개)

Closes #1022

## Test plan

- [ ] `cd backend/alarm-worker && npm test` — 1070 tests 전부 pass 확인
- [ ] `npm run type-check` — 프론트엔드/백엔드 모두 pass 확인
- [ ] CI `Type Check & Test` pass 확인 후 머지