### PR TITLE
feat(#918): A3 PR2 — fire-time re-validation (suppress stale/misfire)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
@@ -8,6 +8,7 @@ import type { ScheduledTripBoundAlarm } from '../../utils/tripBoundScheduler';
 import {
   cancelTripBoundAlarms,
   prescheduleStationAlerts,
+  setRegisteredTripRouteSig,
 } from '../../utils/tripBoundScheduler';
 import { getTripStartedAt } from '../../utils/tripStartStorage';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
@@ -19,6 +20,7 @@ jest.mock('../../utils/tripBoundScheduler', () => {
     ...actual,
     prescheduleStationAlerts: jest.fn(),
     cancelTripBoundAlarms: jest.fn(),
+    setRegisteredTripRouteSig: jest.fn(),
   };
 });
 
@@ -41,6 +43,9 @@ const mockedPreschedule = prescheduleStationAlerts as jest.MockedFunction<
 >;
 const mockedCancel = cancelTripBoundAlarms as jest.MockedFunction<typeof cancelTripBoundAlarms>;
 const mockedGetTripStartedAt = getTripStartedAt as jest.MockedFunction<typeof getTripStartedAt>;
+const mockedSetSig = setRegisteredTripRouteSig as jest.MockedFunction<
+  typeof setRegisteredTripRouteSig
+>;
 
 type Props = Parameters<typeof useTripBoundAlarmScheduler>[0];
 function renderScheduler(initialProps: Props) {
@@ -65,6 +70,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockedPreschedule.mockResolvedValue([]);
   mockedCancel.mockResolvedValue(undefined);
+  mockedSetSig.mockResolvedValue(undefined);
   // 기본은 tripStart 없음 — lock 없는 케이스에서 사전 예약 skip이 유지된다.
   mockedGetTripStartedAt.mockResolvedValue(null);
 });
@@ -285,6 +291,41 @@ describe('useTripBoundAlarmScheduler', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedPreschedule).not.toHaveBeenCalled();
     expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  // -------- PR2 (#918 A3, #729 흡수): fire-time 재검증을 위한 route sig 영속화 --------
+
+  it('PR2: preschedule 성공 직후 현재 route sig를 storage에 영속화한다', async () => {
+    renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    await waitFor(() => expect(mockedSetSig).toHaveBeenCalledTimes(1));
+    // sig는 string 형식(boardingLockScheduler.routeSignature 결과) — 비어 있지 않음.
+    expect(typeof mockedSetSig.mock.calls[0][0]).toBe('string');
+    expect(mockedSetSig.mock.calls[0][0].length).toBeGreaterThan(0);
+  });
+
+  it('PR2: schedule skip 케이스(예: destination=null)에서는 sig 영속화하지 않음', async () => {
+    renderScheduler({ lock: lockA, route, destinationName: null });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedSetSig).not.toHaveBeenCalled();
+  });
+
+  it('PR2: route signature 변경 시 새 sig가 다시 영속화된다', async () => {
+    const altRoute = makeTransferRoute({
+      transferName: '교대',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 3,
+    });
+    const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    await waitFor(() => expect(mockedSetSig).toHaveBeenCalledTimes(1));
+    const firstSig = mockedSetSig.mock.calls[0][0];
+
+    rerender({ lock: lockA, route: altRoute, destinationName: '강남' });
+    await waitFor(() => expect(mockedSetSig).toHaveBeenCalledTimes(2));
+    expect(mockedSetSig.mock.calls[1][0]).not.toBe(firstSig);
   });
 });
 

--- a/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
+++ b/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
@@ -11,6 +11,7 @@ import {
   cancelTripBoundAlarms,
   deriveTripBoundStops,
   prescheduleStationAlerts,
+  setRegisteredTripRouteSig,
 } from '../utils/tripBoundScheduler';
 import { getTripStartedAt } from '../utils/tripStartStorage';
 import { createLogger } from '../../../shared/utils/logger';
@@ -100,7 +101,13 @@ export function useTripBoundAlarmScheduler({
         estimatedHopTimesMs,
         startTime: tripStart,
       });
+      // #918 A3 PR2 (#729 흡수): fire-time 재검증을 위해 route signature 영속화.
+      // canSchedule=true 경로는 hasRouteAndDest=true → routeSignature는 항상 string 반환 → nextSig non-null.
+      // sig persist는 preschedule과 같은 awaited 동기 묶음 — 사이에 추가 token guard 없이도 한 번의 stale 차단
+      // (이미 line 91/79)으로 충분. 새 effect가 fire하면 cancelTripBoundAlarms가 sig를 즉시 cleanup하므로
+      // race 시 stale sig 잔존 위험은 새 effect가 흡수.
       if (myToken !== inFlightTokenRef.current) return;
