### PR TITLE
fix(#1307): silent push payload에 server-authoritative subsurface 전달

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -211,68 +211,32 @@ describe('sendSilentPush', () => {
   });
 
   // #1307 — payload.subsurface wire 검증 (server-authoritative 지하 flag).
-  describe('subsurface (#1307)', () => {
-    it('payload.subsurface=true 시 body.data.subsurface로 전달', async () => {
-      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
-      await sendSilentPush({
-        deviceToken: 'tok',
-        payload: {
-          nextWaypoint: '강남',
-          etaSeconds: 0,
-          phase: 'imminent',
-          kind: 'intermediate',
-          sentAt: 1_700_000_000_000,
-          pushId: 'p',
-          subsurface: true,
-        },
-        config: makeConfig(),
-        host: TEST_HOST,
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-      });
-      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
-      expect(body.data.subsurface).toBe(true);
+  // true일 때만 wire, false/미지정은 byte-level 호환 위해 omit.
+  it.each([
+    ['true면 body.data.subsurface로 전달', true, true],
+    ['false면 body.data에서 omit (구 client/byte 호환)', false, false],
+    ['미지정이면 body.data에서 omit', undefined, false],
+  ])('subsurface %s (#1307)', async (_label, input, expectPresent) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '강남',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'intermediate',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ...(input === undefined ? {} : { subsurface: input }),
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
     });
-
-    it('payload.subsurface=false 시 body.data에서 누락 (구 client/byte 호환)', async () => {
-      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
-      await sendSilentPush({
-        deviceToken: 'tok',
-        payload: {
-          nextWaypoint: '강남',
-          etaSeconds: 0,
-          phase: 'imminent',
-          kind: 'intermediate',
-          sentAt: 1_700_000_000_000,
-          pushId: 'p',
-          subsurface: false,
-        },
-        config: makeConfig(),
-        host: TEST_HOST,
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-      });
-      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
-      expect('subsurface' in body.data).toBe(false);
-    });
-
-    it('payload.subsurface 미지정 시 body.data에서 누락', async () => {
-      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
-      await sendSilentPush({
-        deviceToken: 'tok',
-        payload: {
-          nextWaypoint: '강남',
-          etaSeconds: 0,
-          phase: 'imminent',
-          kind: 'intermediate',
-          sentAt: 1_700_000_000_000,
-          pushId: 'p',
-        },
-        config: makeConfig(),
-        host: TEST_HOST,
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-      });
-      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
-      expect('subsurface' in body.data).toBe(false);
-    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('subsurface' in body.data).toBe(expectPresent);
+    if (expectPresent) expect(body.data.subsurface).toBe(true);
   });
 
   it('uses sandbox host when provided', async () => {

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -210,6 +210,71 @@ describe('sendSilentPush', () => {
     });
   });
 
+  // #1307 — payload.subsurface wire 검증 (server-authoritative 지하 flag).
+  describe('subsurface (#1307)', () => {
+    it('payload.subsurface=true 시 body.data.subsurface로 전달', async () => {
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+      await sendSilentPush({
+        deviceToken: 'tok',
+        payload: {
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          sentAt: 1_700_000_000_000,
+          pushId: 'p',
+          subsurface: true,
+        },
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.data.subsurface).toBe(true);
+    });
+
+    it('payload.subsurface=false 시 body.data에서 누락 (구 client/byte 호환)', async () => {
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+      await sendSilentPush({
+        deviceToken: 'tok',
+        payload: {
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          sentAt: 1_700_000_000_000,
+          pushId: 'p',
+          subsurface: false,
+        },
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+      expect('subsurface' in body.data).toBe(false);
+    });
+
+    it('payload.subsurface 미지정 시 body.data에서 누락', async () => {
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+      await sendSilentPush({
+        deviceToken: 'tok',
+        payload: {
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          sentAt: 1_700_000_000_000,
+          pushId: 'p',
+        },
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+      expect('subsurface' in body.data).toBe(false);
+    });
+  });
+
   it('uses sandbox host when provided', async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('', { status: 200 }),

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -273,6 +273,28 @@ function makeTrip(overrides: Partial<Trip> = {}): Trip {
   };
 }
 
+/**
+ * apnsFetch mock에서 lockless intermediate(kind==='intermediate') 발사 1건의 payload data를
+ * 추출한다. 정확히 1건이 발사됐는지도 단언한다. (#1307 / #1273 lockless wire 검증 공용 헬퍼)
+ */
+function parseLocklessIntermediateData(apnsFetch: {
+  mock: { calls: unknown[][] };
+}): Record<string, unknown> {
+  const calls = apnsFetch.mock.calls.filter((c) => {
+    try {
+      const init = c[1] as { body?: unknown } | undefined;
+      const body = JSON.parse(init?.body as string) as { data?: { kind?: string } };
+      return body?.data?.kind === 'intermediate';
+    } catch {
+      return false;
+    }
+  });
+  expect(calls).toHaveLength(1);
+  const init = calls[0][1] as { body?: unknown };
+  const body = JSON.parse(init.body as string) as { data: Record<string, unknown> };
+  return body.data;
+}
+
 function makeSeoul(arrivals: ArrivalEntry[]): SeoulArrivalClient {
   return new SeoulArrivalClient({
     apiKey: 'K',
@@ -605,17 +627,8 @@ describe('runScheduled', () => {
         arrivals: [ARVL_ARRIVED],
         apnsOk: true,
       });
-      const calls = apnsFetch.mock.calls.filter((c) => {
-        try {
-          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
-          return body?.data?.kind === 'intermediate';
-        } catch {
-          return false;
-        }
-      });
-      expect(calls).toHaveLength(1);
-      const body = JSON.parse(calls[0][1].body as string) as { data: { hopIndex?: number } };
-      expect(body.data.hopIndex).toBe(3);
+      const data = parseLocklessIntermediateData(apnsFetch);
+      expect(data.hopIndex).toBe(3);
     });
 
     it('lockless intermediate 발사 시 waypoint.hopIndex 부재면 payload 본문에서도 hopIndex 누락', async () => {
@@ -630,21 +643,16 @@ describe('runScheduled', () => {
         arrivals: [ARVL_ARRIVED],
         apnsOk: true,
       });
-      const calls = apnsFetch.mock.calls.filter((c) => {
-        try {
-          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
-          return body?.data?.kind === 'intermediate';
-        } catch {
-          return false;
-        }
-      });
-      expect(calls).toHaveLength(1);
-      const body = JSON.parse(calls[0][1].body as string) as { data: Record<string, unknown> };
-      expect('hopIndex' in body.data).toBe(false);
+      const data = parseLocklessIntermediateData(apnsFetch);
+      expect('hopIndex' in data).toBe(false);
     });
 
     // #1307 — lockless intermediate도 server-authoritative subsurface flag forward.
-    it('lockless intermediate 발사 시 trip.subsurface=true가 payload.subsurface로 wire', async () => {
+    // trip.subsurface=true면 payload에 wire, 미설정이면 본문에서 omit.
+    it.each([
+      ['true면 payload.subsurface로 wire', true, true],
+      ['미설정이면 payload 본문에서 omit', undefined, false],
+    ])('lockless intermediate subsurface %s (#1307)', async (_label, input, expectPresent) => {
       const { apnsFetch } = await runLocklessCycle({
         trip: makeTrip({
           waypoints: [
@@ -652,47 +660,14 @@ describe('runScheduled', () => {
             { stationName: '역삼', line: '2', kind: 'destination', hopIndex: 4 },
           ],
           locklessStationPassed: true,
-          subsurface: true,
+          ...(input === undefined ? {} : { subsurface: input }),
         }),
         arrivals: [ARVL_ARRIVED],
         apnsOk: true,
       });
-      const calls = apnsFetch.mock.calls.filter((c) => {
-        try {
-          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
-          return body?.data?.kind === 'intermediate';
-        } catch {
-          return false;
-        }
-      });
-      expect(calls).toHaveLength(1);
-      const body = JSON.parse(calls[0][1].body as string) as { data: { subsurface?: boolean } };
-      expect(body.data.subsurface).toBe(true);
-    });
-
-    it('lockless intermediate 발사 시 trip.subsurface 미설정이면 payload 본문에서 subsurface 누락', async () => {
-      const { apnsFetch } = await runLocklessCycle({
-        trip: makeTrip({
-          waypoints: [
-            { stationName: '강남', line: '2', kind: 'intermediate', hopIndex: 3 },
-            { stationName: '역삼', line: '2', kind: 'destination', hopIndex: 4 },
-          ],
-          locklessStationPassed: true,
-        }),
-        arrivals: [ARVL_ARRIVED],
-        apnsOk: true,
-      });
-      const calls = apnsFetch.mock.calls.filter((c) => {
-        try {
-          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
-          return body?.data?.kind === 'intermediate';
-        } catch {
-          return false;
-        }
-      });
-      expect(calls).toHaveLength(1);
-      const body = JSON.parse(calls[0][1].body as string) as { data: Record<string, unknown> };
-      expect('subsurface' in body.data).toBe(false);
+      const data = parseLocklessIntermediateData(apnsFetch);
+      expect('subsurface' in data).toBe(expectPresent);
+      if (expectPresent) expect(data.subsurface).toBe(true);
     });
 
     it('lock 없음 + intermediate(ARRIVED) → 발사 후 다음 intermediate 남으면 waypoint advance', async () => {
@@ -3942,31 +3917,23 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     expect(data.hopIndex).toBeUndefined();
   });
 
-  // #1307 — server-authoritative subsurface flag forward.
-  it('payload.subsurface=true — trip.subsurface=true가 silent push 본문으로 forward', async () => {
-    const subsurfaceTrip = makeLockTripFixture('arvl-tok', { subsurface: true });
+  // #1307 — server-authoritative subsurface flag forward (arvlCd-fire 경로).
+  // trip.subsurface=true면 본문으로 forward, 미설정이면 omit.
+  it.each([
+    ['true면 본문으로 forward', true, true, 'p-arvl-sub'],
+    ['미설정이면 본문에서 omit', undefined, false, 'p-arvl-no-sub'],
+  ])('payload.subsurface %s (#1307)', async (_label, input, expectPresent, pushId) => {
     const { apnsFetch } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
-      trip: subsurfaceTrip,
-      pushId: 'p-arvl-sub',
+      ...(input === undefined ? {} : { trip: makeLockTripFixture('arvl-tok', { subsurface: input }) }),
+      pushId,
     });
     const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]) as Record<
       string,
       unknown
     >;
-    expect(data.subsurface).toBe(true);
-  });
-
-  it('payload.subsurface 누락 — trip.subsurface 미설정 시 본문에서도 누락', async () => {
-    const { apnsFetch } = await runArvlScheduled({
-      seoul: makeArrivalSeoul('중곡', 0, 1),
-      pushId: 'p-arvl-no-sub',
-    });
-    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]) as Record<
-      string,
-      unknown
-    >;
-    expect('subsurface' in data).toBe(false);
+    expect('subsurface' in data).toBe(expectPresent);
+    if (expectPresent) expect(data.subsurface).toBe(true);
   });
 
   it('arvlCd=0(ENTERING) → 매역 push 발사 (arvlCd=0 dedup key)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -643,6 +643,58 @@ describe('runScheduled', () => {
       expect('hopIndex' in body.data).toBe(false);
     });
 
+    // #1307 — lockless intermediate도 server-authoritative subsurface flag forward.
+    it('lockless intermediate 발사 시 trip.subsurface=true가 payload.subsurface로 wire', async () => {
+      const { apnsFetch } = await runLocklessCycle({
+        trip: makeTrip({
+          waypoints: [
+            { stationName: '강남', line: '2', kind: 'intermediate', hopIndex: 3 },
+            { stationName: '역삼', line: '2', kind: 'destination', hopIndex: 4 },
+          ],
+          locklessStationPassed: true,
+          subsurface: true,
+        }),
+        arrivals: [ARVL_ARRIVED],
+        apnsOk: true,
+      });
+      const calls = apnsFetch.mock.calls.filter((c) => {
+        try {
+          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
+          return body?.data?.kind === 'intermediate';
+        } catch {
+          return false;
+        }
+      });
+      expect(calls).toHaveLength(1);
+      const body = JSON.parse(calls[0][1].body as string) as { data: { subsurface?: boolean } };
+      expect(body.data.subsurface).toBe(true);
+    });
+
+    it('lockless intermediate 발사 시 trip.subsurface 미설정이면 payload 본문에서 subsurface 누락', async () => {
+      const { apnsFetch } = await runLocklessCycle({
+        trip: makeTrip({
+          waypoints: [
+            { stationName: '강남', line: '2', kind: 'intermediate', hopIndex: 3 },
+            { stationName: '역삼', line: '2', kind: 'destination', hopIndex: 4 },
+          ],
+          locklessStationPassed: true,
+        }),
+        arrivals: [ARVL_ARRIVED],
+        apnsOk: true,
+      });
+      const calls = apnsFetch.mock.calls.filter((c) => {
+        try {
+          const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
+          return body?.data?.kind === 'intermediate';
+        } catch {
+          return false;
+        }
+      });
+      expect(calls).toHaveLength(1);
+      const body = JSON.parse(calls[0][1].body as string) as { data: Record<string, unknown> };
+      expect('subsurface' in body.data).toBe(false);
+    });
+
     it('lock 없음 + intermediate(ARRIVED) → 발사 후 다음 intermediate 남으면 waypoint advance', async () => {
       const { kv } = await runLocklessCycle({
         trip: makeTrip({
@@ -3888,6 +3940,33 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     });
     const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]);
     expect(data.hopIndex).toBeUndefined();
+  });
+
+  // #1307 — server-authoritative subsurface flag forward.
+  it('payload.subsurface=true — trip.subsurface=true가 silent push 본문으로 forward', async () => {
+    const subsurfaceTrip = makeLockTripFixture('arvl-tok', { subsurface: true });
+    const { apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: subsurfaceTrip,
+      pushId: 'p-arvl-sub',
+    });
+    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]) as Record<
+      string,
+      unknown
+    >;
+    expect(data.subsurface).toBe(true);
+  });
+
+  it('payload.subsurface 누락 — trip.subsurface 미설정 시 본문에서도 누락', async () => {
+    const { apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      pushId: 'p-arvl-no-sub',
+    });
+    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]) as Record<
+      string,
+      unknown
+    >;
+    expect('subsurface' in data).toBe(false);
   });
 
   it('arvlCd=0(ENTERING) → 매역 push 발사 (arvlCd=0 dedup key)', async () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -67,6 +67,16 @@ export interface SilentPushPayload {
    * 클라이언트는 hop 매칭 분기를 자연 skip하고 거리 게이트만 수행한다.
    */
   hopIndex?: number;
+  /**
+   * #1307 — 발사 시점 trip의 지하(subsurface) 판정. server-authoritative.
+   * 지하에서는 WiFi/cell 보정으로 GPS가 stale/spoof되어 디바이스 위치 게이트가
+   * 정상 intermediate push를 out-of-range로 오거부한다. 클라이언트는 이 flag로
+   * 게이트 거리 검증을 우회한다(`silentPushLocationGate`). 디바이스의 FG-only
+   * subsurface stamp가 BG에서 stale 되어도 server flag가 우선이라 BG에서도 동작.
+   * 구 backend 호환을 위해 optional — 미전달(또는 false) 시 wire에서 자연 누락,
+   * 클라이언트는 기존 거리 게이트로 동작.
+   */
+  subsurface?: boolean;
 }
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
@@ -122,6 +132,9 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex가 정의된 경우에만 wire.
       // 구 backend 호환을 위해 optional이라 undefined일 땐 JSON에서 자연 누락된다.
       ...(options.payload.hopIndex === undefined ? {} : { hopIndex: options.payload.hopIndex }),
+      // #1307 — subsurface는 true일 때만 wire. false/undefined는 JSON에서 자연 누락 →
+      // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+      ...(options.payload.subsurface === true ? { subsurface: true } : {}),
     },
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -688,6 +688,9 @@ export async function fireArvlCdStationPush(
           // 클라이언트 `silentPushLocationGate`가 D1 estimator currentHopIndex와 매칭 시
           // 거리 검증 우회/`gate-no-location` fallback에 사용. 구 trip(부재) → undefined.
           hopIndex: waypoint.hopIndex,
+          // #1307 — server-authoritative subsurface. 지하 trip의 intermediate push는
+          // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
+          subsurface: trip.subsurface === true,
         },
         config: deps.apnsConfig,
         host,
@@ -1325,6 +1328,9 @@ export async function runLocklessIntermediate(
           // Epic #1204 그룹 2 D3 (#1273) — lockless intermediate도 waypoint.hopIndex forward.
           // D1 estimator의 currentHopIndex와 ±tolerance 매칭 시 거리 검증 우회 + GPS 미준비 fallback.
           hopIndex: waypoint.hopIndex,
+          // #1307 — server-authoritative subsurface. lockless intermediate도 지하에선
+          // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
+          subsurface: trip.subsurface === true,
         },
         config: deps.apnsConfig,
         host,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -1068,31 +1068,24 @@ describe('silentPushTask', () => {
       });
 
       // #1307 — server flag(payload.subsurface) 우선, 부재 시 로컬 stamp fallback.
-      it('payload.subsurface=true면 로컬 stamp가 false여도 게이트에 subsurface=true 전달 (server-wins)', async () => {
-        mockGetSubsurfaceState.mockResolvedValue(false);
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent', subsurface: true }));
-        expect(mockCheckGate).toHaveBeenCalledWith(
-          expect.objectContaining({ subsurface: true }),
+      // serverFlag가 있으면 로컬 stamp는 조회조차 안 한다(server-wins). 부재 시에만 stamp fallback.
+      it.each([
+        ['server=true → stamp 미조회, 게이트 subsurface=true (server-wins)', true, false, true, false],
+        ['server 부재 + stamp=true → 게이트 subsurface=true (local fallback)', undefined, true, true, true],
+        ['server 부재 + stamp=false → 게이트 subsurface=false (기존 GPS 게이트)', undefined, false, false, true],
+      ])('%s', async (_label, serverFlag, localStamp, expected, stampQueried) => {
+        mockGetSubsurfaceState.mockResolvedValue(localStamp);
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            ...(serverFlag === undefined ? {} : { subsurface: serverFlag }),
+          }),
         );
-        // server flag가 있으면 로컬 stamp는 조회조차 불필요.
-        expect(mockGetSubsurfaceState).not.toHaveBeenCalled();
-      });
-
-      it('payload.subsurface 부재 + 로컬 stamp=true → 게이트에 subsurface=true (local fallback)', async () => {
-        mockGetSubsurfaceState.mockResolvedValue(true);
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-        expect(mockGetSubsurfaceState).toHaveBeenCalled();
         expect(mockCheckGate).toHaveBeenCalledWith(
-          expect.objectContaining({ subsurface: true }),
+          expect.objectContaining({ subsurface: expected }),
         );
-      });
-
-      it('payload.subsurface 부재 + 로컬 stamp=false → 게이트에 subsurface=false (기존 GPS 게이트)', async () => {
-        mockGetSubsurfaceState.mockResolvedValue(false);
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-        expect(mockCheckGate).toHaveBeenCalledWith(
-          expect.objectContaining({ subsurface: false }),
-        );
+        expect(mockGetSubsurfaceState).toHaveBeenCalledTimes(stampQueried ? 1 : 0);
       });
     });
 

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -58,6 +58,12 @@ jest.mock('../../utils/silentPushLocationGate', () => ({
   checkSilentPushLocationGate: (...args: unknown[]) => mockCheckGate(...args),
 }));
 
+// #1307 — BG에서 stale 되는 로컬 subsurface stamp. 기본 false(미지하).
+const mockGetSubsurfaceState = jest.fn();
+jest.mock('../../../../shared/utils/subsurfaceState', () => ({
+  getSubsurfaceState: (...args: unknown[]) => mockGetSubsurfaceState(...args),
+}));
+
 const mockGetFiredAlarms = jest.fn();
 const mockSetFiredAlarms = jest.fn();
 jest.mock('../../utils/notificationState', () => ({
@@ -224,6 +230,7 @@ describe('silentPushTask', () => {
     jest.clearAllMocks();
     mockScheduleNotificationAsync.mockResolvedValue('id');
     mockCheckGate.mockResolvedValue(PASSING_GATE);
+    mockGetSubsurfaceState.mockResolvedValue(false);
     mockGetFiredAlarms.mockResolvedValue(new Set<string>());
     mockSetFiredAlarms.mockResolvedValue(undefined);
     (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
@@ -414,6 +421,33 @@ describe('silentPushTask', () => {
             bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', hopIndex: Infinity }),
           ),
         ).toMatchObject({ hopIndex: undefined });
+      });
+    });
+
+    // #1307 — backend가 server-authoritative subsurface flag(true일 때만)를 stamp.
+    describe('subsurface (#1307)', () => {
+      it('subsurface=true이면 그대로 전달', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', subsurface: true }),
+          ),
+        ).toMatchObject({ subsurface: true });
+      });
+
+      it('누락/false/비boolean이면 undefined (게이트가 로컬 stamp fallback)', () => {
+        expect(
+          extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' })),
+        ).toMatchObject({ subsurface: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', subsurface: false }),
+          ),
+        ).toMatchObject({ subsurface: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', subsurface: 'true' }),
+          ),
+        ).toMatchObject({ subsurface: undefined });
       });
     });
 
