### PR TITLE
fix(#1284): boardingPrompt context 안정화

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1070,6 +1070,127 @@ describe('useApnsTripRegistration', () => {
       expect(args.promptGeoContext).toBeUndefined();
       expect(args.promptDisplay).toBeUndefined();
     });
+
+    // #1284 — boarding-prompt 컨텍스트 캐싱 (currentStation 일시 null 회귀 방지)
+    describe('#1284 — prompt context 캐싱', () => {
+      // 단조 3호선 대화(3-001) → 정발산(3-003): buildBoardingPromptContext non-null 반환 보장.
+      const origin: Station = {
+        id: '3-001',
+        name: '대화',
+        line: '3',
+        lat: 37.676087,
+        lng: 126.747569,
+        lineColor: '#EF7C1C',
+      };
+      const dest: Station = {
+        id: '3-003',
+        name: '정발산',
+        line: '3',
+        lat: 37.659477,
+        lng: 126.773359,
+        lineColor: '#EF7C1C',
+      };
+      const route3 = makeDirectRoute(2, '3');
+
+      it('currentStation이 일시 null → 직전 캐시된 컨텍스트를 payload에 포함', async () => {
+        // 1st render: currentStation=origin → 컨텍스트 빌드 + 캐시
+        const { rerender } = renderHook(
+          ({ cs }: { cs: Station | null }) =>
+            useApnsTripRegistration({
+              route: route3,
+              destination: dest,
+              nextStationEtaSeconds: 120,
+              currentStation: cs,
+            }),
+          { initialProps: { cs: origin as Station | null } },
+        );
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+        // 첫 register: 컨텍스트 있음
+        expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeDefined();
+        expect(mockRegister.mock.calls[0][0].promptDisplay).toBeDefined();
+
+        // currentStation → null (BG GPS 누락 시뮬레이션). deps에 포함 안 됐으므로
+        // register 재호출 안 됨 (#703). token-refresh나 다음 locklessStationPassed toggle 등으로
+        // re-register 시 캐시 활용 여부를 아래 token-refresh 경로로 검증.
+        rerender({ cs: null });
+        // 재등록 미발생 (currentStation은 deps 아님) — 캐시 검증은 token-refresh로 진행
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        // token-refresh 경로: currentStation=null 상태에서도 캐시된 컨텍스트를 사용해야 함
+        const listener = mockAddPushTokenListener.mock.calls[0][0];
+        await act(async () => {
+          listener({ data: 'token-REFRESH' });
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        await waitFor(() =>
+          expect(mockRegister).toHaveBeenCalledWith(
+            expect.objectContaining({ token: 'token-REFRESH' }),
+          ),
+        );
+        const refreshed = mockRegister.mock.calls.find(
+          (c) => (c[0] as { token: string }).token === 'token-REFRESH',
+        );
+        // 캐시에서 복원된 컨텍스트가 payload에 포함되어야 한다.
+        expect(refreshed?.[0].promptGeoContext).toBeDefined();
+        expect(refreshed?.[0].promptDisplay).toEqual({ originStation: '대화', line: '3' });
+      });
+
+      it('route + destination 모두 없는 경우(trip 없음) → null 반환 (false stamp 없음)', async () => {
+        renderHook(() =>
+          useApnsTripRegistration({
+            route: null,
+            destination: null,
+            nextStationEtaSeconds: null,
+          }),
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        // register 호출 없음 — false stamp 없음
+        expect(mockRegister).not.toHaveBeenCalled();
+      });
+
+      it('trip 종료 후 새 trip 시작 시 캐시 reset — 이전 origin이 새 trip에 누출 안 됨', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return 'token-abc';
+          if (key === ACTIVE_TRIP_KEY) return 'token-abc';
+          return null;
+        });
+
+        // 1st trip: 대화→정발산, origin 컨텍스트 캐시
+        const { rerender } = renderHook(
+          ({ r, d, cs }: { r: Route | null; d: Station | null; cs: Station | null }) =>
+            useApnsTripRegistration({
+              route: r,
+              destination: d,
+              nextStationEtaSeconds: 120,
+              currentStation: cs,
+            }),
+          { initialProps: { r: route3 as Route | null, d: dest as Station | null, cs: origin as Station | null } },
+        );
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+        expect(mockRegister.mock.calls[0][0].promptDisplay).toEqual({ originStation: '대화', line: '3' });
+
+        // trip 종료: 캐시 reset 트리거
+        rerender({ r: null, d: null, cs: null });
+        await waitFor(() => expect(mockClear).toHaveBeenCalled());
+
+        // 2nd trip: 새 노선 + currentStation=null (GPS 아직 없음)
+        rerender({ r: directRoute as Route | null, d: station as Station | null, cs: null });
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+        const secondArgs = mockRegister.mock.calls[1][0] as {
+          promptGeoContext?: unknown;
+          promptDisplay?: unknown;
+        };
+        // 캐시가 reset됐으므로 이전 origin 컨텍스트가 누출 안 됨
+        expect(secondArgs.promptGeoContext).toBeUndefined();
+        expect(secondArgs.promptDisplay).toBeUndefined();
+      });
+    });
   });
 
   // #1264 (N3) — routeSig 전환 시 사전 예약된 tba: 알람 cancel.

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -26,7 +26,7 @@ import { registerActiveTrip, clearActiveTrip, type AlarmBoardingLock } from '../
 import { routeToWaypoints } from '../../route/utils/routeWaypoints';
 import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
 import { cancelTripBoundAlarms } from '../utils/tripBoundScheduler';
