### PR TITLE
feat(#1236): D8 station-passed sleep 룰 wire

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -76,6 +76,7 @@ const mockLogSuppressedDedupStation = jest.fn();
 const mockLogSuppressedMovement = jest.fn();
 const mockLogSuppressedPhaseGate = jest.fn();
 const mockLogSuppressedSleepFirstTransfer = jest.fn();
+const mockLogSuppressedSleepStationPassed = jest.fn();
 const mockLogSuppressedDismissSilence = jest.fn();
 const mockLogSuppressedStationPassedWarmup = jest.fn();
 const mockLogSuppressedHopWindow = jest.fn();
@@ -92,6 +93,8 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedPhaseGate: (...args: unknown[]) => mockLogSuppressedPhaseGate(...args),
   logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
     mockLogSuppressedSleepFirstTransfer(...args),
+  logSuppressedSleepStationPassed: (...args: unknown[]) =>
+    mockLogSuppressedSleepStationPassed(...args),
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
   logSuppressedStationPassedWarmup: (...args: unknown[]) =>
     mockLogSuppressedStationPassedWarmup(...args),
@@ -2502,7 +2505,7 @@ describe('useStationAlarm', () => {
       expect(arvlCdFires).toHaveLength(0);
     });
 
-    it('currentStationArrival 미전달(undefined)이면 fast path no-op (getBoardingLock 미호출)', async () => {
+    it('currentStationArrival 미전달(undefined)이면 fast path no-op (arvlCd fire X)', async () => {
       mockGetBoardingLock.mockResolvedValue(activeLock);
       mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
 
@@ -2510,9 +2513,11 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
-      // mockEvaluateAlarmPhase=null & isImminentByArrivalCode=false → fireAndLog 미호출 →
-      // 본 hook에서 getBoardingLock 호출자는 fast path뿐. fast path가 early return하면 호출 0.
-      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+      await Promise.resolve();
+      // #1236 — GPS station-passed path도 sleep 룰 게이트 위해 getBoardingLock을 호출하므로
+      // 'getBoardingLock 미호출' 대신 'fast path fire 미발생'으로 검증한다.
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
     });
 
     it('currentStationArrival null이면 fast path no-op', async () => {
@@ -2523,7 +2528,9 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
-      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+      await Promise.resolve();
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
     });
 
     it('nearestStation null이면 fast path no-op (fire 대상 station 결정 불가)', async () => {
@@ -2533,6 +2540,7 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
+      // nearestStation null이면 GPS station-passed path도 진입 안 함 → getBoardingLock 호출 0.
       expect(mockGetBoardingLock).not.toHaveBeenCalled();
     });
 
@@ -2647,22 +2655,25 @@ describe('useStationAlarm', () => {
     });
 
     it('effect cleanup (unmount) 후엔 후속 작업이 fast path 발사 안 함', async () => {
-      // getBoardingLock을 지연 resolve로 cleanup 시점을 끼워 넣음.
-      let resolveLock: (v: typeof activeLock) => void = () => {};
-      mockGetBoardingLock.mockReturnValueOnce(
-        new Promise<typeof activeLock>((r) => {
-          resolveLock = r;
-        }),
+      // #1236 — GPS path도 getBoardingLock을 호출하므로 mockImplementation으로 모든 호출 pending.
+      // arvlCd path의 `if (cancelled) return;` 분기 커버.
+      const resolvers: Array<(v: typeof activeLock | null) => void> = [];
+      mockGetBoardingLock.mockImplementation(
+        () =>
+          new Promise<typeof activeLock | null>((r) => {
+            resolvers.push(r);
+          }),
       );
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
 
       const { unmount } = renderHook(() => useStationAlarm(fastPathInputs()));
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      // GPS path + arvlCd path 둘 다 getBoardingLock pending에 도달.
+      await waitFor(() => expect(resolvers.length).toBeGreaterThanOrEqual(2));
       unmount();
-      resolveLock(activeLock);
-      await Promise.resolve();
-      await Promise.resolve();
+      resolvers.forEach((r) => r(activeLock));
+      for (let i = 0; i < 8; i++) await Promise.resolve();
 
       // fast path의 logFiredStationPassed('fg-arvlcd', ...)이 호출되지 않아야 한다.
       const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
@@ -3147,6 +3158,172 @@ describe('useStationAlarm', () => {
         });
       });
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1236 (Epic #1204 D8 wire) — FG dispatch path가 station-passed sleep 룰 게이트를 호출한다.
+  // 2026-06-12 22:11:56 사가정 station-passed 회귀 재현 차단 evidence.
+  // D8(#1227)이 shouldSuppressBySleepRule을 station-passed로 확장했고, 본 PR이 FG GPS / arvlCd
+  // fast path 양쪽에서 게이트를 호출하도록 wire.
+  describe('#1236 sleep 룰 게이트 — station-passed (FG dispatch wire)', () => {
+    const onRouteStation = makeStation('S-PASS', '사가정', 37.5, 127.0);
+    const routeDirect = makeDirectRoute(3, '2');
+    const lockOnSagajeong = {
+      destinationId: destination.id,
+      trainCode: 'T-LOCK',
+      // candidate.id === boardingStationId → isStationPassedFirstHop(lock active) true.
+      boardingStationId: onRouteStation.id,
+      boardingLine: '2' as const,
+      boardedAt: Date.now(),
+      expectedDurationMs: 60 * 60_000,
+    };
+
+    function withSleepGateInputs(
+      overrides: Partial<UseStationAlarmInputs> = {},
+    ): UseStationAlarmInputs {
+      return defaultInputs({
+        route: routeDirect,
+        destination,
+        nearestStation: onRouteStation,
+        userLocation: { lat: 37.5, lng: 127.0 },
+        speedMps: 10,
+        accuracyMeters: 50,
+        ...overrides,
+      });
+    }
+
+    it.each([
+      {
+        name: 'FG GPS path — lockless + sleep ON + currentHopIndex=0 → station-passed 차단 (사가정 22:11:56 evidence)',
+        sleepMode: true,
+        lockValue: null,
+        currentHopIndex: 0 as number | null,
+        expectSuppress: true,
+      },
+      {
+        name: 'FG GPS path — lock 활성 + sleep ON + candidate=boardingStation → station-passed 차단',
+        sleepMode: true,
+        lockValue: lockOnSagajeong,
+        currentHopIndex: null,
+        expectSuppress: true,
+      },
+      {
+        name: 'FG GPS path — sleep OFF + lockless + currentHopIndex=0 → 정상 발사',
+        sleepMode: false,
+        lockValue: null,
+        currentHopIndex: 0 as number | null,
+        expectSuppress: false,
+      },
+      {
+        name: 'FG GPS path — sleep ON + lockless + currentHopIndex=3 → 정상 발사 (첫 hop 아님)',
+        sleepMode: true,
+        lockValue: null,
+        currentHopIndex: 3 as number | null,
+        expectSuppress: false,
+      },
+      {
+        name: 'FG GPS path — sleep ON + lock 활성 + candidate≠boardingStation → 정상 발사',
+        sleepMode: true,
+        lockValue: { ...lockOnSagajeong, boardingStationId: 'S-OTHER' },
+        currentHopIndex: null,
+        expectSuppress: false,
+      },
+    ])('$name', async ({ sleepMode, lockValue, currentHopIndex, expectSuppress }) => {
+      useSettingsStore.setState({ sleepMode });
+      mockGetBoardingLock.mockResolvedValue(lockValue);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
+
+      renderHook(() => useStationAlarm(withSleepGateInputs({ currentHopIndex })));
+
+      if (expectSuppress) {
+        await waitFor(() =>
+          expect(mockLogSuppressedSleepStationPassed).toHaveBeenCalledWith({
+            source: 'fg',
+            stationName: onRouteStation.name,
+          }),
+        );
+        expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+      } else {
+        await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+        expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
+      }
+    });
+
+    it('FG arvlCd fast path — lock 활성 + sleep ON + candidate=boardingStation → 차단 + fg-arvlcd suppress 로그', async () => {
+      // arvlCd fast path는 lock != null 필요 (#640 회귀 가드). lock 활성 + first hop 케이스로 검증.
+      useSettingsStore.setState({ sleepMode: true });
+      mockGetBoardingLock.mockResolvedValue(lockOnSagajeong);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+
+      renderHook(() =>
+        useStationAlarm(
+          withSleepGateInputs({
+            currentHopIndex: null,
+            currentStationArrival: { up: [], down: [] } as unknown as Parameters<
+              typeof useStationAlarm
+            >[0]['currentStationArrival'],
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        const calls = mockLogSuppressedSleepStationPassed.mock.calls;
+        expect(calls.some((c) => c[0]?.source === 'fg-arvlcd')).toBe(true);
+      });
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('FG arvlCd fast path — sleep OFF + lock 활성 + first hop → 정상 발사 (게이트 비활성)', async () => {
+      useSettingsStore.setState({ sleepMode: false });
+      mockGetBoardingLock.mockResolvedValue(lockOnSagajeong);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+
+      renderHook(() =>
+        useStationAlarm(
+          withSleepGateInputs({
+            currentHopIndex: null,
+            currentStationArrival: { up: [], down: [] } as unknown as Parameters<
+              typeof useStationAlarm
+            >[0]['currentStationArrival'],
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
+    });
+
+    it('GPS station-passed IIFE: getBoardingLock 후 cleanup → 후속 dispatch 미실행 (cancelled guard)', async () => {
+      // #1236 — GPS path에 추가된 lock fetch IIFE의 `if (cancelled) return;` 분기 커버.
+      const resolvers: Array<(v: typeof lockOnSagajeong | null) => void> = [];
+      mockGetBoardingLock.mockImplementation(
+        () =>
+          new Promise<typeof lockOnSagajeong | null>((r) => {
+            resolvers.push(r);
+          }),
+      );
+      useSettingsStore.setState({ sleepMode: false });
+
+      const { unmount } = renderHook(() =>
+        useStationAlarm(withSleepGateInputs({ currentHopIndex: null })),
+      );
+      await waitFor(() => expect(mockGetBoardingLock).toHaveBeenCalled());
+      unmount();
+      // unmount 후 lock resolve → IIFE의 `if (cancelled) return;`이 후속 dispatch를 차단.
+      resolvers.forEach((r) => r(null));
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -47,12 +47,13 @@ import {
   logSuppressedMovement,
   logSuppressedPhaseGate,
   logSuppressedSleepFirstTransfer,
+  logSuppressedSleepStationPassed,
   logSuppressedStationPassedWarmup,
   type HydrationPhase,
 } from '../utils/alarmLog';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { getBoardingLock } from '../utils/boardingLockStorage';
-import { shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
+import { isStationPassedFirstHop, shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
 import type { PositionStability } from '../../nearest-station/utils/positionStaticDetector';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
@@ -177,7 +178,33 @@ async function runSilenceGateAndDispatch(params: {
   dismissSilence: import('../utils/dismissSilenceStorage').DismissSilenceState | null;
   userLocation: { lat: number; lng: number } | null;
   clearDismissSilenceAction: () => Promise<void>;
+  // #1236 (Epic #1204 D8 wire) — station-passed sleep 룰 게이트 context.
+  // 호출자가 lock/sleepMode/currentHopIndex를 수집해 전달한다. 게이트 통과 시 dispatch.
+  sleepMode: boolean;
+  currentHopIndex: number | null;
+  /** lock=null이면 lockless trip — currentHopIndex===0으로 판정. lock 활성이면 boardingStationId 비교. */
+  lock: import('../../../shared/types/boardingLock').BoardingLock | null;
 }): Promise<void> {
+  // #1236 — sleep 룰 게이트. dismiss silence 위 — silence 만료/위치 무관하게 sleep 첫 hop은 정책상 차단.
+  // sleep 룰은 정확성 게이트(ADR-013 §B3 / ADR-014)라 silence 만료 부수효과(clear)를 막아도 무방.
+  if (
+    shouldSuppressBySleepRule({
+      lock: params.lock,
+      event: { type: 'station-passed', stationName: params.candidateStation.name },
+      sleepMode: params.sleepMode,
+      isFirstHop: isStationPassedFirstHop({
+        lock: params.lock,
+        candidateStationId: params.candidateStation.id,
+        currentHopIndex: params.currentHopIndex,
+      }),
+    })
+  ) {
+    logSuppressedSleepStationPassed({
+      source: params.source,
+      stationName: params.candidateStation.name,
+    });
+    return;
+  }
   const silenceGate = applySilenceGate(
     params.dismissSilence,
     Date.now(),
@@ -816,19 +843,27 @@ export function useStationAlarm({
 
       // #746 — dismiss silence 게이트 + dispatch는 helper로 통합 (Sonar cpd 회피).
       // userLocation 없이도 시간 조건만 평가 가능 — null 좌표 그대로 전달.
-      void runSilenceGateAndDispatch({
-        source: 'fg',
-        candidateStation,
-        capturedRoute,
-        capturedDestinationId,
-        capturedDestinationName,
-        notificationSource,
-        isCancelled: () => cancelled,
-        errorLogPrefix: '역 통과 알림 실패:',
-        dismissSilence,
-        userLocation,
-        clearDismissSilenceAction,
-      });
+      // #1236 — sleep 룰 게이트는 helper 내부에서 처리. lock은 IIFE에서 async fetch.
+      void (async () => {
+        const lock = await getBoardingLock();
+        if (cancelled) return;
+        await runSilenceGateAndDispatch({
+          source: 'fg',
+          candidateStation,
+          capturedRoute,
+          capturedDestinationId,
+          capturedDestinationName,
+          notificationSource,
+          isCancelled: () => cancelled,
+          errorLogPrefix: '역 통과 알림 실패:',
+          dismissSilence,
+          userLocation,
+          clearDismissSilenceAction,
+          sleepMode: sleepModeRef.current,
+          currentHopIndex,
+          lock,
+        });
+      })();
     }
 
     return () => {
@@ -913,6 +948,7 @@ export function useStationAlarm({
 
       // #746 silence gate + dispatch는 helper로 통합 (Sonar cpd 회피).
       // lastNotifiedStationId 공유 dedup. cancelled 재확인 — getBoardingLock 후 effect cleanup 가능.
+      // #1236 — sleep 룰 게이트 context. lock은 위에서 이미 fetch.
       await runSilenceGateAndDispatch({
         source: 'fg-arvlcd',
         candidateStation,
@@ -925,6 +961,9 @@ export function useStationAlarm({
         dismissSilence,
         userLocation,
         clearDismissSilenceAction,
+        sleepMode: sleepModeRef.current,
+        currentHopIndex,
+        lock,
       });
     })();
 
@@ -946,5 +985,7 @@ export function useStationAlarm({
     userLocation?.lat,
     userLocation?.lng,
     notificationSource,
+    // #1236 — currentHopIndex 변화가 sleep 룰 게이트 isFirstHop 판정에 영향.
+    currentHopIndex,
   ]);
 }

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -31,6 +31,7 @@ import {
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
   logSuppressedSleepFirstTransfer,
+  logSuppressedSleepStationPassed,
   logSuppressedGate,
   logSuppressedMovement,
   logSuppressedPhaseGate,
@@ -599,6 +600,24 @@ describe('alarmLog', () => {
       });
       expect(saved[0].phaseId).toBeUndefined();
     });
+
+    it.each<['fg' | 'fg-arvlcd' | 'bg', string]>([
+      ['fg', '사가정'],
+      ['fg-arvlcd', '강남'],
+      ['bg', '잠실'],
+    ])(
+      '#1236 logSuppressedSleepStationPassed: source=%s — reason=sleep-first-station-passed, kind=station-passed 고정',
+      async (source, stationName) => {
+        logSuppressedSleepStationPassed({ source, stationName });
+        await expectLastSavedEntryMatches({
+          source,
+          outcome: 'suppressed',
+          reason: 'sleep-first-station-passed',
+          stationName,
+          kind: 'station-passed',
+        });
+      },
+    );
 
     it.each([
       ['revalidate-no-trip' as const, '강남', 'early' as const],

--- a/src/features/alarm/utils/__tests__/shouldSuppressBySleepRule.test.ts
+++ b/src/features/alarm/utils/__tests__/shouldSuppressBySleepRule.test.ts
@@ -1,4 +1,4 @@
-import { shouldSuppressBySleepRule } from '../shouldSuppressBySleepRule';
+import { isStationPassedFirstHop, shouldSuppressBySleepRule } from '../shouldSuppressBySleepRule';
 import type {
   SleepRuleEventType,
   SleepRuleInput,
@@ -152,6 +152,24 @@ describe('shouldSuppressBySleepRule', () => {
           }),
         ),
       ).toBe(true);
+    });
+  });
+
+  // #1236 (Epic #1204 D8 wire) — station-passed dispatch path 공통 isFirstHop 헬퍼.
+  describe('isStationPassedFirstHop', () => {
+    it.each<[string, BoardingLock | null, string, number | null | undefined, boolean]>([
+      // [name, lock, candidateStationId, currentHopIndex, expected]
+      ['lock 활성 + candidate=boardingStation → true', lock, 'S-BOARD', null, true],
+      ['lock 활성 + candidate≠boardingStation → false', lock, 'S-OTHER', null, false],
+      ['lock 활성 + candidate=boardingStation + hopIndex=3 → lock SSOT 우선 true', lock, 'S-BOARD', 3, true],
+      ['lockless + hopIndex=0 → true', null, 'S-ANY', 0, true],
+      ['lockless + hopIndex=3 → false (첫 hop 아님)', null, 'S-ANY', 3, false],
+      ['lockless + hopIndex=null → false (SSOT 부재, graceful)', null, 'S-ANY', null, false],
+      ['lockless + hopIndex=undefined → false (BG path 미전달, graceful)', null, 'S-ANY', undefined, false],
+    ])('%s', (_, lockArg, candidateStationId, currentHopIndex, expected) => {
+      expect(
+        isStationPassedFirstHop({ lock: lockArg, candidateStationId, currentHopIndex }),
+      ).toBe(expected);
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -74,6 +74,7 @@ const mockLogFiredStationPassed = jest.fn();
 const mockLogSuppressedDedupStation = jest.fn();
 const mockLogSuppressedDedupAlarm = jest.fn();
 const mockLogSuppressedSleepFirstTransfer = jest.fn();
+const mockLogSuppressedSleepStationPassed = jest.fn();
 const mockLogSuppressedDismissSilence = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
@@ -82,6 +83,8 @@ jest.mock('../alarmLog', () => ({
   logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
   logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
     mockLogSuppressedSleepFirstTransfer(...args),
+  logSuppressedSleepStationPassed: (...args: unknown[]) =>
+    mockLogSuppressedSleepStationPassed(...args),
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
 }));
 
@@ -823,6 +826,77 @@ describe('processLocationUpdate', () => {
       await call({ sleepMode: true });
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1236 (Epic #1204 D8 wire) — BG station-passed dispatch path도 sleep 룰 게이트 호출.
+  // 2026-06-12 22:11:56 사가정 station-passed fire 회귀를 BG/silent push 양쪽에서 차단.
+  describe('#1236 sleep 룰 게이트 — station-passed (BG path)', () => {
+    const lockOnStation1 = {
+      destinationId: 'station-2',
+      trainCode: 'T-1',
+      // boardingStationId가 mockStation.id와 일치 → station-passed 후보가 첫 hop으로 판정됨.
+      boardingStationId: 'station-1',
+      boardingLine: '2' as const,
+      boardedAt: Date.now(),
+      expectedDurationMs: 60_000,
+    };
+
+    beforeEach(() => {
+      mockFindNearestStation.mockReturnValue(mockNearestResult);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockIsStationOnRoute.mockReturnValue(true);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      // alarmEvent는 게이트와 무관 — null로 둬서 transfer/destination sleep 게이트와 격리.
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+    });
+
+    it('sleep ON + lock 활성 + candidate=boardingStation → station-passed 차단 + suppress 로그', async () => {
+      mockGetBoardingLock.mockResolvedValue(lockOnStation1);
+      await call({ sleepMode: true });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+      expect(mockLogSuppressedSleepStationPassed).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: mockStation.name,
+      });
+    });
+
+    it('sleep OFF + lock 활성 + candidate=boardingStation → 정상 발사 (sleep off 우선)', async () => {
+      mockGetBoardingLock.mockResolvedValue(lockOnStation1);
+      await call({ sleepMode: false });
+      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock 활성 + candidate≠boardingStation → 정상 발사 (첫 hop 아님)', async () => {
+      const lockOnOther = { ...lockOnStation1, boardingStationId: 'station-other' };
+      mockGetBoardingLock.mockResolvedValue(lockOnOther);
+      await call({ sleepMode: true });
+      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock null (lockless) → BG는 currentHopIndex SSOT 부재라 graceful 통과', async () => {
+      // BG path는 estimator hopIndex 입력이 없어 lockless trip을 차단하지 않는다(보수적 graceful).
+      // FG path가 currentHopIndex로 동급 보장(useStationAlarm 테스트에서 검증).
+      mockGetBoardingLock.mockResolvedValue(null);
+      await call({ sleepMode: true });
+      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
+    });
+
+    it('sleep ON + lock 활성 + silence 활성 → silence 차단이 우선 (station-passed gate는 호출되지 않음)', async () => {
+      // 같은 candidate에 silence 게이트가 위에 있어 sleep 게이트보다 먼저 차단한다.
+      mockGetBoardingLock.mockResolvedValue(lockOnStation1);
+      mockGetDismissSilence.mockResolvedValue({
+        sinceTs: Date.now(),
+        sinceLat: 37.498,
+        sinceLng: 127.028,
+      });
+      await call({ sleepMode: true });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -87,6 +87,10 @@ export type AlarmLogReason =
   // #750 — 공통 sleep 룰 게이트(shouldSuppressBySleepRule)가 차단한 발사.
   // scheduler/FG/BG 3개 path 어디서든 같은 reason으로 적재 — 정책 단일 출처.
   | 'sleep-first-transfer'
+  // #1236 (Epic #1204 D8 wire) — 같은 게이트가 station-passed 카테고리에서 차단한 발사.
+  // transfer 차단(sleep-first-transfer)과 reason을 분리해 D8 station-passed 누수 회귀(2026-06-12 22:11:56 사가정)
+  // 차단 횟수를 독립 집계.
+  | 'sleep-first-station-passed'
   // #816 C — lockless 분기에서 client 추가 가드가 차단한 발사.
   //   'lockless-non-intermediate': lock 없는 trip에 transfer/destination push 도달 (backend race).
   //   'lockless-opt-out': 사용자 토글 OFF 상태에서 lockless intermediate push 도달.
@@ -765,6 +769,26 @@ export function logSuppressedSleepFirstTransfer(input: {
     stationName: input.stationName,
     kind: 'transfer',
     phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1236 (Epic #1204 D8 wire) — sleep 룰 게이트가 station-passed 카테고리에서 차단한 발사 1건 적재.
+ * D8(#1227)에서 shouldSuppressBySleepRule이 'station-passed'도 차단하도록 확장됐고,
+ * 본 PR이 dispatch path(FG GPS/arvlCd, BG)에서 동 게이트를 호출하도록 wire.
+ * 2026-06-12 22:11:56 사가정 회귀 차단 evidence와 1:1 매핑.
+ */
+export function logSuppressedSleepStationPassed(input: {
+  source: AlarmLogSource;
+  stationName: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'sleep-first-station-passed',
+    stationName: input.stationName,
+    kind: 'station-passed',
   });
 }
 

--- a/src/features/alarm/utils/shouldSuppressBySleepRule.ts
+++ b/src/features/alarm/utils/shouldSuppressBySleepRule.ts
@@ -57,3 +57,25 @@ export function shouldSuppressBySleepRule(input: SleepRuleInput): boolean {
   if (!input.isFirstHop) return false;
   return input.event.type === 'transfer' || input.event.type === 'station-passed';
 }
+
+/**
+ * #1236 (Epic #1204 D8 wire) — station-passed dispatch path에서 `isFirstHop`을 결정하는 공통 헬퍼.
+ *
+ * FG (useStationAlarm GPS/arvlCd) / BG (stationPipeline) 세 경로가 동일 정책으로
+ * sleep 룰을 호출하기 위해 isFirstHop 산출을 한 곳에 둔다.
+ *
+ * - lock 활성 : candidate 역이 사용자가 명시 lock한 boardingStationId와 일치하면 첫 hop.
+ *   사가정 22:11:56 회귀(boardingStationId='사가정', candidate='사가정', station-passed fire)와 직접 매핑.
+ * - lockless  : D1 estimator의 hopIndex===0이 SSOT. 미전달이면 false(graceful skip — 게이트 미적용).
+ *
+ * 두 신호가 모두 없으면 false — 정확성 보강이 불가능하면 알람을 차단하지 않는다(보수적).
+ */
+export function isStationPassedFirstHop(input: {
+  lock: BoardingLock | null;
+  candidateStationId: string;
+  currentHopIndex: number | null | undefined;
+}): boolean {
+  if (input.lock) return input.candidateStationId === input.lock.boardingStationId;
+  if (input.currentHopIndex === 0) return true;
+  return false;
+}

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -21,9 +21,10 @@ import {
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
   logSuppressedSleepFirstTransfer,
+  logSuppressedSleepStationPassed,
   type AlarmLogSource,
 } from './alarmLog';
-import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
+import { isStationPassedFirstHop, shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
 import { evaluateDismissSilence } from './dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from './dismissSilenceStorage';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
@@ -320,50 +321,70 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       kind: 'station-passed',
     });
   } else if (route && isStationOnRoute(nearest.station, route)) {
-    const lastNotifiedStationId = await getLastNotifiedStationId(destination.id);
-    if (nearest.station.id !== lastNotifiedStationId) {
-      // #796: 환승역 도착 timing의 segment 정확 식별. evaluateAlarmPhase(:233)와 동일한
-      // currentLine 결정 — lock.boardingLine 우선 → BG GPS jitter로 nearest가 옆 노선 station을
-      // 잡아도 잘못된 다음-다음 transfer 안내를 차단. lock 없으면 nearest.station.line fallback.
-      const target = resolveNextTarget(
-        route,
-        destination.name,
-        lockForLineGuard?.boardingLine ?? nearest.station.line,
-      );
-      if (target) {
-        // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
-        await sendStationPassedNotification(
-          nearest.station.name,
+    // #1236 (Epic #1204 D8 wire) — station-passed sleep 룰 게이트.
+    // lock 활성: candidate가 boardingStationId면 첫 hop → suppress (2026-06-12 22:11:56 사가정 회귀).
+    // lockless BG: estimator output 부재 → currentHopIndex null로 전달, 게이트는 자동 비적용(보수적).
+    // dedup(lastNotifiedStationId) 위에 위치 — sleep으로 차단되면 lastNotifiedStationId 갱신 안 함
+    // → sleep OFF 토글 후 정상 첫 hop 알림이 재발사 가능.
+    if (
+      shouldSuppressBySleepRule({
+        lock: lockForLineGuard,
+        event: { type: 'station-passed', stationName: nearest.station.name },
+        sleepMode,
+        isFirstHop: isStationPassedFirstHop({
+          lock: lockForLineGuard,
+          candidateStationId: nearest.station.id,
+          currentHopIndex: null,
+        }),
+      })
+    ) {
+      logSuppressedSleepStationPassed({ source, stationName: nearest.station.name });
+    } else {
+      const lastNotifiedStationId = await getLastNotifiedStationId(destination.id);
+      if (nearest.station.id !== lastNotifiedStationId) {
+        // #796: 환승역 도착 timing의 segment 정확 식별. evaluateAlarmPhase(:233)와 동일한
+        // currentLine 결정 — lock.boardingLine 우선 → BG GPS jitter로 nearest가 옆 노선 station을
+        // 잡아도 잘못된 다음-다음 transfer 안내를 차단. lock 없으면 nearest.station.line fallback.
+        const target = resolveNextTarget(
+          route,
           destination.name,
-          target,
-          notificationSource,
+          lockForLineGuard?.boardingLine ?? nearest.station.line,
         );
-        await setLastNotifiedStationId(destination.id, nearest.station.id);
-        logFiredStationPassed(source, nearest.station);
+        if (target) {
+          // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
+          await sendStationPassedNotification(
+            nearest.station.name,
+            destination.name,
+            target,
+            notificationSource,
+          );
+          await setLastNotifiedStationId(destination.id, nearest.station.id);
+          logFiredStationPassed(source, nearest.station);
 
-        // #624 BG-safe stale alarm 차단 — 통과한 waypoint의 pre-scheduled bl:* 알람을
-        // 능동 cancel. useBoardingLockAdvancer는 FG only(React hook)지만 stationPipeline은
-        // backgroundLocationTask에서도 호출되어 BG에서도 동일 청소가 일어난다.
-        // advanceHopWindow는 idempotent — FG advancer와 중복 호출돼도 안전.
-        // dedup 가드(lastNotifiedStationId) 안쪽에 위치 — 동일 station 재보고 시
-        // reentrant advance 방지. dedup 구조 리팩터 시 advance가 silent하게 사라지지 않게 주의.
-        const lock = await getBoardingLock();
-        if (lock && route) {
-          const targets = resolveAllTargets(route, destination.name);
-          const matched = targets.find((t) => isSameStationName(t.name, nearest.station.name));
-          if (matched) {
-            await advanceHopWindow({
-              lock,
-              route,
-              destinationName: destination.name,
-              passedStationName: matched.name,
-              sleepMode,
-            });
+          // #624 BG-safe stale alarm 차단 — 통과한 waypoint의 pre-scheduled bl:* 알람을
+          // 능동 cancel. useBoardingLockAdvancer는 FG only(React hook)지만 stationPipeline은
+          // backgroundLocationTask에서도 호출되어 BG에서도 동일 청소가 일어난다.
+          // advanceHopWindow는 idempotent — FG advancer와 중복 호출돼도 안전.
+          // dedup 가드(lastNotifiedStationId) 안쪽에 위치 — 동일 station 재보고 시
+          // reentrant advance 방지. dedup 구조 리팩터 시 advance가 silent하게 사라지지 않게 주의.
+          const lock = await getBoardingLock();
+          if (lock && route) {
+            const targets = resolveAllTargets(route, destination.name);
+            const matched = targets.find((t) => isSameStationName(t.name, nearest.station.name));
+            if (matched) {
+              await advanceHopWindow({
+                lock,
+                route,
+                destinationName: destination.name,
+                passedStationName: matched.name,
+                sleepMode,
+              });
+            }
           }
         }
+      } else {
+        logSuppressedDedupStation(source, nearest.station);
       }
-    } else {
-      logSuppressedDedupStation(source, nearest.station);
     }
   }
 


### PR DESCRIPTION
## Summary
- D8(#1227 sleep rule expansion)이 차단 카테고리에 `station-passed`와 lockless trip을 추가했지만 dispatch path가 게이트를 호출하지 않아 2026-06-12 22:11:56 사가정 station-passed fire 회귀가 차단되지 않음.
- 본 PR은 FG GPS / FG arvlCd fast path / BG stationPipeline 세 dispatch 경로에 `shouldSuppressBySleepRule` 호출을 wire 한다.
- `isStationPassedFirstHop` 공통 헬퍼로 lock 활성(`boardingStationId` 비교)과 lockless(`currentHopIndex===0`) 두 SSOT를 단일 출처에서 결정.
- `alarmLog`에 `sleep-first-station-passed` reason + `logSuppressedSleepStationPassed` 헬퍼 추가 — D8 station-passed 누수 차단 횟수를 transfer 차단과 독립 집계.

## 회귀 차단 evidence
22:11:56 사가정 station-passed fire 회귀를 다음 unit test로 직접 재현·차단 확인:
- `useStationAlarm › #1236 sleep 룰 게이트 — station-passed (FG dispatch wire) › FG GPS path — lockless + sleep ON + currentHopIndex=0 → station-passed 차단`
- `stationPipeline › #1236 sleep 룰 게이트 — station-passed (BG path) › sleep ON + lock 활성 + candidate=boardingStation → station-passed 차단 + suppress 로그`
- `shouldSuppressBySleepRule › isStationPassedFirstHop` 7케이스 매트릭스 (lock/lockless × hopIndex 조합).

## 정책 매트릭스
| 시나리오 | lock | sleep | isFirstHop SSOT | 결과 |
|---|---|---|---|---|
| 사가정 회귀 (FG GPS, lockless + hopIndex=0) | null | ON | `currentHopIndex === 0` | suppress |
| 사가정 회귀 (FG GPS, lock 활성 + boarding=사가정) | active | ON | `candidate.id === boardingStationId` | suppress |
| 진행 중 trip (hopIndex=3) | null | ON | `hopIndex === 0` 미충족 | fire |
| sleep OFF | any | OFF | n/a | fire |
| BG lockless (estimator 입력 부재) | null | ON | SSOT 없음 → graceful skip | fire (보수적) |

BG path는 D1 estimator 입력이 없어 lockless에서 자동 비적용(graceful). FG가 동급 보장.

## Test plan
- [x] `shouldSuppressBySleepRule` 신규 `isStationPassedFirstHop` 7케이스 it.each
- [x] `stationPipeline` BG sleep 게이트 5케이스 (lock active/lockless/silence 우선순위)
- [x] `useStationAlarm` FG dispatch wire 5케이스 매트릭스 + arvlCd fast path 2케이스 + GPS IIFE cancel guard
- [x] `alarmLog.logSuppressedSleepStationPassed` 3 source it.each
- [x] `npm test` 100% coverage / `npm run type-check` / `npm run lint` 통과

## Dependency
- 본 PR은 D8 (#1251) merge 후 dev에 들어가야 정확한 diff 시각화. D8 미머지 상태에서는 PR diff에 D8 변경이 포함돼 보임.
- D1 (#1207 redo merged), D2 (#1208 redo merged via #1250)는 origin/dev 반영 완료.

Closes #1236
Relates to #1204, #1227