@@ -676,6 +710,7 @@ describe('silentPushTask', () => {
         phase: 'imminent',
         isLockless: false,
         payloadHopIndex: undefined,
+        subsurface: false,
       });
       expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
       const call = mockScheduleNotificationAsync.mock.calls[0][0];
@@ -1029,6 +1064,34 @@ describe('silentPushTask', () => {
         await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
         expect(mockCheckGate).toHaveBeenCalledWith(
           expect.objectContaining({ payloadHopIndex: undefined }),
+        );
+      });
+
+      // #1307 — server flag(payload.subsurface) 우선, 부재 시 로컬 stamp fallback.
+      it('payload.subsurface=true면 로컬 stamp가 false여도 게이트에 subsurface=true 전달 (server-wins)', async () => {
+        mockGetSubsurfaceState.mockResolvedValue(false);
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent', subsurface: true }));
+        expect(mockCheckGate).toHaveBeenCalledWith(
+          expect.objectContaining({ subsurface: true }),
+        );
+        // server flag가 있으면 로컬 stamp는 조회조차 불필요.
+        expect(mockGetSubsurfaceState).not.toHaveBeenCalled();
+      });
+
+      it('payload.subsurface 부재 + 로컬 stamp=true → 게이트에 subsurface=true (local fallback)', async () => {
+        mockGetSubsurfaceState.mockResolvedValue(true);
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockGetSubsurfaceState).toHaveBeenCalled();
+        expect(mockCheckGate).toHaveBeenCalledWith(
+          expect.objectContaining({ subsurface: true }),
+        );
+      });
+
+      it('payload.subsurface 부재 + 로컬 stamp=false → 게이트에 subsurface=false (기존 GPS 게이트)', async () => {
+        mockGetSubsurfaceState.mockResolvedValue(false);
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockCheckGate).toHaveBeenCalledWith(
+          expect.objectContaining({ subsurface: false }),
         );
       });
     });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -67,6 +67,7 @@ import { refreshLiveActivityFromBackgroundContext } from '../utils/refreshLiveAc
 import { type NotificationSource } from '../utils/notificationSource';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { getBoardingLock } from '../utils/boardingLockStorage';
