### PR TITLE
feat(#1209): D3 silent push lockless 위치 게이트 hop window

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -631,6 +631,7 @@ describe('silentPushTask', () => {
         stationName: '강남',
         kind: 'destination',
         phase: 'imminent',
+        isLockless: false,
       });
       expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
       const call = mockScheduleNotificationAsync.mock.calls[0][0];
@@ -953,6 +954,16 @@ describe('silentPushTask', () => {
         await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
         expect(mockScheduleNotificationAsync).toHaveBeenCalled();
         expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      // #1209 D3 — lockless 경로에서 게이트가 widened 임계값 분기를 적용하도록 isLockless 전달.
+      it('lock 없음 + intermediate + 토글 ON → 게이트에 isLockless=true 전달', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        mockLocklessStorage('on');
+        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
+        expect(mockCheckGate).toHaveBeenCalledWith(
+          expect.objectContaining({ isLockless: true }),
+        );
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -764,10 +764,14 @@ async function fireWithGate(
     return;
   }
 
+  // #1209 D3 — lockless 경로는 sticky station 좌표 drift 수용 위해 widened 임계값 사용.
+  // D1(#1207) hop estimator 미연결 단계라 currentHopIndex/payloadHopIndex는 undefined로 두고
+  // 거리 기반 widened fallback 경로로 동작한다.
   const gate = await checkSilentPushLocationGate({
     stationName: payload.nextWaypoint,
     kind: payload.kind,
     phase: payload.phase,
+    isLockless: !lock,
   });
 
   if (!gate.pass) {

--- a/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
@@ -362,4 +362,225 @@ describe('checkSilentPushLocationGate', () => {
       expect(result.accuracyM).toBe(15);
     });
   });
+
+  // #1209 D3 — lockless intermediate 위치 게이트 정밀화.
+  describe('lockless intermediate 위치 게이트 (#1209 D3)', () => {
+    // 강남에서 ~700m 떨어진 좌표 (기존 300m 임계값에선 fail, lockless widened 800m엔 pass)
+    const MID_FROM_GANGNAM = { lat: 37.5042, lng: 127.0276 };
+    // 강남에서 ~1.5km 떨어진 좌표 (lockless 800m도 초과)
+    const FAR_LOCKLESS = { lat: 37.5114, lng: 127.0276 };
+
+    it('lockless + hop index 매치 시 거리 검증 우회 pass', async () => {
+      // 일부러 임계값 초과 거리에 두고 hop window로 통과시킴.
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_LOCKLESS.lat, FAR_LOCKLESS.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        currentHopIndex: 3,
+        payloadHopIndex: 3,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('hop-window-match');
+      // hop window 우회 경로는 distance/threshold 미계산.
+      expect(result.distanceM).toBeUndefined();
+      expect(result.thresholdM).toBeUndefined();
+    });
+
+    it('lockless + hop index 차이가 정확히 1이면 pass (경계)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_LOCKLESS.lat, FAR_LOCKLESS.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        currentHopIndex: 4,
+        payloadHopIndex: 3,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('hop-window-match');
+    });
+
+    it('lockless + hop index 차이가 2면 hop 매치 실패 → distance 게이트 진행', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_LOCKLESS.lat, FAR_LOCKLESS.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        currentHopIndex: 5,
+        payloadHopIndex: 3,
+      });
+      // hop window 실패 + 거리 1.5km는 lockless widened 800m 초과 → out-of-range
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('out-of-range');
+      expect(result.thresholdM).toBe(800);
+    });
+
+    it('lockless + hop index 미제공 + 700m → widened 임계값(800m) 내 pass', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(MID_FROM_GANGNAM.lat, MID_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('within-threshold');
+      expect(result.thresholdM).toBe(800);
+      expect(result.distanceM).toBeGreaterThan(300);
+      expect(result.distanceM).toBeLessThanOrEqual(800);
+    });
+
+    it('lockless + hop index 미제공 + 1.5km → widened 임계값도 초과 → out-of-range', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_LOCKLESS.lat, FAR_LOCKLESS.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+      });
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('out-of-range');
+      expect(result.thresholdM).toBe(800);
+      expect(result.distanceM).toBeGreaterThan(800);
+    });
+
+    it('lockless + early phase는 widened 1200m 임계값', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_LOCKLESS.lat, FAR_LOCKLESS.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'early',
+        isLockless: true,
+      });
+      // 1.5km는 1200m도 초과
+      expect(result.pass).toBe(false);
+      expect(result.thresholdM).toBe(1200);
+    });
+
+    it('lockless + early phase + 700m → widened 1200m 내 pass', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(MID_FROM_GANGNAM.lat, MID_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'early',
+        isLockless: true,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('within-threshold');
+      expect(result.thresholdM).toBe(1200);
+    });
+
+    it('hop window match passReason은 motion fields도 함께 노출', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue({
+        coords: {
+          latitude: FAR_LOCKLESS.lat,
+          longitude: FAR_LOCKLESS.lng,
+          accuracy: 12,
+          altitude: null,
+          heading: null,
+          speed: 4.5,
+          altitudeAccuracy: null,
+        },
+        timestamp: Date.now() - 5_000,
+      });
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        currentHopIndex: 2,
+        payloadHopIndex: 2,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('hop-window-match');
+      expect(result.speedMps).toBe(4.5);
+      expect(result.accuracyM).toBe(12);
+    });
+
+    it('lockless가 아닌데 hop index 제공해도 기존 좁은 임계값 그대로 (회귀 차단)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(MID_FROM_GANGNAM.lat, MID_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: false,
+        currentHopIndex: 3,
+        payloadHopIndex: 3,
+      });
+      // lock 활성으로 간주 → 기존 300m 임계 → 700m fail
+      expect(result.pass).toBe(false);
+      expect(result.thresholdM).toBe(300);
+    });
+
+    it('lockless transfer kind는 widened 적용 X (transfer는 기존 좁은 임계 유지)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(MID_FROM_GANGNAM.lat, MID_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'transfer',
+        phase: 'imminent',
+        isLockless: true,
+        currentHopIndex: 3,
+        payloadHopIndex: 3,
+      });
+      // intermediate만 hop window/widened 분기. transfer는 기존 400m 임계.
+      expect(result.thresholdM).toBe(400);
+      expect(result.pass).toBe(false);
+    });
+
+    it('lockless intermediate + currentHopIndex만 제공(payload 누락) → widened distance 경로', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(MID_FROM_GANGNAM.lat, MID_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        currentHopIndex: 3,
+        // payloadHopIndex 미제공
+      });
+      // hop window 판정 불가 → widened distance 경로
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('within-threshold');
+      expect(result.thresholdM).toBe(800);
+    });
+
+    it('lockless intermediate + payloadHopIndex만 제공(estimator 미연결) → widened distance 경로', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(MID_FROM_GANGNAM.lat, MID_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        // currentHopIndex 미제공
+        payloadHopIndex: 3,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('within-threshold');
+      expect(result.thresholdM).toBe(800);
+    });
+  });
 });

