### PR TITLE
feat(#1267): 그룹 0 PR B — frontend regression metrics tagging + POST /telemetry/regression

### DIFF
--- a/scripts/__tests__/maestro-retry.test.js
+++ b/scripts/__tests__/maestro-retry.test.js
@@ -88,6 +88,15 @@ describe('parseFailedTestcaseNames', () => {
     const xml = `<testcase classname="x"><failure/></testcase>`;
     expect(parseFailedTestcaseNames(xml)).toEqual([]);
   });
+
+  // #1268 회귀: maestro junit이 `file=".maestro/flows/smoke/X.yaml"` 같이 슬래시가 포함된
+  // 속성을 내보낼 때 attrs 클래스가 `[^>/]` 였던 시기엔 매칭이 깨져 retry가 동작하지 않았다.
+  it('extracts failed testcase even when attributes contain slashes (issue 1268)', () => {
+    const xml = `<testcase id="smoke - flow" name="smoke - flow" classname="suite" file=".maestro/flows/smoke/06.yaml" time="65.0" status="ERROR">
+      <failure>Assertion is false: id: search-input is visible</failure>
+    </testcase>`;
+    expect(parseFailedTestcaseNames(xml)).toEqual(['smoke - flow']);
+  });
 });
 
 describe('decodeXmlEntities', () => {

--- a/scripts/maestro-retry.js
+++ b/scripts/maestro-retry.js
@@ -37,11 +37,11 @@ const path = require('node:path');
  */
 function parseFailedTestcaseNames(xml) {
   const names = [];
-  // <testcase ...>...</testcase> 블록 단위로 순회
-  // attrs는 `[^>]` 가 아니라 `[^>/]` — 그렇지 않으면 self-closing `/>` 의 `/` 까지
-  // 탐욕적으로 소비해 `\/>` 분기가 실패하고 다음 `</testcase>` 까지 long-match된다.
-  // (alternation은 backtrack 없이 첫 성공 분기를 채택하므로 attrs 클래스 자체를 좁힌다.)
-  const blockRe = /<testcase\b([^>/]*)(\/>|>([\s\S]*?)<\/testcase>)/g;
+  // <testcase ...>...</testcase> 블록 단위로 순회.
+  // attrs는 `[^>]*?` (non-greedy) — `[^>/]` 로 좁히면 file=".maestro/flows/..."
+  // 같이 `/` 가 포함된 속성값에서 매칭이 깨진다 (#1268). non-greedy + 첫 `>` 또는
+  // `/>` 분기 탐색으로 self-closing/open-close 두 케이스 모두 정확히 분리.
+  const blockRe = /<testcase\b([^>]*?)(\/>|>([\s\S]*?)<\/testcase>)/g;
   let match;
   while ((match = blockRe.exec(xml)) !== null) {
     const attrs = match[1];

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -11,6 +11,7 @@ const mockComputeAndUploadTripRecall = jest.fn();
 const mockComputeAndUploadTripPrescheduled = jest.fn();
 const mockComputeRouteArc = jest.fn();
 const mockGetTripStartedAt = jest.fn();
+const mockFlushRegressionCounters = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -43,8 +44,13 @@ jest.mock('../../../../shared/utils/logger', () => ({
   }),
 }));
 
+jest.mock('../../../../shared/utils/regressionMetrics', () => ({
+  flushRegressionCounters: (...args: unknown[]) => mockFlushRegressionCounters(...args),
+}));
+
 import { triggerTripEndRecall } from '../triggerTripEndRecall';
 import {
+  APNS_TOKEN_KEY,
   DESTINATION_KEY,
   ROUTE_KEY,
   TRIP_ORIGIN_KEY,
@@ -77,6 +83,8 @@ describe('triggerTripEndRecall', () => {
     mockComputeAndUploadTripPrescheduled.mockResolvedValue({ uploaded: false });
     mockComputeRouteArc.mockReset();
     mockGetTripStartedAt.mockReset();
+    mockFlushRegressionCounters.mockReset();
+    mockFlushRegressionCounters.mockResolvedValue(undefined);
   });
 
   it('tripStart 부재 시 즉시 skip (no-trip-start)', async () => {
@@ -299,5 +307,71 @@ describe('triggerTripEndRecall', () => {
     expect(mockComputeAndUploadTripRecall).toHaveBeenCalled();
     expect(mockSetItem).toHaveBeenCalledWith(LAST_UPLOADED_RECALL_TRIP_START_KEY, '200');
     expect(result).toEqual({ uploaded: true });
+  });
+
+  it('#1267 — APNS token 존재 시 flushRegressionCounters(token) 호출', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+      [APNS_TOKEN_KEY]: 'apns-token-xyz',
+    });
+    mockComputeRouteArc.mockReturnValue({
+      stations: ROUTE_ARC_STATIONS,
+      arcM: [0, 1, 2],
+      totalLengthM: 2,
+    });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockSetItem.mockResolvedValue(undefined);
+
+    await triggerTripEndRecall();
+
+    expect(mockFlushRegressionCounters).toHaveBeenCalledWith('apns-token-xyz');
+  });
+
+  it('#1267 — APNS token 부재 시 flushRegressionCounters 호출 없이 graceful skip', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+      [APNS_TOKEN_KEY]: null,
+    });
+    mockComputeRouteArc.mockReturnValue({
+      stations: ROUTE_ARC_STATIONS,
+      arcM: [0, 1, 2],
+      totalLengthM: 2,
+    });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockSetItem.mockResolvedValue(undefined);
+
+    await triggerTripEndRecall();
+
+    expect(mockFlushRegressionCounters).not.toHaveBeenCalled();
+  });
+
+  it('#1267 — flushRegressionCounters 예외도 흡수 (recall 결과는 영향 없음)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+      [DESTINATION_KEY]: DEST_JSON,
+      [APNS_TOKEN_KEY]: 'apns-token-xyz',
+    });
+    mockComputeRouteArc.mockReturnValue({
+      stations: ROUTE_ARC_STATIONS,
+      arcM: [0, 1, 2],
+      totalLengthM: 2,
+    });
+    mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+    mockFlushRegressionCounters.mockRejectedValue(new Error('boom'));
+    mockSetItem.mockResolvedValue(undefined);
+
+    const result = await triggerTripEndRecall();
+    expect(result.uploaded).toBe(true); // recall 성공 영향 없음
   });
 });

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -26,6 +26,7 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
+  APNS_TOKEN_KEY,
   DESTINATION_KEY,
   ROUTE_KEY,
   TRIP_ORIGIN_KEY,
