### PR TITLE
feat(#1261): 그룹 0 PR A — backend regression counter + admin endpoint

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2430,3 +2430,116 @@ describe('GET /admin/quota (#1022)', () => {
     expect(body.count).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe('POST /telemetry/regression (#1261)', () => {
+  const validBody = {
+    token: 'aabbccdd11223344',
+    since: 0,
+    until: 1000,
+    counts: { '8': 1, '10': 2 },
+  };
+
+  it('returns 400 on invalid JSON', async () => {
+    const env = makeKvEnv();
+    const res = await post('/telemetry/regression', 'not-json{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const env = makeKvEnv();
+    const res = await post('/telemetry/regression', { token: '' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('writes counts to KV when payload valid', async () => {
+    const env = makeKvEnv();
+    const res = await post('/telemetry/regression', validBody, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    const kv = env.TRIPS as unknown as InMemoryKV;
+    const dayKeys = [...kv.store.keys()].filter((k) => k.startsWith('regression:day:'));
+    expect(dayKeys.length).toBeGreaterThan(0);
+  });
+
+  it('also writes datapoints to TELEMETRY binding when present', async () => {
+    const writer: AnalyticsEngineWriter = { writeDataPoint: vi.fn() };
+    const env = makeEnv({
+      TRIPS: new InMemoryKV() as unknown as Env['TRIPS'],
+      TELEMETRY: writer,
+    });
+    const res = await post('/telemetry/regression', validBody, env);
+    expect(res.status).toBe(200);
+    expect(writer.writeDataPoint).toHaveBeenCalled();
+  });
+});
+
+describe('GET /admin/telemetry/regressions (#1261)', () => {
+  async function getRegressions(env: Env, authHeader?: string): Promise<Response> {
+    return app.fetch(
+      new Request('http://example.com/admin/telemetry/regressions', {
+        headers: authHeader ? { authorization: authHeader } : undefined,
+      }),
+      env,
+    );
+  }
+
+  function makeAuthEnv(): Env {
+    return makeEnv({ TRIPS: new InMemoryKV() as unknown as Env['TRIPS'], ADMIN_TOKEN: 'secret' });
+  }
+
+  it('returns 503 when ADMIN_TOKEN not configured', async () => {
+    const env = makeKvEnv();
+    const res = await getRegressions(env, 'Bearer x');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'admin_unavailable' });
+  });
+
+  it('returns 401 without bearer header', async () => {
+    const env = makeAuthEnv();
+    const res = await getRegressions(env);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with wrong token', async () => {
+    const env = makeAuthEnv();
+    const res = await getRegressions(env, 'Bearer wrong');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns all known ids with zero windows when KV empty (authorized)', async () => {
+    const env = makeAuthEnv();
+    const res = await getRegressions(env, 'Bearer secret');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ids: string[];
+      counts: Record<string, { last5m: number; lastHour: number; today: number; last7d: number }>;
+    };
+    expect(body.ids).toEqual(['8', '10', '11', '12']);
+    for (const id of body.ids) {
+      expect(body.counts[id]).toEqual({ last5m: 0, lastHour: 0, today: 0, last7d: 0 });
+    }
+  });
+
+  it('reflects counters previously written via POST', async () => {
+    const env = makeAuthEnv();
+    await post(
+      '/telemetry/regression',
+      {
+        token: 'aabbccdd11223344',
+        since: 0,
+        until: 1,
+        counts: { '8': 3 },
+      },
+      env,
+    );
+    const res = await getRegressions(env, 'Bearer secret');
+    const body = (await res.json()) as {
+      counts: Record<string, { last5m: number; today: number }>;
+    };
+    expect(body.counts['8'].last5m).toBe(3);
+    expect(body.counts['8'].today).toBe(3);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/regressionTelemetry.test.ts
+++ b/backend/alarm-worker/src/__tests__/regressionTelemetry.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BUCKET_MS,
+  KNOWN_REGRESSION_IDS,
+  bucketKey,
+  dayKey,
+  incrementRegressionCounters,
+  readRegressionCounters,
+  validateRegressionUpload,
+  writeRegressionDataPoints,
+  type RegressionUpload,
+} from '../regressionTelemetry';
+import { InMemoryKV } from './inMemoryKv';
+
+function base(): Record<string, unknown> {
+  return {
+    token: 'aabbccdd11223344',
+    since: 1_000,
+    until: 2_000,
+    counts: { '8': 1, '10': 2 },
+  };
+}
+
+describe('validateRegressionUpload', () => {
+  it('accepts a valid payload', () => {
+    const result = validateRegressionUpload(base());
+    expect(result).not.toBeNull();
+    expect(result?.counts['8']).toBe(1);
+    expect(result?.counts['10']).toBe(2);
+  });
+
+  it('rejects non-object', () => {
+    expect(validateRegressionUpload(null)).toBeNull();
+    expect(validateRegressionUpload('x')).toBeNull();
+  });
+
+  it('rejects missing/empty token', () => {
+    expect(validateRegressionUpload({ ...base(), token: '' })).toBeNull();
+    const noToken = base();
+    delete noToken.token;
+    expect(validateRegressionUpload(noToken)).toBeNull();
+  });
+
+  it('rejects non-integer / negative time fields', () => {
+    expect(validateRegressionUpload({ ...base(), since: -1 })).toBeNull();
+    expect(validateRegressionUpload({ ...base(), until: -1 })).toBeNull();
+    expect(validateRegressionUpload({ ...base(), since: 1.5 })).toBeNull();
+    expect(validateRegressionUpload({ ...base(), until: NaN })).toBeNull();
+    expect(validateRegressionUpload({ ...base(), since: 'x' })).toBeNull();
+  });
+
+  it('rejects when until < since', () => {
+    expect(validateRegressionUpload({ ...base(), since: 2000, until: 1000 })).toBeNull();
+  });
+
+  it('rejects when counts is missing or wrong type', () => {
+    const missing = base();
+    delete missing.counts;
+    expect(validateRegressionUpload(missing)).toBeNull();
+    expect(validateRegressionUpload({ ...base(), counts: null })).toBeNull();
+    expect(validateRegressionUpload({ ...base(), counts: 'x' })).toBeNull();
+  });
+
+  it('rejects invalid count value', () => {
+    expect(validateRegressionUpload({ ...base(), counts: { '8': -1 } })).toBeNull();
+    expect(validateRegressionUpload({ ...base(), counts: { '8': 1.5 } })).toBeNull();
+    expect(validateRegressionUpload({ ...base(), counts: { '8': 'x' } })).toBeNull();
+  });
+
+  it('drops unknown regression ids', () => {
+    const result = validateRegressionUpload({
+      ...base(),
+      counts: { '8': 1, '99': 5 },
+    });
+    expect(result?.counts['8']).toBe(1);
+    expect((result?.counts as Record<string, number>)['99']).toBeUndefined();
+  });
+
+  it('rejects when total is zero (all known ids missing or zero)', () => {
+    expect(validateRegressionUpload({ ...base(), counts: {} })).toBeNull();
+    expect(
+      validateRegressionUpload({ ...base(), counts: { '8': 0, '10': 0 } }),
+    ).toBeNull();
+    expect(
+      validateRegressionUpload({ ...base(), counts: { '99': 5 } }),
+    ).toBeNull();
+  });
+});
+
+describe('writeRegressionDataPoints', () => {
+  function makeWriter() {
+    return { writeDataPoint: vi.fn() };
+  }
+
+  const payload: RegressionUpload = {
+    token: 'aabbccdd11223344',
+    since: 0,
+    until: 1,
+    counts: { '8': 2, '10': 0, '11': 3 },
+  };
+
+  it('writes one data point per non-zero counter', () => {
+    const writer = makeWriter();
+    writeRegressionDataPoints(writer, payload);
+    expect(writer.writeDataPoint).toHaveBeenCalledTimes(2);
+    const labels = writer.writeDataPoint.mock.calls.map((c) => c[0].blobs[0]);
+    expect(labels).toContain('regression:8');
+    expect(labels).toContain('regression:11');
+    expect(labels).not.toContain('regression:10');
+  });
+
+  it('skips when all counts are zero', () => {
+    const writer = makeWriter();
+    writeRegressionDataPoints(writer, { ...payload, counts: { '8': 0 } });
+    expect(writer.writeDataPoint).not.toHaveBeenCalled();
+  });
+
+  it('includes token prefix in blobs and indexes', () => {
+    const writer = makeWriter();
+    writeRegressionDataPoints(writer, payload);
+    const first = writer.writeDataPoint.mock.calls[0][0];
+    expect(first.blobs[1]).toBe('aabbccdd');
+    expect(first.indexes[0]).toBe('aabbccdd');
+    expect(first.doubles[0]).toBeGreaterThan(0);
+  });
+});
+
+describe('bucketKey / dayKey', () => {
+  it('builds 5m bucket key from bucket timestamp', () => {
+    expect(bucketKey(1_700_000_000_000, '8')).toBe('regression:5m:1700000000000:8');
+  });
+
+  it('builds day key from iso date', () => {
+    expect(dayKey('2026-06-13', '10')).toBe('regression:day:2026-06-13:10');
+  });
+});
+
+describe('incrementRegressionCounters', () => {
+  it('writes both bucket and day key with accumulated value', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const now = Date.UTC(2026, 5, 13, 10, 0, 0);
+    await incrementRegressionCounters(kv, now, { '8': 1 });
+    await incrementRegressionCounters(kv, now, { '8': 2 });
+
+    const bucketTs = Math.floor(now / BUCKET_MS) * BUCKET_MS;
+    expect(await kv.get(bucketKey(bucketTs, '8'))).toBe('3');
+    expect(await kv.get(dayKey('2026-06-13', '8'))).toBe('3');
+  });
+
+  it('skips zero / missing ids', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const now = Date.UTC(2026, 5, 13, 10, 0, 0);
+    await incrementRegressionCounters(kv, now, { '8': 0, '10': 1 });
+
+    const bucketTs = Math.floor(now / BUCKET_MS) * BUCKET_MS;
+    expect(await kv.get(bucketKey(bucketTs, '8'))).toBeNull();
+    expect(await kv.get(bucketKey(bucketTs, '10'))).toBe('1');
+  });
+
+  it('treats malformed KV value as zero on read-modify-write', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(bucketKey(Math.floor(Date.UTC(2026, 5, 13, 10, 0, 0) / BUCKET_MS) * BUCKET_MS, '8'), 'NaN');
+    const now = Date.UTC(2026, 5, 13, 10, 0, 0);
+    await incrementRegressionCounters(kv as unknown as KVNamespace, now, { '8': 5 });
+
+    const bucketTs = Math.floor(now / BUCKET_MS) * BUCKET_MS;
+    expect(await kv.get(bucketKey(bucketTs, '8'))).toBe('5');
+  });
+});
+
+describe('readRegressionCounters', () => {
+  it('returns all known ids with zeros when KV empty', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const now = Date.UTC(2026, 5, 13, 10, 0, 0);
+    const out = await readRegressionCounters(kv, now);
+    for (const id of KNOWN_REGRESSION_IDS) {
+      expect(out[id]).toEqual({ last5m: 0, lastHour: 0, today: 0, last7d: 0 });
+    }
+  });
+
+  it('sums current bucket as last5m, 12 buckets as lastHour, day buckets as today/last7d', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const now = Date.UTC(2026, 5, 13, 10, 0, 0);
+    const currentBucket = Math.floor(now / BUCKET_MS) * BUCKET_MS;
+
+    // 현재 bucket
+    await kv.put(bucketKey(currentBucket, '8'), '5');
+    // 30분 전 bucket (포함되어야 함)
+    await kv.put(bucketKey(currentBucket - 6 * BUCKET_MS, '8'), '3');
+    // 65분 전 bucket (lastHour 윈도우 밖)
+    await kv.put(bucketKey(currentBucket - 13 * BUCKET_MS, '8'), '99');
+
+    // 오늘
+    await kv.put(dayKey('2026-06-13', '8'), '10');
+    // 어제
+    await kv.put(dayKey('2026-06-12', '8'), '7');
+    // 8일 전 (last7d 윈도우 밖)
+    await kv.put(dayKey('2026-06-05', '8'), '99');
+
+    const out = await readRegressionCounters(kv, now);
+    expect(out['8'].last5m).toBe(5);
+    expect(out['8'].lastHour).toBe(8);
+    expect(out['8'].today).toBe(10);
+    expect(out['8'].last7d).toBe(17);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -68,6 +68,13 @@ import {
   validateTelemetryUpload,
   writeTelemetryDataPoints,
 } from './telemetry';
+import {
+  KNOWN_REGRESSION_IDS,
+  incrementRegressionCounters,
+  readRegressionCounters,
+  validateRegressionUpload,
+  writeRegressionDataPoints,
+} from './regressionTelemetry';
 import { getTrip, putTrip } from './trips';
 import { getQuotaStatus, incrementDailyRequestCount } from './quotaTracker';
 import type {
@@ -591,6 +598,58 @@ app.post('/telemetry/delta-vs-estimator', async (c) => {
     }),
   );
   return c.json({ ok: true });
+});
+
+/**
+ * 회귀 카운터 텔레메트리 upload (#1261, Epic #1204 그룹 0).
+ *
+ * 클라이언트가 trip 종료 시 누적된 회귀 8/10/11/12 발생 수를 보고한다.
+ * 5분 sliding window + 일별 KV 카운터에 적재 + AE binding 있으면 datapoint write.
+ * Trip 존재 여부 확인 안 함 — trip 만료 케이스에도 telemetry 보존(데이터 완전성).
+ */
+app.post('/telemetry/regression', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateRegressionUpload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  await incrementRegressionCounters(c.env.TRIPS, Date.now(), payload.counts);
+
+  const writer = c.env.TELEMETRY;
+  if (writer) {
+    writeRegressionDataPoints(writer, payload);
+  }
+  console.log(
+    JSON.stringify({
+      msg: 'regression uploaded',
+      tokenPrefix: tokenPrefix(payload.token),
+      counts: payload.counts,
+      sink: writer ? 'ae' : 'none',
+    }),
+  );
+  return c.json({ ok: true });
+});
+
+/**
+ * 회귀 카운트 조회 (#1261, Epic #1204 그룹 0).
+ *
+ * 운영자가 wrangler tail 없이 5분/일/주 추이 확인. DebugModal Regressions 섹션
+ * (그룹 0 PR C)도 동일 endpoint 사용 (앱이 ADMIN_TOKEN 소지하는 운영 빌드 한정).
+ * 응답은 알려진 모든 id를 포함 (0이어도 키 유지 — 클라이언트 표 안정성).
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — `/admin/feedback`, `/admin/quota`와 동일 정책.
+ * 운영 지표 시계열을 비인증 노출하지 않기 위함.
+ */
+app.get('/admin/telemetry/regressions', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const counts = await readRegressionCounters(c.env.TRIPS, Date.now());
+  return c.json({ ids: KNOWN_REGRESSION_IDS, counts });
 });
 
 /**

--- a/backend/alarm-worker/src/regressionTelemetry.ts
+++ b/backend/alarm-worker/src/regressionTelemetry.ts
@@ -1,0 +1,225 @@
+/**
+ * 회귀 카운터 텔레메트리 (#1261, Epic #1204 그룹 0).
+ *
+ * 2026-06-12 사용자 trip 분석 후 도입한 4개 회귀의 발생 빈도를 자동 카운트한다.
+ * 클라이언트가 trip 종료 시 누적된 회귀 발생 수를 보고하면, 5분 sliding window + 일별 KV
+ * 카운터에 적재한다. 운영자는 `GET /telemetry/regressions`로 5분/일/주 추이를 확인한다.
+ *
+ *   regression_8  — 동일 알림 재발사 (alarmKey에 routeSig 부재)
+ *   regression_10 — trip 재생성 후 실시간 정보 3분+ 지연 (POST /trips 다중 등록)
+ *   regression_11 — BoardingTrainList에 "지난 차" 노출 (시각 표시 누락)
+ *   regression_12 — bg→fg 전환 후 boardingLock/route 휘발 (HomeScreen reload 누락)
+ *
+ * Privacy: 카운트만 적재한다. 좌표/시각/원문 미저장. token은 8자 prefix만 익명 aggregate에 사용.
+ * AE binding 미설정 시 datapoint write는 graceful no-op (recall/prescheduled 동형).
+ * KV(`TRIPS`)는 필수 — 카운터 적재용. KV는 모든 환경에 바인딩되어 있다.
+ */
+
+import { tokenPrefix } from './telemetry';
+import type { AnalyticsEngineWriter } from './types';
+
+/**
+ * client `regressionMetrics.ts:KNOWN_REGRESSION_IDS`와 양방향 SSOT.
+ * 본 배열에 없는 id는 validate 단계에서 silently drop — 구버전/신버전 client 호환.
+ */
+export const KNOWN_REGRESSION_IDS = ['8', '10', '11', '12'] as const;
+export type RegressionId = (typeof KNOWN_REGRESSION_IDS)[number];
+
+/** 5분 bucket size (ms). sliding window 분해능. */
+export const BUCKET_MS = 5 * 60 * 1000;
+
+/** last hour 조회 시 합산할 5분 bucket 개수 (현재 bucket 포함 12개 = 60분). */
+const HOUR_BUCKET_COUNT = 12;
+
+/** last 7d 조회 시 합산할 day key 개수 (오늘 포함 7일). */
+const WEEK_DAY_COUNT = 7;
+
+/** 5분 bucket KV TTL — last hour 조회를 위해 1시간 + 여유. */
+const BUCKET_TTL_SECONDS = 60 * 60 + 300;
+
+/** 일별 카운터 KV TTL — last week 조회를 위해 8일. */
+const DAY_TTL_SECONDS = 8 * 24 * 60 * 60;
+
+export interface RegressionUpload {
+  /** APNs device token (hex). prefix(8자)만 anonymous aggregate에 사용. */
+  token: string;
+  /** 이전 flush 시각(epoch ms). 첫 flush는 0. */
+  since: number;
+  /** 현재 flush 시각(epoch ms). */
+  until: number;
+  /** regression id별 카운트. 알려진 id만 보존. */
+  counts: Partial<Record<RegressionId, number>>;
+}
+
+function isFiniteNonNegativeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && Number.isInteger(value);
+}
+
+/**
+ * payload 검증. 형태가 깨졌으면 null, 정상이면 정규화된 객체.
+ * - 음수/NaN/소수 reject (카운터는 자연수)
+ * - counts는 객체만 허용, 알려진 id만 보존
+ * - 모든 알려진 id 카운트가 0이거나 누락이면 reject (no-op upload 차단)
+ */
+export function validateRegressionUpload(input: unknown): RegressionUpload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (!isFiniteNonNegativeInt(obj.since)) return null;
+  if (!isFiniteNonNegativeInt(obj.until)) return null;
+  if (obj.until < obj.since) return null;
+  if (!obj.counts || typeof obj.counts !== 'object') return null;
+
+  const rawCounts = obj.counts as Record<string, unknown>;
+  const counts: Partial<Record<RegressionId, number>> = {};
+  let total = 0;
+  for (const id of KNOWN_REGRESSION_IDS) {
+    const v = rawCounts[id];
+    if (v === undefined) continue;
+    if (!isFiniteNonNegativeInt(v)) return null;
+    counts[id] = v;
+    total += v;
+  }
+  if (total === 0) return null;
+
+  return {
+    token: obj.token,
+    since: obj.since,
+    until: obj.until,
+    counts,
+  };
+}
+
+/**
+ * Analytics Engine에 회귀 id별 data point를 적재한다.
+ *
+ * Schema:
+ *   blob1 = `regression:<id>`
+ *   blob2 = token prefix (8자)
+ *   double1 = count
+ *   index1 = token prefix (sampling용)
+ */
+export function writeRegressionDataPoints(
+  writer: AnalyticsEngineWriter,
+  payload: RegressionUpload,
+): void {
+  const prefix = tokenPrefix(payload.token);
+  for (const id of KNOWN_REGRESSION_IDS) {
+    const count = payload.counts[id] ?? 0;
+    if (count <= 0) continue;
+    writer.writeDataPoint({
+      blobs: [`regression:${id}`, prefix],
+      doubles: [count],
+      indexes: [prefix],
+    });
+  }
+}
+
+function bucketStart(now: number): number {
+  return Math.floor(now / BUCKET_MS) * BUCKET_MS;
+}
+
+function isoDateUtc(now: number): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+/** 5분 bucket KV 키. */
+export function bucketKey(bucketTs: number, id: RegressionId): string {
+  return `regression:5m:${bucketTs}:${id}`;
+}
+
+/** 일별 KV 키. */
+export function dayKey(dateStr: string, id: RegressionId): string {
+  return `regression:day:${dateStr}:${id}`;
+}
+
+async function readCount(kv: KVNamespace, key: string): Promise<number> {
+  const raw = await kv.get(key);
+  if (raw === null) return 0;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+/**
+ * 회귀 카운트를 5분 bucket + 일별 KV에 누적 적재한다.
+ * 0인 id는 skip.
+ *
+ * Race: read-modify-write 패턴. 분당 ≤ 수회 trip 종료 빈도에서 5분 bucket으로 슬롯이 넓어
+ * 충돌 가능성 낮음 (기존 `incrementDailyRequestCount`와 동형).
+ */
+export async function incrementRegressionCounters(
+  kv: KVNamespace,
+  now: number,
+  counts: Partial<Record<RegressionId, number>>,
+): Promise<void> {
+  const ts = bucketStart(now);
+  const dateStr = isoDateUtc(now);
+  for (const id of KNOWN_REGRESSION_IDS) {
+    const delta = counts[id] ?? 0;
+    if (delta <= 0) continue;
+
+    const bKey = bucketKey(ts, id);
+    const dKey = dayKey(dateStr, id);
+    const [bPrev, dPrev] = await Promise.all([readCount(kv, bKey), readCount(kv, dKey)]);
+    await Promise.all([
+      kv.put(bKey, String(bPrev + delta), { expirationTtl: BUCKET_TTL_SECONDS }),
+      kv.put(dKey, String(dPrev + delta), { expirationTtl: DAY_TTL_SECONDS }),
+    ]);
+  }
+}
+
+/** id별 윈도우 카운트 응답 형태. */
+export interface RegressionWindowCounts {
+  last5m: number;
+  lastHour: number;
+  today: number;
+  last7d: number;
+}
+
+export type RegressionCountsResponse = Record<RegressionId, RegressionWindowCounts>;
+
+async function sumBuckets(
+  kv: KVNamespace,
+  id: RegressionId,
+  startTs: number,
+  endTs: number,
+): Promise<number> {
+  const keys: string[] = [];
+  for (let ts = startTs; ts <= endTs; ts += BUCKET_MS) {
+    keys.push(bucketKey(ts, id));
+  }
+  const vals = await Promise.all(keys.map((k) => readCount(kv, k)));
+  return vals.reduce((a, b) => a + b, 0);
+}
+
+async function sumDays(kv: KVNamespace, id: RegressionId, now: number, days: number): Promise<number> {
+  const keys: string[] = [];
+  for (let i = 0; i < days; i += 1) {
+    keys.push(dayKey(isoDateUtc(now - i * 24 * 60 * 60 * 1000), id));
+  }
+  const vals = await Promise.all(keys.map((k) => readCount(kv, k)));
+  return vals.reduce((a, b) => a + b, 0);
+}
+
+/**
+ * 회귀 id별 last5m / lastHour / today / last7d 카운트를 KV에서 조회한다.
+ * 운영자/DebugModal용. 결과는 모든 알려진 id를 포함 (값이 0이어도 키 포함 — 클라이언트 표 안정성).
+ */
+export async function readRegressionCounters(
+  kv: KVNamespace,
+  now: number,
+): Promise<RegressionCountsResponse> {
+  const currentBucket = bucketStart(now);
+  const hourStart = currentBucket - (HOUR_BUCKET_COUNT - 1) * BUCKET_MS;
+  const out = {} as RegressionCountsResponse;
+  for (const id of KNOWN_REGRESSION_IDS) {
+    const [last5m, lastHour, today, last7d] = await Promise.all([
+      readCount(kv, bucketKey(currentBucket, id)),
+      sumBuckets(kv, id, hourStart, currentBucket),
+      readCount(kv, dayKey(isoDateUtc(now), id)),
+      sumDays(kv, id, now, WEEK_DAY_COUNT),
+    ]);
+    out[id] = { last5m, lastHour, today, last7d };
+  }
+  return out;
+}


### PR DESCRIPTION
Epic #1204 그룹 0 (측정 인프라) PR A. 회귀 8/10/11/12 자동 카운트 인프라.

## 변경
- `backend/alarm-worker/src/regressionTelemetry.ts` 신설
  - `KNOWN_REGRESSION_IDS = ['8','10','11','12']` SSOT (client `regressionMetrics.ts` 양방향)
  - `validateRegressionUpload` — 잘못된 payload 400, `total === 0` reject
  - `writeRegressionDataPoints` — Analytics Engine blob `regression:<id>` 적재
  - `incrementRegressionCounters` — 5분 sliding window bucket + 일별 KV 적재
  - `readRegressionCounters` — last5m / lastHour / today / last7d
- `index.ts`
  - `POST /telemetry/regression` — 클라이언트 trip 종료 시 누적분 보고
  - `GET /admin/telemetry/regressions` — Bearer `ADMIN_TOKEN` 운영자 조회
- 단위 테스트 + 라우트 통합 테스트

## 회귀 매핑
- regression_8: 동일 알림 재발사
- regression_10: trip 재생성 후 실시간 정보 3분+ 지연
- regression_11: BoardingTrainList "지난 차" 노출
- regression_12: bg→fg 전환 후 boardingLock/route 휘발

## Privacy
카운트만. token은 8자 prefix만 익명 aggregate. 좌표/시각/원문 미저장.

## 검증
- `npm test` (backend/alarm-worker): 33 files / 1219 tests pass
- `npm run type-check`: pass
- TELEMETRY binding 미설정 graceful no-op (recall/prescheduled 패턴 동형)

## Evidence 시나리오 (그룹 0 acceptance)
환승 1회 trip (강남(2)→교대(2→3)→양재(3), 약 10분) 종료 후:
1. `GET /admin/telemetry/regressions`로 4 회귀 키 응답 확인 (값은 0이어도 키 유지)
2. PR B/C 머지 후 DebugModal에 Regressions 섹션 노출
3. wrangler tail에 `msg: 'regression uploaded'` 적재 로그 확인

## Plan / 메모리
- plan v7: `/Users/kimdohan/.claude/plans/synchronous-wiggling-zephyr.md` L57-75
- 진입점: `memory/project_2026_06_13_plan_v7_groups.md`
- root cause: `memory/project_2026_06_13_31_root_causes.md`
- cycle rule: `memory/feedback_group_evidence_cycle.md`

Closes #1261
Part of #1204