### PR TITLE
fix(#1239): 위젯 Phase 3 — useWidgetMirror clear 정책 완화

### DIFF
--- a/src/features/widget/hooks/__tests__/useWidgetMirror.test.ts
+++ b/src/features/widget/hooks/__tests__/useWidgetMirror.test.ts
@@ -44,16 +44,17 @@ describe('useWidgetMirror', () => {
     expect(mockClear).not.toHaveBeenCalled();
   });
 
-  it('station이 null이면 clearWidgetStation을 호출한다', () => {
-    renderHook(() => useWidgetMirror(null, null));
-    expect(mockClear).toHaveBeenCalledTimes(1);
-    expect(mockSave).not.toHaveBeenCalled();
-  });
-
-  it('distanceKm이 null이면 station이 있어도 clear', () => {
-    renderHook(() => useWidgetMirror(station, null));
-    expect(mockClear).toHaveBeenCalledTimes(1);
-    expect(mockSave).not.toHaveBeenCalled();
+  describe('일시적 null 입력엔 clear 하지 않고 no-op (#1239)', () => {
+    it.each([
+      ['station=null & distance=null', null, null],
+      ['station=null & distance=number', null, 0.1],
+      ['station 정상 & distance=null', station, null],
+      ['station 정상 & distance=undefined', station, undefined],
+    ] as const)('%s', (_label, s, d) => {
+      renderHook(() => useWidgetMirror(s, d));
+      expect(mockSave).not.toHaveBeenCalled();
+      expect(mockClear).not.toHaveBeenCalled();
+    });
   });
 
   it('같은 50m bucket 내 미세 변경엔 effect가 재실행되지 않는다', () => {
@@ -86,14 +87,15 @@ describe('useWidgetMirror', () => {
     expect(mockSave).toHaveBeenLastCalledWith(other, 0.1);
   });
 
-  it('station → null 전환 시 clear', () => {
+  it('station → null 전환 시에도 clear 호출하지 않음 (위젯은 마지막 역 유지)', () => {
     const { rerender } = renderHook(
       ({ s, d }: { s: Station | null; d: number | null }) => useWidgetMirror(s, d),
       { initialProps: { s: station as Station | null, d: 0.1 as number | null } },
     );
     expect(mockSave).toHaveBeenCalledTimes(1);
     rerender({ s: null, d: null });
-    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockClear).not.toHaveBeenCalled();
+    expect(mockSave).toHaveBeenCalledTimes(1);
   });
 
   it('save 실패 시 logger.error만 호출 (throw 안 함)', async () => {
@@ -101,12 +103,5 @@ describe('useWidgetMirror', () => {
     renderHook(() => useWidgetMirror(station, 0.1));
     await new Promise((r) => setImmediate(r));
     expect(mockLoggerError).toHaveBeenCalledWith('save 실패:', expect.any(Error));
-  });
-
-  it('clear 실패 시 logger.error만 호출 (throw 안 함)', async () => {
-    mockClear.mockRejectedValueOnce(new Error('group missing'));
-    renderHook(() => useWidgetMirror(null, null));
-    await new Promise((r) => setImmediate(r));
-    expect(mockLoggerError).toHaveBeenCalledWith('clear 실패:', expect.any(Error));
   });
 });

--- a/src/features/widget/hooks/useWidgetMirror.ts
+++ b/src/features/widget/hooks/useWidgetMirror.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { Station } from '../../../shared/types/station';
-import { saveStationToWidget, clearWidgetStation } from '../api/widgetStorage';
+import { saveStationToWidget } from '../api/widgetStorage';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('WidgetMirror');
@@ -20,7 +20,11 @@ function distanceBucket(distanceKm: number | undefined | null): number | null {
  * nearest station 결과를 iOS 홈 위젯에 단방향 mirror.
  *
  * - station 존재 (500m 반경 내 감지) → `saveStationToWidget`
- * - station 없음 → `clearWidgetStation` 으로 위젯이 "감지 중" fallback 표시
+ * - station 없음 (loading / locationUncertain 같은 일시적 null) → **no-op**.
+ *   위젯은 마지막 알려진 역 + savedAt freshness 로 stale UX 를 자가 처리한다.
+ *   여기서 UserDefaults 를 비우면 transient null 마다 위젯이 "감지 중" 으로 고착되는
+ *   회귀가 발생한다 (#1239). 명시적 clear 가 필요한 경로(알람 종료 등)는 별도
+ *   `clearWidgetStation` caller(`stationNotification`, `SharedGroupAdapter`)가 담당.
  *
  * 위젯 lifecycle은 destination/route 상태와 분리되어 항상 nearest station을 반영한다(#1094).
  * deps는 50m bucket으로 정규화해 GPS tick마다 불필요한 effect 재실행을 막는다.
@@ -34,7 +38,6 @@ export function useWidgetMirror(
 
   useEffect(() => {
     if (!station || distanceKm == null) {
-      clearWidgetStation().catch((e) => logger.error('clear 실패:', e));
       return;
     }
     saveStationToWidget(station, distanceKm).catch((e) =>


### PR DESCRIPTION
## Summary
- transient null(`loading`, `locationUncertain`) 입력에 `clearWidgetStation` 호출 제거 → UserDefaults zap 회귀 차단
- 위젯은 마지막 알려진 역 + `savedAt` freshness로 stale UX 자가 처리 (위젯 측 정책)
- import에서 `clearWidgetStation` 제거. 다른 caller(`stationNotification`, `SharedGroupAdapter`)는 영향 없음 (export 유지)
- 테스트: null → no-op (it.each + 4가지 transient null 매트릭스), station→null 전환 시에도 clear 미호출 검증

## Why
`useWidgetMirror`가 transient null 마다 위젯을 비우면서 "감지 중" 고착이 발생 (`src/features/widget/hooks/useWidgetMirror.ts:35-42` origin). 위젯은 자체 freshness 정책으로 stale 표기를 처리하므로 hook 측 zap은 회귀 source.

## Caller inventory (`clearWidgetStation`)
- `src/features/alarm/utils/stationNotification.ts` (알람 종료 경로)
- `src/shared/infra/storage/SharedGroupAdapter.ts` (인프라 어댑터)
- `modules/live-activity/` (네이티브 RPC)
→ 모두 명시적 종료 경로. `useWidgetMirror`에서만 호출 제거.

## Test plan
- [x] `npm test` (5116 통과, 커버리지 100%)
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [ ] 실기기: transient null(터널 진입/지하 GPS 끊김) 시 위젯이 마지막 역을 유지하는지 확인

Closes #1239
Relates to #1231

Phase 1 #1232 / Phase 2 #1238 후속.