### PR TITLE
feat(#1169): Fusion tier 동률 시 freshness_ts tie-break

### DIFF
--- a/src/features/nearest-station/utils/__tests__/pickFusedStation.test.ts
+++ b/src/features/nearest-station/utils/__tests__/pickFusedStation.test.ts
@@ -191,4 +191,166 @@ describe('pickFusedStation', () => {
       expect(result?.source).toBe('position');
     });
   });
+
+  describe('R-10 §4.3 tie-break (#1169)', () => {
+    const train = (trainStatus: number, receivedAtMs = NOW) => ({
+      statnId: 'X',
+      statnNm: 'X',
+      trainNo: 'T',
+      trainStatus,
+      updnLine: 0,
+      terminalStationId: '',
+      terminalStationName: '',
+      trainType: 'normal' as const,
+      isLastTrain: false,
+      receivedAtMs,
+    });
+
+    it('같은 tier(arrival-confirmed) + score 동률 + freshness 다름 → 더 최근 신호 후보 선택', () => {
+      // gangnam: 오래된 ARRIVED, chungmuro: 최근 ARRIVED. 점수는 둘 다 100(arrival-confirmed).
+      const olderArrival: StationArrival = {
+        up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW - 60_000 })],
+        down: [],
+      };
+      const newerArrival: StationArrival = {
+        up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW })],
+        down: [],
+      };
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), arrival: olderArrival },
+        { candidate: cand('chungmuro', 0.3), arrival: newerArrival },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+      expect(result?.confidence).toBe('arrival-confirmed');
+    });
+
+    it('score + freshness 모두 동률 → 거리 가까운(첫) 후보 유지 (결정론)', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+        { candidate: cand('chungmuro', 0.3), arrival: arrival(ARRIVAL_CODE.ARRIVED) },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
+
+    it('arrival up/down 중 더 최근 신호의 receivedAtMs가 freshness가 된다', () => {
+      // gangnam: up=오래된 ARRIVED, down=최근 ARRIVED → freshness = down.receivedAtMs.
+      // chungmuro: 중간 ARRIVED 단일 → gangnam(down)이 더 최근 → gangnam 선택.
+      const gangnamMixed: StationArrival = {
+        up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW - 60_000 })],
+        down: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW })],
+      };
+      const chungmuroMid: StationArrival = {
+        up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW - 30_000 })],
+        down: [],
+      };
+      const result = pickFusedStation([
+        { candidate: cand('chungmuro', 0.1), arrival: chungmuroMid },
+        { candidate: cand('gangnam', 0.3), arrival: gangnamMixed },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
+
+    it('position 신호도 동일 tier + score 동률 시 freshness 비교', () => {
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), positionMatches: [train(1, NOW - 60_000)] },
+        { candidate: cand('chungmuro', 0.3), positionMatches: [train(1, NOW)] },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+      expect(result?.source).toBe('position');
+    });
+
+    it('source 라벨: 같은 후보 내 pos/arr score 동률 + freshness 차이 → 더 최근 신호의 source 라벨', () => {
+      // 같은 후보에 arrival ARRIVED(최근) + position ARRIVED(오래됨) → score 동률.
+      // 기본은 position이 우선이지만, freshness가 arrival이 더 최근이라 arrival 라벨이 되어야 함.
+      const recentArrival: StationArrival = {
+        up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW })],
+        down: [],
+      };
+      const result = pickFusedStation([
+        {
+          candidate: cand('gangnam', 0.1),
+          arrival: recentArrival,
+          positionMatches: [train(1, NOW - 60_000)],
+        },
+      ]);
+      expect(result?.source).toBe('arrival');
+      expect(result?.confidence).toBe('arrival-confirmed');
+    });
+
+    it('source 라벨: 같은 후보 내 pos/arr score 동률 + position freshness가 더 큼 → position 라벨', () => {
+      // 대칭 케이스 — position이 더 최근.
+      const olderArrival: StationArrival = {
+        up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW - 60_000 })],
+        down: [],
+      };
+      const result = pickFusedStation([
+        {
+          candidate: cand('gangnam', 0.1),
+          arrival: olderArrival,
+          positionMatches: [train(1, NOW)],
+        },
+      ]);
+      expect(result?.source).toBe('position');
+    });
+
+    it('source 라벨: 같은 후보 내 score + freshness 모두 동률 → tier 표 순서(position 우선)', () => {
+      // 동일 receivedAtMs → 기존 tier 동작 유지(position 우선).
+      const result = pickFusedStation([
+        {
+          candidate: cand('gangnam', 0.1),
+          arrival: arrival(ARRIVAL_CODE.ARRIVED),
+          positionMatches: [train(1, NOW)],
+        },
+      ]);
+      expect(result?.source).toBe('position');
+    });
+
+    it('한 후보 내 같은 점수의 position 트레인 여러 개 → 더 최근 receivedAtMs가 freshness', () => {
+      // 두 후보 모두 ARRIVED 점수 100. gangnam 후보의 두 번째 트레인이 chungmuro보다 더 최근.
+      // → gangnam의 freshness가 max(older, newer)=newer로 잡혀 chungmuro보다 우선.
+      const result = pickFusedStation([
+        {
+          candidate: cand('chungmuro', 0.1),
+          positionMatches: [train(1, NOW - 30_000)],
+        },
+        {
+          candidate: cand('gangnam', 0.3),
+          positionMatches: [train(1, NOW - 60_000), train(1, NOW)],
+        },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
+
+    it('한 후보 내 같은 점수의 arrival info 여러 개 → 더 최근 receivedAtMs가 freshness', () => {
+      // arrival 동일 score, 두 번째 info가 더 신선해 freshness 갱신.
+      const gangnamMulti: StationArrival = {
+        up: [
+          info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW - 60_000 }),
+          info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW }),
+        ],
+        down: [],
+      };
+      const chungmuroOlder: StationArrival = {
+        up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW - 30_000 })],
+        down: [],
+      };
+      const result = pickFusedStation([
+        { candidate: cand('chungmuro', 0.1), arrival: chungmuroOlder },
+        { candidate: cand('gangnam', 0.3), arrival: gangnamMulti },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
+
+    it('한 후보가 명확히 더 높은 score면 freshness 무관하게 채택', () => {
+      // gangnam: ENTERING(낮은 점수) but 최근. chungmuro: ARRIVED(높은 점수) but 오래됨.
+      const result = pickFusedStation([
+        { candidate: cand('gangnam', 0.1), arrival: arrival(ARRIVAL_CODE.ENTERING) },
+        {
+          candidate: cand('chungmuro', 0.3),
+          arrival: { up: [info(ARRIVAL_CODE.ARRIVED, { receivedAtMs: NOW - 120_000 })], down: [] },
+        },
+      ]);
+      expect(result?.result.station.id).toBe(MOCK_STATIONS.chungmuro.id);
+    });
+  });
 });

