### PR TITLE
feat(#1167): boardingPrompt [탑승] 응답 → arvlCd 우선순위 autoLock 측정/실패 fallback 보강

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -30,6 +30,9 @@ jest.mock('../../../nearest-station/api/positionUpload', () => ({
 jest.mock('../../../../shared/utils/stationLookup', () => ({
   findStationByNameAndLine: jest.fn(),
 }));
+jest.mock('../../utils/alarmLog', () => ({
+  logBoardingPromptAutoLock: jest.fn(),
+}));
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -57,6 +60,7 @@ jest.mock('../../store/useBoardingLockStore', () => {
 });
 
 const { findStationByNameAndLine } = jest.requireMock('../../../../shared/utils/stationLookup');
+const { logBoardingPromptAutoLock } = jest.requireMock('../../utils/alarmLog');
 const { __mockCreateLock: createLockMock } = jest.requireMock(
   '../../store/useBoardingLockStore',
 );
@@ -153,6 +157,12 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
       }),
     );
     expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
+    // #1167 — autolock-success telemetry
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-success',
+      originStation: '강남',
+      line: '2',
+    });
   });
 
   it('기본 탭 ($default) → boarded 분기와 동일 처리', async () => {
@@ -276,6 +286,121 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  // #1167 — autoLock telemetry + lock-failed fallback
+  it('destinationId null → autolock-no-trip telemetry', async () => {
+    const deps = makeDeps({ destinationId: null });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-no-trip',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  it('arrivals null → autolock-arrivals-empty telemetry', async () => {
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-arrivals-empty',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  it('line 후보 0개 (모두 필터됨) → autolock-arrivals-empty telemetry', async () => {
+    const arrival: StationArrival = {
+      up: [
+        {
+          destination: '',
+          arrivalMinutes: 1,
+          arrivalSeconds: 60,
+          statusMessage: '',
+          trainCode: 'T1',
+          line: '9', // line 불일치 → 필터됨
+          receivedAtMs: 0,
+          arrivalCode: 2,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+      ],
+      down: [],
+    };
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-arrivals-empty',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  it('ambiguity (same priority 후보 2+) → autolock-ambiguity telemetry', async () => {
+    const arrival: StationArrival = {
+      up: [
+        {
+          destination: '',
+          arrivalMinutes: 1,
+          arrivalSeconds: 60,
+          statusMessage: '',
+          trainCode: 'T1',
+          line: '2',
+          receivedAtMs: 0,
+          arrivalCode: 2,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+        {
+          destination: '',
+          arrivalMinutes: 2,
+          arrivalSeconds: 120,
+          statusMessage: '',
+          trainCode: 'T2',
+          line: '2',
+          receivedAtMs: 0,
+          arrivalCode: 2,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+      ],
+      down: [],
+    };
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-ambiguity',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  it('station lookup 실패 → autolock-station-lookup telemetry', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue(null);
+    const deps = makeDeps();
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-station-lookup',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  it('createLock 예외 → manual fallback + autolock-lock-failed telemetry (예외는 swallow)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    const failingCreateLock = jest.fn(async () => {
+      throw new Error('storage write failed');
+    });
+    const deps = makeDeps({ createLock: failingCreateLock });
+    await expect(
+      handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps),
+    ).resolves.toBeUndefined();
+    expect(failingCreateLock).toHaveBeenCalled();
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-lock-failed',
+      originStation: '강남',
+      line: '2',
+    });
   });
 });
 

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -65,26 +65,40 @@ const { __mockCreateLock: createLockMock } = jest.requireMock(
   '../../store/useBoardingLockStore',
 );
 
