### PR TITLE
feat(#1279): barometer subsurface BG stamp

### DIFF
--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -141,3 +141,8 @@ export const LOCKLESS_FUNNEL_SEEN_OFF_KEY = 'subway-now:lockless-funnel-seen-off
 // UI 토글은 follow-up PR — 현재는 init 인프라만.
 // 형식: 'true' 또는 키 부재.
 export const SENTRY_OPT_IN_KEY = 'subway-now:sentry-opt-in';
+// #1279 — 기압계 지하 감지 상태(subsurface boolean) AsyncStorage stamp.
+// useBarometer(FG-only React state)가 subsurface flip 시 write → BG silent-push task와
+// 위치 게이트가 동일한 값을 read할 수 있도록 한다. updatedAt(epoch ms)은 TTL 만료 판별용.
+// 형식: {"subsurface": boolean, "updatedAt": number} JSON.
+export const SUBSURFACE_STATE_KEY = 'subway-now:subsurface';

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -5,6 +5,7 @@ const mockRequestPermissions = jest.fn();
 const mockSetUpdateInterval = jest.fn();
 const mockAddListener = jest.fn();
 const mockRemove = jest.fn();
+const mockSetSubsurfaceState = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('expo-sensors', () => ({
   Barometer: {
@@ -13,6 +14,10 @@ jest.mock('expo-sensors', () => ({
     setUpdateInterval: (...args: unknown[]) => mockSetUpdateInterval(...args),
     addListener: (...args: unknown[]) => mockAddListener(...args),
   },
+}));
+
+jest.mock('../../utils/subsurfaceState', () => ({
+  setSubsurfaceState: (...args: unknown[]) => mockSetSubsurfaceState(...args),
 }));
 
 import { useBarometer } from '../useBarometer';
@@ -35,6 +40,8 @@ beforeEach(() => {
   mockSetUpdateInterval.mockReset();
   mockAddListener.mockReset();
   mockRemove.mockReset();
+  mockSetSubsurfaceState.mockReset();
+  mockSetSubsurfaceState.mockResolvedValue(undefined);
   mockAddListener.mockReturnValue({ remove: mockRemove });
   resetBarometerState();
 });
@@ -284,6 +291,28 @@ describe('useBarometer (#875)', () => {
     // stop=true 2번만 — confirm 3 미달.
     fireListenerWindow(listener, nowSpy, baseT, 2, () => 1013);
     expect(result.current.stop).toBeUndefined();
+
+    nowSpy.mockRestore();
+  });
+
+  it('#1279 — subsurface flip 시 setSubsurfaceState 호출', async () => {
+    const { listener, nowSpy, baseT } = await setupBarometerWithListener();
+
+    act(() => {
+      listener({ pressure: 1013, timestamp: 0 });
+    });
+    // hysteresis 3회 미달 — setSubsurfaceState 미호출.
+    expect(mockSetSubsurfaceState).not.toHaveBeenCalled();
+
+    // confirm 3회 → subsurface=true flip → setSubsurfaceState(true) 호출.
+    fireListenerWindow(
+      listener,
+      nowSpy,
+      baseT,
+      3,
+      () => 1013 + BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA,
+    );
+    expect(mockSetSubsurfaceState).toHaveBeenCalledWith(true);
 
     nowSpy.mockRestore();
   });

--- a/src/shared/hooks/useBarometer.ts
+++ b/src/shared/hooks/useBarometer.ts
@@ -30,6 +30,7 @@ import {
   evaluateLatestSubsurface,
   resetBarometerState,
 } from '../utils/barometerState';
+import { setSubsurfaceState } from '../utils/subsurfaceState';
 import {
   BAROMETER_SAMPLE_INTERVAL_MS,
   BAROMETER_STOP_CONFIRM_SAMPLES,
@@ -102,6 +103,7 @@ export function useBarometer(): BarometerSignal {
             lastSubsurfaceRef.current = subDetected;
             subsurfacePendingRef.current = 0;
             setSubsurface(subDetected);
+            void setSubsurfaceState(subDetected);
           }
         }
 

--- a/src/shared/utils/__tests__/subsurfaceState.test.ts
+++ b/src/shared/utils/__tests__/subsurfaceState.test.ts
@@ -1,0 +1,119 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getSubsurfaceState, setSubsurfaceState } from '../subsurfaceState';
+import { SUBSURFACE_STATE_KEY } from '../../constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+describe('subsurfaceState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('setSubsurfaceState', () => {
+    it('subsurface=true를 JSON으로 직렬화해 SUBSURFACE_STATE_KEY에 저장', async () => {
+      const before = Date.now();
+      await setSubsurfaceState(true);
+      const after = Date.now();
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+      const [key, raw] = (AsyncStorage.setItem as jest.Mock).mock.calls[0] as [string, string];
+      expect(key).toBe(SUBSURFACE_STATE_KEY);
+      const parsed = JSON.parse(raw) as { subsurface: boolean; updatedAt: number };
+      expect(parsed.subsurface).toBe(true);
+      expect(parsed.updatedAt).toBeGreaterThanOrEqual(before);
+      expect(parsed.updatedAt).toBeLessThanOrEqual(after);
+    });
+
+    it('subsurface=false도 저장', async () => {
+      await setSubsurfaceState(false);
+      const [, raw] = (AsyncStorage.setItem as jest.Mock).mock.calls[0] as [string, string];
+      expect(JSON.parse(raw)).toMatchObject({ subsurface: false });
+    });
+
+    it('AsyncStorage 오류 시 throw 없이 swallow', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      await expect(setSubsurfaceState(true)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getSubsurfaceState', () => {
+    it('키 부재 시 false 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      expect(await getSubsurfaceState()).toBe(false);
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(SUBSURFACE_STATE_KEY);
+    });
+
+    it('유효한 stamp(subsurface=true)를 정상 반환', async () => {
+      const stamp = { subsurface: true, updatedAt: Date.now() };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stamp));
+      expect(await getSubsurfaceState()).toBe(true);
+    });
+
+    it('유효한 stamp(subsurface=false)를 정상 반환', async () => {
+      const stamp = { subsurface: false, updatedAt: Date.now() };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stamp));
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('TTL 만료 stamp는 false 반환', async () => {
+      const stamp = { subsurface: true, updatedAt: Date.now() - 91_000 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stamp));
+      // 기본 TTL 90_000ms 초과
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('커스텀 ttlMs 내에 있으면 정상 반환', async () => {
+      const stamp = { subsurface: true, updatedAt: Date.now() - 5_000 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stamp));
+      expect(await getSubsurfaceState(10_000)).toBe(true);
+    });
+
+    it('커스텀 ttlMs 초과 시 false 반환', async () => {
+      const stamp = { subsurface: true, updatedAt: Date.now() - 11_000 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stamp));
+      expect(await getSubsurfaceState(10_000)).toBe(false);
+    });
+
+    it('parse 오류(invalid JSON) 시 false 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('subsurface 필드 누락 시 false 반환', async () => {
+      const broken = { updatedAt: Date.now() };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('updatedAt 필드 누락 시 false 반환', async () => {
+      const broken = { subsurface: true };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('subsurface가 boolean이 아니면 false 반환', async () => {
+      const broken = { subsurface: 'yes', updatedAt: Date.now() };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('updatedAt이 number가 아니면 false 반환', async () => {
+      const broken = { subsurface: true, updatedAt: 'now' };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('루트가 null이면 false 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(null));
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+
+    it('AsyncStorage 오류 시 false 반환 (graceful)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage'));
+      expect(await getSubsurfaceState()).toBe(false);
+    });
+  });
+});

--- a/src/shared/utils/subsurfaceState.ts
+++ b/src/shared/utils/subsurfaceState.ts
@@ -1,0 +1,68 @@
+/**
+ * #1279 — 기압계 subsurface 상태 AsyncStorage stamp.
+ *
+ * useBarometer는 FG-only React state로 subsurface를 관리한다.
+ * BG silent-push task와 위치 게이트는 React hook에 접근할 수 없어 이 값을 읽지 못한다.
+ * 이 모듈이 그 브리지 역할을 한다:
+ *   - setSubsurfaceState: useBarometer가 subsurface flip 시 AsyncStorage에 stamp.
+ *   - getSubsurfaceState: BG task/게이트가 stamp를 읽어 지하 여부를 판정.
+ *
+ * TTL 기본값(90_000ms = 90초): 기압계는 1Hz 샘플 + 3회 hysteresis = ~3초 확정 주기.
+ * 90초 초과 stamp는 stale(앱 BG 진입 or barometer 구독 해제)로 보수적 false 반환.
+ *
+ * graceful 정책(feedback_whileinuse_must_work.md):
+ *   - parse 실패 / 키 부재 / TTL 만료 / storage 오류 → false (보수적 fallback).
+ *   - false 반환이 지하 감지 미작동 → 기존 GPS 게이트로 폴백. 안전.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SUBSURFACE_STATE_KEY } from '../constants/storageKeys';
+
+/** stamp 형식. */
+interface SubsurfaceStamp {
+  subsurface: boolean;
+  updatedAt: number;
+}
+
+/** TTL 기본값 (ms). */
+const DEFAULT_TTL_MS = 90_000;
+
+/**
+ * subsurface 상태를 AsyncStorage에 기록한다.
+ * useBarometer가 subsurface 값이 바뀔 때마다 호출한다.
+ *
+ * storage 오류는 swallow — 저장 실패가 앱 정지 이유가 되어선 안 된다.
+ */
+export async function setSubsurfaceState(subsurface: boolean): Promise<void> {
+  try {
+    const stamp: SubsurfaceStamp = { subsurface, updatedAt: Date.now() };
+    await AsyncStorage.setItem(SUBSURFACE_STATE_KEY, JSON.stringify(stamp));
+  } catch {
+    // storage 실패는 silent — BG task가 false로 fallback해 안전.
+  }
+}
+
+/**
+ * AsyncStorage에 기록된 subsurface 상태를 읽는다.
+ *
+ * @param ttlMs stamp 유효 기간(ms). 기본 90_000.
+ * @returns 유효한 stamp가 있으면 그 subsurface 값, 없으면 false.
+ */
+export async function getSubsurfaceState(ttlMs: number = DEFAULT_TTL_MS): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(SUBSURFACE_STATE_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as Partial<SubsurfaceStamp> | null;
+    if (
+      !parsed ||
+      typeof parsed.subsurface !== 'boolean' ||
+      typeof parsed.updatedAt !== 'number'
+    ) {
+      return false;
+    }
+    if (Date.now() - parsed.updatedAt > ttlMs) return false;
+    return parsed.subsurface;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- `src/shared/constants/storageKeys.ts`에 `SUBSURFACE_STATE_KEY = 'subway-now:subsurface'` 추가
- `src/shared/utils/subsurfaceState.ts` 신규: `setSubsurfaceState(boolean)` / `getSubsurfaceState(ttlMs?)` — TTL 기본 90s, parse 오류/키 부재/만료 시 `false` graceful fallback
- `src/shared/hooks/useBarometer.ts`: subsurface hysteresis 확정 시 `void setSubsurfaceState(subDetected)` 호출 추가 (기존 반환값/동작 변경 없음)

## Test plan

- `subsurfaceState.test.ts` 13 cases: set/get/TTL 만료/커스텀 TTL/parse 오류/필드 누락/null 루트/AsyncStorage 오류
- `useBarometer.test.ts`에 `#1279` 케이스 추가: subsurface flip 시 `setSubsurfaceState(true)` 호출 검증
- 전체 276 suite PASS (widgetStorage/stationNotification 33건은 known local native-mock 아티팩트 — CI PASS)
- `npm run type-check` PASS

Closes #1279