--- a/src/features/nearest-station/utils/pickFusedStation.ts
+++ b/src/features/nearest-station/utils/pickFusedStation.ts
@@ -31,32 +31,58 @@ export interface FusionCandidate {
   positionMatches?: LinePositions['trains'] | null;
 }
 
-/** mock/stale 무시 + arvlCd 우선순위 최댓값. */
-function bestPriorityForArrival(arrival: StationArrival | null | undefined): number {
-  if (!arrival || arrival.isMock) return 0;
-  let best = 0;
+/**
+ * R-10 §4.3 tie-break: 점수 동률 시 `freshness_ts`(receivedAtMs) 비교가 필요해
+ * 점수와 함께 그 점수를 만든 신호의 receivedAtMs를 반환한다.
+ *
+ * - `score`: 신호의 priority 최댓값. 신호 없음 = 0.
+ * - `freshness`: `score`에 기여한 가장 신선한 신호의 receivedAtMs. score=0이면 0.
+ */
+interface SignalScore {
+  score: number;
+  freshness: number;
+}
+
+const NO_SIGNAL: SignalScore = { score: 0, freshness: 0 };
+
+/** mock/stale 무시 + arvlCd 우선순위 최댓값 + 최댓값 기여 신호의 receivedAtMs. */
+function bestPriorityForArrival(arrival: StationArrival | null | undefined): SignalScore {
+  if (!arrival || arrival.isMock) return NO_SIGNAL;
+  let score = 0;
+  let freshness = 0;
   for (const list of [arrival.up, arrival.down]) {
     for (const info of list) {
       if (info.receivedAtMs <= 0) continue;
       const p = getArrivalPriority(info.arrivalCode);
-      if (p > best) best = p;
+      if (p > score) {
+        score = p;
+        freshness = info.receivedAtMs;
+      } else if (p === score && info.receivedAtMs > freshness) {
+        freshness = info.receivedAtMs;
+      }
     }
   }
-  return best;
+  return { score, freshness };
 }
 
-/** stale(receivedAtMs<=0) 무시 + trainSttus 우선순위 최댓값. */
+/** stale(receivedAtMs<=0) 무시 + trainSttus 우선순위 최댓값 + 최댓값 기여 신호의 receivedAtMs. */
 function bestPriorityForPosition(
   trains: LinePositions['trains'] | null | undefined,
-): number {
-  if (!trains || trains.length === 0) return 0;
-  let best = 0;
+): SignalScore {
+  if (!trains || trains.length === 0) return NO_SIGNAL;
+  let score = 0;
+  let freshness = 0;
   for (const t of trains) {
     if (t.receivedAtMs <= 0) continue;
     const p = getTrainStatusPriority(t.trainStatus);
-    if (p > best) best = p;
+    if (p > score) {
+      score = p;
+      freshness = t.receivedAtMs;
+    } else if (p === score && t.receivedAtMs > freshness) {
+      freshness = t.receivedAtMs;
+    }
   }
-  return best;
+  return { score, freshness };
 }
 
 /**
@@ -74,11 +100,17 @@ function confidenceFromPriority(priority: number): FusionConfidence {
  *
  * 규칙:
  * 1) 각 후보의 점수 = max(arrival 점수, position 점수). 두 신호원이 같은 priority enum 사용.
- * 2) 점수 최댓값 후보 선택. 동점이면 거리 가까운(=먼저 들어온) 후보 유지.
+ * 2) 점수 최댓값 후보 선택.
+ *    - R-10 §4.3 (#1169): 점수 동률 시 `freshness_ts` 비교 — 더 최근 신호를 가진 후보 우선.
+ *    - freshness도 동률이면 거리 가까운(=먼저 들어온) 후보 유지.
  * 3) source 분류: position 점수 > 0 우선(가장 정확) > arrival 점수 > 0 > GPS.
  *    같은 점수라도 신호원이 다르면 정확도 순(position > arrival)으로 source 라벨 결정.
+ *    - R-10 §4.3 (#1169): 같은 score + 같은 tier 후보일 때, freshness가 더 큰 신호원의 라벨을 부여.
  * 4) 모두 0이면 GPS 최근접 사용.
  * 5) 후보가 비어있으면 null.
+ *
+ * R-10 §4.3에서 명시한 `lock 활성 + tier mismatch → 1단계 강등`은 호출자(`useFusedNearestStation`,
+ * 향후 `decideFusionResult`)에서 처리한다 — pickFusedStation은 lock 컨텍스트를 받지 않음.
  */
 export function pickFusedStation(
   candidates: FusionCandidate[],
@@ -87,18 +119,30 @@ export function pickFusedStation(
 
   let winnerIdx = 0;
   let winnerPriority = -1;
-  let winnerArrScore = 0;
-  let winnerPosScore = 0;
+  let winnerArr: SignalScore = NO_SIGNAL;
+  let winnerPos: SignalScore = NO_SIGNAL;
+  let winnerFreshness = 0;
+  let candidateTieBreaks = 0;
   for (let i = 0; i < candidates.length; i++) {
     const c = candidates[i];
-    const arrScore = bestPriorityForArrival(c.arrival);
-    const posScore = bestPriorityForPosition(c.positionMatches);
-    const p = Math.max(arrScore, posScore);
+    const arr = bestPriorityForArrival(c.arrival);
+    const pos = bestPriorityForPosition(c.positionMatches);
+    const p = Math.max(arr.score, pos.score);
+    // 이 후보의 freshness_ts = winning score에 기여한 가장 신선한 신호의 receivedAtMs.
+    const candidateFreshness = freshnessOfWinningScore(p, arr, pos);
     if (p > winnerPriority) {
       winnerIdx = i;
       winnerPriority = p;
-      winnerArrScore = arrScore;
-      winnerPosScore = posScore;
+      winnerArr = arr;
+      winnerPos = pos;
+      winnerFreshness = candidateFreshness;
+    } else if (p === winnerPriority && p > 0 && candidateFreshness > winnerFreshness) {
+      // R-10 §4.3: 점수 동률 + 더 최근 신호 → tie-break로 교체.
+      candidateTieBreaks++;
+      winnerIdx = i;
+      winnerArr = arr;
+      winnerPos = pos;
+      winnerFreshness = candidateFreshness;
     }
   }
 
@@ -118,45 +162,71 @@ export function pickFusedStation(
   }
 
   // R-10 (#1168): source 라벨을 explicit FUSION_TIER_PRIORITY로 결정.
-  // 기존 `winnerPosScore >= winnerArrScore`와 동치(position이 arrival보다 상위 tier)지만,
-  // SSOT를 단일 표(`fusionTierPriority.ts`)로 두어 신호 추가/재배열 시 호출 사이트 수정 불필요.
+  // R-10 §4.3 (#1169): 점수 동률 + tier 동률 시 freshness_ts 비교로 라벨 확정.
   const confidence = confidenceFromPriority(winnerPriority);
-  const source = pickHigherTrustSource(winnerPosScore, winnerArrScore, confidence);
+  const sourcePick = pickHigherTrustSource(winnerPos, winnerArr, confidence);
 
   const decided: FusedStationResult = {
     result: candidates[winnerIdx].candidate,
     confidence,
-    source,
+    source: sourcePick.source,
   };
   logger.debug('decided', {
     tier: tierFor(decided.source, decided.confidence),
     source: decided.source,
     confidence: decided.confidence,
-    posScore: winnerPosScore,
-    arrScore: winnerArrScore,
+    posScore: winnerPos.score,
+    arrScore: winnerArr.score,
     candidates: candidates.length,
+    // R-10 §4.3 telemetry — tie 발생 빈도 추적용 (이슈 #1169 acceptance).
+    candidateTieBreaks,
+    sourceTieBreakBy: sourcePick.tieBreakBy,
   });
   return decided;
 }
 
 /**
- * winning priority에 기여한 신호원 중 더 신뢰되는 source를 tier 표 기준으로 고른다.
+ * 후보의 freshness_ts = winning score(=max(arr, pos))에 기여한 신호 중 더 신선한 receivedAtMs.
  *
- * - 한쪽만 winning score에 도달했다면 그 쪽으로 확정.
- * - 두 신호원이 같은 점수로 동률이면 `FUSION_TIER_PRIORITY` 표 순서로 결정 — position tier가
- *   arrival tier보다 상위라 position이 우선(기존 implicit `>=` 동작과 동치).
+ * - 한쪽만 winning score 도달 → 그 쪽 freshness.
+ * - 양쪽 동률(둘 다 winning score 도달) → 더 큰 freshness.
+ * - winning score = 0 (신호 없음) → 0.
+ */
+function freshnessOfWinningScore(winning: number, arr: SignalScore, pos: SignalScore): number {
+  if (winning <= 0) return 0;
+  const arrContrib = arr.score === winning ? arr.freshness : 0;
+  const posContrib = pos.score === winning ? pos.freshness : 0;
+  return Math.max(arrContrib, posContrib);
+}
+
+interface SourcePick {
+  source: FusionSource;
+  /** telemetry: 어느 규칙으로 source 라벨이 정해졌는가. */
+  tieBreakBy: 'score' | 'freshness' | 'tier';
+}
+
+/**
+ * winning priority에 기여한 신호원 중 더 신뢰되는 source를 결정한다.
+ *
+ * 규칙 (R-10 §4.3):
+ * 1) 한쪽 score가 더 크면 그쪽 — `tieBreakBy='score'`.
+ * 2) score 동률 + freshness 차이 → 더 최근 신호의 source — `tieBreakBy='freshness'`.
+ * 3) score + freshness 모두 동률 → `FUSION_TIER_PRIORITY` 표 순서로 결정 — `tieBreakBy='tier'`.
+ *    현 표에서는 position tier가 arrival tier보다 상위라 'position' 우선(기존 동작과 동치).
  */
 function pickHigherTrustSource(
-  posScore: number,
-  arrScore: number,
+  pos: SignalScore,
+  arr: SignalScore,
   confidence: FusionConfidence,
-): FusionSource {
-  if (posScore > arrScore) return 'position';
-  if (arrScore > posScore) return 'arrival';
-  // 동점 — tier 표로 결정. position tier가 arrival tier보다 상위라 항상 'position'.
-  // 표에서 두 tier가 역전되면 본 분기가 자연스럽게 따라간다(`getTierRank` lookup).
+): SourcePick {
+  if (pos.score > arr.score) return { source: 'position', tieBreakBy: 'score' };
+  if (arr.score > pos.score) return { source: 'arrival', tieBreakBy: 'score' };
+  // score 동률 — freshness_ts 비교 (R-10 §4.3 lexicographic).
+  if (pos.freshness > arr.freshness) return { source: 'position', tieBreakBy: 'freshness' };
+  if (arr.freshness > pos.freshness) return { source: 'arrival', tieBreakBy: 'freshness' };
+  // freshness도 동률 — tier 표로 결정 (결정론 보장).
   const posRank = getTierRank(tierFor('position', confidence));
   const arrRank = getTierRank(tierFor('arrival', confidence));
   // istanbul ignore next — 현 표에서는 posRank < arrRank 보장. 표 재배열 대비 방어 분기.
-  return posRank <= arrRank ? 'position' : 'arrival';
+  return { source: posRank <= arrRank ? 'position' : 'arrival', tieBreakBy: 'tier' };
 }


### PR DESCRIPTION
## Summary
- R-10 spec §4.3 `(confidence_score, freshness_ts)` lexicographic tie-break를 `pickFusedStation`에 반영.
- 후보 간 점수 동률 → 더 최근 신호(receivedAtMs) 후보 우선.
- 같은 후보 내 pos/arr 점수 동률 → freshness 큰 신호의 source 라벨 부여, 동률이면 기존 tier 표(position 우선) 폴백.
- `candidateTieBreaks` + `sourceTieBreakBy` 텔레메트리 추가 (이슈 #1169 acceptance: tie 빈도 metric).
- 단위 테스트 9건 추가, 100% coverage 유지.

## Scope notes
- §4.3 `lock 활성 + tier mismatch → 1단계 강등`은 호출자 layer(`useFusedNearestStation` line 401, 441~448)에 이미 존재 → 본 PR 범위 밖.
- 향후 R-10 PR A `decideFusionResult` 추출 시 통합 예정.

## Stacked on #1182
- Base: `feat/#1168-r10-fusion-priority-apply` (PR #1182).
- **#1182 머지 후 dev로 rebase 필요**. 본 PR이 #1182에서 추가한 `fusionTierPriority.ts` (`getTierRank`, `tierFor`)에 의존.

## Test plan
- [x] `npm test` — 4776 passed, 100% coverage
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] #1182 머지 후 dev rebase + CI 재실행

Closes #1169
Related: #1008 (Epic C 단기 5번)