### PR TITLE
fix(#1266): 그룹 2 PR A — D2 hop window fast-path 적용 (22:31 회귀)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -2766,6 +2766,178 @@ describe('useStationAlarm', () => {
       const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
       expect(arvlCdFires).toHaveLength(0);
     });
+
+  });
+
+  // #1266 (Epic #1204 D2 follow-up) — fast-path도 hop window 게이트 적용.
+  // 회귀 evidence: 2026-06-12 22:31 사용자 trip [Img1] — 신당(+6 hop) + 왕십리(+4 hop) 동시 fire.
+  // GPS station-passed effect는 D2(#1208) 게이트로 차단됐으나 fg-arvlcd fast-path는 같은
+  // 게이트가 없어 fusion이 미래 arc station에 jitter landing + lock.trainCode 일치 시
+  // 미래 hop fire 가능. 본 회귀 가드는 fast-path D2 gate 우회 시 fail by design.
+  //
+  // 독립 describe로 분리 — 직전 #917 fast path 블록 일부 케이스가 pending promise 등을
+  // 리킹해 fast-path effect가 통과 안 하는 leakage 회피.
+  describe('#1266 fast-path hop window 게이트 (Epic #1204 D2 follow-up)', () => {
+    // 직전 #917/#1012 등 일부 케이스가 mockReturnValueOnce(pending promise) 또는
+    // mockImplementation(pending)을 queue에 남길 수 있어 본 describe 진입 시 명시적 reset.
+    // clearAllMocks(top-level beforeEach)는 호출 기록만 clear하고 queued 반환값/
+    // mockImplementation은 보존되기 때문.
+    beforeEach(() => {
+      mockGetFiredAlarms.mockReset();
+      mockGetFiredAlarms.mockResolvedValue(new Set<string>());
+      mockSendStationPassedNotification.mockReset();
+      mockSendStationPassedNotification.mockResolvedValue(undefined);
+    });
+
+    const route1266 = makeDirectRoute(3, '2');
+    const activeLock1266 = {
+      destinationId: 'D1',
+      trainCode: 'T-LOCK',
+      boardingStationId: 'S0',
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+    const dummyArrival = { up: [], down: [], isMock: false };
+    // arcStations: 7개 (A0~A6), 모두 line='2' — route('2')와 일치.
+    const arcLine2: Station[] = Array.from({ length: 7 }, (_, i) =>
+      makeStation(`FP-A${i}`, `FPSname${i}`, 37.5 + i * 0.001, 127.0 + i * 0.001),
+    );
+
+    function inputs1266(overrides: Partial<UseStationAlarmInputs>): UseStationAlarmInputs {
+      return defaultInputs({
+        route: route1266,
+        destination,
+        nearestStation: arcLine2[0],
+        speedMps: 5,
+        accuracyMeters: 50,
+        currentStationArrival: dummyArrival,
+        ...overrides,
+      });
+    }
+
+    it('22:31 회귀 차단 — currentHopIndex=0 + nearestStation=arc[4] (+4 hop 미래) → fast-path suppressed', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock1266);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() =>
+        useStationAlarm(
+          inputs1266({
+            nearestStation: arcLine2[4],
+            currentHopIndex: 0,
+            arcStations: arcLine2,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+          source: 'fg-arvlcd',
+          stationName: arcLine2[4].name,
+          currentHopIndex: 0,
+          candidateIndex: 4,
+        });
+      });
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('22:31 회귀 차단 — currentHopIndex=0 + nearestStation=arc[6] (+6 hop 미래) → fast-path suppressed', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock1266);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() =>
+        useStationAlarm(
+          inputs1266({
+            nearestStation: arcLine2[6],
+            currentHopIndex: 0,
+            arcStations: arcLine2,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+          source: 'fg-arvlcd',
+          stationName: arcLine2[6].name,
+          currentHopIndex: 0,
+          candidateIndex: 6,
+        });
+      });
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
+    });
+
+    it('정상 case — currentHopIndex=3 + nearestStation=arc[3] (동일 hop) → fast-path fire (정상 동작 보존)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock1266);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() =>
+        useStationAlarm(
+          inputs1266({
+            nearestStation: arcLine2[3],
+            currentHopIndex: 3,
+            arcStations: arcLine2,
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', arcLine2[3]),
+      );
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+    });
+
+    it('estimator null + firedAlarms 빈 set → no-source 적재 + fast-path 게이트 미적용 (graceful fallback)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock1266);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() =>
+        useStationAlarm(
+          inputs1266({
+            nearestStation: arcLine2[0],
+            currentHopIndex: null,
+            arcStations: arcLine2,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalledWith({
+          source: 'fg-arvlcd',
+          stationName: arcLine2[0].name,
+        });
+      });
+      // 게이트 미적용이므로 정상 발사.
+      await waitFor(() =>
+        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', arcLine2[0]),
+      );
+    });
+
+    it('arcStations 빈 배열 → 게이트 자체 미적용 (기존 동작 보존)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock1266);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() =>
+        useStationAlarm(
+          inputs1266({
+            currentHopIndex: 99,
+            arcStations: [],
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', arcLine2[0]),
+      );
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+      expect(mockLogSuppressedHopWindowNoSource).not.toHaveBeenCalled();
+    });
   });
 
   // #1012 (H5) — hydration state machine: pre-hydrate → hydrating → storage-synced → ready.

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -946,6 +946,30 @@ export function useStationAlarm({
         return;
       }
 
+      // #1266 (Epic #1204 D2 follow-up) — fast-path에도 hop window 게이트 적용.
+      // 2026-06-12 22:31 회귀: GPS station-passed effect는 D2(#1208) 게이트로 차단됐으나
+      // fg-arvlcd fast-path는 같은 게이트가 없어 fusion이 미래 arc station에 jitter landing
+      // + Seoul API row의 lock.trainCode 일치 + arvlCd∈{0,1}일 때 미래 hop fire 가능.
+      // SSOT 우선순위는 GPS path와 동일 — currentHopIndex prop → firedAlarms fallback → no-source.
+      if (arcStations && arcStations.length > 0) {
+        const effectiveHopIndex =
+          currentHopIndex ?? inferHopIndexFromFiredAlarms(firedAlarmsRef.current, arcStations);
+        if (effectiveHopIndex < 0) {
+          logSuppressedHopWindowNoSource({
+            source: 'fg-arvlcd',
+            stationName: candidateStation.name,
+          });
+        } else if (!isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
+          logSuppressedHopWindow({
+            source: 'fg-arvlcd',
+            stationName: candidateStation.name,
+            currentHopIndex: effectiveHopIndex,
+            candidateIndex: arcIndexOf(arcStations, candidateStation),
+          });
+          return;
+        }
+      }
+
       // #746 silence gate + dispatch는 helper로 통합 (Sonar cpd 회피).
       // lastNotifiedStationId 공유 dedup. cancelled 재확인 — getBoardingLock 후 effect cleanup 가능.
       // #1236 — sleep 룰 게이트 context. lock은 위에서 이미 fetch.
@@ -987,5 +1011,7 @@ export function useStationAlarm({
     notificationSource,
     // #1236 — currentHopIndex 변화가 sleep 룰 게이트 isFirstHop 판정에 영향.
     currentHopIndex,
+    // #1266 — fast-path hop window 게이트 입력. arcStations 변화 시(환승 후 leg 전환 등) 재평가.
+    arcStations,
   ]);
 }