+      await setRegisteredTripRouteSig(nextSig as string);
       scheduledIdentityRef.current = nextIdentity;
       scheduledRouteSigRef.current = nextSig;
     };

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -43,6 +43,7 @@ import {
   summarizeAlarmLogByReason,
   logHydrationTransition,
   logSuppressedStationPassedWarmup,
+  logSuppressedTbaRevalidation,
   summarizeAlarmLogBySource,
   countGateReasons,
   countSilentPushOutcomes,
@@ -590,6 +591,42 @@ describe('alarmLog', () => {
         reason: 'sleep-first-transfer',
         stationName: '역삼',
         kind: 'transfer',
+      });
+      expect(saved[0].phaseId).toBeUndefined();
+    });
+
+    it.each([
+      ['revalidate-no-trip' as const, '강남', 'early' as const],
+      ['revalidate-route-sig-mismatch' as const, '시청', 'imminent' as const],
+      ['revalidate-waypoint-mismatch' as const, '서울역', 'early' as const],
+    ])(
+      '#918 A3 PR2 logSuppressedTbaRevalidation: %s — source=bg-scheduled 고정 + reason/stationName/phaseId 보존',
+      async (reason, stationName, phaseId) => {
+        logSuppressedTbaRevalidation({ reason, stationName, phaseId });
+        await expectLastSavedEntryMatches({
+          source: 'bg-scheduled',
+          outcome: 'suppressed',
+          reason,
+          stationName,
+          phaseId,
+        });
+      },
+    );
+
+    it('#918 A3 PR2 logSuppressedTbaRevalidation: phaseId 미전달 시에도 적재', async () => {
+      logSuppressedTbaRevalidation({
+        reason: 'revalidate-no-trip',
+        stationName: '약수',
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg-scheduled',
+        outcome: 'suppressed',
+        reason: 'revalidate-no-trip',
+        stationName: '약수',
       });
       expect(saved[0].phaseId).toBeUndefined();
     });

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -22,6 +22,38 @@ jest.mock('../prescheduledMetrics', () => ({
   recordFiredAlarm: (...args: unknown[]) => mockRecordFiredAlarm(...args),
 }));
 
+// #918 A3 PR2 — revalidation helpers. 기본값은 'pass' 경로(re-validation 통과 시 기존 동작 유지).
+// 각 테스트에서 mockResolvedValueOnce로 override.
+const mockGetTripStartedAt = jest.fn();
+jest.mock('../tripStartStorage', () => ({
+  getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
+}));
+
+const mockGetRegisteredTripRouteSig = jest.fn();
+jest.mock('../tripBoundScheduler', () => {
+  // 실제 모듈의 TRIP_BOUND_ALARM_PREFIX/parseTripBoundAlarmIdentifier는 그대로 사용해야 한다.
+  const actual = jest.requireActual('../tripBoundScheduler');
+  return {
+    ...actual,
+    getRegisteredTripRouteSig: (...args: unknown[]) => mockGetRegisteredTripRouteSig(...args),
+  };
+});
+
+const mockRouteSignature = jest.fn();
+jest.mock('../boardingLockScheduler', () => ({
+  routeSignature: (...args: unknown[]) => mockRouteSignature(...args),
+}));
+
+const mockResolveAllTargets = jest.fn();
+jest.mock('../stationAlarm', () => ({
+  resolveAllTargets: (...args: unknown[]) => mockResolveAllTargets(...args),
+}));
+
+const mockLogSuppressedTbaRevalidation = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logSuppressedTbaRevalidation: (...args: unknown[]) => mockLogSuppressedTbaRevalidation(...args),
+}));
+
 const mockErrorSpy = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -51,9 +83,20 @@ const mockGetPresented = Notifications.getPresentedNotificationsAsync as jest.Mo
 const mockAsyncGetItem = AsyncStorage.getItem as jest.Mock;
 
 const DEST_JSON = JSON.stringify({ id: 'dest-1', name: '강남' });
+const ROUTE_JSON = JSON.stringify({ type: 'direct', stops: 1, line: '2', travelSeconds: 60 });
 
 function flushAsync(): Promise<void> {
   return new Promise((r) => setImmediate(r));
+}
+
+/**
+ * AsyncStorage.getItem이 키별로 다른 값을 반환하도록 셋업한다 — 재검증 path는 ROUTE_KEY/
+ * DESTINATION_KEY 두 키를 모두 읽기 때문.
+ */
+function setStorageMap(map: Record<string, string | null>): void {
+  mockAsyncGetItem.mockImplementation(async (key: string) =>
+    Object.prototype.hasOwnProperty.call(map, key) ? map[key] : null,
+  );
 }
 
 let appStateSpy: jest.SpyInstance;
