### PR TITLE
perf(#1313): subsurface 시 FG GPS watch throttle (배터리)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -5,7 +5,13 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNearestStation } from '../useNearestStation';
 import * as useStickyStationModule from '../useStickyStation';
 import * as findNearestStationModule from '../../utils/findNearestStation';
-import { MAX_ACCURACY_M, MAX_ACCURACY_M_DISPLAY, MAX_LOCATION_AGE_MS } from '../../../../shared/constants/location';
+import {
+  MAX_ACCURACY_M,
+  MAX_ACCURACY_M_DISPLAY,
+  MAX_LOCATION_AGE_MS,
+  FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+  FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
+} from '../../../../shared/constants/location';
 import { BG_LAST_STATION_KEY } from '../../../../shared/constants/storageKeys';
 
 jest.mock('expo-location');
@@ -1209,5 +1215,126 @@ describe('useNearestStation — #903 Seam G barometer→sticky', () => {
     const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
     expect(lastCall[1]).toEqual(expect.objectContaining({ tripActive: expected }));
     spy.mockRestore();
+  });
+});
+
+describe('useNearestStation — #1313 subsurface GPS throttle', () => {
+  // 지상 기본값: High@2s. 지하 throttle: Balanced@12s. interval은 상수에서 가져와 매직넘버 회피.
+  const SURFACE_OPTIONS = {
+    accuracy: Location.Accuracy.High,
+    distanceInterval: 0,
+    timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+  };
+  const SUBSURFACE_OPTIONS = {
+    accuracy: Location.Accuracy.Balanced,
+    distanceInterval: 0,
+    timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
+  };
+  // RN의 AppState.currentState는 plain property — restart effect가 'active' 가드에 참조한다.
+  const originalCurrentState = AppState.currentState;
+
+  // 마지막 watchPositionAsync 호출의 options 인자.
+  const lastWatchOptions = () => {
+    const calls = (Location.watchPositionAsync as jest.Mock).mock.calls;
+    return calls[calls.length - 1][0];
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+    mockGranted();
+    (AppState as { currentState: string }).currentState = 'active';
+  });
+
+  afterEach(() => {
+    (AppState as { currentState: string }).currentState = originalCurrentState;
+  });
+
+  // 마운트 시 subsurface 값에 따른 초기 watch 옵션 — undefined/false는 절대 throttle하지 않는다(안전 기본값).
+  it.each([
+    { label: 'subsurface 미전달(undefined) → High@2s', props: {}, expected: () => SURFACE_OPTIONS },
+    { label: 'subsurface=false → High@2s', props: { barometerSubsurface: false }, expected: () => SURFACE_OPTIONS },
+    { label: 'subsurface=true → Balanced@12s', props: { barometerSubsurface: true }, expected: () => SUBSURFACE_OPTIONS },
+  ])('마운트 $label', async ({ props, expected }) => {
+    renderHook(() => useNearestStation(props));
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+    // 마운트 effect는 1회만 — restart effect가 중복 start하지 않는다.
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+    expect(lastWatchOptions()).toEqual(expected());
+  });
+
+  it('subsurface false→true flip 시 watch를 teardown 후 Balanced@12s로 재시작한다', async () => {
+    const { rerender } = renderHook(
+      ({ sub }: { sub: boolean }) => useNearestStation({ barometerSubsurface: sub }),
+      { initialProps: { sub: false } },
+    );
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+    expect(lastWatchOptions()).toEqual(SURFACE_OPTIONS);
+
+    await act(async () => { rerender({ sub: true }); });
+
+    // teardown(remove) 후 새 옵션으로 재시작 — 누수/중복 구독 없음.
+    expect(mockSubscription.remove).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
+    expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS);
+  });
+
+  it('subsurface true→false flip 시 watch를 teardown 후 High@2s로 되돌린다', async () => {
+    const { rerender } = renderHook(
+      ({ sub }: { sub: boolean }) => useNearestStation({ barometerSubsurface: sub }),
+      { initialProps: { sub: true } },
+    );
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+    expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS);
+
+    await act(async () => { rerender({ sub: false }); });
+
+    expect(mockSubscription.remove).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
+    expect(lastWatchOptions()).toEqual(SURFACE_OPTIONS);
+  });
+
+  it('warmup(undefined)→false 전이는 throttle boolean 불변이라 재시작하지 않는다 (no-op)', async () => {
+    const { rerender } = renderHook(
+      ({ sub }: { sub?: boolean }) => useNearestStation({ barometerSubsurface: sub }),
+      { initialProps: { sub: undefined } },
+    );
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+
+    await act(async () => { rerender({ sub: false }); });
+
+    // 둘 다 High@2s → 재시작 없음, teardown 없음.
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+    expect(mockSubscription.remove).not.toHaveBeenCalled();
+  });
+
+  it('백그라운드 중 subsurface flip은 FG watch를 켜지 않는다 (active 가드)', async () => {
+    const { rerender } = renderHook(
+      ({ sub }: { sub: boolean }) => useNearestStation({ barometerSubsurface: sub }),
+      { initialProps: { sub: false } },
+    );
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+
+    // 앱이 백그라운드인 동안 flip — restart effect는 'active' 가드에서 early return.
+    (AppState as { currentState: string }).currentState = 'background';
+    await act(async () => { rerender({ sub: true }); });
+
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+    expect(mockSubscription.remove).not.toHaveBeenCalled();
+
+    // FG 복귀 시 'active' 핸들러 refresh→startWatch가 throttledRef를 읽어 Balanced@12s로 반영.
+    (AppState as { currentState: string }).currentState = 'active';
+    await act(async () => { appStateCallback?.('active'); });
+    await waitFor(() => expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS));
   });
 });

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -16,6 +16,8 @@ import {
   MAX_ACCURACY_M,
   MAX_ACCURACY_M_DISPLAY,
   MAX_STATION_DISTANCE_KM,
+  FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+  FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
   isValidGpsSpeedMps,
 } from '../../../shared/constants/location';
 import { E2E_MOCK_LOCATION, IS_E2E_MOCK } from '../../../shared/constants/e2e';
