### PR TITLE
fix(#1240): gps/scenario flow text→testID 마이그레이션

### DIFF
--- a/.maestro/flows/gps/01_near_station.yaml
+++ b/.maestro/flows/gps/01_near_station.yaml
@@ -13,20 +13,21 @@ name: "gps - 역 근처 (강남역)"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(권한 alert) — text 매칭 유지
 - tapOn:
     text: ".*허용.*"
     optional: true
 
 - extendedWaitUntil:
     visible:
-      text: "현재역|Current station"
+      id: "home-origin-label"
     timeout: 15000
 
 - assertVisible:
-    text: "강남|Gangnam"
+    id: "home-origin-station-name"
 - assertVisible:
-    text: "Next trains"
+    id: "home-arrival-section-title"
 - assertVisible:
-    text: "상행|Upbound"
+    id: "arrival-direction-label-up"
 - assertVisible:
-    text: "하행|Downbound"
+    id: "arrival-direction-label-down"

--- a/.maestro/flows/gps/02_station_change.yaml
+++ b/.maestro/flows/gps/02_station_change.yaml
@@ -12,12 +12,15 @@ name: "gps - 역 변경 (강남 → 잠실)"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(권한 alert) — text 매칭 유지
 - tapOn:
     text: ".*허용.*"
     optional: true
 
+# 강남역 표시까지 대기 — testID + text 동시 매칭으로 dynamic station name 검증
 - extendedWaitUntil:
     visible:
+      id: "home-origin-station-name"
       text: "강남|Gangnam"
     timeout: 15000
 
@@ -27,5 +30,6 @@ name: "gps - 역 변경 (강남 → 잠실)"
 
 - extendedWaitUntil:
     visible:
+      id: "home-origin-station-name"
       text: "잠실|Jamsil"
     timeout: 70000

--- a/.maestro/flows/gps/03_jump_rejection.yaml
+++ b/.maestro/flows/gps/03_jump_rejection.yaml
@@ -13,12 +13,14 @@ name: "gps - 경로 잠금 점프 거부 (#310)"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(권한 alert) — text 매칭 유지
 - tapOn:
     text: ".*허용.*"
     optional: true
 
 - extendedWaitUntil:
     visible:
+      id: "home-origin-station-name"
       text: "사가정|Sagajeong"
     timeout: 15000
 
@@ -34,8 +36,10 @@ name: "gps - 경로 잠금 점프 거부 (#310)"
 - tapOn:
     id: "search-input"
 - inputText: "어린이대공원"
-- assertVisible:
-    id: "suggestions-list"
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
 - tapOn:
     id: "suggestion-item-7-018"
 
@@ -54,4 +58,5 @@ name: "gps - 경로 잠금 점프 거부 (#310)"
       - evalScript: maestro.wait(1000)
 
 - assertVisible:
+    id: "home-origin-station-name"
     text: "사가정|Sagajeong"

--- a/.maestro/flows/gps/04_no_station_nearby.yaml
+++ b/.maestro/flows/gps/04_no_station_nearby.yaml
@@ -12,14 +12,15 @@ name: "gps - 역에서 먼 곳"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(권한 alert) — text 매칭 유지
 - tapOn:
     text: ".*허용.*"
     optional: true
 
 - extendedWaitUntil:
     visible:
-      text: "지하철역 근처가 아닙니다|Not near a subway station"
+      id: "home-not-near-station-title"
     timeout: 15000
 
 - assertVisible:
-    text: "새로고침|Refresh"
+    id: "home-refresh-button"

--- a/.maestro/flows/scenario/01_alarm_foreground_arrival.yaml
+++ b/.maestro/flows/scenario/01_alarm_foreground_arrival.yaml
@@ -13,6 +13,7 @@ name: "scenario - 포그라운드 도착 알람"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(dev menu / permission alert) — text 매칭 유지
 - tapOn:
     text: ".*localhost.*"
     optional: true
@@ -39,8 +40,10 @@ name: "scenario - 포그라운드 도착 알람"
 - evalScript: maestro.wait(500)
 - pasteText
 - evalScript: maestro.wait(2000)
-- assertVisible:
-    id: "suggestions-list"
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
 - tapOn:
     id: "suggestion-item-2-016"
 - waitForAnimationToEnd
@@ -50,6 +53,7 @@ name: "scenario - 포그라운드 도착 알람"
     element:
       id: "home-sleep-mode-switch"
     direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "home-sleep-mode-switch"
 - evalScript: maestro.wait(1000)
@@ -64,7 +68,9 @@ name: "scenario - 포그라운드 도착 알람"
     commands:
       - evalScript: maestro.wait(1000)
 
+- extendedWaitUntil:
+    visible:
+      id: "alarm-overlay-title"
+    timeout: 5000
 - assertVisible:
-    text: "하차 알림"
-- assertVisible:
-    text: "알람 끄기"
+    id: "alarm-dismiss-button"

--- a/.maestro/flows/scenario/02_alarm_overlay_resume.yaml
+++ b/.maestro/flows/scenario/02_alarm_overlay_resume.yaml
@@ -12,6 +12,7 @@ name: "scenario - AlarmOverlay 해제"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(dev menu / permission alert) — text 매칭 유지
 - tapOn:
     text: ".*localhost.*"
     optional: true
@@ -37,8 +38,10 @@ name: "scenario - AlarmOverlay 해제"
 - evalScript: maestro.wait(500)
 - pasteText
 - evalScript: maestro.wait(2000)
-- assertVisible:
-    id: "suggestions-list"
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
 - tapOn:
     id: "suggestion-item-2-016"
 - waitForAnimationToEnd
@@ -47,6 +50,7 @@ name: "scenario - AlarmOverlay 해제"
     element:
       id: "home-sleep-mode-switch"
     direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "home-sleep-mode-switch"
 - evalScript: maestro.wait(1000)
@@ -60,13 +64,15 @@ name: "scenario - AlarmOverlay 해제"
     commands:
       - evalScript: maestro.wait(1000)
 
+- extendedWaitUntil:
+    visible:
+      id: "alarm-overlay-title"
+    timeout: 5000
 - assertVisible:
-    text: "하차 알림"
-- assertVisible:
-    text: ".*내리세요"
+    id: "alarm-overlay-message"
 
 - tapOn:
-    text: "알람 끄기"
+    id: "alarm-dismiss-button"
 - evalScript: maestro.wait(1000)
 - assertVisible:
     id: "destination-button"

--- a/.maestro/flows/scenario/03_map_set_destination_auto_switch.yaml
+++ b/.maestro/flows/scenario/03_map_set_destination_auto_switch.yaml
@@ -12,6 +12,7 @@ name: "scenario - 지도 도착역 설정 → 홈 자동 전환"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(dev menu / permission alert) — text 매칭 유지
 - tapOn:
     text: ".*localhost.*"
     optional: true
@@ -31,9 +32,11 @@ name: "scenario - 지도 도착역 설정 → 홈 자동 전환"
     timeout: 15000
 - extendedWaitUntil:
     visible:
+      id: "home-origin-station-name"
       text: "강남"
     timeout: 60000
 
+# Map 탭으로 이동 — 탭바는 좌표 탭 (네이티브 tab UI라 testID 부착 불가)
 - tapOn:
     point: "37%,95%"
 - extendedWaitUntil:
@@ -41,8 +44,9 @@ name: "scenario - 지도 도착역 설정 → 홈 자동 전환"
       id: "recenter-button"
     timeout: 10000
 
+# 지도 마커: 그룹 키는 normalize(station name) — 강남 마커
 - tapOn:
-    text: "강남"
+    id: "marker-강남"
 - extendedWaitUntil:
     visible:
       id: "set-destination-button"

--- a/.maestro/flows/scenario/04_map_search_dismisses_keyboard.yaml
+++ b/.maestro/flows/scenario/04_map_search_dismisses_keyboard.yaml
@@ -12,6 +12,7 @@ name: "scenario - 지도 검색 후 키보드 자동 해제"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(dev menu / permission alert) — text 매칭 유지
 - tapOn:
     text: ".*localhost.*"
     optional: true
@@ -31,9 +32,11 @@ name: "scenario - 지도 검색 후 키보드 자동 해제"
     timeout: 15000
 - extendedWaitUntil:
     visible:
+      id: "home-origin-station-name"
       text: "강남"
     timeout: 60000
 
+# Map 탭으로 이동 — 탭바는 좌표 탭
 - tapOn:
     point: "37%,95%"
 - extendedWaitUntil:

--- a/.maestro/flows/scenario/05_dark_mode_persists.yaml
+++ b/.maestro/flows/scenario/05_dark_mode_persists.yaml
@@ -12,6 +12,7 @@ name: "scenario - 다크모드 재시작 후 즉시 적용"
       location: always
       notifications: allow
 
+# 외부 시스템 UI(dev menu / permission alert) — text 매칭 유지
 - tapOn:
     text: ".*localhost.*"
     optional: true
@@ -31,11 +32,13 @@ name: "scenario - 다크모드 재시작 후 즉시 적용"
     timeout: 15000
 - extendedWaitUntil:
     visible:
+      id: "home-origin-station-name"
       text: "강남"
     timeout: 60000
 
 - takeScreenshot: .maestro/screenshots/01_initial_home_light
 
+# Settings 탭 — 좌표 탭
 - tapOn:
     point: "87%,95%"
 - tapOn:
@@ -68,11 +71,13 @@ name: "scenario - 다크모드 재시작 후 즉시 적용"
     timeout: 15000
 - extendedWaitUntil:
     visible:
+      id: "home-origin-station-name"
       text: "강남"
     timeout: 60000
 
 - takeScreenshot: .maestro/screenshots/03_home_after_restart_should_be_dark
 
+# Settings 탭 — 좌표 탭
 - tapOn:
     point: "87%,95%"
 - extendedWaitUntil:

--- a/src/features/alarm/components/AlarmOverlay.tsx
+++ b/src/features/alarm/components/AlarmOverlay.tsx
@@ -47,8 +47,12 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
   return (
     <Modal visible animationType="fade" testID="alarm-overlay" onRequestClose={handleDismiss}>
       <View style={[styles.container, { backgroundColor: colors.bg }]}>
-        <Text style={[styles.title, { color: colors.accent }]}>{title}</Text>
-        <Text style={[styles.station, { color: colors.ink }]}>{message}</Text>
+        <Text style={[styles.title, { color: colors.accent }]} testID="alarm-overlay-title">
+          {title}
+        </Text>
+        <Text style={[styles.station, { color: colors.ink }]} testID="alarm-overlay-message">
+          {message}
+        </Text>
         <TouchableOpacity
           style={[styles.button, { backgroundColor: colors.accent }]}
           onPress={handleDismiss}

--- a/src/features/alarm/components/__tests__/AlarmOverlay.test.tsx
+++ b/src/features/alarm/components/__tests__/AlarmOverlay.test.tsx
@@ -36,15 +36,19 @@ describe('AlarmOverlay', () => {
   });
 
   it('하차 알림을 표시한다', () => {
-    const { getByText } = renderAlarm('destination', '강남');
+    const { getByText, getByTestId } = renderAlarm('destination', '강남');
     expect(getByText('하차 알림')).toBeTruthy();
     expect(getByText('강남에서\n내리세요')).toBeTruthy();
+    expect(getByTestId('alarm-overlay-title')).toBeTruthy();
+    expect(getByTestId('alarm-overlay-message')).toBeTruthy();
   });
 
   it('환승 알림을 표시한다', () => {
-    const { getByText } = renderAlarm('transfer', '시청');
+    const { getByText, getByTestId } = renderAlarm('transfer', '시청');
     expect(getByText('환승 알림')).toBeTruthy();
     expect(getByText('시청에서\n환승하세요')).toBeTruthy();
+    expect(getByTestId('alarm-overlay-title')).toBeTruthy();
+    expect(getByTestId('alarm-overlay-message')).toBeTruthy();
   });
 
   it('환승 알람 dismiss → trip 유지. clearAlarmNotification만 호출 (#633)', async () => {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -722,7 +722,11 @@ export default function HomeScreen() {
       <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.center}>
           <Text style={[styles.errorText, { color: colors.accent }]}>{error}</Text>
-          <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+          <TouchableOpacity
+            style={[styles.button, { backgroundColor: colors.accent }]}
+            onPress={refresh}
+            testID="home-refresh-button"
+          >
             <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('home.refresh')}</Text>
           </TouchableOpacity>
         </View>
@@ -787,7 +791,10 @@ export default function HomeScreen() {
             <ServiceWindowBanner stationName={effectiveOrigin.name} line={effectiveOrigin.line} />
             {/* Hero: origin station */}
             <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxxl - 4 }}>
-              <Text style={[typography.label, { color: colors.muted, marginBottom: 10 }]}>
+              <Text
+                style={[typography.label, { color: colors.muted, marginBottom: 10 }]}
+                testID="home-origin-label"
+              >
                 {isCustomOrigin
                   ? t('home.originManual')
                   : source !== 'gps'
@@ -1154,8 +1161,16 @@ export default function HomeScreen() {
 
             {/* #634: BoardingTrainList 두 인스턴스(현재역/환승)는 route 박스 안으로 이동됨. */}
             {effectiveOrigin && (
-              <View style={[styles.arrivalSection, { backgroundColor: colors.card }]}>
-                <Text style={[styles.sectionTitle, { color: colors.muted }]}>{t('home.arrivalInfoTitle')}</Text>
+              <View
+                style={[styles.arrivalSection, { backgroundColor: colors.card }]}
+                testID="home-arrival-section"
+              >
+                <Text
+                  style={[styles.sectionTitle, { color: colors.muted }]}
+                  testID="home-arrival-section-title"
+                >
+                  {t('home.arrivalInfoTitle')}
+                </Text>
                 {arrivalLoading && !arrival && (
                   <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.loading')}</Text>
                 )}
@@ -1186,16 +1201,29 @@ export default function HomeScreen() {
             <Text style={styles.icon}>📍</Text>
             <Text style={[styles.title, { color: colors.ink }]}>{t('home.locationUncertainTitle')}</Text>
             <Text style={[styles.subtitle, { color: colors.muted }]}>{t('home.locationUncertainDescription')}</Text>
-            <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+            <TouchableOpacity
+              style={[styles.button, { backgroundColor: colors.accent }]}
+              onPress={refresh}
+              testID="home-refresh-button"
+            >
               <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('home.refresh')}</Text>
             </TouchableOpacity>
           </View>
         ) : (
-          <View style={styles.center}>
+          <View style={styles.center} testID="home-not-near-station">
             <Text style={styles.icon}>🚶</Text>
-            <Text style={[styles.title, { color: colors.ink }]}>{t('home.notNearStationTitle')}</Text>
+            <Text
+              style={[styles.title, { color: colors.ink }]}
+              testID="home-not-near-station-title"
+            >
+              {t('home.notNearStationTitle')}
+            </Text>
             <Text style={[styles.subtitle, { color: colors.muted }]}>{t('home.notNearStationDescription')}</Text>
-            <TouchableOpacity style={[styles.button, { backgroundColor: colors.accent }]} onPress={refresh}>
+            <TouchableOpacity
+              style={[styles.button, { backgroundColor: colors.accent }]}
+              onPress={refresh}
+              testID="home-refresh-button"
+            >
               <Text style={[styles.buttonText, { color: colors.onAccent }]}>{t('home.refresh')}</Text>
             </TouchableOpacity>
           </View>
@@ -1313,8 +1341,16 @@ function ArrivalDirectionGroup({
     [items, label, line, stationName, directionKey],
   );
   return (
-    <View style={[styles.arrivalGroup, { borderTopColor: colors.hair }]}>
-      <Text style={[styles.arrivalLabel, { color: colors.muted }]}>{label}</Text>
+    <View
+      style={[styles.arrivalGroup, { borderTopColor: colors.hair }]}
+      testID={`arrival-direction-${directionKey}`}
+    >
+      <Text
+        style={[styles.arrivalLabel, { color: colors.muted }]}
+        testID={`arrival-direction-label-${directionKey}`}
+      >
+        {label}
+      </Text>
       {trains.length === 0 ? (
         <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.noArrivalInfo')}</Text>
       ) : (


### PR DESCRIPTION
## Summary

#1230 smoke flow testID 마이그레이션 후속. nightly 안정화를 위해 `.maestro/flows/gps/` + `.maestro/flows/scenario/` 전체 flow의 앱 내부 element를 text 매칭에서 testID(`id`) 매칭으로 전환한다. 외부 시스템 UI(권한 alert, dev menu)는 text 매칭 유지.

## 마이그레이션 flow (9개)

### gps/
- `01_near_station.yaml` — 현재역 라벨/역명/도착정보 섹션/상하행 라벨 id 전환
- `02_station_change.yaml` — 역명 동적 매칭은 `id` + `text` 조합 (강남→잠실)
- `03_jump_rejection.yaml` — 사가정 역명 id+text, suggestions-list `extendedWaitUntil` + timeout 명시
- `04_no_station_nearby.yaml` — 안내 타이틀/새로고침 버튼 id 전환

### scenario/
- `01_alarm_foreground_arrival.yaml` — 알람 오버레이 id 전환, `scrollUntilVisible` timeout 명시
- `02_alarm_overlay_resume.yaml` — 알람 제목/메시지/dismiss 모두 id 전환
- `03_map_set_destination_auto_switch.yaml` — 강남 마커는 `marker-강남` id, 홈 역명은 id+text
- `04_map_search_dismisses_keyboard.yaml` — 홈 역명은 id+text 조합
- `05_dark_mode_persists.yaml` — 홈 역명은 id+text 조합

## 추가된 testID

| testID | 위치 |
| --- | --- |
| `home-origin-label` | `HomeScreen` 출발역 라벨(현재역/추정/직접지정 공통) |
| `home-arrival-section` | `HomeScreen` 도착 정보 섹션 컨테이너 |
| `home-arrival-section-title` | `HomeScreen` 도착 정보 섹션 제목 |
| `arrival-direction-up` / `arrival-direction-down` | `ArrivalDirectionGroup` 컨테이너 |
| `arrival-direction-label-up` / `arrival-direction-label-down` | `ArrivalDirectionGroup` 라벨 |
| `home-refresh-button` | `HomeScreen` 새로고침 버튼(error/uncertain/notNear 분기 공통) |
| `home-not-near-station` / `home-not-near-station-title` | 역 미근접 안내 컨테이너/타이틀 |
| `alarm-overlay-title` / `alarm-overlay-message` | `AlarmOverlay` 제목/메시지 |

## 외부 시스템 UI는 text 유지

- `.*localhost.*` (Expo dev menu)
- `"Continue"` (iOS 권한 다이얼로그)
- `".*허용.*"` / `"허용"` (iOS 위치/알림 권한 alert)

탭바는 native tab UI라 testID 부착 불가 → 좌표 탭(`point`) 유지.

## Test plan

- [x] `npm test` 100% coverage 유지 (5115 tests / 274 suites)
- [x] `npm run type-check` pass
- [x] `npm run lint` pass
- [x] AlarmOverlay unit test에 신규 testID assertion 추가
- [ ] nightly gps/scenario job 통과 확인 (PR CI 게이트 아님 — 실기기/nightly 회귀)

## Notes

- 본 PR CI는 smoke만 검증 (gps/scenario는 nightly 전용, ci.yml `changes` job 스킵 경로에 포함됨)
- gps/scenario flow는 PR 게이트가 아니라 사용자 실기기 + nightly로 검증

Closes #1240
Relates to #1228, #1230