-function makeArrival(overrides: Partial<StationArrival['up'][number]> = {}): StationArrival {
+type UpEntry = StationArrival['up'][number];
+
+function makeUpEntry(overrides: Partial<UpEntry> = {}): UpEntry {
   return {
-    up: [
-      {
-        destination: '',
-        arrivalMinutes: 1,
-        arrivalSeconds: 60,
-        statusMessage: '',
-        trainCode: 'T1',
-        line: '2',
-        receivedAtMs: 0,
-        arrivalCode: 2,
-        isLastTrain: false,
-        trainType: 'normal',
-        ...overrides,
-      },
-    ],
-    down: [],
+    destination: '',
+    arrivalMinutes: 1,
+    arrivalSeconds: 60,
+    statusMessage: '',
+    trainCode: 'T1',
+    line: '2',
+    receivedAtMs: 0,
+    arrivalCode: 2,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
   };
 }
+
+function makeArrival(overrides: Partial<UpEntry> = {}): StationArrival {
+  return { up: [makeUpEntry(overrides)], down: [] };
+}
+
+function makeArrivalWithUp(entries: Partial<UpEntry>[]): StationArrival {
+  return { up: entries.map(makeUpEntry), down: [] };
+}
+
+// 두 후보 같은 priority 케이스 — ambiguity fallback 측정용 (행동 + telemetry 양쪽 공유).
+const AMBIGUOUS_TRAINS: Partial<UpEntry>[] = [
+  { arrivalMinutes: 1, arrivalSeconds: 60, trainCode: 'T1' },
+  { arrivalMinutes: 2, arrivalSeconds: 120, trainCode: 'T2' },
+];
+
+// line 불일치 단일 후보 — empty candidate set 케이스 공유 (행동 + telemetry).
+const LINE_MISMATCH_TRAIN: Partial<UpEntry>[] = [{ line: '9' }];
 
 describe('extractBoardingPromptPayload', () => {
   it('valid payload → 보존', () => {
@@ -201,36 +215,9 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
   });
 
   it('ambiguity (같은 priority 후보 2+) → manual fallback, lock 안 함', async () => {
-    const arrival: StationArrival = {
-      up: [
-        {
-          destination: '',
-          arrivalMinutes: 1,
-          arrivalSeconds: 60,
-          statusMessage: '',
-          trainCode: 'T1',
-          line: '2',
-          receivedAtMs: 0,
-          arrivalCode: 2,
-          isLastTrain: false,
-          trainType: 'normal',
-        },
-        {
-          destination: '',
-          arrivalMinutes: 2,
-          arrivalSeconds: 120,
-          statusMessage: '',
-          trainCode: 'T2',
-          line: '2',
-          receivedAtMs: 0,
-          arrivalCode: 2,
-          isLastTrain: false,
-          trainType: 'normal',
-        },
-      ],
-      down: [],
-    };
-    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
+    const deps = makeDeps({
+      fetchArrivalsForStation: jest.fn(async () => makeArrivalWithUp(AMBIGUOUS_TRAINS)),
+    });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).not.toHaveBeenCalled();
   });
@@ -242,162 +229,83 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     expect(createLockMock).not.toHaveBeenCalled();
   });
 
-  it('arrivalSeconds <= 0인 후보는 필터됨 (지나간 열차 lock 차단)', async () => {
-    const arrival: StationArrival = {
-      up: [
-        {
-          destination: '',
-          arrivalMinutes: 0,
-          arrivalSeconds: 0,
-          statusMessage: '',
-          trainCode: 'T-old',
-          line: '2',
-          receivedAtMs: 0,
-          arrivalCode: 2,
-          isLastTrain: false,
-          trainType: 'normal',
-        },
-      ],
-      down: [],
-    };
-    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
+  it.each([
+    ['arrivalSeconds <= 0 (지나간 열차)', [{ arrivalMinutes: 0, arrivalSeconds: 0, trainCode: 'T-old' }]],
+    ['line 불일치', LINE_MISMATCH_TRAIN],
+  ])('후보 필터링 — %s → lock 안 함', async (_label, entries) => {
+    const deps = makeDeps({
+      fetchArrivalsForStation: jest.fn(async () => makeArrivalWithUp(entries)),
+    });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).not.toHaveBeenCalled();
   });
 
-  it('line 불일치 후보는 필터됨', async () => {
-    const arrival: StationArrival = {
-      up: [
-        {
-          destination: '',
-          arrivalMinutes: 1,
-          arrivalSeconds: 60,
-          statusMessage: '',
-          trainCode: 'T1',
-          line: '9',
-          receivedAtMs: 0,
-          arrivalCode: 2,
-          isLastTrain: false,
-          trainType: 'normal',
-        },
-      ],
-      down: [],
-    };
-    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
-    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).not.toHaveBeenCalled();
-  });
+  // #1167 — autoLock telemetry. 모든 케이스가 같은 형태로 logBoardingPromptAutoLock을 호출한다.
+  // setup만 다르고 expected reason 1개만 다르므로 it.each + setup factory로 일반화.
+  type AutoLockReason =
+    | 'autolock-no-trip'
+    | 'autolock-arrivals-empty'
+    | 'autolock-ambiguity'
+    | 'autolock-station-lookup'
+    | 'autolock-lock-failed';
 
