### PR TITLE
feat(#1193): tba reschedule이 중복역 trip의 :n occurrence를 정확히 정정

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -311,6 +311,31 @@ describe('sendReschedulePush (#585)', () => {
     const body = JSON.parse(call[1].body as string);
     expect('channels' in body.data).toBe(false);
   });
+
+  // #1193 — 중복역 trip의 occurrenceIdx wire 검증.
+  it.each([
+    ['양의 정수면 payload에 그대로 직렬화', 2, true, 2],
+    ['0이면 wire에서 omit (base ID와 동등, byte-level 호환)', 0, false, undefined],
+    ['미지정이면 wire에서 omit (구 client/backend 호환)', undefined, false, undefined],
+  ])('occurrenceIdx %s', async (_label, input, expectPresent, expectValue) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendReschedulePush({
+      deviceToken: 'devicetoken-hex',
+      pushId: 'rsch-occ',
+      trainCode: '7246',
+      nextStation: '중곡',
+      newArrivalTimeEpoch: 1_700_000_120_000,
+      sentAt: 1_700_000_000_000,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      ...(input !== undefined ? { occurrenceIdx: input as number } : {}),
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('occurrenceIdx' in body.data).toBe(expectPresent);
+    if (expectPresent) expect(body.data.occurrenceIdx).toBe(expectValue);
+  });
 });
 
 describe('sendLiveActivityUpdate (#586 C)', () => {

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -329,7 +329,7 @@ describe('sendReschedulePush (#585)', () => {
       config: makeConfig(),
       host: TEST_HOST,
       fetchImpl: fetchImpl as unknown as typeof fetch,
-      ...(input !== undefined ? { occurrenceIdx: input as number } : {}),
+      ...(input === undefined ? {} : { occurrenceIdx: input as number }),
     });
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const body = JSON.parse(call[1].body as string);

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -182,6 +182,60 @@ describe('validateTrip', () => {
     expect(validateTrip({ ...base(), subsurface: 1 })?.subsurface).toBeUndefined();
     expect(validateTrip(base())?.subsurface).toBeUndefined();
   });
+
+  // #1193 — 중복역 trip의 waypoint occurrenceIdx stamping.
+  describe('occurrenceIdx stamping (#1193)', () => {
+    it('단일 등장 waypoints는 모두 occurrenceIdx=0', () => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '신도림', line: '2', kind: 'transfer' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.occurrenceIdx)).toEqual([0, 0]);
+    });
+
+    it('같은 stationName 중복 시 0, 1, 2... 순차 stamp', () => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '회차역', line: '2', kind: 'transfer' },
+          { stationName: '다른역', line: '2', kind: 'transfer' },
+          { stationName: '회차역', line: '2', kind: 'transfer' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.occurrenceIdx)).toEqual([0, 0, 1, 0]);
+    });
+
+    it('클라이언트가 명시한 occurrenceIdx는 그대로 신뢰 (round-trip)', () => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '회차역', line: '2', kind: 'transfer', occurrenceIdx: 5 },
+          { stationName: '강남', line: '2', kind: 'destination', occurrenceIdx: 0 },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.occurrenceIdx)).toEqual([5, 0]);
+    });
+
+    it.each([
+      ['음수', -1],
+      ['소수', 1.5],
+      ['문자열', '1'],
+    ] as const)('비정상 occurrenceIdx(%s)는 무시 후 자동 계산', (_label, badValue) => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '회차역', line: '2', kind: 'transfer', occurrenceIdx: badValue },
+          { stationName: '회차역', line: '2', kind: 'transfer' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.occurrenceIdx)).toEqual([0, 1, 0]);
+    });
+  });
 });
 
 describe('validateTrip — boardingLock (#585)', () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -205,6 +205,12 @@ export interface SendReschedulePushOptions {
    * 신규 호출자(maybeReschedulePush)는 `RESCHEDULE_CHANNELS_DEFAULT`(['bl','tba'])를 넘긴다.
    */
   channels?: ReadonlyArray<RescheduleChannel>;
+  /**
+   * #1193 — `tba:` 채널 정정 대상 occurrence(0-based). nextStation이 route에 중복 등장하면
+   * `Trip.waypoints[i].occurrenceIdx`를 그대로 forward한다. 미지정 시 wire에 필드를 넣지 않음
+   * (구 client는 0 fallback, 구 backend payload와 byte-level 호환).
+   */
+  occurrenceIdx?: number;
 }
 
 export async function sendReschedulePush(
@@ -223,6 +229,12 @@ export async function sendReschedulePush(
     sentAt: options.sentAt,
     // channels 미지정 시 wire에 필드를 넣지 않음 — 구 backend payload와 byte-level 호환.
     ...(options.channels !== undefined ? { channels: options.channels } : {}),
+    // #1193 — occurrenceIdx도 동일하게 conditional spread. 미지정 또는 0이면 wire에서 생략해
+    // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환을 보존한다.
+    // 0은 base identifier(`tba:early:역`)로 매핑돼 클라가 자연 fallback하므로 생략해도 의미 동일.
+    ...(options.occurrenceIdx !== undefined && options.occurrenceIdx > 0
+      ? { occurrenceIdx: options.occurrenceIdx }
+      : {}),
   };
 
   const body = JSON.stringify({ aps: { 'content-available': 1 }, data: payload });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1140,11 +1140,29 @@ export function validateTrip(input: unknown): Trip | null {
     if (wp.kind !== 'transfer' && wp.kind !== 'destination' && wp.kind !== 'intermediate') return null;
   }
 
+  // #1193 — incoming waypoints 전체에 대해 occurrenceIdx를 1-pass로 stamp.
+  // 같은 stationName이 중복 등장(순환선/회차)할 때 클라이언트의 `:n` suffix identifier 규약과 일치하도록
+  // 0-based 인덱스를 부여. waypoint shift 진행 후에도 값은 불변 — reschedule push 시점까지 일관.
+  // 클라이언트가 이미 occurrenceIdx를 보내준 경우는 그대로 신뢰 (round-trip 안정).
+  const occurrenceCount = new Map<string, number>();
+  const stampedWaypoints = (obj.waypoints as Array<Record<string, unknown>>).map((wp) => {
+    const stationName = wp.stationName as string;
+    const occIdx = occurrenceCount.get(stationName) ?? 0;
+    occurrenceCount.set(stationName, occIdx + 1);
+    const existing =
+      typeof wp.occurrenceIdx === 'number' &&
+      Number.isInteger(wp.occurrenceIdx) &&
+      wp.occurrenceIdx >= 0
+        ? (wp.occurrenceIdx as number)
+        : occIdx;
+    return { ...wp, occurrenceIdx: existing } as Trip['waypoints'][number];
+  });
+
   return {
     token: obj.token,
     route: obj.route as Trip['route'],
     destination: obj.destination,
-    waypoints: obj.waypoints as Trip['waypoints'],
+    waypoints: stampedWaypoints,
     expiresAt: obj.expiresAt,
     createdAt: typeof obj.createdAt === 'number' ? obj.createdAt : Date.now(),
     alarmAtEpochMs: obj.alarmAtEpochMs,

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1153,7 +1153,7 @@ export function validateTrip(input: unknown): Trip | null {
       typeof wp.occurrenceIdx === 'number' &&
       Number.isInteger(wp.occurrenceIdx) &&
       wp.occurrenceIdx >= 0
-        ? (wp.occurrenceIdx as number)
+        ? wp.occurrenceIdx
         : occIdx;
     return { ...wp, occurrenceIdx: existing } as Trip['waypoints'][number];
   });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1158,6 +1158,10 @@ export async function maybeReschedulePush(
         // #918 A3 PR4 — `bl:` + `tba:` 동시 정정. 구 backend 호환을 위해 채널 상수는
         // types.ts 단일 SSOT (RESCHEDULE_CHANNELS_DEFAULT)에서 import.
         channels: RESCHEDULE_CHANNELS_DEFAULT,
+        // #1193 — 중복역 trip(순환선/회차)에서 `tba:` 채널의 N번째 등장 정정. `validateTrip`이
+        // POST /trips 시점에 stamp한 값(불변)을 그대로 forward해 클라이언트와 routeStops 인덱스가
+        // round-trip 일치하도록 한다. 구 trip(필드 부재) → undefined → wire 생략 → 클라 0 fallback.
+        occurrenceIdx: waypoint.occurrenceIdx,
       }),
     trip.apnsEnv,
     deps.apnsHosts,

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -45,6 +45,18 @@ export interface Waypoint {
   line: LineNumber;
   /** "transfer" — 환승 안내 / "destination" — 최종 도착 / "intermediate" — 중간역 통과 */
   kind: 'transfer' | 'destination' | 'intermediate';
+  /**
+   * #1193 — 같은 stationName이 trip 원본 waypoint 시퀀스에 중복 등장(순환선/회차)할 때,
+   * 이 waypoint가 몇 번째 등장인지(0-based). reschedule push의 `occurrenceIdx`로 전달돼
+   * 클라이언트 `rescheduleTripBoundAlarm`이 정확한 `:n` suffix 알람을 cancel + 재예약한다.
+   *
+   * `validateTrip`(POST /trips)에서 incoming 전체 waypoints에 대해 1-pass로 계산해 stamp한다.
+   * waypoint shift가 진행돼도 occurrenceIdx는 stamp 그대로 유지(불변) — 정정 push 시점에
+   * 클라이언트 routeStops 인덱스와 round-trip 일치 보장.
+   *
+   * 구 backend / 구 client 호환을 위해 optional. 미지정 시 클라이언트가 0(첫 등장)으로 fallback.
+   */
+  occurrenceIdx?: number;
 }
 
 export interface Trip {
@@ -277,6 +289,12 @@ export interface ReschedulePushPayload {
   newArrivalTimeEpoch: number;
   sentAt: number;
   channels?: ReadonlyArray<RescheduleChannel>;
+  /**
+   * #1193 — `tba:` 채널 정정 시 정정 대상 occurrence(0-based). nextStation이 trip route에 중복
+   * 등장하면 클라이언트는 이 인덱스로 N번째 등장의 사전 예약 알람을 정확히 cancel + 재예약한다.
+   * 미지정 시 클라이언트는 0(첫 등장)으로 fallback — 중복 없는 trip / 구 backend 호환.
+   */
+  occurrenceIdx?: number;
 }
 
 /**

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -469,6 +469,43 @@ describe('silentPushTask', () => {
           ),
         ).toMatchObject({ sentAt: undefined, pushId: undefined });
       });
+
+      // #1193 — 중복역 trip의 N번째 occurrence를 정확히 정정하기 위한 인덱스.
+      it.each([
+        ['양의 정수', 2, 2],
+        ['0(첫 등장)', 0, 0],
+      ] as const)('occurrenceIdx 통과 (%s)', (_label, input, expected) => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: 'A',
+              newArrivalTimeEpoch: 1,
+              trainCode: 'X',
+              occurrenceIdx: input,
+            }),
+          ),
+        ).toMatchObject({ occurrenceIdx: expected });
+      });
+
+      it.each([
+        ['누락', undefined],
+        ['음수', -1],
+        ['소수', 1.5],
+        ['문자열', '2'],
+      ] as const)('occurrenceIdx 비정상값(%s) → undefined', (_label, value) => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'reschedule',
+              nextStation: 'A',
+              newArrivalTimeEpoch: 1,
+              trainCode: 'X',
+              ...(value !== undefined ? { occurrenceIdx: value } : {}),
+            }),
+          ),
+        ).toMatchObject({ occurrenceIdx: undefined });
+      });
     });
 
     // #868 — server-side trip auto-end 신호. nextWaypoint 없이 reason만 의미 있는 payload.
@@ -1472,6 +1509,34 @@ describe('silentPushTask', () => {
             );
             expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
             expect(mockRescheduleTripBoundAlarm).not.toHaveBeenCalled();
+          });
+
+          // #1193 — 중복역 trip 정정. payload.occurrenceIdx를 그대로 forward.
+          it('occurrenceIdx는 rescheduleTripBoundAlarm으로 forward (#1193)', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['tba'],
+                occurrenceIdx: 1,
+              }),
+            );
+            expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
+            const tbaArg = mockRescheduleTripBoundAlarm.mock.calls[0][0];
+            expect(tbaArg.occurrenceIdx).toBe(1);
+          });
+
+          it('occurrenceIdx 누락 시 undefined로 전달 (클라가 0 fallback) (#1193)', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['tba'],
+              }),
+            );
+            expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
+            const tbaArg = mockRescheduleTripBoundAlarm.mock.calls[0][0];
+            expect(tbaArg.occurrenceIdx).toBeUndefined();
           });
         });
       });

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -501,7 +501,7 @@ describe('silentPushTask', () => {
               nextStation: 'A',
               newArrivalTimeEpoch: 1,
               trainCode: 'X',
-              ...(value !== undefined ? { occurrenceIdx: value } : {}),
+              ...(value === undefined ? {} : { occurrenceIdx: value }),
             }),
           ),
         ).toMatchObject({ occurrenceIdx: undefined });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -128,6 +128,11 @@ export interface RescheduleSilentPushPayload {
   sentAt?: number;
   pushId?: string;
   channels?: ReadonlyArray<RescheduleChannel>;
+  /**
+   * #1193 — `tba:` 채널 정정 시, 같은 stationName이 route에 중복 등장하는 경우 정정 대상
+   * occurrence(0-based). 미지정 시 0(첫 등장)으로 해석 — 구 backend 호환 및 중복 없는 trip 동작 보존.
+   */
+  occurrenceIdx?: number;
 }
 
 /**
@@ -280,7 +285,8 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
 function extractReschedulePayload(
   obj: Record<string, unknown>,
 ): RescheduleSilentPushPayload | null {
-  const { nextStation, newArrivalTimeEpoch, trainCode, sentAt, pushId, channels } = obj;
+  const { nextStation, newArrivalTimeEpoch, trainCode, sentAt, pushId, channels, occurrenceIdx } =
+    obj;
   if (typeof nextStation !== 'string' || nextStation.length === 0) return null;
   if (typeof newArrivalTimeEpoch !== 'number' || !Number.isFinite(newArrivalTimeEpoch)) return null;
   if (typeof trainCode !== 'string' || trainCode.length === 0) return null;
@@ -292,7 +298,18 @@ function extractReschedulePayload(
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
     channels: validChannels(channels),
+    occurrenceIdx: validOccurrenceIdx(occurrenceIdx),
   };
+}
+
+/**
+ * #1193 — payload.occurrenceIdx 검증. 0 이상 정수만 통과. 구 backend가 필드를 안 보내면 undefined →
+ * `rescheduleTripBoundAlarm`이 0(첫 등장)으로 fallback.
+ */
+function validOccurrenceIdx(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  if (!Number.isInteger(value) || value < 0) return undefined;
+  return value;
 }
 
 /**
@@ -603,6 +620,8 @@ async function applyReschedule(
         route,
         destinationName,
         now: receivedAt,
+        // #1193 — 중복역 trip은 backend가 occurrenceIdx를 명시. 미지정 시 0(첫 등장).
+        occurrenceIdx: payload.occurrenceIdx,
       });
     }
   } catch (e) {

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -107,23 +107,48 @@ describe('tripBoundAlarmIdentifier', () => {
   });
 });
 
-describe('parseTripBoundAlarmIdentifier (#918 A3 PR2)', () => {
-  it('tba:phase:station 형식을 정상 파싱한다', () => {
+describe('parseTripBoundAlarmIdentifier (#918 A3 PR2 → #1193 확장)', () => {
+  it('tba:phase:station 형식을 정상 파싱한다 (occurrenceIdx=0)', () => {
     expect(parseTripBoundAlarmIdentifier('tba:early:강남')).toEqual({
       phaseId: 'early',
       stationName: '강남',
+      occurrenceIdx: 0,
     });
     expect(parseTripBoundAlarmIdentifier('tba:imminent:시청')).toEqual({
       phaseId: 'imminent',
       stationName: '시청',
+      occurrenceIdx: 0,
     });
   });
 
-  it('occurrence suffix(:n)는 stationName에 그대로 포함되어 반환된다', () => {
-    // suffix를 따로 떼지 않음 — 이후 waypoint 매칭 단계에서 자연스럽게 mismatch로 떨어지는 것을 의도.
-    expect(parseTripBoundAlarmIdentifier('tba:imminent:시청:1')).toEqual({
-      phaseId: 'imminent',
-      stationName: '시청:1',
+  // #1193 — :n suffix를 분리해 stationName과 occurrenceIdx를 따로 반환. 이전 PR4까지는
+  // stationName에 ':n'이 합쳐진 채 반환되어 reschedule cancel 매칭이 mismatch였다.
+  it.each([
+    ['tba:imminent:시청:1', 'imminent', '시청', 1],
+    ['tba:early:강남:2', 'early', '강남', 2],
+    ['tba:imminent:홍대입구:10', 'imminent', '홍대입구', 10],
+  ] as const)('occurrence suffix를 분리해 반환한다 (%s)', (id, phaseId, stationName, occurrenceIdx) => {
+    expect(parseTripBoundAlarmIdentifier(id)).toEqual({
+      phaseId,
+      stationName,
+      occurrenceIdx,
+    });
+  });
+
+  it('suffix가 숫자가 아니면 stationName에 흡수 (graceful: 역명에 콜론 포함 케이스)', () => {
+    expect(parseTripBoundAlarmIdentifier('tba:early:역명:abc')).toEqual({
+      phaseId: 'early',
+      stationName: '역명:abc',
+      occurrenceIdx: 0,
+    });
+  });
+
+  it(':0 suffix는 graceful하게 0으로 해석 (round-trip 안전)', () => {
+    // `prescheduleStationAlerts`는 base ID(:0 생략)를 발급하지만, 외부에서 `:0`이 들어와도 동작.
+    expect(parseTripBoundAlarmIdentifier('tba:early:강남:0')).toEqual({
+      phaseId: 'early',
+      stationName: '강남',
+      occurrenceIdx: 0,
     });
   });
 
@@ -865,5 +890,168 @@ describe('rescheduleTripBoundAlarm (#918 A3 PR4)', () => {
     });
     expect(r.scheduled).toBe(0);
     expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+});
+
+// #1193 — 중복역 trip(같은 transferName이 route에 두 번 등장)에서 occurrenceIdx로
+// 정확한 occurrence만 cancel + 재예약. base ID와 :n suffix가 충돌 없이 격리되는지 검증.
+describe('rescheduleTripBoundAlarm 중복역 occurrenceIdx (#1193)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSchedule.mockResolvedValue('id');
+    jest.replaceProperty(Platform, 'OS', 'ios');
+  });
+
+  // 같은 환승역명을 두 번 등장시키는 multi-transfer route — routeStops는 [회차역, 회차역, 도착역].
+  // (deriveTripBoundStops가 transfer name과 destination name을 그대로 stop으로 평탄화함)
+  const loopRoute = makeMultiTransferRoute({
+    transfers: [
+      { transferName: '회차역', fromLine: '2', toLine: '2', stopsToTransfer: 3 },
+      { transferName: '회차역', fromLine: '2', toLine: '2', stopsToTransfer: 3 },
+    ],
+    stopsAfterLastTransfer: 2,
+  });
+  const NOW_MS = new Date('2026-06-12T09:00:00Z').getTime();
+  const destinationName = '강남';
+
+  it('occurrenceIdx=0: base ID만 cancel + 재예약, :1은 보존', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:회차역' }, // occurrence 0
+      { identifier: 'tba:imminent:회차역' }, // occurrence 0
+      { identifier: 'tba:early:회차역:1' }, // occurrence 1 — 보존
+      { identifier: 'tba:imminent:회차역:1' }, // occurrence 1 — 보존
+      { identifier: 'tba:early:강남' }, // 다른 역 보존
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const newArrivalMs = NOW_MS + 600_000;
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '회차역',
+      newArrivalMs,
+      route: loopRoute,
+      destinationName,
+      now: NOW_MS,
+      occurrenceIdx: 0,
+    });
+    expect(r.cancelled).toBe(2);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:회차역');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:회차역');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:회차역:1');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:회차역:1');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:강남');
+    // 재예약은 base ID로 (occurrenceIdx=0).
+    const scheduledIds = mockedSchedule.mock.calls.map(
+      ([opts]) => (opts as { identifier?: string }).identifier,
+    );
+    expect(scheduledIds).toEqual(
+      expect.arrayContaining(['tba:early:회차역', 'tba:imminent:회차역']),
+    );
+    expect(scheduledIds).not.toContain('tba:early:회차역:1');
+  });
+
+  it('occurrenceIdx=1: :1 suffix ID만 cancel + 재예약, base ID는 보존', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:회차역' },
+      { identifier: 'tba:imminent:회차역' },
+      { identifier: 'tba:early:회차역:1' },
+      { identifier: 'tba:imminent:회차역:1' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const newArrivalMs = NOW_MS + 600_000;
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '회차역',
+      newArrivalMs,
+      route: loopRoute,
+      destinationName,
+      now: NOW_MS,
+      occurrenceIdx: 1,
+    });
+    expect(r.cancelled).toBe(2);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:회차역:1');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:회차역:1');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:회차역');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:회차역');
+    // 재예약은 :1 suffix ID로.
+    const scheduledIds = mockedSchedule.mock.calls.map(
+      ([opts]) => (opts as { identifier?: string }).identifier,
+    );
+    expect(scheduledIds).toEqual(
+      expect.arrayContaining(['tba:early:회차역:1', 'tba:imminent:회차역:1']),
+    );
+    expect(scheduledIds).not.toContain('tba:early:회차역');
+  });
+
+  it('occurrenceIdx 미지정 시 0(첫 등장)으로 fallback', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:회차역' },
+      { identifier: 'tba:early:회차역:1' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '회차역',
+      newArrivalMs: NOW_MS + 600_000,
+      route: loopRoute,
+      destinationName,
+      now: NOW_MS,
+      // occurrenceIdx 생략
+    });
+    expect(r.cancelled).toBe(1);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:회차역');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:회차역:1');
+  });
+
+  it('등장 횟수가 occurrenceIdx 이하면 no-op (route 동기화 race)', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const r = await rescheduleTripBoundAlarm({
+      stationName: '회차역',
+      newArrivalMs: NOW_MS + 600_000,
+      route: loopRoute,
+      destinationName,
+      now: NOW_MS,
+      occurrenceIdx: 5, // 5번째 등장은 없음
+    });
+    expect(r).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+});
+
+// #1193 — topUpTripBoundWindow의 활성 윈도우 판정이 stationName 단위가 아닌
+// `${stationName}:${occurrenceIdx}` 단위로 동작해야 같은 역의 다른 occurrence를 혼동하지 않는다.
+describe('topUpTripBoundWindow 중복역 occurrence 격리 (#1193)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSchedule.mockResolvedValue('id');
+    jest.replaceProperty(Platform, 'OS', 'ios');
+  });
+
+  it('passed 이후 같은 역의 다음 occurrence가 윈도우 안이면, 이전 occurrence(:0)는 cancel되고 :1은 보존', async () => {
+    // routeStops = [A:0, B, A:1, C] (A가 두 번 등장).
+    const routeStops: TripBoundStop[] = [
+      { stationName: 'A', alarmType: 'transfer' },
+      { stationName: 'B', alarmType: 'transfer' },
+      { stationName: 'A', alarmType: 'transfer' },
+      { stationName: 'C', alarmType: 'destination' },
+    ];
+    const hops = [60_000, 60_000, 60_000, 60_000];
+
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:A' }, // A의 첫 occurrence(이미 통과한 stop) — cancel 대상.
+      { identifier: 'tba:imminent:A' },
+      { identifier: 'tba:early:A:1' }, // 윈도우 안 — 보존.
+      { identifier: 'tba:imminent:A:1' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const r = await topUpTripBoundWindow({
+      routeStops,
+      estimatedHopTimesMs: hops,
+      startTime: NOW,
+      passedStationName: 'B', // window starts at index 2 → [A:1, C]
+      windowSize: 2,
+    });
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:A');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:A');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:A:1');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:A:1');
+    expect(r.cancelled).toBe(2);
   });
 });

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -913,71 +913,53 @@ describe('rescheduleTripBoundAlarm 중복역 occurrenceIdx (#1193)', () => {
   });
   const NOW_MS = new Date('2026-06-12T09:00:00Z').getTime();
   const destinationName = '강남';
+  // 두 occurrence 알람 + 다른 역 알람이 함께 큐에 있는 상태.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fullScheduled = [
+    { identifier: 'tba:early:회차역' },
+    { identifier: 'tba:imminent:회차역' },
+    { identifier: 'tba:early:회차역:1' },
+    { identifier: 'tba:imminent:회차역:1' },
+    { identifier: 'tba:early:강남' },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ] as any;
 
-  it('occurrenceIdx=0: base ID만 cancel + 재예약, :1은 보존', async () => {
-    mockedGetAll.mockResolvedValue([
-      { identifier: 'tba:early:회차역' }, // occurrence 0
-      { identifier: 'tba:imminent:회차역' }, // occurrence 0
-      { identifier: 'tba:early:회차역:1' }, // occurrence 1 — 보존
-      { identifier: 'tba:imminent:회차역:1' }, // occurrence 1 — 보존
-      { identifier: 'tba:early:강남' }, // 다른 역 보존
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-    const newArrivalMs = NOW_MS + 600_000;
-    const r = await rescheduleTripBoundAlarm({
-      stationName: '회차역',
-      newArrivalMs,
-      route: loopRoute,
-      destinationName,
-      now: NOW_MS,
+  const getScheduledIds = () =>
+    mockedSchedule.mock.calls.map(
+      ([opts]) => (opts as { identifier?: string }).identifier,
+    );
+
+  // occurrenceIdx 별로 cancel/schedule 대상 ID가 어떻게 갈리는지만 데이터로 명시.
+  it.each([
+    {
+      label: 'occurrenceIdx=0: base ID만 cancel + 재예약, :1은 보존',
       occurrenceIdx: 0,
-    });
-    expect(r.cancelled).toBe(2);
-    expect(mockedCancel).toHaveBeenCalledWith('tba:early:회차역');
-    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:회차역');
-    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:회차역:1');
-    expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:회차역:1');
-    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:강남');
-    // 재예약은 base ID로 (occurrenceIdx=0).
-    const scheduledIds = mockedSchedule.mock.calls.map(
-      ([opts]) => (opts as { identifier?: string }).identifier,
-    );
-    expect(scheduledIds).toEqual(
-      expect.arrayContaining(['tba:early:회차역', 'tba:imminent:회차역']),
-    );
-    expect(scheduledIds).not.toContain('tba:early:회차역:1');
-  });
-
-  it('occurrenceIdx=1: :1 suffix ID만 cancel + 재예약, base ID는 보존', async () => {
-    mockedGetAll.mockResolvedValue([
-      { identifier: 'tba:early:회차역' },
-      { identifier: 'tba:imminent:회차역' },
-      { identifier: 'tba:early:회차역:1' },
-      { identifier: 'tba:imminent:회차역:1' },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-    const newArrivalMs = NOW_MS + 600_000;
+      cancelTargets: ['tba:early:회차역', 'tba:imminent:회차역'],
+      preserveTargets: ['tba:early:회차역:1', 'tba:imminent:회차역:1', 'tba:early:강남'],
+    },
+    {
+      label: 'occurrenceIdx=1: :1 suffix ID만 cancel + 재예약, base ID는 보존',
+      occurrenceIdx: 1,
+      cancelTargets: ['tba:early:회차역:1', 'tba:imminent:회차역:1'],
+      preserveTargets: ['tba:early:회차역', 'tba:imminent:회차역', 'tba:early:강남'],
+    },
+  ])('$label', async ({ occurrenceIdx, cancelTargets, preserveTargets }) => {
+    mockedGetAll.mockResolvedValue(fullScheduled);
     const r = await rescheduleTripBoundAlarm({
       stationName: '회차역',
-      newArrivalMs,
+      newArrivalMs: NOW_MS + 600_000,
       route: loopRoute,
       destinationName,
       now: NOW_MS,
-      occurrenceIdx: 1,
+      occurrenceIdx,
     });
     expect(r.cancelled).toBe(2);
-    expect(mockedCancel).toHaveBeenCalledWith('tba:early:회차역:1');
-    expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:회차역:1');
-    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:회차역');
-    expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:회차역');
-    // 재예약은 :1 suffix ID로.
-    const scheduledIds = mockedSchedule.mock.calls.map(
-      ([opts]) => (opts as { identifier?: string }).identifier,
-    );
-    expect(scheduledIds).toEqual(
-      expect.arrayContaining(['tba:early:회차역:1', 'tba:imminent:회차역:1']),
-    );
-    expect(scheduledIds).not.toContain('tba:early:회차역');
+    for (const id of cancelTargets) expect(mockedCancel).toHaveBeenCalledWith(id);
+    for (const id of preserveTargets) expect(mockedCancel).not.toHaveBeenCalledWith(id);
+    const scheduledIds = getScheduledIds();
+    expect(scheduledIds).toEqual(expect.arrayContaining(cancelTargets));
+    // 같은 stop의 다른 occurrence ID는 재예약 대상에 포함되지 않음.
+    for (const id of preserveTargets) expect(scheduledIds).not.toContain(id);
   });
 
   it('occurrenceIdx 미지정 시 0(첫 등장)으로 fallback', async () => {

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -571,6 +571,50 @@ export interface RescheduleTripBoundAlarmResult {
  * `scheduleStopPhase`(내부 `scheduleNotificationAsync`)는 throw 가능 — 호출자(silentPushTask)가
  * try/catch로 silent push handler crash를 차단한다 (alarmScheduler 정책과 일치).
  */
+/**
+ * 주어진 (stationName, occurrenceIdx)에 정확히 매칭하는 사전 예약 알람만 cancel.
+ * 다른 occurrence(예: 같은 역의 :0, :2)는 보존된다.
+ */
+async function cancelMatchingOccurrence(
+  canonicalName: string,
+  occurrenceIdx: number,
+): Promise<number> {
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let cancelled = 0;
+  for (const req of all) {
+    if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
+    const parsed = parseTripBoundAlarmIdentifier(req.identifier);
+    if (parsed === null) continue;
+    if (parsed.stationName !== canonicalName) continue;
+    if (parsed.occurrenceIdx !== occurrenceIdx) continue;
+    await Notifications.cancelScheduledNotificationAsync(req.identifier);
+    cancelled++;
+  }
+  return cancelled;
+}
+
+/**
+ * 단일 stop의 early/imminent 두 phase를 새 도착 시각 기준으로 재예약.
+ * fireMs <= nowMs인 phase는 silent skip (정정 push 도착 시점 기준 과거 차단).
+ */
+async function reschedulePhasesForStop(
+  stop: TripBoundStop,
+  newArrivalMs: number,
+  hopMs: number,
+  nowMs: number,
+  occurrenceIdx: number,
+): Promise<number> {
+  let scheduled = 0;
+  for (const phase of ALARM_PHASES) {
+    const leadMs = phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS;
+    const fireMs = newArrivalMs - leadMs;
+    if (fireMs <= nowMs) continue;
+    await scheduleStopPhase({ phase, stop, fireMs, occurrenceIdx });
+    scheduled++;
+  }
+  return scheduled;
+}
+
 export async function rescheduleTripBoundAlarm(
   params: RescheduleTripBoundAlarmParams,
 ): Promise<RescheduleTripBoundAlarmResult> {
@@ -606,17 +650,7 @@ export async function rescheduleTripBoundAlarm(
   // 기존 `tba:` 알람 중 해당 (stationName, occurrenceIdx)에 정확히 매칭하는 것만 cancel (#1193).
   // 다른 occurrence(예: 같은 역의 :0, :2)는 그대로 보존돼 stale fire 위험 없음.
   const canonicalName = routeStops[targetIndex].stationName;
-  const all = await Notifications.getAllScheduledNotificationsAsync();
-  let cancelled = 0;
-  for (const req of all) {
-    if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
-    const parsed = parseTripBoundAlarmIdentifier(req.identifier);
-    if (parsed === null) continue;
-    if (parsed.stationName === canonicalName && parsed.occurrenceIdx === occurrenceIdx) {
-      await Notifications.cancelScheduledNotificationAsync(req.identifier);
-      cancelled++;
-    }
-  }
+  const cancelled = await cancelMatchingOccurrence(canonicalName, occurrenceIdx);
 
   // 재예약 — newArrivalMs를 두 phase의 절대 도착 시각으로 직접 사용.
   // prescheduleStationAlerts 누적 모델(startTime + Σhop)을 거치지 않으므로 단일 stop을
@@ -627,16 +661,13 @@ export async function rescheduleTripBoundAlarm(
   // (cumulative 모델의 startTime 가드)는 본 시나리오와 무관 — newArrivalMs는 stop의 새 도착
   // 시각으로 backend가 보내 준 값이지 trip의 출발 시각이 아니다.
   // hopMs는 deriveTripBoundStops가 HOP_TIME_MS fallback을 보장 — 본 함수에선 별도 가드 없이 사용.
-  const hopMs = estimatedHopTimesMs[targetIndex];
-  const stop = routeStops[targetIndex];
-  let scheduled = 0;
-  for (const phase of ALARM_PHASES) {
-    const leadMs = phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS;
-    const fireMs = newArrivalMs - leadMs;
-    if (fireMs <= nowMs) continue;
-    await scheduleStopPhase({ phase, stop, fireMs, occurrenceIdx });
-    scheduled++;
-  }
+  const scheduled = await reschedulePhasesForStop(
+    routeStops[targetIndex],
+    newArrivalMs,
+    estimatedHopTimesMs[targetIndex],
+    nowMs,
+    occurrenceIdx,
+  );
 
   logger.info(
     `reschedule done: station=${canonicalName} occurrence=${occurrenceIdx} cancelled=${cancelled} scheduled=${scheduled} newArrivalMs=${newArrivalMs}`,

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -254,26 +254,56 @@ export function tripBoundAlarmIdentifier(
 export interface ParsedTripBoundAlarmIdentifier {
   phaseId: string;
   stationName: string;
+  /**
+   * #1193 — 같은 stationName이 route에 중복 등장(순환선/회차)할 때, n번째 등장의 알람을 식별하는
+   * 0-based 인덱스. base identifier(`tba:early:역명`)는 0, `tba:early:역명:1`은 1, `:2`는 2...
+   *
+   * `parseTripBoundAlarmIdentifier`가 `:n` suffix를 분리해 stationName에서 떼어 낸다 (이전 PR4까지는
+   * stationName에 `:n`이 합쳐진 채 반환되어 reschedule cancel 매칭이 항상 mismatch였다).
+   * suffix 형식이 깨진 경우(`:` 뒤가 숫자가 아니거나 음수 등) `:n` 부분도 stationName으로 간주 —
+   * 기존 호출자 호환성 유지(`isSameStationName` 매칭은 자연 mismatch로 떨어지므로 안전).
+   */
+  occurrenceIdx: number;
 }
 
 /**
- * `tripBoundAlarmIdentifier()`의 역연산 (#918 A3 PR2). prefix 매칭 + phaseId/stationName 분리.
- * 같은 station이 route 안에 두 번 등장해 `:n` occurrence suffix가 붙은 경우(`prescheduleStationAlerts`
- * 내부 로직)에도 station name 안에 콜론이 합쳐진 채 반환된다 — 이후 waypoint 매칭 단계에서 자연스럽게
- * mismatch로 떨어지므로 별도 후처리는 불필요(재검증 안전).
+ * `tripBoundAlarmIdentifier()`의 역연산 (#918 A3 PR2 → #1193 확장).
+ *
+ * 형식:
+ *   `tba:<phaseId>:<stationName>` (occurrenceIdx=0, base identifier)
+ *   `tba:<phaseId>:<stationName>:<n>` (n ≥ 1, 중복역의 n번째 등장)
  *
  * prefix가 다르거나 phaseId/stationName이 비어 있으면 null.
+ * `:n` 의 n이 정수가 아니면 suffix를 stationName 일부로 흡수 (역명에 콜론 포함되는 비정상 케이스도
+ * graceful — backwards-compatible: 기존 호출자가 stationName 그대로 매칭하면 자연 mismatch로 처리).
  */
 export function parseTripBoundAlarmIdentifier(
   identifier: string,
 ): ParsedTripBoundAlarmIdentifier | null {
   if (!identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) return null;
   const rest = identifier.slice(TRIP_BOUND_ALARM_PREFIX.length);
-  const colon = rest.indexOf(':');
-  if (colon <= 0) return null;
-  const stationName = rest.slice(colon + 1);
-  if (!stationName) return null;
-  return { phaseId: rest.slice(0, colon), stationName };
+  const firstColon = rest.indexOf(':');
+  if (firstColon <= 0) return null;
+  const phaseId = rest.slice(0, firstColon);
+  const afterPhase = rest.slice(firstColon + 1);
+  if (!afterPhase) return null;
+  // `:n` suffix 분리 — 마지막 ':' 뒤가 양의 정수면 occurrenceIdx로 채택.
+  const lastColon = afterPhase.lastIndexOf(':');
+  if (lastColon > 0) {
+    const suffix = afterPhase.slice(lastColon + 1);
+    // /^\d+$/ — 숫자만. 빈 문자열은 false.
+    if (suffix.length > 0 && /^\d+$/.test(suffix)) {
+      const occurrenceIdx = Number(suffix);
+      // 0은 base identifier에서 절대 suffix로 표기되지 않으므로(`prescheduleStationAlerts` 규약)
+      // `:0`이 와도 graceful하게 0으로 해석 (round-trip 안전성).
+      return {
+        phaseId,
+        stationName: afterPhase.slice(0, lastColon),
+        occurrenceIdx,
+      };
+    }
+  }
+  return { phaseId, stationName: afterPhase, occurrenceIdx: 0 };
 }
 
 /**
@@ -414,11 +444,20 @@ export async function topUpTripBoundWindow(
   const nextStartIndex = passedIndex + 1;
   const nextEndIndex = Math.min(routeStops.length, nextStartIndex + windowSize);
 
-  // 이미 큐에 있는 `tba:` 알람 중 새 윈도우 밖에 해당하는 것만 cancel.
-  // routeStops[i]의 stationName이 윈도우 안에 있는지 빠르게 판별하기 위한 set.
-  const inWindowStationNames = new Set<string>();
-  for (let i = nextStartIndex; i < nextEndIndex; i++) {
-    inWindowStationNames.add(routeStops[i].stationName);
+  // 이미 큐에 있는 `tba:` 알람 중 새 윈도우 밖에 해당하는 것만 cancel (#1193).
+  // 활성 윈도우는 `${stationName}:${occurrenceIdx}` 단위로 판정해야 정확하다 — 같은 stationName이
+  // route 안에 여러 번 등장하는 경우(순환선/회차) 이미 통과한 occurrence(예: A:0)와 윈도우 안의
+  // 다음 occurrence(예: A:2)는 분리 식별돼야 stale cancel이 누락되지 않는다.
+  const inWindowStationOccurrences = new Set<string>();
+  // 누적은 routeStops 전체에 대해 진행 — `prescheduleStationAlerts`와 동일한 occurrence 규약 보존.
+  const occurrenceCount = new Map<string, number>();
+  for (let i = 0; i < routeStops.length; i++) {
+    const name = routeStops[i].stationName;
+    const occIdx = occurrenceCount.get(name) ?? 0;
+    occurrenceCount.set(name, occIdx + 1);
+    if (i >= nextStartIndex && i < nextEndIndex) {
+      inWindowStationOccurrences.add(`${name}:${occIdx}`);
+    }
   }
 
   const all = await Notifications.getAllScheduledNotificationsAsync();
@@ -427,9 +466,7 @@ export async function topUpTripBoundWindow(
     if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
     const parsed = parseTripBoundAlarmIdentifier(req.identifier);
     if (parsed === null) continue;
-    // occurrence suffix가 붙은 경우 stationName에 ":n"이 포함된다 — 그래도 set lookup으로 mismatch 시
-    // cancel 처리되므로 새 윈도우의 첫 등장 알람과 충돌하지 않는다.
-    if (!inWindowStationNames.has(parsed.stationName)) {
+    if (!inWindowStationOccurrences.has(`${parsed.stationName}:${parsed.occurrenceIdx}`)) {
       await Notifications.cancelScheduledNotificationAsync(req.identifier);
       cancelled++;
     }
@@ -448,6 +485,26 @@ export async function topUpTripBoundWindow(
     `topUp passedIndex=${passedIndex} window=[${nextStartIndex},${nextEndIndex}) cancelled=${cancelled} scheduled=${scheduledAlarms.length}`,
   );
   return { cancelled, scheduled: scheduledAlarms.length };
+}
+
+/**
+ * #1193 — routeStops에서 `stationName`의 `occurrenceIdx`번째 등장 인덱스를 반환.
+ * `isSameStationName`(canonical name 정규화) 기반 비교 — 표기 차이(역/驛/Station 등) 흡수.
+ * 등장 횟수가 occurrenceIdx 이하라면 -1.
+ */
+function findOccurrenceIndex(
+  routeStops: ReadonlyArray<TripBoundStop>,
+  stationName: string,
+  occurrenceIdx: number,
+): number {
+  let seen = 0;
+  for (let i = 0; i < routeStops.length; i++) {
+    if (isSameStationName(routeStops[i].stationName, stationName)) {
+      if (seen === occurrenceIdx) return i;
+      seen++;
+    }
+  }
+  return -1;
 }
 
 export interface RescheduleTripBoundAlarmParams {
@@ -470,6 +527,14 @@ export interface RescheduleTripBoundAlarmParams {
    * (테스트가 결정적 결과를 얻기 위해 주입.)
    */
   now?: number;
+  /**
+   * #1193 — 같은 stationName이 route에 중복 등장할 때 정정 대상 occurrence(0-based).
+   * 누락 시 0 (= 첫 등장)으로 해석 — 중복 없는 trip / 구 backend 호환.
+   *
+   * `prescheduleStationAlerts`가 `${stationName}` (occurrenceIdx=0) 또는 `${stationName}:${n}` (n≥1)
+   * identifier로 예약하므로, cancel 매칭과 재예약 모두 이 인덱스를 따른다.
+   */
+  occurrenceIdx?: number;
 }
 
 export interface RescheduleTripBoundAlarmResult {
@@ -491,11 +556,13 @@ export interface RescheduleTripBoundAlarmResult {
  *   - stationName이 routeStops에 없으면 graceful no-op (정정 신호 폐기).
  *   - route/destinationName이 null이면 graceful no-op.
  *
- * **알려진 한계** (#918 A3 PR4 스코프):
- *   - 같은 stationName이 route에 중복 등장(순환선/회차)하는 경우 본 함수는 *모든* occurrence를
- *     cancel하되 base identifier(`occurrenceIdx=0`) 1개만 재생성한다. `:n` suffix 알람을
- *     cancel하지 못해 stale fire 위험이 있으므로 PR4는 단순/환승 trip만 지원하고 중복역
- *     trip은 후속 이슈에서 occurrence 인덱스 명시 정정 규약으로 다룬다.
+ * **#1193 (중복역 trip 정정)**:
+ *   - 같은 stationName이 route에 중복 등장하는 경우 `occurrenceIdx`로 정정 대상 occurrence를 명시.
+ *   - cancel은 `parsed.stationName === canonicalName && parsed.occurrenceIdx === occurrenceIdx`로
+ *     1건만 정확히 매칭한다 — 다른 occurrence의 사전 예약은 보존.
+ *   - 재예약 시 같은 `occurrenceIdx`로 base ID(`tba:early:역`) 또는 `:n` suffix ID를 생성.
+ *
+ * **남은 한계**:
  *   - rolling window(`TRIPBOUND_WINDOW_SIZE`) 밖 stop에 대해서도 본 함수는 무조건 OS 큐에
  *     예약을 push한다. 호출자(silentPushTask)는 backend payload에서 윈도우 안 stop에
  *     해당하는 정정 신호만 본 함수로 전달해야 한다 (윈도우 invariant 유지 책임은 caller).
@@ -509,6 +576,8 @@ export async function rescheduleTripBoundAlarm(
 ): Promise<RescheduleTripBoundAlarmResult> {
   const { stationName, newArrivalMs, route, destinationName } = params;
   const nowMs = params.now ?? Date.now();
+  // #1193 — 정정 대상 occurrence(0-based). 미지정 시 첫 등장.
+  const occurrenceIdx = params.occurrenceIdx ?? 0;
 
   if (newArrivalMs <= nowMs) {
     logger.info(
@@ -524,14 +593,18 @@ export async function rescheduleTripBoundAlarm(
   }
 
   const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, destinationName);
-  const targetIndex = routeStops.findIndex((s) => isSameStationName(s.stationName, stationName));
+  // #1193 — N번째 occurrence를 routeStops에서 찾는다 (occurrenceIdx=0이면 첫 등장).
+  // 같은 stationName이 occurrenceIdx만큼 등장하지 않으면 silent no-op (backend/client 동기화 race).
+  const targetIndex = findOccurrenceIndex(routeStops, stationName, occurrenceIdx);
   if (targetIndex === -1) {
-    logger.info(`reschedule no-op: ${stationName} not found in routeStops`);
+    logger.info(
+      `reschedule no-op: ${stationName} occurrence=${occurrenceIdx} not found in routeStops`,
+    );
     return { cancelled: 0, scheduled: 0 };
   }
 
-  // 기존 `tba:` 알람 중 해당 stationName의 것만 cancel.
-  // canonical name으로 cancel 매칭 — routeStops[targetIndex].stationName과 OS 큐 id를 직접 비교.
+  // 기존 `tba:` 알람 중 해당 (stationName, occurrenceIdx)에 정확히 매칭하는 것만 cancel (#1193).
+  // 다른 occurrence(예: 같은 역의 :0, :2)는 그대로 보존돼 stale fire 위험 없음.
   const canonicalName = routeStops[targetIndex].stationName;
   const all = await Notifications.getAllScheduledNotificationsAsync();
   let cancelled = 0;
@@ -539,7 +612,7 @@ export async function rescheduleTripBoundAlarm(
     if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
     const parsed = parseTripBoundAlarmIdentifier(req.identifier);
     if (parsed === null) continue;
-    if (parsed.stationName === canonicalName) {
+    if (parsed.stationName === canonicalName && parsed.occurrenceIdx === occurrenceIdx) {
       await Notifications.cancelScheduledNotificationAsync(req.identifier);
       cancelled++;
     }
@@ -561,12 +634,12 @@ export async function rescheduleTripBoundAlarm(
     const leadMs = phase.id === 'early' ? hopMs : IMMINENT_LEAD_MS;
     const fireMs = newArrivalMs - leadMs;
     if (fireMs <= nowMs) continue;
-    await scheduleStopPhase({ phase, stop, fireMs, occurrenceIdx: 0 });
+    await scheduleStopPhase({ phase, stop, fireMs, occurrenceIdx });
     scheduled++;
   }
 
   logger.info(
-    `reschedule done: station=${canonicalName} cancelled=${cancelled} scheduled=${scheduled} newArrivalMs=${newArrivalMs}`,
+    `reschedule done: station=${canonicalName} occurrence=${occurrenceIdx} cancelled=${cancelled} scheduled=${scheduled} newArrivalMs=${newArrivalMs}`,
   );
   return { cancelled, scheduled };
 }


### PR DESCRIPTION
Closes #1193

## Summary
- `parseTripBoundAlarmIdentifier` 확장: `:n` suffix 분리 → `{phaseId, stationName, occurrenceIdx}`. 기존 호출자는 stationName만 쓰면 자연 호환(suffix 제거된 깨끗한 name).
- `rescheduleTripBoundAlarm`: 신규 `occurrenceIdx?` 인자. cancel은 `parsed.stationName === canonical && parsed.occurrenceIdx === target`로 1개 occurrence만 매칭, 재예약도 같은 occurrenceIdx로 base ID(`tba:early:역`) 또는 `:n` suffix ID 생성.
- `topUpTripBoundWindow`: 활성 윈도우 집합을 `${stationName}:${occurrenceIdx}` 키로 변경 — 같은 역의 이미 통과한 occurrence(`A:0`)와 다음 occurrence(`A:2`)가 분리 식별돼 stale cancel 누락 차단.
- `RescheduleSilentPushPayload.occurrenceIdx?`: 0 이상 정수만 통과. `applyReschedule`이 그대로 `rescheduleTripBoundAlarm`에 forward.
- backend `Waypoint.occurrenceIdx?` + `validateTrip` 1-pass stamping: POST /trips 시점에 같은 stationName의 등장 순서를 부여(불변). client 명시값은 round-trip 신뢰. 비정상값은 자동 재계산.
- backend `sendReschedulePush`: `occurrenceIdx` wire 직렬화. 0/undefined는 omit(구 backend/client byte-level 호환), 양수만 payload에 포함.
- backend `maybeReschedulePush`: `waypoint.occurrenceIdx`를 그대로 forward.

PR4의 "알려진 한계"(중복역 trip 정정 불가) 제거. 단순/환승 trip(중복 없음)은 occurrenceIdx=0 fallback으로 기존 동작 유지.

## Test plan
- [x] `parseTripBoundAlarmIdentifier` 단위 테스트: `:1`/`:2`/`:10` suffix 분리, base ID(occurrenceIdx=0), `:0`/`:abc`(graceful), 깨진 포맷(null)
- [x] `rescheduleTripBoundAlarm` 중복역 fixture: occurrenceIdx=0/1/미지정/범위초과 4 케이스 — 정확한 cancel 매칭 + 재예약
- [x] `topUpTripBoundWindow` 중복역 occurrence 격리: 윈도우 안 `:1`은 보존, 윈도우 밖 base ID만 cancel
- [x] `silentPushTask.extractPayload` occurrenceIdx 검증 (정상/음수/소수/문자열/누락)
- [x] `applyReschedule`이 occurrenceIdx를 그대로 forward (`['tba']` 채널)
- [x] backend `validateTrip` occurrenceIdx stamping (단일/중복/client 명시/비정상값)
- [x] backend `sendReschedulePush` occurrenceIdx wire (양수 직렬화, 0/undefined omit)
- [x] `npx tsc --noEmit` (frontend + backend)
- [x] 변경 영향 받는 jest suite PASS (tripBoundScheduler 218, silentPushTask 포함, scheduledAlarmReceiver 36, useTripBoundAlarmScheduler 34)
- [x] backend vitest PASS (index.test.ts 216, apns.test.ts 23, scheduled.test.ts 162)
- [x] CI `Type Check & Test` 통과 확인
- [ ] 실기기 회귀: 단순/환승 trip silent push 정정 동작 보존
- [ ] 실기기 회귀: 순환선/중복역 trip에서 N번째 occurrence 정정 정확