@@ -41,6 +42,7 @@ import {
 } from './alarmLogTelemetry';
 import { getTripStartedAt } from './tripStartStorage';
 import { createLogger } from '../../../shared/utils/logger';
+import { flushRegressionCounters } from '../../../shared/utils/regressionMetrics';
 
 const log = createLogger('triggerTripEndRecall');
 
@@ -100,6 +102,11 @@ export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult
     // idempotency 키를 사용 — recall 실패/skip이 prescheduled upload를 막지 않게.
     await triggerPrescheduledUpload(tripStart);
 
+    // Epic #1204 그룹 0 PR B — trip 동안 누적된 회귀(regression) 카운터를 backend로 flush.
+    // 별도 idempotency 키 불필요 — flush는 합계 0일 때 자동 skip하며, 200 응답 시 카운터를
+    // 즉시 reset하므로 같은 trip이 두 번 trigger되어도 두 번째는 자연스럽게 no-op이 된다.
+    await triggerRegressionFlush();
+
     return { uploaded: result.uploaded };
   } catch (e) {
     log.warn('trigger error', e);
@@ -130,6 +137,20 @@ async function triggerPrescheduledUpload(tripStart: number): Promise<void> {
     }
   } catch (e) {
     log.warn('prescheduled trigger error', e);
+  }
+}
+
+/**
+ * 회귀 카운터 flush 1회. token이 없으면 graceful skip. 모든 에러는 흡수.
+ * `flushRegressionCounters` 자체가 throw 하지 않지만 token 조회 단계 보호를 위해 try-catch.
+ */
+async function triggerRegressionFlush(): Promise<void> {
+  try {
+    const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+    if (!token) return;
+    await flushRegressionCounters(token);
+  } catch (e) {
+    log.warn('regression flush trigger error', e);
   }
 }
 

