### PR TITLE
fix(#1125): smoke 06 — 8-3번 문 라벨 scrollUntilVisible로 viewport 보장

### DIFF
--- a/.maestro/flows/smoke/06_accessibility_mode_route.yaml
+++ b/.maestro/flows/smoke/06_accessibility_mode_route.yaml
@@ -43,6 +43,12 @@ name: "smoke - 거동 불편자 모드가 경로 화면 문번호 라벨에 반�
     id: "suggestion-item-3-019"
 
 # 기본 모드: stairs 우선 — 도착역(경복궁) 라벨에 "8-3번 문" 표시
+# Hero + Hr + route header + segment control + 3-row timeline이 iPhone 16 viewport를 초과해
+# 마지막 row(경복궁)가 fold 아래로 떨어지는 타이밍이 있다 (#1125). scroll로 결정적 노출.
+- scrollUntilVisible:
+    element:
+      text: "8-3번 문|Door 8-3"
+    timeout: 10000
 - extendedWaitUntil:
     visible:
       text: "8-3번 문|Door 8-3"


### PR DESCRIPTION
## Summary

- `06_accessibility_mode_route.yaml`: extendedWaitUntil 전 scrollUntilVisible 추가
- 경복궁 도착 row의 quickExitDoor 라벨이 viewport 밖에 있어도 결정적으로 가져옴
- 시뮬레이터 속도 의존 flake 해소 (PR #1108, #1105에서 발생)

Closes #1125

## Test plan
- [x] Maestro smoke 06 flow 통과 (CI E2E Smoke 결과로 확인)