### PR TITLE
fix(#1014): hydrateLockFromCandidate acceptance gate

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -30,6 +30,12 @@ jest.mock('../../../../shared/utils/stationLookup', () => ({
   findStationByNameAndLine: (...args: unknown[]) => mockFindStationByNameAndLine(...args),
 }));
 
+// #1014 — movementGate 모듈 mock. STATIC_SPEED_THRESHOLD_MPS 실제값(0.5)을 노출해
+// acceptance gate 로직이 테스트에서 일관되게 동작하도록 격리.
+jest.mock('../../../nearest-station/utils/movementGate', () => ({
+  STATIC_SPEED_THRESHOLD_MPS: 0.5,
+}));
+
 function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   return {
     destination: '종착',
@@ -252,8 +258,19 @@ describe('useBoardingLockController', () => {
 
   // #915/#916 — backend autoLockCandidate hydrate. lockController가 createLock으로 위임.
   describe('hydrateLockFromCandidate (#915/#916)', () => {
+    // #1014 acceptance gate: 이 describe의 기본 inputs는 candidate trainCode 'AUTO-7'을
+    // directionalArrivals에 포함시켜 Gate 1을 통과하도록 설정.
+    const autoArrival: StationArrival = {
+      up: [makeTrain({ trainCode: 'AUTO-7' })],
+      down: [],
+    };
+    const hydrateInputs: UseBoardingLockControllerInputs = {
+      ...defaultInputs,
+      arrival: autoArrival,
+    };
+
     it('valid candidate + 컨텍스트 있음 → createLock 호출', async () => {
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
       });
@@ -271,7 +288,7 @@ describe('useBoardingLockController', () => {
 
     it('역명+line 매칭 시 boardingStationId 정정', async () => {
       mockFindStationByNameAndLine.mockReturnValueOnce({ id: 'stn-A-line2', name: '강남', line: '2' });
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
       });
@@ -281,7 +298,7 @@ describe('useBoardingLockController', () => {
 
     it('역명 매칭 실패 → currentStation.id 폴백', async () => {
       mockFindStationByNameAndLine.mockReturnValueOnce(null);
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
       });
@@ -291,7 +308,7 @@ describe('useBoardingLockController', () => {
 
     it('expectedDurationMinutes null → fallback 30분', async () => {
       const { result } = renderHook(() =>
-        useBoardingLockController({ ...defaultInputs, expectedDurationMinutes: null }),
+        useBoardingLockController({ ...hydrateInputs, expectedDurationMinutes: null }),
       );
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
@@ -306,7 +323,7 @@ describe('useBoardingLockController', () => {
       jest.spyOn(Date, 'now').mockReturnValue(1_700_000_111_222);
       try {
         const { result } = renderHook(() =>
-          useBoardingLockController({ ...defaultInputs, destinationId: null }),
+          useBoardingLockController({ ...hydrateInputs, destinationId: null }),
         );
         await act(async () => {
           result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
@@ -324,7 +341,7 @@ describe('useBoardingLockController', () => {
     });
 
     it('destinationId 있음 → sentinel marker 없음 (기존 동작 유지)', async () => {
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
       });
@@ -336,7 +353,7 @@ describe('useBoardingLockController', () => {
 
     it('currentStation null → no-op', async () => {
       const { result } = renderHook(() =>
-        useBoardingLockController({ ...defaultInputs, currentStation: null }),
+        useBoardingLockController({ ...hydrateInputs, currentStation: null }),
       );
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
@@ -345,7 +362,7 @@ describe('useBoardingLockController', () => {
     });
 
     it('candidate.line 무효 값 → no-op (graceful)', async () => {
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '99', subwayId: '1099' });
       });
@@ -367,7 +384,7 @@ describe('useBoardingLockController', () => {
       };
       mockGetBoardingLock.mockResolvedValue(existing);
       useBoardingLockStore.setState({ lock: existing });
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
       await waitFor(() => expect(useBoardingLockStore.getState().lock?.trainCode).toBe(opts.existingTrainCode));
       mockSetBoardingLock.mockClear();
       await act(async () => {
@@ -392,13 +409,120 @@ describe('useBoardingLockController', () => {
       // storage 일시 실패 시뮬레이션. createLock 내부의 setBoardingLock이 throw하면
       // useBoardingLockController의 .catch 분기로 흡수돼 다음 sync에서 자연 재시도.
       mockSetBoardingLock.mockRejectedValueOnce(new Error('storage'));
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
       await act(async () => {
         result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
       });
       // throw가 RN 외부로 새지 않으면 OK — 다음 fix에서 createLock이 다시 호출되도록 lock은 null 유지.
       await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
       expect(useBoardingLockStore.getState().lock).toBeNull();
+    });
+
+    // #1014 RC2 acceptance gate
+    describe('#1014 acceptance gate', () => {
+      it('Gate 1: candidate.trainCode가 directionalArrivals에 없으면 no-op (origin 이미 지난 열차 차단)', async () => {
+        const arrivalOther: StationArrival = {
+          up: [makeTrain({ trainCode: 'OTHER-1' })],
+          down: [],
+        };
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, arrival: arrivalOther }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'PAST-TRAIN', line: '2', subwayId: '1002' });
+        });
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+
+      it('Gate 1: arrival null이면 no-op (arrival 목록 없음 → 방향 확인 불가)', async () => {
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, arrival: null }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+
+      it('Gate 1: direction=up일 때 candidate가 down에만 있으면 no-op (방향 불일치 차단)', async () => {
+        mockResolveTripDirection.mockReturnValue('up');
+        const arrivalDirectional: StationArrival = {
+          up: [makeTrain({ trainCode: 'UP-TRAIN' })],
+          down: [makeTrain({ trainCode: 'DOWN-TRAIN' })],
+        };
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, arrival: arrivalDirectional }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'DOWN-TRAIN', line: '2', subwayId: '1002' });
+        });
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+
+      it('Gate 2: motionStationary=false + speedMps >= threshold → 양쪽 신호 이동 확인 → no-op', async () => {
+        // motionStationary=false 단독으로는 차단하지 않는다 — init 직후 false 초기값과 구별 불가.
+        // speedMps가 이동을 교차 확인할 때만 차단.
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...hydrateInputs, motionStationary: false, speedMps: 1.5 }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+
+      it('Gate 2: motionStationary=false + speedMps null → 단일 신호 불확실 → hydrate 허용 (init race 방지)', async () => {
+        // motionStationary=false는 앱 init 직후 useState 초기값일 수 있다.
+        // speedMps 미측정이면 이동 확신 불가 → 보수적으로 통과.
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...hydrateInputs, motionStationary: false }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      });
+
+      it('Gate 2: speedMps >= STATIC_SPEED_THRESHOLD_MPS(0.5)면 이동 중 → no-op', async () => {
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...hydrateInputs, speedMps: 1.5 }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+
+      it('Gate 2: motionStationary=true면 정적 → hydrate 허용 (speedMps 무관)', async () => {
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...hydrateInputs, motionStationary: true, speedMps: 0.8 }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      });
+
+      it('Gate 2: speedMps < STATIC_SPEED_THRESHOLD_MPS(0.5)면 정적 → hydrate 허용', async () => {
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...hydrateInputs, speedMps: 0.2 }),
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      });
+
+      it('Gate 2: motionStationary/speedMps 모두 미측정이면 보수적 통과 허용 (false negative 방지)', async () => {
+        // motionStationary=undefined, speedMps=undefined → 신호 없음 → 통과
+        const { result } = renderHook(() =>
+          useBoardingLockController(hydrateInputs), // motionStationary/speedMps 미전달
+        );
+        await act(async () => {
+          result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+        });
+        await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      });
     });
   });
 

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -11,6 +11,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import { STATIC_SPEED_THRESHOLD_MPS } from '../../nearest-station/utils/movementGate';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { LineNumber, Station } from '../../../shared/types/station';
@@ -32,6 +33,18 @@ export interface UseBoardingLockControllerInputs {
    * null이면 fallback 30분 — 잘못된 Lock이라도 자동 만료(× 1.5)가 작동한다.
    */
   expectedDurationMinutes: number | null;
+  /**
+   * #1014 acceptance gate: iOS CMMotionActivity stationary 신호.
+   * true이면 사용자가 원점 대기 중 — hydrate 허용.
+   * undefined는 미측정(게이트에서 speedMps로 fallback).
+   */
+  motionStationary?: boolean | undefined;
+  /**
+   * #1014 acceptance gate: GPS 속도(m/s).
+   * STATIC_SPEED_THRESHOLD_MPS(0.5) 미만이면 정적으로 판단 — hydrate 허용.
+   * null은 미측정(게이트에서 motionStationary로 fallback).
+   */
+  speedMps?: number | null;
 }
 
 export interface UseBoardingLockControllerResult {
@@ -83,6 +96,8 @@ export function useBoardingLockController({
   arrival,
   currentStation,
   expectedDurationMinutes,
+  motionStationary,
+  speedMps,
 }: UseBoardingLockControllerInputs): UseBoardingLockControllerResult {
   const lock = useBoardingLockStore((s) => s.lock);
   const loadLock = useBoardingLockStore((s) => s.loadLock);
@@ -170,12 +185,42 @@ export function useBoardingLockController({
   //  - destination 변경 시 controller의 stale-lock release effect가 lock=null로 만든 후에야 hydrate.
   //  - 자동 lock도 한 번 잡히면 변경 X (Seam F swap은 backend cron이 trip.boardingLock을 갱신하고
   //    silent push로 client store가 hydrate되는 별 경로).
+  // #1014 RC2 acceptance gate — 두 조건 모두 통과해야 hydrate:
+  //  1) candidate.trainCode가 directionalArrivals(현재 역 + 방향 필터)에 있는지 확인
+  //     → origin을 이미 지난 열차(arrival list 없음)는 자동 차단.
+  //     → 방향 불일치 열차도 동시에 차단 (directionalArrivals가 direction 필터 적용됨).
+  //  2) 사용자가 origin에서 정적 대기 중인지 확인 — motionStationary 우선, speedMps fallback.
+  //     → 이미 열차에 탑승해 이동 중인 상태에서 backend가 autoLockCandidate를 지연 응답하는
+  //        false positive를 차단.
   const hydrateLockFromCandidate = useCallback(
     (candidate: AutoLockCandidate) => {
       if (!currentStation) return;
       const boardingLine = asLineNumber(candidate.line);
       if (!boardingLine) return;
       if (lock) return;
+
+      // #1014 Gate 1: trainCode가 현재 directionalArrivals에 있는지 확인.
+      // directionalArrivals는 arrival + direction 필터로 이미 방향 일치 검증을 포함한다.
+      const trainInArrivals = directionalArrivals.some(
+        (t) => t.trainCode === candidate.trainCode,
+      );
+      if (!trainInArrivals) return;
+
+      // #1014 Gate 2: 사용자 원점 dwell 확인.
+      // motionStationary=true → 정적 확정 → 통과.
+      // motionStationary=false → 이동 가능성 있음. speedMps로 교차 검증:
+      //   speedMps >= STATIC_SPEED_THRESHOLD_MPS이면 이동 확정 → 차단.
+      //   speedMps null(미측정) 또는 정적이면 → 통과.
+      //   (motionStationary=false는 앱 init 직후 초기값일 수 있어 단독 차단하지 않는다)
+      // motionStationary 미측정(undefined)이면 speedMps로 단독 판단:
+      //   speedMps >= STATIC_SPEED_THRESHOLD_MPS → 차단. 미측정/정적 → 통과.
+      // 두 신호 모두 없거나 불확실하면 보수적으로 통과 — false negative보다 false positive 방지 우선.
+      if (motionStationary === true) {
+        // stationary 확인됨 → Gate 2 통과
+      } else if (speedMps != null && speedMps >= STATIC_SPEED_THRESHOLD_MPS) {
+        return; // GPS speed로 이동 중 확인 → no-op
+      }
+
       // #978 (PR #955 follow-up): destinationId 없으면 free-trip sentinel으로 hydrate.
       // 사용자가 나중에 실제 destination을 설정하면 위의 destination 변경 effect가
       // (sentinel !== realId) → 자동 release하므로 cross-talk 차단.
@@ -207,7 +252,7 @@ export function useBoardingLockController({
         // store action rejection은 graceful — loadLock race / storage 일시 실패는 다음 sync에서 자연 재시도.
       });
     },
-    [destinationId, currentStation, expectedDurationMinutes, lock, createLock],
+    [destinationId, currentStation, expectedDurationMinutes, lock, createLock, directionalArrivals, motionStationary, speedMps],
   );
 
   return {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -365,6 +365,8 @@ export default function HomeScreen() {
     arrival,
     currentStation: result?.station ?? null,
     expectedDurationMinutes: staticEtaMinutes,
+    motionStationary,
+    speedMps,
   });
   // #915 (C1 destination-only baseline UX) — destination 설정 직후 backend로 좋은 fix sync 발사.
   // backend cron이 9단 게이트 통과 시 autoLockCandidate 응답에 부착(#916) → 사용자 명시 탭 없이


### PR DESCRIPTION
## Summary

- **Gate 1**: `candidate.trainCode`가 `directionalArrivals`(방향 필터 포함)에 없으면 hydrate 보류 — origin을 이미 지난 열차 및 방향 불일치 열차 자동 차단
- **Gate 2**: `speedMps >= 0.5 m/s`이면 이동 중으로 판단해 보류. `motionStationary=true`이면 speedMps 무관하게 통과. `motionStationary=false` 단독 차단 제거 — init 직후 `useState(false)` 초기값과 구별 불가하므로 speedMps 교차 검증 필수
- `HomeScreen.tsx`: `motionStationary`/`speedMps`를 `useBoardingLockController`에 전달

Closes #1014

## Test plan

- [ ] `npx jest src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx --no-coverage` → 43 tests pass
- [ ] `npm run type-check` pass
- [ ] Gate 1: trainCode 불일치 → no-op
- [ ] Gate 1: arrival null → no-op
- [ ] Gate 1: direction=up에서 down 열차 → no-op
- [ ] Gate 2: speedMps >= 0.5 → no-op
- [ ] Gate 2: motionStationary=true + speedMps=0.8 → hydrate 허용
- [ ] Gate 2: motionStationary=false + speedMps null → hydrate 허용 (init race 방지)
- [ ] Gate 2: 두 신호 미측정 → hydrate 허용