### PR TITLE
fix(#1282): bl: 사전 예약 cleanup

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockScheduler.test.tsx
@@ -8,10 +8,12 @@ import {
   cancelAllHopsForLock,
   scheduleHopsForLock,
 } from '../../utils/boardingLockScheduler';
+import { clearFiredAlarms } from '../../utils/notificationState';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
 import { makeDirectRoute, makeTransferRoute } from '../../../../testUtils/routeFixtures';
 
+const mockSetRegisteredBlRouteSig = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/boardingLockScheduler', () => {
   const actual = jest.requireActual('../../utils/boardingLockScheduler');
   return {
@@ -20,8 +22,14 @@ jest.mock('../../utils/boardingLockScheduler', () => {
     // routeSignature는 실제 구현을 그대로 사용 — hook이 이 결과로 변경 감지를 하므로
     // mocking하면 트레이드가 의미를 잃는다.
     routeSignature: actual.routeSignature,
+    // #1282: sig 영속화 함수는 storage side-effect가 없는 no-op으로 격리.
+    setRegisteredBlRouteSig: (...args: unknown[]) => mockSetRegisteredBlRouteSig(...args),
   };
 });
+jest.mock('../../utils/notificationState', () => ({
+  // #1282: route-sig 변경 시 firedAlarms 클리어 호출을 격리.
+  clearFiredAlarms: jest.fn().mockResolvedValue(undefined),
+}));
 const mockLoggerError = jest.fn();
 const mockLoggerWarn = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -35,6 +43,7 @@ jest.mock('../../../../shared/utils/logger', () => ({
 
 const mockedSchedule = scheduleHopsForLock as jest.MockedFunction<typeof scheduleHopsForLock>;
 const mockedCancel = cancelAllHopsForLock as jest.MockedFunction<typeof cancelAllHopsForLock>;
+const mockedClearFiredAlarms = clearFiredAlarms as jest.MockedFunction<typeof clearFiredAlarms>;
 
 type SchedulerProps = Parameters<typeof useBoardingLockScheduler>[0];
 
@@ -354,6 +363,43 @@ describe('useBoardingLockScheduler', () => {
       expect(line).toContain('prevTrain=A');
       expect(line).toContain('nextTrain=A');
       expect(line).toContain('routeChange=true');
+    });
+  });
+
+  // #1282 — setRegisteredBlRouteSig + clearFiredAlarms 통합 검증.
+  describe('#1282 bl: route-sig 영속화 및 firedAlarms 초기화', () => {
+    it('신규 lock schedule 시 setRegisteredBlRouteSig를 호출한다', async () => {
+      renderHook(() =>
+        useBoardingLockScheduler({ lock: lockA, route, destinationName: '강남' }),
+      );
+      await waitFor(() => expect(mockSetRegisteredBlRouteSig).toHaveBeenCalled());
+      // routeSignature(route, '강남')는 실제 구현으로 non-null string 반환.
+      expect(mockSetRegisteredBlRouteSig).toHaveBeenCalledWith(expect.any(String));
+    });
+
+    it('route-sig 변경 시 clearFiredAlarms를 호출한 후 reschedule한다 (#1282)', async () => {
+      const altRoute = makeTransferRoute({
+        transferName: '교대',
+        fromLine: '2',
+        toLine: '3',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+      await awaitFirstSchedule();
+      mockedClearFiredAlarms.mockClear();
+      rerender({ lock: lockA, route: altRoute, destinationName: '강남' });
+      await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(2));
+      expect(mockedClearFiredAlarms).toHaveBeenCalledTimes(1);
+    });
+
+    it('trainCode 변경 시에는 clearFiredAlarms를 호출하지 않는다 (route-sig 변경 아님)', async () => {
+      const { rerender } = renderScheduler({ lock: lockA, route, destinationName: '강남' });
+      await awaitFirstSchedule();
+      mockedClearFiredAlarms.mockClear();
+      rerender({ lock: lockB, route, destinationName: '강남' });
+      await waitFor(() => expect(mockedSchedule).toHaveBeenCalledTimes(2));
+      expect(mockedClearFiredAlarms).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/hooks/useBoardingLockScheduler.ts
+++ b/src/features/alarm/hooks/useBoardingLockScheduler.ts
@@ -13,7 +13,9 @@ import {
   cancelAllHopsForLock,
   routeSignature,
   scheduleHopsForLock,
+  setRegisteredBlRouteSig,
 } from '../utils/boardingLockScheduler';
+import { clearFiredAlarms } from '../utils/notificationState';
 import { createLogger } from '../../../shared/utils/logger';
 import { useSleepModeRef } from '../../settings/hooks/useSleepModeRef';
 
@@ -112,12 +114,21 @@ export function useBoardingLockScheduler({
         await cancelAllHopsForLock(prev);
       }
       if (canSchedule) {
+        // #1282: route-sig가 바뀐 경우 firedAlarms를 초기화해 이전 route 기반 dedup이
+        // 새 route의 phase 알람 발사를 억제하지 않도록 한다 (feedback #8 re-fire 방지).
+        if (needsRouteChangeReschedule) {
+          await clearFiredAlarms();
+        }
         await scheduleHopsForLock({
           lock,
           route,
           destinationName,
           sleepMode: sleepModeRef.current,
         });
+        // #1282: 예약 성공 직후 sig를 영속화 — receiver gate가 stale `bl:` 발사를 억제하는 데 사용.
+        // canSchedule=true 조건(route/destinationName 모두 non-null)에서만 진입하므로
+        // nextSig는 non-null이 보장된다.
+        await setRegisteredBlRouteSig(nextSig!);
         scheduledTrainCodeRef.current = nextTrain;
         scheduledRouteSigRef.current = nextSig;
       } else if (nextTrain === null) {

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -873,27 +873,28 @@ describe('setRegisteredBlRouteSig / getRegisteredBlRouteSig / clearRegisteredBlR
   });
 });
 
-// #1282 — cancelAllHopsForLock이 route-sig 변경 시 clearRegisteredBlRouteSig를 호출하는 통합 검증.
-describe('cancelAllHopsForLock: route-sig cleanup (#1282)', () => {
-  it('취소 대상이 있어도 clearRegisteredBlRouteSig를 호출한다', async () => {
-    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:강남', 'bl:T-100:0:imminent:강남']);
-    await cancelAllHopsForLock(lock);
-    // clearRegisteredBlRouteSig는 BOARDING_LOCK_ROUTE_SIG_KEY를 removeItem
-    expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
-  });
-
-  it('취소 대상이 없어도 clearRegisteredBlRouteSig를 호출한다', async () => {
-    mockedGet.mockResolvedValueOnce([]);
-    await cancelAllHopsForLock(lock);
-    expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
-  });
-});
-
-// #1282 — purgeBoardingLockSchedulerQueue도 clearRegisteredBlRouteSig를 호출하는 통합 검증.
-describe('purgeBoardingLockSchedulerQueue: route-sig cleanup (#1282)', () => {
-  it('purge 시 clearRegisteredBlRouteSig를 호출한다', async () => {
-    mockedGet.mockResolvedValueOnce([]);
-    await purgeBoardingLockSchedulerQueue();
+// #1282 — cancel/purge 경로가 항상 clearRegisteredBlRouteSig(=BOARDING_LOCK_ROUTE_SIG_KEY
+// removeItem)를 호출하는지 통합 검증. 호출자/큐 상태만 다르고 단언이 동일하므로 it.each로 통합.
+describe('route-sig cleanup 통합 (#1282)', () => {
+  it.each([
+    {
+      name: 'cancelAllHopsForLock: 취소 대상이 있어도',
+      queued: ['bl:T-100:0:early:강남', 'bl:T-100:0:imminent:강남'],
+      run: () => cancelAllHopsForLock(lock),
+    },
+    {
+      name: 'cancelAllHopsForLock: 취소 대상이 없어도',
+      queued: [],
+      run: () => cancelAllHopsForLock(lock),
+    },
+    {
+      name: 'purgeBoardingLockSchedulerQueue',
+      queued: [],
+      run: () => purgeBoardingLockSchedulerQueue(),
+    },
+  ])('$name clearRegisteredBlRouteSig를 호출한다', async ({ queued, run }) => {
+    mockedGet.mockResolvedValueOnce(queued);
+    await run();
     expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
   });
 });

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -1,14 +1,18 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   advanceHopWindow,
   boardingLockAlarmIdentifier,
   cancelAllHopsForLock,
+  clearRegisteredBlRouteSig,
+  getRegisteredBlRouteSig,
   parseBoardingLockAlarmIdentifier,
   purgeBoardingLockSchedulerQueue,
   rescheduleHopForLock,
   routeSignature,
   scheduleHopsForLock,
+  setRegisteredBlRouteSig,
 } from '../boardingLockScheduler';
 import {
   addScheduledNotificationIds,
@@ -25,6 +29,11 @@ import {
 } from '../../../../testUtils/routeFixtures';
 
 jest.mock('expo-notifications');
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
 jest.mock('../scheduledNotificationsStorage', () => ({
   addScheduledNotificationIds: jest.fn(),
   removeScheduledNotificationIds: jest.fn(),
@@ -96,9 +105,16 @@ const multiRoute: MultiTransferRoute = makeMultiTransferRoute({
   stopsAfterLastTransfer: 2,
 });
 
+const mockAsyncGetItem = AsyncStorage.getItem as jest.Mock;
+const mockAsyncSetItem = AsyncStorage.setItem as jest.Mock;
+const mockAsyncRemoveItem = AsyncStorage.removeItem as jest.Mock;
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockedGet.mockResolvedValue([]);
+  mockAsyncGetItem.mockResolvedValue(null);
+  mockAsyncSetItem.mockResolvedValue(undefined);
+  mockAsyncRemoveItem.mockResolvedValue(undefined);
   Object.defineProperty(Platform, 'OS', { configurable: true, value: 'ios' });
 });
 
@@ -809,5 +825,75 @@ describe('rescheduleHopForLock (#698)', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+// #1282 — bl: route-sig 영속화 함수 단위 테스트.
+describe('setRegisteredBlRouteSig / getRegisteredBlRouteSig / clearRegisteredBlRouteSig (#1282)', () => {
+  it('setRegisteredBlRouteSig: AsyncStorage.setItem을 올바른 키/값으로 호출한다', async () => {
+    await setRegisteredBlRouteSig('SIG-ABC');
+    expect(mockAsyncSetItem).toHaveBeenCalledWith(
+      'subway-now:boarding-lock-route-sig',
+      'SIG-ABC',
+    );
+  });
+
+  it('setRegisteredBlRouteSig: setItem 실패 시 graceful (throw 없음)', async () => {
+    mockAsyncSetItem.mockRejectedValueOnce(new Error('storage fail'));
+    await expect(setRegisteredBlRouteSig('SIG-X')).resolves.toBeUndefined();
+  });
+
+  it('getRegisteredBlRouteSig: 저장된 값을 반환한다', async () => {
+    mockAsyncGetItem.mockResolvedValueOnce('SIG-ABC');
+    const result = await getRegisteredBlRouteSig();
+    expect(result).toBe('SIG-ABC');
+    expect(mockAsyncGetItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
+  });
+
+  it('getRegisteredBlRouteSig: 값 없으면 null', async () => {
+    mockAsyncGetItem.mockResolvedValueOnce(null);
+    const result = await getRegisteredBlRouteSig();
+    expect(result).toBeNull();
+  });
+
+  it('getRegisteredBlRouteSig: getItem 실패 시 null 반환 (graceful)', async () => {
+    mockAsyncGetItem.mockRejectedValueOnce(new Error('storage fail'));
+    const result = await getRegisteredBlRouteSig();
+    expect(result).toBeNull();
+  });
+
+  it('clearRegisteredBlRouteSig: AsyncStorage.removeItem을 올바른 키로 호출한다', async () => {
+    await clearRegisteredBlRouteSig();
+    expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
+  });
+
+  it('clearRegisteredBlRouteSig: removeItem 실패 시 graceful (throw 없음)', async () => {
+    mockAsyncRemoveItem.mockRejectedValueOnce(new Error('storage fail'));
+    await expect(clearRegisteredBlRouteSig()).resolves.toBeUndefined();
+  });
+});
+
+// #1282 — cancelAllHopsForLock이 route-sig 변경 시 clearRegisteredBlRouteSig를 호출하는 통합 검증.
+describe('cancelAllHopsForLock: route-sig cleanup (#1282)', () => {
+  it('취소 대상이 있어도 clearRegisteredBlRouteSig를 호출한다', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:early:강남', 'bl:T-100:0:imminent:강남']);
+    await cancelAllHopsForLock(lock);
+    // clearRegisteredBlRouteSig는 BOARDING_LOCK_ROUTE_SIG_KEY를 removeItem
+    expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
+  });
+
+  it('취소 대상이 없어도 clearRegisteredBlRouteSig를 호출한다', async () => {
+    mockedGet.mockResolvedValueOnce([]);
+    await cancelAllHopsForLock(lock);
+    expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
+  });
+});
+
+// #1282 — purgeBoardingLockSchedulerQueue도 clearRegisteredBlRouteSig를 호출하는 통합 검증.
+describe('purgeBoardingLockSchedulerQueue: route-sig cleanup (#1282)', () => {
+  it('purge 시 clearRegisteredBlRouteSig를 호출한다', async () => {
+    mockedGet.mockResolvedValueOnce([]);
+    await purgeBoardingLockSchedulerQueue();
+    expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
   });
 });

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -40,9 +40,15 @@ jest.mock('../tripBoundScheduler', () => {
 });
 
 const mockRouteSignature = jest.fn();
-jest.mock('../boardingLockScheduler', () => ({
-  routeSignature: (...args: unknown[]) => mockRouteSignature(...args),
-}));
+const mockGetRegisteredBlRouteSig = jest.fn();
+jest.mock('../boardingLockScheduler', () => {
+  const actual = jest.requireActual('../boardingLockScheduler');
+  return {
+    ...actual,
+    routeSignature: (...args: unknown[]) => mockRouteSignature(...args),
+    getRegisteredBlRouteSig: (...args: unknown[]) => mockGetRegisteredBlRouteSig(...args),
+  };
+});
 
 const mockResolveAllTargets = jest.fn();
 jest.mock('../stationAlarm', () => ({
@@ -116,6 +122,8 @@ beforeEach(async () => {
   mockGetTripStartedAt.mockResolvedValue(1_000_000);
   mockGetRegisteredTripRouteSig.mockReset();
   mockGetRegisteredTripRouteSig.mockResolvedValue('SIG-A');
+  mockGetRegisteredBlRouteSig.mockReset();
+  mockGetRegisteredBlRouteSig.mockResolvedValue('SIG-A');
   mockRouteSignature.mockReset();
   mockRouteSignature.mockReturnValue('SIG-A');
   mockResolveAllTargets.mockReset();
@@ -654,6 +662,169 @@ describe('tba: fire-time 재검증 (#918 A3 PR2)', () => {
 
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
       expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+      handle.remove();
+    });
+  });
+});
+
+// #1282 — `bl:` 사전 예약 알람 수신 재검증.
+describe('bl: fire-time 재검증 (#1282)', () => {
+  beforeEach(() => {
+    setStorageMap({
+      'subway-now:destination': DEST_JSON,
+      'subway-now:route': ROUTE_JSON,
+    });
+  });
+
+  describe('reconcileScheduledAlarmDelivery — `bl:` 단건', () => {
+    it('재검증 통과 시 alarm: 경로와 동일하게 fired set + lastStationName을 갱신한다', async () => {
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+
+      expect(mockGetFiredAlarms).toHaveBeenCalledWith('dest-1');
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+    });
+
+    it('등록된 bl sig와 현재 sig 불일치 시 route-sig-mismatch + skip', async () => {
+      mockGetRegisteredBlRouteSig.mockResolvedValueOnce('SIG-OLD');
+      mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:imminent:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-route-sig-mismatch',
+        stationName: '강남',
+        phaseId: 'imminent',
+      });
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+    });
+
+    it('등록된 bl sig가 null이면 sig-mismatch로 분류', async () => {
+      mockGetRegisteredBlRouteSig.mockResolvedValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it('현재 sig가 null(route/destination 미설정)이면 sig-mismatch로 분류', async () => {
+      mockRouteSignature.mockReturnValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+    });
+
+    it('stationName이 현재 waypoint 시퀀스에 없으면 waypoint-mismatch + skip', async () => {
+      mockResolveAllTargets.mockReturnValueOnce([{ name: '시청' }, { name: '서울역' }]);
+
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-waypoint-mismatch',
+        stationName: '강남',
+        phaseId: 'early',
+      });
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+    });
+
+    it('bl: prefix는 매칭되지만 포맷 파손 시 parseAlarmIdentifier=null → no-op', async () => {
+      // "bl:T-100:0:bad:강남" — phase가 'bad'라 parseBoardingLockAlarmIdentifier가 null 반환.
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:bad:강남');
+
+      expect(mockGetRegisteredBlRouteSig).not.toHaveBeenCalled();
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    });
+
+    it('재검증 통과 + destinationId 미설정이면 lastStationName만 갱신', async () => {
+      setStorageMap({
+        'subway-now:destination': null,
+        'subway-now:route': ROUTE_JSON,
+      });
+
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+    });
+  });
+
+  describe('drainDeliveredScheduledAlarms — `bl:` 항목 재검증', () => {
+    it('suppress된 bl 항목은 fired set/lastStationName 갱신에서 제외된다', async () => {
+      // 첫 bl은 sig-mismatch로 suppress, 두 번째 bl은 pass.
+      mockGetRegisteredBlRouteSig
+        .mockResolvedValueOnce('SIG-OLD')
+        .mockResolvedValueOnce('SIG-A');
+      mockRouteSignature
+        .mockReturnValueOnce('SIG-NEW')
+        .mockReturnValueOnce('SIG-A');
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'bl:T-100:0:early:잘못된역' } },
+        { date: 2, request: { identifier: 'bl:T-100:0:imminent:강남' } },
+      ]);
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['imminent:강남']));
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ stationName: '잘못된역' }),
+      );
+      handle.remove();
+    });
+
+    it('모든 bl 항목이 suppress면 fired set/lastStationName 모두 갱신 안 함', async () => {
+      mockGetRegisteredBlRouteSig.mockResolvedValue(null);
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'bl:T-100:0:early:A' } },
+        { date: 2, request: { identifier: 'bl:T-100:0:imminent:B' } },
+      ]);
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+      handle.remove();
+    });
+
+    it('`alarm:` 항목은 bl 재검증과 무관하게 그대로 통과한다 — regression 방지', async () => {
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'alarm:early:강남' } },
+      ]);
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
+      expect(mockGetRegisteredBlRouteSig).not.toHaveBeenCalled();
+      handle.remove();
+    });
+
+    it('`tba:` 항목은 bl 재검증과 무관하게 tba 경로로 처리된다 — regression 방지', async () => {
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'tba:early:강남' } },
+      ]);
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
+      expect(mockGetRegisteredBlRouteSig).not.toHaveBeenCalled();
       handle.remove();
     });
   });

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -667,8 +667,15 @@ describe('tba: fire-time 재검증 (#918 A3 PR2)', () => {
   });
 });
 
