### PR TITLE
feat(#1177): BoardingTrainList 4가지 state(loading/empty/pending/error) 명시 구분

### DIFF
--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -49,6 +49,15 @@ const PENDING_TIMEOUT_MS_DEFAULT = 5000;
 /** pending row 시각 피드백 — accent 색 테두리 두께. row의 borderLeft stripe와 별도 외곽 outline. */
 const PENDING_BORDER_WIDTH = 2;
 
+/**
+ * Loading skeleton row 개수 — #1177. 첫 폴링 응답 도착 전 시각적 placeholder.
+ *
+ * 도착 list는 일반적으로 1~3건이 도착하므로 3행이면 실제 데이터와 시각적 부피 차이가 적어
+ * 응답 도착 시 layout shift가 최소화된다. key를 명시 상수 배열로 분리해 map 순회로 렌더 →
+ * 글로벌 룰 3(데이터 주도, 인덱스 하드코딩 금지) 준수.
+ */
+const SKELETON_ROW_KEYS = ['s1', 's2', 's3'] as const;
+
 interface Props {
   arrivals: ArrivalInfo[];
   line: LineNumber;
@@ -92,6 +101,26 @@ interface Props {
    * 테스트/조정용 노출.
    */
   pendingTimeoutMs?: number;
+  /**
+   * 도착 정보 로딩 중 여부 — #1177 (Epic #1008 C 단기 / B4 UX).
+   *
+   * true이면 arrivals 내용에 상관없이 loading skeleton(placeholder rows) 노출.
+   * 첫 폴링 응답 도착 전 또는 명시적 refresh 동안 사용. 기본 false → 기존 동작 유지.
+   *
+   * 우선순위: error > loading > empty > data. loading과 error가 동시에 true이면 error 우선
+   * (실패한 재시도 중에는 사용자가 무엇이 잘못됐는지 먼저 인지하도록).
+   */
+  loading?: boolean;
+  /**
+   * 도착 정보 로딩 실패 메시지 — #1177.
+   *
+   * null/undefined면 error state 아님. 객체이면 error UI 렌더(메시지 + 자동 재시도 안내).
+   * `message`가 비어 있어도 default 카피(home.boardingTrainListError)로 fallback.
+   *
+   * 호출자는 fetch 실패/timeout/parse 실패 등을 받아 전달한다. 본 컴포넌트는 retry 로직을
+   * 보유하지 않으며 호출자(useArrivalInfo polling)가 다음 tick에 자동 재시도하는 흐름을 전제.
+   */
+  error?: { message?: string | null } | null;
   /**
    * backend round-trip이 사용자가 탭한 train과 다른 trainCode로 lock을 확정했을 때 발화 — #1166.
    *
@@ -142,6 +171,8 @@ export function BoardingTrainList({
   initialEtaSeconds,
   lockedTrainCode = null,
   pendingTimeoutMs = PENDING_TIMEOUT_MS_DEFAULT,
+  loading = false,
+  error = null,
   onLockCorrected,
 }: Props) {
   const { colors } = useTheme();
@@ -207,13 +238,67 @@ export function BoardingTrainList({
   // arrivals는 호출자가 도착시간 오름차순으로 전달한다는 컨벤션을 따른다(#749 카운터와 동일 가정).
   const delayMinutes = computeDelayMinutes(filteredArrivals, initialEtaSeconds);
 
+  // #1177: 4가지 state 구분 — error > loading > empty > data. 낙관적 UI 도입(#1165) 후
+  // 빈 list/loading의 의미를 사용자에게 명확히 전달한다.
+  if (error != null) {
+    const message =
+      error.message != null && error.message.length > 0 ? error.message : t('home.boardingTrainListError');
+    return (
+      <View
+        style={compact ? styles.emptyCompact : styles.empty}
+        testID="boarding-train-list-error"
+        accessibilityRole="alert"
+        accessibilityLabel={t('a11y.alarm.boardingTrainListErrorLabel')}
+      >
+        <Text style={[typography.bodySm, { color: colors.danger, fontWeight: '600' }]}>{message}</Text>
+        <Text style={[typography.bodySm, { color: colors.muted }]}>{t('home.boardingTrainListErrorHint')}</Text>
+      </View>
+    );
+  }
+
+  if (loading) {
+    return (
+      <View
+        style={compact ? styles.containerCompact : styles.container}
+        testID="boarding-train-list-loading"
+        accessibilityLabel={t('a11y.alarm.boardingTrainListLoadingLabel')}
+        accessibilityState={{ busy: true }}
+      >
+        {!compact && (
+          <View style={styles.header}>
+            <LineBadge line={line} />
+            <Text style={[typography.label, { color: colors.muted }]}>{headerTitle}</Text>
+          </View>
+        )}
+        {SKELETON_ROW_KEYS.map((key) => (
+          <View
+            key={key}
+            style={[
+              compact ? styles.rowCompact : styles.row,
+              compact ? null : { backgroundColor: colors.card },
+              { borderLeftWidth: LINE_STRIPE_WIDTH, borderLeftColor: LINE_COLORS[line] },
+              styles.skeletonRow,
+              { backgroundColor: colors.card },
+            ]}
+            testID={`boarding-train-list-skeleton-${key}`}
+          >
+            <View style={[styles.skeletonBar, { backgroundColor: colors.muted, opacity: 0.2, width: '60%' }]} />
+            <View style={[styles.skeletonBar, { backgroundColor: colors.muted, opacity: 0.15, width: '40%' }]} />
+          </View>
+        ))}
+      </View>
+    );
+  }
+
   if (filteredArrivals.length === 0) {
     return (
       <View
         style={compact ? styles.emptyCompact : styles.empty}
         testID="boarding-train-list-empty"
+        accessibilityLabel={t('a11y.alarm.boardingTrainListEmptyLabel')}
       >
         <Text style={[typography.bodySm, { color: colors.muted }]}>{t('home.boardingTrainListEmpty')}</Text>
+        <Text style={[typography.bodySm, { color: colors.subtle }]}>{t('home.boardingTrainListEmptyHint')}</Text>
       </View>
     );
   }
@@ -235,6 +320,20 @@ export function BoardingTrainList({
           testID="boarding-train-delay-chip"
         >
           <Text style={[styles.delayChipText, { color: colors.danger }]}>{`+${delayMinutes}분 지연`}</Text>
+        </View>
+      )}
+      {/* #1177 — pending lock state list-level 안내. row outline highlight와 별도로 list 헤더 영역에
+          상태 텍스트를 노출해 사용자에게 "탭이 처리 중" 임을 명시. row outline만으로는 작은 시각적
+          시그널이라 접근성과 명료성을 위해 텍스트 라인 추가. */}
+      {pendingTrainCode != null && (
+        <View
+          style={styles.pendingNotice}
+          testID="boarding-train-list-pending-notice"
+          accessibilityLabel={t('a11y.alarm.boardingTrainListPendingLabel')}
+        >
+          <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}>
+            {t('home.boardingTrainListPending')}
+          </Text>
         </View>
       )}
       {filteredArrivals.map((train, index) => {
@@ -415,10 +514,26 @@ const styles = StyleSheet.create({
   empty: {
     padding: spacing.lg,
     alignItems: 'center',
+    gap: spacing.xs,
   },
   emptyCompact: {
     paddingVertical: spacing.xs,
     paddingHorizontal: spacing.sm,
+    gap: spacing.xs,
+  },
+  // #1177 — loading skeleton row 내부 bar. 색은 인라인으로 muted/opacity 적용.
+  skeletonRow: {
+    gap: spacing.xs,
+    borderRadius: radius.md,
+  },
+  skeletonBar: {
+    height: 10,
+    borderRadius: 4,
+  },
+  // #1177 — pending list-level notice. row outline 외에 list 영역 상단에 텍스트 한 줄 노출.
+  pendingNotice: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.xs,
   },
   // #897 — outline 칩. ArrivalStatusBadge의 outline variant와 동일 외형(borderWidth 1 + radius 3).
   delayChip: {

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -845,4 +845,152 @@ describe('BoardingTrainList', () => {
       expect(style.borderLeftColor).toBe(LINE_COLORS['7']);
     });
   });
+
+  // #1177 — 4가지 state 명시 구분 (loading / empty / pending / error).
+  // 우선순위: error > loading > empty > data + (pending overlay).
+  describe('#1177 4가지 state 구분', () => {
+    function renderState(props: {
+      arrivals?: ArrivalInfo[];
+      loading?: boolean;
+      error?: { message?: string | null } | null;
+    }) {
+      return renderWithTheme(
+        <BoardingTrainList
+          arrivals={props.arrivals ?? []}
+          line="2"
+          onSelect={() => {}}
+          loading={props.loading}
+          error={props.error}
+        />,
+      );
+    }
+
+    type StateCase = {
+      name: string;
+      input: { arrivals?: ArrivalInfo[]; loading?: boolean; error?: { message?: string | null } | null };
+      visibleTestId: string;
+      hiddenTestIds: string[];
+    };
+
+    const cases: StateCase[] = [
+      {
+        name: 'loading=true → skeleton 노출, empty/error/data row 미노출',
+        input: { loading: true },
+        visibleTestId: 'boarding-train-list-loading',
+        hiddenTestIds: ['boarding-train-list-empty', 'boarding-train-list-error', 'boarding-train-list'],
+      },
+      {
+        name: 'empty(default) → empty placeholder 노출',
+        input: {},
+        visibleTestId: 'boarding-train-list-empty',
+        hiddenTestIds: ['boarding-train-list-loading', 'boarding-train-list-error', 'boarding-train-list'],
+      },
+      {
+        name: 'error 객체 → error UI 노출, loading/empty 무시',
+        input: { loading: true, error: { message: 'network down' } },
+        visibleTestId: 'boarding-train-list-error',
+        hiddenTestIds: ['boarding-train-list-loading', 'boarding-train-list-empty', 'boarding-train-list'],
+      },
+    ];
+
+    it.each(cases)('$name', ({ input, visibleTestId, hiddenTestIds }) => {
+      const { getByTestId, queryByTestId } = renderState(input);
+      expect(getByTestId(visibleTestId)).toBeTruthy();
+      hiddenTestIds.forEach((id) => {
+        expect(queryByTestId(id)).toBeNull();
+      });
+    });
+
+    it('loading → 3개 skeleton row 렌더 (글로벌 룰 3: 인덱스 하드코딩 금지)', () => {
+      const { getByTestId } = renderState({ loading: true });
+      ['s1', 's2', 's3'].forEach((key) => {
+        expect(getByTestId(`boarding-train-list-skeleton-${key}`)).toBeTruthy();
+      });
+    });
+
+    it('loading → compact 모드에서도 skeleton 노출(헤더 생략)', () => {
+      const { getByTestId, queryByText } = renderWithTheme(
+        <BoardingTrainList arrivals={[]} line="2" onSelect={() => {}} loading compact />,
+      );
+      expect(getByTestId('boarding-train-list-loading')).toBeTruthy();
+      // compact는 헤더 라벨 미노출.
+      expect(queryByText('탑승할 열차 선택')).toBeNull();
+    });
+
+    it('error.message 명시 → 그대로 노출', () => {
+      const { getByText } = renderState({ error: { message: '서버가 응답하지 않습니다' } });
+      expect(getByText('서버가 응답하지 않습니다')).toBeTruthy();
+      // 자동 재시도 안내(hint)도 함께 노출.
+      expect(getByText('잠시 후 자동으로 다시 시도합니다.')).toBeTruthy();
+    });
+
+    it('error.message null/빈 문자열 → default 카피로 fallback', () => {
+      const { getByText, rerender } = renderState({ error: { message: null } });
+      expect(getByText('도착 정보를 불러올 수 없어요')).toBeTruthy();
+      rerender(
+        <BoardingTrainList
+          arrivals={[]}
+          line="2"
+          onSelect={() => {}}
+          error={{ message: '' }}
+        />,
+      );
+      expect(getByText('도착 정보를 불러올 수 없어요')).toBeTruthy();
+    });
+
+    it('error 객체이나 message 자체 미전달 → default 카피로 fallback', () => {
+      const { getByText } = renderState({ error: {} });
+      expect(getByText('도착 정보를 불러올 수 없어요')).toBeTruthy();
+    });
+
+    it('empty → 안내 카피 + 자동 재시도 hint 노출 + a11y label 적용', () => {
+      const { getByTestId, getByText } = renderState({});
+      const empty = getByTestId('boarding-train-list-empty');
+      expect(empty.props.accessibilityLabel).toBe('도착 예정 열차 없음');
+      expect(getByText('도착 예정 열차가 없습니다.')).toBeTruthy();
+      expect(getByText('잠시 후 자동으로 다시 확인합니다.')).toBeTruthy();
+    });
+
+    it('data 있을 때 user 탭 → pending banner 노출 + a11y label', () => {
+      const train = makeTrain({ trainCode: 'T-PEND-BANNER' });
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      // 탭 전: banner 미노출.
+      expect(queryByTestId('boarding-train-list-pending-notice')).toBeNull();
+      act(() => {
+        fireEvent.press(getByTestId('boarding-train-row-T-PEND-BANNER'));
+      });
+      const notice = getByTestId('boarding-train-list-pending-notice');
+      expect(notice).toBeTruthy();
+      expect(notice.props.accessibilityLabel).toBe('탑승 등록을 처리하는 중');
+    });
+
+    it('loading state는 accessibilityState.busy=true', () => {
+      const { getByTestId } = renderState({ loading: true });
+      const container = getByTestId('boarding-train-list-loading');
+      expect(container.props.accessibilityState?.busy).toBe(true);
+      expect(container.props.accessibilityLabel).toBe('도착 정보를 불러오는 중');
+    });
+
+    it('error state — compact 모드에서도 노출(스타일 분기)', () => {
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[]}
+          line="2"
+          onSelect={() => {}}
+          error={{ message: 'x' }}
+          compact
+        />,
+      );
+      expect(getByTestId('boarding-train-list-error')).toBeTruthy();
+    });
+
+    it('error state는 accessibilityRole=alert', () => {
+      const { getByTestId } = renderState({ error: { message: 'x' } });
+      const container = getByTestId('boarding-train-list-error');
+      expect(container.props.accessibilityRole).toBe('alert');
+      expect(container.props.accessibilityLabel).toBe('도착 정보를 불러올 수 없음');
+    });
+  });
 });

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -51,7 +51,12 @@
     "refresh": "Refresh",
     "boardingProximityHint": "Move closer to the boarding station to pick a train",
     "boardingTrainListTitle": "Pick your train",
