### PR TITLE
feat(#918): A3 PR1 — lockless trip 사전 예약 일반화

### DIFF
--- a/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
@@ -9,6 +9,7 @@ import {
   cancelTripBoundAlarms,
   prescheduleStationAlerts,
 } from '../../utils/tripBoundScheduler';
+import { getTripStartedAt } from '../../utils/tripStartStorage';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import { makeDirectRoute, makeTransferRoute } from '../../../../testUtils/routeFixtures';
 
@@ -20,6 +21,10 @@ jest.mock('../../utils/tripBoundScheduler', () => {
     cancelTripBoundAlarms: jest.fn(),
   };
 });
+
+jest.mock('../../utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn(),
+}));
 
 const mockLoggerError = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -35,6 +40,7 @@ const mockedPreschedule = prescheduleStationAlerts as jest.MockedFunction<
   typeof prescheduleStationAlerts
 >;
 const mockedCancel = cancelTripBoundAlarms as jest.MockedFunction<typeof cancelTripBoundAlarms>;
+const mockedGetTripStartedAt = getTripStartedAt as jest.MockedFunction<typeof getTripStartedAt>;
 
 type Props = Parameters<typeof useTripBoundAlarmScheduler>[0];
 function renderScheduler(initialProps: Props) {
@@ -59,6 +65,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockedPreschedule.mockResolvedValue([]);
   mockedCancel.mockResolvedValue(undefined);
+  // 기본은 tripStart 없음 — lock 없는 케이스에서 사전 예약 skip이 유지된다.
+  mockedGetTripStartedAt.mockResolvedValue(null);
 });
 
 describe('useTripBoundAlarmScheduler', () => {
@@ -236,6 +244,47 @@ describe('useTripBoundAlarmScheduler', () => {
     // lockA 재진입 시 새 preschedule trigger (ref가 stale에 의해 lockA로 잘못 set되지 않았음 확인).
     rerender({ lock: lockA, route, destinationName: '강남' });
     await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(3));
+  });
+
+  // -------- PR1: lockless 사전 예약 --------
+
+  it('lockless: lock=null + route + destination + tripStart 있으면 startTime=tripStart로 preschedule', async () => {
+    mockedGetTripStartedAt.mockResolvedValue(5_000);
+    renderScheduler({ lock: null, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    const call = mockedPreschedule.mock.calls[0][0];
+    expect(call.startTime).toBe(5_000);
+    expect(call.routeStops).toEqual([{ stationName: '강남', alarmType: 'destination' }]);
+    // 초기 마운트 — prev 없으니 cancel 호출 없음.
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('lockless 후 같은 tripStart로 lock 도착 시 재예약하지 않음 (signature dedup)', async () => {
+    mockedGetTripStartedAt.mockResolvedValue(1_000);
+    const { rerender } = renderScheduler({ lock: null, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    // lock의 boardedAt이 tripStart와 동일 → identity ts:1000 유지 → no-op.
+    rerender({ lock: lockA, route, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedPreschedule).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('lockless 예약 후 destination clear 시 cancel', async () => {
+    mockedGetTripStartedAt.mockResolvedValue(5_000);
+    const { rerender } = renderScheduler({ lock: null, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    rerender({ lock: null, route, destinationName: null });
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledTimes(1));
+    expect(mockedPreschedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('lockless: tripStart 없으면 schedule skip (cold restart pre-destination)', async () => {
+    mockedGetTripStartedAt.mockResolvedValue(null);
+    renderScheduler({ lock: null, route, destinationName: '강남' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedPreschedule).not.toHaveBeenCalled();
+    expect(mockedCancel).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
+++ b/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
@@ -12,12 +12,13 @@ import {
   deriveTripBoundStops,
   prescheduleStationAlerts,
 } from '../utils/tripBoundScheduler';
+import { getTripStartedAt } from '../utils/tripStartStorage';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useTripBoundAlarmScheduler');
 
 export interface UseTripBoundAlarmSchedulerInputs {
-  /** 현재 trip의 boarding lock. `boardedAt`을 startTime의 SSOT로 사용. null이면 cancel만. */
+  /** 현재 trip의 boarding lock. 있으면 `boardedAt`을 startTime으로 사용. */
   lock: BoardingLock | null;
   /** 트립 route. null이면 cancel만. */
   route: Route;
@@ -28,14 +29,20 @@ export interface UseTripBoundAlarmSchedulerInputs {
 /**
  * #918 (A3 후속 wire) — `tripBoundScheduler.prescheduleStationAlerts`의 단일 호출자.
  *
- * - lock + route + destinationName이 모두 갖춰진 첫 시점에 1회 사전 예약.
- * - lock.trainCode 변경 또는 route signature 변경 시 기존 `tba:` 알람 일괄 cancel 후 재예약.
- * - lock=null 전환(release / trip 종료) 시 모든 `tba:` 알람 cancel.
- * - 같은 trainCode + 같은 route signature 재렌더는 no-op (ref 비교).
+ * **PR1 (lockless 일반화):**
+ *   사용자가 목적지를 설정하면 (route + destinationName 존재) lock이 아직 없어도 OS local
+ *   notification을 사전 예약한다. startTime 결정 규칙:
+ *   - lock 있음: `lock.boardedAt`
+ *   - lock 없음 + tripStart 있음: `getTripStartedAt()` 값
+ *   - lock 없음 + tripStart 없음: schedule skip (cold restart pre-destination 상태)
  *
- * useBoardingLockScheduler와 prefix만 다르고 동일 lifecycle 패턴 — `bl:` 사전 예약은 lock 사용자 명시
- * 시작 시점에만 동작하지만 `tba:`는 destination+route+lock 활성 시점부터 OS 큐에 사전 예약된 일반화
- * fallback이다 (네트워크 0 환경 silent push 누락 보완).
+ * **Dedup identity = tripStart (또는 lock 있을 때 boardedAt fallback).**
+ *   lockless로 예약된 trip에 lock이 늦게 도착해도 tripStart가 동일하면 identity 미변경 → 재예약
+ *   없음(이중 발사 회귀 차단).
+ *
+ * - identity 변경 또는 route signature 변경 시 기존 `tba:` 알람 일괄 cancel 후 재예약.
+ * - destinationName=null 또는 route=null 전환 시 모든 `tba:` 알람 cancel.
+ * - 같은 identity + 같은 route signature 재렌더는 no-op.
  *
  * 호출 측은 단일 owner 원칙(useBoardingLockScheduler와 동일) — HomeScreen에서 1회 마운트.
  */
@@ -44,8 +51,9 @@ export function useTripBoundAlarmScheduler({
   route,
   destinationName,
 }: UseTripBoundAlarmSchedulerInputs): void {
-  // 마지막 성공한 schedule의 trainCode/sig. null이면 "현재 큐에 tba 알람 없음".
-  const scheduledTrainCodeRef = useRef<string | null>(null);
+  // 마지막 성공한 schedule의 identity/sig. null이면 "현재 큐에 tba 알람 없음".
+  // identity = `ts:${tripStart}` — lock 도착 전후로 동일 trip이면 안정.
+  const scheduledIdentityRef = useRef<string | null>(null);
   const scheduledRouteSigRef = useRef<string | null>(null);
 
   // async race 가드: 같은 effect의 이전 호출이 아직 진행 중일 수 있으므로 in-flight token으로
@@ -53,30 +61,36 @@ export function useTripBoundAlarmScheduler({
   const inFlightTokenRef = useRef(0);
 
   useEffect(() => {
-    const nextTrain = lock?.trainCode ?? null;
     const nextSig = routeSignature(route, destinationName);
-    const canSchedule = lock !== null && route !== null && destinationName !== null;
+    const hasRouteAndDest = route !== null && destinationName !== null;
 
-    const prevTrain = scheduledTrainCodeRef.current;
+    const prevIdentity = scheduledIdentityRef.current;
     const prevSig = scheduledRouteSigRef.current;
-    const hasPrevSchedule = prevTrain !== null;
+    const hasPrevSchedule = prevIdentity !== null;
 
-    // 이전 예약이 없고 이번에도 schedule 못 함 → 호출 자체 skip (lock=null인 상태에서 route만 바뀜 등).
-    if (!hasPrevSchedule && !canSchedule) return;
-    // 이전과 동일 (trainCode + sig 일치) → no-op.
-    if (hasPrevSchedule && prevTrain === nextTrain && prevSig === nextSig) return;
+    // schedule 가능 여부는 tripStart 조회 후에야 확정 — 여기서는 "확실히 skip" 케이스만 단축.
+    if (!hasPrevSchedule && !hasRouteAndDest) return;
 
     const myToken = ++inFlightTokenRef.current;
 
     const run = async (): Promise<void> => {
-      // 이전 예약이 있으면 항상 먼저 cancel (trainCode change / route change / release 모두 대상).
+      // startTime SSOT: lock 있으면 boardedAt, 없으면 tripStart storage(useDestinationStore가 기록).
+      const tripStart = lock !== null ? lock.boardedAt : await getTripStartedAt();
+      if (myToken !== inFlightTokenRef.current) return;
+
+      const canSchedule = hasRouteAndDest && tripStart !== null;
+      const nextIdentity = canSchedule ? `ts:${tripStart}` : null;
+
+      // 이전과 동일 identity + sig → no-op (lock 늦게 도착해도 tripStart 동일하면 여기서 차단).
+      if (hasPrevSchedule && nextIdentity === prevIdentity && nextSig === prevSig) return;
+
+      // 이전 예약이 있으면 항상 먼저 cancel (identity change / route change / release 모두 대상).
       if (hasPrevSchedule) {
         await cancelTripBoundAlarms();
       }
-      // stale completion: token이 현재 in-flight와 다르면 이번 run 결과로 ref 업데이트하지 않는다.
       if (myToken !== inFlightTokenRef.current) return;
       if (!canSchedule) {
-        scheduledTrainCodeRef.current = null;
+        scheduledIdentityRef.current = null;
         scheduledRouteSigRef.current = null;
         return;
       }
@@ -84,10 +98,10 @@ export function useTripBoundAlarmScheduler({
       await prescheduleStationAlerts({
         routeStops,
         estimatedHopTimesMs,
-        startTime: lock.boardedAt,
+        startTime: tripStart,
       });
       if (myToken !== inFlightTokenRef.current) return;
-      scheduledTrainCodeRef.current = nextTrain;
+      scheduledIdentityRef.current = nextIdentity;
       scheduledRouteSigRef.current = nextSig;
     };
 


### PR DESCRIPTION
## Summary
- `useTripBoundAlarmScheduler`에서 `lock !== null` 게이트 제거 — route + destination이 설정되면 lock이 없어도 OS local notification을 사전 예약.
- startTime SSOT: lock 있으면 `lock.boardedAt`, 없으면 `getTripStartedAt()` (useDestinationStore가 setDestination 시 기록).
- Dedup identity를 `ts:${tripStart}`로 통일 — lockless 예약 후 lock이 늦게 도착해도 tripStart 동일하면 재예약 없이 dedup (이중 발사 회귀 차단).

## Scope (PR1/5 of A3 stack)
이번 PR은 **lockless 활성화만** 다룹니다. 다음 항목은 후속 PR 스코프:
- PR2: fire-time 재검증
- PR3: rolling window
- PR4~5: backend 변경

Closes part of #918 (PR1/5 of A3 stack).

## Test plan
- [x] `npm test` — 4744/4744 통과, coverage 100% lines/functions/branches/statements
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (0 warnings)
- [x] 신규 테스트 4건:
  - lockless: lock=null + route + destination + tripStart 있으면 startTime=tripStart로 preschedule
  - lockless 후 같은 tripStart로 lock 도착 시 재예약 없음 (signature dedup)
  - lockless 예약 후 destination clear 시 cancel
  - lockless: tripStart 없으면 schedule skip (cold restart pre-destination)
- [x] 기존 lock-present 케이스 11건 모두 회귀 없음
- [ ] 실기기 회귀: 목적지 설정만 한 trip(boarding lock 미생성)에서 매역 OS 알람 발사 (PR2~5 후 통합 검증)