### PR TITLE
feat(#918): A3 PR4 — backend tba reschedule + scheduleStopPhase primitive

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -273,6 +273,44 @@ describe('sendReschedulePush (#585)', () => {
     });
     expect(result).toEqual({ ok: false, status: 400, reason: 'BadDeviceToken' });
   });
+
+  // #918 A3 PR4 — channels 옵션 wire 검증.
+  it("channels=['bl','tba']이 payload에 그대로 직렬화된다", async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendReschedulePush({
+      deviceToken: 'devicetoken-hex',
+      pushId: 'rsch-2',
+      trainCode: '7246',
+      nextStation: '중곡',
+      newArrivalTimeEpoch: 1_700_000_120_000,
+      sentAt: 1_700_000_000_000,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      channels: ['bl', 'tba'],
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.channels).toEqual(['bl', 'tba']);
+  });
+
+  it('channels 미지정 시 payload에서 omit (구 backend wire 호환)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendReschedulePush({
+      deviceToken: 'devicetoken-hex',
+      pushId: 'rsch-3',
+      trainCode: '7246',
+      nextStation: '중곡',
+      newArrivalTimeEpoch: 1_700_000_120_000,
+      sentAt: 1_700_000_000_000,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('channels' in body.data).toBe(false);
+  });
 });
 
 describe('sendLiveActivityUpdate (#586 C)', () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -9,6 +9,7 @@ import { importPKCS8, SignJWT } from 'jose';
 import type { AlarmPhase } from './alarm';
 import type {
   BoardingPromptPushPayload,
+  RescheduleChannel,
   ReschedulePushPayload,
   TripEndedPushPayload,
   TripEndedReason,
@@ -198,6 +199,12 @@ export interface SendReschedulePushOptions {
   host: string;
   fetchImpl?: typeof fetch;
   now?: number;
+  /**
+   * #918 A3 PR4 — 정정 대상 scheduler 채널. 미지정 시 구 backend 동작 보존
+   * (`channels` 필드를 payload에서 omit → 클라가 `['bl']` 단독으로 해석).
+   * 신규 호출자(maybeReschedulePush)는 `RESCHEDULE_CHANNELS_DEFAULT`(['bl','tba'])를 넘긴다.
+   */
+  channels?: ReadonlyArray<RescheduleChannel>;
 }
 
 export async function sendReschedulePush(
@@ -214,6 +221,8 @@ export async function sendReschedulePush(
     nextStation: options.nextStation,
     newArrivalTimeEpoch: options.newArrivalTimeEpoch,
     sentAt: options.sentAt,
+    // channels 미지정 시 wire에 필드를 넣지 않음 — 구 backend payload와 byte-level 호환.
+    ...(options.channels !== undefined ? { channels: options.channels } : {}),
   };
 
   const body = JSON.stringify({ aps: { 'content-available': 1 }, data: payload });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -53,6 +53,7 @@ import type {
   Trip,
   Waypoint,
 } from './types';
+import { RESCHEDULE_CHANNELS_DEFAULT } from './types';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -1150,6 +1151,9 @@ export async function maybeReschedulePush(
         host,
         fetchImpl: deps.fetchImpl,
         now,
+        // #918 A3 PR4 — `bl:` + `tba:` 동시 정정. 구 backend 호환을 위해 채널 상수는
+        // types.ts 단일 SSOT (RESCHEDULE_CHANNELS_DEFAULT)에서 import.
+        channels: RESCHEDULE_CHANNELS_DEFAULT,
       }),
     trip.apnsEnv,
     deps.apnsHosts,

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -247,9 +247,27 @@ export interface BoardingLockMeta {
 }
 
 /**
+ * Reschedule push channel discriminator (#918 A3 PR4).
+ *
+ *  - 'bl' — boarding-lock scheduler (`bl:` prefix). 기존 #585 경로. trainCode 매칭으로 hop 정정.
+ *  - 'tba' — trip-bound scheduler (`tba:` prefix). lock-free 사전 예약 정정 — trainCode 무관.
+ *
+ * 한 reschedule push는 둘 다를 동시에 정정할 수 있도록 `ReschedulePushPayload.channels`에
+ * 배열로 담는다 (단일 push로 두 채널의 사전 예약을 동기화 — APNs budget 절약).
+ */
+export type RescheduleChannel = 'bl' | 'tba';
+
+/** 신규 backend가 default로 보내는 channels — bl + tba 모두 정정. */
+export const RESCHEDULE_CHANNELS_DEFAULT: ReadonlyArray<RescheduleChannel> = ['bl', 'tba'];
+
+/**
  * Reschedule silent push payload (#585).
  * 디바이스가 사전 예약한 알람의 도착 시각이 backend 관측과 어긋날 때 발사.
  * 디바이스는 이 push를 받아 기존 예약을 cancel하고 newArrivalTimeEpoch로 재예약한다.
+ *
+ * `channels` (#918 A3 PR4): 정정 대상 scheduler 채널. 미지정 시 구 backend 호환을 위해
+ * 클라가 `['bl']` 단독으로 해석 (기존 동작 보존). 신규 backend는 `RESCHEDULE_CHANNELS_DEFAULT`로
+ * `['bl', 'tba']`를 보내 `tba:` 사전 예약도 함께 정정한다.
  */
 export interface ReschedulePushPayload {
   pushId: string;
@@ -258,6 +276,7 @@ export interface ReschedulePushPayload {
   nextStation: string;
   newArrivalTimeEpoch: number;
   sentAt: number;
+  channels?: ReadonlyArray<RescheduleChannel>;
 }
 
 /**

--- a/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
@@ -15,6 +15,7 @@ import {
 import { getTripStartedAt } from '../../utils/tripStartStorage';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import { makeDirectRoute, makeTransferRoute } from '../../../../testUtils/routeFixtures';
+import { captureAppStateListener } from '../../testHelpers/tripBoundTestFactory';
 
 jest.mock('../../utils/tripBoundScheduler', () => {
   const actual = jest.requireActual('../../utils/tripBoundScheduler');
@@ -471,16 +472,7 @@ describe('useTripBoundAlarmScheduler', () => {
   // -------- PR3: AppState 'active' resume top-up --------
 
   it('PR3: AppState active 진입 + 직전 top-up stop 있으면 top-up 재호출', async () => {
-    // listener를 가로채 직접 fire — addEventListener는 React Native 기본 mock.
-    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
-    const sub: NativeEventSubscription = { remove: jest.fn() };
-    const spy = jest
-      .spyOn(AppState, 'addEventListener')
-      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
-        activeListener = cb;
-        return sub;
-      });
-
+    const appState = captureAppStateListener();
     renderScheduler({
       lock: lockA,
       route: transferRouteForTopUp,
@@ -490,22 +482,13 @@ describe('useTripBoundAlarmScheduler', () => {
     await awaitFirstSchedule();
     await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
 
-    // FG resume
-    if (activeListener) (activeListener as (state: string) => void)('active');
+    appState.fire('active');
     await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(2));
-    spy.mockRestore();
+    appState.restore();
   });
 
   it('PR3: AppState background 진입은 top-up trigger 안 함', async () => {
-    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
-    const sub: NativeEventSubscription = { remove: jest.fn() };
-    const spy = jest
-      .spyOn(AppState, 'addEventListener')
-      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
-        activeListener = cb;
-        return sub;
-      });
-
+    const appState = captureAppStateListener();
     renderScheduler({
       lock: lockA,
       route: transferRouteForTopUp,
@@ -515,22 +498,14 @@ describe('useTripBoundAlarmScheduler', () => {
     await awaitFirstSchedule();
     await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
 
-    if (activeListener) (activeListener as (state: string) => void)('background');
+    appState.fire('background');
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedTopUp).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
+    appState.restore();
   });
 
   it('PR3: AppState active 진입 시 scheduledStops/lastToppedUp 없으면 skip', async () => {
-    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
-    const sub: NativeEventSubscription = { remove: jest.fn() };
-    const spy = jest
-      .spyOn(AppState, 'addEventListener')
-      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
-        activeListener = cb;
-        return sub;
-      });
-
+    const appState = captureAppStateListener();
     // currentStationName 없음 → top-up 안 일어남 → lastToppedUp=null → FG resume skip.
     renderScheduler({
       lock: lockA,
@@ -539,22 +514,14 @@ describe('useTripBoundAlarmScheduler', () => {
     });
     await awaitFirstSchedule();
 
-    if (activeListener) (activeListener as (state: string) => void)('active');
+    appState.fire('active');
     await new Promise((r) => setTimeout(r, 0));
     expect(mockedTopUp).not.toHaveBeenCalled();
-    spy.mockRestore();
+    appState.restore();
   });
 
   it('PR3: AppState active 진입 + top-up 실패는 logger.error 기록', async () => {
-    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
-    const sub: NativeEventSubscription = { remove: jest.fn() };
-    const spy = jest
-      .spyOn(AppState, 'addEventListener')
-      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
-        activeListener = cb;
-        return sub;
-      });
-
+    const appState = captureAppStateListener();
     renderScheduler({
       lock: lockA,
       route: transferRouteForTopUp,
@@ -565,14 +532,14 @@ describe('useTripBoundAlarmScheduler', () => {
     await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
 
     mockedTopUp.mockRejectedValueOnce(new Error('resume-fail'));
-    if (activeListener) (activeListener as (state: string) => void)('active');
+    appState.fire('active');
     await waitFor(() => {
       expect(mockLoggerError).toHaveBeenCalledWith(
         'FG resume top-up 실패:',
         expect.any(Error),
       );
     });
-    spy.mockRestore();
+    appState.restore();
   });
 
   it('PR3: unmount 시 AppState subscription remove 호출', async () => {

--- a/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
@@ -2,6 +2,7 @@
  * Cross-feature test: useTripBoundAlarmScheduler 본체가 orchestrator(file-level disable).
  * 동일 패턴으로 routeFixtures import. ADR Phase 5 (#890).
  */
+import { AppState, type NativeEventSubscription } from 'react-native';
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useTripBoundAlarmScheduler } from '../useTripBoundAlarmScheduler';
 import type { ScheduledTripBoundAlarm } from '../../utils/tripBoundScheduler';
@@ -9,6 +10,7 @@ import {
   cancelTripBoundAlarms,
   prescheduleStationAlerts,
   setRegisteredTripRouteSig,
+  topUpTripBoundWindow,
 } from '../../utils/tripBoundScheduler';
 import { getTripStartedAt } from '../../utils/tripStartStorage';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
@@ -21,6 +23,7 @@ jest.mock('../../utils/tripBoundScheduler', () => {
     prescheduleStationAlerts: jest.fn(),
     cancelTripBoundAlarms: jest.fn(),
     setRegisteredTripRouteSig: jest.fn(),
+    topUpTripBoundWindow: jest.fn(),
   };
 });
 
@@ -46,6 +49,7 @@ const mockedGetTripStartedAt = getTripStartedAt as jest.MockedFunction<typeof ge
 const mockedSetSig = setRegisteredTripRouteSig as jest.MockedFunction<
   typeof setRegisteredTripRouteSig
 >;
+const mockedTopUp = topUpTripBoundWindow as jest.MockedFunction<typeof topUpTripBoundWindow>;
 
 type Props = Parameters<typeof useTripBoundAlarmScheduler>[0];
 function renderScheduler(initialProps: Props) {
@@ -71,6 +75,7 @@ beforeEach(() => {
   mockedPreschedule.mockResolvedValue([]);
   mockedCancel.mockResolvedValue(undefined);
   mockedSetSig.mockResolvedValue(undefined);
+  mockedTopUp.mockResolvedValue({ cancelled: 0, scheduled: 0 });
   // 기본은 tripStart 없음 — lock 없는 케이스에서 사전 예약 skip이 유지된다.
   mockedGetTripStartedAt.mockResolvedValue(null);
 });
@@ -326,6 +331,258 @@ describe('useTripBoundAlarmScheduler', () => {
     rerender({ lock: lockA, route: altRoute, destinationName: '강남' });
     await waitFor(() => expect(mockedSetSig).toHaveBeenCalledTimes(2));
     expect(mockedSetSig.mock.calls[1][0]).not.toBe(firstSig);
+  });
+
+  // -------- PR3 (#918 A3): rolling window 64 cap --------
+
+  const transferRouteForTopUp = makeTransferRoute({
+    transferName: '교대',
+    fromLine: '2',
+    toLine: '3',
+    stopsToTransfer: 2,
+    stopsFromTransfer: 3,
+  });
+
+  it('PR3: 초기 preschedule 호출 시 windowSize=TRIPBOUND_WINDOW_SIZE 전달', async () => {
+    renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    await awaitFirstSchedule();
+    const call = mockedPreschedule.mock.calls[0][0];
+    expect(call.windowSize).toBeGreaterThan(0);
+  });
+
+  it('PR3: currentStationName=null이면 top-up skip', async () => {
+    renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: null,
+    });
+    await awaitFirstSchedule();
+    expect(mockedTopUp).not.toHaveBeenCalled();
+  });
+
+  it('PR3: 초기 마운트 + 매칭 currentStationName이 들어오면 top-up 1회 호출', async () => {
+    const { rerender } = renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: null,
+    });
+    await awaitFirstSchedule();
+    rerender({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
+    const arg = mockedTopUp.mock.calls[0][0];
+    expect(arg.passedStationName).toBe('교대');
+    expect(arg.windowSize).toBeGreaterThan(0);
+    expect(arg.routeStops.map((s) => s.stationName)).toEqual(['교대', '강남']);
+  });
+
+  it('PR3: 같은 currentStationName으로 rerender 시 effect deps 안 바뀌어 추가 호출 없음', async () => {
+    const { rerender } = renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await awaitFirstSchedule();
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
+    rerender({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedTopUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('PR3: matching 안 되는 currentStationName은 no-op', async () => {
+    const { rerender } = renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: null,
+    });
+    await awaitFirstSchedule();
+    rerender({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '관계없는역',
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedTopUp).not.toHaveBeenCalled();
+  });
+
+  it('PR3: scheduledStops 없는 상태(스케줄 skip)에서 currentStationName 변경은 no-op', async () => {
+    renderScheduler({
+      lock: null,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    // tripStart=null + lock=null → preschedule skip → scheduledStopsRef=null → top-up skip.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedTopUp).not.toHaveBeenCalled();
+  });
+
+  it('PR3: lock 교체로 identity 변경 시 top-up 가드 reset → 같은 currentStation에 대해 다시 호출', async () => {
+    const { rerender } = renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await awaitFirstSchedule();
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
+    // 새 lock 진입 → ref reset.
+    rerender({
+      lock: lockB,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await waitFor(() => expect(mockedPreschedule).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(2));
+  });
+
+  it('PR3: top-up 실패는 logger.error 기록 (throw 없음)', async () => {
+    mockedTopUp.mockRejectedValueOnce(new Error('topup-fail'));
+    renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await awaitFirstSchedule();
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'topUpTripBoundWindow 실패:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  // -------- PR3: AppState 'active' resume top-up --------
+
+  it('PR3: AppState active 진입 + 직전 top-up stop 있으면 top-up 재호출', async () => {
+    // listener를 가로채 직접 fire — addEventListener는 React Native 기본 mock.
+    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
+    const sub: NativeEventSubscription = { remove: jest.fn() };
+    const spy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
+        activeListener = cb;
+        return sub;
+      });
+
+    renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await awaitFirstSchedule();
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
+
+    // FG resume
+    if (activeListener) (activeListener as (state: string) => void)('active');
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(2));
+    spy.mockRestore();
+  });
+
+  it('PR3: AppState background 진입은 top-up trigger 안 함', async () => {
+    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
+    const sub: NativeEventSubscription = { remove: jest.fn() };
+    const spy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
+        activeListener = cb;
+        return sub;
+      });
+
+    renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await awaitFirstSchedule();
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
+
+    if (activeListener) (activeListener as (state: string) => void)('background');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedTopUp).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it('PR3: AppState active 진입 시 scheduledStops/lastToppedUp 없으면 skip', async () => {
+    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
+    const sub: NativeEventSubscription = { remove: jest.fn() };
+    const spy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
+        activeListener = cb;
+        return sub;
+      });
+
+    // currentStationName 없음 → top-up 안 일어남 → lastToppedUp=null → FG resume skip.
+    renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+    });
+    await awaitFirstSchedule();
+
+    if (activeListener) (activeListener as (state: string) => void)('active');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockedTopUp).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('PR3: AppState active 진입 + top-up 실패는 logger.error 기록', async () => {
+    let activeListener: ((state: import("react-native").AppStateStatus) => void) | null = null;
+    const sub: NativeEventSubscription = { remove: jest.fn() };
+    const spy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_event: import("react-native").AppStateEvent, cb: (state: import("react-native").AppStateStatus) => void) => {
+        activeListener = cb;
+        return sub;
+      });
+
+    renderScheduler({
+      lock: lockA,
+      route: transferRouteForTopUp,
+      destinationName: '강남',
+      currentStationName: '교대',
+    });
+    await awaitFirstSchedule();
+    await waitFor(() => expect(mockedTopUp).toHaveBeenCalledTimes(1));
+
+    mockedTopUp.mockRejectedValueOnce(new Error('resume-fail'));
+    if (activeListener) (activeListener as (state: string) => void)('active');
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'FG resume top-up 실패:',
+        expect.any(Error),
+      );
+    });
+    spy.mockRestore();
+  });
+
+  it('PR3: unmount 시 AppState subscription remove 호출', async () => {
+    const remove = jest.fn();
+    const sub: NativeEventSubscription = { remove };
+    const spy = jest.spyOn(AppState, 'addEventListener').mockReturnValue(sub);
+    const { unmount } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+    unmount();
+    expect(remove).toHaveBeenCalled();
+    spy.mockRestore();
   });
 });
 

