### PR TITLE
fix(#1281): 환승 자동 detect 백그라운드 진입점 추가

### DIFF
--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -70,6 +70,28 @@ jest.mock('../../../widget/api/widgetStorage', () => ({
   saveStationToWidget: (...args: unknown[]) => mockSaveStationToWidget(...args),
 }));
 
+// ── #1281 BG 환승 자동 detect 모킹 (결정 로직은 backgroundTransferSwap.test.ts에서 별도 검증) ──
+const mockEvaluateBackgroundTransferSwap = jest.fn();
+jest.mock('../../../route/utils/backgroundTransferSwap', () => ({
+  evaluateBackgroundTransferSwap: (...args: unknown[]) => mockEvaluateBackgroundTransferSwap(...args),
+}));
+const mockArrivalProvider = { getArrival: jest.fn() };
+jest.mock('../../../arrival/providers/factory', () => ({
+  createArrivalProvider: () => mockArrivalProvider,
+}));
+const mockFindNearestStations = jest.fn();
+jest.mock('../../utils/findNearestStation', () => ({
+  findNearestStations: (...args: unknown[]) => mockFindNearestStations(...args),
+}));
+const mockSyncBoardingLock = jest.fn();
+jest.mock('../../api/boardingLockSync', () => ({
+  syncBoardingLock: (...args: unknown[]) => mockSyncBoardingLock(...args),
+}));
+const mockGetBoardingLock = jest.fn();
+jest.mock('../../../alarm/utils/boardingLockStorage', () => ({
+  getBoardingLock: () => mockGetBoardingLock(),
+}));
+
 // ── logger 모킹 ──
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -175,6 +197,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockGetCurrentMotionStationary.mockReturnValue(false);
     mockGetLatestAccelSummary.mockReturnValue(null);
     mockSaveStationToWidget.mockResolvedValue(undefined);
+    mockGetBoardingLock.mockResolvedValue(null);
+    mockEvaluateBackgroundTransferSwap.mockResolvedValue({ fired: false });
+    mockFindNearestStations.mockReturnValue(null);
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -992,6 +1017,93 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
       expect(mockUploadPosition).toHaveBeenCalledWith(expect.objectContaining({ motion: 'stationary' }));
       expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#1281 — BG 환승 자동 detect wire', () => {
+    const swapLock = {
+      destinationId: 'station-2',
+      trainCode: 'T-7-old',
+      boardingStationId: 'station-7',
+      boardingLine: '7' as const,
+      boardedAt: Date.now(),
+      expectedDurationMs: 30 * 60_000,
+    };
+
+    /** mockStorageValues 4개 후 BG_LAST_FIX(null) + APNS_TOKEN을 chain. */
+    function stubApnsTokenAfterStorage(token: string | null): void {
+      (AsyncStorage.getItem as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(token);
+    }
+
+    it('lock 활성 + apnsToken 있으면 evaluateBackgroundTransferSwap을 컨텍스트와 함께 호출', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+      mockProcessLocationUpdate.mockResolvedValue({
+        alarmEvent: null,
+        nearest: { station: mockStation, distanceKm: 0.1 },
+      });
+      mockGetBoardingLock.mockResolvedValue(swapLock);
+      mockGetCurrentMotionStationary.mockReturnValue(false);
+
+      const fixTs = Date.now();
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      loc.timestamp = fixTs;
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockEvaluateBackgroundTransferSwap).toHaveBeenCalledTimes(1);
+      const [input, deps] = mockEvaluateBackgroundTransferSwap.mock.calls[0];
+      expect(input).toMatchObject({
+        lat: 37.498,
+        lng: 127.028,
+        accuracy: 10,
+        observedAtMs: fixTs,
+        apnsToken: 'apns-tok-1',
+        lock: swapLock,
+        motionStationary: false,
+        destinationName: '시청',
+      });
+      // 주입된 의존성이 실제 모듈로 연결됐는지 확인.
+      expect(deps.arrivalProvider).toBe(mockArrivalProvider);
+      deps.syncBoardingLock({ token: 't', observedStationName: 's', observedAtMs: 0, accuracy: 0, trainCode: 'c', boardingLine: '2' });
+      expect(mockSyncBoardingLock).toHaveBeenCalled();
+      deps.findNearestStations(1, 2);
+      expect(mockFindNearestStations).toHaveBeenCalledWith(1, 2, expect.any(Number));
+    });
+
+    it('accuracy null fix는 swap input.accuracy=0으로 강등', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+      mockGetBoardingLock.mockResolvedValue(swapLock);
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: null });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      const [input] = mockEvaluateBackgroundTransferSwap.mock.calls[0];
+      expect(input.accuracy).toBe(0);
+    });
+
+    it('lock 없으면 evaluateBackgroundTransferSwap 미호출', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+      mockGetBoardingLock.mockResolvedValue(null);
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockEvaluateBackgroundTransferSwap).not.toHaveBeenCalled();
+    });
+
+    it('apnsToken 없으면 evaluateBackgroundTransferSwap 미호출', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage(null);
+      mockGetBoardingLock.mockResolvedValue(swapLock);
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockEvaluateBackgroundTransferSwap).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -24,8 +24,15 @@ import { evaluateMovement } from '../utils/movementGate';
 // #1237 — BG tick에서도 위젯 SSOT(App Groups UserDefaults)를 갱신해 FG 진입 전까지 stale로 남지 않게 한다.
 // cross-feature import는 파일 헤더의 file-level eslint-disable로 옵트인 (orchestrator 본질).
 import { saveStationToWidget } from '../../widget/api/widgetStorage';
+// #1281 — BG 환승 자동 detect. FG `useTransferAutoDetect`와 같은 `evaluateTransferSwap` pure 결정을
+// 공유하는 route 슬라이스 orchestrator. cross-feature import는 본 파일 헤더 file-level disable로 옵트인.
+import { evaluateBackgroundTransferSwap } from '../../route/utils/backgroundTransferSwap';
+import { createArrivalProvider } from '../../arrival/providers/factory';
+import { findNearestStations } from '../utils/findNearestStation';
+import { syncBoardingLock } from '../api/boardingLockSync';
+import { getBoardingLock } from '../../alarm/utils/boardingLockStorage';
 import type { Route } from '../../../shared/utils/stationRoute';