@@ -36,6 +38,26 @@ export type NearestStationSource = 'sticky' | 'live';
 const logger = createLogger('useNearestStation');
 
 const MIN_DISTANCE_CHANGE_KM = 0.003; // 3m — UI 갱신을 자주 흘려보낸다.
+
+// #1313 — subsurface 여부로 갈리는 FG watch 옵션. accuracy 선택 + interval을 한 데이터로 묶어
+// startWatch가 throttle boolean만 보고 분기 없이 선택하게 한다(하드코딩 분기 회피).
+// distanceInterval:0은 두 모드 공통 — 시간 기반 샘플링만 쓰고 거리 게이트는 적용하지 않는다.
+const FG_WATCH_OPTIONS_SURFACE: Location.LocationOptions = {
+  accuracy: Location.Accuracy.High,
+  distanceInterval: 0,
+  timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+};
+const FG_WATCH_OPTIONS_SUBSURFACE: Location.LocationOptions = {
+  accuracy: Location.Accuracy.Balanced,
+  distanceInterval: 0,
+  timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
+};
+
+// throttle 여부로 watch 옵션을 고른다. true(지하 확정)면 throttle, false면 지상 기본값.
+// 확신 없이(undefined/false) GPS를 낮추지 않는다 — 호출부가 === true로 좁힌 boolean만 넘긴다(#1313).
+function fgWatchOptionsFor(throttled: boolean): Location.LocationOptions {
+  return throttled ? FG_WATCH_OPTIONS_SUBSURFACE : FG_WATCH_OPTIONS_SURFACE;
+}
 
 // userLocation/result는 표시용 완화 게이트(MAX_ACCURACY_M_DISPLAY=1500m)를 통과한 좌표로 갱신된다.
 // 알람 발화 경로에서 이 값을 ETA/거리 계산에 사용할 경우 반드시 accuracyMeters와 함께 묶어