--- a/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
+++ b/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
@@ -3,15 +3,19 @@
  * route stops(shared utils)를 묶어 OS local notification 사전 예약(tripBoundScheduler)을 트리거하는
  * orchestrator. useBoardingLockScheduler와 동일한 옵트인 패턴(file-level disable). ADR Phase 5 (#890).
  */
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { Route } from '../../../shared/utils/stationRoute';
+import { isSameStationName } from '../../../shared/utils/stationRoute';
 import { routeSignature } from '../utils/boardingLockScheduler';
 import {
+  TRIPBOUND_WINDOW_SIZE,
   cancelTripBoundAlarms,
   deriveTripBoundStops,
   prescheduleStationAlerts,
   setRegisteredTripRouteSig,
+  topUpTripBoundWindow,
 } from '../utils/tripBoundScheduler';
 import { getTripStartedAt } from '../utils/tripStartStorage';
 import { createLogger } from '../../../shared/utils/logger';
@@ -25,6 +29,11 @@ export interface UseTripBoundAlarmSchedulerInputs {
   route: Route;
   /** 목적지명. null이면 cancel만. */
   destinationName: string | null;
+  /**
+   * #918 A3 PR3 — Fusion 현재역 이름. 통과 시 rolling window top-up trigger.
+   * null이면 top-up 평가 skip(초기 마운트 + pre-fusion 케이스).
+   */
+  currentStationName?: string | null;
 }
 
 /**
@@ -51,6 +60,7 @@ export function useTripBoundAlarmScheduler({
   lock,
   route,
   destinationName,
+  currentStationName = null,
 }: UseTripBoundAlarmSchedulerInputs): void {
   // 마지막 성공한 schedule의 identity/sig. null이면 "현재 큐에 tba 알람 없음".
   // identity = `ts:${tripStart}` — lock 도착 전후로 동일 trip이면 안정.
@@ -60,6 +70,20 @@ export function useTripBoundAlarmScheduler({
   // async race 가드: 같은 effect의 이전 호출이 아직 진행 중일 수 있으므로 in-flight token으로
   // stale completion이 ref를 잘못 update하지 않게 차단 (self code-review #3).
   const inFlightTokenRef = useRef(0);
+
+  // #918 A3 PR3 — top-up 호출 시 같은 데이터를 재사용하기 위한 ref. 초기 preschedule 성공 시 set.
+  const scheduledStopsRef = useRef<{
+    routeStops: ReturnType<typeof deriveTripBoundStops>['routeStops'];
+    estimatedHopTimesMs: number[];
+    startTime: number;
+  } | null>(null);
+
+  // station-pass 중복 호출 방지 — 마지막 top-up한 stationName. trip identity 변경 시 리셋.
+  const lastToppedUpRef = useRef<string | null>(null);
+
+  // top-up effect가 schedule 완료 시점을 인지하도록 epoch state로 trigger. ref만 사용하면 async run
+  // 완료 후 effect re-run이 없어 currentStationName이 schedule 전에 들어와도 top-up이 시작 안 됨.
+  const [scheduleEpoch, setScheduleEpoch] = useState(0);
 
   useEffect(() => {
     const nextSig = routeSignature(route, destinationName);
@@ -93,6 +117,8 @@ export function useTripBoundAlarmScheduler({
       if (!canSchedule) {
         scheduledIdentityRef.current = null;
         scheduledRouteSigRef.current = null;
+        scheduledStopsRef.current = null;
+        lastToppedUpRef.current = null;
         return;
       }
       const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, destinationName);
@@ -100,6 +126,7 @@ export function useTripBoundAlarmScheduler({
         routeStops,
         estimatedHopTimesMs,
         startTime: tripStart,
+        windowSize: TRIPBOUND_WINDOW_SIZE,
       });
       // #918 A3 PR2 (#729 흡수): fire-time 재검증을 위해 route signature 영속화.
       // canSchedule=true 경로는 hasRouteAndDest=true → routeSignature는 항상 string 반환 → nextSig non-null.
@@ -110,10 +137,63 @@ export function useTripBoundAlarmScheduler({
       await setRegisteredTripRouteSig(nextSig as string);
       scheduledIdentityRef.current = nextIdentity;
       scheduledRouteSigRef.current = nextSig;
+      scheduledStopsRef.current = { routeStops, estimatedHopTimesMs, startTime: tripStart };
+      // identity 변경마다 top-up 중복 가드 리셋 — 새 trip의 첫 station-pass가 막히지 않게.
+      lastToppedUpRef.current = null;
+      // schedule 완료 신호 — top-up effect를 깨운다 (currentStationName이 schedule보다 먼저 들어온 경우 흡수).
+      setScheduleEpoch((n) => n + 1);
     };
 
     run().catch((e: unknown) => {
       logger.error('tripBoundScheduler 전환 실패:', e);
     });
   }, [lock, route, destinationName]);
+
+  // #918 A3 PR3 — rolling window top-up. Fusion 현재역이 routeStops의 stop과 매칭되면
+  // 그 stop의 알람을 cancel하고 다음 N개를 채워 64 cap을 회피한다.
+  useEffect(() => {
+    if (currentStationName === null) return;
+    const stopsCtx = scheduledStopsRef.current;
+    if (stopsCtx === null) return;
+    // canonical name 매칭 — boardingLockAdvancer와 동일 패턴(노선별 부제 흡수).
+    const matched = stopsCtx.routeStops.find((s) =>
+      isSameStationName(s.stationName, currentStationName),
+    );
+    if (!matched) return;
+    // effect deps([currentStationName, scheduleEpoch])가 동일 stationName 재호출을 이미 차단하므로
+    // 추가 dup guard는 두지 않는다. lastToppedUpRef는 FG resume의 "직전 통과 stop" 기준으로만 쓰인다.
+    lastToppedUpRef.current = matched.stationName;
+    topUpTripBoundWindow({
+      routeStops: stopsCtx.routeStops,
+      estimatedHopTimesMs: stopsCtx.estimatedHopTimesMs,
+      startTime: stopsCtx.startTime,
+      passedStationName: matched.stationName,
+      windowSize: TRIPBOUND_WINDOW_SIZE,
+    }).catch((e: unknown) => {
+      logger.error('topUpTripBoundWindow 실패:', e);
+    });
+  }, [currentStationName, scheduleEpoch]);
+
+  // #918 A3 PR3 — FG resume 시 top-up 재실행. BG에서 OS가 일부 알람을 발사/삭제했을 수 있어
+  // 가장 최근 통과 stop 기준으로 윈도우를 다시 채운다 (idempotent).
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state !== 'active') return;
+      const stopsCtx = scheduledStopsRef.current;
+      const passed = lastToppedUpRef.current;
+      if (stopsCtx === null || passed === null) return;
+      topUpTripBoundWindow({
+        routeStops: stopsCtx.routeStops,
+        estimatedHopTimesMs: stopsCtx.estimatedHopTimesMs,
+        startTime: stopsCtx.startTime,
+        passedStationName: passed,
+        windowSize: TRIPBOUND_WINDOW_SIZE,
+      }).catch((e: unknown) => {
+        logger.error('FG resume top-up 실패:', e);
+      });
+    });
+    return () => {
+      subscription.remove();
+    };
+  }, []);
 }

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -24,6 +24,9 @@ describe('tripBoundCleanups', () => {
     // mockRejectedValue가 leak되어 다음 테스트의 cancel을 reject하지 않도록.
     (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockReset();
     (Notifications.dismissNotificationAsync as jest.Mock).mockReset();
+    // #918 A3 PR4 — cancelTripBoundAlarms는 OS 큐 enumerate가 필요. auto-mock default가
+    // undefined를 반환하면 for..of에서 throw → cleanup 흐름이 막힌다. 빈 큐로 graceful 통과.
+    (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
   });
 
   it('TRIP_BOUND_CLEANUPS는 비어있지 않다 (메타 배열 self-check)', () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -29,6 +29,7 @@ import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dism
 import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
 import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
 import { purgeBoardingLockSchedulerQueue } from '../utils/boardingLockScheduler';
+import { cancelTripBoundAlarms } from '../utils/tripBoundScheduler';
 
 // trip-bound storage cleanup 단일 출처.
 // useDestinationStore.setDestination이 isSwitch(목적지 변경 또는 null 클리어) 분기에서 호출한다.
@@ -58,6 +59,10 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // + dismiss 처리한 뒤 storage 큐를 clear한다 — OS 큐 한도(64) 도달과 정정 신호 없는 옛 알람
   // 발사 burst를 동시에 차단한다.
   purgeBoardingLockSchedulerQueue,
+  // #918 A3 PR4 — `tba:` 채널의 OS 사전 예약도 cancel. 트립 종료 시점에 남아 있으면
+  // 다음 trip 시작 후 옛 알람이 burst로 발사된다 (purgeBoardingLockSchedulerQueue가 `bl:`만
+  // 제거하기 때문). cancelTripBoundAlarms는 graceful — 큐가 비어도 안전 통과.
+  cancelTripBoundAlarms,
   () => AsyncStorage.removeItem(ACTIVE_TRIP_KEY),
   () => AsyncStorage.removeItem(TRIP_ORIGIN_KEY),
   clearLastNotifiedStationId,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -110,6 +110,12 @@ jest.mock('../../utils/boardingLockScheduler', () => ({
   rescheduleHopForLock: (...args: unknown[]) => mockRescheduleHopForLock(...args),
 }));
 
+// #918 A3 PR4 — tba 채널 reschedule. mock으로 호출 인자/횟수만 검증.
+const mockRescheduleTripBoundAlarm = jest.fn();
+jest.mock('../../utils/tripBoundScheduler', () => ({
+  rescheduleTripBoundAlarm: (...args: unknown[]) => mockRescheduleTripBoundAlarm(...args),
+}));
+
 const mockGetDismissSilence = jest.fn();
 const mockClearDismissSilence = jest.fn();
 jest.mock('../../utils/dismissSilenceStorage', () => ({
@@ -1368,6 +1374,105 @@ describe('silentPushTask', () => {
             expect.objectContaining({ pushId: 'rs-uuid', outcome: 'fired', reason: 'reschedule-received' }),
           );
           expect(mockLogSilentPushRescheduleReceived).toHaveBeenCalledTimes(1);
+        });
+
+        // #918 A3 PR4 — channels 분기 (bl + tba).
+        describe('channels (#918 A3 PR4)', () => {
+          it('channels=undefined (구 backend) → bl만 호출, tba 미호출', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({ newArrivalTimeEpoch: 9_999_999_999_999 }),
+            );
+            expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleTripBoundAlarm).not.toHaveBeenCalled();
+          });
+
+          it("channels=['bl','tba'] → bl + tba 모두 호출", async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['bl', 'tba'],
+              }),
+            );
+            expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
+            const tbaArg = mockRescheduleTripBoundAlarm.mock.calls[0][0];
+            expect(tbaArg.stationName).toBe('사가정');
+            expect(tbaArg.newArrivalMs).toBe(9_999_999_999_999);
+            expect(tbaArg.destinationName).toBe(destStation.name);
+          });
+
+          it("channels=['tba'] → tba만 호출, bl 미호출 (lock skip 무관)", async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['tba'],
+              }),
+            );
+            expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+            expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
+          });
+
+          it("channels=['tba'] + lock=null → tba는 여전히 호출 (lock-free 채널)", async () => {
+            setStorage({ lock: null });
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['tba'],
+              }),
+            );
+            expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
+          });
+
+          it('channels 빈 배열 → 구 backend 호환 default(bl)로 fallback', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: [],
+              }),
+            );
+            expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleTripBoundAlarm).not.toHaveBeenCalled();
+          });
+
+          it('channels에 unknown 값만 있으면 default(bl)로 fallback', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['unknown'],
+              }),
+            );
+            expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleTripBoundAlarm).not.toHaveBeenCalled();
+          });
+
+          it('channels에 mix(bl + unknown) → bl만 통과', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['bl', 'unknown', 'tba'],
+              }),
+            );
+            expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
+          });
+
+          it('channels가 배열이 아니면 default(bl)로 fallback', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: 'bl',
+              }),
+            );
+            expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleTripBoundAlarm).not.toHaveBeenCalled();
+          });
         });
       });
     });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -58,6 +58,7 @@ import {
   type GateSkipReason,
 } from '../utils/silentPushLocationGate';
 import { rescheduleHopForLock } from '../utils/boardingLockScheduler';
+import { rescheduleTripBoundAlarm } from '../utils/tripBoundScheduler';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
@@ -96,9 +97,28 @@ export interface SilentPushPayload {
 }
 
 /**
+ * Reschedule push channel discriminator (#918 A3 PR4). Backend `types.ts`의 `RescheduleChannel`과 정렬.
+ *
+ *  - 'bl' — boarding-lock scheduler (`bl:` prefix). #585 경로. `rescheduleHopForLock` 호출.
+ *  - 'tba' — trip-bound scheduler (`tba:` prefix). lock-free. `rescheduleTripBoundAlarm` 호출.
+ *
+ * 한 payload는 두 채널을 동시에 정정할 수 있다 (둘 다 호출).
+ */
+export type RescheduleChannel = 'bl' | 'tba';
+
+/** 구 backend 호환 default — `channels` 누락 시 'bl' 단독으로 해석 (기존 동작 보존). */
+const DEFAULT_RESCHEDULE_CHANNELS: ReadonlyArray<RescheduleChannel> = ['bl'];
+
+/** 신규 backend(#918 A3 PR4) default — 'bl' + 'tba' 동시 정정. payload 검증/테스트에서 재사용. */
+export const ALL_RESCHEDULE_CHANNELS: ReadonlyArray<RescheduleChannel> = ['bl', 'tba'];
+
+/**
  * Reschedule silent push payload (#725). 백엔드 `sendReschedulePush`가 일반 silent push와
  * 다른 schema(`nextStation` / `newArrivalTimeEpoch` / `trainCode`)를 보낸다 — 별도 인터페이스로
  * 모델링하고 `kind: 'reschedule'`을 discriminator로 사용해 union narrowing.
+ *
+ * `channels` (#918 A3 PR4): 정정 대상 scheduler 채널 배열. 누락 시 구 backend 호환을 위해
+ * `DEFAULT_RESCHEDULE_CHANNELS`(=['bl'])로 해석한다. 신규 backend는 ['bl','tba']를 보낸다.
  */
 export interface RescheduleSilentPushPayload {
   kind: 'reschedule';
@@ -107,6 +127,7 @@ export interface RescheduleSilentPushPayload {
   trainCode: string;
   sentAt?: number;
   pushId?: string;
+  channels?: ReadonlyArray<RescheduleChannel>;
 }
 
 /**
@@ -259,7 +280,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
 function extractReschedulePayload(
   obj: Record<string, unknown>,
 ): RescheduleSilentPushPayload | null {
-  const { nextStation, newArrivalTimeEpoch, trainCode, sentAt, pushId } = obj;
+  const { nextStation, newArrivalTimeEpoch, trainCode, sentAt, pushId, channels } = obj;
   if (typeof nextStation !== 'string' || nextStation.length === 0) return null;
   if (typeof newArrivalTimeEpoch !== 'number' || !Number.isFinite(newArrivalTimeEpoch)) return null;
   if (typeof trainCode !== 'string' || trainCode.length === 0) return null;
@@ -270,7 +291,28 @@ function extractReschedulePayload(
     trainCode,
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
+    channels: validChannels(channels),
   };
+}
+
+/**
+ * payload.channels 검증. Array of 'bl'|'tba' 만 통과 — 그 외(누락/형식 오류/빈 배열)는 undefined로 정규화.
+ * undefined 결과는 `resolveChannels`에서 `DEFAULT_RESCHEDULE_CHANNELS`로 fallback (구 backend 호환).
+ */
+function validChannels(value: unknown): ReadonlyArray<RescheduleChannel> | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const filtered: RescheduleChannel[] = [];
+  for (const v of value) {
+    if (v === 'bl' || v === 'tba') filtered.push(v);
+  }
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+/** 누락된 channels는 구 backend 호환 default(['bl'])로 해석. */
+function resolveChannels(
+  channels: ReadonlyArray<RescheduleChannel> | undefined,
+): ReadonlyArray<RescheduleChannel> {
+  return channels ?? DEFAULT_RESCHEDULE_CHANNELS;
 }
 
 /**
@@ -535,17 +577,7 @@ async function applyReschedule(
       );
       return;
     }
-    const lock = await getBoardingLock();
-    if (!lock) {
-      logger.info('reschedule skip: no boarding lock');
-      return;
-    }
-    if (lock.trainCode !== payload.trainCode) {
-      logger.info(
-        `reschedule skip: trainCode mismatch lock=${lock.trainCode} payload=${payload.trainCode}`,
-      );
-      return;
-    }
+    // route/destination은 두 채널 모두 사용 — 한 번만 read.
     const [routeRaw, destRaw] = await Promise.all([
       AsyncStorage.getItem(ROUTE_KEY),
       AsyncStorage.getItem(DESTINATION_KEY),
@@ -558,17 +590,55 @@ async function applyReschedule(
       );
       return;
     }
-    await rescheduleHopForLock({
-      lock,
-      route,
-      destinationName,
-      nextStation: payload.nextStation,
-      newArrivalMs: payload.newArrivalTimeEpoch,
-      now: receivedAt,
-    });
+    const channels = resolveChannels(payload.channels);
+    // bl 채널 — 기존 lock-기반 hop 정정. lock 부재/trainCode mismatch 시 graceful skip.
+    if (channels.includes('bl')) {
+      await applyRescheduleBl(payload, route, destinationName, receivedAt);
+    }
+    // tba 채널 (#918 A3 PR4) — lock-free trip-bound 사전 예약 정정.
+    if (channels.includes('tba')) {
+      await rescheduleTripBoundAlarm({
+        stationName: payload.nextStation,
+        newArrivalMs: payload.newArrivalTimeEpoch,
+        route,
+        destinationName,
+        now: receivedAt,
+      });
+    }
   } catch (e) {
     logger.error('reschedule apply 실패:', e);
   }
+}
+
+/**
+ * bl(boarding-lock) 채널 정정 — lock + route + destination 필요. 사전 조건 미충족 시
+ * graceful skip (정정 신호 폐기). tba 채널과 독립적으로 동작 — bl skip이 tba 정정을 막지 않는다.
+ */
+async function applyRescheduleBl(
+  payload: RescheduleSilentPushPayload,
+  route: NonNullable<Route>,
+  destinationName: string,
+  receivedAt: number,
+): Promise<void> {
+  const lock = await getBoardingLock();
+  if (!lock) {
+    logger.info('reschedule bl skip: no boarding lock');
+    return;
+  }
+  if (lock.trainCode !== payload.trainCode) {
+    logger.info(
+      `reschedule bl skip: trainCode mismatch lock=${lock.trainCode} payload=${payload.trainCode}`,
+    );
+    return;
+  }
+  await rescheduleHopForLock({
+    lock,
+    route,
+    destinationName,
+    nextStation: payload.nextStation,
+    newArrivalMs: payload.newArrivalTimeEpoch,
+    now: receivedAt,
+  });
 }
 
 function parseRoute(raw: string | null): Route | null {

--- a/src/features/alarm/testHelpers/tripBoundTestFactory.ts
+++ b/src/features/alarm/testHelpers/tripBoundTestFactory.ts
@@ -1,0 +1,44 @@
+/**
+ * tripBoundScheduler / useTripBoundAlarmScheduler 테스트 공용 헬퍼.
+ * SonarCloud #1187 — test 파일 dup 제거용.
+ */
+import { AppState, type AppStateStatus, type NativeEventSubscription } from 'react-native';
+import type { TripBoundStop } from '../utils/tripBoundScheduler';
+
+/**
+ * AppState.addEventListener를 가로채 FG-resume 시뮬레이션을 한 줄로 만들어준다.
+ * Hook이 mount 시점에 listener를 등록하므로 fire() 호출 시점엔 항상 listener가 잡혀 있다.
+ */
+export function captureAppStateListener(): {
+  fire: (state: AppStateStatus) => void;
+  restore: () => void;
+} {
+  const ref: { current: ((state: AppStateStatus) => void) | null } = { current: null };
+  const sub: NativeEventSubscription = { remove: jest.fn() };
+  const spy = jest
+    .spyOn(AppState, 'addEventListener')
+    .mockImplementation((_event, cb) => {
+      ref.current = cb;
+      return sub;
+    });
+  return {
+    fire: (state) => ref.current!(state),
+    restore: () => spy.mockRestore(),
+  };
+}
+
+/**
+ * Build a uniform-length TripBoundStop list — first N-1 transfer, last destination.
+ * Eliminates copy-pasted 5-stop arrays in window tests.
+ */
+export function makeUniformStops(names: string[]): TripBoundStop[] {
+  return names.map((stationName, idx) => ({
+    stationName,
+    alarmType: idx === names.length - 1 ? 'destination' : 'transfer',
+  }));
+}
+
+/** Build a uniform hop time array. */
+export function makeUniformHops(count: number, hopMs = 120_000): number[] {
+  return Array.from({ length: count }, () => hopMs);
+}

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -10,6 +10,7 @@ import {
   getRegisteredTripRouteSig,
   parseTripBoundAlarmIdentifier,
   prescheduleStationAlerts,
+  rescheduleTripBoundAlarm,
   setRegisteredTripRouteSig,
   topUpTripBoundWindow,
   tripBoundAlarmIdentifier,
@@ -664,5 +665,205 @@ describe('topUpTripBoundWindow (#918 A3 PR3)', () => {
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.stringContaining('topUp passedIndex=0 window=[1,3)'),
     );
+  });
+});
+
+// #918 A3 PR4 — backend의 reschedule push(tba 채널)을 받아 단일 hop 사전 예약 정정.
+describe('rescheduleTripBoundAlarm (#918 A3 PR4)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoggerInfo.mockClear();
+    mockedSchedule.mockResolvedValue('id');
+    jest.replaceProperty(Platform, 'OS', 'ios');
+  });
+
+  const directRoute = makeDirectRoute(3, '2');
+  const NOW_MS = new Date('2026-06-12T09:00:00Z').getTime();
+
+  // fixture sanity: 회귀 가드(early fire == newArrivalMs - hopMs)의 의미가 fixture에 의해
+  // 약해지지 않도록 hopMs 도출 기반인 travelSeconds가 양수임을 명시. fixture가 0이 되면
+  // 아래 silent-drop 회귀 가드도 동시에 trivially 통과해 의미를 잃는다.
+  it('fixture sanity: directRoute.travelSeconds > 0 (회귀 가드 의미 보장)', () => {
+    expect(directRoute.travelSeconds).toBeGreaterThan(0);
+  });
+
+  it('past-time이면 cancel/schedule 둘 다 skip + 0건 반환', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs: NOW_MS - 1,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedGetAll).not.toHaveBeenCalled();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('route=null이면 graceful no-op', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs: NOW_MS + 60_000,
+      route: null,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('destinationName=null이면 graceful no-op', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs: NOW_MS + 60_000,
+      route: directRoute,
+      destinationName: null,
+      now: NOW_MS,
+    });
+    expect(r).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('stationName이 routeStops에 없으면 no-op', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '없는역',
+      newArrivalMs: NOW_MS + 60_000,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('해당 stationName의 tba: 알람만 cancel하고 newArrivalMs 기준으로 재예약', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' },
+      { identifier: 'tba:imminent:강남' },
+      { identifier: 'tba:early:다른역' }, // 보존
+      { identifier: 'bl:T1:0:early:강남' }, // 다른 prefix 보존
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const newArrivalMs = NOW_MS + 600_000;
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r.cancelled).toBe(2);
+    // 두 phase 모두 재예약 — 이전엔 toBeGreaterThan(0)이라 early phase silent drop을 통과시켰다.
+    expect(r.scheduled).toBe(2);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:강남');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:다른역');
+    expect(mockedCancel).not.toHaveBeenCalledWith('bl:T1:0:early:강남');
+    // imminent 알람은 newArrivalMs - 10s에 발사.
+    const scheduledCalls = mockedSchedule.mock.calls;
+    const imminentCall = scheduledCalls.find(
+      ([opts]) => (opts as { identifier?: string }).identifier === 'tba:imminent:강남',
+    );
+    expect(imminentCall).toBeDefined();
+    const imminentTrigger = (
+      imminentCall?.[0] as { trigger: { date: Date } }
+    ).trigger;
+    expect(imminentTrigger.date.getTime()).toBe(newArrivalMs - 10_000);
+  });
+
+  it('parse 실패 identifier는 skip하고 valid한 것만 처리', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:malformed' }, // colon 1개뿐 → parse null
+      { identifier: 'tba:early:강남' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs: NOW_MS + 600_000,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r.cancelled).toBe(1);
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:malformed');
+  });
+
+  it('now 미지정 시 Date.now() 기준으로 past-time 판정', async () => {
+    jest.useFakeTimers().setSystemTime(NOW_MS);
+    try {
+      mockedGetAll.mockResolvedValue([]);
+      const r = await rescheduleTripBoundAlarm({
+        stationName: '강남',
+        newArrivalMs: NOW_MS - 1,
+        route: directRoute,
+        destinationName: '강남',
+      });
+      expect(r).toEqual({ cancelled: 0, scheduled: 0 });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // 회귀: 이전 구현은 startTime = newArrivalMs - hopMs로 역산해 prescheduleStationAlerts에
+  // 단일 stop을 통과시켰고, 그 결과 early phase의 fireMs가 startTime과 정확히 같아져
+  // `fireMs <= startTime` 가드에 silent drop됐다. primitive 직접 호출로 전환 후 검증.
+  it('early phase는 (newArrivalMs - hopMs)에 정확히 fire한다 (silent drop 회귀 차단)', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const newArrivalMs = NOW_MS + 600_000;
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r.scheduled).toBe(2);
+    const scheduledCalls = mockedSchedule.mock.calls;
+    const earlyCall = scheduledCalls.find(
+      ([opts]) => (opts as { identifier?: string }).identifier === 'tba:early:강남',
+    );
+    expect(earlyCall).toBeDefined();
+    const earlyTrigger = (earlyCall?.[0] as { trigger: { date: Date } }).trigger;
+    const expectedHopMs = directRoute.travelSeconds * 1000;
+    expect(earlyTrigger.date.getTime()).toBe(newArrivalMs - expectedHopMs);
+  });
+
+  it('early phase fireMs가 now 이하면 early만 skip, imminent는 예약', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    // newArrivalMs가 hopMs(=directRoute.travelSeconds*1000)보다 짧은 시간 뒤라
+    // early = newArrivalMs - hopMs ≤ now → drop, imminent = newArrivalMs - 10s > now → 예약.
+    const hopMs = directRoute.travelSeconds * 1000;
+    const newArrivalMs = NOW_MS + hopMs - 1; // early fire = NOW_MS - 1
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r.scheduled).toBe(1);
+    const ids = mockedSchedule.mock.calls.map(
+      ([opts]) => (opts as { identifier?: string }).identifier,
+    );
+    expect(ids).toEqual(['tba:imminent:강남']);
+  });
+
+  it('imminent phase fireMs도 now 이하면 둘 다 skip', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    // newArrivalMs가 IMMINENT_LEAD_MS(10s)보다 짧은 시간 뒤 → imminent도 과거.
+    const newArrivalMs = NOW_MS + 5_000;
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '강남',
+      newArrivalMs,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW_MS,
+    });
+    expect(r.scheduled).toBe(0);
+    expect(mockedSchedule).not.toHaveBeenCalled();
   });
 });

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -2,6 +2,7 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
+  TRIPBOUND_WINDOW_SIZE,
   TRIP_BOUND_ALARM_PREFIX,
   cancelTripBoundAlarms,
   clearRegisteredTripRouteSig,
