### PR TITLE
fix(#1316): phase 알람 warmup을 시간 window로 (조기 발사 dedup 오염 방지)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -1820,9 +1820,13 @@ describe('useStationAlarm', () => {
     });
   });
 
-  describe('#670/#672 첫 evaluation suppress 가드', () => {
+  // #670/#672/#1316 — phase 알람 warmup 가드. 하이드레이션 완료 후 HYDRATE_WARMUP_MS(30s) 시간 window
+  // 동안 phase 평가를 보류한다. #1316 이전엔 첫 eval 1회만 suppress(isFirstAlarmEvalRef)했으나, 2번째
+  // eval이 GPS/ETA 안정화 전 destination/transfer early를 발사 → firedAlarms 슬롯 점유로 실제 도착이
+  // dedup되는 회귀(08:24:31 성수)가 있었다. station-passed(#1010)와 동일한 시간 window로 통일한다.
+  describe('#670/#672/#1316 phase warmup window 가드', () => {
     const route = makeDirectRoute(3, '2');
-    // skipWarmupGuard 미전달 → production default(false) 적용. 첫 evaluation 보류 동작 확인.
+    // skipWarmupGuard 미전달 → production default(false) 적용. warmup window 보류 동작 확인.
     function inputsWithGuardDefault(loc: { lat: number; lng: number }): UseStationAlarmInputs {
       return {
         route,
@@ -1840,7 +1844,9 @@ describe('useStationAlarm', () => {
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
 
-    it('다음 deps 변경(좌표 갱신) 후 evaluate 호출됨', async () => {
+    it('warmup window 내에서는 좌표가 갱신돼도 계속 suppress (단발 아님 — #1316)', async () => {
+      const baseTs = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(baseTs);
       const { rerender } = renderHook(
         ({ loc }: { loc: { lat: number; lng: number } }) =>
           useStationAlarm(inputsWithGuardDefault(loc)),
@@ -1848,9 +1854,94 @@ describe('useStationAlarm', () => {
       );
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
-      // 첫 suppress 이후 좌표가 한 번 더 갱신되면 evaluate 진입.
+      // 좌표가 한 번 더 갱신돼도 (window 안, Date.now 불변) 여전히 보류 — 단발 suppress라면 여기서
+      // evaluate가 호출됐을 것. 시간 window라 계속 차단된다.
+      rerender({ loc: { lat: 37.41, lng: 127.01 } });
+      await waitFor(() =>
+        expect(mockLogSuppressedPhaseGate).toHaveBeenCalledWith('gate-phase-warmup', destination.name),
+      );
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('warmup window 경과 후 좌표 갱신 시 evaluate 호출됨 (hydratedAt + 30s 이후)', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      const { rerender } = renderHook(
+        ({ loc }: { loc: { lat: number; lng: number } }) =>
+          useStationAlarm(inputsWithGuardDefault(loc)),
+        { initialProps: { loc: { lat: 37.4, lng: 127.0 } } },
+      );
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+      // window 경과 후(30s + 1ms) 좌표 갱신 → 안정된 입력으로 평가 진입.
+      nowSpy.mockReturnValue(baseTs + 30_001);
       rerender({ loc: { lat: 37.41, lng: 127.01 } });
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+    });
+  });
+
+  // #1316 — 조기 발사가 dedup을 오염시켜 실제 도착 알람이 누락되는 회귀 재현.
+  // device evidence: 08:24:31 트립 생성 직후 destination early(성수, 6역 전) 조기 발사 →
+  // firedAlarms 슬롯 점유 → 08:40:53 실제 도착 시 dedup-alarm으로 억제.
+  // warmup window가 단발 suppress(2번째 eval 발사 가능)였던 게 root cause.
+  // 시간 window 전환 후: window 동안 발사 0 → firedAlarms 청결 → window 경과 후 도착 시 정상 발사.
+  describe('#1316 조기 발사 dedup 오염 방지', () => {
+    const route = makeDirectRoute(6, '2');
+
+    function inputsNearDestination(): UseStationAlarmInputs {
+      return {
+        route,
+        destination,
+        nearestStation: makeStation('S1', '역삼'),
+        userLocation: { lat: 37.498, lng: 127.028 },
+        speedMps: 10,
+        accuracyMeters: 100,
+      };
+    }
+
+    it('warmup window 내 destination early 발사 보류 → firedAlarms 슬롯 미점유', async () => {
+      const baseTs = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      // 트립 시작 직후 evaluateAlarmPhase가 early destination을 반환하려 해도(straight-line ETA 과소추정
+      // 등) warmup이 evaluate 진입 자체를 막아야 한다.
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() => useStationAlarm(inputsNearDestination()));
+
+      await waitFor(() =>
+        expect(mockLogSuppressedPhaseGate).toHaveBeenCalledWith('gate-phase-warmup', destination.name),
+      );
+      // 핵심: evaluate 진입 차단 → firedAlarms 슬롯 점유 없음(setFiredAlarms 미호출) → 발사 없음.
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('조기 발사로 오염되지 않아 window 경과 후 실제 도착에서 destination 정상 발사', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      mockGetBoardingLock.mockResolvedValue(null);
+      // 트립 시작 시점: early destination 조건 매칭(조기 발사 시도).
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      const { rerender } = renderHook(
+        ({ loc }: { loc: { lat: number; lng: number } }) =>
+          useStationAlarm({ ...inputsNearDestination(), userLocation: loc }),
+        { initialProps: { loc: { lat: 37.4, lng: 127.0 } } },
+      );
+
+      // window 내 — 조기 발사 차단 확인.
+      await waitFor(() =>
+        expect(mockLogSuppressedPhaseGate).toHaveBeenCalledWith('gate-phase-warmup', destination.name),
+      );
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+
+      // 실제 도착 시점: window 경과 + 좌표 갱신. firedAlarms가 비어 있으므로 dedup 없이 발사돼야 한다.
+      nowSpy.mockReturnValue(baseTs + 30_001);
+      rerender({ loc: { lat: 37.498, lng: 127.028 } });
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta');
     });
   });
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -68,9 +68,19 @@ import { resolveNotificationSource, type NotificationSource } from '../utils/not
 
 const logger = createLogger('StationAlarm');
 
-// #1010 — station-passed hydration warmup. lock hydrate 완료 후 이 기간 동안 station-passed 차단.
-// 하이드레이션 직후 firedAlarms가 복원되기 전 GPS 신호와 동기화되는 과도 구간 false alarm 방지.
-const STATION_PASSED_HYDRATE_WARMUP_MS = 30_000;
+// #1010/#1316 — 하이드레이션 warmup. lock hydrate 완료 후 이 기간 동안 알람 발사를 차단한다.
+// 하이드레이션 직후 firedAlarms가 복원되기 전 GPS/ETA 신호와 동기화되는 과도 구간 false alarm 방지.
+// station-passed effect(#1010)와 phase 알람 effect(#1316) 양쪽이 같은 window를 공유한다.
+const HYDRATE_WARMUP_MS = 30_000;
+
+/**
+ * #1010/#1316 — 하이드레이션 완료(hydratedAt) 후 HYDRATE_WARMUP_MS 시간 window 안인지 판정.
+ * hydratedAt=null(미완료)이면 false — 발사 보류는 호출부의 hydrationPhase!=='ready' 가드가 담당하므로
+ * 여기선 window 시작 전을 window 밖으로 본다. phase/station-passed 두 effect가 동일 판정을 공유한다.
+ */
+function isWithinHydrateWarmup(hydratedAt: number | null, now: number): boolean {
+  return hydratedAt !== null && now - hydratedAt < HYDRATE_WARMUP_MS;
+}
 
 /**
  * #746 — dismiss silence 게이트 판정 + 만료 시 store clear 호출.
@@ -353,14 +363,13 @@ export function useStationAlarm({
   // 클로저로 진입한다. ref id가 현재 destinationId와 다르면 stale state — phase 평가를 보류해
   // 옛 ref로 새 destination에 잘못된 알람을 발사하는 race를 차단한다.
   const firedAlarmsRefDestIdRef = useRef<string | null>(null);
-  // #670/#672: ETA 평가 effect의 첫 trigger를 suppress.
-  // fg-hydrate 직후 hydrate된 stale firedAlarms·nearestStation과 새 GPS 좌표가 동기화되기 전
-  // 즉시 평가 분기로 진입하면 잘못된 phase 알람이 발사됨. 한 cycle 보류로 다음 deps 변경(좌표/
-  // hydrate state 갱신) 시 안정된 입력으로 평가.
-  const isFirstAlarmEvalRef = useRef(true);
-  // #1010: station-passed hydration warmup — 하이드레이션 완료 시각(ms). null이면 미완료.
-  // warmup window 동안 station-passed effect가 즉시 차단된다.
-  const stationPassedHydratedAtRef = useRef<number | null>(null);
+  // #1010/#1316: 하이드레이션 완료 시각(ms). null이면 미완료.
+  // warmup window(HYDRATE_WARMUP_MS) 동안 station-passed effect(#1010)와 phase 알람 effect(#1316)가
+  // 즉시 차단된다. #1316 — phase 알람은 기존 isFirstAlarmEvalRef 단발 suppress(첫 eval만 차단)였으나,
+  // 2번째 eval(~1초 후)이 GPS/ETA 안정화 전 destination/transfer early를 발사 → 조기 발사가 firedAlarms
+  // 슬롯을 점유해 실제 도착 발사가 dedup되는 회귀(08:24:31 성수)가 있었다. station-passed와 동일한
+  // 시간 window로 통일한다.
+  const hydratedAtRef = useRef<number | null>(null);
   // firedAlarms hydration: BG가 AsyncStorage(FIRED_ALARMS_KEY)에 쓴 dedup 상태를
   // destination별로 격리해 복원한다(#462).
   //
@@ -440,7 +449,7 @@ export function useStationAlarm({
   // → cross-trip stale state가 새 trip의 evaluator를 오염시키지 않는다.
   useEffect(() => {
     let cancelled = false;
-    stationPassedHydratedAtRef.current = null;
+    hydratedAtRef.current = null;
     // #1012 (H5) — Phase 1: pre-hydrate 리셋. destination 전환마다 state machine 재시작.
     setHydrationPhase('pre-hydrate');
     logHydrationTransition('pre-hydrate', destinationId);
@@ -461,8 +470,8 @@ export function useStationAlarm({
       firedAlarmsRefDestIdRef.current = destinationId;
       // #580: hydration 시점 진단 — 같은 destinationId에서 size가 다시 0으로 떨어지면 storage race.
       logFiredAlarmsHydrate(destinationId, stored.size);
-      // #1010: station-passed warmup 시작 — 하이드레이션 완료 시각 기록.
-      stationPassedHydratedAtRef.current = Date.now();
+      // #1010/#1316: warmup 시작 — 하이드레이션 완료 시각 기록. station-passed/phase 알람 effect 공용.
+      hydratedAtRef.current = Date.now();
       // #1012 (H5) — Phase 4: ready. ref 셋업 + warmup 시각 기록 완료 후 phase 평가 허용.
       setHydrationPhase('ready');
       logHydrationTransition('ready', destinationId);
@@ -576,9 +585,13 @@ export function useStationAlarm({
       return;
     }
 
-    // #670/#672: 첫 trigger suppress — fg-hydrate 직후 stale state 발사 차단.
-    if (!skipWarmupGuard && isFirstAlarmEvalRef.current) {
-      isFirstAlarmEvalRef.current = false;
+    // #670/#672/#1316: 하이드레이션 직후 warmup window 동안 발사 보류 — stale firedAlarms·
+    // nearestStation과 새 GPS/ETA 좌표가 동기화되기 전 조기 발사 차단. station-passed effect(#1010)와
+    // 동일한 HYDRATE_WARMUP_MS 시간 window를 공유한다.
+    // #1316 — 기존엔 isFirstAlarmEvalRef로 첫 eval 1회만 suppress했으나, 2번째 eval(~1초 후)이 GPS/ETA
+    // 안정화 전 destination/transfer early를 발사 → 그 조기 발사가 firedAlarms 슬롯을 점유해 실제 도착
+    // 발사가 dedup으로 억제되는 회귀(08:24:31 성수)가 있었다. 시간 window로 전환해 해소.
+    if (!skipWarmupGuard && isWithinHydrateWarmup(hydratedAtRef.current, Date.now())) {
       logSuppressedPhaseGate('gate-phase-warmup', destination.name);
       return;
     }
@@ -812,12 +825,9 @@ export function useStationAlarm({
     // #1010: firedAlarms 복원 완료 전에는 발사 보류.
     if (hydrationPhase !== 'ready') return;
     // #1010: hydration 완료 후 30s warmup window 동안 발사 보류.
-    if (!skipWarmupGuard) {
-      const hydratedAt = stationPassedHydratedAtRef.current;
-      if (hydratedAt !== null && Date.now() - hydratedAt < STATION_PASSED_HYDRATE_WARMUP_MS) {
-        logSuppressedStationPassedWarmup(nearestStation?.name);
-        return;
-      }
+    if (!skipWarmupGuard && isWithinHydrateWarmup(hydratedAtRef.current, Date.now())) {
+      logSuppressedStationPassedWarmup(nearestStation?.name);
+      return;
     }
 
     if (!accuracyOk && !arrivalConfirmed) return;


### PR DESCRIPTION
## 배경
2026-06-15 오전 실기기 trip에서 트립 생성 직후(08:24:32) 목적지(성수, 6역 전) 하차 알림이 **조기 발사**(`08:24:31 fired destination early 성수`, ~0.4s)되고, 이후 dedup이 실제 성수 도착(08:40:53, 98m)까지 억제 → **시작엔 오발사, 정작 도착엔 알림 누락**.

## Root cause
- `useStationAlarm.ts:580` phase 알람 warmup 가드가 `isFirstAlarmEvalRef` — **첫 eval 1회만** suppress하는 단발 가드였다. 2번째 eval(~1초 후, hydrate 직후)이 GPS/ETA 안정화 전 destination/transfer early를 발사할 수 있었다.
- 대조: station-passed 경로(`:781`)는 하이드레이션 완료 시각 + 30s **시간 window**로 보호 → 비대칭이 root cause.
- dedup(`evaluateAlarmPhase`의 firedAlarms)은 정상 동작. 문제는 **조기 발사가 firedAlarms 슬롯을 먼저 점유**해 실제 도착 발사가 `dedup-alarm`으로 억제된 것.

## 변경
- phase 알람 warmup을 station-passed와 동일한 **시간 window**로 전환.
  - `STATION_PASSED_HYDRATE_WARMUP_MS` → `HYDRATE_WARMUP_MS`로 일반화(두 effect 공유, 값 30s 동일).
  - `stationPassedHydratedAtRef` / `isFirstAlarmEvalRef` → `hydratedAtRef` 단일 ref로 통합.
  - `isWithinHydrateWarmup(hydratedAt, now)` 순수 헬퍼 추출 — phase/station-passed 두 effect가 동일 판정 공유(중복 제거).
- `skipWarmupGuard` 테스트 escape hatch 유지.
- 로그 reason은 기존 `gate-phase-warmup` 그대로 재사용 (schema/DebugModal 변경 없음).

## 테스트
- `npm run type-check`: clean.
- `npm test`: 285 suites / 5447 tests pass. 변경 파일(`useStationAlarm.ts`) 커버리지 100% (stmts/branch/funcs/lines).
- 추가 단위 테스트:
  - warmup window 내 → 좌표 갱신돼도 계속 suppress (단발 아님).
  - warmup window 경과(+30s) 후 → 정상 evaluate.
  - 조기 발사 dedup 오염 방지 — window 내 `setFiredAlarms` 미호출(슬롯 청결) → window 경과 후 실제 도착에서 destination 정상 발사.

## 2차 검토 (early-window / ETA)
route `hop count=0` + straight-line ETA 과소추정이 트립 시작에 early를 매칭시킨 보조 원인 가능성. `early` phase는 `remainingStops <= 1`로만 발사되므로, 트립 생성 직후 route `stops`가 아직 0/미확정인 상태에서 `0 <= 1`로 매칭됐을 가능성이 있다(증상과 일치). 본 PR의 시간 window가 그 과도 구간을 모두 덮으므로 1차 해소되나, `evaluateAlarmPhase` early 조건이 "fresh route stops=0"을 1정거장 전으로 오인하지 않도록 하는 보강은 별도 follow-up 권장.

Closes #1316