### PR TITLE
feat(#1271): 그룹 2 W1 — motion gate transfer-swap hint 우회

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2142,6 +2142,72 @@ describe('POST /boarding-lock/sync (#901)', () => {
     expect(body.autoLockCandidate).toBeNull();
   });
 
+  // W1 (#1271, Epic #1204 그룹 2) — payload trainCode가 KV lock과 달라 swap 실제 적용된
+  // cycle에서만 autoLockCandidate.from='transfer-swap' hint를 첨부한다. client는 hint를
+  // 보고 motion gate(#1014 RC2 Gate 2)를 우회 — 환승 직후 이동 중 hydrate 차단 회귀 방지.
+  describe('autoLockCandidate.from (W1 #1271 transfer-swap hint)', () => {
+    it('payload trainCode가 KV와 달라 swap 발생 → from=transfer-swap 첨부', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripWithLock(), env);
+      const res = await post(
+        '/boarding-lock/sync',
+        {
+          token: 'tok-sync',
+          observedStationName: '신촌',
+          observedAtMs: 1,
+          accuracy: 5,
+          trainCode: 'T-NEW',
+          boardingLine: '7',
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        autoLockCandidate: { trainCode: string; line: string; from?: string };
+      };
+      expect(body.autoLockCandidate.trainCode).toBe('T-NEW');
+      expect(body.autoLockCandidate.from).toBe('transfer-swap');
+    });
+
+    it('payload trainCode가 KV와 같음 → from 미첨부 (no swap)', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripWithLock(), env);
+      const res = await post(
+        '/boarding-lock/sync',
+        {
+          token: 'tok-sync',
+          observedStationName: '신촌',
+          observedAtMs: 1,
+          accuracy: 5,
+          trainCode: 'T-1',
+          boardingLine: '2',
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        autoLockCandidate: { trainCode: string; from?: string };
+      };
+      expect(body.autoLockCandidate.trainCode).toBe('T-1');
+      expect(body.autoLockCandidate.from).toBeUndefined();
+    });
+
+    it('payload trainCode 미제공 → from 미첨부 (swap 비대상)', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripWithLock(), env);
+      const res = await post(
+        '/boarding-lock/sync',
+        { token: 'tok-sync', observedStationName: '신촌', observedAtMs: 1, accuracy: 5 },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        autoLockCandidate: { from?: string };
+      };
+      expect(body.autoLockCandidate.from).toBeUndefined();
+    });
+  });
+
   // D4 (#1210) — payload trainCode가 KV lock과 다르면 KV lock 갱신 + consecutiveEtaMissing=0 reset.
   describe('trainCode swap (#1210)', () => {
     /**

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -916,7 +916,17 @@ app.post('/boarding-lock/sync', async (c) => {
   // D4 (#1210) — payload trainCode가 KV lock trainCode와 다르면 환승 leg로 해석.
   // lock의 trainCode/line을 새 값으로 swap하고 consecutiveEtaMissing을 0으로 reset해
   // 신규 trainCode가 Seoul API에서 잡힐 때까지의 자동 종료(`MAX_CONSECUTIVE_ETA_MISSING`)를 차단한다.
+  //
+  // W1 (#1271, Epic #1204 그룹 2) — swap 발생 여부를 본 cycle 안에서 식별해 응답
+  // autoLockCandidate에 `from: 'transfer-swap'` hint 첨부. client는 hint가 있으면
+  // motion gate(#1014 RC2 Gate #2)를 우회한다 — 환승 직후 사용자가 이동 중인 상태에서
+  // hydrate가 영구 차단되는 회귀(피드백 7, 22:53 transfer skip)를 차단.
+  const preSwapTrainCode = working.boardingLock?.trainCode;
   working = applyBoardingLockTrainCodeSwap(working, payload);
+  const transferSwapApplied =
+    preSwapTrainCode !== undefined &&
+    working.boardingLock !== undefined &&
+    working.boardingLock.trainCode !== preSwapTrainCode;
 
   // lock TTL refresh — 사용자가 지상에서 lock을 활성 유지 중임을 confirm.
   if (working.boardingLock) {
@@ -945,6 +955,8 @@ app.post('/boarding-lock/sync', async (c) => {
           trainCode: working.boardingLock.trainCode,
           line: working.boardingLock.line,
           subwayId: working.boardingLock.subwayId,
+          // W1 (#1271): client motion gate 우회 hint — swap 발생 시에만 첨부.
+          ...(transferSwapApplied ? { from: 'transfer-swap' as const } : {}),
         }
       : null,
   });

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -523,6 +523,66 @@ describe('useBoardingLockController', () => {
         });
         await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
       });
+
+      // W1 (#1271, Epic #1204 그룹 2) — backend `from:'transfer-swap'` hint가 있으면
+      // Gate 2(motion dwell) 우회. 환승 직후 사용자가 이미 이동 중이어도 hydrate 허용.
+      // Gate 1은 유지 — false positive 방어.
+      describe('W1 (#1271) transfer-swap hint', () => {
+        it('from=transfer-swap이면 motionStationary=false + speedMps >= threshold여도 hydrate 허용 (Gate 2 우회)', async () => {
+          const { result } = renderHook(() =>
+            useBoardingLockController({ ...hydrateInputs, motionStationary: false, speedMps: 1.5 }),
+          );
+          await act(async () => {
+            result.current.hydrateLockFromCandidate({
+              trainCode: 'AUTO-7',
+              line: '2',
+              subwayId: '1002',
+              from: 'transfer-swap',
+            });
+          });
+          await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+        });
+
+        it('from=transfer-swap이어도 Gate 1(trainCode가 directionalArrivals에 없음) 통과 못하면 no-op', async () => {
+          const arrivalOther: StationArrival = {
+            up: [makeTrain({ trainCode: 'OTHER-1' })],
+            down: [],
+          };
+          const { result } = renderHook(() =>
+            useBoardingLockController({
+              ...hydrateInputs,
+              arrival: arrivalOther,
+              motionStationary: false,
+              speedMps: 1.5,
+            }),
+          );
+          await act(async () => {
+            result.current.hydrateLockFromCandidate({
+              trainCode: 'NOT-IN-ARRIVAL',
+              line: '2',
+              subwayId: '1002',
+              from: 'transfer-swap',
+            });
+          });
+          expect(mockSetBoardingLock).not.toHaveBeenCalled();
+        });
+
+        it('hint 없으면 (from undefined) 기존 Gate 2 동작 그대로 — speedMps >= threshold → no-op', async () => {
+          // 회귀 가드: 기존 동작 보존 박제.
+          const { result } = renderHook(() =>
+            useBoardingLockController({ ...hydrateInputs, speedMps: 1.5 }),
+          );
+          await act(async () => {
+            result.current.hydrateLockFromCandidate({
+              trainCode: 'AUTO-7',
+              line: '2',
+              subwayId: '1002',
+              // from 미제공
+            });
+          });
+          expect(mockSetBoardingLock).not.toHaveBeenCalled();
+        });
+      });
     });
   });
 

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -215,7 +215,16 @@ export function useBoardingLockController({
       // motionStationary 미측정(undefined)이면 speedMps로 단독 판단:
       //   speedMps >= STATIC_SPEED_THRESHOLD_MPS → 차단. 미측정/정적 → 통과.
       // 두 신호 모두 없거나 불확실하면 보수적으로 통과 — false negative보다 false positive 방지 우선.
-      if (motionStationary === true) {
+      //
+      // W1 (#1271, Epic #1204 그룹 2): backend가 `from:'transfer-swap'` hint를 첨부했으면
+      // Gate 2를 우회한다. swap hint는 backend가 (기존 lock + 새 trainCode + trainCode 변경)
+      // 3 조건을 모두 통과한 신뢰 evidence — 사용자가 이미 이동 중(새 leg 탑승)인 게 정상이라
+      // motion 차단을 적용하면 환승 lock 회복이 영구 차단된다(피드백 7, 22:53 transfer skip).
+      // Gate 1(directionalArrivals 매칭)은 유지해 false positive 방어.
+      // ADR-014 첫 줄: lock 활성/lockless 동급 정확도 보장.
+      if (candidate.from === 'transfer-swap') {
+        // transfer swap evidence 신뢰 → Gate 2 우회
+      } else if (motionStationary === true) {
         // stationary 확인됨 → Gate 2 통과
       } else if (speedMps != null && speedMps >= STATIC_SPEED_THRESHOLD_MPS) {
         return; // GPS speed로 이동 중 확인 → no-op

--- a/src/features/nearest-station/api/boardingLockSync.ts
+++ b/src/features/nearest-station/api/boardingLockSync.ts
@@ -49,6 +49,20 @@ export interface AutoLockCandidate {
   trainCode: string;
   line: string;
   subwayId: string;
+  /**
+   * W1 (#1271, Epic #1204 그룹 2) — backend가 본 candidate를 환승 leg swap evidence로
+   * 확정 발급했음을 표시. client는 `'transfer-swap'`이면 motion gate(#1014 RC2 Gate #2)를
+   * 우회해 사용자가 이미 이동 중이어도 hydrate 허용한다.
+   *
+   * 발급 조건(backend `applyBoardingLockTrainCodeSwap` 실제 swap 성공):
+   *   1) 기존 lock 존재
+   *   2) payload.trainCode 제공
+   *   3) trainCode 변경됨 (옛 != 신)
+   * 세 조건 모두 통과 = client가 새 trainCode를 관측한 신뢰 evidence.
+   *
+   * 미발급(undefined) = 기존 자동 lock / 명시 탭 / 단순 sync — motion gate 정상 적용.
+   */
+  from?: 'transfer-swap';
 }
 
 /**


### PR DESCRIPTION
## Summary

Epic #1204 그룹 2 W1. 환승 직후 motion gate가 자동 lock 회복을 영구 차단하는 회귀(피드백 7, 22:53 transfer skip) 차단.

- backend `/boarding-lock/sync` 응답에 swap 실제 적용된 경우에만 `autoLockCandidate.from = 'transfer-swap'` hint 발급 (기존 lock + payload.trainCode + trainCode 변경 3 조건 모두 통과)
- frontend `useBoardingLockController.hydrateLockFromCandidate` Gate 2: `candidate.from === 'transfer-swap'`이면 motion dwell 검사 우회. Gate 1 (directionalArrivals 매칭) 유지 → false positive 방어
- `AutoLockCandidate` 타입에 optional `from?: 'transfer-swap'` 추가

## Root cause

`useBoardingLockController.ts:195-256` #1014 RC2 Gate #2가 `motionStationary===true || speedMps < 0.5`만 통과. 환승 leg 진입 직후 사용자는 이미 이동 중(`speedMps >= 0.5`)이라 backend가 새 trainCode candidate를 계속 발급해도 hydrate 영구 차단. 22:53 transfer skip의 진짜 원인.

원래 Gate 2 의도는 "사용자가 origin에서 정적 대기 중인지 확인 → backend 지연 응답 false positive 차단". 환승 leg에서는 backend가 (기존 lock 존재 + 새 trainCode 관측)이라는 신뢰 evidence 위에서 swap을 한 것이라 origin dwell 가드가 무의미.

## ADR-014 동급 보장

ADR-014 첫 줄: "두 실패 모드(false positive / miss)는 비대칭이 아니라 **동급**." 환승 leg miss는 사용자 명시 의향 trip(원래 lock 활성)에서의 시스템 실패 → lock 활성 동급 정확도 보장 의무.

## Test plan

- [x] backend 1197 tests pass
- [x] frontend 5235 tests pass + coverage 100%
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] 실기기 evidence — 외출 trip에서 환승 leg 자동 lock 회복 확인

Closes #1271
Part of #1204