@@ -10,6 +11,7 @@ import {
   parseTripBoundAlarmIdentifier,
   prescheduleStationAlerts,
   setRegisteredTripRouteSig,
+  topUpTripBoundWindow,
   tripBoundAlarmIdentifier,
   type TripBoundStop,
 } from '../tripBoundScheduler';
@@ -503,5 +505,257 @@ describe('deriveTripBoundStops', () => {
     const route = { type: 'direct' as const, stops: 1, line: '2' as const, travelSeconds: 0 };
     const { estimatedHopTimesMs } = deriveTripBoundStops(route, '강남');
     expect(estimatedHopTimesMs).toEqual([90_000]);
+  });
+});
+
+// #918 A3 PR3 — rolling window 64 cap 회피.
+describe('TRIPBOUND_WINDOW_SIZE', () => {
+  it('64 pending notification cap 안쪽에 들어가는 양수 상수', () => {
+    expect(TRIPBOUND_WINDOW_SIZE).toBeGreaterThan(0);
+    // 한 stop당 2 phase × WINDOW_SIZE + bl: 채널 여유(20여 개) < 64.
+    expect(TRIPBOUND_WINDOW_SIZE * 2).toBeLessThan(64);
+  });
+});
+
+describe('prescheduleStationAlerts windowSize/startStopIndex (#918 A3 PR3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoggerWarn.mockClear();
+    mockLoggerInfo.mockClear();
+    mockedSchedule.mockResolvedValue('id');
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('windowSize=1이면 첫 stop만 schedule (나머지 stop의 누적은 진행)', async () => {
+    // 5 stop trip, window=1 → stop 0의 imminent만(=fire>startTime) 예약.
+    // stop 0 early는 fire=startTime이라 skip.
+    const stops: TripBoundStop[] = [
+      { stationName: 'A', alarmType: 'transfer' },
+      { stationName: 'B', alarmType: 'transfer' },
+      { stationName: 'C', alarmType: 'transfer' },
+      { stationName: 'D', alarmType: 'transfer' },
+      { stationName: 'E', alarmType: 'destination' },
+    ];
+    const hops = [120_000, 120_000, 120_000, 120_000, 120_000];
+    const result = await prescheduleStationAlerts({
+      routeStops: stops,
+      estimatedHopTimesMs: hops,
+      startTime: NOW,
+      windowSize: 1,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].identifier).toBe('tba:imminent:A');
+  });
+
+  it('startStopIndex=2 + windowSize=2면 stop[2], stop[3]만 schedule, 누적은 정확히 보존', async () => {
+    const stops: TripBoundStop[] = [
+      { stationName: 'A', alarmType: 'transfer' },
+      { stationName: 'B', alarmType: 'transfer' },
+      { stationName: 'C', alarmType: 'transfer' },
+      { stationName: 'D', alarmType: 'transfer' },
+      { stationName: 'E', alarmType: 'destination' },
+    ];
+    const hops = [120_000, 120_000, 120_000, 120_000, 120_000];
+    const result = await prescheduleStationAlerts({
+      routeStops: stops,
+      estimatedHopTimesMs: hops,
+      startTime: NOW,
+      startStopIndex: 2,
+      windowSize: 2,
+    });
+    // C의 arrival = NOW + 360_000, early = NOW + 240_000, imminent = NOW + 350_000
+    // D의 arrival = NOW + 480_000, early = NOW + 360_000, imminent = NOW + 470_000
+    expect(result.map((r) => r.identifier)).toEqual([
+      'tba:early:C',
+      'tba:imminent:C',
+      'tba:early:D',
+      'tba:imminent:D',
+    ]);
+    expect(result[0].fireDate).toEqual(new Date(NOW + 240_000));
+    expect(result[1].fireDate).toEqual(new Date(NOW + 350_000));
+  });
+
+  it('windowSize=0이면 0건 schedule', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+      windowSize: 0,
+    });
+    expect(result).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('startStopIndex 음수는 0으로 clamp (caller bug 흡수)', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+      startStopIndex: -5,
+    });
+    // 음수 clamp → 평소 동작과 동일하게 stop 0부터 (stop 0 early skip).
+    expect(result).toHaveLength(5);
+  });
+
+  it('windowSize 음수는 0으로 clamp (no-op)', async () => {
+    const result = await prescheduleStationAlerts({
+      routeStops: defaultStops,
+      estimatedHopTimesMs: defaultHops,
+      startTime: NOW,
+      windowSize: -3,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('중복 stationName이 윈도우 밖에 있어도 occurrence suffix가 보존된다', async () => {
+    // 윈도우 안 두 번째 등장이 :1 suffix를 받도록 — 윈도우 밖 첫 등장도 occurrence 누적.
+    const stops: TripBoundStop[] = [
+      { stationName: '시청', alarmType: 'transfer' }, // skipped(window 밖)
+      { stationName: '강남', alarmType: 'transfer' },
+      { stationName: '시청', alarmType: 'destination' }, // 두 번째 등장
+    ];
+    const hops = [120_000, 120_000, 120_000];
+    const result = await prescheduleStationAlerts({
+      routeStops: stops,
+      estimatedHopTimesMs: hops,
+      startTime: NOW,
+      startStopIndex: 1,
+      windowSize: 2,
+    });
+    const ids = result.map((r) => r.identifier);
+    // 두 번째 시청은 :1 suffix를 받아야 한다 — 윈도우 밖 첫 시청의 occurrence가 누적됨.
+    expect(ids).toContain('tba:imminent:시청:1');
+  });
+});
+
+describe('topUpTripBoundWindow (#918 A3 PR3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoggerInfo.mockClear();
+    mockedSchedule.mockResolvedValue('id');
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    jest.useFakeTimers().setSystemTime(NOW);
+    mockedGetAll.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const longStops: TripBoundStop[] = Array.from({ length: 10 }, (_, i) => ({
+    stationName: `S${i}`,
+    alarmType: i === 9 ? ('destination' as const) : ('transfer' as const),
+  }));
+  const longHops = Array.from({ length: 10 }, () => 120_000);
+
+  it('passedStationName이 routeStops에 없으면 no-op', async () => {
+    const result = await topUpTripBoundWindow({
+      routeStops: longStops,
+      estimatedHopTimesMs: longHops,
+      startTime: NOW,
+      passedStationName: 'UNKNOWN',
+      windowSize: 3,
+    });
+    expect(result).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('routeStops가 비어 있으면 no-op', async () => {
+    const result = await topUpTripBoundWindow({
+      routeStops: [],
+      estimatedHopTimesMs: [],
+      startTime: NOW,
+      passedStationName: 'X',
+    });
+    expect(result).toEqual({ cancelled: 0, scheduled: 0 });
+  });
+
+  it('passedIndex 이전 stop의 tba 알람은 cancel, 윈도우 안 stop은 schedule', async () => {
+    // 큐에 stop S1(passedStation 이전) + S2(현재 윈도우 안) + S5(이전 윈도우 잔여, 새 윈도우 밖) 존재.
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:imminent:S1' },
+      { identifier: 'tba:early:S2' },
+      { identifier: 'tba:imminent:S5' },
+      { identifier: 'bl:T:0:early:X' }, // 다른 prefix — 건드리지 않음.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const result = await topUpTripBoundWindow({
+      routeStops: longStops,
+      estimatedHopTimesMs: longHops,
+      startTime: NOW,
+      passedStationName: 'S2', // window = [3, 6)
+      windowSize: 3,
+    });
+
+    // 새 윈도우 = stops index 3,4,5 = stationName S3, S4, S5. S5는 윈도우 안.
+    // S1, S2는 윈도우 밖 → cancel. S5는 윈도우 안 → cancel 안 함.
+    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:S1');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:S2');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:S5');
+    expect(mockedCancel).not.toHaveBeenCalledWith('bl:T:0:early:X');
+    expect(result.cancelled).toBe(2);
+    // schedule된 stop은 S3, S4, S5 — 각 (early, imminent) 2 phase × 3 stop = 6건.
+    expect(result.scheduled).toBe(6);
+  });
+
+  it('잘못된 identifier(parse=null)는 cancel skip', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:malformed' }, // parse → null
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const result = await topUpTripBoundWindow({
+      routeStops: longStops,
+      estimatedHopTimesMs: longHops,
+      startTime: NOW,
+      passedStationName: 'S0',
+      windowSize: 2,
+    });
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:malformed');
+    expect(result.cancelled).toBe(0);
+  });
+
+  it('windowSize 미지정 시 TRIPBOUND_WINDOW_SIZE 기본값 사용', async () => {
+    const result = await topUpTripBoundWindow({
+      routeStops: longStops,
+      estimatedHopTimesMs: longHops,
+      startTime: NOW,
+      passedStationName: 'S0',
+    });
+    // window = [1, min(10, 1+20)] = [1, 10] → 9 stop × 2 phase = 18.
+    expect(result.scheduled).toBe(18);
+  });
+
+  it('passedIndex가 마지막 stop이면 새 stop 없이 cancel만', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:imminent:S0' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const result = await topUpTripBoundWindow({
+      routeStops: longStops,
+      estimatedHopTimesMs: longHops,
+      startTime: NOW,
+      passedStationName: 'S9', // 마지막
+      windowSize: 3,
+    });
+    expect(result.scheduled).toBe(0);
+    expect(result.cancelled).toBe(1);
+  });
+
+  it('info 로그에 윈도우 범위 + 카운트 출력', async () => {
+    await topUpTripBoundWindow({
+      routeStops: longStops,
+      estimatedHopTimesMs: longHops,
+      startTime: NOW,
+      passedStationName: 'S0',
+      windowSize: 2,
+    });
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.stringContaining('topUp passedIndex=0 window=[1,3)'),
+    );
   });
 });

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -21,6 +21,10 @@ import {
   makeMultiTransferRoute,
   makeTransferRoute,
 } from '../../../../testUtils/routeFixtures';