--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -3,6 +3,11 @@ import { haversine } from '../../../shared/utils/haversine';
 import { findStationByName } from '../../../shared/utils/stationLookup';
 import { createLogger } from '../../../shared/utils/logger';
 import { isValidGpsSpeedMps } from '../../../shared/constants/location';
+import {
+  THRESHOLDS_M,
+  LOCKLESS_INTERMEDIATE_THRESHOLDS_M,
+  LOCKLESS_HOP_WINDOW_TOLERANCE,
+} from '../../../shared/constants/silentPushThresholds';
 
 const logger = createLogger('SilentPushLocationGate');
 
@@ -14,28 +19,22 @@ export const LOCATION_CACHE_TTL_MS = 60_000;
 // 콜드 GPS fetch 타임아웃 — BG 깨움 시 OS가 즉답 못 하면 보수적 skip.
 export const FRESH_FETCH_TIMEOUT_MS = 3_000;
 
-/**
- * phase × kind별 발사 허용 거리(m).
- * - early: 한 정거장 전 알림 → 다음 역이라도 게이트 통과해야 하므로 넓게
- * - imminent: 도착 직전 → 좁게
- * - intermediate: 이미 그 역 근처 통과 시점 → 가장 좁게
- *
- * 초안 값. 운영 alarmLog 데이터로 후속 조정(#478 follow-up).
- */
-const THRESHOLDS_M = {
-  early: { transfer: 800, destination: 800, intermediate: 600 },
-  imminent: { transfer: 400, destination: 400, intermediate: 300 },
-} as const;
-
 export type GateKind = 'transfer' | 'destination' | 'intermediate';
 export type GatePhase = 'early' | 'imminent';
 
 export type GateSkipReason = 'unknown-station' | 'no-location' | 'stale-location' | 'out-of-range';
