### PR TITLE
fix(#1283): fireTripEndedPush APNs env-heal 적용 (BadDeviceToken)

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -337,4 +337,59 @@ describe('cleanupTripWithLa', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(await kv.get('trip:devtoken')).toBeNull();
   });
+
+  // #1283 — trip-ended push도 다른 push 경로와 동일하게 env-heal 적용.
+  it('trip-ended push self-heals on BadDeviceToken (opposite-host retry)', async () => {
+    const kv = new InMemoryKV();
+    // activityPushToken 없음 → dismissal skip, trip-ended push만 발사돼 호출을 격리.
+    const trip = makeTrip({ activityPushToken: undefined, apnsEnv: 'sandbox' });
+    await kv.put('trip:devtoken', JSON.stringify(trip));
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      calls.push(url);
+      // 1차 sandbox host → BadDeviceToken, 2차 production host → 성공.
+      if (url.includes(APNS_HOSTS.sandbox)) {
+        return new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 });
+      }
+      return new Response('', { status: 200 });
+    });
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+      'eta-missing',
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(calls[0]).toContain(APNS_HOSTS.sandbox);
+    expect(calls[1]).toContain(APNS_HOSTS.production);
+    expect(await kv.get('trip:devtoken')).toBeNull();
+  });
+
+  it('trip-ended push logs failure when both hosts reject (env mismatch exhausted)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({ activityPushToken: undefined, apnsEnv: 'sandbox' });
+    await kv.put('trip:devtoken', JSON.stringify(trip));
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const logs: string[] = [];
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      (msg) => logs.push(msg),
+      'eta-missing',
+    );
+    // 1차 + retry 모두 호출, 둘 다 실패 → 'trip-ended push failed' 로그.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(logs).toContain('trip-ended push failed');
+    expect(await kv.get('trip:devtoken')).toBeNull();
+  });
 });

--- a/backend/alarm-worker/src/apnsHost.ts
+++ b/backend/alarm-worker/src/apnsHost.ts
@@ -9,6 +9,9 @@
  */
 
 import type { ApnsEnv } from './types';
