### PR TITLE
fix(#1277): waypoint 시간기반 advance fallback

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -6,9 +6,12 @@ import type { WindowedMetrics } from '../positionSeries';
 import {
   ARVLCD_FIRE_DEDUP_TTL_SEC,
   ARVLCD_FIRE_KEY_PREFIX,
+  FALLBACK_ADVANCE_GRACE_CYCLES,
+  FALLBACK_HOP_SEC,
   MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
   SUBSURFACE_ETA_MISSING_TOLERANCE,
+  VANISH_RE_ATTACH_THRESHOLD,
   arvlCdFireKey,
   estimateArrivalFromPosition,
   estimateBoardingLockArrival,
@@ -988,6 +991,170 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
 
     it('resolveEtaMissingThreshold(subsurface=undefined) → 5 (graceful default)', () => {
       expect(resolveEtaMissingThreshold({})).toBe(MAX_CONSECUTIVE_ETA_MISSING);
+    });
+  });
+
+  // #1277 — trainCode 소실 시 시간 기반 waypoint advance fallback
+  describe('#1277 time-based waypoint advance fallback', () => {
+    const FALLBACK_TRIGGER = VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES;
+    // hop 시간이 경과한 epoch: lastTrackedArrivalEpoch = NOW - FALLBACK_HOP_SEC * 1000 (정확히 경과)
+    const LAST_EPOCH_ELAPSED = NOW - FALLBACK_HOP_SEC * 1000;
+    // hop 시간이 아직 미경과: lastTrackedArrivalEpoch = NOW - 30_000 (30s 전, 90s 미달)
+    const LAST_EPOCH_NOT_ELAPSED = NOW - 30_000;
+
+    async function runVanishedScenario(kv: InMemoryKV) {
+      await runScheduled(makeEnv(kv), {
+        // arrivals/positions 모두 비어있음 → trainCode 소실 상태
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: makeOkFetch() as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p1277',
+      });
+    }
+
+    it('FALLBACK_ADVANCE_GRACE_CYCLES is 1', () => {
+      expect(FALLBACK_ADVANCE_GRACE_CYCLES).toBe(1);
+    });
+
+    it('fallback 미발동: miss 횟수가 fallbackTrigger 미달이면 카운터만 증가', async () => {
+      // fallbackTrigger - 1 miss 상태 → nextMissCount = fallbackTrigger - 1 < trigger
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 2,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      await runVanishedScenario(kv);
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      expect(stored.consecutiveEtaMissing).toBe(FALLBACK_TRIGGER - 1);
+      expect(stored.boardingLock).toBeDefined();
+    });
+
+    it('시간 경과 + fallbackTrigger 도달 → waypoint advance (intermediate → shift)', async () => {
+      // consecutiveEtaMissing = FALLBACK_TRIGGER - 1 → nextMissCount = FALLBACK_TRIGGER
+      // lastTrackedArrivalEpoch = hop 시간 경과 → advanceBoardingLockWaypoint 호출
+      // 첫 waypoint(intermediate 중곡)가 shift되고 남은 waypoint는 군자(destination)
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      await runVanishedScenario(kv);
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      // intermediate 통과 → 다음 waypoint(군자)가 남아야 함
+      expect(stored.waypoints[0].stationName).toBe('군자');
+      // consecutiveEtaMissing 리셋
+      expect(stored.consecutiveEtaMissing).toBe(0);
+    });
+
+    it('시간 경과 + fallbackTrigger 도달 + destination → trip 종료 (cleanupTripWithLa)', async () => {
+      // waypoint가 destination 하나만 남은 경우 → advanceBoardingLockWaypoint → cleanupTripWithLa → trip 삭제
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          waypoints: [{ stationName: '군자', line: '7', kind: 'destination' }],
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      await runVanishedScenario(kv);
+      // destination arrived → cleanupTripWithLa → trip 삭제
+      expect(await kv.get('trip:lock-tok')).toBeNull();
+    });
+
+    it('시간 미경과 + fallbackTrigger 도달 → lock release (lockless 인계)', async () => {
+      // hop 시간이 아직 지나지 않았으면 advance 대신 lock release
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
+        }),
+      );
+      await runVanishedScenario(kv);
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      // lock release → isBoardingLockActive=false
+      expect(stored.boardingLock).toBeUndefined();
+      expect(stored.consecutiveEtaMissing).toBe(0);
+    });
+
+    it('lastTrackedArrivalEpoch 없음 → fallback 미발동, 기존 auto-end 경로 유지', async () => {
+      // lastTrackedArrivalEpoch가 undefined이면 #1277 fallback은 건너뛰고
+      // 기존 consecutiveEtaMissing threshold 경로만 동작해야 한다.
+      // FALLBACK_TRIGGER 도달해도 auto-end threshold(5) 미달이면 카운터 증가.
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          // lastTrackedArrivalEpoch: undefined (미설정)
+        }),
+      );
+      await runVanishedScenario(kv);
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      // fallback 미발동 → 카운터만 증가
+      expect(stored.consecutiveEtaMissing).toBe(FALLBACK_TRIGGER);
+      expect(stored.boardingLock).toBeDefined();
+    });
+
+    it('vanish-swap 후보 존재 시 swap 우선 (time-based fallback 발동 안 됨)', async () => {
+      // 같은 역·노선에 다른 trainCode(7999)가 있으면 attemptVanishSwap이 먼저 성공
+      // → estimate 성공 → handleEtaMissing 호출 안 됨 → fallback 발동 안 됨
+      const kv = new InMemoryKV();
+      // FALLBACK_TRIGGER - 1 miss 상태에서 같은 역에 7999가 보임
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      // arrivals에 다른 trainCode(7999)가 중곡행으로 있음 → attachTrainCodeForLeg가 swap candidate 반환
+      // swap 후 재estimate 성공 → consecutiveEtaMissing 리셋, lock 유지
+      const arrivals: ArrivalEntry[] = [
+        { destination: '중곡', arrivalSeconds: 60, trainCode: '7999', isUp: true, subwayNm: '지하철7호선', arvlCd: null },
+      ];
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo(arrivals, []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: makeOkFetch() as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p1277-swap',
+      });
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      // swap 성공 → consecutiveEtaMissing 리셋, boardingLock 존재
+      expect(stored.consecutiveEtaMissing).toBe(0);
+      expect(stored.boardingLock).toBeDefined();
+      // swap된 trainCode가 7999여야 함
+      expect(stored.boardingLock?.trainCode).toBe('7999');
+    });
+
+    it('subsurface trip도 fallbackTrigger 도달 + 시간 경과 시 advance (지하 무한 동결 방지)', async () => {
+      // subsurface=true여도 FALLBACK_TRIGGER 도달 시 advance 발동 (threshold는 더 크지만 freeze 방지 우선)
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          subsurface: true,
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      await runVanishedScenario(kv);
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      // advance 발동 → intermediate shift, destination(군자) 남음
+      expect(stored.waypoints[0].stationName).toBe('군자');
+      expect(stored.consecutiveEtaMissing).toBe(0);
     });
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -73,7 +73,7 @@ const POLLING_WINDOW_MS = 5 * 60 * 1000;
 export const RESCHEDULE_THRESHOLD_MS = 15_000;
 
 /** boardingLock fallback에서 hop당 기본 소요(90s). 환승역 등 실제 hop은 후속 데이터로 정밀화. */
