### PR TITLE
fix(#1298): subsurface 발사 연결

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3582,4 +3582,195 @@ describe('useStationAlarm', () => {
       expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
   });
+
+  // #1290/#1298 — subsurfaceStationDetected verdict 기반 station-passed 발사.
+  // GPS 거리/정확도 게이트 우회 — fusion 레이어가 이미 ≥2 신호 합의 + 역 근접 통과시킨 신호.
+  describe('#1298 subsurfaceStationDetected → station-passed 발사', () => {
+    const routeDirect = makeDirectRoute(3, '2');
+    const onRouteStation = makeStation('S-SUB', '봉은사', 37.5, 127.0);
+
+    function subsurfaceInputs(
+      overrides: Partial<UseStationAlarmInputs> = {},
+    ): UseStationAlarmInputs {
+      return defaultInputs({
+        route: routeDirect,
+        destination,
+        nearestStation: onRouteStation,
+        // GPS 게이트 차단 상태 (accuracy 불량) — subsurface path는 이 게이트를 우회해야 함
+        accuracyMeters: 500,
+        userLocation: null,
+        speedMps: null,
+        subsurfaceStationDetected: true,
+        ...overrides,
+      });
+    }
+
+    it('subsurfaceStationDetected=true + 새 station → station-passed 발사 (GPS 게이트 무관)', async () => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 2,
+        isTransfer: false,
+        stopsToDestination: 2,
+      });
+
+      renderHook(() => useStationAlarm(subsurfaceInputs()));
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // GPS phase 알람은 accuracyMeters=500으로 차단
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + 이미 발사한 station → dedup으로 미발사', async () => {
+      // lastNotifiedStationId가 이미 onRouteStation.id → 중복 차단
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+
+      renderHook(() => useStationAlarm(subsurfaceInputs()));
+
+      await waitFor(() => expect(mockLogSuppressedDedupStation).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=false → 기존 GPS path 동작 유지 (회귀 없음)', () => {
+      renderHook(() =>
+        useStationAlarm(
+          subsurfaceInputs({
+            subsurfaceStationDetected: false,
+          }),
+        ),
+      );
+
+      // GPS 게이트 차단(accuracyMeters=500) + subsurface=false → 어떤 경로도 발화 안 함
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected 미전달(undefined) → 기존 동작 유지 (graceful fallback)', () => {
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirect,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+          }),
+        ),
+      );
+
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + nearestStation이 route 위에 없음(다른 노선) → 미발사', async () => {
+      // routeDirect는 line='2' 기반. 다른 노선 역은 isStationOnRoute에서 false.
+      const offRouteStation: Station = { ...makeStation('S-OFF', '노원', 37.655, 127.061), line: '7' };
+
+      renderHook(() =>
+        useStationAlarm(
+          subsurfaceInputs({
+            nearestStation: offRouteStation,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + route=null → 미발사 (guard)', async () => {
+      renderHook(() =>
+        useStationAlarm(
+          subsurfaceInputs({
+            route: null,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + destination=null → 미발사 (guard)', async () => {
+      renderHook(() =>
+        useStationAlarm(
+          subsurfaceInputs({
+            destination: null,
+          }),
+        ),
+      );
+
+      // destination=null이면 hydration도 complete되지 않으므로 waitFor 없이 검증
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + nearestStation=null → 미발사 (guard)', async () => {
+      renderHook(() =>
+        useStationAlarm(
+          subsurfaceInputs({
+            nearestStation: null,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + hydrationPhase 미완료(pre-hydrate) → 미발사', () => {
+      // awaitInitialScheduledAlarmDrain을 pending 상태로 두면 hydrationPhase가 ready 미진입
+      mockAwaitInitialScheduledAlarmDrain.mockReturnValue(new Promise(() => {}));
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+
+      renderHook(() => useStationAlarm(subsurfaceInputs()));
+
+      // hydration 미완료이므로 발사 안 됨
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + destination 교체 직후(ref mismatch) → logRefMismatch + 미발사', async () => {
+      // 1) 첫 destination hydration 완료 후 subsurface 발사 확인.
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 2,
+        isTransfer: false,
+        stopsToDestination: 2,
+      });
+
+      const { rerender } = renderHook(
+        ({ dest }: { dest: Station }) =>
+          useStationAlarm(subsurfaceInputs({ destination: dest })),
+        { initialProps: { dest: destination } },
+      );
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+
+      // 2) destination 교체 → hydration 리셋(pre-hydrate). pending getFiredAlarms로 ready 미진입.
+      mockGetFiredAlarms.mockReturnValue(new Promise(() => {}));
+      mockSendStationPassedNotification.mockClear();
+      mockLogRefMismatch.mockClear();
+
+      rerender({ dest: altDestination });
+      // hydration이 pending이라 ref는 아직 destination.id. subsurface effect가 altDestination.id ≠ ref → logRefMismatch.
+      await waitFor(() => expect(mockLogRefMismatch).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurfaceStationDetected=true + IIFE 중 cleanup → 후속 dispatch 미실행 (cancelled guard)', async () => {
+      const resolvers: Array<(v: null) => void> = [];
+      mockGetBoardingLock.mockImplementation(
+        () =>
+          new Promise<null>((r) => {
+            resolvers.push(r);
+          }),
+      );
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+
+      const { unmount } = renderHook(() => useStationAlarm(subsurfaceInputs()));
+      await waitFor(() => expect(mockGetBoardingLock).toHaveBeenCalled());
+      unmount();
+      resolvers.forEach((r) => r(null));
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -319,6 +319,13 @@ export interface UseStationAlarmInputs {
    * 빈 배열/미전달이면 게이트 미적용(graceful).
    */
   arcStations?: readonly Station[];
+  /**
+   * #1290/#1298 — useFusedNearestStation.subsurfaceStationDetected 패스스루.
+   * true이면 지하(subsurface=true) + barometer-stop/motion-stationary/arvlcd-arrived ≥2 합의 +
+   * 역 근접 게이트를 모두 통과한 상태. GPS/arrival 게이트와 독립적으로 station-passed 발사 트리거.
+   * 미전달/false면 기존 동작 유지(graceful fallback).
+   */
+  subsurfaceStationDetected?: boolean;
 }
 
 export function useStationAlarm({
@@ -337,6 +344,7 @@ export function useStationAlarm({
   skipWarmupGuard = false,
   currentHopIndex = null,
   arcStations,
+  subsurfaceStationDetected = false,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   // #699: firedAlarmsRef의 내용이 어느 destinationId에 속하는지 추적.
@@ -1033,5 +1041,66 @@ export function useStationAlarm({
     currentHopIndex,
     // #1266 — fast-path hop window 게이트 입력. arcStations 변화 시(환승 후 leg 전환 등) 재평가.
     arcStations,
+  ]);
+
+  // #1290/#1298 — subsurface verdict 기반 station-passed 발사.
+  // subsurfaceStationDetected=true: 지하(subsurface=true) + ≥2 신호 합의(barometer-stop/
+  // motion-stationary/arvlcd-arrived) + 역 근접 게이트를 useFusedNearestStation이 이미 통과시킨 상태.
+  // GPS 거리/정확도 게이트가 이미 fusion 레이어에서 무효화된 신호이므로 여기서 재적용하지 않는다.
+  // dedup: lastNotifiedStationId 단일 출처 — GPS/FG-arvlcd/subsurface 세 경로 중 첫 발사 이후 나머지 자동 dedup.
+  useEffect(() => {
+    if (!subsurfaceStationDetected) return;
+    if (hydrationPhase !== 'ready') return;
+    if (!route || !destination) return;
+    if (!nearestStation) return;
+    if (firedAlarmsRefDestIdRef.current !== destination.id) {
+      logRefMismatch(destination.id, firedAlarmsRefDestIdRef.current);
+      return;
+    }
+    if (!isStationOnRoute(nearestStation, route)) return;
+
+    const candidateStation = nearestStation;
+    const capturedRoute = route;
+    const capturedDestinationId = destination.id;
+    const capturedDestinationName = destination.name;
+
+    let cancelled = false;
+    void (async () => {
+      const lock = await getBoardingLock();
+      if (cancelled) return;
+      await runSilenceGateAndDispatch({
+        source: 'fg',
+        candidateStation,
+        capturedRoute,
+        capturedDestinationId,
+        capturedDestinationName,
+        notificationSource,
+        isCancelled: () => cancelled,
+        errorLogPrefix: 'subsurface station-passed 알림 실패:',
+        dismissSilence,
+        userLocation,
+        clearDismissSilenceAction,
+        sleepMode: sleepModeRef.current,
+        currentHopIndex,
+        lock,
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    subsurfaceStationDetected,
+    hydrationPhase,
+    route,
+    destination?.id,
+    destination?.name,
+    nearestStation?.id,
+    dismissSilence,
+    clearDismissSilenceAction,
+    userLocation?.lat,
+    userLocation?.lng,
+    notificationSource,
+    currentHopIndex,
   ]);
 }


### PR DESCRIPTION
## Summary

- `useStationAlarm`에 `subsurfaceStationDetected?: boolean` 입력 추가 (#1290이 `useFusedNearestStation`에 노출한 필드 소비)
- `subsurfaceStationDetected===true`이면 GPS 거리/정확도 게이트 우회하여 station-passed 즉시 발사 — fusion 레이어(barometer-stop + motion-stationary + arvlcd-arrived ≥2 합의 + 역 근접)가 이미 통과한 신호이므로 FG 레이어 재적용 불필요
- dedup: `lastNotifiedStationId` 단일 출처 — GPS/FG-arvlcd/subsurface 세 경로 공유, 첫 발사 이후 나머지 자동 dedup
- `subsurfaceStationDetected===false`/미전달: 기존 동작 완전 불변 (graceful fallback)
- 단위 테스트 173개 (신규 12개): 발사 / dedup / subsurface=false 회귀 / route=null guard / nearestStation=null guard / off-route / hydration 미완료 / ref-mismatch / IIFE cancelled

## Files Changed

- `src/features/alarm/hooks/useStationAlarm.ts` — 새 effect + 인터페이스 추가
- `src/features/alarm/hooks/__tests__/useStationAlarm.test.ts` — `#1298` describe 블록 신규

## Test Results

- `npm test`: useStationAlarm 173/173 pass, 100% coverage
- `npm run type-check`: pass
- 알려진 로컬 네이티브 mock 아티팩트 (`widgetStorage` / `stationNotification` ~33): CI PASS (무시)

Closes #1298