+    "boardingTrainListLoading": "Loading arrivals...",
     "boardingTrainListEmpty": "No upcoming trains.",
+    "boardingTrainListEmptyHint": "We'll retry automatically.",
+    "boardingTrainListPending": "Registering boarding...",
+    "boardingTrainListError": "Couldn't load arrivals",
+    "boardingTrainListErrorHint": "We'll retry automatically in a moment.",
     "misBoardingToast": "Can't find your train. Please reselect.",
     "autoDisembarkToast": {
       "message": "Arrived at {{name}} — destination cleared",
@@ -300,6 +305,10 @@
       "dismissHint": "Stops the alarm sound and vibration",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "Tap to board this train",
+      "boardingTrainListLoadingLabel": "Loading arrivals",
+      "boardingTrainListEmptyLabel": "No upcoming trains",
+      "boardingTrainListPendingLabel": "Registering boarding",
+      "boardingTrainListErrorLabel": "Couldn't load arrivals",
       "boardingLockReleaseLabel": "Get off",
       "boardingLockReleaseHint": "Ends the current boarding session"
     },

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -51,7 +51,12 @@
     "refresh": "更新",
     "boardingProximityHint": "乗車駅の近くで列車を選択できます",
     "boardingTrainListTitle": "乗車する列車を選択",
