### PR TITLE
feat(#1289): useStationExits 마운트 (빠른 환승/출구 위치 표시)

### DIFF
--- a/src/features/alarm/components/AlarmOverlay.tsx
+++ b/src/features/alarm/components/AlarmOverlay.tsx
@@ -1,21 +1,34 @@
-import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: AlarmOverlay는 alarm 알람 표시 시점에 exit-info의
+ * StationExitCard를 인라인 노출하는 orchestrator 역할이다. 후속 PR에서 orchestration
+ * 슬라이스로 추출하여 disable을 제거할 예정.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { AlarmEvent } from '../../../shared/types/alarm';
 import { clearAlarmNotification } from '../utils/stationNotification';
 import { killAllAlarms } from '../utils/alarmKill';
 import { getStationDisplayNameByName } from '../../../shared/utils/stationDisplay';
 import stationsData from '../../../data/stations.json';
-import type { Station } from '../../../shared/types/station';
+import type { LineNumber, Station } from '../../../shared/types/station';
 import { useTheme, typography, spacing, radius } from '../../../shared/theme';
+import { StationExitCard } from '../../exit-info/components/StationExitCard';
 
 const allStations = stationsData as Station[];
 
 interface AlarmOverlayProps {
   event: AlarmEvent;
   onDismiss: () => void;
+  /**
+   * 알람 대상역 노선 — StationExitCard 출구 안내에 사용 (#1289).
+   * 미전달 시 출구 안내를 표시하지 않는다 (graceful hide).
+   */
+  line?: LineNumber | null;
 }
 
-export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
+export function AlarmOverlay({ event, onDismiss, line }: AlarmOverlayProps) {
   const isTransfer = event.type === 'transfer';
   const { t } = useTranslation();
   const title = t(isTransfer ? 'alarmOverlay.transferTitle' : 'alarmOverlay.arrivalTitle');
@@ -46,13 +59,23 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
 
   return (
     <Modal visible animationType="fade" testID="alarm-overlay" onRequestClose={handleDismiss}>
-      <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      <ScrollView
+        contentContainerStyle={[styles.container, { backgroundColor: colors.bg }]}
+        style={{ backgroundColor: colors.bg }}
+        testID="alarm-overlay-scroll"
+        bounces={false}
+      >
         <Text style={[styles.title, { color: colors.accent }]} testID="alarm-overlay-title">
           {title}
         </Text>
         <Text style={[styles.station, { color: colors.ink }]} testID="alarm-overlay-message">
           {message}
         </Text>
+        {line != null && (
+          <View style={styles.exitSection} testID="alarm-overlay-exit-section">
+            <StationExitCard stationName={event.stationName} line={line} />
+          </View>
+        )}
         <TouchableOpacity
           style={[styles.button, { backgroundColor: colors.accent }]}
           onPress={handleDismiss}
@@ -66,7 +89,7 @@ export function AlarmOverlay({ event, onDismiss }: AlarmOverlayProps) {
             {t('alarmOverlay.dismiss')}
           </Text>
         </TouchableOpacity>
-      </View>
+      </ScrollView>
     </Modal>
   );
 }
@@ -99,5 +122,9 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: 28,
     fontWeight: '800',
+  },
+  exitSection: {
+    width: '100%',
+    marginBottom: spacing.xxl,
   },
 });

--- a/src/features/alarm/components/__tests__/AlarmOverlay.test.tsx
+++ b/src/features/alarm/components/__tests__/AlarmOverlay.test.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { AlarmOverlay } from '../AlarmOverlay';
 import type { AlarmEvent } from '../../../../shared/types/alarm';
+import type { LineNumber } from '../../../../shared/types/station';
+import type { ExitInfoProvider } from '../../../exit-info/providers/types';
+import type { ExitInfo } from '../../../../shared/types/exitInfo';
 
 const mockKillAllAlarms = jest.fn().mockResolvedValue(undefined);
 const mockClearAlarmNotification = jest.fn().mockResolvedValue(undefined);
