### PR TITLE
chore(#1170): boardingPromptMonitor 게이트/응답 acceptance dashboard

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -101,6 +101,27 @@ const AMBIGUOUS_TRAINS: Partial<UpEntry>[] = [
 // line 불일치 단일 후보 — empty candidate set 케이스 공유 (행동 + telemetry).
 const LINE_MISMATCH_TRAIN: Partial<UpEntry>[] = [{ line: '9' }];
 
+// 공통 fixture — handleResponse describe 블록 2개(#819 행동, #1170 telemetry)가 공유.
+// 모듈 스코프로 끌어올려 중복 제거 (SonarCloud dup).
+const HANDLE_RESPONSE_PAYLOAD = {
+  kind: 'boarding-prompt' as const,
+  originStation: '강남',
+  line: '2',
+  tripToken: 'tok',
+};
+
+function makeHandleResponseDeps(
+  overrides: Partial<Parameters<typeof handleResponse>[2]> = {},
+) {
+  return {
+    fetchArrivalsForStation: jest.fn(async () => makeArrival()),
+    destinationId: 'dst',
+    expectedDurationMs: 600_000,
+    createLock: createLockMock,
+    ...overrides,
+  };
+}
+
 describe('extractBoardingPromptPayload', () => {
   it('valid payload → 보존', () => {
     expect(
@@ -138,22 +159,8 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     jest.clearAllMocks();
   });
 
-  const PAYLOAD = {
-    kind: 'boarding-prompt' as const,
-    originStation: '강남',
-    line: '2',
-    tripToken: 'tok',
-  };
-
-  function makeDeps(overrides: Partial<Parameters<typeof handleResponse>[2]> = {}) {
-    return {
-      fetchArrivalsForStation: jest.fn(async () => makeArrival()),
-      destinationId: 'dst',
-      expectedDurationMs: 600_000,
-      createLock: createLockMock,
-      ...overrides,
-    };
-  }
+  const PAYLOAD = HANDLE_RESPONSE_PAYLOAD;
+  const makeDeps = makeHandleResponseDeps;
 
   it('[탑승] 액션 + 후보 명확 + station 매칭 → createLock 호출 + initialEtaSeconds 스냅샷(#897)', async () => {
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
@@ -395,23 +402,6 @@ describe('handleResponse — #1170 응답 telemetry (logBoardingPromptResponded)
     jest.clearAllMocks();
   });
 
-  const PAYLOAD = {
-    kind: 'boarding-prompt' as const,
-    originStation: '강남',
-    line: '2',
-    tripToken: 'tok',
-  };
-
-  function makeDeps(overrides: Partial<Parameters<typeof handleResponse>[2]> = {}) {
-    return {
-      fetchArrivalsForStation: jest.fn(async () => makeArrival()),
-      destinationId: 'dst',
-      expectedDurationMs: 600_000,
-      createLock: createLockMock,
-      ...overrides,
-    };
-  }
-
   it.each<[string, string, 'boarded' | 'dismissed']>([
     ['[탑승] 액션', BOARDING_PROMPT_ACTION_BOARDED, 'boarded'],
     ['기본 탭 ($default)', Notifications.DEFAULT_ACTION_IDENTIFIER, 'boarded'],
@@ -419,7 +409,7 @@ describe('handleResponse — #1170 응답 telemetry (logBoardingPromptResponded)
     ['알 수 없는 액션', 'SOME_OTHER_ACTION', 'dismissed'],
   ])('%s → logBoardingPromptResponded({outcome: "%s"})', async (_label, action, outcome) => {
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
-    await handleResponse(action, PAYLOAD, makeDeps());
+    await handleResponse(action, HANDLE_RESPONSE_PAYLOAD, makeHandleResponseDeps());
     expect(logBoardingPromptResponded).toHaveBeenCalledWith({ outcome });
   });
 });

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -32,6 +32,7 @@ jest.mock('../../../../shared/utils/stationLookup', () => ({
 }));
 jest.mock('../../utils/alarmLog', () => ({
   logBoardingPromptAutoLock: jest.fn(),
+  logBoardingPromptResponded: jest.fn(),
 }));
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -60,7 +61,7 @@ jest.mock('../../store/useBoardingLockStore', () => {
 });
 
 const { findStationByNameAndLine } = jest.requireMock('../../../../shared/utils/stationLookup');
-const { logBoardingPromptAutoLock } = jest.requireMock('../../utils/alarmLog');
+const { logBoardingPromptAutoLock, logBoardingPromptResponded } = jest.requireMock('../../utils/alarmLog');
 const { __mockCreateLock: createLockMock } = jest.requireMock(
   '../../store/useBoardingLockStore',
 );
@@ -386,5 +387,39 @@ describe('useBoardingPromptResponder hook wiring', () => {
     // hook의 비동기 handleResponse 처리 후 검증
     await new Promise((r) => setTimeout(r, 0));
     expect(createLockMock).toHaveBeenCalled();
+  });
+});
+
+describe('handleResponse — #1170 응답 telemetry (logBoardingPromptResponded)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const PAYLOAD = {
+    kind: 'boarding-prompt' as const,
+    originStation: '강남',
+    line: '2',
+    tripToken: 'tok',
+  };
+
+  function makeDeps(overrides: Partial<Parameters<typeof handleResponse>[2]> = {}) {
+    return {
+      fetchArrivalsForStation: jest.fn(async () => makeArrival()),
+      destinationId: 'dst',
+      expectedDurationMs: 600_000,
+      createLock: createLockMock,
+      ...overrides,
+    };
+  }
+
+  it.each<[string, string, 'boarded' | 'dismissed']>([
+    ['[탑승] 액션', BOARDING_PROMPT_ACTION_BOARDED, 'boarded'],
+    ['기본 탭 ($default)', Notifications.DEFAULT_ACTION_IDENTIFIER, 'boarded'],
+    ['[미탑승] 액션', BOARDING_PROMPT_ACTION_NOT_BOARDED, 'dismissed'],
+    ['알 수 없는 액션', 'SOME_OTHER_ACTION', 'dismissed'],
+  ])('%s → logBoardingPromptResponded({outcome: "%s"})', async (_label, action, outcome) => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    await handleResponse(action, PAYLOAD, makeDeps());
+    expect(logBoardingPromptResponded).toHaveBeenCalledWith({ outcome });
   });
 });

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -28,13 +28,13 @@ import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival'
 import { dismissBoardingPrompt } from '../../nearest-station/api/positionUpload';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
