### PR TITLE
fix(#1252): maestro CI retry 메커니즘 (flake 자동 회복)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,52 @@ jobs:
             --output maestro-smoke.xml \
             --debug-output ./maestro-debug
 
+      - name: 1차 실패 flow 식별 (#1252 retry)
+        # 1차 maestro 결과에서 실패한 flow YAML 경로만 추출. 전수 재실행 비용 회피.
+        # 1차가 success였으면 빈 출력 → 다음 step의 retry는 skip.
+        id: identify_failed
+        if: always() && steps.maestro_smoke.outcome != 'success'
+        run: |
+          if [ ! -f maestro-smoke.xml ]; then
+            echo "::warning::maestro-smoke.xml not found — 1차에서 junit 미생성. retry skip."
+            echo "failed_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FAILED=$(node scripts/maestro-retry.js maestro-smoke.xml .maestro/flows/smoke)
+          if [ -z "$FAILED" ]; then
+            echo "1차 실패 testcase 없음 (junit에 failure 마커 없음). retry skip."
+            echo "failed_count=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "Retry 대상 flow:"
+            echo "$FAILED"
+            # GITHUB_OUTPUT은 줄바꿈 안전을 위해 delimiter heredoc 사용
+            {
+              echo "failed_flows<<EOF"
+              echo "$FAILED"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            COUNT=$(echo "$FAILED" | grep -c . || true)
+            echo "failed_count=$COUNT" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Maestro Smoke 재실행 (실패 flow만)
+        id: maestro_retry
+        # 시뮬레이터 환경 flake를 흡수하는 확률 layer. 진짜 회귀는 2차에서도 실패.
+        if: always() && steps.identify_failed.outputs.failed_count != '0' && steps.identify_failed.outputs.failed_count != ''
+        continue-on-error: true
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '240000'
+        run: |
+          echo "${{ steps.identify_failed.outputs.failed_flows }}" | while IFS= read -r flow; do
+            [ -z "$flow" ] && continue
+            echo "::group::Retry $flow"
+            maestro test "$flow" \
+              --format junit \
+              --output "maestro-smoke-retry-$(basename "$flow" .yaml).xml" \
+              --debug-output ./maestro-debug-retry || exit 1
+            echo "::endgroup::"
+          done
+
       - name: 시뮬레이터 마지막 화면 캡처
         if: always()
         run: |
@@ -312,14 +358,28 @@ jobs:
           name: maestro-smoke-results
           path: |
             maestro-smoke.xml
+            maestro-smoke-retry-*.xml
             maestro-debug/
+            maestro-debug-retry/
             diag/
 
-      - name: Maestro 결과 판정
-        # continue-on-error의 outcome으로 job 최종 결과 결정.
+      - name: Maestro 결과 판정 (#1252 retry 반영)
+        # 1차 PASS → success.
+        # 1차 FAIL → retry 결과로 판정. retry success면 flake 흡수 PASS.
+        # retry도 FAIL이거나 1차 junit 누락이면 FAIL (진짜 회귀).
         if: always()
         run: |
-          if [ "${{ steps.maestro_smoke.outcome }}" != "success" ]; then
-            echo "::error::Maestro smoke 실패. artifact의 diag/last-screen.png를 확인하세요."
+          if [ "${{ steps.maestro_smoke.outcome }}" = "success" ]; then
+            echo "1차 maestro smoke success."
+            exit 0
+          fi
+          if [ "${{ steps.identify_failed.outputs.failed_count }}" = "0" ]; then
+            echo "::error::1차 maestro 실패했으나 junit에서 실패 flow를 식별하지 못함. 환경/빌드 문제 가능성."
             exit 1
           fi
+          if [ "${{ steps.maestro_retry.outcome }}" = "success" ]; then
+            echo "::notice::1차 ${{ steps.identify_failed.outputs.failed_count }}개 flow fail → 2차 retry success. 시뮬레이터 환경 flake로 판정 (#1252)."
+            exit 0
+          fi
+          echo "::error::Maestro smoke 1차+2차 모두 실패. 진짜 회귀. artifact의 diag/last-screen.png + maestro-smoke-retry-*.xml 확인."
+          exit 1

--- a/scripts/__tests__/maestro-retry.test.js
+++ b/scripts/__tests__/maestro-retry.test.js
@@ -1,0 +1,230 @@
+/**
+ * maestro-retry (#1252) — junit XML 파싱 + flow name 맵 + main() 통합 단위 테스트.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  parseFailedTestcaseNames,
+  buildFlowNameMap,
+  resolveFailedFlows,
+  decodeXmlEntities,
+  unquoteYaml,
+  main,
+} = require('../maestro-retry');
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-retry-'));
+}
+
+function writeFlow(dir, file, name) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  const body =
+    name === null
+      ? 'appId: com.example\n---\n- launchApp\n'
+      : `appId: com.example\nname: ${name}\n---\n- launchApp\n`;
+  fs.writeFileSync(full, body);
+  return full;
+}
+
+const PASS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="suite" tests="2" failures="0">
+    <testcase name="flow-one" classname="suite" time="1.0"/>
+    <testcase name="flow-two" classname="suite" time="1.0"/>
+  </testsuite>
+</testsuites>
+`;
+
+const ONE_FAIL_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="suite" tests="2" failures="1">
+    <testcase name="flow-one" classname="suite" time="1.0"/>
+    <testcase name="flow-two" classname="suite" time="0.5">
+      <failure message="boom">stack</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+`;
+
+const MULTI_FAIL_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="suite" tests="3" failures="2">
+    <testcase name="flow-one" classname="suite" time="1.0">
+      <failure message="x">y</failure>
+    </testcase>
+    <testcase name="flow-two" classname="suite" time="0.5">
+      <error message="boom">stack</error>
+    </testcase>
+    <testcase name="flow-three" classname="suite" time="1.0"/>
+  </testsuite>
+</testsuites>
+`;
+
+describe('parseFailedTestcaseNames', () => {
+  it('returns empty for all-pass junit', () => {
+    expect(parseFailedTestcaseNames(PASS_XML)).toEqual([]);
+  });
+
+  it('extracts a single failed testcase name', () => {
+    expect(parseFailedTestcaseNames(ONE_FAIL_XML)).toEqual(['flow-two']);
+  });
+
+  it('extracts both failure and error testcases', () => {
+    expect(parseFailedTestcaseNames(MULTI_FAIL_XML)).toEqual(['flow-one', 'flow-two']);
+  });
+
+  it('decodes XML entities in name attribute', () => {
+    const xml = `<testcase name="A &amp; B"><failure/></testcase>`;
+    expect(parseFailedTestcaseNames(xml)).toEqual(['A & B']);
+  });
+
+  it('skips failed testcase that has no name attribute', () => {
+    const xml = `<testcase classname="x"><failure/></testcase>`;
+    expect(parseFailedTestcaseNames(xml)).toEqual([]);
+  });
+});
+
+describe('decodeXmlEntities', () => {
+  it('decodes the five standard XML entities', () => {
+    expect(decodeXmlEntities('&lt;&gt;&quot;&apos;&amp;')).toBe(`<>"'&`);
+  });
+});
+
+describe('unquoteYaml', () => {
+  it('strips matched double quotes', () => {
+    expect(unquoteYaml('  "hello"  ')).toBe('hello');
+  });
+  it('strips matched single quotes', () => {
+    expect(unquoteYaml("'hello'")).toBe('hello');
+  });
+  it('leaves unquoted values intact', () => {
+    expect(unquoteYaml('hello world')).toBe('hello world');
+  });
+});
+
+describe('buildFlowNameMap', () => {
+  it('maps yaml `name:` field and file stem to the file path', () => {
+    const dir = makeTmpDir();
+    const p1 = writeFlow(dir, '01_launch.yaml', '"smoke - launch"');
+    const p2 = writeFlow(dir, 'sub/02_nav.yaml', 'navigation flow');
+    const map = buildFlowNameMap(dir);
+    expect(map.get('smoke - launch')).toBe(p1);
+    expect(map.get('01_launch')).toBe(p1);
+    expect(map.get('navigation flow')).toBe(p2);
+    expect(map.get('02_nav')).toBe(p2);
+  });
+
+  it('falls back to file stem when yaml has no name field', () => {
+    const dir = makeTmpDir();
+    const p = writeFlow(dir, '03_nameless.yaml', null);
+    const map = buildFlowNameMap(dir);
+    expect(map.get('03_nameless')).toBe(p);
+  });
+
+  it('does not overwrite stem entry when name field already mapped to same key', () => {
+    const dir = makeTmpDir();
+    // file stem matches name field — should still resolve
+    const p = writeFlow(dir, 'shared.yaml', 'shared');
+    const map = buildFlowNameMap(dir);
+    expect(map.get('shared')).toBe(p);
+  });
+
+  it('ignores non-yaml files', () => {
+    const dir = makeTmpDir();
+    fs.writeFileSync(path.join(dir, 'readme.md'), 'not a flow');
+    const p = writeFlow(dir, 'flow.yml', 'flow');
+    const map = buildFlowNameMap(dir);
+    expect(map.get('flow')).toBe(p);
+    expect([...map.values()]).not.toContain(path.join(dir, 'readme.md'));
+  });
+});
+
+describe('resolveFailedFlows', () => {
+  it('deduplicates flow paths when multiple names map to the same file', () => {
+    const map = new Map([
+      ['flow A', '/x/a.yaml'],
+      ['a', '/x/a.yaml'],
+    ]);
+    const { paths, unresolved } = resolveFailedFlows(['flow A', 'a'], map);
+    expect(paths).toEqual(['/x/a.yaml']);
+    expect(unresolved).toEqual([]);
+  });
+
+  it('collects unresolved names', () => {
+    const map = new Map([['known', '/x/k.yaml']]);
+    const { paths, unresolved } = resolveFailedFlows(['known', 'ghost'], map);
+    expect(paths).toEqual(['/x/k.yaml']);
+    expect(unresolved).toEqual(['ghost']);
+  });
+});
+
+describe('main CLI', () => {
+  function runMain(args) {
+    const stdout = { buf: '', write: (s) => (stdout.buf += s) };
+    const stderr = { buf: '', write: (s) => (stderr.buf += s) };
+    const code = main(['node', 'maestro-retry.js', ...args], { stdout, stderr });
+    return { code, stdout: stdout.buf, stderr: stderr.buf };
+  }
+
+  it('exits 1 with usage when args are missing', () => {
+    const { code, stderr } = runMain([]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/Usage:/);
+  });
+
+  it('exits 1 when junit XML does not exist', () => {
+    const dir = makeTmpDir();
+    const { code, stderr } = runMain(['/nope/missing.xml', dir]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/junit XML not found/);
+  });
+
+  it('exits 1 when flows dir does not exist', () => {
+    const dir = makeTmpDir();
+    const xml = path.join(dir, 'r.xml');
+    fs.writeFileSync(xml, PASS_XML);
+    const { code, stderr } = runMain([xml, '/nope/flows']);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/flows directory not found/);
+  });
+
+  it('exits 0 with empty stdout when no failures', () => {
+    const dir = makeTmpDir();
+    writeFlow(dir, '01.yaml', 'flow-one');
+    const xml = path.join(dir, 'r.xml');
+    fs.writeFileSync(xml, PASS_XML);
+    const { code, stdout, stderr } = runMain([xml, dir]);
+    expect(code).toBe(0);
+    expect(stdout).toBe('');
+    expect(stderr).toBe('');
+  });
+
+  it('prints failed flow yaml paths, one per line', () => {
+    const dir = makeTmpDir();
+    writeFlow(dir, '01.yaml', 'flow-one');
+    const failedPath = writeFlow(dir, '02.yaml', 'flow-two');
+    const xml = path.join(dir, 'r.xml');
+    fs.writeFileSync(xml, ONE_FAIL_XML);
+    const { code, stdout } = runMain([xml, dir]);
+    expect(code).toBe(0);
+    expect(stdout.trim().split('\n')).toEqual([failedPath]);
+  });
+
+  it('returns 1 when a failed testcase name has no matching flow', () => {
+    const dir = makeTmpDir();
+    writeFlow(dir, '01.yaml', 'flow-one');
+    // No file for "flow-two" → unresolved
+    const xml = path.join(dir, 'r.xml');
+    fs.writeFileSync(xml, ONE_FAIL_XML);
+    const { code, stderr } = runMain([xml, dir]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/Unresolved/);
+    expect(stderr).toMatch(/flow-two/);
+  });
+});

--- a/scripts/__tests__/maestro-retry.test.js
+++ b/scripts/__tests__/maestro-retry.test.js
@@ -164,18 +164,29 @@ describe('resolveFailedFlows', () => {
   });
 });
 
-describe('main CLI', () => {
-  function runMain(args) {
-    const stdout = { buf: '', write: (s) => (stdout.buf += s) };
-    const stderr = { buf: '', write: (s) => (stderr.buf += s) };
-    const code = main(['node', 'maestro-retry.js', ...args], { stdout, stderr });
-    return { code, stdout: stdout.buf, stderr: stderr.buf };
-  }
+function runMain(args) {
+  const stdout = { buf: '', write: (s) => (stdout.buf += s) };
+  const stderr = { buf: '', write: (s) => (stderr.buf += s) };
+  const code = main(['node', 'maestro-retry.js', ...args], { stdout, stderr });
+  return { code, stdout: stdout.buf, stderr: stderr.buf };
+}
 
+describe('main CLI', () => {
   it('exits 1 with usage when args are missing', () => {
     const { code, stderr } = runMain([]);
     expect(code).toBe(1);
     expect(stderr).toMatch(/Usage:/);
+  });
+
+  it('falls back to process.stdout/stderr when io is omitted', () => {
+    const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const code = main(['node', 'maestro-retry.js']);
+      expect(code).toBe(1);
+      expect(writeSpy).toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
   it('exits 1 when junit XML does not exist', () => {

--- a/scripts/maestro-retry.js
+++ b/scripts/maestro-retry.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Maestro CI retry helper (#1252).
+ *
+ * Maestro의 junit XML(`maestro test --format junit --output X.xml`)을 파싱해
+ * 실패한 flow에 해당하는 YAML 파일 경로만 stdout으로 출력한다.
+ * CI는 이 출력을 받아 실패한 flow만 2차 실행해 시뮬레이터 환경 flake를 흡수한다.
+ *
+ * Maestro junit XML 구조:
+ *   <testsuites>
+ *     <testsuite>
+ *       <testcase name="<flow YAML의 name 필드>" classname="..." time="..">
+ *         <failure>...</failure>  (실패 시)
+ *       </testcase>
+ *     </testsuite>
+ *   </testsuites>
+ *
+ * testcase는 flow yaml 파일 경로를 직접 담지 않으므로, 같은 flows 디렉토리를
+ * 스캔해 yaml `name:` 필드 → 파일 경로 매핑을 구성한다.
+ *
+ * Usage:
+ *   node scripts/maestro-retry.js <junit.xml> <flows-dir>
+ *
+ * Exit codes:
+ *   0  - 성공 (실패한 flow 없거나, 매핑 모두 해석됨)
+ *   1  - 인자 부족 / 입력 파일 누락 / 매핑되지 않은 실패 testcase 존재
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * junit XML에서 실패한 testcase의 name 속성 배열을 추출한다.
+ * 정규식 기반(런너에 xml 의존성 추가 없이 동작).
+ */
+function parseFailedTestcaseNames(xml) {
+  const names = [];
+  // <testcase ...>...</testcase> 블록 단위로 순회
+  // attrs는 `[^>]` 가 아니라 `[^>/]` — 그렇지 않으면 self-closing `/>` 의 `/` 까지
+  // 탐욕적으로 소비해 `\/>` 분기가 실패하고 다음 `</testcase>` 까지 long-match된다.
+  // (alternation은 backtrack 없이 첫 성공 분기를 채택하므로 attrs 클래스 자체를 좁힌다.)
+  const blockRe = /<testcase\b([^>/]*)(\/>|>([\s\S]*?)<\/testcase>)/g;
+  let match;
+  while ((match = blockRe.exec(xml)) !== null) {
+    const attrs = match[1];
+    const inner = match[3] || '';
+    const isFailure = /<failure\b/.test(inner) || /<error\b/.test(inner);
+    if (!isFailure) {
+      continue;
+    }
+    const nameMatch = /\bname="([^"]*)"/.exec(attrs);
+    if (nameMatch) {
+      names.push(decodeXmlEntities(nameMatch[1]));
+    }
+  }
+  return names;
+}
+
+function decodeXmlEntities(s) {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * flows 디렉토리(재귀)를 스캔해 yaml `name:` 필드 → 파일 경로 맵 생성.
+ * name 필드가 없으면 파일 stem을 fallback 키로도 추가.
+ */
+function buildFlowNameMap(flowsDir) {
+  const map = new Map();
+  const stack = [flowsDir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    const entries = fs.readdirSync(cur, { withFileTypes: true });
+    for (const ent of entries) {
+      const full = path.join(cur, ent.name);
+      if (ent.isDirectory()) {
+        stack.push(full);
+      } else if (ent.isFile() && /\.ya?ml$/i.test(ent.name)) {
+        const text = fs.readFileSync(full, 'utf8');
+        const nameMatch = /^\s*name\s*:\s*(.+?)\s*$/m.exec(text);
+        if (nameMatch) {
+          map.set(unquoteYaml(nameMatch[1]), full);
+        }
+        // 파일 stem도 항상 등록 (yaml name 누락된 flow를 위한 fallback)
+        const stem = ent.name.replace(/\.ya?ml$/i, '');
+        if (!map.has(stem)) {
+          map.set(stem, full);
+        }
+      }
+    }
+  }
+  return map;
+}
+
+function unquoteYaml(raw) {
+  const trimmed = raw.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * 실패한 testcase 이름 → flow 파일 경로 변환.
+ * @returns {{ paths: string[], unresolved: string[] }}
+ */
+function resolveFailedFlows(failedNames, nameToPath) {
+  const paths = [];
+  const unresolved = [];
+  for (const name of failedNames) {
+    const p = nameToPath.get(name);
+    if (p) {
+      if (!paths.includes(p)) {
+        paths.push(p);
+      }
+    } else {
+      unresolved.push(name);
+    }
+  }
+  return { paths, unresolved };
+}
+
+function main(argv, { stdout, stderr } = { stdout: process.stdout, stderr: process.stderr }) {
+  const junitXmlPath = argv[2];
+  const flowsDir = argv[3];
+  if (!junitXmlPath || !flowsDir) {
+    stderr.write('Usage: node scripts/maestro-retry.js <junit.xml> <flows-dir>\n');
+    return 1;
+  }
+  if (!fs.existsSync(junitXmlPath)) {
+    stderr.write(`junit XML not found: ${junitXmlPath}\n`);
+    return 1;
+  }
+  if (!fs.existsSync(flowsDir)) {
+    stderr.write(`flows directory not found: ${flowsDir}\n`);
+    return 1;
+  }
+  const xml = fs.readFileSync(junitXmlPath, 'utf8');
+  const failedNames = parseFailedTestcaseNames(xml);
+  if (failedNames.length === 0) {
+    return 0;
+  }
+  const nameToPath = buildFlowNameMap(flowsDir);
+  const { paths, unresolved } = resolveFailedFlows(failedNames, nameToPath);
+  for (const p of paths) {
+    stdout.write(`${p}\n`);
+  }
+  if (unresolved.length > 0) {
+    stderr.write(
+      `Unresolved failed testcase names (not found in ${flowsDir}):\n` +
+        unresolved.map((n) => `  - ${n}`).join('\n') +
+        '\n',
+    );
+    return 1;
+  }
+  return 0;
+}
+
+module.exports = {
+  parseFailedTestcaseNames,
+  buildFlowNameMap,
+  resolveFailedFlows,
+  decodeXmlEntities,
+  unquoteYaml,
+  main,
+};
+
+if (require.main === module) {
+  process.exit(main(process.argv));
+}

--- a/scripts/maestro-retry.js
+++ b/scripts/maestro-retry.js
@@ -68,7 +68,8 @@ function decodeXmlEntities(s) {
 }
 
 const YAML_EXT_RE = /\.ya?ml$/i;
-const YAML_NAME_FIELD_RE = /^\s*name\s*:\s*(.+?)\s*$/m;
+// 선형 시간 보장: `.+?` + `\s*$` 같은 backtracking-prone 조합 대신 라인 단위로 자른 뒤 trim.
+const YAML_NAME_FIELD_RE = /^[ \t]*name[ \t]*:[ \t]*([^\n\r]*)/m;
 
 /**
  * 단일 YAML 파일을 맵에 등록한다.

--- a/scripts/maestro-retry.js
+++ b/scripts/maestro-retry.js
@@ -60,11 +60,31 @@ function parseFailedTestcaseNames(xml) {
 
 function decodeXmlEntities(s) {
   return s
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+const YAML_EXT_RE = /\.ya?ml$/i;
+const YAML_NAME_FIELD_RE = /^\s*name\s*:\s*(.+?)\s*$/m;
+
+/**
+ * 단일 YAML 파일을 맵에 등록한다.
+ *  - yaml `name:` 필드가 있으면 그 값을 키로 등록 (강한 매핑)
+ *  - 파일 stem도 fallback 키로 등록 (yaml name 누락 대비)
+ */
+function registerYamlFlow(map, fullPath, baseName) {
+  const text = fs.readFileSync(fullPath, 'utf8');
+  const nameMatch = YAML_NAME_FIELD_RE.exec(text);
+  if (nameMatch) {
+    map.set(unquoteYaml(nameMatch[1]), fullPath);
+  }
+  const stem = baseName.replace(YAML_EXT_RE, '');
+  if (!map.has(stem)) {
+    map.set(stem, fullPath);
+  }
 }
 
 /**
@@ -76,22 +96,12 @@ function buildFlowNameMap(flowsDir) {
   const stack = [flowsDir];
   while (stack.length > 0) {
     const cur = stack.pop();
-    const entries = fs.readdirSync(cur, { withFileTypes: true });
-    for (const ent of entries) {
+    for (const ent of fs.readdirSync(cur, { withFileTypes: true })) {
       const full = path.join(cur, ent.name);
       if (ent.isDirectory()) {
         stack.push(full);
-      } else if (ent.isFile() && /\.ya?ml$/i.test(ent.name)) {
-        const text = fs.readFileSync(full, 'utf8');
-        const nameMatch = /^\s*name\s*:\s*(.+?)\s*$/m.exec(text);
-        if (nameMatch) {
-          map.set(unquoteYaml(nameMatch[1]), full);
-        }
-        // 파일 stem도 항상 등록 (yaml name 누락된 flow를 위한 fallback)
-        const stem = ent.name.replace(/\.ya?ml$/i, '');
-        if (!map.has(stem)) {
-          map.set(stem, full);
-        }
+      } else if (ent.isFile() && YAML_EXT_RE.test(ent.name)) {
+        registerYamlFlow(map, full, ent.name);
       }
     }
   }
@@ -129,7 +139,9 @@ function resolveFailedFlows(failedNames, nameToPath) {
   return { paths, unresolved };
 }
 
-function main(argv, { stdout, stderr } = { stdout: process.stdout, stderr: process.stderr }) {
+function main(argv, io) {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
   const junitXmlPath = argv[2];
   const flowsDir = argv[3];
   if (!junitXmlPath || !flowsDir) {


### PR DESCRIPTION
## Summary
- 시뮬레이터 환경 flake 흡수용 retry layer. junit XML을 파싱해 **실패한 flow만** 2차 실행 (전수 재실행 비용 회피, 옵션 C 채택).
- `scripts/maestro-retry.js`: maestro junit XML(`<testcase>` + `<failure>/<error>`)에서 실패 testcase name 추출 → `.maestro/flows/smoke` 디렉토리 스캔으로 yaml `name:` 필드 매핑 → 실패 flow YAML 경로를 stdout 출력. testcase는 file path를 직접 담지 않기 때문에 name 매핑이 필요.
- `.github/workflows/ci.yml` E2E Smoke 잡:
  1. 1차 `maestro test` (`continue-on-error: true`)
  2. 실패 flow 식별 step (1차 PASS면 skip)
  3. retry step (식별된 flow만, 없으면 skip)
  4. 최종 판정 step — 1차 PASS / 1차 FAIL+2차 PASS(flake 흡수) / 1차+2차 FAIL(진짜 회귀)
- retry junit + debug 아티팩트(`maestro-smoke-retry-*.xml`, `maestro-debug-retry/`) 함께 업로드.

## Acceptance
- 1차에서 1개 flow fail + 2차 retry로 통과 → CI PASS (시뮬레이터 환경 flake 흡수)
- 1차 + 2차 모두 fail → CI FAIL (진짜 회귀 보존)
- 1차 모두 PASS → 2차 skip (시간 비용 0)

## Test plan
- [x] 21 단위 테스트 PASS (all pass / 1 fail / multiple fail / XML entity / missing-name / dedup / unresolved 케이스)
- [x] `npm test` 100% coverage 유지
- [x] `npm run type-check` PASS
- [x] `npm run lint` PASS
- [x] YAML 문법 검증
- [ ] **재귀 검증**: 본 PR 머지 후 CI 자체에 retry 적용 — 본 PR이 첫 검증 PR이 됨

## Note
- maestro `--shards` 옵션은 별도 PR 검토 가능 (병렬 실행으로 시간 단축).

Closes #1252
Relates to #1228