### PR TITLE
fix(#1264): 그룹 1 PR B — N3 routeSig 전환 시 tba: 사전 예약 cleanup

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1075,43 +1075,37 @@ describe('useApnsTripRegistration', () => {
   // #1264 (N3) — routeSig 전환 시 사전 예약된 tba: 알람 cancel.
   // 2026-06-12 user trip의 50분 영구 `revalidate-route-sig-mismatch` 회귀 차단.
   describe('#1264 (N3) routeSig 전환 시 cancelTripBoundAlarms', () => {
-    it('첫 register(이전 sig 없음)에는 cancelTripBoundAlarms 호출 안 함', async () => {
-      renderHook(() =>
-        useApnsTripRegistration({
-          route: directRoute,
-          destination: station,
-          nextStationEtaSeconds: 120,
-        }),
+    type TripProps = { route: Route | null; destination: Station | null };
+    const renderTrip = (initialProps: TripProps) =>
+      renderHook(
+        ({ route, destination }: TripProps) =>
+          useApnsTripRegistration({ route, destination, nextStationEtaSeconds: 120 }),
+        { initialProps },
       );
+
+    it('첫 register(이전 sig 없음)에는 cancelTripBoundAlarms 호출 안 함', async () => {
+      renderTrip({ route: directRoute, destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
       expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
     });
 
     it('routeSig 전환 시 register 전에 cancelTripBoundAlarms 호출', async () => {
-      const { rerender } = renderHook(
-        ({ route }: { route: Route }) =>
-          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
-        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
-      );
+      const { rerender } = renderTrip({ route: makeDirectRoute(5, '2'), destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
       expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
 
       // route 내용 변경 — routeSig 전환
-      rerender({ route: makeDirectRoute(6, '2') as Route });
+      rerender({ route: makeDirectRoute(6, '2'), destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
     });
 
     it('동일 routeSig 재진입(reference만 변경)에는 cancelTripBoundAlarms 호출 안 함', async () => {
-      const { rerender } = renderHook(
-        ({ route }: { route: Route }) =>
-          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
-        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
-      );
+      const { rerender } = renderTrip({ route: makeDirectRoute(5, '2'), destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
       // 같은 내용 new reference — routeSig 동일
-      rerender({ route: makeDirectRoute(5, '2') as Route });
+      rerender({ route: makeDirectRoute(5, '2'), destination: station });
       await act(async () => {
         await Promise.resolve();
       });
@@ -1120,14 +1114,10 @@ describe('useApnsTripRegistration', () => {
 
     it('cancelTripBoundAlarms 실패해도 register는 graceful 진행', async () => {
       mockCancelTripBoundAlarms.mockRejectedValueOnce(new Error('cancel failed'));
-      const { rerender } = renderHook(
-        ({ route }: { route: Route }) =>
-          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
-        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
-      );
+      const { rerender } = renderTrip({ route: makeDirectRoute(5, '2'), destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
-      rerender({ route: makeDirectRoute(6, '2') as Route });
+      rerender({ route: makeDirectRoute(6, '2'), destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
       // register는 그대로 발사됨
@@ -1140,36 +1130,26 @@ describe('useApnsTripRegistration', () => {
         if (key === ACTIVE_TRIP_KEY) return 'token-abc';
         return null;
       });
-      const { rerender } = renderHook(
-        ({ r, d }: { r: Route; d: Station | null }) =>
-          useApnsTripRegistration({ route: r, destination: d, nextStationEtaSeconds: 120 }),
-        { initialProps: { r: directRoute as Route, d: station as Station | null } },
-      );
+      const { rerender } = renderTrip({ route: directRoute, destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
       // trip 종료
-      rerender({ r: null, d: null });
+      rerender({ route: null, destination: null });
       await waitFor(() => expect(mockClear).toHaveBeenCalled());
       expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
 
       // 새 trip 시작 (다른 route) — lastRouteSigRef가 reset되었으므로 cancel 호출 안 함
-      rerender({ r: makeDirectRoute(7, '2') as Route, d: station as Station | null });
+      rerender({ route: makeDirectRoute(7, '2'), destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
       expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
     });
 
     it('destination 변경 시(routeSig 동일 가정 X — 다른 route 보낼 때) cancel 호출', async () => {
       const altStation: Station = { ...station, id: '2-023', name: '역삼' };
-      const { rerender } = renderHook(
-        ({ r, d }: { r: Route; d: Station }) =>
-          useApnsTripRegistration({ route: r, destination: d, nextStationEtaSeconds: 120 }),
-        {
-          initialProps: { r: makeDirectRoute(5, '2') as Route, d: station },
-        },
-      );
+      const { rerender } = renderTrip({ route: makeDirectRoute(5, '2'), destination: station });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
-      rerender({ r: makeDirectRoute(6, '2') as Route, d: altStation });
+      rerender({ route: makeDirectRoute(6, '2'), destination: altStation });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
     });
@@ -1179,14 +1159,13 @@ describe('useApnsTripRegistration', () => {
       mockCancelTripBoundAlarms.mockImplementation(
         () => new Promise<void>((res) => { resolveCancel = res; }),
       );
-      const { rerender, unmount } = renderHook(
-        ({ route }: { route: Route }) =>
-          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
-        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
-      );
+      const { rerender, unmount } = renderTrip({
+        route: makeDirectRoute(5, '2'),
+        destination: station,
+      });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
-      rerender({ route: makeDirectRoute(6, '2') as Route });
+      rerender({ route: makeDirectRoute(6, '2'), destination: station });
       await waitFor(() => expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1));
       // unmount 직후 cancel resolve — cancelled 가드로 후속 register 진행 안 함
       unmount();

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -21,6 +21,11 @@ jest.mock('../../api/alarmBackend', () => ({
   clearActiveTrip: (...args: unknown[]) => mockClear(...args),
 }));
 
+const mockCancelTripBoundAlarms = jest.fn();
+jest.mock('../../utils/tripBoundScheduler', () => ({
+  cancelTripBoundAlarms: (...args: unknown[]) => mockCancelTripBoundAlarms(...args),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -60,6 +65,7 @@ describe('useApnsTripRegistration', () => {
     mockGetDevicePushTokenAsync.mockResolvedValue({ data: 'token-abc' });
     mockRegister.mockResolvedValue({ ok: true });
     mockClear.mockResolvedValue({ ok: true });
+    mockCancelTripBoundAlarms.mockResolvedValue(undefined);
     (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
       if (key === APNS_TOKEN_KEY) return 'token-abc';
       return null;
@@ -1063,6 +1069,133 @@ describe('useApnsTripRegistration', () => {
       };
       expect(args.promptGeoContext).toBeUndefined();
       expect(args.promptDisplay).toBeUndefined();
+    });
+  });
+
+  // #1264 (N3) — routeSig 전환 시 사전 예약된 tba: 알람 cancel.
+  // 2026-06-12 user trip의 50분 영구 `revalidate-route-sig-mismatch` 회귀 차단.
+  describe('#1264 (N3) routeSig 전환 시 cancelTripBoundAlarms', () => {
+    it('첫 register(이전 sig 없음)에는 cancelTripBoundAlarms 호출 안 함', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+    });
+
+    it('routeSig 전환 시 register 전에 cancelTripBoundAlarms 호출', async () => {
+      const { rerender } = renderHook(
+        ({ route }: { route: Route }) =>
+          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+
+      // route 내용 변경 — routeSig 전환
+      rerender({ route: makeDirectRoute(6, '2') as Route });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
+    });
+
+    it('동일 routeSig 재진입(reference만 변경)에는 cancelTripBoundAlarms 호출 안 함', async () => {
+      const { rerender } = renderHook(
+        ({ route }: { route: Route }) =>
+          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      // 같은 내용 new reference — routeSig 동일
+      rerender({ route: makeDirectRoute(5, '2') as Route });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+    });
+
+    it('cancelTripBoundAlarms 실패해도 register는 graceful 진행', async () => {
+      mockCancelTripBoundAlarms.mockRejectedValueOnce(new Error('cancel failed'));
+      const { rerender } = renderHook(
+        ({ route }: { route: Route }) =>
+          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      rerender({ route: makeDirectRoute(6, '2') as Route });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
+      // register는 그대로 발사됨
+      expect(mockRegister.mock.calls[1][0]).toMatchObject({ destination: station.id });
+    });
+
+    it('trip 종료(route/destination → null) 후 새 trip 시작 시 첫 register는 cancel 호출 안 함', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return 'token-abc';
+        if (key === ACTIVE_TRIP_KEY) return 'token-abc';
+        return null;
+      });
+      const { rerender } = renderHook(
+        ({ r, d }: { r: Route; d: Station | null }) =>
+          useApnsTripRegistration({ route: r, destination: d, nextStationEtaSeconds: 120 }),
+        { initialProps: { r: directRoute as Route, d: station as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      // trip 종료
+      rerender({ r: null, d: null });
+      await waitFor(() => expect(mockClear).toHaveBeenCalled());
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+
+      // 새 trip 시작 (다른 route) — lastRouteSigRef가 reset되었으므로 cancel 호출 안 함
+      rerender({ r: makeDirectRoute(7, '2') as Route, d: station as Station | null });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+    });
+
+    it('destination 변경 시(routeSig 동일 가정 X — 다른 route 보낼 때) cancel 호출', async () => {
+      const altStation: Station = { ...station, id: '2-023', name: '역삼' };
+      const { rerender } = renderHook(
+        ({ r, d }: { r: Route; d: Station }) =>
+          useApnsTripRegistration({ route: r, destination: d, nextStationEtaSeconds: 120 }),
+        {
+          initialProps: { r: makeDirectRoute(5, '2') as Route, d: station },
+        },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      rerender({ r: makeDirectRoute(6, '2') as Route, d: altStation });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancelTripBoundAlarms in-flight 중 unmount되면 후속 register 미발사 (cancelled 가드)', async () => {
+      let resolveCancel!: () => void;
+      mockCancelTripBoundAlarms.mockImplementation(
+        () => new Promise<void>((res) => { resolveCancel = res; }),
+      );
+      const { rerender, unmount } = renderHook(
+        ({ route }: { route: Route }) =>
+          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      rerender({ route: makeDirectRoute(6, '2') as Route });
+      await waitFor(() => expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1));
+      // unmount 직후 cancel resolve — cancelled 가드로 후속 register 진행 안 함
+      unmount();
+      mockRegister.mockClear();
+      await act(async () => {
+        resolveCancel();
+        await Promise.resolve();
+      });
+      expect(mockRegister).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -25,6 +25,7 @@ import { routeSignature, getStationById } from '../../../shared/utils/stationRou
 import { registerActiveTrip, clearActiveTrip, type AlarmBoardingLock } from '../api/alarmBackend';
 import { routeToWaypoints } from '../../route/utils/routeWaypoints';
 import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
+import { cancelTripBoundAlarms } from '../utils/tripBoundScheduler';
 import { buildBoardingPromptContext } from '../utils/boardingPromptContext';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boardingLock';
@@ -181,6 +182,12 @@ export function useApnsTripRegistration({
   // (non-null → null → 새 lock 3 POST) 판정에 사용. 첫 register 시 null로 시작.
   const lastSentLockSigRef = useRef<string | null>(null);
 
+  // #1264 (N3) — 직전 effect cycle의 routeSig. routeSig가 전환되면 이전 trip의 사전 예약된
+  // `tba:` 알람을 cancel — backend가 보낸 정정 silent push가 stale identifier에 매칭되어
+  // 50분간 `revalidate-route-sig-mismatch`로 누락되는 회귀(2026-06-12 user trip)를 차단한다.
+  // 첫 setDestination(이전 sig 없음)에는 cancel 호출 X — 불필요한 OS 호출 방지.
+  const lastRouteSigRef = useRef<string | null>(null);
+
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
   useEffect(() => {
     let cancelled = false;
@@ -267,7 +274,24 @@ export function useApnsTripRegistration({
         // 트립 없음 분기에서도 lock 시그를 reset — 다음 trip이 새로 등록될 때 첫 cycle은
         // 즉시 발사(debounce 미적용) 보장.
         lastSentLockSigRef.current = null;
+        // #1264 (N3): trip 종료 시 routeSig 추적도 reset — 다음 trip 시작 시 첫 routeSig는
+        // 신규로 취급되어 cancel skip(불필요한 OS 호출 방지).
+        lastRouteSigRef.current = null;
         return;
+      }
+
+      // #1264 (N3) — routeSig 전환 감지: 이전 routeSig가 있고 다르면 사전 예약된 `tba:` 알람
+      // cancel. backend 정정 silent push가 stale identifier에 매칭 실패하는 회귀 차단.
+      // 첫 setDestination(lastRouteSigRef=null)에는 호출 X — 신규 trip은 cancel할 대상 없음.
+      // cancel 실패해도 후속 register는 진행 (graceful) — runTripBoundCleanups + useTripBoundAlarmScheduler
+      // 가 별경로로 동일 cleanup을 시도하므로 본 호출은 belt-and-suspenders.
+      if (lastRouteSigRef.current !== null && lastRouteSigRef.current !== routeSig) {
+        try {
+          await cancelTripBoundAlarms();
+        } catch (e) {
+          logger.warn('cancelTripBoundAlarms (route switch) 실패:', e);
+        }
+        if (cancelled) return;
       }
 
       // 트립 있음 → 토큰 없으면 graceful skip.
@@ -291,6 +315,8 @@ export function useApnsTripRegistration({
       // POST 발사 직후(성공/실패 무관) 송신된 lock sig를 기록 — 다음 cycle이 "직전 송신 = lock,
       // 신규 = null" 패턴인지 판정해 race 차단.
       lastSentLockSigRef.current = boardingLockSig;
+      // #1264 (N3) — POST 발사 직후 송신된 routeSig를 기록. 다음 cycle에서 전환 감지에 사용.
+      lastRouteSigRef.current = routeSig;
       // #669: cancelled 가드 밖에서 setItem — backend register 성공이면 UI cleanup 여부와 무관하게
       // ACTIVE_TRIP_KEY를 동기화. 가드 안에 두면 nextStationEtaSeconds·currentStation 변경으로
       // useEffect cleanup이 자주 일어나 setItem이 skip되고 DebugModal activeTrip이 (none)으로 표시됨.


### PR DESCRIPTION
## Summary
- `useApnsTripRegistration`의 register effect에 routeSig 전환 감지 가드 추가
- 이전 routeSig와 다르고 첫 register가 아닐 때 `cancelTripBoundAlarms()` 호출 (narrow — `tba:` prefix만 cancel)
- 50분 영구 `revalidate-route-sig-mismatch` 회귀(2026-06-12 user trip, 22:08~23:30 KST) 차단

## 회귀 (N3)
2026-06-12 사용자 trip 디바이스/백엔드 로그.
- `revalidate-route-sig-mismatch` skipReason이 50분 영구 발생
- setDestination switch 시점에 이전 trip의 사전 예약된 `tba:` 알람이 다음 hook cycle 이전에 cancel되지 않아 새 route와 sig 불일치
- backend가 보낸 정정 silent push가 stale `tba:` identifier에 매칭 실패 → 50분간 누락

## 설계 결정
- `cancelAllScheduledNotificationsAsync()` 대신 `cancelTripBoundAlarms()` (narrow) — `tba:` prefix만 cancel하므로 `alarm:`/`bl:` 등 다른 채널 보존
- 첫 setDestination(lastRouteSigRef=null) + trip 종료(route/destination=null) 후 새 trip 시작 시점에는 호출 안 함 — 불필요한 OS 호출 방지
- cancel 실패는 graceful (try/catch + warn) — `runTripBoundCleanups` + `useTripBoundAlarmScheduler`가 별경로로 동일 cleanup을 시도하므로 본 호출은 belt-and-suspenders 안전망

## Test plan
- [x] `npm test` (useApnsTripRegistration 58 tests pass, 100% coverage on touched file)
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] 실기기 회귀 검증 (epic acceptance — 다른 PR에서)

## 변경 파일
- `src/features/alarm/hooks/useApnsTripRegistration.ts` (+15 lines: import + ref + try/catch + record)
- `src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts` (+ 6 new test cases)

## 관련
- Epic: #1204
- Plan v7 그룹 1 PR B
- 31 root cause 매핑: N3 항목

Part of #1204
Closes #1264