### PR TITLE
fix(#1317): 저품질 GPS에서 sticky station 출발역 고착 해제

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1030,6 +1030,32 @@ describe('useNearestStation — #876 sticky station integration', () => {
     // distanceKm은 userLocation 기준 재계산 (효창 ↔ 강남 ≈ 10km+)
     expect(result.current.result?.distanceKm).toBeGreaterThan(5);
   });
+
+  // #1317 — 지도탭 "현재위치" 명시 탭은 sticky를 비우고 live 위치를 노출.
+  it('requestCurrentLocation 호출 시 sticky를 비우고 live 위치로 복귀한다', async () => {
+    // 효창공원앞 lock 미리 저장. GPS는 강남 → 초기엔 sticky override.
+    const hyochang = { id: '6-019', name: '효창공원앞', line: '6', lineColor: '#cd7c2f',
+      lat: 37.539252, lng: 126.961392 };
+    await AsyncStorage.setItem(
+      'subway-now:sticky-station',
+      JSON.stringify({ station: hyochang, lockedAt: Date.now() - 60_000 }),
+    );
+    mockGranted();
+    mockLocation(37.4980, 127.0277, { accuracy: 100 }); // refresh가 받을 강남 좌표
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+    simulateGps(37.4980, 127.0277, { accuracy: 100 });
+    await waitFor(() => expect(result.current.source).toBe('sticky'));
+
+    // "현재위치" 탭 → releaseLock + refresh. sticky가 비워져 live(강남)로 복귀.
+    await act(async () => {
+      await result.current.requestCurrentLocation();
+    });
+    await waitFor(() => expect(result.current.source).toBe('live'));
+    expect(result.current.result?.station.name).toBe('강남');
+    // refresh 경로로 fresh GPS도 요청됐다.
+    expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
+  });
 });
 
 describe('useNearestStation — E2E mock mode', () => {

--- a/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
@@ -12,9 +12,12 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useStickyStation, type StickyFixInput, type StickyMotionInput } from '../useStickyStation';
-import { STICKY_TTL_MS } from '../../../../shared/constants/stickyStation';
+import {
+  STICKY_DEGRADED_UNLOCK_COUNT,
+  STICKY_TTL_MS,
+} from '../../../../shared/constants/stickyStation';
 import { STICKY_STATION_KEY } from '../../../../shared/constants/storageKeys';
 import * as fusionDebugBuffer from '../../utils/fusionDebugBuffer';
 import type { Station } from '../../../../shared/types/station';
@@ -34,6 +37,20 @@ const seoulNearby: Station = {
 const gangnam: Station = {
   id: '0222', name: '강남', line: '2', lineColor: '#00a84d', lat: 37.4979, lng: 127.0276,
 };
+// #1317 — 용마산 trip의 "여러 역 통과"(군자/건대입구/성수)를 모사하는 distinct far 역들.
+// 모두 서울역에서 1km+ 떨어진 다른 역. 저품질 accuracy(52.7m)와 함께 사용.
+const gunja: Station = {
+  id: '5-616', name: '군자', line: '5', lineColor: '#996cac', lat: 37.557345, lng: 127.079527,
+};
+const konkuk: Station = {
+  id: '2-212', name: '건대입구', line: '2', lineColor: '#00a84d', lat: 37.540408, lng: 127.070061,
+};
+const seongsu: Station = {
+  id: '2-211', name: '성수', line: '2', lineColor: '#00a84d', lat: 37.544581, lng: 127.055961,
+};
+// 용마산 trip의 저품질 GPS(accuracy 52.7m, strict 게이트 50m 초과)를 모사한 fix.
+const degradedFixAt = (station: Station | null) =>
+  fixAt(station, { accuracy: 52.7 });
 
 const fixAt = (
   station: Station | null,
@@ -316,6 +333,97 @@ describe('useStickyStation (#876)', () => {
       const { result, rerender } = await lockSeoul({});
       rerender({ fix: fixAt(seoul), motion: { automotive: true, subsurface: false, tripActive: true } });
       await waitFor(() => expect(result.current.locked).toBeNull());
+    });
+  });
+
+  // #1317 — 저품질 GPS에서 출발역 sticky 고착 회귀 + 명시적 unlock.
+  describe('#1317 — 저품질 GPS moved-away unlock', () => {
+    // 서울역에 lock된 상태를 만드는 헬퍼(좋은 fix 3회).
+    const lockSeoul = async () => {
+      const hook = renderSticky({ fix: fixAt(seoul) });
+      await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+      hook.rerender({ fix: fixAt(seoul) });
+      hook.rerender({ fix: fixAt(seoul) });
+      await waitFor(() => expect(hook.result.current.locked?.id).toBe(seoul.id));
+      return hook;
+    };
+
+    it('lock역에서 1km+ 이동 + 여러 역 통과(저품질) → moved-away unlock', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const { result, rerender } = await lockSeoul();
+      pushSpy.mockClear();
+
+      // 저품질(52.7m) far 역 fix를 N회 연속 — 군자/건대입구/성수 통과 모사.
+      // strict distance/better-fix는 ≤50m를 요구해 막히지만 moved-away는 누적된다.
+      const movedFixes = [gunja, konkuk, seongsu];
+      for (let i = 0; i < STICKY_DEGRADED_UNLOCK_COUNT; i += 1) {
+        rerender({ fix: degradedFixAt(movedFixes[i % movedFixes.length]) });
+      }
+      await waitFor(() => expect(result.current.locked).toBeNull());
+      expect(pushSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'sticky', event: 'unlocked-moved-away' }),
+      );
+    });
+
+    it('단발성 far fix 1회로는 unlock하지 않음 (false unlock 방지)', async () => {
+      const { result, rerender } = await lockSeoul();
+      // 저품질 far fix 1회만 — 임계(N) 미만이라 lock 유지.
+      rerender({ fix: degradedFixAt(gunja) });
+      expect(result.current.locked?.id).toBe(seoul.id);
+    });
+
+    it('far fix 사이에 lock역 근처 fix가 끼면 카운터 리셋 → unlock 안 됨', async () => {
+      const { result, rerender } = await lockSeoul();
+      // far(군자) → 근처(서울) → far(건대) 패턴: 연속이 끊겨 카운터가 리셋된다.
+      rerender({ fix: degradedFixAt(gunja) });
+      rerender({ fix: degradedFixAt(seoul) }); // 같은 역 → moved-away 아님 → 리셋
+      rerender({ fix: degradedFixAt(konkuk) });
+      // 누적이 1로 떨어져 임계 미달 — lock 유지.
+      expect(result.current.locked?.id).toBe(seoul.id);
+    });
+
+    it('지하 + trip 활성에서는 저품질 far fix가 누적돼도 moved-away 보류 (D6 hold)', async () => {
+      const motion: StickyMotionInput = { subsurface: true, tripActive: true };
+      const hook = renderSticky({ fix: fixAt(seoul), motion });
+      await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+      hook.rerender({ fix: fixAt(seoul), motion });
+      hook.rerender({ fix: fixAt(seoul), motion });
+      await waitFor(() => expect(hook.result.current.locked?.id).toBe(seoul.id));
+
+      const movedFixes = [gunja, konkuk, seongsu];
+      for (let i = 0; i < STICKY_DEGRADED_UNLOCK_COUNT; i += 1) {
+        hook.rerender({ fix: degradedFixAt(movedFixes[i % movedFixes.length]), motion });
+      }
+      // 지하 dead-zone 의심 → 누적해도 unlock 안 함.
+      expect(hook.result.current.locked?.id).toBe(seoul.id);
+    });
+
+    it('releaseLock() 호출 → 즉시 unlock + unlocked-manual 이벤트', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const { result, rerender } = await lockSeoul();
+      pushSpy.mockClear();
+
+      act(() => { result.current.releaseLock(); });
+      await waitFor(() => expect(result.current.locked).toBeNull());
+      expect(pushSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'sticky', event: 'unlocked-manual', stationName: '서울역' }),
+      );
+      // unlock 후 persistence도 정리.
+      rerender({ fix: fixAt(null) });
+      await waitFor(() => expect(AsyncStorage.removeItem).toHaveBeenCalledWith(STICKY_STATION_KEY));
+    });
+
+    it('releaseLock() — lock 없을 때 no-op (이벤트 emit 안 함)', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const { result } = renderSticky({ fix: fixAt(null) });
+      await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+      pushSpy.mockClear();
+
+      act(() => { result.current.releaseLock(); });
+      expect(result.current.locked).toBeNull();
+      expect(pushSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'unlocked-manual' }),
+      );
     });
   });
 

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -86,6 +86,9 @@ interface UseNearestStationReturn {
   // 호출자가 출처별 UX(예: 라벨 "탑승 전 추정")로 분기 가능. 알람 트리거에는 영향 없음.
   source: NearestStationSource;
   refresh: () => Promise<void>;
+  // #1317: 사용자가 지도탭 "현재위치"를 명시적으로 탭할 때 호출. sticky lock을 비우고 fresh
+  // GPS fix를 요청해 live fused 위치를 노출한다. 일반 refresh(FG 복귀 등)는 sticky를 유지한다.
+  requestCurrentLocation: () => Promise<void>;
 }
 
 // #711: BG task가 최근 평가한 nearest station. FG 복귀 직후 fresh fix 도착 전 임시 hydrate에 사용.
