### PR TITLE
fix(#1278): silent push 게이트 subsurface 우회 (지하 매 역 알림)

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -676,6 +676,7 @@ describe('silentPushTask', () => {
         phase: 'imminent',
         isLockless: false,
         payloadHopIndex: undefined,
+        subsurface: false,
       });
       expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
       const call = mockScheduleNotificationAsync.mock.calls[0][0];

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../shared/constants/storageKeys';
 import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../../../shared/utils/logger';
+import { getSubsurfaceState } from '../../../shared/utils/subsurfaceState';
 import {
   flushAlarmLog,
   logSilentPushReceived,
@@ -787,12 +788,16 @@ async function fireWithGate(
   // #1273 D3 — payloadHopIndex는 백엔드 silent push payload의 절대 시퀀스 SSOT. wire.
   // currentHopIndex는 D1(#1207) hop estimator 미연결 단계라 undefined — 둘 중 하나라도
   // 없으면 gate가 거리 기반 widened fallback 경로로 동작한다.
+  // #1278 — 지하(subsurface) 여부를 stamp(#1279)에서 읽어 게이트에 전달.
+  // true + intermediate면 게이트가 GPS 거리 검증을 우회하고 backend push를 신뢰한다.
+  const subsurface = await getSubsurfaceState();
   const gate = await checkSilentPushLocationGate({
     stationName: payload.nextWaypoint,
     kind: payload.kind,
     phase: payload.phase,
     isLockless: !lock,
     payloadHopIndex: payload.hopIndex,
+    subsurface,
   });
 
   if (!gate.pass) {

--- a/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
@@ -64,6 +64,48 @@ describe('checkSilentPushLocationGate', () => {
     expect(mockGetLastKnownPositionAsync).not.toHaveBeenCalled();
   });
 
+  it('#1278 subsurface=true + intermediate면 GPS 해석 없이 우회 pass', async () => {
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'intermediate',
+      phase: 'imminent',
+      subsurface: true,
+    });
+    expect(result.pass).toBe(true);
+    expect(result.passReason).toBe('subsurface-bypass');
+    // GPS 해석 자체를 건너뛴다.
+    expect(mockGetLastKnownPositionAsync).not.toHaveBeenCalled();
+  });
+
+  it('#1278 subsurface=true여도 destination은 우회 안 함 (GPS 거리 평가 유지)', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+      subsurface: true,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('out-of-range');
+  });
+
+  it('#1278 subsurface=false intermediate는 기존 GPS 경로 (회귀 없음)', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(
+      makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
+    );
+    const result = await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'intermediate',
+      phase: 'imminent',
+      subsurface: false,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('out-of-range');
+    expect(mockGetLastKnownPositionAsync).toHaveBeenCalled();
+  });
+
   it('캐시 위치가 가까우면 pass (cache source, distance 표기)', async () => {
     mockGetLastKnownPositionAsync.mockResolvedValue(
       makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 10_000),

--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -27,8 +27,9 @@ export type GateSkipReason = 'unknown-station' | 'no-location' | 'stale-location
  * pass=true일 때 어떤 경로로 통과했는지 식별. 운영 측정/디버깅용.
  * - 'within-threshold': 거리 임계값 이내 (기존 경로)
  * - 'hop-window-match': lockless + hop index 매치(거리 검증 우회, #1209 D3)
+ * - 'subsurface-bypass': 지하(subsurface) intermediate — GPS 신뢰 불가로 거리 게이트 우회(#1278)
  */
-export type GatePassReason = 'within-threshold' | 'hop-window-match';
+export type GatePassReason = 'within-threshold' | 'hop-window-match' | 'subsurface-bypass';
 export type GateLocationSource = 'cache' | 'fresh';
 
 export interface GateResult {
@@ -61,6 +62,11 @@ export interface SilentPushLocationGateInput {
    * silent push payload가 명시한 hop index. 백엔드 schema에 추가되기 전까지 undefined.
    */
   payloadHopIndex?: number;
+  /**
+   * #1278 — 지하(subsurface) 여부. silentPushTask가 getSubsurfaceState()로 읽어 전달.
+   * true + intermediate면 GPS 거리 게이트를 우회하고 backend push를 신뢰한다.
+   */
+  subsurface?: boolean;
 }
 
 interface UserPosition {
@@ -187,6 +193,14 @@ export async function checkSilentPushLocationGate(
   const station = findStationByName(input.stationName);
   if (!station) {
     return { pass: false, reason: 'unknown-station' };
+  }
+
+  // #1278 — 지하(subsurface) intermediate는 GPS가 stale/부재라 거리 게이트가 backend의
+  // 정상 station-passed push를 out-of-range로 거부하던 회귀(중곡 등). subsurface=true면
+  // GPS 해석 자체를 건너뛰고 backend push를 신뢰한다. kind==='intermediate'에 한정 —
+  // transfer/destination은 오발사 위험이 커 우회 제외. 역당 dedup은 호출측이 담당.
+  if (input.subsurface === true && input.kind === 'intermediate') {
+    return { pass: true, passReason: 'subsurface-bypass' };
   }
 
   const pos = await resolveUserPosition();


### PR DESCRIPTION
## Summary
지하에서 GPS가 stale/부재라 backend의 정상 intermediate station-passed push가 `out-of-range`로 거부되던 회귀(#1278, 중곡 사례) 수정.
- `checkSilentPushLocationGate`에 `subsurface?: boolean` 입력 + `kind==='intermediate'`일 때 GPS 거리 게이트 우회(`passReason='subsurface-bypass'`). transfer/destination은 오발사 위험으로 우회 제외.
- `silentPushTask`가 `getSubsurfaceState()`(#1279 stamp)를 읽어 게이트에 전달.

## 의존성
- **#1279(barometer subsurface stamp)에 스택** — `getSubsurfaceState()` 소비. base가 `feat/#1279-subsurface-stamp`. #1279 머지 시 GitHub가 dev로 자동 retarget.

## Test plan
- [x] gate + silentPushTask 100% 커버리지 (changed files)
- [x] `npm run type-check` 통과
- [ ] 실기기: 지하 구간 intermediate 알림 fire (gate-out-of-range 0)

Closes #1278