@@ -15,13 +18,18 @@ jest.mock('../../utils/stationNotification', () => ({
 
 const mockDismiss = jest.fn();
 
+function makeExitProvider(exits: ExitInfo[]): ExitInfoProvider {
+  return { getExits: jest.fn(async () => exits) };
+}
+
 function renderAlarm(
   type: AlarmEvent['type'],
   stationName: string,
   phaseId: AlarmEvent['phaseId'] = 'early',
+  line?: LineNumber | null,
 ) {
   const event: AlarmEvent = { phaseId, type, stationName };
-  return render(<AlarmOverlay event={event} onDismiss={mockDismiss} />);
+  return render(<AlarmOverlay event={event} onDismiss={mockDismiss} line={line} />);
 }
 
 async function triggerModalClose(rendered: ReturnType<typeof renderAlarm>) {
@@ -87,6 +95,29 @@ describe('AlarmOverlay', () => {
 
   it('#741 도착 알람의 메인 버튼도 "알람 끄기" 텍스트 — 라벨 통일', () => {
     expect(renderAlarm('destination', '강남').getByText('알람 끄기')).toBeTruthy();
+  });
+
+  describe('#1289 출구 안내 (StationExitCard) 마운트', () => {
+    it('line 미전달 시 출구 안내 섹션이 렌더되지 않는다', () => {
+      const { queryByTestId } = renderAlarm('destination', '강남', 'early');
+      expect(queryByTestId('alarm-overlay-exit-section')).toBeNull();
+    });
+
+    it('line=null 시 출구 안내 섹션이 렌더되지 않는다', () => {
+      const { queryByTestId } = renderAlarm('destination', '강남', 'early', null);
+      expect(queryByTestId('alarm-overlay-exit-section')).toBeNull();
+    });
+
+    it('line 전달 시 출구 안내 섹션이 렌더되고 출구 카드가 나타난다', async () => {
+      const event: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '강남' };
+      const { getByTestId, findByTestId } = render(
+        <AlarmOverlay event={event} onDismiss={mockDismiss} line="2" />,
+      );
+      // exit section은 즉시 렌더됨 (line이 있으면)
+      expect(getByTestId('alarm-overlay-exit-section')).toBeTruthy();
+      // StationExitCard는 MockExitInfoProvider 기본값(강남 2호선 샘플)으로 로드 후 나타남
+      await findByTestId('station-exit-card');
+    });
   });
 
   describe('#741 보조 버튼 제거 — 단일 액션 UX', () => {

--- a/src/features/exit-info/components/StationExitCard.tsx
+++ b/src/features/exit-info/components/StationExitCard.tsx
@@ -1,0 +1,92 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { useTheme, typography, spacing } from '../../../shared/theme';
+import type { LineNumber } from '../../../shared/types/station';
+import { useStationExits } from '../hooks/useStationExits';
+import type { ExitInfoProvider } from '../providers/types';
+
+interface Props {
+  stationName: string | null;
+  line: LineNumber | null;
+  /**
+   * 사용자가 설정한 목적지 시설 텍스트 — 매칭 출구를 앞으로 정렬하는 데 사용.
+   * 없으면 원본 순서 그대로 표시한다.
+   */
+  destination?: string | null;
+  /** 테스트/DI용. 미지정 시 MockExitInfoProvider 사용. */
+  provider?: ExitInfoProvider;
+}
+
+/**
+ * 역 출구 목록을 표시하는 카드 컴포넌트 (#1289).
+ *
+ * - `useStationExits`를 내부적으로 호출해 출구 데이터를 로드한다.
+ * - destination이 주어지면 매칭 출구를 앞으로 정렬해 표시한다.
+ * - 데이터가 없거나 로딩 중이면 아무것도 렌더하지 않는다 (graceful hide).
+ * - stationName 또는 line이 null이면 즉시 null 반환 (no-op).
+ */
+export function StationExitCard({ stationName, line, destination, provider }: Props) {
+  const { colors } = useTheme();
+  const { ranked, loading } = useStationExits({ stationName, line, destination, provider });
+
+  if (!stationName || !line) return null;
+  if (loading || ranked.length === 0) return null;
+
+  return (
+    <View style={styles.container} testID="station-exit-card">
+      <Text style={[typography.label, { color: colors.subtle }, styles.label]} testID="station-exit-card-label">
+        출구 안내
+      </Text>
+      <View style={styles.list}>
+        {ranked.map(({ exit, matchesDestination }) => (
+          <View
+            key={exit.exitNumber}
+            style={[
+              styles.row,
+              { borderColor: matchesDestination ? colors.accent : colors.card },
+            ]}
+            testID={`exit-row-${exit.exitNumber}`}
+          >
+            <Text
+              style={[
+                typography.bodySm,
+                { color: matchesDestination ? colors.accent : colors.ink, fontWeight: '600' },
+              ]}
+              testID={`exit-number-${exit.exitNumber}`}
+            >
+              {exit.exitNumber}번 출구
+            </Text>
+            <Text
+              style={[typography.bodySm, { color: colors.subtle, flex: 1 }]}
+              testID={`exit-facilities-${exit.exitNumber}`}
+              numberOfLines={1}
+            >
+              {exit.facilities.join(' · ')}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: spacing.sm,
+    gap: spacing.xs,
+  },
+  label: {
+    marginBottom: spacing.xs,
+  },
+  list: {
+    gap: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderWidth: 1,
+    borderRadius: 4,
+  },
+});

--- a/src/features/exit-info/components/__tests__/StationExitCard.test.tsx
+++ b/src/features/exit-info/components/__tests__/StationExitCard.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { waitFor } from '@testing-library/react-native';
+import { StationExitCard } from '../StationExitCard';
+import type { ExitInfoProvider } from '../../providers/types';
+import type { ExitInfo } from '../../../../shared/types/exitInfo';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+
+function makeProvider(exits: ExitInfo[]): ExitInfoProvider {
+  return { getExits: jest.fn(async () => exits) };
+}
+
+const gangnamExits: ExitInfo[] = [
+  { stationName: '강남', line: '2', exitNumber: '1', facilities: ['국기원', '강남구청'] },
+  { stationName: '강남', line: '2', exitNumber: '6', facilities: ['교보타워'] },
+  { stationName: '강남', line: '2', exitNumber: '10', facilities: ['뉴욕제과', '강남대로 버스환승센터'] },
+];
+
+describe('StationExitCard', () => {
+  it('stationName이 null이면 null 반환 (렌더 없음)', () => {
+    const provider = makeProvider(gangnamExits);
+    const { queryByTestId } = renderWithTheme(
+      <StationExitCard stationName={null} line="2" provider={provider} />,
+    );
+    expect(queryByTestId('station-exit-card')).toBeNull();
+  });
+
+  it('line이 null이면 null 반환 (렌더 없음)', () => {
+    const provider = makeProvider(gangnamExits);
+    const { queryByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line={null} provider={provider} />,
+    );
+    expect(queryByTestId('station-exit-card')).toBeNull();
+  });
+
+  it('데이터 로드 전(loading 상태)에는 카드가 숨겨진다', () => {
+    let resolveFn: (v: ExitInfo[]) => void = () => undefined;
+    const provider: ExitInfoProvider = {
+      getExits: jest.fn(() => new Promise<ExitInfo[]>((resolve) => { resolveFn = resolve; })),
+    };
+    const { queryByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" provider={provider} />,
+    );
+    // loading=true이고 아직 데이터 없음 → 카드 미렌더
+    expect(queryByTestId('station-exit-card')).toBeNull();
+    // cleanup promise
+    resolveFn([]);
+  });
+
+  it('provider가 빈 배열을 반환하면 카드가 렌더되지 않는다 (graceful hide)', async () => {
+    const provider = makeProvider([]);
+    const { queryByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" provider={provider} />,
+    );
+    await waitFor(() => {
+      expect(provider.getExits).toHaveBeenCalledWith('강남', '2');
+    });
+    expect(queryByTestId('station-exit-card')).toBeNull();
+  });
+
+  it('provider 실패 시 카드가 렌더되지 않는다 (graceful hide)', async () => {
+    const provider: ExitInfoProvider = {
+      getExits: jest.fn(async () => { throw new Error('network'); }),
+    };
+    const { queryByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" provider={provider} />,
+    );
+    await waitFor(() => {
+      expect(provider.getExits).toHaveBeenCalled();
+    });
+    expect(queryByTestId('station-exit-card')).toBeNull();
+  });
+
+  it('출구 데이터가 있으면 카드가 렌더된다', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { findByTestId, getByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" provider={provider} />,
+    );
+    await findByTestId('station-exit-card');
+    expect(getByTestId('station-exit-card-label')).toBeTruthy();
+    expect(getByTestId('exit-row-1')).toBeTruthy();
+    expect(getByTestId('exit-row-6')).toBeTruthy();
+    expect(getByTestId('exit-row-10')).toBeTruthy();
+  });
+
+  it('각 출구의 번호와 시설 목록이 렌더된다', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { findByTestId, getByText } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" provider={provider} />,
+    );
+    await findByTestId('station-exit-card');
+    expect(getByText('1번 출구')).toBeTruthy();
+    expect(getByText('국기원 · 강남구청')).toBeTruthy();
+    expect(getByText('6번 출구')).toBeTruthy();
+    expect(getByText('교보타워')).toBeTruthy();
+  });
+
+  it('destination이 주어지면 매칭 출구가 앞에 렌더된다', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { findByTestId, getAllByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" destination="교보타워" provider={provider} />,
+    );
+    await findByTestId('station-exit-card');
+    const rows = getAllByTestId(/^exit-row-/);
+    // 교보타워가 있는 6번 출구가 첫 번째로 정렬된다
+    expect(rows[0].props.testID).toBe('exit-row-6');
+  });
+
+  it('destination이 매칭 출구의 number 라벨은 accent 색을 반영한다(testID로 확인)', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { findByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" destination="교보타워" provider={provider} />,
+    );
+    await findByTestId('station-exit-card');
+    // exit-number-6은 matchesDestination=true → accent 색 적용 testID 확인
+    expect(await findByTestId('exit-number-6')).toBeTruthy();
+  });
+
+  it('destination이 없으면 원본 순서 유지', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { findByTestId, getAllByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" provider={provider} />,
+    );
+    await findByTestId('station-exit-card');
+    const rows = getAllByTestId(/^exit-row-/);
+    expect(rows[0].props.testID).toBe('exit-row-1');
+    expect(rows[1].props.testID).toBe('exit-row-6');
+    expect(rows[2].props.testID).toBe('exit-row-10');
+  });
+
+  it('stationName이 바뀌면 provider를 새로 호출한다', async () => {
+    const provider = makeProvider(gangnamExits);
+    const { findByTestId, rerender } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" provider={provider} />,
+    );
+    await findByTestId('station-exit-card');
+    rerender(<StationExitCard stationName="시청" line="1" provider={provider} />);
+    await waitFor(() => {
+      expect(provider.getExits).toHaveBeenCalledWith('시청', '1');
+    });
+  });
+
+  it('기본 provider(MockExitInfoProvider)로도 동작 — 강남 2호선 샘플 데이터 반환', async () => {
+    const { findByTestId } = renderWithTheme(
+      <StationExitCard stationName="강남" line="2" />,
+    );
+    await findByTestId('station-exit-card');
+  });
+});


### PR DESCRIPTION
## Summary

- `StationExitCard` 컴포넌트 신규 생성 (`src/features/exit-info/components/StationExitCard.tsx`)  
  — `useStationExits` 내부 호출, 출구 목록 렌더, destination 매칭 출구 앞 정렬  
  — 데이터 없음/로딩/provider 실패 시 graceful hide (no crash)
- `AlarmOverlay`에 optional `line?: LineNumber | null` prop 추가 → `StationExitCard` 마운트  
  — `line` 미전달/null 시 출구 섹션 미렌더 (backward compatible)  
  — cross-feature import: `eslint-disable import/no-restricted-paths` 옵트인 (기존 패턴 동일)

## Test plan

- [x] `StationExitCard.test.tsx`: 12개 신규 테스트 (stationName/line null → no-op, 데이터 없음/실패 → hide, 출구 렌더, destination 정렬, provider 재조회, 기본 MockProvider)
- [x] `AlarmOverlay.test.tsx`: 3개 신규 테스트 (line 미전달 → 섹션 없음, null → 없음, line 있으면 카드 나타남)
- [x] 전체 커버리지: AlarmOverlay 100%, StationExitCard 100%
- [x] `npm run type-check` 통과
- [x] widgetStorage/stationNotification 33건 실패는 기존 known local artifact (CI에서 pass)

Closes #1289