### PR TITLE
fix(#773): trip release 시점 OS 예약 큐 cleanup — #918 선행

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
 import { TRIP_BOUND_CLEANUPS, runTripBoundCleanups } from '../tripBoundCleanups';
 import {
   DESTINATION_KEY,
@@ -8,15 +9,21 @@ import {
   TRIP_STARTED_AT_KEY,
   LAST_UPLOADED_RECALL_TRIP_START_KEY,
   LA_DISMISSED_AT_KEY,
+  SCHEDULED_NOTIFICATIONS_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );
+jest.mock('expo-notifications');
 
 describe('tripBoundCleanups', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // expo-notifications auto-mock의 cancel/dismiss implementation을 명시 초기화 — 다른 테스트의
+    // mockRejectedValue가 leak되어 다음 테스트의 cancel을 reject하지 않도록.
+    (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockReset();
+    (Notifications.dismissNotificationAsync as jest.Mock).mockReset();
   });
 
   it('TRIP_BOUND_CLEANUPS는 비어있지 않다 (메타 배열 self-check)', () => {
@@ -43,6 +50,33 @@ describe('tripBoundCleanups', () => {
     // LA 재상승 허용. 누락 회귀가 발생하면 dismiss 후 새 trip 시작해도 LA가 살아나지 않음.
     expect(removedKeys).toContain(LA_DISMISSED_AT_KEY);
     expect(removedKeys).not.toContain(LAST_UPLOADED_RECALL_TRIP_START_KEY);
+  });
+
+  it('#773 — runTripBoundCleanups 실행 시 OS 사전 예약 큐를 cancel + storage clear한다 (옛 trip 알람 burst 차단)', async () => {
+    // trip release 시점에 추적 큐의 모든 `bl:` 사전 예약을 OS에서 cancel해야 한다.
+    // storage만 비우면 iOS 사전 예약은 살아남아 새 trip 시작 후 옛 알람이 burst로 발사된다.
+    const scheduledIds = ['bl:T-100:0:early:강남', 'bl:T-100:0:imminent:강남'];
+    await AsyncStorage.setItem(SCHEDULED_NOTIFICATIONS_KEY, JSON.stringify(scheduledIds));
+    const mockedCancel = Notifications.cancelScheduledNotificationAsync as jest.Mock;
+    mockedCancel.mockResolvedValue(undefined);
+    (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+
+    await runTripBoundCleanups();
+
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:imminent:강남');
+  });
+
+  it('#773 — OS cancel이 reject해도 runTripBoundCleanups는 graceful 종료 (이미 발사된 알람 등)', async () => {
+    // 이미 발사된 알람을 cancel 시 expo가 reject할 수 있다 — 나머지 cleanup에 전파되면 안 됨.
+    await AsyncStorage.setItem(
+      SCHEDULED_NOTIFICATIONS_KEY,
+      JSON.stringify(['bl:T-100:0:early:강남']),
+    );
+    (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockRejectedValue(
+      new Error('already fired'),
+    );
+    await expect(runTripBoundCleanups()).resolves.toBeUndefined();
   });
 
   it('TRIP_BOUND_CLEANUPS의 모든 항목은 호출 가능하며 Promise를 반환하고 reject하지 않는다', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -12,7 +12,6 @@ import {
   DESTINATION_KEY,
   CUSTOM_ORIGIN_KEY,
   BOARDING_LOCK_KEY,
-  SCHEDULED_NOTIFICATIONS_KEY,
   ACTIVE_TRIP_KEY,
   TRIP_ORIGIN_KEY,
   ALARM_EVENT_KEY,
@@ -29,6 +28,7 @@ import { clearTripTrainCode } from '../../route/utils/tripTrainCode';
 import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dismissSilenceStorage';
 import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
 import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
+import { purgeBoardingLockSchedulerQueue } from '../utils/boardingLockScheduler';
 
 // trip-bound storage cleanup 단일 출처.
 // useDestinationStore.setDestination이 isSwitch(목적지 변경 또는 null 클리어) 분기에서 호출한다.
@@ -52,7 +52,12 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   () => AsyncStorage.removeItem(DESTINATION_KEY),
   () => AsyncStorage.removeItem(CUSTOM_ORIGIN_KEY),
   () => AsyncStorage.removeItem(BOARDING_LOCK_KEY),
-  () => AsyncStorage.removeItem(SCHEDULED_NOTIFICATIONS_KEY),
+  // #773 — trip release 시점에 SCHEDULED_NOTIFICATIONS_KEY storage만 비우면 OS 사전 예약은
+  // 그대로 큐에 남아 새 trip 시작 후 옛 알람이 burst로 발사된다 (#918 A3 일반화의 선행 조건).
+  // purgeBoardingLockSchedulerQueue는 `bl:` prefix id를 모두 Notifications.cancelScheduledNotificationAsync
+  // + dismiss 처리한 뒤 storage 큐를 clear한다 — OS 큐 한도(64) 도달과 정정 신호 없는 옛 알람
+  // 발사 burst를 동시에 차단한다.
+  purgeBoardingLockSchedulerQueue,
   () => AsyncStorage.removeItem(ACTIVE_TRIP_KEY),
   () => AsyncStorage.removeItem(TRIP_ORIGIN_KEY),
   clearLastNotifiedStationId,

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -314,11 +314,13 @@ describe('cancelAllHopsForLock', () => {
 });
 
 describe('purgeBoardingLockSchedulerQueue', () => {
-  it('큐가 비어있으면 no-op', async () => {
+  it('큐가 비어있으면 cancel은 호출하지 않고 storage clear는 멱등으로 항상 수행한다 (#773)', async () => {
     mockedGet.mockResolvedValueOnce([]);
     await purgeBoardingLockSchedulerQueue();
     expect(mockedCancel).not.toHaveBeenCalled();
-    expect(mockedClear).not.toHaveBeenCalled();
+    // #773: TRIP_BOUND_CLEANUPS가 SCHEDULED_NOTIFICATIONS_KEY removal을 본 함수에 위임하므로
+    // empty case에서도 storage key 정리는 보장되어야 한다.
+    expect(mockedClear).toHaveBeenCalled();
   });
 
   it('bl: prefix만 cancel하고 큐 전체 clear', async () => {

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -319,9 +319,13 @@ export async function cancelAllHopsForLock(lock: BoardingLock): Promise<void> {
  */
 export async function purgeBoardingLockSchedulerQueue(): Promise<void> {
   const current = await getScheduledNotificationIds();
-  if (current.length === 0) return;
   const ours = current.filter((id) => id.startsWith(BOARDING_LOCK_ALARM_PREFIX));
-  await cancelAndDismiss(ours);
+  if (ours.length > 0) {
+    await cancelAndDismiss(ours);
+  }
+  // #773: 큐가 비어있어도 storage key는 항상 정리한다. trip release cleanup 호출자
+  // (TRIP_BOUND_CLEANUPS)가 SCHEDULED_NOTIFICATIONS_KEY removal을 본 함수로 위임하므로,
+  // empty case에서도 key가 존재할 수 있다(legacy 잔여 등) — 멱등 보장.
   await clearScheduledNotificationIds();
 }
 

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -151,8 +151,9 @@ describe('useDestinationStore', () => {
   async function flushMicrotasks(): Promise<void> {
     // #919 — setDestination이 triggerTripEndRecall → runTripBoundCleanups → setTripStartedAt
     // 세 단계 then-chain을 돌리는데 cleanup 안에서 Promise.allSettled가 추가 microtask를 만든다.
-    // 충분히 넉넉하게 flush.
-    for (let i = 0; i < 10; i++) {
+    // #773 — purgeBoardingLockSchedulerQueue가 getScheduledNotificationIds + clearScheduledNotificationIds
+    // (각각 AsyncStorage await 2회 포함)를 추가하므로 microtask depth가 더 깊다. 넉넉하게 flush.
+    for (let i = 0; i < 30; i++) {
       await Promise.resolve();
     }
   }


### PR DESCRIPTION
Closes #773

## Summary

trip release(setDestination switch/null) 시점에 `SCHEDULED_NOTIFICATIONS_KEY` storage만 비우고 OS 사전 예약은 cancel하지 않는 회귀 수정.

- iOS 64개 사전 예약 큐 한도 도달 + 새 trip 시작 후 옛 trip의 알람 burst를 차단.
- `#918`(A3 OS-level 사전 예약 매역 일반화)의 **선행 필수** 조건.

SSOT 참조: `tasks/epic-lockless-overfire-guard.md` §6.

## Changes

- `src/features/alarm/store/tripBoundCleanups.ts`
  - `() => AsyncStorage.removeItem(SCHEDULED_NOTIFICATIONS_KEY)` 항목을 `purgeBoardingLockSchedulerQueue`로 교체.
  - 추적 큐의 모든 `bl:` 사전 예약을 `Notifications.cancelScheduledNotificationAsync` + `dismissNotificationAsync`로 처리한 뒤 storage key 정리.
- `src/features/alarm/utils/boardingLockScheduler.ts`
  - `purgeBoardingLockSchedulerQueue`를 멱등으로 변경: 큐가 비어있어도 storage key는 항상 clear (legacy 잔여 회귀 방어).
- Tests
  - `tripBoundCleanups.test.ts`: OS cancel 호출 + cancel reject graceful 검증.
  - `boardingLockScheduler.test.ts`: empty queue case에서도 clear 호출 검증.
  - `useDestinationStore.test.ts`: flushMicrotasks depth를 purge의 추가 await에 맞춰 확장.

## Test plan
- [x] `npm test` — 신규 추가 테스트 8/8 + 기존 회귀 없음. 실패 3 suites는 pre-existing (dev에서도 fail).
- [x] `npm run type-check` 통과.
- [ ] 실기기: trip release 후 새 trip 시작 시 옛 알람 burst 없는지 회귀 확인.