### PR TITLE
fix(#698): silentPushTask reschedule kind 분기 추가 — 사전예약 cancel+재예약

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -104,6 +104,12 @@ jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
 }));
 
+// #698 — reschedule silent push 분기에서 호출. mock으로 호출 인자/횟수만 검증.
+const mockRescheduleHopForLock = jest.fn();
+jest.mock('../../utils/boardingLockScheduler', () => ({
+  rescheduleHopForLock: (...args: unknown[]) => mockRescheduleHopForLock(...args),
+}));
+
 const mockGetDismissSilence = jest.fn();
 const mockClearDismissSilence = jest.fn();
 jest.mock('../../utils/dismissSilenceStorage', () => ({
@@ -148,6 +154,7 @@ import {
   ACTIVE_TRIP_KEY,
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
+  ROUTE_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
@@ -229,6 +236,8 @@ describe('silentPushTask', () => {
     mockClearDismissSilence.mockResolvedValue(undefined);
     // #919 — recall trigger 기본 graceful skip.
     mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
+    // #698 — 기본 graceful: 1건 cancel + 1건 schedule. 개별 테스트에서 override.
+    mockRescheduleHopForLock.mockResolvedValue({ cancelled: 1, scheduled: 1 });
   });
 
   it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
@@ -1221,6 +1230,145 @@ describe('silentPushTask', () => {
         await handleSilentPush(reschedulePayload({ pushId: 'rs-uuid' }));
         expect(mockSendPushAck).not.toHaveBeenCalled();
         expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+      });
+
+      // #698 — reschedule kind: 사전 예약 cancel + 재예약 적용.
+      describe('applyReschedule (#698)', () => {
+        const route = { type: 'direct', stops: 2, line: '2', travelSeconds: 240 };
+        const lockMatch = {
+          destinationId: '0228',
+          trainCode: '7610',
+          boardingStationId: 'b',
+          boardingLine: '2',
+          boardedAt: 1_700_000_000_000,
+          expectedDurationMs: 600_000,
+        };
+        function setStorage(opts: {
+          lock?: unknown;
+          route?: unknown;
+          destination?: unknown;
+        } = {}) {
+          mockGetBoardingLock.mockResolvedValue(opts.lock === undefined ? lockMatch : opts.lock);
+          (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+            if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+            if (key === DESTINATION_KEY)
+              return opts.destination === undefined
+                ? JSON.stringify(destStation)
+                : opts.destination === null
+                  ? null
+                  : JSON.stringify(opts.destination);
+            if (key === ROUTE_KEY)
+              return opts.route === undefined
+                ? JSON.stringify(route)
+                : opts.route === null
+                  ? null
+                  : JSON.stringify(opts.route);
+            return null;
+          });
+        }
+
+        it('lock + route + destination 모두 있으면 rescheduleHopForLock 호출', async () => {
+          setStorage();
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+          const arg = mockRescheduleHopForLock.mock.calls[0][0];
+          expect(arg.lock).toBe(lockMatch);
+          expect(arg.nextStation).toBe('사가정');
+          expect(arg.newArrivalMs).toBe(9_999_999_999_999);
+          expect(arg.destinationName).toBe(destStation.name);
+        });
+
+        it('lock 없으면 호출 skip', async () => {
+          setStorage({ lock: null });
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+          // 로그/ack는 그대로 진행됐는지 확인
+          expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+        });
+
+        it('lock trainCode 불일치 시 skip', async () => {
+          setStorage({ lock: { ...lockMatch, trainCode: '다른코드' } });
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+        });
+
+        it('route 없으면 skip', async () => {
+          setStorage({ route: null });
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+        });
+
+        it('destination 없으면 skip', async () => {
+          setStorage({ destination: null });
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+        });
+
+        it('route JSON 파싱 실패 시 skip — 예외 전파 안 함', async () => {
+          mockGetBoardingLock.mockResolvedValue(lockMatch);
+          (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+            if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+            if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+            if (key === ROUTE_KEY) return 'not-json';
+            return null;
+          });
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+        });
+
+        it('destination JSON 파싱 실패 시 skip', async () => {
+          mockGetBoardingLock.mockResolvedValue(lockMatch);
+          (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+            if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+            if (key === DESTINATION_KEY) return 'not-json';
+            if (key === ROUTE_KEY) return JSON.stringify(route);
+            return null;
+          });
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+        });
+
+        it('destination.name 없는 경우 skip', async () => {
+          setStorage({ destination: { id: 'x' } });
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+        });
+
+        it('newArrivalTimeEpoch가 과거이면 skip — rescheduleHopForLock 미호출', async () => {
+          setStorage();
+          await handleSilentPush(
+            reschedulePayload({ newArrivalTimeEpoch: 1 }),
+          );
+          expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+        });
+
+        it('rescheduleHopForLock throw 해도 ack/log는 그대로 진행', async () => {
+          setStorage();
+          mockRescheduleHopForLock.mockRejectedValueOnce(new Error('boom'));
+          await handleSilentPush(
+            reschedulePayload({ pushId: 'rs-uuid', newArrivalTimeEpoch: 9_999_999_999_999 }),
+          );
+          expect(mockSendPushAck).toHaveBeenCalledWith(
+            expect.objectContaining({ pushId: 'rs-uuid', outcome: 'fired', reason: 'reschedule-received' }),
+          );
+          expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+        });
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -57,6 +57,9 @@ import {
   checkSilentPushLocationGate,
   type GateSkipReason,
 } from '../utils/silentPushLocationGate';
+import { rescheduleHopForLock } from '../utils/boardingLockScheduler';
+import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
+import type { Route } from '../../../shared/utils/stationRoute';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
 import { buildAlarmContent } from '../utils/stationNotification';
 import { refreshLiveActivityFromBackgroundContext } from '../utils/refreshLiveActivityFromBackgroundContext';
@@ -420,6 +423,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         sentAt: payload.sentAt,
         receivedAt,
       });
+      await applyReschedule(payload, receivedAt);
       ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
       return;
     }
