### PR TITLE
fix(#1011): lastNotifiedStationId destination tuple scoping

### DIFF
--- a/src/features/alarm/hooks/__tests__/useScheduledAlarms.test.ts
+++ b/src/features/alarm/hooks/__tests__/useScheduledAlarms.test.ts
@@ -136,6 +136,7 @@ describe('useScheduledAlarms', () => {
     expect(mockedSchedule).toHaveBeenCalledWith({
       route: ROUTE,
       destinationName: '강남',
+      destinationId: 'dest-1',
       currentStationApproachEtaSeconds: 300, // min(300, 420), currentStation=null → 양방향 fallback
       // stamp.direction은 route-resolved intent — currentStation=null이므로 null로 기록.
       // trainCode는 fallback에서 pick된 up arrival(300 < 420)의 'U1'.

--- a/src/features/alarm/hooks/__tests__/useSilentPushDiagnostics.test.ts
+++ b/src/features/alarm/hooks/__tests__/useSilentPushDiagnostics.test.ts
@@ -189,6 +189,27 @@ describe('useSilentPushDiagnostics', () => {
     expect(result.current.destinationId).toBeNull();
   });
 
+  it('lastNotifiedStationId: JSON tuple 포맷 { stationId } → stationId 추출 (#1011)', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      Promise.resolve(
+        key === LAST_NOTIFIED_STATION_KEY
+          ? JSON.stringify({ destinationId: 'dest-1', stationId: '7-015' })
+          : null,
+      ),
+    );
+    const { result } = renderHook(() => useSilentPushDiagnostics());
+    await waitFor(() => expect(result.current.lastNotifiedStationId).toBe('7-015'));
+  });
+
+  it('lastNotifiedStationId: JSON이지만 stationId가 string 아니면 raw 값 그대로 (#1011)', async () => {
+    const raw = JSON.stringify({ stationId: 42 });
+    mockGetItem.mockImplementation((key: string) =>
+      Promise.resolve(key === LAST_NOTIFIED_STATION_KEY ? raw : null),
+    );
+    const { result } = renderHook(() => useSilentPushDiagnostics());
+    await waitFor(() => expect(result.current.lastNotifiedStationId).toBe(raw));
+  });
+
   it('unmount 시 listener 해제', () => {
     const removeSpy = jest.fn();
     jest.spyOn(AppState, 'addEventListener').mockReturnValue({

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -705,7 +705,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => {
         expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', directTarget, undefined);
       });
-      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('S1');
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, 'S1');
     });
 
     it('does not fire when stored lastNotifiedStationId equals nearest station', async () => {
@@ -2284,7 +2284,7 @@ describe('useStationAlarm', () => {
         expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', onRouteStation),
       );
       expect(mockSendStationPassedNotification).toHaveBeenCalled();
-      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(onRouteStation.id);
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, onRouteStation.id);
     });
 
     // #640 회귀 가드 — 본 PR의 핵심.

--- a/src/features/alarm/hooks/useScheduledAlarms.ts
+++ b/src/features/alarm/hooks/useScheduledAlarms.ts
@@ -112,6 +112,7 @@ export function useScheduledAlarms({
     await scheduleAlarmsForRoute({
       route: currentRoute,
       destinationName: currentDestination.name,
+      destinationId: currentDestination.id,
       currentStationApproachEtaSeconds: pick.etaSeconds,
       // stamp.direction은 filter intent(=null이면 "방향 미판정")를 그대로 기록한다.
       // pick.direction(추론된 list)과 다를 수 있으나, 진단 시 의도와 fallback을 구분하기 위함.

--- a/src/features/alarm/hooks/useSilentPushDiagnostics.ts
+++ b/src/features/alarm/hooks/useSilentPushDiagnostics.ts
@@ -120,6 +120,18 @@ export function useSilentPushDiagnostics(): SilentPushDiagnostics {
         // 깨진 entry는 무시 — 진단 표시만 빈 값.
       }
     }
+    // #1011: lastNotifiedStationId는 { destinationId, stationId } JSON. stationId만 표시.
+    // 이전 포맷(plain string) 또는 파싱 실패 시 raw 값으로 graceful degrade.
+    let parsedLastNotifiedStationId: string | null = null;
+    if (lastNotifiedStationId) {
+      try {
+        const parsed = JSON.parse(lastNotifiedStationId) as { stationId?: unknown };
+        parsedLastNotifiedStationId =
+          typeof parsed?.stationId === 'string' ? parsed.stationId : lastNotifiedStationId;
+      } catch {
+        parsedLastNotifiedStationId = lastNotifiedStationId;
+      }
+    }
     setDiag({
       apnsToken,
       activeTripToken,
@@ -130,7 +142,7 @@ export function useSilentPushDiagnostics(): SilentPushDiagnostics {
       ...latest,
       hasRoute: routeJson != null && routeJson.length > 0,
       destinationId,
-      lastNotifiedStationId,
+      lastNotifiedStationId: parsedLastNotifiedStationId,
     });
   }, []);
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -97,6 +97,7 @@ async function dispatchStationPassed(params: {
   source: 'fg' | 'fg-arvlcd';
   candidateStation: Station;
   capturedRoute: Route;
+  capturedDestinationId: string;
   capturedDestinationName: string;
   notificationSource: NotificationSource | undefined;
   isCancelled: () => boolean;
@@ -106,13 +107,14 @@ async function dispatchStationPassed(params: {
     source,
     candidateStation,
     capturedRoute,
+    capturedDestinationId,
     capturedDestinationName,
     notificationSource,
     isCancelled,
     errorLogPrefix,
   } = params;
   try {
-    const lastId = await getLastNotifiedStationId();
+    const lastId = await getLastNotifiedStationId(capturedDestinationId);
     if (isCancelled()) return;
     if (candidateStation.id === lastId) {
       logSuppressedDedupStation(source, candidateStation);
@@ -132,7 +134,7 @@ async function dispatchStationPassed(params: {
       notificationSource,
     );
     if (isCancelled()) return;
-    await setLastNotifiedStationId(candidateStation.id);
+    await setLastNotifiedStationId(capturedDestinationId, candidateStation.id);
     logFiredStationPassed(source, candidateStation);
   } catch (e) {
     logger.error(errorLogPrefix, e);
@@ -150,6 +152,7 @@ async function runSilenceGateAndDispatch(params: {
   source: 'fg' | 'fg-arvlcd';
   candidateStation: Station;
   capturedRoute: Route;
+  capturedDestinationId: string;
   capturedDestinationName: string;
   notificationSource: NotificationSource | undefined;
   isCancelled: () => boolean;
@@ -176,6 +179,7 @@ async function runSilenceGateAndDispatch(params: {
     source: params.source,
     candidateStation: params.candidateStation,
     capturedRoute: params.capturedRoute,
+    capturedDestinationId: params.capturedDestinationId,
     capturedDestinationName: params.capturedDestinationName,
     notificationSource: params.notificationSource,
     isCancelled: params.isCancelled,
@@ -661,6 +665,7 @@ export function useStationAlarm({
     if (nearestStation && isStationOnRoute(nearestStation, route)) {
       const candidateStation = nearestStation;
       const capturedRoute = route;
+      const capturedDestinationId = destination.id;
       const capturedDestinationName = destination.name;
 
       // #733 — station-passed movement gate (S4 fix).
@@ -685,6 +690,7 @@ export function useStationAlarm({
         source: 'fg',
         candidateStation,
         capturedRoute,
+        capturedDestinationId,
         capturedDestinationName,
         notificationSource,
         isCancelled: () => cancelled,
@@ -742,6 +748,7 @@ export function useStationAlarm({
 
     const candidateStation = nearestStation;
     const capturedRoute = route;
+    const capturedDestinationId = destination.id;
     const capturedDestinationName = destination.name;
 
     let cancelled = false;
@@ -773,6 +780,7 @@ export function useStationAlarm({
         source: 'fg-arvlcd',
         candidateStation,
         capturedRoute,
+        capturedDestinationId,
         capturedDestinationName,
         notificationSource,
         isCancelled: () => cancelled,

--- a/src/features/alarm/utils/__tests__/notificationState.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationState.test.ts
@@ -36,20 +36,47 @@ describe('notificationState', () => {
     jest.clearAllMocks();
   });
 
-  describe('getLastNotifiedStationId', () => {
-    it('AsyncStorage에서 LAST_NOTIFIED_STATION_KEY 값을 읽어 반환한다', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('station-1');
+  describe('getLastNotifiedStationId (destination scoped, #1011)', () => {
+    it('저장된 destinationId와 일치하면 stationId를 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ destinationId: 'dest-1', stationId: 'station-1' }),
+      );
 
-      const result = await getLastNotifiedStationId();
+      const result = await getLastNotifiedStationId('dest-1');
 
       expect(AsyncStorage.getItem).toHaveBeenCalledWith(LAST_NOTIFIED_STATION_KEY);
       expect(result).toBe('station-1');
     });
 
+    it('저장된 destinationId와 다르면 stale로 간주하고 null을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ destinationId: 'dest-1', stationId: 'station-1' }),
+      );
+
+      const result = await getLastNotifiedStationId('dest-2');
+
+      expect(result).toBeNull();
+    });
+
+    it('destinationId가 null이면 null을 반환한다 (storage read 스킵)', async () => {
+      const result = await getLastNotifiedStationId(null);
+
+      expect(result).toBeNull();
+      expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    });
+
     it('AsyncStorage가 null을 반환하면 null을 반환한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
 
-      const result = await getLastNotifiedStationId();
+      const result = await getLastNotifiedStationId('dest-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('JSON 파싱 실패 시 null을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+
+      const result = await getLastNotifiedStationId('dest-1');
 
       expect(result).toBeNull();
     });
@@ -57,25 +84,31 @@ describe('notificationState', () => {
     it('AsyncStorage가 에러를 던지면 null을 반환한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
-      const result = await getLastNotifiedStationId();
+      const result = await getLastNotifiedStationId('dest-1');
 
       expect(result).toBeNull();
     });
   });
 
-  describe('setLastNotifiedStationId', () => {
-    it('AsyncStorage에 LAST_NOTIFIED_STATION_KEY로 값을 저장한다', async () => {
+  describe('setLastNotifiedStationId (destination scoped, #1011)', () => {
+    it('destinationId와 stationId를 객체로 직렬화해 저장한다', async () => {
       (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
 
-      await setLastNotifiedStationId('station-2');
+      await setLastNotifiedStationId('dest-1', 'station-2');
 
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(LAST_NOTIFIED_STATION_KEY, 'station-2');
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        LAST_NOTIFIED_STATION_KEY,
+        expect.any(String),
+      );
+      const written = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(written.destinationId).toBe('dest-1');
+      expect(written.stationId).toBe('station-2');
     });
 
     it('AsyncStorage가 에러를 던져도 throw하지 않는다', async () => {
       (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 
-      await expect(setLastNotifiedStationId('station-3')).resolves.toBeUndefined();
+      await expect(setLastNotifiedStationId('dest-1', 'station-3')).resolves.toBeUndefined();
     });
   });
 

--- a/src/features/alarm/utils/__tests__/notificationState.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationState.test.ts
@@ -81,6 +81,14 @@ describe('notificationState', () => {
       expect(result).toBeNull();
     });
 
+    it('유효한 JSON이지만 레코드 형식이 아니면 null을 반환한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
+
+      const result = await getLastNotifiedStationId('dest-1');
+
+      expect(result).toBeNull();
+    });
+
     it('AsyncStorage가 에러를 던지면 null을 반환한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
 

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -431,7 +431,7 @@ describe('processLocationUpdate', () => {
       isTransfer: false,
       stopsToDestination: 3,
     }, undefined);
-    expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('station-1');
+    expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(mockDestination.id, 'station-1');
   });
 
   it('does not send station-passed notification when station is the same as stored', async () => {
@@ -458,7 +458,7 @@ describe('processLocationUpdate', () => {
       isTransfer: false,
       stopsToDestination: 3,
     }, undefined);
-    expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('station-1');
+    expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(mockDestination.id, 'station-1');
   });
 
   it('does not mutate firedAlarms (responsibility moved to caller)', async () => {

--- a/src/features/alarm/utils/alarmScheduler.ts
+++ b/src/features/alarm/utils/alarmScheduler.ts
@@ -68,6 +68,11 @@ export interface ScheduleAlarmsParams {
     direction: AlarmLogDirection | null;
     usedTrainCode: string | null;
   };
+  /**
+   * #1011 — destination-scoped lastNotifiedStationId 진단용. 제공 시 destination-scoped 읽기.
+   * 미제공(undefined) 시 null을 사용해 scoped read를 skip — 이전 진단 로그와 동일 의미.
+   */
+  destinationId?: string;
   /** 테스트에서 시각 주입용. 기본값은 Date.now(). */
   now?: number;
 }
@@ -93,6 +98,7 @@ export async function scheduleAlarmsForRoute(
     destinationName,
     currentStationApproachEtaSeconds,
     stamp,
+    destinationId = null,
     now = Date.now(),
   } = params;
 
@@ -113,7 +119,8 @@ export async function scheduleAlarmsForRoute(
 
   // 발사 시점 비교용으로, 예약 직전 LAST_NOTIFIED_STATION을 한 번만 읽는다.
   // 발사 시 실제 값과 다르면 "예상한 위치와 실제 위치가 어긋났다"는 진단 신호.
-  const actualLastNotifiedStation = await getLastNotifiedStationId();
+  // #1011: destinationId가 제공된 경우 destination-scoped 읽기.
+  const actualLastNotifiedStation = await getLastNotifiedStationId(destinationId);
   const stampDirection = stamp?.direction ?? null;
   const stampTrainCode = stamp?.usedTrainCode ?? null;
 

--- a/src/features/alarm/utils/notificationState.ts
+++ b/src/features/alarm/utils/notificationState.ts
@@ -39,12 +39,46 @@ async function safeRemoveItem(key: string): Promise<void> {
   }
 }
 
-export function getLastNotifiedStationId(): Promise<string | null> {
-  return safeGetItem(LAST_NOTIFIED_STATION_KEY);
+// #1011: lastNotifiedStationId를 destination tuple로 scoping.
+// 저장 포맷: `{ destinationId, stationId }`. read 시점 destinationId가 저장된 것과
+// 다르면 stale로 간주하고 null을 반환한다. destinationId가 null이면 항상 null.
+interface LastNotifiedRecord {
+  destinationId: string;
+  stationId: string;
 }
 
-export function setLastNotifiedStationId(id: string): Promise<void> {
-  return safeSetItem(LAST_NOTIFIED_STATION_KEY, id);
+function isLastNotifiedRecord(value: unknown): value is LastNotifiedRecord {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as LastNotifiedRecord).destinationId === 'string' &&
+    typeof (value as LastNotifiedRecord).stationId === 'string'
+  );
+}
+
+export async function getLastNotifiedStationId(
+  destinationId: string | null,
+): Promise<string | null> {
+  if (!destinationId) return null;
+  const raw = await safeGetItem(LAST_NOTIFIED_STATION_KEY);
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isLastNotifiedRecord(parsed)) return null;
+    if (parsed.destinationId !== destinationId) return null;
+    return parsed.stationId;
+  } catch (e) {
+    logger.error(`${LAST_NOTIFIED_STATION_KEY} 파싱 실패:`, e);
+    return null;
+  }
+}
+
+export function setLastNotifiedStationId(
+  destinationId: string,
+  stationId: string,
+): Promise<void> {
+  const record: LastNotifiedRecord = { destinationId, stationId };
+  return safeSetItem(LAST_NOTIFIED_STATION_KEY, JSON.stringify(record));
 }
 
 export function clearLastNotifiedStationId(): Promise<void> {

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -320,7 +320,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       kind: 'station-passed',
     });
   } else if (route && isStationOnRoute(nearest.station, route)) {
-    const lastNotifiedStationId = await getLastNotifiedStationId();
+    const lastNotifiedStationId = await getLastNotifiedStationId(destination.id);
     if (nearest.station.id !== lastNotifiedStationId) {
       // #796: 환승역 도착 timing의 segment 정확 식별. evaluateAlarmPhase(:233)와 동일한
       // currentLine 결정 — lock.boardingLine 우선 → BG GPS jitter로 nearest가 옆 노선 station을
@@ -338,7 +338,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
           target,
           notificationSource,
         );
-        await setLastNotifiedStationId(nearest.station.id);
+        await setLastNotifiedStationId(destination.id, nearest.station.id);
         logFiredStationPassed(source, nearest.station);
 
         // #624 BG-safe stale alarm 차단 — 통과한 waypoint의 pre-scheduled bl:* 알람을

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -252,7 +252,7 @@ describe('FG↔BG 통합: 알림 dedup (notificationState 단일 출처)', () =>
   it('FG에서 알림 발사 후 BG가 같은 역 받으면 중복 발사하지 않는다', async () => {
     await runFgPipelineAt(fakeStation);
     expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
-    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeStation.id);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
 
     await runBgTaskAt(fakeStation);
 
@@ -262,7 +262,7 @@ describe('FG↔BG 통합: 알림 dedup (notificationState 단일 출처)', () =>
   it('BG에서 알림 발사 후 FG가 같은 역 받으면 중복 발사하지 않는다', async () => {
     await runBgTaskAt(fakeStation);
     expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
-    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeStation.id);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
 
     await runFgPipelineAt(fakeStation);
 
@@ -276,7 +276,7 @@ describe('FG↔BG 통합: 알림 dedup (notificationState 단일 출처)', () =>
     await runBgTaskAt(fakeNextStation);
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
-    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeNextStation.id);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeNextStation.id }));
   });
 
   it('AsyncStorage가 비어 있는 cold start(swipe-kill 직후)에는 BG 첫 콜백이 알림을 발사한다', async () => {
@@ -285,7 +285,7 @@ describe('FG↔BG 통합: 알림 dedup (notificationState 단일 출처)', () =>
     await runBgTaskAt(fakeStation);
 
     expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
-    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(fakeStation.id);
+    expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
   });
 });
 
@@ -388,7 +388,7 @@ describe('FG↔BG 통합: swipe-kill 후 재진입 (AsyncStorage 영속성)', ()
     await runBgTaskAt(fakeStation);
     expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
     const persistedId = mockStorage.get(LAST_NOTIFIED_STATION_KEY);
-    expect(persistedId).toBe(fakeStation.id);
+    expect(persistedId).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
 
     // swipe-kill 시뮬레이션: AsyncStorage는 보존, send mock 만 리셋해 "재진입 후 새 send" 검증.
     mockSendStationPassedNotification.mockClear();


### PR DESCRIPTION
## Summary

- `notificationState.ts`의 `lastNotifiedStationId`를 `{ destinationId, stationId }` JSON 포맷으로 변경해 destination별 격리
- `getLastNotifiedStationId(destinationId)` / `setLastNotifiedStationId(destinationId, stationId)` API 변경 — `firedAlarms` scoping(`#462`)과 동일 패턴
- `stationPipeline`, `useStationAlarm` (GPS path + fg-arvlcd fast-path), `alarmScheduler` 호출자 전부 업데이트
- `useSilentPushDiagnostics`: 새 JSON 포맷에서 `stationId` 추출, 구 plain string graceful fallback
- 테스트: `notificationState` scoped API 검증 6개 케이스 추가, `stationPipeline`/`useStationAlarm` assertion 2개 갱신

## Test plan

- [x] `src/features/alarm/utils/__tests__/notificationState.test.ts` — 신규 scoped API 전 케이스 pass
- [x] `src/features/alarm/utils/__tests__/stationPipeline.test.ts` — `setLastNotifiedStationId(destId, stationId)` assertion pass
- [x] `src/features/alarm/hooks/__tests__/useStationAlarm.test.ts` — GPS path / fg-arvlcd path assertion pass
- [x] `src/features/alarm/hooks/__tests__/useSilentPushDiagnostics.test.ts` — 구 plain string backward compat pass
- [x] `npm run type-check` — 내 변경 범위 내 오류 없음

Closes #1011