+    "boardingTrainListLoading": "到着情報を読み込み中...",
     "boardingTrainListEmpty": "到着予定の列車がありません。",
+    "boardingTrainListEmptyHint": "しばらくしてから自動で再確認します。",
+    "boardingTrainListPending": "乗車を登録中...",
+    "boardingTrainListError": "到着情報を読み込めませんでした",
+    "boardingTrainListErrorHint": "しばらくしてから自動で再試行します。",
     "misBoardingToast": "乗車中の列車が見つかりません。もう一度選択してください。",
     "autoDisembarkToast": {
       "message": "{{name}}に到着し、目的地を解除しました",
@@ -300,6 +305,10 @@
       "dismissHint": "アラーム音と振動を停止します",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "タップしてこの列車に乗車",
+      "boardingTrainListLoadingLabel": "到着情報を読み込み中",
+      "boardingTrainListEmptyLabel": "到着予定の列車なし",
+      "boardingTrainListPendingLabel": "乗車を登録中",
+      "boardingTrainListErrorLabel": "到着情報を読み込めません",
       "boardingLockReleaseLabel": "降車",
       "boardingLockReleaseHint": "現在の乗車を終了します"
     },

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -51,7 +51,12 @@
     "refresh": "새로고침",
     "boardingProximityHint": "탑승역 근처에서 열차를 선택할 수 있어요",
     "boardingTrainListTitle": "탑승할 열차 선택",