-import { buildBoardingPromptContext } from '../utils/boardingPromptContext';
+import { buildBoardingPromptContext, type BoardingPromptContext } from '../utils/boardingPromptContext';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
@@ -86,6 +86,12 @@ interface RegisterCallInputs {
   subsurface: boolean;
   /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
   createdAt: number;
+  /**
+   * #1284 — 직전 사이클에서 성공적으로 빌드된 boarding-prompt 컨텍스트 캐시.
+   * currentStation이 BG GPS 누락으로 일시 null이 됐을 때 fallback으로 사용해
+   * backend cron 진입 시점에 컨텍스트가 반드시 존재하도록 보장한다.
+   */
+  cachedPromptContext: BoardingPromptContext | null;
 }
 
 /**
@@ -113,13 +119,15 @@ async function callRegister(input: RegisterCallInputs) {
     }
   }
 
-  // #1028: boarding-prompt 평가 컨텍스트 (#819). 둘 다 있어야 backend가 9단 게이트를 돌리므로
-  // 항상 함께 송신. currentStation/route lookup 실패 시 null → 필드 누락 → backend 자동 skip.
-  const promptContext = buildBoardingPromptContext({
+  // #1028 / #1284: boarding-prompt 평가 컨텍스트 (#819). 둘 다 있어야 backend가 9단 게이트를
+  // 돌리므로 항상 함께 송신. currentStation이 BG GPS 누락으로 일시 null이면 캐시된 컨텍스트를
+  // fallback으로 사용 — backend cron 진입 전 최소 한 번은 컨텍스트가 stamped되도록 보장.
+  const freshContext = buildBoardingPromptContext({
     route: input.route,
     currentStation: input.currentStation,
     destination: input.destination,
   });
+  const promptContext = freshContext ?? input.cachedPromptContext;
 
   return registerActiveTrip({
     token: input.token,
@@ -182,6 +190,12 @@ export function useApnsTripRegistration({
   // (non-null → null → 새 lock 3 POST) 판정에 사용. 첫 register 시 null로 시작.
   const lastSentLockSigRef = useRef<string | null>(null);
 
+  // #1284 — 직전 사이클에서 성공적으로 빌드된 boarding-prompt 컨텍스트 캐시.
+  // destination이 변경(null→non-null 포함)되면 useEffect deps(destination?.id)가 재실행되어
+  // 자동으로 최신 컨텍스트로 덮어쓰인다. destination이 같은 trip 안에서 일시 null이 되는 경우는
+  // 없으므로 stale context를 잘못된 destination에 stamp할 위험이 없다.
+  const lastPromptContextRef = useRef<BoardingPromptContext | null>(null);
+
   // #1264 (N3) — 직전 effect cycle의 routeSig. routeSig가 전환되면 이전 trip의 사전 예약된
   // `tba:` 알람을 cancel — backend가 보낸 정정 silent push가 stale identifier에 매칭되어
   // 50분간 `revalidate-route-sig-mismatch`로 누락되는 회귀(2026-06-12 user trip)를 차단한다.
@@ -240,6 +254,7 @@ export function useApnsTripRegistration({
           locklessStationPassed: lsp,
           subsurface: sub,
           createdAt: resolveTripCreatedAt(sessionKey),
+          cachedPromptContext: lastPromptContextRef.current,
         });
         // #767 — main effect와 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도
         // 유지. token-refresh는 deps cycle을 거치지 않는 별경로지만 backend엔 동일 POST를 보내므로.
@@ -277,6 +292,9 @@ export function useApnsTripRegistration({
         // #1264 (N3): trip 종료 시 routeSig 추적도 reset — 다음 trip 시작 시 첫 routeSig는
         // 신규로 취급되어 cancel skip(불필요한 OS 호출 방지).
         lastRouteSigRef.current = null;
+        // #1284: trip 종료 시 prompt context 캐시 reset — 다음 trip이 이전 trip의
+        // 출발역 컨텍스트를 stamp하는 오염 방지.
+        lastPromptContextRef.current = null;
         return;
       }
 
@@ -301,6 +319,10 @@ export function useApnsTripRegistration({
       }
 
       const sessionKey = `${token}:${routeSig}:${destination.id}`;
+      // #1284 — buildBoardingPromptContext가 성공하면 캐시 갱신. 이후 currentStation이
+      // 일시 null이 돼도 cachedPromptContext로 fallback하여 backend 9단 게이트가 계속 진입 가능.
+      const freshCtx = buildBoardingPromptContext({ route, currentStation, destination });
+      if (freshCtx) lastPromptContextRef.current = freshCtx;
       const result = await callRegister({
         token,
         route,
@@ -311,6 +333,7 @@ export function useApnsTripRegistration({
         locklessStationPassed,
         subsurface,
         createdAt: resolveTripCreatedAt(sessionKey),
+        cachedPromptContext: lastPromptContextRef.current,
       });
       // POST 발사 직후(성공/실패 무관) 송신된 lock sig를 기록 — 다음 cycle이 "직전 송신 = lock,
       // 신규 = null" 패턴인지 판정해 race 차단.


### PR DESCRIPTION
## Summary

- `useApnsTripRegistration`에 `lastPromptContextRef` 추가: `buildBoardingPromptContext`가 non-null을 반환할 때마다 캐시 갱신
- `callRegister`에서 `freshContext ?? cachedPromptContext` fallback 적용: BG GPS 누락으로 `currentStation`이 일시 null이 돼도 캐시된 컨텍스트를 backend에 stamp
- token-refresh 경로(`addPushTokenListener`)도 `lastPromptContextRef` 전달
- trip 종료 시 캐시 reset — 이전 trip의 origin이 다음 trip에 누출 방지

## Root cause

`buildBoardingPromptContext`는 `!currentStation` 시 null 반환 → `promptGeoContext`/`promptDisplay` 누락 → backend `scheduled.ts:~1468` early-return → `boardingPromptEvaluated=0` 회귀.

## Test plan

- [x] 기존 61개 테스트 전체 통과 (3건 신규 추가 포함)
- [x] `npm run type-check` 통과
- [ ] 실기기: trip 시작 후 BG 진입 → 탑승 프롬프트 푸시 수신 확인

Closes #1284