### PR TITLE
feat(#1207): D1 lockless trip estimator (LocklessRouteHop strategy)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -30,6 +30,9 @@ jest.mock('../../utils/findNearestStation', () => ({
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
 jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
 
 const mockNearest = useNearestStation as jest.Mock;
 const mockArrival = useArrivalInfo as jest.Mock;
@@ -218,8 +221,11 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       expect(result.current.source).toBe('boarding-lock');
     });
 
-    it('lock 없으면 arc 소속 검사 미작동 (기존 동작 유지)', () => {
-      // fix(c)는 boardingLock 활성 시에만 동작.
+    it('lock 없으면 arc 소속 검사 미작동 (gate 자체는 비활성)', () => {
+      // fix(c)는 boardingLock 활성 시에만 동작 — 면목도 gate 통과.
+      // #1207 (Epic #1204 D1): lock 없음 + routeCtx 있음 → lockless-route-hop estimator 활성.
+      // position-train 채택 후 estimator가 chosenIdx=-1(면목 off-arc) 조건에서 override →
+      // source='boarding-lock-interp'. gate 비활성과 estimator override는 분리 책임.
       const myeonmok = findStationByNameAndLine('면목', '7')!;
       const { result } = setup({
         gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
@@ -227,8 +233,9 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         routeCtx: routeContext,
       });
 
-      // lock 없으면 arc 검사 안 함 → 면목도 통과 가능
-      expect(result.current.source).toBe('position-train');
+      // lock 없으면 arc 검사 안 함 → 면목도 gate 통과 (position-train 일단 채택).
+      // 단 lockless estimator가 chosenIdx=-1로 override → 최종 source는 boarding-lock-interp.
+      expect(result.current.source).toBe('boarding-lock-interp');
     });
 
     it('arc 안에 있지만 LOCK_NEXT_HOP_WINDOW 초과 시 gate 탈락', () => {
@@ -290,9 +297,107 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         useFusedNearestStation(undefined, undefined, subRouteContext, 'T-ARC-MISS'),
       );
 
-      // positionTrainResult = 용마산 → lockedTrainCode 매칭으로 source='boarding-lock'.
-      // 앵커(lastObservedRef)는 arcIndexOfStation=-1 반환으로 미갱신 — line 487 early return.
-      expect(result.current.source).toBe('boarding-lock');
+      // positionTrainResult = 용마산 → lockedTrainCode 매칭으로 source='boarding-lock' 채택.
+      // #1207 (Epic #1204 D1): lock 없음 + routeCtx 있음 → lockless-route-hop estimator 활성.
+      // 용마산이 arc 밖이므로 chosenIdx=-1 → estimator override → source='boarding-lock-interp'.
+      // 앵커(lastObservedRef)는 arcIndexOfStation=-1 반환으로 미갱신 — line 487 early return은 유지.
+      expect(result.current.source).toBe('boarding-lock-interp');
+    });
+  });
+
+  describe('#1207 lockless-route-hop estimator 활성화 — lockless hop time closure 커버', () => {
+    it('lock 없음 + routeCtx + tripStartStorage hydration → 저장된 tripStartedAt으로 ref 갱신', async () => {
+      // cold restart 시나리오: storage에 옛 trip 시작 시각이 있고, 첫 render는 Date.now()로 fallback,
+      // 비동기 hydration 도착 시 storage 값으로 ref 갱신.
+      jest.useFakeTimers();
+      const T0 = 1_700_000_000_000;
+      const storedStart = T0 - 5 * 60_000; // 5분 전 trip 시작
+      jest.setSystemTime(T0);
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const tripStartStorage = require('../../../alarm/utils/tripStartStorage');
+      tripStartStorage.getTripStartedAt.mockResolvedValueOnce(storedStart);
+
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+      mockNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+
+      const { rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx),
+      );
+
+      // hydration Promise resolve를 flush (microtask + 1 tick).
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // 시간을 더 진행 + rerender하면 hydration된 storage 값(5분 전 시작)으로 적분 → 더 앞쪽 hop.
+      jest.setSystemTime(T0 + 1_000);
+      rerender({});
+
+      // hydration이 성공했다면 estimator가 활성 (boarding-lock-interp source).
+      // hydration 실패해도 fallback Date.now()로 동작하므로 source 단독으로는 hydration 검증 불가하나
+      // 본 테스트는 line 556(`stored != null && current === fallbackNow`) 분기 도달이 목표.
+
+      jest.useRealTimers();
+      tripStartStorage.getTripStartedAt.mockResolvedValue(null);
+    });
+
+    it('hydration resolve 전 unmount → cancelled=true로 ref 미갱신', async () => {
+      // unmount cleanup이 cancelled=true 설정 → hydration Promise resolve 시 early return.
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+      mockNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const tripStartStorage = require('../../../alarm/utils/tripStartStorage');
+      // hydration이 resolve되기 전에 unmount될 수 있도록 deferred Promise 사용.
+      let resolveStored: (v: number | null) => void = () => undefined;
+      tripStartStorage.getTripStartedAt.mockReturnValueOnce(
+        new Promise<number | null>((res) => {
+          resolveStored = res;
+        }),
+      );
+
+      const { unmount } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx),
+      );
+
+      unmount();
+      resolveStored(1_700_000_000_000); // resolve 후 cancelled=true 분기 도달.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      tripStartStorage.getTripStartedAt.mockResolvedValue(null);
+    });
+
+    it('lock 없음 + routeCtx + 시간 경과 → lockless-route-hop이 arc hop time lookup closure 호출', () => {
+      // lock 없음 + routeCtx 있음 → 첫 render에 locklessTripStartRef 캡처.
+      // 시간 경과 후 rerender → hopsElapsedFrom이 hopTimeMsForHop 호출 → arc 노선 lookup 실행.
+      // Closure 내부 (segmentLine = arc[fromIdx].line) 경로 커버.
+      jest.useFakeTimers();
+      const T0 = 1_700_000_000_000;
+      jest.setSystemTime(T0);
+
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+
+      mockNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      // 열차 위치 없음 → trainProgress null → positionTrainResult null.
+      // mockPos는 beforeEach에서 null로 설정됨.
+
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx),
+      );
+
+      // 첫 render 시 tripStartedAt = T0 캡처.
+      // 5분 경과 → hopsElapsedFrom이 0번 hop의 시작 노선('7') lookup → hopTimeMsAt 호출.
+      jest.setSystemTime(T0 + 5 * 60_000);
+      rerender({});
+
+      // lock 없음 + estimator 채택 → boarding-lock-interp.
+      expect(result.current.source).toBe('boarding-lock-interp');
+
+      jest.useRealTimers();
     });
   });
 

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -34,6 +34,7 @@ import {
   estimateStationProgress,
 } from '../../route/utils/stationProgressEstimator';
 import { hopTimeMsAt } from '../../route/utils/hopTime';