-import { isValidGpsSpeedMps } from '../../../shared/constants/location';
+import { isValidGpsSpeedMps, MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import type { Station } from '../../../shared/types/station';
 
 const logger = createLogger('BackgroundLocation');
@@ -230,6 +237,31 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       // + FRESHNESS_REFRESH_MS는 FG/BG 같은 인스턴스라 자연 동작. null nearest는 호출 X
       // (FG/BG transient null로 widget zap 방지, Phase 3 clear 정책 완화와 정합성).
       await saveStationToWidget(nearest.station, nearest.distanceKm);
+    }
+
+    // #1281 — BG 환승 자동 detect. 주머니 속 환승에서 FG hook 진입점이 없어 옛 노선 lock이
+    // 얼어붙던 회귀를 차단한다. lock 활성 + 환승역 + 다른 노선 임박 + walking이 모두 충족될 때만
+    // 새 노선 trainCode를 backend `/boarding-lock/sync`에 통보 → W1(#1271) swap 경로로 hydrate.
+    // apnsToken 부재(트립 미등록 등)는 함수 내부 게이트가 graceful no-op 처리.
+    const swapLock = await getBoardingLock();
+    if (apnsToken && swapLock) {
+      await evaluateBackgroundTransferSwap(
+        {
+          lat,
+          lng,
+          accuracy: accuracy ?? 0,
+          observedAtMs: latest.timestamp,
+          apnsToken,
+          lock: swapLock,
+          motionStationary: motionStationary === true,
+          destinationName: destination.name,
+        },
+        {
+          findNearestStations: (la, ln) => findNearestStations(la, ln, MAX_STATION_DISTANCE_KM),
+          arrivalProvider: createArrivalProvider(),
+          syncBoardingLock,
+        },
+      );
     }
 
     logger.info('백그라운드 위치 업데이트 완료:', lat.toFixed(4), lng.toFixed(4));

--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -24,13 +24,10 @@
  *   기존 동작(가장 임박) 유지.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { detectTransfer } from '../utils/transferDetect';
+import { evaluateTransferSwap, buildAutoLockCandidate } from '../utils/transferSwap';
 import { findActiveTransferContext } from '../utils/findActiveTransferContext';
