### PR TITLE
fix(#1285): lockless waypoint 진행 보존

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -923,6 +923,83 @@ describe('POST /trips — #705 progress KV preserves advance across POST race', 
   });
 });
 
+// #1285 — lockless trip POST /trips 재등록 시 waypoint 진행 보존
+describe('POST /trips — #1285 lockless progress KV 재등록 시 진행 보존', () => {
+  const LOCKLESS_TOKEN = 'tok-1285';
+  const LOCKLESS_WAYPOINTS = [
+    { stationName: '중곡', line: '5', kind: 'intermediate' },
+    { stationName: '군자', line: '5', kind: 'intermediate' },
+    { stationName: '아차산', line: '5', kind: 'destination' },
+  ];
+
+  function locklessTripBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+      ...base(),
+      token: LOCKLESS_TOKEN,
+      createdAt: SESSION_CREATED,
+      locklessStationPassed: true,
+      waypoints: LOCKLESS_WAYPOINTS,
+      ...overrides,
+    };
+  }
+
+  async function readLocklessTrip(env: Env): Promise<Record<string, unknown>> {
+    return JSON.parse((await env.TRIPS.get(`trip:${LOCKLESS_TOKEN}`)) as string);
+  }
+
+  async function seedLocklessProgress(env: Env, shiftedCount: number): Promise<void> {
+    await env.TRIPS.put(
+      `progress:${LOCKLESS_TOKEN}`,
+      JSON.stringify({ lockless: true, shiftedCount }),
+    );
+  }
+
+  it('lockless trip 재등록 시 progress.shiftedCount=1 → 중곡 제거, 군자가 첫 waypoint', async () => {
+    const env = makeKvEnv();
+    // 첫 등록
+    await post('/trips', locklessTripBody(), env);
+    // 서버가 중곡 발사 후 progress.shiftedCount=1 기록
+    await seedLocklessProgress(env, 1);
+    // 디바이스 재등록 (GPS 동결로 중곡 포함 full route 재전송)
+    await post('/trips', locklessTripBody({ createdAt: SESSION_CREATED + 50_000 }), env);
+    const finalTrip = await readLocklessTrip(env);
+    expect((finalTrip.waypoints as Array<{ stationName: string }>)).toHaveLength(2);
+    expect((finalTrip.waypoints as Array<{ stationName: string }>)[0].stationName).toBe('군자');
+  });
+
+  it('lockless progress 보존 후 중곡 재발사 안 됨 — waypoint가 군자로 advance 유지', async () => {
+    const env = makeKvEnv();
+    await post('/trips', locklessTripBody(), env);
+    await seedLocklessProgress(env, 1);
+    // 재등록 후에도 진행분 보존 검증
+    await post('/trips', locklessTripBody(), env);
+    const finalTrip = await readLocklessTrip(env);
+    expect((finalTrip.waypoints as Array<{ stationName: string }>)[0].stationName).toBe('군자');
+  });
+
+  it('lockless progress가 있어도 locklessStationPassed=false면 progress 폐기', async () => {
+    const env = makeKvEnv();
+    await post('/trips', locklessTripBody(), env);
+    await seedLocklessProgress(env, 1);
+    // locklessStationPassed가 false인 재등록 — progress 미적용
+    await post('/trips', locklessTripBody({ locklessStationPassed: false }), env);
+    expect(await env.TRIPS.get(`progress:${LOCKLESS_TOKEN}`)).toBeNull();
+  });
+
+  it('lock-mode progress(trainCode stamp)가 lockless 재등록 시 폐기됨', async () => {
+    const env = makeKvEnv();
+    await post('/trips', locklessTripBody(), env);
+    // lock 경로가 남긴 progress (lockless 마커 없음)
+    await env.TRIPS.put(
+      `progress:${LOCKLESS_TOKEN}`,
+      JSON.stringify({ trainCode: 'SOME_TRAIN', shiftedCount: 1 }),
+    );
+    await post('/trips', locklessTripBody(), env);
+    // trainCode 기반 progress는 lockless 재등록 시 progressApplies=false → 삭제
+    expect(await env.TRIPS.get(`progress:${LOCKLESS_TOKEN}`)).toBeNull();
+  });
+});
+
 /**
  * 4 tests 공통 패턴 — TELEMETRY 적재형 POST endpoint(/telemetry/silent-push,
  * /metrics/boarding-prompt, /telemetry/recall)는 모두 (1) invalid JSON 400,

--- a/backend/alarm-worker/src/__tests__/progress.test.ts
+++ b/backend/alarm-worker/src/__tests__/progress.test.ts
@@ -60,4 +60,32 @@ describe('progress KV (#705)', () => {
     await deleteProgress(kv, 'tok');
     expect(await getProgress(kv, 'tok')).toBeNull();
   });
+
+  // #1285 — lockless progress 지원
+  it('getProgress accepts lockless entry (lockless=true, no trainCode)', async () => {
+    const kv = makeKv();
+    const locklessProgress: TripProgress = { lockless: true, shiftedCount: 1 };
+    await putProgress(kv, 'lockless-tok', locklessProgress, 3600);
+    const result = await getProgress(kv, 'lockless-tok');
+    expect(result).not.toBeNull();
+    expect(result?.lockless).toBe(true);
+    expect(result?.shiftedCount).toBe(1);
+    expect(result?.trainCode).toBeUndefined();
+  });
+
+  it('getProgress rejects entry with neither trainCode nor lockless=true', async () => {
+    const kv = makeKv();
+    await kv.put('progress:tok', JSON.stringify({ shiftedCount: 1 }));
+    expect(await getProgress(kv, 'tok')).toBeNull();
+  });
+
+  it('getProgress rejects entry where lockless=true but trainCode also present (ambiguous)', async () => {
+    const kv = makeKv();
+    // lockless=true + trainCode 동시 존재 — trainCode 있으면 validTrainCode=true로 통과 (lock 우선)
+    await kv.put('progress:tok', JSON.stringify({ lockless: true, trainCode: 'T1', shiftedCount: 2 }));
+    const result = await getProgress(kv, 'tok');
+    // trainCode가 문자열이면 validTrainCode=true → 통과 (lock 경로로 처리)
+    expect(result).not.toBeNull();
+    expect(result?.trainCode).toBe('T1');
+  });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -660,6 +660,57 @@ describe('runScheduled', () => {
       expect(parsed.waypoints[0].stationName).toBe('역삼');
       expect(parsed.lastFiredPhase).toBeUndefined();
     });
+
+    // #1285 — lockless waypoint shift → progress KV mirror
+    it('#1285 — 발사 성공 시 progress KV에 lockless shiftedCount=1 저장', async () => {
+      const { kv } = await runLocklessCycle({
+        trip: makeTrip({
+          waypoints: [
+            { stationName: '중곡', line: '5', kind: 'intermediate' },
+            { stationName: '군자', line: '5', kind: 'destination' },
+          ],
+          locklessStationPassed: true,
+        }),
+        arrivals: [ARVL_ARRIVED],
+        apnsOk: true,
+      });
+      const progressRaw = await (kv as unknown as KVNamespace).get('progress:tok');
+      expect(progressRaw).not.toBeNull();
+      const progress = JSON.parse(progressRaw as string);
+      expect(progress.lockless).toBe(true);
+      expect(progress.shiftedCount).toBe(1);
+      expect(progress.trainCode).toBeUndefined();
+    });
+
+    it('#1285 — 두 번째 발사 시 progress.shiftedCount 누적 (2)', async () => {
+      const kv = new InMemoryKV();
+      // 첫 발사 후 progress.shiftedCount=1 존재하는 상황
+      await (kv as unknown as KVNamespace).put(
+        'progress:tok',
+        JSON.stringify({ lockless: true, shiftedCount: 1 }),
+      );
+      const trip = makeTrip({
+        waypoints: [
+          { stationName: '군자', line: '5', kind: 'intermediate' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+        locklessStationPassed: true,
+      });
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const seoul = makeSeoul([ARVL_ARRIVED]);
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+      await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      const progressRaw = await (kv as unknown as KVNamespace).get('progress:tok');
+      const progress = JSON.parse(progressRaw as string);
+      expect(progress.lockless).toBe(true);
+      expect(progress.shiftedCount).toBe(2);
+    });
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -335,11 +335,14 @@ app.post('/trips', async (c) => {
       : undefined;
   // #705: progress KV 우선 참조. 같은 trainCode면 shift된 waypoints를 incoming에 적용.
   // 다른 trainCode/none이면 progress 폐기.
+  // #1285: lockless opt-in trip(boardingLock 없음 + locklessStationPassed===true)은
+  // token 기준 lockless progress로 보존 — trainCode 없이 lockless===true 마커로 매칭.
   const progress = existing !== null ? await getProgress(c.env.TRIPS, incoming.token) : null;
   const progressApplies =
     progress !== null &&
-    incoming.boardingLock !== undefined &&
-    progress.trainCode === incoming.boardingLock.trainCode;
+    ((incoming.boardingLock !== undefined &&
+      progress.trainCode === incoming.boardingLock.trainCode) ||
+      (progress.lockless === true && incoming.locklessStationPassed === true));
   if (progress !== null && !progressApplies) {
     await deleteProgress(c.env.TRIPS, incoming.token);
   }

--- a/backend/alarm-worker/src/progress.ts
+++ b/backend/alarm-worker/src/progress.ts
@@ -22,8 +22,11 @@
 const PROGRESS_PREFIX = 'progress:';
 
 export interface TripProgress {
-  /** trainCode stamp. POST 시 incoming lock과 비교해 다른 열차면 progress 폐기. */
-  trainCode: string;
+  /** trainCode stamp. POST 시 incoming lock과 비교해 다른 열차면 progress 폐기.
+   *  lockless trip은 trainCode 없이 token 기준으로만 매칭 — undefined 허용. */
+  trainCode?: string;
+  /** #1285 — lockless opt-in trip 진행 보존 마커. trainCode 없이 token 기준으로 progress를 유지한다. */
+  lockless?: true;
   /** advance로 shift한 waypoint 개수. POST의 incoming.waypoints에 slice(shiftedCount) 적용. */
   shiftedCount: number;
   /** Trip의 lastTrackedArrivalEpoch 사본 — race-isolated. */
