### PR TITLE
fix(#1242): 위젯 Phase 4 회귀 가드 (config integrity 단위 테스트)

### DIFF
--- a/src/features/widget/__tests__/widgetConfigIntegrity.test.ts
+++ b/src/features/widget/__tests__/widgetConfigIntegrity.test.ts
@@ -9,8 +9,8 @@
  * 본 테스트는 두 entitlements SSOT가 같은 App Group을 선언하는지, 그리고 과거에
  * 사용되던 `expo-target.json` (dead 파일) 이 부활하지 않는지를 검증한다.
  */
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 const APP_GROUP_KEY = 'com.apple.security.application-groups';
 const EXPECTED_APP_GROUP = 'group.com.subwaynow.app';
@@ -52,8 +52,9 @@ const loadLiveActivityAppGroups = (): readonly string[] => {
   const raw = readFileSync(liveActivityPluginPath, 'utf8');
   // 메인 앱 entitlements는 modules/live-activity/app.plugin.js의 withEntitlementsPlist
   // 콜백이 inline으로 주입한다. 동적 import 없이 정적 검증을 위해 라인 자체를 검사한다.
+  const escapedKey = APP_GROUP_KEY.replaceAll('.', String.raw`\.`);
   const pattern = new RegExp(
-    `['"]${APP_GROUP_KEY.replace(/\./g, '\\.')}['"]\\s*\\]?\\s*=\\s*\\[([^\\]]+)\\]`,
+    String.raw`['"]` + escapedKey + String.raw`['"]\s*\]?\s*=\s*\[([^\]]+)\]`,
   );
   const match = pattern.exec(raw);
   if (!match) {
@@ -85,7 +86,8 @@ describe('widget config integrity (#1242 regression guard)', () => {
     const widgetGroups = loadWidgetEntitlements()[APP_GROUP_KEY] as readonly string[];
     const mainGroups = loadLiveActivityAppGroups();
     // 양쪽이 같은 set이어야 위젯이 메인 앱의 SharedGroupPreferences를 읽을 수 있다.
-    expect([...widgetGroups].sort()).toEqual([...mainGroups].sort());
+    const byLocale = (a: string, b: string): number => a.localeCompare(b);
+    expect([...widgetGroups].sort(byLocale)).toEqual([...mainGroups].sort(byLocale));
   });
 
   it('과거의 expo-target.json (dead 파일)이 부활하지 않는다', () => {

--- a/src/features/widget/__tests__/widgetConfigIntegrity.test.ts
+++ b/src/features/widget/__tests__/widgetConfigIntegrity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * 위젯 Phase 4 회귀 가드 (issue #1242).
+ *
+ * Phase 1 (#1232 머지) 회귀 evidence: `targets/subway-widget/expo-target.config.json`에
+ * `entitlements` 필드가 누락되어 `@bacons/apple-targets` plugin이 위젯 Xcode 타깃에
+ * `CODE_SIGN_ENTITLEMENTS`를 부착하지 않았고, 결과적으로 위젯이 App Groups에 접근하지
+ * 못해 현재 역 정보를 읽지 못했다. 자동 게이트가 잡지 못한 회귀였다.
+ *
+ * 본 테스트는 두 entitlements SSOT가 같은 App Group을 선언하는지, 그리고 과거에
+ * 사용되던 `expo-target.json` (dead 파일) 이 부활하지 않는지를 검증한다.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+const APP_GROUP_KEY = 'com.apple.security.application-groups';
+const EXPECTED_APP_GROUP = 'group.com.subwaynow.app';
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+
+const widgetConfigPath = join(
+  REPO_ROOT,
+  'targets',
+  'subway-widget',
+  'expo-target.config.json',
+);
+const liveActivityPluginPath = join(
+  REPO_ROOT,
+  'modules',
+  'live-activity',
+  'app.plugin.js',
+);
+const deadTargetConfigPath = join(
+  REPO_ROOT,
+  'targets',
+  'subway-widget',
+  'expo-target.json',
+);
+
+const loadWidgetEntitlements = (): Record<string, unknown> => {
+  const raw = readFileSync(widgetConfigPath, 'utf8');
+  const parsed = JSON.parse(raw) as { entitlements?: Record<string, unknown> };
+  if (!parsed.entitlements) {
+    throw new Error(
+      `widget expo-target.config.json에 entitlements 키가 없음. Phase 1 (#1232) 회귀 재발: ` +
+        `위젯 Xcode 타깃에 CODE_SIGN_ENTITLEMENTS 미부착 → App Groups 접근 불가. ` +
+        `복구: { "entitlements": { "${APP_GROUP_KEY}": ["${EXPECTED_APP_GROUP}"] } } 추가.`,
+    );
+  }
+  return parsed.entitlements;
+};
+
+const loadLiveActivityAppGroups = (): readonly string[] => {
+  const raw = readFileSync(liveActivityPluginPath, 'utf8');
+  // 메인 앱 entitlements는 modules/live-activity/app.plugin.js의 withEntitlementsPlist
+  // 콜백이 inline으로 주입한다. 동적 import 없이 정적 검증을 위해 라인 자체를 검사한다.
+  const pattern = new RegExp(
+    `['"]${APP_GROUP_KEY.replace(/\./g, '\\.')}['"]\\s*\\]?\\s*=\\s*\\[([^\\]]+)\\]`,
+  );
+  const match = pattern.exec(raw);
+  if (!match) {
+    throw new Error(
+      `live-activity app.plugin.js에서 ${APP_GROUP_KEY} 선언을 찾지 못함. ` +
+        `메인 앱 entitlements에서 App Groups가 제거되면 위젯과 sync가 깨진다.`,
+    );
+  }
+  return match[1]
+    .split(',')
+    .map((entry) => entry.trim().replace(/^['"]|['"]$/g, ''))
+    .filter((entry) => entry.length > 0);
+};
+
+describe('widget config integrity (#1242 regression guard)', () => {
+  it('widget expo-target.config.json은 entitlements와 App Groups 배열을 선언한다', () => {
+    const entitlements = loadWidgetEntitlements();
+    const appGroups = entitlements[APP_GROUP_KEY];
+    expect(Array.isArray(appGroups)).toBe(true);
+    expect(appGroups).toContain(EXPECTED_APP_GROUP);
+  });
+
+  it('메인 앱 entitlements (live-activity plugin)는 같은 App Group을 선언한다', () => {
+    const appGroups = loadLiveActivityAppGroups();
+    expect(appGroups).toContain(EXPECTED_APP_GROUP);
+  });
+
+  it('메인 앱과 위젯이 동일한 App Groups 집합을 공유한다 (sync 깨짐 차단)', () => {
+    const widgetGroups = loadWidgetEntitlements()[APP_GROUP_KEY] as readonly string[];
+    const mainGroups = loadLiveActivityAppGroups();
+    // 양쪽이 같은 set이어야 위젯이 메인 앱의 SharedGroupPreferences를 읽을 수 있다.
+    expect([...widgetGroups].sort()).toEqual([...mainGroups].sort());
+  });
+
+  it('과거의 expo-target.json (dead 파일)이 부활하지 않는다', () => {
+    // expo-target.json은 구버전 schema. @bacons/apple-targets는 expo-target.config.{json,js}만
+    // 인식한다. dead 파일이 다시 생기면 사람 눈에 "설정처럼 보이지만" 실제로는 무시되어
+    // Phase 1 같은 silent regression을 유발한다.
+    expect(existsSync(deadTargetConfigPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 (#1232 머지) 위젯 detecting 회귀를 미래에 차단하기 위한 단위 테스트 추가.

### 회귀 evidence (#1232)

- `targets/subway-widget/expo-target.config.json`에 `entitlements` 필드가 누락 → `@bacons/apple-targets` plugin이 위젯 Xcode 타깃에 `CODE_SIGN_ENTITLEMENTS`를 부착하지 못함 → 위젯이 App Groups에 접근 불가 → 현재 역 표기 회귀.
- 자동 게이트(`npm test` / `npm run type-check` / `npm run lint` / E2E Smoke)는 native 설정 파일을 검증하지 않아 차단 실패.

### Change A — 단위 테스트 (`src/features/widget/__tests__/widgetConfigIntegrity.test.ts`)

4건의 회귀 시나리오를 잠금:

1. 위젯 `expo-target.config.json`에 `entitlements.com.apple.security.application-groups` 배열이 존재하고 `group.com.subwaynow.app` 포함.
2. 메인 앱 entitlements SSOT(`modules/live-activity/app.plugin.js`의 `withEntitlementsPlist` 콜백)에 같은 App Group 선언.
3. 위젯 ↔ 메인 두 SSOT가 동일한 App Groups 집합 공유 (sync drift 차단).
4. 과거 schema 파일 `targets/subway-widget/expo-target.json`이 부활하지 않음 (silent regression 차단 — `@bacons/apple-targets`는 `expo-target.config.{json,js}`만 인식).

회귀 시뮬레이션: 임시로 widget config에서 entitlements 필드를 제거 → 1·3번 테스트가 fail (명시적 에러 메시지로 복구 가이드 포함) 확인 후 원복.

### Change B — CI prebuild sync 가드 (생략 결정)

이슈 본문에서 best-effort로 표시된 `expo prebuild --clean` diff 검증 step은 본 PR에서 생략한다:

- `ios/`는 `.gitignore` 대상이라 prebuild 결과 diff가 git에 잡히지 않음 → 검증 가능한 추적 파일이 없음.
- 메인 app entitlements SSOT는 `app.config.js`가 아니라 `modules/live-activity/app.plugin.js`이고, 이 파일과 위젯 `expo-target.config.json`이 본 단위 테스트로 직접 잠긴다 → prebuild 산출물을 우회해 SSOT 자체를 검증하는 편이 더 빠르고 결정적.
- 매 PR에 `expo prebuild` (~30s) 비용을 추가하는 trade-off가 단위 테스트로 cover된 케이스에는 정당화되지 않음.

### Verification

- `npm test` (5122 tests / 275 suites pass, 100% coverage 유지)
- `npm run type-check` pass
- `npm run lint` pass
- 회귀 시뮬레이션으로 테스트가 실제 회귀를 잡는지 확인 (entitlements 필드 제거 → fail)

Closes #1242
Relates to #1231