-import { isExpressStop } from '../utils/expressLookup';
-import { lineToSubwayId } from '../../../shared/constants/lineApiNames';
-import type { OtherLineArrival } from '../utils/transferDetect';
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
-import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
+import type { StationArrival } from '../../../shared/types/arrival';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LineNumber, NearestStationsResult, Station } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
@@ -80,25 +77,25 @@ export function useTransferAutoDetect({
   const currentStation = nearestStations?.primary ?? null;
   const boardingLine = boardingLock?.boardingLine ?? null;
 
-  const otherLineArrivals = useMemo<OtherLineArrival[]>(
-    () => collectOtherLineArrivals(arrival, boardingLine),
-    [arrival, boardingLine],
-  );
-
   // planned route의 transfer waypoint면 기존 useTransferTrainList가 책임지므로 detect skip.
   const onPlannedTransfer = useMemo(
     () => findActiveTransferContext(boardingLock, route, destinationName, currentStation) !== null,
     [boardingLock, route, destinationName, currentStation],
   );
 
-  const detection = useMemo(() => {
-    if (onPlannedTransfer) return { detected: false, candidateLines: [] as LineNumber[] };
-    return detectTransfer({
-      nearestStations,
-      motionWalking: !motionStationary,
-      otherLineArrivals,
-    });
-  }, [onPlannedTransfer, nearestStations, motionStationary, otherLineArrivals]);
+  // #1281 — FG/BG 공유 pure 결정 로직. hook은 결과를 모달/idempotency state와 묶기만 한다.
+  const detection = useMemo(
+    () =>
+      evaluateTransferSwap({
+        nearestStations,
+        motionStationary,
+        arrival,
+        boardingLine,
+        destinationName,
+        onPlannedTransfer,
+      }),
+    [nearestStations, motionStationary, arrival, boardingLine, destinationName, onPlannedTransfer],
+  );
 
   const candidateLines = detection.candidateLines;
 
@@ -120,17 +117,17 @@ export function useTransferAutoDetect({
     }
   }, [stationKey]);
 
+  const { candidate } = detection;
+
   // detect 결과 적용 — 단일 후보면 자동 lock, 다중 후보면 모달 open.
   useEffect(() => {
-    if (!detection.detected || candidateLines.length === 0 || !currentStation) {
+    if (candidateLines.length === 0 || !currentStation) {
       if (candidateLines.length === 0 && modalVisible) setModalVisible(false);
       return;
     }
     if (candidateLines.length === 1) {
-      const [line] = candidateLines;
-      const candidate = buildAutoLockCandidate(line, arrival, destinationName);
       /* istanbul ignore next -- candidateLines가 detectTransfer로 산출되었으면 arrival에 해당 line의
-         imminent 도착이 반드시 존재 → pickImminentTrainCode는 항상 trainCode를 반환. 방어 코드. */
+         imminent 도착이 반드시 존재 → buildAutoLockCandidate는 항상 candidate를 반환. 방어 코드. */
       if (!candidate) return;
       // 같은 환승역 같은 trainCode는 1회만 hydrate 시도 — onAutoLock 자체도 idempotent지만
       // hydrateLockFromCandidate는 ETA 스냅샷이 없어 lock=null 가드만 의존 → 첫 hydrate가 race로
@@ -143,7 +140,7 @@ export function useTransferAutoDetect({
     }
     if (dismissedAtStationRef.current === stationKey) return;
     setModalVisible(true);
-  }, [detection.detected, candidateLines, currentStation, arrival, destinationName, onAutoLock, modalVisible, stationKey]);
+  }, [candidateLines, candidate, currentStation, onAutoLock, modalVisible, stationKey]);
 
   const modalCandidates = useMemo<Station[]>(() => {
     if (!currentStation) return [];
@@ -173,79 +170,6 @@ export function useTransferAutoDetect({
   }, [stationKey]);
 
   return { candidateLines, modalVisible, modalCandidates, selectLine, dismissModal };
-}
-
-/**
- * arrival.up / down을 평탄화한 뒤 `boardingLine`을 제외하고 OtherLineArrival 배열로 변환.
- * 같은 line의 up/down이 모두 있어도 detectTransfer가 dedup하므로 추가 처리 불필요.
- */
-function collectOtherLineArrivals(
-  arrival: StationArrival | null,
-  boardingLine: LineNumber | null,
-): OtherLineArrival[] {
-  if (!arrival) return [];
-  const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
-  const out: OtherLineArrival[] = [];
-  for (const t of all) {
-    if (boardingLine !== null && t.line === boardingLine) continue;
-    out.push({ line: t.line, arrivalSeconds: t.arrivalSeconds, arrivalCode: t.arrivalCode });
-  }
-  return out;
-}
-
-/**
- * candidate line의 첫(=가장 임박) trainCode를 사용해 AutoLockCandidate 구성.
- * subwayId 매핑 누락 시 null — 호출자가 hydrate skip(이미 line valid 가드 있음).
- *
- * #971: destinationName이 주어지면 trainType이 destination에 정차하는 후보를 우선 선택.
- * 일반정차역만 가능한 destination에서 급행/특급이 통과하는 lock 사고를 회피한다.
- */
-function buildAutoLockCandidate(
-  line: LineNumber,
-  arrival: StationArrival | null,
-  destinationName: string | null,
-): AutoLockCandidate | null {
-  const subwayId = lineToSubwayId(line);
-  /* istanbul ignore next -- 모든 LineNumber는 LINE_TO_SUBWAY_ID에 등록되어 있어 null 분기는
-     valid LineNumber 입력 하에서 도달 불가. 타입 보강용 방어. */
-  if (!subwayId) return null;
-  const trainCode = pickImminentTrainCode(arrival, line, destinationName);
-  if (!trainCode) return null;
-  return { trainCode, line, subwayId };
-}
-
-/**
- * 같은 line의 후보 중 가장 임박한 trainCode 반환.
- *
- * #971: destinationName이 있으면 destination 정차 가능한 trainType을 1차 후보군으로,
- * 그 군이 비면 전체에서 fallback. destinationName=null은 기존 동작(전체에서 imminent).
- *
- * `isExpressStop`은 normal에 대해 항상 true, 데이터 미보유 line/type에 대해 보수적으로 true →
- * 미지의 노선/타입을 사용자에게 무리하게 막지 않는다. 일반정차역 only인 destination에서
- * 정확한 express 정차역 데이터가 있는 경우(예: 1·9호선 급행)에만 express 후보를 제외한다.
- */
-function pickImminentTrainCode(
-  arrival: StationArrival | null,
-  line: LineNumber,
-  destinationName: string | null,
-): string | null {
-  if (!arrival) return null;
-  const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
-  let preferred: ArrivalInfo | null = null;
-  let fallback: ArrivalInfo | null = null;
-  for (const t of all) {
-    if (t.line !== line) continue;
-    /* istanbul ignore next -- detectTransfer는 음수 arrivalSeconds를 후보에서 제외한 뒤 line을
-       반환하므로, 그 line의 음수 train이 있더라도 양수 train이 이미 적어도 하나 존재. 양수만
-       best로 선택되어 음수 분기는 도달하지 않는다. 방어 코드. */
-    if (t.arrivalSeconds < 0) continue;
-    if (!fallback || t.arrivalSeconds < fallback.arrivalSeconds) fallback = t;
-    // destination 미설정 → 모든 후보가 preferred와 동등 → fallback만으로 판정.
-    if (destinationName === null) continue;
-    if (!isExpressStop(destinationName, line, t.trainType)) continue;
-    if (!preferred || t.arrivalSeconds < preferred.arrivalSeconds) preferred = t;
-  }
-  return (preferred ?? fallback)?.trainCode ?? null;
 }
 
 /**

--- a/src/features/route/utils/__tests__/backgroundTransferSwap.test.ts
+++ b/src/features/route/utils/__tests__/backgroundTransferSwap.test.ts
@@ -1,0 +1,227 @@
+/**
+ * #1281 — evaluateBackgroundTransferSwap (BG 환승 자동 detect).
+ *
+ * BG context에서 환승역 도착 + 다른 노선 임박(이동 중) 신호가 잡히면 swap candidate 평가 후
+ * backend `/boarding-lock/sync`를 발사하는지, 그리고 같은 노선 직진(비환승) trip에서는 발사하지
+ * 않는지(false positive = 0) 검증한다.
+ */
+import {
+  evaluateBackgroundTransferSwap,
+  resetBackgroundTransferSwapState,
+} from '../backgroundTransferSwap';
+import { makeArrivalInfo } from '../../../../testUtils/fixtures';
+import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { NearestStationsResult, Station } from '../../../../shared/types/station';
+import type {
+  BackgroundTransferSwapDeps,
+  BackgroundTransferSwapSyncPayload,
+} from '../backgroundTransferSwap';
+
+const DDP_7: Station = { id: '0707', name: '건대입구', line: '7', lineColor: '#54640D', lat: 37.54, lng: 127.07 };
+const DDP_2: Station = { id: '0727', name: '건대입구', line: '2', lineColor: '#009D3E', lat: 37.54, lng: 127.07 };
+const NON_TRANSFER: Station = { id: '0222', name: '강남', line: '2', lineColor: '#009D3E', lat: 37.498, lng: 127.027 };
+
+const transferNearest: NearestStationsResult = {
+  primary: DDP_7,
+  variants: [DDP_7, DDP_2],
+  distanceKm: 0.02,
+  isTransfer: true,
+};
+
+const nonTransferNearest: NearestStationsResult = {
+  primary: NON_TRANSFER,
+  variants: [NON_TRANSFER],
+  distanceKm: 0.02,
+  isTransfer: false,
+};
+
+function makeArrival(up: ArrivalInfo[] = [], down: ArrivalInfo[] = []): StationArrival {
+  return { up, down };
+}
+
+// 7호선 탑승 중 lock. 환승 시 2호선(다른 노선)으로 swap 기대.
+const lock7: BoardingLock = {
+  destinationId: 'dest-1',
+  trainCode: 'T-7-old',
+  boardingStationId: DDP_7.id,
+  boardingLine: '7',
+  boardedAt: Date.now(),
+  expectedDurationMs: 30 * 60_000,
+};
+
+function baseInput(overrides: Partial<Parameters<typeof evaluateBackgroundTransferSwap>[0]> = {}) {
+  return {
+    lat: 37.54,
+    lng: 127.07,
+    accuracy: 20,
+    observedAtMs: 1_700_000_000_000,
+    apnsToken: 'tok-abc',
+    lock: lock7 as BoardingLock | null,
+    motionStationary: false,
+    destinationName: null as string | null,
+    ...overrides,
+  };
+}
+
+function makeDeps(
+  overrides: Partial<BackgroundTransferSwapDeps> & {
+    arrival?: StationArrival;
+    arrivalError?: boolean;
+    syncSpy?: jest.Mock;
+    nearest?: NearestStationsResult | null;
+  } = {},
+): { deps: BackgroundTransferSwapDeps; syncSpy: jest.Mock } {
+  const syncSpy = overrides.syncSpy ?? jest.fn().mockResolvedValue({ ok: true });
+  const getArrival = overrides.arrivalError
+    ? jest.fn().mockRejectedValue(new Error('network'))
+    : jest.fn().mockResolvedValue(overrides.arrival ?? makeArrival());
+  const deps: BackgroundTransferSwapDeps = {
+    findNearestStations:
+      overrides.findNearestStations ??
+      jest.fn(() => (overrides.nearest !== undefined ? overrides.nearest : transferNearest)),
+    arrivalProvider: { getArrival },
+    syncBoardingLock: overrides.syncBoardingLock ?? syncSpy,
+  };
+  return { deps, syncSpy };
+}
+
+describe('evaluateBackgroundTransferSwap', () => {
+  beforeEach(() => {
+    resetBackgroundTransferSwapState();
+  });
+
+  it('lock 없으면 no-op', async () => {
+    const { deps, syncSpy } = makeDeps();
+    const result = await evaluateBackgroundTransferSwap(baseInput({ lock: null }), deps);
+    expect(result).toEqual({ fired: false });
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('최근접 역이 환승역이 아니면 no-op (arrival fetch도 안 함)', async () => {
+    const { deps, syncSpy } = makeDeps({ nearest: nonTransferNearest });
+    const result = await evaluateBackgroundTransferSwap(baseInput(), deps);
+    expect(result.fired).toBe(false);
+    expect(deps.arrivalProvider.getArrival).not.toHaveBeenCalled();
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('최근접 역 결과가 null이면 no-op', async () => {
+    const { deps, syncSpy } = makeDeps({ nearest: null });
+    const result = await evaluateBackgroundTransferSwap(baseInput(), deps);
+    expect(result.fired).toBe(false);
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('arrival 조회 실패는 graceful no-op', async () => {
+    const { deps, syncSpy } = makeDeps({ arrivalError: true });
+    const result = await evaluateBackgroundTransferSwap(baseInput(), deps);
+    expect(result.fired).toBe(false);
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('환승역 + 다른 노선 임박 + 이동 중 → swap candidate 평가 후 sync 발사', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const { deps, syncSpy } = makeDeps({ arrival });
+    const result = await evaluateBackgroundTransferSwap(baseInput({ motionStationary: false }), deps);
+
+    expect(result).toEqual({ fired: true, trainCode: 'T-2-new' });
+    expect(deps.arrivalProvider.getArrival).toHaveBeenCalledWith('건대입구', { lineHint: '7' });
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    const payload = syncSpy.mock.calls[0][0] as BackgroundTransferSwapSyncPayload;
+    expect(payload).toMatchObject({
+      token: 'tok-abc',
+      observedStationName: '건대입구',
+      observedAtMs: 1_700_000_000_000,
+      accuracy: 20,
+      trainCode: 'T-2-new',
+      boardingLine: '2',
+    });
+  });
+
+  it('같은 노선 직진(비환승) — 현재 boardingLine 도착만 있으면 swap 미발사 (false positive 0)', async () => {
+    // 7호선 lock 유지 중 7호선 도착만 잡힘 → 다른 노선 후보 없음 → 발사 X.
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '온수', arrivalSeconds: 60, line: '7', trainCode: 'T-7-next' }),
+    ]);
+    const { deps, syncSpy } = makeDeps({ arrival });
+    const result = await evaluateBackgroundTransferSwap(baseInput(), deps);
+
+    expect(result.fired).toBe(false);
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('정지 중(motionStationary=true)이면 다른 노선 임박이어도 swap 미발사', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const { deps, syncSpy } = makeDeps({ arrival });
+    const result = await evaluateBackgroundTransferSwap(baseInput({ motionStationary: true }), deps);
+
+    expect(result.fired).toBe(false);
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('다중 다른 노선 후보(단일 trainCode 미확정)면 swap 미발사', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2' }),
+      makeArrivalInfo({ destination: '천호', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const { deps, syncSpy } = makeDeps({ arrival });
+    const result = await evaluateBackgroundTransferSwap(baseInput(), deps);
+
+    expect(result.fired).toBe(false);
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it('같은 환승역 + 같은 leg lock으로 두 번째 tick은 arrival 재조회 없이 skip', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const { deps, syncSpy } = makeDeps({ arrival });
+
+    const first = await evaluateBackgroundTransferSwap(baseInput(), deps);
+    expect(first.fired).toBe(true);
+
+    const second = await evaluateBackgroundTransferSwap(baseInput(), deps);
+    expect(second.fired).toBe(false);
+    // arrival 조회/ sync 모두 1회만 — 두 번째 tick은 dedup으로 차단.
+    expect(deps.arrivalProvider.getArrival).toHaveBeenCalledTimes(1);
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('새 leg lock(boardingLine 변경)으로 hydrate되면 다음 환승은 다시 발사 허용', async () => {
+    const arrival2 = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const { deps, syncSpy } = makeDeps({ arrival: arrival2 });
+
+    await evaluateBackgroundTransferSwap(baseInput(), deps);
+    // silent push가 2호선 leg로 hydrate → lock.boardingLine='2'. 다음 환승역(2→5)에서 다시 평가.
+    const lock2: BoardingLock = { ...lock7, boardingLine: '2', trainCode: 'T-2-new', boardingStationId: DDP_2.id };
+    const arrival5 = makeArrival([
+      makeArrivalInfo({ destination: '천호', arrivalSeconds: 60, line: '5', trainCode: 'T-5-new' }),
+    ]);
+    (deps.arrivalProvider.getArrival as jest.Mock).mockResolvedValue(arrival5);
+
+    const result = await evaluateBackgroundTransferSwap(baseInput({ lock: lock2 }), deps);
+    expect(result).toEqual({ fired: true, trainCode: 'T-5-new' });
+    expect(syncSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('lock 해제(null) 시 dedup 키 reset — 재탑승 시 같은 환승역 다시 발사', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const { deps, syncSpy } = makeDeps({ arrival });
+
+    await evaluateBackgroundTransferSwap(baseInput(), deps);
+    await evaluateBackgroundTransferSwap(baseInput({ lock: null }), deps); // 하차 → reset
+    const result = await evaluateBackgroundTransferSwap(baseInput(), deps);
+
+    expect(result.fired).toBe(true);
+    expect(syncSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/route/utils/__tests__/transferSwap.test.ts
+++ b/src/features/route/utils/__tests__/transferSwap.test.ts
@@ -1,0 +1,182 @@
+/* eslint-disable import/no-restricted-paths --
+ * 대상 util(transferSwap)이 nearest-station이 소유한 AutoLockCandidate를 산출하는 cross-feature
+ * pure 함수로 file-level 옵트인되어 있으므로 그 테스트도 동일 정책으로 type을 직접 import한다.
+ */
+/**
+ * #1281 — evaluateTransferSwap (FG hook + BG task 공유 pure 결정).
+ *
+ * hook(useTransferAutoDetect) / BG(backgroundTransferSwap) 양쪽에서 재사용되는 결정 로직을 직접 검증:
+ *   - onPlannedTransfer short-circuit
+ *   - detect 실패(비환승/정지/임박 없음) → 빈 결과
+ *   - 단일 후보 → candidate 산출, 다중 후보 → candidate null
+ *   - collectOtherLineArrivals: null arrival / boardingLine 제외
+ *   - buildAutoLockCandidate: destination express 우선순위 / null destination / trainCode 부재
+ */
+import {
+  evaluateTransferSwap,
+  collectOtherLineArrivals,
+  buildAutoLockCandidate,
+} from '../transferSwap';
+import { makeArrivalInfo } from '../../../../testUtils/fixtures';
+import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
+import type { NearestStationsResult, Station } from '../../../../shared/types/station';
+
+const DDP_2: Station = { id: '0205', name: '동대문역사문화공원', line: '2', lineColor: '#009D3E', lat: 37.565, lng: 127.008 };
+const DDP_4: Station = { id: '0405', name: '동대문역사문화공원', line: '4', lineColor: '#00A0E2', lat: 37.565, lng: 127.008 };
+const DDP_5: Station = { id: '0505', name: '동대문역사문화공원', line: '5', lineColor: '#996CAC', lat: 37.565, lng: 127.008 };
+const GANGNAM_2: Station = { id: '0222', name: '강남', line: '2', lineColor: '#009D3E', lat: 37.498, lng: 127.027 };
+
+const transferNearest: NearestStationsResult = {
+  primary: DDP_2,
+  variants: [DDP_2, DDP_4, DDP_5],
+  distanceKm: 0.03,
+  isTransfer: true,
+};
+
+const nonTransferNearest: NearestStationsResult = {
+  primary: GANGNAM_2,
+  variants: [GANGNAM_2],
+  distanceKm: 0.03,
+  isTransfer: false,
+};
+
+function makeArrival(up: ArrivalInfo[] = [], down: ArrivalInfo[] = []): StationArrival {
+  return { up, down };
+}
+
+function baseInput(overrides: Partial<Parameters<typeof evaluateTransferSwap>[0]> = {}) {
+  return {
+    nearestStations: transferNearest,
+    motionStationary: false as boolean | undefined,
+    arrival: makeArrival(),
+    boardingLine: '2' as const,
+    destinationName: null as string | null,
+    onPlannedTransfer: false,
+    ...overrides,
+  };
+}
+
+describe('evaluateTransferSwap', () => {
+  it('onPlannedTransfer이면 즉시 빈 결과(detect 안 함)', () => {
+    const result = evaluateTransferSwap(baseInput({ onPlannedTransfer: true }));
+    expect(result).toEqual({ candidateLines: [], candidate: null });
+  });
+
+  it('비환승 역이면 빈 결과', () => {
+    const result = evaluateTransferSwap(baseInput({ nearestStations: nonTransferNearest }));
+    expect(result.candidateLines).toEqual([]);
+    expect(result.candidate).toBeNull();
+  });
+
+  it('정지(motionStationary=true)이면 빈 결과', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+    ]);
+    const result = evaluateTransferSwap(baseInput({ motionStationary: true, arrival }));
+    expect(result.candidateLines).toEqual([]);
+  });
+
+  it('단일 다른 노선 임박 → candidate 산출(boardingLine 제외 후 다른 노선)', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+    ]);
+    const result = evaluateTransferSwap(baseInput({ arrival }));
+    expect(result.candidateLines).toEqual(['4']);
+    expect(result.candidate).toEqual({ trainCode: 'T-4', line: '4', subwayId: expect.any(String) });
+  });
+
+  it('다중 다른 노선 임박 → candidateLines만, candidate는 null(사용자 선택 위임)', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      makeArrivalInfo({ destination: '왕십리', arrivalSeconds: 90, line: '5', trainCode: 'T-5' }),
+    ]);
+    const result = evaluateTransferSwap(baseInput({ arrival }));
+    expect(result.candidateLines).toHaveLength(2);
+    expect(result.candidate).toBeNull();
+  });
+
+  it('현재 boardingLine만 임박이면 다른 노선 후보 없음 → 빈 결과', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2' }),
+    ]);
+    const result = evaluateTransferSwap(baseInput({ arrival }));
+    expect(result.candidateLines).toEqual([]);
+  });
+});
+
+describe('collectOtherLineArrivals', () => {
+  it('arrival null이면 빈 배열', () => {
+    expect(collectOtherLineArrivals(null, '2')).toEqual([]);
+  });
+
+  it('boardingLine과 같은 노선은 제외, 다른 노선만 수집', () => {
+    const arrival = makeArrival(
+      [makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2' })],
+      [makeArrivalInfo({ destination: '서울역', arrivalSeconds: 90, line: '4', trainCode: 'T-4' })],
+    );
+    const out = collectOtherLineArrivals(arrival, '2');
+    expect(out).toEqual([{ line: '4', arrivalSeconds: 90, arrivalCode: -1 }]);
+  });
+
+  it('boardingLine null이면 전체 수집', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2' }),
+    ]);
+    const out = collectOtherLineArrivals(arrival, null);
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe('buildAutoLockCandidate', () => {
+  it('arrival null이면 trainCode 없음 → null', () => {
+    expect(buildAutoLockCandidate('4', null, null)).toBeNull();
+  });
+
+  it('해당 노선 도착 없으면 null', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2' }),
+    ]);
+    expect(buildAutoLockCandidate('4', arrival, null)).toBeNull();
+  });
+
+  it('destinationName 없으면 가장 임박한 trainCode', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 120, line: '4', trainCode: 'T-late' }),
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-soon' }),
+    ]);
+    expect(buildAutoLockCandidate('4', arrival, null)?.trainCode).toBe('T-soon');
+  });
+
+  it('나중 도착은 fallback(가장 임박)을 교체하지 않음', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-soon' }),
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 120, line: '4', trainCode: 'T-late' }),
+    ]);
+    expect(buildAutoLockCandidate('4', arrival, null)?.trainCode).toBe('T-soon');
+  });
+
+  it('destinationName 미정차 express는 후보에서 제외하고 정차 후보 우선', () => {
+    // 9호선 급행 데이터 보유. '강남'은 express 정차역이 아니므로 express는 제외, normal 선택.
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '개화', arrivalSeconds: 60, line: '9', trainCode: 'T-exp', trainType: 'express' }),
+      makeArrivalInfo({ destination: '개화', arrivalSeconds: 90, line: '9', trainCode: 'T-norm', trainType: 'normal' }),
+    ]);
+    expect(buildAutoLockCandidate('9', arrival, '강남')?.trainCode).toBe('T-norm');
+  });
+
+  it('정차 후보가 여럿이면 가장 임박한 정차 후보를 preferred로 선택', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '개화', arrivalSeconds: 120, line: '9', trainCode: 'T-norm-late', trainType: 'normal' }),
+      makeArrivalInfo({ destination: '개화', arrivalSeconds: 60, line: '9', trainCode: 'T-norm-soon', trainType: 'normal' }),
+    ]);
+    expect(buildAutoLockCandidate('9', arrival, '강남')?.trainCode).toBe('T-norm-soon');
+  });
+
+  it('나중 정차 후보는 preferred를 교체하지 않음', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '개화', arrivalSeconds: 60, line: '9', trainCode: 'T-norm-soon', trainType: 'normal' }),
+      makeArrivalInfo({ destination: '개화', arrivalSeconds: 120, line: '9', trainCode: 'T-norm-late', trainType: 'normal' }),
+    ]);
+    expect(buildAutoLockCandidate('9', arrival, '강남')?.trainCode).toBe('T-norm-soon');
+  });
+});

