### PR TITLE
feat(#1168): R-10 fusion 신호 우선순위 audit spec 적용

### DIFF
--- a/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
@@ -1,0 +1,99 @@
+import {
+  FUSION_TIER_PRIORITY,
+  getTierRank,
+  tierFor,
+  type FusionTier,
+} from '../fusionTierPriority';
+import type { FusionConfidence, FusionSource } from '../../../../shared/types/fusion';
+
+describe('fusionTierPriority (R-10, #1168)', () => {
+  describe('FUSION_TIER_PRIORITY table', () => {
+    it('spec §4.2 순서 — wifi-ssid가 최상위, gps-only가 최하위', () => {
+      expect(FUSION_TIER_PRIORITY[0]).toBe<FusionTier>('wifi-ssid');
+      expect(FUSION_TIER_PRIORITY[FUSION_TIER_PRIORITY.length - 1]).toBe<FusionTier>('gps-only');
+    });
+
+    it('boarding-lock-train-match가 position-train보다 상위', () => {
+      expect(FUSION_TIER_PRIORITY.indexOf('boarding-lock-train-match')).toBeLessThan(
+        FUSION_TIER_PRIORITY.indexOf('position-train'),
+      );
+    });
+
+    it('position-train > fused-position > fused-arrival-* > route-progress > estimator-* > gps-*', () => {
+      const order: FusionTier[] = [
+        'position-train',
+        'fused-position',
+        'fused-arrival-confirmed',
+        'fused-arrival-arriving',
+        'route-progress',
+        'estimator-live-position',
+        'estimator-arrival-eta',
+        'estimator-reanchored-hop',
+        'gps-only-underground',
+        'gps-only',
+      ];
+      const ranks = order.map((t) => FUSION_TIER_PRIORITY.indexOf(t));
+      const sorted = [...ranks].sort((a, b) => a - b);
+      expect(ranks).toEqual(sorted);
+      ranks.forEach((r) => expect(r).toBeGreaterThanOrEqual(0));
+    });
+
+    it('표에 중복 없음', () => {
+      expect(new Set(FUSION_TIER_PRIORITY).size).toBe(FUSION_TIER_PRIORITY.length);
+    });
+  });
+
+  describe('getTierRank', () => {
+    it('표에 있는 tier는 indexOf 결과 반환', () => {
+      expect(getTierRank('wifi-ssid')).toBe(0);
+      expect(getTierRank('gps-only')).toBe(FUSION_TIER_PRIORITY.length - 1);
+    });
+
+    it('표에 없는 tier(타입 위반)는 Infinity — 정렬 시 최하위', () => {
+      expect(getTierRank('unknown' as unknown as FusionTier)).toBe(Number.POSITIVE_INFINITY);
+    });
+  });
+
+  describe('tierFor — (source, confidence) → FusionTier 매핑', () => {
+    const cases: ReadonlyArray<[FusionSource, FusionConfidence, FusionTier]> = [
+      ['wifi-ssid', 'wifi-ssid', 'wifi-ssid'],
+      ['boarding-lock', 'boarding-lock', 'boarding-lock-train-match'],
+      ['boarding-lock-interp', 'boarding-lock-interp', 'estimator-live-position'],
+      ['position-train', 'position-train', 'position-train'],
+      ['position', 'arrival-confirmed', 'fused-position'],
+      ['position', 'arrival-arriving', 'fused-position'],
+      ['arrival', 'arrival-confirmed', 'fused-arrival-confirmed'],
+      ['arrival', 'arrival-arriving', 'fused-arrival-arriving'],
+      ['route-progress', 'route-progress', 'route-progress'],
+      ['gps', 'gps-only', 'gps-only'],
+      ['gps', 'gps-only-underground', 'gps-only-underground'],
+    ];
+
+    it.each(cases)('source=%s + confidence=%s → tier=%s', (source, confidence, expected) => {
+      expect(tierFor(source, confidence)).toBe(expected);
+    });
+
+    it('position source는 confidence와 무관하게 fused-position', () => {
+      expect(tierFor('position', 'arrival-confirmed')).toBe('fused-position');
+      expect(tierFor('position', 'arrival-arriving')).toBe('fused-position');
+    });
+  });
+
+  describe('tier 비교 — spec §1.4 trust 순서', () => {
+    it('position-train > fused-position', () => {
+      expect(getTierRank('position-train')).toBeLessThan(getTierRank('fused-position'));
+    });
+
+    it('fused-position > fused-arrival-confirmed', () => {
+      expect(getTierRank('fused-position')).toBeLessThan(getTierRank('fused-arrival-confirmed'));
+    });
+
+    it('route-progress > gps-only', () => {
+      expect(getTierRank('route-progress')).toBeLessThan(getTierRank('gps-only'));
+    });
+
+    it('gps-only-underground > gps-only — 지하 라벨이 한 단계 위', () => {
+      expect(getTierRank('gps-only-underground')).toBeLessThan(getTierRank('gps-only'));
+    });
+  });
+});

--- a/src/features/nearest-station/utils/fusionTierPriority.ts
+++ b/src/features/nearest-station/utils/fusionTierPriority.ts
@@ -1,0 +1,113 @@
+/**
+ * R-10 (Epic #1008, #1168) — fusion 신호 우선순위 SSOT.
+ *
+ * `docs/research/r10-fusion-signal-priority.md` §4.2의 명시 trust table을 코드로 옮긴 단일 표.
+ * 기존에는 우선순위가 `useFusedNearestStation`(771줄) 안에 if/else 5단계로 분산되어 있고,
+ * `pickFusedStation`은 동점 시 `winnerPosScore >= winnerArrScore` 한 줄로 source 라벨을 결정했다.
+ * 본 표는:
+ *
+ *   1) "어느 신호가 더 신뢰되는가"를 단일 배열로 명시 — 새 신호(wifi-ssid #913, sensor fusion #921)
+ *      추가 시 표에 한 줄 끼우면 결정 트리가 명확.
+ *   2) `pickFusedStation` 동점 tie-break에서 implicit `>=` 비교를 `getTierRank` lookup으로 교체.
+ *      현 동작과 동치(position이 arrival보다 우선)지만 spec 위반 신호가 추가될 때 자동 정렬됨.
+ *   3) tier가 결정되면 호출자가 측정/로그에 그 라벨을 사용할 수 있도록 export.
+ *
+ * 본 PR은 spec과 직접 매칭되는 (source, confidence) 조합만 등재. estimator override 단계
+ * (`boarding-lock-interp`)와 `gps-only-underground` 강등은 `useFusedNearestStation`의 별도 layer에서
+ * 처리되므로 표에 자리만 잡고 호출자는 변경하지 않는다 (B1/B2 미결인 동안 단계적 적용 — spec §6).
+ */
+
+import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
+
+/**
+ * 단일 결정 단계 라벨. 숫자가 작을수록(=배열에서 앞일수록) 더 신뢰되는 신호.
+ * 'wifi-ssid'는 #913 이후 추가될 단계로, 현재 코드 경로에서는 산출되지 않지만
+ * 자리만 미리 박아둔다(미통합이라 결정 트리에 영향 없음).
+ */
+export type FusionTier =
+  | 'wifi-ssid'
+  | 'boarding-lock-train-match'
+  | 'position-train-locked'
+  | 'position-train'
+  | 'fused-position'
+  | 'fused-arrival-confirmed'
+  | 'fused-arrival-arriving'
+  | 'route-progress'
+  | 'estimator-live-position'
+  | 'estimator-arrival-eta'
+  | 'estimator-reanchored-hop'
+  | 'gps-only-underground'
+  | 'gps-only';
+
+/**
+ * 명시 trust table — 더 앞일수록 신뢰 우선.
+ * spec `docs/research/r10-fusion-signal-priority.md` §4.2와 1:1 대응.
+ */
+export const FUSION_TIER_PRIORITY: readonly FusionTier[] = [
+  'wifi-ssid',
+  'boarding-lock-train-match',
+  'position-train-locked',
+  'position-train',
+  'fused-position',
+  'fused-arrival-confirmed',
+  'fused-arrival-arriving',
+  'route-progress',
+  'estimator-live-position',
+  'estimator-arrival-eta',
+  'estimator-reanchored-hop',
+  'gps-only-underground',
+  'gps-only',
+] as const;
+
+/**
+ * tier → rank (0 = 최고 신뢰). 동률 비교를 단일 정수 비교로 환원.
+ * `FUSION_TIER_PRIORITY` 배열 순서가 SSOT이므로 추가/재배열 시 별도 수정 불필요.
+ */
+export function getTierRank(tier: FusionTier): number {
+  // indexOf는 readonly 배열에서도 안전. 표에 없으면 -1 → 정렬 시 최상위로 잘못 가지 않도록
+  // Infinity(=최하위)로 환산.
+  const idx = FUSION_TIER_PRIORITY.indexOf(tier);
+  return idx >= 0 ? idx : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * `pickFusedStation`이 산출하는 (source, confidence) 조합을 단일 tier로 매핑한다.
+ *
+ * 매핑 규칙(spec §1.4와 일관):
+ * - source='wifi-ssid'         → 'wifi-ssid'
+ * - source='boarding-lock'     → 'boarding-lock-train-match'
+ * - source='boarding-lock-interp' → 'estimator-live-position'
+ *   (현 구현은 estimator override를 boarding-lock-interp 한 라벨로만 표시. ADR-008 stage별 세분화는
+ *    후속 — spec §6 "B2 결정 전 estimator tier 세분화 보류".)
+ * - source='position-train'    → 'position-train-locked' or 'position-train'
+ *   (lock 활성 여부는 호출자 컨텍스트라 본 함수만으로는 구분 불가 → 보수적으로 'position-train' 반환.
+ *    호출자가 lock 일치를 알고 있으면 직접 'position-train-locked' 산출.)
+ * - source='position'          → 'fused-position'
+ * - source='arrival'           → confidence='arrival-confirmed' → 'fused-arrival-confirmed'
+ *                              → confidence='arrival-arriving'  → 'fused-arrival-arriving'
+ * - source='route-progress'    → 'route-progress'
+ * - source='gps' + confidence='gps-only-underground' → 'gps-only-underground'
+ * - source='gps'               → 'gps-only'
+ */
+export function tierFor(source: FusionSource, confidence: FusionConfidence): FusionTier {
+  switch (source) {
+    case 'wifi-ssid':
+      return 'wifi-ssid';
+    case 'boarding-lock':
+      return 'boarding-lock-train-match';
+    case 'boarding-lock-interp':
+      return 'estimator-live-position';
+    case 'position-train':
+      return 'position-train';
+    case 'position':
+      return 'fused-position';
+    case 'arrival':
+      return confidence === 'arrival-confirmed'
+        ? 'fused-arrival-confirmed'
+        : 'fused-arrival-arriving';
+    case 'route-progress':
+      return 'route-progress';
+    case 'gps':
+      return confidence === 'gps-only-underground' ? 'gps-only-underground' : 'gps-only';
+  }
+}

--- a/src/features/nearest-station/utils/pickFusedStation.ts
+++ b/src/features/nearest-station/utils/pickFusedStation.ts
@@ -4,6 +4,10 @@ import type { LinePositions } from '../../../shared/types/position';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import { getArrivalPriority } from '../../../shared/constants/arrivalCodes';
 import { getTrainStatusPriority } from '../../../shared/constants/trainStatus';
+import { createLogger } from '../../../shared/utils/logger';
+import { getTierRank, tierFor } from './fusionTierPriority';
+
+const logger = createLogger('pickFusedStation');
 
 // FusionConfidence/FusionSource는 shared/types/fusion으로 추출됨 (#890, Phase 5).
 // 기존 호출자 호환을 위해 re-export 유지.
@@ -99,21 +103,60 @@ export function pickFusedStation(
   }
 
   if (winnerPriority <= 0) {
-    return {
+    const fallback: FusedStationResult = {
       result: candidates[0].candidate,
       confidence: 'gps-only',
       source: 'gps',
     };
+    logger.debug('decided', {
+      tier: tierFor(fallback.source, fallback.confidence),
+      source: fallback.source,
+      confidence: fallback.confidence,
+      candidates: candidates.length,
+    });
+    return fallback;
   }
 
-  // source 라벨은 winning priority에 실제로 기여한 신호원.
-  // 두 신호원이 같은 점수로 동점이면 정확도 우선(position) — UI/로깅에서 더 신뢰 표시.
-  const source: FusionSource =
-    winnerPosScore >= winnerArrScore ? 'position' : 'arrival';
+  // R-10 (#1168): source 라벨을 explicit FUSION_TIER_PRIORITY로 결정.
+  // 기존 `winnerPosScore >= winnerArrScore`와 동치(position이 arrival보다 상위 tier)지만,
+  // SSOT를 단일 표(`fusionTierPriority.ts`)로 두어 신호 추가/재배열 시 호출 사이트 수정 불필요.
+  const confidence = confidenceFromPriority(winnerPriority);
+  const source = pickHigherTrustSource(winnerPosScore, winnerArrScore, confidence);
 
-  return {
+  const decided: FusedStationResult = {
     result: candidates[winnerIdx].candidate,
-    confidence: confidenceFromPriority(winnerPriority),
+    confidence,
     source,
   };
+  logger.debug('decided', {
+    tier: tierFor(decided.source, decided.confidence),
+    source: decided.source,
+    confidence: decided.confidence,
+    posScore: winnerPosScore,
+    arrScore: winnerArrScore,
+    candidates: candidates.length,
+  });
+  return decided;
+}
+
+/**
+ * winning priority에 기여한 신호원 중 더 신뢰되는 source를 tier 표 기준으로 고른다.
+ *
+ * - 한쪽만 winning score에 도달했다면 그 쪽으로 확정.
+ * - 두 신호원이 같은 점수로 동률이면 `FUSION_TIER_PRIORITY` 표 순서로 결정 — position tier가
+ *   arrival tier보다 상위라 position이 우선(기존 implicit `>=` 동작과 동치).
+ */
+function pickHigherTrustSource(
+  posScore: number,
+  arrScore: number,
+  confidence: FusionConfidence,
+): FusionSource {
+  if (posScore > arrScore) return 'position';
+  if (arrScore > posScore) return 'arrival';
+  // 동점 — tier 표로 결정. position tier가 arrival tier보다 상위라 항상 'position'.
+  // 표에서 두 tier가 역전되면 본 분기가 자연스럽게 따라간다(`getTierRank` lookup).
+  const posRank = getTierRank(tierFor('position', confidence));
+  const arrRank = getTierRank(tierFor('arrival', confidence));
+  // istanbul ignore next — 현 표에서는 posRank < arrRank 보장. 표 재배열 대비 방어 분기.
+  return posRank <= arrRank ? 'position' : 'arrival';
 }


### PR DESCRIPTION
## Summary
- `src/features/nearest-station/utils/fusionTierPriority.ts` 신설 — `docs/research/r10-fusion-signal-priority.md` §4.2의 명시 trust table을 코드 SSOT로 옮김 (`FUSION_TIER_PRIORITY` + `FusionTier` union + `getTierRank` + `tierFor`).
- `pickFusedStation` 동점 source 라벨 결정을 implicit `winnerPosScore >= winnerArrScore`에서 `getTierRank` lookup으로 교체. 현 동작과 동치이지만 신호 추가/재배열 시 호출 사이트 수정 불필요.
- 결정 결과(tier/source/confidence/score)를 `logger.debug('decided', ...)`로 기록 — R-10 "우선순위 로그" acceptance 충족.

## Scope 메모
- spec §5 PR A의 full `decideFusionResult` 추출(useFusedNearestStation 771줄 리팩토링)은 본 PR 범위 밖. SSOT 표 + pickFusedStation 적용 + 로그까지가 #1168 "apply" 단계 — 이후 PR B(gateRejections 측정) / PR C(실측 임계 조정)는 별 이슈로 분리(spec §6).
- spec §6의 보류 항목 반영: estimator stage 세분화(B2)와 sensor fusion cascade 결합(B1)은 표에 자리만 잡고 호출자는 변경하지 않음.

## Test plan
- [x] `npm test` — 4766 tests / 265 suites / coverage 100%
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] code-review (low) — (none)
- [ ] 실기기 회귀 — `pickFusedStation`은 표 기반으로 같은 source/confidence를 산출하므로 동작 무변경. 로그 spam은 `logger.debug`라 production에서 `setMinLevel('warn')`로 차단됨.

Closes #1168
Related: #1008 (Epic C 단기 4번)