### PR TITLE
feat(#1286): WiFi SSID fusion 연결

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
@@ -136,6 +136,28 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
       expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
       expect(result.current.source).toBe('wifi-ssid');
     });
+
+    it('GPS userLocation=null(완전 dead)이어도 wifi-ssid 채택 — distanceKm=0', () => {
+      // 지하 GPS 완전 실패(좌표 자체 없음). wifi가 잡히면 거리 산정 없이 wifi 역 채택.
+      mockUseNearest.mockReturnValue(gpsBase({ userLocation: null, result: null }));
+      mockFindTop.mockReturnValue([]);
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: true },
+          yongmasan,
+        ),
+      );
+      expect(result.current.confidence).toBe('wifi-ssid');
+      expect(result.current.result?.station.id).toBe(yongmasan.id);
+      expect(result.current.result?.distanceKm).toBe(0);
+    });
   });
 
   describe('지상(subsurface=false) — WiFi 무시, 기존 cascade', () => {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
@@ -1,0 +1,376 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 파일은 의도적으로 여러 features의 hook/util을 조합하는
+ * orchestrator 역할이라 직접 import가 본질적이다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인 처리. 후속 PR(별도 이슈)에서 orchestration 슬라이스(예: features/fusion/, app shell)로
+ * 추출하여 disable을 제거할 예정.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #1286 — WiFi SSID fusion cascade 격리 검증.
+ *
+ * - barometerSubsurface=true + wifiStation 있음 → result = wifiStation (최우선)
+ * - barometerSubsurface=false(지상) → wifi 무시 → 기존 cascade(GPS fallback)
+ * - wifiStation=null → wifi 무시 → 기존 cascade
+ * - 환승역: boardingLock.boardingLine으로 호선 보정
+ * - 디버그: wifiSsid candidate가 entries에 기록
+ */
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../utils/findNearestStation');
+jest.mock('../../../route/utils/findActiveLines');
+jest.mock('../../utils/fusionDistanceGate', () => ({
+  passesFusionDistanceGate: () => true,
+  isWithinArcWindow: () => true,
+}));
+jest.mock('../../../route/utils/trackTrainProgress', () => ({
+  trackTrainProgress: jest.fn(() => null),
+}));
+jest.mock('../../../arrival/utils/pickCandidateTrains', () => ({
+  pickCandidateTrains: jest.fn(() => []),
+}));
+jest.mock('../../../route/utils/stationProgressEstimator', () => ({
+  arcIndexOfStation: () => -1,
+  estimateStationProgress: () => null,
+}));
+jest.mock('../../../route/utils/routeProgress', () => ({
+  computeRouteArc: () => null,
+}));
+// stationLookup: 기본적으로 null 반환하는 jest.fn()으로 mock.
+// 환승역 보정 테스트에서 mockReturnValue로 제어.
+jest.mock('../../../../shared/utils/stationLookup', () => ({
+  findStationByName: jest.fn(() => null),
+  findStationByNameAndLine: jest.fn(() => null),
+}));
+
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findActiveLines } from '../../../route/utils/findActiveLines';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationLookup';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type { Station } from '../../../../shared/types/station';
+
+const mockUseNearest = useNearestStation as jest.Mock;
+const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockUsePositions = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockFindLines = findActiveLines as jest.Mock;
+
+// 테스트에서 사용하는 WiFi 매칭 결과 역
+const yongmasan: Station = {
+  id: '7-018',
+  name: '용마산',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.58,
+  lng: 127.08,
+};
+// 환승역 — 충무로(3호선). 4호선에도 존재.
+const chungmuro3: Station = MOCK_STATIONS.chungmuro; // line='3'
+
+function gpsBase(overrides?: Record<string, unknown>) {
+  return {
+    result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+    variants: [MOCK_STATIONS.gangnam],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 1,
+    accuracyMeters: 50,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    locationUncertain: false,
+    refresh: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNearest.mockReturnValue(gpsBase());
+    mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+    mockFindLines.mockReturnValue(['2']);
+    mockUseArrival.mockReturnValue({ arrival: null, loading: false, isMock: false });
+    mockUsePositions.mockReturnValue({ positions: null, loading: false, isMock: false });
+  });
+
+  describe('지하 GPS dead zone — SSID 매칭 성공', () => {
+    it('subsurface=true + wifiStation 있음 → wifi-ssid confidence로 해당 역 채택', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: true },
+          yongmasan,
+        ),
+      );
+      expect(result.current.confidence).toBe('wifi-ssid');
+      expect(result.current.source).toBe('wifi-ssid');
+      expect(result.current.result?.station.id).toBe(yongmasan.id);
+      expect(result.current.result?.station.name).toBe(yongmasan.name);
+    });
+
+    it('subsurface=true + wifiStation → source=wifi-ssid (GPS gpsResult는 유지)', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: true },
+          yongmasan,
+        ),
+      );
+      // gpsResult는 GPS 원본 그대로
+      expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+      expect(result.current.source).toBe('wifi-ssid');
+    });
+  });
+
+  describe('지상(subsurface=false) — WiFi 무시, 기존 cascade', () => {
+    it('subsurface=false + wifiStation 있어도 GPS fallback(gps-only)', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: false },
+          yongmasan,
+        ),
+      );
+      expect(result.current.confidence).toBe('gps-only');
+      expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+    });
+
+    it('subsurface 미전달(undefined) + wifiStation 있어도 GPS fallback', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          yongmasan,
+        ),
+      );
+      expect(result.current.confidence).toBe('gps-only');
+    });
+  });
+
+  describe('SSID 미매칭(wifiStation=null) — 기존 cascade', () => {
+    it('subsurface=true + wifiStation=null → gps-only-underground (wifi 무시)', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: true },
+          null,
+        ),
+      );
+      // wifi null → #903 가드만 적용 → gps-only-underground
+      expect(result.current.confidence).toBe('gps-only-underground');
+    });
+
+    it('wifiStation 파라미터 자체 미전달 → gps-only', () => {
+      const { result } = renderHook(() => useFusedNearestStation());
+      expect(result.current.confidence).toBe('gps-only');
+    });
+  });
+
+  describe('환승역 호선 보정 — boardingLock.boardingLine', () => {
+    const mockFindByNameAndLine = findStationByNameAndLine as jest.Mock;
+
+    beforeEach(() => {
+      mockFindByNameAndLine.mockReturnValue(null);
+    });
+
+    it('wifiStation.line이 boardingLock.boardingLine과 다르면 findStationByNameAndLine으로 보정', () => {
+      // wifiSsidLookup은 충무로를 3호선으로 반환하지만, 사용자가 4호선으로 탑승 중인 상황.
+      const chungmuro4: Station = {
+        ...chungmuro3,
+        id: '0401',
+        line: '4',
+        lineColor: '#00A2D1',
+      };
+      mockFindByNameAndLine.mockReturnValue(chungmuro4);
+
+      const boardingLock = {
+        trainCode: 'T-LOCK',
+        boardingLine: '4',
+        boardingStationId: '0401',
+        boardedAt: 1000,
+      };
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          boardingLock as unknown as import('../../../../shared/types/boardingLock').BoardingLock,
+          undefined,
+          { subsurface: true },
+          chungmuro3,
+        ),
+      );
+
+      expect(mockFindByNameAndLine).toHaveBeenCalledWith('충무로', '4');
+      expect(result.current.confidence).toBe('wifi-ssid');
+      expect(result.current.result?.station.line).toBe('4');
+    });
+
+    it('boardingLock이 없으면 wifiStation.line 그대로 채택', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: true },
+          yongmasan,
+        ),
+      );
+
+      expect(mockFindByNameAndLine).not.toHaveBeenCalled();
+      expect(result.current.result?.station.line).toBe(yongmasan.line);
+    });
+
+    it('boardingLock.boardingLine === wifiStation.line이면 findStationByNameAndLine 미호출', () => {
+      const boardingLock = {
+        trainCode: 'T-LOCK',
+        boardingLine: '7',
+        boardingStationId: yongmasan.id,
+        boardedAt: 1000,
+      };
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          boardingLock as unknown as import('../../../../shared/types/boardingLock').BoardingLock,
+          undefined,
+          { subsurface: true },
+          yongmasan,
+        ),
+      );
+
+      expect(mockFindByNameAndLine).not.toHaveBeenCalled();
+      expect(result.current.result?.station.line).toBe('7');
+    });
+
+    it('findStationByNameAndLine이 null(매핑 실패)이면 wifiStation 원본 채택', () => {
+      // mockFindByNameAndLine.mockReturnValue(null) — beforeEach 기본값
+
+      const boardingLock = {
+        trainCode: 'T-LOCK',
+        boardingLine: '99',
+        boardingStationId: 'x99',
+        boardedAt: 1000,
+      };
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          boardingLock as unknown as import('../../../../shared/types/boardingLock').BoardingLock,
+          undefined,
+          { subsurface: true },
+          yongmasan,
+        ),
+      );
+
+      expect(result.current.confidence).toBe('wifi-ssid');
+      // 매핑 실패 → wifiStation 원본(line='7')
+      expect(result.current.result?.station.line).toBe('7');
+    });
+  });
+
+  describe('디버그 buffer — wifiSsid candidate 기록', () => {
+    it('wifi-ssid 채택 시 wifiSsid candidate가 fusion debug entry에 포함', () => {
+      const {
+        clearFusionDebugEntries,
+        getFusionDebugEntries,
+      } = jest.requireActual(
+        '../../utils/fusionDebugBuffer',
+      ) as typeof import('../../utils/fusionDebugBuffer');
+      clearFusionDebugEntries();
+
+      renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: true },
+          yongmasan,
+        ),
+      );
+
+      const entries = getFusionDebugEntries();
+      const last = entries[entries.length - 1];
+      expect(last.kind).toBe('fusion');
+      if (last.kind !== 'fusion') throw new Error('expected fusion entry');
+      const wifiCandidate = last.candidates.find((c) => c.key === 'wifiSsid');
+      expect(wifiCandidate).toBeDefined();
+      expect(wifiCandidate?.stationName).toBe(yongmasan.name);
+      expect(wifiCandidate?.line).toBe(yongmasan.line);
+    });
+
+    it('wifi 미채택(subsurface=false) 시 wifiSsid candidate 없음', () => {
+      const {
+        clearFusionDebugEntries,
+        getFusionDebugEntries,
+      } = jest.requireActual(
+        '../../utils/fusionDebugBuffer',
+      ) as typeof import('../../utils/fusionDebugBuffer');
+      clearFusionDebugEntries();
+
+      renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: false },
+          yongmasan,
+        ),
+      );
+
+      const entries = getFusionDebugEntries();
+      const last = entries[entries.length - 1];
+      if (last?.kind !== 'fusion') return; // entry가 없거나 다른 종류
+      const wifiCandidate = last.candidates.find((c) => c.key === 'wifiSsid');
+      expect(wifiCandidate).toBeUndefined();
+    });
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -27,6 +27,7 @@ import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../../arrival/utils/pickCandidateTrains';
 import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { haversine } from '../../../shared/utils/haversine';