### PR DESCRIPTION
## Summary

Epic #1204 — 그룹 2 PR A. D2 hop window 게이트(#1208)가 fast-path effect에 누락된 gap을 수정.

## 회귀 evidence
2026-06-12 22:31 사용자 trip [Img1] — 신당(+6 hop 미래) + 왕십리(+4 hop 미래) station-passed 알람 동시 fire. D2 PR #1250 머지 후에도 재발.

## Root cause 판정
`useStationAlarm.ts` D2 hop window 게이트는 **GPS station-passed effect(line 812~826)에만 적용**됐고 **FG fast-path `fg-arvlcd` effect(line 909~990)에는 누락**.

fast-path는 `findFgArvlCdFireSignal`(lock.trainCode + arvlCd∈{0,1}) + movement + silence + sleep만 검사. fusion이 미래 arc station에 jitter landing + Seoul API row의 `lock.trainCode` 일치 + arvlCd=0/1이면 미래 hop fire 가능.

재현 여부: GPS path 단위 테스트는 통과(D2 게이트 정상). 본 PR 신규 테스트로 fast-path D2 우회 시나리오를 fail by design 가드.

## 변경
- `src/features/alarm/hooks/useStationAlarm.ts` — fast-path effect에 동일 hop window 가드 추가. SSOT는 `isStationWithinHopWindow` + `inferHopIndexFromFiredAlarms`. `source: 'fg-arvlcd'` 라벨로 GPS path와 구분. arcStations를 effect deps에 추가
- `src/features/alarm/hooks/__tests__/useStationAlarm.test.ts` — 회귀 가드 5개 추가 (22:31 시나리오 +4/+6 hop suppressed, 정상 case fire, no-source fallback, 빈 arcStations graceful)

## Test plan
- [x] `npx jest src/features/alarm/hooks/__tests__/useStationAlarm.test.ts` → 159/159 pass
- [x] `npm run type-check` → clean
- [x] `npm run lint` → clean
- [ ] 실기기 검증: lockless trip + lock.trainCode 일치 trip 모두 22:31 회귀 시나리오 0건

## 절대 금지 영역 (본 PR scope 외)
- D3 (silent push hopIndex) / D4 (trainCode sync) / W1 (motion gate) / N8 (currentLine) — 별도 PR
- 그룹 4 P5F dedup (alarmKey routeSig) — 별도 PR

Closes #1266
Part of #1204