-  // #1167 — autoLock telemetry + lock-failed fallback
-  it('destinationId null → autolock-no-trip telemetry', async () => {
-    const deps = makeDeps({ destinationId: null });
-    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-no-trip',
-      originStation: '강남',
-      line: '2',
-    });
-  });
+  const STATION_MATCH = { id: 'S1', line: '2', name: '강남' };
 
-  it('arrivals null → autolock-arrivals-empty telemetry', async () => {
-    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
-    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-arrivals-empty',
-      originStation: '강남',
-      line: '2',
-    });
-  });
+  // 각 케이스는 deps override + 사전 mock setup을 반환. handleResponse 호출과 assertion은 공통.
+  const autoLockCases: Array<[
+    string,
+    AutoLockReason,
+    () => Partial<Parameters<typeof makeDeps>[0]>,
+  ]> = [
+    ['destinationId null', 'autolock-no-trip', () => ({ destinationId: null })],
+    [
+      'arrivals null',
+      'autolock-arrivals-empty',
+      () => ({ fetchArrivalsForStation: jest.fn(async () => null) }),
+    ],
+    [
+      'line 후보 0개 (모두 필터됨)',
+      'autolock-arrivals-empty',
+      () => ({
+        fetchArrivalsForStation: jest.fn(async () => makeArrivalWithUp(LINE_MISMATCH_TRAIN)),
+      }),
+    ],
+    [
+      'ambiguity (same priority 후보 2+)',
+      'autolock-ambiguity',
+      () => ({
+        fetchArrivalsForStation: jest.fn(async () => makeArrivalWithUp(AMBIGUOUS_TRAINS)),
+      }),
+    ],
+    [
+      'station lookup 실패',
+      'autolock-station-lookup',
+      () => {
+        (findStationByNameAndLine as jest.Mock).mockReturnValue(null);
+        return {};
+      },
+    ],
+    [
+      'createLock 예외 (manual fallback + swallow)',
+      'autolock-lock-failed',
+      () => {
+        (findStationByNameAndLine as jest.Mock).mockReturnValue(STATION_MATCH);
+        return {
+          createLock: jest.fn(async () => {
+            throw new Error('storage write failed');
+          }),
+        };
+      },
+    ],
+  ];
 
