### PR TITLE
fix(#1228): E2E destination flow 결정적 안정화

### DIFF
--- a/.maestro/flows/smoke/02_destination_set_clear.yaml
+++ b/.maestro/flows/smoke/02_destination_set_clear.yaml
@@ -52,7 +52,7 @@ name: "smoke - 목적지 설정 & 초기화"
 # destination 박스 축소 직후 ScrollView contentOffset이 즉시 클램프되지 않아 viewport 밖 가능 — scroll로 보정.
 - scrollUntilVisible:
     element:
-      text: "목적지 설정|Set destination"
-    timeout: 5000
+      id: "destination-button"
+    timeout: 10000
 - assertVisible:
-    text: "목적지 설정|Set destination"
+    id: "destination-button"


### PR DESCRIPTION
## Summary
- `.maestro/flows/smoke/02_destination_set_clear.yaml`의 마지막 `scrollUntilVisible` / `assertVisible` 두 step을 text 정규식 매칭에서 `destination-button` testID 매칭으로 교체
- timeout 5000ms → 10000ms로 상향

## 원인
- destination 선택 시 `addRecentDestination`이 잠실을 recent list에 push
- destination clear 후 UI에서 recent-destinations-list가 destination-button 위에 렌더되어 button이 viewport 아래로 밀림
- 기존 `scrollUntilVisible text:"목적지 설정|Set destination" timeout:5000`이 시뮬레이터 timing에 따라 부족 + 정규식 text 매칭이 비결정적

## 변경
```yaml
# 변경 전
- scrollUntilVisible:
    element:
      text: "목적지 설정|Set destination"
    timeout: 5000
- assertVisible:
    text: "목적지 설정|Set destination"

# 변경 후
- scrollUntilVisible:
    element:
      id: "destination-button"
    timeout: 10000
- assertVisible:
    id: "destination-button"
```

다른 step은 변경하지 않음 (surgical).

## 게이트
- `npm run type-check` PASS
- `npm run lint` PASS
- yaml-only 변경 (소스 코드 무영향)

## 머지 후
- 다른 D 시리즈 PR을 dev에 rebase하거나 rerun으로 stale flow 재실행 가능
- 본 PR의 E2E Smoke 자체가 새 flow로 동작 — 검증 자체

Closes #1228