+    "boardingTrainListLoading": "도착 정보를 불러오는 중...",
     "boardingTrainListEmpty": "도착 예정 열차가 없습니다.",
+    "boardingTrainListEmptyHint": "잠시 후 자동으로 다시 확인합니다.",
+    "boardingTrainListPending": "탑승 등록 중...",
+    "boardingTrainListError": "도착 정보를 불러올 수 없어요",
+    "boardingTrainListErrorHint": "잠시 후 자동으로 다시 시도합니다.",
     "misBoardingToast": "탑승 열차를 찾을 수 없어요. 다시 선택해주세요.",
     "autoDisembarkToast": {
       "message": "{{name}}에 도착해 목적지를 해제했어요",
@@ -300,6 +305,10 @@
       "dismissHint": "알람음과 진동을 중지합니다",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "탭하여 이 열차로 탑승 등록",
+      "boardingTrainListLoadingLabel": "도착 정보를 불러오는 중",
+      "boardingTrainListEmptyLabel": "도착 예정 열차 없음",
+      "boardingTrainListPendingLabel": "탑승 등록을 처리하는 중",
+      "boardingTrainListErrorLabel": "도착 정보를 불러올 수 없음",
       "boardingLockReleaseLabel": "하차",
       "boardingLockReleaseHint": "현재 탑승 상태를 종료합니다"
     },

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -51,7 +51,12 @@
     "refresh": "刷新",
     "boardingProximityHint": "靠近乘车站后可以选择列车",
     "boardingTrainListTitle": "选择乘坐列车",