-const FALLBACK_HOP_SEC = 90;
+export const FALLBACK_HOP_SEC = 90;
 
 /**
  * LA update push 발사 임계치 (#586 D). reschedule push의 15s 임계와는 별개 — LA는 화면 표시용이라
@@ -555,6 +555,14 @@ async function mirrorLocklessProgress(kv: KVNamespace, trip: Trip): Promise<void
 export const VANISH_RE_ATTACH_THRESHOLD = 2;
 
 /**
+ * #1277 — vanish-swap 실패 후 시간 기반 waypoint advance를 시도하기까지의 추가 grace cycle 수.
+ * VANISH_RE_ATTACH_THRESHOLD(2회) 시도 후 이 grace만큼 더 인내하다가 advance 또는 lock release.
+ * swap 시도(2회)와 grace(1회) 합산 총 3회 miss → 시간 게이트를 통과하면 waypoint 전진.
+ * subsurface grace(10회)와 무관하게 적용 — 지하에서도 무한 동결은 막는다.
+ */
+export const FALLBACK_ADVANCE_GRACE_CYCLES = 1;
+
+/**
  * #917 A2 — 매역 알림 dedup KV TTL(초).
  * 같은 trainCode가 같은 역의 arvlCd∈{0,1} 신호를 cron 60s × Seoul API 갱신 지연으로 2~3 cycle
  * 반복 노출하는데, 그 윈도우 동안 push가 중복 발사되지 않도록 차단한다.
@@ -757,6 +765,11 @@ async function attemptVanishSwap(
 /**
  * estimate가 null로 끝난 cycle 처리 — etaMissing 카운터 누적 + 임계 초과 시 trip 자동 종료.
  * runTrainCodeTracking의 cognitive complexity 분담용 추출 (Sonar S3776).
+ *
+ * #1277 — vanish-swap 후보 없음(지하 dead zone)으로 freeze 방지:
+ *   VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES miss 도달 시
+ *   lastTrackedArrivalEpoch 기준 hop 시간 경과를 확인해 waypoint optimistic advance를 시도.
+ *   경과 미달이면 lock release해 lockless/boardingPrompt가 인계받게 함.
  */
 interface HandleEtaMissingInputs {
   trip: Trip;
@@ -779,6 +792,46 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     station: waypoint.stationName,
     consecutiveEtaMissing: nextMissCount,
   });