+import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import {
@@ -269,6 +270,16 @@ export function useFusedNearestStation(
    * S107 회피를 위해 단일 객체로 묶었다. 어느 한 키만 줘도 됨.
    */
   barometer?: { subsurface?: boolean; signal?: BarometerSignal },
+  /**
+   * #1286 — useWifiStation이 반환한 SSID 매칭 결과.
+   * barometerSubsurface===true(지하 GPS dead zone)일 때 fusion cascade 최우선으로 채택.
+   * 지상 / no-match(null)이면 기존 cascade로 자연 fallback.
+   *
+   * 환승역 호선 해소: wifiSsidLookup은 역명으로 첫 번째 호선의 Station을 반환하므로,
+   * boardingLock.boardingLine 또는 routeContext로 호선을 보정한다.
+   * 교차 신호가 없으면 lookupStationBySsid 결과 그대로 채택(단일 호선 역 / 호선 미확정).
+   */
+  wifiStation?: Station | null,
 ): UseFusedNearestStationReturn {
   const barometerSubsurface = barometer?.subsurface;
   const barometerSignal = barometer?.signal;
@@ -491,10 +502,39 @@ export function useFusedNearestStation(
   const routePasses =
     routeResult != null && passesFusionDistanceGate({ ...gateOpts, candidate: routeResult });
 
+  // #1286 — WiFi SSID 역 매칭 → fusion cascade.
+  // barometerSubsurface===true(지하 GPS dead zone)이고 SSID 매칭이 성공했을 때 최우선 채택.
+  // wifiSsidLookup은 역명 → 첫 번째 호선 Station을 반환하므로, 환승역 호선 보정:
+  //   1) boardingLock.boardingLine — 사용자가 명시적으로 탑승한 노선 (가장 정확).
+  //   2) 해당 보정 결과가 없으면 wifiStation 그대로 사용 (단일 호선 역 or 호선 미확정).
+  // 지상(subsurface=false) 또는 SSID 무매칭(null)이면 이 블록을 건너뛰고 기존 cascade로 fallback.
+  const wifiStationResolved: NearestStationResult | null = (() => {
+    if (!barometerSubsurface || !wifiStation) return null;
+    // BoardingLock의 노선으로 환승역 호선 보정 시도.
+    const targetLine = boardingLock?.boardingLine ?? null;
+    const resolvedStation =
+      targetLine && targetLine !== wifiStation.line
+        ? (findStationByNameAndLine(wifiStation.name, targetLine) ?? wifiStation)
+        : wifiStation;
+    const distanceKm = gps.userLocation
+      ? haversine(
+          gps.userLocation.lat,
+          gps.userLocation.lng,
+          resolvedStation.lat,
+          resolvedStation.lng,
+        )
+      : 0;
+    return { station: resolvedStation, distanceKm };
+  })();
+
   let result: NearestStationResult | null;
   let confidence: FusionConfidence;
   let source: FusionSource;
-  if (positionTrainResult) {
+  if (wifiStationResolved) {
+    result = wifiStationResolved;
+    confidence = 'wifi-ssid';
+    source = 'wifi-ssid';
+  } else if (positionTrainResult) {
     result = positionTrainResult;
     // #584 PR D2: position-train의 trainNo가 BoardingLock.trainCode와 일치하면 'boarding-lock'으로 승격.
     // 사용자가 탭한 바로 그 열차가 실시간 위치 API에 잡힌 상태 — 최고 신뢰 신호.
@@ -806,6 +846,10 @@ export function useFusedNearestStation(
     if (lastDecisionKeyRef.current === decisionKey) return;
     lastDecisionKeyRef.current = decisionKey;
     const candidates: FusionCandidateMini[] = [];
+    if (wifiStationResolved) {
+      const { name, line } = wifiStationResolved.station;
+      candidates.push({ key: 'wifiSsid', stationName: name, line });
+    }
     if (positionTrainResult && trainProgress) {
       const { name, line } = positionTrainResult.station;
       // boarding-lock 매칭 근거: 어느 trainNo가 어떤 lock과 비교됐는지 사후 재구성.
@@ -860,7 +904,7 @@ export function useFusedNearestStation(
               signalsAvailable: detectionVerdict.signalsAvailable,
             },
     });
-  }, [decisionKey, source, confidence, result, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, trainProgress, lockedTrainCode, detectionVerdict]);
+  }, [decisionKey, source, confidence, result, wifiStationResolved, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, trainProgress, lockedTrainCode, detectionVerdict]);
 
   return {
     result,

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -10,7 +10,7 @@ export const FUSION_DEBUG_BUFFER_CAPACITY = 200;
 
 /** 후보 신호 — 신호원이 늘면 key를 추가만 하면 됨(타입/포맷터 동시 수정 불필요). */
 export interface FusionCandidateMini {
-  key: 'positionTrain' | 'fused' | 'route' | 'gps';
+  key: 'positionTrain' | 'fused' | 'route' | 'gps' | 'wifiSsid';
   stationName: string;
   line: string;
   /** 추가 정보 — 출처별 의미가 다를 수 있어 자유형으로 둠.


### PR DESCRIPTION
## Summary

- `useFusedNearestStation`에 `wifiStation?: Station | null` 파라미터 추가 (마지막 인자, 기존 호출자 영향 없음)
- `barometerSubsurface === true` + `wifiStation` 비-null → cascade 최우선(wifi-ssid confidence/source)으로 해당 역 채택 — 지하 GPS dead zone에서 SSID가 잡히면 GPS/arrival 독립적으로 현재역 확정
- 환승역 호선 보정: `boardingLock.boardingLine`이 `wifiStation.line`과 다를 때 `findStationByNameAndLine`으로 재조회. 매핑 실패 시 wifiStation 원본 그대로 채택
- 지상(`subsurface=false`) / SSID 미매칭(`null`) → 기존 cascade 무변경 (regression 없음)
- `fusionDebugBuffer.FusionCandidateMini.key`에 `'wifiSsid'` 추가, debug entry에 wifi candidate 기록

**Backend 전송**: 이슈 스펙대로 frontend fusion wire에만 집중. backend payload 확장은 후속 작업으로 defer.

## 변경 파일

- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — `wifiStation` 파라미터 + cascade 분기 + debug entry
- `src/features/nearest-station/utils/fusionDebugBuffer.ts` — `FusionCandidateMini.key`에 `'wifiSsid'` 추가
- `src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts` — 신규 12건

## Test plan

- [x] `npm test` — 33 known failures(widgetStorage/stationNotification) 외 5289 PASS, type-check PASS
- [x] subsurface=true + SSID 매칭 → wifi-ssid 채택
- [x] 지상/SSID null → 기존 cascade fallback
- [x] 환승역 boardingLock 호선 보정
- [x] debug buffer wifiSsid candidate 기록

Closes #1286