### PR TITLE
fix(#1213): D7 ETA provider 일관성

### DIFF
--- a/src/features/arrival/__tests__/etaProviderConsistency.test.ts
+++ b/src/features/arrival/__tests__/etaProviderConsistency.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature SSOT 회귀 게이트. BoardingTrainList(arrival surface)와 EditorialArrivalRow
+ * 의 anchor가 같은 `arrivalAt(item)`에 수렴함을 증명하려면 route 슬라이스의 journeyAdapter
+ * (ArrivalRow가 실제로 거치는 어댑터)를 직접 import해야 한다. test-only.
+ */
+/**
+ * D7 (#1213) — BoardingTrainList ETA vs Arrival 표시 ETA provider 일관성.
+ *
+ * 사용자 보고: 같은 시점에 BoardingTrainList의 ETA와 정상 Arrival 표시(EditorialArrivalRow)의
+ * ETA가 다른 값으로 보일 가능성. 분석 결과 두 surface는 같은 source(useArrivalInfo → useArrivalCountdown)
+ * 를 공유하며, 절대 도착 시각 anchor도 `arrivalAt(item) = Date.now() + arrivalSeconds * 1000`로 통일
+ * (#897 Seam A). 본 테스트는 그 SSOT 계약을 회귀 게이트로 못 박는다.
+ *
+ * 정의:
+ *   - BoardingTrainList 표시 시각:
+ *       formatClockTime(arrivalAt(item))   ← src/features/alarm/components/BoardingTrainList.tsx
+ *   - EditorialArrivalRow 표시 시각의 anchor:
+ *       arrivalInfoToArrivalTrain(items, ...).arrivalAtMs = arrivalAt(item)
+ *                                          ← src/features/route/utils/journeyAdapter.ts
+ *
+ * 두 식이 같은 `arrivalAt(item)` 호출에 수렴해야 두 표시가 같은 시각을 가리킨다.
+ */
+
+import { arrivalAt } from '../../../shared/utils/arrivalClock';
+import { formatClockTime } from '../../../shared/utils/formatTime';
+import { arrivalInfoToArrivalTrain } from '../../route/utils/journeyAdapter';
+import { makeArrivalInfo } from '../../../testUtils/fixtures';
+
+// SonarCloud dup 회피 — outer scope helper. nested function 선언 금지 룰 준수.
+const FIXED_T0 = new Date(2026, 0, 1, 9, 0, 0).getTime();
+
+function setNow(t: number) {
+  jest.useFakeTimers().setSystemTime(t);
+}
+
+function boardingTrainListClock(item: { arrivalSeconds: number }): string {
+  return formatClockTime(arrivalAt(item));
+}
+
+function arrivalRowAnchor(item: { arrivalSeconds: number }): number {
+  // EditorialArrivalRow는 train.arrivalAtMs를 useCountdown에 전달 — arrivalAtMs = arrivalAt(item).
+  const [train] = arrivalInfoToArrivalTrain(
+    [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: item.arrivalSeconds })],
+    '상행',
+    '6',
+  );
+  return train.arrivalAtMs;
+}
+
+describe('D7 #1213 ETA provider consistency', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it.each([0, 60, 134, 271, 600])(
+    'arrivalSeconds=%d: BoardingTrainList anchor === ArrivalRow anchor',
+    (arrivalSeconds) => {
+      setNow(FIXED_T0);
+      const item = { arrivalSeconds };
+      expect(arrivalAt(item)).toBe(arrivalRowAnchor(item));
+    },
+  );
+
+  it.each([
+    [0, 60],
+    [30, 60],
+    [60, 180],
+    [120, 180],
+    [180, 180],
+  ])(
+    'tick elapsed=%ds (initial=%ds) — useArrivalCountdown 차감 후 두 surface anchor stable + 동일',
+    (elapsedSeconds, initialSeconds) => {
+      // useArrivalCountdown이 매초 arrivalSeconds를 1씩 차감하면서 시계도 1초씩 흐른다.
+      // arrivalAt = Date.now() + arrivalSeconds*1000은 양쪽 변화가 상쇄되어 stable.
+      setNow(FIXED_T0);
+      const boardingAnchor = arrivalAt({ arrivalSeconds: initialSeconds });
+      const rowAnchor = arrivalRowAnchor({ arrivalSeconds: initialSeconds });
+      expect(boardingAnchor).toBe(rowAnchor);
+
+      setNow(FIXED_T0 + elapsedSeconds * 1000);
+      const remaining = initialSeconds - elapsedSeconds;
+      const boardingTicked = arrivalAt({ arrivalSeconds: remaining });
+      const rowTicked = arrivalRowAnchor({ arrivalSeconds: remaining });
+
+      // 양 surface가 동일 anchor를 본다 (SSOT 계약).
+      expect(boardingTicked).toBe(rowTicked);
+      // 초기 anchor 대비 stable (시계 + 차감 상쇄 → 0 drift).
+      expect(boardingTicked).toBe(boardingAnchor);
+    },
+  );
+
+  it('formatClockTime 출력이 두 surface에서 동일 (BoardingTrainList 표기 형식 검증)', () => {
+    setNow(FIXED_T0);
+    const item = { arrivalSeconds: 180 };
+    const fromBoardingList = boardingTrainListClock(item);
+    const fromRow = formatClockTime(arrivalRowAnchor(item));
+    expect(fromBoardingList).toBe(fromRow);
+  });
+
+  it('동일 ArrivalInfo가 directionalArrivals와 arrival.up에 동시에 있을 때 두 표시 동일', () => {
+    // 현재역 BoardingTrainList는 useBoardingLockController가 arrival.up/down을 그대로 필터해
+    // directionalArrivals로 노출 — 새 source가 아니다. 같은 reference의 ArrivalInfo는 두 surface
+    // 모두에서 같은 arrivalAt(item) 결과를 가진다.
+    setNow(FIXED_T0);
+    const shared = makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 });
+    // BoardingTrainList path
+    const boardingMs = arrivalAt(shared);
+    // EditorialArrivalRow path
+    const [train] = arrivalInfoToArrivalTrain([shared], '상행', '6');
+    expect(train.arrivalAtMs).toBe(boardingMs);
+  });
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -247,6 +247,10 @@ export default function HomeScreen() {
   // #797: 환승역에서 nearest.station.line이 trip 방향과 어긋나는 회귀 차단.
   // BoardingLock(사용자 선택) > Route(구조적 SSOT) > station.line fallback.
   const approachLine = getApproachLine(route, fusionBoardingLock, effectiveOrigin);
+  // D7 (#1213) ETA provider SSOT — 현재역 BoardingTrainList(via directionalArrivals)와
+  // 정상 Arrival 표시(EditorialArrivalRow via ArrivalDirectionGroup)는 둘 다 아래 `arrival`을
+  // 출처로 사용한다. 절대 시각 anchor도 arrivalAt(item)으로 통일(#897 Seam A). 따라서 두 surface의
+  // ETA는 같은 시점에 항상 동일해야 한다. 회귀 게이트: etaProviderConsistency.test.ts.
   const { arrival: rawArrival, isMock: arrivalIsMock, loading: arrivalLoading, refetch: refetchArrival } = useArrivalInfo(
     effectiveOrigin?.name ?? null,
     approachLine,


### PR DESCRIPTION
## Summary

D7 (Epic #1204): BoardingTrainList ETA와 Arrival 표시 컴포넌트(EditorialArrivalRow) ETA가 같은 시점에 다른 값으로 표시될 가능성에 대한 회귀 게이트.

### 분석 결과
- 현재역 surface: BoardingTrainList(via `directionalArrivals`)와 ArrivalDirectionGroup → EditorialArrivalRow는 **둘 다** `useArrivalInfo` → `arrival.up/down`을 공유한다 (HomeScreen에서 단일 hook 호출).
- 절대 도착 시각 anchor도 #897 Seam A에서 `arrivalAt(item) = Date.now() + arrivalSeconds * 1000` 한 곳으로 통일됨.
- 즉, 두 surface가 동일 ArrivalInfo reference를 보고 동일 anchor를 계산 → 같은 시점 ETA가 다를 수 있는 코드 경로는 현재 없음.
- 회귀 가드 부재 상태였음 → 본 PR로 SSOT 계약을 테스트로 못 박는다.

### 변경
- `src/screens/HomeScreen.tsx`: 현재역 ETA SSOT 주석 추가(코드 변경 없음, 의도 문서화).
- `src/features/arrival/__tests__/etaProviderConsistency.test.ts` (신규):
  - `arrivalSeconds = 0, 60, 134, 271, 600` → `arrivalAt(item) === arrivalInfoToArrivalTrain(...).arrivalAtMs`
  - countdown tick 진행 중에도 양 surface anchor stable + 동일 (initial vs elapsed 5케이스)
  - `formatClockTime` 출력 동일성
  - 동일 ArrivalInfo reference 공유 시 anchor 동일

### 환승역 surface
환승역 BoardingTrainList(`arrivalsAtTransfers`)는 별도 provider 경로(`useTransferArrivals`)지만 본 이슈(D7)는 현재역 일관성 범위. 환승 경로 일관성은 Epic 다른 항목에서 다룸.

## 결정 룰 자가 점검 (CLAUDE.md)
- false binary 회피: 코드 변경 옵션 / 주석만 / 회귀 게이트 테스트만 → "이미 SSOT가 일치하므로 회귀 게이트가 적절" 선택. 코드 변경 없음.
- 사용자 명시 의향 trip 동급 보장: BoardingTrainList 직접 탭 경로 surface ETA가 lock 활성 trip ETA와 정확히 같은 anchor를 가짐을 테스트로 증명.

## Test plan
- [x] `npm test` 전체 4991 / 273 suites pass, 100% coverage
- [x] `npm run type-check` pass
- [x] `npm run lint` pass
- [ ] CI `Type Check & Test` pass
- [ ] CI `E2E Smoke (mock mode)` pass — 참고: dev 베이스에서 `02_destination_set_clear.yaml` flaky 의심. 본 PR 코드 변경은 주석 1줄 + 신규 테스트뿐이라 E2E 회귀 가능성은 사실상 없음.

Closes #1213
Relates to #1204