+import { logBoardingPromptAutoLock, logBoardingPromptResponded } from '../utils/alarmLog';
 import {
   BOARDING_PROMPT_ACTION_BOARDED,
   BOARDING_PROMPT_ACTION_NOT_BOARDED,
 } from '../utils/notificationCategory';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { createLogger } from '../../../shared/utils/logger';
-import { logBoardingPromptAutoLock } from '../utils/alarmLog';
 
 const log = createLogger('boardingPromptResponder');
 
@@ -121,10 +121,15 @@ export async function handleResponse(
     actionIdentifier === BOARDING_PROMPT_ACTION_BOARDED ||
     actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER
   ) {
+    // #1170 — 응답률/탑승률 measurement. autolock 시도 성공/실패와 무관하게 "사용자가 boarded로
+    // 응답했다"는 사실 기록. boardedRate = boarded / (boarded+dismissed)는 게이트 정확도 proxy.
+    logBoardingPromptResponded({ outcome: 'boarded' });
     await tryAutoLock(payload, deps);
     return;
   }
   // [미탑승] 또는 dismiss — 5분 silence.
+  // #1170 — dismissed 측정. dismiss POST 결과(네트워크 성공/실패)와 무관하게 사용자 인지 기준 적재.
+  logBoardingPromptResponded({ outcome: 'dismissed' });
   await dismissBoardingPrompt(payload.tripToken);
 }
 

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -49,6 +49,7 @@ import {
   countSilentPushOutcomes,
   summarizeAlarmLogCounters,
   logBoardingPromptFired,
+  logBoardingPromptResponded,
   BOARDING_PROMPT_WINDOWS,
   countBoardingPromptByWindow,
   logBoardingPromptAutoLock,
@@ -1564,7 +1565,7 @@ describe('alarmLog', () => {
       expect(countBoardingPromptByWindow(entries)['5m']).toBe(1);
     });
 
-    it('reason 필드가 있는 boarding-prompt entry는 #1021 윈도우 집계에서 제외 (autolock과 분리)', () => {
+    it('reason 필드가 있는 boarding-prompt entry는 #1021 윈도우 집계에서 제외 (autolock/response와 분리)', () => {
       const now = Date.now();
       const entries: AlarmLogEntry[] = [
         // autolock-success는 outcome='fired'지만 reason 있음 → 발사 빈도엔 카운트 X.
@@ -1574,8 +1575,12 @@ describe('alarmLog', () => {
           outcome: 'fired',
           reason: 'autolock-success',
         },
+        // #1170 — response telemetry entry도 reason 있음 → 발사 빈도엔 제외.
+        { ts: now - 1500, source: 'boarding-prompt', outcome: 'fired', reason: 'dedup-station' },
+        // reason 없는 fired entry만 카운트.
+        { ts: now - 2000, source: 'boarding-prompt', outcome: 'fired' },
       ];
-      expect(countBoardingPromptByWindow(entries, now)['5m']).toBe(0);
+      expect(countBoardingPromptByWindow(entries, now)['5m']).toBe(1);
     });
   });
 
@@ -1639,6 +1644,24 @@ describe('alarmLog', () => {
       const counts = countBoardingPromptAutoLockOutcomes(entries);
       expect(counts['autolock-success']).toBe(0);
       expect(counts['autolock-no-trip']).toBe(0);
+    });
+  });
+
+  describe('logBoardingPromptResponded (#1170)', () => {
+    it.each<['boarded' | 'dismissed', 'response-boarded' | 'response-dismissed']>([
+      ['boarded', 'response-boarded'],
+      ['dismissed', 'response-dismissed'],
+    ])('%s outcome → reason=%s entry 적재', async (outcome, reason) => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logBoardingPromptResponded({ outcome });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0]).toMatchObject({
+        source: 'boarding-prompt',
+        outcome: 'received',
+        reason,
+      });
     });
   });
 

