### PR TITLE
refactor(#1061): 위치 권한 거부 UI 단일 버튼 + HomeScreen 통일

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -37,6 +37,7 @@ import { AlarmOverlay } from '../features/alarm/components/AlarmOverlay';
 import { createLogger } from '../shared/utils/logger';
 import { useTheme, typography, spacing, radius } from '../shared/theme';
 import { LineBadge } from '../shared/ui/LineBadge';
+import { LocationStateView } from '../shared/ui/LocationStateView';
 import { ServiceWindowBanner } from '../shared/ui/ServiceWindowBanner';
 import { SourceBadge } from '../features/arrival/components/SourceBadge';
 import { resolveNotificationSource } from '../features/alarm/utils/notificationSource';
@@ -677,19 +678,10 @@ export default function HomeScreen() {
   }, [arrivedBanner]);
 
   if (permissionDenied) {
+    // MapScreen과 동일한 단일 UI(LocationStateView)로 통일. iOS 영구 거부 시 OS dialog가
+    // 뜨지 않아 "다시 시도"가 dead end가 되는 문제를 해결한다 (#1061).
     return (
-      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
-        <View style={styles.center}>
-          <Text style={styles.icon}>📍</Text>
-          <Text style={[styles.title, { color: colors.ink }]}>{t('permissions.locationRequiredTitle')}</Text>
-          <Text style={[styles.subtitle, { color: colors.muted }]}>
-            {t('permissions.locationRequiredDescription')}
-          </Text>
-          <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
-            <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('common.retry')}</Text>
-          </TouchableOpacity>
-        </View>
-      </SafeAreaView>
+      <LocationStateView permissionDenied={true} loading={false} error={null} onRetry={refresh} />
     );
   }
 

--- a/src/shared/ui/LocationStateView.tsx
+++ b/src/shared/ui/LocationStateView.tsx
@@ -17,19 +17,19 @@ export function LocationStateView({ permissionDenied, loading, error, onRetry }:
   const { t } = useTranslation();
 
   if (permissionDenied) {
+    // iOS에서 사용자가 권한을 영구 거부하면 requestPermissionsAsync()는 OS dialog 없이
+    // 즉시 denied를 반환한다. 따라서 "권한 요청" 버튼은 무의미하고, 유일한 복구 경로인
+    // "설정 열기"만 노출한다.
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
           <Text style={[styles.message, { color: colors.muted }]}>{t('permissions.locationRequiredShort')}</Text>
-          <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={onRetry} testID="location-retry-button">
-            <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('permissions.request')}</Text>
-          </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.secondaryButton, { borderColor: colors.accent }]}
+            style={[styles.button, { backgroundColor: colors.accent }]}
             onPress={openAppSettings}
             testID="location-open-settings-button"
           >
-            <Text style={[styles.buttonText, { color: colors.accent }]}>{t('permissions.openSettings')}</Text>
+            <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('permissions.openSettings')}</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -81,13 +81,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingVertical: 12,
     borderRadius: 8,
-  },
-  secondaryButton: {
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
-    borderWidth: 1,
-    marginTop: 12,
   },
   buttonText: {
     fontSize: 16,

--- a/src/shared/ui/__tests__/LocationStateView.test.tsx
+++ b/src/shared/ui/__tests__/LocationStateView.test.tsx
@@ -42,22 +42,24 @@ describe('LocationStateView', () => {
       expect(screen.getByText('위치 권한이 필요합니다.')).toBeTruthy();
     });
 
-    it('권한 요청 버튼을 표시한다', () => {
-      expect(screen.getByText('권한 요청')).toBeTruthy();
+    it('"권한 요청" 버튼은 표시하지 않는다', () => {
+      // iOS 영구 거부 후 requestPermissionsAsync가 dialog 없이 즉시 denied를 반환하므로 제거됨
+      expect(screen.queryByText('권한 요청')).toBeNull();
+      expect(screen.queryByTestId('location-retry-button')).toBeNull();
     });
 
-    it('권한 요청 버튼 클릭 시 onRetry를 호출한다', () => {
-      fireEvent.press(screen.getByTestId('location-retry-button'));
-      expect(onRetry).toHaveBeenCalledTimes(1);
-    });
-
-    it('"설정 열기" 버튼을 표시한다', () => {
+    it('"설정 열기" 단일 버튼만 표시한다', () => {
       expect(screen.getByText('설정 열기')).toBeTruthy();
+      expect(screen.getByTestId('location-open-settings-button')).toBeTruthy();
     });
 
     it('"설정 열기" 버튼 클릭 시 openAppSettings를 호출한다', () => {
       fireEvent.press(screen.getByTestId('location-open-settings-button'));
       expect(openAppSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('onRetry는 호출되지 않는다 (permissionDenied 분기는 onRetry를 노출하지 않음)', () => {
+      expect(onRetry).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- LocationStateView permissionDenied: "권한 요청" 버튼 제거, "설정 열기"만 유지 (iOS 영구 거부 후 requestPermissionsAsync는 dialog 안 띄움 → 의미 없는 버튼)
- HomeScreen `:622-637` 인라인 UI를 `LocationStateView`로 교체 → 중복 제거 + 자동 일관성

Closes #1061

## Test plan
- [x] LocationStateView: 단일 "설정 열기" 버튼만 렌더, openAppSettings 호출
- [x] HomeScreen permissionDenied 분기: LocationStateView 렌더
- [x] 100% coverage