### PR TITLE
chore(#1171): autoLock confidence breakdown metric 적재

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   AUTO_LOCK_CONFIDENCE_THRESHOLD,
   AUTO_LOCK_TTL_MS,
   attemptAutoLock,
+  recordAutoLockConfidence,
 } from '../autoLock';
+import { METRIC_KIND } from '../metrics';
 import { SWAP_LOCK_TTL_MS } from '../lockSwap';
 import { type ArrivalEntry } from '../seoul';
 import type { Waypoint } from '../types';
@@ -32,7 +34,7 @@ function arrival(overrides: Partial<ArrivalEntry>): ArrivalEntry {
 
 describe('attemptAutoLock (#916 A1)', () => {
   it('단일 후보 → lock 합성 성공, origin이 segmentStations 첫 원소', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: target,
       originStation: '강남',
@@ -56,7 +58,7 @@ describe('attemptAutoLock (#916 A1)', () => {
   });
 
   it('ambiguity(같은 arvlCd 우선순위 후보 2+) → null', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: target,
       originStation: '강남',
@@ -71,7 +73,7 @@ describe('attemptAutoLock (#916 A1)', () => {
   });
 
   it('arrivals 비어있음 → null', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: target,
       originStation: '강남',
@@ -83,7 +85,7 @@ describe('attemptAutoLock (#916 A1)', () => {
   });
 
   it('subwayId 매핑 불가 line → null', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: { stationName: '역삼', line: 'XX', kind: 'intermediate' },
       originStation: '강남',
@@ -95,7 +97,7 @@ describe('attemptAutoLock (#916 A1)', () => {
   });
 
   it('legStations 비어있음(waypoints 모두 다른 line) → null', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip({
         waypoints: [{ stationName: '역삼', line: '3', kind: 'destination' }],
       }),
@@ -109,7 +111,7 @@ describe('attemptAutoLock (#916 A1)', () => {
   });
 
   it('direction=down → 하행 trainCode만 매칭', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: target,
       originStation: '강남',
@@ -124,7 +126,7 @@ describe('attemptAutoLock (#916 A1)', () => {
   });
 
   it('direction=null → 양방향 허용 (단일 후보)', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: target,
       originStation: '강남',
@@ -138,7 +140,7 @@ describe('attemptAutoLock (#916 A1)', () => {
   it('origin이 legStations 첫 원소와 같으면 dedup (중복 prepend 방지)', async () => {
     // waypoints[0].stationName === originStation인 (방어적) 케이스. 정상 운영에서는 발생하지 않지만
     // 클라가 origin name과 waypoints를 어긋나게 보낸 회귀에 대해 segmentStations에 중복이 없어야 한다.
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip({
         waypoints: [
           { stationName: '강남', line: '2', kind: 'intermediate' },
@@ -186,20 +188,20 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=2 + origin에 동일 trainCode 있음 → confidence=2 → 통과', async () => {
     // next-waypoint: T1이 arvlCd=2 (출발), origin: T1도 보임 → score=2, threshold=2 → pass
-    const lock = await callGate(makeDepartedSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]));
+    const { lock } = await callGate(makeDepartedSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]));
     expect(lock).not.toBeNull();
     expect(lock?.trainCode).toBe('T1');
   });
 
   it('arvlCd=2 + origin에 없음 + 신호 없음 → confidence=0 → null', async () => {
     // next-waypoint: T1이 arvlCd=2, origin: 빈 배열 → score=0 < threshold=2 → null
-    const lock = await callGate(makeDepartedSeoul());
+    const { lock } = await callGate(makeDepartedSeoul());
     expect(lock).toBeNull();
   });
 
   it('arvlCd=2 + origin 없음 + boardingPromptState.fired + 최근 motion → confidence=2 → 통과', async () => {
     // origin 미확인(0) + fired(+1) + lastMotionAt within 3min(+1) = 2 → pass
-    const lock = await callGate(makeDepartedSeoul(), {
+    const { lock } = await callGate(makeDepartedSeoul(), {
       boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
       lastMotionAt: NOW - 60_000, // 1분 전 — 3분 이내
     });
@@ -209,7 +211,7 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=2 + origin 없음 + fired만 있음 → confidence=1 → null', async () => {
     // origin(0) + fired(+1) = 1 < threshold=2 → null
-    const lock = await callGate(makeDepartedSeoul(), {
+    const { lock } = await callGate(makeDepartedSeoul(), {
       boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
       // lastMotionAt 미전달
     });
@@ -218,12 +220,12 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=2 + origin 없음 + 최근 motion만 있음 → confidence=1 → null', async () => {
     // origin(0) + lastMotionAt(+1) = 1 < threshold=2 → null
-    const lock = await callGate(makeDepartedSeoul(), { lastMotionAt: NOW - 60_000 });
+    const { lock } = await callGate(makeDepartedSeoul(), { lastMotionAt: NOW - 60_000 });
     expect(lock).toBeNull();
   });
 
   it('arvlCd=2 + origin 없음 + motion이 너무 오래됨(>3min) → confidence=0 → null', async () => {
-    const lock = await callGate(makeDepartedSeoul(), {
+    const { lock } = await callGate(makeDepartedSeoul(), {
       boardingPromptState: { fired: false },
       lastMotionAt: NOW - 4 * 60_000, // 4분 전 — 3분 초과
     });
@@ -232,7 +234,7 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=1(도착) — confidence gate 미적용, origin fetch 없이 정상 통과', async () => {
     // arvlCd=2가 아니므로 confidence 체크 자체를 하지 않음 → 기존 경로 유지
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: target,
       originStation: '강남',
@@ -245,7 +247,7 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
   });
 
   it('arvlCd=0(진입) — confidence gate 미적용, 정상 통과', async () => {
-    const lock = await attemptAutoLock({
+    const { lock } = await attemptAutoLock({
       trip: makeTrip(),
       targetWaypoint: target,
       originStation: '강남',
@@ -258,9 +260,110 @@ describe('attemptAutoLock RC1 confidence gate (#1018)', () => {
 
   it('arvlCd=2 + origin에 다른 trainCode만 있음 → confidence=0 → null', async () => {
     // origin arrivals에는 T2만 있고 T1은 없음 → origin 미확인(0) + 소프트 신호 없음 → null
-    const lock = await callGate(
+    const { lock } = await callGate(
       makeDepartedSeoul([arrival({ trainCode: 'T2', arvlCd: 1 })]),
     );
     expect(lock).toBeNull();
+  });
+});
+
+describe('attemptAutoLock confidence trace (#1171)', () => {
+  // 공통 헬퍼 재사용 — 본 describe는 result.confidenceTrace 분포 적재용 노출 검증.
+  function makeDepartedSeoul(originArrivals: ArrivalEntry[] = []) {
+    return makeSeoulFixtureByStation({
+      역삼: [arrival({ trainCode: 'T1', arvlCd: 2 })],
+      강남: originArrivals,
+    });
+  }
+
+  it('arvlCd=2 + origin match → trace.score=2, passed=true', async () => {
+    const result = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeDepartedSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+    });
+    expect(result.lock).not.toBeNull();
+    expect(result.confidenceTrace).toEqual({ score: 2, passed: true });
+  });
+
+  it('arvlCd=2 + 모든 신호 충족 → trace.score=4, passed=true', async () => {
+    // origin(+2) + fired(+1) + recent motion(+1) = 4
+    const result = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeDepartedSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
+      lastMotionAt: NOW - 60_000,
+    });
+    expect(result.lock).not.toBeNull();
+    expect(result.confidenceTrace).toEqual({ score: 4, passed: true });
+  });
+
+  it('arvlCd=2 + 신호 부족 → trace.score=0, passed=false, lock=null', async () => {
+    const result = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeDepartedSeoul(),
+      now: NOW,
+    });
+    expect(result.lock).toBeNull();
+    expect(result.confidenceTrace).toEqual({ score: 0, passed: false });
+  });
+
+  it('arvlCd=1 → confidence gate 미평가, trace undefined', async () => {
+    const result = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+    });
+    expect(result.lock).not.toBeNull();
+    expect(result.confidenceTrace).toBeUndefined();
+  });
+
+  it('subwayId 매핑 실패 → trace undefined (gate 미도달)', async () => {
+    const result = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: { stationName: '역삼', line: 'XX', kind: 'intermediate' },
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 2 })]),
+      now: NOW,
+    });
+    expect(result.lock).toBeNull();
+    expect(result.confidenceTrace).toBeUndefined();
+  });
+});
+
+describe('recordAutoLockConfidence (#1171)', () => {
+  it('histogram point를 AE writer에 적재 (kind=AUTO_LOCK_CONFIDENCE_BREAKDOWN)', () => {
+    const writeDataPoint = vi.fn();
+    recordAutoLockConfidence({ writeDataPoint }, 'tok-1234-rest', { score: 3, passed: true });
+    // count=1, mean=3, p95=3 세 point (writeMetricDataPoints schema). 0 sample은 없으므로 모두 적재.
+    expect(writeDataPoint).toHaveBeenCalledTimes(3);
+    const labels = writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain(`phase3:${METRIC_KIND.AUTO_LOCK_CONFIDENCE_BREAKDOWN}:count`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.AUTO_LOCK_CONFIDENCE_BREAKDOWN}:mean`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.AUTO_LOCK_CONFIDENCE_BREAKDOWN}:p95`);
+  });
+
+  it('score=0 sample → 0값 skip 동작 (count point는 적재, mean/p95는 0 skip)', () => {
+    const writeDataPoint = vi.fn();
+    recordAutoLockConfidence({ writeDataPoint }, 'tok-0000', { score: 0, passed: false });
+    // count=1 한 건만 적재 (mean=0, p95=0은 writeMetricDataPoints 0 skip).
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint.mock.calls[0][0].blobs[0]).toBe(
+      `phase3:${METRIC_KIND.AUTO_LOCK_CONFIDENCE_BREAKDOWN}:count`,
+    );
   });
 });

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -25,8 +25,15 @@
 import { pickAutoTrainCode } from './boardingPrompt';
 import { matchLine, subwayIdForLine } from './lineAlias';
 import { buildLegSegmentStations, SWAP_LOCK_TTL_MS } from './lockSwap';
+import { METRIC_KIND, writeMetricDataPoints, type HistogramMetric } from './metrics';
 import type { SeoulArrivalClient } from './seoul';
-import type { BoardingLockMeta, BoardingPromptState, Trip, Waypoint } from './types';
+import type {
+  AnalyticsEngineWriter,
+  BoardingLockMeta,
+  BoardingPromptState,
+  Trip,
+  Waypoint,
+} from './types';
 
 /**
  * 자동 lock의 TTL. lockSwap의 `SWAP_LOCK_TTL_MS`와 동일 30분 — 두 흐름 모두 "사용자 명시
@@ -102,23 +109,55 @@ export interface AttemptAutoLockInputs {
 }
 
 /**
+ * #1171 — RC1 confidence gate 평가 결과를 caller에게 노출하는 trace.
+ *
+ * `attemptAutoLock`이 confidence를 산출했을 때만 set (arvlCd=2 branch). 다른 경로
+ * (subwayId 누락, ambiguity, arvlCd!=2)에서는 undefined. caller는 본 값을 받아
+ * `metrics.autoLockConfidenceBreakdown` histogram에 적재해 운영 분포를 측정한다.
+ *
+ * threshold 튜닝은 본 측정 데이터(1주 운영)로 별도 PR에서 결정한다 — 본 PR은 측정
+ * 인프라만 추가하고 임계값(`AUTO_LOCK_CONFIDENCE_THRESHOLD=2`)은 변경하지 않는다.
+ */
+export interface AutoLockConfidenceTrace {
+  /** RC1 confidence 점수 (0~4). */
+  score: number;
+  /** threshold 통과 여부 (`score >= AUTO_LOCK_CONFIDENCE_THRESHOLD`). */
+  passed: boolean;
+}
+
+/**
+ * #1171 — attemptAutoLock 결과 + confidence trace.
+ *
+ * 기존 nullable return을 wrapping해 caller가 confidence 분포를 적재할 수 있게 한다.
+ * `lock`이 null이고 `confidenceTrace`가 set이면 RC1 gate가 차단한 케이스 (분포 측정 대상).
+ * `lock`이 null이고 `confidenceTrace`가 undefined면 다른 원인의 실패 (subwayId 등).
+ */
+export interface AutoLockAttemptResult {
+  lock: BoardingLockMeta | null;
+  confidenceTrace?: AutoLockConfidenceTrace;
+}
+
+/**
  * lockMissing trip에 대해 trainCode 자동 결정 시도.
  *
- * 성공 (return non-null):
+ * 성공 (`result.lock` non-null):
  *  - subwayId 매핑 성공
  *  - segmentStations 비어있지 않음 (origin + 같은 line 유지 구간)
  *  - arrivals 비어있지 않음
  *  - `pickAutoTrainCode`가 단일 후보로 수렴 (ambiguity 없음)
  *  - RC1 confidence gate 통과 (선택 trainCode의 arvlCd=2인 경우만 평가)
  *
- * 실패 (return null):
+ * 실패 (`result.lock` null):
  *  - 위 중 하나라도 실패 → caller가 기존 boarding-prompt push fallback 진행
+ *
+ * RC1 confidence gate가 평가된 경우(arvlCd=2 branch)에 한해 `result.confidenceTrace`가 set된다.
+ * caller는 이 값을 `metrics.autoLockConfidenceBreakdown` histogram에 적재한다 (#1171).
  *
  * 본 함수는 KV I/O를 하지 않는다 (순수 pipeline). caller가 결과를 trip에 stamp + putTrip.
  */
 export async function attemptAutoLock(
   inputs: AttemptAutoLockInputs,
-): Promise<BoardingLockMeta | null> {
+): Promise<AutoLockAttemptResult> {
   const {
     trip,
     targetWaypoint,
@@ -131,10 +170,10 @@ export async function attemptAutoLock(
   } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
-  if (!subwayId) return null;
+  if (!subwayId) return { lock: null };
 
   const legStations = buildLegSegmentStations(trip.waypoints, line);
-  if (legStations.length === 0) return null;
+  if (legStations.length === 0) return { lock: null };
   // origin은 leg의 시작점 — positions fallback이 train.stationName === origin인 케이스를
   // segmentStations.indexOf로 찾을 수 있도록 prepend. legStations 첫 원소(=waypoints[0])와
   // 중복되지 않게 dedup 한다 (이론상 origin과 waypoints[0]는 서로 다른 역이어야 하지만 방어).
@@ -142,17 +181,18 @@ export async function attemptAutoLock(
     legStations[0] === originStation ? legStations : [originStation, ...legStations];
 
   const arrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
-  if (arrivals.length === 0) return null;
+  if (arrivals.length === 0) return { lock: null };
 
   const trainCode = pickAutoTrainCode(arrivals, line, direction);
-  if (!trainCode) return null;
+  if (!trainCode) return { lock: null };
 
   // #1018 RC1 confidence gate — arvlCd=2(출발) at next-waypoint는 사용자가 이미 그 열차를
   // 타고 origin을 떠났거나, 반대로 그 열차가 사용자보다 먼저 출발했을 수 있다 (origin-pass 후보).
   // 추가 신호로 confidence를 합산해 임계 미달 시 null 반환 → prompt push fallback.
   const chosenEntry = arrivals.find((a) => a.trainCode === trainCode);
+  let confidenceTrace: AutoLockConfidenceTrace | undefined;
   if (chosenEntry?.arvlCd === ARVL_CD_DEPARTED) {
-    const confidence = await computeConfidence({
+    const score = await computeConfidence({
       trainCode,
       line,
       originStation,
@@ -161,10 +201,14 @@ export async function attemptAutoLock(
       lastMotionAt,
       now,
     });
-    if (confidence < AUTO_LOCK_CONFIDENCE_THRESHOLD) return null;
+    const passed = score >= AUTO_LOCK_CONFIDENCE_THRESHOLD;
+    // #1171 — trace는 통과/차단 양쪽 모두 set. caller가 분포 히스토그램에 적재해
+    // 1주 운영 후 threshold 튜닝 근거로 사용한다.
+    confidenceTrace = { score, passed };
+    if (!passed) return { lock: null, confidenceTrace };
   }
 
-  return {
+  const lock: BoardingLockMeta = {
     trainCode,
     line,
     subwayId,
@@ -175,6 +219,30 @@ export async function attemptAutoLock(
     // 케이스에서 existing lock을 보존할지 판단하는 마커 (사용자 명시 lock과 구분).
     autoLockedAt: now,
   };
+  return { lock, confidenceTrace };
+}
+
+/**
+ * #1171 — confidence score 한 건을 AE에 histogram sample로 적재.
+ *
+ * 호출자는 `attemptAutoLock`이 반환한 `confidenceTrace.score`를 그대로 전달한다.
+ * trace가 undefined인 경우(arvlCd!=2로 gate 미평가, 또는 더 이른 실패)는 호출 자체를
+ * skip해야 한다 — 표본 오염 방지.
+ *
+ * `writeMetricDataPoints`가 0값을 skip하므로 score=0 sample은 적재되지 않는다.
+ * 0점 분포 자체를 측정하려면 perf-report 측이 total - (1+2+3+4)로 역산한다 — 본 PR은
+ * 최소 변경 원칙으로 기존 schema 유지.
+ */
+export function recordAutoLockConfidence(
+  writer: AnalyticsEngineWriter,
+  token: string,
+  trace: AutoLockConfidenceTrace,
+): void {
+  const histogram: HistogramMetric = {
+    kind: METRIC_KIND.AUTO_LOCK_CONFIDENCE_BREAKDOWN,
+    samples: [trace.score],
+  };
+  writeMetricDataPoints(writer, token, histogram);
 }
 
 interface ComputeConfidenceInputs {

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -129,6 +129,13 @@
       "description": "#918 A3 — fired 사전 예약 알람의 station 정확도. hit=fired entry 중 alarmLog가 같은 station에서 fired outcome을 남긴 수, total=firedCount. 사전 예약 시점 prediction과 실제 trip 진행 일치도."
     },
     {
+      "key": "autoLockConfidenceBreakdown",
+      "constantName": "AUTO_LOCK_CONFIDENCE_BREAKDOWN",
+      "format": "histogram",
+      "display": "numeric",
+      "description": "#1171 — RC1 confidence gate(#1018) 평가 시 산출된 score(0~4) 분포. arvlCd=2 branch에서만 sample 적재. 본 분포로 1주 운영 후 AUTO_LOCK_CONFIDENCE_THRESHOLD(현재 2) 튜닝 결정 (낮춰서 lock 통과율↑ vs 높여서 false positive↓). p95/mean으로 threshold 후보 산출. Phase 4 결정 게이트 아님 — 운영 튜닝 측정 인프라."
+    },
+    {
       "key": "prescheduledFireDeltaMs",
       "constantName": "PRESCHEDULED_FIRE_DELTA_MS",
       "format": "histogram",

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -12,7 +12,11 @@ import {
   type SendPushResult,
 } from './apns';
 import { flipApnsEnv, pickApnsHost } from './apnsHost';
-import { attemptAutoLock, AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
+import {
+  attemptAutoLock,
+  AUTO_PROMPT_DEDUP_WINDOW_MS,
+  recordAutoLockConfidence,
+} from './autoLock';
 import {
   evaluateBoardingPromptGates,
   markPromptFired,
@@ -1516,7 +1520,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   // 자연 교체. boardingPromptState도 함께 fired stamp해 같은 cycle에서 prompt 발사를 차단.
   const targetWaypoint = pickActiveWaypoint(trip);
   if (targetWaypoint) {
-    const autoLock = await attemptAutoLock({
+    const autoLockResult = await attemptAutoLock({
       trip,
       targetWaypoint,
       originStation: display.originStation,
@@ -1527,6 +1531,13 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       boardingPromptState: trip.boardingPromptState,
       lastMotionAt: fusion.series[fusion.series.length - 1]?.ts,
     });
+    // #1171 — RC1 confidence gate가 평가된 경우(arvlCd=2 branch) score 분포를 AE에 적재.
+    // 1주 운영 후 본 분포로 AUTO_LOCK_CONFIDENCE_THRESHOLD 튜닝 결정.
+    // gate 미평가 케이스(arvlCd!=2 / 더 이른 실패)는 trace undefined → skip.
+    if (autoLockResult.confidenceTrace && env.TELEMETRY) {
+      recordAutoLockConfidence(env.TELEMETRY, trip.token, autoLockResult.confidenceTrace);
+    }
+    const autoLock = autoLockResult.lock;
     if (autoLock) {
       trip.boardingLock = autoLock;
       trip.boardingPromptState = markPromptFired(now);


### PR DESCRIPTION
## Summary
- `attemptAutoLock` 반환을 `{ lock, confidenceTrace }` 객체로 확장 — RC1 gate(#1018) 평가 시 score(0~4)와 passed 여부 노출
- `metrics.catalog.json`에 `autoLockConfidenceBreakdown` histogram 신규 추가 (Phase 4 결정 게이트 아님, **운영 튜닝 측정 인프라**)
- `recordAutoLockConfidence` helper로 AE writer에 score sample 적재 (`writeMetricDataPoints` schema 재사용)
- `scheduled.ts` cron이 `trace.score`를 `env.TELEMETRY`에 wire — arvlCd=2 branch에서만 sample 누적
- **`AUTO_LOCK_CONFIDENCE_THRESHOLD`(=2)는 본 PR에서 변경하지 않음** — 1주 운영 분포 측정 후 별도 PR에서 튜닝 결정

## 측정 catalog 추가 명시
- 새 키: `autoLockConfidenceBreakdown` (histogram, numeric)
- AE label: `phase3:autoLockConfidenceBreakdown:{count,mean,p95}`
- 분포로 산출 가능: score=0/1/2/3/4 빈도, p95 (낮춤=lock 통과율↑ / 높임=false positive↓ trade-off 데이터)

## 변경 사항
- backend tests 1083 → 1090 (+7 new): confidence trace + recordAutoLockConfidence
- backend type-check / root type-check / lint 모두 pass
- 기존 8개 RC1 gate 테스트는 `const { lock } = await attemptAutoLock(...)` 디스트럭처링으로 호환 유지

## Test plan
- [x] backend `npm test` (1090 passed)
- [x] backend `npm run type-check`
- [x] root `npm run type-check`
- [x] root `npm run lint`
- [x] CI pass 확인 후 머지

Closes #1171
Related: #1008 (Epic C 단기 7번), #1018 (RC1 confidence gate)