### PR TITLE
fix(#1287): useAccelerometer 마운트

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -25,6 +25,7 @@ import { initStationNotification, updateStationNotification, clearStationNotific
 import { useWidgetMirror } from '../features/widget/hooks/useWidgetMirror';
 import { useStationAlarm } from '../features/alarm/hooks/useStationAlarm';
 import { useMotionActivity } from '../features/nearest-station/hooks/useMotionActivity';
+import { useAccelerometer } from '../features/nearest-station/hooks/useAccelerometer';
 import { useBarometer } from '../shared/hooks/useBarometer';
 import { useTripOrigin } from '../features/route/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../features/nearest-station/hooks/useBackgroundLocation';
@@ -162,6 +163,10 @@ export default function HomeScreen() {
   // #728 — CMMotionActivity 신호. 권한 요청/폴링은 hook 내부에서 lifecycle 관리.
   // 미지원/거절 시 false로 고정되어 기존 가드만 동작 (graceful fallback).
   const motionStationary = useMotionActivity();
+  // #1287 — 가속도 수집 활성화. BG task(backgroundLocationTask)가 getLatestAccelSummary()로
+  // 조회하는 ambient state를 채운다. 반환값 없음 — useMotionActivity/useBarometer와 동일 패턴.
+  // 미지원/권한 거절은 accelMotionState가 null을 유지해 BG task가 graceful fallback.
+  useAccelerometer();
   // #903 (Seam G) — 기압계 dP/dt 신호. 미지원/권한 거절은 subsurface=false 고정(graceful).
   //   1) useFusedNearestStation: 'gps-only' → 'gps-only-underground' 강등 + sticky automotive 트리거.
   //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).


### PR DESCRIPTION
## Summary

- `useAccelerometer`가 구현되어 있었지만 어디에도 마운트되지 않아 `getLatestAccelSummary()`가 항상 `null`을 반환했다 (backend accel phase input dead).
- `HomeScreen.tsx`에 `useMotionActivity` / `useBarometer`와 동일한 패턴으로 마운트를 추가했다.
- 반환값 없음(`void`) → 결과값 사용 없이 호출만. `useBarometer`와 달리 ambient state 경유라 추가 prop drilling 불필요.
- 미지원/권한 거절 시 `accelMotionState`가 `null`을 유지 → BG task graceful fallback (기존 동작 유지).

## Files Changed

- `src/screens/HomeScreen.tsx` — import 1줄 + `useAccelerometer()` 호출 1줄 (+ 주석 3줄)

## Test Results

- `useAccelerometer.test.ts` 8 tests pass (pre-existing, not touched)
- 전체 275 suites pass / 5243 tests pass
- 2 failing suites (`widgetStorage.test.ts`, `stationNotification.test.ts`) — dev 브랜치에 이미 존재하는 pre-existing 실패, 이 PR과 무관

## Type Check

`npm run type-check` pass (0 errors)

Closes #1287