### PR TITLE
feat(#1308): iOS Low Power Mode 감지 + DebugModal 노출 (텔레메트리)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "expo": "~54.0.33",
         "expo-av": "~16.0.8",
         "expo-background-task": "~1.0.10",
+        "expo-battery": "~10.0.8",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.20",
         "expo-linking": "~8.0.11",
@@ -8254,6 +8255,16 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-battery": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/expo-battery/-/expo-battery-10.0.8.tgz",
+      "integrity": "sha512-4rwg603XNEnMO5XnM0exq3JJMrJmJcQJegh6lkobLUDZPGHXwxE+4b9kDcYcW8+m2v1BenUnr8tNVla6llYQUA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "expo": "~54.0.33",
     "expo-av": "~16.0.8",
     "expo-background-task": "~1.0.10",
+    "expo-battery": "~10.0.8",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",
     "expo-linking": "~8.0.11",

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -65,6 +65,7 @@ import type { FusionConfidence, FusionSource } from '../../../shared/types/fusio
 import type { NearestStationResult } from '../../../shared/types/station';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
 import { useBarometer } from '../../../shared/hooks/useBarometer';
+import { useLowPowerMode } from '../../../shared/hooks/useLowPowerMode';
 
 /**
  * #1215 (D9) — DebugModal 상태 가시화 신규 prop 묶음.
@@ -215,6 +216,7 @@ function silentPushDiagRows(
   d: SilentPushDiagnostics,
   logs: readonly AlarmLogEntry[],
   locklessOn: boolean,
+  lowPowerMode: boolean,
 ): { uiLabel: string; dumpKey: string; value: string }[] {
   const task = d.taskRegistrationError
     ? `${d.taskRegistrationState} (${d.taskRegistrationError})`
@@ -223,6 +225,9 @@ function silentPushDiagRows(
   const receivedValue = buildSilentPushCountValue(silentCounts.received, formatAt(d.lastReceivedAt));
   const firedValue = buildSilentPushCountValue(silentCounts.fired, formatAt(d.lastFiredAt));
   const toggleValue = locklessOn ? SILENT_PUSH_LABELS.toggleOn : SILENT_PUSH_LABELS.toggleOff;
+  // #1308 — LPM은 silent push를 throttle/drop 한다. received 카운트 옆에 두어 "LPM ON인데
+  // received가 안 늘어남"을 한눈에 보고 측정할 수 있게 한다.
+  const lowPowerValue = lowPowerMode ? 'ON' : 'off';
   return [
     { uiLabel: 'permission', dumpKey: 'permission', value: d.permissionStatus ?? '(unknown)' },
     { uiLabel: 'apnsToken', dumpKey: 'apnsToken', value: formatTokenTail(d.apnsToken) },
@@ -248,6 +253,7 @@ function silentPushDiagRows(
       dumpKey: SILENT_PUSH_LABELS.toggleKey,
       value: toggleValue,
     },
+    { uiLabel: 'lowPower', dumpKey: 'lowPowerMode', value: lowPowerValue },
   ];
 }
 
@@ -334,6 +340,8 @@ function buildDumpText(args: {
   // #856: lockless station-passed toggle ON/OFF — Silent Push 섹션 row의 SSOT.
   // optional — DebugModal 본체는 항상 전달, 단순 dump 단위 테스트는 생략 가능(기본 false).
   locklessOn?: boolean;
+  // #1308: iOS 저전력 모드. optional — 미전달 시 false(off). silent push 측정용.
+  lowPowerMode?: boolean;
   // #756: OS 큐 dump. 미전달/null = DebugModal에서 한 번도 Refresh 안 한 상태.
   scheduledDump?: ScheduledNotificationDumpEntry[] | null;
   // #1215 (D9) — 추가 상태 가시화. 모두 optional — 미전달 시 dump의 해당 라인은 '—' 표기.
@@ -413,7 +421,12 @@ function buildDumpText(args: {
   lines.push('', '## Arrival', args.arrivalSummary);
   if (args.isMock) lines.push('(MOCK)');
   lines.push('', '## Silent Push');
-  for (const { dumpKey, value } of silentPushDiagRows(args.silentPush, args.logs, args.locklessOn ?? false)) {
+  for (const { dumpKey, value } of silentPushDiagRows(
+    args.silentPush,
+    args.logs,
+    args.locklessOn ?? false,
+    args.lowPowerMode ?? false,
+  )) {
     lines.push(`${dumpKey}=${value}`);
   }
   lines.push('');
@@ -572,6 +585,8 @@ function DebugModalInner({
   // #1215 (D9) — 기압계 subsurface. useBarometer는 shared/hooks이라 의존 위배 없음.
   // useFusedNearestStation 내부 useBarometer와 별개 listener — DebugModal 관찰자 효과 허용 범위.
   const { subsurface: barometerSubsurface } = useBarometer();
+  // #1308 — iOS 저전력 모드. silent push throttle 측정용 텔레메트리 (동작 변경 없음).
+  const lowPowerMode = useLowPowerMode();
   const fusedLabel = formatStationLabel(result);
   const gpsLabel = formatStationLabel(gpsResult);
   const differs = fusedDiffersFromGps(result, gpsResult);
@@ -710,6 +725,7 @@ function DebugModalInner({
       silentPush,
       logs,
       locklessOn,
+      lowPowerMode,
       scheduledDump,
       barometerSubsurface,
       fusionDetection,
@@ -738,6 +754,7 @@ function DebugModalInner({
     silentPush,
     logs,
     locklessOn,
+    lowPowerMode,
     scheduledDump,
     barometerSubsurface,
     fusionDetection,
@@ -898,9 +915,11 @@ function DebugModalInner({
           </Section>
 
           <Section title="Silent Push" colors={colors}>
-            {silentPushDiagRows(silentPush, logs, locklessOn).map(({ uiLabel, value }) => (
-              <KeyValue key={uiLabel} label={uiLabel} value={value} colors={colors} />
-            ))}
+            {silentPushDiagRows(silentPush, logs, locklessOn, lowPowerMode).map(
+              ({ uiLabel, value }) => (
+                <KeyValue key={uiLabel} label={uiLabel} value={value} colors={colors} />
+              ),
+            )}
           </Section>
 
           <BoardingLockSection lock={lock} colors={colors} />

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -15,6 +15,7 @@ const mockUseSilentPushDiagnostics = jest.fn();
 const mockGetAlarmLog = jest.fn();
 const mockClearAlarmLog = jest.fn();
 const mockUseBarometer = jest.fn();
+const mockUseLowPowerMode = jest.fn();
 // #1235 (D9 wire) — DebugModal이 destinationStore + tripStartStorage SSOT로 trip props 도출.
 const mockGetTripStartedAt = jest.fn();
 jest.mock('../../../alarm/utils/tripStartStorage', () => ({
@@ -30,6 +31,10 @@ jest.mock('../../../arrival/hooks/useArrivalInfo', () => ({
 // #1215 (D9) — DebugModal이 직접 useBarometer를 구독해 subsurface row를 렌더한다.
 jest.mock('../../../../shared/hooks/useBarometer', () => ({
   useBarometer: () => mockUseBarometer(),
+}));
+// #1308 — DebugModal이 useLowPowerMode를 구독해 Silent Push 섹션 lowPower row를 렌더한다.
+jest.mock('../../../../shared/hooks/useLowPowerMode', () => ({
+  useLowPowerMode: () => mockUseLowPowerMode(),
 }));
 // silentPushTask는 expo-task-manager native module이 필요 — jest 환경에서 chain break.
 jest.mock('../../../alarm/hooks/useSilentPushDiagnostics', () => ({
@@ -148,6 +153,8 @@ const setupHookDefaults = () => {
   mockDumpScheduledNotifications.mockResolvedValue([]);
   // #1215 (D9) — 기본은 subsurface=false (지상).
   mockUseBarometer.mockReturnValue({ subsurface: false, stop: undefined });
+  // #1308 — 기본은 LPM off.
+  mockUseLowPowerMode.mockReturnValue(false);
   // #1235 (D9 wire) — tripStartedAt 기본 null (trip 미시작).
   mockGetTripStartedAt.mockResolvedValue(null);
   // #1235 (D9 wire) — destinationStore/settingsStore SSOT 초기화. 매 테스트 독립.
@@ -308,6 +315,20 @@ describe('DebugModal', () => {
     });
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByText('failed (not supported)')).toBeTruthy();
+  });
+
+  it('Silent Push 섹션: LPM off면 lowPower row가 off로 노출된다 (#1308)', () => {
+    mockUseLowPowerMode.mockReturnValue(false);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('lowPower')).toBeTruthy();
+    expect(screen.getAllByText('off').length).toBeGreaterThan(0);
+  });
+
+  it('Silent Push 섹션: LPM on이면 lowPower row가 ON으로 노출된다 (#1308)', () => {
+    mockUseLowPowerMode.mockReturnValue(true);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('lowPower')).toBeTruthy();
+    expect(screen.getByText('ON')).toBeTruthy();
   });
 
   it('Silent Push 섹션: trip 입력이 모두 있으면 set/destination id/currStn id 노출 (#506)', () => {
@@ -663,6 +684,16 @@ describe('DebugModal helpers', () => {
     expect(dump).toContain('## Arrival');
     expect(dump).toContain('(MOCK)');
     expect(dump).toContain('## Alarm log (1)');
+  });
+
+  it('buildDumpText: lowPowerMode=true면 lowPowerMode=ON 라인을 포함한다 (#1308)', () => {
+    const dump = __test__.buildDumpText(makeDumpArgs({ lowPowerMode: true }));
+    expect(dump).toContain('lowPowerMode=ON');
+  });
+
+  it('buildDumpText: lowPowerMode 미전달이면 lowPowerMode=off로 fallback한다 (#1308)', () => {
+    const dump = __test__.buildDumpText(makeDumpArgs());
+    expect(dump).toContain('lowPowerMode=off');
   });
 
   it('buildDumpText: fused != gps이면 diff 라인을 추가한다', () => {

--- a/src/shared/hooks/__tests__/useLowPowerMode.test.ts
+++ b/src/shared/hooks/__tests__/useLowPowerMode.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+const mockReadLowPowerMode = jest.fn();
+const mockSubscribeLowPowerMode = jest.fn();
+const mockUnsubscribe = jest.fn();
+
+jest.mock('../../utils/lowPowerState', () => ({
+  readLowPowerMode: (...args: unknown[]) => mockReadLowPowerMode(...args),
+  subscribeLowPowerMode: (...args: unknown[]) => mockSubscribeLowPowerMode(...args),
+}));
+
+import { useLowPowerMode } from '../useLowPowerMode';
+
+type Listener = (enabled: boolean) => void;
+
+beforeEach(() => {
+  mockReadLowPowerMode.mockReset();
+  mockSubscribeLowPowerMode.mockReset();
+  mockUnsubscribe.mockReset();
+  mockReadLowPowerMode.mockResolvedValue(false);
+  mockSubscribeLowPowerMode.mockReturnValue(mockUnsubscribe);
+});
+
+it('마운트 시 현재 LPM 상태를 조회해 반영한다', async () => {
+  mockReadLowPowerMode.mockResolvedValue(true);
+  const { result } = renderHook(() => useLowPowerMode());
+  expect(result.current).toBe(false);
+  await waitFor(() => expect(result.current).toBe(true));
+});
+
+it('구독 listener가 발화하면 상태가 갱신된다', async () => {
+  const { result } = renderHook(() => useLowPowerMode());
+  await waitFor(() => expect(mockSubscribeLowPowerMode).toHaveBeenCalled());
+  const listener = mockSubscribeLowPowerMode.mock.calls[0][0] as Listener;
+  act(() => listener(true));
+  expect(result.current).toBe(true);
+  act(() => listener(false));
+  expect(result.current).toBe(false);
+});
+
+it('unmount 시 구독을 해제한다', async () => {
+  const { unmount } = renderHook(() => useLowPowerMode());
+  await waitFor(() => expect(mockSubscribeLowPowerMode).toHaveBeenCalled());
+  unmount();
+  expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+});
+
+it('unmount 후 비동기 조회가 늦게 끝나도 상태를 갱신하지 않는다 (cancelled 가드)', async () => {
+  let resolveRead: ((value: boolean) => void) | null = null;
+  mockReadLowPowerMode.mockReturnValue(
+    new Promise<boolean>((resolve) => {
+      resolveRead = resolve;
+    }),
+  );
+  const { unmount } = renderHook(() => useLowPowerMode());
+  unmount();
+  await act(async () => {
+    resolveRead?.(true);
+    await Promise.resolve();
+  });
+  // unmount 후 listener도 발화하지 않는다 — cancelled 가드로 setState 미호출.
+  const listener = mockSubscribeLowPowerMode.mock.calls[0][0] as Listener;
+  expect(() => listener(true)).not.toThrow();
+});

--- a/src/shared/hooks/useLowPowerMode.ts
+++ b/src/shared/hooks/useLowPowerMode.ts
@@ -1,0 +1,41 @@
+/**
+ * #1308 — iOS 저전력 모드(Low Power Mode) 관찰 훅 (텔레메트리 전용).
+ *
+ * mount 시 현재 상태를 1회 조회하고, 이후 변화를 구독한다. unmount 시 구독 해제.
+ * 미지원/throw는 lowPowerState 모듈이 false로 흡수한다 (graceful).
+ *
+ * 본 훅은 동작을 바꾸지 않는다 — DebugModal 노출/측정용. LPM 기반 분기(예: prescheduled
+ * 선호)는 아키텍처 결정 이후 별도 sub-issue.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  readLowPowerMode,
+  subscribeLowPowerMode,
+} from '../utils/lowPowerState';
+
+/**
+ * 현재 저전력 모드 활성 여부. 초기값 false(보수적), 조회/구독으로 갱신.
+ */
+export function useLowPowerMode(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void readLowPowerMode().then((value) => {
+      if (!cancelled) setEnabled(value);
+    });
+
+    const unsubscribe = subscribeLowPowerMode((value) => {
+      if (!cancelled) setEnabled(value);
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  return enabled;
+}

--- a/src/shared/utils/__tests__/lowPowerState.test.ts
+++ b/src/shared/utils/__tests__/lowPowerState.test.ts
@@ -1,0 +1,73 @@
+const mockIsLowPowerModeEnabledAsync = jest.fn();
+const mockAddLowPowerModeListener = jest.fn();
+const mockRemove = jest.fn();
+
+jest.mock('expo-battery', () => ({
+  isLowPowerModeEnabledAsync: (...args: unknown[]) =>
+    mockIsLowPowerModeEnabledAsync(...args),
+  addLowPowerModeListener: (...args: unknown[]) =>
+    mockAddLowPowerModeListener(...args),
+}));
+
+import { readLowPowerMode, subscribeLowPowerMode } from '../lowPowerState';
+
+type ModeListener = (event: { lowPowerMode: boolean }) => void;
+
+beforeEach(() => {
+  mockIsLowPowerModeEnabledAsync.mockReset();
+  mockAddLowPowerModeListener.mockReset();
+  mockRemove.mockReset();
+  mockAddLowPowerModeListener.mockReturnValue({ remove: mockRemove });
+});
+
+describe('readLowPowerMode', () => {
+  it('LPM on이면 true를 반환한다', async () => {
+    mockIsLowPowerModeEnabledAsync.mockResolvedValue(true);
+    await expect(readLowPowerMode()).resolves.toBe(true);
+  });
+
+  it('LPM off면 false를 반환한다', async () => {
+    mockIsLowPowerModeEnabledAsync.mockResolvedValue(false);
+    await expect(readLowPowerMode()).resolves.toBe(false);
+  });
+
+  it('네이티브가 throw하면 false로 폴백한다', async () => {
+    mockIsLowPowerModeEnabledAsync.mockRejectedValue(new Error('unsupported'));
+    await expect(readLowPowerMode()).resolves.toBe(false);
+  });
+});
+
+describe('subscribeLowPowerMode', () => {
+  it('상태 변화를 listener에 boolean으로 전달한다', () => {
+    const listener = jest.fn();
+    subscribeLowPowerMode(listener);
+    const native = mockAddLowPowerModeListener.mock.calls[0][0] as ModeListener;
+    native({ lowPowerMode: true });
+    expect(listener).toHaveBeenCalledWith(true);
+    native({ lowPowerMode: false });
+    expect(listener).toHaveBeenCalledWith(false);
+  });
+
+  it('반환된 함수 호출 시 구독을 해제한다', () => {
+    const unsubscribe = subscribeLowPowerMode(jest.fn());
+    unsubscribe();
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('addListener가 throw하면 no-op 구독을 반환한다 (graceful)', () => {
+    mockAddLowPowerModeListener.mockImplementation(() => {
+      throw new Error('unsupported');
+    });
+    const unsubscribe = subscribeLowPowerMode(jest.fn());
+    expect(() => unsubscribe()).not.toThrow();
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('remove가 throw해도 cleanup이 throw하지 않는다 (graceful)', () => {
+    mockRemove.mockImplementation(() => {
+      throw new Error('detach failed');
+    });
+    const unsubscribe = subscribeLowPowerMode(jest.fn());
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});

--- a/src/shared/utils/lowPowerState.ts
+++ b/src/shared/utils/lowPowerState.ts
@@ -1,0 +1,51 @@
+/**
+ * #1308 — iOS 저전력 모드(Low Power Mode, LPM) 감지 thin wrapper (텔레메트리 전용).
+ *
+ * 배경: iOS LPM은 silent(content-available) push를 강하게 throttle/drop 한다. 현재 앱의
+ * BG 매역 알림은 silent push에 의존하므로 LPM에서 알림이 누락될 수 있다. 본 모듈은
+ * 감지 + 노출(진단)만 제공하며 동작을 바꾸지 않는다 — 실기기 evidence 측정용.
+ *
+ * graceful (CLAUDE.md §2, `feedback_whileinuse_must_work.md` 정책):
+ *   - 미지원 플랫폼 / 네이티브 throw → false 폴백. LPM 감지 실패가 핵심 기능을 막지 않는다.
+ *
+ * Android: expo-battery는 power-save mode를 동일 API로 노출한다 — 별도 분기 불필요
+ * (CLAUDE.md §3 데이터/플랫폼 주도, 하드코딩 분기 금지).
+ */
+
+import * as Battery from 'expo-battery';
+
+/**
+ * 현재 저전력 모드 상태를 1회 조회한다. 미지원/throw 시 false.
+ */
+export async function readLowPowerMode(): Promise<boolean> {
+  try {
+    return await Battery.isLowPowerModeEnabledAsync();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 저전력 모드 변화 구독. listener는 boolean 한 값만 받는다.
+ * 반환된 함수를 호출하면 구독 해제(graceful — remove throw도 무시).
+ */
+export function subscribeLowPowerMode(
+  listener: (enabled: boolean) => void,
+): () => void {
+  let subscription: { remove(): void } | null = null;
+  try {
+    subscription = Battery.addLowPowerModeListener(({ lowPowerMode }) => {
+      listener(lowPowerMode);
+    });
+  } catch {
+    subscription = null;
+  }
+
+  return () => {
+    try {
+      subscription?.remove();
+    } catch {
+      // 구독 해제 실패는 무시 — 텔레메트리 cleanup이 앱을 막아선 안 된다.
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- iOS 저전력 모드(LPM)는 silent(content-available) push를 강하게 throttle/drop 한다. 현재 앱 BG 매역 알림은 silent push 의존 → LPM에서 알림 누락 가능. 본 PR은 **감지 + 노출(진단)만** 추가하고 동작은 바꾸지 않는다 (decision-independent 텔레메트리).
- `src/shared/utils/lowPowerState.ts` — `expo-battery` 기반 thin wrapper. `readLowPowerMode()`(1회 조회) + `subscribeLowPowerMode()`(변화 구독). 미지원/throw는 false/no-op로 graceful 폴백.
- `src/shared/hooks/useLowPowerMode.ts` — mount 조회 + 변화 구독 + unmount cleanup. cancelled 가드로 unmount 후 setState 방지.
- `DebugModal` Silent Push 섹션에 `lowPower` row 추가 (`recv` 카운트 바로 인접) → 실기기 trip 중 "LPM ON인데 received가 안 늘어남"을 나란히 측정 가능. 텍스트 dump에도 `lowPowerMode=ON/off` 포함.
- `expo-battery ~10.0.8` 의존성 추가 (`npx expo install`).

## Non-goals (별도 sub-issue)
- LPM 기반 동작 분기 (예: prescheduled 선호) — 아키텍처 결정 이후.
- 사용자 대상 알림/가이드.

## Step 3 (LPM flag on push telemetry) — 의도적으로 skip
이슈의 optional step. silent-push 수신 텔레메트리는 backend BG task가 쓰는 AsyncStorage stamp 경로에 있어, LPM flag 첨부 시 alarm 슬라이스를 건드려야 하고 본 슬라이스의 decision-independence를 해친다. DebugModal에서 `lowPower` row를 `recv` 카운트 바로 옆에 두어 동일한 side-by-side 측정이 가능하므로 깊은 채널 첨부는 생략했다.

## Test plan
- [x] `npm run type-check` 통과
- [x] 변경 파일 3개 모두 jest coverage 100% (lines/branches/funcs/stmts)
- [x] 유닛 테스트: LPM on/off read, listener cleanup, unsupported/error fallback=false, hook cancelled 가드
- [x] DebugModal: LPM on/off row 렌더 + dump 라인 (renderWithTheme)
- [x] eslint(import/no-restricted-paths) 통과
- [ ] 실기기: 설정 > 배터리 > 저전력 모드 토글 → DebugModal `lowPower` row가 ON/off로 즉시 반영되는지 확인 (1주 trip evidence)

Closes #1308