+    "boardingTrainListLoading": "正在加载到达信息...",
     "boardingTrainListEmpty": "暂无即将到达的列车。",
+    "boardingTrainListEmptyHint": "稍后将自动重新确认。",
+    "boardingTrainListPending": "正在登记乘车...",
+    "boardingTrainListError": "无法加载到达信息",
+    "boardingTrainListErrorHint": "稍后将自动重试。",
     "misBoardingToast": "找不到乘坐的列车,请重新选择。",
     "autoDisembarkToast": {
       "message": "已到达{{name}},已清除目的地",
@@ -300,6 +305,10 @@
       "dismissHint": "停止闹钟声和振动",
       "boardingTrainSelectLabel": "{{meta}}, {{sequence}}, {{arrival}}",
       "boardingTrainSelectHint": "点击乘坐该列车",
+      "boardingTrainListLoadingLabel": "正在加载到达信息",
+      "boardingTrainListEmptyLabel": "无即将到达的列车",
+      "boardingTrainListPendingLabel": "正在登记乘车",
+      "boardingTrainListErrorLabel": "无法加载到达信息",
       "boardingLockReleaseLabel": "下车",
       "boardingLockReleaseHint": "结束当前乘车状态"
     },


### PR DESCRIPTION
Closes #1177

## Summary
- Epic #1008 C 단기 / B4 UX. 낙관적 UI(#1165) 도입 후 모호해진 list state(loading vs empty vs pending vs error)를 사용자에게 명확히 구분.
- `loading`/`error` prop 추가 — 기존 callers는 그대로 동작(둘 다 optional, default off).
- 우선순위: `error > loading > empty > data` + (pending banner overlay).

## 변경 요약
- **loading**: 3행 skeleton placeholder. 헤더 유지, compact 시 헤더 생략. `accessibilityState.busy=true`.
- **empty**: 기존 카피 + "잠시 후 자동으로 다시 확인합니다." hint. `accessibilityLabel` 명시.
- **pending**: 기존 row outline highlight 외에 list 상단 텍스트 banner("탑승 등록 중...") 추가. `accessibilityLabel` 명시.
- **error**: 메시지(빈 값이면 default 카피) + 자동 재시도 hint. `accessibilityRole=alert`.
- 4 locales(ko/en/ja/zh)에 7개 i18n 키 + 4개 a11y label 추가.

## Acceptance 매핑
- ✅ 4가지 state 구분 UI (loading / empty / pending / error)
- ✅ a11y label (각 state별 `accessibilityLabel`, error는 role=alert, loading은 busy)
- ✅ 100% 커버리지 (75 tests, BoardingTrainList.tsx 100%/100%/100%/100%)

## Test plan
- [x] `npx jest src/features/alarm/components/__tests__/BoardingTrainList.test.tsx` — 75/75 PASS
- [x] `npm run type-check` PASS
- [x] BoardingTrainList.tsx coverage 100% lines/branches/funcs/stmts
- [x] CI `Type Check & Test` 통과 확인
- [x] (수동) HomeScreen에서 BoardingTrainList caller가 새 prop을 전달하도록 후속 wiring (별도 이슈)