--- a/src/features/route/utils/backgroundTransferSwap.ts
+++ b/src/features/route/utils/backgroundTransferSwap.ts
@@ -1,0 +1,142 @@
+/**
+ * #1281 — 백그라운드 환승 자동 detect.
+ *
+ * FG의 `useTransferAutoDetect`는 화면이 켜져 있을 때만 동작한다(HomeScreen mount). 주머니 속(BG)
+ * 환승에서는 detect 진입점이 없어 옛 노선 lock이 backend auto-end(~10분)까지 얼어붙고, 새 노선
+ * lock은 사용자가 "탑승 열차"를 직접 탭해야만 활성화됐다(실기기 7→2호선 건대입구 trip, auto 환승 0건).
+ *
+ * 본 함수는 BG tick에서 동일한 `evaluateTransferSwap`(FG와 공유 pure 결정)을 돌려 환승-swap 후보를
+ * 잡고, 후보가 있으면 backend `/boarding-lock/sync`에 새 노선 trainCode를 통보한다. backend가 새
+ * trainCode를 관측하면 W1(#1271) 경로로 swap을 적용하고 `autoLockCandidate.from='transfer-swap'`을
+ * silent push로 발급 → client store가 motion gate 우회로 hydrate. FG/BG가 같은 swap 경로를 탄다.
+ *
+ * 의존성은 모두 주입한다(테스트 가능 + route 슬라이스가 nearest-station/arrival를 직접 import하지
+ * 않게): 호출자(backgroundLocationTask, cross-feature 옵트인 파일)가 provider/sync/lookup을 넘긴다.
+ *
+ * false-positive 방어는 `evaluateTransferSwap`(=`detectTransfer`)의 기존 게이트를 그대로 재사용한다:
+ *   1) 현재 최근접 역이 환승역  2) motion walking(이동 중)  3) 현재 boardingLine 제외 다른 노선의
+ *   임박 도착. 셋을 모두 충족할 때만 후보가 산출되므로 같은 노선 직진(비환승) trip은 발사하지 않는다.
+ *
+ * arrival fetch 비용 절감: lock 활성 + 최근접 역이 환승역일 때만 1회 조회한다(매 tick 폴링 X).
+ */
+import { evaluateTransferSwap } from './transferSwap';
+import type { ArrivalProvider } from '../../../shared/types/providers';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { NearestStationsResult } from '../../../shared/types/station';
+
+/** `/boarding-lock/sync` 발사에 필요한 payload(호출자의 syncBoardingLock 시그니처 부분집합). */
+export interface BackgroundTransferSwapSyncPayload {
+  token: string;
+  observedStationName: string;
+  observedAtMs: number;
+  accuracy: number;
+  trainCode: string;
+  boardingLine: string;
+}
+
+export interface BackgroundTransferSwapDeps {
+  /** 좌표 → fusion 최근접 역(환승 여부 포함). nearest-station feature에서 주입. */
+  findNearestStations: (lat: number, lng: number) => NearestStationsResult | null;
+  /** arrival provider. 환승역 도착 정보 1회 조회용. */
+  arrivalProvider: ArrivalProvider;
+  /** backend sync 발사. 호출자(BG task)가 nearest-station API를 래핑해 주입. */
+  syncBoardingLock: (payload: BackgroundTransferSwapSyncPayload) => Promise<unknown>;
+}
+
+export interface BackgroundTransferSwapInput {
+  lat: number;
+  lng: number;
+  accuracy: number;
+  observedAtMs: number;
+  /** APNs device token. backend sync 키. */
+  apnsToken: string;
+  /** 현재 활성 boarding lock. null이면 환승 detect 대상 trip이 아님. */
+  lock: BoardingLock | null;
+  /** BG motion 신호 — `getCurrentMotionStationary()` 결과. */
+  motionStationary: boolean;
+  /** route 도착역 이름(있으면 express 정차 우선순위 판정). */
+  destinationName: string | null;
+}
+
+export interface BackgroundTransferSwapResult {
+  /** swap 후보를 잡아 sync를 발사했는지. 테스트/로그용. */
+  fired: boolean;
+  /** 발사한 새 노선 trainCode(있으면). */
+  trainCode?: string;
+}
+
+const NO_SWAP: BackgroundTransferSwapResult = { fired: false };
+
+/**
+ * 직전 sync를 발사한 (환승역 + lock leg) 키. 같은 leg lock으로 같은 환승역에 머무는 동안 매 BG tick
+ * 마다 arrival 조회 + sync를 재발사하는 churn을 막는다(FG `useBoardingLockSync`의 lastSent ref 패턴).
+ * silent push가 새 leg를 hydrate하면 lock.boardingLine/boardingStationId가 바뀌어 키가 달라지고
+ * 다음 환승이 다시 허용된다. lock 해제(trip 종료) 시 reset.
+ */
+let lastFiredKey: string | null = null;
+
+/** 테스트 격리용 — 모듈 상태 초기화. production 경로에서는 호출하지 않는다. */
+export function resetBackgroundTransferSwapState(): void {
+  lastFiredKey = null;
+}
+
+/**
+ * BG 환승-swap 평가 + sync 발사. 후보가 없으면 no-op({fired:false}).
+ *
+ * 게이트 순서(저비용 → 고비용):
+ *   1) lock 활성 (없으면 추적 대상 trip 아님 — lastFiredKey reset)
+ *   2) 최근접 역이 환승역 (arrival fetch 비용 게이트)
+ *   3) 같은 환승역 + 같은 leg lock으로 이미 발사했으면 skip (arrival 재조회 churn 차단)
+ *   4) 환승역 arrival 1회 조회 → `evaluateTransferSwap`로 다른 노선 임박 + walking 결합 판정
+ *   5) 단일 후보(=새 노선 trainCode)면 backend sync 발사
+ */
+export async function evaluateBackgroundTransferSwap(
+  input: BackgroundTransferSwapInput,
+  deps: BackgroundTransferSwapDeps,
+): Promise<BackgroundTransferSwapResult> {
+  const { lat, lng, accuracy, observedAtMs, apnsToken, lock, motionStationary, destinationName } = input;
+  if (!lock) {
+    lastFiredKey = null;
+    return NO_SWAP;
+  }
+
+  const nearestStations = deps.findNearestStations(lat, lng);
+  if (!nearestStations || !nearestStations.isTransfer) return NO_SWAP;
+
+  // 환승역 arrival 1회 조회. lineHint는 현재 lock 노선 — schedule fallback의 환승역 첫 매칭
+  // 부정확성을 줄인다. realtime 성공 경로엔 영향 없음. 조회 실패는 graceful no-op.
+  const stationName = nearestStations.primary.name;
+  const fireKey = `${lock.boardingStationId}|${lock.boardingLine}|${stationName}`;
+  if (lastFiredKey === fireKey) return NO_SWAP;
+  let arrival = null;
+  try {
+    arrival = await deps.arrivalProvider.getArrival(stationName, { lineHint: lock.boardingLine });
+  } catch {
+    return NO_SWAP;
+  }
+
+  const { candidate } = evaluateTransferSwap({
+    nearestStations,
+    motionStationary,
+    arrival,
+    boardingLine: lock.boardingLine,
+    destinationName,
+    // BG에는 useTransferTrainList 같은 planned-transfer UI context가 없으므로 항상 false.
+    onPlannedTransfer: false,
+  });
+  if (!candidate) return NO_SWAP;
+
+  // backend가 새 trainCode(≠ 현재 lock)를 관측하면 W1(#1271) swap 경로로 from='transfer-swap'
+  // candidate를 발급한다. candidate.line은 boardingLine 제외 후 산출돼 항상 다른 노선 → 다른 trainCode.
+  lastFiredKey = fireKey;
+  await deps.syncBoardingLock({
+    token: apnsToken,
+    observedStationName: stationName,
+    observedAtMs,
+    accuracy,
+    trainCode: candidate.trainCode,
+    boardingLine: candidate.line,
+  });
+
+  return { fired: true, trainCode: candidate.trainCode };
+}

