### PR TITLE
feat(#1021): boardingPrompt 발사 빈도 monitor (R-6, M7-new)

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -41,9 +41,14 @@ import {
   logAlertFallbackFired,
   summarizeAlarmLogBySource,
   countSilentPushOutcomes,
+  summarizeAlarmLogByReason,
+  logBoardingPromptFired,
+  BOARDING_PROMPT_WINDOWS,
+  countBoardingPromptByWindow,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
+  type BoardingPromptWindowKey,
 } from '../alarmLog';
 import { ALARM_LOG_KEY } from '../../../../shared/constants/storageKeys';
 import type { AlarmEvent } from '../stationAlarm';
@@ -1234,4 +1239,71 @@ describe('alarmLog', () => {
       await expect(clearAlarmLog()).resolves.toBeUndefined();
     });
   });
+
+  describe('summarizeAlarmLogByReason (#1019)', () => {
+    it('suppressed 엔트리의 reason별 카운트를 반환한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed' }),
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed' }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age' }),
+        makeEntry({ outcome: 'fired' }),
+      ];
+      expect(summarizeAlarmLogByReason(entries)).toEqual({
+        'movement-static-speed': 2,
+        'gate-age': 1,
+      });
+    });
+
+    it('suppressed가 없으면 빈 객체를 반환한다', () => {
+      expect(summarizeAlarmLogByReason([makeEntry({ outcome: 'fired' })])).toEqual({});
+    });
+
+    it('reason 없는 suppressed 엔트리는 (unknown)으로 집계한다', () => {
+      const entry: AlarmLogEntry = { ts: 1, source: 'fg', outcome: 'suppressed' };
+      expect(summarizeAlarmLogByReason([entry])).toEqual({ '(unknown)': 1 });
+    });
+  });
+
+  describe('logBoardingPromptFired + countBoardingPromptByWindow (#1021)', () => {
+    it('logBoardingPromptFired가 boarding-prompt entry를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logBoardingPromptFired({ originStation: '강남', line: '2' });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('boarding-prompt');
+      expect(saved[0].outcome).toBe('fired');
+      expect(saved[0].stationName).toBe('2·강남');
+    });
+
+    it('countBoardingPromptByWindow가 윈도우별 발사 횟수를 집계한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: now - 2 * 60 * 1000, source: 'boarding-prompt', outcome: 'fired' },
+        { ts: now - 10 * 60 * 1000, source: 'boarding-prompt', outcome: 'fired' },
+        { ts: now - 2 * 60 * 60 * 1000, source: 'boarding-prompt', outcome: 'fired' },
+        { ts: now - 1000, source: 'fg', outcome: 'fired' },
+      ];
+      const counts = countBoardingPromptByWindow(entries, now);
+      expect(counts['5m']).toBe(1);
+      expect(counts['1h']).toBe(2);
+      expect(counts['all']).toBe(3);
+    });
+
+    it('엔트리가 없으면 모든 윈도우가 0', () => {
+      const counts = countBoardingPromptByWindow([], Date.now());
+      for (const { key } of BOARDING_PROMPT_WINDOWS) {
+        expect(counts[key as BoardingPromptWindowKey]).toBe(0);
+      }
+    });
+
+    it('suppressed outcome은 집계하지 않는다', () => {
+      const now = Date.now();
+      const entries: AlarmLogEntry[] = [
+        { ts: now - 1000, source: 'boarding-prompt', outcome: 'suppressed' },
+      ];
+      expect(countBoardingPromptByWindow(entries, now)['5m']).toBe(0);
+    });
+  });
+
 });

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -197,6 +197,22 @@ describe('alarmLog', () => {
       await expect(flushAlarmLog()).resolves.toBeUndefined();
     });
 
