### PR TITLE
test(#1241): 사용자 trip 11건 회귀 가드 unit test

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2326,6 +2326,36 @@ describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
   });
 });
 
+/**
+ * #1241 — 사용자 trip 2026-06-12 회귀 가드
+ *
+ * Evidence SSOT: tasks/epic-lockless-recovery-2026-06-12.md §1~§2
+ *   - 보고 #5 (08:43 trip BG 강제 종료, 환승 leg trainCode 추적 상실)
+ *   - 보고 #10 (오후 trip에서 동일 재발)
+ *   - 디바이스 로그: `boarding-lock auto-ended (consecutiveEtaMissing=5)`
+ *
+ * 기대 동작: 환승 leg에서 새 trainCode가 도착하면 `applyBoardingLockTrainCodeSwap`이
+ *   1) boardingLock.trainCode를 신규로 갱신
+ *   2) consecutiveEtaMissing을 0으로 리셋
+ * → 5회 누적으로 인한 auto-end가 발생하지 않아야 한다.
+ *
+ * 본 describe는 D4 (#1210, PR #1218) 함수가 향후 회귀로 풀리지 않도록 박제한다.
+ * 위 describe('applyBoardingLockTrainCodeSwap (#1210)') 매트릭스가 기능 검증을 담당하고
+ * 본 describe는 사용자 보고와 1:1로 묶는다.
+ */
+describe('사용자 trip 2026-06-12 회귀 가드 (#1241)', () => {
+  it('보고 #5/#10 — 신규 trainCode 도착 시 consecutiveEtaMissing이 0으로 리셋되어 auto-end 방지', () => {
+    const trip = buildD4SwapBaseTrip();
+    expect(trip.consecutiveEtaMissing).toBeGreaterThan(0);
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      buildD4SwapPayload({ trainCode: 'T-NEW', boardingLine: '7' }),
+    );
+    expect(result.boardingLock?.trainCode).toBe('T-NEW');
+    expect(result.consecutiveEtaMissing).toBe(0);
+  });
+});
+
 // ─── GET /admin/quota (#1022) ─────────────────────────────────────────────────
 
 async function getAdminQuota(

--- a/src/features/nearest-station/utils/__tests__/stickyStationGates.test.ts
+++ b/src/features/nearest-station/utils/__tests__/stickyStationGates.test.ts
@@ -160,3 +160,33 @@ describe('shouldUnlockByMotion', () => {
     expect(shouldUnlockByMotion(motion)).toBe(expected);
   });
 });
+
+/**
+ * #1241 — 사용자 trip 2026-06-12 회귀 가드
+ *
+ * Evidence SSOT: tasks/epic-lockless-recovery-2026-06-12.md §1~§2
+ *   - 보고 #3 (08:35:22 어린이대공원→용마산 화면 회귀): sticky station이 trip 활성 + 지하에서도
+ *     motion=automotive로 즉시 unlock되어 GPS sticky 좌표(용마산)가 그대로 노출됨.
+ *   - 기대 동작: subsurface=true + tripActive=true 매트릭스에서 distance/motion 게이트 모두
+ *     false 반환 (지하 dead-zone 좌표는 unlock 트리거 불가).
+ *
+ * 이 describe는 D6 (#1212, PR #1221)에서 적용된 게이트가 향후 회귀로 풀리지 않도록 박제한다.
+ * 위의 describe('shouldUnlockByDistance' / 'shouldUnlockByMotion')의 매트릭스가 기능 검증을
+ * 담당하고, 본 describe는 사용자 보고와 1:1로 묶어 "이 시점에 이 시나리오가 무엇이었는지" 의도를
+ * 코드에 남긴다.
+ */
+describe('사용자 trip 2026-06-12 회귀 가드', () => {
+  const farFix = { lat: 37.4979, lng: 127.0276, accuracyMeters: 20 };
+
+  it('보고 #3 — subsurface + tripActive에서 distance 게이트는 unlock 트리거 금지', () => {
+    expect(
+      shouldUnlockByDistance(seoulStation, { ...farFix, subsurface: true, tripActive: true }),
+    ).toBe(false);
+  });
+
+  it('보고 #3 — subsurface + tripActive에서 motion(automotive) 게이트는 unlock 트리거 금지', () => {
+    expect(
+      shouldUnlockByMotion({ automotive: true, subsurface: true, tripActive: true }),
+    ).toBe(false);
+  });
+});

--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -489,6 +489,41 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
   });
 });
 