@@ -458,6 +461,16 @@ export function useNearestStation(
     },
   );
 
+  // #1317 — 지도탭 "현재위치" 명시 탭 경로. sticky lock을 즉시 비운 뒤 fresh GPS fix를 요청해
+  // live fused 위치를 노출한다. refresh()만으로는 sticky override가 남아 현재역이 lock된 역
+  // (예: 출발역 용마산)으로 회귀하므로, sticky 해제를 함께 수행한다. FG 복귀 시의 일반 refresh는
+  // sticky를 유지해야 하므로(D6 — 탑승 중 노선 정보 보존) 이 경로를 별도로 분리한다.
+  const { releaseLock } = sticky;
+  const requestCurrentLocation = useCallback(async () => {
+    releaseLock();
+    await refresh();
+  }, [releaseLock, refresh]);
+
   const exposed = useMemo<{ result: NearestStationResult | null; source: NearestStationSource }>(
     () => {
       // sticky 비활성 또는 sticky가 live와 같은 역이면 live 결과 그대로 — reference 유지로
@@ -491,5 +504,6 @@ export function useNearestStation(
     lastFixAtMs,
     source: exposed.source,
     refresh,
+    requestCurrentLocation,
   };
 }

--- a/src/features/nearest-station/hooks/useStickyStation.ts
+++ b/src/features/nearest-station/hooks/useStickyStation.ts
@@ -18,15 +18,25 @@
  *   2. motion — automotive(차/지하철 이동 확정)
  *   3. ttl — STICKY_TTL_MS(30분) 경과
  *   4. better-fix — 좋은 fix가 다른 역에서 N회 연속 관찰 → 즉시 갱신(unlock + 새 lock)
+ *   5. moved-away (#1317) — 저품질 fix(≤250m)여도 lock된 역에서 1km+ 떨어진 다른 역이
+ *      STICKY_DEGRADED_UNLOCK_COUNT(3)회 연속 관찰되면 unlock. 좋은 fix가 안 잡히는 지하·도심
+ *      협곡에서 출발역 lock이 고착되는 회귀 차단. 단발성 부정확 fix는 카운트가 리셋돼 안 풀린다.
+ *
+ * 명시적 unlock: 사용자가 지도탭 "현재위치"를 탭하면 releaseLock()으로 sticky를 비우고 live 위치를
+ * 노출한다(호출자 useNearestStation의 requestCurrentLocation 경로).
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { NearestStationResult, Station } from '../../../shared/types/station';
 import { STICKY_STATION_KEY } from '../../../shared/constants/storageKeys';
-import { STICKY_LOCK_CONSECUTIVE_COUNT } from '../../../shared/constants/stickyStation';
+import {
+  STICKY_DEGRADED_UNLOCK_COUNT,
+  STICKY_LOCK_CONSECUTIVE_COUNT,
+} from '../../../shared/constants/stickyStation';
 import {
   isGoodFix,
+  shouldCountAsMovedAway,
   shouldUnlockByDistance,
   shouldUnlockByMotion,
   shouldUnlockByTtl,
@@ -62,6 +72,11 @@ export interface StickyMotionInput {
 
 export interface UseStickyStationReturn {
   locked: Station | null;
+  /**
+   * #1317 — sticky lock을 즉시 비운다. 지도탭 "현재위치" 명시 탭처럼 사용자가 live 위치를
+   * 명시적으로 요청할 때 호출한다. lock이 없으면 no-op.
+   */
+  releaseLock: () => void;
 }
 
 interface PersistedLock {
@@ -133,9 +148,38 @@ export function useStickyStation(
   // 같은 역 연속 좋은 fix 카운터. 다른 역으로 바뀌거나 나쁜 fix면 리셋.
   const candidateIdRef = useRef<string | null>(null);
   const candidateCountRef = useRef<number>(0);
+  // #1317 — lock된 역에서 1km+ 떨어진 다른 역 fix(저품질 허용)의 연속 관찰 카운터.
+  // shouldCountAsMovedAway가 false면 리셋 — 단발성 부정확 fix로는 풀리지 않는다.
+  const movedAwayCountRef = useRef<number>(0);
+  // #1317 — releaseLock은 render 밖(UI 이벤트)에서 호출될 수 있어 stale closure를 피하려고
+  // locked state와 마지막 fix meta를 ref로 미러링한다(metric 라벨링용).
+  const lockedRef = useRef<Station | null>(null);
+  const lastFixMetaRef = useRef<{ accuracyMeters: number | null; speedMps: number | null }>({
+    accuracyMeters: null,
+    speedMps: null,
+  });
   // hydrate 완료 여부를 state로 — 완료 후 다음 렌더에 평가 effect가 자동 재실행돼
   // hydrate 직전에 받아둔 첫 fix가 정상적으로 카운트된다.
   const [hydrated, setHydrated] = useState<boolean>(false);
+
+  // lock 상태를 비우는 공통 cleanup — ref/state/persistence를 함께 정리한다.
+  // performUnlock(per-fix metric 포함)과 releaseLock(명시 unlock) 양쪽이 재사용.
+  const clearLockState = useCallback(() => {
+    lockedAtRef.current = null;
+    candidateIdRef.current = null;
+    candidateCountRef.current = 0;
+    movedAwayCountRef.current = 0;
+    setLocked(null);
+    void clearPersistedLock();
+  }, []);
+
+  // #1317 — 명시적 unlock. 지도탭 "현재위치" 탭처럼 사용자가 live 위치를 직접 요청할 때 호출.
+  // 평가 effect 밖에서 즉시 lock을 비워 다음 fix가 live 후보를 그대로 노출하게 한다.
+  const releaseLock = useCallback(() => {
+    if (lockedRef.current == null) return;
+    emitMetric('unlocked-manual', lockedRef.current, lastFixMetaRef.current);
+    clearLockState();
+  }, [clearLockState]);
 
   // Hydrate from AsyncStorage on mount. TTL 만료된 lock은 무시.
   useEffect(() => {
@@ -155,25 +199,25 @@ export function useStickyStation(
     };
   }, []);
 
+  // releaseLock이 stale closure 없이 최신 lock/fix를 읽도록 ref를 동기화한다.
+  lockedRef.current = locked;
+
   // 매 fix마다 lock/unlock 평가. hydrate 완료 전엔 평가 보류 (race 방지).
   useEffect(() => {
     if (!hydrated) return;
     const { candidate, accuracyMeters, speedMps } = fix;
     const fixMeta = { accuracyMeters, speedMps };
+    lastFixMetaRef.current = fixMeta;
     const now = Date.now();
 
-    // unlock 공통 cleanup. metrics 이벤트별 라벨링 + ref/state/persistence를 함께 정리한다.
+    // unlock 공통 cleanup. metrics 이벤트별 라벨링 + clearLockState(ref/state/persistence 정리).
     const performUnlock = (event: StickyStationEvent, lockedStation: Station): void => {
       emitMetric(event, lockedStation, fixMeta);
-      lockedAtRef.current = null;
-      candidateIdRef.current = null;
-      candidateCountRef.current = 0;
-      setLocked(null);
-      void clearPersistedLock();
+      clearLockState();
     };
 
     // 1. lock 상태에서 unlock 트리거 평가(better-fix는 카운터 평가 단계에서 처리).
-    //    우선순위: motion > ttl > distance — 각각 stale lock 위험이 큰 순서.
+    //    우선순위: motion > ttl > distance > moved-away — 각각 stale lock 위험이 큰 순서.
     if (locked && lockedAtRef.current != null) {
       if (shouldUnlockByMotion(motion)) {
         performUnlock('unlocked-motion', locked);
@@ -198,6 +242,26 @@ export function useStickyStation(
         // 강제하지 않는다(distance unlock 트리거 한 fix는 카운트에 반영하지 않음).
         performUnlock('unlocked-distance', locked);
         return;
+      }
+      // #1317 — 저품질 GPS 내성 moved-away unlock. strict distance가 ≤50m를 요구해 막히는
+      // 지하·도심 협곡에서, 1km+ 떨어진 다른 역 fix(≤250m)가 연속 누적되면 unlock한다.
+      // 단발성 부정확 fix는 카운트가 리셋돼 풀리지 않는다(false unlock 방지).
+      const movedAway = candidate != null && shouldCountAsMovedAway(locked, {
+        lat: candidate.station.lat,
+        lng: candidate.station.lng,
+        accuracyMeters,
+        candidateId: candidate.station.id,
+        subsurface: motion.subsurface,
+        tripActive: motion.tripActive,
+      });
+      if (movedAway) {
+        movedAwayCountRef.current += 1;
+        if (movedAwayCountRef.current >= STICKY_DEGRADED_UNLOCK_COUNT) {
+          performUnlock('unlocked-moved-away', locked);
+          return;
+        }
+      } else {
+        movedAwayCountRef.current = 0;
       }
     }
 
@@ -224,6 +288,7 @@ export function useStickyStation(
     }
     lockedAtRef.current = now;
     candidateCountRef.current = 0; // 다음 갱신을 위해 리셋
+    movedAwayCountRef.current = 0; // 새 lock 기준으로 moved-away 누적도 초기화
     setLocked(candidate.station);
     emitMetric('locked', candidate.station, fixMeta);
     void writePersistedLock({ station: candidate.station, lockedAt: now });
@@ -233,7 +298,7 @@ export function useStickyStation(
       accuracyMeters,
       speedMps,
     });
-  }, [fix, motion, locked, hydrated]);
+  }, [fix, motion, locked, hydrated, clearLockState]);
 
-  return { locked };
+  return { locked, releaseLock };
 }

--- a/src/features/nearest-station/utils/__tests__/stickyStationGates.test.ts
+++ b/src/features/nearest-station/utils/__tests__/stickyStationGates.test.ts
@@ -10,6 +10,7 @@
 
 import type { Station } from '../../../../shared/types/station';
 import {
+  STICKY_DEGRADED_UNLOCK_ACCURACY_M,
   STICKY_GOOD_FIX_ACCURACY_M,
   STICKY_GOOD_FIX_SPEED_MAX_MPS,
   STICKY_TTL_MS,
@@ -17,6 +18,7 @@ import {
 } from '../../../../shared/constants/stickyStation';
 import {
   isGoodFix,
+  shouldCountAsMovedAway,
   shouldUnlockByDistance,
   shouldUnlockByTtl,
   shouldUnlockByMotion,
@@ -113,6 +115,71 @@ describe('shouldUnlockByDistance', () => {
     expect(
       shouldUnlockByDistance(seoulStation, { ...farFromLocked, ...flags }),
     ).toBe(expected);
+  });
+});
+
+describe('shouldCountAsMovedAway (#1317)', () => {
+  // 강남역 좌표 — 서울역에서 약 10km, 다른 역 id. accuracy는 strict 게이트(50m) 초과지만
+  // degraded 게이트(250m) 이내인 저품질 fix(용마산 trip의 52.7m를 모사).
+  const degradedFarFix = {
+    lat: 37.4979,
+    lng: 127.0276,
+    accuracyMeters: 52.7,
+    candidateId: '0222',
+  };
+
+  it('저품질(>50m, ≤250m) + 1km+ + 다른 역 → true (strict distance는 막히는 케이스)', () => {
+    expect(shouldUnlockByDistance(seoulStation, degradedFarFix)).toBe(false); // strict는 막힘
+    expect(shouldCountAsMovedAway(seoulStation, degradedFarFix)).toBe(true); // degraded는 카운트
+  });
+
+  it('accuracy null → false (좌표 신뢰 불가)', () => {
+    expect(
+      shouldCountAsMovedAway(seoulStation, { ...degradedFarFix, accuracyMeters: null }),
+    ).toBe(false);
+  });
+
+  it('accuracy가 degraded 임계(250m) 초과 → false (쓰레기 좌표 거부)', () => {
+    expect(
+      shouldCountAsMovedAway(seoulStation, {
+        ...degradedFarFix,
+        accuracyMeters: STICKY_DEGRADED_UNLOCK_ACCURACY_M + 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('후보 역 id가 lock된 역과 동일 → false (멀어짐 아님)', () => {
+    expect(
+      shouldCountAsMovedAway(seoulStation, { ...degradedFarFix, candidateId: seoulStation.id }),
+    ).toBe(false);
+  });
+
+  it('후보 역 id가 null → false', () => {
+    expect(
+      shouldCountAsMovedAway(seoulStation, { ...degradedFarFix, candidateId: null }),
+    ).toBe(false);
+  });
+
+  it('1km 이내(근처) 다른 역 → false', () => {
+    // 서울역 근방 좌표 — 1km 미만.
+    expect(
+      shouldCountAsMovedAway(seoulStation, {
+        lat: 37.5565,
+        lng: 126.9707,
+        accuracyMeters: 52.7,
+        candidateId: '0150B',
+      }),
+    ).toBe(false);
+  });
+
+  // D6 (#1212) — degraded 게이트도 strict distance와 동일하게 지하 dead-zone hold를 따른다.
+  it.each<[string, { subsurface?: boolean; tripActive?: boolean }, boolean]>([
+    ['subsurface=true + tripActive=true → 지하 dead-zone 의심 → false', { subsurface: true, tripActive: true }, false],
+    ['subsurface=true + tripActive=false → 지하지만 trip 미활성 → true', { subsurface: true, tripActive: false }, true],
+    ['subsurface=false + tripActive=true → 지상 trip → true', { subsurface: false, tripActive: true }, true],
+    ['둘 다 미정의 → 기존 동작 → true', {}, true],
+  ])('%s', (_label, flags, expected) => {
+    expect(shouldCountAsMovedAway(seoulStation, { ...degradedFarFix, ...flags })).toBe(expected);
   });
 });
 

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -70,7 +70,11 @@ export type StickyStationEvent =
   | 'unlocked-distance'
   | 'unlocked-motion'
   | 'unlocked-ttl'
-  | 'unlocked-better-fix';
+  | 'unlocked-better-fix'
+  // #1317 — 저품질 GPS에서 1km+ 멀어진 다른 역 fix가 N회 연속 관찰돼 unlock.
+  | 'unlocked-moved-away'
+  // #1317 — 사용자가 지도탭 "현재위치"를 명시적으로 탭해 unlock(live 위치 요청).
+  | 'unlocked-manual';
 
 export interface StickyStationEntry {
   kind: 'sticky';

--- a/src/features/nearest-station/utils/stickyStationGates.ts
+++ b/src/features/nearest-station/utils/stickyStationGates.ts
@@ -8,6 +8,7 @@
 import type { Station } from '../../../shared/types/station';
 import { haversine } from '../../../shared/utils/haversine';
 import {
+  STICKY_DEGRADED_UNLOCK_ACCURACY_M,
   STICKY_GOOD_FIX_ACCURACY_M,
   STICKY_GOOD_FIX_SPEED_MAX_MPS,
   STICKY_TTL_MS,
@@ -68,6 +69,33 @@ export function shouldUnlockByDistance(locked: Station, fix: StickyPositionInput
   if (accuracyMeters == null || accuracyMeters > STICKY_GOOD_FIX_ACCURACY_M) return false;
   // D6 (#1212) — trip 활성 + 지하면 GPS 1km+ 점프는 dead-zone 부정확 좌표 가능성이 높다.
   // 지상 trip은 그대로 평가(차로 1km 이동 가능).
+  if (fix.tripActive === true && fix.subsurface === true) return false;
+  const distanceKm = haversine(locked.lat, locked.lng, fix.lat, fix.lng);
+  return distanceKm > STICKY_UNLOCK_DISTANCE_KM;
+}
+
+/**
+ * #1317 — 저품질 GPS 내성 "멀어짐" 증거 판정 (한 fix 단위).
+ *
+ * shouldUnlockByDistance는 accuracy ≤ 50m를 요구해 지하·도심 협곡(50~250m)에서 발동하지
+ * 못하고 출발역 lock이 고착된다. 이 함수는 "한 fix가 lock된 역에서 멀어짐(>1km)의 증거인가"만
+ * 판정한다 — 즉시 unlock하지 않는다. 호출자(useStickyStation)가 이런 fix를 N회 연속 누적해야
+ * unlock한다(단발성 부정확 fix로 풀리는 반대 회귀 방지).
+ *
+ * 조건:
+ *   - accuracy non-null이고 ≤ STICKY_DEGRADED_UNLOCK_ACCURACY_M(250m) — 쓰레기 좌표는 거부.
+ *   - 후보 역이 lock된 역과 다른 역 — 같은 역이면 "멀어짐"이 아니다.
+ *   - lock된 역에서 STICKY_UNLOCK_DISTANCE_KM(1km) 초과로 떨어짐.
+ *   - D6(#1212) — trip 활성 + 지하 조합에서는 보류(strict distance 게이트와 동일 hold).
+ *     지하 dead-zone GPS의 1km+ 점프는 부정확 좌표 가능성이 높다.
+ */
+export function shouldCountAsMovedAway(
+  locked: Station,
+  fix: StickyPositionInput & { candidateId: string | null },
+): boolean {
+  const { accuracyMeters, candidateId } = fix;
+  if (accuracyMeters == null || accuracyMeters > STICKY_DEGRADED_UNLOCK_ACCURACY_M) return false;
+  if (candidateId == null || candidateId === locked.id) return false;
   if (fix.tripActive === true && fix.subsurface === true) return false;
   const distanceKm = haversine(locked.lat, locked.lng, fix.lat, fix.lng);
   return distanceKm > STICKY_UNLOCK_DISTANCE_KM;

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -26,7 +26,7 @@ import {
 } from '../shared/types/station';
 
 export default function MapScreen() {
-  const { userLocation, result, loading, error, permissionDenied, refresh, accuracyMeters, locationUncertain } =
+  const { userLocation, result, loading, error, permissionDenied, refresh, requestCurrentLocation, accuracyMeters, locationUncertain } =
     useNearestStation();
   const allStations = stationsData as Station[];
   const { colors } = useTheme();
@@ -138,8 +138,10 @@ export default function MapScreen() {
           },
         ]}
         onPress={() => {
-          // 카메라 이동만으로는 stale userLocation에서 벗어날 수 없으므로 fresh GPS fix를 함께 요청.
-          void refresh();
+          // #1317 — 카메라 이동만으로는 stale userLocation에서 벗어날 수 없고, sticky lock이 남아
+          // 있으면 현재역이 lock된 역(예: 출발역)으로 회귀한다. sticky를 비우고 fresh GPS fix를
+          // 함께 요청하는 명시적 "현재위치" 경로를 사용한다.
+          void requestCurrentLocation();
           setRecenterNonce((n) => n + 1);
         }}
         accessibilityLabel={t('map.recenter')}

--- a/src/shared/constants/stickyStation.ts
+++ b/src/shared/constants/stickyStation.ts
@@ -22,3 +22,26 @@ export const STICKY_TTL_MS = 30 * 60 * 1000;
 
 /** Unlock 거리 임계값(km). 다른 역으로 진짜 이동했다고 판단. */
 export const STICKY_UNLOCK_DISTANCE_KM = 1.0;
+
+// #1317 — 저품질 GPS 내성 unlock.
+//
+// 기존 distance/better-fix unlock은 모두 "좋은 fix"(accuracy ≤ 50m)를 요구한다. 지하·도심
+// 협곡에서 accuracy가 50~250m로 떨어지면(예: 용마산 trip, accuracy 52.7m, signalMask=UUF)
+// 좋은 fix가 한 번도 누적되지 않아 어느 unlock 게이트도 발동하지 못하고, 출발역 lock이 영구
+// 고착된다(현재역이 출발역으로 회귀). 한 번의 부정확 fix로 풀면 반대 회귀(잘못된 unlock)가
+// 나므로, "여러 fix에 걸쳐 lock된 역에서 멀어진(>1km) 다른 역이 연속 관찰"되는 누적 증거로만
+// 푼다 — lock 메커니즘의 N회 연속 관찰과 대칭.
+
+/**
+ * 저품질 unlock에서 허용하는 최대 accuracy(m). 표시 게이트(MAX_ACCURACY_M_DISPLAY=250m)와
+ * 동일 — 쓰레기 좌표(±1.5km)는 거부하되 50~250m의 열화 fix는 누적 증거로 받아들인다.
+ * useNearestStation은 이미 표시 게이트를 통과한 fix만 sticky로 흘려보내므로 이중 안전장치.
+ */
+export const STICKY_DEGRADED_UNLOCK_ACCURACY_M = 250;
+
+/**
+ * lock된 역에서 1km+ 떨어진 "다른 역" fix가 N회 연속 관찰되면 저품질이어도 unlock.
+ * STICKY_LOCK_CONSECUTIVE_COUNT(3)와 동일한 안정 관찰 기준 — 단발성 부정확 fix는 카운트가
+ * 리셋되어 풀리지 않는다(false unlock 방지).
+ */
+export const STICKY_DEGRADED_UNLOCK_COUNT = 3;


### PR DESCRIPTION
Closes #1317

## 배경 (2026-06-15 오전 실기기 trip)
용마산(출발역)에서 군자·건대입구·성수로 이동했는데 현재역이 용마산으로 회귀. 지도탭 "현재위치" 탭 후에도 용마산으로 돌아감.
- device 덤프: 좌표 (37.557,127.079) = 군자 25m인데 `fused != gps`, `gps: 용마산 1948m`, `signalMask=UUF`, `tier=low`, accuracy 52.7m.

## 확정한 root cause (unlock 게이트)
저품질 GPS(accuracy 52.7m > `STICKY_GOOD_FIX_ACCURACY_M=50`)에서 모든 이동 감지 unlock 경로가 "좋은 fix(≤50m)"를 요구해 막힌다:
- **distance unlock** (`shouldUnlockByDistance`): `accuracyMeters > 50` → 즉시 `false`. 1km+ 떨어져도 발동 못 함.
- **better-fix unlock**: `isGoodFix`가 `false`라 good-fix 카운터가 누적되지 않아 `STICKY_LOCK_CONSECUTIVE_COUNT(3)`에 영원히 도달 못 함.
- **motion unlock**: 이 trip은 `subsurface=false`라 barometer→automotive 신호 없음(D6 hold도 미발동 — 정상).
- **TTL**: 30분, 너무 느림.

→ 출발역(용마산) lock이 영구 고착. (`subsurface=false`이므로 D6/#1212 subsurface-hold는 무관함을 확인.)

## 변경 내용
1. **저품질 GPS 내성 moved-away unlock** (`shouldCountAsMovedAway` 순수 게이트 + 카운터)
   - lock된 역에서 1km+ 떨어진 **다른 역** fix가 저품질(≤250m, 표시 게이트)이어도 `STICKY_DEGRADED_UNLOCK_COUNT(3)`회 연속 관찰되면 unlock.
   - lock 메커니즘의 "N회 연속 관찰"과 대칭 — 단발성 부정확 fix는 카운터가 리셋돼 풀리지 않는다(반대 회귀 방지).
   - strict distance와 동일하게 D6(trip 활성 + 지하) hold를 따른다.
2. **명시적 "현재위치" → sticky bypass** (`useStickyStation.releaseLock()` + `useNearestStation.requestCurrentLocation()`)
   - 지도탭 "현재위치" 버튼이 sticky lock을 비우고 fresh GPS fix를 요청해 live fused 위치를 노출.
   - FG 복귀 시의 일반 `refresh`는 sticky를 유지(D6 — 탑승 중 노선 정보 보존).
3. 상수: `STICKY_DEGRADED_UNLOCK_ACCURACY_M=250`, `STICKY_DEGRADED_UNLOCK_COUNT=3` (하드코딩 회피).
4. 측정 이벤트 `unlocked-moved-away` / `unlocked-manual` 추가 (DebugModal sticky 채널).

## Acceptance / tests
- 단위: lock역에서 1km+ 이동 + 여러 역 통과(저품질 52.7m) → sticky 해제(`unlocked-moved-away`).
- 단위: 단발성 far fix 1회로는 unlock 안 됨 + far 사이 lock역 근처 fix 끼면 카운터 리셋.
- 단위: `requestCurrentLocation` → sticky bypass → live 위치 복귀(source 'sticky' → 'live').
- 단위: subsurface=true + trip 활성 시 저품질 moved-away 누적해도 D6 hold로 보류.
- `releaseLock()` lock 없을 때 no-op.
- 전체 5461 tests green, 커버리지 100%, type-check / lint 통과.

## 실기기 검증 (머지 후 필요)
- 출발역으로 현재역 회귀 0건 (저품질 GPS 환승 trip 1주).