+import { getSubsurfaceState } from '../../../shared/utils/subsurfaceState';
 import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 
@@ -101,6 +102,13 @@ export interface SilentPushPayload {
    * D1(#1207) hop estimator currentHopIndex와 짝지어 사용.
    */
   hopIndex?: number;
+  /**
+   * #1307 — 발사 시점 trip의 지하(subsurface) 판정. server-authoritative.
+   * 위치 게이트는 이 server flag를 우선하고, 부재 시 디바이스 로컬 stamp
+   * (`getSubsurfaceState`)로 fallback한다. true + intermediate면 GPS 거리 검증을 우회해
+   * 지하 stale/spoof GPS로 인한 out-of-range 오거부를 막는다. 구 backend 호환 위해 optional.
+   */
+  subsurface?: boolean;
 }
 
 /**
@@ -272,7 +280,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
   // standard 경로. findFieldsLayer는 isStandardCandidate(nextWaypoint non-empty) 또는
   // isRescheduleCandidate(kind='reschedule') 중 하나로 통과시키지만, kind='reschedule'
   // 케이스는 위 분기에서 잡혔으므로 잔여 케이스는 isStandardCandidate가 보증한 것 — nextWaypoint 보장.
-  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId, hopIndex } = obj as {
+  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId, hopIndex, subsurface } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
@@ -287,7 +295,16 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
     hopIndex: validHopIndex(hopIndex),
+    subsurface: validSubsurface(subsurface),
   };
+}
+
+/**
+ * #1307 — payload.subsurface 검증. boolean true만 의미를 갖는다. backend는 true일 때만
+ * wire하므로 false/누락/형식 오류는 모두 undefined로 정규화 → 게이트가 로컬 stamp fallback.
+ */
+function validSubsurface(value: unknown): boolean | undefined {
+  return value === true ? true : undefined;
 }
 
 /**
@@ -787,12 +804,17 @@ async function fireWithGate(
   // #1273 D3 — payloadHopIndex는 백엔드 silent push payload의 절대 시퀀스 SSOT. wire.
   // currentHopIndex는 D1(#1207) hop estimator 미연결 단계라 undefined — 둘 중 하나라도
   // 없으면 gate가 거리 기반 widened fallback 경로로 동작한다.
+  // #1307 — subsurface는 server flag(payload.subsurface)를 우선하고, 부재 시 디바이스
+  // 로컬 stamp로 fallback한다. server flag가 이겨야 FG-only stamp가 BG에서 stale 되어도
+  // 지하 intermediate 우회가 동작한다.
+  const subsurface = payload.subsurface ?? (await getSubsurfaceState());
   const gate = await checkSilentPushLocationGate({
     stationName: payload.nextWaypoint,
     kind: payload.kind,
     phase: payload.phase,
     isLockless: !lock,
     payloadHopIndex: payload.hopIndex,
+    subsurface,
   });
 
   if (!gate.pass) {

--- a/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
@@ -695,47 +695,40 @@ describe('checkSilentPushLocationGate', () => {
 
   // #1307 — subsurface(지하) intermediate 거리 검증 우회.
   describe('subsurface bypass (#1307)', () => {
-    it('subsurface=true + intermediate + GPS out-of-range → subsurface-bypass pass', async () => {
-      mockGetLastKnownPositionAsync.mockResolvedValue(
-        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
-      );
-      const result = await checkSilentPushLocationGate({
+    const runGate = (overrides: Partial<Parameters<typeof checkSilentPushLocationGate>[0]>) =>
+      checkSilentPushLocationGate({
         stationName: '강남',
         kind: 'intermediate',
         phase: 'imminent',
-        subsurface: true,
+        ...overrides,
       });
-      expect(result.pass).toBe(true);
-      expect(result.passReason).toBe('subsurface-bypass');
-      expect(result.locationSource).toBe('cache');
-    });
 
-    it('subsurface=true + intermediate + 위치 stale(TTL 초과)여도 bypass pass', async () => {
-      mockGetLastKnownPositionAsync.mockResolvedValue(
-        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, LOCATION_CACHE_TTL_MS + 10_000),
-      );
-      const result = await checkSilentPushLocationGate({
-        stationName: '강남',
-        kind: 'intermediate',
-        phase: 'imminent',
-        subsurface: true,
-      });
+    // subsurface=true + intermediate면 위치 상태(out-of-range / stale / 미획득)와 무관하게 우회 pass.
+    it.each([
+      [
+        'GPS out-of-range여도 bypass (cache source 노출)',
+        () => mockGetLastKnownPositionAsync.mockResolvedValue(makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000)),
+        'cache' as const,
+      ],
+      [
+        '위치 stale(TTL 초과)여도 bypass',
+        () => mockGetLastKnownPositionAsync.mockResolvedValue(makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, LOCATION_CACHE_TTL_MS + 10_000)),
+        'cache' as const,
+      ],
+      [
+        '위치 미획득여도 bypass (locationSource 부재)',
+        () => {
+          mockGetLastKnownPositionAsync.mockResolvedValue(null);
+          mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+        },
+        undefined,
+      ],
+    ])('subsurface=true + intermediate + %s', async (_label, setup, expectedSource) => {
+      setup();
+      const result = await runGate({ subsurface: true });
       expect(result.pass).toBe(true);
       expect(result.passReason).toBe('subsurface-bypass');
-    });
-
-    it('subsurface=true + intermediate + 위치 미획득여도 bypass pass (locationSource 부재)', async () => {
-      mockGetLastKnownPositionAsync.mockResolvedValue(null);
-      mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
-      const result = await checkSilentPushLocationGate({
-        stationName: '강남',
-        kind: 'intermediate',
-        phase: 'imminent',
-        subsurface: true,
-      });
-      expect(result.pass).toBe(true);
-      expect(result.passReason).toBe('subsurface-bypass');
-      expect(result.locationSource).toBeUndefined();
+      expect(result.locationSource).toBe(expectedSource);
     });
 
     it('subsurface-bypass도 motion fields(speed/accuracy) 함께 노출', async () => {
@@ -751,55 +744,23 @@ describe('checkSilentPushLocationGate', () => {
         },
         timestamp: Date.now() - 5_000,
       });
-      const result = await checkSilentPushLocationGate({
-        stationName: '강남',
-        kind: 'intermediate',
-        phase: 'imminent',
-        subsurface: true,
-      });
+      const result = await runGate({ subsurface: true });
       expect(result.pass).toBe(true);
       expect(result.passReason).toBe('subsurface-bypass');
       expect(result.speedMps).toBe(3.2);
       expect(result.accuracyM).toBe(18);
     });
 
-    it('subsurface=true + transfer kind는 bypass 미적용 (기존 GPS 게이트 유지, misfire 방지)', async () => {
+    // transfer/destination은 misfire 방지로 bypass 미적용. intermediate라도 subsurface 미지정이면 미적용.
+    it.each([
+      ['subsurface=true + transfer는 미적용 (기존 게이트)', { kind: 'transfer' as const, subsurface: true }],
+      ['subsurface=true + destination은 미적용 (기존 게이트)', { kind: 'destination' as const, subsurface: true }],
+      ['subsurface 미지정 + intermediate는 미적용 (no bypass)', {}],
+    ])('out-of-range로 skip — %s', async (_label, overrides) => {
       mockGetLastKnownPositionAsync.mockResolvedValue(
         makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
       );
-      const result = await checkSilentPushLocationGate({
-        stationName: '강남',
-        kind: 'transfer',
-        phase: 'imminent',
-        subsurface: true,
-      });
-      expect(result.pass).toBe(false);
-      expect(result.reason).toBe('out-of-range');
-    });
-
-    it('subsurface=true + destination kind는 bypass 미적용 (기존 GPS 게이트 유지)', async () => {
-      mockGetLastKnownPositionAsync.mockResolvedValue(
-        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
-      );
-      const result = await checkSilentPushLocationGate({
-        stationName: '강남',
-        kind: 'destination',
-        phase: 'imminent',
-        subsurface: true,
-      });
-      expect(result.pass).toBe(false);
-      expect(result.reason).toBe('out-of-range');
-    });
-
-    it('subsurface 미지정(false) + intermediate + out-of-range → 기존 게이트(no bypass)', async () => {
-      mockGetLastKnownPositionAsync.mockResolvedValue(
-        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
-      );
-      const result = await checkSilentPushLocationGate({
-        stationName: '강남',
-        kind: 'intermediate',
-        phase: 'imminent',
-      });
+      const result = await runGate(overrides);
       expect(result.pass).toBe(false);
       expect(result.reason).toBe('out-of-range');
     });

--- a/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
@@ -692,4 +692,116 @@ describe('checkSilentPushLocationGate', () => {
       expect(result.thresholdM).toBe(800);
     });
   });
+
+  // #1307 — subsurface(지하) intermediate 거리 검증 우회.
+  describe('subsurface bypass (#1307)', () => {
+    it('subsurface=true + intermediate + GPS out-of-range → subsurface-bypass pass', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        subsurface: true,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('subsurface-bypass');
+      expect(result.locationSource).toBe('cache');
+    });
+
+    it('subsurface=true + intermediate + 위치 stale(TTL 초과)여도 bypass pass', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, LOCATION_CACHE_TTL_MS + 10_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        subsurface: true,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('subsurface-bypass');
+    });
+
+    it('subsurface=true + intermediate + 위치 미획득여도 bypass pass (locationSource 부재)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(null);
+      mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        subsurface: true,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('subsurface-bypass');
+      expect(result.locationSource).toBeUndefined();
+    });
+
+    it('subsurface-bypass도 motion fields(speed/accuracy) 함께 노출', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue({
+        coords: {
+          latitude: FAR_FROM_GANGNAM.lat,
+          longitude: FAR_FROM_GANGNAM.lng,
+          accuracy: 18,
+          altitude: null,
+          heading: null,
+          speed: 3.2,
+          altitudeAccuracy: null,
+        },
+        timestamp: Date.now() - 5_000,
+      });
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        subsurface: true,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('subsurface-bypass');
+      expect(result.speedMps).toBe(3.2);
+      expect(result.accuracyM).toBe(18);
+    });
+
+    it('subsurface=true + transfer kind는 bypass 미적용 (기존 GPS 게이트 유지, misfire 방지)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'transfer',
+        phase: 'imminent',
+        subsurface: true,
+      });
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('out-of-range');
+    });
+
+    it('subsurface=true + destination kind는 bypass 미적용 (기존 GPS 게이트 유지)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'destination',
+        phase: 'imminent',
+        subsurface: true,
+      });
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('out-of-range');
+    });
+
+    it('subsurface 미지정(false) + intermediate + out-of-range → 기존 게이트(no bypass)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(FAR_FROM_GANGNAM.lat, FAR_FROM_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+      });
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('out-of-range');
+    });
+  });
 });

--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -27,8 +27,9 @@ export type GateSkipReason = 'unknown-station' | 'no-location' | 'stale-location
  * pass=true일 때 어떤 경로로 통과했는지 식별. 운영 측정/디버깅용.
  * - 'within-threshold': 거리 임계값 이내 (기존 경로)
  * - 'hop-window-match': lockless + hop index 매치(거리 검증 우회, #1209 D3)
+ * - 'subsurface-bypass': 지하 intermediate 푸시 — GPS stale/spoof 회피 위해 거리 검증 우회(#1307)
  */
-export type GatePassReason = 'within-threshold' | 'hop-window-match';
+export type GatePassReason = 'within-threshold' | 'hop-window-match' | 'subsurface-bypass';
 export type GateLocationSource = 'cache' | 'fresh';
 
 export interface GateResult {
@@ -61,6 +62,14 @@ export interface SilentPushLocationGateInput {
    * silent push payload가 명시한 hop index. 백엔드 schema에 추가되기 전까지 undefined.
    */
   payloadHopIndex?: number;
+  /**
+   * 지하(subsurface) 여부. #1307. 호출자가 server payload.subsurface를 우선,
+   * 부재 시 디바이스 로컬 stamp(getSubsurfaceState)로 fallback해 해석한 boolean을 넘긴다.
+   * true + intermediate kind면 GPS 거리 검증을 우회한다 — 지하에서 WiFi/cell 보정으로
+   * stale/spoof된 GPS가 정상 intermediate push를 out-of-range로 오거부하는 회귀를 막는다.
+   * transfer/destination은 misfire 방지를 위해 우회하지 않고 기존 GPS 게이트를 유지한다.
+   */
+  subsurface?: boolean;
 }
 
 interface UserPosition {
@@ -170,12 +179,24 @@ function isHopWindowMatch(
 }
 
 /**
+ * #1307 — 지하 intermediate 푸시는 거리 검증을 우회한다.
+ * 지하에서는 WiFi/cell 보정으로 GPS가 stale/spoof되어 거리 게이트가 정상 push를
+ * out-of-range로 오거부한다. backend Seoul-API가 위치 SSOT인 intermediate(매역) push만
+ * 우회 — transfer/destination은 misfire 방지를 위해 기존 GPS 게이트를 유지한다.
+ */
+function isSubsurfaceBypass(input: SilentPushLocationGateInput): boolean {
+  return input.subsurface === true && input.kind === 'intermediate';
+}
+
+/**
  * silent push 수신 시 "사용자가 실제로 그 역 근처에 있는지" 확인하는 게이트.
  * pass=true면 알림 발사, false면 skip + alarmLog에 skipReason 기록.
  *
  * 정책:
  *   1) stationName이 stations.json에 없으면 skip (unknown-station)
  *   2) 위치 획득 실패 시 skip (no-location) — 보수적
+ *   2.5) subsurface(지하) + intermediate면 거리/stale 검증 우회 pass (#1307) —
+ *        지하 GPS stale/spoof로 인한 out-of-range 오거부 차단. transfer/destination은 제외.
  *   3) 캐시가 TTL 초과면 skip (stale-location) — 보수적
  *   4) lockless + intermediate + hop index 매치면 거리 검증 우회 pass (#1209 D3)
  *   5) phase/kind별 임계값 이내면 pass, 초과면 skip (out-of-range)
@@ -202,7 +223,28 @@ export async function checkSilentPushLocationGate(
     ) {
       return { pass: true, passReason: 'hop-window-match' };
     }
+    // #1307 — 지하 intermediate는 GPS 미준비여도 server SSOT를 신뢰해 pass.
+    if (isSubsurfaceBypass(input)) {
+      return { pass: true, passReason: 'subsurface-bypass' };
+    }
     return { pass: false, reason: 'no-location' };
+  }
+
+  const motionFields = {
+    ...(pos.speedMps == null ? {} : { speedMps: pos.speedMps }),
+    ...(pos.accuracyM == null ? {} : { accuracyM: pos.accuracyM }),
+  };
+
+  // #1307 — 지하 intermediate는 GPS가 stale/spoof되므로 stale/거리 검증을 우회하고 pass.
+  // 후속 movement 가드(silentPushTask)가 speed/accuracy/motion으로 정적 misfire를 추가 차단한다.
+  if (isSubsurfaceBypass(input)) {
+    return {
+      pass: true,
+      passReason: 'subsurface-bypass',
+      locationSource: pos.source,
+      locationAgeMs: pos.ageMs,
+      ...motionFields,
+    };
   }
 
   if (pos.ageMs > LOCATION_CACHE_TTL_MS) {
@@ -215,10 +257,6 @@ export async function checkSilentPushLocationGate(
   }
 
   const isLockless = input.isLockless === true;
-  const motionFields = {
-    ...(pos.speedMps == null ? {} : { speedMps: pos.speedMps }),
-    ...(pos.accuracyM == null ? {} : { accuracyM: pos.accuracyM }),
-  };
 
   // #1209 D3 — lockless + intermediate + hop window 매치 시 거리 검증 우회.
   // D1 estimator의 hop이 payload hop과 ±1 이내라면 GPS 좌표가 drift해도 같은 leg로 간주.


### PR DESCRIPTION
## 배경
지하에서 WiFi/cell 보정으로 GPS가 stale/spoof되어, 디바이스 silent-push 위치 게이트가 backend의 정상 intermediate(매역) push를 `out-of-range`로 오거부한다. 기존 subsurface stamp는 FG-only(`useBarometer`)라 pocket/BG에서 TTL(~90s) 경과 후 stale → #1278 우회가 BG에서 동작하지 않아 매역 알림이 누락된다 (중곡 회귀 BG 재발).

## 변경
**A. Backend — server-authoritative subsurface를 push payload로 전달**
- `SilentPushPayload`에 `subsurface?: boolean` 추가 (`apns.ts`). `sendSilentPush`가 `true`일 때만 wire → false/undefined는 JSON에서 자연 누락 (구 client/backend byte-level 호환).
- `scheduled.ts`의 arvlcd-fire / lockless intermediate 두 발사 site에서 `subsurface: trip.subsurface === true` 전달.

**B. Frontend — 게이트가 server flag 우선, 로컬 stamp fallback**
- `silentPushTask.ts`가 payload의 `subsurface`를 파싱(`validSubsurface`: true만 의미).
- 게이트 호출 시 `subsurface = payload.subsurface ?? (await getSubsurfaceState())` — server flag가 이기므로 FG-only stamp가 BG에서 stale 되어도 우회가 동작.
- `silentPushLocationGate`가 `subsurface=true && kind==='intermediate'`면 거리/stale/no-location 검증을 우회(`passReason: 'subsurface-bypass'`). motion fields는 그대로 노출 → 후속 `#727` 정적 misfire 가드는 유지.

**C. (GPS 게이트 demotion) — 미적용(skip)**
- 별도 hard-reject demotion 로직은 추가하지 않았다. B의 subsurface-bypass가 "지하 intermediate는 backend Seoul-API가 위치 SSOT"라는 동일 목표를 더 좁고 안전하게 달성한다(지하일 때만, intermediate에만). transfer/destination은 misfire 방지를 위해 기존 GPS 게이트를 그대로 유지 — lock/lockless 무관 hard-reject 완화는 회귀 위험이 있어 본 PR 범위에서 제외.

## 테스트
- backend vitest: 1236 passed (apns/scheduled 209). subsurface true/false/absent wire 검증 + 두 발사 site forward 검증 추가.
- frontend jest: 변경 파일(`silentPushTask.ts`, `silentPushLocationGate.ts`) 100% stmts/branch/funcs/lines. extract 파싱 + server-wins/local-fallback + intermediate-only bypass + transfer/destination 미적용 회귀 케이스 커버.
- `npm run type-check`(frontend) / backend `tsc --noEmit` 모두 통과.

## 검증 (실기기 — PR 머지 후 별도)
지하 trip에서 매역 silent push가 BG에서도 `out-of-range`로 skip되지 않고 발사되는지 wrangler tail + 디바이스 로그로 확인 필요.

Closes #1307