### PR TITLE
refactor(#1194): AlarmPhase.getLeadMs(hopMs) 추상화로 lead 계산 중복 제거

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmPhases.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmPhases.test.ts
@@ -1,4 +1,4 @@
-import { ALARM_PHASES, type AlarmContext } from '../alarmPhases';
+import { ALARM_PHASES, IMMINENT_LEAD_MS, type AlarmContext } from '../alarmPhases';
 
 function ctx(partial: Partial<AlarmContext>): AlarmContext {
   return {
@@ -46,6 +46,24 @@ describe('ALARM_PHASES', () => {
 
     it('does not fire when eta is null', () => {
       expect(imminentPhase.evaluate(ctx({ remainingStops: 1, etaSeconds: null }))).toBe(false);
+    });
+  });
+
+  describe('getLeadMs (#1194)', () => {
+    it('early returns hopMs as-is (variable lead)', () => {
+      expect(earlyPhase.getLeadMs(15_000)).toBe(15_000);
+      expect(earlyPhase.getLeadMs(60_000)).toBe(60_000);
+      expect(earlyPhase.getLeadMs(0)).toBe(0);
+    });
+
+    it('imminent returns fixed IMMINENT_LEAD_MS regardless of hopMs', () => {
+      expect(imminentPhase.getLeadMs(15_000)).toBe(IMMINENT_LEAD_MS);
+      expect(imminentPhase.getLeadMs(60_000)).toBe(IMMINENT_LEAD_MS);
+      expect(imminentPhase.getLeadMs(0)).toBe(IMMINENT_LEAD_MS);
+    });
+
+    it('IMMINENT_LEAD_MS is 10 seconds', () => {
+      expect(IMMINENT_LEAD_MS).toBe(10_000);
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/stationAlarm.test.ts
+++ b/src/features/alarm/utils/__tests__/stationAlarm.test.ts
@@ -402,6 +402,7 @@ describe('evaluateAlarmPhase', () => {
         {
           id: 'early' as const,
           evaluate: (ctx: { remainingStops: number }) => ctx.remainingStops <= 3,
+          getLeadMs: (hopMs: number) => hopMs,
         },
       ];
       expect(

--- a/src/features/alarm/utils/alarmPhases.ts
+++ b/src/features/alarm/utils/alarmPhases.ts
@@ -12,15 +12,25 @@ export interface AlarmContext {
 export interface AlarmPhase {
   readonly id: AlarmPhaseId;
   readonly evaluate: (ctx: AlarmContext) => boolean;
+  /**
+   * 도착 시각으로부터 알람 발화까지의 lead(ms).
+   * - early: 입력 `hopMs`(직전 hop 소요 시간)를 그대로 사용.
+   * - imminent: 도착 10초 전 고정.
+   */
+  readonly getLeadMs: (hopMs: number) => number;
 }
 
 const APPROACH_STOPS = 1;
 const IMMINENT_ETA_SECONDS = 10;
 
+/** imminent phase 고정 lead(ms) — 도착 10초 전. early는 입력 `hopMs`를 그대로 사용. */
+export const IMMINENT_LEAD_MS = 10_000;
+
 export const ALARM_PHASES: AlarmPhase[] = [
   {
     id: 'early',
     evaluate: (ctx) => ctx.remainingStops <= APPROACH_STOPS,
+    getLeadMs: (hopMs) => hopMs,
   },
   {
     id: 'imminent',
@@ -28,5 +38,6 @@ export const ALARM_PHASES: AlarmPhase[] = [
       ctx.remainingStops <= APPROACH_STOPS &&
       ctx.etaSeconds !== null &&
       ctx.etaSeconds <= IMMINENT_ETA_SECONDS,
+    getLeadMs: () => IMMINENT_LEAD_MS,
   },
 ];

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -31,8 +31,7 @@ const PHASE_INTERRUPTION: Record<AlarmPhaseId, 'active' | 'timeSensitive'> = {
 /** Android channel id — stationNotification / alarmScheduler / boardingLockScheduler와 동일. */
 const ALARM_CHANNEL_ID = 'station-alarm';
 
-/** imminent phase 고정 lead(ms) — 도착 10초 전. early는 입력 `estimatedHopTimesMs[i]`를 그대로 사용. */
-const IMMINENT_LEAD_MS = 10_000;
+// imminent lead 정책은 `alarmPhases.ts`의 `phase.getLeadMs(hopMs)`에 인코딩됨 (#1194).
 
 /**
  * #918 A3 PR3 — rolling window 64 cap 회피용 윈도우 크기 (stop 단위).
@@ -204,7 +203,7 @@ export async function prescheduleStationAlerts(
     const stop = routeStops[i];
 
     for (const phase of ALARM_PHASES) {
-      const leadMs = phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS;
+      const leadMs = phase.getLeadMs(hopMs);
       const fireMs = cumulativeMs - leadMs;
       // startTime 기준 + 실제 wall-clock 기준 두 조건 모두 통과해야 등록.
       if (fireMs <= startTime || fireMs <= nowMs) continue;
@@ -558,7 +557,7 @@ export async function rescheduleTripBoundAlarm(
   const stop = routeStops[targetIndex];
   let scheduled = 0;
   for (const phase of ALARM_PHASES) {
-    const leadMs = phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS;
+    const leadMs = phase.getLeadMs(hopMs);
     const fireMs = newArrivalMs - leadMs;
     if (fireMs <= nowMs) continue;
     await scheduleStopPhase({ phase, stop, fireMs, occurrenceIdx: 0 });


### PR DESCRIPTION
Closes #1194

## Summary
- `AlarmPhase` 인터페이스에 `getLeadMs(hopMs: number): number` 추가
  - `early`: `(hopMs) => hopMs` — 직전 hop 소요 시간(가변)
  - `imminent`: `() => IMMINENT_LEAD_MS` — 도착 10초 전 고정
- `IMMINENT_LEAD_MS` 상수를 `alarmPhases.ts`로 이동/export (의미 응집)
- `tripBoundScheduler.ts`의 두 호출자(`prescheduleStationAlerts`, `rescheduleTripBoundAlarm`)에서 반복되던 `phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS` 분기를 `phase.getLeadMs(hopMs)`로 통일

## Why
"early는 hop 시간(가변), imminent는 고정 10s"라는 phase 본질이 두 호출자에 복제되어 있었음. lead 정책이 phase 정의에 인코딩되도록 책임 이동 → 새 phase 추가/lead 정책 변경 시 한 곳만 수정.

## Test plan
- [x] `alarmPhases.test.ts` — `getLeadMs` 동작 검증 (early=hopMs, imminent=10_000) 케이스 추가
- [x] `tripBoundScheduler.test.ts` 기존 73개 케이스 PASS (순수 리팩토링)
- [x] `stationAlarm.test.ts` custom phase fixture에 `getLeadMs` 보강 (인터페이스 호환)
- [x] `npx tsc --noEmit` 통과
- [x] alarm utils 전체 41 suite PASS (사전 안내된 거짓 FAIL 1건 — `stationNotification` 환경 의존 — 무시)

## Out of scope
- `boardingLockScheduler.ts`의 `IMMINENT_LEAD_MS`(=45_000)는 다른 값/다른 lock 경로라 별개 상수로 유지