### PR TITLE
feat(#1208): D2 hop window 게이트 (dev 머지 복구)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -78,6 +78,8 @@ const mockLogSuppressedPhaseGate = jest.fn();
 const mockLogSuppressedSleepFirstTransfer = jest.fn();
 const mockLogSuppressedDismissSilence = jest.fn();
 const mockLogSuppressedStationPassedWarmup = jest.fn();
+const mockLogSuppressedHopWindow = jest.fn();
+const mockLogSuppressedHopWindowNoSource = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -93,6 +95,9 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
   logSuppressedStationPassedWarmup: (...args: unknown[]) =>
     mockLogSuppressedStationPassedWarmup(...args),
+  logSuppressedHopWindow: (...args: unknown[]) => mockLogSuppressedHopWindow(...args),
+  logSuppressedHopWindowNoSource: (...args: unknown[]) =>
+    mockLogSuppressedHopWindowNoSource(...args),
 }));
 
 const mockGetBoardingLock = jest.fn();
@@ -2872,6 +2877,246 @@ describe('useStationAlarm', () => {
       expect(phasesAfterStaleResolve).not.toContain('storage-synced');
       expect(phasesAfterStaleResolve).not.toContain('ready');
       unmount();
+    });
+  });
+
+  describe('#1208 (Epic #1204 D2) station-passed hop window 게이트', () => {
+    // arcStations: 7개 (S0~S6), 모두 line='2' — isStationOnRoute(direct, '2') 통과.
+    const arc: Station[] = Array.from({ length: 7 }, (_, i) =>
+      makeStation(`A${i}`, `Sname${i}`, 37.5 + i * 0.001, 127.0 + i * 0.001),
+    );
+    const directRouteOnLine2 = makeDirectRoute(6, '2');
+
+    it('22:11:56 사가정 회귀 차단 — lockless + currentHopIndex=2 + candidate arc[6] → suppressed', async () => {
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[6],
+            currentHopIndex: 2,
+            arcStations: arc,
+            // station-passed effect 통과 조건 — accuracy 통과.
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arc[6].name,
+          currentHopIndex: 2,
+          candidateIndex: 6,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('13:28:35 성수 fire 차단 — lockless + currentHopIndex=2 + candidate arc[6] (=현재+4) → suppressed', async () => {
+      // 4정거장 미래 — currentHopIndex=2면 window [1,3]이라 candidate 6은 차단.
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[6],
+            currentHopIndex: 2,
+            arcStations: arc,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('lock 활성 + 정상 hop (currentHopIndex=3, candidate arc[3]) → 통과 (기존 동작 보존)', async () => {
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[3],
+            currentHopIndex: 3,
+            arcStations: arc,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+    });
+
+    it('estimator null + firedAlarms 빈 set + candidate arc[0] → pass (graceful fallback no-source)', async () => {
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 6,
+        isTransfer: false,
+        stopsToDestination: 6,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[0],
+            currentHopIndex: null,
+            arcStations: arc,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arc[0].name,
+        });
+      });
+      // 게이트 미적용이므로 알람은 정상 발사된다.
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+    });
+
+    it('arcStations 빈 배열 → 게이트 자체 미적용 (기존 동작 보존)', async () => {
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 1,
+        isTransfer: false,
+        stopsToDestination: 1,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[0],
+            currentHopIndex: 5,
+            arcStations: [],
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+      expect(mockLogSuppressedHopWindowNoSource).not.toHaveBeenCalled();
+    });
+
+    it('firedAlarms fallback — fired set의 station이 arc 밖이면 inferred=-1 → no-source 적재 + 게이트 미적용', async () => {
+      mockGetFiredAlarms.mockResolvedValue(new Set<string>(['early:OFFROUTE_STATION']));
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 1,
+        isTransfer: false,
+        stopsToDestination: 1,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[0],
+            currentHopIndex: null,
+            arcStations: arc,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalled();
+      });
+      // 게이트 미적용 → 알람 정상 발사.
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+    });
+
+    it('firedAlarms fallback — fired set의 max station이 arc 마지막이면 inferred는 arc 마지막에 cap', async () => {
+      // arc[6] (마지막) 발사 기록 → inferred = min(6+1, 6) = 6. window [5,7] → arc[5] 통과.
+      mockGetFiredAlarms.mockResolvedValue(new Set<string>([`early:${arc[6].name}`]));
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 1,
+        isTransfer: false,
+        stopsToDestination: 1,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[5],
+            currentHopIndex: null,
+            arcStations: arc,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+    });
+
+    it('firedAlarms fallback — fired set에 arc[2] station 포함 시 inferred hop=3 → arc[5] 차단 / arc[3] 통과', async () => {
+      // firedAlarms에 "early:Sname2" 적재 → arc index 2가 max → inferred = 3.
+      // window [2,4]이므로 arc[5]는 차단, arc[3]은 통과.
+      mockGetFiredAlarms.mockResolvedValue(new Set<string>([`early:${arc[2].name}`]));
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 2,
+        isTransfer: false,
+        stopsToDestination: 2,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRouteOnLine2,
+            destination,
+            nearestStation: arc[5],
+            currentHopIndex: null,
+            arcStations: arc,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arc[5].name,
+          currentHopIndex: 3,
+          candidateIndex: 5,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -7,7 +7,13 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { getFirstLeg, isStationOnRoute, isSameStationName } from '../../../shared/utils/stationRoute';
+import {
+  getFirstLeg,
+  isStationOnRoute,
+  isSameStationName,
+  isStationWithinHopWindow,
+  arcIndexOf,
+} from '../../../shared/utils/stationRoute';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
 import { alarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
@@ -36,6 +42,8 @@ import {
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
+  logSuppressedHopWindow,
+  logSuppressedHopWindowNoSource,
   logSuppressedMovement,
   logSuppressedPhaseGate,
   logSuppressedSleepFirstTransfer,
@@ -196,6 +204,33 @@ async function runSilenceGateAndDispatch(params: {
   });
 }
 
+/**
+ * #1208 (Epic #1204 D2) — firedAlarms set 기반 fallback hop 추정.
+ *
+ * 우선 SSOT(estimator.index / lock 진행 시간)이 모두 부재할 때 사용.
+ * firedAlarms key 형식 `${phaseId}:${stationName}`을 파싱해 arcStations 위 인덱스 중 max를 찾고 +1.
+ * key parse 실패/match 미존재 시 -1 → 호출자가 graceful skip.
+ *
+ * 주의: 본 fallback은 false negative risk가 있음(예: imminent만 fire되고 station-passed dedup이 비어 있으면
+ * 0 반환) — graceful 동작이지 SSOT가 아님. alarmLog reason='gate-hop-window-no-source'를 함께 남겨 분석 가능.
+ */
+function inferHopIndexFromFiredAlarms(
+  firedAlarms: ReadonlySet<string>,
+  arcStations: readonly Station[],
+): number {
+  let maxIdx = -1;
+  for (const key of firedAlarms) {
+    const sep = key.indexOf(':');
+    /* istanbul ignore next — alarmKey()가 항상 `${phaseId}:${stationName}` 형식이라 sep=-1는 도달 불가, 잘못된 key 데이터 방어용 */
+    if (sep === -1) continue;
+    const stationName = key.slice(sep + 1);
+    const idx = arcStations.findIndex((s) => isSameStationName(s.name, stationName));
+    if (idx > maxIdx) maxIdx = idx;
+  }
+  if (maxIdx === -1) return -1;
+  return Math.min(maxIdx + 1, arcStations.length - 1);
+}
+
 export interface UseStationAlarmInputs {
   route: Route;
   destination: Station | null;
@@ -243,6 +278,17 @@ export interface UseStationAlarmInputs {
    * production 호출자는 미설정으로 둠. 단위 테스트에서 mount 직후 alarm 평가 검증 시 사용.
    */
   skipWarmupGuard?: boolean;
+  /**
+   * #1208 (Epic #1204 D2) — D1 estimator가 추정한 현재 hop index.
+   * station-passed 게이트의 1순위 SSOT. null이면 lock 활성 또는 firedAlarms 기반 fallback 시도.
+   * 미전달이면 기존 동작 유지(graceful, 게이트 미적용).
+   */
+  currentHopIndex?: number | null;
+  /**
+   * #1208 — 현재 trip의 arc station 배열. hop window 게이트와 firedAlarms 기반 fallback hop 계산에 사용.
+   * 빈 배열/미전달이면 게이트 미적용(graceful).
+   */
+  arcStations?: readonly Station[];
 }
 
 export function useStationAlarm({
@@ -259,6 +305,8 @@ export function useStationAlarm({
   motionStationary,
   currentStationArrival,
   skipWarmupGuard = false,
+  currentHopIndex = null,
+  arcStations,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   // #699: firedAlarmsRef의 내용이 어느 destinationId에 속하는지 추적.
@@ -727,6 +775,29 @@ export function useStationAlarm({
       const capturedDestinationId = destination.id;
       const capturedDestinationName = destination.name;
 
+      // #1208 (Epic #1204 D2) — trip 진행도 hop window 게이트.
+      // isStationOnRoute는 candidate가 route 노선 위에 있는지만 검사 → 이미 지나간 hop이나
+      // 미래 hop에서도 통과(사가정 22:11:56 / 성수 13:28:35 회귀). hop window로 추가 가드.
+      // SSOT 우선순위:
+      //   1. currentHopIndex prop (D1 estimator 또는 lock 활성 시 interp 결과 — 호출자가 결정)
+      //   2. firedAlarms set 기반 fallback (graceful, false negative risk)
+      //   3. 둘 다 부재 + arcStations 없음 → 게이트 미적용 (gate-hop-window-no-source)
+      if (arcStations && arcStations.length > 0) {
+        const effectiveHopIndex =
+          currentHopIndex ?? inferHopIndexFromFiredAlarms(firedAlarmsRef.current, arcStations);
+        if (effectiveHopIndex < 0) {
+          logSuppressedHopWindowNoSource({ source: 'fg', stationName: candidateStation.name });
+        } else if (!isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
+          logSuppressedHopWindow({
+            source: 'fg',
+            stationName: candidateStation.name,
+            currentHopIndex: effectiveHopIndex,
+            candidateIndex: arcIndexOf(arcStations, candidateStation),
+          });
+          return;
+        }
+      }
+
       // #733 — station-passed movement gate (S4 fix).
       // 기존엔 accuracyOk/arrivalConfirmed만 검사 → fusion이 인접역으로 jitter하면 매번 발사.
       // snapshot 2의 20:16:52 면목 알람(사용자 정적, backend trip 없음) 같은 회귀 차단.
@@ -776,6 +847,8 @@ export function useStationAlarm({
     clearDismissSilenceAction,
     userLocation?.lat,
     userLocation?.lng,
+    currentHopIndex,
+    arcStations,
   ]);
 
   // #917 A2 follow-up — FG fast path: lock.trainCode가 currentStationArrival의 row에

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -43,6 +43,8 @@ import {
   summarizeAlarmLogByReason,
   logHydrationTransition,
   logSuppressedStationPassedWarmup,
+  logSuppressedHopWindow,
+  logSuppressedHopWindowNoSource,
   logSuppressedTbaRevalidation,
   summarizeAlarmLogBySource,
   countGateReasons,
@@ -662,6 +664,43 @@ describe('alarmLog', () => {
         kind: 'station-passed',
       });
       expect(saved[0].stationName).toBeUndefined();
+    });
+
+    it('#1208 logSuppressedHopWindow: reason=gate-hop-window + kind=station-passed + hop 인덱스 stamp', async () => {
+      logSuppressedHopWindow({
+        source: 'fg',
+        stationName: '사가정',
+        currentHopIndex: 2,
+        candidateIndex: 6,
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'gate-hop-window',
+        stationName: '사가정',
+        kind: 'station-passed',
+        currentHopIndex: 2,
+        candidateIndex: 6,
+      });
+    });
+
+    it('#1208 logSuppressedHopWindowNoSource: reason=gate-hop-window-no-source + kind=station-passed', async () => {
+      logSuppressedHopWindowNoSource({ source: 'fg', stationName: '용마산' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'gate-hop-window-no-source',
+        stationName: '용마산',
+        kind: 'station-passed',
+      });
     });
 
     it('#1012 logHydrationTransition: 4 phase 각각 hydration-* reason + fg-hydrate source로 적재', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -98,6 +98,11 @@ export type AlarmLogReason =
   | 'gate-phase-warmup'
   // #1010 — station-passed effect가 lock hydrate 직후 30s warmup window 동안 차단된 발사.
   | 'gate-station-passed-warmup'
+  // #1208 (Epic #1204 D2) — station-passed가 trip 진행도 hop window 밖이라 차단된 발사.
+  // currentHopIndex ± windowSize 범위 밖 candidate station을 fire 차단 — 사가정/성수 회귀 evidence.
+  // 'gate-hop-window-no-source'는 hop SSOT(estimator/lock/firedAlarms)가 모두 없어 게이트 미적용 graceful skip 적재.
+  | 'gate-hop-window'
+  | 'gate-hop-window-no-source'
   // #1012 (H5) — useStationAlarm hydration state machine 각 phase 진입 stamp.
   // pre-hydrate → hydrating → storage-synced → ready 4단계. 'ready' 전 phase에서는
   // 모든 phase 알람 발사가 보류된다. transition 한 번에 1엔트리 적재 — 운영에서 phase
@@ -201,6 +206,10 @@ export interface AlarmLogEntry {
   // #1024 — burst inline counter. 같은 reason 연속 발생 시 count++ (새 entry 추가 대신).
   // 미설정이면 1로 해석 — 기존 entry와 완전 하위 호환.
   count?: number;
+  // #1208 (Epic #1204 D2) — hop window 게이트 적재 시 진단 컨텍스트.
+  // currentHopIndex = D1 estimator/fallback이 결정한 SSOT hop, candidateIndex = arc 위 candidate 위치.
+  currentHopIndex?: number;
+  candidateIndex?: number;
 }
 
 const logger = createLogger('AlarmLog');
@@ -763,6 +772,47 @@ export function logSuppressedSleepFirstTransfer(input: {
  * #1010 — station-passed effect가 lock hydrate 직후 30s warmup window 동안 차단된 발사 1건 적재.
  * stationName은 nearestStation?.name — unknown이면 undefined.
  */
+/**
+ * #1208 (Epic #1204 D2) — station-passed가 trip 진행도 hop window 밖이라 차단된 발사 1건 적재.
+ * candidateIndex/currentHopIndex가 모두 알려진 경우 phaseId 슬롯에 ":hop=cur/cand" 문자열로 노출.
+ * source는 호출 path 식별: FG polling은 'fg', BG는 'bg' 등.
+ */
+export function logSuppressedHopWindow(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  currentHopIndex: number;
+  candidateIndex: number;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'gate-hop-window',
+    stationName: input.stationName,
+    kind: 'station-passed',
+    currentHopIndex: input.currentHopIndex,
+    candidateIndex: input.candidateIndex,
+  });
+}
+
+/**
+ * #1208 (Epic #1204 D2) — hop window SSOT 부재로 게이트 미적용 1건 적재.
+ * estimator/lock/firedAlarms 셋 다 hop index를 결정하지 못한 graceful skip을 측정.
+ */
+export function logSuppressedHopWindowNoSource(input: {
+  source: AlarmLogSource;
+  stationName: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'gate-hop-window-no-source',
+    stationName: input.stationName,
+    kind: 'station-passed',
+  });
+}
+
 export function logSuppressedStationPassedWarmup(stationName: string | undefined): void {
   appendAlarmLog({
     ts: Date.now(),

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -93,6 +93,18 @@ interface UseFusedNearestStationReturn {
    * BoardingLock 비활성 시 null. DebugModal Estimator State 섹션에서 사용.
    */
   estimatorStrategy: import('../../route/utils/stationProgressEstimator').StationProgressStrategy | null;
+  /**
+   * #1208 (Epic #1204 D2) — 현재 채택된 estimator의 arc 위 hop index.
+   * useStationAlarm이 station-passed 게이트(`isStationWithinHopWindow`)의 SSOT로 사용.
+   * estimator 미채택 시 null — 호출자가 firedAlarms 등의 fallback으로 추정.
+   */
+  currentHopIndex: number | null;
+  /**
+   * #1208 — 현재 trip의 arc(탑승역~다음 waypoint) station 배열.
+   * useStationAlarm의 hop window 게이트 입력 및 firedAlarms 기반 fallback hop 계산용.
+   * route/trip 없으면 빈 배열.
+   */
+  arcStations: readonly Station[];
   refresh: () => Promise<void>;
 }
 
@@ -830,6 +842,8 @@ export function useFusedNearestStation(
     lastFixAtMs: gps.lastFixAtMs,
     positionStability,
     estimatorStrategy: estimate?.strategy ?? null,
+    currentHopIndex: estimate?.index ?? null,
+    arcStations,
     refresh: gps.refresh,
   };
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -167,7 +167,7 @@ export default function HomeScreen() {
   //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).
   const barometerSignal = useBarometer();
   const { subsurface: barometerSubsurface } = barometerSignal;
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal });
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal });
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
   // 카드로 노출, 1탭 = customOrigin 적용.
@@ -365,6 +365,10 @@ export default function HomeScreen() {
     // lock.trainCode arvlCd∈{0,1} 첫 관찰 시 매역 알림 즉시 발사. rawArrival(useArrivalCountdown
     // 미적용)을 직접 전달 — 매역 발사 트리거는 분 단위 tick과 무관한 arvlCd 원본 값.
     currentStationArrival: rawArrival,
+    // #1208 (Epic #1204 D2) — station-passed hop window 게이트 입력.
+    // D1 estimator(LocklessRouteHop 포함)의 현재 hop index와 arcStations를 그대로 전달.
+    currentHopIndex,
+    arcStations,
   });
 
   // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, getFirstLeg, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature, getStopDistanceMeters } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, isStationWithinHopWindow, arcIndexOf, LOCKLESS_HOP_WINDOW_DEFAULT, getFirstLeg, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature, getStopDistanceMeters } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 import {
@@ -1622,6 +1622,65 @@ describe('isStationOnRoute', () => {
 
   it('multi-transfer route — 어느 환승 구간에도 없으면 false', () => {
     expect(isStationOnRoute(makeStation('7'), multiTransferRoute)).toBe(false);
+  });
+});
+
+describe('isStationWithinHopWindow (#1208 D2)', () => {
+  // 7개 arc — currentHopIndex=2 기준으로 window 검증.
+  // 사가정/성수 회귀 evidence 시뮬레이션용.
+  const makeArc = (count: number): Station[] =>
+    Array.from({ length: count }, (_, i) => ({
+      id: `7-${i.toString().padStart(3, '0')}`,
+      name: `S${i}`,
+      line: '7',
+      lineColor: '#000',
+      lat: 0,
+      lng: 0,
+    }));
+
+  const arc = makeArc(7);
+
+  it.each<[number, number, boolean, string]>([
+    [2, 0, false, 'currentHopIndex=2 + candidate arcStations[0] → suppressed (이미 지나간 hop)'],
+    [2, 1, true, 'currentHopIndex=2 + candidate arcStations[1] → pass (current-1 window)'],
+    [2, 2, true, 'currentHopIndex=2 + candidate arcStations[2] → pass'],
+    [2, 3, true, 'currentHopIndex=2 + candidate arcStations[3] → pass (current+1 window)'],
+    [2, 5, false, 'currentHopIndex=2 + candidate arcStations[5] → suppressed (미래 hop)'],
+  ])('%s', (currentHopIndex, candidateIdx, expected) => {
+    expect(isStationWithinHopWindow(arc[candidateIdx], arc, currentHopIndex)).toBe(expected);
+  });
+
+  it('windowSize=2 + candidate arcStations[4] → pass (확장된 window)', () => {
+    expect(isStationWithinHopWindow(arc[4], arc, 2, 2)).toBe(true);
+  });
+
+  it('candidate not on route(arc) → suppressed', () => {
+    const offRoute: Station = {
+      id: '9-999',
+      name: 'OFFROUTE',
+      line: '9',
+      lineColor: '#fff',
+      lat: 0,
+      lng: 0,
+    };
+    expect(isStationWithinHopWindow(offRoute, arc, 2)).toBe(false);
+  });
+
+  it('currentHopIndex 음수 → suppressed (방어)', () => {
+    expect(isStationWithinHopWindow(arc[0], arc, -1)).toBe(false);
+  });
+
+  it('LOCKLESS_HOP_WINDOW_DEFAULT === 1 (정책 회귀 가드)', () => {
+    expect(LOCKLESS_HOP_WINDOW_DEFAULT).toBe(1);
+  });
+
+  it('arcIndexOf — arc 위 station 인덱스 반환', () => {
+    expect(arcIndexOf(arc, arc[3])).toBe(3);
+  });
+
+  it('arcIndexOf — arc 밖 station은 -1', () => {
+    const offRoute: Station = { id: 'X', name: 'X', line: '9', lineColor: '#fff', lat: 0, lng: 0 };
+    expect(arcIndexOf(arc, offRoute)).toBe(-1);
   });
 });
 

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -387,6 +387,47 @@ export function getFirstLeg(
   return { line: first.fromLine, endName: first.transferName };
 }
 
+/**
+ * Lockless trip의 station-passed 게이트(#1208, Epic #1204 D2) 기본 hop window 반경.
+ * D1 estimator가 추정한 currentHopIndex 기준 ±N hop 안의 candidate만 통과.
+ * 1이면 이전 hop, 현재 hop, 다음 hop만 fire 허용 — false positive 차단(이미 지나간 hop)
+ * 과 false negative 차단(미래 hop) 사이 보수적 균형.
+ */
+export const LOCKLESS_HOP_WINDOW_DEFAULT = 1;
+
+/**
+ * #1208 (Epic #1204 D2) — station-passed 게이트.
+ * arcStations 위에서 candidate station이 currentHopIndex ± windowSize 범위에 있는지 검사.
+ *
+ * 호출자(useStationAlarm)는 `isStationOnRoute` 다음에 본 함수로 trip 진행도 hop window를 추가 가드한다.
+ * - true: route 위에 있고 hop window 안 → station-passed 발사 허용
+ * - false: route 밖 또는 hop window 밖 → 발사 차단 (caller가 logSuppressedHopWindow로 기록)
+ *
+ * arc 밖 station(arcIndex === -1)이거나 currentHopIndex가 음수면 false.
+ */
+export function isStationWithinHopWindow(
+  station: Station,
+  arcStations: readonly Station[],
+  currentHopIndex: number,
+  windowSize: number = LOCKLESS_HOP_WINDOW_DEFAULT,
+): boolean {
+  if (currentHopIndex < 0) return false;
+  const candidateIndex = arcStations.findIndex((s) => s.id === station.id);
+  if (candidateIndex === -1) return false;
+  return (
+    candidateIndex >= currentHopIndex - windowSize &&
+    candidateIndex <= currentHopIndex + windowSize
+  );
+}
+
+/**
+ * #1208 — arcStations에서 station의 인덱스. 미발견 -1.
+ * useStationAlarm이 fallback hop 추정(firedAlarms max+1) 시 사용.
+ */
+export function arcIndexOf(arcStations: readonly Station[], station: Station): number {
+  return arcStations.findIndex((s) => s.id === station.id);
+}
+
 export function isStationOnRoute(station: Station, route: NonNullable<Route>): boolean {
   if (route.type === 'direct') {
     return station.line === route.line;


### PR DESCRIPTION
## 배경

PR #1234 (D2 hop window 게이트)가 stacked PR로 `feat/#1207-lockless-estimator` (D1 브랜치)에 머지됐지만, D1 PR #1219가 dev로 squash-merge되면서 D2 추가 commit이 dev에 propagate되지 않음.

## 검증

`git show origin/dev:src/shared/utils/stationRoute.ts | grep isStationWithinHopWindow` → 0건 (D2 코드 없음)

## 변경

PR #1234와 동일 변경을 dev base 위에 다시 적용. 코드 변경 0 — stack 머지의 dev propagate 누락만 복구.

- `src/shared/utils/stationRoute.ts`: `isStationWithinHopWindow`, `arcIndexOf`, `LOCKLESS_HOP_WINDOW_DEFAULT` 추가
- `src/features/alarm/hooks/useStationAlarm.ts`: `isStationOnRoute` 이후 hop window 게이트, `currentHopIndex` / `arcStations` 입력 props 추가
- `src/features/nearest-station/hooks/useFusedNearestStation.ts`: `currentHopIndex` (estimate.index ?? null) + `arcStations` 노출
- `src/features/alarm/utils/alarmLog.ts`: `gate-hop-window` / `gate-hop-window-no-source` reason 추가
- `src/screens/HomeScreen.tsx`: fusion 출력 → useStationAlarm wire
- 테스트 13건 추가

## 검증 결과 (worktree)

- `npm run type-check`: PASS
- `npm run lint`: PASS
- `npm test`: 5138/5139 PASS (DebugModal 1건 timeout flake — 격리 실행 시 141/141 PASS, worktree env drift)

```
Closes #1208
Relates to #1204
```