+
+  // #1277 — vanish-swap(VANISH_RE_ATTACH_THRESHOLD 도달 시 한 번 시도)이 실패한 후
+  // FALLBACK_ADVANCE_GRACE_CYCLES grace를 더 기다린 시점에서 시간 기반 fallback.
+  // lastTrackedArrivalEpoch가 있을 때만 활성화 — 한 번도 추적된 적 없는 trip(새벽 무운행 등)은
+  // 기존 auto-end 임계 경로로 처리한다.
+  // 이 분기는 auto-end 임계(threshold) 전에 평가되어 무한 동결을 막는다.
+  const fallbackTrigger = VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES;
+  const lastEpoch = trip.lastTrackedArrivalEpoch;
+  if (nextMissCount >= fallbackTrigger && lastEpoch !== undefined) {
+    const hopElapsed = now >= lastEpoch + FALLBACK_HOP_SEC * 1000;
+    if (hopElapsed) {
+      // hop 시간 경과 → optimistic waypoint advance.
+      // advance 내부에서 destination 도착이면 cleanupTripWithLa, 그 외엔 waypoints.shift().
+      log('boarding-lock: trainCode vanished — time-based waypoint advance fallback', {
+        token: trip.token.slice(0, 8),
+        trainCode: activeLock.trainCode,
+        station: waypoint.stationName,
+        consecutiveEtaMissing: nextMissCount,
+        lastTrackedArrivalEpoch: lastEpoch,
+      });
+      trip.consecutiveEtaMissing = 0;
+      await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
+      return;
+    }
+    // hop 시간 미경과 → lock release해 lockless/boardingPrompt가 인계받도록.
+    // isBoardingLockActive=false가 되는 즉시 다음 cycle의 evaluateAndMaybeFireBoardingPrompt 경로 복구.
+    log('boarding-lock: trainCode vanished — releasing lock (hop time not yet elapsed)', {
+      token: trip.token.slice(0, 8),
+      trainCode: activeLock.trainCode,
+      station: waypoint.stationName,
+      consecutiveEtaMissing: nextMissCount,
+      lastTrackedArrivalEpoch: lastEpoch,
+    });
+    trip.boardingLock = undefined;
+    trip.consecutiveEtaMissing = 0;
+    await deleteProgress(env.TRIPS, trip.token);
+    await putTrip(env.TRIPS, trip);
+    return;
+  }
+
   // #903 (Seam G) — subsurface=true trip은 인내 임계(10)로 분기. 지하 dead zone GPS/trainCode 일시 누락 인내.
   const threshold = resolveEtaMissingThreshold(trip);
   if (nextMissCount >= threshold) {


### PR DESCRIPTION
## Summary

boardingLock의 trainCode가 Seoul API(arrivals + positions) 양쪽에서 사라지면 `handleEtaMissing`이 `consecutiveEtaMissing`만 올리다가 10분 후 auto-end로 trip이 종료되는 동결 문제 수정.

## 변경 내용

- `handleEtaMissing`에 `#1277` fallback 분기 추가
  - `vanish-swap`(VANISH_RE_ATTACH_THRESHOLD=2회) 실패 후 `FALLBACK_ADVANCE_GRACE_CYCLES`(1회) grace 경과 시점(총 3회 miss)에서 시간 게이트 평가
  - `lastTrackedArrivalEpoch + FALLBACK_HOP_SEC(90s)` 경과 → optimistic waypoint advance (`advanceBoardingLockWaypoint`)
  - 시간 미경과 → lock release → lockless/boardingPrompt 경로 인계
  - `lastTrackedArrivalEpoch` 미설정(새벽 무운행 등)은 기존 auto-end 경로 유지
- `FALLBACK_HOP_SEC`, `FALLBACK_ADVANCE_GRACE_CYCLES` export 추가 (테스트 참조용)
- 단위 테스트 8개 추가 (advance/release/no-op/vanish-swap 우선/subsurface)

## 테스트

- 기존 1221개 테스트 전부 통과 (회귀 없음)
- 신규 8개 테스트 추가 → 총 1229개 PASS
- `npm run type-check` PASS

Closes #1277