@@ -508,6 +512,81 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     } catch (e) {
       logger.error('refreshLiveActivityFromBackgroundContext 실패:', e);
     }
+  }
+}
+
+/**
+ * reschedule silent push(#698) 적용 — 백엔드가 보낸 nextStation/newArrivalTimeEpoch로
+ * 해당 hop의 사전 예약을 cancel + 재예약한다. 본 함수는 SLA 게이트가 아니라 정정 신호이므로
+ * 결과 무관 ack(`reschedule-received`)는 호출자가 처리한다.
+ *
+ * 사전 조건 누락(`lock`/`route`/`destination` 중 하나라도 없음, 또는 newArrivalTimeEpoch 과거)은
+ * 모두 graceful no-op — 신호가 도달했어도 SLA를 깨지 않는다(원본 사전 예약 유지).
+ * 예외는 외부로 전파하지 않고 logger.error 후 swallow — 다른 silent push 흐름과 일관.
+ */
+async function applyReschedule(
+  payload: RescheduleSilentPushPayload,
+  receivedAt: number,
+): Promise<void> {
+  try {
+    if (payload.newArrivalTimeEpoch <= receivedAt) {
+      logger.info(
+        `reschedule skip: newArrivalTimeEpoch=${payload.newArrivalTimeEpoch} <= receivedAt=${receivedAt}`,
+      );
+      return;
+    }
+    const lock = await getBoardingLock();
+    if (!lock) {
+      logger.info('reschedule skip: no boarding lock');
+      return;
+    }
+    if (lock.trainCode !== payload.trainCode) {
+      logger.info(
+        `reschedule skip: trainCode mismatch lock=${lock.trainCode} payload=${payload.trainCode}`,
+      );
+      return;
+    }
+    const [routeRaw, destRaw] = await Promise.all([
+      AsyncStorage.getItem(ROUTE_KEY),
+      AsyncStorage.getItem(DESTINATION_KEY),
+    ]);
+    const route = parseRoute(routeRaw);
+    const destinationName = parseDestinationName(destRaw);
+    if (!route || !destinationName) {
+      logger.info(
+        `reschedule skip: route=${route ? 'ok' : 'null'} destination=${destinationName ?? 'null'}`,
+      );
+      return;
+    }
+    await rescheduleHopForLock({
+      lock,
+      route,
+      destinationName,
+      nextStation: payload.nextStation,
+      newArrivalMs: payload.newArrivalTimeEpoch,
+      now: receivedAt,
+    });
+  } catch (e) {
+    logger.error('reschedule apply 실패:', e);
+  }
+}
+
+function parseRoute(raw: string | null): Route | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Route;
+  } catch {
+    return null;
+  }
+}
+
+function parseDestinationName(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<Station> | null;
+    return parsed && typeof parsed.name === 'string' ? parsed.name : null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -6,6 +6,7 @@ import {
   cancelAllHopsForLock,
   parseBoardingLockAlarmIdentifier,
   purgeBoardingLockSchedulerQueue,
+  rescheduleHopForLock,
   routeSignature,
   scheduleHopsForLock,
 } from '../boardingLockScheduler';
@@ -672,5 +673,139 @@ describe('routeSignature', () => {
     expect(routeSignature(directRoute, '강남')).not.toBe(
       routeSignature(directRoute, '잠실'),
     );
+  });
+});
+
+describe('rescheduleHopForLock (#698)', () => {
+  it('일치하는 사전 예약 없으면 cancel/schedule 모두 호출 안 함', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:다른역']);
+    const result = await rescheduleHopForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      nextStation: '강남',
+      newArrivalMs: NOW + 600_000,
+    });
+    expect(result).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedRemove).not.toHaveBeenCalled();
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it('nextStation 매칭되는 사전 예약을 cancel + 새 arrivalMs로 재예약', async () => {
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+      'bl:T-100:1:early:잠실', // 다른 hop — 보존
+      'bl:T-200:0:early:강남', // 다른 lock — 보존
+    ]);
+    const newArrivalMs = NOW + 600_000; // 충분히 미래
+    const result = await rescheduleHopForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      nextStation: '강남',
+      newArrivalMs,
+      now: NOW,
+    });
+    expect(mockedCancel).toHaveBeenCalledTimes(2);
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:imminent:강남');
+    expect(mockedRemove).toHaveBeenCalledWith([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+    ]);
+    // 재예약: directRoute stops=2, travel=240s → earlyLeadMs=120s, imminentLeadMs=45s
+    // 두 trigger 모두 newArrivalMs 미만 → 2건 schedule
+    expect(mockedSchedule).toHaveBeenCalledTimes(2);
+    const scheduledIds = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(scheduledIds).toContain('bl:T-100:0:early:강남');
+    expect(scheduledIds).toContain('bl:T-100:0:imminent:강남');
+    const earlyCall = mockedSchedule.mock.calls.find((c) => c[0].identifier === 'bl:T-100:0:early:강남')!;
+    const earlyTrigger = earlyCall[0].trigger as { date: Date };
+    expect(earlyTrigger.date.getTime()).toBe(newArrivalMs - 120_000);
+    const imminentCall = mockedSchedule.mock.calls.find(
+      (c) => c[0].identifier === 'bl:T-100:0:imminent:강남',
+    )!;
+    const imminentTrigger = imminentCall[0].trigger as { date: Date };
+    expect(imminentTrigger.date.getTime()).toBe(newArrivalMs - 45_000);
+    expect(mockedAdd).toHaveBeenCalledWith([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+    ]);
+    expect(result).toEqual({ cancelled: 2, scheduled: 2 });
+  });
+
+  it('newArrivalMs가 now 직후이면 과거 phase는 skip', async () => {
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+    ]);
+    // newArrivalMs = NOW+30s → imminent(45s lead)는 NOW-15s 과거, early(120s lead)도 과거 → 둘 다 skip
+    const result = await rescheduleHopForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      nextStation: '강남',
+      newArrivalMs: NOW + 30_000,
+      now: NOW,
+    });
+    expect(mockedCancel).toHaveBeenCalledTimes(2);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedAdd).not.toHaveBeenCalled();
+    expect(result).toEqual({ cancelled: 2, scheduled: 0 });
+  });
+
+  it('nextStation이 route 안에 없으면 cancel만 수행하고 재예약 skip', async () => {
+    // route는 destinationName='강남' direct이지만, 추적 큐에 알 수 없는 station id가 있고
+    // nextStation이 route 상 target과 매칭되지 않는 케이스 — 정정 신호 폐기.
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:없는역']);
+    const result = await rescheduleHopForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      nextStation: '없는역',
+      newArrivalMs: NOW + 600_000,
+      now: NOW,
+    });
+    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(result).toEqual({ cancelled: 1, scheduled: 0 });
+  });
+
+  it('target.stops=0이면 earlyLeadMs는 HOP_TIME_MS fallback', async () => {
+    // stops=0 direct route → travelSeconds=0 → arrival 즉시. newArrivalMs를 충분히 미래로 두면
+    // imminent(45s lead)와 early(HOP_TIME_MS fallback) 모두 미래 → 2건 schedule.
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:강남']);
+    const zeroStopsRoute = makeDirectRoute(0, '2');
+    const result = await rescheduleHopForLock({
+      lock,
+      route: zeroStopsRoute,
+      destinationName: '강남',
+      nextStation: '강남',
+      newArrivalMs: NOW + 600_000,
+      now: NOW,
+    });
+    expect(result.cancelled).toBe(1);
+    expect(mockedSchedule).toHaveBeenCalled();
+  });
+
+  it('default now는 Date.now() — newArrivalMs가 충분히 미래면 정상 동작', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:강남']);
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    try {
+      const result = await rescheduleHopForLock({
+        lock,
+        route: directRoute,
+        destinationName: '강남',
+        nextStation: '강남',
+        newArrivalMs: NOW + 600_000,
+      });
+      expect(result.cancelled).toBe(1);
+      expect(result.scheduled).toBeGreaterThan(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -431,6 +431,94 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   );
 }
 
+export interface RescheduleHopParams {
+  lock: BoardingLock;
+  route: NonNullable<Route>;
+  destinationName: string;
+  /** Backend가 보낸 정정 대상 hop의 stationName(`nextStation`). */
+  nextStation: string;
+  /** 새 도착 시각(ms epoch). 이 시점을 기준으로 phase별 leadMs를 차감해 재예약한다. */
+  newArrivalMs: number;
+  /** 과거 시각 가드 기준점 (ms epoch). 기본 Date.now(). */
+  now?: number;
+}
+
+export interface RescheduleHopResult {
+  cancelled: number;
+  scheduled: number;
+}
+
+/**
+ * Backend의 reschedule silent push(#698)를 받아 특정 hop의 사전 예약을 cancel + 재예약한다.
+ *
+ * - 매칭 대상은 `bl:${lock.trainCode}:*:*:${nextStation}` (phase 무관). nextStation 자체가
+ *   현재 추적 큐에 없으면(이미 통과/미예약) 아무 일도 하지 않는다 — 정정 신호의 graceful skip.
+ * - route + destinationName으로 hopIndex를 다시 매칭해 `scheduleSingleHop`에 `arrivalMs = newArrivalMs`로
+ *   넘긴다 — earlyLeadMs는 leg 평균 hop time(`legSeconds/legStops`)에서 산출(기존 schedule과 동일 로직).
+ * - 과거 시각으로 산출되는 phase는 scheduleSingleHop가 skip한다(`fireMs <= observedMs`).
+ *
+ * 단순 정정만 — windowSize 확장이나 sleep 룰은 본 함수의 책임이 아니다 (정상 schedule 흐름이 별도 처리).
+ */
+export async function rescheduleHopForLock(
+  params: RescheduleHopParams,
+): Promise<RescheduleHopResult> {
+  const { lock, route, destinationName, nextStation, newArrivalMs, now } = params;
+  const observedMs = now ?? Date.now();
+
+  const current = await getScheduledNotificationIds();
+  const lockPrefix = `${BOARDING_LOCK_ALARM_PREFIX}${lock.trainCode}:`;
+  const matches = current
+    .filter((id) => id.startsWith(lockPrefix))
+    .map((id) => ({ id, parsed: parseBoardingLockAlarmIdentifier(id) }))
+    .filter(
+      (x): x is { id: string; parsed: BoardingLockAlarmIdParts } =>
+        x.parsed !== null && isSameStationName(x.parsed.stationName, nextStation),
+    );
+
+  if (matches.length === 0) {
+    logger.info(
+      `reschedule no-op: no scheduled ids for trainCode=${lock.trainCode} nextStation=${nextStation}`,
+    );
+    return { cancelled: 0, scheduled: 0 };
+  }
+
+  const idsToCancel = matches.map((x) => x.id);
+  await cancelAndDismiss(idsToCancel);
+  await removeScheduledNotificationIds(idsToCancel);
+
+  // 새 arrivalMs로 재예약. hopIndex는 cancelled identifier가 알려주지만(여러 phase가 동일),
+  // earlyLeadMs는 route의 leg 정보에서 다시 산출해야 정확하다.
+  const allTargets = resolveAllTargets(route, destinationName);
+  const targetIndex = allTargets.findIndex((t) => isSameStationName(t.name, nextStation));
+  if (targetIndex === -1) {
+    // 캔슬은 했지만 route 매칭 실패 — 재예약 불가. 정정 의미상 신호 폐기. logger.info 만.
+    logger.info(
+      `reschedule cancel-only: nextStation=${nextStation} not found in route — skipped re-schedule`,
+    );
+    return { cancelled: idsToCancel.length, scheduled: 0 };
+  }
+  const target = allTargets[targetIndex];
+  const legSeconds = legSecondsAt(route, targetIndex, target.name);
+  const legMs = legSeconds * 1000;
+  const earlyLeadMs = target.stops > 0 ? legMs / target.stops : HOP_TIME_MS;
+
+  const newIds = await scheduleSingleHop({
+    lock,
+    target,
+    hopIndex: targetIndex,
+    arrivalMs: newArrivalMs,
+    earlyLeadMs,
+    observedMs,
+  });
+  if (newIds.length > 0) {
+    await addScheduledNotificationIds(newIds);
+  }
+  logger.info(
+    `reschedule done: trainCode=${lock.trainCode} nextStation=${nextStation} cancelled=${idsToCancel.length} scheduled=${newIds.length} newArrivalMs=${newArrivalMs}`,
+  );
+  return { cancelled: idsToCancel.length, scheduled: newIds.length };
+}
+
 /**
  * #708: route + destinationName이 만드는 hop 시퀀스의 구조적 signature.
  *


### PR DESCRIPTION
## Summary

backend가 보내는 `kind: 'reschedule'` silent push를 받아 해당 hop의 사전 예약을 cancel + 새 fireDate로 재예약. 그동안 정정 신호가 수신만 되고(`#725`) 실제 사전 예약 시간이 갱신되지 않아 90s/hop 고정 사전예약이 열차 지연/급행을 반영 못하던 문제 해소.

- `boardingLockScheduler.rescheduleHopForLock` 추가
  - `bl:${trainCode}:*:*:${nextStation}` 매칭 사전 예약을 cancel + dismiss
  - route + destinationName으로 hopIndex 재매칭, `earlyLeadMs = legSeconds/legStops`로 산출 (기존 schedule 로직과 동일)
  - `newArrivalMs - leadMs`로 phase별 재예약 (`fireMs <= observedMs`는 자동 skip)
- `silentPushTask.applyReschedule` 추가
  - lock + ROUTE_KEY + DESTINATION_KEY 컨텍스트를 BG에서 직접 load
  - lock null / trainCode mismatch / route·destination 부재 / 과거 epoch는 graceful no-op (원본 사전 예약 유지 — SLA 안전)
  - rescheduleHopForLock 예외는 swallow (log + ack 흐름 차단 없음)
- 기존 `logSilentPushRescheduleReceived` + `ackOutcome('fired', 'reschedule-received')` 흐름은 보존
- backend `sendReschedulePush`(#585)와 짝

Closes #698

## Test plan
- [x] lock + route + destination 모두 있으면 `rescheduleHopForLock` 호출
- [x] lock 없음 / trainCode mismatch / route 없음 / destination 없음 / 과거 epoch → 호출 skip
- [x] route·destination JSON 파싱 실패 → graceful skip
- [x] rescheduleHopForLock throw → ack/log 그대로 진행
- [x] rescheduleHopForLock: 매칭 없음 / 정상 cancel+reschedule / 과거 fireDate phase skip / route 미매칭 cancel-only / stops=0 fallback
- [x] 기존 130 silentPushTask + 48 boardingLockScheduler 회귀 없음
- [x] 두 modified 파일 100% coverage