### PR TITLE
chore(#1164): tasks/* 분석 문서 8개 정리

### DIFF
--- a/tasks/bg-alarm-analysis.md
+++ b/tasks/bg-alarm-analysis.md
@@ -1,0 +1,364 @@
+# BG 알람/추적 — "꺼지지 않고 계속 깨우면서 이동 + BG 알림" 동작 분석 및 원인 추적
+
+작성: 2026-05-27. 사용자 보고 ("군자 통과 중인데 앱은 용마산 표시 — 3개 역 차이") 의 원인을 코드 차원에서 분리해 분석한다.
+
+## TL;DR
+
+### 권한 정책 (1차 시나리오)
+**WhileInUse("사용하는 동안") 권한이 다수 사용자의 기본값**. 모든 핵심 기능이 **WhileInUse에서 정상 동작**해야 함. Always는 추가 보강 경로로 취급. (메모리: `feedback_whileinuse_must_work`)
+
+### 코드 차원 평가
+코드는 BG에서 알림이 오게 **이미 짜여 있다**. WhileInUse 시나리오에 대해서도 **Silent Push를 1차 채널로 설계**되어 있음(#478 완료). "꺼지지 않고 계속 깨우면서" 동작도 OS가 허용하는 한계까지 옵션 적용됨.
+
+### 사용자 증상의 직접 원인
+> **FG의 React state(useNearestStation의 result)는 BG task와 독립적으로 살아 있다. BG 동안 BG task가 GPS를 받아 알람/AsyncStorage는 갱신하지만, FG 복귀 시 화면에 표시되는 "현재 역"은 BG 진입 시점의 fix로 정지된 채 watchPosition 첫 콜백을 기다린다.**
+
+WhileInUse 사용자는 BG에서 GPS 갱신 자체가 없어 **이 stale 표시 문제가 더 빈번**. PR #543이 fix.
+
+## 1. 시스템 분리 — BG와 FG는 같은 GPS를 공유하지 않는다
+
+| 출처 | 컨텍스트 | 갱신 대상 | 살아있는 시점 |
+|---|---|---|---|
+| `useNearestStation` `watchPositionAsync` | React tree (FG) | React state (result, userLocation, accuracyMeters) → 화면 표시 | FG 활성 시 |
+| `backgroundLocationTask` (`TaskManager.defineTask`) | iOS BG task | AsyncStorage (`ALARM_EVENT_KEY`, FIRED_ALARMS, `BG_LAST_FIX_KEY`) + 알림 발사 | BG, "항상" 권한 시 |
+| `silentPushTask` (`Notifications.registerTaskAsync`) | iOS notification BG | AsyncStorage + 알림 발사 | 앱 종료/Suspended에서도 OS가 깨움 |
+
+**핵심**: BG task가 동작 중이어도 `useNearestStation`의 React state는 직접 갱신되지 않는다. FG 복귀 시 화면이 BG 시점 fix를 그대로 보여주는 이유.
+
+## 2. 사용자 증상 → 원인 가설 매트릭스
+
+### 가설 A — FG state stale (PR #543가 해결)
+- **시나리오**: 사용자가 용마산에서 화면을 끈다 → BG task가 20m/30s마다 깨워 GPS 받아 알람 트리거(있다면)는 정상 → 군자에 도착해 화면을 켠다 → `useNearestStation`의 React state는 여전히 BG 진입 직전 fix(용마산 좌표). UI는 watchPositionAsync 첫 콜백(~2s)까지 그 state를 표시.
+- **증거**:
+  - `app/(tabs)/index.tsx:215`의 AppState 'active' 리스너는 `startWatch()`만 호출 — fresh fix를 명시적으로 요청하지 않음
+  - `startWatch()` 내부에서 `getLastKnownPositionAsync()` 호출하나, freshness(15s)/accuracy(200m) 게이트로 BG 중 마지막 fix는 대부분 stale 처리 → 적용 안 됨
+  - 따라서 fresh watchPosition 콜백 도착까지 state는 그대로
+- **3개 역의 의미**: BG 5분 (역간 평균 1km, 시속 35km → 100s/역, 3역 = 300s)에서 흔히 발생. 화면 잠깐 끈 시간으로 자연스러움.
+- **해결**: AppState 'active' → `setLocationUncertain(true)` + `refresh()`. PR #543.
+
+### 가설 B — WhileInUse 권한 (BG task 자체 미실행)
+- **시나리오**: 사용자 권한이 "사용 중"이면 `Location.startLocationUpdatesAsync` 자체가 무효. BG 동안 GPS 추적 0. 알람도 BG GPS 경로로는 발사 0 → silent push 단독 의존.
+- **증상 매칭**: BG → FG 전환 시 가설 A와 동일하게 stale. 게다가 BG에 받았어야 할 알람도 못 받음.
+- **확인 방법**: `useBackgroundLocation`의 `Location.requestBackgroundPermissionsAsync` 결과 status. iOS Settings → 앱 → 위치 → "항상" 여부.
+- **메모리**: `feedback_location_permission_scope` — 사용자 다수가 WhileInUse라는 운영 인식.
+
+### 가설 C — Track A 활성이지만 BG GPS 좌표 게이트 drop
+- **시나리오**: "항상" 권한 + BG task 실행. 그러나 지하/터널/약신호에서 fix accuracy가 200m 초과 → `backgroundLocationTask` 진입부에서 `isAccuracyAcceptable` drop → processLocationUpdate 미호출 → 알람 미발화 + `BG_LAST_FIX_KEY` 미갱신.
+- **증상 매칭**: 알람 안 옴 + FG 복귀 시 stale.
+- **확인 방법**: `logSuppressedGate('gate-accuracy', ...)` 진단 로그 발생 빈도. DebugModal에 노출됨.
+- **관련**: 메모리 `feedback_realtime_priority` — "나쁜 좌표 거부" 정책 의도적.
+
+### 가설 D — Silent push 미수신 (release 빌드 회귀)
+- **시나리오**: alarm-worker가 silent push 보냈으나 디바이스에 도달 못 함 (APNs token / env / OS throttle).
+- **증상 매칭**: train data 기반 알람 안 옴. 하지만 "현재 역 3개 차이"는 silent push로 표시 갱신 안 함 → 가설 A/B/C와 직교.
+- **관련**: #506 트랙, `getSilentPushRegistrationStatus`로 가시화.
+
+### 가설 E — iOS BG location update 빈도 자율 감속
+- **시나리오**: "항상" 권한이어도 iOS가 사용자 패턴 학습 후 BG location 빈도 throttle. 코드는 `pausesUpdatesAutomatically:false` + `AutomotiveNavigation`으로 완화하나 OS 정책 한계.
+- **증상 매칭**: BG GPS 콜백이 30s가 아니라 수 분에 1회 → 가설 C와 결합되어 알람 누락 + state 갱신 누락.
+- **확인 방법**: 운영 alarmLog에서 BG fix 도달 시각 간격 분포.
+
+## 3. "BG에서 알림이 오게" 코딩 — 단계별 검증
+
+### A. iOS Background Modes (`app.config.js`)
+```js
+UIBackgroundModes: ['location', 'fetch', 'remote-notification']
+```
+- `location` ✅ — BG GPS 콜백 허용
+- `remote-notification` ✅ — silent push 수신 허용
+- `fetch` — 레거시 BGAppRefreshTask. `alarmRefreshTask`는 self-unregister만 (#411).
+
+### B. 권한 사용 문구 (Info.plist 매핑)
+```js
+locationAlwaysAndWhenInUsePermission
+locationAlwaysPermission        // "백그라운드에서 지하철역을 지속적으로 감지하기 위해..."
+locationWhenInUsePermission
+```
+
+### C. BG GPS 시작/중단 (`useBackgroundLocation`)
+- `destination` 있을 때만 시작. 해제 시 stopLocationUpdatesAsync.
+- 권한 거부 시 사용자에게 모달 1회 + Settings 이동. 거부 후 다시 묻지 않음 (deniedAlertShownRef).
+
+### D. BG GPS 옵션 (`LOCATION_TRACKING_OPTIONS`)
+```ts
+accuracy: BestForNavigation
+activityType: AutomotiveNavigation          // iOS가 GPS를 가장 공격적으로 유지
+pausesUpdatesAutomatically: false           // stationary 오판 차단
+distanceInterval: 20m + timeInterval: 30s   // 거리/시간 둘 다 보장
+showsBackgroundLocationIndicator: true      // iOS 상태바 점 표시 (사용자 인지)
+// deferredUpdatesInterval 미설정 — batching 비활성 (#189)
+```
+
+### E. BG GPS 콜백 처리 (`backgroundLocationTask`)
+```
+locations[] → latest → 게이트(fresh<15s, accuracy<200m, jump<50m/s)
+→ AsyncStorage에서 destination/sleepMode/route/allowSpeaker 로드
+→ processLocationUpdate → alarmEvent 발생 시 FIRED_ALARMS + ALARM_EVENT_KEY 저장
+```
+- **이 task가 알람 발사를 직접 한다**. `processLocationUpdate`가 내부에서 `Notifications.scheduleNotificationAsync` 호출.
+
+### F. Silent Push 처리 (`silentPushTask`)
+```
+APNs payload → extractPayload → 위치 게이트(거리 800m/400m/300m phase별)
+→ FIRED_ALARMS dedup → buildAlarmContent → Notifications.scheduleNotificationAsync(trigger:null)
+```
+- `registerSilentPushTask`가 앱 시작 시 호출되어 OS에 task 라우팅 등록.
+
+### G. APNs Trip 등록 (`useApnsTripRegistration`)
+- destination 설정 → device push token 발급 → alarm-worker에 trip 등록(POST /trips)
+- 백엔드가 train data 기반 ETA 계산 후 silent push 발사
+
+### 검증 결과
+- A~G 모두 코드 차원에서 정상 구현됨.
+- "BG에서 알림 오게 코딩되어 있는가?" → **YES**, 두 채널(BG GPS, Silent Push) 독립 발화 + 공통 dedup.
+
+## 3.1 WhileInUse 사용자 — 실제 동작 검증 (1차 시나리오)
+
+WhileInUse 권한 사용자는 BG 동안 OS가 GPS를 앱에 전달하지 않는다. 따라서 다음 두 경로만으로 모든 동작이 보장돼야 한다.
+
+### 동작하는 것
+| 동작 | 경로 | 코드 |
+|---|---|---|
+| FG GPS 추적/표시 | `useNearestStation.watchPositionAsync` | ✅ FG 활성 시 2s 간격 |
+| BG 알람 발사 | Silent Push → `silentPushTask` | ✅ alarm-worker 기반 |
+| 강제 종료 후 알람 | OS가 silent push로 ~30s 깨움 | ✅ |
+| 알람 dedup | FIRED_ALARMS (FG/BG/silent push 공통) | ✅ |
+| FG 복귀 시 위치 갱신 | (PR #543 이후) refresh + uncertain 마킹 | ✅ #543 |
+
+### 동작하지 않는 것 (Always 전용)
+| 동작 | 비고 |
+|---|---|
+| BG GPS 추적 | `Location.startLocationUpdatesAsync`가 WhileInUse에서 no-op |
+| BG GPS 기반 알람 | backgroundLocationTask 미실행 |
+| 정밀 지도 폴리라인 BG 업데이트 | 사용자가 화면 켜야 갱신 |
+
+### 결론 — WhileInUse 시나리오 보장 여부
+- **알람 발사**: ✅ Silent Push 단독 채널로 보장 (#478 완료)
+- **알람 신뢰성**: ⚠️ Silent push delivery 의존 — #506/#542 진단 트랙 가동 중
+- **FG 표시**: ✅ #543 머지 시 stale 해결
+- **앱 강제 종료 케이스**: ✅ Silent push가 OS 깨움으로 처리
+- **지하 구간**: ⚠️ silent push는 train data 기반이라 GPS 무관하나, 디바이스 네트워크 끊김 시 수신 지연
+
+**현실적 약점**: WhileInUse 사용자의 알람 신뢰성 = silent push delivery 신뢰성. 백엔드/APNs 트랙(#506)이 핵심.
+
+## 4. "계속 깨우면서 이동" 시나리오별 매트릭스
+
+| 시나리오 | Track A (BG GPS) | Track B (Silent Push) | React state 갱신 | 알람 발화 |
+|---|---|---|---|---|
+| FG + 화면 켜짐 | — | — | ✅ 2s/콜백 | FG GPS 기반 |
+| BG + "항상" 권한 | ✅ 20m/30s | ✅ 백업 | ❌ (FG 복귀 시 stale) | ✅ |
+| BG + "사용 중" 권한 | ❌ | ✅ 단독 | ❌ | Silent push 의존 |
+| 앱 강제 종료 | ❌ | ✅ OS가 ~30s 깨움 | ❌ (앱 죽음) | Silent push 단독 |
+| 지하/터널 (BG) | ⚠️ accuracy 게이트 drop | ✅ train data 기반 | ❌ | Silent push가 주력 |
+| 사용자 정지 (BG) | ⚠️ OS 자율 감속 | — | ❌ | 발사 안 함 |
+| BG→FG 전환 (이동 후) | — | — | ❌ → 첫 watch 콜백까지 stale | — |
+
+**"꺼지지 않고 계속 깨우면서 이동"의 실제 의미**:
+- 알람 발사 관점: **YES** ("항상" 권한 + 정상 신호 시). 지하/throttle 케이스는 silent push로 보완.
+- 화면 표시 관점: **NO** (가설 A) — React state는 BG 중 정지. PR #543가 FG 복귀 시 명시적 fresh fix로 보강.
+
+## 5. 사용자 보고 증상의 코드 차원 진단 흐름
+
+```
+"군자 통과 중 → 앱은 용마산 표시"
+         │
+         ├─ 화면 켰을 때 보이는가? (한 번 본 후 갱신은 빠른가?)
+         │   ├─ YES: 가설 A 단독. PR #543가 해결.
+         │   └─ NO (시간 지나도 안 바뀜): 가설 B/C/E 의심
+         │
+         ├─ 알람은 받았는가?
+         │   ├─ YES (이전 trip의 알람들이 잘 옴): Track A or B 정상. 가설 A 단독.
+         │   └─ NO: 가설 B (WhileInUse) or C (게이트 drop) or D (silent push 미수신)
+         │
+         ├─ 권한이 "항상"인가?
+         │   ├─ YES: 가설 B 제외. 가설 C/E 검토.
+         │   └─ NO: 가설 B 강력. "항상"으로 업그레이드 UX 필요 (service-gap-plan §4).
+         │
+         └─ DebugModal에서 `gate-accuracy` drop 로그 빈도 확인
+             ├─ 잦음: 가설 C 강력. MAX_ACCURACY_M=200m가 운영 환경에 엄격할 수 있음 (#447 트랙).
+             └─ 거의 없음: 가설 E (iOS throttle) or A.
+```
+
+## 6. PR #543가 해결하는 부분 / 안 하는 부분
+
+### 해결 (가설 A)
+- AppState 'active' 핸들러에서 `setLocationUncertain(true)` + `refresh()` 호출
+- refresh가 `getCurrentPositionAsync` one-shot fresh fix를 즉시 요청 → `applyLocation` → uncertain 해제 + React state 갱신
+- UI는 "위치 확인 중" 표시 후 fresh 위치로 자동 갱신
+
+### 안 함 (다른 가설)
+- 가설 B: WhileInUse → BG GPS 자체 부재. 별도 UX 트랙 필요(권한 업그레이드 안내 — #447/494 영역)
+- 가설 C: 지하 정확도 → 게이트 임계값 튜닝 트랙(#447)
+- 가설 D: Silent push 미수신 → 백엔드/APNs 트랙(#506)
+- 가설 E: iOS throttle → OS 정책 한계, 코드 옵션은 이미 최대치
+
+## 7. 추가 개선 후보 (#543 후속 또는 별도 이슈)
+
+### WhileInUse 우선 보강 (다수 사용자 시나리오)
+1. **Silent push 수신 신뢰성 측정 + 가시화** (#506 트랙 확장)
+   - 백엔드 발사 시각 vs 디바이스 수신 시각 분포
+   - APNs token 갱신 빈도/실패율
+   - sentAt → receivedAt latency 분포
+   - **WhileInUse 사용자에겐 이게 1순위 신뢰성 지표**
+2. **Silent push delivery 실패 시 fallback** (#493 트랙)
+   - silent push → alert push 전환 (강제 종료 BG 알림 보완)
+3. **Region monitoring / Geofence** (#494)
+   - iOS는 WhileInUse 앱에 대해서도 region monitoring 콜백 허용
+   - 목적지/환승역 진입 시 OS가 앱을 깨워 silent push 백업 채널로 사용
+4. **권한 상태 안내 UI** (강제 X)
+   - 메모리 `feedback_whileinuse_must_work`: "현재 권한에서 가능한 동작 + 제한"을 사용자에게 명확히 전달
+   - "사용하는 동안" 권한이어도 모든 알람이 동작함을 안내. "항상"은 추가 보강이라고 명시
+
+### FG state freshness 보강 (#543 후속)
+5. **BG task의 last fix를 FG 복귀 시 적용**
+   - 현재: `BG_LAST_FIX_KEY`는 jump gate용으로만 사용
+   - 제안: AppState 'active' 시 `BG_LAST_FIX_KEY`를 읽어 freshness 통과하면 `applyLocation`에 주입 → fresh fix 도착 전 stale 시간을 더 줄임
+   - **다만 WhileInUse 사용자에겐 효과 없음 (BG task 미실행)** → Always 사용자만 보강
+6. **`Location.getLastKnownPositionAsync` 활용 강화**
+   - WhileInUse에서도 iOS는 시스템 차원의 last known을 일부 보유. 단 갱신 여부는 OS 정책.
+
+### 진단 인프라
+7. **DebugModal에 BG fix 도달 빈도 그래프** (alarmLog 기반)
+8. **DebugModal에 silent push 수신 latency 분포** (#506 측정 인프라 확장)
+9. **권한 상태 노출** (DebugModal "권한: WhileInUse / Always" 표시)
+
+## 8. 결론
+
+### Q1. "BG가 꺼지지 않고 계속 깨우면서 이동 + 알람 가능하게 코딩되어 있는가?"
+
+**WhileInUse(다수 사용자) 관점**:
+- 알람 발사: ✅ Silent Push가 1차 채널. WhileInUse에서도 alarm-worker가 train data 기반으로 발사 → OS가 silent push로 앱 깨움 → silentPushTask 처리 → 알림 발사.
+- 화면 표시: BG 동안 GPS 갱신 0 → FG 복귀 시 stale. **PR #543가 직접 해결**.
+
+**Always 관점 (추가 보강)**:
+- BG GPS 추적까지 활성화. 알람 발사 경로가 2개(BG GPS + Silent Push) → 신뢰성 더 높음.
+- 단 "꺼지지 않고 계속"의 지속성은 iOS OS 정책 종속.
+
+### Q2. "BG에서 알림 오게 코딩되어 있는가?"
+
+**YES**. iOS Background Modes 선언 + BG location task + silent push task 모두 등록. WhileInUse 사용자도 silent push로 알림 수신 보장 설계. 알림 발사 자체는 `Notifications.scheduleNotificationAsync({trigger:null})`로 단일 출구.
+
+### 실제 위험 지점
+
+코드 자체가 아니라 **외부 의존성**에 의존하는 구간:
+1. **Silent push delivery 신뢰성** (WhileInUse 다수 사용자에게 가장 중요) → 백엔드/APNs/OS budget — #506/#542 트랙
+2. iOS BG location throttling (Always 사용자) → 옵션은 최대치, OS 정책 한계
+3. 지하 구간 디바이스 네트워크 끊김 → silent push 수신 지연 (지연 후 한꺼번에 도착)
+
+### 우선순위 순서 (다음 작업)
+
+1. **PR #543** — FG 복귀 stale 해결 (✅ 머지 완료)
+2. **#506/#542** — silent push delivery 진단/검증 (WhileInUse 사용자 1순위) ← **현재 작업 중**
+3. **#493** — alert push fallback (silent push 강제종료 보완)
+4. **#494** — Region monitoring (WhileInUse도 활용 가능한 OS 깨움)
+5. **권한 상태 안내 UI** — "WhileInUse에서도 동작합니다" 명확히 안내
+
+## 10. 실기기 진단 데이터 (2026-05-27 13:11) — #506 직접 분석
+
+### 입수 데이터 (DebugModal export)
+```
+permission=granted
+apnsToken=…35b3502c
+activeTrip=…35b3502c        ← 토큰 일치 (등록 OK)
+apnsEnv=sandbox             ← Debug build, sandbox APNs 토큰
+taskRegistration=success    ← Notifications.registerTaskAsync OK
+route=set
+destination=2-011
+currentStation=7-015 (용마산)
+lastReceived=(never)        ← 🚨 silent push 한 번도 도달 안 함
+lastFired=(never)
+lastSkipped=(never)
+
+Alarm log 87건 전체 source=fg (foreground GPS 발사만)
+BG/silent push entry 0건
+```
+
+### 차단표 (가설 a~f 중 어디서 막혔는가)
+
+| 원인 | 진단 근거 | 판정 |
+|---|---|---|
+| (a) `registerSilentPushTask` 실패 | `taskRegistration=success` | ❌ 제외 |
+| (b) `getDevicePushTokenAsync` 실패 | `apnsToken=…35b3502c` 발급됨 | ❌ 제외 |
+| (e) `Notifications.registerTaskAsync` 실패 | `taskRegistration=success` | ❌ 제외 |
+| (f) 알림 권한 미동의 | `permission=granted` | ❌ 제외 |
+| (b'') 토큰이 백엔드에 등록 안 됨 | `activeTrip=…35b3502c` (같은 토큰) | ❌ 제외 |
+| (c1) 백엔드 cron이 trip 폴링 못 함 | 미확인 (wrangler tail 필요) | ⚠️ **유력** |
+| (c2) Seoul API 응답 빈 → `etaMissing` | 미확인 | ⚠️ 가능 |
+| (c3) Phase 미발사 (ETA > 240s + 큰 변화 없음) | 미확인 | ⚠️ 가능 |
+| (d1) APNs sandbox 도달 실패 (BadDeviceToken 등) | 미확인 (wrangler tail 응답 코드 필요) | ⚠️ **유력** |
+| (d2) self-heal로 production 시도했으나 양쪽 실패 | 미확인 | ⚠️ 가능 |
+| **(g) iOS Background App Refresh OFF** | iOS Settings 확인 필요 | ⚠️ **매우 유력** |
+| (h) iOS Low Power Mode로 silent push throttle | 미확인 | ⚠️ 가능 |
+| (i) Trip이 KV에 미저장 (backend 등록 실패) | `wrangler kv:key get` 확인 필요 | ⚠️ 가능 |
+
+### 가설 g — iOS Background App Refresh가 가장 의심
+- iOS는 "Background App Refresh" 설정이 꺼져 있으면 **silent push를 앱에 전혀 전달하지 않음**. 시스템 차원 + 앱별 차원 두 단계 모두 ON이어야 함.
+- 사용자는 배터리 절약 / 데이터 절약 목적으로 종종 OFF로 설정.
+- 코드 차원에서 감지 불가 (iOS API 미노출).
+- 확인 경로: iOS Settings → General → Background App Refresh (전역) → subway-now (개별) 모두 ON 여부.
+
+### 가설 c/d — 백엔드/APNs 경로 격리 필요
+- 현재 진단 도구로는 "백엔드가 silent push를 발사하려고 시도했는지" 알 수 없음.
+- `wrangler tail`로 cron이 trip 폴링 → push 발사 시도 → APNs 응답을 봐야 c/d 격리됨.
+- **하지만** wrangler tail은 cron 1분 간격이라 한번에 5분 정도 봐야 의미 있는 데이터 수집.
+
+## 11. 오늘 fix 계획 — 직접 발사 진단 엔드포인트
+
+진단을 wrangler tail에만 의존하면 시간이 오래 걸리고 cron/Seoul API/phase 로직 변수에 가려진다. **이를 격리하기 위해 backend에 즉시 발사 엔드포인트 추가**:
+
+### 제안: `POST /diag/push`
+- Input: `{ token, host?: 'sandbox' | 'production' }` (또는 token에서 trip 조회해 apnsEnv 사용)
+- 동작: `sendSilentPush`를 cron/Seoul/phase 로직 우회하고 즉시 호출
+- 응답: `{ ok, status, reason }` — APNs HTTP 응답 그대로 노출
+- 보안: token 본인 검증(token을 입력으로 받으므로 본인만 가능)
+- 측정용 payload: `{ nextWaypoint: 'DIAG', etaSeconds: 0, phase: 'imminent', kind: 'destination', sentAt: now }`
+
+### 격리 효과
+| 응답 | 해석 |
+|---|---|
+| `200` + 디바이스 수신 ✅ | 가설 c/d 제외 → 가설 g(BG App Refresh) 또는 h(Low Power) 의심 |
+| `200` + 디바이스 미수신 | 가설 g 거의 확정 — APNs는 받았으나 iOS가 앱에 전달 안 함 |
+| `400 BadDeviceToken` | 가설 d2 — 환경 불일치 또는 토큰 무효 |
+| `403/410` | 토큰 expire / 앱 미설치 |
+| `5xx` | APNs 측 문제 |
+| 응답 자체 없음/timeout | 가설 d1 — APNs 도달 실패 |
+
+### 클라 측 변경 (선택)
+- DebugModal에 "진단 push 발사" 버튼 추가 → `/diag/push` 호출 → 응답 인라인 표시
+- 또는 사용자가 직접 `curl`로 호출하게 노출
+
+### 작업 단위
+- 새 이슈: `chore(#506): 즉시 silent push 진단 엔드포인트`
+- backend route + 단위 테스트
+- (선택) 클라 DebugModal 진단 버튼
+
+이렇게 오늘 fix → 사용자가 내일 trip 시작 전 진단 버튼 한 번 눌러봄 → 즉시 가설 격리 가능.
+
+## 9. 관련 자료
+
+### 메모리
+- `feedback_location_permission_scope` — Always 전제 금지, 다수 WhileInUse 사용자
+- `project_bg_alarm_no_always_roadmap` — 사전 예약 + Silent push로 Always 없이 동작
+- `project_alarm_accuracy_roadmap` — alarmLog 측정 인프라
+- `feedback_realtime_priority` — 나쁜 좌표 거부, grace period 도입 금지
+
+### 이슈/PR
+- #478 silent push 단독화 (Track B 단일 채널)
+- #506 release 빌드 silent-push-* 0건 진단
+- #527 GPS jump gate 도입
+- #494 Geofence/Region monitoring (지하 보강)
+- #542 BG silent push 실기기 검증
+- #543 (현재) FG 복귀 stale 표시 — 본 분석의 직접 fix
+- #447 GPS 신뢰 정책 재검토 (가설 C 후속)
+- #411 사전 예약 stopgap 제거
+
+### 코드
+- `app.config.js` (UIBackgroundModes)
+- `src/hooks/useBackgroundLocation.ts` (BG 시작/중단)
+- `src/constants/locationTracking.ts` (BG 옵션)
+- `src/tasks/backgroundLocationTask.ts` (BG GPS 콜백 처리)
+- `src/tasks/silentPushTask.ts` (silent push 핸들러)
+- `src/utils/silentPushLocationGate.ts` (위치 게이트)
+- `src/hooks/useApnsTripRegistration.ts` (백엔드 trip 등록)
+- `src/utils/notificationState.ts` (FIRED_ALARMS dedup)
+- `src/hooks/useNearestStation.ts` (FG GPS + AppState 핸들러)

--- a/tasks/bg-alarm-multi-channel-plan.md
+++ b/tasks/bg-alarm-multi-channel-plan.md
@@ -1,0 +1,229 @@
+# BG 알람 다중 채널 아키텍처 — 조사 결과 + 이슈 분해 + 진행 순서
+
+작성: 2026-05-27. `tasks/bg-alarm-analysis.md` 후속. WhileInUse + 매 역 알람 + 저전력 모드 OK를 동시에 만족하는 다중 채널 설계 확정.
+
+---
+
+## 1. 문제 정의 (재확인)
+
+### 사용자 시나리오
+- 권한: WhileInUse ("사용하는 동안")
+- 상태: 앱 BG + 저전력 모드 ON (배터리 20% 자동 진입)
+- 요구: 10개 역 이동 시 10개 알람 모두 수신 (intermediate imminent + transfer/destination early/imminent)
+
+### 현재 차단점
+저전력 모드 ON이면 iOS가 **Background App Refresh를 자동 OFF + 수동 변경 불가**.
+→ 현재 silent push 단독 구조는 OS가 강제로 차단함 → `lastReceived=(never)`.
+
+### 가치 (정확성·신뢰성 우선)
+1. 알람 누락 0 (false negative 없음)
+2. 잘못된 알람 최소 (false positive 차단)
+3. 타이밍 정확 (10초 단위 오차)
+→ 단일 채널로는 불가능. **다중 채널 + 공유 dedup** 필수.
+
+---
+
+## 2. 조사 결과 — 사용 가능/불가능 경로 (검증된 사실)
+
+### 폐기된 경로
+| 경로 | 폐기 사유 |
+|---|---|
+| **사전 예약 (#478에서 제거)** | "안 움직여도 알람 발사" — 위치 게이트 무력. 의도적 제거 결정 유지. |
+| **CLLocationPushServiceExtension** | Apple 공식 문서 명시: **"Always" 권한 필수**. WhileInUse 정책과 양립 불가. |
+| **자체 WiFi BSSID 매칭 (카카오 방식)** | iOS는 BG WiFi 스캔 API 없음. FG에서도 연결된 1개 AP만. 카카오도 iOS는 시간표 fallback. |
+| **WiFi 핑거프린팅 알고리즘 자체 구현** | KRRI 논문(2016) 방식. 안드로이드는 가능, iOS는 BG 스캔 API 부재로 불가. **단 iOS Location Services가 내부적으로 동등한 추정을 자동 수행** → Region Monitoring이 이 이점을 자동 활용. |
+
+### 채택된 경로 — 다중 채널
+| 채널 | 동작 | 실패 조건 |
+|---|---|---|
+| **채널 1: Silent push + 위치 게이트 (현재)** | 정확한 1차 채널 | BG App Refresh OFF / 저전력 |
+| **채널 2: Alert push fallback (ACK 타임아웃)** | silent 미도달 시 백엔드가 alert로 폴백 | 거의 없음 (단 위치 게이트 무력) |
+| ~~**채널 3: Region Monitoring**~~ | ~~iOS 내장 WiFi 위치 추정 활용~~ | **폐기 — #582** (WhileInUse에서 SDK가 Always 권한 강제) |
+| **(Always 사용자 자동) 채널 4: BG GPS task** | 기존 backgroundLocationTask 유지 | "Always" 권한 사용자에게만 |
+
+> **채널 3 폐기 (2026-05-28)** — #563 PoC 결과 `Location.startGeofencingAsync()`가 WhileInUse 권한에서 SDK 레벨로 실패. iOS CoreLocation이 region monitoring API에 Background 권한 entitlement를 요구해 우회 불가. 정책상 WhileInUse가 1차 시나리오이므로 채널 3은 작동 불가. 자세한 내용: `region-monitoring-poc-result.md` (#582).
+>
+> **메인 BG 채널 대안**: Local Notification 사전 예약 + Live Activity push update (BoardingLock 아키텍처, 이슈 #584/#585/#586).
+
+### 채널 매트릭스 (시나리오별 보장)
+| 시나리오 | 채널 1 | 채널 2 | 채널 4 | BoardingLock 사전예약 | 결과 |
+|---|---|---|---|---|---|
+| WhileInUse + BG App Refresh ON + 지상 | ✅ | (불필요) | — | ✅ | ✅ |
+| WhileInUse + BG App Refresh OFF + 지상 | ❌ | ✅ | — | ✅ | ✅ |
+| WhileInUse + BG App Refresh OFF + 지하 | ❌ | ✅ | — | ✅ | ✅ |
+| WhileInUse + 저전력 + 약한 신호 | ❌ | ⚠️ | — | ✅ (사전 예약) | ✅ |
+| Always + 모든 OS 차단 | ❌ | ❌ | ✅ | ✅ | ✅ |
+
+**채널 3 폐기 이후의 메인 BG 경로**: Local Notification 사전 예약 (BoardingLock 아키텍처). 네트워크/푸시 채널과 무관하게 OS 스케줄러가 발사 → WhileInUse + 저전력 + 지하 약신호 시나리오까지 커버.
+
+---
+
+## 3. 아키텍처
+
+```
+                       ┌──────────────────────────────────────┐
+                       │  공유 dedup: FIRED_ALARMS[alarmKey]    │
+                       │  alarmKey = waypointId + phase        │
+                       │  먼저 fire한 채널이 이김                │
+                       └──────────────────────────────────────┘
+                                       ▲
+        ┌──────────────────────────────┼──────────────────────────────┐
+        │                              │                              │
+   채널 1 (정확)                  채널 2 (도달 보장)              채널 3 (push 무관)
+   Silent push +                 Alert push fallback             Region Monitoring
+   위치 게이트                    (ACK 타임아웃 시만)              (iOS 내장 WiFi 추정)
+```
+
+### 채널 1 — Silent push + 위치 게이트 (현재 유지)
+```
+[backend cron]
+  └─ phase 평가 → 발사 조건 만족
+     └─ silent push 발사 (pushId 포함, apns-push-type: background, priority: 5)
+
+[device silentPushTask]
+  ├─ 위치 게이트 통과? → 알람 발사 + FIRED_ALARMS[alarmKey] 기록
+  └─ 백엔드에 ACK 전송 (pushId, fired/skip, reason)
+```
+
+### 채널 2 — ACK 기반 Alert push fallback (신규)
+```
+[backend cron]
+  └─ silent push 발사 후 30초 타이머 시작 (pushId 추적)
+     ├─ 30초 내 device ACK 수신 → 종료 (채널 1이 처리함)
+     └─ 30초 ACK 없음 → alert push 발사 (같은 pushId, title/body 포함)
+
+[device]
+  ├─ iOS가 OS 레벨에서 자동 표시
+  └─ 앱이 FG면 listener에서 FIRED_ALARMS[alarmKey] 체크 → 중복 무시
+```
+
+### ~~채널 3 — Region Monitoring (폐기, #582)~~
+
+> #563 실기기 PoC 결과 `Location.startGeofencingAsync()`가 WhileInUse 권한에서 SDK 레벨로 거부됨 (Background location permission required). iOS CoreLocation의 region monitoring API는 Always 권한 entitlement 강제 — WhileInUse 1차 시민 정책과 양립 불가. 자세한 내용: `region-monitoring-poc-result.md`.
+
+### BoardingLock 사전 예약 (채널 3 대체)
+
+```
+[trip 등록 시점]
+  └─ Per-Hop Adaptive Scheduling: 다음 waypoint별 도착 예상 시각을 Local Notification 사전 예약
+     └─ 환승 후: 직전 leg 알람 cancel, 다음 leg 알람 신규 예약 (BoardingLock 갱신)
+
+[iOS 스케줄러]
+  └─ 네트워크/푸시 채널과 무관하게 예약된 시각에 알람 발사
+
+[device 진입 시]
+  └─ 위치 게이트(채널 1) 또는 alert(채널 2)가 예약 알람보다 먼저 발사하면 dedup
+```
+
+자세한 설계: `project_alarm_sla_architecture` 메모, 이슈 #584/#585/#586.
+
+---
+
+## 4. 이슈 분해 + 진행 순서
+
+### Phase 0 — PoC (모든 후속 결정의 기반, 가장 먼저)
+| # | 제목 | 공수 | 산출물 |
+|---|---|---|---|
+| **P0** | `chore: Region Monitoring PoC — WhileInUse + BG 진입 wake 검증` | 1~2일 | 실기기 측정: WhileInUse에서 region 진입 wake 안정성, 지하 구간 감지율, 환승 재등록 매끄러움 |
+
+**P0 결과 시나리오**:
+- ✅ 안정 → 채널 3 본구현 진행, 채널 2 비중 축소 가능
+- ⚠️ 부분 → 채널 2 + 3 병렬 구축
+- ❌ 불안정 → 채널 2(alert fallback)가 메인
+
+### Phase 1 — 측정 인프라 (P0와 병렬, 1일)
+| # | 제목 | 공수 |
+|---|---|---|
+| **P1** | `chore: 채널별 도달률 측정 — alarmLog source 확장 (region-entry, alert-fallback)` | 1일 |
+
+### Phase 2 — 채널 2 (Alert push + ACK fallback)
+**#562 폐기** 후 다음으로 분해:
+
+| # | 제목 | 공수 | 의존 |
+|---|---|---|---|
+| **P2a** | `feat: backend pushId 발급 + 디바이스 ACK endpoint` | 2일 | P1 |
+| **P2b** | `feat: device silentPushTask가 발사/스킵 결과 ACK 전송` | 1일 | P2a |
+| **P2c** | `feat: backend 30s ACK 타임아웃 → alert push fallback 발사` | 2일 | P2a, P2b |
+| **P2d** | `feat: backend alert title/body 생성 (buildAlarmContent 동등)` | 1일 | — |
+| **P2e** | `feat: device alert push notification dedup (pushId + FIRED_ALARMS)` | 1일 | P2c, P2d |
+
+**머지 순서**: P1 → P2a → P2b → P2d → P2c → P2e
+
+### ~~Phase 3 — 채널 3 (Region Monitoring 본구현)~~ — **폐기 (#582)**
+
+P0 결과: WhileInUse에서 `startGeofencingAsync` SDK 거부. 본구현 불가. 메인 BG 채널은 BoardingLock 사전 예약(#584/#585/#586)으로 전환.
+
+### Phase 4 — 권한 UX (Phase 2 머지 후, 선택)
+| # | 제목 | 공수 |
+|---|---|---|
+| **P4** | `feat: 권한별 알람 신뢰도 안내 + Always 권한 선택적 업그레이드 안내 UX` | 1~2일 |
+
+WhileInUse 강제 X, "Always로 더 정확하게" 옵션 제공. 메모리 `feedback_whileinuse_must_work` 준수.
+
+---
+
+## 5. 전체 타임라인
+
+```
+Day 1     : P0 PoC + P1 측정 인프라 (병렬)        ← P0 결과: 채널 3 폐기 (#582)
+Day 2     : P1 머지
+Day 3~4   : P2a (backend pushId + ACK)
+Day 5     : P2b (device ACK 전송)
+Day 6     : P2d (alert 문구)
+Day 7~8   : P2c (타이머 + fallback)
+Day 9     : P2e (dedup)
+Day 10    : Phase 2 통합 검증 (실기기 저전력 모드 시나리오)
+Day 11~17 : BoardingLock 사전 예약 (#584/#585/#586) — Phase 3 채널 3 대체
+Day 18~19 : P4 (권한 UX)
+```
+
+총 약 **3주**. Phase 3가 region monitoring → BoardingLock 사전 예약으로 교체됨.
+
+---
+
+## 6. 폐기/유지 결정
+
+### 폐기
+- **#562 (단순 alert push hybrid)** — 위 Phase 2 분해가 더 정확. close 처리 후 P2a~P2e 신규 생성.
+
+### 유지
+- 현재 silent push 채널 (채널 1) — 정확도 1차 채널로 유지
+- 기존 위치 게이트 (`silentPushLocationGate.ts`) — 채널 1에서 유효
+- 기존 BG GPS task (`backgroundLocationTask`) — Always 사용자용 채널 4
+
+---
+
+## 7. 검증되지 않은 가정 (정직)
+
+PoC 없이 단정할 수 없는 것:
+1. ~~**Region Monitoring + WhileInUse**~~ — **검증 완료 (#563 / #582): 동작 불가**. SDK가 Always 권한 강제. 채널 3 폐기.
+2. **ACK round-trip 시간** — 디바이스가 silent push 받고 ACK 보내는 시간 분포. 30초 타임아웃이 적절한지 측정 필요. P2 통합 검증 단계에서 결정.
+3. **Cloudflare Worker cron 1분 단위** — 30초 타이머 구현 시 Durable Object 도입 필요할 수 있음. P2c 작업 시 결정.
+4. ~~**Apple WiFi DB의 한국 지하철역 커버리지**~~ — 채널 3 폐기로 측정 무의미.
+
+---
+
+## 8. 관련 자료
+
+### 분석/메모리
+- `tasks/bg-alarm-analysis.md` — 원본 진단 (가설 a~i)
+- `tasks/service-gap-plan.md` — 서비스 갭 정책 트랙
+- 메모리 `feedback_whileinuse_must_work` — WhileInUse 1차 시민
+- 메모리 `feedback_realtime_priority` — 나쁜 좌표 거부, grace period 금지
+- 메모리 `project_bg_alarm_no_always_roadmap` — 사전 예약 부활 폐기, silent push 우선
+
+### 관련 이슈
+- #478 silent push 단독화 (위치 게이트 도입, 사전 예약 제거)
+- #493 alert push fallback 트랙 (본 계획의 Phase 2 출발점)
+- #494 Region monitoring (본 계획의 Phase 3 출발점)
+- #506 silent push 미도달 진단 (본 계획 시발점)
+- #542 BG silent push 실기기 검증
+- #543 FG 복귀 stale 표시 해결
+- #562 단순 alert push hybrid (본 계획으로 대체, 폐기 예정)
+
+### 외부 참고
+- [CLLocationPushServiceExtension | Apple Developer](https://developer.apple.com/documentation/corelocation/cllocationpushserviceextension) — Always 필수 명시
+- [Citymapper SDK iOS Setup](https://docs.external.citymapper.com/getting-started/iOS-setup.html) — Always + BG Location 표준
+- [카카오지하철 - 나무위키](https://namu.wiki/w/%EC%B9%B4%EC%B9%B4%EC%98%A4%EC%A7%80%ED%95%98%EC%B2%A0) — iOS 시간표 fallback
+- [Geofencing iOS limitations](https://radar.com/blog/limitations-of-ios-geofencing) — 20 region 제한, 20초 머무름 요구
+- KRRI 논문 (안태기 외, 2016) — WiFi 핑거프린팅 k-NN Minkowski, 0.5m 그리드 + 8 AP → 평균 1m 정확도. iOS Location Services 내부 추정의 기술 근거.

--- a/tasks/bg-silent-push-real-trip-result.md
+++ b/tasks/bg-silent-push-real-trip-result.md
@@ -1,0 +1,49 @@
+# BG silent push 알람 미발화 — 실기기 검증 결과
+
+작성: 2026-05-27. 실기기 출퇴근 trip 검증 후.
+
+## 증상
+
+- 실기기 (iPhone 13 mini, iOS 26.3.1) Release 빌드 설치 후 출퇴근 trip
+- 앱 trip 활성화 → BG 진입 (잠금/이동)
+- **BG에서 환승/도착 알람 미발화**
+- 잠금화면 LA는 잘 보임 (PR #535 #534 정상)
+
+## 선행 차단 요인
+
+**[[bg-trip-persistence]] 이슈 — BG에서 trip 사라짐**.
+
+trip이 사라지면 silent push 자체가 발사 조건 미충족. trip 사라짐을 먼저 해결해야 silent push 검증 가능.
+
+## #506 본 이슈 상태
+
+| 항목 | 상태 |
+|---|---|
+| permission, apnsToken, taskRegistration, apnsEnv | ✅ 정상 (DebugModal 확인) |
+| activeTrip 등록 | ✅ 정상 (FG 상태에서 확인) |
+| backend 발사 시도 | ❓ wrangler tail 확인 필요 |
+| 클라 수신 (lastReceived) | ❌ never |
+
+## 다음 단계 (trip 영속화 후)
+
+1. trip 영속화 fix 머지 후 동일 실기기 검증
+2. BG 진입 후에도 activeTrip 유지 확인
+3. 위치 변화 발생 시 backend 발사 시도 → wrangler tail에서 푸시 발사 응답 확인
+4. APNs 응답 (200 vs BadDeviceToken/410) 분석
+
+## 가능 원인 후순위 (trip 살아있다고 가정 시)
+
+- **silent push 클라 수신 차단**: iOS BG fetch 권한 또는 expo-notifications 콜백 미동작
+- **backend가 위치 phase 진행 감지 못함**: 위치 업데이트 freq + APNs 발사 임계값 검토
+- **silent push TTL**: 네트워크 일시 끊김 시 큐잉 만료
+
+## 관련
+
+- [[subway-now-506-silent-push-diag]] (이전 메모리)
+- [[bg-trip-persistence]] (선행 이슈)
+- [[subway-now-bg-alarm-infra]] (BG 알람 인프라 3중 막힘 진단)
+
+## 작업
+
+- GitHub Issue 등록 (label: `fix`)
+- "BG trip 사라짐 해결 후 재검증" 의존성 명시

--- a/tasks/bg-trip-persistence.md
+++ b/tasks/bg-trip-persistence.md
@@ -1,0 +1,74 @@
+# BG에서 trip 사라짐 — 진단 트랙
+
+작성: 2026-05-27. 실기기 회귀 발견 (출퇴근 trip).
+
+## 증상
+
+- 앱에서 출발/도착 설정 → trip 활성화
+- 백그라운드 진입 (홈 / 잠금 / 다른 앱)
+- 일정 시간 후 앱 복귀 → **trip이 사라져 있음** (destination=null, route 초기화)
+- 결과: silent push 조건 미충족, 알람 미발화, Live Activity 종료
+
+## 영향
+
+**가장 큰 단일 회귀**. trip이 살아있어야:
+- silent push 발사 조건 (#506)
+- BG 알람 (#506, #494)
+- Live Activity 유지 (#534)
+- 정확한 도착시각 추적
+
+모두 trip 의존이라 본 이슈가 우선.
+
+## 가능한 원인 (코드 동선)
+
+### A. iOS BG task 종료
+- iOS는 BG 앱을 메모리 압박 시 종료. trip 상태가 메모리에만 있다면 손실.
+- 대응: trip을 AsyncStorage로 persist + FG 복귀 시 복원
+
+### B. Zustand store 휘발성
+- `src/store/useAppStore.ts`의 `destination` 필드가 persist 설정 누락?
+- `destinationPersist` middleware가 있다면 검증 필요
+
+### C. 도착 감지 false positive로 자동 해제
+- `app/(tabs)/index.tsx`의 arrivedBanner 로직이 BG에서 잘못 발화 →
+  `setDestination(null)` 호출 → trip 해제
+- 위치가 destination 근처 0.5km 안 들어왔는데 발화하는지 확인
+
+### D. AppState 'background' 핸들러에서 cleanup
+- AppState 리스너 어딘가에서 trip 정리하는 코드가 있을 가능성
+- grep으로 destination=null 설정 위치 전부 확인 필요
+
+### E. useApnsTripRegistration 또는 silentPushTask에서 trip 만료 로직
+- 백엔드 trip 등록이 만료되면 클라가 자동 해제하는지 검토
+
+## 진단 단계
+
+- [ ] **1. Zustand persist 확인**: `useAppStore`의 destination이 AsyncStorage로 영속화되는지
+- [ ] **2. setDestination(null) 호출처 그렙**: 어디서 trip 해제하는지 전수 조사
+- [ ] **3. AppState 'background' 리스너 확인**: BG 진입 시 cleanup 로직 있는지
+- [ ] **4. DebugModal로 BG 진입 전후 비교**:
+  - trip 시작 직후 dump (activeTrip 등록 확인)
+  - BG 진입 후 1분, 5분, 10분 시점 dump
+  - FG 복귀 후 dump
+- [ ] **5. 알람로그에서 trip 해제 시각 추적**: setDestination 호출 로그 추가 필요할 수도
+
+## 진단 결과별 후속 액션
+
+| 원인 | 액션 |
+|---|---|
+| Zustand persist 누락 | `persist` middleware 추가 |
+| 도착 false positive | arrivedBanner 발화 조건 강화 (GPS accuracy + 시간 필터) |
+| AppState 핸들러 cleanup | 의도된 동작인지 확인 후 제거 |
+| iOS BG 종료 | persist 추가 + FG 복귀 시 복원 |
+
+## 관련
+
+- #506 silent push 검증 — 본 이슈 해결 후 가능
+- #494 region monitoring — BG 알람 보강
+- subway_now_506_silent_push_diag.md (이전 진단 메모리)
+
+## 작업
+
+1. 본 이슈를 GitHub Issue로 등록 (label: `fix`, `bug`)
+2. 진단 1~4 단계 결과 → 이슈 코멘트
+3. fix PR 별도 브랜치 (`fix/#<번호>-bg-trip-persistence`)

--- a/tasks/gps-realtime-drift-3stations.md
+++ b/tasks/gps-realtime-drift-3stations.md
@@ -1,0 +1,63 @@
+# 실시간 GPS 위치가 실제 위치 대비 약 3개 역 차이 — 진단 트랙
+
+작성: 2026-05-27. 실기기 회귀 발견 (출퇴근 trip).
+
+## 증상
+
+- 사용자 실제 위치와 앱이 추정한 "현재 역"이 **약 3개 역 차이**
+- 예: 실제 군자역 통과 중 → 앱은 "용마산" 표시
+- 이동 중에도 갱신이 느려서 사용자가 실제로 도착할 때쯤 비로소 갱신
+
+## 가능한 원인
+
+### A. BG GPS 미동작 + 캐시된 stale 위치 표시
+- `useFusedNearestStation`이 BG 시간 동안 캐시 위치 유지
+- FG 복귀 시 즉시 fresh fix 요청 (`refreshRef.current()`) 하지만 새 fix까지 수~수십초
+- 그 사이 stale 위치로 표시
+- 관련: `app/(tabs)/index.tsx:189-201` AppState 'active' 리스너
+
+### B. WhileInUse 권한 환경
+- "Always" 권한 없으면 BG GPS 안 돔 → 이동 거리만큼 위치 갱신 지연
+- `feedback_location_permission_scope.md` (memory): "Always 전제 금지", 사용자 다수가 WhileInUse
+
+### C. Fusion이 train data로 잘못 단정
+- `useFusedNearestStation`의 train fusion 로직이 환승역/병행 노선에서 오인
+- service-gap-plan.md §2.7 보류 결정 — trip 없을 때 train fusion 약하게 가도록
+
+### D. expo-location 정확도 설정
+- `MAX_ACCURACY_M_DISPLAY=250m`가 운영 환경에서 너무 관대
+- #447 (콜드스타트 GPS 신뢰 정책) 트랙과 직결
+
+### E. 지하 구간 무선 끊김
+- 터널/지하역에서 GPS/WiFi/cell triangulation 모두 약함
+- iOS가 stale 위치 반환 → 앱이 그걸 그대로 사용
+
+## 진단 단계
+
+- [ ] **1. 권한 설정 확인**: 실기기 위치 권한이 "사용 중" vs "Always"
+- [ ] **2. DebugModal에서 GPS accuracy + last update time 확인**:
+  - trip 중 GPS 응답 freq
+  - accuracy 분포 (3역 차이 시점에 accuracy 값)
+- [ ] **3. AlarmLog의 위치 fix 시각 추적**
+- [ ] **4. 환승역/병행 노선 케이스 vs 단일 노선 케이스 비교**:
+  - fusion 영향이면 환승역에서 더 심함
+
+## 진단 결과별 후속 액션
+
+| 원인 | 액션 |
+|---|---|
+| WhileInUse + BG GPS 부재 | "Always" upgrade UX (trip 시작 시) — service-gap-plan 4. |
+| Stale 캐시 표시 | FG 복귀 시 stale 위치 명시적 invalidate |
+| MAX_ACCURACY 관대 | #447 트랙에서 임계값 튜닝 |
+| Fusion 오인 | trip 활성화 시 train fusion 비활성화 (이미 jump gate 일부 처리) |
+
+## 관련
+
+- #447 (콜드스타트/저정확도 GPS 신뢰 정책 재검토)
+- #494 (region monitoring/geofence) — 정확한 wake-up 보완
+- service-gap-plan §2.1 (GPS jump gate) — 이미 머지된 PR #528 보강
+
+## 작업
+
+- GitHub Issue 등록 (label: `fix`, `bug`)
+- 실기기 alarmLog 1-2주 수집 후 분포 분석 (#447 트랙과 통합)

--- a/tasks/region-monitoring-poc-result.md
+++ b/tasks/region-monitoring-poc-result.md
@@ -1,0 +1,40 @@
+# Region Monitoring PoC 결과 (#563)
+
+> 다중 채널 BG 알람 아키텍처(`bg-alarm-multi-channel-plan.md`) 채널 3 본구현 전 신뢰도 검증.
+> 결론: **WhileInUse 권한으로는 동작 불가 → 채널 3 폐기**.
+
+## 실측 환경
+
+- **디바이스**: iPhone (실기기)
+- **앱 빌드**: dev (`chore/#563-region-monitoring-poc` 브랜치 로컬 빌드)
+- **시도한 권한 조합**: WhileInUse only (정책상 1차 시나리오)
+
+## 결과
+
+`Location.startGeofencingAsync()` 호출 시 SDK 레벨에서 실패:
+
+```
+state: failed
+count: 0
+error: "Calling the 'startGeofencingAsync' function has failed
+        → Caused by: Background location permission is required
+          to do this operation"
+```
+
+expo-location SDK (= iOS CoreLocation `startMonitoring(for:)`) 가 region 등록 시점에 **Always(Background) location 권한 entitlement를 요구**. WhileInUse에서는 API 진입 자체가 거부됨 — 우회 경로 없음.
+
+## 결론
+
+**채널 3 (Region Monitoring) 폐기.**
+
+근거:
+- 프로젝트 정책: WhileInUse 권한이 1차 시나리오 (다수 사용자가 "사용하는 동안" 선택). `Always` 권한 강제는 정책 위반.
+- expo-location / iOS CoreLocation이 region monitoring API에 Background 권한을 강제하므로 SDK 레벨 우회 불가.
+- 따라서 WhileInUse 기반 사용자에게는 채널 3이 작동할 수 없음 → 측정/도달률 무의미.
+
+## 후속 액션
+
+- PoC 코드(`src/tasks/regionMonitoringPocTask.ts`, DebugModal Region PoC 섹션) 정리는 별도 이슈로 분리.
+- BG 알람 메인 채널은 **Local Notification 사전 예약 + Live Activity push update**로 전환 (BoardingLock 아키텍처, `project_alarm_sla_architecture` 메모 참조).
+- 채널 1 (Silent push) — reschedule 정정 역할로 재정의.
+- 채널 2 (Alert push) — 사후 fallback 그대로 유지.

--- a/tasks/service-gap-plan.md
+++ b/tasks/service-gap-plan.md
@@ -1,0 +1,329 @@
+# subway-now 서비스 갭 분석 및 실행 계획
+
+작성일: 2026-05-26
+대화 컨텍스트: 21:29 효창공원앞↔신내 GPS 텔레포트 사고 진단 후, "카카오/네이버 수준의 지하철 안내" 목표 대비 현 상태 점검
+
+---
+
+## 0. 목표 — 사용자가 원하는 서비스 (여정 순)
+
+1. 앱 실행 → 현재 위치/현재역 표시 (지상·지하 모두)
+2. 출발/도착 입력 → 경로(환승 포함) 탐색
+3. "안내 시작" → 트립 활성화
+4. FG에서 현재역이 매끄럽게 갱신 (텔레포트 없음)
+5. FG 알람: 역 통과 / 환승 안내 / 도착 임박
+6. BG(잠금화면, 다른 앱 사용 중)에서 알람 발화
+7. BG 실시간 현황 UI — 잠금화면/Dynamic Island Live Activity
+8. 강제종료 상태에서도 알람 도달
+9. 출처/신뢰도가 화면에 자백 (지하·정지·부정확 시 오인 방지)
+10. 막차 알림 등 시간 기반 안내
+
+---
+
+## 1. 현재 상태 평가
+
+| # | 항목 | 동작 | 결함 | 근거 |
+|---|---|---|---|---|
+| 1 | 현재역 표시 | ⚠️ | jump gate 부재 | `useNearestStation.ts:68-106` accuracy 게이트만 존재 |
+| 2 | 경로 탐색 | ✅ | — | `stationRoute.ts` `findRoute` |
+| 3 | 트립 활성화 | ✅ | — | activeTrip 토큰 정상 전환 확인 (txt1 → txt2) |
+| 4 | FG 현재역 안정화 | ⚠️ | route 없을 때 GPS-only fallback | `useFusedNearestStation.ts:283-287` |
+| 5 | FG 알람 | ⚠️ | false-positive (21:29:23 신내) | alarm log |
+| 6 | BG 알람 | ⚠️ | GPS-only fusion, train data 미사용 | `backgroundLocationTask.ts` → `stationPipeline.ts` 의 import에 positionApi/arrivalApi 없음 |
+| 7 | BG Live Activity | ⚠️ | 인프라 진행 중 | #506, memory `subway_now_bg_alarm_infra.md` |
+| 8 | 강제종료 BG 알림 | ❌ | silent push만 의존 | #493, #478 OPEN |
+| 9 | uncertainty UI | ❌ | 미구현 | #327, #475 OPEN |
+| 10 | 막차 알림 | ❌ | 미구현 | #474 OPEN |
+
+### 21:29 사고가 노출한 3중 갭
+
+1. **#1·#6 GPS jump gate 부재** → 효창공원앞↔신내 25km/8s 텔레포트 좌표 수용
+2. **#4 fusion fallback** → trip/route 미설정 시 position-train 비활성, GPS 잡음 그대로 표시
+3. **#9 uncertainty UI 부재** → 사용자가 의심할 단서 없이 false-positive 알람을 100% 신뢰
+
+---
+
+## 2. 갭별 실행 계획
+
+### 2.1 GPS jump gate (Phase A · #1·#5·#6 동시 해결)
+
+**무엇**: 이전 fix 대비 거리·시간으로 물리적으로 불가능한 좌표를 drop.
+
+**파일**
+- 새 헬퍼: `src/utils/locationGates.ts` 에 `isPlausibleJump(prev, curr): boolean`
+- 적용 1: `src/hooks/useNearestStation.ts:68-106` `applyLocation` — accuracy 게이트 다음. 실패 시 `setLocationUncertain(true)` 후 early return
+- 적용 2: `src/tasks/backgroundLocationTask.ts:31-43` age/accuracy 게이트 옆
+- 적용 3: `src/utils/stationPipeline.ts` 진입부 (BG·silent push 공통 입구 방어)
+
+**임계값**
+- 속도: `> 50 m/s` (지하철 최고 ~22 m/s + 안전마진)
+- 짧은 Δt 보강: `Δt < 5s && Δ > 500m`
+- 첫 fix / prev null 시 통과
+
+**테스트**: `__tests__/locationGates.test.ts` — 정상/25km 점프/정지 노이즈/콜드스타트 4 케이스
+
+**리스크**: 낮음 — 단일 게이트, fallback은 기존 `locationUncertain` UX 재사용
+
+**공수**: 1 PR, 반나절. **ROI 1위.**
+
+---
+
+### 2.2 uncertainty UI (Phase B · #327, #475)
+
+**무엇**: 카카오/네이버 패턴 — 정확도/출처를 FG·BG·잠금화면 모든 표면에 자백.
+
+**현황 (2026-05-26 dev 기준)**
+- `useFusedNearestStation`이 이미 `source`/`confidence`/`locationUncertain`/`accuracyMeters` 노출
+- 홈은 `__DEV__` 한정 텍스트(`testID="home-fusion-source-badge"`)만 — 프로덕션 사용자 노출 0
+- 지도는 react-native-maps 네이티브 전환 완료 (`buildMapConfig.ts`) — Circle 컴포넌트로 1줄 추가 가능
+- Live Activity `SubwayActivityAttributes.swift`에 source 필드 없음
+- 알람 본문(`stationNotification.ts` `buildAlarmContent`/`sendAlarmNotification`/`sendStationPassedNotification`)에 source 인자 없음
+- `silentPushLocationGate.ts`는 이미 `locationSource: GateLocationSource` 추적 중 → 재활용
+
+**i18n 키 (3 PR 공용)**
+- `source.positionTrain`: "열차 데이터"
+- `source.routeProgress`: "경로 추정"
+- `source.gpsOnly`: "GPS 추정"
+- `source.uncertain`: "위치 확인 중"
+
+**PR 1 — 홈 source 배지 (#327)**
+- 신규 `src/components/SourceBadge.tsx`
+- `app/(tabs)/index.tsx:375-385` `__DEV__` 텍스트를 프로덕션 배지로 승격 (디버그 `source·confidence` 텍스트는 `__DEV__` 안에 별도 유지)
+- locationUncertain일 때 배지 라벨 "위치 확인 중"으로 오버라이드
+- 공수: 반나절
+
+**PR 2 — 지도 사용자 정확도 원 (#327)**
+- `src/components/StationMap.tsx`에 `react-native-maps`의 `Circle` import
+- props에 `accuracyMeters?`, `locationUncertain?` 추가
+- 사용자 좌표 위 Circle radius=accuracyMeters, uncertain 시 회색/투명도↓
+- `app/(tabs)/map.tsx`에서 `useFusedNearestStation` 값 전달
+- `StationMap.web.tsx`는 props 미러만
+- 공수: 반나절 (네이티브 전환 덕)
+
+**PR 3 — BG·잠금화면·푸시 본문 source 라벨 (#475 + 알람 보강)**
+
+LA/위젯:
+- `targets/subway-widget/_shared/SubwayActivityAttributes.swift` `source: String` 추가
+- `modules/live-activity` start/update payload 확장
+- `SubwayLiveActivityWidget.swift` + `SubwayWidget.swift` 라벨 표시
+- `src/utils/widgetStorage.ts` App Groups 스키마 확장
+
+알람 본문 (보강 — BG 자백 핵심):
+- `stationNotification.ts` 3 함수에 `source?: NotificationSource` 추가 (`'position-train'|'route-progress'|'gps'|'uncertain'`). undefined면 라벨 생략(기존 caller 회귀 최소화)
+- body 끝에 `· ${t('source.' + key)}` 부착 (`appendQuickHint` 패턴 재사용)
+- `src/utils/stationPipeline.ts` `ProcessLocationInputs`에 `fusionSource?`, `locationUncertain?` 추가 → notificationSource 결정 후 전파
+- `src/tasks/backgroundLocationTask.ts`: `fusionSource: 'gps'` 명시 (BG가 GPS-only라는 사실 자백)
+- `src/tasks/silentPushTask.ts`: `gate.locationSource` → notificationSource 매핑. payload 경로 = `'position-train'`(서버 train data 기반), GPS gate 경로 = `'gps'`
+
+리스크:
+- 알람 본문 길이 증가 → iOS 푸시 잘림. 라벨 최대 6자 유지
+- caller 시그니처 변경 — optional이라 점진 적용
+- 네이티브 빌드 필요 — dev build 실기기 회귀 1회
+
+공수: 1.5~2일
+
+**총 공수**: 2.5~3일 (원안 3일 유지, 분배만 변경 — 지도 단순화 ↔ 알람 보강 추가)
+
+---
+
+### 2.3 silent push 도달 검증 (Phase A · #506)
+
+**무엇**: 인프라는 memory상 1·2 해결. 남은 건 실제 trip에서 도달 카운트 확인.
+
+**파일**: 코드 변경 0. `src/tasks/silentPushTask.ts:handleSilentPush`의 `lastReceived` 카운터를 다음 trip에서 캡처.
+
+**검증 절차**
+1. 실기기에서 trip 시작
+2. 한 사이클 후 DebugModal 캡처
+3. `Silent Push > lastReceived != (never)` 확인
+4. 안 잡히면 #339 통합 검증 트랙으로 escalation
+
+**리스크**: 코드 0, 사용자 수동 검증 필요
+
+**공수**: 다음 출퇴근 1회
+
+---
+
+### 2.4 Region monitoring / Geofence (Phase C · #494)
+
+**무엇**: 강제종료/딥슬립 상태에서도 OS가 역 진입 시 앱을 깨움.
+
+**접근**
+- `expo-location.startGeofencingAsync` + `TaskManager.defineTask` 결합
+- 트립 시작 시 `route.stations` 중 다음 N개(예: 5개)에 `CLCircularRegion(radius=150m)` 등록
+- 진입 task → `stationPipeline.processLocationUpdate({source:'geofence'})`로 라우팅
+- 트립 종료/역 통과 시 region 해제 + 다음 N개로 이동창 갱신
+
+**리스크**: 높음
+- iOS region 동시 등록 한도 20개
+- 권한 "Always" 필요 — memory `feedback_location_permission_scope.md` 룰("Always 전제 금지")과 충돌
+- 완화: trip 시작 시점에만 "Always" upgrade 권유, 평소엔 "사용 중" 유지
+
+**공수**: 1주 내외 (권한 UX 포함)
+
+---
+
+### 2.5 silent push → alert push 전환 (Phase C · #493)
+
+**무엇**: 강제종료에서 silent는 OS가 안 깨움 → alert(content-available 0)로 직접 표시.
+
+**파일**
+- 서버 측 페이로드: `apns-priority: 10`, `alert` 본문 포함
+- 클라: `handleSilentPush`의 `scheduleNotificationAsync` 우회 (OS가 직접 표시). `lastFired` 마킹 경로만 보전
+
+**리스크**: 중간 — trip 외 alert 노출 위험. **반드시 #496(정지 사용자 push 차단)과 함께** 진행
+
+**공수**: 서버 PR 1 + 클라 PR 1
+
+---
+
+### 2.6 정지 사용자 push 차단 (Phase C · #496)
+
+**무엇**: 서버가 progress 인지 → 정지 시 push 발사 skip
+
+**파일**: 백엔드 트랙 (이 레포 밖)
+
+**리스크**: 백엔드 의존, 본 레포 단독 해결 불가
+
+**공수**: 백엔드 1주
+
+---
+
+### 2.7 trip 없이도 fusion 효과 (보류)
+
+**검토 결과: 보류**
+
+- jump gate(2.1)만으로 21:29 사고는 차단됨
+- trip 없을 때 train data로 단정 → 환승역/병행 노선에서 새 오인 위험
+- 대신 trip 설정 UX를 친절하게 (권유 배너) 해서 자연스럽게 trip 켜도록 유도
+
+---
+
+### 2.8 작은 fix들
+
+| 이슈 | 무엇 | 파일 | 공수 |
+|---|---|---|---|
+| #517 | Mock arrival 상행/하행 동일 | `src/providers/MockProvider.ts` | 반시간 |
+| #447 | 콜드스타트 lastKnown 정책 재검토 | `useNearestStation.ts:144-164` | jump gate 후 재평가 |
+| #411 | 사전 예약 stopgap 제거 | — | #506 안정화 후 |
+| #410 | PR #402/#407 실기기 회귀 | — | 수동 |
+
+---
+
+### 2.9 큰 트랙 (별도 페이즈)
+
+- **#474 막차 알림** — 시간표 API ETL + 스케줄러. 1~2주
+- **#473 전체 시간표 ETL Option B** — 상세 플랜은 §5 참고. #474·#517 동시 해소
+- **#79 OAuth** — 다중기기 trip 동기화 필요시
+
+---
+
+## 5. 시간표 ETL 도입 플랜 (#473) — 후속 트랙
+
+작성: 2026-05-26. Phase A·B 완료 후 진행. 연관: #473, #474, #517.
+
+### 5.1 배경
+
+- 실시간 도착 API(`fetchArrivalInfo`)는 정상. 실패 시 `scheduleFallback.buildScheduleArrival`이 헤드웨이만으로 다음 2편 추정
+- 상하행 동일값 출력(#517) + 디버그 패널 `(MOCK)` 라벨
+- 막차 알림(#474)은 시간표 부재가 근본 원인
+- fallback을 헤드웨이 → 실제 시간표로 교체하면 #517·#474 함께 해소
+
+### 5.2 의사결정 (확정)
+
+| 항목 | 결정 | 근거 |
+|---|---|---|
+| 데이터 소스 | **번들 내장** | 지하 오프라인 동작 핵심. CDN 인프라/캐시 복잡도 회피 |
+| 데이터 분할 | **노선별 파일** | `await import('./timetables/line-${n}.json')` 동적 로딩 |
+| 갱신 주기 | **수동 (분기별)** | 서울교통공사 개정 빈도 낮음. YAGNI |
+| ETL 책임자 | **개정 발생 시 PR** | 자동화는 첫 운영 사이클 후 검토 |
+| Remote override | **v1 미포함** | 향후 필요 시 추가 |
+
+예상 크기: 528역 × 3요일 × 2방향 × ~250편/일 = ~80만 엔트리 → minify + 노선 분할 + gzip = **5~8 MB**
+
+### 5.3 Phase별 작업
+
+| Phase | 내용 | 산출물 | 공수 |
+|---|---|---|---|
+| 1 — 소싱·스키마 | 서울 API `SearchSTNTimeTableByFRCodeService` 검증, `stnId` 매핑, 1노선 prefetch로 크기 실측 | API 샘플, 매핑 초안, 크기 측정 | 반나절~1일 |
+| 2 — ETL 스크립트 | `scripts/fetch-timetables.js`(rate limit, 재시도, idempotent) + `scripts/validate-timetables.js` | 노선별 JSON, 검증 스크립트 | 1~2일 |
+| 3 — fallback 교체 | `buildScheduleArrival` 동적 import 기반 재작성, `isMock:false` / `source:'timetable'`, `ArrivalSourceNotice` 라벨 분기 조정 | 새 fallback, MOCK 라벨 제거 | 1일 |
+| 4 — 테스트 | ETL 단위, fallback lookup(평일/토/일·자정 경계·막차 후), 커버리지 100%, 빌드 크기, RN 동적 import 검증 | 테스트, 크기 보고 | 1~2일 |
+| 5 — 운영 | 갱신 정책 문서, PR 템플릿 체크리스트, 무결성 CI 게이트 | 운영 문서, CI 워크플로우 | 반나절 |
+
+데이터 형식 예시:
+```json
+{
+  "weekday":  { "up": ["0530", "0535", ...], "down": [...] },
+  "saturday": { "up": [...], "down": [...] },
+  "sunday":   { "up": [...], "down": [...] }
+}
+```
+
+### 5.4 리스크
+
+| 리스크 | 완화책 |
+|---|---|
+| API rate limit (528역) | 분산 호출 + 지수 백오프 |
+| 데이터 크기 부풀림 | minify + 노선별 분할 + gzip 측정 |
+| 개정 누락 | PR 템플릿 체크리스트 + CI 무결성 게이트 |
+| RN 동적 import 호환성 | Phase 1에서 1노선으로 사전 검증 |
+| Scope creep | #473 트랙으로 분리. #517은 본 트랙 완료 시 자동 해소 |
+
+### 5.5 #517 단독 처리
+
+ETL 완료 시 #517 자동 해소 → **별도 PR 불필요**. ETL 일정이 길어지면 임시 stopgap(헤드웨이/2 dir 오프셋, 반시간)을 도입 검토 — 단 MOCK 라벨 유지되어 근본 해결은 아님.
+
+### 5.6 공수·트리거
+
+- 총: **5~7 작업일** (외부 의존 변수로 ±2일)
+- 시작 트리거: Phase A·B(GPS 사고 차단 / uncertainty UI) 완료 후
+
+---
+
+## 3. 실행 순서
+
+### Phase A — 이번 주 (1~2일)
+- [x] 2.1 GPS jump gate ← #527/PR #528 머지 (2026-05-26)
+- [x] 2.8 #517 Mock arrival fix ← PR #537 머지 (2026-05-26)
+- [ ] 2.3 #506 silent push 도달 검증 ← **#541 (BG trip 사라짐) 선행 차단** (2026-05-27 실기기 검증)
+
+### Phase B — 이번 달 (1주) ← 진행 중
+- [x] PR 1: 홈 source 배지 (#327)
+- [x] PR 2: 지도 사용자 정확도 원 (#327)
+- [x] PR 3: BG/LA/위젯/알람 본문 source 라벨 (#475 + 알람 보강, PR #533)
+
+### Phase C — 다음 사이클 (1~2주)
+- [ ] 2.4 Region monitoring (#494)
+- [ ] 2.5 alert push 전환 (#493) + 2.6 정지 차단 (#496) 동기
+
+### Phase D — 사이클 외
+- [ ] #474 막차
+- [ ] #79 OAuth
+
+---
+
+## 3.1 추가 발견 이슈 (2026-05-27 실기기 회귀)
+
+오늘 새벽까지 진행한 ETL Phase 1+2+3(#473) 머지 후 실기기 회귀에서 발견. 모두 BG/실기기 트랙으로 오늘 PR 범위 밖.
+
+- **#541 BG trip 사라짐** ← **최우선** (silent push/알람/LA 모두 의존). 자세히: `tasks/bg-trip-persistence.md`
+- **#542 BG silent push 알람 미발화 (#506 후속)** ← #541 해결 후 재검증. 자세히: `tasks/bg-silent-push-real-trip-result.md`
+- **#543 실시간 위치 3역 차이** ← #447과 통합 관리 가능. 자세히: `tasks/gps-realtime-drift-3stations.md`
+
+## 3.2 ETL 트랙 (#473) — 오늘 세션 완료
+
+- [x] Phase 1 — 1호선 ETL + 크기 실측 (PR #538)
+- [x] Phase 2 — 2~9호선 ETL (PR #539)
+- [x] Phase 3 — buildScheduleArrival 시간표 lookup 재작성 (PR #540)
+- [ ] Phase 4-5 — 테스트 보강, CI 무결성 게이트, 운영 문서 (별도 트랙)
+- [ ] 분당/신분당/경의중앙/공항 시간표 — 다른 API 사용, 향후 별도 트랙
+
+---
+
+## 4. 의사결정 메모
+
+- **Always 권한**은 trip 시작 시에만 upgrade 권유. 기본은 "사용 중" 유지 (memory `feedback_location_permission_scope.md`)
+- **jump gate 임계값**은 운영 alarmLog 1~2주 관찰 후 #495에서 튜닝
+- **trip 없을 때 fusion 강화**는 보류 — 환승역 오인 위험 > GPS 안정화 이득
+- **막차/OAuth**는 핵심 사고 차단(Phase A·B·C) 끝난 뒤 검토

--- a/tasks/system-stability-plan-2026-05-31.md
+++ b/tasks/system-stability-plan-2026-05-31.md
@@ -1,0 +1,200 @@
+# System Stability Plan — 2026-05-31
+
+> 4개 영역 100% 코드 분석 결과 + 디바이스 debug modal + Cloudflare cron 로그 기반.
+> 사용자가 보고한 5가지 핵심 문제 (BG 광범위, 위치 정체, BG 알람 미발화, 재실행 경로 어긋남, 환승역 오알람)의 root cause 식별 및 통합 fix 로드맵.
+
+---
+
+## 분석 입력
+- `tasks/` 내 기존 분석 문서 (bg-alarm-analysis, bg-trip-persistence 등)
+- Cloudflare Workers cron 로그 11.5h window
+- 디바이스 debug modal 1회 캡쳐
+- 코드: `src/`, `backend/alarm-worker/src/`, `ios/`, `app.config.js`, `eas.json`, `.entitlements`
+
+---
+
+## 사용자 보고 5가지 문제 (요약)
+1. BG에서 광범위한 문제
+2. 위치 서비스가 현재역을 따라가지 못함 (이동했는데 정체)
+3. BG에서 알람 미발화, FG에서만 발화
+4. 앱 재실행 시 현재역이 시작점이 아니라 다른 역
+5. 노선 X/Y 환승역(예: line 1/7)에서 X호선 탑승 중인데 Y호선 환승 알람 오발화
+
+---
+
+## 결정적 발견 5건 (이번에 새로 식별)
+
+### F-1. `aps-environment = development` (entitlement vs eas.json mismatch)
+- `ios/subwaynow/subwaynow.entitlements:6` = `development`
+- `eas.json` production profile = `EXPO_PUBLIC_APNS_ENV=production`
+- → production APNS host(`api.push.apple.com`)에 development 토큰 전송 → 100% BadDeviceToken
+- 디바이스 debug modal의 `lastReceived=(never)` 가장 유력한 원인
+- backend `sendWithEnvHeal`이 self-heal하지만 fallback path에는 없음
+
+### F-2. Backend `kind: 'reschedule'`을 client가 100% drop
+- `src/tasks/silentPushTask.ts:134-135` valid kind = `{transfer, destination, intermediate}`
+- backend `backend/alarm-worker/src/apns.ts:191 sendReschedulePush`는 `kind: 'reschedule'` 발사
+- client는 `payload-missing-kind` skip → **사전 예약 정정 신호 100% 무의미**
+
+### F-3. Backend `isSameSession`이 `createdAt` strict 비교
+- `backend/alarm-worker/src/index.ts:46` — `existing.createdAt === incoming.createdAt`
+- client `useApnsTripRegistration.ts:118-126`의 `lastSessionKeyRef`는 hook lifetime
+- → cold restart마다 `createdAt=Date.now()` 새로 박힘 → backend waypoints 통째 wipe
+- **backend 로그의 "advance → 다음 minute 첫 waypoint reset" 사이클 직접 원인**
+
+### F-4. `TRIP_ORIGIN_KEY`가 존재하지 않음
+- `src/constants/storageKeys.ts` 17개 키 전수조사 결과 없음
+- `src/hooks/useTripOrigin.ts:31-44`는 `useState` 전용
+- → cold restart 시 첫 GPS fix를 origin으로 캡쳐 = **사용자 보고 #4 직접 root cause**
+
+### F-5. `useStationAlarm setFiredAlarms`가 fire-and-forget
+- `src/hooks/useStationAlarm.ts:175` — AsyncStorage write 완료 대기 안 함
+- → 다음 evaluation이 stale state 봄 = **destination 2분 차 2번 발사 직접 원인**
+
+### 보조 발견
+- F-6. Backend `sendSilentPush`/`putPending` production caller 없음 (grep 결과). 로그의 fallback fire 6건과 mismatch — deploy vs repo 추적 필요
+- F-7. `_layout.tsx:39-44 cancelScheduledAlarms()`가 매 cold start 호출 → `bl:` 사전예약 알람 wipe 가능성
+- F-8. `useApnsTripRegistration.ts:238` deps에 `nextStationEtaSeconds`/`currentStation?.id` 포함 → 30s마다 effect 재실행 → ms-동일 3개 POST race
+- F-9. `purgeBoardingLockSchedulerQueue` exported but never called (`src/utils/boardingLockScheduler.ts:253-259`)
+- F-10. 모든 fusion 가드 (#662)가 FG `useFusedNearestStation`에만 — BG path/silent push 핸들러에는 가드 없음
+
+---
+
+## P0 통합 16건 (이슈 #696~#711)
+
+### 채널 / 인프라
+| ID | Issue | 작업 | type | 작업량 |
+|---|---|---|---|---|
+| **C1** | [#696](https://github.com/handokei/subway-now/issues/696) | EAS production `aps-environment=production` 강제 | chore | S |
+| **C2** | [#697](https://github.com/handokei/subway-now/issues/697) | 실기기 DebugModal 진단 캡쳐 1회 | chore | XS |
+| **C3** | [#698](https://github.com/handokei/subway-now/issues/698) | silentPushTask reschedule kind 분기 추가 | fix | M |
+| **C4** | [#699](https://github.com/handokei/subway-now/issues/699) | useStationAlarm setFiredAlarms await | fix | S |
+
+### Trip lifecycle
+| ID | Issue | 작업 | type | 작업량 |
+|---|---|---|---|---|
+| **L1** | [#700](https://github.com/handokei/subway-now/issues/700) | TRIP_ORIGIN_KEY 신규 + atomic persist | feat | S |
+| **L2** | [#701](https://github.com/handokei/subway-now/issues/701) | useApnsTripRegistration in-flight Promise dedup | fix | M |
+| **L3** | [#702](https://github.com/handokei/subway-now/issues/702) | setDestination 시 customOrigin/lock/scheduled 자동 클리어 | fix | S |
+| **L4** | [#703](https://github.com/handokei/subway-now/issues/703) | useApnsTripRegistration deps 정리 | refactor | S |
+
+### Backend resilience
+| ID | Issue | 작업 | type | 작업량 |
+|---|---|---|---|---|
+| **B1** | [#704](https://github.com/handokei/subway-now/issues/704) | isSameSession trainCode 기반 + createdAt drift 허용 | refactor | M |
+| **B2** | [#705](https://github.com/handokei/subway-now/issues/705) | waypoint advance 별도 KV(progress:<token>) 분리 | refactor | M |
+| **B3** | [#706](https://github.com/handokei/subway-now/issues/706) | consecutiveEtaMissing 카운터 + 자동 종료 | feat | S |
+
+### Fusion / 알람 정확도
+| ID | Issue | 작업 | type | 작업량 |
+|---|---|---|---|---|
+| **A1** | [#707](https://github.com/handokei/subway-now/issues/707) | BG/silent/lock 3곳 BoardingLock line 가드 | fix | S |
+| **A2** | [#708](https://github.com/handokei/subway-now/issues/708) | scheduler route 변경 감지 + cancel/reschedule | fix | M |
+| **A3** | [#709](https://github.com/handokei/subway-now/issues/709) | scheduler cold restart schedule 보장 (hasScheduledRef) | fix | S |
+| **A4** | [#710](https://github.com/handokei/subway-now/issues/710) | advanceHopWindow canonical name resolve | fix | M |
+
+### BG → React state 채널
+| ID | Issue | 작업 | type | 작업량 |
+|---|---|---|---|---|
+| **S1** | [#711](https://github.com/handokei/subway-now/issues/711) | BG_LAST_STATION_KEY + FG 복귀 시 임시 hydrate | feat | M |
+
+---
+
+## 사용자 보고 ↔ P0 매핑
+
+| 사용자 보고 | 해결 P0 |
+|---|---|
+| ① BG 광범위 | C1+C2 (entitlement+진단), S1, B3, P1-D1 (region monitoring) |
+| ② 현재역 정체 | B1+B2 (isSameSession+advance KV), L2 (POST dedup), S1 |
+| ③ BG 알람 미발화 | **C1** (직격), C3 (reschedule), A3 (cold restart 보장), C4 (dedup) |
+| ④ 재실행 시 시작점 어긋남 | **L1** (TRIP_ORIGIN), L3 (customOrigin 클리어), P1-D6 |
+| ⑤ 환승역 오알람 | A1+A2+A3+A4 (가드+cancel/reschedule+canonical) |
+
+---
+
+## P1 (단계적 신뢰성/UX)
+- **D1** Region Monitoring (`expo-location` Geofencing) — WhileInUse 사용자에서 BG wake-up [L]
+- **D2** `DEFAULT_WINDOW_SIZE` 동적화 — 4 hop 이후 사전예약 누락 차단 [S]
+- **D3** 운영 시간대 인식 (KST 01:00-05:00 polling skip) — Seoul API 절감 + 무한 폴링 차단 [M]
+- **D4** backend `isSameSession` tolerance window + push idempotency [S]
+- **D5** hydration ordering Promise.all + `hydrated` flag로 hook 차단 [M]
+- **D6** boot-time consistency check (stale trip 정리) [M]
+- **D7** iOS Accuracy Authorization 명시 (reduced accuracy 감지 UI) [S]
+- **D8** fusion 가드 BG path 이식 (boardingLockInterp + 거리 게이트) [M]
+- **D9** silent push gate에 `BG_LAST_FIX` fallback [M]
+- **D10** `advanceHopWindow` 90s/hop 보정 (노선/환승 페널티) [L]
+- **D11** backend `expiresAt` 상한 검증 (6h) [S]
+- **D12** useEffect single-fire 가드 (effect race 전반) [M]
+
+## P2 (구조 정리)
+- trip SSOT consolidation (`useTripStore` 신규) [XL]
+- dead code 정리 (`purgeBoardingLockSchedulerQueue`, `sendSilentPush`/`putPending`) [M]
+- `useStationAlarm` single-owner [M]
+- backend `forceAlertMode` flag [M]
+- kv.put 실패 try/catch [S]
+
+---
+
+## 의존성 그래프 + Sprint 분할
+
+### Sprint 1 (Week 1) — 진단 + 즉시 차단
+**병렬 가능 (4트랙)**:
+- **Track 1 (진단)**: C2 → C1
+- **Track 2 (Trip lifecycle)**: L1, L3 (서로 독립, L3는 L1과 분리)
+- **Track 3 (알람 정확도)**: C4, A1, A3 (독립 작은 fix들)
+- **Track 4 (스케줄러)**: A2 → A4 (A2 후 A4가 같은 advance 영역)
+
+**순차 의존**:
+- C2 → C1 (진단 결과 봐야 entitlement 확정)
+- A2 → A4 (route 변경 cancel 후 canonical resolve 보강이 같은 코드 영역)
+
+### Sprint 2 (Week 2) — Backend + race
+**병렬 가능 (3트랙)**:
+- **Track 5 (Backend)**: B1 + B2 + B3 (모두 backend, 같은 PR로 묶을 수도)
+- **Track 6 (Client race)**: L2 → L4 (in-flight dedup 후 deps 정리)
+- **Track 7 (Channel)**: C3 (reschedule kind), S1 (BG state hydrate)
+
+**순차 의존**:
+- B1 ↔ B2 (같은 파일이므로 한 PR로 권장)
+- L2 → L4 (in-flight dedup 검증 후 deps 정리해야 안전)
+- C3은 client만, backend reschedule push 발사 검증 필요
+
+### Sprint 3+ (Week 3+)
+- D1 Region Monitoring (대규모, 단독 sprint 권장)
+- 나머지 P1 12건 우선순위에 따라
+
+### 전역 순차 의존 (반드시 순서)
+1. **C2 (진단) → C1 (entitlement fix)** — 진단으로 가설 확정 후 fix
+2. **C1 → C3** — entitlement 살아난 후 reschedule kind 검증 가능
+3. **B1+B2 → L2** — backend advance 영속화 후 client dedup 효과 측정
+4. **모든 P0 → P1 D1 (region monitoring)** — P0 기반 안정화 후 새 채널 추가
+
+### 병렬 친화 (서로 영향 없음)
+- L1 ↔ L3 ↔ A1 ↔ S1 (각각 다른 파일/관심사)
+- A1 + A2 + A3 + A4는 같은 알람 영역이지만 파일이 분산되어 병렬 가능
+- B1+B2+B3는 모두 backend이지만 함께 한 PR로 묶는 게 효율
+
+---
+
+## 추가 검증 필요 (코드만으로 단정 불가)
+- F-1 entitlement: EAS production 빌드 IPA inspect 또는 `apple developer console`에서 토큰 환경 확인
+- F-6 dead code mismatch: backend production deploy의 실제 코드 wrangler tail로 확인
+- F-7 cancelScheduledAlarms 동작: 실기기에서 cold restart 후 `bl:` identifier 알람이 살아있는지 검증
+- iOS Live Activity push update가 알람 백업 채널로 활용 가능한지 (#586 series 머지된 상태)
+
+---
+
+## 솔직한 평가
+
+**Q: P0 16건 완료하면 사용자 보고 5건 해결되나?**
+**A**: F-1 entitlement 가설이 사실로 확정되면 **5건 모두 차단 가능**. F-1이 다른 원인(예: token 등록 실패)이라면 C2 진단 결과에 따라 C1 대신 별도 fix 필요.
+
+**Q: 진정한 SLA를 위해선 추가로 무엇이?**
+- P1-D1 Region Monitoring 없이는 WhileInUse 사용자가 silent push 의존 → 채널 redundancy 부족
+- Live Activity push update를 알람 백업 채널로 활용 가능한지 검토
+- 사용자에게 "정확한 알람을 위해 Always 권한 권장" UX nudge
+
+---
+
+## Issue tracking
+이 문서의 P0 16건은 각각 GitHub issue로 생성됨. Sprint별/track별 진행 상황은 issue 라벨로 추적.


### PR DESCRIPTION
Closes #1164

## Summary
- PR #1154/#1155로 `tasks/` gitignore 해제됨. 로컬에 untracked 상태로 남아 있던 분석/계획 문서 8개를 dev에 반영.
- 코드/설정 변경 없음 — 컨텍스트 보존 목적.

## 처리 내역
유지 (8개 모두 tasks/에 추가):
- bg-alarm-analysis.md
- bg-alarm-multi-channel-plan.md
- bg-silent-push-real-trip-result.md
- bg-trip-persistence.md
- gps-realtime-drift-3stations.md
- region-monitoring-poc-result.md
- service-gap-plan.md
- system-stability-plan-2026-05-31.md

이관/삭제: 없음 (이슈 본문에 명시되지 않았고, 모두 진행 중/참조 가치 있는 분석 문서).

## Test plan
- 문서 추가뿐이라 src/ 영향 없음. CI Type Check & Test 통과만 확인.