### PR TITLE
fix(#1230): smoke flow 전수 text→testID 마이그레이션

### DIFF
--- a/.maestro/flows/smoke/01_app_launch.yaml
+++ b/.maestro/flows/smoke/01_app_launch.yaml
@@ -28,9 +28,9 @@ name: "smoke - 앱 실행 및 홈 화면 노출"
       id: "destination-button"
     timeout: 10000
 
-# CI 시뮬레이터 locale은 영어라 station이 nameEn("Gangnam")으로 표시됨.
-# 한/영 둘 다 매칭되는 정규식으로 로컬 KO 환경과도 호환.
+# i18n 회귀 차단을 위해 testID로 검증 (#1230). HomeScreen의 origin station hero Text와
+# destination button은 안정 testID를 노출하므로 locale/번역 변경 무관하게 결정적.
 - assertVisible:
-    text: "강남|Gangnam"
+    id: "home-origin-station-name"
 - assertVisible:
-    text: "목적지 설정|Set destination"
+    id: "destination-button"

--- a/.maestro/flows/smoke/03_tab_navigation.yaml
+++ b/.maestro/flows/smoke/03_tab_navigation.yaml
@@ -33,19 +33,26 @@ name: "smoke - 탭 내비게이션 순회"
     timeout: 10000
 
 # 즐겨찾기 탭 (62.5%)
+# 탭 전환 후 화면 mount까지 maestro default(~1s)를 넘는 경우가 있어 extendedWaitUntil로 흡수 (#1230).
 - tapOn:
     point: "62%,95%"
-- assertVisible:
-    id: "favorites-search-input"
+- extendedWaitUntil:
+    visible:
+      id: "favorites-search-input"
+    timeout: 5000
 
 # 설정 탭 (87.5%)
 - tapOn:
     point: "87%,95%"
-- assertVisible:
-    id: "sleep-mode-switch"
+- extendedWaitUntil:
+    visible:
+      id: "sleep-mode-switch"
+    timeout: 5000
 
 # 홈 탭 복귀 (12.5%)
 - tapOn:
     point: "12%,95%"
-- assertVisible:
-    id: "destination-button"
+- extendedWaitUntil:
+    visible:
+      id: "destination-button"
+    timeout: 5000

--- a/.maestro/flows/smoke/04_favorites_add_remove.yaml
+++ b/.maestro/flows/smoke/04_favorites_add_remove.yaml
@@ -24,10 +24,13 @@ name: "smoke - 즐겨찾기 추가 & 삭제"
     timeout: 10000
 
 # 즐겨찾기 탭 (62.5%)
+# 탭 전환 직후 mount까지 maestro default(~1s)를 넘는 케이스를 흡수 (#1230).
 - tapOn:
     point: "62%,95%"
-- assertVisible:
-    id: "favorites-empty"
+- extendedWaitUntil:
+    visible:
+      id: "favorites-empty"
+    timeout: 5000
 
 # 추가
 - tapOn:
@@ -42,11 +45,15 @@ name: "smoke - 즐겨찾기 추가 & 삭제"
 
 # FavoriteCard는 TouchableOpacity가 여러 Text를 감싸 a11y aggregation으로
 # 단독 station 이름 텍스트가 매처에 안 잡힘. testID로 검증해 a11y 구조 무관하게 결정적.
-- assertVisible:
-    id: "favorite-remove-2-022"
+- extendedWaitUntil:
+    visible:
+      id: "favorite-remove-2-022"
+    timeout: 5000
 
 # 삭제
 - tapOn:
     id: "favorite-remove-2-022"
-- assertVisible:
-    id: "favorites-empty"
+- extendedWaitUntil:
+    visible:
+      id: "favorites-empty"
+    timeout: 5000

--- a/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
+++ b/.maestro/flows/smoke/05_sleep_mode_toggle.yaml
@@ -26,8 +26,10 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 # 취침 모드는 목적지 설정 시에만 노출되므로 잠실 지정
 - tapOn:
     id: "destination-button"
-- assertVisible:
-    id: "search-input"
+- extendedWaitUntil:
+    visible:
+      id: "search-input"
+    timeout: 5000
 - tapOn:
     id: "search-input"
 - inputText: "잠실"
@@ -63,8 +65,10 @@ name: "smoke - 취침 모드 토글 (홈 ↔ 설정 동기화)"
 # 설정 탭 동기화 확인
 - tapOn:
     point: "87%,95%"
-- assertVisible:
-    id: "sleep-mode-switch"
+- extendedWaitUntil:
+    visible:
+      id: "sleep-mode-switch"
+    timeout: 5000
 - tapOn:
     id: "sleep-mode-switch"
 

--- a/.maestro/flows/smoke/06_accessibility_mode_route.yaml
+++ b/.maestro/flows/smoke/06_accessibility_mode_route.yaml
@@ -32,26 +32,32 @@ name: "smoke - 거동 불편자 모드가 경로 화면 문번호 라벨에 반�
 # 경복궁 목적지 지정 → 강남(2)→교대(2)→[환승]→경복궁(3) 경로 표시
 - tapOn:
     id: "destination-button"
-- assertVisible:
-    id: "search-input"
+- extendedWaitUntil:
+    visible:
+      id: "search-input"
+    timeout: 5000
 - tapOn:
     id: "search-input"
 - inputText: "경복궁"
-- assertVisible:
-    id: "suggestions-list"
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
 - tapOn:
     id: "suggestion-item-3-019"
 
 # 기본 모드: stairs 우선 — 도착역(경복궁) 라벨에 "8-3번 문" 표시
 # Hero + Hr + route header + segment control + 3-row timeline이 iPhone 16 viewport를 초과해
 # 마지막 row(경복궁)가 fold 아래로 떨어지는 타이밍이 있다 (#1125). scroll로 결정적 노출.
+# testID는 quick-exit-door-{index}-{door} 형식(#1230) — door 값을 id에 인코딩해 i18n 텍스트 변경
+# 회귀를 차단. index는 timeline에서 가변(직통/환승)이라 정규식으로 매칭.
 - scrollUntilVisible:
     element:
-      text: "8-3번 문|Door 8-3"
+      id: "quick-exit-door-.*-8-3"
     timeout: 10000
 - extendedWaitUntil:
     visible:
-      text: "8-3번 문|Door 8-3"
+      id: "quick-exit-door-.*-8-3"
     timeout: 10000
 
 # 설정 탭으로 이동해 거동 불편자 모드 ON
@@ -67,12 +73,17 @@ name: "smoke - 거동 불편자 모드가 경로 화면 문번호 라벨에 반�
 - tapOn:
     id: "accessibility-mode-switch"
 
-# 홈 탭 복귀 후 라벨이 elevator 우선("6-2번 문")으로 바뀌었는지 확인
+# 홈 탭 복귀 후 라벨이 elevator 우선("6-2번 문")으로 바뀌었는지 확인.
+# 타임라인 위치가 fold 아래에 있을 수 있어 scrollUntilVisible로 진입 후 assert.
 - tapOn:
     point: "12%,95%"
+- scrollUntilVisible:
+    element:
+      id: "quick-exit-door-.*-6-2"
+    timeout: 10000
 - extendedWaitUntil:
     visible:
-      text: "6-2번 문|Door 6-2"
+      id: "quick-exit-door-.*-6-2"
     timeout: 10000
 - assertNotVisible:
-    text: "8-3번 문"
+    id: "quick-exit-door-.*-8-3"

--- a/src/features/arrival/components/EditorialTimeline.tsx
+++ b/src/features/arrival/components/EditorialTimeline.tsx
@@ -163,7 +163,7 @@ export function EditorialTimeline({ stops, renderHopSlot }: Props) {
               {quickExitDoor != null && (
                 <Text
                   style={[typography.label, { color: colors.subtle, marginTop: 2 }]}
-                  testID={`quick-exit-door-${i}`}
+                  testID={`quick-exit-door-${i}-${quickExitDoor}`}
                 >
                   {t('route.quickExitDoor', { door: quickExitDoor })}
                 </Text>
@@ -171,7 +171,7 @@ export function EditorialTimeline({ stops, renderHopSlot }: Props) {
               {boardingDoor != null && (
                 <Text
                   style={[typography.label, { color: colors.subtle, marginTop: 2 }]}
-                  testID={`boarding-door-${i}`}
+                  testID={`boarding-door-${i}-${boardingDoor}`}
                 >
                   {t('route.boardingDoor', { door: boardingDoor })}
                 </Text>

--- a/src/features/arrival/components/__tests__/EditorialTimeline.test.tsx
+++ b/src/features/arrival/components/__tests__/EditorialTimeline.test.tsx
@@ -176,9 +176,10 @@ describe('EditorialTimeline quickExit door label', () => {
     // stopsWithQuickExit: 교대(filled, 3호선) → 경복궁(dest, 3호선). 다음 stop 도어 3-2.
     render(<EditorialTimeline stops={stopsWithQuickExit} />);
     expect(screen.getByText('탑승 3-2번 문')).toBeTruthy();
-    expect(screen.getByTestId('boarding-door-0')).toBeTruthy();
-    // 도착 stop은 원래 "3-2번 문"(탑승 prefix 없음) 그대로 유지
-    expect(screen.getByTestId('quick-exit-door-1')).toBeTruthy();
+    expect(screen.getByTestId('boarding-door-0-3-2')).toBeTruthy();
+    // 도착 stop은 원래 "3-2번 문"(탑승 prefix 없음) 그대로 유지.
+    // testID는 door 값을 suffix로 포함해 E2E flow에서 i18n 텍스트 대신 id 정규식으로 검증 가능 (#1230).
+    expect(screen.getByTestId('quick-exit-door-1-3-2')).toBeTruthy();
   });
 
   it('#635 출발역만 있고 다음 stop 없으면 boarding-door 라벨 안 뜬다', () => {
@@ -223,7 +224,7 @@ describe('EditorialTimeline quickExit door label', () => {
     ];
     render(<EditorialTimeline stops={stops} />);
     expect(screen.getByText('탑승 3-2번 문')).toBeTruthy();
-    expect(screen.getByTestId('boarding-door-0')).toBeTruthy();
+    expect(screen.getByTestId('boarding-door-0-3-2')).toBeTruthy();
   });
 
   // 라벨 미표시 케이스 — fromName→toName 단일 segment fixture.

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -789,7 +789,10 @@ export default function HomeScreen() {
                   : t('home.originNearest')}
               </Text>
               <View style={styles.heroRow}>
-                <Text style={[typography.hero, { color: colors.ink, flex: 1, fontWeight: '900' }]}>
+                <Text
+                  style={[typography.hero, { color: colors.ink, flex: 1, fontWeight: '900' }]}
+                  testID="home-origin-station-name"
+                >
                   {getStationDisplayName(effectiveOrigin)}
                 </Text>
                 <TouchableOpacity


### PR DESCRIPTION
## Summary

5개 smoke flow의 앱 내부 element 매칭을 text(정규식) → id(testID)로 전수 마이그레이션. i18n/번역 변경 시 flow가 자동으로 깨지지 않도록 보강 (#1228 후속).

### 마이그레이션 대상 flow
- `01_app_launch.yaml` — origin station name + destination button
- `03_tab_navigation.yaml` — assertVisible → extendedWaitUntil(5s)
- `04_favorites_add_remove.yaml` — assertVisible → extendedWaitUntil(5s)
- `05_sleep_mode_toggle.yaml` — search-input/sleep-mode-switch 대기 보강
- `06_accessibility_mode_route.yaml` — 문번호 라벨 text → id 정규식

### 추가된 testID
| 위치 | testID | 용도 |
| --- | --- | --- |
| `src/screens/HomeScreen.tsx` Hero `Text` | `home-origin-station-name` | flow 01 origin station 검증 |
| `src/features/arrival/components/EditorialTimeline.tsx` | `quick-exit-door-{i}-{door}` | door 값 인코딩 (flow 06) |
| `src/features/arrival/components/EditorialTimeline.tsx` | `boarding-door-{i}-{door}` | 동일 패턴 통일 |

기존 `quick-exit-door-{i}` / `boarding-door-{i}` 단순 형식은 door 값이 testID에 없어 maestro에서 "어떤 door 값이냐"를 검증하려면 text 매칭이 필요했음. suffix 인코딩으로 id 정규식만으로도 결정적 검증 가능.

### 외부 시스템 UI는 text 유지
- Expo dev-client 화면(`text: ".*localhost.*"`, `text: "Continue"`)
- iOS Alert(`text: "OK|확인"`)

### Timeout 정책
모든 `extendedWaitUntil` / `scrollUntilVisible`에 명시 timeout 부여 (5000ms 기본, viewport scroll은 10000ms). default 의존 제거.

### Tests
- `EditorialTimeline.test.tsx` testID assertion을 새 형식으로 갱신.
- `npm test`: 4979 tests pass, 100% coverage.
- `npm run type-check` / `npm run lint` pass.

Closes #1230
Relates to #1228

## Test plan
- [x] CI `Type Check & Test` 통과
- [x] CI `E2E Smoke (mock mode)` 5 flow 모두 pass — 본 PR이 검증 대상 그 자체
- [ ] 실기기에서 i18n 토글(KO/EN) 시 flow 동작 무관 확인 (후속)