-  it('line 후보 0개 (모두 필터됨) → autolock-arrivals-empty telemetry', async () => {
-    const arrival: StationArrival = {
-      up: [
-        {
-          destination: '',
-          arrivalMinutes: 1,
-          arrivalSeconds: 60,
-          statusMessage: '',
-          trainCode: 'T1',
-          line: '9', // line 불일치 → 필터됨
-          receivedAtMs: 0,
-          arrivalCode: 2,
-          isLastTrain: false,
-          trainType: 'normal',
-        },
-      ],
-      down: [],
-    };
-    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
-    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-arrivals-empty',
-      originStation: '강남',
-      line: '2',
-    });
-  });
-
-  it('ambiguity (same priority 후보 2+) → autolock-ambiguity telemetry', async () => {
-    const arrival: StationArrival = {
-      up: [
-        {
-          destination: '',
-          arrivalMinutes: 1,
-          arrivalSeconds: 60,
-          statusMessage: '',
-          trainCode: 'T1',
-          line: '2',
-          receivedAtMs: 0,
-          arrivalCode: 2,
-          isLastTrain: false,
-          trainType: 'normal',
-        },
-        {
-          destination: '',
-          arrivalMinutes: 2,
-          arrivalSeconds: 120,
-          statusMessage: '',
-          trainCode: 'T2',
-          line: '2',
-          receivedAtMs: 0,
-          arrivalCode: 2,
-          isLastTrain: false,
-          trainType: 'normal',
-        },
-      ],
-      down: [],
-    };
-    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => arrival) });
-    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-ambiguity',
-      originStation: '강남',
-      line: '2',
-    });
-  });
-
-  it('station lookup 실패 → autolock-station-lookup telemetry', async () => {
-    (findStationByNameAndLine as jest.Mock).mockReturnValue(null);
-    const deps = makeDeps();
-    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-station-lookup',
-      originStation: '강남',
-      line: '2',
-    });
-  });
-
-  it('createLock 예외 → manual fallback + autolock-lock-failed telemetry (예외는 swallow)', async () => {
-    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
-    const failingCreateLock = jest.fn(async () => {
-      throw new Error('storage write failed');
-    });
-    const deps = makeDeps({ createLock: failingCreateLock });
+  it.each(autoLockCases)('telemetry — %s → %s', async (_label, reason, setup) => {
+    const deps = makeDeps(setup());
     await expect(
       handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps),
     ).resolves.toBeUndefined();
-    expect(failingCreateLock).toHaveBeenCalled();
     expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-lock-failed',
+      reason,
       originStation: '강남',
       line: '2',
     });

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -34,6 +34,7 @@ import {
 } from '../utils/notificationCategory';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { createLogger } from '../../../shared/utils/logger';
+import { logBoardingPromptAutoLock } from '../utils/alarmLog';
 
 const log = createLogger('boardingPromptResponder');
 
@@ -131,8 +132,11 @@ async function tryAutoLock(
   payload: BoardingPromptPayload,
   deps: HandleDeps,
 ): Promise<void> {
+  const telemetry = { originStation: payload.originStation, line: payload.line };
+
   if (!deps.destinationId) {
     // trip이 이미 끝남 — lock 시도 안 함, dismiss로 backend silence.
+    logBoardingPromptAutoLock({ reason: 'autolock-no-trip', ...telemetry });
     await dismissBoardingPrompt(payload.tripToken);
     return;
   }
@@ -140,6 +144,7 @@ async function tryAutoLock(
   const arrival = await deps.fetchArrivalsForStation(payload.originStation);
   if (!arrival) {
     log.info('arrivals fetch returned null — falling back to manual');
+    logBoardingPromptAutoLock({ reason: 'autolock-arrivals-empty', ...telemetry });
     return;
   }
 
@@ -152,6 +157,9 @@ async function tryAutoLock(
   const chosen = pickAutoTrainCodeFromArrivals(sameLine);
   if (!chosen) {
     log.info('ambiguity or empty — auto lock skipped');
+    // 빈 후보와 ambiguity 구분: sameLine이 1개 이상인데 chosen이 null이면 ambiguity.
+    const reason = sameLine.length === 0 ? 'autolock-arrivals-empty' : 'autolock-ambiguity';
+    logBoardingPromptAutoLock({ reason, ...telemetry });
     return;
   }
 
@@ -159,17 +167,26 @@ async function tryAutoLock(
   const station = findStationByNameAndLine(payload.originStation, chosen.line);
   if (!station) {
     log.info('station lookup failed — auto lock skipped');
+    logBoardingPromptAutoLock({ reason: 'autolock-station-lookup', ...telemetry });
     return;
   }
 
-  await deps.createLock({
-    destinationId: deps.destinationId,
-    trainCode: chosen.trainCode,
-    boardingStationId: station.id,
-    boardingLine: chosen.line,
-    boardedAt: Date.now(),
-    expectedDurationMs: deps.expectedDurationMs,
-    // #897 Seam A: auto-lock 시점 ETA 스냅샷. 지연 신호의 기준치.
-    initialEtaSeconds: chosen.arrivalSeconds,
-  });
+  try {
+    await deps.createLock({
+      destinationId: deps.destinationId,
+      trainCode: chosen.trainCode,
+      boardingStationId: station.id,
+      boardingLine: chosen.line,
+      boardedAt: Date.now(),
+      expectedDurationMs: deps.expectedDurationMs,
+      // #897 Seam A: auto-lock 시점 ETA 스냅샷. 지연 신호의 기준치.
+      initialEtaSeconds: chosen.arrivalSeconds,
+    });
+    logBoardingPromptAutoLock({ reason: 'autolock-success', ...telemetry });
+  } catch (err) {
+    // #1167 — lock 실패 시 fallback 경로. createLock는 storage/network 예외 가능.
+    // 사용자는 manual BoardingTrainList에서 재선택. 예외는 swallow — autoLock은 best-effort.
+    log.warn('createLock failed — falling back to manual', err as Error);
+    logBoardingPromptAutoLock({ reason: 'autolock-lock-failed', ...telemetry });
+  }
 }

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -51,6 +51,8 @@ import {
   logBoardingPromptFired,
   BOARDING_PROMPT_WINDOWS,
   countBoardingPromptByWindow,
+  logBoardingPromptAutoLock,
+  countBoardingPromptAutoLockOutcomes,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -1560,6 +1562,83 @@ describe('alarmLog', () => {
         { ts: Date.now() - 1000, source: 'boarding-prompt', outcome: 'fired' },
       ];
       expect(countBoardingPromptByWindow(entries)['5m']).toBe(1);
+    });
+
+    it('reason 필드가 있는 boarding-prompt entry는 #1021 윈도우 집계에서 제외 (autolock과 분리)', () => {
+      const now = Date.now();
+      const entries: AlarmLogEntry[] = [
+        // autolock-success는 outcome='fired'지만 reason 있음 → 발사 빈도엔 카운트 X.
+        {
+          ts: now - 1000,
+          source: 'boarding-prompt',
+          outcome: 'fired',
+          reason: 'autolock-success',
+        },
+      ];
+      expect(countBoardingPromptByWindow(entries, now)['5m']).toBe(0);
+    });
+  });
+
+  describe('logBoardingPromptAutoLock + countBoardingPromptAutoLockOutcomes (#1167)', () => {
+    it.each([
+      ['autolock-success', 'fired'],
+      ['autolock-no-trip', 'suppressed'],
+      ['autolock-arrivals-empty', 'suppressed'],
+      ['autolock-ambiguity', 'suppressed'],
+      ['autolock-station-lookup', 'suppressed'],
+      ['autolock-lock-failed', 'suppressed'],
+    ] as const)('reason=%s → outcome=%s + stationName 합성', async (reason, expectedOutcome) => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logBoardingPromptAutoLock({ reason, originStation: '강남', line: '2' });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0]).toMatchObject({
+        source: 'boarding-prompt',
+        outcome: expectedOutcome,
+        reason,
+        stationName: '2·강남',
+      });
+    });
+
+    it('countBoardingPromptAutoLockOutcomes가 reason별 분포 집계', () => {
+      const entries: AlarmLogEntry[] = [
+        { ts: 1, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        { ts: 2, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        { ts: 3, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
+        { ts: 4, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-no-trip' },
+        { ts: 5, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-arrivals-empty' },
+        { ts: 6, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-station-lookup' },
+        { ts: 7, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+        // reason 없는 #1021 발사 entry는 제외
+        { ts: 8, source: 'boarding-prompt', outcome: 'fired' },
+        // 다른 source는 제외
+        { ts: 9, source: 'fg', outcome: 'fired' },
+      ];
+      const counts = countBoardingPromptAutoLockOutcomes(entries);
+      expect(counts).toEqual({
+        'autolock-success': 2,
+        'autolock-no-trip': 1,
+        'autolock-arrivals-empty': 1,
+        'autolock-ambiguity': 1,
+        'autolock-station-lookup': 1,
+        'autolock-lock-failed': 1,
+      });
+    });
+
+    it('boarding-prompt source인데 reason이 autolock 계열이 아니면 무시 (방어)', () => {
+      const entries: AlarmLogEntry[] = [
+        {
+          ts: 1,
+          source: 'boarding-prompt',
+          outcome: 'suppressed',
+          // 다른 도메인 reason — counts에 영향 없음
+          reason: 'gate-age',
+        },
+      ];
+      const counts = countBoardingPromptAutoLockOutcomes(entries);
+      expect(counts['autolock-success']).toBe(0);
+      expect(counts['autolock-no-trip']).toBe(0);
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -112,7 +112,20 @@ export type AlarmLogReason =
   //   'revalidate-waypoint-mismatch': 파싱된 stationName이 현재 route waypoint에 없음.
   | 'revalidate-no-trip'
   | 'revalidate-route-sig-mismatch'
-  | 'revalidate-waypoint-mismatch';
+  | 'revalidate-waypoint-mismatch'
+  // #1167 — boardingPrompt [탑승] 응답 → arvlCd 우선순위 autoLock 결과.
+  //   'autolock-success': arvlCd 우선순위로 1대 확정 → createLock 성공.
+  //   'autolock-no-trip': destinationId null (사용자 trip 종료 후 늦은 탭).
+  //   'autolock-arrivals-empty': fetchArrivalsForStation null/no candidates.
+  //   'autolock-ambiguity': 같은 priority 후보 2+ → manual fallback.
+  //   'autolock-station-lookup': originStation/line 매칭 실패.
+  //   'autolock-lock-failed': createLock 예외 (저장/네트워크 등) → manual fallback.
+  | 'autolock-success'
+  | 'autolock-no-trip'
+  | 'autolock-arrivals-empty'
+  | 'autolock-ambiguity'
+  | 'autolock-station-lookup'
+  | 'autolock-lock-failed';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -835,10 +848,62 @@ export function countBoardingPromptByWindow(
   const counts: Record<BoardingPromptWindowKey, number> = { '5m': 0, '1h': 0, all: 0 };
   for (const entry of entries) {
     if (entry.source !== 'boarding-prompt' || entry.outcome !== 'fired') continue;
+    // #1167 — autolock outcome도 source='boarding-prompt'를 재사용하지만 outcome='suppressed'
+    // 또는 reason='autolock-success'로 구분. 발사 빈도(#1021) 집계에는 reason 미설정 entry만 포함.
+    if (entry.reason !== undefined) continue;
     const ageMs = now - entry.ts;
     for (const { key, ms } of BOARDING_PROMPT_WINDOWS) {
       if (ageMs <= ms) counts[key] += 1;
     }
+  }
+  return counts;
+}
+
+/**
+ * #1167 — boardingPrompt autoLock outcome 적재.
+ *
+ * 성공 시 outcome='fired' + reason='autolock-success', skip 시 outcome='suppressed' + skip 이유.
+ * source='boarding-prompt'를 재사용해 한 화면에서 발사 빈도(#1021) + autolock 분포를 같이 본다.
+ */
+export type BoardingPromptAutoLockReason =
+  | 'autolock-success'
+  | 'autolock-no-trip'
+  | 'autolock-arrivals-empty'
+  | 'autolock-ambiguity'
+  | 'autolock-station-lookup'
+  | 'autolock-lock-failed';
+
+export function logBoardingPromptAutoLock(input: {
+  reason: BoardingPromptAutoLockReason;
+  originStation: string;
+  line: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'boarding-prompt',
+    outcome: input.reason === 'autolock-success' ? 'fired' : 'suppressed',
+    reason: input.reason,
+    stationName: `${input.line}·${input.originStation}`,
+  });
+}
+
+/** #1167 — 최근 N건의 autolock outcome 분포 (운영 측정용). */
+export function countBoardingPromptAutoLockOutcomes(
+  entries: readonly AlarmLogEntry[],
+): Record<BoardingPromptAutoLockReason, number> {
+  const counts: Record<BoardingPromptAutoLockReason, number> = {
+    'autolock-success': 0,
+    'autolock-no-trip': 0,
+    'autolock-arrivals-empty': 0,
+    'autolock-ambiguity': 0,
+    'autolock-station-lookup': 0,
+    'autolock-lock-failed': 0,
+  };
+  for (const entry of entries) {
+    if (entry.source !== 'boarding-prompt') continue;
+    const reason = entry.reason;
+    if (reason === undefined) continue;
+    if (reason in counts) counts[reason as BoardingPromptAutoLockReason] += 1;
   }
   return counts;
 }


### PR DESCRIPTION
## Summary
- boardingPrompt push [탑승] 응답 시 arvlCd 우선순위 autoLock의 6개 분기에 telemetry 적재(`logBoardingPromptAutoLock`) — `autolock-success` / `autolock-no-trip` / `autolock-arrivals-empty` / `autolock-ambiguity` / `autolock-station-lookup` / `autolock-lock-failed`.
- `createLock` 예외를 `try/catch`로 swallow → manual `BoardingTrainList` fallback 보장 ("lock 실패 시 fallback 경로").
- `source='boarding-prompt'` 재사용. `countBoardingPromptByWindow`(#1021 발사 빈도)는 reason 없는 entry만 집계해 측정 채널 분리.
- 신규 분기·helper 모두 100% 커버리지.

## Test plan
- [x] `npx jest src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts src/features/alarm/utils/__tests__/alarmLog.test.ts` 146 passed
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] 실기기: 탑승 prompt 수신 → [탑승] 탭 → 즉시 autoLock 진입, debug 모달에서 `boarding-prompt / fired / autolock-success` 1건 적재 확인
- [ ] 실기기: createLock 강제 실패(스토리지 시뮬) 시 manual lock 화면 도달 + `autolock-lock-failed` 적재 확인

Closes #1167
Related: #1008 (Epic C 단기 3번, B4 경로 3)