### PR TITLE
feat(#1166): backend lock 정정 시 toast UX

### DIFF
--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -16,6 +16,7 @@ import type { LineNumber, Station } from '../../../shared/types/station';
 import { formatClockTime } from '../../../shared/utils/formatTime';
 import { arrivalAt } from '../../../shared/utils/arrivalClock';
 import { isScheduleFallbackTrainCode } from '../utils/scheduleFallback';
+import { recordLockCorrection } from '../utils/lockCorrectionMetrics';
 import { buildDirectionMeta } from '../../route/utils/trainLineDirection';
 import { parseArrivalDistance } from '../../arrival/utils/arrivalStatusDistance';
 import { LINE_COLORS } from '../../../shared/constants/lineColors';
@@ -91,6 +92,15 @@ interface Props {
    * 테스트/조정용 노출.
    */
   pendingTimeoutMs?: number;
+  /**
+   * backend round-trip이 사용자가 탭한 train과 다른 trainCode로 lock을 확정했을 때 발화 — #1166.
+   *
+   * pending(`pendingTrainCode`)과 부모가 전달한 `lockedTrainCode`가 모두 set이지만 서로 다른 값이면
+   * 본 컴포넌트가 pending을 즉시 해제하고 callback을 호출한다. 부모는 toast UX로 사용자에게 정정 사실을
+   * 알린다. 같은 값으로 확정되는 정상 케이스(`lockedTrainCode === pendingTrainCode`)에서는 호출되지 않는다.
+   * 미전달이면 내부 로직(pending 해제 + metric 적재)은 그대로 수행되고 callback만 skip.
+   */
+  onLockCorrected?: (pendingTrainCode: string, confirmedTrainCode: string) => void;
 }
 
 /**
@@ -132,6 +142,7 @@ export function BoardingTrainList({
   initialEtaSeconds,
   lockedTrainCode = null,
   pendingTimeoutMs = PENDING_TIMEOUT_MS_DEFAULT,
+  onLockCorrected,
 }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -147,14 +158,23 @@ export function BoardingTrainList({
     }
   }, []);
 
-  // 부모가 lockedTrainCode로 확정 신호 → pending 해제(confirmed). 확정된 후 lock 칩/highlight는
-  // 호출자가 자체적으로 처리(별도 lock UI). 본 컴포넌트는 pending 상태만 책임진다.
+  // 부모가 lockedTrainCode로 확정 신호 → pending 해제. 본 컴포넌트는 pending 상태만 책임진다.
+  // #1166: lockedTrainCode가 pendingTrainCode와 다른 값으로 확정되면 정정(round-trip correction).
+  //   pending 즉시 해제 + metric 적재 + onLockCorrected callback 호출 → 부모가 toast UX로 표기.
+  //   metric은 callback 미전달 케이스에서도 적재(테스트/배포 직후 wiring 누락 회귀 차단).
   useEffect(() => {
-    if (pendingTrainCode != null && lockedTrainCode === pendingTrainCode) {
+    if (pendingTrainCode == null || lockedTrainCode == null) return;
+    if (lockedTrainCode === pendingTrainCode) {
       clearRollbackTimer();
       setPendingTrainCode(null);
+      return;
     }
-  }, [lockedTrainCode, pendingTrainCode, clearRollbackTimer]);
+    // 정정 — pending(A) ≠ confirmed(B).
+    clearRollbackTimer();
+    recordLockCorrection(pendingTrainCode, lockedTrainCode);
+    onLockCorrected?.(pendingTrainCode, lockedTrainCode);
+    setPendingTrainCode(null);
+  }, [lockedTrainCode, pendingTrainCode, clearRollbackTimer, onLockCorrected]);
 
   // unmount 시 timer 정리.
   useEffect(() => clearRollbackTimer, [clearRollbackTimer]);

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -4,6 +4,10 @@ import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { LINE_COLORS } from '../../../../shared/constants/lineColors';
 import type { ArrivalInfo } from '../../../../shared/types/arrival';
 import type { LineNumber } from '../../../../shared/types/station';
+import {
+  getLockCorrectionMetrics,
+  resetLockCorrectionMetrics,
+} from '../../utils/lockCorrectionMetrics';
 
 function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   return {
@@ -606,22 +610,9 @@ describe('BoardingTrainList', () => {
       }
     });
 
-    it('lockedTrainCode가 미일치(다른 trainCode)면 pending 유지 — timeout으로만 해제', () => {
-      const train = makeTrain({ trainCode: 'T-MISS' });
-      const { getByTestId, rerender } = renderWithTheme(
-        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
-      );
-      fireEvent.press(getByTestId('boarding-train-row-T-MISS'));
-      rerender(
-        <BoardingTrainList
-          arrivals={[train]}
-          line="2"
-          onSelect={() => {}}
-          lockedTrainCode="T-OTHER"
-        />,
-      );
-      expect(getByTestId('boarding-train-pending-T-MISS')).toBeTruthy();
-    });
+    // #1166: 정정 case는 별도 describe(`#1166 정정 toast UX`)에서 다룬다. #1165 단계에서 mismatch는
+    // pending을 유지했으나, #1166이 적용된 이후로는 mismatch가 정정 신호로 해석되어 pending이 즉시
+    // 해제된다. 기존 회귀 가드는 정정 동작 테스트(`pending(A) → lock(B) 정정...`)로 대체된다.
 
     it('lockedTrainCode만 있고 pending이 없으면 effect는 no-op (다른 채널로 lock 생성된 케이스)', () => {
       const train = makeTrain({ trainCode: 'T-EXT' });
@@ -663,6 +654,147 @@ describe('BoardingTrainList', () => {
       const rowAfter = getByTestId('boarding-train-row-T-BUSY');
       expect(rowAfter.props.accessibilityState.busy).toBe(true);
       expect(rowAfter.props.accessibilityState.disabled).toBe(false);
+    });
+  });
+
+  describe('#1166 lock 정정 toast UX (Epic #1008 C 단기 2번 / B4 round-trip)', () => {
+    beforeEach(() => {
+      resetLockCorrectionMetrics();
+    });
+
+    it('pending(A) → lockedTrainCode(B) 정정 시 pending 즉시 해제 + onLockCorrected(A, B) 호출', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const onLockCorrected = jest.fn();
+      const { getByTestId, queryByTestId, rerender } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          onLockCorrected={onLockCorrected}
+        />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-A'));
+      expect(getByTestId('boarding-train-pending-T-A')).toBeTruthy();
+      rerender(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          lockedTrainCode="T-B"
+          onLockCorrected={onLockCorrected}
+        />,
+      );
+      expect(queryByTestId('boarding-train-pending-T-A')).toBeNull();
+      expect(onLockCorrected).toHaveBeenCalledTimes(1);
+      expect(onLockCorrected).toHaveBeenCalledWith('T-A', 'T-B');
+    });
+
+    it('정정 시 metric counter 적재 — fired 누적 + lastFiredAtMs > 0', () => {
+      const train = makeTrain({ trainCode: 'T-METRIC' });
+      const { getByTestId, rerender } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getLockCorrectionMetrics().fired).toBe(0);
+      fireEvent.press(getByTestId('boarding-train-row-T-METRIC'));
+      rerender(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          lockedTrainCode="T-OTHER"
+        />,
+      );
+      const metrics = getLockCorrectionMetrics();
+      expect(metrics.fired).toBe(1);
+      expect(metrics.lastFiredAtMs).toBeGreaterThan(0);
+    });
+
+    it('정상 확정(같은 trainCode) 시 onLockCorrected 미호출 + metric 미적재', () => {
+      const train = makeTrain({ trainCode: 'T-SAME' });
+      const onLockCorrected = jest.fn();
+      const { getByTestId, rerender } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          onLockCorrected={onLockCorrected}
+        />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-SAME'));
+      rerender(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          lockedTrainCode="T-SAME"
+          onLockCorrected={onLockCorrected}
+        />,
+      );
+      expect(onLockCorrected).not.toHaveBeenCalled();
+      expect(getLockCorrectionMetrics().fired).toBe(0);
+    });
+
+    it('onLockCorrected 미전달이어도 정정 동작은 동일 — pending 해제 + metric 적재(wiring 회귀 가드)', () => {
+      const train = makeTrain({ trainCode: 'T-NOCB' });
+      const { getByTestId, queryByTestId, rerender } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-NOCB'));
+      rerender(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          lockedTrainCode="T-DIFF"
+        />,
+      );
+      expect(queryByTestId('boarding-train-pending-T-NOCB')).toBeNull();
+      expect(getLockCorrectionMetrics().fired).toBe(1);
+    });
+
+    it('정정 후 lock 해제되면 같은 row를 다시 탭해 새 pending 진입 가능 (rollback timer 해제 확인)', () => {
+      const train = makeTrain({ trainCode: 'T-RETAP' });
+      const onSelect = jest.fn();
+      const { getByTestId, rerender } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={onSelect} />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-RETAP'));
+      rerender(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={onSelect}
+          lockedTrainCode="T-X"
+        />,
+      );
+      // 정정 후 lockedTrainCode가 다시 null로 풀린 상태(사용자 명시 해제 등)에서 재탭이 새 pending 진입.
+      rerender(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={onSelect}
+          lockedTrainCode={null}
+        />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-RETAP'));
+      expect(onSelect).toHaveBeenCalledTimes(2);
+      expect(getByTestId('boarding-train-pending-T-RETAP')).toBeTruthy();
+    });
+
+    it('lockedTrainCode만 set이고 pending이 없으면 정정 신호 무시 (외부 lock — 별 채널)', () => {
+      const train = makeTrain({ trainCode: 'T-EXT2' });
+      const onLockCorrected = jest.fn();
+      renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          lockedTrainCode="T-EXT2"
+          onLockCorrected={onLockCorrected}
+        />,
+      );
+      expect(onLockCorrected).not.toHaveBeenCalled();
+      expect(getLockCorrectionMetrics().fired).toBe(0);
     });
   });
 

--- a/src/features/alarm/utils/__tests__/lockCorrectionMetrics.test.ts
+++ b/src/features/alarm/utils/__tests__/lockCorrectionMetrics.test.ts
@@ -1,0 +1,50 @@
+import {
+  getLockCorrectionMetrics,
+  recordLockCorrection,
+  resetLockCorrectionMetrics,
+} from '../lockCorrectionMetrics';
+
+describe('lockCorrectionMetrics (#1166)', () => {
+  beforeEach(() => {
+    resetLockCorrectionMetrics();
+  });
+
+  it('초기 상태는 fired=0, lastFiredAtMs=0', () => {
+    const m = getLockCorrectionMetrics();
+    expect(m.fired).toBe(0);
+    expect(m.lastFiredAtMs).toBe(0);
+  });
+
+  it('recordLockCorrection 호출 시 fired 누적 + lastFiredAtMs 갱신', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    try {
+      recordLockCorrection('A', 'B');
+      let m = getLockCorrectionMetrics();
+      expect(m.fired).toBe(1);
+      expect(m.lastFiredAtMs).toBe(1_000_000);
+
+      nowSpy.mockReturnValue(2_000_000);
+      recordLockCorrection('B', 'C');
+      m = getLockCorrectionMetrics();
+      expect(m.fired).toBe(2);
+      expect(m.lastFiredAtMs).toBe(2_000_000);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('reset 후 counter는 다시 0', () => {
+    recordLockCorrection('A', 'B');
+    resetLockCorrectionMetrics();
+    const m = getLockCorrectionMetrics();
+    expect(m.fired).toBe(0);
+    expect(m.lastFiredAtMs).toBe(0);
+  });
+
+  it('getLockCorrectionMetrics는 호출자가 mutate해도 내부 상태 보호 (복사본 반환)', () => {
+    recordLockCorrection('A', 'B');
+    const m = getLockCorrectionMetrics() as { fired: number; lastFiredAtMs: number };
+    m.fired = 999;
+    expect(getLockCorrectionMetrics().fired).toBe(1);
+  });
+});

--- a/src/features/alarm/utils/lockCorrectionMetrics.ts
+++ b/src/features/alarm/utils/lockCorrectionMetrics.ts
@@ -1,0 +1,53 @@
+/**
+ * Lock 정정 빈도 metric — #1166 / Epic #1008 C 단기 2번 (B4 round-trip).
+ *
+ * 낙관적 탭으로 pending(A)이 잡힌 뒤 backend(또는 다른 채널)에서 다른 trainCode(B)로
+ * lock이 확정되면 BoardingTrainList가 사용자에게 toast를 노출함과 동시에 본 모듈의
+ * `recordLockCorrection`을 호출한다.
+ *
+ * 단순 in-memory counter — 1주 운영 분포 측정 후 별도 PR에서 backend POST(필요 시)로
+ * 승격. logger emit으로 디버그/로컬 분석은 즉시 가능하다(`createLogger('lockCorrection')`).
+ *
+ * 동작 변경 없음 — 순수 측정. 호출 실패가 toast UX를 차단하지 않는다.
+ */
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('lockCorrection');
+
+interface Counters {
+  /** pending→confirmed 정정 fire 누적 횟수(앱 lifetime). */
+  fired: number;
+  /** 마지막 fire 시각(epoch ms). 호출 전 0. */
+  lastFiredAtMs: number;
+}
+
+const counters: Counters = { fired: 0, lastFiredAtMs: 0 };
+
+/**
+ * Pending(A) → 확정(B)으로 정정될 때 호출. log emit + counter 적재.
+ *
+ * @param pendingTrainCode 사용자가 탭한 시점의 train code (A).
+ * @param confirmedTrainCode backend가 실제로 잠근 train code (B). A와 같을 수 없다 —
+ *   호출자(BoardingTrainList)가 mismatch만 호출하도록 가드한다.
+ */
+export function recordLockCorrection(
+  pendingTrainCode: string,
+  confirmedTrainCode: string,
+): void {
+  counters.fired += 1;
+  counters.lastFiredAtMs = Date.now();
+  log.info(
+    `lock correction fired pending=${pendingTrainCode} confirmed=${confirmedTrainCode} total=${counters.fired}`,
+  );
+}
+
+/** 현재 누적 counter 스냅샷. DebugModal/테스트 노출. */
+export function getLockCorrectionMetrics(): Readonly<Counters> {
+  return { ...counters };
+}
+
+/** 테스트 격리용 reset. production code에서 호출하지 않는다. */
+export function resetLockCorrectionMetrics(): void {
+  counters.fired = 0;
+  counters.lastFiredAtMs = 0;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -175,6 +175,10 @@ export default function HomeScreen() {
   // 매칭되면 useStationCandidates가 단일 후보로 자동 확정.
   const wifiStation = useWifiStation();
   const [confirmAutoToast, setConfirmAutoToast] = useState<string | null>(null);
+  // #1166 — backend가 사용자 탭과 다른 trainCode로 lock을 확정했을 때 노출하는 정정 toast.
+  // BoardingTrainList의 onLockCorrected callback이 채워주며, 같은 메시지가 두 인스턴스(현재역/환승)에
+  // 공통 적용된다. dismiss는 Toast의 5초 timer 또는 사용자 tap.
+  const [lockCorrectionToast, setLockCorrectionToast] = useState<string | null>(null);
   const handleConfirmStation = useCallback(
     (station: Station) => {
       setCustomOrigin(station);
@@ -199,6 +203,14 @@ export default function HomeScreen() {
     }
   }, [confirmModal.autoConfirmedStation, confirmModal.consumeAutoConfirmed, t]);
   const handleConfirmAutoToastDismiss = useCallback(() => setConfirmAutoToast(null), []);
+  // #1166 — pending(prev) → confirmed(next) 정정 시 toast 메시지 구성. 4언어 i18n.
+  const handleLockCorrected = useCallback(
+    (prev: string, next: string) => {
+      setLockCorrectionToast(t('home.lockCorrectionToast', { prev, next }));
+    },
+    [t],
+  );
+  const handleLockCorrectionToastDismiss = useCallback(() => setLockCorrectionToast(null), []);
   // #977 — F4 검색 fallback wire. confirm 모달 dismiss(setDismissed=true) + origin picker 오픈.
   // 사용자가 picker에서 station 선택 시 setCustomOrigin → confirm 모달은 hasEffectiveOrigin
   // 으로 자동 차단되어 재오픈하지 않는다.
@@ -972,6 +984,10 @@ export default function HomeScreen() {
                                   onSelect={createLockFromTrain}
                                   compact
                                   nextStationLabel={label}
+                                  // #1166: 낙관적 탭 → backend 정정 UX. lockedTrainCode를 prop으로 넘겨야
+                                  // pending 일치/정정 effect가 발화한다. fusionBoardingLock 기반 SSOT 사용.
+                                  lockedTrainCode={lockedTrainCode}
+                                  onLockCorrected={handleLockCorrected}
                                 />
                               );
                             }
@@ -997,6 +1013,10 @@ export default function HomeScreen() {
                                   walkingBufferSeconds={TRANSFER_WALKING_BUFFER_SECONDS}
                                   compact
                                   nextStationLabel={label}
+                                  // #1166: 환승 leg lock도 같은 SSOT(fusionBoardingLock). 환승 row에서도
+                                  // round-trip 정정 시 동일 toast UX 적용.
+                                  lockedTrainCode={lockedTrainCode}
+                                  onLockCorrected={handleLockCorrected}
                                 />
                               );
                             }
@@ -1215,6 +1235,13 @@ export default function HomeScreen() {
         message={confirmAutoToast ?? ''}
         onDismiss={handleConfirmAutoToastDismiss}
         testID="current-station-auto-confirm-toast"
+      />
+      {/* #1166 — backend round-trip 정정 toast. 5초 자동 dismiss + tap 닫기. */}
+      <Toast
+        visible={lockCorrectionToast !== null}
+        message={lockCorrectionToast ?? ''}
+        onDismiss={handleLockCorrectionToastDismiss}
+        testID="lock-correction-toast"
       />
 
       <DestinationPicker

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -57,6 +57,7 @@
       "message": "Arrived at {{name}} — destination cleared",
       "undo": "Undo"
     },
+    "lockCorrectionToast": "Boarding train corrected: {{prev}} → {{next}}",
     "congestion": {
       "level": {
         "low": "Light",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -57,6 +57,7 @@
       "message": "{{name}}に到着し、目的地を解除しました",
       "undo": "元に戻す"
     },
+    "lockCorrectionToast": "乗車中の列車を {{prev}} → {{next}} に修正しました",
     "congestion": {
       "level": {
         "low": "余裕",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -57,6 +57,7 @@
       "message": "{{name}}에 도착해 목적지를 해제했어요",
       "undo": "되돌리기"
     },
+    "lockCorrectionToast": "탑승 열차가 {{prev}} → {{next}}로 정정되었어요",
     "congestion": {
       "level": {
         "low": "여유",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -57,6 +57,7 @@
       "message": "已到达{{name}},已清除目的地",
       "undo": "撤销"
     },
+    "lockCorrectionToast": "已将乘车列车修正为 {{prev}} → {{next}}",
     "congestion": {
       "level": {
         "low": "宽松",


### PR DESCRIPTION
Closes #1166
Related: #1008 (Epic C 단기 2번 / B4 round-trip), #1165 (낙관적 lock 탭)

## Summary
- 낙관적 탭 pending(A)이 backend에서 다른 trainCode(B)로 확정되면 정정 toast로 사용자에게 알림.
- `BoardingTrainList`: pending vs lockedTrainCode mismatch 분기 추가 → pending 즉시 해제 + `onLockCorrected` callback.
- `lockCorrectionMetrics` 신설: in-memory counter(fired/lastFiredAtMs) + logger emit으로 정정 빈도 측정 인프라.
- `HomeScreen`: 두 BoardingTrainList 인스턴스(현재역/환승)에 `lockedTrainCode`/`onLockCorrected` wire-up, 정정 toast 렌더.
- i18n 4언어(ko/en/ja/zh) `home.lockCorrectionToast` ({{prev}} → {{next}} 보간).
- 100% 커버리지 — BoardingTrainList + lockCorrectionMetrics.

## Test plan
- [x] `npm test` BoardingTrainList/lockCorrectionMetrics 통과 (변경 영역 100%)
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [ ] 실기기: 탭 → 다른 trainCode 잠금 시 toast 노출 + 5초 후 자동 dismiss
- [ ] 실기기: 같은 trainCode 확정 시 toast 미노출 (정상 케이스)

## Dependency
- #1183 (#1165 optimistic-lock-tap)이 base. 본 PR은 PR #1183 위에 stacked — 머지 시 dev로 rebase 또는 #1183 머지 후 자동 reconcile.