### PR TITLE
fix(#1212): D6 sticky station trip 활성 + 지하 유지

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1185,15 +1185,29 @@ describe('useNearestStation — #903 Seam G barometer→sticky', () => {
   });
 
   it.each([
-    { label: '기본(미전달) → automotive=false', input: undefined, expected: false },
-    { label: 'barometerSubsurface=true → automotive=true', input: true, expected: true },
+    { label: '기본(미전달) → automotive=false, subsurface=false', input: undefined, expected: false },
+    { label: 'barometerSubsurface=true → automotive=true, subsurface=true', input: true, expected: true },
     { label: 'barometerSubsurface=false → automotive=false (graceful)', input: false, expected: false },
   ])('$label', async ({ input, expected }) => {
     const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
     renderHook(() => useNearestStation(input === undefined ? {} : { barometerSubsurface: input }));
     await waitFor(() => expect(spy).toHaveBeenCalled());
     const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
-    expect(lastCall[1]).toEqual({ automotive: expected });
+    // D6 (#1212) — motion 입력에 subsurface(=barometerSubsurface mirror) + tripActive 추가.
+    expect(lastCall[1]).toEqual({ automotive: expected, subsurface: expected, tripActive: false });
+    spy.mockRestore();
+  });
+
+  // D6 (#1212) — tripActive 입력이 sticky motion에 전달되는지 검증.
+  it.each([
+    { label: 'tripActive=true 전달', input: true, expected: true },
+    { label: 'tripActive=false 전달', input: false, expected: false },
+  ])('$label', async ({ input, expected }) => {
+    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
+    renderHook(() => useNearestStation({ tripActive: input }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(lastCall[1]).toEqual(expect.objectContaining({ tripActive: expected }));
     spy.mockRestore();
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
@@ -279,6 +279,46 @@ describe('useStickyStation (#876)', () => {
     await waitFor(() => expect(removeSpy).toHaveBeenCalledWith(STICKY_STATION_KEY));
   });
 
+  // D6 (#1212) — trip 활성 + 지하 시 sticky 유지 검증.
+  describe('D6 (#1212) — trip 활성 + 지하 시 sticky 유지', () => {
+    const lockSeoul = async (motion: StickyMotionInput) => {
+      const hook = renderSticky({ fix: fixAt(seoul), motion });
+      await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+      hook.rerender({ fix: fixAt(seoul), motion });
+      hook.rerender({ fix: fixAt(seoul), motion });
+      await waitFor(() => expect(hook.result.current.locked?.id).toBe(seoul.id));
+      return hook;
+    };
+
+    it('지하 + trip 활성 + automotive → unlock 보류 (lock 유지)', async () => {
+      const motion: StickyMotionInput = { subsurface: true, tripActive: true };
+      const { result, rerender } = await lockSeoul(motion);
+      // automotive=true가 들어와도 subsurface+tripActive 동시 → unlock 안 함.
+      rerender({ fix: fixAt(seoul), motion: { ...motion, automotive: true } });
+      expect(result.current.locked?.id).toBe(seoul.id);
+    });
+
+    it('지하 + trip 활성 + 멀리 떨어진 좋은 fix → distance unlock 보류', async () => {
+      const motion: StickyMotionInput = { subsurface: true, tripActive: true };
+      const { result, rerender } = await lockSeoul(motion);
+      // 강남역(10km+) 좋은 fix가 들어와도 지하 dead-zone 의심 → unlock 안 함.
+      rerender({ fix: fixAt(gangnam), motion });
+      expect(result.current.locked?.id).toBe(seoul.id);
+    });
+
+    it('지하 + trip 미활성 + automotive → 기존 unlock 동작 (lock 해제)', async () => {
+      const { result, rerender } = await lockSeoul({});
+      rerender({ fix: fixAt(seoul), motion: { automotive: true, subsurface: true, tripActive: false } });
+      await waitFor(() => expect(result.current.locked).toBeNull());
+    });
+
+    it('지상 + trip 활성 + automotive → 기존 unlock 동작 (차/도보 환승 가능)', async () => {
+      const { result, rerender } = await lockSeoul({});
+      rerender({ fix: fixAt(seoul), motion: { automotive: true, subsurface: false, tripActive: true } });
+      await waitFor(() => expect(result.current.locked).toBeNull());
+    });
+  });
+
   it('candidate=null 상태에서는 카운트 안 함', async () => {
     const { result, rerender } = renderSticky({ fix: fixAt(null) });
     await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -234,7 +234,10 @@ export function useFusedNearestStation(
 ): UseFusedNearestStationReturn {
   const barometerSubsurface = barometer?.subsurface;
   const barometerSignal = barometer?.signal;
-  const gps = useNearestStation({ barometerSubsurface });
+  // D6 (#1212) — trip 활성(origin+destination+route 모두 채워진 상태)을 sticky 게이트에 전달.
+  // routeContext는 HomeScreen에서 trip 시작 시 채워지고 종료 시 undefined로 돌아간다.
+  const tripActive = routeContext != null;
+  const gps = useNearestStation({ barometerSubsurface, tripActive });
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
   // useNearestStation의 userLocation 변경마다 자동 누적/판정.
   const positionStability = usePositionStability(gps.userLocation);

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -113,6 +113,11 @@ export interface UseNearestStationInputs {
    * 무관하게 지상→지하 전이를 가장 일찍 감지하므로 sticky의 motion unlock 트리거로 사용한다.
    */
   barometerSubsurface?: boolean;
+  /**
+   * D6 (#1212) — trip(목적지/경로) 활성 여부. sticky 게이트에 전달되어 trip 활성 + 지하 조합에서
+   * sticky unlock(motion/distance) 보류. 미전달이면 false로 간주(기존 동작 보존).
+   */
+  tripActive?: boolean;
 }
 
 export function useNearestStation(
@@ -401,7 +406,13 @@ export function useNearestStation(
       accuracyMeters,
       speedMps,
     },
-    { automotive: inputs.barometerSubsurface === true },
+    {
+      automotive: inputs.barometerSubsurface === true,
+      // D6 (#1212) — subsurface + tripActive를 sticky 게이트에 직접 전달.
+      // automotive=subsurface 매핑은 유지하되, 지하 + trip 활성 조합에서는 unlock 보류.
+      subsurface: inputs.barometerSubsurface === true,
+      tripActive: inputs.tripActive === true,
+    },
   );
 
   const exposed = useMemo<{ result: NearestStationResult | null; source: NearestStationSource }>(

--- a/src/features/nearest-station/hooks/useStickyStation.ts
+++ b/src/features/nearest-station/hooks/useStickyStation.ts
@@ -48,6 +48,16 @@ export interface StickyFixInput {
 export interface StickyMotionInput {
   /** automotive=true면 차/지하철 이동 확정으로 간주 — unlock 트리거. */
   automotive?: boolean;
+  /**
+   * D6 (#1212) — 기압계가 지하 진입을 시사하는지. 지하 + trip 활성 시 automotive 신호는
+   * 지하철 탑승의 정상 신호로 간주하여 sticky를 풀지 않는다. distance 게이트도 같은 조합에서 보류.
+   */
+  subsurface?: boolean;
+  /**
+   * D6 (#1212) — trip(목적지/경로) 활성 여부. 지하 dead-zone GPS로 sticky가 잘못 풀려
+   * "탑승 중 노선 정보 사라짐" 회귀가 발생하던 케이스 차단.
+   */
+  tripActive?: boolean;
 }
 
 export interface UseStickyStationReturn {
@@ -180,6 +190,8 @@ export function useStickyStation(
           lat: candidate.station.lat,
           lng: candidate.station.lng,
           accuracyMeters,
+          subsurface: motion.subsurface,
+          tripActive: motion.tripActive,
         })
       ) {
         // distance unlock은 즉시 — 새 후보 카운트는 다음 fix부터 시작. better-fix 갱신을 같은 effect에서

--- a/src/features/nearest-station/utils/__tests__/stickyStationGates.test.ts
+++ b/src/features/nearest-station/utils/__tests__/stickyStationGates.test.ts
@@ -101,6 +101,19 @@ describe('shouldUnlockByDistance', () => {
     // 게이트 의미가 ">"인지 ">="인지 명확히 한다 — 구현은 ">"(초과)로 정의.
     expect(exactlyAtThreshold).toBeGreaterThan(0);
   });
+
+  // D6 (#1212) — trip 활성 + 지하 케이스. 강남역 좌표는 서울역에서 ~10km로 거리 게이트 통과.
+  const farFromLocked = { lat: 37.4979, lng: 127.0276, accuracyMeters: 20 };
+  it.each<[string, { subsurface?: boolean; tripActive?: boolean }, boolean]>([
+    ['subsurface=true + tripActive=true → 지하 dead-zone 부정확 좌표 의심 → false', { subsurface: true, tripActive: true }, false],
+    ['subsurface=true + tripActive=false → 기존 동작 → true', { subsurface: true, tripActive: false }, true],
+    ['subsurface=false + tripActive=true → 지상 trip(차/도보) → true', { subsurface: false, tripActive: true }, true],
+    ['둘 다 미정의 → 기존 동작 → true', {}, true],
+  ])('%s', (_label, flags, expected) => {
+    expect(
+      shouldUnlockByDistance(seoulStation, { ...farFromLocked, ...flags }),
+    ).toBe(expected);
+  });
 });
 
 describe('shouldUnlockByTtl', () => {
@@ -134,5 +147,16 @@ describe('shouldUnlockByMotion', () => {
 
   it('automotive 미정의 (motion 신호 없음) → false (보수적 — 풀지 않음)', () => {
     expect(shouldUnlockByMotion({})).toBe(false);
+  });
+
+  // D6 (#1212) — trip 활성 + 지하 케이스 매트릭스
+  it.each<[string, { automotive?: boolean; subsurface?: boolean; tripActive?: boolean }, boolean]>([
+    ['automotive=true + subsurface=true + tripActive=true → 지하철 탑승 정상 신호 → false', { automotive: true, subsurface: true, tripActive: true }, false],
+    ['automotive=true + subsurface=true + tripActive=false → trip 미활성, 풀어도 영향 적음 → true', { automotive: true, subsurface: true, tripActive: false }, true],
+    ['automotive=true + subsurface=false + tripActive=true → 지상 trip은 차/도보 환승 가능 → true', { automotive: true, subsurface: false, tripActive: true }, true],
+    ['automotive=true + subsurface=true (tripActive 미정의) → false로 간주, 기존 동작 → true', { automotive: true, subsurface: true }, true],
+    ['automotive=true + tripActive=true (subsurface 미정의) → false로 간주, 기존 동작 → true', { automotive: true, tripActive: true }, true],
+  ])('%s', (_label, motion, expected) => {
+    expect(shouldUnlockByMotion(motion)).toBe(expected);
   });
 });

--- a/src/features/nearest-station/utils/stickyStationGates.ts
+++ b/src/features/nearest-station/utils/stickyStationGates.ts
@@ -24,6 +24,16 @@ export interface StickyPositionInput {
   lat: number;
   lng: number;
   accuracyMeters: number | null;
+  /**
+   * D6 (#1212) — 기압계가 지하 진입을 시사하는지. trip 활성 + 지하면 GPS 거리 게이트도
+   * 신뢰할 수 없다 — dead-zone에서 부정확한 좌표가 1km+ 점프해 sticky가 잘못 풀리는 케이스 차단.
+   */
+  subsurface?: boolean;
+  /**
+   * D6 (#1212) — trip(목적지/경로) 활성 여부. 사용자가 trip 중이면 sticky를 풀어도
+   * 의미가 없고(현재역은 trip context로 확정), 지하 dead-zone GPS로 풀리면 회귀를 유발한다.
+   */
+  tripActive?: boolean;
 }
 
 /**
@@ -56,6 +66,9 @@ export function isGoodFix(fix: StickyFixInput): boolean {
 export function shouldUnlockByDistance(locked: Station, fix: StickyPositionInput): boolean {
   const { accuracyMeters } = fix;
   if (accuracyMeters == null || accuracyMeters > STICKY_GOOD_FIX_ACCURACY_M) return false;
+  // D6 (#1212) — trip 활성 + 지하면 GPS 1km+ 점프는 dead-zone 부정확 좌표 가능성이 높다.
+  // 지상 trip은 그대로 평가(차로 1km 이동 가능).
+  if (fix.tripActive === true && fix.subsurface === true) return false;
   const distanceKm = haversine(locked.lat, locked.lng, fix.lat, fix.lng);
   return distanceKm > STICKY_UNLOCK_DISTANCE_KM;
 }
@@ -76,8 +89,22 @@ export function shouldUnlockByTtl(lockedAt: number, now: number): boolean {
  */
 export interface StickyMotionInput {
   automotive?: boolean;
+  /**
+   * D6 (#1212) — 기압계가 지하 진입을 시사하는지. 지하 + trip 활성 시 automotive=true는
+   * 지하철 탑승이라는 정상 신호 — 이 조합에서는 sticky를 풀지 않는다.
+   */
+  subsurface?: boolean;
+  /**
+   * D6 (#1212) — trip(목적지/경로) 활성 여부. ADR-010 첫 줄(false positive / miss 동급)에 따라
+   * 사용자 명시 의향 trip은 lock 활성과 동급으로 정확도를 보장한다.
+   */
+  tripActive?: boolean;
 }
 
 export function shouldUnlockByMotion(motion: StickyMotionInput): boolean {
-  return motion.automotive === true;
+  if (motion.automotive !== true) return false;
+  // D6 (#1212) — 지하 + trip 활성 시 automotive는 지하철 탑승의 정상 신호.
+  // 지상 trip은 차/도보 환승 가능성이 있어 그대로 unlock 허용.
+  if (motion.subsurface === true && motion.tripActive === true) return false;
+  return true;
 }


### PR DESCRIPTION
## Summary

지하 dead-zone에서 GPS가 부정확한 좌표를 보고하거나 CMMotionActivity가 automotive=true로 보고할 때, trip 활성 상태에서 sticky station이 잘못 풀려 "탑승 중 노선 정보가 사라지는" 회귀(D6)를 차단한다.

### 변경
- `shouldUnlockByMotion`: `subsurface && tripActive`면 automotive=true는 지하철 탑승의 정상 신호로 간주하여 unlock 보류
- `shouldUnlockByDistance`: 같은 조합에서 1km+ 점프는 dead-zone 부정확 좌표 가능성이 높아 unlock 보류
- `StickyMotionInput` / `StickyPositionInput`에 optional `subsurface`, `tripActive` 추가 (미전달 시 기존 동작 보존)
- `useNearestStation`이 `tripActive` 입력을 받아 sticky 게이트에 prop drilling
- `useFusedNearestStation`이 `routeContext != null`을 tripActive로 매핑 (HomeScreen은 이미 routeContext 전달 중 → 추가 변경 불필요)

### 동작 매트릭스 (motion 게이트)
| automotive | subsurface | tripActive | unlock? |
| --- | --- | --- | --- |
| true | true | true | **false (보류)** |
| true | true | false | true |
| true | false | true | true (지상 trip, 차/도보 환승 가능) |
| true | false | false | true |
| false | * | * | false |

distance 게이트도 동일 매트릭스(좋은 fix + trip + 지하 시 보류).

Closes #1212
Relates to #1204

## Test plan
- [x] `npm test` — 4994 passed, coverage 100%
- [x] `npm run type-check` — pass
- [x] `npm run lint` — pass
- [x] CI / Type Check & Test
- [x] E2E Smoke (mock mode) — UI 영향 경로 변경 감지 시 실행
- [x] 실기기 회귀 확인 (지하 trip 중 sticky 유지)