### PR TITLE
feat(#1273): 그룹 2 D3 — silent push hopIndex (backend payload + gate fallback)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -145,6 +145,71 @@ describe('sendSilentPush', () => {
     expect(result.reason).toBeUndefined();
   });
 
+  // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex wire 검증.
+  describe('hopIndex (#1273)', () => {
+    it('payload.hopIndex 지정 시 body.data.hopIndex로 전달', async () => {
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+      await sendSilentPush({
+        deviceToken: 'tok',
+        payload: {
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          sentAt: 1_700_000_000_000,
+          pushId: 'p',
+          hopIndex: 5,
+        },
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.data.hopIndex).toBe(5);
+    });
+
+    it('payload.hopIndex 미지정 시 body.data에서 누락 (구 client 호환)', async () => {
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+      await sendSilentPush({
+        deviceToken: 'tok',
+        payload: {
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          sentAt: 1_700_000_000_000,
+          pushId: 'p',
+        },
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+      expect('hopIndex' in body.data).toBe(false);
+    });
+
+    it('payload.hopIndex=0 (첫 hop) 도 정상 wire', async () => {
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+      await sendSilentPush({
+        deviceToken: 'tok',
+        payload: {
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          sentAt: 1_700_000_000_000,
+          pushId: 'p',
+          hopIndex: 0,
+        },
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.data.hopIndex).toBe(0);
+    });
+  });
+
   it('uses sandbox host when provided', async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('', { status: 200 }),

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -237,6 +237,62 @@ describe('validateTrip', () => {
       expect(trip?.waypoints.map((w) => w.occurrenceIdx)).toEqual([0, 1, 0]);
     });
   });
+
+  // Epic #1204 그룹 2 D3 (#1273) — silent push payload hopIndex SSOT용 stamping.
+  describe('hopIndex stamping (#1273)', () => {
+    it('waypoint 시퀀스 0-based 위치로 stamp (단일 등장)', () => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '용마산', line: '7', kind: 'transfer' },
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '군자', line: '7', kind: 'destination' },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.hopIndex)).toEqual([0, 1, 2]);
+    });
+
+    it('중복 station이 있어도 hopIndex는 절대 시퀀스 위치 유지', () => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '회차역', line: '2', kind: 'transfer' },
+          { stationName: '다른역', line: '2', kind: 'transfer' },
+          { stationName: '회차역', line: '2', kind: 'transfer' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.hopIndex)).toEqual([0, 1, 2, 3]);
+      // occurrenceIdx와 별개로 카운트되는지 동시 검증.
+      expect(trip?.waypoints.map((w) => w.occurrenceIdx)).toEqual([0, 0, 1, 0]);
+    });
+
+    it('클라이언트가 명시한 hopIndex는 그대로 신뢰 (round-trip)', () => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '용마산', line: '7', kind: 'transfer', hopIndex: 7 },
+          { stationName: '강남', line: '2', kind: 'destination', hopIndex: 8 },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.hopIndex)).toEqual([7, 8]);
+    });
+
+    it.each([
+      ['음수', -1],
+      ['소수', 1.5],
+      ['문자열', '1'],
+    ] as const)('비정상 hopIndex(%s)는 무시 후 시퀀스 위치로 fallback', (_label, badValue) => {
+      const trip = validateTrip({
+        ...base(),
+        waypoints: [
+          { stationName: '용마산', line: '7', kind: 'transfer', hopIndex: badValue },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+      });
+      expect(trip?.waypoints.map((w) => w.hopIndex)).toEqual([0, 1]);
+    });
+  });
 });
 
 describe('validateTrip — boardingLock (#585)', () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -159,6 +159,8 @@ function parseArvlCdStationPassedData(call: [string, RequestInit]): {
   kind: string;
   pushId: string;
   sentAt: number;
+  // Epic #1204 그룹 2 D3 (#1273) — 구 client 호환을 위해 optional.
+  hopIndex?: number;
 } {
   const body = JSON.parse(call[1].body as string) as {
     data: {
@@ -168,6 +170,7 @@ function parseArvlCdStationPassedData(call: [string, RequestInit]): {
       kind: string;
       pushId: string;
       sentAt: number;
+      hopIndex?: number;
     };
   };
   return body.data;
@@ -584,6 +587,57 @@ describe('runScheduled', () => {
         expect(apnsFetch).not.toHaveBeenCalled();
       }
       if (seoulCalled === false) expect(seoulFetch).not.toHaveBeenCalled();
+    });
+
+    // Epic #1204 그룹 2 D3 (#1273)
+    it('lockless intermediate 발사 시 payload.hopIndex가 waypoint.hopIndex로 wire', async () => {
+      const { apnsFetch } = await runLocklessCycle({
+        trip: makeTrip({
+          waypoints: [
+            { stationName: '강남', line: '2', kind: 'intermediate', hopIndex: 3 },
+            { stationName: '역삼', line: '2', kind: 'destination', hopIndex: 4 },
+          ],
+          locklessStationPassed: true,
+        }),
+        arrivals: [ARVL_ARRIVED],
+        apnsOk: true,
+      });
+      const calls = apnsFetch.mock.calls.filter((c) => {
+        try {
+          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
+          return body?.data?.kind === 'intermediate';
+        } catch {
+          return false;
+        }
+      });
+      expect(calls).toHaveLength(1);
+      const body = JSON.parse(calls[0][1].body as string) as { data: { hopIndex?: number } };
+      expect(body.data.hopIndex).toBe(3);
+    });
+
+    it('lockless intermediate 발사 시 waypoint.hopIndex 부재면 payload 본문에서도 hopIndex 누락', async () => {
+      const { apnsFetch } = await runLocklessCycle({
+        trip: makeTrip({
+          waypoints: [
+            { stationName: '강남', line: '2', kind: 'intermediate' },
+            { stationName: '역삼', line: '2', kind: 'destination' },
+          ],
+          locklessStationPassed: true,
+        }),
+        arrivals: [ARVL_ARRIVED],
+        apnsOk: true,
+      });
+      const calls = apnsFetch.mock.calls.filter((c) => {
+        try {
+          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
+          return body?.data?.kind === 'intermediate';
+        } catch {
+          return false;
+        }
+      });
+      expect(calls).toHaveLength(1);
+      const body = JSON.parse(calls[0][1].body as string) as { data: Record<string, unknown> };
+      expect('hopIndex' in body.data).toBe(false);
     });
 
     it('lock 없음 + intermediate(ARRIVED) → 발사 후 다음 intermediate 남으면 waypoint advance', async () => {
@@ -3590,6 +3644,32 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     expect(data.sentAt).toBe(NOW);
     // dedup KV stamp 확인 (TTL은 InMemoryKV가 그대로 보관 — expiration 무시)
     expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 1))).toBe('1');
+  });
+
+  // Epic #1204 그룹 2 D3 (#1273)
+  it('payload.hopIndex 포함 — waypoint.hopIndex stamp가 그대로 forward', async () => {
+    const tripWithHop = makeLockTripFixture('arvl-tok', {
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate', hopIndex: 4 },
+        { stationName: '군자', line: '7', kind: 'destination', hopIndex: 5 },
+      ],
+    });
+    const { apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: tripWithHop,
+      pushId: 'p-arvl-hop',
+    });
+    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]);
+    expect(data.hopIndex).toBe(4);
+  });
+
+  it('payload.hopIndex 누락 — waypoint.hopIndex 부재 시 silent push 본문에서도 누락', async () => {
+    const { apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      pushId: 'p-arvl-no-hop',
+    });
+    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]);
+    expect(data.hopIndex).toBeUndefined();
   });
 
   it('arvlCd=0(ENTERING) → 매역 push 발사 (arvlCd=0 dedup key)', async () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -60,6 +60,13 @@ export interface SilentPushPayload {
    * P2c가 30s 미ACK push를 alert fallback으로 재발사할 때 dedup 키로도 사용.
    */
   pushId: string;
+  /**
+   * Epic #1204 그룹 2 D3 (#1273) — 발사 시점 waypoint의 원본 hop index.
+   * 디바이스 `silentPushLocationGate`가 D1 estimator의 currentHopIndex와 비교해 hop-window-match
+   * 분기/`gate-no-location` fallback에 사용한다. 구 backend 호환을 위해 optional — 미전달 시
+   * 클라이언트는 hop 매칭 분기를 자연 skip하고 거리 게이트만 수행한다.
+   */
+  hopIndex?: number;
 }
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
@@ -112,6 +119,9 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       kind: options.payload.kind,
       sentAt: options.payload.sentAt,
       pushId: options.payload.pushId,
+      // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex가 정의된 경우에만 wire.
+      // 구 backend 호환을 위해 optional이라 undefined일 땐 JSON에서 자연 누락된다.
+      ...(options.payload.hopIndex === undefined ? {} : { hopIndex: options.payload.hopIndex }),
     },
   });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1260,18 +1260,24 @@ export function validateTrip(input: unknown): Trip | null {
   // 같은 stationName이 중복 등장(순환선/회차)할 때 클라이언트의 `:n` suffix identifier 규약과 일치하도록
   // 0-based 인덱스를 부여. waypoint shift 진행 후에도 값은 불변 — reschedule push 시점까지 일관.
   // 클라이언트가 이미 occurrenceIdx를 보내준 경우는 그대로 신뢰 (round-trip 안정).
+  // Epic #1204 그룹 2 D3 (#1273) — hopIndex는 시퀀스 0-based 위치. occurrenceIdx와 같은 1-pass에서
+  // 계산하지만 별개 카운터(시퀀스 절대 위치 ≠ stationName 등장 횟수). 클라가 명시 송신한 값은 그대로 신뢰.
   const occurrenceCount = new Map<string, number>();
-  const stampedWaypoints = (obj.waypoints as Array<Record<string, unknown>>).map((wp) => {
+  const stampedWaypoints = (obj.waypoints as Array<Record<string, unknown>>).map((wp, idx) => {
     const stationName = wp.stationName as string;
     const occIdx = occurrenceCount.get(stationName) ?? 0;
     occurrenceCount.set(stationName, occIdx + 1);
-    const existing =
+    const existingOcc =
       typeof wp.occurrenceIdx === 'number' &&
       Number.isInteger(wp.occurrenceIdx) &&
       wp.occurrenceIdx >= 0
         ? wp.occurrenceIdx
         : occIdx;
-    return { ...wp, occurrenceIdx: existing } as Trip['waypoints'][number];
+    const existingHop =
+      typeof wp.hopIndex === 'number' && Number.isInteger(wp.hopIndex) && wp.hopIndex >= 0
+        ? wp.hopIndex
+        : idx;
+    return { ...wp, occurrenceIdx: existingOcc, hopIndex: existingHop } as Trip['waypoints'][number];
   });
 
   return {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -705,6 +705,10 @@ export async function fireArvlCdStationPush(
           kind: waypoint.kind,
           sentAt: now,
           pushId,
+          // Epic #1204 그룹 2 D3 (#1273) — validateTrip stamp 결과를 forward.
+          // 클라이언트 `silentPushLocationGate`가 D1 estimator currentHopIndex와 매칭 시
+          // 거리 검증 우회/`gate-no-location` fallback에 사용. 구 trip(부재) → undefined.
+          hopIndex: waypoint.hopIndex,
         },
         config: deps.apnsConfig,
         host,
@@ -1294,6 +1298,9 @@ export async function runLocklessIntermediate(
           kind: 'intermediate',
           sentAt: now,
           pushId,
+          // Epic #1204 그룹 2 D3 (#1273) — lockless intermediate도 waypoint.hopIndex forward.
+          // D1 estimator의 currentHopIndex와 ±tolerance 매칭 시 거리 검증 우회 + GPS 미준비 fallback.
+          hopIndex: waypoint.hopIndex,
         },
         config: deps.apnsConfig,
         host,

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -57,6 +57,18 @@ export interface Waypoint {
    * 구 backend / 구 client 호환을 위해 optional. 미지정 시 클라이언트가 0(첫 등장)으로 fallback.
    */
   occurrenceIdx?: number;
+  /**
+   * Epic #1204 그룹 2 D3 (#1273) — 원본 waypoint 시퀀스에서의 0-based 위치(=hop index).
+   * `validateTrip`(POST /trips)이 incoming waypoints 전체에 대해 1-pass로 stamp하며, waypoint
+   * shift가 진행돼도 값은 불변. silent push payload `hopIndex` 필드의 SSOT로 사용된다.
+   *
+   * 클라이언트 `silentPushLocationGate`는 D1 estimator의 `currentHopIndex`와 이 값을 비교해
+   * ±LOCKLESS_HOP_WINDOW_TOLERANCE 이내면 거리 검증 우회(hop-window-match), `gate-no-location`
+   * skipReason 발생 시에도 동일 매치로 fallback pass 한다.
+   *
+   * 구 client 호환을 위해 optional — `occurrenceIdx`와 동일 패턴.
+   */
+  hopIndex?: number;
 }
 
 export interface Trip {

--- a/scripts/__tests__/maestro-retry.test.js
+++ b/scripts/__tests__/maestro-retry.test.js
@@ -88,6 +88,15 @@ describe('parseFailedTestcaseNames', () => {
     const xml = `<testcase classname="x"><failure/></testcase>`;
     expect(parseFailedTestcaseNames(xml)).toEqual([]);
   });
+
+  // #1268 회귀: maestro junit이 `file=".maestro/flows/smoke/X.yaml"` 같이 슬래시가 포함된
+  // 속성을 내보낼 때 attrs 클래스가 `[^>/]` 였던 시기엔 매칭이 깨져 retry가 동작하지 않았다.
+  it('extracts failed testcase even when attributes contain slashes (issue 1268)', () => {
+    const xml = `<testcase id="smoke - flow" name="smoke - flow" classname="suite" file=".maestro/flows/smoke/06.yaml" time="65.0" status="ERROR">
+      <failure>Assertion is false: id: search-input is visible</failure>
+    </testcase>`;
+    expect(parseFailedTestcaseNames(xml)).toEqual(['smoke - flow']);
+  });
 });
 
 describe('decodeXmlEntities', () => {

--- a/scripts/maestro-retry.js
+++ b/scripts/maestro-retry.js
@@ -37,11 +37,11 @@ const path = require('node:path');
  */
 function parseFailedTestcaseNames(xml) {
   const names = [];
-  // <testcase ...>...</testcase> 블록 단위로 순회
-  // attrs는 `[^>]` 가 아니라 `[^>/]` — 그렇지 않으면 self-closing `/>` 의 `/` 까지
-  // 탐욕적으로 소비해 `\/>` 분기가 실패하고 다음 `</testcase>` 까지 long-match된다.
-  // (alternation은 backtrack 없이 첫 성공 분기를 채택하므로 attrs 클래스 자체를 좁힌다.)
-  const blockRe = /<testcase\b([^>/]*)(\/>|>([\s\S]*?)<\/testcase>)/g;
+  // <testcase ...>...</testcase> 블록 단위로 순회.
+  // attrs는 `[^>]*?` (non-greedy) — `[^>/]` 로 좁히면 file=".maestro/flows/..."
+  // 같이 `/` 가 포함된 속성값에서 매칭이 깨진다 (#1268). non-greedy + 첫 `>` 또는
+  // `/>` 분기 탐색으로 self-closing/open-close 두 케이스 모두 정확히 분리.
+  const blockRe = /<testcase\b([^>]*?)(\/>|>([\s\S]*?)<\/testcase>)/g;
   let match;
   while ((match = blockRe.exec(xml)) !== null) {
     const attrs = match[1];

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -374,6 +374,49 @@ describe('silentPushTask', () => {
       ).toMatchObject({ pushId: undefined });
     });
 
+    // Epic #1204 그룹 2 D3 (#1273) — backend가 silent push payload에 hopIndex(0-based 절대 시퀀스)를 stamp.
+    // 0 이상 정수만 통과. 음수/non-integer/비숫자/누락은 모두 undefined로 정규화 → gate가 widened fallback.
+    describe('hopIndex (#1273 D3)', () => {
+      it('non-negative integer이면 그대로 전달', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', hopIndex: 0 }),
+          ),
+        ).toMatchObject({ hopIndex: 0 });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', hopIndex: 7 }),
+          ),
+        ).toMatchObject({ hopIndex: 7 });
+      });
+
+      it('누락/음수/non-integer/비숫자/Infinity이면 undefined (구 백엔드 호환)', () => {
+        expect(
+          extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' })),
+        ).toMatchObject({ hopIndex: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', hopIndex: -1 }),
+          ),
+        ).toMatchObject({ hopIndex: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', hopIndex: 1.5 }),
+          ),
+        ).toMatchObject({ hopIndex: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', hopIndex: '3' }),
+          ),
+        ).toMatchObject({ hopIndex: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', hopIndex: Infinity }),
+          ),
+        ).toMatchObject({ hopIndex: undefined });
+      });
+    });
+
     // #725 — reschedule schema는 standard와 다르므로 별도 분기 검증.
     describe('reschedule kind (#725)', () => {
       it('정상 reschedule payload → RescheduleSilentPushPayload', () => {
@@ -632,6 +675,7 @@ describe('silentPushTask', () => {
         kind: 'destination',
         phase: 'imminent',
         isLockless: false,
+        payloadHopIndex: undefined,
       });
       expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
       const call = mockScheduleNotificationAsync.mock.calls[0][0];
@@ -963,6 +1007,28 @@ describe('silentPushTask', () => {
         await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
         expect(mockCheckGate).toHaveBeenCalledWith(
           expect.objectContaining({ isLockless: true }),
+        );
+      });
+
+      // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex가 gate.payloadHopIndex로 그대로 전달되는지.
+      // backend SSOT가 frontend gate hop-window 매치 분기에 도달해야 D3 효과 발생.
+      it('payload.hopIndex가 정의되면 게이트에 payloadHopIndex로 wire', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        mockLocklessStorage('on');
+        await handleSilentPush(
+          payload({ kind: 'intermediate', phase: 'imminent', hopIndex: 5 }),
+        );
+        expect(mockCheckGate).toHaveBeenCalledWith(
+          expect.objectContaining({ payloadHopIndex: 5 }),
+        );
+      });
+
+      it('payload.hopIndex가 없으면 게이트에 payloadHopIndex=undefined (거리 fallback)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        mockLocklessStorage('on');
+        await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
+        expect(mockCheckGate).toHaveBeenCalledWith(
+          expect.objectContaining({ payloadHopIndex: undefined }),
         );
       });
     });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -94,6 +94,13 @@ export interface SilentPushPayload {
    * 구 백엔드 호환 위해 optional — 누락 시 ACK skip(P2c fallback이 발사할 가능성 감수).
    */
   pushId?: string;
+  /**
+   * 백엔드 trip waypoint의 0-based 절대 시퀀스 위치 (#1273 D3 / Epic #1204 그룹 2).
+   * lockless intermediate hop-window 매치 게이트의 SSOT. 구 백엔드 호환 위해 optional —
+   * 누락 시 거리 기반 widened fallback 경로로 동작 (silentPushLocationGate가 처리).
+   * D1(#1207) hop estimator currentHopIndex와 짝지어 사용.
+   */
+  hopIndex?: number;
 }
 
 /**
@@ -265,7 +272,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
   // standard 경로. findFieldsLayer는 isStandardCandidate(nextWaypoint non-empty) 또는
   // isRescheduleCandidate(kind='reschedule') 중 하나로 통과시키지만, kind='reschedule'
   // 케이스는 위 분기에서 잡혔으므로 잔여 케이스는 isStandardCandidate가 보증한 것 — nextWaypoint 보장.
-  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId } = obj as {
+  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId, hopIndex } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
@@ -279,7 +286,19 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     kind: validKind,
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
+    hopIndex: validHopIndex(hopIndex),
   };
+}
+
+/**
+ * #1273 D3 — payload.hopIndex 검증. 0 이상 정수만 통과. 구 backend가 필드를 안 보내면 undefined →
+ * `silentPushLocationGate`가 거리 기반 widened fallback 경로로 동작.
+ * (validOccurrenceIdx와 의미가 다르므로 별도 헬퍼 — hopIndex는 절대 시퀀스, occurrenceIdx는 중복 station 선택.)
+ */
+function validHopIndex(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  if (!Number.isInteger(value) || value < 0) return undefined;
+  return value;
 }
 
 function extractReschedulePayload(
@@ -765,13 +784,15 @@ async function fireWithGate(
   }
 
   // #1209 D3 — lockless 경로는 sticky station 좌표 drift 수용 위해 widened 임계값 사용.
-  // D1(#1207) hop estimator 미연결 단계라 currentHopIndex/payloadHopIndex는 undefined로 두고
-  // 거리 기반 widened fallback 경로로 동작한다.
+  // #1273 D3 — payloadHopIndex는 백엔드 silent push payload의 절대 시퀀스 SSOT. wire.
+  // currentHopIndex는 D1(#1207) hop estimator 미연결 단계라 undefined — 둘 중 하나라도
+  // 없으면 gate가 거리 기반 widened fallback 경로로 동작한다.
   const gate = await checkSilentPushLocationGate({
     stationName: payload.nextWaypoint,
     kind: payload.kind,
     phase: payload.phase,
     isLockless: !lock,
+    payloadHopIndex: payload.hopIndex,
   });
 
   if (!gate.pass) {

--- a/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
@@ -566,6 +566,115 @@ describe('checkSilentPushLocationGate', () => {
       expect(result.thresholdM).toBe(800);
     });
 
+    // Epic #1204 그룹 2 D3 (#1273) — gate-no-location fallback 분기.
+    describe('gate-no-location hop fallback (#1273)', () => {
+      it('lockless intermediate + hop 매치 + 위치 미획득 → hop-window-match pass (locationSource 부재)', async () => {
+        mockGetLastKnownPositionAsync.mockResolvedValue(null);
+        mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        const result = await checkSilentPushLocationGate({
+          stationName: '강남',
+          kind: 'intermediate',
+          phase: 'imminent',
+          isLockless: true,
+          currentHopIndex: 4,
+          payloadHopIndex: 4,
+        });
+        expect(result.pass).toBe(true);
+        expect(result.passReason).toBe('hop-window-match');
+        expect(result.locationSource).toBeUndefined();
+        expect(result.distanceM).toBeUndefined();
+        expect(result.thresholdM).toBeUndefined();
+      });
+
+      it('lockless intermediate + hop ±1 매치 (경계) + 위치 미획득 → fallback pass', async () => {
+        mockGetLastKnownPositionAsync.mockResolvedValue(null);
+        mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        const result = await checkSilentPushLocationGate({
+          stationName: '강남',
+          kind: 'intermediate',
+          phase: 'imminent',
+          isLockless: true,
+          currentHopIndex: 5,
+          payloadHopIndex: 4,
+        });
+        expect(result.pass).toBe(true);
+        expect(result.passReason).toBe('hop-window-match');
+      });
+
+      it('lockless intermediate + hop diff ≥2 + 위치 미획득 → no-location skip (fallback 미적용)', async () => {
+        mockGetLastKnownPositionAsync.mockResolvedValue(null);
+        mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        const result = await checkSilentPushLocationGate({
+          stationName: '강남',
+          kind: 'intermediate',
+          phase: 'imminent',
+          isLockless: true,
+          currentHopIndex: 6,
+          payloadHopIndex: 4,
+        });
+        expect(result.pass).toBe(false);
+        expect(result.reason).toBe('no-location');
+      });
+
+      it('lockless + transfer kind + 위치 미획득 → fallback 미적용 (intermediate만 허용)', async () => {
+        mockGetLastKnownPositionAsync.mockResolvedValue(null);
+        mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        const result = await checkSilentPushLocationGate({
+          stationName: '강남',
+          kind: 'transfer',
+          phase: 'imminent',
+          isLockless: true,
+          currentHopIndex: 4,
+          payloadHopIndex: 4,
+        });
+        expect(result.pass).toBe(false);
+        expect(result.reason).toBe('no-location');
+      });
+
+      it('isLockless=false + 위치 미획득 + hop 매치 → fallback 미적용 (lock 활성 trip은 보수적)', async () => {
+        mockGetLastKnownPositionAsync.mockResolvedValue(null);
+        mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        const result = await checkSilentPushLocationGate({
+          stationName: '강남',
+          kind: 'intermediate',
+          phase: 'imminent',
+          isLockless: false,
+          currentHopIndex: 4,
+          payloadHopIndex: 4,
+        });
+        expect(result.pass).toBe(false);
+        expect(result.reason).toBe('no-location');
+      });
+
+      it('lockless intermediate + currentHopIndex 부재 + 위치 미획득 → no-location skip', async () => {
+        mockGetLastKnownPositionAsync.mockResolvedValue(null);
+        mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        const result = await checkSilentPushLocationGate({
+          stationName: '강남',
+          kind: 'intermediate',
+          phase: 'imminent',
+          isLockless: true,
+          payloadHopIndex: 4,
+        });
+        expect(result.pass).toBe(false);
+        expect(result.reason).toBe('no-location');
+      });
+
+      it('lockless intermediate + payloadHopIndex 부재 + 위치 미획득 → no-location skip', async () => {
+        mockGetLastKnownPositionAsync.mockResolvedValue(null);
+        mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        const result = await checkSilentPushLocationGate({
+          stationName: '강남',
+          kind: 'intermediate',
+          phase: 'imminent',
+          isLockless: true,
+          currentHopIndex: 4,
+        });
+        expect(result.pass).toBe(false);
+        expect(result.reason).toBe('no-location');
+      });
+    });
+
     it('lockless intermediate + payloadHopIndex만 제공(estimator 미연결) → widened distance 경로', async () => {
       mockGetLastKnownPositionAsync.mockResolvedValue(
         makePosition(MID_FROM_GANGNAM.lat, MID_FROM_GANGNAM.lng, 5_000),

--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -191,6 +191,17 @@ export async function checkSilentPushLocationGate(
 
   const pos = await resolveUserPosition();
   if (!pos) {
+    // Epic #1204 그룹 2 D3 (#1273) — BG 깨움 직후 GPS 미준비 fallback.
+    // lockless intermediate + D1 estimator currentHopIndex가 payload hopIndex와 매칭되면
+    // 거리 게이트 우회하고 hop 매칭만으로 pass. (사용자 피드백 14/15: 14건 received / 0건 fired)
+    // 측정 가시성을 위해 locationSource는 부재로 두고 passReason='hop-window-match'만 노출.
+    if (
+      input.isLockless === true &&
+      input.kind === 'intermediate' &&
+      isHopWindowMatch(input.currentHopIndex, input.payloadHopIndex)
+    ) {
+      return { pass: true, passReason: 'hop-window-match' };
+    }
     return { pass: false, reason: 'no-location' };
   }
 


### PR DESCRIPTION
Part of #1204 (Epic — lockless trip 정확도 복구). Closes #1273.

## Why
사용자 피드백 14(매 역 도착 알림 없음) / 15(왕십리 도착인데 답십리 알림 22:45)의 root cause:

- backend `scheduled.ts:700-708, 1286-1292` silent push payload에 hopIndex 부재
- frontend `silentPushLocationGate.ts:137`은 `hop-window-match` 분기를 이미 보유하나 payload에 hopIndex가 없어 항상 false
- `gate-no-location` skipReason 발생 시 매칭 가능한 hop이 있어도 무조건 skip → silent push 14건 received / 0건 fired

## What
### backend
1. `Waypoint.hopIndex?: number` (types.ts) — 원본 시퀀스 0-based 위치, waypoint shift 후에도 불변
2. `validateTrip` 1-pass stamping — `occurrenceIdx`와 같은 패턴 (절대 시퀀스 인덱스 ≠ stationName 등장 횟수). 클라가 명시 송신 시 그대로 신뢰
3. `SilentPushPayload.hopIndex?: number` (apns.ts) + APNs body.data에 conditional wire
4. arvlcd-fire (`fireArvlCdStationPush`) + lockless intermediate (`runLocklessIntermediate`) push 사이트에서 `waypoint.hopIndex`를 payload로 forward

### frontend
1. `silentPushLocationGate`: 위치 미획득(`no-location`) 시 `isLockless + kind='intermediate' + isHopWindowMatch(currentHopIndex, payloadHopIndex)` 만족이면 `hop-window-match` fallback pass. `locationSource`/`distanceM`/`thresholdM`은 부재로 두어 측정 가시성 유지
2. **`silentPushTask.ts` payload parse + gate input wire (추가 커밋)**:
   - `SilentPushPayload.hopIndex?: number` 필드 + `validHopIndex` 검증(0 이상 정수만, 음수/non-integer/Infinity → undefined)
   - `fireWithGate`가 `checkSilentPushLocationGate` 호출 시 `payloadHopIndex: payload.hopIndex` 그대로 전달

## Scope
**변경**: `backend/alarm-worker/src/{types,apns,index,scheduled}.ts` + `src/features/alarm/utils/silentPushLocationGate.ts` + `src/features/alarm/tasks/silentPushTask.ts` + 양쪽 테스트

**변경 금지 (그룹 2 분리)**: `useStationAlarm.ts`, `useBoardingLockController.ts`, `useBoardingLockSync.ts`

## Tests
- frontend: 7 new (gate-no-location hop fallback 매트릭스) + 6 new (silentPushTask hopIndex parse 4 + gate input wire 2)
- backend: 13 new
  - apns hopIndex wire 3건 (지정/누락/0 경계)
  - validateTrip hopIndex stamping 6건 (시퀀스/중복 station/클라 명시/비정상 fallback)
  - scheduled arvlcd-fire / lockless 각 2건 (waypoint.hopIndex 있을 때/없을 때)
- frontend `npm test` 5243 tests pass, 100% coverage 유지
- backend `npm test` 1207 tests pass
- frontend `npm run type-check`, `npm run lint`, backend `npm run type-check` 모두 통과

## Out of scope (후속 PR)
- D1 estimator `currentHopIndex` wire — D1 (#1207) 머지 후 통합 (현재는 `currentHopIndex=undefined` → 거리 기반 widened fallback 경로로 동작)

## Evidence 수집 plan
내일 사용자 외출 trip에서 silent push 14/15 회귀 재발 여부 + `gate-no-location` skipReason 빈도를 alarmLog로 측정