@@ -137,6 +159,13 @@ export function useNearestStation(
   const [gpsActive, setGpsActive] = useState<GpsActiveState>(() => currentGpsActive());
   const [lastFixAtMs, setLastFixAtMs] = useState<number | null>(null);
   const subscriptionRef = useRef<Location.LocationSubscription | null>(null);
+  // #1313 — "지하라 throttle 중인가"의 SSOT. startWatch가 호출 시점에 이 ref를 읽어 watch 옵션을
+  // 고른다. subsurface 원시값이 아니라 throttle 여부(=== true)를 들고 있어 warmup(undefined)과
+  // false가 동일 분기로 합쳐진다. inputs를 startWatch deps에 넣으면 identity가 매 render 흔들려
+  // mount effect가 재실행되므로 ref로 분리한다(콜백 identity 안정 유지).
+  // 초기값을 첫 render의 subsurface로 맞춰, 마운트 시 이미 지하면 startWatch가 곧장 throttle 옵션을
+  // 고르고 restart effect는 변화 없음으로 early return → 마운트 중복 start 방지.
+  const throttledRef = useRef(inputs.barometerSubsurface === true);
   const lastStationIdRef = useRef<string | null>(null);
   const lastDistanceRef = useRef<number>(0);
   // 진단용 누적 카운터: lastKnown 캐시 fix가 freshness/accuracy 게이트에서 거부된 횟수.
@@ -283,18 +312,17 @@ export function useNearestStation(
 
       // 연속 GPS 스트리밍 — 지하 구간 horizontalAccuracy(300~1500m)도 표시용으로는 수용.
       // 알람은 useStationAlarm에서 accuracyMeters로 별도 엄격 게이트.
-      // High + distanceInterval:0 + timeInterval:2000:
+      // 지상(기본): High + distanceInterval:0 + timeInterval:2000:
       //  좌표를 최대한 자주 흘려보낸다 (foreground 한정, 화면 켜진 동안만).
       //  High는 GPS hardware fix가 없으면 WiFi BSSID / Cell tower triangulation으로 fallback
       //  → 지하 구간에서도 ~50~100m 위치가 들어옴 (BestForNavigation은 fallback 없이 stale).
+      // 지하(subsurface 확정, #1313): Balanced + timeInterval:12000으로 throttle — GPS가 무의미한
+      //  구간에서 full-power watch가 배터리를 태우는 것을 막는다. throttledRef가 현재 throttle 여부를
+      //  들고 있어 flip 시 effect가 stopWatch→startWatch로 재구성한다(아래 useEffect).
       // 참고: pausesUpdatesAutomatically / activityType은 expo-location foreground 옵션에
       //  노출되지 않아 적용 불가. background task 옵션에서만 사용 가능.
       subscriptionRef.current = await Location.watchPositionAsync(
-        {
-          accuracy: Location.Accuracy.High,
-          distanceInterval: 0,
-          timeInterval: 2000,
-        },
+        fgWatchOptionsFor(throttledRef.current),
         (location) => {
           if (!isAccuracyAcceptableForDisplay(location.coords.accuracy)) {
             setLocationUncertain(true);
@@ -392,6 +420,21 @@ export function useNearestStation(
       appStateSub.remove();
     };
   }, [startWatch, stopWatch, refresh]);
+
+  // #1313 — subsurface(지하) 확정 여부가 뒤집히면 FG watch를 재구성한다. expo-location FG 옵션은
+  // 라이브 변경이 불가해 stopWatch→startWatch로 재시작한다(startWatch가 throttledRef를 읽어 새 옵션 채택).
+  // 3가지 가드:
+  //  - throttle boolean이 실제로 바뀐 경우만 동작 → mount 시 중복 start 방지 + warmup(undefined)→false no-op.
+  //  - AppState 'active'일 때만 재시작 → BG 중 flip이 FG watch를 켜 'background'→stopWatch 규약을 깨는 것 방지.
+  //    (FG 복귀 시 'active' 핸들러의 refresh→startWatch가 ref를 읽어 현재 옵션으로 자연 반영.)
+  useEffect(() => {
+    const next = inputs.barometerSubsurface === true;
+    if (next === throttledRef.current) return;
+    throttledRef.current = next;
+    if (AppState.currentState !== 'active') return;
+    stopWatch();
+    void startWatch();
+  }, [inputs.barometerSubsurface, startWatch, stopWatch]);
 
   // #876 — 매 fix를 sticky 훅에 전달. lock된 역이 있으면 result를 그것으로 override.
   // fusion candidates는 useFusedNearestStation에서 userLocation 기반으로 별도 계산하므로 영향 없음.

--- a/src/shared/constants/location.ts
+++ b/src/shared/constants/location.ts
@@ -27,6 +27,20 @@ export const MIN_JUMP_DISTANCE_M = 100;
 // 위치 지능을 먹인다. 연속 fix가 이 간격보다 자주 들어와도 1회로 묶인다.
 export const FG_POSITION_UPLOAD_THROTTLE_MS = 10_000;
 
+// #1313 — foreground GPS watch 샘플링 파라미터. subsurface(지하) 여부로 갈린다.
+// 지상/warmup/미지원에서는 High@2s를 그대로 유지(정확도 우선), 지하에서만 throttle.
+//
+// 지상(기본): High + distanceInterval:0 + timeInterval:2000.
+//  GPS hardware fix를 최대한 자주 흘려보낸다. subsurface가 true로 확정되기 전까지는
+//  항상 이 값을 사용한다(undefined/false 포함) — 확신 없이 GPS를 절대 낮추지 않는다.
+export const FG_WATCH_SURFACE_TIME_INTERVAL_MS = 2_000;
+// 지하(subsurface 확정): Balanced + distanceInterval:0 + timeInterval:12000.
+//  지하 GPS는 WiFi BSSID/Cell triangulation으로 300~1500m라 알람에 무의미(useStationAlarm 게이트가
+//  별도 차단) — 표시 전용. 위치 지능은 WiFi SSID/기압계/backend dead-reckoning이 담당하므로
+//  FG watch는 12s로 늦춰 배터리를 아낀다. WiFi 역 DB가 ~19개 역만 커버해 표시 공백을 피하려고
+//  완전 정지가 아닌 보수적 throttle을 택했다. High→Balanced로 고정밀 측위 시도도 줄인다.
+export const FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS = 12_000;
+
 // iOS CoreLocation은 속도를 측정할 수 없을 때 음수(보통 -1)를 반환한다.
 // stationary/indoor/cold-start 등에서 자주 발생 — null로 정규화해 다운스트림이
 // "측정 불가"와 "정지(0 m/s)"를 명확히 구분하도록 한다.


### PR DESCRIPTION
## 배경 / 왜
FG GPS watch가 지하에서도 항상 full-power(High@2s)로 돌아 trip 중 배터리 최대 소모원이 된다. 지하 GPS는 WiFi BSSID/Cell triangulation으로 300~1500m라 알람에 무의미하고 표시 전용이며, 지하 측위는 WiFi SSID/기압계/backend dead-reckoning이 담당한다. 따라서 지하 확정(subsurface) 구간에서만 FG watch를 throttle해 배터리를 아낀다.

## 변경
- `useNearestStation.ts`: `barometerSubsurface===true`(지하 확정)일 때만 FG `watchPositionAsync`를 `Balanced` + `timeInterval:12000`으로 낮춘다. `undefined`/`false`(지상/warmup/미지원)는 기존 `High` + `timeInterval:2000`을 그대로 유지 — 확신 없이 GPS를 낮추지 않는 안전 기본값.
- expo-location FG 옵션은 라이브 변경 불가 → subsurface flip 시 `stopWatch()`→`startWatch()`로 재구성. `throttledRef`(throttle 여부 SSOT)를 `startWatch`가 읽어 옵션 선택, `barometerSubsurface` 키 effect가 flip을 감지.
- 3가지 가드: (1) throttle boolean이 실제 바뀐 경우만 재시작 → mount 중복 start 방지 + warmup(undefined)→false no-op, (2) `AppState.currentState==='active'`일 때만 재시작 → BG flip이 FG watch를 켜는 것 방지.
- FG watch 샘플링 interval 매직넘버를 `src/shared/constants/location.ts`로 분리(`FG_WATCH_SURFACE_TIME_INTERVAL_MS`, `FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS`).

## 정확도/안전
- 지상 동작은 byte-identical (`throttledRef=false` → 기존 inline 옵션과 동일 객체).
- 보수적 throttle(완전 정지 X) — WiFi 역 DB가 ~19개 역만 커버해 표시 공백을 피하려는 의도.
- 알람 정확도 영향 없음 — 알람 경로는 `useStationAlarm`에서 `accuracyMeters` 엄격 게이트로 별도 차단.

## 테스트
- 신규 7케이스: 마운트 시 subsurface undefined/false→High@2s(single start), true→Balanced@12s; flip false→true / true→false → teardown(remove) 후 새 옵션 재시작; warmup→false no-op; BG flip은 active 가드로 차단 후 FG 복귀 시 반영.
- 변경 파일 2개(`useNearestStation.ts`, `location.ts`) 커버리지 100% (stmt/branch/func/line).
- `npm run type-check` 통과, ESLint clean, nearest-station 전체 895 테스트 통과.

Closes #1313