@@ -68,6 +111,16 @@ beforeEach(async () => {
   mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
   mockGetPresented.mockResolvedValue([]);
   mockAsyncGetItem.mockResolvedValue(DEST_JSON);
+  // #918 A3 PR2 — 기본 mocks: tba 재검증 'pass' 경로 (tripStart 존재 + sig 일치 + waypoint 매칭).
+  mockGetTripStartedAt.mockReset();
+  mockGetTripStartedAt.mockResolvedValue(1_000_000);
+  mockGetRegisteredTripRouteSig.mockReset();
+  mockGetRegisteredTripRouteSig.mockResolvedValue('SIG-A');
+  mockRouteSignature.mockReset();
+  mockRouteSignature.mockReturnValue('SIG-A');
+  mockResolveAllTargets.mockReset();
+  mockResolveAllTargets.mockReturnValue([{ name: '강남' }, { name: '시청' }, { name: '서울역' }]);
+  mockLogSuppressedTbaRevalidation.mockReset();
   // 기본 AppState 스파이 — 각 테스트는 mockImplementationOnce로 추가 override 가능.
   appStateSpy = jest
     .spyOn(AppState, 'addEventListener')
@@ -360,5 +413,248 @@ describe('#918 A3 prescheduled fire ledger 기록', () => {
     });
     handle.remove();
     (Date.now as jest.Mock).mockRestore();
+  });
+});
+
+// #918 A3 PR2 (#729 흡수) — `tba:` 알람 fire-time 재검증.
+describe('tba: fire-time 재검증 (#918 A3 PR2)', () => {
+  beforeEach(() => {
+    // ROUTE_KEY + DESTINATION_KEY 두 키 모두 읽기 — 매핑된 default를 셋업.
+    setStorageMap({
+      'subway-now:destination': DEST_JSON,
+      'subway-now:route': ROUTE_JSON,
+    });
+  });
+
+  describe('reconcileScheduledAlarmDelivery — `tba:` 단건', () => {
+    it('재검증 통과 시 alarm: 경로와 동일하게 fired set + lastStationName을 갱신한다', async () => {
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockGetFiredAlarms).toHaveBeenCalledWith('dest-1');
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+    });
+
+    it('tripStart 미존재 시 revalidate-no-trip 적재 후 상태 갱신 skip', async () => {
+      mockGetTripStartedAt.mockResolvedValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-no-trip',
+        stationName: '강남',
+        phaseId: 'early',
+      });
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+    });
+
+    it('등록 시점 sig와 현재 sig 불일치 시 revalidate-route-sig-mismatch + skip', async () => {
+      mockGetRegisteredTripRouteSig.mockResolvedValueOnce('SIG-OLD');
+      mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+
+      await reconcileScheduledAlarmDelivery('tba:imminent:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-route-sig-mismatch',
+        stationName: '강남',
+        phaseId: 'imminent',
+      });
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+    });
+
+    it('등록된 sig가 null이면 sig-mismatch로 분류', async () => {
+      mockGetRegisteredTripRouteSig.mockResolvedValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+    });
+
+    it('현재 sig가 null(route/destination 미설정)이면 sig-mismatch로 분류', async () => {
+      mockRouteSignature.mockReturnValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+    });
+
+    it('stationName이 현재 waypoint 시퀀스에 없으면 revalidate-waypoint-mismatch + skip', async () => {
+      // sig는 일치하지만 targets에 없는 역. 방어 검증 경로.
+      mockResolveAllTargets.mockReturnValueOnce([{ name: '시청' }, { name: '서울역' }]);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-waypoint-mismatch',
+        stationName: '강남',
+        phaseId: 'early',
+      });
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+    });
+
+    it('ROUTE_KEY JSON 파싱 실패 시 currentSig=null → sig-mismatch', async () => {
+      setStorageMap({
+        'subway-now:destination': DEST_JSON,
+        'subway-now:route': 'not-json',
+      });
+      mockRouteSignature.mockReturnValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+    });
+
+    it('DESTINATION_KEY JSON 파싱 실패 시 currentSig=null → sig-mismatch', async () => {
+      setStorageMap({
+        'subway-now:destination': 'not-json',
+        'subway-now:route': ROUTE_JSON,
+      });
+      mockRouteSignature.mockReturnValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+    });
+
+    it('ROUTE_KEY 미설정(null) → safeParseRoute=null → sig-mismatch', async () => {
+      setStorageMap({
+        'subway-now:destination': DEST_JSON,
+        'subway-now:route': null,
+      });
+      mockRouteSignature.mockReturnValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+    });
+
+    it('tba: prefix는 매칭되지만 포맷 파손 시 parseAlarmIdentifier=null → no-op', async () => {
+      // "tba:onlyphase" — 콜론 1개로 phaseId만 있고 stationName 부재. parseTripBoundAlarmIdentifier가
+      // null을 반환해 reconcile 자체가 early return.
+      await reconcileScheduledAlarmDelivery('tba:onlyphase');
+
+      expect(mockGetTripStartedAt).not.toHaveBeenCalled();
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it('DESTINATION_KEY에 name 필드가 없으면 currentSig=null → sig-mismatch', async () => {
+      setStorageMap({
+        'subway-now:destination': JSON.stringify({ id: 'x' }),
+        'subway-now:route': ROUTE_JSON,
+      });
+      mockRouteSignature.mockReturnValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+    });
+
+    it('재검증 통과 + destinationId 미설정이면 lastStationName만 갱신', async () => {
+      setStorageMap({
+        'subway-now:destination': null,
+        'subway-now:route': ROUTE_JSON,
+      });
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+    });
+  });
+
+  describe('drainDeliveredScheduledAlarms — `tba:` 항목 재검증', () => {
+    it('suppress된 tba 항목은 fired set/lastStationName 갱신에서 제외된다', async () => {
+      // 첫 tba는 sig-mismatch로 suppress, 두 번째 tba는 pass.
+      mockGetTripStartedAt.mockResolvedValue(1_000_000);
+      mockGetRegisteredTripRouteSig
+        .mockResolvedValueOnce('SIG-OLD') // 첫 항목 재검증
+        .mockResolvedValueOnce('SIG-A'); // 두 번째 항목 재검증
+      mockRouteSignature
+        .mockReturnValueOnce('SIG-NEW')
+        .mockReturnValueOnce('SIG-A');
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'tba:early:잘못된역' } },
+        { date: 2, request: { identifier: 'tba:imminent:강남' } },
+      ]);
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      // suppress된 첫 항목 + pass된 두 번째 항목 — fired set엔 두 번째만.
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['imminent:강남']));
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ stationName: '잘못된역' }),
+      );
+      handle.remove();
+    });
+
+    it('모든 tba 항목이 suppress면 fired set/lastStationName 모두 갱신 안 함', async () => {
+      mockGetTripStartedAt.mockResolvedValue(null);
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'tba:early:A' } },
+        { date: 2, request: { identifier: 'tba:imminent:B' } },
+      ]);
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+      handle.remove();
+    });
+
+    it('`alarm:` 항목은 재검증 없이 그대로 통과한다', async () => {
+      // tba가 섞여 있어도 alarm 경로는 재검증 우회.
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'alarm:early:강남' } },
+      ]);
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
+      expect(mockGetTripStartedAt).not.toHaveBeenCalled();
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+      handle.remove();
+    });
+
+    it('재검증 통과 + destinationId 미설정 — pass된 tba 항목으로 lastStationName 갱신', async () => {
+      setStorageMap({
+        'subway-now:destination': null,
+        'subway-now:route': ROUTE_JSON,
+      });
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'tba:imminent:강남' } },
+      ]);
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+      handle.remove();
+    });
   });
 });

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -1,13 +1,19 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   TRIP_BOUND_ALARM_PREFIX,
   cancelTripBoundAlarms,
