### PR TITLE
refactor(#1012): useStationAlarm hydration state machine (H5)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -69,6 +69,7 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 const mockLogFiredAlarm = jest.fn();
 const mockLogFiredAlarmsHydrate = jest.fn();
 const mockLogFiredStationPassed = jest.fn();
+const mockLogHydrationTransition = jest.fn();
 const mockLogRefMismatch = jest.fn();
 const mockLogSuppressedDedupAlarm = jest.fn();
 const mockLogSuppressedDedupStation = jest.fn();
@@ -81,6 +82,7 @@ jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
+  logHydrationTransition: (...args: unknown[]) => mockLogHydrationTransition(...args),
   logRefMismatch: (...args: unknown[]) => mockLogRefMismatch(...args),
   logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
   logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
@@ -98,8 +100,9 @@ jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: () => mockGetBoardingLock(),
 }));
 
+const mockAwaitInitialScheduledAlarmDrain = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/scheduledAlarmReceiver', () => ({
-  awaitInitialScheduledAlarmDrain: jest.fn().mockResolvedValue(undefined),
+  awaitInitialScheduledAlarmDrain: () => mockAwaitInitialScheduledAlarmDrain(),
 }));
 
 const mockIsImminentByArrivalCode = jest.fn();
@@ -170,6 +173,7 @@ describe('useStationAlarm', () => {
     mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
     mockGetBoardingLock.mockResolvedValue(null);
     mockFindFgArvlCdFireSignal.mockReturnValue(null);
+    mockAwaitInitialScheduledAlarmDrain.mockResolvedValue(undefined);
   });
 
   it('does not evaluate when route is null', () => {
@@ -2715,6 +2719,159 @@ describe('useStationAlarm', () => {
 
       const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
       expect(arvlCdFires).toHaveLength(0);
+    });
+  });
+
+  // #1012 (H5) — hydration state machine: pre-hydrate → hydrating → storage-synced → ready.
+  // 'ready' 도달 전 phase 알람 발사가 보류되는지, transition이 alarmLog로 측정되는지 검증.
+  describe('#1012 hydration state machine (H5)', () => {
+    it('4 phase transition이 순서대로 logHydrationTransition으로 적재된다', async () => {
+      const route = makeDirectRoute(1, '2');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      // 'ready' 도달까지 대기 — hydration 완료 후에만 사이클이 끝난다.
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+
+      const phases = mockLogHydrationTransition.mock.calls.map((c) => c[0]);
+      expect(phases).toEqual(['pre-hydrate', 'hydrating', 'storage-synced', 'ready']);
+      // 모든 transition은 같은 destinationId로 묶인다.
+      for (const call of mockLogHydrationTransition.mock.calls) {
+        expect(call[1]).toBe(destination.id);
+      }
+    });
+
+    it("'ready' 도달 전(drain pending)에는 phase 알람 발사 보류", async () => {
+      // drain을 영원히 pending → storage-synced에 도달 못함 → 'ready' 도달 못함.
+      mockAwaitInitialScheduledAlarmDrain.mockReturnValueOnce(new Promise(() => {}));
+      const route = makeDirectRoute(1, '2');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      // pre-hydrate / hydrating까지만 sync 적재 — storage-synced/ready 없음.
+      await Promise.resolve();
+      await Promise.resolve();
+      const phases = mockLogHydrationTransition.mock.calls.map((c) => c[0]);
+      expect(phases).toContain('pre-hydrate');
+      expect(phases).toContain('hydrating');
+      expect(phases).not.toContain('storage-synced');
+      expect(phases).not.toContain('ready');
+      // 'ready' 미도달 → phase 알람 보류.
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it("'ready' 도달 후에만 phase 알람 발사 허용", async () => {
+      const route = makeDirectRoute(1, '2');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      // 'ready' 도달 후 발사.
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      const phases = mockLogHydrationTransition.mock.calls.map((c) => c[0]);
+      expect(phases[phases.length - 1]).toBe('ready');
+    });
+
+    it("destination 전환 시 state machine 재시작 (새 destinationId로 4 phase 재적재)", async () => {
+      const route = makeDirectRoute(1, '2');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      const { rerender } = renderHook(
+        ({ dest }: { dest: Station }) =>
+          useStationAlarm(defaultInputs({ route, destination: dest })),
+        { initialProps: { dest: destination } },
+      );
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalledWith(destination.id));
+
+      mockLogHydrationTransition.mockClear();
+      rerender({ dest: altDestination });
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalledWith(altDestination.id));
+      const phases = mockLogHydrationTransition.mock.calls.map((c) => c[0]);
+      expect(phases).toEqual(['pre-hydrate', 'hydrating', 'storage-synced', 'ready']);
+      for (const call of mockLogHydrationTransition.mock.calls) {
+        expect(call[1]).toBe(altDestination.id);
+      }
+    });
+
+    it('drain 완료 후 destination 전환 → getFiredAlarms resolve 시 cancelled로 ready 미적재', async () => {
+      const route = makeDirectRoute(1, '2');
+      // 첫 destination: getFiredAlarms를 controllable promise로 보류.
+      let resolveFired = (_s: Set<string>): void => {};
+      mockGetFiredAlarms.mockReturnValueOnce(
+        new Promise<Set<string>>((resolve) => {
+          resolveFired = resolve;
+        }),
+      );
+
+      const { rerender } = renderHook(
+        ({ dest }: { dest: Station }) =>
+          useStationAlarm(defaultInputs({ route, destination: dest })),
+        { initialProps: { dest: destination } },
+      );
+      // drain 통과 → storage-synced 적재까지 진행.
+      await waitFor(() =>
+        expect(
+          mockLogHydrationTransition.mock.calls.some((c) => c[0] === 'storage-synced'),
+        ).toBe(true),
+      );
+
+      // destination 교체 → 첫 effect cleanup → cancelled=true.
+      rerender({ dest: altDestination });
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalledWith(altDestination.id));
+
+      mockLogHydrationTransition.mockClear();
+      // 첫 effect의 getFiredAlarms 뒤늦게 resolve → cancelled 가드로 ready 적재 안 됨.
+      resolveFired(new Set<string>());
+      await Promise.resolve();
+      await Promise.resolve();
+      const phasesAfterStale = mockLogHydrationTransition.mock.calls.map((c) => c[0]);
+      expect(phasesAfterStale).not.toContain('ready');
+    });
+
+    it('destination 전환으로 effect cleanup → drain 완료 후 setState 호출되지 않음 (cancelled gate)', async () => {
+      const route = makeDirectRoute(1, '2');
+      // drain을 controllable promise로 보류.
+      let resolveDrain = (): void => {};
+      mockAwaitInitialScheduledAlarmDrain.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveDrain = () => resolve();
+        }),
+      );
+
+      const { rerender, unmount } = renderHook(
+        ({ dest }: { dest: Station }) =>
+          useStationAlarm(defaultInputs({ route, destination: dest })),
+        { initialProps: { dest: destination } },
+      );
+
+      // 첫 destination 효과는 pre-hydrate + hydrating까지만 적재.
+      await Promise.resolve();
+      // destination 교체 → 첫 effect cleanup, 두 번째 effect는 즉시 drain resolve된 default mock 사용.
+      rerender({ dest: altDestination });
+      // 두 번째 effect는 정상 사이클 완료.
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalledWith(altDestination.id));
+
+      mockLogHydrationTransition.mockClear();
+      // 첫 effect의 drain promise 뒤늦게 resolve → cancelled 가드로 storage-synced/ready 적재 안 됨.
+      resolveDrain();
+      await Promise.resolve();
+      await Promise.resolve();
+      const phasesAfterStaleResolve = mockLogHydrationTransition.mock.calls.map((c) => c[0]);
+      expect(phasesAfterStaleResolve).not.toContain('storage-synced');
+      expect(phasesAfterStaleResolve).not.toContain('ready');
+      unmount();
     });
   });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -31,6 +31,7 @@ import {
   logFiredAlarm,
   logFiredAlarmsHydrate,
   logFiredStationPassed,
+  logHydrationTransition,
   logRefMismatch,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
@@ -39,6 +40,7 @@ import {
   logSuppressedPhaseGate,
   logSuppressedSleepFirstTransfer,
   logSuppressedStationPassedWarmup,
+  type HydrationPhase,
 } from '../utils/alarmLog';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { getBoardingLock } from '../utils/boardingLockStorage';
@@ -260,8 +262,8 @@ export function useStationAlarm({
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   // #699: firedAlarmsRef의 내용이 어느 destinationId에 속하는지 추적.
-  // destination 변경 직후엔 hydrate effect가 setFiredHydrated(false)를 호출하지만,
-  // 같은 render cycle의 ETA/API effect는 React state 전파 전이라 firedHydrated=true(stale)
+  // destination 변경 직후엔 hydrate effect가 hydrationPhase를 'pre-hydrate'로 리셋하지만,
+  // 같은 render cycle의 ETA/API effect는 React state 전파 전이라 hydrationPhase='ready'(stale)
   // 클로저로 진입한다. ref id가 현재 destinationId와 다르면 stale state — phase 평가를 보류해
   // 옛 ref로 새 destination에 잘못된 알람을 발사하는 race를 차단한다.
   const firedAlarmsRefDestIdRef = useRef<string | null>(null);
@@ -274,9 +276,16 @@ export function useStationAlarm({
   // warmup window 동안 station-passed effect가 즉시 차단된다.
   const stationPassedHydratedAtRef = useRef<number | null>(null);
   // firedAlarms hydration: BG가 AsyncStorage(FIRED_ALARMS_KEY)에 쓴 dedup 상태를
-  // destination별로 격리해 복원한다(#462). hydrated=false인 동안 phase 평가를 보류해
-  // 빈 ref로 false re-fire가 발생하지 않도록 가드한다.
-  const [firedHydrated, setFiredHydrated] = useState(false);
+  // destination별로 격리해 복원한다(#462).
+  //
+  // #1012 (H5) — 명시적 state machine:
+  //   'pre-hydrate'    : 초기/destination 전환 직후. 모든 phase 평가 보류.
+  //   'hydrating'      : effect entry. drain 대기 중. 보류.
+  //   'storage-synced' : awaitInitialScheduledAlarmDrain 완료. getFiredAlarms 직전. 보류.
+  //   'ready'          : firedAlarmsRef + refDestId 셋업 완료. phase 평가 허용.
+  // hydration race(lock hydrate / storage sync / fired ref 사이) 차단을 위해 각 transition을
+  // 명시화 + alarmLog로 측정 — DebugModal Gates 섹션에서 자동 카운트.
+  const [hydrationPhase, setHydrationPhase] = useState<HydrationPhase>('pre-hydrate');
   const destinationId = destination?.id ?? null;
   // #396: 목적지 역의 도착정보를 별도로 폴링. arrivalCode가 ENTERING/ARRIVED가 되는 순간
   // imminent 신호로 사용. useArrivalInfo는 모듈 스코프 TtlCache를 공유해 추가 호출 비용이 적다.
@@ -334,11 +343,20 @@ export function useStationAlarm({
   useEffect(() => {
     let cancelled = false;
     stationPassedHydratedAtRef.current = null;
-    setFiredHydrated(false);
+    // #1012 (H5) — Phase 1: pre-hydrate 리셋. destination 전환마다 state machine 재시작.
+    setHydrationPhase('pre-hydrate');
+    logHydrationTransition('pre-hydrate', destinationId);
+    // #1012 (H5) — Phase 2: hydrating. effect entry 직후 sync 표기 — drain await 진입 전.
+    setHydrationPhase('hydrating');
+    logHydrationTransition('hydrating', destinationId);
     void (async () => {
       // 사전 예약 알람의 첫 drain이 완료된 후 read해야 cold start 직후
       // BG-fired 알람이 dedup set에 반영된 상태로 hydrate된다.
       await awaitInitialScheduledAlarmDrain();
+      if (cancelled) return;
+      // #1012 (H5) — Phase 3: storage-synced. drain 완료 + getFiredAlarms 직전.
+      setHydrationPhase('storage-synced');
+      logHydrationTransition('storage-synced', destinationId);
       const stored = await getFiredAlarms(destinationId);
       if (cancelled) return;
       firedAlarmsRef.current = stored;
@@ -347,7 +365,9 @@ export function useStationAlarm({
       logFiredAlarmsHydrate(destinationId, stored.size);
       // #1010: station-passed warmup 시작 — 하이드레이션 완료 시각 기록.
       stationPassedHydratedAtRef.current = Date.now();
-      setFiredHydrated(true);
+      // #1012 (H5) — Phase 4: ready. ref 셋업 + warmup 시각 기록 완료 후 phase 평가 허용.
+      setHydrationPhase('ready');
+      logHydrationTransition('ready', destinationId);
     })();
     return () => {
       cancelled = true;
@@ -433,11 +453,11 @@ export function useStationAlarm({
   }
 
   // Phase 알람 효과: ETA 기반 phase 평가 + firedAlarms 갱신.
-  // firedHydrated=false인 동안에는 보류 — BG가 이미 발화한 phase를 빈 ref로 재발화하는 것을 막는다.
+  // hydrationPhase!=='ready'인 동안에는 보류 — BG가 이미 발화한 phase를 빈 ref로 재발화하는 것을 막는다.
   // station-passed와 분리: 하이드레이션 완료로 인한 effect 재실행이 station-passed 중복 발사를
   // 일으키지 않도록 한다(station-passed는 자체 lastNotifiedStationId dedup만 사용).
   useEffect(() => {
-    if (!firedHydrated) return;
+    if (hydrationPhase !== 'ready') return;
 
     if (!route || !destination) return;
 
@@ -549,7 +569,7 @@ export function useStationAlarm({
     userLocation?.lng,
     speedMps,
     accuracyMeters,
-    firedHydrated,
+    hydrationPhase,
     setAlarmEvent,
     nearestStation?.id,
     nearestStation?.line,
@@ -573,7 +593,7 @@ export function useStationAlarm({
   // adoption → 그 trainCode가 목적지역 도착하면 ENTERED → 알람 발사). evaluateMovement로
   // 정적/저신호 거부.
   useEffect(() => {
-    if (!firedHydrated) return;
+    if (hydrationPhase !== 'ready') return;
     if (!route || !destination) return;
     // #699: ETA effect와 동일 guard — destination 전환 race로 stale ref가 imminent를
     // 잘못 발사하는 것을 차단한다.
@@ -632,7 +652,7 @@ export function useStationAlarm({
     // 재발사하지 않도록 storage가 sync된 후 다음 cycle 진입.
     void fireAndLog(rawEvent, 'api', route, destination);
   }, [
-    firedHydrated,
+    hydrationPhase,
     route,
     destination?.id,
     destination?.name,
@@ -655,7 +675,7 @@ export function useStationAlarm({
   // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.
   // dedup은 AsyncStorage(lastNotifiedStationId)를 단일 출처로 사용 — Foreground/Background
   // 양쪽에서 동일하게 적용된다.
-  // #1010: firedHydrated 가드 + 30s warmup — lock hydrate 직후 GPS가 stabilize되기 전
+  // #1010: hydrationPhase 가드 + 30s warmup — lock hydrate 직후 GPS가 stabilize되기 전
   // false alarm이 발사되는 회귀를 차단한다.
   // #452: deps에 raw accuracyMeters를 두면 GPS 노이즈로 매 fix 재실행 → dedup-suppressed
   // 로그가 cap까지 차서 다른 진단을 밀어낸다. 게이트 통과 여부(boolean)만 dep로 둔다.
@@ -687,7 +707,7 @@ export function useStationAlarm({
     if (!route || !destination) return;
 
     // #1010: firedAlarms 복원 완료 전에는 발사 보류.
-    if (!firedHydrated) return;
+    if (hydrationPhase !== 'ready') return;
     // #1010: hydration 완료 후 30s warmup window 동안 발사 보류.
     if (!skipWarmupGuard) {
       const hydratedAt = stationPassedHydratedAtRef.current;
@@ -748,7 +768,7 @@ export function useStationAlarm({
     destination?.id,
     destination?.name,
     nearestStation?.id,
-    firedHydrated,
+    hydrationPhase,
     accuracyOk,
     arrivalConfirmed,
     movementSuppressionReason,
@@ -766,7 +786,7 @@ export function useStationAlarm({
   // Seoul `realtimeArrivalList`.
   //
   // 가드 (AND, 하나라도 false면 no-op):
-  //   1. firedHydrated — destination별 firedAlarms 복원 완료 후
+  //   1. hydrationPhase==='ready' — destination별 firedAlarms 복원 완료 후
   //   2. route + destination + nearestStation 존재 (nearest 없으면 fire 대상 station 결정 불가)
   //   3. firedAlarmsRef destinationId 일치 (#699 race 가드)
   //   4. nearestStation이 route 상에 있음 (off-route 신호 무시)
@@ -779,7 +799,7 @@ export function useStationAlarm({
   // GPS 경로/Fast path 어느 쪽이 먼저 발사해도 다른 쪽은 자동 dedup. 이슈가 명시한
   // `(trainCode, station, arvlCd)` granularity는 station-level dedup의 superset이라 충족된다.
   useEffect(() => {
-    if (!firedHydrated) return;
+    if (hydrationPhase !== 'ready') return;
     if (!route || !destination) return;
     if (!nearestStation) return;
     // #580 M4: mismatch stamp.
@@ -839,7 +859,7 @@ export function useStationAlarm({
       cancelled = true;
     };
   }, [
-    firedHydrated,
+    hydrationPhase,
     route,
     destination?.id,
     destination?.name,

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -41,6 +41,7 @@ import {
   logSilentPushSkipped,
   logAlertFallbackFired,
   summarizeAlarmLogByReason,
+  logHydrationTransition,
   logSuppressedStationPassedWarmup,
   summarizeAlarmLogBySource,
   countSilentPushOutcomes,
@@ -620,6 +621,45 @@ describe('alarmLog', () => {
         kind: 'station-passed',
       });
       expect(saved[0].stationName).toBeUndefined();
+    });
+
+    it('#1012 logHydrationTransition: 4 phase 각각 hydration-* reason + fg-hydrate source로 적재', async () => {
+      logHydrationTransition('pre-hydrate', 'D1');
+      logHydrationTransition('hydrating', 'D1');
+      logHydrationTransition('storage-synced', 'D1');
+      logHydrationTransition('ready', 'D1');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved).toHaveLength(4);
+      expect(saved.map((e) => e.reason)).toEqual([
+        'hydration-pre-hydrate',
+        'hydration-hydrating',
+        'hydration-storage-synced',
+        'hydration-ready',
+      ]);
+      for (const entry of saved) {
+        expect(entry).toMatchObject({
+          source: 'fg-hydrate',
+          outcome: 'received',
+          destinationId: 'D1',
+        });
+      }
+    });
+
+    it('#1012 logHydrationTransition: destinationId=null 허용', async () => {
+      logHydrationTransition('pre-hydrate', null);
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg-hydrate',
+        outcome: 'received',
+        reason: 'hydration-pre-hydrate',
+        destinationId: null,
+      });
     });
 
     it('#626 같은 키 윈도우 내 재호출은 drop (FG polling 매초 평가 스팸 차단)', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -97,7 +97,15 @@ export type AlarmLogReason =
   | 'gate-phase-accuracy'
   | 'gate-phase-warmup'
   // #1010 — station-passed effect가 lock hydrate 직후 30s warmup window 동안 차단된 발사.
-  | 'gate-station-passed-warmup';
+  | 'gate-station-passed-warmup'
+  // #1012 (H5) — useStationAlarm hydration state machine 각 phase 진입 stamp.
+  // pre-hydrate → hydrating → storage-synced → ready 4단계. 'ready' 전 phase에서는
+  // 모든 phase 알람 발사가 보류된다. transition 한 번에 1엔트리 적재 — 운영에서 phase
+  // 도달 시점·체류 시간 분포 측정.
+  | 'hydration-pre-hydrate'
+  | 'hydration-hydrating'
+  | 'hydration-storage-synced'
+  | 'hydration-ready';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -738,6 +746,37 @@ export function logSuppressedStationPassedWarmup(stationName: string | undefined
     reason: 'gate-station-passed-warmup',
     stationName,
     kind: 'station-passed',
+  });
+}
+
+/**
+ * #1012 (H5) — useStationAlarm hydration state machine transition 1건 적재.
+ *
+ * pre-hydrate → hydrating → storage-synced → ready 4단계 중 진입 직후 호출.
+ * destinationId는 같은 trip 내 transition 묶음을 그루핑하기 위한 컨텍스트.
+ * source는 'fg-hydrate' 재사용 — 기존 hydrate 측정과 동일 소스에서 phase별 reason으로 구분.
+ *
+ * outcome='received'는 정책적으로 "관찰 신호" 의미 (적재만 하고 발사·억제 없음).
+ */
+export type HydrationPhase = 'pre-hydrate' | 'hydrating' | 'storage-synced' | 'ready';
+
+const HYDRATION_PHASE_REASON: Record<HydrationPhase, AlarmLogReason> = {
+  'pre-hydrate': 'hydration-pre-hydrate',
+  hydrating: 'hydration-hydrating',
+  'storage-synced': 'hydration-storage-synced',
+  ready: 'hydration-ready',
+};
+
+export function logHydrationTransition(
+  phase: HydrationPhase,
+  destinationId: string | null,
+): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'fg-hydrate',
+    outcome: 'received',
+    reason: HYDRATION_PHASE_REASON[phase],
+    destinationId,
   });
 }
 


### PR DESCRIPTION
## Summary

Epic A — hydration race 차단을 위한 명시적 state machine 도입.

- `HydrationPhase` type: pre-hydrate → hydrating → storage-synced → ready
- 'ready' 도달 전까지 4개 effect(phase ETA / API imminent / station-passed / fg arvlCd fast-path) 모두 발사 보류
- 각 transition `logHydrationTransition`으로 alarmLog 적재 — 새 reason 4개(`hydration-pre-hydrate`/`hydration-hydrating`/`hydration-storage-synced`/`hydration-ready`)
- 기존 `firedHydrated` boolean을 `hydrationPhase` state로 대체 (gate check 통일)
- DebugModal Gates 섹션 자동 카운트 (`summarizeAlarmLogByReason`이 reason 추가에 자동 cascade)
- #1010 `stationPassedHydratedAtRef` 및 30s warmup 가드 보존

Pipeline A 2단 (PR #1140 머지 완료 후속).

Closes #1012

## Test plan
- [x] 기존 useStationAlarm 131개 테스트 통과
- [x] state machine transition 순서 검증 (pre-hydrate → hydrating → storage-synced → ready)
- [x] 'ready' 전(drain pending) phase 알람 보류 검증
- [x] destination 전환 시 state machine 재시작 검증
- [x] cancelled gate 검증 (drain/getFiredAlarms 양쪽)
- [x] alarmLog helper 단위 테스트 (4 phase + destinationId=null)
- [x] 100% coverage (useStationAlarm.ts / alarmLog.ts)
- [x] npm run type-check pass