@@ -58,7 +61,10 @@ export async function getProgress(
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as TripProgress;
-    if (typeof parsed.trainCode !== 'string' || typeof parsed.shiftedCount !== 'number') {
+    // lockless progress: lockless===true, trainCode 없음. lock progress: trainCode 문자열 필수.
+    const validTrainCode = typeof parsed.trainCode === 'string';
+    const validLockless = parsed.lockless === true && parsed.trainCode === undefined;
+    if ((!validTrainCode && !validLockless) || typeof parsed.shiftedCount !== 'number') {
       return null;
     }
     return parsed;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -566,6 +566,23 @@ async function mirrorProgress(
 }
 
 /**
+ * #1285 — lockless trip의 waypoint shift를 progress KV에 mirror해 POST /trips 재등록 race 보존.
+ * trip.waypoints는 이미 shift() 완료된 상태로 전달된다 — shiftedCount는 (totalWaypoints - remaining).
+ * mirrorProgress(lock 경로)와 동형이지만 trainCode 없이 lockless===true 마커로 저장.
+ */
+async function mirrorLocklessProgress(kv: KVNamespace, trip: Trip): Promise<void> {
+  // #766 — cron path는 cacheTtl=10s로 PUT 직후 stale read 방지.
+  const existing = await getProgress(kv, trip.token, { cacheTtl: CRON_PROGRESS_CACHE_TTL_SEC });
+  const prevShifted = existing?.lockless === true ? existing.shiftedCount : 0;
+  const next: TripProgress = {
+    lockless: true,
+    shiftedCount: prevShifted + 1,
+  };
+  const ttlSec = Math.max(60, Math.floor((trip.expiresAt - Date.now()) / 1000));
+  await putProgress(kv, trip.token, next, ttlSec);
+}
+
+/**
  * boardingLock trip 추적 (#585).
  *
  * 3단계로 분리: estimate → arrival 시 waypoint 진행(early return) → 아니면 reschedule push.
@@ -1348,6 +1365,9 @@ export async function runLocklessIntermediate(
   }
   // 다음 waypoint를 위해 dedup stamp reset (위 shift 직후 첫 waypoint는 새 발사 대상).
   trip.lastFiredPhase = undefined;
+  // #1285 — lockless shift를 progress KV에 mirror해 POST /trips 재등록 race로부터 진행분 보존.
+  // lock 경로의 mirrorProgress와 동형 — token 기준 lockless 마커로 저장.
+  await mirrorLocklessProgress(env.TRIPS, trip);
   await putTrip(env.TRIPS, trip);
 }
 


### PR DESCRIPTION
## Summary

- `progress.ts`: `TripProgress`에 `lockless?: true` 마커 추가, `trainCode`를 선택적(`?`)으로 변경. `getProgress` 검증 로직을 lockless 엔트리(lockless=true, trainCode 없음)도 허용하도록 확장.
- `index.ts`: `progressApplies` 조건에 lockless 분기 추가 — `locklessStationPassed===true` trip은 `progress.lockless===true` 마커로 token 기준 매칭 (trainCode 불필요). 기존 lock 경로는 변경 없음.
- `scheduled.ts`: `runLocklessIntermediate` 발사 성공 후 `mirrorLocklessProgress` 호출 추가. shift된 waypoint 수를 progress KV에 mirror해 POST /trips 재등록 race에서 진행분 보존. `mirrorProgress`(lock 경로)와 동형.

Root cause: `progressApplies` 조건이 `incoming.boardingLock !== undefined`를 요구해 lockless trip(보드락 없음)은 항상 `false` → progress 삭제. 디바이스 재등록 시 서버 shift 진행분이 clobber되어 중곡이 되살아나 중복 발사.

Closes #1285

## Test plan

- [x] `npx vitest run` — 1219 tests all pass (9 new tests added)
- [x] `npm run type-check` — 0 errors
- [x] `progress.test.ts` +3: lockless 엔트리 roundtrip, 마커 없음 → null, trainCode+lockless 동시 존재 처리
- [x] `index.test.ts` +4: lockless progress 재등록 시 waypoint 진행 보존, `locklessStationPassed=false` 시 폐기, lock-mode progress가 lockless 재등록 시 폐기
- [x] `scheduled.test.ts` +2: 발사 성공 시 `progress.shiftedCount=1` 저장, 두 번째 발사 시 누적 `shiftedCount=2`