+/**
+ * pass=true일 때 어떤 경로로 통과했는지 식별. 운영 측정/디버깅용.
+ * - 'within-threshold': 거리 임계값 이내 (기존 경로)
+ * - 'hop-window-match': lockless + hop index 매치(거리 검증 우회, #1209 D3)
+ */
+export type GatePassReason = 'within-threshold' | 'hop-window-match';
 export type GateLocationSource = 'cache' | 'fresh';
 
 export interface GateResult {
   pass: boolean;
   reason?: GateSkipReason;
+  passReason?: GatePassReason;
   distanceM?: number;
   thresholdM?: number;
   locationSource?: GateLocationSource;
@@ -43,6 +42,25 @@ export interface GateResult {
   // #727 — movementGate가 후속 정적 misfire 평가에 사용. expo-location 응답에 있을 때만 노출.
   speedMps?: number;
   accuracyM?: number;
+}
+
+export interface SilentPushLocationGateInput {
+  stationName: string;
+  kind: GateKind;
+  phase: GatePhase;
+  /**
+   * lockless trip(BoardingLock 미활성) 경로 여부. #1209 D3.
+   * true면 intermediate kind에 한해 widened 임계값과 hop window 매치 분기가 적용된다.
+   */
+  isLockless?: boolean;
+  /**
+   * D1(#1207) hop estimator가 추정한 현재 hop index. 미연결 시 undefined.
+   */
+  currentHopIndex?: number;
+  /**
+   * silent push payload가 명시한 hop index. 백엔드 schema에 추가되기 전까지 undefined.
+   */
+  payloadHopIndex?: number;
 }
 
 interface UserPosition {
@@ -125,6 +143,33 @@ async function resolveUserPosition(): Promise<UserPosition | null> {
 }
 
 /**
+ * lockless intermediate 경로에서 적용할 임계값을 결정.
+ * lock 활성 또는 lockless의 transfer/destination은 기존 좁은 임계값을 그대로 쓴다.
+ */
+function resolveThresholdM(
+  isLockless: boolean,
+  kind: GateKind,
+  phase: GatePhase,
+): number {
+  if (isLockless && kind === 'intermediate') {
+    return LOCKLESS_INTERMEDIATE_THRESHOLDS_M[phase];
+  }
+  return THRESHOLDS_M[phase][kind];
+}
+
+/**
+ * D1 estimator가 제공한 현재 hop index가 payload hop과 ±TOLERANCE 이내인지.
+ * 둘 중 하나라도 undefined면 매치 판정 불가 → false.
+ */
+function isHopWindowMatch(
+  currentHopIndex: number | undefined,
+  payloadHopIndex: number | undefined,
+): boolean {
+  if (currentHopIndex == null || payloadHopIndex == null) return false;
+  return Math.abs(currentHopIndex - payloadHopIndex) <= LOCKLESS_HOP_WINDOW_TOLERANCE;
+}
+
+/**
  * silent push 수신 시 "사용자가 실제로 그 역 근처에 있는지" 확인하는 게이트.
  * pass=true면 알림 발사, false면 skip + alarmLog에 skipReason 기록.
  *
@@ -132,13 +177,13 @@ async function resolveUserPosition(): Promise<UserPosition | null> {
  *   1) stationName이 stations.json에 없으면 skip (unknown-station)
  *   2) 위치 획득 실패 시 skip (no-location) — 보수적
  *   3) 캐시가 TTL 초과면 skip (stale-location) — 보수적
- *   4) phase/kind별 임계값 이내면 pass, 초과면 skip (out-of-range)
+ *   4) lockless + intermediate + hop index 매치면 거리 검증 우회 pass (#1209 D3)
+ *   5) phase/kind별 임계값 이내면 pass, 초과면 skip (out-of-range)
+ *      — lockless intermediate는 sticky station 좌표 drift 수용 위해 widened
  */
-export async function checkSilentPushLocationGate(input: {
-  stationName: string;
-  kind: GateKind;
-  phase: GatePhase;
-}): Promise<GateResult> {
+export async function checkSilentPushLocationGate(
+  input: SilentPushLocationGateInput,
+): Promise<GateResult> {
   const station = findStationByName(input.stationName);
   if (!station) {
     return { pass: false, reason: 'unknown-station' };
@@ -158,19 +203,41 @@ export async function checkSilentPushLocationGate(input: {
     };
   }
 
+  const isLockless = input.isLockless === true;
+  const motionFields = {
+    ...(pos.speedMps == null ? {} : { speedMps: pos.speedMps }),
+    ...(pos.accuracyM == null ? {} : { accuracyM: pos.accuracyM }),
+  };
+
+  // #1209 D3 — lockless + intermediate + hop window 매치 시 거리 검증 우회.
+  // D1 estimator의 hop이 payload hop과 ±1 이내라면 GPS 좌표가 drift해도 같은 leg로 간주.
+  if (
+    isLockless &&
+    input.kind === 'intermediate' &&
+    isHopWindowMatch(input.currentHopIndex, input.payloadHopIndex)
+  ) {
+    return {
+      pass: true,
+      passReason: 'hop-window-match',
+      locationSource: pos.source,
+      locationAgeMs: pos.ageMs,
+      ...motionFields,
+    };
+  }
+
   // haversine은 km 반환 → m로 변환 후 임계값(m)과 비교.
   const distanceM = Math.round(haversine(pos.lat, pos.lng, station.lat, station.lng) * 1000);
-  const thresholdM = THRESHOLDS_M[input.phase][input.kind];
+  const thresholdM = resolveThresholdM(isLockless, input.kind, input.phase);
   const pass = distanceM <= thresholdM;
 
   return {
     pass,
     reason: pass ? undefined : 'out-of-range',
+    passReason: pass ? 'within-threshold' : undefined,
     distanceM,
     thresholdM,
     locationSource: pos.source,
     locationAgeMs: pos.ageMs,
-    ...(pos.speedMps == null ? {} : { speedMps: pos.speedMps }),
-    ...(pos.accuracyM == null ? {} : { accuracyM: pos.accuracyM }),
+    ...motionFields,
   };
 }

--- a/src/shared/constants/silentPushThresholds.ts
+++ b/src/shared/constants/silentPushThresholds.ts
@@ -1,0 +1,41 @@
+/**
+ * silent push 위치 게이트(`checkSilentPushLocationGate`) 임계값 모음.
+ *
+ * 기존 inline 값(`src/features/alarm/utils/silentPushLocationGate.ts`)을
+ * #1209 D3에서 분리.
+ *
+ * 임계값 운영 원칙:
+ * - lock 활성 경로(`THRESHOLDS_M`): trainCode/노선이 확정되어 좁은 거리(300~400m)로
+ *   false positive를 차단할 수 있다.
+ * - lockless 경로(`LOCKLESS_INTERMEDIATE_THRESHOLDS_M`): sticky station 좌표가
+ *   실제 위치와 500m 이상 어긋날 수 있어 좁은 임계로는 정상 trip도 모두 미스한다
+ *   (2026-06-12 14건 silent push 전부 out-of-range 사고). 800m/1200m로 넓혀
+ *   "사용자 명시 의향 trip은 lock 활성과 동급 보장" 원칙을 충족한다.
+ * - hop window(`LOCKLESS_HOP_WINDOW_TOLERANCE`): D1 estimator가 현재 hop을 제공할 경우,
+ *   payload hop과 ±1 이내면 거리 검증을 우회한다 (좌표 drift 무시).
+ */
+
+/**
+ * phase × kind별 발사 허용 거리(m). lock 활성 경로 + lockless의 transfer/destination 경로.
+ */
+export const THRESHOLDS_M = {
+  early: { transfer: 800, destination: 800, intermediate: 600 },
+  imminent: { transfer: 400, destination: 400, intermediate: 300 },
+} as const;
+
+/**
+ * lockless 경로의 intermediate kind 전용 widened 임계값(m).
+ *
+ * D1(#1207) hop estimator 미연결 시 fallback. sticky station 좌표 drift를 수용해
+ * lock 활성 대비 ~2.6배 넓힘.
+ */
+export const LOCKLESS_INTERMEDIATE_THRESHOLDS_M = {
+  early: 1200,
+  imminent: 800,
+} as const;
+
+/**
+ * D1 estimator 연동 시 사용. `currentHopIndex`/`payloadHopIndex` 차이가 이 값 이하면
+ * 거리 검증을 우회하고 pass.
+ */
+export const LOCKLESS_HOP_WINDOW_TOLERANCE = 1;


### PR DESCRIPTION
## Summary
- lockless 경로(BoardingLock 미활성)의 intermediate kind 임계값을 widened: imminent 300m→800m, early 600m→1200m (sticky station 좌표 drift 수용)
- D1 estimator(#1207) 연동 가능한 hop window 매치 분기 추가 — `currentHopIndex`와 `payloadHopIndex`가 ±1 이내면 거리 검증 우회 pass (`passReason='hop-window-match'`)
- 새 필드는 모두 optional이라 estimator/payload 미연결 단계에선 widened distance 경로로 fallback (D1 대기 없이 독립 동작)
- 임계값을 `src/shared/constants/silentPushThresholds.ts`로 분리, magic number 제거

## Why
2026-06-12 trip에서 GPS 정확도 8.7m였지만 sticky-station 좌표가 500m+ drift해 silent push 14건이 모두 `out-of-range`로 차단됐다. 기존 300m 임계값은 lock 활성 trip(trainCode 확정) 기준이라 lockless에선 false-miss를 양산. 사용자 명시 의향 trip(C 토글 ON)은 lock 활성과 동급 정확도 보장 의무가 있어(ADR-010, CLAUDE.md 결정룰) widened 임계값 + hop window로 정확도를 회복한다.

## Changes
- `src/features/alarm/utils/silentPushLocationGate.ts` — `SilentPushLocationGateInput`에 `isLockless`/`currentHopIndex`/`payloadHopIndex` 추가. lockless intermediate + hop 매치 시 거리 검증 우회. `GatePassReason` 타입 추가
- `src/shared/constants/silentPushThresholds.ts` — `THRESHOLDS_M`/`LOCKLESS_INTERMEDIATE_THRESHOLDS_M`/`LOCKLESS_HOP_WINDOW_TOLERANCE` 신설
- `src/features/alarm/tasks/silentPushTask.ts` — 게이트 호출 시 `isLockless: !lock` 전달
- 테스트 14건 추가 (lockless hop match / hop diff / widened distance / non-lockless 회귀 차단 / transfer kind 회귀 / partial hop index 등)

## Test plan
- [x] `npm test` — 4992 tests pass, 100% coverage (lines/functions/branches/statements)
- [x] `npm run type-check` — pass
- [x] `npm run lint` — pass
- [ ] 실기기 검증: lockless trip(BoardingLock 미활성) + 토글 ON에서 silent push 발사율 측정 (Epic #1204 evidence)
- [ ] regression: lock 활성 destination/transfer trip에서 false positive 0건 확인

Closes #1209
Relates to #1204