### PR TITLE
refactor(#837): Kalman reset grace window drift 측정 사각지대 해소 (P2-2)

### DIFF
--- a/backend/alarm-worker/src/__tests__/kalmanFilter.test.ts
+++ b/backend/alarm-worker/src/__tests__/kalmanFilter.test.ts
@@ -426,24 +426,27 @@ describe('DRIFT_WARNING_THRESHOLD_KMH 상수 (#826 E4)', () => {
 // ─────────────────────────────────────────────────────
 
 describe('resetKalmanForArrival — 정거장 도착 ground truth hard reset (#826 E4)', () => {
-  it('now=1000 → { v: 0, P: R_LOW(=4), ts: 1000 }', () => {
+  it('now=1000 → { v: 0, P: R_LOW(=4), ts: 1000, lastResetTs: 1000 }', () => {
     const result = resetKalmanForArrival(1000);
-    expect(result).toEqual({ v: 0, P: R_LOW, ts: 1000 });
+    // #837 P2-2 — lastResetTs stamp는 drift grace window 활성화 입력.
+    expect(result).toEqual({ v: 0, P: R_LOW, ts: 1000, lastResetTs: 1000 });
   });
 
-  it('now=0 → ts=0, v=0, P=R_LOW', () => {
+  it('now=0 → ts=0, v=0, P=R_LOW, lastResetTs=0', () => {
     const result = resetKalmanForArrival(0);
     expect(result.v).toBe(0);
     expect(result.P).toBe(R_LOW);
     expect(result.ts).toBe(0);
+    expect(result.lastResetTs).toBe(0);
   });
 
-  it('큰 ts 값도 그대로 반영', () => {
+  it('큰 ts 값도 그대로 반영 (ts와 lastResetTs 동일)', () => {
     const ts = 1_700_000_000_000;
     const result = resetKalmanForArrival(ts);
     expect(result.ts).toBe(ts);
     expect(result.v).toBe(0);
     expect(result.P).toBe(R_LOW);
+    expect(result.lastResetTs).toBe(ts);
   });
 
   it('v는 항상 0 — 어떤 now에서도 불변', () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2561,10 +2561,12 @@ function makeEmptyStats(): ScheduledStats {
 }
 
 describe('maybeCountDrift (#837 P2-3)', () => {
+  const NOW = 1_000_000;
+
   it('prior=null이면 drift 카운트 skip (첫 cycle)', () => {
     const stats = makeEmptyStats();
     const posMetrics = makePosMetricsFixture(30); // delta=30 ≥ 15지만 prior 없음
-    maybeCountDrift(null, posMetrics, stats);
+    maybeCountDrift(null, posMetrics, stats, NOW);
     expect(stats.kalmanDriftWarning).toBe(0);
   });
 
@@ -2573,7 +2575,7 @@ describe('maybeCountDrift (#837 P2-3)', () => {
     const prior: KalmanState = { v: 0, P: R_LOW, ts: 0 };
     // state.v=0, gpsAvg=DRIFT_WARNING_THRESHOLD_KMH → |delta|=15 (경계 포함)
     const posMetrics = makePosMetricsFixture(DRIFT_WARNING_THRESHOLD_KMH);
-    maybeCountDrift(prior, posMetrics, stats);
+    maybeCountDrift(prior, posMetrics, stats, NOW);
     expect(stats.kalmanDriftWarning).toBe(1);
   });
 
@@ -2582,8 +2584,38 @@ describe('maybeCountDrift (#837 P2-3)', () => {
     const prior: KalmanState = { v: 30, P: 25, ts: 0 };
     // |30 - 32| = 2 < 15
     const posMetrics = makePosMetricsFixture(32);
-    maybeCountDrift(prior, posMetrics, stats);
+    maybeCountDrift(prior, posMetrics, stats, NOW);
     expect(stats.kalmanDriftWarning).toBe(0);
+  });
+
+  // #837 P2-2 — reset 직후 grace window
+  it('reset 직후 grace window 안 + |delta| ≥ 임계 → 카운트 skip', () => {
+    const stats = makeEmptyStats();
+    // resetKalmanForArrival 결과 그대로 — lastResetTs = ts
+    const prior: KalmanState = { v: 0, P: R_LOW, ts: NOW, lastResetTs: NOW };
+    // 회복 phase GPS 30 km/h — |delta|=30 ≥ 15
+    const posMetrics = makePosMetricsFixture(30);
+    // grace window 내 (30s 경과)
+    maybeCountDrift(prior, posMetrics, stats, NOW + 30_000);
+    expect(stats.kalmanDriftWarning).toBe(0);
+  });
+
+  it('reset 후 grace window 만료 + |delta| ≥ 임계 → 카운트 +1', () => {
+    const stats = makeEmptyStats();
+    const prior: KalmanState = { v: 0, P: R_LOW, ts: NOW, lastResetTs: NOW };
+    const posMetrics = makePosMetricsFixture(30);
+    // grace window(60s) 만료 (61s 경과)
+    maybeCountDrift(prior, posMetrics, stats, NOW + 61_000);
+    expect(stats.kalmanDriftWarning).toBe(1);
+  });
+
+  it('legacy state(lastResetTs 미존재) + |delta| ≥ 임계 → 정상 카운트 (회귀 없음)', () => {
+    const stats = makeEmptyStats();
+    // 구버전 KV에서 읽은 state — lastResetTs 필드 없음.
+    const prior: KalmanState = { v: 0, P: R_LOW, ts: 0 };
+    const posMetrics = makePosMetricsFixture(30);
+    maybeCountDrift(prior, posMetrics, stats, NOW);
+    expect(stats.kalmanDriftWarning).toBe(1);
   });
 });
 

--- a/backend/alarm-worker/src/kalmanFilter.ts
+++ b/backend/alarm-worker/src/kalmanFilter.ts
@@ -79,6 +79,13 @@ export interface KalmanState {
   P: number;
   /** 마지막 update 시각 (epoch ms). */
   ts: number;
+  /**
+   * #837 P2-2 — 마지막 `resetKalmanForArrival` 호출 시각 (epoch ms).
+   * 직후 cycle에서 prior.v=0과 GPS 회복 phase의 |delta|가 임계 근처라
+   * drift warning이 false positive로 카운트되는 사각지대를 회피하기 위한 grace window 입력.
+   * 미존재(undefined)면 reset 이력 없음 — drift 평가 정상 수행.
+   */
+  lastResetTs?: number;
 }
 
 export interface KalmanStepInputs {
@@ -208,6 +215,19 @@ export async function clearKalmanState(
 export const DRIFT_WARNING_THRESHOLD_KMH = 15;
 
 /**
+ * #837 P2-2 — reset 직후 drift 측정 사각지대를 가리는 grace window (ms).
+ *
+ * `resetKalmanForArrival`은 v=0/P=R_LOW로 state를 강제 초기화한다. 직후 cycle에서
+ * GPS가 정거장 정차 phase가 아닌 출발/회복 phase로 측정되면 |state.v - gpsAvg|가
+ * DRIFT_WARNING_THRESHOLD_KMH 근처/초과로 잡힐 수 있어 `kalmanReset`과
+ * `kalmanDriftWarning`이 같은 trip에서 동시 카운트된다. telemetry 해석이 흐려지므로
+ * reset 후 이 window 동안은 drift warning 카운트를 skip한다.
+ *
+ * 1분 — Kalman state가 다음 1~2 cycle GPS 관측(예: 30s 주기)으로 정상 phase에 안착하는 시간.
+ */
+export const KALMAN_DRIFT_GRACE_MS = 60_000;
+
+/**
  * Kalman state hard reset — 정거장 도착 (arvlCd=1) ground truth (#826 Phase 3 E4).
  *
  * 정거장에 도착하는 순간은 가장 강한 ground truth — 열차는 사실상 정차 상태.
@@ -218,7 +238,8 @@ export const DRIFT_WARNING_THRESHOLD_KMH = 15;
  * R 단계 함수의 가장 좋은 GPS(<20m)과 같은 신뢰도를 부여한다.
  */
 export function resetKalmanForArrival(now: number): KalmanState {
-  return { v: 0, P: R_LOW, ts: now };
+  // #837 P2-2 — lastResetTs stamp로 직후 cycle drift warning grace window 활성화.
+  return { v: 0, P: R_LOW, ts: now, lastResetTs: now };
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -20,6 +20,7 @@ import {
 } from './boardingPrompt';
 import {
   detectKalmanDrift,
+  KALMAN_DRIFT_GRACE_MS,
   type KalmanState,
   readKalmanState,
   resetKalmanForArrival,
@@ -428,7 +429,7 @@ interface FusionStepResult {
  *   - phaseState non-null이면 trip.stationPhase에 stamp + putTrip 시 persist
  *   - kalmanKmh를 게이트/fusion 입력으로 전달
  *   - series는 본 함수가 fetched한 raw KV 값 — 추가 read 불필요
- *   - #837 P2-3 — drift 카운트(stats.kalmanDriftWarning)는 호출자가 maybeCountDrift(prior, posMetrics, stats)
+ *   - #837 P2-3 — drift 카운트(stats.kalmanDriftWarning)는 호출자가 maybeCountDrift(prior, posMetrics, stats, now)
  *     로 수행. fusion 자체는 stats를 받지 않아 SRP 유지(HTTP path 등에서 stats 없이 재사용 가능).
  */
 async function runFusionStep(
@@ -508,13 +509,24 @@ async function runFusionStep(
  * skip 조건:
  *  - prior=null (첫 cycle, v=gpsAvg 초기화라 delta=0 의미 없음)
  *  - posMetrics가 fusion observation 무효 cycle의 것이면 호출자가 prior=null로 받음 (#826 정합)
+ *  - #837 P2-2 reset grace window: prior.lastResetTs가 있고 now - lastResetTs < KALMAN_DRIFT_GRACE_MS면
+ *    카운트 skip. `resetKalmanForArrival` 직후 cycle은 prior.v=0과 GPS 회복 phase 사이 |delta|가
+ *    임계 근처/초과로 잡혀 kalmanReset과 동시 카운트되는 telemetry 사각지대 — 해석 불명확 해소.
+ *    legacy state는 lastResetTs 미존재(undefined) — grace skip 없이 정상 평가 (회귀 없음).
  */
 export function maybeCountDrift(
   prior: KalmanState | null,
   posMetrics: WindowedMetrics,
   stats: ScheduledStats,
+  now: number,
 ): void {
   if (prior === null) return;
+  if (
+    prior.lastResetTs !== undefined &&
+    now - prior.lastResetTs < KALMAN_DRIFT_GRACE_MS
+  ) {
+    return;
+  }
   const drift = detectKalmanDrift(prior, posMetrics.gpsAvgKmh);
   if (drift.warning) {
     stats.kalmanDriftWarning += 1;
@@ -1208,7 +1220,7 @@ export async function runLocklessIntermediate(
   // #825 — Phase 3 E3 fusion step. 분류 결과를 trip에 stamp + imminent push 발사 가드에 사용.
   const fusion = await runFusionStep(trip, env, now);
   // #837 P2-3 — drift 카운트는 fusion 외부 (SRP). fusion 결과 직후 동일 시점/조건으로 평가.
-  maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats);
+  maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats, now);
   let dirty = false;
   if (fusion.phaseState) {
     trip.stationPhase = fusion.phaseState;
@@ -1467,7 +1479,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   const fusion = await runFusionStep(trip, env, now);
   // #837 P2-3 — drift 카운트는 fusion 외부 (SRP). fusion 결과 직후 동일 시점/조건으로 평가.
-  maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats);
+  maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats, now);
   let dirty = false;
   // phase 분류 결과가 있으면 trip에 stamp — 다음 cycle hysteresis 입력 + lockless 가드용 상태.
   if (fusion.phaseState) {


### PR DESCRIPTION
## Summary

P2-2: `resetKalmanForArrival` 직후 prior.v=0과 GPS 회복 phase 사이 |delta|가 임계 근처라 같은 trip에서 `kalmanReset`과 `kalmanDriftWarning`이 동시 카운트되는 telemetry 해석 불명확 해소.

- KalmanState에 `lastResetTs` optional 필드 추가
- `resetKalmanForArrival(now)` → `{ v: 0, P: R_LOW, ts: now, lastResetTs: now }`
- `maybeCountDrift` signature에 `now` 추가 — `now - prior.lastResetTs < KALMAN_DRIFT_GRACE_MS` 이면 카운트 skip
- `KALMAN_DRIFT_GRACE_MS = 60_000ms` (Kalman state가 1~2 cycle GPS 관측으로 정상 phase에 안착하는 시간)
- legacy state(lastResetTs 미존재)는 grace skip 없이 정상 평가 → 회귀 없음

Pipeline H (병렬 안전) — backend/alarm-worker only.

P2-1(#840), P2-3(#849) 머지 후속. P2-4는 별도 PR.

Closes #837 partially (P2-2).

## Test plan
- [x] reset 직후 grace window 안 cycle → drift skip
- [x] grace 만료 후 cycle → drift count +1
- [x] legacy state (lastResetTs 미존재) → 회귀 없이 정상 카운트
- [x] backend type-check pass
- [x] backend test suite 1083 pass