-// #1282 — `bl:` 사전 예약 알람 수신 재검증.
+// #1282 — `bl:` 사전 예약 알람 수신 재검증. tba:와 동형 게이트를 공유하므로 채널 config를
+// 인자로 둔 it.each로 통합해 셋업 중복을 제거한다([[lesson_sonarcloud_dup_prevention]]).
 describe('bl: fire-time 재검증 (#1282)', () => {
+  // 채널별 차이만 캡슐화: identifier 빌더 + 등록 sig mock. waypoint/route-sig 게이트는 공통.
+  const blChannel = {
+    id: (phase: string, station: string) => `bl:T-100:0:${phase}:${station}`,
+    registeredSigMock: mockGetRegisteredBlRouteSig,
+  };
+
   beforeEach(() => {
     setStorageMap({
       'subway-now:destination': DEST_JSON,
@@ -680,7 +687,7 @@ describe('bl: fire-time 재검증 (#1282)', () => {
     it('재검증 통과 시 alarm: 경로와 동일하게 fired set + lastStationName을 갱신한다', async () => {
       mockGetFiredAlarms.mockResolvedValueOnce(new Set());
 
-      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+      await reconcileScheduledAlarmDelivery(blChannel.id('early', '강남'));
 
       expect(mockGetFiredAlarms).toHaveBeenCalledWith('dest-1');
       expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
@@ -688,51 +695,44 @@ describe('bl: fire-time 재검증 (#1282)', () => {
       expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
     });
 
-    it('등록된 bl sig와 현재 sig 불일치 시 route-sig-mismatch + skip', async () => {
-      mockGetRegisteredBlRouteSig.mockResolvedValueOnce('SIG-OLD');
-      mockRouteSignature.mockReturnValueOnce('SIG-NEW');
-
-      await reconcileScheduledAlarmDelivery('bl:T-100:0:imminent:강남');
-
-      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+    // suppress 분기 — reason별 셋업만 다르고 단언 패턴은 동일하므로 it.each로 통합.
+    it.each([
+      {
+        name: 'bl sig와 현재 sig 불일치 → route-sig-mismatch',
+        phase: 'imminent',
+        setup: () => {
+          blChannel.registeredSigMock.mockResolvedValueOnce('SIG-OLD');
+          mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+        },
         reason: 'revalidate-route-sig-mismatch',
-        stationName: '강남',
-        phaseId: 'imminent',
-      });
-      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
-      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
-    });
+      },
+      {
+        name: '등록된 bl sig=null → route-sig-mismatch',
+        phase: 'early',
+        setup: () => blChannel.registeredSigMock.mockResolvedValueOnce(null),
+        reason: 'revalidate-route-sig-mismatch',
+      },
+      {
+        name: '현재 sig=null(route/destination 미설정) → route-sig-mismatch',
+        phase: 'early',
+        setup: () => mockRouteSignature.mockReturnValueOnce(null),
+        reason: 'revalidate-route-sig-mismatch',
+      },
+      {
+        name: 'stationName이 waypoint 시퀀스에 없음 → waypoint-mismatch',
+        phase: 'early',
+        setup: () => mockResolveAllTargets.mockReturnValueOnce([{ name: '시청' }, { name: '서울역' }]),
+        reason: 'revalidate-waypoint-mismatch',
+      },
+    ])('$name → 적재 + 상태 갱신 skip', async ({ phase, setup, reason }) => {
+      setup();
 
-    it('등록된 bl sig가 null이면 sig-mismatch로 분류', async () => {
-      mockGetRegisteredBlRouteSig.mockResolvedValueOnce(null);
-
-      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
-
-      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
-        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
-      );
-      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
-    });
-
-    it('현재 sig가 null(route/destination 미설정)이면 sig-mismatch로 분류', async () => {
-      mockRouteSignature.mockReturnValueOnce(null);
-
-      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
-
-      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
-        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
-      );
-    });
-
-    it('stationName이 현재 waypoint 시퀀스에 없으면 waypoint-mismatch + skip', async () => {
-      mockResolveAllTargets.mockReturnValueOnce([{ name: '시청' }, { name: '서울역' }]);
-
-      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+      await reconcileScheduledAlarmDelivery(blChannel.id(phase, '강남'));
 
       expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
-        reason: 'revalidate-waypoint-mismatch',
+        reason,
         stationName: '강남',
-        phaseId: 'early',
+        phaseId: phase,
       });
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
       expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
@@ -742,7 +742,7 @@ describe('bl: fire-time 재검증 (#1282)', () => {
       // "bl:T-100:0:bad:강남" — phase가 'bad'라 parseBoardingLockAlarmIdentifier가 null 반환.
       await reconcileScheduledAlarmDelivery('bl:T-100:0:bad:강남');
 
-      expect(mockGetRegisteredBlRouteSig).not.toHaveBeenCalled();
+      expect(blChannel.registeredSigMock).not.toHaveBeenCalled();
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
     });
 
@@ -752,7 +752,7 @@ describe('bl: fire-time 재검증 (#1282)', () => {
         'subway-now:route': ROUTE_JSON,
       });
 
-      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:강남');
+      await reconcileScheduledAlarmDelivery(blChannel.id('early', '강남'));
 
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
       expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
@@ -762,15 +762,15 @@ describe('bl: fire-time 재검증 (#1282)', () => {
   describe('drainDeliveredScheduledAlarms — `bl:` 항목 재검증', () => {
     it('suppress된 bl 항목은 fired set/lastStationName 갱신에서 제외된다', async () => {
       // 첫 bl은 sig-mismatch로 suppress, 두 번째 bl은 pass.
-      mockGetRegisteredBlRouteSig
+      blChannel.registeredSigMock
         .mockResolvedValueOnce('SIG-OLD')
         .mockResolvedValueOnce('SIG-A');
       mockRouteSignature
         .mockReturnValueOnce('SIG-NEW')
         .mockReturnValueOnce('SIG-A');
       mockGetPresented.mockResolvedValueOnce([
-        { date: 1, request: { identifier: 'bl:T-100:0:early:잘못된역' } },
-        { date: 2, request: { identifier: 'bl:T-100:0:imminent:강남' } },
+        { date: 1, request: { identifier: blChannel.id('early', '잘못된역') } },
+        { date: 2, request: { identifier: blChannel.id('imminent', '강남') } },
       ]);
       mockGetFiredAlarms.mockResolvedValueOnce(new Set());
 
@@ -786,10 +786,10 @@ describe('bl: fire-time 재검증 (#1282)', () => {
     });
 
     it('모든 bl 항목이 suppress면 fired set/lastStationName 모두 갱신 안 함', async () => {
-      mockGetRegisteredBlRouteSig.mockResolvedValue(null);
+      blChannel.registeredSigMock.mockResolvedValue(null);
       mockGetPresented.mockResolvedValueOnce([
-        { date: 1, request: { identifier: 'bl:T-100:0:early:A' } },
-        { date: 2, request: { identifier: 'bl:T-100:0:imminent:B' } },
+        { date: 1, request: { identifier: blChannel.id('early', 'A') } },
+        { date: 2, request: { identifier: blChannel.id('imminent', 'B') } },
       ]);
 
       const handle = registerScheduledAlarmListener();
@@ -800,31 +800,19 @@ describe('bl: fire-time 재검증 (#1282)', () => {
       handle.remove();
     });
 
-    it('`alarm:` 항목은 bl 재검증과 무관하게 그대로 통과한다 — regression 방지', async () => {
-      mockGetPresented.mockResolvedValueOnce([
-        { date: 1, request: { identifier: 'alarm:early:강남' } },
-      ]);
+    // 다른 prefix는 bl 재검증을 거치지 않아야 한다 — regression 방지를 it.each로 통합.
+    it.each([
+      { prefix: 'alarm:', identifier: 'alarm:early:강남' },
+      { prefix: 'tba:', identifier: 'tba:early:강남' },
+    ])('`$prefix` 항목은 bl 재검증과 무관하게 처리된다 — regression 방지', async ({ identifier }) => {
+      mockGetPresented.mockResolvedValueOnce([{ date: 1, request: { identifier } }]);
       mockGetFiredAlarms.mockResolvedValueOnce(new Set());
 
       const handle = registerScheduledAlarmListener();
       await awaitInitialScheduledAlarmDrain();
 
       expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
-      expect(mockGetRegisteredBlRouteSig).not.toHaveBeenCalled();
-      handle.remove();
-    });
-
-    it('`tba:` 항목은 bl 재검증과 무관하게 tba 경로로 처리된다 — regression 방지', async () => {
-      mockGetPresented.mockResolvedValueOnce([
-        { date: 1, request: { identifier: 'tba:early:강남' } },
-      ]);
-      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
-
-      const handle = registerScheduledAlarmListener();
-      await awaitInitialScheduledAlarmDrain();
-
-      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
-      expect(mockGetRegisteredBlRouteSig).not.toHaveBeenCalled();
+      expect(blChannel.registeredSigMock).not.toHaveBeenCalled();
       handle.remove();
     });
   });

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
 import { resolveAllTargets, type AlarmEvent, type CurrentTarget } from './stationAlarm';
 import { isSameStationName, type Route } from '../../../shared/utils/stationRoute';
@@ -15,6 +16,7 @@ import { createLogger } from '../../../shared/utils/logger';
 import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
 import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
 import { logSuppressedSleepFirstTransfer } from './alarmLog';
+import { BOARDING_LOCK_ROUTE_SIG_KEY } from '../../../shared/constants/storageKeys';
 
 const logger = createLogger('BoardingLockScheduler');
 
@@ -305,11 +307,13 @@ export async function cancelAllHopsForLock(lock: BoardingLock): Promise<void> {
   const current = await getScheduledNotificationIds();
   const lockPrefix = `${BOARDING_LOCK_ALARM_PREFIX}${lock.trainCode}:`;
   const toCancel = current.filter((id) => id.startsWith(lockPrefix));
-  if (toCancel.length === 0) return;
-
-  await cancelAndDismiss(toCancel);
-  await removeScheduledNotificationIds(toCancel);
-  logger.info(`cancelled ${toCancel.length} alarms for lock ${lock.trainCode}`);
+  if (toCancel.length > 0) {
+    await cancelAndDismiss(toCancel);
+    await removeScheduledNotificationIds(toCancel);
+    logger.info(`cancelled ${toCancel.length} alarms for lock ${lock.trainCode}`);
+  }
+  // #1282: sig를 항상 clear — 잔여 OS 발사 분이 receiver gate를 통과하지 않도록.
+  await clearRegisteredBlRouteSig();
 }
 
 /**
@@ -327,6 +331,8 @@ export async function purgeBoardingLockSchedulerQueue(): Promise<void> {
   // (TRIP_BOUND_CLEANUPS)가 SCHEDULED_NOTIFICATIONS_KEY removal을 본 함수로 위임하므로,
   // empty case에서도 key가 존재할 수 있다(legacy 잔여 등) — 멱등 보장.
   await clearScheduledNotificationIds();
+  // #1282: sig도 함께 정리 — trip 종료 후 잔여 OS 발사가 receiver gate를 통과하지 않도록.
+  await clearRegisteredBlRouteSig();
 }
 
 export interface AdvanceHopWindowParams {
@@ -521,6 +527,40 @@ export async function rescheduleHopForLock(
     `reschedule done: trainCode=${lock.trainCode} nextStation=${nextStation} cancelled=${idsToCancel.length} scheduled=${newIds.length} newArrivalMs=${newArrivalMs}`,
   );
   return { cancelled: idsToCancel.length, scheduled: newIds.length };
+}
+
+/**
+ * #1282 — `bl:` 알람 예약 시점의 route signature 영속화 SSOT.
+ *
+ * `tba:` 채널의 setRegisteredTripRouteSig(tripBoundScheduler.ts)와 동형.
+ * useBoardingLockScheduler가 scheduleHopsForLock 성공 직후 write,
+ * cancelAllHopsForLock / purgeBoardingLockSchedulerQueue 시 clear.
+ * scheduledAlarmReceiver가 `bl:` 발사 수신 시 현재 sig와 비교해 stale 알람 억제.
+ *
+ * 모든 함수는 graceful — storage 실패는 측정 정확도만 영향, 본 흐름 무관.
+ */
+export async function setRegisteredBlRouteSig(sig: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(BOARDING_LOCK_ROUTE_SIG_KEY, sig);
+  } catch {
+    // graceful.
+  }
+}
+
+export async function getRegisteredBlRouteSig(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(BOARDING_LOCK_ROUTE_SIG_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function clearRegisteredBlRouteSig(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(BOARDING_LOCK_ROUTE_SIG_KEY);
+  } catch {
+    // graceful.
+  }
 }
 
 /**

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -87,115 +87,98 @@ function parseDestinationName(raw: string | null): string | null {
 }
 
 /**
- * `tba:` 알람의 fire-time 재검증 (#918 A3 PR2, #729 흡수).
+ * 사전 예약 알람(`tba:` / `bl:`)의 fire-time 재검증 공통 구현 (#918 A3 PR2, #729 흡수, #1282).
  *
- * OS가 예약된 시각에 발사한 trip-bound 알람이 *현재* 시점에도 유효한지 확인한다.
- * 세 조건 모두 충족해야 reconcile 진행:
- *   1) tripStart 존재 — trip이 종료되지 않았다.
+ * OS가 예약된 시각에 발사한 알람이 *현재* 시점에도 유효한지 확인한다. 두 채널이 동일한
+ * route-sig + waypoint 검증을 공유하므로 단일 헬퍼로 추출하고, 채널별 차이만 인자로 분리한다:
+ *   - `requireTripStart`: `tba:`는 tripStart 존재를 선행 게이트로 요구한다(`true`). `bl:`은 lock
+ *     scheduler가 SSOT이라 tripStart 게이트가 불필요하므로 `false`.
+ *   - `getRegisteredSig`: 채널의 예약 시점 route-sig 영속화 getter.
+ *
+ * 검증 순서:
+ *   1) (requireTripStart 시) tripStart 존재 — trip이 종료되지 않았다.
  *   2) ROUTE_KEY/DESTINATION_KEY 기반 현재 sig가 등록 시점 sig와 동일 — 목적지/환승 변경 없음.
  *   3) 파싱된 stationName이 현재 route waypoint 시퀀스 안에 있음 — 방어 검증.
  *
  * 한 가지라도 실패하면 reason과 함께 alarmLog에 적재하고 'suppress'를 반환한다.
  * 호출자는 fired set / lastStationName 갱신을 skip해 stale 알람이 후속 상태를 오염시키지 않게 한다.
  */
-async function revalidateTbaAlarm(parsed: {
-  phaseId: string;
-  stationName: string;
-}): Promise<'pass' | 'suppress'> {
+type RevalidationSuppressReason = Parameters<typeof logSuppressedTbaRevalidation>[0]['reason'];
+
+async function revalidatePrescheduledAlarm(
+  parsed: { phaseId: string; stationName: string },
+  options: {
+    requireTripStart: boolean;
+    getRegisteredSig: () => Promise<string | null>;
+  },
+): Promise<'pass' | 'suppress'> {
   // phaseId는 'early'/'imminent' 둘 중 하나 — alarmLog에는 그대로 통과시켜도 안전.
   const phaseId = parsed.phaseId as AlarmPhaseId;
-
-  const tripStart = await getTripStartedAt();
-  if (tripStart === null) {
-    logSuppressedTbaRevalidation({
-      reason: 'revalidate-no-trip',
-      stationName: parsed.stationName,
-      phaseId,
-    });
+  const suppress = (reason: RevalidationSuppressReason): 'suppress' => {
+    logSuppressedTbaRevalidation({ reason, stationName: parsed.stationName, phaseId });
     return 'suppress';
+  };
+
+  if (options.requireTripStart && (await getTripStartedAt()) === null) {
+    return suppress('revalidate-no-trip');
   }
 
   const [routeRaw, destRaw, registeredSig] = await Promise.all([
     AsyncStorage.getItem(ROUTE_KEY),
     AsyncStorage.getItem(DESTINATION_KEY),
-    getRegisteredTripRouteSig(),
+    options.getRegisteredSig(),
   ]);
   const route: Route = safeParseRoute(routeRaw);
   const destinationName = parseDestinationName(destRaw);
   const currentSig = routeSignature(route, destinationName);
 
   // registeredSig 부재 / 현재 sig 미산출 / 두 값 불일치 모두 mismatch로 묶는다.
-  // (registeredSig 부재는 cancelTripBoundAlarms 직후 잔여 OS 발사 케이스.)
+  // (registeredSig 부재는 cancel* 직후 잔여 OS 발사 케이스.)
   if (registeredSig === null || currentSig === null || registeredSig !== currentSig) {
-    logSuppressedTbaRevalidation({
-      reason: 'revalidate-route-sig-mismatch',
-      stationName: parsed.stationName,
-      phaseId,
-    });
-    return 'suppress';
+    return suppress('revalidate-route-sig-mismatch');
   }
 
   // 방어 검증: parsed stationName이 현재 waypoint 시퀀스에 존재해야 한다.
   // currentSig !== null이면 route, destinationName 둘 다 non-null 보장됨.
   const targets = resolveAllTargets(route as NonNullable<Route>, destinationName as string);
   if (!targets.some((t) => t.name === parsed.stationName)) {
-    logSuppressedTbaRevalidation({
-      reason: 'revalidate-waypoint-mismatch',
-      stationName: parsed.stationName,
-      phaseId,
-    });
-    return 'suppress';
+    return suppress('revalidate-waypoint-mismatch');
   }
 
   return 'pass';
 }
 
-/**
- * `bl:` 알람의 fire-time 재검증 (#1282).
- *
- * `tba:` 채널의 revalidateTbaAlarm과 동형. `bl:` 알람이 OS에서 발사됐을 때
- * 현재 trip의 route-sig가 예약 시점 sig와 일치하는지 확인한다.
- * 일치하지 않으면 route 변경 후 남은 stale 알람이므로 suppress.
- *
- * 조건: getRegisteredBlRouteSig()가 null이거나 현재 sig와 불일치면 suppress.
- * (null은 cancelAllHopsForLock/purgeBoardingLockSchedulerQueue가 clear한 직후 OS 잔여 발사 케이스.)
- */
-async function revalidateBlAlarm(parsed: {
+/** `tba:` 알람 재검증 — tripStart 게이트 + trip-bound sig (#918 A3 PR2, #729 흡수). */
+function revalidateTbaAlarm(parsed: {
   phaseId: string;
   stationName: string;
 }): Promise<'pass' | 'suppress'> {
-  const phaseId = parsed.phaseId as AlarmPhaseId;
+  return revalidatePrescheduledAlarm(parsed, {
+    requireTripStart: true,
+    getRegisteredSig: getRegisteredTripRouteSig,
+  });
+}
 
-  const [routeRaw, destRaw, registeredSig] = await Promise.all([
-    AsyncStorage.getItem(ROUTE_KEY),
-    AsyncStorage.getItem(DESTINATION_KEY),
-    getRegisteredBlRouteSig(),
-  ]);
-  const route: Route = safeParseRoute(routeRaw);
-  const destinationName = parseDestinationName(destRaw);
-  const currentSig = routeSignature(route, destinationName);
+/** `bl:` 알람 재검증 — lock SSOT이라 tripStart 게이트 없음 + boarding-lock sig (#1282). */
+function revalidateBlAlarm(parsed: {
+  phaseId: string;
+  stationName: string;
+}): Promise<'pass' | 'suppress'> {
+  return revalidatePrescheduledAlarm(parsed, {
+    requireTripStart: false,
+    getRegisteredSig: getRegisteredBlRouteSig,
+  });
+}
 
-  if (registeredSig === null || currentSig === null || registeredSig !== currentSig) {
-    logSuppressedTbaRevalidation({
-      reason: 'revalidate-route-sig-mismatch',
-      stationName: parsed.stationName,
-      phaseId,
-    });
-    return 'suppress';
-  }
-
-  // 방어 검증: parsed stationName이 현재 waypoint 시퀀스에 존재해야 한다.
-  const targets = resolveAllTargets(route as NonNullable<Route>, destinationName as string);
-  if (!targets.some((t) => t.name === parsed.stationName)) {
-    logSuppressedTbaRevalidation({
-      reason: 'revalidate-waypoint-mismatch',
-      stationName: parsed.stationName,
-      phaseId,
-    });
-    return 'suppress';
-  }
-
-  return 'pass';
+/**
+ * prefix별 사전 예약 알람 재검증 디스패처. `alarm:`은 BoardingLock scheduler cancel/reschedule이
+ * SSOT이므로 재검증 없이 'pass'. `tba:` / `bl:`만 채널별 게이트를 거친다.
+ * reconcile 단건/ drain batch 두 호출자가 공유한다.
+ */
+function revalidateByPrefix(parsed: ParsedAlarmIdentifier): Promise<'pass' | 'suppress'> {
+  if (parsed.prefix === 'tba') return revalidateTbaAlarm(parsed);
+  if (parsed.prefix === 'bl') return revalidateBlAlarm(parsed);
+  return Promise.resolve('pass');
 }
 
 /**
@@ -222,12 +205,7 @@ export async function reconcileScheduledAlarmDelivery(
   const parsed = parseAlarmIdentifier(identifier);
   if (!parsed) return;
 
-  if (parsed.prefix === 'tba' && (await revalidateTbaAlarm(parsed)) === 'suppress') {
-    return;
-  }
-  if (parsed.prefix === 'bl' && (await revalidateBlAlarm(parsed)) === 'suppress') {
-    return;
-  }
+  if ((await revalidateByPrefix(parsed)) === 'suppress') return;
 
   const destinationId = await getCurrentDestinationId();
   // destinationId가 없으면 이미 trip이 종료/변경된 알람의 잔여 발화 — 상태 갱신 스킵.
@@ -268,8 +246,7 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
   for (const n of presented) {
     const parsed = parseAlarmIdentifier(n.request.identifier);
     if (!parsed) continue;
-    if (parsed.prefix === 'tba' && (await revalidateTbaAlarm(parsed)) === 'suppress') continue;
-    if (parsed.prefix === 'bl' && (await revalidateBlAlarm(parsed)) === 'suppress') continue;
+    if ((await revalidateByPrefix(parsed)) === 'suppress') continue;
     accepted.push(parsed);
   }
 

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -17,7 +17,12 @@ import {
 } from './tripBoundScheduler';
 import { getTripStartedAt } from './tripStartStorage';
 import { resolveAllTargets } from './stationAlarm';
-import { routeSignature } from './boardingLockScheduler';
+import {
+  parseBoardingLockAlarmIdentifier,
+  routeSignature,
+  getRegisteredBlRouteSig,
+  BOARDING_LOCK_ALARM_PREFIX,
+} from './boardingLockScheduler';
 import { logSuppressedTbaRevalidation } from './alarmLog';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { AlarmPhaseId } from './alarmPhases';
@@ -40,16 +45,20 @@ async function getCurrentDestinationId(): Promise<string | null> {
 }
 
 interface ParsedAlarmIdentifier {
-  prefix: 'alarm' | 'tba';
+  prefix: 'alarm' | 'tba' | 'bl';
   phaseId: string;
   stationName: string;
 }
 
 /**
- * `alarm:` / `tba:` 두 prefix 단일 진입점 (#918 A3 PR2).
- * 두 경로의 phaseId/stationName 추출 로직이 같으므로 호출자는 prefix 분기만 본다.
+ * `alarm:` / `tba:` / `bl:` 세 prefix 단일 진입점 (#918 A3 PR2, #1282).
+ * 세 경로의 phaseId/stationName 추출 로직이 같으므로 호출자는 prefix 분기만 본다.
  */
 function parseAlarmIdentifier(identifier: string): ParsedAlarmIdentifier | null {
+  if (identifier.startsWith(BOARDING_LOCK_ALARM_PREFIX)) {
+    const p = parseBoardingLockAlarmIdentifier(identifier);
+    return p ? { prefix: 'bl', phaseId: p.phase, stationName: p.stationName } : null;
+  }
   if (identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) {
     const p = parseTripBoundAlarmIdentifier(identifier);
     return p ? { prefix: 'tba', phaseId: p.phaseId, stationName: p.stationName } : null;
@@ -142,7 +151,55 @@ async function revalidateTbaAlarm(parsed: {
 }
 
 /**
- * 사전 예약된 `alarm:` / `tba:` 알림이 OS에 의해 발사된 직후 클라이언트 상태를 갱신한다.
+ * `bl:` 알람의 fire-time 재검증 (#1282).
+ *
+ * `tba:` 채널의 revalidateTbaAlarm과 동형. `bl:` 알람이 OS에서 발사됐을 때
+ * 현재 trip의 route-sig가 예약 시점 sig와 일치하는지 확인한다.
+ * 일치하지 않으면 route 변경 후 남은 stale 알람이므로 suppress.
+ *
+ * 조건: getRegisteredBlRouteSig()가 null이거나 현재 sig와 불일치면 suppress.
+ * (null은 cancelAllHopsForLock/purgeBoardingLockSchedulerQueue가 clear한 직후 OS 잔여 발사 케이스.)
+ */
+async function revalidateBlAlarm(parsed: {
+  phaseId: string;
+  stationName: string;
+}): Promise<'pass' | 'suppress'> {
+  const phaseId = parsed.phaseId as AlarmPhaseId;
+
+  const [routeRaw, destRaw, registeredSig] = await Promise.all([
+    AsyncStorage.getItem(ROUTE_KEY),
+    AsyncStorage.getItem(DESTINATION_KEY),
+    getRegisteredBlRouteSig(),
+  ]);
+  const route: Route = safeParseRoute(routeRaw);
+  const destinationName = parseDestinationName(destRaw);
+  const currentSig = routeSignature(route, destinationName);
+
+  if (registeredSig === null || currentSig === null || registeredSig !== currentSig) {
+    logSuppressedTbaRevalidation({
+      reason: 'revalidate-route-sig-mismatch',
+      stationName: parsed.stationName,
+      phaseId,
+    });
+    return 'suppress';
+  }
+
+  // 방어 검증: parsed stationName이 현재 waypoint 시퀀스에 존재해야 한다.
+  const targets = resolveAllTargets(route as NonNullable<Route>, destinationName as string);
+  if (!targets.some((t) => t.name === parsed.stationName)) {
+    logSuppressedTbaRevalidation({
+      reason: 'revalidate-waypoint-mismatch',
+      stationName: parsed.stationName,
+      phaseId,
+    });
+    return 'suppress';
+  }
+
+  return 'pass';
+}
+
+/**
+ * 사전 예약된 `alarm:` / `tba:` / `bl:` 알림이 OS에 의해 발사된 직후 클라이언트 상태를 갱신한다.
  * 사전 예약 알람은 클라이언트 콜백을 거치지 않으므로(`alarmScheduler.ts`), 이 함수가
  * FG/BG 양쪽 발화 모두에 대한 상태 동기화 단일 진입점이다.
  *
@@ -166,6 +223,9 @@ export async function reconcileScheduledAlarmDelivery(
   if (!parsed) return;
 
   if (parsed.prefix === 'tba' && (await revalidateTbaAlarm(parsed)) === 'suppress') {
+    return;
+  }
+  if (parsed.prefix === 'bl' && (await revalidateBlAlarm(parsed)) === 'suppress') {
     return;
   }
 
@@ -203,11 +263,13 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
   // #918 A3 PR2 — `tba:` 항목은 발사 시점 재검증을 거친다. suppress인 경우 fired set /
   // lastStationName 갱신에 포함하지 않아 stale 알람이 후속 상태(BG arrival 기준역 등)를 오염시키지
   // 않게 한다. `alarm:` 경로는 기존 BoardingLock SSOT을 신뢰해 통과.
+  // #1282 — `bl:` 항목도 동일하게 route-sig 재검증을 거친다.
   const accepted: ParsedAlarmIdentifier[] = [];
   for (const n of presented) {
     const parsed = parseAlarmIdentifier(n.request.identifier);
     if (!parsed) continue;
     if (parsed.prefix === 'tba' && (await revalidateTbaAlarm(parsed)) === 'suppress') continue;
+    if (parsed.prefix === 'bl' && (await revalidateBlAlarm(parsed)) === 'suppress') continue;
     accepted.push(parsed);
   }
 

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -113,6 +113,12 @@ export const LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY =
 // useTripBoundAlarmScheduler가 preschedule 성공 직후 write, cancel 시 clear.
 // 형식: string (boardingLockScheduler.routeSignature 결과).
 export const TRIP_BOUND_ROUTE_SIG_KEY = 'subway-now:trip-bound-route-sig';
+// #1282 — boardingLockScheduler가 `bl:` 알람 예약 시 스냅샷하는 route signature.
+// `tba:` 채널의 TRIP_BOUND_ROUTE_SIG_KEY와 동형. scheduledAlarmReceiver가 `bl:` 발사
+// 수신 시 현재 route sig와 비교해 stale 알람을 억제한다.
+// useBoardingLockScheduler가 scheduleHopsForLock 성공 직후 write, cancel 시 clear.
+// 형식: string (boardingLockScheduler.routeSignature 결과).
+export const BOARDING_LOCK_ROUTE_SIG_KEY = 'subway-now:boarding-lock-route-sig';
 // #828 — Phase 1+2 fusion wire — active trip의 boarding line code.
 // BG/FG location task가 좌표 upload 시 이 line으로 linePolyline snap을 수행해
 // `mapMatchedArcM` + `mapMatchedLine`을 backend에 첨부한다.


### PR DESCRIPTION
## Summary

- `scheduledAlarmReceiver`에 `bl:` prefix 재검증 게이트 추가 — `tba:` 경로와 동형. route-sig mismatch 시 stale `bl:` 발사가 `firedAlarms`/`lastStationName`을 오염시키지 않도록 억제
- `boardingLockScheduler`에 `BOARDING_LOCK_ROUTE_SIG_KEY` 영속화 3-함수 추가 (`set/get/clearRegisteredBlRouteSig`)
- `cancelAllHopsForLock` / `purgeBoardingLockSchedulerQueue` — `bl:` alarms cancel 시 route-sig key도 함께 clear
- `useBoardingLockScheduler` — `scheduleHopsForLock` 성공 직후 `setRegisteredBlRouteSig`; `needsRouteChangeReschedule` 시 `clearFiredAlarms` 호출(feedback #8 re-fire 방지)

**Verified**: `bl:` identifiers were previously returning `null` from `parseAlarmIdentifier` (only handled `alarm:` and `tba:`), so they bypassed all reconcile state updates. Now they go through proper route-sig revalidation.

## Test plan

- [ ] `scheduledAlarmReceiver.test.ts`: `bl:` pass/suppress 재검증 케이스 (route-sig mismatch, waypoint mismatch, format corrupt, drain suppress)
- [ ] `boardingLockScheduler.test.ts`: `setRegisteredBlRouteSig`/`getRegisteredBlRouteSig`/`clearRegisteredBlRouteSig` 단위; `cancelAllHopsForLock`/`purgeBoardingLockSchedulerQueue` cleanup 통합
- [ ] `useBoardingLockScheduler.test.tsx`: `setRegisteredBlRouteSig` schedule 직후 호출; route-sig 변경 시 `clearFiredAlarms` 호출; trainCode 변경 시 `clearFiredAlarms` 미호출
- [ ] 100% coverage on all modified files
- [ ] No regression to `tba:` or `alarm:` handling (explicit regression tests added)

Closes #1282