--- a/src/features/route/utils/transferSwap.ts
+++ b/src/features/route/utils/transferSwap.ts
@@ -1,0 +1,164 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature: 본 pure 결정 함수는 nearest-station이 소유한 `AutoLockCandidate`를 산출한다
+ * (FG hook `useTransferAutoDetect`도 동일 import를 file-level disable로 옵트인). 후속 PR에서
+ * orchestration 슬라이스로 이전하며 disable을 제거할 예정 (#1281 본문 명시).
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #1281 — route 미설정 환승 자동 detect의 순수 결정 로직.
+ *
+ * `useTransferAutoDetect`(FG hook)와 `backgroundLocationTask`(BG task)가 동일한 환승-swap 후보
+ * 산출 로직을 공유하도록 hook에서 추출한 pure 함수. FG/BG 어느 진입점에서도 같은 신호 결합과
+ * false-positive 방어(`detectTransfer`)를 거쳐 결정한다.
+ *
+ * pure: React/AsyncStorage/네트워크 의존 없음. 호출자가 fusion 결과·arrival·lock·route 컨텍스트를
+ * 모두 인자로 전달한다. hook은 결과를 모달/idempotency state와 묶고, BG task는 결과 candidate로
+ * `/boarding-lock/sync`를 발사한다.
+ *
+ * 신호 결합(모두 충족 시 detect, `detectTransfer` 위임):
+ *   1) 현재 가장 가까운 역이 환승역(`isTransfer`)
+ *   2) motion walking(이동 중)
+ *   3) 현재 boardingLine을 제외한 다른 노선의 임박 도착 신호
+ *
+ * candidate(단일 후보일 때만 산출): backend `/boarding-lock/sync` payload + client hydrate에 쓰는
+ * AutoLockCandidate. 다중 후보는 candidateLines로만 노출하고 호출자(FG 모달)가 사용자 선택을 받는다.
+ */
+import { detectTransfer } from './transferDetect';
+import { isExpressStop } from './expressLookup';
+import { lineToSubwayId } from '../../../shared/constants/lineApiNames';
+import type { OtherLineArrival } from './transferDetect';
+import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
+import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
+import type { LineNumber, NearestStationsResult } from '../../../shared/types/station';
+
+export interface EvaluateTransferSwapInput {
+  /** 현재 fusion된 최근접 역(환승역 후보 포함). */
+  readonly nearestStations: NearestStationsResult | null;
+  /** 현재 정차 중 여부. `false`/`undefined`(warmup)일 때만 detect 활성. */
+  readonly motionStationary: boolean | undefined;
+  /** 현재 origin station의 도착 데이터. 다른 노선 후보 추출 입력. */
+  readonly arrival: StationArrival | null;
+  /** 현재 boardingLock의 노선. 같은 노선 후보는 제외(자기 노선 무한 detect 회피). */
+  readonly boardingLine: LineNumber | null;
+  /** route 도착역 이름. trainType 우선순위(express 정차 여부) 판정에 사용. */
+  readonly destinationName: string | null;
+  /**
+   * 사용자가 이미 planned route의 transfer waypoint에 있다(기존 환승 list flow가 책임). true면
+   * 자동 detect skip. FG hook은 `findActiveTransferContext`로 산출, BG task는 항상 false.
+   */
+  readonly onPlannedTransfer: boolean;
+}
+
+export interface EvaluateTransferSwapResult {
+  /** detect된 다른 노선 후보(0/1/N), imminence 정렬. */
+  readonly candidateLines: readonly LineNumber[];
+  /** 단일 후보일 때만 산출되는 AutoLockCandidate. 0개/다중 후보면 null. */
+  readonly candidate: AutoLockCandidate | null;
+}
+
+const EMPTY_RESULT: EvaluateTransferSwapResult = { candidateLines: [], candidate: null };
+
+/**
+ * 환승-swap 후보를 결정한다. FG hook과 BG task가 공유하는 단일 결정 지점.
+ *
+ * 단일 후보면 `candidate`를 함께 산출(자동 lock / sync 발사용), 다중 후보면 `candidateLines`만
+ * 노출(호출자가 사용자 선택 모달로 연결). detect 실패(0개)면 둘 다 비운다.
+ */
+export function evaluateTransferSwap(
+  input: EvaluateTransferSwapInput,
+): EvaluateTransferSwapResult {
+  const { nearestStations, motionStationary, arrival, boardingLine, destinationName, onPlannedTransfer } = input;
+
+  if (onPlannedTransfer) return EMPTY_RESULT;
+
+  const otherLineArrivals = collectOtherLineArrivals(arrival, boardingLine);
+  const detection = detectTransfer({
+    nearestStations,
+    motionWalking: !motionStationary,
+    otherLineArrivals,
+  });
+  if (!detection.detected) return EMPTY_RESULT;
+
+  const { candidateLines } = detection;
+  if (candidateLines.length !== 1) {
+    return { candidateLines, candidate: null };
+  }
+
+  const [line] = candidateLines;
+  const candidate = buildAutoLockCandidate(line, arrival, destinationName);
+  return { candidateLines, candidate };
+}
+
+/**
+ * arrival.up / down을 평탄화한 뒤 `boardingLine`을 제외하고 OtherLineArrival 배열로 변환.
+ * 같은 line의 up/down이 모두 있어도 detectTransfer가 dedup하므로 추가 처리 불필요.
+ */
+export function collectOtherLineArrivals(
+  arrival: StationArrival | null,
+  boardingLine: LineNumber | null,
+): OtherLineArrival[] {
+  if (!arrival) return [];
+  const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
+  const out: OtherLineArrival[] = [];
+  for (const t of all) {
+    if (boardingLine !== null && t.line === boardingLine) continue;
+    out.push({ line: t.line, arrivalSeconds: t.arrivalSeconds, arrivalCode: t.arrivalCode });
+  }
+  return out;
+}
+
+/**
+ * candidate line의 가장 임박한 trainCode를 사용해 AutoLockCandidate 구성.
+ * subwayId 매핑 누락 시 null — 호출자가 hydrate/sync skip.
+ *
+ * #971: destinationName이 주어지면 trainType이 destination에 정차하는 후보를 우선 선택.
+ * 일반정차역만 가능한 destination에서 급행/특급이 통과하는 lock 사고를 회피한다.
+ */
+export function buildAutoLockCandidate(
+  line: LineNumber,
+  arrival: StationArrival | null,
+  destinationName: string | null,
+): AutoLockCandidate | null {
+  const subwayId = lineToSubwayId(line);
+  /* istanbul ignore next -- 모든 LineNumber는 LINE_TO_SUBWAY_ID에 등록되어 있어 null 분기는
+     valid LineNumber 입력 하에서 도달 불가. 타입 보강용 방어. */
+  if (!subwayId) return null;
+  const trainCode = pickImminentTrainCode(arrival, line, destinationName);
+  if (!trainCode) return null;
+  return { trainCode, line, subwayId };
+}
+
+/**
+ * 같은 line의 후보 중 가장 임박한 trainCode 반환.
+ *
+ * #971: destinationName이 있으면 destination 정차 가능한 trainType을 1차 후보군으로,
+ * 그 군이 비면 전체에서 fallback. destinationName=null은 기존 동작(전체에서 imminent).
+ *
+ * `isExpressStop`은 normal에 대해 항상 true, 데이터 미보유 line/type에 대해 보수적으로 true →
+ * 미지의 노선/타입을 사용자에게 무리하게 막지 않는다. 일반정차역 only인 destination에서
+ * 정확한 express 정차역 데이터가 있는 경우(예: 1·9호선 급행)에만 express 후보를 제외한다.
+ */
+function pickImminentTrainCode(
+  arrival: StationArrival | null,
+  line: LineNumber,
+  destinationName: string | null,
+): string | null {
+  if (!arrival) return null;
+  const all: ArrivalInfo[] = [...arrival.up, ...arrival.down];
+  let preferred: ArrivalInfo | null = null;
+  let fallback: ArrivalInfo | null = null;
+  for (const t of all) {
+    if (t.line !== line) continue;
+    /* istanbul ignore next -- detectTransfer는 음수 arrivalSeconds를 후보에서 제외한 뒤 line을
+       반환하므로, 그 line의 음수 train이 있더라도 양수 train이 이미 적어도 하나 존재. 양수만
+       best로 선택되어 음수 분기는 도달하지 않는다. 방어 코드. */
+    if (t.arrivalSeconds < 0) continue;
+    if (!fallback || t.arrivalSeconds < fallback.arrivalSeconds) fallback = t;
+    // destination 미설정 → 모든 후보가 preferred와 동등 → fallback만으로 판정.
+    if (destinationName === null) continue;
+    if (!isExpressStop(destinationName, line, t.trainType)) continue;
+    if (!preferred || t.arrivalSeconds < preferred.arrivalSeconds) preferred = t;
+  }
+  return (preferred ?? fallback)?.trainCode ?? null;
+}


