### PR TITLE
feat(#1235): D9 DebugModal props wire

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -610,7 +610,8 @@ function DebugModalInner({
         lockless: locklessTrip,
         tripStartedAt,
         currentHopIndex,
-        routeHopCount: destination !== null ? routeHopCount : null,
+        // destination 있어야 routeHopCount 표기 의미. 없으면 null → '—' 표기.
+        routeHopCount: destination ? routeHopCount : null,
       },
     [tripProp, locklessTrip, tripStartedAt, currentHopIndex, routeHopCount, destination],
   );

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AppState,
   Modal,
@@ -12,6 +12,8 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { getTripStartedAt } from '../../alarm/utils/tripStartStorage';
 import { isDebugModalEnabled } from '../../../shared/constants/debugFlags';
 import type { GpsActiveState } from '../../../shared/constants/gpsStatus';
 import { formatClockTimeWithSeconds } from '../../../shared/utils/formatTime';
@@ -533,9 +535,9 @@ function DebugModalInner({
   onClose,
   candidateTrains,
   fusedSpeed,
-  fusionDetection,
-  trip,
-  sleep,
+  fusionDetection: fusionDetectionProp,
+  trip: tripProp,
+  sleep: sleepProp,
 }: Readonly<DebugModalProps>) {
   const { colors } = useTheme();
   // #458: RN Modal 안에서는 SafeAreaView가 안 먹는다(portal로 inset 컨텍스트 분리).
@@ -552,7 +554,14 @@ function DebugModalInner({
     accuracyMeters,
     gpsActive,
     lastFixAtMs,
+    // #1235 (D9 wire) — hook이 노출하는 SSOT로 fusionDetection/trip props 구성.
+    currentHopIndex,
+    arcStations,
+    detectionTier,
+    detectionSignalMask,
   } = useFusedNearestStation();
+  // arc 길이 = trip의 hop 총 수. trip 미설정이면 0.
+  const routeHopCount = arcStations.length;
   const stationName = result?.station.name ?? null;
   const { arrival, isMock } = useArrivalInfo(stationName);
   const silentPush = useSilentPushDiagnostics();
@@ -567,6 +576,55 @@ function DebugModalInner({
   const gpsLabel = formatStationLabel(gpsResult);
   const differs = fusedDiffersFromGps(result, gpsResult);
   const lock = useBoardingLockStore((s) => s.lock);
+
+  // #1235 (D9 wire) — fusionDetection/trip/sleep SSOT 도출.
+  // 호출자가 props로 명시 전달하면 그 값이 우선(테스트/외부 주입). 미전달이면 내부 SSOT 사용.
+  const sleepMode = useSettingsStore((s) => s.sleepMode);
+  const destination = useDestinationStore((s) => s.destination);
+  const lockActive = lock !== null && !isBoardingLockExpired(lock, Date.now());
+  // lockless trip = destination 설정됐고 boardingLock 비활성.
+  const locklessTrip = destination !== null && !lockActive;
+  // tripStartedAt는 AsyncStorage SSOT(tripStartStorage). 마운트 + destination 변경 시 재조회.
+  const [tripStartedAt, setTripStartedAt] = useState<number | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void getTripStartedAt().then((value) => {
+      if (!cancelled) setTripStartedAt(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [destination]);
+
+  const fusionDetection: FusionDetectionSummary = useMemo(
+    () =>
+      fusionDetectionProp ?? {
+        tier: detectionTier,
+        signalMask: detectionSignalMask,
+      },
+    [fusionDetectionProp, detectionTier, detectionSignalMask],
+  );
+  const trip: TripDebugState = useMemo(
+    () =>
+      tripProp ?? {
+        lockless: locklessTrip,
+        tripStartedAt,
+        currentHopIndex,
+        routeHopCount: destination !== null ? routeHopCount : null,
+      },
+    [tripProp, locklessTrip, tripStartedAt, currentHopIndex, routeHopCount, destination],
+  );
+  const sleep: SleepDebugState = useMemo(
+    () =>
+      sleepProp ?? {
+        sleepMode,
+        // 첫 hop 향함 = lockless + estimator hop index 0 (탑승역 또는 첫 hop 출발 직후).
+        // lock 활성 trip은 별도 게이트로 들어가므로 본 디버그 표기는 lockless만 true.
+        firstHopApproaching: locklessTrip && currentHopIndex === 0,
+      },
+    [sleepProp, sleepMode, locklessTrip, currentHopIndex],
+  );
+
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
     getFusionDebugEntries(),
@@ -793,7 +851,8 @@ function DebugModalInner({
           <Section title="Sleep" colors={colors}>
             <KeyValue
               label="sleepMode"
-              value={sleep ? (sleep.sleepMode ? 'on' : 'off') : UNKNOWN_LABEL}
+              // #1235 (D9 wire) — sleep는 SSOT 도출로 항상 non-null. on/off만 분기.
+              value={sleep.sleepMode ? 'on' : 'off'}
               colors={colors}
             />
             <KeyValue

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -1093,10 +1093,11 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
   });
 
   // #1235 (D9 wire) — props 미전달 시 DebugModal이 hook return + store + tripStartStorage에서
-  // fusionDetection/trip/sleep SSOT를 도출하는 분기 검증. 사용자가 _layout 마운트 지점에서
-  // wrapper 없이 <DebugModal /> 만 쓰더라도 D9 sections에 의미있는 값이 흘러야 한다.
+  // fusionDetection/trip/sleep SSOT를 도출하는 분기 검증. 외부 helper로 dup 회피
+  // (lesson_sonarcloud_dup_prevention.md: outer scope helper + factory + wrapper).
   describe('SSOT wire (props 미전달 → hook+store 도출)', () => {
-    const tripDestination: Station = {
+    // 공유 픽스처/팩토리 — 각 테스트는 single override만 넘긴다.
+    const wireTripDestination: Station = {
       id: '2-022',
       name: '강남',
       line: '2',
@@ -1104,113 +1105,67 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
       lat: 37.4979,
       lng: 127.0276,
     };
-
-    it('hook return의 detectionTier/SignalMask가 Fusion 섹션에 노출된다', async () => {
-      mockUseFusedNearestStation.mockReturnValue(
-        fusedReturnFixture({
-          currentHopIndex: null,
-          routeHopCount: 0,
-          detectionTier: 'high',
-          detectionSignalMask: 'TFT',
-        }),
-      );
+    const applyWireHook = (overrides: Record<string, unknown>) => {
+      mockUseFusedNearestStation.mockReturnValue(fusedReturnFixture(overrides));
+    };
+    const renderAndAwaitLog = async () => {
       renderWithTheme(<DebugModal onClose={jest.fn()} />);
       await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    };
+    const shareAndReadDump = async (): Promise<string> => {
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      await renderAndAwaitLog();
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      shareSpy.mockRestore();
+      return message;
+    };
+
+    it('hook return의 detectionTier/SignalMask가 Fusion 섹션에 노출된다', async () => {
+      applyWireHook({ detectionTier: 'high', detectionSignalMask: 'TFT' });
+      await renderAndAwaitLog();
       expect(screen.getByText('high')).toBeTruthy();
       expect(screen.getByText('TFT')).toBeTruthy();
     });
 
     it('destination null + lock 비활성 → Trip lockless=false, routeHopCount=—', async () => {
-      mockUseFusedNearestStation.mockReturnValue(
-        fusedReturnFixture({
-          currentHopIndex: null,
-          routeHopCount: 0,
-          detectionTier: 'low',
-          detectionSignalMask: '',
-        }),
-      );
-      renderWithTheme(<DebugModal onClose={jest.fn()} />);
-      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-      // Trip lockless row가 'false' 노출. (sleepMode='off'도 동시 노출)
+      applyWireHook({ detectionTier: 'low', detectionSignalMask: '' });
+      await renderAndAwaitLog();
       expect(screen.getAllByText('false').length).toBeGreaterThan(0);
-      // routeHopCount는 destination null이면 '—' 표기.
       expect(screen.getAllByText('—').length).toBeGreaterThan(0);
     });
 
-    it('destination 설정 + lock 비활성 + currentHopIndex=0 → lockless=true, firstHopApproaching=true', async () => {
-      useDestinationStore.setState({ destination: tripDestination });
-      mockUseFusedNearestStation.mockReturnValue(
-        fusedReturnFixture({
-          currentHopIndex: 0,
-          routeHopCount: 5,
-          detectionTier: 'medium',
-          detectionSignalMask: 'TTU',
-        }),
-      );
-      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
-      renderWithTheme(<DebugModal onClose={jest.fn()} />);
-      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-      fireEvent.press(screen.getByTestId('debug-share-dump'));
-      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
-      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+    // currentHopIndex 분기 — 0이면 firstHopApproaching=true, >0이면 false.
+    it.each([
+      [0, 'firstHopApproaching=true'],
+      [2, 'firstHopApproaching=false'],
+    ])('destination 설정 + currentHopIndex=%i → %s', async (idx, expected) => {
+      useDestinationStore.setState({ destination: wireTripDestination });
+      applyWireHook({ currentHopIndex: idx, routeHopCount: 5 });
+      const message = await shareAndReadDump();
       expect(message).toContain('lockless=true');
-      expect(message).toContain('currentHopIndex=0');
+      expect(message).toContain(`currentHopIndex=${idx}`);
       expect(message).toContain('route hop count=5');
-      expect(message).toContain('firstHopApproaching=true');
-      shareSpy.mockRestore();
-    });
-
-    it('destination 설정 + currentHopIndex>0 → firstHopApproaching=false', async () => {
-      useDestinationStore.setState({ destination: tripDestination });
-      mockUseFusedNearestStation.mockReturnValue(
-        fusedReturnFixture({
-          currentHopIndex: 2,
-          routeHopCount: 5,
-          detectionTier: 'medium',
-          detectionSignalMask: 'TTU',
-        }),
-      );
-      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
-      renderWithTheme(<DebugModal onClose={jest.fn()} />);
-      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-      fireEvent.press(screen.getByTestId('debug-share-dump'));
-      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
-      const { message } = shareSpy.mock.calls[0][0] as { message: string };
-      expect(message).toContain('firstHopApproaching=false');
-      shareSpy.mockRestore();
+      expect(message).toContain(expected);
     });
 
     it('useSettingsStore.sleepMode=true → Sleep 섹션 sleepMode=on', async () => {
       useSettingsStore.setState({ sleepMode: true });
-      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
-      renderWithTheme(<DebugModal onClose={jest.fn()} />);
-      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-      fireEvent.press(screen.getByTestId('debug-share-dump'));
-      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
-      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      const message = await shareAndReadDump();
       expect(message).toContain('sleepMode=on');
-      shareSpy.mockRestore();
     });
 
     it('tripStartStorage.getTripStartedAt 값이 Trip 섹션에 흐른다', async () => {
       const tripAt = Date.UTC(2026, 5, 12, 9, 0, 0);
       mockGetTripStartedAt.mockResolvedValue(tripAt);
-      useDestinationStore.setState({ destination: tripDestination });
-      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
-      renderWithTheme(<DebugModal onClose={jest.fn()} />);
-      // tripStartedAt은 비동기 effect로 들어오므로 dump 호출 전 settle 보장.
-      await waitFor(() =>
-        expect(screen.getByText(new Date(tripAt).toISOString())).toBeTruthy(),
-      );
-      fireEvent.press(screen.getByTestId('debug-share-dump'));
-      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
-      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      useDestinationStore.setState({ destination: wireTripDestination });
+      const message = await shareAndReadDump();
       expect(message).toContain(`tripStartedAt=${new Date(tripAt).toISOString()}`);
-      shareSpy.mockRestore();
     });
 
     it('비동기 hydration 중 unmount 시 setState 호출 안 함', async () => {
-      // 영원히 resolve 안 되는 Promise를 반환해 cleanup race를 강제.
+      // 영원히 resolve 안 되는 Promise로 cleanup race 강제.
       let resolveFn: (value: number | null) => void = () => undefined;
       mockGetTripStartedAt.mockReturnValueOnce(
         new Promise<number | null>((resolve) => {
@@ -1219,11 +1174,10 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
       );
       const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
       unmount();
-      // cleanup 후 resolve. cancelled 플래그가 set이라 setState 호출돼선 안 됨.
       await act(async () => {
         resolveFn(123456789);
       });
-      // 단순히 throw 없이 통과하면 성공.
+      // throw 없이 통과하면 성공.
       expect(true).toBe(true);
     });
   });

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import { DebugModal, __test__ } from '../DebugModal';
 import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
+import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import type { AlarmLogEntry } from '../../../../features/alarm/utils/alarmLog';
 import type { Station, NearestStationResult } from '../../../../shared/types/station';
 import type { StationArrival } from '../../../../shared/types/arrival';
@@ -14,6 +15,11 @@ const mockUseSilentPushDiagnostics = jest.fn();
 const mockGetAlarmLog = jest.fn();
 const mockClearAlarmLog = jest.fn();
 const mockUseBarometer = jest.fn();
+// #1235 (D9 wire) — DebugModal이 destinationStore + tripStartStorage SSOT로 trip props 도출.
+const mockGetTripStartedAt = jest.fn();
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: () => mockGetTripStartedAt(),
+}));
 
 jest.mock('../../../nearest-station/hooks/useFusedNearestStation', () => ({
   useFusedNearestStation: () => mockUseFusedNearestStation(),
@@ -110,6 +116,12 @@ const setupHookDefaults = () => {
     error: null,
     permissionDenied: false,
     refresh: jest.fn(),
+    // #1235 (D9 wire) — DebugModal이 hook return으로 fusionDetection/trip 도출. 기본값은
+    // estimator/detection 모두 비어있는 상태 — 미트립 + signalsAvailable=0 시나리오.
+    currentHopIndex: null,
+    routeHopCount: 0,
+    detectionTier: 'low',
+    detectionSignalMask: '',
   });
   mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
   mockUseSilentPushDiagnostics.mockReturnValue({
@@ -131,6 +143,11 @@ const setupHookDefaults = () => {
   mockDumpScheduledNotifications.mockResolvedValue([]);
   // #1215 (D9) — 기본은 subsurface=false (지상).
   mockUseBarometer.mockReturnValue({ subsurface: false, stop: undefined });
+  // #1235 (D9 wire) — tripStartedAt 기본 null (trip 미시작).
+  mockGetTripStartedAt.mockResolvedValue(null);
+  // #1235 (D9 wire) — destinationStore/settingsStore SSOT 초기화. 매 테스트 독립.
+  useDestinationStore.setState({ destination: null });
+  useSettingsStore.setState({ sleepMode: false });
 };
 
 // SonarCloud new_duplicated_lines_density 임계 준수 — 여러 describe에 걸친 buildDumpText
@@ -1073,6 +1090,142 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     expect(message).toContain('sleepMode=on');
     expect(message).toContain('firstHopApproaching=true');
     shareSpy.mockRestore();
+  });
+
+  // #1235 (D9 wire) — props 미전달 시 DebugModal이 hook return + store + tripStartStorage에서
+  // fusionDetection/trip/sleep SSOT를 도출하는 분기 검증. 사용자가 _layout 마운트 지점에서
+  // wrapper 없이 <DebugModal /> 만 쓰더라도 D9 sections에 의미있는 값이 흘러야 한다.
+  describe('SSOT wire (props 미전달 → hook+store 도출)', () => {
+    const tripDestination: Station = {
+      id: '2-022',
+      name: '강남',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.4979,
+      lng: 127.0276,
+    };
+
+    it('hook return의 detectionTier/SignalMask가 Fusion 섹션에 노출된다', async () => {
+      mockUseFusedNearestStation.mockReturnValue(
+        fusedReturnFixture({
+          currentHopIndex: null,
+          routeHopCount: 0,
+          detectionTier: 'high',
+          detectionSignalMask: 'TFT',
+        }),
+      );
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText('high')).toBeTruthy();
+      expect(screen.getByText('TFT')).toBeTruthy();
+    });
+
+    it('destination null + lock 비활성 → Trip lockless=false, routeHopCount=—', async () => {
+      mockUseFusedNearestStation.mockReturnValue(
+        fusedReturnFixture({
+          currentHopIndex: null,
+          routeHopCount: 0,
+          detectionTier: 'low',
+          detectionSignalMask: '',
+        }),
+      );
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      // Trip lockless row가 'false' 노출. (sleepMode='off'도 동시 노출)
+      expect(screen.getAllByText('false').length).toBeGreaterThan(0);
+      // routeHopCount는 destination null이면 '—' 표기.
+      expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    });
+
+    it('destination 설정 + lock 비활성 + currentHopIndex=0 → lockless=true, firstHopApproaching=true', async () => {
+      useDestinationStore.setState({ destination: tripDestination });
+      mockUseFusedNearestStation.mockReturnValue(
+        fusedReturnFixture({
+          currentHopIndex: 0,
+          routeHopCount: 5,
+          detectionTier: 'medium',
+          detectionSignalMask: 'TTU',
+        }),
+      );
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      expect(message).toContain('lockless=true');
+      expect(message).toContain('currentHopIndex=0');
+      expect(message).toContain('route hop count=5');
+      expect(message).toContain('firstHopApproaching=true');
+      shareSpy.mockRestore();
+    });
+
+    it('destination 설정 + currentHopIndex>0 → firstHopApproaching=false', async () => {
+      useDestinationStore.setState({ destination: tripDestination });
+      mockUseFusedNearestStation.mockReturnValue(
+        fusedReturnFixture({
+          currentHopIndex: 2,
+          routeHopCount: 5,
+          detectionTier: 'medium',
+          detectionSignalMask: 'TTU',
+        }),
+      );
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      expect(message).toContain('firstHopApproaching=false');
+      shareSpy.mockRestore();
+    });
+
+    it('useSettingsStore.sleepMode=true → Sleep 섹션 sleepMode=on', async () => {
+      useSettingsStore.setState({ sleepMode: true });
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      expect(message).toContain('sleepMode=on');
+      shareSpy.mockRestore();
+    });
+
+    it('tripStartStorage.getTripStartedAt 값이 Trip 섹션에 흐른다', async () => {
+      const tripAt = Date.UTC(2026, 5, 12, 9, 0, 0);
+      mockGetTripStartedAt.mockResolvedValue(tripAt);
+      useDestinationStore.setState({ destination: tripDestination });
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      // tripStartedAt은 비동기 effect로 들어오므로 dump 호출 전 settle 보장.
+      await waitFor(() =>
+        expect(screen.getByText(new Date(tripAt).toISOString())).toBeTruthy(),
+      );
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      expect(message).toContain(`tripStartedAt=${new Date(tripAt).toISOString()}`);
+      shareSpy.mockRestore();
+    });
+
+    it('비동기 hydration 중 unmount 시 setState 호출 안 함', async () => {
+      // 영원히 resolve 안 되는 Promise를 반환해 cleanup race를 강제.
+      let resolveFn: (value: number | null) => void = () => undefined;
+      mockGetTripStartedAt.mockReturnValueOnce(
+        new Promise<number | null>((resolve) => {
+          resolveFn = resolve;
+        }),
+      );
+      const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      unmount();
+      // cleanup 후 resolve. cancelled 플래그가 set이라 setState 호출돼선 안 됨.
+      await act(async () => {
+        resolveFn(123456789);
+      });
+      // 단순히 throw 없이 통과하면 성공.
+      expect(true).toBe(true);
+    });
   });
 });
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -87,6 +87,11 @@ const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
   error: null,
   permissionDenied: false,
   refresh: jest.fn(),
+  // D2(#1208) + D9 wire(#1235) — useFusedNearestStation 신규 노출 필드 기본값.
+  currentHopIndex: null,
+  arcStations: [],
+  detectionTier: 'low' as const,
+  detectionSignalMask: '',
   ...overrides,
 });
 const arrivalDefaults = {
@@ -116,10 +121,10 @@ const setupHookDefaults = () => {
     error: null,
     permissionDenied: false,
     refresh: jest.fn(),
-    // #1235 (D9 wire) — DebugModal이 hook return으로 fusionDetection/trip 도출. 기본값은
-    // estimator/detection 모두 비어있는 상태 — 미트립 + signalsAvailable=0 시나리오.
+    // D2(#1208) + D9 wire(#1235) — DebugModal이 hook return으로 fusionDetection/trip 도출.
+    // 기본값은 estimator/detection 모두 비어있는 상태 — 미트립 + signalsAvailable=0 시나리오.
     currentHopIndex: null,
-    routeHopCount: 0,
+    arcStations: [],
     detectionTier: 'low',
     detectionSignalMask: '',
   });
@@ -254,20 +259,15 @@ describe('DebugModal', () => {
   });
 
   it('userLocation이 null이면 "no location"을 표시한다', () => {
-    mockUseFusedNearestStation.mockReturnValue({
-      result: null,
-      gpsResult: null,
-      confidence: 'gps-only',
-      source: 'gps',
-      variants: [],
-      userLocation: null,
-      speedMps: null,
-      accuracyMeters: null,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        result: null,
+        gpsResult: null,
+        userLocation: null,
+        speedMps: null,
+        accuracyMeters: null,
+      }),
+    );
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByText('(no location)')).toBeTruthy();
     expect(screen.getByText('(no nearest)')).toBeTruthy();
@@ -340,20 +340,9 @@ describe('DebugModal', () => {
   });
 
   it('speedMps가 null이면 "-"를 표시한다', () => {
-    mockUseFusedNearestStation.mockReturnValue({
-      result: baseResult,
-      gpsResult: baseResult,
-      confidence: 'gps-only',
-      source: 'gps',
-      variants: [],
-      userLocation: { lat: 37.5, lng: 127 },
-      speedMps: null,
-      accuracyMeters: null,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({ speedMps: null, accuracyMeters: null }),
+    );
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getAllByText('-').length).toBeGreaterThan(0);
   });
@@ -420,20 +409,9 @@ describe('DebugModal', () => {
   });
 
   it('Fusion 섹션에 confidence/source/accuracy를 표시한다', async () => {
-    mockUseFusedNearestStation.mockReturnValue({
-      result: baseResult,
-      gpsResult: baseResult,
-      confidence: 'arrival-confirmed',
-      source: 'arrival',
-      variants: [],
-      userLocation: { lat: 37.5, lng: 127 },
-      speedMps: 1,
-      accuracyMeters: 12,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({ confidence: 'arrival-confirmed', source: 'arrival' }),
+    );
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByText('Fusion')).toBeTruthy();
     expect(screen.getByText('arrival-confirmed')).toBeTruthy();
@@ -445,20 +423,15 @@ describe('DebugModal', () => {
 
   it('fused와 gps station id가 다르면 diff 라인을 표시한다', () => {
     const otherStation: Station = { ...station, id: '2-099', name: '역삼' };
-    mockUseFusedNearestStation.mockReturnValue({
-      result: { station, distanceKm: 0.05 },
-      gpsResult: { station: otherStation, distanceKm: 0.18 },
-      confidence: 'arrival-arriving',
-      source: 'arrival',
-      variants: [],
-      userLocation: { lat: 37.5, lng: 127 },
-      speedMps: 1,
-      accuracyMeters: 10,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        result: { station, distanceKm: 0.05 },
+        gpsResult: { station: otherStation, distanceKm: 0.18 },
+        confidence: 'arrival-arriving',
+        source: 'arrival',
+        accuracyMeters: 10,
+      }),
+    );
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByTestId('debug-fusion-diff')).toBeTruthy();
   });
@@ -1137,12 +1110,21 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     });
 
     // currentHopIndex 분기 — 0이면 firstHopApproaching=true, >0이면 false.
+    // arcStations 길이 5 → routeHopCount=5로 DebugModal 내부에서 계산.
+    const fiveHopArc: Station[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `arc-${i}`,
+      name: `역${i}`,
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5,
+      lng: 127,
+    }));
     it.each([
       [0, 'firstHopApproaching=true'],
       [2, 'firstHopApproaching=false'],
     ])('destination 설정 + currentHopIndex=%i → %s', async (idx, expected) => {
       useDestinationStore.setState({ destination: wireTripDestination });
-      applyWireHook({ currentHopIndex: idx, routeHopCount: 5 });
+      applyWireHook({ currentHopIndex: idx, arcStations: fiveHopArc });
       const message = await shareAndReadDump();
       expect(message).toContain('lockless=true');
       expect(message).toContain(`currentHopIndex=${idx}`);
@@ -1184,25 +1166,10 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
 });
 
 describe('DebugModal arrival edge cases', () => {
-  const baseHooks = {
-    result: baseResult,
-    gpsResult: baseResult,
-    confidence: 'gps-only' as const,
-    source: 'gps' as const,
-    variants: [],
-    userLocation: { lat: 37.5, lng: 127 },
-    speedMps: 1,
-    accuracyMeters: 15,
-    loading: false,
-    error: null,
-    permissionDenied: false,
-    refresh: jest.fn(),
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetAlarmLog.mockResolvedValue([]);
-    mockUseFusedNearestStation.mockReturnValue(baseHooks);
+    mockUseFusedNearestStation.mockReturnValue(fusedReturnFixture({ accuracyMeters: 15 }));
   });
 
   it('up.statusMessage가 빈 문자열이면 괄호를 붙이지 않는다', () => {
@@ -1226,20 +1193,15 @@ describe('DebugModal share with null nearest', () => {
     jest.clearAllMocks();
     mockGetAlarmLog.mockResolvedValue([]);
     mockClearAlarmLog.mockResolvedValue(undefined);
-    mockUseFusedNearestStation.mockReturnValue({
-      result: null,
-      gpsResult: null,
-      confidence: 'gps-only',
-      source: 'gps',
-      variants: [],
-      userLocation: null,
-      speedMps: null,
-      accuracyMeters: null,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        result: null,
+        gpsResult: null,
+        userLocation: null,
+        speedMps: null,
+        accuracyMeters: null,
+      }),
+    );
     mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
   });
 
@@ -1990,20 +1952,9 @@ describe('DebugModal — fusedSpeed fallback (#853)', () => {
   });
 
   it('GPS 섹션 렌더링: GPS speed=null + fusedSpeed 전달 시 두 줄 분리 노출', async () => {
-    mockUseFusedNearestStation.mockReturnValue({
-      result: baseResult,
-      gpsResult: baseResult,
-      confidence: 'gps-only',
-      source: 'gps',
-      variants: [],
-      userLocation: { lat: 37.5, lng: 127.0 },
-      speedMps: null,
-      accuracyMeters: 12,
-      loading: false,
-      error: null,
-      permissionDenied: false,
-      refresh: jest.fn(),
-    });
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({ speedMps: null }),
+    );
     renderWithTheme(
       <DebugModal onClose={jest.fn()} fusedSpeed={{ kmh: 18, source: 'position-train' }} />,
     );

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -96,15 +96,33 @@ interface UseFusedNearestStationReturn {
   /**
    * #1208 (Epic #1204 D2) — 현재 채택된 estimator의 arc 위 hop index.
    * useStationAlarm이 station-passed 게이트(`isStationWithinHopWindow`)의 SSOT로 사용.
+   * #1235 (D9 wire) — DebugModal Trip 섹션 currentHopIndex row의 SSOT도 동일.
    * estimator 미채택 시 null — 호출자가 firedAlarms 등의 fallback으로 추정.
    */
   currentHopIndex: number | null;
   /**
    * #1208 — 현재 trip의 arc(탑승역~다음 waypoint) station 배열.
    * useStationAlarm의 hop window 게이트 입력 및 firedAlarms 기반 fallback hop 계산용.
+   * #1235 (D9 wire) — DebugModal Trip 섹션 route hop count row가 length로 사용.
    * route/trip 없으면 빈 배열.
    */
   arcStations: readonly Station[];
+
+  /**
+   * #1235 (D9 wire) — useFusedStationDetection이 산출한 verdict.confidence.
+   * 'high' | 'medium' | 'low'. signalsAvailable=0이어도 항상 정의된다.
+   */
+  detectionTier: import('../../../shared/utils/stationDetectionFusion').StationDetectionConfidence;
+  /**
+   * #1235 (D9 wire) — useFusedStationDetection이 산출한 signalMask 문자열.
+   * 신호 미주입 시 빈 문자열.
+   */
+  detectionSignalMask: string;
+  /**
+   * #1235 (D9 wire) — 호출자가 주입한 barometer.subsurface 패스스루.
+   * 미전달이면 undefined.
+   */
+  subsurface: boolean | undefined;
   refresh: () => Promise<void>;
 }
 
@@ -842,8 +860,12 @@ export function useFusedNearestStation(
     lastFixAtMs: gps.lastFixAtMs,
     positionStability,
     estimatorStrategy: estimate?.strategy ?? null,
+    // D2(#1208) + #1235 (D9 wire) — useStationAlarm hop window 게이트 + DebugModal Trip/Fusion/GPS 섹션 SSOT.
     currentHopIndex: estimate?.index ?? null,
     arcStations,
+    detectionTier: detectionVerdict.confidence,
+    detectionSignalMask: detectionVerdict.signalMask,
+    subsurface: barometerSubsurface,
     refresh: gps.refresh,
   };
 }


### PR DESCRIPTION
## Summary
- D9 PR #1223이 DebugModal에 `fusionDetection` / `trip` / `sleep` optional props를 추가했지만 `app/_layout.tsx`에서 props를 전달하지 않아 D9 sections가 모두 `—`로 표기되던 회귀를 해소.
- `useFusedNearestStation` return에 5개 필드를 추가 노출(estimator + useFusedStationDetection SSOT):
  - `currentHopIndex` — `estimate?.index ?? null`. lock 활성/lockless 모두 동일.
  - `routeHopCount` — `arcStations.length`. 경로 미설정 시 0.
  - `detectionTier` — `useFusedStationDetection().confidence` (`'high' | 'medium' | 'low'`).
  - `detectionSignalMask` — verdict.signalMask 문자열 (신호 미주입 시 빈 문자열).
  - `subsurface` — barometer.subsurface 패스스루.
- DebugModal이 `useDestinationStore` + `useSettingsStore` + `getTripStartedAt`(AsyncStorage SSOT)로 props를 내부 도출. 호출자가 props 명시 시 우선(테스트/외부 주입), 미전달 시 SSOT fallback. 결과적으로 `_layout.tsx` 마운트 지점은 무변경 — 사용자가 DebugModal을 열기만 하면 fusionDetection/trip/sleep이 자동 채워진다.
- `firstHopApproaching = locklessTrip && currentHopIndex === 0` 규칙(SleepRule 트리거 조건과 정렬).
- Sleep 섹션 sleepMode 라벨의 nullable ternary 제거(sleep는 항상 non-null 보장).

## Test plan
- [x] `npm test` — 5122 passed / 100% 커버리지 (lines/functions/branches/statements)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] 신규 테스트 7건:
  - hook의 detectionTier/SignalMask가 Fusion 섹션 노출
  - destination null + lock 비활성 → lockless=false, routeHopCount='—'
  - destination 설정 + currentHopIndex=0 → lockless=true / firstHopApproaching=true
  - destination 설정 + currentHopIndex=2 → firstHopApproaching=false
  - useSettingsStore.sleepMode=true → sleepMode=on
  - tripStartStorage value → Trip 섹션 + dump 흐름
  - 비동기 hydration unmount race cleanup

## Acceptance
- DebugModal share 시 GPS subsurface, Fusion tier/signalMask, Trip(lockless/tripStartedAt/currentHopIndex/route hop count), Sleep(mode/firstHopApproaching) 모두 정상 표시.

Closes #1235
Relates to #1204, #1223