### PR TITLE
fix(#1280): silent-push-driven position upload (WhileInUse 위치 채널)

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -99,6 +99,22 @@ jest.mock('../../../nearest-station/utils/motionActivity', () => ({
   getCurrentMotionStationary: () => mockGetMotionStationary(),
 }));
 
+// #1280 — silent-push-driven position upload. expo-location 마지막 fix + uploadPosition mock.
+const mockGetLastKnownPositionAsync = jest.fn();
+jest.mock('expo-location', () => ({
+  getLastKnownPositionAsync: (...args: unknown[]) => mockGetLastKnownPositionAsync(...args),
+}));
+const mockUploadPosition = jest.fn();
+jest.mock('../../../nearest-station/api/positionUpload', () => ({
+  uploadPosition: (...args: unknown[]) => mockUploadPosition(...args),
+}));
+
+// #1278 — subsurface stamp. 기본 false (지상), 특정 테스트에서 override.
+const mockGetSubsurfaceState = jest.fn(async (): Promise<boolean> => false);
+jest.mock('../../../../shared/utils/subsurfaceState', () => ({
+  getSubsurfaceState: () => mockGetSubsurfaceState(),
+}));
+
 const mockGetBoardingLock = jest.fn();
 jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
@@ -226,6 +242,12 @@ describe('silentPushTask', () => {
     mockCheckGate.mockResolvedValue(PASSING_GATE);
     mockGetFiredAlarms.mockResolvedValue(new Set<string>());
     mockSetFiredAlarms.mockResolvedValue(undefined);
+    // #1280 / #1278 기본값.
+    mockGetLastKnownPositionAsync.mockResolvedValue(null);
+    mockUploadPosition.mockReturnValue(undefined);
+    mockGetSubsurfaceState.mockResolvedValue(false);
+    // motion 기본 false — 테스트에서 true override 시 다음 테스트로 누수 방지.
+    mockGetMotionStationary.mockReturnValue(false);
     (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
       if (key === DESTINATION_KEY) return JSON.stringify(destStation);
       if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
@@ -665,6 +687,51 @@ describe('silentPushTask', () => {
       );
       expect(mockCheckGate).not.toHaveBeenCalled();
       expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+    });
+
+    // #1280 — silent push로 깨어나면 마지막 좋은 fix를 backend로 upload (WhileInUse 위치 채널).
+    it('#1280 마지막 fix가 있으면 backend로 uploadPosition (silent-push-driven)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue({
+        coords: { latitude: 37.4979, longitude: 127.0276, accuracy: 18 },
+        timestamp: 1_700_000_000_000,
+      });
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockUploadPosition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: DEFAULT_APNS_TOKEN,
+          lat: 37.4979,
+          lng: 127.0276,
+          accuracy: 18,
+          ts: 1_700_000_000_000,
+          motion: 'unknown',
+        }),
+      );
+    });
+
+    it('#1280 motion stationary + accuracy 없으면 motion=stationary, accuracy=0', async () => {
+      mockGetMotionStationary.mockReturnValue(true);
+      mockGetLastKnownPositionAsync.mockResolvedValue({
+        coords: { latitude: 37.4979, longitude: 127.0276 },
+        timestamp: 1_700_000_000_000,
+      });
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockUploadPosition).toHaveBeenCalledWith(
+        expect.objectContaining({ motion: 'stationary', accuracy: 0 }),
+      );
+    });
+
+    it('#1280 마지막 fix가 없으면 uploadPosition 호출 안 함', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(null);
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      expect(mockUploadPosition).not.toHaveBeenCalled();
+    });
+
+    it('#1280 위치 조회 throw해도 graceful (전체 흐름 계속)', async () => {
+      mockGetLastKnownPositionAsync.mockRejectedValue(new Error('loc fail'));
+      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+      // 발사 흐름은 정상 진행.
+      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      expect(mockUploadPosition).not.toHaveBeenCalled();
     });
 
     it('게이트 통과 시 destination 즉시 발사 + fired 로그 + FIRED_ALARMS 갱신', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -53,6 +53,8 @@ import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
 import { getCurrentMotionStationary } from '../../nearest-station/utils/motionActivity';
+import { uploadPosition, type PositionMotion } from '../../nearest-station/api/positionUpload';
+import * as Location from 'expo-location';
 import { addFiredPushId } from '../utils/firedPushIds';
 import {
   checkSilentPushLocationGate,
@@ -462,6 +464,35 @@ async function loadLocklessOptIn(): Promise<boolean> {
 }
 
 /**
+ * #1280 — silent push wakeup을 위치 채널로 재활용 (트레이드오프 A).
+ *
+ * WhileInUse 권한에선 BG 위치 task(backgroundLocationTask)가 fire되지 않아 POST /position이
+ * 영구 0건 → backend 위치 지능(Kalman/phase/lock advance/boarding-prompt window)이 굶는다.
+ * backend가 매 cron 보내는 silent push가 device를 깨운 이 시점에, 마지막 좋은 fix를 backend로
+ * upload해 Always 권한 없이도 위치 채널을 점등한다.
+ *
+ * getLastKnownPositionAsync는 즉답(콜드 fetch 아님)이라 짧은 BG 윈도우에 안전. fire-and-forget —
+ * 위치 미준비/오류/URL 미설정 모두 graceful(다음 push에서 자연 retry).
+ */
+async function uploadPositionFromSilentPush(apnsToken: string): Promise<void> {
+  try {
+    const last = await Location.getLastKnownPositionAsync({ maxAge: 60_000 });
+    if (!last) return;
+    const motion: PositionMotion = getCurrentMotionStationary() ? 'stationary' : 'unknown';
+    void uploadPosition({
+      token: apnsToken,
+      lat: last.coords.latitude,
+      lng: last.coords.longitude,
+      accuracy: last.coords.accuracy ?? 0,
+      ts: last.timestamp,
+      motion,
+    });
+  } catch {
+    // graceful — BG 위치 미준비/오류는 무시.
+  }
+}
+
+/**
  * Task 콜백 본체 — 단위 테스트가 직접 호출할 수 있도록 export.
  */
 export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
@@ -788,6 +819,11 @@ async function fireWithGate(
   // #1273 D3 — payloadHopIndex는 백엔드 silent push payload의 절대 시퀀스 SSOT. wire.
   // currentHopIndex는 D1(#1207) hop estimator 미연결 단계라 undefined — 둘 중 하나라도
   // 없으면 gate가 거리 기반 widened fallback 경로로 동작한다.
+  // #1280 — silent push로 깨어난 이 시점에 마지막 좋은 fix를 backend로 upload (WhileInUse 위치 채널).
+  if (apnsToken) {
+    await uploadPositionFromSilentPush(apnsToken);
+  }
+
   // #1278 — 지하(subsurface) 여부를 stamp(#1279)에서 읽어 게이트에 전달.
   // true + intermediate면 게이트가 GPS 거리 검증을 우회하고 backend push를 신뢰한다.
   const subsurface = await getSubsurfaceState();


### PR DESCRIPTION
## Summary
WhileInUse 권한에선 BG 위치 task가 fire 안 돼 POST /position이 영구 0건 → backend 위치 지능(Kalman/phase/lock advance/boarding-prompt window)이 굶던 문제(#1280). backend가 매 cron 보내는 silent push가 device를 깨운 시점에 마지막 좋은 fix를 backend로 upload해 **Always 권한 없이 위치 채널 점등**(트레이드오프 A).
- `getLastKnownPositionAsync`(즉답, 콜드 fetch 아님)로 짧은 BG 윈도우에서 안전.
- fire-and-forget + graceful.

## 의존성 / 범위
- **#1278에 스택** (base `fix/#1278-gate-subsurface-bypass`, 그 위 #1279). silentPushTask 공유. 앞 PR 머지 시 GitHub 자동 retarget.
- 범위: silent-push-driven upload. FG 연속 upload(앱 포그라운드 10초 주기)는 useFusedNearestStation/#1286과 파일 겹쳐 follow-up으로 분리.

## Test plan
- [x] silentPushTask.ts 100% 커버리지, 155 테스트 통과
- [x] `npm run type-check` 통과
- [ ] 실기기: WhileInUse + trip 중 backend POST /position 수신 (wrangler tail)

Closes #1280