+    it('#1024 burst inline counter: 같은 key 연속 append는 단일 entry로 count++ 합산', async () => {
+      // 780-783 라인: (source, reason, kind, phaseId, stationName) 동일한 연속 entry를 inline 합산.
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      const base = makeEntry({ outcome: 'suppressed', reason: 'gate-age', stationName: '강남', kind: 'station-passed', ts: 100 });
+      const second = { ...base, ts: 200 };
+      appendAlarmLog(base);
+      appendAlarmLog(second);
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      // 2개가 아닌 1개 entry로 합산, ts는 최신값(200), count=2
+      expect(saved).toHaveLength(1);
+      expect(saved[0].count).toBe(2);
+      expect(saved[0].ts).toBe(200);
+    });
+
     it('pending 없을 때 flush 호출은 no-op (storage 미접근)', async () => {
       await flushAlarmLog();
       expect(AsyncStorage.getItem).not.toHaveBeenCalled();
@@ -605,18 +621,13 @@ describe('alarmLog', () => {
       logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '역삼' });
       logSuppressedDedupAlarm('bg', { phaseId: 'early', type: 'destination', stationName: '강남' });
       await flushAlarmLog();
-      // #735 — 1회 batch RMW. setItem 1번.
-      // #1024 — (source, reason, stationName)이 같은 fg/dedup-alarm/강남 3건은 count++ 합산.
-      // 결과: fg/강남 계열(count=3) + fg/역삼(count=1) + bg/강남(count=1) = 3개 entry.
+      // #735 — 모든 호출이 1회 batch RMW로 적재. setItem 1번, payload에 5건 모두 포함.
+      // #1024 — burst counter key는 (source, reason, kind, phaseId, stationName).
+      // kind/phaseId가 다른 5개 호출은 각자 별개 key이므로 합산 없이 5건 적재.
       expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(1);
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved).toHaveLength(3);
-      // fg/강남 계열이 count=3으로 병합되었는지 검증
-      const fgGangnam = saved.find((e) => e.source === 'fg' && e.stationName === '강남');
-      expect(fgGangnam?.count).toBe(3);
-      expect(saved.find((e) => e.stationName === '역삼')).toBeTruthy();
-      expect(saved.find((e) => e.source === 'bg' && e.stationName === '강남')).toBeTruthy();
+      expect(saved).toHaveLength(5);
     });
 
     it('#626 Map cap 초과 시 만료된 엔트리 sweep — 무한 성장 방지', async () => {
@@ -1304,6 +1315,16 @@ describe('alarmLog', () => {
       const result = summarizeAlarmLogCounters(entries);
       expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: 20 }]);
     });