### PR DESCRIPTION
## Summary

환승 자동 detect가 백그라운드(주머니 속)에서 동작하지 않던 회귀를 차단한다. 실기기 7→2호선(건대입구) 환승 trip에서 auto 환승 0건 — 옛 노선 lock이 backend auto-end(~10분)까지 얼어붙고, 새 노선 lock은 사용자가 "탑승 열차"를 직접 탭해야만 활성화됐다.

**Root cause**: `useTransferAutoDetect`(`src/features/route/hooks/useTransferAutoDetect.ts`)가 `HomeScreen`에만 mount되어 FG 전용. BG 진입점이 없어 W1(#1271 motion-gate transfer-swap)이 머지됐어도 BG에서 실행되지 못함.

## 변경

- **`transferSwap.ts` 신규** — 환승-swap 결정 로직(다른 노선 arrival 수집 + `detectTransfer` + candidate 산출)을 hook에서 pure 함수 `evaluateTransferSwap`로 추출. FG hook과 BG task가 동일 함수를 공유. FG 동작 변경 없음(기존 43개 hook 테스트 그대로 통과 = regression guard).
- **`backgroundTransferSwap.ts` 신규** — BG orchestrator(의존성 주입). lock 활성 + 최근접 역이 환승역 + 다른 노선 임박(이동 중) 신호가 모두 충족되면 새 노선 trainCode를 backend `/boarding-lock/sync`에 통보 → backend가 새 trainCode 관측 시 W1(#1271) 경로로 `from:'transfer-swap'` candidate 발급 → silent push로 client hydrate. FG/BG가 같은 swap 경로를 탄다.
- **`backgroundLocationTask.ts` wire** — BG tick에서 lock 활성 + apnsToken 존재 시 `evaluateBackgroundTransferSwap` 호출.
- **false-positive 방어 유지** — `detectTransfer`의 환승역/walking/다른 노선 임박 결합 게이트를 그대로 재사용. 같은 노선 직진(비환승) trip은 발사하지 않음(테스트로 검증, false positive = 0).
- **churn 차단** — 같은 leg lock으로 같은 환승역에 머무는 동안 arrival 재조회 + sync 재발사를 dedup(silent push hydrate로 leg 변경 시 자동 해제).
- **cross-feature import** — `transferSwap.ts`는 nearest-station 소유 `AutoLockCandidate`를 산출하므로 file-level `eslint-disable import/no-restricted-paths`로 옵트인(기존 orchestrator 패턴). 후속 PR에서 orchestration 슬라이스로 이전 예정.

## Test plan

- [x] Unit: BG에서 환승역 도착 + 방향 변경(다른 노선 임박) → transfer-swap candidate 평가 + sync 발사
- [x] Unit: 같은 노선 직진(비환승) → swap 미발사 (false positive = 0)
- [x] Unit: FG hook 동작 동일(pure 함수 추출 후 regression guard 43 tests)
- [x] 변경 4개 source 파일 100% coverage (lines/branches/funcs/stmts)
- [x] `npm run type-check` clean
- [x] `npm run lint` clean (changed files)
- [ ] 실기기 evidence — BG 7→2호선 환승에서 auto lock 회복 확인

Closes #1281
Part of #1204