+import {
+  makeUniformHops,
+  makeUniformStops,
+} from '../../testHelpers/tripBoundTestFactory';
 
 jest.mock('expo-notifications');
 
@@ -62,6 +66,31 @@ const defaultStops: TripBoundStop[] = [
   { stationName: '강남', alarmType: 'destination' },
 ];
 const defaultHops = [120_000, 120_000, 120_000];
+
+// `prescheduleStationAlerts` wrapper that fills NOW + defaults — eliminates copy-pasted
+// `routeStops/estimatedHopTimesMs/startTime` triples across ~15 call sites.
+const prescheduleWith = (
+  overrides: Partial<Parameters<typeof prescheduleStationAlerts>[0]> = {},
+) =>
+  prescheduleStationAlerts({
+    routeStops: defaultStops,
+    estimatedHopTimesMs: defaultHops,
+    startTime: NOW,
+    ...overrides,
+  });
+
+// Shared iOS + fake-timer setup used by both `prescheduleStationAlerts` describes.
+const setupIosFakeTimers = () => {
+  jest.clearAllMocks();
+  mockLoggerWarn.mockClear();
+  mockLoggerInfo.mockClear();
+  mockedSchedule.mockResolvedValue('id');
+  jest.replaceProperty(Platform, 'OS', 'ios');
+  jest.useFakeTimers().setSystemTime(NOW);
+};
+const teardownFakeTimers = () => {
+  jest.useRealTimers();
+};
 
 describe('tripBoundAlarmIdentifier', () => {
   it('prefix + phaseId + stationName 결합 identifier를 만든다', () => {
@@ -155,39 +184,20 @@ describe('registered trip route sig storage (#918 A3 PR2)', () => {
 });
 
 describe('prescheduleStationAlerts', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockLoggerWarn.mockClear();
-    mockLoggerInfo.mockClear();
-    mockedSchedule.mockResolvedValue('id');
-    jest.replaceProperty(Platform, 'OS', 'ios');
-    // wall-clock 가드 (Date.now())가 NOW 기준 fixture를 통과시키도록 fake timer 시점을 NOW에 고정.
-    jest.useFakeTimers().setSystemTime(NOW);
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
+  beforeEach(setupIosFakeTimers);
+  afterEach(teardownFakeTimers);
 
   it('stop별 early/imminent 두 phase를 예약한다 — stop 0 early는 정의상 fire=startTime이라 skip', async () => {
     // 첫 stop의 early lead는 자기 자신의 hopMs라 fire = startTime + hopMs - hopMs = startTime.
     // `fireMs <= startTime` 가드로 skip된다. 따라서 N stop trip은 (N*2 - 1)건 예약된다.
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
+    const result = await prescheduleWith();
 
     expect(result).toHaveLength(defaultStops.length * 2 - 1);
     expect(mockedSchedule).toHaveBeenCalledTimes(defaultStops.length * 2 - 1);
   });
 
   it('각 stop의 early는 (arrival - hopMs), imminent는 (arrival - 10s)에 fire한다', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
+    const result = await prescheduleWith();
 
     // stop 0: arrival=NOW+120_000, early=NOW+0(=startTime → skip), imminent=NOW+110_000
     // stop 1: arrival=NOW+240_000, early=NOW+120_000, imminent=NOW+230_000
@@ -207,11 +217,7 @@ describe('prescheduleStationAlerts', () => {
   });
 
   it('alarmType이 event.type으로 그대로 전달된다 (transfer/destination 데이터 주도)', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
+    const result = await prescheduleWith();
     const types = result.map((r) => `${r.event.stationName}/${r.event.type}`);
     expect(types).toContain('동대문/transfer');
     expect(types).toContain('서울역/transfer');
@@ -219,11 +225,7 @@ describe('prescheduleStationAlerts', () => {
   });
 
   it('routeStops가 비어 있으면 0건 반환, schedule을 호출하지 않는다', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: [],
-      estimatedHopTimesMs: [],
-      startTime: NOW,
-    });
+    const result = await prescheduleWith({ routeStops: [], estimatedHopTimesMs: [] });
     expect(result).toEqual([]);
     expect(mockedSchedule).not.toHaveBeenCalled();
     // 빈 입력은 정상 — warn 없음.
@@ -231,11 +233,7 @@ describe('prescheduleStationAlerts', () => {
   });
 
   it('routeStops와 estimatedHopTimesMs 길이가 다르면 0건 + warn', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: [120_000, 120_000],
-      startTime: NOW,
-    });
+    const result = await prescheduleWith({ estimatedHopTimesMs: [120_000, 120_000] });
     expect(result).toEqual([]);
     expect(mockedSchedule).not.toHaveBeenCalled();
     expect(mockLoggerWarn).toHaveBeenCalledWith(
@@ -245,10 +243,9 @@ describe('prescheduleStationAlerts', () => {
 
   it('모든 fireMs가 startTime 이하라면 0건 + reason=all-past warn', async () => {
     // 단일 stop + hop=0ms → arrival=startTime, 모든 phase의 fireMs<=startTime → 전부 skip.
-    const result = await prescheduleStationAlerts({
+    const result = await prescheduleWith({
       routeStops: [{ stationName: '강남', alarmType: 'destination' }],
       estimatedHopTimesMs: [0],
-      startTime: NOW,
     });
     expect(result).toEqual([]);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
@@ -257,47 +254,27 @@ describe('prescheduleStationAlerts', () => {
   });
 
   it('정상 예약 케이스에서는 warn을 발화하지 않고 info만 남긴다', async () => {
-    await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
+    await prescheduleWith();
     expect(mockLoggerWarn).not.toHaveBeenCalled();
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.stringContaining('prescheduled 5 alarms for 3 stops'),
     );
   });
 
-  it('iOS imminent phase는 interruptionLevel=timeSensitive', async () => {
-    await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
-    // imminent phase 호출 — 적어도 한 번은 timeSensitive로 호출되어야 한다.
+  // iOS phase별 interruptionLevel — phase identifier prefix + 기대 level 매핑.
+  it.each([
+    ['imminent', 'tba:imminent:', 'timeSensitive'],
+    ['early', 'tba:early:', 'active'],
+  ])('iOS %s phase는 interruptionLevel=%s', async (_phase, prefix, level) => {
+    await prescheduleWith();
     const calls = mockedSchedule.mock.calls.map((c) => c[0]);
-    const imminent = calls.find((c) => c.identifier?.startsWith('tba:imminent:'));
-    expect(imminent?.content).toMatchObject({ interruptionLevel: 'timeSensitive' });
-  });
-
-  it('iOS early phase는 interruptionLevel=active', async () => {
-    await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
-    const calls = mockedSchedule.mock.calls.map((c) => c[0]);
-    const early = calls.find((c) => c.identifier?.startsWith('tba:early:'));
-    expect(early?.content).toMatchObject({ interruptionLevel: 'active' });
+    const match = calls.find((c) => c.identifier?.startsWith(prefix));
+    expect(match?.content).toMatchObject({ interruptionLevel: level });
   });
 
   it('Android는 channelId + priority MAX를 포함, iOS interruptionLevel은 없음', async () => {
     jest.replaceProperty(Platform, 'OS', 'android');
-    await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
+    await prescheduleWith();
     const call = mockedSchedule.mock.calls[0][0];
     expect(call.content).toMatchObject({
       channelId: 'station-alarm',
@@ -308,11 +285,7 @@ describe('prescheduleStationAlerts', () => {
   });
 
   it('trigger.date에 fireDate가 전달된다', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-    });
+    const result = await prescheduleWith();
     const firstCall = mockedSchedule.mock.calls[0][0];
     expect(firstCall.trigger).toEqual({
       type: Notifications.SchedulableTriggerInputTypes.DATE,
@@ -322,13 +295,7 @@ describe('prescheduleStationAlerts', () => {
 
   it('scheduleNotificationAsync가 throw하면 caller로 전파한다 (try/catch 미흡수)', async () => {
     mockedSchedule.mockRejectedValueOnce(new Error('permission denied'));
-    await expect(
-      prescheduleStationAlerts({
-        routeStops: defaultStops,
-        estimatedHopTimesMs: defaultHops,
-        startTime: NOW,
-      }),
-    ).rejects.toThrow('permission denied');
+    await expect(prescheduleWith()).rejects.toThrow('permission denied');
   });
 
   it('stop 1개짜리 trip(direct route)도 데이터 그대로 처리한다', async () => {
@@ -337,10 +304,9 @@ describe('prescheduleStationAlerts', () => {
     // 그래서 30s 전 시작이라도 early는 항상 startTime에 떨어진다. 미래로 보내려면 hop을 분리해야.
     // 단일 stop 시나리오에서 early는 정의상 fire=startTime이라 skip된다 — 의도된 정책.
     // imminent만 1건 예약된다.
-    const result = await prescheduleStationAlerts({
+    const result = await prescheduleWith({
       routeStops: [{ stationName: '강남', alarmType: 'destination' }],
       estimatedHopTimesMs: [600_000],
-      startTime: NOW,
     });
     expect(result).toHaveLength(1);
     expect(result[0].identifier).toBe('tba:imminent:강남');
@@ -348,14 +314,8 @@ describe('prescheduleStationAlerts', () => {
   });
 
   it('hopMs가 NaN/Infinity/음수면 해당 stop skip + warn', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: [
-        { stationName: '동대문', alarmType: 'transfer' },
-        { stationName: '서울역', alarmType: 'transfer' },
-        { stationName: '강남', alarmType: 'destination' },
-      ],
+    const result = await prescheduleWith({
       estimatedHopTimesMs: [120_000, Number.NaN, 120_000],
-      startTime: NOW,
     });
     // NaN stop은 cumulativeMs에 누적되지 않아 다음 stop fireMs가 startTime+120_000 그대로.
     // result는 정상 hop stop만 포함.
@@ -370,14 +330,12 @@ describe('prescheduleStationAlerts', () => {
   it('route에 같은 stationName이 중복 등장하면 두 번째부터 :n suffix로 unique', async () => {
     // 순환 노선/route 다시 방문 케이스. iOS scheduleNotificationAsync는 동일 identifier 시
     // silent overwrite하므로 phaseStationOccurrence map으로 idx suffix 추가.
-    const result = await prescheduleStationAlerts({
+    const result = await prescheduleWith({
       routeStops: [
         { stationName: '시청', alarmType: 'transfer' },
         { stationName: '강남', alarmType: 'transfer' },
         { stationName: '시청', alarmType: 'destination' },
       ],
-      estimatedHopTimesMs: [120_000, 120_000, 120_000],
-      startTime: NOW,
     });
     const ids = result.map((r) => r.identifier);
     // 첫 시청 imminent → 기본 identifier, 두 번째 시청 imminent → :1 suffix.
@@ -518,33 +476,19 @@ describe('TRIPBOUND_WINDOW_SIZE', () => {
 });
 
 describe('prescheduleStationAlerts windowSize/startStopIndex (#918 A3 PR3)', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockLoggerWarn.mockClear();
-    mockLoggerInfo.mockClear();
-    mockedSchedule.mockResolvedValue('id');
-    jest.replaceProperty(Platform, 'OS', 'ios');
-    jest.useFakeTimers().setSystemTime(NOW);
-  });
-  afterEach(() => {
-    jest.useRealTimers();
-  });
+  beforeEach(setupIosFakeTimers);
+  afterEach(teardownFakeTimers);
+
+  // 5-stop ABCDE fixture — windowSize/startStopIndex 테스트 공통.
+  const fiveStops = makeUniformStops(['A', 'B', 'C', 'D', 'E']);
+  const fiveHops = makeUniformHops(5);
 
   it('windowSize=1이면 첫 stop만 schedule (나머지 stop의 누적은 진행)', async () => {
     // 5 stop trip, window=1 → stop 0의 imminent만(=fire>startTime) 예약.
     // stop 0 early는 fire=startTime이라 skip.
-    const stops: TripBoundStop[] = [
-      { stationName: 'A', alarmType: 'transfer' },
-      { stationName: 'B', alarmType: 'transfer' },
-      { stationName: 'C', alarmType: 'transfer' },
-      { stationName: 'D', alarmType: 'transfer' },
-      { stationName: 'E', alarmType: 'destination' },
-    ];
-    const hops = [120_000, 120_000, 120_000, 120_000, 120_000];
-    const result = await prescheduleStationAlerts({
-      routeStops: stops,
-      estimatedHopTimesMs: hops,
-      startTime: NOW,
+    const result = await prescheduleWith({
+      routeStops: fiveStops,
+      estimatedHopTimesMs: fiveHops,
       windowSize: 1,
     });
     expect(result).toHaveLength(1);
@@ -552,18 +496,9 @@ describe('prescheduleStationAlerts windowSize/startStopIndex (#918 A3 PR3)', () 
   });
 
   it('startStopIndex=2 + windowSize=2면 stop[2], stop[3]만 schedule, 누적은 정확히 보존', async () => {
-    const stops: TripBoundStop[] = [
-      { stationName: 'A', alarmType: 'transfer' },
-      { stationName: 'B', alarmType: 'transfer' },
-      { stationName: 'C', alarmType: 'transfer' },
-      { stationName: 'D', alarmType: 'transfer' },
-      { stationName: 'E', alarmType: 'destination' },
-    ];
-    const hops = [120_000, 120_000, 120_000, 120_000, 120_000];
-    const result = await prescheduleStationAlerts({
-      routeStops: stops,
-      estimatedHopTimesMs: hops,
-      startTime: NOW,
+    const result = await prescheduleWith({
+      routeStops: fiveStops,
+      estimatedHopTimesMs: fiveHops,
       startStopIndex: 2,
       windowSize: 2,
     });
@@ -580,49 +515,30 @@ describe('prescheduleStationAlerts windowSize/startStopIndex (#918 A3 PR3)', () 
   });
 
   it('windowSize=0이면 0건 schedule', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-      windowSize: 0,
-    });
+    const result = await prescheduleWith({ windowSize: 0 });
     expect(result).toEqual([]);
     expect(mockedSchedule).not.toHaveBeenCalled();
   });
 
   it('startStopIndex 음수는 0으로 clamp (caller bug 흡수)', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-      startStopIndex: -5,
-    });
+    const result = await prescheduleWith({ startStopIndex: -5 });
     // 음수 clamp → 평소 동작과 동일하게 stop 0부터 (stop 0 early skip).
     expect(result).toHaveLength(5);
   });
 
   it('windowSize 음수는 0으로 clamp (no-op)', async () => {
-    const result = await prescheduleStationAlerts({
-      routeStops: defaultStops,
-      estimatedHopTimesMs: defaultHops,
-      startTime: NOW,
-      windowSize: -3,
-    });
+    const result = await prescheduleWith({ windowSize: -3 });
     expect(result).toEqual([]);
   });
 
   it('중복 stationName이 윈도우 밖에 있어도 occurrence suffix가 보존된다', async () => {
     // 윈도우 안 두 번째 등장이 :1 suffix를 받도록 — 윈도우 밖 첫 등장도 occurrence 누적.
-    const stops: TripBoundStop[] = [
-      { stationName: '시청', alarmType: 'transfer' }, // skipped(window 밖)
-      { stationName: '강남', alarmType: 'transfer' },
-      { stationName: '시청', alarmType: 'destination' }, // 두 번째 등장
-    ];
-    const hops = [120_000, 120_000, 120_000];
-    const result = await prescheduleStationAlerts({
-      routeStops: stops,
-      estimatedHopTimesMs: hops,
-      startTime: NOW,
+    const result = await prescheduleWith({
+      routeStops: [
+        { stationName: '시청', alarmType: 'transfer' }, // skipped(window 밖)
+        { stationName: '강남', alarmType: 'transfer' },
+        { stationName: '시청', alarmType: 'destination' }, // 두 번째 등장
+      ],
       startStopIndex: 1,
       windowSize: 2,
     });
@@ -634,22 +550,13 @@ describe('prescheduleStationAlerts windowSize/startStopIndex (#918 A3 PR3)', () 
 
 describe('topUpTripBoundWindow (#918 A3 PR3)', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    mockLoggerInfo.mockClear();
-    mockedSchedule.mockResolvedValue('id');
-    jest.replaceProperty(Platform, 'OS', 'ios');
-    jest.useFakeTimers().setSystemTime(NOW);
+    setupIosFakeTimers();
     mockedGetAll.mockResolvedValue([]);
   });
-  afterEach(() => {
-    jest.useRealTimers();
-  });
+  afterEach(teardownFakeTimers);
 
-  const longStops: TripBoundStop[] = Array.from({ length: 10 }, (_, i) => ({
-    stationName: `S${i}`,
-    alarmType: i === 9 ? ('destination' as const) : ('transfer' as const),
-  }));
-  const longHops = Array.from({ length: 10 }, () => 120_000);
+  const longStops = makeUniformStops(Array.from({ length: 10 }, (_, i) => `S${i}`));
+  const longHops = makeUniformHops(10);
 
   it('passedStationName이 routeStops에 없으면 no-op', async () => {
     const result = await topUpTripBoundWindow({

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -35,6 +35,19 @@ const ALARM_CHANNEL_ID = 'station-alarm';
 const IMMINENT_LEAD_MS = 10_000;
 
 /**
+ * #918 A3 PR3 — rolling window 64 cap 회피용 윈도우 크기 (stop 단위).
+ *
+ * iOS는 앱당 pending local notification 64개 한도. 한 stop당 (early, imminent) 2개씩 예약되므로
+ * `TRIPBOUND_WINDOW_SIZE * 2`가 tba: 채널이 OS 큐에서 점유하는 상한이다. 20 stop으로 둔 이유:
+ *  - tba: 40개 + bl: 채널 6~8개(현재 windowSize 3 × 2 phase, 다음 leg 진입 시 일시적 중복 포함)
+ *    + 시스템(silent push delivery 1~2건) ≈ 50개 — 64 cap 안쪽 안전 마진.
+ *  - 평균 trip 길이(서울 1~9호선 30~40 stop) 대비 절반 이상 커버해, 사용자 통과 1회당 top-up 1회로
+ *    rolling이 매끄럽게 진행된다 — 너무 작으면(예: 5) top-up이 매역 발생해 storage I/O 부담.
+ *  - 64 cap에 너무 가까우면(예: 30) bl: 채널이 lock 전환기에 일시적으로 부풀 때 cap 초과 위험.
+ */
+export const TRIPBOUND_WINDOW_SIZE = 20;
+
+/**
  * 사전 예약 대상 단일 stop. lock-free — boarding lock 메타에 의존하지 않고,
  * 호출자가 route 어떤 형태(direct/transfer/multi-transfer)든 평탄화해 넘긴다.
  */
@@ -59,6 +72,22 @@ export interface PrescheduleParams {
   estimatedHopTimesMs: ReadonlyArray<number>;
   /** 누적의 기준점. trip 등록 시각(ms epoch). */
   startTime: number;
+  /**
+   * #918 A3 PR3 — rolling window. 예약할 stop 개수 상한. 미지정이면 routeStops 전체.
+   * `startTime` 누적은 항상 routeStops[0]부터 시작하므로 windowSize는 "앞에서 N개만 예약"으로
+   * 동작한다. 매역 통과 시 `topUpTripBoundWindow`가 다음 N개로 rolling.
+   */
+  windowSize?: number;
+  /**
+   * #918 A3 PR3 — top-up 진입점용. 누적은 routeStops[0]부터 진행하되, 실제 OS schedule은
+   * `startStopIndex` 이상인 stop에만 호출한다 (그 이전 stop은 이미 cancel됨).
+   * 미지정이면 0. 호출자(topUpTripBoundWindow)는 passedIndex+1을 넘긴다.
+   *
+   * 이 옵션을 두는 이유: top-up도 fire 시각을 같은 startTime + 누적 hop으로 산출해야
+   * 초기 preschedule과 정확히 동일한 fire 시각을 보장한다. 그렇지 않으면 매역 통과마다
+   * 누적 오차가 쌓여 imminent가 실제 도착 시각과 어긋난다.
+   */
+  startStopIndex?: number;
 }
 
 export interface ScheduledTripBoundAlarm {
@@ -82,7 +111,7 @@ export interface ScheduledTripBoundAlarm {
 export async function prescheduleStationAlerts(
   params: PrescheduleParams,
 ): Promise<ScheduledTripBoundAlarm[]> {
-  const { routeStops, estimatedHopTimesMs, startTime } = params;
+  const { routeStops, estimatedHopTimesMs, startTime, windowSize, startStopIndex = 0 } = params;
 
   if (routeStops.length !== estimatedHopTimesMs.length) {
     logger.warn(
@@ -93,6 +122,15 @@ export async function prescheduleStationAlerts(
   if (routeStops.length === 0) {
     return [];
   }
+
+  // window 상한 — 미지정이면 전체. 호출자가 명시한 음수/0이면 0 stop schedule(자연스럽게 no-op).
+  // startStopIndex 음수 입력은 0으로 clamp — caller(top-up) bug 흡수.
+  const effectiveStartIndex = startStopIndex < 0 ? 0 : startStopIndex;
+  const effectiveWindowSize = windowSize === undefined ? routeStops.length : windowSize;
+  const scheduleEndIndex = Math.min(
+    routeStops.length,
+    effectiveStartIndex + Math.max(0, effectiveWindowSize),
+  );
 
   const scheduled: ScheduledTripBoundAlarm[] = [];
   let cumulativeMs = startTime;
@@ -122,15 +160,21 @@ export async function prescheduleStationAlerts(
       // startTime 기준 + 실제 wall-clock 기준 두 조건 모두 통과해야 등록.
       if (fireMs <= startTime || fireMs <= nowMs) continue;
 
+      // 같은 station이 route 안에 중복 등장하는 경우, identifier 충돌을 피하기 위해 occurrence 누적은
+      // 윈도우 밖 stop에서도 진행해야 한다 (초기 preschedule과 top-up 호출에서 동일 identifier 산출 보장).
+      const occKey = `${phase.id}:${stop.stationName}`;
+      const occIdx = phaseStationOccurrence.get(occKey) ?? 0;
+      phaseStationOccurrence.set(occKey, occIdx + 1);
+
+      // 윈도우 밖 stop은 누적/occurrence 진행만, OS schedule은 skip — fire 시각/identifier 정렬 보존.
+      if (i < effectiveStartIndex || i >= scheduleEndIndex) continue;
+
       const event: AlarmEvent = {
         phaseId: phase.id,
         type: stop.alarmType,
         stationName: stop.stationName,
       };
       const baseId = tripBoundAlarmIdentifier(event);
-      const occKey = `${phase.id}:${stop.stationName}`;
-      const occIdx = phaseStationOccurrence.get(occKey) ?? 0;
-      phaseStationOccurrence.set(occKey, occIdx + 1);
       // 첫 등장은 base identifier 유지 (호환), 두 번째 이상은 :n suffix로 unique.
       const identifier = occIdx === 0 ? baseId : `${baseId}:${occIdx}`;
       const fireDate = new Date(fireMs);
@@ -290,6 +334,95 @@ function legSecondsForHop(
   }
   if (hopIndex < route.transfers.length) return route.transfers[hopIndex].secondsToTransfer;
   return route.secondsAfterLastTransfer;
+}
+
+export interface TopUpTripBoundWindowParams extends PrescheduleParams {
+  /**
+   * Fusion 등에서 통과 보고된 stop의 stationName. routeStops에 존재해야 effect 발생.
+   * resolveAllTargets canonical name 기준 — caller가 `isSameStationName`으로 매칭해 넘긴다.
+   */
+  passedStationName: string;
+}
+
+export interface TopUpTripBoundWindowResult {
+  cancelled: number;
+  scheduled: number;
+}
+
+/**
+ * #918 A3 PR3 — rolling window top-up.
+ *
+ * Fusion이 새 stop을 통과 보고하면 호출. 통과한 stop과 그 이전 stop의 사전 예약 알람을 cancel하고,
+ * `[passedIndex+1, passedIndex+1+windowSize)` 범위에서 큐에 없는 hop을 채워 예약한다.
+ *
+ * `boardingLockScheduler.advanceHopWindow`와 동일 패턴 — lock-free trip-bound 예약 채널에 적용.
+ * iOS 64 pending notification cap을 회피하기 위해 한 번에 큐에 두는 stop 수를 `windowSize` 이하로
+ * 유지한다(기본 {@link TRIPBOUND_WINDOW_SIZE}).
+ *
+ * - `passedStationName`이 routeStops에 없으면 no-op (no-cancel, no-schedule).
+ * - 큐가 이미 정확한 윈도우 상태면 cancel 0건 + schedule은 idempotent overwrite로 진행되지만
+ *   호출이 빈번하면 OS 부하 — 호출자가 직전 passedStationName을 기억해 중복 호출을 차단해야 한다
+ *   (`useTripBoundAlarmScheduler` 책임).
+ * - FG resume 시 같은 함수로 진입 가능 — passedStationName이 가장 최근 통과한 stop이면 동작 일관.
+ */
+export async function topUpTripBoundWindow(
+  params: TopUpTripBoundWindowParams,
+): Promise<TopUpTripBoundWindowResult> {
+  const {
+    routeStops,
+    estimatedHopTimesMs,
+    startTime,
+    passedStationName,
+    windowSize = TRIPBOUND_WINDOW_SIZE,
+  } = params;
+
+  if (routeStops.length === 0) {
+    return { cancelled: 0, scheduled: 0 };
+  }
+
+  const passedIndex = routeStops.findIndex((s) => s.stationName === passedStationName);
+  if (passedIndex === -1) {
+    return { cancelled: 0, scheduled: 0 };
+  }
+
+  // 새 윈도우 범위 = [nextStartIndex, nextEndIndex).
+  const nextStartIndex = passedIndex + 1;
+  const nextEndIndex = Math.min(routeStops.length, nextStartIndex + windowSize);
+
+  // 이미 큐에 있는 `tba:` 알람 중 새 윈도우 밖에 해당하는 것만 cancel.
+  // routeStops[i]의 stationName이 윈도우 안에 있는지 빠르게 판별하기 위한 set.
+  const inWindowStationNames = new Set<string>();
+  for (let i = nextStartIndex; i < nextEndIndex; i++) {
+    inWindowStationNames.add(routeStops[i].stationName);
+  }
+
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let cancelled = 0;
+  for (const req of all) {
+    if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
+    const parsed = parseTripBoundAlarmIdentifier(req.identifier);
+    if (parsed === null) continue;
+    // occurrence suffix가 붙은 경우 stationName에 ":n"이 포함된다 — 그래도 set lookup으로 mismatch 시
+    // cancel 처리되므로 새 윈도우의 첫 등장 알람과 충돌하지 않는다.
+    if (!inWindowStationNames.has(parsed.stationName)) {
+      await Notifications.cancelScheduledNotificationAsync(req.identifier);
+      cancelled++;
+    }
+  }
+
+  // 윈도우 안 stop 예약 — idempotent overwrite. 누적 startTime 기반이라 fire 시각은 초기 preschedule과 동일.
+  const scheduledAlarms = await prescheduleStationAlerts({
+    routeStops,
+    estimatedHopTimesMs,
+    startTime,
+    startStopIndex: nextStartIndex,
+    windowSize,
+  });
+
+  logger.info(
+    `topUp passedIndex=${passedIndex} window=[${nextStartIndex},${nextEndIndex}) cancelled=${cancelled} scheduled=${scheduledAlarms.length}`,
+  );
+  return { cancelled, scheduled: scheduledAlarms.length };
 }
 
 /**

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -1,7 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
+import { ALARM_PHASES, type AlarmPhase, type AlarmPhaseId } from './alarmPhases';
 import { alarmKey, resolveAllTargets, type AlarmEvent } from './stationAlarm';
 import { buildAlarmContent } from './stationNotification';
 import type { AlarmType } from '../../../shared/types/alarm';
@@ -97,6 +97,55 @@ export interface ScheduledTripBoundAlarm {
 }
 
 /**
+ * 단일 (stop, phase) OS local notification 1건 예약 primitive.
+ *
+ * 가드는 일절 갖지 않는다 — 호출자가 fireMs 가드(과거 시각 / trip 도메인 trivial 등)를 결정한
+ * 뒤 호출한다. identifier 충돌 회피를 위해 `occurrenceIdx ≥ 1`이면 `:n` suffix가 붙는다
+ * (`prescheduleStationAlerts`의 같은-역-중복 등장 로직과 동일 규약).
+ *
+ * `prescheduleStationAlerts`와 `rescheduleTripBoundAlarm` 양쪽에서 공통 사용 — 한쪽이 누적
+ * `startTime` 모델, 다른 쪽이 `arrivalMs` 직접 지정 모델로 다른 도메인이지만 OS 큐 등록 책임은
+ * 동일하다. 그 책임만 primitive에 둔다.
+ *
+ * 실패 시 caller로 throw (alarmScheduler 정책 일치). `recordScheduledAlarm`은 graceful 내부 처리.
+ */
+async function scheduleStopPhase(params: {
+  phase: AlarmPhase;
+  stop: TripBoundStop;
+  fireMs: number;
+  occurrenceIdx: number;
+}): Promise<ScheduledTripBoundAlarm> {
+  const { phase, stop, fireMs, occurrenceIdx } = params;
+  const event: AlarmEvent = {
+    phaseId: phase.id,
+    type: stop.alarmType,
+    stationName: stop.stationName,
+  };
+  const baseId = tripBoundAlarmIdentifier(event);
+  const identifier = occurrenceIdx === 0 ? baseId : `${baseId}:${occurrenceIdx}`;
+  const fireDate = new Date(fireMs);
+  const { title, body } = buildAlarmContent(event);
+
+  await Notifications.scheduleNotificationAsync({
+    identifier,
+    content: {
+      title,
+      body,
+      sound: 'alarm.wav',
+      ...(Platform.OS === 'android' && {
+        channelId: ALARM_CHANNEL_ID,
+        priority: Notifications.AndroidNotificationPriority.MAX,
+      }),
+      ...(Platform.OS === 'ios' && { interruptionLevel: PHASE_INTERRUPTION[phase.id] }),
+    },
+    trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: fireDate },
+  });
+
+  await recordScheduledAlarm({ identifier, scheduledFireMs: fireMs });
+  return { identifier, event, fireDate };
+}
+
+/**
  * trip 등록(자동 lock 직후 포함) 시점에 destinationName 까지 모든 stop에 대해
  * (early, imminent) OS local notification을 사전 예약한다. lock 유무와 무관.
  *
@@ -169,39 +218,15 @@ export async function prescheduleStationAlerts(
       // 윈도우 밖 stop은 누적/occurrence 진행만, OS schedule은 skip — fire 시각/identifier 정렬 보존.
       if (i < effectiveStartIndex || i >= scheduleEndIndex) continue;
 
-      const event: AlarmEvent = {
-        phaseId: phase.id,
-        type: stop.alarmType,
-        stationName: stop.stationName,
-      };
-      const baseId = tripBoundAlarmIdentifier(event);
-      // 첫 등장은 base identifier 유지 (호환), 두 번째 이상은 :n suffix로 unique.
-      const identifier = occIdx === 0 ? baseId : `${baseId}:${occIdx}`;
-      const fireDate = new Date(fireMs);
-      const { title, body } = buildAlarmContent(event);
-
-      // scheduleNotificationAsync가 throw하면 caller로 전파 — alarmScheduler 정책 일치.
-      await Notifications.scheduleNotificationAsync({
-        identifier,
-        content: {
-          title,
-          body,
-          sound: 'alarm.wav',
-          ...(Platform.OS === 'android' && {
-            channelId: ALARM_CHANNEL_ID,
-            priority: Notifications.AndroidNotificationPriority.MAX,
-          }),
-          ...(Platform.OS === 'ios' && { interruptionLevel: PHASE_INTERRUPTION[phase.id] }),
-        },
-        trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: fireDate },
+      // 가드 통과한 (stop, phase)는 primitive에 위임. ledger 적재 + identifier 결정도 primitive 책임.
+      // 첫 등장은 base identifier 유지(호환), 두 번째 이상은 occIdx ≥ 1로 :n suffix가 붙는다.
+      const scheduledAlarm = await scheduleStopPhase({
+        phase,
+        stop,
+        fireMs,
+        occurrenceIdx: occIdx,
       });
-
-      scheduled.push({ identifier, event, fireDate });
-      // #918 A3 measurement — ledger에 적재해 trip 종료 시 fire delta / miss rate / station 정확도 산출.
-      // 실패는 graceful (prescheduledMetrics 내부에서 try/catch — schedule 흐름 차단 안 함).
-      // 순차 await — 동시 RMW가 서로 덮어쓰는 race 차단. 30+ 역 trip 1회 약 ~100-300ms 추가지만
-      // 사전 예약은 trip 시작 시 1회만 발생하는 oneshot이라 허용.
-      await recordScheduledAlarm({ identifier, scheduledFireMs: fireMs });
+      scheduled.push(scheduledAlarm);
     }
   }
 
@@ -423,6 +448,127 @@ export async function topUpTripBoundWindow(
     `topUp passedIndex=${passedIndex} window=[${nextStartIndex},${nextEndIndex}) cancelled=${cancelled} scheduled=${scheduledAlarms.length}`,
   );
   return { cancelled, scheduled: scheduledAlarms.length };
+}
+
+export interface RescheduleTripBoundAlarmParams {
+  /** 정정 대상 stop의 canonical 역명 (silent push payload.nextStation과 동일 비교). */
+  stationName: string;
+  /** 새 도착 시각 (epoch ms). past-time이면 graceful no-op. */
+  newArrivalMs: number;
+  /**
+   * 현재 trip의 route. 직접/환승/다중환승 어떤 형태든 — `deriveTripBoundStops`로 평탄화한다.
+   * null이면 no-op (silent push 도달 시점에 client storage가 클리어된 race).
+   */
+  route: Route | null;
+  /**
+   * 현재 destination name. trip-bound stop 시퀀스의 마지막 waypoint.
+   * null이면 no-op (race로 destination이 이미 클리어된 경우).
+   */
+  destinationName: string | null;
+  /**
+   * 현 시각 (epoch ms). past-time 가드용. 미지정 시 Date.now().
+   * (테스트가 결정적 결과를 얻기 위해 주입.)
+   */
+  now?: number;
+}
+
+export interface RescheduleTripBoundAlarmResult {
+  cancelled: number;
+  scheduled: number;
+}
+
+/**
+ * #918 A3 PR4 — `tba:` 채널 단일 hop 정정.
+ *
+ * Backend가 보낸 reschedule silent push(`channels`에 'tba' 포함)를 받아 사전 예약된
+ * 해당 stop의 `tba:` 알람(both phases)을 cancel하고 newArrivalMs 기준으로 재예약한다.
+ *
+ * `boardingLockScheduler.rescheduleHopForLock`의 lock-free 사촌 — `trainCode` 매칭 대신
+ * stationName으로 routeStops에서 hop index를 찾는다.
+ *
+ *   - past-time 가드: newArrivalMs ≤ now이면 cancel + reschedule 모두 skip
+ *     (이미 지난 시각으로 OS에 들어가면 즉시 발사 — 잘못된 burst 차단).
+ *   - stationName이 routeStops에 없으면 graceful no-op (정정 신호 폐기).
+ *   - route/destinationName이 null이면 graceful no-op.
+ *
+ * **알려진 한계** (#918 A3 PR4 스코프):
+ *   - 같은 stationName이 route에 중복 등장(순환선/회차)하는 경우 본 함수는 *모든* occurrence를
+ *     cancel하되 base identifier(`occurrenceIdx=0`) 1개만 재생성한다. `:n` suffix 알람을
+ *     cancel하지 못해 stale fire 위험이 있으므로 PR4는 단순/환승 trip만 지원하고 중복역
+ *     trip은 후속 이슈에서 occurrence 인덱스 명시 정정 규약으로 다룬다.
+ *   - rolling window(`TRIPBOUND_WINDOW_SIZE`) 밖 stop에 대해서도 본 함수는 무조건 OS 큐에
+ *     예약을 push한다. 호출자(silentPushTask)는 backend payload에서 윈도우 안 stop에
+ *     해당하는 정정 신호만 본 함수로 전달해야 한다 (윈도우 invariant 유지 책임은 caller).
+ *
+ * OS API(`cancelScheduledNotificationAsync` / `getAllScheduledNotificationsAsync`)와
+ * `scheduleStopPhase`(내부 `scheduleNotificationAsync`)는 throw 가능 — 호출자(silentPushTask)가
+ * try/catch로 silent push handler crash를 차단한다 (alarmScheduler 정책과 일치).
+ */
+export async function rescheduleTripBoundAlarm(
+  params: RescheduleTripBoundAlarmParams,
+): Promise<RescheduleTripBoundAlarmResult> {
+  const { stationName, newArrivalMs, route, destinationName } = params;
+  const nowMs = params.now ?? Date.now();
+
+  if (newArrivalMs <= nowMs) {
+    logger.info(
+      `reschedule skip: past-time newArrivalMs=${newArrivalMs} now=${nowMs} station=${stationName}`,
+    );
+    return { cancelled: 0, scheduled: 0 };
+  }
+  if (!route || !destinationName) {
+    logger.info(
+      `reschedule skip: route=${route ? 'ok' : 'null'} destination=${destinationName ?? 'null'}`,
+    );
+    return { cancelled: 0, scheduled: 0 };
+  }
+
+  const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, destinationName);
+  const targetIndex = routeStops.findIndex((s) => isSameStationName(s.stationName, stationName));
+  if (targetIndex === -1) {
+    logger.info(`reschedule no-op: ${stationName} not found in routeStops`);
+    return { cancelled: 0, scheduled: 0 };
+  }
+
+  // 기존 `tba:` 알람 중 해당 stationName의 것만 cancel.
+  // canonical name으로 cancel 매칭 — routeStops[targetIndex].stationName과 OS 큐 id를 직접 비교.
+  const canonicalName = routeStops[targetIndex].stationName;
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let cancelled = 0;
+  for (const req of all) {
+    if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
+    const parsed = parseTripBoundAlarmIdentifier(req.identifier);
+    if (parsed === null) continue;
+    if (parsed.stationName === canonicalName) {
+      await Notifications.cancelScheduledNotificationAsync(req.identifier);
+      cancelled++;
+    }
+  }
+
+  // 재예약 — newArrivalMs를 두 phase의 절대 도착 시각으로 직접 사용.
+  // prescheduleStationAlerts 누적 모델(startTime + Σhop)을 거치지 않으므로 단일 stop을
+  // 위해 startTime을 역산할 필요가 없다 (역산 시 early phase의 fireMs == startTime이 되어
+  // 누적 모델의 `fireMs <= startTime` 가드에 정확히 걸려 silent drop되던 회귀 차단).
+  //
+  // 가드: nowMs 단일 — 정정 push 도착 시점 기준으로 과거 시각만 차단. trip 시작 trivial 가드
+  // (cumulative 모델의 startTime 가드)는 본 시나리오와 무관 — newArrivalMs는 stop의 새 도착
+  // 시각으로 backend가 보내 준 값이지 trip의 출발 시각이 아니다.
+  // hopMs는 deriveTripBoundStops가 HOP_TIME_MS fallback을 보장 — 본 함수에선 별도 가드 없이 사용.
+  const hopMs = estimatedHopTimesMs[targetIndex];
+  const stop = routeStops[targetIndex];
+  let scheduled = 0;
+  for (const phase of ALARM_PHASES) {
+    const leadMs = phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS;
+    const fireMs = newArrivalMs - leadMs;
+    if (fireMs <= nowMs) continue;
+    await scheduleStopPhase({ phase, stop, fireMs, occurrenceIdx: 0 });
+    scheduled++;
+  }
+
+  logger.info(
+    `reschedule done: station=${canonicalName} cancelled=${cancelled} scheduled=${scheduled} newArrivalMs=${newArrivalMs}`,
+  );
+  return { cancelled, scheduled };
 }
 
 /**

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -391,6 +391,8 @@ export default function HomeScreen() {
     lock: boardingLock,
     route,
     destinationName: destination?.name ?? null,
+    // #918 A3 PR3 — Fusion 현재역 통과 시 rolling window top-up trigger (64 cap 회피).
+    currentStationName: result?.station.name ?? null,
   });
   useBoardingLockAdvancer({
     lock: boardingLock,


### PR DESCRIPTION
## Summary

#918 A3 PR4 — backend의 reschedule silent push가 새 `channels: ['bl','tba']` 필드로 두 채널을 동시에 정정하도록 확장하고, 클라이언트가 `tba:` (trip-bound 사전 예약) 채널을 lock-free로 정정하는 경로를 추가한다. 동시에 `prescheduleStationAlerts` / `rescheduleTripBoundAlarm` 공통의 single (stop, phase) OS schedule 책임을 `scheduleStopPhase` primitive로 추출했다.

Stacked on #1187. **base를 PR3 머지 후 dev로 변경 필요.**

## 변경 요약

- **backend** (`backend/alarm-worker/`)
  - `types.ts` — `RescheduleChannel = 'bl' | 'tba'` + `RESCHEDULE_CHANNELS_DEFAULT = ['bl','tba']` 추가. `ReschedulePushPayload.channels?` optional 필드 (구 backend payload byte-호환 유지).
  - `apns.ts` — `SendReschedulePushOptions.channels?` 받아 payload에 conditional 포함.
  - `scheduled.ts` — `maybeReschedulePush`가 default로 `RESCHEDULE_CHANNELS_DEFAULT` 송신.
- **client** (`src/features/alarm/`)
  - `tasks/silentPushTask.ts` — `RescheduleSilentPushPayload.channels` 파싱(`validChannels`) + `resolveChannels` fallback(`['bl']`). bl/tba 채널을 독립 호출 (`applyRescheduleBl` + `rescheduleTripBoundAlarm`).
  - `utils/tripBoundScheduler.ts` —
    - `scheduleStopPhase` primitive 추출.
    - `rescheduleTripBoundAlarm(params)` 신규 — stationName으로 routeStops에서 hop index 매칭 후 해당 stop의 `tba:` 알람 cancel + newArrivalMs 기준 재예약.
  - `store/tripBoundCleanups.ts` — `cancelTripBoundAlarms`를 trip 종료 cleanup 시퀀스에 추가 (`tba:` 사전 예약이 다음 trip으로 leak되는 burst 차단).

## Root fix — early phase silent drop 회귀 차단

초기 구현은 `rescheduleTripBoundAlarm`을 위해 `startTime = newArrivalMs - hopMs`로 역산해 `prescheduleStationAlerts`에 단일 stop을 통과시켰다. 그 결과 early phase의 fireMs(= newArrivalMs - hopMs)가 startTime과 정확히 같아져 누적 모델의 `fireMs <= startTime` 가드에 silent drop됐다.

해결: 두 호출자(`prescheduleStationAlerts` 누적 startTime 모델 + `rescheduleTripBoundAlarm` 절대 arrivalMs 모델)가 공통으로 사용하는 OS schedule 책임을 `scheduleStopPhase` primitive로 추출. `rescheduleTripBoundAlarm`은 primitive를 직접 호출 → startTime 가드를 거치지 않는다. 회귀 가드 테스트: `early phase는 (newArrivalMs - hopMs)에 정확히 fire한다 (silent drop 회귀 차단)`.

기존 reschedule 테스트의 weak assertion(`toBeGreaterThan(0)`)도 `toBe(2)`로 강화 — early phase가 drop돼도 통과하던 약점 제거.

## 알려진 한계 (PR4 스코프)

- **중복역 trip occurrence**: 같은 stationName이 route에 중복 등장(순환선/회차)할 경우 *모든* occurrence를 cancel하되 base identifier(`occurrenceIdx=0`) 1개만 재생성한다. `:n` suffix 알람을 cancel하진 못해 stale fire 위험. PR4는 단순/환승 trip만 보장하고 중복역 trip은 후속 이슈에서 occurrence 인덱스 명시 정정 규약으로 다룬다.
- **Rolling window invariant은 caller 책임**: `rescheduleTripBoundAlarm`은 윈도우 밖 stop이어도 OS에 push한다. 호출자(silentPushTask)는 backend payload에서 윈도우(`TRIPBOUND_WINDOW_SIZE`) 안 stop에 해당하는 정정 신호만 전달해야 한다.

JSDoc에 동일 내용 명시.

## 후속 이슈 후보

- **(a)** 중복역 trip occurrence 정정 규약 — payload에 `occurrenceIdx`(또는 시퀀스 인덱스) 동반 + 호출자에서 명시 매칭.
- **(b)** `AlarmPhase.getLeadMs(hopMs)` 추상화 — `early` / `imminent` phase 분기를 `phase` 객체로 흡수하면 `rescheduleTripBoundAlarm` 안의 `phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS` 패턴이 제거된다. `prescheduleStationAlerts`에도 동일 분기 존재 → 공통 정리.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts` PASS (63 tests)
- [x] `npx jest src/features/alarm/tasks/__tests__/silentPushTask.test.ts` PASS
- [x] `npx jest src/features/alarm/store/__tests__/tripBoundCleanups.test.ts` PASS
- [x] `cd backend/alarm-worker && npx vitest run src/__tests__/apns.test.ts` PASS (20 tests)
- [x] CI Type Check & Test green
- [ ] 실기기 회귀: trip 시작 → reschedule silent push 도착 → 해당 stop의 early/imminent 둘 다 정상 fire
- [ ] 중복역 없는 환승 trip에서 정정 push가 의도한 stop만 정정함을 확인