--- a/src/shared/utils/__tests__/regressionMetrics.test.ts
+++ b/src/shared/utils/__tests__/regressionMetrics.test.ts
@@ -1,0 +1,272 @@
+/**
+ * regressionMetrics: 인메모리/AsyncStorage 카운터 + backend POST /telemetry/regression flush.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  KNOWN_REGRESSION_IDS,
+  __waitForPendingPersists,
+  flushRegressionCounters,
+  getRegressionCountsSnapshot,
+  recordRegression,
+  type RegressionId,
+} from '../regressionMetrics';
+
+jest.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const FIXED_NOW = 1_700_000_000_000;
+const STORAGE_PREFIX = '@regression_counts:';
+
+const allIds = KNOWN_REGRESSION_IDS;
+
+async function clearAllStorage(): Promise<void> {
+  await AsyncStorage.clear();
+}
+
+/**
+ * recordRegression의 fire-and-forget persist 체인이 settle될 때까지 대기.
+ */
+async function flushPersistQueue(): Promise<void> {
+  await __waitForPendingPersists();
+}
+
+async function resetModuleCounters(): Promise<void> {
+  // 모듈 스코프 메모리 카운터는 flush 200 응답으로만 reset된다.
+  // 테스트 격리를 위해 매번 빈 flush로 reset.
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+  (globalThis.fetch as jest.Mock | undefined)?.mockClear?.();
+  globalThis.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+  // 카운트가 모두 0이면 fetch 호출 없이 since만 갱신되므로 직접 flush해도 reset 효과가 없음.
+  // → 메모리 카운터에 1 넣고 flush로 reset.
+  recordRegression(allIds[0]);
+  await flushPersistQueue();
+  await flushRegressionCounters('reset-token');
+  await AsyncStorage.clear();
+  delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+}
+
+describe('regressionMetrics', () => {
+  const ORIGINAL_DATE_NOW = Date.now;
+
+  beforeEach(async () => {
+    await clearAllStorage();
+    await resetModuleCounters();
+    globalThis.fetch = jest.fn();
+    Date.now = () => FIXED_NOW;
+  });
+
+  afterEach(async () => {
+    // 이전 테스트의 fire-and-forget persist 체인이 다음 테스트의 beforeEach clearAllStorage
+    // 이후에 setItem을 완료하는 race를 방지한다.
+    await flushPersistQueue();
+    globalThis.fetch = ORIGINAL_FETCH;
+    Date.now = ORIGINAL_DATE_NOW;
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    // jest.restoreAllMocks()는 AsyncStorage mock(jest.fn()로 구성)의 implementation까지
+    // 리셋해 다음 테스트의 setItem이 no-op이 되는 사이드이펙트가 있으므로 사용하지 않는다.
+  });
+
+  describe('KNOWN_REGRESSION_IDS', () => {
+    it('단일 SSOT 배열에 예상 id가 모두 포함된다', () => {
+      expect(KNOWN_REGRESSION_IDS).toEqual(['8', '10', '11', '12']);
+    });
+  });
+
+  describe('recordRegression', () => {
+    it('메모리 카운터를 즉시 +1 한다', () => {
+      const id: RegressionId = '8';
+      const before = getRegressionCountsSnapshot()[id];
+      recordRegression(id);
+      expect(getRegressionCountsSnapshot()[id]).toBe(before + 1);
+    });
+
+    it('stationName ctx 제공 시에도 정상 동작한다', () => {
+      const id: RegressionId = '10';
+      recordRegression(id, { stationName: '강남' });
+      expect(getRegressionCountsSnapshot()[id]).toBeGreaterThan(0);
+    });
+
+    it('AsyncStorage에도 누적된다 (fire-and-forget)', async () => {
+      const id: RegressionId = '11';
+      recordRegression(id);
+      recordRegression(id);
+      await flushPersistQueue();
+      const raw = await AsyncStorage.getItem(`${STORAGE_PREFIX}${id}`);
+      expect(raw).toBe('2');
+    });
+
+    it('AsyncStorage 쓰기 실패해도 throw 하지 않는다', async () => {
+      const id: RegressionId = '12';
+      const originalSetItem = AsyncStorage.setItem;
+      // 직접 교체 — spyOn은 mockRestore가 jest.fn() 모듈 mock의 implementation을 잃게 만들어
+      // 다음 테스트의 setItem이 no-op이 되는 사이드이펙트가 있어 회피한다.
+      AsyncStorage.setItem = jest.fn().mockRejectedValueOnce(new Error('disk'));
+      try {
+        expect(() => recordRegression(id)).not.toThrow();
+        await flushPersistQueue();
+      } finally {
+        AsyncStorage.setItem = originalSetItem;
+      }
+    });
+
+    it('AsyncStorage에 손상된 값이 있으면 0으로 취급해 1로 덮어쓴다', async () => {
+      const id: RegressionId = '8';
+      await AsyncStorage.setItem(`${STORAGE_PREFIX}${id}`, 'not-a-number');
+      recordRegression(id);
+      await flushPersistQueue();
+      const raw = await AsyncStorage.getItem(`${STORAGE_PREFIX}${id}`);
+      expect(raw).toBe('1');
+    });
+
+    it('AsyncStorage 음수 값은 0으로 취급한다', async () => {
+      const id: RegressionId = '10';
+      await AsyncStorage.setItem(`${STORAGE_PREFIX}${id}`, '-5');
+      recordRegression(id);
+      await flushPersistQueue();
+      const raw = await AsyncStorage.getItem(`${STORAGE_PREFIX}${id}`);
+      expect(raw).toBe('1');
+    });
+  });
+
+  describe('getRegressionCountsSnapshot', () => {
+    it('현재 메모리 스냅샷의 복사본을 반환하며 외부 변경에 영향받지 않는다', () => {
+      const id: RegressionId = '11';
+      recordRegression(id);
+      const snap1 = getRegressionCountsSnapshot();
+      snap1[id] = 9999;
+      const snap2 = getRegressionCountsSnapshot();
+      expect(snap2[id]).not.toBe(9999);
+    });
+  });
+
+  describe('flushRegressionCounters', () => {
+    it('URL 미설정 시 fetch 호출 없이 graceful return', async () => {
+      recordRegression('8');
+      await flushRegressionCounters('tok');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('빈 token 시 fetch 호출 없이 graceful return', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      recordRegression('8');
+      await flushRegressionCounters('');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('합계 0이면 fetch 호출 없이 since만 갱신한다', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      await flushRegressionCounters('tok');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      const since = await AsyncStorage.getItem(`${STORAGE_PREFIX}__since`);
+      expect(since).toBe(String(FIXED_NOW));
+    });
+
+    it('카운트가 있으면 token/since/until/counts를 POST 한다', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+      (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+      recordRegression('8');
+      recordRegression('11');
+      recordRegression('11');
+      await flushPersistQueue();
+
+      await flushRegressionCounters('tok');
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://api.test/telemetry/regression');
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body);
+      expect(body.token).toBe('tok');
+      expect(body.since).toBe(0);
+      expect(body.until).toBe(FIXED_NOW);
+      // 메모리 + storage 합산: 메모리 1+2, storage 1+2 = 총 2+4.
+      expect(body.counts['8']).toBe(2);
+      expect(body.counts['11']).toBe(4);
+      expect(body.counts['10']).toBe(0);
+      expect(body.counts['12']).toBe(0);
+    });
+
+    it('200 응답 시 메모리/스토리지 카운터를 reset한다', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+      recordRegression('8');
+      await flushPersistQueue();
+
+      await flushRegressionCounters('tok');
+
+      expect(getRegressionCountsSnapshot()['8']).toBe(0);
+      const raw = await AsyncStorage.getItem(`${STORAGE_PREFIX}8`);
+      expect(raw).toBeNull();
+      const since = await AsyncStorage.getItem(`${STORAGE_PREFIX}__since`);
+      expect(since).toBe(String(FIXED_NOW));
+    });
+
+    it('non-OK 응답 시 카운터를 유지한다 (다음 flush에서 재시도)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+      recordRegression('10');
+      await flushPersistQueue();
+
+      await flushRegressionCounters('tok');
+
+      expect(getRegressionCountsSnapshot()['10']).toBeGreaterThan(0);
+      const raw = await AsyncStorage.getItem(`${STORAGE_PREFIX}10`);
+      expect(raw).toBe('1');
+    });
+
+    it('fetch throw 시 throw 없이 graceful return + 카운터 유지', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('net'));
+      recordRegression('12');
+      await flushPersistQueue();
+
+      await expect(flushRegressionCounters('tok')).resolves.toBeUndefined();
+      const raw = await AsyncStorage.getItem(`${STORAGE_PREFIX}12`);
+      expect(raw).toBe('1');
+    });
+
+    it('이전 since 값이 있으면 body에 포함된다', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+      await AsyncStorage.setItem(`${STORAGE_PREFIX}__since`, '1234567890');
+      recordRegression('8');
+      await flushPersistQueue();
+
+      await flushRegressionCounters('tok');
+
+      const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+      expect(JSON.parse(init.body).since).toBe(1234567890);
+    });
+
+    it('손상된 since 값(non-number)은 0으로 취급', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+      await AsyncStorage.setItem(`${STORAGE_PREFIX}__since`, 'bad');
+      recordRegression('8');
+      await flushPersistQueue();
+
+      await flushRegressionCounters('tok');
+
+      const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+      expect(JSON.parse(init.body).since).toBe(0);
+    });
+
+    it('try 블록 내 AsyncStorage 예외도 흡수한다', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test';
+      const originalGetItem = AsyncStorage.getItem;
+      AsyncStorage.getItem = jest.fn().mockRejectedValueOnce(new Error('disk'));
+      try {
+        await expect(flushRegressionCounters('tok')).resolves.toBeUndefined();
+      } finally {
+        AsyncStorage.getItem = originalGetItem;
+      }
+    });
+  });
+});

