### PR TITLE
fix(#1010): station-passed firedHydrated + 30s hydration warmup 가드

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -75,6 +75,7 @@ const mockLogSuppressedDedupStation = jest.fn();
 const mockLogSuppressedMovement = jest.fn();
 const mockLogSuppressedSleepFirstTransfer = jest.fn();
 const mockLogSuppressedDismissSilence = jest.fn();
+const mockLogSuppressedStationPassedWarmup = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -86,6 +87,8 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
     mockLogSuppressedSleepFirstTransfer(...args),
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
+  logSuppressedStationPassedWarmup: (...args: unknown[]) =>
+    mockLogSuppressedStationPassedWarmup(...args),
 }));
 
 const mockGetBoardingLock = jest.fn();
@@ -1983,6 +1986,107 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+  });
+
+  // #1010 — station-passed firedHydrated 가드 + 30s hydration warmup.
+  // lock hydrate 직후 GPS가 stabilize되기 전 false alarm 방지.
+  describe('#1010 station-passed hydration warmup guard', () => {
+    const route = makeDirectRoute(3, '2');
+    const station = makeStation('S1', '역삼');
+
+    it('firedHydrated=false (hydration pending) 동안 station-passed 발사 보류', async () => {
+      // getFiredAlarms를 영원히 pending 상태로 두면 firedHydrated=false 유지
+      mockGetFiredAlarms.mockReturnValue(new Promise(() => {}));
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2, isTransfer: false, stopsToDestination: 2 });
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            accuracyMeters: 50,
+            skipWarmupGuard: false,
+          }),
+        ),
+      );
+
+      // hydration이 완료되지 않으면 발사 없음
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('warmup window 내 (hydratedAt 직후) station-passed 차단 + gate-station-passed-warmup 적재', async () => {
+      const baseTs = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2, isTransfer: false, stopsToDestination: 2 });
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            accuracyMeters: 50,
+            skipWarmupGuard: false,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      // warmup window 안 — 발사 차단
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedStationPassedWarmup).toHaveBeenCalledWith(station.name);
+    });
+
+    it('skipWarmupGuard=true면 warmup window 안에서도 즉시 발사', async () => {
+      const baseTs = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2, isTransfer: false, stopsToDestination: 2 });
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            accuracyMeters: 50,
+            skipWarmupGuard: true,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+    });
+
+    it('warmup window 경과 후 발사 허용 (hydratedAt + 30s 이후)', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2, isTransfer: false, stopsToDestination: 2 });
+
+      const { rerender } = renderHook(
+        ({ s }: { s: typeof station | null }) =>
+          useStationAlarm(
+            defaultInputs({
+              route,
+              destination,
+              nearestStation: s,
+              accuracyMeters: 50,
+              skipWarmupGuard: false,
+            }),
+          ),
+        { initialProps: { s: null as typeof station | null } },
+      );
+
+      // hydration 완료 대기 (hydratedAt이 baseTs로 설정됨)
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+
+      // warmup window 경과 후 nearestStation 제공 — 이 시점엔 warmup guard를 통과해야 함.
+      nowSpy.mockReturnValue(baseTs + 30_001);
+      rerender({ s: station });
 
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
     });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -37,6 +37,7 @@ import {
   logSuppressedDismissSilence,
   logSuppressedMovement,
   logSuppressedSleepFirstTransfer,
+  logSuppressedStationPassedWarmup,
 } from '../utils/alarmLog';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { getBoardingLock } from '../utils/boardingLockStorage';
@@ -51,6 +52,10 @@ import type { FusionConfidence, FusionSource } from '../../../shared/types/fusio
 import { resolveNotificationSource, type NotificationSource } from '../utils/notificationSource';
 
 const logger = createLogger('StationAlarm');
