### PR TITLE
test(#1200): Maestro Seam C(hydration) 회귀 시나리오 추가

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -164,6 +164,7 @@ jobs:
       matrix:
         scenario:
           - seam-b-13-19
+          - seam-c-hydration
           - seam-e-13-39
           - seam-f-13-24
           - seam-a-delay-chip
@@ -172,8 +173,9 @@ jobs:
           - seam-la-refresh-heartbeat
           - a1-auto-lock
           - a3-preschedule-fire-delta
-          # Seam C는 transfer-leg / FG-return 이벤트 mock 설계 결함으로 보류
-          # ([[project-2026-06-05-epic-912-session-end]]).
+          # Seam C는 #922에서 transfer-leg/FG-return 이벤트 mock 설계 결함으로 보류했다가
+          # H5(#1012, hydration state machine) 머지 후 #1200에서 client-observable 경로
+          # (destination 해제 + BG/FG cycle 재수화)만 가드하는 형태로 추가됨.
     env:
       SIM_NAME: 'iPhone 16'
       EXPO_PUBLIC_USE_BFF: 'true'

--- a/.maestro/flows/regression/README.md
+++ b/.maestro/flows/regression/README.md
@@ -35,6 +35,7 @@ maestro test .maestro/flows/regression/seam-b-13-19.yaml
 | 파일 | Seam | 회귀 시점 | 검증 내용 |
 | --- | --- | --- | --- |
 | `seam-b-13-19.yaml` | B | 13:19 transfer/early/건대입구 fired @ 성수 | 성수 정지 + 건대입구 5분 후 ETA → false-positive 발사 없음 |
+| `seam-c-hydration.yaml` | C | #899 hydration seam (#922 deferred / #1200) | 강남→역삼 trip 형성 후 destination 해제 + BG/FG cycle 재수화 → stale chip/ghost 알람 0건 |
 | `seam-e-13-39.yaml` | E | 13:39~45 lockMissing | `/boarding-lock/sync` 응답이 advanced=true여도 ghost 알람 발사 0건, chip 안정 |
 | `seam-f-13-24.yaml` | F | 13:24~28 trainCode 7174 사라짐 | 25s 시점 trainCode drop 후에도 lockMissing/ghost 알람 발사 0건 |
 | `seam-a-delay-chip.yaml` | A | #897 lock 지연 칩 | 어린이대공원에서 7180 lock 후 phase 30s 전환 → `boarding-lock-hop-delay-chip` `+4분 지연` 노출 |
@@ -44,10 +45,12 @@ maestro test .maestro/flows/regression/seam-b-13-19.yaml
 | `a1-auto-lock.yaml` | A1 | #916 backend 자동 lock | 강남 → 역삼 destination만 설정 → `autoLockCandidate` 응답으로 row 탭 없이 `boarding-lock-hop-card` 노출 |
 | `a3-preschedule-fire-delta.yaml` | A3 | #918 사전 예약 burst | 어린이대공원 자동 lock 후 30초 안에 `alarm-overlay` 미노출 — fire 시각 가드(`fireMs <= nowMs`) 회귀 방지 |
 
-보류:
-- Seam C — 13:23 waypoint advanced + 14:02 stale chip. transfer-leg / FG-return /
-  명시적 event mock 설계가 fixture-driven 구조에 맞지 않아 별도 인프라 PR 후로 미룸
-  ([[project-2026-06-05-epic-912-session-end]]).
+보류 → 해제:
+- Seam C — 원래 #922에서 transfer-leg / FG-return / silent push 이벤트 mock 설계 결함으로
+  보류됐다. H5(#1012, hydration state machine) 머지 후 #1200에서 **client-observable 경로**
+  (사용자 destination 해제 + stopApp/launchApp BG/FG cycle 재수화)만 가드하는 형태로
+  추가됨. server-side trip-ended silent push / 환승 waypoint 통과 검증은 fixture 구조상
+  여전히 단위 테스트 영역(#899 acceptance)에 위임한다.
 
 ## fixture 작성 가이드
 

--- a/.maestro/flows/regression/seam-c-hydration.yaml
+++ b/.maestro/flows/regression/seam-c-hydration.yaml
@@ -1,0 +1,180 @@
+appId: com.subwaynow.app
+name: "regression - Seam C (#922 deferred / #1200) — 상태 hydration seam"
+# Epic #896 Seam C(#899) — 상태 hydration seam 회귀 가드.
+# #922에서 transfer-leg/FG-return 이벤트 mock 설계 결함으로 보류했던 시나리오를
+# H5(#1012, hydration state machine) 머지 후 #1200에서 다시 추가한다.
+#
+# Maestro fixture는 silent push(trip-ended) / 환승 waypoint 통과 같은 server-side
+# 이벤트를 직접 발사할 수 없으므로, 본 시나리오는 #899 acceptance 중 client-observable
+# 경로만 회귀 가드한다:
+#   1) 사용자 destination 해제 경로 — destination-clear-button 탭 → chip/banner 즉시 정리
+#   2) FG 복귀 재수화 — stopApp + relaunch(clearState=false) → 재수화 후 정합성 유지
+#      + ghost 알람 발사 0건 (hydration race 회귀 시 alarm flag/lock 잔류 → ghost 표면화)
+#   3) 재수화 후 cleanup — 재수화 상태에서 destination 해제 → stale UI 없음
+#
+# 전제: scripts/maestro-mock-backend.js가 SCENARIO=seam-c-hydration PORT=8788로 떠 있고
+# 앱은 EXPO_PUBLIC_BFF_URL/EXPO_PUBLIC_ALARM_BACKEND_URL로 mock을 가리키도록 빌드되어야 한다.
+---
+# 강남역 2호선 좌표 — stations.json id "2-022"
+- setLocation:
+    latitude: 37.49799
+    longitude: 127.027912
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 현재역 강남 확인 (한/영 둘 다 매칭)
+- assertVisible:
+    text: "강남|Gangnam"
+
+# === Phase 1: trip 형성 ===
+# 목적지: 역삼 (2호선 단순 trip — Seam C 검증은 trip 형성 후 종료 cleanup이 핵심)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "역삼"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-2-021"
+- waitForAnimationToEnd
+
+# 트립 형성 후 짧게 안정화 대기 — arrival 폴링 1 cycle (~30s) 확보.
+- repeat:
+    times: 30
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# === Phase 2: 사용자 destination 해제 경로 ===
+# #899 acceptance: 사용자 destination 해제 시 storage + zustand + UI 모두 즉시 정리.
+# destination chip이 노출되어 있어야 destination-clear-button이 존재한다.
+- assertVisible:
+    id: "destination-clear-button"
+- tapOn:
+    id: "destination-clear-button"
+- waitForAnimationToEnd
+
+# 해제 직후 stale UI 부재 — destination-button(미설정 상태 entry)이 다시 노출되고
+# 알람 overlay/banner 잔류 없음.
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 10000
+- assertNotVisible:
+    id: "destination-clear-button"
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# === Phase 3: 새 trip 형성 + FG 복귀 재수화 ===
+# 다시 trip을 형성한 뒤 stopApp + relaunch(clearState=false)로 BG/FG cycle을 모사한다.
+# H5(#1012) hydration state machine + Seam C(#899) useStateRehydration 회귀 시 재수화 race로
+# ghost 알람이 발사되거나 destination chip 정합성이 깨진다.
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(800)
+- setClipboard: "역삼"
+- evalScript: maestro.wait(400)
+- pasteText
+- evalScript: maestro.wait(1500)
+- assertVisible:
+    id: "suggestions-list"
+- tapOn:
+    id: "suggestion-item-2-021"
+- waitForAnimationToEnd
+
+# 트립 정착 대기 (~15s).
+- repeat:
+    times: 15
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# BG 전이 모사 — stopApp + relaunch(clearState=false)로 권한/스토리지 보존.
+- stopApp:
+    appId: com.subwaynow.app
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: false
+
+# 권한 다이얼로그 자동 닫기 (시뮬레이터 환경에 따라 노출되지 않을 수 있음)
+- tapOn:
+    text: "허용|Allow|Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# 홈 화면 노출 확인
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 15000
+
+# 재수화 정합성:
+#   - 현재역 강남 정상 노출 (위치 재취득)
+#   - destination clear 가능 entry(=clear-button) 노출 (trip 복원됨)
+- assertVisible:
+    text: "강남|Gangnam"
+- extendedWaitUntil:
+    visible:
+      id: "destination-clear-button"
+    timeout: 15000
+
+# 재수화 직후 알람 race 검증 — 60초 동안 ghost 알람 UI가 표면화되지 않아야 한다.
+# Seam C 또는 H5 회귀 시 hydration 도중 fired ref/lock 상태 불일치로 잘못된 시점에
+# '곧 도착' / '하차 알림' overlay가 떠오른다.
+- repeat:
+    times: 60
+    commands:
+      - evalScript: maestro.wait(1000)
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"
+
+# === Phase 4: 재수화 후 cleanup ===
+# 재수화된 상태에서 다시 destination 해제 → 모든 UI/chip이 정상 정리되는지 검증.
+# (cleanup 레지스트리가 BG/FG cycle 전후로 동일하게 동작해야 한다 — #899 unification 의 본질)
+- tapOn:
+    id: "destination-clear-button"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 10000
+- assertNotVisible:
+    id: "destination-clear-button"
+- assertNotVisible:
+    text: "곧 도착|Arriving soon"
+- assertNotVisible:
+    text: "하차 알림|Get off"
+- assertNotVisible:
+    text: "알람 끄기|Stop alarm"

--- a/scripts/fixtures/regression/seam-c-hydration.json
+++ b/scripts/fixtures/regression/seam-c-hydration.json
@@ -1,0 +1,69 @@
+{
+  "name": "Seam C — 상태 hydration seam 회귀 (#899 / #922 deferred / #1200)",
+  "seam": "C",
+  "_doc": [
+    "Epic #896 Seam C(#899) — 상태 hydration seam 회귀 가드. #922에서 transfer-leg/FG-return",
+    "이벤트 mock 설계 결함으로 보류했던 시나리오를 H5(#1012, hydration state machine) 머지 후",
+    "다시 추가한다(#1200).",
+    "",
+    "Maestro fixture는 silent push(trip-ended) / 환승 waypoint 통과 같은 server-side 이벤트를",
+    "직접 발사할 수 없으므로, 본 시나리오는 #899 acceptance 중 **client-observable** 경로만",
+    "회귀 가드한다:",
+    "  1) 사용자 destination 해제 경로 — destination-clear-button 탭 → chip/banner 즉시 정리",
+    "  2) FG 복귀 재수화 — stopApp + relaunch(clearState=false) → 재수화 후 destination/UI",
+    "     정합성 유지 + ghost 알람 발사 0건",
+    "  3) 재수화 후 cleanup — 재수화된 상태에서 다시 destination 해제 → stale UI 없음",
+    "",
+    "fixture는 강남(2-220) 단순 trip(역삼 2-221)을 안정 ETA(5분)로 응답해 알람 발사 조건을",
+    "충족하지 않는다(Seam B/E/F와 동일한 안정 trip 패턴). hydration race 회귀 시 ghost 알람",
+    "이 표면화 + stale destination chip이 BG/FG cycle 이후 잔존한다."
+  ],
+  "arrivals": {
+    "강남": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "역삼",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "2231",
+              "line": "2",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ],
+    "역삼": [
+      {
+        "fromMs": 0,
+        "body": {
+          "up": [
+            {
+              "destination": "역삼",
+              "arrivalMinutes": 5,
+              "arrivalSeconds": 300,
+              "statusMessage": "5분 후 도착",
+              "trainCode": "2231",
+              "line": "2",
+              "receivedAtMs": 0,
+              "arrivalCode": 99,
+              "isLastTrain": false,
+              "trainType": "normal"
+            }
+          ],
+          "down": [],
+          "source": "realtime"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #1200

## Summary
- `#922`에서 transfer-leg / FG-return event mock 설계 결함으로 보류됐던 Seam C(hydration) Maestro 시나리오를, H5(`#1012`) 머지 후 client-observable 경로만 가드하는 형태로 추가.
- 강남(2-022) → 역삼(2-021) 단순 trip을 fixture로 띄우고, 3단계로 검증:
  1. **사용자 destination 해제** — `destination-clear-button` 탭 직후 chip/banner/알람 overlay 즉시 정리.
  2. **FG 복귀 재수화** — trip 재형성 → `stopApp` + `launchApp(clearState:false)` BG/FG cycle → 재수화 후 destination/현재역 정합성 유지 + 60초간 ghost 알람 발사 0건.
  3. **재수화 후 cleanup** — 재수화 상태에서 다시 destination 해제 → stale UI 없음 (cleanup 레지스트리가 BG/FG 전후 동일하게 동작).
- silent push(trip-ended) / 환승 waypoint 통과는 fixture 구조상 시뮬레이션 불가 → `#899` acceptance의 해당 항목은 단위 테스트 영역으로 유지.

## 추가 파일
- `.maestro/flows/regression/seam-c-hydration.yaml`
- `scripts/fixtures/regression/seam-c-hydration.json`
- `.github/workflows/e2e.yml` — regression matrix에 `seam-c-hydration` 추가 + 보류 코멘트 갱신.
- `.maestro/flows/regression/README.md` — 시나리오 인덱스 + 보류→해제 이력 갱신.

## CI 게이트
- PR 게이트(`ci.yml` smoke) 아님. nightly `e2e.yml` regression job의 matrix에 편입 → nightly cron 또는 workflow_dispatch에서 실행.
- PR 자체는 `.maestro/flows/regression/`만 변경 → ci.yml `changes` job이 e2e-smoke를 트리거하지 않음(경로 스킵 기준). `Type Check & Test`만 통과 확인하면 머지 가능.

## Test plan
- [x] 로컬 mock backend 기동 검증: `SCENARIO=seam-c-hydration PORT=8799 node scripts/maestro-mock-backend.js` → `/healthz` 200, `/api/arrival/강남` 응답 정상.
- [x] YAML / JSON 문법 검증 (`js-yaml` parse, `require()` JSON parse).
- [ ] nightly 1회차 통과 확인 (workflow_dispatch로 즉시 트리거 가능).
- [ ] 실기기 H5 머지 후 회귀 발생 시 본 시나리오가 빨간불을 띄우는지 dry-run.