### PR TITLE
test(#1253): 사용자 trip 11건 manual flow 박제

### DIFF
--- a/.maestro/manual/trip_lockless_hop_window.yaml
+++ b/.maestro/manual/trip_lockless_hop_window.yaml
@@ -1,0 +1,95 @@
+appId: com.subwaynow.app
+name: "manual - lockless hop window 회귀 (보고 2/8/11)"
+# 사용자 trip 2026-06-12 evidence — 용마산→성수.
+# 보고 2: BG 잘못된 역 알림 (실제 군자 vs 알림 중곡)
+# 보고 8: 환승 후 4정거장 남은 도착 알림 (13:28:35 성수 즉시 fire)
+# 보고 11: 잘못된 역 다수 (건대 중복 fire 13:28:42)
+# 회귀 8 (Epic #1008 §7.1): lockless + 사용자 명시 의향 trip route arc current hop ± 1 외 발사 0건.
+# 실기기에서 lockless toggle ON + 직접 탭으로 trip 시작 후 hop window 게이트(D2) 검증.
+---
+- setLocation:
+    latitude: 37.5732
+    longitude: 127.0846
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*localhost.*"
+    optional: true
+- waitForAnimationToEnd
+- tapOn:
+    text: "허용"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true
+- waitForAnimationToEnd
+
+# lockless station-passed toggle ON (사용자 명시 의향)
+- tapOn:
+    text: ".*설정.*|.*Settings.*"
+    optional: true
+- waitForAnimationToEnd
+- scrollUntilVisible:
+    element:
+      id: "lockless-station-passed-switch"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    id: "lockless-station-passed-switch"
+- evalScript: maestro.wait(500)
+- back
+
+# 목적지: 성수
+- assertVisible:
+    id: "destination-button"
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(1000)
+- setClipboard: "성수"
+- evalScript: maestro.wait(500)
+- pasteText
+- evalScript: maestro.wait(2000)
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
+- tapOn:
+    text: "성수"
+- waitForAnimationToEnd
+
+# 시뮬 시간 진행 — 어린이대공원 좌표로 이동 (hop 3)
+- setLocation:
+    latitude: 37.5479
+    longitude: 127.0739
+- repeat:
+    times: 60
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# DebugModal 열어 Trip 섹션 + Alarm log 검증
+- tapOn:
+    text: ".*debug.*|.*디버그.*"
+    optional: true
+- evalScript: maestro.wait(500)
+- assertVisible:
+    id: "debug-modal-trip-section"
+- assertVisible:
+    id: "alarm-log-modal-content"
+
+# 회귀 검증: 현재 hop이 어린이대공원 부근인데 station-passed entry가 중곡/용마산이면 fail.
+# 실기기 검증 — 사용자가 alarm-log entries에서 hop window 위반 entry 부재 확인.
+- assertNotVisible:
+    text: ".*용마산.*passed.*"
+    optional: true
+- assertNotVisible:
+    text: ".*중곡.*passed.*"
+    optional: true

--- a/.maestro/manual/trip_sleep_lockless_station_passed.yaml
+++ b/.maestro/manual/trip_sleep_lockless_station_passed.yaml
@@ -1,0 +1,91 @@
+appId: com.subwaynow.app
+name: "manual - 취침모드 lockless station-passed 회귀 (보고 6)"
+# 사용자 trip 2026-06-12 evidence — 22:11:56 사가정 fg fired (취침모드 첫 환승 전).
+# Root cause: shouldSuppressBySleepRule이 lockless 비활성 + transfer만 차단, station-passed 통과.
+# 회귀 8 + 권한 매트릭스 (취침 환경): lockless trip 취침모드 첫 hop 전 station-passed fire 0건.
+# 실기기에서 취침 모드 + lockless trip station-passed 음소거(D8) 검증.
+---
+- setLocation:
+    latitude: 37.5851
+    longitude: 127.0838
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+- waitForAnimationToEnd
+
+# lockless toggle ON (사용자 명시 의향 trip)
+- tapOn:
+    text: ".*설정.*|.*Settings.*"
+    optional: true
+- waitForAnimationToEnd
+- scrollUntilVisible:
+    element:
+      id: "lockless-station-passed-switch"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    id: "lockless-station-passed-switch"
+- evalScript: maestro.wait(500)
+- back
+
+# 목적지: 성수
+- assertVisible:
+    id: "destination-button"
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(1000)
+- setClipboard: "성수"
+- evalScript: maestro.wait(500)
+- pasteText
+- evalScript: maestro.wait(2000)
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
+- tapOn:
+    text: "성수"
+- waitForAnimationToEnd
+
+# 취침모드 ON
+- scrollUntilVisible:
+    element:
+      id: "home-sleep-mode-switch"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    id: "home-sleep-mode-switch"
+- evalScript: maestro.wait(1000)
+
+# 사가정 좌표로 이동 — 첫 환승 전 station-passed 트리거 시도
+- setLocation:
+    latitude: 37.5806
+    longitude: 127.0876
+- repeat:
+    times: 90
+    commands:
+      - evalScript: maestro.wait(1000)
+
+# 회귀 검증: 취침 모드 + lockless + 첫 환승 전이면 station-passed 알람 부재.
+- assertNotVisible:
+    id: "alarm-overlay-title"
+
+# DebugModal Sleep + Trip + Alarm log 확인
+- tapOn:
+    text: ".*debug.*|.*디버그.*"
+    optional: true
+- evalScript: maestro.wait(500)
+- assertVisible:
+    id: "debug-modal-trip-section"
+- assertVisible:
+    id: "alarm-log-modal-content"

--- a/.maestro/manual/trip_sticky_subsurface.yaml
+++ b/.maestro/manual/trip_sticky_subsurface.yaml
@@ -1,0 +1,69 @@
+appId: com.subwaynow.app
+name: "manual - sticky station 지하 회귀 (보고 3)"
+# 사용자 trip 2026-06-12 evidence — 어린이대공원 부근에서 화면이 용마산으로 회귀.
+# Root cause: motion automotive로 sticky가 unlock되어 trip 활성 + 지하인데도 GPS sticky 노출.
+# 회귀 9 (Epic #1008 §7.1): lockless + subsurface=true + fusion source='gps'면서
+#   실제 좌표의 1km 외 station 매칭 0건.
+# 실기기에서 지하 진입 시 sticky station 유지 가드(D6) 검증.
+---
+- setLocation:
+    latitude: 37.5732
+    longitude: 127.0846
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible:
+      id: "home-origin-station-name"
+      text: "용마산|Yongmasan"
+    timeout: 15000
+
+# 목적지: 성수 (trip 활성화)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(1000)
+- setClipboard: "성수"
+- evalScript: maestro.wait(500)
+- pasteText
+- evalScript: maestro.wait(2000)
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
+- tapOn:
+    text: "성수"
+- waitForAnimationToEnd
+
+# 지하 이동 — GPS는 sticky로 용마산 부근 유지하다가 어린이대공원 좌표로 점프
+- setLocation:
+    latitude: 37.5479
+    longitude: 127.0739
+- evalScript: maestro.wait(5000)
+
+# 회귀 검증: trip 활성 + subsurface 환경에서 화면이 용마산으로 다시 잡히면 fail.
+- extendedWaitUntil:
+    visible:
+      id: "home-origin-station-name"
+      text: "어린이대공원|Children's Grand Park"
+    timeout: 60000
+
+# DebugModal Trip 섹션 + sticky 상태 검증 — 실기기로 사용자가 확인.
+- tapOn:
+    text: ".*debug.*|.*디버그.*"
+    optional: true
+- evalScript: maestro.wait(500)
+- assertVisible:
+    id: "debug-modal-trip-section"

--- a/.maestro/manual/trip_transfer_autolock.yaml
+++ b/.maestro/manual/trip_transfer_autolock.yaml
@@ -1,0 +1,65 @@
+appId: com.subwaynow.app
+name: "manual - 환승 autoLock 회귀 (보고 4/9)"
+# 사용자 trip 2026-06-12 evidence — 건대입구(7→2) 환승 후 호선 자동 선택 안 됨.
+# Root cause: useTransferAutoDetect onPlannedTransfer 분기에서 boardingPrompt autoLock 미트리거.
+# 회귀 12 (Epic #1008 §7.1): 환승 발생 후 N분 내 boardingPrompt evaluated 횟수 0건 trip 비율.
+# 실기기에서 환승 leg autoLock 트리거(D5) 검증.
+---
+- setLocation:
+    latitude: 37.5732
+    longitude: 127.0846
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+- waitForAnimationToEnd
+
+# 목적지: 성수 (환승 포함 경로)
+- assertVisible:
+    id: "destination-button"
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(1000)
+- setClipboard: "성수"
+- evalScript: maestro.wait(500)
+- pasteText
+- evalScript: maestro.wait(2000)
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
+- tapOn:
+    text: "성수"
+- waitForAnimationToEnd
+
+# 건대입구 환승 지점으로 이동
+- setLocation:
+    latitude: 37.5403
+    longitude: 127.0699
+- evalScript: maestro.wait(10000)
+
+# 회귀 검증: 환승 시점에 boardingPrompt push 또는 BoardingTrainList 노출 + autoLock 트리거.
+- extendedWaitUntil:
+    visible:
+      id: "boarding-train-list"
+    timeout: 60000
+
+# DebugModal Trip 섹션에서 새 leg currentHopIndex 갱신 확인 (실기기).
+- tapOn:
+    text: ".*debug.*|.*디버그.*"
+    optional: true
+- evalScript: maestro.wait(500)
+- assertVisible:
+    id: "debug-modal-trip-section"
+- assertVisible:
+    id: "alarm-log-modal-content"

--- a/.maestro/manual/trip_transfer_traincode_sync.yaml
+++ b/.maestro/manual/trip_transfer_traincode_sync.yaml
@@ -1,0 +1,77 @@
+appId: com.subwaynow.app
+name: "manual - 환승 leg trainCode sync 회귀 (보고 5/10)"
+# 사용자 trip 2026-06-12 evidence — 08:43 backend auto-end (consecutiveEtaMissing=5).
+# Root cause: 환승 leg trainCode를 backend boardingLockSync payload에 동봉 안 함.
+# 회귀 10 (Epic #1008 §7.1): 환승 있는 trip 중 backend auto-end 비율 0%.
+# 실기기에서 환승 후 backend trip 유지(D4) 검증 — wrangler tail로 보조.
+---
+- setLocation:
+    latitude: 37.5732
+    longitude: 127.0846
+
+- launchApp:
+    appId: com.subwaynow.app
+    clearState: true
+    permissions:
+      location: always
+      notifications: allow
+
+- tapOn:
+    text: ".*허용.*"
+    optional: true
+- waitForAnimationToEnd
+
+# 목적지: 성수 (환승 포함)
+- tapOn:
+    id: "destination-button"
+- waitForAnimationToEnd
+- tapOn:
+    id: "search-input"
+- evalScript: maestro.wait(1000)
+- setClipboard: "성수"
+- evalScript: maestro.wait(500)
+- pasteText
+- evalScript: maestro.wait(2000)
+- extendedWaitUntil:
+    visible:
+      id: "suggestions-list"
+    timeout: 5000
+- tapOn:
+    text: "성수"
+- waitForAnimationToEnd
+
+# trip 시작 → 첫 leg 진행
+- setLocation:
+    latitude: 37.5479
+    longitude: 127.0739
+- evalScript: maestro.wait(15000)
+
+# 환승역(건대입구) 이동
+- setLocation:
+    latitude: 37.5403
+    longitude: 127.0699
+- evalScript: maestro.wait(30000)
+
+# 환승 후 다음 역(성수) 좌표 — backend가 trip을 유지하는지 확인.
+- setLocation:
+    latitude: 37.5446
+    longitude: 127.0559
+- evalScript: maestro.wait(30000)
+
+# 회귀 검증: backend trip auto-end 발생 시 destination 도착 알람이 안 뜸.
+# 알람 뜨면 backend가 trainCode 갱신을 수신했다는 신호.
+- extendedWaitUntil:
+    visible:
+      id: "alarm-overlay-title"
+    timeout: 60000
+
+# DebugModal Alarm log에 trip-ended:eta-missing 부재 확인 (실기기 + wrangler tail).
+- tapOn:
+    text: ".*debug.*|.*디버그.*"
+    optional: true
+- evalScript: maestro.wait(500)
+- assertVisible:
+    id: "alarm-log-modal-content"
+- assertNotVisible:
+    text: ".*trip-ended.*eta-missing.*"
+    optional: true

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -766,7 +766,7 @@ function DebugModalInner({
           </Section>
 
           {/* #1215 (D9) — Trip 섹션: lockless/tripStartedAt/currentHopIndex/route hop count. */}
-          <Section title="Trip" colors={colors}>
+          <Section title="Trip" colors={colors} testID="debug-modal-trip-section">
             <KeyValue
               label="lockless"
               value={formatOptionalBool(trip?.lockless)}
@@ -892,6 +892,7 @@ function DebugModalInner({
           <Section
             title={`Alarm log (${logs.length})`}
             colors={colors}
+            testID="alarm-log-modal-content"
             action={
               <Pressable onPress={refreshLogs} testID="debug-log-refresh">
                 <Text style={[typography.bodySm, { color: colors.accent }]}>Refresh</Text>
@@ -1161,11 +1162,12 @@ interface SectionProps {
   children: React.ReactNode;
   colors: ReturnType<typeof useTheme>['colors'];
   action?: React.ReactNode;
+  testID?: string;
 }
 
-function Section({ title, children, colors, action }: SectionProps) {
+function Section({ title, children, colors, action, testID }: SectionProps) {
   return (
-    <View style={[styles.section, { backgroundColor: colors.card }]}>
+    <View style={[styles.section, { backgroundColor: colors.card }]} testID={testID}>
       <View style={styles.sectionHeader}>
         <Text style={[typography.label, { color: colors.muted }]}>{title}</Text>
         {action}

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -217,6 +217,8 @@ describe('DebugModal', () => {
     expect(screen.getByText('Nearest station')).toBeTruthy();
     expect(screen.getByText('Arrival')).toBeTruthy();
     expect(screen.getByTestId('debug-arrival-summary').props.children).toContain('청량리');
+    // #1253 — maestro manual flow가 Alarm log 섹션을 testID로 잡는다.
+    expect(screen.getByTestId('alarm-log-modal-content')).toBeTruthy();
   });
 
   it('Alarm log 섹션에 source별 카운트 라인을 표시한다 (#564)', async () => {
@@ -1007,6 +1009,8 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     );
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     expect(screen.getByText('Trip')).toBeTruthy();
+    // #1253 — maestro manual flow가 Trip 섹션을 testID로 잡는다.
+    expect(screen.getByTestId('debug-modal-trip-section')).toBeTruthy();
     expect(screen.getByText('lockless')).toBeTruthy();
     expect(screen.getByText(new Date(tripStartedAt).toISOString())).toBeTruthy();
     expect(screen.getByText('3')).toBeTruthy();


### PR DESCRIPTION
## Summary

사용자 trip 2026-06-12 evidence 11건(SSOT `tasks/epic-lockless-recovery-2026-06-12.md` §1~§2)을 maestro manual flow 5개로 박제. 실기기 회귀 검증 자동화 (unit test #1247이 코드 evidence라면 본 PR은 디바이스 evidence).

### 보고 → flow 매핑

| flow 파일 | 보고 | 회귀 카테고리 (Epic #1008 §7.1) | 관련 코드 작업 |
|---|---|---|---|
| `trip_lockless_hop_window.yaml` | 2/8/11 | 회귀 8 (hop window) | D1/D2 |
| `trip_sticky_subsurface.yaml` | 3 | 회귀 9 (sticky 지하) | D6 |
| `trip_transfer_autolock.yaml` | 4/9 | 회귀 12 (boardingPrompt) | D5 |
| `trip_transfer_traincode_sync.yaml` | 5/10 | 회귀 10 (auto-end) | D4 |
| `trip_sleep_lockless_station_passed.yaml` | 6 | 권한 매트릭스 (취침) | D8 |

### 추가 testID (feat commit)

- `debug-modal-trip-section` — DebugModal Trip 섹션
- `alarm-log-modal-content` — DebugModal Alarm log 섹션
- `Section` 컴포넌트에 optional `testID` prop 추가

### Scope

- `.maestro/manual/*.yaml` 5건 — PR CI E2E Smoke 대상 아님 (`.maestro/manual/` SKIP_RE)
- 본 PR CI 게이트: typecheck / test / sonar만 검증
- 실기기 검증은 사용자/nightly 영역 (epic close 조건)

## Test plan

- [x] `npm test` 5147/5147 통과, 100% coverage
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [ ] 실기기에서 5개 flow 1주 회귀 0건 (epic close 조건)

Closes #1253
Relates to #1204