### PR TITLE
feat(#1173): serverProgress.received metric catalog 등록

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1512,6 +1512,16 @@ describe('POST /telemetry/prescheduled (#918 A3)', () => {
   });
 });
 
+describe('POST /telemetry/server-progress (#1173)', () => {
+  runTelemetryEndpointSuite('/telemetry/server-progress', {
+    token: 'aabbccdd11223344',
+    windowStart: 1_000,
+    windowEnd: 2_000,
+    attempts: 10,
+    received: 9,
+  });
+});
+
 describe('GET /metrics/recall/summary (#919 후속)', () => {
   async function get(env: Env): Promise<Response> {
     return app.fetch(

--- a/backend/alarm-worker/src/__tests__/serverProgressTelemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/serverProgressTelemetry.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  recordServerProgressUpload,
+  validateServerProgressUpload,
+  type ServerProgressUpload,
+} from '../serverProgressTelemetry';
+import { METRIC_KIND, MIN_SERVER_PROGRESS_RECEIVED_RATIO } from '../metrics';
+
+function base(): Record<string, unknown> {
+  return {
+    token: 'aabbccdd11223344',
+    windowStart: 1_000,
+    windowEnd: 2_000,
+    attempts: 10,
+    received: 9,
+  };
+}
+
+describe('validateServerProgressUpload', () => {
+  it('accepts a valid payload', () => {
+    const result = validateServerProgressUpload(base());
+    expect(result).not.toBeNull();
+    expect(result?.attempts).toBe(10);
+    expect(result?.received).toBe(9);
+  });
+
+  it.each([
+    ['null', null],
+    ['string', 'x'],
+  ])('rejects non-object (%s)', (_label, value) => {
+    expect(validateServerProgressUpload(value)).toBeNull();
+  });
+
+  it('rejects missing/empty token', () => {
+    expect(validateServerProgressUpload({ ...base(), token: '' })).toBeNull();
+    const noToken = base();
+    delete noToken.token;
+    expect(validateServerProgressUpload(noToken)).toBeNull();
+  });
+
+  it.each([
+    ['windowStart', Number.NaN],
+    ['windowStart', 'x'],
+    ['windowEnd', Number.NaN],
+    ['windowEnd', 'x'],
+  ])('rejects non-finite %s (%p)', (field, value) => {
+    expect(validateServerProgressUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects windowEnd < windowStart', () => {
+    expect(
+      validateServerProgressUpload({ ...base(), windowStart: 2_000, windowEnd: 1_000 }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['attempts', -1],
+    ['attempts', 1.5],
+    ['attempts', Number.NaN],
+    ['attempts', 'x'],
+    ['received', -1],
+    ['received', 1.5],
+  ])('rejects non-natural %s (%p)', (field, value) => {
+    expect(validateServerProgressUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects received > attempts', () => {
+    expect(
+      validateServerProgressUpload({ ...base(), attempts: 2, received: 3 }),
+    ).toBeNull();
+  });
+
+  it('accepts attempts=0, received=0 (idle window — caller decides whether to upload)', () => {
+    const result = validateServerProgressUpload({ ...base(), attempts: 0, received: 0 });
+    expect(result).not.toBeNull();
+    expect(result?.attempts).toBe(0);
+  });
+});
+
+describe('recordServerProgressUpload', () => {
+  function makeWriter() {
+    return { writeDataPoint: vi.fn() };
+  }
+
+  it('writes hit + total data points for non-zero rate', () => {
+    const writer = makeWriter();
+    const payload: ServerProgressUpload = {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      attempts: 10,
+      received: 9,
+    };
+    recordServerProgressUpload(writer, payload);
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(2);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain(`phase3:${METRIC_KIND.SERVER_PROGRESS_RECEIVED}:hit`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.SERVER_PROGRESS_RECEIVED}:total`);
+  });
+
+  it('skips zero-hit point (writes only total)', () => {
+    const writer = makeWriter();
+    recordServerProgressUpload(writer, {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      attempts: 10,
+      received: 0,
+    });
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writer.writeDataPoint.mock.calls[0][0].blobs[0]).toBe(
+      `phase3:${METRIC_KIND.SERVER_PROGRESS_RECEIVED}:total`,
+    );
+  });
+
+  it('skips both points when attempts=0 (idle window — no noise)', () => {
+    const writer = makeWriter();
+    recordServerProgressUpload(writer, {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      attempts: 0,
+      received: 0,
+    });
+    expect(writer.writeDataPoint).not.toHaveBeenCalled();
+  });
+
+  it('uses 8-char token prefix for anonymous aggregate', () => {
+    const writer = makeWriter();
+    recordServerProgressUpload(writer, {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      attempts: 1,
+      received: 1,
+    });
+    const first = writer.writeDataPoint.mock.calls[0][0];
+    expect(first.blobs[1]).toBe('aabbccdd');
+    expect(first.indexes[0]).toBe('aabbccdd');
+  });
+});
+
+describe('MIN_SERVER_PROGRESS_RECEIVED_RATIO (catalog SSOT)', () => {
+  it('matches the B5 95% upgrade gate threshold (catalog default)', () => {
+    expect(MIN_SERVER_PROGRESS_RECEIVED_RATIO).toBe(0.95);
+  });
+
+  it('is a valid ratio (0 < x <= 1)', () => {
+    expect(MIN_SERVER_PROGRESS_RECEIVED_RATIO).toBeGreaterThan(0);
+    expect(MIN_SERVER_PROGRESS_RECEIVED_RATIO).toBeLessThanOrEqual(1);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -56,6 +56,10 @@ import {
   validatePrescheduledUpload,
 } from './prescheduledTelemetry';
 import {
+  recordServerProgressUpload,
+  validateServerProgressUpload,
+} from './serverProgressTelemetry';
+import {
   tokenPrefix,
   validateTelemetryUpload,
   writeTelemetryDataPoints,
@@ -507,6 +511,42 @@ app.post('/telemetry/prescheduled', async (c) => {
       // #986 — miss trip 진단 컨텍스트. 없으면 omit (JSON.stringify가 undefined 자동 제거).
       // Logpush로 사후 root cause 분석 (AE blob에는 미적재 — free-form/PII 회피).
       missContext: payload.missContext,
+    }),
+  );
+  return c.json({ ok: true });
+});
+
+/**
+ * BFF `/progress` 폴링 수신율 텔레메트리 upload (#1173, Epic #1008 C 단기 B5).
+ *
+ * Client SeoulBffProgressProvider가 폴링 윈도우 단위로 attempts/received를 집계해 업로드.
+ * TELEMETRY binding 미설정 시 graceful no-op (recall/prescheduled 동형).
+ *
+ * 본 엔드포인트는 catalog SSOT(`serverProgressReceived`)와 짝 — 95% 충족이
+ * B5(server progress) optional → required 승격 게이트 측정 신호.
+ */
+app.post('/telemetry/server-progress', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateServerProgressUpload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const writer = c.env.TELEMETRY;
+  if (writer) {
+    recordServerProgressUpload(writer, payload);
+  }
+  console.log(
+    JSON.stringify({
+      msg: 'server-progress uploaded',
+      tokenPrefix: tokenPrefix(payload.token),
+      attempts: payload.attempts,
+      received: payload.received,
+      sink: writer ? 'ae' : 'none',
     }),
   );
   return c.json({ ok: true });

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -8,7 +8,8 @@
     "SLA_PERCENTILE": 0.95,
     "METRIC_LABEL_PREFIX": "phase3",
     "MIN_RECALL_RATIO_THRESHOLD": 0.95,
-    "RECALL_THRESHOLD_CRITICAL": 0.9
+    "RECALL_THRESHOLD_CRITICAL": 0.9,
+    "MIN_SERVER_PROGRESS_RECEIVED_RATIO": 0.95
   },
   "metrics": [
     {
@@ -134,6 +135,13 @@
       "format": "histogram",
       "display": "numeric",
       "description": "#918 A3 — actualFireMs - scheduledFireMs (양수=OS 늦게 발사). p95로 OS 타이밍 SLA 추적. 시계 보정/timer drift 진단 신호."
+    },
+    {
+      "key": "serverProgressReceived",
+      "constantName": "SERVER_PROGRESS_RECEIVED",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#1173 Epic C B5 — BFF /progress 폴링 응답 수신율. hit=2xx 응답 수, total=요청 시도 수. MIN_SERVER_PROGRESS_RECEIVED_RATIO(0.95) 미달이면 backend down/네트워크 회귀 신호. Phase 4 결정 게이트 아님 — B5 optional→required 승격 게이트 측정 인프라(운영 KPI)."
     }
   ]
 }

--- a/backend/alarm-worker/src/metrics.ts
+++ b/backend/alarm-worker/src/metrics.ts
@@ -101,6 +101,14 @@ export const MIN_RECALL_RATIO_THRESHOLD = readNumber('MIN_RECALL_RATIO_THRESHOLD
  */
 export const RECALL_THRESHOLD_CRITICAL = readNumber('RECALL_THRESHOLD_CRITICAL');
 
+/**
+ * #1173 Epic C B5 — BFF `/progress` 폴링 응답 수신율 하한.
+ * 1주 baseline rolling 평균이 본 값 미만이면 backend down / 네트워크 회귀로 분류 → 운영 alert.
+ * 95% 충족 시 B5(server progress) optional → required 승격 게이트로 활용.
+ * Phase 4 결정 게이트(`decidePhaseFour`)와 분리된 운영 KPI.
+ */
+export const MIN_SERVER_PROGRESS_RECEIVED_RATIO = readNumber('MIN_SERVER_PROGRESS_RECEIVED_RATIO');
+
 /** AE 적재 label prefix — 기존 silent-push 텔레메트리와 namespace 분리. */
 const METRIC_LABEL_PREFIX = readString('METRIC_LABEL_PREFIX');
 

--- a/backend/alarm-worker/src/serverProgressTelemetry.ts
+++ b/backend/alarm-worker/src/serverProgressTelemetry.ts
@@ -1,0 +1,86 @@
+/**
+ * BFF `/progress` 폴링 수신율 텔레메트리 (#1173, Epic #1008 C 단기 B5 측정 인프라).
+ *
+ * Client(`SeoulBffProgressProvider` 등)가 폴링 윈도우(예: 1분/5분 단위 또는 trip 종료 시점)에서
+ * 시도/수신 카운트를 집계해 본 엔드포인트로 업로드한다. backend는 단순 적재:
+ *
+ *   serverProgressReceived : RateMetric (hit=received, total=attempts)
+ *                            → MIN_SERVER_PROGRESS_RECEIVED_RATIO(0.95) 미달 시 backend down/
+ *                              네트워크 회귀 운영 신호. 95% 충족이 B5 optional→required 승격 게이트.
+ *
+ * Privacy: 좌표/URL/원문 미적재. token 8자 prefix만 anonymous aggregate(recallTelemetry 동형).
+ * Phase 4 결정 게이트와 분리된 운영 KPI — `decidePhaseFour`에 포함하지 않는다.
+ *
+ * 본 모듈은 `SeoulBffProgressProvider`(#1172 진행 중)와 파일 분리 — emit wiring은 후속 PR에서
+ * 본 모듈의 `recordServerProgressUpload`만 호출하면 된다(provider 본체 미수정).
+ */
+
+import { METRIC_KIND, writeMetricDataPoints, type RateMetric } from './metrics';
+import type { AnalyticsEngineWriter } from './types';
+
+/** client → backend upload payload. */
+export interface ServerProgressUpload {
+  /** APNs device token (hex). 8자 prefix만 anonymous aggregate. */
+  token: string;
+  /** 폴링 윈도우 시작 epoch ms. */
+  windowStart: number;
+  /** 폴링 윈도우 종료 epoch ms. windowStart <= windowEnd 강제. */
+  windowEnd: number;
+  /** `/progress` 호출 시도 총 횟수 (분모). */
+  attempts: number;
+  /** 2xx 응답 수신 횟수 (분자). attempts 이하 강제. */
+  received: number;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isNonNegativeInt(v: unknown): v is number {
+  return isFiniteNumber(v) && Number.isInteger(v) && v >= 0;
+}
+
+/**
+ * payload 검증. 한 필드라도 깨졌으면 null — 호출자는 400 반환.
+ *
+ * 규칙 (recallTelemetry validateRecallUpload와 동형):
+ *   - token 비어있으면 reject
+ *   - windowStart/windowEnd는 유한수 + windowStart <= windowEnd
+ *   - attempts/received는 자연수
+ *   - received <= attempts
+ */
+export function validateServerProgressUpload(input: unknown): ServerProgressUpload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (!isFiniteNumber(obj.windowStart)) return null;
+  if (!isFiniteNumber(obj.windowEnd)) return null;
+  if (obj.windowEnd < obj.windowStart) return null;
+  if (!isNonNegativeInt(obj.attempts)) return null;
+  if (!isNonNegativeInt(obj.received)) return null;
+  if (obj.received > obj.attempts) return null;
+
+  return {
+    token: obj.token,
+    windowStart: obj.windowStart,
+    windowEnd: obj.windowEnd,
+    attempts: obj.attempts,
+    received: obj.received,
+  };
+}
+
+/**
+ * upload 1건을 AE에 적재. `writeMetricDataPoints`가 0값은 skip하므로 attempts=0 윈도우는
+ * 자동으로 noise free(rate hit/total 두 포인트 모두 0이면 적재 안 됨).
+ */
+export function recordServerProgressUpload(
+  writer: AnalyticsEngineWriter,
+  payload: ServerProgressUpload,
+): void {
+  const rate: RateMetric = {
+    kind: METRIC_KIND.SERVER_PROGRESS_RECEIVED,
+    hit: payload.received,
+    total: payload.attempts,
+  };
+  writeMetricDataPoints(writer, payload.token, rate);
+}


### PR DESCRIPTION
## Summary

Epic C 단기 9번 — B5(server progress) optional→required 승격 게이트 측정 인프라.

- `metrics.catalog.json`에 `serverProgressReceived` rate metric + `MIN_SERVER_PROGRESS_RECEIVED_RATIO`(0.95) 임계 상수 등록 (SSOT)
- `serverProgressTelemetry.ts` — BFF `/progress` 폴링 윈도우 attempts/received upload validate + AE 적재 (recallTelemetry/prescheduledTelemetry와 동형, token 8자 prefix anonymous)
- `POST /telemetry/server-progress` endpoint — TELEMETRY binding 부재 시 graceful no-op
- 1주 baseline rolling 평균 ≥ 95% 충족 시 B5 승격 신호

## Scope 분리

`SeoulBffProgressProvider` 본체 wiring(attempts/received 카운트 → endpoint 호출)은 본 PR에서 미포함:
- #1172(`backend-down-fallback-pull`)가 같은 provider를 동시 수정 중이라 conflict 회피
- 본 PR은 catalog + recorder + endpoint만 등록 → 후속 PR에서 `recordServerProgressUpload` 1줄 호출로 wire

## Test plan

- [x] `npx vitest run` — 1110 tests pass (신규 23 + endpoint 4)
- [x] `npm run type-check` clean
- [x] `npm run lint` clean (--max-warnings=0)
- [x] catalog data-driven 회귀(`METRIC_CATALOG` 순회 테스트)에 신규 entry 자동 포함

Closes #1173
Related: #1008 (Epic Lockless Over-Fire Guard, Epic C 단기 9번)