### PR TITLE
docs(#1008): ADR-013 신설 + ADR-010 C 흐름 의미 재정의 (B1 확정, PR-α)

### DIFF
--- a/docs/decisions/ADR-010-sensor-fusion-policy.md
+++ b/docs/decisions/ADR-010-sensor-fusion-policy.md
@@ -2,7 +2,7 @@
 
 ## 상태
 
-Accepted (2026-06-03)
+Accepted (2026-06-03) · Amended 2026-06-11 (ADR-013 보완)
 
 관련 이슈: #816 (D 방향 epic), #817 (Phase 2 map matching), #819 (B 슬라이스 — 탑승 푸시)
 관련 PR (머지): #820/#816(C 슬라이스), #821/#817(Phase 2), #822/#819(B 슬라이스)
@@ -35,15 +35,23 @@ GPS-only로는 정확도 마지노선이 두 가지 면에서 깨졌다:
 
 핵심 — 사용자에게 **"몇 호선 탔어?"가 아니라 "탔어?" 하나만 묻는다.** trainCode 선택은 arvlCd 신호로 백엔드가 결정.
 
-### C 흐름 — Lockless station-passed (opt-in 토글)
+### C 흐름 — 전체역 보기 (정보용 토글) + lock cleanup 트리거
+
+> **Amended 2026-06-11 (B1 확정, ADR-013 통합):**
+> 토글의 의미를 "lockless trip 자동 보완"이 아닌 **"전체역 보기 (정보 표시용)"** 으로 재정의한다.
+> lockless trip의 실제 보완 경로는 §B 흐름(boardingPrompt). 본 토글은 사용자가 명시적으로
+> "모든 역을 보겠다"고 선택한 정보 모드이며, lock과 직교한다.
 
 | 결정 | 값 | 근거 |
 |---|---|---|
 | 기본 상태 | OFF | #640 회귀(잘못된 알림) 차단 — 사용자 동의 영역 |
 | 활성 조건 | `locklessStationPassed=true` AND trip route 존재 | trip route 없으면 zero — zero trip = zero push |
+| 토글 OFF 동작 | **활성 BoardingLock 즉시 cleanup (`tripBoundCleanups` 활용)** | "전체역 보기" 모드 해제 시 lock도 정리 — 정보 표시 모드 일관성 |
 | 저장소 | AsyncStorage `LOCKLESS_STATION_PASSED_KEY` | `src/constants/storageKeys.ts:58` |
 | 백엔드 동기화 | trip register payload에 `locklessStationPassed` 필드 | `backend/alarm-worker/src/types.ts` `Trip.locklessStationPassed` |
 | 발사 게이트 | scheduled.ts lockless 분기 | `backend/alarm-worker/src/scheduled.ts` |
+
+**Lockless trip 보완은 §B (boardingPrompt)가 1순위 경로** — 본 토글은 사용자 명시 의향의 정보 모드. 통합 우선순위는 ADR-013 §결정 참조.
 
 ### False positive 9단 AND 게이트 (B 흐름의 핵심)
 
@@ -140,6 +148,7 @@ B 흐름이 안정화되면 환승 시 next-leg에도 같은 prompt를 자동 �
 2. **A 옵션 환승 자동 prompt 도입 여부** — 위 측정 결과로 결정. false positive ≤ 5% AND 탭률 ≥ 70%면 A+C 권장.
 3. **Phase 4 Particle filter** — Phase 3 dead zone drift 측정 후 정확도 부족 시만. 현시점 보류.
 4. **`project_item6_d_direction_design` 메모 SSOT 통합** — 본 ADR이 SSOT 정착 후 메모는 "ADR-010 참조"로 슬림화.
+5. **ADR-013 — lockless 보완 정책 통합** — B+C 통합 우선순위 SSOT (2026-06-11 B1 확정). 본 ADR §B/§C 의미 재정의 반영.
 
 ## References
 

--- a/docs/decisions/ADR-013-lockless-supplementation-policy.md
+++ b/docs/decisions/ADR-013-lockless-supplementation-policy.md
@@ -1,0 +1,73 @@
+# ADR-013: Lockless 보완 정책 (B+C 통합)
+
+## 상태
+
+Accepted (2026-06-11)
+
+관련 ADR: ADR-010 (sensor fusion policy)
+관련 epic: #1008
+
+> **번호 메모**: 본 ADR은 작성 요청 시점에 "ADR-011"로 지칭됐으나, ADR-011(boarding-prompt context wireup)과 ADR-012(alarm dedup idempotency key)가 이미 점유 중이라 다음 가용 번호 ADR-013으로 정착. 의도(B1 결정 SSOT)는 동일.
+
+## 배경
+
+ADR-010이 B 흐름(boardingPrompt 자동 push)과 C 흐름(전체역 보기 토글)을 정의했으나, 두 흐름은 독립 결정이었고 lockless trip(사용자가 trip을 시작했으나 BoardingLock을 생성하지 않은 상태)의 보완 경로 정합성이 부재했다.
+
+- B 흐름은 9단 AND 게이트 통과 시에만 자동 prompt 발사 → 게이트 미통과 trip은 침묵
+- C 흐름은 사용자 명시 opt-in 정보 토글 → OFF 사용자는 lockless 사각지대 그대로
+- 두 흐름의 우선순위와 충돌 정책이 명시 안 됨 → 동시 발사 / cleanup 누락 위험
+
+2026-06-11 사용자 B1 결정으로 두 흐름의 통합 정책을 본 ADR이 SSOT로 정착한다.
+
+## 결정
+
+### 1. lockless 정의
+
+`lockless` = **trip 활성(`trip.status === 'active'`) AND BoardingLock 미생성(`boardingLock === null`)** 상태.
+
+trip 시작 직후·열차 미선택·lock cleanup 직후 모두 동일 상태로 취급.
+
+### 2. 보완 경로 우선순위
+
+| 순위 | 경로 | 진입 | 결과 |
+|---|---|---|---|
+| 1 | **B 흐름 — boardingPrompt push** | 9단 AND 게이트 통과 (ADR-010 §B 표) | [탑승] 응답 → arvlCd 우선순위로 autoLock → 매역 알림 SLA 진입 |
+| 2 | **사용자 manual lock** | BoardingTrainList 직접 탭 (B4 결정 — 낙관적 UI) | 즉시 lock 생성 → 매역 알림 SLA 진입 |
+| 3 | **C 토글 정보 표시** | `locklessStationPassed=true` AND lockless 유지 | lockless station-passed 푸시 (사용자 명시 의향) |
+
+순위 1 → 2 → 3 순서로 동작. 순위 1이 발사되면 사용자 응답으로 lock 생성 → lockless 종료 → 순위 3 자연 비활성화.
+
+### 3. 토글 OFF 시 cleanup 트리거
+
+C 토글을 OFF로 전환할 때 활성 BoardingLock이 있으면 **즉시 cleanup** (`tripBoundCleanups` 활용).
+
+근거: 토글의 의미가 "전체역 보기 (정보 표시용)"로 재정의됐으므로(ADR-010 §C amended), OFF = "정보 표시 모드 종료" = lock 정리. 토글 ON/OFF가 lock 상태와 일관되게 동작해야 사용자 mental model 단순.
+
+## #912 acceptance 재해석 (B3 확정)
+
+| 시나리오 | acceptance | 근거 |
+|---|---|---|
+| lock 활성 trip | ✅ 매역 알림 100% | 기존 ADR-008 SLA 그대로 |
+| lockless trip — boardingPrompt 게이트 통과 + [탑승] 응답 | ✅ 100% (autoLock 직후 100%) | 순위 1 정상 동작 |
+| lockless trip — 게이트 미통과 | acceptance 위반 아님 | 9단 AND 보호망 — 사용자 선택 영역 |
+| lockless trip — 사용자 무응답 ([탑승] 미탭) | acceptance 위반 아님 | 사용자 선택 영역 |
+| lockless trip — C 토글 OFF | acceptance 위반 아님 | 토글 = 명시 opt-in, OFF 사용자는 sub-시각지대 수용 |
+
+핵심: **"매역 알림 100%"는 lock 활성 trip 또는 사용자 명시 의향 trip에 한정**. 게이트/사용자 응답을 우회한 강제 100%는 false positive 폭발과 직교 — 추구하지 않는다.
+
+## D 흐름 부재 사유
+
+D 흐름 신설(별도 자동 lock 생성 경로)은 불필요. B의 게이트 통과 + autoLock 흐름과 C의 정보 표시 흐름이 직교 결합으로 동일 효과를 낸다. D를 추가하면:
+
+- 게이트 정의가 분산 → SSOT 와해
+- B와 D 중복 발사 가능 → dedup 책임 모호
+- 사용자 mental model 복잡화 (자동 lock 경로가 둘)
+
+B(자동 진입로) + 사용자 manual(2순위) + C(opt-in 정보) 3순위로 충분.
+
+## References
+
+- Epic #1008 SSOT (`tasks/epic-lockless-overfire-guard.md` §4 B1/B3)
+- ADR-010 §결정 (B+C 흐름 — 본 ADR이 amend 트리거)
+- ADR-011 (boarding-prompt context wireup — B 흐름 9단 게이트 필드 와이어업)
+- ADR-008 (boarding progress estimator — lock 생성 이후 SLA)


### PR DESCRIPTION
## Summary

Epic #1008 B1 확정 (2026-06-11) 반영 — ADR 레이어 SSOT 정착.

### 변경
- **ADR-013** (신규) — Lockless 보완 정책 (B+C 통합):
  - lockless 정의 = trip 활성 + BoardingLock 미생성
  - 보완 경로 우선순위: **B(boardingPrompt)** > 직접 탭(낙관적 UI) > **C(정보 토글)**
  - 토글 OFF 시 활성 lock cleanup 트리거 명시
  - #912 acceptance 재해석 (B3) 반영
  - D 흐름 부재 사유

- **ADR-010** (수정) — C 흐름 의미 재정의:
  - "opt-in lockless 토글" → **"전체역 보기 (정보용 토글)"**
  - 토글 OFF 동작에 활성 BoardingLock cleanup 명시
  - §B를 lockless 1순위 보완 경로로 명시

### 번호 노트
원안은 ADR-011 신설이었으나 ADR-011(boarding-prompt-context)/ADR-012(alarm-dedup-idempotency-key)가 이미 점유 중. 다음 가용 ADR-013으로 정착.

### 짝 PR
- **PR-β** (예정): `setLocklessStationPassed(false)` → 활성 lock cleanup + UI 레이블 변경
- **PR-γ** (#1159): acceptance 측정 결과 템플릿
- **PR-δ** (예정): SSOT §4 B1~B14 결정 확정 반영

Closes 일부분: B1 ADR 레이어 SSOT.

## Test plan
- [x] docs only — type-check pass