### PR TITLE
fix(#1280): foreground 주기 위치 업로드 (WhileInUse 위치 채널)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useFgPositionUpload.test.ts
+++ b/src/features/alarm/hooks/__tests__/useFgPositionUpload.test.ts
@@ -1,0 +1,128 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature test mirroring source's disable. ADR Phase 5 (#890).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { act, renderHook } from '@testing-library/react-native';
+import { useFgPositionUpload } from '../useFgPositionUpload';
+import { GOOD_FIX_ACCURACY_MAX_M } from '../useBoardingLockSync';
+import { uploadPosition } from '../../../nearest-station/api/positionUpload';
+import { FG_POSITION_UPLOAD_THROTTLE_MS } from '../../../../shared/constants/location';
+import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('../../../nearest-station/api/positionUpload', () => ({
+  uploadPosition: jest.fn(),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const mockedUpload = uploadPosition as jest.MockedFunction<typeof uploadPosition>;
+
+const SEOUL = { lat: 37.5, lng: 127.0 };
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await AsyncStorage.clear();
+  await AsyncStorage.setItem(APNS_TOKEN_KEY, 'apns-tok');
+  await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'trip-tok');
+  mockedUpload.mockResolvedValue({ ok: true, status: 200 });
+  jest.useFakeTimers();
+  jest.setSystemTime(0);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+async function flushAsyncStorage(): Promise<void> {
+  // AsyncStorage getItem은 microtask 큐로 처리 — fake timers 사용 중에도 promise를 흘려보낸다.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useFgPositionUpload (#1280)', () => {
+  type Inputs = Parameters<typeof useFgPositionUpload>[0];
+  const defaults: Inputs = { userLocation: SEOUL, accuracyMeters: 10, tripActive: true };
+  const renderUpload = (overrides: Partial<Inputs> = {}) =>
+    renderHook((props: Partial<Inputs>) => useFgPositionUpload({ ...defaults, ...props }), {
+      initialProps: overrides,
+    });
+
+  it.each<{ label: string; overrides: Partial<Inputs> }>([
+    { label: 'tripActive=false', overrides: { tripActive: false } },
+    { label: 'userLocation=null', overrides: { userLocation: null } },
+    { label: 'accuracy=null', overrides: { accuracyMeters: null } },
+    { label: 'accuracy > 50m', overrides: { accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 1 } },
+  ])('게이트 실패 ($label) → 미업로드', async ({ overrides }) => {
+    renderUpload(overrides);
+    await flushAsyncStorage();
+    expect(mockedUpload).not.toHaveBeenCalled();
+  });
+
+  it('좋은 fix + activeTrip → 즉시 1회 업로드 (motion/payload 포함)', async () => {
+    renderUpload({ motionStationary: true });
+    await flushAsyncStorage();
+    expect(mockedUpload).toHaveBeenCalledTimes(1);
+    expect(mockedUpload.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        token: 'apns-tok',
+        lat: SEOUL.lat,
+        lng: SEOUL.lng,
+        accuracy: 10,
+        motion: 'stationary',
+      }),
+    );
+  });
+
+  it('motionStationary 미지정 → motion=unknown', async () => {
+    renderUpload();
+    await flushAsyncStorage();
+    expect(mockedUpload.mock.calls[0][0]).toEqual(expect.objectContaining({ motion: 'unknown' }));
+  });
+
+  it('throttle 내 연속 fix → 1회만 업로드, 간격 경과 후 재발사', async () => {
+    const { rerender } = renderUpload();
+    await flushAsyncStorage();
+    expect(mockedUpload).toHaveBeenCalledTimes(1);
+
+    // throttle 간격 미만에서 새 fix → 미발사
+    act(() => jest.advanceTimersByTime(FG_POSITION_UPLOAD_THROTTLE_MS - 1));
+    rerender({ userLocation: { lat: 37.51, lng: 127.01 } });
+    await flushAsyncStorage();
+    expect(mockedUpload).toHaveBeenCalledTimes(1);
+
+    // throttle 간격 경과 후 새 fix → 재발사
+    act(() => jest.advanceTimersByTime(2));
+    rerender({ userLocation: { lat: 37.52, lng: 127.02 } });
+    await flushAsyncStorage();
+    expect(mockedUpload).toHaveBeenCalledTimes(2);
+  });
+
+  it('trip 비활성 → 활성 전환 시 throttle 리셋 → 첫 fix 즉시 발사', async () => {
+    const { rerender } = renderUpload({ tripActive: false });
+    await flushAsyncStorage();
+    expect(mockedUpload).not.toHaveBeenCalled();
+
+    rerender({ tripActive: true });
+    await flushAsyncStorage();
+    expect(mockedUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it.each<{ label: string; key: typeof APNS_TOKEN_KEY | typeof ACTIVE_TRIP_KEY }>([
+    { label: 'apns token 부재', key: APNS_TOKEN_KEY },
+    { label: 'active trip 부재', key: ACTIVE_TRIP_KEY },
+  ])('$label → graceful no-op', async ({ key }) => {
+    await AsyncStorage.removeItem(key);
+    renderUpload();
+    await flushAsyncStorage();
+    expect(mockedUpload).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/hooks/useFgPositionUpload.ts
+++ b/src/features/alarm/hooks/useFgPositionUpload.ts
@@ -1,0 +1,121 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: alarm hook이 nearest-station feature의 API client
+ * `uploadPosition`을 직접 호출한다. useBoardingLockSync(같은 슬라이스, syncBoardingLock 호출)와
+ * 동형이라 file-level disable 패턴을 따른다. ADR Phase 5 (#890).
+ */
+/**
+ * #1280 — foreground(WhileInUse) 위치 업로드 훅.
+ *
+ * `uploadPosition`(POST /position)은 그동안 BG task(backgroundLocationTask) 한 곳에서만 호출됐다.
+ * WhileInUse 권한 사용자는 BG task가 fire되지 않아 POST /position이 영구 0건 → backend 위치
+ * 지능(lock advance / boarding-prompt window)이 굶는다. 1시간 실기기 trip에서 POST /position = 0건
+ * 으로 확인된 회귀(#1280)다.
+ *
+ * 사용자가 앱을 FG에서 보고 있는 동안 fix-watch가 좋은 fix를 흘리므로, 그 fix를 throttle 간격
+ * (FG_POSITION_UPLOAD_THROTTLE_MS, ~10s)마다 backend로 송신해 위치 채널을 점등한다.
+ *
+ * 게이트(useBoardingLockSync와 동형):
+ *   - tripActive=false → no-op (lock 없는 좌표는 backend trip series에 의미 없음)
+ *   - accuracy null / GOOD_FIX_ACCURACY_MAX_M 초과 → skip (positionUpload의 ≥50m drop과 정합)
+ *   - userLocation null → skip
+ *
+ * APNs token / trip token 부재(트립 미시작)는 자연 no-op. 송신은 fire-and-forget —
+ * URL 미설정 / 네트워크 실패는 uploadPosition 내부에서 graceful 처리(throw 없음).
+ */
+
+import { useEffect, useRef } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import { FG_POSITION_UPLOAD_THROTTLE_MS } from '../../../shared/constants/location';
+import { uploadPosition, type PositionMotion } from '../../nearest-station/api/positionUpload';
+import { GOOD_FIX_ACCURACY_MAX_M } from './useBoardingLockSync';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('useFgPositionUpload');
+
+export interface UseFgPositionUploadOptions {
+  /** 클라가 표시용 게이트를 통과한 현재 좌표. null이면 no-op. */
+  userLocation: { lat: number; lng: number } | null;
+  /** 직전 fix accuracy meters. null/임계 초과면 no-op. */
+  accuracyMeters: number | null;
+  /**
+   * 트립 활성 여부 — 호출자가 trip 활성 게이트를 결정해 전달한다(useBoardingLockSync와 동형).
+   * false면 업로드하지 않는다 (lock 없는 fix는 backend trip series에 의미 없어 트래픽만 발생).
+   */
+  tripActive: boolean;
+  /** 모션 stationary 확정 여부(graceful false). payload.motion 산출용. */
+  motionStationary?: boolean;
+}
+
+/**
+ * Effect-only 훅 — 외부 상태를 mutate하지 않고 backend POST만 발사한다(return 없음).
+ *
+ * userLocation/accuracy가 바뀔 때마다 effect가 재실행되지만, 마지막 발사 시각을 ref로 들고
+ * throttle 간격 이내의 연속 fix는 1회로 묶는다(BG보다 촘촘하되 과송신 방지).
+ */
+export function useFgPositionUpload({
+  userLocation,
+  accuracyMeters,
+  tripActive,
+  motionStationary,
+}: UseFgPositionUploadOptions): void {
+  // 마지막 업로드 시각(epoch ms). throttle 판정용. null = 미발사(첫 fix 즉시 발사).
+  const lastUploadedAtRef = useRef<number | null>(null);
+
+  // tripActive false → true 전환 시 throttle ref를 리셋해 새 trip 첫 fix가 즉시 발사되도록 한다.
+  useEffect(() => {
+    if (!tripActive) {
+      lastUploadedAtRef.current = null;
+    }
+  }, [tripActive]);
+
+  useEffect(() => {
+    if (!tripActive) return;
+    if (!userLocation) return;
+    if (accuracyMeters === null) return;
+    if (accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
+
+    const now = Date.now();
+    const lastUploadedAt = lastUploadedAtRef.current;
+    if (lastUploadedAt !== null && now - lastUploadedAt < FG_POSITION_UPLOAD_THROTTLE_MS) return;
+    lastUploadedAtRef.current = now;
+
+    void fireUpload({
+      lat: userLocation.lat,
+      lng: userLocation.lng,
+      accuracy: accuracyMeters,
+      ts: now,
+      motionStationary: motionStationary === true,
+    });
+  }, [tripActive, userLocation, accuracyMeters, motionStationary]);
+}
+
+interface FireUploadInput {
+  lat: number;
+  lng: number;
+  accuracy: number;
+  ts: number;
+  motionStationary: boolean;
+}
+
+/**
+ * AsyncStorage에서 token을 읽어 uploadPosition 호출. token/trip 부재는 graceful no-op.
+ * mapMatched / nearestStationDistance enrich는 uploadPosition 내부가 BG 호출자와 동일하게 처리.
+ */
+async function fireUpload(input: FireUploadInput): Promise<void> {
+  const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+  const activeTrip = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+  if (!token || !activeTrip) {
+    logger.info('skip — apns or trip token missing');
+    return;
+  }
+  const motion: PositionMotion = input.motionStationary ? 'stationary' : 'unknown';
+  void uploadPosition({
+    token,
+    lat: input.lat,
+    lng: input.lng,
+    accuracy: input.accuracy,
+    ts: input.ts,
+    motion,
+  });
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -52,6 +52,7 @@ import { useBoardingLockAdvancer } from '../features/alarm/hooks/useBoardingLock
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
 import { useDestinationAutoClear } from '../features/alarm/hooks/useDestinationAutoClear';
 import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
+import { useFgPositionUpload } from '../features/alarm/hooks/useFgPositionUpload';
 import { useCurrentStationConfirmModal } from '../features/nearest-station/hooks/useCurrentStationConfirmModal';
 import { useWifiStation } from '../features/nearest-station/hooks/useWifiStation';
 import { CurrentStationConfirmModal } from '../features/nearest-station/components/CurrentStationConfirmModal';
@@ -407,6 +408,15 @@ export default function HomeScreen() {
     boardingLockTrainCode: boardingLock?.trainCode ?? null,
     boardingLockLine: boardingLock?.boardingLine ?? null,
     onAutoLockCandidate: hydrateLockFromCandidate,
+  });
+  // #1280 — FG(WhileInUse) 위치 채널. BG task가 안 도는 WhileInUse 권한에서 FG fix-watch가
+  // ~10s throttle로 좌표를 backend에 송신해 POST /position 0건 회귀를 메운다. useBoardingLockSync와
+  // 동일하게 trip 활성 + 좋은 fix(≤50m) 게이트. fire-and-forget(URL 미설정/네트워크 실패 graceful).
+  useFgPositionUpload({
+    userLocation,
+    accuracyMeters: accuracyMeters ?? null,
+    tripActive: Boolean(destination && route),
+    motionStationary,
   });
   useBoardingLockScheduler({
     lock: boardingLock,

--- a/src/shared/constants/location.ts
+++ b/src/shared/constants/location.ts
@@ -21,6 +21,12 @@ export const MAX_PLAUSIBLE_SPEED_MPS = 50;
 // 차단이 발생하는 것을 막는다. 21:29 사고(25km)는 이 임계값보다 한참 위라 영향 없음.
 export const MIN_JUMP_DISTANCE_M = 100;
 
+// #1280 — foreground(WhileInUse) 위치 업로드 throttle 간격.
+// BG 위치 task가 못 도는 WhileInUse 권한에서 FG fix-watch가 ~10s마다 backend로 좌표를 송신해
+// POST /position 채널을 점등한다. BG `timeInterval`(30s)보다 짧아 FG 활성 동안은 더 촘촘히
+// 위치 지능을 먹인다. 연속 fix가 이 간격보다 자주 들어와도 1회로 묶인다.
+export const FG_POSITION_UPLOAD_THROTTLE_MS = 10_000;
+
 // iOS CoreLocation은 속도를 측정할 수 없을 때 음수(보통 -1)를 반환한다.
 // stationary/indoor/cold-start 등에서 자주 발생 — null로 정규화해 다운스트림이
 // "측정 불가"와 "정지(0 m/s)"를 명확히 구분하도록 한다.


### PR DESCRIPTION
## 배경
1시간 실기기 trip에서 backend `POST /position` = 0건으로 확인된 회귀. `uploadPosition`은 그동안 BG task(`backgroundLocationTask`) 한 곳에서만 호출됐다. WhileInUse 권한 사용자는 BG task가 fire되지 않아 POST /position이 영구 0건 → backend 위치 지능(lock advance / boarding-prompt window)이 굶는다.

PR #1305는 **silent-push wakeup** 시점 업로드를 추가했고, 본 PR은 남은 **foreground(FG) 주기 업로드** 경로를 채운다.

## 변경
- `useFgPositionUpload` 훅 신규 (`src/features/alarm/hooks/`) — FG fix-watch가 `FG_POSITION_UPLOAD_THROTTLE_MS`(~10s) throttle로 `uploadPosition` 호출
- 게이트는 `useBoardingLockSync`와 동형: `tripActive` + 좋은 fix(`accuracy ≤ GOOD_FIX_ACCURACY_MAX_M` = 50m) + userLocation 존재. APNs/trip token 부재는 graceful no-op
- throttle 상수는 `src/shared/constants/location.ts`로 분리(하드코딩 금지). 좋은-fix 임계는 `useBoardingLockSync`의 `GOOD_FIX_ACCURACY_MAX_M` 재사용(중복 금지)
- `HomeScreen`에 배선(useBoardingLockSync 호출부 바로 뒤, 동일 게이트 입력)
- fire-and-forget — URL 미설정/네트워크 실패는 `uploadPosition` 내부가 graceful 처리(throw 없음)

## 설계 노트
- **FG 경로 선택**: `HomeScreen`이 이미 노출하는 `useFusedNearestStation`의 `userLocation`/`accuracyMeters`/`motionStationary`를 입력으로 사용 — `useBoardingLockSync`가 동일 소스를 쓰므로 게이트를 그대로 미러
- **throttle**: 마지막 업로드 시각 ref + 동기 게이트. 연속 fix는 1회로 묶이고 BG `timeInterval`(30s)보다 촘촘. `null` sentinel로 첫 fix는 즉시 발사, trip 비활성→활성 전환 시 리셋
- **(선택) subsurface 전이 강제 업로드는 미구현** — ~10s throttle이 subsurface-true window를 이미 촘촘히 커버하고, `forceTriggerKey` 머신을 복제하는 비용 대비 이득이 작아 스킵(임시방편 회피)

## 테스트
- 신규 훅 단위 테스트 10건 — 게이트 4종(trip/userLocation/accuracy null/accuracy>50m), 즉시 업로드, motion=unknown, throttle 묶음+간격 경과 재발사, trip 전환 리셋, token/trip 부재 graceful
- 변경 파일 100% 커버리지 (lines/branches/functions/statements), it.each + factory로 SonarCloud 중복 회피
- `npm run type-check` PASS, ESLint 변경 파일 clean

Closes #1280