### PR TITLE
feat(#1210): D4 boarding-lock sync trainCode

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2264,8 +2264,8 @@ describe('POST /boarding-lock/sync (#901)', () => {
 
 // D4 (#1210) — applyBoardingLockTrainCodeSwap 순수 함수 단위 테스트.
 describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
-  const baseTrip = (): import('../types').Trip =>
-    validateTrip({
+  function baseTrip() {
+    const trip = validateTrip({
       token: 'tok',
       route: { type: 'direct', line: '2', stops: 3 },
       destination: 'dst',
@@ -2281,7 +2281,10 @@ describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
         expiresAt: FUTURE,
       },
       consecutiveEtaMissing: 4,
-    }) as import('../types').Trip;
+    });
+    if (!trip) throw new Error('baseTrip fixture failed validateTrip');
+    return trip;
+  }
 
   function payload(over: Partial<Parameters<typeof applyBoardingLockTrainCodeSwap>[1]> = {}) {
     return {

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1786,44 +1786,42 @@ describe('validateBoardingLockSync (#901)', () => {
     expect(p?.subsurface).toBeUndefined();
   });
 
-  // D4 (#1210) — trainCode / boardingLine optional 검증.
-  it('#1210 — trainCode + boardingLine 정상 통과', () => {
+  // D4 (#1210) — trainCode / boardingLine optional 검증. validBase에 trainCode/boardingLine만
+  // 변형해 일괄 검증 (정상/빈문자열/비문자열).
+  it.each<{
+    label: string;
+    extra: Record<string, unknown>;
+    expectedTrainCode: string | undefined;
+    expectedBoardingLine: string | undefined;
+  }>([
+    {
+      label: '정상 string forward',
+      extra: { trainCode: 'T-1', boardingLine: '2' },
+      expectedTrainCode: 'T-1',
+      expectedBoardingLine: '2',
+    },
+    {
+      label: '빈 문자열은 누락 처리',
+      extra: { trainCode: '', boardingLine: '' },
+      expectedTrainCode: undefined,
+      expectedBoardingLine: undefined,
+    },
+    {
+      label: '비문자열 타입은 무시',
+      extra: { trainCode: 123, boardingLine: { x: 1 } },
+      expectedTrainCode: undefined,
+      expectedBoardingLine: undefined,
+    },
+  ])('#1210 — trainCode/boardingLine: $label', ({ extra, expectedTrainCode, expectedBoardingLine }) => {
     const p = validateBoardingLockSync({
       token: 'tok',
       observedStationName: '강남',
       observedAtMs: 1,
       accuracy: 10,
-      trainCode: 'T-1',
-      boardingLine: '2',
+      ...extra,
     });
-    expect(p?.trainCode).toBe('T-1');
-    expect(p?.boardingLine).toBe('2');
-  });
-
-  it('#1210 — 빈 trainCode/boardingLine 문자열은 누락 처리', () => {
-    const p = validateBoardingLockSync({
-      token: 'tok',
-      observedStationName: '강남',
-      observedAtMs: 1,
-      accuracy: 10,
-      trainCode: '',
-      boardingLine: '',
-    });
-    expect(p?.trainCode).toBeUndefined();
-    expect(p?.boardingLine).toBeUndefined();
-  });
-
-  it('#1210 — trainCode/boardingLine 비문자열 타입은 무시', () => {
-    const p = validateBoardingLockSync({
-      token: 'tok',
-      observedStationName: '강남',
-      observedAtMs: 1,
-      accuracy: 10,
-      trainCode: 123,
-      boardingLine: { x: 1 },
-    });
-    expect(p?.trainCode).toBeUndefined();
-    expect(p?.boardingLine).toBeUndefined();
+    expect(p?.trainCode).toBe(expectedTrainCode);
+    expect(p?.boardingLine).toBe(expectedBoardingLine);
   });
 
   it('non-object reject', () => {
@@ -2146,99 +2144,77 @@ describe('POST /boarding-lock/sync (#901)', () => {
 
   // D4 (#1210) — payload trainCode가 KV lock과 다르면 KV lock 갱신 + consecutiveEtaMissing=0 reset.
   describe('trainCode swap (#1210)', () => {
-    it('payload trainCode != KV lock trainCode → KV trainCode 갱신 + line 갱신', async () => {
-      const env = makeKvEnv();
-      // 환승 전 leg — line 2, trainCode T-1, consecutiveEtaMissing 4 (자동 종료 임계 근처).
-      const trip = validateTrip({
-        ...tripWithLock(),
-        consecutiveEtaMissing: 4,
-      });
-      await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
-      const res = await post(
-        '/boarding-lock/sync',
-        {
-          token: 'tok-sync',
-          observedStationName: '신촌',
-          observedAtMs: 1,
-          accuracy: 5,
-          trainCode: 'T-7',
-          boardingLine: '7',
-        },
-        env,
-      );
-      expect(res.status).toBe(200);
-      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
-      expect(stored.boardingLock.trainCode).toBe('T-7');
-      expect(stored.boardingLock.line).toBe('7');
-      expect(stored.consecutiveEtaMissing).toBe(0);
-    });
+    /**
+     * 4 trip+payload 케이스 ($label) × 동일 assertion 셰이프(lock + counter)로 1 케이스 1 시나리오
+     * 검증. payload 분기는 sync POST 직전에 spread로 추가.
+     */
+    it.each<{
+      label: string;
+      preCounter: number;
+      payloadExtra: Record<string, unknown>;
+      expectedTrainCode: string;
+      expectedLine: string;
+      expectedCounter: number;
+    }>([
+      {
+        label: 'trainCode != KV → KV trainCode + line 갱신, counter reset',
+        preCounter: 4,
+        payloadExtra: { trainCode: 'T-7', boardingLine: '7' },
+        expectedTrainCode: 'T-7',
+        expectedLine: '7',
+        expectedCounter: 0,
+      },
+      {
+        label: 'trainCode == KV → no-op (lock + counter 보존)',
+        preCounter: 2,
+        payloadExtra: { trainCode: 'T-1', boardingLine: '2' },
+        expectedTrainCode: 'T-1',
+        expectedLine: '2',
+        expectedCounter: 2,
+      },
+      {
+        label: 'trainCode 누락 → KV lock + counter 그대로 (backward compat)',
+        preCounter: 3,
+        payloadExtra: {},
+        expectedTrainCode: 'T-1',
+        expectedLine: '2',
+        expectedCounter: 3,
+      },
+      {
+        label: 'boardingLine 누락 + trainCode만 변경 → 기존 line 유지',
+        preCounter: 0,
+        payloadExtra: { trainCode: 'T-NEW' },
+        expectedTrainCode: 'T-NEW',
+        expectedLine: '2',
+        expectedCounter: 0,
+      },
+    ])(
+      'lock 있는 trip — $label',
+      async ({ preCounter, payloadExtra, expectedTrainCode, expectedLine, expectedCounter }) => {
+        const env = makeKvEnv();
+        const trip = validateTrip({ ...tripWithLock(), consecutiveEtaMissing: preCounter });
+        await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
+        const res = await post(
+          '/boarding-lock/sync',
+          {
+            token: 'tok-sync',
+            observedStationName: '신촌',
+            observedAtMs: 1,
+            accuracy: 5,
+            ...payloadExtra,
+          },
+          env,
+        );
+        expect(res.status).toBe(200);
+        const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+        expect(stored.boardingLock.trainCode).toBe(expectedTrainCode);
+        expect(stored.boardingLock.line).toBe(expectedLine);
+        expect(stored.consecutiveEtaMissing).toBe(expectedCounter);
+      },
+    );
 
-    it('payload trainCode == KV lock trainCode → no-op (lock 그대로, counter 보존)', async () => {
-      const env = makeKvEnv();
-      const trip = validateTrip({
-        ...tripWithLock(),
-        consecutiveEtaMissing: 2,
-      });
-      await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
-      const res = await post(
-        '/boarding-lock/sync',
-        {
-          token: 'tok-sync',
-          observedStationName: '신촌',
-          observedAtMs: 1,
-          accuracy: 5,
-          trainCode: 'T-1',
-          boardingLine: '2',
-        },
-        env,
-      );
-      expect(res.status).toBe(200);
-      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
-      expect(stored.boardingLock.trainCode).toBe('T-1');
-      expect(stored.consecutiveEtaMissing).toBe(2);
-    });
-
-    it('payload trainCode 누락 → KV lock 그대로 (backward compat)', async () => {
-      const env = makeKvEnv();
-      const trip = validateTrip({
-        ...tripWithLock(),
-        consecutiveEtaMissing: 3,
-      });
-      await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
-      const res = await post(
-        '/boarding-lock/sync',
-        { token: 'tok-sync', observedStationName: '신촌', observedAtMs: 1, accuracy: 5 },
-        env,
-      );
-      expect(res.status).toBe(200);
-      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
-      expect(stored.boardingLock.trainCode).toBe('T-1');
-      expect(stored.consecutiveEtaMissing).toBe(3);
-    });
-
-    it('boardingLine 누락 + trainCode만 변경 → line은 기존 값 유지, trainCode만 갱신', async () => {
-      const env = makeKvEnv();
-      await env.TRIPS.put(
-        'trip:tok-sync',
-        JSON.stringify(validateTrip(tripWithLock())),
-      );
-      await post(
-        '/boarding-lock/sync',
-        {
-          token: 'tok-sync',
-          observedStationName: '신촌',
-          observedAtMs: 1,
-          accuracy: 5,
-          trainCode: 'T-NEW',
-        },
-        env,
-      );
-      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
-      expect(stored.boardingLock.trainCode).toBe('T-NEW');
-      // 기존 line 보존.
-      expect(stored.boardingLock.line).toBe('2');
-    });
-
+    // lock 없는 trip은 setup 경로(POST /trips)가 다르고 expectation(boardingLock undefined)이
+    // 별개라 it.each에 합치지 않고 단독 케이스로 둔다.
     it('lock 없는 trip + payload trainCode → no-op (lock 생성 안 함)', async () => {
       const env = makeKvEnv();
       const tripNoLock = tripWithLock();
@@ -2263,62 +2239,74 @@ describe('POST /boarding-lock/sync (#901)', () => {
 });
 
 // D4 (#1210) — applyBoardingLockTrainCodeSwap 순수 함수 단위 테스트.
-describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
-  function baseTrip() {
-    const trip = validateTrip({
-      token: 'tok',
-      route: { type: 'direct', line: '2', stops: 3 },
-      destination: 'dst',
-      waypoints: [{ stationName: '강남', line: '2', kind: 'intermediate' }],
+//
+// outer scope에 fixture builder 둠 — describe 내부 nested function 선언은 SonarCloud의
+// CODE_SMELL (typescript:S6535/S2392 family) 으로 잡힌다. 모든 케이스가 같은 fixture를 쓰므로
+// outer 헬퍼로 hoist.
+function buildD4SwapBaseTrip() {
+  const trip = validateTrip({
+    token: 'tok',
+    route: { type: 'direct', line: '2', stops: 3 },
+    destination: 'dst',
+    waypoints: [{ stationName: '강남', line: '2', kind: 'intermediate' }],
+    expiresAt: FUTURE,
+    alarmAtEpochMs: FUTURE - 60_000,
+    boardingLock: {
+      trainCode: 'T-OLD',
+      line: '2',
+      subwayId: '1002',
+      selectedDepartureTime: 1,
+      segmentStations: ['강남'],
       expiresAt: FUTURE,
-      alarmAtEpochMs: FUTURE - 60_000,
-      boardingLock: {
-        trainCode: 'T-OLD',
-        line: '2',
-        subwayId: '1002',
-        selectedDepartureTime: 1,
-        segmentStations: ['강남'],
-        expiresAt: FUTURE,
-      },
-      consecutiveEtaMissing: 4,
-    });
-    if (!trip) throw new Error('baseTrip fixture failed validateTrip');
-    return trip;
-  }
+    },
+    consecutiveEtaMissing: 4,
+  });
+  if (!trip) throw new Error('buildD4SwapBaseTrip fixture failed validateTrip');
+  return trip;
+}
 
-  function payload(over: Partial<Parameters<typeof applyBoardingLockTrainCodeSwap>[1]> = {}) {
-    return {
-      token: 'tok',
-      observedStationName: '강남',
-      observedAtMs: 1,
-      accuracy: 5,
-      ...over,
-    };
-  }
+function buildD4SwapPayload(
+  over: Partial<Parameters<typeof applyBoardingLockTrainCodeSwap>[1]> = {},
+) {
+  return {
+    token: 'tok',
+    observedStationName: '강남',
+    observedAtMs: 1,
+    accuracy: 5,
+    ...over,
+  };
+}
 
+describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
   it('trainCode 미제공 → 동일 trip 그대로 반환', () => {
-    const trip = baseTrip();
-    const result = applyBoardingLockTrainCodeSwap(trip, payload());
+    const trip = buildD4SwapBaseTrip();
+    const result = applyBoardingLockTrainCodeSwap(trip, buildD4SwapPayload());
     expect(result).toBe(trip);
   });
 
   it('lock 없는 trip → 동일 trip 그대로 반환', () => {
-    const trip = { ...baseTrip(), boardingLock: undefined };
-    const result = applyBoardingLockTrainCodeSwap(trip, payload({ trainCode: 'T-NEW' }));
+    const trip = { ...buildD4SwapBaseTrip(), boardingLock: undefined };
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      buildD4SwapPayload({ trainCode: 'T-NEW' }),
+    );
     expect(result).toBe(trip);
   });
 
   it('trainCode 동일 → 동일 trip 그대로 반환', () => {
-    const trip = baseTrip();
-    const result = applyBoardingLockTrainCodeSwap(trip, payload({ trainCode: 'T-OLD' }));
+    const trip = buildD4SwapBaseTrip();
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      buildD4SwapPayload({ trainCode: 'T-OLD' }),
+    );
     expect(result).toBe(trip);
   });
 
   it('trainCode 변경 → lock.trainCode + line 갱신 + counter reset', () => {
-    const trip = baseTrip();
+    const trip = buildD4SwapBaseTrip();
     const result = applyBoardingLockTrainCodeSwap(
       trip,
-      payload({ trainCode: 'T-NEW', boardingLine: '7' }),
+      buildD4SwapPayload({ trainCode: 'T-NEW', boardingLine: '7' }),
     );
     expect(result.boardingLock?.trainCode).toBe('T-NEW');
     expect(result.boardingLock?.line).toBe('7');
@@ -2329,8 +2317,11 @@ describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
   });
 
   it('trainCode 변경 + line 누락 → 기존 line 유지', () => {
-    const trip = baseTrip();
-    const result = applyBoardingLockTrainCodeSwap(trip, payload({ trainCode: 'T-NEW' }));
+    const trip = buildD4SwapBaseTrip();
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      buildD4SwapPayload({ trainCode: 'T-NEW' }),
+    );
     expect(result.boardingLock?.line).toBe('2');
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   app,
+  applyBoardingLockTrainCodeSwap,
   computeLockSyncAdvance,
   LOCK_TTL_REFRESH_MS,
   validateBoardingLockSync,
@@ -1785,6 +1786,46 @@ describe('validateBoardingLockSync (#901)', () => {
     expect(p?.subsurface).toBeUndefined();
   });
 
+  // D4 (#1210) — trainCode / boardingLine optional 검증.
+  it('#1210 — trainCode + boardingLine 정상 통과', () => {
+    const p = validateBoardingLockSync({
+      token: 'tok',
+      observedStationName: '강남',
+      observedAtMs: 1,
+      accuracy: 10,
+      trainCode: 'T-1',
+      boardingLine: '2',
+    });
+    expect(p?.trainCode).toBe('T-1');
+    expect(p?.boardingLine).toBe('2');
+  });
+
+  it('#1210 — 빈 trainCode/boardingLine 문자열은 누락 처리', () => {
+    const p = validateBoardingLockSync({
+      token: 'tok',
+      observedStationName: '강남',
+      observedAtMs: 1,
+      accuracy: 10,
+      trainCode: '',
+      boardingLine: '',
+    });
+    expect(p?.trainCode).toBeUndefined();
+    expect(p?.boardingLine).toBeUndefined();
+  });
+
+  it('#1210 — trainCode/boardingLine 비문자열 타입은 무시', () => {
+    const p = validateBoardingLockSync({
+      token: 'tok',
+      observedStationName: '강남',
+      observedAtMs: 1,
+      accuracy: 10,
+      trainCode: 123,
+      boardingLine: { x: 1 },
+    });
+    expect(p?.trainCode).toBeUndefined();
+    expect(p?.boardingLine).toBeUndefined();
+  });
+
   it('non-object reject', () => {
     expect(validateBoardingLockSync(null)).toBeNull();
     expect(validateBoardingLockSync('s')).toBeNull();
@@ -2101,6 +2142,193 @@ describe('POST /boarding-lock/sync (#901)', () => {
       autoLockCandidate: unknown;
     };
     expect(body.autoLockCandidate).toBeNull();
+  });
+
+  // D4 (#1210) — payload trainCode가 KV lock과 다르면 KV lock 갱신 + consecutiveEtaMissing=0 reset.
+  describe('trainCode swap (#1210)', () => {
+    it('payload trainCode != KV lock trainCode → KV trainCode 갱신 + line 갱신', async () => {
+      const env = makeKvEnv();
+      // 환승 전 leg — line 2, trainCode T-1, consecutiveEtaMissing 4 (자동 종료 임계 근처).
+      const trip = validateTrip({
+        ...tripWithLock(),
+        consecutiveEtaMissing: 4,
+      });
+      await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
+      const res = await post(
+        '/boarding-lock/sync',
+        {
+          token: 'tok-sync',
+          observedStationName: '신촌',
+          observedAtMs: 1,
+          accuracy: 5,
+          trainCode: 'T-7',
+          boardingLine: '7',
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+      expect(stored.boardingLock.trainCode).toBe('T-7');
+      expect(stored.boardingLock.line).toBe('7');
+      expect(stored.consecutiveEtaMissing).toBe(0);
+    });
+
+    it('payload trainCode == KV lock trainCode → no-op (lock 그대로, counter 보존)', async () => {
+      const env = makeKvEnv();
+      const trip = validateTrip({
+        ...tripWithLock(),
+        consecutiveEtaMissing: 2,
+      });
+      await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
+      const res = await post(
+        '/boarding-lock/sync',
+        {
+          token: 'tok-sync',
+          observedStationName: '신촌',
+          observedAtMs: 1,
+          accuracy: 5,
+          trainCode: 'T-1',
+          boardingLine: '2',
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+      expect(stored.boardingLock.trainCode).toBe('T-1');
+      expect(stored.consecutiveEtaMissing).toBe(2);
+    });
+
+    it('payload trainCode 누락 → KV lock 그대로 (backward compat)', async () => {
+      const env = makeKvEnv();
+      const trip = validateTrip({
+        ...tripWithLock(),
+        consecutiveEtaMissing: 3,
+      });
+      await env.TRIPS.put('trip:tok-sync', JSON.stringify(trip));
+      const res = await post(
+        '/boarding-lock/sync',
+        { token: 'tok-sync', observedStationName: '신촌', observedAtMs: 1, accuracy: 5 },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+      expect(stored.boardingLock.trainCode).toBe('T-1');
+      expect(stored.consecutiveEtaMissing).toBe(3);
+    });
+
+    it('boardingLine 누락 + trainCode만 변경 → line은 기존 값 유지, trainCode만 갱신', async () => {
+      const env = makeKvEnv();
+      await env.TRIPS.put(
+        'trip:tok-sync',
+        JSON.stringify(validateTrip(tripWithLock())),
+      );
+      await post(
+        '/boarding-lock/sync',
+        {
+          token: 'tok-sync',
+          observedStationName: '신촌',
+          observedAtMs: 1,
+          accuracy: 5,
+          trainCode: 'T-NEW',
+        },
+        env,
+      );
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+      expect(stored.boardingLock.trainCode).toBe('T-NEW');
+      // 기존 line 보존.
+      expect(stored.boardingLock.line).toBe('2');
+    });
+
+    it('lock 없는 trip + payload trainCode → no-op (lock 생성 안 함)', async () => {
+      const env = makeKvEnv();
+      const tripNoLock = tripWithLock();
+      delete tripNoLock.boardingLock;
+      await post('/trips', tripNoLock, env);
+      await post(
+        '/boarding-lock/sync',
+        {
+          token: 'tok-sync',
+          observedStationName: '신촌',
+          observedAtMs: 1,
+          accuracy: 5,
+          trainCode: 'T-1',
+          boardingLine: '2',
+        },
+        env,
+      );
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+      expect(stored.boardingLock).toBeUndefined();
+    });
+  });
+});
+
+// D4 (#1210) — applyBoardingLockTrainCodeSwap 순수 함수 단위 테스트.
+describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
+  const baseTrip = (): import('../types').Trip =>
+    validateTrip({
+      token: 'tok',
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination: 'dst',
+      waypoints: [{ stationName: '강남', line: '2', kind: 'intermediate' }],
+      expiresAt: FUTURE,
+      alarmAtEpochMs: FUTURE - 60_000,
+      boardingLock: {
+        trainCode: 'T-OLD',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: 1,
+        segmentStations: ['강남'],
+        expiresAt: FUTURE,
+      },
+      consecutiveEtaMissing: 4,
+    }) as import('../types').Trip;
+
+  function payload(over: Partial<Parameters<typeof applyBoardingLockTrainCodeSwap>[1]> = {}) {
+    return {
+      token: 'tok',
+      observedStationName: '강남',
+      observedAtMs: 1,
+      accuracy: 5,
+      ...over,
+    };
+  }
+
+  it('trainCode 미제공 → 동일 trip 그대로 반환', () => {
+    const trip = baseTrip();
+    const result = applyBoardingLockTrainCodeSwap(trip, payload());
+    expect(result).toBe(trip);
+  });
+
+  it('lock 없는 trip → 동일 trip 그대로 반환', () => {
+    const trip = { ...baseTrip(), boardingLock: undefined };
+    const result = applyBoardingLockTrainCodeSwap(trip, payload({ trainCode: 'T-NEW' }));
+    expect(result).toBe(trip);
+  });
+
+  it('trainCode 동일 → 동일 trip 그대로 반환', () => {
+    const trip = baseTrip();
+    const result = applyBoardingLockTrainCodeSwap(trip, payload({ trainCode: 'T-OLD' }));
+    expect(result).toBe(trip);
+  });
+
+  it('trainCode 변경 → lock.trainCode + line 갱신 + counter reset', () => {
+    const trip = baseTrip();
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      payload({ trainCode: 'T-NEW', boardingLine: '7' }),
+    );
+    expect(result.boardingLock?.trainCode).toBe('T-NEW');
+    expect(result.boardingLock?.line).toBe('7');
+    expect(result.consecutiveEtaMissing).toBe(0);
+    // 다른 필드는 보존.
+    expect(result.boardingLock?.subwayId).toBe('1002');
+    expect(result.boardingLock?.segmentStations).toEqual(['강남']);
+  });
+
+  it('trainCode 변경 + line 누락 → 기존 line 유지', () => {
+    const trip = baseTrip();
+    const result = applyBoardingLockTrainCodeSwap(trip, payload({ trainCode: 'T-NEW' }));
+    expect(result.boardingLock?.line).toBe('2');
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -854,6 +854,11 @@ app.post('/boarding-lock/sync', async (c) => {
     await maybeMirrorLockSyncProgress(c.env.TRIPS, working, advance.shiftedCount);
   }
 
+  // D4 (#1210) — payload trainCode가 KV lock trainCode와 다르면 환승 leg로 해석.
+  // lock의 trainCode/line을 새 값으로 swap하고 consecutiveEtaMissing을 0으로 reset해
+  // 신규 trainCode가 Seoul API에서 잡힐 때까지의 자동 종료(`MAX_CONSECUTIVE_ETA_MISSING`)를 차단한다.
+  working = applyBoardingLockTrainCodeSwap(working, payload);
+
   // lock TTL refresh — 사용자가 지상에서 lock을 활성 유지 중임을 confirm.
   if (working.boardingLock) {
     working = {
@@ -895,6 +900,17 @@ interface BoardingLockSyncPayload {
   observedAtMs: number;
   accuracy: number;
   subsurface?: boolean;
+  /**
+   * D4 (#1210) — 클라가 직전 fix 시점에 활성으로 보고 있는 boarding lock trainCode.
+   * KV `trip.boardingLock.trainCode`와 다르면 backend가 환승 leg 진입으로 해석해 lock을 갱신하고
+   * `consecutiveEtaMissing`을 0으로 reset한다 (자동 종료 차단). 구버전 클라/lock 없는 trip은 미전송.
+   */
+  trainCode?: string;
+  /**
+   * D4 (#1210) — `trainCode`와 페어. 환승 leg의 새 노선(`BoardingLockMeta.line`)을 갱신한다.
+   * trainCode 없이 단독 전송은 무시 (trainCode가 primary key).
+   */
+  boardingLine?: string;
 }
 
 export function validateBoardingLockSync(input: unknown): BoardingLockSyncPayload | null {
@@ -915,7 +931,48 @@ export function validateBoardingLockSync(input: unknown): BoardingLockSyncPayloa
     accuracy: obj.accuracy,
   };
   if (typeof obj.subsurface === 'boolean') result.subsurface = obj.subsurface;
+  // D4 (#1210) — trainCode/boardingLine은 optional. 빈 문자열은 누락과 동일 (보호 차원).
+  if (typeof obj.trainCode === 'string' && obj.trainCode.length > 0) {
+    result.trainCode = obj.trainCode;
+  }
+  if (typeof obj.boardingLine === 'string' && obj.boardingLine.length > 0) {
+    result.boardingLine = obj.boardingLine;
+  }
   return result;
+}
+
+/**
+ * D4 (#1210) — payload trainCode가 KV trip.boardingLock과 불일치하면 lock의 trainCode/line을
+ * 교체하고 `consecutiveEtaMissing`을 0으로 reset한다. 일치하거나 trainCode 미제공 / lock 부재면
+ * no-op (trip 그대로 반환).
+ *
+ * 정책 근거: 환승 leg 진입 직후 backend Seoul API가 새 trainCode 응답을 받기까지 수십 초 공백이
+ * 생긴다. lock의 trainCode가 옛 값이면 `runTrainCodeTracking`이 매 cycle estimate=null로 카운터를
+ * 누적해 `MAX_CONSECUTIVE_ETA_MISSING` 초과 시 trip을 자동 종료한다 (#1210 evidence). 사용자가
+ * Seam E sync로 새 trainCode를 보내면 KV를 즉시 갱신해 자동 종료를 차단한다.
+ *
+ * 순수 함수 — 호출자(handler)가 putTrip으로 영속화한다.
+ */
+export function applyBoardingLockTrainCodeSwap(
+  trip: Trip,
+  payload: BoardingLockSyncPayload,
+): Trip {
+  const incomingTrainCode = payload.trainCode;
+  if (!incomingTrainCode) return trip;
+  const lock = trip.boardingLock;
+  if (!lock) return trip;
+  if (lock.trainCode === incomingTrainCode) return trip;
+  // 환승 leg 감지 → lock 교체 + 카운터 reset.
+  return {
+    ...trip,
+    boardingLock: {
+      ...lock,
+      trainCode: incomingTrainCode,
+      // boardingLine은 optional payload — 미제공 시 기존 line 유지.
+      line: payload.boardingLine ?? lock.line,
+    },
+    consecutiveEtaMissing: 0,
+  };
 }
 
 /**

--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -399,6 +399,131 @@ describe('useBoardingLockSync (#901)', () => {
     });
   });
 
+  // D4 (#1210) — 활성 lock trainCode/line forward + 환승 leg trainCode 변경 시 재발사.
+  describe('boardingLock trainCode/line forward (#1210)', () => {
+    it('trainCode + line 제공 → payload에 그대로 forward', async () => {
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          boardingLockTrainCode: 'T-1',
+          boardingLockLine: '2',
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+      expect(mockedSync.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ trainCode: 'T-1', boardingLine: '2' }),
+      );
+    });
+
+    it('trainCode/line null → payload에 trainCode/boardingLine 키 미포함', async () => {
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          boardingLockTrainCode: null,
+          boardingLockLine: null,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      const sent = mockedSync.mock.calls[0][0];
+      expect(sent).not.toHaveProperty('trainCode');
+      expect(sent).not.toHaveProperty('boardingLine');
+    });
+
+    it('같은 station + trainCode 변경 → debounce 후 재발사', async () => {
+      const { rerender } = renderHook(
+        ({ tc }: { tc: string | null }) =>
+          useBoardingLockSync({
+            currentStationName: '건대입구',
+            accuracyMeters: 10,
+            tripActive: true,
+            boardingLockTrainCode: tc,
+            boardingLockLine: tc === 'T-1' ? '2' : '7',
+          }),
+        { initialProps: { tc: 'T-1' as string | null } },
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+      expect(mockedSync.mock.calls[0][0].trainCode).toBe('T-1');
+      // 환승 leg simulation — 같은 환승역에서 lock이 새 trainCode로 교체됨.
+      rerender({ tc: 'T-2' });
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(2);
+      expect(mockedSync.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ trainCode: 'T-2', boardingLine: '7' }),
+      );
+    });
+
+    it('같은 station + 같은 trainCode → 재발사 안 함', async () => {
+      const { rerender } = renderHook(
+        ({ tc }: { tc: string }) =>
+          useBoardingLockSync({
+            currentStationName: '강남',
+            accuracyMeters: 10,
+            tripActive: true,
+            boardingLockTrainCode: tc,
+          }),
+        { initialProps: { tc: 'T-1' } },
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+      rerender({ tc: 'T-1' });
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('force-trigger 경로도 trainCode/line forward', async () => {
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          forceTriggerKey: 'k1',
+          boardingLockTrainCode: 'T-FORCE',
+          boardingLockLine: '9',
+        }),
+      );
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+      expect(mockedSync.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ trainCode: 'T-FORCE', boardingLine: '9' }),
+      );
+    });
+
+    it('tripActive false → true 전환 시 trainCode dedup ref도 reset', async () => {
+      const { rerender } = renderHook(
+        ({ active }: { active: boolean }) =>
+          useBoardingLockSync({
+            currentStationName: '강남',
+            accuracyMeters: 10,
+            tripActive: active,
+            boardingLockTrainCode: 'T-1',
+          }),
+        { initialProps: { active: true } },
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+      // trip 종료.
+      rerender({ active: false });
+      // trip 재시작 — 같은 station/trainCode면서 첫 sync는 다시 나가야 함.
+      rerender({ active: true });
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('debounce timer cleanup — unmount 시 미발사', async () => {
     const { unmount } = renderHook(() =>
       useBoardingLockSync({

--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -401,39 +401,56 @@ describe('useBoardingLockSync (#901)', () => {
 
   // D4 (#1210) — 활성 lock trainCode/line forward + 환승 leg trainCode 변경 시 재발사.
   describe('boardingLock trainCode/line forward (#1210)', () => {
-    it('trainCode + line 제공 → payload에 그대로 forward', async () => {
+    // 단일 렌더 + debounce 또는 force 발사 케이스 3건을 1 시나리오 1 케이스로 일괄 검증.
+    // 각 케이스는 옵션 셋과 expectedPayloadFields, expectedAbsent를 명시한다.
+    it.each<{
+      label: string;
+      options: Partial<Parameters<typeof useBoardingLockSync>[0]>;
+      expectedFields: Record<string, string> | null;
+      expectedAbsent: ReadonlyArray<string>;
+    }>([
+      {
+        label: 'trainCode + line 제공 → payload에 forward',
+        options: { boardingLockTrainCode: 'T-1', boardingLockLine: '2' },
+        expectedFields: { trainCode: 'T-1', boardingLine: '2' },
+        expectedAbsent: [],
+      },
+      {
+        label: 'trainCode/line null → payload에 미포함',
+        options: { boardingLockTrainCode: null, boardingLockLine: null },
+        expectedFields: null,
+        expectedAbsent: ['trainCode', 'boardingLine'],
+      },
+      {
+        label: 'force-trigger 경로도 trainCode/line forward',
+        options: {
+          forceTriggerKey: 'k1',
+          boardingLockTrainCode: 'T-FORCE',
+          boardingLockLine: '9',
+        },
+        expectedFields: { trainCode: 'T-FORCE', boardingLine: '9' },
+        expectedAbsent: [],
+      },
+    ])('$label', async ({ options, expectedFields, expectedAbsent }) => {
       renderHook(() =>
         useBoardingLockSync({
           currentStationName: '강남',
           accuracyMeters: 10,
           tripActive: true,
-          boardingLockTrainCode: 'T-1',
-          boardingLockLine: '2',
+          ...options,
         }),
       );
+      // force-trigger 케이스는 debounce 우회 → advance 호출도 영향 없음 (timer 미설정).
       act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
       await flushAsyncStorage();
       expect(mockedSync).toHaveBeenCalledTimes(1);
-      expect(mockedSync.mock.calls[0][0]).toEqual(
-        expect.objectContaining({ trainCode: 'T-1', boardingLine: '2' }),
-      );
-    });
-
-    it('trainCode/line null → payload에 trainCode/boardingLine 키 미포함', async () => {
-      renderHook(() =>
-        useBoardingLockSync({
-          currentStationName: '강남',
-          accuracyMeters: 10,
-          tripActive: true,
-          boardingLockTrainCode: null,
-          boardingLockLine: null,
-        }),
-      );
-      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-      await flushAsyncStorage();
       const sent = mockedSync.mock.calls[0][0];
-      expect(sent).not.toHaveProperty('trainCode');
-      expect(sent).not.toHaveProperty('boardingLine');
+      if (expectedFields) {
+        expect(sent).toEqual(expect.objectContaining(expectedFields));
+      }
+      for (const key of expectedAbsent) {
+        expect(sent).not.toHaveProperty(key);
+      }
     });
 
     it('같은 station + trainCode 변경 → debounce 후 재발사', async () => {
@@ -480,24 +497,6 @@ describe('useBoardingLockSync (#901)', () => {
       act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
       await flushAsyncStorage();
       expect(mockedSync).toHaveBeenCalledTimes(1);
-    });
-
-    it('force-trigger 경로도 trainCode/line forward', async () => {
-      renderHook(() =>
-        useBoardingLockSync({
-          currentStationName: '강남',
-          accuracyMeters: 10,
-          tripActive: true,
-          forceTriggerKey: 'k1',
-          boardingLockTrainCode: 'T-FORCE',
-          boardingLockLine: '9',
-        }),
-      );
-      await flushAsyncStorage();
-      expect(mockedSync).toHaveBeenCalledTimes(1);
-      expect(mockedSync.mock.calls[0][0]).toEqual(
-        expect.objectContaining({ trainCode: 'T-FORCE', boardingLine: '9' }),
-      );
     });
 
     it('tripActive false → true 전환 시 trainCode dedup ref도 reset', async () => {

--- a/src/features/alarm/hooks/useBoardingLockSync.ts
+++ b/src/features/alarm/hooks/useBoardingLockSync.ts
@@ -53,6 +53,17 @@ export interface UseBoardingLockSyncOptions {
   /** Seam G subsurface 신호 (옵션) — backend 로그에 진단 라벨로 첨부. */
   subsurface?: boolean;
   /**
+   * D4 (#1210) — 현재 활성 boarding lock의 trainCode. 있으면 sync payload에 동봉돼
+   * backend가 환승 leg trainCode 변경을 즉시 인식하고 `consecutiveEtaMissing` 자동 종료를 차단한다.
+   * null/undefined면 payload에 trainCode 미포함 (구버전 backend / lock 없는 trip 호환).
+   */
+  boardingLockTrainCode?: string | null;
+  /**
+   * D4 (#1210) — 현재 활성 boarding lock의 노선. trainCode와 함께 sync payload에 동봉된다.
+   * trainCode 없이 단독 전송은 backend에서 무시 (trainCode가 동일성 판정의 primary key).
+   */
+  boardingLockLine?: string | null;
+  /**
    * #915/#916 A1 — backend 응답에서 autoLockCandidate를 받으면 호출. 호출자는 이 콜백에서
    * useBoardingLockStore.createLock으로 hydrate해 사용자 명시 탭 없이 lock UX 활성화한다.
    *
@@ -72,10 +83,16 @@ export function useBoardingLockSync({
   tripActive,
   forceTriggerKey,
   subsurface,
+  boardingLockTrainCode,
+  boardingLockLine,
   onAutoLockCandidate,
 }: UseBoardingLockSyncOptions): void {
   // 이미 보낸 currentStation을 기억해 debounce 안의 중복 발사를 방지.
   const lastSentStationRef = useRef<string | null>(null);
+  // D4 (#1210) — 이미 보낸 trainCode를 기억해 환승 leg에서 trainCode가 바뀐 trip은 같은 역에서도
+  // 1회 재발사하도록 한다. station 단독 dedup만 두면 환승 직후 사용자가 환승역에 계속 머무는 동안
+  // backend가 새 trainCode를 영영 못 받는 회귀가 생긴다 (D4 evidence consecutiveEtaMissing 자동 종료).
+  const lastSentTrainCodeRef = useRef<string | null>(null);
   // forceTriggerKey 이전 값 — 같은 key 재전달 시 no-op 판정용.
   const lastForceKeyRef = useRef<string | null>(null);
   // #915 — 매 렌더 새 함수일 가능성 → ref로 latest 보관해 effect deps churn 회피.
@@ -89,27 +106,40 @@ export function useBoardingLockSync({
   useEffect(() => {
     if (!tripActive) {
       lastSentStationRef.current = null;
+      lastSentTrainCodeRef.current = null;
       lastForceKeyRef.current = null;
     }
   }, [tripActive]);
 
   // 1) currentStationName 변경 debounce 트리거.
+  // D4: trainCode 변경(환승 leg)도 동일 트리거로 다뤄 같은 역에서도 새 lock으로 1회 재발사.
   useEffect(() => {
     if (!tripActive) return;
     if (!currentStationName) return;
     if (accuracyMeters === null) return;
     if (accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
-    if (lastSentStationRef.current === currentStationName) return;
+    const trainCodeForFire = boardingLockTrainCode ?? null;
+    const stationUnchanged = lastSentStationRef.current === currentStationName;
+    const trainCodeUnchanged = lastSentTrainCodeRef.current === trainCodeForFire;
+    if (stationUnchanged && trainCodeUnchanged) return;
 
     const timer = setTimeout(() => {
-      // race: force-trigger 경로가 같은 station을 이미 발사했을 수 있음. setTimeout 내부에서
-      // 한 번 더 lastSentStation 체크해 중복 발사 차단.
-      if (lastSentStationRef.current === currentStationName) return;
+      // race: force-trigger 경로가 같은 station+trainCode를 이미 발사했을 수 있음. setTimeout
+      // 내부에서 한 번 더 체크해 중복 발사 차단.
+      if (
+        lastSentStationRef.current === currentStationName &&
+        lastSentTrainCodeRef.current === trainCodeForFire
+      ) {
+        return;
+      }
       lastSentStationRef.current = currentStationName;
+      lastSentTrainCodeRef.current = trainCodeForFire;
       void fireSync({
         observedStationName: currentStationName,
         accuracy: accuracyMeters,
         subsurface,
+        trainCode: boardingLockTrainCode ?? null,
+        boardingLine: boardingLockLine ?? null,
         reason: 'station-change',
         onAutoLockCandidate: onAutoLockCandidateRef.current,
       });
@@ -118,7 +148,14 @@ export function useBoardingLockSync({
     return () => {
       clearTimeout(timer);
     };
-  }, [tripActive, currentStationName, accuracyMeters, subsurface]);
+  }, [
+    tripActive,
+    currentStationName,
+    accuracyMeters,
+    subsurface,
+    boardingLockTrainCode,
+    boardingLockLine,
+  ]);
 
   // 2) 명시 트리거 (forceTriggerKey) — debounce 우회.
   useEffect(() => {
@@ -130,24 +167,39 @@ export function useBoardingLockSync({
     if (accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
 
     lastForceKeyRef.current = forceTriggerKey;
-    // lastSentStation을 즉시 동기로 set — effect 1의 debounce timer가 같은 station을 따라
-    // 발사하지 않도록 차단. fire 실패해도 force 트리거는 forceTriggerKey 변경으로만 재시도되므로
+    // lastSent ref들을 즉시 동기로 set — effect 1의 debounce timer가 같은 station/trainCode로
+    // 추가 발사하지 않도록 차단. fire 실패해도 force 트리거는 forceTriggerKey 변경으로만 재시도되므로
     // false-positive 무발사는 발생하지 않음.
     lastSentStationRef.current = currentStationName;
+    lastSentTrainCodeRef.current = boardingLockTrainCode ?? null;
     void fireSync({
       observedStationName: currentStationName,
       accuracy: accuracyMeters,
       subsurface,
+      trainCode: boardingLockTrainCode ?? null,
+      boardingLine: boardingLockLine ?? null,
       reason: 'force-trigger',
       onAutoLockCandidate: onAutoLockCandidateRef.current,
     });
-  }, [tripActive, forceTriggerKey, currentStationName, accuracyMeters, subsurface]);
+  }, [
+    tripActive,
+    forceTriggerKey,
+    currentStationName,
+    accuracyMeters,
+    subsurface,
+    boardingLockTrainCode,
+    boardingLockLine,
+  ]);
 }
 
 interface FireSyncInput {
   observedStationName: string;
   accuracy: number;
   subsurface?: boolean;
+  /** D4 (#1210) — 호출 시점 lock trainCode. null이면 payload에 미포함. */
+  trainCode?: string | null;
+  /** D4 (#1210) — 호출 시점 lock 노선. trainCode와 페어로만 의미. */
+  boardingLine?: string | null;
   reason: 'station-change' | 'force-trigger';
   onAutoLockCandidate?: (candidate: AutoLockCandidate) => void;
 }
@@ -170,10 +222,13 @@ async function fireSync(input: FireSyncInput): Promise<void> {
     observedAtMs: Date.now(),
     accuracy: input.accuracy,
     ...(input.subsurface !== undefined ? { subsurface: input.subsurface } : {}),
+    ...(input.trainCode ? { trainCode: input.trainCode } : {}),
+    ...(input.boardingLine ? { boardingLine: input.boardingLine } : {}),
   };
   const res = await syncBoardingLock(payload);
   logger.info('boarding-lock sync sent', {
     reason: input.reason,
+    trainCode: input.trainCode ?? null,
     advanced: res.advanced ?? false,
     currentWaypoint: res.currentWaypoint ?? null,
     autoLockCandidate: res.autoLockCandidate?.trainCode ?? null,

--- a/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
+++ b/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
@@ -92,6 +92,35 @@ describe('syncBoardingLock (#901)', () => {
     expect(JSON.parse(init.body).subsurface).toBe(false);
   });
 
+  // D4 (#1210) — 환승 leg trainCode + 노선 동봉 정확성.
+  it('#1210 — trainCode + boardingLine 제공 시 body에 그대로 포함', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    await syncBoardingLock({ ...basePayload, trainCode: 'T-2', boardingLine: '2' });
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    const parsed = JSON.parse(init.body);
+    expect(parsed.trainCode).toBe('T-2');
+    expect(parsed.boardingLine).toBe('2');
+  });
+
+  it('#1210 — trainCode 없으면 body에 trainCode/boardingLine 키 미포함 (구버전 backend 호환)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    await syncBoardingLock(basePayload);
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    const parsed = JSON.parse(init.body);
+    expect(parsed).not.toHaveProperty('trainCode');
+    expect(parsed).not.toHaveProperty('boardingLine');
+  });
+
   it('non-OK status → ok=false + status', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
     (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });

--- a/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
+++ b/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
@@ -92,33 +92,42 @@ describe('syncBoardingLock (#901)', () => {
     expect(JSON.parse(init.body).subsurface).toBe(false);
   });
 
-  // D4 (#1210) — 환승 leg trainCode + 노선 동봉 정확성.
-  it('#1210 — trainCode + boardingLine 제공 시 body에 그대로 포함', async () => {
+  // D4 (#1210) — 환승 leg trainCode + 노선 동봉 정확성. payload extra 분기만 다르고 검증
+  // 셰이프는 동일하므로 1 시나리오 1 케이스로 일괄 검증.
+  it.each<{
+    label: string;
+    payloadExtra: Record<string, string>;
+    expectedPresent: Record<string, string>;
+    expectedAbsent: ReadonlyArray<string>;
+  }>([
+    {
+      label: 'trainCode + boardingLine 제공 → body에 그대로 포함',
+      payloadExtra: { trainCode: 'T-2', boardingLine: '2' },
+      expectedPresent: { trainCode: 'T-2', boardingLine: '2' },
+      expectedAbsent: [],
+    },
+    {
+      label: 'trainCode/boardingLine 미제공 → body에 키 미포함 (구버전 backend 호환)',
+      payloadExtra: {},
+      expectedPresent: {},
+      expectedAbsent: ['trainCode', 'boardingLine'],
+    },
+  ])('#1210 — $label', async ({ payloadExtra, expectedPresent, expectedAbsent }) => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
     (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: () => Promise.resolve({ ok: true }),
     });
-    await syncBoardingLock({ ...basePayload, trainCode: 'T-2', boardingLine: '2' });
+    await syncBoardingLock({ ...basePayload, ...payloadExtra });
     const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
     const parsed = JSON.parse(init.body);
-    expect(parsed.trainCode).toBe('T-2');
-    expect(parsed.boardingLine).toBe('2');
-  });
-
-  it('#1210 — trainCode 없으면 body에 trainCode/boardingLine 키 미포함 (구버전 backend 호환)', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ ok: true }),
-    });
-    await syncBoardingLock(basePayload);
-    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
-    const parsed = JSON.parse(init.body);
-    expect(parsed).not.toHaveProperty('trainCode');
-    expect(parsed).not.toHaveProperty('boardingLine');
+    for (const [k, v] of Object.entries(expectedPresent)) {
+      expect(parsed[k]).toBe(v);
+    }
+    for (const k of expectedAbsent) {
+      expect(parsed).not.toHaveProperty(k);
+    }
   });
 
   it('non-OK status → ok=false + status', async () => {

--- a/src/features/nearest-station/api/boardingLockSync.ts
+++ b/src/features/nearest-station/api/boardingLockSync.ts
@@ -25,6 +25,10 @@ const log = createLogger('boardingLockSync');
  *  - observedAtMs: 디바이스 측정 시각 (epoch ms) — backend 시계 drift는 본 endpoint에서 미사용
  *  - accuracy: GPS accuracy meters — 호출자가 ≤ 50m 게이트 통과 후 호출
  *  - subsurface: Seam G 신호 (optional). false = 지상 진입 즉시 재동기 트리거 식별용 로그
+ *  - trainCode/boardingLine: D4 (#1210) — 현재 lock의 trainCode + 노선. 환승 leg 진입 시
+ *    새 trainCode가 backend에 즉시 반영돼 `consecutiveEtaMissing` 자동 종료를 차단한다.
+ *    optional — 구버전 backend / lock 없는 trip은 미전송. backend는 trainCode 변경 감지 시
+ *    KV `trip.boardingLock`을 갱신하고 `consecutiveEtaMissing`을 0으로 reset.
  */
 export interface BoardingLockSyncPayload {
   token: string;
@@ -32,6 +36,8 @@ export interface BoardingLockSyncPayload {
   observedAtMs: number;
   accuracy: number;
   subsurface?: boolean;
+  trainCode?: string;
+  boardingLine?: string;
 }
 
 /**

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -384,11 +384,15 @@ export default function HomeScreen() {
   // #915 (C1 destination-only baseline UX) — destination 설정 직후 backend로 좋은 fix sync 발사.
   // backend cron이 9단 게이트 통과 시 autoLockCandidate 응답에 부착(#916) → 사용자 명시 탭 없이
   // boardingLock hydrate. lock 활성 여부와 무관하게 trip 활성 동안 폴링.
+  // D4 (#1210) — 활성 lock의 trainCode + 노선을 동봉해 환승 leg 진입 시 backend가
+  // 새 trainCode로 추적을 갱신하도록 한다 (consecutiveEtaMissing 자동 종료 차단).
   useBoardingLockSync({
     currentStationName: result?.station.name ?? null,
     accuracyMeters: accuracyMeters ?? null,
     tripActive: Boolean(destination && route),
     subsurface: barometerSubsurface,
+    boardingLockTrainCode: boardingLock?.trainCode ?? null,
+    boardingLockLine: boardingLock?.boardingLine ?? null,
     onAutoLockCandidate: hydrateLockFromCandidate,
   });
   useBoardingLockScheduler({


### PR DESCRIPTION
## Summary
D4 (Epic #1204 — Lockless Trip 정확도 복구). 환승 leg 진입 시 backend가 새 trainCode를 영영 못 받아 `consecutiveEtaMissing` 임계 초과로 trip이 자동 종료되던 회귀를 차단한다.

- `BoardingLockSyncPayload`에 `trainCode?: string` + `boardingLine?: string` optional 필드 추가 (client + backend 양쪽 1:1 정합)
- `useBoardingLockSync`: 활성 lock의 trainCode/line을 sync payload에 동봉. 환승 leg에서 같은 역에 머무는 동안에도 trainCode 변경 시 1회 재발사하도록 `lastSentTrainCodeRef`로 dedup 확장
- `HomeScreen`이 `boardingLock?.trainCode` / `boardingLock?.boardingLine`을 hook에 전달
- backend `applyBoardingLockTrainCodeSwap` (신규 export, 순수 함수): payload trainCode가 KV `trip.boardingLock.trainCode`와 다르면 lock을 교체하고 `consecutiveEtaMissing`을 0으로 reset
- `validateBoardingLockSync`: 빈 문자열/비문자열 타입을 누락과 동일하게 처리 — 구버전 backend / lock 없는 trip 호환

## 호환성
- 양쪽 모두 optional — 구버전 client는 trainCode 미전송, 구버전 backend는 trainCode 무시
- `boardingLine` 단독 전송은 backend에서 무시 (trainCode가 primary key)
- payload trainCode === KV trainCode인 경우 no-op (lock TTL refresh만 적용)

## Test plan
- [x] client `boardingLockSync.test.ts` — payload trainCode/boardingLine forward + 미제공 시 키 부재
- [x] client `useBoardingLockSync.test.ts` — trainCode dedup, 환승 leg 재발사, force-trigger 경로
- [x] backend `validateBoardingLockSync` — optional 통과 / 빈문자열·비문자열 거부
- [x] backend `POST /boarding-lock/sync` — trainCode swap / no-op / line 보존 / lock 없는 trip
- [x] backend `applyBoardingLockTrainCodeSwap` 순수 함수 단위 테스트
- [x] `npm run type-check` pass
- [x] `npm test` — 4987 tests pass, 100% coverage
- [x] backend `npm test` — 1165 tests pass
- [x] `npm run lint` clean
- [ ] 실기기 환승 trip evidence — backend `boarding-lock: trainCode not found` 0건 + `consecutiveEtaMissing` 환승 직후 0 reset 확인

Closes #1210
Relates to #1204