### PR TITLE
feat(#1175): lockless 토글 학습 funnel 4 step telemetry

### DIFF
--- a/src/features/alarm/api/telemetryBackend.ts
+++ b/src/features/alarm/api/telemetryBackend.ts
@@ -10,6 +10,10 @@ import type { TripRecallResult } from '../utils/recallMetrics';
 import type { PrescheduledMetricsResult } from '../utils/prescheduledMetrics';
 import type { PrescheduledMissContext } from '../utils/prescheduledMissContext';
 import { createLogger } from '../../../shared/utils/logger';
+import {
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from '../../../shared/utils/telemetryHttp';
 
 const log = createLogger('telemetryBackend');
 
@@ -20,30 +24,11 @@ export interface TelemetryUploadResult {
   status?: number;
 }
 
-/** fetch 타임아웃 — 텔레메트리는 후속 알람 흐름에 영향 주지 않게 짧게 끊는다. */
-const REQUEST_TIMEOUT_MS = 5000;
-
-function getBackendUrl(): string | null {
-  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
-  if (!url) return null;
-  return url.replace(/\/$/, '');
-}
-
-async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 export async function uploadSilentPushTelemetry(
   token: string,
   payload: SilentPushTelemetryPayload,
 ): Promise<TelemetryUploadResult> {
-  const base = getBackendUrl();
+  const base = getAlarmBackendUrl();
   if (!base) {
     log.info('ALARM_BACKEND_URL not set — skip telemetry upload');
     return { ok: false, skipped: true };
@@ -63,7 +48,7 @@ export async function uploadSilentPushTelemetry(
   };
 
   try {
-    const res = await fetchWithTimeout(`${base}/telemetry/silent-push`, {
+    const res = await fetchWithTelemetryTimeout(`${base}/telemetry/silent-push`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
@@ -92,7 +77,7 @@ export async function uploadRecallTelemetry(
   token: string,
   recall: TripRecallResult,
 ): Promise<TelemetryUploadResult> {
-  const base = getBackendUrl();
+  const base = getAlarmBackendUrl();
   if (!base) {
     log.info('ALARM_BACKEND_URL not set — skip recall upload');
     return { ok: false, skipped: true };
@@ -112,7 +97,7 @@ export async function uploadRecallTelemetry(
   };
 
   try {
-    const res = await fetchWithTimeout(`${base}/telemetry/recall`, {
+    const res = await fetchWithTelemetryTimeout(`${base}/telemetry/recall`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
@@ -141,7 +126,7 @@ export async function uploadPrescheduledTelemetry(
   metrics: PrescheduledMetricsResult,
   missContext?: PrescheduledMissContext,
 ): Promise<TelemetryUploadResult> {
-  const base = getBackendUrl();
+  const base = getAlarmBackendUrl();
   if (!base) {
     log.info('ALARM_BACKEND_URL not set — skip prescheduled upload');
     return { ok: false, skipped: true };
@@ -164,7 +149,7 @@ export async function uploadPrescheduledTelemetry(
   }
 
   try {
-    const res = await fetchWithTimeout(`${base}/telemetry/prescheduled`, {
+    const res = await fetchWithTelemetryTimeout(`${base}/telemetry/prescheduled`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),

--- a/src/features/settings/api/__tests__/locklessFunnelBackend.test.ts
+++ b/src/features/settings/api/__tests__/locklessFunnelBackend.test.ts
@@ -1,0 +1,101 @@
+import { uploadLocklessFunnelStep } from '../locklessFunnelBackend';
+import { LOCKLESS_FUNNEL_STEPS } from '../../utils/locklessFunnel';
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const FIXED_NOW = 1_700_000_000_000;
+
+describe('uploadLocklessFunnelStep', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+    jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  it('URL 미설정이면 skipped=true', async () => {
+    const result = await uploadLocklessFunnelStep('tok', LOCKLESS_FUNNEL_STEPS.VIEWED);
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('빈 token이면 skipped=true', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    const result = await uploadLocklessFunnelStep('', LOCKLESS_FUNNEL_STEPS.ON);
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('정상 응답 시 ok=true + body에 token/step/at 직렬화', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    const result = await uploadLocklessFunnelStep('tok', LOCKLESS_FUNNEL_STEPS.OFF);
+    expect(result).toEqual({ ok: true, status: 200 });
+    const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test/telemetry/lockless-funnel');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      token: 'tok',
+      step: LOCKLESS_FUNNEL_STEPS.OFF,
+      at: FIXED_NOW,
+    });
+  });
+
+  it('meta 제공 시 body에 포함된다', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    await uploadLocklessFunnelStep('tok', LOCKLESS_FUNNEL_STEPS.RE_ON, { src: 'unit' });
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(JSON.parse(init.body).meta).toEqual({ src: 'unit' });
+  });
+
+  it('non-OK 응답 시 ok=false + status 반환', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+    const result = await uploadLocklessFunnelStep('tok', LOCKLESS_FUNNEL_STEPS.VIEWED);
+    expect(result).toEqual({ ok: false, status: 500 });
+  });
+
+  it('fetch throw 시 ok=false (throw 안 함)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('net'));
+    const result = await uploadLocklessFunnelStep('tok', LOCKLESS_FUNNEL_STEPS.VIEWED);
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('REQUEST_TIMEOUT_MS 경과 시 AbortController가 fetch를 중단한다', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+    jest.useFakeTimers();
+    (globalThis.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    );
+    const promise = uploadLocklessFunnelStep('tok', LOCKLESS_FUNNEL_STEPS.VIEWED);
+    jest.advanceTimersByTime(5000);
+    const result = await promise;
+    expect(result).toEqual({ ok: false });
+    jest.useRealTimers();
+  });
+
+  it('URL 끝 슬래시는 제거된다', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    await uploadLocklessFunnelStep('tok', LOCKLESS_FUNNEL_STEPS.ON);
+    const [url] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test/telemetry/lockless-funnel');
+  });
+});

--- a/src/features/settings/api/locklessFunnelBackend.ts
+++ b/src/features/settings/api/locklessFunnelBackend.ts
@@ -12,11 +12,12 @@
 
 import type { LocklessFunnelStep } from '../utils/locklessFunnel';
 import { createLogger } from '../../../shared/utils/logger';
+import {
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from '../../../shared/utils/telemetryHttp';
 
 const log = createLogger('locklessFunnelBackend');
-
-/** fetch 타임아웃 — telemetry는 후속 흐름 차단 금지. */
-const REQUEST_TIMEOUT_MS = 5000;
 
 export interface LocklessFunnelUploadResult {
   ok: boolean;
@@ -25,28 +26,12 @@ export interface LocklessFunnelUploadResult {
   status?: number;
 }
 
-function getBackendUrl(): string | null {
-  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
-  if (!url) return null;
-  return url.replace(/\/$/, '');
-}
-
-async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 export async function uploadLocklessFunnelStep(
   token: string,
   step: LocklessFunnelStep,
   meta?: Record<string, unknown>,
 ): Promise<LocklessFunnelUploadResult> {
-  const base = getBackendUrl();
+  const base = getAlarmBackendUrl();
   if (!base) {
     log.info('ALARM_BACKEND_URL not set — skip funnel upload');
     return { ok: false, skipped: true };
@@ -65,7 +50,7 @@ export async function uploadLocklessFunnelStep(
   }
 
   try {
-    const res = await fetchWithTimeout(`${base}/telemetry/lockless-funnel`, {
+    const res = await fetchWithTelemetryTimeout(`${base}/telemetry/lockless-funnel`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),

--- a/src/features/settings/api/locklessFunnelBackend.ts
+++ b/src/features/settings/api/locklessFunnelBackend.ts
@@ -1,0 +1,82 @@
+/**
+ * Lockless funnel telemetry backend client (#1175, Epic #1008).
+ *
+ * alarm-worker `/telemetry/lockless-funnel` endpoint로 funnel step 1건을 POST 한다.
+ * 동작 변경 없음 — 순수 측정 인프라. 기존 telemetryBackend.ts와 동형 graceful 정책:
+ *   - URL 미설정 → skipped=true (no-op)
+ *   - fetch 실패 → ok=false 반환 (throw 안 함)
+ *
+ * apnsToken은 alarm flow에서 이미 등록된 device 식별자를 그대로 사용해
+ * funnel을 device 단위로 dedup 가능하게 한다.
+ */
+
+import type { LocklessFunnelStep } from '../utils/locklessFunnel';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('locklessFunnelBackend');
+
+/** fetch 타임아웃 — telemetry는 후속 흐름 차단 금지. */
+const REQUEST_TIMEOUT_MS = 5000;
+
+export interface LocklessFunnelUploadResult {
+  ok: boolean;
+  /** URL/token 미설정 등으로 호출 자체가 건너뛰어진 경우. */
+  skipped?: boolean;
+  status?: number;
+}
+
+function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function uploadLocklessFunnelStep(
+  token: string,
+  step: LocklessFunnelStep,
+  meta?: Record<string, unknown>,
+): Promise<LocklessFunnelUploadResult> {
+  const base = getBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip funnel upload');
+    return { ok: false, skipped: true };
+  }
+  if (!token) {
+    return { ok: false, skipped: true };
+  }
+
+  const body: Record<string, unknown> = {
+    token,
+    step,
+    at: Date.now(),
+  };
+  if (meta !== undefined) {
+    body.meta = meta;
+  }
+
+  try {
+    const res = await fetchWithTimeout(`${base}/telemetry/lockless-funnel`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      log.warn(`funnel upload failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('funnel upload error', e);
+    return { ok: false };
+  }
+}

--- a/src/features/settings/store/__tests__/useSettingsStore.test.ts
+++ b/src/features/settings/store/__tests__/useSettingsStore.test.ts
@@ -9,6 +9,7 @@ import {
   setSentryOptIn,
 } from '../../../../shared/infra/monitoring/sentryInit';
 import { useBoardingLockStore } from '../../../alarm/store/useBoardingLockStore';
+import { emitLocklessToggleTransition } from '../../utils/locklessFunnel';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
@@ -17,6 +18,10 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 jest.mock('../../../../shared/infra/monitoring/sentryInit', () => ({
   getSentryOptIn: jest.fn().mockResolvedValue(false),
   setSentryOptIn: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../utils/locklessFunnel', () => ({
+  emitLocklessToggleTransition: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../../../alarm/store/useBoardingLockStore', () => ({
@@ -220,6 +225,19 @@ describe('useSettingsStore', () => {
     (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
     await useSettingsStore.getState().loadLocklessStationPassed();
     expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
+  });
+
+  // #1175 — lockless funnel transition emit
+  it('setLocklessStationPassed: prev=true → next=false 시 emit(true, false) 호출', async () => {
+    useSettingsStore.setState({ locklessStationPassed: true });
+    await useSettingsStore.getState().setLocklessStationPassed(false);
+    expect(emitLocklessToggleTransition).toHaveBeenCalledWith(true, false);
+  });
+
+  it('setLocklessStationPassed: prev=false → next=true 시 emit(false, true) 호출', async () => {
+    useSettingsStore.setState({ locklessStationPassed: false });
+    await useSettingsStore.getState().setLocklessStationPassed(true);
+    expect(emitLocklessToggleTransition).toHaveBeenCalledWith(false, true);
   });
 
   // ── #1038 — sentryOptIn (default OFF, opt-in only) ──

--- a/src/features/settings/store/useSettingsStore.ts
+++ b/src/features/settings/store/useSettingsStore.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../shared/constants/storageKeys';
 import { getSentryOptIn, setSentryOptIn } from '../../../shared/infra/monitoring/sentryInit';
 import { useBoardingLockStore } from '../../alarm/store/useBoardingLockStore';
+import { emitLocklessToggleTransition } from '../utils/locklessFunnel';
 
 /**
  * Settings store — ADR 후속 Step 6 (#892).
@@ -114,6 +115,8 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   },
 
   setLocklessStationPassed: async (enabled: boolean) => {
+    // #1175 — funnel transition emit. set() 전에 prev를 캡처해야 정확한 분기를 얻는다.
+    const prev = useSettingsStore.getState().locklessStationPassed;
     set({ locklessStationPassed: enabled });
     await AsyncStorage.setItem(LOCKLESS_STATION_PASSED_KEY, JSON.stringify(enabled));
     // B1 (ADR-013): 토글 OFF 전환 시 활성 BoardingLock을 즉시 해제하여
@@ -121,6 +124,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     if (!enabled) {
       await useBoardingLockStore.getState().releaseLock();
     }
+    await emitLocklessToggleTransition(prev, enabled);
   },
 
   loadLocklessStationPassed: async () => {

--- a/src/features/settings/utils/__tests__/locklessFunnel.test.ts
+++ b/src/features/settings/utils/__tests__/locklessFunnel.test.ts
@@ -1,0 +1,86 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  LOCKLESS_FUNNEL_STEPS,
+  emitLocklessToggleTransition,
+  emitLocklessToggleViewed,
+  setLocklessFunnelEmitter,
+  type LocklessFunnelEmitter,
+} from '../locklessFunnel';
+import { LOCKLESS_FUNNEL_SEEN_OFF_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+describe('locklessFunnel', () => {
+  let emitter: jest.Mock;
+
+  beforeEach(() => {
+    emitter = jest.fn<ReturnType<LocklessFunnelEmitter>, Parameters<LocklessFunnelEmitter>>(
+      async () => undefined,
+    );
+    setLocklessFunnelEmitter(emitter as unknown as LocklessFunnelEmitter);
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockReset();
+    (AsyncStorage.setItem as jest.Mock).mockReset();
+  });
+
+  it('emitLocklessToggleViewed: viewed step을 emit한다', async () => {
+    await emitLocklessToggleViewed();
+    expect(emitter).toHaveBeenCalledWith(LOCKLESS_FUNNEL_STEPS.VIEWED, undefined);
+  });
+
+  it('transition: prev === next면 emit하지 않는다 (no-op)', async () => {
+    await emitLocklessToggleTransition(true, true);
+    await emitLocklessToggleTransition(false, false);
+    expect(emitter).not.toHaveBeenCalled();
+  });
+
+  it('transition true → false: off emit + seenOff 플래그 set', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+    await emitLocklessToggleTransition(true, false);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      LOCKLESS_FUNNEL_SEEN_OFF_KEY,
+      'true',
+    );
+    expect(emitter).toHaveBeenCalledWith(LOCKLESS_FUNNEL_STEPS.OFF, undefined);
+  });
+
+  it('transition false → true (seenOff 없음): on emit', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+    await emitLocklessToggleTransition(false, true);
+    expect(emitter).toHaveBeenCalledWith(LOCKLESS_FUNNEL_STEPS.ON, undefined);
+  });
+
+  it('transition false → true (seenOff = "true"): re_on emit', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('true');
+    await emitLocklessToggleTransition(false, true);
+    expect(emitter).toHaveBeenCalledWith(LOCKLESS_FUNNEL_STEPS.RE_ON, undefined);
+  });
+
+  it('transition false → true: seenOff getItem 실패 시 on으로 분류 (graceful)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+    await emitLocklessToggleTransition(false, true);
+    expect(emitter).toHaveBeenCalledWith(LOCKLESS_FUNNEL_STEPS.ON, undefined);
+  });
+
+  it('transition true → false: markSeenOff setItem 실패해도 off는 emit된다 (graceful)', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+    await emitLocklessToggleTransition(true, false);
+    expect(emitter).toHaveBeenCalledWith(LOCKLESS_FUNNEL_STEPS.OFF, undefined);
+  });
+
+  it('emitter throw해도 토글 흐름을 막지 않는다 (warn만)', async () => {
+    emitter.mockRejectedValueOnce(new Error('sink fail'));
+    await expect(emitLocklessToggleViewed()).resolves.toBeUndefined();
+  });
+
+  it('기본 emitter는 logger 호출만 한다 (sink 미설정 동작 — setEmitter 안 한 import 경로)', async () => {
+    // 모듈을 isolated로 다시 import하면 기본 emitter(=logger)가 활성.
+    jest.isolateModules(() => {
+      const mod = require('../locklessFunnel');
+      // 호출 자체가 throw 없이 성공하면 OK (반환은 Promise).
+      return expect(mod.emitLocklessToggleViewed()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/features/settings/utils/__tests__/locklessFunnel.test.ts
+++ b/src/features/settings/utils/__tests__/locklessFunnel.test.ts
@@ -19,7 +19,7 @@ describe('locklessFunnel', () => {
     emitter = jest.fn<ReturnType<LocklessFunnelEmitter>, Parameters<LocklessFunnelEmitter>>(
       async () => undefined,
     );
-    setLocklessFunnelEmitter(emitter as unknown as LocklessFunnelEmitter);
+    setLocklessFunnelEmitter(emitter);
     jest.clearAllMocks();
     (AsyncStorage.getItem as jest.Mock).mockReset();
     (AsyncStorage.setItem as jest.Mock).mockReset();

--- a/src/features/settings/utils/locklessFunnel.ts
+++ b/src/features/settings/utils/locklessFunnel.ts
@@ -1,0 +1,110 @@
+/**
+ * Lockless 토글 학습 funnel — Epic #1008 Epic C 단기 11 (#1175).
+ *
+ * "전체역 보기" 토글이 사용자에게 어떻게 학습되는지 4 step funnel로 측정한다.
+ * B1 UX 검증용 — 토글 ON/OFF 동작 자체는 변경하지 않고 순수 측정 layer만 추가한다.
+ *
+ *  - `viewed`  : Settings 화면에 토글이 노출 (SettingsScreen 마운트 시 세션당 1회 emit)
+ *  - `on`      : OFF → ON 전환 (의미 학습 전/후 무관)
+ *  - `off`     : ON → OFF 전환 (사용자가 "이게 뭔지" 파악 후 비활성화)
+ *  - `re_on`   : 한 번 OFF 했던 사용자가 다시 ON — "이해 후 의도적 사용" 신호
+ *
+ * `re_on` 분류를 위해 "한 번이라도 OFF한 적이 있는지"를 AsyncStorage에 영속화한다
+ * (`LOCKLESS_FUNNEL_SEEN_OFF_KEY`). 키가 'true'이면 다음 ON 전환은 `re_on`이다.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LOCKLESS_FUNNEL_SEEN_OFF_KEY } from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('locklessFunnel');
+
+/** Funnel step 식별자. backend telemetry payload + 로컬 logger 양쪽에서 공유. */
+export const LOCKLESS_FUNNEL_STEPS = {
+  VIEWED: 'lockless_toggle.viewed',
+  ON: 'lockless_toggle.on',
+  OFF: 'lockless_toggle.off',
+  RE_ON: 'lockless_toggle.re_on',
+} as const;
+
+export type LocklessFunnelStep =
+  (typeof LOCKLESS_FUNNEL_STEPS)[keyof typeof LOCKLESS_FUNNEL_STEPS];
+
+/**
+ * Funnel emit sink. 기본 구현은 logger + backend client.
+ * 테스트는 jest.spyOn으로 호출 검증 — 동작 자체는 graceful (실패해도 토글 흐름 안 막음).
+ */
+export type LocklessFunnelEmitter = (
+  step: LocklessFunnelStep,
+  meta?: Record<string, unknown>,
+) => Promise<void>;
+
+let activeEmitter: LocklessFunnelEmitter = async (step, meta) => {
+  log.info(`funnel ${step}`, meta);
+};
+
+/**
+ * 기본 emitter 교체 (테스트 + backend client 주입용).
+ * 호출자가 직접 sink를 swap할 수 있게 하지만, 기본은 logger.
+ */
+export function setLocklessFunnelEmitter(emitter: LocklessFunnelEmitter): void {
+  activeEmitter = emitter;
+}
+
+async function emit(step: LocklessFunnelStep, meta?: Record<string, unknown>): Promise<void> {
+  try {
+    await activeEmitter(step, meta);
+  } catch (e) {
+    log.warn(`emit failed step=${step}`, e);
+  }
+}
+
+/**
+ * SettingsScreen 마운트 시 호출. 토글이 뷰에 노출됐음을 1회 기록.
+ * (현재 토글은 카드 안에 항상 렌더되므로 화면 진입 = 노출로 본다.)
+ */
+export async function emitLocklessToggleViewed(): Promise<void> {
+  await emit(LOCKLESS_FUNNEL_STEPS.VIEWED);
+}
+
+/** 한 번이라도 OFF로 전환한 적이 있는지 (`re_on` 분류 기준). */
+async function hasSeenOffOnce(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(LOCKLESS_FUNNEL_SEEN_OFF_KEY);
+    return raw === 'true';
+  } catch {
+    return false;
+  }
+}
+
+async function markSeenOff(): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LOCKLESS_FUNNEL_SEEN_OFF_KEY, 'true');
+  } catch {
+    // graceful — funnel은 best-effort.
+  }
+}
+
+/**
+ * 토글 transition emit. `setLocklessStationPassed` 직전에 prev 값과 next 값을 넘긴다.
+ * 동일 값(no-op)은 emit하지 않는다 — 측정 노이즈 방지.
+ */
+export async function emitLocklessToggleTransition(
+  prev: boolean,
+  next: boolean,
+): Promise<void> {
+  if (prev === next) return;
+
+  if (next === false) {
+    // ON → OFF
+    await markSeenOff();
+    await emit(LOCKLESS_FUNNEL_STEPS.OFF);
+    return;
+  }
+
+  // OFF → ON. 이전에 OFF 경험 있었으면 re_on, 아니면 on.
+  const seenOff = await hasSeenOffOnce();
+  await emit(
+    seenOff ? LOCKLESS_FUNNEL_STEPS.RE_ON : LOCKLESS_FUNNEL_STEPS.ON,
+  );
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -13,6 +13,7 @@ import { ROUTE_CATEGORIES } from '../shared/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../shared/i18n/types';
 import { useTheme, spacing, radius } from '../shared/theme';
 import { useSleepModeGuide } from '../features/settings/hooks/useSleepModeGuide';
+import { emitLocklessToggleViewed } from '../features/settings/utils/locklessFunnel';
 import { FeedbackModal } from '../features/feedback/components/FeedbackModal';
 import {
   DEBUG_MODAL_TRIGGER_RESET_MS,
@@ -64,6 +65,8 @@ export default function SettingsScreen() {
     loadRoutePreference();
     loadLocklessStationPassed();
     loadSentryOptIn();
+    // #1175 — lockless 토글 학습 funnel viewed step. SettingsScreen 진입 = 토글 노출.
+    emitLocklessToggleViewed();
   }, []);
 
   return (

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -117,6 +117,12 @@ export const ACTIVE_BOARDING_LINE_KEY = 'subway-now:active-boarding-line';
 // 최대 RECENT_ROUTES_LIMIT개(`src/shared/constants/recentDestinations.ts`)까지 보관.
 // 형식: Station[] JSON.
 export const RECENT_DESTINATIONS_KEY = 'subway-now:recent-destinations';
+// #1175 — lockless 토글 학습 funnel: 사용자가 한 번이라도 토글을 OFF로 전환한 적이
+// 있는지(즉, "전체역 보기"가 무엇을 하는지 인지 후 의도적으로 비활성화한 적이 있는지)를
+// 추적한다. ON으로 되돌리는 시점에 이 키가 'true'면 `re_on` funnel step으로 분류해
+// 학습 곡선의 "이해 후 의도적 사용" 신호로 집계한다.
+// 형식: 'true' 또는 키 부재.
+export const LOCKLESS_FUNNEL_SEEN_OFF_KEY = 'subway-now:lockless-funnel-seen-off';
 // #1038 — Sentry 에러 모니터링 opt-in 토글. 기본 OFF (opt-in only).
 // 사용자 명시 동의 전에는 외부 SaaS(Sentry)로 어떤 데이터도 전송하지 않는다.
 // 'true'일 때만 boot 시 Sentry.init 실행. DSN(EXPO_PUBLIC_SENTRY_DSN) 미설정 시 추가 no-op.

--- a/src/shared/utils/__tests__/telemetryHttp.test.ts
+++ b/src/shared/utils/__tests__/telemetryHttp.test.ts
@@ -1,0 +1,72 @@
+import {
+  TELEMETRY_REQUEST_TIMEOUT_MS,
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from '../telemetryHttp';
+
+describe('telemetryHttp', () => {
+  const originalUrl = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    if (originalUrl === undefined) {
+      delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    } else {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = originalUrl;
+    }
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  describe('getAlarmBackendUrl', () => {
+    it('returns null when env not set', () => {
+      delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+      expect(getAlarmBackendUrl()).toBeNull();
+    });
+
+    it('returns env value trimmed of trailing slash', () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.example.com/';
+      expect(getAlarmBackendUrl()).toBe('https://api.example.com');
+    });
+
+    it('returns env value as-is when no trailing slash', () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.example.com';
+      expect(getAlarmBackendUrl()).toBe('https://api.example.com');
+    });
+  });
+
+  describe('fetchWithTelemetryTimeout', () => {
+    it('resolves to response when fetch succeeds', async () => {
+      const fakeResponse = { ok: true, status: 200 } as Response;
+      global.fetch = jest.fn().mockResolvedValue(fakeResponse);
+      const res = await fetchWithTelemetryTimeout('https://x/y', { method: 'POST' });
+      expect(res).toBe(fakeResponse);
+      expect((global.fetch as jest.Mock).mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('aborts when timeout elapses', async () => {
+      jest.useFakeTimers();
+      global.fetch = jest.fn((input, init?: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+      ) as unknown as typeof fetch;
+      const promise = fetchWithTelemetryTimeout('https://x/y', { method: 'POST' });
+      jest.advanceTimersByTime(TELEMETRY_REQUEST_TIMEOUT_MS);
+      await expect(promise).rejects.toThrow('aborted');
+    });
+
+    it('clears timer when fetch resolves before timeout', async () => {
+      jest.useFakeTimers();
+      const clearSpy = jest.spyOn(global, 'clearTimeout');
+      global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+      await fetchWithTelemetryTimeout('https://x/y', { method: 'POST' });
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+  });
+
+  it('exports timeout constant', () => {
+    expect(TELEMETRY_REQUEST_TIMEOUT_MS).toBe(5000);
+  });
+});

--- a/src/shared/utils/telemetryHttp.ts
+++ b/src/shared/utils/telemetryHttp.ts
@@ -1,0 +1,31 @@
+/**
+ * Telemetry HTTP 공용 헬퍼 (#1175 SonarCloud 중복 제거).
+ *
+ * alarm-worker `/telemetry/*` 엔드포인트 호출자들이 공유하는 base URL 조회 +
+ * AbortController 기반 timeout fetch. 텔레메트리는 후속 알람 흐름을 차단하지
+ * 않도록 짧은 timeout으로 끊는다.
+ */
+
+/** fetch 타임아웃 — 텔레메트리 호출이 후속 알람 흐름에 영향 주지 않게 짧게 끊는다. */
+export const TELEMETRY_REQUEST_TIMEOUT_MS = 5000;
+
+/** alarm-worker base URL. 미설정 시 null → 호출자는 graceful skip 처리. */
+export function getAlarmBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+/** AbortController 기반 timeout fetch. 타임아웃 시 호출자가 catch. */
+export async function fetchWithTelemetryTimeout(
+  input: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TELEMETRY_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Closes #1175
Related: #1008 (Epic C 단기 11)

## Summary

"전체역 보기" 토글(`locklessStationPassed`) 학습 곡선을 측정하기 위해 4 step funnel telemetry를 추가한다. 토글 동작(BoardingLock cleanup 포함)은 불변.

## Funnel step 명세

| Step | 정의 | Emit 트리거 |
| --- | --- | --- |
| `lockless_toggle.viewed` | 토글이 사용자에게 노출 | SettingsScreen 마운트 시 1회 |
| `lockless_toggle.on` | OFF → ON 전환, 이전에 OFF한 적 없음 | `setLocklessStationPassed(true)` + `seenOff` 키 부재 |
| `lockless_toggle.off` | ON → OFF 전환 | `setLocklessStationPassed(false)` (동시에 `seenOff='true'` 영속) |
| `lockless_toggle.re_on` | OFF → ON 전환, 이전에 OFF 경험 있음 | `setLocklessStationPassed(true)` + `seenOff='true'` (학습 후 의도적 재활성 신호) |

prev === next no-op은 emit 안 함.

## 변경 파일

- `src/features/settings/utils/locklessFunnel.ts` — funnel step 상수 + emit/transition 로직 + emitter swap 인터페이스
- `src/features/settings/api/locklessFunnelBackend.ts` — alarm-worker `/telemetry/lockless-funnel` POST 클라이언트 (URL/token graceful skip, 5s timeout)
- `src/shared/constants/storageKeys.ts` — `LOCKLESS_FUNNEL_SEEN_OFF_KEY` 추가
- `src/features/settings/store/useSettingsStore.ts` — `setLocklessStationPassed`에서 prev 캡처 후 `emitLocklessToggleTransition` 호출
- `src/screens/SettingsScreen.tsx` — `emitLocklessToggleViewed` 마운트 시 1회 호출
- `src/features/settings/utils/__tests__/locklessFunnel.test.ts` — 9 케이스 (no-op / 4 step 분기 / graceful)
- `src/features/settings/api/__tests__/locklessFunnelBackend.test.ts` — 8 케이스 (skip / 성공 / non-OK / fetch throw / timeout / URL 정규화)
- `src/features/settings/store/__tests__/useSettingsStore.test.ts` — funnel transition emit 검증 2건 추가

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npx jest src/features/settings/` 73 passed (신규 파일 100% line/branch/function coverage)
- [ ] 실기기: Settings 화면 진입 → viewed log, 토글 OFF/ON 반복으로 off/on/re_on 분기 logger 확인
- [ ] backend `/telemetry/lockless-funnel` endpoint 구현 (follow-up 이슈)

## 비고

- backend endpoint는 본 PR 범위 밖. 엔드포인트 부재 시 graceful no-op(`skipped=true`).
- emit sink는 기본 logger. 후속 PR에서 `setLocklessFunnelEmitter`로 backend client 주입 wiring(apnsToken 보유 후).