### PR TITLE
feat(#1172): backend down 감지 + Phase A pull retry/backoff

### DIFF
--- a/src/features/arrival/providers/progress/SeoulBffProgressProvider.ts
+++ b/src/features/arrival/providers/progress/SeoulBffProgressProvider.ts
@@ -1,3 +1,9 @@
+import {
+  BACKOFF_BASE_MS,
+  BACKOFF_FACTOR,
+  BACKOFF_MAX_MS,
+  FAILURE_THRESHOLD,
+} from '../../../../shared/constants/bffProgressFallback';
 import type { BffProgressProvider, BffProgressResponse } from './types';
 
 /**
@@ -10,10 +16,20 @@ import type { BffProgressProvider, BffProgressResponse } from './types';
  *   - 만료 응답: `nowMs - receivedAtMs > ttlMs`
  *   - `confidence === 'low'`
  *
+ * ### Backend down 감지 + exponential backoff (#1172)
+ *
+ * 네트워크/timeout/non-2xx가 `FAILURE_THRESHOLD`회 연속이면 backend down으로 판정한다.
+ * down 모드에서는 backoff 만료 전까지 fetch 자체를 건너뛰고 `null`을 반환해 estimator의
+ * Stage 1-3 fallback으로 자연 진행 (R-2 / R-9 / B5: 알람 over-fire 방지).
+ * backoff 만료 시점에 다시 시도하고, 성공하면 down 모드를 즉시 해제한다.
+ * `confidence === 'low'`는 데이터 품질 게이트일 뿐 backend 건강과 무관하므로 실패로 세지 않는다.
+ *
  * @see docs/decisions/ADR-008-boarding-progress-estimator.md Stage 4
  */
 export class SeoulBffProgressProvider implements BffProgressProvider {
   private readonly cache = new Map<string, BffProgressResponse>();
+  private consecutiveFailures = 0;
+  private nextRetryAtMs = 0;
 
   constructor(
     private readonly baseUrl: string,
@@ -26,13 +42,21 @@ export class SeoulBffProgressProvider implements BffProgressProvider {
       return this.gate(cached, nowMs);
     }
 
-    const fresh = await this.fetchFromBff(tripToken);
-    if (!fresh) {
-      // 네트워크/timeout/non-2xx — stale 캐시는 폐기하지 않고 그대로 둔다.
-      // 다음 호출이 만료된 캐시를 다시 만나도 게이트가 null을 반환하므로 안전.
+    if (this.isInBackoff(nowMs)) {
+      // backend down 의심 — backoff 만료 전이면 fetch 생략. estimator는 Stage 1-3 fallback 유지.
       return null;
     }
 
+    const fresh = await this.fetchFromBff(tripToken);
+    if (!fresh) {
+      // 네트워크/timeout/non-2xx — 실패 카운터 증가, 임계치 초과 시 backoff 스케줄.
+      // stale 캐시는 폐기하지 않고 그대로 둔다.
+      this.recordFailure(nowMs);
+      return null;
+    }
+
+    // backend 회복 — down 모드 즉시 해제.
+    this.recordSuccess();
     this.cache.set(tripToken, fresh);
     return this.gate(fresh, nowMs);
   }
@@ -48,6 +72,24 @@ export class SeoulBffProgressProvider implements BffProgressProvider {
       return null;
     }
     return response;
+  }
+
+  private isInBackoff(nowMs: number): boolean {
+    return this.consecutiveFailures >= FAILURE_THRESHOLD && nowMs < this.nextRetryAtMs;
+  }
+
+  private recordFailure(nowMs: number): void {
+    this.consecutiveFailures += 1;
+    if (this.consecutiveFailures >= FAILURE_THRESHOLD) {
+      const exponent = this.consecutiveFailures - FAILURE_THRESHOLD;
+      const delay = Math.min(BACKOFF_BASE_MS * BACKOFF_FACTOR ** exponent, BACKOFF_MAX_MS);
+      this.nextRetryAtMs = nowMs + delay;
+    }
+  }
+
+  private recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.nextRetryAtMs = 0;
   }
 
   private async fetchFromBff(tripToken: string): Promise<BffProgressResponse | null> {

--- a/src/features/arrival/providers/progress/__tests__/SeoulBffProgressProvider.test.ts
+++ b/src/features/arrival/providers/progress/__tests__/SeoulBffProgressProvider.test.ts
@@ -155,6 +155,160 @@ describe('SeoulBffProgressProvider', () => {
     expect(result).toBeNull();
   });
 
+  describe('backend down 감지 + exponential backoff (#1172)', () => {
+    function mockFetchFail() {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+    }
+
+    it('연속 실패가 임계치 미만이면 매번 fetch를 시도한다', async () => {
+      const provider = new SeoulBffProgressProvider(BASE_URL);
+      mockFetchFail();
+      mockFetchFail();
+
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 1_000);
+
+      // 2회 실패는 아직 임계치(3) 미만 — 매 호출마다 fetch.
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('연속 실패가 임계치를 넘으면 backoff 동안 fetch를 건너뛴다', async () => {
+      const provider = new SeoulBffProgressProvider(BASE_URL);
+      mockFetchFail();
+      mockFetchFail();
+      mockFetchFail();
+
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 1_000);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 2_000);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+
+      // 4번째 호출은 backoff 진입으로 fetch 생략, null 반환.
+      const result = await provider.fetch(TRIP_TOKEN, NOW_MS + 3_000);
+      expect(result).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('backoff 만료 시점이 되면 다시 fetch를 시도한다', async () => {
+      const provider = new SeoulBffProgressProvider(BASE_URL);
+      // 임계치 도달.
+      mockFetchFail();
+      mockFetchFail();
+      mockFetchFail();
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+      // 충분히 큰 시간이 지나면 backoff 만료 → 재시도.
+      mockFetchFail();
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 10 * 60_000);
+      expect(global.fetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('backoff 만료 후 성공하면 down 모드가 해제된다 (즉시 재진입 fetch)', async () => {
+      const provider = new SeoulBffProgressProvider(BASE_URL);
+      mockFetchFail();
+      mockFetchFail();
+      mockFetchFail();
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+      const recovery: BffProgressResponse = {
+        waypointIndex: 1,
+        remainingHopsMs: 40_000,
+        confidence: 'high',
+        receivedAtMs: NOW_MS + 10 * 60_000,
+        ttlMs: 60_000,
+      };
+      mockFetchOk(recovery);
+      const recovered = await provider.fetch(TRIP_TOKEN, NOW_MS + 10 * 60_000);
+      expect(recovered).toEqual(recovery);
+
+      // 회복 후 캐시 만료 시점에 새로 fetch가 정상 동작 — backoff 미적용.
+      const next: BffProgressResponse = {
+        waypointIndex: 2,
+        remainingHopsMs: 30_000,
+        confidence: 'high',
+        receivedAtMs: NOW_MS + 11 * 60_000 + 30_000,
+        ttlMs: 60_000,
+      };
+      mockFetchOk(next);
+      const after = await provider.fetch(TRIP_TOKEN, NOW_MS + 11 * 60_000 + 30_000);
+      expect(after).toEqual(next);
+      expect(global.fetch).toHaveBeenCalledTimes(5);
+    });
+
+    it('중간에 성공이 끼면 실패 카운터가 초기화된다', async () => {
+      const provider = new SeoulBffProgressProvider(BASE_URL);
+      mockFetchFail();
+      mockFetchFail();
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+
+      const ok: BffProgressResponse = {
+        waypointIndex: 0,
+        remainingHopsMs: 50_000,
+        confidence: 'high',
+        receivedAtMs: NOW_MS + 1_000,
+        ttlMs: 60_000,
+      };
+      mockFetchOk(ok);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 1_000);
+
+      // 캐시 만료 후 또 2회 실패해도 아직 임계치 미만(누적 리셋됨).
+      mockFetchFail();
+      mockFetchFail();
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 80_000);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 90_000);
+
+      // 모두 실제 fetch 호출 — backoff 미진입.
+      expect(global.fetch).toHaveBeenCalledTimes(5);
+    });
+
+    it('confidence=low 응답은 backend 건강과 무관하므로 실패로 세지 않는다', async () => {
+      const provider = new SeoulBffProgressProvider(BASE_URL);
+      const low: BffProgressResponse = {
+        waypointIndex: 0,
+        remainingHopsMs: 40_000,
+        confidence: 'low',
+        receivedAtMs: NOW_MS,
+        ttlMs: 60_000,
+      };
+      mockFetchOk(low);
+      mockFetchOk(low);
+      mockFetchOk(low);
+      mockFetchOk(low);
+
+      // 4회 모두 low (게이트는 null 반환) — backoff 미진입, 매번 캐시 만료 후 fetch.
+      await provider.fetch(TRIP_TOKEN, NOW_MS);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 70_000);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 140_000);
+      await provider.fetch(TRIP_TOKEN, NOW_MS + 210_000);
+
+      expect(global.fetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('backoff 지연은 BACKOFF_MAX_MS를 넘지 않는다', async () => {
+      const provider = new SeoulBffProgressProvider(BASE_URL);
+      // 매번 backoff 만료 직후 실패시켜 지수가 계속 증가하도록 유도.
+      let now = NOW_MS;
+      for (let i = 0; i < 20; i += 1) {
+        mockFetchFail();
+        await provider.fetch(TRIP_TOKEN, now);
+        // 충분히 큰 점프로 다음 backoff 만료를 항상 넘기게 함.
+        now += 10 * 60_000;
+      }
+      const fetchCallsAfterLoop = (global.fetch as jest.Mock).mock.calls.length;
+      expect(fetchCallsAfterLoop).toBe(20);
+
+      // 직전 실패 시점으로부터 BACKOFF_MAX_MS + 여유가 지나면 무조건 재시도 가능해야 함.
+      mockFetchFail();
+      await provider.fetch(TRIP_TOKEN, now + 60_001);
+      expect((global.fetch as jest.Mock).mock.calls.length).toBe(21);
+    });
+  });
+
   it('특수 문자가 포함된 tripToken을 URL 인코딩한다', async () => {
     const provider = new SeoulBffProgressProvider(BASE_URL);
     const response: BffProgressResponse = {

--- a/src/shared/constants/__tests__/bffProgressFallback.test.ts
+++ b/src/shared/constants/__tests__/bffProgressFallback.test.ts
@@ -1,0 +1,20 @@
+import {
+  BACKOFF_BASE_MS,
+  BACKOFF_FACTOR,
+  BACKOFF_MAX_MS,
+  FAILURE_THRESHOLD,
+} from '../bffProgressFallback';
+
+describe('bffProgressFallback constants', () => {
+  it('FAILURE_THRESHOLD는 1 이상이다 (down 판정에 최소 1회 실패 필요)', () => {
+    expect(FAILURE_THRESHOLD).toBeGreaterThanOrEqual(1);
+  });
+
+  it('BACKOFF_BASE_MS < BACKOFF_MAX_MS (지수 증가 여지 확보)', () => {
+    expect(BACKOFF_BASE_MS).toBeLessThan(BACKOFF_MAX_MS);
+  });
+
+  it('BACKOFF_FACTOR는 1보다 크다 (지수 증가)', () => {
+    expect(BACKOFF_FACTOR).toBeGreaterThan(1);
+  });
+});

--- a/src/shared/constants/bffProgressFallback.ts
+++ b/src/shared/constants/bffProgressFallback.ts
@@ -1,0 +1,21 @@
+/**
+ * #1172 / Epic #1008 Epic C 단기 — Phase A pull retry/backoff 상수.
+ *
+ * BFF progress 호출이 N회 연속 실패하면 backend down으로 판정하고, exponential backoff로
+ * 재호출 시도를 미룬다. down 상태에서는 fetch가 즉시 null을 반환해 Stage 1-3 estimator로
+ * 자연 fallback (R-2 / R-9 / B5 회피, 즉 backend 장애 시 알람 over-fire 방지).
+ *
+ * 회복 즉시 down 모드를 해제하기 위해 backoff 만료 시점에는 다시 시도한다.
+ */
+
+/** 연속 실패 임계치. 이 횟수만큼 실패하면 down 모드 진입. */
+export const FAILURE_THRESHOLD = 3;
+
+/** down 모드 진입 직후 첫 재시도까지 대기 시간 (ms). */
+export const BACKOFF_BASE_MS = 5_000;
+
+/** backoff 상한 (ms). 지수 증가가 이 값을 넘지 않도록 클램프. */
+export const BACKOFF_MAX_MS = 60_000;
+
+/** backoff 지수. delay = min(BACKOFF_BASE_MS * FACTOR^attempt, BACKOFF_MAX_MS). */
+export const BACKOFF_FACTOR = 2;


### PR DESCRIPTION
## Summary
- `SeoulBffProgressProvider`에 연속 실패 카운터 + exponential backoff 추가. `FAILURE_THRESHOLD`회 연속 네트워크/timeout/non-2xx면 backend down으로 판정해 backoff 만료 전까지 fetch 자체를 건너뛰고 null을 반환 → Stage 1-3 estimator로 자연 fallback (R-2 / R-9 / B5: backend 장애 시 알람 over-fire 방지)
- backoff 만료 시 재시도하고, 성공하면 down 모드를 즉시 해제. `confidence === 'low'`는 데이터 품질 게이트일 뿐 backend 건강과 무관하므로 실패로 세지 않음
- backoff 파라미터(BASE/MAX/FACTOR)는 `src/shared/constants/bffProgressFallback.ts`에 분리 (CLAUDE.md 매직 넘버 룰)

## Test plan
- [x] `SeoulBffProgressProvider` 신규 테스트 7개 + `bffProgressFallback` 상수 테스트 3개 통과
- [x] 변경 파일 100% 커버리지 (Stmts / Branch / Funcs / Lines)
- [x] `npm run type-check` / `npm run lint` 통과
- [x] 전체 jest run의 37개 실패는 origin/dev에서도 동일하게 실패 (SharedGroupAdapter / widgetStorage / stationNotification — 본 PR 무관)
- [ ] 실기기/실 백엔드 down 시뮬레이션은 후속 측정 sub-issue에서 처리

Closes #1172
Related: #1008 (Epic C 단기 8번)