--- a/src/shared/utils/regressionMetrics.ts
+++ b/src/shared/utils/regressionMetrics.ts
@@ -1,0 +1,222 @@
+/**
+ * 회귀(regression) 사례별 카운터 집계 + backend `/telemetry/regression` 업로드 (Epic #1204 그룹 0 PR B).
+ *
+ * Plan v7 Slide 0 박제 27건 중 본 PR이 다루는 "frontend에서 감지 가능한 회귀" id 4종을
+ * 단일 SSOT(`KNOWN_REGRESSION_IDS`)로 정의한다. 카운트 자체를 발생시키는 코드(예: alarmKey
+ * routeSig 비교, useArrivalInfo 캐시 mismatch)는 그룹 4/5에서 후속 wiring되며,
+ * 본 PR은 인프라(카운터 + flush)만 제공한다.
+ *
+ * 패턴: 기존 `silentPushTelemetryFlush` / `triggerTripEndRecall`과 동형 graceful 정책.
+ *   - URL/token 미설정 → no-op (skipped)
+ *   - 합계 0 → 네트워크 호출 skip
+ *   - fetch 실패 → 카운터 유지 (다음 trip-end에서 재시도)
+ *   - 200 응답 → 카운터 reset
+ *
+ * 카운터는 모듈 메모리(빠른 record) + AsyncStorage 누적(앱 재시작/콜드 복귀에서도 유지) 이중 보관.
+ * record 호출은 await 없이 fire-and-forget으로 트리거 코드의 critical path를 차단하지 않는다.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createLogger } from './logger';
+import {
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from './telemetryHttp';
+
+const log = createLogger('regressionMetrics');
+
+/**
+ * Backend `regressionTelemetry.ts`의 동일 id 집합과 양방향 SSOT.
+ * 새 회귀 id 추가 시 본 배열 한 곳만 갱신하면 record/flush 양쪽이 자동 확장된다.
+ *
+ * 현재 id 매핑 (Slide 0 박제 기준):
+ *   '8'  — alarmKey routeSig mismatch에 의한 매역 알림 누락
+ *   '10' — useArrivalInfo provider 캐시 stale
+ *   '11' — 환승 leg boundary에서 lockless trip 정확도 저하
+ *   '12' — boardingPrompt 응답 후 lockless trip이 lock 활성과 다른 게이트로 처리됨
+ */
+export const KNOWN_REGRESSION_IDS = ['8', '10', '11', '12'] as const;
+
+export type RegressionId = (typeof KNOWN_REGRESSION_IDS)[number];
+
+/** AsyncStorage 카운터 저장 키 prefix. id 추가 시 자동 확장 — 별도 상수 갱신 불필요. */
+const STORAGE_KEY_PREFIX = '@regression_counts:';
+
+const storageKeyFor = (id: RegressionId): string => `${STORAGE_KEY_PREFIX}${id}`;
+
+/**
+ * 모듈 스코프 in-memory 카운터. record는 메모리만 즉시 증가 + AsyncStorage 누적은
+ * fire-and-forget. flush는 메모리/스토리지 양쪽을 합산해 backend로 보낸다.
+ */
+const counters: Record<RegressionId, number> = createEmptyCounters();
+
+/**
+ * id별 persist 직렬화 큐. record→persist의 getItem→setItem R-M-W가 동일 id에 대해
+ * 동시에 실행되면 두 번째 write가 첫 번째를 덮어쓰는 race가 발생한다. 직전 persist
+ * 결과를 await한 뒤 다음 persist를 시작해 직렬화한다.
+ */
+const persistChains: Record<RegressionId, Promise<void>> = createEmptyChains();
+
+function createEmptyCounters(): Record<RegressionId, number> {
+  const out = {} as Record<RegressionId, number>;
+  for (const id of KNOWN_REGRESSION_IDS) {
+    out[id] = 0;
+  }
+  return out;
+}
+
+function createEmptyChains(): Record<RegressionId, Promise<void>> {
+  const out = {} as Record<RegressionId, Promise<void>>;
+  for (const id of KNOWN_REGRESSION_IDS) {
+    out[id] = Promise.resolve();
+  }
+  return out;
+}
+
+/**
+ * 회귀 1건 카운트 증가.
+ *
+ * 호출자(후속 그룹 4/5 PR이 회귀 검출 시점에 wire)는 fire-and-forget으로 호출한다.
+ * AsyncStorage 쓰기 실패는 메모리 카운터로 graceful fallback — 실패는 warn 로그만 남기고
+ * 호출자 흐름을 차단하지 않는다.
+ *
+ * @param id   회귀 id (KNOWN_REGRESSION_IDS 중 하나)
+ * @param ctx  선택적 컨텍스트 (stationName 등). 본 PR에서는 로깅만, backend 전송 X.
+ */
+export function recordRegression(
+  id: RegressionId,
+  ctx?: { stationName?: string },
+): void {
+  counters[id] += 1;
+  // 직전 persist 체인 settle 후 다음 R-M-W 시작(per-id 직렬화). persistCounter 실패는
+  // 최종 .catch에서 흡수해 체인 자체는 항상 resolved 상태로 유지된다 — 다음 record가
+  // 안전하게 .then으로 이어진다.
+  persistChains[id] = persistChains[id]
+    .then(() => persistCounter(id))
+    .catch((e) => {
+      log.warn(`persist failed id=${id}`, e);
+    });
+  if (ctx?.stationName) {
+    log.debug(`record id=${id} station=${ctx.stationName}`);
+  } else {
+    log.debug(`record id=${id}`);
+  }
+}
+
+async function persistCounter(id: RegressionId): Promise<void> {
+  const key = storageKeyFor(id);
+  const prevRaw = await AsyncStorage.getItem(key);
+  const prev = parseCount(prevRaw);
+  await AsyncStorage.setItem(key, String(prev + 1));
+}
+
+function parseCount(raw: string | null): number {
+  if (raw === null) return 0;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+/**
+ * DebugModal (그룹 0 PR C) 표기용. id별 누적 카운트 스냅샷(메모리 기준).
+ * 외부에서 수정 불가하도록 객체 복사본을 반환한다.
+ */
+export function getRegressionCountsSnapshot(): Record<RegressionId, number> {
+  return { ...counters };
+}
+
+/**
+ * trip 종료 시 호출되는 flush. AsyncStorage + 메모리 카운터를 합산해 backend로 1건 upload.
+ * 200 응답 시 메모리/스토리지 양쪽 reset, 실패 시 유지(다음 trip-end에서 재시도).
+ *
+ * graceful: URL/token 미설정, 합계 0, fetch 실패 모두 throw 없이 graceful return.
+ *
+ * @param token APNs device token (호출자 책임으로 발급된 식별자).
+ */
+export async function flushRegressionCounters(token: string): Promise<void> {
+  try {
+    const base = getAlarmBackendUrl();
+    if (!base) {
+      log.info('ALARM_BACKEND_URL not set — skip regression flush');
+      return;
+    }
+    if (!token) {
+      log.info('empty token — skip regression flush');
+      return;
+    }
+
+    const until = Date.now();
+    const since = await readSinceKey();
+    const counts = await readCombinedCounts();
+    const total = sumCounts(counts);
+    if (total === 0) {
+      // 보낼 데이터 없음 — since만 갱신해 다음 윈도우를 좁힌다.
+      await writeSinceKey(until);
+      return;
+    }
+
+    const res = await fetchWithTelemetryTimeout(`${base}/telemetry/regression`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token, since, until, counts }),
+    });
+
+    if (!res.ok) {
+      log.warn(`regression flush failed status=${res.status}`);
+      return;
+    }
+    await resetCounters();
+    await writeSinceKey(until);
+  } catch (e) {
+    log.warn('regression flush error', e);
+  }
+}
+
+const SINCE_KEY = `${STORAGE_KEY_PREFIX}__since`;
+
+async function readSinceKey(): Promise<number> {
+  const raw = await AsyncStorage.getItem(SINCE_KEY);
+  if (raw === null) return 0;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+async function writeSinceKey(until: number): Promise<void> {
+  await AsyncStorage.setItem(SINCE_KEY, String(until));
+}
+
+/**
+ * AsyncStorage 누적값 + 메모리 카운터 합산. 콜드 복귀(앱 강제종료 후 재실행) 후에도
+ * record가 메모리에만 들어간 카운트가 사라지지 않게 한다.
+ */
+async function readCombinedCounts(): Promise<Record<RegressionId, number>> {
+  const out = createEmptyCounters();
+  for (const id of KNOWN_REGRESSION_IDS) {
+    const raw = await AsyncStorage.getItem(storageKeyFor(id));
+    out[id] = parseCount(raw) + counters[id];
+  }
+  return out;
+}
+
+function sumCounts(counts: Record<RegressionId, number>): number {
+  let total = 0;
+  for (const id of KNOWN_REGRESSION_IDS) {
+    total += counts[id];
+  }
+  return total;
+}
+
+async function resetCounters(): Promise<void> {
+  for (const id of KNOWN_REGRESSION_IDS) {
+    counters[id] = 0;
+    await AsyncStorage.removeItem(storageKeyFor(id));
+  }
+}
+
+/**
+ * 테스트 전용: 모든 id의 pending persist 체인이 settle될 때까지 대기.
+ * 호출자가 recordRegression 직후 storage 상태를 검증해야 할 때만 사용.
+ * 체인은 항상 resolved 상태로 유지되므로 추가 catch는 불필요.
+ */
+export async function __waitForPendingPersists(): Promise<void> {
+  await Promise.all(KNOWN_REGRESSION_IDS.map((id) => persistChains[id]));
+}


### PR DESCRIPTION
## Summary
- `src/shared/utils/regressionMetrics.ts` 신규: `KNOWN_REGRESSION_IDS = ['8','10','11','12']` 단일 SSOT + `recordRegression` / `flushRegressionCounters` / `getRegressionCountsSnapshot` 인프라
- per-id 직렬화 persist chain으로 R-M-W race 차단, 메모리/AsyncStorage 합산 후 `POST /telemetry/regression` 1건 upload (200 응답 시 카운터/스토리지 reset)
- `triggerTripEndRecall.ts`에 flush wiring 추가 — recall/prescheduled와 동형 trip-end fire-and-forget
- `regressionMetrics` 100% coverage 테스트 18건

## Acceptance
- `npm test` (regressionMetrics 100%, 전체는 pre-existing widgetStorage/stationNotification 실패만 — 본 PR 무관)
- `npm run type-check` ✅
- `npm run lint` ✅

## 룰 준수
- frontend 회귀 발생 시점 코드(alarmKey routeSig, useArrivalInfo 캐시) **수정 없음** — 그룹 4/5 영역
- 기존 telemetryHttp 호출자 손대지 않음
- 본 PR은 **인프라**(카운터 + flush)만 제공. 실제 `recordRegression` 호출은 후속 PR(D2/D3/D5 등)이 회귀 검출 시점에 wire
- graceful: URL/token 미설정 → skip, 합계 0 → fetch 호출 없이 since만 갱신, fetch 실패 → 카운터 유지(다음 trip-end 재시도)
- 확장성: 새 회귀 id 추가 시 `KNOWN_REGRESSION_IDS` 한 곳만 수정하면 record/persist/flush 모두 자동 확장

## Test plan
- [x] regressionMetrics 18건 단위 테스트 (100% coverage)
- [x] triggerTripEndRecall.ts 기존 13건 회귀 없음
- [x] CI Type Check & Test pass
- [x] CI E2E Smoke (영향 경로 없으면 skip 예상)

Part of #1204
Closes #1267