+
+// #1010 — station-passed hydration warmup. lock hydrate 완료 후 이 기간 동안 station-passed 차단.
+// 하이드레이션 직후 firedAlarms가 복원되기 전 GPS 신호와 동기화되는 과도 구간 false alarm 방지.
+const STATION_PASSED_HYDRATE_WARMUP_MS = 30_000;
 
 /**
  * #746 — dismiss silence 게이트 판정 + 만료 시 store clear 호출.
@@ -264,6 +269,9 @@ export function useStationAlarm({
   // 즉시 평가 분기로 진입하면 잘못된 phase 알람이 발사됨. 한 cycle 보류로 다음 deps 변경(좌표/
   // hydrate state 갱신) 시 안정된 입력으로 평가.
   const isFirstAlarmEvalRef = useRef(true);
+  // #1010: station-passed hydration warmup — 하이드레이션 완료 시각(ms). null이면 미완료.
+  // warmup window 동안 station-passed effect가 즉시 차단된다.
+  const stationPassedHydratedAtRef = useRef<number | null>(null);
   // firedAlarms hydration: BG가 AsyncStorage(FIRED_ALARMS_KEY)에 쓴 dedup 상태를
   // destination별로 격리해 복원한다(#462). hydrated=false인 동안 phase 평가를 보류해
   // 빈 ref로 false re-fire가 발생하지 않도록 가드한다.
@@ -324,6 +332,7 @@ export function useStationAlarm({
   // → cross-trip stale state가 새 trip의 evaluator를 오염시키지 않는다.
   useEffect(() => {
     let cancelled = false;
+    stationPassedHydratedAtRef.current = null;
     setFiredHydrated(false);
     void (async () => {
       // 사전 예약 알람의 첫 drain이 완료된 후 read해야 cold start 직후
@@ -335,6 +344,8 @@ export function useStationAlarm({
       firedAlarmsRefDestIdRef.current = destinationId;
       // #580: hydration 시점 진단 — 같은 destinationId에서 size가 다시 0으로 떨어지면 storage race.
       logFiredAlarmsHydrate(destinationId, stored.size);
+      // #1010: station-passed warmup 시작 — 하이드레이션 완료 시각 기록.
+      stationPassedHydratedAtRef.current = Date.now();
       setFiredHydrated(true);
     })();
     return () => {
@@ -638,8 +649,9 @@ export function useStationAlarm({
 
   // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.
   // dedup은 AsyncStorage(lastNotifiedStationId)를 단일 출처로 사용 — Foreground/Background
-  // 양쪽에서 동일하게 적용된다. firedHydrated에 의존하지 않으므로 하이드레이션 완료가
-  // station-passed를 재발사시키지 않는다.
+  // 양쪽에서 동일하게 적용된다.
+  // #1010: firedHydrated 가드 + 30s warmup — lock hydrate 직후 GPS가 stabilize되기 전
+  // false alarm이 발사되는 회귀를 차단한다.
   // #452: deps에 raw accuracyMeters를 두면 GPS 노이즈로 매 fix 재실행 → dedup-suppressed
   // 로그가 cap까지 차서 다른 진단을 밀어낸다. 게이트 통과 여부(boolean)만 dep로 둔다.
   const accuracyOk = isAccuracyAcceptable(accuracyMeters);
@@ -668,6 +680,17 @@ export function useStationAlarm({
   useEffect(() => {
     let cancelled = false;
     if (!route || !destination) return;
+
+    // #1010: firedAlarms 복원 완료 전에는 발사 보류.
+    if (!firedHydrated) return;
+    // #1010: hydration 완료 후 30s warmup window 동안 발사 보류.
+    if (!skipWarmupGuard) {
+      const hydratedAt = stationPassedHydratedAtRef.current;
+      if (hydratedAt !== null && Date.now() - hydratedAt < STATION_PASSED_HYDRATE_WARMUP_MS) {
+        logSuppressedStationPassedWarmup(nearestStation?.name);
+        return;
+      }
+    }
 
     if (!accuracyOk && !arrivalConfirmed) return;
 
@@ -720,6 +743,7 @@ export function useStationAlarm({
     destination?.id,
     destination?.name,
     nearestStation?.id,
+    firedHydrated,
     accuracyOk,
     arrivalConfirmed,
     movementSuppressionReason,

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -39,6 +39,7 @@ import {
   logSilentPushFired,
   logSilentPushSkipped,
   logAlertFallbackFired,
+  logSuppressedStationPassedWarmup,
   summarizeAlarmLogBySource,
   countSilentPushOutcomes,
   ALARM_LOG_BUFFER_SIZE,
@@ -565,6 +566,36 @@ describe('alarmLog', () => {
         kind: 'transfer',
       });
       expect(saved[0].phaseId).toBeUndefined();
+    });
+
+    it('#1010 logSuppressedStationPassedWarmup: reason=gate-station-passed-warmup + kind=station-passed + source=fg 고정', async () => {
+      logSuppressedStationPassedWarmup('역삼');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'gate-station-passed-warmup',
+        stationName: '역삼',
+        kind: 'station-passed',
+      });
+    });
+
+    it('#1010 logSuppressedStationPassedWarmup: stationName=undefined 허용', async () => {
+      logSuppressedStationPassedWarmup(undefined);
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'gate-station-passed-warmup',
+        kind: 'station-passed',
+      });
+      expect(saved[0].stationName).toBeUndefined();
     });
 
     it('#626 같은 키 윈도우 내 재호출은 drop (FG polling 매초 평가 스팸 차단)', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -91,7 +91,9 @@ export type AlarmLogReason =
   | 'lockless-non-intermediate'
   | 'lockless-opt-out'
   // #746 — 사용자가 알람을 dismiss한 직후 5분 또는 200m 이내 동안 모든 카테고리 차단.
-  | 'dismiss-silence';
+  | 'dismiss-silence'
+  // #1010 — station-passed effect가 lock hydrate 직후 30s warmup window 동안 차단된 발사.
+  | 'gate-station-passed-warmup';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -656,6 +658,21 @@ export function logSuppressedSleepFirstTransfer(input: {
     stationName: input.stationName,
     kind: 'transfer',
     phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1010 — station-passed effect가 lock hydrate 직후 30s warmup window 동안 차단된 발사 1건 적재.
+ * stationName은 nearestStation?.name — unknown이면 undefined.
+ */
+export function logSuppressedStationPassedWarmup(stationName: string | undefined): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'fg',
+    outcome: 'suppressed',
+    reason: 'gate-station-passed-warmup',
+    stationName,
+    kind: 'station-passed',
   });
 }
 


### PR DESCRIPTION
## Summary

- station-passed effect에 `firedHydrated` 가드 추가 — lock hydrate 직후 false alarm 방지
- hydrate 후 30s warmup window 동안 station-passed 발사 보류 (`STATION_PASSED_HYDRATE_WARMUP_MS`)
- `skipWarmupGuard` 파라미터로 테스트 bypass 지원 (기존 패턴과 일치)
- `alarmLog.ts`에 `'gate-station-passed-warmup'` reason 추가 + `logSuppressedStationPassedWarmup` 헬퍼

Closes #1010

## Test plan
- [x] station-passed tests pass with firedHydrated=false → no fire
- [x] station-passed tests pass with firedHydrated=true + warmup window → suppressed + log
- [x] station-passed tests pass with skipWarmupGuard=true → fires immediately
- [x] station-passed tests pass with warmup elapsed (30s+) → fires
- [x] 100% coverage (alarmLog.ts + useStationAlarm.ts)
- [x] type-check pass