### PR TITLE
feat(#1214): D8 sleep rule lockless 적용 (dev 머지 복구)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -635,10 +635,12 @@ describe('useStationAlarm', () => {
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
-    // Sonar cpd 통합 — sleep OFF/lock 활성 vs sleep ON/lock null 모두 게이트 비활성 → 정상 발사.
+    // Sonar cpd 통합 — sleep OFF는 lock 유무와 무관하게 게이트 비활성 → 정상 발사.
+    // #1214 (Epic #1204 D8): lock=null 조기 종료가 제거됐으므로 "sleep ON + lock null" 케이스는
+    // 별도 신규 케이스(아래)에서 suppress=true 로 검증.
     it.each([
-      { name: 'sleep OFF + 첫 hop transfer → 정상 발사', sleepMode: false, lockValue: lock },
-      { name: 'sleep ON + lock null → 게이트 비활성, 정상 발사', sleepMode: true, lockValue: null },
+      { name: 'sleep OFF + lock 활성 + 첫 hop transfer → 정상 발사', sleepMode: false, lockValue: lock },
+      { name: 'sleep OFF + lock null + 첫 hop transfer → 정상 발사', sleepMode: false, lockValue: null },
     ])('$name', async ({ sleepMode, lockValue }) => {
       useSettingsStore.setState({ sleepMode });
       mockGetBoardingLock.mockResolvedValue(lockValue);
@@ -654,6 +656,34 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock null + 첫 hop transfer → suppress (#1214 lockless 적용)', async () => {
+      // #1214 (Epic #1204 D8): 사용자 명시 의향 trip(lockless)도 lock 활성과 동급 정확도 보장.
+      // getFirstLeg.endName === stationName 이면 lockless에서도 isFirstHop=true → suppress.
+      useSettingsStore.setState({ sleepMode: true });
+      mockGetBoardingLock.mockResolvedValue(null);
+      const route = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '2',
+        toLine: '1',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      await waitFor(() =>
+        expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: '시청',
+            phaseId: 'early',
+          }),
+        ),
+      );
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('sleep ON + lock 활성 + destination 카테고리 → 정상 발사 (transfer 외 영향 없음)', async () => {

--- a/src/features/alarm/utils/__tests__/shouldSuppressBySleepRule.test.ts
+++ b/src/features/alarm/utils/__tests__/shouldSuppressBySleepRule.test.ts
@@ -1,9 +1,14 @@
 import { shouldSuppressBySleepRule } from '../shouldSuppressBySleepRule';
+import type {
+  SleepRuleEventType,
+  SleepRuleInput,
+} from '../shouldSuppressBySleepRule';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 
 // #750 — 공통 게이트 단위 테스트.
-// 동일 규칙(="탑승/leg 시작 직후 첫 hop이 transfer + sleep ON → suppress")이
+// 동일 규칙(="탑승/leg 시작 직후 첫 hop이 transfer/station-passed + sleep ON → suppress")이
 // scheduler/FG/BG 3개 path에서 일관 적용되는지 검증한다.
+// #1214 (Epic #1204 D8): station-passed 카테고리 추가 + lock=null(lockless trip) 적용.
 
 const lock: BoardingLock = {
   destinationId: 'D1',
@@ -14,70 +19,139 @@ const lock: BoardingLock = {
   expectedDurationMs: 60_000,
 };
 
+// Sonar S1192 — input factory로 case별 boilerplate를 줄여 it.each 매트릭스 사용.
+function makeInput(overrides: {
+  lock?: BoardingLock | null;
+  eventType: SleepRuleEventType;
+  stationName?: string;
+  sleepMode: boolean;
+  isFirstHop: boolean;
+}): SleepRuleInput {
+  return {
+    lock: overrides.lock === undefined ? lock : overrides.lock,
+    event: {
+      type: overrides.eventType,
+      stationName: overrides.stationName ?? '교대',
+    },
+    sleepMode: overrides.sleepMode,
+    isFirstHop: overrides.isFirstHop,
+  };
+}
+
 describe('shouldSuppressBySleepRule', () => {
-  it('transfer + sleep ON + firstHop=true → suppress', () => {
-    expect(
-      shouldSuppressBySleepRule({
-        lock,
-        event: { type: 'transfer', stationName: '교대' },
-        sleepMode: true,
-        isFirstHop: true,
-      }),
-    ).toBe(true);
+  describe('lock 활성', () => {
+    it.each<[SleepRuleEventType, boolean]>([
+      ['transfer', true],
+      ['station-passed', true],
+    ])(
+      '%s + sleep ON + firstHop=true → suppress',
+      (eventType, expected) => {
+        expect(
+          shouldSuppressBySleepRule(
+            makeInput({ eventType, sleepMode: true, isFirstHop: true }),
+          ),
+        ).toBe(expected);
+      },
+    );
+
+    it.each<SleepRuleEventType>(['transfer', 'station-passed'])(
+      '%s + sleep ON + firstHop=false → fire (첫 hop 아님)',
+      (eventType) => {
+        expect(
+          shouldSuppressBySleepRule(
+            makeInput({ eventType, sleepMode: true, isFirstHop: false }),
+          ),
+        ).toBe(false);
+      },
+    );
+
+    it('destination + sleep ON + firstHop=true → fire (도착 알람 보존)', () => {
+      expect(
+        shouldSuppressBySleepRule(
+          makeInput({ eventType: 'destination', sleepMode: true, isFirstHop: true }),
+        ),
+      ).toBe(false);
+    });
+
+    it.each<SleepRuleEventType>(['transfer', 'station-passed', 'destination'])(
+      '%s + sleep OFF → fire (sleep off면 모든 카테고리 통과)',
+      (eventType) => {
+        expect(
+          shouldSuppressBySleepRule(
+            makeInput({ eventType, sleepMode: false, isFirstHop: true }),
+          ),
+        ).toBe(false);
+      },
+    );
   });
 
-  it('transfer + sleep ON + firstHop=false → fire (둘째 이후 hop은 영향 없음)', () => {
-    expect(
-      shouldSuppressBySleepRule({
-        lock,
-        event: { type: 'transfer', stationName: '약수' },
-        sleepMode: true,
-        isFirstHop: false,
-      }),
-    ).toBe(false);
-  });
+  describe('lockless trip (lock=null, #1214)', () => {
+    // 호출자(useStationAlarm / stationPipeline)가 lockless estimator hopIndex===0으로
+    // isFirstHop을 계산해 전달한 케이스 — 22:11:56 사가정 회귀 차단(Epic #1204 §1 회귀 6).
+    it('station-passed + sleep ON + lockless hopIndex=0 → suppress (✅ 사가정 회귀)', () => {
+      expect(
+        shouldSuppressBySleepRule(
+          makeInput({
+            lock: null,
+            eventType: 'station-passed',
+            stationName: '사가정',
+            sleepMode: true,
+            isFirstHop: true,
+          }),
+        ),
+      ).toBe(true);
+    });
 
-  it('destination + sleep ON + firstHop=true → fire (destination 카테고리 영향 없음)', () => {
-    expect(
-      shouldSuppressBySleepRule({
-        lock,
-        event: { type: 'destination', stationName: '강남' },
-        sleepMode: true,
-        isFirstHop: true,
-      }),
-    ).toBe(false);
-  });
+    it('station-passed + sleep ON + lockless hopIndex≠0 → fire', () => {
+      expect(
+        shouldSuppressBySleepRule(
+          makeInput({
+            lock: null,
+            eventType: 'station-passed',
+            sleepMode: true,
+            isFirstHop: false,
+          }),
+        ),
+      ).toBe(false);
+    });
 
-  it('station-passed + sleep ON + firstHop=true → fire (station-passed 카테고리 영향 없음)', () => {
-    expect(
-      shouldSuppressBySleepRule({
-        lock,
-        event: { type: 'station-passed', stationName: '교대' },
-        sleepMode: true,
-        isFirstHop: true,
-      }),
-    ).toBe(false);
-  });
+    it('station-passed + sleep OFF → fire (sleep off면 통과)', () => {
+      expect(
+        shouldSuppressBySleepRule(
+          makeInput({
+            lock: null,
+            eventType: 'station-passed',
+            sleepMode: false,
+            isFirstHop: true,
+          }),
+        ),
+      ).toBe(false);
+    });
 
-  it('transfer + sleep OFF + firstHop=true → fire', () => {
-    expect(
-      shouldSuppressBySleepRule({
-        lock,
-        event: { type: 'transfer', stationName: '교대' },
-        sleepMode: false,
-        isFirstHop: true,
-      }),
-    ).toBe(false);
-  });
+    it('destination + sleep ON + lockless hopIndex=0 → fire (도착 알람 보존)', () => {
+      expect(
+        shouldSuppressBySleepRule(
+          makeInput({
+            lock: null,
+            eventType: 'destination',
+            sleepMode: true,
+            isFirstHop: true,
+          }),
+        ),
+      ).toBe(false);
+    });
 
-  it('lock=null + 모든 조합 → fire (게이트는 lock 활성 시에만 의미)', () => {
-    expect(
-      shouldSuppressBySleepRule({
-        lock: null,
-        event: { type: 'transfer', stationName: '교대' },
-        sleepMode: true,
-        isFirstHop: true,
-      }),
-    ).toBe(false);
+    it('transfer + sleep ON + lockless hopIndex=0 → suppress', () => {
+      expect(
+        shouldSuppressBySleepRule(
+          makeInput({
+            lock: null,
+            eventType: 'transfer',
+            sleepMode: true,
+            isFirstHop: true,
+          }),
+        ),
+      ).toBe(true);
+    });
   });
 });

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -758,9 +758,22 @@ describe('processLocationUpdate', () => {
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
-    it('sleep ON + lock null → 게이트 비활성, 정상 발사', async () => {
+    it('sleep ON + lock null + 첫 hop transfer → suppress (#1214 lockless 적용)', async () => {
+      // #1214 (Epic #1204 D8): lock=null 조기 종료 제거 — lockless trip도 동급 정확도 보장.
+      // 호출자(stationPipeline)의 isFirstHop 계산은 getFirstLeg.endName 매칭으로 lockless에서도 동작.
       mockGetBoardingLock.mockResolvedValue(null);
       await call({ sleepMode: true });
+      expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: '교대',
+        phaseId: 'early',
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('sleep OFF + lock null + 첫 hop transfer → 정상 발사 (sleep off 우선)', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      await call({ sleepMode: false });
       expect(mockSendAlarmNotification).toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });

--- a/src/features/alarm/utils/shouldSuppressBySleepRule.ts
+++ b/src/features/alarm/utils/shouldSuppressBySleepRule.ts
@@ -3,8 +3,8 @@ import type { AlarmType } from './stationAlarm';
 
 /**
  * 공통 sleep 룰 게이트가 다루는 알람 카테고리.
- * scheduler/FG/BG 경로 모두에서 적용되는 좁은 식별자 — 'transfer'일 때만 suppress 가능,
- * 'destination' / 'station-passed'는 항상 fire 한다.
+ * scheduler/FG/BG 경로 모두에서 적용되는 좁은 식별자 — 'transfer' / 'station-passed' 일 때
+ * suppress 가능. 'destination'은 항상 fire(도착 놓치면 안 됨).
  */
 export type SleepRuleEventType = AlarmType | 'station-passed';
 
@@ -14,6 +14,10 @@ export interface SleepRuleEvent {
 }
 
 export interface SleepRuleInput {
+  /**
+   * 활성 BoardingLock. null이면 lockless trip — `isFirstHop`을 호출자가 lockless estimator
+   * (`stationProgressEstimator` hopIndex===0)로 판단해 전달한다(#1214, Epic #1204 D8).
+   */
   lock: BoardingLock | null;
   event: SleepRuleEvent;
   sleepMode: boolean;
@@ -22,28 +26,34 @@ export interface SleepRuleInput {
    *
    * - `scheduleHopsForLock` : 배치 안의 hopIndex === 0
    * - `advanceHopWindow`     : hopIndex === passedIndex + 1
-   * - FG/BG 즉시 발사 path   : `lock.boardingStationId`가 사용자가 직전에 lock한 탑승역이므로
-   *                            "현재 노선의 다음 transfer"가 곧 첫 hop. 호출자는 자신이 보는
-   *                            event.stationName이 lock이 시작된 leg의 첫 transfer waypoint와
-   *                            일치하는지로 판단해 전달한다.
+   * - FG/BG 즉시 발사 path (lock 활성): `lock.boardingStationId`가 사용자가 직전에 lock한
+   *                            탑승역이므로 "현재 노선의 다음 transfer" / "탑승역에서의
+   *                            station-passed"가 곧 첫 hop. 호출자는 event.stationName이
+   *                            lock이 시작된 leg의 첫 waypoint와 일치하는지로 판단해 전달.
+   * - Lockless trip (#1214) : D1 lockless estimator(`stationProgressEstimator`)의 hopIndex===0
+   *                            을 호출자가 fallback으로 계산해 전달. signature는 유지.
    */
   isFirstHop: boolean;
 }
 
 /**
  * #750 — 취침모드 첫 환승 알람 누수 차단용 공통 게이트.
+ * #1214 (Epic #1204 D8) — 'station-passed' 도 차단 대상 추가 + lockless trip 적용.
  *
- * 단일 정책: lock 활성 + sleep ON + event가 현재 leg의 첫 hop transfer면 suppress.
+ * 단일 정책: sleep ON + event가 현재 leg의 첫 hop을 향함 + event.type이 transfer/station-passed면 suppress.
  *
- * 이전 구현(`boardingLockScheduler.shouldSkipFirstTransferForSleep`)은 scheduler에만
- * 적용돼 폴링 기반 즉시 발사 path(useStationAlarm FG, stationPipeline BG)가 동일 조건에서
- * 발사를 우회했다. 이 함수를 세 경로 공통으로 호출해 정책을 한 곳에서 결정한다.
+ * - 이전 구현(`boardingLockScheduler.shouldSkipFirstTransferForSleep`)은 scheduler에만 적용돼
+ *   폴링 기반 즉시 발사 path(useStationAlarm FG, stationPipeline BG)가 우회했다 — #750에서 통합.
+ * - 'station-passed' 통과 회귀(2026-06-12 사가정 fire, Epic #1204 §1 회귀 6)는 본 함수가
+ *   transfer에만 적용돼 사용자가 자던 중 출발역 매역 알림이 발사된 결과 — D8에서 차단.
+ * - lock=null 조기 종료를 제거 — 사용자 명시 의향 trip(C 토글 ON / boardingPrompt 응답 /
+ *   BoardingTrainList 직접 탭)은 lock 활성과 동급 정확도 보장 의무(ADR-013 §B3, ADR-014).
+ *   호출자가 lockless estimator로 `isFirstHop`을 계산해 전달하면 본 함수는 동일 정책 적용.
  *
- * lock=null이면 규칙은 비활성(scheduler가 동작하지 않고 "첫 hop" 개념이 없는 자유 트립).
+ * 'destination'은 항상 통과 — 도착 알람을 놓치면 사용자가 종착역을 지나칠 수 있음.
  */
 export function shouldSuppressBySleepRule(input: SleepRuleInput): boolean {
-  if (!input.lock) return false;
   if (!input.sleepMode) return false;
   if (!input.isFirstHop) return false;
-  return input.event.type === 'transfer';
+  return input.event.type === 'transfer' || input.event.type === 'station-passed';
 }


### PR DESCRIPTION
## 배경

PR #1227 (D8 취침모드 station-passed + lockless 적용)이 stacked PR로 `feat/#1207-lockless-estimator` (D1 브랜치)에 머지됐지만, D1 PR #1219가 dev로 squash-merge되면서 D8 추가 commit이 dev에 propagate되지 않음.

## 검증

`grep '!input.lock' src/features/alarm/utils/shouldSuppressBySleepRule.ts` on dev → 여전히 lockless 비활성. D8 변경 미반영 확인.

## 변경

PR #1227과 동일 변경을 dev base 위에 다시 적용. 코드 차이 0 — stack 머지의 dev propagate 누락만 복구.

## 정책 (D8)

- lockless trip에도 sleep 룰 적용 (ADR-013 §B3 / ADR-014 동급 보장 의무)
- station-passed도 차단 (잠 깨우지 않음)
- destination은 항상 통과 (도착 보존)

```
Closes #1214
Relates to #1204, #1227
```