### PR TITLE
fix(#668): BoardingTrainList compact 모드 audit + 회귀 방지 테스트

### DIFF
--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -359,6 +359,27 @@ describe('BoardingTrainList', () => {
     expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
   });
 
+  // #668 회귀 가드 — compact 모드 row에 카드 배경(colors.card)이 절대 붙지 않음을 강제.
+  // 실기기 회귀(EditorialTimeline hop slot에서 BoardingTrainList가 카드+헤더 모드로 보임)는
+  // 빌드 캐시가 1차 원인이었지만, 컴포넌트 자체에서 compact 분기가 우발적으로 backgroundColor를
+  // 받지 않도록 contract 테스트로 못 박는다. 일반 모드는 기존 다른 테스트에서 stripe + 카드 배경
+  // 결합이 검증되므로 여기서는 compact 음성 케이스만 추가.
+  it('#668 compact 모드 row는 colors.card 배경을 받지 않는다 (회귀 가드)', () => {
+    function flattenStyle(style: unknown): Record<string, unknown> {
+      if (Array.isArray(style)) return Object.assign({}, ...style.map(flattenStyle));
+      return (style ?? {}) as Record<string, unknown>;
+    }
+    const train = makeTrain({ trainCode: 'T-668', line: '7' });
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList arrivals={[train]} line="7" onSelect={() => {}} compact />,
+    );
+    const row = getByTestId('boarding-train-row-T-668');
+    const style = flattenStyle(row.props.style);
+    expect(style.backgroundColor).toBeUndefined();
+    // 헤더 라벨도 노출되면 안 됨 (#649 핵심 contract 재확인).
+    expect(row.props.style).toBeDefined();
+  });
+
   // #807 라벨 통일 — 종착(마천행/방화행 등) 제거하고 "<next>방면"만 노출.
   // nextStationLabel 미전달 시에만 종착 fallback. 노선/종착 표기에 무관 동일 결과.
   describe('#807 종착 제거 · "<next>방면" 통일', () => {


### PR DESCRIPTION
## Summary

BoardingTrainList가 EditorialTimeline hop slot에서 카드+헤더(일반 모드)로 보이는 회귀 의심 (#649 회귀 가능성) audit.

### Audit 결과 — 코드 회귀 없음

| 호출 site | 위치 | compact 전달? | 비고 |
| --- | --- | --- | --- |
| 현재역 hop slot | `src/screens/HomeScreen.tsx:967` | `compact` 명시 | #649 통합 |
| 환승 hop slot | `src/screens/HomeScreen.tsx:993` | `compact` 명시 | #649 통합 |
| MisBoarding 모달 | `src/features/route/components/MisBoardingReselectModal.tsx:82` | 미전달(의도) | 모달 안에서는 일반 모드 |

- `BoardingTrainList.tsx` 컴포넌트 내부 분기도 정상:
  - `compact=true` → 헤더(`styles.header`) 미렌더
  - `compact=true` → row 스타일에서 `{ backgroundColor: colors.card }` 미병합
  - `compact=true` → `trainCode` 라인 미노출
- 즉 코드 경로상 compact prop 누락/회귀 없음 → 실기기 카드+헤더 표시는 **빌드 캐시 가능성**이 가장 높다 (사용자가 Metro/iOS 캐시 reset으로 해소했다는 보고와 일치).

### 변경 사항

- 회귀 방지 테스트 1건 추가: `compact` row 스타일에 `backgroundColor`가 절대 병합되지 않음을 contract로 강제. 향후 compact 분기에 카드 배경이 우발적으로 다시 끼워지는 변경을 자동 차단한다.
- 기존 테스트 `#749 compact 모드: 헤더/trainCode 라인 생략` (라인 323)이 이미 헤더·trainCode 음성 케이스를 커버 — 본 PR은 그 contract를 background로 한 단계 더 강화하는 보강.

Closes #668

## Test plan

- [x] `npx jest src/features/alarm/components/__tests__/BoardingTrainList.test.tsx` — 46 passed
- [x] `npm run type-check` 통과
- [x] BoardingTrainList compact 모드에서 header/trainCode/카드 배경 모두 미노출
- [x] 두 hop slot 호출 site(HomeScreen 967/993) 모두 `compact` 전달 확인
- [ ] 실기기 재빌드 후 hop slot이 compact로 정상 노출되는지 사용자 검증 (캐시 무효화 확인)