### PR TITLE
fix(#1016): positionTrainResult 거리 게이트 3 hole 봉합

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",
       "!src/**/__tests__/**",
+      "!src/**/*.d.ts",
       "!src/shared/types/**",
       "!src/features/*/types/**",
       "!src/features/*/ports/**",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,src/**/__tests__/**,src/**/__tests__/**/*,app/**/__tests__/**,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx,backend/**,backend/**/*
+sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,src/**/__tests__/**,src/**/__tests__/**/*,app/**/__tests__/**,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx,backend/**,backend/**/*,src/features/nearest-station/utils/fusionDistanceGate.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.sources=src,app
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, i18n 번역 데이터)
 # 디렉토리 패턴 + 파일 패턴 모두 명시 — SonarCloud가 일부 경로에서 디렉토리 와일드카드를
 # 제대로 적용하지 못하는 케이스를 대비해 *.test.ts(x) 파일 단위 패턴도 추가한다.
-sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**
+sonar.exclusions=assets/**,**/__tests__/**,**/__tests__/**/*,src/**/__tests__/**,src/**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**
 
 # 중복 분석 제외 — Swift 파일은 sonar.sources(src,app) 밖이라 분석 대상이 아니지만
 # CPD는 별도 패스로 동작할 수 있어 명시적으로 전체 Swift를 CPD에서 제외.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.exclusions=assets/**,**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/__mocks
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx,backend/**,backend/**/*
+sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,src/**/__tests__/**,src/**/__tests__/**/*,app/**/__tests__/**,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx,backend/**,backend/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,11 +7,11 @@ sonar.sources=src,app
 # 분석 제외 (네이티브 HTML 에셋, 테스트, 빌드 산출물, 네이티브 모듈/위젯, i18n 번역 데이터)
 # 디렉토리 패턴 + 파일 패턴 모두 명시 — SonarCloud가 일부 경로에서 디렉토리 와일드카드를
 # 제대로 적용하지 못하는 케이스를 대비해 *.test.ts(x) 파일 단위 패턴도 추가한다.
-sonar.exclusions=assets/**,**/__tests__/**,**/__tests__/**/*,src/**/__tests__/**,src/**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**
+sonar.exclusions=assets/**,**/__tests__/**,**/__tests__/**/*,src/**/__tests__/**,src/**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,**/__mocks__/**,coverage/**,dist/**,node_modules/**,ios/**,android/**,targets/**,modules/**,backend/**,src/shared/i18n/locales/**,src/data/timetables/**,scripts/**,src/testUtils/**
 
 # 중복 분석 제외 — Swift 파일은 sonar.sources(src,app) 밖이라 분석 대상이 아니지만
 # CPD는 별도 패스로 동작할 수 있어 명시적으로 전체 Swift를 CPD에서 제외.
 # Live Activity ActivityKit 구조체가 widget 타겟과 CocoaPod 모듈에서 동일 정의를
 # 요구하는 의도된 중복(_shared 자동 링크가 pod 컴파일 단위 커버 못 함)이라 불가피.
 # i18n locales는 다국어 번역으로 키 구조 동일이 정상 — CPD 의미 없음.
-sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,src/**/__tests__/**,src/**/__tests__/**/*,app/**/__tests__/**,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx,backend/**,backend/**/*,src/features/nearest-station/utils/fusionDistanceGate.ts
+sonar.cpd.exclusions=**/*.swift,**/SubwayActivityAttributes.swift,targets/**,targets/**/*,modules/**,modules/**/*,src/shared/i18n/locales/**,**/__tests__/**,**/__tests__/**/*,**/*.test.ts,**/*.test.tsx,src/**/__tests__/**,src/**/__tests__/**/*,app/**/__tests__/**,src/data/timetables/**,**/__tests__/*.ts,**/__tests__/*.tsx,backend/**,backend/**/*,src/features/nearest-station/utils/fusionDistanceGate.ts,src/testUtils/**

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -19,20 +19,21 @@ import {
   arrivalRet,
   positionRet,
   makeTrain as train,
+  GPS_BASE_DEFAULTS,
 } from '../../../../testUtils/positionApiFixtures';
-import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
 
-jest.mock('../useNearestStation');
-jest.mock('../../../arrival/hooks/useArrivalInfo');
-jest.mock('../../../route/hooks/useTrainPositions');
 jest.mock('../../utils/findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
 }));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
 
-const mockUseNearest = useNearestStation as jest.Mock;
-const mockUseArrival = useArrivalInfo as jest.Mock;
-const mockUsePositions = useTrainPositions as jest.Mock;
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
 const mockFindTop = findTopNearestStations as jest.Mock;
 
 // Real 7호선 stations for arc tests
@@ -48,12 +49,7 @@ function gpsBase(overrides?: Record<string, unknown>) {
     result: { station: yongmasan, distanceKm: 0 },
     variants: [yongmasan],
     userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-    speedMps: 1,
-    accuracyMeters: 50,
-    loading: false,
-    error: null,
-    permissionDenied: false,
-    locationUncertain: false,
+    ...GPS_BASE_DEFAULTS,
     refresh: jest.fn(),
     ...overrides,
   };
@@ -90,21 +86,21 @@ function setup({
   trainCode,
   lock,
 }: SetupOpts = {}) {
-  mockUseNearest.mockReturnValue(gpsBase(gps));
+  mockNearest.mockReturnValue(gpsBase(gps));
   mockFindTop.mockReturnValue([{ station: findTopStation, distanceKm: 0 }]);
   const posVal = positionRet(positions ?? null);
   if (positionsOnce) {
-    mockUsePositions.mockReturnValueOnce(posVal);
+    mockPos.mockReturnValueOnce(posVal);
   } else {
-    mockUsePositions.mockReturnValue(posVal);
+    mockPos.mockReturnValue(posVal);
   }
   return renderHook(() => useFusedNearestStation(undefined, undefined, routeCtx, trainCode, lock));
 }
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockUseArrival.mockReturnValue(arrivalRet(null));
-  mockUsePositions.mockReturnValue(positionRet(null));
+  mockArrival.mockReturnValue(arrivalRet(null));
+  mockPos.mockReturnValue(positionRet(null));
 });
 
 describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
@@ -276,10 +272,10 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       const subRoute = makeDirectRoute(3, '7');
       const subRouteContext = { route: subRoute, origin: junggok, destination: konkuk };
 
-      mockUseNearest.mockReturnValue(gpsBase()); // GPS at 용마산(yongmasan)
+      mockNearest.mockReturnValue(gpsBase()); // GPS at 용마산(yongmasan)
       mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
       // line='7'(p0)이면 positions 반환, null이면(p1/p2) null 반환. 모든 render에서 일관 적용.
-      mockUsePositions.mockImplementation((line: string | null) =>
+      mockPos.mockImplementation((line: string | null) =>
         line === '7'
           ? positionRet({
               line: '7',
@@ -317,10 +313,10 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         expectedDurationMs: 600_000,
       });
 
-      mockUseNearest.mockReturnValue(gpsBase());
+      mockNearest.mockReturnValue(gpsBase());
       mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
       // 열차 위치 없음 → trainProgress null → positionTrainResult null.
-      // mockUsePositions는 beforeEach에서 null로 설정됨.
+      // mockPos는 beforeEach에서 null로 설정됨.
 
       const { result, rerender } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, routeCtx, 'T-INTERP', lock),

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -1,11 +1,4 @@
-/* eslint-disable import/no-restricted-paths --
- * Cross-feature orchestration: 이 파일은 의도적으로 여러 features의 hook/util을 조합하는
- * orchestrator 역할이라 직접 import가 본질적이다. Phase 5 enforce 모드에서 file-level disable로
- * 옵트인 처리. 후속 PR(별도 이슈)에서 orchestration 슬라이스(예: features/fusion/, app shell)로
- * 추출하여 disable을 제거할 예정.
- *
- * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
- */
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
 
 /**
  * #1016 positionTrainResult 거리 게이트 3 hole 봉합 회귀 방지 테스트.
@@ -78,6 +71,36 @@ function makeLock(overrides?: Partial<BoardingLock>): BoardingLock {
   };
 }
 
+type SetupOpts = {
+  gps?: Record<string, unknown>;
+  findTopStation?: ReturnType<typeof findStationByNameAndLine>;
+  positions?: Parameters<typeof positionRet>[0];
+  positionsOnce?: boolean;
+  routeCtx?: Parameters<typeof useFusedNearestStation>[2];
+  trainCode?: string;
+  lock?: BoardingLock;
+};
+
+function setup({
+  gps,
+  findTopStation = yongmasan,
+  positions,
+  positionsOnce = false,
+  routeCtx,
+  trainCode,
+  lock,
+}: SetupOpts = {}) {
+  mockUseNearest.mockReturnValue(gpsBase(gps));
+  mockFindTop.mockReturnValue([{ station: findTopStation, distanceKm: 0 }]);
+  const posVal = positionRet(positions ?? null);
+  if (positionsOnce) {
+    mockUsePositions.mockReturnValueOnce(posVal);
+  } else {
+    mockUsePositions.mockReturnValue(posVal);
+  }
+  return renderHook(() => useFusedNearestStation(undefined, undefined, routeCtx, trainCode, lock));
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockUseArrival.mockReturnValue(arrivalRet(null));
@@ -90,21 +113,14 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       // GPS 없는 상태. 이전 버전은 distanceKm=0으로 gate 자동 통과. 수정 후 null.
       // p0만 positions 반환(ReturnValueOnce) → p1/p2는 beforeEach의 null fallthrough.
       // → candidateTrains 후보 1개(single) → trackTrainProgress non-null → line 368 도달.
-      mockUseNearest.mockReturnValue(
-        gpsBase({ userLocation: null, result: null, accuracyMeters: 50 }),
-      );
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValueOnce(
-        positionRet({
-          line: '7',
-          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })],
-        }),
-      );
-
       const lock = makeLock({ boardingLine: '7', trainCode: 'T-A' });
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, 'T-A', lock),
-      );
+      const { result } = setup({
+        gps: { userLocation: null, result: null, accuracyMeters: 50 },
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })] },
+        positionsOnce: true,
+        trainCode: 'T-A',
+        lock,
+      });
 
       // userLocation=null → line 368 `if (!gps.userLocation) return null` → positionTrainResult null
       expect(result.current.source).not.toBe('position-train');
@@ -113,21 +129,10 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('GPS 좌표 복구되면 positionTrainResult 정상 채택', () => {
       // accuracyMeters=1500: 지하 bypass 모드. userLocation 있으므로 (a) 통과.
       // arc 없으므로 fix(b) 적용 — 하지만 거리 0(같은 좌표)이므로 gate 통과.
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-          accuracyMeters: 1500,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })],
-        }),
-      );
-
-      const { result } = renderHook(() => useFusedNearestStation());
+      const { result } = setup({
+        gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })] },
+      });
 
       expect(result.current.source).toBe('position-train');
     });
@@ -138,20 +143,17 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       // 충무로(3호선)는 yongmasan GPS(37.573647, 127.086727)에서 ~6.85km 떨어져 있다.
       // 이전 버전: accuracy=1500 > MAX_ACCURACY_M → bypass → 자동 통과.
       // 수정 후: lock 활성 + arc 없음 → bypass 비활성 → 거리 초과 → 탈락.
-      mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
+      const lock = makeLock({ boardingLine: '3' });
+      const { result } = setup({
+        gps: { accuracyMeters: 1500 },
+        positions: {
           line: '3',
           // 실제 충무로(3호선) 좌표는 yongmasan GPS에서 ~6.85km 떨어져 있다
           trains: [train(chungmuro3.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-B' })],
-        }),
-      );
-
-      const lock = makeLock({ boardingLine: '3' });
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, 'T-B', lock),
-      );
+        },
+        trainCode: 'T-B',
+        lock,
+      });
 
       // 충무로가 게이트 탈락 → positionTrain 미채택
       expect(result.current.source).not.toBe('position-train');
@@ -159,35 +161,23 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
 
     it('lock 활성 + arc 없을 때 accuracy=1500이지만 같은 좌표(0km)이면 gate 통과', () => {
       // 같은 좌표에 있으면 거리 = 0 → MAX_FUSION_DISTANCE_KM 이하 → 통과.
-      mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-B2' })],
-        }),
-      );
-
       const lock = makeLock({ boardingLine: '7', trainCode: 'T-B2' });
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, 'T-B2', lock),
-      );
+      const { result } = setup({
+        gps: { accuracyMeters: 1500 },
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-B2' })] },
+        trainCode: 'T-B2',
+        lock,
+      });
 
       expect(result.current.source).toBe('boarding-lock');
     });
 
     it('lock 없을 때 accuracy=1500(지하) bypass는 그대로 동작', () => {
       // fix(b)는 lock 활성 시에만 적용 — lock 없으면 기존 bypass 유지.
-      mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-NOLOCK' })],
-        }),
-      );
-
-      const { result } = renderHook(() => useFusedNearestStation());
+      const { result } = setup({
+        gps: { accuracyMeters: 1500 },
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-NOLOCK' })] },
+      });
 
       expect(result.current.source).toBe('position-train');
     });
@@ -201,24 +191,14 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       // 면목은 7호선이지만 yongmasan→konkuk arc 밖 (용마산보다 출발방향 뒤편)
       const myeonmok = findStationByNameAndLine('면목', '7')!;
       // accuracy=1500: arc 있으므로 fix(b) bypass 유지. fix(c)가 arc 소속을 검사.
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-          accuracyMeters: 1500,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(myeonmok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-OFF' })],
-        }),
-      );
-
       const lock = makeLock({ boardingLine: '7' });
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeContext, 'T-C-OFF', lock),
-      );
+      const { result } = setup({
+        gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
+        positions: { line: '7', trains: [train(myeonmok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-OFF' })] },
+        routeCtx: routeContext,
+        trainCode: 'T-C-OFF',
+        lock,
+      });
 
       // 면목은 arc 밖 → gate 탈락 → positionTrain 미채택
       expect(result.current.source).not.toBe('position-train');
@@ -228,25 +208,15 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('arc 위의 역(중곡)은 통과', () => {
       // 중곡 = arc idx 1. GPS를 중곡 좌표에 놓아 거리 게이트(b)도 통과시킨다.
       // accuracy=50(정상): fix(b) 엄격 모드이나 거리가 0(같은 좌표)이므로 통과.
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          userLocation: { lat: junggok.lat, lng: junggok.lng },
-          result: { station: junggok, distanceKm: 0 },
-          accuracyMeters: 50,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: junggok, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(junggok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-IN' })],
-        }),
-      );
-
       const lock = makeLock({ boardingLine: '7', trainCode: 'T-C-IN' });
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeContext, 'T-C-IN', lock),
-      );
+      const { result } = setup({
+        gps: { userLocation: { lat: junggok.lat, lng: junggok.lng }, result: { station: junggok, distanceKm: 0 }, accuracyMeters: 50 },
+        findTopStation: junggok,
+        positions: { line: '7', trains: [train(junggok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-IN' })] },
+        routeCtx: routeContext,
+        trainCode: 'T-C-IN',
+        lock,
+      });
 
       expect(result.current.result?.station.id).toBe(junggok.id);
       expect(result.current.source).toBe('boarding-lock');
@@ -255,23 +225,11 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('lock 없으면 arc 소속 검사 미작동 (기존 동작 유지)', () => {
       // fix(c)는 boardingLock 활성 시에만 동작.
       const myeonmok = findStationByNameAndLine('면목', '7')!;
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-          accuracyMeters: 1500,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(myeonmok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-NOLOCK' })],
-        }),
-      );
-
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeContext),
-      );
+      const { result } = setup({
+        gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
+        positions: { line: '7', trains: [train(myeonmok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-NOLOCK' })] },
+        routeCtx: routeContext,
+      });
 
       // lock 없으면 arc 검사 안 함 → 면목도 통과 가능
       expect(result.current.source).toBe('position-train');
@@ -280,25 +238,15 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('arc 안에 있지만 LOCK_NEXT_HOP_WINDOW 초과 시 gate 탈락', () => {
       // 건대입구: arc idx 4. boardingIdx(용마산=0) + WINDOW(3) = 3 → idx 4 초과 → 탈락.
       // GPS를 건대입구 좌표에 놓아 거리 게이트(b)는 통과시킴 → fix(c)가 탈락 원인.
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          result: { station: konkuk, distanceKm: 0 },
-          userLocation: { lat: konkuk.lat, lng: konkuk.lng },
-          accuracyMeters: 50,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: konkuk, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(konkuk.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-WINDOW' })],
-        }),
-      );
-
       const lock = makeLock({ boardingLine: '7', trainCode: 'T-C-WINDOW' });
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeContext, 'T-C-WINDOW', lock),
-      );
+      const { result } = setup({
+        gps: { result: { station: konkuk, distanceKm: 0 }, userLocation: { lat: konkuk.lat, lng: konkuk.lng }, accuracyMeters: 50 },
+        findTopStation: konkuk,
+        positions: { line: '7', trains: [train(konkuk.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-WINDOW' })] },
+        routeCtx: routeContext,
+        trainCode: 'T-C-WINDOW',
+        lock,
+      });
 
       // arc window 초과 → positionTrainResult null → position-train/boarding-lock 미채택
       expect(result.current.source).not.toBe('position-train');
@@ -308,24 +256,13 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('arc 없으면 arc 소속 검사 미작동 (routeContext 없는 경우)', () => {
       // arc 없으므로 fix(c) 비활성. fix(b)가 거리 검사 담당.
       // 용마산과 같은 좌표이므로 거리=0 → 통과.
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-          accuracyMeters: 1500,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
-        positionRet({
-          line: '7',
-          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-NOARC' })],
-        }),
-      );
-
       const lock = makeLock({ boardingLine: '7', trainCode: 'T-C-NOARC' });
-      const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, 'T-C-NOARC', lock),
-      );
+      const { result } = setup({
+        gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-NOARC' })] },
+        trainCode: 'T-C-NOARC',
+        lock,
+      });
 
       expect(result.current.source).toBe('boarding-lock');
     });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -22,8 +22,11 @@ import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
 import { findTopNearestStations } from '../../utils/findNearestStation';
 import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
 import { TRAIN_STATUS } from '../../../../shared/constants/trainStatus';
-import type { StationArrival } from '../../../../shared/types/arrival';
-import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import {
+  arrivalRet,
+  positionRet,
+  makeTrain as train,
+} from '../../../../testUtils/positionApiFixtures';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
 
@@ -59,34 +62,6 @@ function gpsBase(overrides?: Record<string, unknown>) {
     permissionDenied: false,
     locationUncertain: false,
     refresh: jest.fn(),
-    ...overrides,
-  };
-}
-
-function arrivalRet(stationArrival: StationArrival | null = null) {
-  return { arrival: stationArrival, loading: false, isMock: false };
-}
-
-function positionRet(positions: LinePositions | null = null) {
-  return { positions, loading: false, isMock: false };
-}
-
-function train(
-  statnNm: string,
-  trainStatus: number,
-  overrides?: Partial<TrainPosition>,
-): TrainPosition {
-  return {
-    statnId: '',
-    statnNm,
-    trainNo: 'T',
-    trainStatus,
-    updnLine: 0,
-    terminalStationId: '',
-    terminalStationName: '',
-    trainType: 'normal',
-    isLastTrain: false,
-    receivedAtMs: 1_700_000_000_000,
     ...overrides,
   };
 }

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -1,0 +1,325 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 파일은 의도적으로 여러 features의 hook/util을 조합하는
+ * orchestrator 역할이라 직접 import가 본질적이다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인 처리. 후속 PR(별도 이슈)에서 orchestration 슬라이스(예: features/fusion/, app shell)로
+ * 추출하여 disable을 제거할 예정.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+
+/**
+ * #1016 positionTrainResult 거리 게이트 3 hole 봉합 회귀 방지 테스트.
+ *
+ * (a) userLocation==null → distanceKm=0 placeholder가 gate 자동 통과하는 hole 방지.
+ * (b) lock 활성 + arc 없을 때 accuracy>200m bypass 비활성화 hole 방지.
+ * (c) lock 활성 + arc 있을 때 station.id가 arc에 없는 역은 gate 탈락 hole 방지.
+ */
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { TRAIN_STATUS } from '../../../../shared/constants/trainStatus';
+import type { StationArrival } from '../../../../shared/types/arrival';
+import type { LinePositions, TrainPosition } from '../../api/positionApi';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+
+const mockUseNearest = useNearestStation as jest.Mock;
+const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockUsePositions = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+// Real 7호선 stations for arc tests
+const yongmasan = findStationByNameAndLine('용마산', '7')!;
+const junggok = findStationByNameAndLine('중곡', '7')!;
+const gunja = findStationByNameAndLine('군자', '7')!;
+const konkuk = findStationByNameAndLine('건대입구', '7')!;
+// Real 3호선 station outside line 7 arc
+const chungmuro3 = findStationByNameAndLine('충무로', '3')!;
+
+function gpsBase(overrides?: Record<string, unknown>) {
+  return {
+    result: { station: yongmasan, distanceKm: 0 },
+    variants: [yongmasan],
+    userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+    speedMps: 1,
+    accuracyMeters: 50,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    locationUncertain: false,
+    refresh: jest.fn(),
+    ...overrides,
+  };
+}
+
+function arrivalRet(stationArrival: StationArrival | null = null) {
+  return { arrival: stationArrival, loading: false, isMock: false };
+}
+
+function positionRet(positions: LinePositions | null = null) {
+  return { positions, loading: false, isMock: false };
+}
+
+function train(
+  statnNm: string,
+  trainStatus: number,
+  overrides?: Partial<TrainPosition>,
+): TrainPosition {
+  return {
+    statnId: '',
+    statnNm,
+    trainNo: 'T',
+    trainStatus,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeLock(overrides?: Partial<BoardingLock>): BoardingLock {
+  return {
+    destinationId: konkuk.id,
+    trainCode: 'T-LOCK',
+    boardingStationId: yongmasan.id,
+    boardingLine: '7',
+    boardedAt: Date.now(),
+    expectedDurationMs: 600_000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseArrival.mockReturnValue(arrivalRet(null));
+  mockUsePositions.mockReturnValue(positionRet(null));
+});
+
+describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
+  describe('(a) userLocation==null → positionTrainResult null 반환', () => {
+    it('GPS 좌표 없을 때 trainProgress가 있어도 null 반환 — distanceKm=0 placeholder gate 통과 방지', () => {
+      // GPS 없는 상태. 이전 버전은 distanceKm=0으로 gate 자동 통과. 수정 후 null.
+      mockUseNearest.mockReturnValue(
+        gpsBase({ userLocation: null, result: null, accuracyMeters: 50 }),
+      );
+      mockFindTop.mockReturnValue([]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })],
+        }),
+      );
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      // positionTrainResult가 null이므로 source는 gps 또는 gps-only
+      expect(result.current.source).not.toBe('position-train');
+    });
+
+    it('GPS 좌표 복구되면 positionTrainResult 정상 채택', () => {
+      // accuracyMeters=1500: 지하 bypass 모드. userLocation 있으므로 (a) 통과.
+      // arc 없으므로 fix(b) 적용 — 하지만 거리 0(같은 좌표)이므로 gate 통과.
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          accuracyMeters: 1500,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })],
+        }),
+      );
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      expect(result.current.source).toBe('position-train');
+    });
+  });
+
+  describe('(b) lock 활성 + arc 없을 때 accuracy>MAX_ACCURACY_M bypass 비활성화', () => {
+    it('lock 활성 + arc 없을 때 accuracy=1500(지하)이어도 먼 역(6km+)은 gate 탈락', () => {
+      // 충무로(3호선)는 yongmasan GPS(37.573647, 127.086727)에서 ~6.85km 떨어져 있다.
+      // 이전 버전: accuracy=1500 > MAX_ACCURACY_M → bypass → 자동 통과.
+      // 수정 후: lock 활성 + arc 없음 → bypass 비활성 → 거리 초과 → 탈락.
+      mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '3',
+          // 실제 충무로(3호선) 좌표는 yongmasan GPS에서 ~6.85km 떨어져 있다
+          trains: [train(chungmuro3.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-B' })],
+        }),
+      );
+
+      const lock = makeLock({ boardingLine: '3' });
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-B', lock),
+      );
+
+      // 충무로가 게이트 탈락 → positionTrain 미채택
+      expect(result.current.source).not.toBe('position-train');
+    });
+
+    it('lock 활성 + arc 없을 때 accuracy=1500이지만 같은 좌표(0km)이면 gate 통과', () => {
+      // 같은 좌표에 있으면 거리 = 0 → MAX_FUSION_DISTANCE_KM 이하 → 통과.
+      mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-B2' })],
+        }),
+      );
+
+      const lock = makeLock({ boardingLine: '7', trainCode: 'T-B2' });
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-B2', lock),
+      );
+
+      expect(result.current.source).toBe('boarding-lock');
+    });
+
+    it('lock 없을 때 accuracy=1500(지하) bypass는 그대로 동작', () => {
+      // fix(b)는 lock 활성 시에만 적용 — lock 없으면 기존 bypass 유지.
+      mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-NOLOCK' })],
+        }),
+      );
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      expect(result.current.source).toBe('position-train');
+    });
+  });
+
+  describe('(c) lock 활성 + arc 있을 때 station이 arc에 없으면 gate 탈락', () => {
+    const route = makeDirectRoute(4, '7');
+    const routeContext = { route, origin: yongmasan, destination: konkuk };
+
+    it('arc에 없는 역(면목)이 position-train으로 오면 탈락', () => {
+      // 면목은 7호선이지만 yongmasan→konkuk arc 밖 (용마산보다 출발방향 뒤편)
+      const myeonmok = findStationByNameAndLine('면목', '7')!;
+      // accuracy=1500: arc 있으므로 fix(b) bypass 유지. fix(c)가 arc 소속을 검사.
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          accuracyMeters: 1500,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(myeonmok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-OFF' })],
+        }),
+      );
+
+      const lock = makeLock({ boardingLine: '7' });
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeContext, 'T-C-OFF', lock),
+      );
+
+      // 면목은 arc 밖 → gate 탈락 → positionTrain 미채택
+      expect(result.current.source).not.toBe('position-train');
+      expect(result.current.source).not.toBe('boarding-lock');
+    });
+
+    it('arc 위의 역(중곡)은 통과', () => {
+      // 중곡 = arc idx 1. GPS를 중곡 좌표에 놓아 거리 게이트(b)도 통과시킨다.
+      // accuracy=50(정상): fix(b) 엄격 모드이나 거리가 0(같은 좌표)이므로 통과.
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: junggok.lat, lng: junggok.lng },
+          result: { station: junggok, distanceKm: 0 },
+          accuracyMeters: 50,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: junggok, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(junggok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-IN' })],
+        }),
+      );
+
+      const lock = makeLock({ boardingLine: '7', trainCode: 'T-C-IN' });
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeContext, 'T-C-IN', lock),
+      );
+
+      expect(result.current.result?.station.id).toBe(junggok.id);
+      expect(result.current.source).toBe('boarding-lock');
+    });
+
+    it('lock 없으면 arc 소속 검사 미작동 (기존 동작 유지)', () => {
+      // fix(c)는 boardingLock 활성 시에만 동작.
+      const myeonmok = findStationByNameAndLine('면목', '7')!;
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          accuracyMeters: 1500,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(myeonmok.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-NOLOCK' })],
+        }),
+      );
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeContext),
+      );
+
+      // lock 없으면 arc 검사 안 함 → 면목도 통과 가능
+      expect(result.current.source).toBe('position-train');
+    });
+
+    it('arc 없으면 arc 소속 검사 미작동 (routeContext 없는 경우)', () => {
+      // arc 없으므로 fix(c) 비활성. fix(b)가 거리 검사 담당.
+      // 용마산과 같은 좌표이므로 거리=0 → 통과.
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          accuracyMeters: 1500,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-NOARC' })],
+        }),
+      );
+
+      const lock = makeLock({ boardingLine: '7', trainCode: 'T-C-NOARC' });
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-C-NOARC', lock),
+      );
+
+      expect(result.current.source).toBe('boarding-lock');
+    });
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -111,14 +111,15 @@ beforeEach(() => {
 
 describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
   describe('(a) userLocation==null → positionTrainResult null 반환', () => {
-    it('GPS 좌표 없을 때 trainProgress가 있어도 null 반환 — distanceKm=0 placeholder gate 통과 방지', () => {
+    it('GPS 좌표 없을 때 trainProgress non-null이어도 null 반환 — distanceKm=0 placeholder gate 통과 방지', () => {
       // GPS 없는 상태. 이전 버전은 distanceKm=0으로 gate 자동 통과. 수정 후 null.
-      // trainProgress가 non-null이 되도록 lockedTrainCode + lock 제공 (line 368 도달).
+      // p0만 positions 반환(ReturnValueOnce) → p1/p2는 beforeEach의 null fallthrough.
+      // → candidateTrains 후보 1개(single) → trackTrainProgress non-null → line 368 도달.
       mockUseNearest.mockReturnValue(
         gpsBase({ userLocation: null, result: null, accuracyMeters: 50 }),
       );
       mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      mockUsePositions.mockReturnValue(
+      mockUsePositions.mockReturnValueOnce(
         positionRet({
           line: '7',
           trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })],
@@ -352,6 +353,75 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       );
 
       expect(result.current.source).toBe('boarding-lock');
+    });
+  });
+
+  describe('lastObservedRef 앵커 업데이트 — line 487 커버', () => {
+    it('freshTrainProgress의 station이 arc에 없으면(arcIndexOfStation=-1) 앵커 미갱신 — 기존 source 유지', () => {
+      // lockedTrainCode 있고 boardingLock 없는 상태. positionTrainResult는 gate 통과(boardingLock null → hole-c 비활성).
+      // 하지만 trainProgress.currentStation(용마산)이 중곡→건대입구 arc 밖 → arcIndexOfStation=-1 → line 487 early return.
+      // routeContext origin=중곡, destination=건대입구 → arc=[중곡,군자,건대입구], 용마산 미포함.
+      const subRoute = makeDirectRoute(3, '7');
+      const subRouteContext = { route: subRoute, origin: junggok, destination: konkuk };
+
+      mockUseNearest.mockReturnValue(gpsBase()); // GPS at 용마산(yongmasan)
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      // line='7'(p0)이면 positions 반환, null이면(p1/p2) null 반환. 모든 render에서 일관 적용.
+      mockUsePositions.mockImplementation((line: string | null) =>
+        line === '7'
+          ? positionRet({
+              line: '7',
+              trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-ARC-MISS' })],
+            })
+          : positionRet(null),
+      );
+
+      // lockedTrainCode 있음 + boardingLock 없음 → hole-c 검사 스킵 → positionTrainResult non-null.
+      // 하지만 arcIndexOfStation(arcStations, 용마산) === -1 → line 487 early return.
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, subRouteContext, 'T-ARC-MISS'),
+      );
+
+      // positionTrainResult = 용마산 → lockedTrainCode 매칭으로 source='boarding-lock'.
+      // 앵커(lastObservedRef)는 arcIndexOfStation=-1 반환으로 미갱신 — line 487 early return.
+      expect(result.current.source).toBe('boarding-lock');
+    });
+  });
+
+  describe('observation ceiling — line 564 커버', () => {
+    it('interpolated estimate + positionTrainResult null → livePositionIdx=-1 분기 통과', () => {
+      // boardingLock 활성 + 90s 경과 → estimator default-hop 채택 (isInterpolated=true).
+      // 열차 위치 없음 → positionTrainResult null → line 564 ternary false branch(: -1) 실행.
+      jest.useFakeTimers();
+      const T0 = 1_700_000_000_000;
+      jest.setSystemTime(T0);
+
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+      const lock = makeLock({
+        trainCode: 'T-INTERP',
+        boardingStationId: yongmasan.id,
+        boardingLine: '7',
+        boardedAt: T0,
+        expectedDurationMs: 600_000,
+      });
+
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      // 열차 위치 없음 → trainProgress null → positionTrainResult null.
+      // mockUsePositions는 beforeEach에서 null로 설정됨.
+
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx, 'T-INTERP', lock),
+      );
+
+      // 90s 후 default-hop이 중곡(arc idx 1)을 채택. positionTrainResult null.
+      // → line 564 positionTrainResult ? ... : -1 의 false branch 실행.
+      jest.setSystemTime(T0 + 90_000);
+      rerender({});
+
+      expect(result.current.source).toBe('boarding-lock-interp');
+
+      jest.useRealTimers();
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -113,10 +113,11 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
   describe('(a) userLocation==null → positionTrainResult null 반환', () => {
     it('GPS 좌표 없을 때 trainProgress가 있어도 null 반환 — distanceKm=0 placeholder gate 통과 방지', () => {
       // GPS 없는 상태. 이전 버전은 distanceKm=0으로 gate 자동 통과. 수정 후 null.
+      // trainProgress가 non-null이 되도록 lockedTrainCode + lock 제공 (line 368 도달).
       mockUseNearest.mockReturnValue(
         gpsBase({ userLocation: null, result: null, accuracyMeters: 50 }),
       );
-      mockFindTop.mockReturnValue([]);
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
       mockUsePositions.mockReturnValue(
         positionRet({
           line: '7',
@@ -124,9 +125,12 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         }),
       );
 
-      const { result } = renderHook(() => useFusedNearestStation());
+      const lock = makeLock({ boardingLine: '7', trainCode: 'T-A' });
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-A', lock),
+      );
 
-      // positionTrainResult가 null이므로 source는 gps 또는 gps-only
+      // userLocation=null → line 368 `if (!gps.userLocation) return null` → positionTrainResult null
       expect(result.current.source).not.toBe('position-train');
     });
 
@@ -295,6 +299,34 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
 
       // lock 없으면 arc 검사 안 함 → 면목도 통과 가능
       expect(result.current.source).toBe('position-train');
+    });
+
+    it('arc 안에 있지만 LOCK_NEXT_HOP_WINDOW 초과 시 gate 탈락', () => {
+      // 건대입구: arc idx 4. boardingIdx(용마산=0) + WINDOW(3) = 3 → idx 4 초과 → 탈락.
+      // GPS를 건대입구 좌표에 놓아 거리 게이트(b)는 통과시킴 → fix(c)가 탈락 원인.
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          result: { station: konkuk, distanceKm: 0 },
+          userLocation: { lat: konkuk.lat, lng: konkuk.lng },
+          accuracyMeters: 50,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: konkuk, distanceKm: 0 }]);
+      mockUsePositions.mockReturnValue(
+        positionRet({
+          line: '7',
+          trains: [train(konkuk.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-C-WINDOW' })],
+        }),
+      );
+
+      const lock = makeLock({ boardingLine: '7', trainCode: 'T-C-WINDOW' });
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeContext, 'T-C-WINDOW', lock),
+      );
+
+      // arc window 초과 → positionTrainResult null → position-train/boarding-lock 미채택
+      expect(result.current.source).not.toBe('position-train');
+      expect(result.current.source).not.toBe('boarding-lock');
     });
 
     it('arc 없으면 arc 소속 검사 미작동 (routeContext 없는 경우)', () => {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -313,6 +313,32 @@ describe('useFusedNearestStation', () => {
   });
 
   describe('#662 환승역 fusion 강등 가드 (BoardingLock 기준)', () => {
+    // #1016 fix (b): lock 활성 시 accuracy>MAX_ACCURACY_M bypass 제거로 GPS를 실좌표 근처에 놓아야 함.
+    // 실 충무로(3호선) 좌표를 GPS로 사용 — distance≈0 → gate 통과.
+    const realChungmuro3 = findStationByNameAndLine('충무로', '3')!;
+
+    function setupPositionTrainWithRealCoords(trainNo: string): void {
+      // GPS를 실 충무로(3호선) 좌표에 배치 — lock 활성 + accuracyMeters=50이어도 gate 통과.
+      mockUseNearest.mockReturnValue(gpsBase({
+        userLocation: { lat: realChungmuro3.lat, lng: realChungmuro3.lng },
+        accuracyMeters: 50,
+      }));
+      mockFindTop.mockReturnValue([
+        { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+        { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
+      ]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      mockUsePositions
+        .mockReturnValueOnce(positionRet({ line: '2', trains: [] }))
+        .mockReturnValueOnce(
+          positionRet({
+            line: '3',
+            trains: [train(MOCK_STATIONS.chungmuro.name, TRAIN_STATUS.ARRIVED, { trainNo })],
+          }),
+        )
+        .mockReturnValueOnce(positionRet(null));
+    }
+
     const lockOnLine = (line: '2' | '3'): import('../../../../shared/types/boardingLock').BoardingLock => ({
       destinationId: 'dest-1',
       trainCode: 'T-3',
@@ -323,16 +349,16 @@ describe('useFusedNearestStation', () => {
     });
 
     it('lock.boardingLine과 positionTrain.line이 다르면 positionTrain 강등 → GPS로 fallthrough', () => {
-      setupPositionTrainTransferStation('T-3');
+      setupPositionTrainWithRealCoords('T-3');
       const { result } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, undefined, null, lockOnLine('2')),
       );
       expect(result.current.source).toBe('gps');
-      expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
     });
 
     it('lock.boardingLine과 positionTrain.line이 같으면 positionTrain 유지', () => {
-      setupPositionTrainTransferStation('T-3');
+      // #1016 fix (b): lock 활성이므로 accuracy bypass 없음. GPS를 실 충무로 좌표에 배치.
+      setupPositionTrainWithRealCoords('T-3');
       const { result } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, undefined, null, lockOnLine('3')),
       );
@@ -437,7 +463,7 @@ describe('useFusedNearestStation', () => {
     expect(result.current.source).toBe('arrival');
   });
 
-  it('position-train 다중 후보: lastConfirmedTrainNo 우선(sticky) — 이전 결과 유지', () => {
+  it('position-train 다중 후보: lastConfirmedTrainNo 우선(sticky) — GPS 있을 때 이전 결과 유지', () => {
     // #445 거리 게이트 우회 — MOCK 좌표와 stations.json 실좌표가 다르므로.
     mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
     mockFindTop.mockReturnValue([
@@ -455,7 +481,9 @@ describe('useFusedNearestStation', () => {
     const { result, rerender } = renderHook(() => useFusedNearestStation());
     expect(result.current.confidence).toBe('position-train');
 
-    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS 없이도 sticky로 T-1 유지.
+    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS 유지(accuracy=1500). sticky로 T-1 유지.
+    // #1016 fix (a): userLocation=null 이면 positionTrainResult=null → GPS null 케이스는
+    // position-train 미채택. GPS 있는 케이스에서만 sticky가 동작하는지 검증.
     mockUsePositions.mockReturnValue(
       positionRet({
         line: '2',
@@ -465,10 +493,28 @@ describe('useFusedNearestStation', () => {
         ],
       }),
     );
-    mockUseNearest.mockReturnValue(gpsBase({ userLocation: null }));
+    // GPS 유지 (userLocation 있음) — sticky가 동작해야 함
     rerender(undefined);
     expect(result.current.source).toBe('position-train');
     expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
+  });
+
+  it('position-train: userLocation null → positionTrainResult null — #1016 fix (a)', () => {
+    // #1016 hole (a): userLocation==null 이면 distanceKm=0 placeholder가 게이트를 자동 통과했었음.
+    // fix 이후 userLocation 없으면 positionTrainResult=null → position-train 미채택.
+    mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500, userLocation: null }));
+    mockFindTop.mockReturnValue([]);
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockUsePositions.mockReturnValue(
+      positionRet({
+        line: '2',
+        trains: [train(MOCK_STATIONS.gangnam.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-U' })],
+      }),
+    );
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.source).not.toBe('position-train');
   });
 
   it('GPS pass-through 필드들(loading/error/permissionDenied/locationUncertain/refresh 등)이 보존된다', () => {
@@ -960,9 +1006,10 @@ describe('useFusedNearestStation', () => {
     it('LivePosition(trainNo===trainCode) + arc 위 → effect가 lastObservedRef 갱신 (#739 Stage 1)', () => {
       jest.useFakeTimers();
       try {
-        // GPS는 용마산(arc 첫 역). 7093이 군자(arc idx 2)에서 도착 — trainProgress → 군자.
+        // #1016 fix (b): lock 활성 + accuracy bypass 제거로 GPS를 실 군자 좌표에 배치해야 gate 통과.
+        // GPS는 군자(arc idx 2). 7093이 군자에서 도착 — trainProgress → 군자, positionTrainResult 채택.
         jest.setSystemTime(T0 + 2 * 90_000);
-        setupGpsAtWithLoosAccuracy(yongmasan);
+        setupGpsAt(gunja);
         const t7093 = train('군자', TRAIN_STATUS.ARRIVED, { trainNo: '7093' });
         mockUsePositions.mockReturnValue(positionRet({ line: '7', trains: [t7093] }));
 

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -19,9 +19,13 @@ import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute'
 import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
 import { TRAIN_STATUS } from '../../../../shared/constants/trainStatus';
 import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import {
+  arrivalRet,
+  positionRet,
+  makeTrain as train,
+} from '../../../../testUtils/positionApiFixtures';
 import type { StationArrival, ArrivalInfo } from '../../../../shared/types/arrival';
 import type { Station } from '../../../../shared/types/station';
-import type { LinePositions, TrainPosition } from '../../api/positionApi';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
 
 jest.mock('../useNearestStation');
@@ -64,34 +68,6 @@ function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInf
     arrivalCode,
     isLastTrain: false,
     trainType: 'normal',
-    ...overrides,
-  };
-}
-
-function arrivalRet(stationArrival: StationArrival | null = null) {
-  return { arrival: stationArrival, loading: false, isMock: false };
-}
-
-function positionRet(positions: LinePositions | null = null) {
-  return { positions, loading: false, isMock: false };
-}
-
-function train(
-  statnNm: string,
-  trainStatus: number,
-  overrides?: Partial<TrainPosition>,
-): TrainPosition {
-  return {
-    statnId: '',
-    statnNm,
-    trainNo: 'T',
-    trainStatus,
-    updnLine: 0,
-    terminalStationId: '',
-    terminalStationName: '',
-    trainType: 'normal',
-    isLastTrain: false,
-    receivedAtMs: 1_700_000_000_000,
     ...overrides,
   };
 }

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -26,7 +26,7 @@ import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../../arrival/utils/pickCandidateTrains';
 import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { haversine } from '../../../shared/utils/haversine';
-import { passesFusionDistanceGate } from '../utils/fusionDistanceGate';
+import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import {
   arcIndexOfStation,
@@ -35,7 +35,6 @@ import {
 import { hopTimeMsAt } from '../../route/utils/hopTime';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import {
-  LOCK_NEXT_HOP_WINDOW,
   MAX_ACTIVE_LINES,
   MAX_FUSION_DELTA_KM,
   MAX_FUSION_DISTANCE_KM,
@@ -392,17 +391,9 @@ export function useFusedNearestStation(
     if (boardingLock && station.line !== boardingLock.boardingLine) {
       return null;
     }
-    // #1016 hole (c): BoardingLock 활성이고 arcStations 있으면 station.id가 arc의 nextHops
-    // window(탑승역 인덱스 + LOCK_NEXT_HOP_WINDOW) 내에 있어야 함. arc가 없거나 탑승역이 arc에
-    // 없으면 스킵(routeContext 없는 free-trip 또는 데이터 불일치 — 기존 동작 유지).
-    if (boardingLock && arcStations.length > 0) {
-      const boardingIdx = arcStations.findIndex((s) => s.id === boardingLock.boardingStationId);
-      if (boardingIdx !== -1) {
-        const stationIdx = arcStations.findIndex((s) => s.id === station.id);
-        if (stationIdx === -1 || stationIdx > boardingIdx + LOCK_NEXT_HOP_WINDOW) {
-          return null;
-        }
-      }
+    // #1016 hole (c): lock 활성 시 arc window 내 역만 허용.
+    if (boardingLock && !isWithinArcWindow(arcStations, station.id, boardingLock.boardingStationId)) {
+      return null;
     }
     return candidate;
   }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates, boardingLock, arcStations]);

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -561,8 +561,11 @@ export function useFusedNearestStation(
       estimate.strategy !== 'live-position' && estimate.strategy !== 'arrival-eta';
     let withinObservationCeiling = true;
     if (isInterpolated) {
-      const livePositionIdx = positionTrainResult
-        ? arcIndexOfStation(arcStations, positionTrainResult.station)
+      // positionTrainResult non-null → freshTrainProgress non-null → tryLivePosition='live-position' →
+      // isInterpolated=false → 이 블록 도달 불가. positionTrainResult는 항상 null.
+      // 향후 새 전략(non-live/non-arrival)이 추가될 때를 대비한 future-proofing.
+      const livePositionIdx = /* istanbul ignore next */ positionTrainResult
+        ? /* istanbul ignore next */ arcIndexOfStation(arcStations, positionTrainResult.station)
         : -1;
       const reanchoredObservedIdx = lastObservedRef.current?.arcIndex ?? -1;
       // estimate가 non-null이면 boardingLock도 non-null(estimator 245 가드) — false branch 도달 불가.

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -35,6 +35,7 @@ import {
 import { hopTimeMsAt } from '../../route/utils/hopTime';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import {
+  LOCK_NEXT_HOP_WINDOW,
   MAX_ACTIVE_LINES,
   MAX_FUSION_DELTA_KM,
   MAX_FUSION_DISTANCE_KM,
@@ -290,6 +291,19 @@ export function useFusedNearestStation(
     );
   }, [candidates, a0.arrival, a1.arrival, a2.arrival, p0.positions, p1.positions, p2.positions]);
 
+  // arcStations — routeContext에서 미리 산출. positionTrainResult 내 (c) 게이트가 arc window를
+  // 참조하므로 positionTrainResult useMemo보다 앞에 위치해야 한다.
+  // ADR-008 stationProgressEstimator — 이후 estimate override에서도 재사용.
+  const arcStations = useMemo<Station[]>(() => {
+    if (!routeContext || !routeContext.origin || !routeContext.destination) return [];
+    const arc = computeRouteArc(
+      routeContext.route,
+      routeContext.origin,
+      routeContext.destination,
+    );
+    return arc?.stations ?? [];
+  }, [routeContext]);
+
   // Phase 1C: Position-first fusion.
   // 후보 trainNo들(pickCandidateTrains) → trackTrainProgress로 단일 trainNo·현재역 결정.
   // anchor = 각 호선의 GPS 최근접 후보. 후보 1개로 단정되거나 GPS로 disambiguation되면 채택.
@@ -340,12 +354,12 @@ export function useFusedNearestStation(
 
   const positionTrainResult: NearestStationResult | null = useMemo(() => {
     if (!trainProgress) return null;
+    // #1016 hole (a): userLocation 없으면 distanceKm=0 placeholder 대신 null 반환.
+    // placeholder는 거리 게이트를 자동 통과시켜 GPS가 전혀 없는 상태에서도 position-train이
+    // 채택되는 hole을 만든다. userLocation 없으면 거리 sanity 자체가 불가하므로 강등.
+    if (!gps.userLocation) return null;
     const station = trainProgress.currentStation;
-    // userLocation 부재(sticky 케이스 등) 시 placeholder 0. 신뢰도 보조 신호로 사용 금지 —
-    // distanceKm은 화면 표시용이며 알람/정확도 판단은 source=='position-train'으로만 분기.
-    const distanceKm = gps.userLocation
-      ? haversine(gps.userLocation.lat, gps.userLocation.lng, station.lat, station.lng)
-      : 0;
+    const distanceKm = haversine(gps.userLocation.lat, gps.userLocation.lng, station.lat, station.lng);
 
     // #445 TTL: trainProgress가 신선해야 함. stale하면 강등.
     // ref가 0이면 effect가 첫 ts를 commit하기 전 — useMemo는 pure하게 두기 위해 면제.
@@ -356,6 +370,7 @@ export function useFusedNearestStation(
       return null;
     }
     // #444 거리 sanity — fused/route와 공통 헬퍼 재사용.
+    // #1016 hole (b): boardingLock 활성 시 lockActive=true로 accuracy>200m bypass 거부.
     const candidate = { station, distanceKm };
     if (
       !passesFusionDistanceGate({
@@ -365,6 +380,7 @@ export function useFusedNearestStation(
         gpsNearest: candidates[0],
         maxAbsoluteKm: MAX_FUSION_DISTANCE_KM,
         maxDeltaKm: MAX_FUSION_DELTA_KM,
+        lockActive: boardingLock != null,
       })
     ) {
       return null;
@@ -376,8 +392,20 @@ export function useFusedNearestStation(
     if (boardingLock && station.line !== boardingLock.boardingLine) {
       return null;
     }
+    // #1016 hole (c): BoardingLock 활성이고 arcStations 있으면 station.id가 arc의 nextHops
+    // window(탑승역 인덱스 + LOCK_NEXT_HOP_WINDOW) 내에 있어야 함. arc가 없거나 탑승역이 arc에
+    // 없으면 스킵(routeContext 없는 free-trip 또는 데이터 불일치 — 기존 동작 유지).
+    if (boardingLock && arcStations.length > 0) {
+      const boardingIdx = arcStations.findIndex((s) => s.id === boardingLock.boardingStationId);
+      if (boardingIdx !== -1) {
+        const stationIdx = arcStations.findIndex((s) => s.id === station.id);
+        if (stationIdx === -1 || stationIdx > boardingIdx + LOCK_NEXT_HOP_WINDOW) {
+          return null;
+        }
+      }
+    }
     return candidate;
-  }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates, boardingLock]);
+  }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates, boardingLock, arcStations]);
 
   const routeResult: NearestStationResult | null = progress.position
     ? {
@@ -439,15 +467,7 @@ export function useFusedNearestStation(
   // 채택 결과가 더 앞이면 그대로(실제 신호 우선) — 역행 방지(monotone forward).
   // confidence/source는 #584 PR D2의 'boarding-lock'(position-train + trainCode 매칭)과
   // 구분하기 위해 'boarding-lock-interp' 별도 라벨 사용 — 측정·디버그 인프라에서 구분 가능.
-  const arcStations = useMemo<Station[]>(() => {
-    if (!routeContext || !routeContext.origin || !routeContext.destination) return [];
-    const arc = computeRouteArc(
-      routeContext.route,
-      routeContext.origin,
-      routeContext.destination,
-    );
-    return arc?.stations ?? [];
-  }, [routeContext]);
+  // arcStations는 positionTrainResult의 (c) 게이트가 참조하므로 위에서 미리 산출됨.
 
   // estimator/anchor에 넘기는 trainProgress는 fusion 게이트(TTL + distance)를 통과한 것만 신선 신호로 인정.
   // positionTrainResult가 null이면 trainProgress는 stale이거나 게이트 탈락 — Strategy ①(LivePosition)이

--- a/src/features/nearest-station/utils/__tests__/fusionDistanceGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionDistanceGate.test.ts
@@ -1,4 +1,4 @@
-import { passesFusionDistanceGate } from '../fusionDistanceGate';
+import { isWithinArcWindow, passesFusionDistanceGate } from '../fusionDistanceGate';
 import { MAX_ACCURACY_M } from '../../../../shared/constants/location';
 import type { NearestStationResult, Station } from '../../../../shared/types/station';
 
@@ -176,6 +176,38 @@ describe('passesFusionDistanceGate', () => {
         }),
       ).toBe(true);
     });
+  });
+});
+
+describe('isWithinArcWindow (#1016 hole c)', () => {
+  const arc: Station[] = ['S0', 'S1', 'S2', 'S3', 'S4', 'S5'].map((id) =>
+    makeStation(id, 0, 0),
+  );
+
+  it('arc 비어있으면 true(free-trip)', () => {
+    expect(isWithinArcWindow([], 'S5', 'S0')).toBe(true);
+  });
+
+  it('탑승역이 arc에 없으면 true(데이터 불일치)', () => {
+    expect(isWithinArcWindow(arc, 'S2', 'UNKNOWN')).toBe(true);
+  });
+
+  it('후보가 arc에 없으면 false', () => {
+    expect(isWithinArcWindow(arc, 'UNKNOWN', 'S0')).toBe(false);
+  });
+
+  it('탑승역 인덱스 + WINDOW 이내 → true', () => {
+    // S0(0) + WINDOW(3) = S3까지 허용
+    expect(isWithinArcWindow(arc, 'S3', 'S0')).toBe(true);
+  });
+
+  it('탑승역 인덱스 + WINDOW 초과 → false', () => {
+    // S0(0) + WINDOW(3) = S3까지, S4는 초과
+    expect(isWithinArcWindow(arc, 'S4', 'S0')).toBe(false);
+  });
+
+  it('후보가 탑승역 자신이면 true', () => {
+    expect(isWithinArcWindow(arc, 'S2', 'S2')).toBe(true);
   });
 });
 

--- a/src/features/nearest-station/utils/__tests__/fusionDistanceGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionDistanceGate.test.ts
@@ -119,5 +119,63 @@ describe('passesFusionDistanceGate', () => {
       }),
     ).toBe(true);
   });
+
+  describe('#1016 hole (b) — lockActive 엄격 모드', () => {
+    it('lockActive=false 이면 accuracy>MAX_ACCURACY_M 지하 bypass 유지(기존 동작)', () => {
+      expect(
+        passesFusionDistanceGate({
+          candidate: makeResult('A', 0, 0, 0.7),
+          userLocation,
+          accuracyMeters: MAX_ACCURACY_M + 1,
+          gpsNearest,
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+          lockActive: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('lockActive=true 이면 accuracy>MAX_ACCURACY_M 이어도 bypass 거부 — 절대 거리 초과 시 실패', () => {
+      expect(
+        passesFusionDistanceGate({
+          candidate: makeResult('A', 0, 0, 0.7),
+          userLocation,
+          accuracyMeters: MAX_ACCURACY_M + 1,
+          gpsNearest,
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+          lockActive: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('lockActive=true 이어도 accuracyMeters=null 이면 통과(측정 불가)', () => {
+      expect(
+        passesFusionDistanceGate({
+          candidate: makeResult('A', 0, 0, 0.2),
+          userLocation,
+          accuracyMeters: null,
+          gpsNearest,
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+          lockActive: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('lockActive=true + accuracy 양호 + 거리 정상 → 통과', () => {
+      expect(
+        passesFusionDistanceGate({
+          candidate: makeResult('A', 0, 0, 0.2),
+          userLocation,
+          accuracyMeters: 50,
+          gpsNearest,
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+          lockActive: true,
+        }),
+      ).toBe(true);
+    });
+  });
 });
 

--- a/src/features/nearest-station/utils/fusionDistanceGate.ts
+++ b/src/features/nearest-station/utils/fusionDistanceGate.ts
@@ -1,5 +1,6 @@
 import { MAX_ACCURACY_M } from '../../../shared/constants/location';
-import type { NearestStationResult } from '../../../shared/types/station';
+import { LOCK_NEXT_HOP_WINDOW } from '../../../shared/constants/realtime';
+import type { NearestStationResult, Station } from '../../../shared/types/station';
 
 // #444: fusion 결과(non-gps source)가 사용자 실위치와 동떨어진 station을 채택하지 않도록
 // 거리·정확도 sanity 검사. positionTrain/fused/route 우선순위에 공통 적용.
@@ -29,6 +30,22 @@ export interface FusionDistanceGateInput {
  * - 절대 거리 > maxAbsoluteKm → 실패
  * - GPS-nearest와 다른 station이고 거리 차이 > maxDeltaKm → 실패
  */
+/**
+ * BoardingLock 활성 시 후보 역이 arc window 내에 있는지 검사 (#1016 hole c).
+ * arc 없거나 탑승역이 arc에 없으면 true(기존 동작 유지).
+ */
+export function isWithinArcWindow(
+  arcStations: readonly Station[],
+  candidateId: string,
+  boardingStationId: string,
+): boolean {
+  if (arcStations.length === 0) return true;
+  const boardingIdx = arcStations.findIndex((s) => s.id === boardingStationId);
+  if (boardingIdx === -1) return true;
+  const candidateIdx = arcStations.findIndex((s) => s.id === candidateId);
+  return candidateIdx !== -1 && candidateIdx <= boardingIdx + LOCK_NEXT_HOP_WINDOW;
+}
+
 export function passesFusionDistanceGate(input: FusionDistanceGateInput): boolean {
   const { candidate, userLocation, accuracyMeters, gpsNearest, maxAbsoluteKm, maxDeltaKm, lockActive } = input;
   if (!userLocation) return true;

--- a/src/features/nearest-station/utils/fusionDistanceGate.ts
+++ b/src/features/nearest-station/utils/fusionDistanceGate.ts
@@ -15,18 +15,25 @@ export interface FusionDistanceGateInput {
   gpsNearest: NearestStationResult | undefined;
   maxAbsoluteKm: number;
   maxDeltaKm: number;
+  /**
+   * BoardingLock 활성 여부 (#1016 hole b).
+   * true이면 accuracy>MAX_ACCURACY_M bypass를 거부 — 지하라도 lock이 있으면 거리 게이트를 엄격히 적용.
+   */
+  lockActive?: boolean;
 }
 
 /**
  * 후보 station이 GPS sanity 검사를 통과하는지.
- * - userLocation 없거나 accuracy null/저조 → 통과(검사 불가)
+ * - userLocation 없거나 accuracy null/저조(lock 비활성 시만) → 통과(검사 불가)
+ * - lockActive=true면 accuracy 저조 bypass 거부 — lock이 있으면 지하라도 엄격 검사
  * - 절대 거리 > maxAbsoluteKm → 실패
  * - GPS-nearest와 다른 station이고 거리 차이 > maxDeltaKm → 실패
  */
 export function passesFusionDistanceGate(input: FusionDistanceGateInput): boolean {
-  const { candidate, userLocation, accuracyMeters, gpsNearest, maxAbsoluteKm, maxDeltaKm } = input;
+  const { candidate, userLocation, accuracyMeters, gpsNearest, maxAbsoluteKm, maxDeltaKm, lockActive } = input;
   if (!userLocation) return true;
-  if (accuracyMeters == null || accuracyMeters > MAX_ACCURACY_M) return true;
+  if (accuracyMeters == null) return true;
+  if (!lockActive && accuracyMeters > MAX_ACCURACY_M) return true;
   if (candidate.distanceKm > maxAbsoluteKm) return false;
   if (
     gpsNearest &&

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -15,3 +15,8 @@ export const MAX_FUSION_DELTA_KM = 0.2;
 // #445 positionTrain trainProgress 신선도. 7호선 역간 평균 100~120s의 절반.
 // 이 시간 이상 갱신 없으면 sticky 락(lastConfirmedTrainNo) 자체를 해제한다.
 export const POSITION_TRAIN_TTL_MS = 60_000;
+// #1016 hole (c): BoardingLock 활성 시 positionTrain 후보가 유효한 arc 구간 window.
+// 탑승역 인덱스 + LOCK_NEXT_HOP_WINDOW 범위 내 역만 허용. 지하 dead zone에서 훨씬 앞의
+// 역을 채택하는 false positive를 차단한다. 인접역 간 평균 주행 시간(90s) × TTL(60s) 기준으로
+// 한 사이클에 1~2 hop이 최대 — 여유 margin 포함 3 hops.
+export const LOCK_NEXT_HOP_WINDOW = 3;

--- a/src/testUtils/positionApiFixtures.ts
+++ b/src/testUtils/positionApiFixtures.ts
@@ -5,6 +5,19 @@
 import type { StationArrival } from '../shared/types/arrival';
 import type { LinePositions, TrainPosition } from '../features/nearest-station/api/positionApi';
 
+/**
+ * useNearestStation mock의 고정 필드 기본값.
+ * 각 테스트 파일은 result/variants/userLocation만 오버라이드하면 된다.
+ */
+export const GPS_BASE_DEFAULTS = {
+  speedMps: 1,
+  accuracyMeters: 50,
+  loading: false,
+  error: null,
+  permissionDenied: false,
+  locationUncertain: false,
+} as const;
+
 export function arrivalRet(stationArrival: StationArrival | null = null) {
   return { arrival: stationArrival, loading: false, isMock: false };
 }

--- a/src/testUtils/positionApiFixtures.ts
+++ b/src/testUtils/positionApiFixtures.ts
@@ -18,11 +18,11 @@ export const GPS_BASE_DEFAULTS = {
   locationUncertain: false,
 } as const;
 
-export function arrivalRet(stationArrival: StationArrival | null = null) {
+export function arrivalRet(stationArrival: StationArrival | null) {
   return { arrival: stationArrival, loading: false, isMock: false };
 }
 
-export function positionRet(positions: LinePositions | null = null) {
+export function positionRet(positions: LinePositions | null) {
   return { positions, loading: false, isMock: false };
 }
 

--- a/src/testUtils/positionApiFixtures.ts
+++ b/src/testUtils/positionApiFixtures.ts
@@ -1,0 +1,34 @@
+/**
+ * useFusedNearestStation 계열 테스트에서 공통으로 사용하는 mock 응답 빌더.
+ * 여러 테스트 파일에 동일 함수가 중복 정의되는 것을 방지하기 위해 추출.
+ */
+import type { StationArrival } from '../shared/types/arrival';
+import type { LinePositions, TrainPosition } from '../features/nearest-station/api/positionApi';
+
+export function arrivalRet(stationArrival: StationArrival | null = null) {
+  return { arrival: stationArrival, loading: false, isMock: false };
+}
+
+export function positionRet(positions: LinePositions | null = null) {
+  return { positions, loading: false, isMock: false };
+}
+
+export function makeTrain(
+  statnNm: string,
+  trainStatus: number,
+  overrides?: Partial<TrainPosition>,
+): TrainPosition {
+  return {
+    statnId: '',
+    statnNm,
+    trainNo: 'T',
+    trainStatus,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Closes #1016

## 변경 내용

### (a) userLocation==null → positionTrainResult=null
- `gps.userLocation` 없으면 `distanceKm=0` placeholder 대신 즉시 `null` 반환
- 기존: placeholder 0이 `passesFusionDistanceGate(userLocation==null → return true)`와 맞물려 GPS 없이도 position-train이 자동 채택되는 hole
- 수정: GPS 없으면 거리 sanity 불가 → 강등

### (b) lockActive=true 시 accuracy>200m bypass 거부
- `passesFusionDistanceGate`에 `lockActive?: boolean` 파라미터 추가
- `lockActive=true`이면 `accuracy > MAX_ACCURACY_M(200m)` bypass 제거 — 지하라도 lock이 있으면 엄격 검사
- `accuracyMeters==null`은 여전히 통과 (측정 불가)
- `positionTrainResult` 게이트 호출 시 `lockActive: boardingLock != null`으로 전달

### (c) arcStations nextHops window 검사
- `LOCK_NEXT_HOP_WINDOW=3` 상수 추가 (`src/shared/constants/realtime.ts`)
- BoardingLock 활성 + arcStations 있을 때: `station.id`가 `boardingIdx + LOCK_NEXT_HOP_WINDOW` 초과이거나 arc에 없으면 강등
- arc 없거나 탑승역이 arc에 없으면 검사 스킵 (free-trip/데이터 불일치 호환)

## 구조 변경
- `arcStations` useMemo를 `positionTrainResult` useMemo보다 앞으로 이동 — (c) 게이트 의존성 충족

## 테스트
- `fusionDistanceGate.test.ts`: `lockActive` 파라미터 4케이스 추가
- `useFusedNearestStation.positionGate.test.ts`: 3 hole 격리 검증 9케이스 (기존 파일 fix 포함)
- `useFusedNearestStation.test.ts`: fix (b) 엄격 모드에 맞게 기존 3케이스 GPS 좌표를 실 역 위치 기반으로 수정