--- a/src/features/alarm/utils/__tests__/boardingPromptMonitor.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingPromptMonitor.test.ts
@@ -1,0 +1,175 @@
+/**
+ * #1170 — boardingPromptMonitor 단위 테스트.
+ */
+
+import {
+  computeBoardingPromptMonitor,
+  exportRecentDays,
+  toLocalDayKey,
+} from '../boardingPromptMonitor';
+import type { AlarmLogEntry, AlarmLogReason, AlarmLogSource } from '../alarmLog';
+
+// ── factory ──
+// 모든 case가 entry 1개씩만 다른 필드로 만들어 컴파일러가 typo를 잡도록 한다.
+function entry(overrides: Partial<AlarmLogEntry> & Pick<AlarmLogEntry, 'ts'>): AlarmLogEntry {
+  return {
+    source: 'boarding-prompt' as AlarmLogSource,
+    outcome: 'fired',
+    ...overrides,
+  };
+}
+
+function displayed(ts: number, extra: Partial<AlarmLogEntry> = {}): AlarmLogEntry {
+  return entry({ ts, outcome: 'fired', ...extra });
+}
+
+function response(
+  ts: number,
+  reason: Extract<AlarmLogReason, 'response-boarded' | 'response-dismissed'>,
+  extra: Partial<AlarmLogEntry> = {},
+): AlarmLogEntry {
+  return entry({ ts, outcome: 'received', reason, ...extra });
+}
+
+const T0 = new Date('2026-06-12T10:00:00+09:00').getTime();
+
+describe('computeBoardingPromptMonitor — totals', () => {
+  it('빈 입력 → 0 카운트 + null rate', () => {
+    const stats = computeBoardingPromptMonitor([]);
+    expect(stats).toEqual({
+      displayed: 0,
+      responded: 0,
+      boarded: 0,
+      dismissed: 0,
+      responseRatePct: null,
+      boardedRatePct: null,
+      byDay: {},
+    });
+  });
+
+  it.each<[string, AlarmLogEntry, Partial<ReturnType<typeof computeBoardingPromptMonitor>>]>([
+    [
+      'displayed 1건만',
+      displayed(T0),
+      { displayed: 1, responded: 0, responseRatePct: 0 },
+    ],
+    [
+      'boarded 응답 1건',
+      response(T0, 'response-boarded'),
+      { responded: 1, boarded: 1, dismissed: 0 },
+    ],
+    [
+      'dismissed 응답 1건',
+      response(T0, 'response-dismissed'),
+      { responded: 1, boarded: 0, dismissed: 1 },
+    ],
+  ])('단일 entry 분류 — %s', (_label, e, expected) => {
+    const stats = computeBoardingPromptMonitor([e]);
+    expect(stats).toMatchObject(expected);
+  });
+
+  it('다른 source / 다른 reason은 무시', () => {
+    const entries: AlarmLogEntry[] = [
+      // 다른 source
+      { ts: T0, source: 'fg', outcome: 'fired' },
+      // boarding-prompt fired인데 reason이 있음 → autolock telemetry (#1167 채널) — 제외
+      { ts: T0, source: 'boarding-prompt', outcome: 'fired', reason: 'dedup-station' },
+      // received인데 reason이 다른 측정 채널
+      { ts: T0, source: 'boarding-prompt', outcome: 'received' },
+      // received + reason이 response-* 외 (다른 telemetry 채널) — 제외
+      { ts: T0, source: 'boarding-prompt', outcome: 'received', reason: 'dedup-station' },
+      // 진짜 displayed
+      displayed(T0),
+    ];
+    const stats = computeBoardingPromptMonitor(entries);
+    expect(stats.displayed).toBe(1);
+    expect(stats.responded).toBe(0);
+  });
+
+  it('count 필드 (burst inline counter)를 곱해 누적', () => {
+    const stats = computeBoardingPromptMonitor([
+      displayed(T0, { count: 3 }),
+      response(T0, 'response-boarded', { count: 2 }),
+    ]);
+    expect(stats.displayed).toBe(3);
+    expect(stats.responded).toBe(2);
+    expect(stats.boarded).toBe(2);
+  });
+
+  it('responseRate / boardedRate 계산 (소수점 1자리 반올림)', () => {
+    // displayed=3, responded=2(boarded=1, dismissed=1)
+    // responseRate = 66.7%, boardedRate = 50%
+    const stats = computeBoardingPromptMonitor([
+      displayed(T0),
+      displayed(T0 + 1),
+      displayed(T0 + 2),
+      response(T0 + 3, 'response-boarded'),
+      response(T0 + 4, 'response-dismissed'),
+    ]);
+    expect(stats.responseRatePct).toBeCloseTo(66.7, 1);
+    expect(stats.boardedRatePct).toBe(50);
+  });
+
+  it('displayed=0인데 응답이 있으면 responseRate=null (분모 0)', () => {
+    const stats = computeBoardingPromptMonitor([
+      response(T0, 'response-boarded'),
+    ]);
+    expect(stats.responseRatePct).toBeNull();
+    expect(stats.boardedRatePct).toBe(100);
+  });
+});
+
+describe('computeBoardingPromptMonitor — byDay', () => {
+  it('같은 로컬 날짜의 entry는 한 bucket에 누적', () => {
+    const stats = computeBoardingPromptMonitor([
+      displayed(T0),
+      displayed(T0 + 60_000),
+      response(T0 + 120_000, 'response-boarded'),
+    ]);
+    const key = toLocalDayKey(T0);
+    expect(stats.byDay[key]).toEqual({
+      displayed: 2,
+      responded: 1,
+      boarded: 1,
+      dismissed: 0,
+    });
+  });
+
+  it('다른 날짜는 별도 bucket', () => {
+    const t1 = T0;
+    const t2 = T0 + 26 * 60 * 60 * 1000; // 다음 날
+    const stats = computeBoardingPromptMonitor([displayed(t1), displayed(t2)]);
+    expect(Object.keys(stats.byDay).sort()).toEqual(
+      [toLocalDayKey(t1), toLocalDayKey(t2)].sort(),
+    );
+  });
+});
+
+describe('toLocalDayKey', () => {
+  it('YYYY-MM-DD 형식 (sv-SE locale)', () => {
+    expect(toLocalDayKey(T0)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('exportRecentDays', () => {
+  it('요청 일수만큼 row 반환, 데이터 없는 날은 0 채움', () => {
+    const stats = computeBoardingPromptMonitor([displayed(T0)]);
+    const rows = exportRecentDays(stats, 3, T0);
+    expect(rows).toHaveLength(3);
+    // 마지막(=오늘)에 displayed=1, 나머지는 0
+    expect(rows[rows.length - 1]).toMatchObject({ displayed: 1 });
+    expect(rows[0]).toMatchObject({ displayed: 0, responded: 0 });
+  });
+
+  it('과거 → 현재 순서', () => {
+    const rows = exportRecentDays(computeBoardingPromptMonitor([]), 5, T0);
+    const keys = rows.map((r) => r.dayKey);
+    const sorted = [...keys].sort();
+    expect(keys).toEqual(sorted);
+  });
+
+  it('default now 사용 (now 인자 미지정 호환)', () => {
+    const rows = exportRecentDays(computeBoardingPromptMonitor([]), 1);
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/src/features/alarm/utils/__tests__/boardingPromptMonitor.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingPromptMonitor.test.ts
@@ -139,8 +139,8 @@ describe('computeBoardingPromptMonitor — byDay', () => {
     const t1 = T0;
     const t2 = T0 + 26 * 60 * 60 * 1000; // 다음 날
     const stats = computeBoardingPromptMonitor([displayed(t1), displayed(t2)]);
-    expect(Object.keys(stats.byDay).sort()).toEqual(
-      [toLocalDayKey(t1), toLocalDayKey(t2)].sort(),
+    expect(Object.keys(stats.byDay).sort((a, b) => a.localeCompare(b))).toEqual(
+      [toLocalDayKey(t1), toLocalDayKey(t2)].sort((a, b) => a.localeCompare(b)),
     );
   });
 });
@@ -164,7 +164,7 @@ describe('exportRecentDays', () => {
   it('과거 → 현재 순서', () => {
     const rows = exportRecentDays(computeBoardingPromptMonitor([]), 5, T0);
     const keys = rows.map((r) => r.dayKey);
-    const sorted = [...keys].sort();
+    const sorted = [...keys].sort((a, b) => a.localeCompare(b));
     expect(keys).toEqual(sorted);
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -125,7 +125,12 @@ export type AlarmLogReason =
   | 'autolock-arrivals-empty'
   | 'autolock-ambiguity'
   | 'autolock-station-lookup'
-  | 'autolock-lock-failed';
+  | 'autolock-lock-failed'
+  // #1170 — boarding-prompt 사용자 응답 측정. 9단 게이트 통과 후 발사된 prompt에 대한 응답.
+  //   'response-boarded': [탑승] 또는 default 탭 액션.
+  //   'response-dismissed': [미탑승] 또는 dismiss.
+  | 'response-boarded'
+  | 'response-dismissed';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -847,9 +852,12 @@ export function countBoardingPromptByWindow(
 ): Record<BoardingPromptWindowKey, number> {
   const counts: Record<BoardingPromptWindowKey, number> = { '5m': 0, '1h': 0, all: 0 };
   for (const entry of entries) {
+    // #1170 — fired 중에서도 reason이 없는 entry만 "발사 빈도"로 계산. response/autolock telemetry
+    // entry는 별도 채널이므로 제외(중복 집계 방지).
     if (entry.source !== 'boarding-prompt' || entry.outcome !== 'fired') continue;
     // #1167 — autolock outcome도 source='boarding-prompt'를 재사용하지만 outcome='suppressed'
     // 또는 reason='autolock-success'로 구분. 발사 빈도(#1021) 집계에는 reason 미설정 entry만 포함.
+    // #1170 — response telemetry entry도 reason 필드를 채워 같은 규칙으로 제외된다.
     if (entry.reason !== undefined) continue;
     const ageMs = now - entry.ts;
     for (const { key, ms } of BOARDING_PROMPT_WINDOWS) {
@@ -907,6 +915,19 @@ export function countBoardingPromptAutoLockOutcomes(
   }
   return counts;
 }
+
+/** #1170: boardingPrompt 사용자 응답 1건 적재. */
+export function logBoardingPromptResponded(input: {
+  outcome: 'boarded' | 'dismissed';
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'boarding-prompt',
+    outcome: 'received',
+    reason: input.outcome === 'boarded' ? 'response-boarded' : 'response-dismissed',
+  });
+}
+
 
 
 // ── CRUD ──

--- a/src/features/alarm/utils/boardingPromptMonitor.ts
+++ b/src/features/alarm/utils/boardingPromptMonitor.ts
@@ -1,0 +1,166 @@
+/**
+ * #1170 — boarding-prompt 게이트/응답 acceptance dashboard 측정.
+ *
+ * Epic #1008 B3 acceptance 측정 인프라. backend 9단 게이트(#819)를 통과해 발사된
+ * boarding-prompt push에 대해 사용자가 어떻게 응답하는지 정량 추적.
+ *
+ * 측정 채널 (모두 source='boarding-prompt' alarmLog entry):
+ *
+ *   - displayed: `logBoardingPromptFired` (#1021) — gate 통과 후 prompt 표시.
+ *     `outcome='fired'`이고 `reason` 미설정인 entry.
+ *
+ *   - responded:
+ *       boarded   = `logBoardingPromptResponded({outcome:'boarded'})` — [탑승]/$default tap.
+ *       dismissed = `logBoardingPromptResponded({outcome:'dismissed'})` — [미탑승]/dismiss.
+ *     `outcome='received'`이고 `reason='response-boarded'|'response-dismissed'`인 entry.
+ *
+ * 측정 한계:
+ *   - "gate 진입" (backend가 9단 게이트 평가에 진입한 횟수)은 client에서 직접 관찰 불가.
+ *     backend `/admin/quota`/cron stats가 진입 카운터를 가지고 있다 (`scheduled.ts` stats).
+ *     본 모듈은 client 관찰 가능 metric에 집중 — "표시 vs 응답" 응답률이 acceptance 핵심 지표.
+ *
+ *   - response가 backend 미도달(네트워크 실패)인 경우에도 client 적재는 발생 — 사용자 인지
+ *     기준 응답률을 측정. backend 도달률은 별도 channel.
+ *
+ * 일별 집계 (`byDay`):
+ *   - 1주 baseline 측정을 위해 로컬 날짜(YYYY-MM-DD) key로 displayed/responded 누적.
+ *   - 타임존: client 로컬. acceptance dashboard는 사용자 체감 기준이라 UTC 대신 로컬이 적절.
+ */
+
+import type { AlarmLogEntry, AlarmLogReason } from './alarmLog';
+
+export interface BoardingPromptDayCounts {
+  displayed: number;
+  responded: number;
+  boarded: number;
+  dismissed: number;
+}
+
+export interface BoardingPromptMonitorStats {
+  /** 전체 prompt 표시 횟수 (gate 통과 후 발사). */
+  displayed: number;
+  /** 응답 (boarded + dismissed) 총합. */
+  responded: number;
+  boarded: number;
+  dismissed: number;
+  /**
+   * 응답률 = responded / displayed (%, 소수점 1자리). displayed=0이면 null.
+   * dashboard에서 "—"로 표기.
+   */
+  responseRatePct: number | null;
+  /**
+   * 탑승률 = boarded / responded (%, 소수점 1자리). responded=0이면 null.
+   * 9단 게이트 정확도 proxy — 게이트가 정확하면 boarded 비율이 높다.
+   */
+  boardedRatePct: number | null;
+  /** 로컬 날짜(YYYY-MM-DD) → 카운트. 1주 baseline export 용. */
+  byDay: Record<string, BoardingPromptDayCounts>;
+}
+
+const RESPONSE_REASONS: ReadonlySet<AlarmLogReason> = new Set<AlarmLogReason>([
+  'response-boarded',
+  'response-dismissed',
+]);
+
+/**
+ * 엔트리를 displayed / boarded / dismissed 중 어디로 분류할지 결정.
+ * 분류 안 되면 null (다른 채널 entry — autolock telemetry 등).
+ */
+function classify(
+  entry: AlarmLogEntry,
+): 'displayed' | 'boarded' | 'dismissed' | null {
+  if (entry.source !== 'boarding-prompt') return null;
+  if (entry.outcome === 'fired' && entry.reason === undefined) return 'displayed';
+  if (entry.outcome === 'received' && entry.reason !== undefined) {
+    if (entry.reason === 'response-boarded') return 'boarded';
+    if (entry.reason === 'response-dismissed') return 'dismissed';
+  }
+  return null;
+}
+
+/**
+ * 로컬 타임존 기준 YYYY-MM-DD 변환. ISO UTC string(slice(0,10)) 사용 시 타임존 경계에서
+ * "전날 23:30 fire가 다음날로 집계"되는 사고가 생기므로 toLocaleDateString sv-SE (ISO format)
+ * 채택 — 모든 region에서 YYYY-MM-DD 형태.
+ */
+export function toLocalDayKey(ts: number): string {
+  return new Date(ts).toLocaleDateString('sv-SE');
+}
+
+function emptyDay(): BoardingPromptDayCounts {
+  return { displayed: 0, responded: 0, boarded: 0, dismissed: 0 };
+}
+
+function pct(numerator: number, denominator: number): number | null {
+  if (denominator === 0) return null;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+export function computeBoardingPromptMonitor(
+  entries: readonly AlarmLogEntry[],
+): BoardingPromptMonitorStats {
+  const stats: BoardingPromptMonitorStats = {
+    displayed: 0,
+    responded: 0,
+    boarded: 0,
+    dismissed: 0,
+    responseRatePct: null,
+    boardedRatePct: null,
+    byDay: {},
+  };
+
+  for (const entry of entries) {
+    const bucket = classify(entry);
+    if (bucket === null) continue;
+
+    const dayKey = toLocalDayKey(entry.ts);
+    const day = stats.byDay[dayKey] ?? emptyDay();
+    const count = entry.count ?? 1;
+
+    if (bucket === 'displayed') {
+      stats.displayed += count;
+      day.displayed += count;
+    } else {
+      stats.responded += count;
+      day.responded += count;
+      if (bucket === 'boarded') {
+        stats.boarded += count;
+        day.boarded += count;
+      } else {
+        stats.dismissed += count;
+        day.dismissed += count;
+      }
+    }
+    stats.byDay[dayKey] = day;
+  }
+
+  stats.responseRatePct = pct(stats.responded, stats.displayed);
+  stats.boardedRatePct = pct(stats.boarded, stats.responded);
+  return stats;
+}
+
+/**
+ * 일별 집계를 최근 N일 (오늘 포함) 시계열로 정렬해 반환. dashboard / export 진입점.
+ * 누락된 날짜는 0 채움. 정렬: 과거 → 현재.
+ */
+export interface BoardingPromptDayRow extends BoardingPromptDayCounts {
+  dayKey: string;
+}
+
+export function exportRecentDays(
+  stats: BoardingPromptMonitorStats,
+  days: number,
+  now: number = Date.now(),
+): BoardingPromptDayRow[] {
+  const rows: BoardingPromptDayRow[] = [];
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  // 로컬 자정 정렬을 위해 dayKey 기반으로 역산. 단순 ts-=DAY_MS는 DST 경계 1시간 어긋날 수 있지만
+  // 본 dashboard는 정확한 자정 정렬보다 "최근 N일" 추세 표시가 목적이라 허용.
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const ts = now - i * DAY_MS;
+    const dayKey = toLocalDayKey(ts);
+    const counts = stats.byDay[dayKey] ?? emptyDay();
+    rows.push({ dayKey, ...counts });
+  }
+  return rows;
+}

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -35,6 +35,10 @@ import {
   type AlarmLogReason,
   type AlarmLogReasonCounter,
 } from '../../../features/alarm/utils/alarmLog';
+import {
+  computeBoardingPromptMonitor,
+  exportRecentDays,
+} from '../../../features/alarm/utils/boardingPromptMonitor';
 import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingLockStore';
 import { isBoardingLockExpired } from '../../../shared/types/boardingLock';
 import {
@@ -771,6 +775,9 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
             ))}
           </Section>
 
+          {/* #1170: boarding-prompt acceptance dashboard (gate 통과율/응답률) */}
+          <BoardingPromptMonitorSection logs={logs} colors={colors} />
+
           {/* #1024 — ## Counters: reason별 누적 count + 마지막 발생 시각 */}
           <CountersSection logs={logs} colors={colors} />
 
@@ -1045,6 +1052,62 @@ function CountersSection({
           />
         ))
       )}
+    </Section>
+  );
+}
+
+/**
+ * #1170 — boarding-prompt acceptance dashboard.
+ *
+ * 표시: displayed / responded / 응답률 / 탑승률 + 최근 7일 일별 표 (export 진입점).
+ * 응답률·탑승률 0건 시 "—" 표기.
+ */
+const RECENT_DAYS = 7;
+
+function formatRatePct(value: number | null): string {
+  return value === null ? '—' : `${value.toFixed(1)}%`;
+}
+
+function BoardingPromptMonitorSection({
+  logs,
+  colors,
+}: Readonly<{
+  logs: readonly AlarmLogEntry[];
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  const stats = computeBoardingPromptMonitor(logs);
+  const rows = exportRecentDays(stats, RECENT_DAYS);
+  return (
+    <Section title="Boarding Prompt Acceptance" colors={colors}>
+      <KeyValue label="displayed" value={String(stats.displayed)} colors={colors} />
+      <KeyValue label="responded" value={String(stats.responded)} colors={colors} />
+      <KeyValue label="boarded" value={String(stats.boarded)} colors={colors} />
+      <KeyValue label="dismissed" value={String(stats.dismissed)} colors={colors} />
+      <KeyValue
+        label="responseRate"
+        value={formatRatePct(stats.responseRatePct)}
+        colors={colors}
+      />
+      <KeyValue
+        label="boardedRate"
+        value={formatRatePct(stats.boardedRatePct)}
+        colors={colors}
+      />
+      <Text
+        style={[typography.mono, { color: colors.muted, marginTop: spacing.xs }]}
+        testID="debug-boarding-prompt-recent-header"
+      >
+        {`recent ${RECENT_DAYS}d (day / disp / resp / brd / dis)`}
+      </Text>
+      {rows.map((row) => (
+        <Text
+          key={row.dayKey}
+          style={[typography.mono, { color: colors.ink }]}
+          testID={`debug-boarding-prompt-day-${row.dayKey}`}
+        >
+          {`${row.dayKey}  ${row.displayed}/${row.responded}/${row.boarded}/${row.dismissed}`}
+        </Text>
+      ))}
     </Section>
   );
 }

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -510,6 +510,30 @@ describe('DebugModal', () => {
     expect(screen.getByText('Boarding Prompt')).toBeTruthy();
   });
 
+  it('#1170: Boarding Prompt Acceptance 섹션이 displayed/responded/rate 라벨을 표시한다', async () => {
+    const now = Date.now();
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 60_000, source: 'boarding-prompt', outcome: 'fired' },
+      { ts: now - 30_000, source: 'boarding-prompt', outcome: 'received', reason: 'response-boarded' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Boarding Prompt Acceptance')).toBeTruthy();
+    expect(screen.getByText('displayed')).toBeTruthy();
+    expect(screen.getByText('responded')).toBeTruthy();
+    expect(screen.getByText('responseRate')).toBeTruthy();
+    expect(screen.getByText('boardedRate')).toBeTruthy();
+    // 7일 timeline 진입점 header
+    expect(screen.getByTestId('debug-boarding-prompt-recent-header')).toBeTruthy();
+  });
+
+  it('#1170: 데이터 없으면 rate가 "—" 로 표기된다', async () => {
+    mockGetAlarmLog.mockResolvedValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
     it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());


### PR DESCRIPTION
Closes #1170
Related: #1008 (Epic C 단기 — B3 acceptance 측정)

## Summary
- `boardingPromptMonitor.ts` 신규: `computeBoardingPromptMonitor` + `exportRecentDays` — displayed/responded/boarded/dismissed 카운트 + responseRate(%)/boardedRate(%) + 일별 집계(`byDay`).
- `alarmLog`:
  - `logBoardingPromptResponded({ outcome })` 추가 — `response-boarded` / `response-dismissed` reason으로 source='boarding-prompt', outcome='received' entry 1건 적재.
  - `countBoardingPromptByWindow`(#1021) 필터를 `reason === undefined`로 좁혀 발사 빈도 채널과 response 채널 분리(이중 집계 방지).
- `useBoardingPromptResponder`: 4분기([탑승]/`$default`/[미탑승]/dismiss) 모두에서 `logBoardingPromptResponded` 호출. autoLock 성공/실패와 무관한 사용자 인지 기준 측정.
- `DebugModal`: "Boarding Prompt Acceptance" 섹션 — displayed/responded/boarded/dismissed + responseRate/boardedRate(0건 시 "—") + 최근 7일 일별 표(daily aggregate export 진입점, `testID='debug-boarding-prompt-recent-header'`).

## Design notes
- "gate 진입" (backend 9단 게이트 평가 진입)은 client 직접 관찰 불가 — backend `scheduled.ts` stats가 보유. client 측 acceptance 지표는 "displayed → responded" 응답률에 집중.
- `boardedRate = boarded / responded` — 9단 게이트 정확도 proxy. 게이트가 정확하면 boarded 비율이 높다.
- 일별 key는 로컬 타임존 기준 `YYYY-MM-DD` (`toLocaleDateString('sv-SE')`) — UTC slice 사용 시 자정 경계에서 전날 fire가 다음날로 집계되는 사고 회피.
- `count` 필드(burst inline counter)도 누적에 반영.

## Test plan
- [x] `npx jest src/features/alarm/utils/__tests__/boardingPromptMonitor.test.ts` — 14 passed, 100% line/branch/func
- [x] `npx jest src/features/alarm/utils/__tests__/alarmLog.test.ts` — 111 passed, 100% coverage 유지
- [x] `npx jest src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts` — 27 passed
- [x] `npx jest src/features/debug/components/__tests__/DebugModal.test.tsx` — 115 passed
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] 실기기: boarding-prompt 수신 → [탑승] 탭 → DebugModal Boarding Prompt Acceptance에서 displayed=1, responded=1, boarded=1, responseRate=100% 확인
- [ ] 실기기 1주 baseline: 일별 표에 7일치 누적 확인

## Conflict notice (PR #1188 동시 작업)
같은 디렉토리(`alarmLog.ts`, `useBoardingPromptResponder.ts`)에서 PR #1188(#1167 boarding-prompt-tap-autolock)이 OPEN. 양쪽 모두 `countBoardingPromptByWindow` 필터에 동일한 `reason !== undefined` 제외를 추가하지만, PR #1188은 `autolock-*` reason(outcome='fired')을, 본 PR은 `response-*` reason(outcome='received')을 추가 — 의미적 충돌 없음. 머지 순서에 따라 trivial rebase 가능성 있음.