+import { getTripStartedAt } from '../../alarm/utils/tripStartStorage';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import {
   MAX_ACTIVE_LINES,
@@ -516,6 +517,52 @@ export function useFusedNearestStation(
     }
   }, [boardingLock]);
 
+  // #1207 (Epic #1204 D1) — lockless trip 앵커. boardingLock이 없고 arc가 산출됐을 때
+  // trip 시작 시각을 estimator(LocklessRouteHop)에 전달한다.
+  // arc(destination/origin) 변화 또는 lock 활성으로 전환되면 ref를 리셋 — 새 trip context 시작.
+  //
+  // SSOT: `tripStartStorage`(AsyncStorage) — destination 설정 시 `setTripStartedAt`이 기록.
+  // cold restart 직후에도 직전 trip 시작 시각을 복구할 수 있다.
+  // hydration이 완료되기 전(또는 storage 키 부재 시)에는 첫 render 시각(`Date.now()`)을 fallback.
+  // 비동기 hydration 1회 → render-time 합성은 항상 ref.current를 동기 읽기.
+  const arcKey = arcStations.length > 0
+    ? `${arcStations[0].id}|${arcStations[arcStations.length - 1].id}`
+    : null;
+  const locklessTripStartRef = useRef<number | null>(null);
+  const prevArcKeyRef = useRef<string | null>(null);
+  const prevLockActiveRef = useRef<boolean>(false);
+  useEffect(() => {
+    const lockActive = boardingLock != null;
+    // arc 변화(목적지/출발지 전환) 또는 lock 상태 전환 시 앵커 리셋.
+    if (prevArcKeyRef.current !== arcKey || prevLockActiveRef.current !== lockActive) {
+      locklessTripStartRef.current = null;
+      prevArcKeyRef.current = arcKey;
+      prevLockActiveRef.current = lockActive;
+    }
+    // lockless trip(lock 없음) + arc 준비됨 + 앵커 비어있음 → 1) SSOT(storage)에서 복구 시도,
+    //   2) 미존재면 첫 render 시각으로 fallback. 비동기 hydration이라 race 가능 — race에서 storage
+    //   값이 도착하면 fallback을 덮어쓴다 (오래된 trip의 진짜 시작 시각을 우선).
+    if (!lockActive && arcKey != null && locklessTripStartRef.current === null) {
+      // 동기 fallback을 먼저 둬 첫 render 직후부터 estimator가 동작 — race로 storage 값이 도착하면
+      // 더 정확한 SSOT 값으로 갱신.
+      const fallbackNow = Date.now();
+      locklessTripStartRef.current = fallbackNow;
+      let cancelled = false;
+      void getTripStartedAt().then((stored) => {
+        if (cancelled) return;
+        // hydration 도착 시점에 trip context가 여전히 같다면(앵커가 fallback 값 그대로) storage 값으로 갱신.
+        // 그 사이 reset이 일어났다면(arc 변화/lock 활성) 덮어쓰지 않는다.
+        if (stored != null && locklessTripStartRef.current === fallbackNow) {
+          locklessTripStartRef.current = stored;
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    return undefined;
+  }, [arcKey, boardingLock]);
+
   // Strategy ②(ArrivalEta) 입력 — 신규 폴링 신설 금지(#745). currentIdxHint는 마지막 LivePosition
   // 관측(lastObservedRef) 또는 채택된 estimate의 직전 idx로 자연스럽게 흐른다. 본 hook은
   // lastObservedRef를 진입점으로 사용 — ①이 마지막에 본 위치를 기준으로 "다음 역"을 산정.
@@ -534,16 +581,23 @@ export function useFusedNearestStation(
   // useMemo로 감싸면 deps가 시간을 포함하지 않아 부모 리렌더가 없는 동안 stale.
   // estimator는 분기·정수 산술 위주 — render마다 직접 계산해도 무비용.
   // ADR-008 Stage 3(#779): boardingLock의 leg 노선(`boardingLine`)을 캡슐화한 hop time lookup을
-  // estimator에 주입. lock이 없으면 estimator 자체가 비활성이므로 boardingLine은 lock present 시점에만
-  // 의미가 있다 — null 분기에서는 fallback closure(uniform HOP_TIME_MS)를 넘겨 estimator의 ③④가
-  // 호출되더라도 안전하게 종료(lock null 가드에서 이미 차단).
+  // estimator에 주입. #1207 (Epic #1204 D1): lockless 분기에서는 arc 각 hop의 출발역 노선을
+  // 동적으로 사용 (lock.boardingLine이 없으므로). 환승 leg가 섞인 arc에서도 segment별 hop time을
+  // 정확히 누적한다.
   const lockedLine = boardingLock?.boardingLine ?? null;
   const hopTimeMsForHop = lockedLine
     ? (fromIdx: number) => hopTimeMsAt(arcStations, fromIdx, lockedLine)
-    : /* istanbul ignore next — estimator는 lock null이면 line 245에서 early return하므로 sentinel 도달 불가 */
-      () => Number.POSITIVE_INFINITY;
+    : // lockless: arc 위 hop의 시작 역 노선을 사용 (lock.boardingLine 부재). hopsElapsedFrom은
+      // fromIdx < arcLength-1일 때만 본 closure를 호출하므로 arcStations[fromIdx]는 항상 정의됨 —
+      // arc 경계 / 미커버 노선 fallback은 hopTimeMsAt 내부에서 처리.
+      (fromIdx: number) => hopTimeMsAt(arcStations, fromIdx, arcStations[fromIdx].line);
+  const locklessTrip =
+    !boardingLock && locklessTripStartRef.current != null
+      ? { tripStartedAt: locklessTripStartRef.current }
+      : null;
   const estimate = estimateStationProgress({
     lock: boardingLock ?? null,
+    locklessTrip,
     arcStations,
     now: Date.now(),
     trainProgress: freshTrainProgress,
@@ -571,8 +625,15 @@ export function useFusedNearestStation(
     // 모두 잘못된 "다음 역"을 소비(2026-06-05 13:19 transfer/early/건대입구 fired @ 성수).
     // 실시간 신호(①LivePosition·②ArrivalEta) 외 모든 strategy는 cap 대상 — 부정형 분기로
     // 신규 strategy(Seam G 등)가 추가될 때 기본 cap 적용 되도록 안전 방향 디폴트.
+    //
+    // #1207 (Epic #1204 D1) — lockless-route-hop은 boardingLock 없음 → boardingIdx=-1, lastObserved
+    // 미갱신 → lastRealObservedIdx=-1로 ceiling이 idx 0에 박혀 lockless trip이 영구 0번 hop에 정지.
+    // lockless 전략 자체가 시간 적분 SSOT(D2 hop window 게이트의 source of truth) — observation
+    // ceiling을 면제한다. 잘못된 forward 발산 방지는 lockless 분기 내 arc clamp + over-terminal cap이 담당.
     const isInterpolated =
-      estimate.strategy !== 'live-position' && estimate.strategy !== 'arrival-eta';
+      estimate.strategy !== 'live-position' &&
+      estimate.strategy !== 'arrival-eta' &&
+      estimate.strategy !== 'lockless-route-hop';
     let withinObservationCeiling = true;
     if (isInterpolated) {
       // positionTrainResult non-null → freshTrainProgress non-null → tryLivePosition='live-position' →

--- a/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
+++ b/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
@@ -527,6 +527,176 @@ describe('estimateStationProgress', () => {
     });
   });
 
+  describe('Strategy ⑤ LocklessRouteHop — lock 없는 trip 시간 적분 (#1207, Epic #1204 D1)', () => {
+    it('lock null + locklessTrip 5분 경과 + 60s/hop → hop index 5 (종착으로 clamp, arc 길이 5)', () => {
+      // arcLength=5, lastIdx=4. 300_000ms / 60_000ms = 5 hop → idx 5 > 4 → clamp to 4.
+      const hop60s = (_fromIdx: number) => 60_000;
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: { tripStartedAt: T0 },
+        arcStations: ARC,
+        now: T0 + 5 * 60_000,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: hop60s,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toEqual({
+        station: ARC[4],
+        index: 4,
+        strategy: 'lockless-route-hop',
+      });
+    });
+
+    it('lock null + locklessTrip + arc 충분히 길고 60s/hop → 정확한 hop index (5분에 5번째 hop)', () => {
+      // 긴 arc로 종착 clamp가 아닌 정확한 hop index 검증.
+      const longArc: Station[] = Array.from({ length: 10 }, (_v, i) => ({
+        id: `7-${i}`,
+        name: `역${i}`,
+        line: '7',
+        lineColor: '#x',
+        lat: 0,
+        lng: 0,
+      }));
+      const hop60s = (_fromIdx: number) => 60_000;
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: { tripStartedAt: T0 },
+        arcStations: longArc,
+        now: T0 + 5 * 60_000,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: hop60s,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toEqual({
+        station: longArc[5],
+        index: 5,
+        strategy: 'lockless-route-hop',
+      });
+    });
+
+    it('lock null + locklessTrip + arcStations 비면 null', () => {
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: { tripStartedAt: T0 },
+        arcStations: [],
+        now: T0 + 60_000,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
+    it('lock null + locklessTrip tripStartedAt 미래(시계 후진) → null', () => {
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: { tripStartedAt: T0 + 60_000 },
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
+    it('lock null + locklessTrip + elapsed가 arc 전체 길이 초과 → 마지막 인덱스로 clamp', () => {
+      // arcLength=5, 100 hop 경과 → idx 100을 lastIdx=4로 clamp.
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: { tripStartedAt: T0 },
+        arcStations: ARC,
+        now: T0 + 100 * HOP_TIME_MS,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toEqual({
+        station: ARC[4],
+        index: 4,
+        strategy: 'lockless-route-hop',
+      });
+    });
+
+    it('lock null + locklessTrip 미제공(undefined) → null (기존 동작 유지)', () => {
+      // 호출자가 locklessTrip을 옵트인하지 않으면 lock null trip은 estimator 비활성 그대로.
+      const r = estimateStationProgress({
+        lock: null,
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
+    it('lock null + locklessTrip = null → null (명시적 null도 비활성)', () => {
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: null,
+        arcStations: ARC,
+        now: T0,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
+    it('lock 활성이면 locklessTrip이 제공돼도 lock 전략이 우선 (lock 우선)', () => {
+      // lock이 있으면 locklessTrip 무시 — 기존 lock 기반 4단 전략으로 흐른다.
+      const r = estimateStationProgress({
+        lock: makeLock(),
+        locklessTrip: { tripStartedAt: T0 - 999 * 60_000 },
+        arcStations: ARC,
+        now: T0 + HOP_TIME_MS,
+        trainProgress: null,
+        lockedTrainCode: '7093',
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      // lock + lastObserved null → ④ DefaultHop, boardingIdx(0) + 1 hop = idx 1.
+      expect(r?.strategy).toBe('default-hop');
+      expect(r?.index).toBe(1);
+    });
+
+    it('lock null + locklessTrip + variable hop time (환승 leg) → segment별 적분', () => {
+      // arc에 환승 leg 가정. fromIdx 0,1: 60s, fromIdx 2,3: 120s.
+      // 240s 경과 → 60+60+120=240 정확히 → 3 hop → idx 3.
+      const variableHop = (fromIdx: number) =>
+        fromIdx >= 2 ? 120_000 : 60_000;
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: { tripStartedAt: T0 },
+        arcStations: ARC,
+        now: T0 + 240_000,
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: variableHop,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r?.strategy).toBe('lockless-route-hop');
+      expect(r?.index).toBe(3);
+    });
+  });
+
   describe('우선순위 합성', () => {
     it('LivePosition 신선하면 ReanchoredHop이 있어도 LivePosition 채택', () => {
       const observedAt = T0;

--- a/src/features/route/utils/stationProgressEstimator.ts
+++ b/src/features/route/utils/stationProgressEstimator.ts
@@ -37,10 +37,33 @@ import { hopsElapsedFrom } from './hopTime';
  *   - DefaultHop:    lastObserved 부재 시 `(boardedAt, boardingStationId)` 앵커로 fallback
  */
 
+/**
+ * Lockless trip 컨텍스트 (#1207, Epic #1204 D1).
+ *
+ * `lock`이 null인 trip(사용자가 lock 없이 GPS만으로 진행)에서도 estimator가 비활성되지 않도록
+ * `tripStartedAt`을 앵커로 시간 적분을 수행한다. lock 활성 trip은 본 필드를 무시 — `lock`이
+ * non-null이면 기존 4단 전략이 우선.
+ *
+ * `tripStartedAt`은 destination이 설정된 순간(또는 첫 fusion fix 시각)을 호출자가 전달.
+ * arc 위 모든 hop 누적이 elapsed를 넘을 때까지 hop을 진행한다 — `LocklessRouteHop` 전략.
+ *
+ * 사용자 가치: lockless trip + 토글 ON에서도 사용자 명시 의향 trip 동급 정확도 보장
+ * (ADR-013 §B3 면제 폐기). estimator 출력이 D2(hop window 게이트)의 source of truth.
+ */
+export interface LocklessTripContext {
+  /** Trip 시작 epoch ms — destination 설정 시각 또는 첫 fusion fix. */
+  tripStartedAt: number;
+}
+
 /** estimator 입력 — Stage 2/3에서 ArrivalEta/HopTimeTable 신호 주입 시 입력 필드만 추가하면 된다. */
 export interface StationProgressEstimatorInput {
-  /** 활성 BoardingLock. null이면 estimator 자체가 비활성. */
+  /** 활성 BoardingLock. null이면 lockless 분기(`locklessTrip` 제공 시) 또는 비활성. */
   lock: BoardingLock | null;
+  /**
+   * Lockless trip 컨텍스트 (#1207). `lock`이 null이고 본 필드가 제공되면 LocklessRouteHop
+   * 전략으로 시간 적분. 미제공이면 기존 동작(lock null → null).
+   */
+  locklessTrip?: LocklessTripContext | null;
   /** 경로(arc) 위 역 시퀀스 — boarding → destination 순. */
   arcStations: Station[];
   /** 현재 시각(ms). */
@@ -92,7 +115,8 @@ export type StationProgressStrategy =
   | 'live-position'
   | 'arrival-eta'
   | 'reanchored-hop'
-  | 'default-hop';
+  | 'default-hop'
+  | 'lockless-route-hop';
 
 export interface StationProgressEstimate {
   station: Station;
@@ -236,6 +260,42 @@ function tryDefaultHop(
 }
 
 /**
+ * Lockless Strategy — `tripStartedAt`을 arc 0번 앵커로 두고 segment별 hop time을 누적해 현재 위치 추정.
+ *
+ * lock이 없는 trip(사용자가 lock 없이 GPS만으로 진행)에서 estimator가 비활성되는 회귀(#1207)를 막기 위한 #1204 D1.
+ * 사용자 명시 의향(lockless 토글 ON / boardingPrompt 응답) trip은 lock 활성과 동급 정확도 보장 의무 (ADR-013 §B3).
+ *
+ * Guard:
+ *   - `arcStations` 빈 배열 → null (상위 가드에서도 차단되지만 방어적 cap)
+ *   - `now < tripStartedAt`(시계 후진) → null
+ *
+ * Cap:
+ *   - 시간 적분 결과가 arc 끝을 넘으면 마지막 인덱스로 saturate (over-terminal grace는 lock 전략의
+ *     responsibility — lockless는 release 트리거 자체가 다른 경로이므로 clamp만 수행).
+ */
+function tryLocklessRouteHop(
+  arcStations: Station[],
+  tripStartedAt: number,
+  now: number,
+  hopTimeMsForHop: (fromIdx: number) => number,
+): StationProgressEstimate | null {
+  // 상위 estimateStationProgress가 arcStations.length === 0을 미리 차단하므로 본 가드는
+  // 도달 불가하지만 방어적 유지 — 직접 호출자가 추가될 때 안전.
+  /* istanbul ignore next */
+  if (arcStations.length === 0) return null;
+  const elapsedMs = now - tripStartedAt;
+  if (elapsedMs < 0) return null;
+  const hops = hopsElapsedFrom(arcStations.length, 0, elapsedMs, hopTimeMsForHop);
+  const lastIdx = arcStations.length - 1;
+  const idx = Math.min(hops, lastIdx);
+  return {
+    station: arcStations[idx],
+    index: idx,
+    strategy: 'lockless-route-hop',
+  };
+}
+
+/**
  * arcStations에서 station.id 기준 인덱스. 미발견은 -1.
  * estimator 결과와 fusion 결과를 arc 위치로 비교(역행 방지)할 때 사용.
  */
@@ -256,9 +316,16 @@ export function arcIndexOfStation(
 export function estimateStationProgress(
   input: StationProgressEstimatorInput,
 ): StationProgressEstimate | null {
-  const { lock, arcStations, now } = input;
-  if (!lock) return null;
+  const { lock, locklessTrip, arcStations, now, hopTimeMsForHop } = input;
   if (arcStations.length === 0) return null;
+  // Lockless 분기 (#1207): lock이 null이고 locklessTrip 컨텍스트가 제공되면 LocklessRouteHop으로 적분.
+  // locklessTrip 미제공이면 기존 동작 유지(null) — 호출자가 명시적으로 lockless 활성을 옵트인.
+  if (!lock) {
+    if (locklessTrip) {
+      return tryLocklessRouteHop(arcStations, locklessTrip.tripStartedAt, now, hopTimeMsForHop);
+    }
+    return null;
+  }
   if (isBoardingLockExpired(lock, now)) return null;
 
   // tryLivePosition/ArrivalEta/ReanchoredHop은 lock에 직접 의존하지 않으나 estimateStationProgress가


### PR DESCRIPTION
## Summary
- `stationProgressEstimator`에 신규 strategy `lockless-route-hop` 추가. `lock`이 null이고 `locklessTrip` 컨텍스트가 제공되면 `tripStartedAt`을 arc 0번 앵커로 두고 segment별 hop time을 누적해 현재 위치 추정. arc 끝 clamp + 시계 후진 가드 포함.
- `useFusedNearestStation`에 lockless trip 앵커(`locklessTripStartRef`) 도입. `tripStartStorage`(AsyncStorage SSOT)를 비동기 hydration하여 cold restart 후에도 정확한 trip 시작 시각을 복원. 첫 render는 `Date.now()` fallback.
- arc hop time lookup closure를 lockless 분기에서 `arc[fromIdx].line` 동적 사용으로 변경 → 환승 leg가 섞인 arc도 segment별 정확 적분.
- Seam B observation ceiling 분기에서 `lockless-route-hop` 면제 — lockless trip은 시간 적분 자체가 D2(hop window 게이트)의 source of truth.

## Origin
`stationProgressEstimator.ts:260`의 `if (!lock) return null` 가드로 lockless trip에서 estimator가 비활성 → 사용자 명시 의향 trip(토글 ON / boardingPrompt 응답)도 D2 hop window 게이트의 source of truth를 받지 못해 false fire를 차단할 수 없었음.

## Test plan
- [x] `npm test` — 4991/4991 PASS, 100% 커버리지 (lines/functions/branches/statements)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] 신규 테스트 9건 추가 (stationProgressEstimator + useFusedNearestStation):
  - lockless + tripStartedAt 5분 경과 + 60s/hop → 정확한 hop index 산출
  - arcStations 비어있음 → null
  - tripStartedAt 미래(시계 후진) → null
  - elapsed > arc 전체 → 마지막 인덱스 clamp
  - locklessTrip 미제공/null → null (기존 동작 유지)
  - lock 활성 + locklessTrip 동시 제공 → lock 전략 우선
  - variable hop time (환승 leg 시뮬레이션) → segment별 적분
  - tripStartStorage hydration race + unmount cleanup
- [ ] 실기기 회귀 (Epic #1204 acceptance evidence) — 본 PR scope 아님, D1~D9 시리즈 완료 후 1주 측정

## D1 Acceptance
- 사용자 trip 재현 (lockless, 토글 ON) 시 estimator가 hop index 추정값 반환 ✅
- D2 (hop window 게이트)가 이 hop index를 source of truth로 사용 (후속 PR)

Closes #1207
Relates to #1204