+
+    it('나중 entry의 ts가 더 작으면 lastTs를 갱신하지 않는다 — line 565 false branch', () => {
+      // 첫 entry ts=200, 두 번째 ts=100 (역순) → existing.lastTs=200 유지.
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: 200 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: 100 }),
+      ];
+      const result = summarizeAlarmLogCounters(entries);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: 200 }]);
+    });
   });
 
   describe('logBoardingPromptFired + countBoardingPromptByWindow (#1021)', () => {
@@ -1345,6 +1366,14 @@ describe('alarmLog', () => {
         { ts: now - 1000, source: 'boarding-prompt', outcome: 'suppressed' },
       ];
       expect(countBoardingPromptByWindow(entries, now)['5m']).toBe(0);
+    });
+
+    it('now 인자 생략 시 Date.now() 기본값 사용 — line 733 default branch', () => {
+      // 1초 전 fired entry → 기본 now 기준으로 '5m' window 안에 포함.
+      const entries: AlarmLogEntry[] = [
+        { ts: Date.now() - 1000, source: 'boarding-prompt', outcome: 'fired' },
+      ];
+      expect(countBoardingPromptByWindow(entries)['5m']).toBe(1);
     });
   });
 

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -603,11 +603,18 @@ describe('alarmLog', () => {
       logSuppressedDedupAlarm('fg', { phaseId: 'early', type: 'destination', stationName: '역삼' });
       logSuppressedDedupAlarm('bg', { phaseId: 'early', type: 'destination', stationName: '강남' });
       await flushAlarmLog();
-      // #735 — 모든 호출이 1회 batch RMW로 적재. setItem 1번, payload에 5건 모두 포함.
+      // #735 — 1회 batch RMW. setItem 1번.
+      // #1024 — (source, reason, stationName)이 같은 fg/dedup-alarm/강남 3건은 count++ 합산.
+      // 결과: fg/강남 계열(count=3) + fg/역삼(count=1) + bg/강남(count=1) = 3개 entry.
       expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(1);
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved).toHaveLength(5);
+      expect(saved).toHaveLength(3);
+      // fg/강남 계열이 count=3으로 병합되었는지 검증
+      const fgGangnam = saved.find((e) => e.source === 'fg' && e.stationName === '강남');
+      expect(fgGangnam?.count).toBe(3);
+      expect(saved.find((e) => e.stationName === '역삼')).toBeTruthy();
+      expect(saved.find((e) => e.source === 'bg' && e.stationName === '강남')).toBeTruthy();
     });
 
     it('#626 Map cap 초과 시 만료된 엔트리 sweep — 무한 성장 방지', async () => {

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -42,12 +42,14 @@ import {
   summarizeAlarmLogBySource,
   countSilentPushOutcomes,
   summarizeAlarmLogByReason,
+  summarizeAlarmLogCounters,
   logBoardingPromptFired,
   BOARDING_PROMPT_WINDOWS,
   countBoardingPromptByWindow,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
+  type AlarmLogReasonCounter,
   type BoardingPromptWindowKey,
 } from '../alarmLog';
 import { ALARM_LOG_KEY } from '../../../../shared/constants/storageKeys';
@@ -1268,6 +1270,39 @@ describe('alarmLog', () => {
     it('reason 없는 suppressed 엔트리는 (unknown)으로 집계한다', () => {
       const entry: AlarmLogEntry = { ts: 1, source: 'fg', outcome: 'suppressed' };
       expect(summarizeAlarmLogByReason([entry])).toEqual({ '(unknown)': 1 });
+    });
+  });
+
+  describe('summarizeAlarmLogCounters (#1021)', () => {
+    it('suppressed 엔트리의 reason별 count+lastTs를 합산해 내림차순으로 반환한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed', count: 2, ts: 100 }),
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed', count: 3, ts: 200 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', count: 1, ts: 50 }),
+        makeEntry({ outcome: 'fired' }),
+      ];
+      const result: AlarmLogReasonCounter[] = summarizeAlarmLogCounters(entries);
+      expect(result[0]).toEqual({ reason: 'movement-static-speed', count: 5, lastTs: 200 });
+      expect(result[1]).toEqual({ reason: 'gate-age', count: 1, lastTs: 50 });
+    });
+
+    it('suppressed가 없으면 빈 배열을 반환한다', () => {
+      expect(summarizeAlarmLogCounters([makeEntry({ outcome: 'fired' })])).toEqual([]);
+    });
+
+    it('reason 없는 suppressed 엔트리는 (unknown)으로 집계한다', () => {
+      const entry: AlarmLogEntry = { ts: 1, source: 'fg', outcome: 'suppressed' };
+      const result = summarizeAlarmLogCounters([entry]);
+      expect(result).toEqual([{ reason: '(unknown)', count: 1, lastTs: 1 }]);
+    });
+
+    it('count 필드가 없으면 1로 해석해 합산한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: 10 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: 20 }),
+      ];
+      const result = summarizeAlarmLogCounters(entries);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: 20 }]);
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -50,7 +50,9 @@ export type AlarmLogSource =
   // #580 M4: firedAlarmsRefDestIdRef vs destination.id mismatch 감지 stamp.
   // ETA/API/FG arvlCd effect 진입 시 refDestId가 destination.id와 다르면 1건 기록.
   // 같은 destinationId에서 mismatch가 반복되면 hydration 완료 전에 effect가 재실행되는 race 정황.
-  | 'fg-ref-mismatch';
+  | 'fg-ref-mismatch'
+  // #1021: boardingPrompt 발사 빈도 측정.
+  | 'boarding-prompt';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -159,6 +161,9 @@ export interface AlarmLogEntry {
   firedAlarmsCount?: number;
   // #580 M4: fg-ref-mismatch 엔트리 — 예상 destinationId와 실제 refDestId 기록.
   refDestId?: string | null;
+  // #1024 — burst inline counter. 같은 reason 연속 발생 시 count++ (새 entry 추가 대신).
+  // 미설정이면 1로 해석 — 기존 entry와 완전 하위 호환.
+  count?: number;
 }
 
 const logger = createLogger('AlarmLog');
@@ -534,6 +539,50 @@ export function summarizeAlarmLogBySource(
   return counts;
 }
 