+  clearRegisteredTripRouteSig,
   deriveTripBoundStops,
+  getRegisteredTripRouteSig,
+  parseTripBoundAlarmIdentifier,
   prescheduleStationAlerts,
+  setRegisteredTripRouteSig,
   tripBoundAlarmIdentifier,
   type TripBoundStop,
 } from '../tripBoundScheduler';
+import { TRIP_BOUND_ROUTE_SIG_KEY } from '../../../../shared/constants/storageKeys';
 import {
   makeDirectRoute,
   makeMultiTransferRoute,
@@ -66,6 +72,83 @@ describe('tripBoundAlarmIdentifier', () => {
   });
   it('prefix 상수는 노출된 값과 일치한다', () => {
     expect(TRIP_BOUND_ALARM_PREFIX).toBe('tba:');
+  });
+});
+
+describe('parseTripBoundAlarmIdentifier (#918 A3 PR2)', () => {
+  it('tba:phase:station 형식을 정상 파싱한다', () => {
+    expect(parseTripBoundAlarmIdentifier('tba:early:강남')).toEqual({
+      phaseId: 'early',
+      stationName: '강남',
+    });
+    expect(parseTripBoundAlarmIdentifier('tba:imminent:시청')).toEqual({
+      phaseId: 'imminent',
+      stationName: '시청',
+    });
+  });
+
+  it('occurrence suffix(:n)는 stationName에 그대로 포함되어 반환된다', () => {
+    // suffix를 따로 떼지 않음 — 이후 waypoint 매칭 단계에서 자연스럽게 mismatch로 떨어지는 것을 의도.
+    expect(parseTripBoundAlarmIdentifier('tba:imminent:시청:1')).toEqual({
+      phaseId: 'imminent',
+      stationName: '시청:1',
+    });
+  });
+
+  it('prefix가 다르면 null', () => {
+    expect(parseTripBoundAlarmIdentifier('alarm:early:강남')).toBeNull();
+    expect(parseTripBoundAlarmIdentifier('bl:T1:0:early:강남')).toBeNull();
+    expect(parseTripBoundAlarmIdentifier('current-station')).toBeNull();
+  });
+
+  it('포맷이 망가지면 null (콜론 없음 / phaseId 비어 있음 / stationName 비어 있음)', () => {
+    expect(parseTripBoundAlarmIdentifier('tba:onlyphase')).toBeNull();
+    expect(parseTripBoundAlarmIdentifier('tba::강남')).toBeNull();
+    expect(parseTripBoundAlarmIdentifier('tba:early:')).toBeNull();
+  });
+});
+
+describe('registered trip route sig storage (#918 A3 PR2)', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('set → get round-trip 동일 값을 반환한다', async () => {
+    await setRegisteredTripRouteSig('A:1|B:2');
+    expect(await getRegisteredTripRouteSig()).toBe('A:1|B:2');
+  });
+
+  it('미설정 시 null', async () => {
+    expect(await getRegisteredTripRouteSig()).toBeNull();
+  });
+
+  it('clear는 다시 null을 반환하게 한다', async () => {
+    await setRegisteredTripRouteSig('A:1');
+    await clearRegisteredTripRouteSig();
+    expect(await getRegisteredTripRouteSig()).toBeNull();
+  });
+
+  it('set은 TRIP_BOUND_ROUTE_SIG_KEY 키에 저장한다', async () => {
+    await setRegisteredTripRouteSig('A:1|B:2');
+    expect(await AsyncStorage.getItem(TRIP_BOUND_ROUTE_SIG_KEY)).toBe('A:1|B:2');
+  });
+
+  it('AsyncStorage setItem이 throw해도 graceful (예외 전파 없음)', async () => {
+    const spy = jest.spyOn(AsyncStorage, 'setItem').mockRejectedValueOnce(new Error('disk'));
+    await expect(setRegisteredTripRouteSig('A:1')).resolves.toBeUndefined();
+    spy.mockRestore();
+  });
+
+  it('AsyncStorage getItem이 throw해도 null 반환', async () => {
+    const spy = jest.spyOn(AsyncStorage, 'getItem').mockRejectedValueOnce(new Error('disk'));
+    expect(await getRegisteredTripRouteSig()).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('AsyncStorage removeItem이 throw해도 graceful', async () => {
+    const spy = jest.spyOn(AsyncStorage, 'removeItem').mockRejectedValueOnce(new Error('disk'));
+    await expect(clearRegisteredTripRouteSig()).resolves.toBeUndefined();
+    spy.mockRestore();
   });
 });
 
@@ -347,6 +430,15 @@ describe('cancelTripBoundAlarms', () => {
     mockedGetAll.mockResolvedValue([]);
     await expect(cancelTripBoundAlarms()).resolves.toBeUndefined();
     expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('#918 A3 PR2 — sig storage도 함께 클리어한다 (재예약 사이 stale sig 차단)', async () => {
+    // spy로 set 호출 횟수만 검증 — auto-mock storage state는 테스트 순서에 의존하지 않게.
+    const removeSpy = jest.spyOn(AsyncStorage, 'removeItem');
+    mockedGetAll.mockResolvedValue([]);
+    await cancelTripBoundAlarms();
+    expect(removeSpy).toHaveBeenCalledWith(TRIP_BOUND_ROUTE_SIG_KEY);
+    removeSpy.mockRestore();
   });
 });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -105,7 +105,14 @@ export type AlarmLogReason =
   | 'hydration-pre-hydrate'
   | 'hydration-hydrating'
   | 'hydration-storage-synced'
-  | 'hydration-ready';
+  | 'hydration-ready'
+  // #918 A3 PR2 (#729 흡수) — `tba:` 사전 예약 알람 fire-time 재검증 실패.
+  //   'revalidate-no-trip': tripStart 미존재(이미 종료된 trip의 잔여 발화).
+  //   'revalidate-route-sig-mismatch': 예약 시점 sig와 현재 sig 불일치(목적지 변경/환승 재산정).
+  //   'revalidate-waypoint-mismatch': 파싱된 stationName이 현재 route waypoint에 없음.
+  | 'revalidate-no-trip'
+  | 'revalidate-route-sig-mismatch'
+  | 'revalidate-waypoint-mismatch';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -777,6 +784,28 @@ export function logHydrationTransition(
     outcome: 'received',
     reason: HYDRATION_PHASE_REASON[phase],
     destinationId,
+  });
+}
+
+/**
+ * #918 A3 PR2 (#729 흡수) — `tba:` 사전 예약 알람의 fire-time 재검증 실패 1건 적재.
+ *
+ * scheduledAlarmReceiver가 OS-fired identifier를 reconcile하기 직전에 호출 — 적재 후 fired set /
+ * lastStationName 갱신을 skip해 stale 알람이 후속 상태(BG arrival 기준역 등)를 오염시키지 않게 한다.
+ * source='bg-scheduled' 재사용 — preschedule path 출처 통일(stamp/fired log와 동일 source).
+ */
+export function logSuppressedTbaRevalidation(input: {
+  reason: 'revalidate-no-trip' | 'revalidate-route-sig-mismatch' | 'revalidate-waypoint-mismatch';
+  stationName: string;
+  phaseId?: AlarmPhaseId;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg-scheduled',
+    outcome: 'suppressed',
+    reason: input.reason,
+    stationName: input.stationName,
+    phaseId: input.phaseId,
   });
 }
 

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -7,9 +7,20 @@ import {
   setFiredAlarms,
   setLastFiredAlarmStationName,
 } from './notificationState';
