### PR TITLE
feat(#1174): delta vs estimator P50/P95 측정 추가 (B5 게이트)

### DIFF
--- a/backend/alarm-worker/src/__tests__/deltaVsEstimatorTelemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/deltaVsEstimatorTelemetry.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  recordDeltaVsEstimatorUpload,
+  validateDeltaVsEstimatorUpload,
+  type DeltaVsEstimatorUpload,
+} from '../deltaVsEstimatorTelemetry';
+import { METRIC_KIND, percentile, SLA_PERCENTILE } from '../metrics';
+
+function base(): Record<string, unknown> {
+  return {
+    token: 'aabbccdd11223344',
+    windowStart: 1_000,
+    windowEnd: 2_000,
+    deltaSamples: [0, 1, 2, 1, 0],
+  };
+}
+
+describe('validateDeltaVsEstimatorUpload', () => {
+  it('accepts a valid payload', () => {
+    const result = validateDeltaVsEstimatorUpload(base());
+    expect(result).not.toBeNull();
+    expect(result?.deltaSamples).toEqual([0, 1, 2, 1, 0]);
+  });
+
+  it.each([
+    ['null', null],
+    ['string', 'x'],
+  ])('rejects non-object (%s)', (_label, value) => {
+    expect(validateDeltaVsEstimatorUpload(value)).toBeNull();
+  });
+
+  it('rejects missing/empty token', () => {
+    expect(validateDeltaVsEstimatorUpload({ ...base(), token: '' })).toBeNull();
+    const noToken = base();
+    delete noToken.token;
+    expect(validateDeltaVsEstimatorUpload(noToken)).toBeNull();
+  });
+
+  it.each([
+    ['windowStart', Number.NaN],
+    ['windowStart', 'x'],
+    ['windowEnd', Number.NaN],
+    ['windowEnd', 'x'],
+  ])('rejects non-finite %s (%p)', (field, value) => {
+    expect(validateDeltaVsEstimatorUpload({ ...base(), [field]: value })).toBeNull();
+  });
+
+  it('rejects windowEnd < windowStart', () => {
+    expect(
+      validateDeltaVsEstimatorUpload({ ...base(), windowStart: 2_000, windowEnd: 1_000 }),
+    ).toBeNull();
+  });
+
+  it('rejects non-array deltaSamples', () => {
+    expect(validateDeltaVsEstimatorUpload({ ...base(), deltaSamples: 'x' })).toBeNull();
+    expect(validateDeltaVsEstimatorUpload({ ...base(), deltaSamples: 5 })).toBeNull();
+  });
+
+  it.each([
+    ['negative', [0, -1, 2]],
+    ['fractional', [0, 1.5, 2]],
+    ['NaN', [0, Number.NaN, 2]],
+    ['string', [0, 'x', 2]],
+    ['Infinity', [0, Number.POSITIVE_INFINITY, 2]],
+  ])('rejects non-natural sample entry (%s)', (_label, samples) => {
+    expect(validateDeltaVsEstimatorUpload({ ...base(), deltaSamples: samples })).toBeNull();
+  });
+
+  it('accepts empty deltaSamples (idle window — caller decides whether to upload)', () => {
+    const result = validateDeltaVsEstimatorUpload({ ...base(), deltaSamples: [] });
+    expect(result).not.toBeNull();
+    expect(result?.deltaSamples).toEqual([]);
+  });
+});
+
+describe('recordDeltaVsEstimatorUpload', () => {
+  function makeWriter() {
+    return { writeDataPoint: vi.fn() };
+  }
+
+  it('writes count + mean + p95 data points for non-empty samples', () => {
+    const writer = makeWriter();
+    const payload: DeltaVsEstimatorUpload = {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      deltaSamples: [0, 1, 2, 3, 4],
+    };
+    recordDeltaVsEstimatorUpload(writer, payload);
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(3);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain(`phase3:${METRIC_KIND.DELTA_VS_ESTIMATOR_INDEX}:count`);
+    expect(labels).toContain(`phase3:${METRIC_KIND.DELTA_VS_ESTIMATOR_INDEX}:mean`);
+    const percentileLabel = `p${Math.round(SLA_PERCENTILE * 100)}`;
+    expect(labels).toContain(`phase3:${METRIC_KIND.DELTA_VS_ESTIMATOR_INDEX}:${percentileLabel}`);
+    // P95 reported value matches `percentile` (SSOT) — no inline magic.
+    const p95Call = writer.writeDataPoint.mock.calls.find(
+      (c) => c[0].blobs[0].endsWith(`:${percentileLabel}`),
+    );
+    expect(p95Call?.[0].doubles[0]).toBe(percentile([0, 1, 2, 3, 4], SLA_PERCENTILE));
+  });
+
+  it('skips all-zero samples (writes only count) — mean/p95 are 0', () => {
+    const writer = makeWriter();
+    recordDeltaVsEstimatorUpload(writer, {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      deltaSamples: [0, 0, 0],
+    });
+    // writeMetricDataPoints skips 0 values → only count point survives.
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writer.writeDataPoint.mock.calls[0][0].blobs[0]).toBe(
+      `phase3:${METRIC_KIND.DELTA_VS_ESTIMATOR_INDEX}:count`,
+    );
+  });
+
+  it('skips all points when samples is empty (idle window — no noise)', () => {
+    const writer = makeWriter();
+    recordDeltaVsEstimatorUpload(writer, {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      deltaSamples: [],
+    });
+    expect(writer.writeDataPoint).not.toHaveBeenCalled();
+  });
+
+  it('uses 8-char token prefix for anonymous aggregate', () => {
+    const writer = makeWriter();
+    recordDeltaVsEstimatorUpload(writer, {
+      token: 'aabbccdd11223344',
+      windowStart: 0,
+      windowEnd: 1_000,
+      deltaSamples: [1, 2, 3],
+    });
+    const first = writer.writeDataPoint.mock.calls[0][0];
+    expect(first.blobs[1]).toBe('aabbccdd');
+    expect(first.indexes[0]).toBe('aabbccdd');
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1522,6 +1522,15 @@ describe('POST /telemetry/server-progress (#1173)', () => {
   });
 });
 
+describe('POST /telemetry/delta-vs-estimator (#1174)', () => {
+  runTelemetryEndpointSuite('/telemetry/delta-vs-estimator', {
+    token: 'aabbccdd11223344',
+    windowStart: 1_000,
+    windowEnd: 2_000,
+    deltaSamples: [0, 1, 2, 1, 0],
+  });
+});
+
 describe('GET /metrics/recall/summary (#919 후속)', () => {
   async function get(env: Env): Promise<Response> {
     return app.fetch(

--- a/backend/alarm-worker/src/deltaVsEstimatorTelemetry.ts
+++ b/backend/alarm-worker/src/deltaVsEstimatorTelemetry.ts
@@ -1,0 +1,107 @@
+/**
+ * Shadow Stage 1-3 vs server progress delta 텔레메트리 (#1174, Epic #1008 C 단기 B5 측정 인프라).
+ *
+ * Client(`useFusedNearestStation` 또는 estimator 호출자)가 같은 trip tick에서 server
+ * `BffProgressResponse.waypointIndex`와 local `stationProgressEstimator`(Stage 1-3) 결과가
+ * 모두 살아있을 때 `delta = |serverIdx - estimatorIdx|`(arc-index hop 단위)를 누적해
+ * 폴링 윈도우 단위(또는 trip 종료 시점)로 본 엔드포인트로 업로드한다. backend는 단순 적재:
+ *
+ *   deltaVsEstimatorIndex : HistogramMetric (samples = arc-index hop 단위 abs delta)
+ *                           → 1주 baseline P50/P95 산출. P95가 B5(server progress)
+ *                             optional→required 승격 시 임계 결정 근거.
+ *
+ * Privacy: 좌표/station id/원문 미적재. 정수 hop delta만 적재. token 8자 prefix만
+ * anonymous aggregate(serverProgressTelemetry / recallTelemetry / prescheduledTelemetry 동형).
+ * Phase 4 결정 게이트와 분리된 운영 KPI — `decidePhaseFour`에 포함하지 않는다.
+ *
+ * 본 모듈은 client 측 shadow 비교 wiring과 파일 분리 — emit wiring은 후속 PR에서 본 모듈의
+ * `recordDeltaVsEstimatorUpload`만 호출하면 된다(estimator/provider 본체 미수정,
+ * #1173 PR 슬라이싱 패턴과 동일).
+ */
+
+import {
+  METRIC_KIND,
+  writeMetricDataPoints,
+  type HistogramMetric,
+} from './metrics';
+import type { AnalyticsEngineWriter } from './types';
+
+/** client → backend upload payload. */
+export interface DeltaVsEstimatorUpload {
+  /** APNs device token (hex). 8자 prefix만 anonymous aggregate. */
+  token: string;
+  /** 폴링 윈도우 시작 epoch ms. */
+  windowStart: number;
+  /** 폴링 윈도우 종료 epoch ms. windowStart <= windowEnd 강제. */
+  windowEnd: number;
+  /**
+   * shadow tick별 `|serverWaypointIndex - estimatorIndex|`(arc-index hop 단위, 정수, ≥0) sample.
+   * 두 신호가 모두 살아있던 tick 만큼 길이. 비유한/음수/비정수는 reject(전체 payload 거부).
+   */
+  deltaSamples: readonly number[];
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isNonNegativeInt(v: unknown): v is number {
+  return isFiniteNumber(v) && Number.isInteger(v) && v >= 0;
+}
+
+/**
+ * delta sample 배열 검증 — 비음수 정수만 보존. 한 entry라도 비정상이면 전체 reject
+ * (조용히 drop하지 않음 — 비정상 sample이 P50/P95를 오염시키지 않게).
+ * `prescheduledTelemetry.parseDeltaSamples`와 동형이나 본 메트릭은 abs hop이라 음수도 reject.
+ */
+function parseDeltaSamples(raw: unknown): number[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out: number[] = [];
+  for (const v of raw) {
+    if (!isNonNegativeInt(v)) return null;
+    out.push(v);
+  }
+  return out;
+}
+
+/**
+ * payload 검증. 한 필드라도 깨졌으면 null — 호출자는 400 반환.
+ *
+ * 규칙 (serverProgressTelemetry validateServerProgressUpload와 동형):
+ *   - token 비어있으면 reject
+ *   - windowStart/windowEnd는 유한수 + windowStart <= windowEnd
+ *   - deltaSamples는 비음수 정수 배열 (한 entry라도 비정상이면 전체 reject)
+ *   - 빈 배열 허용 (idle window — 호출자가 업로드 여부 결정)
+ */
+export function validateDeltaVsEstimatorUpload(input: unknown): DeltaVsEstimatorUpload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (!isFiniteNumber(obj.windowStart)) return null;
+  if (!isFiniteNumber(obj.windowEnd)) return null;
+  if (obj.windowEnd < obj.windowStart) return null;
+  const samples = parseDeltaSamples(obj.deltaSamples);
+  if (samples === null) return null;
+
+  return {
+    token: obj.token,
+    windowStart: obj.windowStart,
+    windowEnd: obj.windowEnd,
+    deltaSamples: samples,
+  };
+}
+
+/**
+ * upload 1건을 AE에 적재. `writeMetricDataPoints`가 0값은 skip하므로 빈 배열은
+ * 자동으로 noise free(count/mean/p95 모두 0이면 적재 안 됨).
+ */
+export function recordDeltaVsEstimatorUpload(
+  writer: AnalyticsEngineWriter,
+  payload: DeltaVsEstimatorUpload,
+): void {
+  const histogram: HistogramMetric = {
+    kind: METRIC_KIND.DELTA_VS_ESTIMATOR_INDEX,
+    samples: payload.deltaSamples,
+  };
+  writeMetricDataPoints(writer, payload.token, histogram);
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -60,6 +60,10 @@ import {
   validateServerProgressUpload,
 } from './serverProgressTelemetry';
 import {
+  recordDeltaVsEstimatorUpload,
+  validateDeltaVsEstimatorUpload,
+} from './deltaVsEstimatorTelemetry';
+import {
   tokenPrefix,
   validateTelemetryUpload,
   writeTelemetryDataPoints,
@@ -546,6 +550,43 @@ app.post('/telemetry/server-progress', async (c) => {
       tokenPrefix: tokenPrefix(payload.token),
       attempts: payload.attempts,
       received: payload.received,
+      sink: writer ? 'ae' : 'none',
+    }),
+  );
+  return c.json({ ok: true });
+});
+
+/**
+ * Shadow Stage 1-3 vs server progress delta 텔레메트리 upload (#1174, Epic #1008 C 단기 B5).
+ *
+ * Client가 같은 trip tick에서 server `BffProgressResponse.waypointIndex`와 local
+ * `stationProgressEstimator` 결과가 모두 살아있을 때 |serverIdx - estimatorIdx|(arc-index hop)을
+ * 누적해 폴링 윈도우 단위로 업로드한다. backend는 단순 적재 — TELEMETRY binding 미설정 시
+ * graceful no-op (recall/prescheduled/server-progress 동형).
+ *
+ * 본 엔드포인트는 catalog SSOT(`deltaVsEstimatorIndex`)와 짝 — 1주 baseline P50/P95가
+ * B5(server progress) optional → required 승격 시 P95 임계 결정 근거.
+ */
+app.post('/telemetry/delta-vs-estimator', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateDeltaVsEstimatorUpload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const writer = c.env.TELEMETRY;
+  if (writer) {
+    recordDeltaVsEstimatorUpload(writer, payload);
+  }
+  console.log(
+    JSON.stringify({
+      msg: 'delta-vs-estimator uploaded',
+      tokenPrefix: tokenPrefix(payload.token),
+      sampleCount: payload.deltaSamples.length,
       sink: writer ? 'ae' : 'none',
     }),
   );

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -149,6 +149,13 @@
       "format": "rate",
       "display": "percentage",
       "description": "#1173 Epic C B5 — BFF /progress 폴링 응답 수신율. hit=2xx 응답 수, total=요청 시도 수. MIN_SERVER_PROGRESS_RECEIVED_RATIO(0.95) 미달이면 backend down/네트워크 회귀 신호. Phase 4 결정 게이트 아님 — B5 optional→required 승격 게이트 측정 인프라(운영 KPI)."
+    },
+    {
+      "key": "deltaVsEstimatorIndex",
+      "constantName": "DELTA_VS_ESTIMATOR_INDEX",
+      "format": "histogram",
+      "display": "numeric",
+      "description": "#1174 Epic C B5 — server BffProgressResponse.waypointIndex와 local stationProgressEstimator(Stage 1-3) 결과의 arc-index 차이 절댓값(|serverIdx - estimatorIdx|, 단위=hop). 1주 baseline 운영으로 P50/P95 산출 → B5(server progress) optional→required 승격 시 P95 임계 결정 근거. Phase 4 결정 게이트 아님 — 운영 측정 KPI(운영 임계는 P95 baseline 확정 후 별도 const로 카탈로그에 추가)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Epic C 단기 10번 — B5(server progress) optional→required 승격 임계 결정 근거 측정 인프라.

- `metrics.catalog.json`에 `deltaVsEstimatorIndex` histogram entry 추가 (server `BffProgressResponse.waypointIndex` vs local `stationProgressEstimator` Stage 1-3 결과의 `|serverIdx - estimatorIdx|` arc-index hop sample → P50/P95)
- `deltaVsEstimatorTelemetry.ts` — validate + record (`serverProgressTelemetry` / `prescheduledTelemetry` 동형, abs hop이라 음수도 reject, token 8자 prefix anonymous)
- `POST /telemetry/delta-vs-estimator` endpoint — TELEMETRY binding 부재 시 graceful no-op
- 1주 baseline rolling P95가 B5 승격 시 임계 결정 근거 (P95 baseline 확정 후 별도 const로 카탈로그에 추가)

## Scope 분리

Client-side shadow 비교 wiring(server `BffProgressResponse` vs `StationProgressEstimate` 동시 살아있는 tick에서 abs delta sample 누적 + 윈도우별 upload)은 본 PR에서 미포함:
- #1173 PR 슬라이싱 패턴과 동일 — catalog + recorder + endpoint만 등록
- 후속 PR에서 estimator 호출자(`useFusedNearestStation` 등)에 `recordDeltaSample` 1줄 호출로 wire

Phase 4 결정 게이트(`decidePhaseFour`)와 분리된 운영 측정 KPI — catalog entry에 `gate` 필드 없음.

## Test plan

- [x] `npx vitest run` — 1141 tests pass (신규 20 + endpoint suite)
- [x] `npm run type-check` clean (repo + backend)
- [x] `npm run lint` clean (--max-warnings=0)
- [x] catalog data-driven 회귀(`METRIC_CATALOG` 순회 테스트 + perf-report.js)에 신규 entry 자동 포함

Closes #1174
Related: #1008 (Epic Lockless Over-Fire Guard, Epic C 단기 10번, B5 승격 게이트)