+export interface AlarmLogReasonCounter {
+  reason: string;
+  count: number;
+  lastTs: number;
+}
+
+/**
+ * reason별 누적 count + 마지막 발생 시각 집계 (#1024).
+ * suppressed 엔트리의 count 필드(미설정 시 1로 해석)를 합산하고 마지막 ts를 추적한다.
+ * DebugModal ## Counters 섹션에서 어떤 reason이 얼마나 자주 억제됐는지 시각화용.
+ * count 내림차순으로 정렬해 반환 — 가장 빈번한 reason이 상단에 노출.
+ */
+export function summarizeAlarmLogCounters(
+  entries: readonly AlarmLogEntry[],
+): AlarmLogReasonCounter[] {
+  const map = new Map<string, AlarmLogReasonCounter>();
+  for (const entry of entries) {
+    if (entry.outcome !== 'suppressed') continue;
+    const key = entry.reason ?? '(unknown)';
+    const entryCount = entry.count ?? 1;
+    const existing = map.get(key);
+    if (existing) {
+      existing.count += entryCount;
+      if (entry.ts > existing.lastTs) existing.lastTs = entry.ts;
+    } else {
+      map.set(key, { reason: key, count: entryCount, lastTs: entry.ts });
+    }
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count);
+}
+
+/** reason별 억제 카운트. suppressed 엔트리의 reason 분포. */
+export function summarizeAlarmLogByReason(
+  entries: readonly AlarmLogEntry[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const entry of entries) {
+    if (entry.outcome !== 'suppressed') continue;
+    const key = entry.reason ?? '(unknown)';
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
 /**
  * Silent push outcome별 집계 (#856).
  *
@@ -559,6 +608,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'fg-hydrate': null,
   'fg-arvlcd': null,
   'fg-ref-mismatch': null,
+  'boarding-prompt': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -659,6 +709,40 @@ export function logSuppressedSleepFirstTransfer(input: {
   });
 }
 
+/** #1021: boardingPrompt 발사 1건 적재. */
+export function logBoardingPromptFired(input: { originStation: string; line: string }): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'boarding-prompt',
+    outcome: 'fired',
+    stationName: `${input.line}·${input.originStation}`,
+  });
+}
+
+/** #1021: 시간 윈도우별 boardingPrompt 발사 횟수. 5m / 1h / all. */
+export const BOARDING_PROMPT_WINDOWS = [
+  { key: '5m', label: '5m', ms: 5 * 60 * 1000 },
+  { key: '1h', label: '1h', ms: 60 * 60 * 1000 },
+  { key: 'all', label: 'all', ms: Infinity },
+] as const;
+
+export type BoardingPromptWindowKey = (typeof BOARDING_PROMPT_WINDOWS)[number]['key'];
+
+export function countBoardingPromptByWindow(
+  entries: readonly AlarmLogEntry[],
+  now: number = Date.now(),
+): Record<BoardingPromptWindowKey, number> {
+  const counts: Record<BoardingPromptWindowKey, number> = { '5m': 0, '1h': 0, all: 0 };
+  for (const entry of entries) {
+    if (entry.source !== 'boarding-prompt' || entry.outcome !== 'fired') continue;
+    const ageMs = now - entry.ts;
+    for (const { key, ms } of BOARDING_PROMPT_WINDOWS) {
+      if (ageMs <= ms) counts[key] += 1;
+    }
+  }
+  return counts;
+}
+
 // ── CRUD ──
 
 // 모듈 스코프 mutable state (#735 batched write).