+/**
+ * #1241 — 사용자 trip 2026-06-12 회귀 가드
+ *
+ * Evidence SSOT: tasks/epic-lockless-recovery-2026-06-12.md §1~§2
+ *   - 보고 #4 (08:36:46 환승 후 호선 자동 선택 안 됨, 건대입구 7→2)
+ *   - 보고 #9 (오후 trip에서 동일 재발)
+ * 기대 동작: 사용자 명시 의향 trip(=lock 존재 + planned transfer waypoint 도달)에서
+ * arvlCd 우선순위로 단일 train이 결정되면 createTransferLock이 자동 호출되어야 한다.
+ *
+ * 이 describe는 D5 (#1211, PR #1220)에서 적용된 autoLock 트리거가 향후 회귀로 풀리지 않도록
+ * 박제한다. 위 '#1211 D5 환승 leg autoLock 트리거' describe가 기능 검증을 담당하고,
+ * 본 describe는 사용자 보고와 직접 매핑된다.
+ */
+describe('사용자 trip 2026-06-12 회귀 가드', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockPrefetchArrival.mockResolvedValue(undefined);
+  });
+
+  it('보고 #4/#9 — lock 존재 + planned transfer 도달 + arvlCd 단일 train → autoLock 1회', () => {
+    const arrived = makeTrain({ trainCode: 'T-ARRIVED', arrivalCode: 1, arrivalSeconds: 30 });
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [arrived], down: [] }));
+    renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(mockCreateLock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('filterArrivalsByDirection', () => {
   const up = makeTrain({ trainCode: 'UP' });
   const down = makeTrain({ trainCode: 'DN' });


### PR DESCRIPTION
## Summary
2026-06-12 사용자 trip 11건 회귀 보고를 unit test로 박제하여 향후 회귀 시 CI에서 즉시 fail하도록 한다. Epic #1204 acceptance(§7.1 회귀 12개) 측정의 코드 evidence.

## 사용자 보고 → it 케이스 매핑

| 보고 # | Evidence (SSOT §1) | unit test 위치 | 박제 대상 |
|---|---|---|---|
| 3 | 08:35:22 어린이대공원→용마산 화면 회귀 (sticky station unlock) | `stickyStationGates.test.ts` — `'사용자 trip 2026-06-12 회귀 가드' › 보고 #3` (distance + motion 2 케이스) | D6 (#1212, PR #1221) 게이트 |
| 4 / 9 | 08:36:46 환승 후 호선 자동 선택 안 됨 + 오후 재발 | `useTransferTrainList.test.tsx` — `'사용자 trip 2026-06-12 회귀 가드' › 보고 #4/#9` | D5 (#1211, PR #1220) autoLock |
| 5 / 10 | 08:43 trip BG auto-end (`consecutiveEtaMissing=5`) + 오후 재발 | `backend/.../index.test.ts` — `'사용자 trip 2026-06-12 회귀 가드 (#1241)' › 보고 #5/#10` | D4 (#1210, PR #1218) trainCode swap |

## 본 PR에서 다루지 않은 보고 (사유)

| 보고 # | 사유 |
|---|---|
| 2 / 8 (hop window) | D2 (#1208, PR #1234) 미머지 — base에 `isStationWithinHopWindow` 없음. D2 머지 후 별도 PR. |
| 6 (sleep + station-passed) | D8 (#1214, PR #1227) 미머지 — base의 `shouldSuppressBySleepRule`은 `station-passed` 통과(`type === 'transfer'`만 차단). D8 머지 후 별도 PR. |
| 11 (08:37 / 13:28 중복 fire) | #1193 (PR #1202) `parseTripBoundAlarmIdentifier` occurrence suffix 테스트가 이미 cover — `tripBoundScheduler.test.ts:126`. 중복 회피 (이슈 스펙 "기존 테스트가 cover하면 skip"). |
| 1 / 7 | UI/표시 source 일관성 — 별도 fix PR 필요 (단순 박제 대상 X). |

## 박제 패턴
- 각 describe는 SSOT 파일 경로(`tasks/epic-lockless-recovery-2026-06-12.md`)와 보고 번호를 주석에 명시.
- 기능 검증은 기존 매트릭스(`it.each`)가 담당하고, 본 evidence describe는 사용자 보고와 1:1 묶음 의도만 박제 → SonarCloud 중복 위험 회피.
- 박제 it 케이스는 기존 fixture/helper(`seoulStation`, `farFix`, `arrivalRet`, `buildD4SwapBaseTrip` 등)를 재사용.

## Tests
- `npm test` — 5118 tests pass, 100% coverage 유지.
- `backend/alarm-worker`: `vitest run` 1166 tests pass.
- `npm run type-check` pass.
- `npm run lint` pass.

## CI
E2E Smoke는 본 PR 변경 경로(`src/**/__tests__/`, `backend/`)가 ci.yml `changes` job 스킵 기준에 포함되어 자동 skip 예상. Type Check & Test만 게이트.

Closes #1241
Relates to #1204