### PR TITLE
fix(#1013): motion warmup window + positionStability 60s fallback

### DIFF
--- a/src/features/alarm/hooks/useDestinationAutoClear.ts
+++ b/src/features/alarm/hooks/useDestinationAutoClear.ts
@@ -54,8 +54,8 @@ export interface UseDestinationAutoClearInputs {
   destination: Station | null;
   /** Fusion에서 결정된 사용자 좌표. null이면 거리 게이트 통과 불가 → detect=false. */
   userLocation: { lat: number; lng: number } | null;
-  /** CMMotionActivity stationary 신호. 미지원/거절 케이스는 false로 전달되어 detect=false. */
-  motionStationary: boolean;
+  /** CMMotionActivity stationary 신호. 미지원/거절 케이스는 false, warmup은 undefined로 전달. */
+  motionStationary: boolean | undefined;
   /**
    * 자동 해제 시 호출. `setDestination(null)` 등 cleanup은 caller 책임이다.
    * #1058: cleared station을 인자로 받아 caller가 undo toast에 노출하거나 복원할 수 있다.

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -216,8 +216,10 @@ export interface UseStationAlarmInputs {
    * #728 — CMMotionActivity(iOS) motion=stationary 신호. true면 OS 가속도계가 사용자 정적으로 판정.
    * evaluateMovement가 'motion-stationary' reason으로 모든 카테고리(destination/transfer/station-passed)
    * 알람을 차단. 미전달/false면 기존 가드만 동작 (graceful fallback).
+   * #1013 — undefined는 warmup 상태(fg-hydrate 직후 ~30s). speed=null + positionStability=unknown과
+   * 동시 발생 시 evaluateMovement가 'motion-warmup'으로 차단.
    */
-  motionStationary?: boolean;
+  motionStationary?: boolean | undefined;
   /**
    * #917 A2 follow-up — FG fast path arvlCd∈{0,1} 매역 알림 입력.
    *

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -74,12 +74,14 @@ export type AlarmLogReason =
   // #727 — 정적 misfire 가드(movementGate.ts)가 차단한 발사.
   // #733 — 'movement-static-position'은 speed 미측정 시 위치 이력(usePositionStability) 기반 정적 차단.
   // #728 — 'movement-motion-stationary'는 CMMotionActivity(iOS) motion=stationary 신호 기반.
+  // #1013 — 'movement-motion-warmup'은 fg-hydrate 직후 warmup window 동안 신호 부재 차단.
   | 'movement-no-location'
   | 'movement-stale-timestamp'
   | 'movement-low-accuracy'
   | 'movement-static-speed'
   | 'movement-static-position'
   | 'movement-motion-stationary'
+  | 'movement-motion-warmup'
   // #750 — 공통 sleep 룰 게이트(shouldSuppressBySleepRule)가 차단한 발사.
   // scheduler/FG/BG 3개 path 어디서든 같은 reason으로 적재 — 정책 단일 출처.
   | 'sleep-first-transfer'

--- a/src/features/alarm/utils/recallMetrics.ts
+++ b/src/features/alarm/utils/recallMetrics.ts
@@ -80,6 +80,7 @@ export const GATE_SUPPRESSION_REASONS: readonly AlarmLogReason[] = [
   'movement-static-speed',
   'movement-static-position',
   'movement-motion-stationary',
+  'movement-motion-warmup',
   'sleep-first-transfer',
   'lockless-non-intermediate',
   'lockless-opt-out',

--- a/src/features/nearest-station/hooks/__tests__/useMotionActivity.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useMotionActivity.test.ts
@@ -39,23 +39,24 @@ describe('useMotionActivity (#728)', () => {
     jest.useRealTimers();
   });
 
-  it('미지원 디바이스 — stationary 항상 false, start/stop 호출 안 함', async () => {
+  it('미지원 디바이스 — stationary false로 확정, start/stop 호출 안 함', async () => {
     mockSupported.mockReturnValue(false);
     const { result, unmount } = renderHook(() => useMotionActivity());
-    await waitFor(() => expect(mockSupported).toHaveBeenCalled());
-    expect(result.current).toBe(false);
+    // #1013: 초기값 undefined → init()에서 미지원 감지 후 false로 확정. waitFor로 상태 정착 대기.
+    await waitFor(() => expect(result.current).toBe(false));
     expect(mockRequest).not.toHaveBeenCalled();
     expect(mockStart).not.toHaveBeenCalled();
     unmount();
     expect(mockStop).not.toHaveBeenCalled();
   });
 
-  it('권한 거절 — stationary false, startUpdates 호출 안 함', async () => {
+  it('권한 거절 — stationary false로 확정, startUpdates 호출 안 함', async () => {
     mockSupported.mockReturnValue(true);
     mockRequest.mockResolvedValue(false);
     const { result, unmount } = renderHook(() => useMotionActivity());
-    await waitFor(() => expect(mockRequest).toHaveBeenCalled());
-    expect(result.current).toBe(false);
+    // #1013: 초기값 undefined → 권한 거절 후 false로 확정. waitFor로 상태 정착 대기.
+    await waitFor(() => expect(result.current).toBe(false));
+    expect(mockRequest).toHaveBeenCalled();
     expect(mockStart).not.toHaveBeenCalled();
     unmount();
     expect(mockStop).not.toHaveBeenCalled();
@@ -112,5 +113,30 @@ describe('useMotionActivity (#728)', () => {
     await waitFor(() => expect(mockStart).toHaveBeenCalled());
     unmount();
     expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+
+  // #1013 — warmup window 보호: mount 직후 async init 완료 전 undefined 반환.
+  it('mount 직후 초기값 undefined (warmup 상태)', () => {
+    mockSupported.mockReturnValue(true);
+    // requestPermission을 resolve하지 않으면 async init이 pending 상태 유지.
+    mockRequest.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useMotionActivity());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('권한 요청 중 unmount — cancelled=true로 init 조기 종료', async () => {
+    // await requestPermission 중 unmount → cancelled=true → setStationary/startUpdates 미호출.
+    let resolveRequest!: (v: boolean) => void;
+    mockSupported.mockReturnValue(true);
+    mockRequest.mockReturnValue(new Promise<boolean>((res) => { resolveRequest = res; }));
+
+    const { result, unmount } = renderHook(() => useMotionActivity());
+    // init이 await requestPermission에서 멈춰 있는 동안 undefined 상태.
+    expect(result.current).toBeUndefined();
+    // unmount → cancelled=true.
+    unmount();
+    // requestPermission resolve 후 cancelled=true → 즉시 return (startUpdates 미호출).
+    act(() => { resolveRequest(true); });
+    expect(mockStart).not.toHaveBeenCalled();
   });
 });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -214,8 +214,10 @@ export function useFusedNearestStation(
   /**
    * #728 — CMMotionActivity(iOS) motion=stationary 신호. shouldDowngradeFusion이 speed=null인
    * 정적 사용자 케이스에서 positionStability보다 우선 적용. 미전달이면 기존 동작 유지.
+   * #1013 — undefined는 warmup 상태(fg-hydrate 직후 ~30s). evaluateMovement로 전달되어
+   * speed=null + positionStability=unknown과 동시 발생 시 'motion-warmup'으로 차단.
    */
-  motionStationary?: boolean,
+  motionStationary?: boolean | undefined,
   /**
    * #903 (Seam G) + #921 — 기압계 신호 묶음.
    * - `subsurface`: dP/dt가 지하 진입을 시사하는지. true면 GPS-only 결과는 'gps-only-underground'로

--- a/src/features/nearest-station/hooks/useMotionActivity.ts
+++ b/src/features/nearest-station/hooks/useMotionActivity.ts
@@ -4,13 +4,17 @@
  * 동작:
  *   1. mount 시 isMotionActivitySupported 확인 → true면 권한 요청
  *   2. 권한 부여되면 startMotionActivityUpdates + 폴링으로 stationary 상태 sync
- *   3. 미지원/거절 케이스는 false 유지 — 호출자(useStationAlarm 등)는 motion 가드 비활성화로 인식
+ *   3. 미지원/거절 케이스는 false로 확정 — 호출자는 motion 가드 비활성화로 인식
  *   4. unmount 시 stopMotionActivityUpdates로 cleanup
  *
  * 폴링 간격(POLL_INTERVAL_MS): 5초 — 알람 평가 주기(30초)보다 짧아 stale 우려 적음.
  *   너무 짧으면 native 부하, 너무 길면 motion 변화 누락. 5초가 절충점.
  *
- * 반환값: stationary boolean. true면 사용자 정적 확정.
+ * #1013 — 반환 타입을 `boolean | undefined`로 확장.
+ *   - `undefined` : 초기화 중 warmup 상태. mount 직후 async init 완료 전 (~30s).
+ *                   evaluateMovement가 'motion-warmup'으로 차단해 신호 부재 구간 게이트 우회 방지.
+ *   - `false`     : 미지원/권한 거절로 motion 가드 영구 비활성화. speed/positionStability fallback으로.
+ *   - `true/false`: 권한 부여 후 실시간 stationary 상태.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -25,8 +29,9 @@ import {
 /** 폴링 주기 — 너무 짧으면 native 부하, 너무 길면 motion 변화 누락. 5s는 절충점. */
 const POLL_INTERVAL_MS = 5_000;
 
-export function useMotionActivity(): boolean {
-  const [stationary, setStationary] = useState<boolean>(false);
+export function useMotionActivity(): boolean | undefined {
+  // undefined = warmup(초기화 중). 권한 결과 또는 첫 stationary 값을 받으면 boolean으로 확정.
+  const [stationary, setStationary] = useState<boolean | undefined>(undefined);
   const startedRef = useRef<boolean>(false);
 
   useEffect(() => {
@@ -34,9 +39,16 @@ export function useMotionActivity(): boolean {
     let intervalId: ReturnType<typeof setInterval> | null = null;
 
     const init = async () => {
-      if (!isMotionActivitySupported()) return;
+      if (!isMotionActivitySupported()) {
+        setStationary(false);
+        return;
+      }
       const granted = await requestMotionActivityPermission();
-      if (cancelled || !granted) return;
+      if (cancelled) return;
+      if (!granted) {
+        setStationary(false);
+        return;
+      }
 
       startMotionActivityUpdates();
       startedRef.current = true;

--- a/src/features/nearest-station/utils/__tests__/movementGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/movementGate.test.ts
@@ -287,8 +287,16 @@ describe('movementGate', () => {
       expect(m.reliable).toBe(true);
     });
 
-    it('speed 없음 + positionStability=unknown이면 reliable=true (보수)', () => {
+    it('speed 없음 + positionStability=unknown + motionStationary 미전달이면 warmup으로 차단 (#1013)', () => {
+      // fg-hydrate 직후 warmup: motion=undefined + speed=null + position=unknown = 신호 부재 구간 차단.
       const m = evaluateMovement({ accuracyM: 50 }, undefined, 'unknown');
+      expect(m.reliable).toBe(false);
+      expect(m.reason).toBe('motion-warmup');
+    });
+
+    it('speed 없음 + positionStability=unknown + motionStationary=false이면 reliable=true (권한 거절 후 정상 경로)', () => {
+      // motion 권한 거절로 motionStationary=false 고정 → warmup 조건 미충족 → gate 통과.
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'unknown', false);
       expect(m.reliable).toBe(true);
     });
 
@@ -419,6 +427,52 @@ describe('movementGate', () => {
     it('motionStationary=true + positionStability=moving이면 true (motion이 우선)', () => {
       // speed 미측정인 경우 motion이 positionStability보다 우선 — OS 가속도계가 더 신뢰성 있음
       expect(isStaticSpeedSignal(null, 50, 'moving', true)).toBe(true);
+    });
+  });
+
+  // #1013 — fg-hydrate warmup window 보호: motionStationary=undefined(초기화 중) +
+  // speedMps=null + positionStability='unknown' 동시 발생 시 'motion-warmup' 차단.
+  describe('#1013 — evaluateMovement motion-warmup 보호', () => {
+    it('motionStationary=undefined + speed=null + positionStability=unknown → motion-warmup', () => {
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'unknown', undefined);
+      expect(m.reliable).toBe(false);
+      expect(m.reason).toBe('motion-warmup');
+    });
+
+    it('motionStationary=false + speed=null + positionStability=unknown → reliable=true (권한 거절은 warmup 아님)', () => {
+      // motion 권한 거절로 false 고정: warmup 조건(undefined) 미충족 → gate 통과.
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'unknown', false);
+      expect(m.reliable).toBe(true);
+    });
+
+    it('motionStationary=undefined + speedMps 있음 → warmup 조건 미충족 → speed 게이트로 평가', () => {
+      // speed가 있으면 warmup 방어선 도달 전에 speed 게이트에서 처리.
+      const mStatic = evaluateMovement({ speedMps: 0, accuracyM: 50 }, undefined, 'unknown', undefined);
+      expect(mStatic.reason).toBe('static-speed');
+      const mMoving = evaluateMovement({ speedMps: 5, accuracyM: 50 }, undefined, 'unknown', undefined);
+      expect(mMoving.reliable).toBe(true);
+    });
+
+    it('motionStationary=undefined + speed=null + positionStability=moving → reliable=true (이동 확정)', () => {
+      // positionStability가 'moving'이면 warmup 조건 미충족 → gate 통과.
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'moving', undefined);
+      expect(m.reliable).toBe(true);
+    });
+
+    it('motionStationary=undefined + speed=null + positionStability 미전달 → reliable=true (기존 동작 유지)', () => {
+      // positionStability가 undefined면 'unknown'과 다름 → warmup 미발동.
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, undefined, undefined);
+      expect(m.reliable).toBe(true);
+    });
+
+    it('평가 순서: motion-warmup은 static-position보다 앞에 도달하지 않음 (static-position이 우선)', () => {
+      // positionStability='static' → static-position이 먼저 (warmup 조건=unknown).
+      const m = evaluateMovement({ accuracyM: 50 }, undefined, 'static', undefined);
+      expect(m.reason).toBe('static-position');
+    });
+
+    it('MOVEMENT_TO_ALARM_LOG_REASON에 motion-warmup 포함', () => {
+      expect(MOVEMENT_TO_ALARM_LOG_REASON['motion-warmup']).toBe('movement-motion-warmup');
     });
   });
 

--- a/src/features/nearest-station/utils/movementGate.ts
+++ b/src/features/nearest-station/utils/movementGate.ts
@@ -23,7 +23,15 @@
  *   - 평가 순서: stale > accuracy > **motion-stationary** > speed > position.
  *     motion이 speed보다 우선 — 16:14:22 회귀에서 snapshot speed=0.69 m/s가 STATIC_SPEED_THRESHOLD_MPS=0.5를
  *     우회한 phantom 케이스를 잡기 위함. destination/transfer 카테고리도 같은 가드로 보호.
- *   - 권한 거절/미지원: motionStationary 미전달 → 기존 가드만 동작 (graceful fallback).
+ *   - 권한 거절/미지원: motionStationary=false → speed/positionStability 가드로 fallback.
+ *
+ * #1013 — warmup window 보호 + positionStability 60s fallback:
+ *   - fg-hydrate 직후 30s warmup window 동안 motionStationary=undefined (아직 초기화 중).
+ *     이 상태에서 speedMps=null + positionStability='unknown'이면 신호 부재 구간 → 'motion-warmup'으로 차단.
+ *   - motion 권한 거절(motionStationary=false 고정) 시 speed 미측정이면 positionStability fallback이
+ *     유일한 정적 판정 수단. positionStability 60s 수집이 완료되면 'static'/'moving'으로 정상 동작.
+ *   - 평가 순서 확장: stale > accuracy > motion-stationary(=true) > speed > position > **motion-warmup**
+ *     (motion=undefined + speed=null + positionStability=unknown일 때 마지막 보호막).
  *
  * 입력 필드는 모두 옵션 — 호출자가 측정 가능한 신호만 전달하면 된다. 누락된 신호는
  * 해당 분기 검증을 skip (false negative보다 false positive 차단 우선).
@@ -49,7 +57,11 @@ export type MovementReason =
   | 'static-position'
   // #728 — CMMotionActivity(iOS) motion=stationary 신호. OS 가속도계 기반 정적 판정.
   // speed=0.69 m/s 같은 임계 우회 phantom과 destination/transfer 카테고리 무방비 회귀를 동시에 차단.
-  | 'motion-stationary';
+  | 'motion-stationary'
+  // #1013 — fg-hydrate 직후 warmup window(~30s) 동안 motion 신호가 아직 초기화되지 않은 상태.
+  // motionStationary=undefined + speedMps=null + positionStability='unknown' 동시 발생 시 신호 부재
+  // 구간으로 차단. positionStability 60s 수집 또는 motion 초기화 완료 후 자연 해소.
+  | 'motion-warmup';
 
 interface MovementSignalShared {
   speedMps?: number;
@@ -76,6 +88,7 @@ export const MOVEMENT_TO_ALARM_LOG_REASON = {
   'static-speed': 'movement-static-speed',
   'static-position': 'movement-static-position',
   'motion-stationary': 'movement-motion-stationary',
+  'motion-warmup': 'movement-motion-warmup',
 } as const satisfies Record<MovementReason, string>;
 
 /**
@@ -177,7 +190,9 @@ export interface LocationSignalInput {
  *        destination/transfer 카테고리 무방비를 동시 차단하는 핵심 신호.
  *   5. speedMps 있으면서 < STATIC_SPEED_THRESHOLD_MPS → 'static-speed'
  *   6. (#733) speedMps 없고 positionStability='static' → 'static-position'
- *   7. 그 외 → reliable=true
+ *   7. (#1013) motionStationary=undefined + speedMps=null + positionStability='unknown' → 'motion-warmup'
+ *      - fg-hydrate 직후 warmup window. 모든 신호가 부재할 때 한시적 차단.
+ *   8. 그 외 → reliable=true
  *
  * 호출자는 결과의 reason으로 logSuppressedGate/logSilentPushSkipped 등 적재.
  */
@@ -185,6 +200,13 @@ export function evaluateMovement(
   loc: LocationSignalInput | null,
   now: number = Date.now(),
   positionStability?: PositionStability,
+  /**
+   * CMMotionActivity stationary 신호.
+   *   - `true`  : OS 가속도계가 정적 확정 → 즉시 차단 (speed보다 우선).
+   *   - `false` : 이동 중 또는 motion 권한 거절/미지원 → motion 가드 스킵, speed/position fallback.
+   *   - `undefined` : 초기화 중 warmup 상태(fg-hydrate 직후 ~30s). speed=null + positionStability=unknown
+   *                   동시 발생 시 'motion-warmup'으로 차단해 신호 부재 구간 게이트 우회 방지 (#1013).
+   */
   motionStationary?: boolean,
 ): MovementSignal {
   if (!loc) return { reliable: false, reason: 'no-location' };
@@ -215,6 +237,14 @@ export function evaluateMovement(
   // 차단. 'unknown'/'moving'은 신뢰성 없음 → 기존 path 유지 (reliable).
   if (loc.speedMps == null && positionStability === 'static') {
     return { reliable: false, reason: 'static-position' };
+  }
+
+  // #1013 — warmup window 보호. fg-hydrate 직후 motionStationary=undefined(초기화 중) +
+  // speedMps=null + positionStability='unknown' 동시 발생 = 모든 신호 부재 구간.
+  // 이 상태에서 gate를 통과시키면 stale 좌표 기반 잘못된 알람 발사 위험.
+  // positionStability 60s 수집 또는 motion 초기화 완료 후 자연 해소 — 한시적 차단.
+  if (motionStationary === undefined && loc.speedMps == null && positionStability === 'unknown') {
+    return { reliable: false, reason: 'motion-warmup' };
   }
 
   const result: MovementSignal = { reliable: true };

--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -38,8 +38,8 @@ import type { Route } from '../../../shared/utils/stationRoute';
 export interface UseTransferAutoDetectInputs {
   /** 환승역 신호 + 후보 산출에 필요한 현재 fusion 결과. */
   readonly nearestStations: NearestStationsResult | null;
-  /** 현재 정차 중 여부 — `false`(walking)일 때만 detect 활성. */
-  readonly motionStationary: boolean;
+  /** 현재 정차 중 여부 — `false`/`undefined`(warmup)일 때만 detect 활성. */
+  readonly motionStationary: boolean | undefined;
   /** 현재 origin station의 도착 데이터(useArrivalInfo 결과). 다른 노선 후보 추출 입력. */
   readonly arrival: StationArrival | null;
   /** 현재 BoardingLock. 활성이면 boardingLine과 같은 후보는 제외(자기 노선 무한 detect 회피). */


### PR DESCRIPTION
Closes #1013

## 변경 사항

### movementGate.ts
- `motion-warmup` MovementReason 추가
- `evaluateMovement`: `motionStationary=undefined + speedMps=null + positionStability='unknown'` 동시 발생 시 `'motion-warmup'` 반환 (fg-hydrate 직후 신호 부재 구간 차단)
- `MOVEMENT_TO_ALARM_LOG_REASON`에 `movement-motion-warmup` 등록
- 평가 순서 확장: stale > accuracy > motion-stationary(=true) > speed > static-position > **motion-warmup**
- 권한 거절(`motionStationary=false`) 케이스는 warmup 조건 미충족 → gate 통과

### useMotionActivity.ts
- 반환 타입 `boolean` → `boolean | undefined`
- 초기 state `undefined` (warmup) — mount 직후 async init 완료 전 evaluateMovement가 'motion-warmup'으로 차단
- 미지원/거절 시 명시적으로 `setStationary(false)` → evaluateMovement의 warmup 조건 미충족

### 타입 정합 정리
- `useStationAlarm`, `useDestinationAutoClear`, `useTransferAutoDetect`, `useFusedNearestStation`: `motionStationary` 타입 `boolean | undefined` 정합
- `alarmLog.ts`: `movement-motion-warmup` AlarmLogReason 등록
- `recallMetrics.ts`: `GATE_SUPPRESSION_REASONS`에 `movement-motion-warmup` 포함

## 테스트
- `movementGate.test.ts`: #1013 describe 블록 추가 (7개 케이스) + 기존 `positionStability=unknown` 케이스 warmup 동작으로 수정
- `useMotionActivity.test.ts`: warmup 초기값 undefined 케이스, unmount 중 취소 케이스, 미지원/거절 waitFor 정착 수정
- 두 파일 모두 커버리지 100%