-import { DESTINATION_KEY } from '../../../shared/constants/storageKeys';
+import { DESTINATION_KEY, ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
 import { recordFiredAlarm } from './prescheduledMetrics';
+import {
+  TRIP_BOUND_ALARM_PREFIX,
+  getRegisteredTripRouteSig,
+  parseTripBoundAlarmIdentifier,
+} from './tripBoundScheduler';
+import { getTripStartedAt } from './tripStartStorage';
+import { resolveAllTargets } from './stationAlarm';
+import { routeSignature } from './boardingLockScheduler';
+import { logSuppressedTbaRevalidation } from './alarmLog';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { AlarmPhaseId } from './alarmPhases';
 
 const logger = createLogger('ScheduledAlarmReceiver');
 
@@ -28,8 +39,110 @@ async function getCurrentDestinationId(): Promise<string | null> {
   }
 }
 
+interface ParsedAlarmIdentifier {
+  prefix: 'alarm' | 'tba';
+  phaseId: string;
+  stationName: string;
+}
+
 /**
- * 사전 예약된 `alarm:` 알림이 OS에 의해 발사된 직후 클라이언트 상태를 갱신한다.
+ * `alarm:` / `tba:` 두 prefix 단일 진입점 (#918 A3 PR2).
+ * 두 경로의 phaseId/stationName 추출 로직이 같으므로 호출자는 prefix 분기만 본다.
+ */
+function parseAlarmIdentifier(identifier: string): ParsedAlarmIdentifier | null {
+  if (identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) {
+    const p = parseTripBoundAlarmIdentifier(identifier);
+    return p ? { prefix: 'tba', phaseId: p.phaseId, stationName: p.stationName } : null;
+  }
+  const p = parseScheduledAlarmIdentifier(identifier);
+  return p ? { prefix: 'alarm', phaseId: p.phaseId, stationName: p.stationName } : null;
+}
+
+function safeParseRoute(raw: string | null): Route {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Route;
+  } catch {
+    return null;
+  }
+}
+
+function parseDestinationName(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.name === 'string' ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `tba:` 알람의 fire-time 재검증 (#918 A3 PR2, #729 흡수).
+ *
+ * OS가 예약된 시각에 발사한 trip-bound 알람이 *현재* 시점에도 유효한지 확인한다.
+ * 세 조건 모두 충족해야 reconcile 진행:
+ *   1) tripStart 존재 — trip이 종료되지 않았다.
+ *   2) ROUTE_KEY/DESTINATION_KEY 기반 현재 sig가 등록 시점 sig와 동일 — 목적지/환승 변경 없음.
+ *   3) 파싱된 stationName이 현재 route waypoint 시퀀스 안에 있음 — 방어 검증.
+ *
+ * 한 가지라도 실패하면 reason과 함께 alarmLog에 적재하고 'suppress'를 반환한다.
+ * 호출자는 fired set / lastStationName 갱신을 skip해 stale 알람이 후속 상태를 오염시키지 않게 한다.
+ */
+async function revalidateTbaAlarm(parsed: {
+  phaseId: string;
+  stationName: string;
+}): Promise<'pass' | 'suppress'> {
+  // phaseId는 'early'/'imminent' 둘 중 하나 — alarmLog에는 그대로 통과시켜도 안전.
+  const phaseId = parsed.phaseId as AlarmPhaseId;
+
+  const tripStart = await getTripStartedAt();
+  if (tripStart === null) {
+    logSuppressedTbaRevalidation({
+      reason: 'revalidate-no-trip',
+      stationName: parsed.stationName,
+      phaseId,
+    });
+    return 'suppress';
+  }
+
+  const [routeRaw, destRaw, registeredSig] = await Promise.all([
+    AsyncStorage.getItem(ROUTE_KEY),
+    AsyncStorage.getItem(DESTINATION_KEY),
+    getRegisteredTripRouteSig(),
+  ]);
+  const route: Route = safeParseRoute(routeRaw);
+  const destinationName = parseDestinationName(destRaw);
+  const currentSig = routeSignature(route, destinationName);
+
+  // registeredSig 부재 / 현재 sig 미산출 / 두 값 불일치 모두 mismatch로 묶는다.
+  // (registeredSig 부재는 cancelTripBoundAlarms 직후 잔여 OS 발사 케이스.)
+  if (registeredSig === null || currentSig === null || registeredSig !== currentSig) {
+    logSuppressedTbaRevalidation({
+      reason: 'revalidate-route-sig-mismatch',
+      stationName: parsed.stationName,
+      phaseId,
+    });
+    return 'suppress';
+  }
+
+  // 방어 검증: parsed stationName이 현재 waypoint 시퀀스에 존재해야 한다.
+  // currentSig !== null이면 route, destinationName 둘 다 non-null 보장됨.
+  const targets = resolveAllTargets(route as NonNullable<Route>, destinationName as string);
+  if (!targets.some((t) => t.name === parsed.stationName)) {
+    logSuppressedTbaRevalidation({
+      reason: 'revalidate-waypoint-mismatch',
+      stationName: parsed.stationName,
+      phaseId,
+    });
+    return 'suppress';
+  }
+
+  return 'pass';
+}
+
+/**
+ * 사전 예약된 `alarm:` / `tba:` 알림이 OS에 의해 발사된 직후 클라이언트 상태를 갱신한다.
  * 사전 예약 알람은 클라이언트 콜백을 거치지 않으므로(`alarmScheduler.ts`), 이 함수가
  * FG/BG 양쪽 발화 모두에 대한 상태 동기화 단일 진입점이다.
  *
@@ -37,6 +150,9 @@ async function getCurrentDestinationId(): Promise<string | null> {
  *   해당 phase를 이미 발화된 것으로 간주해 중복 발화를 막는다.
  * - LAST_FIRED_ALARM_STATION_NAME_KEY를 해당 역 이름으로 갱신 → BGAppRefreshTask가
  *   다음 사이클에서 Arrival API를 올바른 기준역으로 호출.
+ *
+ * `tba:` (#918 A3 PR2, #729 흡수): revalidateTbaAlarm이 stale/misfire를 차단한 뒤 위 동작 수행.
+ * `alarm:` 경로는 BoardingLock scheduler cancel/reschedule이 SSOT이므로 별도 재검증 없이 통과.
  */
 export async function reconcileScheduledAlarmDelivery(
   identifier: string,
@@ -46,8 +162,12 @@ export async function reconcileScheduledAlarmDelivery(
   // `alarm:` prefix와 무관 — graceful no-op for non-tba identifier.
   await recordFiredAlarm({ identifier, actualFireMs });
 
-  const parsed = parseScheduledAlarmIdentifier(identifier);
+  const parsed = parseAlarmIdentifier(identifier);
   if (!parsed) return;
+
+  if (parsed.prefix === 'tba' && (await revalidateTbaAlarm(parsed)) === 'suppress') {
+    return;
+  }
 
   const destinationId = await getCurrentDestinationId();
   // destinationId가 없으면 이미 trip이 종료/변경된 알람의 잔여 발화 — 상태 갱신 스킵.
@@ -80,14 +200,23 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
     await recordFiredAlarm({ identifier: n.request.identifier, actualFireMs: fireMs });
   }
 
+  // #918 A3 PR2 — `tba:` 항목은 발사 시점 재검증을 거친다. suppress인 경우 fired set /
+  // lastStationName 갱신에 포함하지 않아 stale 알람이 후속 상태(BG arrival 기준역 등)를 오염시키지
+  // 않게 한다. `alarm:` 경로는 기존 BoardingLock SSOT을 신뢰해 통과.
+  const accepted: ParsedAlarmIdentifier[] = [];
+  for (const n of presented) {
+    const parsed = parseAlarmIdentifier(n.request.identifier);
+    if (!parsed) continue;
+    if (parsed.prefix === 'tba' && (await revalidateTbaAlarm(parsed)) === 'suppress') continue;
+    accepted.push(parsed);
+  }
+
   const destinationId = await getCurrentDestinationId();
   let lastStationName: string | null = null;
   if (destinationId) {
     const fired = await getFiredAlarms(destinationId);
     let firedChanged = false;
-    for (const n of presented) {
-      const parsed = parseScheduledAlarmIdentifier(n.request.identifier);
-      if (!parsed) continue;
+    for (const parsed of accepted) {
       const key = `${parsed.phaseId}:${parsed.stationName}`;
       if (!fired.has(key)) {
         fired.add(key);
@@ -98,9 +227,8 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
     if (firedChanged) await setFiredAlarms(destinationId, fired);
   } else {
     // destinationId 미설정 — fired set 갱신은 스킵하고 lastStationName만 추출.
-    for (const n of presented) {
-      const parsed = parseScheduledAlarmIdentifier(n.request.identifier);
-      if (parsed) lastStationName = parsed.stationName;
+    for (const parsed of accepted) {
+      lastStationName = parsed.stationName;
     }
   }
   if (lastStationName) await setLastFiredAlarmStationName(lastStationName);

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -1,11 +1,13 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
 import { alarmKey, resolveAllTargets, type AlarmEvent } from './stationAlarm';
 import { buildAlarmContent } from './stationNotification';
 import type { AlarmType } from '../../../shared/types/alarm';
 import { isSameStationName, type Route } from '../../../shared/utils/stationRoute';
 import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
+import { TRIP_BOUND_ROUTE_SIG_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
 import { recordScheduledAlarm } from './prescheduledMetrics';
 
@@ -170,13 +172,70 @@ export async function prescheduleStationAlerts(
 }
 
 /**
- * identifier 형식: `tba:${phaseId}:${stationName}`.
+ * identifier 형식: `tba:${phaseId}:${stationName}` 또는 같은 (phaseId, stationName) 중복 시
+ * `tba:${phaseId}:${stationName}:${n}` (n ≥ 1).
  * alarmScheduler의 `alarm:` prefix와 분리해 trip-bound 사전 예약만 식별/취소한다.
  */
 export function tripBoundAlarmIdentifier(
   event: Pick<AlarmEvent, 'phaseId' | 'stationName'>,
 ): string {
   return `${TRIP_BOUND_ALARM_PREFIX}${alarmKey(event)}`;
+}
+
+export interface ParsedTripBoundAlarmIdentifier {
+  phaseId: string;
+  stationName: string;
+}
+
+/**
+ * `tripBoundAlarmIdentifier()`의 역연산 (#918 A3 PR2). prefix 매칭 + phaseId/stationName 분리.
+ * 같은 station이 route 안에 두 번 등장해 `:n` occurrence suffix가 붙은 경우(`prescheduleStationAlerts`
+ * 내부 로직)에도 station name 안에 콜론이 합쳐진 채 반환된다 — 이후 waypoint 매칭 단계에서 자연스럽게
+ * mismatch로 떨어지므로 별도 후처리는 불필요(재검증 안전).
+ *
+ * prefix가 다르거나 phaseId/stationName이 비어 있으면 null.
+ */
+export function parseTripBoundAlarmIdentifier(
+  identifier: string,
+): ParsedTripBoundAlarmIdentifier | null {
+  if (!identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) return null;
+  const rest = identifier.slice(TRIP_BOUND_ALARM_PREFIX.length);
+  const colon = rest.indexOf(':');
+  if (colon <= 0) return null;
+  const stationName = rest.slice(colon + 1);
+  if (!stationName) return null;
+  return { phaseId: rest.slice(0, colon), stationName };
+}
+
+/**
+ * #918 A3 PR2 (#729 흡수) — preschedule 시점의 route signature 영속화 SSOT.
+ * useTripBoundAlarmScheduler가 preschedule 성공 직후 1회 write하고, cancel 시 clear한다.
+ * scheduledAlarmReceiver가 fire 시점에 *현재* sig와 비교해 stale 알람을 식별한다.
+ *
+ * 모든 함수는 graceful — storage 실패는 측정 정확도만 영향, 본 흐름 무관.
+ */
+export async function setRegisteredTripRouteSig(sig: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(TRIP_BOUND_ROUTE_SIG_KEY, sig);
+  } catch {
+    // graceful — 다음 preschedule cycle에서 재시도.
+  }
+}
+
+export async function getRegisteredTripRouteSig(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(TRIP_BOUND_ROUTE_SIG_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function clearRegisteredTripRouteSig(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(TRIP_BOUND_ROUTE_SIG_KEY);
+  } catch {
+    // graceful.
+  }
 }
 
 /**
@@ -251,4 +310,6 @@ export async function cancelTripBoundAlarms(): Promise<void> {
   if (cancelled > 0) {
     logger.info(`cancelled ${cancelled} trip-bound alarms`);
   }
+  // #918 A3 PR2: sig storage도 함께 cleanup — 다음 reconcile 시 stale sig가 남지 않게.
+  await clearRegisteredTripRouteSig();
 }

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -107,6 +107,12 @@ export const PRESCHEDULED_LEDGER_KEY = 'subway-now:prescheduled-ledger';
 // 형식: 숫자(epoch ms) 문자열.
 export const LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY =
   'subway-now:last-uploaded-prescheduled-trip-start';
+// #918 A3 PR2 — preschedule 시점의 route signature 스냅샷 (#729 흡수).
+// `tba:` 알람이 OS로 발사돼 클라가 reconcile할 때 *현재* sig와 비교해 trip 도중 route가
+// 바뀐(목적지 변경/환승 재산정/노선 갈아탐) 잔여 알람을 식별·억제한다.
+// useTripBoundAlarmScheduler가 preschedule 성공 직후 write, cancel 시 clear.
+// 형식: string (boardingLockScheduler.routeSignature 결과).
+export const TRIP_BOUND_ROUTE_SIG_KEY = 'subway-now:trip-bound-route-sig';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.


### PR DESCRIPTION
## Summary
- `tba:` OS-fired 사전 예약 알람을 reconcile하기 직전 3중 재검증으로 stale/misfire 차단 (#729 흡수).
- `useTripBoundAlarmScheduler`가 preschedule 직후 route signature를 영속 SSOT에 write, cancel 시 clear.
- 재검증 실패 시 `logSuppressedTbaRevalidation` 적재 + fired set / lastStationName 갱신을 skip해 BG arrival 기준역 오염 차단.

## 변경 사항
- `tripBoundScheduler.ts`: `parseTripBoundAlarmIdentifier`, sig storage helpers (`set/get/clearRegisteredTripRouteSig`) 추가. `cancelTripBoundAlarms`가 sig도 함께 cleanup.
- `scheduledAlarmReceiver.ts`: `reconcileScheduledAlarmDelivery` + `drainDeliveredScheduledAlarms`가 `tba:` 분기에서 `revalidateTbaAlarm` 호출. `alarm:` 경로는 BoardingLock SSOT 신뢰해 무변경.
- `alarmLog.ts`: `revalidate-no-trip` / `revalidate-route-sig-mismatch` / `revalidate-waypoint-mismatch` 3종 reason + `logSuppressedTbaRevalidation` helper.
- `useTripBoundAlarmScheduler.ts`: preschedule 성공 직후 `setRegisteredTripRouteSig(nextSig)`.
- 신규 storage key: `TRIP_BOUND_ROUTE_SIG_KEY`.

## 테스트
- 단위 테스트 추가 (재검증 3종 분기 + drain `tba:` suppression + sig storage round-trip + parse helper).
- `npm test` ALL GREEN, coverage 100%.
- `npm run lint` / `npm run type-check` 통과.

## 제약
- PR3+(rolling window) / PR4(backend) / PR5(E2E) scope 미포함.
- 본 PR은 OS local notification fire-time을 hook할 수 없는 expo-notifications 제약 안에서, OS가 발사한 알람을 reconcile 단계에서 식별·억제하는 client-side gate를 제공.

Closes part of #918 (PR2/5 of A3 stack).
Absorbs #729.

## Test plan
- [x] CI Type Check & Test pass
- [ ] 실기기: 목적지 변경 후 사전 예약된 알람이 OS 시각에 발사돼도 stale로 식별·suppression 확인 (DebugModal `revalidate-*` reason 적재)
- [ ] 실기기: 정상 trip에서 `tba:` 알람이 fire 시 정상 reconcile 진행 확인