### PR TITLE
feat(#1272): 그룹 2 N8 — currentLine boardingLock 우선

### DIFF
--- a/scripts/__tests__/maestro-retry.test.js
+++ b/scripts/__tests__/maestro-retry.test.js
@@ -88,6 +88,15 @@ describe('parseFailedTestcaseNames', () => {
     const xml = `<testcase classname="x"><failure/></testcase>`;
     expect(parseFailedTestcaseNames(xml)).toEqual([]);
   });
+
+  // #1268 회귀: maestro junit이 `file=".maestro/flows/smoke/X.yaml"` 같이 슬래시가 포함된
+  // 속성을 내보낼 때 attrs 클래스가 `[^>/]` 였던 시기엔 매칭이 깨져 retry가 동작하지 않았다.
+  it('extracts failed testcase even when attributes contain slashes (issue 1268)', () => {
+    const xml = `<testcase id="smoke - flow" name="smoke - flow" classname="suite" file=".maestro/flows/smoke/06.yaml" time="65.0" status="ERROR">
+      <failure>Assertion is false: id: search-input is visible</failure>
+    </testcase>`;
+    expect(parseFailedTestcaseNames(xml)).toEqual(['smoke - flow']);
+  });
 });
 
 describe('decodeXmlEntities', () => {

--- a/scripts/maestro-retry.js
+++ b/scripts/maestro-retry.js
@@ -37,11 +37,11 @@ const path = require('node:path');
  */
 function parseFailedTestcaseNames(xml) {
   const names = [];
-  // <testcase ...>...</testcase> 블록 단위로 순회
-  // attrs는 `[^>]` 가 아니라 `[^>/]` — 그렇지 않으면 self-closing `/>` 의 `/` 까지
-  // 탐욕적으로 소비해 `\/>` 분기가 실패하고 다음 `</testcase>` 까지 long-match된다.
-  // (alternation은 backtrack 없이 첫 성공 분기를 채택하므로 attrs 클래스 자체를 좁힌다.)
-  const blockRe = /<testcase\b([^>/]*)(\/>|>([\s\S]*?)<\/testcase>)/g;
+  // <testcase ...>...</testcase> 블록 단위로 순회.
+  // attrs는 `[^>]*?` (non-greedy) — `[^>/]` 로 좁히면 file=".maestro/flows/..."
+  // 같이 `/` 가 포함된 속성값에서 매칭이 깨진다 (#1268). non-greedy + 첫 `>` 또는
+  // `/>` 분기 탐색으로 self-closing/open-close 두 케이스 모두 정확히 분리.
+  const blockRe = /<testcase\b([^>]*?)(\/>|>([\s\S]*?)<\/testcase>)/g;
   let match;
   while ((match = blockRe.exec(xml)) !== null) {
     const attrs = match[1];

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -412,6 +412,81 @@ describe('useStationAlarm', () => {
     });
   });
 
+  // Epic #1204 N8 — currentLine 소스 boardingLock 우선.
+  // 5호선 답십리 lock 진행 중 fusion이 2호선 상왕십리 nearest로 jitter해도
+  // currentLine은 lock.boardingLine을 유지해 다른 leg의 hop fire를 차단해야 한다.
+  describe('#1204 N8 — currentLine boardingLock 우선', () => {
+    const route = makeDirectRoute(3, '5');
+    // nearest는 2호선으로 잘못 잡힌 jitter 시나리오 — 실제 사용자는 5호선 trip 진행 중.
+    const wrongNearest = makeStation('N-wrong', '상왕십리', 37.5638, 127.0288);
+    const baseInputs = () =>
+      defaultInputs({
+        route,
+        destination,
+        nearestStation: { ...wrongNearest, line: '2' as const },
+        userLocation: { lat: 37.4, lng: 127.0 },
+        speedMps: 10,
+        accuracyMeters: 100,
+      });
+
+    it('lock.boardingLine 있으면 currentLine은 lock 노선', async () => {
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: destination.id,
+        trainCode: 'T-5',
+        boardingStationId: 'S-답십리',
+        boardingLine: '5' as const,
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+      });
+      renderHook(() => useStationAlarm(baseInputs()));
+      await waitFor(() =>
+        expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+          expect.objectContaining({ currentLine: '5' }),
+          expect.any(Set),
+          undefined,
+          expect.any(Array),
+        ),
+      );
+    });
+
+    it('lock 없으면 nearestStation.line으로 fallback', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      renderHook(() => useStationAlarm(baseInputs()));
+      await waitFor(() =>
+        expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+          expect.objectContaining({ currentLine: '2' }),
+          expect.any(Set),
+          undefined,
+          expect.any(Array),
+        ),
+      );
+    });
+
+    it('lock + nearestStation 둘 다 null이면 currentLine=null', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: null,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+          }),
+        ),
+      );
+      await waitFor(() =>
+        expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+          expect.objectContaining({ currentLine: null }),
+          expect.any(Set),
+          undefined,
+          expect.any(Array),
+        ),
+      );
+    });
+  });
+
   it('passes null etaSeconds when speed is null', async () => {
     const route = makeDirectRoute(3, '2');
     renderHook(() =>
@@ -2540,8 +2615,10 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
-      // nearestStation null이면 GPS station-passed path도 진입 안 함 → getBoardingLock 호출 0.
-      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+      // #1272 (N8) — destinationId 기반 lock mirror effect가 destinationId 설정 시 lock을
+      // 1회 prefetch 한다. fast path 발사 자체는 nearestStation null이므로 발생하지 않음.
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
     });
 
     it('nearestStation이 route 밖이면(line 불일치) fast path no-op', async () => {
@@ -2551,7 +2628,8 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
-      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
     });
 
     it('route 또는 destination 미설정이면 fast path no-op', async () => {
@@ -2561,7 +2639,8 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
-      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
     });
 
     it('destination 미설정이면 fast path no-op', async () => {
@@ -2571,6 +2650,7 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
+      // destination=null이면 lock mirror effect도 early return → getBoardingLock 호출 0.
       expect(mockGetBoardingLock).not.toHaveBeenCalled();
     });
 
@@ -2633,7 +2713,11 @@ describe('useStationAlarm', () => {
 
       await Promise.resolve();
       // hydration 보류 — fast path는 firedHydrated 가드로 early return.
-      expect(mockGetBoardingLock).not.toHaveBeenCalled();
+      // #1272 (N8) — destinationId 기반 lock mirror effect는 hydration과 무관하게 destinationId
+      // 설정 시 lock을 prefetch하므로 getBoardingLock 호출 자체는 발생할 수 있다. 단 fast path
+      // 발사는 발생하지 않음(logFiredStationPassed fg-arvlcd 호출 0).
+      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
+      expect(arvlCdFires).toHaveLength(0);
     });
 
     it('내부 storage read/send 실패 시 catch로 swallow (logger.error 분기 커버)', async () => {

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -53,6 +53,9 @@ import {
 } from '../utils/alarmLog';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { getBoardingLock } from '../utils/boardingLockStorage';
+import { resolveCurrentLine } from '../utils/resolveCurrentLine';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { LineNumber } from '../../../shared/types/station';
 import { isStationPassedFirstHop, shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
 import type { PositionStability } from '../../nearest-station/utils/positionStaticDetector';
@@ -371,6 +374,11 @@ export function useStationAlarm({
   // 트립에 lock된 사용자 열차 코드. AsyncStorage에서 비동기 로드. lock 실패 상태(null)면
   // API 신호 평가는 보수적으로 false 반환 — 잘못된 train으로 imminent 오발사 방지.
   const [trackedTrainCode, setTrackedTrainCode] = useState<string | null>(null);
+  // Epic #1204 N8 — phase 알람의 currentLine 입력에 lock.boardingLine을 우선 반영하기 위한
+  // 동기 mirror. getBoardingLock은 비동기이므로 trackedTrainCode와 같은 주기(destinationId /
+  // destinationArrival 갱신)로 sync 한다. lock 부재면 null → resolveCurrentLine이
+  // nearestStation.line으로 자연 fallback.
+  const [currentLockLine, setCurrentLockLine] = useState<LineNumber | null>(null);
   // fusion source → 알람 본문 라벨. 두 effect(phase / station-passed)가 공유.
   const notificationSource = useMemo(
     () => (fusionSource ? resolveNotificationSource(fusionSource, locationUncertain) : undefined),
@@ -400,12 +408,19 @@ export function useStationAlarm({
   useEffect(() => {
     if (!destinationId) {
       setTrackedTrainCode(null);
+      setCurrentLockLine(null);
       return;
     }
     let cancelled = false;
     void (async () => {
       const code = await getStoredTripTrainCode(destinationId);
       if (!cancelled) setTrackedTrainCode(code);
+    })();
+    // N8 — lock.boardingLine 동기 mirror. trackedTrainCode와 동일 주기로 refresh되어
+    // phase 알람 effect가 GPS jitter와 무관하게 lock 노선을 currentLine으로 사용한다.
+    void (async () => {
+      const lock: BoardingLock | null = await getBoardingLock();
+      if (!cancelled) setCurrentLockLine(lock?.boardingLine ?? null);
     })();
     return () => {
       cancelled = true;
@@ -580,7 +595,10 @@ export function useStationAlarm({
         route,
         destinationName: destination.name,
         etaSeconds,
-        currentLine: nearestStation?.line ?? null,
+        // Epic #1204 N8 — lock.boardingLine 우선, nearestStation.line fallback.
+        // 5호선 답십리 lock 진행 중 fusion이 2호선 상왕십리를 momentary adopt해도
+        // currentLine='5'로 유지되어 다른 leg의 hop fire를 차단한다.
+        currentLine: resolveCurrentLine(currentLockLine, nearestStation),
         degradedConfidence: degraded,
       },
       firedAlarmsRef.current,
@@ -648,6 +666,8 @@ export function useStationAlarm({
     setAlarmEvent,
     nearestStation?.id,
     nearestStation?.line,
+    // Epic #1204 N8 — lock.boardingLine 변경 시(환승 leg 교체 등) currentLine 재평가.
+    currentLockLine,
     positionStability,
     motionStationary,
     skipWarmupGuard,

--- a/src/features/alarm/utils/__tests__/resolveCurrentLine.test.ts
+++ b/src/features/alarm/utils/__tests__/resolveCurrentLine.test.ts
@@ -1,0 +1,38 @@
+import { resolveCurrentLine } from '../resolveCurrentLine';
+import type { Station } from '../../../../shared/types/station';
+
+const makeStation = (line: Station['line']): Station => ({
+  id: 'S1',
+  name: '상왕십리',
+  line,
+  lineColor: '#33A23D',
+  lat: 37.5638,
+  lng: 127.0288,
+});
+
+describe('resolveCurrentLine (Epic #1204 N8)', () => {
+  it('lock.boardingLine 있으면 lock 우선', () => {
+    const nearest = makeStation('2');
+    expect(resolveCurrentLine('5', nearest)).toBe('5');
+  });
+
+  it('lock 없으면 nearestStation.line fallback', () => {
+    const nearest = makeStation('2');
+    expect(resolveCurrentLine(null, nearest)).toBe('2');
+  });
+
+  it('lock + nearestStation 둘 다 null이면 null', () => {
+    expect(resolveCurrentLine(null, null)).toBe(null);
+  });
+
+  it('lock 있고 nearestStation null이어도 lock 사용', () => {
+    expect(resolveCurrentLine('5', null)).toBe('5');
+  });
+
+  it('회귀 evidence (22:52:40): lock=5호선 vs nearest=2호선 → 5호선', () => {
+    // 5호선 답십리 lock 진행 중 fusion이 2호선 상왕십리를 momentary adopt하는 시나리오.
+    // currentLine='5'로 유지되어야 다른 leg의 hop fire 차단.
+    const wrongNearest = makeStation('2');
+    expect(resolveCurrentLine('5', wrongNearest)).toBe('5');
+  });
+});

--- a/src/features/alarm/utils/resolveCurrentLine.ts
+++ b/src/features/alarm/utils/resolveCurrentLine.ts
@@ -1,0 +1,23 @@
+import type { LineNumber, Station } from '../../../shared/types/station';
+
+/**
+ * Epic #1204 N8 — Phase 알람 evaluator의 `currentLine` 입력 SSOT.
+ *
+ * 우선순위:
+ *   1) `boardingLine` — 사용자 명시 의향 trip의 노선 (lock 활성 시 GPS jitter보다 우선)
+ *   2) `nearestStation.line` — GPS 기반 fusion fallback (lockless trip 또는 lock 부재)
+ *   3) null — 둘 다 없으면 `evaluateAlarmPhase`가 silent skip
+ *
+ * 회귀 evidence (22:52:40): 5호선 답십리 lock 활성 중 fusion이 2호선 상왕십리를
+ * nearest로 잡으면 currentLine='2'로 잘못 평가되어 다른 leg의 hop fire 가능.
+ * boardingLine='5' 우선으로 GPS jitter 무시 (ADR-014 사용자 명시 의향 trip 보호).
+ *
+ * 호출자는 BoardingLock 전체를 가지고 있지 않아도 `boardingLine`만 전달하면 된다 —
+ * useStationAlarm은 동기 mirror state(`currentLockLine`)만 보관한다.
+ */
+export function resolveCurrentLine(
+  boardingLine: LineNumber | null,
+  nearestStation: Station | null,
+): LineNumber | null {
+  return boardingLine ?? nearestStation?.line ?? null;
+}


### PR DESCRIPTION
## Summary
- Epic #1204 그룹 2 N8 — currentLine 소스 boardingLock 우선.
- 5호선 답십리 lock 활성 trip 중 fusion이 2호선 상왕십리를 nearest로 momentary adopt해도 `currentLine='5'`로 유지 → 다른 leg의 hop fire 차단.
- 22:52:40 회귀 root cause (`memory/project_2026_06_13_31_root_causes.md` N8).

## 변경
- 신규 `src/features/alarm/utils/resolveCurrentLine.ts` — SSOT 우선순위 함수 (boardingLine → nearestStation.line → null).
- `src/features/alarm/hooks/useStationAlarm.ts`:
  - `currentLockLine` state mirror 추가 — destinationId / destinationArrival 갱신 시 `getBoardingLock()` 1회 prefetch.
  - phase effect `currentLine` 입력을 `resolveCurrentLine(currentLockLine, nearestStation)`로 교체.
  - deps array에 `currentLockLine` 추가.
- D2 영역(812-826, 909-990) 변경 없음.
- 기존 #917 fast-path no-op 테스트 4건 mirror prefetch 효과 반영해 갱신 (검증 기준: `mockLogFiredStationPassed('fg-arvlcd')` 미호출).

## Test plan
- [x] resolveCurrentLine 단위 테스트 5건 (lock 우선, fallback, 둘 다 null, 회귀 evidence).
- [x] useStationAlarm describe `#1204 N8` — lock=5호선 vs nearest=2호선 → `currentLine='5'` 전달 검증.
- [x] lock 없을 때 nearestStation.line으로 fallback 검증.
- [x] 둘 다 null이면 `currentLine: null` 검증.
- [x] `npm test` — 5240/5240 PASS, coverage 100%.
- [x] `npm run type-check` PASS.
- [x] `npm run lint` PASS.
- [ ] 실기기 evidence — 2026-06-14 외출 trip에서 5호선 lock 중 fusion jitter 시 다른 leg fire 0건 확인.

Closes #1272
Part of #1204