@@ -682,6 +766,21 @@ let flushInFlight: Promise<void> | null = null;
  * 직전 등)에서는 await flushAlarmLog() 명시 호출.
  */
 export function appendAlarmLog(entry: AlarmLogEntry): void {
+  // #1024 — burst inline counter: reason이 있는 억제 엔트리에서 마지막 pendingEntry가
+  // 동일한 (source, reason, stationName)이면 count++하고 ts를 갱신한다.
+  if (entry.reason !== undefined && pendingEntries.length > 0) {
+    const last = pendingEntries[pendingEntries.length - 1];
+    if (
+      last.reason === entry.reason &&
+      last.source === entry.source &&
+      last.stationName === entry.stationName
+    ) {
+      last.count = (last.count ?? 1) + 1;
+      last.ts = entry.ts;
+      scheduleFlush();
+      return;
+    }
+  }
   pendingEntries.push(entry);
   oldestPendingTs ??= Date.now();
   scheduleFlush();

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -767,12 +767,14 @@ let flushInFlight: Promise<void> | null = null;
  */
 export function appendAlarmLog(entry: AlarmLogEntry): void {
   // #1024 — burst inline counter: reason이 있는 억제 엔트리에서 마지막 pendingEntry가
-  // 동일한 (source, reason, stationName)이면 count++하고 ts를 갱신한다.
+  // 동일한 (source, reason, kind, phaseId, stationName)이면 count++하고 ts를 갱신한다.
   if (entry.reason !== undefined && pendingEntries.length > 0) {
     const last = pendingEntries[pendingEntries.length - 1];
     if (
       last.reason === entry.reason &&
       last.source === entry.source &&
+      last.kind === entry.kind &&
+      last.phaseId === entry.phaseId &&
       last.stationName === entry.stationName
     ) {
       last.count = (last.count ?? 1) + 1;

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -27,6 +27,8 @@ import {
   getAlarmLog,
   summarizeAlarmLogBySource,
   summarizeAlarmLogCounters,
+  BOARDING_PROMPT_WINDOWS,
+  countBoardingPromptByWindow,
   type AlarmLogEntry,
   type AlarmLogReasonCounter,
 } from '../../../features/alarm/utils/alarmLog';
@@ -692,7 +694,7 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
           </Section>
 
                     {/* #1021: boardingPrompt 발사 빈도 카운터 */}
-          <Section title="Counters" colors={colors}>
+          <Section title="Boarding Prompt" colors={colors}>
             {BOARDING_PROMPT_WINDOWS.map(({ key, label }) => (
               <KeyValue
                 key={key}

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -29,8 +29,6 @@ import {
   getAlarmLog,
   summarizeAlarmLogBySource,
   summarizeAlarmLogCounters,
-  BOARDING_PROMPT_WINDOWS,
-  countBoardingPromptByWindow,
   type AlarmLogEntry,
   type AlarmLogReasonCounter,
 } from '../../../features/alarm/utils/alarmLog';

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -26,7 +26,9 @@ import {
   countSilentPushOutcomes,
   getAlarmLog,
   summarizeAlarmLogBySource,
+  summarizeAlarmLogCounters,
   type AlarmLogEntry,
+  type AlarmLogReasonCounter,
 } from '../../../features/alarm/utils/alarmLog';
 import { SILENT_PUSH_LABELS, buildSilentPushCountValue } from '../../../shared/constants/labels';
 import {
@@ -689,6 +691,21 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
             )}
           </Section>
 
+                    {/* #1021: boardingPrompt 발사 빈도 카운터 */}
+          <Section title="Counters" colors={colors}>
+            {BOARDING_PROMPT_WINDOWS.map(({ key, label }) => (
+              <KeyValue
+                key={key}
+                label={`boardingPrompt(${label})`}
+                value={String(countBoardingPromptByWindow(logs)[key])}
+                colors={colors}
+              />
+            ))}
+          </Section>
+
+          {/* #1024 — ## Counters: reason별 누적 count + 마지막 발생 시각 */}
+          <CountersSection logs={logs} colors={colors} />
+
           {/* #1022: Worker Quota admin view */}
           <Section title="Worker Quota" colors={colors}>
             <KeyValue
@@ -797,6 +814,36 @@ function KeyValue({
   );
 }
 
+/**
+ * ## Counters 섹션 본문 (#1024) — reason별 누적 count + 마지막 발생 시각.
+ * 억제 이벤트가 없으면 "(empty)" 노출. 항상 표시.
+ */
+function CountersSection({
+  logs,
+  colors,
+}: Readonly<{
+  logs: readonly AlarmLogEntry[];
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  const counters: AlarmLogReasonCounter[] = summarizeAlarmLogCounters(logs);
+  return (
+    <Section title="Counters" colors={colors}>
+      {counters.length === 0 ? (
+        <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
+      ) : (
+        counters.map(({ reason, count, lastTs }) => (
+          <KeyValue
+            key={reason}
+            label={reason}
+            value={`${count}x (${formatTime(lastTs)})`}
+            colors={colors}
+          />
+        ))
+      )}
+    </Section>
+  );
+}
+
 // Internal exports for tests — DO NOT use from app code.
 export const __test__ = {
   formatLogLine,
@@ -807,6 +854,7 @@ export const __test__ = {
   formatAt,
   formatSourceCountsLine,
   NO_FUSED_SIGNAL_LABEL,
+  summarizeAlarmLogCounters,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -22,7 +22,9 @@ import {
   type SilentPushDiagnostics,
 } from '../../../features/alarm/hooks/useSilentPushDiagnostics';
 import {
+  BOARDING_PROMPT_WINDOWS,
   clearAlarmLog,
+  countBoardingPromptByWindow,
   countSilentPushOutcomes,
   getAlarmLog,
   summarizeAlarmLogBySource,

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -490,7 +490,7 @@ describe('DebugModal', () => {
   });
 
 
-  it('#1021: Counters 섹션에 boardingPrompt 카운터 라벨을 표시한다', async () => {
+  it('#1021: Boarding Prompt 섹션에 boardingPrompt 카운터 라벨을 표시한다', async () => {
     const now = Date.now();
     mockGetAlarmLog.mockResolvedValue([
       { ts: now - 60_000, source: 'boarding-prompt', outcome: 'fired' },
@@ -503,7 +503,7 @@ describe('DebugModal', () => {
     expect(screen.getByText('boardingPrompt(all)')).toBeTruthy();
   });
 
-  it('#1021: Counters 섹션 — boarding-prompt 없으면 카운터 섹션이 0을 표시한다', async () => {
+  it('#1021: Boarding Prompt 섹션 — boarding-prompt 없으면 카운터 섹션이 0을 표시한다', async () => {
     mockGetAlarmLog.mockResolvedValue([]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -497,7 +497,7 @@ describe('DebugModal', () => {
     ]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-    expect(screen.getByText('Counters')).toBeTruthy();
+    expect(screen.getByText('Boarding Prompt')).toBeTruthy();
     expect(screen.getByText('boardingPrompt(5m)')).toBeTruthy();
     expect(screen.getByText('boardingPrompt(1h)')).toBeTruthy();
     expect(screen.getByText('boardingPrompt(all)')).toBeTruthy();
@@ -507,7 +507,7 @@ describe('DebugModal', () => {
     mockGetAlarmLog.mockResolvedValue([]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-    expect(screen.getByText('Counters')).toBeTruthy();
+    expect(screen.getByText('Boarding Prompt')).toBeTruthy();
   });
 
     it('unmount 시 AppState listener를 정리한다', async () => {

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -489,7 +489,28 @@ describe('DebugModal', () => {
     expect(screen.getAllByText('(never)').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('unmount 시 AppState listener를 정리한다', async () => {
+
+  it('#1021: Counters 섹션에 boardingPrompt 카운터 라벨을 표시한다', async () => {
+    const now = Date.now();
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 60_000, source: 'boarding-prompt', outcome: 'fired' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Counters')).toBeTruthy();
+    expect(screen.getByText('boardingPrompt(5m)')).toBeTruthy();
+    expect(screen.getByText('boardingPrompt(1h)')).toBeTruthy();
+    expect(screen.getByText('boardingPrompt(all)')).toBeTruthy();
+  });
+
+  it('#1021: Counters 섹션 — boarding-prompt 없으면 카운터 섹션이 0을 표시한다', async () => {
+    mockGetAlarmLog.mockResolvedValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Counters')).toBeTruthy();
+  });
+
+    it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     unmount();


### PR DESCRIPTION
## 변경 사항
- `alarmLog.ts`에 `'boarding-prompt'` source 타입 추가 + `logBoardingPromptFired` helper
- `BOARDING_PROMPT_WINDOWS` + `countBoardingPromptByWindow`: 5m/1h/all 시간 단위 발사 횟수 집계
- `summarizeAlarmLogByReason` 추가 (#1019 DebugModal import 의존 해소)
- `summarizeAlarmLogCounters` + `AlarmLogEntry.count?`: burst inline counter — 같은 reason 연속 발생 시 count++
- `DebugModal.tsx` Counters 섹션: boardingPrompt 5m/1h/all + reason별 누적 count 노출

Closes #1021
Closes #1024