### PR TITLE
fix(#1291): motion BG 알람 게이트

### DIFF
--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -67,6 +67,8 @@ export type AlarmLogReason =
   | 'gate-age'
   | 'gate-accuracy'
   | 'gate-jump'
+  // #1291 — BG 알람 경로에서 motionStationary=true(주머니 정지) 확정 시 오발사 차단.
+  | 'gate-motion-stationary'
   | 'gate-unknown-station'
   | 'gate-no-location'
   | 'gate-stale-location'
@@ -680,7 +682,7 @@ export function countSilentPushOutcomes(
 }
 
 export function logSuppressedGate(
-  reason: 'gate-age' | 'gate-accuracy' | 'gate-jump',
+  reason: 'gate-age' | 'gate-accuracy' | 'gate-jump' | 'gate-motion-stationary',
   location: AlarmLogLocation,
 ): void {
   appendAlarmLog({

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -933,4 +933,65 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       expect(call?.accelSummary).toBeUndefined();
     });
   });
+
+  describe('#1291 — BG 알람 모션 게이트 (주머니 지하 오발사 억제)', () => {
+    it('motionStationary=true이면 processLocationUpdate를 호출하지 않는다 (억제)', async () => {
+      mockGetCurrentMotionStationary.mockReturnValue(true);
+      mockStorageValues(JSON.stringify(mockDestination));
+
+      await taskCallback({
+        data: { locations: [makeLocation(37.498, 127.028, { accuracy: 30 })] },
+        error: null,
+      });
+
+      expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+
+    it('motionStationary=true이면 logSuppressedGate(gate-motion-stationary)를 호출한다', async () => {
+      mockGetCurrentMotionStationary.mockReturnValue(true);
+      mockStorageValues(JSON.stringify(mockDestination));
+
+      await taskCallback({
+        data: { locations: [makeLocation(37.498, 127.028, { accuracy: 30 })] },
+        error: null,
+      });
+
+      expect(mockLogSuppressedGate).toHaveBeenCalledWith(
+        'gate-motion-stationary',
+        expect.objectContaining({ lat: 37.498, lng: 127.028 }),
+      );
+    });
+
+    it('motionStationary=false이면 processLocationUpdate를 호출한다 (회귀 없음 — 이동 중)', async () => {
+      mockGetCurrentMotionStationary.mockReturnValue(false);
+      mockStorageValues(JSON.stringify(mockDestination));
+      mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+      await taskCallback({
+        data: { locations: [makeLocation(37.498, 127.028, { accuracy: 30 })] },
+        error: null,
+      });
+
+      expect(mockProcessLocationUpdate).toHaveBeenCalled();
+    });
+
+    it('motionStationary=true여도 uploadPosition(motion=stationary)은 정상 호출된다 (업로드 후 게이트)', async () => {
+      mockGetCurrentMotionStationary.mockReturnValue(true);
+      (AsyncStorage.getItem as jest.Mock)
+        .mockResolvedValueOnce(JSON.stringify(mockDestination))
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)  // BG_LAST_FIX_KEY
+        .mockResolvedValueOnce('apns-tok-1'); // APNS_TOKEN_KEY
+
+      await taskCallback({
+        data: { locations: [makeLocation(37.498, 127.028, { accuracy: 30 })] },
+        error: null,
+      });
+
+      expect(mockUploadPosition).toHaveBeenCalledWith(expect.objectContaining({ motion: 'stationary' }));
+      expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -20,6 +20,7 @@ import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY } from '../../../shared/constants/
 import { uploadPosition, type PositionMotion } from '../api/positionUpload';
 import { getCurrentMotionStationary } from '../utils/motionActivity';
 import { getLatestAccelSummary } from '../utils/accelMotionState';
+import { evaluateMovement } from '../utils/movementGate';
 // #1237 — BG tick에서도 위젯 SSOT(App Groups UserDefaults)를 갱신해 FG 진입 전까지 stale로 남지 않게 한다.
 // cross-feature import는 파일 헤더의 file-level eslint-disable로 옵트인 (orchestrator 본질).
 import { saveStationToWidget } from '../../widget/api/widgetStorage';
@@ -157,6 +158,26 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
         motion,
         accelSummary,
       });
+    }
+
+    // #1291 — BG 알람 모션 게이트. FG(`useStationAlarm`/`evaluateMovement`)와 동일 정책:
+    // motionStationary=true(주머니 속 정지 확정)이면 GPS 노이즈로 인한 오발사를 차단한다.
+    // 위 isLocationFresh/isAccuracyAcceptable 게이트를 통과한 fix에 대해서만 평가한다.
+    // evaluateMovement에 motionStationary를 전달해 FG와 동일 판정 로직을 재사용.
+    // BG에서는 motion 신선도를 별도로 관리할 수 없으므로 getCurrentMotionStationary()의 graceful
+    // fallback(미지원/권한 거절 → false)에 의존한다. false이면 게이트를 건너뛰고 기존 경로를 유지.
+    const motionStationary = getCurrentMotionStationary();
+    const motionSignal = evaluateMovement(
+      { timestamp: latest.timestamp, accuracyM: accuracy ?? undefined, speedMps: speedMps ?? undefined },
+      Date.now(),
+      undefined,
+      // motionStationary=false(이동 중 or 권한 거절)이면 undefined 대신 false를 전달해 motion-warmup 차단 안 함.
+      // BG task는 FG hydrate 직후 warmup window 개념이 없으므로 warmup 차단은 의도적으로 배제.
+      motionStationary === true ? true : false,
+    );
+    if (!motionSignal.reliable && motionSignal.reason === 'motion-stationary') {
+      logSuppressedGate('gate-motion-stationary', { lat, lng, accuracy, ageMs });
+      return;
     }
 
     // destinationId scoped — 이전 trip의 stale entry는 빈 set으로 반환된다(#462).


### PR DESCRIPTION
## 변경 사항

BG 알람 경로(`backgroundLocationTask` → `processLocationUpdate`)에 FG와 동일한 모션 게이트(`evaluateMovement`)를 적용합니다.

- **root cause**: `processLocationUpdate` 호출 전 `motionStationary` 체크가 없어, 주머니 속 정지 중 GPS 노이즈로 오발사 가능
- **fix**: `getCurrentMotionStationary()` 읽어 `evaluateMovement`에 전달 → `motion-stationary` reason이면 즉시 return
- `uploadPosition`(백엔드 KV 적재)은 게이트 **이전** 실행 유지 — 서버 ring buffer 누락 방지
- 이동 중(`motionStationary=false`)이면 기존 경로 완전 유지 — 회귀 없음
- `alarmLog`에 `'gate-motion-stationary'` reason 추가 (`logSuppressedGate` 확장)

## 파일 변경

- `src/features/nearest-station/tasks/backgroundLocationTask.ts` — 모션 게이트 추가
- `src/features/alarm/utils/alarmLog.ts` — `'gate-motion-stationary'` reason 추가
- `src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts` — 4건 신규 테스트

## 테스트

- `npm test` 전체 통과 (pre-existing failures: `widgetStorage`/`stationNotification` 2개 suite — 본 PR 이전부터 존재)
- `npm run type-check` 통과
- BG + stationary → 억제 / BG + 이동 → 통과 / 업로드→게이트 순서 검증

Closes #1291