### PR TITLE
feat(#1215): D9 DebugModal 상태 가시화

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -62,6 +62,57 @@ import {
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import type { NearestStationResult } from '../../../shared/types/station';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+import { useBarometer } from '../../../shared/hooks/useBarometer';
+
+/**
+ * #1215 (D9) — DebugModal 상태 가시화 신규 prop 묶음.
+ * D1(lockless estimator)/D8(sleep rule wiring) PR 미머지 환경에서도 동작하도록 모두 optional.
+ * 미정의는 UI/dump에서 'unknown'으로 표기 — "신호 없음"과 "신호=false"를 명시적으로 구분.
+ */
+export interface FusionDetectionSummary {
+  /** stationDetectionFusion confidence — 'high' | 'medium' | 'low'. */
+  tier: string;
+  /** signal mask 문자열 (예: 'TFT', 'UUU') — 순서는 STATION_DETECTION_SIGNALS 따름. */
+  signalMask: string;
+}
+
+export interface TripDebugState {
+  /** lockless trip 여부. true면 BoardingLock 없이 사용자 명시 의향만으로 진행 중. */
+  lockless: boolean;
+  /** trip 시작 시각 (ms epoch). null이면 미정. */
+  tripStartedAt: number | null;
+  /** D1 estimator 출력 hop index. undefined면 D1 미머지 또는 estimator null. */
+  currentHopIndex: number | null | undefined;
+  /** 경로 arcStations 총 개수. */
+  routeHopCount: number | null;
+}
+
+export interface SleepDebugState {
+  sleepMode: boolean;
+  /** shouldSuppressBySleepRule의 isFirstHop 입력 — 첫 hop 향하는 중인가. */
+  firstHopApproaching: boolean;
+}
+
+const UNKNOWN_LABEL = '—';
+
+function formatOptionalBool(value: boolean | null | undefined): string {
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  return UNKNOWN_LABEL;
+}
+
+function formatOptionalString(value: string | null | undefined): string {
+  return value == null || value === '' ? UNKNOWN_LABEL : value;
+}
+
+function formatOptionalNumber(value: number | null | undefined): string {
+  return value == null ? UNKNOWN_LABEL : String(value);
+}
+
+function formatOptionalTs(value: number | null | undefined): string {
+  if (value == null) return UNKNOWN_LABEL;
+  return new Date(value).toISOString();
+}
 
 function formatTime(ts: number): string {
   const d = new Date(ts);
@@ -283,6 +334,11 @@ function buildDumpText(args: {
   locklessOn?: boolean;
   // #756: OS 큐 dump. 미전달/null = DebugModal에서 한 번도 Refresh 안 한 상태.
   scheduledDump?: ScheduledNotificationDumpEntry[] | null;
+  // #1215 (D9) — 추가 상태 가시화. 모두 optional — 미전달 시 dump의 해당 라인은 '—' 표기.
+  barometerSubsurface?: boolean | null;
+  fusionDetection?: FusionDetectionSummary | null;
+  trip?: TripDebugState | null;
+  sleep?: SleepDebugState | null;
 }): string {
   const lines: string[] = [];
   // SonarCloud S7778: 인접한 정적 push 호출은 다인자 단일 호출로 묶는다.
@@ -307,6 +363,7 @@ function buildDumpText(args: {
     '## GPS',
     ...gpsLines,
     `state=${args.gpsActive ?? 'fg'}, lastFix=${formatClockTimeWithSeconds(args.lastFixAtMs ?? null)}`,
+    `subsurface=${formatOptionalBool(args.barometerSubsurface)}`,
     '',
     '## Nearest',
     args.nearestName
@@ -329,6 +386,28 @@ function buildDumpText(args: {
       `candidateTrains(${args.fusion.candidateTrains.length}): ${args.fusion.candidateTrains.join(', ') || '-'}`,
     );
   }
+  // #1215 (D9) — tier / signalMask
+  lines.push(
+    `tier=${formatOptionalString(args.fusionDetection?.tier)}`,
+    `signalMask=${formatOptionalString(args.fusionDetection?.signalMask)}`,
+  );
+  // #1215 (D9) — Trip 섹션
+  lines.push(
+    '',
+    '## Trip',
+    `lockless=${formatOptionalBool(args.trip?.lockless)}`,
+    `tripStartedAt=${formatOptionalTs(args.trip?.tripStartedAt ?? null)}`,
+    `currentHopIndex=${formatOptionalNumber(args.trip?.currentHopIndex)}`,
+    `route hop count=${formatOptionalNumber(args.trip?.routeHopCount ?? null)}`,
+  );
+  // #1215 (D9) — Sleep 섹션
+  const sleepModeText = args.sleep ? (args.sleep.sleepMode ? 'on' : 'off') : UNKNOWN_LABEL;
+  lines.push(
+    '',
+    '## Sleep',
+    `sleepMode=${sleepModeText}`,
+    `firstHopApproaching=${formatOptionalBool(args.sleep?.firstHopApproaching)}`,
+  );
   lines.push('', '## Arrival', args.arrivalSummary);
   if (args.isMock) lines.push('(MOCK)');
   lines.push('', '## Silent Push');
@@ -422,6 +501,22 @@ interface DebugModalProps {
    * 클라 자체 산출 함수는 #819 후속.
    */
   fusedSpeed?: FusedSpeedSignal;
+  /**
+   * #1215 (D9) — Fusion 섹션에 노출할 detection verdict 요약(tier/signalMask).
+   * SSOT는 `useFusedStationDetection` 결과. DebugModal은 호출부가 명시적으로 주입.
+   * 미전달 시 두 row 모두 `—`로 표기.
+   */
+  fusionDetection?: FusionDetectionSummary;
+  /**
+   * #1215 (D9) — lockless trip 진행도. D1 estimator 미머지 환경에서도 graceful.
+   * currentHopIndex가 `undefined`면 D1 미머지(unknown 표기), `null`이면 estimator null 반환.
+   */
+  trip?: TripDebugState;
+  /**
+   * #1215 (D9) — 취침모드 + 첫 hop 향하는지(=sleep rule suppress 트리거 조건).
+   * D8 미머지면 미전달 가능 — Sleep 섹션 두 row가 `—`로 표기.
+   */
+  sleep?: SleepDebugState;
 }
 
 // 디버그 모달은 측정 인프라 — 관찰자 효과를 피하려고 모달이 열린 동안에만 마운트한다.
@@ -434,7 +529,14 @@ export function DebugModal(props: DebugModalProps) {
   return <DebugModalInner {...props} />;
 }
 
-function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<DebugModalProps>) {
+function DebugModalInner({
+  onClose,
+  candidateTrains,
+  fusedSpeed,
+  fusionDetection,
+  trip,
+  sleep,
+}: Readonly<DebugModalProps>) {
   const { colors } = useTheme();
   // #458: RN Modal 안에서는 SafeAreaView가 안 먹는다(portal로 inset 컨텍스트 분리).
   // 루트 SafeAreaProvider의 insets를 hook으로 직접 받아 헤더에 manual padding.
@@ -458,6 +560,9 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
   // intermediate 알림을 차단 → "received는 늘어도 fired는 안 늘어남"이 정상 동작.
   // DebugModal에 한 줄로 노출해 사용자가 설정 위치를 즉시 알 수 있게 한다.
   const locklessOn = useSettingsStore((s) => s.locklessStationPassed);
+  // #1215 (D9) — 기압계 subsurface. useBarometer는 shared/hooks이라 의존 위배 없음.
+  // useFusedNearestStation 내부 useBarometer와 별개 listener — DebugModal 관찰자 효과 허용 범위.
+  const { subsurface: barometerSubsurface } = useBarometer();
   const fusedLabel = formatStationLabel(result);
   const gpsLabel = formatStationLabel(gpsResult);
   const differs = fusedDiffersFromGps(result, gpsResult);
@@ -547,6 +652,10 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
       logs,
       locklessOn,
       scheduledDump,
+      barometerSubsurface,
+      fusionDetection,
+      trip,
+      sleep,
     });
     void Share.share({ message });
   }, [
@@ -571,6 +680,10 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
     logs,
     locklessOn,
     scheduledDump,
+    barometerSubsurface,
+    fusionDetection,
+    trip,
+    sleep,
   ]);
 
   return (
@@ -609,6 +722,12 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
               value={formatClockTimeWithSeconds(lastFixAtMs ?? null)}
               colors={colors}
             />
+            {/* #1215 (D9) — 기압계 subsurface(지하 진입 후보). 사용자 trip의 지상/지하 분기 확인 진입점. */}
+            <KeyValue
+              label="subsurface"
+              value={formatOptionalBool(barometerSubsurface)}
+              colors={colors}
+            />
           </Section>
 
           <Section title="Fusion" colors={colors}>
@@ -631,6 +750,55 @@ function DebugModalInner({ onClose, candidateTrains, fusedSpeed }: Readonly<Debu
                   ? `${candidateTrains.length}: ${candidateTrains.join(', ') || '-'}`
                   : '(n/a)'
               }
+              colors={colors}
+            />
+            {/* #1215 (D9) — fusion detection verdict (tier/signalMask). */}
+            <KeyValue
+              label="tier"
+              value={formatOptionalString(fusionDetection?.tier)}
+              colors={colors}
+            />
+            <KeyValue
+              label="signalMask"
+              value={formatOptionalString(fusionDetection?.signalMask)}
+              colors={colors}
+            />
+          </Section>
+
+          {/* #1215 (D9) — Trip 섹션: lockless/tripStartedAt/currentHopIndex/route hop count. */}
+          <Section title="Trip" colors={colors}>
+            <KeyValue
+              label="lockless"
+              value={formatOptionalBool(trip?.lockless)}
+              colors={colors}
+            />
+            <KeyValue
+              label="tripStartedAt"
+              value={formatOptionalTs(trip?.tripStartedAt ?? null)}
+              colors={colors}
+            />
+            <KeyValue
+              label="currentHopIndex"
+              value={formatOptionalNumber(trip?.currentHopIndex)}
+              colors={colors}
+            />
+            <KeyValue
+              label="route hop count"
+              value={formatOptionalNumber(trip?.routeHopCount ?? null)}
+              colors={colors}
+            />
+          </Section>
+
+          {/* #1215 (D9) — Sleep 섹션: sleepMode + 첫 hop 향하는 중인가. */}
+          <Section title="Sleep" colors={colors}>
+            <KeyValue
+              label="sleepMode"
+              value={sleep ? (sleep.sleepMode ? 'on' : 'off') : UNKNOWN_LABEL}
+              colors={colors}
+            />
+            <KeyValue
+              label="firstHopApproaching"
+              value={formatOptionalBool(sleep?.firstHopApproaching)}
               colors={colors}
             />
           </Section>
@@ -1125,6 +1293,11 @@ export const __test__ = {
   formatReasonCountsLine,
   NO_FUSED_SIGNAL_LABEL,
   summarizeAlarmLogCounters,
+  formatOptionalBool,
+  formatOptionalString,
+  formatOptionalNumber,
+  formatOptionalTs,
+  UNKNOWN_LABEL,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -13,12 +13,17 @@ const mockUseArrivalInfo = jest.fn();
 const mockUseSilentPushDiagnostics = jest.fn();
 const mockGetAlarmLog = jest.fn();
 const mockClearAlarmLog = jest.fn();
+const mockUseBarometer = jest.fn();
 
 jest.mock('../../../nearest-station/hooks/useFusedNearestStation', () => ({
   useFusedNearestStation: () => mockUseFusedNearestStation(),
 }));
 jest.mock('../../../arrival/hooks/useArrivalInfo', () => ({
   useArrivalInfo: (name: string | null) => mockUseArrivalInfo(name),
+}));
+// #1215 (D9) — DebugModal이 직접 useBarometer를 구독해 subsurface row를 렌더한다.
+jest.mock('../../../../shared/hooks/useBarometer', () => ({
+  useBarometer: () => mockUseBarometer(),
 }));
 // silentPushTask는 expo-task-manager native module이 필요 — jest 환경에서 chain break.
 jest.mock('../../../alarm/hooks/useSilentPushDiagnostics', () => ({
@@ -124,6 +129,8 @@ const setupHookDefaults = () => {
   mockGetAlarmLog.mockResolvedValue([]);
   mockClearAlarmLog.mockResolvedValue(undefined);
   mockDumpScheduledNotifications.mockResolvedValue([]);
+  // #1215 (D9) — 기본은 subsurface=false (지상).
+  mockUseBarometer.mockReturnValue({ subsurface: false, stop: undefined });
 };
 
 // SonarCloud new_duplicated_lines_density 임계 준수 — 여러 describe에 걸친 buildDumpText
@@ -842,6 +849,230 @@ describe('DebugModal helpers', () => {
     });
     expect(line).not.toContain('acc=');
     expect(line).not.toContain('age=');
+  });
+});
+
+// #1215 (D9) — 신규 optional formatter 유닛 케이스.
+// outer scope factory + it.each — SonarCloud nested function 회피.
+describe('DebugModal helpers — D9 optional formatters (#1215)', () => {
+  it.each([
+    [true, 'true'],
+    [false, 'false'],
+    [null, '—'],
+    [undefined, '—'],
+  ])('formatOptionalBool(%p) → %p', (input, expected) => {
+    expect(__test__.formatOptionalBool(input as boolean | null | undefined)).toBe(expected);
+  });
+
+  it.each([
+    ['high', 'high'],
+    ['', '—'],
+    [null, '—'],
+    [undefined, '—'],
+  ])('formatOptionalString(%p) → %p', (input, expected) => {
+    expect(__test__.formatOptionalString(input as string | null | undefined)).toBe(expected);
+  });
+
+  it.each([
+    [0, '0'],
+    [3, '3'],
+    [null, '—'],
+    [undefined, '—'],
+  ])('formatOptionalNumber(%p) → %p', (input, expected) => {
+    expect(__test__.formatOptionalNumber(input as number | null | undefined)).toBe(expected);
+  });
+
+  it('formatOptionalTs: 값이 있으면 ISO, null이면 —', () => {
+    const ts = Date.UTC(2026, 5, 12, 5, 0, 0);
+    expect(__test__.formatOptionalTs(ts)).toBe(new Date(ts).toISOString());
+    expect(__test__.formatOptionalTs(null)).toBe('—');
+    expect(__test__.formatOptionalTs(undefined)).toBe('—');
+  });
+});
+
+// #1215 (D9) — buildDumpText의 D9 신규 섹션. makeDumpArgs로 baseline 공유.
+describe('DebugModal buildDumpText — D9 sections (#1215)', () => {
+  it('미전달 시 subsurface/tier/signalMask/Trip/Sleep 모두 — 표기', () => {
+    const dump = __test__.buildDumpText(makeDumpArgs());
+    expect(dump).toContain('subsurface=—');
+    expect(dump).toContain('tier=—');
+    expect(dump).toContain('signalMask=—');
+    expect(dump).toContain('## Trip');
+    expect(dump).toContain('lockless=—');
+    expect(dump).toContain('tripStartedAt=—');
+    expect(dump).toContain('currentHopIndex=—');
+    expect(dump).toContain('route hop count=—');
+    expect(dump).toContain('## Sleep');
+    expect(dump).toContain('sleepMode=—');
+    expect(dump).toContain('firstHopApproaching=—');
+  });
+
+  it('lockless trip + hop index + sleep on 입력을 dump에 반영', () => {
+    const tripStartedAt = Date.UTC(2026, 5, 12, 4, 0, 0);
+    const dump = __test__.buildDumpText(
+      makeDumpArgs({
+        barometerSubsurface: true,
+        fusionDetection: { tier: 'high', signalMask: 'TFT' },
+        trip: {
+          lockless: true,
+          tripStartedAt,
+          currentHopIndex: 2,
+          routeHopCount: 7,
+        },
+        sleep: { sleepMode: true, firstHopApproaching: false },
+      }),
+    );
+    expect(dump).toContain('subsurface=true');
+    expect(dump).toContain('tier=high');
+    expect(dump).toContain('signalMask=TFT');
+    expect(dump).toContain('lockless=true');
+    expect(dump).toContain(`tripStartedAt=${new Date(tripStartedAt).toISOString()}`);
+    expect(dump).toContain('currentHopIndex=2');
+    expect(dump).toContain('route hop count=7');
+    expect(dump).toContain('sleepMode=on');
+    expect(dump).toContain('firstHopApproaching=false');
+  });
+
+  it('lock 활성 trip(lockless=false) + currentHopIndex=null estimator → currentHopIndex=—', () => {
+    const dump = __test__.buildDumpText(
+      makeDumpArgs({
+        trip: {
+          lockless: false,
+          tripStartedAt: null,
+          currentHopIndex: null,
+          routeHopCount: 5,
+        },
+        sleep: { sleepMode: false, firstHopApproaching: false },
+      }),
+    );
+    expect(dump).toContain('lockless=false');
+    expect(dump).toContain('currentHopIndex=—');
+    expect(dump).toContain('route hop count=5');
+    expect(dump).toContain('sleepMode=off');
+  });
+});
+
+// #1215 (D9) — UI 렌더 분기. setupHookDefaults를 그대로 활용해 hook 입력은 최소화.
+describe('DebugModal — D9 UI sections (#1215)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupHookDefaults();
+  });
+
+  it.each([
+    [true, 'true'],
+    [false, 'false'],
+  ])('GPS 섹션에 subsurface=%p 노출', async (input, expected) => {
+    mockUseBarometer.mockReturnValue({ subsurface: input, stop: undefined });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('subsurface')).toBeTruthy();
+    // KeyValue의 value 텍스트로 노출. 정확한 매칭은 row 내 텍스트 검색.
+    expect(screen.getAllByText(expected).length).toBeGreaterThan(0);
+  });
+
+  it('fusionDetection 미전달 시 tier/signalMask = —', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('tier')).toBeTruthy();
+    expect(screen.getByText('signalMask')).toBeTruthy();
+    // — 표기가 최소 1회 이상 노출되는지 (다른 row도 — 일 수 있음).
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+
+  it('fusionDetection 전달 시 tier/signalMask 값 표기', async () => {
+    renderWithTheme(
+      <DebugModal
+        onClose={jest.fn()}
+        fusionDetection={{ tier: 'medium', signalMask: 'TFU' }}
+      />,
+    );
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('medium')).toBeTruthy();
+    expect(screen.getByText('TFU')).toBeTruthy();
+  });
+
+  it('Trip 섹션: lockless=true + currentHopIndex 정의', async () => {
+    const tripStartedAt = Date.UTC(2026, 5, 12, 4, 0, 0);
+    renderWithTheme(
+      <DebugModal
+        onClose={jest.fn()}
+        trip={{
+          lockless: true,
+          tripStartedAt,
+          currentHopIndex: 3,
+          routeHopCount: 8,
+        }}
+      />,
+    );
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Trip')).toBeTruthy();
+    expect(screen.getByText('lockless')).toBeTruthy();
+    expect(screen.getByText(new Date(tripStartedAt).toISOString())).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('8')).toBeTruthy();
+  });
+
+  it('Trip 섹션: currentHopIndex undefined(D1 미머지) → —', async () => {
+    renderWithTheme(
+      <DebugModal
+        onClose={jest.fn()}
+        trip={{
+          lockless: false,
+          tripStartedAt: null,
+          currentHopIndex: undefined,
+          routeHopCount: null,
+        }}
+      />,
+    );
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('currentHopIndex')).toBeTruthy();
+    expect(screen.getAllByText('false').length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    [{ sleepMode: true, firstHopApproaching: true }, 'on', 'true'],
+    [{ sleepMode: false, firstHopApproaching: false }, 'off', 'false'],
+  ])('Sleep 섹션 분기: sleep=%p → %p / firstHop=%p', async (input, modeText, hopText) => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} sleep={input} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Sleep')).toBeTruthy();
+    expect(screen.getAllByText(modeText).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(hopText).length).toBeGreaterThan(0);
+  });
+
+  it('Sleep prop 미전달 시 sleepMode = —', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Sleep')).toBeTruthy();
+    expect(screen.getByText('sleepMode')).toBeTruthy();
+    expect(screen.getByText('firstHopApproaching')).toBeTruthy();
+  });
+
+  it('Share dump가 D9 신규 props를 dump에 포함', async () => {
+    mockUseBarometer.mockReturnValue({ subsurface: true, stop: undefined });
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(
+      <DebugModal
+        onClose={jest.fn()}
+        fusionDetection={{ tier: 'high', signalMask: 'TTT' }}
+        trip={{ lockless: true, tripStartedAt: null, currentHopIndex: 1, routeHopCount: 4 }}
+        sleep={{ sleepMode: true, firstHopApproaching: true }}
+      />,
+    );
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    const { message } = shareSpy.mock.calls[0][0] as { message: string };
+    expect(message).toContain('subsurface=true');
+    expect(message).toContain('tier=high');
+    expect(message).toContain('signalMask=TTT');
+    expect(message).toContain('lockless=true');
+    expect(message).toContain('currentHopIndex=1');
+    expect(message).toContain('route hop count=4');
+    expect(message).toContain('sleepMode=on');
+    expect(message).toContain('firstHopApproaching=true');
+    shareSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- `## GPS` 섹션에 `subsurface=true/false` row 추가 (`useBarometer` 직접 구독)
- `## Fusion` 섹션에 `tier`, `signalMask` row 추가 (호출부가 prop으로 주입)
- `## Trip` 섹션 신규 — `lockless` / `tripStartedAt` / `currentHopIndex` / `route hop count`
- `## Sleep` 섹션 신규 — `sleepMode` / `firstHopApproaching`
- 신규 props 모두 optional. D1(lockless estimator) / D8(sleep rule wiring) PR 미머지 환경에서도 graceful 동작
- 미정의 값은 `—`로 표기해 "신호 없음"과 "값=false"를 명시적으로 구분
- `buildDumpText` 및 Share dump에도 동일 라인 포함 — 실기기 캡처 시 한 화면에서 분기 진단 가능

## Why
사용자 trip(2026-06-12 용마산→성수) 회귀 evidence에서 지상/지하 분기, lockless trip 진행도, 취침모드 첫 hop 가드 상태가 DebugModal에 보이지 않아 root cause 진단 불가. Epic #1204 §4 D9 SSOT 반영.

## Test plan
- [x] `npm test` — 100% 커버리지 통과 (5005 / 5005)
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [x] 신규 helper 4개 (`formatOptionalBool/String/Number/Ts`) it.each + 단위 케이스
- [x] `buildDumpText` D9 신규 섹션 (미전달 / 전체 채움 / lock 활성 분기) 케이스
- [x] UI 분기 케이스 (subsurface true/false, tier 전달/미전달, Trip lockless on/off + currentHopIndex 정의/undefined, Sleep on/off + 미전달)
- [x] Share dump가 D9 prop을 모두 포함하는지 검증
- [ ] 실기기 dev 빌드에서 DebugModal 캡처 — D9 sub-issue 머지 후 실측

Closes #1215
Relates to #1204