+import type { SendPushResult } from './apns';
+
+type Logger = (message: string, meta?: Record<string, unknown>) => void;
 
 export function pickApnsHost(apnsEnv: ApnsEnv | undefined, hosts: Record<ApnsEnv, string>): string {
   return hosts[apnsEnv ?? 'sandbox'];
@@ -16,4 +19,54 @@ export function pickApnsHost(apnsEnv: ApnsEnv | undefined, hosts: Record<ApnsEnv
 
 export function flipApnsEnv(env: ApnsEnv | undefined): ApnsEnv {
   return (env ?? 'sandbox') === 'sandbox' ? 'production' : 'sandbox';
+}
+
+/** BadDeviceToken(400) — 토큰이 잘못된 APNs env로 전송됐다는 신호. */
+export function isApnsEnvMismatch(status: number, reason: string | undefined): boolean {
+  return status === 400 && reason === 'BadDeviceToken';
+}
+
+export interface EnvHealResult {
+  result: SendPushResult;
+  /** retry로 정정된 새 env. 정정 발생 시에만 set. */
+  correctedEnv?: ApnsEnv;
+  /** 양쪽 host 모두 BadDeviceToken — 토큰 자체 무효 신호. */
+  envMismatchExhausted: boolean;
+}
+
+/**
+ * APNs env mismatch self-heal (#482). 1차 호출 → BadDeviceToken이면 opposite host로 1회 retry.
+ * `sender`는 host를 받아 push를 보내는 클로저 — phase / reschedule / lockless / trip-ended push가 재사용.
+ *
+ * 호출자 책임:
+ *   - correctedEnv set → trip.apnsEnv 갱신 + envCorrected stat 카운트
+ *   - envMismatchExhausted true → trip 삭제
+ *   - result.ok / !ok 분기는 각 경로별 후처리에 맡김
+ */
+export async function sendWithEnvHeal(
+  sender: (host: string) => Promise<SendPushResult>,
+  currentEnv: ApnsEnv | undefined,
+  apnsHosts: Record<ApnsEnv, string>,
+  log: Logger,
+  tokenForLog: string,
+): Promise<EnvHealResult> {
+  const initial = await sender(pickApnsHost(currentEnv, apnsHosts));
+  if (initial.ok || !isApnsEnvMismatch(initial.status, initial.reason)) {
+    return { result: initial, envMismatchExhausted: false };
+  }
+  const corrected = flipApnsEnv(currentEnv);
+  log('apns env mismatch — retry with opposite host', {
+    token: tokenForLog,
+    from: currentEnv ?? 'sandbox',
+    to: corrected,
+  });
+  const retry = await sender(apnsHosts[corrected]);
+  if (retry.ok) {
+    log('apns env corrected', { token: tokenForLog, to: corrected });
+    return { result: retry, correctedEnv: corrected, envMismatchExhausted: false };
+  }
+  return {
+    result: retry,
+    envMismatchExhausted: isApnsEnvMismatch(retry.status, retry.reason),
+  };
 }

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -18,7 +18,7 @@ import {
   sendTripEndedPush,
   type LiveActivityContentState,
 } from './apns';
-import { pickApnsHost } from './apnsHost';
+import { pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
 import { deleteTrip } from './trips';
@@ -214,29 +214,38 @@ async function fireTripEndedPush(
   now: number,
   log: Logger,
 ): Promise<void> {
-  const host = pickApnsHost(trip.apnsEnv, deps.apnsHosts);
   const pushId = crypto.randomUUID();
   // JWT 서명 / network reject 등의 throw가 cleanup 흐름을 차단하지 않도록 swallow.
   // trip-ended push는 graceful fail-soft — graceful loss 시 클라는 다음 FG hydrate에서 회복.
   try {
-    const result = await sendTripEndedPush({
-      deviceToken: trip.token,
-      pushId,
-      reason,
-      sentAt: now,
-      // race 가드(#868 P1-2) — push 도착 시점에 클라가 trip 갈아탔으면 ACTIVE_TRIP_KEY 불일치로 cleanup skip.
-      tripToken: trip.token,
-      config: deps.apnsConfig,
-      host,
-      fetchImpl: deps.fetchImpl,
-      now,
-    });
-    if (!result.ok) {
+    // #1283 — 다른 push 경로(reschedule/lockless/arvlcd)와 동일하게 env-heal 적용.
+    // trip.apnsEnv가 stale/오설정이면 BadDeviceToken → opposite host 1회 retry로 종료 푸시 도달.
+    // trip은 곧 deleteTrip되므로 correctedEnv KV 반영은 불필요 — retry 성공만으로 충분(로그만 남김).
+    const heal = await sendWithEnvHeal(
+      (host) =>
+        sendTripEndedPush({
+          deviceToken: trip.token,
+          pushId,
+          reason,
+          sentAt: now,
+          // race 가드(#868 P1-2) — push 도착 시점에 클라가 trip 갈아탔으면 ACTIVE_TRIP_KEY 불일치로 cleanup skip.
+          tripToken: trip.token,
+          config: deps.apnsConfig,
+          host,
+          fetchImpl: deps.fetchImpl,
+          now,
+        }),
+      trip.apnsEnv,
+      deps.apnsHosts,
+      log,
+      trip.token.slice(0, 8),
+    );
+    if (!heal.result.ok) {
       log('trip-ended push failed', {
         token: trip.token.slice(0, 8),
         reason,
-        status: result.status,
-        pushReason: result.reason,
+        status: heal.result.status,
+        pushReason: heal.result.reason,
       });
     }
   } catch (e) {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -9,9 +9,8 @@ import {
   sendReschedulePush,
   sendSilentPush,
   type ApnsConfig,
-  type SendPushResult,
 } from './apns';
-import { flipApnsEnv, pickApnsHost } from './apnsHost';
+import { flipApnsEnv, pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import {
   attemptAutoLock,
   AUTO_PROMPT_DEDUP_WINDOW_MS,
@@ -125,51 +124,6 @@ export function resolveEtaMissingThreshold(trip: Pick<Trip, 'subsurface'>): numb
  * 런타임에서 `Invalid cache_ttl` 던짐(#770 hotfix).
  */
 const CRON_PROGRESS_CACHE_TTL_SEC = 30;
-
-export interface EnvHealResult {
-  result: SendPushResult;
-  /** retry로 정정된 새 env. 정정 발생 시에만 set. */
-  correctedEnv?: ApnsEnv;
-  /** 양쪽 host 모두 BadDeviceToken — 토큰 자체 무효 신호. */
-  envMismatchExhausted: boolean;
-}
-
-/**
- * APNs env mismatch self-heal (#482). 1차 호출 → BadDeviceToken이면 opposite host로 1회 retry.
- * `sender`는 host를 받아 push를 보내는 클로저 — phase push / reschedule push 양쪽에서 재사용.
- *
- * 호출자 책임:
- *   - correctedEnv set → trip.apnsEnv 갱신 + envCorrected stat 카운트
- *   - envMismatchExhausted true → trip 삭제
- *   - result.ok / !ok 분기는 각 경로별 후처리에 맡김
- */
-export async function sendWithEnvHeal(
-  sender: (host: string) => Promise<SendPushResult>,
-  currentEnv: ApnsEnv | undefined,
-  apnsHosts: Record<ApnsEnv, string>,
-  log: Logger,
-  tokenForLog: string,
-): Promise<EnvHealResult> {
-  const initial = await sender(pickApnsHost(currentEnv, apnsHosts));
-  if (initial.ok || !isApnsEnvMismatch(initial.status, initial.reason)) {
-    return { result: initial, envMismatchExhausted: false };
-  }
-  const corrected = flipApnsEnv(currentEnv);
-  log('apns env mismatch — retry with opposite host', {
-    token: tokenForLog,
-    from: currentEnv ?? 'sandbox',
-    to: corrected,
-  });
-  const retry = await sender(apnsHosts[corrected]);
-  if (retry.ok) {
-    log('apns env corrected', { token: tokenForLog, to: corrected });
-    return { result: retry, correctedEnv: corrected, envMismatchExhausted: false };
-  }
-  return {
-    result: retry,
-    envMismatchExhausted: isApnsEnvMismatch(retry.status, retry.reason),
-  };
-}
 
 type Logger = (message: string, meta?: Record<string, unknown>) => void;
 
@@ -1444,10 +1398,6 @@ function isUnrecoverableApnsError(status: number, _reason: string | undefined): 
  * APNs 토큰 환경(sandbox/production)과 host가 어긋났을 때 Apple이 내는 시그널.
  * 이 조건에 한해서만 self-heal retry를 시도한다.
  */
-function isApnsEnvMismatch(status: number, reason: string | undefined): boolean {
-  return status === 400 && reason === 'BadDeviceToken';
-}
-
 /**
  * "탑승했냐?" 푸시 평가 + 발사 (#819 B 슬라이스).
  *


### PR DESCRIPTION
## Summary
- `fireTripEndedPush`(`liveActivity.ts`)가 다른 push 경로(reschedule/lockless/arvlcd)와 달리 `sendWithEnvHeal`를 거치지 않아, `trip.apnsEnv`가 stale/오설정이면 BadDeviceToken으로 종료 푸시가 실패하던 회귀(#1283) 수정.
- `sendWithEnvHeal` + `isApnsEnvMismatch` + `EnvHealResult`를 `scheduled.ts` → `apnsHost.ts`(공유 SSOT)로 이동. liveActivity.ts가 scheduled.ts를 import하면 순환 참조가 되므로 공용 모듈로 추출.
- 이제 BadDeviceToken 시 opposite host로 1회 retry → 종료 푸시 도달. trip은 곧 삭제되므로 correctedEnv KV 반영은 불필요(로그만).

## 실측 근거
2026-06-13 trip: `trip-ended push failed status=400 pushReason=BadDeviceToken` (apnsEnv=production).

## Test plan
- [x] `npm test` (vitest) 1212 → 1214 통과, 신규 self-heal 테스트 2건 (retry 성공 / 양쪽 실패 로그)
- [x] `npm run type-check` 통과
- [ ] 실기기: trip 자동 종료 시 `trip-ended push failed` 0건 (wrangler tail)

## 범위 밖
client `EXPO_PUBLIC_APNS_ENV` 빌드 오설정으로 token 자체가 invalid한 경우는 새 EAS 빌드 종속 — 본 PR은 backend env-heal 누락만 수정.

Closes #1283